### PR TITLE
feat(dashboard): extract typed keeper-status classifiers (RFC-0174)

### DIFF
--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -21,6 +21,7 @@ import type {
   PreCompactEvent,
   HandoffEvent,
 } from './harness-health-state'
+import { verdictWithoutRejectPrefix, verdictToneClass, railStatusMessage } from '../lib/keeper-classifiers'
 
 function ItemTitle({ children, class: cx }: { children: unknown; class?: string }) {
   return html`<div class=${`text-sm font-medium text-[var(--color-fg-secondary)] ${cx ?? ''}`}>${children}</div>
@@ -174,14 +175,11 @@ export function emptyReasonText(reason?: string | null): string {
 }
 
 export function verdictTone(verdict: string): string {
-  return verdict.startsWith('approve')
-    ? 'bg-[var(--color-status-ok)]'
-    : 'bg-[var(--color-status-err)]'
+  return verdictToneClass(verdict)
 }
 
 export function verdictSummary(verdict: string): string {
-  if (!verdict.startsWith('reject:')) return verdict
-  return verdict.slice('reject:'.length).trim() || '(no reject reason)'
+  return verdictWithoutRejectPrefix(verdict)
 }
 
 export function heroTitle(data: HarnessHealthData): string {
@@ -190,8 +188,8 @@ export function heroTitle(data: HarnessHealthData): string {
     data.overview.pre_compact_status,
     data.overview.handoff_status,
   ]
-  if (statuses.includes('warning')) return '감시 채널에 주의가 필요합니다.'
-  if (statuses.includes('stale')) return '신호는 있지만 최신성이 떨어집니다.'
+  const msg = railStatusMessage(statuses)
+  if (msg) return msg
   if (statuses.every(status => status === 'idle')) return '아직 감시 기록이 없습니다.'
   return '감시 채널이 정상 작동 중입니다.'
 }

--- a/dashboard/src/components/journey-waterfall-state.ts
+++ b/dashboard/src/components/journey-waterfall-state.ts
@@ -6,6 +6,7 @@ import type {
 import type { KeeperRuntimeTraceResponse } from '../api/keeper'
 import { asNullableString } from './common/normalize'
 import type { Keeper } from '../types'
+import { keeperPriority as classifyKeeperPriority } from '../lib/keeper-classifiers'
 import {
   buildTraceEvents,
   type UnifiedTraceEvent,
@@ -303,9 +304,7 @@ function keeperActivityAge(keeper: Keeper): number {
 function keeperPriority(keeper: Keeper): number {
   const status = keeper.status.trim().toLowerCase()
   if (keeper.keepalive_running === true || keeper.presence_keepalive === true) return 0
-  if (['active', 'running', 'thinking', 'tool_use', 'claimed', 'in_progress'].includes(status)) return 1
-  if (['offline', 'inactive', 'stopped', 'dead'].includes(status)) return 3
-  return 2
+  return classifyKeeperPriority(status)
 }
 
 export function selectDefaultJourneyKeeper(

--- a/dashboard/src/components/session-trace/session-trace-view.ts
+++ b/dashboard/src/components/session-trace/session-trace-view.ts
@@ -19,6 +19,7 @@ import {
   _traceSlots,
 } from './session-trace-state'
 import type { TraceSummary } from './session-trace-state'
+import { isOfflineStatus } from '../../lib/keeper-classifiers'
 
 // ── Summary bar ────────────────────────────────────────
 
@@ -149,7 +150,7 @@ export function SessionTraceView({ agentName, isKeeper, keeperStatus, keeperGene
 
   // Empty state — contextual message based on keeper status
   if (events.length === 0) {
-    const isOffline = keeperStatus && ['offline', 'inactive', 'dead', 'crashed'].includes(keeperStatus)
+    const isOffline = keeperStatus && isOfflineStatus(keeperStatus)
     const msg = isOffline
       ? '키퍼가 오프라인입니다. 기동하면 활동이 기록됩니다.'
       : (keeperGeneration ?? 0) === 0

--- a/dashboard/src/components/status-tray.ts
+++ b/dashboard/src/components/status-tray.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 import { Activity, AlertTriangle, Bell, Radio, Users, X } from 'lucide-preact'
 import type { JournalEntry, Keeper, Task } from '../types'
 import { isKeeperCrashed } from '../lib/keeper-predicates'
+import { isAttentionCodeSatisfied } from '../lib/keeper-classifiers'
 import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
 import {
   dashboardWsConnected,
@@ -155,7 +156,7 @@ function isExecutionAttentionCode(value: string | null | undefined): boolean {
   if (!value) return false
   const normalized = value.trim().toLowerCase()
   if (!normalized || normalized === 'unknown') return false
-  if (normalized.startsWith('satisfied')) return false
+  if (isAttentionCodeSatisfied(normalized)) return false
   return EXECUTION_ATTENTION_SET.has(normalized)
 }
 

--- a/dashboard/src/lib/keeper-classifiers.test.ts
+++ b/dashboard/src/lib/keeper-classifiers.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import {
+  keeperPriority,
+  isOfflineStatus,
+  isAttentionCodeSatisfied,
+  classifyCrashReason,
+  isApproveVerdict,
+  verdictWithoutRejectPrefix,
+  verdictToneClass,
+  railStatusMessage,
+} from './keeper-classifiers'
+import type { KeeperPriority, CrashCategory } from './keeper-classifiers'
+
+describe('keeperPriority', () => {
+  it.each(['active', 'running', 'thinking', 'tool_use', 'claimed', 'in_progress'] as const)
+  ('returns 1 for active status: %s', (status) => {
+    expect(keeperPriority(status)).toBe<KeeperPriority>(1)
+  })
+
+  it.each(['offline', 'inactive', 'stopped', 'dead'] as const)
+  ('returns 3 for terminal status: %s', (status) => {
+    expect(keeperPriority(status)).toBe<KeeperPriority>(3)
+  })
+
+  it('returns 2 for unknown/intermediate status (including crashed)', () => {
+    expect(keeperPriority('idle')).toBe<KeeperPriority>(2)
+    expect(keeperPriority('paused')).toBe<KeeperPriority>(2)
+    expect(keeperPriority('crashed')).toBe<KeeperPriority>(2)
+    expect(keeperPriority('')).toBe<KeeperPriority>(2)
+    expect(keeperPriority('something_new')).toBe<KeeperPriority>(2)
+  })
+})
+
+describe('isOfflineStatus', () => {
+  it.each(['offline', 'inactive', 'dead', 'crashed'])
+  ('returns true for %s', (status) => {
+    expect(isOfflineStatus(status)).toBe(true)
+  })
+
+  it.each(['active', 'running', 'idle', 'paused', ''])
+  ('returns false for %s', (status) => {
+    expect(isOfflineStatus(status)).toBe(false)
+  })
+})
+
+describe('isAttentionCodeSatisfied', () => {
+  it('returns true for "satisfied" prefix', () => {
+    expect(isAttentionCodeSatisfied('satisfied')).toBe(true)
+    expect(isAttentionCodeSatisfied('satisfied_with_caveats')).toBe(true)
+  })
+
+  it('returns false for non-satisfied codes', () => {
+    expect(isAttentionCodeSatisfied('violated')).toBe(false)
+    expect(isAttentionCodeSatisfied('unknown')).toBe(false)
+    expect(isAttentionCodeSatisfied('')).toBe(false)
+  })
+})
+
+describe('classifyCrashReason', () => {
+  it.each([
+    ['heartbeat', 'heartbeat'],
+    ['heartbeat_timeout', 'heartbeat'],
+    ['HEARTBEAT_TIMEOUT', 'heartbeat'],
+    ['turn', 'turn'],
+    ['turn_timeout', 'turn'],
+    ['fiber', 'fiber'],
+    ['fiber_cancel', 'fiber'],
+    ['exception', 'exception'],
+    ['exception_io', 'exception'],
+  ] as const)
+  ('classifies "%s" as %s', (input, expected) => {
+    expect(classifyCrashReason(input)).toBe<CrashCategory>(expected)
+  })
+
+  it('returns unknown for unrecognized reason', () => {
+    expect(classifyCrashReason('random_error')).toBe<CrashCategory>('unknown')
+    expect(classifyCrashReason('')).toBe<CrashCategory>('unknown')
+  })
+})
+
+describe('isApproveVerdict', () => {
+  it('returns true for approve variants', () => {
+    expect(isApproveVerdict('approve')).toBe(true)
+    expect(isApproveVerdict('approve_with_comments')).toBe(true)
+  })
+
+  it('returns false for non-approve verdicts', () => {
+    expect(isApproveVerdict('reject:reason')).toBe(false)
+    expect(isApproveVerdict('pending')).toBe(false)
+  })
+})
+
+describe('verdictWithoutRejectPrefix', () => {
+  it('strips reject: prefix', () => {
+    expect(verdictWithoutRejectPrefix('reject:bad code')).toBe('bad code')
+  })
+
+  it('returns raw verdict if no prefix', () => {
+    expect(verdictWithoutRejectPrefix('approve')).toBe('approve')
+  })
+
+  it('handles empty reject reason', () => {
+    expect(verdictWithoutRejectPrefix('reject:')).toBe('(no reject reason)')
+    expect(verdictWithoutRejectPrefix('reject:  ')).toBe('(no reject reason)')
+  })
+})
+
+describe('verdictToneClass', () => {
+  it('returns ok class for approve', () => {
+    expect(verdictToneClass('approve')).toContain('ok')
+  })
+
+  it('returns err class for non-approve', () => {
+    expect(verdictToneClass('reject:x')).toContain('err')
+  })
+})
+
+describe('railStatusMessage', () => {
+  it('returns warning message', () => {
+    expect(railStatusMessage(['warning'])).toBe('감시 채널에 주의가 필요합니다.')
+  })
+
+  it('returns stale message', () => {
+    expect(railStatusMessage(['stale'])).toBe('신호는 있지만 최신성이 떨어집니다.')
+  })
+
+  it('prioritizes warning over stale', () => {
+    expect(railStatusMessage(['stale', 'warning'])).toBe('감시 채널에 주의가 필요합니다.')
+  })
+
+  it('returns null for no actionable status', () => {
+    expect(railStatusMessage(['idle', 'ok'])).toBeNull()
+    expect(railStatusMessage([])).toBeNull()
+  })
+})

--- a/dashboard/src/lib/keeper-classifiers.ts
+++ b/dashboard/src/lib/keeper-classifiers.ts
@@ -1,0 +1,107 @@
+/**
+ * RFC-0174: Centralized typed classifiers for keeper status/phase/verdict strings.
+ *
+ * Every function takes `string` input from backend wire-format and returns a
+ * typed result. Unknown inputs map to explicit fallbacks (null, false, or
+ * 'unknown') — never silently accepted as a valid variant.
+ *
+ * Pattern follows `keeper-store-normalize.ts` (`BACKEND_PHASE_LOWERCASE_MAP`
+ * + compile-time coverage checks).
+ */
+
+// ── Keeper priority (journey-waterfall sorting) ──────────
+
+export type KeeperPriority = 1 | 2 | 3
+
+const ACTIVE_STATUSES: ReadonlySet<string> = new Set([
+  'active', 'running', 'thinking', 'tool_use', 'claimed', 'in_progress',
+])
+
+/** Terminal statuses for waterfall priority — does NOT include 'crashed'
+ *  (a crashed keeper was recently active, so it gets priority 2, not 3). */
+const PRIORITY_TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  'offline', 'inactive', 'stopped', 'dead',
+])
+
+/** Offline display statuses — includes 'crashed' (keeper is not running
+ *  but was recently active). Used for UI contextual messages, not sorting. */
+const OFFLINE_DISPLAY_STATUSES: ReadonlySet<string> = new Set([
+  'offline', 'inactive', 'dead', 'crashed',
+])
+
+/** Classify keeper status into a priority tier for waterfall display ordering.
+ *  1 = active, 2 = intermediate (includes crashed), 3 = terminal. */
+export function keeperPriority(status: string): KeeperPriority {
+  if (ACTIVE_STATUSES.has(status)) return 1
+  if (PRIORITY_TERMINAL_STATUSES.has(status)) return 3
+  return 2
+}
+
+/** True if the status string represents an offline keeper for display purposes.
+ *  Includes 'crashed' — the keeper is not currently running. */
+export function isOfflineStatus(status: string): boolean {
+  return OFFLINE_DISPLAY_STATUSES.has(status)
+}
+
+// ── Execution attention code ─────────────────────────────
+
+/** True if an attention code value starts with "satisfied" (no attention needed). */
+export function isAttentionCodeSatisfied(code: string): boolean {
+  return code.startsWith('satisfied')
+}
+
+// ── Crash reason classification ──────────────────────────
+
+export type CrashCategory = 'heartbeat' | 'turn' | 'fiber' | 'exception' | 'unknown'
+
+const CRASH_EXACT: ReadonlySet<CrashCategory> = new Set<CrashCategory>([
+  'heartbeat', 'turn', 'fiber', 'exception',
+])
+
+const CRASH_PREFIX_MAP: readonly { prefix: string; category: CrashCategory }[] = [
+  { prefix: 'heartbeat', category: 'heartbeat' },
+  { prefix: 'turn', category: 'turn' },
+  { prefix: 'fiber', category: 'fiber' },
+  { prefix: 'exception', category: 'exception' },
+]
+
+/** Classify a raw crash reason string into a typed category.
+ *  Exact match preferred over prefix heuristic to avoid ambiguity. */
+export function classifyCrashReason(raw: string): CrashCategory {
+  const lower = raw.toLowerCase()
+  if (CRASH_EXACT.has(lower as CrashCategory)) return lower as CrashCategory
+  for (const { prefix, category } of CRASH_PREFIX_MAP) {
+    if (lower.startsWith(prefix)) return category
+  }
+  return 'unknown'
+}
+
+// ── Harness verdict ──────────────────────────────────────
+
+/** True if a harness verdict string starts with "approve". */
+export function isApproveVerdict(verdict: string): boolean {
+  return verdict.startsWith('approve')
+}
+
+/** Strip "reject:" prefix from verdict, returning the reason or the raw value. */
+export function verdictWithoutRejectPrefix(verdict: string): string {
+  if (!verdict.startsWith('reject:')) return verdict
+  return verdict.slice('reject:'.length).trim() || '(no reject reason)'
+}
+
+/** CSS tone class for verdict display. */
+export function verdictToneClass(verdict: string): string {
+  return isApproveVerdict(verdict)
+    ? 'bg-[var(--color-status-ok)]'
+    : 'bg-[var(--color-status-err)]'
+}
+
+// ── Rail status message ──────────────────────────────────
+
+/** Derive a Korean status message from rail status strings.
+ *  Returns null when no actionable message is warranted. */
+export function railStatusMessage(statuses: string[]): string | null {
+  if (statuses.includes('warning')) return '감시 채널에 주의가 필요합니다.'
+  if (statuses.includes('stale')) return '신호는 있지만 최신성이 떨어집니다.'
+  return null
+}

--- a/docs/rfc/RFC-0174-dashboard-substring-classifier-to-typed.md
+++ b/docs/rfc/RFC-0174-dashboard-substring-classifier-to-typed.md
@@ -1,0 +1,171 @@
+---
+rfc: "0174"
+title: "Dashboard substring classifier to typed — TypeScript"
+status: Draft
+created: 2026-05-24
+updated: 2026-05-24
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0089"]
+implementation_prs: []
+---
+
+# RFC-0174 — Dashboard substring classifier to typed variant
+
+## §1 Context
+
+RFC-0089 closed 215+ OCaml `String.starts_with ~prefix:"..."` sites in `lib/`
+by replacing them with typed variant constructors. Its scope was backend-only.
+
+The TypeScript dashboard (`dashboard/src/`) has **8 sites** that classify
+backend wire-format strings via `.includes()`, `.startsWith()`, and inline
+array literals. These patterns are structurally identical to RFC-0089 §2's
+anti-pattern: when the backend adds a new variant, the dashboard silently
+falls through to an untyped fallback instead of surfacing a typecheck failure.
+
+The existing `keeper-store-normalize.ts` already demonstrates the correct
+pattern — closed `ReadonlySet`/`Record` maps with compile-time coverage
+checks (`_BACKEND_PHASE_COVERAGE_CHECK`). This RFC extends that pattern to
+the remaining 8 scattered sites.
+
+## §2 Scope
+
+### §2.1 In-scope (8 sites)
+
+| # | File | Line(s) | Pattern | Typed replacement |
+|---|------|---------|---------|-------------------|
+| S1 | `status-tray.ts` | 158 | `.startsWith('satisfied')` | `isAttentionCodeSatisfied(code)` |
+| S2 | `keeper-supervisor-helpers.ts` | 37-38 | `CRASH_CATEGORY_KEYS` + prefix map | `classifyCrashReason(raw): CrashCategory` |
+| S3 | `fsm-hub-types.ts` | 677 | `.startsWith(prefix)` for terminal reason labels | `terminalReasonLabel(code): string` |
+| S4 | `journey-waterfall-state.ts` | 306-307 | `['active','running',...].includes(status)` | `keeperPriority(status): 1|2|3` |
+| S5 | `session-trace-view.ts` | 152 | `['offline','inactive','dead'].includes(...)` | `isOfflineStatus(status): boolean` |
+| S6 | `tool-call-shared.ts` | 66 | `.includes('bash')` etc. for tool categories | `classifyToolCategory(name): ToolCategory` |
+| S7 | `harness-health-sections.ts` | 177 | `.startsWith('approve')` | `isApproveVerdict(verdict): boolean` |
+| S8 | `harness-health-sections.ts` | 193-194 | `.includes('warning')` / `.includes('stale')` | `railStatusMessage(statuses): string` |
+
+### §2.2 Out of scope
+
+- Search/filter `.includes(needle)` where `needle` is user input (governance.ts, history.ts, etc.) — these are text search, not classification.
+- `keeper-store-normalize.ts` — already typed via `toKeeperPhase`/`toPipelineStage`/`normalizeKeeperAgentStatus`.
+- Backend OCaml changes — RFC-0089 territory.
+
+## §3 Design
+
+### §3.1 New file: `dashboard/src/lib/keeper-classifiers.ts`
+
+Central typed classifier module. Every function takes `string` input and
+returns a typed result. Unknown inputs map to explicit fallback values
+(`null`, `false`, or a `'unknown'` variant) — never silently accepted.
+
+```typescript
+// keeper-classifiers.ts
+
+/** Keeper priority for waterfall/journey sorting. */
+export type KeeperPriority = 1 | 2 | 3
+
+/** Closed set of offline-status strings. */
+const OFFLINE_STATUSES: ReadonlySet<string> = new Set([
+  'offline', 'inactive', 'dead', 'crashed',
+])
+
+/** Active-status strings → priority 1. */
+const ACTIVE_STATUSES: ReadonlySet<string> = new Set([
+  'active', 'running', 'thinking', 'tool_use', 'claimed', 'in_progress',
+])
+
+/** Satisfied attention code prefixes. */
+const SATISFIED_PREFIXES: readonly string[] = ['satisfied']
+
+/** Crash reason classification. */
+export type CrashCategory = 'heartbeat' | 'turn' | 'fiber' | 'exception' | 'unknown'
+
+const CRASH_PREFIX_MAP: readonly { prefix: string; category: CrashCategory }[] = [
+  { prefix: 'heartbeat', category: 'heartbeat' },
+  { prefix: 'turn', category: 'turn' },
+  { prefix: 'fiber', category: 'fiber' },
+  { prefix: 'exception', category: 'exception' },
+]
+
+export function isOfflineStatus(status: string): boolean {
+  return OFFLINE_STATUSES.has(status)
+}
+
+export function keeperPriority(status: string): KeeperPriority {
+  if (ACTIVE_STATUSES.has(status)) return 1
+  if (OFFLINE_STATUSES.has(status)) return 3
+  return 2
+}
+
+export function isAttentionCodeSatisfied(code: string): boolean {
+  return SATISFIED_PREFIXES.some(p => code.startsWith(p))
+}
+
+export function classifyCrashReason(raw: string): CrashCategory {
+  const lower = raw.toLowerCase()
+  for (const { prefix, category } of CRASH_PREFIX_MAP) {
+    if (lower.startsWith(prefix)) return category
+  }
+  return 'unknown'
+}
+
+export function isApproveVerdict(verdict: string): boolean {
+  return verdict.startsWith('approve')
+}
+
+export function railStatusMessage(statuses: string[]): string | null {
+  if (statuses.includes('warning')) return '감시 채널에 주의가 필요합니다.'
+  if (statuses.includes('stale')) return '신호는 있지만 최신성이 떨어집니다.'
+  return null
+}
+```
+
+### §3.2 Tool category classifier
+
+`tool-call-shared.ts` has a `TOOL_CATEGORIES` array of `{ match, icon, label }`
+where `match` is `(n: string) => boolean` using `.includes()`. This stays
+where it is but gains typed return via a `ToolCategory` union:
+
+```typescript
+export type ToolCategory =
+  | 'shell' | 'github' | 'git' | 'status' | 'dashboard'
+  | 'agent' | 'memory' | 'search' | 'other'
+```
+
+The match functions remain inline (they're rendering logic, not wire-format
+parsing) but the category label becomes the typed union instead of a free
+string.
+
+### §3.3 Terminal reason label map
+
+`fsm-hub-types.ts` line 677 uses a `REASON_LABEL_MAP` array of
+`{ prefix, label }` objects. This is display-only (Korean labels) and the
+prefix set mirrors the backend closed sum. This stays where it is but gains
+a compile-time completeness assertion via a `satisfies` constraint against
+the `KeeperTrustTerminalReason` union.
+
+## §4 Migration plan
+
+Single PR, 8 consumer files + 1 new utility file:
+
+1. Create `dashboard/src/lib/keeper-classifiers.ts`
+2. Write tests in `dashboard/src/lib/keeper-classifiers.test.ts`
+3. Replace S1-S8 call sites one by one
+4. Run `tsc --noEmit` + existing tests to verify no regressions
+
+No flag-gating. Direct replacement.
+
+## §5 Test requirements
+
+- `isOfflineStatus`: test all 4 known values + unknown → false
+- `keeperPriority`: test each priority tier + unknown → 2
+- `isAttentionCodeSatisfied`: test "satisfied", "satisfied_*" prefix → true; "violated" → false
+- `classifyCrashReason`: test 4 known prefixes + unknown → 'unknown'
+- `isApproveVerdict`: test "approve", "approve_*" → true; "reject:*" → false
+- `railStatusMessage`: test ['warning'], ['stale'], ['ok'], [] → correct message or null
+
+## §6 Non-goals
+
+- TypeScript strict enum enforcement (TS union types provide adequate exhaustiveness via `never`)
+- Dashboard-wide lint rule for `.includes` (RFC-0089 §2 rationale: lint for string classifiers is self-referential workaround)
+- Backend wire-format changes (OCaml territory)


### PR DESCRIPTION
## Summary
- Extract 4 inline `.includes()`/`.startsWith()` substring classifications into centralized `lib/keeper-classifiers.ts`
- RFC-0174 extends RFC-0089 (OCaml backend) philosophy to TypeScript dashboard
- 43 unit tests, `tsc --noEmit` clean

## Consumer sites wired
| Component | Before | After |
|-----------|--------|-------|
| `status-tray.ts` | `normalized.startsWith('satisfied')` | `isAttentionCodeSatisfied()` |
| `journey-waterfall-state.ts` | `['active',...].includes(status)` ×2 | `keeperPriority()` |
| `session-trace-view.ts` | `['offline',...].includes(status)` | `isOfflineStatus()` |
| `harness-health-sections.ts` | `verdict.startsWith('approve')` + `.includes('warning')` | `verdictToneClass()` + `railStatusMessage()` |

## Sites intentionally NOT migrated (already well-typed)
- `keeper-supervisor-helpers.ts` — already has typed `categorizeCrashReason()`
- `fsm-hub-types.ts` — display label map, not state classification
- `tool-call-shared.ts` — UI rendering categories, not wire-format parsing

## Test plan
- [x] `vitest run dashboard/src/lib/keeper-classifiers.test.ts` — 43 pass
- [x] `tsc --noEmit` — 0 errors
- [ ] CI dashboard build passes
- [ ] Visual verification: keeper status badges render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)