### PR TITLE
fix(ci): shard shell ir tla spec

### DIFF
--- a/specs/Makefile
+++ b/specs/Makefile
@@ -149,7 +149,8 @@ check-social: check-all
 
 OTHER_DIRS := admission-queue auth autonomous boundary bug-models cascade \
               checkpoint-trim keeper-switch-hierarchy keeper-turn-fsm \
-              multimodal resilience server-state shared task-lifecycle
+              multimodal resilience server-state shared shell-ir-first-class \
+              task-lifecycle
 check-others: CLEAN_CFGS := $(foreach d,$(OTHER_DIRS),$(call clean_cfgs_in,$(d)/))
 check-others: BUGGY_CFGS := $(foreach d,$(OTHER_DIRS),$(call buggy_cfgs_in,$(d)/))
 check-others: check-all


### PR DESCRIPTION
## Summary
- Add specs/shell-ir-first-class to the TLA check-others shard.
- Restore TLA matrix coverage after main started failing on #18246.

## Validation
- make -C specs check-matrix-coverage
- make -C specs check-others
- git diff --check