### PR TITLE
feat(keeper): wire InputRequired as special stop condition

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -68,6 +68,7 @@ type sdk_termination_semantics =
   | Oas_tool_retry_exhausted
   | Oas_guardrail_violation
   | Oas_tripwire_violation
+  | Oas_input_required
   | Sdk_error_failure
 
 let sdk_termination_semantics = function
@@ -96,7 +97,7 @@ let sdk_termination_semantics = function
     Oas_guardrail_violation
   | Agent_sdk.Error.Agent (Agent_sdk.Error.TripwireViolation _) ->
     Oas_tripwire_violation
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired _) -> Sdk_error_failure
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired _) -> Oas_input_required
   | Agent_sdk.Error.Agent (Agent_sdk.Error.UnrecognizedStopReason _) -> Sdk_error_failure
   | Agent_sdk.Error.Provider _ -> Sdk_error_failure
   | Agent_sdk.Error.Api _ -> Sdk_error_failure
@@ -121,6 +122,7 @@ let sdk_termination_semantics_to_string = function
   | Oas_tool_retry_exhausted -> "oas_tool_retry_exhausted"
   | Oas_guardrail_violation -> "oas_guardrail_violation"
   | Oas_tripwire_violation -> "oas_tripwire_violation"
+  | Oas_input_required -> "oas_input_required"
   | Sdk_error_failure -> "sdk_error_failure"
 ;;
 
@@ -324,6 +326,7 @@ let receipt_outcome_kind_of_sdk_error err =
   | Oas_turn_budget_exhausted
   | Oas_idle_budget_exhausted
   | Oas_exit_condition_reached -> `Cancelled
+  | Oas_input_required -> `Cancelled
   | Oas_token_budget_exhausted
   | Oas_cost_budget_exhausted
   | Oas_cost_budget_unenforceable

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -50,6 +50,7 @@ type sdk_termination_semantics =
   | Oas_tool_retry_exhausted
   | Oas_guardrail_violation
   | Oas_tripwire_violation
+  | Oas_input_required
   | Sdk_error_failure
 
 val sdk_termination_semantics

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -979,6 +979,32 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.A2a _
   | Agent_sdk.Error.Internal _ -> false
 
+(** [true] when the error is an OAS [InputRequired] — the agent paused
+    to request human input.  Not a failure; a special stop condition. *)
+let is_input_required_error (err : Agent_sdk.Error.sdk_error) : bool =
+  match err with
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired _) -> true
+  | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
+  | Agent_sdk.Error.Agent (CostBudgetExceeded _)
+  | Agent_sdk.Error.Agent (CostBudgetUnenforceable _)
+  | Agent_sdk.Error.Agent (TokenBudgetExceeded _)
+  | Agent_sdk.Error.Agent (UnrecognizedStopReason _)
+  | Agent_sdk.Error.Agent (IdleDetected _)
+  | Agent_sdk.Error.Agent (ToolRetryExhausted _)
+  | Agent_sdk.Error.Agent (CompletionContractViolation _)
+  | Agent_sdk.Error.Agent (GuardrailViolation _)
+  | Agent_sdk.Error.Agent (TripwireViolation _)
+  | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
+  | Agent_sdk.Error.Api _
+  | Agent_sdk.Error.Provider _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> false
+
 (** [true] when an error represents terminal cascade exhaustion or a
     final accept-rejected result from the MASC OAS boundary. *)
 let is_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -51,6 +51,10 @@ val is_ambiguous_side_effect_error : Agent_sdk.Error.sdk_error -> bool
 (** [true] when a structured error indicates context overflow. *)
 val is_context_overflow : Agent_sdk.Error.sdk_error -> bool
 
+(** [true] when the error is an OAS [InputRequired] — the agent paused
+    to request human input.  Not a failure; a special stop condition. *)
+val is_input_required_error : Agent_sdk.Error.sdk_error -> bool
+
 (** [true] when an error represents terminal cascade exhaustion or a
     final accept-rejected result from the MASC OAS boundary. *)
 val is_cascade_exhausted_error : Agent_sdk.Error.sdk_error -> bool

--- a/lib/keeper/keeper_passive_loop_detector.ml
+++ b/lib/keeper/keeper_passive_loop_detector.ml
@@ -42,7 +42,7 @@ let progress_class_of_disposition (d : Keeper_turn_disposition.t) =
       Some required_tool_no_call_progress_class
   | Required_tool_use_unsatisfied ->
       Some required_tool_unsatisfied_progress_class
-  | Success | External_cancel | Turn_wall_clock_timeout
+  | Success | External_cancel | Input_required | Turn_wall_clock_timeout
   | Post_commit_ambiguous
   | Cascade_attempts_exhausted
   | Provider_error _ | Unknown _ ->

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -89,6 +89,8 @@ let disposition_of_runtime_blocker_class raw_blocker_class =
       Keeper_turn_disposition.Turn_wall_clock_timeout
   | "ambiguous_post_commit_timeout" | "ambiguous_post_commit_failure" ->
       Keeper_turn_disposition.Post_commit_ambiguous
+  | "sdk_input_required" ->
+      Keeper_turn_disposition.Input_required
   | ("cascade_exhausted" | "no_tool_capable_provider"
      | "provider_runtime_error") as cls ->
       Keeper_turn_disposition.Provider_error

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -233,7 +233,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
      | Agent_sdk.Error.Agent (GuardrailViolation _) -> Some Sdk_guardrail_violation
      | Agent_sdk.Error.Agent (TripwireViolation _) -> Some Sdk_tripwire_violation
      | Agent_sdk.Error.Agent (ExitConditionMet _) -> Some Sdk_exit_condition_met
-     | Agent_sdk.Error.Agent (InputRequired _) -> None
+     | Agent_sdk.Error.Agent (InputRequired _) -> Some Sdk_input_required
      (* Provider-level [Api] errors are surfaced via OAS retry / cascade
          layers and do not map to a typed blocker_class by themselves. *)
      | Agent_sdk.Error.Api _

--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -11,6 +11,7 @@ module Code = Keeper_turn_terminal_code
 type t =
   | Success
   | External_cancel
+  | Input_required
   | Turn_wall_clock_timeout
   | Cascade_attempts_exhausted
   | Required_tool_use_no_tool_call
@@ -27,6 +28,7 @@ type severity =
 
 let severity = function
   | Success -> Ok
+  | Input_required -> Ok
   | External_cancel
   | Turn_wall_clock_timeout
   | Cascade_attempts_exhausted -> Warn
@@ -39,6 +41,7 @@ let severity = function
 
 let summary = function
   | Success -> "turn completed"
+  | Input_required -> "agent paused to request human input"
   | External_cancel -> "keeper turn was cancelled before completion"
   | Turn_wall_clock_timeout ->
     "keeper turn hit the wall-clock timeout"
@@ -58,6 +61,7 @@ let summary = function
 
 let next_action = function
   | Success -> None
+  | Input_required -> Some "provide_input_or_decline"
   | External_cancel -> Some "rerun_if_still_relevant"
   | Turn_wall_clock_timeout -> Some "inspect_turn_timeout"
   | Cascade_attempts_exhausted -> Some "inspect_cascade_attempts"
@@ -71,6 +75,7 @@ let next_action = function
 
 let to_wire = function
   | Success -> "success"
+  | Input_required -> "input_required"
   | External_cancel -> "external_cancel"
   | Turn_wall_clock_timeout -> "turn_wall_clock_timeout"
   | Cascade_attempts_exhausted -> "cascade_attempts_exhausted"
@@ -114,6 +119,7 @@ let of_termination_code (c : Code.t) : t =
 
 let of_wire = function
   | "success" -> Success
+  | "input_required" -> Input_required
   | "external_cancel" -> External_cancel
   | "turn_wall_clock_timeout" -> Turn_wall_clock_timeout
   | "cascade_attempts_exhausted" -> Cascade_attempts_exhausted
@@ -130,6 +136,7 @@ let of_wire = function
 let equal a b =
   match a, b with
   | Success, Success
+  | Input_required, Input_required
   | External_cancel, External_cancel
   | Turn_wall_clock_timeout, Turn_wall_clock_timeout
   | Cascade_attempts_exhausted, Cascade_attempts_exhausted
@@ -139,6 +146,7 @@ let equal a b =
   | Provider_error a, Provider_error b -> String.equal (Code.to_wire a) (Code.to_wire b)
   | Unknown a, Unknown b -> String.equal a.raw_error b.raw_error
   | Success, _
+  | Input_required, _
   | External_cancel, _
   | Turn_wall_clock_timeout, _
   | Cascade_attempts_exhausted, _

--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -28,6 +28,10 @@ type t =
   | Success (** Turn completed normally. *)
   | External_cancel
   (** Turn cancelled before completion (operator stop, switch_keeper, …). *)
+  | Input_required
+  (** Agent paused to request human input. Not a failure — a special
+          stop condition analogous to [ExitConditionMet]. Operator action:
+          provide input or decline. *)
   | Turn_wall_clock_timeout (** Turn exceeded its wall-clock budget. *)
   | Cascade_attempts_exhausted
   (** Cascade aggregate outcome: all candidate attempts were exhausted.
@@ -88,6 +92,7 @@ val next_action : t -> string option
 
     Mapping:
     - [Success] → ["success"]
+    - [Input_required] → ["input_required"]
     - [External_cancel] → ["external_cancel"]
     - [Turn_wall_clock_timeout] → ["turn_wall_clock_timeout"]
     - [Cascade_attempts_exhausted] → ["cascade_attempts_exhausted"]

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -3,6 +3,7 @@ type cancel_reason =
   | Cancelled_phase_gate_close
   | Cancelled_provider_timeout
   | Cancelled_fleet_shutdown
+  | Cancelled_input_required
 
 type failure_reason =
   | Failure_cascade_unavailable of {
@@ -77,6 +78,7 @@ let cancel_reason_label = function
   | Cancelled_phase_gate_close -> "phase_gate_close"
   | Cancelled_provider_timeout -> "provider_timeout"
   | Cancelled_fleet_shutdown -> "fleet_shutdown"
+  | Cancelled_input_required -> "input_required"
 
 let failure_reason_label = function
   | Failure_cascade_unavailable _ -> "cascade_unavailable"

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -17,6 +17,8 @@ type cancel_reason =
           past the cooperative-cancel deadline. *)
   | Cancelled_fleet_shutdown
       (** Process is exiting; no more turns will be dispatched. *)
+  | Cancelled_input_required
+      (** Agent paused to request human input (InputRequired). *)
 
 type failure_reason =
   | Failure_cascade_unavailable of {

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -614,12 +614,37 @@ let run_keeper_cycle
                            Cascade_name.to_string execution.cascade_name
                          in
                          let mark_terminal_error err =
-                           Keeper_unified_turn_terminal_error.handle
-                             ~config
-                             ~keeper_name:meta.name
-                             ~attempt
-                             ~attempted_cascades
-                             err
+                           if EC.is_input_required_error err then begin
+                             let ir =
+                               match err with
+                               | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired ir) -> ir
+                               | _ -> assert false
+                             in
+                             Keeper_registry.mark_turn_cascade_done
+                               ~base_path:config.base_path
+                               meta.name;
+                             Log.Keeper.info
+                               "[input_required] keeper=%s agent paused: request_id=%s \
+                                question=%s"
+                               meta.name
+                               ir.Agent_sdk.Error.request_id
+                               (let q = ir.Agent_sdk.Error.question in
+                                if String.length q > 80
+                                then String.sub q 0 80 ^ "…"
+                                else q);
+                             Keeper_turn_fsm.emit_transition
+                               ~keeper_name:meta.name
+                               ~turn_id:keeper_turn_id
+                               ~prev:Keeper_turn_fsm.Streaming
+                               (Keeper_turn_fsm.Cancelled
+                                  Keeper_turn_fsm.Cancelled_input_required)
+                           end else
+                             Keeper_unified_turn_terminal_error.handle
+                               ~config
+                               ~keeper_name:meta.name
+                               ~attempt
+                               ~attempted_cascades
+                               err
                          in
                          let attempt_provider_timeout_budget = ref None in
                          let max_turns =
@@ -1403,6 +1428,23 @@ let run_keeper_cycle
                     ~success
                 | None -> ());
                (match run_result with
+                | Error err when EC.is_input_required_error err ->
+                  (* InputRequired: special stop condition (not a failure).
+                     mark_terminal_error already emitted FSM Cancelled
+                     transition and info-level log. Surface as Ok so the
+                     keeper cycle does not enter failure processing. *)
+                  finalize_trajectory_acc
+                    ~config
+                    ~keeper_name:meta.name
+                    trajectory_acc
+                    (Trajectory.Gated "input_required");
+                  Prometheus.inc_counter
+                    Keeper_metrics.metric_keeper_turns
+                    ~labels:[ "keeper_name", meta.name; "outcome", "input_required" ]
+                    ();
+                  cycle_completed := true;
+                  post_turn_complete_task ~cycle_completed;
+                  Ok meta
                 | Error err ->
                   let final_execution = !last_execution in
                   finalize_trajectory_acc

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -209,6 +209,7 @@ let registry_failure_reason_of_terminal_reason
          })
   | Keeper_turn_disposition.Success
   | Keeper_turn_disposition.External_cancel
+  | Keeper_turn_disposition.Input_required
   | Keeper_turn_disposition.Turn_wall_clock_timeout
   | Keeper_turn_disposition.Post_commit_ambiguous
   | Keeper_turn_disposition.Unknown _ -> None


### PR DESCRIPTION
## Summary

- Wire OAS 0.196.16 `InputRequired` error as a **special stop condition** (not failure), following the `ExitConditionMet` pattern
- Two-stage interception: `mark_terminal_error` (info log + FSM transition) + `run_result` match (bypass failure processing, return `Ok meta`)
- Add `Oas_input_required` to `sdk_termination_semantics`, `Cancelled_input_required` FSM reason, `Input_required` disposition (severity=Ok)
- Wire blocker class (`Sdk_input_required`) and disposition mapping in `keeper_runtime_trust_snapshot`

## Changes (13 files, +105/-9)

### Type foundations (Iter 1)
- `keeper_agent_error.ml/mli`: `Oas_input_required` variant + receipt `` `Cancelled ``
- `keeper_error_classify.ml/mli`: `is_input_required_error` predicate
- `keeper_turn_fsm.ml/mli`: `Cancelled_input_required` cancel reason

### Surface & disposition (Iter 2)
- `keeper_status_bridge.ml`: `InputRequired → Some Sdk_input_required` blocker class
- `keeper_turn_disposition.ml/mli`: `Input_required` disposition (severity=Ok, wire="input_required")

### Core wiring (Iter 3-4)
- `keeper_unified_turn.ml`: InputRequired interception in `mark_terminal_error` + early `Ok meta` return
- `keeper_runtime_trust_snapshot.ml`: `"sdk_input_required"` → `Input_required` disposition
- `keeper_passive_loop_detector.ml`, `keeper_unified_turn_types.ml`: exhaustiveness fixes

## Key design decision

Original plan was Error→Ok conversion inside `retry_loop`, but `run_result` has 20+ fields that can't be constructed without an actual Agent.run. Changed to **two-stage interception**:

1. `mark_terminal_error`: replaces error handler with info log + FSM `Cancelled_input_required` transition
2. `match run_result with | Error err when is_input_required_error err`: bypasses all failure metrics/FSM/log/social-state, returns `Ok meta`

This ensures InputRequired flows through the error path but gets intercepted at both the recording point and the final result point.

## Test plan
- [x] `dune build` passes (keeper files compile cleanly)
- [ ] Integration test: inject `Agent_sdk.Error.Agent (InputRequired _)` into turn loop
- [ ] Verify FSM log: `Streaming → Cancelled Cancelled_input_required`
- [ ] Verify `metric_keeper_turns{outcome="input_required"}` increments
- [ ] Verify dashboard blocker: `sdk_input_required`
- [ ] Verify no `metric_keeper_oas_execution_errors` increment for InputRequired

🤖 Generated with [Claude Code](https://claude.com/claude-code)