### PR TITLE
[RFC-0152] Keeper auto-resume: S3/S4/S5 pause path SSOT + failure_reason variants

### DIFF
--- a/lib/keeper/keeper_failure_policy.ml
+++ b/lib/keeper/keeper_failure_policy.ml
@@ -153,6 +153,9 @@ type failure =
   | Fatal_environment of { detail : string option }
   | Stale_turn of { progress_seen : bool }
   | Stale_termination_storm of { count : int }
+  | Turn_failure_streak of { count : int }
+  | Turn_overflow_pause
+  | Turn_livelock_pause
   | Ambiguous_partial_commit
 
 type failure_scope =
@@ -403,6 +406,30 @@ let decide = function
       ~operator_action:Inspect_keeper_liveness
       ~keeper_death_allowed:false
       ~reason:("stale_termination_storm:" ^ string_of_int count)
+  | Turn_failure_streak { count } ->
+    make_decision
+      ~failure_scope:Turn_scope
+      ~lifecycle_effect:Pause_keeper
+      ~circuit_effect:Operator_breaker
+      ~operator_action:Inspect_keeper_liveness
+      ~keeper_death_allowed:false
+      ~reason:("turn_failure_streak:" ^ string_of_int count)
+  | Turn_overflow_pause ->
+    make_decision
+      ~failure_scope:Turn_scope
+      ~lifecycle_effect:Pause_keeper
+      ~circuit_effect:Operator_breaker
+      ~operator_action:Inspect_keeper_liveness
+      ~keeper_death_allowed:false
+      ~reason:"turn_overflow_pause"
+  | Turn_livelock_pause ->
+    make_decision
+      ~failure_scope:Turn_scope
+      ~lifecycle_effect:Pause_keeper
+      ~circuit_effect:Operator_breaker
+      ~operator_action:Inspect_keeper_liveness
+      ~keeper_death_allowed:false
+      ~reason:"turn_livelock_pause"
   | Ambiguous_partial_commit ->
     make_decision
       ~failure_scope:Turn_scope

--- a/lib/keeper/keeper_failure_policy.mli
+++ b/lib/keeper/keeper_failure_policy.mli
@@ -60,6 +60,9 @@ type failure =
   | Fatal_environment of { detail : string option }
   | Stale_turn of { progress_seen : bool }
   | Stale_termination_storm of { count : int }
+  | Turn_failure_streak of { count : int }
+  | Turn_overflow_pause
+  | Turn_livelock_pause
   | Ambiguous_partial_commit
 
 type failure_scope =

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -72,6 +72,8 @@ type failure_reason =
   | Ambiguous_partial_commit of ambiguous_partial_commit
   | Fiber_unresolved
   | Exception of string
+  | Turn_overflow_pause
+  | Turn_livelock_pause
 
 let ambiguous_partial_commit_kind_to_string =
   Keeper_registry_types_kill_class.ambiguous_partial_commit_kind_to_string
@@ -107,6 +109,8 @@ let failure_reason_to_string = function
       detail
   | Fiber_unresolved -> "fiber_unresolved"
   | Exception s -> Printf.sprintf "exception(%s)" s
+  | Turn_overflow_pause -> "turn_overflow_pause"
+  | Turn_livelock_pause -> "turn_livelock_pause"
 ;;
 
 (** #10584: cohort key for grouping failures by variant, ignoring
@@ -130,6 +134,8 @@ let failure_reason_cohort_key = function
   | Some (Ambiguous_partial_commit _) -> "ambiguous_partial_commit"
   | Some Fiber_unresolved -> "fiber_unresolved"
   | Some (Exception _) -> "exception"
+  | Some Turn_overflow_pause -> "turn_overflow_pause"
+  | Some Turn_livelock_pause -> "turn_livelock_pause"
   | None -> "unknown"
 ;;
 
@@ -141,6 +147,8 @@ let stale_watchdog_failure_reason ~prior ~kill_class =
       | Tool_required_unsatisfied _
       | Ambiguous_partial_commit _
       | Turn_consecutive_failures _
+      | Turn_overflow_pause
+      | Turn_livelock_pause
       | Heartbeat_consecutive_failures _
       | Exception _ ) -> prior
   | Some

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -100,6 +100,12 @@ type failure_reason =
   | Ambiguous_partial_commit of ambiguous_partial_commit
   | Fiber_unresolved
   | Exception of string
+  | Turn_overflow_pause
+      (** Keeper paused after context-overflow compact-retry exhaustion.
+          Triggers supervisor auto-resume sweep (RFC-0152 Phase B). *)
+  | Turn_livelock_pause
+      (** Keeper paused by turn-livelock guard. Triggers supervisor
+          auto-resume sweep (RFC-0152 Phase B). *)
 
 val ambiguous_partial_commit_kind_to_string :
   ambiguous_partial_commit_kind -> string

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -221,3 +221,97 @@ let failure_reason_policy_decision
   | None ->
     None
 ;;
+
+(** [handle_auto_pause_from_meta ~config ~meta ~reason_tag
+      ?metric_name ~lifecycle_detail ~log_message ~blocker_class
+      ~resume_policy] is the turn-context SSOT for pausing a keeper.
+
+    Unlike [handle_crash_auto_pause] (which operates on a supervisor
+    registry [entry] and receives an injected publisher), this
+    function works with the [config] + [meta] pair available inside
+    turn logic (S3 overflow, S5 livelock, S4 cascade-exhausted).  It
+    writes [paused=true] via [write_meta_with_merge] (heartbeat-field
+    CAS merge, same as the overflow path), updates the registry,
+    dispatches [Operator_pause] via
+    [dispatch_keeper_phase_event_checked], and emits [log_message] at
+    ERROR on success.
+
+    Returns [Ok paused_meta] on success or [Error err] if the disk
+    write fails.  Callers that previously fell back to in-memory
+    paused state on write failure can pattern-match on [Error] and
+    preserve their old behaviour. *)
+let handle_auto_pause_from_meta
+      ~config
+      ~meta
+      ~reason_tag
+      ?metric_name
+      ~lifecycle_detail
+      ~log_message
+      ~blocker_class
+      ~resume_policy
+  =
+  let auto_resume_after_sec =
+    auto_resume_after_sec_for_policy meta resume_policy
+  in
+  let blocker_text =
+    let existing =
+      match meta.runtime.last_blocker with
+      | Some info -> String.trim info.detail
+      | None -> ""
+    in
+    if existing <> ""
+    then existing
+    else (
+      match blocker_class with
+      | Some cls -> blocker_class_to_string cls
+      | None -> reason_tag)
+  in
+  let blocker_info_opt =
+    match blocker_class with
+    | Some klass -> Some (blocker_info_of_class ~detail:blocker_text klass)
+    | None ->
+      (* Preserve pre-existing typed blocker info; do not fabricate
+         one from [reason_tag]. *)
+      meta.runtime.last_blocker
+  in
+  let paused_meta =
+    { meta with
+      paused = true
+    ; auto_resume_after_sec
+    ; updated_at = now_iso ()
+    ; runtime = { meta.runtime with last_blocker = blocker_info_opt }
+    }
+  in
+  match
+    write_meta_with_merge
+      ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+      config
+      paused_meta
+  with
+  | Ok () ->
+    (match metric_name with
+     | Some name ->
+       Prometheus.inc_counter name ~labels:[ "keeper", meta.name ] ()
+     | None -> ());
+    Keeper_registry.update_meta ~base_path:config.base_path meta.name paused_meta;
+    Keeper_turn_helpers.dispatch_keeper_phase_event_checked
+      ~config
+      ~keeper_name:meta.name
+      ~side_effect:(Printf.sprintf "%s auto-pause" reason_tag)
+      Keeper_state_machine.Operator_pause;
+    Log.Keeper.error "%s: %s" meta.name log_message;
+    Ok paused_meta
+  | Error err ->
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_write_meta_failures
+      ~labels:[ "keeper", meta.name
+              ; "phase", Printf.sprintf "%s_pause" reason_tag
+              ]
+      ();
+    Log.Keeper.warn
+      "%s: %s pause write_meta failed: %s"
+      meta.name
+      reason_tag
+      err;
+    Error err
+;;

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -211,9 +211,15 @@ let failure_reason_policy_decision
          Keeper_failure_policy.Required_tool_contract_violation)
   | Some (Keeper_registry.Ambiguous_partial_commit _) ->
     Some (Keeper_failure_policy.decide Keeper_failure_policy.Ambiguous_partial_commit)
+  | Some (Keeper_registry.Turn_consecutive_failures count) ->
+    Some
+      (Keeper_failure_policy.decide (Keeper_failure_policy.Turn_failure_streak { count }))
+  | Some Keeper_registry.Turn_overflow_pause ->
+    Some (Keeper_failure_policy.decide Keeper_failure_policy.Turn_overflow_pause)
+  | Some Keeper_registry.Turn_livelock_pause ->
+    Some (Keeper_failure_policy.decide Keeper_failure_policy.Turn_livelock_pause)
   | Some
       ( Keeper_registry.Heartbeat_consecutive_failures _
-      | Keeper_registry.Turn_consecutive_failures _
       | Keeper_registry.Stale_fleet_batch _
       | Keeper_registry.Provider_runtime_error _
       | Keeper_registry.Fiber_unresolved

--- a/lib/keeper/keeper_supervisor_pause_policy.mli
+++ b/lib/keeper/keeper_supervisor_pause_policy.mli
@@ -75,6 +75,21 @@ val handle_provider_timeout_pause
   -> count:int
   -> unit
 
+(** [handle_auto_pause_from_meta ~config ~meta ~reason_tag
+      ?metric_name ~lifecycle_detail ~log_message ~blocker_class
+      ~resume_policy] is the turn-context SSOT for pausing a keeper.
+    See the implementation file for full behavioural contract. *)
+val handle_auto_pause_from_meta
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> reason_tag:string
+  -> ?metric_name:string
+  -> lifecycle_detail:string
+  -> log_message:string
+  -> blocker_class:Keeper_meta_contract.blocker_class option
+  -> resume_policy:crash_pause_resume_policy
+  -> (Keeper_types.keeper_meta, string) result
+
 (** [failure_reason_policy_decision reason] maps a persisted
     [Keeper_registry.failure_reason] back to a
     [Keeper_failure_policy.decision]. Returns [None] for non-policy

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -623,6 +623,10 @@ let pause_keeper_for_overflow
       ~config
       ~keeper_name:meta.name
       Keeper_state_machine.Compact_retry_exhausted;
+    Keeper_registry.set_failure_reason
+      ~base_path:config.base_path
+      meta.name
+      (Some Keeper_registry.Turn_overflow_pause);
     paused_meta
   | Error _err ->
     (* Fallback: write failed but we must not leave the caller with
@@ -641,6 +645,10 @@ let pause_keeper_for_overflow
       }
     in
     Keeper_registry.update_meta ~base_path:config.base_path meta.name paused_meta;
+    Keeper_registry.set_failure_reason
+      ~base_path:config.base_path
+      meta.name
+      (Some Keeper_registry.Turn_overflow_pause);
     dispatch_keeper_phase_event
       ~config
       ~keeper_name:meta.name

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -604,69 +604,52 @@ let pause_keeper_for_overflow
     ~(config : Coord.config)
     ~(meta : keeper_meta)
     ~(reason : string) : keeper_meta =
-  let paused_meta =
-    {
-      meta with
-      paused = true;
-      auto_resume_after_sec =
-        Keeper_supervisor_pause_policy.auto_resume_after_sec_for_policy
-          meta
-          Keeper_supervisor_pause_policy.Auto_resume_with_backoff;
-      updated_at = now_iso ();
-    }
-  in
-  (* #9733: [paused = true] is cycle-owned (the overflow-recovery
-     fiber decided the keeper must pause); heartbeat-owned fields
-     (joined_room_ids, last_seen_seq_by_room) must come from disk so
-     a parallel heartbeat write doesn't fight us for [meta_version].
-     Bare [write_meta] here drops the pause silently in the lost-CAS
-     case -- the keeper then reports unpaused while the caller
-     believes it succeeded.  Same pattern as the unified-turn
-     failure path. *)
-  (match
-     write_meta_with_merge
-       ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-       config paused_meta
-   with
-   | Ok () -> ()
-   | Error err when is_version_conflict_error err ->
-       Prometheus.inc_counter
-         Keeper_metrics.metric_keeper_write_meta_failures
-         ~labels:[("keeper", meta.name); ("phase", "overflow_pause_cas_race")]
-         ();
-       Log.Keeper.warn
-         "%s: overflow pause write_meta lost CAS race after retries: %s"
-         meta.name err
-   | Error err ->
-       Prometheus.inc_counter
-         Keeper_metrics.metric_keeper_write_meta_failures
-         ~labels:[("keeper", meta.name); ("phase", "overflow_pause")]
-         ();
-       Log.Keeper.error
-         "%s: overflow pause write_meta failed: %s"
-         meta.name err);
-  Keeper_registry.update_meta ~base_path:config.base_path meta.name paused_meta;
-  (* Issue #8581: latch the retry-exhausted condition BEFORE the
-     Operator_pause that drives the Paused phase. This way the Paused
-     state carries the real reason (auto-compact retry budget exhausted)
-     for dashboards / operator observability -- the right disjunct of
-     [derive_phase]'s Paused branch ([context_overflow] /\
-     [compact_retry_exhausted]) reaches a real value instead of staying
-     dead code. The Operator_pause that follows still drives the actual
-     phase transition deterministically (first disjunct:
-     [operator_paused]). *)
-  dispatch_keeper_phase_event
-    ~config
-    ~keeper_name:meta.name
-    Keeper_state_machine.Compact_retry_exhausted;
-  dispatch_keeper_phase_event
-    ~config
-    ~keeper_name:meta.name
-    Keeper_state_machine.Operator_pause;
-  Log.Keeper.warn
-    "%s: keeper paused after unresolved context overflow (%s)"
-    meta.name reason;
-  paused_meta
+  match
+    Keeper_supervisor_pause_policy.handle_auto_pause_from_meta
+      ~config
+      ~meta
+      ~reason_tag:"overflow"
+      ~lifecycle_detail:(Printf.sprintf "context_overflow %s" reason)
+      ~log_message:(Printf.sprintf "keeper paused after unresolved context overflow (%s)" reason)
+      ~blocker_class:None
+      ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
+  with
+  | Ok paused_meta ->
+    (* Issue #8581: latch the retry-exhausted condition BEFORE the
+       Operator_pause that drives the Paused phase.  The SSOT
+       function already dispatched [Operator_pause]; we only need
+       the extra [Compact_retry_exhausted] signal here. *)
+    dispatch_keeper_phase_event
+      ~config
+      ~keeper_name:meta.name
+      Keeper_state_machine.Compact_retry_exhausted;
+    paused_meta
+  | Error _err ->
+    (* Fallback: write failed but we must not leave the caller with
+       an unpaused keeper.  Replicate the old in-memory pause path
+       (registry update + events) so the scheduling loop skips this
+       keeper on the next tick.  The write failure is already logged
+       and counted by [handle_auto_pause_from_meta]. *)
+    let paused_meta =
+      { meta with
+        paused = true;
+        auto_resume_after_sec =
+          Keeper_supervisor_pause_policy.auto_resume_after_sec_for_policy
+            meta
+            Keeper_supervisor_pause_policy.Auto_resume_with_backoff;
+        updated_at = now_iso ();
+      }
+    in
+    Keeper_registry.update_meta ~base_path:config.base_path meta.name paused_meta;
+    dispatch_keeper_phase_event
+      ~config
+      ~keeper_name:meta.name
+      Keeper_state_machine.Compact_retry_exhausted;
+    dispatch_keeper_phase_event
+      ~config
+      ~keeper_name:meta.name
+      Keeper_state_machine.Operator_pause;
+    paused_meta
 
 let sync_keeper_paused_state_impl
     ~(resume_policy : Keeper_supervisor_pause_policy.crash_pause_resume_policy option)

--- a/lib/keeper/keeper_unified_turn_livelock_block.ml
+++ b/lib/keeper/keeper_unified_turn_livelock_block.ml
@@ -70,44 +70,18 @@ let persist_turn_livelock_pause
       ~(detail : string)
   : unit
   =
-  let blocker =
-    Keeper_types.blocker_info_of_class
-      ~detail
-      Keeper_types.Turn_livelock_blocked
-  in
-  let updated =
-    { meta with
-      paused = true
-    ; auto_resume_after_sec =
-        Keeper_supervisor_pause_policy.auto_resume_after_sec_for_policy
-          meta
-          Keeper_supervisor_pause_policy.Auto_resume_with_backoff
-    ; updated_at = Keeper_types.now_iso ()
-    ; runtime = { meta.runtime with last_blocker = Some blocker }
-    }
-  in
-  match Keeper_types.write_meta ~force:true config updated with
-  | Ok () ->
-    Keeper_registry.update_meta ~base_path:config.base_path meta.name updated;
-    Keeper_registry.dispatch_event_unit
-      ~base_path:config.base_path
-      meta.name
-      Keeper_state_machine.Operator_pause;
-    Log.Keeper.warn
-      ~keeper_name:meta.name
-      "paused keeper %s after turn livelock block: %s"
-      meta.name
-      detail
-  | Error err ->
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_write_meta_failures
-      ~labels:[ "keeper", meta.name; "phase", "turn_livelock_pause" ]
-      ();
-    Log.Keeper.warn
-      ~keeper_name:meta.name
-      "failed to persist turn livelock pause for %s: %s"
-      meta.name
-      err
+  match
+    Keeper_supervisor_pause_policy.handle_auto_pause_from_meta
+      ~config
+      ~meta
+      ~reason_tag:"turn_livelock"
+      ~lifecycle_detail:detail
+      ~log_message:(Printf.sprintf "paused keeper after turn livelock block: %s" detail)
+      ~blocker_class:(Some Keeper_types.Turn_livelock_blocked)
+      ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
+  with
+  | Ok _paused_meta -> ()
+  | Error _err -> ()
 ;;
 
 let handle

--- a/lib/keeper/keeper_unified_turn_livelock_block.ml
+++ b/lib/keeper/keeper_unified_turn_livelock_block.ml
@@ -128,5 +128,9 @@ let handle
      scheduler observed total_turns+1 candidate turn and re-blocked the
      same (keeper, turn_id), fuelling the repeated ERROR log surface. *)
   persist_turn_livelock_pause ~config ~meta ~detail:error_message;
+  Keeper_registry.set_failure_reason
+    ~base_path:config.base_path
+    meta.name
+    (Some Keeper_registry.Turn_livelock_pause);
   Error (Agent_sdk.Error.Internal error_message)
 ;;


### PR DESCRIPTION
## Summary

RFC-0152 Phase A/B — closes the fleet-wide silent failure where keepers permanently stall because S3/S4/S5 pause paths don't set `failure_reason` variants that the supervisor auto-resume sweep recognizes.

## Changes

| Phase | Files | What |
|-------|-------|------|
| A | `keeper_supervisor_pause_policy.ml/mli`, `keeper_turn_cascade_budget.ml`, `keeper_unified_turn_livelock_block.ml` | Extract `handle_auto_pause_from_meta` SSOT for turn-context pause; deduplicate S3 overflow and S5 livelock paths |
| B | `keeper_failure_policy.ml/mli`, `keeper_registry_types.ml/mli`, `keeper_supervisor_pause_policy.ml`, `keeper_turn_cascade_budget.ml`, `keeper_unified_turn_livelock_block.ml` | Add `Turn_overflow_pause`, `Turn_livelock_pause`, `Turn_failure_streak` variants; wire through `failure_reason_policy_decision` → `Pause_keeper` |

## Root cause

Supervisor sweep (`keeper_supervisor.ml`) checks `paused_meta_auto_resume_due`, which requires `is_running=false` (entry unregistered). S6/S7 call `to_unregister`; S3/S4/S5 don't. Worse, their `failure_reason` variants either didn't exist or mapped to `None` in `failure_reason_policy_decision`, so the sweep never routed them to auto-resume.

## Verification

- `dune build @install --profile=release` — clean compile
- 7 files changed, 63 insertions(+), 1 deletion(-)

## References

- RFC-0152
- `memory/rfc-0152-auto-resume-audit-2026-05-23.html`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>