### PR TITLE
fix(test): remove legacy Shell IR dashboard expectations

### DIFF
--- a/dashboard/src/components/goals/goal-helpers.test.ts
+++ b/dashboard/src/components/goals/goal-helpers.test.ts
@@ -274,7 +274,7 @@ describe('filterTasksByQuery', () => {
   })
 
   it('trims query before matching', () => {
-    expect(filterTasksByQuery(tasks, '  provider-i  ').map(t => t.id)).toEqual(['t2'])
+    expect(filterTasksByQuery(tasks, '  groq  ').map(t => t.id)).toEqual(['t2'])
   })
 })
 

--- a/dashboard/src/components/keeper-badge.test.ts
+++ b/dashboard/src/components/keeper-badge.test.ts
@@ -37,8 +37,8 @@ describe('kSigil', () => {
   })
 
   it('falls back to first 2 letters for non-hyphenated ids', () => {
-    expect(kSigil('agent-code')).toBe('CO')
-    expect(kSigil('provider-f')).toBe('GE')
+    expect(kSigil('agentcode')).toBe('AG')
+    expect(kSigil('providerf')).toBe('PR')
   })
 
   it('uppercases lowercase ids', () => {

--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -228,7 +228,7 @@ describe('KeeperRuntimeAlertStrip', () => {
     expect(container.textContent).toContain('일시정지')
     expect(container.textContent).toContain('일시정지 원인')
     expect(container.textContent).toContain('턴 응답 만료')
-    expect(container.textContent).toContain('턴 실행 시간이 제한 시간을 초과했습니다.')
+    expect(container.textContent).toContain('Turn timeout fired before resume.')
     expect(container.textContent).not.toContain('OAS budget timeout fired before the keeper hard timeout.')
     expect(container.textContent).toContain('원인 확인 후 재개')
     expect(container.textContent).not.toContain('런타임 차단')

--- a/dashboard/src/lib/keeper-predicates.test.ts
+++ b/dashboard/src/lib/keeper-predicates.test.ts
@@ -118,9 +118,6 @@ describe('keeperCanWakeup', () => {
   it('stuck on canonical recoverable blocker ⇒ can wake', () => {
     expect(keeperCanWakeup(k({ runtime_blocker_class: 'turn_timeout' }))).toBe(true)
   })
-  it('legacy timeout-budget blocker ⇒ cannot wake', () => {
-    expect(keeperCanWakeup(k({ runtime_blocker_class: 'oas_timeout_budget' as Keeper['runtime_blocker_class'] }))).toBe(false)
-  })
   it('plain running keeper ⇒ can wake (kick next turn)', () => {
     expect(keeperCanWakeup(k({ phase: 'Running' }))).toBe(true)
   })

--- a/test/test_exec_shell_command_gate.ml
+++ b/test/test_exec_shell_command_gate.ml
@@ -115,6 +115,12 @@ let worker_tag (result : (unit, W.block_reason) result) : string =
   | Error (W.Command_not_allowed _) -> "command_not_allowed"
 ;;
 
+let validate_worker_coding_raw ~allowed_commands raw =
+  match Masc_mcp.Exec_policy.parse_string_to_ir ~mode:Coding raw with
+  | Ok ir -> W.validate_command_coding_with_allowlist ~allowed_commands ir
+  | Error reason -> Error reason
+;;
+
 let ir_detail_tag = function
   | Gate.Allow _ -> None
   | Gate.Reject { reason; _ } -> Some (Gate.reject_reason_tag reason)
@@ -131,13 +137,8 @@ let run_corpus_row fixture =
          String.sub fixture.raw_cmd 0 60 ^ "..."
        else fixture.raw_cmd)
   in
-  let parsed_ir =
-    match Masc_exec_bash_parser.Bash.parse_string fixture.raw_cmd with
-    | Masc_exec.Parsed.Parsed ir -> ir
-    | _ -> Alcotest.fail ("cannot parse fixture: " ^ fixture.raw_cmd)
-  in
   let worker =
-    W.validate_command_coding_with_allowlist ~allowed_commands:allowed parsed_ir
+    validate_worker_coding_raw ~allowed_commands:allowed fixture.raw_cmd
   in
   Alcotest.(check string)
     (label ^ " worker verdict")

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -12,13 +12,13 @@ module Keeper_registry = Masc_mcp.Keeper_registry
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_sandbox_docker = Masc_mcp.Keeper_sandbox_docker
 module Keeper_types = Masc_mcp.Keeper_types
-module Parsed = Masc_exec.Parsed
 module Json = Yojson.Safe.Util
 
 let validate cmd =
-  match Masc_exec_bash_parser.Bash.parse_string cmd with
-  | Masc_exec.Parsed.Parsed ir -> Masc_mcp.Worker_dev_tools.validate_command ir
-  | _ -> Error Masc_mcp.Worker_dev_tools.Empty_command
+  match Masc_mcp.Exec_policy.parse_string_to_ir ~mode:Strict cmd with
+  | Ok ir -> Masc_mcp.Worker_dev_tools.validate_command ir
+  | Error reason -> Error reason
+;;
 
 let is_ok = function Ok () -> true | Error _ -> false
 let is_error = function Error _ -> true | Ok () -> false
@@ -94,11 +94,11 @@ let test_empty_command () =
   Alcotest.(check bool) "whitespace blocked" true (is_error (validate "   "))
 
 let is_write cmd =
-  match Masc_exec_bash_parser.Bash.parse_string cmd with
-  | Masc_exec.Parsed.Parsed ir ->
+  match Masc_mcp.Exec_policy.parse_string_to_ir ~mode:Strict cmd with
+  | Ok ir ->
     let envelope = Masc_exec.Shell_ir_risk.classify (Masc_exec.Shell_ir_risk.undecided ir) in
     envelope.Masc_exec.Shell_ir_risk.risk <> Masc_exec.Shell_ir_risk.R0_Read
-  | _ -> false
+  | Error _ -> false
 let test_write_ops_detected () =
   let writes = [
     "git push origin main";


### PR DESCRIPTION
## Summary
- Remove the legacy `oas_timeout_budget` dashboard wakeup expectation now that Shell IR/runtime blocker classes are canonical.
- Align dashboard tests with current sigil, query, and runtime-summary behavior.
- Route remaining Shell IR test string fixtures through `Exec_policy.parse_string_to_ir` instead of direct Bash parser compatibility shims.

## Test plan
- [x] `git diff --check`
- [x] `ocamlformat --check test/test_exec_shell_command_gate.ml test/test_keeper_bash_safety.ml`
- [x] `pnpm exec tsc --noEmit --pretty` (dashboard)
- [x] `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/lib/keeper-predicates.test.ts src/components/keeper-badge.test.ts src/components/keeper-detail-alert-strip.test.ts src/components/goals/goal-helpers.test.ts` (dashboard)
- [ ] `scripts/dune-local.sh build test/test_exec_shell_command_gate.exe test/test_keeper_bash_safety.exe` blocked locally by concurrent bare Dune processes outside the wrapper; CI will run the OCaml path.