### PR TITLE
fix(keeper): cover pause failure reasons

### DIFF
--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -114,6 +114,8 @@ let runtime_pressure_class_of_failure_reason = function
   | Some
       ( Keeper_registry.Fiber_unresolved
       | Keeper_registry.Exception _
+      | Keeper_registry.Turn_overflow_pause
+      | Keeper_registry.Turn_livelock_pause
       | Keeper_registry.Stale_termination_storm _
       | Keeper_registry.Stale_fleet_batch _
       | Keeper_registry.Ambiguous_partial_commit _ ) ->

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -228,6 +228,8 @@ let failure_reason_batch_root_cause
       Some Cascade_unhealthy
   | Heartbeat_consecutive_failures _
   | Turn_consecutive_failures _
+  | Turn_overflow_pause
+  | Turn_livelock_pause
   | Tool_required_unsatisfied _
   | Ambiguous_partial_commit _
   | Fiber_unresolved

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -492,8 +492,20 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
            (Printf.sprintf
               "Stale watchdog terminated %d distinct keeper(s) inside the fleet batch \
                window; keeper was auto-paused before restart loop."
-              distinct_count)
+               distinct_count)
          Stale_fleet_batch)
+  | Keeper_registry.Turn_overflow_pause ->
+    Some
+      { blocker_class = "turn_overflow_pause"
+      ; summary =
+          "Turn context overflow persisted a keeper pause after retry exhaustion."
+      ; continue_gate = false
+      }
+  | Keeper_registry.Turn_livelock_pause ->
+    Some
+      (runtime_blocker_surface_of_typed_class
+         ~summary:"Turn livelock guard persisted a keeper pause."
+         Turn_livelock_blocked)
   | Keeper_registry.Provider_runtime_error { code; detail } ->
     Some
       { blocker_class = "provider_runtime_error"

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -191,6 +191,8 @@ let launch_supervised_fiber
                   | Some (Keeper_registry.Turn_consecutive_failures _)
                   | Some (Keeper_registry.Provider_runtime_error _)
                   | Some (Keeper_registry.Tool_required_unsatisfied _)
+                  | Some Keeper_registry.Turn_overflow_pause
+                  | Some Keeper_registry.Turn_livelock_pause
                   | Some (Keeper_registry.Ambiguous_partial_commit _)
                   | Some Keeper_registry.Fiber_unresolved
                   | Some (Keeper_registry.Exception _)
@@ -723,6 +725,9 @@ let sweep_and_recover (ctx : _ context) =
             keeper death. *)
          handle_provider_timeout_pause ctx entry ~count;
          to_unregister := entry :: !to_unregister
+       | Some Keeper_registry.Turn_overflow_pause
+       | Some Keeper_registry.Turn_livelock_pause ->
+         to_unregister := entry :: !to_unregister
        | Some
            ( Keeper_registry.Heartbeat_consecutive_failures _
            | Keeper_registry.Turn_consecutive_failures _
@@ -760,6 +765,8 @@ let sweep_and_recover (ctx : _ context) =
     | Some (Keeper_registry.Turn_consecutive_failures _)
     | Some (Keeper_registry.Provider_runtime_error _)
     | Some (Keeper_registry.Tool_required_unsatisfied _)
+    | Some Keeper_registry.Turn_overflow_pause
+    | Some Keeper_registry.Turn_livelock_pause
     | Some (Keeper_registry.Ambiguous_partial_commit _)
     | Some Keeper_registry.Fiber_unresolved
     | Some (Keeper_registry.Exception _)
@@ -791,6 +798,8 @@ let sweep_and_recover (ctx : _ context) =
       | Some (Keeper_registry.Turn_consecutive_failures _)
       | Some (Keeper_registry.Provider_runtime_error _)
       | Some (Keeper_registry.Tool_required_unsatisfied _)
+      | Some Keeper_registry.Turn_overflow_pause
+      | Some Keeper_registry.Turn_livelock_pause
       | Some (Keeper_registry.Ambiguous_partial_commit _)
       | Some Keeper_registry.Fiber_unresolved
       | Some (Keeper_registry.Exception _)

--- a/lib/keeper/keeper_supervisor_alive_but_stuck.ml
+++ b/lib/keeper/keeper_supervisor_alive_but_stuck.ml
@@ -87,7 +87,9 @@ let request_recovery ~base_path ~elapsed (entry : Keeper_registry.registry_entry
     | Some
         ( Keeper_registry.Stale_turn_timeout _
         | Keeper_registry.Stale_termination_storm _
-        | Keeper_registry.Provider_timeout_loop _ ) as kept -> kept
+        | Keeper_registry.Provider_timeout_loop _
+        | Keeper_registry.Turn_overflow_pause
+        | Keeper_registry.Turn_livelock_pause ) as kept -> kept
     | Some (Keeper_registry.Heartbeat_consecutive_failures _)
     | Some (Keeper_registry.Turn_consecutive_failures _)
     | Some (Keeper_registry.Provider_runtime_error _)

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -255,6 +255,7 @@ let handle_auto_pause_from_meta
       ~log_message
       ~blocker_class
       ~resume_policy
+      ()
   =
   let auto_resume_after_sec =
     auto_resume_after_sec_for_policy meta resume_policy

--- a/lib/keeper/keeper_supervisor_pause_policy.mli
+++ b/lib/keeper/keeper_supervisor_pause_policy.mli
@@ -88,6 +88,7 @@ val handle_auto_pause_from_meta
   -> log_message:string
   -> blocker_class:Keeper_meta_contract.blocker_class option
   -> resume_policy:crash_pause_resume_policy
+  -> unit
   -> (Keeper_types.keeper_meta, string) result
 
 (** [failure_reason_policy_decision reason] maps a persisted

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -613,6 +613,7 @@ let pause_keeper_for_overflow
       ~log_message:(Printf.sprintf "keeper paused after unresolved context overflow (%s)" reason)
       ~blocker_class:None
       ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
+      ()
   with
   | Ok paused_meta ->
     (* Issue #8581: latch the retry-exhausted condition BEFORE the

--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -111,6 +111,8 @@ let of_termination_code (c : Code.t) : t =
   | Code.Turn_failures
   | Code.Stale_termination_storm
   | Code.Stale_fleet_batch
+  | Code.Turn_overflow_pause
+  | Code.Turn_livelock_pause
   | Code.Provider_runtime_error _
   | Code.Fiber_unresolved
   | Code.Exception_unhandled _

--- a/lib/keeper/keeper_turn_terminal_code.ml
+++ b/lib/keeper/keeper_turn_terminal_code.ml
@@ -12,6 +12,8 @@ type t =
   | Stale_turn_timeout_noop
   | Stale_termination_storm
   | Stale_fleet_batch
+  | Turn_overflow_pause
+  | Turn_livelock_pause
   | Heartbeat_failures
   | Turn_failures
   | Provider_runtime_error of string
@@ -34,6 +36,8 @@ let to_wire = function
     "stale_turn_timeout"
   | Stale_termination_storm -> "stale_termination_storm"
   | Stale_fleet_batch -> "stale_fleet_batch"
+  | Turn_overflow_pause -> "turn_overflow_pause"
+  | Turn_livelock_pause -> "turn_livelock_pause"
   | Heartbeat_failures -> "heartbeat_failures"
   | Turn_failures -> "turn_failures"
   | Provider_runtime_error code -> code
@@ -54,6 +58,8 @@ let of_wire = function
     Some Stale_turn_timeout_in_turn
   | "stale_termination_storm" -> Some Stale_termination_storm
   | "stale_fleet_batch" -> Some Stale_fleet_batch
+  | "turn_overflow_pause" -> Some Turn_overflow_pause
+  | "turn_livelock_pause" -> Some Turn_livelock_pause
   | "heartbeat_failures" -> Some Heartbeat_failures
   | "turn_failures" -> Some Turn_failures
   | "ambiguous_partial_commit" ->
@@ -83,6 +89,8 @@ let of_failure_reason : Keeper_registry.failure_reason -> t = function
     Stale_turn_timeout_noop
   | Keeper_registry.Stale_termination_storm _ -> Stale_termination_storm
   | Keeper_registry.Stale_fleet_batch _ -> Stale_fleet_batch
+  | Keeper_registry.Turn_overflow_pause -> Turn_overflow_pause
+  | Keeper_registry.Turn_livelock_pause -> Turn_livelock_pause
   | Keeper_registry.Provider_timeout_loop _ ->
     Provider_runtime_error "provider_timeout_loop"
   | Keeper_registry.Provider_runtime_error { code; _ } -> Provider_runtime_error code

--- a/lib/keeper/keeper_turn_terminal_code.mli
+++ b/lib/keeper/keeper_turn_terminal_code.mli
@@ -38,6 +38,12 @@ type t =
   (** [Keeper_registry.Stale_fleet_batch]: legacy fleet-batch wire value.
       Current fleet-batch detection is observation-only; fresh watchdog kills
       retain their per-keeper terminal code. *)
+  | Turn_overflow_pause
+  (** [Keeper_registry.Turn_overflow_pause]: the turn-context overflow path
+      persisted a keeper pause. *)
+  | Turn_livelock_pause
+  (** [Keeper_registry.Turn_livelock_pause]: the livelock guard persisted a
+      keeper pause. *)
   | Heartbeat_failures (** [Keeper_registry.Heartbeat_consecutive_failures]. *)
   | Turn_failures (** [Keeper_registry.Turn_consecutive_failures]. *)
   | Provider_runtime_error of string

--- a/lib/keeper/keeper_unified_turn_livelock_block.ml
+++ b/lib/keeper/keeper_unified_turn_livelock_block.ml
@@ -79,6 +79,7 @@ let persist_turn_livelock_pause
       ~log_message:(Printf.sprintf "paused keeper after turn livelock block: %s" detail)
       ~blocker_class:(Some Keeper_types.Turn_livelock_blocked)
       ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
+      ()
   with
   | Ok _paused_meta -> ()
   | Error _err -> ()

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -141,7 +141,17 @@ let test_runtime_pressure_classifier () =
     pressure_label_t
     "legacy oas timeout normalizes to provider timeout"
     (Some "provider_timeout")
-    (pressure_label_of_failure_reason (R.Provider_timeout_loop { count = 2 }))
+    (pressure_label_of_failure_reason (R.Provider_timeout_loop { count = 2 }));
+  Alcotest.check
+    pressure_label_t
+    "turn overflow pause is runtime pressure"
+    (Some "runtime_failure")
+    (pressure_label_of_failure_reason R.Turn_overflow_pause);
+  Alcotest.check
+    pressure_label_t
+    "turn livelock pause is runtime pressure"
+    (Some "runtime_failure")
+    (pressure_label_of_failure_reason R.Turn_livelock_pause)
 ;;
 
 let test_run_once_records_specific_failure_ratio_reason () =

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -156,6 +156,8 @@ let round_trippable : (string * D.t) list =
   ; "Provider_error/Turn_failures", D.Provider_error Code.Turn_failures
   ; "Provider_error/Storm", D.Provider_error Code.Stale_termination_storm
   ; "Provider_error/FleetBatch", D.Provider_error Code.Stale_fleet_batch
+  ; "Provider_error/TurnOverflow", D.Provider_error Code.Turn_overflow_pause
+  ; "Provider_error/TurnLivelock", D.Provider_error Code.Turn_livelock_pause
   ; "Provider_error/Fiber", D.Provider_error Code.Fiber_unresolved
   ]
 ;;
@@ -224,6 +226,8 @@ let runtime_codes_to_projection : (string * Code.t * D.t) list =
   ; "Turn_failures", Code.Turn_failures, D.Provider_error Code.Turn_failures
   ; "Storm", Code.Stale_termination_storm, D.Provider_error Code.Stale_termination_storm
   ; "FleetBatch", Code.Stale_fleet_batch, D.Provider_error Code.Stale_fleet_batch
+  ; "TurnOverflow", Code.Turn_overflow_pause, D.Provider_error Code.Turn_overflow_pause
+  ; "TurnLivelock", Code.Turn_livelock_pause, D.Provider_error Code.Turn_livelock_pause
   ; ( "Provider_runtime"
     , Code.Provider_runtime_error "p"
     , D.Provider_error (Code.Provider_runtime_error "p") )

--- a/test/test_keeper_turn_terminal_disposition_field.ml
+++ b/test/test_keeper_turn_terminal_disposition_field.ml
@@ -36,6 +36,8 @@ let constructor_cases : (string * T.t) list =
   ; "of_code/unknown", T.of_code "totally_unmapped"
   ; "of_code/empty", T.of_code ""
   ; "of_code/turn_wall_clock", T.of_code "turn_wall_clock_timeout"
+  ; "of_code/turn_overflow_pause", T.of_code "turn_overflow_pause"
+  ; "of_code/turn_livelock_pause", T.of_code "turn_livelock_pause"
   ; "of_code/require_tool_use", T.of_code "required_tool_use_no_tool_call"
   ]
 ;;


### PR DESCRIPTION
## Summary
- Cover the new Turn_overflow_pause / Turn_livelock_pause failure reasons across keeper health, supervisor, stale-watchdog, status, and terminal-code classifiers.
- Close the handle_auto_pause_from_meta optional-argument leak by adding the final unit application required for labeled optional args.
- Refresh the current shell parse-site ratchet baseline so the branch reflects current main truth.

## Verification
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 scripts/dune-local.sh build test/test_keeper_health_probe.exe test/test_keeper_turn_disposition.exe test/test_keeper_turn_terminal_disposition_field.exe test/test_keeper_supervisor.exe test/test_keeper_sandbox_boundary_policy.exe test/test_keeper_sandbox_docker_route.exe test/test_keeper_sandbox_read_runner.exe test/test_shell_parse_site_ratchet.exe
- _build/default/test/test_keeper_turn_disposition.exe
- _build/default/test/test_keeper_turn_terminal_disposition_field.exe
- _build/default/test/test_keeper_health_probe.exe test cascade 1 --show-errors --compact
- _build/default/test/test_keeper_sandbox_boundary_policy.exe
- _build/default/test/test_keeper_sandbox_read_runner.exe
- _build/default/test/test_keeper_sandbox_docker_route.exe test docker_route_fires 17-21 --show-errors --compact
- _build/default/test/test_shell_parse_site_ratchet.exe
- opam exec -- ocamlformat --check ...
- git diff --check
- bash scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json
- scripts/ocaml-structure-ratchet.sh

Note: running the entire test_keeper_health_probe.exe directly still hits the existing Eio context issue in cascade test 2; this PR verifies the classifier subtest touched by the change.