### PR TITLE
fix(keeper): cover Turn_overflow_pause / Turn_livelock_pause in all match sites

### DIFF
--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -114,6 +114,8 @@ let runtime_pressure_class_of_failure_reason = function
   | Some
       ( Keeper_registry.Fiber_unresolved
       | Keeper_registry.Exception _
+      | Keeper_registry.Turn_overflow_pause
+      | Keeper_registry.Turn_livelock_pause
       | Keeper_registry.Stale_termination_storm _
       | Keeper_registry.Stale_fleet_batch _
       | Keeper_registry.Ambiguous_partial_commit _ ) ->

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -228,6 +228,8 @@ let failure_reason_batch_root_cause
       Some Cascade_unhealthy
   | Heartbeat_consecutive_failures _
   | Turn_consecutive_failures _
+  | Turn_overflow_pause
+  | Turn_livelock_pause
   | Tool_required_unsatisfied _
   | Ambiguous_partial_commit _
   | Fiber_unresolved

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -524,6 +524,18 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
            "Keeper fiber did not resolve a terminal outcome; supervisor cleanup is \
             required."
          Fiber_unresolved)
+  | Keeper_registry.Turn_overflow_pause ->
+    Some
+      { blocker_class = "turn_overflow_pause"
+      ; summary = "Context overflow with compact retry exhausted; keeper was auto-paused."
+      ; continue_gate = false
+      }
+  | Keeper_registry.Turn_livelock_pause ->
+    Some
+      { blocker_class = "turn_livelock_pause"
+      ; summary = "Turn livelock guard blocked dispatch; keeper was auto-paused."
+      ; continue_gate = false
+      }
   | Keeper_registry.Exception detail ->
     Some
       { blocker_class = "exception"

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -191,6 +191,8 @@ let launch_supervised_fiber
                   | Some (Keeper_registry.Turn_consecutive_failures _)
                   | Some (Keeper_registry.Provider_runtime_error _)
                   | Some (Keeper_registry.Tool_required_unsatisfied _)
+                  | Some Keeper_registry.Turn_overflow_pause
+                  | Some Keeper_registry.Turn_livelock_pause
                   | Some (Keeper_registry.Ambiguous_partial_commit _)
                   | Some Keeper_registry.Fiber_unresolved
                   | Some (Keeper_registry.Exception _)
@@ -723,6 +725,9 @@ let sweep_and_recover (ctx : _ context) =
             keeper death. *)
          handle_provider_timeout_pause ctx entry ~count;
          to_unregister := entry :: !to_unregister
+       | Some Keeper_registry.Turn_overflow_pause
+       | Some Keeper_registry.Turn_livelock_pause ->
+         to_unregister := entry :: !to_unregister
        | Some
            ( Keeper_registry.Heartbeat_consecutive_failures _
            | Keeper_registry.Turn_consecutive_failures _
@@ -760,6 +765,8 @@ let sweep_and_recover (ctx : _ context) =
     | Some (Keeper_registry.Turn_consecutive_failures _)
     | Some (Keeper_registry.Provider_runtime_error _)
     | Some (Keeper_registry.Tool_required_unsatisfied _)
+    | Some Keeper_registry.Turn_overflow_pause
+    | Some Keeper_registry.Turn_livelock_pause
     | Some (Keeper_registry.Ambiguous_partial_commit _)
     | Some Keeper_registry.Fiber_unresolved
     | Some (Keeper_registry.Exception _)
@@ -791,6 +798,8 @@ let sweep_and_recover (ctx : _ context) =
       | Some (Keeper_registry.Turn_consecutive_failures _)
       | Some (Keeper_registry.Provider_runtime_error _)
       | Some (Keeper_registry.Tool_required_unsatisfied _)
+      | Some Keeper_registry.Turn_overflow_pause
+      | Some Keeper_registry.Turn_livelock_pause
       | Some (Keeper_registry.Ambiguous_partial_commit _)
       | Some Keeper_registry.Fiber_unresolved
       | Some (Keeper_registry.Exception _)

--- a/lib/keeper/keeper_supervisor_alive_but_stuck.ml
+++ b/lib/keeper/keeper_supervisor_alive_but_stuck.ml
@@ -94,6 +94,8 @@ let request_recovery ~base_path ~elapsed (entry : Keeper_registry.registry_entry
     | Some (Keeper_registry.Tool_required_unsatisfied _)
     | Some (Keeper_registry.Ambiguous_partial_commit _)
     | Some (Keeper_registry.Stale_fleet_batch _)
+    | Some Keeper_registry.Turn_overflow_pause
+    | Some Keeper_registry.Turn_livelock_pause
     | Some Keeper_registry.Fiber_unresolved
     | Some (Keeper_registry.Exception _)
     | None -> Some (Keeper_registry.Stale_turn_timeout kill_class)

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -255,6 +255,7 @@ let handle_auto_pause_from_meta
       ~log_message
       ~blocker_class
       ~resume_policy
+      ()
   =
   let auto_resume_after_sec =
     auto_resume_after_sec_for_policy meta resume_policy

--- a/lib/keeper/keeper_supervisor_pause_policy.mli
+++ b/lib/keeper/keeper_supervisor_pause_policy.mli
@@ -88,6 +88,7 @@ val handle_auto_pause_from_meta
   -> log_message:string
   -> blocker_class:Keeper_meta_contract.blocker_class option
   -> resume_policy:crash_pause_resume_policy
+  -> unit
   -> (Keeper_types.keeper_meta, string) result
 
 (** [failure_reason_policy_decision reason] maps a persisted

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -613,6 +613,7 @@ let pause_keeper_for_overflow
       ~log_message:(Printf.sprintf "keeper paused after unresolved context overflow (%s)" reason)
       ~blocker_class:None
       ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
+      ()
   with
   | Ok paused_meta ->
     (* Issue #8581: latch the retry-exhausted condition BEFORE the

--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -111,6 +111,8 @@ let of_termination_code (c : Code.t) : t =
   | Code.Turn_failures
   | Code.Stale_termination_storm
   | Code.Stale_fleet_batch
+  | Code.Turn_overflow_pause
+  | Code.Turn_livelock_pause
   | Code.Provider_runtime_error _
   | Code.Fiber_unresolved
   | Code.Exception_unhandled _

--- a/lib/keeper/keeper_turn_terminal_code.ml
+++ b/lib/keeper/keeper_turn_terminal_code.ml
@@ -19,6 +19,8 @@ type t =
   | Ambiguous_partial_commit_post_commit_timeout
   | Ambiguous_partial_commit_post_commit_failure
   | Fiber_unresolved
+  | Turn_overflow_pause
+  | Turn_livelock_pause
   | Exception_unhandled of string
   | Sdk_error of string
 
@@ -41,6 +43,8 @@ let to_wire = function
   | Ambiguous_partial_commit_post_commit_timeout
   | Ambiguous_partial_commit_post_commit_failure -> "ambiguous_partial_commit"
   | Fiber_unresolved -> "fiber_unresolved"
+  | Turn_overflow_pause -> "turn_overflow_pause"
+  | Turn_livelock_pause -> "turn_livelock_pause"
   | Exception_unhandled _ -> "exception"
   | Sdk_error wire -> wire
 ;;
@@ -61,6 +65,8 @@ let of_wire = function
          to [Post_commit_timeout]. *)
     Some Ambiguous_partial_commit_post_commit_timeout
   | "fiber_unresolved" -> Some Fiber_unresolved
+  | "turn_overflow_pause" -> Some Turn_overflow_pause
+  | "turn_livelock_pause" -> Some Turn_livelock_pause
   | "exception" -> Some (Exception_unhandled "")
   | _other ->
     (* Could be a [Provider_runtime_error] / [Tool_required_unsatisfied]
@@ -95,6 +101,8 @@ let of_failure_reason : Keeper_registry.failure_reason -> t = function
       { kind = Keeper_registry.Post_commit_failure; _ } ->
     Ambiguous_partial_commit_post_commit_failure
   | Keeper_registry.Fiber_unresolved -> Fiber_unresolved
+  | Keeper_registry.Turn_overflow_pause -> Turn_overflow_pause
+  | Keeper_registry.Turn_livelock_pause -> Turn_livelock_pause
   | Keeper_registry.Exception msg -> Exception_unhandled msg
 ;;
 

--- a/lib/keeper/keeper_turn_terminal_code.mli
+++ b/lib/keeper/keeper_turn_terminal_code.mli
@@ -53,6 +53,12 @@ type t =
   (** [Keeper_registry.Ambiguous_partial_commit] with
           [kind = Post_commit_failure]. *)
   | Fiber_unresolved (** [Keeper_registry.Fiber_unresolved]. *)
+  | Turn_overflow_pause
+  (** [Keeper_registry.Turn_overflow_pause]: context overflow with
+          compact retry exhausted; keeper auto-paused. *)
+  | Turn_livelock_pause
+  (** [Keeper_registry.Turn_livelock_pause]: turn livelock guard
+          blocked dispatch; keeper auto-paused. *)
   | Exception_unhandled of string
   (** [Keeper_registry.Exception]: payload is the exception
           message. *)

--- a/lib/keeper/keeper_unified_turn_livelock_block.ml
+++ b/lib/keeper/keeper_unified_turn_livelock_block.ml
@@ -79,6 +79,7 @@ let persist_turn_livelock_pause
       ~log_message:(Printf.sprintf "paused keeper after turn livelock block: %s" detail)
       ~blocker_class:(Some Keeper_types.Turn_livelock_blocked)
       ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
+      ()
   with
   | Ok _paused_meta -> ()
   | Error _err -> ()

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -141,7 +141,17 @@ let test_runtime_pressure_classifier () =
     pressure_label_t
     "legacy oas timeout normalizes to provider timeout"
     (Some "provider_timeout")
-    (pressure_label_of_failure_reason (R.Provider_timeout_loop { count = 2 }))
+    (pressure_label_of_failure_reason (R.Provider_timeout_loop { count = 2 }));
+  Alcotest.check
+    pressure_label_t
+    "turn overflow pause is runtime pressure"
+    (Some "runtime_failure")
+    (pressure_label_of_failure_reason R.Turn_overflow_pause);
+  Alcotest.check
+    pressure_label_t
+    "turn livelock pause is runtime pressure"
+    (Some "runtime_failure")
+    (pressure_label_of_failure_reason R.Turn_livelock_pause)
 ;;
 
 let test_run_once_records_specific_failure_ratio_reason () =

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -156,6 +156,8 @@ let round_trippable : (string * D.t) list =
   ; "Provider_error/Turn_failures", D.Provider_error Code.Turn_failures
   ; "Provider_error/Storm", D.Provider_error Code.Stale_termination_storm
   ; "Provider_error/FleetBatch", D.Provider_error Code.Stale_fleet_batch
+  ; "Provider_error/TurnOverflow", D.Provider_error Code.Turn_overflow_pause
+  ; "Provider_error/TurnLivelock", D.Provider_error Code.Turn_livelock_pause
   ; "Provider_error/Fiber", D.Provider_error Code.Fiber_unresolved
   ]
 ;;
@@ -224,6 +226,8 @@ let runtime_codes_to_projection : (string * Code.t * D.t) list =
   ; "Turn_failures", Code.Turn_failures, D.Provider_error Code.Turn_failures
   ; "Storm", Code.Stale_termination_storm, D.Provider_error Code.Stale_termination_storm
   ; "FleetBatch", Code.Stale_fleet_batch, D.Provider_error Code.Stale_fleet_batch
+  ; "TurnOverflow", Code.Turn_overflow_pause, D.Provider_error Code.Turn_overflow_pause
+  ; "TurnLivelock", Code.Turn_livelock_pause, D.Provider_error Code.Turn_livelock_pause
   ; ( "Provider_runtime"
     , Code.Provider_runtime_error "p"
     , D.Provider_error (Code.Provider_runtime_error "p") )

--- a/test/test_keeper_turn_terminal_disposition_field.ml
+++ b/test/test_keeper_turn_terminal_disposition_field.ml
@@ -36,6 +36,8 @@ let constructor_cases : (string * T.t) list =
   ; "of_code/unknown", T.of_code "totally_unmapped"
   ; "of_code/empty", T.of_code ""
   ; "of_code/turn_wall_clock", T.of_code "turn_wall_clock_timeout"
+  ; "of_code/turn_overflow_pause", T.of_code "turn_overflow_pause"
+  ; "of_code/turn_livelock_pause", T.of_code "turn_livelock_pause"
   ; "of_code/require_tool_use", T.of_code "required_tool_use_no_tool_call"
   ]
 ;;


### PR DESCRIPTION
## Summary

PR #18251 (RFC-0152) added `Turn_overflow_pause` and `Turn_livelock_pause` variants to `Keeper_registry.failure_reason` for supervisor auto-resume sweep recognition, but the squash-merge did not include the downstream match-site fixes. This PR adds the missing match arms in all consumers to eliminate warning 8 [partial-match] build warnings.

## Changes

15 files, 64 insertions(+), 1 deletion(-):

- `lib/keeper/keeper_supervisor.ml` — sweep recovery, watchdog filter, batch root cause, cohort stamp
- `lib/keeper/keeper_supervisor_alive_but_stuck.ml` — `request_recovery` catch-all
- `lib/keeper/keeper_status_bridge.ml` — `runtime_blocker_surface_of_failure_reason`
- `lib/keeper/keeper_health_probe.ml` — `runtime_pressure_class_of_failure_reason`
- `lib/keeper/keeper_stale_watchdog.ml` — `failure_reason_batch_root_cause`
- `lib/keeper/keeper_turn_disposition.ml` — `of_termination_code`
- `lib/keeper/keeper_turn_terminal_code.ml{i}` — RFC-0042 closed sum type extensions
- `lib/keeper/keeper_supervisor_pause_policy.ml{i}` — `handle_auto_pause_from_meta` final `()` param
- `lib/keeper/keeper_turn_cascade_budget.ml` — caller update for `()`
- `lib/keeper/keeper_unified_turn_livelock_block.ml` — caller update for `()`
- `test/test_keeper_health_probe.ml` — test fixture
- `test/test_keeper_turn_disposition.ml` — test fixture
- `test/test_keeper_turn_terminal_disposition_field.ml` — test fixture

## Verification

- `dune build lib/masc_mcp.cma` compiles cleanly
- No warning 8 [partial-match] regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)