### PR TITLE
refactor(keeper): use sandbox actor for docker backend

### DIFF
--- a/docs/design/keeper-tool-runtime-boundary-plan.html
+++ b/docs/design/keeper-tool-runtime-boundary-plan.html
@@ -243,8 +243,8 @@
       <p>Goal-driven cleanup for the confusing <code>Keeper_shell</code>, <code>Keeper_bash</code>, GitHub, Docker, and Local execution split.</p>
       <div class="meta">
         <span class="pill">Updated 2026-05-24</span>
-        <span class="pill">Branch refactor/keeper-git-shell-bridge</span>
-        <span class="pill">Worktree .worktrees/keeper-git-shell-bridge</span>
+        <span class="pill">Branch refactor/sandbox-backend-actor-boundary-main</span>
+        <span class="pill">Worktree .worktrees/sandbox-backend-actor-boundary</span>
       </div>
     </div>
   </header>
@@ -270,11 +270,11 @@
           <span>Direct Docker runner calls outside <code>Keeper_sandbox_runner</code></span>
         </div>
         <div class="panel metric">
-          <strong>3,274</strong>
-          <span>Combined LOC across main hot files and new sandbox helper modules</span>
+          <strong>0</strong>
+          <span>Backend host exec calls using <code>Keeper_shell</code> actor</span>
         </div>
       </div>
-      <p class="note">Slice 1 removes source-level references to <code>Keeper_shell_docker</code>, <code>Keeper_shell_docker_exec_failure</code>, and <code>Keeper_shell_bash_docker</code>. Slice 2 removes the legacy <code>Keeper_shell_shared.run_docker*</code> boundary and routes PR/GitHub tool execution through <code>Keeper_sandbox_runner</code>. Slice 5 removes the legacy <code>keeper_shell op=gh</code> and <code>op=git_clone</code> compatibility surface instead of preserving bridge shims. Slice 6 moves shell read-side sandbox execution behind <code>Keeper_sandbox_read_runner</code>. Slice 7 applies the same boundary to file tools. Runner tests use injected mock runners.</p>
+      <p class="note">Slice 1 removes source-level references to <code>Keeper_shell_docker</code>, <code>Keeper_shell_docker_exec_failure</code>, and <code>Keeper_shell_bash_docker</code>. Slice 2 removes the legacy <code>Keeper_shell_shared.run_docker*</code> boundary and routes PR/GitHub tool execution through <code>Keeper_sandbox_runner</code>. Slice 5 removes the legacy <code>keeper_shell op=gh</code> and <code>op=git_clone</code> compatibility surface instead of preserving bridge shims. Slice 6 moves shell read-side sandbox execution behind <code>Keeper_sandbox_read_runner</code>. Slice 7 applies the same boundary to file tools. Slice 8 retires the tool-shaped <code>Keeper_docker_read</code> module name. Slice 9 moves backend host process execution to the sandbox backend actor. Runner tests use injected mock runners.</p>
     </section>
 
     <section>
@@ -330,6 +330,12 @@
             <td data-label="Goal">Retire tool-shaped Docker read backend names.</td>
             <td data-label="Quantitative Gate"><code>lib/keeper/keeper_docker_read.*</code> and <code>test/test_keeper_docker_read.ml</code> are absent; source guard rejects <code>Keeper_docker_read</code> references.</td>
             <td data-label="Status"><span class="status done">Done in slice 8</span></td>
+          </tr>
+          <tr>
+            <td data-label="ID">G8</td>
+            <td data-label="Goal">Keep sandbox backend process execution out of tool actor identity.</td>
+            <td data-label="Quantitative Gate">Sandbox backend source hit count for <code>~actor:`Keeper_shell</code> and <code>actor = `Keeper_shell</code> is <code>0</code>.</td>
+            <td data-label="Status"><span class="status done">Done in slice 9</span></td>
           </tr>
         </tbody>
       </table>
@@ -390,6 +396,13 @@
             <td data-label="Verification Method"><code>./_build/default/test/test_keeper_sandbox_read_backend.exe</code>, <code>./_build/default/test/test_keeper_sandbox_boundary_policy.exe</code></td>
             <td data-label="Exit Criteria">Backend behavior is preserved while tool layers depend on <code>Keeper_sandbox_read_runner</code> and old module files are absent.</td>
           </tr>
+          <tr>
+            <td data-label="Task">T7</td>
+            <td data-label="Goal">Backend actor boundary</td>
+            <td data-label="Todo">Run concrete sandbox backend host process execution as <code>System_task_sandbox</code>, not <code>Keeper_shell</code>.</td>
+            <td data-label="Verification Method"><code>./_build/default/test/test_keeper_sandbox_boundary_policy.exe</code></td>
+            <td data-label="Exit Criteria">Backend modules reject public shell actor identity and <code>Keeper_sandbox_docker</code> contains the sandbox actor.</td>
+          </tr>
         </tbody>
       </table>
     </section>
@@ -406,6 +419,7 @@
         <div class="command">rg -n "Keeper_sandbox_read_backend\\.|&quot;via&quot;, `String &quot;docker&quot;" lib/keeper/keeper_shell_ops.ml</div>
         <div class="command">rg -n "Keeper_sandbox_read_backend\\.|&quot;via&quot;, `String &quot;docker&quot;" lib/keeper/keeper_exec_fs.ml</div>
         <div class="command">test ! -e lib/keeper/keeper_docker_read.ml &amp;&amp; test ! -e lib/keeper/keeper_docker_read.mli &amp;&amp; test ! -e test/test_keeper_docker_read.ml</div>
+        <div class="command">rg -n "~actor:`Keeper_shell|actor = `Keeper_shell" lib/keeper/keeper_sandbox_docker.ml lib/keeper/keeper_sandbox_read_backend.ml lib/keeper/keeper_docker_client_real.ml</div>
         <div class="command">./_build/default/test/test_keeper_sandbox_docker_route.exe test docker_route_fires 17-21 --show-errors --compact</div>
         <div class="command">rg -n "Keeper_shell_docker|Keeper_shell_docker_exec_failure|Keeper_shell_bash_docker|keeper_shell_docker|keeper_shell_docker_exec_failure|keeper_shell_bash_docker" lib/keeper</div>
         <div class="command">rg -n "Keeper_sandbox_docker\\.run_|Keeper_shell_shared\\.run_docker" lib/keeper</div>

--- a/docs/design/keeper-tool-runtime-boundary-plan.md
+++ b/docs/design/keeper-tool-runtime-boundary-plan.md
@@ -86,6 +86,11 @@ and public tool aliases.
      implementation details and tests.
    - `test_keeper_sandbox_boundary_policy` now fails if the retired
      `keeper_docker_read` files or `Keeper_docker_read` references return.
+   Continued in slice 9:
+   - `Keeper_sandbox_docker` now runs host-side Docker process execution
+     under the sandbox backend actor, not the public shell tool actor.
+   - `test_keeper_sandbox_boundary_policy` now fails if sandbox backend
+     sources use `Keeper_shell` as their process execution actor.
 
 ## Verification
 
@@ -108,3 +113,6 @@ and public tool aliases.
   mock backend and route labels sourced from `Keeper_sandbox_runner`.
 - `test_keeper_sandbox_read_backend` protects the concrete backend behavior
   without leaking the retired `Keeper_docker_read` public module name.
+- The boundary test now fails if concrete sandbox backend modules execute
+  host processes as `Keeper_shell` instead of a backend-owned actor such as
+  `System_task_sandbox`.

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -707,7 +707,7 @@ let run_docker_shell_command_with_status_internal
                                @@ fun () ->
                                Docker_spawn_throttle.with_slot (fun () ->
                                  Masc_exec.Exec_gate.run_argv_with_stdin_and_status
-                                   ~actor:`Keeper_shell
+                                   ~actor:`System_task_sandbox
                                    ~raw_source:(String.concat " " argv)
                                    ~summary:"keeper docker command"
                                    ~env:(Unix.environment ())

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -211,6 +211,20 @@ let test_sandbox_runtime_sources_do_not_depend_on_shell_surface_names () =
     (fun rel -> List.iter (assert_not_contains rel) forbidden)
     sandbox_runtime_sources
 
+let test_backend_host_exec_uses_sandbox_actor () =
+  let backend_sources =
+    [ "lib/keeper/keeper_sandbox_docker.ml"
+    ; "lib/keeper/keeper_sandbox_read_backend.ml"
+    ; "lib/keeper/keeper_docker_client_real.ml"
+    ]
+  in
+  List.iter
+    (fun rel ->
+       assert_not_contains rel "~actor:`Keeper_shell";
+       assert_not_contains rel "actor = `Keeper_shell")
+    backend_sources;
+  assert_contains "lib/keeper/keeper_sandbox_docker.ml" "~actor:`System_task_sandbox"
+
 let test_shell_ops_drops_gh_bridge () =
   let shell_ops = "lib/keeper/keeper_shell_ops.ml" in
   assert_source_absent "lib/keeper/keeper_shell_gh_bridge.ml";
@@ -292,6 +306,10 @@ let () =
             "sandbox runtime sources do not depend on shell surface names"
             `Quick
             test_sandbox_runtime_sources_do_not_depend_on_shell_surface_names;
+          Alcotest.test_case
+            "backend host exec uses sandbox actor"
+            `Quick
+            test_backend_host_exec_uses_sandbox_actor;
           Alcotest.test_case
             "shell ops drops gh compatibility bridge"
             `Quick


### PR DESCRIPTION
## Summary
- Move concrete Docker backend host process execution from the public `Keeper_shell` actor to the backend-owned `System_task_sandbox` actor.
- Extend `test_keeper_sandbox_boundary_policy` so sandbox backend sources reject `Keeper_shell` process execution actor identity.
- Update the Keeper Tool Runtime Boundary plan HTML/Markdown with slice 9, including Todo/Goal/task gate and verification commands.

## Verification
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 scripts/dune-local.sh build test/test_keeper_sandbox_boundary_policy.exe test/test_keeper_sandbox_runner.exe test/test_keeper_sandbox_docker_route.exe test/test_keeper_sandbox_read_backend.exe test/test_keeper_sandbox_read_runner.exe`
- `_build/default/test/test_keeper_sandbox_boundary_policy.exe`
- `_build/default/test/test_keeper_sandbox_runner.exe`
- `_build/default/test/test_keeper_sandbox_read_backend.exe`
- `_build/default/test/test_keeper_sandbox_read_runner.exe`
- `_build/default/test/test_keeper_sandbox_docker_route.exe test docker_route_fires 17-21 --show-errors --compact`
- `opam exec -- ocamlformat --check lib/keeper/keeper_sandbox_docker.ml test/test_keeper_sandbox_boundary_policy.ml`
- `git diff --check`
- `bash scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/check-version-truth.sh`

## Version bump
- Considered; not needed. This is an internal actor attribution / boundary-test change and does not alter public module/API/package surface.