### PR TITLE
refactor(keeper): drop legacy Shell IR bash handler

### DIFF
--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -70,16 +70,6 @@ val handle_keeper_shell_ir :
   unit ->
   string
 
-val handle_keeper_bash :
-  turn_sandbox_factory:Keeper_sandbox_factory.t option ->
-  turn_sandbox_factory_git:Keeper_sandbox_factory.t option ->
-  exec_cache:Masc_exec.Exec_cache.t option ->
-  config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
-  args:Yojson.Safe.t ->
-  unit ->
-  string
-
 module For_testing : sig
   val elapsed_duration_ms : start_time:float -> end_time:float -> int
 end

--- a/lib/keeper/keeper_sandbox_shell_ir_target.ml
+++ b/lib/keeper/keeper_sandbox_shell_ir_target.ml
@@ -11,8 +11,7 @@ let docker_image (meta : keeper_meta) =
 let docker_target ~turn_sandbox_factory ~meta ~cwd =
   match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
   | None ->
-    Error
-      "typed Bash Docker Shell IR dispatch requires a turn sandbox factory"
+    Error "typed Shell IR Docker dispatch requires a turn sandbox factory"
   | Some runtime ->
     let image = docker_image meta in
     let runner ~stdin_content ~argv ~env:_ ~cwd:stage_cwd ~timeout_sec =

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -91,7 +91,7 @@ let handle_keeper_shell_ir_typed
           | Local -> Ok (Masc_exec.Sandbox_target.host (), [])
           | Docker ->
             if typed_input_has_env input
-            then Error "typed Bash Docker Shell IR dispatch does not support env yet"
+            then Error "typed Shell IR Docker dispatch does not support env yet"
             else (
               match docker_local_fallback_target ~meta ~timeout_sec with
               | Some fallback when in_playground -> Ok fallback
@@ -283,7 +283,5 @@ let handle_keeper_shell_ir
   else
     error_json
       ~fields:[ "typed", `Bool true ]
-      "Typed Bash input is required. Provide executable/argv or pipeline/stages."
+      "Typed Shell IR input is required. Provide executable/argv or pipeline/stages."
 ;;
-
-let handle_keeper_bash = handle_keeper_shell_ir

--- a/lib/keeper/keeper_shell_bash.mli
+++ b/lib/keeper/keeper_shell_bash.mli
@@ -13,16 +13,6 @@ val handle_keeper_shell_ir :
   unit ->
   string
 
-val handle_keeper_bash :
-  turn_sandbox_factory:Keeper_sandbox_factory.t option ->
-  turn_sandbox_factory_git:Keeper_sandbox_factory.t option ->
-  exec_cache:Masc_exec.Exec_cache.t option ->
-  config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
-  args:Yojson.Safe.t ->
-  unit ->
-  string
-
 module For_testing : sig
   val elapsed_duration_ms : start_time:float -> end_time:float -> int
 end

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -594,7 +594,7 @@ let test_keeper_bash_typed_pipeline_runs_via_shell_ir () =
      |> Json.to_string
      |> fun output -> String_util.contains_substring output "5")
 
-let test_keeper_bash_typed_docker_requires_factory () =
+let test_keeper_bash_typed_docker_falls_back_to_local_playground () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
@@ -617,11 +617,22 @@ let test_keeper_bash_typed_docker_requires_factory () =
            ])
       ()
   in
-  match parse_error_field raw with
-  | Some err ->
-    if not (String_util.contains_substring err "turn sandbox factory")
-    then Alcotest.fail ("unexpected typed docker error: " ^ err)
-  | None -> Alcotest.fail ("expected typed docker factory error, got: " ^ raw)
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "typed docker fallback succeeds" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check (option string))
+    "requested docker sandbox"
+    (Some "docker")
+    (json |> Json.member "requested_sandbox" |> Json.to_string_option);
+  Alcotest.(check (option string))
+    "falls back to local playground"
+    (Some "local_playground")
+    (json |> Json.member "sandbox_fallback" |> Json.to_string_option);
+  Alcotest.(check bool) "output propagated" true
+    (json
+     |> Json.member "output"
+     |> Json.to_string
+     |> fun output -> String_util.contains_substring output "typed-docker")
 
 let test_keeper_shell_find_accepts_name_alias () =
   with_eio_fs @@ fun () ->
@@ -825,7 +836,7 @@ let test_bash_missing_typed_input_field () =
   match parse_error_field raw with
   | Some err ->
       Alcotest.(check bool) "error mentions typed input is required" true
-        (String_util.contains_substring err "Typed Bash input is required")
+        (String_util.contains_substring err "Typed Shell IR input is required")
   | None ->
       Alcotest.fail ("expected error json for missing typed input field, got: " ^ raw)
 
@@ -1078,9 +1089,9 @@ let () =
             `Quick
             test_keeper_bash_typed_pipeline_runs_via_shell_ir
         ; Alcotest.test_case
-            "typed docker dispatch requires factory"
+            "typed docker dispatch falls back to local playground"
             `Quick
-            test_keeper_bash_typed_docker_requires_factory
+            test_keeper_bash_typed_docker_falls_back_to_local_playground
         ] )
     ; ( "keeper_shell"
       , [ Alcotest.test_case

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -767,7 +767,7 @@ let check_typed_validation_error needle raw =
 let test_bash_typed_env_wrapper_target_rejected () =
   setup ~sandbox:Keeper_types.Local
   @@ fun ~config ~meta ~playground ->
-  Keeper_exec_shell.handle_keeper_bash
+  Keeper_exec_shell.handle_keeper_shell_ir
     ~turn_sandbox_factory:None
     ~turn_sandbox_factory_git:None
     ~exec_cache:None
@@ -780,7 +780,7 @@ let test_bash_typed_env_wrapper_target_rejected () =
 let test_bash_typed_single_stage_pipeline_rejected () =
   setup ~sandbox:Keeper_types.Local
   @@ fun ~config ~meta ~playground ->
-  Keeper_exec_shell.handle_keeper_bash
+  Keeper_exec_shell.handle_keeper_shell_ir
     ~turn_sandbox_factory:None
     ~turn_sandbox_factory_git:None
     ~exec_cache:None
@@ -795,7 +795,7 @@ let test_bash_typed_pipeline_falls_back_to_local_playground () =
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash
+    Keeper_exec_shell.handle_keeper_shell_ir
       ~turn_sandbox_factory:None
       ~turn_sandbox_factory_git:None
       ~exec_cache:None
@@ -814,7 +814,7 @@ let test_bash_typed_pipeline_falls_back_to_local_playground () =
 let test_bash_typed_pipeline_uses_local_shell_ir_dispatch () =
   setup ~sandbox:Keeper_types.Local
   @@ fun ~config ~meta ~playground ->
-  Keeper_exec_shell.handle_keeper_bash
+  Keeper_exec_shell.handle_keeper_shell_ir
     ~turn_sandbox_factory:None
     ~turn_sandbox_factory_git:None
     ~exec_cache:None
@@ -838,7 +838,7 @@ let test_bash_typed_pipeline_uses_turn_sandbox_docker_runner () =
       ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
     @@ fun () ->
     let raw =
-      Keeper_exec_shell.handle_keeper_bash
+      Keeper_exec_shell.handle_keeper_shell_ir
         ~turn_sandbox_factory:(Some factory)
         ~turn_sandbox_factory_git:None
         ~exec_cache:None
@@ -857,7 +857,7 @@ let test_bash_routes_through_docker () =
   @@ fun ~config ~meta ~playground ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:(Some factory)
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:(Some factory)
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:(keeper_bash_typed_exec_args ~cwd:playground "echo" ~argv:[ "hello" ])
       ()
@@ -877,7 +877,7 @@ let test_bash_legacy_skips_docker () =
   let outside_cwd = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir outside_cwd) @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:None
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "echo hello"); ("cwd", `String outside_cwd) ])
       ()
@@ -970,7 +970,7 @@ let test_bash_git_creds_routes_through_docker () =
   ensure_dir repo;
   git_ok ~cwd:repo [ "init"; "-q" ];
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:None
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:(keeper_bash_typed_exec_args ~cwd:repo "git" ~argv:[ "status" ])
       ()
@@ -1000,7 +1000,7 @@ let test_bash_git_creds_uses_oneshot_with_turn_runtime () =
   with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_CLEANUP_ENABLED" "false" @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:(Some factory)
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:(Some factory)
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:(keeper_bash_typed_exec_args ~cwd:repo "git" ~argv:[ "status" ])
       ()
@@ -1042,7 +1042,7 @@ let test_bash_git_creds_missing_bundle_is_structured_blocker () =
   with_env "MASC_KEEPER_SANDBOX_CLEANUP_ENABLED" "false" @@ fun () ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash
+    Keeper_exec_shell.handle_keeper_shell_ir
       ~turn_sandbox_factory:(Some factory)
       ~turn_sandbox_factory_git:None
       ~exec_cache:None
@@ -1068,7 +1068,7 @@ let test_bash_git_c_option_missing_dir_blocks_before_docker () =
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:(Some factory)
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:(Some factory)
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:
         (keeper_bash_typed_exec_args ~cwd:playground "git"
@@ -1139,7 +1139,7 @@ let test_bash_git_c_bare_worktrees_from_root_uses_single_repo () =
   with_env "MASC_KEEPER_SANDBOX_CLEANUP_ENABLED" "false" @@ fun () ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:(Some factory)
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:(Some factory)
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:
         (keeper_bash_typed_exec_args ~cwd:playground "git"
@@ -1167,7 +1167,7 @@ let test_bash_git_push_requires_write_preset_before_docker () =
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:(Some factory)
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:(Some factory)
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:
         (keeper_bash_typed_exec_args ~cwd:repo "git"
@@ -1197,7 +1197,7 @@ let test_bash_git_push_routes_through_git_creds_docker () =
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:(Some factory)
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:(Some factory)
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:
         (keeper_bash_typed_exec_args ~cwd:repo "git"
@@ -1400,7 +1400,7 @@ let test_bash_missing_image_falls_back_to_local_playground () =
   with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_CLEANUP_ENABLED" "false" @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash
+    Keeper_exec_shell.handle_keeper_shell_ir
       ~turn_sandbox_factory:None
       ~turn_sandbox_factory_git:None
       ~exec_cache:None
@@ -1855,7 +1855,7 @@ let test_bash_fake_docker_executes () =
   @@ fun ~config ~meta ~playground ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:(Some factory)
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:(Some factory)
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:(keeper_bash_typed_exec_args ~cwd:playground "echo" ~argv:[ "hello" ])
       ()
@@ -1877,7 +1877,7 @@ let test_bash_allows_validator_safe_pipe_redirect_in_docker_route () =
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:(Some factory)
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:(Some factory)
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:
         (keeper_bash_typed_pipeline_args_of ~cwd:playground
@@ -1911,7 +1911,7 @@ let test_bash_rg_no_match_remains_successful_in_docker_route () =
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:(Some factory)
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:(Some factory)
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:
         (keeper_bash_typed_exec_args ~cwd:playground "rg"
@@ -1937,7 +1937,7 @@ let test_bash_blocks_file_redirect_before_docker () =
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:None
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
@@ -1952,7 +1952,7 @@ let test_bash_blocks_file_redirect_before_docker () =
    | Some false | None -> ());
   Alcotest.(check (option string))
     "typed boundary error"
-    (Some "Typed Bash input is required. Provide executable/argv or pipeline/stages.")
+    (Some "Typed Shell IR input is required. Provide executable/argv or pipeline/stages.")
     (parse_string_field raw "error");
   Alcotest.(check bool) "docker was not invoked" false
     (Sys.file_exists log_path)
@@ -1966,7 +1966,7 @@ let test_bash_blocks_gh_pr_checks_before_docker () =
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:(Some factory)
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:(Some factory)
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:
         (keeper_bash_typed_exec_args ~cwd:playground "gh"
@@ -1997,7 +1997,7 @@ let test_bash_search_pipeline_exposes_structured_recovery_plan () =
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:(Some factory)
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:(Some factory)
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:
         (keeper_bash_typed_pipeline_args_of ~cwd:playground
@@ -2022,7 +2022,7 @@ let test_bash_rewrites_host_path_command_for_docker () =
   ensure_dir (Filename.concat (Filename.concat playground "repos") "masc-mcp");
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:(Some factory)
+    Keeper_exec_shell.handle_keeper_shell_ir ~turn_sandbox_factory:(Some factory)
       ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
       ~args:
         (keeper_bash_typed_exec_args ~cwd:playground "ls"


### PR DESCRIPTION
## Summary

- Remove the legacy `handle_keeper_bash` facade/export so typed execution goes through `handle_keeper_shell_ir` only.
- Update remaining sandbox-route tests to call the Shell IR handler directly.
- Replace the old Docker factory-required expectation with the current local-playground fallback behavior and update Shell IR error wording away from typed Bash compatibility language.

## Validation

- `ocamlformat --check lib/keeper/keeper_exec_shell.mli lib/keeper/keeper_sandbox_shell_ir_target.ml lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_shell_bash.mli test/test_keeper_bash_safety.ml test/test_keeper_sandbox_docker_route.ml`
- `git diff --check`

Blocked locally:

- `scripts/dune-local.sh build test/test_keeper_bash_safety.exe test/test_keeper_sandbox_docker_route.exe` was refused because another session is running bare `dune build lib/keeper/keeper_unified_turn.cma`; CI must cover the focused OCaml build/test.