### PR TITLE
docs(auth): purge vendor brand residue in client-agnostic doc comments

### DIFF
--- a/lib/auth_doctor.mli
+++ b/lib/auth_doctor.mli
@@ -45,11 +45,11 @@ type watched_agent = {
 
 (** Per-client MCP identity readiness was previously exposed here as
     [type mcp_client] alongside a hardcoded list of "known" MCP
-    clients (Claude, Provider_f). That list lived inside server code and
-    made the server client-aware — the wrong direction for an MCP
-    server. The diagnostic is removed; operators who need per-client
-    readiness checks compose them externally over the raw
-    [doctor auth --json] output and their own client roster. *)
+    clients. That list lived inside server code and made the server
+    client-aware — the wrong direction for an MCP server. The
+    diagnostic is removed; operators who need per-client readiness
+    checks compose them externally over the raw [doctor auth --json]
+    output and their own client roster. *)
 
 (** {1 Aggregate report} *)
 

--- a/lib/auth_login.mli
+++ b/lib/auth_login.mli
@@ -22,9 +22,8 @@
     The server is client-agnostic: the caller (CLI / API consumer)
     supplies the env var name ([~token_env_var]) and the
     token-lifetime policy ([~token_lifetime]). This module holds
-    no list of "known" MCP clients (Claude, Provider_f, etc.) — those
-    conventions live in the operator's wrapper scripts and the
-    runbook, not in server code. *)
+    no list of "known" MCP clients — those conventions live in the
+    operator's wrapper scripts and the runbook, not in server code. *)
 
 (** {1 Auth configuration change taxonomy} *)
 


### PR DESCRIPTION
## Summary

Drop the last vendor brand literals ("Claude") from `lib/auth_login.mli`
and `lib/auth_doctor.mli` historical-reference docstrings.

RFC-0165 (PR #18203, merged) removed the per-client MCP identity
surface and made the server client-agnostic. Two doc comments still
named a specific vendor brand next to the post-purge identifier — pure
documentation residue, no code impact.

## Plan reference

`~/me/planning/claude-plans/option-b-abundant-stardust.md` proposed a
5+ file overhaul (mint signature, `--client-env`/`--no-expiry` flags,
mcp_clients diagnostic deletion, tests, docs, RFC). Tracing actual
state on `origin/main`:

| Plan section | Status | Where |
|---|---|---|
| §A `auth_login.ml` mint signature + `token_lifetime` variant | ✅ DONE | PR #18203 |
| §B `bin/main_eio.ml` `--client-env` / `--no-expiry` flags | ✅ DONE | PR #18203 (lines 560, 568, 1590) |
| §C `auth_doctor.ml` mcp_clients diagnostic delete | ✅ DONE | PR #18203 |
| §D `Auth.create_token_without_expiry` retention | ✅ REVISED (kept) | plan note |
| §E `test/test_auth_login.ml` + `test_auth_doctor.ml` | ✅ DONE | PR #18203 |
| §F docs (`LOCAL-DASHBOARD-AUTH-RUNBOOK.md`) | ✅ DONE | PR #18203 |
| §G RFC | ✅ DONE | `RFC-0165-mcp-server-client-agnostic.md` |
| §A *last bullet* "Comment 갱신" | **this PR** | `lib/auth_login.mli:25`, `lib/auth_doctor.mli:48` |

Plan was 99% absorbed by RFC-0165. This PR closes the final
documentation bullet.

## Diff

`2 files changed, +7 / -8`

```
- no list of "known" MCP clients (Claude, Provider_f, etc.) — those
+ no list of "known" MCP clients — those

- clients (Claude, Provider_f). That list lived inside server code and
+ clients. That list lived inside server code and
```

## Verification

- `rg -in 'claude|gemini|kimi|openai|anthropic|moonshot' lib/auth_login.ml lib/auth_login.mli lib/auth_doctor.ml lib/auth_doctor.mli` → 0 hits.
- No code change: `.mli` docstring only. Compile output identical.

## Workaround-rejection self-check

Pure doc comment cleanup. 7 signatures: NO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)