### PR TITLE
fix(oas-env): migrate vendor-named env vars to OAS 0.197.0 OAS_CLI_TOOL_* names (RFC-0176 follow-up)

### DIFF
--- a/lib/keeper/keeper_cli_mcp_config.ml
+++ b/lib/keeper/keeper_cli_mcp_config.ml
@@ -1,6 +1,6 @@
 (* #10049: auto-construct CLI MCP config JSON for keepers whose cascade
    includes CLI providers but whose env
-   (OAS_CLAUDE_MCP_CONFIG) is unset.
+   (OAS_CLI_TOOL_D_MCP_CONFIG) is unset.
 
    Without this fallback, affected CLI providers launch with no [mcpServers]
    entry and the keeper cannot reach the masc-mcp HTTP
@@ -10,7 +10,7 @@
 
    Gated behind [MASC_AUTO_CONSTRUCT_CLAUDE_MCP] (default true since
    #10059 validation; the legacy explicit-env path still wins when
-   [OAS_CLAUDE_MCP_CONFIG] is set, and operators can opt out with
+   [OAS_CLI_TOOL_D_MCP_CONFIG] is set, and operators can opt out with
    [MASC_AUTO_CONSTRUCT_CLAUDE_MCP=false]). *)
 
 let feature_flag_env = "MASC_AUTO_CONSTRUCT_CLAUDE_MCP"

--- a/lib/keeper/keeper_cli_mcp_config.mli
+++ b/lib/keeper/keeper_cli_mcp_config.mli
@@ -1,4 +1,4 @@
-(* #10049: auto-construct CLI MCP config JSON when OAS_CLAUDE_MCP_CONFIG env is
+(* #10049: auto-construct CLI MCP config JSON when OAS_CLI_TOOL_D_MCP_CONFIG env is
    unset. Gated behind
    MASC_AUTO_CONSTRUCT_CLAUDE_MCP (default true since #10059 validation;
    set to "false" to opt out). *)

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -149,15 +149,15 @@ let keeper_oas_context_of_defaults defaults =
   let module Oas_env = Keeper_types_profile_oas_env in
   let env_pairs = Oas_env.effective_oas_env defaults.oas_env in
   let gemini_mcp_disabled =
-    match List.assoc_opt "OAS_GEMINI_NO_MCP" env_pairs with
+    match List.assoc_opt "OAS_CLI_TOOL_B_NO_MCP" env_pairs with
     | Some value -> Oas_env.oas_env_truthy value
     | None -> false
   in
   let gemini_approval_mode_explicit =
-    non_empty_trimmed_assoc "OAS_GEMINI_APPROVAL_MODE" defaults.oas_env
+    non_empty_trimmed_assoc "OAS_CLI_TOOL_B_APPROVAL_MODE" defaults.oas_env
   in
   let gemini_approval_mode =
-    non_empty_trimmed_assoc "OAS_GEMINI_APPROVAL_MODE" env_pairs
+    non_empty_trimmed_assoc "OAS_CLI_TOOL_B_APPROVAL_MODE" env_pairs
   in
   let gemini_approval_mode_derived =
     gemini_mcp_disabled
@@ -165,11 +165,11 @@ let keeper_oas_context_of_defaults defaults =
     && Option.is_some gemini_approval_mode
   in
   let claude_mcp_config =
-    match List.assoc_opt "OAS_CLAUDE_MCP_CONFIG" env_pairs with
+    match List.assoc_opt "OAS_CLI_TOOL_D_MCP_CONFIG" env_pairs with
     | Some raw when String.trim raw <> "" -> Some raw
     | _ ->
       if
-        match List.assoc_opt "OAS_CLAUDE_STRICT_MCP" env_pairs with
+        match List.assoc_opt "OAS_CLI_TOOL_D_STRICT_MCP" env_pairs with
         | Some value -> Oas_env.oas_env_truthy value
         | None -> false
       then Some {|{"mcpServers":{}}|}
@@ -177,7 +177,7 @@ let keeper_oas_context_of_defaults defaults =
   in
   let gemini_allowed_mcp_derived =
     (not gemini_mcp_disabled)
-    && not (Oas_env.oas_env_has_non_empty "OAS_GEMINI_ALLOWED_MCP" defaults.oas_env)
+    && not (Oas_env.oas_env_has_non_empty "OAS_CLI_TOOL_B_ALLOWED_MCP" defaults.oas_env)
   in
   {
     env_pairs;

--- a/lib/keeper/keeper_types_profile_oas_env.ml
+++ b/lib/keeper/keeper_types_profile_oas_env.ml
@@ -129,15 +129,15 @@ let oas_env_has_non_empty key pairs =
 
 let effective_oas_env pairs =
   let gemini_mcp_disabled =
-    match List.assoc_opt "OAS_GEMINI_NO_MCP" pairs with
+    match List.assoc_opt "OAS_CLI_TOOL_B_NO_MCP" pairs with
     | Some value -> oas_env_truthy value
     | None -> false
   in
   let pairs =
     if
       gemini_mcp_disabled
-      && not (oas_env_has_non_empty "OAS_GEMINI_APPROVAL_MODE" pairs)
-    then pairs @ [ "OAS_GEMINI_APPROVAL_MODE", "plan" ]
+      && not (oas_env_has_non_empty "OAS_CLI_TOOL_B_APPROVAL_MODE" pairs)
+    then pairs @ [ "OAS_CLI_TOOL_B_APPROVAL_MODE", "plan" ]
     else pairs
   in
   (* Enable Provider_f CLI MCP by default: when not explicitly disabled and
@@ -146,7 +146,7 @@ let effective_oas_env pairs =
      MASC MCP server instead of the __oas_no_mcp__ sentinel. *)
   if
     (not gemini_mcp_disabled)
-    && not (oas_env_has_non_empty "OAS_GEMINI_ALLOWED_MCP" pairs)
-  then pairs @ [ "OAS_GEMINI_ALLOWED_MCP", "masc" ]
+    && not (oas_env_has_non_empty "OAS_CLI_TOOL_B_ALLOWED_MCP" pairs)
+  then pairs @ [ "OAS_CLI_TOOL_B_ALLOWED_MCP", "masc" ]
   else pairs
 ;;

--- a/test/test_effective_oas_env.ml
+++ b/test/test_effective_oas_env.ml
@@ -2,12 +2,12 @@
 
     Pins three invariants of [Keeper_types_profile.effective_oas_env]:
 
-    1. Default injection: when no OAS_GEMINI_* env vars are set,
-       [OAS_GEMINI_ALLOWED_MCP] is injected with value "masc".
-    2. Disabled passthrough: when [OAS_GEMINI_NO_MCP=true],
+    1. Default injection: when no OAS_CLI_TOOL_B_* env vars are set,
+       [OAS_CLI_TOOL_B_ALLOWED_MCP] is injected with value "masc".
+    2. Disabled passthrough: when [OAS_CLI_TOOL_B_NO_MCP=true],
        injection must NOT occur (operator opted out).
     3. Operator override preserved: when operator sets a custom
-       [OAS_GEMINI_ALLOWED_MCP], it is preserved verbatim.
+       [OAS_CLI_TOOL_B_ALLOWED_MCP], it is preserved verbatim.
 
     Also pins [keeper_oas_context_of_defaults] derived field:
     4. [gemini_allowed_mcp_derived] is [true] when default injection
@@ -25,33 +25,33 @@ module KTP = Masc_mcp.Keeper_types_profile
 
 let test_default_injects_masc () =
   let pairs = KTP.effective_oas_env [] in
-  match List.assoc_opt "OAS_GEMINI_ALLOWED_MCP" pairs with
+  match List.assoc_opt "OAS_CLI_TOOL_B_ALLOWED_MCP" pairs with
   | Some value ->
     check string "default injection is 'masc'" "masc" value
   | None ->
-    fail "OAS_GEMINI_ALLOWED_MCP not injected on empty input"
+    fail "OAS_CLI_TOOL_B_ALLOWED_MCP not injected on empty input"
 
 let test_disabled_skips_injection () =
   let pairs =
-    KTP.effective_oas_env [ ("OAS_GEMINI_NO_MCP", "true") ]
+    KTP.effective_oas_env [ ("OAS_CLI_TOOL_B_NO_MCP", "true") ]
   in
-  match List.assoc_opt "OAS_GEMINI_ALLOWED_MCP" pairs with
+  match List.assoc_opt "OAS_CLI_TOOL_B_ALLOWED_MCP" pairs with
   | Some _ ->
-    fail "OAS_GEMINI_ALLOWED_MCP injected despite NO_MCP=true"
+    fail "OAS_CLI_TOOL_B_ALLOWED_MCP injected despite NO_MCP=true"
   | None ->
     check bool "disabled skips injection" true true
 
 let test_operator_override_preserved () =
   let pairs =
     KTP.effective_oas_env
-      [ ("OAS_GEMINI_ALLOWED_MCP", "custom-server,other") ]
+      [ ("OAS_CLI_TOOL_B_ALLOWED_MCP", "custom-server,other") ]
   in
-  match List.assoc_opt "OAS_GEMINI_ALLOWED_MCP" pairs with
+  match List.assoc_opt "OAS_CLI_TOOL_B_ALLOWED_MCP" pairs with
   | Some value ->
     check string "operator override preserved"
       "custom-server,other" value
   | None ->
-    fail "OAS_GEMINI_ALLOWED_MCP missing despite operator setting"
+    fail "OAS_CLI_TOOL_B_ALLOWED_MCP missing despite operator setting"
 
 let test_operator_empty_string_preserved () =
   (* When operator explicitly sets empty string, the key exists in input
@@ -59,37 +59,37 @@ let test_operator_empty_string_preserved () =
      appends "masc" as a second entry. This means operator's empty-string
      opt-out is preserved — the transport reads the first value. *)
   let pairs =
-    KTP.effective_oas_env [ ("OAS_GEMINI_ALLOWED_MCP", "") ]
+    KTP.effective_oas_env [ ("OAS_CLI_TOOL_B_ALLOWED_MCP", "") ]
   in
-  match List.assoc_opt "OAS_GEMINI_ALLOWED_MCP" pairs with
+  match List.assoc_opt "OAS_CLI_TOOL_B_ALLOWED_MCP" pairs with
   | Some value ->
     check string "empty string preserved (first match)" "" value
   | None ->
-    fail "OAS_GEMINI_ALLOWED_MCP missing"
+    fail "OAS_CLI_TOOL_B_ALLOWED_MCP missing"
 
 let test_approval_mode_injected_with_no_mcp () =
   let pairs =
-    KTP.effective_oas_env [ ("OAS_GEMINI_NO_MCP", "true") ]
+    KTP.effective_oas_env [ ("OAS_CLI_TOOL_B_NO_MCP", "true") ]
   in
-  match List.assoc_opt "OAS_GEMINI_APPROVAL_MODE" pairs with
+  match List.assoc_opt "OAS_CLI_TOOL_B_APPROVAL_MODE" pairs with
   | Some value ->
     check string "approval mode injected when MCP disabled" "plan" value
   | None ->
-    fail "OAS_GEMINI_APPROVAL_MODE not injected when MCP disabled"
+    fail "OAS_CLI_TOOL_B_APPROVAL_MODE not injected when MCP disabled"
 
 let test_approval_mode_not_overridden () =
   let pairs =
     KTP.effective_oas_env
       [
-        ("OAS_GEMINI_NO_MCP", "true");
-        ("OAS_GEMINI_APPROVAL_MODE", "auto");
+        ("OAS_CLI_TOOL_B_NO_MCP", "true");
+        ("OAS_CLI_TOOL_B_APPROVAL_MODE", "auto");
       ]
   in
-  match List.assoc_opt "OAS_GEMINI_APPROVAL_MODE" pairs with
+  match List.assoc_opt "OAS_CLI_TOOL_B_APPROVAL_MODE" pairs with
   | Some value ->
     check string "operator approval mode preserved" "auto" value
   | None ->
-    fail "OAS_GEMINI_APPROVAL_MODE missing"
+    fail "OAS_CLI_TOOL_B_APPROVAL_MODE missing"
 
 (* ── keeper_oas_context_of_defaults tests ──────────────────── *)
 
@@ -103,7 +103,7 @@ let test_context_derived_flag_disabled () =
   let defaults =
     {
       KTP.empty_keeper_profile_defaults with
-      oas_env = [ ("OAS_GEMINI_NO_MCP", "true") ];
+      oas_env = [ ("OAS_CLI_TOOL_B_NO_MCP", "true") ];
     }
   in
   let ctx = KTP.keeper_oas_context_of_defaults defaults in
@@ -114,7 +114,7 @@ let test_context_derived_flag_operator () =
   let defaults =
     {
       KTP.empty_keeper_profile_defaults with
-      oas_env = [ ("OAS_GEMINI_ALLOWED_MCP", "my-server") ];
+      oas_env = [ ("OAS_CLI_TOOL_B_ALLOWED_MCP", "my-server") ];
     }
   in
   let ctx = KTP.keeper_oas_context_of_defaults defaults in
@@ -124,11 +124,11 @@ let test_context_derived_flag_operator () =
 let test_context_env_pairs_contain_masc () =
   let defaults = { KTP.empty_keeper_profile_defaults with oas_env = [] } in
   let ctx = KTP.keeper_oas_context_of_defaults defaults in
-  match List.assoc_opt "OAS_GEMINI_ALLOWED_MCP" ctx.env_pairs with
+  match List.assoc_opt "OAS_CLI_TOOL_B_ALLOWED_MCP" ctx.env_pairs with
   | Some value ->
     check string "env_pairs contains masc" "masc" value
   | None ->
-    fail "OAS_GEMINI_ALLOWED_MCP missing from env_pairs"
+    fail "OAS_CLI_TOOL_B_ALLOWED_MCP missing from env_pairs"
 
 (* ── Test suite ────────────────────────────────────────────── *)
 
@@ -137,7 +137,7 @@ let () =
     [
       ( "injection",
         [
-          Alcotest.test_case "empty input injects OAS_GEMINI_ALLOWED_MCP=masc"
+          Alcotest.test_case "empty input injects OAS_CLI_TOOL_B_ALLOWED_MCP=masc"
             `Quick test_default_injects_masc;
           Alcotest.test_case "NO_MCP=true skips injection"
             `Quick test_disabled_skips_injection;

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1541,9 +1541,9 @@ let test_oas_env_parses_allowed_keys () =
 [keeper]
 persona_name = "analyst"
 [keeper.oas_env]
-OAS_CLAUDE_STRICT_MCP = "1"
-OAS_GEMINI_NO_MCP = "1"
-OAS_CODEX_CONFIG = "mcp_servers={}"
+OAS_CLI_TOOL_D_STRICT_MCP = "1"
+OAS_CLI_TOOL_B_NO_MCP = "1"
+OAS_CLI_TOOL_A_CONFIG = "mcp_servers={}"
 MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS = 8192
 |} in
   match TL.parse_toml input with
@@ -1554,11 +1554,11 @@ MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS = 8192
     | Ok d ->
       check int "oas_env count" 4 (List.length d.oas_env);
       check string "strict_mcp value"
-        "1" (List.assoc "OAS_CLAUDE_STRICT_MCP" d.oas_env);
+        "1" (List.assoc "OAS_CLI_TOOL_D_STRICT_MCP" d.oas_env);
       check string "no_mcp value"
-        "1" (List.assoc "OAS_GEMINI_NO_MCP" d.oas_env);
+        "1" (List.assoc "OAS_CLI_TOOL_B_NO_MCP" d.oas_env);
       check string "codex_config value"
-        "mcp_servers={}" (List.assoc "OAS_CODEX_CONFIG" d.oas_env);
+        "mcp_servers={}" (List.assoc "OAS_CLI_TOOL_A_CONFIG" d.oas_env);
       check string "unified max tokens value"
         "8192" (List.assoc "MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS" d.oas_env);
       check (option int) "unified max tokens override"
@@ -1588,7 +1588,7 @@ MASC_KEEPER_UNIFIED_MAX_TOKENS = 4096
 let test_keeper_oas_context_demotes_gemini_no_mcp_to_plan () =
   let defaults =
     { KTP.empty_keeper_profile_defaults with
-      oas_env = [ "OAS_GEMINI_NO_MCP", "1" ];
+      oas_env = [ "OAS_CLI_TOOL_B_NO_MCP", "1" ];
     }
   in
   let ctx = KTP.keeper_oas_context_of_defaults defaults in
@@ -1602,8 +1602,8 @@ let test_keeper_oas_context_preserves_explicit_gemini_approval_mode () =
     { KTP.empty_keeper_profile_defaults with
       oas_env =
         [
-          "OAS_GEMINI_NO_MCP", "1";
-          "OAS_GEMINI_APPROVAL_MODE", "yolo";
+          "OAS_CLI_TOOL_B_NO_MCP", "1";
+          "OAS_CLI_TOOL_B_APPROVAL_MODE", "yolo";
         ];
     }
   in
@@ -1622,7 +1622,7 @@ persona_name = "analyst"
 [keeper.oas_env]
 PATH = "/evil/bin:/usr/bin"
 LD_PRELOAD = "/tmp/hack.so"
-OAS_CLAUDE_STRICT_MCP = "1"
+OAS_CLI_TOOL_D_STRICT_MCP = "1"
 MASC_KEEPER_AUTONOMOUS_MAX_TOKENS = "9999"
 RANDOM_VAR = "nope"
 |} in
@@ -1657,7 +1657,7 @@ let test_oas_env_not_flagged_as_unknown () =
 [keeper]
 persona_name = "analyst"
 [keeper.oas_env]
-OAS_CLAUDE_STRICT_MCP = "1"
+OAS_CLI_TOOL_D_STRICT_MCP = "1"
 |} in
   match TL.parse_toml input with
   | Error e -> fail e
@@ -1671,8 +1671,8 @@ let test_oas_env_coerces_bool_to_string () =
 [keeper]
 persona_name = "analyst"
 [keeper.oas_env]
-OAS_CLAUDE_STRICT_MCP = true
-OAS_CODEX_SKIP_GIT = false
+OAS_CLI_TOOL_D_STRICT_MCP = true
+OAS_CLI_TOOL_A_SKIP_GIT = false
 |} in
   match TL.parse_toml input with
   | Error e -> fail e
@@ -1681,9 +1681,9 @@ OAS_CODEX_SKIP_GIT = false
     | Error e -> fail e
     | Ok d ->
       check string "true → 1" "1"
-        (List.assoc "OAS_CLAUDE_STRICT_MCP" d.oas_env);
+        (List.assoc "OAS_CLI_TOOL_D_STRICT_MCP" d.oas_env);
       check string "false → 0" "0"
-        (List.assoc "OAS_CODEX_SKIP_GIT" d.oas_env)
+        (List.assoc "OAS_CLI_TOOL_A_SKIP_GIT" d.oas_env)
 
 let test_detect_unknown_keys_flags_also_allow_alias () =
   let input = {|

--- a/test/test_rfc_0085_pr3_server_runtime_paths.ml
+++ b/test/test_rfc_0085_pr3_server_runtime_paths.ml
@@ -33,10 +33,10 @@ let test_no_gemini_specific_policy_wiring () =
   let admin_env =
     Ast_grep.count_string_literals
       ~module_path:path
-      ~needle:"OAS_GEMINI_ADMIN_POLICY"
+      ~needle:"OAS_CLI_TOOL_B_ADMIN_POLICY"
   in
   check int "gemini_headless_admin literals in runtime_bootstrap" 0 headless;
-  check int "OAS_GEMINI_ADMIN_POLICY literals in runtime_bootstrap" 0 admin_env
+  check int "OAS_CLI_TOOL_B_ADMIN_POLICY literals in runtime_bootstrap" 0 admin_env
 ;;
 
 let test_takeover_uses_host_config () =


### PR DESCRIPTION
## Summary

Production-blocking contract drift fix. After PR #18262 (RFC-0176)
bumped `agent_sdk` to 0.197.0, the OAS transport modules read CLI-tool
env vars only under their post-purge names (`OAS_CLI_TOOL_B_NO_MCP`,
etc.), but masc-mcp was still setting and reading the old vendor names
(`OAS_GEMINI_NO_MCP`, etc.) → silent runtime failure of CLI-tool
approval-mode / no-mcp / allowed-mcp / admin-policy / config behaviour.

## Mapping

| Old (masc-mcp side) | New (OAS 0.197.0 side) |
|---|---|
| `OAS_GEMINI_*` | `OAS_CLI_TOOL_B_*` |
| `OAS_CLAUDE_*` | `OAS_CLI_TOOL_D_*` |
| `OAS_CODEX_*` | `OAS_CLI_TOOL_A_*` |
| `OAS_KIMI_*` | `OAS_CLI_TOOL_C_*` |

Verified against `~/.opam/5.4.1/lib/agent_sdk/llm_provider/transport_cli_tool_b.ml`:
```
  OAS_CLI_TOOL_B_NO_MCP         1     → --allowed-mcp-server-names __oas_no_mcp__
  OAS_CLI_TOOL_B_APPROVAL_MODE  default|auto_edit|yolo|plan
  OAS_CLI_TOOL_B_ALLOWED_MCP    "a,b" → --allowed-mcp-server-names a,b
```

## Files

| File | Sites |
|---|---|
| `lib/keeper/keeper_cli_mcp_config.ml`+`.mli` | 4 (CLAUDE) |
| `lib/keeper/keeper_types_profile_defaults.ml` | 8 (GEMINI + CLAUDE) |
| `lib/keeper/keeper_types_profile_oas_env.ml` | 6 (GEMINI) |
| `test/test_effective_oas_env.ml` | 27 (GEMINI) |
| `test/test_keeper_toml.ml` | 14 (CLAUDE + GEMINI + CODEX) |
| `test/test_rfc_0085_pr3_server_runtime_paths.ml` | 2 (GEMINI) |

`7 files changed, +58 / -58 LoC` (pure rename — no semantic change).

## Scope discipline

**In scope**: literal `OAS_(GEMINI|CLAUDE|CODEX|KIMI)_*` env var strings —
the contract between masc-mcp and OAS `transport_cli_tool_*` modules.

**Out of scope (separate work)**:
- API key env vars (`KIMI_API_KEY → PROVIDER_C_API_KEY` etc.) —
  user-facing breaking change; requires operator-facing RFC + migration
  window.
- `cascade.toml auth_env = "..."` fixture entries — user-supplied env
  var names; masc-mcp does not own them.
- masc-mcp internal field names (`gemini_mcp_disabled`,
  `claude_mcp_config`) — internal symbols; non-load-bearing relative
  to the OAS contract; follow-up sweep candidate.

## RFC linkage

RFC-0176 §3 "Out of scope" explicitly deferred non-`Provider_config`
sites. This PR closes the `OAS_CLI_TOOL_*` env var subset of that
deferred work. No new RFC; closes RFC-0176 §3 partially.

## Verification

`rg -in 'OAS_(GEMINI|CLAUDE|CODEX|KIMI)_' lib/ bin/ test/` → **0 hits**.

Local build verification skipped (opam pin source cache corruption
documented in RFC-0176 §4); CI fresh opam env validates.

## Workaround-rejection self-check

Pure identifier rename to match the new SDK API. No catch-all, no
string classifier, no cap/cooldown/dedup, no test backdoor. All 7
signatures: NO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)