### PR TITLE
[codex] Clarify dashboard coverage gap incidents

### DIFF
--- a/dashboard/src/components/common/coverage-gap-block.ts
+++ b/dashboard/src/components/common/coverage-gap-block.ts
@@ -92,18 +92,34 @@ export function errorHintFromGap(display: CoverageGapDisplay): CoverageErrorHint
     ?? classifyCoverageError(display.structured.error)
 }
 
+function causeLabel(display: CoverageGapDisplay, hint: CoverageErrorHint | null): string {
+  if (hint) return hint.label.split(' — ')[0] ?? hint.label
+  return display.structured.reason.replace(/_/g, ' ')
+}
+
+function stateToneClass(stateLabel: string): string {
+  switch (stateLabel) {
+    case 'active':
+      return 'border-[var(--bad)]/40 bg-[var(--bad)]/10 text-[var(--bad-light)]'
+    case 'recent':
+      return 'border-[var(--color-status-warn)]/40 bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+    case 'historical':
+      return 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)]'
+    default:
+      return 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-secondary)]'
+  }
+}
+
 /**
  * Coverage-gap provenance block. Shared by tool-quality-panel and
  * fleet-health-panel Operations view so the collapsible-error UX is the
  * same regardless of which surface the operator lands on.
  *
  * Visual hierarchy (top → bottom):
- *  1. Warn-tone summary line (`⚠ coverage gaps N: <reason>`)
- *  2. Triage chips (producer / store / surface / trace) — always visible
- *  3. Error blob inside a closed `<details>` (1-line truncated preview
- *     when closed, full `<pre>` block when open)
- *  4. Optional "see RFC-XXXX" anchor when the error matches a known
- *     incident class (see `classifyCoverageError`)
+ *  1. Incident title + active/recent/historical chip.
+ *  2. Operator summary (cause / impact / latest / store).
+ *  3. Optional runbook link when the error maps to a known incident class.
+ *  4. Collapsed raw evidence (reason / producer / surface / trace / error).
  *
  * Label spans use `${label + ' '}` (not adjacent siblings) so DOM
  * textContent preserves "label value" as a contiguous substring —
@@ -112,47 +128,74 @@ export function errorHintFromGap(display: CoverageGapDisplay): CoverageErrorHint
 export function CoverageGapBlock({ display }: { display: CoverageGapDisplay }) {
   const { structured } = display
   const hint = errorHintFromGap(display)
+  const summaryRows = [
+    { label: 'cause', value: causeLabel(display, hint) },
+    { label: 'impact', value: structured.impact },
+    { label: 'latest', value: structured.latest },
+    { label: 'store', value: structured.store },
+  ].filter((row): row is { label: string; value: string } => !!row.value)
+  const evidenceRows = [
+    { label: 'reason', value: structured.reason },
+    { label: 'producer', value: structured.producer },
+    { label: 'surface', value: structured.surface },
+    { label: 'trace', value: structured.trace },
+  ].filter((row): row is { label: string; value: string } => !!row.value)
   return html`
-    <div class="mt-1 grid gap-1 rounded-[var(--r-1)] border border-[var(--color-status-warn)]/30 bg-[var(--warn-10)]/30 px-2 py-1.5 text-3xs" data-testid="coverage-gap-block">
-      <div class="flex items-center gap-1.5 font-medium text-[var(--color-status-warn)]">
-        <span aria-hidden="true">⚠</span>
-        <span>${display.summary}</span>
-      </div>
-      ${structured.fields.length > 0 ? html`
-        <div class="grid gap-0.5 font-mono">
-          ${structured.fields.map(({ label, value }) => html`
-            <div class="flex items-baseline">
-              <span class="w-16 shrink-0 text-[var(--color-fg-disabled)] uppercase tracking-wide">${label + ' '}</span>
-              <span class="min-w-0 break-all text-[var(--color-fg-muted)]">${value}</span>
-            </div>
-          `)}
+    <div class="mt-1 grid gap-2 rounded-[var(--r-1)] border border-[var(--color-status-warn)]/30 bg-[var(--warn-10)]/25 px-2.5 py-2 text-3xs" data-testid="coverage-gap-block">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <div class="flex min-w-0 items-center gap-1.5 font-medium text-[var(--color-status-warn)]">
+          <span aria-hidden="true">⚠</span>
+          <span class="min-w-0">${display.summary}</span>
         </div>
-      ` : null}
-      ${structured.error ? html`
-        <details class="group">
-          <summary class="flex items-baseline cursor-pointer list-none [&::-webkit-details-marker]:hidden font-mono">
-            <span class="w-16 shrink-0 uppercase tracking-wide text-[var(--color-fg-disabled)]">error </span>
-            <span class="min-w-0 flex-1 truncate text-[var(--color-fg-muted)] group-open:hidden">${structured.error}</span>
-            <span class="ml-2 shrink-0 text-[var(--color-fg-disabled)]" aria-hidden="true">
-              <span class="group-open:hidden">▸</span>
-              <span class="hidden group-open:inline">▾</span>
-            </span>
-          </summary>
-          <pre class="mt-1 ml-16 max-h-32 overflow-auto rounded-[var(--r-1)] bg-[var(--bg-deepest)] p-2 font-mono text-3xs leading-snug text-[var(--color-fg-muted)] whitespace-pre-wrap break-all">${structured.error}</pre>
-        </details>
-      ` : null}
+        <span class=${`shrink-0 rounded-[var(--r-1)] border px-1.5 py-0.5 font-mono uppercase tracking-wide ${stateToneClass(structured.stateLabel)}`}>
+          ${structured.stateLabel}
+        </span>
+      </div>
+      <div class="grid gap-1 md:grid-cols-2">
+        ${summaryRows.map(({ label, value }) => html`
+          <div class="flex items-baseline gap-2">
+            <span class="w-14 shrink-0 text-[var(--color-fg-disabled)] uppercase tracking-wide">${label + ' '}</span>
+            <span class="min-w-0 break-words text-[var(--color-fg-muted)]">${value}</span>
+          </div>
+        `)}
+      </div>
       ${hint ? html`
         <a
           href=${hint.href}
           target="_blank"
           rel="noopener noreferrer"
-          class="ml-16 inline-flex items-center gap-1 self-start rounded-[var(--r-1)] border border-[var(--color-status-warn)]/40 bg-[var(--warn-10)] px-1.5 py-0.5 font-medium text-[var(--color-status-warn)] hover:bg-[var(--warn-20)]"
+          class="inline-flex items-center gap-1 self-start rounded-[var(--r-1)] border border-[var(--color-status-warn)]/40 bg-[var(--warn-10)] px-1.5 py-0.5 font-medium text-[var(--color-status-warn)] hover:bg-[var(--warn-20)]"
           data-testid=${`coverage-gap-hint-${hint.reason}`}
         >
-          <span aria-hidden="true">💡</span>
           <span>${hint.label}</span>
           <span aria-hidden="true">↗</span>
         </a>
+      ` : null}
+      ${(evidenceRows.length > 0 || structured.error) ? html`
+        <details class="group">
+          <summary class="flex cursor-pointer items-center gap-1.5 list-none text-[var(--color-fg-secondary)] [&::-webkit-details-marker]:hidden">
+            <span class="font-medium">Evidence</span>
+            ${structured.trace ? html`<span class="min-w-0 truncate font-mono text-[var(--color-fg-disabled)]">${structured.trace}</span>` : null}
+            <span class="ml-auto shrink-0 text-[var(--color-fg-disabled)]" aria-hidden="true">
+              <span class="group-open:hidden">▸</span>
+              <span class="hidden group-open:inline">▾</span>
+            </span>
+          </summary>
+          <div class="mt-1 grid gap-0.5 font-mono">
+            ${evidenceRows.map(({ label, value }) => html`
+              <div class="flex items-baseline gap-2">
+                <span class="w-20 shrink-0 text-[var(--color-fg-disabled)] uppercase tracking-wide">${label + ' '}</span>
+                <span class="min-w-0 break-all text-[var(--color-fg-muted)]">${value}</span>
+              </div>
+            `)}
+            ${structured.error ? html`
+              <div>
+                <div class="text-[var(--color-fg-disabled)] uppercase tracking-wide">error </div>
+                <pre class="mt-1 max-h-32 overflow-auto rounded-[var(--r-1)] bg-[var(--bg-deepest)] p-2 font-mono text-3xs leading-snug text-[var(--color-fg-muted)] whitespace-pre-wrap break-all">${structured.error}</pre>
+              </div>
+            ` : null}
+          </div>
+        </details>
       ` : null}
     </div>
   `

--- a/dashboard/src/components/common/source-health.test.ts
+++ b/dashboard/src/components/common/source-health.test.ts
@@ -11,7 +11,7 @@ describe('sourceHealthClass', () => {
 describe('freshnessText', () => {
   it('prefers stale reason over latest age', () => {
     expect(freshnessText({ stale_reason: 'tool_call_io_append_failed', latest_age_s: 4 })).toBe(
-      'tool_call_io_append_failed',
+      'tool-call log write failed',
     )
   })
 })
@@ -40,8 +40,11 @@ describe('coverageGapDisplay', () => {
 
     expect(display).toEqual({
       count: 2,
-      summary: 'coverage gaps 2: tool_call_io_append_failed',
+      summary: 'Tool-call log write failed · 2 recorded gaps',
       details: [
+        'status recorded',
+        'impact Tool Monitor may undercount keeper tool I/O around this trace.',
+        'reason tool_call_io_append_failed',
         'producer keeper_tool_call_log.append',
         'store .masc/tool_calls',
         'surface /api/v1/keepers/:name/tool-calls',
@@ -50,12 +53,14 @@ describe('coverageGapDisplay', () => {
       ],
       structured: {
         reason: 'tool_call_io_append_failed',
-        fields: [
-          { label: 'producer', value: 'keeper_tool_call_log.append' },
-          { label: 'store', value: '.masc/tool_calls' },
-          { label: 'surface', value: '/api/v1/keepers/:name/tool-calls' },
-          { label: 'trace', value: 'trace-tool-call-gap' },
-        ],
+        title: 'Tool-call log write failed',
+        stateLabel: 'recorded',
+        latest: null,
+        impact: 'Tool Monitor may undercount keeper tool I/O around this trace.',
+        producer: 'keeper_tool_call_log.append',
+        store: '.masc/tool_calls',
+        surface: '/api/v1/keepers/:name/tool-calls',
+        trace: 'trace-tool-call-gap',
         error: 'append denied',
         errorClass: null,
       },
@@ -92,8 +97,11 @@ describe('coverageGapDisplay', () => {
 
     expect(display).toEqual({
       count: 2,
-      summary: 'coverage gaps 2: NEW_reason',
+      summary: 'Tool-call telemetry coverage issue · 2 recorded gaps',
       details: [
+        'status recorded',
+        'impact Tool Monitor may undercount keeper tool I/O around this trace.',
+        'reason NEW_reason',
         'producer NEW-producer',
         'store NEW-store',
         'surface NEW-surface',
@@ -102,12 +110,14 @@ describe('coverageGapDisplay', () => {
       ],
       structured: {
         reason: 'NEW_reason',
-        fields: [
-          { label: 'producer', value: 'NEW-producer' },
-          { label: 'store', value: 'NEW-store' },
-          { label: 'surface', value: 'NEW-surface' },
-          { label: 'trace', value: 'NEW-trace' },
-        ],
+        title: 'Tool-call telemetry coverage issue',
+        stateLabel: 'recorded',
+        latest: null,
+        impact: 'Tool Monitor may undercount keeper tool I/O around this trace.',
+        producer: 'NEW-producer',
+        store: 'NEW-store',
+        surface: 'NEW-surface',
+        trace: 'NEW-trace',
         error: 'NEW-error',
         errorClass: null,
       },

--- a/dashboard/src/components/common/source-health.ts
+++ b/dashboard/src/components/common/source-health.ts
@@ -29,7 +29,7 @@ export function sourceHealthClass(health?: string | null): string {
 
 /** Format telemetry freshness metadata into a human-readable label. */
 export function freshnessText(d: TelemetryFreshnessMetadata): string {
-  if (d.stale_reason) return d.stale_reason
+  if (d.stale_reason) return humanizeCoverageReason(d.stale_reason)
   if (typeof d.latest_age_s !== 'number' || !Number.isFinite(d.latest_age_s)) {
     return 'latest n/a'
   }
@@ -52,24 +52,118 @@ function latestCoverageGap(d: TelemetryFreshnessMetadata): TelemetryCoverageGap 
   return gaps[gaps.length - 1] ?? null
 }
 
-export type CoverageGapField = { label: string; value: string }
-
 export type CoverageGapDisplay = {
   count: number
   summary: string
   details: string[]
-  // Structured split of `details` so panels can render error text inside a
-  // collapsible block while keeping producer/store/surface/trace visible.
-  // `details` remains the flat SSOT for callers that just want strings.
+  // Structured split of `details` so panels can keep the operator-facing
+  // diagnosis separate from raw provenance. `details` remains the flat SSOT
+  // for compact callers that just want strings.
   structured: {
     reason: string
-    fields: CoverageGapField[]
+    title: string
+    stateLabel: string
+    latest: string | null
+    impact: string
+    producer: string | null
+    store: string | null
+    surface: string | null
+    trace: string | null
     error: string | null
     // RFC-0154 PR-3: backend-classified short tag. Absent on v1 wire rows
     // (pre-RFC-0154 PR-2 deployment); present on v2 rows. Consumers should
     // prefer this typed lookup over substring matching on `error`.
     errorClass: string | null
   }
+}
+
+const ACTIVE_GAP_AGE_S = 15 * 60
+const RECENT_GAP_AGE_S = 24 * 60 * 60
+
+export function humanizeCoverageReason(reason: string): string {
+  switch (reason) {
+    case 'tool_call_io_append_failed':
+      return 'tool-call log write failed'
+    case 'tool_call_io_store_unavailable':
+      return 'tool-call log unavailable'
+    case 'tool_call_io_init_failed':
+      return 'tool-call log init failed'
+    case 'trajectory_append_failed':
+      return 'tool trajectory write failed'
+    case 'execution_receipt_append_failed':
+      return 'execution receipt write failed'
+    case 'freshness_slo_exceeded':
+      return 'freshness SLO exceeded'
+    case 'store_missing':
+      return 'store missing'
+    case 'no_entries':
+      return 'no entries'
+    default:
+      return reason.replace(/_/g, ' ')
+  }
+}
+
+function titleForCoverageGap(source: string | null, reason: string): string {
+  switch (reason) {
+    case 'tool_call_io_append_failed':
+      return 'Tool-call log write failed'
+    case 'tool_call_io_store_unavailable':
+      return 'Tool-call log unavailable'
+    case 'tool_call_io_init_failed':
+      return 'Tool-call log init failed'
+    case 'trajectory_append_failed':
+      return 'Tool trajectory write failed'
+    case 'execution_receipt_append_failed':
+      return 'Execution receipt write failed'
+    default:
+      if (reason.endsWith('_append_failed')) return 'Telemetry write failed'
+      if (source === 'tool_call_io') return 'Tool-call telemetry coverage issue'
+      return 'Telemetry coverage issue'
+  }
+}
+
+function impactForCoverageGap(source: string | null, reason: string, surface: string | null): string {
+  if (reason === 'tool_call_io_append_failed' || source === 'tool_call_io') {
+    return 'Tool Monitor may undercount keeper tool I/O around this trace.'
+  }
+  if (reason === 'trajectory_append_failed' || source === 'trajectory_tool_call') {
+    return 'Keeper tool stats or trajectory drilldowns may miss events around this trace.'
+  }
+  if (reason === 'execution_receipt_append_failed' || source === 'execution_receipt') {
+    return 'Execution-trust views may miss receipt evidence around this trace.'
+  }
+  if (surface) return 'This dashboard surface may be missing telemetry rows.'
+  return 'One telemetry lane may be missing rows.'
+}
+
+function gapUnixSeconds(gap: TelemetryCoverageGap | null): number | null {
+  if (!gap) return null
+  if (typeof gap.ts === 'number' && Number.isFinite(gap.ts) && gap.ts > 0) return gap.ts
+  const parsed = gap.ts_iso ? Date.parse(gap.ts_iso) : Number.NaN
+  if (!Number.isFinite(parsed)) return null
+  return parsed / 1000
+}
+
+function latestGapText(gap: TelemetryCoverageGap | null): string | null {
+  const ts = gapUnixSeconds(gap)
+  if (ts != null) {
+    const age = Math.max(0, Date.now() / 1000 - ts)
+    return `latest gap ${formatElapsedCompact(age)} ago`
+  }
+  return nonEmpty(gap?.ts_iso) ? `latest gap ${gap?.ts_iso}` : null
+}
+
+function stateLabelForGap(gap: TelemetryCoverageGap | null): string {
+  const ts = gapUnixSeconds(gap)
+  if (ts == null) return 'recorded'
+  const age = Math.max(0, Date.now() / 1000 - ts)
+  if (age <= ACTIVE_GAP_AGE_S) return 'active'
+  if (age <= RECENT_GAP_AGE_S) return 'recent'
+  return 'historical'
+}
+
+function recordedGapCount(count: number): string {
+  return count === 1 ? '1 recorded gap' : `${count} recorded gaps`
 }
 
 /** Build compact operator-visible coverage-gap details for freshness lines. */
@@ -79,27 +173,47 @@ export function coverageGapDisplay(d: TelemetryFreshnessMetadata): CoverageGapDi
 
   const gap = latestCoverageGap(d)
   const reason = nonEmpty(gap?.stale_reason) ?? nonEmpty(d.stale_reason) ?? 'coverage_gap'
-  const rawDetails: Array<[string, string | null]> = [
-    ['producer', nonEmpty(gap?.producer) ?? nonEmpty(d.producer)],
-    ['store', nonEmpty(gap?.durable_store) ?? nonEmpty(d.durable_store)],
-    ['surface', nonEmpty(gap?.dashboard_surface) ?? nonEmpty(d.dashboard_surface)],
-    ['trace', nonEmpty(gap?.trace_id)],
-    ['error', nonEmpty(gap?.error)],
+  const source = nonEmpty(gap?.source) ?? nonEmpty(d.source)
+  const producer = nonEmpty(gap?.producer) ?? nonEmpty(d.producer)
+  const store = nonEmpty(gap?.durable_store) ?? nonEmpty(d.durable_store)
+  const surface = nonEmpty(gap?.dashboard_surface) ?? nonEmpty(d.dashboard_surface)
+  const trace = nonEmpty(gap?.trace_id)
+  const errorValue = nonEmpty(gap?.error)
+  const errorClass = nonEmpty(gap?.error_class)
+  const title = titleForCoverageGap(source, reason)
+  const latest = latestGapText(gap)
+  const stateLabel = stateLabelForGap(gap)
+  const impact = impactForCoverageGap(source, reason, surface)
+  const detailRows: Array<[string, string | null]> = [
+    ['status', latest ? `${stateLabel} · ${latest}` : stateLabel],
+    ['impact', impact],
+    ['reason', reason],
+    ['producer', producer],
+    ['store', store],
+    ['surface', surface],
+    ['trace', trace],
+    ['error', errorValue],
   ]
-  const details = rawDetails
+  const details = detailRows
     .filter((entry): entry is [string, string] => entry[1] != null)
     .map(([label, value]) => `${label} ${value}`)
 
-  const fields: CoverageGapField[] = rawDetails
-    .filter((entry): entry is [string, string] => entry[1] != null && entry[0] !== 'error')
-    .map(([label, value]) => ({ label, value }))
-  const errorValue = nonEmpty(gap?.error)
-  const errorClass = nonEmpty(gap?.error_class)
-
   return {
     count,
-    summary: `coverage gaps ${count}: ${reason}`,
+    summary: `${title} · ${recordedGapCount(count)}`,
     details,
-    structured: { reason, fields, error: errorValue, errorClass },
+    structured: {
+      reason,
+      title,
+      stateLabel,
+      latest,
+      impact,
+      producer,
+      store,
+      surface,
+      trace,
+      error: errorValue,
+      errorClass,
+    },
   }
 }

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -315,7 +315,8 @@ describe('FleetTelemetryPanel', () => {
     await flushUi()
 
     expect(fetchDashboardExecutionTrust).toHaveBeenCalledTimes(1)
-    expect(container.textContent).toContain('coverage gaps 1: execution_receipt_append_failed')
+    expect(container.textContent).toContain('Execution receipt write failed · 1 recorded gap')
+    expect(container.textContent).toContain('reason execution_receipt_append_failed')
     expect(container.textContent).toContain('producer keeper_agent_run.execution_receipt')
     expect(container.textContent).toContain('store .masc/keepers/*/execution-receipts')
     expect(container.textContent).toContain('surface /api/v1/dashboard/execution-trust')

--- a/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
@@ -273,7 +273,9 @@ describe('KeeperToolCallInspector render', () => {
     })
     await flushUi()
 
-    expect(container.textContent).toContain('coverage gaps 1: tool_call_io_append_failed')
+    expect(container.textContent).toContain('Tool-call log write failed · 1 recorded gap')
+    expect(container.textContent).toContain('impact Tool Monitor may undercount keeper tool I/O around this trace.')
+    expect(container.textContent).toContain('reason tool_call_io_append_failed')
     expect(container.textContent).toContain('producer keeper_tool_call_log.append')
     expect(container.textContent).toContain('store .masc/tool_calls')
     expect(container.textContent).toContain('surface /api/v1/keepers/:name/tool-calls')

--- a/dashboard/src/components/keeper-tool-telemetry.test.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.test.ts
@@ -162,7 +162,8 @@ describe('KeeperToolTelemetry render', () => {
     })
     await flushUi()
 
-    expect(container.textContent).toContain('coverage gaps 1: trajectory_append_failed')
+    expect(container.textContent).toContain('Tool trajectory write failed · 1 recorded gap')
+    expect(container.textContent).toContain('reason trajectory_append_failed')
     expect(container.textContent).toContain('producer keeper_hooks_oas.post_tool_use')
     expect(container.textContent).toContain('store .masc/keepers/analyst/trajectories')
     expect(container.textContent).toContain('surface /api/v1/keepers/:name/tool-stats')

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -329,7 +329,9 @@ describe('TelemetryUnified', () => {
     })
     await flushUi()
 
-    expect(container.textContent).toContain('coverage gaps 1: append_failed')
+    expect(container.textContent).toContain('Telemetry coverage issue · 1 recorded gap')
+    expect(container.textContent).toContain('gap reason')
+    expect(container.textContent).toContain('append_failed')
     expect(container.textContent).toContain('gap producer')
     expect(container.textContent).toContain('telemetry_eio')
     expect(container.textContent).toContain('gap store')

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -270,7 +270,10 @@ describe('ToolQualityPanel', () => {
     })
     await flushUi()
 
-    expect(container.textContent).toContain('coverage gaps 1: append_failed')
+    expect(container.textContent).toContain('Tool-call telemetry coverage issue · 1 recorded gap')
+    expect(container.textContent).toContain('cause Disk pressure')
+    expect(container.textContent).toContain('impact Tool Monitor may undercount keeper tool I/O around this trace.')
+    expect(container.textContent).toContain('reason append_failed')
     expect(container.textContent).toContain('producer keeper_tool_call_log.append')
     expect(container.textContent).toContain('store .masc/tool_calls')
     expect(container.textContent).toContain('surface /api/v1/dashboard/tool-quality')
@@ -533,7 +536,14 @@ describe('errorHintFromGap (RFC-0154 PR-3 cascading resolver)', () => {
     details: [],
     structured: {
       reason: 'x',
-      fields: [],
+      title: 'x',
+      stateLabel: 'recorded',
+      latest: null,
+      impact: 'impact',
+      producer: null,
+      store: null,
+      surface: null,
+      trace: null,
       error,
       errorClass,
     },

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -113,7 +113,8 @@ describe('Tools', () => {
     render(html`<${Tools} />`, container)
     await flush()
 
-    expect(container.textContent).toContain('coverage gaps 1: tool_usage_append_failed')
+    expect(container.textContent).toContain('Telemetry write failed · 1 recorded gap')
+    expect(container.textContent).toContain('reason tool_usage_append_failed')
     expect(container.textContent).toContain('producer tool_usage_log')
     expect(container.textContent).toContain('store .masc/tool_usage')
     expect(container.textContent).toContain('surface /api/v1/dashboard/tools')


### PR DESCRIPTION
## Summary

- Reframe dashboard coverage-gap alerts as operator-facing incidents instead of raw telemetry internals.
- Show cause, impact, latest gap age, store, and active/recent/historical state before raw evidence.
- Keep raw reason, producer, surface, trace, and error available under an Evidence disclosure.

## Why

The Tool Monitor page exposed useful coverage-gap data, but the primary text was implementation-heavy (`coverage gaps N: tool_call_io_append_failed`). Operators could not quickly tell whether the event was current, what was impacted, or whether the raw error should be treated as evidence rather than the headline.

## Validation

- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/components/common/source-health.ts src/components/common/coverage-gap-block.ts`
- `pnpm exec vitest run --config vitest.config.ts src/components/common/source-health.test.ts src/components/tool-quality-panel.test.ts src/components/keeper-tool-call-inspector-render.test.ts src/components/fleet-telemetry-panel.test.ts src/components/telemetry-unified.test.ts src/components/tools/tools-main.test.ts src/components/keeper-tool-telemetry.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm build`
- Playwright smoke against `http://localhost:5173/dashboard/#monitoring?section=fleet-health` at desktop and mobile viewports.
