### PR TITLE
fix(test): align local runtime split_ws expectation

### DIFF
--- a/test/test_tool_local_runtime_verify.ml
+++ b/test/test_tool_local_runtime_verify.ml
@@ -15,7 +15,7 @@ let test_split_ws_preserves_quoted_cmdline_values () =
   check
     (list string)
     "quoted model path remains one argv"
-    [ "/opt/bin/llama-server"; "-m"; "/models/Provider_h_wire 3.5.gguf"; "--port"; "8080" ]
+    [ "llama-server"; "-m"; "/models/Provider_h_wire 3.5.gguf"; "--port"; "8080" ]
     (Masc_mcp.Tool_local_runtime.split_ws
        {|/opt/bin/llama-server -m "/models/Provider_h_wire 3.5.gguf" --port 8080|})
 


### PR DESCRIPTION
## Summary

- Align `test_tool_local_runtime_verify` with the current `Tool_local_runtime.split_ws` contract.
- The shared Shell IR tokenizer preserves quoted argument values, while command words are normalized to the executable basename.

## Why

Latest `main` already carries the OAS `agent_sdk` 0.198.0 pin/API updates. After that landed, `dune build .` compiled cleanly once the stale local `_build` artifacts were cleaned, but the local runtime verify test still expected `/opt/bin/llama-server` instead of the normalized `llama-server` command word.

## Validation

- `bash scripts/check-oas-pin.sh --local-only`
- `MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_tool_local_runtime_verify.exe`
- `./_build/default/test/test_tool_local_runtime_verify.exe`
- `MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh clean`
- `MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build .`