### PR TITLE
fix(cascade): purge legacy protocol hint strings

### DIFF
--- a/docs/rfc/RFC-0058-declarative-cascade-config.md
+++ b/docs/rfc/RFC-0058-declarative-cascade-config.md
@@ -155,13 +155,13 @@ never by provider name.
 
 | Protocol string in TOML | `api_format` in code | Adapter module | Wire format |
 |--------------------------|---------------------|----------------|-------------|
-| `"provider-a-cli"` | `Messages_api` | `Messages_api_adapter` | Provider-A Messages |
-| `"provider-a-http"` | `Messages_api` | `Messages_api_adapter` | Provider-A Messages |
-| `"google-cli"` | `Chat_completions_api` | `Chat_completions_cli_adapter` | Google format |
+| `"provider_a-cli"` | `Messages_api` | `Messages_api_adapter` | Provider-A Messages |
+| `"provider_a-http"` | `Messages_api` | `Messages_api_adapter` | Provider-A Messages |
+| `"provider_f-cli"` | `Chat_completions_api` | `Chat_completions_cli_adapter` | Provider-F format |
 | `"ollama-http"` | `Ollama_api` | `Ollama_api_adapter` | Ollama native |
-| `"provider-d-cli"` | `Chat_completions_api` | `Chat_completions_cli_adapter` | Provider-D-compatible CLI |
-| `"provider-d-http"` | `Chat_completions_api` | `Chat_completions_api_adapter` | Provider-D format |
-| `"provider-c-cli"` | `Chat_completions_api` | `Kimi_cli_adapter` | Provider-C format |
+| `"provider_d-cli"` | `Chat_completions_api` | `Chat_completions_cli_adapter` | Provider-D-compatible CLI |
+| `"provider_d-http"` | `Chat_completions_api` | `Chat_completions_api_adapter` | Provider-D format |
+| `"provider_c-cli"` | `Chat_completions_api` | `Kimi_cli_adapter` | Provider-C format |
 
 Adding a new provider that uses an existing protocol = TOML entry only.
 Adding a new protocol = thin adapter module + TOML protocol string registration.
@@ -182,7 +182,7 @@ Any provider alias that collides with a reserved namespace is a load-time error.
 ```toml
 [providers.claude-code]
 display-name = "Provider-A CLI"
-protocol = "provider-a-cli"
+protocol = "provider_a-cli"
 command = "agent-llm-a"
 is-non-interactive = true
 
@@ -192,7 +192,7 @@ key = "PROVIDER-A_API_KEY"
 
 [providers.claude-code-alt]
 display-name = "Provider-A CLI (alt account)"
-protocol = "provider-a-cli"
+protocol = "provider_a-cli"
 command = "agent-llm-a"
 is-non-interactive = true
 
@@ -202,7 +202,7 @@ path = "~/.config/claude-alt/key"
 
 [providers.provider-c-code]
 display-name = "Provider-B Provider-C Code"
-protocol = "provider-c-cli"
+protocol = "provider_c-cli"
 command = "provider-c"
 is-non-interactive = true
 
@@ -213,13 +213,13 @@ endpoint = "http://localhost:11434"
 
 [providers.provider-f-cli]
 display-name = "Google CLI-Tool-C"
-protocol = "google-cli"
+protocol = "provider_f-cli"
 command = "provider-f"
 is-non-interactive = true
 
 [providers.agent-code]
 display-name = "Provider-D CLI-Tool-B"
-protocol = "provider-d-http"
+protocol = "provider_d-http"
 endpoint = "https://api.provider-d.com"
 
 [providers.agent-code.credentials]

--- a/docs/rfc/RFC-0177-phonebook-internal-vendor-purge.md
+++ b/docs/rfc/RFC-0177-phonebook-internal-vendor-purge.md
@@ -48,7 +48,7 @@ These are *serving infrastructure*, not vendor brands. Same rationale as OAS RFC
 ## 3. Out of scope
 
 - Other masc-mcp internal vendor references not in `cascade_phonebook_types.ml` (e.g., string fixtures `"anthropic"` / `"openai"` in tests, comment references) — future audit.
-- Dashboard string fixtures (`"provider_a-cli"`, `"google-cli"`) — separate dashboard sweep.
+- Dashboard string fixtures (`"provider_a-cli"`, `"provider_f-cli"`) — separate dashboard sweep.
 
 ## 4. Verification
 

--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -52,7 +52,8 @@ let api_format_of_protocol (s : string) : (cascade_api_format, string) result =
     Error
       (Printf.sprintf
          "unknown protocol %S: expected one of provider_a-cli, provider_a-http, \
-          provider_d-cli, provider_d-http, google-cli, provider_c-cli, ollama-http"
+          provider_d-cli, provider_d-http, provider_f-cli, provider_c-cli, \
+          ollama-http"
          s)
 ;;
 

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -503,6 +503,14 @@ let test_api_format_of_protocol () =
     (api_format_of_protocol "provider_f-cli" = Ok Chat_completions_api);
   check bool "provider_c-cli" true (api_format_of_protocol "provider_c-cli" = Ok Chat_completions_api);
   check bool "ollama-http" true (api_format_of_protocol "ollama-http" = Ok Ollama_api);
+  (match api_format_of_protocol "google-cli" with
+   | Ok _ -> fail "legacy google-cli protocol should not parse"
+   | Error msg ->
+     check
+       string
+       "legacy protocol hint uses canonical provider_f-cli"
+       "unknown protocol \"google-cli\": expected one of provider_a-cli, provider_a-http, provider_d-cli, provider_d-http, provider_f-cli, provider_c-cli, ollama-http"
+       msg);
   check bool "unknown" true (api_format_of_protocol "unknown" |> Result.is_error)
 ;;
 


### PR DESCRIPTION
## Summary
- Replace stale cascade protocol hints/docs with canonical provider_f/provider_* protocol strings
- Keep google-cli rejected and lock that behavior with a parser test
- No compatibility alias is added

## Verification
- git diff --check
- ocamlformat --check lib/cascade_decl/cascade_declarative_parser.ml test/test_cascade_declarative_parser.ml
- rg -n 'google-cli|openai-cli|openai-http' config lib docs scripts (no matches)
- scripts/dune-local.sh build test/test_cascade_declarative_parser.exe blocked by existing bare Dune processes outside wrapper