### PR TITLE
[codex] Fix dashboard keeper presence classification

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -301,6 +301,36 @@ describe('countRuntimeKinds', () => {
     })
   })
 
+  it('keeps paused keeper runtime truth when live agent presence still exists', () => {
+    const result = countRuntimeKinds(
+      [
+        makeAgent({
+          name: 'keeper-sangsu-agent',
+          status: 'busy',
+        }),
+      ],
+      [
+        {
+          name: 'sangsu',
+          agent_name: 'keeper-sangsu-agent',
+          status: 'offline',
+          phase: 'Paused',
+          pipeline_stage: 'paused',
+          paused: false,
+          registered: false,
+          keepalive_running: false,
+        } as Keeper,
+      ],
+    )
+
+    expect(result).toEqual({
+      agents: 0,
+      keepers: 0,
+      pausedKeepers: 1,
+      totalRuntimes: 1,
+    })
+  })
+
   it('collapses keeper-owned generated sub-op aliases when agent meta carries keeper identity', () => {
     const result = countRuntimeKinds(
       [

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -253,8 +253,41 @@ function isRuntimeBackedKeeper(keeper: Keeper): boolean {
   return true
 }
 
-function runtimeBackedKeepers(keeperList: Keeper[]): Keeper[] {
-  return keeperList.filter(isRuntimeBackedKeeper)
+function agentCanBackKeeperRuntime(agent: Agent): boolean {
+  const normalized = agent.status?.trim().toLowerCase()
+  return normalized !== 'inactive' && normalized !== 'offline'
+}
+
+function keeperHasLiveAgentPresence(
+  keeper: Keeper,
+  liveAgentKeys: ReadonlySet<string>,
+): boolean {
+  const candidates = keeperIdentityKeys(keeper.keeper_id ?? null, keeper.name, keeper.agent_name)
+  return candidates.some(candidate => liveAgentKeys.has(candidate))
+}
+
+function liveAgentIdentityKeys(agentList: readonly Agent[]): Set<string> {
+  const keys = new Set<string>()
+  for (const agent of agentList) {
+    if (!agentCanBackKeeperRuntime(agent)) continue
+    for (const candidate of keeperIdentityKeys(
+      agent.keeper_id ?? null,
+      agent.keeper_name ?? null,
+      agent.name,
+    )) {
+      keys.add(candidate)
+    }
+  }
+  return keys
+}
+
+function runtimeBackedKeepers(
+  keeperList: Keeper[],
+  agentList: readonly Agent[] = [],
+): Keeper[] {
+  const liveAgentKeys = liveAgentIdentityKeys(agentList)
+  return keeperList.filter(keeper =>
+    isRuntimeBackedKeeper(keeper) || keeperHasLiveAgentPresence(keeper, liveAgentKeys))
 }
 
 function expectedCountForKeeperFilter(
@@ -476,7 +509,7 @@ export function countRuntimeKinds(
   agentList: Agent[],
   keeperList: Keeper[],
 ): { agents: number; keepers: number; pausedKeepers: number; totalRuntimes: number } {
-  const runtimeKeepers = runtimeBackedKeepers(keeperList)
+  const runtimeKeepers = runtimeBackedKeepers(keeperList, agentList)
   const rosterAgents = buildAgentRoster(agentList, runtimeKeepers)
   const keeperLookup = buildKeeperRuntimeLookup(runtimeKeepers)
   const allKeepers = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeepers, 'keeper-only', keeperLookup)
@@ -507,8 +540,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const agentList = agents.value
   const keeperList = keepers.value
   const runtimeKeeperList = useMemo(
-    () => runtimeBackedKeepers(keeperList),
-    [keeperList],
+    () => runtimeBackedKeepers(keeperList, agentList),
+    [keeperList, agentList],
   )
 
   // Memoize roster and lookup Maps — these iterate full keeper/agent arrays.


### PR DESCRIPTION
## Summary

- Keep keeper runtime truth in the dashboard roster when a paused keeper still has live agent presence.
- Classify these rows from keeper FSM/runtime state instead of falling back to the presence row's busy/active status.
- Add a regression test for a paused keeper with a live `keeper-*-agent` presence row.

## Root Cause

The roster filtered out paused, non-registered, non-keepalive keeper rows before merging them with agent presence. When a stale/live presence row still existed, the UI had no keeper runtime truth left and rendered the keeper from the agent row as `busy`/active.

## Validation

- `pnpm --dir dashboard exec vitest run src/components/agent-roster.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `git diff --check`
- Playwright smoke against live `127.0.0.1:8935` via Vite proxy: roster showed `Runtime Truth 활성 keeper 2 · 일시정지 9 · 설정 keeper 16 · 미기동 5` and status chips `가동중 1 / 일시정지 9 / 오프라인 1`.

## Follow-up

Similar UI bugs may exist where presence-derived rows override runtime/FSM truth. This PR keeps the current fix narrow; broader surface sweep should be handled separately.