### PR TITLE
[codex] fix keeper auto-resume registry wakeup

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1223,6 +1223,15 @@ let sweep_and_recover (ctx : _ context) =
                  resumed_meta
              with
              | Ok () ->
+               Keeper_turn_livelock.reset_keeper_livelock ~keeper:name;
+               (match Keeper_registry.get_phase ~base_path:ctx.config.base_path name with
+                | Some _ ->
+                  Keeper_registry.dispatch_event_unit
+                    ~base_path:ctx.config.base_path
+                    name
+                    Keeper_state_machine.Operator_resume;
+                  Keeper_registry.wakeup ~base_path:ctx.config.base_path name
+                | None -> ());
                publish_lifecycle
                  ~event:
                    (Keeper_lifecycle_events.Custom_event

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1510,6 +1510,69 @@ let test_sweep_auto_resumes_after_backoff () =
       check (float 0.001) "metric_keeper_auto_resumed_total incremented by 1"
         (baseline_auto_resume +. 1.0) after_auto_resume)
 
+let test_sweep_auto_resumes_registered_paused_entry () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  with_config_dir @@ fun config_dir ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc_mcp.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
+      let name = "auto-resume-registered" in
+      write_keeper_toml config_dir ~name;
+      let two_hours_ago =
+        let t = Unix.gmtime (Unix.time () -. 7200.0) in
+        Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+          (t.tm_year + 1900) (t.tm_mon + 1) t.tm_mday
+          t.tm_hour t.tm_min t.tm_sec
+      in
+      let paused_meta =
+        { (make_meta name) with
+          paused = true;
+          auto_resume_after_sec = Some 3600.0;
+          updated_at = two_hours_ago;
+        }
+      in
+      (match KT.write_meta config paused_meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      let entry = Reg.register ~base_path:config.base_path name paused_meta in
+      ignore (Reg.dispatch_event ~base_path:config.base_path name KSM.Operator_pause);
+      (match Reg.get_phase ~base_path:config.base_path name with
+       | Some phase ->
+           check string "precondition: registry phase paused" "paused"
+             (KSM.phase_to_string phase)
+       | None -> fail "precondition: registry entry missing");
+      let ctx : _ KT.context =
+        {
+          config;
+          agent_name = "supervisor";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = Some (Eio.Stdenv.net env);
+        }
+      in
+      Sup.sweep_and_recover ctx;
+      (match KT.read_meta config name with
+       | Ok (Some m) ->
+           check bool "meta.paused = false after auto-resume" false m.paused
+       | Ok None -> fail "meta missing after auto-resume"
+       | Error err -> fail ("read_meta failed: " ^ err));
+      (match Reg.get_phase ~base_path:config.base_path name with
+       | Some phase ->
+           check string "registered keeper resumed in registry" "running"
+             (KSM.phase_to_string phase)
+       | None -> fail "registered keeper missing after auto-resume");
+      check bool "auto-resume wakes existing keeper fiber" true
+        (Atomic.get entry.Reg.fiber_wakeup))
+
 (* Test: operator-paused keeper ([auto_resume_after_sec = None]) is NOT
    auto-resumed by the sweep — only the human can clear it. *)
 let test_operator_pause_not_auto_resumed () =
@@ -1989,6 +2052,8 @@ let () =
         test_oas_auto_resume_after_sec_doubles_on_repause;
       test_case "sweep auto-resumes keeper when timer elapsed" `Quick
         test_sweep_auto_resumes_after_backoff;
+      test_case "sweep auto-resumes registered paused keeper in registry" `Quick
+        test_sweep_auto_resumes_registered_paused_entry;
       test_case "operator pause (None) is NOT auto-resumed by sweep" `Quick
         test_operator_pause_not_auto_resumed;
       test_case "turn timeout blocker without resume policy is NOT auto-resumed"


### PR DESCRIPTION
## Summary

- Wake the keeper runtime registry when supervisor auto-resume clears durable paused metadata.
- Reset keeper livelock state on auto-resume so a previously blocked keeper can re-enter scheduling cleanly.
- Add regression coverage for a registered paused keeper whose auto-resume window has elapsed.

## Root cause

Supervisor auto-resume updated durable keeper metadata to `paused=false`, but did not dispatch `Operator_resume` to the keeper registry or wake the existing registry entry. That left runtime phase stuck in `Paused`, so subsequent cycles kept skipping with `non-executable phase=paused` even though durable metadata looked resumed.

## Validation

- `git diff --check`
- `ocamlformat --check lib/keeper/keeper_supervisor.ml test/test_keeper_supervisor.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_supervisor.exe`
- `./_build/default/test/test_keeper_supervisor.exe test self_healing_circuit_breaker 3 --show-errors`

Note: plain `scripts/dune-local.sh build test/test_keeper_supervisor.exe` refused to start because other sessions have live bare Dune jobs. I did not kill those processes; I reran through the wrapper's explicit `MASC_DUNE_ALLOW_BARE_DUNE=1` path.