### PR TITLE
fix(ci): register cascade tier wait flag

### DIFF
--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -105,6 +105,11 @@ let all_flags : flag list = [
     default = true; category = "keeper";
     lifecycle = Active; since = "2.243.0" };
 
+  { env_name = "MASC_CASCADE_TIER_WAIT_ENABLED";
+    description = "Wait with bounded backoff when per-tier cascade admission is saturated";
+    default = false; category = "keeper";
+    lifecycle = Active; since = "0.19.30" };
+
   { env_name = "MASC_KEEPER_ALERT_ENABLED";
     description = "Master switch for keeper interesting alert detection";
     default = true; category = "keeper";


### PR DESCRIPTION
## Summary
- register MASC_CASCADE_TIER_WAIT_ENABLED in Feature_flag_registry
- keep default false to match Env_config_keeper.CascadeTierWait docs

## Verification
- scripts/check-feature-flag-consistency.sh
- git diff --check

## Not run
- scripts/dune-local.sh build @test/runtest-test_feature_flag_registry (blocked by existing bare Dune processes on host)