### PR TITLE
[codex] fix dashboard runtime truth sweep

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -108,6 +108,21 @@ describe('post', () => {
     expect(actorHeader).not.toContain('%')
   })
 
+  it('bypasses browser HTTP cache for dashboard API reads', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"keepers":[]}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await get('/api/v1/operator')
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(init.cache).toBe('no-store')
+  })
+
   it('keeps board voter resolution scoped to query params', () => {
     window.localStorage?.setItem?.('masc_dashboard_agent_name', 'stored-agent')
     window.history.replaceState({}, '', '/')

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -251,6 +251,7 @@ export async function fetchWithTimeout(path: string, init: RequestInit, timeoutM
   try {
     return await fetch(path, {
       ...init,
+      cache: init.cache ?? 'no-store',
       signal: controller.signal,
     })
   } catch (err) {

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -10,6 +10,7 @@ import { EmptyState, ErrorState } from './common/feedback-state'
 import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
 import { resolveUnifiedStatus } from '../lib/unified-status'
+import { keeperDisplayStatus } from '../lib/keeper-runtime-display'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
 import { keeperIdentityHint } from './common/keeper-identity'
@@ -192,7 +193,8 @@ export function AgentDetailOverlay() {
   const isFilteringTasks = taskQuery.value.trim() !== ''
   const displayName = missionBrief?.display_name ?? keeper?.name ?? agentName
   const secondaryLabel = displayName !== agentName ? agentName : null
-  const unified = resolveUnifiedStatus(keeper?.status, agent?.status, missionBrief?.signal_truth)
+  const keeperStatus = keeper ? keeperDisplayStatus(keeper, agent?.status) : null
+  const unified = resolveUnifiedStatus(keeperStatus, agent?.status, missionBrief?.signal_truth)
   const isArchivedParticipant = !agent && missionBrief?.is_live === false
   const lastSeenAt =
     agent?.last_seen

--- a/dashboard/src/components/board/composer-v2.test.ts
+++ b/dashboard/src/components/board/composer-v2.test.ts
@@ -32,7 +32,13 @@ vi.mock('../common/toast', () => ({
   showToast: showToastMock,
 }))
 
-function snapshotWithKeepers(keepers: Array<{ name: string; status: string }>): OperatorSnapshot {
+function snapshotWithKeepers(keepers: Array<{
+  name: string
+  status?: string
+  phase?: string | null
+  pipeline_stage?: string | null
+  paused?: boolean | null
+}>): OperatorSnapshot {
   return {
     root: { paused: false, namespace: 'default' },
     sessions: [],
@@ -128,6 +134,21 @@ describe('ComposerV2', () => {
       })
     })
     expect(sendBroadcastMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps phase-paused keepers selectable for DMs even when status is offline', () => {
+    operatorSnapshot.value = snapshotWithKeepers([
+      { name: 'paused-one', status: 'offline', phase: 'paused', pipeline_stage: 'paused' },
+      { name: 'offline-one', status: 'offline', phase: 'offline' },
+    ])
+
+    render(h(ComposerV2, { roomId: 'ops' }))
+    fireEvent.click(screen.getByRole('button', { name: 'DM mode' }))
+
+    const select = screen.getByLabelText('Composer v2 keeper target') as HTMLSelectElement
+    const options = Array.from(select.options).map(option => option.textContent)
+    expect(options).toContain('paused-one')
+    expect(options).not.toContain('offline-one')
   })
 
   it('requires a parsed state block before state sends', async () => {

--- a/dashboard/src/components/board/composer-v2.ts
+++ b/dashboard/src/components/board/composer-v2.ts
@@ -16,7 +16,7 @@ import {
   stateBlockKeys,
   STATE_BLOCK_TEMPLATE,
 } from '../ops/ops-state'
-import { isKeeperOffline } from '../../lib/keeper-predicates'
+import { isKeeperOperatorTargetable } from '../../lib/keeper-predicates'
 import {
   keeperNameFromTarget,
   mentionQueryFromMessage,
@@ -114,13 +114,10 @@ export function ComposerV2({ roomId }: { roomId?: string | null }) {
   const room = normalizeRoomId(roomId)
   const snapshot = operatorSnapshot.value
   const busy = submitting || operatorActionBusy.value
-  // RFC-0135 audit B5 (2026-05-19): the previous local
-  // normalizeStatus-against-the-offline-literal filter matched only
-  // the literal offline token and silently let inactive / unbooted
-  // keepers through as "online". The SSOT isKeeperOffline catches
-  // all three off-tokens.
+  // Paused keepers stay targetable so operators can DM/probe/resume them,
+  // even when another lifecycle axis still carries an offline-ish token.
   const onlineKeepers = (snapshot?.keepers ?? [])
-    .filter(keeper => !isKeeperOffline(keeper))
+    .filter(isKeeperOperatorTargetable)
     .map(keeper => ({ name: keeper.name, status: keeper.status }))
   const onlineKeeperNames = onlineKeepers.map(keeper => keeper.name).join('\0')
   const selectedKeeper = keeperNameFromTarget(keeperTarget)
@@ -235,7 +232,7 @@ export function ComposerV2({ roomId }: { roomId?: string | null }) {
           #${room}
         </span>
         <span class="ml-auto text-2xs tabular-nums text-[var(--color-fg-muted)]" aria-live="polite">
-          ${draft.length} chars · ${onlineKeepers.length} keepers
+          ${draft.length} chars · ${onlineKeepers.length} keeper targets
         </span>
       </div>
 
@@ -275,7 +272,7 @@ export function ComposerV2({ roomId }: { roomId?: string | null }) {
                               <span class="ml-auto text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${candidate.status ?? 'online'}</span>
                             </button>
                           `)
-                        : html`<div class="px-2 py-2 text-xs text-[var(--color-fg-muted)]">No online keeper matches @${mentionQuery}</div>`}
+                        : html`<div class="px-2 py-2 text-xs text-[var(--color-fg-muted)]">No keeper target matches @${mentionQuery}</div>`}
                     </div>
                   `
                 : effectiveKeeperOnline

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -32,6 +32,7 @@ import { invalidateDashboardCache, refreshDashboard, keepers } from '../store'
 import type { Keeper } from '../types'
 import {
   isKeeperOffline,
+  isKeeperOperatorTargetable,
   isKeeperPaused,
   isKeeperRunningExcludingRestarting,
   keeperIsStuckOnRecoverableBlocker,
@@ -221,7 +222,7 @@ export function KeeperActionPanel() {
   // panel?" filter through the typed predicates instead of an inline OR
   // chain — paused keepers should still appear (so operator can resume)
   // even when their status appears offline.
-  const online = keeperList.filter(k => !isKeeperOffline(k) || isKeeperPaused(k))
+  const online = keeperList.filter(isKeeperOperatorTargetable)
 
   if (keeperList.length === 0) {
     return null

--- a/dashboard/src/components/ops/keeper-utilities.ts
+++ b/dashboard/src/components/ops/keeper-utilities.ts
@@ -6,7 +6,7 @@ import { Select } from '../common/select'
 import { operatorActionBusy, operatorSnapshot } from '../../operator-store'
 import type { OperatorActionDescriptor } from '../../types'
 import { actionTypeLabel, executeAction } from './helpers'
-import { isKeeperOffline } from '../../lib/keeper-predicates'
+import { isKeeperOperatorTargetable } from '../../lib/keeper-predicates'
 
 const ADAPTED_KEEPER_ACTIONS = new Set([
   'keeper_probe',
@@ -56,11 +56,10 @@ export function KeeperUtilitiesPanel() {
   const actions = (snapshot?.available_actions ?? []).filter(visibleKeeperAction)
   if (actions.length === 0) return null
 
-  // RFC-0135 audit B5 (2026-05-19): SSOT-routed presence filter (see
-  // composer-v2.ts for the same migration). The previous status-only
-  // literal-offline check undercounted inactive / unbooted keepers.
+  // Keep paused keepers action-targetable even if another axis still
+  // carries an offline-ish status.
   const onlineKeepers = (snapshot?.keepers ?? [])
-    .filter(keeper => !isKeeperOffline(keeper))
+    .filter(isKeeperOperatorTargetable)
   const selectedName = onlineKeepers.some(keeper => keeper.name === selectedKeeper.value)
     ? selectedKeeper.value
     : (onlineKeepers[0]?.name ?? '')
@@ -91,7 +90,7 @@ export function KeeperUtilitiesPanel() {
           value=${selectedName}
           disabled=${busy || onlineKeepers.length === 0}
           options=${onlineKeepers.length === 0
-            ? [{ value: '', label: 'No online keepers' }]
+            ? [{ value: '', label: 'No keeper targets' }]
             : onlineKeepers.map(keeper => ({ value: keeper.name, label: keeper.name }))}
           onInput=${(v: string) => { selectedKeeper.value = v }}
         />

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -24,7 +24,7 @@ import {
   type QuickComposerMode,
 } from './ops-state'
 import { executeAction } from './helpers'
-import { isKeeperOffline } from '../../lib/keeper-predicates'
+import { isKeeperOperatorTargetable } from '../../lib/keeper-predicates'
 import {
   type OnlineKeeper,
   keeperNameFromTarget,
@@ -118,9 +118,9 @@ export function QuickIntervene() {
   const busy = operatorActionBusy.value
   const currentRoute = route.value
 
-  // RFC-0135 audit B5 (2026-05-19): SSOT-routed presence filter — see
-  // composer-v2.ts/keeper-utilities.ts for the parallel migrations.
-  const onlineKeepers = keepers.filter(k => !isKeeperOffline(k))
+  // Keep paused keepers targetable for operator DMs even if their agent
+  // status is currently offline-ish.
+  const onlineKeepers = keepers.filter(isKeeperOperatorTargetable)
   const onlineKeeperNames = onlineKeepers.map(keeper => keeper.name).join('\0')
   const mode = quickComposerMode.value
   const stateKeys = mode === 'state' ? stateBlockKeys(quickMessage.value) : []
@@ -202,7 +202,7 @@ export function QuickIntervene() {
           })}
         </div>
         <div class="text-2xs text-[var(--color-fg-muted)]" aria-live="polite">
-          ${quickMessage.value.length} chars / ${onlineKeepers.length} keepers online
+          ${quickMessage.value.length} chars / ${onlineKeepers.length} keeper targets
         </div>
       </div>
 
@@ -244,7 +244,7 @@ export function QuickIntervene() {
                               <span class="ml-auto text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${candidate.status ?? 'online'}</span>
                             </button>
                           `)
-                        : html`<div class="px-2 py-2 text-xs text-[var(--color-fg-muted)]">No online keeper matches @${mentionQuery}</div>`}
+                        : html`<div class="px-2 py-2 text-xs text-[var(--color-fg-muted)]">No keeper target matches @${mentionQuery}</div>`}
                     </div>
                   `
                   : effectiveKeeperOnline

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -262,6 +262,21 @@ describe('pickActiveKeepers', () => {
     expect(picked[0]?.name).toBe('active-older')
   })
 
+  it('deprioritizes phase-paused keepers even when the paused flag is absent', () => {
+    const keepers: Keeper[] = [
+      makeKeeper({
+        name: 'phase-paused-recent',
+        status: 'offline',
+        phase: 'Paused',
+        pipeline_stage: 'paused',
+        last_heartbeat: '2026-04-18T09:59:00+09:00',
+      }),
+      makeKeeper({ name: 'active-older', status: 'busy', last_heartbeat: '2026-04-18T08:00:00+09:00' }),
+    ]
+    const picked = pickActiveKeepers(keepers, 2)
+    expect(picked[0]?.name).toBe('active-older')
+  })
+
   it('respects max parameter', () => {
     const keepers: Keeper[] = Array.from({ length: 5 }, (_, i) =>
       makeKeeper({ name: `k${i}`, last_heartbeat: `2026-04-18T0${i}:00:00+09:00` }),
@@ -337,6 +352,28 @@ describe('deriveFleetTickerEvents', () => {
     expect(events).toHaveLength(2)
     expect(events.map(event => event.id)).toEqual(['task:done', 'task:verify'])
     expect(events.map(event => event.tone)).toEqual(['ok', 'warn'])
+  })
+
+  it('uses keeper pause truth for heartbeat ticker text and tone', () => {
+    const events = deriveFleetTickerEvents({
+      taskList: [],
+      messageList: [],
+      boardPostList: [],
+      keeperList: [
+        makeKeeper({
+          name: 'sangsu',
+          status: 'offline',
+          phase: 'Paused',
+          pipeline_stage: 'paused',
+          last_heartbeat: localIsoAt(4),
+          agent: { exists: true, status: 'busy' },
+        }),
+      ],
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]?.text).toBe('Paused')
+    expect(events[0]?.tone).toBe('warn')
   })
 })
 

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -29,6 +29,8 @@ import type {
 import { openAgentDetail } from '../agent-detail-state'
 import { openTaskDetail } from '../goals/task-detail-state'
 import { nowSecondsSignal, useNowSecondsTicker } from '../../lib/now-signal'
+import { keeperDisplayStatus } from '../../lib/keeper-runtime-display'
+import { isKeeperPaused } from '../../lib/keeper-predicates'
 
 // ─── Alert Panel ─────────────────────────────────────────────────────────────
 
@@ -149,6 +151,8 @@ function keeperTickerTone(status?: string | null): FleetTickerEvent['tone'] {
       return 'info'
     case 'offline':
     case 'dead':
+    case 'stopped':
+    case 'unbooted':
       return 'err'
     case 'paused':
     case 'inactive':
@@ -218,14 +222,15 @@ export function deriveFleetTickerEvents({
   }
   for (const keeper of keeperList) {
     if (!keeper.last_heartbeat) continue
+    const displayStatus = keeperDisplayStatus(keeper)
     pushTickerEvent(events, {
       id: `keeper:${keeper.name}`,
       timestamp: keeper.last_heartbeat,
       actor: keeper.koreanName && keeper.koreanName !== '' ? keeper.koreanName : keeper.name,
       label: 'heartbeat',
-      text: keeperStatusLabel(keeper.status),
+      text: keeperStatusLabel(displayStatus),
       kind: 'keeper',
-      tone: keeperTickerTone(keeper.status),
+      tone: keeperTickerTone(displayStatus),
     })
   }
   return events
@@ -491,6 +496,8 @@ function keeperPillClass(status?: string | null): string {
       return 'pill is-running'
     case 'offline':
     case 'dead':
+    case 'stopped':
+    case 'unbooted':
       return 'pill is-err'
     default:
       return 'pill is-paused'
@@ -501,8 +508,11 @@ function keeperStatusLabel(status?: string | null): string {
   switch ((status ?? '').toLowerCase()) {
     case 'active': case 'live': return 'Active'
     case 'busy': case 'executing': return 'Busy'
+    case 'paused': return 'Paused'
     case 'offline': return 'Offline'
     case 'dead': return 'Dead'
+    case 'stopped': return 'Stopped'
+    case 'unbooted': return 'Unbooted'
     default: return status ?? 'Unknown'
   }
 }
@@ -512,8 +522,8 @@ export function pickActiveKeepers(keeperList: readonly Keeper[], max = 3): Keepe
     .sort((a, b) => {
       const tsA = parseIsoMs(a.last_heartbeat) ?? 0
       const tsB = parseIsoMs(b.last_heartbeat) ?? 0
-      const pausedA = a.paused === true ? -1e15 : 0
-      const pausedB = b.paused === true ? -1e15 : 0
+      const pausedA = isKeeperPaused(a) ? -1e15 : 0
+      const pausedB = isKeeperPaused(b) ? -1e15 : 0
       return tsB + pausedB - (tsA + pausedA)
     })
     .slice(0, max)
@@ -542,7 +552,9 @@ function KeeperStrip({ keeperList }: { keeperList: readonly Keeper[] }) {
         )}
         <ul class="flex flex-wrap gap-x-6 gap-y-2 border-t border-[var(--color-border-default)] pt-4">
           ${activeKeepers.slice(1).map(
-            k => html`
+            k => {
+              const displayStatus = keeperDisplayStatus(k)
+              return html`
               <li key=${k.name} class="flex items-center gap-2">
                 <div class="min-w-0">
                   <p class="text-xs font-medium truncate">${k.koreanName && k.koreanName !== '' ? k.koreanName : k.name}</p>
@@ -550,9 +562,10 @@ function KeeperStrip({ keeperList }: { keeperList: readonly Keeper[] }) {
                     ? html`<${TimeAgo} timestamp=${k.last_heartbeat} class="text-3xs text-[var(--color-fg-muted)]" />`
                     : null}
                 </div>
-                <span class="${keeperPillClass(k.status)} text-3xs shrink-0">${keeperStatusLabel(k.status)}</span>
+                <span class="${keeperPillClass(displayStatus)} text-3xs shrink-0">${keeperStatusLabel(displayStatus)}</span>
               </li>
-            `,
+              `
+            },
           )}
         </ul>
       </div>

--- a/dashboard/src/lib/keeper-predicates.test.ts
+++ b/dashboard/src/lib/keeper-predicates.test.ts
@@ -5,6 +5,7 @@ import {
   isCrashedPhase,
   isKeeperPaused,
   isKeeperOffline,
+  isKeeperOperatorTargetable,
   isKeeperRunningExcludingRestarting,
   keeperIsStuckOnRecoverableBlocker,
   keeperCanWakeup,
@@ -24,6 +25,9 @@ describe('isKeeperPaused — RFC-0135 PR-3 SSOT', () => {
   })
   it('returns true on FSM phase Paused', () => {
     expect(isKeeperPaused(k({ phase: 'Paused' }))).toBe(true)
+  })
+  it('returns true on lowercase phase paused from operator snapshots', () => {
+    expect(isKeeperPaused({ phase: 'paused' })).toBe(true)
   })
   it('returns true on pipeline_stage paused', () => {
     expect(isKeeperPaused(k({ pipeline_stage: 'paused' }))).toBe(true)
@@ -45,6 +49,9 @@ describe('isKeeperOffline', () => {
   ])('phase=%s ⇒ offline', (phase) => {
     expect(isKeeperOffline(k({ phase }))).toBe(true)
   })
+  it.each(['offline', 'stopped', 'dead', 'crashed', 'zombie'])('lowercase phase=%s ⇒ offline', (phase) => {
+    expect(isKeeperOffline({ phase })).toBe(true)
+  })
   it.each([['offline'], ['inactive'], ['unbooted'], ['stopped']])('status=%s ⇒ offline', (status) => {
     expect(isKeeperOffline(k({ status }))).toBe(true)
   })
@@ -57,6 +64,20 @@ describe('isKeeperOffline', () => {
     // now absorbs it so a wire-format-only snapshot (phase missing)
     // still routes to the offline branch.
     expect(isKeeperOffline({ status: 'stopped' })).toBe(true)
+  })
+})
+
+describe('isKeeperOperatorTargetable', () => {
+  it('keeps phase-paused keepers targetable even when status is offline', () => {
+    expect(isKeeperOperatorTargetable({
+      status: 'offline',
+      phase: 'paused',
+      pipeline_stage: 'paused',
+    })).toBe(true)
+  })
+
+  it('excludes truly offline keepers', () => {
+    expect(isKeeperOperatorTargetable({ status: 'offline', phase: 'offline' })).toBe(false)
   })
 })
 

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -22,15 +22,31 @@ import type { Keeper } from '../types/core'
 
 const PAUSED_PHASE = 'Paused'
 const PAUSED_LOWER_TOKEN = 'paused'
+const PAUSED_PHASE_LOWER = PAUSED_PHASE.toLowerCase()
+
+function lowerToken(value: string | null | undefined): string {
+  return (value ?? '').toLowerCase()
+}
+
+/** Structural subset accepted by pause predicates.
+ *  Operator snapshots may carry lowercase lifecycle tokens while the
+ *  hydrated Keeper type uses PascalCase phases, so these predicates
+ *  normalize token casing before comparing. */
+export interface KeeperPausedInput {
+  paused?: boolean | null
+  phase?: Keeper['phase'] | string | null
+  pipeline_stage?: Keeper['pipeline_stage'] | string | null
+  status?: string | null
+}
 
 /** Operator considers the keeper paused on any of: explicit `paused`
  *  flag, FSM phase `Paused`, pipeline stage `paused`, or lowercased
  *  status `paused`. */
-export function isKeeperPaused(keeper: Keeper): boolean {
+export function isKeeperPaused(keeper: KeeperPausedInput): boolean {
   if (keeper.paused === true) return true
-  if (keeper.phase === PAUSED_PHASE) return true
-  if (keeper.pipeline_stage === PAUSED_LOWER_TOKEN) return true
-  if ((keeper.status ?? '').toLowerCase() === PAUSED_LOWER_TOKEN) return true
+  if (lowerToken(keeper.phase) === PAUSED_PHASE_LOWER) return true
+  if (lowerToken(keeper.pipeline_stage) === PAUSED_LOWER_TOKEN) return true
+  if (lowerToken(keeper.status) === PAUSED_LOWER_TOKEN) return true
   return false
 }
 
@@ -81,25 +97,25 @@ export function isCrashedPhase(phase: string | null | undefined): boolean {
  *  one of the three off-tokens (`offline | inactive | unbooted`).
  *  Routing them through this predicate closes the undercount. */
 export interface KeeperOfflineInput {
-  phase?: Keeper['phase']
-  status?: string
+  phase?: Keeper['phase'] | string | null
+  status?: string | null
 }
 
 /** Operator considers the keeper offline / down on any of: terminal
  *  FSM phases (Offline/Stopped/Dead/Crashed/Zombie) or one of the
  *  off-tokens emitted in `keeper.status`. */
 export function isKeeperOffline(keeper: KeeperOfflineInput): boolean {
-  switch (keeper.phase) {
-    case 'Offline':
-    case 'Stopped':
-    case 'Dead':
-    case 'Crashed':
-    case 'Zombie':
-      return true
-    default:
-      break
+  const phase = lowerToken(keeper.phase)
+  if (
+    phase === 'offline'
+    || phase === 'stopped'
+    || phase === 'dead'
+    || phase === 'crashed'
+    || phase === 'zombie'
+  ) {
+    return true
   }
-  const status = (keeper.status ?? '').toLowerCase()
+  const status = lowerToken(keeper.status)
   // RFC-0139 PR-2: the `'stopped'` status token is emitted from
   // `Keeper_state_machine.phase_to_string`
   // (lib/keeper/keeper_lifecycle_events.ml:74) when only the
@@ -137,6 +153,13 @@ export function keeperIsStuckOnRecoverableBlocker(keeper: Keeper): boolean {
 export function keeperCanWakeup(keeper: Keeper): boolean {
   if (keeperIsStuckOnRecoverableBlocker(keeper)) return true
   return !isKeeperPaused(keeper) && !isKeeperOffline(keeper)
+}
+
+/** Operator-facing target lists must keep paused keepers selectable so
+ *  the operator can message/probe/resume them even if another axis still
+ *  reports an offline-ish status. */
+export function isKeeperOperatorTargetable(keeper: KeeperPausedInput & KeeperOfflineInput): boolean {
+  return isKeeperPaused(keeper) || !isKeeperOffline(keeper)
 }
 
 // RFC-0135 PR-11 — running predicate excluding `Restarting`.

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -23,6 +23,11 @@ describe('keeperDisplayStatus', () => {
     expect(keeperDisplayStatus(makeKeeper({ paused: true }))).toBe('paused')
   })
 
+  it('returns paused when phase or pipeline carries pause truth', () => {
+    expect(keeperDisplayStatus(makeKeeper({ status: 'offline', phase: 'Paused' }))).toBe('paused')
+    expect(keeperDisplayStatus(makeKeeper({ status: 'offline', pipeline_stage: 'paused' }))).toBe('paused')
+  })
+
   it('returns unknown for null keeper', () => {
     expect(keeperDisplayStatus(null)).toBe('unknown')
   })

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -1,5 +1,6 @@
 import type { Keeper, KeeperRuntimeBlockerClass } from '../types'
 import { relativeTime } from './format-time'
+import { isKeeperPaused } from './keeper-predicates'
 
 /** Max seconds since last heartbeat to consider the keeper process alive. */
 const HEARTBEAT_ALIVE_THRESHOLD_S = 120
@@ -122,7 +123,7 @@ export function keeperActivityDisplay(
 }
 
 export function keeperDisplayStatus(keeper: Keeper | null | undefined, fallbackStatus?: string | null): string {
-  if (keeper?.paused) return 'paused'
+  if (keeper && isKeeperPaused(keeper)) return 'paused'
   const status = keeper?.status ?? fallbackStatus
   const normalized = (status ?? '').trim().toLowerCase()
 

--- a/dashboard/src/lib/unified-status.test.ts
+++ b/dashboard/src/lib/unified-status.test.ts
@@ -18,6 +18,13 @@ describe('resolveUnifiedStatus', () => {
     expect(r.canonical).toBe('offline')
   })
 
+  it('resolves paused before live agent fallback', () => {
+    const r = resolveUnifiedStatus('paused', 'busy', 'live')
+    expect(r.canonical).toBe('paused')
+    expect(r.label).toBe('일시정지')
+    expect(r.description).toContain('미션 신호는 최근 수신됨')
+  })
+
   it('resolves running status', () => {
     const r = resolveUnifiedStatus('running', null, null)
     expect(r.canonical).toBe('running')

--- a/dashboard/src/lib/unified-status.ts
+++ b/dashboard/src/lib/unified-status.ts
@@ -36,6 +36,16 @@ export function resolveUnifiedStatus(
     }
   }
 
+  if (primary === 'paused') {
+    return {
+      canonical: 'paused',
+      label: statusLabel(primary),
+      description: signal === 'live'
+        ? '일시정지됨 (미션 신호는 최근 수신됨)'
+        : '일시정지됨',
+    }
+  }
+
   // Active states
   if (primary === 'active' || primary === 'running' || primary === 'busy' || primary === 'working') {
     const desc = signal === 'stale'

--- a/dashboard/src/mission-normalizers.test.ts
+++ b/dashboard/src/mission-normalizers.test.ts
@@ -113,12 +113,22 @@ describe('normalizeMission', () => {
     const result = normalizeMission({
       operator_targets: {
         keepers: [
-          { name: 'janitor', status: 'Running', generation: 5 },
+          {
+            name: 'janitor',
+            status: 'Running',
+            phase: 'paused',
+            pipeline_stage: 'paused',
+            paused: true,
+            generation: 5,
+          },
         ],
       },
     })
     expect(result.operator_targets.keepers).toHaveLength(1)
     expect(result.operator_targets.keepers[0]!.name).toBe('janitor')
+    expect(result.operator_targets.keepers[0]!.phase).toBe('paused')
+    expect(result.operator_targets.keepers[0]!.pipeline_stage).toBe('paused')
+    expect(result.operator_targets.keepers[0]!.paused).toBe(true)
   })
 
   it('extracts pending_confirms from operator_targets', () => {

--- a/dashboard/src/mission-normalizers.ts
+++ b/dashboard/src/mission-normalizers.ts
@@ -148,6 +148,9 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
   if (!name) return null
   return {
     name,
+    phase: asString(raw.phase) ?? null,
+    pipeline_stage: asString(raw.pipeline_stage) ?? null,
+    paused: asBoolean(raw.paused) ?? null,
     agent_name: asString(raw.agent_name),
     status: asString(raw.status),
     context_ratio: asNumber(raw.context_ratio),

--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -231,12 +231,23 @@ describe('normalizeOperatorSnapshot', () => {
   it('extracts keepers with valid name', () => {
     const result = normalizeOperatorSnapshot({
       keepers: [
-        { name: 'janitor', status: 'Running', generation: 10, active_model: 'agent-llm-a-sonnet' },
+        {
+          name: 'janitor',
+          status: 'Running',
+          phase: 'paused',
+          pipeline_stage: 'paused',
+          paused: true,
+          generation: 10,
+          active_model: 'agent-llm-a-sonnet',
+        },
         { name: 'dreamer', status: 'Idle' },
       ],
     })
     expect(result.keepers).toHaveLength(2)
     expect(result.keepers[0]!.name).toBe('janitor')
+    expect(result.keepers[0]!.phase).toBe('paused')
+    expect(result.keepers[0]!.pipeline_stage).toBe('paused')
+    expect(result.keepers[0]!.paused).toBe(true)
     expect(result.keepers[0]!.generation).toBe(10)
     expect(result.keepers[0]!.model).toBe('runtime')
   })

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -230,6 +230,9 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
   return {
     name,
     runtime_class: 'keeper' as const,
+    phase: asString(raw.phase) ?? null,
+    pipeline_stage: asString(raw.pipeline_stage) ?? null,
+    paused: asBoolean(raw.paused) ?? null,
     registered: asBoolean(raw.registered),
     agent_name: asString(raw.agent_name),
     status: asString(raw.status),

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -350,6 +350,9 @@ export interface OperatorSessionSnapshot {
 export interface OperatorKeeperSnapshot {
   name: string
   runtime_class?: 'keeper'
+  phase?: string | null
+  pipeline_stage?: string | null
+  paused?: boolean | null
   registered?: boolean
   agent_name?: string
   status?: string


### PR DESCRIPTION
## Summary
- Preserve keeper pause axes through operator and mission snapshot normalization.
- Route keeper status rendering, overview ticker ordering, agent detail badges, and operator target lists through shared runtime-truth predicates.
- Bypass browser HTTP cache for dashboard API reads so stale operator snapshots cannot overwrite fresher runtime truth.

## Root Cause
Paused keepers could arrive with conflicting axes such as `status=offline` plus `phase/pipeline_stage=paused`, and several UI paths used only the raw `status` field or dropped pause axes during normalization. In browser smoke, `/api/v1/operator` was also reused from browser cache, allowing an older inactive/offline operator snapshot to clobber the fresh paused state.

## Validation
- `pnpm --dir dashboard exec vitest run src/api/core.test.ts src/lib/keeper-predicates.test.ts src/lib/keeper-runtime-display.test.ts src/lib/unified-status.test.ts src/operator-normalizers.test.ts src/mission-normalizers.test.ts src/components/board/composer-v2.test.ts src/components/overview/overview.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `git diff --check`
- Browser smoke against local dev server proxied to `http://127.0.0.1:8935`: paused keepers appeared in the Ops DM target list, while truly offline `masc-improver` stayed excluded.