### PR TITLE
[codex] Remove ghost keeper PR create runtime paths

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -232,8 +232,8 @@ describe('keeper runtime trace', () => {
             matched_tool_call_count: 2,
             successful_tool_call_count: 2,
             failed_tool_call_count: 0,
-            tools: ['keeper_bash', 'keeper_pr_create'],
-            successful_tools: ['keeper_bash', 'keeper_pr_create'],
+            tools: ['keeper_bash', 'keeper_shell'],
+            successful_tools: ['keeper_bash', 'keeper_shell'],
             failed_tools: [],
             sandbox_profiles: ['docker'],
             network_modes: ['inherit'],
@@ -329,7 +329,7 @@ describe('keeper runtime trace', () => {
     expect(result.runtime_lens.axes.runtime_proof.status).toBe('pass')
     expect(result.runtime_lens.axes.runtime_proof.docker_visible).toBe(true)
     expect(result.runtime_lens.axes.runtime_proof.github_identity_materialized).toBe(true)
-    expect(result.runtime_lens.axes.runtime_proof.tools).toEqual(['keeper_bash', 'keeper_pr_create'])
+    expect(result.runtime_lens.axes.runtime_proof.tools).toEqual(['keeper_bash', 'keeper_shell'])
     expect(result.runtime_lens.swimlanes.provider.terminal_status).toBe('timeout')
     expect(result.runtime_lens.swimlanes.memory_context.terminal_status).toBe('unknown')
     expect(result.runtime_lens.clock_edges[0]?.edge_id).toBe('edge-provider-start')

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -536,8 +536,8 @@ describe('RuntimeLensSection', () => {
             matched_tool_call_count: 2,
             successful_tool_call_count: 2,
             failed_tool_call_count: 0,
-            tools: ['keeper_bash', 'keeper_pr_create'],
-            successful_tools: ['keeper_bash', 'keeper_pr_create'],
+            tools: ['keeper_bash', 'keeper_shell'],
+            successful_tools: ['keeper_bash', 'keeper_shell'],
             failed_tools: [],
             sandbox_profiles: ['docker'],
             network_modes: ['inherit'],
@@ -781,7 +781,7 @@ describe('RuntimeLensSection', () => {
     expect(screen.getByText('GitHub proof')).toBeInTheDocument()
     expect(screen.getByText('git creds / identity materialized')).toBeInTheDocument()
     expect(screen.getByText('proof tools')).toBeInTheDocument()
-    expect(screen.getByText('keeper_bash, keeper_pr_create')).toBeInTheDocument()
+    expect(screen.getByText('keeper_bash, keeper_shell')).toBeInTheDocument()
     expect(screen.getByText('network proof')).toBeInTheDocument()
     expect(screen.getByText('inherit')).toBeInTheDocument()
     expect(screen.getByText('working loops')).toBeInTheDocument()

--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -91,7 +91,6 @@ let risk_overrides : (string * risk_level) list =
     ("masc_keeper_msg", Low);
     ("masc_claim_next", Medium);
     ("masc_worktree_create", Medium); (* routine sandbox setup; removal stays Critical *)
-    ("keeper_pr_create", Medium); (* routine PR creation; force/merge/push stay gated *)
     ("keeper_task_create", Medium); (* routine keeper backlog expansion; force/delete stays gated *)
   ]
 

--- a/lib/keeper/keeper_hooks_oas_pr_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_pr_metrics.ml
@@ -139,7 +139,7 @@ let pr_work_actions_of_command command =
          | actions -> actions)
 
 let is_pr_work_action_tool_name tool_name =
-  List.mem tool_name [ "masc_code_git"; "keeper_bash"; "masc_code_shell"; "keeper_pr_create" ]
+  List.mem tool_name [ "masc_code_git"; "keeper_bash"; "masc_code_shell" ]
 
 let pr_work_action_metric_events_of_tool_io
     ~route_via_fallback
@@ -161,20 +161,7 @@ let pr_work_action_metric_events_of_tool_io
       route_via_fallback
   in
   let success = output_success ~transport_success output_json in
-  if String.equal tool_name "keeper_pr_create"
-  then
-    [
-      {
-        work_action = "PR_CREATE";
-        work_source = "keeper_pr_create";
-        work_ref = Safe_ops.json_string_opt "head" input;
-        pr_url = Option.bind output_json pr_url_of_json;
-        command = None;
-        success;
-        route_via;
-      };
-    ]
-  else if String.equal tool_name "masc_code_git"
+  if String.equal tool_name "masc_code_git"
   then
     let action =
       match output_json with

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml
@@ -181,9 +181,8 @@ let runtime_lens_accumulate_tool_proof acc json =
   runtime_lens_collect_profile acc json;
   let output_opt = parse_tool_output_json_opt json in
   let text = runtime_lens_tool_text json in
-  if String.equal tool "keeper_pr_create"
-     || (String.equal tool "keeper_shell"
-         && String_util.contains_substring text "gh pr create")
+  if String.equal tool "keeper_shell"
+     && String_util.contains_substring text "gh pr create"
   then acc.pr_create_observed <- true;
   if runtime_lens_call_has_docker_proof json output_opt text
   then acc.docker_visible <- true;

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1691,6 +1691,13 @@ let test_keeper_github_pr_tool_contracts () =
        "Credential_materializer.verify_state");
   check bool "keeper PR create is absent from github group" true
     (file_not_contains_pattern "config/tool_policy.toml" {|keeper_pr_create|});
+  check bool "keeper PR create is absent from active runtime special-cases" true
+    (file_not_contains_pattern "lib/keeper/keeper_hooks_oas_pr_metrics.ml"
+       {|keeper_pr_create|}
+     && file_not_contains_pattern "lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml"
+          {|keeper_pr_create|}
+     && file_not_contains_pattern "lib/governance_pipeline_risk.ml"
+          {|keeper_pr_create|});
   check bool "keeper core prompt routes PR review through native tool" true
     (file_contains_pattern "config/prompts/keeper.core_behavior.md"
        "PR REVIEW MUTATIONS"

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -237,11 +237,6 @@ let test_risk_medium_worktree_create () =
   Alcotest.(check string) "worktree_create is medium"
     "medium" (Gp.risk_level_to_string risk)
 
-let test_risk_medium_keeper_pr_create () =
-  let risk = Gp.assess_risk ~tool_name:"keeper_pr_create" ~input:no_args in
-  Alcotest.(check string) "keeper_pr_create is medium"
-    "medium" (Gp.risk_level_to_string risk)
-
 let test_risk_medium_keeper_task_create () =
   let risk = Gp.assess_risk ~tool_name:"keeper_task_create" ~input:no_args in
   Alcotest.(check string) "keeper_task_create is medium"
@@ -958,8 +953,6 @@ let () =
         test_risk_medium_transition_start;
       Alcotest.test_case "medium: worktree create" `Quick
         test_risk_medium_worktree_create;
-      Alcotest.test_case "medium: keeper PR create" `Quick
-        test_risk_medium_keeper_pr_create;
       Alcotest.test_case "medium: keeper task create" `Quick
         test_risk_medium_keeper_task_create;
       Alcotest.test_case "payload: rm -rf is critical" `Quick

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -1462,26 +1462,22 @@ let test_pr_work_action_metric_extracts_embedded_output_json () =
   let before = hook_output_parse_failures "pr_work_action" in
   let events =
     pr_work_events
-      ~tool_name:"keeper_pr_create"
-      ~input:(`Assoc [ "title", `String "proof"; "head", `String "proof/embedded-json" ])
+      ~tool_name:"masc_code_git"
+      ~input:(`Assoc [ "action", `String "push" ])
       ~output_text:
         "Created draft PR successfully:\n\
-         {\"ok\":true,\"tool\":\"keeper_pr_create\",\"operation\":\"pr_create\",\"via\":\"brokered\",\"result\":{\"output\":\"https://github.com/acme/repo/pull/43\\n\"}}\n\
+         {\"ok\":true,\"tool\":\"masc_code_git\",\"action\":\"push\",\"via\":\"brokered\"}\n\
          Done."
       ()
   in
-  check (list string) "pr create action" [ "PR_CREATE" ] (work_actions events);
+  check (list string) "git push action" [ "GIT_PUSH" ] (work_actions events);
   (match events with
    | [ event ] ->
-     check string "source" "keeper_pr_create" event.work_source;
-     check (option string) "head ref" (Some "proof/embedded-json") event.work_ref;
-     check
-       (option string)
-       "pr url"
-       (Some "https://github.com/acme/repo/pull/43")
-       event.pr_url;
+     check string "source" "masc_code_git" event.work_source;
+     check (option string) "head ref" None event.work_ref;
+     check (option string) "pr url" None event.pr_url;
      check (option string) "route via" (Some "brokered") event.route_via
-   | _ -> failf "expected one keeper_pr_create event");
+   | _ -> failf "expected one masc_code_git event");
   check
     (float 0.001)
     "parse failure not counted"
@@ -1511,46 +1507,6 @@ let test_pr_work_action_metric_extracts_quoted_output_gh_pr_create () =
       ()
   in
   check (list string) "legacy keeper_shell gh output ignored" [] (work_actions events)
-;;
-
-let test_pr_work_action_metric_extracts_keeper_pr_create () =
-  let events =
-    pr_work_events
-      ~tool_name:"keeper_pr_create"
-      ~input:(`Assoc [ "title", `String "proof"; "head", `String "proof/keeper-docker" ])
-      ~output_text:
-        {|{"ok":true,"tool":"keeper_pr_create","operation":"pr_create","via":"brokered","result":{"output":"https://github.com/acme/repo/pull/42\n"}}|}
-      ()
-  in
-  check (list string) "pr create action" [ "PR_CREATE" ] (work_actions events);
-  match events with
-  | [ event ] ->
-    check string "source" "keeper_pr_create" event.work_source;
-    check (option string) "head ref" (Some "proof/keeper-docker") event.work_ref;
-    check
-      (option string)
-      "pr url"
-      (Some "https://github.com/acme/repo/pull/42")
-      event.pr_url;
-    check (option string) "route via" (Some "brokered") event.route_via
-  | _ -> failf "expected one keeper_pr_create event"
-;;
-
-let test_pr_work_action_metric_uses_native_pr_create_route_fallback () =
-  let events =
-    pr_work_events
-      ~route_via_fallback:"brokered"
-      ~tool_name:"keeper_pr_create"
-      ~input:(`Assoc [ "title", `String "proof"; "head", `String "proof/keeper-docker" ])
-      ~output_text:{|{"ok":true,"tool":"keeper_pr_create","operation":"pr_create"}|}
-      ()
-  in
-  check (list string) "pr create action" [ "PR_CREATE" ] (work_actions events);
-  match events with
-  | [ event ] ->
-    check (option string) "head ref" (Some "proof/keeper-docker") event.work_ref;
-    check (option string) "route fallback" (Some "brokered") event.route_via
-  | _ -> failf "expected one keeper_pr_create event"
 ;;
 
 let test_pr_work_action_metric_extracts_bash_git_push_with_redirection () =
@@ -1860,14 +1816,6 @@ let () =
             "ignores legacy keeper_shell gh output pr create"
             `Quick
             test_pr_work_action_metric_extracts_quoted_output_gh_pr_create
-        ; test_case
-            "extracts keeper_pr_create"
-            `Quick
-            test_pr_work_action_metric_extracts_keeper_pr_create
-        ; test_case
-            "uses native pr create route fallback"
-            `Quick
-            test_pr_work_action_metric_uses_native_pr_create_route_fallback
         ; test_case
             "extracts bash git push with redirection"
             `Quick

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1347,10 +1347,10 @@ let test_runtime_trace_lens_surfaces_docker_github_sandbox_proof () =
         ();
       Masc_mcp.Keeper_tool_call_log.log_call
         ~keeper_name
-        ~tool_name:"keeper_pr_create"
-        ~input:(`Assoc [ ("draft", `Bool true) ])
+        ~tool_name:"keeper_shell"
+        ~input:(`Assoc [ ("cmd", `String "gh pr create --draft --title t") ])
         ~output_text:
-          {|{"ok":true,"sandbox_profile":"docker","via":"docker","credential":{"credential_scope":"keeper_identity","git_identity_mode":"github_identity","credential_state":{"state":"materialized"}},"url":"https://github.com/jeong-sik/masc-mcp/pull/1"}|}
+          {|{"ok":true,"sandbox_profile":"docker","via":"docker","command":"gh pr create --draft --title t","credential":{"credential_scope":"keeper_identity","git_identity_mode":"github_identity","credential_state":{"state":"materialized"}},"url":"https://github.com/jeong-sik/masc-mcp/pull/1"}|}
         ~success:true
         ~duration_ms:1.0
         ~trace_id
@@ -1405,7 +1405,7 @@ let test_runtime_trace_lens_surfaces_docker_github_sandbox_proof () =
         (json_string_list_member "network_modes" proof);
       Alcotest.(check (list string))
         "proof tools"
-        [ "keeper_bash"; "keeper_pr_create" ]
+        [ "keeper_bash"; "keeper_shell" ]
         (json_string_list_member "tools" proof))
 
 let test_runtime_trace_lens_terminal_uses_latest_turn_without_turn_filter () =


### PR DESCRIPTION
## Summary

Remove the retired `keeper_pr_create` tool name from active runtime paths so it cannot be treated as a live keeper tool again.

## Changes

- Drop `keeper_pr_create` from PR work-action metric extraction.
- Stop runtime lens PR-create proof from accepting `keeper_pr_create`; PR creation proof now stays on the shell `gh pr create` path.
- Remove the governance risk override for `keeper_pr_create`.
- Update OCaml and dashboard fixtures to use `keeper_shell` where PR-create proof is still needed.
- Add a source guard so `keeper_pr_create` cannot reappear in active runtime special-cases.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build ./test/test_keeper_hooks_oas_telemetry.exe ./test/test_governance_pipeline.exe ./test/test_keeper_runtime_manifest.exe ./test/test_ci_hardening_source.exe` with `MASC_SKIP_PIN_CHECK=1` due local `agent_sdk` pin drift
- `_build/default/test/test_keeper_hooks_oas_telemetry.exe` passed
- `_build/default/test/test_governance_pipeline.exe` passed
- `_build/default/test/test_keeper_tool_resolution.exe` passed
- `_build/default/test/test_config_coverage.exe` passed
- `_build/default/test/test_goal_tools.exe` passed

## Notes

- `test_ci_hardening_source` still has unrelated pre-existing source guard failures, but the `keeper github PR tool contracts` case passed.
- `test_keeper_runtime_manifest` still has unrelated `Cascade_name.of_string_exn: invalid prefix: "default"` failures, but the runtime lens Docker/GitHub proof case touched by this PR passed.
- Dashboard Vitest was not run in this worktree because `dashboard/node_modules` is absent (`vitest` not found).