### PR TITLE
[codex] Mark keeper PR metrics tool-name boundary

### DIFF
--- a/lib/keeper/keeper_hooks_oas_pr_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_pr_metrics.ml
@@ -138,6 +138,7 @@ let pr_work_actions_of_command command =
          | [] -> pr_work_actions_of_git_segment segment
          | actions -> actions)
 
+(* STR-OK: tool_name is the external MCP tool-name boundary for telemetry. *)
 let is_pr_work_action_tool_name tool_name =
   List.mem tool_name [ "masc_code_git"; "keeper_bash"; "masc_code_shell" ]
 


### PR DESCRIPTION
## Summary
- Add a narrow STR-OK marker for the keeper PR metrics tool-name classifier.
- Documents that this string list is an external MCP tool-name telemetry boundary.

## Why
PR #18289 removed the ghost `keeper_pr_create` runtime path, but the changed tool-name list tripped the Meta Guards STR ratchet. This follow-up keeps the ratchet explicit without reintroducing the removed ghost tool.

## Validation
- `git diff --check`
- `scripts/ci/check-enum-string-safety.sh`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build ./test/test_keeper_hooks_oas_telemetry.exe`