### PR TITLE
[codex] Fix paused keeper stale busy display

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -202,13 +202,17 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
     expect(note).toEqual({ label: '참고', text: '관찰 메모' })
   })
 
-  it('paused keeper produces no state note (signaled by badge elsewhere)', () => {
+  it('paused keeper surfaces its blocker reason in the state note', () => {
     const note = rosterStateNote(
       k({ paused: true, runtime_blocker_class: 'supervisor_paused' }),
       null,
       null,
     )
-    expect(note).toBeNull()
+    expect(note).toEqual({
+      label: '일시정지 원인',
+      text: 'Supervisor가 keeper를 일시정지한 상태라 재개 조건을 확인해야 합니다.',
+      kind: 'supervisor_paused',
+    })
   })
 
   it('offline keeper produces no state note', () => {
@@ -565,6 +569,57 @@ describe('AgentRoster live-only cards', () => {
     expect(text).toContain('파생')
     expect(text).toContain('현재 차단: Fiber 미해결')
     expect(text).toContain('Keeper fiber가 종료 상태를 확정하지 못해 supervisor 확인이 필요합니다.')
+  })
+
+  it('lets paused runtime truth override stale busy agent presence', async () => {
+    agents.value = [
+      makeAgent({
+        name: 'keeper-executor-agent',
+        status: 'busy',
+        current_task: 'task-463',
+        last_seen: '2026-05-24T14:01:04Z',
+      }),
+    ]
+    keepers.value = [
+      {
+        name: 'executor',
+        agent_name: 'keeper-executor-agent',
+        status: 'paused',
+        phase: 'Paused',
+        pipeline_stage: 'paused',
+        paused: true,
+        registered: false,
+        keepalive_running: false,
+        runtime_blocker_class: 'no_tool_capable_provider',
+        runtime_blocker_summary: 'no_tool_capable_provider',
+        agent: {
+          exists: true,
+          status: 'busy',
+          current_task: 'task-463',
+          last_seen: '2026-05-24T14:01:04Z',
+        },
+      } as Keeper,
+    ]
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    const row = container.querySelector('[data-testid="keeper-operations-row"]') as HTMLElement
+    const presence = row.querySelector('[data-agent-presence]') as HTMLElement
+    expect(presence.dataset.presenceRawStatus).toBe('paused')
+    expect(presence.dataset.presenceState).toBe('paused')
+    expect(presence.dataset.presenceLabel).toBe('일시정지')
+    expect(presence.textContent).toContain('오래된 작업 신호 task-463')
+
+    const labels = Array.from(container.querySelectorAll('[data-agent-presence]'))
+      .map(el => (el as HTMLElement).dataset.presenceLabel)
+    expect(labels).not.toContain('작업 중')
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('일시정지 원인: 도구 실행 Provider 없음')
+    expect(text).toContain('요구 도구를 실행할 수 있는 provider가 없어 라우팅 또는 tool surface 확인이 필요합니다.')
   })
 
   it('uses heartbeat and full keeper model for cards when action/model fallbacks disagree', async () => {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -67,6 +67,7 @@ import { fleetCompositeSnapshot } from '../composite-signals'
 type StatusFilter = 'all' | RuntimeBand
 
 type RosterStateNote = { label: string; text: string; kind?: string }
+type RosterPresenceDisplay = { status: string | null; detail: string | null }
 
 function stageBadgeClass(stageKey: string): string {
   if (stageKey === 'tool_use') return 'border-[var(--info-border)] bg-[var(--accent-12)] text-[var(--color-accent-fg)]'
@@ -123,6 +124,23 @@ export function rosterStateNote(
 
   const state = deriveKeeperOperationalState({ keeper, composite })
 
+  if (state.kind === 'paused') {
+    const blockerClass = keeper.runtime_blocker_class ?? undefined
+    const runtimeHint = keeperRuntimeBlockerHint(keeper)
+    if (runtimeHint) {
+      return { label: '일시정지 원인', text: runtimeHint, kind: blockerClass }
+    }
+
+    const summary = keeper.runtime_blocker_summary?.trim()
+    if (summary) {
+      return { label: '일시정지 원인', text: summary, kind: blockerClass }
+    }
+
+    const hint = monitoringHint?.trim()
+    if (hint) return { label: '일시정지', text: hint, kind: blockerClass }
+    return null
+  }
+
   if (state.kind === 'stuck') {
     const summary = keeper.runtime_blocker_summary?.trim()
     if (summary) {
@@ -160,6 +178,29 @@ export function rosterStateNote(
 function noteLooksLikeRawKind(note: RosterStateNote): boolean {
   if (!note.kind) return false
   return note.text === note.kind || note.text === `차단 종류: ${note.kind} (요약 메시지 없음)`
+}
+
+function rosterPresenceDisplay(
+  agent: Agent,
+  keeper: Keeper | null,
+  composite: KeeperCompositeSnapshot | null,
+): RosterPresenceDisplay {
+  if (!keeper) return { status: agent.status ?? null, detail: null }
+
+  const state = deriveKeeperOperationalState({ keeper, composite })
+  if (state.kind === 'paused') {
+    const staleTask = agent.current_task?.trim()
+    return {
+      status: 'paused',
+      detail: staleTask ? `오래된 작업 신호 ${staleTask}` : null,
+    }
+  }
+
+  if (state.kind === 'offline' && agent.current_task) {
+    return { status: 'offline', detail: `중단된 작업 ${agent.current_task}` }
+  }
+
+  return { status: agent.status ?? keeper.status ?? null, detail: null }
 }
 
 export function rosterBlockerDisplay(
@@ -787,6 +828,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             band.key === 'active' ? null : keeperMonitoring?.hint ?? null,
           )
         : null
+    const presenceDisplay = rosterPresenceDisplay(agent, keeperRuntime, compositeForKeeper)
     const recentTools = uniqueToolNames(
       keeperRuntime?.recent_tool_names,
       keeperRuntime?.latest_tool_names,
@@ -827,6 +869,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       currentWork,
       summaryText,
       stateNote,
+      presenceDisplay,
       recentTools,
       toolCallCount,
       toolAuditAt,
@@ -948,7 +991,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     <span class="shrink-0">
                       <${AgentAvatar}
                         name=${row.agent.name}
-                        status=${row.agent.status}
+                        status=${row.presenceDisplay.status}
                         traits=${row.agent.traits}
                         size="md"
                         currentWork=${row.currentWork}
@@ -958,7 +1001,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     <span class="min-w-0">
                       <span class="block truncate text-sm font-semibold text-[var(--color-fg-secondary)]">${row.displayName}</span>
                       <span class="mt-0.5 flex flex-wrap items-center gap-1.5 text-3xs text-[var(--color-fg-muted)]">
-                        <${AgentPresence} status=${row.agent.status} size="sm" />
+                        <${AgentPresence} status=${row.presenceDisplay.status} detail=${row.presenceDisplay.detail} size="sm" />
                         ${row.agent.synthetic ? html`<span class="rounded-[var(--r-0)] border border-dashed border-[var(--color-border-default)] px-1.5 py-0.5 italic">파생</span>` : null}
                       </span>
                     </span>
@@ -1009,7 +1052,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   <span class="text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">selected runtime</span>
                   <h3 class="m-0 mt-1 truncate text-xl font-semibold text-[var(--color-fg-secondary)]">${selectedRow.displayName}</h3>
                 </div>
-                <${AgentPresence} status=${selectedRow.agent.status} size="sm" />
+                <${AgentPresence} status=${selectedRow.presenceDisplay.status} detail=${selectedRow.presenceDisplay.detail} size="sm" />
               </div>
 
               <p class="m-0 text-sm leading-paragraph text-[var(--color-fg-primary)]" title=${selectedRow.summaryText}>${selectedRow.summaryText}</p>

--- a/dashboard/src/components/common/agent-presence.test.ts
+++ b/dashboard/src/components/common/agent-presence.test.ts
@@ -25,6 +25,10 @@ describe('agentStatusToPresence', () => {
     expect(agentStatusToPresence('idle')).toBe('idle')
   })
 
+  it('maps paused to paused', () => {
+    expect(agentStatusToPresence('paused')).toBe('paused')
+  })
+
   it('maps inactive to offline', () => {
     expect(agentStatusToPresence('inactive')).toBe('offline')
   })
@@ -50,6 +54,8 @@ describe('presenceConfig', () => {
     expect(presenceConfig('working').colorClass).toContain('var(--color-accent-fg)')
     expect(presenceConfig('idle').label).toBe('대기')
     expect(presenceConfig('idle').colorClass).toContain('var(--color-status-warn)')
+    expect(presenceConfig('paused').label).toBe('일시정지')
+    expect(presenceConfig('paused').pulse).toBe(false)
     expect(presenceConfig('offline').label).toBe('오프라인')
   })
 })
@@ -76,6 +82,18 @@ describe('summarizeAgentPresence', () => {
       size: 'sm',
       detail: '',
       detailPresent: false,
+    })
+  })
+
+  it('summarizes paused as a non-pulsing presence state', () => {
+    expect(summarizeAgentPresence('paused', '오래된 작업 신호 task-463', 'sm')).toEqual({
+      rawStatus: 'paused',
+      state: 'paused',
+      label: '일시정지',
+      pulse: false,
+      size: 'sm',
+      detail: '오래된 작업 신호 task-463',
+      detailPresent: true,
     })
   })
 })
@@ -115,6 +133,17 @@ describe('AgentPresence', () => {
     const container = document.createElement('div')
     render(h(AgentPresence, { status: 'busy' }), container)
     expect(container.textContent).toContain('작업 중')
+  })
+
+  it('renders paused label and data attributes', () => {
+    const container = document.createElement('div')
+    render(h(AgentPresence, { status: 'paused' }), container)
+    const el = container.querySelector('[data-agent-presence]') as HTMLElement
+    expect(el.dataset.presenceRawStatus).toBe('paused')
+    expect(el.dataset.presenceState).toBe('paused')
+    expect(el.dataset.presenceLabel).toBe('일시정지')
+    expect(el.hasAttribute('data-presence-pulse')).toBe(false)
+    expect(container.textContent).toContain('일시정지')
   })
 
   it('renders detail when provided', () => {

--- a/dashboard/src/components/common/agent-presence.ts
+++ b/dashboard/src/components/common/agent-presence.ts
@@ -4,14 +4,14 @@
 // indicator. The dot + pulse animation communicates "this agent is a
 // digital colleague" rather than an abstract process.
 //
-// Maps the internal Agent.status domain (6 values) to 4 visual presence
-// states (online / working / idle / offline). The mapping is intentionally
+// Maps the internal Agent.status domain to compact visual presence states.
+// The mapping is intentionally
 // lossy — visual density in a roster card cannot carry 6 states without
 // crowding.
 
 import { html } from 'htm/preact'
 
-export type PresenceVisualState = 'online' | 'working' | 'idle' | 'offline'
+export type PresenceVisualState = 'online' | 'working' | 'idle' | 'paused' | 'offline'
 export type AgentPresenceSize = 'sm' | 'md'
 
 export interface PresenceConfig {
@@ -46,6 +46,11 @@ const PRESENCE_CONFIG: Record<PresenceVisualState, PresenceConfig> = {
     pulse: false,
     label: '대기',
   },
+  paused: {
+    colorClass: 'bg-[var(--purple)]',
+    pulse: false,
+    label: '일시정지',
+  },
   offline: {
     colorClass: 'bg-[var(--color-bg-hover)]',
     pulse: false,
@@ -54,7 +59,7 @@ const PRESENCE_CONFIG: Record<PresenceVisualState, PresenceConfig> = {
 }
 
 /** Pure: map the backend Agent.status to a visual presence state.
-    The mapping collapses 6 backend states into 4 visual buckets so
+    The mapping collapses backend states into compact visual buckets so
     the roster grid stays scannable. */
 export function agentStatusToPresence(
   status: string | null | undefined,
@@ -67,6 +72,8 @@ export function agentStatusToPresence(
       return 'working'
     case 'idle':
       return 'idle'
+    case 'paused':
+      return 'paused'
     case 'inactive':
     case 'offline':
     default:

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -135,6 +135,7 @@ function normalizeKeeperAgentStatus(value: unknown): Keeper['status'] {
     || raw === 'idle'
     || raw === 'inactive'
     || raw === 'offline'
+    || raw === 'paused'
     || raw === 'unbooted'
     || raw === 'stopped'
   ) {

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -353,11 +353,14 @@ let keepers_json
                           ~diagnostic
                     in
                     let aligned_status =
-                      align_keeper_runtime_status
-                        ~surface_status
-                        ~diagnostic
-                        ~agent_status_json:agent_json
-                        ~keepalive_running
+                      if meta.paused
+                      then "paused"
+                      else
+                        align_keeper_runtime_status
+                          ~surface_status
+                          ~diagnostic
+                          ~agent_status_json:agent_json
+                          ~keepalive_running
                     in
                     let t_phase = Time_compat.now () in
                     let registry_phase =
@@ -365,14 +368,23 @@ let keepers_json
                     in
                     dt_phase := Time_compat.now () -. t_phase;
                     let pipeline_stage =
-                      match registry_phase with
-                      | Some phase -> Keeper_exec_status.pipeline_stage_of_phase phase
-                      | None -> "offline"
+                      if meta.paused
+                      then "paused"
+                      else
+                        match registry_phase with
+                        | Some phase -> Keeper_exec_status.pipeline_stage_of_phase phase
+                        | None -> "offline"
                     in
                     let phase_str =
-                      match registry_phase with
-                      | Some p -> `String (Keeper_state_machine.phase_to_string p)
-                      | None -> `Null
+                      if meta.paused
+                      then (
+                        match registry_phase with
+                        | Some p -> `String (Keeper_state_machine.phase_to_string p)
+                        | None -> `String "paused")
+                      else
+                        match registry_phase with
+                        | Some p -> `String (Keeper_state_machine.phase_to_string p)
+                        | None -> `Null
                     in
                     let context_snapshot =
                       if lightweight
@@ -409,6 +421,8 @@ let keepers_json
                          ; "mid_goal", `String meta.mid_goal
                          ; "long_goal", `String meta.long_goal
                          ; "status", `String aligned_status
+                         ; "paused", `Bool meta.paused
+                         ; "pause_state", `String (if meta.paused then "paused" else "active")
                          ; "agent", agent_json
                          ; "generation", `Int meta.runtime.generation
                          ; "turn_count", `Int meta.runtime.usage.total_turns

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -357,49 +357,34 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
       let config = Coord.default_config base_dir in
       (* See: this fixture only needs an initialized room for digest reads. *)
       ignore (Coord.init config ~agent_name:(Some "operator"));
-      let keeper_ctx : _ Tool_keeper.context =
-        {
-          config;
-          agent_name = "operator";
-          sw;
-          clock = Eio.Stdenv.clock env;
-          proc_mgr = Some (Eio.Stdenv.process_mgr env);
-          net = None;
-        }
-      in
-      let ok, _ =
-        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
-          ~args:
+      let meta =
+        match
+          Masc_test_deps.meta_of_json_fixture
             (`Assoc
               [
                 ("name", `String keeper_name);
+                ("agent_name", `String (Keeper_types.keeper_agent_name keeper_name));
+                ("trace_id", `String "trace-paused-runtime-trust");
                 ("goal", `String "Expose paused keeper failure in summary");
-                ("proactive_enabled", `Bool false);
-                ("autoboot_enabled", `Bool false);
+                ("short_goal", `String "Expose paused keeper failure in summary");
+                ("cascade_name", `String "tier-group.primary");
               ])
-      in
-      Alcotest.(check bool) "keeper up ok" true ok;
-      Keeper_keepalive.stop_keepalive keeper_name;
-      let meta =
-        match Keeper_types.read_meta config keeper_name with
-        | Ok (Some meta) -> meta
-        | Ok None -> Alcotest.fail "expected keeper meta"
-        | Error err -> Alcotest.fail err
-      in
-      let meta =
-        {
-          meta with
-          paused = true;
-          runtime =
-            {
-              meta.runtime with
-              last_blocker =
-                Some
-                  (Keeper_types.blocker_info_of_class
-                     ~detail:"Completion contract [require_tool_use] violated: actionable keeper signal was present, but the model called no keeper tools"
-                     Keeper_types.Completion_contract_violation);
-            };
-        }
+        with
+        | Ok meta ->
+          {
+            meta with
+            paused = true;
+            runtime =
+              {
+                meta.runtime with
+                last_blocker =
+                  Some
+                    (Keeper_types.blocker_info_of_class
+                       ~detail:"Completion contract [require_tool_use] violated: actionable keeper signal was present, but the model called no keeper tools"
+                       Keeper_types.Completion_contract_violation);
+              };
+          }
+        | Error err -> Alcotest.fail ("keeper meta fixture failed: " ^ err)
       in
       (match Keeper_types.write_meta config meta with
       | Ok () -> ()
@@ -475,7 +460,28 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
       Alcotest.(check string) "terminal code preserved"
         "completion_contract_violation:require_tool_use"
         (trust |> member "latest_terminal_reason" |> member "code"
-       |> to_string))
+       |> to_string);
+      Operator_control.invalidate_snapshot_cache ();
+      let full_snapshot =
+        Operator_control.snapshot_json ~view:"summary" ~include_messages:false
+          ~include_keepers:true ~include_summary_fields:false
+          ~lightweight_summary:false
+          (operator_ctx env sw config "operator")
+      in
+      let full_keeper =
+        full_snapshot |> member "keepers" |> member "items" |> to_list
+        |> List.find_opt (fun row -> row |> member "name" |> to_string = keeper_name)
+        |> Option.value ~default:`Null
+      in
+      Alcotest.(check bool) "full keeper present" true (full_keeper <> `Null);
+      Alcotest.(check string) "full paused status" "paused"
+        (full_keeper |> member "status" |> to_string);
+      Alcotest.(check bool) "full paused flag" true
+        (full_keeper |> member "paused" |> to_bool);
+      Alcotest.(check string) "full pause state" "paused"
+        (full_keeper |> member "pause_state" |> to_string);
+      Alcotest.(check string) "full paused pipeline" "paused"
+        (full_keeper |> member "pipeline_stage" |> to_string))
 
 let test_digest_room_includes_keeper_runtime_attention () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## What changed

- Preserve paused keeper truth in the full operator snapshot by forcing `status`, `pipeline_stage`, `paused`, and `pause_state` from durable keeper meta before stale agent presence can promote the row back to busy.
- Add a paused presence state to the dashboard roster and make keeper operational state override stale agent `busy/current_task` signals.
- Surface paused blocker reasons in the roster so cases like missing tool-capable provider are visible instead of appearing as generic work-in-progress.
- Add frontend and operator snapshot regression coverage for the stale busy/paused projection case.

## Why

The dashboard could show a keeper as `작업 중` while the runtime verdict was `일시정지` because the agent status file still had `busy/current_task`. The runtime fiber and keeper meta were already paused, but the roster presence dot trusted stale agent presence too late in the projection pipeline.

## Validation

- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/common/agent-presence.test.ts src/components/agent-roster.test.ts`
- `pnpm --dir dashboard exec eslint src/components/common/agent-presence.ts src/components/common/agent-presence.test.ts src/components/agent-roster.ts src/components/agent-roster.test.ts src/keeper-store-normalize.ts` (0 errors; repo config ignores two targeted files with warnings)
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 MASC_SKIP_PIN_CHECK=1 MASC_INCLUDE_OPERATOR_CONTROL=true scripts/dune-local.sh build test/test_operator_control.exe`
- `_build/default/test/test_operator_control.exe test --color=never operator 8`

Note: the local opam `agent_sdk` pin was drifted, so the focused Dune build used `MASC_SKIP_PIN_CHECK=1` to validate this target without mutating the shared switch.