### PR TITLE
[codex] Classify no-tool cascade routing failures

### DIFF
--- a/lib/cascade/cascade_error_classify.mli
+++ b/lib/cascade/cascade_error_classify.mli
@@ -28,9 +28,10 @@ val admission_wait_timeout_error :
 
 val classify_masc_internal_error :
   Agent_sdk.Error.sdk_error -> masc_internal_error option
-(** Parse an SDK error back into a [masc_internal_error] when it was
-    originally produced by {!sdk_error_of_masc_internal_error}.  Returns
-    [None] for errors that do not carry the [masc_oas_error] prefix. *)
+(** Parse an SDK error back into a [masc_internal_error] when it carries the
+    [[masc_oas_error]] prefix, including wrapped [Internal] messages where the
+    prefix is embedded inside a larger diagnostic.  Returns [None] when the
+    prefix is absent or the JSON payload is malformed. *)
 
 val classify_masc_internal_error_of_string :
   string -> masc_internal_error option

--- a/lib/cascade/cascade_error_from_sdk.ml
+++ b/lib/cascade/cascade_error_from_sdk.ml
@@ -10,7 +10,7 @@
     - {!classify_masc_internal_error_of_string} — raw string entry point
       that locates the [[masc_oas_error]] prefix anywhere in the text;
     - {!classify_masc_internal_error} — SDK error entry point for
-      [Agent_sdk.Error.Internal] values that carry the prefix.
+      [Agent_sdk.Error.Internal] values that carry or wrap the prefix.
 
     RFC-0142 Phase 2 PR-2 extracted these three functions from
     {!Cascade_error_classify}; the facade in that module continues to
@@ -285,10 +285,5 @@ let classify_masc_internal_error_of_string (raw : string) :
 let classify_masc_internal_error (err : Agent_sdk.Error.sdk_error) :
     masc_internal_error option =
   match err with
-  | Agent_sdk.Error.Internal msg when String.starts_with ~prefix:masc_internal_error_prefix msg ->
-    (try parse_masc_internal_error_json (Yojson.Safe.from_string
-         (String.sub msg
-            (String.length masc_internal_error_prefix)
-            (String.length msg - String.length masc_internal_error_prefix)))
-     with Yojson.Json_error _ -> None)
+  | Agent_sdk.Error.Internal msg -> classify_masc_internal_error_of_string msg
   | _ -> None

--- a/lib/cascade/cascade_error_from_sdk.mli
+++ b/lib/cascade/cascade_error_from_sdk.mli
@@ -19,7 +19,7 @@ val classify_masc_internal_error_of_string :
 
 val classify_masc_internal_error :
   Agent_sdk.Error.sdk_error -> Cascade_internal_error.masc_internal_error option
-(** Parse an SDK error back into a [masc_internal_error] when it was
-    originally produced by
-    {!Cascade_internal_error.sdk_error_of_masc_internal_error}.  Returns
-    [None] for errors that do not carry the [[masc_oas_error]] prefix. *)
+(** Parse an SDK error back into a [masc_internal_error] when it carries the
+    [[masc_oas_error]] prefix, including wrapped [Internal] messages where the
+    prefix is embedded inside a larger diagnostic.  Returns [None] when the
+    prefix is absent or the JSON payload is malformed. *)

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -10,6 +10,10 @@ type failure_reason =
       base : string;
       resolved : string option;
     }
+  | Failure_no_tool_capable_provider of {
+      cascade_name : string;
+      detail : string;
+    }
   | Failure_provider_error of { kind : string; detail : string }
   | Failure_tool_contract_violation of { reason_code : string }
   | Failure_receipt_lost of {
@@ -82,6 +86,7 @@ let cancel_reason_label = function
 
 let failure_reason_label = function
   | Failure_cascade_unavailable _ -> "cascade_unavailable"
+  | Failure_no_tool_capable_provider _ -> "no_tool_capable_provider"
   | Failure_provider_error _ -> "provider_error"
   | Failure_tool_contract_violation _ -> "tool_contract_violation"
   | Failure_receipt_lost _ -> "receipt_lost"
@@ -104,6 +109,9 @@ let pp_failure_reason fmt = function
       Format.fprintf fmt "cascade_unavailable(base=%s,resolved=%s)"
         base
         (Option.value resolved ~default:"-")
+  | Failure_no_tool_capable_provider { cascade_name; detail } ->
+      Format.fprintf fmt "no_tool_capable_provider(cascade=%s,detail=%s)"
+        cascade_name detail
   | Failure_provider_error { kind; detail } ->
       Format.fprintf fmt "provider_error(kind=%s,detail=%s)" kind detail
   | Failure_tool_contract_violation { reason_code } ->
@@ -137,6 +145,7 @@ type transition_action =
   | ContractViolation
   | ReceiptLost
   | LivelockBlocked
+  | NoToolCapableProvider
   | ProviderError
   | GenericFail
   | SupervisorRequestsStop
@@ -158,6 +167,7 @@ let transition_action_label = function
   | ContractViolation -> "ContractViolation"
   | ReceiptLost -> "ReceiptLost"
   | LivelockBlocked -> "LivelockBlocked"
+  | NoToolCapableProvider -> "NoToolCapableProvider"
   | ProviderError -> "ProviderError"
   | GenericFail -> "GenericFail"
   | SupervisorRequestsStop -> "SupervisorRequestsStop"
@@ -231,6 +241,9 @@ let classify_transition ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_stat
   | Any Cascade_routing, Any (Failed (Failure_turn_livelock_blocked _))
     when not stop_signaled_before ->
       Some LivelockBlocked
+  | Any Cascade_routing, Any (Failed (Failure_no_tool_capable_provider _))
+    when not stop_signaled_before ->
+      Some NoToolCapableProvider
   | Any Cascade_routing, Any (Failed (Failure_provider_error _))
     when not stop_signaled_before ->
       Some ProviderError

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -25,6 +25,10 @@ type failure_reason =
       base : string;
       resolved : string option;
     }
+  | Failure_no_tool_capable_provider of {
+      cascade_name : string;
+      detail : string;
+    }
   | Failure_provider_error of { kind : string; detail : string }
   | Failure_tool_contract_violation of { reason_code : string }
   | Failure_receipt_lost of {
@@ -93,6 +97,7 @@ type transition_action =
   | ContractViolation
   | ReceiptLost
   | LivelockBlocked
+  | NoToolCapableProvider
   | ProviderError
   | GenericFail
   | SupervisorRequestsStop

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -238,13 +238,20 @@ let run_keeper_cycle
               ~keeper_turn_id
               ();
             let failure_reason =
-              if EC.is_cascade_exhausted_error err
-              then
+              match Keeper_turn_driver.classify_masc_internal_error err with
+              | Some
+                  (Keeper_turn_driver.No_tool_capable_provider
+                     { cascade_name; _ }) ->
+                Keeper_turn_fsm.Failure_no_tool_capable_provider
+                  { cascade_name = Cascade_name.to_string cascade_name
+                  ; detail = error_message
+                  }
+              | _ when EC.is_cascade_exhausted_error err ->
                 Keeper_turn_fsm.Failure_cascade_unavailable
                   { base = Cascade_name.to_string effective_cascade_runtime_name
                   ; resolved = None
                   }
-              else
+              | _ ->
                 Keeper_turn_fsm.Failure_provider_error
                   { kind = sdk_error_kind err; detail = error_message }
             in
@@ -1506,8 +1513,17 @@ let run_keeper_cycle
                          Keeper_turn_fsm.Failure_receipt_lost
                            { primary_error = e_str; fallback_path = None }
                        else
-                         Keeper_turn_fsm.Failure_provider_error
-                           { kind = sdk_error_kind err; detail = short_preview e_str }
+                         match Keeper_turn_driver.classify_masc_internal_error err with
+                         | Some
+                             (Keeper_turn_driver.No_tool_capable_provider
+                                { cascade_name; _ }) ->
+                           Keeper_turn_fsm.Failure_no_tool_capable_provider
+                             { cascade_name = Cascade_name.to_string cascade_name
+                             ; detail = short_preview e_str
+                             }
+                         | _ ->
+                           Keeper_turn_fsm.Failure_provider_error
+                             { kind = sdk_error_kind err; detail = short_preview e_str }
                      in
                      Keeper_turn_fsm.emit_transition
                        ~keeper_name:meta.name

--- a/test/test_cascade_error_classify_decoder.ml
+++ b/test/test_cascade_error_classify_decoder.ml
@@ -33,7 +33,7 @@ let test_roundtrip_other_detail () =
   let payload =
     `Assoc
       [ ("kind", `String "cascade_exhausted")
-      ; ("cascade_name", `String "primary")
+      ; ("cascade_name", `String "tier-group.primary")
       ; ( "reason"
         , `Assoc
             [ ("tag", `String "other_detail")
@@ -48,7 +48,7 @@ let test_roundtrip_other_detail () =
   | Some (Classify.Cascade_exhausted { cascade_name; reason }) ->
     Alcotest.(check string)
       "cascade name preserved"
-      "primary"
+      "tier-group.primary"
       (Classify.cascade_name_to_string cascade_name);
     (match reason with
      | Keeper_types.Other_detail msg ->
@@ -60,7 +60,7 @@ let test_roundtrip_structural_attempt_timeout () =
   let payload =
     `Assoc
       [ ("kind", `String "cascade_exhausted")
-      ; ("cascade_name", `String "primary")
+      ; ("cascade_name", `String "tier-group.primary")
       ; ( "reason"
         , `Assoc
             [ ("tag", `String "structural_attempt_timeout")
@@ -88,7 +88,7 @@ let test_roundtrip_bare_string_reason () =
   let payload =
     `Assoc
       [ ("kind", `String "cascade_exhausted")
-      ; ("cascade_name", `String "secondary")
+      ; ("cascade_name", `String "tier-group.secondary")
       ; ("reason", `String "no_providers_available")
       ]
   in
@@ -110,7 +110,7 @@ let test_roundtrip_capacity_backpressure () =
   let payload =
     `Assoc
       [ ("kind", `String "capacity_backpressure")
-      ; ("cascade_name", `String "primary")
+      ; ("cascade_name", `String "tier-group.primary")
       ; ("source", `String "client_capacity")
       ; ("detail", `String "client capacity key provider_k is full")
       ; ("retry_after_sec", `Float 2.5)
@@ -125,7 +125,7 @@ let test_roundtrip_capacity_backpressure () =
          { cascade_name; source; detail; retry_after_sec }) ->
     Alcotest.(check string)
       "cascade name preserved"
-      "primary"
+      "tier-group.primary"
       (Classify.cascade_name_to_string cascade_name);
     Alcotest.(check string)
       "source preserved"
@@ -141,6 +141,49 @@ let test_roundtrip_capacity_backpressure () =
       retry_after_sec
   | _ -> Alcotest.fail "expected Capacity_backpressure"
 
+let test_sdk_internal_nested_prefix_roundtrip () =
+  let payload =
+    `Assoc
+      [ ("kind", `String "no_tool_capable_provider")
+      ; ("cascade_name", `String "tier-group.tools")
+      ; ("configured_labels", `List [ `String "codex_cli" ])
+      ; ("required_tool_names", `List [ `String "masc_tool" ])
+      ; ( "provider_rejections"
+        , `List
+            [ `Assoc
+                [ ("provider_label", `String "codex_cli")
+                ; ("reason", `String "tool_lane_unsupported")
+                ]
+            ] )
+      ]
+  in
+  let err =
+    Agent_sdk.Error.Internal
+      ("all cascades exhausted (terminal) -- last_err=Internal error: "
+       ^ wrap_masc_oas_error payload)
+  in
+  match Classify.classify_masc_internal_error err with
+  | Some
+      (Classify.No_tool_capable_provider
+         { cascade_name; required_tool_names; provider_rejections; _ }) ->
+    Alcotest.(check string)
+      "cascade name preserved"
+      "tier-group.tools"
+      (Classify.cascade_name_to_string cascade_name);
+    Alcotest.(check (list string))
+      "required tools preserved"
+      [ "masc_tool" ]
+      required_tool_names;
+    Alcotest.(check int)
+      "provider rejection count"
+      1
+      (List.length provider_rejections)
+  | decoded ->
+    Alcotest.failf
+      "expected nested No_tool_capable_provider, got %a"
+      pp_internal_error
+      decoded
+
 (* --- schema-drift cases: must return None ---------------------------- *)
 
 let test_unknown_reason_tag_decodes_to_none () =
@@ -152,7 +195,7 @@ let test_unknown_reason_tag_decodes_to_none () =
   let payload =
     `Assoc
       [ ("kind", `String "cascade_exhausted")
-      ; ("cascade_name", `String "primary")
+      ; ("cascade_name", `String "tier-group.primary")
       ; ( "reason"
         , `Assoc
             [ ("tag", `String "future_reason_not_yet_known")
@@ -171,7 +214,7 @@ let test_missing_reason_field_decodes_to_none () =
   let payload =
     `Assoc
       [ ("kind", `String "cascade_exhausted")
-      ; ("cascade_name", `String "primary")
+      ; ("cascade_name", `String "tier-group.primary")
       ]
   in
   let decoded =
@@ -186,7 +229,7 @@ let test_malformed_reason_payload_decodes_to_none () =
   let payload =
     `Assoc
       [ ("kind", `String "cascade_exhausted")
-      ; ("cascade_name", `String "primary")
+      ; ("cascade_name", `String "tier-group.primary")
       ; ("reason", `Bool true)
       ]
   in
@@ -295,6 +338,10 @@ let () =
             "bare string reason" `Quick test_roundtrip_bare_string_reason
         ; Alcotest.test_case
             "capacity backpressure" `Quick test_roundtrip_capacity_backpressure
+        ; Alcotest.test_case
+            "nested Internal prefix"
+            `Quick
+            test_sdk_internal_nested_prefix_roundtrip
         ] )
     ; ( "schema-drift → None"
       , [ Alcotest.test_case

--- a/test/test_keeper_turn_fsm_emit.ml
+++ b/test/test_keeper_turn_fsm_emit.ml
@@ -52,6 +52,11 @@ let test_turn_state_labels_cover_every_variant () =
     ; F.Any F.Completing, "completing"
     ; F.Any F.Done, "done"
     ; F.Any (F.Failed (F.Failure_runtime_error "x")), "failed:runtime_error"
+    ; ( F.Any
+          (F.Failed
+             (F.Failure_no_tool_capable_provider
+                { cascade_name = "tools"; detail = "no candidate supports tools" }))
+      , "failed:no_tool_capable_provider" )
     ; F.Any (F.Cancelled F.Cancelled_phase_gate_close), "cancelled:phase_gate_close"
     ]
   in
@@ -94,6 +99,13 @@ let test_transition_actions_cover_tla_next () =
     ~from_state:F.Cascade_routing
     ~to_state:
       (F.Failed (F.Failure_turn_livelock_blocked { reason = "cycle_cap" }));
+  check_action
+    F.NoToolCapableProvider
+    ~from_state:F.Cascade_routing
+    ~to_state:
+      (F.Failed
+         (F.Failure_no_tool_capable_provider
+            { cascade_name = "tools"; detail = "no provider supports required tools" }));
   check_action
     F.ProviderError
     ~from_state:F.Cascade_routing
@@ -184,7 +196,9 @@ let test_invalid_emit_transition_fails_closed_and_bumps_counter () =
         ~prev:F.Idle
         F.Done;
       false
-    with Assert_failure _ -> true
+    with
+    | Invalid_argument _ -> true
+    | Assert_failure _ -> true
   in
   let after = read_fsm_guard_count ~stage in
   Alcotest.(check bool)
@@ -341,6 +355,9 @@ let test_failure_reason_labels_documented () =
   let pairs : (F.failure_reason * string) list =
     [ ( F.Failure_cascade_unavailable { base = "ollama:7b"; resolved = None }
       , "cascade_unavailable" )
+    ; ( F.Failure_no_tool_capable_provider
+          { cascade_name = "tools"; detail = "no candidate supports tools" }
+      , "no_tool_capable_provider" )
     ; F.Failure_provider_error { kind = "k"; detail = "d" }, "provider_error"
     ; F.Failure_tool_contract_violation { reason_code = "rc" }, "tool_contract_violation"
     ; F.Failure_receipt_lost { primary_error = "e"; fallback_path = None }, "receipt_lost"

--- a/test/test_keeper_typed_labels.ml
+++ b/test/test_keeper_typed_labels.ml
@@ -60,6 +60,7 @@ let test_cancel_reason_labels_unique () =
 let all_failure_reasons : Keeper_turn_fsm.failure_reason list =
   [
     Failure_cascade_unavailable { base = "x"; resolved = None };
+    Failure_no_tool_capable_provider { cascade_name = "x"; detail = "d" };
     Failure_provider_error { kind = "k"; detail = "d" };
     Failure_tool_contract_violation { reason_code = "rc" };
     Failure_receipt_lost { primary_error = "e"; fallback_path = None };


### PR DESCRIPTION
## Summary
- preserve structured `no_tool_capable_provider` as its own keeper turn FSM failure reason and `NoToolCapableProvider` transition action from `cascade_routing`
- parse nested `[masc_oas_error]` payloads inside wrapped `Agent_sdk.Error.Internal` diagnostics so pre-dispatch cascade failures keep their typed root cause
- add regression coverage for nested no-tool payloads, FSM labels/actions, and typed label uniqueness

## Why
Live keeper logs showed `cascade_routing -> failed:provider_error action=ProviderError` even when the root cause was a no-tool-capable cascade failure, usually with provider rejections such as `tool_lane_unsupported`. That collapsed a configuration/capability routing failure into a provider error and made the next operator action ambiguous.

## Validation
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build ./test/test_keeper_turn_fsm_emit.exe`
- `_build/default/test/test_keeper_turn_fsm_emit.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build ./test/test_cascade_error_classify_decoder.exe ./test/test_keeper_typed_labels.exe`
- `_build/default/test/test_cascade_error_classify_decoder.exe`
- `_build/default/test/test_keeper_typed_labels.exe`
- `git diff --check`