### PR TITLE
[codex] Fix declarative provider_d labels

### DIFF
--- a/lib/cascade/cascade_declarative_hotpath.ml
+++ b/lib/cascade/cascade_declarative_hotpath.ml
@@ -11,6 +11,7 @@
 
 open Cascade_declarative_adapter
 module Loader = Cascade_config_loader
+module Runtime_binding = Agent_sdk.Provider_runtime_binding
 
 (* --- Lightweight mirror types (no Cascade_catalog_runtime dependency) --- *)
 
@@ -41,11 +42,42 @@ type decl_snapshot = {
 
 (* --- Low-level helpers --- *)
 
+let provider_name_of_label (label : string) : string option =
+  match String.index_opt label ':' with
+  | None -> None
+  | Some idx ->
+    if idx = 0
+    then None
+    else Some (String.sub label 0 idx |> String.trim |> String.lowercase_ascii)
+
+let is_provider_d_compat_kind_label = function
+  | "provider_d" | "provider_d_compat" -> true
+  | _ -> false
+
 let provider_config_to_model_string (cfg : Llm_provider.Provider_config.t) :
     string =
-  Printf.sprintf "%s:%s"
-    (Llm_provider.Provider_kind.to_string cfg.Llm_provider.Provider_config.kind)
-    cfg.Llm_provider.Provider_config.model_id
+  let provider_label =
+    match Runtime_binding.binding_for_provider_config cfg with
+    | Some binding -> binding.Runtime_binding.id
+    | None -> Llm_provider.Provider_registry.provider_name_of_config cfg
+  in
+  let label =
+    Printf.sprintf "%s:%s" provider_label cfg.Llm_provider.Provider_config.model_id
+  in
+  match
+    cfg.Llm_provider.Provider_config.kind,
+    provider_name_of_label label
+  with
+  | Llm_provider.Provider_config.Provider_d_compat, Some provider_name
+    when is_provider_d_compat_kind_label provider_name ->
+    let base_url = String.trim cfg.Llm_provider.Provider_config.base_url in
+    if String.equal base_url ""
+    then label
+    else
+      Printf.sprintf "custom:%s@%s"
+        cfg.Llm_provider.Provider_config.model_id
+        base_url
+  | _ -> label
 
 (* --- Synthetic weighted_entry reconstruction --- *)
 

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -308,6 +308,45 @@ let test_model_string_format () =
   check bool "model_string contains colon" true
     (String.contains candidate.Hotpath.model_string ':')
 
+let test_provider_d_http_model_string_uses_custom_label () =
+  let toml =
+    {|
+[providers.glm-coding]
+protocol = "provider_d-http"
+endpoint = "https://api.z.ai/api/coding/paas/v4"
+
+[models.glm-5-turbo]
+max-context = 128000
+api-name = "glm-5-turbo"
+tools-support = true
+
+[glm-coding.glm-5-turbo]
+
+[tier.glm]
+members = ["glm-coding.glm-5-turbo"]
+strategy = "failover"
+|}
+  in
+  let snapshot = get_snapshot toml in
+  let profile = find_profile snapshot "tier.glm" in
+  match profile.Hotpath.candidates, profile.Hotpath.weighted_entries with
+  | [ candidate ], [ entry ] ->
+    let expected =
+      "custom:glm-5-turbo@https://api.z.ai/api/coding/paas/v4"
+    in
+    check string "candidate model label" expected
+      candidate.Hotpath.model_string;
+    check string "weighted entry model label" expected entry.model;
+    check bool "pre-dispatch api-key gate accepts custom label" true
+      (Result.is_ok
+         (Masc_mcp.Cascade_runtime.ensure_api_keys_for_labels [ entry.model ]))
+  | candidates, entries ->
+    fail
+      (Printf.sprintf
+         "expected one candidate and one weighted entry, got %d/%d"
+         (List.length candidates)
+         (List.length entries))
+
 let test_weighted_entries_count () =
   let snapshot = get_snapshot valid_toml in
   List.iter
@@ -860,6 +899,10 @@ let () =
         test_case "profile names" `Quick test_profile_names;
         test_case "candidates" `Quick test_candidates;
         test_case "model_string format" `Quick test_model_string_format;
+        test_case
+          "provider_d-http model strings use custom labels"
+          `Quick
+          test_provider_d_http_model_string_uses_custom_label;
         test_case "weighted_entries count" `Quick test_weighted_entries_count;
         test_case
           "failover inference max_tokens uses narrowest candidate"


### PR DESCRIPTION
## Summary

- Stop declarative hotpath model labels from falling back to raw `provider_d` / `provider_d_compat` kind labels.
- Emit `custom:<model>@<endpoint>` labels for unmatched `provider_d-http` endpoints so pre-dispatch API-key checks do not treat provider kind strings as registry provider ids.
- Add a regression test covering a `provider_d-http` declarative provider and the pre-dispatch API-key gate.

## Root Cause

Declarative profiles reconstructed weighted entry labels from `Provider_config.kind`. For OpenAI-compatible custom endpoints, that erased the declared provider identity and produced kind labels such as `provider_d_compat:<model>`, which `ensure_api_keys_for_labels` then interpreted as an unknown registry provider before any cascade attempt was dispatched.

## Validation

- `scripts/dune-local.sh build test/test_cascade_declarative_hotpath.exe`
- `./_build/default/test/test_cascade_declarative_hotpath.exe`