### PR TITLE
[codex] Expose keeper tool call IO previews

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -27,13 +27,17 @@ const TARGET_FILES = [
   'src/components/logs.ts',
   'src/components/mission.ts',
   'src/components/runtime-monitor.ts',
+  'src/components/session-trace/session-trace-live-store.ts',
   'src/components/status.ts',
   'src/components/transport-health.ts',
   'src/dashboard-ws.ts',
   'src/goal-loop-status.ts',
   'src/lib/async-state.ts',
   'src/components/common/normalize.ts',
+  'src/schemas/sse.ts',
+  'src/sse.ts',
   'src/tab-refresh.ts',
+  'src/types/sse.ts',
 ]
 
 const TEST_FILES = [
@@ -48,10 +52,12 @@ const TEST_FILES = [
   'src/components/journey-waterfall-state.test.ts',
   'src/components/keeper-tool-call-inspector.test.ts',
   'src/components/logs.test.ts',
+  'src/components/session-trace/session-trace-state.test.ts',
   'src/components/transport-health.test.ts',
   'src/dashboard-ws.test.ts',
   'src/goal-loop-status.test.ts',
   'src/lib/async-state.test.ts',
+  'src/schemas/sse.test.ts',
 ]
 
 export default tseslint.config(

--- a/dashboard/src/components/session-trace/session-trace-live-store.ts
+++ b/dashboard/src/components/session-trace/session-trace-live-store.ts
@@ -40,9 +40,16 @@ export function appendLiveToolCall(
     success: boolean
     error: string | null
     tsUnix: number
+    toolArgs?: string | Record<string, unknown> | null
+    toolResult?: string | null
+    toolIoRedacted?: boolean
   },
 ): void {
   const tsMs = evt.tsUnix * 1000
+  const detail: Record<string, unknown> = {}
+  if (evt.toolArgs != null) detail.tool_args_preview = evt.toolArgs
+  if (evt.toolResult != null) detail.tool_output_preview = evt.toolResult
+  if (evt.toolIoRedacted === true) detail.tool_io_redacted = true
   appendLiveTraceEvent(agentName, {
     id: `live-masc-tool-${tsMs}-${evt.toolName}`,
     ts: tsMs,
@@ -50,9 +57,11 @@ export function appendLiveToolCall(
     kind: 'tool_call',
     sourceLane: 'masc',
     summary: evt.toolName,
-    detail: {},
+    detail,
     agentName,
     toolName: evt.toolName,
+    toolArgs: evt.toolArgs ?? undefined,
+    toolResult: evt.toolResult ?? null,
     duration_ms: evt.durationMs,
     error: evt.error,
   })

--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -56,6 +56,8 @@ describe('appendLiveToolCall', () => {
       success: true,
       error: null,
       tsUnix: 1712400000,
+      toolArgs: '{"file_path":"/tmp/readme.md"}',
+      toolResult: 'file contents',
     })
 
     const events = getTraceEvents('keeper-a')
@@ -65,6 +67,10 @@ describe('appendLiveToolCall', () => {
     expect(e.toolName).toBe('keeper_fs_read')
     expect(e.duration_ms).toBe(250)
     expect(e.error).toBeNull()
+    expect(e.toolArgs).toBe('{"file_path":"/tmp/readme.md"}')
+    expect(e.toolResult).toBe('file contents')
+    expect(e.detail.tool_args_preview).toBe('{"file_path":"/tmp/readme.md"}')
+    expect(e.detail.tool_output_preview).toBe('file contents')
     expect(e.ts).toBe(1712400000 * 1000)
     expect(e.id).toMatch(/^live-/)
   })

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -90,6 +90,9 @@ describe('SSEMessageSchema', () => {
       tool_name: 'bash',
       duration_ms: 1234,
       success: true,
+      tool_args_preview: '{"path":"/tmp/a"}',
+      tool_output_preview: '{"ok":true}',
+      tool_io_redacted: false,
     })
     expect(r.success).toBe(true)
   })

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -105,6 +105,8 @@ const STRING_FIELDS = new Set([
   'event',
   'tool_name',
   'error_text',
+  'tool_args_preview',
+  'tool_output_preview',
   'reason_code',
   'phase',
   'from_state',
@@ -135,7 +137,7 @@ const NUMBER_FIELDS = new Set([
   'total_turns',
 ])
 
-const BOOLEAN_FIELDS = new Set(['success', 'reacted'])
+const BOOLEAN_FIELDS = new Set(['success', 'reacted', 'tool_io_redacted'])
 
 function ok<T>(data: T): SafeParseSuccess<T> {
   return { success: true, data }

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -22,6 +22,7 @@ import { asNumber } from './components/common/normalize'
 import { RingBuffer } from './lib/ring-buffer'
 import { createSseTransport } from './transports/sse-transport'
 import type { Transport } from './transports/transport'
+import type * as OasRuntimeStore from './oas-runtime-store'
 
 import {
   RECONNECT_BASE_MS,
@@ -30,9 +31,9 @@ import {
 } from './config/constants'
 
 const SSE_SESSION_KEY = 'masc_dashboard_sse_session_id'
-let oasRuntimeStorePromise: Promise<typeof import('./oas-runtime-store')> | null = null
+let oasRuntimeStorePromise: Promise<typeof OasRuntimeStore> | null = null
 
-function loadOasRuntimeStore(): Promise<typeof import('./oas-runtime-store')> {
+function loadOasRuntimeStore(): Promise<typeof OasRuntimeStore> {
   oasRuntimeStorePromise ??= import('./oas-runtime-store')
   return oasRuntimeStorePromise
 }
@@ -574,6 +575,9 @@ function handleEvent(event: SSEEvent): void {
           success: event.success !== false,
           error: event.error_text ?? null,
           tsUnix: typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000,
+          toolArgs: event.tool_args_preview ?? null,
+          toolResult: event.tool_output_preview ?? null,
+          toolIoRedacted: event.tool_io_redacted === true,
         })
       }
       break

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -178,6 +178,9 @@ export interface SSEEvent {
   duration_ms?: number
   success?: boolean
   error_text?: string
+  tool_args_preview?: string
+  tool_output_preview?: string
+  tool_io_redacted?: boolean
   reason_code?: string
   turn?: number
   phase?: string

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -63,6 +63,8 @@ let make_keeper_tool_handler
         ~duration_ms
         ~success:false
         ~error_text
+        ~extra_fields:
+          (tool_io_preview_fields ~tool_name:name ~input ~output:output_text ())
         ~site:"input_validation"
         ~ts
         ();

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -169,6 +169,8 @@ let execute_with_observers
         ~duration_ms
         ~success:false
         ~error_text:detail
+        ~extra_fields:
+          (tool_io_preview_fields ~tool_name:name ~input ~output:raw_result ())
         ~site:"error_result"
         ~ts
         ();
@@ -349,6 +351,8 @@ let execute_with_observers
         ~tool_name:name
         ~duration_ms
         ~success:true
+        ~extra_fields:
+          (tool_io_preview_fields ~tool_name:name ~input ~output:raw_result ())
         ~site:"success"
         ~ts
         ();
@@ -483,7 +487,9 @@ let execute_with_observers
       ~success:false
       ~error_text
       ~extra_fields:
-        (if is_edeadlk
+        (tool_io_preview_fields ~tool_name:name ~input ~output:error_text ()
+         @
+         if is_edeadlk
          then
            [ "error_class", `String transient_mutex_contention_error_class
            ; "recoverable", `Bool true

--- a/lib/keeper/keeper_tools_oas_handler_telemetry.ml
+++ b/lib/keeper/keeper_tools_oas_handler_telemetry.ml
@@ -30,6 +30,25 @@ let keeper_tool_call_event_json
   `Assoc (fields @ extra_fields)
 ;;
 
+let string_preview_field key = function
+  | Some value when String.trim value <> "" -> [ key, `String value ]
+  | Some _ | None -> []
+;;
+
+let tool_io_preview_fields ~tool_name ~input ?output () =
+  let input_preview = Observability_redact.redact_tool_input ~tool_name input in
+  let output_preview =
+    match output with
+    | Some output -> Observability_redact.redact_tool_output ~tool_name output
+    | None -> None
+  in
+  (if Observability_redact.is_denied_tool ~tool_name
+   then [ "tool_io_redacted", `Bool true ]
+   else [])
+  @ string_preview_field "tool_args_preview" input_preview
+  @ string_preview_field "tool_output_preview" output_preview
+;;
+
 let broadcast_keeper_tool_call_event
       ~keeper_name
       ~tool_name

--- a/lib/keeper/keeper_tools_oas_handler_telemetry.mli
+++ b/lib/keeper/keeper_tools_oas_handler_telemetry.mli
@@ -12,6 +12,17 @@ val keeper_tool_call_event_json
   -> unit
   -> Yojson.Safe.t
 
+(** Redacted, bounded live-preview fields for keeper tool-call SSE payloads.
+    Full I/O remains in [Keeper_tool_call_log]; SSE carries only operator-safe
+    previews so live traces can show immediate context without leaking secrets
+    or large outputs. *)
+val tool_io_preview_fields
+  :  tool_name:string
+  -> input:Yojson.Safe.t
+  -> ?output:string
+  -> unit
+  -> (string * Yojson.Safe.t) list
+
 (** Broadcast a keeper tool-call event via SSE, swallowing non-cancellation
     exceptions and logging a warning instead of crashing the turn. *)
 val broadcast_keeper_tool_call_event

--- a/test/dune
+++ b/test/dune
@@ -292,6 +292,7 @@
   test_tool_surface_ssot
   test_keeper_retrieval_quality
   test_observability_redact
+  test_keeper_tool_call_sse_io_preview
   test_observability_provider_contracts
   test_config_doctor
   test_cascade_name
@@ -619,6 +620,7 @@
   test_tool_surface_ssot
   test_keeper_retrieval_quality
   test_observability_redact
+  test_keeper_tool_call_sse_io_preview
   test_observability_provider_contracts
   test_config_doctor
   test_cascade_name

--- a/test/test_keeper_tool_call_sse_io_preview.ml
+++ b/test/test_keeper_tool_call_sse_io_preview.ml
@@ -1,0 +1,79 @@
+open Masc_mcp
+
+let member key json = Yojson.Safe.Util.member key json
+
+let string_member key json =
+  match member key json with
+  | `String value -> Some value
+  | _ -> None
+;;
+
+let bool_member key json =
+  match member key json with
+  | `Bool value -> Some value
+  | _ -> None
+;;
+
+let test_tool_io_preview_fields_are_redacted () =
+  let fields =
+    Keeper_tools_oas_handler_telemetry.tool_io_preview_fields
+      ~tool_name:"keeper_bash"
+      ~input:
+        (`Assoc
+           [ "cmd", `String "echo ok"
+           ; "api_key", `String "abcdefghijklmnopqrstuvwxyz123456"
+           ])
+      ~output:"result token abcdefghijklmnopqrstuvwxyz123456"
+      ()
+  in
+  let json = `Assoc fields in
+  let args_preview = Option.get (string_member "tool_args_preview" json) in
+  let output_preview = Option.get (string_member "tool_output_preview" json) in
+  Alcotest.(check bool)
+    "sensitive input redacted"
+    true
+    (String_util.contains_substring args_preview "[REDACTED]");
+  Alcotest.(check bool)
+    "sensitive output redacted"
+    true
+    (String_util.contains_substring output_preview "[REDACTED]")
+;;
+
+let test_denied_tool_omits_io_previews () =
+  let fields =
+    Keeper_tools_oas_handler_telemetry.tool_io_preview_fields
+      ~tool_name:"keeper_auth_token"
+      ~input:(`Assoc [ "token", `String "abcdefghijklmnopqrstuvwxyz123456" ])
+      ~output:"abcdefghijklmnopqrstuvwxyz123456"
+      ()
+  in
+  let json = `Assoc fields in
+  Alcotest.(check (option bool))
+    "redacted flag"
+    (Some true)
+    (bool_member "tool_io_redacted" json);
+  Alcotest.(check bool)
+    "input preview omitted"
+    true
+    (Option.is_none (string_member "tool_args_preview" json));
+  Alcotest.(check bool)
+    "output preview omitted"
+    true
+    (Option.is_none (string_member "tool_output_preview" json))
+;;
+
+let () =
+  Alcotest.run
+    "keeper_tool_call_sse_io_preview"
+    [ ( "preview_fields"
+      , [ Alcotest.test_case
+            "redacts bounded previews"
+            `Quick
+            test_tool_io_preview_fields_are_redacted
+        ; Alcotest.test_case
+            "omits denied tool io"
+            `Quick
+            test_denied_tool_omits_io_previews
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

This addresses the Kimi MASC/OAS dashboard report item for missing keeper tool-call I/O visibility in the live SSE/dashboard path.

- Add redacted, bounded `tool_args_preview` and `tool_output_preview` fields to `keeper_tool_call` SSE payloads.
- Omit previews entirely for denied auth/credential/secret-style tools and emit `tool_io_redacted` instead.
- Preserve the previews through the dashboard SSE schema into live session trace `toolArgs` / `toolResult` rendering.
- Add focused backend and dashboard tests, and add the touched dashboard boundary files to ESLint coverage.

## Validation

- `ocamlformat --check lib/keeper/keeper_tools_oas_handler.ml lib/keeper/keeper_tools_oas_handler_exec.ml lib/keeper/keeper_tools_oas_handler_telemetry.ml lib/keeper/keeper_tools_oas_handler_telemetry.mli test/test_keeper_tool_call_sse_io_preview.ml`
- `git diff --check origin/main..HEAD`
- `scripts/dune-local.sh build test/test_keeper_tool_call_sse_io_preview.exe`
- `./_build/default/test/test_keeper_tool_call_sse_io_preview.exe`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run src/schemas/sse.test.ts src/components/session-trace/session-trace-state.test.ts`
- `pnpm --dir dashboard exec eslint src/schemas/sse.ts src/schemas/sse.test.ts src/sse.ts src/types/sse.ts src/components/session-trace/session-trace-live-store.ts src/components/session-trace/session-trace-state.test.ts`
