### PR TITLE
[codex] Add goal creation to goal loop panel

### DIFF
--- a/dashboard/src/components/goal-loop-panel.test.ts
+++ b/dashboard/src/components/goal-loop-panel.test.ts
@@ -1,8 +1,21 @@
 import { html } from 'htm/preact'
-import { cleanup, render, screen } from '@testing-library/preact'
-import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { GoalLoopPanel } from './goal-loop-panel'
 import { normalizeGoalLoopStatus } from '../goal-loop-status'
+
+const mocks = vi.hoisted(() => ({
+  callMcpTool: vi.fn(),
+  fetchGoalLoopStatus: vi.fn(),
+}))
+
+vi.mock('../api/mcp', () => ({
+  callMcpTool: mocks.callMcpTool,
+}))
+
+vi.mock('../api/goal-loop', () => ({
+  fetchGoalLoopStatus: mocks.fetchGoalLoopStatus,
+}))
 
 function blockedStatus() {
   return normalizeGoalLoopStatus({
@@ -64,6 +77,8 @@ function blockedStatus() {
 describe('GoalLoopPanel', () => {
   afterEach(() => {
     cleanup()
+    mocks.callMcpTool.mockReset()
+    mocks.fetchGoalLoopStatus.mockReset()
   })
 
   it('renders phase table, audit, next action, and the strict corpus blocker', () => {
@@ -129,5 +144,36 @@ describe('GoalLoopPanel', () => {
 
     expect(screen.getByTestId('goal-loop-verify-evidence').textContent).toContain('Post-ACT live Verify evidence')
     expect(screen.getByTestId('goal-loop-verify-evidence').textContent).toContain('/tmp/goal-loop-post-act.log')
+  })
+
+  it('creates a goal through the goal store tool and refreshes the loop status', async () => {
+    mocks.callMcpTool.mockResolvedValue('{"ok":true}')
+    mocks.fetchGoalLoopStatus.mockResolvedValue(blockedStatus())
+
+    render(html`<${GoalLoopPanel} initialStatus=${blockedStatus()} />`)
+
+    fireEvent.input(screen.getByLabelText('Goal title'), {
+      target: { value: 'Stabilize runtime truth' },
+    })
+    fireEvent.change(screen.getByLabelText('Horizon'), {
+      target: { value: 'mid' },
+    })
+    fireEvent.change(screen.getByLabelText('Priority'), {
+      target: { value: '2' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Create goal' }))
+
+    await waitFor(() => {
+      expect(mocks.callMcpTool).toHaveBeenCalledWith('masc_goal_upsert', {
+        title: 'Stabilize runtime truth',
+        horizon: 'mid',
+        priority: 2,
+      })
+    })
+    await waitFor(() => {
+      expect(mocks.fetchGoalLoopStatus).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.getByTestId('goal-loop-create-goal').textContent)
+      .toContain('created Stabilize runtime truth')
   })
 })

--- a/dashboard/src/components/goal-loop-panel.ts
+++ b/dashboard/src/components/goal-loop-panel.ts
@@ -1,13 +1,16 @@
 import { html } from 'htm/preact'
 import { useCallback, useEffect, useState } from 'preact/hooks'
-import { RefreshCw } from 'lucide-preact'
+import { Plus, RefreshCw } from 'lucide-preact'
 import { SectionCard } from './common/card'
 import { LoadingState } from './common/feedback-state'
 import { ActionButton } from './common/button'
 import { Table, type TableColumn } from './common/table'
 import { Drawer } from './common/drawer'
 import { CollapsibleSection } from './common/collapsible'
+import { TextInput } from './common/input'
+import { Select } from './common/select'
 import { fetchGoalLoopStatus } from '../api/goal-loop'
+import { callMcpTool } from '../api/mcp'
 import { formatMsCompact } from '../lib/format-number'
 import {
   GOAL_LOOP_PHASES,
@@ -26,6 +29,21 @@ import {
 interface GoalLoopPanelProps {
   initialStatus?: GoalLoopStatusResponse
 }
+
+type GoalHorizon = 'short' | 'mid' | 'long'
+
+const GOAL_HORIZON_OPTIONS = [
+  { value: 'short', label: 'Short' },
+  { value: 'mid', label: 'Mid' },
+  { value: 'long', label: 'Long' },
+]
+
+const GOAL_PRIORITY_OPTIONS = [
+  { value: '1', label: 'P1' },
+  { value: '2', label: 'P2' },
+  { value: '3', label: 'P3' },
+  { value: '4', label: 'P4' },
+]
 
 function displayValue(value: unknown): string {
   if (value === null || value === undefined || value === '') return 'n/a'
@@ -244,6 +262,108 @@ function VerifyEvidenceBlock({ status }: { status: GoalLoopStatusResponse }) {
   `
 }
 
+function GoalCreateBlock({ onCreated }: { onCreated: () => void }) {
+  const [title, setTitle] = useState('')
+  const [horizon, setHorizon] = useState<GoalHorizon>('short')
+  const [priority, setPriority] = useState('3')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [created, setCreated] = useState<string | null>(null)
+
+  const submit = useCallback((event?: Event) => {
+    event?.preventDefault()
+    const trimmedTitle = title.trim()
+    if (!trimmedTitle) {
+      setError('title required')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    setCreated(null)
+    void callMcpTool('masc_goal_upsert', {
+      title: trimmedTitle,
+      horizon,
+      priority: Number(priority),
+    })
+      .then(() => {
+        setTitle('')
+        setHorizon('short')
+        setPriority('3')
+        setCreated(trimmedTitle)
+        onCreated()
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : String(err))
+      })
+      .finally(() => setSubmitting(false))
+  }, [horizon, onCreated, priority, title])
+
+  return html`
+    <${SectionCard} title="Create Goal" data-testid="goal-loop-create-goal">
+      <form class="grid gap-3 md:grid-cols-[minmax(0,1fr)_8rem_6rem_auto]" onSubmit=${submit}>
+        <label class="flex min-w-0 flex-col gap-1 text-2xs font-medium text-[var(--color-fg-muted)]">
+          Title
+          <${TextInput}
+            value=${title}
+            placeholder="Goal title"
+            ariaLabel="Goal title"
+            disabled=${submitting}
+            onInput=${(e: Event) => setTitle((e.target as HTMLInputElement).value)}
+          />
+        </label>
+        <label class="flex min-w-0 flex-col gap-1 text-2xs font-medium text-[var(--color-fg-muted)]">
+          Horizon
+          <${Select}
+            value=${horizon}
+            options=${GOAL_HORIZON_OPTIONS}
+            disabled=${submitting}
+            onInput=${(next: string) => setHorizon(next as GoalHorizon)}
+          />
+        </label>
+        <label class="flex min-w-0 flex-col gap-1 text-2xs font-medium text-[var(--color-fg-muted)]">
+          Priority
+          <${Select}
+            value=${priority}
+            options=${GOAL_PRIORITY_OPTIONS}
+            disabled=${submitting}
+            onInput=${setPriority}
+          />
+        </label>
+        <div class="flex items-end">
+          <${ActionButton}
+            type="submit"
+            variant="primary"
+            size="md"
+            disabled=${submitting || title.trim() === ''}
+            ariaBusy=${submitting}
+            ariaLabel="Create goal"
+            title="Create goal"
+          >
+            <span class="inline-flex items-center gap-1">
+              <${Plus} size=${14} />
+              ${submitting ? 'Creating' : 'Create'}
+            </span>
+          <//>
+        </div>
+      </form>
+      ${error
+        ? html`
+          <div class="rounded-[var(--r-1)] border border-[var(--err-25)] bg-[var(--err-10)] px-3 py-2 text-xs text-[var(--color-status-err)]">
+            ${error}
+          </div>
+        `
+        : null}
+      ${created
+        ? html`
+          <div class="rounded-[var(--r-1)] border border-[var(--ok-25)] bg-[var(--ok-10)] px-3 py-2 text-xs text-[var(--color-status-ok)]">
+            created ${created}
+          </div>
+        `
+        : null}
+    <//>
+  `
+}
+
 interface GoalLoopTableRow {
   phase: GoalLoopPhaseName
   status: string
@@ -438,6 +558,8 @@ export function GoalLoopPanel({ initialStatus }: GoalLoopPanelProps) {
       <//>
 
       <${NextActionBlock} status=${status} />
+
+      <${GoalCreateBlock} onCreated=${refresh} />
 
       <${GoalLoopDetailDrawer}
         phase=${selectedPhase}


### PR DESCRIPTION
## Summary
- Add a compact goal creation block to the Goal Loop panel with title, horizon, and priority controls.
- Call `masc_goal_upsert` through the MCP API and refresh Goal Loop state after creation.
- Extend Goal Loop panel coverage for the create flow and refresh behavior.

## Why
The dashboard review report flagged GOAL-UI-01: goal creation was not available from the Goal Loop panel, forcing users out of the runtime goal surface to create new goals.

## Validation
- `git diff --check origin/main..HEAD`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run src/components/goal-loop-panel.test.ts`
- `pnpm --dir dashboard exec eslint src/components/goal-loop-panel.ts src/components/goal-loop-panel.test.ts`