### PR TITLE
Fix custom endpoint cascade health keys

### DIFF
--- a/lib/cascade/cascade_config_provider_binding.ml
+++ b/lib/cascade/cascade_config_provider_binding.ml
@@ -43,8 +43,7 @@ let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
 
 let provider_health_key_of_config (cfg : Llm_provider.Provider_config.t) =
   match cfg.kind with
-  | Llm_provider.Provider_config.Provider_d_compat
-    when Llm_provider.Provider_config.is_local cfg ->
+  | Llm_provider.Provider_config.Provider_d_compat ->
     let base_url = String.trim cfg.base_url in
     if base_url = ""
     then provider_label_of_config cfg

--- a/lib/cascade/cascade_config_provider_binding.mli
+++ b/lib/cascade/cascade_config_provider_binding.mli
@@ -27,8 +27,9 @@ val cascade_prefix_of_provider_kind :
 val provider_label_of_config : Llm_provider.Provider_config.t -> string
 
 val provider_health_key_of_config : Llm_provider.Provider_config.t -> string
-(** Key used by {!Cascade_health_tracker}. For local OpenAI-compat configs
-    the base URL is appended so each endpoint is tracked independently. *)
+(** Key used by {!Cascade_health_tracker}. For OpenAI-compatible configs
+    the model and base URL are appended so each endpoint is tracked
+    independently. *)
 
 val runtime_kind_of_binding : Runtime_binding.t -> string
 (** ["cli_agent"] | ["local"] | ["direct_api"]. *)

--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -77,8 +77,7 @@ let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
 
 let provider_health_key_of_config (cfg : Llm_provider.Provider_config.t) =
   match cfg.kind with
-  | Llm_provider.Provider_config.Provider_d_compat
-    when Llm_provider.Provider_config.is_local cfg ->
+  | Llm_provider.Provider_config.Provider_d_compat ->
     let base_url = String.trim cfg.base_url in
     if base_url = ""
     then provider_label_of_config cfg

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -67,8 +67,7 @@ let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
 
 let provider_health_key_of_config (cfg : Llm_provider.Provider_config.t) =
   match cfg.kind with
-  | Llm_provider.Provider_config.Provider_d_compat
-    when Llm_provider.Provider_config.is_local cfg ->
+  | Llm_provider.Provider_config.Provider_d_compat ->
       let base_url = String.trim cfg.base_url in
       if String.equal base_url ""
       then provider_label_of_config cfg

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -725,6 +725,68 @@ strategy = "priority_tier"
   check_kind "tier.priority-t" Cascade_strategy.Priority_tier
 ;;
 
+let test_provider_d_http_tier_group_uses_endpoint_scoped_health_keys () =
+  let toml =
+    {|
+[providers.runpod]
+protocol = "provider_d-http"
+endpoint = "https://runpod.example.test/v1"
+
+[providers.glm]
+protocol = "provider_d-http"
+endpoint = "https://api.z.ai/api/coding/paas/v4"
+
+[models.runpod-qwen]
+max-context = 128000
+api-name = "runpod-qwen"
+tools-support = true
+
+[models.glm-5-turbo]
+max-context = 128000
+api-name = "glm-5-turbo"
+tools-support = true
+
+[runpod.runpod-qwen]
+[glm.glm-5-turbo]
+
+[tier.runpod]
+members = ["runpod.runpod-qwen"]
+strategy = "failover"
+
+[tier.glm]
+members = ["glm.glm-5-turbo"]
+strategy = "failover"
+
+[tier-group.custom-priority]
+tiers = ["runpod", "glm"]
+strategy = "priority_tier"
+|}
+  in
+  let catalog = adapt_toml toml in
+  no_errors catalog.errors;
+  let profile =
+    List.find
+      (fun (p : adapted_profile) -> p.name = "tier-group.custom-priority")
+      catalog.profiles
+  in
+  match profile.strategy.Cascade_strategy.tiers with
+  | [ [ first ]; [ second ] ] ->
+    check bool "tier health keys are endpoint-scoped"
+      true
+      (not (String.equal first second));
+    check bool "runpod tier key includes endpoint"
+      true
+      (String.contains first '@');
+    check bool "glm tier key includes endpoint"
+      true
+      (String.contains second '@')
+  | tiers ->
+    fail
+      (Printf.sprintf
+         "expected two single-entry tiers, got %d tiers"
+         (List.length tiers))
+;;
+
 (* --- Multiple errors accumulated --- *)
 
 let test_multiple_errors () =
@@ -902,7 +964,12 @@ let () =
         ; test_case "duplicate routes" `Quick test_duplicate_routes
         ] )
     ; ( "strategy"
-      , [ test_case "supported variants" `Quick test_strategy_mapping ] )
+      , [ test_case "supported variants" `Quick test_strategy_mapping
+        ; test_case
+            "provider_d-http tier-group keys are endpoint-scoped"
+            `Quick
+            test_provider_d_http_tier_group_uses_endpoint_scoped_health_keys
+        ] )
     ; "edge_cases", [ test_case "empty tier-group" `Quick test_empty_tier_group ]
     ]
 ;;

--- a/test/test_cascade_runtime.ml
+++ b/test/test_cascade_runtime.ml
@@ -70,6 +70,42 @@ let test_openai_compat_declarative_labels_do_not_require_registry_entry () =
        (Masc_mcp.Cascade_runtime.ensure_api_keys_for_labels
           [ "openai_compat:qwen3.5" ]))
 
+let test_custom_urls_use_endpoint_scoped_health_keys () =
+  let first = "custom:runpod-qwen@https://runpod.example.test/v1" in
+  let second = "custom:glm-5-turbo@https://api.z.ai/api/coding/paas/v4" in
+  match
+    Masc_mcp.Cascade_config.parse_model_string first,
+    Masc_mcp.Cascade_config.parse_model_string second
+  with
+  | Some first_cfg, Some second_cfg ->
+    let binding_first =
+      Masc_mcp.Cascade_config_provider_binding.provider_health_key_of_config
+        first_cfg
+    in
+    let binding_second =
+      Masc_mcp.Cascade_config_provider_binding.provider_health_key_of_config
+        second_cfg
+    in
+    let runtime_keys =
+      Masc_mcp.Cascade_runtime_candidate.runtime_health_keys_of_labels
+        [ first; second ]
+    in
+    check
+      bool
+      "binding health keys are endpoint-scoped"
+      true
+      (not (String.equal binding_first binding_second));
+    check bool "first key contains base URL"
+      true
+      (String.contains binding_first '@');
+    check bool "second key contains base URL"
+      true
+      (String.contains binding_second '@');
+    check int "runtime has separate custom URL health keys"
+      2
+      (List.length runtime_keys)
+  | _ -> fail "custom URL specs should parse"
+
 let () =
   run "Cascade_runtime"
     [
@@ -81,5 +117,7 @@ let () =
             test_oas_failure_classification_keeps_terminal_branches_non_cascading;
           test_case "typed openai_compat labels skip registry api-key gate" `Quick
             test_openai_compat_declarative_labels_do_not_require_registry_entry;
+          test_case "custom URLs use endpoint-scoped health keys" `Quick
+            test_custom_urls_use_endpoint_scoped_health_keys;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Track all Provider_d_compat health keys by model and base URL, not only local endpoints.
- Keep config selection, runtime candidates, and declarative tier-group strategy keys aligned.
- Add regressions for custom URL runtime keys and provider_d-http tier-group keys.

Fixes #18298.

## Validation
- scripts/dune-local.sh build test/test_cascade_runtime.exe
- ./_build/default/test/test_cascade_runtime.exe
- scripts/dune-local.sh build test/test_cascade_declarative_adapter.exe
- ./_build/default/test/test_cascade_declarative_adapter.exe test strategy 1
- git diff --check
- ocamlformat --check touched OCaml files

## Notes
- Full local test_provider_kind_resolution.exe still has pre-existing registry drift failures for openrouter/provider_c.
- Full local test_cascade_declarative_adapter.exe still has an existing env fallback failure in valid_catalog.008; the new strategy regression passes in isolation.
- Remaining route legacy aliases are tracked separately in #18299.