### PR TITLE
[codex] Stabilize dashboard async tests

### DIFF
--- a/dashboard/design-system/headless-preact/use-collaboration.ts
+++ b/dashboard/design-system/headless-preact/use-collaboration.ts
@@ -14,6 +14,49 @@ import type {
   FileConflict,
 } from '../headless-core/collaboration'
 
+function sameCursors(
+  a: ReadonlyArray<AgentCursor>,
+  b: ReadonlyArray<AgentCursor>,
+): boolean {
+  if (a.length !== b.length) return false
+  return a.every((cursor, index) => {
+    const next = b[index]
+    if (next === undefined) return false
+    if (cursor.agent.id !== next.agent.id) return false
+    if (cursor.file !== next.file) return false
+    if (cursor.position.line !== next.position.line) return false
+    if (cursor.position.column !== next.position.column) return false
+    const currentSelection = cursor.selection
+    const nextSelection = next.selection
+    if (currentSelection === undefined && nextSelection === undefined) return true
+    if (currentSelection === undefined || nextSelection === undefined) return false
+    return (
+      currentSelection.line === nextSelection.line &&
+      currentSelection.column === nextSelection.column &&
+      currentSelection.end.line === nextSelection.end.line &&
+      currentSelection.end.column === nextSelection.end.column
+    )
+  })
+}
+
+function sameConflicts(
+  a: ReadonlyArray<FileConflict>,
+  b: ReadonlyArray<FileConflict>,
+): boolean {
+  if (a.length !== b.length) return false
+  return a.every((conflict, index) => {
+    const next = b[index]
+    if (next === undefined) return false
+    if (conflict.file !== next.file) return false
+    if (conflict.lineFrom !== next.lineFrom) return false
+    if (conflict.lineTo !== next.lineTo) return false
+    if (conflict.agents.length !== next.agents.length) return false
+    const currentAgentIds = conflict.agents.map(agent => agent.id).sort()
+    const nextAgentIds = next.agents.map(agent => agent.id).sort()
+    return currentAgentIds.every((id, agentIndex) => id === nextAgentIds[agentIndex])
+  })
+}
+
 export function useFileCursors(
   manager: CollaborationManager,
   file: string,
@@ -22,8 +65,11 @@ export function useFileCursors(
     manager.activeAgentsInFile(file),
   )
   useEffect(() => {
-    setCursors(manager.activeAgentsInFile(file))
-    const dispose = manager.subscribeFile(file, (cs) => setCursors(cs))
+    const updateCursors = (next: ReadonlyArray<AgentCursor>): void => {
+      setCursors((prev) => sameCursors(prev, next) ? prev : next)
+    }
+    updateCursors(manager.activeAgentsInFile(file))
+    const dispose = manager.subscribeFile(file, updateCursors)
     return dispose
   }, [manager, file])
   return cursors
@@ -37,9 +83,12 @@ export function useFileConflicts(
     manager.conflictsInFile(file),
   )
   useEffect(() => {
-    setConflicts(manager.conflictsInFile(file))
+    const updateConflicts = (next: ReadonlyArray<FileConflict>): void => {
+      setConflicts((prev) => sameConflicts(prev, next) ? prev : next)
+    }
+    updateConflicts(manager.conflictsInFile(file))
     const dispose = manager.subscribeConflicts((all) => {
-      setConflicts(all.filter((c) => c.file === file))
+      updateConflicts(all.filter((c) => c.file === file))
     })
     return dispose
   }, [manager, file])

--- a/dashboard/design-system/headless-preact/use-inline-suggestion.ts
+++ b/dashboard/design-system/headless-preact/use-inline-suggestion.ts
@@ -15,6 +15,14 @@ import {
   type SuggestionController,
 } from '../headless-core/inline-suggestion'
 
+function sameSuggestions(
+  a: ReadonlyArray<InlineSuggestion>,
+  b: ReadonlyArray<InlineSuggestion>,
+): boolean {
+  if (a.length !== b.length) return false
+  return a.every((suggestion, index) => suggestion.id === b[index]?.id)
+}
+
 export function useFileSuggestions(
   manager: InlineSuggestionManager,
   file: string,
@@ -23,8 +31,11 @@ export function useFileSuggestions(
     manager.inFile(file),
   )
   useEffect(() => {
-    setList(manager.inFile(file))
-    const dispose = manager.subscribeFile(file, (xs) => setList(xs))
+    const updateList = (next: ReadonlyArray<InlineSuggestion>): void => {
+      setList((prev) => sameSuggestions(prev, next) ? prev : next)
+    }
+    updateList(manager.inFile(file))
+    const dispose = manager.subscribeFile(file, updateList)
     return dispose
   }, [manager, file])
   return list

--- a/dashboard/design-system/headless-preact/use-tabs.test.ts
+++ b/dashboard/design-system/headless-preact/use-tabs.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
+import { waitFor } from '@testing-library/preact'
 import type { TabDescriptor } from '../headless-core/tabs'
 import { useTabs } from './use-tabs'
 
@@ -73,8 +74,7 @@ describe('useTabs', () => {
     render(html`<${Probe} />`, container)
     await flushEffects()
     captured.close('t2')
-    await flushEffects()
-    expect(captured.tabs.map((t) => t.id)).toEqual(['t1', 't3'])
+    await waitFor(() => expect(captured.tabs.map((t) => t.id)).toEqual(['t1', 't3']))
   })
 
   it('getTabListProps returns role=tablist', async () => {

--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -3,6 +3,8 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import tseslint from 'typescript-eslint'
 
 const TARGET_FILES = [
+  'design-system/headless-preact/use-inline-suggestion.ts',
+  'design-system/headless-preact/use-collaboration.ts',
   'src/api/dashboard-cascade.ts',
   'src/api/dashboard.ts',
   'src/api/gate.ts',
@@ -41,13 +43,21 @@ const TARGET_FILES = [
 ]
 
 const TEST_FILES = [
+  'design-system/headless-preact/use-inline-suggestion.test.ts',
+  'design-system/headless-preact/use-collaboration.test.ts',
+  'design-system/headless-preact/use-tabs.test.ts',
   'src/api/schemas/cascade.test.ts',
   'src/api/schemas/dashboard-config.test.ts',
   'src/cb-shared-telemetry-source.test.ts',
   'src/components/common/markdown.test.ts',
+  'src/components/common/rich-content.test.ts',
+  'src/components/common/window.test.ts',
+  'src/components/common/cytoscape-fsm.test.ts',
+  'src/components/auth-status.test.ts',
   'src/components/connector-status.test.ts',
   'src/components/fleet-fsm-matrix.test.ts',
   'src/components/goal-loop-panel.test.ts',
+  'src/components/ide/ide-activity-panel.test.ts',
   'src/components/journey-panel.test.ts',
   'src/components/journey-waterfall-state.test.ts',
   'src/components/keeper-tool-call-inspector.test.ts',
@@ -58,6 +68,15 @@ const TEST_FILES = [
   'src/goal-loop-status.test.ts',
   'src/lib/async-state.test.ts',
   'src/schemas/sse.test.ts',
+  'src/sse-store.test.ts',
+]
+
+const DEFAULT_PROJECT_FILES = [
+  'design-system/headless-preact/use-inline-suggestion.ts',
+  'design-system/headless-preact/use-inline-suggestion.test.ts',
+  'design-system/headless-preact/use-collaboration.ts',
+  'design-system/headless-preact/use-collaboration.test.ts',
+  'design-system/headless-preact/use-tabs.test.ts',
 ]
 
 export default tseslint.config(
@@ -73,7 +92,9 @@ export default tseslint.config(
         ...globals.node,
       },
       parserOptions: {
-        projectService: true,
+        projectService: {
+          allowDefaultProject: DEFAULT_PROJECT_FILES,
+        },
         tsconfigRootDir: import.meta.dirname,
       },
     },
@@ -105,7 +126,9 @@ export default tseslint.config(
         ...globals.node,
       },
       parserOptions: {
-        projectService: true,
+        projectService: {
+          allowDefaultProject: DEFAULT_PROJECT_FILES,
+        },
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/dashboard/src/components/auth-status.test.ts
+++ b/dashboard/src/components/auth-status.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
+import { waitFor } from '@testing-library/preact'
 
 vi.mock('../store', () => ({
   shellAuthSummary: { value: null },
@@ -115,14 +116,19 @@ describe('AuthStatus popover behavior (Iter 2)', () => {
 
     trigger.click()
     await flushUi()
-    expect(container.querySelector('[role="dialog"]')).not.toBeNull()
+    const panel = container.querySelector('[role="dialog"]')
+    expect(panel).not.toBeNull()
+    await waitFor(() => {
+      expect(panel?.contains(document.activeElement)).toBe(true)
+    })
 
     document.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
     )
-    await flushUi()
 
-    expect(container.querySelector('[role="dialog"]')).toBeNull()
+    await waitFor(() => {
+      expect(container.querySelector('[role="dialog"]')).toBeNull()
+    })
     expect(document.activeElement).toBe(trigger)
   })
 })

--- a/dashboard/src/components/common/cytoscape-fsm.test.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
+import { waitFor } from '@testing-library/preact'
 import { CytoscapeFsm } from './cytoscape-fsm'
 
 const mockStyleApi = {
@@ -61,9 +62,8 @@ describe('CytoscapeFsm', () => {
   it('calls cytoscape after mount', async () => {
     const container = document.createElement('div')
     render(h(CytoscapeFsm, { spec: baseSpec }), container)
-    await new Promise((r) => setTimeout(r, 10))
     const cytoscape = (await import('cytoscape')).default
-    expect(cytoscape).toHaveBeenCalled()
+    await waitFor(() => expect(cytoscape).toHaveBeenCalled())
   })
 
   it('passes height to inner container', () => {
@@ -76,8 +76,9 @@ describe('CytoscapeFsm', () => {
   it('hides loading after init', async () => {
     const container = document.createElement('div')
     render(h(CytoscapeFsm, { spec: baseSpec }), container)
-    await new Promise((r) => setTimeout(r, 10))
-    expect(container.textContent).not.toContain('그래프 로딩중')
+    await waitFor(() => {
+      expect(container.textContent).not.toContain('그래프 로딩중')
+    })
   })
 
   it('shows error when cytoscape throws', async () => {
@@ -87,14 +88,15 @@ describe('CytoscapeFsm', () => {
     })
     const container = document.createElement('div')
     render(h(CytoscapeFsm, { spec: baseSpec }), container)
-    await new Promise((r) => setTimeout(r, 10))
-    expect(container.textContent).toContain('fail')
+    await waitFor(() => {
+      expect(container.textContent).toContain('fail')
+    })
   })
 
   it('updates elements when spec changes', async () => {
     const container = document.createElement('div')
     render(h(CytoscapeFsm, { spec: baseSpec }), container)
-    await new Promise((r) => setTimeout(r, 10))
+    await waitFor(() => expect(mockCyInstance.on).toHaveBeenCalled())
 
     mockCyInstance.elements.mockClear()
     mockCyInstance.add.mockClear()
@@ -112,8 +114,7 @@ describe('CytoscapeFsm', () => {
       }),
       container,
     )
-    await new Promise((r) => setTimeout(r, 10))
-    expect(mockCyInstance.elements).toHaveBeenCalled()
+    await waitFor(() => expect(mockCyInstance.elements).toHaveBeenCalled())
   })
 
   it('passes resolved token colors to cytoscape', async () => {
@@ -122,9 +123,9 @@ describe('CytoscapeFsm', () => {
 
     const container = document.createElement('div')
     render(h(CytoscapeFsm, { spec: baseSpec }), container)
-    await new Promise((r) => setTimeout(r, 10))
 
     const cytoscape = (await import('cytoscape')).default
+    await waitFor(() => expect(cytoscape).toHaveBeenCalled())
     const options = cytoscape.mock.calls.at(-1)?.[0]
     const nodeStyle = options.style.find((block) => block.selector === 'node').style
     expect(nodeStyle.color).toBe('rgb(1, 2, 3)')
@@ -135,13 +136,14 @@ describe('CytoscapeFsm', () => {
   it('refreshes stylesheet when root theme attributes change', async () => {
     const container = document.createElement('div')
     render(h(CytoscapeFsm, { spec: baseSpec }), container)
-    await new Promise((r) => setTimeout(r, 10))
+    await waitFor(() => expect(mockCyInstance.on).toHaveBeenCalled())
 
     document.documentElement.setAttribute('data-theme', 'high-contrast')
-    await new Promise((r) => setTimeout(r, 10))
 
-    expect(mockCyInstance.style).toHaveBeenCalled()
-    expect(mockStyleApi.fromJson).toHaveBeenCalled()
-    expect(mockStyleApi.update).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(mockCyInstance.style).toHaveBeenCalled()
+      expect(mockStyleApi.fromJson).toHaveBeenCalled()
+      expect(mockStyleApi.update).toHaveBeenCalled()
+    })
   })
 })

--- a/dashboard/src/components/common/markdown.test.ts
+++ b/dashboard/src/components/common/markdown.test.ts
@@ -7,6 +7,7 @@ import { MarkdownContent as MarkdownRenderer } from './markdown-renderer'
 
 describe('Markdown', () => {
   let container: HTMLDivElement
+  const shikiRenderTimeoutMs = 10_000
 
   beforeEach(() => {
     container = document.createElement('div')
@@ -176,7 +177,7 @@ describe('Markdown', () => {
   describe('shiki highlighting', () => {
     const waitForShiki = () => waitFor(() => {
       expect(container.querySelector('pre.shiki-rendered')).not.toBeNull()
-    })
+    }, { timeout: shikiRenderTimeoutMs })
 
     it('highlights non-mermaid code fences via shiki', async () => {
       const md = '```typescript\nconst x = 1\n```'
@@ -186,7 +187,7 @@ describe('Markdown', () => {
       expect(shikiPre).not.toBeNull()
       // The mock escapes HTML entities — verify content is present
       expect(shikiPre?.textContent).toContain('const x = 1')
-    })
+    }, shikiRenderTimeoutMs)
 
     it('does not apply shiki to mermaid code fences', async () => {
       // Render both a mermaid and a non-mermaid block to verify selectivity
@@ -197,7 +198,7 @@ describe('Markdown', () => {
       const shikiBlocks = container.querySelectorAll('pre.shiki-rendered')
       expect(shikiBlocks.length).toBe(1)
       expect(shikiBlocks[0]?.textContent).toContain('const a = 1')
-    })
+    }, shikiRenderTimeoutMs)
 
     it('escapes HTML entities in highlighted code (XSS prevention)', async () => {
       const md = '```html\n<script>alert("xss")</script>\n```'
@@ -205,7 +206,7 @@ describe('Markdown', () => {
       await waitForShiki()
       // The shiki mock escapes < and > so no raw <script> in DOM
       expect(container.innerHTML).not.toContain('<script>')
-    })
+    }, shikiRenderTimeoutMs)
   })
 
   describe('truncated markdown repair', () => {

--- a/dashboard/src/components/common/rich-content.test.ts
+++ b/dashboard/src/components/common/rich-content.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
+import { waitFor } from '@testing-library/preact'
 import { RichContent } from './rich-content'
 
 vi.mock('../../api/link-previews', () => ({
@@ -43,8 +44,7 @@ describe('RichContent', () => {
   it('calls fetchLinkPreviews when URLs are present', async () => {
     const container = document.createElement('div')
     render(h(RichContent, { text: 'Check out https://example.com' }), container)
-    await new Promise((r) => setTimeout(r, 10))
-    expect(mockedFetchLinkPreviews).toHaveBeenCalled()
+    await waitFor(() => expect(mockedFetchLinkPreviews).toHaveBeenCalled())
     const urls = mockedFetchLinkPreviews.mock.calls[0]?.[0] as string[]
     expect(urls).toContain('https://example.com')
     render(null, container)
@@ -73,8 +73,7 @@ describe('RichContent', () => {
     })
     const container = document.createElement('div')
     render(h(RichContent, { text: 'See https://example.com' }), container)
-    await new Promise((r) => setTimeout(r, 10))
-    expect(container.textContent).toContain('Example')
+    await waitFor(() => expect(container.textContent).toContain('Example'))
     render(null, container)
   })
 
@@ -87,7 +86,7 @@ describe('RichContent', () => {
       }),
       container,
     )
-    await new Promise((r) => setTimeout(r, 10))
+    await waitFor(() => expect(mockedFetchLinkPreviews).toHaveBeenCalled())
     const urls = mockedFetchLinkPreviews.mock.calls[0]?.[0] as string[]
     expect(urls.length).toBeLessThanOrEqual(2)
     render(null, container)
@@ -107,7 +106,7 @@ describe('RichContent', () => {
       }),
       container,
     )
-    await new Promise((r) => setTimeout(r, 10))
+    await waitFor(() => expect(mockedFetchLinkPreviews).toHaveBeenCalled())
     const urls = mockedFetchLinkPreviews.mock.calls[0]?.[0] as string[]
     expect(urls).toContain('https://link.com')
     expect(urls).not.toContain('https://img.com/pic.png')

--- a/dashboard/src/components/common/window.test.ts
+++ b/dashboard/src/components/common/window.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
+import { waitFor } from '@testing-library/preact'
 import { Window } from './window'
 
 describe('Window', () => {
@@ -52,8 +53,7 @@ describe('Window', () => {
     const ev = new Event('keydown', { bubbles: true })
     ;(ev as any).key = 'Escape'
     document.dispatchEvent(ev)
-    await new Promise((r) => setTimeout(r, 0))
-    expect(onClose).toHaveBeenCalledOnce()
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce())
   })
 
   it('calls onClose on Alt+F4', async () => {
@@ -65,7 +65,6 @@ describe('Window', () => {
     ;(ev as any).key = 'F4'
     ;(ev as any).altKey = true
     document.dispatchEvent(ev)
-    await new Promise((r) => setTimeout(r, 0))
-    expect(onClose).toHaveBeenCalledOnce()
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce())
   })
 })

--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -241,7 +241,7 @@ describe('IdeActivityPanel', () => {
       'Telemetry',
       'Keeper',
     ])
-    expect(keeperTraceState.value.events).toEqual([expect.objectContaining({
+    await waitFor(() => expect(keeperTraceState.value.events).toEqual([expect.objectContaining({
       id: 'activity:run-default:evt-1',
       keeperName: 'sangsu',
       source: 'activity-event',
@@ -249,7 +249,7 @@ describe('IdeActivityPanel', () => {
       filePath: 'lib/runtime.ml',
       line: 4,
       surface: 'PR',
-    })])
+    })]))
   })
 
   it('shows linked context coverage for mixed activity events', async () => {

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -98,6 +98,8 @@ async function loadSseStore() {
 }
 
 describe('setupSSEReaction reconnect hydration', () => {
+  const dashboardDeltaTimeoutMs = 10_000
+
   beforeEach(() => {
     vi.useFakeTimers()
     route.value = { tab: 'overview', params: {}, postId: null }
@@ -518,5 +520,5 @@ describe('setupSSEReaction reconnect hydration', () => {
 
     expect(hydrateBoardSnapshot).not.toHaveBeenCalled()
     expect(refreshBoard).toHaveBeenCalledTimes(1)
-  })
+  }, dashboardDeltaTimeoutMs)
 })


### PR DESCRIPTION
## What changed
- Preserved referential stability for file-scoped headless Preact lists in `useFileSuggestions`, `useFileCursors`, and `useFileConflicts` so unchanged empty/equivalent snapshots do not trigger extra renders.
- Replaced brittle fixed sleeps/short waits in dashboard tests with condition-based waits for auth popover Escape handling, Cytoscape mount/update timing, IDE activity trace bridging, rich link previews, window shortcuts, and tab close updates.
- Added the touched dashboard/headless test files to the focused ESLint allowlist, including default-project coverage for headless files outside the dashboard tsconfig include set.

## Why
A full dashboard test audit after the goal-loop PR exposed load-sensitive failures that passed in isolation but failed under the full `vitest run` suite. The common causes were effect timing, asynchronous imports, and file-scoped hooks returning fresh equivalent arrays.

## Validation
- `git diff --check origin/main..HEAD`
- `pnpm --dir dashboard exec vitest run design-system/headless-preact/use-tabs.test.ts src/components/common/window.test.ts src/components/common/rich-content.test.ts design-system/headless-preact/use-collaboration.test.ts design-system/headless-preact/use-inline-suggestion.test.ts src/components/common/markdown.test.ts src/sse-store.test.ts src/components/common/cytoscape-fsm.test.ts src/components/auth-status.test.ts src/components/ide/ide-activity-panel.test.ts src/components/goal-loop-panel.test.ts` -> 11 files / 113 tests passed
- `pnpm --dir dashboard exec eslint design-system/headless-preact/use-tabs.test.ts src/components/common/window.test.ts src/components/common/rich-content.test.ts design-system/headless-preact/use-collaboration.ts design-system/headless-preact/use-collaboration.test.ts src/components/common/markdown.test.ts src/sse-store.test.ts src/components/common/cytoscape-fsm.test.ts src/components/auth-status.test.ts design-system/headless-preact/use-inline-suggestion.ts design-system/headless-preact/use-inline-suggestion.test.ts src/components/ide/ide-activity-panel.test.ts src/components/goal-loop-panel.test.ts src/components/goal-loop-panel.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- GitHub `Dashboard` job passed on the merged PR.

## Full-suite note
Multiple full `pnpm --dir dashboard exec vitest run` attempts were used to discover the load-sensitive cases. The final full-suite attempt still failed before the last two fixed-sleep patches landed, in `use-tabs.test.ts` and `window.test.ts`; those files now pass in the focused validation above. The full suite also emits repeated existing `happy-dom` localhost fetch noise, which is separate from these assertions.
