### PR TITLE
fix(keeper): re-qualify public cascade names in fail-open rotation

### DIFF
--- a/lib/keeper/keeper_turn_cascade_budget_routing.ml
+++ b/lib/keeper/keeper_turn_cascade_budget_routing.ml
@@ -82,11 +82,27 @@ let active_fail_open_excluded_route_targets () =
   |> dedupe_keep_order
 
 let active_fail_open_rotation_cascades () =
-  fail_open_rotation_cascades_from_catalog
-    ~excluded_targets:(active_fail_open_excluded_route_targets ())
-    ~catalog_names:(Keeper_cascade_profile.catalog_names ())
-    ~keeper_assignable:(Keeper_cascade_profile.keeper_catalog_names ())
-    ()
+  let qualified_names =
+    match Keeper_cascade_profile.catalog_metadata_query () with
+    | Keeper_cascade_profile.Catalog_ok meta ->
+        meta.Keeper_cascade_profile.qualified_names
+    | Keeper_cascade_profile.Catalog_unavailable _ -> []
+  in
+  let qualify_public_name pub =
+    List.find_opt
+      (fun q -> String.equal (public_profile_name q) pub)
+      qualified_names
+    |> Option.value ~default:pub
+  in
+  match
+    fail_open_rotation_cascades_from_catalog
+      ~excluded_targets:(active_fail_open_excluded_route_targets ())
+      ~catalog_names:(Keeper_cascade_profile.catalog_names ())
+      ~keeper_assignable:(Keeper_cascade_profile.keeper_catalog_names ())
+      ()
+  with
+  | None -> None
+  | Some names -> Some (List.map qualify_public_name names)
 
 let tool_required_rotation_cascade_name () =
   try


### PR DESCRIPTION
## Summary

- `active_fail_open_rotation_cascades` returns qualified cascade names (with `tier-group.`/`tier.` prefix) instead of public names, preventing `Cascade_name.of_string_exn` crash during degraded retry rotation
- The internal filtering logic (`fail_open_rotation_cascades_from_catalog`) still operates on public names as before — only the output is re-qualified via `catalog_metadata_query().qualified_names`

## Root Cause

`Keeper_cascade_profile.catalog_names()` returns public names (prefix-stripped, e.g. `"local_llama"`). These flowed through `active_fail_open_rotation_cascades` → `degraded_retry.next_cascade` → `Cascade_name.of_string_exn`, which only accepts canonical prefixed names (`"tier.local_llama"`).

## Fix

Added a re-qualification step in `active_fail_open_rotation_cascades` that maps each public name back to its qualified counterpart using `catalog_metadata_query().qualified_names`. Falls back to the original name when no qualified match exists (e.g., route names that don't need prefixes).

## Test plan

- [x] `dune build @install` passes
- [x] Pre-existing rotation tests (`fail_open_rotation_cascades_from_catalog_*`) unaffected — they test the unchanged internal function directly
- [x] 5 pre-existing test failures confirmed identical on main (unrelated `"scoring"` bare name issue in `test_provider_capacity_blocked_backlog_count_requ`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)