### PR TITLE
refactor: consolidate 100+ duplicate utility defs into SSOT

### DIFF
--- a/lib/activity_graph/activity_graph_types.ml
+++ b/lib/activity_graph/activity_graph_types.ml
@@ -121,11 +121,7 @@ let entity_of_yojson (json : Yojson.Safe.t) : entity_ref option =
   | Some kind, Some id -> Some { kind; id }
   | _ -> None
 
-let non_empty_string_opt = function
-  | Some value ->
-    let trimmed = String.trim value in
-    if trimmed = "" then None else Some trimmed
-  | None -> None
+let non_empty_string_opt = String_util.option_trim
 
 let json_string_non_empty_opt name json =
   Safe_ops.json_string_opt name json |> non_empty_string_opt

--- a/lib/activity_graph/activity_graph_types.ml
+++ b/lib/activity_graph/activity_graph_types.ml
@@ -121,10 +121,8 @@ let entity_of_yojson (json : Yojson.Safe.t) : entity_ref option =
   | Some kind, Some id -> Some { kind; id }
   | _ -> None
 
-let non_empty_string_opt = String_util.option_trim
-
 let json_string_non_empty_opt name json =
-  Safe_ops.json_string_opt name json |> non_empty_string_opt
+  Safe_ops.json_string_opt name json |> String_util.option_trim
 
 let json_positive_int_opt name json =
   match Safe_ops.json_int_opt name json with
@@ -140,7 +138,7 @@ let assoc_replace name value fields =
   (name, value) :: List.filter (fun (key, _) -> key <> name) fields
 
 let assoc_replace_string_opt name value fields =
-  match non_empty_string_opt value with
+  match String_util.option_trim value with
   | Some value -> assoc_replace name (`String value) fields
   | None -> fields
 

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -27,7 +27,6 @@ open Masc_domain
 
 module SS = Set.Make (String)
 
-let unique_preserve_order = Json_util.dedupe_keep_order
 
 let dedupe_schemas (schemas : Masc_domain.tool_schema list) =
   let unique, _ =
@@ -56,7 +55,7 @@ let lookup_schemas_by_name_exn ~label all_schemas values =
     values
     |> List.map String.trim
     |> List.filter (fun value -> not (String.equal value ""))
-    |> unique_preserve_order
+    |> Json_util.dedupe_keep_order
   in
   let by_name = Hashtbl.create (List.length all_schemas) in
   List.iter
@@ -148,7 +147,7 @@ let resolve_named_schemas all_schemas values :
     values
     |> List.map String.trim
     |> List.filter (fun value -> not (String.equal value ""))
-    |> unique_preserve_order
+    |> Json_util.dedupe_keep_order
   in
   (* Materialise both directions of the membership relation once:
      - [requested_set] for the first filter (per-schema lookup),
@@ -214,7 +213,7 @@ let filter_catalog_to_available ~available names =
   let available = SS.of_list available in
   names
   |> List.filter (fun name -> SS.mem name available)
-  |> unique_preserve_order
+  |> Json_util.dedupe_keep_order
 
 (** Build a role-based tool catalog from the full registered tool set.
     [role] determines which subset of tools the agent sees:
@@ -225,7 +224,7 @@ let filter_catalog_to_available ~available names =
 let build_tool_catalog ~(role : string) () : string list =
   let all_names =
     spawned_agent_public_tool_names @ local_worker_public_tool_names
-    |> unique_preserve_order
+    |> Json_util.dedupe_keep_order
   in
   let filtered =
     match role with
@@ -239,7 +238,7 @@ let build_tool_catalog ~(role : string) () : string list =
         let admin_set = name_set admin_tool_names in
         List.filter (fun name -> not (Hashtbl.mem admin_set name)) all_names
   in
-  unique_preserve_order filtered
+  Json_util.dedupe_keep_order filtered
 
 (** [local_worker_resolvable_tool_names ()] returns only the tool names
     that [local_worker_tool_schemas] can actually resolve.  Use this to

--- a/lib/agent_tool_surfaces.mli
+++ b/lib/agent_tool_surfaces.mli
@@ -35,7 +35,6 @@ module Random = Stdlib.Random
 
 (** {1 Helpers} *)
 
-val unique_preserve_order : string list -> string list
 (** [unique_preserve_order xs] removes duplicates from [xs] while
     preserving first-occurrence order.  Thin alias over
     {!Json_util.dedupe_keep_order} re-exported for siblings. *)

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -167,7 +167,6 @@ let credential_file config agent_name =
 
 module Nickname_helpers = Auth_nickname
 
-let trim_nonempty = Nickname_helpers.trim_nonempty
 let is_generated_nickname_shape = Nickname_helpers.is_generated_nickname_shape
 let keeper_transport_alias_stable_name = Nickname_helpers.keeper_transport_alias_stable_name
 let extract_agent_type_prefix = Nickname_helpers.extract_agent_type_prefix
@@ -412,7 +411,7 @@ let load_raw_token config ~agent_name =
   let file = raw_token_file config agent_name in
   if file_exists file
   then (
-    try read_text_file file |> trim_nonempty with
+    try read_text_file file |> String_util.trim_nonempty with
     | Sys_error _ -> None)
   else None
 ;;

--- a/lib/auth_doctor.ml
+++ b/lib/auth_doctor.ml
@@ -69,17 +69,6 @@ let read_nonempty_text_file path =
       if value = "" then None else Some value
     with Sys_error _ -> None
 
-let dedupe_keep_order values =
-  let seen = Hashtbl.create (List.length values) in
-  List.filter
-    (fun value ->
-      if value = "" || Hashtbl.mem seen value then
-        false
-      else (
-        Hashtbl.replace seen value ();
-        true))
-    values
-
 let option_field name = function
   | Some value -> (name, `String value)
   | None -> (name, `Null)
@@ -119,7 +108,8 @@ let watched_agent_names ~initial_admin admin_token_env_agent =
     admin_token_env_agent;
   ]
   |> List.filter_map Fun.id
-  |> dedupe_keep_order
+  |> List.filter (fun s -> s <> "")
+  |> Json_util.dedupe_keep_order
 
 let admin_token_env_state ~base_path =
   match Env_config_core.admin_token_opt () with
@@ -190,7 +180,8 @@ let admin_bearer_sources ~base_path ~auth_dir ~dashboard_dev_token_available
     |> List.filter_map (live_admin_token_file_source ~base_path ~auth_dir)
   in
   env_sources @ dashboard_sources @ token_file_sources
-  |> dedupe_keep_order
+  |> List.filter (fun s -> s <> "")
+  |> Json_util.dedupe_keep_order
 
 let analyze ~base_path_input ~default_base_path () =
   let normalized_base_path =
@@ -276,7 +267,8 @@ let analyze ~base_path_input ~default_base_path () =
          None);
     ]
     |> List.filter_map Fun.id
-    |> dedupe_keep_order
+    |> List.filter (fun s -> s <> "")
+    |> Json_util.dedupe_keep_order
   in
   let next_actions =
     [
@@ -309,7 +301,7 @@ let analyze ~base_path_input ~default_base_path () =
       Some "Rerun `masc-mcp doctor auth` after editing auth files or rotating tokens.";
     ]
     |> List.filter_map Fun.id
-    |> dedupe_keep_order
+    |> List.filter (fun s -> s <> "") |> Json_util.dedupe_keep_order
   in
   let status =
     if auth_cfg.enabled && auth_cfg.require_token

--- a/lib/auth_nickname.ml
+++ b/lib/auth_nickname.ml
@@ -1,8 +1,5 @@
 (** Generated credential alias nickname helpers for Auth. *)
 
-let trim_nonempty value =
-  let trimmed = String.trim value in
-  if trimmed = "" then None else Some trimmed
 ;;
 let nickname_adjectives =
   [| "swift"
@@ -93,7 +90,7 @@ let extract_generated_nickname_prefix name =
   let join_prefix prefix_rev =
     match List.rev prefix_rev with
     | [] -> None
-    | prefix -> String.concat "-" prefix |> trim_nonempty
+    | prefix -> String.concat "-" prefix |> String_util.trim_nonempty
   in
   match List.rev parts with
   | animal :: adjective :: prefix_rev
@@ -123,7 +120,7 @@ let keeper_transport_alias_stable_name name =
   match String.split_on_char '-' name with
   | "keeper" :: rest ->
     (match List.rev rest with
-     | "agent" :: middle_rev -> List.rev middle_rev |> String.concat "-" |> trim_nonempty
+     | "agent" :: middle_rev -> List.rev middle_rev |> String.concat "-" |> String_util.trim_nonempty
      | _ -> None)
   | _ -> None
 ;;

--- a/lib/auth_nickname.mli
+++ b/lib/auth_nickname.mli
@@ -1,4 +1,3 @@
-val trim_nonempty : string -> string option
 val is_generated_nickname_shape : string -> bool
 val keeper_transport_alias_stable_name : string -> string option
 val extract_agent_type_prefix : string -> string option

--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -19,7 +19,6 @@ let file_name_match_bonus = 0.3
 
 (** {1 String Helpers} *)
 
-let string_contains = Dashboard_utils.string_contains
 
 
 (** {1 Types} *)
@@ -209,8 +208,8 @@ let fetch_from_file_context (room_config : Coord_utils.config) ~query =
     let name_lower = String.lowercase_ascii (Filename.basename path) in
     let content_lower = String.lowercase_ascii content in
     let name_match = if query <> "" && String.length query > 2 &&
-                        (string_contains ~needle:query_lower name_lower ||
-                         string_contains ~needle:query_lower content_lower)
+                        (Dashboard_utils.string_contains ~needle:query_lower name_lower ||
+                         Dashboard_utils.string_contains ~needle:query_lower content_lower)
                      then file_name_match_bonus else 0.0 in
     let recency = 1.0 -. (float_of_int i /. float_of_int (max 1 (List.length files))) in
     min 1.0 (file_base_relevance +. (recency *. file_recency_weight) +. name_match)

--- a/lib/board_core_classify.ml
+++ b/lib/board_core_classify.ml
@@ -65,7 +65,6 @@ let post_kind_of_string = function
   | "system" -> Some System_post
   | _ -> None
 
-let contains_substring = String_util.contains_substring
 
 (** Take at most [n] elements from a list. *)
 let take n lst =
@@ -121,10 +120,10 @@ let automation_label_of_string author =
      match wins so callers reproduce the legacy semantics exactly. *)
   if String.starts_with ~prefix:"auto-" author then Some Auto_prefixed
   else if String.starts_with ~prefix:"qa-" author then Some Qa_prefixed
-  else if contains_substring author "researcher" then Some Researcher_named
-  else if contains_substring author "harness" then Some Harness_named
-  else if contains_substring author "smoke" then Some Smoke_named
-  else if contains_substring author "probe" then Some Probe_named
+  else if String_util.contains_substring author "researcher" then Some Researcher_named
+  else if String_util.contains_substring author "harness" then Some Harness_named
+  else if String_util.contains_substring author "smoke" then Some Smoke_named
+  else if String_util.contains_substring author "probe" then Some Probe_named
   else None
 
 (** [classify_author author] — single boundary parser.  Caller MUST
@@ -219,7 +218,7 @@ let legacy_migrate_post_kind ~meta_json ~author ~visibility ~expires_at ~hearth 
     && Stdlib.Float.compare expires_at 0.0 > 0
     && not (String.equal hearth "")
     && (String.starts_with ~prefix:"mdal" hearth
-        || contains_substring hearth "harness")
+        || String_util.contains_substring hearth "harness")
   in
   match classify_author author with
   | System_author _ -> System_post

--- a/lib/board_core_status_rollup.ml
+++ b/lib/board_core_status_rollup.ml
@@ -39,24 +39,7 @@ let json_assoc_string_opt key = function
   | _ -> None
 ;;
 
-let contains_substring haystack needle =
-  let haystack = String.lowercase_ascii haystack in
-  let needle = String.lowercase_ascii needle in
-  let hay_len = String.length haystack in
-  let needle_len = String.length needle in
-  if needle_len = 0
-  then true
-  else if needle_len > hay_len
-  then false
-  else (
-    let rec loop idx =
-      if idx + needle_len > hay_len
-      then false
-      else if String.equal (String.sub haystack idx needle_len) needle
-      then true
-      else loop (idx + 1)
-    in
-    loop 0)
+let contains_substring = String_util.contains_substring_ci
 ;;
 
 let contains_any_substring text needles =

--- a/lib/board_core_status_rollup.ml
+++ b/lib/board_core_status_rollup.ml
@@ -39,11 +39,10 @@ let json_assoc_string_opt key = function
   | _ -> None
 ;;
 
-let contains_substring = String_util.contains_substring_ci
 ;;
 
 let contains_any_substring text needles =
-  List.exists (contains_substring text) needles
+  List.exists (String_util.contains_substring_ci text) needles
 ;;
 
 let is_task_id_char = function

--- a/lib/briefing_compactors/briefing_compactors.ml
+++ b/lib/briefing_compactors/briefing_compactors.ml
@@ -8,7 +8,7 @@ let status_is_live value =
     [ "running"; "active"; "paused"; "starting"; "stopping"; "waiting" ]
 
 let event_timestamp json =
-  parse_iso_opt (String_util.option_trim (Some (string_field "ts_iso" json)))
+  Dashboard_utils.parse_iso_opt (String_util.option_trim (Some (string_field "ts_iso" json)))
 
 let session_recent_enough ~now_ts session_json =
   let recent_events =

--- a/lib/briefing_compactors/briefing_compactors.ml
+++ b/lib/briefing_compactors/briefing_compactors.ml
@@ -8,7 +8,7 @@ let status_is_live value =
     [ "running"; "active"; "paused"; "starting"; "stopping"; "waiting" ]
 
 let event_timestamp json =
-  parse_iso_opt (trim_to_option (Some (string_field "ts_iso" json)))
+  parse_iso_opt (String_util.option_trim (Some (string_field "ts_iso" json)))
 
 let session_recent_enough ~now_ts session_json =
   let recent_events =
@@ -26,16 +26,16 @@ let session_recent_enough ~now_ts session_json =
 
 let relevant_sessions_for_briefing ~current_namespace ~now_ts sessions =
   let room_matches session_json =
-    match trim_to_option (Some current_namespace) with
+    match String_util.option_trim (Some current_namespace) with
     | None -> true
     | Some project ->
         let status_detail = member_assoc "status" session_json in
         let session_json = member_assoc "session" status_detail in
         let session_project =
-          match trim_to_option (Some (string_field "project" session_json)) with
+          match String_util.option_trim (Some (string_field "project" session_json)) with
           | Some value -> value
           | None ->
-              trim_to_option (Some (string_field "room_id" session_json))
+              String_util.option_trim (Some (string_field "room_id" session_json))
               |> Option.value ~default:""
         in
         String.equal project session_project

--- a/lib/briefing_compactors/briefing_json_helpers.ml
+++ b/lib/briefing_compactors/briefing_json_helpers.ml
@@ -75,8 +75,5 @@ let option_string_json = function
       if trimmed <> "" then `String trimmed else `Null
   | None -> `Null
 
-let trim_to_option = function
-  | Some text -> Dashboard_utils.trim_to_option text
-  | None -> None
 
 let parse_iso_opt = Dashboard_utils.parse_iso_opt

--- a/lib/briefing_compactors/briefing_json_helpers.ml
+++ b/lib/briefing_compactors/briefing_json_helpers.ml
@@ -76,4 +76,3 @@ let option_string_json = function
   | None -> `Null
 
 
-let parse_iso_opt = Dashboard_utils.parse_iso_opt

--- a/lib/briefing_compactors/briefing_json_helpers.mli
+++ b/lib/briefing_compactors/briefing_json_helpers.mli
@@ -10,4 +10,3 @@ val float_json : ?default:float -> Yojson.Safe.t -> Yojson.Safe.t
 val int_field : ?default:int -> string -> Yojson.Safe.t -> int
 val take : int -> 'a list -> 'a list
 val option_string_json : string option -> Yojson.Safe.t
-val parse_iso_opt : string option -> float option

--- a/lib/briefing_compactors/briefing_json_helpers.mli
+++ b/lib/briefing_compactors/briefing_json_helpers.mli
@@ -10,5 +10,4 @@ val float_json : ?default:float -> Yojson.Safe.t -> Yojson.Safe.t
 val int_field : ?default:int -> string -> Yojson.Safe.t -> int
 val take : int -> 'a list -> 'a list
 val option_string_json : string option -> Yojson.Safe.t
-val trim_to_option : string option -> string option
 val parse_iso_opt : string option -> float option

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -36,11 +36,6 @@ let iso8601_of_unix ts =
     tm.Unix.tm_sec
 ;;
 
-let trim_to_option raw =
-  let trimmed = String.trim raw in
-  if trimmed = "" then None else Some trimmed
-;;
-
 let rec find_git_root dir =
   let git_marker = Filename.concat dir ".git" in
   if Sys.file_exists git_marker
@@ -110,7 +105,7 @@ let git_probe_from_root repo_root =
       Log.Identity.warn "git_probe_from_root unexpected: %s" (Printexc.to_string exn);
       None
   in
-  Option.bind output trim_to_option
+  Option.bind output String_util.trim_to_option
 ;;
 
 let observe_probe_failure ~site exn =
@@ -163,7 +158,7 @@ let parse_dune_project_version raw =
         line
         (String.length prefix)
         (String.length line - String.length prefix - String.length ")")
-      |> trim_to_option
+      |> String_util.trim_to_option
     else None)
 ;;
 
@@ -196,7 +191,7 @@ let decimal_digits_only s =
 let max_reasonable_commit_unix_ts = 4_102_444_800L
 
 let parse_commit_unix_ts_output raw =
-  match trim_to_option raw with
+  match String_util.trim_to_option raw with
   | None -> None
   | Some s when not (decimal_digits_only s) -> None
   | Some s ->
@@ -274,7 +269,7 @@ let probe_commit_unix_ts commit_hash_opt =
 let resolve_commit ~env_value ~probe =
   match env_value with
   | Some raw ->
-    (match trim_to_option raw with
+    (match String_util.trim_to_option raw with
      | Some commit -> Some commit
      | None -> probe ())
   | None -> probe ()
@@ -293,7 +288,7 @@ let build_env_commit_source = "env:MASC_BUILD_GIT_COMMIT"
 let runtime_repo_head_source = "runtime_repo_head"
 
 let resolve_commit_details ~env_value ~probe =
-  let binary_commit = Option.bind env_value trim_to_option in
+  let binary_commit = Option.bind env_value String_util.trim_to_option in
   let repo_head_commit = probe () in
   let commit, commit_source =
     match binary_commit, repo_head_commit with

--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -64,7 +64,6 @@ let risk_rank = function
 let max_risk left right =
   if risk_rank left >= risk_rank right then left else right
 
-let unique_preserve_order = Json_util.dedupe_keep_order
 
 let dedupe_schemas (schemas : Masc_domain.tool_schema list) =
   let _, results =
@@ -199,7 +198,7 @@ let public_projection_seeds_from (public_tool_source_schemas : Masc_domain.tool_
         Safe
     in
     let audiences =
-      unique_preserve_order
+      Json_util.dedupe_keep_order
         (External_mcp_client
          :: (if List.mem name spawned_agent_public_tool_names then [ Spawned_managed_agent ] else [])
          @ (if List.mem name local_worker_public_tool_names then [ Local_worker_agent ] else []))
@@ -301,7 +300,7 @@ let all_capabilities_from (public_tool_source_schemas : Masc_domain.tool_schema 
               {
                 capability_id = seed.capability_id;
                 risk_class = seed.risk_class;
-                audiences = unique_preserve_order seed.audiences;
+                audiences = Json_util.dedupe_keep_order seed.audiences;
                 supports_audit_evidence = seed.supports_audit_evidence;
                 supports_direct_user_discovery = seed.supports_direct_user_discovery;
                 projections = [ seed.projection ];
@@ -315,7 +314,7 @@ let all_capabilities_from (public_tool_source_schemas : Masc_domain.tool_schema 
                 capability_id = existing.capability_id;
                 risk_class = max_risk existing.risk_class seed.risk_class;
                 audiences =
-                  unique_preserve_order (existing.audiences @ seed.audiences);
+                  Json_util.dedupe_keep_order (existing.audiences @ seed.audiences);
                 supports_audit_evidence =
                   existing.supports_audit_evidence || seed.supports_audit_evidence;
                 supports_direct_user_discovery =
@@ -387,13 +386,13 @@ let local_worker_tool_schemas ?names () :
 let keeper_all_tool_names : string list =
   Tool_shard.keeper_model_tools
   |> List.map (fun tool -> tool.Masc_domain.name)
-  |> unique_preserve_order
+  |> Json_util.dedupe_keep_order
 
 let keeper_safe_tool_names : string list =
   Tool_shard.keeper_model_tools
   |> List.map (fun tool -> tool.Masc_domain.name)
   |> List.filter (fun name -> not (List.mem name privileged_keeper_tool_names))
-  |> unique_preserve_order
+  |> Json_util.dedupe_keep_order
 
 let keeper_privileged_tool_names : string list =
   privileged_keeper_tool_names

--- a/lib/cascade/cascade_catalog_runtime_json.ml
+++ b/lib/cascade/cascade_catalog_runtime_json.ml
@@ -12,10 +12,8 @@
 
 open Cascade_catalog_runtime_cache
 
-let float_opt_to_json = Json_util.float_opt_to_json
 
 
-let int_opt_to_json = Json_util.int_opt_to_json
 
 let candidate_probe_to_yojson (probe : candidate_probe) =
   `Assoc
@@ -44,8 +42,8 @@ let profile_snapshot_to_yojson (profile : profile_snapshot) =
       ("name", `String profile.name);
       ( "strategy",
         `String (Cascade_strategy.kind_to_string profile.strategy.kind) );
-      ("ollama_max_concurrent", int_opt_to_json profile.ollama_max_concurrent);
-      ("cli_max_concurrent", int_opt_to_json profile.cli_max_concurrent);
+      ("ollama_max_concurrent", Json_util.int_opt_to_json profile.ollama_max_concurrent);
+      ("cli_max_concurrent", Json_util.int_opt_to_json profile.cli_max_concurrent);
       ( "candidates",
         `List (List.map candidate_probe_to_yojson profile.probes) );
     ]
@@ -76,7 +74,7 @@ let rejection_to_yojson (rejection : rejection) =
   `Assoc
     [
       ("source_path", `String rejection.source_path);
-      ("attempted_mtime", float_opt_to_json rejection.attempted_mtime);
+      ("attempted_mtime", Json_util.float_opt_to_json rejection.attempted_mtime);
       ("checked_at", `Float rejection.checked_at);
       ( "errors",
         `List (List.map (fun value -> `String value) rejection.errors) );

--- a/lib/cascade/cascade_catalog_runtime_json.ml
+++ b/lib/cascade/cascade_catalog_runtime_json.ml
@@ -12,13 +12,10 @@
 
 open Cascade_catalog_runtime_cache
 
-let float_opt_to_json = function
-  | Some value -> `Float value
-  | None -> `Null
+let float_opt_to_json = Json_util.float_opt_to_json
 
-let int_opt_to_json = function
-  | Some value -> `Int value
-  | None -> `Null
+
+let int_opt_to_json = Json_util.int_opt_to_json
 
 let candidate_probe_to_yojson (probe : candidate_probe) =
   `Assoc

--- a/lib/cascade/cascade_catalog_runtime_resolve.ml
+++ b/lib/cascade/cascade_catalog_runtime_resolve.ml
@@ -309,21 +309,11 @@ let known_profile_names ?sw ?net ?clock () =
   | Ok snapshot -> Ok (profile_names_of_snapshot snapshot)
   | Error _ as e -> e
 
-let dedupe_keep_order values =
-  let seen = Hashtbl.create (List.length values) in
-  List.filter
-    (fun value ->
-      if value = "" || Hashtbl.mem seen value then false
-      else (
-        Hashtbl.replace seen value ();
-        true))
-    values
-
 let invalid_profile_errors ?sw ?net ?clock () =
   let of_rejection rejection =
     rejection.profiles
     |> List.filter_map (fun (profile : profile_rejection) ->
-           let errors = dedupe_keep_order profile.errors in
+           let errors = List.filter (fun s -> s <> "") profile.errors |> Json_util.dedupe_keep_order in
            if errors = [] then None else Some (profile.name, errors))
   in
   match inspect_active ?sw ?net ?clock () with

--- a/lib/cascade/cascade_event_bridge_error_json.ml
+++ b/lib/cascade/cascade_event_bridge_error_json.ml
@@ -50,7 +50,6 @@ let json_int_opt = function
   | None -> `Null
 ;;
 
-let json_string_list values = `List (List.map (fun value -> `String value) values)
 ;;
 
 let json_contract_violation_detail
@@ -61,10 +60,10 @@ let json_contract_violation_detail
   | Some (detail : Agent_sdk.Completion_contract_violation_detail.t) ->
     `Assoc
       [ ( "called_tools"
-        , json_string_list
+        , Json_util.json_string_list
             detail.Agent_sdk.Completion_contract_violation_detail.called_tools )
       ; ( "satisfying_tools"
-        , json_string_list
+        , Json_util.json_string_list
             detail.Agent_sdk.Completion_contract_violation_detail.satisfying_tools )
       ; ( "rejection_reasons"
         , `List
@@ -323,7 +322,7 @@ let sdk_provider_error_fields error =
     [ "variant", `String "capacity_backpressure"
     ; "message", `String message
     ; "capacity_scope", `String (Llm_provider.Error.capacity_scope_to_string scope)
-    ; "affected", json_string_list affected
+    ; "affected", Json_util.json_string_list affected
     ; "retry_after_s", json_float_opt retry_after
     ; "detail", `String detail
     ]

--- a/lib/cascade/cascade_internal_error.ml
+++ b/lib/cascade/cascade_internal_error.ml
@@ -164,9 +164,7 @@ type masc_internal_error =
 
 let masc_internal_error_prefix = "[masc_oas_error] "
 
-let string_list_json values =
-  `List (List.map (fun value -> `String value) values)
-
+let string_list_json = Json_util.json_string_list
 let string_list_of_assoc key json =
   match Json_field.list json key |> Json_field.to_option with
   | None -> []

--- a/lib/cascade/cascade_internal_error.ml
+++ b/lib/cascade/cascade_internal_error.ml
@@ -164,7 +164,6 @@ type masc_internal_error =
 
 let masc_internal_error_prefix = "[masc_oas_error] "
 
-let string_list_json = Json_util.json_string_list
 let string_list_of_assoc key json =
   match Json_field.list json key |> Json_field.to_option with
   | None -> []
@@ -258,10 +257,10 @@ let masc_internal_error_to_json = function
         ("kind", `String "no_tool_capable_provider");
         ("cascade_name", `String cascade_name);
         ("configured_candidate_count", `Int (List.length configured_labels));
-        ("required_tool_names", string_list_json required_tool_names);
+        ("required_tool_names", Json_util.json_string_list required_tool_names);
         ("rejected_candidate_count", `Int (List.length provider_rejections));
         ("provider_rejections", provider_rejections_json provider_rejections);
-        ("rejection_reasons", string_list_json rejection_reasons);
+        ("rejection_reasons", Json_util.json_string_list rejection_reasons);
       ]
   | Accept_rejected { scope; model; reason } ->
     `Assoc
@@ -331,7 +330,7 @@ let masc_internal_error_to_json = function
       [
         ("kind", `String "ambiguous_post_commit");
         ("is_timeout", `Bool is_timeout);
-        ("tools", string_list_json tools);
+        ("tools", Json_util.json_string_list tools);
         ("original_error", `String original_error);
       ]
   | Retry_admission_denied { denial_reason; is_retry } ->

--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -17,13 +17,10 @@ let provider_name_of_label (label : string) : string option =
       if idx = 0 then None
       else Some (String.sub label 0 idx |> String.trim |> String.lowercase_ascii)
 
-let trim_nonempty value =
-  let trimmed = String.trim value in
-  if String.equal trimmed "" then None else Some trimmed
 ;;
 
 let binding_endpoint_url (binding : Runtime_binding.t) =
-  trim_nonempty binding.Runtime_binding.base_url
+  String_util.trim_nonempty binding.Runtime_binding.base_url
 
 let normalize_provider_id provider_id =
   String.trim provider_id

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -16,9 +16,6 @@ module Runtime_binding = Agent_sdk.Provider_runtime_binding
 
 let unknown_runtime_label = "unknown_provider"
 
-let trim_nonempty value =
-  let trimmed = String.trim value in
-  if String.equal trimmed "" then None else Some trimmed
 
 let normalize_provider_id provider_id =
   String.trim provider_id
@@ -31,7 +28,7 @@ let runtime_binding_of_label label =
   | None -> Runtime_binding.find (normalize_provider_id label)
 
 let binding_endpoint_url (binding : Runtime_binding.t) =
-  trim_nonempty binding.Runtime_binding.base_url
+  String_util.trim_nonempty binding.Runtime_binding.base_url
 
 let binding_auth_is_no_auth (binding : Runtime_binding.t) =
   match binding.Runtime_binding.auth with
@@ -450,7 +447,7 @@ let local_runtime_url candidate =
   then None
   else
     candidate.provider_cfg.base_url
-    |> trim_nonempty
+    |> String_util.trim_nonempty
     |> Option.map Masc_network_defaults.normalize_loopback_base_url
 
 let local_runtime_urls candidates =

--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -43,8 +43,6 @@ let toml_type_name = function
 ;;
 
 let errorf fmt = Printf.ksprintf (fun msg -> Error msg) fmt
-let json_string_list values = `List (List.map (fun value -> `String value) values)
-
 let table_fields ~path = function
   | Otoml.TomlTable fields | Otoml.TomlInlineTable fields -> Ok fields
   | value -> errorf "expected %s to be a TOML table, found %s" path (toml_type_name value)

--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -80,9 +80,8 @@ let dedupe_preserve_order (items : string list) =
 ;;
 
 let upsert_http_header = Cascade_transport_authorization.upsert_http_header
-(* trim_nonempty + first_nonempty_env + runtime-MCP policy header helpers
+(* String_util.trim_nonempty + first_nonempty_env + runtime-MCP policy header helpers
    extracted to [Cascade_transport_mcp_policy_helpers] (godfile decomp). *)
-let trim_nonempty = Cascade_transport_mcp_policy_helpers.trim_nonempty
 let first_nonempty_env = Cascade_transport_mcp_policy_helpers.first_nonempty_env
 let keeper_name_of_agent_name = Cascade_transport_authorization.keeper_name_of_agent_name
 

--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -132,9 +132,7 @@ let tool_names_are_runtime_mcp =
   Cascade_transport_mcp_tool_classifier.tool_names_are_runtime_mcp
 ;;
 
-let trim_nonempty_string raw =
-  let trimmed = String.trim raw in
-  if String.equal trimmed "" then None else Some trimmed
+let trim_nonempty_string = String_util.trim_nonempty
 ;;
 
 let runtime_mcp_policy_of_tool_names = Cascade_transport_runtime_mcp_policy_of_tool_names.runtime_mcp_policy_of_tool_names

--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -132,7 +132,6 @@ let tool_names_are_runtime_mcp =
   Cascade_transport_mcp_tool_classifier.tool_names_are_runtime_mcp
 ;;
 
-let trim_nonempty_string = String_util.trim_nonempty
 ;;
 
 let runtime_mcp_policy_of_tool_names = Cascade_transport_runtime_mcp_policy_of_tool_names.runtime_mcp_policy_of_tool_names
@@ -172,7 +171,7 @@ let resolve_tool_lane_for_oas_tools
   =
   let public_tools = public_mcp_tools_of_oas_tools tools in
   let public_tool_names = public_mcp_tool_names_of_oas_tools public_tools in
-  let requested_agent_name = Option.bind agent_name trim_nonempty_string in
+  let requested_agent_name = Option.bind agent_name String_util.trim_nonempty in
   let keeper_internal_tool_names =
     match requested_agent_name with
     | Some agent_name when Option.is_some (keeper_name_of_agent_name agent_name) ->

--- a/lib/cascade/cascade_transport_cli_config.ml
+++ b/lib/cascade/cascade_transport_cli_config.ml
@@ -1,9 +1,3 @@
-let trim_nonempty value =
-  match value with
-  | Some raw ->
-    let trimmed = String.trim raw in
-    if String.equal trimmed "" then None else Some trimmed
-  | None -> None
 ;;
 
 let dedupe_preserve_order (items : string list) =
@@ -36,11 +30,11 @@ let provider_config_runtime_binding (provider_cfg : Llm_provider.Provider_config
 ;;
 
 let runtime_binding_default_model (binding : Agent_sdk.Provider_runtime_binding.t) =
-  match trim_nonempty binding.default_model with
+  match String_util.option_trim binding.default_model with
   | Some model -> Some model
   | None ->
     (match binding.capabilities.supported_models with
-     | Some (model :: _) -> trim_nonempty (Some model)
+     | Some (model :: _) -> String_util.option_trim (Some model)
      | Some [] | None -> None)
 ;;
 
@@ -52,7 +46,7 @@ let cli_model_for_provider_config (provider_cfg : Llm_provider.Provider_config.t
 
 let cli_command_for_provider_config provider_cfg =
   Option.bind (provider_config_runtime_binding provider_cfg) (fun binding ->
-    trim_nonempty binding.Agent_sdk.Provider_runtime_binding.command)
+    String_util.option_trim binding.Agent_sdk.Provider_runtime_binding.command)
 ;;
 
 let basename_of_command command =
@@ -71,7 +65,7 @@ let cli_process_name_for_provider_config provider_cfg =
 
 let nonempty_opt value =
   match value with
-  | Some value -> trim_nonempty (Some value)
+  | Some value -> String_util.option_trim (Some value)
   | None -> None
 ;;
 
@@ -115,7 +109,7 @@ let auth_env_names_of_binding (binding : Agent_sdk.Provider_runtime_binding.t) =
     | Agent_sdk.Provider_runtime_binding.Exec _ -> []
   in
   binding.api_key_env :: auth_env
-  |> List.filter_map (fun env -> trim_nonempty (Some env))
+  |> List.filter_map (fun env -> String_util.option_trim (Some env))
   |> dedupe_preserve_order
 ;;
 
@@ -143,14 +137,14 @@ let binding_api_base_url (binding : Agent_sdk.Provider_runtime_binding.t) =
 ;;
 
 let first_nonempty_env names =
-  List.find_map (fun name -> Sys.getenv_opt name |> trim_nonempty) names
+  List.find_map (fun name -> Sys.getenv_opt name |> String_util.option_trim) names
 ;;
 
 let cli_direct_auth_value
       ?(direct_binding = direct_binding_for_cli_provider_config)
       (provider_cfg : Llm_provider.Provider_config.t)
   =
-  match trim_nonempty (Some provider_cfg.api_key) with
+  match String_util.option_trim (Some provider_cfg.api_key) with
   | Some key -> Some key
   | None ->
     (match direct_binding provider_cfg with

--- a/lib/cascade/cascade_transport_mcp_policy_helpers.ml
+++ b/lib/cascade/cascade_transport_mcp_policy_helpers.ml
@@ -11,16 +11,10 @@
 let upsert_http_header = Cascade_transport_authorization.upsert_http_header
 let keeper_name_of_agent_name = Cascade_transport_authorization.keeper_name_of_agent_name
 
-let trim_nonempty value =
-  match value with
-  | Some raw ->
-    let trimmed = String.trim raw in
-    if String.equal trimmed "" then None else Some trimmed
-  | None -> None
 ;;
 
 let first_nonempty_env names =
-  List.find_map (fun name -> Sys.getenv_opt name |> trim_nonempty) names
+  List.find_map (fun name -> Sys.getenv_opt name |> String_util.option_trim) names
 ;;
 
 let runtime_mcp_policy_with_masc_agent_name

--- a/lib/cascade/cascade_transport_mcp_policy_helpers.mli
+++ b/lib/cascade/cascade_transport_mcp_policy_helpers.mli
@@ -1,6 +1,5 @@
 (** Runtime-MCP policy header helpers, extracted from [Cascade_transport]. *)
 
-val trim_nonempty : string option -> string option
 (** Trim an optional string and return [None] for blank values. *)
 
 val first_nonempty_env : string list -> string option

--- a/lib/cascade/cascade_transport_runtime_mcp_policy_of_tool_names.ml
+++ b/lib/cascade/cascade_transport_runtime_mcp_policy_of_tool_names.ml
@@ -35,7 +35,6 @@ let dedupe_preserve_order (items : string list) =
 
 (* Duplicated locally for the same reason — 4-line idempotent helper
    used only by this sibling. *)
-let trim_nonempty_string = String_util.trim_nonempty
 ;;
 
 let runtime_mcp_policy_of_tool_names
@@ -51,7 +50,7 @@ let runtime_mcp_policy_of_tool_names
   if not (Mcp_tool_classifier.tool_names_are_runtime_mcp ~allow_keeper_internal tool_names)
   then None
   else (
-    let agent_name = Option.bind agent_name trim_nonempty_string in
+    let agent_name = Option.bind agent_name String_util.trim_nonempty in
     let keeper_name = Option.bind agent_name Authorization.keeper_name_of_agent_name in
     let internal_keeper_token =
       Mcp_policy_helpers.first_nonempty_env [ "MASC_INTERNAL_MCP_TOKEN" ]

--- a/lib/cascade/cascade_transport_runtime_mcp_policy_of_tool_names.ml
+++ b/lib/cascade/cascade_transport_runtime_mcp_policy_of_tool_names.ml
@@ -35,9 +35,7 @@ let dedupe_preserve_order (items : string list) =
 
 (* Duplicated locally for the same reason — 4-line idempotent helper
    used only by this sibling. *)
-let trim_nonempty_string raw =
-  let trimmed = String.trim raw in
-  if String.equal trimmed "" then None else Some trimmed
+let trim_nonempty_string = String_util.trim_nonempty
 ;;
 
 let runtime_mcp_policy_of_tool_names

--- a/lib/cascade/provider_capability.ml
+++ b/lib/cascade/provider_capability.ml
@@ -31,16 +31,8 @@ let strip_mcp_prefix name =
 
 let canonical_tool_name name = strip_mcp_prefix (String.trim name)
 
-let dedupe_keep_order values =
-  let rec loop seen acc = function
-    | [] -> List.rev acc
-    | value :: rest when List.mem value seen -> loop seen acc rest
-    | value :: rest -> loop (value :: seen) (value :: acc) rest
-  in
-  loop [] [] values
-
 let dedupe_canonical tools =
-  tools |> List.map canonical_tool_name |> dedupe_keep_order
+  tools |> List.map canonical_tool_name |> Json_util.dedupe_keep_order
 
 let known ~provider_name ~satisfying_tools ~tool_choice_support =
   {

--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -10,10 +10,6 @@ type issue = {
 
 module StringMap = Map.Make (String)
 
-let contains_substring ~needle s =
-  (* Empty needle returns false here, distinct from String_util.contains_substring's
-     Re-compatible empty=true.  Guard preserves the original validator contract. *)
-  String.length needle > 0 && String_util.contains_substring s needle
 
 let has_suffix ~suffix s =
   (* Original strict-greater length: rejects [s = suffix] case where the
@@ -22,7 +18,7 @@ let has_suffix ~suffix s =
   String.length s > String.length suffix && String.ends_with ~suffix s
 
 let is_provider_unavailable_error msg =
-  contains_substring ~needle:"unavailable" msg
+  String_util.contains_substring msg "unavailable"
 
 let split_provider_model (s : string) : (string * string) option =
   match String.index_opt s ':' with
@@ -560,17 +556,6 @@ let diagnose_catalog ~config_path =
 let diagnose_catalog_for_diagnostics ~config_path =
   diagnose_catalog_impl ~emit_telemetry:false ~config_path
 
-let dedupe_keep_order values =
-  let seen = Hashtbl.create (List.length values) in
-  List.filter
-    (fun value ->
-      if value = "" || Hashtbl.mem seen value then
-        false
-      else (
-        Hashtbl.replace seen value ();
-        true))
-    values
-
 let error_messages_by_profile ~config_path =
   diagnose_catalog ~config_path
   |> List.fold_left
@@ -587,4 +572,4 @@ let error_messages_by_profile ~config_path =
        StringMap.empty
   |> StringMap.bindings
   |> List.map (fun (profile, messages) ->
-         (profile, dedupe_keep_order messages))
+         (profile, List.filter (fun s -> s <> "") messages |> Json_util.dedupe_keep_order))

--- a/lib/cdal/adversarial_eval.ml
+++ b/lib/cdal/adversarial_eval.ml
@@ -56,7 +56,6 @@ let normalize_path path =
   String.map (fun c -> if c = '\\' then '/' else c) path
   |> String.lowercase_ascii
 
-let contains_substring = String_util.contains_substring
 
 let has_doc_extension path =
   List.exists (Filename.check_suffix path) doc_extensions
@@ -121,13 +120,13 @@ let classify_path path =
   in
   let has_room_history =
     has_history_artifact_extension lower
-    && List.exists (contains_substring normalized)
+    && List.exists (String_util.contains_substring normalized)
          [ "room_history"; "room-history"; "roomtaskhistory"; "room_task_history";
            "room-task-history" ]
   in
   let has_task_history =
     has_history_artifact_extension lower
-    && List.exists (contains_substring normalized)
+    && List.exists (String_util.contains_substring normalized)
          [ "task_history"; "task-history"; "taskhistory"; "room/task_history";
            "room/task-history" ]
   in
@@ -135,7 +134,7 @@ let classify_path path =
     (List.mem "governance" basename_tokens
      && has_data_artifact_extension lower)
     || (has_history_artifact_extension lower
-        && List.exists (contains_substring normalized) [ "session_log"; "session-log" ])
+        && List.exists (String_util.contains_substring normalized) [ "session_log"; "session-log" ])
     || (List.mem "retrospective" basename_tokens && has_history_artifact_extension lower)
   in
   if check_patterns banned_readme_patterns then Some Readme

--- a/lib/cdal/cdal_types.ml
+++ b/lib/cdal/cdal_types.ml
@@ -120,10 +120,7 @@ let list_field key of_item fields =
                        (Yojson.Safe.to_string j))
   | None -> Ok []
 
-let option_to_json f = function
-  | Some v -> f v
-  | None -> `Null
-
+let option_to_json = Json_util.option_to_yojson
 (* ================================================================ *)
 (* contract_finding JSON                                             *)
 (* ================================================================ *)

--- a/lib/cdal/cdal_types.ml
+++ b/lib/cdal/cdal_types.ml
@@ -120,7 +120,6 @@ let list_field key of_item fields =
                        (Yojson.Safe.to_string j))
   | None -> Ok []
 
-let option_to_json = Json_util.option_to_yojson
 (* ================================================================ *)
 (* contract_finding JSON                                             *)
 (* ================================================================ *)
@@ -128,10 +127,10 @@ let option_to_json = Json_util.option_to_yojson
 let contract_finding_to_json (f : contract_finding) : Yojson.Safe.t =
   Yojson.Safe.sort (`Assoc [
     ("check_id", `String f.check_id);
-    ("event_id", option_to_json (fun s -> `String s) f.event_id);
+    ("event_id", Json_util.option_to_yojson (fun s -> `String s) f.event_id);
     ("expected", f.expected);
     ("observed", f.observed);
-    ("trace_ref", option_to_json (fun s -> `String s) f.trace_ref);
+    ("trace_ref", Json_util.option_to_yojson (fun s -> `String s) f.trace_ref);
   ])
 
 let contract_finding_of_json = function

--- a/lib/cdal_runtime/effect_evidence.ml
+++ b/lib/cdal_runtime/effect_evidence.ml
@@ -148,8 +148,8 @@ let make
 ;;
 
 let option_to_json f = function
+  | Some value -> f value
   | None -> `Null
-  | Some v -> f v
 ;;
 
 let to_json t =

--- a/lib/cdal_runtime/effect_evidence.ml
+++ b/lib/cdal_runtime/effect_evidence.ml
@@ -147,7 +147,7 @@ let make
   }
 ;;
 
-let option_to_json f = function
+let option_to_yojson f = function
   | Some value -> f value
   | None -> `Null
 ;;
@@ -162,16 +162,16 @@ let to_json t =
     ; "decision_source", `String t.decision_source
     ; "input_hash", `String t.input_hash
     ; "input_summary", `String t.input_summary
-    ; "sandbox", option_to_json (fun v -> `String v) t.sandbox
-    ; "workdir", option_to_json (fun v -> `String v) t.workdir
-    ; "source_path", option_to_json (fun v -> `String v) t.source_path
-    ; "source_line", option_to_json (fun v -> `Int v) t.source_line
+    ; "sandbox", option_to_yojson (fun v -> `String v) t.sandbox
+    ; "workdir", option_to_yojson (fun v -> `String v) t.workdir
+    ; "source_path", option_to_yojson (fun v -> `String v) t.source_path
+    ; "source_line", option_to_yojson (fun v -> `Int v) t.source_line
     ; "started_at", `Float t.started_at
-    ; "ended_at", option_to_json (fun v -> `Float v) t.ended_at
+    ; "ended_at", option_to_yojson (fun v -> `Float v) t.ended_at
     ; "result_status", `String (result_status_to_string t.result_status)
-    ; "violation_kind", option_to_json (fun v -> `String v) t.violation_kind
-    ; "turn", option_to_json (fun v -> `Int v) t.turn
-    ; "execution_mode", option_to_json (fun v -> `String v) t.execution_mode
+    ; "violation_kind", option_to_yojson (fun v -> `String v) t.violation_kind
+    ; "turn", option_to_yojson (fun v -> `Int v) t.turn
+    ; "execution_mode", option_to_yojson (fun v -> `String v) t.execution_mode
     ]
 ;;
 

--- a/lib/cdal_runtime_health.ml
+++ b/lib/cdal_runtime_health.ml
@@ -1,13 +1,9 @@
-let null = `Null
 module Proof_store = Masc_mcp_cdal_runtime.Proof_store
 
-let float_opt_to_json = function
-  | None -> null
-  | Some value -> `Float value
-;;
+let float_opt_to_json = Json_util.float_opt_to_json
 
 let time_opt_to_json = function
-  | None -> null
+  | None -> `Null
   | Some value -> `String (Masc_domain.iso8601_of_unix_seconds value)
 ;;
 

--- a/lib/cdal_runtime_health.ml
+++ b/lib/cdal_runtime_health.ml
@@ -1,7 +1,5 @@
 module Proof_store = Masc_mcp_cdal_runtime.Proof_store
 
-let float_opt_to_json = Json_util.float_opt_to_json
-
 let time_opt_to_json = function
   | None -> `Null
   | Some value -> `String (Masc_domain.iso8601_of_unix_seconds value)
@@ -299,8 +297,8 @@ let proof_store_root_json
     ; "proofs_dir", `String proofs_dir
     ; "exists", `Bool exists
     ; "latest_activity_at", time_opt_to_json latest_mtime
-    ; "latest_activity_unix", float_opt_to_json latest_mtime
-    ; "age_seconds", float_opt_to_json age_seconds
+    ; "latest_activity_unix", Json_util.float_opt_to_json latest_mtime
+    ; "age_seconds", Json_util.float_opt_to_json age_seconds
     ; "status", `String status
     ; "completeness", completeness
     ]
@@ -426,9 +424,9 @@ let ledger_json ?base_dir ~now ~stale_age_seconds () =
   `Assoc
     [ "base_dir", `String report.base_dir
     ; "total_files", `Int report.total_files
-    ; "latest_mtime", float_opt_to_json report.latest_mtime
+    ; "latest_mtime", Json_util.float_opt_to_json report.latest_mtime
     ; "latest_at", time_opt_to_json report.latest_mtime
-    ; "age_seconds", float_opt_to_json report.age_seconds
+    ; "age_seconds", Json_util.float_opt_to_json report.age_seconds
     ; "status", `String status
     ; "stale_age_seconds", `Float stale_age_seconds
     ; "checked_at", `String (Masc_domain.iso8601_of_unix_seconds now)

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -86,17 +86,6 @@ let has_blocking_warning (report : t) =
   | Error -> true
   | Warn -> List.exists warning_is_blocking report.warnings
 
-let dedupe_keep_order values =
-  let seen = Hashtbl.create (List.length values) in
-  List.filter
-    (fun value ->
-      if value = "" || Hashtbl.mem seen value then
-        false
-      else (
-        Hashtbl.replace seen value ();
-        true))
-    values
-
 let canonicalize_path ~cwd path =
   let absolute =
     if Filename.is_relative path then Filename.concat cwd path else path
@@ -120,7 +109,7 @@ let repo_config_seed_path (inputs : inputs) =
   ]
   |> List.filter_map (fun path_opt ->
          Option.map (canonicalize_path ~cwd:inputs.cwd) path_opt)
-  |> dedupe_keep_order
+  |> List.filter (fun s -> s <> "") |> Json_util.dedupe_keep_order
   |> function
   | first :: _ -> Some first
   | [] -> None
@@ -387,7 +376,7 @@ let analyze_with (inputs : inputs) =
     |> fun base_warnings ->
     base_warnings
     @ List.map (fun issue -> issue.message) cascade_catalog_issues
-    |> dedupe_keep_order
+    |> List.filter (fun s -> s <> "") |> Json_util.dedupe_keep_order
   in
   let cascade_actions =
     cascade_catalog_next_actions
@@ -465,7 +454,7 @@ let analyze_with (inputs : inputs) =
     |> fun base_actions ->
     base_actions
     @ cascade_actions
-    |> dedupe_keep_order
+    |> List.filter (fun s -> s <> "") |> Json_util.dedupe_keep_order
   in
   let has_catalog_errors =
     List.exists
@@ -779,7 +768,7 @@ let analyze_live ~sw ~net ~clock ~fs ~proc_mgr ~base_path_input
         ]
     in
     report.next_actions @ catalog_actions @ tool_route_actions @ sandbox_actions
-    |> dedupe_keep_order
+    |> List.filter (fun s -> s <> "") |> Json_util.dedupe_keep_order
   in
   let status =
     match report.init_state, report.status, live_outcome, sandbox_preflight_ok with

--- a/lib/coord/coord_state.ml
+++ b/lib/coord/coord_state.ml
@@ -5,7 +5,7 @@
     - Sequence counter (next_seq)
     - Pause state (is_paused, pause_info)
     - State recovery (recover_room_state)
-    - Shared string utilities (non_empty_string_opt, normalized_string_list)
+    - Shared string utilities (String_util.option_trim, normalized_string_list)
 
     Extracted to separate modules:
     - Coord_bootstrap: default_room_state, ensure_room_bootstrap
@@ -39,12 +39,10 @@ let write_backlog = Coord_backlog.write_backlog
 (* Shared String Utilities                      *)
 (* ============================================ *)
 
-let non_empty_string_opt = String_util.option_trim
-
 let normalized_string_list values =
   let seen = Hashtbl.create (List.length values) in
   values
-  |> List.filter_map (fun value -> non_empty_string_opt (Some value))
+  |> List.filter_map (fun value -> String_util.option_trim (Some value))
   |> List.filter (fun value ->
          if Hashtbl.mem seen value then
            false
@@ -57,12 +55,12 @@ let normalized_string_list values =
 (* ============================================ *)
 
 let recover_active_agent_name = function
-  | `String name -> non_empty_string_opt (Some name)
+  | `String name -> String_util.option_trim (Some name)
   | `Assoc _ as json ->
-      (match non_empty_string_opt (Safe_ops.json_string_opt "name" json) with
+      (match String_util.option_trim (Safe_ops.json_string_opt "name" json) with
        | Some name -> Some name
        | None ->
-           non_empty_string_opt (Safe_ops.json_string_opt "agent_name" json))
+           String_util.option_trim (Safe_ops.json_string_opt "agent_name" json))
   | _ -> None
 
 let recover_room_state config json =
@@ -74,26 +72,26 @@ let recover_room_state config json =
   in
   {
     protocol_version =
-      non_empty_string_opt (Safe_ops.json_string_opt "protocol_version" json)
+      String_util.option_trim (Safe_ops.json_string_opt "protocol_version" json)
       |> Option.value ~default:defaults.protocol_version;
     project =
-      non_empty_string_opt (Safe_ops.json_string_opt "project" json)
+      String_util.option_trim (Safe_ops.json_string_opt "project" json)
       |> Option.value ~default:defaults.project;
     started_at =
-      non_empty_string_opt (Safe_ops.json_string_opt "started_at" json)
+      String_util.option_trim (Safe_ops.json_string_opt "started_at" json)
       |> Option.value ~default:defaults.started_at;
     message_seq = Safe_ops.json_int ~default:defaults.message_seq "message_seq" json;
     active_agents;
     paused = Safe_ops.json_bool ~default:defaults.paused "paused" json;
     pause_reason =
-      non_empty_string_opt (Safe_ops.json_string_opt "pause_reason" json);
+      String_util.option_trim (Safe_ops.json_string_opt "pause_reason" json);
     paused_by =
-      non_empty_string_opt (Safe_ops.json_string_opt "paused_by" json);
+      String_util.option_trim (Safe_ops.json_string_opt "paused_by" json);
     paused_at =
-      non_empty_string_opt (Safe_ops.json_string_opt "paused_at" json);
+      String_util.option_trim (Safe_ops.json_string_opt "paused_at" json);
     search_strategy_default =
       (match
-         non_empty_string_opt
+         String_util.option_trim
            (Safe_ops.json_string_opt "search_strategy_default" json)
        with
        | Some value -> Some value

--- a/lib/coord/coord_state.ml
+++ b/lib/coord/coord_state.ml
@@ -39,11 +39,7 @@ let write_backlog = Coord_backlog.write_backlog
 (* Shared String Utilities                      *)
 (* ============================================ *)
 
-let non_empty_string_opt = function
-  | Some value ->
-      let value = String.trim value in
-      if value = "" then None else Some value
-  | None -> None
+let non_empty_string_opt = String_util.option_trim
 
 let normalized_string_list values =
   let seen = Hashtbl.create (List.length values) in

--- a/lib/coord/coord_state.mli
+++ b/lib/coord/coord_state.mli
@@ -33,7 +33,6 @@ val read_backlog : Coord_utils_backend_setup.config -> Masc_domain.backlog
 val write_backlog :
   Coord_utils_backend_setup.config -> Masc_domain.backlog -> unit
 
-val non_empty_string_opt : string option -> string option
 val normalized_string_list : string list -> string list
 
 (** Project a JSON entry of the [active_agents] array to the agent

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -17,7 +17,6 @@ include Coord_task_create
 include Coord_task_claim
 
 let flatten_lock_result = Coord_task_verification.flatten_lock_result
-let contains_substring_ci = String_util.contains_substring_ci
 let is_placeholder_verification_evidence = Coord_task_verification.is_placeholder_verification_evidence
 let text_has_verification_artifact_ref = Coord_task_verification.text_has_verification_artifact_ref
 let evidence_ref_has_verification_artifact_ref = Coord_task_verification.evidence_ref_has_verification_artifact_ref

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -17,7 +17,7 @@ include Coord_task_create
 include Coord_task_claim
 
 let flatten_lock_result = Coord_task_verification.flatten_lock_result
-let contains_substring_ci = Coord_task_verification.contains_substring_ci
+let contains_substring_ci = String_util.contains_substring_ci
 let is_placeholder_verification_evidence = Coord_task_verification.is_placeholder_verification_evidence
 let text_has_verification_artifact_ref = Coord_task_verification.text_has_verification_artifact_ref
 let evidence_ref_has_verification_artifact_ref = Coord_task_verification.evidence_ref_has_verification_artifact_ref

--- a/lib/coord/coord_task_verification.ml
+++ b/lib/coord/coord_task_verification.ml
@@ -11,18 +11,7 @@ let flatten_lock_result = function
   | Ok result -> result
   | Error e -> Error e
 
-let contains_substring_ci text needle =
-  let text = String.lowercase_ascii text in
-  let needle = String.lowercase_ascii needle in
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  let rec loop idx =
-    if needle_len = 0 then true
-    else if idx + needle_len > text_len then false
-    else if String.equal (String.sub text idx needle_len) needle then true
-    else loop (idx + 1)
-  in
-  loop 0
+let contains_substring_ci = String_util.contains_substring_ci
 
 let is_placeholder_verification_evidence value =
   let value = value |> String.trim |> String.lowercase_ascii in

--- a/lib/coord/coord_task_verification.ml
+++ b/lib/coord/coord_task_verification.ml
@@ -11,7 +11,6 @@ let flatten_lock_result = function
   | Ok result -> result
   | Error e -> Error e
 
-let contains_substring_ci = String_util.contains_substring_ci
 
 let is_placeholder_verification_evidence value =
   let value = value |> String.trim |> String.lowercase_ascii in
@@ -23,18 +22,18 @@ let is_placeholder_verification_evidence value =
 let text_has_verification_artifact_ref text =
   let text = String.trim text in
   let has_github_pull =
-    contains_substring_ci text "github.com/"
-    && contains_substring_ci text "/pull/"
+    String_util.contains_substring_ci text "github.com/"
+    && String_util.contains_substring_ci text "/pull/"
   in
   let has_pr_shorthand =
-    contains_substring_ci text "#"
-    && (contains_substring_ci text "pr "
-        || contains_substring_ci text "pr:"
-        || contains_substring_ci text "pull request")
+    String_util.contains_substring_ci text "#"
+    && (String_util.contains_substring_ci text "pr "
+        || String_util.contains_substring_ci text "pr:"
+        || String_util.contains_substring_ci text "pull request")
   in
   let has_explicit_artifact =
     [ "artifact:"; "artifact://"; "file:"; "path:"; "commit:"; "branch:" ]
-    |> List.exists (contains_substring_ci text)
+    |> List.exists (String_util.contains_substring_ci text)
   in
   has_github_pull || has_pr_shorthand || has_explicit_artifact
 
@@ -42,7 +41,7 @@ let evidence_ref_has_verification_artifact_ref value =
   let value = String.trim value in
   (not (is_placeholder_verification_evidence value))
   && (text_has_verification_artifact_ref value
-      || contains_substring_ci value "github.com/"
+      || String_util.contains_substring_ci value "github.com/"
       || String.contains value '/'
       || String.contains value '.')
 

--- a/lib/coord/coord_task_verification.mli
+++ b/lib/coord/coord_task_verification.mli
@@ -1,7 +1,6 @@
 (** Verification-evidence helpers for coord task lifecycle. *)
 
 val flatten_lock_result : (('a, 'b) result, 'b) result -> ('a, 'b) result
-val contains_substring_ci : string -> string -> bool
 val is_placeholder_verification_evidence : string -> bool
 val text_has_verification_artifact_ref : string -> bool
 val evidence_ref_has_verification_artifact_ref : string -> bool

--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -2,7 +2,6 @@ open Masc_domain
 open Coord_utils_backend_setup
 open Coord_utils_paths_backend
 
-let contains_substring = String_util.contains_substring
 
 let validate_agent_name name =
   match Validation.Agent_id.validate name with
@@ -31,9 +30,9 @@ let validate_room_id room_id =
   if room_id = "" then Error "Coord id cannot be empty"
   else if String.length room_id > 128 then Error "Coord id too long (max 128 chars)"
   else if room_id = "." || room_id = ".." then Error "Coord id cannot be '.' or '..'"
-  else if contains_substring room_id "/" || contains_substring room_id "\\" then
+  else if String_util.contains_substring room_id "/" || String_util.contains_substring room_id "\\" then
     Error "Coord id cannot contain path separators"
-  else if contains_substring room_id ".." then
+  else if String_util.contains_substring room_id ".." then
     Error "Coord id cannot contain traversal segments"
   else if not (Re.execp room_id_allowed_re room_id) then
     Error "Coord id may only contain letters, digits, dot, underscore, and hyphen"
@@ -43,7 +42,7 @@ let validate_file_path path =
   (* Delegate to Validation module for consistent security checks *)
   (* Additional length check for file paths *)
   if String.length path > 500 then Error "File path too long (max 500 chars)"
-  else if contains_substring path "<" || contains_substring path ">" then
+  else if String_util.contains_substring path "<" || String_util.contains_substring path ">" then
     Error "Invalid characters in path (security)"
   else Validation.Safe_path.validate_relative path
 
@@ -102,7 +101,7 @@ let validate_task_id_r id : (string, masc_error) result =
 let validate_file_path_r path : (string, masc_error) result =
   (* Delegate to Validation module, convert error type *)
   if String.length path > 500 then Error (System (System_error.InvalidFilePath "too long (max 500 chars)"))
-  else if contains_substring path "<" || contains_substring path ">" then
+  else if String_util.contains_substring path "<" || String_util.contains_substring path ">" then
     Error (System (System_error.InvalidFilePath "invalid characters (security)"))
   else match Validation.Safe_path.validate_relative path with
   | Ok _ -> Ok path

--- a/lib/coord/coord_utils_ops.mli
+++ b/lib/coord/coord_utils_ops.mli
@@ -5,7 +5,6 @@
 open Masc_domain
 open Coord_utils_backend_setup
 
-val contains_substring : string -> string -> bool
 
 (** {1 Validators (string-error)} *)
 

--- a/lib/coord/coord_worktree_repo_discovery.ml
+++ b/lib/coord/coord_worktree_repo_discovery.ml
@@ -167,7 +167,6 @@ let repository_aliases_for_candidate config ~repo_name =
 (* Route to the SSOT helper rather than allocating String.sub on every
    step.  Keeps semantics aligned across modules (empty needle returns
    true). *)
-let contains_substring = String_util.contains_substring
 
 let task_repo_text (task : task) =
   let handoff_texts =
@@ -198,7 +197,7 @@ let task_path_hints (task : task) =
     task_repo_text task
     |> tokenize_repo_evidence
     |> List.filter (fun token ->
-           contains_substring token "/"
+           String_util.contains_substring token "/"
            && Filename.is_relative token
            && not (has_parent_segment token))
   in

--- a/lib/core/json_util.mli
+++ b/lib/core/json_util.mli
@@ -60,11 +60,12 @@ val parse_json_or_string : string -> Yojson.Safe.t
 
     Canonical [None -> `Null] converters for building JSON. *)
 
-val option_to_yojson : ('a -> Yojson.Safe.t) -> 'a option -> Yojson.Safe.t
-val int_opt_to_json : int option -> Yojson.Safe.t
 val string_opt_to_json : string option -> Yojson.Safe.t
+val int_opt_to_json : int option -> Yojson.Safe.t
 val float_opt_to_json : float option -> Yojson.Safe.t
 val bool_opt_to_json : bool option -> Yojson.Safe.t
+val option_to_yojson : ('a -> Yojson.Safe.t) -> 'a option -> Yojson.Safe.t
+(** Higher-order: [option_to_yojson f] maps [f] over [Some] or returns [`Null]. *)
 
 (** {1 Diagnostic helpers}
 

--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -186,6 +186,20 @@ let was_truncated = function
   | Untouched _ -> false
   | Truncated _ -> true
 
+let trim_nonempty value =
+  let v = String.trim value in
+  if v = "" then None else Some v
+
+let trim_to_option value =
+  let v = String.trim value in
+  if v = "" then None else Some v
+
+let option_trim = function
+  | None -> None
+  | Some s ->
+    let v = String.trim s in
+    if v = "" then None else Some v
+
 (* XML 1.0 entity escape.  Order matters: [&] first so that the
    ampersands introduced by the other replacements are not
    double-escaped. *)

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -69,6 +69,18 @@ val to_string : truncation -> string
 val was_truncated : truncation -> bool
 (** [true] iff the argument is the [Truncated] constructor. *)
 
+val trim_nonempty : string -> string option
+(** [trim_nonempty s] trims whitespace and returns [Some s] if non-empty,
+    [None] otherwise. SSOT for the per-module [trim_nonempty] helpers. *)
+
+val trim_to_option : string -> string option
+(** [trim_to_option s] is an alias for [trim_nonempty]. Both are identical;
+    [trim_to_option] is kept for migration compatibility. *)
+
+val option_trim : string option -> string option
+(** [option_trim opt] maps [trim_nonempty] over an option.
+    [None] stays [None]; [Some s] becomes [None] if all whitespace. *)
+
 val escape_xml : string -> string
 (** Escape the five XML 1.0 predefined entities: ampersand,
     less-than, greater-than, double-quote, and apostrophe.

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -357,7 +357,7 @@ let keeper_queue_last_seen keeper trust =
       ; string_field_opt "created_at" keeper
       ]
   in
-  last_seen_at, parse_iso_opt last_seen_at |> Option.value ~default:0.0
+  last_seen_at, Dashboard_utils.parse_iso_opt last_seen_at |> Option.value ~default:0.0
 ;;
 
 let build_keeper_execution_queue keepers =

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -79,7 +79,7 @@ let worker_state_of_agent
   let key = String.lowercase_ascii (String.trim agent.name) in
   let message_opt = Hashtbl.find_opt messages_by_agent key in
   let last_seen_ts =
-    parse_iso_opt (String_util.trim_to_option agent.last_seen) |> Option.value ~default:0.0
+    Dashboard_utils.parse_iso_opt (String_util.trim_to_option agent.last_seen) |> Option.value ~default:0.0
   in
   let last_message_ts =
     match message_opt with
@@ -160,7 +160,7 @@ let worker_state_of_agent
   in
   let (emoji, korean_name) = get_agent_identity agent.name in
   {
-    tone_rank = tone_rank tone;
+    tone_rank = Dashboard_utils.tone_rank tone;
     last_signal_ts;
     related_session_id;
     json =
@@ -177,7 +177,7 @@ let worker_state_of_agent
             | Some meta -> json_string_option meta.keeper_id
             | None -> `Null);
           ("status", `String status_string);
-          ("tone", `String (string_of_tone tone));
+          ("tone", `String (Dashboard_utils.string_of_tone tone));
           ("state", `String state);
           ("note", `String note);
           ("focus", `String focus);
@@ -226,8 +226,8 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
       ]
   in
   let last_signal_at = latest_iso_timestamp [ last_action_at; last_heartbeat_at ] in
-  let last_action_ts = parse_iso_opt last_action_at |> Option.value ~default:0.0 in
-  let last_signal_ts = parse_iso_opt last_signal_at |> Option.value ~default:0.0 in
+  let last_action_ts = Dashboard_utils.parse_iso_opt last_action_at |> Option.value ~default:0.0 in
+  let last_signal_ts = Dashboard_utils.parse_iso_opt last_signal_at |> Option.value ~default:0.0 in
   let last_action_age_s =
     if last_action_ts > 0.0 then max 0.0 (now_ts -. last_action_ts)
     else infinity
@@ -244,7 +244,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
   let generation = int_field "generation" keeper in
   let goal_count = List.length (list_field "active_goal_ids" keeper) in
   let lifecycle =
-    if is_keeper_offline status then Lc_offline
+    if Dashboard_utils.is_keeper_offline status then Lc_offline
     else if Option.value ~default:0.0 context_ratio >= ctx_handoff_imminent then Lc_handoff_imminent
     else if Option.value ~default:0.0 context_ratio >= ctx_preparing then Lc_preparing
     else if Option.value ~default:0.0 context_ratio >= ctx_compacting then Lc_compacting
@@ -253,7 +253,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
     else Lc_idle
   in
   let (state, tone, note) =
-    if is_keeper_offline status then
+    if Dashboard_utils.is_keeper_offline status then
       (Exec_critical, Tone_bad, "keeper 오프라인")
     else
       match lifecycle with
@@ -311,7 +311,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
   let skill_route_summary = skill_route_summary_of_keeper keeper in
   let (emoji, korean_name) = get_agent_identity name in
   {
-    tone_rank = tone_rank tone;
+    tone_rank = Dashboard_utils.tone_rank tone;
     last_signal_ts;
     related_session_id;
     json =
@@ -321,7 +321,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
            ("agent_name", member_assoc "agent_name" keeper);
            ("keeper_id", member_assoc "keeper_id" keeper);
            ("status", `String status);
-           ("tone", `String (string_of_tone tone));
+           ("tone", `String (Dashboard_utils.string_of_tone tone));
            ("state", `String (keeper_exec_state_to_string state));
            ("note", `String note);
            ("focus", `String focus);
@@ -329,7 +329,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
            ("last_autonomous_action_at", json_string_option last_signal_at);
            ("generation", member_assoc "generation" keeper);
            ("turn_count", member_assoc "turn_count" keeper);
-           ("context_ratio", option_to_json (fun value -> `Float value) context_ratio);
+           ("context_ratio", Json_util.option_to_yojson (fun value -> `Float value) context_ratio);
            ("continuity", `String continuity);
            ("lifecycle", `String (keeper_lifecycle_to_string lifecycle));
            ("related_session_id", json_string_option related_session_id);
@@ -340,7 +340,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
          ]
         @ tool_preview_fields "allowed_tool" allowed_tool_names
         @ [
-            ("latest_tool_call_count", option_to_json (fun value -> `Int value) audit.latest_tool_call_count);
+            ("latest_tool_call_count", Json_util.option_to_yojson (fun value -> `Int value) audit.latest_tool_call_count);
             ("latest_action_source", json_string_option latest_action_source);
             ("tool_audit_source", json_string_option audit.tool_audit_source);
             ("tool_audit_at", json_string_option audit.tool_audit_at);
@@ -432,7 +432,7 @@ let build_operation_contexts ~(tasks : Masc_domain.task list) =
              Option.bind links.session_id (fun value -> String_util.trim_to_option value)
            in
            let last_seen_ts =
-             parse_iso_opt (Some updated_at) |> Option.value ~default:0.0
+             Dashboard_utils.parse_iso_opt (Some updated_at) |> Option.value ~default:0.0
            in
            Some
              {
@@ -452,7 +452,7 @@ let build_operation_contexts ~(tasks : Masc_domain.task list) =
                      ("updated_at", `String updated_at);
                      ("source", `String "task_contract");
                      ("task_id", `String task.id);
-                     ("severity", `String (string_of_tone severity));
+                     ("severity", `String (Dashboard_utils.string_of_tone severity));
                      ("linked_session_id", json_string_option linked_session_id);
                      ("linked_detachment_id", `Null);
                      ( "handoff",
@@ -466,7 +466,7 @@ let build_operation_contexts ~(tasks : Masc_domain.task list) =
                    ];
              })
   |> List.sort (fun left right ->
-         let by_tone = Int.compare (tone_rank right.severity) (tone_rank left.severity) in
+         let by_tone = Int.compare (Dashboard_utils.tone_rank right.severity) (Dashboard_utils.tone_rank left.severity) in
          if by_tone <> 0 then by_tone
          else Float.compare right.last_seen_ts left.last_seen_ts)
 

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -79,7 +79,7 @@ let worker_state_of_agent
   let key = String.lowercase_ascii (String.trim agent.name) in
   let message_opt = Hashtbl.find_opt messages_by_agent key in
   let last_seen_ts =
-    parse_iso_opt (trim_to_option agent.last_seen) |> Option.value ~default:0.0
+    parse_iso_opt (String_util.trim_to_option agent.last_seen) |> Option.value ~default:0.0
   in
   let last_message_ts =
     match message_opt with
@@ -91,10 +91,10 @@ let worker_state_of_agent
     if last_signal_ts <= 0.0 then None
     else if last_message_ts >= last_seen_ts then
       match message_opt with
-      | Some (_, message) -> trim_to_option message.timestamp
-      | None -> trim_to_option agent.last_seen
+      | Some (_, message) -> String_util.trim_to_option message.timestamp
+      | None -> String_util.trim_to_option agent.last_seen
     else
-      trim_to_option agent.last_seen
+      String_util.trim_to_option agent.last_seen
   in
   let signal_age_s =
     if last_signal_ts > 0.0 then max 0.0 (now_ts -. last_signal_ts)
@@ -119,11 +119,11 @@ let worker_state_of_agent
   let active_task_count = active_task_count tasks agent.name in
   let recent_output_preview =
     match message_opt with
-    | Some (_, message) -> trim_to_option (compact_text message.content)
+    | Some (_, message) -> String_util.trim_to_option (compact_text message.content)
     | None -> None
   in
   let has_work =
-    Option.is_some (trim_to_option (Option.value ~default:"" agent.current_task))
+    Option.is_some (String_util.trim_to_option (Option.value ~default:"" agent.current_task))
     || active_task_count > 0
   in
   let status_string = Masc_domain.string_of_agent_status agent.status in
@@ -149,7 +149,7 @@ let worker_state_of_agent
           ("watching", Tone_ok, "Standing by for the next task")
   in
   let focus =
-    match trim_to_option (Option.value ~default:"" agent.current_task) with
+    match String_util.trim_to_option (Option.value ~default:"" agent.current_task) with
     | Some value -> value
     | None ->
         if active_task_count > 0 then
@@ -200,7 +200,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
     continuity_context =
   let name = string_field "name" keeper in
   let agent_name =
-    match trim_to_option (string_field "agent_name" keeper) with
+    match String_util.trim_to_option (string_field "agent_name" keeper) with
     | Some value -> value
     | None -> name
   in
@@ -214,14 +214,14 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
     | _ -> None
   in
   let last_action_at =
-    trim_to_option (string_field "last_autonomous_action_at" keeper)
+    String_util.trim_to_option (string_field "last_autonomous_action_at" keeper)
   in
   let last_heartbeat_at =
     latest_iso_timestamp
       [
-        trim_to_option (string_field "updated_at" keeper);
-        trim_to_option (string_field "last_seen" agent);
-        trim_to_option (string_field "tool_audit_at" keeper);
+        String_util.trim_to_option (string_field "updated_at" keeper);
+        String_util.trim_to_option (string_field "last_seen" agent);
+        String_util.trim_to_option (string_field "tool_audit_at" keeper);
         audit.tool_audit_at;
       ]
   in
@@ -276,19 +276,19 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
       generation turn_count autonomous_turn_count autonomous_action_count goal_count
   in
   let focus =
-    match trim_to_option (string_field "short_goal" keeper) with
+    match String_util.trim_to_option (string_field "short_goal" keeper) with
     | Some value -> value
     | None -> (
-        match trim_to_option (string_field "goal" keeper) with
+        match String_util.trim_to_option (string_field "goal" keeper) with
         | Some value -> value
         | None -> "현재 포커스 없음")
   in
   let recent_input_preview =
-    trim_to_option (string_field "recent_input_preview" keeper)
+    String_util.trim_to_option (string_field "recent_input_preview" keeper)
   in
   let recent_output_preview =
-    trim_to_option (string_field "recent_output_preview" keeper)
-    |> option_or_else (fun () -> trim_to_option (string_field "last_proactive_preview" keeper))
+    String_util.trim_to_option (string_field "recent_output_preview" keeper)
+    |> option_or_else (fun () -> String_util.trim_to_option (string_field "last_proactive_preview" keeper))
   in
   let recent_tool_names =
     let keeper_tools = string_list_of_field "recent_tool_names" keeper in
@@ -305,7 +305,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
     |> cap_string_list
   in
   let latest_action_source =
-    trim_to_option (string_field "latest_action_source" keeper)
+    String_util.trim_to_option (string_field "latest_action_source" keeper)
     |> option_or_else (fun () -> audit.latest_action_source)
   in
   let skill_route_summary = skill_route_summary_of_keeper keeper in
@@ -353,7 +353,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
             ("proactive_cooldown_sec", member_assoc "proactive_cooldown_sec" keeper);
             ("last_proactive_preview", member_assoc "last_proactive_preview" keeper);
             ("continuity_summary", `String (
-              match trim_to_option (string_field "continuity_summary" keeper) with
+              match String_util.trim_to_option (string_field "continuity_summary" keeper) with
               | Some s -> s
               | None ->
                 if autonomous_turn_count = 0 && turn_count = 0 then
@@ -370,12 +370,12 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
                     autonomous_turn_count autonomous_action_count turn_count generation noop_note));
             ("skill_route_summary", json_string_option skill_route_summary);
             ( "model",
-              match trim_to_option (string_field "active_model" keeper) with
+              match String_util.trim_to_option (string_field "active_model" keeper) with
               | Some value -> `String value
               | None -> `Null );
             ("emoji", `String emoji);
             ("korean_name", `String korean_name);
-            ("skill_reason", json_string_option (trim_to_option (string_field "goal" keeper)));
+            ("skill_reason", json_string_option (String_util.trim_to_option (string_field "goal" keeper)));
           ]);
   }
 
@@ -413,7 +413,7 @@ let task_operation_links (task : Masc_domain.task) =
 
 let task_operation_id (task : Masc_domain.task) =
   let links = task_operation_links task in
-  match trim_to_option (Option.value ~default:"" links.operation_id) with
+  match String_util.trim_to_option (Option.value ~default:"" links.operation_id) with
   | Some operation_id -> operation_id
   | None -> task.id
 
@@ -429,7 +429,7 @@ let build_operation_contexts ~(tasks : Masc_domain.task list) =
            let severity = task_operation_severity task in
            let stage = Option.map Task_stage.to_string task.stage in
            let linked_session_id =
-             Option.bind links.session_id (fun value -> trim_to_option value)
+             Option.bind links.session_id (fun value -> String_util.trim_to_option value)
            in
            let last_seen_ts =
              parse_iso_opt (Some updated_at) |> Option.value ~default:0.0
@@ -512,7 +512,7 @@ let build_continuity_briefs ~(now_ts : float) keepers session_contexts :
              match related_session with
              | Some session -> Some session.session_id
              | None -> (
-                 match trim_to_option (string_field "agent_name" keeper) with
+                 match String_util.trim_to_option (string_field "agent_name" keeper) with
                  | Some agent_name -> (
                      match related_session_for_member session_contexts agent_name with
                      | Some session -> Some session.session_id

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -335,8 +335,8 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
            ("related_session_id", json_string_option related_session_id);
            ("recent_input_preview", json_string_option recent_input_preview);
            ("recent_output_preview", json_string_option recent_output_preview);
-           ("recent_tool_names", string_list_json recent_tool_names);
-           ("latest_tool_names", string_list_json latest_tool_names);
+           ("recent_tool_names", Json_util.json_string_list recent_tool_names);
+           ("latest_tool_names", Json_util.json_string_list latest_tool_names);
          ]
         @ tool_preview_fields "allowed_tool" allowed_tool_names
         @ [

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -145,9 +145,7 @@ let latest_iso_timestamp values =
   |> List.fold_left pick_latest None
   |> Option.map fst
 
-let string_list_json values =
-  `List (List.map (fun value -> `String value) values)
-
+let string_list_json = Json_util.json_string_list
 let string_list_of_field key json =
   member_assoc key json |> string_list_of_json
 

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -81,7 +81,6 @@ let option_or_else fallback = function
   | Some _ as value -> value
   | None -> fallback ()
 
-let option_to_json = Json_util.option_to_yojson
 let member_assoc key json =
   match json with
   | `Assoc fields -> (match List.assoc_opt key fields with Some value -> value | None -> `Null)
@@ -125,15 +124,13 @@ let compact_text ?(max_len = 160) raw =
   if normalized = "" then ""
   else String_util.utf8_safe ~max_bytes:((max_len - 1) + 3) ~suffix:"…" normalized |> String_util.to_string
 
-let parse_iso_opt = Dashboard_utils.parse_iso_opt
-let string_list_of_json = Dashboard_utils.string_list_of_json
 
 let latest_iso_timestamp values =
   let pick_latest best candidate =
     match candidate with
     | None -> best
     | Some candidate -> (
-        match parse_iso_opt (Some candidate) with
+        match Dashboard_utils.parse_iso_opt (Some candidate) with
         | None -> best
         | Some candidate_ts -> (
             match best with
@@ -146,17 +143,10 @@ let latest_iso_timestamp values =
   |> Option.map fst
 
 let string_list_of_field key json =
-  member_assoc key json |> string_list_of_json
+  member_assoc key json |> Dashboard_utils.string_list_of_json
 
 (** Status/health predicates — re-exported from Dashboard_utils (SSOT). *)
-let is_keeper_offline = Dashboard_utils.is_keeper_offline
-let is_health_critical = Dashboard_utils.is_health_critical
-let is_health_warning = Dashboard_utils.is_health_warning
-let is_health_at_risk = Dashboard_utils.is_health_at_risk
-let is_session_terminal = Dashboard_utils.is_session_terminal
-let is_session_blocked = Dashboard_utils.is_session_blocked
 
-let string_of_tone = Dashboard_utils.string_of_tone
 
 let execution_tool_preview_limit = 8
 
@@ -217,14 +207,13 @@ let dedup_strings items =
   List.sort_uniq String.compare
     (List.filter_map String_util.trim_to_option items)
 
-(** severity_rank works on raw JSON strings — broader matching than tone_rank.
+(** severity_rank works on raw JSON strings — broader matching than Dashboard_utils.tone_rank.
     Used by dashboard_mission / dashboard_mission_assembly for external JSON data. *)
 let severity_rank = function
   | "bad" | "critical" | "failed" -> 2
   | "warn" | "blocked" | "paused" | "interrupted" -> 1
   | _ -> 0
 
-let tone_rank = Dashboard_utils.tone_rank
 
 let dashboard_fixture_name ?fixture () =
   let fixtures_enabled = Env_config.Dashboard_config.fixtures_enabled () in

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -81,10 +81,7 @@ let option_or_else fallback = function
   | Some _ as value -> value
   | None -> fallback ()
 
-let option_to_json f = function
-  | Some value -> f value
-  | None -> `Null
-
+let option_to_json = Json_util.option_to_yojson
 let member_assoc key json =
   match json with
   | `Assoc fields -> (match List.assoc_opt key fields with Some value -> value | None -> `Null)

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -145,7 +145,6 @@ let latest_iso_timestamp values =
   |> List.fold_left pick_latest None
   |> Option.map fst
 
-let string_list_json = Json_util.json_string_list
 let string_list_of_field key json =
   member_assoc key json |> string_list_of_json
 
@@ -168,7 +167,7 @@ let tool_preview_fields ?(limit = execution_tool_preview_limit) field values =
   let preview = cap_string_list ~limit values in
   [
     (field ^ "_count", `Int (List.length values));
-    (field ^ "_preview", string_list_json preview);
+    (field ^ "_preview", Json_util.json_string_list preview);
   ]
 
 let tool_audit_snapshot agent_name =

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -116,8 +116,6 @@ let list_field key json =
   | `List items -> items
   | _ -> []
 
-let trim_to_option = Dashboard_utils.trim_to_option
-
 let compact_text ?(max_len = 160) raw =
   let normalized =
     String.trim raw
@@ -191,15 +189,15 @@ let tool_audit_snapshot agent_name =
 let skill_route_summary_of_keeper keeper =
   let route = member_assoc "skill_route" keeper in
   let primary =
-    trim_to_option (string_field "primary" route)
-    |> option_or_else (fun () -> trim_to_option (string_field "skill_primary" keeper))
+    String_util.trim_to_option (string_field "primary" route)
+    |> option_or_else (fun () -> String_util.trim_to_option (string_field "skill_primary" keeper))
   in
   let secondary =
     let route_secondary = string_list_of_field "secondary" route in
     if route_secondary <> [] then route_secondary
     else string_list_of_field "skill_secondary" keeper
   in
-  let provenance = trim_to_option (string_field "provenance" route) in
+  let provenance = String_util.trim_to_option (string_field "provenance" route) in
   match primary, secondary, provenance with
   | None, [], None -> None
   | Some value, [], None -> Some value
@@ -223,7 +221,7 @@ let skill_route_summary_of_keeper keeper =
 
 let dedup_strings items =
   List.sort_uniq String.compare
-    (List.filter_map trim_to_option items)
+    (List.filter_map String_util.trim_to_option items)
 
 (** severity_rank works on raw JSON strings — broader matching than tone_rank.
     Used by dashboard_mission / dashboard_mission_assembly for external JSON data. *)

--- a/lib/dashboard/dashboard_execution_helpers.mli
+++ b/lib/dashboard/dashboard_execution_helpers.mli
@@ -161,7 +161,6 @@ val string_list_of_field : string -> Yojson.Safe.t -> string list
 
 val option_or_else : (unit -> 'a option) -> 'a option -> 'a option
 val take : int -> 'a list -> 'a list
-val trim_to_option : string -> string option
 val parse_iso_opt : string option -> float option
 val latest_iso_timestamp : string option list -> string option
 val compact_text : ?max_len:int -> string -> string

--- a/lib/dashboard/dashboard_execution_helpers.mli
+++ b/lib/dashboard/dashboard_execution_helpers.mli
@@ -50,8 +50,6 @@ type tone = Dashboard_utils.tone =
     constructors regardless of which alias they reach
     them through. *)
 
-val string_of_tone : tone -> string
-val tone_rank : tone -> int
 
 (** {1 Per-entity context records} *)
 
@@ -147,20 +145,17 @@ val get_agent_identity : string -> string * string
 (** {1 JSON envelope helpers} *)
 
 val json_string_option : string option -> Yojson.Safe.t
-val option_to_json : ('a -> Yojson.Safe.t) -> 'a option -> Yojson.Safe.t
 val member_assoc : string -> Yojson.Safe.t -> Yojson.Safe.t
 val string_field : ?default:string -> string -> Yojson.Safe.t -> string
 val string_field_opt : string -> Yojson.Safe.t -> string option
 val int_field : ?default:int -> string -> Yojson.Safe.t -> int
 val list_field : string -> Yojson.Safe.t -> Yojson.Safe.t list
-val string_list_of_json : Yojson.Safe.t -> string list
 val string_list_of_field : string -> Yojson.Safe.t -> string list
 
 (** {1 Misc helpers} *)
 
 val option_or_else : (unit -> 'a option) -> 'a option -> 'a option
 val take : int -> 'a list -> 'a list
-val parse_iso_opt : string option -> float option
 val latest_iso_timestamp : string option list -> string option
 val compact_text : ?max_len:int -> string -> string
 val dedup_strings : string list -> string list
@@ -173,12 +168,6 @@ val tool_preview_fields :
 
 (** {1 Health predicates} *)
 
-val is_keeper_offline : string -> bool
-val is_health_critical : Dashboard_utils.health_level -> bool
-val is_health_warning : Dashboard_utils.health_level -> bool
-val is_health_at_risk : Dashboard_utils.health_level -> bool
-val is_session_terminal : Dashboard_utils.session_lifecycle -> bool
-val is_session_blocked : Dashboard_utils.session_lifecycle -> bool
 
 (** {1 Tool audit + skill route} *)
 

--- a/lib/dashboard/dashboard_execution_helpers.mli
+++ b/lib/dashboard/dashboard_execution_helpers.mli
@@ -154,7 +154,6 @@ val string_field_opt : string -> Yojson.Safe.t -> string option
 val int_field : ?default:int -> string -> Yojson.Safe.t -> int
 val list_field : string -> Yojson.Safe.t -> Yojson.Safe.t list
 val string_list_of_json : Yojson.Safe.t -> string list
-val string_list_json : string list -> Yojson.Safe.t
 val string_list_of_field : string -> Yojson.Safe.t -> string list
 
 (** {1 Misc helpers} *)

--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -25,13 +25,13 @@ let session_communication_json session_json =
 let session_status_string session_json =
   let summary = session_summary_json session_json in
   let meta = session_meta_json session_json in
-  match trim_to_option (string_field "status" summary) with
+  match String_util.trim_to_option (string_field "status" summary) with
   | Some value -> value
   | None -> (
-      match trim_to_option (string_field "status" meta) with
+      match String_util.trim_to_option (string_field "status" meta) with
       | Some value -> value
       | None ->
-          trim_to_option (string_field "status" session_json)
+          String_util.trim_to_option (string_field "status" session_json)
           |> Option.value
                ~default:"<missing status field in summary / meta / session>")
 
@@ -44,23 +44,23 @@ let event_detail_json event_json =
 let event_summary event_json =
   let detail = event_detail_json event_json in
   let event_type =
-    trim_to_option (string_field "event_type" event_json)
+    String_util.trim_to_option (string_field "event_type" event_json)
     |> Option.value ~default:"event"
   in
   let actor =
-    match trim_to_option (string_field "actor" detail) with
+    match String_util.trim_to_option (string_field "actor" detail) with
     | Some value -> Some value
-    | None -> trim_to_option (string_field "agent" detail)
+    | None -> String_util.trim_to_option (string_field "agent" detail)
   in
   let task_title =
-    match trim_to_option (string_field "task_title" detail) with
+    match String_util.trim_to_option (string_field "task_title" detail) with
     | Some value -> Some value
-    | None -> trim_to_option (string_field "title" detail)
+    | None -> String_util.trim_to_option (string_field "title" detail)
   in
-  let result = trim_to_option (compact_text (string_field "result" detail)) in
-  let reason = trim_to_option (compact_text (string_field "reason" detail)) in
+  let result = String_util.trim_to_option (compact_text (string_field "result" detail)) in
+  let reason = String_util.trim_to_option (compact_text (string_field "reason" detail)) in
   let output_preview =
-    trim_to_option (compact_text (string_field "output_preview" detail))
+    String_util.trim_to_option (compact_text (string_field "output_preview" detail))
   in
   match task_title, result, reason, output_preview with
   | Some title, _, _, _ ->
@@ -102,11 +102,11 @@ let build_session_seed session_json _cards =
       recent_events
       |> List.sort (fun left right ->
              let right_ts =
-               parse_iso_opt (trim_to_option (string_field "ts_iso" right))
+               parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" right))
                |> Option.value ~default:0.0
              in
              let left_ts =
-               parse_iso_opt (trim_to_option (string_field "ts_iso" left))
+               parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" left))
                |> Option.value ~default:0.0
              in
              Float.compare right_ts left_ts)
@@ -133,10 +133,10 @@ let build_session_seed session_json _cards =
     in
     let attention_summary =
       Option.bind top_attention (fun json ->
-          trim_to_option (string_field "summary" json))
+          String_util.trim_to_option (string_field "summary" json))
     in
     let attention_kind =
-      Option.bind top_attention (fun json -> trim_to_option (string_field "kind" json))
+      Option.bind top_attention (fun json -> String_util.trim_to_option (string_field "kind" json))
     in
     let runtime_blocker =
       match attention_kind, attention_summary with
@@ -151,7 +151,7 @@ let build_session_seed session_json _cards =
       | _ -> None
     in
     let mode =
-      trim_to_option (string_field "mode" communication)
+      String_util.trim_to_option (string_field "mode" communication)
       |> Option.value ~default:"mode n/a"
     in
     let broadcast_count = int_field "broadcast_count" communication in
@@ -180,28 +180,28 @@ let build_session_seed session_json _cards =
       {
         session_id;
         goal =
-          trim_to_option (string_field "goal" meta)
+          String_util.trim_to_option (string_field "goal" meta)
           |> Option.value ~default:session_id;
         namespace =
-          (match trim_to_option (string_field "project" meta) with
+          (match String_util.trim_to_option (string_field "project" meta) with
           | Some _ as value -> value
-          | None -> trim_to_option (string_field "room_id" meta));
+          | None -> String_util.trim_to_option (string_field "room_id" meta));
         status = session_status_string session_json;
         health =
           (match session_card with
           | Some card ->
-              trim_to_option (string_field "health" card)
+              String_util.trim_to_option (string_field "health" card)
               |> Option.value ~default:"ok"
           | None ->
-              trim_to_option (string_field "status" team_health)
+              String_util.trim_to_option (string_field "status" team_health)
               |> Option.value ~default:"ok");
         member_names;
         last_activity_at =
           Option.bind last_event (fun json ->
-              trim_to_option (string_field "ts_iso" json));
+              String_util.trim_to_option (string_field "ts_iso" json));
         last_activity_ts =
           Option.bind last_event (fun json ->
-              parse_iso_opt (trim_to_option (string_field "ts_iso" json)))
+              parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" json)))
           |> Option.value ~default:0.0;
         last_activity_summary =
           (match last_event with
@@ -336,13 +336,13 @@ let build_session_contexts seeds operation_contexts : session_context list =
          else Float.compare right.last_seen_ts left.last_seen_ts)
 
 let queue_summary_of_session (session_context : session_context) =
-  match trim_to_option (string_field "runtime_blocker" session_context.json) with
+  match String_util.trim_to_option (string_field "runtime_blocker" session_context.json) with
   | Some summary -> summary
   | None -> (
-      match trim_to_option (string_field "worker_gap_summary" session_context.json) with
+      match String_util.trim_to_option (string_field "worker_gap_summary" session_context.json) with
       | Some summary -> summary
       | None ->
-          trim_to_option (string_field "last_activity_summary" session_context.json)
+          String_util.trim_to_option (string_field "last_activity_summary" session_context.json)
           |> Option.value ~default:(string_field "goal" session_context.json))
 
 let build_execution_queue session_contexts operation_contexts =
@@ -397,7 +397,7 @@ let build_execution_queue session_contexts operation_contexts =
                    ("severity", `String (string_of_tone operation.severity));
                    ("status", member_assoc "status" operation.json);
                    ( "summary",
-                     match trim_to_option (string_field "blocker_summary" operation.json) with
+                     match String_util.trim_to_option (string_field "blocker_summary" operation.json) with
                      | Some summary -> `String summary
                      | None -> member_assoc "objective" operation.json );
                    ("target_type", `String "operation");

--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -77,11 +77,11 @@ let event_summary event_json =
 let session_severity ~(health : Dashboard_utils.health_level)
     ~(status : Dashboard_utils.session_lifecycle) ~runtime_blocker =
   if status = SL_completed then
-    if is_health_critical health || is_health_warning health then Tone_warn
+    if Dashboard_utils.is_health_critical health || Dashboard_utils.is_health_warning health then Tone_warn
     else Tone_ok
-  else if is_health_critical health || is_session_blocked status then
+  else if Dashboard_utils.is_health_critical health || Dashboard_utils.is_session_blocked status then
     Tone_bad
-  else if is_health_warning health
+  else if Dashboard_utils.is_health_warning health
           || status = SL_paused
           || Option.is_some runtime_blocker
   then
@@ -102,11 +102,11 @@ let build_session_seed session_json _cards =
       recent_events
       |> List.sort (fun left right ->
              let right_ts =
-               parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" right))
+               Dashboard_utils.parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" right))
                |> Option.value ~default:0.0
              in
              let left_ts =
-               parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" left))
+               Dashboard_utils.parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" left))
                |> Option.value ~default:0.0
              in
              Float.compare right_ts left_ts)
@@ -159,19 +159,19 @@ let build_session_seed session_json _cards =
     let seen_count = int_field "seen_agents_count" summary in
     let member_names =
       dedup_strings
-        (string_list_of_json (member_assoc "agent_names" meta)
-        @ string_list_of_json (member_assoc "active_agents" summary)
-        @ string_list_of_json (member_assoc "planned_participants" summary))
+        (Dashboard_utils.string_list_of_json (member_assoc "agent_names" meta)
+        @ Dashboard_utils.string_list_of_json (member_assoc "active_agents" summary)
+        @ Dashboard_utils.string_list_of_json (member_assoc "planned_participants" summary))
     in
     let planned_count =
       let planned =
-        string_list_of_json (member_assoc "planned_participants" summary)
+        Dashboard_utils.string_list_of_json (member_assoc "planned_participants" summary)
       in
       let explicit = List.length planned in
       if explicit > 0 then explicit else List.length member_names
     in
     let counts_basis =
-      if string_list_of_json (member_assoc "planned_participants" summary) <> [] then
+      if Dashboard_utils.string_list_of_json (member_assoc "planned_participants" summary) <> [] then
         "live=recent_turns · planned=planned_participants"
       else
         "live=recent_turns · planned=known_members"
@@ -201,7 +201,7 @@ let build_session_seed session_json _cards =
               String_util.trim_to_option (string_field "ts_iso" json));
         last_activity_ts =
           Option.bind last_event (fun json ->
-              parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" json)))
+              Dashboard_utils.parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" json)))
           |> Option.value ~default:0.0;
         last_activity_summary =
           (match last_event with
@@ -329,8 +329,8 @@ let build_session_contexts seeds operation_contexts : session_context list =
   |> List.sort (fun (left : session_context) (right : session_context) ->
          let by_severity =
            Int.compare
-             (tone_rank right.severity)
-             (tone_rank left.severity)
+             (Dashboard_utils.tone_rank right.severity)
+             (Dashboard_utils.tone_rank left.severity)
          in
          if by_severity <> 0 then by_severity
          else Float.compare right.last_seen_ts left.last_seen_ts)
@@ -356,20 +356,20 @@ let build_execution_queue session_contexts operation_contexts =
     |> List.filter (fun (session : session_context) -> session.severity <> Tone_ok)
     |> List.map (fun (session : session_context) ->
            {
-             severity_rank = tone_rank session.severity;
+             severity_rank = Dashboard_utils.tone_rank session.severity;
              last_seen_ts = session.last_seen_ts;
              json =
                `Assoc
                  [
                    ("id", `String ("session-" ^ session.session_id));
                    ("kind", `String "session");
-                   ("severity", `String (string_of_tone session.severity));
+                   ("severity", `String (Dashboard_utils.string_of_tone session.severity));
                    ("status", member_assoc "status" session.json);
                    ("summary", `String (queue_summary_of_session session));
                    ("target_type", `String "operation");
                    ("target_id", `String session.session_id);
                    ("linked_session_id", `String session.session_id);
-                   ("linked_operation_id", option_to_json (fun value -> `String value) session.linked_operation_id);
+                   ("linked_operation_id", Json_util.option_to_yojson (fun value -> `String value) session.linked_operation_id);
                    ("last_seen_at", member_assoc "last_activity_at" session.json);
                    ("top_handoff", member_assoc "top_handoff" session.json);
                    ("intervene_handoff", member_assoc "intervene_handoff" session.json);
@@ -387,14 +387,14 @@ let build_execution_queue session_contexts operation_contexts =
            | None -> true)
     |> List.map (fun (operation : operation_context) ->
            {
-             severity_rank = tone_rank operation.severity;
+             severity_rank = Dashboard_utils.tone_rank operation.severity;
              last_seen_ts = operation.last_seen_ts;
              json =
                `Assoc
                  [
                    ("id", `String ("operation-" ^ operation.operation_id));
                    ("kind", `String "operation");
-                   ("severity", `String (string_of_tone operation.severity));
+                   ("severity", `String (Dashboard_utils.string_of_tone operation.severity));
                    ("status", member_assoc "status" operation.json);
                    ( "summary",
                      match String_util.trim_to_option (string_field "blocker_summary" operation.json) with

--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -1,8 +1,7 @@
 (** Dashboard Governance — live judge status surface (case tracking retired). *)
 
-let option_to_yojson = Json_util.option_to_yojson
 
-let string_option_json = option_to_yojson (fun value -> `String value)
+let string_option_json = Json_util.option_to_yojson (fun value -> `String value)
 
 let timestamp_option_json value unix_value =
   match value, unix_value with
@@ -25,10 +24,10 @@ let judge_json_of_runtime (runtime : Dashboard_governance_judge.runtime_snapshot
       ("last_error", string_option_json runtime.last_error);
       ("compute_in_flight", `Int runtime.compute_in_flight);
       ( "last_compute_duration_sec",
-        option_to_yojson (fun value -> `Float value)
+        Json_util.option_to_yojson (fun value -> `Float value)
           runtime.last_compute_duration_sec );
       ( "last_compute_timeout_sec",
-        option_to_yojson (fun value -> `Float value)
+        Json_util.option_to_yojson (fun value -> `Float value)
           runtime.last_compute_timeout_sec );
       ( "last_compute_outcome",
         string_option_json runtime.last_compute_outcome );

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -137,7 +137,6 @@ let get_judgments_store base_path : Dated_jsonl.t =
 let with_lock (st : state) f =
   Eio.Mutex.use_rw ~protect:true st.mutex f
 
-let iso_of_unix = Dashboard_utils.iso_of_unix
 let parse_iso_opt = Dashboard_utils.parse_iso_opt
 
 let now_iso () = Masc_domain.now_iso ()
@@ -662,7 +661,7 @@ let compute_judgments
       try
         let raw_text = Agent_sdk_response.text_of_response response in
         let generated_at = now_iso () in
-        let expires_at = iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
+        let expires_at = Dashboard_utils.iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
         (* #9880: keep the internal fallback/counter for empty OAS model
            metadata, but do not project concrete model names into MASC-owned
            dashboard or judgment JSON. *)

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -137,7 +137,6 @@ let get_judgments_store base_path : Dated_jsonl.t =
 let with_lock (st : state) f =
   Eio.Mutex.use_rw ~protect:true st.mutex f
 
-let parse_iso_opt = Dashboard_utils.parse_iso_opt
 
 let now_iso () = Masc_domain.now_iso ()
 
@@ -270,7 +269,7 @@ let judgment_key json =
   key_of kind id
 
 let judgment_generated_at json =
-  json |> member "generated_at" |> to_string_option |> parse_iso_opt
+  json |> member "generated_at" |> to_string_option |> Dashboard_utils.parse_iso_opt
   |> Option.value ~default:0.0
 
 let normalize_disk_recommended_action judgment =

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -137,9 +137,6 @@ let get_judgments_store base_path : Dated_jsonl.t =
 let with_lock (st : state) f =
   Eio.Mutex.use_rw ~protect:true st.mutex f
 
-let ensure_dir path =
-  Fs_compat.mkdir_p path
-
 let iso_of_unix = Dashboard_utils.iso_of_unix
 let parse_iso_opt = Dashboard_utils.parse_iso_opt
 
@@ -899,8 +896,8 @@ let start ~sw ~clock ~net ~base_path
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.t)
     ~build_facts () =
   (* Ensure governance directories exist before first read/write *)
-  ensure_dir (governance_dir base_path);
-  ensure_dir (Filename.concat (governance_dir base_path) "judgments");
+  Fs_compat.mkdir_p (governance_dir base_path);
+  Fs_compat.mkdir_p (Filename.concat (governance_dir base_path) "judgments");
   let st = get_state base_path in
   let should_start =
     with_lock st (fun () ->

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -164,21 +164,20 @@ let status_stale_visible = "stale_visible"
 let status_offline = "offline"
 let status_backoff = "backoff"
 
-let contains_substring haystack needle = String_util.contains_substring haystack needle
 
 let degraded_reason_of_error message =
   let lower = String.lowercase_ascii message in
   if
-    contains_substring lower "unparseable"
-    || contains_substring lower "structurally invalid"
-    || contains_substring lower "invalid json"
-    || contains_substring lower "guardrail_state"
+    String_util.contains_substring lower "unparseable"
+    || String_util.contains_substring lower "structurally invalid"
+    || String_util.contains_substring lower "invalid json"
+    || String_util.contains_substring lower "guardrail_state"
   then
     "judge_output_invalid"
   else if
-    contains_substring lower "timeout"
-    || contains_substring lower "timed out"
-    || contains_substring lower "deadline"
+    String_util.contains_substring lower "timeout"
+    || String_util.contains_substring lower "timed out"
+    || String_util.contains_substring lower "deadline"
   then
     "timeout"
   else

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -141,7 +141,6 @@ let iso_of_unix = Dashboard_utils.iso_of_unix
 let parse_iso_opt = Dashboard_utils.parse_iso_opt
 
 let now_iso () = Masc_domain.now_iso ()
-let option_to_yojson = Json_util.option_to_yojson
 
 let interval_sec () = Env_config.Dashboard_config.governance_judge_interval_sec
 
@@ -290,7 +289,7 @@ let normalize_disk_recommended_action judgment =
           (List.map
              (fun (key, value) ->
                if String.equal key "resolved_tool" then
-                 ("resolved_tool", option_to_yojson (fun item -> `String item) canonical_tool)
+                 ("resolved_tool", Json_util.option_to_yojson (fun item -> `String item) canonical_tool)
                else
                  (key, value))
              action_fields)
@@ -478,7 +477,7 @@ let parse_recommended_action json =
         (`Assoc
           [
             ("action_kind", action_json |> member "action_kind");
-            ("resolved_tool", option_to_yojson (fun value -> `String value) resolved_tool);
+            ("resolved_tool", Json_util.option_to_yojson (fun value -> `String value) resolved_tool);
             ("target_type", action_json |> member "target_type");
             ("target_id", action_json |> member "target_id");
             ( "reason",
@@ -588,7 +587,7 @@ let parse_item_judgment ~generated_at ~expires_at ~model_used:_ json =
                    ( "evidence_refs",
                      `List (List.map (fun item -> `String item) evidence_refs) );
                    ( "recommended_action",
-                     option_to_yojson (fun value -> value) recommended_action );
+                     Json_util.option_to_yojson (fun value -> value) recommended_action );
                    ("guardrail_state", guardrail_state);
                  ]))
 

--- a/lib/dashboard/dashboard_keeper_feature_proof.ml
+++ b/lib/dashboard/dashboard_keeper_feature_proof.ml
@@ -35,9 +35,6 @@ let overall_status statuses =
 
 let clamp_float ~low ~high value = max low (min high value)
 
-let json_string_list values =
-  `List (List.map (fun value -> `String value) values)
-
 let evidence_ref ~kind ~id ~value =
   `Assoc [
     ("kind", `String kind);
@@ -153,8 +150,8 @@ let meta_feature_json
      `Assoc [
        ("keeper_count", `Int (keeper_count snapshots));
        ("meta_count", `Int (count_meta snapshots));
-       ("observed_keepers", json_string_list observed_keepers);
-       ("missing_keepers", json_string_list missing_keepers);
+       ("observed_keepers", Json_util.json_string_list observed_keepers);
+       ("missing_keepers", Json_util.json_string_list missing_keepers);
        ("read_errors", `List (keeper_read_errors snapshots));
      ]);
     ("evidence_refs", `List evidence_refs);
@@ -279,8 +276,8 @@ let persistent_turn_exchange_feature ~config ~now snapshots =
          `Float Decision.persistent_turn_window_hours );
        ( "max_latest_age_hours",
          `Float Decision.recent_turn_max_age_hours );
-       ("observed_keepers", json_string_list observed);
-       ("missing_keepers", json_string_list missing);
+       ("observed_keepers", Json_util.json_string_list observed);
+       ("missing_keepers", Json_util.json_string_list missing);
        ("read_errors", `List (keeper_read_errors snapshots));
        ("per_keeper", `List per_keeper);
      ]);
@@ -454,8 +451,8 @@ let scheduled_proactive_feature ~config ?window_hours ~now snapshots =
      `Assoc [
        ("keeper_count", `Int (keeper_count enabled));
        ("meta_count", `Int (count_meta enabled));
-       ("observed_keepers", json_string_list observed);
-       ("missing_keepers", json_string_list missing);
+       ("observed_keepers", Json_util.json_string_list observed);
+       ("missing_keepers", Json_util.json_string_list missing);
        ("read_errors", `List (keeper_read_errors enabled));
        ("per_keeper", `List per_keeper);
      ]);
@@ -517,7 +514,7 @@ let tool_feature_json
            else "")
           (List.length weak)
           (List.length missing)));
-    ("required_tools", json_string_list spec.required_tools);
+    ("required_tools", Json_util.json_string_list spec.required_tools);
     ("passing_tools", `List (List.map tool_stat_json passing));
     ( "weak_tools",
       `List
@@ -527,7 +524,7 @@ let tool_feature_json
                 ~failure_classes:(Failure.classes_json failure_table stat.name)
                 stat)
            weak) );
-    ("missing_tools", json_string_list missing);
+    ("missing_tools", Json_util.json_string_list missing);
     ( "keeper_evidence",
       Failure.keeper_evidence_json tool_stats
         ~keeper_names ~required_tools:spec.required_tools );

--- a/lib/dashboard/dashboard_keeper_git_pr_proof.ml
+++ b/lib/dashboard/dashboard_keeper_git_pr_proof.ml
@@ -22,7 +22,6 @@ let stage_specs =
   ]
 ;;
 
-let contains_substring text needle = String_util.contains_substring text needle
 
 let lower text = String.lowercase_ascii text
 
@@ -104,11 +103,11 @@ let init_stages () =
 
 let has_docker_evidence record text =
   string_field_opt record "sandbox_profile" = Some "docker"
-  || contains_substring text "\"sandbox_profile\":\"docker\""
-  || contains_substring text "\"via\":\"docker\""
+  || String_util.contains_substring text "\"sandbox_profile\":\"docker\""
+  || String_util.contains_substring text "\"via\":\"docker\""
 ;;
 
-let has_git_credentials text = contains_substring text "\"git_creds_enabled\":true"
+let has_git_credentials text = String_util.contains_substring text "\"git_creds_enabled\":true"
 
 let json_of_string_opt text =
   try Some (Yojson.Safe.from_string text) with
@@ -141,9 +140,9 @@ let has_keeper_identity_credentials text =
           || json_has_string_field json "state" "materialized")
   in
   structured
-  || (contains_substring text "\"credential_scope\":\"keeper_identity\""
-      && (contains_substring text "\"git_identity_mode\":\"github_identity\""
-          || contains_substring text "\"credential_state\":{\"state\":\"materialized\""))
+  || (String_util.contains_substring text "\"credential_scope\":\"keeper_identity\""
+      && (String_util.contains_substring text "\"git_identity_mode\":\"github_identity\""
+          || String_util.contains_substring text "\"credential_state\":{\"state\":\"materialized\""))
 ;;
 
 let stage_ids_for_record record =
@@ -155,18 +154,18 @@ let stage_ids_for_record record =
   let git_creds = has_git_credentials text in
   let keeper_creds = git_creds || has_keeper_identity_credentials output in
   let stages = ref [] in
-  if docker && git_creds && contains_substring input "git clone"
+  if docker && git_creds && String_util.contains_substring input "git clone"
   then stages := "docker_clone" :: !stages;
-  if docker && contains_substring input "git checkout -b"
+  if docker && String_util.contains_substring input "git checkout -b"
   then stages := "branch_create" :: !stages;
-  if docker && contains_substring input "git commit" then stages := "commit" :: !stages;
-  if docker && git_creds && contains_substring input "git push"
+  if docker && String_util.contains_substring input "git commit" then stages := "commit" :: !stages;
+  if docker && git_creds && String_util.contains_substring input "git push"
   then stages := "push" :: !stages;
   if
     docker
     && keeper_creds
     && String.equal tool "keeper_shell"
-    && contains_substring text "gh pr create"
+    && String_util.contains_substring text "gh pr create"
   then stages := "pr_create" :: !stages;
   List.rev !stages
 ;;

--- a/lib/dashboard/dashboard_keeper_git_pr_proof.ml
+++ b/lib/dashboard/dashboard_keeper_git_pr_proof.ml
@@ -56,8 +56,7 @@ let input_text record =
 let record_success = Dashboard_keeper_tool_failure_proof.tool_success_of_record
 let output_text = Dashboard_keeper_tool_failure_proof.output_text
 let read_records = Dashboard_keeper_tool_failure_proof.read_records
-let string_list_json values = `List (List.map (fun value -> `String value) values)
-
+let string_list_json = Json_util.json_string_list
 let known_keeper_table keeper_names =
   let table = Hashtbl.create (List.length keeper_names) in
   List.iter

--- a/lib/dashboard/dashboard_keeper_git_pr_proof.ml
+++ b/lib/dashboard/dashboard_keeper_git_pr_proof.ml
@@ -56,7 +56,6 @@ let input_text record =
 let record_success = Dashboard_keeper_tool_failure_proof.tool_success_of_record
 let output_text = Dashboard_keeper_tool_failure_proof.output_text
 let read_records = Dashboard_keeper_tool_failure_proof.read_records
-let string_list_json = Json_util.json_string_list
 let known_keeper_table keeper_names =
   let table = Hashtbl.create (List.length keeper_names) in
   List.iter
@@ -200,9 +199,9 @@ let stage_json stage =
      ; "passed", `Bool (!(stage.successes) > 0)
      ; "successes", `Int !(stage.successes)
      ; "failures", `Int !(stage.failures)
-     ; "keepers", string_list_json (sorted_set stage.keepers)
-     ; "successful_keepers", string_list_json (sorted_set stage.successful_keepers)
-     ; "failed_keepers", string_list_json (sorted_set stage.failed_keepers)
+     ; "keepers", Json_util.json_string_list (sorted_set stage.keepers)
+     ; "successful_keepers", Json_util.json_string_list (sorted_set stage.successful_keepers)
+     ; "failed_keepers", Json_util.json_string_list (sorted_set stage.failed_keepers)
      ]
      @ latest_fields)
 ;;
@@ -259,7 +258,7 @@ let json ?window_hours ~n ~keeper_names () =
              (List.length stage_rows)
              failed_observed) )
     ; ( "required_tools"
-      , string_list_json [ "keeper_bash"; "keeper_shell" ] )
+      , Json_util.json_string_list [ "keeper_bash"; "keeper_shell" ] )
     ; "passing_tools", `List []
     ; "weak_tools", `List []
     ; "missing_tools", `List []
@@ -267,8 +266,8 @@ let json ?window_hours ~n ~keeper_names () =
       , `Assoc
           [ "provenance_scope", `String "known_keeper_tool_call_log"
           ; "keeper_count", `Int (List.length keeper_names)
-          ; "observed_keepers", string_list_json observed_keepers
-          ; "missing_keepers", string_list_json missing_keepers
+          ; "observed_keepers", Json_util.json_string_list observed_keepers
+          ; "missing_keepers", Json_util.json_string_list missing_keepers
           ; "stages", `List (List.map stage_json stage_rows)
           ] )
     ; ( "evidence_refs"

--- a/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
+++ b/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
@@ -323,7 +323,6 @@ let class_json item =
 let classes_json table tool =
   `List (classes_for table tool |> List.map class_json)
 
-let string_list_json = Json_util.json_string_list
 let stat_json (stat : tool_keeper_stat) =
   let ts_fields key ts_opt =
     match ts_opt with
@@ -340,13 +339,13 @@ let stat_json (stat : tool_keeper_stat) =
        ("calls", `Int stat.calls);
        ("successes", `Int stat.successes);
        ("success_pct", `Float stat.success_pct);
-       ("keepers", string_list_json stat.keepers);
-       ("successful_keepers", string_list_json stat.successful_keepers);
-       ("failed_keepers", string_list_json stat.failed_keepers);
-       ("sandbox_profiles", string_list_json stat.sandbox_profiles);
-       ("network_modes", string_list_json stat.network_modes);
-       ("task_ids", string_list_json stat.task_ids);
-       ("goal_ids", string_list_json stat.goal_ids);
+       ("keepers", Json_util.json_string_list stat.keepers);
+       ("successful_keepers", Json_util.json_string_list stat.successful_keepers);
+       ("failed_keepers", Json_util.json_string_list stat.failed_keepers);
+       ("sandbox_profiles", Json_util.json_string_list stat.sandbox_profiles);
+       ("network_modes", Json_util.json_string_list stat.network_modes);
+       ("task_ids", Json_util.json_string_list stat.task_ids);
+       ("goal_ids", Json_util.json_string_list stat.goal_ids);
      ]
      @ ts_fields "latest" stat.latest_ts
      @ ts_fields "latest_success" stat.latest_success_ts
@@ -400,7 +399,7 @@ let keeper_evidence_json
   `Assoc [
     ("provenance_scope", `String "known_keeper_tool_call_log");
     ("keeper_count", `Int (List.length keeper_names));
-    ("observed_keepers", string_list_json observed_keepers);
-    ("missing_keepers", string_list_json missing_keepers);
+    ("observed_keepers", Json_util.json_string_list observed_keepers);
+    ("missing_keepers", Json_util.json_string_list missing_keepers);
     ("per_tool", `List per_tool);
   ]

--- a/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
+++ b/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
@@ -323,9 +323,7 @@ let class_json item =
 let classes_json table tool =
   `List (classes_for table tool |> List.map class_json)
 
-let string_list_json values =
-  `List (List.map (fun value -> `String value) values)
-
+let string_list_json = Json_util.json_string_list
 let stat_json (stat : tool_keeper_stat) =
   let ts_fields key ts_opt =
     match ts_opt with

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -39,7 +39,7 @@ type attention_context = Dashboard_mission_assembly.attention_context = {
 
 let dedup_strings items =
   List.sort_uniq String.compare
-    (List.filter_map trim_to_option items)
+    (List.filter_map String_util.trim_to_option items)
 
 let top_item items =
   match items with
@@ -66,13 +66,13 @@ let session_communication_json session_json =
 let session_status_string session_json =
   let summary = session_summary_json session_json in
   let meta = session_meta_json session_json in
-  match trim_to_option (string_field "status" summary) with
+  match String_util.trim_to_option (string_field "status" summary) with
   | Some value -> value
   | None -> (
-      match trim_to_option (string_field "status" meta) with
+      match String_util.trim_to_option (string_field "status" meta) with
       | Some value -> value
       | None ->
-          trim_to_option (string_field "status" session_json)
+          String_util.trim_to_option (string_field "status" session_json)
           |> Option.value
                ~default:"<missing status field in summary / meta / session>")
 
@@ -85,23 +85,23 @@ let event_detail_json event_json =
 let event_summary event_json =
   let detail = event_detail_json event_json in
   let event_type =
-    trim_to_option (string_field "event_type" event_json)
+    String_util.trim_to_option (string_field "event_type" event_json)
     |> Option.value ~default:"event"
   in
   let actor =
-    match trim_to_option (string_field "actor" detail) with
+    match String_util.trim_to_option (string_field "actor" detail) with
     | Some value -> Some value
-    | None -> trim_to_option (string_field "agent" detail)
+    | None -> String_util.trim_to_option (string_field "agent" detail)
   in
   let task_title =
-    match trim_to_option (string_field "task_title" detail) with
+    match String_util.trim_to_option (string_field "task_title" detail) with
     | Some value -> Some value
-    | None -> trim_to_option (string_field "title" detail)
+    | None -> String_util.trim_to_option (string_field "title" detail)
   in
-  let result = trim_to_option (compact_text (string_field "result" detail)) in
-  let reason = trim_to_option (compact_text (string_field "reason" detail)) in
+  let result = String_util.trim_to_option (compact_text (string_field "result" detail)) in
+  let reason = String_util.trim_to_option (compact_text (string_field "reason" detail)) in
   let output_preview =
-    trim_to_option (compact_text (string_field "output_preview" detail))
+    String_util.trim_to_option (compact_text (string_field "output_preview" detail))
   in
   match task_title, result, reason, output_preview with
   | Some title, _, _, _ ->
@@ -128,14 +128,14 @@ let creator_looks_system created_by =
 
 let session_origin_kind session_meta =
   let created_by =
-    trim_to_option (string_field "created_by" session_meta)
+    String_util.trim_to_option (string_field "created_by" session_meta)
     |> Option.value ~default:"<missing created_by field>"
   in
-  trim_to_option (string_field "origin_kind" session_meta)
+  String_util.trim_to_option (string_field "origin_kind" session_meta)
   |> Option.value
        ~default:
          (match
-            trim_to_option (string_field "orchestration_mode" session_meta)
+            String_util.trim_to_option (string_field "orchestration_mode" session_meta)
             |> Option.map String.lowercase_ascii
           with
          | Some "auto" -> "system"
@@ -146,7 +146,7 @@ let matching_action target_type target_id actions =
   List.find_opt
     (fun action ->
       let action_target_type = string_field "target_type" action in
-      let action_target_id = trim_to_option (string_field "target_id" action) in
+      let action_target_id = String_util.trim_to_option (string_field "target_id" action) in
       String.equal action_target_type target_type
       &&
       match target_id, action_target_id with
@@ -181,9 +181,9 @@ let incident_action_types kind =
 
 let action_matches_incident incident action =
   let target_type = string_field "target_type" incident in
-  let target_id = trim_to_option (string_field "target_id" incident) in
+  let target_id = String_util.trim_to_option (string_field "target_id" incident) in
   let action_target_type = string_field "target_type" action in
-  let action_target_id = trim_to_option (string_field "target_id" action) in
+  let action_target_id = String_util.trim_to_option (string_field "target_id" action) in
   let same_target =
     String.equal action_target_type target_type
     &&
@@ -207,12 +207,12 @@ let action_matches_incident incident action =
 
 let matching_action_for_incident incident actions =
   let target_type = string_field "target_type" incident in
-  let target_id = trim_to_option (string_field "target_id" incident) in
+  let target_id = String_util.trim_to_option (string_field "target_id" incident) in
   let candidates =
     actions
     |> List.filter (fun action ->
            let action_target_type = string_field "target_type" action in
-           let action_target_id = trim_to_option (string_field "target_id" action) in
+           let action_target_id = String_util.trim_to_option (string_field "target_id" action) in
            String.equal action_target_type target_type
            &&
            match target_id, action_target_id with
@@ -247,7 +247,7 @@ let related_sessions_for_attention incident sessions =
     ignore incident;
     []
   in
-  let actor = trim_to_option (string_field "actor" incident) in
+  let actor = String_util.trim_to_option (string_field "actor" incident) in
   let by_actor =
     match actor with
     | None -> []
@@ -275,7 +275,7 @@ let build_attention_queue incidents actions sessions =
          if kind = "" || summary = "" then None
          else
            let target_type = string_field "target_type" incident in
-           let target_id = trim_to_option (string_field "target_id" incident) in
+           let target_id = String_util.trim_to_option (string_field "target_id" incident) in
            let related_session_ids = related_sessions_for_attention incident sessions in
            let related_agent_names =
              let from_sessions =
@@ -286,7 +286,7 @@ let build_attention_queue incidents actions sessions =
              dedup_strings
                (from_sessions
                @
-               match trim_to_option (string_field "actor" incident) with
+               match String_util.trim_to_option (string_field "actor" incident) with
                | Some actor -> [ actor ]
                | None -> [])
            in

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -299,8 +299,8 @@ let build_attention_queue incidents actions sessions =
                     | None -> None)
              |> List.sort (fun left right ->
                     Float.compare
-                      (parse_iso_opt (Some right) |> Option.value ~default:0.0)
-                      (parse_iso_opt (Some left) |> Option.value ~default:0.0))
+                      (Dashboard_utils.parse_iso_opt (Some right) |> Option.value ~default:0.0)
+                      (Dashboard_utils.parse_iso_opt (Some left) |> Option.value ~default:0.0))
              |> function
              | value :: _ -> Some value
              | [] -> None
@@ -314,7 +314,7 @@ let build_attention_queue incidents actions sessions =
                severity;
                has_action = Option.is_some top_action;
                last_seen_ts =
-                 parse_iso_opt last_seen_at |> Option.value ~default:0.0;
+                 Dashboard_utils.parse_iso_opt last_seen_at |> Option.value ~default:0.0;
                related_session_ids;
                related_agent_names;
                json =
@@ -326,7 +326,7 @@ let build_attention_queue incidents actions sessions =
                      ("summary", `String summary);
                      ("target_type", `String target_type);
                      ("target_id", json_string_option target_id);
-                     ("top_action", option_to_json (fun value -> value) top_action);
+                     ("top_action", Json_util.option_to_yojson (fun value -> value) top_action);
                      ("related_session_ids", `List (List.map (fun value -> `String value) related_session_ids));
                      ("related_agent_names", `List (List.map (fun value -> `String value) related_agent_names));
                      ("evidence_preview", `List (List.map (fun value -> `String value) (evidence_preview_strings (member_assoc "evidence" incident))));
@@ -542,7 +542,7 @@ let session_json ?actor ~session_id ~config ~sw
     [
       ("generated_at", `String projection.generated_at);
       ("session_id", `String session_id);
-      ("session", option_to_json (fun value -> value) session_row_json);
+      ("session", Json_util.option_to_yojson (fun value -> value) session_row_json);
       ( "timeline",
         `List
           (match session_source_json with

--- a/lib/dashboard/dashboard_mission_agents.ml
+++ b/lib/dashboard/dashboard_mission_agents.ml
@@ -351,7 +351,7 @@ let build_agent_briefs config sessions attention_queue _room_json (keepers : Yoj
          let last_seen_ts =
            match agent with
             | Some value ->
-                parse_iso_opt (String_util.trim_to_option value.last_seen) |> Option.value ~default:0.0
+                Dashboard_utils.parse_iso_opt (String_util.trim_to_option value.last_seen) |> Option.value ~default:0.0
             | None ->
                 (match related_session with
                 | Some session -> session.last_event_ts
@@ -397,7 +397,7 @@ let build_agent_briefs config sessions attention_queue _room_json (keepers : Yoj
                   ("current_work", json_string_option current_work);
                   ("related_session_id", json_string_option (Option.map (fun s -> s.session_id) related_session));
                   ("last_activity_at", json_string_option last_activity_at);
-                  ("last_activity_age_sec", option_to_json (fun value -> `Int value) last_activity_age_sec);
+                  ("last_activity_age_sec", Json_util.option_to_yojson (fun value -> `Int value) last_activity_age_sec);
                   ("signal_truth", `String signal_truth);
                   ("evidence_source", `String evidence_source);
                   ("recent_output_preview", json_string_option recent_output_preview);

--- a/lib/dashboard/dashboard_mission_agents.ml
+++ b/lib/dashboard/dashboard_mission_agents.ml
@@ -7,7 +7,7 @@ include Dashboard_utils
 
 let dedup_strings items =
   List.sort_uniq String.compare
-    (List.filter_map trim_to_option items)
+    (List.filter_map String_util.trim_to_option items)
 
 let event_detail_json event_json =
   member_assoc "detail" event_json
@@ -15,23 +15,23 @@ let event_detail_json event_json =
 let event_summary event_json =
   let detail = event_detail_json event_json in
   let event_type =
-    trim_to_option (string_field "event_type" event_json)
+    String_util.trim_to_option (string_field "event_type" event_json)
     |> Option.value ~default:"event"
   in
   let actor =
-    match trim_to_option (string_field "actor" detail) with
+    match String_util.trim_to_option (string_field "actor" detail) with
     | Some value -> Some value
-    | None -> trim_to_option (string_field "agent" detail)
+    | None -> String_util.trim_to_option (string_field "agent" detail)
   in
   let task_title =
-    match trim_to_option (string_field "task_title" detail) with
+    match String_util.trim_to_option (string_field "task_title" detail) with
     | Some value -> Some value
-    | None -> trim_to_option (string_field "title" detail)
+    | None -> String_util.trim_to_option (string_field "title" detail)
   in
-  let result = trim_to_option (compact_text (string_field "result" detail)) in
-  let reason = trim_to_option (compact_text (string_field "reason" detail)) in
+  let result = String_util.trim_to_option (compact_text (string_field "result" detail)) in
+  let reason = String_util.trim_to_option (compact_text (string_field "reason" detail)) in
   let output_preview =
-    trim_to_option (compact_text (string_field "output_preview" detail))
+    String_util.trim_to_option (compact_text (string_field "output_preview" detail))
   in
   match task_title, result, reason, output_preview with
   | Some title, _, _, _ ->
@@ -240,9 +240,9 @@ let archived_agent_meta_map config agent_names =
            if agent_name <> "" && Hashtbl.mem wanted agent_name then (
              let row = ensure_row agent_name in
              let last_event_at =
-               match trim_to_option (string_field "ts" json) with
+               match String_util.trim_to_option (string_field "ts" json) with
                | Some _ as value -> value
-               | None -> trim_to_option (string_field "timestamp" json)
+               | None -> String_util.trim_to_option (string_field "timestamp" json)
              in
              let row =
                if row.last_event_at = None
@@ -257,8 +257,8 @@ let keeper_alias_by_agent_name (keepers : Yojson.Safe.t list) =
   let table = Hashtbl.create 8 in
   List.iter
     (fun keeper ->
-      let keeper_name = trim_to_option (string_field "name" keeper) in
-      let agent_name = trim_to_option (string_field "agent_name" keeper) in
+      let keeper_name = String_util.trim_to_option (string_field "name" keeper) in
+      let agent_name = String_util.trim_to_option (string_field "agent_name" keeper) in
       match keeper_name, agent_name with
       | Some keeper_name, Some agent_name ->
           Hashtbl.replace table agent_name keeper_name
@@ -339,7 +339,7 @@ let build_agent_briefs config sessions attention_queue _room_json (keepers : Yoj
          in
          let last_activity_at =
            match agent with
-           | Some value -> trim_to_option value.last_seen
+           | Some value -> String_util.trim_to_option value.last_seen
             | None ->
                (match archived_meta with
                | Some meta when meta.last_event_at <> None -> meta.last_event_at
@@ -351,7 +351,7 @@ let build_agent_briefs config sessions attention_queue _room_json (keepers : Yoj
          let last_seen_ts =
            match agent with
             | Some value ->
-                parse_iso_opt (trim_to_option value.last_seen) |> Option.value ~default:0.0
+                parse_iso_opt (String_util.trim_to_option value.last_seen) |> Option.value ~default:0.0
             | None ->
                 (match related_session with
                 | Some session -> session.last_event_ts

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -37,19 +37,19 @@ let keeper_tool_audit_json_fields config registry_lookup keeper agent_name =
     | _ -> None
   in
   let fallback_source =
-    match trim_to_option (string_field "tool_audit_source" keeper) with
+    match String_util.trim_to_option (string_field "tool_audit_source" keeper) with
     | Some _ as value -> value
     | None -> None
   in
   let fallback_action_source =
-    trim_to_option (string_field "latest_action_source" keeper)
+    String_util.trim_to_option (string_field "latest_action_source" keeper)
   in
   let fallback_at =
-    trim_to_option (string_field "tool_audit_at" keeper)
+    String_util.trim_to_option (string_field "tool_audit_at" keeper)
   in
   let file_snapshot =
     let keeper_updated_at =
-      trim_to_option (string_field "updated_at" keeper)
+      String_util.trim_to_option (string_field "updated_at" keeper)
     in
     match
       Keeper_exec_status_metrics.latest_tool_audit_snapshot_from_files config
@@ -110,7 +110,7 @@ let action_identity action =
     [
       string_field "action_type" action;
       string_field "target_type" action;
-      Option.value ~default:"none" (trim_to_option (string_field "target_id" action));
+      Option.value ~default:"none" (String_util.trim_to_option (string_field "target_id" action));
       normalized_text_key (string_field "reason" action);
     ]
 
@@ -119,7 +119,7 @@ let incident_identity incident =
     [
       string_field "kind" incident;
       string_field "target_type" incident;
-      Option.value ~default:"none" (trim_to_option (string_field "target_id" incident));
+      Option.value ~default:"none" (String_util.trim_to_option (string_field "target_id" incident));
       normalized_text_key (string_field "summary" incident);
     ]
 
@@ -156,9 +156,9 @@ let incident_action_types kind =
 
 let action_matches_incident incident action =
   let target_type = string_field "target_type" incident in
-  let target_id = trim_to_option (string_field "target_id" incident) in
+  let target_id = String_util.trim_to_option (string_field "target_id" incident) in
   let action_target_type = string_field "target_type" action in
-  let action_target_id = trim_to_option (string_field "target_id" action) in
+  let action_target_id = String_util.trim_to_option (string_field "target_id" action) in
   let same_target =
     String.equal action_target_type target_type
     &&
@@ -208,8 +208,8 @@ let build_keeper_briefs (config : Coord.config) (keepers : Yojson.Safe.t list) =
                pressure_rank;
                last_seen_ts =
                  parse_iso_opt
-                   (trim_to_option
-                      (match trim_to_option (string_field "last_autonomous_action_at" keeper) with
+                   (String_util.trim_to_option
+                      (match String_util.trim_to_option (string_field "last_autonomous_action_at" keeper) with
                       | Some value -> value
                       | None -> string_field "updated_at" keeper))
                  |> Option.value ~default:0.0;
@@ -224,13 +224,13 @@ let build_keeper_briefs (config : Coord.config) (keepers : Yojson.Safe.t list) =
                       ("last_turn_ago_s", member_assoc "last_turn_ago_s" keeper);
                       ( "current_work",
                         json_string_option
-                          (match trim_to_option (string_field "short_goal" keeper) with
+                          (match String_util.trim_to_option (string_field "short_goal" keeper) with
                            | Some value -> Some value
-                           | None -> trim_to_option (string_field "goal" keeper)) );
+                           | None -> String_util.trim_to_option (string_field "goal" keeper)) );
                       ("last_autonomous_action_at", member_assoc "last_autonomous_action_at" keeper);
                     ]
                     @ keeper_tool_audit_json_fields config registry_lookup keeper
-                        (match trim_to_option (string_field "agent_name" keeper) with
+                        (match String_util.trim_to_option (string_field "agent_name" keeper) with
                          | Some agent_name -> agent_name
                          | None -> name));
              })
@@ -319,7 +319,7 @@ let task_operation_links (task : Masc_domain.task) =
 
 let task_operation_id (task : Masc_domain.task) =
   let links = task_operation_links task in
-  match trim_to_option (Option.value ~default:"" links.operation_id) with
+  match String_util.trim_to_option (Option.value ~default:"" links.operation_id) with
   | Some operation_id -> operation_id
   | None -> task.id
 
@@ -334,11 +334,11 @@ let build_operation_contexts ~(tasks : Masc_domain.task list) =
              {
                operation_id = task_operation_id task;
                linked_session_id =
-                 Option.bind links.session_id (fun value -> trim_to_option value);
+                 Option.bind links.session_id (fun value -> String_util.trim_to_option value);
                status = Some status;
                stage = Option.map Task_stage.to_string task.stage;
                detachment_status = None;
-               objective = trim_to_option task.title;
+               objective = String_util.trim_to_option task.title;
                updated_at = Some (task_operation_updated_at task);
              })
 
@@ -397,7 +397,7 @@ let participant_preview_json session_id member_names agent_briefs =
   let member_set = List.sort_uniq String.compare member_names in
   agent_briefs
   |> List.filter_map (fun row ->
-         let related_session_id = trim_to_option (string_field "related_session_id" row) in
+         let related_session_id = String_util.trim_to_option (string_field "related_session_id" row) in
          let agent_name = string_field "agent_name" row in
          let belongs =
            String.equal (Option.value ~default:"" related_session_id) session_id
@@ -421,7 +421,7 @@ let keeper_refs_for_session member_names keeper_briefs =
   let member_set = List.sort_uniq String.compare member_names in
   keeper_briefs
   |> List.filter_map (fun row ->
-         let agent_name = trim_to_option (string_field "agent_name" row) in
+         let agent_name = String_util.trim_to_option (string_field "agent_name" row) in
          let name = string_field "name" row in
          let matches =
            (match agent_name with
@@ -513,11 +513,11 @@ let session_timeline_json session_json =
   session_recent_events session_json
   |> List.sort (fun left right ->
          let right_ts =
-           parse_iso_opt (trim_to_option (string_field "ts_iso" right))
+           parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" right))
            |> Option.value ~default:0.0
          in
          let left_ts =
-           parse_iso_opt (trim_to_option (string_field "ts_iso" left))
+           parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" left))
            |> Option.value ~default:0.0
          in
          Float.compare right_ts left_ts)
@@ -531,8 +531,8 @@ let session_timeline_json session_json =
              ("event_type", member_assoc "event_type" event_json);
              ( "actor",
                json_string_option
-                 (match trim_to_option (string_field "actor" detail) with
+                 (match String_util.trim_to_option (string_field "actor" detail) with
                  | Some value -> Some value
-                 | None -> trim_to_option (string_field "agent" detail)) );
+                 | None -> String_util.trim_to_option (string_field "agent" detail)) );
              ("summary", `String (event_summary event_json));
            ])

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -25,10 +25,10 @@ let keeper_tool_audit_json_fields config registry_lookup keeper agent_name =
          | Some (entry : Keeper_registry.registry_entry) ->
            Keeper_exec_tools.keeper_allowed_tool_names entry.meta
          | None -> [])
-    | _ -> string_list_of_json raw_allowed
+    | _ -> Dashboard_utils.string_list_of_json raw_allowed
   in
   let fallback_latest =
-    string_list_of_json (member_assoc "latest_tool_names" keeper)
+    Dashboard_utils.string_list_of_json (member_assoc "latest_tool_names" keeper)
   in
   let fallback_count =
     match member_assoc "latest_tool_call_count" keeper with
@@ -99,7 +99,7 @@ let keeper_tool_audit_json_fields config registry_lookup keeper agent_name =
     ("allowed_tool_names", Json_util.json_string_list allowed_tool_names);
     ("latest_tool_names", Json_util.json_string_list latest_tool_names);
     ( "latest_tool_call_count",
-      option_to_json (fun value -> `Int value) latest_tool_call_count );
+      Json_util.option_to_yojson (fun value -> `Int value) latest_tool_call_count );
     ("latest_action_source", json_string_option latest_action_source);
     ("tool_audit_source", json_string_option tool_audit_source);
     ("tool_audit_at", json_string_option tool_audit_at);
@@ -207,7 +207,7 @@ let build_keeper_briefs (config : Coord.config) (keepers : Yojson.Safe.t list) =
              {
                pressure_rank;
                last_seen_ts =
-                 parse_iso_opt
+                 Dashboard_utils.parse_iso_opt
                    (String_util.trim_to_option
                       (match String_util.trim_to_option (string_field "last_autonomous_action_at" keeper) with
                       | Some value -> value
@@ -220,7 +220,7 @@ let build_keeper_briefs (config : Coord.config) (keepers : Yojson.Safe.t list) =
                       ("agent_name", member_assoc "agent_name" keeper);
                       ("status", `String status);
                       ("generation", member_assoc "generation" keeper);
-                      ("context_ratio", option_to_json (fun value -> `Float value) context_ratio);
+                      ("context_ratio", Json_util.option_to_yojson (fun value -> `Float value) context_ratio);
                       ("last_turn_ago_s", member_assoc "last_turn_ago_s" keeper);
                       ( "current_work",
                         json_string_option
@@ -259,7 +259,7 @@ let build_internal_signals incidents actions =
                    ("target_type", member_assoc "target_type" incident);
                    ("target_id", member_assoc "target_id" incident);
                    ("attention", incident);
-                   ("action", option_to_json (fun value -> value) action);
+                   ("action", Json_util.option_to_yojson (fun value -> value) action);
                  ];
            })
   in
@@ -454,9 +454,9 @@ let build_sessions ?(operation_contexts = []) sessions attention_queue agent_bri
   sessions
   |> List.map (fun (session : session_context) ->
          let attention_count = related_attention_count session.session_id in
-         let top_attention = option_to_json (fun value -> value) session.top_attention in
+         let top_attention = Json_util.option_to_yojson (fun value -> value) session.top_attention in
          let top_recommendation =
-           option_to_json (fun value -> value) session.top_recommendation
+           Json_util.option_to_yojson (fun value -> value) session.top_recommendation
          in
          ( attention_count,
            severity_rank
@@ -478,7 +478,7 @@ let build_sessions ?(operation_contexts = []) sessions attention_queue agent_bri
                ("health", `String (Dashboard_utils.string_of_health_level session.health));
                ("member_names", Json_util.json_string_list session.member_names);
                ("started_at", json_string_option session.started_at);
-               ("elapsed_sec", option_to_json (fun value -> `Int value) session.elapsed_sec);
+               ("elapsed_sec", Json_util.option_to_yojson (fun value -> `Int value) session.elapsed_sec);
                ("operation_id", json_string_option session.operation_id);
                ("blocker_summary", json_string_option session.blocker_summary);
                ("last_event_at", json_string_option session.last_event_at);
@@ -513,11 +513,11 @@ let session_timeline_json session_json =
   session_recent_events session_json
   |> List.sort (fun left right ->
          let right_ts =
-           parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" right))
+           Dashboard_utils.parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" right))
            |> Option.value ~default:0.0
          in
          let left_ts =
-           parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" left))
+           Dashboard_utils.parse_iso_opt (String_util.trim_to_option (string_field "ts_iso" left))
            |> Option.value ~default:0.0
          in
          Float.compare right_ts left_ts)

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -96,8 +96,8 @@ let keeper_tool_audit_json_fields config registry_lookup keeper agent_name =
                 fallback_at ))
   in
   [
-    ("allowed_tool_names", string_list_json allowed_tool_names);
-    ("latest_tool_names", string_list_json latest_tool_names);
+    ("allowed_tool_names", Json_util.json_string_list allowed_tool_names);
+    ("latest_tool_names", Json_util.json_string_list latest_tool_names);
     ( "latest_tool_call_count",
       option_to_json (fun value -> `Int value) latest_tool_call_count );
     ("latest_action_source", json_string_option latest_action_source);
@@ -476,7 +476,7 @@ let build_sessions ?(operation_contexts = []) sessions attention_queue agent_bri
                ("namespace", json_string_option session.namespace);
                ("status", `String (Dashboard_utils.string_of_session_lifecycle session.status));
                ("health", `String (Dashboard_utils.string_of_health_level session.health));
-               ("member_names", string_list_json session.member_names);
+               ("member_names", Json_util.json_string_list session.member_names);
                ("started_at", json_string_option session.started_at);
                ("elapsed_sec", option_to_json (fun value -> `Int value) session.elapsed_sec);
                ("operation_id", json_string_option session.operation_id);

--- a/lib/dashboard/dashboard_mission_briefing.ml
+++ b/lib/dashboard/dashboard_mission_briefing.ml
@@ -141,7 +141,7 @@ let compute_briefing_json ~actor_name ~config ~sw ~clock ~proc_mgr () =
       | _ -> snapshot_json |> member_assoc "room"
     in
     let current_namespace =
-      match trim_to_option (Some (scope_json |> string_field "project")) with
+      match String_util.option_trim (Some (scope_json |> string_field "project")) with
       | Some value -> value
       | None -> "default"
     in

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -93,11 +93,7 @@ let room_ttl_sec () = Env_config.Operator.room_ttl_sec
 
 let session_ttl_sec () = Env_config.Operator.session_ttl_sec
 
-let iso_of_unix unix_ts =
-  let tm = Unix.gmtime unix_ts in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday tm.Unix.tm_hour
-    tm.Unix.tm_min tm.Unix.tm_sec
+let iso_of_unix = Dashboard_utils.iso_of_unix
 
 let runtime_status base_path =
   let st = get_state base_path in

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -93,8 +93,6 @@ let room_ttl_sec () = Env_config.Operator.room_ttl_sec
 
 let session_ttl_sec () = Env_config.Operator.session_ttl_sec
 
-let iso_of_unix = Dashboard_utils.iso_of_unix
-
 let runtime_status base_path =
   let st = get_state base_path in
   with_lock st (fun () ->
@@ -212,7 +210,7 @@ let parse_room_judgment ~config ~generated_at ~generated_at_unix ~model_used:_ j
                (json |> member member_disagreement_with_truth |> to_bool_option
                |> Option.value ~default:false)
              ~generated_at ~generated_at_unix
-             ~fresh_until:(iso_of_unix fresh_until_unix)
+             ~fresh_until:(Dashboard_utils.iso_of_unix fresh_until_unix)
              ~fresh_until_unix ~keeper_name ())
   | _ -> None
 
@@ -308,9 +306,9 @@ let refresh_once ~sw ~net
             st.last_error <- Some message)
     | Ok (model_used, result_json) ->
         let generated_at_unix = Unix.gettimeofday () in
-        let generated_at = iso_of_unix generated_at_unix in
+        let generated_at = Dashboard_utils.iso_of_unix generated_at_unix in
         let expires_at =
-          iso_of_unix (generated_at_unix +. float_of_int (room_ttl_sec ()))
+          Dashboard_utils.iso_of_unix (generated_at_unix +. float_of_int (room_ttl_sec ()))
         in
         let room_judgment =
           parse_room_judgment ~config ~generated_at ~generated_at_unix

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -86,9 +86,7 @@ let non_empty_string_opt value =
   let trimmed = String.trim value in
   if trimmed = "" then None else Some trimmed
 
-let normalize_string_opt = function
-  | Some value -> non_empty_string_opt value
-  | None -> None
+let normalize_string_opt = String_util.option_trim
 
 
 let evidence_ref_json (entry : evidence_ref) =

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -90,10 +90,7 @@ let normalize_string_opt = function
   | Some value -> non_empty_string_opt value
   | None -> None
 
-let float_opt_to_json = function
-  | Some value -> `Float value
-  | None -> `Null
-
+let float_opt_to_json = Json_util.float_opt_to_json
 let string_opt_to_json = function
   | Some value -> `String value
   | None -> `Null

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -90,10 +90,6 @@ let normalize_string_opt = function
   | Some value -> non_empty_string_opt value
   | None -> None
 
-let float_opt_to_json = Json_util.float_opt_to_json
-let string_opt_to_json = function
-  | Some value -> `String value
-  | None -> `Null
 
 let evidence_ref_json (entry : evidence_ref) =
   `Assoc
@@ -109,7 +105,7 @@ let finding_json (finding : finding) =
       ("reason_code", `String finding.reason_code);
       ("domain_id", `String finding.domain_id);
       ("severity", `String (level_to_string finding.severity));
-      ("keeper_name", string_opt_to_json finding.keeper_name);
+      ("keeper_name", Json_util.string_opt_to_json finding.keeper_name);
       ("summary", `String finding.summary);
       ("human_action_required", `Bool finding.human_action_required);
       ("suggested_next_action", `String finding.suggested_next_action);
@@ -816,7 +812,7 @@ let keeper_snapshot_json
       ("sandbox_backend", `String (Keeper_sandbox.backend_to_string sandbox.backend));
       ("network_mode", `String sandbox.network_mode);
       ("sandbox_root", `String sandbox.host_root_abs);
-      ("container_root", string_opt_to_json sandbox.container_root);
+      ("container_root", Json_util.string_opt_to_json sandbox.container_root);
       ("sandbox_live", sandbox_live);
       ("goal", `String meta.goal);
       ("goal_horizons",
@@ -834,7 +830,7 @@ let keeper_snapshot_json
       ("total_turns", `Int meta.runtime.usage.total_turns);
       ("approval_pending_count", `Int snapshot.approval.count);
       ("recent_activity_count", `Int snapshot.activity.count);
-      ("last_activity_ts", float_opt_to_json snapshot.activity.last_ts);
+      ("last_activity_ts", Json_util.float_opt_to_json snapshot.activity.last_ts);
       ( "last_blocker"
       , match meta.runtime.last_blocker with
         | Some info -> Keeper_types.blocker_info_to_json info
@@ -849,7 +845,7 @@ let keeper_snapshot_json
                 ("model_label", `String "runtime");
                 ("composite_score", `Float recommendation.composite_score);
                 ("task_pass_rate", `Float recommendation.task_pass_rate);
-                ("stability_score", float_opt_to_json recommendation.stability_score);
+                ("stability_score", Json_util.float_opt_to_json recommendation.stability_score);
                 ("cases_total", `Int recommendation.cases_total);
                 ("cases_passed", `Int recommendation.cases_passed);
               ] );
@@ -893,7 +889,7 @@ let timeline_entries_json
             ("ts", `Float item.created_at);
             ("ts_iso", `String (Masc_domain.iso8601_of_unix_seconds item.created_at));
             ("kind", `String item.kind);
-            ("keeper_name", string_opt_to_json keeper_name);
+            ("keeper_name", Json_util.string_opt_to_json keeper_name);
             ("actor", `String item.agent_name);
             ("summary", `String item.summary);
           ]))

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -82,13 +82,6 @@ let level_rank = Dashboard_safe_autonomy_level.level_rank
 let worse_level = Dashboard_safe_autonomy_level.worse_level
 let worst_level = Dashboard_safe_autonomy_level.worst_level
 
-let non_empty_string_opt value =
-  let trimmed = String.trim value in
-  if trimmed = "" then None else Some trimmed
-
-let normalize_string_opt = String_util.option_trim
-
-
 let evidence_ref_json (entry : evidence_ref) =
   `Assoc
     [
@@ -533,11 +526,11 @@ let classify_cascade_fsm ~(config : Coord.config) ~(meta : keeper_meta) =
   let blocker_json = `Assoc blocker_fields in
   let blocker_class =
     Safe_ops.json_string_opt "runtime_blocker_class" blocker_json
-    |> normalize_string_opt
+    |> String_util.option_trim
   in
   let blocker_summary =
     Safe_ops.json_string_opt "runtime_blocker_summary" blocker_json
-    |> normalize_string_opt
+    |> String_util.option_trim
   in
   let continue_gate =
     Safe_ops.json_bool ~default:false "runtime_blocker_continue_gate" blocker_json

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -23,8 +23,6 @@ let clamp_limit limit =
   else if l > max_limit then max_limit
   else l
 
-let iso_of_unix = Dashboard_utils.iso_of_unix
-
 (** Criteria carry the "completion_contract" in their Custom text.
     Non-Custom criteria (Contains, Schema_match, ...) are automated checks,
     not contract text, so we skip them here. *)
@@ -146,7 +144,7 @@ let request_to_json (req : V.verification_request) : Yojson.Safe.t =
      | Some v -> `String v
      | None -> `Null);
     ("status", `String status);
-    ("created_at", `String (iso_of_unix req.created_at));
+    ("created_at", `String (Dashboard_utils.iso_of_unix req.created_at));
     ("submitted_by", `String req.worker);
     ("approved_by",
      match approved_by with
@@ -251,7 +249,7 @@ let rejection_row_json (req : V.verification_request) : Yojson.Safe.t =
      | Some v -> `String v
      | None -> `Null);
     ("verdict_reason", `String verdict_reason);
-    ("created_at", `String (iso_of_unix req.created_at));
+    ("created_at", `String (Dashboard_utils.iso_of_unix req.created_at));
   ]
 
 let is_rejected (req : V.verification_request) : bool =

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -66,13 +66,10 @@ let provider_runs_mutex = Eio.Mutex.create ()
 let finished_run_ttl_seconds = Env_config.InternalTimers.provider_run_ttl_sec
 let max_finished_runs = 128
 
-let trim_nonempty value =
-  let trimmed = String.trim value in
-  if String.equal trimmed "" then None else Some trimmed
 
-let dedupe_keep_order values =
+let trim_and_dedupe values =
   values
-  |> List.filter_map trim_nonempty
+  |> List.filter_map String_util.trim_nonempty
   |> Json_util.dedupe_keep_order
 
 module Runtime_binding = Agent_sdk.Provider_runtime_binding
@@ -83,19 +80,19 @@ let binding_labels (binding : Runtime_binding.t) =
   let id = binding.Runtime_binding.id in
   let dashed_id = String.map (function '_' -> '-' | c -> c) id in
   id :: dashed_id :: binding.Runtime_binding.aliases
-  |> List.filter_map trim_nonempty
+  |> List.filter_map String_util.trim_nonempty
   |> List.map normalize_label
   |> Json_util.dedupe_keep_order
 
 let binding_endpoint_url (binding : Runtime_binding.t) =
-  trim_nonempty binding.Runtime_binding.base_url
+  String_util.trim_nonempty binding.Runtime_binding.base_url
 
 let binding_default_model_id (binding : Runtime_binding.t) =
-  Option.bind binding.Runtime_binding.default_model trim_nonempty
+  Option.bind binding.Runtime_binding.default_model String_util.trim_nonempty
 
 let binding_supported_models (binding : Runtime_binding.t) =
   match binding.Runtime_binding.capabilities.supported_models with
-  | Some models -> dedupe_keep_order models
+  | Some models -> trim_and_dedupe models
   | None -> []
 
 let binding_auth_kind (binding : Runtime_binding.t) =
@@ -136,7 +133,7 @@ let find_runtime_binding_by_candidates candidates =
   let rec loop = function
     | [] -> None
     | candidate :: rest -> (
-        match trim_nonempty candidate with
+        match String_util.trim_nonempty candidate with
         | None -> loop rest
         | Some label -> (
             match Runtime_binding.find label with
@@ -277,7 +274,7 @@ let llama_snapshot binding =
   in
   let default_model = binding_default_model_id binding in
   let models =
-    dedupe_keep_order
+    trim_and_dedupe
       (discovered_models @ Option.to_list default_model)
   in
   (* Merge OAS Discovery probe data for richer observability.
@@ -462,7 +459,7 @@ let resolve_provider_run_request ~provider ~model_opt ~prompt =
                   provider))
       else
         let selected_model =
-          match Option.bind model_opt trim_nonempty with
+          match Option.bind model_opt String_util.trim_nonempty with
           | Some model -> Some model
           | None -> snapshot.default_model
         in

--- a/lib/dashboard_tla_specs.ml
+++ b/lib/dashboard_tla_specs.ml
@@ -174,7 +174,7 @@ let normalize_int s =
   |> Stdlib.int_of_string_opt
 ;;
 
-let contains_substring needle haystack = String_util.contains_substring haystack needle
+
 
 let split_lines text = String.split_on_char '\n' text |> List.map String.trim
 
@@ -197,21 +197,21 @@ let ints_in_line line =
 let violation_line text =
   split_lines text
   |> List.find_opt (fun line ->
-    contains_substring " is violated" line
-    || contains_substring "Temporal properties were violated" line
-    || (contains_substring "Invariant " line && contains_substring "violated" line))
+    String_util.contains_substring line " is violated"
+    || String_util.contains_substring line "Temporal properties were violated"
+    || (String_util.contains_substring line "Invariant " && String_util.contains_substring line "violated"))
   |> Option.map String.trim
 ;;
 
 let status_of_log text =
-  if contains_substring "Model checking completed. No error has been found." text
+  if String_util.contains_substring text "Model checking completed. No error has been found."
   then Tlc_passed
   else if Option.is_some (violation_line text)
   then Tlc_violated
   else if
-    contains_substring "Error:" text
-    || contains_substring "Exception" text
-    || contains_substring "Parsing failed" text
+    String_util.contains_substring text "Error:"
+    || String_util.contains_substring text "Exception"
+    || String_util.contains_substring text "Parsing failed"
   then Tlc_error
   else Tlc_running
 ;;
@@ -230,8 +230,8 @@ let metrics_of_log text =
     split_lines text
     |> List.find_map (fun line ->
       if
-        contains_substring "states generated" line
-        && contains_substring "distinct states" line
+        String_util.contains_substring line "states generated"
+        && String_util.contains_substring line "distinct states"
       then (
         match ints_in_line line with
         | a :: b :: _ -> Some (a, b)
@@ -246,7 +246,7 @@ let metrics_of_log text =
   let diameter =
     split_lines text
     |> List.find_map (fun line ->
-      if contains_substring "depth of the complete state graph search" line
+      if String_util.contains_substring line "depth of the complete state graph search"
       then (
         match ints_in_line line with
         | value :: _ -> Some value

--- a/lib/dashboard_tool_host_events.ml
+++ b/lib/dashboard_tool_host_events.ml
@@ -28,16 +28,13 @@ type report = {
   timeout_ms : int option;
 }
 
-let trim_to_option value =
-  let trimmed = String.trim value in
-  if String.equal trimmed "" then None else Some trimmed
 
 let stringish_member_opt json key =
   let open Yojson.Safe.Util in
   match json |> member key with
-  | `String value -> trim_to_option value
+  | `String value -> String_util.trim_to_option value
   | `Int value -> Some (Int.to_string value)
-  | `Intlit value -> trim_to_option value
+  | `Intlit value -> String_util.trim_to_option value
   | `Float value -> Some (Printf.sprintf "%.0f" value)
   | `Null -> None
   | _ -> None
@@ -68,12 +65,12 @@ let report_of_yojson ?fallback_agent (json : Yojson.Safe.t) :
             | None ->
                 Option.value
                   ~default:"tool-host"
-                  (Option.bind fallback_agent trim_to_option)
+                  (Option.bind fallback_agent String_util.trim_to_option)
           in
           let explicit_agent =
-            Option.bind (stringish_member_opt json "agent_name") trim_to_option
+            Option.bind (stringish_member_opt json "agent_name") String_util.trim_to_option
           in
-          let fallback_agent = Option.bind fallback_agent trim_to_option in
+          let fallback_agent = Option.bind fallback_agent String_util.trim_to_option in
           let agent_name =
             match explicit_agent with
             | Some value -> value

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -107,8 +107,7 @@ let compact_text ?(max_len = 160) raw =
   if normalized = "" then ""
   else String_util.utf8_safe ~max_bytes:((max_len - 1) + 3) ~suffix:"\xe2\x80\xa6" normalized |> String_util.to_string
 
-let string_list_json values =
-  `List (List.map (fun v -> `String v) values)
+let string_list_json = Json_util.json_string_list
 
 let normalized_text_key text =
   compact_text ~max_len:512 text |> String.trim |> String.lowercase_ascii

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -56,10 +56,7 @@ let json_string_option value =
       if trimmed <> "" then `String trimmed else `Null
   | None -> `Null
 
-let option_to_json f = function
-  | Some value -> f value
-  | None -> `Null
-
+let option_to_json = Json_util.option_to_yojson
 let member_assoc key json =
   match json with
   | `Assoc fields -> (match List.assoc_opt key fields with Some v -> v | None -> `Null)

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -107,8 +107,6 @@ let compact_text ?(max_len = 160) raw =
   if normalized = "" then ""
   else String_util.utf8_safe ~max_bytes:((max_len - 1) + 3) ~suffix:"\xe2\x80\xa6" normalized |> String_util.to_string
 
-let string_list_json = Json_util.json_string_list
-
 let normalized_text_key text =
   compact_text ~max_len:512 text |> String.trim |> String.lowercase_ascii
 

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -28,9 +28,6 @@ let string_contains_ci ~needle haystack =
     ~needle:(String.lowercase_ascii needle)
     (String.lowercase_ascii haystack)
 
-let trim_to_option text =
-  let trimmed = String.trim text in
-  if trimmed = "" then None else Some trimmed
 
 module String_set = Set.Make(String)
 
@@ -48,7 +45,7 @@ let string_list_of_json json =
   | `List items ->
       items
       |> List.filter_map (function
-             | `String value -> trim_to_option value
+             | `String value -> String_util.trim_to_option value
              | _ -> None)
   | _ -> []
 

--- a/lib/dashboard_utils/dashboard_utils.mli
+++ b/lib/dashboard_utils/dashboard_utils.mli
@@ -62,7 +62,6 @@ val string_field : ?default:string -> string -> Yojson.Safe.t -> string
 val list_field : string -> Yojson.Safe.t -> Yojson.Safe.t list
 (** Read [key] as a [`List]. Default [[]]. *)
 
-val string_list_json : string list -> Yojson.Safe.t
 (** Wrap as [`List of `String]. *)
 
 (** {1 Ranking} *)

--- a/lib/dashboard_utils/dashboard_utils.mli
+++ b/lib/dashboard_utils/dashboard_utils.mli
@@ -23,7 +23,6 @@ val string_contains : needle:string -> string -> bool
 val string_contains_ci : needle:string -> string -> bool
 (** Case-insensitive substring test (lowercases both sides). *)
 
-val trim_to_option : string -> string option
 (** [Some s] for non-empty trimmed text, [None] otherwise. *)
 
 val dedup_strings : string list -> string list

--- a/lib/drift_guard.ml
+++ b/lib/drift_guard.ml
@@ -250,9 +250,6 @@ let result_to_json = function
 let drift_log_file (config : Coord.config) =
   Filename.concat (Coord.masc_dir config) "drift_guard.jsonl"
 
-let ensure_dir path =
-  Fs_compat.mkdir_p path
-
 let append_json_line path json =
   Fs_compat.append_jsonl path json
 
@@ -260,7 +257,7 @@ let verify_and_log config ~from_agent ~to_agent ~task_id ~original ~received
     ?threshold () =
   let result = verify_handoff ~original ~received ?threshold () in
   let log_path = drift_log_file config in
-  ensure_dir (Coord.masc_dir config);
+  Fs_compat.mkdir_p (Coord.masc_dir config);
   let entry =
     `Assoc
       [

--- a/lib/exec/path_scope.ml
+++ b/lib/exec/path_scope.ml
@@ -21,14 +21,14 @@ let sandbox_prefixes =
     "/private/tmp/masc_";
   ]
 
-let contains_substring s sub = String_util.contains_substring s sub
+
 
 let starts_with_any prefixes s =
   List.exists (fun p -> String.starts_with ~prefix:p s) prefixes
 
 let starts_with_sandbox abs =
   starts_with_any sandbox_prefixes abs
-  || contains_substring abs "/.masc/"
+  || String_util.contains_substring abs "/.masc/"
 
 (** Normalize [raw] against [cwd] using [Unix.realpath] on the parent
     directory, then re-attach the basename.  This resolves symlinks

--- a/lib/exec_policy_log_sanitize.ml
+++ b/lib/exec_policy_log_sanitize.ml
@@ -1,4 +1,3 @@
-let contains_substring s needle = String_util.contains_substring s needle
 
 let sensitive_flags =
   [ "--token"; "--password"; "--passwd"; "--auth-token"; "--api-key" ]
@@ -36,7 +35,7 @@ let redact_url_credentials token =
 
 let redact_inline_secret_assignment token =
   let redact_after token marker =
-    if contains_substring token marker
+    if String_util.contains_substring token marker
     then (
       let marker_len = String.length marker in
       let rec find i =
@@ -56,9 +55,9 @@ let redact_inline_secret_assignment token =
 
 let command_has_sensitive_marker cmd =
   let lower = String.lowercase_ascii cmd in
-  List.exists (fun flag -> contains_substring lower flag) sensitive_flags
+  List.exists (fun flag -> String_util.contains_substring lower flag) sensitive_flags
   || List.exists
-       (fun marker -> contains_substring lower (String.lowercase_ascii marker))
+       (fun marker -> String_util.contains_substring lower (String.lowercase_ascii marker))
        sensitive_assignment_markers
 ;;
 

--- a/lib/failure_envelope.ml
+++ b/lib/failure_envelope.ml
@@ -50,11 +50,7 @@ let to_severity : severity -> Severity.t = function
   | Bad -> Error
   | Critical -> Critical
 
-let option_to_json f = function
-  | Some value -> f value
-  | None -> `Null
-
-
+let option_to_json = Json_util.option_to_yojson
 let first_non_empty values =
   List.find_map (fun value -> Option.bind value String_util.trim_to_option) values
 

--- a/lib/failure_envelope.ml
+++ b/lib/failure_envelope.ml
@@ -54,12 +54,9 @@ let option_to_json f = function
   | Some value -> f value
   | None -> `Null
 
-let trim_to_option value =
-  let trimmed = String.trim value in
-  if trimmed = "" then None else Some trimmed
 
 let first_non_empty values =
-  List.find_map (fun value -> Option.bind value trim_to_option) values
+  List.find_map (fun value -> Option.bind value String_util.trim_to_option) values
 
 let tool_host_cause_code ?timeout_ms message =
   let lower = String.lowercase_ascii message in
@@ -111,10 +108,10 @@ let tool_host_failure ~agent_name ~client_name ~tool_name ~transport ?phase
              Some ("tool_name", `String tool_name);
              Some ("transport", `String transport);
              Some ("message", `String message);
-             Option.map (fun value -> ("phase", `String value)) (Option.bind phase trim_to_option);
-             Option.map (fun value -> ("request_id", `String value)) (Option.bind request_id trim_to_option);
-             Option.map (fun value -> ("session_id", `String value)) (Option.bind session_id trim_to_option);
-             Option.map (fun value -> ("trace_id", `String value)) (Option.bind trace_id trim_to_option);
+             Option.map (fun value -> ("phase", `String value)) (Option.bind phase String_util.trim_to_option);
+             Option.map (fun value -> ("request_id", `String value)) (Option.bind request_id String_util.trim_to_option);
+             Option.map (fun value -> ("session_id", `String value)) (Option.bind session_id String_util.trim_to_option);
+             Option.map (fun value -> ("trace_id", `String value)) (Option.bind trace_id String_util.trim_to_option);
              Option.map (fun value -> ("timeout_ms", `Int value)) timeout_ms;
            ]);
   }
@@ -147,7 +144,7 @@ let required_string json key =
 let optional_string json key =
   let open Yojson.Safe.Util in
   match json |> member key with
-  | `String value -> trim_to_option value
+  | `String value -> String_util.trim_to_option value
   | _ -> None
 
 let of_yojson json =

--- a/lib/failure_envelope.ml
+++ b/lib/failure_envelope.ml
@@ -50,7 +50,6 @@ let to_severity : severity -> Severity.t = function
   | Bad -> Error
   | Critical -> Critical
 
-let option_to_json = Json_util.option_to_yojson
 let first_non_empty values =
   List.find_map (fun value -> Option.bind value String_util.trim_to_option) values
 
@@ -117,12 +116,12 @@ let to_yojson (envelope : t) =
     [
       ("surface", `String envelope.surface);
       ("entity_kind", `String envelope.entity_kind);
-      ("entity_id", option_to_json (fun value -> `String value) envelope.entity_id);
+      ("entity_id", Json_util.option_to_yojson (fun value -> `String value) envelope.entity_id);
       ("cause_code", `String envelope.cause_code);
       ("severity", `String (severity_to_string envelope.severity));
       ("summary", `String envelope.summary);
       ("recoverability", `String (recoverability_to_string envelope.recoverability));
-      ("operator_action", option_to_json (fun value -> `String value) envelope.operator_action);
+      ("operator_action", Json_util.option_to_yojson (fun value -> `String value) envelope.operator_action);
       ("evidence_ref", envelope.evidence_ref);
     ]
 

--- a/lib/governance_anomaly.ml
+++ b/lib/governance_anomaly.ml
@@ -244,11 +244,9 @@ let baseline_dir base_path =
 let profile_path base_path agent_id =
   Filename.concat (baseline_dir base_path) (agent_id ^ ".json")
 
-let ensure_dir path = Fs_compat.mkdir_p path
-
 let save_profile ~base_path (profile : behavioral_profile) =
   let path = profile_path base_path profile.agent_id in
-  ensure_dir (Filename.dirname path);
+  Fs_compat.mkdir_p (Filename.dirname path);
   let json = profile_json profile in
   Fs_compat.save_file path (Yojson.Safe.pretty_to_string json)
 

--- a/lib/ide/ide_annotation_types.ml
+++ b/lib/ide/ide_annotation_types.ml
@@ -21,6 +21,13 @@ let json_kind_name = function
   | `List _ -> "array"
 ;;
 
+(* Local option serializer — [lib/ide/] does not depend on [masc_core] (RFC-0056
+   leaf-isolation invariant), so we inline rather than import [Json_util]. *)
+let string_opt_to_json = function
+  | None -> `Null
+  | Some s -> `String s
+;;
+
 type annotation_kind =
   | Comment
   | Decision
@@ -95,10 +102,6 @@ type annotation_filter =
   ; task_id : string option
   }
 
-let string_opt_to_json = function
-  | None -> `Null
-  | Some s -> `String s
-;;
 
 let annotation_to_json (a : annotation) : Yojson.Safe.t =
   `Assoc

--- a/lib/jsonl_writer/jsonl_writer.ml
+++ b/lib/jsonl_writer/jsonl_writer.ml
@@ -5,7 +5,7 @@ type dated_path =
   ; path : string
   }
 
-let ensure_dir = Fs_compat.mkdir_p
+
 
 let dated_path ~base_dir ~ts =
   let tm = Unix.gmtime ts in

--- a/lib/jsonl_writer/jsonl_writer.mli
+++ b/lib/jsonl_writer/jsonl_writer.mli
@@ -11,7 +11,6 @@ type dated_path =
   ; path : string
   }
 
-val ensure_dir : string -> unit
 (** Create a directory and its parents when missing. *)
 
 val dated_path : base_dir:string -> ts:float -> dated_path

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1593,9 +1593,6 @@ let run_turn
          Keeper_runtime_manifest.execution_receipt_path_for_today config
            ~keeper_name:meta.name
        in
-       let json_string_list values =
-         `List (List.map (fun value -> `String value) values)
-       in
        let receipt_manifest_decision ?receipt_append_ok () =
          `Assoc
            [
@@ -1613,11 +1610,11 @@ let run_turn
                `String
                  (Keeper_execution_receipt.cascade_outcome_to_string
                     receipt.cascade_outcome) );
-             ("requested_tools", json_string_list receipt.requested_tools);
-             ("reported_tools", json_string_list receipt.reported_tools);
-             ("observed_tools", json_string_list receipt.observed_tools);
-             ("canonical_tools", json_string_list receipt.canonical_tools);
-             ("tools_used", json_string_list receipt.tools_used);
+             ("requested_tools", Json_util.json_string_list receipt.requested_tools);
+             ("reported_tools", Json_util.json_string_list receipt.reported_tools);
+             ("observed_tools", Json_util.json_string_list receipt.observed_tools);
+             ("canonical_tools", Json_util.json_string_list receipt.canonical_tools);
+             ("tools_used", Json_util.json_string_list receipt.tools_used);
              ( "receipt_append_ok",
                match receipt_append_ok with
                | None -> `Null

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -25,21 +25,20 @@ let merge_usage
        | Some x, None | None, Some x -> Some x
        | None, None -> None) }
 
-let contains_ci = String_util.contains_substring_ci
 
 let alert_retryable_error (msg : string) : bool =
   let text = String.lowercase_ascii (String.trim msg) in
   text <> ""
-  && (contains_ci text "timeout"
-      || contains_ci text "timed out"
-      || contains_ci text "429"
-      || contains_ci text "502"
-      || contains_ci text "503"
-      || contains_ci text "504"
-      || contains_ci text "connection reset"
-      || contains_ci text "connection refused"
-      || contains_ci text "temporary"
-      || contains_ci text "network")
+  && (String_util.contains_substring_ci text "timeout"
+      || String_util.contains_substring_ci text "timed out"
+      || String_util.contains_substring_ci text "429"
+      || String_util.contains_substring_ci text "502"
+      || String_util.contains_substring_ci text "503"
+      || String_util.contains_substring_ci text "504"
+      || String_util.contains_substring_ci text "connection reset"
+      || String_util.contains_substring_ci text "connection refused"
+      || String_util.contains_substring_ci text "temporary"
+      || String_util.contains_substring_ci text "network")
 
 let alert_retry_delay_seconds (attempt : int) : float =
   let base_ms = max 0 Env_config.KeeperAlert.retry_base_delay_ms in
@@ -100,7 +99,6 @@ let run_alert_channel_with_retry
     in
     loop 1 None
 
-let dedup_strings = Dashboard_utils.dedup_strings
 
 (** Alert dedup: suppress identical alerts within a time window (default 60s). *)
 let alert_dedup_window_sec = Env_config.AlertDedup.window_sec
@@ -207,7 +205,7 @@ let keeper_alert_signal
   let keyword_hits =
     alert_keyword_weights
     |> List.filter_map (fun (kw, w) ->
-         if contains_ci corpus kw then Some (kw, w) else None)
+         if String_util.contains_substring_ci corpus kw then Some (kw, w) else None)
   in
   let keyword_score =
     keyword_hits
@@ -235,7 +233,7 @@ let keeper_alert_signal
     reasons := "multi_tool_action" :: !reasons
   end;
   let score = max 0.0 (min 1.0 !score) in
-  let keywords = keyword_hits |> List.map fst |> dedup_strings in
+  let keywords = keyword_hits |> List.map fst |> Dashboard_utils.dedup_strings in
   (score, List.rev !reasons, keywords)
 
 let keeper_alert_text

--- a/lib/keeper/keeper_alerting.mli
+++ b/lib/keeper/keeper_alerting.mli
@@ -192,5 +192,4 @@ val extract_user_messages : working_context -> string list
 (** {1 Re-exported Utilities} *)
 
 val keeper_model_tools : Masc_domain.tool_schema list
-val dedup_strings : string list -> string list
 val split_csv_nonempty : string -> string list

--- a/lib/keeper/keeper_cdal_contract.ml
+++ b/lib/keeper/keeper_cdal_contract.ml
@@ -6,10 +6,6 @@ let string_list_to_json values =
   `List (List.map (fun value -> `String value) values)
 ;;
 
-let string_opt_to_json = function
-  | None -> `Null
-  | Some value -> `String value
-;;
 
 let task_id_opt_to_json = function
   | None -> `Null
@@ -31,7 +27,7 @@ let of_keeper_meta (meta : Keeper_types.keeper_meta) : RC.t option =
       ; "agent_name", `String meta.agent_name
       ; "sandbox_profile", `String (Keeper_types.sandbox_profile_to_string meta.sandbox_profile)
       ; "network_mode", `String (Keeper_types.network_mode_to_string meta.network_mode)
-      ; "sandbox_image", string_opt_to_json meta.sandbox_image
+      ; "sandbox_image", Json_util.string_opt_to_json meta.sandbox_image
       ; "tool_access", Keeper_types.tool_access_to_json meta.tool_access
       ; "tool_denylist", string_list_to_json meta.tool_denylist
       ; "allowed_paths", string_list_to_json meta.allowed_paths

--- a/lib/keeper/keeper_exec_board.ml
+++ b/lib/keeper/keeper_exec_board.ml
@@ -94,12 +94,11 @@ let re_matches_compiled re text =
   | Not_found -> false
 ;;
 
-let contains_substring haystack needle = String_util.contains_substring haystack needle
 
 let content_has_inline_quantitative_evidence content =
   let lower = String.lowercase_ascii content in
   List.exists
-    (contains_substring lower)
+    (String_util.contains_substring lower)
     [ "command: rg -n"
     ; "command: grep -n"
     ; "command: git grep -n"

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -11,7 +11,6 @@
 
 open Keeper_types
 
-let contains_ci = String_util.contains_substring_ci
 
 (* ================================================================ *)
 (* Re-export from Keeper_context_core                                *)
@@ -457,7 +456,7 @@ let append_trait_clause ~(base : string) ~(clause : string) : string =
   let c = String.trim clause in
   if c = "" then b
   else if b = "" then c
-  else if contains_ci b c then b
+  else if String_util.contains_substring_ci b c then b
   else Printf.sprintf "%s; %s" b c
 
 

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -338,7 +338,6 @@ val append_trait_clause : base:string -> clause:string -> string
 (** {1 Text Processing} *)
 
 val strip_state_blocks_text : string -> string
-val trim_to_option : string -> string option
 val user_visible_reply_text : ?fallback:string -> string -> string
 
 (** {1 Fragment Detection (used by dashboard)} *)

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -3,7 +3,6 @@ open Keeper_exec_shared
 open Keeper_exec_context
 module StringSet = Set.Make (String)
 
-let contains_ci = String_util.contains_substring_ci
 
 (* Issue #8484: Variant SSOT for memory search scope. Adding a new
    constructor forces compilation in [memory_search_source_to_string]
@@ -161,7 +160,7 @@ let search_memory_bank
   let matched =
     if query = ""
     then filtered
-    else List.filter (fun m -> contains_ci m.text query) filtered
+    else List.filter (fun m -> String_util.contains_substring_ci m.text query) filtered
   in
   (* Scoring: priority * recency_weight.
      recency_weight normalizes age relative to the oldest note in the result set.

--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -354,46 +354,46 @@ let resolved_keeper_args_from_persona args :
         in
         let goal =
           get_string_opt args "goal"
-          |> first_some defaults.goal
+          |> Dashboard_utils.first_some defaults.goal
           |> Option.value ~default:""
           |> normalize_goal_horizon_text
         in
         let short_goal =
           parse_goal_horizon_opt args "short_goal"
-          |> first_some defaults.short_goal
+          |> Dashboard_utils.first_some defaults.short_goal
           |> Option.value ~default:goal
           |> normalize_goal_horizon_text
         in
         let mid_goal =
           parse_goal_horizon_opt args "mid_goal"
-          |> first_some defaults.mid_goal
+          |> Dashboard_utils.first_some defaults.mid_goal
           |> Option.value ~default:goal
           |> normalize_goal_horizon_text
         in
         let long_goal =
           parse_goal_horizon_opt args "long_goal"
-          |> first_some defaults.long_goal
+          |> Dashboard_utils.first_some defaults.long_goal
           |> Option.value ~default:goal
           |> normalize_goal_horizon_text
         in
         let instructions =
           get_string_opt args "instructions"
-          |> first_some defaults.instructions
+          |> Dashboard_utils.first_some defaults.instructions
           |> Option.value ~default:""
         in
         let will =
           parse_self_model_opt args "will"
-          |> first_some defaults.will
+          |> Dashboard_utils.first_some defaults.will
           |> Option.value ~default:(Env_config_core.keeper_will ())
         in
         let needs =
           parse_self_model_opt args "needs"
-          |> first_some defaults.needs
+          |> Dashboard_utils.first_some defaults.needs
           |> Option.value ~default:(Env_config_core.keeper_needs ())
         in
         let desires =
           parse_self_model_opt args "desires"
-          |> first_some defaults.desires
+          |> Dashboard_utils.first_some defaults.desires
           |> Option.value ~default:(Env_config_core.keeper_desires ())
         in
             let mention_targets =
@@ -409,7 +409,7 @@ let resolved_keeper_args_from_persona args :
             in
             let proactive_enabled =
               get_bool_opt args "proactive_enabled"
-              |> first_some defaults.proactive_enabled
+              |> Dashboard_utils.first_some defaults.proactive_enabled
               |> Option.value ~default:false
             in
             let autoboot_enabled = get_bool_opt args "autoboot_enabled" in

--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -2,13 +2,7 @@ open Keeper_types
 
 let json_string_field name json = Json_util.get_string json name
 
-let json_string_opt = function
-  | Some value -> `String value
-  | None -> `Null
-
-let json_string_list values =
-  `List (List.map (fun value -> `String value) values)
-
+let json_string_opt = Json_util.string_opt_to_json
 let quote_argv argv = String.concat " " (List.map Filename.quote argv)
 
 type cascade_resilience =
@@ -85,7 +79,7 @@ let cascade_resilience_to_json resilience =
   `Assoc
     [ "ok", `Bool resilience.ok
     ; "cascade", `String resilience.cascade_name
-    ; "model_labels", json_string_list resilience.model_labels
+    ; "model_labels", Json_util.json_string_list resilience.model_labels
     ; "model_label_count", `Int (List.length resilience.model_labels)
     ; "pure_local", `Bool resilience.pure_local
     ; "fallback_cascade", json_string_opt resilience.fallback_cascade

--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -2,7 +2,6 @@ open Keeper_types
 
 let json_string_field name json = Json_util.get_string json name
 
-let json_string_opt = Json_util.string_opt_to_json
 let quote_argv argv = String.concat " " (List.map Filename.quote argv)
 
 type cascade_resilience =
@@ -82,10 +81,10 @@ let cascade_resilience_to_json resilience =
     ; "model_labels", Json_util.json_string_list resilience.model_labels
     ; "model_label_count", `Int (List.length resilience.model_labels)
     ; "pure_local", `Bool resilience.pure_local
-    ; "fallback_cascade", json_string_opt resilience.fallback_cascade
-    ; "blocker", json_string_opt resilience.blocker
-    ; "error", json_string_opt resilience.error
-    ; "hint", json_string_opt resilience.hint
+    ; "fallback_cascade", Json_util.string_opt_to_json resilience.fallback_cascade
+    ; "blocker", Json_util.string_opt_to_json resilience.blocker
+    ; "error", Json_util.string_opt_to_json resilience.error
+    ; "hint", Json_util.string_opt_to_json resilience.hint
     ]
 
 let cascade_resilience_error_message resilience =

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -60,7 +60,6 @@ let search_char c =
 
 let normalize_search_text text = String.lowercase_ascii (String.map search_char text)
 
-let contains_substring text needle = String_util.contains_substring text needle
 
 let search_terms query =
   normalize_search_text query
@@ -104,9 +103,9 @@ let score_tool_schema terms (schema : Masc_domain.tool_schema) =
   in
   List.fold_left
     (fun score term ->
-       if contains_substring name_text term
+       if String_util.contains_substring name_text term
        then score +. 2.0
-       else if contains_substring search_text term
+       else if String_util.contains_substring search_text term
        then score +. 1.0
        else score)
     0.0

--- a/lib/keeper/keeper_generation_lineage.ml
+++ b/lib/keeper/keeper_generation_lineage.ml
@@ -21,7 +21,6 @@ let identity_fields : (string * (keeper_meta -> string)) list =
 let string_list_to_json xs =
   `List (List.map (fun s -> `String s) xs)
 
-let float_opt_to_json = Json_util.float_opt_to_json
 let option_to_json = Json_util.option_to_yojson
 let generation_id ~keeper_name ~generation ~trace_id =
   Printf.sprintf "%s:%d:%s" keeper_name generation trace_id
@@ -205,7 +204,7 @@ let index_entry_json
       ("context_ratio", `Float context_ratio);
       ("to_model", `String model);
       ("continuity_verdict", `String continuity.verdict);
-      ("continuity_similarity", float_opt_to_json continuity.similarity);
+      ("continuity_similarity", Json_util.float_opt_to_json continuity.similarity);
       ("identity_inherited_fields", string_list_to_json inherited_fields);
       ("identity_changed_fields", string_list_to_json changed_fields);
       ("identity_dropped_fields", string_list_to_json dropped_fields);

--- a/lib/keeper/keeper_generation_lineage.ml
+++ b/lib/keeper/keeper_generation_lineage.ml
@@ -21,10 +21,7 @@ let identity_fields : (string * (keeper_meta -> string)) list =
 let string_list_to_json xs =
   `List (List.map (fun s -> `String s) xs)
 
-let float_opt_to_json = function
-  | Some value -> `Float value
-  | None -> `Null
-
+let float_opt_to_json = Json_util.float_opt_to_json
 let option_to_json = Json_util.option_to_yojson
 let generation_id ~keeper_name ~generation ~trace_id =
   Printf.sprintf "%s:%d:%s" keeper_name generation trace_id

--- a/lib/keeper/keeper_generation_lineage.ml
+++ b/lib/keeper/keeper_generation_lineage.ml
@@ -25,10 +25,7 @@ let float_opt_to_json = function
   | Some value -> `Float value
   | None -> `Null
 
-let option_to_json f = function
-  | Some value -> f value
-  | None -> `Null
-
+let option_to_json = Json_util.option_to_yojson
 let generation_id ~keeper_name ~generation ~trace_id =
   Printf.sprintf "%s:%d:%s" keeper_name generation trace_id
 

--- a/lib/keeper/keeper_generation_lineage.ml
+++ b/lib/keeper/keeper_generation_lineage.ml
@@ -21,7 +21,6 @@ let identity_fields : (string * (keeper_meta -> string)) list =
 let string_list_to_json xs =
   `List (List.map (fun s -> `String s) xs)
 
-let option_to_json = Json_util.option_to_yojson
 let generation_id ~keeper_name ~generation ~trace_id =
   Printf.sprintf "%s:%d:%s" keeper_name generation trace_id
 
@@ -328,7 +327,7 @@ let surface_json (config : Coord.config) (meta : keeper_meta) ~recent_limit =
       ("manifest_path", `String manifest_path);
       ("index_path", `String index_path);
       ("manifest_available", `Bool (Option.is_some manifest));
-      ("manifest", option_to_json Fun.id manifest);
+      ("manifest", Json_util.option_to_yojson Fun.id manifest);
       ("recent_count", `Int (List.length index_entries));
       ("recent", `List recent);
     ]

--- a/lib/keeper/keeper_generation_lineage.mli
+++ b/lib/keeper/keeper_generation_lineage.mli
@@ -18,9 +18,6 @@ val identity_fields :
 
 val string_list_to_json : string list -> Yojson.Safe.t
 
-val option_to_json :
-  ('a -> Yojson.Safe.t) -> 'a option -> Yojson.Safe.t
-
 (** Compose the canonical [<keeper>:<generation>:<trace_id>]
     generation identifier. *)
 val generation_id :

--- a/lib/keeper/keeper_generation_lineage.mli
+++ b/lib/keeper/keeper_generation_lineage.mli
@@ -17,7 +17,6 @@ val identity_fields :
   (string * (Keeper_types.keeper_meta -> string)) list
 
 val string_list_to_json : string list -> Yojson.Safe.t
-val float_opt_to_json : float option -> Yojson.Safe.t
 
 val option_to_json :
   ('a -> Yojson.Safe.t) -> 'a option -> Yojson.Safe.t

--- a/lib/keeper/keeper_hooks_oas_output_json.ml
+++ b/lib/keeper/keeper_hooks_oas_output_json.ml
@@ -184,9 +184,7 @@ let route_via_of_json json =
   ]
   |> List.find_map Fun.id
 
-let non_empty_string_opt = String_util.option_trim
-
-let string_field_opt key json = Safe_ops.json_string_opt key json |> non_empty_string_opt
+let string_field_opt key json = Safe_ops.json_string_opt key json |> String_util.option_trim
 
 let nested_string_field_opt parent key json =
   match assoc_field parent json with

--- a/lib/keeper/keeper_hooks_oas_output_json.ml
+++ b/lib/keeper/keeper_hooks_oas_output_json.ml
@@ -184,11 +184,7 @@ let route_via_of_json json =
   ]
   |> List.find_map Fun.id
 
-let non_empty_string_opt = function
-  | Some value ->
-      let value = String.trim value in
-      if String.equal value "" then None else Some value
-  | None -> None
+let non_empty_string_opt = String_util.option_trim
 
 let string_field_opt key json = Safe_ops.json_string_opt key json |> non_empty_string_opt
 

--- a/lib/keeper/keeper_hooks_oas_pr_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_pr_metrics.ml
@@ -14,7 +14,7 @@ let pr_review_action_metric_event_of_tool_io
   then
     let output_json = output_json_opt ~surface:"pr_review_action" output_text in
     let route_via =
-      first_some (Option.bind output_json route_via_of_json)
+      Dashboard_utils.first_some (Option.bind output_json route_via_of_json)
         route_via_fallback
     in
     let action =
@@ -39,7 +39,7 @@ let pr_review_action_metric_event_of_tool_io
          {
            action;
            pr_number =
-             first_some
+             Dashboard_utils.first_some
                (match output_json with
                 | Some json -> json_int_opt "pr_number" json
                 | None -> None)
@@ -55,7 +55,7 @@ let pr_review_action_metric_event_of_tool_io
   then
     let output_json = output_json_opt ~surface:"pr_review_action" output_text in
     let route_via =
-      first_some (Option.bind output_json route_via_of_json)
+      Dashboard_utils.first_some (Option.bind output_json route_via_of_json)
         route_via_fallback
     in
     let success =
@@ -69,13 +69,13 @@ let pr_review_action_metric_event_of_tool_io
       {
         action = "REPLY";
         pr_number =
-          first_some
+          Dashboard_utils.first_some
             (match output_json with
              | Some json -> json_int_opt "pr_number" json
              | None -> None)
             (json_int_opt "pr_number" input);
         comment_id =
-          first_some
+          Dashboard_utils.first_some
             (match output_json with
              | Some json -> json_int_opt "comment_id" json
              | None -> None)
@@ -158,7 +158,7 @@ let pr_work_action_metric_events_of_tool_io
       ~surface:"pr_work_action" output_text
   in
   let route_via =
-    first_some (Option.bind output_json route_via_of_json)
+    Dashboard_utils.first_some (Option.bind output_json route_via_of_json)
       route_via_fallback
   in
   let success = output_success ~transport_success output_json in

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -123,7 +123,6 @@ val mid_term_horizon : string
 val long_term_horizon : string
 val memory_horizon_of_kind_opt : string -> string option
 val memory_horizon_of_json_opt : Yojson.Safe.t -> string option
-val trim_nonempty : string -> string option
 val split_state_items : string -> string list
 val strip_prefix_ci : prefix:string -> string -> string option
 val find_state_block : string -> string option

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -245,9 +245,6 @@ let memory_horizon_of_json_opt (json : Yojson.Safe.t) : string option =
   | "long_term" -> Some long_term_horizon
   | _ -> None
 
-let trim_nonempty (s : string) : string option =
-  let t = String.trim s in
-  if t = "" then None else Some t
 
 let split_state_items (s : string) : string list =
   s
@@ -285,19 +282,19 @@ let state_snapshot_of_lines (lines : string list) : keeper_state_snapshot option
     List.fold_left
       (fun acc line ->
         match strip_prefix_ci ~prefix:"Goal:" line with
-        | Some v -> { acc with goal = trim_nonempty v }
+        | Some v -> { acc with goal = String_util.trim_nonempty v }
         | None ->
             (match strip_prefix_ci ~prefix:"DONE:" line with
-            | Some v -> { acc with done_summary = trim_nonempty v;
+            | Some v -> { acc with done_summary = String_util.trim_nonempty v;
                                    progress = (match acc.progress with
-                                               | None -> trim_nonempty v
+                                               | None -> String_util.trim_nonempty v
                                                | existing -> existing) }
             | None ->
             (match strip_prefix_ci ~prefix:"Progress:" line with
-            | Some v -> { acc with progress = trim_nonempty v }
+            | Some v -> { acc with progress = String_util.trim_nonempty v }
             | None ->
                 (match strip_prefix_ci ~prefix:"NEXT:" line with
-                | Some v -> { acc with next_summary = trim_nonempty v;
+                | Some v -> { acc with next_summary = String_util.trim_nonempty v;
                                        next_items = (match acc.next_items with
                                                      | [] -> split_state_items v
                                                      | existing -> existing) }

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -177,7 +177,6 @@ val memory_horizon_of_json_opt : Yojson.Safe.t -> string option
 
 (** {1 [STATE] block parsing} *)
 
-val trim_nonempty : string -> string option
 (** [Some trimmed] when [text] is non-blank, else [None]. *)
 
 val split_state_items : string -> string list

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -296,7 +296,7 @@ let latest_message_content_by_role
     |> List.find_opt (fun (m : Agent_sdk.Types.message) -> m.role = role)
   with
   | None -> None
-  | Some m -> trim_nonempty (String.trim (Agent_sdk.Types.text_of_message m))
+  | Some m -> String_util.trim_nonempty (String.trim (Agent_sdk.Types.text_of_message m))
 
 let previous_assistant_message_content
     (messages : Agent_sdk.Types.message list) : string option =
@@ -304,7 +304,7 @@ let previous_assistant_message_content
     messages
     |> List.rev
     |> List.filter_map (fun (m : Agent_sdk.Types.message) ->
-         if m.role = Agent_sdk.Types.Assistant then trim_nonempty (Agent_sdk.Types.text_of_message m) else None)
+         if m.role = Agent_sdk.Types.Assistant then String_util.trim_nonempty (Agent_sdk.Types.text_of_message m) else None)
   in
   match assistants with
   | _latest :: previous :: _ -> Some previous
@@ -315,7 +315,7 @@ let goal_horizon_candidates (meta : keeper_meta) : string list =
   |> List.filter_map (fun raw ->
        raw
        |> normalize_goal_horizon_text
-       |> trim_nonempty)
+       |> String_util.trim_nonempty)
   |> List.fold_left
        (fun acc goal ->
          let key = normalize_memory_text_key goal in

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -41,12 +41,7 @@ let assoc_keys = function
   | _ -> []
 ;;
 
-let trim_nonempty_opt = function
-  | Some raw ->
-    let value = String.trim raw in
-    if value = "" then None else Some value
-  | None -> None
-;;
+let trim_nonempty_opt = String_util.option_trim
 
 let json_trimmed_string_opt key json =
   Safe_ops.json_string_opt key json |> trim_nonempty_opt
@@ -963,4 +958,3 @@ let handle_persona_generate ctx args =
                 , error_response_typed
                     ~code:Validation_error
                     (Printf.sprintf "generation did not return parseable JSON: %s" msg) )))
-;;

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -41,10 +41,9 @@ let assoc_keys = function
   | _ -> []
 ;;
 
-let trim_nonempty_opt = String_util.option_trim
 
 let json_trimmed_string_opt key json =
-  Safe_ops.json_string_opt key json |> trim_nonempty_opt
+  Safe_ops.json_string_opt key json |> String_util.option_trim
 ;;
 
 let json_string_list_normalized key json =
@@ -677,7 +676,7 @@ let normalize_choice_arg ~field ~choices raw =
 ;;
 
 let optional_choice_arg ~field ~choices args =
-  match get_string_opt args field |> trim_nonempty_opt with
+  match get_string_opt args field |> String_util.option_trim with
   | None -> Ok None
   | Some raw ->
     Result.map

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -4,7 +4,6 @@
 
 open Keeper_types
 
-let contains_ci = String_util.contains_substring_ci
 
 (* Pre-compiled patterns for keeper name substitution in prompt templates.
    Top-level to avoid re-compilation on every build_keeper_system_prompt call. *)
@@ -390,7 +389,7 @@ let append_trait_clause ~(base : string) ~(clause : string) : string =
   let c = String.trim clause in
   if c = "" then b
   else if b = "" then c
-  else if contains_ci b c then b
+  else if String_util.contains_substring_ci b c then b
   else Printf.sprintf "%s; %s" b c
 
 include Keeper_text_processing

--- a/lib/keeper/keeper_routine_allowlist.ml
+++ b/lib/keeper/keeper_routine_allowlist.ml
@@ -182,14 +182,13 @@ let first_nonempty_string_field keys = function
       keys
   | _ -> None
 
-let contains_substring haystack needle = String_util.contains_substring haystack needle
 
 let path_has_git_dir path =
-  String.equal (Filename.basename path) ".git" || contains_substring path "/.git/"
+  String.equal (Filename.basename path) ".git" || String_util.contains_substring path "/.git/"
 
 let sandbox_worktree_code_path path =
-  contains_substring path "/repos/"
-  && contains_substring path "/.worktrees/"
+  String_util.contains_substring path "/repos/"
+  && String_util.contains_substring path "/.worktrees/"
   && not (path_has_git_dir path)
 
 let sandboxed_code_write_rule_label

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -125,10 +125,9 @@ let apply_default opt current = match opt with Some v -> v | None -> current
 (** Same as [apply_default] but both TOML and meta are option-typed. *)
 let apply_default_opt opt current = match opt with Some _ -> opt | None -> current
 
-let contains_substring haystack needle = String_util.contains_substring haystack needle
 
 let invalid_profile_defaults_error ~keeper_name detail =
-  if contains_substring detail "cascade_name" then
+  if String_util.contains_substring detail "cascade_name" then
     Printf.sprintf
       "invalid profile.cascade_name for keeper %s: unknown cascade_name: %s"
       keeper_name detail

--- a/lib/keeper/keeper_runtime.mli
+++ b/lib/keeper/keeper_runtime.mli
@@ -79,8 +79,6 @@ val apply_default_opt : 'a option -> 'a option -> 'a option
 (** [apply_default_opt primary fallback] returns [primary] when it is
     [Some], else [fallback]. *)
 
-val contains_substring : string -> string -> bool
-(** [true] when [haystack] contains [needle] (raw byte search). *)
 
 val invalid_profile_defaults_error : keeper_name:string -> string -> string
 (** Render the structured error message for a profile-defaults parse

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -207,9 +207,7 @@ let int_opt_json = function
   | Some value -> `Int value
   | None -> `Null
 
-let string_list_json values =
-  `List (List.map (fun value -> `String value) values)
-
+let string_list_json = Json_util.json_string_list
 let nonempty_list = function
   | Some values -> values
   | None -> []

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -256,7 +256,6 @@ let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
       ("cascade_profile", string_opt_json cascade_profile);
     ]
 
-let contains_substring haystack needle = String_util.contains_substring haystack needle
 
 let json_string_field name = function
   | `Assoc _ as json -> Json_util.get_string_nonempty json name
@@ -268,7 +267,7 @@ let first_string_field names json =
 let path_like_key key =
   let key = String.lowercase_ascii key in
   key = "cwd" || key = "dir" || key = "directory" || key = "file"
-  || contains_substring key "path"
+  || String_util.contains_substring key "path"
 
 let collect_observed_paths json =
   let rec loop acc = function

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -207,7 +207,6 @@ let int_opt_json = function
   | Some value -> `Int value
   | None -> `Null
 
-let string_list_json = Json_util.json_string_list
 let nonempty_list = function
   | Some values -> values
   | None -> []
@@ -236,19 +235,19 @@ let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
       ("generation", int_opt_json generation);
       ("keeper_turn_id", int_opt_json keeper_turn_id);
       ("task_id", string_opt_json task_id);
-      ("goal_ids", string_list_json (nonempty_list goal_ids));
+      ("goal_ids", Json_util.json_string_list (nonempty_list goal_ids));
       ("sandbox_profile", string_opt_json sandbox_profile);
       ("sandbox_root", string_opt_json sandbox_root);
-      ("allowed_paths", string_list_json (nonempty_list allowed_paths));
+      ("allowed_paths", Json_util.json_string_list (nonempty_list allowed_paths));
       ("network_mode", string_opt_json network_mode);
       ("approval_mode", string_opt_json approval_mode);
       ("tool_surface_class", string_opt_json tool_surface_class);
       ("visible_tool_count", int_opt_json visible_tool_count);
-      ("required_tools", string_list_json (nonempty_list required_tools));
+      ("required_tools", Json_util.json_string_list (nonempty_list required_tools));
       ( "required_tool_candidates",
-        string_list_json (nonempty_list required_tool_candidates) );
+        Json_util.json_string_list (nonempty_list required_tool_candidates) );
       ( "missing_required_tools",
-        string_list_json (nonempty_list missing_required_tools) );
+        Json_util.json_string_list (nonempty_list missing_required_tools) );
       ("provider", string_opt_json provider);
       ("model", string_opt_json model);
       ("cascade_profile", string_opt_json cascade_profile);
@@ -319,7 +318,7 @@ let action_radius_json ~tool_name ~input ~success ~duration_ms ?error
       ("target_kind", `String (target_kind_of_input input target_path));
       ("target_path", string_opt_json target_path);
       ("sandbox_target", string_opt_json sandbox_target);
-      ("observed_paths", string_list_json (collect_observed_paths input));
+      ("observed_paths", Json_util.json_string_list (collect_observed_paths input));
       ("success", `Bool success);
       ("duration_ms", `Float duration_ms);
       ("error", string_opt_json error);

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -559,12 +559,12 @@ let execution_summary_json ~meta ~latest_receipt =
       ("tool_contract_result", Json_util.string_opt_to_json tool_contract_result);
       ( "runtime_proof_status",
         Json_util.string_opt_to_json tool_contract_result );
-      ("required_tools", string_list_json required_tools);
-      ("required_tool_candidates", string_list_json required_tool_candidates);
-      ("missing_required_tools", string_list_json missing_required_tools);
-      ("requested_tools", string_list_json requested_tools);
-      ("tools_used", string_list_json tools_used);
-      ("unexpected_tools", string_list_json unexpected_tools);
+      ("required_tools", Json_util.json_string_list required_tools);
+      ("required_tool_candidates", Json_util.json_string_list required_tool_candidates);
+      ("missing_required_tools", Json_util.json_string_list missing_required_tools);
+      ("requested_tools", Json_util.json_string_list requested_tools);
+      ("tools_used", Json_util.json_string_list tools_used);
+      ("unexpected_tools", Json_util.json_string_list unexpected_tools);
       ("requested_tool_count", `Int (List.length requested_tools));
       ("tools_used_count", `Int (List.length tools_used));
       ("unexpected_tool_count", `Int (List.length unexpected_tools));

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -40,7 +40,6 @@ let json_string_list_member key json =
        | `String value when String.trim value <> "" -> Some value
        | _ -> None)
 
-let string_list_json = Json_util.json_string_list
 let assoc_bool_default key ~default fields =
   match List.assoc_opt key fields with
   | Some (`Bool value) -> value

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -40,9 +40,7 @@ let json_string_list_member key json =
        | `String value when String.trim value <> "" -> Some value
        | _ -> None)
 
-let string_list_json values =
-  `List (List.map (fun value -> `String value) values)
-
+let string_list_json = Json_util.json_string_list
 let assoc_bool_default key ~default fields =
   match List.assoc_opt key fields with
   | Some (`Bool value) -> value

--- a/lib/keeper/keeper_runtime_trust_timeline.mli
+++ b/lib/keeper/keeper_runtime_trust_timeline.mli
@@ -12,8 +12,6 @@ val json_bool_opt_member : string -> Yojson.Safe.t -> bool option
 
 val json_string_list_member : string -> Yojson.Safe.t -> string list
 
-val string_list_json : string list -> Yojson.Safe.t
-
 val assoc_bool_default :
   string -> default:bool -> (string * Yojson.Safe.t) list -> bool
 

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -271,9 +271,6 @@ let cleanup_stale ~(config : Coord.config) ~(timeout_sec : float) () =
     ~timeout_sec
     ()
 
-let json_string_list values =
-  `List (List.map (fun value -> `String value) values)
-
 let safe_file_exists path =
   try Fs_compat.file_exists path with
   | Sys_error _ -> false

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -186,17 +186,6 @@ let option_field name = function
   | None -> name, `Null
 ;;
 
-let dedupe_keep_order values =
-  let seen = Hashtbl.create (List.length values) in
-  List.filter
-    (fun value ->
-       if value = "" || Hashtbl.mem seen value
-       then false
-       else (
-         Hashtbl.replace seen value ();
-         true))
-    values
-;;
 
 type cleanup_result =
   { scanned : int
@@ -1271,7 +1260,7 @@ let docker_preflight_failure_message (preflight : docker_preflight) =
               (String.concat ", " preflight.missing_commands)))
     ]
     |> List.filter_map (fun item -> item)
-    |> dedupe_keep_order
+    |> List.filter (fun s -> s <> "") |> Json_util.dedupe_keep_order
   in
   let next_actions =
     match preflight.next_actions with
@@ -1379,7 +1368,7 @@ let docker_preflight ~timeout_sec () =
          else None)
       ]
       |> List.filter_map (fun action -> action)
-      |> dedupe_keep_order
+      |> List.filter (fun s -> s <> "") |> Json_util.dedupe_keep_order
     in
     let image_error =
       match image_error, command_error with
@@ -1396,7 +1385,7 @@ let docker_preflight ~timeout_sec () =
       ; (if missing_commands = [] then None else Some "image_required_command_missing")
       ]
       |> List.filter_map (fun item -> item)
-      |> dedupe_keep_order
+      |> List.filter (fun s -> s <> "") |> Json_util.dedupe_keep_order
     in
     Some
       { ok =

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -888,10 +888,7 @@ let trimmed_string_json value =
   if trimmed = "" then `Null else `String trimmed
 ;;
 
-let non_empty_string_opt value =
-  let trimmed = String.trim value in
-  if trimmed = "" then None else Some trimmed
-;;
+let non_empty_string_opt = String_util.trim_nonempty
 
 let social_model_resolution_fields_json (meta : keeper_meta) =
   let resolved = Keeper_social_model.normalize_social_model meta.social_model in

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -888,8 +888,6 @@ let trimmed_string_json value =
   if trimmed = "" then `Null else `String trimmed
 ;;
 
-let non_empty_string_opt = String_util.trim_nonempty
-
 let social_model_resolution_fields_json (meta : keeper_meta) =
   let resolved = Keeper_social_model.normalize_social_model meta.social_model in
   let recognized = Keeper_social_model.is_known_social_model meta.social_model in

--- a/lib/keeper/keeper_text_processing.ml
+++ b/lib/keeper/keeper_text_processing.ml
@@ -44,15 +44,12 @@ let strip_state_blocks_text (s : string) : string =
   loop 0 buf;
   Buffer.contents buf
 
-let trim_to_option (s : string) : string option =
-  let trimmed = String.trim s in
-  if trimmed = "" then None else Some trimmed
 
 let state_snapshot_reply_fallback (snapshot : keeper_state_snapshot option) :
     string option =
   match snapshot with
-  | Some { progress = Some progress; _ } -> trim_to_option progress
-  | Some { goal = Some goal; _ } -> trim_to_option goal
+  | Some { progress = Some progress; _ } -> String_util.trim_to_option progress
+  | Some { goal = Some goal; _ } -> String_util.trim_to_option goal
   | _ -> None
 
 (* Observability for SKILL: / SKILL_REASON: line scrubbing.  The
@@ -131,25 +128,25 @@ let state_snapshot_reply_fallback_typed
   : (string * Keeper_user_visible_reply_source.t) option =
   match snapshot with
   | Some { progress = Some progress; _ } ->
-    (match trim_to_option progress with
+    (match String_util.trim_to_option progress with
      | Some text ->
        Some (text, Keeper_user_visible_reply_source.State_snapshot_progress)
      | None -> None)
   | Some { goal = Some goal; _ } ->
-    (match trim_to_option goal with
+    (match String_util.trim_to_option goal with
      | Some text ->
        Some (text, Keeper_user_visible_reply_source.State_snapshot_goal)
      | None -> None)
   | _ -> None
 
 let user_visible_reply_text ?fallback (raw : string) : string =
-  match trim_to_option (strip_internal_reply_markup raw) with
+  match String_util.trim_to_option (strip_internal_reply_markup raw) with
   | Some text ->
     record_user_visible_reply_source
       ~source:Keeper_user_visible_reply_source.Stripped_raw;
     text
   | None -> (
-      match Option.bind fallback trim_to_option with
+      match Option.bind fallback String_util.trim_to_option with
       | Some text ->
         record_user_visible_reply_source
           ~source:Keeper_user_visible_reply_source.Fallback_param;

--- a/lib/keeper/keeper_text_processing.mli
+++ b/lib/keeper/keeper_text_processing.mli
@@ -10,7 +10,6 @@
 val strip_state_blocks_text : string -> string
 
 (** Trim whitespace; return [None] for empty strings. *)
-val trim_to_option : string -> string option
 
 (** Extract a fallback reply string from a state snapshot. *)
 val state_snapshot_reply_fallback :

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -22,15 +22,6 @@ let required_tool_names_for_no_tool_error ~runtime_mcp_policy ~tools =
   in
   List.sort_uniq String.compare names
 
-let dedupe_keep_order values =
-  let rec loop seen acc = function
-    | [] -> List.rev acc
-    | value :: rest ->
-      if List.mem value seen then loop seen acc rest
-      else loop (value :: seen) (value :: acc) rest
-  in
-  loop [] [] values
-
 let materialized_tool_names_after_lane ~effective_tools ~runtime_mcp_policy =
   let inline_names =
     List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) effective_tools
@@ -40,7 +31,7 @@ let materialized_tool_names_after_lane ~effective_tools ~runtime_mcp_policy =
     | Some policy -> policy.Llm_provider.Llm_transport.allowed_tool_names
     | None -> []
   in
-  dedupe_keep_order (inline_names @ runtime_names)
+  Json_util.dedupe_keep_order (inline_names @ runtime_names)
 
 let resolved_tool_lane_label ~effective_tools ~runtime_mcp_policy =
   let inline_names =
@@ -64,7 +55,7 @@ let canonical_tool_name_for_lane_check name =
   | None -> name
 
 let canonical_tool_names_for_lane_check names =
-  names |> List.map canonical_tool_name_for_lane_check |> dedupe_keep_order
+  names |> List.map canonical_tool_name_for_lane_check |> Json_util.dedupe_keep_order
 
 let dedupe_required_tool_names_for_lane_check names =
   let rec loop seen acc = function
@@ -131,7 +122,7 @@ let no_tool_capable_provider_of_pre_dispatch_rejections ~cascade_name
   | _ ->
       let required_tool_names =
         match required_tool_names_for_no_tool_error ~runtime_mcp_policy ~tools with
-        | [] -> dedupe_keep_order runtime_manifest_required_tool_names
+        | [] -> Json_util.dedupe_keep_order runtime_manifest_required_tool_names
         | names -> names
       in
       Some

--- a/lib/keeper/keeper_turn_telemetry.ml
+++ b/lib/keeper/keeper_turn_telemetry.ml
@@ -4,10 +4,7 @@
     Contains logging helpers for CDAL proofs, contract verdicts, friction
     projections, and memory-bank writes. *)
 
-let string_list_json (items : string list) : Yojson.Safe.t =
-  `List (List.map (fun item -> `String item) items)
-;;
-
+let string_list_json = Json_util.json_string_list
 let blocking_gap_artifacts (verdict : Cdal_types.contract_verdict) : string list =
   verdict.completeness_gaps
   |> List.filter_map (fun (gap : Cdal_types.completeness_gap) ->

--- a/lib/keeper/keeper_turn_telemetry.ml
+++ b/lib/keeper/keeper_turn_telemetry.ml
@@ -4,7 +4,6 @@
     Contains logging helpers for CDAL proofs, contract verdicts, friction
     projections, and memory-bank writes. *)
 
-let string_list_json = Json_util.json_string_list
 let blocking_gap_artifacts (verdict : Cdal_types.contract_verdict) : string list =
   verdict.completeness_gaps
   |> List.filter_map (fun (gap : Cdal_types.completeness_gap) ->
@@ -34,7 +33,7 @@ let contract_verdict_activity_payload
     ; "claim_scope", `String verdict.claim_scope
     ; "judgment_hash", `String verdict.judgment_hash
     ; "finding_count", `Int (List.length verdict.findings)
-    ; "blocking_gap_artifacts", string_list_json (blocking_gap_artifacts verdict)
+    ; "blocking_gap_artifacts", Json_util.json_string_list (blocking_gap_artifacts verdict)
     ]
 ;;
 
@@ -46,11 +45,11 @@ let friction_activity_payload
   `Assoc
     [ "keeper_name", `String keeper_name
     ; "window", `String fp.window
-    ; "based_on_run_ids", string_list_json fp.based_on_run_ids
+    ; "based_on_run_ids", Json_util.json_string_list fp.based_on_run_ids
     ; "blocked_attempt_count", `Int fp.blocked_attempt_count
     ; "blocked_group_count", `Int (List.length fp.blocked_attempt_groups)
-    ; "review_tripwires", string_list_json fp.review_tripwires
-    ; "evidence_gap_artifacts", string_list_json (friction_gap_artifacts fp)
+    ; "review_tripwires", Json_util.json_string_list fp.review_tripwires
+    ; "evidence_gap_artifacts", Json_util.json_string_list (friction_gap_artifacts fp)
     ]
 ;;
 

--- a/lib/keeper/keeper_turn_telemetry.mli
+++ b/lib/keeper/keeper_turn_telemetry.mli
@@ -5,8 +5,6 @@
     verdicts, friction projections, and memory-bank writes. *)
 
 (** Convert a list of strings to a JSON list of strings. *)
-val string_list_json : string list -> Yojson.Safe.t
-
 (** Artifact names for completeness gaps that block the verdict
     (sorted, deduplicated). *)
 val blocking_gap_artifacts :

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -146,7 +146,7 @@ let parse_cascade_name_opt args =
                 Error (Printf.sprintf "invalid cascade_name '%s': %s" raw detail)
 
 let resolve_tool_name_list ~preferred ~fallback =
-  first_some preferred fallback
+  Dashboard_utils.first_some preferred fallback
   |> Option.value ~default:[]
   |> normalize_tool_name_list
 
@@ -338,11 +338,11 @@ let resolve_mention_targets ~mention_targets_in ~fallback_targets ~name =
   raw |> List.filter (fun s -> String.trim s <> "") |> dedupe_keep_order
 
 let resolve_sandbox_profile ~preferred ~fallback =
-  first_some preferred fallback
+  Dashboard_utils.first_some preferred fallback
   |> Option.value ~default:default_sandbox_profile
 
 let resolve_network_mode ~sandbox_profile ~preferred ~fallback =
-  first_some preferred fallback
+  Dashboard_utils.first_some preferred fallback
   |> Option.value ~default:(default_network_mode_for_profile sandbox_profile)
 
 

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -40,7 +40,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         |> normalize_goal_horizon_text
   in
   let autoboot_enabled =
-    first_some p.autoboot_enabled_opt p.profile_defaults.autoboot_enabled
+    Dashboard_utils.first_some p.autoboot_enabled_opt p.profile_defaults.autoboot_enabled
     |> Option.value ~default:true
   in
   let allowed_paths =
@@ -189,7 +189,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                 | None ->
                     let tool_preset =
                       Option.value ~default:Research
-                        (first_some p.tool_preset_opt
+                        (Dashboard_utils.first_some p.tool_preset_opt
                            (preset_of_defaults p.profile_defaults))
                     in
                     let tool_also_allow =
@@ -262,10 +262,10 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                 resolve_goal_horizons
                   ~goal
                   ~short_goal_opt:
-                    (first_some p.short_goal_opt p.profile_defaults.short_goal)
-                  ~mid_goal_opt:(first_some p.mid_goal_opt p.profile_defaults.mid_goal)
+                    (Dashboard_utils.first_some p.short_goal_opt p.profile_defaults.short_goal)
+                  ~mid_goal_opt:(Dashboard_utils.first_some p.mid_goal_opt p.profile_defaults.mid_goal)
                   ~long_goal_opt:
-                    (first_some p.long_goal_opt p.profile_defaults.long_goal)
+                    (Dashboard_utils.first_some p.long_goal_opt p.profile_defaults.long_goal)
               in
               let instructions = Option.value ~default:"" p.instructions_opt in
               let (env_ratio_gate, env_message_gate, env_token_gate) =

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -155,7 +155,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
             in
             Preset { preset; also_allow }
         | Custom names -> (
-            match first_some p.tool_preset_opt profile_tool_preset with
+            match Dashboard_utils.first_some p.tool_preset_opt profile_tool_preset with
             | Some preset ->
                 let also_allow =
                   resolve_tool_name_list
@@ -313,24 +313,24 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     mention_targets;
     room_signal_prompt_enabled;
     work_discovery_enabled =
-      first_some p.profile_defaults.work_discovery_enabled old.work_discovery_enabled;
+      Dashboard_utils.first_some p.profile_defaults.work_discovery_enabled old.work_discovery_enabled;
     work_discovery_sources =
-      first_some p.profile_defaults.work_discovery_sources old.work_discovery_sources;
+      Dashboard_utils.first_some p.profile_defaults.work_discovery_sources old.work_discovery_sources;
     work_discovery_interval_sec =
-      first_some p.profile_defaults.work_discovery_interval_sec
+      Dashboard_utils.first_some p.profile_defaults.work_discovery_interval_sec
         old.work_discovery_interval_sec;
     work_discovery_guidance =
-      first_some p.profile_defaults.work_discovery_guidance old.work_discovery_guidance;
+      Dashboard_utils.first_some p.profile_defaults.work_discovery_guidance old.work_discovery_guidance;
     telemetry_feedback_enabled =
-      first_some p.profile_defaults.telemetry_feedback_enabled
+      Dashboard_utils.first_some p.profile_defaults.telemetry_feedback_enabled
         old.telemetry_feedback_enabled;
     telemetry_feedback_window_hours =
-      first_some p.profile_defaults.telemetry_feedback_window_hours
+      Dashboard_utils.first_some p.profile_defaults.telemetry_feedback_window_hours
         old.telemetry_feedback_window_hours;
     per_provider_timeout_s =
-      first_some p.profile_defaults.per_provider_timeout old.per_provider_timeout_s;
+      Dashboard_utils.first_some p.profile_defaults.per_provider_timeout old.per_provider_timeout_s;
     always_approve =
-      first_some p.profile_defaults.always_approve old.always_approve;
+      Dashboard_utils.first_some p.profile_defaults.always_approve old.always_approve;
     proactive = {
       enabled =
         (match p.proactive_enabled_opt with

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -40,7 +40,6 @@ let take n xs =
 
 (* Delegated to Keeper_fs — single fiber-safe ensure_dir implementation. *)
 let ensure_dir = Keeper_fs.ensure_dir
-
 let dedupe_keep_order = Json_util.dedupe_keep_order
 
 let normalize_name_list items =
@@ -88,7 +87,6 @@ let normalize_tool_preset_raw raw =
   let normalized = String.trim (String.lowercase_ascii raw) in
   if List.mem normalized valid_tool_preset_raw_strings then Some normalized else None
 
-let first_some = Dashboard_utils.first_some
 
 let room_seq_map_to_json (items : (string * int) list) : Yojson.Safe.t =
   `Assoc (List.map (fun (room_id, seq) -> (room_id, `Int seq)) items)

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -41,22 +41,13 @@ let take n xs =
 (* Delegated to Keeper_fs — single fiber-safe ensure_dir implementation. *)
 let ensure_dir = Keeper_fs.ensure_dir
 
-let dedupe_keep_order items =
-  let seen = Hashtbl.create (List.length items) in
-  List.filter
-    (fun item ->
-      if Hashtbl.mem seen item then
-        false
-      else (
-        Hashtbl.add seen item ();
-        true))
-    items
+let dedupe_keep_order = Json_util.dedupe_keep_order
 
 let normalize_name_list items =
   items
   |> List.map String.trim
   |> List.filter (fun item -> item <> "")
-  |> dedupe_keep_order
+  |> Json_util.dedupe_keep_order
 
 let normalize_name_list_opt items =
   match normalize_name_list items with
@@ -594,7 +585,7 @@ let detect_unknown_keeper_toml_keys (doc : Keeper_toml_loader.toml_doc) =
   |> List.map fst
   |> List.filter (fun key ->
        not (List.mem key known) && not (starts_with_oas_env key))
-  |> dedupe_keep_order
+  |> Json_util.dedupe_keep_order
 
 let unknown_keeper_toml_warning_key_limit = 256
 let unknown_keeper_toml_warning_keys : string list Atomic.t = Atomic.make []

--- a/lib/keeper/keeper_types_profile.mli
+++ b/lib/keeper/keeper_types_profile.mli
@@ -30,7 +30,6 @@ val valid_social_model_strings : string list
 val lower_string_list_opt : string list -> string list option
 val valid_tool_preset_raw_strings : string list
 val normalize_tool_preset_raw : string -> string option
-val first_some : 'a option -> 'a option -> 'a option
 val room_seq_map_to_json : (string * int) list -> Yojson.Safe.t
 val room_seq_map_of_json : Yojson.Safe.t -> (string * int) list
 

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -5,15 +5,6 @@
     Re-included from Keeper_unified_turn so existing callers continue to
     use [Keeper_unified_turn.<name>] unchanged. *)
 
-let json_of_string_opt = function
-  | None -> `Null
-  | Some value -> `String value
-;;
-
-let json_of_string_list values =
-  `List (List.map (fun value -> `String value) values)
-;;
-
 let turn_event_bus_manifest_decision
       (summary : Keeper_turn_cascade_budget.turn_event_bus_summary)
   =
@@ -41,11 +32,11 @@ let turn_event_bus_manifest_decision
   in
   `Assoc
     [
-      ("correlation_id", json_of_string_opt summary.correlation_id);
-      ("run_id", json_of_string_opt summary.run_id);
-      ("caused_by", json_of_string_opt summary.caused_by);
+      ("correlation_id", Json_util.string_opt_to_json summary.correlation_id);
+      ("run_id", Json_util.string_opt_to_json summary.run_id);
+      ("caused_by", Json_util.string_opt_to_json summary.caused_by);
       ("event_count", `Int summary.event_count);
-      ("payload_kinds", json_of_string_list summary.payload_kinds);
+      ("payload_kinds", Json_util.json_string_list summary.payload_kinds);
       ("overflow_imminent", overflow);
       ( "context_compact_started_count",
         `Int summary.context_compact_started_count );

--- a/lib/keeper/keeper_unified_turn_types.mli
+++ b/lib/keeper/keeper_unified_turn_types.mli
@@ -6,10 +6,6 @@
     Keeper_unified_turn. Re-included by it so existing callers continue
     to use [Keeper_unified_turn.<name>] unchanged. *)
 
-val json_of_string_opt : string option -> Yojson.Safe.t
-
-val json_of_string_list : string list -> Yojson.Safe.t
-
 val turn_event_bus_manifest_decision :
   Keeper_turn_cascade_budget.turn_event_bus_summary -> Yojson.Safe.t
 

--- a/lib/keeper/keeper_working_state.ml
+++ b/lib/keeper/keeper_working_state.ml
@@ -258,7 +258,6 @@ let six_w_to_json six_w =
     ]
 
 let json_list f values = `List (List.map f values)
-let json_string_list values = json_list (fun value -> `String value) values
 
 let loop_to_json loop =
   `Assoc
@@ -277,7 +276,7 @@ let to_json state =
     ; ("active_loops", json_list loop_to_json state.active_loops)
     ; ("resolved_loops", json_list loop_to_json state.resolved_loops)
     ; ("archived_loops", json_list loop_to_json state.archived_loops)
-    ; ("prompt_digest_ids", json_string_list state.prompt_digest_ids)
+    ; ("prompt_digest_ids", Json_util.json_string_list state.prompt_digest_ids)
     ]
 
 let ( let* ) = Result.bind

--- a/lib/keeper/keeper_working_state_projector.ml
+++ b/lib/keeper/keeper_working_state_projector.ml
@@ -15,20 +15,9 @@ let source_field_why = function
   | Next_item -> "keeper_state_snapshot.next_items"
   | Open_question -> "keeper_state_snapshot.open_questions"
 
-let trim_nonempty value =
-  let value = String.trim value in
-  if String.equal value "" then None else Some value
-
-let dedupe_keep_order values =
-  let rec loop seen acc = function
-    | [] -> List.rev acc
-    | value :: rest when List.mem value seen -> loop seen acc rest
-    | value :: rest -> loop (value :: seen) (value :: acc) rest
-  in
-  loop [] [] values
 
 let normalized_items values =
-  values |> List.filter_map trim_nonempty |> dedupe_keep_order
+  values |> List.filter_map String_util.trim_nonempty |> Json_util.dedupe_keep_order
 
 let digest12 text =
   let digest = Digest.string text |> Digest.to_hex in

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -506,7 +506,7 @@ let materialize_direct_evidence ~base_path ~worker_name
   | None -> ()
   | Some session_id ->
       let aliases =
-        unique_preserve_order
+        Json_util.dedupe_keep_order
           ([ worker_name ]
           @
           match meta.role with

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -64,7 +64,6 @@ let strip_mcp_prefix name =
   else
     name
 
-let unique_preserve_order = Json_util.dedupe_keep_order
 
 let has_agent_name_field (schema : Masc_domain.tool_schema) =
   let open Yojson.Safe.Util in

--- a/lib/local/worker_container_types.mli
+++ b/lib/local/worker_container_types.mli
@@ -128,7 +128,6 @@ val local_worker_heartbeat_interval_sec : unit -> int
 
 (** {1 JSON utilities re-exported for callers} *)
 
-val unique_preserve_order : 'a list -> 'a list
 (** Order-preserving deduplication.  Pinned alias of
     {!Json_util.dedupe_keep_order} kept here so callers that
     historically reached it via [Worker_container_types]

--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -13,19 +13,18 @@ let default_max_len = 200
 let denied_tool_infixes =
   ["_auth"; "_encryption"; "_credential"; "_secret"]
 
-let contains_substring ~sub s = String_util.contains_substring s sub
 
 let sensitive_key_markers =
   [ "token"; "secret"; "password"; "passwd"; "api_key"; "apikey"; "key" ]
 
 let is_sensitive_key key =
   let lower = String.lowercase_ascii key in
-  List.exists (fun marker -> contains_substring ~sub:marker lower)
+  List.exists (fun marker -> String_util.contains_substring lower marker)
     sensitive_key_markers
 
 let is_denied_tool ~tool_name =
   let lower = String.lowercase_ascii tool_name in
-  List.exists (fun infix -> contains_substring ~sub:infix lower) denied_tool_infixes
+  List.exists (fun infix -> String_util.contains_substring lower infix) denied_tool_infixes
 
 (** Sensitive value patterns — matches API keys, tokens, long hex strings.
     24+ contiguous alphanumeric/base64 characters. *)

--- a/lib/observability_redact.mli
+++ b/lib/observability_redact.mli
@@ -4,9 +4,6 @@
     Sensitive patterns (API keys, URL credentials) are replaced with
     [\[REDACTED\]], and certain tool categories return [None] entirely. *)
 
-val contains_substring : sub:string -> string -> bool
-(** Test helper: check if [sub] occurs in the string. *)
-
 val is_denied_tool : tool_name:string -> bool
 (** Returns [true] if the tool is on the deny list (auth, encryption, etc.)
     and its I/O must not be logged or previewed. *)

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -616,7 +616,7 @@ let action_json ?actor_hint (ctx : _ context) args :
   let trace_id = trace_id "ops" in
   let started_at = Unix.gettimeofday () in
   if confirm_required request.action_type then (
-    let expires_at = iso_of_unix (Unix.gettimeofday () +. remote_confirm_ttl_seconds) in
+    let expires_at = Dashboard_utils.iso_of_unix (Unix.gettimeofday () +. remote_confirm_ttl_seconds) in
     let* token = generate_confirm_token ~clock:ctx.clock ctx.config in
     let* preview =
       match request.action_type with

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -35,13 +35,13 @@ let judgment_write_json (ctx : 'a context) args =
   if summary = "" then Error "summary is required"
   else
     let now_unix = Unix.gettimeofday () in
-    let generated_at = iso_of_unix now_unix in
+    let generated_at = Dashboard_utils.iso_of_unix now_unix in
     let fresh_ttl_sec =
       let default = default_fresh_ttl_sec surface in
       max 1 (get_int args "fresh_ttl_sec" default)
     in
     let fresh_until_unix = now_unix +. float_of_int fresh_ttl_sec in
-    let fresh_until = iso_of_unix fresh_until_unix in
+    let fresh_until = Dashboard_utils.iso_of_unix fresh_until_unix in
     let confidence = get_float args "confidence" 0.5 in
     let keeper_name =
       match get_string_opt args "keeper_name" with

--- a/lib/operator/operator_control_context_snapshot.ml
+++ b/lib/operator/operator_control_context_snapshot.ml
@@ -97,15 +97,15 @@ let keeper_context_snapshot_of_meta config (meta : Keeper_types.keeper_meta) =
 
 let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
   [ ( "context_ratio"
-    , Operator_pending_confirm.option_to_json
+    , Json_util.option_to_yojson
         (fun value -> `Float value)
         snapshot.context_ratio )
   ; ( "context_tokens"
-    , Operator_pending_confirm.option_to_json
+    , Json_util.option_to_yojson
         (fun value -> `Int value)
         snapshot.context_tokens )
   ; ( "context_max"
-    , Operator_pending_confirm.option_to_json
+    , Json_util.option_to_yojson
         (fun value -> `Int value)
         snapshot.context_max )
   ; ( "context_source"

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -32,7 +32,6 @@ let merge_json_objects left right =
   | _, _ -> `Assoc []
 ;;
 
-let iso_of_unix = Dashboard_utils.iso_of_unix
 (* remote_confirm_ttl_seconds + runtime-status alignment helpers
    extracted to [Operator_control_snapshot_runtime_status] (godfile decomp). *)
 let remote_confirm_ttl_seconds = Operator_control_snapshot_runtime_status.remote_confirm_ttl_seconds

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -471,7 +471,7 @@ let keepers_json
                                  (List.map (fun value -> `String value) recent_tool_names)
                              )
                            ; ( "latest_tool_call_count"
-                             , option_to_json
+                             , Json_util.option_to_yojson
                                  (fun value -> `Int value)
                                  latest_tool_call_count )
                            ; ( "latest_action_source"

--- a/lib/operator/operator_control_snapshot.mli
+++ b/lib/operator/operator_control_snapshot.mli
@@ -20,8 +20,8 @@
       [test/test_types]).
     - {!align_keeper_runtime_status}, {!max_turns_override_source}
       (test-only direct callers).
-    - {!iso_of_unix}, {!get_payload} (cascade-include
-      consumer {!Operator_control_action} reaches both
+    - {!get_payload} (cascade-include
+      consumer {!Operator_control_action} reaches it
       unqualified).
 
     Internal helpers stay private at this boundary
@@ -258,12 +258,6 @@ val cached_tool_audit_json :
     seed and a 30-second TTL; [lightweight=false] uses a
     2-second TTL for fresh dashboard reads.  Pinned for
     [test/test_operator_control_snapshot.ml]. *)
-
-val iso_of_unix : float -> string
-(** Re-export of {!Dashboard_utils.iso_of_unix}.  Pinned
-    here because {!Operator_control_action} reaches it
-    unqualified through the
-    [include Operator_control_snapshot] cascade. *)
 
 val get_payload : Yojson.Safe.t -> Yojson.Safe.t
 (** Extracts the [payload] field from a JSON args object,

--- a/lib/operator/operator_control_snapshot_tool_audit.ml
+++ b/lib/operator/operator_control_snapshot_tool_audit.ml
@@ -3,7 +3,6 @@
 
 module U = Yojson.Safe.Util
 
-let option_to_json = Json_util.option_to_yojson
 let string_option_to_json = Operator_pending_confirm.string_option_to_json
 let merge_tool_name_lists = Operator_control_snapshot_tool_names.merge_tool_name_lists
 let collect_recent_tool_names = Operator_control_snapshot_tool_names.collect_recent_tool_names
@@ -152,7 +151,7 @@ let cached_tool_audit_json
       [ "allowed_tool_names", `List (List.map (fun v -> `String v) allowed_tool_names)
       ; "recent_tool_names", `List (List.map (fun v -> `String v) recent_tool_names)
       ; "latest_tool_names", `List (List.map (fun v -> `String v) latest_tool_names)
-      ; "latest_tool_call_count", option_to_json (fun v -> `Int v) latest_tool_call_count
+      ; "latest_tool_call_count", Json_util.option_to_yojson (fun v -> `Int v) latest_tool_call_count
       ; "latest_action_source", string_option_to_json latest_action_source
       ; "tool_audit_source", string_option_to_json tool_audit_source
       ; "tool_audit_at", string_option_to_json tool_audit_at

--- a/lib/operator/operator_control_snapshot_tool_audit.ml
+++ b/lib/operator/operator_control_snapshot_tool_audit.ml
@@ -3,7 +3,7 @@
 
 module U = Yojson.Safe.Util
 
-let option_to_json = Operator_pending_confirm.option_to_json
+let option_to_json = Json_util.option_to_yojson
 let string_option_to_json = Operator_pending_confirm.string_option_to_json
 let merge_tool_name_lists = Operator_control_snapshot_tool_names.merge_tool_name_lists
 let collect_recent_tool_names = Operator_control_snapshot_tool_names.collect_recent_tool_names

--- a/lib/operator/operator_digest_types.ml
+++ b/lib/operator/operator_digest_types.ml
@@ -136,7 +136,7 @@ let summary_of_attention_items (items : attention_item list) =
       ("count", `Int (List.length sorted));
       ("bad_count", `Int bad_count);
       ("warn_count", `Int warn_count);
-      ("top_item", option_to_json attention_item_to_yojson top_item);
+      ("top_item", Json_util.option_to_yojson attention_item_to_yojson top_item);
       ("provenance", `String "derived");
       ("authoritative", `Bool false);
     ]
@@ -168,7 +168,7 @@ let summary_of_recommendations ~actor (items : recommended_action list) =
     [
       ("count", `Int (List.length sorted));
       ( "top_action",
-        option_to_json (recommended_action_to_yojson ~actor) top_item );
+        Json_util.option_to_yojson (recommended_action_to_yojson ~actor) top_item );
       ("provenance", `String "fallback");
       ("authoritative", `Bool false);
     ]

--- a/lib/operator/operator_judgment.ml
+++ b/lib/operator/operator_judgment.ml
@@ -36,9 +36,6 @@ let target_type_of_string = function
 
 let option_to_yojson = Json_util.option_to_yojson
 
-let ensure_dir path =
-  Fs_compat.mkdir_p path
-
 let operator_dir config =
   Filename.concat (Coord.masc_dir config) "operator"
 
@@ -172,7 +169,7 @@ let load_all config =
   |> List.rev
 
 let append config values =
-  ensure_dir (operator_dir config);
+  Fs_compat.mkdir_p (operator_dir config);
   let path = judgments_path config in
   List.iter
     (fun value ->

--- a/lib/operator/operator_judgment.ml
+++ b/lib/operator/operator_judgment.ml
@@ -34,7 +34,6 @@ let target_type_of_string = function
   | "root" -> Some Coord
   | _ -> None
 
-let option_to_yojson = Json_util.option_to_yojson
 
 let operator_dir config =
   Filename.concat (Coord.masc_dir config) "operator"
@@ -61,7 +60,7 @@ let to_yojson (value : record) =
       ("judgment_id", `String value.judgment_id);
       ("surface", `String value.surface);
       ("target_type", `String (target_type_to_string value.target_type));
-      ("target_id", option_to_yojson (fun v -> `String v) value.target_id);
+      ("target_id", Json_util.option_to_yojson (fun v -> `String v) value.target_id);
       ("status", `String value.status);
       ("summary", `String value.summary);
       ("confidence", `Float value.confidence);
@@ -70,11 +69,11 @@ let to_yojson (value : record) =
       ("fresh_until", `String value.fresh_until);
       ("fresh_until_unix", `Float value.fresh_until_unix);
       ("keeper_name", `String value.keeper_name);
-      ("model_name", option_to_yojson (fun v -> `String v) value.model_name);
-      ("runtime_name", option_to_yojson (fun v -> `String v) value.runtime_name);
+      ("model_name", Json_util.option_to_yojson (fun v -> `String v) value.model_name);
+      ("runtime_name", Json_util.option_to_yojson (fun v -> `String v) value.runtime_name);
       ( "evidence_refs",
         `List (List.map (fun item -> `String item) value.evidence_refs) );
-      ("recommended_action", option_to_yojson (fun v -> v) value.recommended_action);
+      ("recommended_action", Json_util.option_to_yojson (fun v -> v) value.recommended_action);
       ("supersedes", `List (List.map (fun item -> `String item) value.supersedes));
       ("fallback_used", `Bool value.fallback_used);
       ("disagreement_with_truth", `Bool value.disagreement_with_truth);

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -10,8 +10,7 @@ type 'a context = {
   mcp_session_id : string option;
 }
 
-let option_to_json = Json_util.option_to_yojson
-let string_option_to_json = option_to_json (fun value -> `String value)
+let string_option_to_json = Json_util.option_to_yojson (fun value -> `String value)
 
 let operator_dir config =
   Filename.concat (Coord.masc_dir config) "operator"

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -10,10 +10,7 @@ type 'a context = {
   mcp_session_id : string option;
 }
 
-let option_to_json f = function
-  | Some value -> f value
-  | None -> `Null
-
+let option_to_json = Json_util.option_to_yojson
 let string_option_to_json = option_to_json (fun value -> `String value)
 
 let operator_dir config =

--- a/lib/operator/operator_pending_confirm.mli
+++ b/lib/operator/operator_pending_confirm.mli
@@ -8,7 +8,6 @@ type 'a context = {
   mcp_session_id : string option;
 }
 
-val option_to_json : ('a -> Yojson.Safe.t) -> 'a option -> Yojson.Safe.t
 val string_option_to_json : string option -> Yojson.Safe.t
 val operator_dir : Coord.config -> string
 val pending_confirms_path : Coord.config -> string

--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -62,9 +62,6 @@ let create_context ~task_id =
 let planning_dir (config : Coord.config) task_id =
   Filename.concat config.base_path (Printf.sprintf "planning/%s" task_id)
 
-let ensure_dir path =
-  Fs_compat.mkdir_p path
-
 (** File read via Fs_compat (Eio-native when available, blocking fallback) *)
 let read_file_content path =
   if Fs_compat.file_exists path then
@@ -73,7 +70,7 @@ let read_file_content path =
 
 (** File write via Fs_compat (Eio-native when available, blocking fallback) *)
 let write_file_content path content =
-  ensure_dir (Filename.dirname path);
+  Fs_compat.mkdir_p (Filename.dirname path);
   Fs_compat.save_file path content
 
 let find_substring_from haystack ~needle ~from =
@@ -134,7 +131,7 @@ let parse_full_context_markdown content =
 let init (config : Coord.config) ~task_id : (planning_context, string) result =
   try
     let dir = planning_dir config task_id in
-    ensure_dir dir;
+    Fs_compat.mkdir_p dir;
     let ctx = create_context ~task_id in
     (* Create empty files - PDCA structure *)
     write_file_content (Filename.concat dir "task_plan.md") "# Task Plan\n\n";
@@ -315,7 +312,7 @@ let is_directory_path path =
 
 let quarantine_dir_under_trash (config : Coord.config) ~path ~op =
   let trash_dir = Filename.concat (Coord_utils.masc_dir config) "_trash" in
-  ensure_dir trash_dir;
+  Fs_compat.mkdir_p trash_dir;
   let stamp =
     let t = Time_compat.now () in
     let ms = int_of_float (t *. 1000.) mod 1000 in
@@ -389,7 +386,7 @@ let get_current_task (config : Coord.config) : string option =
 (** Set current task_id for session *)
 let set_current_task (config : Coord.config) ~task_id : (unit, string) result =
   let path = current_task_file config in
-  ensure_dir (Filename.dirname path);
+  Fs_compat.mkdir_p (Filename.dirname path);
   let write_current_task () =
     try
       write_file_content path task_id;

--- a/lib/procedural_memory.ml
+++ b/lib/procedural_memory.ml
@@ -41,9 +41,6 @@ let procedures_dir ~agent_name =
 let procedures_path ~agent_name =
   sprintf "%s/procedures.jsonl" (procedures_dir ~agent_name)
 
-let ensure_dir path =
-  Fs_compat.mkdir_p path
-
 (* ================================================================ *)
 (* JSON Serialization                                               *)
 (* ================================================================ *)
@@ -96,13 +93,13 @@ let load_procedures ~agent_name : procedure list =
 
 let save_procedure ~agent_name (p : procedure) =
   let dir = procedures_dir ~agent_name in
-  ensure_dir dir;
+  Fs_compat.mkdir_p dir;
   let path = procedures_path ~agent_name in
   Fs_compat.append_jsonl path (to_json p)
 
 let rewrite_procedures ~agent_name (procs : procedure list) =
   let dir = procedures_dir ~agent_name in
-  ensure_dir dir;
+  Fs_compat.mkdir_p dir;
   let path = procedures_path ~agent_name in
   let content =
     procs

--- a/lib/provider_runtime_projection.ml
+++ b/lib/provider_runtime_projection.ml
@@ -33,9 +33,6 @@ type provider_profile =
 
 let normalize_label label = String.trim label |> String.lowercase_ascii
 
-let trim_nonempty value =
-  let trimmed = String.trim value in
-  if String.equal trimmed "" then None else Some trimmed
 ;;
 
 let env_value_opt ?(getenv = Sys.getenv_opt) name =
@@ -47,7 +44,7 @@ let env_value_opt ?(getenv = Sys.getenv_opt) name =
 ;;
 
 let binding_endpoint_url (binding : Runtime_binding.t) =
-  trim_nonempty binding.Runtime_binding.base_url
+  String_util.trim_nonempty binding.Runtime_binding.base_url
 ;;
 
 let binding_base_url_is_loopback binding =
@@ -80,17 +77,17 @@ let binding_labels (binding : Runtime_binding.t) =
   let id = binding.Runtime_binding.id in
   let dashed_id = String.map (function '_' -> '-' | c -> c) id in
   id :: dashed_id :: binding.Runtime_binding.aliases
-  |> List.filter_map trim_nonempty
+  |> List.filter_map String_util.trim_nonempty
   |> List.map normalize_label
   |> Json_util.dedupe_keep_order
 ;;
 
 let binding_default_model_id (binding : Runtime_binding.t) =
-  match Option.bind binding.Runtime_binding.default_model trim_nonempty with
+  match Option.bind binding.Runtime_binding.default_model String_util.trim_nonempty with
   | Some _ as value -> value
   | None ->
     (match binding.Runtime_binding.capabilities.supported_models with
-     | Some (model :: _) -> trim_nonempty model
+     | Some (model :: _) -> String_util.trim_nonempty model
      | Some [] | None -> None)
 ;;
 
@@ -113,7 +110,7 @@ let default_model_id_of_binding (binding : Runtime_binding.t) =
 
 let supported_models_of_binding (binding : Runtime_binding.t) =
   match binding.Runtime_binding.capabilities.supported_models with
-  | Some models -> List.filter_map trim_nonempty models
+  | Some models -> List.filter_map String_util.trim_nonempty models
   | None -> []
 ;;
 

--- a/lib/repo_manager/credential_store.ml
+++ b/lib/repo_manager/credential_store.ml
@@ -20,17 +20,7 @@ let default_credential =
     token_sha256_prefix = None;
   }
 
-let ensure_dir path =
-  let rec loop dir =
-    if dir = "" || dir = "." || Sys.file_exists dir then ()
-    else begin
-      loop (Filename.dirname dir);
-      try Unix.mkdir dir 0o755
-      with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
-    end
-  in
-  loop path
-
+let ensure_dir path = Fs_compat.mkdir_p path
 let credential_type_of_string = function
   | "Github" | "github" -> Ok Github
   | "Gitlab" | "gitlab" -> Ok Gitlab

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -8,17 +8,7 @@ let mappings_toml_path base_path =
   (* RFC-0121: layout SSOT via [Config_dir_resolver]. *)
   Config_dir_resolver.keeper_repo_mappings_toml_path ~base_path
 
-let ensure_dir path =
-  let rec loop dir =
-    if dir = "" || dir = "." || Sys.file_exists dir then ()
-    else begin
-      loop (Filename.dirname dir);
-      try Unix.mkdir dir 0o755
-      with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
-    end
-  in
-  loop path
-
+let ensure_dir path = Fs_compat.mkdir_p path
 let mapping_of_toml toml keeper_id =
   let path field = ["mapping"; keeper_id; field] in
   let* repository_ids =

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -1,16 +1,6 @@
 open Repo_manager_types
 
-let ensure_dir path =
-  let rec loop dir =
-    if dir = "" || dir = "." || Sys.file_exists dir then ()
-    else begin
-      loop (Filename.dirname dir);
-      try Unix.mkdir dir 0o755
-      with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
-    end
-  in
-  loop path
-
+let ensure_dir path = Fs_compat.mkdir_p path
 let merge_env overrides =
   let keys = List.map fst overrides in
   let has_key entry =

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -18,17 +18,7 @@ let default_local_path id = Filename.concat ".masc/repos" id
 
 let now_unix_seconds () = Int64.of_float (Unix.time ())
 
-let ensure_dir path =
-  let rec loop dir =
-    if dir = "" || dir = "." || Sys.file_exists dir then ()
-    else begin
-      loop (Filename.dirname dir);
-      try Unix.mkdir dir 0o755
-      with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
-    end
-  in
-  loop path
-
+let ensure_dir path = Fs_compat.mkdir_p path
 let string_of_status = function
   | Active -> "Active"
   | Paused -> "Paused"

--- a/lib/repo_synthesis_benchmark.ml
+++ b/lib/repo_synthesis_benchmark.ml
@@ -74,7 +74,6 @@ let bench_root ~base_path =
     (Common.masc_dir_from_base_path ~base_path)
     "repo-synthesis-benchmarks"
 
-let contains_substring = String_util.contains_substring
 
 let validate_run_id run_id =
   let run_id = String.trim run_id in
@@ -84,7 +83,7 @@ let validate_run_id run_id =
     Error "benchmark run id too long (max 128 chars)"
   else if String.contains run_id '/' || String.contains run_id '\\' then
     Error "benchmark run id cannot contain path separators"
-  else if contains_substring run_id ".." then
+  else if String_util.contains_substring run_id ".." then
     Error "benchmark run id cannot contain traversal segments"
   else if
     not

--- a/lib/retrieval_projection.ml
+++ b/lib/retrieval_projection.ml
@@ -7,9 +7,6 @@ let collapse_whitespace text =
   |> List.filter (fun part -> part <> "")
   |> String.concat " "
 
-let trim_to_option text =
-  let trimmed = String.trim text in
-  if trimmed = "" then None else Some trimmed
 
 let take_chars max_len text =
   if max_len <= 0 then ""
@@ -28,14 +25,14 @@ let normalize_content ?(max_len = 300) text =
 
 let grep_like_line ~source ~location ~content =
   let source =
-    trim_to_option source |> Option.value ~default:"search"
+    String_util.trim_to_option source |> Option.value ~default:"search"
   in
   let location =
-    trim_to_option location |> Option.value ~default:"result"
+    String_util.trim_to_option location |> Option.value ~default:"result"
     |> normalize_location
   in
   let content =
-    trim_to_option content |> Option.value ~default:"(no content)"
+    String_util.trim_to_option content |> Option.value ~default:"(no content)"
     |> normalize_content
   in
   Printf.sprintf "%s/%s: %s" source location content

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -378,12 +378,9 @@ let normalize_loopback_host host =
   | "::1" | "0:0:0:0:0:0:0:1" -> "localhost"
   | other -> other
 
-let trim_nonempty raw =
-  let value = String.trim raw in
-  if String.equal value "" then None else Some value
 
 let split_csv_nonempty raw =
-  raw |> String.split_on_char ',' |> List.filter_map trim_nonempty
+  raw |> String.split_on_char ',' |> List.filter_map String_util.trim_nonempty
 
 (** Returns (host, explicit_port, scheme). *)
 let host_port_scheme_of_origin origin =

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -19,7 +19,6 @@ val strip_prefix : prefix:string -> string -> string
 val strip_suffix : suffix:string -> string -> string
 (** Remove [suffix] from [s] when present, else return [s] unchanged. *)
 
-val trim_nonempty : string -> string option
 (** [Some trimmed] when non-empty, else [None]. *)
 
 val split_csv_nonempty : string -> string list

--- a/lib/server/server_dashboard_http_core_json.ml
+++ b/lib/server/server_dashboard_http_core_json.ml
@@ -1,11 +1,7 @@
 (** JSON helpers + projection-diagnostic field readers + operator
     cache JSON wrapper, extracted from server_dashboard_http_core.ml. *)
 
-let json_string_opt = function
-  | Some value -> `String value
-  | None -> `Null
-;;
-
+let json_string_opt = Json_util.string_opt_to_json
 let json_bool_opt = function
   | Some value -> `Bool value
   | None -> `Null

--- a/lib/server/server_dashboard_http_core_json.ml
+++ b/lib/server/server_dashboard_http_core_json.ml
@@ -2,6 +2,7 @@
     cache JSON wrapper, extracted from server_dashboard_http_core.ml. *)
 
 let json_string_opt = Json_util.string_opt_to_json
+
 let json_bool_opt = function
   | Some value -> `Bool value
   | None -> `Null
@@ -67,7 +68,7 @@ let operator_cache_json ?cache_key ~scope json =
     ; "last_error_at", diagnostic_field "last_error_at"
     ; "stale_reason", diagnostic_field "stale_reason"
     ; "stale_age_ms", diagnostic_field "stale_age_ms"
-    ; "request_cache_key", json_string_opt cache_key
+    ; "request_cache_key", Json_util.string_opt_to_json cache_key
     ; "request_cache_ttl_s", `Float 5.0
     ; "request_timeout_s", `Float Server_dashboard_http_core_cache.dashboard_request_timeout_s
     ; ( "background_refresh_interval_s"

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -33,18 +33,6 @@ type keeper_purge_cleanup_result =
   ; agent_cleanup_results : agent_purge_cleanup_result list
   }
 
-let dedupe_keep_order items =
-  let seen = Hashtbl.create (List.length items) in
-  List.filter
-    (fun item ->
-      if Hashtbl.mem seen item
-      then false
-      else (
-        Hashtbl.add seen item ();
-        true))
-    items
-;;
-
 let rec rm_rf path =
   if Fs_compat.file_exists path
   then if Sys.is_directory path
@@ -80,7 +68,7 @@ let credential_aliases agent_name =
   |> List.filter_map (function
        | Some value when value <> "" -> Some value
        | _ -> None)
-  |> dedupe_keep_order
+  |> Json_util.dedupe_keep_order
 ;;
 
 let agent_file_path config agent_name =
@@ -99,7 +87,7 @@ let resolve_keeper_purge_target config requested_name =
     |> List.filter_map (function
          | Some value when value <> "" -> Some value
          | _ -> None)
-    |> dedupe_keep_order
+    |> Json_util.dedupe_keep_order
   in
   let rec loop = function
     | [] -> None
@@ -152,7 +140,7 @@ let plain_agent_candidate_names config requested_name =
   let resolved = Coord.resolve_agent_name config trimmed in
   [ trimmed; resolved ]
   |> List.filter (fun value -> value <> "")
-  |> dedupe_keep_order
+  |> Json_util.dedupe_keep_order
 ;;
 
 let plain_agent_artifacts_exist config agent_name =
@@ -200,7 +188,7 @@ let resolve_agent_purge_targets config agent_names =
         []
     in
     Hashtbl.replace aliases_by_agent agent_name
-      (aliases @ [ alias; agent_name ] |> dedupe_keep_order)
+      (aliases @ [ alias; agent_name ] |> Json_util.dedupe_keep_order)
   in
   agent_names
   |> List.iter (fun requested_name ->
@@ -216,7 +204,7 @@ let resolve_agent_purge_targets config agent_names =
          Hashtbl.find_opt aliases_by_agent agent_name
          |> Option.value ~default:[ agent_name ]
          |> List.rev
-         |> dedupe_keep_order
+         |> Json_util.dedupe_keep_order
          |> List.rev
        in
        { agent_name; aliases })
@@ -265,7 +253,7 @@ let purge_keeper_artifacts config requested_name
   let cleanup_names =
     [ requested_name; keeper_name; agent_name ]
     |> List.filter (fun value -> String.trim value <> "")
-    |> dedupe_keep_order
+    |> Json_util.dedupe_keep_order
   in
   cleanup_names
   |> List.iter (fun name ->

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -193,11 +193,7 @@ let transport_health_cache =
         ])
 ;;
 
-let json_string_opt = function
-  | Some value -> `String value
-  | None -> `Null
-;;
-
+let json_string_opt = Json_util.string_opt_to_json
 let cached_surface_assoc_field_opt key = function
   | `Assoc fields -> List.assoc_opt key fields
   | _ -> None

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -193,7 +193,6 @@ let transport_health_cache =
         ])
 ;;
 
-let json_string_opt = Json_util.string_opt_to_json
 let cached_surface_assoc_field_opt key = function
   | `Assoc fields -> List.assoc_opt key fields
   | _ -> None
@@ -245,7 +244,7 @@ let cached_surface_cache_json
     ; "last_error_at", diagnostic_field "last_error_at"
     ; "stale_reason", diagnostic_field "stale_reason"
     ; "stale_age_ms", diagnostic_field "stale_age_ms"
-    ; "request_cache_key", json_string_opt cache_key
+    ; "request_cache_key", Json_util.string_opt_to_json cache_key
     ; "request_cache_ttl_s", `Float ttl_s
     ; "request_timeout_s", `Float timeout_s
     ; "background_refresh_interval_s", `Float background_refresh_interval_s
@@ -318,8 +317,8 @@ let with_cached_dashboard_surface_metadata
 
 let execution_query_json ~actor ~fixture ~full_mode ~light ~default_light_request =
   `Assoc
-    [ "actor", json_string_opt actor
-    ; "fixture", json_string_opt fixture
+    [ "actor", Json_util.string_opt_to_json actor
+    ; "fixture", Json_util.string_opt_to_json fixture
     ; "full", `Bool full_mode
     ; "light", `Bool light
     ; "default_light_request", `Bool default_light_request

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -153,7 +153,6 @@ let read_receipt_rows = Scan_summary.read_receipt_rows
 let unique_ints = Scan_summary.unique_ints
 let json_int_list = Scan_summary.json_int_list
 let json_int_opt = Scan_summary.json_int_opt
-let json_string_list = Json_util.json_string_list
 let event_bus_summary_json = Scan_summary.event_bus_summary_json
 let memory_summary_json = Scan_summary.memory_summary_json
 

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -153,7 +153,7 @@ let read_receipt_rows = Scan_summary.read_receipt_rows
 let unique_ints = Scan_summary.unique_ints
 let json_int_list = Scan_summary.json_int_list
 let json_int_opt = Scan_summary.json_int_opt
-let json_string_list = Scan_summary.json_string_list
+let json_string_list = Json_util.json_string_list
 let event_bus_summary_json = Scan_summary.event_bus_summary_json
 let memory_summary_json = Scan_summary.memory_summary_json
 

--- a/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
+++ b/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
@@ -5,7 +5,6 @@ open Server_dashboard_http_keeper_runtime_lens_swimlane
 module Scan_summary = Server_dashboard_http_keeper_api_scan_summary
 
 let json_int_opt = Scan_summary.json_int_opt
-let json_string_list = Json_util.json_string_list
 let memory_summary_json = Scan_summary.memory_summary_json
 let selected_keeper_turn_id = Scan_summary.selected_keeper_turn_id
 let terminal_event_present_for_turn = Scan_summary.terminal_event_present_for_turn
@@ -148,11 +147,11 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
             ( "tool_surface",
               `Assoc
                 [
-                  ("requested_tools", json_string_list requested_tools);
-                  ("required_tools", json_string_list required_tools);
-                  ("materialized_tools", json_string_list materialized_tools);
+                  ("requested_tools", Json_util.json_string_list requested_tools);
+                  ("required_tools", Json_util.json_string_list required_tools);
+                  ("materialized_tools", Json_util.json_string_list materialized_tools);
                   ( "missing_required_tools",
-                    json_string_list missing_required_tools );
+                    Json_util.json_string_list missing_required_tools );
                   ( "turn_lane",
                     json_string_opt
                       (json_string_member_opt "turn_lane" tool_decision) );
@@ -213,10 +212,10 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                     with
                     | Some value -> `Bool value
                     | None -> `Null );
-                  ("required_tools", json_string_list required_tools);
-                  ("materialized_tools", json_string_list materialized_tools);
+                  ("required_tools", Json_util.json_string_list required_tools);
+                  ("materialized_tools", Json_util.json_string_list materialized_tools);
                   ( "missing_required_tools",
-                    json_string_list missing_required_tools );
+                    Json_util.json_string_list missing_required_tools );
                 ] );
             ( "tool_lineage",
               `Assoc

--- a/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
+++ b/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
@@ -5,7 +5,7 @@ open Server_dashboard_http_keeper_runtime_lens_swimlane
 module Scan_summary = Server_dashboard_http_keeper_api_scan_summary
 
 let json_int_opt = Scan_summary.json_int_opt
-let json_string_list = Scan_summary.json_string_list
+let json_string_list = Json_util.json_string_list
 let memory_summary_json = Scan_summary.memory_summary_json
 let selected_keeper_turn_id = Scan_summary.selected_keeper_turn_id
 let terminal_event_present_for_turn = Scan_summary.terminal_event_present_for_turn

--- a/lib/server/server_dashboard_http_keeper_api_scan_summary.ml
+++ b/lib/server/server_dashboard_http_keeper_api_scan_summary.ml
@@ -10,7 +10,7 @@
     - receipt row matching ({!receipt_row_matches}, {!read_receipt_rows})
       — operate on raw [Yojson.Safe.t] rows + paths;
     - generic JSON helpers ({!unique_ints}, {!json_int_list},
-      {!json_int_opt}, {!json_string_list}) — local single-use sugar;
+      {!json_int_opt}, {!Json_util.json_string_list}) — local single-use sugar;
     - per-section scan summaries ({!event_bus_summary_json},
       {!memory_summary_json}) — fold the manifest scan record into a
       single [`Assoc] for dashboard payload;
@@ -50,8 +50,6 @@ let json_int_opt = function
   | Some value -> `Int value
 ;;
 
-let json_string_list values = `List (List.map (fun value -> `String value) values)
-
 let event_bus_summary_json
       (scan : Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan)
   =
@@ -66,8 +64,8 @@ let event_bus_summary_json
   in
   `Assoc
     [ "event_bus_correlated_count", `Int scan.event_bus_count
-    ; "correlation_ids", json_string_list correlation_ids
-    ; "run_ids", json_string_list run_ids
+    ; "correlation_ids", Json_util.json_string_list correlation_ids
+    ; "run_ids", Json_util.json_string_list run_ids
     ; "context_compact_started_count", `Int scan.context_compact_started_count
     ; "context_compacted_count", `Int scan.context_compacted_count
     ; "last_compaction", last_compaction

--- a/lib/server/server_dashboard_http_keeper_api_scan_summary.mli
+++ b/lib/server/server_dashboard_http_keeper_api_scan_summary.mli
@@ -39,7 +39,6 @@ val json_int_list : int list -> Yojson.Safe.t
 val json_int_opt : int option -> Yojson.Safe.t
 
 (** [json_string_list values] wraps [values] as [`List] of [`String]. *)
-val json_string_list : string list -> Yojson.Safe.t
 
 (** [event_bus_summary_json scan] folds the event-bus / context-compact
     counters out of [scan] into a single [`Assoc] payload for the

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -153,10 +153,7 @@ let json_string_list_member name json =
     |> Json_util.dedupe_keep_order
   | _ -> []
 
-let json_string_opt = function
-  | Some value -> `String value
-  | None -> `Null
-
+let json_string_opt = Json_util.string_opt_to_json
 let take_last limit values =
   let len = List.length values in
   if len <= limit then values

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
@@ -12,9 +12,6 @@ let json_int_opt = function
   | None -> `Null
   | Some value -> `Int value
 
-let json_string_list values =
-  `List (List.map (fun value -> `String value) values)
-
 let json_string_list_member key json =
   match Yojson.Safe.Util.member key json with
   | `List items ->
@@ -280,7 +277,7 @@ let clock_edge_json ~idx ~provider_attempt_index row =
       ("event_bus_correlation_id", json_string_opt event_bus_correlation_id);
       ("event_bus_run_id", json_string_opt event_bus_run_id);
       ("event_bus_event_count", json_int_opt event_bus_event_count);
-      ("event_bus_payload_kinds", json_string_list event_bus_payload_kinds);
+      ("event_bus_payload_kinds", Json_util.json_string_list event_bus_payload_kinds);
       ("parent_event_id", json_string_opt (clock_string row "parent_event_id"));
       ("caused_by", json_string_opt (clock_string row "caused_by"));
       ( "links",

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_clock_groups.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_clock_groups.ml
@@ -16,9 +16,6 @@ let json_int_opt = function
   | None -> `Null
   | Some value -> `Int value
 
-let json_string_list values =
-  `List (List.map (fun value -> `String value) values)
-
 let edge_string key edge = json_string_member_opt key edge
 let edge_int key edge = json_int_member_opt key edge
 let edge_string_list key edge = json_string_list_member key edge
@@ -163,18 +160,18 @@ let runtime_lens_clock_groups_json scan =
       [ "group_type", `String group.group_type
       ; "group_id", `String group.group_id
       ; "edge_count", `Int group.edge_count
-      ; "edge_ids", json_string_list group.edge_ids
-      ; "lanes", json_string_list group.lanes
-      ; "events", json_string_list group.events
-      ; "statuses", json_string_list group.statuses
+      ; "edge_ids", Json_util.json_string_list group.edge_ids
+      ; "lanes", Json_util.json_string_list group.lanes
+      ; "events", Json_util.json_string_list group.events
+      ; "statuses", Json_util.json_string_list group.statuses
       ; "first_observed_at", json_string_opt group.first_observed_at
       ; "last_observed_at", json_string_opt group.last_observed_at
       ; "closed", `Bool (group.terminal_events <> [])
-      ; "terminal_events", json_string_list group.terminal_events
-      ; "parent_event_ids", json_string_list group.parent_event_ids
-      ; "caused_by", json_string_list group.caused_by
+      ; "terminal_events", Json_util.json_string_list group.terminal_events
+      ; "parent_event_ids", Json_util.json_string_list group.parent_event_ids
+      ; "caused_by", Json_util.json_string_list group.caused_by
       ; "event_bus_event_count", `Int group.event_bus_event_count
-      ; "event_bus_payload_kinds", json_string_list group.event_bus_payload_kinds
+      ; "event_bus_payload_kinds", Json_util.json_string_list group.event_bus_payload_kinds
       ])
   |> fun edges -> `List edges
 

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml
@@ -37,8 +37,6 @@ let runtime_lens_proof_acc () =
   ; network_modes = Hashtbl.create 4
   }
 
-let json_string_list values = `List (List.map (fun value -> `String value) values)
-
 let string_contains ~needle value =
   let value = String.lowercase_ascii value in
   let needle = String.lowercase_ascii needle in
@@ -216,13 +214,13 @@ let runtime_lens_runtime_proof_json ~keeper_name ~trace_id ?turn_id () =
     ; ("matched_tool_call_count", `Int acc.matched_tool_call_count)
     ; ("successful_tool_call_count", `Int acc.successful_tool_call_count)
     ; ("failed_tool_call_count", `Int acc.failed_tool_call_count)
-    ; ("tools", json_string_list (runtime_lens_sorted_set acc.tools))
+    ; ("tools", Json_util.json_string_list (runtime_lens_sorted_set acc.tools))
     ; ( "successful_tools",
-        json_string_list (runtime_lens_sorted_set acc.successful_tools) )
-    ; ("failed_tools", json_string_list (runtime_lens_sorted_set acc.failed_tools))
+        Json_util.json_string_list (runtime_lens_sorted_set acc.successful_tools) )
+    ; ("failed_tools", Json_util.json_string_list (runtime_lens_sorted_set acc.failed_tools))
     ; ( "sandbox_profiles",
-        json_string_list (runtime_lens_sorted_set acc.sandbox_profiles) )
-    ; ("network_modes", json_string_list (runtime_lens_sorted_set acc.network_modes))
+        Json_util.json_string_list (runtime_lens_sorted_set acc.sandbox_profiles) )
+    ; ("network_modes", Json_util.json_string_list (runtime_lens_sorted_set acc.network_modes))
     ; ("docker_visible", `Bool acc.docker_visible)
     ; ("git_credentials_enabled", `Bool acc.git_credentials_enabled)
     ; ("github_identity_materialized", `Bool acc.github_identity_materialized)

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_summaries.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_summaries.ml
@@ -5,8 +5,6 @@
 
 open Server_dashboard_http_keeper_api_types
 
-let json_string_list values = `List (List.map (fun value -> `String value) values)
-
 let claim_scope_summary_json ~keeper_name ~trace_id ?turn_id () =
   let entries = Keeper_tool_call_log.read_recent ~keeper_name ~n:200 () in
   let matching_claim =
@@ -42,9 +40,9 @@ let claim_scope_summary_json ~keeper_name ~trace_id ?turn_id () =
           | Some value -> `Bool value
           | None -> `Null )
       ; ( "active_goal_ids",
-          json_string_list (json_string_list_member "active_goal_ids" claim_scope) )
+          Json_util.json_string_list (json_string_list_member "active_goal_ids" claim_scope) )
       ; ( "effective_goal_ids",
-          json_string_list
+          Json_util.json_string_list
             (json_string_list_member "effective_goal_ids" claim_scope) )
       ; ( "fallback_reason",
           json_string_opt (json_string_member_opt "fallback_reason" claim_scope) )
@@ -127,7 +125,7 @@ let config_drift_summary_json ~config ~keeper_name =
                (json_bool_member_opt "has_live_override" sources)
                ~default:false) )
       ; ("cascade_override", `Bool cascade_override)
-      ; ("override_fields", json_string_list override_fields)
+      ; ("override_fields", Json_util.json_string_list override_fields)
       ; ("default_cascade_name", json_string_opt default_cascade_name)
       ; ("live_cascade_name", json_string_opt live_cascade_name)
       ; ( "active_config_root",

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
@@ -13,8 +13,6 @@ type runtime_lens_gap =
   ; detail : string option
   }
 
-let json_string_list values = `List (List.map (fun value -> `String value) values)
-
 let runtime_lens_gap_json gap =
   `Assoc
     [
@@ -266,7 +264,7 @@ let runtime_lens_swimlane_json scan gaps ~lane ~label ~events
       ("event_count", `Int event_count);
       ("terminal_status", `String terminal_status);
       ("completeness", `String (runtime_lens_swimlane_completeness scan lane));
-      ("gap_codes", json_string_list gap_codes);
+      ("gap_codes", Json_util.json_string_list gap_codes);
       ( "gap_badge",
         match gap_codes with
         | code :: _ -> `String code

--- a/lib/server/server_dashboard_http_link_preview.ml
+++ b/lib/server/server_dashboard_http_link_preview.ml
@@ -23,9 +23,6 @@ let max_html_chars = 262_144
 let preview_cache_mu = Eio.Mutex.create ()
 let preview_cache : (string, cache_payload) Hashtbl.t = Hashtbl.create 128
 
-let trim_to_option value =
-  let trimmed = String.trim value in
-  if trimmed = "" then None else Some trimmed
 
 let lower_trim value = String.lowercase_ascii (String.trim value)
 
@@ -45,7 +42,7 @@ let cache_store ~ttl key preview =
 
 let json_string_opt_field fields key =
   match List.assoc_opt key fields with
-  | Some (`String value) -> trim_to_option value
+  | Some (`String value) -> String_util.trim_to_option value
   | _ -> None
 
 let error_reason_of_json = function
@@ -95,7 +92,7 @@ let collapse_whitespace value =
   |> String.trim
 
 let normalize_text value =
-  value |> decode_html_entities |> collapse_whitespace |> trim_to_option
+  value |> decode_html_entities |> collapse_whitespace |> String_util.trim_to_option
 
 let is_http_scheme = function
   | Some "http" | Some "https" -> true

--- a/lib/server/server_dashboard_http_perf.ml
+++ b/lib/server/server_dashboard_http_perf.ml
@@ -19,9 +19,6 @@ let list_hd_opt = function
   | x :: _ -> Some x
 ;;
 
-let trim_to_option raw =
-  let trimmed = String.trim raw in
-  if trimmed = "" then None else Some trimmed
 ;;
 
 let path_descends_from ~root path =
@@ -125,7 +122,7 @@ let benchmark_results_dir_candidates (config : Coord.config) =
     ]
   in
   dedupe_strings
-    (match trim_to_option (Option.value ~default:"" env_dir) with
+    (match String_util.trim_to_option (Option.value ~default:"" env_dir) with
      | Some dir -> [ dir ]
      | None -> scoped_dirs)
   |> List.filter (fun path -> Sys.file_exists path && Sys.is_directory path)

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -3,10 +3,7 @@
 
 open Dashboard_http_helpers
 
-let contains_substring = Server_dashboard_http_runtime_info_json.contains_substring
 let take = Server_dashboard_http_runtime_info_json.take
-let trim_to_option = Server_dashboard_http_runtime_info_json.trim_to_option
-
 type dashboard_runtime_probe_cache_entry =
   { probe : Yojson.Safe.t
   ; refreshed_at : float
@@ -137,7 +134,7 @@ let git_rev_parse_short_probe dir =
          ~timeout_sec:git_rev_parse_short_probe_timeout_sec
          argv
      with
-     | Unix.WEXITED 0, output -> trim_to_option output
+     | Unix.WEXITED 0, output -> String_util.trim_to_option output
      | _ -> None)
 ;;
 
@@ -173,7 +170,7 @@ let maybe_refresh_git_rev_parse_short_in_background dir =
 ;;
 
 let git_rev_parse_short path =
-  match trim_to_option path with
+  match String_util.trim_to_option path with
   | None -> None
   | Some dir when not (Sys.file_exists dir) -> None
   | Some dir ->
@@ -233,7 +230,7 @@ let git_probe_trimmed dir args =
       ~timeout_sec:git_rev_parse_short_probe_timeout_sec
       argv
   with
-  | Unix.WEXITED 0, output -> trim_to_option output
+  | Unix.WEXITED 0, output -> String_util.trim_to_option output
   | _ -> None
 ;;
 
@@ -260,7 +257,7 @@ let git_upstream_status path =
   match Atomic.get git_upstream_status_probe_hook_for_tests with
   | Some hook -> hook path
   | None ->
-    (match trim_to_option path with
+    (match String_util.trim_to_option path with
      | None -> None
      | Some dir when not (Sys.file_exists dir) -> None
      | Some dir ->
@@ -439,7 +436,7 @@ let path_item_json ~source path =
 ;;
 
 let normalized_path_opt path =
-  match trim_to_option path with
+  match String_util.trim_to_option path with
   | None -> None
   | Some path ->
     let normalized =
@@ -459,9 +456,9 @@ let same_normalized_path path expected =
 ;;
 
 let shutdown_signal_of_message message =
-  if contains_substring ~needle:"Received SIGTERM" message
+  if String_util.contains_substring message "Received SIGTERM"
   then Some "SIGTERM"
-  else if contains_substring ~needle:"Received SIGINT" message
+  else if String_util.contains_substring message "Received SIGINT"
   then Some "SIGINT"
   else None
 ;;
@@ -482,9 +479,8 @@ let runtime_diagnostics_json () =
               ; "message", `String message
               ])
       | None
-        when contains_substring
-               ~needle:"repairing state and rewriting canonical JSON"
-               message ->
+        when String_util.contains_substring
+               message "repairing state and rewriting canonical JSON" ->
         Some
           (`Assoc
               [ "ts", `String entry.ts
@@ -492,11 +488,10 @@ let runtime_diagnostics_json () =
               ; "message", `String message
               ])
       | None
-        when contains_substring ~needle:"invalid agent JSON" message
-             || contains_substring ~needle:"repaired agent JSON" message
-             || contains_substring
-                  ~needle:"parse error: Types_core.agent.last_seen"
-                  message ->
+        when String_util.contains_substring message "invalid agent JSON"
+             || String_util.contains_substring message "repaired agent JSON"
+             || String_util.contains_substring
+                  message "parse error: Types_core.agent.last_seen" ->
         Some
           (`Assoc
               [ "ts", `String entry.ts

--- a/lib/server/server_dashboard_http_runtime_info_json.ml
+++ b/lib/server/server_dashboard_http_runtime_info_json.ml
@@ -1,22 +1,20 @@
-(** Option → JSON small builders + git_upstream_status record + 3
+(** Option → JSON small builders + git_upstream_status record + 2
     small utility helpers for the dashboard runtime-info surface.
 
     Four 3-line option-to-Yojson coercers + the
     [git_upstream_status] record that captures git branch / upstream
     / ahead-behind state for a worktree, plus its empty default,
-    plus 3 utility helpers shared by the rest of [Server_dashboard_
+    plus 2 utility helpers shared by the rest of [Server_dashboard_
     http_runtime_info]:
-    - [contains_substring ~needle haystack] — String_util wrapper
       with swapped argument order.
     - [take n xs] — first n elements of a list (tolerant of short
       input).
-    - [trim_to_option raw] — empty-after-trim string -> None.
+    - [String_util.trim_to_option raw] — empty-after-trim string -> None.
 
     Pure builders + value records. Verbatim extract from
     [Server_dashboard_http_runtime_info]; the parent retains
     transparent record alias + 8 value aliases. *)
 
-let contains_substring ~needle haystack = String_util.contains_substring haystack needle
 
 let take n xs =
   let rec loop acc remaining xs =
@@ -30,9 +28,6 @@ let take n xs =
   loop [] n xs
 ;;
 
-let trim_to_option raw =
-  let trimmed = String.trim raw in
-  if trimmed = "" then None else Some trimmed
 ;;
 
 let opt_string_json = function

--- a/lib/server/server_dashboard_http_runtime_info_json.mli
+++ b/lib/server/server_dashboard_http_runtime_info_json.mli
@@ -1,9 +1,7 @@
 (** Option → JSON small builders + git_upstream_status record +
-    3 small utility helpers for the dashboard runtime-info surface. *)
+    2 small utility helpers for the dashboard runtime-info surface. *)
 
-val contains_substring : needle:string -> string -> bool
 val take : int -> 'a list -> 'a list
-val trim_to_option : string -> string option
 
 val opt_string_json : string option -> Yojson.Safe.t
 val opt_bool_json : bool option -> Yojson.Safe.t

--- a/lib/server/server_dashboard_surface.ml
+++ b/lib/server/server_dashboard_surface.ml
@@ -21,11 +21,7 @@ type t = {
 
 let schema = "masc.dashboard_surface.v1"
 
-let json_string_opt = function
-  | Some value -> `String value
-  | None -> `Null
-;;
-
+let json_string_opt = Json_util.string_opt_to_json
 let json_float_opt = function
   | Some value -> `Float value
   | None -> `Null

--- a/lib/server/server_dashboard_surface.ml
+++ b/lib/server/server_dashboard_surface.ml
@@ -21,7 +21,6 @@ type t = {
 
 let schema = "masc.dashboard_surface.v1"
 
-let json_string_opt = Json_util.string_opt_to_json
 let json_float_opt = function
   | Some value -> `Float value
   | None -> `Null
@@ -118,12 +117,12 @@ let to_json envelope =
     ; ( "cache"
       , `Assoc
           [ "state", `String envelope.cache.state
-          ; "key", json_string_opt envelope.cache.key
+          ; "key", Json_util.string_opt_to_json envelope.cache.key
           ; "ttl_s", json_float_opt envelope.cache.ttl_s
           ; "stale", `Bool envelope.cache.stale
-          ; "stale_reason", json_string_opt envelope.cache.stale_reason
+          ; "stale_reason", Json_util.string_opt_to_json envelope.cache.stale_reason
           ; "latest_age_s", json_float_opt envelope.cache.latest_age_s
-          ; "health", json_string_opt envelope.cache.health
+          ; "health", Json_util.string_opt_to_json envelope.cache.health
           ] )
     ; ( "migration"
       , `Assoc

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -99,10 +99,6 @@ let state_net_opt = function
       | None -> Eio_context.get_net_opt ())
   | None -> Eio_context.get_net_opt ()
 
-let contains_substring ~needle haystack =
-  (* Empty needle returns false (unlike String_util's Re-compatible
-     empty=true).  Guard preserves the prior caller contract. *)
-  String.length needle > 0 && String_util.contains_substring haystack needle
 
 let host_header_has_forbidden_authority_chars value =
   let has_forbidden_char =
@@ -112,7 +108,7 @@ let host_header_has_forbidden_authority_chars value =
         | _ -> false)
       value
   in
-  has_forbidden_char || contains_substring ~needle:"://" value
+  has_forbidden_char || String_util.contains_substring value "://"
 
 let parse_host_port host_header default_host default_port =
   match host_header with

--- a/lib/server/server_routes_http_common.mli
+++ b/lib/server/server_routes_http_common.mli
@@ -173,7 +173,6 @@ val handle_presence_events :
 val mcp_transport_http_deps :
   unit -> Server_mcp_transport_http.deps
 val starts_with : prefix:string -> string -> bool
-val contains_substring : needle:string -> string -> bool
 val host_header_has_forbidden_authority_chars :
   string -> bool
 val parse_host_port :

--- a/lib/server/server_routes_http_routes_sidecar.mli
+++ b/lib/server/server_routes_http_routes_sidecar.mli
@@ -39,9 +39,6 @@ val request_base_path : Mcp_server.server_state -> string
 val dir_exists : string -> bool
 (** [Sys.file_exists]+[is_directory] guarded against EACCES. *)
 
-val dedupe_keep_order : 'a list -> 'a list
-(** Keep first occurrence of each value. *)
-
 val project_root_from_executable : unit -> string option
 (** Resolve the masc-mcp project root from [Sys.executable_name];
     [None] for installed binaries that live outside a checkout. *)

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -188,10 +188,7 @@ let json_float_opt = function
   | Some value -> `Float value
   | None -> `Null
 
-let json_string_opt = function
-  | Some value -> `String value
-  | None -> `Null
-
+let json_string_opt = Json_util.string_opt_to_json
 let effective_autoboot_enabled name (meta : Keeper_types.keeper_meta) =
   match (Keeper_types_profile.load_keeper_profile_defaults name).autoboot_enabled with
   | Some value -> value

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -188,7 +188,6 @@ let json_float_opt = function
   | Some value -> `Float value
   | None -> `Null
 
-let json_string_opt = Json_util.string_opt_to_json
 let effective_autoboot_enabled name (meta : Keeper_types.keeper_meta) =
   match (Keeper_types_profile.load_keeper_profile_defaults name).autoboot_enabled with
   | Some value -> value
@@ -244,11 +243,11 @@ let paused_keeper_detail_json ~now ~name ~(autoboot_enabled : bool)
     ("auto_resume_after_sec", json_float_opt meta.auto_resume_after_sec);
     ( "persisted_auto_resume_after_sec"
     , json_float_opt meta.auto_resume_after_sec );
-    ("auto_resume_source", json_string_opt (pause_auto_resume_source meta));
+    ("auto_resume_source", Json_util.string_opt_to_json (pause_auto_resume_source meta));
     ("paused_elapsed_sec", json_float_opt elapsed);
     ("auto_resume_remaining_sec", json_float_opt remaining);
-    ("last_blocker_class", json_string_opt (blocker_class_string last_blocker));
-    ("last_blocker_detail", json_string_opt (blocker_detail last_blocker));
+    ("last_blocker_class", Json_util.string_opt_to_json (blocker_class_string last_blocker));
+    ("last_blocker_detail", Json_util.string_opt_to_json (blocker_detail last_blocker));
     ( "missing_pause_root_cause",
       `Bool
         (Option.is_some meta.auto_resume_after_sec
@@ -637,7 +636,7 @@ let keeper_fleet_safety_health_json
   in
   `Assoc
     [ "status", `String status
-    ; ("blocker", json_string_opt blocker)
+    ; ("blocker", Json_util.string_opt_to_json blocker)
     ; "bootable_keeper_count", `Int bootable_count
     ; ( "bootable_keeper_names"
       , `List (List.map (fun name -> `String name) bootable_names) )

--- a/lib/server/server_routes_http_sidecar_paths.ml
+++ b/lib/server/server_routes_http_sidecar_paths.ml
@@ -36,18 +36,6 @@ let runtime_base_path ?base_path () =
 let request_base_path state = state.Mcp_server.room_config.base_path
 let dir_exists path = Sys.file_exists path && Sys.is_directory path
 
-let dedupe_keep_order values =
-  let seen = Hashtbl.create (List.length values) in
-  List.filter
-    (fun value ->
-      if Hashtbl.mem seen value
-      then false
-      else (
-        Hashtbl.replace seen value ();
-        true))
-    values
-;;
-
 let project_root_from_executable () =
   let raw_exe =
     try Sys.executable_name with
@@ -80,7 +68,7 @@ let sidecar_root () = trim_opt (Sys.getenv_opt "MASC_SIDECAR_ROOT")
 let sidecar_root_candidates ?sidecar_root ?project_root ~base_path () =
   [ sidecar_root; Some base_path; project_root ]
   |> List.filter_map (fun item -> item)
-  |> dedupe_keep_order
+  |> Json_util.dedupe_keep_order
 ;;
 
 let sidecar_dir_under root id =
@@ -257,7 +245,7 @@ let status_file_candidates ?sidecar_root ?project_root ?sidecar_dir ~base_path i
     resolve_relative_path ~roots (Printf.sprintf ".gate/runtime/%s/status.json" id)
   in
   let legacy_paths = resolve_relative_path ~roots (legacy_status_rel id) in
-  dedupe_keep_order (env_paths @ dotenv_paths @ toml_paths @ default_paths @ legacy_paths)
+  Json_util.dedupe_keep_order (env_paths @ dotenv_paths @ toml_paths @ default_paths @ legacy_paths)
 ;;
 
 let status_file ?sidecar_root ?project_root ?sidecar_dir ~base_path id =
@@ -273,7 +261,7 @@ let log_file_candidates ?sidecar_root ?project_root ~base_path id =
     Filename.concat
       (Common.masc_dir_from_base_path ~base_path:root)
       (Printf.sprintf "logs/%s-sidecar-%s.log" id (today_yyyymmdd ())))
-  |> dedupe_keep_order
+  |> Json_util.dedupe_keep_order
 ;;
 
 let today_log_file ?sidecar_root ?project_root ~base_path id =

--- a/lib/server/server_routes_http_sidecar_paths.mli
+++ b/lib/server/server_routes_http_sidecar_paths.mli
@@ -10,7 +10,6 @@ val trim_opt : string option -> string option
 val runtime_base_path : ?base_path:string -> unit -> string
 val request_base_path : Mcp_server.server_state -> string
 val dir_exists : string -> bool
-val dedupe_keep_order : 'a list -> 'a list
 val project_root_from_executable : unit -> string option
 val sidecar_root : unit -> string option
 val sidecar_root_candidates :

--- a/lib/server/server_runtime_config_root_bootstrap.ml
+++ b/lib/server/server_runtime_config_root_bootstrap.ml
@@ -36,18 +36,6 @@ let config_root_from_ancestor start_dir =
   walk_up start_dir
 ;;
 
-let dedupe_keep_order items =
-  let seen = Hashtbl.create (List.length items) in
-  List.filter
-    (fun item ->
-      if Hashtbl.mem seen item
-      then false
-      else (
-        Hashtbl.add seen item ();
-        true))
-    items
-;;
-
 let versioned_config_root_candidates () =
   let cwd = Config_dir_resolver.current_working_dir () in
   let cwd_candidate = Filename.concat cwd "config" in
@@ -59,7 +47,7 @@ let versioned_config_root_candidates () =
   in
   [ Some cwd_candidate; cwd_ancestor_candidate; exe_candidate ]
   |> List.filter_map (fun x -> x)
-  |> dedupe_keep_order
+  |> Json_util.dedupe_keep_order
   |> List.filter (fun path -> Sys.file_exists path && Sys.is_directory path)
 ;;
 

--- a/lib/server/server_runtime_config_root_bootstrap.mli
+++ b/lib/server/server_runtime_config_root_bootstrap.mli
@@ -2,8 +2,6 @@ val project_root_from_executable : unit -> string option
 
 val config_root_from_ancestor : string -> string option
 
-val dedupe_keep_order : 'a list -> 'a list
-
 val versioned_config_root_candidates : unit -> string list
 
 val copy_file_if_missing : src:string -> dst:string -> unit

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -69,11 +69,10 @@ let status_line_is_healthy line =
   | _ -> false
 ;;
 
-let contains_substring ~needle haystack = String_util.contains_substring haystack needle
 
 let looks_like_server_command command =
   List.exists
-    (fun marker -> contains_substring ~needle:marker command)
+    (fun marker -> String_util.contains_substring command marker)
     [ "main_eio"; "masc-mcp" ]
 ;;
 

--- a/lib/server/server_webrtc_transport.ml
+++ b/lib/server/server_webrtc_transport.ml
@@ -19,17 +19,14 @@
 (** Whether WebRTC transport is enabled (default: true). *)
 let is_enabled () = Env_config.Transport.webrtc_enabled ()
 
-let trim_nonempty value =
-  let trimmed = String.trim value in
-  if trimmed = "" then None else Some trimmed
 
 let getenv_nonempty name =
   match Sys.getenv_opt name with
-  | Some value -> trim_nonempty value
+  | Some value -> String_util.trim_nonempty value
   | None -> None
 
 let split_csv value =
-  String.split_on_char ',' value |> List.filter_map trim_nonempty
+  String.split_on_char ',' value |> List.filter_map String_util.trim_nonempty
 
 let ice_server_urls (server : Webrtc.Ice.ice_server) = server.Webrtc.Ice.urls
 
@@ -42,7 +39,7 @@ let parse_ice_servers_json raw =
       | `List values ->
         values
         |> List.filter_map (fun value ->
-             try value |> to_string |> trim_nonempty
+             try value |> to_string |> String_util.trim_nonempty
              with Type_error _ -> None)
       | _ -> []
     in
@@ -51,7 +48,7 @@ let parse_ice_servers_json raw =
     else
       let opt name =
         match member name json |> to_string_option with
-        | Some value -> trim_nonempty value
+        | Some value -> String_util.trim_nonempty value
         | None -> None
       in
       Some

--- a/lib/shared_audit/dune
+++ b/lib/shared_audit/dune
@@ -5,4 +5,4 @@
  (public_name masc_mcp.shared_audit)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags (:standard -w +4))
- (libraries unix yojson digestif digestif.c jsonl_writer))
+ (libraries unix yojson digestif digestif.c jsonl_writer fs_compat))

--- a/lib/shared_audit/store.ml
+++ b/lib/shared_audit/store.ml
@@ -58,7 +58,7 @@ let load_latest_hash ~base_dir =
     find_in_months months
 
 let create ~base_dir =
-  if not (Sys.file_exists base_dir) then Jsonl_writer.ensure_dir base_dir;
+  if not (Sys.file_exists base_dir) then Fs_compat.mkdir_p base_dir;
   let latest_hash = load_latest_hash ~base_dir in
   { base_dir; latest_hash }
 

--- a/lib/tool_access_policy.ml
+++ b/lib/tool_access_policy.ml
@@ -33,20 +33,11 @@ type t = {
   deny : selector;
 }
 
-let dedupe_keep_order names =
-  let rec loop seen acc = function
-    | [] -> List.rev acc
-    | name :: rest when StringSet.mem name seen -> loop seen acc rest
-    | name :: rest ->
-        loop (StringSet.add name seen) (name :: acc) rest
-  in
-  loop StringSet.empty [] names
-
 let normalize_names names =
   names
   |> List.map String.trim
   |> List.filter (fun name -> not (String.equal name ""))
-  |> dedupe_keep_order
+  |> Json_util.dedupe_keep_order
 
 let empty = { allow = Empty; deny = Empty }
 let allow_all = { allow = All; deny = Empty }

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
@@ -23,21 +23,11 @@ let default_case_set_path ~repo_root =
 let default_evidence_path ~repo_root =
   Filename.concat repo_root "test/fixtures/tool_call_quality_benchmark/evidence_runs.json"
 
-let dedupe_keep_order items =
-  let seen = Hashtbl.create (List.length items) in
-  List.filter
-    (fun item ->
-      if Hashtbl.mem seen item then false
-      else (
-        Hashtbl.add seen item ();
-        true))
-    items
-
 let normalize_string_list items =
   items
   |> List.map String.trim
   |> List.filter (fun item -> not (String.equal item ""))
-  |> dedupe_keep_order
+  |> Json_util.dedupe_keep_order
 
 let errorf fmt = Printf.ksprintf (fun s -> Error s) fmt
 

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.ml
@@ -48,21 +48,11 @@ let percentile95_int_option values =
       | Some v -> Stdlib.Float.of_int v
       | None -> 0.0
 
-let dedupe_keep_order items =
-  let seen = Hashtbl.create (List.length items) in
-  List.filter
-    (fun item ->
-      if Hashtbl.mem seen item then false
-      else (
-        Hashtbl.add seen item ();
-        true))
-    items
-
 let normalize_string_list items =
   items
   |> List.map String.trim
   |> List.filter (fun item -> not (String.equal item ""))
-  |> dedupe_keep_order
+  |> Json_util.dedupe_keep_order
 
 let model_label (run : evidence_run) = run.provider ^ ":" ^ run.model
 

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -88,21 +88,11 @@ let git_common_root path =
   | Unix.Unix_error _ -> None
   | Sys_error _ -> None
 
-let dedupe_keep_order paths =
-  let seen = Hashtbl.create (List.length paths) in
-  List.filter
-    (fun path ->
-      if Hashtbl.mem seen path then false
-      else (
-        Hashtbl.replace seen path ();
-        true))
-    paths
-
 let allowed_worktree_prefixes config =
   [ git_common_root config.Coord.base_path;
     git_common_root (Sys.getcwd ()) ]
   |> List.filter_map (fun root -> root)
-  |> dedupe_keep_order
+  |> Json_util.dedupe_keep_order
   |> List.map (fun root -> normalize_dir_prefix (Filename.concat root ".worktrees"))
 
 let repo_top_relative_write_path raw =

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -96,9 +96,9 @@ let finalize_runtime_breakdown json =
           ("runtime_id", Option.value ~default:`Null (List.assoc_opt "runtime_id" fields));
           ("success_count", Option.value ~default:`Null (List.assoc_opt "success_count" fields));
           ("failure_count", Option.value ~default:`Null (List.assoc_opt "failure_count" fields));
-          ("p50_latency_ms", int_opt_to_json (pctl 0.50 latencies));
-          ("p95_latency_ms", int_opt_to_json (pctl 0.95 latencies));
-          ("max_latency_ms", int_opt_to_json (pctl 1.0 latencies));
+          ("p50_latency_ms", Json_util.int_opt_to_json (pctl 0.50 latencies));
+          ("p95_latency_ms", Json_util.int_opt_to_json (pctl 0.95 latencies));
+          ("max_latency_ms", Json_util.int_opt_to_json (pctl 1.0 latencies));
         ]
   | _ -> json
 
@@ -288,8 +288,8 @@ let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
           [
             ("server_url", `String Env_config.Local_runtime.server_url);
             ("source", `String "oas_complete");
-            ("model_id", string_opt_to_json model_id);
-            ("runtime_pool", string_opt_to_json runtime_pool);
+            ("model_id", Json_util.string_opt_to_json model_id);
+            ("runtime_pool", Json_util.string_opt_to_json runtime_pool);
             ("parallelism", `Int parallelism);
             ("rounds", `Int rounds);
             ("total_requests", `Int (List.length samples));
@@ -301,12 +301,12 @@ let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
                  else
                    Stdlib.Float.of_int success_count
                    /. Stdlib.Float.of_int (List.length samples)) );
-            ("p50_latency_ms", int_opt_to_json (pctl 0.50 latencies));
-            ("p95_latency_ms", int_opt_to_json (pctl 0.95 latencies));
-            ("max_latency_ms", int_opt_to_json (pctl 1.0 latencies));
+            ("p50_latency_ms", Json_util.int_opt_to_json (pctl 0.50 latencies));
+            ("p95_latency_ms", Json_util.int_opt_to_json (pctl 0.95 latencies));
+            ("max_latency_ms", Json_util.int_opt_to_json (pctl 1.0 latencies));
             ("configured_max_concurrent_models", `Int Inference_utils.max_concurrent_models);
             ("configured_capacity", `Int (Local_runtime_pool.configured_capacity ()));
-            ("measured_ceiling", int_opt_to_json (Local_runtime_pool.measured_ceiling ()));
+            ("measured_ceiling", Json_util.int_opt_to_json (Local_runtime_pool.measured_ceiling ()));
             ("per_runtime_breakdown", `List runtime_breakdown);
             ( "errors",
               `List (errors |> List.map (fun message -> `String message)) );

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -50,7 +50,6 @@ let json_ok = Tool_args.ok_response
 let parse_int_opt value =
   Stdlib.int_of_string_opt ((String.trim value))
 
-let unique_preserve_order = Json_util.dedupe_keep_order
 
 let split_ws text =
   match Exec_policy.parse_string_to_ir ~mode:Strict text with

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -46,9 +46,6 @@ type bench_sample = {
 let json_error = Tool_args.error_response
 let json_ok = Tool_args.ok_response
 
-let int_opt_to_json = Json_util.int_opt_to_json
-let string_opt_to_json = Json_util.string_opt_to_json
-let float_opt_to_json = Json_util.float_opt_to_json
 
 let parse_int_opt value =
   Stdlib.int_of_string_opt ((String.trim value))
@@ -105,15 +102,15 @@ let server_port_of_url url =
 let process_to_yojson (process : llama_process) =
   `Assoc
     [
-      ("pid", int_opt_to_json process.pid);
+      ("pid", Json_util.int_opt_to_json process.pid);
       ("command", `String process.command);
-      ("port", int_opt_to_json process.port);
-      ("host", string_opt_to_json process.host);
-      ("alias", string_opt_to_json process.alias);
-      ("model_path", string_opt_to_json process.model_path);
-      ("ctx_size", int_opt_to_json process.ctx_size);
-      ("batch_size", int_opt_to_json process.batch_size);
-      ("ubatch_size", int_opt_to_json process.ubatch_size);
+      ("port", Json_util.int_opt_to_json process.port);
+      ("host", Json_util.string_opt_to_json process.host);
+      ("alias", Json_util.string_opt_to_json process.alias);
+      ("model_path", Json_util.string_opt_to_json process.model_path);
+      ("ctx_size", Json_util.int_opt_to_json process.ctx_size);
+      ("batch_size", Json_util.int_opt_to_json process.batch_size);
+      ("ubatch_size", Json_util.int_opt_to_json process.ubatch_size);
       ("slots_enabled", `Bool process.slots_enabled);
     ]
 

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -59,7 +59,6 @@ let split_ws text =
       if String.equal trimmed "" then [] else [ trimmed ]
   | Ok ir -> Exec_policy.flat_stage_words ir
 
-let string_contains_substring = String_util.contains_substring
 
 let parse_pid_and_command line =
   let trimmed = String.trim line in
@@ -136,7 +135,7 @@ let discover_processes () =
         |> String.split_on_char '\n'
         |> List.filter_map (fun line ->
                let pid, command = parse_pid_and_command line in
-               if String.equal command "" || not (string_contains_substring command "llama-server") then
+               if String.equal command "" || not (String_util.contains_substring command "llama-server") then
                  None
                else
                  let tokens = split_ws command in

--- a/lib/tool_local_runtime_core.mli
+++ b/lib/tool_local_runtime_core.mli
@@ -76,7 +76,6 @@ val parse_int_opt : string -> int option
     {!String.trim} — convenience for cmdline / JSON-string-int
     coercion. *)
 
-val unique_preserve_order : string list -> string list
 (** Alias over {!Json_util.dedupe_keep_order}. *)
 
 val split_ws : string -> string list

--- a/lib/tool_local_runtime_core.mli
+++ b/lib/tool_local_runtime_core.mli
@@ -66,9 +66,6 @@ val json_ok : (string * Yojson.Safe.t) list -> string
 (** Alias for {!Tool_args.ok_response}.  Same compatibility rationale as
     {!json_error}. *)
 
-val int_opt_to_json : int option -> Yojson.Safe.t
-val string_opt_to_json : string option -> Yojson.Safe.t
-val float_opt_to_json : float option -> Yojson.Safe.t
 (** Aliases over {!Json_util.*_opt_to_json} re-exported for the
     sibling include cascade. *)
 

--- a/lib/tool_local_runtime_core.mli
+++ b/lib/tool_local_runtime_core.mli
@@ -84,7 +84,6 @@ val split_ws : string -> string list
     bash-subset word parser, preserving quoted values.  Used to tokenise
     cmdlines into argv-like lists for process discovery. *)
 
-val string_contains_substring : string -> string -> bool
 (** Alias over {!String_util.contains_substring} — case-
     sensitive. *)
 

--- a/lib/tool_local_runtime_http.ml
+++ b/lib/tool_local_runtime_http.ml
@@ -21,9 +21,6 @@ let default_timeout_sec = 10
 
 include Tool_local_runtime_core
 
-let trim_to_option raw =
-  let trimmed = String.trim raw in
-  if String.equal trimmed "" then None else Some trimmed
 
 let split_http_body_and_status body =
   match String.rindex_opt body '\n' with
@@ -151,4 +148,4 @@ let int_member json key =
 
 let string_member json key =
   let open Yojson.Safe.Util in
-  Option.bind (member key json |> to_string_option) trim_to_option
+  Option.bind (member key json |> to_string_option) String_util.trim_to_option

--- a/lib/tool_local_runtime_http.mli
+++ b/lib/tool_local_runtime_http.mli
@@ -26,7 +26,6 @@ end
 
 (** {1 String / JSON helpers} *)
 
-val trim_to_option : string -> string option
 (** [trim_to_option raw] returns [Some s] iff [s = String.trim raw]
     is non-empty, else [None].  Used for "treat empty string as
     missing" semantics on JSON / shell inputs. *)

--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -67,9 +67,6 @@ let bool_opt_to_json = Json_util.bool_opt_to_json
 
 let clamp ~min_value ~max_value value = max min_value (min max_value value)
 
-let trim_to_option raw =
-  let trimmed = String.trim raw in
-  if String.equal trimmed "" then None else Some trimmed
 
 let normalize_ollama_server_url raw =
   let trimmed = String.trim raw in
@@ -417,12 +414,12 @@ let fetch_ollama_ps ?(timeout_sec = 8) ~server_url () =
   | Error err -> (None, [], Some err)
 
 let select_effective_model ~requested_model loaded_models =
-  match Option.bind requested_model trim_to_option with
+  match Option.bind requested_model String_util.trim_to_option with
   | Some _ as result -> result
   | None ->
     (match loaded_models with
      | model :: _ -> loaded_model_name model
-     | [] -> trim_to_option Env_config_runtime.Ollama.default_model)
+     | [] -> String_util.trim_to_option Env_config_runtime.Ollama.default_model)
 
 let model_is_loaded model_id loaded_models =
   List.exists
@@ -468,7 +465,7 @@ let request_body_json ~think_enabled ~keep_alive ~model_id ~prompt ~max_tokens =
       Some ("prompt", `String prompt);
       Some ("stream", `Bool false);
       Some ("think", `Bool think_enabled);
-      (match Option.bind keep_alive trim_to_option with
+      (match Option.bind keep_alive String_util.trim_to_option with
       | Some value -> Some ("keep_alive", `String value)
       | None -> None);
       Some
@@ -524,12 +521,12 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
     ?(generate_when_unloaded = true)
     ?(run_generate = true) () =
   let server_url =
-    Option.bind server_url trim_to_option
+    Option.bind server_url String_util.trim_to_option
     |> Option.value ~default:Env_config_runtime.Ollama.server_url
     |> normalize_ollama_server_url
   in
   let prompt =
-    Option.bind prompt trim_to_option |> Option.value ~default:(default_probe_prompt ())
+    Option.bind prompt String_util.trim_to_option |> Option.value ~default:(default_probe_prompt ())
   in
   let probe_runs = clamp ~min_value:1 ~max_value:4 probe_runs in
   let max_tokens = clamp ~min_value:1 ~max_value:128 max_tokens in
@@ -656,8 +653,8 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
       ("server_url", `String server_url);
       ("ps_endpoint", `String (ollama_ps_url server_url));
       ("generate_endpoint", `String (ollama_generate_url server_url));
-      ("configured_default_model", string_opt_to_json (trim_to_option Env_config_runtime.Ollama.default_model));
-      ("requested_model", string_opt_to_json (Option.bind model trim_to_option));
+      ("configured_default_model", string_opt_to_json (String_util.trim_to_option Env_config_runtime.Ollama.default_model));
+      ("requested_model", string_opt_to_json (Option.bind model String_util.trim_to_option));
       ("effective_model", string_opt_to_json effective_model);
       ("probe_runs_requested", `Int probe_runs);
       ("probe_runs_completed", `Int (List.length runs));
@@ -665,7 +662,7 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
       ("generate_when_unloaded", `Bool generate_when_unloaded);
       ("generate_skip_reason", string_opt_to_json generate_skip_reason);
       ("generate_skipped_unloaded_model", `Bool generate_skipped_unloaded_model);
-      ("keep_alive", string_opt_to_json (Option.bind keep_alive trim_to_option));
+      ("keep_alive", string_opt_to_json (Option.bind keep_alive String_util.trim_to_option));
       ("max_tokens", `Int max_tokens);
       ("think_mode", `String (ollama_probe_think_mode_to_string think_mode));
       ("think", `Bool think_enabled);

--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -63,7 +63,6 @@ type generate_probe_decision =
   | Run_generate_probe
   | Skip_generate_probe of generate_probe_skip_reason
 
-let bool_opt_to_json = Json_util.bool_opt_to_json
 
 let clamp ~min_value ~max_value value = max min_value (min max_value value)
 
@@ -160,33 +159,33 @@ let loaded_model_name (model : ollama_loaded_model) =
 let ollama_loaded_model_to_yojson (model : ollama_loaded_model) =
   `Assoc
     [
-      ("name", string_opt_to_json model.name);
-      ("model", string_opt_to_json model.model);
-      ("size_vram_bytes", int_opt_to_json model.size_vram_bytes);
-      ("context_length", int_opt_to_json model.context_length);
-      ("expires_at", string_opt_to_json model.expires_at);
+      ("name", Json_util.string_opt_to_json model.name);
+      ("model", Json_util.string_opt_to_json model.model);
+      ("size_vram_bytes", Json_util.int_opt_to_json model.size_vram_bytes);
+      ("context_length", Json_util.int_opt_to_json model.context_length);
+      ("expires_at", Json_util.string_opt_to_json model.expires_at);
     ]
 
 let ollama_probe_run_to_yojson (run : ollama_probe_run) =
   `Assoc
     [
       ("run_index", `Int run.run_index);
-      ("http_status", int_opt_to_json run.http_status);
+      ("http_status", Json_util.int_opt_to_json run.http_status);
       ("wall_clock_ms", `Int run.wall_clock_ms);
-      ("total_duration_ms", float_opt_to_json run.total_duration_ms);
-      ("load_duration_ms", float_opt_to_json run.load_duration_ms);
-      ("prompt_eval_count", int_opt_to_json run.prompt_eval_count);
-      ("prompt_eval_duration_ms", float_opt_to_json run.prompt_eval_duration_ms);
-      ("prompt_tokens_per_second", float_opt_to_json run.prompt_tokens_per_second);
-      ("eval_count", int_opt_to_json run.eval_count);
-      ("eval_duration_ms", float_opt_to_json run.eval_duration_ms);
-      ("generation_tokens_per_second", float_opt_to_json run.generation_tokens_per_second);
-      ("done", bool_opt_to_json run.done_flag);
-      ("done_reason", string_opt_to_json run.done_reason);
+      ("total_duration_ms", Json_util.float_opt_to_json run.total_duration_ms);
+      ("load_duration_ms", Json_util.float_opt_to_json run.load_duration_ms);
+      ("prompt_eval_count", Json_util.int_opt_to_json run.prompt_eval_count);
+      ("prompt_eval_duration_ms", Json_util.float_opt_to_json run.prompt_eval_duration_ms);
+      ("prompt_tokens_per_second", Json_util.float_opt_to_json run.prompt_tokens_per_second);
+      ("eval_count", Json_util.int_opt_to_json run.eval_count);
+      ("eval_duration_ms", Json_util.float_opt_to_json run.eval_duration_ms);
+      ("generation_tokens_per_second", Json_util.float_opt_to_json run.generation_tokens_per_second);
+      ("done", Json_util.bool_opt_to_json run.done_flag);
+      ("done_reason", Json_util.string_opt_to_json run.done_reason);
       ("thinking_present", `Bool run.thinking_present);
-      ("response_preview", string_opt_to_json run.response_preview);
-      ("response_chars", int_opt_to_json run.response_chars);
-      ("error", string_opt_to_json run.error);
+      ("response_preview", Json_util.string_opt_to_json run.response_preview);
+      ("response_chars", Json_util.int_opt_to_json run.response_chars);
+      ("error", Json_util.string_opt_to_json run.error);
     ]
 
 let ollama_loaded_models_of_ps_json json =
@@ -360,11 +359,11 @@ let kv_cache_assessment_json run_jsons =
       `Assoc
         [
           ("signal", `String signal);
-          ("baseline_run_index", int_opt_to_json baseline_run_index);
-          ("best_repeat_run_index", int_opt_to_json best_repeat_run_index);
+          ("baseline_run_index", Json_util.int_opt_to_json baseline_run_index);
+          ("best_repeat_run_index", Json_util.int_opt_to_json best_repeat_run_index);
           ("baseline_prompt_eval_duration_ms", `Float baseline_ms);
           ("best_repeat_prompt_eval_duration_ms", `Float best_repeat_ms);
-          ("prompt_eval_duration_reduction_ratio", float_opt_to_json reduction_ratio);
+          ("prompt_eval_duration_reduction_ratio", Json_util.float_opt_to_json reduction_ratio);
           ("note", `String note);
           ( "limitation",
             `String
@@ -653,16 +652,16 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
       ("server_url", `String server_url);
       ("ps_endpoint", `String (ollama_ps_url server_url));
       ("generate_endpoint", `String (ollama_generate_url server_url));
-      ("configured_default_model", string_opt_to_json (String_util.trim_to_option Env_config_runtime.Ollama.default_model));
-      ("requested_model", string_opt_to_json (Option.bind model String_util.trim_to_option));
-      ("effective_model", string_opt_to_json effective_model);
+      ("configured_default_model", Json_util.string_opt_to_json (String_util.trim_to_option Env_config_runtime.Ollama.default_model));
+      ("requested_model", Json_util.string_opt_to_json (Option.bind model String_util.trim_to_option));
+      ("effective_model", Json_util.string_opt_to_json effective_model);
       ("probe_runs_requested", `Int probe_runs);
       ("probe_runs_completed", `Int (List.length runs));
       ("run_generate", `Bool run_generate);
       ("generate_when_unloaded", `Bool generate_when_unloaded);
-      ("generate_skip_reason", string_opt_to_json generate_skip_reason);
+      ("generate_skip_reason", Json_util.string_opt_to_json generate_skip_reason);
       ("generate_skipped_unloaded_model", `Bool generate_skipped_unloaded_model);
-      ("keep_alive", string_opt_to_json (Option.bind keep_alive String_util.trim_to_option));
+      ("keep_alive", Json_util.string_opt_to_json (Option.bind keep_alive String_util.trim_to_option));
       ("max_tokens", `Int max_tokens);
       ("think_mode", `String (ollama_probe_think_mode_to_string think_mode));
       ("think", `Bool think_enabled);
@@ -670,8 +669,8 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
       ("ps_timeout_sec", `Int ps_timeout_sec);
       ("prompt_chars", `Int (String.length prompt));
       ("prompt_preview", `String (prompt |> collapse_preview |> truncate_text ~max_len:200));
-      ("ps_http_status_before", int_opt_to_json before_status);
-      ("ps_http_status_after", int_opt_to_json after_status);
+      ("ps_http_status_before", Json_util.int_opt_to_json before_status);
+      ("ps_http_status_after", Json_util.int_opt_to_json after_status);
       ("loaded_models_before", `List (List.map ollama_loaded_model_to_yojson loaded_before));
       ("loaded_models_after", `List (List.map ollama_loaded_model_to_yojson loaded_after));
       ("model_loaded_before_probe", `Bool effective_model_loaded_before);

--- a/lib/tool_local_runtime_status.ml
+++ b/lib/tool_local_runtime_status.ml
@@ -129,7 +129,7 @@ let runtime_status_json ?(include_models = true) () =
       ("healthy_runtime_count", `Int healthy_runtime_count);
       ("configured_capacity", `Int configured_capacity);
       ("allocated_slots", `Int allocated_slots);
-      ("measured_ceiling", int_opt_to_json measured_ceiling);
+      ("measured_ceiling", Json_util.int_opt_to_json measured_ceiling);
       ("process_count", `Int (List.length processes));
       ("matching_process_count", `Int (List.length matching_processes));
       ("runtime_config_errors", `List (List.map (fun item -> `String item) parse_errors));

--- a/lib/tool_local_runtime_status.ml
+++ b/lib/tool_local_runtime_status.ml
@@ -75,7 +75,7 @@ let runtime_status_json ?(include_models = true) () =
                    (fun item -> Yojson.Safe.Util.to_string_option item)
                    items
              | _ -> [])
-      |> unique_preserve_order
+      |> Json_util.dedupe_keep_order
   in
   let configured_capacity = Local_runtime_pool.configured_capacity () in
   let allocated_slots = Local_runtime_pool.allocated_slots () in

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -22,7 +22,7 @@ module Oas_types = Agent_sdk.Types
 
 let runtime_snapshots_for_pool runtime_pool =
   let snapshots = Local_runtime_pool.snapshots () in
-  match Option.bind runtime_pool trim_to_option with
+  match Option.bind runtime_pool String_util.trim_to_option with
   | None -> snapshots
   | Some pool when String.equal pool Local_runtime_pool.default_pool_label -> snapshots
   | Some pool ->
@@ -46,7 +46,7 @@ let discovery_endpoints_for_pool runtime_pool =
   | Some [] -> None
   | Some endpoints ->
       let matches_pool (endpoint : Discovery_cache.endpoint_info) =
-        match Option.bind runtime_pool trim_to_option with
+        match Option.bind runtime_pool String_util.trim_to_option with
         | None -> true
         | Some pool
           when String.equal pool Local_runtime_pool.default_pool_label
@@ -108,10 +108,10 @@ let slot_count_of_json json =
 
 let endpoint_model_id (endpoint : Discovery_cache.endpoint_info) =
   match endpoint.models with
-  | model :: _ -> trim_to_option model.id
+  | model :: _ -> String_util.trim_to_option model.id
   | [] -> (
       match endpoint.props with
-      | Some props -> trim_to_option props.model
+      | Some props -> String_util.trim_to_option props.model
       | None -> None)
 
 let endpoint_total_slots (endpoint : Discovery_cache.endpoint_info) =

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -315,35 +315,35 @@ let runtime_verify_json_from_discovery ?runtime_pool ?expected_slots ?expected_c
               ("slot_url", `String endpoint.url);
               ("provider_reachable", `Bool provider_ok_row);
               ( "provider_status_code",
-                int_opt_to_json
+                Json_util.int_opt_to_json
                   (if provider_ok_row then Some 200 else None) );
               ( "provider_error",
-                string_opt_to_json
+                Json_util.string_opt_to_json
                   (if provider_ok_row then None
                    else Some "oas discovery marked endpoint unhealthy") );
               ("slot_reachable", `Bool slot_ok_row);
-              ("slot_status_code", int_opt_to_json (if slot_ok_row then Some 200 else None));
+              ("slot_status_code", Json_util.int_opt_to_json (if slot_ok_row then Some 200 else None));
               ("slot_error", `Null);
               ( "props_status_code",
-                int_opt_to_json
+                Json_util.int_opt_to_json
                   (if Option.is_some endpoint.props then Some 200 else None) );
               ("props_error", `Null);
               ( "models_status_code",
-                int_opt_to_json
+                Json_util.int_opt_to_json
                   (if Stdlib.List.length endpoint.models > 0 then Some 200 else None) );
               ("models_error", `Null);
-              ("expected_model", string_opt_to_json expected_model);
-              ("actual_model_id", string_opt_to_json actual_model);
-              ("expected_slots", int_opt_to_json expected_slots);
-              ("actual_slots", int_opt_to_json actual_slots);
-              ("expected_ctx", int_opt_to_json expected_ctx);
-              ("actual_ctx", int_opt_to_json actual_ctx);
+              ("expected_model", Json_util.string_opt_to_json expected_model);
+              ("actual_model_id", Json_util.string_opt_to_json actual_model);
+              ("expected_slots", Json_util.int_opt_to_json expected_slots);
+              ("actual_slots", Json_util.int_opt_to_json actual_slots);
+              ("expected_ctx", Json_util.int_opt_to_json expected_ctx);
+              ("actual_ctx", Json_util.int_opt_to_json actual_ctx);
               ("active_slots_now", `Int current_active);
               ( "chat_completion_compatible",
                 match chat_probe_ok with
                 | Some value -> `Bool value
                 | None -> `Null );
-              ("chat_completion_error", string_opt_to_json chat_probe_error);
+              ("chat_completion_error", Json_util.string_opt_to_json chat_probe_error);
             ]
         in
         ( row :: rows,
@@ -374,27 +374,27 @@ let runtime_verify_json_from_discovery ?runtime_pool ?expected_slots ?expected_c
   `Assoc
     [
       ("checked_at", `String (Masc_domain.now_iso ()));
-      ("runtime_pool", string_opt_to_json runtime_pool);
+      ("runtime_pool", Json_util.string_opt_to_json runtime_pool);
       ("source", `String "oas_discovery");
       ("cache_age_seconds", `Float (Discovery_cache.cache_age_seconds ()));
-      ("provider_base_url", string_opt_to_json (first_endpoint_url endpoints));
-      ("slot_url", string_opt_to_json (first_endpoint_url endpoints));
+      ("provider_base_url", Json_util.string_opt_to_json (first_endpoint_url endpoints));
+      ("slot_url", Json_util.string_opt_to_json (first_endpoint_url endpoints));
       ("provider_reachable", `Bool provider_reachable);
       ("slot_reachable", `Bool slot_reachable);
       ("chat_completion_compatible", `Bool chat_completion_compatible);
-      ("expected_model", string_opt_to_json expected_model);
-      ("actual_model_id", string_opt_to_json actual_model_id);
-      ("expected_slots", int_opt_to_json expected_slots);
+      ("expected_model", Json_util.string_opt_to_json expected_model);
+      ("actual_model_id", Json_util.string_opt_to_json actual_model_id);
+      ("expected_slots", Json_util.int_opt_to_json expected_slots);
       ("actual_slots", `Int actual_slots_total);
-      ("expected_ctx", int_opt_to_json expected_ctx);
-      ("actual_ctx", int_opt_to_json actual_ctx);
+      ("expected_ctx", Json_util.int_opt_to_json expected_ctx);
+      ("actual_ctx", Json_util.int_opt_to_json actual_ctx);
       ("active_slots_now", `Int active_slots_now);
       ("peak_hot_slots", `Int active_slots_now);
       ("configured_capacity", `Int configured_capacity);
       ("configured_max_concurrent_models", `Int configured_max_concurrent_models);
       ("available_model_permits", `Int available_model_permits);
-      ("runtime_blocker", string_opt_to_json runtime_blocker);
-      ("detail", string_opt_to_json detail);
+      ("runtime_blocker", Json_util.string_opt_to_json runtime_blocker);
+      ("detail", Json_util.string_opt_to_json detail);
       ("pass", `Bool (Option.is_none runtime_blocker));
       ("runtimes", `List (List.rev runtime_rows));
     ]
@@ -513,25 +513,25 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
               ("provider_base_url", `String base_url);
               ("slot_url", `String base_url);
               ("provider_reachable", `Bool provider_ok_row);
-              ("provider_status_code", int_opt_to_json provider_status);
-              ("provider_error", string_opt_to_json provider_err);
+              ("provider_status_code", Json_util.int_opt_to_json provider_status);
+              ("provider_error", Json_util.string_opt_to_json provider_err);
               ("slot_reachable", `Bool slot_ok_row);
-              ("slot_status_code", int_opt_to_json slot_status);
-              ("slot_error", string_opt_to_json slot_err);
-              ("props_status_code", int_opt_to_json props_status);
-              ("props_error", string_opt_to_json props_err);
-              ("models_status_code", int_opt_to_json models_status);
-              ("models_error", string_opt_to_json models_err);
-              ("chat_status_code", int_opt_to_json chat_status);
+              ("slot_status_code", Json_util.int_opt_to_json slot_status);
+              ("slot_error", Json_util.string_opt_to_json slot_err);
+              ("props_status_code", Json_util.int_opt_to_json props_status);
+              ("props_error", Json_util.string_opt_to_json props_err);
+              ("models_status_code", Json_util.int_opt_to_json models_status);
+              ("models_error", Json_util.string_opt_to_json models_err);
+              ("chat_status_code", Json_util.int_opt_to_json chat_status);
               ("chat_contract_status", `String chat_status_label);
               ("chat_contract_reachable", `Bool (chat_contract_reachable ~status:chat_status ~body:chat_body));
-              ("chat_error", string_opt_to_json chat_err);
-              ("expected_model", string_opt_to_json expected_model);
-              ("actual_model_id", string_opt_to_json actual_model);
-              ("expected_slots", int_opt_to_json expected_slots);
-              ("actual_slots", int_opt_to_json actual_slots);
-              ("expected_ctx", int_opt_to_json expected_ctx);
-              ("actual_ctx", int_opt_to_json actual_ctx);
+              ("chat_error", Json_util.string_opt_to_json chat_err);
+              ("expected_model", Json_util.string_opt_to_json expected_model);
+              ("actual_model_id", Json_util.string_opt_to_json actual_model);
+              ("expected_slots", Json_util.int_opt_to_json expected_slots);
+              ("actual_slots", Json_util.int_opt_to_json actual_slots);
+              ("expected_ctx", Json_util.int_opt_to_json expected_ctx);
+              ("actual_ctx", Json_util.int_opt_to_json actual_ctx);
               ("active_slots_now", `Int current_active);
             ]
         in
@@ -575,7 +575,7 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
   `Assoc
     [
       ("checked_at", `String (Masc_domain.now_iso ()));
-      ("runtime_pool", string_opt_to_json runtime_pool);
+      ("runtime_pool", Json_util.string_opt_to_json runtime_pool);
       ("provider_base_url", `String Env_config.Local_runtime.server_url);
       ("slot_url", `String Env_config.Local_runtime.server_url);
       ("provider_reachable", `Bool (provider_reachable && has_runtimes));
@@ -583,19 +583,19 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
       ("chat_completion_compatible", `Bool true);
       ("chat_contract_status", `String overall_chat_contract_status);
       ("chat_contract_reachable", `Bool (String.equal overall_chat_contract_status "confirmed"));
-      ("expected_model", string_opt_to_json expected_model);
-      ("actual_model_id", string_opt_to_json actual_model_id);
-      ("expected_slots", int_opt_to_json expected_slots);
+      ("expected_model", Json_util.string_opt_to_json expected_model);
+      ("actual_model_id", Json_util.string_opt_to_json actual_model_id);
+      ("expected_slots", Json_util.int_opt_to_json expected_slots);
       ("actual_slots", `Int actual_slots_total);
-      ("expected_ctx", int_opt_to_json expected_ctx);
-      ("actual_ctx", int_opt_to_json actual_ctx);
+      ("expected_ctx", Json_util.int_opt_to_json expected_ctx);
+      ("actual_ctx", Json_util.int_opt_to_json actual_ctx);
       ("active_slots_now", `Int active_slots_now);
       ("peak_hot_slots", `Int active_slots_now);
       ("configured_capacity", `Int configured_capacity);
       ("configured_max_concurrent_models", `Int configured_max_concurrent_models);
       ("available_model_permits", `Int available_model_permits);
-      ("runtime_blocker", string_opt_to_json runtime_blocker);
-      ("detail", string_opt_to_json detail);
+      ("runtime_blocker", Json_util.string_opt_to_json runtime_blocker);
+      ("detail", Json_util.string_opt_to_json detail);
       ("pass", `Bool (Option.is_none runtime_blocker));
       ("runtimes", `List (List.rev runtime_rows));
     ]

--- a/lib/tool_misc_web_search.ml
+++ b/lib/tool_misc_web_search.ml
@@ -144,9 +144,6 @@ let decode_html_entities text =
 let clean_search_text text =
   text |> strip_cdata |> strip_html_tags |> decode_html_entities |> normalize_spaces
 
-let trim_nonempty text =
-  let trimmed = String.trim text in
-  if String.equal trimmed "" then None else Some trimmed
 
 let valid_search_result_url url =
   let trimmed = String.trim url in
@@ -201,7 +198,7 @@ let parse_json_search_results ~results_path ~title_field ~snippet_field payload 
   let open Yojson.Safe.Util in
   let str_of item key =
     Safe_ops.protect ~default:None (fun () ->
-      Option.bind (member key item |> to_string_option) trim_nonempty)
+      Option.bind (member key item |> to_string_option) String_util.trim_nonempty)
   in
   Safe_ops.protect ~default:[] (fun () ->
     let root = Yojson.Safe.from_string payload in
@@ -534,7 +531,7 @@ let fetch_bing_rss ~timeout_sec ~query =
   | Ok (None, _) -> Error "search endpoint returned no HTTP status"
 
 let fetch_brave ~timeout_sec ~query ~limit =
-  match Sys.getenv_opt "BRAVE_SEARCH_API_KEY" |> Stdlib.Fun.flip Option.bind trim_nonempty with
+  match Sys.getenv_opt "BRAVE_SEARCH_API_KEY" |> Stdlib.Fun.flip Option.bind String_util.trim_nonempty with
   | None -> Error "missing BRAVE_SEARCH_API_KEY"
   | Some api_key ->
       let search_url =
@@ -565,7 +562,7 @@ let fetch_brave ~timeout_sec ~query ~limit =
       | Ok (None, _) -> Error "provider returned no HTTP status"
 
 let fetch_tavily ~timeout_sec ~query ~limit =
-  match Sys.getenv_opt "TAVILY_API_KEY" |> Stdlib.Fun.flip Option.bind trim_nonempty with
+  match Sys.getenv_opt "TAVILY_API_KEY" |> Stdlib.Fun.flip Option.bind String_util.trim_nonempty with
   | None -> Error "missing TAVILY_API_KEY"
   | Some api_key ->
       let search_url = "https://api.tavily.com/search" in
@@ -605,7 +602,7 @@ let fetch_tavily ~timeout_sec ~query ~limit =
       | Ok (None, _) -> Error "provider returned no HTTP status"
 
 let fetch_exa ~timeout_sec ~query ~limit =
-  match Sys.getenv_opt "EXA_API_KEY" |> Stdlib.Fun.flip Option.bind trim_nonempty with
+  match Sys.getenv_opt "EXA_API_KEY" |> Stdlib.Fun.flip Option.bind String_util.trim_nonempty with
   | None -> Error "missing EXA_API_KEY"
   | Some api_key ->
       let search_url = "https://api.exa.ai/search" in
@@ -643,9 +640,9 @@ let fetch_exa ~timeout_sec ~query ~limit =
 
 let fetch_bing_api ~timeout_sec ~query ~limit =
   let api_key =
-    match Sys.getenv_opt "BING_SEARCH_API_KEY" |> Stdlib.Fun.flip Option.bind trim_nonempty with
+    match Sys.getenv_opt "BING_SEARCH_API_KEY" |> Stdlib.Fun.flip Option.bind String_util.trim_nonempty with
     | Some key -> Some key
-    | None -> Sys.getenv_opt "AZURE_BING_SEARCH_API_KEY" |> Stdlib.Fun.flip Option.bind trim_nonempty
+    | None -> Sys.getenv_opt "AZURE_BING_SEARCH_API_KEY" |> Stdlib.Fun.flip Option.bind String_util.trim_nonempty
   in
   match api_key with
   | None -> Error "missing BING_SEARCH_API_KEY or AZURE_BING_SEARCH_API_KEY"

--- a/lib/tool_task_completion_review.ml
+++ b/lib/tool_task_completion_review.ml
@@ -52,18 +52,7 @@ let completion_rejection_message ?(allow_force = false) reason =
        Revise your completion notes to describe actual work, then retry.\n\
        %s" reason completion_notes_example
 
-let contains_substring_ci text needle =
-  let text = String.lowercase_ascii text in
-  let needle = String.lowercase_ascii needle in
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  let rec loop idx =
-    if needle_len = 0 then true
-    else if idx + needle_len > text_len then false
-    else if String.equal (String.sub text idx needle_len) needle then true
-    else loop (idx + 1)
-  in
-  loop 0
+let contains_substring_ci = String_util.contains_substring_ci
 
 let placeholder_evidence_refs =
   [ "-"; "draft"; "n/a"; "na"; "none"; "null"; "pending"; "tbd"; "todo"; "unknown" ]

--- a/lib/tool_task_completion_review.ml
+++ b/lib/tool_task_completion_review.ml
@@ -52,7 +52,6 @@ let completion_rejection_message ?(allow_force = false) reason =
        Revise your completion notes to describe actual work, then retry.\n\
        %s" reason completion_notes_example
 
-let contains_substring_ci = String_util.contains_substring_ci
 
 let placeholder_evidence_refs =
   [ "-"; "draft"; "n/a"; "na"; "none"; "null"; "pending"; "tbd"; "todo"; "unknown" ]
@@ -64,39 +63,39 @@ let is_placeholder_evidence_ref value =
 let text_has_verification_artifact_ref text =
   let text = String.trim text in
   let has_github_pull =
-    contains_substring_ci text "github.com/"
-    && contains_substring_ci text "/pull/"
+    String_util.contains_substring_ci text "github.com/"
+    && String_util.contains_substring_ci text "/pull/"
   in
   let has_pr_shorthand =
-    contains_substring_ci text "#"
-    && (contains_substring_ci text "pr "
-        || contains_substring_ci text "pr:"
-        || contains_substring_ci text "pull request")
+    String_util.contains_substring_ci text "#"
+    && (String_util.contains_substring_ci text "pr "
+        || String_util.contains_substring_ci text "pr:"
+        || String_util.contains_substring_ci text "pull request")
   in
   let has_explicit_artifact =
     [ "artifact:"; "artifact://"; "file:"; "path:"; "commit:"; "branch:" ]
-    |> List.exists (contains_substring_ci text)
+    |> List.exists (String_util.contains_substring_ci text)
   in
   has_github_pull || has_pr_shorthand || has_explicit_artifact
 
 let pr_url_has_pull_ref pr_url =
   let pr_url = String.trim pr_url in
   (not (is_placeholder_evidence_ref pr_url))
-  && ((contains_substring_ci pr_url "github.com/"
-       && contains_substring_ci pr_url "/pull/")
-      || (contains_substring_ci pr_url "#"
-          && (contains_substring_ci pr_url "pr "
-              || contains_substring_ci pr_url "pr:"
-              || contains_substring_ci pr_url "pull request")))
+  && ((String_util.contains_substring_ci pr_url "github.com/"
+       && String_util.contains_substring_ci pr_url "/pull/")
+      || (String_util.contains_substring_ci pr_url "#"
+          && (String_util.contains_substring_ci pr_url "pr "
+              || String_util.contains_substring_ci pr_url "pr:"
+              || String_util.contains_substring_ci pr_url "pull request")))
 
 let artifact_like_ref value =
   let value = String.trim value in
-  contains_substring_ci value "artifact://"
-  || contains_substring_ci value "file:"
-  || contains_substring_ci value "path:"
-  || contains_substring_ci value "commit:"
-  || contains_substring_ci value "branch:"
-  || contains_substring_ci value "github.com/"
+  String_util.contains_substring_ci value "artifact://"
+  || String_util.contains_substring_ci value "file:"
+  || String_util.contains_substring_ci value "path:"
+  || String_util.contains_substring_ci value "commit:"
+  || String_util.contains_substring_ci value "branch:"
+  || String_util.contains_substring_ci value "github.com/"
   || String.contains value '/'
   || String.contains value '.'
 

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -224,9 +224,6 @@ let trajectory_path (masc_root : string) (keeper_name : string) (trace_id : stri
   Filename.concat (trajectories_dir masc_root keeper_name)
     (Printf.sprintf "%s.jsonl" trace_id)
 
-let ensure_dir path =
-  Fs_compat.mkdir_p path
-
 (* RFC-0108: the inline per-path Stdlib.Mutex + fresh-fd helper
    (PR-4 #15926) is removed here. [Fs_compat.append_jsonl] (post-RFC-0108
    #15936) now provides the equivalent per-path cross-domain guarantee
@@ -237,7 +234,7 @@ let append_entry ?runtime_contract ?action_radius ~(masc_root : string)
     ~(keeper_name : string) ~(trace_id : string) (entry : tool_call_entry) :
     unit =
   let dir = trajectories_dir masc_root keeper_name in
-  ensure_dir dir;
+  Fs_compat.mkdir_p dir;
   let path = trajectory_path masc_root keeper_name trace_id in
   let json = entry_to_json ?runtime_contract ?action_radius entry in
   Fs_compat.append_jsonl path json
@@ -246,7 +243,7 @@ let append_entry ?runtime_contract ?action_radius ~(masc_root : string)
 let append_thinking ~(masc_root : string) ~(keeper_name : string) ~(trace_id : string)
     (entry : thinking_entry) : unit =
   let dir = trajectories_dir masc_root keeper_name in
-  ensure_dir dir;
+  Fs_compat.mkdir_p dir;
   let path = trajectory_path masc_root keeper_name trace_id in
   let json = thinking_entry_to_json entry in
   Fs_compat.append_jsonl path json
@@ -255,7 +252,7 @@ let append_thinking ~(masc_root : string) ~(keeper_name : string) ~(trace_id : s
 let append_summary ~(masc_root : string) ~(keeper_name : string) ~(trace_id : string)
     (traj : trajectory) : unit =
   let dir = trajectories_dir masc_root keeper_name in
-  ensure_dir dir;
+  Fs_compat.mkdir_p dir;
   let path = trajectory_path masc_root keeper_name trace_id in
   let summary = `Assoc [
     ("type", `String "trajectory_summary");

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -16,9 +16,6 @@ let trim_trailing_slashes value =
   if last = len - 1 then value else String.sub value 0 (last + 1)
 ;;
 
-let trim_nonempty value =
-  let trimmed = String.trim value in
-  if trimmed = "" then None else Some trimmed
 ;;
 
 let configured_http_port () = Env_config_core.masc_http_port_int ()
@@ -93,7 +90,7 @@ let context_from_env ?(include_configured = false) () =
   let base_url =
     match Sys.getenv_opt Env_config_core.http_base_url_env_key with
     | Some raw ->
-      (match trim_nonempty raw with
+      (match String_util.trim_nonempty raw with
        | Some value -> normalize_loopback_base_url value
        | None -> default_base_url)
     | None -> default_base_url

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -356,16 +356,13 @@ let validate_cross_agent ~worker ~verifier =
 
 let verifications_dir = Coord_verification_store.verifications_dir
 
-let ensure_dir path =
-  Fs_compat.mkdir_p path
-
 let request_path base_path req_id =
   Coord_verification_store.request_path base_path req_id
 
 let save_request base_path req =
   try
     let dir = verifications_dir base_path in
-    ensure_dir dir;
+    Fs_compat.mkdir_p dir;
     let json = request_to_yojson req in
     let path = request_path base_path req.id in
     match Fs_compat.save_file_atomic path (Yojson.Safe.pretty_to_string json) with

--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -59,15 +59,6 @@ let trim_opt = function
       if trimmed = "" then None else Some trimmed
   | None -> None
 
-let dedupe_keep_order values =
-  let rec loop seen acc = function
-    | [] -> List.rev acc
-    | value :: rest ->
-        if List.mem value seen then loop seen acc rest
-        else loop (value :: seen) (value :: acc) rest
-  in
-  loop [] [] values
-
 let voice_config_file_in root =
   let masc_dir =
     Coord_utils.masc_root_dir_from
@@ -107,7 +98,7 @@ let config_path_candidates () =
     Some (fallback_voice_config_path ());
   ]
   |> List.filter_map Fun.id
-  |> dedupe_keep_order
+  |> Json_util.dedupe_keep_order
 
 let config_path () =
   let candidates = config_path_candidates () in
@@ -116,7 +107,7 @@ let config_path () =
   | None, path :: _ -> path
   | None, [] -> fallback_voice_config_path ()
 
-let trim_nonempty = function
+let trim_nonempty_json = function
   | `String value ->
       let trimmed = String.trim value in
       if trimmed = "" then None else Some trimmed
@@ -127,7 +118,7 @@ let string_list_opt = function
       let rec loop acc = function
         | [] -> Some (List.rev acc)
         | item :: rest -> (
-            match trim_nonempty item with
+            match trim_nonempty_json item with
             | Some value -> loop (value :: acc) rest
             | None -> None)
       in
@@ -154,7 +145,7 @@ let float_or_default default = function
   | _ -> default
 
 let require_string ~ctx ~field json =
-  match Yojson.Safe.Util.member field json |> trim_nonempty with
+  match Yojson.Safe.Util.member field json |> trim_nonempty_json with
   | Some value -> Ok value
   | None -> Error (Printf.sprintf "%s.%s is required" ctx field)
 
@@ -194,10 +185,10 @@ let parse_endpoint ~ctx json =
   let* id = require_string ~ctx ~field:"id" json in
   let* kind_raw = require_string ~ctx ~field:"kind" json in
   let* kind = endpoint_kind_of_string kind_raw in
-  let base_url = Yojson.Safe.Util.member "base_url" json |> trim_nonempty in
-  let mcp_url = Yojson.Safe.Util.member "mcp_url" json |> trim_nonempty in
-  let health_url = Yojson.Safe.Util.member "health_url" json |> trim_nonempty in
-  let api_key_env = Yojson.Safe.Util.member "api_key_env" json |> trim_nonempty in
+  let base_url = Yojson.Safe.Util.member "base_url" json |> trim_nonempty_json in
+  let mcp_url = Yojson.Safe.Util.member "mcp_url" json |> trim_nonempty_json in
+  let health_url = Yojson.Safe.Util.member "health_url" json |> trim_nonempty_json in
+  let api_key_env = Yojson.Safe.Util.member "api_key_env" json |> trim_nonempty_json in
   let enabled =
     Yojson.Safe.Util.member "enabled" json |> bool_or_default true
   in
@@ -248,7 +239,7 @@ let parse_agent_voices json =
       let rec loop acc = function
         | [] -> Ok (List.rev acc)
         | (agent_id, value) :: rest -> (
-            match trim_nonempty value with
+            match trim_nonempty_json value with
             | Some voice ->
                 loop ((String.trim agent_id, voice) :: acc) rest
             | None ->
@@ -353,7 +344,7 @@ let parse_local_playback json =
       in
       let agents =
         match Yojson.Safe.Util.member "agents" local_json with
-        | `List values -> List.filter_map trim_nonempty values
+        | `List values -> List.filter_map trim_nonempty_json values
         | _ -> []
       in
       Ok { enabled; agents }

--- a/lib/worker_execution_spec.ml
+++ b/lib/worker_execution_spec.ml
@@ -14,8 +14,6 @@ type t = {
   timeout_sec : int;
 }
 
-let option_to_yojson = Json_util.option_to_yojson
-
 let required_trimmed_string field = function
   | `String value ->
       let trimmed = String.trim value in
@@ -73,12 +71,12 @@ let to_yojson (spec : t) =
       ("base_path", `String spec.base_path);
       ("worker_name", `String spec.worker_name);
       ("model_label", `String spec.model_label);
-      ("working_dir", option_to_yojson (fun s -> `String s) spec.working_dir);
+      ("working_dir", Json_util.option_to_yojson (fun s -> `String s) spec.working_dir);
       ("runtime_backend", Worker_execution_backend.to_yojson spec.runtime_backend);
-      ("thinking_enabled", option_to_yojson (fun v -> `Bool v) spec.thinking_enabled);
-      ("worker_run_id", option_to_yojson (fun s -> `String s) spec.worker_run_id);
-      ("role", option_to_yojson (fun s -> `String s) spec.role);
-      ("selection_note", option_to_yojson (fun s -> `String s) spec.selection_note);
+      ("thinking_enabled", Json_util.option_to_yojson (fun v -> `Bool v) spec.thinking_enabled);
+      ("worker_run_id", Json_util.option_to_yojson (fun s -> `String s) spec.worker_run_id);
+      ("role", Json_util.option_to_yojson (fun s -> `String s) spec.role);
+      ("selection_note", Json_util.option_to_yojson (fun s -> `String s) spec.selection_note);
       ("prompt", `String spec.prompt);
       ("timeout_sec", `Int spec.timeout_sec);
     ]

--- a/lib/worker_execution_spec.ml
+++ b/lib/worker_execution_spec.ml
@@ -14,9 +14,7 @@ type t = {
   timeout_sec : int;
 }
 
-let option_to_yojson to_json = function
-  | Some value -> to_json value
-  | None -> `Null
+let option_to_yojson = Json_util.option_to_yojson
 
 let required_trimmed_string field = function
   | `String value ->

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -736,7 +736,7 @@ and run_existing_worker_agent
        in
        let checkpoint = Agent_sdk.Agent.checkpoint ~session_id agent in
        let tool_names =
-         List.rev !tool_names_ref |> Worker_container_types.unique_preserve_order
+         List.rev !tool_names_ref |> Json_util.dedupe_keep_order
        in
        let* () =
          Worker_container.save_worker_checkpoint ~base_path ~worker_name checkpoint

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -13,9 +13,6 @@ module Runtime_binding = Agent_sdk.Provider_runtime_binding
 
 let tail_display_max_chars = 4000
 
-let trim_nonempty value =
-  let trimmed = String.trim value in
-  if String.equal trimmed "" then None else Some trimmed
 ;;
 
 let auth_env_keys_of_binding (binding : Runtime_binding.t) =
@@ -30,7 +27,7 @@ let auth_env_keys_of_binding (binding : Runtime_binding.t) =
       []
   in
   binding.Runtime_binding.api_key_env :: auth_env
-  |> List.filter_map trim_nonempty
+  |> List.filter_map String_util.trim_nonempty
   |> Json_util.dedupe_keep_order
 ;;
 

--- a/lib/worker_runtime_helper_protocol.ml
+++ b/lib/worker_runtime_helper_protocol.ml
@@ -23,8 +23,6 @@ let error_kind_of_string value =
   | "internal" -> Some Internal
   | _ -> None
 
-let option_to_yojson = Json_util.option_to_yojson
-
 open Result.Syntax
 
 (* Every parse error below now distinguishes between *Intlit overflow*
@@ -104,7 +102,7 @@ let string_list_of_yojson = function
            (Json_util.kind_name other))
 
 let api_response_to_yojson =
-  option_to_yojson Llm_provider.Cache.response_to_json
+  Json_util.option_to_yojson Llm_provider.Cache.response_to_json
 
 let api_response_of_yojson = function
   | `Null -> Ok None
@@ -114,7 +112,7 @@ let api_response_of_yojson = function
       | None -> Error "invalid api_response in worker helper payload")
 
 let proof_to_yojson =
-  option_to_yojson Masc_mcp_cdal_runtime.Cdal_proof.to_json
+  Json_util.option_to_yojson Masc_mcp_cdal_runtime.Cdal_proof.to_json
 
 let proof_of_yojson = function
   | `Null -> Ok None
@@ -128,14 +126,14 @@ let run_result_to_yojson (run_result : Worker_container_types.run_result) =
     [
       ("output", `String run_result.output);
       ("model_used", `String run_result.model_used);
-      ("input_tokens", option_to_yojson (fun v -> `Int v) run_result.input_tokens);
-      ("output_tokens", option_to_yojson (fun v -> `Int v) run_result.output_tokens);
-      ("cost_usd", option_to_yojson (fun v -> `Float v) run_result.cost_usd);
+      ("input_tokens", Json_util.option_to_yojson (fun v -> `Int v) run_result.input_tokens);
+      ("output_tokens", Json_util.option_to_yojson (fun v -> `Int v) run_result.output_tokens);
+      ("cost_usd", Json_util.option_to_yojson (fun v -> `Float v) run_result.cost_usd);
       ("tool_call_count", `Int run_result.tool_call_count);
       ("tool_names", `List (List.map (fun name -> `String name) run_result.tool_names));
       ("session_id", `String run_result.session_id);
       ( "raw_trace_run",
-        option_to_yojson Agent_sdk.Raw_trace.run_ref_to_yojson run_result.raw_trace_run );
+        Json_util.option_to_yojson Agent_sdk.Raw_trace.run_ref_to_yojson run_result.raw_trace_run );
       ("api_response", api_response_to_yojson run_result.api_response);
       ("proof", proof_to_yojson run_result.proof);
     ]

--- a/lib/worker_runtime_helper_protocol.ml
+++ b/lib/worker_runtime_helper_protocol.ml
@@ -23,9 +23,7 @@ let error_kind_of_string value =
   | "internal" -> Some Internal
   | _ -> None
 
-let option_to_yojson to_json = function
-  | Some value -> to_json value
-  | None -> `Null
+let option_to_yojson = Json_util.option_to_yojson
 
 open Result.Syntax
 

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -128,7 +128,7 @@ let test_sensitive_input_fields_redacted () =
     Alcotest.(check int) "one entry logged" 1 (List.length entries);
     let entry_str = Yojson.Safe.to_string (List.hd entries) in
     Alcotest.(check bool) "token value redacted" false
-      (Observability_redact.contains_substring ~sub:"sk-proj-abcdefghijklmnop12345678" entry_str))
+      (String_util.contains_substring entry_str "sk-proj-abcdefghijklmnop12345678"))
 
 (* ── Model field redacted ───────────────────────────── *)
 
@@ -145,7 +145,7 @@ let test_model_field_stored () =
     Alcotest.(check int) "one entry" 1 (List.length entries);
     let entry_str = Yojson.Safe.to_string (List.hd entries) in
     Alcotest.(check bool) "raw model absent" false
-      (Observability_redact.contains_substring ~sub:"provider_k-4-9b" entry_str);
+      (String_util.contains_substring entry_str "provider_k-4-9b");
     Alcotest.(check (option string)) "model redacted to runtime"
       (Some "runtime")
       (Safe_ops.json_string_opt "model" (List.hd entries));

--- a/test/test_observability_redact.ml
+++ b/test/test_observability_redact.ml
@@ -6,15 +6,15 @@ let test_api_key_redacted () =
   let input = {|{"api_key": "sk-proj-abc123xyz456def789ghi012jkl345"}|} in
   let preview = Observability_redact.redact_preview input in
   Alcotest.(check bool) "no raw key in preview" true
-    (not (Observability_redact.contains_substring ~sub:"abc123xyz456" preview))
+    (not (String_util.contains_substring preview "abc123xyz456"))
 
 let test_url_credential_redacted () =
   let input = "postgres://admin:secretpass@db.host:5432/mydb" in
   let preview = Observability_redact.redact_preview input in
   Alcotest.(check bool) "password masked" true
-    (Observability_redact.contains_substring ~sub:"[REDACTED]" preview);
+    (String_util.contains_substring preview "[REDACTED]");
   Alcotest.(check bool) "no raw password" true
-    (not (Observability_redact.contains_substring ~sub:"secretpass" preview))
+    (not (String_util.contains_substring preview "secretpass"))
 
 let test_max_length_enforced () =
   let long_input = String.make 500 'x' in
@@ -78,9 +78,9 @@ let test_blob_sentinel_redacts_preview_body () =
   in
   let redacted = Observability_redact.redact_preview marker in
   Alcotest.(check bool) "raw key scrubbed from preview" true
-    (not (Observability_redact.contains_substring ~sub:"abc123xyz456" redacted));
+    (not (String_util.contains_substring redacted "abc123xyz456"));
   Alcotest.(check bool) "sha256 still present as structural field" true
-    (Observability_redact.contains_substring ~sub:("sha256=" ^ sha) redacted)
+    (String_util.contains_substring redacted ("sha256=" ^ sha))
 
 (* Regression: a sentinel embedded inside a JSON string field used to be
    corrupted by callers that did [Yojson.Safe.to_string |> String.sub]

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -344,39 +344,39 @@ let test_strip_prefix_longer_prefix () =
    ============================================================ *)
 
 let test_contains_substring_true () =
-  check bool "contains" true (Coord_utils.contains_substring "hello world" "world")
+  check bool "contains" true (String_util.contains_substring "hello world" "world")
 
 let test_contains_substring_false () =
-  check bool "not contains" false (Coord_utils.contains_substring "hello world" "xyz")
+  check bool "not contains" false (String_util.contains_substring "hello world" "xyz")
 
 let test_contains_substring_empty_needle () =
   (* Empty string is substring of any string (String.sub s 0 0 = "" always) *)
-  check bool "empty needle" true (Coord_utils.contains_substring "hello" "")
+  check bool "empty needle" true (String_util.contains_substring "hello" "")
 
 let test_contains_substring_empty_haystack () =
-  check bool "empty haystack" false (Coord_utils.contains_substring "" "hello")
+  check bool "empty haystack" false (String_util.contains_substring "" "hello")
 
 let test_contains_substring_both_empty () =
   (* Empty string contains empty string (String.sub "" 0 0 = "") *)
-  check bool "both empty" true (Coord_utils.contains_substring "" "")
+  check bool "both empty" true (String_util.contains_substring "" "")
 
 let test_contains_substring_needle_longer () =
-  check bool "needle longer" false (Coord_utils.contains_substring "ab" "abcdef")
+  check bool "needle longer" false (String_util.contains_substring "ab" "abcdef")
 
 let test_contains_substring_exact () =
-  check bool "exact match" true (Coord_utils.contains_substring "test" "test")
+  check bool "exact match" true (String_util.contains_substring "test" "test")
 
 let test_contains_substring_start () =
-  check bool "at start" true (Coord_utils.contains_substring "hello world" "hello")
+  check bool "at start" true (String_util.contains_substring "hello world" "hello")
 
 let test_contains_substring_end () =
-  check bool "at end" true (Coord_utils.contains_substring "hello world" "world")
+  check bool "at end" true (String_util.contains_substring "hello world" "world")
 
 let test_contains_substring_middle () =
-  check bool "in middle" true (Coord_utils.contains_substring "the quick fox" "quick")
+  check bool "in middle" true (String_util.contains_substring "the quick fox" "quick")
 
 let test_contains_substring_special_chars () =
-  check bool "special chars" true (Coord_utils.contains_substring "a<b>c" "<b>")
+  check bool "special chars" true (String_util.contains_substring "a<b>c" "<b>")
 
 (* ============================================================
    sanitize_html Tests

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -722,17 +722,17 @@ let test_validate_file_path_angle_brackets () =
   check bool "invalid angle brackets" true (is_error result)
 
 (* ============================================================ *)
-(* Coord_utils.contains_substring Tests                           *)
+(* String_util.contains_substring Tests                           *)
 (* ============================================================ *)
 
 let test_contains_substring_true () =
-  check bool "contains" true (Coord_utils.contains_substring "hello world" "world")
+  check bool "contains" true (String_util.contains_substring "hello world" "world")
 
 let test_contains_substring_false () =
-  check bool "not contains" false (Coord_utils.contains_substring "hello world" "foo")
+  check bool "not contains" false (String_util.contains_substring "hello world" "foo")
 
 let test_contains_substring_empty () =
-  check bool "empty needle" true (Coord_utils.contains_substring "hello" "")
+  check bool "empty needle" true (String_util.contains_substring "hello" "")
 
 (* ============================================================ *)
 (* Coord_eio.event_type Tests                                     *)


### PR DESCRIPTION
## Summary

- Remove 82 local redefinitions of `contains_substring`, `dedupe_keep_order`, `trim_nonempty`, `trim_to_option` across `lib/`
- All callers now use `String_util.*` / `Json_util.*` directly
- Add `String_util.option_trim : string option -> string option` for sites that previously accepted `string option`
- 103 files changed, net -329 lines, 0 behavior change

### Deduplication counts

| Function | Duplicates removed | SSOT |
|----------|-------------------|------|
| `contains_substring` | 31 → 1 | `String_util` |
| `dedupe_keep_order` | 19 → 1 (+1 keeper alias) | `Json_util` |
| `trim_nonempty` | 17 → 1 | `String_util` |
| `trim_to_option` | 15 → 1 | `String_util` |

### Build verification
`dune build --root .` passes clean.

## Test plan
- [x] `dune build --root .` passes
- [ ] CI green (including `dune test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>