### PR TITLE
fix(keeper): map Ok+not_dispatched receipts to healthy disposition

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -706,6 +706,13 @@ let operator_disposition (receipt : t)
       | `Cancelled -> Disp_user_cancelled, Reason_cancelled
       | `Skipped -> Disp_skipped, Reason_phase_skipped
       | `Ok when receipt.cascade_outcome = Cascade_completed -> Disp_pass, Reason_healthy
+      | `Ok when receipt.cascade_outcome = Cascade_not_dispatched ->
+        (* Pre-dispatch shortcut: the turn completed successfully without
+           dispatching to the LLM (cached response, immediate tool result,
+           or pre-dispatch check resolved the turn).  Treated as healthy
+           because the outcome is success — the cascade was simply not
+           needed.  Previously unmapped (1062 WARN/day on 2026-05-24). *)
+        Disp_pass, Reason_healthy
       | _ ->
         Prometheus.inc_counter Keeper_metrics.metric_keeper_receipt_unmapped_disposition ();
         Prometheus.inc_counter

--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -1,26 +1,37 @@
 (** Keeper_turn_driver_backpressure — Capacity backpressure classification.
 
     Extracted from [keeper_turn_driver.ml] during godfile decomposition.
-    Pure functions: classify HTTP/SDK errors into capacity backpressure signals. *)
+    Pure functions: classify HTTP/SDK errors into capacity backpressure signals.
 
+    @since God file decomposition *)
+
+(** Classify an HTTP error into a backpressure source, if applicable. *)
 val capacity_backpressure_source_of_http_error :
   Llm_provider.Http_client.http_error ->
   Cascade_internal_error.capacity_backpressure_source option
 
+(** Build a capacity-backpressure internal error from an HTTP error,
+    when the error indicates capacity exhaustion. *)
 val capacity_backpressure_of_http_error :
   ?source:Cascade_internal_error.capacity_backpressure_source ->
   cascade_name:Cascade_name.t ->
   Llm_provider.Http_client.http_error option ->
   Cascade_internal_error.masc_internal_error option
 
+(** Build a capacity-backpressure internal error from a pending
+    backpressure triple [(source, detail, retry_after_sec)]. *)
 val capacity_backpressure_of_pending :
   cascade_name:Cascade_name.t ->
   (Cascade_internal_error.capacity_backpressure_source * string * float option) option ->
   Cascade_internal_error.masc_internal_error option
 
+(** Classify an SDK error into a capacity-backpressure error,
+    when the error indicates provider capacity exhaustion or a
+    backpressure-like internal message. *)
 val capacity_backpressure_of_sdk_error :
   cascade_name:Cascade_name.t ->
   message_looks_like_capacity_backpressure:(string -> bool) ->
-  sdk_error_of_masc_internal_error:(Cascade_internal_error.masc_internal_error -> 'a) ->
+  sdk_error_of_masc_internal_error:(Cascade_internal_error.masc_internal_error ->
+                                    Agent_sdk.Error.sdk_error) ->
   Agent_sdk.Error.sdk_error ->
-  'a option
+  Agent_sdk.Error.sdk_error option


### PR DESCRIPTION
## Summary
- Add explicit branch for `Ok` outcome + `Cascade_not_dispatched` cascade outcome in `operator_disposition`
- Pre-dispatch shortcuts (cache hits, immediate tool results) no longer fall through to unmapped catch-all
- Also adds `.mli` for `keeper_turn_driver_backpressure` (PR #18306 regression)

## Evidence
- 1062 `operator_disposition: unmapped` WARN/day on 2026-05-24
- All entries: `outcome=ok, cascade_outcome=not_dispatched, terminal_reason=pre_dispatch_success`
- These are legitimate successes — the cascade was simply not needed

## Test plan
- [x] `dune build --root .` passes
- [x] OCaml structure ratchet: all metrics ≤ baseline
- [ ] CI Build and Test passes
- [ ] No new `unmapped` dispositions after deploy

Closes #18312

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>