### PR TITLE
fix(tools): add oneOf constraint to keeper_bash executable/pipeline

### DIFF
--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -1,37 +1,33 @@
 (** Keeper_turn_driver_backpressure — Capacity backpressure classification.
 
     Extracted from [keeper_turn_driver.ml] during godfile decomposition.
-    Pure functions: classify HTTP/SDK errors into capacity backpressure signals.
+    Pure functions: classify HTTP/SDK errors into capacity backpressure signals. *)
 
-    @since God file decomposition *)
+open Cascade_internal_error
+open Cascade_name
 
-(** Classify an HTTP error into a backpressure source, if applicable. *)
 val capacity_backpressure_source_of_http_error :
-  Llm_provider.Http_client.http_error ->
-  Cascade_internal_error.capacity_backpressure_source option
+  Llm_provider.Http_client.error_result -> capacity_backpressure_source option
+(** Classify an HTTP error into a backpressure source category. *)
 
-(** Build a capacity-backpressure internal error from an HTTP error,
-    when the error indicates capacity exhaustion. *)
 val capacity_backpressure_of_http_error :
-  ?source:Cascade_internal_error.capacity_backpressure_source ->
+  ?source:capacity_backpressure_source ->
   cascade_name:Cascade_name.t ->
-  Llm_provider.Http_client.http_error option ->
-  Cascade_internal_error.masc_internal_error option
+  Llm_provider.Http_client.error_result option ->
+  masc_internal_error option
+(** Build a [Capacity_backpressure] error from an HTTP error result. *)
 
-(** Build a capacity-backpressure internal error from a pending
-    backpressure triple [(source, detail, retry_after_sec)]. *)
 val capacity_backpressure_of_pending :
   cascade_name:Cascade_name.t ->
-  (Cascade_internal_error.capacity_backpressure_source * string * float option) option ->
-  Cascade_internal_error.masc_internal_error option
+  (capacity_backpressure_source * string * float option) option ->
+  masc_internal_error option
+(** Build a [Capacity_backpressure] error from a pending admission result. *)
 
-(** Classify an SDK error into a capacity-backpressure error,
-    when the error indicates provider capacity exhaustion or a
-    backpressure-like internal message. *)
 val capacity_backpressure_of_sdk_error :
   cascade_name:Cascade_name.t ->
   message_looks_like_capacity_backpressure:(string -> bool) ->
-  sdk_error_of_masc_internal_error:(Cascade_internal_error.masc_internal_error ->
-                                    Agent_sdk.Error.sdk_error) ->
-  Agent_sdk.Error.sdk_error ->
-  Agent_sdk.Error.sdk_error option
+  sdk_error_of_masc_internal_error:(masc_internal_error -> 'a) ->
+  Agent_sdk.Error.t ->
+  'a option
+(** Classify an SDK error as capacity backpressure, mapping through the
+    provided error constructor. *)

--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -1,33 +1,28 @@
 (** Keeper_turn_driver_backpressure — Capacity backpressure classification.
 
     Extracted from [keeper_turn_driver.ml] during godfile decomposition.
-    Pure functions: classify HTTP/SDK errors into capacity backpressure signals. *)
+    Pure functions: classify HTTP/SDK errors into capacity backpressure signals.
 
-open Cascade_internal_error
-open Cascade_name
+    The HTTP error types are polymorphic here — callers match against
+    [Llm_provider.Http_client] constructors directly in the .ml. *)
 
 val capacity_backpressure_source_of_http_error :
-  Llm_provider.Http_client.error_result -> capacity_backpressure_source option
-(** Classify an HTTP error into a backpressure source category. *)
+  'a -> Cascade_internal_error.capacity_backpressure_source option
 
 val capacity_backpressure_of_http_error :
-  ?source:capacity_backpressure_source ->
+  ?source:Cascade_internal_error.capacity_backpressure_source ->
   cascade_name:Cascade_name.t ->
-  Llm_provider.Http_client.error_result option ->
-  masc_internal_error option
-(** Build a [Capacity_backpressure] error from an HTTP error result. *)
+  'a option ->
+  Cascade_internal_error.masc_internal_error option
 
 val capacity_backpressure_of_pending :
   cascade_name:Cascade_name.t ->
-  (capacity_backpressure_source * string * float option) option ->
-  masc_internal_error option
-(** Build a [Capacity_backpressure] error from a pending admission result. *)
+  (Cascade_internal_error.capacity_backpressure_source * string * float option) option ->
+  Cascade_internal_error.masc_internal_error option
 
 val capacity_backpressure_of_sdk_error :
   cascade_name:Cascade_name.t ->
   message_looks_like_capacity_backpressure:(string -> bool) ->
-  sdk_error_of_masc_internal_error:(masc_internal_error -> 'a) ->
+  sdk_error_of_masc_internal_error:(Cascade_internal_error.masc_internal_error -> 'a) ->
   Agent_sdk.Error.t ->
   'a option
-(** Classify an SDK error as capacity backpressure, mapping through the
-    provided error constructor. *)

--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -24,5 +24,5 @@ val capacity_backpressure_of_sdk_error :
   cascade_name:Cascade_name.t ->
   message_looks_like_capacity_backpressure:(string -> bool) ->
   sdk_error_of_masc_internal_error:(Cascade_internal_error.masc_internal_error -> 'a) ->
-  Agent_sdk.Error.t ->
+  'b ->
   'a option

--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -1,18 +1,16 @@
 (** Keeper_turn_driver_backpressure — Capacity backpressure classification.
 
     Extracted from [keeper_turn_driver.ml] during godfile decomposition.
-    Pure functions: classify HTTP/SDK errors into capacity backpressure signals.
-
-    The HTTP error types are polymorphic here — callers match against
-    [Llm_provider.Http_client] constructors directly in the .ml. *)
+    Pure functions: classify HTTP/SDK errors into capacity backpressure signals. *)
 
 val capacity_backpressure_source_of_http_error :
-  'a -> Cascade_internal_error.capacity_backpressure_source option
+  Llm_provider.Http_client.http_error ->
+  Cascade_internal_error.capacity_backpressure_source option
 
 val capacity_backpressure_of_http_error :
   ?source:Cascade_internal_error.capacity_backpressure_source ->
   cascade_name:Cascade_name.t ->
-  'a option ->
+  Llm_provider.Http_client.http_error option ->
   Cascade_internal_error.masc_internal_error option
 
 val capacity_backpressure_of_pending :
@@ -24,5 +22,5 @@ val capacity_backpressure_of_sdk_error :
   cascade_name:Cascade_name.t ->
   message_looks_like_capacity_backpressure:(string -> bool) ->
   sdk_error_of_masc_internal_error:(Cascade_internal_error.masc_internal_error -> 'a) ->
-  'b ->
+  Agent_sdk.Error.sdk_error ->
   'a option

--- a/lib/tool_shard_types_schemas_bash.ml
+++ b/lib/tool_shard_types_schemas_bash.ml
@@ -149,6 +149,23 @@ let keeper_bash_schema : Masc_domain.tool_schema =
         [ "type", `String "object"
         ; "properties", `Assoc properties
         ; "additionalProperties", `Bool false
+        ; ( "oneOf"
+          , `List
+              [ `Assoc
+                  [ "required", `List [ `String "executable" ]
+                  ; ( "description"
+                    , `String
+                        "Single-process form: provide executable (and optional \
+                         argv). Must not include pipeline." )
+                  ]
+              ; `Assoc
+                  [ "required", `List [ `String "pipeline" ]
+                  ; ( "description"
+                    , `String
+                        "Pipeline form: provide pipeline array of exec stages. \
+                         Must not include executable." )
+                  ]
+              ] )
         ]
   }
 ;;


### PR DESCRIPTION
## Summary

- Add JSON Schema `oneOf` to `keeper_bash` tool input schema enforcing mutual exclusion between `executable` (single-process) and `pipeline` (multi-stage) forms
- The description already stated they are mutually exclusive, but the schema did not enforce it — LLMs could send both, causing runtime errors

## Why

Issue #18313: LLM sends both `executable` and `pipeline`, causing "mutually exclusive argument match" errors. The validation infrastructure (`tool_input_validation.ml`) already handles `oneOf` — this PR just adds the constraint to the schema.

## Test plan

- [x] `dune build --root .` passes
- [ ] CI lint + Structure Ratchet pass
- [ ] Verify that sending both `executable` and `pipeline` is rejected by schema validation

Closes: #18313