### PR TITLE
fix(keeper_bash): strip argv[0] when LLM duplicates executable

### DIFF
--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -328,12 +328,17 @@ let shell_bin ~mode executable =
     Error (Executable_not_allowlisted { name; mode })
 ;;
 
+let strip_leading_executable executable = function
+  | arg :: rest when String.equal arg executable -> rest
+  | argv -> argv
+
 let shell_simple ~mode ?(sandbox = Masc_exec.Sandbox_target.host ()) ?cwd ?(env = []) { executable; argv } =
   let ( let* ) = Result.bind in
   let* bin = shell_bin ~mode executable in
+  let normalized_argv = strip_leading_executable executable argv in
   Ok
     { Masc_exec.Shell_ir.bin
-    ; args = List.map shell_arg argv
+    ; args = List.map shell_arg normalized_argv
     ; env = shell_env env
     ; cwd = shell_cwd cwd
     ; redirects = []

--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -1,0 +1,37 @@
+(** Keeper_turn_driver_backpressure — Capacity backpressure classification.
+
+    Extracted from [keeper_turn_driver.ml] during godfile decomposition.
+    Pure functions: classify HTTP/SDK errors into capacity backpressure signals.
+
+    @since God file decomposition *)
+
+(** Classify an HTTP error into a backpressure source, if applicable. *)
+val capacity_backpressure_source_of_http_error :
+  Llm_provider.Http_client.http_error ->
+  Cascade_internal_error.capacity_backpressure_source option
+
+(** Build a capacity-backpressure internal error from an HTTP error,
+    when the error indicates capacity exhaustion. *)
+val capacity_backpressure_of_http_error :
+  ?source:Cascade_internal_error.capacity_backpressure_source ->
+  cascade_name:Cascade_name.t ->
+  Llm_provider.Http_client.http_error option ->
+  Cascade_internal_error.masc_internal_error option
+
+(** Build a capacity-backpressure internal error from a pending
+    backpressure triple [(source, detail, retry_after_sec)]. *)
+val capacity_backpressure_of_pending :
+  cascade_name:Cascade_name.t ->
+  (Cascade_internal_error.capacity_backpressure_source * string * float option) option ->
+  Cascade_internal_error.masc_internal_error option
+
+(** Classify an SDK error into a capacity-backpressure error,
+    when the error indicates provider capacity exhaustion or a
+    backpressure-like internal message. *)
+val capacity_backpressure_of_sdk_error :
+  cascade_name:Cascade_name.t ->
+  message_looks_like_capacity_backpressure:(string -> bool) ->
+  sdk_error_of_masc_internal_error:(Cascade_internal_error.masc_internal_error ->
+                                    Agent_sdk.Error.sdk_error) ->
+  Agent_sdk.Error.sdk_error ->
+  Agent_sdk.Error.sdk_error option


### PR DESCRIPTION
## Summary
- When an LLM sends `{"executable":"cat","argv":["cat","file.txt"]}`, the resulting Shell_ir produces `cat cat file.txt` at exec time
- `strip_leading_executable` removes the leading argv element when it matches the executable name
- Affects only `shell_simple` (Exec mode); Pipeline stages are unaffected since each stage has independent executable/argv

## Test plan
- [ ] `dune build --root . @check` passes (typecheck verified locally)
- [ ] Existing `test_keeper_tool_bash_input` still passes (argv normalization is transparent to callers)
- [ ] Manual: send `{"executable":"cat","argv":["cat","/etc/hosts"]}` via MCP tool — verify single `cat /etc/hosts`

Closes #18326

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>