### PR TITLE
feat(cascade): add exhaustion reason label to Prometheus counter

### DIFF
--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -93,6 +93,16 @@ let provider_outcome_option_to_string = function
   | Some outcome -> "some-" ^ provider_outcome_to_string outcome
   | None -> "none"
 
+let exhaustion_reason_of_last_err = function
+  | Some (Llm_provider.Http_client.HttpError _) -> "http_error"
+  | Some (Llm_provider.Http_client.AcceptRejected _) -> "accept_rejected"
+  | Some (Llm_provider.Http_client.CliTransportRequired _) -> "cli_required"
+  | Some (Llm_provider.Http_client.NetworkError _) -> "network_error"
+  | Some (Llm_provider.Http_client.TimeoutError _) -> "timeout"
+  | Some (Llm_provider.Http_client.ProviderTerminal _) -> "provider_terminal"
+  | Some (Llm_provider.Http_client.ProviderFailure _) -> "provider_failure"
+  | None -> "no_providers"
+
 (* ── Observable wrapper (preserves pure decide) ── *)
 
 let decide_and_record ~cascade_name ~accept_on_exhaustion ~is_last outcome =
@@ -118,7 +128,9 @@ let decide_and_record ~cascade_name ~accept_on_exhaustion ~is_last outcome =
          | Call_ok _ -> "unexpected"
        in
        Cascade_metrics.on_fallback ~cascade_name ~reason
-   | Exhausted _ -> Cascade_metrics.on_exhausted ~cascade_name
+   | Exhausted { last_err } ->
+       let reason = exhaustion_reason_of_last_err last_err in
+       Cascade_metrics.on_exhausted ~cascade_name ~reason
    | _ -> ());
   decision
 

--- a/lib/cascade/cascade_metrics.ml
+++ b/lib/cascade/cascade_metrics.ml
@@ -54,9 +54,9 @@ let on_fallback ~cascade_name ~reason =
     ~labels:[ ("reason", reason); ("cascade", cascade_name) ]
     ()
 
-let on_exhausted ~cascade_name =
+let on_exhausted ~cascade_name ~reason =
   Prometheus.inc_counter metric_providers_exhausted
-    ~labels:[ ("cascade", cascade_name) ]
+    ~labels:[ ("reason", reason); ("cascade", cascade_name) ]
     ()
 
 let on_phase_override ~phase ~from_cascade ~to_cascade =

--- a/lib/cascade/cascade_metrics.mli
+++ b/lib/cascade/cascade_metrics.mli
@@ -2,7 +2,12 @@
 
 val on_decision : cascade_name:string -> decision_label:string -> unit
 val on_fallback : cascade_name:string -> reason:string -> unit
-val on_exhausted : cascade_name:string -> unit
+val on_exhausted : cascade_name:string -> reason:string -> unit
+(** Tick the cascade exhaustion counter when all tiers failed.
+    [reason] is classified from the last error:
+    [accept_rejected], [http_error], [cli_required],
+    [network_error], [timeout], [provider_terminal],
+    [provider_failure], or [no_providers]. *)
 val on_phase_override : phase:string -> from_cascade:string -> to_cascade:string -> unit
 
 val on_profile_discovery : path:string -> unit


### PR DESCRIPTION
## Summary
- Adds `reason` Prometheus label to `masc_cascade_providers_exhausted_total` counter
- Classifies each `Http_client.http_error` variant into a stable reason string (`http_error`, `accept_rejected`, `cli_required`, `network_error`, `timeout`, `provider_terminal`, `provider_failure`, `no_providers`)
- Enables operators to distinguish WHY a cascade exhausted without reading keeper logs

## Motivation
82 cascade exhaustion events in 24h all showed "Not Found" runtime error, but the Prometheus counter only had a `cascade` label — impossible to alert on specific exhaustion causes.

## Test plan
- [x] `dune build --root . @check` passes
- [x] `test_cascade_fsm.exe` 4/4 tests pass
- [ ] CI ratchet + build checks
- [ ] Verify `reason` label appears in `/metrics` output on deploy

Closes: task-403

🤖 Generated with [Claude Code](https://claude.com/claude-code)