### PR TITLE
fix(keeper_bash): reject empty executable at schema level

### DIFF
--- a/lib/tool_shard_types_schemas_bash.ml
+++ b/lib/tool_shard_types_schemas_bash.ml
@@ -15,6 +15,7 @@ let keeper_bash_exec_stage_schema =
           [ ( "executable"
             , `Assoc
                 [ "type", `String "string"
+                ; "minLength", `Float 1.
                 ; ( "description"
                   , `String "Allowlisted executable name, e.g. rg, sed, sort, head." )
                 ] )
@@ -37,6 +38,7 @@ let keeper_bash_executable_field =
   ( "executable"
   , `Assoc
       [ "type", `String "string"
+      ; "minLength", `Float 1.
       ; ( "description"
         , `String
             "Typed argv form: allowlisted executable name. Provide argv separately; \


### PR DESCRIPTION
## Summary
- Add `minLength: 1` to both `executable` field schema definitions in `tool_shard_types_schemas_bash.ml`
- Prevents LLMs from passing `executable=""` which causes 312/day "executable \"\" not in dev_full allowlist" errors

## Evidence
- 2026-05-24 system log: 312 occurrences of empty-executable allowlist rejection
- Pattern: LLM sends `{"executable":"","argv":["cat","file"]}` → allowlist check fails → retry loop

## Test plan
- [ ] CI Build and Test passes
- [ ] Verify schema rejects `executable=""` at provider input validation layer

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>