### PR TITLE
fix(keeper): add voice keys to canonical meta allowlist

### DIFF
--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -254,6 +254,10 @@ let fallback_canonical_keeper_meta_key_names =
   ; "telemetry_feedback_window_hours"
   ; "per_provider_timeout_s"
   ; "oas_env"
+  ; "policy_voice_enabled"
+  ; "voice_enabled"
+  ; "voice_channel"
+  ; "voice_agent_id"
   ]
 ;;
 


### PR DESCRIPTION
## Summary
- Add 4 voice-related keys to `fallback_canonical_keeper_meta_key_names` in `keeper_meta_json.ml`
- Keys: `policy_voice_enabled`, `voice_enabled`, `voice_channel`, `voice_agent_id`
- Eliminates 800+/day WARN noise from `warn_unknown_keeper_meta_keys`

## Evidence
Today's system log (91K lines):
```
114 keeper meta ... has unknown keys: policy_voice_enabled, voice_enabled, voice_channel, voice_agent_id
```
Repeated for every keeper load cycle across ~7 keepers.

## Test plan
- [x] `dune build --root . @install` passes
- [ ] Deploy and verify voice key WARN drops to 0

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>