### PR TITLE
fix(telemetry): skip readdir for deleted trajectory dirs

### DIFF
--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -941,7 +941,8 @@ let trajectory_tool_call_summary_stats ~masc_root =
            protect_source_read Trajectory_tool_call
              ~site:"trajectory_tool_call_summary_readdir" ~default:[]
              (fun () ->
-             Sys.readdir dir
+             if not (Sys.file_exists dir) then []
+             else Sys.readdir dir
              |> Array.to_list
              |> List.filter (fun name -> Filename.check_suffix name ".jsonl")
              |> List.concat_map (fun name ->


### PR DESCRIPTION
## Summary
- Add Sys.file_exists check before Sys.readdir in trajectory_tool_call_summary_stats
- Eliminates 10 WARN/day for keeper trajectory dirs deleted between discovery and read

## Evidence
system_log_2026-05-24.jsonl: 10 entries for bench-analyst, bench-verifier, jobsian_purist, lifecycle-worker-3, kimi

## Test plan
- [x] dune build passes
- [ ] CI Build and Test passes

Closes #18340

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>