### PR TITLE
fix(keeper): prevent crash on unqualified cascade rotation names

### DIFF
--- a/lib/cascade_name/cascade_name.ml
+++ b/lib/cascade_name/cascade_name.ml
@@ -19,5 +19,10 @@ let of_string_exn raw =
       failwith
         (Printf.sprintf "Cascade_name.of_string_exn: invalid prefix: %S" raw)
 
+let of_string_or ~fallback raw =
+  match of_string raw with
+  | Ok t -> t
+  | Error _ -> fallback
+
 let to_string (v : t) = v
 let pp fmt (v : t) = Format.pp_print_string fmt (v :> string)

--- a/lib/cascade_name/cascade_name.mli
+++ b/lib/cascade_name/cascade_name.mli
@@ -13,6 +13,11 @@ val of_string : string -> (t, [ `Invalid_prefix | `Empty ]) result
 val of_string_exn : string -> t
 (** Development-time convenience. Raises [Failure] on invalid input. *)
 
+val of_string_or : fallback:t -> string -> t
+(** Parse a cascade name, returning [fallback] on invalid input instead of
+    raising. Use at sites where the input may be a public (stripped) catalog
+    name that lacks a canonical prefix. *)
+
 val to_string : t -> string
 (** Extract canonical string for profile_lookup, manifest emission,
     Prometheus labels. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -956,7 +956,9 @@ let run_keeper_cycle
                                     ~meta
                                     ~profile_defaults
                                     ~cascade_name:
-                                      (Cascade_name.of_string_exn degraded_retry.next_cascade)
+                                      (Cascade_name.of_string_or
+                                         ~fallback:execution.cascade_name
+                                         degraded_retry.next_cascade)
                                 with
                                 | Error fail_open_err ->
                                   let productive_phase_elapsed_ms, retry_phase_elapsed_ms =

--- a/lib/keeper/keeper_unified_turn_rotation_attempt.ml
+++ b/lib/keeper/keeper_unified_turn_rotation_attempt.ml
@@ -10,7 +10,15 @@ let build
   : Keeper_execution_receipt.cascade_rotation_attempt
   =
   { from_cascade
-  ; to_cascade = Cascade_name.of_string_exn retry.next_cascade
+  ; to_cascade =
+      (match Cascade_name.of_string retry.next_cascade with
+       | Ok t -> t
+       | Error (`Invalid_prefix | `Empty) ->
+         Log.Misc.warn
+           "rotation_attempt: next_cascade %S is not a qualified cascade name, \
+            falling back to from_cascade"
+           retry.next_cascade;
+         from_cascade)
   ; reason = retry.fallback_reason
   ; outcome
   ; slot_release_at_phase


### PR DESCRIPTION
## Summary
- Degraded rotation candidates (`normalized_cascade_name`) may return public (prefix-stripped) catalog names like `local_llama` instead of qualified names like `tier.local_llama`
- `Cascade_name.of_string_exn` rejects these public names, causing ~92 keeper cycle exceptions/day across 10+ keepers (echo, verifier, sangsu, qa-king, etc.)
- Replace crash-prone `of_string_exn` with graceful `of_string_or ~fallback` at 2 consumption sites
- Add `Cascade_name.of_string_or` API for safe name resolution

## Impact
- **Before**: Keeper crashes with `Failure("Cascade_name.of_string_exn: invalid prefix: \"local_llama\"")` 
- **After**: Falls back to current cascade name with warning log, keeper continues retry cycle

## Root cause (deeper fix deferred)
`normalized_cascade_name` in `keeper_error_classify.ml` compares against `catalog_names` (public/stripped names) and returns the public form. The deeper fix would be to have `normalized_cascade_name` return qualified names, but this requires changing the catalog name interface and all ~10 callers.

Closes #18328

## Test plan
- [x] `dune build --root . @install` passes
- [ ] CI Build and Test passes
- [ ] Verify echo/verifier keeper cycles no longer crash with `invalid prefix` errors after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)