### PR TITLE
[codex] Fix keeper cascade name normalization

### DIFF
--- a/config/keepers/verifier.toml
+++ b/config/keepers/verifier.toml
@@ -18,7 +18,6 @@ tool_denylist = [
   "masc_batch_add_tasks",
   "masc_claim_next",
   "masc_deliver",
-  "masc_transition",
 ]
 github_identity = "reviewer-keepers-nonoperator-0506b"
 git_identity_mode = "github_identity"

--- a/lib/cascade/cascade_routes.ml
+++ b/lib/cascade/cascade_routes.ml
@@ -310,31 +310,23 @@ let cascade_provider_configs_for_use_via_phonebook
       in
       if configs = [] then None else Some configs
 
-(** Phonebook-first resolution for route callers.
-
-    Tries the phonebook path (route use → [task_use] → tier-group → model
-    strings), returning the first model string. Falls back to TOML
-    [routes.<key>] when the phonebook is unavailable or returns no models. *)
 let cascade_name_for_use ?config_path use =
-  match cascade_models_for_use_via_phonebook ?config_path use with
-  | Some (first_model :: _) -> first_model
-  | _ ->
-    let route_key = logical_use_key use in
-    let route_target =
-      configured_route_bindings ?config_path ()
-      |> List.find_map (fun (key, target) ->
-             if String.equal key route_key then Some target else None)
-    in
-    let catalog_names = live_catalog_names ?config_path () in
-    let fallback = fallback_name_for_catalog use ~catalog:catalog_names in
-    match route_target with
-    | Some target when catalog_names = [] ->
-        Cascade_metrics.on_route_resolve_fallback ~reason:"catalog_unvalidated";
-        warn_unvalidated_route_target_once ~route_key ~target ~fallback;
-        target
-    | Some target when List.mem target catalog_names -> target
-    | Some target ->
-        Cascade_metrics.on_route_resolve_fallback ~reason:"target_not_in_catalog";
-        warn_invalid_route_target_once ~route_key ~target ~fallback;
-        fallback
-    | None -> fallback
+  let route_key = logical_use_key use in
+  let route_target =
+    configured_route_bindings ?config_path ()
+    |> List.find_map (fun (key, target) ->
+           if String.equal key route_key then Some target else None)
+  in
+  let catalog_names = live_catalog_names ?config_path () in
+  let fallback = fallback_name_for_catalog use ~catalog:catalog_names in
+  match route_target with
+  | Some target when catalog_names = [] ->
+      Cascade_metrics.on_route_resolve_fallback ~reason:"catalog_unvalidated";
+      warn_unvalidated_route_target_once ~route_key ~target ~fallback;
+      target
+  | Some target when List.mem target catalog_names -> target
+  | Some target ->
+      Cascade_metrics.on_route_resolve_fallback ~reason:"target_not_in_catalog";
+      warn_invalid_route_target_once ~route_key ~target ~fallback;
+      fallback
+  | None -> fallback

--- a/lib/cascade/cascade_routes.mli
+++ b/lib/cascade/cascade_routes.mli
@@ -41,7 +41,12 @@ val cascade_name_for_use : ?config_path:string -> logical_use -> string
     binding is declared.  Falls back to the canonical [route.<key>] name when the
     catalog itself is empty — [Cascade_catalog_runtime.validate_path_result]
     remains the boot-time boundary that prevents this state from being
-    reached at runtime. *)
+    reached at runtime.
+
+    This returns a cascade profile name, never a provider/model string.
+    Phonebook model/provider resolution is exposed separately through
+    {!cascade_models_for_use_via_phonebook} and
+    {!cascade_provider_configs_for_use_via_phonebook}. *)
 
 val route_bindings_from_json : Yojson.Safe.t -> (string * string) list
 (** Decode the [routes] object of the in-memory cascade view into a

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -518,13 +518,31 @@ let canonicalize_with_catalog ~catalog raw =
         | Some _ -> trimmed
         | None -> trimmed)
 
-let normalize_declared_name (raw : string) : string =
+let canonical_member_of_lookup_catalog ~catalog raw =
+  let trimmed = String.trim raw in
+  if not (List.mem trimmed catalog) then None
+  else if Cascade_name.is_canonical_prefix trimmed then Some trimmed
+  else
+    let tier_group = qualified_tier_group_name trimmed in
+    let tier = qualified_tier_name trimmed in
+    if List.mem tier_group catalog then Some tier_group
+    else if List.mem tier catalog then Some tier
+    else None
+
+let normalize_declared_name ?config_path (raw : string) : string =
   let trimmed = String.trim raw in
   if String.equal trimmed "" then trimmed
   else
     match logical_use_of_string_opt trimmed with
-    | Some use -> cascade_name_for_use use
-    | None -> trimmed
+    | Some use -> cascade_name_for_use ?config_path use
+    | None ->
+        (match
+           canonical_member_of_lookup_catalog
+             ~catalog:(catalog_lookup_names ?config_path ())
+             trimmed
+         with
+         | Some canonical -> canonical
+         | None -> trimmed)
 
 let keeper_runtime_route_uses =
   [ Keeper_turn; Phase_recovery; Phase_buffer; Tool_required ]
@@ -537,7 +555,7 @@ let route_target_public_name ?config_path use =
   with Failure _ -> None
 
 let normalize_keeper_runtime_declared_name ?config_path raw =
-  let normalized = normalize_declared_name raw in
+  let normalized = normalize_declared_name ?config_path raw in
   let public_name = public_name_of_target normalized in
   let explicitly_keeper_assignable =
     (* RFC-0143 PR-2 — typed catalog query. *)
@@ -563,23 +581,29 @@ let normalize_keeper_runtime_declared_name ?config_path raw =
   else normalized
 
 (* RFC-0149 §3.3 — "Parse, don't validate" reverse of the silent-fallback
-   shape.  [resolve_live_with_catalog_result] returns [Ok cascade_name]
-   when the catalog can resolve the input, otherwise [Error (`Unresolved
-   raw)].  The legacy [resolve_live_with_catalog] below keeps the silent
-   fallback + WARN-once + counter for callers that have not yet migrated,
-   but the unresolved branch is now isolated to a single [Error] arm so
-   the sunset path is mechanical. *)
+  shape.  [resolve_live_with_catalog_result] returns [Ok cascade_name]
+  when the catalog can resolve the input, otherwise [Error (`Unresolved
+   raw)].  The unresolved branch is isolated to a single [Error] arm so
+   the sunset path stays mechanical. *)
 let resolve_live_with_catalog_result ~catalog raw :
     (Cascade_name.t, [ `Unresolved of string ]) result =
   let trimmed = String.trim raw in
   let normalized =
-    if List.mem trimmed catalog then trimmed
-    else
-      match logical_use_of_string_opt trimmed with
-      | Some use when catalog <> [] ->
-          Cascade_routes.fallback_name_for_catalog use ~catalog
-      | Some _ -> trimmed
-      | None -> trimmed
+    match canonical_member_of_lookup_catalog ~catalog trimmed with
+    | Some canonical -> canonical
+    | None ->
+      if List.mem trimmed catalog then trimmed
+      else
+        match logical_use_of_string_opt trimmed with
+        | Some use when catalog <> [] ->
+            Cascade_routes.fallback_name_for_catalog use ~catalog
+        | Some _ -> trimmed
+        | None -> trimmed
+  in
+  let normalized =
+    match canonical_member_of_lookup_catalog ~catalog normalized with
+    | Some canonical -> canonical
+    | None -> normalized
   in
   (* Catalog members are canonical by construction; verify with
      [Cascade_name.of_string] so the result is typed. *)

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -43,13 +43,16 @@ val cascade_name_for_use : ?config_path:string -> logical_use -> string
 (** Runtime cascade profile for a logical call site.
 
     Resolution order:
-    1. Phonebook: [logical_use] → [task_use] → tier-group → model strings,
-       returning the first model string.
-    2. TOML [routes.<logical_use_key>] from the active cascade config,
+    1. TOML [routes.<logical_use_key>] from the active cascade config,
        when it points at a live catalog profile.
-    3. The first catalog entry from the live catalog.
-    Raises [Failure] when the catalog is empty — boot-time validation is
-    the upstream gate that prevents this state at runtime.
+    2. The first catalog entry from the live catalog.
+    3. The canonical [route.<key>] name when the catalog itself is empty —
+       boot-time validation is the upstream gate that prevents this state at
+       runtime.
+
+    This returns a cascade profile name, never a provider/model string.
+    Phonebook model/provider resolution is exposed separately through
+    {!model_strings_for_use} and {!provider_configs_for_use}.
 
     This is the boundary for code that used to hardcode profile names such as
     ["governance_judge"], ["operator_judge"], ["phase_recovery"], or
@@ -87,6 +90,11 @@ val catalog_names_result : ?config_path:string -> unit -> (string list, string) 
 (** Like {!catalog_names}, but preserves the loader error so validation
     boundaries can fail loud instead of collapsing catalog drift into an empty
     dynamic profile set. *)
+
+val catalog_lookup_names : ?config_path:string -> unit -> string list
+(** Live catalog names usable for lookup. Includes canonical declarative
+    names such as ["tier-group.primary"] / ["tier.primary"] plus public
+    short aliases such as ["primary"]. *)
 
 val catalog_names_for_validation :
   ?config_path:string -> unit -> (string list, string) result
@@ -170,9 +178,11 @@ val canonicalize : string -> string
     applied and the name is returned as-is.  If the catalog is empty, a
     canonical [route.<key>] name remains the fallback. *)
 
-val normalize_declared_name : string -> string
-(** Normalizes keeper-side canonical route keys through
-    {!cascade_name_for_use}; otherwise the trimmed input is returned. *)
+val normalize_declared_name : ?config_path:string -> string -> string
+(** Normalizes keeper-side logical route aliases.
+    Logical route aliases resolve through {!cascade_name_for_use}; public live
+    catalog names resolve to their canonical [tier.*] / [tier-group.*] form;
+    otherwise the trimmed input is returned. *)
 
 val normalize_keeper_runtime_declared_name : ?config_path:string -> string -> string
 (** Like {!normalize_declared_name}, but ignores stale keeper-local profile

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -567,8 +567,8 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
 let requalify_bare_catalog_name bare =
   let tier_q = "tier." ^ bare in
   let tg_q = "tier-group." ^ bare in
-  (* Prefer tier. over tier-group. when both collide — in practice
-     catalog_names strips both, but the qualified form disambiguates. *)
+  (* Prefer tier. over tier-group. when the catalog only exposes public names;
+     qualified lookup catalogs below still disambiguate concrete members. *)
   match
     Cascade_name.of_string tier_q |> Result.is_ok,
     Cascade_name.of_string tg_q |> Result.is_ok
@@ -579,6 +579,15 @@ let requalify_bare_catalog_name bare =
 
 let normalized_cascade_name ~catalog_names name =
   let trimmed = String.trim name in
+  let canonical_catalog_name =
+    if Cascade_name.is_canonical_prefix trimmed then Some trimmed
+    else
+      let tier_group = "tier-group." ^ trimmed in
+      let tier = "tier." ^ trimmed in
+      if List.mem tier_group catalog_names then Some tier_group
+      else if List.mem tier catalog_names then Some tier
+      else None
+  in
   let is_live_catalog_profile =
     List.exists (String.equal trimmed) catalog_names
   in
@@ -588,15 +597,17 @@ let normalized_cascade_name ~catalog_names name =
      When the input is a bare catalog name (stripped of tier/tier-group
      prefix), re-qualify it so downstream [Cascade_name.of_string_exn]
      does not crash on the missing canonical prefix. *)
-  if
-    is_live_catalog_profile
-    || String.equal trimmed Keeper_config.phase_buffer_cascade_name
+  if is_live_catalog_profile then
+    Option.value canonical_catalog_name
+      ~default:
+        (if Cascade_name.is_canonical_prefix trimmed
+         then trimmed
+         else requalify_bare_catalog_name trimmed)
+  else if
+    String.equal trimmed Keeper_config.phase_buffer_cascade_name
     || String.equal trimmed Keeper_config.phase_recovery_cascade_name
     || String.equal trimmed Keeper_config.tool_required_cascade_name
-  then
-    if is_live_catalog_profile && not (Cascade_name.is_canonical_prefix trimmed)
-    then requalify_bare_catalog_name trimmed
-    else trimmed
+  then Option.value canonical_catalog_name ~default:trimmed
   else Keeper_cascade_profile.normalize_declared_name trimmed
 
 let strip_prefix ~prefix value =
@@ -740,7 +751,7 @@ let degraded_rotation_after_recoverable_error
       (* Load the live catalog once at the degraded-rotation boundary and pass
          the snapshot through normalization/filter helpers.  This preserves
          concrete profile names without adding per-candidate catalog I/O. *)
-      let catalog_names = Keeper_cascade_profile.catalog_names () in
+      let catalog_names = Keeper_cascade_profile.catalog_lookup_names () in
       let attempted =
         attempted_cascades
         |> List.map (normalized_cascade_name ~catalog_names)

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -320,6 +320,12 @@ let operator_disposition (receipt : t)
       receipt.cascade_fallback_applied
       || receipt.cascade_outcome = Cascade_passed_to_next_model
     then Disp_pass_next_model, Reason_cascade_fallback
+    else if
+      receipt.outcome = `Ok
+      && receipt.cascade_outcome = Cascade_not_dispatched
+      && receipt.tool_contract_result = Contract_not_dispatched
+      && String.equal terminal_reason "pre_dispatch_success"
+    then Disp_pass, Reason_healthy
     (* "healthy" requires an explicit success signal: turn completed without
        error AND cascade reached the configured terminal. Any other fallthrough
        is an unmapped state — surface it as "unknown" so a new cascade_outcome

--- a/lib/keeper/keeper_types_profile_sandbox.ml
+++ b/lib/keeper/keeper_types_profile_sandbox.ml
@@ -45,10 +45,15 @@ let sandbox_profile_to_string profile =
   |> Keeper_sandbox_config.sandbox_profile_to_string
 ;;
 
+let legacy_reserved_cascade_names =
+  [ "local_only"; "local_recovery"; "tool_use_strict" ]
+;;
+
 let reserved_cascade_names =
   List.sort_uniq
     String.compare
-    (Keeper_config.phase_routing_cascade_names
+    (legacy_reserved_cascade_names
+     @ Keeper_config.phase_routing_cascade_names
      @ [ Keeper_config.default_cascade_name ()
        ; Keeper_config.tool_required_cascade_name
        ])

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -21,7 +21,15 @@ module Owne = Masc_mcp.Keeper_turn_driver
 module KT = Masc_mcp.Keeper_types
 module Retry = Llm_provider.Retry
 
-let cascade_name raw = Cascade_name.of_string_exn raw
+let cascade_name raw =
+  let trimmed = String.trim raw in
+  let canonical =
+    if Cascade_name.is_canonical_prefix trimmed
+    then trimmed
+    else "tier-group." ^ trimmed
+  in
+  Cascade_name.of_string_exn canonical
+;;
 
 let test_cascade = cascade_name "tier.test_cascade"
 
@@ -66,7 +74,7 @@ let test_other_detail_generic_recoverable () =
   | None ->
     fail "Generic Cascade_exhausted with Other_detail should be recoverable"
 
-let test_slot_full_other_detail_stays_legacy_cascade_exhausted () =
+let test_slot_full_other_detail_maps_to_capacity_backpressure () =
   let err =
     make_cascade_exhausted
       (KT.Other_detail "slot full, cascading to next provider")
@@ -78,7 +86,7 @@ let test_slot_full_other_detail_stays_legacy_cascade_exhausted () =
     check string "slot full -> capacity_backpressure" "capacity_backpressure"
       (KEC.degraded_retry_reason_to_string reason)
   | None ->
-    fail "slot full should be recoverable"
+    fail "slot full should be capacity-backpressure recoverable"
 
 let test_typed_capacity_backpressure_is_not_cascade_exhausted () =
   let err = make_capacity_backpressure () in
@@ -506,8 +514,8 @@ let () =
             test_auto_recoverable_cascade_exhausted_is_still_cascade_exhausted;
           test_case "Other_detail (non-quota) is recoverable" `Quick
             test_other_detail_generic_recoverable;
-          test_case "slot full Other_detail stays legacy cascade exhausted" `Quick
-            test_slot_full_other_detail_stays_legacy_cascade_exhausted;
+          test_case "slot full Other_detail maps to capacity backpressure" `Quick
+            test_slot_full_other_detail_maps_to_capacity_backpressure;
           test_case "typed capacity backpressure is not cascade exhausted" `Quick
             test_typed_capacity_backpressure_is_not_cascade_exhausted;
           test_case "provider CapacityExhausted is capacity backpressure" `Quick

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -97,7 +97,7 @@ let mk_receipt
   ; network_mode = Masc_mcp.Keeper_types.Network_none
   ; approval_profile = None
   ; approval_profile_derived = false
-  ; cascade_name = Cascade_name.of_string_exn "default"
+  ; cascade_name = Cascade_name.of_string_exn "tier-group.default"
   ; cascade_selected_model = None
   ; cascade_attempt_count = 1
   ; cascade_fallback_applied
@@ -328,6 +328,20 @@ let test_pass_for_healthy () =
       ()
   in
   check_disp "healthy" r "pass" "healthy"
+;;
+
+let test_pass_for_pre_dispatch_success () =
+  let r =
+    mk_receipt
+      ~outcome:`Ok
+      ~cascade_outcome:R.Cascade_not_dispatched
+      ~tool_contract_result:Contract_not_dispatched
+      ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.No_tools
+      ~tools_used:[]
+      ~terminal_reason_code:"pre_dispatch_success"
+      ()
+  in
+  check_disp "pre_dispatch_success" r "pass" "healthy"
 ;;
 
 let test_pass_for_completed_claim_progress () =
@@ -656,7 +670,7 @@ let test_stale_broadcast_payload_uses_low_cardinality_stale_reason () =
     R.stale_broadcast_payload
       ~keeper_name:"executor"
       ~agent_name:"executor-agent"
-      ~cascade_name:(Cascade_name.of_string_exn "primary")
+      ~cascade_name:(Cascade_name.of_string_exn "tier-group.primary")
       ~trace_id:"trace-stale"
       ~generation:7
       ~failure_reason:None
@@ -702,7 +716,7 @@ let test_stale_broadcast_payload_preserves_provider_failure_reason () =
     R.stale_broadcast_payload
       ~keeper_name:"executor"
       ~agent_name:"executor-agent"
-      ~cascade_name:(Cascade_name.of_string_exn "primary")
+      ~cascade_name:(Cascade_name.of_string_exn "tier-group.primary")
       ~trace_id:"trace-stale"
       ~generation:7
       ~failure_reason:(Some failure_reason)
@@ -745,7 +759,7 @@ let test_stale_broadcast_payload_preserves_required_tool_failure_reason () =
     R.stale_broadcast_payload
       ~keeper_name:"executor"
       ~agent_name:"executor-agent"
-      ~cascade_name:(Cascade_name.of_string_exn "primary")
+      ~cascade_name:(Cascade_name.of_string_exn "tier-group.primary")
       ~trace_id:"trace-stale"
       ~generation:7
       ~failure_reason:(Some failure_reason)
@@ -785,7 +799,7 @@ let test_stale_broadcast_payload_preserves_timeout_budget_failure_reason () =
     R.stale_broadcast_payload
       ~keeper_name:"executor"
       ~agent_name:"executor-agent"
-      ~cascade_name:(Cascade_name.of_string_exn "primary")
+      ~cascade_name:(Cascade_name.of_string_exn "tier-group.primary")
       ~trace_id:"trace-stale"
       ~generation:7
       ~failure_reason:(Some failure_reason)
@@ -870,6 +884,10 @@ let () =
             test_alert_for_cascade_exhausted
         ; test_case "unmapped -> unknown" `Quick test_unknown_when_unmapped
         ; test_case "ok+completed -> pass" `Quick test_pass_for_healthy
+        ; test_case
+            "ok+pre_dispatch_success -> pass"
+            `Quick
+            test_pass_for_pre_dispatch_success
         ; test_case
             "ok+completed claim progress -> pass"
             `Quick

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -254,7 +254,6 @@ let test_verifier_config_hides_worker_lifecycle_tools () =
           "masc_batch_add_tasks";
           "masc_claim_next";
           "masc_deliver";
-          "masc_transition";
         ]
 
 (** Write a temporary TOML file, run load_keeper_toml, clean up. *)
@@ -566,7 +565,7 @@ let test_cascade_profile_metadata_from_toml () =
     (Masc_mcp.Keeper_cascade_profile.is_system_only_cascade "llm_rerank");
   check bool "scoring catalog entry is system-only" true
     (Masc_mcp.Keeper_cascade_profile.is_system_only_cascade "scoring");
-  check (option string) "primary fallback hint" (Some "backup")
+  check (option string) "primary fallback hint" (Some "tier.backup")
     (Masc_mcp.Keeper_cascade_profile.fallback_cascade_for "primary")
 
 let test_cascade_name_accepts_unrouted_assignable_catalog_entry () =
@@ -704,13 +703,100 @@ target = "tier-group.primary"
   in
   with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
   check (option string) "public primary resolves as tier-group.primary"
-    (Some "slow")
+    (Some "tier.slow")
     (Masc_mcp.Keeper_cascade_profile.fallback_cascade_for
        ~config_path:cascade_path "primary");
   check (option string) "qualified tier.primary keeps tier edge"
-    (Some "mid")
+    (Some "tier.mid")
     (Masc_mcp.Keeper_cascade_profile.fallback_cascade_for
        ~config_path:cascade_path "tier.primary")
+
+let test_fallback_cascade_returns_canonical_tier_target () =
+  let cascade_toml =
+    {|
+[providers.ollama]
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.qwen3]
+api-name = "qwen3:8b"
+max-context = 32768
+tools-support = true
+
+[ollama.qwen3]
+is-default = true
+max-concurrent = 1
+
+[tier.primary]
+members = ["ollama.qwen3"]
+strategy = "failover"
+
+[tier.local_llama]
+members = ["ollama.qwen3"]
+strategy = "failover"
+
+[tier.glm]
+members = ["ollama.qwen3"]
+strategy = "failover"
+
+[tier-group.coding]
+tiers = ["primary", "local_llama", "glm"]
+strategy = "priority_tier"
+fallback = true
+
+[routes.keeper_turn]
+target = "tier-group.coding"
+|}
+  in
+  with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
+  check
+    (option string)
+    "tier-group fallback keeps canonical tier target"
+    (Some "tier.local_llama")
+    (Masc_mcp.Keeper_cascade_profile.fallback_cascade_for
+       ~config_path:cascade_path "tier-group.coding")
+
+let test_normalize_declared_name_canonicalizes_public_catalog_members () =
+  let cascade_toml =
+    {|
+[providers.ollama]
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.qwen3]
+api-name = "qwen3:8b"
+max-context = 32768
+tools-support = true
+
+[ollama.qwen3]
+is-default = true
+max-concurrent = 1
+
+[tier.strict_tool_candidates]
+members = ["ollama.qwen3"]
+strategy = "failover"
+
+[tier.local_llama]
+members = ["ollama.qwen3"]
+strategy = "failover"
+
+[tier-group.strict_tool_candidates]
+tiers = ["strict_tool_candidates"]
+strategy = "priority_tier"
+
+[routes.keeper_turn]
+target = "tier-group.strict_tool_candidates"
+|}
+  in
+  with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
+  check string "public tier-group alias canonicalizes to tier-group"
+    "tier-group.strict_tool_candidates"
+    (Masc_mcp.Keeper_cascade_profile.normalize_declared_name
+       ~config_path:cascade_path "strict_tool_candidates");
+  check string "public tier alias canonicalizes to tier"
+    "tier.local_llama"
+    (Masc_mcp.Keeper_cascade_profile.normalize_declared_name
+       ~config_path:cascade_path "local_llama")
 
 let test_keeper_runtime_declared_name_ignores_non_keeper_route_target () =
   let cascade_toml =
@@ -1066,6 +1152,10 @@ let () =
             test_keeper_assignability_uses_preferred_qualified_profile;
           test_case "fallback preserves qualified source profile" `Quick
             test_fallback_cascade_preserves_qualified_source_profile;
+          test_case "fallback returns canonical tier target" `Quick
+            test_fallback_cascade_returns_canonical_tier_target;
+          test_case "declared public names canonicalize to catalog members" `Quick
+            test_normalize_declared_name_canonicalizes_public_catalog_members;
           test_case "keeper runtime ignores non-keeper route target" `Quick
             test_keeper_runtime_declared_name_ignores_non_keeper_route_target;
           test_case "surfaces declarative adapter errors" `Quick


### PR DESCRIPTION
## Summary

- canonicalize public cascade catalog names before they reach typed `Cascade_name` boundaries
- keep declarative fallback hints qualified so degraded retry does not emit bare tier aliases like `local_llama`
- classify `pre_dispatch_success` receipts as healthy instead of unmapped operator broadcasts
- let verifier keep `masc_transition` visible for approve/reject while still hiding worker lifecycle tools

## Root Cause

Recent keeper logs showed provider/runtime failures being amplified by MASC-internal name drift. The live cascade catalog can expose public aliases such as `local_llama` or `strict_tool_candidates`, but downstream typed code expects canonical names such as `tier.local_llama` or `tier-group.strict_tool_candidates`. When degraded retry or keeper turn setup passed the public alias into `Cascade_name.of_string_exn`, keepers crashed with `invalid prefix`.

The same logs also showed `pre_dispatch_success` receipts falling through the operator disposition mapper as `unknown`, causing silent-path regressions to surface as operator broadcasts.

## Validation

- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_pause_broadcast.exe test/test_keeper_toml_config_validation.exe test/test_keeper_error_classify_recoverable.exe`
- `env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH= GRAPHQL_API_KEY= ZAI_API_KEY= MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED=false MASC_KEEPER_DOCKER_PLAYGROUND=false _build/default/test/test_keeper_pause_broadcast.exe`
- `env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH= GRAPHQL_API_KEY= ZAI_API_KEY= MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED=false MASC_KEEPER_DOCKER_PLAYGROUND=false _build/default/test/test_keeper_error_classify_recoverable.exe`
- `env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH= GRAPHQL_API_KEY= ZAI_API_KEY= MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED=false MASC_KEEPER_DOCKER_PLAYGROUND=false _build/default/test/test_keeper_toml_config_validation.exe`
- `git diff --check`
