### PR TITLE
[codex] Retire cascade route legacy aliases

### DIFF
--- a/lib/cascade/cascade_routes.ml
+++ b/lib/cascade/cascade_routes.ml
@@ -25,7 +25,6 @@ type logical_use = Cascade_ref.logical_use =
 type route_spec = {
   use : logical_use;
   key : string;
-  aliases : string list;
 }
 
 (* Per RFC-0041 cascade routing SSOT, the live cascade catalog
@@ -35,49 +34,36 @@ type route_spec = {
    the runtime cascade chain handles try/fail/next-cascade.  If the
    catalog is empty at runtime,
    [Cascade_catalog_runtime.validate_path_result] already rejects keeper
-   boot.  [fallback_name_for_catalog] returns the first alias from
-   [spec_for_use] as a soft fallback, so test executables that link
-   these modules transitively do not crash at module-init time. *)
+   boot; the canonical-key empty fallback only keeps module init and
+   focused test executables from depending on historical aliases. *)
 
-let route use key aliases = { use; key; aliases }
+let route use key = { use; key }
 
-(* [spec_for_use] is the SSOT for the (logical_use → key/aliases) mapping.
+(* [spec_for_use] is the SSOT for the (logical_use → route key) mapping.
    Written as an exhaustive [match] so adding a new constructor to
    [logical_use] is a compile-time error here, not a runtime
    [assert false] surfaced by [spec_for_use] callers.  Per CLAUDE.md
    §"FSM Sparse Match" anti-pattern: a list lookup keyed by a closed
    sum type silently degrades when the list and the type drift apart. *)
 let spec_for_use : logical_use -> route_spec = function
-  | Keeper_turn ->
-      route Keeper_turn "keeper_turn"
-        [
-          "default";
-          "default_models";
-          "oas-keeper_unified";
-          "coding_first";
-          "oas-coding_first";
-          "keeper_reply";
-          "keeper_unified";
-        ]
-  | Phase_recovery -> route Phase_recovery "phase_recovery" [ "local_recovery" ]
-  | Phase_buffer -> route Phase_buffer "phase_buffer" [ "local_only" ]
-  | Tool_required ->
-      route Tool_required "tool_required"
-        [ "tool_use_strict"; "resilient_breaker" ]
-  | Governance_judge -> route Governance_judge "governance_judge" []
-  | Operator_judge -> route Operator_judge "operator_judge" []
-  | Cross_verifier -> route Cross_verifier "cross_verifier" []
-  | Verifier -> route Verifier "verifier" []
-  | Adversarial_reviewer -> route Adversarial_reviewer "adversarial_reviewer" []
-  | Auto_responder -> route Auto_responder "auto_responder" []
-  | Routing -> route Routing "routing" [ "routing_judge" ]
-  | Openai_compat -> route Openai_compat "openai_compat" []
-  | Persona_generation -> route Persona_generation "persona_generation" []
-  | Provider_benchmark -> route Provider_benchmark "provider_benchmark" []
-  | Simple_task -> route Simple_task "simple_task" []
-  | Moderate_task -> route Moderate_task "moderate_task" []
-  | Complex_task -> route Complex_task "complex_task" []
-  | Tool_rerank_use -> route Tool_rerank_use "llm_rerank" []
+  | Keeper_turn -> route Keeper_turn "keeper_turn"
+  | Phase_recovery -> route Phase_recovery "phase_recovery"
+  | Phase_buffer -> route Phase_buffer "phase_buffer"
+  | Tool_required -> route Tool_required "tool_required"
+  | Governance_judge -> route Governance_judge "governance_judge"
+  | Operator_judge -> route Operator_judge "operator_judge"
+  | Cross_verifier -> route Cross_verifier "cross_verifier"
+  | Verifier -> route Verifier "verifier"
+  | Adversarial_reviewer -> route Adversarial_reviewer "adversarial_reviewer"
+  | Auto_responder -> route Auto_responder "auto_responder"
+  | Routing -> route Routing "routing"
+  | Openai_compat -> route Openai_compat "openai_compat"
+  | Persona_generation -> route Persona_generation "persona_generation"
+  | Provider_benchmark -> route Provider_benchmark "provider_benchmark"
+  | Simple_task -> route Simple_task "simple_task"
+  | Moderate_task -> route Moderate_task "moderate_task"
+  | Complex_task -> route Complex_task "complex_task"
+  | Tool_rerank_use -> route Tool_rerank_use "llm_rerank"
 
 (* The known-uses enumeration must remain in sync with [logical_use].
    When a new constructor is added, the [match] in [spec_for_use] will
@@ -117,14 +103,11 @@ let logical_use_key use = (spec_for_use use).key
 
 let logical_use_of_string_opt raw =
   match String.trim raw |> String.lowercase_ascii with
-  | "" -> Some Keeper_turn
+  | "" -> None
   | normalized ->
       route_specs
       |> List.find_map (fun spec ->
-             if String.equal normalized spec.key
-                || List.mem normalized spec.aliases
-             then Some spec.use
-             else None)
+             if String.equal normalized spec.key then Some spec.use else None)
 
 (* RFC-0058 v2 route encoding in the materialized JSON:
    {"routes": {"X": {"target": "tier-..."}}}.
@@ -222,16 +205,10 @@ let declarative_catalog_names ?config_path () =
 let live_catalog_names ?config_path () =
   declarative_catalog_names ?config_path ()
 
-let first_alias_or_key (spec : route_spec) =
-  match spec.aliases with
-  | first :: _ -> first
-  | [] -> spec.key
-
 let fallback_name_for_catalog use ~catalog =
-  let spec = spec_for_use use in
   match catalog with
   | name :: _ -> name
-  | [] -> first_alias_or_key spec
+  | [] -> "route." ^ logical_use_key use
 
 let logged_invalid_route_targets : (string * string, unit) Hashtbl.t =
   Hashtbl.create 8
@@ -260,19 +237,28 @@ let warn_unvalidated_route_target_once ~route_key ~target ~fallback =
 
 (* ── Phonebook-based routing (RFC Cascade-Phonebook Phase 4) ───── *)
 
+let task_use_of_logical_use = function
+  | Keeper_turn | Phase_recovery | Phase_buffer | Openai_compat
+  | Persona_generation ->
+      Cascade_routing_policy.Code_generation
+  | Tool_required | Tool_rerank_use -> Cascade_routing_policy.Tool_execution
+  | Governance_judge | Operator_judge | Cross_verifier | Verifier
+  | Adversarial_reviewer ->
+      Cascade_routing_policy.Code_review
+  | Auto_responder | Routing | Provider_benchmark | Simple_task
+  | Moderate_task ->
+      Cascade_routing_policy.Quick_decision
+  | Complex_task -> Cascade_routing_policy.Long_reasoning
+
 (** Resolve a logical_use to model strings via the phonebook.
 
-    Maps legacy [logical_use] → new [task_use] → tier-group → model strings.
-    Returns [None] when the phonebook is unavailable or the logical_use
-    has no task_use mapping. *)
+    Maps canonical route use → [task_use] → tier-group → model strings.
+    Returns [None] when the phonebook is unavailable. *)
 let cascade_models_for_use_via_phonebook
     ?config_path
     (use : logical_use)
   : string list option =
-  let logical_key = logical_use_key use in
-  match Cascade_routing_policy.task_use_of_legacy_logical_use logical_key with
-  | None -> None
-  | Some task ->
+  let task = task_use_of_logical_use use in
     let phonebook =
       match config_path with
       | Some path ->
@@ -294,7 +280,7 @@ let cascade_models_for_use_via_phonebook
 
 (** Resolve a logical_use to Provider_config.t list via the phonebook.
 
-    Full phonebook path: logical_use → task_use → tier-group → models →
+    Full phonebook path: route use → task_use → tier-group → models →
     providers → endpoint/auth → Provider_config.t.
     Returns [None] when phonebook is unavailable or no models resolve. *)
 let cascade_provider_configs_for_use_via_phonebook
@@ -303,10 +289,7 @@ let cascade_provider_configs_for_use_via_phonebook
     ?max_tokens
     (use : logical_use)
   : Llm_provider.Provider_config.t list option =
-  let logical_key = logical_use_key use in
-  match Cascade_routing_policy.task_use_of_legacy_logical_use logical_key with
-  | None -> None
-  | Some task ->
+  let task = task_use_of_logical_use use in
     let phonebook =
       match config_path with
       | Some path ->
@@ -327,12 +310,11 @@ let cascade_provider_configs_for_use_via_phonebook
       in
       if configs = [] then None else Some configs
 
-(** Phonebook-first resolution for legacy callers.
+(** Phonebook-first resolution for route callers.
 
-    Tries the phonebook path ([logical_use] → [task_use] → tier-group →
-    model strings), returning the first model string. Falls back to the
-    legacy TOML [routes] binding system when the phonebook is unavailable
-    or returns no models. *)
+    Tries the phonebook path (route use → [task_use] → tier-group → model
+    strings), returning the first model string. Falls back to TOML
+    [routes.<key>] when the phonebook is unavailable or returns no models. *)
 let cascade_name_for_use ?config_path use =
   match cascade_models_for_use_via_phonebook ?config_path use with
   | Some (first_model :: _) -> first_model

--- a/lib/cascade/cascade_routes.mli
+++ b/lib/cascade/cascade_routes.mli
@@ -27,6 +27,7 @@ type logical_use = Cascade_ref.logical_use =
 
 val logical_use_key : logical_use -> string
 val logical_use_of_string_opt : string -> logical_use option
+val task_use_of_logical_use : logical_use -> Cascade_routing_policy.task_use
 
 val all_logical_uses : logical_use list
 (** Logical call-site uses known by the route registry. *)
@@ -37,9 +38,10 @@ val known_route_keys : string list
 val cascade_name_for_use : ?config_path:string -> logical_use -> string
 (** Resolve a logical use through [routes.<logical_use_key>] in the live
     cascade catalog.  Falls back to the first catalog entry when no route
-    binding is declared.  Raises [Failure] when the catalog itself is
-    empty — [Cascade_catalog_runtime.validate_path_result] is the boot-time
-    boundary that prevents this state from being reached at runtime. *)
+    binding is declared.  Falls back to the canonical [route.<key>] name when the
+    catalog itself is empty — [Cascade_catalog_runtime.validate_path_result]
+    remains the boot-time boundary that prevents this state from being
+    reached at runtime. *)
 
 val route_bindings_from_json : Yojson.Safe.t -> (string * string) list
 (** Decode the [routes] object of the in-memory cascade view into a
@@ -57,15 +59,14 @@ val configured_unknown_route_keys : ?config_path:string -> unit -> string list
 
 val fallback_name_for_catalog : logical_use -> catalog:string list -> string
 (** Catalog-only fallback used by string normalizers that already have an
-    explicit active profile list.  Returns the first catalog entry; raises
-    [Failure] when [catalog] is empty. *)
+    explicit active profile list.  Returns the first catalog entry, or the
+    canonical [route.<key>] name when [catalog] is empty. *)
 
 val cascade_models_for_use_via_phonebook :
   ?config_path:string -> logical_use -> string list option
 (** Resolve a logical use to model strings via the phonebook.
-    Maps legacy [logical_use] → new [task_use] → tier-group → model strings.
-    Returns [None] when the phonebook is unavailable or the logical_use
-    has no task_use mapping. *)
+    Maps canonical route use → [task_use] → tier-group → model strings.
+    Returns [None] when the phonebook is unavailable. *)
 
 val cascade_provider_configs_for_use_via_phonebook :
   ?config_path:string ->
@@ -74,6 +75,6 @@ val cascade_provider_configs_for_use_via_phonebook :
   logical_use ->
   Llm_provider.Provider_config.t list option
 (** Resolve a logical use to [Provider_config.t] list via the phonebook.
-    Full phonebook path: logical_use → task_use → tier-group → models →
+    Full phonebook path: route use → task_use → tier-group → models →
     providers → endpoint/auth → Provider_config.t.
     Returns [None] when phonebook is unavailable or no models resolve. *)

--- a/lib/cascade/cascade_routing_policy.ml
+++ b/lib/cascade/cascade_routing_policy.ml
@@ -40,27 +40,6 @@ let task_use_of_string = function
   | "conversation" -> Some Conversation
   | _ -> None
 
-(* ── Legacy logical_use → task_use mapping ───────────────────── *)
-
-(** Map the old 18-variant [logical_use] to new 6-variant [task_use].
-
-    Used during migration to translate keeper/supervisor routing
-    requests without touching all callers at once. *)
-let task_use_of_legacy_logical_use = function
-  | "keeper_turn" | "phase_recovery" | "phase_buffer" -> Some Code_generation
-  | "tool_required" -> Some Tool_execution
-  | "governance_judge" | "operator_judge" -> Some Code_review
-  | "cross_verifier" | "verifier" | "adversarial_reviewer" -> Some Code_review
-  | "auto_responder" -> Some Quick_decision
-  | "routing" -> Some Quick_decision
-  | "openai_compat" -> Some Code_generation
-  | "persona_generation" -> Some Code_generation
-  | "provider_benchmark" -> Some Quick_decision
-  | "simple_task" | "moderate_task" -> Some Quick_decision
-  | "complex_task" -> Some Long_reasoning
-  | "tool_rerank_use" -> Some Tool_execution
-  | _ -> None
-
 (* ── Routing Policy ──────────────────────────────────────────── *)
 
 (** Which tier-group to use for a given task, and any diversity constraint

--- a/lib/cascade/cascade_routing_policy.mli
+++ b/lib/cascade/cascade_routing_policy.mli
@@ -7,7 +7,6 @@ type task_use =
 
 val task_use_to_string : task_use -> string
 val task_use_of_string : string -> task_use option
-val task_use_of_legacy_logical_use : string -> task_use option
 
 type task_routing_policy = {
   task : task_use;

--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -579,18 +579,14 @@ let declarative_route_target
     raw_name =
   let open Cascade_declarative_types in
   let trimmed = String.trim raw_name in
-  let candidate_keys =
-    (match Cascade_routes.logical_use_of_string_opt trimmed with
-     | Some use -> [ trimmed; Cascade_routes.logical_use_key use ]
-     | None -> [ trimmed ])
-    |> List.filter (fun key -> not (String.equal key ""))
-  in
+  let route_key = strip_prefix ~prefix:"route." trimmed in
   let routes = cfg.routes @ cfg.system_targets in
-  candidate_keys
-  |> List.find_map (fun key ->
-       routes
-       |> List.find_opt (fun (route : cascade_route) -> String.equal route.name key)
-       |> Option.map (fun route -> route.target))
+  match route_key with
+  | None -> None
+  | Some route_key ->
+    routes
+    |> List.find_opt (fun (route : cascade_route) -> String.equal route.name route_key)
+    |> Option.map (fun route -> route.target)
 
 let first_nonempty_members cfg candidates =
   candidates

--- a/lib/cascade_ref/cascade_ref.ml
+++ b/lib/cascade_ref/cascade_ref.ml
@@ -5,9 +5,8 @@
 
     This module defines the data model for cascades as hierarchical
     structures: cascade_profile -> cascade_group -> cascade_item.
-    The previous flat [cascade_name:string] is migrated to this model
-    with backward compatibility: a plain string becomes a single-group,
-    single-item profile. *)
+    The previous flat [cascade_name:string] is represented only when it
+    already uses the canonical cascade-name prefix. *)
 
 (** A single callable item within a cascade group.
     Represents one provider+model combination with its routing metadata. *)
@@ -215,13 +214,12 @@ let cascade_ref_of_json (json : Yojson.Safe.t) : cascade_ref option =
 (* Migration helper: string -> cascade_ref                            *)
 (* ------------------------------------------------------------------ *)
 
-(** Convert a legacy cascade_name string into a cascade_ref option.
+(** Convert a canonical cascade_name string into a cascade_ref option.
     The string is treated as both the group name and (if non-empty)
-    the single item id. This preserves backward compatibility with
-    existing keeper configurations that use flat cascade_name strings.
+    the single item id.
 
     Empty string -> None (unconfigured keeper).
-    Non-canonical string -> None (rejected; falls back to unconfigured). *)
+    Non-canonical string -> None (rejected). *)
 let cascade_ref_of_string (cascade_name : string) : cascade_ref option =
   if String.equal cascade_name "" then None
   else

--- a/lib/cascade_ref/cascade_ref.mli
+++ b/lib/cascade_ref/cascade_ref.mli
@@ -6,9 +6,9 @@
     - [cascade_item]: single callable provider+model combination
     - [cascade_ref]: keeper's routing position (group + optional pinned item)
 
-    Backward compatibility: existing [cascade_name:string] configurations
-    are migrated via [cascade_ref_of_string] to a single-group,
-    single-item profile. *)
+    Existing [cascade_name:string] values are migrated via
+    [cascade_ref_of_string] only when they already use a canonical cascade
+    prefix. *)
 
 (** A single callable item within a cascade group. *)
 type cascade_item = {
@@ -65,9 +65,9 @@ val cascade_ref_of_json : Yojson.Safe.t -> cascade_ref option
 
 (** {1 Migration helper} *)
 
-(** Convert a legacy cascade_name string into a cascade_ref option.
+(** Convert a canonical cascade_name string into a cascade_ref option.
     The string becomes both the group name and (if non-empty) the item id.
-    Empty string or non-canonical string produces [None] (unconfigured). *)
+    Empty string or non-canonical string produces [None]. *)
 val cascade_ref_of_string : string -> cascade_ref option
 
 (** {1 Lookup helpers} *)

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -507,18 +507,19 @@ let fallback_cascade_for ?config_path name =
 
 let canonicalize_with_catalog ~catalog raw =
   match String.trim raw with
-  | "" -> Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog
+  | "" -> ""
   | trimmed ->
       if List.mem trimmed catalog then trimmed
       else (
         match logical_use_of_string_opt trimmed with
-        | Some use -> Cascade_routes.fallback_name_for_catalog use ~catalog
+        | Some use when catalog <> [] ->
+            Cascade_routes.fallback_name_for_catalog use ~catalog
+        | Some _ -> trimmed
         | None -> trimmed)
 
 let normalize_declared_name (raw : string) : string =
   let trimmed = String.trim raw in
-  if String.equal trimmed "" then
-    cascade_name_for_use Keeper_turn
+  if String.equal trimmed "" then trimmed
   else
     match logical_use_of_string_opt trimmed with
     | Some use -> cascade_name_for_use use
@@ -574,7 +575,9 @@ let resolve_live_with_catalog_result ~catalog raw :
     if List.mem trimmed catalog then trimmed
     else
       match logical_use_of_string_opt trimmed with
-      | Some use -> Cascade_routes.fallback_name_for_catalog use ~catalog
+      | Some use when catalog <> [] ->
+          Cascade_routes.fallback_name_for_catalog use ~catalog
+      | Some _ -> trimmed
       | None -> trimmed
   in
   (* Catalog members are canonical by construction; verify with

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -36,16 +36,16 @@ val logical_use_key : logical_use -> string
 (** Stable config key under [routes]. *)
 
 val logical_use_of_string_opt : string -> logical_use option
-(** Parse a logical route key or historical alias.  Concrete cascade
-    profile names are not logical route keys — they live in the catalog. *)
+(** Parse a canonical logical route key. Concrete cascade profile names are
+    not logical route keys — they live in the catalog. *)
 
 val cascade_name_for_use : ?config_path:string -> logical_use -> string
 (** Runtime cascade profile for a logical call site.
 
-    Resolution order (phonebook-first):
+    Resolution order:
     1. Phonebook: [logical_use] → [task_use] → tier-group → model strings,
        returning the first model string.
-    2. Legacy TOML [routes.<logical_use_key>] from the active cascade config,
+    2. TOML [routes.<logical_use_key>] from the active cascade config,
        when it points at a live catalog profile.
     3. The first catalog entry from the live catalog.
     Raises [Failure] when the catalog is empty — boot-time validation is
@@ -140,13 +140,13 @@ val resolve_live_with_catalog_result :
 (** Resolves a keeper-declared cascade against an explicit live catalog.
 
     Returns [Ok normalized] when [raw] either matches the
-    catalog directly or normalizes via a logical route alias that lands
-    on a catalog member; otherwise [Error (`Unresolved raw)] carrying the
+    catalog directly or normalizes via a canonical logical route key that
+    lands on a catalog member; otherwise [Error (`Unresolved raw)] carrying the
     original (un-trimmed) input so the operator-visible diagnostic can
     point to exactly what was provided.
 
-    Names already present in the catalog pass through; logical route
-    aliases collapse via [routes].  Callers that accept qualified
+    Names already present in the catalog pass through; canonical route
+    keys resolve via [routes].  Callers that accept qualified
     declarative names must pass a lookup catalog containing those
     qualified names, not only display/public names.
 
@@ -165,15 +165,14 @@ val resolve_live_result :
     @since RFC-0149 Phase 1 *)
 
 val canonicalize : string -> string
-(** Catalog-aware normalization: legacy aliases collapse to their canonical
-    name through [routes], live catalog names pass through, otherwise
-    [String.trim] is applied and the name is returned as-is.  Raises
-    [Failure] when the catalog is empty (boot-time gate is upstream). *)
+(** Catalog-aware normalization: canonical route keys resolve through
+    [routes], live catalog names pass through, otherwise [String.trim] is
+    applied and the name is returned as-is.  If the catalog is empty, a
+    canonical [route.<key>] name remains the fallback. *)
 
 val normalize_declared_name : string -> string
-(** Normalizes keeper-side implicit default and legacy aliases.
-    Logical route aliases resolve through {!cascade_name_for_use}; otherwise
-    the trimmed input is returned. *)
+(** Normalizes keeper-side canonical route keys through
+    {!cascade_name_for_use}; otherwise the trimmed input is returned. *)
 
 val normalize_keeper_runtime_declared_name : ?config_path:string -> string -> string
 (** Like {!normalize_declared_name}, but ignores stale keeper-local profile

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -5,9 +5,9 @@ open Tool_args
 (** Default cascade name for keeper turns. Resolved through the live
     [Cascade_catalog_runtime] snapshot so the answer reflects the
     currently-installed catalog rather than module-init state. Falls
-    back to [Cascade_routes.cascade_name_for_use Keeper_turn] (legacy
-    spec-driven path) when the snapshot is not yet available, which
-    matches pre-RFC-0066 behavior during early boot.
+    back to [Cascade_routes.cascade_name_for_use Keeper_turn] (canonical
+    route path) when the snapshot is not yet available, which matches
+    pre-RFC-0066 behavior during early boot.
 
     RFC-0066 Phase 1: was a string value evaluated at module init,
     freezing to the static fallback when the catalog was empty at

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -390,30 +390,21 @@ type keeper_meta = {
 val cascade_name_of_meta : keeper_meta -> string
 (** [cascade_name_of_meta m] is the canonical cascade name for the keeper.
 
-    Resolution order (RFC-0041 transition phase):
+    Resolution order:
     1. If [m.cascade_ref] is [Some] and [.group] is non-empty, return [.group].
-    2. Otherwise return [m.cascade_name].
-
-    During the migration phase both fields coexist and may diverge if a
-    caller writes only one. New code MUST set [cascade_ref] when changing
-    routing — read sites should use this helper instead of touching
-    [m.cascade_name] directly. The plain [m.cascade_name] field will be
-    removed once all read sites migrate. *)
+    2. Otherwise return the current keeper default route. *)
 
 val set_cascade_name : string -> keeper_meta -> keeper_meta
-(** [set_cascade_name name m] returns a meta where both [cascade_name]
-    and [cascade_ref] are pinned to [name]. The cascade_ref takes the
+(** [set_cascade_name name m] returns a meta where [cascade_ref] is pinned
+    to [name]. The cascade_ref takes the
     form [{ group = name; item = None }] so the group's traversal
     strategy decides item selection at routing time.
 
     Use this helper for every write that intends to change the keeper's
-    cascade routing target. Direct record updates of only [cascade_name]
-    are deprecated and produce drift — [cascade_name_of_meta] would then
-    return the stale [cascade_ref.group] instead of the new value.
-
-    For record-literal initialization (full keeper_meta construction)
-    callers must still set both fields explicitly; this helper applies
-    only to update-style writes ([{ m with ... }]). *)
+    cascade routing target. For record-literal initialization (full
+    keeper_meta construction) callers must still set [cascade_ref]
+    explicitly; this helper applies only to update-style writes
+    ([{ m with ... }]). *)
 
 (** {1 Outcome <-> string} *)
 

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -600,7 +600,31 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                  not (validate_name (Keeper_id.Trace_id.to_string identity.pk_trace_id))
                then Error "invalid keeper meta (bad trace_id)"
                else
-                 Ok
+                 let cascade_ref_result =
+                   match identity.pk_cascade_ref with
+                   | Some _ as ref_ -> Ok ref_
+                   | None ->
+                       let raw_cascade_name =
+                         String.trim identity.pk_cascade_name
+                       in
+                       if String.equal raw_cascade_name ""
+                       then Ok None
+                       else
+                         match Cascade_name.of_string raw_cascade_name with
+                         | Ok cn -> Ok (Some Cascade_ref.{ group = cn; item = None })
+                         | Error `Empty -> Ok None
+                         | Error `Invalid_prefix ->
+                             Error
+                               (Printf.sprintf
+                                  "invalid keeper meta cascade_name %S: expected \
+                                   canonical cascade prefix tier-group., tier., or \
+                                   route."
+                                  identity.pk_cascade_name)
+                 in
+                 (match cascade_ref_result with
+                  | Error _ as e -> e
+                  | Ok cascade_ref ->
+                    Ok
                    { id = None
                    ; name = identity.pk_name
                    ; agent_name =
@@ -612,19 +636,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                    ; mid_goal = identity.pk_mid_goal
                    ; long_goal = identity.pk_long_goal
                    ; social_model = identity.pk_social_model
-                   ; cascade_ref =
-                       (match identity.pk_cascade_ref with
-                        | Some _ as ref_ -> ref_
-                        | None ->
-                            (* RFC-0041: derive cascade_ref from legacy
-                               cascade_name string when persisted JSON
-                               predates the field.  RFC-0163 Phase D1
-                               typed [group] as [Cascade_name.t], so we
-                               must parse via [Cascade_name.of_string]
-                               and drop non-canonical names. *)
-                            (match Cascade_name.of_string identity.pk_cascade_name with
-                             | Ok cn -> Some Cascade_ref.{ group = cn; item = None }
-                             | Error _ -> None))
+                   ; cascade_ref
                    ; models = []
                    ; will = identity.pk_will
                    ; needs = identity.pk_needs
@@ -708,7 +720,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                        (match Safe_ops.json_int_opt "meta_version" json with
                         | Some v -> v
                         | None -> 0)
-                   })))
+                   }))))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))

--- a/lib/keeper/keeper_turn_liveness.mli
+++ b/lib/keeper/keeper_turn_liveness.mli
@@ -1,4 +1,4 @@
-(* Keeper_turn_liveness — local-only cascade liveness decisions and turn
+(* Keeper_turn_liveness — phase-buffer cascade liveness decisions and turn
    livelock configuration.
 
    Provider-specific probe knowledge lives in
@@ -12,8 +12,8 @@ open Keeper_types
 (** Deterministic decision for the local-only phase fallback boundary. This
     does not probe runtime liveness; it only decides whether the selected
     labels resolve to runtime URLs that [Cascade_capacity_probe.can_probe]
-    before preserving [local_only]. The provider/model label resolver stays
-    behind [Cascade_runtime_candidate]. *)
+    before preserving the canonical phase-buffer route. The provider/model
+    label resolver stays behind [Cascade_runtime_candidate]. *)
 type local_only_liveness_decision =
   | Keep_effective_cascade of string
   | Probe_local_only_urls of
@@ -31,8 +31,8 @@ val decide_local_only_liveness
 
 (** When phase routing temporarily forces the phase-buffer route, fail open to the
     keeper's configured base cascade if no registered local-capable probe
-    reports the endpoint as serving. Legacy [local_only] aliases
-    normalize through [routes.phase_buffer]. *)
+    reports the endpoint as serving. Only the canonical phase-buffer route
+    is treated as the phase routing boundary. *)
 val fail_open_local_only_when_unavailable
   :  ?resolve_runtime_url:(string -> string option)
   -> ?probe_base_url:(string -> bool)

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -336,20 +336,13 @@ val now_iso : unit -> string
 val cascade_name_of_meta : keeper_meta -> string
 (** [cascade_name_of_meta m] is the canonical cascade name for the keeper.
 
-    Resolution order (RFC-0041 transition phase):
+    Resolution order:
     1. If [m.cascade_ref] is [Some] and [.group] is non-empty, return [.group].
-    2. Otherwise return [m.cascade_name].
-
-    During the migration phase both fields coexist and may diverge if a
-    caller writes only one. New code MUST set [cascade_ref] when changing
-    routing — read sites should use this helper instead of touching
-    [m.cascade_name] directly. *)
+    2. Otherwise return the current keeper default route. *)
 
 val set_cascade_name : string -> keeper_meta -> keeper_meta
-(** [set_cascade_name name m] pins both [cascade_name] and [cascade_ref]
-    to [name] in a single update. Use for every write that changes the
-    keeper's cascade routing target — direct field-only updates produce
-    drift. *)
+(** [set_cascade_name name m] pins [cascade_ref] to [name]. Use for every
+    write that changes the keeper's cascade routing target. *)
 
 val tool_preset_to_string : tool_preset -> string
 val tool_preset_of_string : string -> tool_preset option

--- a/lib/keeper/keeper_types_profile_sandbox.ml
+++ b/lib/keeper/keeper_types_profile_sandbox.ml
@@ -49,7 +49,9 @@ let reserved_cascade_names =
   List.sort_uniq
     String.compare
     (Keeper_config.phase_routing_cascade_names
-     @ [ Keeper_config.tool_use_strict_cascade_name ])
+     @ [ Keeper_config.default_cascade_name ()
+       ; Keeper_config.tool_use_strict_cascade_name
+       ])
 ;;
 
 (** Parse a sandbox profile string. Canonical values are ["local"] and

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -177,8 +177,9 @@ val ensure_local_discovery_ready
 (** Deterministic decision for the phase-buffer fallback boundary. This
     does not probe runtime liveness; it only decides whether the selected
     labels resolve to a probeable runtime URL before preserving the configured
-    [routes.phase_buffer] target. Legacy [local_only] aliases are normalized
-    through routes before this decision. *)
+    [routes.phase_buffer] target. Removed route aliases are left as raw
+    names; only canonical route keys resolve through routes before this
+    decision. *)
 type local_only_liveness_decision =
   | Keep_effective_cascade of string
   | Probe_local_only_urls of
@@ -196,8 +197,8 @@ val decide_local_only_liveness
 
 (** When phase routing temporarily forces the phase-buffer route, fail open to the
     keeper's configured base cascade if the probeable runtime endpoint is
-    unavailable. Explicit legacy [local_only] aliases follow the configured
-    [routes.phase_buffer] target. Exposed for targeted tests. *)
+    unavailable. Removed route aliases are not treated as phase-buffer
+    targets. Exposed for targeted tests. *)
 val fail_open_local_only_when_unavailable
   :  ?resolve_runtime_url:(string -> string option)
   -> ?probe_base_url:(string -> bool)

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -10,7 +10,7 @@ module CE = Masc_mcp.Cascade_error_classify
 module CR = Masc_mcp.Cascade_runtime
 module P = Masc_mcp.Prometheus
 
-let cascade_name = Cascade_name.of_string_exn "keeper_unified"
+let cascade_name = Cascade_name.of_string_exn "route.keeper_turn"
 let metric_max_tokens_clamped = "masc_cascade_max_tokens_clamped_total"
 
 let validate ?(provider_ceiling = Some 40960) max_tokens =
@@ -26,7 +26,7 @@ let check_violation expected_reason expected_requested expected_ceiling = functi
     check
       string
       "cascade_name"
-      "keeper_unified"
+      "route.keeper_turn"
       (CE.cascade_name_to_string cascade_name);
     check int "requested_max_tokens" expected_requested requested_max_tokens;
     check int "provider_ceiling" expected_ceiling provider_ceiling;
@@ -126,7 +126,7 @@ max-concurrent = 1
 [tier.primary]
 members = ["remote.long"]
 
-[routes.keeper_unified]
+[routes.keeper_turn]
 target = "tier.primary"
 |}
     (fun () ->
@@ -157,7 +157,7 @@ max-concurrent = 1
 [tier.primary]
 members = ["remote.narrow"]
 
-[routes.keeper_unified]
+[routes.keeper_turn]
 target = "tier.primary"
 |}
     (fun () ->
@@ -225,7 +225,7 @@ strategy = "failover"
 tiers = ["strict_tool_candidates"]
 strategy = "failover"
 
-[routes.keeper_unified]
+[routes.keeper_turn]
 target = "tier-group.strict_tool_candidates"
 |}
     (fun () ->
@@ -355,7 +355,7 @@ strategy = "failover"
 tiers = ["strict_tool_candidates", "local_recovery"]
 strategy = "failover"
 
-[routes.keeper_unified]
+[routes.keeper_turn]
 target = "tier-group.strict_tool_candidates"
 |}
     (fun () ->

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -151,7 +151,7 @@ strategy = "failover"
 tiers = ["primary", "local"]
 strategy = "priority_tier"
 
-[routes.default]
+[routes.keeper_turn]
 target = "tier-group.primary"
 
 [system.governance]

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -141,7 +141,7 @@ strategy = "failover"
 tiers = ["primary", "local"]
 strategy = "priority_tier"
 
-[routes.default]
+[routes.keeper_turn]
 target = "tier-group.primary"
 
 [system.governance]

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -130,7 +130,7 @@ strategy = "priority_tier"
 fallback = true
 keeper-assignable = true
 
-[routes.default]
+[routes.keeper_turn]
 target = "tier-group.primary"
 
 [system.governance]
@@ -288,9 +288,11 @@ keeper_assignable = false
 let test_routes () =
   let cfg = ok_config (parse_string full_toml) in
   check int "routes" 1 (List.length cfg.routes);
-  match List.find_opt (fun (r : cascade_route) -> r.name = "default") cfg.routes with
+  match
+    List.find_opt (fun (r : cascade_route) -> r.name = "keeper_turn") cfg.routes
+  with
   | Some r -> check string "route target" "tier-group.primary" r.target
-  | None -> failwith "missing default route"
+  | None -> failwith "missing keeper_turn route"
 ;;
 
 let test_system_targets () =
@@ -1333,7 +1335,7 @@ supports-image-input = true
 |}
   in
   let cfg = ok_config (parse_string toml) in
-  match model_capabilities_for_api_name cfg "model-d-spark" with
+  match model_capabilities_for_api_name cfg "model-d-5-spark" with
   | Some c ->
     check bool "parallel via prefix lookup" true c.supports_parallel_tool_calls;
     check bool "image via prefix lookup" true c.supports_image_input

--- a/test/test_cascade_declarative_validator.ml
+++ b/test/test_cascade_declarative_validator.ml
@@ -94,7 +94,7 @@ strategy = "failover"
 tiers = ["primary", "local"]
 strategy = "priority_tier"
 
-[routes.default]
+[routes.keeper_turn]
 target = "tier-group.primary"
 
 [system.governance]

--- a/test/test_cascade_phonebook_integration.ml
+++ b/test/test_cascade_phonebook_integration.ml
@@ -137,20 +137,26 @@ let test_fast_tier_group_no_thinking () =
         false m.capabilities.supports_extended_thinking
     ) models
 
-(* --- Legacy mapping integration --- *)
+(* --- Canonical route mapping integration --- *)
 
-let test_legacy_logical_use_to_phonebook_route () =
+let test_logical_route_to_phonebook_route () =
   let pb = load_fixture () in
-  (match task_use_of_legacy_logical_use "keeper_turn" with
-   | Some keeper_turn ->
-     let models = resolve_models_for_task pb default_routing_policies keeper_turn in
-     check bool "keeper_turn → at least 1 model" true (List.length models >= 1)
-   | None -> failwith "keeper_turn not mapped");
-  (match task_use_of_legacy_logical_use "adversarial_reviewer" with
-   | Some adversarial ->
-     let adv_models = resolve_models_for_task pb default_routing_policies adversarial in
-     check bool "adversarial_reviewer → at least 1 model" true (List.length adv_models >= 1)
-   | None -> failwith "adversarial_reviewer not mapped")
+  let keeper_turn =
+    Masc_mcp.Cascade_routes.task_use_of_logical_use
+      Masc_mcp.Cascade_routes.Keeper_turn
+  in
+  let models = resolve_models_for_task pb default_routing_policies keeper_turn in
+  check bool "keeper_turn -> at least 1 model" true (List.length models >= 1);
+  let adversarial =
+    Masc_mcp.Cascade_routes.task_use_of_logical_use
+      Masc_mcp.Cascade_routes.Adversarial_reviewer
+  in
+  let adv_models = resolve_models_for_task pb default_routing_policies adversarial in
+  check
+    bool
+    "adversarial_reviewer -> at least 1 model"
+    true
+    (List.length adv_models >= 1)
 
 (* --- Tier-group completeness --- *)
 
@@ -199,8 +205,8 @@ let () =
         ; test_case "thinking control per model" `Quick test_thinking_control_per_model
         ; test_case "fast tier no extended thinking" `Quick test_fast_tier_group_no_thinking
         ] )
-    ; ( "legacy_compat"
-      , [ test_case "legacy logical_use routes" `Quick test_legacy_logical_use_to_phonebook_route
+    ; ( "route_mapping"
+      , [ test_case "logical route maps to phonebook task" `Quick test_logical_route_to_phonebook_route
         ] )
     ; ( "tier_group_completeness"
       , [ test_case "all tier-groups resolve" `Quick test_all_tier_groups_resolve

--- a/test/test_cascade_routing_policy.ml
+++ b/test/test_cascade_routing_policy.ml
@@ -1,11 +1,12 @@
 (** Routing policy unit tests.
 
-    Validates task_use categories, legacy mapping,
+    Validates task_use categories, canonical route mapping,
     default policies, model resolution, and diversity constraints. *)
 
 open Alcotest
 open Masc_mcp.Cascade_phonebook_types
 open Masc_mcp.Cascade_routing_policy
+module Routes = Masc_mcp.Cascade_routes
 
 let task_use_of_string_exn (s : string) : task_use =
   match task_use_of_string s with
@@ -32,44 +33,53 @@ let test_unknown_is_none () =
   check (option string) "unknown" None
     (Option.map task_use_to_string (task_use_of_string "nonexistent"))
 
-(* --- Legacy logical_use mapping --- *)
+(* --- Canonical logical route mapping --- *)
 
-let unwrap = function Some x -> x | None -> failwith "unexpected None"
-
-let test_legacy_keeper_turn () =
-  check string "keeper_turn → Code_generation"
+let test_route_keeper_turn () =
+  check string "keeper_turn -> Code_generation"
     "code_generation"
-    (task_use_to_string (unwrap (task_use_of_legacy_logical_use "keeper_turn")))
+    (task_use_to_string
+       (Routes.task_use_of_logical_use Routes.Keeper_turn))
 
-let test_legacy_tool_required () =
-  check string "tool_required → Tool_execution"
+let test_route_tool_required () =
+  check string "tool_required -> Tool_execution"
     "tool_execution"
-    (task_use_to_string (unwrap (task_use_of_legacy_logical_use "tool_required")))
+    (task_use_to_string
+       (Routes.task_use_of_logical_use Routes.Tool_required))
 
-let test_legacy_adversarial_reviewer () =
-  check string "adversarial_reviewer → Code_review"
+let test_route_adversarial_reviewer () =
+  check string "adversarial_reviewer -> Code_review"
     "code_review"
-    (task_use_to_string (unwrap (task_use_of_legacy_logical_use "adversarial_reviewer")))
+    (task_use_to_string
+       (Routes.task_use_of_logical_use Routes.Adversarial_reviewer))
 
-let test_legacy_cross_verifier () =
-  check string "cross_verifier → Code_review"
+let test_route_cross_verifier () =
+  check string "cross_verifier -> Code_review"
     "code_review"
-    (task_use_to_string (unwrap (task_use_of_legacy_logical_use "cross_verifier")))
+    (task_use_to_string
+       (Routes.task_use_of_logical_use Routes.Cross_verifier))
 
-let test_legacy_auto_responder () =
-  check string "auto_responder → Quick_decision"
+let test_route_auto_responder () =
+  check string "auto_responder -> Quick_decision"
     "quick_decision"
-    (task_use_to_string (unwrap (task_use_of_legacy_logical_use "auto_responder")))
+    (task_use_to_string
+       (Routes.task_use_of_logical_use Routes.Auto_responder))
 
-let test_legacy_complex_task () =
-  check string "complex_task → Long_reasoning"
+let test_route_complex_task () =
+  check string "complex_task -> Long_reasoning"
     "long_reasoning"
-    (task_use_to_string (unwrap (task_use_of_legacy_logical_use "complex_task")))
+    (task_use_to_string
+       (Routes.task_use_of_logical_use Routes.Complex_task))
 
-let test_legacy_unknown () =
-  check (option string) "unknown → None"
-    None
-    (Option.map task_use_to_string (task_use_of_legacy_logical_use "something_new"))
+let test_route_aliases_are_not_accepted () =
+  List.iter
+    (fun legacy ->
+       check (option string) (legacy ^ " is not a route key") None
+         (Option.map
+            Routes.logical_use_key
+            (Routes.logical_use_of_string_opt legacy)))
+    [ ""; "default_models"; "oas-keeper_unified"; "local_only";
+      "tool_use_strict"; "resilient_breaker"; "routing_judge" ]
 
 (* --- Default routing policies --- *)
 
@@ -237,14 +247,14 @@ let () =
       , [ test_case "roundtrip" `Quick test_roundtrip
         ; test_case "unknown is None" `Quick test_unknown_is_none
         ] )
-    ; ( "legacy_mapping"
-      , [ test_case "keeper_turn" `Quick test_legacy_keeper_turn
-        ; test_case "tool_required" `Quick test_legacy_tool_required
-        ; test_case "adversarial_reviewer" `Quick test_legacy_adversarial_reviewer
-        ; test_case "cross_verifier" `Quick test_legacy_cross_verifier
-        ; test_case "auto_responder" `Quick test_legacy_auto_responder
-        ; test_case "complex_task" `Quick test_legacy_complex_task
-        ; test_case "unknown → Conversation" `Quick test_legacy_unknown
+    ; ( "route_mapping"
+      , [ test_case "keeper_turn" `Quick test_route_keeper_turn
+        ; test_case "tool_required" `Quick test_route_tool_required
+        ; test_case "adversarial_reviewer" `Quick test_route_adversarial_reviewer
+        ; test_case "cross_verifier" `Quick test_route_cross_verifier
+        ; test_case "auto_responder" `Quick test_route_auto_responder
+        ; test_case "complex_task" `Quick test_route_complex_task
+        ; test_case "aliases rejected" `Quick test_route_aliases_are_not_accepted
         ] )
     ; ( "default_policies"
       , [ test_case "count" `Quick test_policy_count

--- a/test/test_keeper_identity_parse.ml
+++ b/test/test_keeper_identity_parse.ml
@@ -36,12 +36,9 @@ let test_explicit_keeper_name_is_not_nickname_canonicalized () =
         "personality-resync-test" meta.name
   | Error e -> fail ("expected Ok, got Error: " ^ e)
 
-let test_legacy_keeper_cascade_alias_preserved_raw () =
-  (* Parse should preserve the raw cascade_name as declared in JSON so the
-     dashboard can surface config drift between the declared value and its
-     canonicalized resolution.  Legacy aliases (e.g. "oas-keeper_unified")
-     still resolve to the canonical at point-of-use via
-     [Keeper_cascade_profile.canonicalize]. *)
+let test_removed_keeper_cascade_alias_rejected () =
+  (* Removed route aliases must fail at the persisted JSON boundary instead
+     of silently collapsing to the keeper route. *)
   let json =
     `Assoc
       [
@@ -53,21 +50,22 @@ let test_legacy_keeper_cascade_alias_preserved_raw () =
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
+  | Error msg ->
+      check bool "error mentions cascade_name" true
+        (try
+           ignore
+             (Str.search_forward (Str.regexp_string "cascade_name") msg 0);
+           true
+         with
+         | Not_found -> false)
   | Ok meta ->
-      check string "legacy alias preserved raw"
-        "oas-keeper_unified" (Keeper_types.cascade_name_of_meta meta);
-      check string "legacy alias canonicalizes to default"
-        (Keeper_config.default_cascade_name ())
-        (Keeper_cascade_profile.canonicalize
-           (Keeper_types.cascade_name_of_meta meta))
-  | Error e -> fail ("expected Ok, got Error: " ^ e)
+      fail
+        ("expected removed alias rejection, got "
+         ^ Keeper_types.cascade_name_of_meta meta)
 
-let test_unknown_cascade_name_preserved_raw () =
-  (* Genuinely unknown user-declared cascade names (typos, personal
-     playground profiles, vendor drift) must survive parse so the
-     dashboard [canonical] column can show the mismatch.  Prior
-     behaviour silently collapsed them to "keeper_unified", masking
-     config drift. *)
+let test_unknown_bare_cascade_name_rejected () =
+  (* Bare cascade names are no longer accepted. Operators must use
+     canonical tier-group./tier./route. names. *)
   let json =
     `Assoc
       [
@@ -79,15 +77,21 @@ let test_unknown_cascade_name_preserved_raw () =
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
+  | Error msg ->
+      check bool "error mentions canonical prefix" true
+        (try
+           ignore
+             (Str.search_forward
+                (Str.regexp_string "canonical cascade prefix")
+                msg
+                0);
+           true
+         with
+         | Not_found -> false)
   | Ok meta ->
-      check string "raw user-declared cascade preserved"
-        "playground_experiment_xyz" (Keeper_types.cascade_name_of_meta meta);
-      (* Point-of-use canonicalize still maps unknown → default. *)
-      check string "unknown canonicalizes to default"
-        (Keeper_config.default_cascade_name ())
-        (Keeper_cascade_profile.canonicalize
-           (Keeper_types.cascade_name_of_meta meta))
-  | Error e -> fail ("expected Ok, got Error: " ^ e)
+      fail
+        ("expected bare cascade rejection, got "
+         ^ Keeper_types.cascade_name_of_meta meta)
 
 let test_missing_trace_id () =
   let json =
@@ -132,10 +136,10 @@ let () =
       , [ test_case "valid trace_id" `Quick test_valid_trace_id
         ; test_case "explicit keeper name is not nickname-canonicalized" `Quick
             test_explicit_keeper_name_is_not_nickname_canonicalized
-        ; test_case "legacy keeper cascade alias preserved raw" `Quick
-            test_legacy_keeper_cascade_alias_preserved_raw
-        ; test_case "unknown cascade name preserved raw" `Quick
-            test_unknown_cascade_name_preserved_raw
+        ; test_case "removed keeper cascade alias rejected" `Quick
+            test_removed_keeper_cascade_alias_rejected
+        ; test_case "unknown bare cascade name rejected" `Quick
+            test_unknown_bare_cascade_name_rejected
         ; test_case "missing trace_id field" `Quick test_missing_trace_id
         ; test_case "empty trace_id" `Quick test_empty_trace_id
         ; test_case "invalid trace_id (..)" `Quick test_invalid_trace_id

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -670,7 +670,7 @@ let test_load_keeper_toml_inherits_base_defaults () =
     (fun () ->
       write_file base_path {|
 [keeper]
-cascade_name = "primary"
+cascade_name = "route.keeper_turn"
 sandbox_profile = "docker"
 network_mode = "inherit"
 work_discovery_enabled = true
@@ -691,7 +691,7 @@ preset = "coding"
       | Error e -> fail e
       | Ok (name, defaults) ->
           check string "name from filename" "sangsu" name;
-          check (option string) "base cascade" (Some "primary")
+          check (option string) "base cascade" (Some "route.keeper_turn")
             defaults.cascade_name;
           check (option string) "base sandbox" (Some "docker")
             (Option.map KTP.sandbox_profile_to_string defaults.sandbox_profile);
@@ -935,7 +935,7 @@ max_turns_per_call_scheduled_autonomous = 0
        check int "zero autonomous falls back" 10
          (KTP.effective_max_turns_per_call_scheduled_autonomous d))
 
-let test_profile_normalizes_legacy_keeper_cascade_alias () =
+let test_profile_rejects_removed_keeper_cascade_alias () =
   let input = {|
 [keeper]
 goal = "test"
@@ -945,11 +945,15 @@ cascade_name = "oas-coding_first"
   | Error e -> fail e
   | Ok doc ->
     (match KTP.profile_defaults_of_toml doc with
-     | Error e -> fail e
-     | Ok d ->
-       check (option string) "legacy keeper cascade normalized"
-         (Some Masc_mcp.(Keeper_config.default_cascade_name ()))
-         d.cascade_name)
+     | Error e ->
+       check bool "removed alias rejected" true
+         (try
+            ignore
+              (Str.search_forward (Str.regexp_string "invalid cascade_name") e 0);
+            true
+          with
+          | Not_found -> false)
+     | Ok _ -> fail "expected removed keeper cascade alias rejection")
 
 let test_persona_resolver_defaults_to_research_tool_access () =
   with_personas_dir @@ fun personas_dir ->
@@ -1976,8 +1980,8 @@ let () =
             test_profile_rejects_removed_initiative_keys;
           test_case "legacy allowed_providers rejected" `Quick
             test_profile_rejects_legacy_allowed_providers;
-          test_case "legacy keeper cascade alias normalized" `Quick
-            test_profile_normalizes_legacy_keeper_cascade_alias;
+          test_case "removed keeper cascade alias rejected" `Quick
+            test_profile_rejects_removed_keeper_cascade_alias;
           test_case "max_turns overrides parsed and applied" `Quick
             test_profile_max_turns_overrides;
           test_case "max_turns defaults when absent" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6258,8 +6258,8 @@ let test_decide_local_only_liveness_keeps_explicit_local_only () =
   | UT.Keep_effective_cascade cascade ->
     check
       string
-      "legacy local_only alias follows phase-buffer route"
-      (phase_buffer_cascade_name ())
+      "removed local_only alias stays raw"
+      "local_only"
       cascade
   | UT.Probe_local_only_urls _ -> fail "unexpected local-only probe decision"
 ;;
@@ -6310,8 +6310,8 @@ let test_fail_open_local_only_preserves_explicit_local_only_base () =
   check int "probe not called" 0 !probe_calls;
   check
     string
-    "legacy local_only alias follows phase-buffer route"
-    (phase_buffer_cascade_name ())
+    "removed local_only alias stays raw"
+    "local_only"
     cascade
 ;;
 

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -781,7 +781,7 @@ let test_cascade_names_produce_models () =
     ; "classification"
     ; "verifier"
     ; "briefing"
-    ; "routing_judge"
+    ; "routing"
     ]
   in
   List.iter
@@ -791,34 +791,40 @@ let test_cascade_names_produce_models () =
     cascades
 ;;
 
-let test_cascade_inference_normalizes_keeper_aliases () =
+let test_cascade_inference_rejects_removed_keeper_aliases () =
   let json =
     `Assoc
       [ "keeper_unified_temperature", `Float 0.2
       ; "keeper_unified_max_tokens", `Int 16384
       ]
   in
-  let canonical =
-    Cascade_inference.for_json ~name:Masc_mcp.(Keeper_config.default_cascade_name ()) json
-  in
-  let legacy_oas = Cascade_inference.for_json ~name:"oas-keeper_unified" json in
-  let legacy_removed = Cascade_inference.for_json ~name:"oas-coding_first" json in
+  let canonical = Cascade_inference.for_json ~name:"keeper_unified" json in
+  let removed_oas = Cascade_inference.for_json ~name:"oas-keeper_unified" json in
+  let removed_coding = Cascade_inference.for_json ~name:"oas-coding_first" json in
   Alcotest.(check (option (float 0.0001)))
     "canonical temp"
-    canonical.temperature
-    legacy_oas.temperature;
+    (Some 0.2)
+    canonical.temperature;
   Alcotest.(check (option int))
     "canonical max_tokens"
-    canonical.max_tokens
-    legacy_oas.max_tokens;
+    (Some 16384)
+    canonical.max_tokens;
   Alcotest.(check (option (float 0.0001)))
-    "removed alias temp"
-    canonical.temperature
-    legacy_removed.temperature;
+    "removed oas alias temp"
+    None
+    removed_oas.temperature;
   Alcotest.(check (option int))
-    "removed alias max_tokens"
-    canonical.max_tokens
-    legacy_removed.max_tokens
+    "removed oas alias max_tokens"
+    None
+    removed_oas.max_tokens;
+  Alcotest.(check (option (float 0.0001)))
+    "removed coding alias temp"
+    None
+    removed_coding.temperature;
+  Alcotest.(check (option int))
+    "removed coding alias max_tokens"
+    None
+    removed_coding.max_tokens
 ;;
 
 let test_cascade_observation_json_includes_fallback_fields () =
@@ -6206,9 +6212,9 @@ let () =
             `Quick
             test_cascade_names_produce_models
         ; Alcotest.test_case
-            "cascade inference normalizes keeper aliases"
+            "cascade inference rejects removed keeper aliases"
             `Quick
-            test_cascade_inference_normalizes_keeper_aliases
+            test_cascade_inference_rejects_removed_keeper_aliases
         ; Alcotest.test_case
             "cascade observation json includes fallback fields"
             `Quick


### PR DESCRIPTION
## Summary

- remove cascade route alias matching and the `task_use_of_legacy_logical_use` bridge
- require canonical route refs (`route.<key>`) or concrete catalog names instead of bare/removed route aliases
- reject removed keeper cascade aliases at TOML and persisted-meta parse boundaries
- update route, capability, declarative parser, keeper TOML, and OAS worker tests to pin the no-backcompat behavior

Fixes #18299

## Validation

- `ocamlformat --check ...`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_cascade_routing_policy.exe test/test_cascade_phonebook_integration.exe test/test_cascade_capability_gate.exe test/test_cascade_declarative_adapter.exe test/test_cascade_declarative_hotpath.exe test/test_cascade_declarative_parser.exe test/test_cascade_declarative_validator.exe test/test_keeper_identity_parse.exe test/test_keeper_toml.exe test/test_keeper_unified.exe test/test_oas_worker.exe`
- `_build/default/test/test_cascade_routing_policy.exe`
- `_build/default/test/test_cascade_capability_gate.exe`
- `_build/default/test/test_keeper_identity_parse.exe`
- `_build/default/test/test_keeper_toml.exe`
- `_build/default/test/test_cascade_declarative_parser.exe`
- `_build/default/test/test_cascade_declarative_validator.exe`

## Local Notes

- `_build/default/test/test_cascade_phonebook_integration.exe` still fails before the changed route-mapping assertion because the fixture rejects several `provider-d-http` protocols as unknown.
- `_build/default/test/test_cascade_declarative_adapter.exe` still has an unrelated local credential fallback assertion failure for `ZAI_API_KEY`.
