### PR TITLE
[codex] Add GOAL LOOP prompt TLA specs

### DIFF
--- a/docs/observability/goal-loop-verify-pipeline.md
+++ b/docs/observability/goal-loop-verify-pipeline.md
@@ -23,14 +23,17 @@ Covered gate groups:
 - `regression_metric`: semaphore skip, pricing miss, UTF-8 repair, recovery
   execution, and admission backpressure
 - `metric_verification`: keeper turn success rate and dashboard snapshot latency
-- `tla_check`: prompt specs `TierRouting.tla`, `Validation.tla`, `Liveness.tla`
+- `tla_check`: prompt specs
+  `specs/goal-loop/{TierRouting,Validation,Liveness}.tla`
 - `log_verification`: required and forbidden post-ACT production log patterns
 - `orient_recheck`: still-present and new-finding counts from the Orient recheck
 
-The current prompt TLA spec names are intentionally checked by exact filename.
-If those specs are absent, the gate is `BLOCKED` with
-`reason: prompt_tla_spec_missing`; it is not silently satisfied by adjacent
-TLA assets.
+The current prompt TLA spec names are intentionally checked by exact filename:
+`TierRouting.tla`, `Validation.tla`, and `Liveness.tla`. If those specs are
+absent, the gate is `BLOCKED` with `reason: prompt_tla_spec_missing`; it is not
+silently satisfied by adjacent TLA assets. The clean and buggy cfg pairs under
+`specs/goal-loop/` are included in the TLA matrix shard so CI verifies both the
+happy path and the corresponding bug model.
 
 ## Completion Audit
 

--- a/scripts/lint/no-provider-name-hardcoding.allowlist
+++ b/scripts/lint/no-provider-name-hardcoding.allowlist
@@ -3,10 +3,10 @@
 # catalog/runtime-binding replacement task.
 #
 # Format: path:line:literal
-lib/cascade/cascade_runtime.ml:69:auto
-lib/cascade/cascade_runtime.ml:78:custom
-lib/cascade/cascade_runtime.ml:99:openai_compat
-lib/cascade/cascade_runtime.ml:353:auto
-lib/provider_runtime_projection.ml:111:auto
-lib/provider_runtime_projection.ml:209:auto
-lib/provider_runtime_projection.ml:257:openrouter
+lib/cascade/cascade_runtime.ml:66:auto
+lib/cascade/cascade_runtime.ml:75:custom
+lib/cascade/cascade_runtime.ml:96:openai_compat
+lib/cascade/cascade_runtime.ml:350:auto
+lib/provider_runtime_projection.ml:108:auto
+lib/provider_runtime_projection.ml:206:auto
+lib/provider_runtime_projection.ml:254:openrouter

--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -238,6 +238,13 @@ run_tlc_buggy "$REPO_ROOT/specs/state-product" "CoordinationProduct.tla"
 run_tlc "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 
+run_tlc "$REPO_ROOT/specs/goal-loop" "TierRouting.tla"
+run_tlc_buggy "$REPO_ROOT/specs/goal-loop" "TierRouting.tla"
+run_tlc "$REPO_ROOT/specs/goal-loop" "Validation.tla"
+run_tlc_buggy "$REPO_ROOT/specs/goal-loop" "Validation.tla"
+run_tlc "$REPO_ROOT/specs/goal-loop" "Liveness.tla"
+run_tlc_buggy "$REPO_ROOT/specs/goal-loop" "Liveness.tla"
+
 run_tlc "$REPO_ROOT/specs/cascade" "CascadeAttemptLiveness.tla"
 run_tlc_buggy "$REPO_ROOT/specs/cascade" "CascadeAttemptLiveness.tla"
 

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-23T17:05:01Z (HEAD: 99cd905c9)
+Generated: 2026-05-25T01:42:04Z (HEAD: 3418e92b3)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -13,12 +13,12 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | Metric | Value |
 |--------|-------|
-| Total .tla files | 100 |
-| Manual specs | 100 |
+| Total .tla files | 103 |
+| Manual specs | 103 |
 | TTrace (auto-generated) | 0 |
-| Directories | 19 |
-| Total .cfg files | 208 |
-| Buggy .cfg (bug-model pair) | 106 |
+| Directories | 20 |
+| Total .cfg files | 214 |
+| Buggy .cfg (bug-model pair) | 109 |
 
 `kind` column: **manual** = hand-authored spec; **ttrace** = TLC counterexample export (`*TTrace*` or trace marker in header). `cfg`/`buggy` columns count companion `.cfg` files. `invariants/properties` lists names per cfg label (`clean=...`, `buggy=...`). `source hash` is the tracked `.tla` blob fingerprint.
 
@@ -106,6 +106,14 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
 | CheckpointTrim.tla | CheckpointTrim | manual | 2 | 1 | clean={inv:NoOrphan, inv:CapOk} buggy={inv:NoOrphan} | 3402b580acb9 |
+
+### specs/goal-loop (3 specs)
+
+| File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
+|------|--------|------|-----|-------|-------------------------|---------------|
+| Liveness.tla | Liveness | manual | 2 | 1 | clean={inv:Safety, prop:EvidenceEventuallyPasses} buggy={inv:PassRequiresEvidence} | eddd9ed65162 |
+| TierRouting.tla | TierRouting | manual | 2 | 1 | clean={inv:Safety} buggy={inv:MissingNeverPass} | ec2a467bf853 |
+| Validation.tla | Validation | manual | 2 | 1 | clean={inv:Safety} buggy={inv:PassRequiresComplete, inv:PassRequiresAllPassed} | c1310b236bcc |
 
 ### specs/keeper-state-machine (36 specs)
 

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -148,7 +148,7 @@ check-social: BUGGY_CFGS := $(foreach d,$(SOCIAL_DIRS),$(call buggy_cfgs_in,$(d)
 check-social: check-all
 
 OTHER_DIRS := admission-queue auth autonomous boundary bug-models cascade \
-              checkpoint-trim keeper-switch-hierarchy keeper-turn-fsm \
+              checkpoint-trim goal-loop keeper-switch-hierarchy keeper-turn-fsm \
               multimodal resilience server-state shared shell-ir-first-class \
               task-lifecycle
 check-others: CLEAN_CFGS := $(foreach d,$(OTHER_DIRS),$(call clean_cfgs_in,$(d)/))

--- a/specs/goal-loop/Liveness-buggy.cfg
+++ b/specs/goal-loop/Liveness-buggy.cfg
@@ -1,0 +1,10 @@
+\* Buggy model: PASS is emitted without supplied TLC evidence.
+\* Expected: PassRequiresEvidence MUST be violated.
+
+SPECIFICATION SpecBuggy
+
+INVARIANTS
+    PassRequiresEvidence
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/goal-loop/Liveness.cfg
+++ b/specs/goal-loop/Liveness.cfg
@@ -1,0 +1,13 @@
+\* Clean model: once prompt TLA evidence is supplied, the gate eventually
+\* resolves, and PASS requires supplied evidence.
+
+SPECIFICATION Spec
+
+INVARIANTS
+    Safety
+
+PROPERTIES
+    EvidenceEventuallyPasses
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/goal-loop/Liveness.tla
+++ b/specs/goal-loop/Liveness.tla
@@ -1,0 +1,80 @@
+------------------------------- MODULE Liveness --------------------------------
+(***************************************************************************)
+(* Prompt-level Verify liveness for supplied TLA evidence.                  *)
+(*                                                                         *)
+(* Once TLC evidence for a prompt spec is supplied, the gate cannot remain  *)
+(* indefinitely unresolved. A PASS result also requires supplied evidence.  *)
+(***************************************************************************)
+
+VARIABLES phase, evidence_available, result_status
+
+vars == << phase, evidence_available, result_status >>
+
+PhaseSet == {"unobserved", "available", "resolved"}
+StatusSet == {"SKIPPED", "PASS"}
+
+TypeOK ==
+    /\ phase \in PhaseSet
+    /\ evidence_available \in BOOLEAN
+    /\ result_status \in StatusSet
+
+Init ==
+    /\ phase = "unobserved"
+    /\ evidence_available = FALSE
+    /\ result_status = "SKIPPED"
+
+WaitForEvidence ==
+    /\ phase = "unobserved"
+    /\ UNCHANGED vars
+
+SupplyEvidence ==
+    /\ phase = "unobserved"
+    /\ phase' = "available"
+    /\ evidence_available' = TRUE
+    /\ result_status' = "SKIPPED"
+
+MarkPass ==
+    /\ phase = "available"
+    /\ evidence_available
+    /\ phase' = "resolved"
+    /\ result_status' = "PASS"
+    /\ UNCHANGED evidence_available
+
+Resolved ==
+    /\ phase = "resolved"
+    /\ UNCHANGED vars
+
+NextClean ==
+    \/ WaitForEvidence
+    \/ SupplyEvidence
+    \/ MarkPass
+    \/ Resolved
+
+Spec == Init /\ [][NextClean]_vars /\ WF_vars(MarkPass)
+
+PassRequiresEvidence ==
+    result_status = "PASS" =>
+        /\ evidence_available
+        /\ phase = "resolved"
+
+EvidenceEventuallyPasses ==
+    [](evidence_available => <> (result_status = "PASS"))
+
+Safety ==
+    /\ TypeOK
+    /\ PassRequiresEvidence
+
+\* Bug model: PASS is emitted even though no TLC evidence was supplied.
+PassWithoutEvidence ==
+    /\ phase = "unobserved"
+    /\ phase' = "resolved"
+    /\ evidence_available' = FALSE
+    /\ result_status' = "PASS"
+
+NextBuggy ==
+    \/ NextClean
+    \/ PassWithoutEvidence
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+===============================================================================

--- a/specs/goal-loop/TierRouting-buggy.cfg
+++ b/specs/goal-loop/TierRouting-buggy.cfg
@@ -1,0 +1,10 @@
+\* Buggy model: a missing prompt TLA spec is incorrectly marked PASS.
+\* Expected: MissingNeverPass MUST be violated.
+
+SPECIFICATION SpecBuggy
+
+INVARIANTS
+    MissingNeverPass
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/goal-loop/TierRouting.cfg
+++ b/specs/goal-loop/TierRouting.cfg
@@ -1,0 +1,10 @@
+\* Clean model: missing, failed, or unrun prompt TLA evidence is never routed
+\* as PASS.
+
+SPECIFICATION Spec
+
+INVARIANTS
+    Safety
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/goal-loop/TierRouting.tla
+++ b/specs/goal-loop/TierRouting.tla
@@ -1,0 +1,89 @@
+------------------------------ MODULE TierRouting ------------------------------
+(***************************************************************************)
+(* Prompt-level Verify gate routing for TLA evidence.                       *)
+(*                                                                         *)
+(* The production Verify pipeline maps each exact prompt TLA filename into *)
+(* one gate status. A missing spec, failed TLC result, or unrun TLC result  *)
+(* must never be routed as PASS.                                            *)
+(***************************************************************************)
+
+VARIABLES evidence, routed_status
+
+vars == << evidence, routed_status >>
+
+EvidenceSet == {"none", "missing", "failed", "unrun", "ready"}
+StatusSet == {"BLOCKED", "FAIL", "SKIPPED", "PASS"}
+
+TypeOK ==
+    /\ evidence \in EvidenceSet
+    /\ routed_status \in StatusSet
+
+Init ==
+    /\ evidence = "none"
+    /\ routed_status = "SKIPPED"
+
+ObserveMissing ==
+    /\ evidence = "none"
+    /\ evidence' = "missing"
+    /\ routed_status' = "BLOCKED"
+
+ObserveFailed ==
+    /\ evidence = "none"
+    /\ evidence' = "failed"
+    /\ routed_status' = "FAIL"
+
+ObserveUnrun ==
+    /\ evidence = "none"
+    /\ evidence' = "unrun"
+    /\ routed_status' = "SKIPPED"
+
+ObserveReady ==
+    /\ evidence = "none"
+    /\ evidence' = "ready"
+    /\ routed_status' = "PASS"
+
+Terminal ==
+    /\ evidence # "none"
+    /\ UNCHANGED vars
+
+NextClean ==
+    \/ ObserveMissing
+    \/ ObserveFailed
+    \/ ObserveUnrun
+    \/ ObserveReady
+    \/ Terminal
+
+Spec == Init /\ [][NextClean]_vars
+
+MissingNeverPass ==
+    evidence = "missing" => routed_status # "PASS"
+
+FailedNeverPass ==
+    evidence = "failed" => routed_status # "PASS"
+
+UnrunNeverPass ==
+    evidence = "unrun" => routed_status # "PASS"
+
+ReadyPasses ==
+    evidence = "ready" => routed_status = "PASS"
+
+Safety ==
+    /\ TypeOK
+    /\ MissingNeverPass
+    /\ FailedNeverPass
+    /\ UnrunNeverPass
+    /\ ReadyPasses
+
+\* Bug model: a missing prompt spec is incorrectly treated as passing.
+MissingMarkedPass ==
+    /\ evidence = "none"
+    /\ evidence' = "missing"
+    /\ routed_status' = "PASS"
+
+NextBuggy ==
+    \/ NextClean
+    \/ MissingMarkedPass
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+===============================================================================

--- a/specs/goal-loop/Validation-buggy.cfg
+++ b/specs/goal-loop/Validation-buggy.cfg
@@ -1,0 +1,12 @@
+\* Buggy model: PASS is emitted before the required Verify gate set is
+\* complete. Expected: PassRequiresComplete or PassRequiresAllPassed MUST be
+\* violated.
+
+SPECIFICATION SpecBuggy
+
+INVARIANTS
+    PassRequiresComplete
+    PassRequiresAllPassed
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/goal-loop/Validation.cfg
+++ b/specs/goal-loop/Validation.cfg
@@ -1,0 +1,10 @@
+\* Clean model: PASS requires the exact required gate set and all required
+\* gates marked passing.
+
+SPECIFICATION Spec
+
+INVARIANTS
+    Safety
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/goal-loop/Validation.tla
+++ b/specs/goal-loop/Validation.tla
@@ -1,0 +1,96 @@
+------------------------------- MODULE Validation -------------------------------
+(***************************************************************************)
+(* Prompt-level Verify completion validation.                               *)
+(*                                                                         *)
+(* The GOAL LOOP completion audit may report PASS only after the required   *)
+(* Verify gate set has been observed and every required gate has passed.    *)
+(***************************************************************************)
+
+VARIABLES observed, passed, status
+
+vars == << observed, passed, status >>
+
+Required == {
+    "unit_tests",
+    "tla_prompt_spec_tierrouting",
+    "post_act_log_contract"
+}
+StatusSet == {"BLOCKED", "FAIL", "SKIPPED", "PASS"}
+
+TypeOK ==
+    /\ observed \subseteq Required
+    /\ passed \subseteq observed
+    /\ status \in StatusSet
+
+Init ==
+    /\ observed = {}
+    /\ passed = {}
+    /\ status = "SKIPPED"
+
+ObserveGate ==
+    \E gate \in (Required \ observed):
+        /\ observed' = observed \cup {gate}
+        /\ passed' = passed
+        /\ status' = "SKIPPED"
+
+PassGate ==
+    \E gate \in (observed \ passed):
+        /\ observed' = observed
+        /\ passed' = passed \cup {gate}
+        /\ status' = "SKIPPED"
+
+BlockIncomplete ==
+    /\ \/ observed # Required
+       \/ passed # Required
+    /\ status' = "BLOCKED"
+    /\ UNCHANGED << observed, passed >>
+
+MarkPass ==
+    /\ observed = Required
+    /\ passed = Required
+    /\ status' = "PASS"
+    /\ UNCHANGED << observed, passed >>
+
+Terminal ==
+    /\ status = "PASS"
+    /\ UNCHANGED vars
+
+NextClean ==
+    \/ ObserveGate
+    \/ PassGate
+    \/ BlockIncomplete
+    \/ MarkPass
+    \/ Terminal
+
+Spec == Init /\ [][NextClean]_vars
+
+PassRequiresComplete ==
+    status = "PASS" => observed = Required
+
+PassRequiresAllPassed ==
+    status = "PASS" => passed = Required
+
+PassedSubsetObserved ==
+    passed \subseteq observed
+
+Safety ==
+    /\ TypeOK
+    /\ PassRequiresComplete
+    /\ PassRequiresAllPassed
+    /\ PassedSubsetObserved
+
+\* Bug model: the completion audit marks PASS while required gates are still
+\* missing or not passing.
+PartialMarkedPass ==
+    /\ \/ observed # Required
+       \/ passed # Required
+    /\ status' = "PASS"
+    /\ UNCHANGED << observed, passed >>
+
+NextBuggy ==
+    \/ NextClean
+    \/ PartialMarkedPass
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+===============================================================================

--- a/test/fixtures/goal_loop/verify-pipeline.current.external-claim.json
+++ b/test/fixtures/goal_loop/verify-pipeline.current.external-claim.json
@@ -222,13 +222,13 @@
       ],
       "evidence": {
         "prompt_spec": "TierRouting.tla",
-        "resolved_path": null,
+        "resolved_path": "specs/goal-loop/TierRouting.tla",
         "result_status": null
       },
       "gate_id": "tla_prompt_spec_tierrouting",
-      "reason": "prompt_tla_spec_missing",
-      "status": "BLOCKED",
-      "summary": "Prompt TLA spec TierRouting.tla is not present in specs/."
+      "reason": "tla_result_not_supplied",
+      "status": "SKIPPED",
+      "summary": "Prompt TLA spec TierRouting.tla exists but no TLC result was supplied."
     },
     {
       "category": "tla_check",
@@ -237,13 +237,13 @@
       ],
       "evidence": {
         "prompt_spec": "Validation.tla",
-        "resolved_path": null,
+        "resolved_path": "specs/goal-loop/Validation.tla",
         "result_status": null
       },
       "gate_id": "tla_prompt_spec_validation",
-      "reason": "prompt_tla_spec_missing",
-      "status": "BLOCKED",
-      "summary": "Prompt TLA spec Validation.tla is not present in specs/."
+      "reason": "tla_result_not_supplied",
+      "status": "SKIPPED",
+      "summary": "Prompt TLA spec Validation.tla exists but no TLC result was supplied."
     },
     {
       "category": "tla_check",
@@ -252,13 +252,13 @@
       ],
       "evidence": {
         "prompt_spec": "Liveness.tla",
-        "resolved_path": null,
+        "resolved_path": "specs/goal-loop/Liveness.tla",
         "result_status": null
       },
       "gate_id": "tla_prompt_spec_liveness",
-      "reason": "prompt_tla_spec_missing",
-      "status": "BLOCKED",
-      "summary": "Prompt TLA spec Liveness.tla is not present in specs/."
+      "reason": "tla_result_not_supplied",
+      "status": "SKIPPED",
+      "summary": "Prompt TLA spec Liveness.tla exists but no TLC result was supplied."
     },
     {
       "category": "log_verification",
@@ -292,10 +292,10 @@
       "summary": "Post-ACT production log contract was not evaluated."
     }
   ],
-  "gates_blocked": 13,
+  "gates_blocked": 10,
   "gates_failed": 0,
   "gates_passed": 0,
-  "gates_skipped": 1,
+  "gates_skipped": 4,
   "gates_total": 14,
   "schema_version": 1,
   "status": "BLOCKED"

--- a/test/test_goal_loop_verify_pipeline.py
+++ b/test/test_goal_loop_verify_pipeline.py
@@ -123,6 +123,51 @@ class GoalLoopVerifyPipelineTest(unittest.TestCase):
         self.assertEqual(report.status, "BLOCKED")
         self.assertEqual(by_id["tla_prompt_spec_tierrouting"].status, "BLOCKED")
 
+    def test_prompt_tla_specs_exist_but_require_supplied_results(self) -> None:
+        report = goal_loop_verify_pipeline.build_pipeline_report(
+            repo_root=REPO_ROOT,
+            metrics_json=passing_metrics(),
+            tla_results=None,
+            log_paths=[],
+            unit_tests_passed=True,
+            unit_tests_failed=False,
+        )
+
+        by_id = {item.gate_id: item for item in report.gates}
+        for gate_id, spec_name in (
+            ("tla_prompt_spec_tierrouting", "TierRouting.tla"),
+            ("tla_prompt_spec_validation", "Validation.tla"),
+            ("tla_prompt_spec_liveness", "Liveness.tla"),
+        ):
+            self.assertEqual(by_id[gate_id].status, "SKIPPED", gate_id)
+            self.assertEqual(by_id[gate_id].reason, "tla_result_not_supplied")
+            self.assertEqual(
+                by_id[gate_id].evidence["resolved_path"],
+                f"specs/goal-loop/{spec_name}",
+            )
+
+    def test_supplied_tla_results_pass_prompt_spec_gates(self) -> None:
+        report = goal_loop_verify_pipeline.build_pipeline_report(
+            repo_root=REPO_ROOT,
+            metrics_json=passing_metrics(),
+            tla_results={
+                "TierRouting.tla": "PASS",
+                "Validation.tla": "PASS",
+                "Liveness.tla": "PASS",
+            },
+            log_paths=[],
+            unit_tests_passed=True,
+            unit_tests_failed=False,
+        )
+
+        by_id = {item.gate_id: item for item in report.gates}
+        for gate_id in (
+            "tla_prompt_spec_tierrouting",
+            "tla_prompt_spec_validation",
+            "tla_prompt_spec_liveness",
+        ):
+            self.assertEqual(by_id[gate_id].status, "PASS", gate_id)
+
     def test_metric_gate_commands_reference_snapshot_metric_keys(self) -> None:
         report = goal_loop_verify_pipeline.build_pipeline_report(
             repo_root=REPO_ROOT,
@@ -214,7 +259,7 @@ class GoalLoopVerifyPipelineTest(unittest.TestCase):
         self.assertEqual(by_id["post_act_log_contract"].status, "FAIL")
         self.assertEqual(by_id["post_act_log_contract"].reason, "log_contract_failed")
 
-    def test_cli_require_pass_returns_nonzero_for_blocked_tla_specs(self) -> None:
+    def test_cli_require_pass_returns_nonzero_for_incomplete_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as raw_dir:
             metrics_path = Path(raw_dir) / "metrics.json"
             metrics_path.write_text(json.dumps(passing_metrics()), encoding="utf-8")
@@ -237,6 +282,7 @@ class GoalLoopVerifyPipelineTest(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertEqual(payload["status"], "BLOCKED")
         self.assertGreater(payload["gates_blocked"], 0)
+        self.assertGreater(payload["gates_skipped"], 0)
 
     def test_emitted_gate_ids_match_required_contract(self) -> None:
         # Real build path emits exactly the REQUIRED_VERIFY_GATE_IDS set


### PR DESCRIPTION
## Summary
- add the exact prompt-level TLA specs required by the GOAL LOOP Verify pipeline: `TierRouting.tla`, `Validation.tla`, and `Liveness.tla`
- add clean and buggy cfg pairs under `specs/goal-loop/` and wire the directory into both the TLA matrix shard and `scripts/tla-check.sh`
- refresh the Verify pipeline fixture/tests so existing-but-unrun prompt specs become `tla_result_not_supplied` instead of `prompt_tla_spec_missing`
- refresh the provider-name ratchet allowlist line numbers after rebasing onto current `main`

## Why
The Verify pipeline already had strict gate IDs for these prompt spec names, but the files did not exist, so GOAL LOOP verification stayed blocked at the prompt TLA layer. This makes the contract concrete and keeps missing-spec behavior covered with a temp-repo test.

## Validation
- `python3 test/test_goal_loop_verify_pipeline.py`
- `make -C specs check-clean CLEAN_CFGS='goal-loop/Liveness.cfg goal-loop/TierRouting.cfg goal-loop/Validation.cfg'`
- `make -C specs check-buggy BUGGY_CFGS='goal-loop/Liveness-buggy.cfg goal-loop/TierRouting-buggy.cfg goal-loop/Validation-buggy.cfg'`
- `make -C specs check-matrix-coverage`
- `bash scripts/ci/check-tla-harness-coverage.sh`
- `bash scripts/lint/no-provider-name-hardcoding.sh --fail`
- `git diff --check`
- `git diff --cached --check`