### PR TITLE
refactor(cascade): rename legacy runner observation surface

### DIFF
--- a/ci/code-smell-baseline.json
+++ b/ci/code-smell-baseline.json
@@ -465,7 +465,7 @@
           "value": 3
         },
         {
-          "file": "lib/cascade/cascade_legacy_runner.ml",
+          "file": "lib/cascade/cascade_observation.ml",
           "value": 5
         },
         {

--- a/docs/architecture/runtime-lens-boundary.md
+++ b/docs/architecture/runtime-lens-boundary.md
@@ -32,7 +32,7 @@ surfaces.
 | Surface | Owner | Carve-out site | Test |
 |---|---|---|---|
 | "Validated active cascade catalog" boot log | `Cascade_catalog_runtime.candidate_probe_to_yojson` (called from `server_runtime_bootstrap.ml`) | #15070 commit `fd50aa68f6` | `test/test_cascade_catalog_runtime_yojson.ml` "candidate_probe real identity" |
-| Audit log (`record_cascade_audit`) | `Cascade_legacy_runner.cascade_attempt_to_json` / `cascade_fallback_event_to_json` (called from `cascade_observation_to_json`) | #15070 commit `f567e57272` | `test/test_cascade_catalog_runtime_yojson.ml` "cascade_observation audit-log real identity" |
+| Audit log (`record_cascade_audit`) | `Cascade_observation.cascade_attempt_to_json` / `cascade_fallback_event_to_json` (called from `cascade_observation_to_json`) | #15070 commit `f567e57272` | `test/test_cascade_catalog_runtime_yojson.ml` "cascade_observation audit-log real identity" |
 
 ## Decision rule for future serializers
 
@@ -48,7 +48,7 @@ identity, ask:
 2. **Is there already a `redacted_*` companion?** If yes, treat the
    non-prefixed variant as internal and emit real. (See
    `Keeper_unified_metrics.redacted_cascade_attempt_to_json` paired
-   with `Cascade_legacy_runner.cascade_attempt_to_json`.)
+   with `Cascade_observation.cascade_attempt_to_json`.)
 
 3. **Does a sibling field in the same envelope emit real values?** If
    yes, the inner record should match. #15040 introduced

--- a/docs/audit/2026-05-12-keeper-oas-agent-runtime-flow-comparison.md
+++ b/docs/audit/2026-05-12-keeper-oas-agent-runtime-flow-comparison.md
@@ -277,7 +277,7 @@ flowchart TD
 | Tool capability filter | MASC/OAS bridge | `Provider_tool_support.apply_required_tool_use_filter` and `resolve_tool_lane_for_oas_tools` |
 | Provider attempt timeout | MASC | `effective_provider_attempt_timeout_s` |
 | Agent loop and tool execution per attempt | OAS | `Agent.run` -> pipeline |
-| Cascade observation and receipt | MASC | `Cascade_legacy_runner.cascade_observation_with_metrics`, `Keeper_execution_receipt` |
+| Cascade observation and receipt | MASC | `Cascade_observation.cascade_observation_with_metrics`, `Keeper_execution_receipt` |
 
 ### Key Reflection
 

--- a/docs/rfc/RFC-0047-oas-adapter-decomposition.md
+++ b/docs/rfc/RFC-0047-oas-adapter-decomposition.md
@@ -204,7 +204,7 @@ prefix removes the gravity well.
 | `oas_event_bridge.ml` | move (already bridge-shaped) | `lib/cascade/cascade_event_bridge.ml` | 5 |
 | `oas_events.ml` | move + invert push→subscribe | `lib/cascade/cascade_events.ml` | 5 |
 | `oas_model_resolve.ml` | move | `lib/cascade/cascade_model_resolve.ml` | 3 |
-| `oas_worker_cascade.ml` | move (legacy cascade entry) | `lib/cascade/cascade_legacy_runner.ml` | 3 |
+| `oas_worker_cascade.ml` | move (cascade observation entry) | `lib/cascade/cascade_observation.ml` | 3 |
 | `oas_worker_named_cascade.ml` | move | `lib/cascade/cascade_oas_runner.ml` | 3 |
 | `oas_worker_named_fsm.ml` | move | `lib/cascade/cascade_attempt_fsm.ml` | 3 |
 | `oas_worker_named_error.ml` | move | `lib/cascade/cascade_error_classify.ml` | 3 |
@@ -249,7 +249,7 @@ Build-green hard gate at every PR.
 
 **Scope correction (during Phase 2 PR, 2026-05-08).** The original RFC
 listed 4 files. Inspection found `lib/oas_worker.ml` is structurally a
-**facade** — `include Cascade_runner`, `include Cascade_legacy_runner`,
+**facade** — `include Cascade_runner`, `include Cascade_observation`,
 `include Keeper_turn_driver` — over three modules that are NOT clean
 (Phase 3 / Phase 4 targets). Renaming the facade alone produces an
 `Agent_sdk_call` module that still re-exports `Keeper_turn_driver.run_named`,

--- a/docs/rfc/RFC-0071-inventory.csv
+++ b/docs/rfc/RFC-0071-inventory.csv
@@ -114,7 +114,7 @@ lib/cascade/cascade_event_bridge.ml,126,(),unclassified
 lib/cascade/cascade_event_bridge.ml,815,None,unclassified
 lib/cascade/cascade_event_bridge.ml,830,false,unclassified
 lib/cascade/cascade_http_probe.ml,117,None,unclassified
-lib/cascade/cascade_legacy_runner.ml,174,None,unclassified
+lib/cascade/cascade_observation.ml,174,None,unclassified
 lib/cascade/cascade_pool.ml,21,None,unclassified
 lib/cascade_ref/cascade_ref.ml,101,None,unclassified
 lib/cascade_ref/cascade_ref.ml,118,None,unclassified

--- a/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
+++ b/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
@@ -233,7 +233,7 @@ PR-14 CI lint `ci/lint-no-direct-dispatch.sh`가 강제.
 |---|---|
 | **OAS Agent SDK ↔ masc-mcp keeper runtime** | masc-mcp의 oas usage는 `Worker_oas` 단일 module에 집중. 역방향 의존 0. (RFC-OAS-011 + SDK Independence Gate strict mode 이미 강제) |
 | **Public MCP ↔ Internal** | `Surface.Public_mcp` vs 그 외. 같은 dispatch path, 다른 capability set. |
-| **Runtime lens (외부 `"runtime"` placeholder vs 내부 real provider)** | `lib/cascade/cascade_catalog_runtime.candidate_probe_to_yojson` + `cascade_legacy_runner.cascade_attempt_to_json` carve-out — typed surface로 명시. 메모리 `reference_runtime_lens_boundary_carve_out`. |
+| **Runtime lens (외부 `"runtime"` placeholder vs 내부 real provider)** | `lib/cascade/cascade_catalog_runtime.candidate_probe_to_yojson` + `cascade_observation.cascade_attempt_to_json` carve-out — typed surface로 명시. 메모리 `reference_runtime_lens_boundary_carve_out`. |
 | **Boot policy ↔ runtime route** | 같은 `Tool_resolution.resolve` 결과를 *재사용*. 두 번 결정하지 않음 (PR-6). |
 
 ---

--- a/docs/rfc/RFC-0090-write-side-success-model-attribution.md
+++ b/docs/rfc/RFC-0090-write-side-success-model-attribution.md
@@ -72,7 +72,7 @@ L969 branch 의 코드 주석은 *"Should be unreachable with accept_on_exhausti
 ```ocaml
 (* before *)
 let observation =
-  Cascade_legacy_runner.cascade_observation_with_metrics
+  Cascade_observation.cascade_observation_with_metrics
     ~cascade_name:error_cascade_name
     ?strategy:!cascade_strategy_name_ref ~configured_labels
     ~candidate_count ~selected_model_raw:None ~capture ()
@@ -82,7 +82,7 @@ in
 ```ocaml
 (* after *)
 let observation =
-  Cascade_legacy_runner.cascade_observation_with_metrics
+  Cascade_observation.cascade_observation_with_metrics
     ~cascade_name:error_cascade_name
     ?strategy:!cascade_strategy_name_ref ~configured_labels
     ~candidate_count

--- a/docs/rfc/RFC-0132-redaction-ssot.md
+++ b/docs/rfc/RFC-0132-redaction-ssot.md
@@ -101,7 +101,7 @@ Decomposed by shape:
 | File | Line | Constant name |
 |---|---|---|
 | `lib/cascade/cascade_catalog_runtime_probe.ml` | 14–15 | `public_runtime_provider_label`, `public_runtime_model_label` |
-| `lib/cascade/cascade_legacy_runner.ml` | 49 | `public_runtime_model_label` |
+| `lib/cascade/cascade_observation.ml` | 49 | `public_runtime_model_label` |
 | `lib/cascade/cascade_attempt_liveness_observer.ml` | 34 | `public_runtime_provider_label` |
 | `lib/cascade/cascade_attempt_fsm.ml` | 556 | `public_runtime_provider_label` |
 | `lib/cascade/cascade_attempt_liveness_config.ml` | 92 | `runtime_candidate_key` |

--- a/docs/rfc/RFC-0166-mcp-client-coupling-closeout.md
+++ b/docs/rfc/RFC-0166-mcp-client-coupling-closeout.md
@@ -33,7 +33,7 @@ The big-bang inventory (2026-05-24) measured:
 | `lib/server/server_runtime_bootstrap.ml` agent-code hits | 0 | Already clean |
 | `bin/gen_tool_descriptors.ml` MCP-client examples | 5 | Cleared (description text → free-form) |
 | `lib/cascade/cascade_config_provider_filter.ml` comment | 1 | Cleared (comment rewritten) |
-| `lib/cascade/cascade_config.mli`, `cascade_config_loader.ml`, `cascade_config_parser.ml`, `cascade_legacy_runner.{ml,mli}` JSON/docstring examples | ~6 | Cleared |
+| `lib/cascade/cascade_config.mli`, `cascade_config_loader.ml`, `cascade_config_parser.ml`, `cascade_observation.{ml,mli}` JSON/docstring examples | ~6 | Cleared |
 | `lib/cascade/cascade_event_bridge_inference.ml` `inference_model_bucket` | substring classifier | Body collapsed to `"upstream"` (label cardinality = 1) |
 | `lib/cascade/cascade_config_builder.ml` `binding.command = "agent-code"` dispatch | 1 | `provider_requires_argv_prompt_preflight` always returns `false` (legacy agent-code preflight path effectively disabled) |
 | `lib/notify.ml` agent emoji roster (`agent-llm-a`/`provider-f`/`agent-code`/`llama`) | 4 | Roster emptied; operators register via `register_agent_emoji` |

--- a/lib/cascade/cascade_metrics.ml
+++ b/lib/cascade/cascade_metrics.ml
@@ -796,7 +796,7 @@ let metric_cascade_invariant_violation =
 let on_cascade_invariant_violation () =
   Prometheus.inc_counter metric_cascade_invariant_violation ()
 
-(* [Cascade_legacy_runner]'s in-memory cascade-counter table is
+(* [Cascade_observation]'s in-memory cascade-counter table is
    bounded by [cascade_max_keys].  When a new cascade name arrives
    and the table is full, the LRU entry is silently evicted and the
    existing WARN-once line logs the eviction event.  Operators
@@ -822,7 +822,7 @@ let metric_max_tokens_clamped = "masc_cascade_max_tokens_clamped_total"
 let on_max_tokens_clamped () =
   Prometheus.inc_counter metric_max_tokens_clamped ()
 
-(* [Cascade_legacy_runner] persists cascade-decision audit records
+(* [Cascade_observation] persists cascade-decision audit records
    to [Dated_jsonl] storage for post-incident analysis.  Two
    exception arms swallow non-cancellation failures with only a
    WARN log:

--- a/lib/cascade/cascade_metrics.mli
+++ b/lib/cascade/cascade_metrics.mli
@@ -266,7 +266,7 @@ val on_cascade_invariant_violation : unit -> unit
 
 val on_cascade_metrics_eviction : unit -> unit
 (** Tick the cascade-metrics LRU eviction counter at
-    [Cascade_legacy_runner] when the in-memory cascade-counter
+    [Cascade_observation] when the in-memory cascade-counter
     table evicts an LRU entry to admit a new cascade name.  High
     rate signals cascade-name churn — either raise
     [cascade_max_keys] or canonicalize synthesized names. *)
@@ -279,7 +279,7 @@ val on_max_tokens_clamped : unit -> unit
 
 val on_cascade_audit_failure : stage:string -> unit
 (** Tick the cascade-audit subsystem failure counter at
-    [Cascade_legacy_runner].  [stage] must be one of
+    [Cascade_observation].  [stage] must be one of
     [store_creation] (JSONL store init failed) or [append]
     (single record append failed).  Audit subsystem failures
     don't break keeper turns but compromise post-incident

--- a/lib/cascade/cascade_observation.ml
+++ b/lib/cascade/cascade_observation.ml
@@ -1,4 +1,4 @@
-(** Cascade_legacy_runner — Cascade metrics types, observation building, and recording.
+(** Cascade_observation — Cascade metrics types, observation building, and recording.
 
     Tracks per-cascade call counts, model selection distribution, fallback
     hops, and per-attempt latency/error detail. Aggregate counters stay
@@ -47,7 +47,7 @@ and cascade_fallback_event = {
 
 module StringMap = Map.Make(String)
 
-(* RFC-0132 PR-2: legacy-runner OAS/dashboard surface = external boundary; redact via SSOT. *)
+(* RFC-0132 PR-2: cascade observation OAS/dashboard surface = external boundary; redact via SSOT. *)
 let public_runtime_model_label =
   Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 

--- a/lib/cascade/cascade_observation.mli
+++ b/lib/cascade/cascade_observation.mli
@@ -1,4 +1,4 @@
-(** Cascade_legacy_runner — cascade observation, metrics
+(** Cascade_observation — cascade observation, metrics
     capture, and a single-actor cascade-counter store.
 
     The .ml splits into two concerns:
@@ -14,7 +14,7 @@
       callers do not contend on the in-memory counter
       maps.
 
-    Dotted callers ({!Cascade_legacy_runner.X}) and the
+    Dotted callers ({!Cascade_observation.X}) and the
     cascade-include consumer rely on the surface pinned here.
 
     Internal helpers stay private at this boundary
@@ -216,7 +216,7 @@ val cascade_metrics_json : unit -> Yojson.Safe.t
     aggregated cascade-counter JSON snapshot for the
     operator dashboard.  Pinned because
     [lib/oas_worker.mli] re-exposes it via the
-    [include Cascade_legacy_runner] cascade. *)
+    [include Cascade_observation] cascade. *)
 
 val cascade_observation_to_json :
   cascade_observation -> Yojson.Safe.t

--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -2,7 +2,7 @@
 
     Contains the [config] type, [build], [run], and [run_with_masc_tools]
     functions. All model-selection and cascade logic lives in
-    {!Cascade_legacy_runner} and {!Keeper_turn_driver}.
+    {!Cascade_observation} and {!Keeper_turn_driver}.
 
     @since God file decomposition — extracted from oas_worker.ml *)
 
@@ -93,7 +93,7 @@ type run_result = {
   trace_ref : Agent_sdk.Raw_trace.run_ref option;
   run_validation : Agent_sdk.Raw_trace.run_validation option;
   proof : Masc_mcp_cdal_runtime.Cdal_proof.t option;
-  cascade_observation : Cascade_legacy_runner.cascade_observation option;
+  cascade_observation : Cascade_observation.cascade_observation option;
   stop_reason : stop_reason;
 }
 

--- a/lib/cascade/cascade_runner.mli
+++ b/lib/cascade/cascade_runner.mli
@@ -10,7 +10,7 @@
     diagnostics) are owned by {!Cascade_transport}.
 
     All model-selection and cascade logic lives in
-    {!Cascade_legacy_runner} and {!Keeper_turn_driver}.
+    {!Cascade_observation} and {!Keeper_turn_driver}.
 
     Internal helpers stay private at this boundary
     ([invalid_runtime_config],
@@ -133,7 +133,7 @@ type run_result = {
   trace_ref : Agent_sdk.Raw_trace.run_ref option;
   run_validation : Agent_sdk.Raw_trace.run_validation option;
   proof : Masc_mcp_cdal_runtime.Cdal_proof.t option;
-  cascade_observation : Cascade_legacy_runner.cascade_observation option;
+  cascade_observation : Cascade_observation.cascade_observation option;
   stop_reason : stop_reason;
 }
 

--- a/lib/dashboard_cascade_audit_runs.ml
+++ b/lib/dashboard_cascade_audit_runs.ml
@@ -216,7 +216,7 @@ let audit_runs_json ?(dashboard_surface = "/api/v1/cascade/audit_runs") ~base_pa
     ; ( "retention"
       , retention_json
           ~scope:"cascade_audit_runs"
-          ~producer:"Cascade_legacy_runner.cascade_observation_to_json"
+          ~producer:"Cascade_observation.cascade_observation_to_json"
           ~store_kind:"dated_jsonl"
           ~durable_store:audit_store_dir
           ~cache_policy:"uncached; reads recent persisted JSONL rows newest first"

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -347,7 +347,7 @@ let checkpoint_persistence_error ~keeper_name ~detail =
 
 let cascade_outcome_of_observation
     : _ -> Keeper_execution_receipt.cascade_outcome = function
-  | Some (obs : Cascade_legacy_runner.cascade_observation) when obs.fallback_applied ->
+  | Some (obs : Cascade_observation.cascade_observation) when obs.fallback_applied ->
     Keeper_execution_receipt.Cascade_passed_to_next_model
   | Some _ -> Keeper_execution_receipt.Cascade_completed
   | None -> Keeper_execution_receipt.Cascade_not_observed

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -101,5 +101,5 @@ val checkpoint_persistence_error
     ([Cascade_passed_to_next_model] / [Cascade_completed] /
     [Cascade_not_observed]). *)
 val cascade_outcome_of_observation
-  :  Cascade_legacy_runner.cascade_observation option
+  :  Cascade_observation.cascade_observation option
   -> Keeper_execution_receipt.cascade_outcome

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -46,7 +46,7 @@ type run_result =
   ; model_used : string
   ; prompt_metrics : prompt_metrics
   ; ctx_composition : ctx_composition_metrics
-  ; cascade_observation : Cascade_legacy_runner.cascade_observation option
+  ; cascade_observation : Cascade_observation.cascade_observation option
   ; turn_count : int
   ; tool_calls_made : int
   ; usage : Agent_sdk.Types.api_usage

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -16,7 +16,7 @@ type run_result =
   ; model_used : string
   ; prompt_metrics : Keeper_agent_prompt_metrics.prompt_metrics
   ; ctx_composition : Keeper_agent_prompt_metrics.ctx_composition_metrics
-  ; cascade_observation : Cascade_legacy_runner.cascade_observation option
+  ; cascade_observation : Cascade_observation.cascade_observation option
   ; turn_count : int
   ; tool_calls_made : int
   ; usage : Agent_sdk.Types.api_usage

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -85,7 +85,7 @@ type run_result =
   ; model_used : string
   ; prompt_metrics : prompt_metrics
   ; ctx_composition : ctx_composition_metrics
-  ; cascade_observation : Cascade_legacy_runner.cascade_observation option
+  ; cascade_observation : Cascade_observation.cascade_observation option
   ; turn_count : int
   ; tool_calls_made : int
   ; usage : Agent_sdk.Types.api_usage

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -103,7 +103,7 @@ let cascade_rotation_outcome_to_string = function
 (* Receipt-level summary of how the in-turn cascade attempt sequence
    ended.  Closed set across two producer paths:
      - [Keeper_agent_error.cascade_outcome_of_observation] — 3 values
-       sourced from [Cascade_legacy_runner.cascade_observation].
+       sourced from [Cascade_observation.cascade_observation].
      - [keeper_turn_helpers.build_pending_receipt] — emits
        [Cascade_not_dispatched] for pre-dispatch pending receipts.
    JSON wire form is the lowercase string via

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -87,7 +87,7 @@ type agent_setup =
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
   ; receipt_stop_reason_ref : Cascade_runner.stop_reason option ref
-  ; receipt_cascade_observation_ref : Cascade_legacy_runner.cascade_observation option ref
+  ; receipt_cascade_observation_ref : Cascade_observation.cascade_observation option ref
   ; receipt_response_text_present_ref : bool ref
   ; reported_tool_names_ref : string list ref
   ; observed_tool_names_ref : string list ref
@@ -516,7 +516,7 @@ let prepare_agent_setup
     ref None
   in
   let receipt_cascade_observation_ref
-    : Cascade_legacy_runner.cascade_observation option ref
+    : Cascade_observation.cascade_observation option ref
     =
     ref None
   in

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -102,7 +102,7 @@ type agent_setup =
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
   ; receipt_stop_reason_ref : Cascade_runner.stop_reason option ref
-  ; receipt_cascade_observation_ref : Cascade_legacy_runner.cascade_observation option ref
+  ; receipt_cascade_observation_ref : Cascade_observation.cascade_observation option ref
   ; receipt_response_text_present_ref : bool ref
   ; reported_tool_names_ref : string list ref
   ; observed_tool_names_ref : string list ref

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -592,7 +592,7 @@ let run_named
   | _ ->
   let candidate_count = List.length candidates in
   let capture, _metrics =
-    Cascade_legacy_runner.cascade_metrics_for_candidates ~candidate_count ()
+    Cascade_observation.cascade_metrics_for_candidates ~candidate_count ()
   in
   let cascade_strategy_name_ref = ref None in
   let name = Printf.sprintf "oas-%s" cascade_name in
@@ -1050,12 +1050,12 @@ let run_named
         | None -> Keeper_types.No_providers_available
       in
       let observation =
-        Cascade_legacy_runner.cascade_observation_with_metrics
+        Cascade_observation.cascade_observation_with_metrics
           ~cascade_name:error_cascade_name
           ?strategy:!cascade_strategy_name_ref ~configured_labels
           ~candidate_count ~selected_model_raw:error_selected_model_raw ~capture ()
       in
-      Cascade_legacy_runner.record_cascade ~keeper_name
+      Cascade_observation.record_cascade ~keeper_name
         ~cascade_name:error_cascade_name
         ~outcome:`Failure ~observation:(Some observation) ();
       let terminal_error =
@@ -1282,7 +1282,7 @@ let run_named
       | `Full (capacity_key, retry_after_s) ->
         emit_capacity_blocked_manifest ~capacity_key;
         record_cascade_attempt candidate ~outcome:(`Failure "client_capacity_full") ();
-        Cascade_legacy_runner.record_fallback_event capture
+        Cascade_observation.record_fallback_event capture
           ~from_model:runtime_candidate_label
           ~to_model:runtime_candidate_label
           ~reason:"client_capacity_full";
@@ -1405,7 +1405,7 @@ let run_named
           then Some (int_of_float attempt_latency_ms)
           else None
         in
-        Cascade_legacy_runner.record_attempt_terminal capture
+        Cascade_observation.record_attempt_terminal capture
           ~model_id:runtime_candidate_label ~latency_ms ~error
       in
       let attempt_with_admission =
@@ -1505,7 +1505,7 @@ let run_named
         emit_tier_admission_blocked_manifest signal;
         emit_cascade_tier_admission_signal_metric ~cascade_name signal;
         record_cascade_attempt candidate ~outcome:(`Failure "tier_admission_full") ();
-        Cascade_legacy_runner.record_fallback_event capture
+        Cascade_observation.record_fallback_event capture
           ~from_model:runtime_candidate_label
           ~to_model:runtime_candidate_label
           ~reason:"tier_admission_full";
@@ -1559,7 +1559,7 @@ let run_named
         record_candidate_success candidate ~latency_ms:attempt_latency_ms result;
         (* FSM: Call_ok → Accept *)
         let observation =
-          Cascade_legacy_runner.cascade_observation_with_metrics
+          Cascade_observation.cascade_observation_with_metrics
             ~cascade_name:error_cascade_name
             ?strategy:!cascade_strategy_name_ref ~configured_labels
             ~candidate_count ~selected_model_raw:(success_selected_model_raw candidate)
@@ -1568,7 +1568,7 @@ let run_named
           ()
         in
         let result = { result with cascade_observation = Some observation } in
-                Cascade_legacy_runner.record_cascade ~keeper_name
+                Cascade_observation.record_cascade ~keeper_name
                   ~cascade_name:error_cascade_name
                   ~outcome:`Success ~observation:(Some observation) ();
                 record_cascade_attempt candidate ~outcome:`Success ();
@@ -1594,7 +1594,7 @@ let run_named
            record_accepted_liveness_sample ();
            record_candidate_success candidate ~latency_ms:attempt_latency_ms result;
            let observation =
-             Cascade_legacy_runner.cascade_observation_with_metrics
+             Cascade_observation.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_count ~selected_model_raw:(success_selected_model_raw candidate)
@@ -1603,7 +1603,7 @@ let run_named
           ()
            in
            let result = { result with cascade_observation = Some observation } in
-                   Cascade_legacy_runner.record_cascade ~keeper_name
+                   Cascade_observation.record_cascade ~keeper_name
                      ~cascade_name:error_cascade_name
                      ~outcome:`Success ~observation:(Some observation) ();
                    record_cascade_attempt candidate ~outcome:`Success ();
@@ -1615,7 +1615,7 @@ let run_named
               can distinguish recovery-in-progress from hard failures. *)
            record_candidate_health_rejected candidate ~reason;
            Log.Misc.info "[cascade-fallback] cascade %s: accept rejected %s (%s), trying next" cascade_name runtime_candidate_label reason;
-           Cascade_legacy_runner.record_fallback_event capture
+           Cascade_observation.record_fallback_event capture
              ~from_model:runtime_candidate_label ~to_model:runtime_candidate_label ~reason;
            (* The rejected response is not trusted progress.  Resuming
               from its checkpoint can turn a fallback provider into a
@@ -1628,7 +1628,7 @@ let run_named
          | Cascade_fsm.Exhausted _ ->
            record_candidate_health_rejected candidate ~reason;
            let observation =
-             Cascade_legacy_runner.cascade_observation_with_metrics
+             Cascade_observation.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_count ~selected_model_raw:error_selected_model_raw
@@ -1636,7 +1636,7 @@ let run_named
           ~oas_internal_cascade_allowed:(Keeper_cascade_engine.allows_oas_internal_cascade cascade_engine)
           ()
            in
-           Cascade_legacy_runner.record_cascade ~keeper_name
+           Cascade_observation.record_cascade ~keeper_name
              ~cascade_name:error_cascade_name
              ~outcome:`Rejected ~observation:(Some observation) ();
            Log.Misc.error "cascade %s exhausted: all tiers rejected by accept predicate (last runtime=%s, reason=%s)"
@@ -1661,7 +1661,7 @@ let run_named
            record_accepted_liveness_sample ();
            record_candidate_success candidate ~latency_ms:attempt_latency_ms result;
            let observation =
-             Cascade_legacy_runner.cascade_observation_with_metrics
+             Cascade_observation.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_count ~selected_model_raw:(success_selected_model_raw candidate)
@@ -1670,7 +1670,7 @@ let run_named
           ()
            in
            let result = { result with cascade_observation = Some observation } in
-                   Cascade_legacy_runner.record_cascade ~keeper_name
+                   Cascade_observation.record_cascade ~keeper_name
                      ~cascade_name:error_cascade_name
                      ~outcome:`Success ~observation:(Some observation) ();
                    record_cascade_attempt candidate ~outcome:`Success ();
@@ -1784,7 +1784,7 @@ let run_named
                   "[cascade-fallback] cascade %s: %s failed (%s%s), trying next"
                   cascade_name runtime_candidate_label class_label
                   (Agent_sdk.Error.to_string sdk_err);
-              Cascade_legacy_runner.record_fallback_event capture
+              Cascade_observation.record_fallback_event capture
                 ~from_model:runtime_candidate_label ~to_model:runtime_candidate_label
                 ~reason:(class_label ^ Agent_sdk.Error.to_string sdk_err);
               let retry_resume_checkpoint =
@@ -1809,12 +1809,12 @@ let run_named
                 new_err
             | Cascade_fsm.Exhausted _ ->
               let observation =
-                Cascade_legacy_runner.cascade_observation_with_metrics
+                Cascade_observation.cascade_observation_with_metrics
                   ~cascade_name:error_cascade_name
                   ?strategy:!cascade_strategy_name_ref ~configured_labels
                   ~candidate_count ~selected_model_raw:error_selected_model_raw ~capture ()
               in
-              Cascade_legacy_runner.record_cascade ~keeper_name
+              Cascade_observation.record_cascade ~keeper_name
                 ~cascade_name:error_cascade_name
                 ~outcome:`Failure ~observation:(Some observation) ();
               let log =
@@ -1839,12 +1839,12 @@ let run_named
          | None ->
            (* Non-API error (agent, config, etc.) — not cascadeable *)
            let observation =
-             Cascade_legacy_runner.cascade_observation_with_metrics
+             Cascade_observation.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_count ~selected_model_raw:error_selected_model_raw ~capture ()
            in
-           Cascade_legacy_runner.record_cascade ~keeper_name
+           Cascade_observation.record_cascade ~keeper_name
              ~cascade_name:error_cascade_name
              ~outcome:`Failure ~observation:(Some observation) ();
            Log.Misc.error "cascade %s: non-cascadable error from %s: %s"
@@ -1899,12 +1899,12 @@ let run_named
   in
   let cascade_exhausted_after_filter ~cycle =
     let observation =
-      Cascade_legacy_runner.cascade_observation_with_metrics
+      Cascade_observation.cascade_observation_with_metrics
         ~cascade_name:error_cascade_name
         ?strategy:!cascade_strategy_name_ref ~configured_labels
         ~candidate_count ~selected_model_raw:error_selected_model_raw ~capture ()
     in
-    Cascade_legacy_runner.record_cascade ~keeper_name
+    Cascade_observation.record_cascade ~keeper_name
       ~cascade_name:error_cascade_name
       ~outcome:`Failure ~observation:(Some observation) ();
     Error

--- a/lib/keeper/keeper_unified_metrics_json_support.ml
+++ b/lib/keeper/keeper_unified_metrics_json_support.ml
@@ -52,7 +52,7 @@ let provider_context_json ~(meta : keeper_meta)
         ]
 
 let redacted_cascade_attempt_to_json
-    (attempt : Cascade_legacy_runner.cascade_attempt) : Yojson.Safe.t =
+    (attempt : Cascade_observation.cascade_attempt) : Yojson.Safe.t =
   `Assoc
     [ "attempt_index", `Int attempt.attempt_index
     ; ( "latency_ms"
@@ -67,12 +67,12 @@ let redacted_cascade_attempt_to_json
 ;;
 
 let redacted_cascade_fallback_event_to_json
-    (event : Cascade_legacy_runner.cascade_fallback_event) : Yojson.Safe.t =
+    (event : Cascade_observation.cascade_fallback_event) : Yojson.Safe.t =
   `Assoc [ "reason", `String event.reason ]
 ;;
 
 let redacted_cascade_observation_to_json
-    (obs : Cascade_legacy_runner.cascade_observation) : Yojson.Safe.t =
+    (obs : Cascade_observation.cascade_observation) : Yojson.Safe.t =
   let cascade_name =
     Cascade_name.to_string obs.cascade_name
   in

--- a/lib/keeper/keeper_unified_metrics_json_support.mli
+++ b/lib/keeper/keeper_unified_metrics_json_support.mli
@@ -12,7 +12,7 @@ val provider_context_json :
   Yojson.Safe.t
 
 val redacted_cascade_observation_to_json :
-  Cascade_legacy_runner.cascade_observation -> Yojson.Safe.t
+  Cascade_observation.cascade_observation -> Yojson.Safe.t
 
 val tool_contract_json :
   tool_call_count:int ->

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -88,7 +88,7 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
     match result.cascade_observation with
     | Some observation ->
       Cascade_name.to_string
-        observation.Cascade_legacy_runner.cascade_name
+        observation.Cascade_observation.cascade_name
     | None -> (cascade_name_of_meta meta)
   in
   (* #9933: same latency bucket, split by provider/model/cascade.

--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -116,7 +116,7 @@ let provider_label_of_resolution = function
 (** Emit a single HTTP status observation to the Prometheus counter.
 
     Exposed so that per-call metrics sinks (e.g. the cascade-observation
-    capture in [Cascade_legacy_runner]) can forward [on_http_status] to the
+    capture in [Cascade_observation]) can forward [on_http_status] to the
     same counter without duplicating the label shape.  This is the
     single source of truth for the label key names. *)
 let emit_http_status ~provider ~model_id ~status =
@@ -408,7 +408,7 @@ let emit_request_latency_clamped ~provider ~model_id ~reason =
 (** Emit a single latency observation to the Prometheus histogram.
 
     Exposed so that per-call metrics sinks (e.g. the cascade-observation
-    capture in [Cascade_legacy_runner]) can forward [on_request_end] to the
+    capture in [Cascade_observation]) can forward [on_request_end] to the
     same histogram without duplicating the label shape.  This is the
     single source of truth for the label key names. *)
 let emit_request_latency ?provider ~model_id ~latency_ms () =

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -537,13 +537,13 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
      Missed when #10664 introduced the actor model. *)
   Session.start_loop registry ~sw;
   (* Same sweep miss as Session.start_loop above: PR #10730 introduced
-     [Cascade_legacy_runner] as an Eio actor (mailbox + Promise.await) but
+     [Cascade_observation] as an Eio actor (mailbox + Promise.await) but
      never wired its [start_actor_if_needed] into a bootstrap path.
      [cascade_metrics_json ()] (called from [tool_unified.ml:summary_report],
      which the dashboard tool inspector hits) does
      [Stream.add Get_metrics_json u; Promise.await p]. Without an actor
      fiber draining [stream], the await blocks forever. *)
-  Cascade_legacy_runner.start_actor_if_needed ~sw;
+  Cascade_observation.start_actor_if_needed ~sw;
   (* Wire notification harness: subscription events → session queues *)
   Subscriptions.set_session_push_fn (fun event ->
     Session.push_notification_to_active_agents registry ~event

--- a/lib/mcp_server.mli
+++ b/lib/mcp_server.mli
@@ -207,7 +207,7 @@ val create_state_eio :
   server_state
 (** Production bootstrap.  Wires every Eio handle into
     [Some], starts the [Session] actor consumer, starts
-    the {!Cascade_legacy_runner} actor, and installs the
+    the {!Cascade_observation} actor, and installs the
     Subscriptions notification harness. *)
 
 (** {1 SSE broadcast} *)

--- a/lib/tool_unified.ml
+++ b/lib/tool_unified.ml
@@ -122,5 +122,5 @@ let summary_report () : Yojson.Safe.t =
        Hashtbl dispatch path is now the only code path so the field
        carried no signal. *)
     ("registered_count", `Int (Tool_dispatch.registered_count ()));
-    ("cascade_metrics", Cascade_legacy_runner.cascade_metrics_json ());
+    ("cascade_metrics", Cascade_observation.cascade_metrics_json ());
   ]

--- a/scripts/lint/exhaustive-guard.allowlist
+++ b/scripts/lint/exhaustive-guard.allowlist
@@ -122,7 +122,7 @@ lib/cascade/cascade_event_bridge.ml:126
 lib/cascade/cascade_event_bridge.ml:815
 lib/cascade/cascade_event_bridge.ml:830
 lib/cascade/cascade_http_probe.ml:117
-lib/cascade/cascade_legacy_runner.ml:174
+lib/cascade/cascade_observation.ml:174
 lib/cascade/cascade_pool.ml:21
 lib/cascade_ref/cascade_ref.ml:101
 lib/cascade_ref/cascade_ref.ml:118

--- a/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
+++ b/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
@@ -51,7 +51,7 @@ SCAN_FILES=(
   "lib/cascade/cascade_attempt_liveness_observer.ml"
   "lib/cascade/cascade_catalog_runtime_probe.ml"
   "lib/cascade/cascade_event_bridge.ml"
-  "lib/cascade/cascade_legacy_runner.ml"
+  "lib/cascade/cascade_observation.ml"
   "lib/cascade/cascade_runner.ml"
   "lib/keeper/keeper_agent_result.ml"
   "lib/keeper/keeper_agent_run.ml"

--- a/test/test_cascade_catalog_runtime_yojson.ml
+++ b/test/test_cascade_catalog_runtime_yojson.ml
@@ -252,7 +252,7 @@ let test_no_runtime_placeholder_when_identity_is_real () =
     contains_placeholder
 
 (* ───────────────────────────────────────────────────────────────────
-   Companion coverage: Cascade_legacy_runner.cascade_observation_to_json
+   Companion coverage: Cascade_observation.cascade_observation_to_json
    pins the same Runtime Lens carve-out for the audit-log surface
    (second site fixed in PR #15070's second commit f567e57272). The
    non-redacted serializer must emit real model_id / model_label on
@@ -260,7 +260,7 @@ let test_no_runtime_placeholder_when_identity_is_real () =
    external metrics lives in Keeper_unified_metrics.
    ─────────────────────────────────────────────────────────────────── *)
 
-module LR = Cascade_legacy_runner
+module LR = Cascade_observation
 module KP = Keeper_cascade_profile
 
 let mk_attempt ~model_id ~model_label : LR.cascade_attempt =

--- a/test/test_cascade_per_candidate_telemetry.ml
+++ b/test/test_cascade_per_candidate_telemetry.ml
@@ -1,7 +1,7 @@
 (** test_cascade_per_candidate_telemetry — pin the JSON shape contract
     of the per-candidate cascade attempt telemetry payload emitted into
     [system_log_YYYY-MM-DD.jsonl] from
-    [Cascade_legacy_runner.cascade_attempt_terminal_event_json].
+    [Cascade_observation.cascade_attempt_terminal_event_json].
 
     The shape is the operator-facing contract: when a cascade exhausts
     all 14 candidates and [selected_model: null] lands in the decision
@@ -39,7 +39,7 @@ let assoc_field key json =
 
 let test_success_shape () =
   let json =
-    Cascade_legacy_runner.cascade_attempt_terminal_event_json
+    Cascade_observation.cascade_attempt_terminal_event_json
       ~model_id:"provider_k-coding:provider_k-4.7"
       ~model_label:(Some "provider_k-coding:provider_k-4.7") ~latency_ms:(Some 35921)
       ~error:None ()
@@ -78,7 +78,7 @@ let test_success_shape () =
 
 let test_failure_shape () =
   let json =
-    Cascade_legacy_runner.cascade_attempt_terminal_event_json
+    Cascade_observation.cascade_attempt_terminal_event_json
       ~model_id:"cli_tool_b:provider_f-3.1-pro-preview" ~model_label:None
       ~latency_ms:(Some 1200)
       ~error:(Some "OAS budget timeout after 600.0s") ()
@@ -102,7 +102,7 @@ let test_failure_with_no_latency () =
   (* Provider that never started a request (e.g. CLI exit 1, DNS fail) —
      latency_ms is None, error is Some. Outcome must still be "failure". *)
   let json =
-    Cascade_legacy_runner.cascade_attempt_terminal_event_json
+    Cascade_observation.cascade_attempt_terminal_event_json
       ~model_id:"cli_tool_a:model-d-spark"
       ~model_label:(Some "cli_tool_a:model-d-spark") ~latency_ms:None
       ~error:(Some "rollout thread not found") ()
@@ -116,7 +116,7 @@ let test_failure_with_no_latency () =
 
 let test_slot_phase_shape () =
   let json =
-    Cascade_legacy_runner.cascade_attempt_terminal_event_json
+    Cascade_observation.cascade_attempt_terminal_event_json
       ~slot_release_at_phase:"productive_phase_exhausted"
       ~productive_phase_elapsed_ms:174000 ~retry_phase_elapsed_ms:0
       ~model_id:"provider_a:model-a-sonnet"

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -83,7 +83,7 @@ let with_dashboard_eio f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio.Switch.run @@ fun sw ->
-  Lib.Cascade_legacy_runner.start_actor_if_needed ~sw;
+  Lib.Cascade_observation.start_actor_if_needed ~sw;
   f ()
 
 let test_git_upstream_status_uses_origin_head_for_detached_checkout () =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3645,7 +3645,7 @@ let test_metrics_surface_model_prefers_successful_cascade_label () =
       ~input_tok:100
       ~output_tok:50
       ~cascade_observation:
-        { Masc_mcp.Cascade_legacy_runner.cascade_name =
+        { Masc_mcp.Cascade_observation.cascade_name =
             oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
         ; strategy = Some "round_robin"
         ; configured_labels = [ "llama:auto" ]
@@ -3657,7 +3657,7 @@ let test_metrics_surface_model_prefers_successful_cascade_label () =
         ; fallback_hops = Some 1
         ; fallback_applied = true
         ; attempts =
-            [ { Masc_mcp.Cascade_legacy_runner.attempt_index = 0
+            [ { Masc_mcp.Cascade_observation.attempt_index = 0
               ; model_id = "qwen3.5-35b-a3b-ud-q8-xl"
               ; model_label = Some "llama:qwen3.5-35b-a3b-ud-q8-xl"
               ; latency_ms = None
@@ -4297,7 +4297,7 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
          ; run_validation = Some validation
          ; cascade_observation =
              Some
-               { Masc_mcp.Cascade_legacy_runner.cascade_name =
+               { Masc_mcp.Cascade_observation.cascade_name =
                    oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
                ; strategy = Some "round_robin"
                ; configured_labels = [ "llama:auto" ]
@@ -4310,7 +4310,7 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
                ; fallback_hops = Some 1
                ; fallback_applied = true
                ; attempts =
-                   [ { Masc_mcp.Cascade_legacy_runner.attempt_index = 0
+                   [ { Masc_mcp.Cascade_observation.attempt_index = 0
                      ; model_id = "qwen3.5-35b-a3b-ud-q8-xl"
                      ; model_label = Some "llama:qwen3.5-35b-a3b-ud-q8-xl"
                      ; latency_ms = None

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -351,7 +351,8 @@ let with_cascade_attempt_liveness mode f =
 ;;
 
 let flush_cascade_actor () =
-  ignore (Cascade_legacy_runner.cascade_metrics_json () : Yojson.Safe.t)
+  (* See cascade actor tests: this forces the actor to drain before assertions. *)
+  ignore (Cascade_observation.cascade_metrics_json () : Yojson.Safe.t)
 ;;
 
 let with_liveness_off f = with_cascade_attempt_liveness "off" f
@@ -828,7 +829,7 @@ let test_cascade_inference_rejects_removed_keeper_aliases () =
 ;;
 
 let test_cascade_observation_json_includes_fallback_fields () =
-  let observation : Cascade_legacy_runner.cascade_observation =
+  let observation : Cascade_observation.cascade_observation =
     { cascade_name =
         Cascade_name.of_string_exn
           Masc_mcp.(Keeper_config.default_cascade_name ())
@@ -868,7 +869,7 @@ let test_cascade_observation_json_includes_fallback_fields () =
     ; oas_internal_cascade_allowed = false
     }
   in
-  let json = Cascade_legacy_runner.cascade_observation_to_json observation in
+  let json = Cascade_observation.cascade_observation_to_json observation in
   Alcotest.(check string)
     "cascade name preserved"
     Masc_mcp.(Keeper_config.default_cascade_name ())
@@ -912,15 +913,15 @@ let find_cascade_metric_entry name (json : Yojson.Safe.t) =
 let test_cascade_metrics_concurrent_recording () =
   with_temp_masc_base_path "test_cascade_metrics_concurrent"
   @@ fun () ->
-  Masc_mcp.Cascade_legacy_runner.reset_cascade_counters_for_test ();
+  Masc_mcp.Cascade_observation.reset_cascade_counters_for_test ();
   Fun.protect
-    ~finally:(fun () -> Masc_mcp.Cascade_legacy_runner.reset_cascade_counters_for_test ())
+    ~finally:(fun () -> Masc_mcp.Cascade_observation.reset_cascade_counters_for_test ())
     (fun () ->
        Eio.Fiber.all
          (List.init 8 (fun _ ->
             fun () ->
             for _ = 1 to 25 do
-              Masc_mcp.Cascade_legacy_runner.record_cascade
+              Masc_mcp.Cascade_observation.record_cascade
                 ~cascade_name:(internal_cascade_name "concurrent-cascade")
                 ~observation:None
                 ~outcome:`Success
@@ -929,7 +930,7 @@ let test_cascade_metrics_concurrent_recording () =
        match
          find_cascade_metric_entry
            "concurrent-cascade"
-           (Cascade_legacy_runner.cascade_metrics_json ())
+           (Cascade_observation.cascade_metrics_json ())
        with
        | None -> Alcotest.fail "expected concurrent-cascade metrics"
        | Some entry ->
@@ -950,45 +951,45 @@ let test_cascade_metrics_concurrent_recording () =
 let test_cascade_metrics_evicts_lowest_call_key () =
   with_temp_masc_base_path "test_cascade_metrics_evicts"
   @@ fun () ->
-  Masc_mcp.Cascade_legacy_runner.reset_cascade_counters_for_test ();
+  Masc_mcp.Cascade_observation.reset_cascade_counters_for_test ();
   Fun.protect
-    ~finally:(fun () -> Masc_mcp.Cascade_legacy_runner.reset_cascade_counters_for_test ())
+    ~finally:(fun () -> Masc_mcp.Cascade_observation.reset_cascade_counters_for_test ())
     (fun () ->
-       Masc_mcp.Cascade_legacy_runner.record_cascade
+       Masc_mcp.Cascade_observation.record_cascade
          ~cascade_name:(internal_cascade_name "victim-key")
          ~observation:None
          ~outcome:`Success
          ();
        for i = 1 to 254 do
          let name = Printf.sprintf "stable-%03d" i in
-         Masc_mcp.Cascade_legacy_runner.record_cascade
+         Masc_mcp.Cascade_observation.record_cascade
            ~cascade_name:(internal_cascade_name name)
            ~observation:None
            ~outcome:`Success
            ();
-         Masc_mcp.Cascade_legacy_runner.record_cascade
+         Masc_mcp.Cascade_observation.record_cascade
            ~cascade_name:(internal_cascade_name name)
            ~observation:None
            ~outcome:`Success
            ()
        done;
        for _ = 1 to 3 do
-         Masc_mcp.Cascade_legacy_runner.record_cascade
+         Masc_mcp.Cascade_observation.record_cascade
            ~cascade_name:(internal_cascade_name "hot-key")
            ~observation:None
            ~outcome:`Success
            ()
        done;
        let before =
-         Yojson.Safe.Util.to_list (Cascade_legacy_runner.cascade_metrics_json ())
+         Yojson.Safe.Util.to_list (Cascade_observation.cascade_metrics_json ())
        in
        Alcotest.(check int) "table capped before admit" 256 (List.length before);
-       Masc_mcp.Cascade_legacy_runner.record_cascade
+       Masc_mcp.Cascade_observation.record_cascade
          ~cascade_name:(internal_cascade_name "new-key")
          ~observation:None
          ~outcome:`Success
          ();
-       let after_json = Cascade_legacy_runner.cascade_metrics_json () in
+       let after_json = Cascade_observation.cascade_metrics_json () in
        let after = Yojson.Safe.Util.to_list after_json in
        Alcotest.(check int) "table stays capped" 256 (List.length after);
        Alcotest.(check bool)
@@ -1009,7 +1010,7 @@ let test_cascade_audit_persists_observation () =
   let base = temp_dir "test_cascade_audit" in
   let old_base_path = Sys.getenv_opt "MASC_BASE_PATH" in
   let old_base_path_input = Sys.getenv_opt "MASC_BASE_PATH_INPUT" in
-  Masc_mcp.Cascade_legacy_runner.reset_cascade_counters_for_test ();
+  Masc_mcp.Cascade_observation.reset_cascade_counters_for_test ();
   Fun.protect
     ~finally:(fun () ->
       (match old_base_path with
@@ -1018,12 +1019,12 @@ let test_cascade_audit_persists_observation () =
       (match old_base_path_input with
        | Some value -> Unix.putenv "MASC_BASE_PATH_INPUT" value
        | None -> Unix.putenv "MASC_BASE_PATH_INPUT" "");
-      Masc_mcp.Cascade_legacy_runner.reset_cascade_counters_for_test ();
+      Masc_mcp.Cascade_observation.reset_cascade_counters_for_test ();
       cleanup_dir base)
     (fun () ->
        Unix.putenv "MASC_BASE_PATH" base;
        Unix.putenv "MASC_BASE_PATH_INPUT" base;
-       let observation : Masc_mcp.Cascade_legacy_runner.cascade_observation =
+       let observation : Masc_mcp.Cascade_observation.cascade_observation =
          { cascade_name = Cascade_name.of_string_exn "audit-cascade"
          ; strategy = Some "round_robin"
          ; configured_labels = [ "primary:auto"; "secondary:auto" ]
@@ -1061,13 +1062,14 @@ let test_cascade_audit_persists_observation () =
          ; oas_internal_cascade_allowed = false
          }
        in
-       Masc_mcp.Cascade_legacy_runner.record_cascade
+       Masc_mcp.Cascade_observation.record_cascade
          ~keeper_name:"keeper-provider-agent-test"
          ~cascade_name:(internal_cascade_name "audit-cascade")
          ~observation:(Some observation)
          ~outcome:`Failure
          ();
-       ignore (Cascade_legacy_runner.cascade_metrics_json ());
+       (* See cascade audit assertions below: this forces the actor to drain. *)
+       ignore (Cascade_observation.cascade_metrics_json ());
        let store =
          Dated_jsonl.create ~base_dir:(Filename.concat base ".masc/cascade_audit") ()
        in
@@ -6168,7 +6170,7 @@ let () =
   Eio_guard.enable ();
   Eio.Switch.run
   @@ fun sw ->
-  Masc_mcp.Cascade_legacy_runner.start_actor_if_needed ~sw;
+  Masc_mcp.Cascade_observation.start_actor_if_needed ~sw;
   Masc_mcp.Masc_eio_env.reset_for_test ();
   Alcotest.run
     "OAS Worker"

--- a/test/test_oas_worker_provider_labels.ml
+++ b/test/test_oas_worker_provider_labels.ml
@@ -92,9 +92,9 @@ let make_cli_tool_c_provider_cfg ?(model_id = "model-c-coding") () =
 ;;
 
 let test_cascade_provider_labels_keep_glm_and_glm_coding_distinct () =
-  let provider_k = Cascade_legacy_runner.provider_name_of_config (make_glm_provider_cfg ()) in
+  let provider_k = Cascade_observation.provider_name_of_config (make_glm_provider_cfg ()) in
   let glm_coding =
-    Cascade_legacy_runner.provider_name_of_config
+    Cascade_observation.provider_name_of_config
       (make_glm_provider_cfg ~base_url:(provider_binding_base_url_exn "provider_k-coding") ())
   in
   Alcotest.(check string) "general GLM label" "provider_k" provider_k;
@@ -223,10 +223,10 @@ let test_provider_attempt_timeout_resolution_sources () =
 
 let test_cascade_provider_labels_preserve_registered_openai_compat_family () =
   let provider_name =
-    Cascade_legacy_runner.provider_name_of_config (make_openrouter_provider_cfg ())
+    Cascade_observation.provider_name_of_config (make_openrouter_provider_cfg ())
   in
   let model_label =
-    Cascade_legacy_runner.model_label_of_config (make_openrouter_provider_cfg ())
+    Cascade_observation.model_label_of_config (make_openrouter_provider_cfg ())
   in
   Alcotest.(check string) "openrouter provider name" "openrouter" provider_name;
   Alcotest.(check string)
@@ -237,10 +237,10 @@ let test_cascade_provider_labels_preserve_registered_openai_compat_family () =
 
 let test_cascade_provider_labels_detect_kimi_from_kind_metadata () =
   let provider_name =
-    Cascade_legacy_runner.provider_name_of_config (make_kimi_provider_cfg ())
+    Cascade_observation.provider_name_of_config (make_kimi_provider_cfg ())
   in
   let model_label =
-    Cascade_legacy_runner.model_label_of_config (make_kimi_provider_cfg ())
+    Cascade_observation.model_label_of_config (make_kimi_provider_cfg ())
   in
   Alcotest.(check string) "provider_c provider name" "provider_c" provider_name;
   Alcotest.(check string) "provider_c model label" "provider_c:model-c-coding" model_label


### PR DESCRIPTION
Summary:
- rename Cascade_legacy_runner to Cascade_observation across code, tests, docs, and lint baselines
- remove the legacy runner filename/module surface while preserving the existing cascade observation wire shape
- update RFC/doc references that pointed at the old module name

Verification:
- rg -n "Cascade_legacy_runner|cascade_legacy_runner|legacy_runner|legacy-runner" lib test docs bin ci scripts (no matches)
- rg --files | rg "cascade_legacy_runner|legacy_runner" (no matches)
- git diff --check
- git diff --name-only -- "*.ml" "*.mli" | xargs ocamlformat --check
- scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD
- scripts/dune-local.sh build lib/masc_mcp.cmxa blocked by live bare Dune processes outside the wrapper (exit 75); did not bypass the guard