### PR TITLE
fix(keeper): correct memory recall path + positive bash fields

### DIFF
--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -134,18 +134,18 @@ let run
      let recall_eval =
        if used_search
        then (
-         let bank_path =
-           Keeper_types_support.keeper_memory_bank_path config meta.name
+         (* Use session history (role+content), not the decision memory bank
+            (kind+text+priority).  The bank format caused 60 Type_error
+            WARN/cycle — every line skipped because [load_history_user_messages]
+            expects [role] and [content] fields. *)
+         let history_path =
+           Keeper_types_support.keeper_history_path config
+             (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
          in
-         (* RFC-0149 §3.1 closeout — route through the typed Result
-            variant.  The dispatch-failure counter + WARN are retained
-            (this is a behavioural error boundary for post-turn memory
-            recall, not the §3.1 read-side path) but now consume a
-            bounded [exn_class] label instead of the raw [exn]. *)
          let candidates =
            match
              Keeper_memory_recall.load_history_user_messages_result
-               ~path:bank_path
+               ~path:history_path
                ~max_n:50
            with
            | Ok msgs -> msgs

--- a/lib/tool_shard_types_schemas_bash.ml
+++ b/lib/tool_shard_types_schemas_bash.ml
@@ -119,9 +119,9 @@ let keeper_bash_description =
   "Execute one command through the typed execution gates via typed argv. \
    Provide EITHER executable/argv OR pipeline, never both. If both are \
    provided, executable takes precedence. Use executable/argv for one process, \
-   or pipeline for explicit Shell IR pipelines. The legacy 'cmd' string field \
-   is no longer accepted. Shell metacharacters in argv are data, not syntax. \
-   Good: executable='git' argv=['status','--short'], \
+   or pipeline for explicit Shell IR pipelines. Accepted fields: executable, \
+   argv, pipeline, env, cwd, timeout_sec. Shell metacharacters in argv are \
+   data, not syntax. Good: executable='git' argv=['status','--short'], \
    pipeline=[{executable='git',...}, {executable='head',...}]. Runs in the \
    keeper sandbox by default; use cwd to target an explicit allowed directory. \
    Paths resolve automatically — never include host storage prefixes such as \


### PR DESCRIPTION
## Summary
- **Memory recall file format mismatch** (#18349): `keeper_agent_run_post_turn_memory.ml` passed `keeper_memory_bank_path` (decision format: `kind`/`text`/`priority`) to `load_history_user_messages_result` which expects conversation format (`role`/`content`). 60 `Type_error("Expected string, got null")` WARN per cycle, zero effective candidates. Now uses `keeper_history_path` matching the correct pattern in `keeper_exec_memory.ml:248`.
- **keeper_bash command hallucination** (#18350): Description mentioned deprecated `'cmd'` field by name, paradoxically priming LLMs to send `'command'`. Replaced with positive-only field enumeration (`executable, argv, pipeline, env, cwd, timeout_sec`).

## Test plan
- [ ] `dune build` passes (verified locally)
- [ ] Deploy and verify zero `load_history_user_messages: skipping line` WARN in system log
- [ ] Deploy and verify zero `unsupported field(s): command` in keeper_bash tool errors

Closes #18349
Closes #18350

🤖 Generated with [Claude Code](https://claude.com/claude-code)