### PR TITLE
refactor(otel): stop emitting duplicate legacy span attrs

### DIFF
--- a/lib/otel/otel_dispatch_hook.ml
+++ b/lib/otel/otel_dispatch_hook.ml
@@ -3,16 +3,10 @@
     Creates an OTel span for each tool call using data from [Tool_result.t].
     Also records a Prometheus histogram observation for tool call duration.
 
-    Span attributes are dual-emitted: the legacy [tool.*] keys stay so
-    existing custom dashboards keep working, and the OpenTelemetry GenAI
-    semantic-convention keys ([gen_ai.tool.name],
-    [gen_ai.operation.name]) are added so vendors that auto-categorise
-    on [gen_ai.*] (Datadog v1.37+, Grafana, etc.) classify these spans
-    as AI/LLM activity instead of generic tool calls. See #7461 Step 1.
-
-    Note: as of 2026-04 most GenAI semconv attributes are
-    Stability.Experimental, so dual-emit also acts as a hedge against
-    spec changes — only the legacy keys would survive a rename event.
+    Span attributes use OpenTelemetry GenAI semantic-convention keys
+    ([gen_ai.tool.name], [gen_ai.operation.name]) so vendors that
+    auto-categorise on [gen_ai.*] classify these spans as AI/LLM activity
+    instead of generic tool calls. See #7461 Step 1.
 
     @since 2.103.0 *)
 
@@ -68,12 +62,6 @@ let tool_span_attrs (result : Tool_result.t) =
     then [ "otel.status_code", `String "OK" ]
     else [ "otel.status_code", `String "ERROR" ]
   in
-  let legacy_attrs =
-    [ Otel_genai.Attr_key.tool_name, `String result.tool_name
-    ; Otel_genai.Attr_key.tool_success, `Bool result.success
-    ; Otel_genai.Attr_key.tool_duration_ms, `Int (int_of_float result.duration_ms)
-    ]
-  in
   (* OpenTelemetry GenAI semantic conventions
      (https://opentelemetry.io/docs/specs/semconv/gen-ai/). Tool execution
      within an agent run is the [execute_tool] operation per the spec.
@@ -84,7 +72,7 @@ let tool_span_attrs (result : Tool_result.t) =
     Otel_genai.tool_execution_attrs ~tool_name:result.tool_name
     |> List.map (fun (key, value) -> key, (value :> OT.value))
   in
-  legacy_attrs @ gen_ai_attrs @ status_attrs
+  gen_ai_attrs @ status_attrs
 ;;
 
 (** Record a tool call as an OTel span and Prometheus histogram observation. *)

--- a/lib/otel/otel_dispatch_hook.mli
+++ b/lib/otel/otel_dispatch_hook.mli
@@ -3,12 +3,9 @@
     (always active) and an OpenTelemetry span (gated by
     {!Otel_config.enabled}).
 
-    Span attributes are dual-emitted: legacy [tool.*] keys for
-    existing custom dashboards, and OpenTelemetry GenAI semantic
-    convention keys ([gen_ai.tool.name], [gen_ai.operation.name]) so
-    Datadog v1.37+/Grafana auto-categorise these spans as AI/LLM
-    activity. The dual-emit also hedges against semconv churn while
-    GenAI fields remain Stability.Experimental.
+    Span attributes use OpenTelemetry GenAI semantic-convention keys
+    ([gen_ai.tool.name], [gen_ai.operation.name]) so Datadog
+    v1.37+/Grafana auto-categorise these spans as AI/LLM activity.
 
     Internal helper [on_tool_result] is intentionally hidden — the
     hook is registered through {!install} once at startup, after

--- a/lib/otel/otel_genai.ml
+++ b/lib/otel/otel_genai.ml
@@ -1,8 +1,7 @@
 (** GenAI semantic-convention helpers for MASC OTel spans.
 
-    GenAI semantic conventions are still Development as of 2026-05-06, so these
-    helpers dual-emit MASC legacy [keeper.*] attributes with [gen_ai.*]
-    attributes. *)
+    Emits canonical [gen_ai.*] attributes plus MASC-owned extension keys for
+    fields that are outside the OpenTelemetry GenAI semantic convention. *)
 
 type attr = string * [ `Bool of bool | `Int of int | `String of string ]
 
@@ -43,7 +42,6 @@ module Attr_key = struct
 
   let keeper_name = register Legacy "keeper.name"
   let keeper_agent_name = register Legacy "keeper.agent_name"
-  let keeper_cascade_name = register Legacy "keeper.cascade.name"
   let keeper_trace_id = register Legacy "keeper.trace_id"
   let keeper_generation = register Legacy "keeper.generation"
   let keeper_max_context = register Legacy "keeper.max_context"
@@ -52,9 +50,6 @@ module Attr_key = struct
   let keeper_channel = register Legacy "keeper.channel"
   let keeper_is_retry = register Legacy "keeper.is_retry"
   let keeper_current_task_id = register Legacy "keeper.current_task_id"
-  let tool_name = register Legacy "tool.name"
-  let tool_success = register Legacy "tool.success"
-  let tool_duration_ms = register Legacy "tool.duration_ms"
 
   let registry = List.rev !registry_ref
 
@@ -96,7 +91,6 @@ let keeper_turn_attrs
   in
   [ Attr_key.keeper_name, `String keeper_name
   ; Attr_key.keeper_agent_name, `String agent_name
-  ; Attr_key.keeper_cascade_name, `String cascade_name
   ; Attr_key.keeper_trace_id, `String trace_id
   ; Attr_key.keeper_generation, `Int generation
   ; Attr_key.keeper_max_context, `Int max_context

--- a/lib/otel/otel_genai.mli
+++ b/lib/otel/otel_genai.mli
@@ -13,7 +13,6 @@ module Attr_key : sig
   val masc_gen_ai_cascade_name : string
   val keeper_name : string
   val keeper_agent_name : string
-  val keeper_cascade_name : string
   val keeper_trace_id : string
   val keeper_generation : string
   val keeper_max_context : string
@@ -22,9 +21,6 @@ module Attr_key : sig
   val keeper_channel : string
   val keeper_is_retry : string
   val keeper_current_task_id : string
-  val tool_name : string
-  val tool_success : string
-  val tool_duration_ms : string
 
   (** Every registered Attr_key constant exported by this module.
 

--- a/test/test_otel_genai.ml
+++ b/test/test_otel_genai.ml
@@ -11,10 +11,6 @@ let attr_bool = function
   | Some (`Bool b) -> Some b
   | _ -> None
 
-let attr_int = function
-  | Some (`Int i) -> Some i
-  | _ -> None
-
 let test_keeper_turn_span_name () =
   check
     string
@@ -23,7 +19,7 @@ let test_keeper_turn_span_name () =
     (Lib.Otel_genai.keeper_turn_span_name ~keeper_name:"ani1999")
 ;;
 
-let test_keeper_turn_attrs_dual_emit () =
+let test_keeper_turn_attrs_canonical_emit () =
   let attrs =
     Lib.Otel_genai.keeper_turn_attrs
       ~keeper_name:"ani1999"
@@ -68,11 +64,7 @@ let test_keeper_turn_attrs_dual_emit () =
     "masc cascade extension"
     (Some "research")
     (attr_string (assoc Lib.Otel_genai.Attr_key.masc_gen_ai_cascade_name attrs));
-  check
-    (option (of_pp Fmt.Dump.string))
-    "legacy cascade"
-    (Some "research")
-    (attr_string (assoc Lib.Otel_genai.Attr_key.keeper_cascade_name attrs));
+  check bool "no duplicate cascade key" false (List.mem_assoc "keeper.cascade.name" attrs);
   check
     (option (of_pp Fmt.Dump.string))
     "task id"
@@ -362,21 +354,13 @@ let test_dispatch_hook_emits_tool_span_payload () =
             (Some "keeper_shell")
             (attr_string
                (assoc Lib.Otel_genai.Attr_key.gen_ai_tool_name attrs));
+          check bool "no legacy tool.name" false (List.mem_assoc "tool.name" attrs);
+          check bool "no legacy tool.success" false (List.mem_assoc "tool.success" attrs);
           check
-            (option (of_pp Fmt.Dump.string))
-            "legacy tool name"
-            (Some "keeper_shell")
-            (attr_string (assoc Lib.Otel_genai.Attr_key.tool_name attrs));
-          check
-            (option bool)
-            "legacy tool success"
-            (Some true)
-            (attr_bool (assoc Lib.Otel_genai.Attr_key.tool_success attrs));
-          check
-            (option int)
-            "legacy duration ms"
-            (Some 123)
-            (attr_int (assoc Lib.Otel_genai.Attr_key.tool_duration_ms attrs));
+            bool
+            "no legacy tool.duration_ms"
+            false
+            (List.mem_assoc "tool.duration_ms" attrs);
           check
             (option (of_pp Fmt.Dump.string))
             "otel status"
@@ -390,7 +374,7 @@ let () =
     "otel_genai"
     [ ( "keeper turn"
       , [ test_case "span name" `Quick test_keeper_turn_span_name
-        ; test_case "dual emit attrs" `Quick test_keeper_turn_attrs_dual_emit
+        ; test_case "canonical emit attrs" `Quick test_keeper_turn_attrs_canonical_emit
         ; test_case "omit missing task id" `Quick test_keeper_turn_attrs_omit_missing_task
         ; test_case "attr key registry boundaries" `Quick
             test_attr_key_registry_boundaries


### PR DESCRIPTION
Summary:
- stop emitting duplicate keeper.cascade.name in keeper-turn OTel attrs
- stop emitting duplicate tool.name/tool.success/tool.duration_ms in tool-call OTel spans
- update OTel tests to assert canonical gen_ai/masc.gen_ai attrs and absence of the old duplicate keys

Verification:
- rg -n "keeper_cascade_name|Attr_key\.(tool_name|tool_success|tool_duration_ms)" lib/otel test/test_otel_genai.ml (no matches)
- git diff --check
- git diff --name-only -- "*.ml" "*.mli" | xargs ocamlformat --check
- scripts/dune-local.sh build ./test/test_otel_genai.exe blocked by live bare Dune processes outside the wrapper (exit 75); did not bypass the guard