### PR TITLE
refactor(keeper): shrink Keeper_types legacy facade

### DIFF
--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -322,7 +322,7 @@ let resolved_keeper_args_from_persona args :
   if not (validate_name persona_name) then
     Error "persona_name is required"
   else
-    match reject_legacy_model_args ~tool_name:"masc_keeper_create_from_persona" args with
+    match Keeper_meta_contract.reject_legacy_model_args ~tool_name:"masc_keeper_create_from_persona" args with
     | Error err -> Error err
     | Ok () ->
     match reject_removed_keeper_input_keys

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -676,3 +676,22 @@ let map_proactive_rt (f : proactive_runtime -> proactive_runtime) (m : keeper_me
 let map_scheduled_autonomous_rt = map_proactive_rt
 let now_iso () = Masc_domain.now_iso ()
 let keeper_legacy_model_arg_names = [ "models"; "allowed_models"; "active_model" ]
+
+let reject_legacy_model_args ~tool_name (args : Yojson.Safe.t) =
+  let present =
+    keeper_legacy_model_arg_names
+    |> List.filter (fun key ->
+      match Yojson.Safe.Util.member key args with
+      | `Null -> false
+      | _ -> true)
+  in
+  match present with
+  | [] -> Ok ()
+  | fields ->
+    Error
+      (Printf.sprintf
+         "legacy keeper model args removed for %s: %s. Use cascade_name; concrete \
+          provider/model identity is OAS-owned."
+         tool_name
+         (String.concat ", " fields))
+;;

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -488,8 +488,14 @@ val keeper_legacy_model_arg_names : string list
 (** Names of legacy keeper-creation tool arguments that have
     been retired in favour of the [cascade_name] field
     (["models"], ["allowed_models"], ["active_model"]).
-    Consumed by {!Keeper_types.reject_legacy_model_args} which
+    Consumed by {!reject_legacy_model_args} which
     surfaces operator-readable rejection messages instead of
     silently ignoring deprecated args.  Pinned data table —
     drift would either re-accept retired args silently or
     reject newly added args by mistake. *)
+
+val reject_legacy_model_args :
+  tool_name:string -> Yojson.Safe.t -> (unit, string) result
+(** Reject retired keeper model-selection input fields at tool/API boundaries.
+    Model and provider identity is resolved from [cascade_name] and the cascade
+    catalog, not per-call keeper arguments. *)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -145,7 +145,7 @@ let preflight_keeper_msg ctx args : (unit, string) result =
     match keeper_msg_timeout_override args with
     | Error e -> Error e
     | Ok _ ->
-    (match reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with
+    (match Keeper_meta_contract.reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with
     | Error e -> Error e
     | Ok () ->
     (match reject_removed_keeper_input_keys ~tool_name:"masc_keeper_msg" args with
@@ -216,7 +216,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
     (match keeper_msg_timeout_override args with
     | Error e -> (false, e)
     | Ok keeper_msg_oas_timeout_s ->
-    (match reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with
+    (match Keeper_meta_contract.reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with
     | Error e -> (false, "" ^ e)
     | Ok () ->
     (match reject_removed_keeper_input_keys ~tool_name:"masc_keeper_msg" args with

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -195,7 +195,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
   if not (validate_name name) then
     Error (false, "invalid keeper name (allowed: [A-Za-z0-9._-])")
   else
-    match reject_legacy_model_args ~tool_name:"masc_keeper_up" args with
+    match Keeper_meta_contract.reject_legacy_model_args ~tool_name:"masc_keeper_up" args with
     | Error e -> Error (false, e)
     | Ok () ->
     match reject_removed_keeper_input_keys ~tool_name:"masc_keeper_up" args with

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -10,25 +10,6 @@ include Keeper_types_profile
    compatibility. *)
 include Keeper_meta_contract
 
-let reject_legacy_model_args ~tool_name (args : Yojson.Safe.t) =
-  let present =
-    keeper_legacy_model_arg_names
-    |> List.filter (fun key ->
-      match Yojson.Safe.Util.member key args with
-      | `Null -> false
-      | _ -> true)
-  in
-  match present with
-  | [] -> Ok ()
-  | fields ->
-    Error
-      (Printf.sprintf
-         "legacy keeper model args removed for %s: %s. Use cascade_name; concrete \
-          provider/model identity is OAS-owned."
-         tool_name
-         (String.concat ", " fields))
-;;
-
 (* JSON scrubbing, serialization, and parsing is factored out so this facade
    can focus on keeper meta store I/O and the public compatibility surface. *)
 include Keeper_meta_json
@@ -101,5 +82,3 @@ type session_context =
   ; session_dir : string
   ; mutable checkpoints : checkpoint list
   }
-
-let legacy_provider_filter_name = Keeper_config.legacy_provider_filter_name

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -382,14 +382,6 @@ val map_scheduled_autonomous_rt :
   (scheduled_autonomous_runtime -> scheduled_autonomous_runtime) ->
   keeper_meta -> keeper_meta
 
-(** {1 Legacy model arg rejection} *)
-
-val keeper_legacy_model_arg_names : string list
-val legacy_provider_filter_name : string
-
-val reject_legacy_model_args :
-  tool_name:string -> Yojson.Safe.t -> (unit, string) result
-
 (** {1 Runtime meta write sync hook} *)
 
 val runtime_meta_write_sync_hook : (Coord.config -> keeper_meta -> unit) ref

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -161,7 +161,7 @@ let parse_keeper_chat_stream_request body_str =
           "channel, channel_user_id, and channel_room_id are required when connector context is supplied"
       else
         match
-          Keeper_types.reject_legacy_model_args ~tool_name:"masc_keeper_msg" json
+          Keeper_meta_contract.reject_legacy_model_args ~tool_name:"masc_keeper_msg" json
         with
         | Error err -> Error err
         | Ok () -> (


### PR DESCRIPTION
## Summary
- move retired keeper model-argument rejection to Keeper_meta_contract, its actual owner
- update keeper/server call sites to use Keeper_meta_contract.reject_legacy_model_args directly
- stop exposing keeper_legacy_model_arg_names, legacy_provider_filter_name, and reject_legacy_model_args through the broad Keeper_types facade

## Verification
- rg backstop confirmed Keeper_types no longer exposes or serves those legacy names; only owner-module declarations remain
- git diff --check
- ocamlformat --check on changed .ml/.mli files
- scripts/dune-local.sh build lib/masc_mcp.cmxa blocked with exit 75 because bare Dune processes were already running outside the wrapper

Implements the Keeper_types facade P1 leaf-alias purge from #18357.