### PR TITLE
refactor(cascade): reject deprecated profile names

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -837,7 +837,7 @@ strategy = "priority_tier"
 fallback = true
 keeper-assignable = false
 
-[tier-group.provider_benchmark]
+[tier-group.provider_inventory_sweep]
 # Sweep lane for full provider inventory performance measurement
 # (docs/CASCADE-ROUTES.md §sweep). Background only; isolated from
 # production fallback chains to avoid resource contention with live work.
@@ -895,7 +895,7 @@ target = "tier-group.primary"
 target = "tier-group.primary"
 
 [routes.provider_benchmark]
-target = "tier-group.primary"
+target = "tier-group.provider_inventory_sweep"
 
 [routes.llm_rerank]
 target = "tier-group.primary"

--- a/docs/CASCADE-ROUTES.md
+++ b/docs/CASCADE-ROUTES.md
@@ -194,7 +194,7 @@ strategy = "failover"
 fallback = true
 
 # ── Sweep lane: provider benchmark only ──────────────────────
-[tier-group.provider_benchmark]
+[tier-group.provider_inventory_sweep]
 tiers = ["provider-k-coding-primary", "strict_tool_candidates",
          "cli_manual", "direct_api_manual",
          "ollama_cloud_primary", "recovery"]
@@ -227,7 +227,7 @@ routes 는 §2 분류대로 매핑. 18 개 모두 명시 (누락 = silent fallba
 [routes.openai_compat]      target = "tier-group.fast_judge"   # Provider-D-호환 inbound passthrough
 
 # Sweep — 배경 측정
-[routes.provider_benchmark] target = "tier-group.provider_benchmark"   # 전체 inventory 성능 측정
+[routes.provider_benchmark] target = "tier-group.provider_inventory_sweep"   # 전체 inventory 성능 측정
 ```
 
 ---
@@ -240,7 +240,7 @@ routes 는 §2 분류대로 매핑. 18 개 모두 명시 (누락 = silent fallba
 | `target = "tier.X"` (group 아님) | fallback chain 끊김. 1차 tier 다운 시 즉시 실패. | 의도일 때 주석 명시. 아니면 `tier-group.X`. |
 | 멤버 `max-output` 불일치 | ceiling = min, 큰 멤버 사전 reject. | alias 로 모든 멤버 같은 cap 정렬 (§3.1 c). |
 | alias 이름을 모델 특성으로 명명 | 같은 binding 이 다른 lane 재사용될 때 의미 충돌. | 시나리오 명명 (`.fast_judge`, `.tool_candidate`). |
-| sweep 을 production fallback 에 끼움 | benchmark 가 본 작업 자원 점유. | 별도 `tier-group.provider_benchmark`. |
+| sweep 을 production fallback 에 끼움 | benchmark 가 본 작업 자원 점유. | 별도 `tier-group.provider_inventory_sweep`. |
 | system-only tier 에 `keeper-assignable` 누락 | keeper 가 자기 cascade 를 fast_judge 로 잘못 설정. | system-only 는 `keeper-assignable = false`. |
 | RFC 번호 동시 claim 충돌 | 작업자 split 시 같은 번호 두 PR (#14396 vs #14394 선례). | 새 RFC 직전 `git fetch origin main && ls docs/rfc/`. |
 | endpoint quota / auth 미검증 멤버 등록 | fast_judge_primary 1차가 production 호출 시 "Insufficient balance" / 401 로 매번 fail → 2차로 silent fallback. RFC-0038 substitution 사고와 동형. | alias 추가 전 `curl <endpoint>/chat/completions` probe 의무 (§6.7 참조). |

--- a/lib/cascade/cascade_catalog_runtime_validate.ml
+++ b/lib/cascade/cascade_catalog_runtime_validate.ml
@@ -26,6 +26,38 @@ let render_declarative_adapter_error error =
   Printf.sprintf "declarative cascade adapter error: %s"
     (Cascade_declarative_adapter.show_adapter_error error)
 
+let deprecated_logical_profile_name_error ~kind name :
+    Cascade_declarative_parser.parse_error option =
+  if Cascade_config_loader.is_deprecated_logical_profile_name name then
+    Some
+      {
+        path = Printf.sprintf "%s.%s" kind name;
+        message =
+          Printf.sprintf
+            "deprecated cascade profile name %S is no longer supported as a %s \
+             name; use a non-route catalog profile name and point [routes.*] \
+             at it"
+            name
+            kind;
+      }
+  else None
+
+let deprecated_logical_profile_name_errors
+    (cfg : Cascade_declarative_types.cascade_config) =
+  let tier_errors =
+    List.filter_map
+      (fun (tier : Cascade_declarative_types.cascade_tier) ->
+        deprecated_logical_profile_name_error ~kind:"tier" tier.name)
+      cfg.tiers
+  in
+  let tier_group_errors =
+    List.filter_map
+      (fun (group : Cascade_declarative_types.cascade_tier_group) ->
+        deprecated_logical_profile_name_error ~kind:"tier-group" group.name)
+      cfg.tier_groups
+  in
+  tier_errors @ tier_group_errors
+
 (* RFC-0058 Phase 8.3: operator opt-in flag for cold-boot tolerance of
    partial cascade catalogs. Default is [false], preserving the existing
    all-or-nothing boot semantics. When set, [validate_path_result] and
@@ -57,6 +89,9 @@ let load_declarative_catalog_info ~config_path =
         Cascade_declarative_hotpath.adapted_catalog_to_snapshot
           ~source_path:config_path catalog
       in
+      let declarative_parse_errors =
+        deprecated_logical_profile_name_errors cfg
+      in
       let profile_names =
         match snapshot with
         | Some snap ->
@@ -67,7 +102,7 @@ let load_declarative_catalog_info ~config_path =
         {
           declarative_snapshot = snapshot;
           declarative_profile_names = profile_names;
-          declarative_parse_errors = [];
+          declarative_parse_errors;
           declarative_errors = catalog.errors;
         }
 
@@ -263,8 +298,9 @@ let profile_build_of_declarative
 let runtime_required_profiles ~config_path =
   let keepers_from_catalog =
     match load_declarative_catalog_info ~config_path with
-    | Some { declarative_profile_names; _ } -> declarative_profile_names
-    | None -> []
+    | Some { declarative_parse_errors = []; declarative_profile_names; _ } ->
+      declarative_profile_names
+    | Some { declarative_parse_errors = _ :: _; _ } | None -> []
   in
   List.sort_uniq String.compare
     (keepers_from_catalog

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -234,6 +234,55 @@ type weighted_entry =
   ; secondary_supports_tool_choice : bool option
   }
 
+let deprecated_logical_profile_names =
+  [ ""
+  ; "default"
+  ; "default_models"
+  ; "oas-keeper_unified"
+  ; "coding_first"
+  ; "oas-coding_first"
+  ; "keeper_reply"
+  ; "keeper_unified"
+  ; "phase_recovery"
+  ; "phase_buffer"
+  ; (* [local_recovery] is intentionally not listed here. Operators can
+       declare it as a concrete fallback_cascade profile, and the loader must
+       keep that profile visible so fallback chains do not collapse back into
+       routes.phase_recovery. *)
+    "local_only"
+  ; "tool_required"
+  ; "tool_use_strict"
+  ; "resilient_breaker"
+  ; "governance_judge"
+  ; "operator_judge"
+  ; "cross_verifier"
+  ; "verifier"
+  ; "adversarial_reviewer"
+  ; "auto_responder"
+  ; "routing"
+  ; "routing_judge"
+  ; "openai_compat"
+  ; "persona_generation"
+  ; "provider_benchmark"
+  ; "llm_rerank"
+  ]
+;;
+
+let unqualified_profile_name normalized =
+  if String.starts_with ~prefix:"tier-group." normalized then
+    String.sub normalized 11 (String.length normalized - 11)
+  else if String.starts_with ~prefix:"tier." normalized then
+    String.sub normalized 5 (String.length normalized - 5)
+  else normalized
+;;
+
+let is_deprecated_logical_profile_name raw =
+  let normalized =
+    String.trim raw |> String.lowercase_ascii |> unqualified_profile_name
+  in
+  List.mem normalized deprecated_logical_profile_names
+;;
+
 (* ── Inference parameter resolution ───────────────────── *)
 
 type inference_params =

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -66,6 +66,11 @@ type weighted_entry = {
       when no explicit override is declared. *)
 }
 
+(** Deprecated logical route keys must not be treated as concrete catalog
+    profiles. Qualified names such as ["tier.local_only"] are checked by their
+    raw profile suffix. *)
+val is_deprecated_logical_profile_name : string -> bool
+
 (** Per-cascade inference parameter overrides. *)
 type inference_params = {
   temperature: float option;

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -9,6 +9,10 @@ include Coord_backlog
 include Coord_bootstrap
 include Coord_identity
 include Coord_state
+include Coord_bootstrap
+include Coord_identity
+include Coord_task_id
+include Coord_backlog
 include Coord_broadcast
 
 (* Agent join/leave lifecycle *)

--- a/lib/coord.mli
+++ b/lib/coord.mli
@@ -10,6 +10,10 @@ include module type of Coord_backlog
 include module type of Coord_bootstrap
 include module type of Coord_identity
 include module type of Coord_state
+include module type of Coord_bootstrap
+include module type of Coord_identity
+include module type of Coord_task_id
+include module type of Coord_backlog
 include module type of Coord_broadcast
 include module type of Coord_lifecycle
 include module type of Coord_init

--- a/lib/coord/coord_init.ml
+++ b/lib/coord/coord_init.ml
@@ -6,6 +6,7 @@
 open Masc_domain
 open Coord_utils
 open Coord_state
+open Coord_backlog
 open Coord_broadcast
 open Coord_backlog
 

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -6,6 +6,7 @@
 open Masc_domain
 open Coord_utils
 open Coord_state
+open Coord_identity
 open Coord_broadcast
 open Coord_identity
 

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -7,6 +7,8 @@
 open Masc_domain
 include Coord_utils
 include Coord_state
+open Coord_backlog
+open Coord_identity
 include Coord_broadcast
 open Coord_backlog
 open Coord_identity

--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -8,6 +8,8 @@
 open Masc_domain
 include Coord_utils
 include Coord_state
+open Coord_backlog
+open Coord_identity
 include Coord_broadcast
 open Coord_backlog
 open Coord_identity

--- a/lib/coord/coord_task_create.ml
+++ b/lib/coord/coord_task_create.ml
@@ -7,6 +7,8 @@
 open Masc_domain
 include Coord_utils
 include Coord_state
+open Coord_backlog
+open Coord_task_id
 include Coord_broadcast
 open Coord_backlog
 open Coord_task_id

--- a/test/test_cascade_config_validity.ml
+++ b/test/test_cascade_config_validity.ml
@@ -158,6 +158,31 @@ let test_strict_tool_group_does_not_bypass_glm_before_ollama_cloud () =
              provider_k-coding-with-spark ahead of it"))
 ;;
 
+let test_no_deprecated_profile_names () =
+  let cfg = load_checked_in_cascade_toml () in
+  let deprecated_tiers =
+    cfg.Types.tiers
+    |> List.filter_map (fun (tier : Types.cascade_tier) ->
+      if Masc_mcp.Cascade_config_loader.is_deprecated_logical_profile_name tier.name
+      then Some ("tier." ^ tier.name)
+      else None)
+  in
+  let deprecated_groups =
+    cfg.Types.tier_groups
+    |> List.filter_map (fun (group : Types.cascade_tier_group) ->
+      if
+        Masc_mcp.Cascade_config_loader.is_deprecated_logical_profile_name
+          group.name
+      then Some ("tier-group." ^ group.name)
+      else None)
+  in
+  check
+    string
+    "deprecated tier/tier-group names"
+    ""
+    (String.concat ", " (deprecated_tiers @ deprecated_groups))
+;;
+
 let check_qwen_thinking_control cfg model_id =
   match Types.model_capabilities_for_id cfg model_id with
   | Some c ->
@@ -214,6 +239,10 @@ let () =
             "strict tool group does not bypass GLM before Ollama Cloud"
             `Quick
             test_strict_tool_group_does_not_bypass_glm_before_ollama_cloud
+        ; test_case
+            "cascade.toml has no deprecated profile names"
+            `Quick
+            test_no_deprecated_profile_names
         ; test_case
             "provider_h models use chat_template_kwargs thinking control"
             `Quick

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -68,14 +68,14 @@ tools-support = true
 
 [custom.mock]
 
-[tier.keeper_unified]
+[tier.primary]
 members = ["custom.mock"]
 
-[tier-group.keeper_unified]
-tiers = ["keeper_unified"]
+[tier-group.primary]
+tiers = ["primary"]
 
 [routes.keeper_turn]
-target = "tier-group.keeper_unified"
+target = "tier-group.primary"
 |}
 
 let write_keeper_toml_exn ?autoboot_enabled config ~name =

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -97,14 +97,14 @@ tools-support = true
 
 [custom.mock]
 
-[tier.keeper_unified]
+[tier.primary]
 members = ["custom.mock"]
 
-[tier-group.keeper_unified]
-tiers = ["keeper_unified"]
+[tier-group.primary]
+tiers = ["primary"]
 
 [routes.keeper_turn]
-target = "tier-group.keeper_unified"
+target = "tier-group.primary"
 |};
       Unix.putenv "MASC_CONFIG_DIR" config_dir;
       Config_dir_resolver.reset ();

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -913,6 +913,46 @@ target = "tier.broken"
               && contains ~needle:"Binding_resolution_failed" message)
            errors)
 
+let test_runtime_validation_rejects_deprecated_profile_names () =
+  let cascade_toml =
+    {|
+[providers.ollama]
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.qwen3]
+api-name = "qwen3:8b"
+max-context = 32768
+tools-support = true
+
+[ollama.qwen3]
+max-concurrent = 1
+
+[tier.local_only]
+members = ["ollama.qwen3"]
+strategy = "failover"
+
+[tier-group.local_only]
+tiers = ["local_only"]
+
+[routes.keeper_turn]
+target = "tier-group.local_only"
+|}
+  in
+  with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
+  match
+    Masc_mcp.Cascade_catalog_runtime.validate_path ~config_path:cascade_path ()
+  with
+  | Ok _ -> fail "runtime validation should reject deprecated cascade profile names"
+  | Error rejection ->
+      let errors = rejection_error_messages rejection in
+      check bool "runtime rejection contains deprecated profile name" true
+        (List.exists
+           (fun message ->
+              contains ~needle:"deprecated cascade profile name" message
+              && contains ~needle:"local_only" message)
+           errors)
+
 let test_cascade_name_rejects_system_only_catalog_entry () =
   with_temp_config_dir minimal_cascade_profile_metadata_toml
   @@ fun ~config_root:_ ~cascade_path:_ ->
@@ -1076,6 +1116,8 @@ let () =
             test_runtime_validation_rejects_declarative_parse_errors;
           test_case "runtime rejects declarative adapter errors" `Quick
             test_runtime_validation_rejects_declarative_adapter_errors;
+          test_case "runtime rejects deprecated profile names" `Quick
+            test_runtime_validation_rejects_deprecated_profile_names;
           test_case "rejects system-only catalog entry" `Quick
             test_cascade_name_rejects_system_only_catalog_entry;
           test_case "accepts dispatch tool_access preset" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -442,14 +442,14 @@ api-name = "qwen3.6:35b-a3b-mlx-bf16"
 max-context = 32768
 tools-support = false
 
-[tier.local_only]
+[tier.invalid_local_lane]
 members = ["missing_provider.provider_h"]
 
-[tier-group.local_only]
-tiers = ["local_only"]
+[tier-group.invalid_local_lane]
+tiers = ["invalid_local_lane"]
 
 [routes.keeper_turn]
-target = "tier-group.local_only"
+target = "tier-group.invalid_local_lane"
 |}
 
 let split_custom_model_spec spec =


### PR DESCRIPTION
## Summary
- reject deprecated raw tier and tier-group names during cascade catalog load instead of filtering them later
- remove the deprecated-profile filter metric and registry entry because deprecated names are now load errors
- rename checked-in and fixture profile declarations away from retired logical names, including the provider benchmark sweep lane

## Verification
- rg backstop confirmed deprecated-profile filter metric symbols are gone
- rg backstop confirmed no raw deprecated tier/tier-group declarations remain outside the intentional rejection test
- git diff --check
- ocamlformat --check on changed .ml/.mli files
- scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_keeper_toml_config_validation.exe test/test_cascade_config_validity.exe blocked with exit 75 because bare Dune processes were already running outside the wrapper

Implements the cascade deprecated profile name P2 purge from #18357.