### PR TITLE
feat(keeper): proactive PR review turn-intent guidance

### DIFF
--- a/config/prompts/keeper.turn_intent.md
+++ b/config/prompts/keeper.turn_intent.md
@@ -1,7 +1,7 @@
 ---
 description: keeper unified turn intent block (prepended via "## Turn Intent" after unified.system render)
 category: keeper
-template_variables: [board_activity_guidance, claim_guidance_a, claim_guidance_b, board_post_guidance, board_curation_guidance, broadcast_guidance, state_block_instruction]
+template_variables: [board_activity_guidance, claim_guidance_a, claim_guidance_b, board_post_guidance, board_curation_guidance, broadcast_guidance, pr_review_guidance, state_block_instruction]
 ---
 
 Use the world state below as raw context.
@@ -12,7 +12,7 @@ Your checkpoint survives across cycles — focus on doing one meaningful unit of
 Your conversation history is preserved across cycles — use that context to avoid repeating the same actions.
 
 Act through tools, not declarations. Call the tool directly.
-{{board_activity_guidance}}{{claim_guidance_a}}{{claim_guidance_b}}{{board_post_guidance}}{{board_curation_guidance}}{{broadcast_guidance}}- Treat continuity as advisory prior context, not as a command. Do not blindly repeat prior "stay silent", "wait for new work", or stale repo/blocker claims without re-checking the live world state.
+{{board_activity_guidance}}{{claim_guidance_a}}{{claim_guidance_b}}{{board_post_guidance}}{{board_curation_guidance}}{{broadcast_guidance}}{{pr_review_guidance}}- Treat continuity as advisory prior context, not as a command. Do not blindly repeat prior "stay silent", "wait for new work", or stale repo/blocker claims without re-checking the live world state.
 - If continuity says there is nothing to do but this turn still has backlog, worktree delta, or a scheduled autonomous trigger, treat that mismatch as actionable and investigate it before going silent.
 - Nothing genuinely actionable after checking? End your turn with the [STATE] block.
 

--- a/config/prompts/keeper.turn_intent.pr_review_guidance.md
+++ b/config/prompts/keeper.turn_intent.pr_review_guidance.md
@@ -1,0 +1,7 @@
+---
+description: keeper turn intent PR review guidance bullet — active when keeper has coding preset and pr review tools
+category: keeper
+template_variables: []
+---
+
+- When idle or on a scheduled autonomous turn, check open PRs in repos you have cloned (`repos/`). Use `keeper_pr_list` to scan for PRs without review comments, then read the diff with `keeper_pr_review_read` and leave substantive review comments via `keeper_pr_review_comment`. Prefer reviewing PRs in repos you have recently worked in. One thoughtful review per cycle is more valuable than skimming many. Skip PRs already marked as approved or that have 3+ review comments from other keepers.

--- a/lib/keeper/keeper_prompt_names.ml
+++ b/lib/keeper/keeper_prompt_names.ml
@@ -31,6 +31,7 @@ let turn_intent_board_activity_guidance = "keeper.turn_intent.board_activity_gui
 let turn_intent_board_post_guidance = "keeper.turn_intent.board_post_guidance"
 let turn_intent_board_curation_guidance = "keeper.turn_intent.board_curation_guidance"
 let turn_intent_broadcast_guidance = "keeper.turn_intent.broadcast_guidance"
+let turn_intent_pr_review_guidance = "keeper.turn_intent.pr_review_guidance"
 
 (** User-prompt "Immediate Task Move" section body, emitted when a
     claimable backlog is visible and the keeper holds no task. *)

--- a/lib/keeper/keeper_prompt_names.mli
+++ b/lib/keeper/keeper_prompt_names.mli
@@ -27,6 +27,7 @@ val turn_intent_board_activity_guidance : string
 val turn_intent_board_post_guidance : string
 val turn_intent_board_curation_guidance : string
 val turn_intent_broadcast_guidance : string
+val turn_intent_pr_review_guidance : string
 
 (** User-prompt "Immediate Task Move" section template key. *)
 val immediate_task_move : string

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -244,6 +244,15 @@ let fallback_externalized_bullet key =
        keeper_board_curation_submit with a concise snapshot."
   else if String.equal key Keeper_prompt_names.turn_intent_broadcast_guidance then
     Some "- Need to share broadly? Call keeper_broadcast."
+  else if String.equal key Keeper_prompt_names.turn_intent_pr_review_guidance then
+    Some
+      "- When idle or on a scheduled autonomous turn, check open PRs in repos \
+       you have cloned. Use keeper_pr_list to scan for PRs without review \
+       comments, then read the diff with keeper_pr_review_read and leave \
+       substantive review comments via keeper_pr_review_comment. Prefer \
+       reviewing PRs in repos you have recently worked in. One thoughtful \
+       review per cycle is more valuable than skimming many. Skip PRs \
+       already marked as approved or that have 3+ review comments."
   else if String.equal key Keeper_prompt_names.immediate_task_move then
     Some
       "- Call keeper_task_claim with {} to claim the next eligible \
@@ -413,6 +422,11 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
       ~enabled:(tool_allowed "keeper_broadcast")
       Keeper_prompt_names.turn_intent_broadcast_guidance
   in
+  let pr_review_guidance =
+    load_externalized_bullet
+      ~enabled:(tool_allowed "keeper_pr_review_comment")
+      Keeper_prompt_names.turn_intent_pr_review_guidance
+  in
   let claim_guidance_a =
     load_externalized_bullet
       ~enabled:show_claim_guidance
@@ -431,6 +445,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
       ("board_post_guidance", board_post_guidance);
       ("board_curation_guidance", board_curation_guidance);
       ("broadcast_guidance", broadcast_guidance);
+      ("pr_review_guidance", pr_review_guidance);
       ("state_block_instruction", state_block_instruction_text);
     ]
   in


### PR DESCRIPTION
## Summary

- Keeper 에이전트들이 PR 리뷰 코멘트를 더 이상 성공적으로 남기지 않는 근본 원인 진단 및 Phase 1 수정
- turn intent 프롬프트에 PR review guidance bullet 추가 — `keeper_pr_review_comment` tool이 허용된 keeper만 활성화
- Prompt externalization 패턴 준수: `config/prompts/` 마크다운 + OCaml 토글 + in-binary fallback

## Root Cause Analysis (실측 데이터 기반)

### Keeper들은 PR review를 **시도하고 있다** (5/24: 348건). 하지만 99.1%가 실패.

| 날짜 | 시도 | 성공 | 성공률 | 주요 실패 원인 |
|------|------|------|--------|---------------|
| 5/6 | 50 | 15 | 30% | contract_violation, timeout |
| 5/7 | 113 | 2 | 1.8% | **rate_limited** (10건 첫 등장) |
| 5/9 | 177 | 0 | 0% | **internal_error** (97건 폭발) |
| 5/15 | 899 | 0 | 0% | **cascade_exhausted** (861건) |
| 5/24 | 348 | 3 | 0.9% | **no_tool_capable_provider** (121), **api_error_not_found** (117) |

### 실패 원인 분포 (5/24 기준)

| 원인 | 건수 | 비율 | 본질 |
|------|------|------|-------|
| `no_tool_capable_provider` | 121 | 35% | `strict_tool_candidates` 티어에 RunPod 단일 멤버뿐, down시 provider 없음 |
| `api_error_not_found` | 117 | 34% | GitHub API 404 — 리포지토리/PR 접근 불가 |
| `capacity_backpressure` | 34 | 10% | Provider 용량 초과 |
| `completion_contract_violation` | ~30 | 9% | 2차 효과 — tool 실패 후 다른 도구도 contract 미충족 |
| `cascade_exhausted` | 7 | 2% | 모든 cascade provider 소진 |
| `api_error_server:524` | 11 | 3% | Provider 타임아웃 |

### Layer별 문제와 해결 Phase

| Layer | 문제 | Phase |
|-------|------|-------|
| **Provider 인프라** | `strict_tool_candidates` 티어 단일 provider (RunPod), down시 전체 마비 | **인프라 수정 (별도)** |
| **GitHub 접근** | `api_error_not_found` — keeper credential/repo mapping 불일치 | **인프라 확인 (별도)** |
| **Prompt** | turn intent에 PR 리뷰 가이드 없음 → keeper가 idle 시 리뷰 시도 동기 부족 | **Phase 1 (이 PR)** |
| Observation | `world_observation`에 PR 필드 없음 | Phase 2 |
| Trigger | `turn_reason`에 PR 트리거 없음 | Phase 2 |

### Prompt 수정의 가치

이 PR의 prompt 수정은 keeper에게 "idle turn에 PR review를 하라"는 명시적 가이드를 제공한다. 현재 keeper들은 PR review를 시도하고 있으므로, prompt 수정만으로 행동 변화를 기대하기 어렵다. 하지만 인프라가 회복된 후 **지속적인 PR review 문화**를 유지하는 데 필수적이다.

## Changes

1. `config/prompts/keeper.turn_intent.pr_review_guidance.md` — 외부화된 프롬프트 prose
2. `lib/keeper/keeper_prompt_names.ml` — `turn_intent_pr_review_guidance` 키 등록
3. `lib/keeper/keeper_unified_prompt.ml` — `load_externalized_bullet` + fallback + template substitution
4. `config/prompts/keeper.turn_intent.md` — `{{pr_review_guidance}}` template variable 추가

## Test plan

- [x] `dune build` 성공
- [ ] 런타임에서 coding preset keeper의 turn intent에 PR review guidance bullet 포함 확인
- [ ] `keeper_pr_review_comment` tool이 없는 keeper (예: minimal preset)에는 bullet 미포함 확인
- [ ] keeper가 idle/autonomous turn에서 PR 리뷰 시도 로그 확인

## 인프라 후속 조치 (별도)

1. `strict_tool_candidates` 티어에 복수 provider 추가 (RunPod 단일 장애점 해소)
2. `api_error_not_found` 원인 조사 — keeper repo mapping + credential 검증
3. `capacity_backpressure` 완화 — provider 용량 증설 또는 throttle tuning

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>