### PR TITLE
fix(cascade): include runtime MCP tools in pre-dispatch satisfying_tools

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1181,10 +1181,17 @@ let run_named
         | Error _ ->
           (* Tool resolution failed — fall through as Capability_unknown. *)
           None
-        | Ok (effective_tools, _) ->
+        | Ok (effective_tools, runtime_mcp_policy) ->
           let satisfying_tools =
             effective_tools
             |> List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name)
+          in
+          let satisfying_tools =
+            match runtime_mcp_policy with
+            | Some policy ->
+              Json_util.dedupe_keep_order
+                (satisfying_tools @ policy.Llm_provider.Llm_transport.allowed_tool_names)
+            | None -> satisfying_tools
           in
           let snapshot =
             Provider_capability.known


### PR DESCRIPTION
## Summary
- Pre-dispatch gate (RFC-0157 PR-1) built `satisfying_tools` only from inline OAS tools, discarding `runtime_mcp_policy` with `_`
- GLM providers take the inline tools path → `keeper_bash` (runtime MCP-only tool) was missing from satisfying_tools
- All candidates rejected → `no_tool_capable_provider` error (66 occurrences in 2026-05-25 logs)

## Root Cause
```
resolve_tool_lane_for_oas_tools → Ok(effective_tools, runtime_mcp_policy)
                                                          ^ discarded
satisfying_tools = only inline tool names
required_tools includes keeper_bash (via runtime_mcp_policy.allowed_tool_names)
→ keeper_bash seen as missing → all 9 candidates rejected
```

## Fix
Union inline tool names with `runtime_mcp_policy.allowed_tool_names` so the capability snapshot reflects the full effective tool surface (inline + runtime MCP).

## Test plan
- [x] `dune build --root .` — compiles clean
- [x] `test_provider_capability_required_action` — 6/6 pass
- [x] `test_oas_compat_cascade_fallback` — 25/25 pass
- [x] `test_cascade_error_classify_decoder` — 12/12 pass
- [ ] Verify no `no_tool_capable_provider` errors in live keeper logs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)