### PR TITLE
refactor(keeper): drop legacy history content fallback

### DIFF
--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -32,20 +32,6 @@ let content_blocks_of_json
       if List.length parsed = List.length blocks then Some parsed else None
   | _ -> None
 
-let legacy_content_blocks_of_json
-    (json : Yojson.Safe.t) : Agent_sdk.Types.content_block list option =
-  let open Yojson.Safe.Util in
-  match json |> member "content" with
-  | `String text -> Some [ Agent_sdk.Types.Text text ]
-  | `List blocks ->
-    let parse_legacy_block = function
-      | `String text -> Some (Agent_sdk.Types.Text text)
-      | block -> Agent_sdk.Api.content_block_of_json block
-    in
-    let parsed = List.filter_map parse_legacy_block blocks in
-    if List.length parsed = List.length blocks then Some parsed else None
-  | _ -> None
-
 let string_field_opt key value =
   match value with
   | Some text -> [ (key, `String text) ]
@@ -82,8 +68,6 @@ let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
         | Agent_sdk.Types.User
         | Agent_sdk.Types.Assistant -> None)
   in
-  (* SSOT for new writes: structured [content_blocks]. Readers below still
-     accept legacy flat [content] rows when [content_blocks] is absent. *)
   let base =
     [
       ("role", `String (role_to_string m.role));
@@ -109,7 +93,7 @@ let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
   let content =
     match content_blocks_of_json json with
     | Some blocks -> blocks
-    | None -> Option.value (legacy_content_blocks_of_json json) ~default:[]
+    | None -> []
   in
   Inference_utils.sanitize_message_utf8
     {
@@ -124,9 +108,8 @@ let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
       metadata = [];
     }
 
-(** Extract human-readable text from a single history.jsonl line. Reads
-    structured [content_blocks] first and falls back to legacy [content] rows
-    when the canonical shape is absent. *)
+(** Extract human-readable text from a single history.jsonl line.
+    Structured [content_blocks] is the only supported message-content shape. *)
 let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
   let text_of_blocks blocks =
     if blocks = []
@@ -145,7 +128,4 @@ let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
   in
   match content_blocks_of_json json with
   | Some blocks -> text_of_blocks blocks
-  | None ->
-    (match legacy_content_blocks_of_json json with
-     | Some blocks -> text_of_blocks blocks
-     | None -> "")
+  | None -> ""

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -4,8 +4,8 @@
 
     1. [message_to_json] no longer emits the flat ["content"] field;
        [content_blocks] is the write-side source of truth.
-    2. Readers prefer [content_blocks] and keep a legacy read fallback for
-       older flat ["content"] history/checkpoint rows.
+    2. Readers consume [content_blocks] as the sole supported history /
+       checkpoint content shape.
     3. [tool_result_text_of_block] caps json-only results at the existing
        [default_max_checkpoint_tool_result_chars] threshold instead of
        inlining the full [Yojson.Safe.to_string] output. *)
@@ -36,7 +36,7 @@ let test_message_to_json_omits_flat_content () =
         (List.mem_assoc "content_blocks" fields)
   | _ -> Alcotest.fail "expected `Assoc"
 
-(* --- message_of_json: canonical content_blocks first, legacy content fallback --- *)
+(* --- message_of_json: canonical content_blocks only --- *)
 
 let test_message_of_json_new_content_blocks_only () =
   (* New checkpoints have only content_blocks — must load as before. *)
@@ -54,15 +54,6 @@ let test_message_of_json_new_content_blocks_only () =
   match parsed.content with
   | [ T.Text s ] -> Alcotest.(check string) "text" "world" s
   | _ -> Alcotest.fail "expected one Text block"
-
-let test_message_of_json_loads_flat_content_fallback () =
-  let flat_content : Yojson.Safe.t =
-    `Assoc [ ("role", `String "user"); ("content", `String "flat hi") ]
-  in
-  let msg = C.message_of_json flat_content in
-  match msg.content with
-  | [ T.Text text ] -> Alcotest.(check string) "flat content text" "flat hi" text
-  | _ -> Alcotest.fail "expected legacy flat content to load as one Text block"
 
 let test_message_of_json_rejects_unknown_role () =
   let json : Yojson.Safe.t =
@@ -88,38 +79,6 @@ let test_history_jsonl_text_uses_blocks_first () =
   in
   let text = C.text_of_history_jsonl_json new_format in
   Alcotest.(check string) "text from blocks" "structured payload" text
-
-let test_history_jsonl_text_loads_flat_content_fallback () =
-  let flat_content : Yojson.Safe.t =
-    `Assoc
-      [
-        ("role", `String "user");
-        ("content", `String "flat payload");
-      ]
-  in
-  let text = C.text_of_history_jsonl_json flat_content in
-  Alcotest.(check string) "flat content fallback" "flat payload" text
-
-let test_history_jsonl_text_loads_legacy_content_array () =
-  let source : T.message =
-    {
-      T.role = T.User;
-      content = [ T.Text "array history payload" ];
-      name = None;
-      tool_call_id = None;
-      metadata = [];
-    }
-  in
-  let content_blocks =
-    match C.message_to_json source with
-    | `Assoc fields -> List.assoc "content_blocks" fields
-    | _ -> Alcotest.fail "expected object"
-  in
-  let content_array : Yojson.Safe.t =
-    `Assoc [ ("role", `String "user"); ("content", content_blocks) ]
-  in
-  let text = C.text_of_history_jsonl_json content_array in
-  Alcotest.(check string) "content array fallback" "array history payload" text
 
 let test_history_jsonl_text_empty_when_neither () =
   let empty : Yojson.Safe.t = `Assoc [ ("role", `String "user") ] in
@@ -210,8 +169,6 @@ let () =
         [
           Alcotest.test_case "new content_blocks-only loads" `Quick
             test_message_of_json_new_content_blocks_only;
-          Alcotest.test_case "flat content fallback loads" `Quick
-            test_message_of_json_loads_flat_content_fallback;
           Alcotest.test_case "unknown role rejected" `Quick
             test_message_of_json_rejects_unknown_role;
           Alcotest.test_case "round-trip text preserved" `Quick
@@ -221,10 +178,6 @@ let () =
         [
           Alcotest.test_case "blocks first" `Quick
             test_history_jsonl_text_uses_blocks_first;
-          Alcotest.test_case "flat content fallback loads" `Quick
-            test_history_jsonl_text_loads_flat_content_fallback;
-          Alcotest.test_case "legacy content array fallback loads" `Quick
-            test_history_jsonl_text_loads_legacy_content_array;
           Alcotest.test_case "empty when neither" `Quick
             test_history_jsonl_text_empty_when_neither;
         ] );

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -332,16 +332,35 @@ let rec cleanup_tmpdir_recursive dir =
     (try Unix.rmdir dir with _ -> ())
   end
 
+let history_role = function
+  | "system" -> Agent_sdk.Types.System
+  | "user" -> Agent_sdk.Types.User
+  | "assistant" -> Agent_sdk.Types.Assistant
+  | "tool" -> Agent_sdk.Types.Tool
+  | role -> fail ("unsupported history role fixture: " ^ role)
+
+let history_json_line ?source role text =
+  let msg = Agent_sdk.Types.text_message (history_role role) text in
+  match KEC.message_to_json msg with
+  | `Assoc fields ->
+      let fields =
+        match source with
+        | Some source -> ("source", `String source) :: fields
+        | None -> fields
+      in
+      Yojson.Safe.to_string (`Assoc fields)
+  | _ -> fail "history message fixture must encode as object"
+
 let test_load_history_user_messages () =
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
     let path = Filename.concat dir "history.jsonl" in
     let lines = [
-      {|{"role":"user","content":"hello world"}|};
-      {|{"role":"assistant","content":"hi there"}|};
-      {|{"role":"user","content":"second question"}|};
-      {|{"role":"user","content":""}|};
-      {|{"role":"user","content":"third question"}|};
+      history_json_line "user" "hello world";
+      history_json_line "assistant" "hi there";
+      history_json_line "user" "second question";
+      history_json_line "user" "";
+      history_json_line "user" "third question";
     ] in
     let oc = open_out path in
     List.iter (fun l -> output_string oc (l ^ "\n")) lines;
@@ -361,10 +380,12 @@ let test_load_history_user_messages_ignores_internal_prompt_entries () =
   Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
     let path = Filename.concat dir "history.jsonl" in
     let lines = [
-      {|{"role":"user","source":"world_state_prompt","content":"## Current World State\n\n### Namespace State\n- Unclaimed tasks: 1\n\n### Available Tools\n- keeper_board_list\n\n### Continuity\nGoal: keep going"}|};
-      {|{"role":"user","content":"real user question"}|};
-      {|{"role":"user","source":"memory_jsonl","content":"## Current World State\n\n### Namespace State\n- User-authored world memory should survive history filtering"}|};
-      {|{"role":"user","content":"second real question"}|};
+      history_json_line ~source:"world_state_prompt" "user"
+        "## Current World State\n\n### Namespace State\n- Unclaimed tasks: 1\n\n### Available Tools\n- keeper_board_list\n\n### Continuity\nGoal: keep going";
+      history_json_line "user" "real user question";
+      history_json_line ~source:"memory_jsonl" "user"
+        "## Current World State\n\n### Namespace State\n- User-authored world memory should survive history filtering";
+      history_json_line "user" "second real question";
     ] in
     let oc = open_out path in
     List.iter (fun l -> output_string oc (l ^ "\n")) lines;
@@ -491,8 +512,8 @@ let test_recall_candidates_with_history_dedup () =
     let path = Filename.concat dir "history.jsonl" in
     (* history contains same message as checkpoint *)
     let lines = [
-      {|{"role":"user","content":"hello world"}|};
-      {|{"role":"user","content":"unique from history"}|};
+      history_json_line "user" "hello world";
+      history_json_line "user" "unique from history";
     ] in
     let oc = open_out path in
     List.iter (fun l -> output_string oc (l ^ "\n")) lines;
@@ -514,8 +535,8 @@ let test_recall_candidates_with_history_appends () =
   Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
     let path = Filename.concat dir "history.jsonl" in
     let lines = [
-      {|{"role":"user","content":"old question from 3 days ago"}|};
-      {|{"role":"user","content":"another old question"}|};
+      history_json_line "user" "old question from 3 days ago";
+      history_json_line "user" "another old question";
     ] in
     let oc = open_out path in
     List.iter (fun l -> output_string oc (l ^ "\n")) lines;
@@ -974,10 +995,10 @@ let test_memory_search_cross_generation () =
     (* Write history.jsonl with messages from previous generations *)
     let history_path = Keeper_types.keeper_history_path config (Masc_mcp.Keeper_id.Trace_id.to_string trace_id) in
     write_lines history_path [
-      {|{"role":"user","content":"deploy the canary release"}|};
-      {|{"role":"assistant","content":"deploying now"}|};
-      {|{"role":"user","content":"what was the incident root cause"}|};
-      {|{"role":"user","content":"scale the fleet to 12 pods"}|};
+      history_json_line "user" "deploy the canary release";
+      history_json_line "assistant" "deploying now";
+      history_json_line "user" "what was the incident root cause";
+      history_json_line "user" "scale the fleet to 12 pods";
     ];
     (* Current checkpoint has different messages — no overlap with history query *)
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
@@ -1023,8 +1044,8 @@ let test_memory_search_dedup () =
     let trace_id = meta.runtime.trace_id in
     let history_path = Keeper_types.keeper_history_path config (Masc_mcp.Keeper_id.Trace_id.to_string trace_id) in
     write_lines history_path [
-      {|{"role":"user","content":"unique needle from history"}|};
-      {|{"role":"user","content":"shared needle message"}|};
+      history_json_line "user" "unique needle from history";
+      history_json_line "user" "shared needle message";
     ];
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
     let ctx_work = KEC.append ctx_work
@@ -1054,13 +1075,13 @@ let test_memory_search_prev_generation () =
     (* Previous generation's history — different trace_id directory *)
     let prev_history_path = Keeper_types.keeper_history_path config prev_trace in
     write_lines prev_history_path [
-      {|{"role":"user","content":"migrate the postgres schema to v3"}|};
-      {|{"role":"user","content":"rollback the failed deployment"}|};
+      history_json_line "user" "migrate the postgres schema to v3";
+      history_json_line "user" "rollback the failed deployment";
     ];
     (* Current generation's history — empty (just started) *)
     let curr_history_path = Keeper_types.keeper_history_path config curr_trace in
     write_lines curr_history_path [
-      {|{"role":"user","content":"check cluster health"}|};
+      history_json_line "user" "check cluster health";
     ];
     (* Checkpoint has only new-gen messages *)
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
@@ -1476,7 +1497,7 @@ let test_memory_search_bank_no_match () =
     let no_match = Yojson.Safe.Util.(json |> member "no_match" |> to_bool) in
     check bool "no_match for unrelated query" true no_match)
 
-(** Test: source=history uses legacy cross-generation search. *)
+(** Test: source=history reads canonical history JSONL. *)
 let test_memory_search_source_history () =
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir_r dir) (fun () ->
@@ -1485,7 +1506,7 @@ let test_memory_search_source_history () =
     let trace_id = meta.runtime.trace_id in
     let history_path = Keeper_types.keeper_history_path config (Masc_mcp.Keeper_id.Trace_id.to_string trace_id) in
     write_lines history_path [
-      {|{"role":"user","content":"deploy the legacy service"}|};
+      history_json_line "user" "deploy the legacy service";
     ];
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
     let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
@@ -1512,7 +1533,7 @@ let test_memory_search_source_all () =
     let trace_id = meta.runtime.trace_id in
     let history_path = Keeper_types.keeper_history_path config (Masc_mcp.Keeper_id.Trace_id.to_string trace_id) in
     write_lines history_path [
-      {|{"role":"user","content":"alpha from history"}|};
+      history_json_line "user" "alpha from history";
     ];
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
     let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None


### PR DESCRIPTION
## Summary
- remove legacy flat content and content-array fallback readers from keeper context message JSON
- keep content_blocks as the only supported history/checkpoint message content shape
- delete fallback-preservation tests and update history-memory fixtures to write canonical content_blocks rows

## Verification
- rg backstop confirmed legacy content fallback symbols and flat-content fixture rows are gone from the touched surfaces
- git diff --check
- ocamlformat --check on changed .ml files
- scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_keeper_context_core_dedup.exe test/test_keeper_memory.exe blocked with exit 75 because a bare Dune process was already running outside the wrapper

Implements the memory/context legacy read fallback P1 purge from #18357.