### PR TITLE
fix(keeper): reject empty executable before allowlist check

### DIFF
--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -25,6 +25,7 @@ type validation_error =
       name : string;
       mode : allowlist_mode;
     }
+  | Empty_executable
   | Empty_argv of { executable : string }
   | Argv_contains_shell_metachar of {
       executable : string;
@@ -280,8 +281,10 @@ let check_wrapper_exec_target ~mode ~executable ~argv =
 
 let check_exec ~mode ~executable ~argv ~cwd ~env =
   let ( let* ) = Result.bind in
-  if not (is_allowed ~mode executable)
-  then Error (Executable_not_allowlisted { name = executable; mode })
+  let trimmed = String.trim executable in
+  if String.length trimmed = 0 then Error Empty_executable
+  else if not (is_allowed ~mode trimmed)
+  then Error (Executable_not_allowlisted { name = trimmed; mode })
   else
     let* () =
       if argv = [] then Ok () else check_argv ~executable argv
@@ -369,6 +372,10 @@ let pp_mode ppf = function
 let pp_validation_error ppf = function
   | Executable_not_allowlisted { name; mode } ->
     Format.fprintf ppf "executable %S not in %a allowlist" name pp_mode mode
+  | Empty_executable ->
+    Format.pp_print_string ppf
+      "executable is empty — provide a non-empty allowlisted command name, \
+       e.g. executable=\"cat\" argv=[\"file.txt\"]"
   | Empty_argv { executable } ->
     Format.fprintf ppf "executable %S invoked with empty argv" executable
   | Argv_contains_shell_metachar { executable; index; token } ->

--- a/lib/keeper/keeper_tool_bash_input.mli
+++ b/lib/keeper/keeper_tool_bash_input.mli
@@ -57,6 +57,7 @@ type validation_error =
       name : string;
       mode : allowlist_mode;
     }
+  | Empty_executable
   | Empty_argv of { executable : string }
   | Argv_contains_shell_metachar of {
       executable : string;


### PR DESCRIPTION
## Summary
- Add `Empty_executable` validation_error variant that rejects `executable=""` or whitespace-only before the allowlist check
- LLM sends `'' cat goal-loop/status.json` → executable="" → confusing "not in allowlist" error → circuit breaker trips (albini 18, verifier 17 on 2026-05-25)
- New error message includes format guidance: `executable="cat" argv=["file.txt"]`

## Root Cause
The allowlist check produced `executable "" not in dev_full allowlist` for empty strings, which is technically correct but unhelpful. The LLM couldn't self-correct because the error didn't explain *why* it was wrong.

## Verification
- `dune build @default` passes (exhaustive match confirmed)
- No test files pattern-match on `validation_error` variants

Closes #18367

🤖 Generated with [Claude Code](https://claude.com/claude-code)