### PR TITLE
refactor(keeper): remove Keeper_types mkdir_p facade

### DIFF
--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -90,7 +90,7 @@ let prepare_run_context
   let session_dir =
     Filename.concat base_dir (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
   in
-  mkdir_p session_dir;
+  let (_ : string) = Keeper_fs.ensure_dir session_dir in
   (* 2. Load checkpoint *)
   let session, ctx_opt =
     Keeper_exec_context.load_context_from_checkpoint

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -854,7 +854,7 @@ let maybe_prune_retention ~base_dir =
 let append_to_path path manifest =
   try
     let dir = Filename.dirname path in
-    Keeper_types_support.mkdir_p dir;
+    let (_ : string) = Keeper_fs.ensure_dir dir in
     Keeper_types_support.append_jsonl_line path (to_json manifest);
     Ok ()
   with

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -301,7 +301,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               match channel_session_key with
               | Some key when direct_reply ->
                 let d = Filename.concat (Filename.concat root "channels") key in
-                Keeper_types.mkdir_p d; d
+                let (_ : string) = Keeper_fs.ensure_dir d in
+                d
               | _ -> root
             in
             let effective_no_skill_route = no_skill_route || direct_reply in

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -6,13 +6,7 @@
 
 include Keeper_config
 
-(* Delegated to Keeper_fs — single fiber-safe ensure_dir implementation. *)
-let mkdir_p_ path = Fs_compat.mkdir_p path
 let ensure_dir_ = Keeper_fs.ensure_dir
-
-(** Backward-compatible mkdir_p: delegates to Keeper_fs.ensure_dir.
-    Used by external callers via [Keeper_types.mkdir_p]. *)
-let mkdir_p path = ignore (Keeper_fs.ensure_dir path)
 
 let keeper_dir_ (config : Coord.config) =
   let d = Filename.concat (Coord.masc_root_dir config) "keepers" in

--- a/lib/keeper/keeper_types_support.mli
+++ b/lib/keeper/keeper_types_support.mli
@@ -6,9 +6,6 @@
 
 include module type of Keeper_config
 
-(** Backward-compatible mkdir_p: delegates to [Keeper_fs.ensure_dir]. *)
-val mkdir_p : string -> unit
-
 (** Resolve the keeper base directory ([.masc/keepers]) for [config],
     creating it if missing. *)
 val keeper_dir_ : Coord.config -> string

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -311,11 +311,13 @@ let run_keeper_cycle
                in
                Eio.Fiber.yield ();
                let base_dir = session_base_dir config in
-               (* Ensure session dir tree for filesystem fallback (issue #3019) *)
-               Keeper_types.mkdir_p
-                 (Filename.concat
-                    base_dir
-                    (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
+               (* Ensure session dir tree for trace artifacts. *)
+               let (_ : string) =
+                 Keeper_fs.ensure_dir
+                   (Filename.concat
+                      base_dir
+                      (Keeper_id.Trace_id.to_string meta.runtime.trace_id))
+               in
                let masc_root = Coord.masc_root_dir config in
                let trajectory_acc =
                  Trajectory.create_accumulator

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -201,7 +201,7 @@ let migrate_legacy_dirs_with_renames (state : Mcp_server.server_state) renames =
       ~prefer_room_flatten_conflicts =
     if not (Sys.file_exists old_dir) then ()
     else begin
-      Keeper_types.mkdir_p new_dir;
+      let (_ : string) = Keeper_fs.ensure_dir new_dir in
       Array.iter (fun name ->
         let old_path = Filename.concat old_dir name in
         let new_path = Filename.concat new_dir name in
@@ -221,12 +221,16 @@ let migrate_legacy_dirs_with_renames (state : Mcp_server.server_state) renames =
                     ~legacy_path:old_path ~current_path:new_path
             then begin
               let replaced_q_path = quarantine_replaced_path ~source_name ~rel_path:rel in
-              Keeper_types.mkdir_p (Filename.dirname replaced_q_path);
+              let (_ : string) =
+                Keeper_fs.ensure_dir (Filename.dirname replaced_q_path)
+              in
               Sys.rename new_path replaced_q_path;
               Sys.rename old_path new_path
             end else if prefer_room_flatten_conflicts then begin
               let replaced_q_path = quarantine_replaced_path ~source_name ~rel_path:rel in
-              Keeper_types.mkdir_p (Filename.dirname replaced_q_path);
+              let (_ : string) =
+                Keeper_fs.ensure_dir (Filename.dirname replaced_q_path)
+              in
               Sys.rename new_path replaced_q_path;
               Sys.rename old_path new_path
             end else begin
@@ -234,7 +238,7 @@ let migrate_legacy_dirs_with_renames (state : Mcp_server.server_state) renames =
                 Filename.concat quarantine
                   (quarantine_rel_path ~source_name ~rel_path:rel)
               in
-              Keeper_types.mkdir_p (Filename.dirname q_path);
+              let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname q_path) in
               Sys.rename old_path q_path
             end
           end else

--- a/test/test_dashboard_k2_feeds.ml
+++ b/test/test_dashboard_k2_feeds.ml
@@ -12,6 +12,7 @@ open Alcotest
 module Coord = Masc_mcp.Coord
 module Dash = Masc_mcp.Dashboard_http_keeper
 module Keeper_config = Masc_mcp.Keeper_config
+module Keeper_fs = Masc_mcp.Keeper_fs
 module Keeper_types = Masc_mcp.Keeper_types
 module Json = Yojson.Safe.Util
 
@@ -58,7 +59,7 @@ let keeper_meta name =
 ;;
 
 let append_jsonl path json =
-  Keeper_types.mkdir_p (Filename.dirname path);
+  let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname path) in
   Masc_mcp.Keeper_types_support.append_jsonl_line path json
 ;;
 

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -5,6 +5,7 @@ module Metrics = Masc_mcp.Keeper_exec_status_metrics
 module KSB = Masc_mcp.Keeper_status_bridge
 module KR = Masc_mcp.Keeper_registry
 module KT = Masc_mcp.Keeper_types
+module KFS = Masc_mcp.Keeper_fs
 module KMP = Masc_mcp.Keeper_memory_policy
 module KTS = Masc_mcp.Keeper_types_support
 module Coord = Masc_mcp.Coord
@@ -129,7 +130,7 @@ let assoc_member key fields =
   | None -> `Null
 
 let write_lines path lines =
-  KT.mkdir_p (Filename.dirname path);
+  let (_ : string) = KFS.ensure_dir (Filename.dirname path) in
   let oc = open_out path in
   Fun.protect
     ~finally:(fun () -> close_out_noerr oc)

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -6,6 +6,7 @@ module KR = Masc_mcp.Keeper_registry
 module KHB = Masc_mcp.Keeper_heartbeat_snapshot
 module KHS = Masc_mcp.Keeper_keepalive_signal
 module KST = Masc_mcp.Keeper_state_machine
+module KFS = Masc_mcp.Keeper_fs
 module P = Masc_mcp.Prometheus
 
 let temp_dir prefix =
@@ -26,7 +27,7 @@ let cleanup_dir dir =
   try rm dir with _ -> ()
 
 let write_lines path lines =
-  KT.mkdir_p (Filename.dirname path);
+  let (_ : string) = KFS.ensure_dir (Filename.dirname path) in
   let oc = open_out path in
   Fun.protect
     ~finally:(fun () -> close_out_noerr oc)

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -7,6 +7,7 @@ module Keeper_memory_recall = Masc_mcp.Keeper_memory_recall
 module Keeper_memory_recall_exn_class = Masc_mcp.Keeper_memory_recall_exn_class
 module Keeper_world_observation = Masc_mcp.Keeper_world_observation
 module Meas = Masc_mcp.Keeper_measurement
+module Keeper_fs = Masc_mcp.Keeper_fs
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_memory_policy = Masc_mcp.Keeper_memory_policy
 module KET = Masc_mcp.Keeper_exec_tools
@@ -799,7 +800,7 @@ let test_read_continuity_summary_prefers_progress_log () =
     let config = make_test_room_config dir in
     let meta = keeper_meta ~name:"progress-pref-keeper" ~mention_targets:["progress-pref-keeper"] () in
     let progress_path = Keeper_types.keeper_progress_path config "progress-pref-keeper" in
-    Keeper_types.mkdir_p (Filename.dirname progress_path);
+    let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname progress_path) in
     (match
        Fs_compat.save_file_atomic progress_path
          "# Keeper Progress\nGoal: recover from progress file\nNEXT: verify only progress path is used\n"
@@ -821,7 +822,7 @@ let test_read_continuity_summary_caps_progress_log () =
     let keeper = "progress-cap-keeper" in
     let meta = keeper_meta ~name:keeper ~mention_targets:[keeper] () in
     let progress_path = Keeper_types.keeper_progress_path config keeper in
-    Keeper_types.mkdir_p (Filename.dirname progress_path);
+    let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname progress_path) in
     let max_chars =
       Masc_mcp.Keeper_memory_policy.default_continuity_summary_max_chars
     in
@@ -848,7 +849,7 @@ let test_keeper_context_status_reports_recovery_source_and_tiers () =
     let config = make_test_room_config dir in
     let meta = keeper_meta ~name:"status-keeper" ~mention_targets:["status-keeper"] () in
     let progress_path = Keeper_types.keeper_progress_path config "status-keeper" in
-    Keeper_types.mkdir_p (Filename.dirname progress_path);
+    let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname progress_path) in
     (match
        Fs_compat.save_file_atomic progress_path
          "# Keeper Progress\nGoal: status recovery\nNEXT: emit recovery source\n"
@@ -957,7 +958,7 @@ let rec cleanup_tmpdir_r dir =
 
 (** Write lines to a file, creating parent dirs as needed. *)
 let write_lines path lines =
-  Keeper_types.mkdir_p (Filename.dirname path);
+  let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname path) in
   let oc = open_out path in
   Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
     List.iter (fun l -> output_string oc (l ^ "\n")) lines)
@@ -1435,7 +1436,10 @@ let test_memory_search_decision_log_failure_is_observable () =
     let config = make_test_room_config dir in
     let keeper_name = "memory-search-log-failure" in
     let meta = keeper_meta ~name:keeper_name ~mention_targets:[keeper_name] () in
-    Keeper_types.mkdir_p (Keeper_types.keeper_decision_log_path config keeper_name);
+    let (_ : string) =
+      Keeper_fs.ensure_dir
+        (Keeper_types.keeper_decision_log_path config keeper_name)
+    in
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
     let before =
       Masc_mcp.Prometheus.metric_value_or_zero
@@ -1793,7 +1797,7 @@ let test_compaction_records_consolidation_metrics () =
     let config = make_test_room_config dir in
     let meta = keeper_meta ~name:keeper ~mention_targets:[keeper] () in
     let bank_path = Keeper_types.keeper_memory_bank_path config keeper in
-    Keeper_types.mkdir_p (Filename.dirname bank_path);
+    let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname bank_path) in
     let progress_rows =
       List.init 3 (fun i ->
         memory_bank_test_row
@@ -1904,7 +1908,7 @@ let test_compaction_runs_on_note_pressure_under_byte_trigger () =
     let config = make_test_room_config dir in
     let meta = keeper_meta ~name:keeper ~mention_targets:[ keeper ] () in
     let bank_path = Keeper_types.keeper_memory_bank_path config keeper in
-    Keeper_types.mkdir_p (Filename.dirname bank_path);
+    let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname bank_path) in
     let target_notes = Keeper_memory_bank.memory_compaction_target_notes () in
     let rows =
       List.init (target_notes + 1) (fun i ->

--- a/test/test_keeper_meta_unknown_keys_warn.ml
+++ b/test/test_keeper_meta_unknown_keys_warn.ml
@@ -60,7 +60,7 @@ let test_counter_ticks_on_genuine_unknown_key () =
 let fresh_tmpdir () =
   let path = Filename.temp_file "masc-progress-refresh-" ".tmp" in
   Sys.remove path;
-  Keeper_types.mkdir_p path;
+  let (_ : string) = Keeper_fs.ensure_dir path in
   path
 
 let cleanup_tmpdir path =
@@ -72,7 +72,7 @@ let test_progress_updated_line_failure_is_observable () =
     let config = Coord.default_config dir in
     let keeper_name = "progress-refresh-failure" in
     let progress_path = Keeper_types.keeper_progress_path config keeper_name in
-    Keeper_types.mkdir_p progress_path;
+    let (_ : string) = Keeper_fs.ensure_dir progress_path in
     let before =
       Prometheus.metric_total
         Masc_mcp.Keeper_metrics.metric_keeper_progress_updated_line_failures

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -23,6 +23,7 @@ module HK = Masc_mcp.Keeper_hooks_oas
 module KG = Masc_mcp.Keeper_guards
 module OMR = Masc_mcp.Cascade_runtime
 module AQ = Masc_mcp.Keeper_approval_queue
+module Keeper_fs = Masc_mcp.Keeper_fs
 module Keeper_types = Masc_mcp.Keeper_types
 
 let oas_error_cascade_name raw =
@@ -226,7 +227,7 @@ let set_test_base_path base_dir =
 
 let prepare_test_config_root base_dir =
   let config_dir = Filename.concat (Filename.concat base_dir ".masc") "config" in
-  Keeper_types.mkdir_p config_dir;
+  let (_ : string) = Keeper_fs.ensure_dir config_dir in
   copy_file
     (Filename.concat (repo_root ()) "config/cascade.toml")
     (Filename.concat config_dir "cascade.toml");
@@ -2167,7 +2168,7 @@ let test_runtime_trust_snapshot_tolerates_null_telemetry () =
        let keeper_name = "runtime-trust-null-telemetry" in
        let meta = { minimal_meta with name = keeper_name } in
        let decision_path = Keeper_types.keeper_decision_log_path config keeper_name in
-       Keeper_types.mkdir_p (Filename.dirname decision_path);
+       let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname decision_path) in
        Masc_mcp.Keeper_types_support.append_jsonl_line
          decision_path
          (`Assoc [ "telemetry", `Null ]);
@@ -2200,7 +2201,7 @@ let test_runtime_trust_snapshot_surfaces_terminal_reason () =
          }
        in
        let decision_path = Keeper_types.keeper_decision_log_path config keeper_name in
-       Keeper_types.mkdir_p (Filename.dirname decision_path);
+       let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname decision_path) in
        Masc_mcp.Keeper_types_support.append_jsonl_line
          decision_path
          (`Assoc
@@ -2263,7 +2264,7 @@ let test_runtime_trust_snapshot_reads_terminal_reason_code_alias () =
        let keeper_name = "runtime-trust-terminal-code-alias" in
        let meta = { minimal_meta with name = keeper_name } in
        let decision_path = Keeper_types.keeper_decision_log_path config keeper_name in
-       Keeper_types.mkdir_p (Filename.dirname decision_path);
+       let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname decision_path) in
        Masc_mcp.Keeper_types_support.append_jsonl_line
          decision_path
          (`Assoc
@@ -6134,7 +6135,7 @@ let test_sync_keeper_paused_state_surfaces_write_failure_without_mutating_regist
        let meta = make_meta "paused-sync-failure" in
        ignore (KR.register ~base_path:base_dir meta.name meta);
        let masc_root = Masc_mcp.Coord.masc_root_dir config in
-       Masc_mcp.Keeper_types.mkdir_p masc_root;
+       let (_ : string) = Masc_mcp.Keeper_fs.ensure_dir masc_root in
        let keepers_path = Filename.concat masc_root "keepers" in
        let oc = open_out_bin keepers_path in
        close_out oc;


### PR DESCRIPTION
Summary
- Remove the backward-compatible Keeper_types/Keeper_types_support mkdir_p facade.
- Move production and test callers to the canonical Keeper_fs.ensure_dir path.
- Remove the stale filesystem fallback wording from the unified turn setup comment.

Verification
- ocamlformat --check on touched OCaml files
- git diff --check
- rg Keeper_types.mkdir_p / Keeper_types_support.mkdir_p / Backward-compatible mkdir_p backstop: no matches in keeper/server/test paths
- scripts/dune-local.sh build lib/masc_mcp.cmxa and touched test executables was attempted but blocked by the machine-wide bare Dune guard: existing dune build --root . processes 11674, 88545, 38246. I did not bypass the guard.

Plan
- Continues docs/audit/2026-05-25-legacy-purge-plan.html from #18357.