### PR TITLE
fix(keeper): replace Cascade_name.of_string_exn with graceful fallback

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -564,10 +564,12 @@ let cascade_name_of_meta (m : keeper_meta) : string =
 ;;
 
 let set_cascade_name (name : string) (m : keeper_meta) : keeper_meta =
-  let cascade_ref =
-    Some Cascade_ref.{ group = Cascade_name.of_string_exn name; item = None }
-  in
-  { m with cascade_ref }
+  match Cascade_name.of_string name with
+  | Ok group ->
+    { m with cascade_ref = Some Cascade_ref.{ group; item = None } }
+  | Error (`Invalid_prefix | `Empty) ->
+    (* Non-canonical cascade name — keep existing cascade_ref unchanged *)
+    m
 ;;
 
 let proactive_cycle_outcome_to_string = function


### PR DESCRIPTION
## Summary
- Replace `Cascade_name.of_string_exn` with `of_string` + `Result` match in `set_cascade_name`
- Non-canonical cascade names (e.g. `"ollama_cloud_stable"`) no longer crash the keeper cycle
- On invalid input, existing `cascade_ref` is preserved unchanged

## Test plan
- [ ] `dune build --root .` passes
- [ ] Existing keeper meta contract tests pass
- [ ] Verify analyst keeper no longer throws `Failure("Cascade_name.of_string_exn: invalid prefix")`

Closes #18370

🤖 Generated with [Claude Code](https://claude.com/claude-code)