### PR TITLE
fix(taskboard): enhance keeper_task_done description with pr_url requirement

### DIFF
--- a/lib/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_shard_types_schemas_taskboard.ml
@@ -147,7 +147,11 @@ let taskboard_tools : Masc_domain.tool_schema list =
   ; { name = "keeper_task_done"
     ; description =
         "Mark your claimed task as complete with a result summary. The task must be \
-         claimed by you. Other agents verify completion from the result field."
+         claimed by you. If the task was previously submitted for verification \
+         (keeper_task_submit_for_verification), the result MUST include a pr_url \
+         field linking to the PR or evidence artifact — the call will be rejected \
+         otherwise. For tasks still in progress, use keeper_task_submit_for_verification \
+         first."
     ; input_schema =
         `Assoc
           [ "type", `String "object"


### PR DESCRIPTION
## Summary
- Enhance `keeper_task_done` tool description to state pr_url requirement when task is in `submit_for_verification` state
- Direct LLM to use `keeper_task_submit_for_verification` for tasks still in progress

## Why
Base keeper loops on `keeper_task_done` without pr_url (5 blocked/day, Issue #18342). The handler rejects the call but the tool description doesn't mention the state-dependent requirement, so the LLM can't adapt.

## Test plan
- [ ] `dune build --root .` passes
- [ ] Monitor system logs for reduced `keeper_task_done` workflow_rejection count

Closes #18342

🤖 Generated with [Claude Code](https://claude.com/claude-code)