### PR TITLE
fix(github-pr): add negative hint to prevent keeper_pr_create hallucination

### DIFF
--- a/lib/tool_shard_types_schemas_github_pr.ml
+++ b/lib/tool_shard_types_schemas_github_pr.ml
@@ -7,7 +7,8 @@ let keeper_github_pr_tools : Masc_domain.tool_schema list =
     ; description =
         "List GitHub pull requests with keeper-scoped credentials. Runs credential \
          preflight before gh, accepts repo owner/name or cwd, and returns gh JSON. \
-         Read-only."
+         Read-only. NOTE: there is no keeper_pr_create tool — to create a PR, use \
+         keeper_bash with executable=\"gh\" argv=[\"pr\",\"create\",...]."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -49,7 +50,9 @@ let keeper_github_pr_tools : Masc_domain.tool_schema list =
   ; { name = "keeper_pr_status"
     ; description =
         "Read one GitHub PR status/details with keeper-scoped credentials. Runs \
-         credential preflight before gh. Pass pr_number."
+         credential preflight before gh. Pass pr_number. NOTE: there is no \
+         keeper_pr_create tool — to create a PR, use keeper_bash with \
+         executable=\"gh\" argv=[\"pr\",\"create\",...]."
     ; input_schema =
         `Assoc
           [ "type", `String "object"


### PR DESCRIPTION
## Summary
- Add explicit NOTE to `keeper_pr_list` and `keeper_pr_status` descriptions: "there is no keeper_pr_create tool — use keeper_bash with gh CLI"
- Prevents LLM pattern completion from `keeper_pr_*` naming to non-existent `keeper_pr_create`

## Why
36/day unresolved tool warnings from LLMs hallucinating `keeper_pr_create`. The tool_policy logs show it as an unknown tool name. The naming pattern (list, status → create?) creates a false affordance.

## Test plan
- [ ] `dune build --root .` passes
- [ ] Monitor system logs for reduced `keeper_pr_create` unresolved warnings

Closes #18337

🤖 Generated with [Claude Code](https://claude.com/claude-code)