### PR TITLE
refactor(tools): remove local runtime json aliases

### DIFF
--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -44,10 +44,10 @@ let kv_cache_assessment_json = Tool_local_runtime_probe.kv_cache_assessment_json
 
 let handle_models _ctx : tool_result =
   match fetch_models () with
-  | Error msg -> (false, json_error msg)
+  | Error msg -> (false, Tool_args.error_response msg)
   | Ok (url, models) ->
       ( true,
-        json_ok
+        Tool_args.ok_response
           [
             ( "result",
               `Assoc
@@ -66,7 +66,8 @@ let handle_runtime_status _ctx args : tool_result =
     | `Bool flag -> flag
     | _ -> true
   in
-  (true, json_ok [ ("result", runtime_status_json ~include_models ()) ])
+  ( true,
+    Tool_args.ok_response [ ("result", runtime_status_json ~include_models ()) ] )
 
 let handle_runtime_verify _ctx args : tool_result =
   let open Yojson.Safe.Util in
@@ -85,7 +86,7 @@ let handle_runtime_verify _ctx args : tool_result =
     | _ -> None
   in
   ( true,
-    json_ok
+    Tool_args.ok_response
       [
         ( "result",
           runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx
@@ -141,8 +142,8 @@ let handle_runtime_bench _ctx args : tool_result =
     run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt
       ~max_tokens ~timeout_sec ()
   with
-  | Ok json -> (true, json_ok [ ("result", json) ])
-  | Error err -> (false, json_error err)
+  | Ok json -> (true, Tool_args.ok_response [ ("result", json) ])
+  | Error err -> (false, Tool_args.error_response err)
 
 let handle_runtime_ollama_probe _ctx args : tool_result =
   let open Yojson.Safe.Util in
@@ -195,10 +196,10 @@ let handle_runtime_ollama_probe _ctx args : tool_result =
     | _ -> true
   in
   match think_mode with
-  | Error msg -> (false, json_error msg)
+  | Error msg -> (false, Tool_args.error_response msg)
   | Ok think_mode ->
       ( true,
-        json_ok
+        Tool_args.ok_response
           [
             ( "result",
               runtime_ollama_probe_json ?server_url ?model ?prompt ?keep_alive

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -43,10 +43,6 @@ type bench_sample = {
   error : string option;
 }
 
-let json_error = Tool_args.error_response
-let json_ok = Tool_args.ok_response
-
-
 let parse_int_opt value =
   Stdlib.int_of_string_opt ((String.trim value))
 

--- a/lib/tool_local_runtime_core.mli
+++ b/lib/tool_local_runtime_core.mli
@@ -54,18 +54,6 @@ type bench_sample = {
     bench loops; exposed here so all four siblings see the same
     type via include. *)
 
-(** {1 JSON envelope helpers} *)
-
-val json_error : string -> string
-(** Alias for {!Tool_args.error_response}.  Kept for compatibility with
-    sibling [Tool_local_runtime_*] modules that consume this surface via
-    [include]; new code should call {!Tool_args.error_response}
-    directly. *)
-
-val json_ok : (string * Yojson.Safe.t) list -> string
-(** Alias for {!Tool_args.ok_response}.  Same compatibility rationale as
-    {!json_error}. *)
-
 (** Aliases over {!Json_util.*_opt_to_json} re-exported for the
     sibling include cascade. *)
 


### PR DESCRIPTION
Summary:
- Remove Tool_local_runtime_core.json_ok/json_error compatibility aliases.
- Move Tool_local_runtime facade handlers to call Tool_args.ok_response/error_response directly.
- Keep the tuple-returning local runtime tool_result contract unchanged while deleting the alias surface.

Verification:
- ocamlformat --check lib/tool_local_runtime.ml lib/tool_local_runtime_core.ml lib/tool_local_runtime_core.mli
- git diff --check
- rg '\bjson_ok\b|\bjson_error\b|JSON envelope helpers|Tool_args\.error_response.*Kept for compatibility|Tool_args\.ok_response.*compatibility' lib/tool_local_runtime* -g '*.{ml,mli}' returned no matches
- bash scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD
- bash scripts/lint/godfile-size-regression.sh
- bash scripts/code-smell/measure.sh
- scripts/dune-local.sh build lib/masc_mcp.cmxa attempted but blocked by machine-wide bare-Dune guard: existing bare dune build processes 11674, 38246, 10579.

Plan:
- Continues docs/audit/2026-05-25-legacy-purge-plan.html from #18357.