### PR TITLE
refactor(tools): remove tuple tool bridge overload

### DIFF
--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -17,9 +17,8 @@ module Float = Stdlib.Float
 
 (** OAS boundary adapter for tool results, schemas, and tool definitions.
 
-    MASC dispatch uses typed [Tool_result.t] internally.  Some older leaf
-    helpers still expose [(bool * string)] locally; this module is the boundary
-    adapter that converts those leaf results to/from
+    MASC dispatch uses typed [Tool_result.t] internally.  This module is the
+    boundary adapter that converts typed MASC results to/from
     [Agent_sdk.Types.tool_result = (tool_output, tool_error) Result.t].
 
     Central [Tool_dispatch.handler] implementations should return
@@ -132,19 +131,6 @@ let tool_error_metadata_from_json_message msg =
         (recoverable, error_class)
     | _ -> (false, None)
   with Yojson.Json_error _ -> (false, None)
-
-let recoverable_from_json_message msg =
-  fst (tool_error_metadata_from_json_message msg)
-
-let to_oas_tool_result ?(recoverable = false) (success, msg)
-  : Agent_sdk.Types.tool_result =
-  if success then Ok { Agent_sdk.Types.content = maybe_externalize msg }
-  else
-    let json_recoverable, error_class =
-      tool_error_metadata_from_json_message msg
-    in
-    let recoverable = recoverable || json_recoverable in
-    make_tool_error ~recoverable ?error_class (maybe_externalize msg)
 
 let oas_error_class_of_tool_failure_class = function
   | Tool_result.Transient_error -> Some Agent_sdk.Types.Transient

--- a/lib/tool_bridge.mli
+++ b/lib/tool_bridge.mli
@@ -33,16 +33,6 @@ val maybe_externalize : ?mime:string -> string -> string
 
 (** {1 Result Conversion} *)
 
-val to_oas_tool_result :
-  ?recoverable:bool -> bool * string -> Agent_sdk.Types.tool_result
-(** Convert MASC [(success, message)] to OAS [tool_result].
-    [recoverable] defaults to [true] for error cases.
-    Large [message] values are externalized via {!maybe_externalize}.
-
-    @deprecated Prefer {!to_oas_typed_result} when a {!Tool_result.t} is
-    available.  This overload accepts legacy handler output and exists
-    for callers that have not yet migrated to the typed interface. *)
-
 val to_oas_typed_result : Tool_result.t -> Agent_sdk.Types.tool_result
 (** Convert a {!Tool_result.t} to OAS [tool_result].
     Preserves the structured payload, maps [failure_class] to OAS

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -86,31 +86,41 @@ let test_threshold_env_override () =
     (B.externalize_threshold_bytes ());
   Unix.putenv "MASC_TOOL_EXTERNALIZE_THRESHOLD_BYTES" ""
 
-(* --- Round-trip via to_oas_tool_result on small payloads --- *)
+(* --- Round-trip via to_oas_typed_result on small payloads --- *)
 
-let test_to_oas_small_inlined () =
+let test_to_oas_typed_small_inlined () =
   Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
   let small = "small ok" in
-  match B.to_oas_tool_result (true, small) with
+  match B.to_oas_typed_result (Tool_result.quick_ok ~tool_name:"test" small) with
   | Ok { content } ->
       Alcotest.(check string) "inlined verbatim" small content;
       Alcotest.(check bool) "no sentinel" false (O.is_sentinel content)
   | Error _ -> Alcotest.fail "expected Ok"
 
-let test_to_oas_error_inlined () =
+let test_to_oas_typed_error_inlined () =
   Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
-  match B.to_oas_tool_result (false, "fail") with
+  match B.to_oas_typed_result (Tool_result.quick_error ~tool_name:"test" "fail") with
   | Ok _ -> Alcotest.fail "expected Error"
   | Error { message; recoverable; _ } ->
       Alcotest.(check string) "message" "fail" message;
       Alcotest.(check bool) "default recoverable=false" false recoverable
 
-let test_to_oas_error_uses_json_recoverable_flag () =
+let test_to_oas_typed_error_uses_json_recoverable_flag () =
   Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
   let msg =
     {|{"ok":false,"error":"try again","recoverable":true,"error_class":"transient_mutex_contention"}|}
   in
-  match B.to_oas_tool_result (false, msg) with
+  let tr =
+    Tool_result.
+      { success = false
+      ; data = Yojson.Safe.from_string msg
+      ; legacy_message = msg
+      ; tool_name = "test"
+      ; duration_ms = 0.0
+      ; failure_class = None
+      }
+  in
+  match B.to_oas_typed_result tr with
   | Ok _ -> Alcotest.fail "expected Error"
   | Error { message; recoverable; error_class } ->
       Alcotest.(check string) "message" msg message;
@@ -159,7 +169,7 @@ let test_to_oas_typed_result_preserves_transient_failure_class () =
 let test_round_trip_through_oas () =
   Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
   let payload = String.make 5000 'p' in
-  match B.to_oas_tool_result (true, payload) with
+  match B.to_oas_typed_result (Tool_result.quick_ok ~tool_name:"test" payload) with
   | Ok { content } ->
       let decoded = O.decode_from_oas content in
       (match decoded with
@@ -209,12 +219,12 @@ let () =
           Alcotest.test_case "threshold env override" `Quick
             test_threshold_env_override;
         ] );
-      ( "to_oas_tool_result",
+      ( "to_oas_typed_result",
         [
-          Alcotest.test_case "small inlined" `Quick test_to_oas_small_inlined;
-          Alcotest.test_case "error inlined" `Quick test_to_oas_error_inlined;
+          Alcotest.test_case "small inlined" `Quick test_to_oas_typed_small_inlined;
+          Alcotest.test_case "error inlined" `Quick test_to_oas_typed_error_inlined;
           Alcotest.test_case "error recoverable from JSON" `Quick
-            test_to_oas_error_uses_json_recoverable_flag;
+            test_to_oas_typed_error_uses_json_recoverable_flag;
           Alcotest.test_case "typed workflow rejection is deterministic" `Quick
             test_to_oas_typed_result_preserves_workflow_rejection;
           Alcotest.test_case "typed transient remains recoverable" `Quick


### PR DESCRIPTION
Summary:
- Remove the deprecated Tool_bridge.to_oas_tool_result tuple overload.
- Keep OAS bridge conversion on Tool_result.t only.
- Move externalization tests from the legacy overload to to_oas_typed_result and remove the now-orphaned recoverable_from_json_message helper.

Verification:
- ocamlformat --check lib/tool_bridge.ml lib/tool_bridge.mli test/test_tool_bridge_externalize.ml
- git diff --check origin/main...HEAD
- rg 'to_oas_tool_result|recoverable_from_json_message|legacy handler output|deprecated.*typed interface' lib test -g '*.{ml,mli}' returned no matches
- check-ignore-without-comment-diff
- godfile-size-regression
- code-smell/measure
- scripts/dune-local.sh build test/test_tool_bridge_externalize.exe attempted but blocked by machine-wide bare-Dune guard: PIDs 82564, 11674, 99845, 38246

Plan:
- Continues the legacy purge plan tracked in #18357.