### PR TITLE
refactor(tools): remove deprecated alias source metrics

### DIFF
--- a/lib/tool_registry.ml
+++ b/lib/tool_registry.ml
@@ -33,13 +33,11 @@ type call_source =
   | External_mcp
   | Keeper_internal
   | Inline_dispatch
-  | Deprecated_alias
 
 let string_of_source = function
   | External_mcp -> "external_mcp"
   | Keeper_internal -> "keeper_internal"
   | Inline_dispatch -> "inline_dispatch"
-  | Deprecated_alias -> "deprecated_alias"
 ;;
 
 (** Per-tool call statistics *)
@@ -52,7 +50,6 @@ type call_stats =
   ; external_mcp_count : int Atomic.t
   ; keeper_internal_count : int Atomic.t
   ; inline_dispatch_count : int Atomic.t
-  ; deprecated_alias_count : int Atomic.t
   ; last_assignment_id : string option Atomic.t
   }
 
@@ -116,7 +113,6 @@ let get_or_create_stats tool_name =
           ; external_mcp_count = Atomic.make 0
           ; keeper_internal_count = Atomic.make 0
           ; inline_dispatch_count = Atomic.make 0
-          ; deprecated_alias_count = Atomic.make 0
           ; last_assignment_id = Atomic.make None
           }
         in
@@ -137,8 +133,7 @@ let record_call
   (match source with
    | External_mcp -> Atomic.incr stats.external_mcp_count
    | Keeper_internal -> Atomic.incr stats.keeper_internal_count
-   | Inline_dispatch -> Atomic.incr stats.inline_dispatch_count
-   | Deprecated_alias -> Atomic.incr stats.deprecated_alias_count);
+   | Inline_dispatch -> Atomic.incr stats.inline_dispatch_count);
   if success then Atomic.incr stats.success_count else Atomic.incr stats.failure_count;
   Atomic.set stats.last_called_at (Time_compat.now ());
   ignore (Atomic.fetch_and_add stats.total_duration_ms duration_ms);
@@ -238,7 +233,6 @@ let stats_to_json (name, (stats : call_stats)) : Yojson.Safe.t =
           [ "external_mcp", `Int (Atomic.get stats.external_mcp_count)
           ; "keeper_internal", `Int (Atomic.get stats.keeper_internal_count)
           ; "inline_dispatch", `Int (Atomic.get stats.inline_dispatch_count)
-          ; "deprecated_alias", `Int (Atomic.get stats.deprecated_alias_count)
           ] )
     ]
 ;;
@@ -292,7 +286,6 @@ let warm_up (summary : Telemetry_eio.tool_usage_summary) : int =
              ; external_mcp_count = Atomic.make 0
              ; keeper_internal_count = Atomic.make 0
              ; inline_dispatch_count = Atomic.make 0
-             ; deprecated_alias_count = Atomic.make 0
              ; last_assignment_id = Atomic.make None
              };
            Stdlib.incr count))

--- a/lib/tool_registry.mli
+++ b/lib/tool_registry.mli
@@ -12,7 +12,6 @@ type call_source =
   | External_mcp
   | Keeper_internal
   | Inline_dispatch
-  | Deprecated_alias
 
 type call_stats = {
   call_count : int Atomic.t;
@@ -23,7 +22,6 @@ type call_stats = {
   external_mcp_count : int Atomic.t;
   keeper_internal_count : int Atomic.t;
   inline_dispatch_count : int Atomic.t;
-  deprecated_alias_count : int Atomic.t;
   last_assignment_id : string option Atomic.t;
 }
 

--- a/test/test_tool_registry.ml
+++ b/test/test_tool_registry.ml
@@ -178,7 +178,20 @@ let () =
             let s = Yojson.Safe.to_string json in
             check bool "contains total_calls" (String.length s > 0) true;
             check bool "contains by_source" (String.length s > 10) true;
-            let _ = Yojson.Safe.from_string s in
+            let parsed = Yojson.Safe.from_string s in
+            let open Yojson.Safe.Util in
+            let by_source =
+              parsed
+              |> member "top_tools"
+              |> to_list
+              |> List.hd
+              |> member "by_source"
+            in
+            check int "external_mcp" 1 (by_source |> member "external_mcp" |> to_int);
+            check bool "deprecated_alias removed" true
+              (match by_source |> member "deprecated_alias" with
+               | `Null -> true
+               | _ -> false);
             ())
         ; test_case "respects top_n" `Quick (fun () ->
             Tool_registry.reset ();


### PR DESCRIPTION
Summary:
- Remove the unused Tool_registry.Deprecated_alias call source.
- Drop the deprecated_alias counter from call_stats and by_source JSON output.
- Update Tool_registry tests to assert the canonical source breakdown without the old alias bucket.

Verification:
- ocamlformat --check lib/tool_registry.ml lib/tool_registry.mli test/test_tool_registry.ml
- git diff --check
- rg 'Deprecated_alias|deprecated_alias_count|"deprecated_alias"\s*,' lib/tool_registry.ml lib/tool_registry.mli test/test_tool_registry.ml returned no matches
- check-ignore-without-comment-diff
- godfile-size-regression
- code-smell/measure
- scripts/dune-local.sh build test/test_tool_registry.exe attempted but blocked by machine-wide bare-Dune guard: PIDs 11674, 38246

Plan:
- Continues the legacy purge plan tracked in #18357.