### PR TITLE
refactor(memory): remove legacy compact anchor prefixes

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -51,10 +51,8 @@ type strategy =
 (* ================================================================ *)
 
 let memory_summary_prefix = "[MEMORY_SUMMARY]"
-let legacy_memory_summary_prefix = "[MASC_MEMORY_SUMMARY v1]"
 
 let goal_prefix = "[GOAL]"
-let legacy_goal_prefix = "[MASC_GOAL]"
 
 let first_sentence (s : string) =
   let s = String.trim s in
@@ -173,9 +171,7 @@ let score_message ~index ~total (m : Agent_sdk.Types.message) : float =
   let score = w_recency *. recency +. w_role *. role_w +. w_tool *. tool_w in
   let score =
     if String.starts_with ~prefix:memory_summary_prefix msg_text
-       || String.starts_with ~prefix:legacy_memory_summary_prefix msg_text
-       || String.starts_with ~prefix:goal_prefix msg_text
-       || String.starts_with ~prefix:legacy_goal_prefix msg_text then
+       || String.starts_with ~prefix:goal_prefix msg_text then
       Float.max score anchor_boost
     else score
   in

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -148,28 +148,22 @@ let test_scoring_single () =
   let (_, score) = List.hd scores in
   check bool "score in range" true (score >= 0.0 && score <= 1.0)
 
-(* ================================================================ *)
-(* Backward Compatibility: Legacy Marker Tests                      *)
-(* ================================================================ *)
-
-let test_scoring_legacy_memory_summary () =
+let test_old_masc_memory_marker_is_not_anchor () =
   let msgs = [
     msg Agent_sdk.Types.Assistant "[MASC_MEMORY_SUMMARY v1] old format summary";
     msg Agent_sdk.Types.Assistant "normal message";
   ] in
   let scores = Scoring.score_messages msgs in
-  let legacy_score = List.assoc 0 scores in
-  let normal_score = List.assoc 1 scores in
-  check bool "legacy memory summary still sticky" true (legacy_score >= 0.95);
-  check bool "legacy > normal" true (legacy_score > normal_score)
+  let old_score = List.assoc 0 scores in
+  check bool "old memory marker is not sticky" true (old_score < 0.95)
 
-let test_scoring_legacy_goal () =
+let test_old_masc_goal_marker_is_not_anchor () =
   let msgs = [
     msg Agent_sdk.Types.User "[MASC_GOAL] old format goal";
   ] in
   let scores = Scoring.score_messages msgs in
   let score = List.assoc 0 scores in
-  check bool "legacy goal still sticky" true (score >= 0.95)
+  check bool "old goal marker is not sticky" true (score < 0.95)
 
 (* ================================================================ *)
 (* Dynamic Strategy Resolution Tests (#3164)                        *)
@@ -297,8 +291,10 @@ let () =
       test_case "sticky goal" `Quick test_scoring_goal_sticky;
       test_case "empty input" `Quick test_scoring_empty;
       test_case "single message" `Quick test_scoring_single;
-      test_case "legacy memory summary compat" `Quick test_scoring_legacy_memory_summary;
-      test_case "legacy goal compat" `Quick test_scoring_legacy_goal;
+      test_case "old MASC memory marker not anchored" `Quick
+        test_old_masc_memory_marker_is_not_anchor;
+      test_case "old MASC goal marker not anchored" `Quick
+        test_old_masc_goal_marker_is_not_anchor;
     ];
     "dynamic_strategy", [
       test_case "high pressure multi-agent" `Quick test_dynamic_high_pressure_multi_agent;

--- a/test/test_rfc_0085_pr13_underscore_rename.ml
+++ b/test/test_rfc_0085_pr13_underscore_rename.ml
@@ -5,13 +5,11 @@ open Alcotest
     1 truly dead: governance_pipeline_risk._tool_names_of_input
        (definition only, 0 callers) -> deleted.
 
-    8 active (PR-12 pattern: misleading _ prefix on used bindings):
+    6 active (PR-12 pattern: misleading _ prefix on used bindings):
        - config_dir_resolver._cached_resolution
        - tool_code_write._policy_config_cache
        - tool_keeper._keeper_list_cache
        - tool_board._board_list_cache
-       - context_compact_oas._legacy_memory_summary_prefix
-       - context_compact_oas._legacy_goal_prefix
        - governance_pipeline_risk._destructive_pattern_strings
        - tool_coord._status_cache
     All renamed (drop _ prefix), callers in same file updated.
@@ -31,10 +29,6 @@ let renamed_identifiers =
   ; "lib/tool_code_write.ml", "_policy_config_cache", "policy_config_cache"
   ; "lib/tool_keeper.ml", "_keeper_list_cache", "keeper_list_cache"
   ; "lib/tool_board.ml", "_board_list_cache", "board_list_cache"
-  ; ( "lib/context_compact_oas.ml"
-    , "_legacy_memory_summary_prefix"
-    , "legacy_memory_summary_prefix" )
-  ; "lib/context_compact_oas.ml", "_legacy_goal_prefix", "legacy_goal_prefix"
   ; ( "lib/governance_pipeline_risk.ml"
     , "_destructive_pattern_strings"
     , "destructive_pattern_strings" )


### PR DESCRIPTION
Summary:
- Stop treating [MASC_MEMORY_SUMMARY v1] and [MASC_GOAL] as sticky context compaction anchors.
- Remove the legacy prefix bindings from Context_compact_oas scoring.
- Replace compat-preservation tests with negative tests proving old MASC markers no longer receive anchor boost.

Verification:
- ocamlformat --check lib/context_compact_oas.ml test/test_context_compact_oas_coverage.ml test/test_rfc_0085_pr13_underscore_rename.ml
- git diff --check
- rg 'legacy_memory_summary_prefix|legacy_goal_prefix|legacy memory summary compat|legacy goal compat|legacy memory summary still sticky|legacy goal still sticky' lib/context_compact_oas.ml test/test_context_compact_oas_coverage.ml test/test_rfc_0085_pr13_underscore_rename.ml returned no matches
- check-ignore-without-comment-diff
- godfile-size-regression
- code-smell/measure
- scripts/dune-local.sh build test/test_context_compact_oas_coverage.exe test/test_rfc_0085_pr13_underscore_rename.exe attempted but blocked by machine-wide bare-Dune guard: PIDs 11674, 98950, 38246

Plan:
- Continues the legacy purge plan tracked in #18357.