### PR TITLE
refactor(coord): drop legacy active agent object repair

### DIFF
--- a/lib/coord/coord_state.ml
+++ b/lib/coord/coord_state.ml
@@ -56,11 +56,6 @@ let normalized_string_list values =
 
 let recover_active_agent_name = function
   | `String name -> String_util.option_trim (Some name)
-  | `Assoc _ as json ->
-      (match String_util.option_trim (Safe_ops.json_string_opt "name" json) with
-       | Some name -> Some name
-       | None ->
-           String_util.option_trim (Safe_ops.json_string_opt "agent_name" json))
   | _ -> None
 
 let recover_room_state config json =

--- a/lib/coord/coord_state.mli
+++ b/lib/coord/coord_state.mli
@@ -36,8 +36,8 @@ val write_backlog :
 val normalized_string_list : string list -> string list
 
 (** Project a JSON entry of the [active_agents] array to the agent
-    name it identifies, accepting either a bare [`String name] or
-    an object with a [name]/[agent_name] field. *)
+    name it identifies. Current state accepts only bare [`String name]
+    entries; object-shaped historical entries are ignored during repair. *)
 val recover_active_agent_name : Yojson.Safe.t -> string option
 
 val recover_room_state :

--- a/test/test_room_state_recovery.ml
+++ b/test/test_room_state_recovery.ml
@@ -53,7 +53,7 @@ let test_read_state_repairs_empty_object () =
       check int "repaired message_seq" 0
         (Safe_ops.json_int ~default:(-1) "message_seq" repaired_json))
 
-let test_read_state_recovers_legacy_active_agent_entries () =
+let test_read_state_drops_legacy_active_agent_objects () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
@@ -83,8 +83,8 @@ let test_read_state_recovers_legacy_active_agent_entries () =
 
       let state = Coord.read_state config in
       check int "message_seq preserved" 7 state.message_seq;
-      check (list string) "legacy active_agents recovered"
-        [ "agent_code-swift-fox"; "provider_f-brave-bear"; "keeper-sangsu-agent" ]
+      check (list string) "only canonical string active_agents recovered"
+        [ "provider_f-brave-bear" ]
         state.active_agents;
 
       let open Yojson.Safe.Util in
@@ -125,7 +125,7 @@ let test_read_state_filters_invalid_active_agent_entries () =
 
       let state = Coord.read_state config in
       check (list string) "invalid entries filtered"
-        [ "agent_code-swift-fox"; "provider_f-brave-bear" ]
+        [ "provider_f-brave-bear" ]
         state.active_agents)
 
 let test_agent_of_yojson_accepts_numeric_last_seen () =
@@ -319,8 +319,8 @@ let () =
         [
           test_case "repairs empty object" `Quick
             test_read_state_repairs_empty_object;
-          test_case "recovers legacy active_agents entries" `Quick
-            test_read_state_recovers_legacy_active_agent_entries;
+          test_case "drops legacy active_agents objects" `Quick
+            test_read_state_drops_legacy_active_agent_objects;
           test_case "filters invalid active_agents entries" `Quick
             test_read_state_filters_invalid_active_agent_entries;
           test_case "agent parser accepts numeric last_seen" `Quick


### PR DESCRIPTION
Summary:
- Stop recovering object-shaped entries in room_state.active_agents.
- Keep only canonical string entries during room-state repair.
- Replace the legacy recovery test with a negative object-drop assertion.

Verification:
- ocamlformat --check lib/coord/coord_state.ml lib/coord/coord_state.mli test/test_room_state_recovery.ml
- git diff --check
- rg 'recovers_legacy_active_agent|legacy active_agents recovered|agent_name.*active_agents|object with a \[name\]/\[agent_name\]|accepting either a bare' lib/coord/coord_state.ml lib/coord/coord_state.mli test/test_room_state_recovery.ml returned no matches
- check-ignore-without-comment-diff
- godfile-size-regression
- code-smell/measure
- scripts/dune-local.sh build test/test_room_state_recovery.exe attempted but blocked by machine-wide bare-Dune guard: PIDs 11674, 38246

Plan:
- Continues the legacy purge plan tracked in #18357.