### PR TITLE
refactor(tools): remove local worker compat passthrough

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -86,28 +86,6 @@ let local_worker_public_tool_names : string list =
 let local_worker_contract_schemas : Masc_domain.tool_schema list =
   Sdk_tool_contract.sdk_tool_schemas
 
-let local_worker_compat_passthrough_tool_names =
-  [
-    "masc_status";
-    "masc_tasks";
-    "masc_claim_next";
-    "masc_transition";
-    "masc_add_task";
-    "masc_broadcast";
-  ]
-
-let local_worker_compat_passthrough_schemas : Masc_domain.tool_schema list =
-  lookup_schemas_by_name_exn
-    ~label:"agent_tool_surfaces.local_worker_compat_passthrough_schemas"
-    (* Tool_schemas_inline_coord.schemas tools (masc_start/join/leave/
-       broadcast/messages/who) now come from Tool_descriptors_gen and
-       are re-surfaced through Tool_schemas_inline.schemas filter (see
-       lib/tool_schemas/tool_schemas_inline.ml) — RFC-0057 PR-2d. *)
-    (Tool_schemas_coord_core.schemas
-     @ Tool_task_schemas.schemas
-     @ Tool_schemas_inline.schemas)
-    local_worker_compat_passthrough_tool_names
-
 let local_worker_internal_schemas : Masc_domain.tool_schema list =
   List.filter
     (fun (schema : Masc_domain.tool_schema) -> String.equal schema.name "masc_heartbeat")
@@ -184,7 +162,6 @@ let local_worker_tool_schemas ?names () :
   let all_schemas =
     dedupe_schemas
       ( local_worker_internal_schemas
-      @ local_worker_compat_passthrough_schemas
       @ local_worker_contract_schemas
       @ select_public_local_worker_schemas () )
   in

--- a/lib/agent_tool_surfaces.mli
+++ b/lib/agent_tool_surfaces.mli
@@ -28,8 +28,7 @@ module Random = Stdlib.Random
     - **Spawned-agent**: tools available to MCP-spawned agent
       sub-processes (a small public set for scripting agents).
     - **Local-worker**: tools available to in-process worker
-      flows (a larger set including SDK contract schemas + compat
-      passthroughs).
+      flows (a larger set including SDK contract schemas).
     - **Role-catalogue**: dynamic role-based filtering for the
       autonomous agent (worker / coordinator / fleet_leader). *)
 
@@ -84,20 +83,6 @@ val local_worker_public_tool_names : string list
 val local_worker_contract_schemas : Masc_domain.tool_schema list
 (** Re-export of {!Sdk_tool_contract.sdk_tool_schemas}. *)
 
-val local_worker_compat_passthrough_tool_names : string list
-(** Six tools passed through to local workers for backward-
-    compatibility: [masc_status] / [masc_tasks] / [masc_claim_next]
-    / [masc_transition] / [masc_add_task] / [masc_broadcast].
-
-    Pinned at the contract seam — operator runbooks reference the
-    exact six names. *)
-
-val local_worker_compat_passthrough_schemas :
-  Masc_domain.tool_schema list
-(** Resolved schemas for the passthrough names.  Computed at
-    module init via {!lookup_schemas_by_name_exn}; an unknown name
-    fails fast at startup. *)
-
 val local_worker_internal_schemas : Masc_domain.tool_schema list
 (** Internal-only schemas (currently just [masc_heartbeat]).
     Filtered from {!Tool_schemas_coord_core.schemas}. *)
@@ -134,8 +119,8 @@ val local_worker_tool_schemas :
 (** [local_worker_tool_schemas ?names ()] returns the full local-
     worker schema set when [names] is omitted, or the named
     subset when provided.  The full set is the deduped union of
-    internal + compat-passthrough + contract +
-    {!select_public_local_worker_schemas} outputs.
+    internal + contract + {!select_public_local_worker_schemas}
+    outputs.
 
     [Error] when [names] contains an unknown name (operator-
     visible message format from {!resolve_named_schemas}). *)

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -448,21 +448,6 @@ let test_role_catalogs_drop_stale_entries_when_built () =
   Alcotest.(check bool) "coordinator role excludes portal_open" false
     (List.mem "masc_portal_open" coordinator_tools)
 
-let test_local_worker_compat_passthrough_schemas_match_registry () =
-  List.iter (fun (schema : Masc_domain.tool_schema) ->
-    match raw_schema_by_name schema.name with
-    | None ->
-        Alcotest.failf "missing raw schema for passthrough tool %s" schema.name
-    | Some raw_schema ->
-        Alcotest.(check string)
-          (schema.name ^ " passthrough description")
-          raw_schema.description schema.description;
-        Alcotest.(check bool)
-          (schema.name ^ " passthrough input_schema")
-          true
-          (Yojson.Safe.equal raw_schema.input_schema schema.input_schema))
-    Agent_tool_surfaces.local_worker_compat_passthrough_schemas
-
 let () =
   Alcotest.run "tool_surface_ssot"
     [
@@ -507,8 +492,6 @@ let () =
              test_role_catalogs_only_expose_available_tools;
            Alcotest.test_case "built role catalogs drop stale entries" `Quick
              test_role_catalogs_drop_stale_entries_when_built;
-           Alcotest.test_case "local worker passthrough schemas use registry"
-             `Quick test_local_worker_compat_passthrough_schemas_match_registry;
          ] );
       ( "ssot_validation",
         [


### PR DESCRIPTION
Summary: remove Agent_tool_surfaces.local_worker_compat_passthrough_* and the dedicated passthrough registry test so local-worker schemas come only from internal, SDK contract, and catalog-backed public surfaces. Verification: ocamlformat --check lib/agent_tool_surfaces.ml lib/agent_tool_surfaces.mli test/test_tool_surface_ssot.ml; git diff --check; rg no remaining local_worker_compat_passthrough references in touched files; scripts/ci/check-ignore-without-comment-diff.sh; scripts/lint/godfile-size-regression.sh; scripts/code-smell-ratchet.sh. Gap: scripts/dune-local.sh build test/test_tool_surface_ssot.exe was blocked by machine-wide bare-Dune guard detecting live 'dune build --root .' processes.