### PR TITLE
refactor(memory): remove legacy audit file fallback

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -324,7 +324,7 @@ Allowed path model:
 ### 3.8 Logs, Audit, Metrics, and Tool Traces
 
 - `<runtime_root>/logs/`: service logs.
-- `<runtime_root>/audit/YYYY-MM/DD.jsonl` and legacy `<runtime_root>/audit.jsonl`
+- `<runtime_root>/audit/YYYY-MM/DD.jsonl`
 - `<runtime_root>/tool_calls/YYYY-MM/DD.jsonl`
 - `<runtime_root>/tool_usage/YYYY-MM/DD.jsonl`
 - `<runtime_root>/runtime_params.json`

--- a/docs/JSONL-CONTRACT-INVENTORY.md
+++ b/docs/JSONL-CONTRACT-INVENTORY.md
@@ -26,7 +26,7 @@ fixtures before any writer implementation is changed.
 
 | Store family | Runtime path contract | Writer | Reader / projection | Current schema owner | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Audit log | `.masc/audit/YYYY-MM/DD.jsonl`, fallback `.masc/audit.jsonl` | `Dated_jsonl.append` | `Dated_jsonl.read_recent`, legacy single-file fallback | `Audit_log.entry_to_json` / parser | Cache is guarded so callers share a store per base dir. Structural parse failures are logged. |
+| Audit log | `.masc/audit/YYYY-MM/DD.jsonl` | `Dated_jsonl.append` | `Dated_jsonl.read_recent` | `Audit_log.entry_to_json` / parser | Cache is guarded so callers share a store per base dir. Structural parse failures are logged. |
 | Telemetry | `.masc/telemetry/YYYY-MM/DD.jsonl`, legacy fallback for old file readers | `Dated_jsonl.append` | `Dated_jsonl.read_recent`, parse/drop metrics | `Telemetry_eio.event_record_to_yojson` | Mirrors audit cache invariant. |
 | Tool usage | `.masc/tool_usage/YYYY-MM/DD.jsonl` | `Dated_jsonl.append` | `Dated_jsonl.read_recent` and coverage-gap path on failures | `Tool_usage_log.record_to_json` | Has retention and coverage-gap fallback for init/append failures. |
 | Keeper tool calls | `.masc/tool_calls/YYYY-MM/DD.jsonl` | `Dated_jsonl.append` after UTF-8 sanitization | Dashboard/tool-call readers | `Keeper_tool_call_log` record builders | Explicitly sanitizes tool output before append. |

--- a/docs/reverse-engineering-design.html
+++ b/docs/reverse-engineering-design.html
@@ -1209,9 +1209,9 @@
                 <code>lib/dated_jsonl/dated_jsonl.ml:259-283, lib/fs_compat/fs_compat.ml:591-610</code>
               </li>
               <li>
-                <strong>Audit log caches dated stores and falls back to legacy audit</strong>
-                <span>Store cache prevents two mutexes for the same date path; read path falls back to legacy <code>audit.jsonl</code> when dated rows are empty.</span>
-                <code>lib/audit_log.ml:222-307</code>
+                <strong>Audit log caches dated stores</strong>
+                <span>Store cache prevents two mutexes for the same date path; read path now uses only the date-split audit store.</span>
+                <code>lib/audit_log.ml:218-286</code>
               </li>
               <li>
                 <strong>LSP route already exists as a dashboard WebSocket lane</strong>

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -1,6 +1,6 @@
 (** Audit Log Writer for MASC
 
-    Writes audit events to .masc/audit.jsonl for security monitoring.
+    Writes audit events to .masc/audit/YYYY-MM/DD.jsonl for security monitoring.
     JSONL format for grep-ability and stream processing.
 
     Security basis:
@@ -214,11 +214,6 @@ let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
 
 type config = Coord_utils.config
 
-(** Legacy single-file path (for fallback reads). *)
-let legacy_audit_path (config : config) =
-  let masc_dir = Coord_utils.masc_dir config in
-  Filename.concat masc_dir "audit.jsonl"
-
 (** Date-split store: [.masc/audit/YYYY-MM/DD.jsonl].
     Cached per base_dir so all callers share the same Eio.Mutex.
 
@@ -273,39 +268,11 @@ let parse_entries (jsons : Yojson.Safe.t list) : audit_entry list =
        else "");
   List.rev ok_rev
 
-(** Read recent audit entries.
-    Tries date-split store first; falls back to legacy single file.
-    Legacy JSON parse failures are logged at WARN (rate-limited, first N only).
+(** Read recent audit entries from the date-split store.
     Structural parse failures go through [parse_entries] ERROR path. *)
 let read_entries ?(n = 10_000) (config : config) : audit_entry list =
   let store = get_audit_store config in
-  let entries = Dated_jsonl.read_recent store n in
-  if entries <> [] then
-    parse_entries entries
-  else
-    let path = legacy_audit_path config in
-    if not (Sys.file_exists path) then []
-    else
-      let content = Fs_compat.load_file path in
-      let invalid_count = ref 0 in
-      let jsons = String.split_on_char '\n' content
-        |> List.filter (fun line -> String.trim line <> "")
-        |> List.filter_map (fun line ->
-            match Yojson.Safe.from_string line with
-            | json -> Some json
-            | exception Yojson.Json_error msg ->
-                incr invalid_count;
-                if !invalid_count <= max_logged_errors then
-                  Log.Misc.warn "audit_log: invalid JSON line (#%d): %s | line: %s"
-                    !invalid_count msg (preview ~max_len:100 line);
-                None) in
-      if !invalid_count > 0 then
-        Log.Misc.warn "audit_log: %d invalid JSON line(s) in legacy audit log%s"
-          !invalid_count
-          (if !invalid_count > max_logged_errors
-           then Printf.sprintf " (%d more suppressed)" (!invalid_count - max_logged_errors)
-           else "");
-      parse_entries jsons
+  Dated_jsonl.read_recent store n |> parse_entries
 
 (** Append a single entry to the audit log (thread-safe via Dated_jsonl). *)
 let append_entry (config : config) (entry : audit_entry) =

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -76,7 +76,7 @@ type audit_entry = {
 (** {1 Wire-format} *)
 
 val action_to_string : action -> string
-(** Stable serialisation; round-tripped by the legacy reader. The
+(** Stable serialisation; round-tripped by {!string_to_action}. The
     parametric variants ([ToolCall] / [GovernanceDecision] /
     [Custom]) are encoded as ["<tag>:<arg>"]. *)
 
@@ -96,10 +96,6 @@ val entry_of_json : Yojson.Safe.t -> audit_entry option
     bad entries. *)
 
 (** {1 Storage} *)
-
-val legacy_audit_path : config -> string
-(** Pre-date-split [audit.jsonl] location, kept for migration
-    callers that need to detect the old single-file layout. *)
 
 val read_entries : ?n:int -> config -> audit_entry list
 (** Most-recent [n] (default 10000) parsed entries from the


### PR DESCRIPTION
Summary: remove Audit_log.legacy_audit_path and the read_entries fallback to .masc/audit.jsonl; audit reads now use only the date-split .masc/audit/YYYY-MM/DD.jsonl store. Updated docs that still advertised the legacy path. Verification: ocamlformat --check lib/audit_log.ml lib/audit_log.mli; git diff --check; rg no remaining legacy audit fallback references in touched files; scripts/ci/check-ignore-without-comment-diff.sh; scripts/lint/godfile-size-regression.sh; scripts/code-smell-ratchet.sh. Gap: scripts/dune-local.sh build lib/masc_mcp.cmxa was blocked by machine-wide bare-Dune guard detecting live 'dune build --root .' processes.