### PR TITLE
fix(taskboard): auto-release Claimed tasks on re-claim

### DIFF
--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -424,7 +424,7 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
                   ~site:"claim_task" ~agent_name ~task_id exn);
            (* Broadcast auto-released tasks (Claimed-only, preempted for this claim) *)
            List.iter (fun released_id ->
-             (* best-effort: broadcast auto-release for operator visibility *)
+             (* fire-and-forget: broadcast auto-release for operator visibility *)
              ignore (broadcast config ~from_agent:agent_name
                ~content:(Printf.sprintf
                  "Auto-released %s (claimed, not started) to claim %s"

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -92,8 +92,8 @@ let active_owned_task_ids_for_agent config ~agent_name (backlog : Masc_domain.ba
 
 let active_ownership_conflict_message ~agent_name ~requested_task_id task_ids =
   Printf.sprintf
-    "Agent %s already owns active task(s): %s. Finish, release, or cancel them \
-     before claiming %s."
+    "Agent %s has task(s) in progress: %s. Use keeper_task_done (task_id + result) \
+     or keeper_task_force_release (task_id + reason) to finish them before claiming %s."
     agent_name
     (String.concat ", " task_ids)
     requested_task_id
@@ -278,6 +278,36 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
                (Masc_domain.Task (Masc_domain.Task_error.InvalidState
                   (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r)))
          in
+         (* Auto-release Claimed-only tasks owned by this agent.
+            Claimed = claimed but work not started; safe to preempt
+            for a new claim. Only InProgress/AwaitingVerification
+            tasks block the claim (those represent active work). *)
+         let (backlog, auto_released_ids) =
+           let claimed_by_me =
+             backlog.tasks
+             |> List.filter_map (fun (t : task) ->
+                    match t.task_status with
+                    | Claimed { assignee; _ }
+                      when Coord_task_classify.same_task_actor
+                             config assignee agent_name
+                           && t.id <> task_id ->
+                      Some t.id
+                    | Todo | Claimed _ | InProgress _
+                    | AwaitingVerification _ | Done _
+                    | Cancelled _ -> None)
+           in
+           match claimed_by_me with
+           | [] -> (backlog, [])
+           | ids ->
+             let new_tasks =
+               List.map (fun (t : task) ->
+                 if List.mem t.id ids
+                 then { t with task_status = Todo }
+                 else t
+               ) backlog.tasks
+             in
+             ({ backlog with tasks = new_tasks }, ids)
+         in
          let* () =
            match task.task_status with
            | Todo ->
@@ -392,7 +422,28 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
             | exn ->
                 Coord_hooks.observe_claim_post_provision_failure
                   ~site:"claim_task" ~agent_name ~task_id exn);
-           Ok (Printf.sprintf "%s claimed %s" agent_name task_id)
+           (* Broadcast auto-released tasks (Claimed-only, preempted for this claim) *)
+           List.iter (fun released_id ->
+             ignore (broadcast config ~from_agent:agent_name
+               ~content:(Printf.sprintf
+                 "Auto-released %s (claimed, not started) to claim %s"
+                 released_id task_id));
+             log_event config (`Assoc
+               [ ("type", `String "task_auto_release")
+               ; ("agent", `String agent_name)
+               ; ("task", `String released_id)
+               ; ("reason", `String "preempted_for_claim")
+               ; ("ts", `String (now_iso ()))
+               ])
+           ) auto_released_ids;
+           let claim_msg =
+             match auto_released_ids with
+             | [] -> Printf.sprintf "%s claimed %s" agent_name task_id
+             | ids ->
+               Printf.sprintf "%s claimed %s (auto-released %s)"
+                 agent_name task_id (String.concat ", " ids)
+           in
+           Ok claim_msg
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | e -> Error (Masc_domain.System (Masc_domain.System_error.IoError (Printexc.to_string e)))))

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -424,6 +424,7 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
                   ~site:"claim_task" ~agent_name ~task_id exn);
            (* Broadcast auto-released tasks (Claimed-only, preempted for this claim) *)
            List.iter (fun released_id ->
+             (* best-effort: broadcast auto-release for operator visibility *)
              ignore (broadcast config ~from_agent:agent_name
                ~content:(Printf.sprintf
                  "Auto-released %s (claimed, not started) to claim %s"

--- a/lib/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_shard_types_schemas_taskboard.ml
@@ -138,10 +138,13 @@ let taskboard_tools : Masc_domain.tool_schema list =
     ; description =
         "Claim the next unclaimed todo task that matches your capabilities. Returns \
          claimed task details (task_id, title, description) or empty if none available. \
-         If active_goal_ids are configured, only tasks linked to those goals are \
-         eligible; when that scoped pool has no claimable task for your current \
-         capabilities, the claim stops instead of crossing into unrelated goals. \
-         Auto-repaired keeper-purpose goals may still fall back to all claimable tasks."
+         If you already own a task in Claimed state (not yet started), it is \
+         auto-released to Todo so the claim can proceed. Tasks in InProgress or \
+         AwaitingVerification block the claim -- use keeper_task_done or \
+         keeper_task_force_release on them first. If active_goal_ids are configured, \
+         only tasks linked to those goals are eligible; when that scoped pool has no \
+         claimable task for your current capabilities, the claim stops instead of \
+         crossing into unrelated goals."
     ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
     }
   ; { name = "keeper_task_done"


### PR DESCRIPTION
## Summary
- `claim_task_r` auto-releases `Claimed`-only tasks (not yet started) before the ownership conflict check, so keepers can claim new tasks without manually releasing stale claims
- Only `InProgress`/`AwaitingVerification` tasks now block claims — error message references specific tool names (`keeper_task_done`, `keeper_task_force_release`)
- `keeper_task_claim` tool description documents the auto-release behavior

## Problem
28/day `masc_transition deterministic error` from keepers trying to claim without releasing. LLM receives "already owns active task(s)" but doesn't act on it, loops instead.

## Test plan
- [x] `dune build` passes
- [ ] CI Build and Test
- [ ] Verify auto-release broadcast appears in system log

Closes #18333

🤖 Generated with [Claude Code](https://claude.com/claude-code)