### PR TITLE
refactor(memory): remove compact audit precompact fallback

### DIFF
--- a/bin/masc_compaction_audit.ml
+++ b/bin/masc_compaction_audit.ml
@@ -1,10 +1,9 @@
 (** [masc_compaction_audit] — CLI for inspecting the compaction audit JSONL.
 
-    Reads events from [{base}/data/harness-compact/] (plus legacy
-    [harness-pre-compact/] fallback) via {!Masc_mcp.Keeper_compact_audit},
-    pairs Start/Complete rows by [compaction_id], and prints a human-
-    readable summary. Supports date range / keeper filter / orphan-only
-    view, plus manual retention prune.
+    Reads events from [{base}/data/harness-compact/] via
+    {!Masc_mcp.Keeper_compact_audit}, pairs Start/Complete rows by
+    [compaction_id], and prints a human-readable summary. Supports date
+    range / keeper filter / orphan-only view, plus manual retention prune.
 
     Invoked as [sb compaction list ...] once wired into the [sb] shim. *)
 

--- a/docs/compaction/COMPACTION-LIFECYCLE.md
+++ b/docs/compaction/COMPACTION-LIFECYCLE.md
@@ -108,8 +108,8 @@ separate storage / lifecycle / retention.
 
 | Surface | Location | Lifecycle | Retention |
 |---------|----------|-----------|-----------|
-| **Paired audit JSONL (new)** | `.masc/data/harness-compact/YYYY-MM/DD.jsonl` | written by `Keeper_compact_audit` subscriber on every ContextCompactStarted + ContextCompacted | rolling, default 14 days (`MASC_COMPACTION_AUDIT_RETENTION_DAYS` override) |
-| Legacy pre-compact JSONL | `.masc/data/harness-pre-compact/YYYY-MM/DD.jsonl` | written by `Dashboard_harness_health.record_pre_compact` (deprecated) | historical; read-only fallback for existing dashboards |
+| **Paired audit JSONL** | `.masc/data/harness-compact/YYYY-MM/DD.jsonl` | written by `Keeper_compact_audit` subscriber on every ContextCompactStarted + ContextCompacted | rolling, default 14 days (`MASC_COMPACTION_AUDIT_RETENTION_DAYS` override) |
+| Pre-compact dashboard JSONL | `.masc/data/harness-pre-compact/YYYY-MM/DD.jsonl` | written by `Dashboard_harness_health.record_pre_compact` for the dashboard harness summary | dashboard harness retention |
 | Prometheus | `masc_keeper_compactions_total`, `masc_keeper_compaction_ratio_change` | incremented on every compaction attempt / completion | process-lifetime, scrape-based |
 | TLA+ trace (opt-in) | `.masc/keepers/<name>.tla-trace.jsonl` | written when `MASC_TLA_TRACE=1` | until operator deletes; zero overhead when disabled |
 | Checkpoint store | `.masc/keepers/<name>/traces/<trace_id>/<trace_id>.json` | canonical OAS checkpoint write after successful keeper turns | current checkpoint plus OAS history snapshots |

--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -65,9 +65,6 @@ type pair_result =
 let store_base_dir base_path =
   Filename.concat base_path "data/harness-compact"
 
-let legacy_base_dir base_path =
-  Filename.concat base_path "data/harness-pre-compact"
-
 (* One store per process. Keeps Dated_jsonl's mutex alive for append safety. *)
 let store_ref : Dated_jsonl.t option ref = ref None
 
@@ -144,7 +141,7 @@ let int_field json key =
 
 let start_of_json json : start_record option =
   match str_field json "record_type" with
-  | "compaction_start" | "pre_compact"  (* legacy support *) ->
+  | "compaction_start" ->
     Some {
       compaction_id  = str_field   json "compaction_id";
       ts_unix        = float_field json "ts_unix";
@@ -287,13 +284,7 @@ let read_events ~base_path ~since ~until ?keeper () :
       ~since:(iso_of_unix since) ~until:(iso_of_unix until)
   in
   try
-    let new_rows  = List.filter_map classify (read_dir (store_base_dir base_path))  in
-    let legacy    =
-      if Sys.file_exists (legacy_base_dir base_path)
-      then List.filter_map classify (read_dir (legacy_base_dir base_path))
-      else []
-    in
-    let all = new_rows @ legacy in
+    let all = List.filter_map classify (read_dir (store_base_dir base_path)) in
     let sort_ts = function Start r -> r.ts_unix | Complete r -> r.ts_unix in
     let sorted = List.sort (fun a b -> compare (sort_ts a) (sort_ts b)) all in
     Ok sorted

--- a/lib/keeper/keeper_compact_audit.mli
+++ b/lib/keeper/keeper_compact_audit.mli
@@ -21,10 +21,8 @@
       are parsed into variants with [Unknown] fallback. Unknown tags
       are preserved, not rejected, so forward compat with OAS is
       automatic.
-    - Legacy reader: [Dashboard_harness_health] previously wrote to
-      [{base_path}/data/harness-pre-compact/*.jsonl]; that path is
-      read as a fallback so existing dashboards keep working during
-      the transition. New writes go only to the new path. *)
+    - Reads and writes use only the paired audit store. Historical
+      [harness-pre-compact/] rows are not projected into this API. *)
 
 (** {1 Types} *)
 
@@ -97,10 +95,8 @@ type row =
   | Start    of start_record
   | Complete of complete_record
 
-(** Read events from both the new [harness-compact/] path and the
-    legacy [harness-pre-compact/] path (Start rows only, since the
-    legacy format had no post event). Results merged and sorted by
-    [ts_unix] ascending. *)
+(** Read events from the [harness-compact/] paired audit path. Results
+    are sorted by [ts_unix] ascending. *)
 val read_events
   :  base_path:string
   -> since:float

--- a/test/test_keeper_compact_audit.ml
+++ b/test/test_keeper_compact_audit.ml
@@ -1,8 +1,7 @@
 (** Tests for [Keeper_compact_audit].
 
     Covers: trigger parser round-trip, pure pairing (Paired /
-    Orphan_start / Orphan_complete), persist → prune → read integration,
-    and legacy pre-compact JSONL fallback. *)
+    Orphan_start / Orphan_complete), and persist → prune → read integration. *)
 
 open Alcotest
 


### PR DESCRIPTION
Summary: remove Keeper_compact_audit's legacy data/harness-pre-compact read fallback and stop accepting record_type=pre_compact as a start row. The compaction audit CLI/docs now describe only the paired data/harness-compact audit store; the dashboard pre-compact store remains documented as its own dashboard surface, not a fallback for the paired audit API. Verification: ocamlformat --check lib/keeper/keeper_compact_audit.ml lib/keeper/keeper_compact_audit.mli bin/masc_compaction_audit.ml test/test_keeper_compact_audit.ml; git diff --check; rg no legacy precompact fallback references in touched KCA/CLI/test/doc paths; scripts/ci/check-ignore-without-comment-diff.sh; scripts/lint/godfile-size-regression.sh; scripts/code-smell-ratchet.sh. Gap: scripts/dune-local.sh build test/test_keeper_compact_audit.exe bin/masc_compaction_audit.exe was blocked by machine-wide bare-Dune guard detecting live 'dune build --root .' processes.