### PR TITLE
refactor(agent): remove from_agent_name identity helper

### DIFF
--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -218,22 +218,6 @@ let from_mcp_params params =
     metadata = [];
   }
 
-(** Create identity from agent_name (legacy support) *)
-let from_agent_name agent_name =
-  let now = Time_compat.now () in
-  {
-    uuid = generate_uuid ~agent_name;
-    session_key = generate_session_key ();
-    agent_name;
-    channel = None;
-    user_id = None;
-    room_id = None;
-    capabilities = [];
-    registered_at = now;
-    last_seen = now;
-    metadata = [];
-  }
-
 (** Create anonymous/unknown identity *)
 let anonymous () =
   let now = Time_compat.now () in

--- a/lib/agent_identity.mli
+++ b/lib/agent_identity.mli
@@ -52,7 +52,6 @@ val string_of_channel : channel -> string
 val generate_uuid : agent_name:string -> string
 val generate_session_key : unit -> string
 val from_mcp_params : Yojson.Safe.t -> t
-val from_agent_name : string -> t
 val anonymous : unit -> t
 
 (** {1 Identity Registry} *)

--- a/test/test_agent_identity.ml
+++ b/test/test_agent_identity.ml
@@ -4,21 +4,24 @@ open Alcotest
 open Masc_mcp
 open Types_core
 
+let identity_for ?session_key agent_name =
+  let session_key =
+    match session_key with
+    | Some value -> value
+    | None -> "session-" ^ agent_name
+  in
+  Agent_identity.from_mcp_params
+    (`Assoc
+      [
+        ("_agent_name", `String agent_name);
+        ("_session_key", `String session_key);
+      ])
+
 let test_generate_session_key () =
   let key1 = Agent_identity.generate_session_key () in
   let key2 = Agent_identity.generate_session_key () in
   check bool "keys are different" true (key1 <> key2);
   check bool "key length >= 32" true (String.length key1 >= 32)
-
-let test_from_agent_name () =
-  let identity = Agent_identity.from_agent_name "test-agent" in
-  check string "agent_name matches" "test-agent" identity.agent_name;
-  check bool "session_key generated" true (String.length identity.session_key > 0);
-  check (option (module struct
-    type t = Agent_identity.channel
-    let pp = Fmt.nop
-    let equal _ _ = true
-  end)) "channel is None" None identity.channel
 
 let test_from_mcp_params () =
   let params = `Assoc [
@@ -150,10 +153,10 @@ let test_archetype_parser_strict () =
     (Agent_identity.archetype_of_string_opt "planner-ish")
 
 let test_same_agent () =
-  let id1 = Agent_identity.from_agent_name "agent-a" in
+  let id1 = identity_for ~session_key:"session-agent-a-1" "agent-a" in
   let id2 = { id1 with Agent_identity.last_seen = Unix.gettimeofday () +. 100.0 } in
-  let id3 = Agent_identity.from_agent_name "agent-a" in
-  let id4 = Agent_identity.from_agent_name "agent-b" in
+  let id3 = identity_for ~session_key:"session-agent-a-2" "agent-a" in
+  let id4 = identity_for "agent-b" in
   check bool "same session_key" true (Agent_identity.same_agent id1 id2);
   check bool "same agent_name" true (Agent_identity.same_agent id1 id3);
   check bool "different agents" false (Agent_identity.same_agent id1 id4)
@@ -210,7 +213,7 @@ module RegistryTests = struct
     Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
     let reg = Agent_identity.Registry.create () in
-    let identity = Agent_identity.from_agent_name "test-agent" in
+    let identity = identity_for "test-agent" in
     let _ = Agent_identity.Registry.register reg identity in
     
     let found_by_session = Agent_identity.Registry.find_by_session reg identity.session_key in
@@ -223,7 +226,7 @@ module RegistryTests = struct
     Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
     let reg = Agent_identity.Registry.create () in
-    let identity = Agent_identity.from_agent_name "test-agent" in
+    let identity = identity_for "test-agent" in
     let registered = Agent_identity.Registry.register reg identity in
     
     check int "count after register" 1 (Agent_identity.Registry.count reg);
@@ -237,7 +240,7 @@ module RegistryTests = struct
     (* Create identity with old timestamp *)
     let old_time = Unix.gettimeofday () -. 10.0 in
     let identity = Agent_identity.({
-      (from_agent_name "test-agent") with
+      (identity_for "test-agent") with
       last_seen = old_time;
       registered_at = old_time;
     }) in
@@ -255,9 +258,9 @@ module RegistryTests = struct
     Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
     let reg = Agent_identity.Registry.create () in
-    let id1 = Agent_identity.from_agent_name "active-agent" in
+    let id1 = identity_for "active-agent" in
     let id2 = Agent_identity.({
-      (from_agent_name "stale-agent") with
+      (identity_for "stale-agent") with
       last_seen = Unix.gettimeofday () -. 1000.0;
       registered_at = Unix.gettimeofday () -. 1000.0;
     }) in
@@ -274,7 +277,6 @@ let () =
   run "Agent_identity" [
     "basics", [
       test_case "generate_session_key" `Quick test_generate_session_key;
-      test_case "from_agent_name" `Quick test_from_agent_name;
       test_case "from_mcp_params" `Quick test_from_mcp_params;
       test_case "from_mcp_params_minimal" `Quick test_from_mcp_params_minimal;
       test_case "from_mcp_params_empty_session_key" `Quick test_from_mcp_params_empty_session_key;

--- a/test/test_mcp_full_cycle.ml
+++ b/test/test_mcp_full_cycle.ml
@@ -18,6 +18,19 @@ module Fixtures = struct
       ("_agent_name", `String agent_name);
       ("_channel", `String "internal");
     ]
+
+  let identity_for ?session_key agent_name =
+    let session_key =
+      match session_key with
+      | Some value -> value
+      | None -> "session-" ^ agent_name
+    in
+    Agent_identity.from_mcp_params
+      (`Assoc
+        [
+          ("_agent_name", `String agent_name);
+          ("_session_key", `String session_key);
+        ])
 end
 
 (** Test: Agent identity extracted from MCP params *)
@@ -39,7 +52,7 @@ let test_identity_registry_persistence () =
   let reg = Agent_identity.Registry.create () in
   
   (* First call - register agent *)
-  let id1 = Agent_identity.from_agent_name "persistent-agent" in
+  let id1 = Fixtures.identity_for "persistent-agent" in
   let registered = Agent_identity.Registry.register reg id1 in
   
   (* Simulate second call - should find existing *)
@@ -58,7 +71,7 @@ let test_multi_agent_isolation () =
   
   let agents = ["agent-a"; "agent-b"; "agent-c"] in
   let identities = List.map (fun name ->
-    Agent_identity.Registry.register reg (Agent_identity.from_agent_name name)
+    Agent_identity.Registry.register reg (Fixtures.identity_for name)
   ) agents in
   
   (* Verify all agents have unique session keys *)
@@ -79,7 +92,7 @@ let test_room_context () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let reg = Agent_identity.Registry.create () in
   
-  let id = Agent_identity.from_agent_name "room-agent" in
+  let id = Fixtures.identity_for "room-agent" in
   let _ = Agent_identity.Registry.register reg id in
   
   (* Agent joins room *)
@@ -114,12 +127,12 @@ let test_stale_agent_cleanup () =
   let reg = Agent_identity.Registry.create () in
   
   (* Active agent *)
-  let active = Agent_identity.from_agent_name "active-agent" in
+  let active = Fixtures.identity_for "active-agent" in
   let _ = Agent_identity.Registry.register reg active in
   
   (* Stale agent (last_seen in the past) *)
   let stale = Agent_identity.({
-    (from_agent_name "stale-agent") with
+    (Fixtures.identity_for "stale-agent") with
     last_seen = Unix.gettimeofday () -. 3600.0;  (* 1 hour ago *)
   }) in
   let _ = Agent_identity.Registry.register reg stale in
@@ -139,7 +152,7 @@ let test_concurrent_registration () =
   (* Spawn multiple fibers registering agents *)
   Eio.Fiber.all (List.init 10 (fun i () ->
     let name = Printf.sprintf "concurrent-agent-%d" i in
-    let id = Agent_identity.from_agent_name name in
+    let id = Fixtures.identity_for name in
     let _ = Agent_identity.Registry.register reg id in
     (* Touch a few times *)
     for _ = 1 to 5 do
@@ -156,7 +169,7 @@ let test_session_key_stability () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let reg = Agent_identity.Registry.create () in
   
-  let id = Agent_identity.from_agent_name "stable-agent" in
+  let id = Fixtures.identity_for "stable-agent" in
   let original_key = id.session_key in
   let _ = Agent_identity.Registry.register reg id in
   


### PR DESCRIPTION
Summary: remove the test-only Agent_identity.from_agent_name legacy convenience helper from the public identity API. Tests now build explicit identities through the canonical from_mcp_params path with _agent_name and _session_key. Verification: ocamlformat --check lib/agent_identity.ml lib/agent_identity.mli test/test_agent_identity.ml test/test_mcp_full_cycle.ml; git diff --check; rg no remaining from_agent_name symbol in touched identity/test paths; scripts/ci/check-ignore-without-comment-diff.sh; scripts/lint/godfile-size-regression.sh; scripts/code-smell-ratchet.sh. Gap: scripts/dune-local.sh build test/test_agent_identity.exe test/test_mcp_full_cycle.exe was blocked by machine-wide bare-Dune guard detecting live 'dune build --root .' processes.