### PR TITLE
refactor(coord): remove Coord_state compatibility reexports

### DIFF
--- a/lib/coord/coord_state.ml
+++ b/lib/coord/coord_state.ml
@@ -7,7 +7,7 @@
     - State recovery (recover_room_state)
     - Shared string utilities (String_util.option_trim, normalized_string_list)
 
-    Extracted to separate modules:
+    Extracted owner modules:
     - Coord_bootstrap: default_room_state, ensure_room_bootstrap
     - Coord_identity: generate_session_id, get_hostname, get_tty, resolve_agent_name
     - Coord_task_id: task_id_to_int, archive management, next_task_number
@@ -16,24 +16,6 @@
 
 open Masc_domain
 open Coord_utils
-
-(* ============================================ *)
-(* Re-exports (backward compat)                 *)
-(* ============================================ *)
-
-let default_room_state = Coord_bootstrap.default_room_state
-let ensure_room_bootstrap = Coord_bootstrap.ensure_room_bootstrap
-let generate_session_id = Coord_identity.generate_session_id
-let get_hostname = Coord_identity.get_hostname
-let get_tty = Coord_identity.get_tty
-let resolve_agent_name = Coord_identity.resolve_agent_name
-let task_id_to_int = Coord_task_id.task_id_to_int
-let read_archive_task_ids = Coord_task_id.read_archive_task_ids
-let append_archive_tasks = Coord_task_id.append_archive_tasks
-let next_task_number = Coord_task_id.next_task_number
-let read_backlog_r = Coord_backlog.read_backlog_r
-let read_backlog = Coord_backlog.read_backlog
-let write_backlog = Coord_backlog.write_backlog
 
 (* ============================================ *)
 (* Shared String Utilities                      *)
@@ -64,7 +46,7 @@ let recover_active_agent_name = function
   | _ -> None
 
 let recover_room_state config json =
-  let defaults = default_room_state config in
+  let defaults = Coord_bootstrap.default_room_state config in
   let active_agents =
     match Safe_ops.json_list_opt "active_agents" json with
     | Some agents -> List.filter_map recover_active_agent_name agents

--- a/lib/coord/coord_state.mli
+++ b/lib/coord/coord_state.mli
@@ -3,36 +3,6 @@
 open Masc_domain
 open Coord_utils
 
-val default_room_state :
-  Coord_utils_backend_setup.config -> Masc_domain.room_state
-
-val ensure_room_bootstrap : Coord_utils_backend_setup.config -> unit
-val generate_session_id : unit -> string
-val get_hostname : unit -> string option
-val get_tty : unit -> string option
-
-val resolve_agent_name :
-  Coord_utils_backend_setup.config -> string -> string
-
-val task_id_to_int : string -> int option
-
-val read_archive_task_ids : Coord_utils_backend_setup.config -> int list
-
-val append_archive_tasks :
-  Coord_utils_backend_setup.config -> Masc_domain.task list -> unit
-
-val next_task_number :
-  Coord_utils_backend_setup.config -> Masc_domain.backlog -> int
-
-val read_backlog_r :
-  Coord_utils_backend_setup.config ->
-  (Masc_domain.backlog, string) result
-
-val read_backlog : Coord_utils_backend_setup.config -> Masc_domain.backlog
-
-val write_backlog :
-  Coord_utils_backend_setup.config -> Masc_domain.backlog -> unit
-
 val normalized_string_list : string list -> string list
 
 (** Project a JSON entry of the [active_agents] array to the agent

--- a/lib/coord/coord_task_cache_invariant.ml
+++ b/lib/coord/coord_task_cache_invariant.ml
@@ -74,7 +74,7 @@ let check_cache_signal ~config ~content =
   if task_ids = [] || not (active_cache_language_present content)
   then No_cache_signal
   else
-    match Coord_state.read_backlog_r config with
+    match Coord_backlog.read_backlog_r config with
     | Error msg ->
       Log.Misc.warn "task cache invariant: backlog read failed before broadcast: %s" msg;
       Backlog_unavailable { task_ids; error = msg }


### PR DESCRIPTION
Summary: remove Coord_state's backward-compatible re-export block for Coord_bootstrap, Coord_identity, Coord_task_id, and Coord_backlog helpers. The one remaining repo caller of Coord_state.read_backlog_r now calls Coord_backlog.read_backlog_r directly, and recover_room_state uses Coord_bootstrap.default_room_state explicitly. Verification: ocamlformat --check lib/coord/coord_state.ml lib/coord/coord_state.mli lib/coord/coord_task_cache_invariant.ml; git diff --check; rg no remaining compatibility re-export symbols or Coord_state.read_backlog_r in touched paths; scripts/ci/check-ignore-without-comment-diff.sh; scripts/lint/godfile-size-regression.sh; scripts/code-smell-ratchet.sh. Gap: scripts/dune-local.sh build lib/masc_mcp.cmxa was blocked by machine-wide bare-Dune guard detecting live 'dune build --root .' processes.