### PR TITLE
refactor(gh): remove legacy gh result adapter

### DIFF
--- a/lib/gh_exit_class.ml
+++ b/lib/gh_exit_class.ml
@@ -118,18 +118,3 @@ type gh_result = {
 let make ~stdout ~stderr ~exit_code =
   let class_ = classify ~exit_code ~stderr in
   { stdout; stderr; exit_code; class_; interpretation = interpretation_of class_ }
-
-let to_legacy_result r =
-  match r.class_ with
-  | Ok_0 -> Ok r.stdout
-  | _ ->
-    let summary =
-      match r.interpretation with
-      | Some s -> Printf.sprintf "[%s] %s" (to_string r.class_) s
-      | None -> Printf.sprintf "[%s] exit=%d" (to_string r.class_) r.exit_code
-    in
-    let body =
-      if r.stderr = "" then summary
-      else Printf.sprintf "%s\n%s" summary (String.trim r.stderr)
-    in
-    Error body

--- a/lib/gh_exit_class.mli
+++ b/lib/gh_exit_class.mli
@@ -18,11 +18,7 @@
       [String.contains] probes on [stderr].
     - [Unknown] is a first-class bucket, not a bug. It fires the
       [Unknown] metric so operators can see emerging patterns without
-      the classifier lying about them.
-
-    Backward compatibility: callers migrating to {!gh_result} may keep
-    their [(string, string) result] API via {!to_legacy_result} for
-    one release cycle. *)
+      the classifier lying about them. *)
 
 (** Classification bucket. Order matches RFC-0007 §PR-2 table. *)
 type t =
@@ -47,8 +43,7 @@ val to_string : t -> string
 (** [classify ~exit_code ~stderr] is pure. *)
 val classify : exit_code:int -> stderr:string -> t
 
-(** Structured result for a [gh] subprocess invocation. New callers
-    return this directly; legacy callers use {!to_legacy_result}. *)
+(** Structured result for a [gh] subprocess invocation. *)
 type gh_result = private {
   stdout : string;
   stderr : string;
@@ -61,11 +56,6 @@ type gh_result = private {
     result. [interpretation] is a short, ready-to-show hint derived
     from [class_]; [None] for [Ok_0] and [Unknown]. *)
 val make : stdout:string -> stderr:string -> exit_code:int -> gh_result
-
-(** Convert to the legacy [(string, string) result]. [Ok_0 →
-    Ok stdout]; everything else → [Error] with a one-line summary
-    prefixed by the class name. *)
-val to_legacy_result : gh_result -> (string, string) result
 
 (** A single classification rule: [(predicate, class)]. The classifier
     walks the rule list head-to-tail and returns the class of the

--- a/test/test_gh_exit_class.ml
+++ b/test/test_gh_exit_class.ml
@@ -10,8 +10,7 @@
    4. Network uses curl/TLS keywords, not stdout.
    5. Type_mismatch on exit=2 (Go/cobra argparse) or flag/command errors.
    6. Unknown is a first-class, stable bucket — never misclassify.
-   7. [install_overrides] takes precedence over defaults.
-   8. [to_legacy_result] preserves the one-release compat contract. *)
+   7. [install_overrides] takes precedence over defaults. *)
 
 module GEC = Masc_mcp.Gh_exit_class
 
@@ -90,25 +89,6 @@ let test_make_carries_interpretation () =
                 in sub_at 0)))
    | None -> Alcotest.fail "expected interpretation for Auth_failed")
 
-let test_to_legacy_ok () =
-  let r = GEC.make ~stdout:"hello\n" ~stderr:"" ~exit_code:0 in
-  match GEC.to_legacy_result r with
-  | Ok s -> Alcotest.(check string) "stdout preserved" "hello\n" s
-  | Error e -> Alcotest.fail ("expected Ok, got Error: " ^ e)
-
-let test_to_legacy_err_prefix () =
-  let r = GEC.make ~stdout:"" ~stderr:"Bad credentials" ~exit_code:1 in
-  match GEC.to_legacy_result r with
-  | Ok _ -> Alcotest.fail "expected Error"
-  | Error body ->
-    (* The error body must be prefixed by the class name in square
-       brackets. Callers may grep for [Auth_failed] etc. *)
-    let has_prefix =
-      String.length body >= 14
-      && String.sub body 0 13 = "[Auth_failed]"
-    in
-    Alcotest.(check bool) "legacy Error starts with class tag" true has_prefix
-
 let test_overrides_precedence () =
   (* Override: stderr containing "QUOTA" + exit 1 → Policy_blocked.
      Without the override, defaults bucket this to Unknown. *)
@@ -137,8 +117,6 @@ let () =
         [
           Alcotest.test_case "make carries interpretation"
             `Quick test_make_carries_interpretation;
-          Alcotest.test_case "to_legacy Ok"  `Quick test_to_legacy_ok;
-          Alcotest.test_case "to_legacy Err prefix" `Quick test_to_legacy_err_prefix;
         ] );
       ( "overrides",
         [


### PR DESCRIPTION
## Summary
- remove Gh_exit_class.to_legacy_result and its public signature
- drop the one-release compatibility wording from Gh_exit_class docs
- remove tests that only pinned the deleted legacy adapter

## Verification
- ocamlformat --check lib/gh_exit_class.ml lib/gh_exit_class.mli test/test_gh_exit_class.ml
- git diff --check
- rg -n "to_legacy_result|legacy callers use|one-release compat contract|one-release compat" lib test (no matches)
- scripts/ci/check-ignore-without-comment-diff.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh

## Not run
- scripts/dune-local.sh build test/test_gh_exit_class.exe (blocked by existing bare dune build --root . processes: 11674, 38246)