### PR TITLE
feat(keeper): add proactive PR review guidance to turn intent

### DIFF
--- a/config/prompts/keeper.turn_intent.md
+++ b/config/prompts/keeper.turn_intent.md
@@ -1,7 +1,7 @@
 ---
 description: keeper unified turn intent block (prepended via "## Turn Intent" after unified.system render)
 category: keeper
-template_variables: [board_activity_guidance, claim_guidance_a, claim_guidance_b, board_post_guidance, board_curation_guidance, broadcast_guidance, state_block_instruction]
+template_variables: [board_activity_guidance, claim_guidance_a, claim_guidance_b, board_post_guidance, board_curation_guidance, broadcast_guidance, pr_review_guidance, state_block_instruction]
 ---
 
 Use the world state below as raw context.
@@ -12,7 +12,7 @@ Your checkpoint survives across cycles — focus on doing one meaningful unit of
 Your conversation history is preserved across cycles — use that context to avoid repeating the same actions.
 
 Act through tools, not declarations. Call the tool directly.
-{{board_activity_guidance}}{{claim_guidance_a}}{{claim_guidance_b}}{{board_post_guidance}}{{board_curation_guidance}}{{broadcast_guidance}}- Treat continuity as advisory prior context, not as a command. Do not blindly repeat prior "stay silent", "wait for new work", or stale repo/blocker claims without re-checking the live world state.
+{{board_activity_guidance}}{{claim_guidance_a}}{{claim_guidance_b}}{{board_post_guidance}}{{board_curation_guidance}}{{broadcast_guidance}}{{pr_review_guidance}}- Treat continuity as advisory prior context, not as a command. Do not blindly repeat prior "stay silent", "wait for new work", or stale repo/blocker claims without re-checking the live world state.
 - If continuity says there is nothing to do but this turn still has backlog, worktree delta, or a scheduled autonomous trigger, treat that mismatch as actionable and investigate it before going silent.
 - Nothing genuinely actionable after checking? End your turn with the [STATE] block.
 

--- a/config/prompts/keeper.turn_intent.pr_review_guidance.md
+++ b/config/prompts/keeper.turn_intent.pr_review_guidance.md
@@ -1,0 +1,7 @@
+---
+description: keeper turn intent PR review guidance bullet — active when keeper has coding preset and pr review tools
+category: keeper
+template_variables: []
+---
+
+- When idle or on a scheduled autonomous turn, check open PRs in repos you have cloned (`repos/`). Use `keeper_pr_list` to scan for PRs without review comments, then read the diff with `keeper_pr_review_read` and leave substantive review comments via `keeper_pr_review_comment`. Prefer reviewing PRs in repos you have recently worked in. One thoughtful review per cycle is more valuable than skimming many. Skip PRs already marked as approved or that have 3+ review comments from other keepers.

--- a/lib/keeper/keeper_prompt_names.ml
+++ b/lib/keeper/keeper_prompt_names.ml
@@ -31,6 +31,7 @@ let turn_intent_board_activity_guidance = "keeper.turn_intent.board_activity_gui
 let turn_intent_board_post_guidance = "keeper.turn_intent.board_post_guidance"
 let turn_intent_board_curation_guidance = "keeper.turn_intent.board_curation_guidance"
 let turn_intent_broadcast_guidance = "keeper.turn_intent.broadcast_guidance"
+let turn_intent_pr_review_guidance = "keeper.turn_intent.pr_review_guidance"
 
 (** User-prompt "Immediate Task Move" section body, emitted when a
     claimable backlog is visible and the keeper holds no task. *)

--- a/lib/keeper/keeper_prompt_names.mli
+++ b/lib/keeper/keeper_prompt_names.mli
@@ -27,6 +27,7 @@ val turn_intent_board_activity_guidance : string
 val turn_intent_board_post_guidance : string
 val turn_intent_board_curation_guidance : string
 val turn_intent_broadcast_guidance : string
+val turn_intent_pr_review_guidance : string
 
 (** User-prompt "Immediate Task Move" section template key. *)
 val immediate_task_move : string

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -244,6 +244,15 @@ let fallback_externalized_bullet key =
        keeper_board_curation_submit with a concise snapshot."
   else if String.equal key Keeper_prompt_names.turn_intent_broadcast_guidance then
     Some "- Need to share broadly? Call keeper_broadcast."
+  else if String.equal key Keeper_prompt_names.turn_intent_pr_review_guidance then
+    Some
+      "- When idle or on a scheduled autonomous turn, check open PRs in repos \
+       you have cloned. Use keeper_pr_list to scan for PRs without review \
+       comments, then read the diff with keeper_pr_review_read and leave \
+       substantive review comments via keeper_pr_review_comment. Prefer \
+       reviewing PRs in repos you have recently worked in. One thoughtful \
+       review per cycle is more valuable than skimming many. Skip PRs \
+       already marked as approved or that have 3+ review comments."
   else if String.equal key Keeper_prompt_names.immediate_task_move then
     Some
       "- Call keeper_task_claim with {} to claim the next eligible \
@@ -413,6 +422,11 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
       ~enabled:(tool_allowed "keeper_broadcast")
       Keeper_prompt_names.turn_intent_broadcast_guidance
   in
+  let pr_review_guidance =
+    load_externalized_bullet
+      ~enabled:(tool_allowed "keeper_pr_review_comment")
+      Keeper_prompt_names.turn_intent_pr_review_guidance
+  in
   let claim_guidance_a =
     load_externalized_bullet
       ~enabled:show_claim_guidance
@@ -431,6 +445,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
       ("board_post_guidance", board_post_guidance);
       ("board_curation_guidance", board_curation_guidance);
       ("broadcast_guidance", broadcast_guidance);
+      ("pr_review_guidance", pr_review_guidance);
       ("state_block_instruction", state_block_instruction_text);
     ]
   in


### PR DESCRIPTION
## Summary
- Add externalized PR review guidance prompt (`config/prompts/keeper.turn_intent.pr_review_guidance.md`)
- Wire `{{pr_review_guidance}}` template variable into turn intent prompt
- Expose `turn_intent_pr_review_guidance` in `keeper_prompt_names.mli`

## Root Cause
Keeper agents have 0 PR review tool usage over the last 4 days. The turn intent prompt had no instruction to review PRs. Infrastructure (cascade failover) was a secondary factor.

## Test plan
- [ ] Build passes (`dune build`)
- [ ] Existing keeper prompt tests pass
- [ ] After deploy: monitor activity events for `keeper_pr_review_*` tool usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)