### PR TITLE
refactor(board): remove vote direction compatibility fallbacks

### DIFF
--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -29,12 +29,12 @@ let all_vote_directions = [ Up; Down ]
 let valid_vote_direction_strings =
   List.map vote_direction_to_string all_vote_directions
 
-(* Sound partial parser — case-insensitive, trims whitespace, accepts
-   empty as default Up for back-compat with [tool_board.ml] which
-   defaults to "up" when the field is missing. *)
+(* Sound partial parser — case-insensitive, trims whitespace, and
+   rejects empty input. Missing direction defaults belong at the tool
+   boundary, not in the wire-value parser. *)
 let vote_direction_of_string_opt raw =
   match String.trim (String.lowercase_ascii raw) with
-  | "up" | "" -> Some Up
+  | "up" -> Some Up
   | "down" -> Some Down
   | _ -> None
 
@@ -436,30 +436,32 @@ let load_persisted_votes store =
         match Safe_ops.json_string_opt "target" json,
               Safe_ops.json_string_opt "direction" json with
         | Some target, Some dir_str ->
-          let direction = if String.equal dir_str "down" then Down else Up in
-          (* #10086: legacy rows persisted before this fix may have
-             [ts] overwritten by a prior flush cycle.  Use the
-             recorded value when present; fall back to 0.0 rather
-             than [Time_compat.now ()] — loading a ledger at server
-             start time must NOT advance the ts of every pre-fix
-             vote to "now".  Downstream readers treat ts=0.0 as
-             "unknown cast time". *)
-          let ts =
-            match Safe_ops.json_float_opt "ts" json with
-            | Some t -> t
-            | None -> 0.0
-          in
-          (match classify_voter_target target with
-           | Fixture_voter _ ->
-               Stdlib.incr fixture_detected;
-               if quarantine then Stdlib.incr quarantined
-               else begin
-                 Hashtbl.replace store.vote_log target (direction, ts);
-                 Stdlib.incr loaded
-               end
-           | Production_voter ->
-               Hashtbl.replace store.vote_log target (direction, ts);
-               Stdlib.incr loaded)
+          (match vote_direction_of_string_opt dir_str with
+           | None -> ()
+           | Some direction ->
+             (* #10086: legacy rows persisted before this fix may have
+                [ts] overwritten by a prior flush cycle.  Use the
+                recorded value when present; fall back to 0.0 rather
+                than [Time_compat.now ()] — loading a ledger at server
+                start time must NOT advance the ts of every pre-fix
+                vote to "now".  Downstream readers treat ts=0.0 as
+                "unknown cast time". *)
+             let ts =
+               match Safe_ops.json_float_opt "ts" json with
+               | Some t -> t
+               | None -> 0.0
+             in
+             (match classify_voter_target target with
+              | Fixture_voter _ ->
+                  Stdlib.incr fixture_detected;
+                  if quarantine then Stdlib.incr quarantined
+                  else begin
+                    Hashtbl.replace store.vote_log target (direction, ts);
+                    Stdlib.incr loaded
+                  end
+              | Production_voter ->
+                  Hashtbl.replace store.vote_log target (direction, ts);
+                  Stdlib.incr loaded))
         | _ -> ()
       ) lines;
       if !fixture_detected > 0 then begin

--- a/lib/board_votes.mli
+++ b/lib/board_votes.mli
@@ -46,21 +46,18 @@ val vote_direction_to_string : vote_direction -> string
 
 val valid_vote_direction_strings : string list
 (** SSOT mirror of the encoded forms that
-    [vote_direction_of_string_opt] accepts.  Used by the
-    JSON Schema generator for the [direction] enum field
-    in the vote MCP tool. *)
+    [vote_direction_of_string_opt] accepts.  Used by the JSON Schema
+    generator for the [direction] enum field in the vote MCP tool. *)
 
 val all_vote_directions : vote_direction list
 (** Witness list — one entry per {!vote_direction}
     constructor, in declaration order. *)
 
 val vote_direction_of_string_opt : string -> vote_direction option
-(** Sound partial parser: case-insensitive, trims whitespace.
-    [""] is accepted as [Some Up] for back-compat with
-    [tool_board.ml] which defaults to ["up"] when the field
-    is missing.  Unknown input returns [None] (no silent
-    permissive fallback).  Pinned for behaviour-tests under
-    {!test/test_types}. *)
+(** Sound partial parser: case-insensitive, trims whitespace, and
+    accepts only ["up"] / ["down"].  Empty or unknown input returns
+    [None] (no silent permissive fallback).  Pinned for
+    behaviour-tests under {!test/test_types}. *)
 
 (** {1 Vote log path} *)
 

--- a/lib/tool_board_handlers.ml
+++ b/lib/tool_board_handlers.ml
@@ -83,71 +83,96 @@ let register_evolution_callback cb = Atomic.set evolution_hook (Some cb)
 
 (** {1 Vote / stats / search handlers} *)
 
+let invalid_vote_direction ~tool_name ~start_time raw =
+  Tool_result.error
+    ~tool_name
+    ~start_time
+    (Printf.sprintf "invalid vote direction %S; expected up or down" raw)
+;;
+
+let legacy_vote_parameter_removed ~tool_name ~start_time raw =
+  Tool_result.error
+    ~tool_name
+    ~start_time
+    (Printf.sprintf
+       "legacy vote parameter %S is no longer accepted; use direction"
+       raw)
+;;
+
 let handle_vote ~tool_name ~start_time args =
   let post_id = get_string args "post_id" "" in
   let voter = get_string args "voter" "anonymous" in
-  let direction_str =
-    let from_direction = get_string args "direction" "" in
-    if not (String.equal from_direction "")
-    then from_direction
-    else get_string args "vote" "up"
-  in
-  let direction = if String.equal direction_str "down" then Board.Down else Board.Up in
-  match Board_dispatch.vote ~voter ~post_id ~direction with
-  | Ok new_score ->
-    let arrow = if direction = Board.Up then "↑" else "↓" in
-    (* SOUL Evolution via callback (breaks compile-time dependency cycle). *)
-    let evolution_msg =
-      match Atomic.get evolution_hook with
-      | None -> "" (* Not initialized yet. *)
-      | Some cb ->
-        (match Board_dispatch.get_post ~post_id with
-         | Ok post ->
-           let author = Board.Agent_id.to_string post.author in
-           (* Agent-only evolution: 에이전트끼리만 서로 진화시킴. *)
-           if is_agent voter && is_agent author
-           then (
-             let dimension =
-               match cb.get_primary_value author with
-               | Some pv -> pv
-               | None -> "Creativity"
-             in
-             let is_positive = direction = Board.Up in
-             cb.record_feedback ~name:author ~dimension ~is_positive;
-             Printf.sprintf
-               " [%s evolved: %s %s]"
-               author
-               dimension
-               (if is_positive then "+0.01" else "-0.01"))
-           else ""
-         | Error e ->
-           Log.Misc.warn
-             "[ToolBoard] get_reputation_evolution failed: %s"
-             (Tool_board_format.board_error_to_string e);
-           "")
+  match Safe_ops.json_string_opt "direction" args, get_string_opt args "vote" with
+  | None, Some raw ->
+    legacy_vote_parameter_removed ~tool_name ~start_time raw
+  | direction_arg, _ ->
+    let direction_str =
+      match direction_arg with
+      | Some raw -> raw
+      | None -> "up"
     in
-    Tool_result.ok
-      ~tool_name
-      ~start_time
-      (Printf.sprintf "%s Vote recorded. New score: %+d%s" arrow new_score evolution_msg)
-  | Error (Board.Already_voted _) ->
-    (* Idempotent: same-direction duplicate vote is a no-op success.
-       The desired state already exists, so the tool call succeeds. *)
-    (match Board_dispatch.get_post ~post_id with
-     | Ok post ->
-       let score = post.votes_up - post.votes_down in
-       let arrow = if direction = Board.Up then "↑" else "↓" in
-       Tool_result.ok
-         ~tool_name
-         ~start_time
-         (Printf.sprintf "%s Already voted (idempotent). Score: %+d" arrow score)
-     | Error _ ->
-       Tool_result.ok
-         ~tool_name
-         ~start_time
-         "Already voted (idempotent). Score unchanged.")
-  | Error e ->
-    Tool_board_format.error_of_board_error ~tool_name ~start_time e
+    (match Board.vote_direction_of_string_opt direction_str with
+     | None -> invalid_vote_direction ~tool_name ~start_time direction_str
+     | Some direction ->
+       (match Board_dispatch.vote ~voter ~post_id ~direction with
+        | Ok new_score ->
+          let arrow = if direction = Board.Up then "↑" else "↓" in
+          (* SOUL Evolution via callback (breaks compile-time dependency cycle). *)
+          let evolution_msg =
+            match Atomic.get evolution_hook with
+            | None -> "" (* Not initialized yet. *)
+            | Some cb ->
+              (match Board_dispatch.get_post ~post_id with
+               | Ok post ->
+                 let author = Board.Agent_id.to_string post.author in
+                 (* Agent-only evolution: 에이전트끼리만 서로 진화시킴. *)
+                 if is_agent voter && is_agent author
+                 then (
+                   let dimension =
+                     match cb.get_primary_value author with
+                     | Some pv -> pv
+                     | None -> "Creativity"
+                   in
+                   let is_positive = direction = Board.Up in
+                   cb.record_feedback ~name:author ~dimension ~is_positive;
+                   Printf.sprintf
+                     " [%s evolved: %s %s]"
+                     author
+                     dimension
+                     (if is_positive then "+0.01" else "-0.01"))
+                 else ""
+               | Error e ->
+                 Log.Misc.warn
+                   "[ToolBoard] get_reputation_evolution failed: %s"
+                   (Tool_board_format.board_error_to_string e);
+                 "")
+          in
+          Tool_result.ok
+            ~tool_name
+            ~start_time
+            (Printf.sprintf
+               "%s Vote recorded. New score: %+d%s"
+               arrow
+               new_score
+               evolution_msg)
+        | Error (Board.Already_voted _) ->
+          (* Idempotent: same-direction duplicate vote is a no-op success.
+             The desired state already exists, so the tool call succeeds. *)
+          (match Board_dispatch.get_post ~post_id with
+           | Ok post ->
+             let score = post.votes_up - post.votes_down in
+             let arrow = if direction = Board.Up then "↑" else "↓" in
+             Tool_result.ok
+               ~tool_name
+               ~start_time
+               (Printf.sprintf "%s Already voted (idempotent). Score: %+d" arrow score)
+           | Error _ ->
+             Tool_result.ok
+               ~tool_name
+               ~start_time
+               "Already voted (idempotent). Score unchanged.")
+        | Error e ->
+          Tool_board_format.error_of_board_error ~tool_name ~start_time e))
 ;;
 
 let handle_stats ~tool_name ~start_time _args =
@@ -192,28 +217,30 @@ let handle_comment_vote ~tool_name ~start_time args =
   let comment_id = get_string args "comment_id" "" in
   let voter = get_string args "voter" "anonymous" in
   let direction_str = get_string args "direction" "up" in
-  let direction = if String.equal direction_str "down" then Board.Down else Board.Up in
-  if String.equal comment_id ""
-  then Tool_result.error ~tool_name ~start_time "comment_id required"
-  else (
-    match Board_dispatch.vote_comment ~voter ~comment_id ~direction with
-    | Ok score ->
-      Tool_result.ok
-        ~tool_name
-        ~start_time
-        (Printf.sprintf
-           "%s 코멘트 투표 완료! 점수: %+d"
-           (if String.equal direction_str "down" then "👎" else "👍")
-           score)
-    | Error (Board.Already_voted _) ->
-      Tool_result.ok
-        ~tool_name
-        ~start_time
-        (Printf.sprintf
-           "%s Already voted (idempotent)."
-           (if String.equal direction_str "down" then "👎" else "👍"))
-    | Error e ->
-      Tool_board_format.error_of_board_error ~tool_name ~start_time e)
+  match Board.vote_direction_of_string_opt direction_str with
+  | None -> invalid_vote_direction ~tool_name ~start_time direction_str
+  | Some direction ->
+    if String.equal comment_id ""
+    then Tool_result.error ~tool_name ~start_time "comment_id required"
+    else (
+      match Board_dispatch.vote_comment ~voter ~comment_id ~direction with
+      | Ok score ->
+        Tool_result.ok
+          ~tool_name
+          ~start_time
+          (Printf.sprintf
+             "%s 코멘트 투표 완료! 점수: %+d"
+             (if String.equal direction_str "down" then "👎" else "👍")
+             score)
+      | Error (Board.Already_voted _) ->
+        Tool_result.ok
+          ~tool_name
+          ~start_time
+          (Printf.sprintf
+             "%s Already voted (idempotent)."
+             (if String.equal direction_str "down" then "👎" else "👍"))
+      | Error e ->
+        Tool_board_format.error_of_board_error ~tool_name ~start_time e)
 ;;
 
 let handle_reaction ~tool_name ~start_time args =

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1445,6 +1445,45 @@ let test_vote_not_found () =
     result;
   Alcotest.(check bool) "has error" true (String.length body > 0)
 
+let test_vote_rejects_legacy_direction_fallbacks () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let empty_direction =
+    dispatch_result
+      "masc_board_vote"
+      (make_args
+         [
+           ("post_id", `String "missing");
+           ("voter", `String "v");
+           ("direction", `String "");
+         ])
+  in
+  Alcotest.(check bool) "empty direction rejected" false empty_direction.success;
+  Alcotest.(check bool)
+    "empty direction error"
+    true
+    (String_util.contains_substring
+       (Tool_result.message empty_direction)
+       "invalid vote direction");
+  let legacy_vote_alias =
+    dispatch_result
+      "masc_board_vote"
+      (make_args
+         [
+           ("post_id", `String "missing");
+           ("voter", `String "v");
+           ("vote", `String "down");
+         ])
+  in
+  Alcotest.(check bool) "legacy vote alias rejected" false legacy_vote_alias.success;
+  Alcotest.(check bool)
+    "legacy vote alias error"
+    true
+    (String_util.contains_substring
+       (Tool_result.message legacy_vote_alias)
+       "legacy vote parameter")
+
 (** {2 Group 5: Comment} *)
 
 let test_comment_add_missing_post () =
@@ -1894,6 +1933,10 @@ let () =
       ( "voting",
         [
           Alcotest.test_case "vote not found" `Quick test_vote_not_found;
+          Alcotest.test_case
+            "legacy direction fallbacks rejected"
+            `Quick
+            test_vote_rejects_legacy_direction_fallbacks;
         ] );
       ( "comments",
         [

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -716,12 +716,12 @@ let () =
         in
         witness Masc_mcp.Board_votes.Up; witness Masc_mcp.Board_votes.Down;
         Alcotest.(check int) "count" 2 (List.length B.valid_vote_direction_strings));
-      Alcotest.test_case "of_string_opt sound partial + back-compat" `Quick (fun () ->
+      Alcotest.test_case "of_string_opt sound partial" `Quick (fun () ->
         let module B = Masc_mcp.Board_votes in
         Alcotest.(check bool) "up" true (B.vote_direction_of_string_opt "up" <> None);
         Alcotest.(check bool) "DOWN (case)" true (B.vote_direction_of_string_opt "DOWN" <> None);
-        Alcotest.(check bool) "  empty -> Up back-compat" true
-          (B.vote_direction_of_string_opt "" = Some Masc_mcp.Board_votes.Up);
+        Alcotest.(check bool) "empty rejected" true
+          (B.vote_direction_of_string_opt "" = None);
         Alcotest.(check bool) "garbage rejected" true
           (B.vote_direction_of_string_opt "left" = None));
       Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->


### PR DESCRIPTION
## Summary
- stop treating an empty board vote direction as up
- remove the hidden legacy vote parameter fallback from masc_board_vote
- use the strict vote-direction parser for post votes, comment votes, and persisted vote-log loading
- replace the empty-string compatibility test with a rejection assertion and add a tool-level regression for the removed fallback paths

## Verification
- ocamlformat --check lib/board_votes.ml lib/board_votes.mli lib/tool_board_handlers.ml test/test_types.ml test/test_tool_board_coverage.ml
- git diff --check
- rg -n "vote_direction.*back|empty -> Up|from_direction|get_string args \"vote\"|legacy vote parameter|invalid vote direction" lib/board_votes.ml lib/board_votes.mli lib/tool_board_handlers.ml test/test_types.ml test/test_tool_board_coverage.ml
- scripts/ci/check-ignore-without-comment-diff.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Not run
- scripts/dune-local.sh build test/test_types.exe test/test_tool_board_coverage.exe (blocked by existing bare dune build --root . processes: 11674, 78887, 38246)