### PR TITLE
refactor(bounded): remove token buffer compatibility field

### DIFF
--- a/lib/bounded.ml
+++ b/lib/bounded.ml
@@ -50,11 +50,6 @@ type constraints = {
   max_tokens: int option;
   max_cost_usd: float option;
   max_time_seconds: float option;
-  token_buffer: int;
-  (* Deprecated since RFC-0028.  Kept on the record so that JSON
-     inputs that still set it parse without raising; no longer
-     consulted by the predictive token check, which now reads
-     {!Usage_history.predict_p95}. *)
   hard_max_iterations: int;    (** Absolute failsafe limit *)
   retry: retry_config;         (** Retry configuration *)
 }
@@ -65,9 +60,6 @@ let default_constraints = {
   max_tokens = Some 100000;
   max_cost_usd = Some 1.0;
   max_time_seconds = Some 300.0;
-  (* Was 5000 pre-RFC-0028.  Now 0 — the predictor consults
-     [Usage_history.predict_p95] instead of this magic constant. *)
-  token_buffer = 0;
   hard_max_iterations = 100;
   retry = default_retry_config;
 }
@@ -432,8 +424,6 @@ let constraints_of_json json =
       max_tokens = get_int_opt "max_tokens";
       max_cost_usd = get_float_opt "max_cost_usd";
       max_time_seconds = get_float_opt "max_time_seconds";
-      token_buffer =
-        Safe_ops.json_int ~default:default_constraints.token_buffer "token_buffer" json;
       hard_max_iterations =
         Safe_ops.json_int ~default:default_constraints.hard_max_iterations "hard_max_iterations" json;
       retry = retry_config_of_json json;

--- a/lib/bounded.mli
+++ b/lib/bounded.mli
@@ -20,14 +20,11 @@
     \[retry_config_of_json].  All consumed only inside
     {!bounded_run} or the {!constraints_of_json} parser.
 
-    The predictive token-budget check used to read
-    \[constraints.token_buffer] as a magic constant (5000 by default).
-    Since RFC-0028 it instead consults {!Usage_history.predict_p95}
-    over per-agent empirical distributions, falling back to a
-    documented constant only when fewer than ten samples have
-    accumulated for an agent.  The \[token_buffer] field is retained
-    for JSON-input compatibility and is no longer read; see
-    {!constraints} for the deprecation note. *)
+    The predictive token-budget check used to read a token-buffer magic
+    constant. Since RFC-0028 it instead consults
+    {!Usage_history.predict_p95} over per-agent empirical
+    distributions, falling back to a documented constant only when
+    fewer than ten samples have accumulated for an agent. *)
 
 (** {1 Goal conditions} *)
 
@@ -69,14 +66,6 @@ type constraints = {
   max_tokens : int option;
   max_cost_usd : float option;
   max_time_seconds : float option;
-  token_buffer : int;
-  (** {b Deprecated since RFC-0028.}  Retained for JSON-input
-      compatibility ({!constraints_of_json} still parses it without
-      raising), but no longer consulted by the predictive token check.
-      The next-turn estimate now comes from
-      {!Usage_history.predict_p95}.  Set to [0] in
-      {!default_constraints}.  Plan: removed once external producers
-      stop emitting it. *)
   hard_max_iterations : int;   (** Absolute failsafe — termination guarantee. *)
   retry : retry_config;
 }
@@ -84,8 +73,7 @@ type constraints = {
 val default_constraints : constraints
 (** Safe defaults: [max_turns = Some 10], [max_tokens = Some 100000],
     [max_cost_usd = Some 1.0], [max_time_seconds = Some 300.0],
-    [token_buffer = 0] (deprecated; see field doc), [hard_max_iterations = 100],
-    [retry = default_retry_config]. *)
+    [hard_max_iterations = 100], [retry = default_retry_config]. *)
 
 (** {1 Execution state} *)
 

--- a/test/test_bounded_coverage.ml
+++ b/test/test_bounded_coverage.ml
@@ -47,12 +47,6 @@ let test_default_constraints_max_time () =
   | Some f -> check (float 0.01) "max_time" 300.0 f
   | None -> fail "expected Some"
 
-let test_default_constraints_buffer () =
-  (* RFC-0028: token_buffer is deprecated.  Default is now 0 — the
-     predictor uses Usage_history.predict_p95 instead. *)
-  check int "token_buffer (RFC-0028 deprecated)" 0
-    Bounded.default_constraints.token_buffer
-
 let test_default_constraints_hard_max () =
   check int "hard_max_iterations" 100 Bounded.default_constraints.hard_max_iterations
 
@@ -232,7 +226,6 @@ let () =
       test_case "max_tokens" `Quick test_default_constraints_max_tokens;
       test_case "max_cost" `Quick test_default_constraints_max_cost;
       test_case "max_time" `Quick test_default_constraints_max_time;
-      test_case "buffer" `Quick test_default_constraints_buffer;
       test_case "hard_max" `Quick test_default_constraints_hard_max;
     ];
     "calc_backoff_delay", [


### PR DESCRIPTION
## Summary
- remove the deprecated Bounded.constraints.token_buffer field
- stop parsing token_buffer from constraints JSON
- remove the compatibility-only default_constraints buffer test and update public docs to the p95 predictor contract

## Verification
- ocamlformat --check lib/bounded.ml lib/bounded.mli test/test_bounded_coverage.ml
- git diff --check
- rg -n "token_buffer|test_default_constraints_buffer|\"buffer\"" lib/bounded.ml lib/bounded.mli test/test_bounded_coverage.ml (no matches)
- scripts/ci/check-ignore-without-comment-diff.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh

## Not run
- scripts/dune-local.sh build test/test_bounded_coverage.exe (blocked by existing bare dune build --root . processes: 11674, 38246)