### PR TITLE
refactor(cascade): drop legacy resumable marker

### DIFF
--- a/lib/cascade/cascade_transport_json_stream_cli_local.ml
+++ b/lib/cascade/cascade_transport_json_stream_cli_local.ml
@@ -322,7 +322,6 @@ let resumable_session_detail =
 
 let resume_hint_marker = "to resume this session:"
 let resumable_session_public_marker = "resumable session available via -r."
-let legacy_resumable_session_public_marker = "the session is resumable with -r flag."
 
 let is_resume_hint_line line =
   let trimmed = String.trim line in
@@ -424,10 +423,7 @@ let text_looks_like_resumable_session text =
   in
   trimmed <> ""
   && (has_raw_resume_hint
-      || String_util.contains_substring_ci trimmed resumable_session_public_marker
-      || String_util.contains_substring_ci
-           trimmed
-           legacy_resumable_session_public_marker)
+      || String_util.contains_substring_ci trimmed resumable_session_public_marker)
 ;;
 
 let resumable_session_detail_of_text text =


### PR DESCRIPTION
## Summary
- remove the old public resumable-session marker string from the JSON-stream CLI transport
- keep raw CLI resume hints and the current canonical public marker detection intact

## Verification
- ocamlformat --check lib/cascade/cascade_transport_json_stream_cli_local.ml
- git diff --check
- rg -n "legacy_resumable_session_public_marker|the session is resumable with -r flag" lib test docs (no matches)
- scripts/ci/check-ignore-without-comment-diff.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Not run
- scripts/dune-local.sh build test/test_oas_worker.exe test/test_oas_worker_sdk_error.exe test/test_keeper_error_classify_recoverable.exe: blocked by live bare Dune processes 11674 and 38246; dune-local refused to start another local build.