### PR TITLE
refactor(tools): drop runtime health body compat arg

### DIFF
--- a/lib/tool_local_runtime.mli
+++ b/lib/tool_local_runtime.mli
@@ -79,10 +79,8 @@ val run_bench :
   (Yojson.Safe.t, string) Result.t
 (** Re-export of {!Tool_local_runtime_bench.run_bench}. *)
 
-val provider_health_reachable :
-  status:int option -> body:string option -> bool
-(** Re-export of {!Tool_local_runtime_verify.provider_health_reachable}.
-    [body] is unused; required for caller-shape compat. *)
+val provider_health_reachable : status:int option -> bool
+(** Re-export of {!Tool_local_runtime_verify.provider_health_reachable}. *)
 
 val classify_runtime_blocker :
   provider_reachable:bool ->

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -190,7 +190,7 @@ let probe_chat_completion_compatible
       | Ok (Error http_error) ->
           (Some false, Some (error_message_of_http_error http_error))
 
-let provider_health_reachable ~status ~body:_ =
+let provider_health_reachable ~status =
   Option.equal Int.equal status (Some 200)
 
 let chat_contract_probe_body ~model_id =
@@ -426,7 +426,7 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
         let models_url =
           base_url ^ Masc_network_defaults.openai_models_path
         in
-        let provider_status, provider_body, provider_err =
+        let provider_status, _provider_body, provider_err =
           match http_get_text_with_status provider_url with
           | Ok (status_code, payload) -> (status_code, Some payload, None)
           | Error err -> (None, None, Some err)
@@ -447,7 +447,7 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
           | Error err -> (None, None, Some err)
         in
         let provider_ok_row =
-          provider_health_reachable ~status:provider_status ~body:provider_body
+          provider_health_reachable ~status:provider_status
         in
         let provider_ok' = provider_ok && provider_ok_row in
         let slot_ok_row = Option.equal Int.equal slot_status (Some 200) in

--- a/lib/tool_local_runtime_verify.mli
+++ b/lib/tool_local_runtime_verify.mli
@@ -22,14 +22,12 @@
     + the [include Tool_local_runtime_http] cascade.  All
     consumed only inside {!runtime_verify_json}'s pipeline. *)
 
-val provider_health_reachable :
-  status:int option -> body:string option -> bool
-(** [provider_health_reachable ~status ~body] is [true] iff
-    [status = Some 200].  [body] is currently ignored — the
-    health endpoint is a status-code-only check.  Drift to
-    body-content validation would change "what counts as
-    reachable" and need a coordinated update with the
-    health-check probe. *)
+val provider_health_reachable : status:int option -> bool
+(** [provider_health_reachable ~status] is [true] iff
+    [status = Some 200].  The health endpoint is a status-code-only
+    check. Drift to body-content validation would change "what counts
+    as reachable" and need a coordinated update with the health-check
+    probe. *)
 
 val classify_runtime_blocker :
   provider_reachable:bool ->

--- a/test/test_tool_local_runtime_verify.ml
+++ b/test/test_tool_local_runtime_verify.ml
@@ -1,15 +1,12 @@
 open Alcotest
 
-let test_provider_health_reachable_accepts_json_health () =
-  check bool "json health body counts as reachable" true
-    (Masc_mcp.Tool_local_runtime.provider_health_reachable ~status:(Some 200)
-       ~body:(Some {|{"status":"ok"}|}));
-  check bool "plain text health body counts as reachable" true
-    (Masc_mcp.Tool_local_runtime.provider_health_reachable ~status:(Some 200)
-       ~body:(Some "ok"));
+let test_provider_health_reachable_uses_status_only () =
+  check bool "200 counts as reachable" true
+    (Masc_mcp.Tool_local_runtime.provider_health_reachable ~status:(Some 200));
+  check bool "200 remains reachable without body input" true
+    (Masc_mcp.Tool_local_runtime.provider_health_reachable ~status:(Some 200));
   check bool "non-200 is unreachable" false
-    (Masc_mcp.Tool_local_runtime.provider_health_reachable ~status:(Some 503)
-       ~body:(Some {|{"status":"error"}|}))
+    (Masc_mcp.Tool_local_runtime.provider_health_reachable ~status:(Some 503))
 
 let test_split_ws_preserves_quoted_cmdline_values () =
   check
@@ -123,8 +120,8 @@ let () =
     [
       ( "provider_health_reachable",
         [
-          test_case "accepts json health payload" `Quick
-            test_provider_health_reachable_accepts_json_health;
+          test_case "uses health status only" `Quick
+            test_provider_health_reachable_uses_status_only;
           test_case "split_ws preserves quoted cmdline values" `Quick
             test_split_ws_preserves_quoted_cmdline_values;
         ] );


### PR DESCRIPTION
## Summary
- remove the unused `~body` compatibility argument from runtime health reachability checks
- update the local-runtime public re-export and tests to the status-only contract

## Verification
- ocamlformat --check lib/tool_local_runtime_verify.mli lib/tool_local_runtime_verify.ml lib/tool_local_runtime.mli test/test_tool_local_runtime_verify.ml
- git diff --check
- rg -n "provider_health_reachable.*body|body.*provider_health_reachable|required for caller-shape compat|accepts json health payload|health body counts" lib test docs (no matches)
- scripts/ci/check-ignore-without-comment-diff.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Not run
- scripts/dune-local.sh build test/test_tool_local_runtime_verify.exe: blocked by live bare Dune processes 11674 and 38246; dune-local refused to start another local build.