### PR TITLE
refactor(board): drop legacy author mismatch fields

### DIFF
--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -106,12 +106,6 @@ let record_identity_raw_surface field raw canonical fields =
   if String.equal raw "" || String.equal raw canonical then fields
   else json_upsert_meta_string_field (field ^ "_raw_agent_name") raw fields
 
-let record_author_legacy_mismatch claim fields =
-  fields
-  |> json_upsert_meta_string_field "caller_supplied_author" claim
-  |> json_upsert_meta_string_field "author_rewrite_reason"
-       "caller_author_mismatch"
-
 (** #10297: enforce that a board-tool caller cannot author / vote under
     a principal other than the runtime contract's [agent_name].  Pre-fix
     [ensure_board_post_author] only consulted [agent_name] when the
@@ -130,8 +124,7 @@ let record_author_legacy_mismatch claim fields =
        like [keeper-velvet-hammer-agent] vs [velvet-hammer]).
     3. Caller's canonical disagrees -> rewrite the field to ctx
        canonical, preserve the caller's claim in
-       [meta.<field>_caller_claim] for forensics, retain the older
-       author-specific mismatch fields for compatibility, and increment
+       [meta.<field>_caller_claim] for forensics, and increment
        [masc_board_actor_identity_spoof_total{tool, field}].
 
     Lenient mode (rewrite + preserve) is preferred over strict
@@ -203,11 +196,6 @@ let enforce_caller_identity ~tool ~field ~agent_name arguments =
             in
             let fields =
               record_identity_raw_surface field ctx_raw ctx_canonical fields
-            in
-            let fields =
-              if String.equal field "author" then
-                record_author_legacy_mismatch claim fields
-              else fields
             in
             `Assoc fields))
   | _ -> arguments

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -495,10 +495,7 @@ let test_inline_board_post_author_rewrites_caller_claim () =
     Yojson.Safe.Util.(normalized |> member "author" |> to_string);
   Alcotest.(check string) "caller claim preserved" "analyst"
     Yojson.Safe.Util.(
-      normalized |> member "meta" |> member "caller_supplied_author" |> to_string);
-  Alcotest.(check string) "rewrite reason preserved" "caller_author_mismatch"
-    Yojson.Safe.Util.(
-      normalized |> member "meta" |> member "author_rewrite_reason" |> to_string);
+      normalized |> member "meta" |> member "author_caller_claim" |> to_string);
   Alcotest.(check string) "raw ctx agent preserved" "keeper-velvet-hammer-agent"
     Yojson.Safe.Util.(
       normalized |> member "meta" |> member "author_raw_agent_name" |> to_string);
@@ -521,7 +518,7 @@ let test_inline_board_post_author_accepts_matching_alias () =
     Yojson.Safe.Util.(normalized |> member "author" |> to_string);
   Alcotest.(check bool) "no mismatch claim" true
     Yojson.Safe.Util.(
-      normalized |> member "meta" |> member "caller_supplied_author" = `Null)
+      normalized |> member "meta" |> member "author_caller_claim" = `Null)
 
 (** {2 Group 2: JSON helper functions} *)
 


### PR DESCRIPTION
## Summary
- stop writing author-specific compatibility fields `meta.caller_supplied_author` and `meta.author_rewrite_reason`
- keep the canonical forensic field `meta.author_caller_claim`, raw-agent surface, and spoof counter behavior
- update board coverage to assert the canonical mismatch field only

## Verification
- ocamlformat --check lib/tool_inline_dispatch_extra.ml test/test_tool_board_coverage.ml
- git diff --check
- rg -n "record_author_legacy_mismatch|caller_supplied_author|author_rewrite_reason|caller_author_mismatch|retain the older" lib test docs (no matches)
- scripts/ci/check-ignore-without-comment-diff.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Not run
- scripts/dune-local.sh build test/test_tool_board_coverage.exe test/test_board_author_identity_10297.exe: blocked by live bare Dune processes 11674, 48298, and 38246; dune-local refused to start another local build.