### PR TITLE
refactor(board): reject human post kind alias

### DIFF
--- a/lib/board_core_classify.ml
+++ b/lib/board_core_classify.ml
@@ -60,7 +60,6 @@ let post_kind_to_string = function
 
 let post_kind_of_string = function
   | "direct" -> Some Human_post
-  | "human" -> Some Human_post
   | "automation" -> Some Automation_post
   | "system" -> Some System_post
   | _ -> None

--- a/lib/board_core_classify.mli
+++ b/lib/board_core_classify.mli
@@ -73,9 +73,8 @@ val post_kind_to_string : post_kind -> string
     ["automation"] / ["system"]. *)
 
 val post_kind_of_string : string -> post_kind option
-(** [post_kind_of_string s] accepts ["direct"] {b and} ["human"]
-    (both -> [Human_post]) for backward compat; returns [None] for
-    unrecognised inputs. *)
+(** [post_kind_of_string s] accepts ["direct"] / ["automation"] /
+    ["system"]; returns [None] for unrecognised inputs. *)
 
 (** {1 Author classification (RFC-0089 §4-3 G2)} *)
 

--- a/lib/tool_board_schemas.ml
+++ b/lib/tool_board_schemas.ml
@@ -97,7 +97,7 @@ let tool_post_create : Masc_domain.tool_schema =
                     [ "type", `String "string"
                     ; ( "description"
                       , `String
-                          "Optional post classification: 'direct' (alias 'human') = \
+                          "Optional post classification: 'direct' = \
                            caller is a human user; 'automation' = caller is an agent or \
                            automated source. 'system' is reserved for internal surfaces \
                            (keeper, operator) and will be rejected if sent by an \

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1971,7 +1971,7 @@ let () =
             Alcotest.(check string) "classified as direct" "direct"
               Yojson.Safe.Util.(
                 parse_create_response_json msg |> member "post_kind" |> to_string));
-          Alcotest.test_case "legacy human override normalizes to direct" `Quick (fun () ->
+          Alcotest.test_case "human post_kind alias is rejected" `Quick (fun () ->
             Eio_main.run @@ fun env ->
             Fs_compat.set_fs (Eio.Stdenv.fs env);
             cleanup ();
@@ -1981,10 +1981,9 @@ let () =
               ("author", `String "agent_llm_a-agent");
               ("post_kind", `String "human")
             ]) in
-            Alcotest.(check bool) "post created" true ok;
-            Alcotest.(check string) "legacy override normalized to direct" "direct"
-              Yojson.Safe.Util.(
-                parse_create_response_json msg |> member "post_kind" |> to_string));
+            Alcotest.(check bool) "post rejected" false ok;
+            Alcotest.(check bool) "unknown post_kind surfaced" true
+              (contains_substring msg "unknown post_kind: human"));
         ] );
       ( "board_list_cache",
         [


### PR DESCRIPTION
## Summary
- remove the legacy `post_kind = human` alias from board post-kind parsing
- document `direct` as the only human/direct wire value in the tool schema and interface
- replace the alias-preservation test with rejection coverage

## Verification
- ocamlformat --check lib/board_core_classify.ml lib/board_core_classify.mli lib/tool_board_schemas.ml test/test_tool_board_coverage.ml
- git diff --check
- rg -n "alias 'human'|legacy human override|post_kind_of_string.*human|accepts \"direct\".*human|\| \"human\" -> Some Human_post" lib test docs (no matches)
- scripts/ci/check-ignore-without-comment-diff.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Not run
- scripts/dune-local.sh build test/test_tool_board_coverage.exe: blocked by live bare Dune processes 11674 and 38246; dune-local refused to start another local build.