### PR TITLE
refactor(tools): drop probe decision compat projection

### DIFF
--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -447,16 +447,6 @@ let decide_generate_probe ~effective_model ~before_status ~before_error
           else
             Skip_generate_probe Policy_skip)
 
-let should_attempt_generate_probe ~before_status ~before_error ~run_generate
-    ~generate_when_unloaded ~effective_model_loaded_before =
-  match
-    decide_generate_probe ~effective_model:(Some "__probe_decision_compat__")
-      ~before_status ~before_error ~run_generate ~generate_when_unloaded
-      ~effective_model_loaded_before
-  with
-  | Run_generate_probe -> true
-  | Skip_generate_probe _ -> false
-
 let request_body_json ~think_enabled ~keep_alive ~model_id ~prompt ~max_tokens =
   let fields =
     [

--- a/lib/tool_local_runtime_probe.mli
+++ b/lib/tool_local_runtime_probe.mli
@@ -171,18 +171,6 @@ val decide_generate_probe :
 
     Order matters — pinned at contract seam. *)
 
-val should_attempt_generate_probe :
-  before_status:int option ->
-  before_error:string option ->
-  run_generate:bool ->
-  generate_when_unloaded:bool ->
-  effective_model_loaded_before:bool ->
-  bool
-(** Boolean projection of {!decide_generate_probe} with a
-    sentinel [effective_model] of
-    ["__probe_decision_compat__"] — used by callers that only
-    need the run/skip bit and have already validated the model. *)
-
 (** {1 JSON parsers} *)
 
 val ollama_loaded_models_of_ps_json :

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -199,48 +199,6 @@ let test_kv_cache_assessment_requires_two_successful_runs () =
   check string "insufficient data" "insufficient_data"
     (assessment |> member "signal" |> to_string)
 
-let test_generate_probe_is_skipped_after_failed_preflight () =
-  check bool "ps preflight error skips generate" false
-    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
-       ~before_status:None ~before_error:(Some "curl exit code 28")
-       ~run_generate:true
-       ~generate_when_unloaded:true ~effective_model_loaded_before:true);
-  check bool "ps preflight error dominates successful status" false
-    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
-       ~before_status:(Some 200) ~before_error:(Some "invalid ps payload")
-       ~run_generate:true
-       ~generate_when_unloaded:true ~effective_model_loaded_before:true);
-  check bool "successful ps allows generate" true
-    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
-       ~before_status:(Some 200) ~before_error:None
-       ~run_generate:true
-       ~generate_when_unloaded:true ~effective_model_loaded_before:false);
-  check bool "successful ps skips cold model when disabled" false
-    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
-       ~before_status:(Some 200) ~before_error:None
-       ~run_generate:true
-       ~generate_when_unloaded:false ~effective_model_loaded_before:false);
-  check bool "resident model can still be probed when cold load disabled" true
-    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
-       ~before_status:(Some 200) ~before_error:None
-       ~run_generate:true
-       ~generate_when_unloaded:false ~effective_model_loaded_before:true);
-  check bool "status-only probe skips generate even when resident" false
-    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
-       ~before_status:(Some 200) ~before_error:None
-       ~run_generate:false
-       ~generate_when_unloaded:true ~effective_model_loaded_before:true);
-  check bool "default path with no status allows generate when enabled" true
-    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
-       ~before_status:None ~before_error:None
-       ~run_generate:true
-       ~generate_when_unloaded:true ~effective_model_loaded_before:false);
-  check bool "default path blocks when disabled and not resident" false
-    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
-       ~before_status:None ~before_error:None
-       ~run_generate:true
-       ~generate_when_unloaded:false ~effective_model_loaded_before:false)
-
 let test_generate_probe_decision_reports_typed_reasons () =
   let decision ?(effective_model = Some "qwen3") ?before_status
       ?before_error ?(run_generate = true) ?(generate_when_unloaded = true)
@@ -260,6 +218,8 @@ let test_generate_probe_decision_reports_typed_reasons () =
     (decision ~before_status:200 ~generate_when_unloaded:false ());
   check string "unknown preflight skip reason" "policy_skip"
     (decision ~generate_when_unloaded:false ());
+  check string "default path with no status runs when enabled" "run_generate"
+    (decision ());
   check string "resident model runs even with cold-load disabled" "run_generate"
     (decision ~before_status:200 ~generate_when_unloaded:false
        ~effective_model_loaded_before:true ())
@@ -303,8 +263,6 @@ let () =
             test_kv_cache_assessment_detects_repeat_improvement;
           test_case "needs at least two successful runs" `Quick
             test_kv_cache_assessment_requires_two_successful_runs;
-          test_case "skips generate after failed ps preflight" `Quick
-            test_generate_probe_is_skipped_after_failed_preflight;
           test_case "generate probe decision reports typed reasons" `Quick
             test_generate_probe_decision_reports_typed_reasons;
         ] );


### PR DESCRIPTION
## Summary
- remove the unused `Tool_local_runtime_probe.should_attempt_generate_probe` boolean compatibility projection
- remove the `__probe_decision_compat__` sentinel path
- keep structured `decide_generate_probe` coverage as the only decision contract

## Verification
- ocamlformat --check lib/tool_local_runtime_probe.ml lib/tool_local_runtime_probe.mli test/test_tool_local_runtime_probe.ml
- git diff --check
- rg -n "should_attempt_generate_probe|__probe_decision_compat__|Boolean projection of .*decide_generate_probe|skips generate after failed ps preflight" lib test docs (no matches)
- scripts/ci/check-ignore-without-comment-diff.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Not run
- scripts/dune-local.sh build test/test_tool_local_runtime_probe.exe: blocked by live bare Dune processes 11674 and 38246; dune-local refused to start another local build.