### PR TITLE
fix(supervisor): resolve dual-resolve race causing false Fiber_unresolved

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -116,11 +116,21 @@ let launch_supervised_fiber
     fork_body (fun () ->
       let resolved = ref false in
       let resolve_done value =
-        if (not !resolved) && Keeper_registry.try_resolve_done reg value
-        then (
-          resolved := true;
-          true)
-        else false
+        if not !resolved then
+          (* Issue #18335: the keepalive layer (keeper_keepalive.ml:760-791)
+             may have already resolved done_p via record_keeper_stopped.
+             When the Promise is already resolved, treat it as success —
+             the keeper completed normally via the keepalive exit path. *)
+          if Keeper_registry.try_resolve_done reg value then (
+            resolved := true;
+            true)
+          else if Option.is_some (Eio.Promise.peek reg.done_p) then (
+            resolved := true;
+            true)
+          else
+            false
+        else
+          false
       in
       Eio_guard.protect
         (fun () ->


### PR DESCRIPTION
## Summary
- Fix false Fiber_unresolved errors (~153/day) caused by a dual-resolve race between the keepalive layer and supervisor layer on the done_p Promise
- When keepalive resolves the Promise first (normal exit path), supervisor now recognizes the already-resolved state as success instead of treating it as a crash
- Single-file change to resolve_done in keeper_supervisor.ml

## Root Cause
The done_p Promise is resolved from two independent code paths:
1. Keepalive layer (keeper_keepalive.ml:760): record_keeper_stopped -> try_resolve_done Stopped
2. Supervisor layer (keeper_supervisor.ml:273): resolve_done Stopped

When keepalive resolves first, supervisor try_resolve_done returns false, leaving resolved := false. The finally block then stamps Fiber_unresolved -- a false positive since the keeper completed normally.

## Fix
resolve_done now checks Eio.Promise.peek reg.done_p when try_resolve_done fails. If the Promise was already resolved (by keepalive), it sets resolved := true instead of returning false.

## Test plan
- [ ] CI green (all existing ratchet/lint checks pass)
- [ ] Deploy and observe Fiber_unresolved count drop to near-zero (should only occur during actual shutdown)

Closes #18335

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Generated with Claude Code