### PR TITLE
refactor(keeper): drop legacy checkpoint shadow cleanup

### DIFF
--- a/docs/design/checkpoint-truth-replay-implementation-checklist.md
+++ b/docs/design/checkpoint-truth-replay-implementation-checklist.md
@@ -31,7 +31,7 @@ code_refs:
 
 - [ ] `lib/keeper/keeper_checkpoint_store.ml`
   - `save_oas` / `load_oas`를 runtime truth path로 유지
-  - legacy `ckpt-*.json` load path 제거; 남은 surface는 cleanup/count only
+  - legacy `ckpt-*.json` load/count/delete/prune surface 제거
 - [ ] `lib/keeper/keeper_agent_run.ml`
   - checkpoint load/write comments와 variable naming이 truth hierarchy와 일치하는지 정리
 - [ ] `lib/keeper/keeper_post_turn.ml`

--- a/docs/design/keeper-continuity-diagnosis-rfc.md
+++ b/docs/design/keeper-continuity-diagnosis-rfc.md
@@ -51,7 +51,7 @@ masc-mcp filesystem 진단에서 keeper memory 시스템의 여러 gap을 발견
 | H3: LLM이 context를 무시 | model quality | 동일 `run_turn` 경로에서 모델/max_context/temperature/max_tokens 4개 값을 명시적으로 고정한 비교. `cascade_name` 변경은 4개 값을 모두 재resolve하므로, cascade swap 시 각 값을 동일하게 오버라이드. **`masc_keeper_msg` 사용자 도구로는 수행 불가 — 내부 harness/테스트 경로로 수행.** | 모델 교체 또는 prompt 강화 |
 | H4: prompt assembly 문제 | `keeper_agent_run.ml:147-200` | debug log: `initial_messages` 길이 + 첫/마지막 메시지 + `turn_system_prompt` 길이/hash | prompt assembly 수정 |
 
-**OAS `<trace_id>.json` is the only checkpoint recovery source.** Legacy `ckpt-*.json` files may still be counted or deleted by cleanup surfaces, but `load_context_from_checkpoint` no longer reads them.
+**OAS `<trace_id>.json` is the only checkpoint recovery source.** Legacy `ckpt-*.json` files are not counted, deleted, pruned, or read by keeper recovery surfaces.
 
 ## Gap Classification
 

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -1,6 +1,6 @@
 (** Keeper_checkpoint_store — checkpoint file I/O.
 
-    Handles saving, loading, listing, and pruning checkpoint JSON files
+    Handles saving, loading, listing, and pruning OAS checkpoint JSON files
     within a session directory. Separated from [Keeper_working_context]
     so that file I/O concerns do not mix with context types and
     pure operations.
@@ -8,32 +8,6 @@
     @since keeper-ctx-split *)
 
 open Printf
-
-(* ================================================================ *)
-(* Checkpoint File Conventions                                        *)
-(* ================================================================ *)
-
-let checkpoint_prefix = "ckpt-"
-let checkpoint_suffix = ".json"
-
-let is_checkpoint_file (filename : string) : bool =
-  let len = String.length filename in
-  len > String.length checkpoint_prefix + String.length checkpoint_suffix
-  && String.sub filename 0 (String.length checkpoint_prefix) = checkpoint_prefix
-  && String.sub filename (len - String.length checkpoint_suffix)
-       (String.length checkpoint_suffix) = checkpoint_suffix
-
-(* ================================================================ *)
-(* List                                                               *)
-(* ================================================================ *)
-
-let list_checkpoints ~(session_dir : string) : string list =
-  if not (Fs_compat.file_exists session_dir) then []
-  else
-    Sys.readdir session_dir
-    |> Array.to_list
-    |> List.filter is_checkpoint_file
-    |> List.sort (fun a b -> compare b a)
 
 (* ================================================================ *)
 (* OAS Checkpoints                                                    *)

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -1,12 +1,5 @@
 (** Keeper checkpoint store — OAS checkpoint persistence, OAS
-    history archive, SDK error classification, and cleanup helpers
-    for pre-OAS checkpoint shadows. *)
-
-(** Sorted-descending list of legacy checkpoint filenames in
-    [session_dir] (latest first). This is retained for delete/count
-    surfaces only; legacy checkpoint files are no longer a recovery
-    source. *)
-val list_checkpoints : session_dir:string -> string list
+    history archive, and SDK error classification. *)
 
 (** Path of the canonical OAS checkpoint file
     [session_dir/<session_id>.json]. *)

--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
@@ -108,8 +108,6 @@ let inventory_json (config : Coord.config) (name : string)
             | Some (json, _snapshot_id) -> json
             | None -> `Null )
         ; "history", `List history_json
-        ; ( "legacy_shadow_count"
-          , `Int (List.length (Keeper_checkpoint_store.list_checkpoints ~session_dir)) )
         ] )
 ;;
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -693,7 +693,6 @@ let lazy_startup_plan ~has_legacy_traces =
         task_names =
           [
             "jsonl_prune";
-            "keeper_checkpoint_prune";
             "auth_archive_prune";
           ];
       };
@@ -803,44 +802,6 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn -> Log.Misc.warn "startup prune failed: %s (next boot retries; disk impact bounded by retention)" (Printexc.to_string exn))
-
-let startup_prune_keeper_checkpoints (state : Mcp_server.server_state) =
-  (try
-     let traces_dir =
-       Filename.concat (Coord.masc_root_dir state.room_config) "traces"
-     in
-     if Sys.file_exists traces_dir then begin
-       let total = ref 0 in
-       Array.iter (fun trace_name ->
-         let trace_dir = Filename.concat traces_dir trace_name in
-         if Sys.is_directory trace_dir then begin
-           let files = Sys.readdir trace_dir |> Array.to_list in
-           let ckpt_files =
-             files
-             |> List.filter (fun f ->
-               let len = String.length f in
-               len > 5 && String.starts_with ~prefix:"ckpt-" f
-               && String.ends_with ~suffix:".json" f)
-             |> List.sort (fun a b -> compare b a)
-           in
-           if List.length ckpt_files > 3 then
-             List.iteri (fun i f ->
-               if i >= 3 then begin
-                 (try Sys.remove (Filename.concat trace_dir f)
-                  with Sys_error _ -> ());
-                 incr total
-               end
-             ) ckpt_files
-         end
-       ) (Sys.readdir traces_dir);
-       if !total > 0 then
-         Log.Misc.info "startup prune: deleted %d old keeper checkpoint files" !total
-     end
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-     Log.Misc.warn "startup checkpoint prune failed: %s (next boot retries)"
-       (Printexc.to_string exn))
 
 let startup_prune_auth_archive (state : Mcp_server.server_state) =
   (try
@@ -1206,8 +1167,6 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         | "legacy_trace_dir_migration" -> fun () ->
             migrate_legacy_trace_dirs state
         | "jsonl_prune" -> fun () -> startup_prune_jsonl state
-        | "keeper_checkpoint_prune" -> fun () ->
-            startup_prune_keeper_checkpoints state
         | "auth_archive_prune" -> fun () -> startup_prune_auth_archive state
         | task_name ->
             raise

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -72,7 +72,6 @@ val bootstrap_prompt_state : Mcp_server.server_state -> unit
 val warm_tool_registry_from_telemetry : Mcp_server.server_state -> unit
 val migrate_legacy_dirs : Mcp_server.server_state -> unit
 val startup_prune_jsonl : Mcp_server.server_state -> unit
-val startup_prune_keeper_checkpoints : Mcp_server.server_state -> unit
 val startup_migrate_keeper_histories : Mcp_server.server_state -> unit
 val sync_bootable_keeper_credentials : Mcp_server.server_state -> unit
 

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1209,23 +1209,6 @@ let handle_keeper_clear ctx args : tool_result =
            | None -> ());
           msg_count - List.length cleared_messages
       in
-      let legacy_shadow_removed_count =
-        let files = Keeper_checkpoint_store.list_checkpoints ~session_dir:session.session_dir in
-        List.fold_left
-          (fun count filename ->
-            let path = Filename.concat session.session_dir filename in
-            try
-              Sys.remove path;
-              count + 1
-            with
-            | Eio.Cancel.Cancelled _ as e -> raise e
-            | exn ->
-                Log.Keeper.warn
-                  "%s: failed to remove legacy checkpoint shadow %s: %s"
-                  name path (Stdlib.Printexc.to_string exn);
-                count)
-          0 files
-      in
       let continuity_cleared =
         match meta_for_trace with
         | Some meta ->
@@ -1277,7 +1260,6 @@ let handle_keeper_clear ctx args : tool_result =
            ("cleared_message_count", `Int cleared_count);
            ("checkpoint_found", `Bool checkpoint_found);
            ("continuity_cleared", `Bool continuity_cleared);
-           ("legacy_shadow_removed_count", `Int legacy_shadow_removed_count);
            ("preserve_system_prompt", `Bool preserve_system);
            ("reason", `String reason);
          ]))

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1649,7 +1649,7 @@ let test_blocking_bootstrap_promotes_legacy_keeper_meta_before_autoboot () =
       Fs_compat.mkdir_p legacy_trace_dir;
       write_file (Filename.concat legacy_dir "sangsu.json")
         (make_keeper_meta_json ());
-      write_file (Filename.concat legacy_trace_dir "ckpt-1.json") {|{"ok":true}|};
+      write_file (Filename.concat legacy_trace_dir "trace.jsonl") {|{"ok":true}|};
       Server_runtime_bootstrap.bootstrap_server_state_blocking state;
       Alcotest.(check bool) "legacy keeper meta promoted during blocking bootstrap"
         true
@@ -1815,7 +1815,7 @@ let test_lazy_startup_plan_groups_independent_tasks () =
         ~tasks:[ "telemetry_warmup"; "tool_metrics_restore" ];
       check_lazy_group cleanup ~name:"cleanup" ~execution:"serial"
         ~tasks:
-          [ "jsonl_prune"; "keeper_checkpoint_prune"; "auth_archive_prune" ];
+          [ "jsonl_prune"; "auth_archive_prune" ];
       Alcotest.(check (list string))
         "flattened task order"
         [
@@ -1826,7 +1826,6 @@ let test_lazy_startup_plan_groups_independent_tasks () =
           "telemetry_warmup";
           "tool_metrics_restore";
           "jsonl_prune";
-          "keeper_checkpoint_prune";
           "auth_archive_prune";
         ]
         (Server_runtime_bootstrap.lazy_startup_task_names
@@ -1856,7 +1855,6 @@ let test_lazy_startup_plan_keeps_legacy_migration_serial () =
           "tool_metrics_restore";
           "legacy_trace_dir_migration";
           "jsonl_prune";
-          "keeper_checkpoint_prune";
           "auth_archive_prune";
         ]
         (Server_runtime_bootstrap.lazy_startup_task_names


### PR DESCRIPTION
Summary
- remove the legacy ckpt-* checkpoint shadow lister from Keeper_checkpoint_store
- stop operator clear/dashboard inventory/startup lazy cleanup from counting, deleting, or pruning legacy checkpoint shadows
- update bootstrap plan tests and checkpoint truth docs to state OAS-only recovery with no legacy cleanup surface

Verification
- ocamlformat --check lib/keeper/keeper_checkpoint_store.ml lib/keeper/keeper_checkpoint_store.mli lib/tool_keeper.ml lib/server/server_dashboard_http_keeper_api_checkpoints.ml lib/server/server_runtime_bootstrap.ml lib/server/server_runtime_bootstrap.mli test/test_server_runtime_bootstrap.ml
- git diff --check
- rg legacy_shadow_count|legacy_shadow_removed_count|list_checkpoints|keeper_checkpoint_prune|startup_prune_keeper_checkpoints|cleanup/count only|counted or deleted by cleanup surfaces (no matches)
- scripts/ci/check-ignore-without-comment-diff.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

Dune gap
- scripts/dune-local.sh build test/test_oas_worker.exe test/test_server_runtime_bootstrap.exe test/test_dashboard_keeper_routes.exe exited 75 because existing bare dune build --root . processes were active: 11674 and 38246.