### PR TITLE
refactor(keeper): drop unused transient failure metric arg

### DIFF
--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -167,7 +167,6 @@ val update_metrics_from_failure :
   latency_ms:int ->
   observation:Keeper_world_observation.world_observation ->
   reason:string ->
-  ?is_transient:bool ->
   ?social_state:Keeper_social_model.social_state ->
   ?social_transition_reason:string ->
   ?sdk_error:Agent_sdk.Error.sdk_error ->

--- a/lib/keeper/keeper_unified_metrics_failure.ml
+++ b/lib/keeper/keeper_unified_metrics_failure.ml
@@ -38,12 +38,9 @@ let provider_timeout_failure_summary
 
 let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
     ~(observation : Keeper_world_observation.world_observation)
-    ~(reason : string) ?(is_transient = false) ?social_state
-    ?social_transition_reason
+    ~(reason : string) ?social_state ?social_transition_reason
     ?sdk_error
     () : keeper_meta =
-  ignore is_transient; (* Param retained for caller compatibility; no longer
-                          used internally after zombie-fix #5594. *)
   let now_ts = Time_compat.now () in
   record_keeper_idle_seconds
     ~keeper_name:meta.name

--- a/lib/keeper/keeper_unified_metrics_failure.mli
+++ b/lib/keeper/keeper_unified_metrics_failure.mli
@@ -5,7 +5,6 @@ val update_metrics_from_failure :
   latency_ms:int ->
   observation:Keeper_world_observation.world_observation ->
   reason:string ->
-  ?is_transient:bool ->
   ?social_state:Keeper_social_model.social_state ->
   ?social_transition_reason:string ->
   ?sdk_error:Agent_sdk.Error.sdk_error ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1585,7 +1585,6 @@ let run_keeper_cycle
                       ~latency_ms
                       ~observation
                       ~reason:e_str
-                      ~is_transient
                       ~social_state
                       ~social_transition_reason:
                         (Social.transition_reason_to_string social_transition_reason)


### PR DESCRIPTION
Summary
- remove the unused ?is_transient compatibility argument from Keeper_unified_metrics.update_metrics_from_failure
- remove the only caller-side ~is_transient projection into failure metric updates
- delete the caller-compatibility ignore comment so transient classification remains local to the turn-control path that actually uses it

Verification
- ocamlformat --check lib/keeper/keeper_unified_metrics_failure.ml lib/keeper/keeper_unified_metrics_failure.mli lib/keeper/keeper_unified_metrics.mli lib/keeper/keeper_unified_turn.ml
- git diff --check
- rg ?is_transient|~is_transient|caller compatibility; no longer over the touched keeper files (no matches)
- scripts/ci/check-ignore-without-comment-diff.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

Dune gap
- scripts/dune-local.sh build test/test_keeper_unified.exe exited 75 because existing bare dune build --root . processes were active: 11674, 66289, and 38246.