### PR TITLE
fix(memory): handle null role in JSONL history parsing

### DIFF
--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -703,13 +703,14 @@ let history_user_messages_from_lines
   |> List.filter_map (fun line ->
        try
          let json = Yojson.Safe.from_string line in
-         let role = Yojson.Safe.Util.(json |> member "role" |> to_string) in
+         let role = Yojson.Safe.Util.(json |> member "role" |> to_string_option) in
          let source =
            Yojson.Safe.Util.(json |> member "source" |> to_string_option)
            |> Option.value ~default:""
            |> String.trim
          in
-         if role = "user" then
+         (* Issue #18400: role may be null in corrupted JSONL lines. Use to_string_option so null/missing roles are skipped instead of throwing Type_error. *)
+         if role = Some "user" then
            let content =
              String.trim
                (Keeper_context_core.text_of_history_jsonl_json json)


### PR DESCRIPTION
## Summary
- `keeper_memory_recall.ml:706` used `Yojson.Safe.Util.to_string` for the `role` field, which throws `Type_error("Expected string, got null")` when the value is null
- Changed to `to_string_option` (matching existing pattern for `source` field at line 708) so null roles are skipped instead of throwing
- Eliminates ~120 Type_error warnings/day in keeper memory recall

## Test plan
- [x] `dune build --root . @check` passes
- [ ] CI Build and Test passes
- [ ] Verify `metric_keeper_memory_bank_load_history_swallowed_exceptions{exception_class="type_error"}` drops after deploy

Closes #18400

🤖 Generated with [Claude Code](https://claude.com/claude-code)