### PR TITLE
refactor(dashboard): drop compat helper re-exports

### DIFF
--- a/dashboard/src/components/governance-store.ts
+++ b/dashboard/src/components/governance-store.ts
@@ -1,5 +1,4 @@
-// Barrel re-export for backward compatibility.
-// Governance store is split into governance-signals and governance-actions.
+// Governance store grouped exports from governance-signals and governance-actions.
 export {
   governanceLoading,
   governanceStarting,

--- a/dashboard/src/components/keeper-detail-ctx-utils.test.ts
+++ b/dashboard/src/components/keeper-detail-ctx-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { autonomyHint, formatDuration } from './keeper-detail-ctx-utils'
+import { formatDurationCompound as formatDuration } from '../lib/format-time'
+import { autonomyHint } from './keeper-detail-ctx-utils'
 
 describe('autonomyHint', () => {
   it('returns active hint when count is 0 and proactive enabled', () => {

--- a/dashboard/src/components/keeper-detail-ctx-utils.ts
+++ b/dashboard/src/components/keeper-detail-ctx-utils.ts
@@ -1,8 +1,5 @@
 import type { PromptSegmentTelemetry } from '../types'
 
-// Re-export formatDurationCompound from SSOT for backward-compatible consumers.
-export { formatDurationCompound as formatDuration } from '../lib/format-time'
-
 // ── Context pressure thresholds (shared across KPIs, charts) ─
 export const CTX_CRITICAL_PCT = 85
 export const CTX_WARN_PCT = 70

--- a/dashboard/src/components/keeper-detail-kpi.ts
+++ b/dashboard/src/components/keeper-detail-kpi.ts
@@ -1,10 +1,10 @@
 import { html } from 'htm/preact'
 import { formatPct1, formatTokens } from '../lib/format-number'
+import { formatDurationCompound as formatDuration } from '../lib/format-time'
 import { Eyebrow } from './common/eyebrow'
 import { StatTile } from './common/stat-tile'
 import type { Keeper, KeeperMetricPoint } from '../types'
 import {
-  formatDuration,
   CTX_CRITICAL_PCT,
   CTX_WARN_PCT,
 } from './keeper-detail-ctx-utils'

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -1,6 +1,4 @@
-// Keeper detail sub-components — barrel re-exports.
-// Components were decomposed into keeper-detail-* flat modules.
-// This file remains for backward compatibility.
+// Keeper detail sub-components — grouped exports for decomposed flat modules.
 
 export {
   autonomyHint,
@@ -8,7 +6,6 @@ export {
   ctxSegmentLabel,
   ctxSegmentColor,
   filterCtxCompositionEntries,
-  formatDuration,
   CTX_CRITICAL_PCT,
   CTX_WARN_PCT,
   CTX_COLOR_CRITICAL,

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -1,5 +1,4 @@
-// Barrel re-export for backward compatibility.
-// All implementation has been decomposed into keeper-detail-*.ts modules.
+// Keeper detail grouped exports from decomposed keeper-detail-*.ts modules.
 
 export { KeeperDetailPage } from './keeper-detail-page'
 export {

--- a/dashboard/src/components/repo-detail-panel.test.ts
+++ b/dashboard/src/components/repo-detail-panel.test.ts
@@ -4,8 +4,8 @@ import {
   normalizeBranch,
   unwrapRepository,
   branchRows,
-  formatDate,
 } from './repo-detail-panel'
+import { formatDateTimeKo as formatDate } from '../lib/format-time'
 import { normalizeRepoStatus } from './repo-sidebar'
 import type { BranchInfo } from './repo-detail-panel'
 

--- a/dashboard/src/components/repo-detail-panel.ts
+++ b/dashboard/src/components/repo-detail-panel.ts
@@ -10,8 +10,6 @@ import { selectedRepoId, syncRepository, deleteRepository, normalizeRepoStatus, 
 import { requestConfirm } from './common/confirm-dialog'
 import { StatusBadge as CommonStatusBadge } from './common/status-badge'
 import { formatDateTimeKo as formatDate } from '../lib/format-time'
-// Re-export for backward-compatible test imports
-export { formatDateTimeKo as formatDate } from '../lib/format-time'
 import { Trash2, GitBranch, Clock, Calendar, Folder, Link, Shield, RefreshCw } from 'lucide-preact'
 
 // ── Branch type ──────────────────────────────────────────

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -4,13 +4,12 @@ import { act } from 'preact/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ToolQualityResponse } from '../api/dashboard'
 import {
-  classifyCoverageError,
   filterTools,
   pickAxisLabelIndices,
   rateColorVar,
   toolMatchesSearch,
 } from './tool-quality-panel'
-import { errorHintFromClass, errorHintFromGap } from './common/coverage-gap-block'
+import { classifyCoverageError, errorHintFromClass, errorHintFromGap } from './common/coverage-gap-block'
 import type { CoverageGapDisplay } from './common/source-health'
 
 vi.setConfig({

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -21,12 +21,7 @@ import {
   freshnessText,
   coverageGapDisplay,
 } from './common/source-health'
-import { CoverageGapBlock, classifyCoverageError } from './common/coverage-gap-block'
-
-// Re-export for backward compatibility with existing tests that imported
-// classifyCoverageError from this module. The SSOT now lives in
-// `./common/coverage-gap-block`; this alias keeps test fixtures working.
-export { classifyCoverageError }
+import { CoverageGapBlock } from './common/coverage-gap-block'
 
 const TOOL_QUALITY_WINDOW_HOURS = 24
 

--- a/dashboard/src/keeper-runtime.ts
+++ b/dashboard/src/keeper-runtime.ts
@@ -1,5 +1,4 @@
-// Barrel re-export for backward compatibility.
-// Keeper runtime is split into keeper-state, keeper-stream, keeper-actions.
+// Keeper runtime grouped exports from keeper-state, keeper-stream, and keeper-actions.
 export {
   activeKeeperName,
   keeperStatusDetails,

--- a/dashboard/src/mission-store.ts
+++ b/dashboard/src/mission-store.ts
@@ -1,5 +1,4 @@
-// Barrel re-export for backward compatibility.
-// Mission store is split into mission-signals, mission-normalizers, mission-actions.
+// Mission store grouped exports from mission-signals, mission-normalizers, and mission-actions.
 export {
   missionSnapshot,
   missionAgentBriefs,

--- a/dashboard/src/operator-store.ts
+++ b/dashboard/src/operator-store.ts
@@ -1,5 +1,4 @@
-// Barrel re-export for backward compatibility.
-// Operator store is split into operator-signals, operator-normalizers, operator-actions.
+// Operator store grouped exports from operator-signals, operator-normalizers, and operator-actions.
 export {
   operatorSnapshot,
   operatorRoomDigest,


### PR DESCRIPTION
## Summary
- Remove dashboard helper re-export aliases that only existed for compatibility with older test/component import paths.
- Move tests and callers to the SSOT modules: common/coverage-gap-block and lib/format-time.
- Rewrite dashboard barrel comments so they describe current grouped exports instead of teaching backward-compatibility as the contract.

## Validation
- PASS pnpm --dir dashboard install --offline --frozen-lockfile (setup only; reused local store, downloaded 0)
- PASS pnpm --dir dashboard typecheck
- PASS pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/tool-quality-panel.test.ts src/components/repo-detail-panel.test.ts src/components/keeper-detail-ctx-utils.test.ts --no-file-parallelism --maxWorkers=1 (3 files, 87 tests)
- PASS git diff --check
- PASS removed-compat grep for selected dashboard files
- PASS pnpm --dir dashboard exec eslint <touched files> (0 errors; config reports ignored-file warnings for some tests/barrel files)