### PR TITLE
refactor(tools): reject transition compat aliases

### DIFF
--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -37,35 +37,6 @@ let strip_internal_marker_args (args : Yojson.Safe.t) : Yojson.Safe.t =
   | _ -> args
 ;;
 
-let normalize_transition_args (args : Yojson.Safe.t) : Yojson.Safe.t =
-  match args with
-  | `Assoc fields ->
-    let has key = List.exists (fun (field, _) -> String.equal field key) fields in
-    let fields =
-      if has "note" && not (has "notes")
-      then
-        List.map
-          (fun (key, value) ->
-             if String.equal key "note" then "notes", value else key, value)
-          fields
-      else
-        List.filter (fun (key, _) -> not (String.equal key "note" && has "notes")) fields
-    in
-    let has key = List.exists (fun (field, _) -> String.equal field key) fields in
-    let fields =
-      if has "to" && not (has "action")
-      then
-        List.map
-          (fun (key, value) ->
-             if String.equal key "to" then "action", value else key, value)
-          fields
-      else
-        List.filter (fun (key, _) -> not (String.equal key "to" && has "action")) fields
-    in
-    `Assoc fields
-  | _ -> args
-;;
-
 let required_names schema =
   match Yojson.Safe.Util.member "required" schema with
   | `List items ->
@@ -116,9 +87,6 @@ let normalize_blank_optional_enum_args ?schema args =
 
 let prepare_args ?schema ~name args =
   let args = strip_internal_marker_args args in
-  let args =
-    if String.equal name "masc_transition" then normalize_transition_args args else args
-  in
   normalize_blank_optional_enum_args ?schema args
 ;;
 
@@ -252,6 +220,15 @@ let schema_shape_error schema args =
   | [] -> one_of_required_shape_error schema args
 ;;
 
+let retired_transition_alias_names ~name = function
+  | `Assoc fields when String.equal name "masc_transition" ->
+    fields
+    |> List.filter_map (fun (field, _) ->
+      if String.equal field "to" || String.equal field "note" then Some field else None)
+    |> List.sort_uniq String.compare
+  | _ -> []
+;;
+
 let empty_tool_args = function
   | `Null | `Assoc [] -> true
   | _ -> false
@@ -370,6 +347,19 @@ let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
                "Tool '%s' declares no input fields but received arguments"
                name)
     | Some schema ->
+      (match retired_transition_alias_names ~name prepared_args with
+       | alias :: aliases ->
+         let aliases = String.concat ", " (alias :: aliases) in
+         reject_validation
+           ~name
+           ~reason:"invalid_args"
+           ~message:
+             (Printf.sprintf
+                "Tool '%s' received retired transition alias field(s): %s; use \
+                 action and notes"
+                name
+                aliases)
+       | [] ->
       (match schema_shape_error schema prepared_args with
        | Some message ->
          reject_validation
@@ -416,7 +406,7 @@ let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
              actual category instead of bucketing as "unclassified". *)
           failure_class = Some Tool_result.Policy_rejection
         }
-      ))
+      )))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> validation_exception_action ~name exn

--- a/lib/tool_input_validation.mli
+++ b/lib/tool_input_validation.mli
@@ -4,8 +4,7 @@
     Delegates to [Agent_sdk.Tool_middleware.make_validation_hook] for strict
     type coercion and structured error feedback.  The pre-hook preserves the
     MASC transport contract by stripping underscore-prefixed protocol markers
-    before validation and by normalising [masc_transition] [to]/[note] aliases
-    to [action]/[notes] without changing action vocabulary. *)
+    before validation. *)
 
 (** Register input validation as a Tool_dispatch pre-hook.
     Must be called after all tool schemas are registered (server init). *)

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -600,28 +600,8 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   let is_internal_marker k =
     String.length k > 0 && Char.equal k.[0] '_'
   in
-  (* Issue #8312: small LLM keepers and operator UIs frequently send
-     - target-state aliases via [to] instead of canonical [action]
-     - singular [note] instead of [notes]
-     Normalize before strict-schema validation so callers do not have
-     to memorize canonical vocabulary. The Variant ([Masc_domain.task_action])
-     remains the SSOT — only the transport-level keys get rewritten.
-     Existing canonical keys are never overridden. *)
   let normalize_args = function
     | `Assoc kvs ->
-      let has k = List.exists (fun (k', _) -> String.equal k k') kvs in
-      let kvs =
-        if has "note" && not (has "notes") then
-          List.map (fun (k, v) -> if String.equal k "note" then ("notes", v) else (k, v)) kvs
-        else
-          List.filter (fun (k, _) -> not (String.equal k "note") || not (has "notes")) kvs
-      in
-      let kvs =
-        if has "to" && not (has "action") then
-          List.map (fun (k, v) -> if String.equal k "to" then ("action", v) else (k, v)) kvs
-        else
-          List.filter (fun (k, _) -> not (String.equal k "to") || not (has "action")) kvs
-      in
       (* Transport-level alias [pr_url] is hoisted into the typed
          [handoff_context.evidence_refs] list. Previously this aliased
          into a "PR: <url>" string blob inside [notes], which the
@@ -697,7 +677,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   if String.equal action_raw "" then
     Tool_result.error ~tool_name ~start_time (Printf.sprintf "action is required (%s)" (String.concat ", " Masc_domain.valid_task_action_strings))
   else
-  match Masc_domain.task_action_of_string_lenient action_raw with
+  match Masc_domain.task_action_of_string action_raw with
   | Error msg -> Tool_result.error ~tool_name ~start_time msg
   | Ok action ->
   let requested_action = action in

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -272,36 +272,6 @@ let task_action_of_string s =
   | "submit_pr_evidence" -> Ok Submit_pr_evidence
   | other -> Error (Printf.sprintf "Unknown task action: %s" other)
 
-(** Issue #8312: callers (especially small LLM keepers) often pass target-state
-    aliases such as "claimed" or status verbs from the lifecycle vocabulary.
-    [task_action_of_alias] returns [Some action] when the input maps to a
-    canonical action via a documented alias, and [None] when it does not.
-    Compose with [task_action_of_string] for "permissive input, strict output":
-    canonical strings still parse via [task_action_of_string]; only foreign
-    inputs fall through to the alias map. *)
-let task_action_of_alias s =
-  match String.lowercase_ascii s with
-  | "claimed" -> Some Claim
-  | "started" | "in_progress" | "inprogress" | "running" -> Some Start
-  | "completed" | "complete" | "finished" -> Some Done_action
-  | "cancelled" | "canceled" | "abort" | "aborted" -> Some Cancel
-  | "todo" | "released" | "unclaim" | "unclaimed" -> Some Release
-  | "awaiting_verification" | "submit" -> Some Submit_for_verification
-  | "approved" -> Some Approve_verification
-  | "rejected" -> Some Reject_verification
-  | _ -> None
-
-(** Lenient parser: tries strict canonical first, then alias map.
-    Strict callers (registry validation, schema docs) keep using
-    [task_action_of_string]; user-facing tool dispatch uses this. *)
-let task_action_of_string_lenient s =
-  match task_action_of_string s with
-  | Ok _ as ok -> ok
-  | Error _ as err ->
-    (match task_action_of_alias s with
-     | Some action -> Ok action
-     | None -> err)
-
 let task_action_to_string = function
   | Claim -> "claim"
   | Start -> "start"

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -87,8 +87,6 @@ type task_action =
 [@@deriving show]
 
 val task_action_of_string : string -> (task_action, string) result
-val task_action_of_alias : string -> task_action option
-val task_action_of_string_lenient : string -> (task_action, string) result
 val task_action_to_string : task_action -> string
 val all_task_actions : task_action list
 val valid_task_action_strings : string list

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -800,11 +800,11 @@ let test_validation_telemetry_records_pass_and_fail_counters () =
               "expected empty schema no-arg pass, got %s"
               (Yojson.Safe.to_string result.Tool_result.data)))
 
-let test_validation_telemetry_records_normalized_transition () =
+let test_validation_telemetry_rejects_retired_transition_aliases () =
   check_validation_metric_increment
     ~tool:"masc_transition"
-    ~result:"pass"
-    ~reason:"normalized"
+    ~result:"fail"
+    ~reason:"invalid_args"
     (fun () ->
        match
          Tool_input_validation.validate_args
@@ -815,25 +815,21 @@ let test_validation_telemetry_records_normalized_transition () =
                 [
                   "agent_name", `String "agent_code-local-admin";
                   "task_id", `String "task-239";
+                  "action", `String "claim";
                   "to", `String "claimed";
                   "note", `String "PR #8308 Draft";
                 ])
            ()
        with
-       | Ok forwarded ->
-         Alcotest.(check string)
-           "to normalized to action"
-           "claimed"
-           (assoc_string "action" forwarded);
-         Alcotest.(check string)
-           "note normalized to notes"
-           "PR #8308 Draft"
-           (assoc_string "notes" forwarded)
        | Error result ->
+         let msg = Yojson.Safe.to_string result.Tool_result.data in
+         Alcotest.(check bool) "mentions retired to" true (string_contains msg "to");
+         Alcotest.(check bool) "mentions retired note" true (string_contains msg "note")
+       | Ok forwarded ->
          Alcotest.fail
            (Printf.sprintf
-              "expected normalized transition, got %s"
-              (Yojson.Safe.to_string result.Tool_result.data)))
+              "expected transition alias rejection, got %s"
+              (Yojson.Safe.to_string forwarded)))
 
 let test_validation_telemetry_emits_otel_event () =
   let tool = "__tool_input_validation_otel_event" in
@@ -872,12 +868,13 @@ let test_validation_telemetry_emits_otel_event () =
       (attr_string "tool.param.validation.reason" attrs)
   | _ -> Alcotest.fail "expected exactly one validation event"
 
-let test_registered_hook_transition_compat_to_and_note () =
+let test_registered_hook_transition_rejects_to_and_note () =
   let args =
     `Assoc
       [
         ("agent_name", `String "agent_code-local-admin");
         ("task_id", `String "task-239");
+        ("action", `String "claim");
         ("to", `String "claimed");
         ("note", `String "PR #8308 Draft");
       ]
@@ -889,23 +886,23 @@ let test_registered_hook_transition_compat_to_and_note () =
       ~args
       ()
   in
-  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
-  Alcotest.(check string) "to -> action, value preserved for handler" "claimed"
-    (assoc_string "action" forwarded);
-  Alcotest.(check string) "note -> notes" "PR #8308 Draft"
-    (assoc_string "notes" forwarded);
-  Alcotest.(check bool) "to removed" true
-    (Yojson.Safe.Util.member "to" forwarded = `Null);
-  Alcotest.(check bool) "note removed" true
-    (Yojson.Safe.Util.member "note" forwarded = `Null)
+  match blocked with
+  | Some result ->
+    let msg = Yojson.Safe.to_string result.Tool_result.data in
+    Alcotest.(check bool) "mentions to" true (string_contains msg "to");
+    Alcotest.(check bool) "mentions note" true (string_contains msg "note")
+  | None ->
+    Alcotest.failf
+      "expected transition aliases to be rejected, got forwarded=%s"
+      (Yojson.Safe.to_string forwarded)
 
-let test_registered_hook_transition_compat_status_action () =
+let test_registered_hook_transition_preserves_canonical_action () =
   let args =
     `Assoc
       [
         ("agent_name", `String "keeper-ani1999-agent");
         ("task_id", `String "task-193");
-        ("action", `String "claimed");
+        ("action", `String "claim");
       ]
   in
   let blocked, forwarded =
@@ -916,7 +913,7 @@ let test_registered_hook_transition_compat_status_action () =
       ()
   in
   Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
-  Alcotest.(check string) "status-like action value preserved for handler" "claimed"
+  Alcotest.(check string) "canonical action value preserved for handler" "claim"
     (assoc_string "action" forwarded)
 
 let test_registered_hook_transition_strips_internal_agent_marker () =
@@ -1404,8 +1401,8 @@ let () =
     ("telemetry", [
       Alcotest.test_case "records pass and fail counters" `Quick
         test_validation_telemetry_records_pass_and_fail_counters;
-      Alcotest.test_case "records normalized transition counter" `Quick
-        test_validation_telemetry_records_normalized_transition;
+      Alcotest.test_case "rejects retired transition aliases counter" `Quick
+        test_validation_telemetry_rejects_retired_transition_aliases;
       Alcotest.test_case "emits OTel validation event" `Quick
         test_validation_telemetry_emits_otel_event;
     ]);
@@ -1446,10 +1443,10 @@ let () =
         test_validate_args_uses_explicit_schema_without_registry;
       Alcotest.test_case "direct keeper_board_post accepts sources array" `Quick
         test_validate_args_keeper_board_post_accepts_sources_array;
-      Alcotest.test_case "masc_transition compat: to/note keys" `Quick
-        test_registered_hook_transition_compat_to_and_note;
-      Alcotest.test_case "masc_transition compat: status-like action value" `Quick
-        test_registered_hook_transition_compat_status_action;
+      Alcotest.test_case "masc_transition rejects to/note aliases" `Quick
+        test_registered_hook_transition_rejects_to_and_note;
+      Alcotest.test_case "masc_transition canonical action value" `Quick
+        test_registered_hook_transition_preserves_canonical_action;
       Alcotest.test_case "masc_transition strips internal markers" `Quick
         test_registered_hook_transition_strips_internal_agent_marker;
       Alcotest.test_case "masc_goal_list strips blank optional enum filters"

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -86,8 +86,6 @@ let test_parse_iso8601_epoch_utc () =
   let parsed = parse_iso8601 "1970-01-01T00:00:00Z" in
   Alcotest.(check (float 0.001)) "utc epoch" 0.0 parsed
 
-(* Issue #8312: lenient parser must accept target-state aliases without
-   widening canonical Variant SSOT. *)
 let action_to_canonical = function
   | Claim -> "claim"
   | Start -> "start"
@@ -99,30 +97,23 @@ let action_to_canonical = function
   | Reject_verification -> "reject"
   | Submit_pr_evidence -> "submit_pr_evidence"
 
-let check_lenient input expected =
-  match task_action_of_string_lenient input with
+let check_action input expected =
+  match task_action_of_string input with
   | Ok a -> Alcotest.(check string) input expected (action_to_canonical a)
   | Error e -> Alcotest.failf "expected %s for %s, got error: %s" expected input e
 
-let test_action_alias_claimed () = check_lenient "claimed" "claim"
-let test_action_alias_todo () = check_lenient "todo" "release"
-let test_action_alias_in_progress () = check_lenient "in_progress" "start"
-let test_action_alias_completed () = check_lenient "completed" "done"
-let test_action_alias_cancelled () = check_lenient "cancelled" "cancel"
-let test_action_canonical_still_works () = check_lenient "claim" "claim"
-let test_action_case_insensitive () = check_lenient "CLAIMED" "claim"
+let test_action_canonical_claim () = check_action "claim" "claim"
+let test_action_canonical_case_insensitive () = check_action "CLAIM" "claim"
 
-let test_action_unknown_still_rejected () =
-  match task_action_of_string_lenient "definitely-not-an-action" with
+let test_action_unknown_rejected () =
+  match task_action_of_string "definitely-not-an-action" with
   | Error _ -> ()
-  | Ok _ -> Alcotest.fail "lenient parser must reject genuine garbage"
+  | Ok _ -> Alcotest.fail "parser must reject genuine garbage"
 
-(* Strict parser must NOT have grown alias support — preserves SSOT
-   for places that document only canonical vocabulary. *)
-let test_strict_parser_unchanged () =
+let test_action_alias_rejected () =
   match task_action_of_string "claimed" with
   | Error _ -> ()
-  | Ok _ -> Alcotest.fail "strict parser must reject aliases; lenient owns aliases"
+  | Ok _ -> Alcotest.fail "parser must reject retired action aliases"
 
 (* Issue #8372: schema enums for [agent_status] used to be hand-rolled.
    The witness function ensures every variant produces a string that
@@ -321,16 +312,11 @@ let () =
       Alcotest.test_case "live shape with nested null optionals" `Quick
         test_backlog_parse_live_shape_with_null_optional_nested_fields;
     ];
-    "task_action_lenient", [
-      Alcotest.test_case "alias claimed -> claim" `Quick test_action_alias_claimed;
-      Alcotest.test_case "alias todo -> release" `Quick test_action_alias_todo;
-      Alcotest.test_case "alias in_progress -> start" `Quick test_action_alias_in_progress;
-      Alcotest.test_case "alias completed -> done" `Quick test_action_alias_completed;
-      Alcotest.test_case "alias cancelled -> cancel" `Quick test_action_alias_cancelled;
-      Alcotest.test_case "canonical claim still works" `Quick test_action_canonical_still_works;
-      Alcotest.test_case "case insensitive" `Quick test_action_case_insensitive;
-      Alcotest.test_case "garbage still rejected" `Quick test_action_unknown_still_rejected;
-      Alcotest.test_case "strict parser ssot preserved" `Quick test_strict_parser_unchanged;
+    "task_action", [
+      Alcotest.test_case "canonical claim works" `Quick test_action_canonical_claim;
+      Alcotest.test_case "canonical case insensitive" `Quick test_action_canonical_case_insensitive;
+      Alcotest.test_case "garbage rejected" `Quick test_action_unknown_rejected;
+      Alcotest.test_case "retired alias rejected" `Quick test_action_alias_rejected;
     ];
     "agent_status_ssot", [
       Alcotest.test_case "witness covers all variants" `Quick test_agent_status_witness_in_enum;


### PR DESCRIPTION
Summary
- Remove masc_transition to/note normalization from pre-dispatch validation and reject those retired alias fields explicitly.
- Remove task-action status-word alias parsing and route transition handling through canonical task_action_of_string.
- Replace preservation tests with rejection/canonical action coverage.

Validation
- ocamlformat --check lib/tool_input_validation.ml lib/tool_input_validation.mli lib/tool_task.ml lib/types/types_core.ml lib/types/types_core.mli test/test_tool_input_validation.ml test/test_types.ml
- ocamlc -stop-after parsing lib/tool_input_validation.ml
- git diff --check
- rg backstop for removed transition/action compat symbols: no relevant hits
- scripts/ci/check-ignore-without-comment-diff.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh (PASS; existing baseline warnings only)

Known gap
- scripts/dune-local.sh build test/test_tool_input_validation.exe test/test_types.exe test/test_tool_task_coverage.exe exited 75 because bare dune build --root . processes were already running (PIDs 11674, 38246). I did not bypass with MASC_DUNE_ALLOW_BARE_DUNE=1.