### PR TITLE
refactor(keeper): drop meta separator alias lookup

### DIFF
--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -169,38 +169,23 @@ let canonical_keeper_name_from_agent_name =
 
 let canonical_keeper_name = Keeper_identity.canonical_keeper_name
 
-let separator_alias_variants name =
-  let map_sep ~from_ch ~to_ch value =
-    String.map (fun c -> if c = from_ch then to_ch else c) value
-  in
-  Json_util.dedupe_keep_order
-    [ name; map_sep ~from_ch:'_' ~to_ch:'-' name; map_sep ~from_ch:'-' ~to_ch:'_' name ]
-;;
-
 let read_meta_resolved config name : ((string * keeper_meta) option, string) result =
   let requested_name = String.trim name in
   let read_candidate candidate =
     read_meta_file_path (keeper_meta_path config candidate)
     |> Result.map (Option.map (fun meta -> candidate, meta))
   in
-  let rec read_first = function
-    | [] -> Ok None
-    | candidate :: rest ->
-      (match read_candidate candidate with
-       | Ok None -> read_first rest
-       | Ok (Some _) as ok -> ok
-       | Error _ as err -> err)
-  in
   if requested_name = ""
   then Ok None
-  else (
-    let alias_candidates =
-      match keeper_name_from_agent_name requested_name with
-      | Some alias_name when not (String.equal alias_name requested_name) ->
-        separator_alias_variants alias_name
-      | _ -> []
-    in
-    read_first (separator_alias_variants requested_name @ alias_candidates))
+  else
+    match read_candidate requested_name with
+    | Ok (Some _) as ok -> ok
+    | Error _ as err -> err
+    | Ok None ->
+      (match keeper_name_from_agent_name requested_name with
+       | Some alias_name when not (String.equal alias_name requested_name) ->
+         read_candidate alias_name
+       | _ -> Ok None)
 ;;
 
 let read_meta config name : (keeper_meta option, string) result =

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -66,13 +66,9 @@ val keeper_name_from_agent_name : string -> string option
 val canonical_keeper_name_from_agent_name : string -> string option
 val canonical_keeper_name : string -> string option
 
-(** Variants of [name] used for alias-tolerant lookup
-    ([_]/[-] swap). Order-preserving + deduped. *)
-val separator_alias_variants : string -> string list
-
-(** Read the keeper meta for [name] under alias-tolerant lookup
-    (separator variants + agent-alias derivation). Returns the
-    matched filename component plus the parsed meta. *)
+(** Read the keeper meta for [name]. Operator-facing lookups require
+    the canonical keeper filename component; runtime agent names still
+    resolve through [keeper_name_from_agent_name]. *)
 val read_meta_resolved :
   Coord.config ->
   string ->

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -236,6 +236,31 @@ let keeper_ctx env sw config agent_name : _ Tool_keeper.context =
     net = None;
   }
 
+let test_read_meta_resolved_rejects_separator_alias () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Config_dir_resolver.reset ();
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      (* See test setup: initialized state is not needed for this direct meta lookup. *)
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      write_keeper_meta_exn config ~name:"alpha-beta" ~trace_id:"trace-alpha";
+      match Keeper_types.read_meta_resolved config "alpha_beta" with
+      | Ok None -> ()
+      | Error e -> fail ("read_meta_resolved failed: " ^ e)
+      | Ok (Some (resolved_name, _)) ->
+        fail
+          (Printf.sprintf
+             "separator alias unexpectedly resolved to %s"
+             resolved_name))
+
 let test_keeper_listing_ignores_sidecar_json_files () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -1151,6 +1176,8 @@ let () =
     [
       ( "listing",
         [
+          test_case "read_meta_resolved rejects separator alias" `Quick
+            test_read_meta_resolved_rejects_separator_alias;
           test_case "keeper_names and keeper_list ignore sidecar json" `Quick
             test_keeper_listing_ignores_sidecar_json_files;
           test_case "bootable list skips autoboot-disabled meta" `Quick


### PR DESCRIPTION
Summary
- Remove keeper meta filename separator fallback that treated '_' and '-' variants as the same keeper name.
- Keep runtime agent-name resolution through keeper_name_from_agent_name, but require operator-facing meta lookups to use the canonical keeper filename component.
- Add negative coverage proving read_meta_resolved no longer resolves alpha_beta to alpha-beta.

Validation
- ocamlformat --check lib/keeper/keeper_meta_store.ml lib/keeper/keeper_meta_store.mli test/test_keeper_meta_listing.ml
- ocamlc -stop-after parsing lib/keeper/keeper_meta_store.ml
- ocamlc -stop-after parsing test/test_keeper_meta_listing.ml
- git diff --check
- rg backstop for separator_alias_variants / alias-tolerant lookup wording: no hits
- scripts/ci/check-ignore-without-comment-diff.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh (PASS; existing baseline warnings only)

Known gap
- scripts/dune-local.sh build test/test_keeper_meta_listing.exe exited 75 because bare dune build --root . processes were already running (PIDs 11674, 66238, 38246). I did not bypass with MASC_DUNE_ALLOW_BARE_DUNE=1.