### PR TITLE
refactor: SSOT consolidation — functor instances + safe_member + json_member + dead code

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -5,7 +5,7 @@ include Activity_graph_types
 include Activity_graph_registry
 include Activity_graph_reducer
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (* ================================================================ *)
 (* File storage paths                                               *)

--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -36,7 +36,7 @@ module Random = Stdlib.Random
    every RNG access through [with_identity_rng].  Same discipline
    used by [Lib.A2a_tools] ([a2a_rng] / [a2a_rng_mutex]). *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 let identity_rng = Random.State.make_self_init ()
 let identity_rng_mutex = Eio.Mutex.create ()

--- a/lib/agent_registry_eio.ml
+++ b/lib/agent_registry_eio.ml
@@ -35,7 +35,7 @@ module Random = Stdlib.Random
     @since 0.5.0
 *)
 
-module SMap = Map.Make(String)
+module SMap = Set_util.StringMap
 
 (** {1 Actor State} *)
 

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -25,7 +25,7 @@ module Random = Stdlib.Random
 
 open Masc_domain
 
-module SS = Set.Make (String)
+module SS = Set_util.StringSet
 
 
 let dedupe_schemas (schemas : Masc_domain.tool_schema list) =

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -10,7 +10,7 @@
     @since 0.6.0 - MASC Social v4 Tier 1
 *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** {1 Types} *)
 

--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -7,8 +7,8 @@
 
 open Masc_domain
 
-module StringSet = Set.Make (String)
-module StringMap = Map.Make (String)
+module StringSet = Set_util.StringSet
+module StringMap = Set_util.StringMap
 
 type risk_class =
   | Safe

--- a/lib/cascade/cascade_observation.ml
+++ b/lib/cascade/cascade_observation.ml
@@ -45,7 +45,7 @@ and cascade_fallback_event = {
   reason : string;
 }
 
-module StringMap = Map.Make(String)
+module StringMap = Set_util.StringMap
 
 (* RFC-0132 PR-2: cascade observation OAS/dashboard surface = external boundary; redact via SSOT. *)
 let public_runtime_model_label =

--- a/lib/cascade/cascade_state.ml
+++ b/lib/cascade/cascade_state.ml
@@ -2,7 +2,7 @@
 
 (* ── Round-robin ────────────────────────────────────────────────── *)
 
-module String_map = Map.Make (String)
+module String_map = Set_util.StringMap
 
 let rr_table : int Atomic.t String_map.t Atomic.t =
   Atomic.make String_map.empty

--- a/lib/cascade/cascade_throttle.ml
+++ b/lib/cascade/cascade_throttle.ml
@@ -13,7 +13,7 @@
     @since 0.92.0 extracted from Cascade_config
     @since 0.93.2 lock-free reads (Eio.Mutex → Atomic+immutable Map) *)
 
-module String_map = Map.Make (String)
+module String_map = Set_util.StringMap
 
 let throttle_table :
   Llm_provider.Provider_throttle.t String_map.t Atomic.t =

--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -8,7 +8,7 @@ type issue = {
   message : string;
 }
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 
 let has_suffix ~suffix s =

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -1,6 +1,6 @@
 (** Tool schema registry and visibility helpers. *)
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 let dedupe_schemas (schemas : Masc_domain.tool_schema list) =
   let unique, _ =

--- a/lib/config/config_boot_overrides.ml
+++ b/lib/config/config_boot_overrides.ml
@@ -9,7 +9,7 @@
     - hardcoded default
 *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 let table : string StringMap.t Atomic.t = Atomic.make StringMap.empty
 

--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -1,4 +1,4 @@
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 (** SSOT for config filenames documented in [docs/TOML-RELOAD-MATRIX.md].
     Consumed by the resolver here and by config loaders elsewhere in the

--- a/lib/core/circuit_breaker.ml
+++ b/lib/core/circuit_breaker.ml
@@ -15,7 +15,7 @@
     @since 0.6.0 - MASC Social v4 Tier 1
 *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** {1 Types} *)
 

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -40,14 +40,6 @@ let try_with_default ~default context f =
 (** Cancel-aware Result wrapper.
     Re-raises [Eio.Cancel.Cancelled] with backtrace; captures other
     exceptions as [Error exn]. *)
-let try_catch f =
-  try Ok (f ())
-  with
-  | Eio.Cancel.Cancelled _ as e ->
-    let bt = Printexc.get_raw_backtrace () in
-    Printexc.raise_with_backtrace e bt
-  | exn -> Error exn
-
 (** Cancel-aware exception handler.
     Re-raises [Eio.Cancel.Cancelled] with backtrace; delegates other
     exceptions to [handler]. *)

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -16,10 +16,6 @@ val try_with_log : string -> (unit -> 'a) -> 'a option
 val try_with_default : default:'a -> string -> (unit -> 'a) -> 'a
 (** Execute with default value on failure. *)
 
-val try_catch : (unit -> 'a) -> ('a, exn) result
-(** Cancel-aware Result wrapper.
-    Re-raises [Eio.Cancel.Cancelled]; captures any other exception as [Error exn]. *)
-
 val handle : (unit -> 'a) -> (exn -> 'a) -> 'a
 (** Cancel-aware exception handler.
     Re-raises [Eio.Cancel.Cancelled]; delegates other exceptions to the handler. *)
@@ -205,6 +201,10 @@ val json_assoc : string -> Yojson.Safe.t -> (string * Yojson.Safe.t) list
 
 val json_member_opt : string -> Yojson.Safe.t -> Yojson.Safe.t option
 (** Extract any non-null JSON value by key. Returns [None] for [`Null] or missing key. *)
+
+val safe_member : string -> Yojson.Safe.t -> Yojson.Safe.t
+(** Extract a JSON value by key from an object. Returns [`Null] if key is
+    missing or the enclosing value is not an object. *)
 
 (** {1 Tail-recursive list helpers} *)
 

--- a/lib/core/set_util.ml
+++ b/lib/core/set_util.ml
@@ -1,3 +1,6 @@
+module StringSet = Set.Make (String)
+module StringMap = Map.Make (String)
+
 (** Hashtbl-as-set membership kernels. See [set_util.mli] for design rationale
     (Hashtbl over Set.Make: polymorphic key; [Hashtbl.t] is exposed
     concretely, so a future [Set.Make] swap would be an API change, not a

--- a/lib/core/set_util.mli
+++ b/lib/core/set_util.mli
@@ -22,3 +22,7 @@ val count_difference
   -> present:('a -> 'b option)
   -> absent:('a -> 'b option)
   -> int
+
+module StringSet : Set.S with type elt = string
+
+module StringMap : Map.S with type key = string

--- a/lib/core/text_similarity.ml
+++ b/lib/core/text_similarity.ml
@@ -1,5 +1,5 @@
-module StringSet = Set.Make (String)
-module StringMap = Map.Make (String)
+module StringSet = Set_util.StringSet
+module StringMap = Set_util.StringMap
 
 (** Text_similarity — pure text similarity functions.
 

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -25,7 +25,7 @@
     that the table still holds its [cond].  This prevents an evicted
     fiber from clobbering a replacement slot. *)
 
-module SMap = Map.Make(String)
+module SMap = Set_util.StringMap
 
 let rec atomic_update atomic f =
   let old_val = Atomic.get atomic in

--- a/lib/dashboard/dashboard_http_helpers.ml
+++ b/lib/dashboard/dashboard_http_helpers.ml
@@ -119,10 +119,7 @@ let safe_age_seconds_opt ~(now_ts : float) ~(event_ts : float) : int option =
     let bounded = max 0.0 (min delta (float_of_int max_int)) in
     Some (int_of_float bounded)
 
-let safe_member key json =
-  match json with
-  | `Assoc _ -> Yojson.Safe.Util.member key json
-  | _ -> `Null
+let safe_member = Safe_ops.safe_member
 
 (* RFC-0142 PR-4: lift the silent [| _ -> default] catch-all through
    [Json_field.{list,string,assoc} |> to_option] so a Wrong_shape

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -22,7 +22,7 @@ let tool_call_health_json ?(now_ts = Unix.gettimeofday ()) (config : Coord.confi
       []
   in
   (* Single pass: aggregate totals and per-tool failure counts. *)
-  let module SMap = Map.Make (String) in
+  let module SMap = Set_util.StringMap in
   let total, failures, per_tool =
     List.fold_left
       (fun (t, f, m) (e : Audit_log.audit_entry) ->

--- a/lib/dashboard_cascade_helpers.ml
+++ b/lib/dashboard_cascade_helpers.ml
@@ -22,7 +22,7 @@ module Float = Stdlib.Float
     [source_info] is invoked. *)
 
 module CC = Cascade_config
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 let now_iso () = Masc_domain.now_iso ()
 

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -29,7 +29,7 @@ let string_contains_ci ~needle haystack =
     (String.lowercase_ascii haystack)
 
 
-module String_set = Set.Make(String)
+module String_set = Set_util.StringSet
 
 let dedup_strings (xs : string list) : string list =
   let rec go seen acc = function

--- a/lib/drift_guard.ml
+++ b/lib/drift_guard.ml
@@ -1,5 +1,5 @@
-module StringSet = Set.Make (String)
-module StringMap = Map.Make (String)
+module StringSet = Set_util.StringSet
+module StringMap = Set_util.StringMap
 
 (** Drift Guard - truthful handoff integrity verification.
 

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -1,4 +1,4 @@
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** Eval_calibration — Verdict logging and evaluator calibration loop.
 

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -1,6 +1,6 @@
 (** Tool-surface gating, selection constants, and backlog task reconciliation. *)
 
-module String_set = Set.Make (String)
+module String_set = Set_util.StringSet
 
 let unexpected_tool_partial_warned : (string, unit) Hashtbl.t =
   Hashtbl.create 32

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -149,7 +149,7 @@ let find_suffix_matches_under_root
   : string list
   =
   let root_norm = normalize_path_for_check root |> strip_trailing_slashes in
-  let module StringSet = Set.Make (String) in
+  let module StringSet = Set_util.StringSet in
   let rec walk visited ~dirs_seen acc dir =
     if dirs_seen >= max_dirs || List.length acc >= max_matches
     then visited, dirs_seen, acc

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -263,7 +263,7 @@ let approval_rule_of_yojson json =
 
 (* ── Global queue (Lock-free Atomic.t) ───────────────────── *)
 
-module SMap = Map.Make (String)
+module SMap = Set_util.StringMap
 
 let rec atomic_update atomic f =
   let old_val = Atomic.get atomic in

--- a/lib/keeper/keeper_context_core_history.ml
+++ b/lib/keeper/keeper_context_core_history.ml
@@ -2,7 +2,7 @@
 
 open Keeper_types
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 (* Note: this module is `include`d into Keeper_context_core which already
    exposes `module Message_json = Keeper_context_core_message_json`. Avoid

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -1,7 +1,7 @@
 open Keeper_types
 open Keeper_exec_shared
 open Keeper_exec_context
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 
 (* Issue #8484: Variant SSOT for memory search scope. Adding a new

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -1,6 +1,6 @@
 open Keeper_types
 open Keeper_alerting
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 let count_context_tokens (ctx : working_context) = Keeper_exec_context.token_count ctx
 

--- a/lib/keeper/keeper_hooks_oas_idle.ml
+++ b/lib/keeper/keeper_hooks_oas_idle.ml
@@ -9,7 +9,7 @@ open Keeper_hooks_oas_types
     known set. The LLM (non-deterministic) decides which to use. *)
 let suggest_alternatives ~(allowed_tools : string list)
     ~(repeated_tools : string list) ~(max_suggestions : int) : string list =
-  let module SS = Set.Make (String) in
+  let module SS = Set_util.StringSet in
   let repeated_set =
     List.fold_left (fun acc t -> SS.add t acc) SS.empty repeated_tools
   in

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -135,7 +135,7 @@ let select_memory_candidates
 (** Filter a list to unique items by a key function.
     Empty keys are skipped (treated as duplicates). *)
 let dedup_by_key (key_of : 'a -> string) (items : 'a list) : 'a list =
-  let module SS = Set.Make (String) in
+  let module SS = Set_util.StringSet in
   let rec go seen acc = function
     | [] -> List.rev acc
     | item :: rest ->

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -798,7 +798,7 @@ let recall_candidates_with_history
     let len = min 100 (String.length s) in
     String.sub s 0 len
   in
-  let module SS = Set.Make (String) in
+  let module SS = Set_util.StringSet in
   let seen =
     List.fold_left (fun acc s -> SS.add (key_of s) acc)
       SS.empty from_checkpoint

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -4,7 +4,7 @@
     See keeper_registry_types.mli for rationale and contract. *)
 
 open Keeper_types
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** Structured failure reason for cohort detection in self-preservation.
     ADT matching replaces string prefix matching for crash_msg grouping. *)

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -81,7 +81,7 @@ type logical_ordering = {
   logical_seq : int option;
 }
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 type links = {
   receipt_path : string option;

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -1,6 +1,4 @@
-let json_member key = function
-  | `Assoc _ as json -> Yojson.Safe.Util.member key json
-  | _ -> `Null
+let json_member = Server_dashboard_http_json_utils.json_member
 
 let json_int_opt_member key json =
   match json_member key json with

--- a/lib/keeper/keeper_supervisor_self_preservation.ml
+++ b/lib/keeper/keeper_supervisor_self_preservation.ml
@@ -1,6 +1,6 @@
 (** See [keeper_supervisor_self_preservation.mli] for the contract. *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 type escape_state =
   { mutable last_dominant_cohort : string

--- a/lib/keeper/keeper_tool_diversity.ml
+++ b/lib/keeper/keeper_tool_diversity.ml
@@ -92,7 +92,7 @@ let compute_diversity ~(available_tools : string list)
     |> List.map (fun s -> s.name)
   in
   (* Underused: available tools never called or called < 1% *)
-  let module SS = Set.Make (String) in
+  let module SS = Set_util.StringSet in
   let used_set =
     List.fold_left (fun acc s ->
       if s.count > 0 then SS.add s.name acc else acc)

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -407,7 +407,7 @@ let tool_policy_of_meta (meta : keeper_meta) =
     deny = Tool_access_policy.Names meta.tool_denylist;
   }
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 (* ── Access lookup (O(1) per tool) ────────────────────────────── *)
 

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -976,7 +976,7 @@ let classify_provider_timeout_strike ~strikes =
   then Provider_timeout_soft_backoff
   else Provider_timeout_warn
 
-module Budget_strike_map = Map.Make (String)
+module Budget_strike_map = Set_util.StringMap
 
 (* Stdlib.Mutex: this ledger is updated from keeper Eio fibers and from
    non-Eio unit tests. The critical section is pure map replacement and

--- a/lib/keeper/keeper_types_profile_persona.ml
+++ b/lib/keeper/keeper_types_profile_persona.ml
@@ -232,7 +232,7 @@ let list_persona_summaries () : persona_summary list =
     | Sys_error _ -> []
   in
   (* Collect all persona (name, path) from all dirs; later dirs override. *)
-  let module SS = Set.Make (String) in
+  let module SS = Set_util.StringSet in
   let raw = dirs |> List.concat_map entries_from_dir in
   let all_entries =
     List.fold_left

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -45,8 +45,8 @@ let managed_agent_passthrough_tool_set : (string, unit) Hashtbl.t =
     managed_agent_passthrough_tool_names;
   tbl
 
-module StringSet = Set.Make (String)
-module StringMap = Map.Make (String)
+module StringSet = Set_util.StringSet
+module StringMap = Set_util.StringMap
 
 let dedupe_tool_schemas_by_name (schemas : Masc_domain.tool_schema list) =
   let _, result =

--- a/lib/memory_oas_bridge_cache.ml
+++ b/lib/memory_oas_bridge_cache.ml
@@ -1,6 +1,6 @@
 (** File-stamp caches for {!Memory_oas_bridge}. *)
 
-module SMap = Map.Make (String)
+module SMap = Set_util.StringMap
 
 let rec atomic_update atomic f =
   let old_val = Atomic.get atomic in

--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -1,4 +1,4 @@
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** Meta_cognition_snapshot — Data loading, JSON builders, and snapshot generation.
 

--- a/lib/model_inference_metrics_entry.ml
+++ b/lib/model_inference_metrics_entry.ml
@@ -12,7 +12,7 @@
     Internal sibling module of the facade; do not call directly from
     outside the library. *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 module IntMap = Map.Make (Int)
 
 let model_id_unknown = "unknown"

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -11,7 +11,7 @@
     Distributed backend paths (Some key in room_utils_ops.ml) are not
     affected — this only replaces the local filesystem lock path. *)
 
-module SMap = Map.Make(String)
+module SMap = Set_util.StringMap
 
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 

--- a/lib/rate_limit.ml
+++ b/lib/rate_limit.ml
@@ -9,7 +9,7 @@
     @since 0.4.0
 *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** {1 Token Bucket Algorithm} *)
 

--- a/lib/server/server_dashboard_compact_receipt_json.ml
+++ b/lib/server/server_dashboard_compact_receipt_json.ml
@@ -19,13 +19,7 @@ let compact_preview ~max_chars text =
 (* Local member-lookup helper.  The parent's [json_member] returns
    `Null on miss; matching that shape lets the caller pattern-match
    on `Assoc / `Null without options. *)
-let json_member key = function
-  | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some v -> v
-     | None -> `Null)
-  | _ -> `Null
-;;
+let json_member = Server_dashboard_http_json_utils.json_member
 
 let json_string key json = Json_util.get_string json key
 let json_int key json = Json_util.get_int json key

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -408,7 +408,7 @@ let compose_namespace_truth_initializing ~(config : Coord.config) ~message =
          ("message", `String message);
        ])
 
-module String_set = Set.Make (String)
+module String_set = Set_util.StringSet
 
 let json_bool_field key json ~default =
   match safe_member key json with

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -12,7 +12,7 @@ type sse_conn_info = {
   mutable closed : bool;
 }
 
-module SMap = Map.Make(String)
+module SMap = Set_util.StringMap
 
 let rec atomic_update atomic f =
   let old_val = Atomic.get atomic in

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -1,6 +1,6 @@
 open Result.Syntax
 
-module SMap = Map.Make(String)
+module SMap = Set_util.StringMap
 
 let rec atomic_update atomic f =
   let old_val = Atomic.get atomic in

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -2,7 +2,7 @@
 
 open Masc_domain
 
-module AgentMap = Map.Make(String)
+module AgentMap = Set_util.StringMap
 
 (** Session info stored in registry *)
 type session = {

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -25,7 +25,7 @@
     waiting on a lock held by another fiber. *)
 
 (** Classification of an SSE session's traffic role. *)
-module SMap = Map.Make(String)
+module SMap = Set_util.StringMap
 
 (* Test-only hooks for forcing a CAS retry in white-box unit tests. *)
 let register_commit_test_hook : (unit -> unit) option Atomic.t = Atomic.make None

--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -26,7 +26,7 @@ type response_mode =
 type request_handler =
   Yojson.Safe.t -> Yojson.Safe.t
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** Session storage with mutex protection *)
 module Session = struct

--- a/lib/tool_access_policy.ml
+++ b/lib/tool_access_policy.ml
@@ -17,7 +17,7 @@ module Float = Stdlib.Float
 
 (** Tool_access_policy — shared allow/deny selector ADT for runtime tool policies. *)
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 type selector =
   | Empty

--- a/lib/tool_blob_store/tool_blob_store.ml
+++ b/lib/tool_blob_store/tool_blob_store.ml
@@ -1,4 +1,4 @@
-module SS = Set.Make (String)
+module SS = Set_util.StringSet
 
 type t = { root : string } [@@unboxed]
 

--- a/lib/tool_call_quality_benchmark/post_verifier.ml
+++ b/lib/tool_call_quality_benchmark/post_verifier.ml
@@ -1,4 +1,4 @@
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** Post Verifier — 3-dimension output verification gate for agents.
 

--- a/lib/tool_metrics.ml
+++ b/lib/tool_metrics.ml
@@ -15,7 +15,7 @@ module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** Per-tool timing metrics *)
 

--- a/lib/tool_prefilter.ml
+++ b/lib/tool_prefilter.ml
@@ -14,8 +14,8 @@ module String = Stdlib.String
 module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
-module StringMap = Map.Make (String)
-module StringSet = Set.Make (String)
+module StringMap = Set_util.StringMap
+module StringSet = Set_util.StringSet
 
 (** Tool_prefilter — TF-IDF cosine similarity for tool relevance scoring.
 

--- a/lib/tool_registry.ml
+++ b/lib/tool_registry.ml
@@ -72,7 +72,7 @@ let registry_mu = Eio.Mutex.create ()
 let with_registry_rw f = Eio_guard.with_mutex registry_mu f
 let with_registry_ro f = Eio_guard.with_mutex_ro registry_mu f
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 (** Use the leaf surface-name SSOT instead of Config.raw_all_tool_schemas.
     Tool_registry sits below keeper/OAS dispatch, and depending on Config

--- a/lib/tool_shard_types_core.ml
+++ b/lib/tool_shard_types_core.ml
@@ -15,7 +15,7 @@ type shard =
   ; description : string
   }
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 let select_named_schemas (names : string list) (schemas : Masc_domain.tool_schema list)
   : Masc_domain.tool_schema list

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -15,8 +15,8 @@ module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
 
-module StringSet = Set.Make (String)
-module StringMap = Map.Make (String)
+module StringSet = Set_util.StringSet
+module StringMap = Set_util.StringMap
 
 (** Tool_usage_log -- Durable call logging for System_internal surface tools.
 

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -6,7 +6,7 @@
 
 open Masc_domain
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 let dedupe_schemas_by_name (schemas : tool_schema list) =
   let unique, _ =


### PR DESCRIPTION
## Summary
- **Set_util.StringSet/StringMap SSOT**: 모든 `Set.Make(String)` (28개)와 `Map.Make(String)` (37개) functor instance를 `Set_util.StringSet/StringMap`으로 통합
- **safe_member 위임**: `dashboard_http_helpers.ml`의 `safe_member`를 `Safe_ops.safe_member`에 위임
- **json_member 위임**: `server_dashboard_compact_receipt_json.ml`, `keeper_runtime_trust_timeline.ml`의 `json_member`를 `Server_dashboard_http_json_utils.json_member`에 위임
- **Dead code 제거**: `Safe_ops.try_catch` (0 caller) 제거
- **mli export**: `Safe_ops.safe_member` `.mli` export 추가

## 변경 통계
- 65 files changed, +78/-90
- OCaml functor type identity 통일로 모듈 간 `Set.t`/`Map.t` 호환

## 제외
- `keeper_invariant/` — standalone library (zero dependencies), local functor 유지 불가피
- 서로 다른 시그니처의 json_* helpers — SSOT 불가

## Test plan
- [x] `dune build --root .` 통과
- [ ] CI 빌드 확인
- [ ] `dune runtest` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)