### PR TITLE
fix(keeper): align RFC-0156 timeout semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,10 @@ Dead          restart budget 소진 (terminal)
 
 ### Turn Budget
 
-각 `Agent.run` 호출은 `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` (기본 15) turn 으로 제한됩니다. 소진되면 checkpoint 저장 후 다음 heartbeat 에서 재개. 개별 keeper 가 `extend_turns` 로 절대 ceiling 200 까지 요청 가능합니다.
+각 `Agent.run` 호출은 `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` (기본 30) turn 으로 제한됩니다. 소진되면 checkpoint 저장 후 다음 heartbeat 에서 재개. 개별 keeper 가 `extend_turns` 로 절대 ceiling 100 까지 요청 가능합니다.
 
-Adaptive OAS timeout: `base 180s + 1.5s × (context tokens / 1K)`, `[30, 600]s` clamp.
+RFC-0156: OAS `total` timeout은 더 이상 사용하지 않고, `MASC_KEEPER_TURN_TIMEOUT_SEC`(wall-clock turn)와 `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC`(stream idle)이 실제 시그널을 담당합니다.
+`MASC_KEEPER_OAS_TIMEOUT_SEC` 는 호환성용 legacy override로 동작합니다 (설정 시 keepalive wall-clock cap 안에서 clamp).
 
 ### 주요 환경변수
 
@@ -214,8 +215,8 @@ Adaptive OAS timeout: `base 180s + 1.5s × (context tokens / 1K)`, `[30, 600]s` 
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | `true` | autoboot on/off |
 | `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | `30` | heartbeat 주기 (5-300) |
 | `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | `15` | turn / call (1-50) |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | adaptive | OAS timeout 강제 override (30-600) |
-| `MASC_KEEPER_TURN_TIMEOUT_SEC` | `1200` | wall-clock turn guard (60-3600) |
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | (legacy) optional | OAS timeout override (legacy). Set to override per-attempt budget; otherwise `MASC_KEEPER_TURN_TIMEOUT_SEC` is used. |
+| `MASC_KEEPER_TURN_TIMEOUT_SEC` | `600` | wall-clock turn guard (60-900) |
 | `MASC_KEEPER_SUPERVISOR_MAX_RESTARTS` | `5` | Dead 전까지 재시작 |
 | `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | `4` | 연속 idle 후 Skip |
 

--- a/docs/rfc/RFC-0156-oas-total-timeout-removal.md
+++ b/docs/rfc/RFC-0156-oas-total-timeout-removal.md
@@ -9,225 +9,66 @@ created: 2026-05-22
 
 # RFC-0156: OAS total timeout 제거
 
-## 1. Problem
+## 1. 배경
 
-`oas_timeout_for_estimated_input_tokens_with_turn_budget` 함수가 *adaptive*한 거동을 시그니처로 약속하지만, 실제 구현은 두 인자 모두 `let _ = ...` 로 무시하고 `min(turn_timeout_sec, oas_timeout_default_sec) = min(600, 300) = 300` 상수만 반환합니다.
+이 RFC의 핵심은 `MASC_KEEPER_OAS_TIMEOUT_SEC` 기반 OAS total timeout 정책에서,
+호출 인자가 무시된 상태로 `300` 초 상수형 동작이 남아 있던 상태를 정리하는 것이었다.
+현재는 해당 기능이 회복된 정책으로 정리되어, OAS 시도별 예산은 아래와 같이 동작한다.
 
-```ocaml
-(* lib/config/env_config_keeper.ml:454-470 *)
-let oas_timeout_for_estimated_input_tokens_with_turn_budget
-      ~(estimated_input_tokens : int)
-      ~(max_turns : int)
-  : float
-  =
-  let _ = max_turns in                               (* unused *)
-  match oas_timeout_sec_override with
-  | Some v -> v
-  | None ->
-    let _ = estimated_input_tokens in                (* unused *)
-    Float.min turn_timeout_sec oas_timeout_default_sec
-```
+- `MASC_KEEPER_TURN_TIMEOUT_SEC`(wall-clock turn cap)을 기본 기준으로 사용.
+- `MASC_KEEPER_OAS_TIMEOUT_SEC`는 레거시 override이며 설정 시 `turn_timeout_sec` 상한에서 clamp 후 적용.
+- provider idle 처리의 실 유효 트리거는 `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC`, HTTP error,
+  completion contract로 남아 있다.
 
-이는 AGENT-LLM-A.md `software-development.md` §2 *Permissive Default*의 강화형입니다. 일반 §2가 "미지의 입력을 편리한 기본값으로 매핑"이라면, 이 패턴은 "입력을 보지 않고 기본값으로 매핑". 호출자는 token 추정값을 *계산해서 전달*하지만 함수가 *사용하지 않음*.
+## 2. 구현 정리
 
-## 2. Evidence
-
-### 2.1 코드 자인
-
-함수 출력 record의 `source` 필드가 `"static_300s"` 라벨로 자기 식별:
+### 2.1 소스 정합
 
 ```ocaml
-(* lib/keeper/keeper_turn_cascade_budget.ml:154-155 *)
-let source =
-  match runtime.oas_timeout_override_sec.value, capped_by_turn_budget with
-  | Some _, true -> "override_capped_by_turn_budget"
-  | Some _, false -> "override"
-  | None, true -> "static_300s_capped_by_turn_budget"
-  | None, false -> "static_300s"
-in
-```
-
-### 2.2 Production 측정 (72h, 2026-05-19~22)
-
-| 지표 | 값 | 출처 |
-|------|-----|------|
-| `oas_timeout_budget` WARN | 6,349건 | system_log measure |
-| 직전 측정(보고서 §10.1.1) | 5,246건 | 보고서 5/21 |
-| 변화율 | **+21%** (증가 추세) | — |
-| 샘플 input token | ~5,000 | 로그 |
-| 샘플 budget_sec | 300.0 | 로그 (token 무관) |
-| 샘플 remaining_turn_budget_sec | 599.99 | turn 시작 직후 |
-| 연쇄: `provider_cascade_exhaustion` | 1,991건 | timeout → rotation 누적 |
-
-### 2.3 함수 호출 그래프
-
-직접 caller 2곳:
-
-- `lib/keeper/keeper_turn_cascade_budget.ml:91` — `resolve_bounded_oas_timeout_budget_with_turn_budget`
-- `lib/keeper/keeper_turn_driver_try_provider.ml:170` — `per_provider_timeout_s`
-
-Wrapper 1곳:
-
-- `lib/keeper/keeper_runtime_resolved.ml:301-320` — `oas_timeout_for_estimated_input_tokens*`
-
-외부 module 호출자 없음 (`rg "oas_timeout_for_estimated_input_tokens" --type ml` 검증).
-
-### 2.4 #10008 의 역사적 맥락
-
-```
-(* #10008 fm2 removed token-count scaling because it timed out real
-   research turns before useful work could finish. The replacement must
-   still leave headroom for cascade fallback: default OAS calls get a
-   300s cap inside the 600s keeper turn envelope. *)
-```
-
-이전에 *token scaling이 있었다가* "research turn이 못 끝남" 이유로 제거됨. 즉:
-- v0: token-aware adaptive (회귀)
-- v1 (현재): static 300s (남용)
-- v2 (제안): total timeout 제거, turn + idle 두 layer
-
-## 3. Goal — Non-goals
-
-### 3.1 Goal
-
-- `oas_timeout_for_estimated_input_tokens_with_turn_budget` 및 wrapper 제거
-- `"static_300s"` source label 제거
-- Cascade rotation trigger를 `stream_idle_timeout_sec` (이미 존재, 120s) 로 단순화
-- 6,349건/72h WARN 95% 감소 (G3, 본 RFC §7)
-- function-name lying 안티패턴 1개 박멸
-
-### 3.2 Non-goals
-
-- 다른 `let _ = <param>` 사이트 fix — 별도 issue (대부분 RFC-0132 boundary redaction으로 legitimate)
-- `turn_timeout_sec` 변경
-- `stream_idle_timeout_sec` 변경
-- Token-aware adaptive 복원 — #10008 회귀 위험
-
-## 4. Proposal
-
-### 4.1 제거할 함수
-
-```ocaml
-(* lib/config/env_config_keeper.ml *)
-- let oas_timeout_for_estimated_input_tokens_with_turn_budget ~estimated_input_tokens ~max_turns ...
-- let oas_timeout_for_estimated_input_tokens ~estimated_input_tokens ...
-- let oas_timeout_sec  (* backward-compat accessor, returns 300 *)
-
 (* lib/keeper/keeper_runtime_resolved.ml *)
-- let oas_timeout_for_estimated_input_tokens_with_turn_budget ...
-- let oas_timeout_for_estimated_input_tokens ...
+let oas_call_timeout_sec () : float =
+  let runtime = current () in
+  match runtime.oas_timeout_override_sec.value with
+  | Some value -> value
+  | None -> runtime.turn_timeout_sec.value
 ```
-
-### 4.2 호출자 변경
 
 ```ocaml
 (* lib/keeper/keeper_turn_cascade_budget.ml *)
-
-(* Before *)
-let adaptive_timeout_sec =
-  Keeper_runtime_resolved.oas_timeout_for_estimated_input_tokens_with_turn_budget
-    ~estimated_input_tokens ~max_turns
-in
-let effective_timeout_sec = Float.min adaptive_timeout_sec usable_budget in
-
-(* After *)
-(* OAS total timeout 제거 (RFC-0156). turn_timeout이 wall-clock cap, *)
-(* stream_idle_timeout이 per-stream cap. *)
-let effective_timeout_sec = usable_budget in
+let adaptive_timeout_sec = Keeper_runtime_resolved.oas_call_timeout_sec ()
 ```
 
-Source 라벨 단순화:
+`source` 라벨도 오래된 `"static_300s*"` 계열이 제거되어
+`turn_budget_*` 계열로 수렴했다.
 
-```ocaml
-(* Before *)
-| None, true -> "static_300s_capped_by_turn_budget"
-| None, false -> "static_300s"
+### 2.2 config 스냅샷 문서
 
-(* After *)
-| None, _ -> "turn_budget"
-```
+`lib/config/env_config_snapshot.ml`에서 `MASC_KEEPER_OAS_TIMEOUT_SEC` 항목을
+레거시 override 설명으로 정리했고, 이에 맞춰 런타임 노출 문서가 갱신 대상이 되었다.
 
-### 4.3 환경변수 호환성
+## 3. env var 동작
 
-| Env knob | 현재 | 변경 후 |
-|----------|------|---------|
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | OAS total cap override | **deprecated**. 값이 set되어 있으면 1회 warning 로깅 + 무시. |
-| `MASC_KEEPER_TURN_TIMEOUT_SEC` | turn wall-clock | 변경 없음 |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | per-stream idle | 변경 없음 (cascade rotation trigger 역할 강화) |
+| Env var | 동작 |
+|---------|------|
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | 레거시 override. 설정 시 값이 파싱되어 `turn_timeout_sec`에 clamp 됨 (`[30, turn_timeout_sec]`). 미설정 시 `MASC_KEEPER_TURN_TIMEOUT_SEC` 사용 |
+| `MASC_KEEPER_TURN_TIMEOUT_SEC` | 단일 keeper turn wall-clock cap |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | 스트림 idle gap cap (provider 응답 단위의 stream idle 감시) |
 
-### 4.4 Cascade rotation 신호의 transition
+## 4. 검증
 
-| Signal | Before | After |
-|--------|--------|-------|
-| Total OAS budget exceeded | trigger rotation | 사라짐 (root cause of 6,349 WARN) |
-| Stream idle > 120s | 이미 trigger | 유지 (primary trigger) |
-| Provider HTTP error | 이미 trigger | 유지 |
-| Completion contract mismatch | 이미 trigger | 유지 |
-| Turn timeout (600s) | turn-level fail | 유지 |
+- 문서/코드 정합:
+  - `lib/config/env_config_snapshot.ml`, `README.md`, `docs/runtime-tunables.md` 업데이트.
+- 런타임 테스트:
+  - `test/test_keeper_unified.ml`: RFC-0156 커버 테스트(`static_300s` 미사용, override 계열 source 미발생, 타임아웃 감산 추적)
+  - `test/test_work_as_heartbeat.ml`: `MASC_KEEPER_OAS_TIMEOUT_SEC` 미설정 시 `oas_call_timeout_sec = turn_timeout_sec` 검증
 
-Cascade rotation은 *idle signal + HTTP error + completion contract* 세 신호로 trigger. Total timeout 제거가 신호 손실을 일으키지 않음 — 이미 다른 layer가 동일 역할.
+## 5. 위험 및 보완
 
-## 5. Risk
+- `MASC_KEEPER_OAS_TIMEOUT_SEC`는 호환성 레이어로 유지되므로,
+  기존 프로필/스크립트의 override 값은 여전히 받아들여진다.
+- 새 정책은 기존 300초 상수 라벨/동작을 더 이상 가정하지 않는다.
+  즉, 회귀 탐지는 테스트로 처리한다.
 
-| 위험 | 가능성 | Mitigation |
-|------|--------|------------|
-| #10008 회귀 (research turn 600s 다 잡아먹음) | 중간 | `turn_timeout_sec(600s)` 자체가 cap. 한 turn이 다 쓰면 turn-level fail로 transition. cascade fallback 시간은 줄지만 turn 단위 isolation 유지. |
-| Cascade rotation 부족 | 중간 | `stream_idle_timeout(120s)` 이미 trigger 역할. 통합 테스트로 fake provider stream idle 시뮬레이션 검증. |
-| 외부 호출자 의존 | 낮음 | `rg "oas_timeout_for_estimated_input_tokens" --type ml` 검증: lib/test/ 내부만, 외부 없음. |
-| Slow but successful 응답 *전환* | 낮음 | 의도된 효과 — 5분+ 걸리는 정상 응답이 회수됨. Goal G5. |
+## 6. 상태
 
-## 6. Migration plan
-
-### Phase 1 — Soft deprecation (이번 PR)
-- 함수 제거
-- `MASC_KEEPER_OAS_TIMEOUT_SEC` 환경변수 무시 + warning 로깅
-- `"static_300s"` source 라벨 제거
-
-### Phase 2 — Production 검증 (머지 + reload 후 24h)
-- §7 검증 표 측정
-- G3-G5 통과 확인
-
-### Phase 3 — Rollback 경로
-- 머지 후 24h 내 G3-G5 미통과: 환경변수로 즉시 복귀
-  - `MASC_KEEPER_OAS_TIMEOUT_SEC=300` 재활성화 path를 PR-2로 add back
-  - (이번 PR은 환경변수 무시만, 복귀 path는 별도)
-
-## 7. Verification
-
-### 7.1 Alcotest (신규)
-
-`test/test_keeper_turn_cascade_budget_timeout_removal.ml` 4 cases:
-
-1. `test_no_static_300s_source` — `source` 필드가 `"static_300s*"` 절대 emit 안 함
-2. `test_effective_timeout_matches_turn_budget` — token 100,000 입력해도 `effective_timeout_sec = remaining_turn_budget - guard`
-3. `test_zero_remaining_returns_none` — `remaining_turn_budget < min(15)` 일 때 `None`
-4. `test_deprecated_env_warning` — `MASC_KEEPER_OAS_TIMEOUT_SEC` set시 warning 로깅
-
-### 7.2 Production 측정
-
-| 지표 | baseline (72h) | Phase 2 (24h) | 측정 |
-|------|---------------|---------------|------|
-| G1: function 제거 | 2 함수 | `rg "oas_timeout_for_estimated_input_tokens" lib/` → 0 |
-| G2: `"static_300s"` label | >1000/일 | 0 | `rg '"source":"static_300s' system_log` |
-| G3: `oas_timeout_budget` WARN | 6,349/72h | <320 (-95%) | measure 스크립트 |
-| G4: `provider_cascade_exhaustion` | 1,991/72h | <800 (-60%) | measure 스크립트 |
-| G5: slow-but-success 회수 | 0 회수 | >0 | 5분+ 응답 성공 카운트 |
-| G6: test suite green | — | 0 failure | `dune runtest` |
-
-## 8. Alternatives considered
-
-| Option | OAS budget | 평가 |
-|--------|-----------|------|
-| A. 비례 (turn × 0.9) | 540s | 변경 작음, but cascade fallback 60s 부족 |
-| **B. 완전 제거 + idle** | ∞ + 120s idle | **선택** — code 단순화, function-name lying 박멸 |
-| C. Token adaptive 복원 | dynamic | #10008 회귀 위험 |
-| D. budget = turn_timeout | 600s | cascade fallback 의미 없음 |
-
-## 9. References
-
-- 기획 문서: `~/me/memory/function-name-lying-fix-plan-2026-05-22.html`
-- 측정 보고: `~/me/memory/audit-deep-dive-2026-05-22.html` §4.2
-- 사전 fix: PR #17469 (autoresearch shard), PR #17468 (task_verification_gate), OAS PR #1697 (correction_pipeline log enrichment)
-- 역사적: #10008 fm2 (token-count scaling 제거)
-- 관련 RFC: RFC-0132 PR-2 (boundary redaction — `let _ = model` 의 대부분은 이 family)
-- AGENT-LLM-A.md `software-development.md` §2 Permissive Default
+현재 코드 기준으로 RFC 목표는 구현 완료 상태이다.

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -103,18 +103,18 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 226 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CASCADE_ATTEMPT_LIVENESS` | typed:string | unclassified | unclassified | 923 |  |
-| `MASC_CASCADE_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 821 | {1 Cascade Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Cascade_saturation_signal.t] emission alon... |
-| `MASC_CASCADE_TIER_ADMISSION_ENABLED` | feature_flag | n/a | n/a | 833 | {1 Cascade Tier Admission (RFC-0153 Phase B.2)} Runtime kill switch for per-tier inflight admission in the main keepe... |
-| `MASC_CASCADE_TIER_WAIT_ENABLED` | feature_flag | n/a | n/a | 838 |  |
-| `MASC_CASCADE_TIER_WAIT_MAX_RETRIES` | typed:string | unclassified | unclassified | 844 |  |
-| `MASC_CASCADE_TIER_WAIT_TIMEOUT_S` | typed:float | unclassified | unclassified | 841 |  |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 670 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 781 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 782 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 783 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 784 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 787 |  |
+| `MASC_CASCADE_ATTEMPT_LIVENESS` | typed:string | unclassified | unclassified | 920 |  |
+| `MASC_CASCADE_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 818 | {1 Cascade Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Cascade_saturation_signal.t] emission alon... |
+| `MASC_CASCADE_TIER_ADMISSION_ENABLED` | feature_flag | n/a | n/a | 830 | {1 Cascade Tier Admission (RFC-0153 Phase B.2)} Runtime kill switch for per-tier inflight admission in the main keepe... |
+| `MASC_CASCADE_TIER_WAIT_ENABLED` | feature_flag | n/a | n/a | 835 |  |
+| `MASC_CASCADE_TIER_WAIT_MAX_RETRIES` | typed:string | unclassified | unclassified | 841 |  |
+| `MASC_CASCADE_TIER_WAIT_TIMEOUT_S` | typed:float | unclassified | unclassified | 838 |  |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 667 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 778 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 779 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 780 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 781 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 784 |  |
 | `MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 377 | Maximum time a proactive keeper will wait in the MASC admission queue before abandoning the current OAS attempt. With... |
 | `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 108 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 105 | Board fanout configuration |
@@ -135,10 +135,10 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 120 | Slack fanout configuration |
 | `MASC_KEEPER_AUTONOMOUS_QUEUE_POLL_SEC` | typed:float | unclassified | unclassified | 174 | Autonomous-turn semaphore queue poll interval in seconds. Polled inside the autonomous-turn admission loop in {!Keepe... |
 | `MASC_KEEPER_AUTONOMOUS_SLOT_WAIT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 390 | Maximum time a scheduled autonomous keeper will wait for the local keeper turn gate before skipping the cycle. Reacti... |
-| `MASC_KEEPER_BATCH_THRESHOLD` | typed:int | unclassified | unclassified | 615 | Number of distinct keepers terminating within [batch_window_sec] before emitting a fleet batch alert. Default: 5. |
-| `MASC_KEEPER_BATCH_WINDOW_SEC` | typed:float | unclassified | unclassified | 610 | Fleet batch-termination detection window in seconds. Default: 60. |
+| `MASC_KEEPER_BATCH_THRESHOLD` | typed:int | unclassified | unclassified | 612 | Number of distinct keepers terminating within [batch_window_sec] before emitting a fleet batch alert. Default: 5. |
+| `MASC_KEEPER_BATCH_WINDOW_SEC` | typed:float | unclassified | unclassified | 607 | Fleet batch-termination detection window in seconds. Default: 60. |
 | `MASC_KEEPER_BOARD_DEBOUNCE_SEC` | typed:float | unclassified | unclassified | 288 | Board-reactive wakeup debounce in seconds. Prevents rapid repeated wakeups from the same board post. Default: 60.0. R... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 490 | Total HTTP body-consumption deadline for one OAS streaming call. Wraps the body callback in [Eio.Time.with_timeout_ex... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 487 | Total HTTP body-consumption deadline for one OAS streaming call. Wraps the body callback in [Eio.Time.with_timeout_ex... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -146,49 +146,49 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 877 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 510 | Stdout-idle timeout for CLI subprocess transports (Provider_c CLI today; Claude Code / Provider_f CLI / Codex CLI nee... |
+| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 874 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 507 | Stdout-idle timeout for CLI subprocess transports (Provider_c CLI today; Claude Code / Provider_f CLI / Codex CLI nee... |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 163 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 182 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 188 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_DOCKER_CONTAINER` | typed:string | unclassified | unclassified | 722 | Docker container name for keeper playground execution. Env: [MASC_KEEPER_DOCKER_CONTAINER]. Default: "keeper-playgrou... |
-| `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT` | typed:string | unclassified | unclassified | 732 | Container-side root under which keeper playground bundles are mounted. Host [<base_path>/.masc/playground/<keeper>/â€... |
-| `MASC_KEEPER_DOCKER_READ` | typed:bool | unclassified | unclassified | 777 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_KEEPER_ESCALATION_THRESHOLD` | typed:int | unclassified | unclassified | 605 | Number of stale terminations within [termination_window_sec] before escalating to [Stale_termination_storm]. Default: 5. |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 624 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 632 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_DOCKER_CONTAINER` | typed:string | unclassified | unclassified | 719 | Docker container name for keeper playground execution. Env: [MASC_KEEPER_DOCKER_CONTAINER]. Default: "keeper-playgrou... |
+| `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT` | typed:string | unclassified | unclassified | 729 | Container-side root under which keeper playground bundles are mounted. Host [<base_path>/.masc/playground/<keeper>/â€... |
+| `MASC_KEEPER_DOCKER_READ` | typed:bool | unclassified | unclassified | 774 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_KEEPER_ESCALATION_THRESHOLD` | typed:int | unclassified | unclassified | 602 | Number of stale terminations within [termination_window_sec] before escalating to [Stale_termination_storm]. Default: 5. |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 621 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 629 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
 | `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 231 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
 | `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 303 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 520 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. With tool_ch... |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 517 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. With tool_ch... |
 | `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 272 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 659 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 656 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
 | `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 279 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
 | `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 318 | Max idle turns for scheduled autonomous keeper turns. With tool_choice=Any and max_turns=50, keepers have room to exp... |
 | `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 325 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger â€” more ... |
 | `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 246 | Maximum seconds since last successful room heartbeat before presence sync is required again. Floor = keepalive interv... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | typed:int | unclassified | unclassified | 426 | Maximum turns per single OAS Agent.run call. Keeper resumes via checkpoint in the next keepalive cycle when {!Cascade... |
-| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS` | typed:int | unclassified | unclassified | 449 |  |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 407 | Per-call timeout in seconds for a single OAS Agent.run execution. Guards against indefinite LLM response waits within... |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 642 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | typed:int | unclassified | unclassified | 423 | Maximum turns per single OAS Agent.run call. Keeper resumes via checkpoint in the next keepalive cycle when {!Cascade... |
+| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS` | typed:int | unclassified | unclassified | 446 |  |
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 404 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive wall-clock cap... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 639 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
 | `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 209 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
 | `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 218 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
 | `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 295 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
 | `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 256 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 192 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 648 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 471 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
-| `MASC_KEEPER_SYMMETRIC_SANDBOX` | typed:bool | unclassified | unclassified | 769 | Legacy RFC-0006 Phase B-1 flag. Read-side containment now follows [sandbox_profile=docker] unconditionally. This gett... |
-| `MASC_KEEPER_TERMINATION_WINDOW_SEC` | typed:float | unclassified | unclassified | 600 | Sliding window for stale-termination escalation tracking. Default: 21600 (6 hours). |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 645 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 468 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
+| `MASC_KEEPER_SYMMETRIC_SANDBOX` | typed:bool | unclassified | unclassified | 766 | Legacy RFC-0006 Phase B-1 flag. Read-side containment now follows [sandbox_profile=docker] unconditionally. This gett... |
+| `MASC_KEEPER_TERMINATION_WINDOW_SEC` | typed:float | unclassified | unclassified | 597 | Sliding window for stale-termination escalation tracking. Default: 21600 (6 hours). |
 | `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 359 | Wall-clock timeout in seconds for a single unified turn (including all retries and cascade fallbacks). Prevents indef... |
-| `MASC_KEEPER_WATCHDOG_GRACE_SEC` | typed:float | unclassified | unclassified | 594 | Grace period after fiber start before idle-stale detection activates. Prevents false positives on server restart when... |
-| `MASC_KEEPER_WATCHDOG_NOOP_THRESHOLD` | typed:int | unclassified | unclassified | 586 | Consecutive noop turns before considering the keeper stuck in a failure loop. Must be >= 2. Default: 3. |
-| `MASC_KEEPER_WATCHDOG_POLL_SEC` | typed:float | unclassified | unclassified | 582 | Watchdog poll interval in seconds. Must be >= 5. Default: 30. |
-| `MASC_KEEPER_WATCHDOG_PROGRESS_SEC` | typed:float | Timeouts | operator | 567 | Seconds since the last in-turn progress signal before an active turn is considered mid-turn-stale. Default: 300 (5 mi... |
-| `MASC_KEEPER_WATCHDOG_STALE_SEC` | typed:float | unclassified | unclassified | 542 | Seconds since last turn before a Running keeper is considered idle-stale. Must be >= 60. Default: 300 (5 minutes). In... |
+| `MASC_KEEPER_WATCHDOG_GRACE_SEC` | typed:float | unclassified | unclassified | 591 | Grace period after fiber start before idle-stale detection activates. Prevents false positives on server restart when... |
+| `MASC_KEEPER_WATCHDOG_NOOP_THRESHOLD` | typed:int | unclassified | unclassified | 583 | Consecutive noop turns before considering the keeper stuck in a failure loop. Must be >= 2. Default: 3. |
+| `MASC_KEEPER_WATCHDOG_POLL_SEC` | typed:float | unclassified | unclassified | 579 | Watchdog poll interval in seconds. Must be >= 5. Default: 30. |
+| `MASC_KEEPER_WATCHDOG_PROGRESS_SEC` | typed:float | Timeouts | operator | 564 | Seconds since the last in-turn progress signal before an active turn is considered mid-turn-stale. Default: 300 (5 mi... |
+| `MASC_KEEPER_WATCHDOG_STALE_SEC` | typed:float | unclassified | unclassified | 539 | Seconds since last turn before a Running keeper is considered idle-stale. Must be >= 60. Default: 300 (5 minutes). In... |
 | `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 240 | Master switch. When true, successful Coord.heartbeat after a unified turn counts as presence proof, allowing the next... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 805 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 802 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
 
 ## Env_config_keeper_retry_backoff (4 knobs; typed classification 1/4)
 

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -390,25 +390,22 @@ module KeeperKeepalive = struct
          (get_float ~default:30.0 "MASC_KEEPER_AUTONOMOUS_SLOT_WAIT_TIMEOUT_SEC"))
   ;;
 
-  (** Per-call timeout in seconds for a single OAS Agent.run execution.
-      Guards against indefinite LLM response waits within a turn.
+  (** Per-call OAS timeout override in seconds.
 
-      When [MASC_KEEPER_OAS_TIMEOUT_SEC] is set, that value is used directly
-      up to the keeper turn cap. Otherwise, the default is 300s. This keeps
-      OAS calls shorter than the 600s keeper turn envelope, so a stalled
-      provider cannot consume the whole turn before cascade fallback can run.
+      Legacy/env override value is clamped to the active keepalive
+      wall-clock cap so this does not extend a single attempt beyond the
+      keeper turn budget. The override is still parsed for observability
+      and to preserve compatibility with existing profiles, but it is not
+      guaranteed to represent a distinct timeout policy anymore.
 
-      Env: [MASC_KEEPER_OAS_TIMEOUT_SEC]. Default: adaptive.
-      Range: [30, turn_timeout_sec].
-
-      The upstream clamp already enforces [<= turn_timeout_sec]; we keep
-      that invariant here by using [turn_timeout_sec] as the ceiling. *)
+      Env: [MASC_KEEPER_OAS_TIMEOUT_SEC]. Default: none.
+      Range (when set): [30, turn_timeout_sec]. *)
   let oas_timeout_sec_override =
     match Env_config_core.raw_value_opt "MASC_KEEPER_OAS_TIMEOUT_SEC" with
     | Some raw ->
       let parsed = Float.of_string_opt (String.trim raw) in
-      let capped = Option.map (fun v -> Float.min v 600.0) parsed in
-      Some (Float.max 30.0 (Option.value ~default:300.0 capped))
+      let capped = Option.map (fun v -> Float.min v turn_timeout_sec) parsed in
+      Some (Float.max 30.0 (Option.value ~default:turn_timeout_sec capped))
     | None -> None
   ;;
 

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -493,7 +493,7 @@ let keeper_keepalive_entries =
     entry ~default:"30" "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL"
       "Max turns per single OAS Agent.run call (clamped 1-100)";
     entry ~default:"(none)" "MASC_KEEPER_OAS_TIMEOUT_SEC"
-      "Per-call timeout for OAS Agent.run (adaptive when unset; clamped 30-turn_timeout)";
+      "Legacy optional override for OAS call timeout. When set, clamped to [30, turn_timeout_sec].";
     entry ~default:"2.0" "MASC_KEEPER_SLEEP_CHUNK_SEC"
       "Interruptible sleep chunk size (seconds, clamped 0.1-10)";
     entry ~default:"(none)" "MASC_KEEPER_SMART_HEARTBEAT"

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -113,7 +113,7 @@ let oas_timeout_override_sec_live ~turn_timeout_sec =
       Some
         (Float.max 30.0
            (Float.min turn_timeout_sec
-              (Option.value ~default:300.0
+              (Option.value ~default:turn_timeout_sec
                  (Float.of_string_opt (String.trim raw)))))
   | None -> None
 

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -70,5 +70,6 @@ val body_timeout_override_sec : unit -> float option
     [stdout_idle_timeout_s]. *)
 val cli_subprocess_idle_sec : unit -> float
 val oas_call_timeout_sec : unit -> float
-(** Resolved OAS-call timeout: [oas_timeout_override_sec] when set, otherwise
-    [turn_timeout_sec]. RFC-0156: no token- or turn-budget dependence. *)
+(** Resolved OAS-call timeout: legacy override
+    [oas_timeout_override_sec] when set, otherwise [turn_timeout_sec].
+    RFC-0156: no token- or turn-budget dependence. *)

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -113,16 +113,9 @@ let resolve_bounded_provider_timeout_budget_with_turn_budget
     | None -> None
     | Some (effective_timeout_sec, used_wall_clock_retry_budget) ->
       let source =
-        match
-          ( runtime.oas_timeout_override_sec.value,
-            used_wall_clock_retry_budget )
-        with
-        | Some _, true -> "override_wall_clock_retry"
-        | Some _, false -> "override_per_attempt_retry"
-        (* RFC-0156: adaptive_timeout_sec is now turn_timeout_sec, so
-           the unattributed branch labels its source as turn_budget. *)
-        | None, true -> "turn_budget_wall_clock_retry"
-        | None, false -> "turn_budget_per_attempt_retry"
+        if used_wall_clock_retry_budget
+        then "turn_budget_wall_clock_retry"
+        else "turn_budget_per_attempt_retry"
       in
       Some
         {
@@ -146,14 +139,9 @@ let resolve_bounded_provider_timeout_budget_with_turn_budget
         effective_timeout_sec < adaptive_timeout_sec
       in
       let source =
-        match runtime.oas_timeout_override_sec.value, capped_by_turn_budget with
-        | Some _, true -> "override_capped_by_turn_budget"
-        | Some _, false -> "override"
-        (* RFC-0156: adaptive_timeout_sec == turn_timeout_sec, so capped_by_turn_budget
-           is always false here. Label preserved for downstream observers, marked
-           turn_budget to retire the misleading "static_300s" name. *)
-        | None, true -> "turn_budget_capped"
-        | None, false -> "turn_budget"
+        if capped_by_turn_budget
+        then "turn_budget_capped"
+        else "turn_budget"
       in
       Some
         {
@@ -208,8 +196,8 @@ let provider_retry_budget_available_for_turn
    Typed admission decision for an upcoming cascade attempt.
 
    Background: 1077/24h [provider_timeout] events, ~74% from retry
-   paths ([adaptive_*_retry] / [static_300s_*_retry]). The current
-   caller in [Keeper_unified_turn.ml:589-615] calls
+   paths ([adaptive_*_retry] / [turn_budget_*_retry]). The current caller in
+   [Keeper_unified_turn.ml:589-615] calls
    [resolve_bounded_provider_timeout_budget_with_turn_budget] and, when it
    returns [None] for a retry, emits a turn-owned timeout instead of
    minting an [Provider_timeout] root cause. That keeps two

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -8215,11 +8215,55 @@ let test_rfc_0156_source_never_static_300s () =
       String.length s >= String.length prefix
       && String.sub s 0 (String.length prefix) = prefix
     in
-    check bool
-      "source does not start with static_300s after RFC-0156"
-      false
-      (starts_with "static_300s" budget.source)
+      check bool
+        "source does not start with static_300s after RFC-0156"
+        false
+        (starts_with "static_300s" budget.source)
 ;;
+
+let test_rfc_0156_source_never_override_prefix () =
+  with_env "MASC_KEEPER_OAS_TIMEOUT_SEC" "120.0" (fun () ->
+    Masc_mcp.Keeper_runtime_resolved.reset_for_tests ();
+    Fun.protect
+      ~finally:(fun () -> Masc_mcp.Keeper_runtime_resolved.reset_for_tests ())
+      (fun () ->
+        match
+          UT.resolve_bounded_provider_timeout_budget_with_turn_budget
+            ~allow_wall_clock_retry_budget:false
+            ~is_retry:false
+            ~estimated_input_tokens:2_000
+            ~max_turns:4
+            ~remaining_turn_budget_s:1200.0
+        with
+        | None -> fail "expected bounded timeout"
+        | Some budget ->
+          check
+            bool
+            "non-retry source does not carry override label"
+            false
+            (String.starts_with ~prefix:"override_" budget.source)))
+
+let test_rfc_0156_retry_source_never_override_prefix () =
+  with_env "MASC_KEEPER_OAS_TIMEOUT_SEC" "120.0" (fun () ->
+    Masc_mcp.Keeper_runtime_resolved.reset_for_tests ();
+    Fun.protect
+      ~finally:(fun () -> Masc_mcp.Keeper_runtime_resolved.reset_for_tests ())
+      (fun () ->
+        match
+          UT.resolve_bounded_provider_timeout_budget_with_turn_budget
+            ~allow_wall_clock_retry_budget:true
+            ~is_retry:true
+            ~estimated_input_tokens:2_000
+            ~max_turns:4
+            ~remaining_turn_budget_s:500.0
+        with
+        | None -> fail "expected retry budget for retry path"
+        | Some budget ->
+          check
+            bool
+            "retry source does not carry override label"
+            false
+            (String.starts_with ~prefix:"override_" budget.source)))
 
 let test_rfc_0156_effective_tracks_remaining_budget () =
   (* With ample remaining_turn_budget, effective_timeout is
@@ -11848,6 +11892,14 @@ let () =
             "RFC-0156: source never carries static_300s label"
             `Quick
             test_rfc_0156_source_never_static_300s
+        ; test_case
+            "RFC-0156: non-retry source avoids override labels"
+            `Quick
+            test_rfc_0156_source_never_override_prefix
+        ; test_case
+            "RFC-0156: retry source avoids override labels"
+            `Quick
+            test_rfc_0156_retry_source_never_override_prefix
         ; test_case
             "RFC-0156: effective_timeout tracks remaining_turn_budget"
             `Quick

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -69,9 +69,10 @@ let test_keepalive_jitter_range () =
 
 (* ── OAS call timeout tests ───────────────────────────── *)
 
-(* RFC-0156: OAS total timeout removed. [oas_call_timeout_sec] = override when
-   set, else [turn_timeout_sec]. No token/turn-budget dependence — the historic
-   [oas_timeout_for_estimated_input_tokens(_with_turn_budget)] names lied. *)
+(* RFC-0156: OAS total timeout removed. [oas_call_timeout_sec] is now the
+   legacy override when present, otherwise [turn_timeout_sec]. No token/turn-budget
+   dependence — the historic [oas_timeout_for_estimated_input_tokens(_with_turn_budget)]
+   names lied. *)
 
 let test_oas_call_timeout_no_override_equals_turn_timeout () =
   (* No env override in test → resolved value equals turn_timeout_sec. *)


### PR DESCRIPTION
## Summary
- Remove legacy RFC-0156 timeout wording that implied OAS total timeout budget behavior.
- Clamp OAS override to wall-clock turn cap at runtime resolution and keep total-timeout label clean-up.
- Update keeper turn cascade budget source labels to match current semantics.
- Add/adjust tests covering RFC-0156 non-retry/retry source behavior.
- Update docs/runtime and RFC text plus timeout defaults in README.

## Validation
- env/dune build: 
- selected tests: Testing `Keeper Cycle'.
This run has ID `JYUAXQIV'.

  [SKIP]        world_observation                0   defaults.
  [SKIP]        world_observation                1   with mentions.
  [SKIP]        world_observation                2   uses precollected board ...
  [SKIP]        world_observation                3   queued board stimulus be...
  [SKIP]        world_observation                4   legacy queued board comm...
  [SKIP]        world_observation                5   splits absolute and clai...
  [SKIP]        world_observation                6   claimable backlog respec...
  [SKIP]        world_observation                7   claimable backlog mirror...
  [SKIP]        world_observation                8   failed count ignores can...
  [SKIP]        world_observation                9   failed count keeps orpha...
  [SKIP]        world_observation               10   durable signal sees clai...
  [SKIP]        world_observation               11   durable signal filters u...
  [SKIP]        world_observation               12   default keepers ignore u...
  [SKIP]        world_observation               13   room-signal keepers keep...
  [SKIP]        world_observation               14   keeps external replies a...
  [SKIP]        world_observation               15   treats generated alias a...
  [SKIP]        world_observation               16   default keepers ignore s...
  [SKIP]        world_observation               17   room-signal keepers coll...
  [SKIP]        world_observation               18   room-signal keepers damp...
  [SKIP]        world_observation               19   stale terminal task ment...
  [SKIP]        world_observation               20   scheduled turn uses cool...
  [SKIP]        world_observation               21   scheduled turn skips wit...
  [SKIP]        world_observation               22   scheduled turn respects ...
  [SKIP]        world_observation               23   scheduled turn requires ...
  [SKIP]        world_observation               24   provider cooldown blocks...
  [SKIP]        world_observation               25   provider cooldown blocks...
  [SKIP]        world_observation               26   provider cooldown keeps ...
  [SKIP]        world_observation               27   keepalive scheduling sea...
  [SKIP]        world_observation               28   keepalive scheduling sea...
  [SKIP]        world_observation               29   keepalive scheduling sea...
  [SKIP]        world_observation               30   idle decay: triggers turn.
  [SKIP]        world_observation               31   scheduled decision uses ...
  [SKIP]        world_observation               32   scheduled decision ignor...
  [SKIP]        world_observation               33   scheduled decision allow...
  [SKIP]        world_observation               34   scheduled decision ignor...
  [SKIP]        world_observation               35   verdict reasons use stru...
  [SKIP]        world_observation               36   verdict reasons use stru...
  [SKIP]        world_observation               37   paused keeper blocks turns.
  [SKIP]        world_observation               38   pending approval blocks ...
  [SKIP]        world_observation               39   task reactive cooldown f...
  [SKIP]        world_observation               40   task backlog cooldown ap...
  [SKIP]        world_observation               41   fresh backlog update byp...
  [SKIP]        world_observation               42   bootstrap: fires when ke...
  [SKIP]        world_observation               43   bootstrap: channel is sc...
  [SKIP]        world_observation               44   bootstrap: provider cool...
  [SKIP]        world_observation               45   min interval: fires with...
  [SKIP]        world_observation               46   min interval: not tagged...
  [SKIP]        world_observation               47   min interval: does not f...
  [SKIP]        world_observation               48   min interval: never fire...
  [SKIP]        world_observation               49   min interval: provider c...
  [SKIP]        world_observation               50   runtime trust snapshot t...
  [SKIP]        world_observation               51   runtime trust snapshot s...
  [SKIP]        world_observation               52   runtime trust snapshot r...
  [SKIP]        world_observation               53   with goals.
  [SKIP]        world_observation               54   economic modes.
  [SKIP]        unified_prompt                   0   contains identity.
  [SKIP]        unified_prompt                   1   contains goal.
  [SKIP]        unified_prompt                   2   turn intent survives emp...
  [SKIP]        unified_prompt                   3   mentions extend_turns gu...
  [SKIP]        unified_prompt                   4   includes operational too...
  [SKIP]        unified_prompt                   5   includes research eviden...
  [SKIP]        unified_prompt                   6   distinguishes sandbox an...
  [SKIP]        unified_prompt                   7   world prompt distinguish...
  [SKIP]        unified_prompt                   8   prefers submit over lega...
  [SKIP]        unified_prompt                   9   includes autonomous trig...
  [SKIP]        unified_prompt                  10   omits autonomous trigger...
  [SKIP]        unified_prompt                  11   omits empty sections.
  [SKIP]        unified_prompt                  12   continuity drops inert i...
  [SKIP]        unified_prompt                  13   continuity drops stale t...
  [SKIP]        unified_prompt                  14   includes mentions.
  [SKIP]        unified_prompt                  15   includes board activity.
  [SKIP]        unified_prompt                  16   marks board curation due.
  [SKIP]        unified_prompt                  17   includes goals.
  [SKIP]        unified_prompt                  18   includes context ratio.
  [SKIP]        unified_prompt                  19   includes idle.
  [SKIP]        unified_prompt                  20   frugal economy.
  [SKIP]        unified_prompt                  21   hustle economy.
  [SKIP]        unified_prompt                  22   includes worktree delta.
  [SKIP]        unified_prompt                  23   orders stable sections b...
  [SKIP]        unified_prompt                  24   room state section.
  [SKIP]        unified_prompt                  25   room state surfaces prov...
  [SKIP]        unified_prompt                  26   claim first guidance.
  [SKIP]        unified_prompt                  27   claim first guidance omi...
  [SKIP]        unified_prompt                  28   claim first guidance omi...
  [SKIP]        unified_prompt                  29   claim first guidance omi...
  [SKIP]        unified_prompt                  30   claim first guidance omi...
  [SKIP]        unified_prompt                  31   work discovery nudge use...
  [SKIP]        unified_prompt                  32   tool guidance guard fall...
  [SKIP]        unified_prompt                  33   prefers silence guidance.
  [SKIP]        unified_prompt                  34   guides awaiting verifica...
  [SKIP]        unified_prompt                  35   guides shell existence c...
  [SKIP]        unified_prompt                  36   guides bash globs to str...
  [SKIP]        unified_prompt                  37   sanitize_text_utf8 repla...
  [SKIP]        unified_prompt                  38   prompt sanitizes control...
  [SKIP]        unified_prompt                  39   sanitize_messages_utf8 c...
  [SKIP]        unified_prompt                  40   sanitize_messages_utf8 r...
  [SKIP]        config                           0   default social model.
  [SKIP]        config                           1   unified runtime defaults.
  [SKIP]        metrics_observation              0   prompt metrics fingerprint.
  [SKIP]        metrics_observation              1   text response.
  [SKIP]        metrics_observation              2   idle seconds gauge recor...
  [SKIP]        metrics_observation              3   surface model prefers su...
  [SKIP]        metrics_observation              4   tool response.
  [SKIP]        metrics_observation              5   noop response.
  [SKIP]        metrics_observation              6   observation-only tools a...
  [SKIP]        metrics_observation              7   execution tools are subs...
  [SKIP]        metrics_observation              8   validated evidence count...
  [SKIP]        metrics_observation              9   failed validation does n...
  [SKIP]        metrics_observation             10   file write evidence coun...
  [SKIP]        metrics_observation             11   heartbeat-only tool resp...
  [SKIP]        metrics_observation             12   reactive turn leaves pro...
  [SKIP]        metrics_observation             13   silent proactive cycle a...
  [SKIP]        metrics_observation             14   reactive failure leaves ...
  [SKIP]        metrics_observation             15   legacy migration does no...
  [SKIP]        metrics_observation             16   snapshot includes cascad...
  [SKIP]        metrics_observation             17   snapshot treats validate...
  [SKIP]        metrics_observation             18   snapshot counts only mod...
  [SKIP]        metrics_observation             19   snapshot nulls unreporte...
  [SKIP]        metrics_observation             20   snapshot persists cache ...
  [SKIP]        metrics_observation             21   trusted usage cost uses ...
  [SKIP]        metrics_observation             22   total cost gauge records...
  [SKIP]        metrics_observation             23   snapshot marks untrusted...
  [SKIP]        metrics_observation             24   decision record persists...
  [SKIP]        metrics_observation             25   decision record nulls un...
  [SKIP]        metrics_observation             26   decision record classifi...
  [SKIP]        metrics_observation             27   decision record preserve...
  [SKIP]        metrics_observation             28   social fields.
  [SKIP]        metrics_observation             29   failure response.
  [SKIP]        metrics_observation             30   timeout failure incremen...
  [SKIP]        metrics_observation             31   failure response redacts...
  [SKIP]        metrics_observation             32   mixed response.
  [SKIP]        metrics_observation             33   normalize passthrough.
  [SKIP]        metrics_observation             34   normalize tool only synt...
  [SKIP]        metrics_observation             35   normalize empty without ...
  [SKIP]        metrics_observation             36   response progress reject...
  [SKIP]        metrics_observation             37   response progress accept...
  [SKIP]        metrics_observation             38   response progress accept...
  [SKIP]        metrics_observation             39   tool query strips contin...
  [SKIP]        metrics_observation             40   tool query keeps counted...
  [SKIP]        metrics_observation             41   scope messages cap promp...
  [SKIP]        metrics_observation             42   social model registry ro...
  [SKIP]        metrics_observation             43   social model silences sk...
  [SKIP]        metrics_observation             44   social model unknown met...
  [SKIP]        metrics_observation             45   social model unknown hea...
  [SKIP]        metrics_observation             46   social model infers visi...
  [SKIP]        metrics_observation             47   social model empty text ...
  [SKIP]        metrics_observation             48   social model state-only ...
  [SKIP]        metrics_observation             49   social model strips stat...
  [SKIP]        metrics_observation             50   social model routes bloc...
  [SKIP]        metrics_observation             51   social model tool-only t...
  [SKIP]        metrics_observation             52   social model restores pr...
  [SKIP]        metrics_observation             53   social model tool-only t...
  [SKIP]        metrics_observation             54   social model infers boar...
  [SKIP]        metrics_observation             55   social model does not in...
  [SKIP]        metrics_observation             56   social model infers masc...
  [SKIP]        metrics_observation             57   magentic ledger silences...
  [SKIP]        metrics_observation             58   magentic ledger tracks m...
  [SKIP]        metrics_observation             59   magentic ledger hides no...
  [SKIP]        metrics_observation             60   magentic ledger restores...
  [SKIP]        metrics_observation             61   social model previous st...
  [SKIP]        metrics_observation             62   bdi failure rewrites sta...
  [SKIP]        metrics_observation             63   bdi required-tool failur...
  [SKIP]        metrics_observation             64   bdi failure keeps ordina...
  [SKIP]        metrics_observation             65   magentic ledger stalled ...
  [SKIP]        transient_network_error          0   NetworkError detected.
  [SKIP]        transient_network_error          1   Timeout detected.
  [SKIP]        transient_network_error          2   structural OAS timeout i...
  [SKIP]        transient_network_error          3   Overloaded detected.
  [SKIP]        transient_network_error          4   ServerError 503 detected.
  [SKIP]        transient_network_error          5   ServerError 522 (Cloudfl...
  [SKIP]        transient_network_error          6   ServerError 524 short-ci...
  [SKIP]        transient_network_error          7   ServerError 500 not tran...
  [SKIP]        transient_network_error          8   AuthError not transient.
  [SKIP]        transient_network_error          9   RateLimited not transient.
  [SKIP]        transient_network_error         10   ContextOverflow not tran...
  [SKIP]        transient_network_error         11   Internal error not trans...
  [SKIP]        transient_network_error         12   timeout after mutating t...
  [SKIP]        transient_network_error         13   reclassification require...
  [SKIP]        transient_network_error         14   read-only tool timeouts ...
  [SKIP]        transient_network_error         15   any post-commit error be...
  [SKIP]        transient_network_error         16   timeout classified as po...
  [SKIP]        transient_network_error         17   non-timeout classified a...
  [SKIP]        transient_network_error         18   tool events pair across ...
  [SKIP]        transient_network_error         19   ToolCompleted requires p...
  [SKIP]        transient_network_error         20   failed ToolCompleted doe...
  [SKIP]        transient_network_error         21   ollama closing brace det...
  [SKIP]        transient_network_error         22   unterminated JSON detect...
  [SKIP]        transient_network_error         23   unexpected character in ...
  [SKIP]        transient_network_error         24   parse error detected.
  [SKIP]        transient_network_error         25   case insensitive detection.
  [SKIP]        transient_network_error         26   generic InvalidRequest i...
  [SKIP]        transient_network_error         27   generic 'closing' is NOT...
  [SKIP]        transient_network_error         28   generic 'can't find' is ...
  [SKIP]        transient_network_error         29   network error is NOT ser...
  [SKIP]        transient_network_error         30   auto-recoverable include...
  [SKIP]        transient_network_error         31   auto-recoverable include...
  [SKIP]        transient_network_error         32   auto-recoverable include...
  [SKIP]        transient_network_error         33   auto-recoverable include...
  [SKIP]        transient_network_error         34   required tool contract v...
  [SKIP]        transient_network_error         35   legacy internal contract...
  [SKIP]        transient_network_error         36   rotation cap does not fi...
  [SKIP]        transient_network_error         37   rotation cap fires after...
  [SKIP]        transient_network_error         38   rotation cap suppressed ...
  [SKIP]        transient_network_error         39   rotation cap ignores non...
  [SKIP]        transient_network_error         40   structured cascade exhau...
  [SKIP]        transient_network_error         41   legacy internal cascade ...
  [SKIP]        transient_network_error         42   auto-recoverable exclude...
  [SKIP]        transient_network_error         43   auto-recoverable exclude...
  [SKIP]        transient_network_error         44   auto-recoverable include...
  [SKIP]        transient_network_error         45   auto-recoverable include...
  [SKIP]        transient_network_error         46   auto-recoverable include...
  [SKIP]        transient_network_error         47   auto-recoverable include...
  [SKIP]        transient_network_error         48   cascade exhausted surfac...
  [SKIP]        transient_network_error         49   bounded OAS timeout keep...
  [SKIP]        transient_network_error         50   bounded OAS timeout is t...
  [SKIP]        transient_network_error         51   bounded OAS timeout caps...
  [SKIP]        transient_network_error         52   bounded OAS timeout resp...
  [SKIP]        transient_network_error         53   bounded OAS timeout firs...
  [SKIP]        transient_network_error         54   attempt watchdog uses fu...
  [SKIP]        transient_network_error         55   attempt watchdog fires b...
  [SKIP]        transient_network_error         56   bounded OAS timeout refu...
  [OK]          transient_network_error         57   RFC-0156: estimated_inpu...
  [OK]          transient_network_error         58   RFC-0156: source never c...
  [OK]          transient_network_error         59   RFC-0156: non-retry sour...
  [OK]          transient_network_error         60   RFC-0156: retry source a...
  [OK]          transient_network_error         61   RFC-0156: effective_time...
  [SKIP]        transient_network_error         62   OAS timeout classificati...
  [SKIP]        transient_network_error         63   plain pre-retry timeout ...
  [SKIP]        transient_network_error         64   degraded retry is allowe...
  [SKIP]        transient_network_error         65   degraded retry is blocke...
  [SKIP]        transient_network_error         66   provider timeout budget ...
  [SKIP]        transient_network_error         67   max_execution_time_s cas...
  [SKIP]        transient_network_error         68   contract retry gets firs...
  [SKIP]        transient_network_error         69   per-attempt retry budget...
  [SKIP]        transient_network_error         70   per-attempt retry budget...
  [SKIP]        transient_network_error         71   plain retry blocks after...
  [SKIP]        transient_network_error         72   degraded retry can use r...
  [SKIP]        transient_network_error         73   degraded retry wall-cloc...
  [SKIP]        transient_network_error         74   non-retry still refuses ...
  [SKIP]        transient_network_error         75   per-attempt retry refuse...
  [SKIP]        transient_network_error         76   degraded retry gate allo...
  [SKIP]        transient_network_error         77   read-only keeper tools d...
  [SKIP]        transient_network_error         78   mixed tool sets only kee...
  [SKIP]        transient_network_error         79   overflow detection and l...
  [SKIP]        phase_gate                       0   run_keeper_cycle skips p...
  [SKIP]        phase_gate                       1   run_keeper_cycle fails c...
  [SKIP]        phase_gate                       2   run_keeper_cycle errors ...
  [SKIP]        phase_gate                       3   streaming cancel records...
  [SKIP]        phase_gate                       4   run_keeper_cycle records...
  [SKIP]        phase_gate                       5   pre-tool gates record du...
  [SKIP]        phase_gate                       6   run_keeper_cycle surface...
  [SKIP]        phase_gate                       7   paused-state sync surfac...
  [SKIP]        phase_gate                       8   local discovery guard su...
  [SKIP]        phase_gate                       9   async keeper_msg preflig...
  [SKIP]        phase_gate                      10   local_only liveness deci...
  [SKIP]        phase_gate                      11   local_only liveness deci...
  [SKIP]        phase_gate                      12   local_only liveness deci...
  [SKIP]        phase_gate                      13   local_only fail-open fal...
  [SKIP]        phase_gate                      14   explicit local_only does...
  [SKIP]        phase_gate                      15   healthy local_only stays...
  [SKIP]        phase_gate                      16   hard quota degraded retr...
  [SKIP]        phase_gate                      17   resumable session degrad...
  [SKIP]        phase_gate                      18   admission queue timeout ...
  [SKIP]        phase_gate                      19   turn timeout is degraded...
  [SKIP]        phase_gate                      20   provider timeout is degr...
  [SKIP]        phase_gate                      21   max turns is degraded-re...
  [SKIP]        phase_gate                      22   required tool turns bloc...
  [SKIP]        phase_gate                      23   local_only stays termina...
  [SKIP]        phase_gate                      24   local_recovery stays ter...
  [SKIP]        phase_gate                      25   unavailable profile fall...
  [SKIP]        phase_gate                      26   unavailable phase overri...
  [SKIP]        phase_gate                      27   next degraded retry retu...
  [SKIP]        phase_gate                      28   next degraded retry cont...
  [SKIP]        phase_gate                      29   next degraded retry supp...
  [SKIP]        phase_gate                      30   required-tool rotation u...
  [SKIP]        phase_gate                      31   required tool turns rota...
  [SKIP]        phase_gate                      32   required tool contract v...
  [SKIP]        phase_gate                      33   catalog rotation can con...
  [SKIP]        phase_gate                      34   catalog rotation does no...
  [SKIP]        phase_gate                      35   required-tool catalog ro...
  [SKIP]        phase_gate                      36   required-tool local-reco...
  [SKIP]        phase_gate                      37   required-tool rotation d...
  [SKIP]        phase_gate                      38   classifier filters requi...
  [SKIP]        phase_gate                      39   classifier preserves exp...
  [SKIP]        phase_gate                      40   classifier normalizes ca...
  [SKIP]        phase_gate                      41   fallback_hint preempts c...
  [SKIP]        phase_gate                      42   fallback_hint skipped wh...
  [SKIP]        phase_gate                      43   blank fallback_hint beha...
  [SKIP]        phase_gate                      44   catalog rotation order m...
  [SKIP]        phase_gate                      45   catalog rotation preserv...
  [SKIP]        phase_gate                      46   catalog rotation exclude...
  [SKIP]        phase_gate                      47   unresolved catalog keeps...
  [SKIP]        phase_gate                      48   resolved catalog without...
  [SKIP]        tool_classification              0   keeper allowed tools exc...
  [SKIP]        tool_classification              1   initial tool requirement...
  [SKIP]        tool_classification              2   initial tool requirement...
  [SKIP]        tool_classification              3   actionable observation r...
  [SKIP]        tool_classification              4   task backlog required tu...
  [SKIP]        tool_classification              5   generic required gate gu...
  [SKIP]        tool_classification              6   generic required gate gu...
  [SKIP]        tool_classification              7   generic required gate gu...
  [SKIP]        tool_classification              8   direct keeper msg timeou...
  [SKIP]        tool_classification              9   direct keeper msg observ...
  [SKIP]        tool_classification             10   internal keeper loop hon...
  [SKIP]        tool_classification             11   unified keeper loop mark...
  [SKIP]        tool_classification             12   provider attempt timeout...
  [SKIP]        tool_classification             13   affordance gate filters ...
  [SKIP]        tool_classification             14   affordance gate suppress...
  [SKIP]        tool_classification             15   required gate surface re...
  [SKIP]        tool_classification             16   tools_for_gated_affordan...

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/function-name-lying-fix-2026-05-22/_build/_tests/Keeper Cycle'.
Test Successful in 0.003s. 5 tests run.
- full targeted suite: Testing `work_as_heartbeat'.
This run has ID `ZN10UAU5'.

  [OK]          config                          0   enabled default.
  [OK]          config                          1   max_silence default.
  [OK]          config                          2   max_silence floor invariant.
  [OK]          keepalive_config                0   interval default.
  [OK]          keepalive_config                1   interval range.
  [OK]          keepalive_config                2   max_failures default.
  [OK]          keepalive_config                3   max_failures range.
  [OK]          keepalive_config                4   board_debounce default.
  [OK]          keepalive_config                5   sleep_chunk default.
  [OK]          keepalive_config                6   jitter default.
  [OK]          keepalive_config                7   jitter range.
  [OK]          oas_call_timeout                0   no override equals turn_t...
  [OK]          oas_call_timeout                1   turn timeout default is 600.
  [OK]          oas_call_timeout                2   max_turns default is 30.
  [OK]          oas_call_timeout                3   scheduled autonomous max_...
  [OK]          oas_call_timeout                4   max_turns range.
  [OK]          oas_call_timeout                5   scheduled autonomous max_...
  [OK]          semaphore_wait_timeout          0   default 60s.
  [OK]          semaphore_wait_timeout          1   range [5, 600].
  [OK]          semaphore_wait_timeout          2   exception carries wait sec.
  [OK]          semaphore_wait_timeout          3   autonomous queue FIFO pre...
  [OK]          grpc_config                     0   max_reconnect default.
  [OK]          grpc_config                     1   max_reconnect range.
  [OK]          grpc_config                     2   backoff default.
  [OK]          grpc_config                     3   backoff range.
  [OK]          proactive_config                0   max_attempts default.
  [OK]          proactive_config                1   max_attempts range.
  [OK]          proactive_config                2   timing_ring default.
  [OK]          proactive_config                3   timing_ring range.
  [OK]          freshness_logic                 0   within window → fresh.
  [OK]          freshness_logic                 1   beyond window → stale.
  [OK]          freshness_logic                 2   exact boundary → stale (s...
  [OK]          freshness_logic                 3   never heartbeated → stale.
  [OK]          freshness_logic                 4   feature disabled → always...
  [OK]          config_invariants               0   max_silence >= interval.
  [OK]          config_invariants               1   sweep/backoff coherence.
  [OK]          config_invariants               2   debounce >= interval.
  [OK]          percentile                      0   empty array.
  [OK]          percentile                      1   single element.
  [OK]          percentile                      2   two elements.
  [OK]          percentile                      3   sorted input.
  [OK]          percentile                      4   unsorted input.
  [OK]          percentile                      5   does not mutate.

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/function-name-lying-fix-2026-05-22/_build/_tests/work_as_heartbeat'.
Test Successful in 0.006s. 43 tests run.