### PR TITLE
refactor(tools): drop legacy_message test construction

### DIFF
--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -114,7 +114,7 @@ let test_to_oas_typed_error_uses_json_recoverable_flag () =
     Tool_result.
       { success = false
       ; data = Yojson.Safe.from_string msg
-      ; legacy_message = msg
+      ; message = msg
       ; tool_name = "test"
       ; duration_ms = 0.0
       ; failure_class = None


### PR DESCRIPTION
## Summary
- finish the Tool_result legacy_message purge by updating the remaining direct test record construction to the canonical message field
- keep the unrelated legacy_messages_endpoint negative transport check intact; it is a different endpoint contract

## Verification
- ocamlformat --check test/test_tool_bridge_externalize.ml
- ocamlc -stop-after parsing test/test_tool_bridge_externalize.ml
- rg -n '\blegacy_message\b|Tool_result\.legacy_message' lib test docs dashboard  # no matches
- git diff --check
- scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

Focused Dune gap: scripts/dune-local.sh build test/test_tool_bridge_externalize.exe returned exit 75 because machine-wide bare Dune processes are active; I did not bypass the guard.