### PR TITLE
[codex] Link Goal Loop creation to Goal Manager

### DIFF
--- a/dashboard/src/components/goal-loop-panel.test.ts
+++ b/dashboard/src/components/goal-loop-panel.test.ts
@@ -7,6 +7,9 @@ import { normalizeGoalLoopStatus } from '../goal-loop-status'
 const mocks = vi.hoisted(() => ({
   callMcpTool: vi.fn(),
   fetchGoalLoopStatus: vi.fn(),
+  fetchDashboardGoalsTree: vi.fn(),
+  hydrateGoalTreeSnapshot: vi.fn(),
+  navigate: vi.fn(),
 }))
 
 vi.mock('../api/mcp', () => ({
@@ -15,6 +18,18 @@ vi.mock('../api/mcp', () => ({
 
 vi.mock('../api/goal-loop', () => ({
   fetchGoalLoopStatus: mocks.fetchGoalLoopStatus,
+}))
+
+vi.mock('../api/dashboard', () => ({
+  fetchDashboardGoalsTree: mocks.fetchDashboardGoalsTree,
+}))
+
+vi.mock('../goal-tree-state', () => ({
+  hydrateGoalTreeSnapshot: mocks.hydrateGoalTreeSnapshot,
+}))
+
+vi.mock('../router', () => ({
+  navigate: mocks.navigate,
 }))
 
 function blockedStatus() {
@@ -79,6 +94,9 @@ describe('GoalLoopPanel', () => {
     cleanup()
     mocks.callMcpTool.mockReset()
     mocks.fetchGoalLoopStatus.mockReset()
+    mocks.fetchDashboardGoalsTree.mockReset()
+    mocks.hydrateGoalTreeSnapshot.mockReset()
+    mocks.navigate.mockReset()
   })
 
   it('renders phase table, audit, next action, and the strict corpus blocker', () => {
@@ -149,6 +167,7 @@ describe('GoalLoopPanel', () => {
   it('creates a goal through the goal store tool and refreshes the loop status', async () => {
     mocks.callMcpTool.mockResolvedValue('{"ok":true}')
     mocks.fetchGoalLoopStatus.mockResolvedValue(blockedStatus())
+    mocks.fetchDashboardGoalsTree.mockResolvedValue({ tree: [], summary: {} })
 
     render(html`<${GoalLoopPanel} initialStatus=${blockedStatus()} />`)
 
@@ -175,5 +194,43 @@ describe('GoalLoopPanel', () => {
     })
     expect(screen.getByTestId('goal-loop-create-goal').textContent)
       .toContain('created Stabilize runtime truth')
+  })
+
+  it('surfaces the created goal id, refreshes the goal tree cache, and routes to goal manager', async () => {
+    const treePayload = { tree: [], summary: {} }
+    mocks.callMcpTool.mockResolvedValue(JSON.stringify({
+      ok: true,
+      goal_id: 'goal-runtime-truth',
+      task_link_field: 'goal_id',
+    }))
+    mocks.fetchGoalLoopStatus.mockResolvedValue(blockedStatus())
+    mocks.fetchDashboardGoalsTree.mockResolvedValue(treePayload)
+
+    render(html`<${GoalLoopPanel} initialStatus=${blockedStatus()} />`)
+
+    fireEvent.input(screen.getByLabelText('Goal title'), {
+      target: { value: 'Stabilize runtime truth' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Create goal' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('goal-loop-created-goal-id').textContent)
+        .toContain('goal goal-runtime-truth')
+    })
+    expect(screen.getByTestId('goal-loop-created-goal-id').textContent)
+      .toContain('task link goal_id')
+    await waitFor(() => {
+      expect(mocks.fetchDashboardGoalsTree).toHaveBeenCalledTimes(1)
+    })
+    expect(mocks.hydrateGoalTreeSnapshot).toHaveBeenCalledWith(treePayload)
+
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Open Stabilize runtime truth in Goal Manager',
+    }))
+
+    expect(mocks.navigate).toHaveBeenCalledWith('workspace', {
+      section: 'planning',
+      goal: 'goal-runtime-truth',
+    })
   })
 })

--- a/dashboard/src/components/goal-loop-panel.ts
+++ b/dashboard/src/components/goal-loop-panel.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useCallback, useEffect, useState } from 'preact/hooks'
-import { Plus, RefreshCw } from 'lucide-preact'
+import { ArrowRight, Plus, RefreshCw } from 'lucide-preact'
 import { SectionCard } from './common/card'
 import { LoadingState } from './common/feedback-state'
 import { ActionButton } from './common/button'
@@ -10,8 +10,12 @@ import { CollapsibleSection } from './common/collapsible'
 import { TextInput } from './common/input'
 import { Select } from './common/select'
 import { fetchGoalLoopStatus } from '../api/goal-loop'
+import { fetchDashboardGoalsTree } from '../api/dashboard'
 import { callMcpTool } from '../api/mcp'
+import { asString, isRecord } from './common/normalize'
 import { formatMsCompact } from '../lib/format-number'
+import { hydrateGoalTreeSnapshot } from '../goal-tree-state'
+import { navigate } from '../router'
 import {
   GOAL_LOOP_PHASES,
   auditCatalogSummary,
@@ -31,6 +35,12 @@ interface GoalLoopPanelProps {
 }
 
 type GoalHorizon = 'short' | 'mid' | 'long'
+
+interface CreatedGoal {
+  title: string
+  goalId: string | null
+  taskLinkField: string | null
+}
 
 const GOAL_HORIZON_OPTIONS = [
   { value: 'short', label: 'Short' },
@@ -262,13 +272,26 @@ function VerifyEvidenceBlock({ status }: { status: GoalLoopStatusResponse }) {
   `
 }
 
+function parseGoalUpsertResult(text: string): Omit<CreatedGoal, 'title'> {
+  try {
+    const raw = JSON.parse(text) as unknown
+    if (!isRecord(raw)) return { goalId: null, taskLinkField: null }
+    return {
+      goalId: asString(raw.goal_id) ?? null,
+      taskLinkField: asString(raw.task_link_field) ?? null,
+    }
+  } catch {
+    return { goalId: null, taskLinkField: null }
+  }
+}
+
 function GoalCreateBlock({ onCreated }: { onCreated: () => void }) {
   const [title, setTitle] = useState('')
   const [horizon, setHorizon] = useState<GoalHorizon>('short')
   const [priority, setPriority] = useState('3')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [created, setCreated] = useState<string | null>(null)
+  const [created, setCreated] = useState<CreatedGoal | null>(null)
 
   const submit = useCallback((event?: Event) => {
     event?.preventDefault()
@@ -285,12 +308,20 @@ function GoalCreateBlock({ onCreated }: { onCreated: () => void }) {
       horizon,
       priority: Number(priority),
     })
-      .then(() => {
+      .then((resultText) => {
+        const upsertResult = parseGoalUpsertResult(resultText)
         setTitle('')
         setHorizon('short')
         setPriority('3')
-        setCreated(trimmedTitle)
+        setCreated({
+          title: trimmedTitle,
+          goalId: upsertResult.goalId,
+          taskLinkField: upsertResult.taskLinkField,
+        })
         onCreated()
+        void fetchDashboardGoalsTree()
+          .then(hydrateGoalTreeSnapshot)
+          .catch(() => undefined)
       })
       .catch((err) => {
         setError(err instanceof Error ? err.message : String(err))
@@ -355,8 +386,40 @@ function GoalCreateBlock({ onCreated }: { onCreated: () => void }) {
         : null}
       ${created
         ? html`
-          <div class="rounded-[var(--r-1)] border border-[var(--ok-25)] bg-[var(--ok-10)] px-3 py-2 text-xs text-[var(--color-status-ok)]">
-            created ${created}
+          <div
+            class="rounded-[var(--r-1)] border border-[var(--ok-25)] bg-[var(--ok-10)] px-3 py-2 text-xs text-[var(--color-status-ok)]"
+            data-testid="goal-loop-created-goal"
+          >
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <div class="min-w-0">
+                <div class="min-w-0 truncate">created ${created.title}</div>
+                ${created.goalId
+                  ? html`
+                    <div class="mt-1 font-mono text-3xs text-[var(--color-fg-muted)]" data-testid="goal-loop-created-goal-id">
+                      goal ${created.goalId}
+                      ${created.taskLinkField ? html` · task link ${created.taskLinkField}` : null}
+                    </div>
+                  `
+                  : null}
+              </div>
+              ${created.goalId
+                ? html`
+                  <${ActionButton}
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    ariaLabel=${`Open ${created.title} in Goal Manager`}
+                    title=${`Open ${created.title} in Goal Manager`}
+                    onClick=${() => navigate('workspace', { section: 'planning', goal: created.goalId! })}
+                  >
+                    <span class="inline-flex items-center gap-1">
+                      Open
+                      <${ArrowRight} size=${14} />
+                    </span>
+                  <//>
+                `
+                : null}
+            </div>
           </div>
         `
         : null}

--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -1,0 +1,186 @@
+import { html } from 'htm/preact'
+import { cleanup, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  DashboardGoalDetailResponse,
+  DashboardGoalsTreeResponse,
+  GoalTreeNode,
+} from '../../types'
+import { hydrateGoalTreeSnapshot } from '../../goal-tree-state'
+
+const mocks = vi.hoisted(() => ({
+  fetchDashboardGoalDetail: vi.fn(),
+  fetchDashboardGoalsTree: vi.fn(),
+  route: {
+    value: {
+      tab: 'workspace',
+      params: { section: 'planning' } as Record<string, string>,
+      postId: null,
+    },
+  },
+  coordinationFsmSnapshot: { value: null },
+}))
+
+vi.mock('../../api/dashboard', () => ({
+  fetchDashboardGoalDetail: mocks.fetchDashboardGoalDetail,
+  fetchDashboardGoalsTree: mocks.fetchDashboardGoalsTree,
+}))
+
+vi.mock('../../router', () => ({
+  route: mocks.route,
+}))
+
+vi.mock('../../store', () => ({
+  coordinationFsmSnapshot: mocks.coordinationFsmSnapshot,
+}))
+
+vi.mock('../task-manage/task-create-form', () => ({
+  TaskCreateForm: () => null,
+}))
+
+import { GoalTree } from './goal-tree'
+
+function emptySummary(): DashboardGoalsTreeResponse['summary'] {
+  return {
+    total_goals: 0,
+    active_goals: 0,
+    on_track_goals: 0,
+    done_goals: 0,
+    paused_goals: 0,
+    at_risk_goals: 0,
+    blocked_goals: 0,
+    total_tasks: 0,
+    done_tasks: 0,
+    pending_approvals: 0,
+    infra_risk_count: 0,
+    overall_convergence: 0,
+    overall_convergence_pct: 0,
+  }
+}
+
+function makeGoal(id: string, title: string, children: GoalTreeNode[] = []): GoalTreeNode {
+  return {
+    id,
+    title,
+    horizon: 'short',
+    status: 'active',
+    status_color: '',
+    phase: 'executing',
+    phase_color: '',
+    goal_fsm: {
+      state: 'executing',
+      source: 'goal.phase',
+      state_kind: 'active',
+      next_actions: [],
+      activity_observation: 'goal_metadata',
+      stagnation_status: 'recent',
+    },
+    health: 'on_track',
+    health_color: '',
+    badges: [],
+    status_reason: 'ready',
+    priority: 3,
+    metric: null,
+    target_value: null,
+    require_completion_approval: false,
+    due_date: null,
+    parent_goal_id: null,
+    convergence: 0,
+    convergence_pct: 0,
+    attainment: {
+      state: 'unmeasured',
+      basis: 'unmeasured',
+      metric: null,
+      target_value: null,
+      target_parse_status: 'absent',
+      unit: 'unknown',
+      observed_value: null,
+      target_numeric: null,
+      attainment_pct: null,
+      task_done_count: 0,
+      task_count: 0,
+      note: '',
+    },
+    tasks: [],
+    task_count: 0,
+    task_done_count: 0,
+    verification_summary: {
+      effective_policy: null,
+      open_request: null,
+      latest_request: null,
+      approve_count: 0,
+      reject_count: 0,
+      remaining_possible: 0,
+    },
+    pending_verification_count: 0,
+    timeline_events: [],
+    children,
+    child_count: children.length,
+    last_activity_at: '2026-05-25T00:00:00Z',
+    stagnation_seconds: 0,
+    activity_observation: 'goal_metadata',
+    stagnation_status: 'recent',
+    linked_keeper_names: [],
+    pending_approval_count: 0,
+    infra_risk_count: 0,
+    linkage_source: 'explicit',
+    linkage_warning_count: 0,
+    blocking_source: 'none',
+    blocking_reason: '',
+    created_at: '2026-05-25T00:00:00Z',
+    updated_at: '2026-05-25T00:00:00Z',
+  }
+}
+
+describe('GoalTree', () => {
+  beforeEach(() => {
+    mocks.route.value = {
+      tab: 'workspace',
+      params: { section: 'planning' },
+      postId: null,
+    }
+    mocks.coordinationFsmSnapshot.value = null
+    hydrateGoalTreeSnapshot({ tree: [], summary: emptySummary() })
+  })
+
+  afterEach(() => {
+    cleanup()
+    mocks.fetchDashboardGoalDetail.mockReset()
+    mocks.fetchDashboardGoalsTree.mockReset()
+  })
+
+  it('selects and expands the goal from the planning route focus', async () => {
+    const child = makeGoal('goal-child', 'Child goal')
+    const parent = makeGoal('goal-parent', 'Parent goal', [child])
+    const treePayload: DashboardGoalsTreeResponse = {
+      tree: [parent],
+      summary: { ...emptySummary(), total_goals: 2, active_goals: 2 },
+    }
+    const detailPayload: DashboardGoalDetailResponse = {
+      goal: child,
+      linked_tasks: [],
+      linked_keepers: [],
+      approvals: [],
+      execution_receipts: [],
+      timeline: [],
+    }
+    mocks.route.value = {
+      tab: 'workspace',
+      params: { section: 'planning', goal: 'goal-child' },
+      postId: null,
+    }
+    mocks.fetchDashboardGoalsTree.mockResolvedValue(treePayload)
+    mocks.fetchDashboardGoalDetail.mockResolvedValue(detailPayload)
+
+    render(html`<${GoalTree} />`)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('goal-detail-panel').getAttribute('data-selected-goal-id'))
+        .toBe('goal-child')
+    })
+    expect(screen.getAllByText('Child goal').length).toBeGreaterThan(0)
+    await waitFor(() => {
+      expect(mocks.fetchDashboardGoalDetail).toHaveBeenCalledWith('goal-child')
+    })
+  })
+})

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -5,6 +5,7 @@ import { signal } from '@preact/signals'
 import { useEffect, useMemo } from 'preact/hooks'
 import { SECONDS_PER_HOUR } from '../../lib/format-time'
 import { fetchDashboardGoalDetail, fetchDashboardGoalsTree } from '../../api/dashboard'
+import { route } from '../../router'
 import {
   goalTreeData as treeData,
   goalTreeError as treeError,
@@ -490,6 +491,20 @@ function toggleNode(id: string) {
 
 function selectGoal(id: string) {
   selectedGoalId.value = id
+}
+
+function cleanRouteGoalId(value: string | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed && trimmed.length > 0 ? trimmed : null
+}
+
+function goalExpansionPath(nodes: readonly GoalTreeNode[], goalId: string): string[] | null {
+  for (const node of nodes) {
+    if (node.id === goalId) return [node.id]
+    const childPath = goalExpansionPath(node.children, goalId)
+    if (childPath) return [node.id, ...childPath]
+  }
+  return null
 }
 
 function expandAll(nodes: GoalTreeNode[]) {
@@ -1247,7 +1262,12 @@ function GoalDetailPanel({
   const verificationSummary = selectedNode.verification_summary ?? EMPTY_GOAL_VERIFICATION_SUMMARY
 
   return html`
-    <section class=${`${GOAL_PANEL} flex flex-col gap-4`} aria-label="목표 상세">
+    <section
+      class=${`${GOAL_PANEL} flex flex-col gap-4`}
+      aria-label="목표 상세"
+      data-testid="goal-detail-panel"
+      data-selected-goal-id=${selectedNode.id}
+    >
       <div class="flex flex-wrap items-start justify-between gap-3">
         <div class="max-w-150">
           <div class="text-2xs font-semibold uppercase tracking-[var(--track-label)] text-text-muted">목표 상세</div>
@@ -1461,6 +1481,7 @@ export function GoalTree() {
   const query = filterQuery.value
   const activePhaseFilter = treePhaseFilter.value
   const selectedId = selectedGoalId.value
+  const routeGoalId = cleanRouteGoalId(route.value.params.goal)
 
   const visibleTree = useMemo(
     () => {
@@ -1495,11 +1516,21 @@ export function GoalTree() {
       selectedGoalId.value = null
       return
     }
+    if (routeGoalId) {
+      const expansionPath = goalExpansionPath(data.tree, routeGoalId)
+      if (expansionPath && visibleNodes.some(node => node.id === routeGoalId)) {
+        if (selectedGoalId.value !== routeGoalId) selectedGoalId.value = routeGoalId
+        if (expansionPath.some(id => !expandedNodes.value.has(id))) {
+          expandedNodes.value = new Set([...expandedNodes.value, ...expansionPath])
+        }
+        return
+      }
+    }
     if (!selectedGoalId.value || !visibleNodes.some(node => node.id === selectedGoalId.value)) {
       selectedGoalId.value = visibleNodes[0]!.id
       expandedNodes.value = new Set([visibleNodes[0]!.id])
     }
-  }, [allNodes, data, visibleNodes])
+  }, [allNodes, data, routeGoalId, visibleNodes])
 
   useEffect(() => {
     if (!selectedId) {


### PR DESCRIPTION
## Summary
- surface the `goal_id` and structured task link field returned by `masc_goal_upsert` in the Goal Loop create flow
- refresh the Goal Tree snapshot after goal creation and add an Open action into the Goal Manager route focus
- make GoalTree honor `?goal=<id>` route focus, including nested-goal expansion

## Validation
- `pnpm exec vitest run --config vitest.config.ts src/components/goal-loop-panel.test.ts src/components/goals/goal-tree.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/goal-loop-panel.ts src/components/goal-loop-panel.test.ts src/components/goals/goal-tree.ts src/components/goals/goal-tree.test.ts`
- `pnpm exec tsc --noEmit --pretty`
- `git diff --check HEAD~1..HEAD`

## Notes
- Browser plugin was not available in this session. The local `playwright` CLI only exposes open/screenshot commands, not the test runner, so the interactive route was covered with rendered Testing Library tests instead.