### PR TITLE
docs: add keeper tool boundary matrix ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,9 +349,10 @@ jobs:
       - name: Check doc truth
         if: needs.changes.outputs.doc_truth == 'true'
         run: |
-          chmod +x scripts/check-doc-truth.sh scripts/sync-oas-pin-docs.sh
+          chmod +x scripts/check-doc-truth.sh scripts/sync-oas-pin-docs.sh scripts/audit-keeper-tool-boundary-matrix.sh
           scripts/check-doc-truth.sh
           scripts/sync-oas-pin-docs.sh --check
+          scripts/audit-keeper-tool-boundary-matrix.sh
 
       - name: Check OAS pin consistency
         if: needs.changes.outputs.oas_pin == 'true'
@@ -969,6 +970,9 @@ jobs:
 
       - name: Run OAS boundary ratchet
         run: scripts/oas-boundary-ratchet.sh
+
+      - name: Run keeper tool boundary matrix ratchet
+        run: scripts/audit-keeper-tool-boundary-matrix.sh
 
       - name: Run silent-failure ratchet
         run: scripts/silent-failure-ratchet.sh

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -1,0 +1,221 @@
+# Keeper Tool Boundary Matrix
+
+Status: P0 ratchet source for keeper agent tool boundaries.
+Last updated: 2026-05-25.
+
+This matrix freezes the owner map for keeper modules that participate in the
+agent tool path. A new file in scope must be added here with exactly one owner
+category before it can land.
+
+Audit command:
+
+```bash
+scripts/audit-keeper-tool-boundary-matrix.sh
+```
+
+Scope:
+
+```text
+^lib/keeper/keeper_(gh|hooks|sandbox|exec|shell|tool|tools)[^/]*\.mli?$
+```
+
+## Owner Categories
+
+| Owner | Responsibility | Must not own |
+| --- | --- | --- |
+| `execution-dispatch` | Keeper-side command, board, status, task, persona, memory, and receipt execution dispatch. | Tool name policy, sandbox runtime mechanics, GitHub transport details. |
+| `github-runtime` | GitHub environment, repository, runner, and shared GitHub runtime helpers. | Generic keeper execution dispatch or tool policy. |
+| `hook-observation` | OAS hook event parsing, metrics, and observational adapters. | OAS tool handler execution or keeper runtime dispatch. |
+| `oas-tool-bridge` | Keeper tool bridge for OAS bundle, handler, telemetry, JSON, markers, workflow, and deterministic errors. | Generic tool policy or non-OAS hook observation. |
+| `sandbox-runtime` | Sandbox containment, Docker runtime, read/session runners, executor, and shell IR target plumbing. | Tool naming policy or GitHub runtime. |
+| `shell-surface` | Shell command parsing, typed bash input, shell ops, path, readonly policy, runtime paths, and timeout semantics. | Sandbox runtime or keeper tool registry/policy. |
+| `tool-surface-policy` | Keeper tool aliasing, boundary, disclosure, diversity, emission, registry, policy, resolution, and tool-specific policy records. | OAS bridge implementation, shell parsing, sandbox execution. |
+
+## Coverage Manifest
+
+Each path below must appear exactly once and use one owner from the table above.
+
+- `lib/keeper/keeper_exec_board.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_board.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_context.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_context.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_fs.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_fs.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_ide.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_ide.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_masc.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_masc.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_memory.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_memory.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_persona.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_persona.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_preflight.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_preflight.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_shared.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_shared.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_shell.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_shell.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_status_metrics.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_status_metrics.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_status.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_status.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_task.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_task.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_tools.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_tools.mli` - execution-dispatch
+- `lib/keeper/keeper_exec_voice.ml` - execution-dispatch
+- `lib/keeper/keeper_exec_voice.mli` - execution-dispatch
+- `lib/keeper/keeper_execution_receipt_failure_site.ml` - execution-dispatch
+- `lib/keeper/keeper_execution_receipt_failure_site.mli` - execution-dispatch
+- `lib/keeper/keeper_execution_receipt_outcome_kind.ml` - execution-dispatch
+- `lib/keeper/keeper_execution_receipt_outcome_kind.mli` - execution-dispatch
+- `lib/keeper/keeper_execution_receipt.ml` - execution-dispatch
+- `lib/keeper/keeper_execution_receipt.mli` - execution-dispatch
+- `lib/keeper/keeper_execution.ml` - execution-dispatch
+- `lib/keeper/keeper_execution.mli` - execution-dispatch
+- `lib/keeper/keeper_gh_env.ml` - github-runtime
+- `lib/keeper/keeper_gh_env.mli` - github-runtime
+- `lib/keeper/keeper_gh_repo.ml` - github-runtime
+- `lib/keeper/keeper_gh_repo.mli` - github-runtime
+- `lib/keeper/keeper_gh_runner.ml` - github-runtime
+- `lib/keeper/keeper_gh_runner.mli` - github-runtime
+- `lib/keeper/keeper_gh_shared.ml` - github-runtime
+- `lib/keeper/keeper_gh_shared.mli` - github-runtime
+- `lib/keeper/keeper_hooks_oas_cost_events.ml` - hook-observation
+- `lib/keeper/keeper_hooks_oas_cost_events.mli` - hook-observation
+- `lib/keeper/keeper_hooks_oas_gate_attempt.ml` - hook-observation
+- `lib/keeper/keeper_hooks_oas_gate_attempt.mli` - hook-observation
+- `lib/keeper/keeper_hooks_oas_idle.ml` - hook-observation
+- `lib/keeper/keeper_hooks_oas_idle.mli` - hook-observation
+- `lib/keeper/keeper_hooks_oas_introspection.ml` - hook-observation
+- `lib/keeper/keeper_hooks_oas_introspection.mli` - hook-observation
+- `lib/keeper/keeper_hooks_oas_output_json.ml` - hook-observation
+- `lib/keeper/keeper_hooks_oas_output_json.mli` - hook-observation
+- `lib/keeper/keeper_hooks_oas_pr_metrics.ml` - hook-observation
+- `lib/keeper/keeper_hooks_oas_pr_metrics.mli` - hook-observation
+- `lib/keeper/keeper_hooks_oas_response_metrics.ml` - hook-observation
+- `lib/keeper/keeper_hooks_oas_response_metrics.mli` - hook-observation
+- `lib/keeper/keeper_hooks_oas_types.ml` - hook-observation
+- `lib/keeper/keeper_hooks_oas_types.mli` - hook-observation
+- `lib/keeper/keeper_hooks_oas.ml` - hook-observation
+- `lib/keeper/keeper_hooks_oas.mli` - hook-observation
+- `lib/keeper/keeper_sandbox_containment.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_containment.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_control.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_control.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_docker_container_name.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_docker_container_name.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_docker_nested_runtime.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_docker_nested_runtime.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_docker_semantic.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_docker_semantic.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_docker_worktree_gitdir.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_docker_worktree_gitdir.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_docker.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_docker.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_exec_failure.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_exec_failure.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_executor.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_executor.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_factory.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_factory.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_oneshot_plan.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_oneshot_plan.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_read_backend.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_read_backend.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_read_runner.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_read_runner.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_runner.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_runner.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_runtime_classify.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_runtime_classify.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_runtime.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_runtime.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_session_executor.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_session_executor.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_session_plan.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_session_plan.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_shell_ir_target.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_shell_ir_target.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox.mli` - sandbox-runtime
+- `lib/keeper/keeper_shell_bash_typed_input.ml` - shell-surface
+- `lib/keeper/keeper_shell_bash_typed_input.mli` - shell-surface
+- `lib/keeper/keeper_shell_bash.ml` - shell-surface
+- `lib/keeper/keeper_shell_bash.mli` - shell-surface
+- `lib/keeper/keeper_shell_command_parse.ml` - shell-surface
+- `lib/keeper/keeper_shell_command_parse.mli` - shell-surface
+- `lib/keeper/keeper_shell_command_semantics.ml` - shell-surface
+- `lib/keeper/keeper_shell_command_semantics.mli` - shell-surface
+- `lib/keeper/keeper_shell_command_words.ml` - shell-surface
+- `lib/keeper/keeper_shell_command_words.mli` - shell-surface
+- `lib/keeper/keeper_shell_ir.ml` - shell-surface
+- `lib/keeper/keeper_shell_ir.mli` - shell-surface
+- `lib/keeper/keeper_shell_op.ml` - shell-surface
+- `lib/keeper/keeper_shell_op.mli` - shell-surface
+- `lib/keeper/keeper_shell_ops.ml` - shell-surface
+- `lib/keeper/keeper_shell_ops.mli` - shell-surface
+- `lib/keeper/keeper_shell_path.ml` - shell-surface
+- `lib/keeper/keeper_shell_path.mli` - shell-surface
+- `lib/keeper/keeper_shell_readonly_policy.ml` - shell-surface
+- `lib/keeper/keeper_shell_readonly_policy.mli` - shell-surface
+- `lib/keeper/keeper_shell_runtime_paths.ml` - shell-surface
+- `lib/keeper/keeper_shell_runtime_paths.mli` - shell-surface
+- `lib/keeper/keeper_shell_timeout.ml` - shell-surface
+- `lib/keeper/keeper_shell_timeout.mli` - shell-surface
+- `lib/keeper/keeper_tool_affinity.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_affinity.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_alias.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_alias.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_bash_input.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_bash_input.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_boundary.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_boundary.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_deterministic_error.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_deterministic_error.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_disclosure_completion_contract.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_disclosure_completion_contract.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_disclosure.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_disclosure.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_diversity.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_diversity.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_emission_hook.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_emission_hook.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_github_pr.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_github_pr.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_guidance.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_guidance.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_name_projection.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_name_projection.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_outcome.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_outcome.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_policy_config.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_policy_config.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_policy_failure_site.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_policy_failure_site.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_policy.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_policy.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_pr_review.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_pr_review.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_registry.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_registry.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_resolution.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_resolution.mli` - tool-surface-policy
+- `lib/keeper/keeper_tools_oas_bundle.ml` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_bundle.mli` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_deterministic_error.ml` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_deterministic_error.mli` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_handler_exec.ml` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_handler_exec.mli` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_handler_telemetry.ml` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_handler_telemetry.mli` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_handler.ml` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_handler.mli` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_json.ml` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_json.mli` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_markers.ml` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_markers.mli` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_workflow.ml` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_workflow.mli` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas.ml` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas.mli` - oas-tool-bridge

--- a/scripts/audit-keeper-tool-boundary-matrix.sh
+++ b/scripts/audit-keeper-tool-boundary-matrix.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Keeper agent tool boundary matrix audit.
+#
+# The matrix is intentionally file-granular. If a scoped keeper module appears
+# without an owner, the tool boundary can drift silently across execution,
+# sandbox, shell, GitHub, hook, and OAS bridge surfaces.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MATRIX_FILE="${REPO_ROOT}/docs/design/keeper-tool-boundary-matrix.md"
+
+for tool in python3; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "[keeper-tool-boundary-matrix] required tool missing: $tool" >&2
+    exit 1
+  }
+done
+
+python3 - "$REPO_ROOT" "$MATRIX_FILE" <<'PYEOF'
+from __future__ import annotations
+
+import collections
+import pathlib
+import re
+import sys
+
+
+repo_root = pathlib.Path(sys.argv[1])
+matrix_file = pathlib.Path(sys.argv[2])
+
+scope_re = re.compile(
+    r"^lib/keeper/keeper_(?:gh|hooks|sandbox|exec|shell|tool|tools)[^/]*\.mli?$"
+)
+manifest_re = re.compile(
+    r"^\s*-\s+`(?P<path>lib/keeper/[^`]+)`\s+-\s+(?P<owner>[a-z][a-z0-9-]*)\s*$"
+)
+owners = {
+    "execution-dispatch",
+    "github-runtime",
+    "hook-observation",
+    "oas-tool-bridge",
+    "sandbox-runtime",
+    "shell-surface",
+    "tool-surface-policy",
+}
+
+if not matrix_file.is_file():
+    print(
+        f"[keeper-tool-boundary-matrix] missing matrix: {matrix_file.relative_to(repo_root)}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+source_paths: set[str] = set()
+keeper_dir = repo_root / "lib" / "keeper"
+for path in keeper_dir.iterdir():
+    if not path.is_file():
+        continue
+    rel = path.relative_to(repo_root).as_posix()
+    if scope_re.match(rel):
+        source_paths.add(rel)
+
+records: dict[str, list[tuple[int, str]]] = collections.defaultdict(list)
+with matrix_file.open(encoding="utf-8") as handle:
+    for line_no, line in enumerate(handle, start=1):
+        match = manifest_re.match(line)
+        if match is None:
+            continue
+        records[match.group("path")].append((line_no, match.group("owner")))
+
+listed_paths = set(records)
+missing = sorted(source_paths - listed_paths)
+stale = sorted(path for path in listed_paths if path not in source_paths)
+duplicate = sorted(path for path, entries in records.items() if len(entries) != 1)
+invalid_owner = sorted(
+    (path, line_no, owner)
+    for path, entries in records.items()
+    for line_no, owner in entries
+    if owner not in owners
+)
+invalid_scope = sorted(path for path in listed_paths if not scope_re.match(path))
+
+errors = []
+if missing:
+    errors.append("missing source paths")
+if stale:
+    errors.append("stale matrix paths")
+if duplicate:
+    errors.append("duplicate matrix entries")
+if invalid_owner:
+    errors.append("invalid owner categories")
+if invalid_scope:
+    errors.append("out-of-scope manifest paths")
+
+if errors:
+    print(
+        "[keeper-tool-boundary-matrix] FAIL - " + ", ".join(errors),
+        file=sys.stderr,
+    )
+    if missing:
+        print("\nMissing source paths:", file=sys.stderr)
+        for path in missing:
+            print(f"  - {path}", file=sys.stderr)
+    if stale:
+        print("\nStale matrix paths:", file=sys.stderr)
+        for path in stale:
+            print(f"  - {path}", file=sys.stderr)
+    if duplicate:
+        print("\nDuplicate matrix entries:", file=sys.stderr)
+        for path in duplicate:
+            lines = ", ".join(str(line_no) for line_no, _owner in records[path])
+            print(f"  - {path} (lines {lines})", file=sys.stderr)
+    if invalid_owner:
+        print("\nInvalid owner categories:", file=sys.stderr)
+        for path, line_no, owner in invalid_owner:
+            print(f"  - line {line_no}: {path} -> {owner}", file=sys.stderr)
+    if invalid_scope:
+        print("\nOut-of-scope manifest paths:", file=sys.stderr)
+        for path in invalid_scope:
+            print(f"  - {path}", file=sys.stderr)
+    sys.exit(2)
+
+print(
+    "[keeper-tool-boundary-matrix] OK - "
+    f"{len(source_paths)} scoped keeper files covered by "
+    f"{matrix_file.relative_to(repo_root)}"
+)
+PYEOF


### PR DESCRIPTION
## Summary
- add a keeper tool boundary matrix for scoped lib/keeper modules
- add scripts/audit-keeper-tool-boundary-matrix.sh to fail on missing, stale, duplicate, out-of-scope, or invalid-owner entries
- wire the audit into doc truth and structure-ratchet CI lanes

## Verification
- scripts/audit-keeper-tool-boundary-matrix.sh
- bash -n scripts/audit-keeper-tool-boundary-matrix.sh
- git diff --check
- git diff --cached --check
- scripts/sync-oas-pin-docs.sh --check
- bash scripts/check-doc-truth.sh