### PR TITLE
refactor(operator): drop compat result facades

### DIFF
--- a/dashboard/src/api/schemas/operator-action.test.ts
+++ b/dashboard/src/api/schemas/operator-action.test.ts
@@ -36,14 +36,6 @@ describe('parseOperatorActionResult', () => {
     expect(out.executed_action).toBe('keeper_message')
   })
 
-  it('accepts the deprecated delegated_tool_result field', () => {
-    const out = parseOperatorActionResult({
-      status: 'executed',
-      delegated_tool_result: { legacy: true },
-    })
-    expect(out.delegated_tool_result).toEqual({ legacy: true })
-  })
-
   it('throws when status is missing', () => {
     expect(() => parseOperatorActionResult({})).toThrow(OperatorActionSchemaDriftError)
   })

--- a/dashboard/src/api/schemas/operator-action.ts
+++ b/dashboard/src/api/schemas/operator-action.ts
@@ -3,7 +3,7 @@
 //
 // `status` is the only always-present field (backend contract).
 // `confirm_required` / `confirm_token` drive the two-step confirm
-// flow. `preview`, `result`, `executed_action`, `delegated_tool_result`
+// flow. `preview`, `result`, and `executed_action`
 // are truly opaque — callers render them via JSON pretty-print without
 // branching on shape, so they stay as `unknown()`.
 //
@@ -28,8 +28,6 @@ const OperatorActionResultSchema = object({
   preview: optional(unknown()),
   tool_name: optional(string()),
   result: optional(unknown()),
-  /** @deprecated use `result`. Kept for backward compat during migration. */
-  delegated_tool_result: optional(unknown()),
   executed_action: optional(unknown()),
 })
 

--- a/dashboard/src/operator-actions.ts
+++ b/dashboard/src/operator-actions.ts
@@ -64,7 +64,6 @@ function logMessageFromResult(result: OperatorActionResult): string {
     return stringifyUnknown(result.preview) || '확인 필요'
   }
   return stringifyUnknown(result.result)
-    || stringifyUnknown(result.delegated_tool_result)
     || stringifyUnknown(result.executed_action)
     || result.status
 }

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -661,7 +661,7 @@ let action_json ?actor_hint (ctx : _ context) args :
         created_at = Masc_domain.now_iso ();
       };
     Ok
-      (json_ok
+      (Tool_args.ok_assoc
          [
            ("trace_id", `String trace_id);
            ("confirm_required", `Bool true);
@@ -689,7 +689,7 @@ let action_json ?actor_hint (ctx : _ context) args :
         created_at = Masc_domain.now_iso ();
       };
     Ok
-      (json_ok
+      (Tool_args.ok_assoc
          [
            ("trace_id", `String trace_id);
            ("confirm_required", `Bool false);
@@ -781,7 +781,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
               ~decision:Audit_log.Governance_deny ~action_type:entry.action_type
               ~confirmation_state:(confirmation_state_to_string Denied) ();
             Ok
-              (json_ok
+              (Tool_args.ok_assoc
                  [
                    ("trace_id", `String entry.trace_id);
                    ("decision", `String "deny");
@@ -822,13 +822,11 @@ let confirm_json ?actor_hint (ctx : _ context) args :
               ~decision:Audit_log.Governance_confirm ~action_type:entry.action_type
               ~confirmation_state:(confirmation_state_to_string Confirmed) ();
             Ok
-              (json_ok
+              (Tool_args.ok_assoc
                  [
                    ("trace_id", `String entry.trace_id);
                    ("decision", `String "confirm");
                    ("tool_name", `String entry.delegated_tool);
                    ("result", executed);
                    ("executed_action", pending_confirm_to_yojson entry);
-                   (* backward compat — remove after dashboard migration *)
-                   ("delegated_tool_result", executed);
                  ]))

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -16,8 +16,6 @@ let degraded_keeper_runtime_identity_fields = Operator_control_snapshot_identity
    [Operator_control_action] in the existing include chain. *)
 include Operator_control_snapshot_action_log
 
-let json_ok = Tool_args.ok_assoc
-
 let get_payload args =
   match U.member "payload" args with
   | `Assoc _ as payload -> payload

--- a/lib/operator/operator_control_snapshot.mli
+++ b/lib/operator/operator_control_snapshot.mli
@@ -39,7 +39,7 @@
     [keeper_context_snapshot_fields],
     [action_result_status] / [confirmation_state] /
     [action_log_entry] types and their stringifiers,
-    [json_ok], [action_log_path],
+    [action_log_path],
     [remote_confirm_ttl_seconds],
     [runtime_status_from_live_signal],
     [health_state_allows_runtime_status_override],
@@ -192,12 +192,6 @@ val append_action_log :
 (** Appends [entry] to the operator action log JSONL.
     Pinned because {!Operator_control} reaches it via the
     cascade-include of this module. *)
-
-val json_ok : (string * Yojson.Safe.t) list -> Yojson.Safe.t
-(** Alias for {!Tool_args.ok_assoc}.  Kept here because
-    {!Operator_control} consumes it via the cascade-include of this
-    module; new code in [lib/operator/] should call
-    {!Tool_args.ok_assoc} directly. *)
 
 val remote_client_type_of_context : 'a context -> string
 (** Classifies the [mcp_session_id] of an operator


### PR DESCRIPTION
## Summary
- delete Operator_control_snapshot.json_ok from the public snapshot facade
- move Operator_control call sites to Tool_args.ok_assoc directly
- stop emitting the deprecated delegated_tool_result confirm-response key
- remove dashboard schema/type/display fallback support and the deprecated-field preservation test

## Verification
- ocamlformat --check lib/operator/operator_control.ml lib/operator/operator_control_snapshot.ml lib/operator/operator_control_snapshot.mli
- ocamlc -stop-after parsing lib/operator/operator_control.ml && ocamlc -stop-after parsing lib/operator/operator_control_snapshot.ml && ocamlc -stop-after parsing lib/operator/operator_control_snapshot.mli
- rg -n 'delegated_tool_result|backward compat — remove after dashboard migration|Operator_control_snapshot\.json_ok|\bjson_ok\b' lib/operator dashboard/src/api/schemas/operator-action.ts dashboard/src/api/schemas/operator-action.test.ts dashboard/src/operator-actions.ts  # no matches
- git diff --check
- pnpm install --offline --frozen-lockfile  # dashboard deps only, reused local store
- pnpm exec tsc --noEmit --pretty false
- pnpm exec vitest run --config vitest.config.ts src/api/schemas/operator-action.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec eslint src/api/schemas/operator-action.ts src/api/schemas/operator-action.test.ts src/operator-actions.ts  # 0 errors; existing ignored-file warnings when direct paths are used
- scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

Focused Dune gap: scripts/dune-local.sh build lib/masc_mcp.cmxa returned exit 75 because machine-wide bare Dune processes are active; I did not bypass the guard.