### PR TITLE
refactor: SSOT consolidation — functor unification + starts_with elimination

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -5,7 +5,7 @@ include Activity_graph_types
 include Activity_graph_registry
 include Activity_graph_reducer
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (* ================================================================ *)
 (* File storage paths                                               *)

--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -36,7 +36,7 @@ module Random = Stdlib.Random
    every RNG access through [with_identity_rng].  Same discipline
    used by [Lib.A2a_tools] ([a2a_rng] / [a2a_rng_mutex]). *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 let identity_rng = Random.State.make_self_init ()
 let identity_rng_mutex = Eio.Mutex.create ()

--- a/lib/agent_registry_eio.ml
+++ b/lib/agent_registry_eio.ml
@@ -35,7 +35,7 @@ module Random = Stdlib.Random
     @since 0.5.0
 *)
 
-module SMap = Map.Make(String)
+module SMap = Set_util.StringMap
 
 (** {1 Actor State} *)
 

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -25,7 +25,7 @@ module Random = Stdlib.Random
 
 open Masc_domain
 
-module SS = Set.Make (String)
+module SS = Set_util.StringSet
 
 
 let dedupe_schemas (schemas : Masc_domain.tool_schema list) =

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -10,7 +10,7 @@
     @since 0.6.0 - MASC Social v4 Tier 1
 *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** {1 Types} *)
 

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -367,7 +367,6 @@ module FileSystem = struct
     )
 
   (** List keys with prefix *)
-  let starts_with ~prefix value = String.starts_with ~prefix value
 
 
   let rec collect_keys_under ~requested_prefix ~logical_prefix path acc =
@@ -385,7 +384,7 @@ module FileSystem = struct
     | `Regular_file ->
         if (not (is_atomic_tmp_key logical_prefix))
            && (requested_prefix = ""
-               || starts_with ~prefix:requested_prefix logical_prefix)
+               || String.starts_with ~prefix:requested_prefix logical_prefix)
         then
           logical_prefix :: acc
         else

--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -7,8 +7,8 @@
 
 open Masc_domain
 
-module StringSet = Set.Make (String)
-module StringMap = Map.Make (String)
+module StringSet = Set_util.StringSet
+module StringMap = Set_util.StringMap
 
 type risk_class =
   | Safe

--- a/lib/cascade/cascade_observation.ml
+++ b/lib/cascade/cascade_observation.ml
@@ -45,7 +45,7 @@ and cascade_fallback_event = {
   reason : string;
 }
 
-module StringMap = Map.Make(String)
+module StringMap = Set_util.StringMap
 
 (* RFC-0132 PR-2: cascade observation OAS/dashboard surface = external boundary; redact via SSOT. *)
 let public_runtime_model_label =

--- a/lib/cascade/cascade_state.ml
+++ b/lib/cascade/cascade_state.ml
@@ -2,7 +2,7 @@
 
 (* ── Round-robin ────────────────────────────────────────────────── *)
 
-module String_map = Map.Make (String)
+module String_map = Set_util.StringMap
 
 let rr_table : int Atomic.t String_map.t Atomic.t =
   Atomic.make String_map.empty

--- a/lib/cascade/cascade_throttle.ml
+++ b/lib/cascade/cascade_throttle.ml
@@ -13,7 +13,7 @@
     @since 0.92.0 extracted from Cascade_config
     @since 0.93.2 lock-free reads (Eio.Mutex → Atomic+immutable Map) *)
 
-module String_map = Map.Make (String)
+module String_map = Set_util.StringMap
 
 let throttle_table :
   Llm_provider.Provider_throttle.t String_map.t Atomic.t =

--- a/lib/cascade/cascade_transport_json_stream_cli_local.ml
+++ b/lib/cascade/cascade_transport_json_stream_cli_local.ml
@@ -313,8 +313,6 @@ let emit_blocks ~on_event ~start_index blocks =
     blocks
 ;;
 
-let starts_with text prefix = String.starts_with ~prefix text
-
 let resumable_session_detail =
   "CLI JSON-stream transport reported a resumable session. Resumable session \
    available via -r."

--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -8,7 +8,7 @@ type issue = {
   message : string;
 }
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 
 let has_suffix ~suffix s =

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -414,10 +414,6 @@ let model_spec_for_api_name (cfg : cascade_config) (model_id : string)
      - Ties on length resolve to the first-declared entry (List.fold_left
        keeps the earlier-seen winner unless a strictly-longer match arrives).
      - Returns None if no entry matches. *)
-  let starts_with ~prefix s =
-    let plen = String.length prefix in
-    String.length s >= plen && String.sub s 0 plen = prefix
-  in
   let best_match =
     List.fold_left
       (fun acc (m : cascade_model_spec) ->
@@ -428,7 +424,7 @@ let model_spec_for_api_name (cfg : cascade_config) (model_id : string)
          let prefix_candidates =
            List.filter_map
              (fun p ->
-                if starts_with ~prefix:p model_id then Some (String.length p, m) else None)
+                if String.starts_with ~prefix:p model_id then Some (String.length p, m) else None)
              m.match_prefixes
          in
          let candidates =

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -1,6 +1,6 @@
 (** Tool schema registry and visibility helpers. *)
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 let dedupe_schemas (schemas : Masc_domain.tool_schema list) =
   let unique, _ =

--- a/lib/config/config_boot_overrides.ml
+++ b/lib/config/config_boot_overrides.ml
@@ -9,7 +9,7 @@
     - hardcoded default
 *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 let table : string StringMap.t Atomic.t = Atomic.make StringMap.empty
 

--- a/lib/config/keeper_sandbox_config.ml
+++ b/lib/config/keeper_sandbox_config.ml
@@ -91,12 +91,7 @@ let container_root_of_agent ~agent_name =
     Env_config_keeper.DockerPlayground.container_playground_root
     (Playground_paths.sanitize_keeper_name agent_name)
 
-let strip_trailing_slashes path =
-  let rec loop i =
-    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
-  in
-  let len = loop (String.length path) in
-  if len = String.length path then path else String.sub path 0 len
+let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 
 let suffix_under ~prefix path =
   let prefix = strip_trailing_slashes prefix in

--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -1,4 +1,4 @@
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 (** SSOT for config filenames documented in [docs/TOML-RELOAD-MATRIX.md].
     Consumed by the resolver here and by config loaders elsewhere in the

--- a/lib/coord/coord_worktree_paths.ml
+++ b/lib/coord/coord_worktree_paths.ml
@@ -158,12 +158,7 @@ let repos_dir_of_keeper config agent_name =
   in
   Filename.concat config.base_path repos_rel
 
-let strip_trailing_slashes path =
-  let rec loop i =
-    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
-  in
-  let len = loop (String.length path) in
-  if len = String.length path then path else String.sub path 0 len
+let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 
 let keeper_visible_worktree_path ~config ~agent_name ~host_path =
   Keeper_sandbox_config.visible_path_of_host_path

--- a/lib/core/circuit_breaker.ml
+++ b/lib/core/circuit_breaker.ml
@@ -15,7 +15,7 @@
     @since 0.6.0 - MASC Social v4 Tier 1
 *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** {1 Types} *)
 

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -40,14 +40,6 @@ let try_with_default ~default context f =
 (** Cancel-aware Result wrapper.
     Re-raises [Eio.Cancel.Cancelled] with backtrace; captures other
     exceptions as [Error exn]. *)
-let try_catch f =
-  try Ok (f ())
-  with
-  | Eio.Cancel.Cancelled _ as e ->
-    let bt = Printexc.get_raw_backtrace () in
-    Printexc.raise_with_backtrace e bt
-  | exn -> Error exn
-
 (** Cancel-aware exception handler.
     Re-raises [Eio.Cancel.Cancelled] with backtrace; delegates other
     exceptions to [handler]. *)

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -16,10 +16,6 @@ val try_with_log : string -> (unit -> 'a) -> 'a option
 val try_with_default : default:'a -> string -> (unit -> 'a) -> 'a
 (** Execute with default value on failure. *)
 
-val try_catch : (unit -> 'a) -> ('a, exn) result
-(** Cancel-aware Result wrapper.
-    Re-raises [Eio.Cancel.Cancelled]; captures any other exception as [Error exn]. *)
-
 val handle : (unit -> 'a) -> (exn -> 'a) -> 'a
 (** Cancel-aware exception handler.
     Re-raises [Eio.Cancel.Cancelled]; delegates other exceptions to the handler. *)
@@ -205,6 +201,10 @@ val json_assoc : string -> Yojson.Safe.t -> (string * Yojson.Safe.t) list
 
 val json_member_opt : string -> Yojson.Safe.t -> Yojson.Safe.t option
 (** Extract any non-null JSON value by key. Returns [None] for [`Null] or missing key. *)
+
+val safe_member : string -> Yojson.Safe.t -> Yojson.Safe.t
+(** Extract a JSON value by key from an object. Returns [`Null] if key is
+    missing or the enclosing value is not an object. *)
 
 (** {1 Tail-recursive list helpers} *)
 

--- a/lib/core/set_util.ml
+++ b/lib/core/set_util.ml
@@ -1,3 +1,6 @@
+module StringSet = Set.Make (String)
+module StringMap = Map.Make (String)
+
 (** Hashtbl-as-set membership kernels. See [set_util.mli] for design rationale
     (Hashtbl over Set.Make: polymorphic key; [Hashtbl.t] is exposed
     concretely, so a future [Set.Make] swap would be an API change, not a

--- a/lib/core/set_util.mli
+++ b/lib/core/set_util.mli
@@ -22,3 +22,7 @@ val count_difference
   -> present:('a -> 'b option)
   -> absent:('a -> 'b option)
   -> int
+
+module StringSet : Set.S with type elt = string
+
+module StringMap : Map.S with type key = string

--- a/lib/core/text_similarity.ml
+++ b/lib/core/text_similarity.ml
@@ -1,5 +1,5 @@
-module StringSet = Set.Make (String)
-module StringMap = Map.Make (String)
+module StringSet = Set_util.StringSet
+module StringMap = Set_util.StringMap
 
 (** Text_similarity — pure text similarity functions.
 

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -25,7 +25,7 @@
     that the table still holds its [cond].  This prevents an evicted
     fiber from clobbering a replacement slot. *)
 
-module SMap = Map.Make(String)
+module SMap = Set_util.StringMap
 
 let rec atomic_update atomic f =
   let old_val = Atomic.get atomic in

--- a/lib/dashboard/dashboard_http_helpers.ml
+++ b/lib/dashboard/dashboard_http_helpers.ml
@@ -119,10 +119,7 @@ let safe_age_seconds_opt ~(now_ts : float) ~(event_ts : float) : int option =
     let bounded = max 0.0 (min delta (float_of_int max_int)) in
     Some (int_of_float bounded)
 
-let safe_member key json =
-  match json with
-  | `Assoc _ -> Yojson.Safe.Util.member key json
-  | _ -> `Null
+let safe_member = Safe_ops.safe_member
 
 (* RFC-0142 PR-4: lift the silent [| _ -> default] catch-all through
    [Json_field.{list,string,assoc} |> to_option] so a Wrong_shape

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -22,7 +22,7 @@ let tool_call_health_json ?(now_ts = Unix.gettimeofday ()) (config : Coord.confi
       []
   in
   (* Single pass: aggregate totals and per-tool failure counts. *)
-  let module SMap = Map.Make (String) in
+  let module SMap = Set_util.StringMap in
   let total, failures, per_tool =
     List.fold_left
       (fun (t, f, m) (e : Audit_log.audit_entry) ->

--- a/lib/dashboard_cascade_helpers.ml
+++ b/lib/dashboard_cascade_helpers.ml
@@ -22,7 +22,7 @@ module Float = Stdlib.Float
     [source_info] is invoked. *)
 
 module CC = Cascade_config
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 let now_iso () = Masc_domain.now_iso ()
 

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -29,7 +29,7 @@ let string_contains_ci ~needle haystack =
     (String.lowercase_ascii haystack)
 
 
-module String_set = Set.Make(String)
+module String_set = Set_util.StringSet
 
 let dedup_strings (xs : string list) : string list =
   let rec go seen acc = function

--- a/lib/drift_guard.ml
+++ b/lib/drift_guard.ml
@@ -1,5 +1,5 @@
-module StringSet = Set.Make (String)
-module StringMap = Map.Make (String)
+module StringSet = Set_util.StringSet
+module StringMap = Set_util.StringMap
 
 (** Drift Guard - truthful handoff integrity verification.
 

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -1,4 +1,4 @@
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** Eval_calibration — Verdict logging and evaluator calibration loop.
 

--- a/lib/git_graph_snapshot.ml
+++ b/lib/git_graph_snapshot.ml
@@ -133,12 +133,8 @@ let split_lines raw =
 
 let split_tab line = String.split_on_char '\t' line
 
-let starts_with ~prefix s =
-  let plen = String.length prefix in
-  String.length s >= plen && String.sub s 0 plen = prefix
-
 let strip_prefix ~prefix s =
-  if starts_with ~prefix s then
+  if String.starts_with ~prefix s then
     Some (String.sub s (String.length prefix) (String.length s - String.length prefix))
   else None
 
@@ -167,7 +163,7 @@ let normalize_ref_name name =
       | None -> name)
 
 let ref_kind name =
-  if starts_with ~prefix:"origin/" name then "remote" else "branch"
+  if String.starts_with ~prefix:"origin/" name then "remote" else "branch"
 
 let parse_ref_line line =
   match split_tab line with

--- a/lib/ide/ide_paths.ml
+++ b/lib/ide/ide_paths.ml
@@ -38,10 +38,6 @@ let partition_store_dir ~base_dir = function
    to the same bucket regardless of which transport the remote was
    registered with. *)
 
-let starts_with ~prefix s =
-  let n = String.length prefix in
-  String.length s >= n && String.sub s 0 n = prefix
-;;
 
 let strip_prefix ~prefix s =
   let n = String.length prefix in
@@ -85,7 +81,7 @@ let normalize_scp_like s =
 
 let strip_scheme s =
   let candidates = [ "https://"; "http://"; "ssh://"; "git://" ] in
-  match List.find_opt (fun p -> starts_with ~prefix:p s) candidates with
+  match List.find_opt (fun p -> String.starts_with ~prefix:p s) candidates with
   | Some p -> strip_prefix ~prefix:p s
   | None -> s
 ;;

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -1,6 +1,6 @@
 (** Tool-surface gating, selection constants, and backlog task reconciliation. *)
 
-module String_set = Set.Make (String)
+module String_set = Set_util.StringSet
 
 let unexpected_tool_partial_warned : (string, unit) Hashtbl.t =
   Hashtbl.create 32

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -149,7 +149,7 @@ let find_suffix_matches_under_root
   : string list
   =
   let root_norm = normalize_path_for_check root |> strip_trailing_slashes in
-  let module StringSet = Set.Make (String) in
+  let module StringSet = Set_util.StringSet in
   let rec walk visited ~dirs_seen acc dir =
     if dirs_seen >= max_dirs || List.length acc >= max_matches
     then visited, dirs_seen, acc

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -71,7 +71,6 @@ let project_root_of_config (config : Coord.config) : string =
   if Filename.basename base = Common.masc_dirname then Filename.dirname base else base
 ;;
 
-let starts_with ~(prefix : string) (s : string) : bool = String.starts_with ~prefix s
 let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 
 let normalize_path_for_check (path : string) : string =
@@ -136,7 +135,7 @@ let parent_exists (path : string) : bool =
 
 let is_within_root_norm ~(root_norm : string) (path : string) : bool =
   let normalized = normalize_path_for_check path |> strip_trailing_slashes in
-  normalized = root_norm || starts_with ~prefix:(root_norm ^ "/") normalized
+  normalized = root_norm || String.starts_with ~prefix:(root_norm ^ "/") normalized
 ;;
 
 let find_suffix_matches_under_root
@@ -228,7 +227,7 @@ let allows_missing_leaf_read ~(raw : string) ~(candidate : string) : bool =
 let is_within_allowed_norms ~(target_norm : string) (allowed_norms : string list) : bool =
   List.exists
     (fun allowed_norm ->
-       target_norm = allowed_norm || starts_with ~prefix:(allowed_norm ^ "/") target_norm)
+       target_norm = allowed_norm || String.starts_with ~prefix:(allowed_norm ^ "/") target_norm)
     allowed_norms
 ;;
 
@@ -285,8 +284,8 @@ let playground_root_of_allowed (allowed_norms : string list) : string option =
 ;;
 
 let raw_looks_like_playground_subdir (raw : string) : bool =
-  starts_with ~prefix:"repos/" raw
-  || starts_with ~prefix:"mind/" raw
+  String.starts_with ~prefix:"repos/" raw
+  || String.starts_with ~prefix:"mind/" raw
   || raw = "repos"
   || raw = "mind"
 ;;
@@ -306,7 +305,7 @@ let resolve_keeper_target_path
     let root_norm = normalize_path_for_check root in
     let target_norm = normalize_path_for_check candidate in
     let within_root =
-      target_norm = root_norm || starts_with ~prefix:(root_norm ^ "/") target_norm
+      target_norm = root_norm || String.starts_with ~prefix:(root_norm ^ "/") target_norm
     in
     if not within_root
     then
@@ -327,7 +326,7 @@ let resolve_keeper_target_path
         List.exists
           (fun allowed_norm ->
              target_norm = allowed_norm
-             || starts_with ~prefix:(allowed_norm ^ "/") target_norm)
+             || String.starts_with ~prefix:(allowed_norm ^ "/") target_norm)
           allowed_norms
       in
       if matches_any
@@ -431,7 +430,7 @@ let resolve_keeper_read_path
     let root_norm = normalize_path_for_check root in
     let target_norm = normalize_path_for_check candidate in
     let within_root =
-      target_norm = root_norm || starts_with ~prefix:(root_norm ^ "/") target_norm
+      target_norm = root_norm || String.starts_with ~prefix:(root_norm ^ "/") target_norm
     in
     if not within_root
     then

--- a/lib/keeper/keeper_alerting_path.mli
+++ b/lib/keeper/keeper_alerting_path.mli
@@ -24,7 +24,6 @@ val rejection_to_telemetry : keeper_path_rejection -> unit
     trailing [.masc] base-path component when present. *)
 val project_root_of_config : Coord.config -> string
 
-val starts_with : prefix:string -> string -> bool
 
 (** Re-export of [Env_config_core.strip_trailing_slashes]. *)
 val strip_trailing_slashes : string -> string

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -263,7 +263,7 @@ let approval_rule_of_yojson json =
 
 (* ── Global queue (Lock-free Atomic.t) ───────────────────── *)
 
-module SMap = Map.Make (String)
+module SMap = Set_util.StringMap
 
 let rec atomic_update atomic f =
   let old_val = Atomic.get atomic in

--- a/lib/keeper/keeper_context_core_history.ml
+++ b/lib/keeper/keeper_context_core_history.ml
@@ -2,7 +2,7 @@
 
 open Keeper_types
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 (* Note: this module is `include`d into Keeper_context_core which already
    exposes `module Message_json = Keeper_context_core_message_json`. Avoid

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -1,7 +1,7 @@
 open Keeper_types
 open Keeper_exec_shared
 open Keeper_exec_context
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 
 (* Issue #8484: Variant SSOT for memory search scope. Adding a new

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -1,6 +1,6 @@
 open Keeper_types
 open Keeper_alerting
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 let count_context_tokens (ctx : working_context) = Keeper_exec_context.token_count ctx
 

--- a/lib/keeper/keeper_hooks_oas_idle.ml
+++ b/lib/keeper/keeper_hooks_oas_idle.ml
@@ -9,7 +9,7 @@ open Keeper_hooks_oas_types
     known set. The LLM (non-deterministic) decides which to use. *)
 let suggest_alternatives ~(allowed_tools : string list)
     ~(repeated_tools : string list) ~(max_suggestions : int) : string list =
-  let module SS = Set.Make (String) in
+  let module SS = Set_util.StringSet in
   let repeated_set =
     List.fold_left (fun acc t -> SS.add t acc) SS.empty repeated_tools
   in

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -135,7 +135,7 @@ let select_memory_candidates
 (** Filter a list to unique items by a key function.
     Empty keys are skipped (treated as duplicates). *)
 let dedup_by_key (key_of : 'a -> string) (items : 'a list) : 'a list =
-  let module SS = Set.Make (String) in
+  let module SS = Set_util.StringSet in
   let rec go seen acc = function
     | [] -> List.rev acc
     | item :: rest ->

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -798,7 +798,7 @@ let recall_candidates_with_history
     let len = min 100 (String.length s) in
     String.sub s 0 len
   in
-  let module SS = Set.Make (String) in
+  let module SS = Set_util.StringSet in
   let seen =
     List.fold_left (fun acc s -> SS.add (key_of s) acc)
       SS.empty from_checkpoint

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -4,7 +4,7 @@
     See keeper_registry_types.mli for rationale and contract. *)
 
 open Keeper_types
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** Structured failure reason for cohort detection in self-preservation.
     ADT matching replaces string prefix matching for crash_msg grouping. *)

--- a/lib/keeper/keeper_run_prompt.ml
+++ b/lib/keeper/keeper_run_prompt.ml
@@ -34,16 +34,12 @@ let prompt_injection_prefixes =
     "user:";
   ]
 
-let starts_with ~prefix text =
-  let prefix_len = String.length prefix in
-  String.length text >= prefix_len && String.sub text 0 prefix_len = prefix
-
 let strip_prompt_injection_prefix line =
   let trimmed = String.trim line in
   let lower = String.lowercase_ascii trimmed in
   match
     List.find_opt
-      (fun prefix -> starts_with ~prefix lower)
+      (fun prefix -> String.starts_with ~prefix lower)
       prompt_injection_prefixes
   with
   | None -> None

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -81,7 +81,7 @@ type logical_ordering = {
   logical_seq : int option;
 }
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 type links = {
   receipt_path : string option;

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -1,6 +1,4 @@
-let json_member key = function
-  | `Assoc _ as json -> Yojson.Safe.Util.member key json
-  | _ -> `Null
+let json_member = Server_dashboard_http_json_utils.json_member
 
 let json_int_opt_member key json =
   match json_member key json with

--- a/lib/keeper/keeper_sandbox.ml
+++ b/lib/keeper/keeper_sandbox.ml
@@ -23,12 +23,7 @@ type t =
   ; task_overlay_pattern : string
   }
 
-let strip_trailing_slashes path =
-  let rec loop i =
-    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
-  in
-  let len = loop (String.length path) in
-  if len = String.length path then path else String.sub path 0 len
+let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 
 let backend_of_profile = function
   | Keeper_types.Local -> Local

--- a/lib/keeper/keeper_sandbox_containment.ml
+++ b/lib/keeper/keeper_sandbox_containment.ml
@@ -3,8 +3,6 @@
 let normalize p =
   Keeper_alerting_path.normalize_path_for_check_stripped p
 
-let starts_with ~prefix s = String.starts_with ~prefix s
-
 (** Build the absolute, normalized playground bundle root for [meta]
     under [config.base_path]. *)
 let playground_root_abs ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) =
@@ -12,7 +10,7 @@ let playground_root_abs ~(config : Coord.config) ~(meta : Keeper_types.keeper_me
 
 let target_is_inside_playground ~playground ~target =
   let playground = playground in
-  target = playground || starts_with ~prefix:(playground ^ "/") target
+  target = playground || String.starts_with ~prefix:(playground ^ "/") target
 
 let is_hardened_profile = function
   | Keeper_types.Docker -> true

--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -22,12 +22,7 @@ let create ?default_network_override
 let with_lock (t : t) f =
   Eio.Mutex.use_rw ~protect:true t.mutex f
 
-let strip_trailing_slashes path =
-  let rec loop i =
-    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
-  in
-  let len = loop (String.length path) in
-  if len = String.length path then path else String.sub path 0 len
+let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 
 let normalize p =
   Keeper_alerting_path.normalize_path_for_check p

--- a/lib/keeper/keeper_sandbox_read_backend.ml
+++ b/lib/keeper/keeper_sandbox_read_backend.ml
@@ -16,12 +16,7 @@ let is_hardened = function
 let should_route_read ~(meta : keeper_meta) : bool =
   is_hardened meta.sandbox_profile
 
-let strip_trailing_slashes path =
-  let rec loop i =
-    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
-  in
-  let len = loop (String.length path) in
-  if len = String.length path then path else String.sub path 0 len
+let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 
 let host_playground_root ~config ~(meta : keeper_meta) =
   Keeper_sandbox.host_root_abs_of_meta ~config meta

--- a/lib/keeper/keeper_sandbox_runner.ml
+++ b/lib/keeper/keeper_sandbox_runner.ml
@@ -159,12 +159,7 @@ end
 
 include Make (Docker_backend)
 
-let strip_trailing_slashes path =
-  let rec loop i =
-    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
-  in
-  let len = loop (String.length path) in
-  if len = String.length path then path else String.sub path 0 len
+let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 
 let normalize p =
   Keeper_alerting_path.normalize_path_for_check p

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -204,11 +204,7 @@ let sandbox_network_label_key = "masc.mcp.network"
 let sandbox_ttl_sec_label_key = "masc.mcp.ttl_sec"
 let sandbox_turn_id_label_key = "masc.mcp.turn_id"
 
-let strip_trailing_slashes path =
-  let rec loop i = if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i in
-  let len = loop (String.length path) in
-  if len = String.length path then path else String.sub path 0 len
-;;
+let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 
 let normalize_base_path_for_hash base_path =
   let abs =

--- a/lib/keeper/keeper_supervisor_self_preservation.ml
+++ b/lib/keeper/keeper_supervisor_self_preservation.ml
@@ -1,6 +1,6 @@
 (** See [keeper_supervisor_self_preservation.mli] for the contract. *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 type escape_state =
   { mutable last_dominant_cohort : string

--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -76,11 +76,6 @@ let assoc_int_opt key json =
   | _ -> None
 ;;
 
-let starts_with ~prefix text =
-  let prefix_len = String.length prefix in
-  String.length text >= prefix_len && String.sub text 0 prefix_len = prefix
-;;
-
 (* [error_or_detail key json] reads [key] at top level, falling back
    to a nested ["detail"] object. Mirrors the lookup pattern used in
    [keeper_tools_oas.workflow_rejection_info_of_raw]. *)
@@ -149,17 +144,17 @@ let classify_git_exit_128 json =
       |> Option.map String.lowercase_ascii
       |> Option.value ~default:""
     in
-    if starts_with ~prefix:"git " command
+    if String.starts_with ~prefix:"git " command
        && String_util.contains_substring output "no merge base"
     then Some Git_ref_precondition_failed
-    else if starts_with ~prefix:"git " command
+    else if String.starts_with ~prefix:"git " command
             && String_util.contains_substring output "ambiguous argument"
             && String_util.contains_substring output "unknown revision"
     then Some Git_ref_precondition_failed
-    else if starts_with ~prefix:"git " command
+    else if String.starts_with ~prefix:"git " command
             && String_util.contains_substring output "unknown revision or path"
     then Some Git_ref_precondition_failed
-    else if starts_with ~prefix:"git " command
+    else if String.starts_with ~prefix:"git " command
             && String_util.contains_substring output "fatal: unrecognized argument:"
     then Some Git_command_usage_error
     else None

--- a/lib/keeper/keeper_tool_diversity.ml
+++ b/lib/keeper/keeper_tool_diversity.ml
@@ -92,7 +92,7 @@ let compute_diversity ~(available_tools : string list)
     |> List.map (fun s -> s.name)
   in
   (* Underused: available tools never called or called < 1% *)
-  let module SS = Set.Make (String) in
+  let module SS = Set_util.StringSet in
   let used_set =
     List.fold_left (fun acc s ->
       if s.count > 0 then SS.add s.name acc else acc)

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -407,7 +407,7 @@ let tool_policy_of_meta (meta : keeper_meta) =
     deny = Tool_access_policy.Names meta.tool_denylist;
   }
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 (* ── Access lookup (O(1) per tool) ────────────────────────────── *)
 

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -976,7 +976,7 @@ let classify_provider_timeout_strike ~strikes =
   then Provider_timeout_soft_backoff
   else Provider_timeout_warn
 
-module Budget_strike_map = Map.Make (String)
+module Budget_strike_map = Set_util.StringMap
 
 (* Stdlib.Mutex: this ledger is updated from keeper Eio fibers and from
    non-Eio unit tests. The critical section is pure map replacement and

--- a/lib/keeper/keeper_types_profile_persona.ml
+++ b/lib/keeper/keeper_types_profile_persona.ml
@@ -232,7 +232,7 @@ let list_persona_summaries () : persona_summary list =
     | Sys_error _ -> []
   in
   (* Collect all persona (name, path) from all dirs; later dirs override. *)
-  let module SS = Set.Make (String) in
+  let module SS = Set_util.StringSet in
   let raw = dirs |> List.concat_map entries_from_dir in
   let all_entries =
     List.fold_left

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -45,8 +45,8 @@ let managed_agent_passthrough_tool_set : (string, unit) Hashtbl.t =
     managed_agent_passthrough_tool_names;
   tbl
 
-module StringSet = Set.Make (String)
-module StringMap = Map.Make (String)
+module StringSet = Set_util.StringSet
+module StringMap = Set_util.StringMap
 
 let dedupe_tool_schemas_by_name (schemas : Masc_domain.tool_schema list) =
   let _, result =

--- a/lib/memory_oas_bridge_cache.ml
+++ b/lib/memory_oas_bridge_cache.ml
@@ -1,6 +1,6 @@
 (** File-stamp caches for {!Memory_oas_bridge}. *)
 
-module SMap = Map.Make (String)
+module SMap = Set_util.StringMap
 
 let rec atomic_update atomic f =
   let old_val = Atomic.get atomic in

--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -1,4 +1,4 @@
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** Meta_cognition_snapshot — Data loading, JSON builders, and snapshot generation.
 

--- a/lib/model_inference_metrics_entry.ml
+++ b/lib/model_inference_metrics_entry.ml
@@ -12,7 +12,7 @@
     Internal sibling module of the facade; do not call directly from
     outside the library. *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 module IntMap = Map.Make (Int)
 
 let model_id_unknown = "unknown"

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -11,7 +11,7 @@
     Distributed backend paths (Some key in room_utils_ops.ml) are not
     affected — this only replaces the local filesystem lock path. *)
 
-module SMap = Map.Make(String)
+module SMap = Set_util.StringMap
 
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 

--- a/lib/rate_limit.ml
+++ b/lib/rate_limit.ml
@@ -9,7 +9,7 @@
     @since 0.4.0
 *)
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** {1 Token Bucket Algorithm} *)
 

--- a/lib/server/server_dashboard_compact_receipt_json.ml
+++ b/lib/server/server_dashboard_compact_receipt_json.ml
@@ -9,12 +9,7 @@
    mapping over receipt-shaped [Yojson.Safe.t] values.  No shared
    state, no I/O. *)
 
-let compact_preview ~max_chars text =
-  let text = String.trim text in
-  if String.length text <= max_chars
-  then text, false
-  else String.sub text 0 max_chars ^ "...", true
-;;
+let compact_preview = Server_dashboard_http_json_utils.compact_preview
 
 (* Local member-lookup helper.  The parent's [json_member] returns
    `Null on miss; matching that shape lets the caller pattern-match

--- a/lib/server/server_dashboard_compact_receipt_json.ml
+++ b/lib/server/server_dashboard_compact_receipt_json.ml
@@ -19,13 +19,7 @@ let compact_preview ~max_chars text =
 (* Local member-lookup helper.  The parent's [json_member] returns
    `Null on miss; matching that shape lets the caller pattern-match
    on `Assoc / `Null without options. *)
-let json_member key = function
-  | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some v -> v
-     | None -> `Null)
-  | _ -> `Null
-;;
+let json_member = Server_dashboard_http_json_utils.json_member
 
 let json_string key json = Json_util.get_string json key
 let json_int key json = Json_util.get_int json key

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -408,7 +408,7 @@ let compose_namespace_truth_initializing ~(config : Coord.config) ~message =
          ("message", `String message);
        ])
 
-module String_set = Set.Make (String)
+module String_set = Set_util.StringSet
 
 let json_bool_field key json ~default =
   match safe_member key json with

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -12,7 +12,7 @@ type sse_conn_info = {
   mutable closed : bool;
 }
 
-module SMap = Map.Make(String)
+module SMap = Set_util.StringMap
 
 let rec atomic_update atomic f =
   let old_val = Atomic.get atomic in

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -1,6 +1,6 @@
 open Result.Syntax
 
-module SMap = Map.Make(String)
+module SMap = Set_util.StringMap
 
 let rec atomic_update atomic f =
   let old_val = Atomic.get atomic in

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -125,9 +125,6 @@ let parse_host_port host_header default_host default_port =
           (host, port)
         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> (default_host, default_port))
 
-(** Utility: string prefix check *)
-let starts_with ~prefix s = String.starts_with ~prefix s
-
 (** Allowed origins for DNS rebinding protection.
     SSOT: [Masc_network_defaults.allowed_origins]. *)
 let allowed_origins = Masc_network_defaults.allowed_origins
@@ -137,7 +134,7 @@ let validate_origin (request : Httpun.Request.t) =
   match Httpun.Headers.get request.headers "origin" with
   | None -> true
   | Some origin ->
-      List.exists (fun prefix -> starts_with ~prefix origin) allowed_origins
+      List.exists (fun prefix -> String.starts_with ~prefix origin) allowed_origins
 
 (** Check if client accepts SSE *)
 let accepts_sse (request : Httpun.Request.t) =

--- a/lib/server/server_routes_http_common.mli
+++ b/lib/server/server_routes_http_common.mli
@@ -172,7 +172,6 @@ val handle_presence_events :
 
 val mcp_transport_http_deps :
   unit -> Server_mcp_transport_http.deps
-val starts_with : prefix:string -> string -> bool
 val host_header_has_forbidden_authority_chars :
   string -> bool
 val parse_host_port :

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -30,7 +30,7 @@ let env_with_base_path ~base_path =
   let prefix = key ^ "=" in
   Unix.environment ()
   |> Array.to_list
-  |> List.filter (fun entry -> not (starts_with ~prefix entry))
+  |> List.filter (fun entry -> not (String.starts_with ~prefix entry))
   |> fun rest -> Array.of_list ((prefix ^ base_path) :: rest)
 ;;
 

--- a/lib/server/server_routes_http_routes_sidecar.mli
+++ b/lib/server/server_routes_http_routes_sidecar.mli
@@ -24,7 +24,6 @@ val parse_name : Httpun.Request.t -> (string, string) result
 
 (** {1 String helpers} *)
 
-val starts_with : prefix:string -> string -> bool
 val trim_opt : string option -> string option
 
 (** {1 Base-path / project root resolution} *)

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -7,8 +7,8 @@ open Server_routes_http_common
 module Http = Http_server_eio
 
 let is_dashboard_spa_deep_link path =
-  starts_with ~prefix:"/dashboard/" path
-  && not (starts_with ~prefix:"/dashboard/assets/" path)
+  String.starts_with ~prefix:"/dashboard/" path
+  && not (String.starts_with ~prefix:"/dashboard/assets/" path)
   && path <> "/dashboard/credits"
 
 (** CORS preflight response headers *)

--- a/lib/server/server_routes_http_sidecar_paths.ml
+++ b/lib/server/server_routes_http_sidecar_paths.ml
@@ -15,7 +15,6 @@ let validate_name = function
 ;;
 
 let parse_name request = validate_name (Server_utils.query_param request "name")
-let starts_with ~prefix value = String.starts_with ~prefix value
 
 let trim_opt = function
   | Some raw ->
@@ -149,11 +148,11 @@ let strip_matching_quotes value =
 
 let parse_env_assignment line =
   let trimmed = String.trim line in
-  if trimmed = "" || starts_with ~prefix:"#" trimmed
+  if trimmed = "" || String.starts_with ~prefix:"#" trimmed
   then None
   else (
     let body =
-      if starts_with ~prefix:"export " trimmed
+      if String.starts_with ~prefix:"export " trimmed
       then String.sub trimmed 7 (String.length trimmed - 7) |> String.trim
       else trimmed
     in

--- a/lib/server/server_routes_http_sidecar_paths.mli
+++ b/lib/server/server_routes_http_sidecar_paths.mli
@@ -4,7 +4,6 @@ val known_ids : string list
 val validate_name : string option -> (string, string) result
 val parse_name : Httpun.Request.t -> (string, string) result
 
-val starts_with : prefix:string -> string -> bool
 val trim_opt : string option -> string option
 
 val runtime_base_path : ?base_path:string -> unit -> string

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -2,7 +2,7 @@
 
 open Masc_domain
 
-module AgentMap = Map.Make(String)
+module AgentMap = Set_util.StringMap
 
 (** Session info stored in registry *)
 type session = {

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -25,7 +25,7 @@
     waiting on a lock held by another fiber. *)
 
 (** Classification of an SSE session's traffic role. *)
-module SMap = Map.Make(String)
+module SMap = Set_util.StringMap
 
 (* Test-only hooks for forcing a CAS retry in white-box unit tests. *)
 let register_commit_test_hook : (unit -> unit) option Atomic.t = Atomic.make None

--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -26,7 +26,7 @@ type response_mode =
 type request_handler =
   Yojson.Safe.t -> Yojson.Safe.t
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** Session storage with mutex protection *)
 module Session = struct

--- a/lib/task_sandbox.ml
+++ b/lib/task_sandbox.ml
@@ -90,13 +90,7 @@ let safe_is_directory path =
   | Sys_error _ -> false
 ;;
 
-let strip_trailing_slashes path =
-  let rec loop i =
-    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
-  in
-  let len = loop (String.length path) in
-  if len = String.length path then path else String.sub path 0 len
-;;
+let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 
 let suffix_under ~prefix path =
   let prefix = strip_trailing_slashes prefix in

--- a/lib/tool_access_policy.ml
+++ b/lib/tool_access_policy.ml
@@ -17,7 +17,7 @@ module Float = Stdlib.Float
 
 (** Tool_access_policy — shared allow/deny selector ADT for runtime tool policies. *)
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 type selector =
   | Empty

--- a/lib/tool_blob_store/tool_blob_store.ml
+++ b/lib/tool_blob_store/tool_blob_store.ml
@@ -1,4 +1,4 @@
-module SS = Set.Make (String)
+module SS = Set_util.StringSet
 
 type t = { root : string } [@@unboxed]
 

--- a/lib/tool_call_quality_benchmark/post_verifier.ml
+++ b/lib/tool_call_quality_benchmark/post_verifier.ml
@@ -1,4 +1,4 @@
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** Post Verifier — 3-dimension output verification gate for agents.
 

--- a/lib/tool_metrics.ml
+++ b/lib/tool_metrics.ml
@@ -15,7 +15,7 @@ module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 (** Per-tool timing metrics *)
 

--- a/lib/tool_misc_web_search.ml
+++ b/lib/tool_misc_web_search.ml
@@ -463,14 +463,7 @@ let endpoint_error ~fallback detail =
 
 let searxng_default_url = Masc_network_defaults.searxng_default_url
 
-let strip_trailing_slashes s =
-  let rec find_last_non_slash i =
-    if i < 0 then -1
-    else if Char.equal s.[i] '/' then find_last_non_slash (i - 1)
-    else i
-  in
-  let last = find_last_non_slash (String.length s - 1) in
-  if last < 0 then "" else String.sub s 0 (last + 1)
+let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 
 let searxng_base_url () =
   let url =

--- a/lib/tool_prefilter.ml
+++ b/lib/tool_prefilter.ml
@@ -14,8 +14,8 @@ module String = Stdlib.String
 module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
-module StringMap = Map.Make (String)
-module StringSet = Set.Make (String)
+module StringMap = Set_util.StringMap
+module StringSet = Set_util.StringSet
 
 (** Tool_prefilter — TF-IDF cosine similarity for tool relevance scoring.
 

--- a/lib/tool_registry.ml
+++ b/lib/tool_registry.ml
@@ -72,7 +72,7 @@ let registry_mu = Eio.Mutex.create ()
 let with_registry_rw f = Eio_guard.with_mutex registry_mu f
 let with_registry_ro f = Eio_guard.with_mutex_ro registry_mu f
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 (** Use the leaf surface-name SSOT instead of Config.raw_all_tool_schemas.
     Tool_registry sits below keeper/OAS dispatch, and depending on Config

--- a/lib/tool_shard_types_core.ml
+++ b/lib/tool_shard_types_core.ml
@@ -15,7 +15,7 @@ type shard =
   ; description : string
   }
 
-module StringMap = Map.Make (String)
+module StringMap = Set_util.StringMap
 
 let select_named_schemas (names : string list) (schemas : Masc_domain.tool_schema list)
   : Masc_domain.tool_schema list

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -15,8 +15,8 @@ module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
 
-module StringSet = Set.Make (String)
-module StringMap = Map.Make (String)
+module StringSet = Set_util.StringSet
+module StringMap = Set_util.StringMap
 
 (** Tool_usage_log -- Durable call logging for System_internal surface tools.
 

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -6,7 +6,7 @@
 
 open Masc_domain
 
-module StringSet = Set.Make (String)
+module StringSet = Set_util.StringSet
 
 let dedupe_schemas_by_name (schemas : tool_schema list) =
   let unique, _ =

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -218,9 +218,6 @@ type turn_request_result =
 (** Timeout exception for Eio.Fiber.first pattern *)
 exception Timeout of string
 
-(** Safe string prefix check *)
-let starts_with ~prefix s = String.starts_with ~prefix s
-
 (** Check if an error is retryable (transient)
     Retryable errors: connection failures, timeouts, HTTP 5xx *)
 let is_retryable_error error =
@@ -228,8 +225,8 @@ let is_retryable_error error =
   then false
   else (
     let s = String.lowercase_ascii error in
-    starts_with ~prefix:"connection" s
-    || starts_with ~prefix:"timeout" s
+    String.starts_with ~prefix:"connection" s
+    || String.starts_with ~prefix:"timeout" s
     ||
     try Scanf.sscanf s "http %d" (fun code -> code >= 500 && code < 600) with
     | Scanf.Scan_failure _ | Failure _ | End_of_file -> false)

--- a/test/test_keeper_alerting_path.ml
+++ b/test/test_keeper_alerting_path.ml
@@ -73,24 +73,6 @@ let test_join_multiple () =
   check_string "[a;b;c] joins to a/b/c" "a/b/c"
     (KAP.join_path_components ["a"; "b"; "c"])
 
-(* ── starts_with ─────────────────────────────────────────────────────── *)
-
-let test_starts_with_match () =
-  check_bool "/foo starts with /" true
-    (KAP.starts_with ~prefix:"/" "/foo")
-
-let test_starts_with_full_match () =
-  check_bool "abc starts with abc" true
-    (KAP.starts_with ~prefix:"abc" "abc")
-
-let test_starts_with_no_match () =
-  check_bool "abc does not start with xyz" false
-    (KAP.starts_with ~prefix:"xyz" "abc")
-
-let test_starts_with_empty_prefix () =
-  check_bool "anything starts with empty" true
-    (KAP.starts_with ~prefix:"" "anything")
-
 (* ── runner ──────────────────────────────────────────────────────────── *)
 
 let () =
@@ -119,12 +101,5 @@ let () =
           Alcotest.test_case "empty -> '.'" `Quick test_join_empty;
           Alcotest.test_case "single component" `Quick test_join_single;
           Alcotest.test_case "multiple components" `Quick test_join_multiple;
-        ] );
-      ( "starts_with",
-        [
-          Alcotest.test_case "prefix match" `Quick test_starts_with_match;
-          Alcotest.test_case "exact match" `Quick test_starts_with_full_match;
-          Alcotest.test_case "no match" `Quick test_starts_with_no_match;
-          Alcotest.test_case "empty prefix" `Quick test_starts_with_empty_prefix;
         ] );
     ]


### PR DESCRIPTION
## Summary

- Consolidate 65 `Set.Make(String)` / `Map.Make(String)` functor instantiations into `Set_util.StringSet` / `Set_util.StringMap` SSOT modules
- Eliminate 12 manual `starts_with` implementations (hand-rolled `String.sub` prefix checks + thin wrappers) — all callers now use stdlib `String.starts_with` (OCaml 4.13+)
- Delegate `safe_member`, `json_member`, `compact_preview` to canonical modules
- Remove dead `try_catch` function from `safe_ops`

## Impact

- 20 files changed, net -95 lines (functor commit: 82 files, +4/-316; starts_with commit: 20 files, +27/-95)
- Zero behavioral change — all replacements are semantically identical
- `keeper_invariant` sub-library intentionally excluded (zero-dependency isolation)

## Test plan

- [x] `dune build --root .` passes clean
- [ ] CI `Build and Test` check
- [ ] Review: verify no `Set.Make(String)` or manual `starts_with` remains in `lib/` (excluding `set_util.ml` and `keeper_invariant`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)