### PR TITLE
fix(bash): add empty-executable guard to shell_bin

### DIFF
--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -310,10 +310,13 @@ let validate ~mode = function
 ;;
 
 let shell_bin ~mode executable =
-  match Masc_exec.Bin.of_string executable with
-  | Ok bin -> Ok bin
-  | Error (`Unknown name) ->
-    Error (Executable_not_allowlisted { name; mode })
+  let trimmed = String.trim executable in
+  if String.length trimmed = 0 then Error Empty_executable
+  else
+    match Masc_exec.Bin.of_string trimmed with
+    | Ok bin -> Ok bin
+    | Error (`Unknown name) ->
+      Error (Executable_not_allowlisted { name = trimmed; mode })
 ;;
 
 let strip_leading_executable executable = function


### PR DESCRIPTION
Add empty-string guard to shell_bin() matching check_exec() behavior. 44 occurrences/day of misleading Executable_not_allowlisted for empty executables. Closes #18407. Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>