### PR TITLE
refactor(goals): drop goal_list status filter alias

### DIFF
--- a/docs/spec/03-room-coordination.md
+++ b/docs/spec/03-room-coordination.md
@@ -284,7 +284,7 @@ type goal_phase =
 - `goal.require_completion_approval`: verification 통과 후 operator approval gate 필요 여부
 
 도구 surface:
-- `masc_goal_list`: `phase` 기준 조회를 우선 지원하고, `status`는 compatibility alias로만 유지
+- `masc_goal_list`: `phase` 기준 조회만 지원한다. `status` 입력 alias는 제거됐다.
 - `masc_goal_upsert`: goal metadata + verifier policy 설정
 - `masc_goal_transition`: explicit Goal FSM action (`request_complete`, `pause`, `resume`, `operator_block`, `approve_completion`, ...)
 - `masc_goal_verify`: open verification request에 대한 1 principal 1 vote

--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -140,6 +140,22 @@ let parse_optional_goal_phase args field =
          ~received:(Yojson.Safe.to_string json))
 ;;
 
+let reject_retired_goal_list_status args =
+  match args with
+  | `Assoc fields ->
+    (match List.assoc_opt "status" fields with
+     | None -> Ok ()
+     | Some json ->
+       Error
+         { field = "status"
+         ; constraint_violated = One_of goal_phase_strings
+         ; message = "status filter was removed from masc_goal_list; use phase"
+         ; expected = Some "phase"
+         ; received = Some (Yojson.Safe.to_string json)
+         })
+  | _ -> Ok ()
+;;
+
 let goal_upsert_lifecycle_error ~tool_name ~start_time field =
   error_result_typed
     ~tool_name
@@ -353,14 +369,14 @@ let emit_goal_event = Coord_goals_verification.emit_goal_event
 
 let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.t =
   match
-    ( parse_optional_horizon args "horizon"
-    , parse_optional_goal_status args "status"
+    ( reject_retired_goal_list_status args
+    , parse_optional_horizon args "horizon"
     , parse_optional_goal_phase args "phase" )
   with
   | Error err, _, _ | _, Error err, _ | _, _, Error err ->
     validation_error_result ~tool_name ~start_time [ err ]
-  | Ok horizon, Ok status, Ok phase ->
-    let goals = Goal_store.list_goals ctx.config ?horizon ?status ?phase () in
+  | Ok (), Ok horizon, Ok phase ->
+    let goals = Goal_store.list_goals ctx.config ?horizon ?phase () in
     let rollup = Goal_store.compute_rollup goals in
     ok_result
       ~tool_name

--- a/lib/tool_schemas/tool_schemas_coord_extra.ml
+++ b/lib/tool_schemas/tool_schemas_coord_extra.ml
@@ -4,7 +4,6 @@
 open Masc_domain
 
 let goal_horizon_enum = [ "short"; "mid"; "long" ]
-let goal_status_enum = [ "active"; "paused"; "done"; "dropped" ]
 let goal_phase_enum =
   [
     "executing";
@@ -77,7 +76,7 @@ let schemas : tool_schema list =
     {
       name = "masc_goal_list";
       description =
-        "List shared planning goals from the Goal Store, optionally filtered by horizon, explicit phase, or legacy status. \
+        "List shared planning goals from the Goal Store, optionally filtered by horizon or explicit phase. \
 Use when a PM/planner agent needs current long/mid/short goals before creating tasks or reviews. \
 The dashboard Goal Tree reads the same store. Linked tasks require structured task.goal_id. \
 The response includes each goal's explicit lifecycle phase and verification policy.";
@@ -90,7 +89,6 @@ The response includes each goal's explicit lifecycle phase and verification poli
                 [
                   ("horizon", enum_schema ~description:"Optional horizon filter" goal_horizon_enum);
                   ("phase", enum_schema ~description:"Optional explicit Goal FSM phase filter" goal_phase_enum);
-                  ("status", enum_schema ~description:"Optional legacy status filter" goal_status_enum);
                 ] );
             ("additionalProperties", `Bool false);
           ];

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -222,7 +222,7 @@ let test_goal_list_ignores_blank_optional_filters () =
     Tool_coord.dispatch
       (coord_ctx config)
       ~name:"masc_goal_list"
-      ~args:(`Assoc [ "horizon", `String ""; "phase", `String ""; "status", `String "" ])
+      ~args:(`Assoc [ "horizon", `String ""; "phase", `String "" ])
   in
   let listed_json =
     match listed with
@@ -234,6 +234,35 @@ let test_goal_list_ignores_blank_optional_filters () =
     "blank filters are ignored"
     1
     (Yojson.Safe.Util.member "count" listed_json |> Yojson.Safe.Util.to_int)
+;;
+
+let test_goal_list_rejects_status_filter () =
+  with_room
+  @@ fun config ->
+  let rejected =
+    Tool_coord.dispatch
+      (coord_ctx config)
+      ~name:"masc_goal_list"
+      ~args:(`Assoc [ "status", `String "active" ])
+  in
+  let error_json = expect_error rejected in
+  check
+    string
+    "status filter blocked"
+    "validation_error"
+    (get_string_field error_json "error_code");
+  check
+    bool
+    "error points to removed status"
+    true
+    (contains_substring (Yojson.Safe.to_string error_json) "status filter was removed");
+  let field_errors =
+    Yojson.Safe.Util.member "field_errors" error_json |> Yojson.Safe.Util.to_list
+  in
+  match field_errors with
+  | field_error :: _ ->
+    check string "field" "status" (get_string_field field_error "field")
+  | [] -> fail "expected status field error"
 ;;
 
 let test_goal_upsert_rejects_lifecycle_fields () =
@@ -948,6 +977,10 @@ let () =
             "list ignores blank optional filters"
             `Quick
             test_goal_list_ignores_blank_optional_filters
+        ; test_case
+            "list rejects status filter"
+            `Quick
+            test_goal_list_rejects_status_filter
         ; test_case
             "upsert rejects lifecycle fields"
             `Quick

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -945,7 +945,6 @@ let test_registered_hook_goal_list_strips_blank_optional_enums () =
       [
         ("horizon", `String "");
         ("phase", `String " ");
-        ("status", `String "");
       ]
   in
   let blocked, forwarded =
@@ -959,9 +958,18 @@ let test_registered_hook_goal_list_strips_blank_optional_enums () =
   Alcotest.(check bool) "horizon removed" true
     (Yojson.Safe.Util.member "horizon" forwarded = `Null);
   Alcotest.(check bool) "phase removed" true
-    (Yojson.Safe.Util.member "phase" forwarded = `Null);
-  Alcotest.(check bool) "status removed" true
-    (Yojson.Safe.Util.member "status" forwarded = `Null)
+    (Yojson.Safe.Util.member "phase" forwarded = `Null)
+
+let test_registered_hook_goal_list_rejects_status_filter () =
+  let args = `Assoc [ ("status", `String "active") ] in
+  let blocked, _forwarded =
+    run_registered_hook
+      ~schema:masc_goal_list_schema
+      ~tool_name:"masc_goal_list"
+      ~args
+      ()
+  in
+  Alcotest.(check bool) "blocked" true (Option.is_some blocked)
 
 let test_registered_hook_goal_list_preserves_invalid_enum_for_handler () =
   let args = `Assoc [("horizon", `String "week")] in
@@ -1451,6 +1459,8 @@ let () =
         test_registered_hook_transition_strips_internal_agent_marker;
       Alcotest.test_case "masc_goal_list strips blank optional enum filters"
         `Quick test_registered_hook_goal_list_strips_blank_optional_enums;
+      Alcotest.test_case "masc_goal_list rejects status filter" `Quick
+        test_registered_hook_goal_list_rejects_status_filter;
       Alcotest.test_case "masc_goal_list preserves invalid enum filters" `Quick
         test_registered_hook_goal_list_preserves_invalid_enum_for_handler;
       Alcotest.test_case "required enum blanks are not stripped" `Quick

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -216,7 +216,8 @@ let test_masc_goal_list_schema () =
       match get_json_assoc "properties" schema.input_schema with
       | Some props ->
           Alcotest.(check bool) "has horizon" true (List.mem_assoc "horizon" props);
-          Alcotest.(check bool) "has status" true (List.mem_assoc "status" props)
+          Alcotest.(check bool) "has phase" true (List.mem_assoc "phase" props);
+          Alcotest.(check bool) "no legacy status filter" false (List.mem_assoc "status" props)
       | None -> Alcotest.fail "masc_goal_list missing properties"
 
 let test_masc_goal_upsert_schema () =


### PR DESCRIPTION
## Summary
- Remove the `masc_goal_list.status` input schema/docs alias.
- Reject `status` in the direct Tool_coord handler instead of silently ignoring it.
- Keep persisted goal status/upsert lifecycle rejection intact; list filtering is `horizon`/`phase` only.
- Add schema-hook and direct-dispatch regression coverage.

## Validation
- `ocamlformat --check lib/tool_schemas/tool_schemas_coord_extra.ml lib/coord_goals.ml test/test_tool_input_validation.ml test/test_goal_tools.ml test/test_tools_coverage.ml`
- `ocamlc -stop-after parsing` on changed OCaml files
- `git diff --check origin/main...HEAD`
- `scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD`
- `scripts/lint/godfile-size-regression.sh`
- `scripts/code-smell-ratchet.sh`
- `scripts/ci/check-determinism-contract.sh`

## Gap
- `scripts/dune-local.sh build test/test_goal_tools.exe test/test_tool_input_validation.exe test/test_tools_coverage.exe` blocked with exit 75 by the machine-wide bare Dune guard; I did not override it.