### PR TITLE
refactor(keeper): drop meta retry wrapper

### DIFF
--- a/lib/keeper/keeper_meta_merge.mli
+++ b/lib/keeper/keeper_meta_merge.mli
@@ -1,13 +1,12 @@
 (** Field-ownership merges for keeper_meta on CAS retry (#9769).
 
-    The existing [write_meta_with_retry] re-reads the disk version on
-    conflict and then writes the caller's payload wholesale, only
-    bumping [meta_version] to [latest.meta_version]. When the retry
-    loser is the turn-failure writer and the winner is the heartbeat
-    fiber, the heartbeat's updates to [joined_room_ids] and
-    [last_seen_seq_by_room] are clobbered — even though the turn path
-    never touches those fields. This is false sharing on a single
-    version counter.
+    A caller-wins retry re-reads the disk version on conflict and then
+    writes the caller's payload wholesale, only bumping [meta_version]
+    to [latest.meta_version]. When the retry loser is the turn-failure
+    writer and the winner is the heartbeat fiber, the heartbeat's
+    updates to [joined_room_ids] and [last_seen_seq_by_room] are
+    clobbered — even though the turn path never touches those fields.
+    This is false sharing on a single version counter.
 
     A correct three-way merge requires the caller to declare which
     fields it owns. This module provides named merge strategies; the
@@ -22,8 +21,8 @@ type t = latest:Keeper_types.keeper_meta -> caller:Keeper_types.keeper_meta -> K
 
 val caller_wins : t
 (** Take every field from the caller except [meta_version], which
-    follows the disk version. This is the historical behaviour of
-    [write_meta_with_retry]. *)
+    follows the disk version. Use only when payload-wins is the intended
+    CAS conflict policy. *)
 
 val heartbeat_fields_from_disk : t
 (** Take heartbeat-owned fields ([joined_room_ids],

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -348,57 +348,9 @@ let is_version_conflict_error msg =
   | Not_found -> false
 ;;
 
-(* #9764/#9733/#9769: cycle-completion writes lose data when a heartbeat or
-   supervisor fiber bumps meta_version between the cycle's read and its
-   write. Bounded retry that re-reads the latest disk version, lifts the
-   caller's payload onto it, and writes again.
-
-   Trade-off: the caller's payload wins at the field level. Concurrent
-   updates from heartbeat (last_seen, cursor) are overwritten. This is
-   acceptable for cycle completion because (a) heartbeat fields are
-   ephemeral and resync on the next heartbeat tick, while (b) cycle
-   payload (usage tokens, trace_history, generation) is non-recoverable.
-   Heartbeat itself must NOT use this helper (it would cause the inverse
-   problem). *)
-let write_meta_with_retry ?(max_retries = 3) config (m : keeper_meta)
-  : (unit, string) result
-  =
-  let path = keeper_meta_path config m.name in
-  let rec attempt n m =
-    match write_meta config m with
-    | Ok () -> Ok ()
-    | Error msg when n >= max_retries -> Error msg
-    | Error msg when not (is_version_conflict_error msg) -> Error msg
-    | Error _ ->
-      (* Version conflict: read latest disk state, lift caller's payload
-       onto its version, and try again. *)
-      (match read_meta_file_path path with
-       | Ok (Some latest) ->
-         Prometheus.inc_counter
-           Prometheus.metric_write_meta_cas_retry_total
-           ~labels:[("keeper_name", m.name)]
-           ();
-         Log.Keeper.info
-           "write_meta CAS retry %d/%d for %s (caller had %d, disk %d)"
-           (n + 1)
-           max_retries
-           m.name
-           m.meta_version
-           latest.meta_version;
-         attempt (n + 1) { m with meta_version = latest.meta_version }
-       | Ok None ->
-         (* Disk file vanished between attempts; fall back to fresh write. *)
-         attempt (n + 1) { m with meta_version = 0 }
-       | Error read_msg ->
-         Error (Printf.sprintf "write_meta retry: failed to re-read for CAS: %s" read_msg))
-  in
-  attempt 0 m
-;;
-
-(* #9769 root fix: like [write_meta_with_retry], but lets the caller
-   declare field ownership via [merge]. The turn-failure/cycle path
-   uses [Keeper_meta_merge.heartbeat_fields_from_disk] so its retry
-   does not clobber heartbeat-owned fields ([joined_room_ids],
+(* #9769 root fix: CAS retry with explicit field ownership. The
+   turn-failure/cycle path uses [Keeper_meta_merge.heartbeat_fields_from_disk]
+   so its retry does not clobber heartbeat-owned fields ([joined_room_ids],
    [last_seen_seq_by_room]). *)
 let write_meta_with_merge
       ?(max_retries = 3)

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -8,8 +8,8 @@ open Keeper_types_profile
 open Keeper_meta_contract
 
 (** Hook invoked after each successful [write_meta] /
-    [write_meta_with_retry] / [write_meta_with_merge]. Reset by the
-    runtime to keep [Coord_state] caches in sync. *)
+    [write_meta_with_merge]. Reset by the runtime to keep
+    [Coord_state] caches in sync. *)
 val runtime_meta_write_sync_hook :
   (Coord.config -> keeper_meta -> unit) ref
 
@@ -113,21 +113,11 @@ val write_meta :
 (** [true] iff [msg] matches [version_conflict_re]. *)
 val is_version_conflict_error : string -> bool
 
-(** Like [write_meta] but retries up to [max_retries] times on a
-    CAS version conflict, lifting the caller's payload onto the
-    latest disk version each retry. Caller payload wins at the
-    field level (see #9764/#9733/#9769). Heartbeat must NOT use
-    this helper — it would invert the data-loss tradeoff. *)
-val write_meta_with_retry :
-  ?max_retries:int ->
-  Coord.config ->
-  keeper_meta ->
-  (unit, string) result
-
-(** Like [write_meta_with_retry] but lets the caller declare field
-    ownership via [merge]. Used by the turn-failure / cycle path
-    via [Keeper_meta_merge.heartbeat_fields_from_disk] so retry
-    does not clobber heartbeat-owned fields. *)
+(** Retry [write_meta] on CAS version conflicts using caller-declared
+    field ownership via [merge]. Use [Keeper_meta_merge.caller_wins]
+    for payload-wins writes, or a narrower merge such as
+    [Keeper_meta_merge.heartbeat_fields_from_disk] when concurrent
+    writers own specific fields. *)
 val write_meta_with_merge :
   ?max_retries:int ->
   merge:(latest:keeper_meta -> caller:keeper_meta -> keeper_meta) ->

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -55,7 +55,10 @@ let handle_keeper_down ctx args : tool_result =
              paused = true;
            }
          in
-         ((match write_meta_with_retry ctx.config retained with
+         ((match
+             write_meta_with_merge
+               ~merge:Keeper_meta_merge.caller_wins ctx.config retained
+           with
            | Ok () -> ()
            | Error err ->
                Prometheus.inc_counter

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -409,25 +409,6 @@ val keepalive_keeper_names : Coord.config -> string list
 val persistent_agent_names : Coord.config -> string list
 val write_meta : ?force:bool -> Coord.config -> keeper_meta -> (unit, string) result
 
-val write_meta_with_retry :
-  ?max_retries:int -> Coord.config -> keeper_meta -> (unit, string) result
-(** CAS write with bounded retry on version conflict.
-
-    On version conflict, re-reads disk to learn the latest version,
-    lifts the caller's payload onto it, and writes again. Retries up
-    to [max_retries] (default 3) times. Non-conflict errors fail
-    immediately.
-
-    Trade-off: payload-wins-at-field-level. Concurrent writes from
-    other fibers (e.g. heartbeat updating last_seen) are overwritten
-    by this caller's payload. Use only when the caller's data is
-    less recoverable than the concurrent writer's (cycle completion
-    qualifies; heartbeat does NOT — it should keep using {!write_meta}
-    and tolerate occasional CAS conflicts). See #9764 / #9733 / #9769.
-
-    Equivalent to [write_meta_with_merge ~merge:Keeper_meta_merge.caller_wins];
-    kept as a thin wrapper for backwards compatibility. *)
-
 val write_meta_with_merge :
   ?max_retries:int ->
   merge:(latest:keeper_meta -> caller:keeper_meta -> keeper_meta) ->
@@ -436,9 +417,8 @@ val write_meta_with_merge :
   (unit, string) result
 (** CAS write with bounded retry and caller-supplied field merge (#9769).
 
-    Like {!write_meta_with_retry}, but on CAS conflict the caller's
-    [merge] function decides which fields to take from the disk
-    snapshot and which from the caller. This eliminates the false
+    On CAS conflict the caller's [merge] function decides which fields
+    to take from the disk snapshot and which from the caller. This eliminates the false
     sharing that caused turn-failure writes to lose the CAS race
     against concurrent heartbeat writers: the turn path never modifies
     [joined_room_ids] / [last_seen_seq_by_room], so preserving those

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -69,7 +69,10 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
               updated_at = Keeper_types.now_iso ();
             }
           in
-          (match Keeper_types.write_meta_with_retry config updated_meta with
+          (match
+             Keeper_types.write_meta_with_merge
+               ~merge:Keeper_meta_merge.caller_wins config updated_meta
+           with
            | Ok () -> ()
            | Error err ->
                Log.Keeper.warn

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -1,6 +1,7 @@
 (** #9764/#9733/#9769: write_meta CAS retry semantics.
 
-    Verifies that [Keeper_types.write_meta_with_retry]:
+    Verifies that [Keeper_types.write_meta_with_merge] with
+    [Keeper_meta_merge.caller_wins]:
       - succeeds when no concurrent writer interferes
       - succeeds after N attempts when the disk version has advanced
       - distinguishes version conflicts from real I/O errors via
@@ -57,7 +58,10 @@ let test_no_conflict_writes_first_attempt () =
     ignore (Coord.init config ~agent_name:(Some "operator"));
     let m0 = make_meta ~name:"alpha" in
     (* Initial write — no existing file. *)
-    (match Keeper_types.write_meta_with_retry config m0 with
+    (match
+       Keeper_types.write_meta_with_merge
+         ~merge:Keeper_meta_merge.caller_wins config m0
+     with
      | Ok () -> ()
      | Error e -> fail ("first write failed: " ^ e));
     (* Read what landed on disk and bump caller's version to match. *)
@@ -66,7 +70,10 @@ let test_no_conflict_writes_first_attempt () =
       | _ -> fail "disk read failed"
     in
     let m1 = { disk with goal = "updated goal" } in
-    match Keeper_types.write_meta_with_retry config m1 with
+    match
+      Keeper_types.write_meta_with_merge
+        ~merge:Keeper_meta_merge.caller_wins config m1
+    with
     | Ok () ->
       let after = match Keeper_types.read_meta config "alpha" with
         | Ok (Some m) -> m
@@ -98,8 +105,8 @@ let test_retry_succeeds_after_concurrent_bump () =
      | Ok () -> ()
      | Error e -> fail ("racing write failed: " ^ e));
     (* Now the cycle attempts to write its own payload. CAS would fail
-       once; write_meta_with_retry must lift the payload onto the new
-       disk version and succeed. *)
+       once; caller_wins retry must lift the payload onto the new disk
+       version and succeed. *)
     let cycle_payload = { caller_view with goal = "cycle payload" } in
     let before_retry_metric =
       Prometheus.metric_value_or_zero
@@ -107,7 +114,10 @@ let test_retry_succeeds_after_concurrent_bump () =
         ~labels:[("keeper_name", "beta")]
         ()
     in
-    (match Keeper_types.write_meta_with_retry config cycle_payload with
+    (match
+       Keeper_types.write_meta_with_merge
+         ~merge:Keeper_meta_merge.caller_wins config cycle_payload
+     with
      | Ok () -> ()
      | Error e -> fail ("retry write failed: " ^ e));
     let after_retry_metric =
@@ -137,7 +147,7 @@ let test_is_version_conflict_error_classifies () =
 let () =
   run "Keeper_types CAS retry (#9764/#9733/#9769)"
     [
-      ( "write_meta_with_retry",
+      ( "write_meta_with_merge caller_wins",
         [
           test_case "writes on first attempt when no conflict" `Quick
             test_no_conflict_writes_first_attempt;

--- a/test/test_keeper_meta_heartbeat_retain_9733.ml
+++ b/test/test_keeper_meta_heartbeat_retain_9733.ml
@@ -147,8 +147,8 @@ let test_caller_wins_cycle_disk_wins_heartbeat () =
       (after_retry_metric -. before_retry_metric))
 
 (* Sanity: when no concurrent writer interferes, the merge function
-   is never called and behaviour matches plain
-   [write_meta_with_retry]. *)
+   is never called and behaviour matches a plain first-attempt
+   [write_meta] success. *)
 let test_no_race_writes_first_attempt () =
   Eio_main.run @@ fun env ->
   ensure_fs env;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -2892,10 +2892,10 @@ proactive_enabled = true
       Alcotest.(check bool) "unknown active goal rejected" false ok;
       Alcotest.(check bool) "unknown active goal names surfaced" true
         (contains_substring msg "goal-missing");
-      (* Stop keepalive before write_meta_with_retry to reduce CAS retries.
+      (* Stop keepalive before the CAS retry write to reduce retries.
          The keepalive fiber bumps meta_version on each tick; using
-         write_meta_with_retry resolves the flake by automatically retrying
-         on version conflict.  Issue #17231. *)
+         write_meta_with_merge resolves the flake by automatically retrying
+         on version conflict with an explicit caller-wins merge.  Issue #17231. *)
       Keeper_keepalive.stop_keepalive keeper_name;
       let meta = read_keeper_meta_exn config keeper_name in
       let mutated =
@@ -2923,7 +2923,10 @@ proactive_enabled = true
           updated_at = Masc_domain.now_iso ();
         }
       in
-      (match Masc_mcp.Keeper_types.write_meta_with_retry config mutated with
+      (match
+         Masc_mcp.Keeper_types.write_meta_with_merge
+           ~merge:Masc_mcp.Keeper_meta_merge.caller_wins config mutated
+       with
       | Ok () -> ()
       | Error err -> Alcotest.fail ("meta write failed: " ^ err));
       let status, json =


### PR DESCRIPTION
## Summary
- Remove the `write_meta_with_retry` compatibility wrapper from keeper meta storage and the public `Keeper_types` facade.
- Move remaining callers/tests to `write_meta_with_merge ~merge:Keeper_meta_merge.caller_wins`, making the CAS conflict policy explicit.
- Keep the narrower heartbeat-preserving merge path intact.

## Validation
- `rg -n "write_meta_with_retry" lib test docs` returns no matches
- `ocamlformat --check lib/keeper/keeper_meta_merge.mli lib/keeper/keeper_meta_store.ml lib/keeper/keeper_meta_store.mli lib/keeper/keeper_types.mli lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml lib/keeper/keeper_turn_lifecycle.ml test/test_operator_control_keeper.ml test/test_keeper_meta_cas_retry.ml test/test_keeper_meta_heartbeat_retain_9733.ml`
- `ocamlc -stop-after parsing` on changed OCaml files
- `git diff --check origin/main...HEAD`
- `scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD`
- `scripts/lint/godfile-size-regression.sh`
- `scripts/code-smell-ratchet.sh`
- `scripts/ci/check-determinism-contract.sh`

## Gap
- `scripts/dune-local.sh build test/test_keeper_meta_cas_retry.exe test/test_keeper_meta_heartbeat_retain_9733.exe test/test_operator_control_keeper.exe` blocked with exit 75 by the machine-wide bare Dune guard; this PR relies on GitHub CI for full OCaml typechecking.