### PR TITLE
refactor(keeper): drop tools oas entry alias

### DIFF
--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -81,9 +81,9 @@ let keeper_tool_audit_json_fields config registry_lookup keeper agent_name =
             let tracked = Keeper_tools_oas.tool_usage_for_keeper agent_name in
             if tracked <> [] then
               let names = List.map fst tracked in
-              let total = List.fold_left (fun acc (_, e) -> acc + e.Keeper_tools_oas.count) 0 tracked in
+              let total = List.fold_left (fun acc (_, e) -> acc + e.Keeper_types.count) 0 tracked in
               let latest_at = List.fold_left (fun acc (_, e) ->
-                max acc e.Keeper_tools_oas.last_used_at) 0.0 tracked in
+                max acc e.Keeper_types.last_used_at) 0.0 tracked in
               let at_str = if latest_at > 0.0
                 then Some (Dashboard_utils.iso_of_unix latest_at) else None in
               (fallback_allowed, names, Some total, None, Some "keeper_dispatch", at_str)

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -9,26 +9,16 @@
 
     @since Phase 4 — Keeper → Agent.run() migration *)
 
-(* ── Per-keeper tool usage tracking ──────────────────────────── *)
-
-(** Re-export from Keeper_types so dashboard code using
-    [e.Keeper_tools_oas.count] keeps compiling. *)
-type tool_call_entry = Keeper_types.tool_call_entry =
-  { count : int
-  ; successes : int
-  ; failures : int
-  ; last_used_at : float
-  }
-
 type tool_bundle =
   { tools : Agent_sdk.Tool.t list
   ; cleanup : unit -> unit
   }
 
 (** Tool usage now lives in Keeper_registry (per-entry tool_usage Hashtbl).
-    These public functions preserve the existing API surface. *)
+    These public functions expose the registry view without re-exporting
+    the entry record type. *)
 
-let tool_usage_for_keeper keeper_name : (string * tool_call_entry) list =
+let tool_usage_for_keeper keeper_name : (string * Keeper_types.tool_call_entry) list =
   Keeper_registry_lookup.tool_usage_of_by_name keeper_name
 ;;
 
@@ -317,4 +307,3 @@ let transient_mutex_contention_tool_error
 (* Handlers moved to [Keeper_tools_oas_handler] — see
    keeper_tools_oas_handler.mli for [make_keeper_tool_handler],
    [make_tool_bundle], and [make_tools]. *)
-

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -8,15 +8,6 @@
 
     @since Phase 4 — Keeper → Agent.run() migration *)
 
-(** Re-export of [Keeper_types.tool_call_entry] so dashboard code
-    using [e.Keeper_tools_oas.count] keeps compiling. *)
-type tool_call_entry = Keeper_types.tool_call_entry =
-  { count : int
-  ; successes : int
-  ; failures : int
-  ; last_used_at : float
-  }
-
 (** Bundle returned by [make_tool_bundle]: the [Agent_sdk.Tool.t list]
     plus a [cleanup] thunk that releases the per-turn sandbox
     runtimes. *)
@@ -26,7 +17,7 @@ type tool_bundle =
   }
 
 (** Per-keeper tool usage view from [Keeper_registry]. *)
-val tool_usage_for_keeper : string -> (string * tool_call_entry) list
+val tool_usage_for_keeper : string -> (string * Keeper_types.tool_call_entry) list
 
 (** Project [tool_usage_for_keeper] to a JSON array. *)
 val tool_usage_json : string -> Yojson.Safe.t
@@ -148,4 +139,3 @@ val transient_mutex_contention_tool_error
     runtimes (Docker case). *)
 
 (** Convenience over [make_tool_bundle] returning only [.tools]. *)
-


### PR DESCRIPTION
## Summary
- Remove the `Keeper_tools_oas.tool_call_entry` type re-export kept for old dashboard record-label access.
- Return `Keeper_types.tool_call_entry` directly from `tool_usage_for_keeper`.
- Move the remaining dashboard fallback record-label access to `Keeper_types`.

## Validation
- `rg -n "Keeper_tools_oas\\.tool_call_entry|type tool_call_entry = Keeper_types\\.tool_call_entry|e\\.Keeper_tools_oas\\.|using \\[e\\.Keeper_tools_oas\\.count\\]" lib test docs` returns no matches
- `ocamlformat --check lib/keeper/keeper_tools_oas.ml lib/keeper/keeper_tools_oas.mli lib/dashboard/dashboard_mission_assembly.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_tools_oas.ml lib/keeper/keeper_tools_oas.mli lib/dashboard/dashboard_mission_assembly.ml`
- `git diff --check origin/main...HEAD`
- `scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD`
- `scripts/lint/godfile-size-regression.sh`
- `scripts/code-smell-ratchet.sh`
- `scripts/ci/check-determinism-contract.sh`

## Gap
- `scripts/dune-local.sh build lib/keeper/keeper_tools_oas.cmx lib/dashboard/dashboard_mission_assembly.cmx` blocked with exit 75 by the machine-wide bare Dune guard; full typechecking is left to GitHub CI.