### PR TITLE
[codex] Show tool output previews in session traces

### DIFF
--- a/dashboard/src/components/session-trace/session-trace-entry.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.test.ts
@@ -210,6 +210,21 @@ describe('SessionTraceEntry', () => {
     expect(screen.getByText('Error')).toBeTruthy()
   })
 
+  it('surfaces redacted tool I/O preview state when full details are withheld', () => {
+    const { container } = render(h(SessionTraceEntry, {
+      event: sampleToolCallEvent({
+        toolArgs: undefined,
+        toolResult: null,
+        detail: { tool_io_redacted: true },
+      }),
+    }))
+
+    fireEvent.click(container.querySelector('summary') as HTMLElement)
+
+    expect(screen.getByText('Tool I/O preview redacted')).toBeTruthy()
+    expect(container.textContent ?? '').not.toContain('세부 정보가 기록되지 않았습니다.')
+  })
+
   it('renders ThinkingDetail with markdown content when expanded', () => {
     const { container } = render(h(SessionTraceEntry, {
       event: sampleThinkingEvent(),

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -478,6 +478,7 @@ function ResultViewer({ text, hint, isError: isErr }: { text: string; hint: Cont
 
 function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
   const gateRejected = event.gate?.status === 'reject'
+  const toolIoRedacted = event.detail.tool_io_redacted === true
   const resultText = event.error ?? event.toolResult ?? null
   const hint = resultText ? detectContentHint(resultText) : 'plain'
   const codeRouteLink = toolCallCodeRouteLink(event)
@@ -517,7 +518,12 @@ function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
           거부: ${event.gate?.reason ?? ''}
         </div>
       ` : null}
-      ${!event.toolArgs && !resultText && !gateRejected ? html`
+      ${toolIoRedacted ? html`
+        <div class="inline-block rounded-[var(--r-1)] border border-[var(--warn-25)] bg-[var(--warn-10)] px-2 py-1 text-3xs text-[var(--color-status-warn)]">
+          Tool I/O preview redacted
+        </div>
+      ` : null}
+      ${!event.toolArgs && !resultText && !gateRejected && !toolIoRedacted ? html`
         <div class="text-3xs text-[var(--color-fg-disabled)] italic px-2 py-1">
           세부 정보가 기록되지 않았습니다.
         </div>

--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -219,6 +219,7 @@ describe('buildTraceEvents', () => {
             tool_name: 'keeper_fs_read',
             duration_ms: 42,
             tool_args_preview: '{"path":"/tmp/test.txt"}',
+            tool_output_preview: 'file preview',
           },
         }],
         summary: { tasks_completed: 0, tasks_claimed: 0, messages_sent: 0, active_duration_minutes: 0, total_events: 1 },
@@ -229,6 +230,7 @@ describe('buildTraceEvents', () => {
     expect(events[0]!.kind).toBe('tool_call')
     expect(events[0]!.summary).toBe('keeper_fs_read')
     expect(events[0]!.toolArgs).toBe('{"path":"/tmp/test.txt"}')
+    expect(events[0]!.toolResult).toBe('file preview')
   })
 
   it('enriches trajectory rows from tool-call log and suppresses shallow timeline duplicates', () => {

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -637,6 +637,7 @@ function timelineEventToTrace(evt: AgentTimelineEvent, index: number): UnifiedTr
     const toolName = stringField(detail.tool_name) ?? 'TOOL_CALL'
     const durationMs = numberField(detail.duration_ms)
     const toolArgsPreview = stringField(detail.tool_args_preview)
+    const toolOutputPreview = stringField(detail.tool_output_preview)
     const explicitSuccess = typeof detail.success === 'boolean' ? detail.success : undefined
     const errorText = stringField(detail.error)
     const success = explicitSuccess ?? (errorText == null)
@@ -652,8 +653,9 @@ function timelineEventToTrace(evt: AgentTimelineEvent, index: number): UnifiedTr
       operationId: stringField(detail.operation_id) ?? null,
       toolName,
       toolArgs: toolArgsPreview,
+      toolResult: success ? (toolOutputPreview ?? null) : null,
       duration_ms: durationMs,
-      error: success ? null : (errorText ?? 'tool call failed'),
+      error: success ? null : (errorText ?? toolOutputPreview ?? 'tool call failed'),
     }
   }
 


### PR DESCRIPTION
## Summary
- consume `tool_output_preview` from historical `tool_call` timeline rows so session traces show the redacted output preview when durable Tool I/O has not hydrated yet
- use the output preview as failed-tool fallback error text when no explicit error is present
- show an explicit redaction badge when SSE/tool timeline data says Tool I/O previews were withheld

## Validation
- `pnpm exec vitest run --config vitest.config.ts src/components/session-trace/session-trace-state.test.ts src/components/session-trace/session-trace-entry.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/session-trace/session-trace-state.ts src/components/session-trace/session-trace-state.test.ts src/components/session-trace/session-trace-entry.ts src/components/session-trace/session-trace-entry.test.ts`
- `pnpm exec tsc --noEmit --pretty`
- `git diff --check HEAD~1..HEAD`

## Notes
- Browser plugin was not available; local Playwright CLI lacks the `test` runner, so this route was validated with rendered component tests plus static checks.