### PR TITLE
[codex] Prefer namespace truth for runtime count authority

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -36,6 +36,7 @@ const TARGET_FILES = [
   'src/goal-loop-status.ts',
   'src/lib/async-state.ts',
   'src/components/common/normalize.ts',
+  'src/runtime-counts.ts',
   'src/schemas/sse.ts',
   'src/sse.ts',
   'src/tab-refresh.ts',
@@ -67,6 +68,7 @@ const TEST_FILES = [
   'src/dashboard-ws.test.ts',
   'src/goal-loop-status.test.ts',
   'src/lib/async-state.test.ts',
+  'src/runtime-counts.test.ts',
   'src/schemas/sse.test.ts',
   'src/sse-store.test.ts',
 ]

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -37,7 +37,7 @@ describe('resolveRuntimeCounts', () => {
     })
   })
 
-  it('preserves shell configured keepers when namespace counts omit configured keepers', () => {
+  it('keeps namespace-truth as configured authority when shell counts disagree', () => {
     expect(resolveRuntimeCounts({
       executionLoaded: false,
       agentsCount: 0,
@@ -47,8 +47,8 @@ describe('resolveRuntimeCounts', () => {
       shellConfiguredKeepers: 7,
     })).toEqual({
       live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
-      configured: { keepers: 7, totalRuntimes: 8, source: 'shell' },
-      source: 'shell',
+      configured: { keepers: 3, totalRuntimes: 5, source: 'namespace-truth' },
+      source: 'project-snapshot',
     })
   })
 

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -83,18 +83,18 @@ function resolveConfiguredView({
       source: 'namespace-truth',
     }
   }
-  if (shellConfiguredKeepers != null || shellTotalRuntimes > 0) {
-    return {
-      keepers: shellConfiguredKeepers ?? 0,
-      totalRuntimes: shellTotalRuntimes,
-      source: 'shell',
-    }
-  }
   if (namespaceTotalRuntimes > 0) {
     return {
       keepers: namespaceKeepers,
       totalRuntimes: namespaceTotalRuntimes,
       source: 'namespace-truth',
+    }
+  }
+  if (shellConfiguredKeepers != null || shellTotalRuntimes > 0) {
+    return {
+      keepers: shellConfiguredKeepers ?? 0,
+      totalRuntimes: shellTotalRuntimes,
+      source: 'shell',
     }
   }
   return { keepers: 0, totalRuntimes: 0, source: 'none' }


### PR DESCRIPTION
## Summary
- make namespace-truth the configured runtime-count authority whenever a namespace snapshot exists
- keep shell counts as a fallback-only source for cold-start/missing namespace data instead of letting shell win over namespace-truth
- add `runtime-counts` and its regression test to the dashboard ESLint target set so the SSOT resolver stays lint-covered

## Validation
- `pnpm exec vitest run --config vitest.config.ts src/runtime-counts.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/runtime-counts.ts src/runtime-counts.test.ts`
- `pnpm exec tsc --noEmit --pretty`
- `git diff --check`

## Notes
- This is a GOAL-SSOT-01 slice from the Kimi MASC/OAS report: it removes one dashboard-side arbitration case where stale shell configured counts could override namespace-truth configured inventory.