### PR TITLE
refactor(keeper): drop hook model compat args

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -305,11 +305,10 @@ let make_hooks
         let meta = !meta_ref in
         let model = resolve_after_turn_model ~keeper_name:meta.name ~response in
         let usage_trust =
-          classify_usage_trust ?usage:response.usage ~model
-            ~telemetry:response.telemetry ()
+          classify_usage_trust ?usage:response.usage ~telemetry:response.telemetry ()
         in
         let usage_trusted = Keeper_usage_trust.is_trusted usage_trust in
-        record_usage_anomaly_metrics ~keeper_name:meta.name ~model usage_trust;
+        record_usage_anomaly_metrics ~keeper_name:meta.name usage_trust;
         let raw_input_tok, raw_output_tok =
           match response.usage with
           | Some u -> u.input_tokens, u.output_tokens
@@ -371,8 +370,7 @@ let make_hooks
            Missing telemetry stays a separate counter; zero/negative latency
            increments the zero-latency counter and observes a 1ms floor so the
            histogram still proves the hook ran. *)
-        record_llm_inference_latency_metric ~model
-          ~telemetry:response.telemetry;
+        record_llm_inference_latency_metric ~telemetry:response.telemetry;
         record_response_content_quality_metric ~keeper_name:meta.name response;
         let fmt_tok_s = function
           | Some v -> Printf.sprintf "%.1f" v
@@ -401,7 +399,7 @@ let make_hooks
               ~telemetry:response.telemetry
           else None
         in
-        record_llm_tok_s_metrics ~model ~telemetry:response.telemetry;
+        record_llm_tok_s_metrics ~telemetry:response.telemetry;
         let wall_tok_s = fmt_tok_s wall_tok_s_opt in
         let prompt_tok_s = fmt_tok_s prompt_tok_s_opt in
         let decode_tok_s = fmt_tok_s decode_tok_s_opt in
@@ -421,7 +419,7 @@ let make_hooks
          | Some acc ->
            emit_cost_event ~masc_root:acc.masc_root
              ~agent_name:meta.name ~task_id:acc.task_id
-             ~model ~input_tokens:raw_input_tok ~output_tokens:raw_output_tok
+             ~input_tokens:raw_input_tok ~output_tokens:raw_output_tok
              ~cost_usd:cost_usd_for_event ~usage_missing
              ~usage_trust
              ?telemetry:response.telemetry ()

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -52,15 +52,12 @@ val record_response_content_quality_metric :
 
 val classify_usage_trust :
   ?usage:Agent_sdk.Types.api_usage ->
-  model:string ->
   telemetry:Agent_sdk.Types.inference_telemetry option ->
   unit -> Keeper_usage_trust.t
-(** Combine usage and OAS capability telemetry into a usage-trust verdict.
-    The [model] argument is retained for caller compatibility but is not used
-    to reconstruct concrete provider/model identity. *)
+(** Combine usage and OAS capability telemetry into a usage-trust verdict. *)
 
 val record_usage_anomaly_metrics :
-  keeper_name:string -> model:string -> Keeper_usage_trust.t -> unit
+  keeper_name:string -> Keeper_usage_trust.t -> unit
 (** Emit Prometheus counters for each anomaly category in the verdict. *)
 
 (** {1 Cost ledger}
@@ -83,12 +80,10 @@ val record_keeper_tool_duration_metric :
 (** {1 Throughput metrics} *)
 
 val record_llm_tok_s_metrics :
-  model:string ->
   telemetry:Agent_sdk.Types.inference_telemetry option -> unit
 (** Record provider-reported tokens-per-second when telemetry exposes it. *)
 
 val record_llm_inference_latency_metric :
-  model:string ->
   telemetry:Agent_sdk.Types.inference_telemetry option -> unit
 (** Record after-turn inference latency. [request_latency_ms <= 0] is counted
     by [masc_after_turn_telemetry_zero_latency_total] and floored to 1ms in
@@ -121,7 +116,6 @@ val record_cost_emit_source : String.t -> unit
 val cost_event_payload :
   agent_name:string ->
   task_id:string option ->
-  model:string ->
   input_tokens:int ->
   output_tokens:int ->
   cost_usd:float ->
@@ -134,7 +128,6 @@ val emit_cost_event :
   masc_root:string ->
   agent_name:string ->
   task_id:string option ->
-  model:string ->
   input_tokens:int ->
   output_tokens:int ->
   cost_usd:float ->

--- a/lib/keeper/keeper_hooks_oas_cost_events.ml
+++ b/lib/keeper/keeper_hooks_oas_cost_events.ml
@@ -51,7 +51,6 @@ type assembled_cost_event_payload = {
 let assemble_cost_event_payload
     ~(agent_name : string)
     ~(task_id : string option)
-    ~(model : string)
     ~(input_tokens : int)
     ~(output_tokens : int)
     ~(cost_usd : float)
@@ -82,12 +81,11 @@ let assemble_cost_event_payload
     | None ->
         classify_usage_trust
           ?usage:(if usage_missing then None else Some usage_for_trust)
-          ~model ~telemetry ()
+          ~telemetry ()
   in
   let usage_trusted = Keeper_usage_trust.is_trusted usage_trust in
   let safe_input_tokens = if usage_trusted then input_tokens else 0 in
   let safe_output_tokens = if usage_trusted then output_tokens else 0 in
-  let _ = model in
   let provider = runtime_lane_label in
   let runtime_unknown = false in
   let runtime_unmetered = false in
@@ -183,7 +181,6 @@ let assemble_cost_event_payload
 let cost_event_payload
     ~(agent_name : string)
     ~(task_id : string option)
-    ~(model : string)
     ~(input_tokens : int)
     ~(output_tokens : int)
     ~(cost_usd : float)
@@ -194,7 +191,6 @@ let cost_event_payload
   (assemble_cost_event_payload
      ~agent_name
      ~task_id
-     ~model
      ~input_tokens
      ~output_tokens
      ~cost_usd
@@ -211,7 +207,6 @@ let emit_cost_event
     ~(masc_root : string)
     ~(agent_name : string)
     ~(task_id : string option)
-    ~(model : string)
     ~(input_tokens : int)
     ~(output_tokens : int)
     ~(cost_usd : float)
@@ -236,7 +231,6 @@ let emit_cost_event
     assemble_cost_event_payload
       ~agent_name
       ~task_id
-      ~model
       ~input_tokens
       ~output_tokens
       ~cost_usd
@@ -265,4 +259,3 @@ let emit_cost_event
           ();
         Log.Keeper.error "emit_cost_event: failed to write %s: %s"
           (Dated_jsonl.base_dir store) (Printexc.to_string exn))
-

--- a/lib/keeper/keeper_hooks_oas_cost_events.mli
+++ b/lib/keeper/keeper_hooks_oas_cost_events.mli
@@ -22,7 +22,6 @@ val record_cost_emit_source : string -> unit
 val assemble_cost_event_payload
   :  agent_name:string
   -> task_id:string option
-  -> model:string
   -> input_tokens:int
   -> output_tokens:int
   -> cost_usd:float
@@ -35,7 +34,6 @@ val assemble_cost_event_payload
 val cost_event_payload
   :  agent_name:string
   -> task_id:string option
-  -> model:string
   -> input_tokens:int
   -> output_tokens:int
   -> cost_usd:float
@@ -51,7 +49,6 @@ val emit_cost_event
   :  masc_root:string
   -> agent_name:string
   -> task_id:string option
-  -> model:string
   -> input_tokens:int
   -> output_tokens:int
   -> cost_usd:float

--- a/lib/keeper/keeper_hooks_oas_response_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_response_metrics.ml
@@ -120,8 +120,7 @@ let record_response_content_quality_metric ~keeper_name
 (* default_context_max + context_max_of_telemetry moved to
    Keeper_hooks_oas_types (intra-library file split, 2026-05-16). *)
 
-let classify_usage_trust ?usage ~model ~telemetry () =
-  let _ = model in
+let classify_usage_trust ?usage ~telemetry () =
   let usage_reported, usage =
     match usage with
     | Some usage -> true, usage
@@ -132,7 +131,7 @@ let classify_usage_trust ?usage ~model ~telemetry () =
     ~resolved_model_id:runtime_lane_label
     ~context_max:(context_max_of_telemetry telemetry)
 
-let record_usage_anomaly_metrics ~keeper_name ~model usage_trust =
+let record_usage_anomaly_metrics ~keeper_name usage_trust =
   if not (Keeper_usage_trust.is_trusted usage_trust) then
     let reasons =
       match Keeper_usage_trust.reasons usage_trust with
@@ -177,7 +176,6 @@ let record_keeper_tool_duration_metric
     Extracted so the after_turn hook is unit-testable without
     constructing a full [Agent_sdk.Hooks.AfterTurn] event. *)
 let record_llm_tok_s_metrics
-    ~(model : string)
     ~(telemetry : Agent_sdk.Types.inference_telemetry option)
   : unit =
   let prompt_tok_s_opt, decode_tok_s_opt =
@@ -187,7 +185,6 @@ let record_llm_tok_s_metrics
     | _ -> None, None
   in
   let provider_kind_label = runtime_lane_label in
-  let _ = model in
   let provider = runtime_lane_label in
   let labels =
     [ "model", runtime_lane_label
@@ -211,10 +208,8 @@ let record_llm_tok_s_metrics
     zero-latency counter remains the alertable signal; the histogram receives
     a 1ms floor to avoid "hook ran but latency count stayed zero" dashboards. *)
 let record_llm_inference_latency_metric
-    ~(model : string)
     ~(telemetry : Agent_sdk.Types.inference_telemetry option)
   : unit =
-  let _ = model in
   let labels = [("model", runtime_lane_label)] in
   Prometheus.inc_counter Prometheus.metric_after_turn_hook ~labels ();
   match telemetry with
@@ -256,4 +251,3 @@ let wall_tokens_per_second
         Some (Float.of_int output_tokens /. (latency_ms /. ms_per_second))
       | _ -> None)
   | _ -> None
-

--- a/lib/keeper/keeper_hooks_oas_response_metrics.mli
+++ b/lib/keeper/keeper_hooks_oas_response_metrics.mli
@@ -16,16 +16,12 @@ val record_response_content_quality_metric
 
 val classify_usage_trust
   :  ?usage:Agent_sdk.Types.api_usage
-  -> model:string
   -> telemetry:Agent_sdk.Types.inference_telemetry option
   -> unit
   -> Keeper_usage_trust.t
 
 val record_usage_anomaly_metrics
-  :  keeper_name:string
-  -> model:string
-  -> Keeper_usage_trust.t
-  -> unit
+  :  keeper_name:string -> Keeper_usage_trust.t -> unit
 
 val record_keeper_tool_duration_metric
   :  keeper_name:string
@@ -33,13 +29,11 @@ val record_keeper_tool_duration_metric
   -> unit
 
 val record_llm_tok_s_metrics
-  :  model:string
-  -> telemetry:Agent_sdk.Types.inference_telemetry option
+  :  telemetry:Agent_sdk.Types.inference_telemetry option
   -> unit
 
 val record_llm_inference_latency_metric
-  :  model:string
-  -> telemetry:Agent_sdk.Types.inference_telemetry option
+  :  telemetry:Agent_sdk.Types.inference_telemetry option
   -> unit
 
 val wall_tokens_per_second

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -166,7 +166,6 @@ let test_emit_cost_event_writes_inference_telemetry () =
     ~masc_root:root
     ~agent_name:"keeper"
     ~task_id:(Some "task-1")
-    ~model:"provider_k-coding:provider_k-5.1"
     ~input_tokens:11
     ~output_tokens:5
     ~cost_usd:0.12
@@ -234,7 +233,6 @@ let test_emit_cost_event_marks_usage_missing () =
     ~masc_root:root
     ~agent_name:"keeper"
     ~task_id:None
-    ~model:"cli_tool_c:model-c-coding"
     ~input_tokens:0
     ~output_tokens:0
     ~cost_usd:0.0
@@ -266,7 +264,6 @@ let test_emit_cost_event_redacts_typed_provider_kind_for_bare_model () =
     ~masc_root:root
     ~agent_name:"keeper"
     ~task_id:None
-    ~model:"model-c-coding"
     ~input_tokens:0
     ~output_tokens:0
     ~cost_usd:0.0
@@ -309,7 +306,6 @@ let test_emit_cost_event_writes_wall_tok_s_without_provider_timings () =
     ~masc_root:root
     ~agent_name:"keeper"
     ~task_id:None
-    ~model:"ollama:qwen3.6:27b-coding-nvfp4"
     ~input_tokens:100
     ~output_tokens:50
     ~cost_usd:0.0
@@ -359,7 +355,6 @@ let test_emit_cost_event_derives_wall_tok_s_after_first_chunk () =
     ~masc_root:root
     ~agent_name:"keeper"
     ~task_id:None
-    ~model:"ollama:qwen3.6:27b-coding-nvfp4"
     ~input_tokens:100
     ~output_tokens:50
     ~cost_usd:0.0
@@ -395,7 +390,6 @@ let test_emit_cost_event_marks_untrusted_usage () =
     ~masc_root:root
     ~agent_name:"keeper"
     ~task_id:None
-    ~model:"ollama:qwen3.6:27b-coding-nvfp4"
     ~input_tokens:2_000_000
     ~output_tokens:50
     ~cost_usd:0.99
@@ -451,7 +445,6 @@ let test_emit_cost_event_marks_unpriced_paid_model () =
     ~masc_root:root
     ~agent_name:"keeper"
     ~task_id:None
-    ~model:"future-provider_d-model-v9"
     ~input_tokens:1000
     ~output_tokens:500
     ~cost_usd:0.0
@@ -496,7 +489,6 @@ let test_emit_cost_event_records_auto_resolution_source () =
     ~masc_root:root
     ~agent_name:"keeper"
     ~task_id:None
-    ~model:"auto"
     ~input_tokens:1000
     ~output_tokens:500
     ~cost_usd:0.01
@@ -532,7 +524,6 @@ let test_emit_cost_event_records_provider_prefixed_auto_resolution_source () =
     ~masc_root:root
     ~agent_name:"keeper"
     ~task_id:None
-    ~model:"cli_tool_c:auto"
     ~input_tokens:1000
     ~output_tokens:500
     ~cost_usd:0.0
@@ -690,7 +681,7 @@ let test_record_llm_tok_s_metrics_both_histograms_observe () =
   let decode_sum_before, decode_count_before =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_decode_tok_per_sec ~labels
   in
-  Hooks.record_llm_tok_s_metrics ~model:"ollama:qwen3.6" ~telemetry:(Some telemetry);
+  Hooks.record_llm_tok_s_metrics ~telemetry:(Some telemetry);
   let prompt_sum_after, prompt_count_after =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_prompt_tok_per_sec ~labels
   in
@@ -721,9 +712,7 @@ let test_record_llm_tok_s_metrics_timings_none_is_noop () =
   let _, decode_count_before =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_decode_tok_per_sec ~labels
   in
-  Hooks.record_llm_tok_s_metrics
-    ~model:"agent_llm_a:model-a-haiku"
-    ~telemetry:(Some telemetry);
+  Hooks.record_llm_tok_s_metrics ~telemetry:(Some telemetry);
   let _, prompt_count_after =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_prompt_tok_per_sec ~labels
   in
@@ -761,7 +750,7 @@ let test_record_llm_tok_s_metrics_zero_value_is_skipped () =
   let _, decode_count_before =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_decode_tok_per_sec ~labels
   in
-  Hooks.record_llm_tok_s_metrics ~model:"provider_d:gpt-5.4" ~telemetry:(Some telemetry);
+  Hooks.record_llm_tok_s_metrics ~telemetry:(Some telemetry);
   let _, prompt_count_after =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_prompt_tok_per_sec ~labels
   in
@@ -782,7 +771,7 @@ let test_record_llm_tok_s_metrics_none_telemetry_is_noop () =
   let _, prompt_count_before =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_prompt_tok_per_sec ~labels
   in
-  Hooks.record_llm_tok_s_metrics ~model:"unknown:nothing" ~telemetry:None;
+  Hooks.record_llm_tok_s_metrics ~telemetry:None;
   let _, prompt_count_after =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_prompt_tok_per_sec ~labels
   in
@@ -823,11 +812,10 @@ let test_summarize_thinking_blocks_none () =
   check string "none kind" "none" summary.thinking_kind
 ;;
 
-let inference_latency_labels _model = [ "model", "runtime" ]
+let inference_latency_labels = [ "model", "runtime" ]
 
 let test_record_llm_inference_latency_metric_positive_observes () =
-  let model = "latency-positive-test-model" in
-  let labels = inference_latency_labels model in
+  let labels = inference_latency_labels in
   let telemetry = make_telemetry ~request_latency_ms:42 () in
   let sum_before, count_before =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_inference_duration ~labels
@@ -838,7 +826,7 @@ let test_record_llm_inference_latency_metric_positive_observes () =
       ~labels
       ()
   in
-  Hooks.record_llm_inference_latency_metric ~model ~telemetry:(Some telemetry);
+  Hooks.record_llm_inference_latency_metric ~telemetry:(Some telemetry);
   let sum_after, count_after =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_inference_duration ~labels
   in
@@ -854,8 +842,7 @@ let test_record_llm_inference_latency_metric_positive_observes () =
 ;;
 
 let test_record_llm_inference_latency_metric_zero_floors () =
-  let model = "latency-zero-test-model" in
-  let labels = inference_latency_labels model in
+  let labels = inference_latency_labels in
   let telemetry = make_telemetry ~request_latency_ms:0 () in
   let sum_before, count_before =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_inference_duration ~labels
@@ -866,7 +853,7 @@ let test_record_llm_inference_latency_metric_zero_floors () =
       ~labels
       ()
   in
-  Hooks.record_llm_inference_latency_metric ~model ~telemetry:(Some telemetry);
+  Hooks.record_llm_inference_latency_metric ~telemetry:(Some telemetry);
   let sum_after, count_after =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_inference_duration ~labels
   in
@@ -882,8 +869,7 @@ let test_record_llm_inference_latency_metric_zero_floors () =
 ;;
 
 let test_record_llm_inference_latency_metric_none_counts_missing () =
-  let model = "latency-missing-test-model" in
-  let labels = inference_latency_labels model in
+  let labels = inference_latency_labels in
   let _, count_before =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_inference_duration ~labels
   in
@@ -893,7 +879,7 @@ let test_record_llm_inference_latency_metric_none_counts_missing () =
       ~labels
       ()
   in
-  Hooks.record_llm_inference_latency_metric ~model ~telemetry:None;
+  Hooks.record_llm_inference_latency_metric ~telemetry:None;
   let _, count_after =
     histogram_snapshot Masc_mcp.Prometheus.metric_llm_inference_duration ~labels
   in


### PR DESCRIPTION
## Summary
- remove unused ~model compatibility arguments from Keeper OAS hook helper APIs
- keep runtime-lane redaction behavior for usage trust, anomaly, tok/s, latency, and cost event telemetry
- update telemetry tests so runtime labels are asserted without passing concrete model strings

## Validation
- rg targeted compatibility grep: clean
- ocamlformat --check touched OCaml files
- ocamlc -stop-after parsing touched OCaml files
- git diff --check origin/main...HEAD
- scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Known gap
- scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe is blocked by the machine-wide bare Dune guard: existing bare dune build --root . processes 12446, 11674, 38246.