### PR TITLE
refactor(keeper): drop lineage model compat args

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-25 18:13:06 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-25 18:20:10 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -345,6 +345,12 @@
             <td><code>Keeper_hooks_oas</code> model compatibility args</td>
             <td><span class="status done">draft PR #18427</span></td>
             <td>Delete unused <code>~model</code> compatibility arguments from usage-trust classification, anomaly metrics, tok/s metrics, latency metrics, and cost event assembly/emission. Runtime-lane redaction remains the only exported label behavior.</td>
+            <td>Targeted compatibility grep is clean. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_generation_lineage</code> model compatibility args</td>
+            <td><span class="status done">draft PR #18429</span></td>
+            <td>Remove unused <code>~model</code> compatibility arguments from the generation-lineage manifest, index-entry, and best-effort append helpers. Handoff and lineage JSON continue to emit the redacted <code>runtime</code> lane.</td>
             <td>Targeted compatibility grep is clean. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>
           <tr>

--- a/lib/keeper/keeper_generation_lineage.ml
+++ b/lib/keeper/keeper_generation_lineage.ml
@@ -106,10 +106,8 @@ let manifest_json
     ~(child : keeper_meta)
     ~(parent_trace_id : string)
     ~(trigger_reason : string)
-    ~(context_ratio : float)
-    ~(model : string) =
+    ~(context_ratio : float) =
   (* RFC-0132 PR-2: lineage emit surface = external boundary; redact via SSOT. *)
-  let _ = model in
   let model =
     Boundary_redaction.to_string Boundary_redaction.runtime_model_label
   in
@@ -158,10 +156,8 @@ let index_entry_json
     ~(child : keeper_meta)
     ~(parent_trace_id : string)
     ~(trigger_reason : string)
-    ~(context_ratio : float)
-    ~(model : string) =
+    ~(context_ratio : float) =
   (* RFC-0132 PR-2: lineage emit surface = external boundary; redact via SSOT. *)
-  let _ = model in
   let model =
     Boundary_redaction.to_string Boundary_redaction.runtime_model_label
   in
@@ -216,8 +212,7 @@ let record_handoff_artifacts
     ~(child : keeper_meta)
     ~(parent_trace_id : string)
     ~(trigger_reason : string)
-    ~(context_ratio : float)
-    ~(model : string) =
+    ~(context_ratio : float) =
   let child_trace_id = Keeper_id.Trace_id.to_string child.runtime.trace_id in
   let manifest_path =
     keeper_generation_manifest_path config child_trace_id
@@ -225,12 +220,12 @@ let record_handoff_artifacts
   let index_path = keeper_generation_index_path config child.name in
   let manifest =
     manifest_json
-      ~parent ~child ~parent_trace_id ~trigger_reason ~context_ratio ~model
+      ~parent ~child ~parent_trace_id ~trigger_reason ~context_ratio
   in
   let index_entry =
     index_entry_json
       ~manifest_path
-      ~parent ~child ~parent_trace_id ~trigger_reason ~context_ratio ~model
+      ~parent ~child ~parent_trace_id ~trigger_reason ~context_ratio
   in
   ignore (Keeper_fs.ensure_dir (Filename.dirname manifest_path));
   match

--- a/lib/keeper/keeper_generation_lineage.mli
+++ b/lib/keeper/keeper_generation_lineage.mli
@@ -59,7 +59,6 @@ val manifest_json :
   parent_trace_id:string ->
   trigger_reason:string ->
   context_ratio:float ->
-  model:string ->
   Yojson.Safe.t
 
 (** Build the per-rollover index-entry JSON appended to the keeper
@@ -71,7 +70,6 @@ val index_entry_json :
   parent_trace_id:string ->
   trigger_reason:string ->
   context_ratio:float ->
-  model:string ->
   Yojson.Safe.t
 
 (** Persist both the manifest (atomic write) and the index entry
@@ -84,7 +82,6 @@ val record_handoff_artifacts :
   parent_trace_id:string ->
   trigger_reason:string ->
   context_ratio:float ->
-  model:string ->
   unit
 
 (** Load a JSON file as [Some json] when present and parseable;

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -103,8 +103,7 @@ let append_lineage_artifacts_best_effort
     ~(child : keeper_meta)
     ~(parent_trace_id : string)
     ~(trigger_reason : string)
-    ~(context_ratio : float)
-    ~(model : string) =
+    ~(context_ratio : float) =
   try
     Keeper_generation_lineage.record_handoff_artifacts
       ~config
@@ -113,7 +112,6 @@ let append_lineage_artifacts_best_effort
       ~parent_trace_id
       ~trigger_reason
       ~context_ratio
-      ~model
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -348,8 +346,7 @@ let maybe_rollover_oas_handoff
                    ~child:updated_meta
                    ~parent_trace_id:(Keeper_id.Trace_id.to_string prev_trace_id)
                    ~trigger_reason
-                   ~context_ratio:ratio
-                   ~model;
+                   ~context_ratio:ratio;
                  { rollover_base with
                    updated_meta;
                    handoff_json = Some handoff_json;

--- a/lib/keeper/keeper_rollover.mli
+++ b/lib/keeper/keeper_rollover.mli
@@ -45,7 +45,6 @@ val append_lineage_artifacts_best_effort :
   parent_trace_id:string ->
   trigger_reason:string ->
   context_ratio:float ->
-  model:string ->
   unit
 
 (** Classify the rollover gate without side effects. The [signal_gate]


### PR DESCRIPTION
## Summary
- remove unused ~model compatibility arguments from Keeper generation-lineage manifest/index helpers
- stop passing the already-redacted rollover model label into best-effort lineage append
- preserve the existing runtime-lane to_model output in handoff/lineage JSON

## Validation
- rg targeted compatibility grep: clean
- ocamlformat --check touched OCaml files
- ocamlc -stop-after parsing touched OCaml files
- git diff --check origin/main...HEAD
- scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Known gap
- scripts/dune-local.sh build test/test_keeper_generation_lineage.exe is blocked by the machine-wide bare Dune guard: existing bare dune build --root . processes 12446, 11674, 38246.