### PR TITLE
feat(work-discovery): add open_prs source for keeper PR review nudges

### DIFF
--- a/lib/keeper/keeper_run_tools_work_discovery.ml
+++ b/lib/keeper/keeper_run_tools_work_discovery.ml
@@ -75,6 +75,46 @@ let section_for_source ~config ~(meta : Keeper_types.keeper_meta) source =
     Some
       "**Board cleanup requested:** inspect stale board posts and use visible board \
        cleanup or curation tools when there is safe cleanup work."
+  | "open_prs" ->
+    let repos_text =
+      match Repo_store.load_all ~base_path:config.base_path with
+      | Ok [] ->
+        "jeong-sik/masc-mcp"
+      | Ok repos ->
+        let slugs =
+          List.filter_map (fun (r : Repo_manager_types.repository) ->
+            match String.split_on_char '/' r.name with
+            | [ _owner; _name ] -> Some r.name
+            | _ ->
+              (* Try extracting owner/name from URL *)
+              match String.split_on_char '/' r.url with
+              | parts ->
+                let len = List.length parts in
+                if len >= 2 then
+                  let rec nth = function
+                    | [], _ -> None
+                    | x :: _, 0 -> Some x
+                    | _ :: xs, n -> nth (xs, n - 1)
+                  in
+                  (match nth (parts, len - 2), nth (parts, len - 1) with
+                   | Some o, Some n ->
+                     let n = String.map (fun c -> if c = '.' then '_' else c) n in
+                     Some (o ^ "/" ^ n)
+                   | _ -> Some r.name)
+                else Some r.name)
+            repos
+        in
+        (match slugs with [] -> "jeong-sik/masc-mcp" | _ -> String.concat ", " slugs)
+      | Error _ -> "jeong-sik/masc-mcp"
+    in
+    Some
+      (Printf.sprintf
+         "**Open PR review:** call `keeper_pr_list` with `repo=\"%s\"` to find PRs \
+          without review comments. For each unreviewed PR, use `keeper_pr_review_read` \
+          to read the diff, then `keeper_pr_review_comment` to leave a substantive \
+          review. Skip PRs with 3+ review comments or already approved. One thorough \
+          review per cycle is more valuable than skimming many."
+         repos_text)
   | _ -> None
 ;;
 


### PR DESCRIPTION
## Summary

- Add `"open_prs"` match case to `section_for_source` in `keeper_run_tools_work_discovery.ml`
- When enabled, keepers receive periodic nudge text listing registered repos with specific tool call instructions (`keeper_pr_list` → `keeper_pr_review_read` → `keeper_pr_review_comment`)
- Reads repos from `repositories.toml` via `Repo_store.load_all`, falls back to `jeong-sik/masc-mcp` when empty
- Extracts `owner/name` slugs from both `repository.name` and `repository.url` fields

## Root cause

Keepers stopped reviewing PRs because:
1. **work_discovery had no `"open_prs"` source** — the system that injects discoverable work items into every keeper turn only knew about `unclaimed_tasks`, `verification_tasks`, `stale_tasks`, and `board_cleanup`
2. **Prompt-only guidance is insufficient** — despite `work_discovery_guidance` being set to include PR review instructions on all 15 keepers, 0 `keeper_pr` tool calls occurred across all traces. LLMs (qwen/kimi) don't spontaneously initiate 4-step tool chains from prompt text alone without structural nudge injection
3. **`_ -> None` catch-all silently drops unknown sources** — keeper `work_discovery_sources` arrays contained strings like `"github_issues"`, `"lint_errors"`, `"board_posts"` that were all silently ignored

## Test plan

- [x] `dune build --root . lib/keeper/keeper_run_tools_work_discovery.ml` compiles clean
- [ ] Deploy and monitor `system_log` for "Discovered Work" entries containing "Open PR review"
- [ ] Verify `keeper_pr_list` tool calls appear in keeper traces within 2 discovery intervals (~20 min)
- [ ] Verify nudge text includes correct repo slugs from `repositories.toml`

## Deployment note

After merge, all 16 keeper JSON files in `~/me/.masc/keepers/` need `"open_prs"` added to their `work_discovery_sources` arrays (already done locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)