### PR TITLE
fix(cascade): strip request_path version collision for Z.ai /v4 endpoints

### DIFF
--- a/lib/cascade/cascade_config_provider_binding.ml
+++ b/lib/cascade/cascade_config_provider_binding.ml
@@ -126,6 +126,35 @@ let trim_trailing_slash path =
     String.sub path 0 (String.length path - 1)
   else path
 
+let is_version_segment s =
+  let len = String.length s in
+  len >= 2
+  && s.[0] = 'v'
+  && let rec all_digits i =
+       i >= len || (Char.isdigit s.[i] && all_digits (i + 1))
+     in
+     all_digits 1
+
+let last_path_segment path =
+  match String.rindex_opt path '/' with
+  | Some idx -> String.sub path (idx + 1) (String.length path - idx - 1)
+  | None -> path
+
+let strip_leading_version request_path =
+  let len = String.length request_path in
+  if len >= 4 && request_path.[0] = '/' && request_path.[1] = 'v'
+     && Char.isdigit request_path.[2]
+  then
+    let rec find_slash i =
+      if i >= len then len
+      else if request_path.[i] = '/' then i
+      else find_slash (i + 1)
+    in
+    let slash_pos = find_slash 2 in
+    String.sub request_path slash_pos (len - slash_pos)
+  else
+    request_path
+
 let normalize_openai_compat_request_path ~base_url ~request_path =
   let request_path =
     match String.trim request_path with
@@ -144,4 +173,12 @@ let normalize_openai_compat_request_path ~base_url ~request_path =
       "/"
       ^ String.sub request_path suffix_start
           (String.length request_path - suffix_start)
-    else request_path
+    else if is_version_segment (last_path_segment base_path)
+         && String.length request_path >= 4
+         && request_path.[0] = '/'
+         && request_path.[1] = 'v'
+         && Char.isdigit request_path.[2]
+    then
+      strip_leading_version request_path
+    else
+      request_path

--- a/test/dune
+++ b/test/dune
@@ -1413,6 +1413,11 @@
  (modules keeper_tool_matrix_case_runner)
  (libraries masc_test_deps keeper_tool_matrix_cases_lib))
 
+(test
+ (name test_normalize_request_path)
+ (modules test_normalize_request_path)
+ (libraries masc_test_deps))
+
 ; Individual test stanzas — each in its own file to prevent
 ; merge conflicts when multiple PRs add tests concurrently.
 ; To add a new test: create test/stanzas/test_name.inc and

--- a/test/test_normalize_request_path.ml
+++ b/test/test_normalize_request_path.ml
@@ -1,0 +1,81 @@
+open Alcotest
+
+module Normalize = Masc_mcp.Cascade_config
+
+let normalize = Normalize.normalize_openai_compat_request_path
+
+let () =
+  run "normalize_request_path"
+    [ ( "exact_prefix_dedup",
+        [
+          test_case "openai /v1 base + /v1/chat/completions → /chat/completions"
+            `Quick
+            (fun () ->
+              check
+                string
+                "strips duplicated /v1"
+                "/chat/completions"
+                (normalize
+                   ~base_url:"https://api.openai.com/v1"
+                   ~request_path:"/v1/chat/completions"));
+
+          test_case "deep path /a/b/v2 + /v2/chat/completions → /chat/completions"
+            `Quick
+            (fun () ->
+              check
+                string
+                "strips duplicated deep path"
+                "/chat/completions"
+                (normalize
+                   ~base_url:"https://host.example.com/a/b/v2"
+                   ~request_path:"/v2/chat/completions"));
+        ] );
+      ( "version_collision",
+        [
+          test_case "z.ai /v4 base + /v1/chat/completions → /chat/completions"
+            `Quick
+            (fun () ->
+              check
+                string
+                "strips /v1 prefix when base ends with /v4"
+                "/chat/completions"
+                (normalize
+                   ~base_url:"https://api.z.ai/api/coding/paas/v4"
+                   ~request_path:"/v1/chat/completions"));
+
+          test_case "ollama_cloud /v1 base + /v1/chat/completions → /chat/completions"
+            `Quick
+            (fun () ->
+              check
+                string
+                "same version handled by exact_prefix path"
+                "/chat/completions"
+                (normalize
+                   ~base_url:"https://ollama.com/v1"
+                   ~request_path:"/v1/chat/completions"));
+        ] );
+      ( "no_collision",
+        [
+          test_case "non-versioned base + /v1/chat/completions → unchanged"
+            `Quick
+            (fun () ->
+              check
+                string
+                "no stripping when base has no version segment"
+                "/v1/chat/completions"
+                (normalize
+                   ~base_url:"https://api.example.com/chat"
+                   ~request_path:"/v1/chat/completions"));
+
+          test_case "empty base → unchanged"
+            `Quick
+            (fun () ->
+              check
+                string
+                "no stripping for empty base"
+                "/v1/chat/completions"
+                (normalize
+                   ~base_url:"https://api.example.com"
+                   ~request_path:"/v1/chat/completions"));
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- `normalize_openai_compat_request_path`에 cross-version collision fallback 추가
- base_url의 마지막 path segment가 version identifier (예: `/v4`)이고, request_path가 다른 버전 (예: `/v1/chat/completions`)으로 시작하면 leading version을 strip

## Problem
Z.ai에는 2개의 별도 API가 있다 (OAS `zai_catalog.ml` 기준):

| API | Base URL |
|-----|----------|
| Z.ai General | `https://api.z.ai/api/paas/v4` |
| Z.ai Coding | `https://api.z.ai/api/coding/paas/v4` |

OAS SDK의 `Provider_d_compat`는 항상 `/v1/chat/completions`를 기본 request_path로 사용.
→ 최종 URL: `https://api.z.ai/api/coding/paas/v4/v1/chat/completions` → **HTTP 404**

기존 exact-prefix dedup은 동일 버전 충돌(`/v1` + `/v1/...`)만 처리. cross-version 충돌(`/v4` + `/v1/...`)은 누락.

## Fix
3개 헬퍼 함수 추가 후 `normalize_openai_compat_request_path`에 두 번째 fallback 브랜치 추가:
1. `is_version_segment`: 문자열이 `v` + digits 패턴인지 검사
2. `last_path_segment`: 마지막 `/` 이후 segment 추출
3. `strip_leading_version`: request_path에서 leading `/vN` 제거

처리 순서:
1. exact prefix match (기존) — `/v1` base + `/v1/...` request → strip
2. version collision (신규) — `/v4` base + `/v1/...` request → strip leading `/v1`
3. no match → request_path 그대로

Z.ai General과 Coding 모두 동일하게 `/v4`로 끝나므로 하나의 fix로 커버.

## Test plan
- [x] `test_normalize_request_path.ml` — 6 test cases (exact_prefix_dedup × 2, version_collision × 2, no_collision × 2)
- [ ] `dune runtest` — main의 pre-existing coord library build error로 실행 불가 (별도 수정 필요)
- [ ] Z.ai coding provider 실제 호출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)