### PR TITLE
fix(bash): add negative hint to prevent command/cmd field hallucination

### DIFF
--- a/lib/tool_shard_types_schemas_bash.ml
+++ b/lib/tool_shard_types_schemas_bash.ml
@@ -107,8 +107,11 @@ let keeper_bash_description =
   "Execute one command through the typed execution gates via typed argv. \
    Provide EITHER executable/argv OR pipeline, never both. If both are \
    provided, executable takes precedence. Use executable/argv for one process, \
-   or pipeline for explicit Shell IR pipelines. Accepted fields: executable, \
-   argv, pipeline, env, cwd, timeout_sec. Shell metacharacters in argv are \
+   or pipeline for explicit Shell IR pipelines. IMPORTANT: there is no 'cmd' \
+   or 'command' field. Those fields are not supported and will be rejected. \
+   Always use 'executable' (string) and 'argv' (string array) instead. \
+   Accepted fields: executable, argv, pipeline, env, cwd, timeout_sec. \
+   Shell metacharacters in argv are \
    data, not syntax. Good: executable='git' argv=['status','--short'], \
    pipeline=[{executable='git',...}, {executable='head',...}]. Runs in the \
    keeper sandbox by default; use cwd to target an explicit allowed directory. \


### PR DESCRIPTION
## Summary
- Add explicit "no cmd/command field" negative hint to `keeper_bash` tool description
- LLM keepers generate ~20 rejected calls/day using `{"command": "..."}` instead of `{"executable": "...", "argv": [...]}`
- Same approach as PR #18374 (keeper_pr_create negative hint)

## Test plan
- [ ] Verify keeper_bash tool description includes negative hint
- [ ] Monitor system_log for reduction in "unsupported field: command" rejections over 24h

Closes: #18410

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>