### PR TITLE
refactor(keeper): drop unified metric model compat args

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-25 18:54:35 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-25 18:32:42 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -349,27 +349,15 @@
           </tr>
           <tr>
             <td><code>Keeper_generation_lineage</code> model compatibility args</td>
-            <td><span class="status done">merged #18429</span></td>
+            <td><span class="status done">draft PR #18429</span></td>
             <td>Remove unused <code>~model</code> compatibility arguments from the generation-lineage manifest, index-entry, and best-effort append helpers. Handoff and lineage JSON continue to emit the redacted <code>runtime</code> lane.</td>
             <td>Targeted compatibility grep is clean. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>
           <tr>
-            <td><code>Keeper_unified_metrics</code> model compatibility args</td>
-            <td><span class="status now">open PR #18435</span></td>
-            <td>Remove compatibility <code>model_used</code> / <code>resolved_model_id</code> inputs from usage-trust classification, context-window observation, latency-bucket recording, and trusted-cost estimation. The public lane stays <code>runtime</code>.</td>
-            <td>Targeted compatibility grep is clean and tests now assert the runtime lane instead of preserving concrete model labels. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
-          </tr>
-          <tr>
-            <td><code>Keeper_oas_checkpoint.partial_response_of_stop</code> model id arg</td>
-            <td><span class="status now">draft PR #18438</span></td>
-            <td>Remove ignored <code>~model_id</code> from synthetic stop responses and update cascade early-stop/error call sites to build the response without pretending a model id is part of the checkpoint contract.</td>
+            <td><code>Keeper_unified_metrics</code> model-label compatibility args</td>
+            <td><span class="status done">draft PR #18435</span></td>
+            <td>Delete ignored <code>model_used</code> / <code>resolved_model_id</code> inputs from usage-trust and unified metric helpers, remove the public <code>provider_kind_of_model_used</code> compatibility helper, and keep metric labels on the redacted <code>runtime</code> lane.</td>
             <td>Targeted compatibility grep is clean. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
-          </tr>
-          <tr>
-            <td><code>Keeper_runtime_contract</code> provider/model compatibility inputs</td>
-            <td><span class="status now">draft PR #18440</span></td>
-            <td>Remove <code>?provider</code> / <code>?model</code> inputs from <code>runtime_contract_json_from_fields</code>, drop runtime-contract provider/model output fields, and remove the model passthrough shim from tool-call runtime-contract helpers.</td>
-            <td>Receipt regression now asserts the provider/model fields are absent, not merely null-compatible. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.mkdir_p</code> compatibility wrapper</td>

--- a/lib/keeper/keeper_hooks_oas_response_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_response_metrics.ml
@@ -127,9 +127,7 @@ let classify_usage_trust ?usage ~telemetry () =
     | None -> false, zero_usage
   in
   Keeper_usage_trust.classify
-    ~usage_reported ~usage ~model_used:runtime_lane_label
-    ~resolved_model_id:runtime_lane_label
-    ~context_max:(context_max_of_telemetry telemetry)
+    ~usage_reported ~usage ~context_max:(context_max_of_telemetry telemetry)
 
 let record_usage_anomaly_metrics ~keeper_name usage_trust =
   if not (Keeper_usage_trust.is_trusted usage_trust) then

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -23,43 +23,27 @@ type tool_result = Keeper_types.tool_result
 let handle_keeper_up = Keeper_turn_up.handle_keeper_up
 let handle_keeper_down = Keeper_turn_lifecycle.handle_keeper_down
 
-let resolved_model_id_for_result ~(meta : keeper_meta)
-    (result : Keeper_agent_run.run_result) : string =
-  Cascade_runtime_candidate.resolve_reported_runtime_id
-    ~labels:(Keeper_model_labels.configured_model_labels_of_meta meta)
-    ~reported_runtime_id:result.model_used
-
-let turn_cost_for_result ~(meta : keeper_meta)
-    (result : Keeper_agent_run.run_result) : float =
-  let resolved_model_id = resolved_model_id_for_result ~meta result in
-  let surface_model_used = Keeper_agent_run.runtime_lane_label in
+let turn_cost_for_result (result : Keeper_agent_run.run_result) : float =
   let usage_trust =
     Keeper_unified_metrics.classify_usage_trust
       ~usage_reported:result.usage_reported
       ~usage:result.usage
-      ~model_used:surface_model_used
-      ~resolved_model_id
       ~context_max:0
   in
   if Keeper_unified_metrics.usage_trust_is_trusted usage_trust then
     Keeper_unified_metrics.estimate_trusted_usage_cost_usd
       ~usage_trusted:true
-      ~model:resolved_model_id
       result.usage
   else 0.0
 
 let update_direct_turn_meta (meta : keeper_meta) ~(latency_ms : int)
     (result : Keeper_agent_run.run_result) : keeper_meta =
   let now_ts = Time_compat.now () in
-  let turn_cost = turn_cost_for_result ~meta result in
-  let surface_model_used = Keeper_agent_run.runtime_lane_label in
-  let resolved_model_id = resolved_model_id_for_result ~meta result in
+  let turn_cost = turn_cost_for_result result in
   let usage_trust =
     Keeper_unified_metrics.classify_usage_trust
       ~usage_reported:result.usage_reported
       ~usage:result.usage
-      ~model_used:surface_model_used
-      ~resolved_model_id
       ~context_max:0
   in
   let usage_trusted =

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -35,19 +35,15 @@ type usage_trust = Keeper_usage_trust.t =
 val classify_usage_trust :
   usage_reported:bool ->
   usage:Agent_sdk.Types.api_usage ->
-  model_used:string ->
-  resolved_model_id:string ->
   context_max:int ->
   usage_trust
 (** Classify usage counters without reconstructing concrete provider/model
-    identity. [model_used] and [resolved_model_id] are retained for legacy
-    call sites but collapsed to the neutral runtime lane. *)
+    identity. *)
 
 val usage_trust_is_trusted : usage_trust -> bool
 
 val estimate_trusted_usage_cost_usd :
   usage_trusted:bool ->
-  model:string ->
   Agent_sdk.Types.api_usage ->
   float
 (** Return the OAS-reported turn cost for trusted usage.  MASC does not
@@ -102,8 +98,6 @@ val context_max_bucket : int -> string
 
 val record_context_max_observation :
   keeper:string ->
-  model_used:string ->
-  resolved_model_id:string ->
   context_max:int ->
   unit
 (** #9953: emit the
@@ -136,15 +130,9 @@ val long_turn_warn_threshold_ms : unit -> int
 val record_turn_latency_bucket :
   keeper:string -> latency_ms:int -> unit
 
-val provider_kind_of_model_used : string -> string
-(** Legacy metric label value for provider kind.  Keeper-facing metrics emit the
-    neutral ["runtime"] lane instead of deriving provider identity. *)
-
 val record_turn_latency_by_model_bucket :
   keeper:string ->
   channel:string ->
-  model_used:string ->
-  resolved_model_id:string ->
   cascade_profile:string ->
   latency_ms:int ->
   unit

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -262,10 +262,6 @@ let append_decision_record
         ( "telemetry",
           match result with
           | Some r ->
-              let surface_model_used = Keeper_agent_run.runtime_lane_label in
-              let resolved_model_id =
-                Keeper_agent_run.runtime_lane_label
-              in
               let telemetry_reported = telemetry_reported_of_result r in
               let coverage_reason = coverage_reason_of_result r in
               let coverage_stage = coverage_stage_of_result r in
@@ -273,8 +269,6 @@ let append_decision_record
                 classify_usage_trust
                   ~usage_reported:r.usage_reported
                   ~usage:r.usage
-                  ~model_used:surface_model_used
-                  ~resolved_model_id
                   ~context_max:0
               in
               let thinking_enabled_field =

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -20,14 +20,10 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
     ?(context_max = 0)
     (result : Keeper_agent_run.run_result) : keeper_meta =
   let now_ts = Time_compat.now () in
-  let surface_model_used = Keeper_agent_run.runtime_lane_label in
-  let resolved_model_id = Keeper_agent_run.runtime_lane_label in
   let usage_trust =
     classify_usage_trust
       ~usage_reported:result.usage_reported
       ~usage:result.usage
-      ~model_used:surface_model_used
-      ~resolved_model_id
       ~context_max
   in
   (* #9959: surface classification into Prometheus exactly once per
@@ -50,7 +46,6 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
   let turn_cost =
     estimate_trusted_usage_cost_usd
       ~usage_trusted
-      ~model:surface_model_used
       result.usage
   in
   let substantive_tool_call_count =
@@ -249,4 +244,3 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
     ~keeper_name:updated_meta.name
     ~total_cost_usd:updated_meta.runtime.usage.total_cost_usd;
   updated_meta
-

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -25,25 +25,17 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
   let now_ts = Time_compat.now () in
   let _observation = observation in
   let turn_mode = turn_mode_of_result result in
-  let surface_model_used = Keeper_agent_run.runtime_lane_label in
-  let resolved_model_id = Keeper_agent_run.runtime_lane_label in
   let usage_trust =
     classify_usage_trust
       ~usage_reported:result.usage_reported
       ~usage:result.usage
-      ~model_used:surface_model_used
-      ~resolved_model_id
       ~context_max
   in
-  (* #9953: record the (keeper, model_used, resolved_model_id,
-     context_max_bucket) tuple so dashboards can directly count
-     drift.  A model whose label takes >1 bucket on a single
-     deployment indicates the resolution path produced
-     different ceilings on different turns. *)
+  (* #9953: record context_max_bucket on the neutral runtime lane so
+     dashboards can directly count drift without preserving provider/model
+     identity at the MASC boundary. *)
   record_context_max_observation
     ~keeper:meta.name
-    ~model_used:surface_model_used
-    ~resolved_model_id
     ~context_max;
   let scheduled_autonomous_outcome =
     if is_scheduled_autonomous_channel channel then
@@ -93,12 +85,10 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
   in
   (* #9933: same latency bucket, split by provider/model/cascade.
      This keeps the existing keeper-only counter stable while making
-     timeout-budget burn attributable to a concrete model surface. *)
+     timeout-budget burn attributable to the redacted runtime lane. *)
   record_turn_latency_by_model_bucket
     ~keeper:meta.name
     ~channel
-    ~model_used:surface_model_used
-    ~resolved_model_id
     ~cascade_profile
     ~latency_ms;
   Prometheus.inc_counter

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -82,14 +82,8 @@ let runtime_lane_label =
 
 let classify_usage_trust ~(usage_reported : bool)
     ~(usage : Agent_sdk.Types.api_usage)
-    ~(model_used : string)
-    ~(resolved_model_id : string)
     ~(context_max : int) : usage_trust =
-  let _ = model_used, resolved_model_id in
-  Keeper_usage_trust.classify ~usage_reported ~usage
-    ~model_used:runtime_lane_label
-    ~resolved_model_id:runtime_lane_label
-    ~context_max
+  Keeper_usage_trust.classify ~usage_reported ~usage ~context_max
 
 (* #9953: bucket the raw [context_max] integer into a tightly
    bounded vocabulary so the Prometheus label cardinality stays
@@ -115,10 +109,7 @@ let context_max_bucket (n : int) : string =
 
 let record_context_max_observation
     ~(keeper : string)
-    ~(model_used : string)
-    ~(resolved_model_id : string)
     ~(context_max : int) : unit =
-  let _ = model_used, resolved_model_id in
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_context_max_observed
     ~labels:
@@ -184,29 +175,24 @@ let label_or_unknown raw =
   let trimmed = String.trim raw in
   if trimmed = "" then "unknown" else trimmed
 
-let provider_kind_of_model_used raw =
-  (* RFC-0132 PR-2: provider kind label = external boundary; redact via SSOT. *)
-  let _ = raw in
-  Boundary_redaction.to_string Boundary_redaction.runtime_provider_label
-
 let record_turn_latency_by_model_bucket
     ~(keeper : string)
     ~(channel : string)
-    ~(model_used : string)
-    ~(resolved_model_id : string)
     ~(cascade_profile : string)
     ~(latency_ms : int) : unit =
   let bucket = turn_latency_bucket latency_ms in
-  let _ = model_used, resolved_model_id in
   let model_used = runtime_lane_label in
   let resolved_model_id = runtime_lane_label in
+  let provider_kind =
+    Boundary_redaction.to_string Boundary_redaction.runtime_provider_label
+  in
   let cascade_profile = label_or_unknown cascade_profile in
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_turn_latency_by_model_bucket
     ~labels:
       [ ("keeper", label_or_unknown keeper)
       ; ("channel", label_or_unknown channel)
-      ; ("provider_kind", provider_kind_of_model_used model_used)
+      ; ("provider_kind", provider_kind)
       ; ("model_used", model_used)
       ; ("resolved_model_id", resolved_model_id)
       ; ("cascade_profile", cascade_profile)
@@ -217,7 +203,7 @@ let record_turn_latency_by_model_bucket
 
 let usage_trust_is_trusted = Keeper_usage_trust.is_trusted
 
-let estimate_trusted_usage_cost_usd ~usage_trusted ~model:_ usage =
+let estimate_trusted_usage_cost_usd ~usage_trusted usage =
   if usage_trusted then
     match usage.Agent_sdk.Types.cost_usd with
     | Some cost when cost > 0.0 -> cost

--- a/lib/keeper/keeper_unified_metrics_support.mli
+++ b/lib/keeper/keeper_unified_metrics_support.mli
@@ -26,8 +26,6 @@ val work_discovery_allows_task_claim : Keeper_types.keeper_meta -> bool
 val classify_usage_trust :
   usage_reported:bool ->
   usage:Agent_sdk.Types.api_usage ->
-  model_used:string ->
-  resolved_model_id:string ->
   context_max:int ->
   usage_trust
 
@@ -35,7 +33,6 @@ val usage_trust_is_trusted : usage_trust -> bool
 
 val estimate_trusted_usage_cost_usd :
   usage_trusted:bool ->
-  model:string ->
   Agent_sdk.Types.api_usage ->
   float
 
@@ -55,8 +52,6 @@ val context_max_bucket : int -> string
 
 val record_context_max_observation :
   keeper:string ->
-  model_used:string ->
-  resolved_model_id:string ->
   context_max:int ->
   unit
 
@@ -64,13 +59,10 @@ val turn_latency_bucket : int -> string
 val long_turn_warn_threshold_ms_default : int
 val long_turn_warn_threshold_ms : unit -> int
 val record_turn_latency_bucket : keeper:string -> latency_ms:int -> unit
-val provider_kind_of_model_used : string -> string
 
 val record_turn_latency_by_model_bucket :
   keeper:string ->
   channel:string ->
-  model_used:string ->
-  resolved_model_id:string ->
   cascade_profile:string ->
   latency_ms:int ->
   unit

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -10,19 +10,14 @@ let runtime_lane_label =
   Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 let turn_cost result =
-  let used_model_id = Keeper_agent_run.runtime_lane_label in
-  let resolved_model_id = Keeper_agent_run.runtime_lane_label in
   let usage_trust_for_cost =
     KUM.classify_usage_trust
       ~usage_reported:result.Keeper_agent_run.usage_reported
       ~usage:result.usage
-      ~model_used:used_model_id
-      ~resolved_model_id
       ~context_max:0
   in
   KUM.estimate_trusted_usage_cost_usd
     ~usage_trusted:(KUM.usage_trust_is_trusted usage_trust_for_cost)
-    ~model:used_model_id
     result.usage
 ;;
 
@@ -519,14 +514,10 @@ let handle
     ~last_provider_timeout_budget;
   let turn_mode = KUM.turn_mode_of_result result in
   let turn_mode_label = KUM.turn_mode_to_string turn_mode in
-  let model_used = Keeper_agent_run.runtime_lane_label in
-  let resolved_model_id = Keeper_agent_run.runtime_lane_label in
   let usage_trust =
     KUM.classify_usage_trust
       ~usage_reported:result.Keeper_agent_run.usage_reported
       ~usage:result.usage
-      ~model_used
-      ~resolved_model_id
       ~context_max:lifecycle.context_max
   in
   let usage_trusted = KUM.usage_trust_is_trusted usage_trust in

--- a/lib/keeper/keeper_usage_trust.ml
+++ b/lib/keeper/keeper_usage_trust.ml
@@ -46,11 +46,7 @@ let add_reason reason reasons =
 
 let classify ~(usage_reported : bool)
     ~(usage : Agent_sdk.Types.api_usage)
-    ~(model_used : string)
-    ~(resolved_model_id : string)
     ~(context_max : int) : t =
-  let _ = model_used in
-  let _ = resolved_model_id in
   if not usage_reported then Usage_missing
   else
     let reasons = ref [] in

--- a/lib/keeper/keeper_usage_trust.mli
+++ b/lib/keeper/keeper_usage_trust.mli
@@ -8,8 +8,6 @@ type t =
 val classify :
   usage_reported:bool ->
   usage:Agent_sdk.Types.api_usage ->
-  model_used:string ->
-  resolved_model_id:string ->
   context_max:int ->
   t
 

--- a/test/test_context_max_observed_9953.ml
+++ b/test/test_context_max_observed_9953.ml
@@ -12,18 +12,16 @@
      2. Boundary behaviour for each bucket transition (off-by-
         one regression guard).
      3. The counter increments on the bucket inferred from the
-        observed value, with the labels operators expect.
-     4. Per-(keeper, model_used, resolved_model_id) bucket
-        isolation — a turn that lands in [200k] must not leak
-        into the [256k] bucket for the same keeper.
+        observed value, on the redacted runtime lane.
+     4. Per-keeper bucket isolation — a turn that lands in [200k]
+        must not leak into the [256k] bucket for the same keeper.
 
    The point of the metric is that
    [count by (model_used, resolved_model_id)
             (masc_keeper_context_max_observed_total)] returning
-   > 1 directly indicates drift.  Test #4 pins this counting
-   contract by exercising two distinct buckets for one
-   (model_used, resolved_model_id) and asserting both labels
-   carry the expected count. *)
+   > 1 directly indicates drift. MASC emits the redacted ["runtime"]
+   lane for both labels. Test #4 pins this counting contract by
+   exercising two distinct buckets for one runtime-lane tuple. *)
 
 let () =
   let dir =
@@ -37,6 +35,7 @@ module UM = Masc_mcp.Keeper_unified_metrics
 module Prom = Masc_mcp.Prometheus
 
 let metric = Masc_mcp.Keeper_metrics.metric_keeper_context_max_observed
+let runtime_label = "runtime"
 
 let counter_for ~keeper ~model_used ~resolved_model_id ~bucket =
   Prom.metric_value_or_zero metric
@@ -99,86 +98,72 @@ let test_bucket_boundary_1m () =
   Alcotest.(check string) "1_048_577 → other" "other"
     (UM.context_max_bucket 1_048_577)
 
-(* The counter increments on the inferred bucket and labels are
-   isolated across (keeper, model_used, resolved_model_id). *)
+(* The counter increments on the inferred bucket and is recorded on
+   the redacted runtime lane. *)
 let test_record_increments_correct_bucket () =
   let keeper = "test-keeper-9953" in
-  let model = "cli_tool_d:auto-9953" in
-  let resolved = "provider_a-model-a-opus" in
   let before_1m =
-    counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+    counter_for ~keeper ~model_used:runtime_label ~resolved_model_id:runtime_label
       ~bucket:"1m"
   in
   let before_256k =
-    counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+    counter_for ~keeper ~model_used:runtime_label ~resolved_model_id:runtime_label
       ~bucket:"256k"
   in
-  UM.record_context_max_observation
-    ~keeper ~model_used:model ~resolved_model_id:resolved
-    ~context_max:1_000_000;
+  UM.record_context_max_observation ~keeper ~context_max:1_000_000;
   Alcotest.(check (float 0.0001))
     "1m bucket +1"
     (before_1m +. 1.0)
-    (counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+    (counter_for ~keeper ~model_used:runtime_label ~resolved_model_id:runtime_label
        ~bucket:"1m");
   Alcotest.(check (float 0.0001))
     "256k bucket unchanged"
     before_256k
-    (counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+    (counter_for ~keeper ~model_used:runtime_label ~resolved_model_id:runtime_label
        ~bucket:"256k")
 
-(* The whole point of the metric: same (model_used,
-   resolved_model_id) pair landing in two buckets directly
-   visible in counter rows.  A future fix that pins context_max
-   to one bucket per pair will see this test still pass — it
-   pins the OBSERVABILITY contract, not the underlying bug. *)
+(* The whole point of the metric: the same runtime-lane tuple landing
+   in two buckets is directly visible in counter rows. A future fix
+   that pins context_max to one bucket per pair will see this test still
+   pass — it pins the OBSERVABILITY contract, not the underlying bug. *)
 let test_drift_visible_as_two_bucket_rows () =
   let keeper = "test-keeper-drift-9953" in
-  let model = "cli_tool_d:auto-drift-9953" in
-  let resolved = "auto-drift-resolved-9953" in
   let before_64k =
-    counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+    counter_for ~keeper ~model_used:runtime_label ~resolved_model_id:runtime_label
       ~bucket:"64k"
   in
   let before_1m =
-    counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+    counter_for ~keeper ~model_used:runtime_label ~resolved_model_id:runtime_label
       ~bucket:"1m"
   in
   (* Simulate the #9953 split: 1 turn lands at 64k, another at 1m. *)
-  UM.record_context_max_observation
-    ~keeper ~model_used:model ~resolved_model_id:resolved
-    ~context_max:64_000;
-  UM.record_context_max_observation
-    ~keeper ~model_used:model ~resolved_model_id:resolved
-    ~context_max:1_000_000;
+  UM.record_context_max_observation ~keeper ~context_max:64_000;
+  UM.record_context_max_observation ~keeper ~context_max:1_000_000;
   Alcotest.(check (float 0.0001))
     "64k bucket recorded one drift turn"
     (before_64k +. 1.0)
-    (counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+    (counter_for ~keeper ~model_used:runtime_label ~resolved_model_id:runtime_label
        ~bucket:"64k");
   Alcotest.(check (float 0.0001))
     "1m bucket recorded the other drift turn"
     (before_1m +. 1.0)
-    (counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+    (counter_for ~keeper ~model_used:runtime_label ~resolved_model_id:runtime_label
        ~bucket:"1m")
 
 (* keeper isolation — a turn for keeper A must not affect
-   keeper B's counters even with identical model labels. *)
+   keeper B's counters on the same runtime lane. *)
 let test_keeper_label_isolation () =
-  let model = "model-iso-9953" in
-  let resolved = "resolved-iso-9953" in
   let before_b =
-    counter_for ~keeper:"keeper-B-9953" ~model_used:model
-      ~resolved_model_id:resolved ~bucket:"1m"
+    counter_for ~keeper:"keeper-B-9953" ~model_used:runtime_label
+      ~resolved_model_id:runtime_label ~bucket:"1m"
   in
   UM.record_context_max_observation
-    ~keeper:"keeper-A-9953" ~model_used:model ~resolved_model_id:resolved
-    ~context_max:1_000_000;
+    ~keeper:"keeper-A-9953" ~context_max:1_000_000;
   Alcotest.(check (float 0.0001))
     "keeper B unaffected"
     before_b
-    (counter_for ~keeper:"keeper-B-9953" ~model_used:model
-       ~resolved_model_id:resolved ~bucket:"1m")
+    (counter_for ~keeper:"keeper-B-9953" ~model_used:runtime_label
+       ~resolved_model_id:runtime_label ~bucket:"1m")
 
 let () =
   Alcotest.run "context_max_observed_9953"

--- a/test/test_keeper_long_turn_9943.ml
+++ b/test/test_keeper_long_turn_9943.ml
@@ -159,21 +159,6 @@ let test_warn_threshold_reads_env () =
    | Some v -> Unix.putenv "MASC_KEEPER_LONG_TURN_WARN_MS" v
    | None -> Unix.putenv "MASC_KEEPER_LONG_TURN_WARN_MS" "")
 
-let test_provider_kind_of_model_used () =
-  Alcotest.(check string) "cli_tool_d label"
-    "runtime" (M.provider_kind_of_model_used "cli_tool_d:auto");
-  Alcotest.(check string) "cli_tool_c label"
-    "runtime" (M.provider_kind_of_model_used " cli_tool_c:model-c-coding ");
-  Alcotest.(check string) "direct api prefix stays distinct from cli"
-    "runtime" (M.provider_kind_of_model_used "agent_llm_a:auto");
-  Alcotest.(check string) "unknown prefixed label is not trusted"
-    "runtime" (M.provider_kind_of_model_used "pretend_provider:model");
-  Alcotest.(check string) "custom endpoint label remains bounded"
-    "runtime" (M.provider_kind_of_model_used "custom:model@https://example.test/v1");
-  Alcotest.(check string) "unprefixed"
-    "runtime" (M.provider_kind_of_model_used "model-d-5.4");
-  Alcotest.(check string) "empty" "runtime" (M.provider_kind_of_model_used "")
-
 let test_record_by_model_bucket () =
   let keeper = "test-keeper-provider-latency-9933" in
   let before =
@@ -181,16 +166,14 @@ let test_record_by_model_bucket () =
       ~keeper
       ~channel:"scheduled_autonomous"
       ~provider_kind:"runtime"
-      ~model_used:"cli_tool_d:auto"
-      ~resolved_model_id:"model-a-sonnet"
+      ~model_used:"runtime"
+      ~resolved_model_id:"runtime"
       ~cascade_profile:"primary"
       ~bucket:"over_1200s"
   in
   M.record_turn_latency_by_model_bucket
     ~keeper
     ~channel:"scheduled_autonomous"
-    ~model_used:"cli_tool_d:auto"
-    ~resolved_model_id:"model-a-sonnet"
     ~cascade_profile:"primary"
     ~latency_ms:1_200_000;
   Alcotest.(check (float 0.0001))
@@ -200,8 +183,8 @@ let test_record_by_model_bucket () =
        ~keeper
        ~channel:"scheduled_autonomous"
        ~provider_kind:"runtime"
-       ~model_used:"cli_tool_d:auto"
-       ~resolved_model_id:"model-a-sonnet"
+       ~model_used:"runtime"
+       ~resolved_model_id:"runtime"
        ~cascade_profile:"primary"
        ~bucket:"over_1200s");
   Alcotest.(check (float 0.0001))
@@ -211,8 +194,8 @@ let test_record_by_model_bucket () =
        ~keeper
        ~channel:"scheduled_autonomous"
        ~provider_kind:"runtime"
-       ~model_used:"cli_tool_d:auto"
-       ~resolved_model_id:"model-a-sonnet"
+       ~model_used:"runtime"
+       ~resolved_model_id:"runtime"
        ~cascade_profile:"tool_use_strict"
        ~bucket:"over_1200s")
 
@@ -242,8 +225,6 @@ let () =
         ] );
       ( "provider-model",
         [
-          Alcotest.test_case "provider kind is runtime lane" `Quick
-            test_provider_kind_of_model_used;
           Alcotest.test_case "records by model/cascade bucket" `Quick
             test_record_by_model_bucket;
         ] );

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4868,7 +4868,6 @@ let test_trusted_usage_cost_uses_oas_reported_cost () =
   let cost =
     UM.estimate_trusted_usage_cost_usd
       ~usage_trusted:true
-      ~model:"model-a-sonnet"
       reported_usage
   in
   check (float 0.001) "OAS-reported trusted cost" 2.535 cost;
@@ -4878,7 +4877,6 @@ let test_trusted_usage_cost_uses_oas_reported_cost () =
     0.0
     (UM.estimate_trusted_usage_cost_usd
        ~usage_trusted:true
-       ~model:"model-a-sonnet"
        result.usage);
   check
     (float 0.001)
@@ -4886,7 +4884,6 @@ let test_trusted_usage_cost_uses_oas_reported_cost () =
     0.0
     (UM.estimate_trusted_usage_cost_usd
        ~usage_trusted:false
-       ~model:"model-a-sonnet"
        reported_usage)
 ;;
 


### PR DESCRIPTION
## Summary
- remove unused model_used/resolved_model_id compatibility args from Keeper usage-trust and unified metric helpers
- remove the public provider_kind_of_model_used compatibility helper and use the runtime provider lane directly
- update metric tests so they assert runtime-lane labels instead of preserving concrete model-label inputs

## Validation
- targeted compatibility grep: clean
- ocamlformat --check touched OCaml files
- ocamlc -stop-after parsing touched OCaml files
- git diff --check origin/main...HEAD
- scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Known gap
- scripts/dune-local.sh build test/test_context_max_observed_9953.exe test/test_keeper_long_turn_9943.exe test/test_keeper_unified.exe is blocked by the machine-wide bare Dune guard: existing bare dune build --root . processes 12446, 11674, 38246.