### PR TITLE
refactor: SSOT cleanup wave 4 — repo_manager thin wrappers + dead exports

### DIFF
--- a/lib/repo_manager/credential_store.ml
+++ b/lib/repo_manager/credential_store.ml
@@ -20,7 +20,6 @@ let default_credential =
     token_sha256_prefix = None;
   }
 
-let ensure_dir path = Fs_compat.mkdir_p path
 let credential_type_of_string = function
   | "Github" | "github" -> Ok Github
   | "Gitlab" | "gitlab" -> Ok Gitlab
@@ -167,7 +166,7 @@ let load_all ~base_path =
 let save_all ~base_path (creds : credential list) =
   let path = creds_toml_path base_path in
   let config_dir = Filename.dirname path in
-  ensure_dir config_dir;
+  Fs_compat.mkdir_p config_dir;
   let cred_entries =
     List.map (fun (cred : credential) -> (cred.id, toml_of_credential cred)) creds
   in

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -8,7 +8,6 @@ let mappings_toml_path base_path =
   (* RFC-0121: layout SSOT via [Config_dir_resolver]. *)
   Config_dir_resolver.keeper_repo_mappings_toml_path ~base_path
 
-let ensure_dir path = Fs_compat.mkdir_p path
 let mapping_of_toml toml keeper_id =
   let path field = ["mapping"; keeper_id; field] in
   let* repository_ids =
@@ -236,7 +235,7 @@ let save_all ~base_path mappings =
   in
   let toml = Otoml.TomlTable [("mapping", Otoml.TomlTable table)] in
   let dir = Filename.dirname path in
-  ensure_dir dir;
+  Fs_compat.mkdir_p dir;
   let content = Otoml.Printer.to_string toml in
   try
     let oc = open_out path in

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -1,6 +1,5 @@
 open Repo_manager_types
 
-let ensure_dir path = Fs_compat.mkdir_p path
 let merge_env overrides =
   let keys = List.map fst overrides in
   let has_key entry =
@@ -75,7 +74,7 @@ let run_git ~cwd ?(env = []) args : (string list, string) result =
 let clone ~repository ~credential =
   let env = env_of_credential credential in
   let parent_dir = Filename.dirname repository.local_path in
-  ensure_dir parent_dir;
+  Fs_compat.mkdir_p parent_dir;
   match
     run_git ~cwd:parent_dir ~env
       ["clone"; repository.url; repository.local_path]
@@ -102,7 +101,7 @@ let checkout_worktree ~repository ~branch =
   let worktree_path =
     Filename.concat repository.local_path (Printf.sprintf "_worktrees/%s" safe_branch_path)
   in
-  ensure_dir (Filename.dirname worktree_path);
+  Fs_compat.mkdir_p (Filename.dirname worktree_path);
   match
     run_git ~cwd:repository.local_path
       ["worktree"; "add"; worktree_path; branch]

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -18,7 +18,6 @@ let default_local_path id = Filename.concat ".masc/repos" id
 
 let now_unix_seconds () = Int64.of_float (Unix.time ())
 
-let ensure_dir path = Fs_compat.mkdir_p path
 let string_of_status = function
   | Active -> "Active"
   | Paused -> "Paused"
@@ -179,7 +178,7 @@ let load_all ~base_path =
 let save_all ~base_path (repos : repository list) =
   let path = repos_toml_path base_path in
   let config_dir = Filename.dirname path in
-  ensure_dir config_dir;
+  Fs_compat.mkdir_p config_dir;
   let repo_entries =
     List.map (fun (repo : repository) -> (repo.id, toml_of_repository repo)) repos
   in


### PR DESCRIPTION
## Summary
- Remove 4 identical `ensure_dir = Fs_compat.mkdir_p` private wrappers in repo_manager, replace call sites with direct `Fs_compat.mkdir_p`
- Remove 2 dead exports (`find_url_by_id`, `find_repo_by_path_prefix`) from `repo_store.ml/.mli` — zero callers anywhere

Follow-up to #18417 (starts_with + strip_trailing_slashes + functor SSOT cleanup, merged).

## Test plan
- [x] `dune build --root .` passes
- [ ] CI lint + structure ratchet pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)