### PR TITLE
fix(build): restore split coord interfaces

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -5,6 +5,9 @@
 
 (* Foundation: utilities and state management *)
 include Coord_utils
+include Coord_backlog
+include Coord_bootstrap
+include Coord_identity
 include Coord_state
 include Coord_broadcast
 
@@ -37,6 +40,7 @@ include Coord_task_schedule
 
 (* Task/agent/message query and listing *)
 include Coord_query
+include Coord_agent
 
 (* Portal / A2A Protocol *)
 

--- a/lib/coord.mli
+++ b/lib/coord.mli
@@ -6,6 +6,9 @@
 (** {1 Included sub-modules} *)
 
 include module type of Coord_utils
+include module type of Coord_backlog
+include module type of Coord_bootstrap
+include module type of Coord_identity
 include module type of Coord_state
 include module type of Coord_broadcast
 include module type of Coord_lifecycle

--- a/lib/coord/coord_agent.ml
+++ b/lib/coord/coord_agent.ml
@@ -6,6 +6,7 @@
 open Masc_domain
 include Coord_utils
 include Coord_state
+open Coord_identity
 
 let get_agents_status config =
   ensure_initialized config;

--- a/lib/coord/coord_gc.ml
+++ b/lib/coord/coord_gc.ml
@@ -6,6 +6,9 @@
 open Masc_domain
 open Coord_utils
 open Coord_state
+open Coord_identity
+open Coord_backlog
+open Coord_task_id
 
 (** Structured result of zombie cleanup to eliminate string-based parsing at call sites. *)
 type cleanup_zombie_result =

--- a/lib/coord/coord_init.ml
+++ b/lib/coord/coord_init.ml
@@ -7,6 +7,7 @@ open Masc_domain
 open Coord_utils
 open Coord_state
 open Coord_broadcast
+open Coord_backlog
 
 (** Initialize MASC room *)
 let init config ~agent_name =

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -7,6 +7,7 @@ open Masc_domain
 open Coord_utils
 open Coord_state
 open Coord_broadcast
+open Coord_identity
 
 (* Single-namespace: room_id/namespace_id concepts retired (#unify-namespace).
    All coordination scoped by cluster basepath only. *)

--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -6,6 +6,8 @@
 open Masc_domain
 include Coord_utils
 include Coord_state
+open Coord_backlog
+open Coord_identity
 
 let update_priority config ~task_id ~priority =
   ensure_initialized config;

--- a/lib/coord/coord_status.ml
+++ b/lib/coord/coord_status.ml
@@ -6,6 +6,7 @@
 open Masc_domain
 open Coord_utils
 open Coord_state
+open Coord_backlog
 
 (** Get room status *)
 let status config =

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -4,6 +4,7 @@
     create, claim sub-modules). *)
 
 open Masc_domain
+open Coord_backlog
 
 include Coord_task_transitions
 

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -8,6 +8,8 @@ open Masc_domain
 include Coord_utils
 include Coord_state
 include Coord_broadcast
+open Coord_backlog
+open Coord_identity
 
 let is_legacy_auto_cycle_do_not_reclaim_reason reason =
   let trimmed = String.trim reason in

--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -9,6 +9,8 @@ open Masc_domain
 include Coord_utils
 include Coord_state
 include Coord_broadcast
+open Coord_backlog
+open Coord_identity
 
 (* activity_room_id removed — namespace retired (#unify-namespace). *)
 

--- a/lib/coord/coord_task_cleanup.ml
+++ b/lib/coord/coord_task_cleanup.ml
@@ -3,6 +3,25 @@ open Masc_domain
 open Coord_utils
 open Coord_state
 
+let worktree_not_found_payload = function
+  | System (System_error.WorktreeNotFound { worktree; searched_in }) ->
+    Some (worktree, searched_in)
+  | System
+      ( System_error.NotInitialized
+      | System_error.AlreadyInitialized
+      | System_error.InvalidJson _
+      | System_error.IoError _
+      | System_error.InvalidFilePath _
+      | System_error.StorageError _
+      | System_error.ValidationError _ )
+  | Task _
+  | Agent _
+  | Auth _
+  | Portal _
+  | RateLimitExceeded _
+  | CacheError _ -> None
+;;
+
 let cleanup_worktree_for_transition config ~agent_name ~task_id task reason_label =
   match task.worktree with
   | None -> ()
@@ -11,14 +30,19 @@ let cleanup_worktree_for_transition config ~agent_name ~task_id task reason_labe
        match Coord_worktree.worktree_remove_r config ~agent_name ~task_id with
        | Ok msg ->
          Log.RoomTask.info "%s worktree auto-cleanup: %s" reason_label msg
-       | Error (System (System_error.WorktreeNotFound { worktree; searched_in })) ->
-         Log.RoomTask.info
-           "%s worktree auto-cleanup: skipped (already absent: worktree=%s searched_in=%s)"
-           reason_label worktree searched_in
        | Error e ->
-         Log.RoomTask.warn
-           "%s worktree auto-cleanup failed (best-effort, suppressed): %s"
-           reason_label (Masc_domain.masc_error_to_string e)
+         (match worktree_not_found_payload e with
+          | Some (worktree, searched_in) ->
+            Log.RoomTask.info
+              "%s worktree auto-cleanup: skipped (already absent: worktree=%s searched_in=%s)"
+              reason_label
+              worktree
+              searched_in
+          | None ->
+            Log.RoomTask.warn
+              "%s worktree auto-cleanup failed (best-effort, suppressed): %s"
+              reason_label
+              (Masc_domain.masc_error_to_string e))
      with
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn ->

--- a/lib/coord/coord_task_create.ml
+++ b/lib/coord/coord_task_create.ml
@@ -8,6 +8,8 @@ open Masc_domain
 include Coord_utils
 include Coord_state
 include Coord_broadcast
+open Coord_backlog
+open Coord_task_id
 
 (** Normalize title for deduplication: lowercase, keep only alphanumeric+space.
     Deterministic string transform — no LLM involved. *)

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -7,6 +7,7 @@
 open Masc_domain
 include Coord_utils
 include Coord_state
+open Coord_backlog
 
 (** #10421: stable lowercase string label for a [task_status] suitable
     for embedding in JSONL diagnostic events.  Mirrors what the

--- a/lib/coord/coord_task_transitions.ml
+++ b/lib/coord/coord_task_transitions.ml
@@ -3,6 +3,7 @@ open Masc_domain
 include Coord_utils
 include Coord_state
 include Coord_broadcast
+open Coord_backlog
 (* Sub-module includes — re-export all bindings from extracted modules. *)
 include Coord_task_classify
 include Coord_task_create
@@ -548,7 +549,13 @@ let transition_task_r
           let duration_ms = match action with
             | Masc_domain.Done_action | Masc_domain.Cancel ->
               Some (max 0 (int_of_float ((now_ts -. task_started_at_unix task.task_status) *. 1000.0)))
-            | _ -> None
+            | Masc_domain.Claim
+            | Masc_domain.Start
+            | Masc_domain.Release
+            | Masc_domain.Submit_for_verification
+            | Masc_domain.Submit_pr_evidence
+            | Masc_domain.Approve_verification
+            | Masc_domain.Reject_verification -> None
           in
           observe_task_transition
             config
@@ -591,4 +598,3 @@ let transition_task_r
       Error (Masc_domain.System (Masc_domain.System_error.IoError (Printexc.to_string e))))
   |> Coord_task_verification.flatten_lock_result
 ;;
-

--- a/lib/keeper/keeper_sandbox_runtime_setup.mli
+++ b/lib/keeper/keeper_sandbox_runtime_setup.mli
@@ -44,7 +44,6 @@ val docker_preflight_max_sec : float
 val docker_preflight_timeout : timeout_sec:float -> float
 val required_commands : string list
 val option_field : 'a -> 'b option -> 'a * [> `Null | `String of 'b ]
-val dedupe_keep_order : string list -> string list
 type cleanup_result = { scanned : int; removed : int; errors : string list; }
 val sandbox_component_label_key : string
 val sandbox_component_label_value : string

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -28,10 +28,10 @@ let tool_usage_json keeper_name : Yojson.Safe.t =
        (fun (name, e) ->
           `Assoc
             [ "tool_name", `String name
-            ; "count", `Int e.count
-            ; "successes", `Int e.successes
-            ; "failures", `Int e.failures
-            ; "last_used_at", `Float e.last_used_at
+            ; "count", `Int e.Keeper_types.count
+            ; "successes", `Int e.Keeper_types.successes
+            ; "failures", `Int e.Keeper_types.failures
+            ; "last_used_at", `Float e.Keeper_types.last_used_at
             ])
        (tool_usage_for_keeper keeper_name))
 ;;
@@ -42,7 +42,8 @@ let record_keeper_internal_tool_call ~tool_name ~success ~duration_ms =
 
 let recent_tools_for_keeper ?(limit = 5) keeper_name : string list =
   tool_usage_for_keeper keeper_name
-  |> List.sort (fun (_, a) (_, b) -> Float.compare b.last_used_at a.last_used_at)
+  |> List.sort (fun (_, a) (_, b) ->
+    Float.compare b.Keeper_types.last_used_at a.Keeper_types.last_used_at)
   |> fun l ->
   let rec take n acc = function
     | [] -> List.rev acc

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -1,8 +1,8 @@
 val default_cascade_name : unit -> string
-val local_recovery_cascade_name : string
-val local_only_cascade_name : string
+val phase_recovery_cascade_name : string
+val phase_buffer_cascade_name : string
 val phase_routing_cascade_names : string list
-val tool_use_strict_cascade_name : string
+val tool_required_cascade_name : string
 val min_keeper_context_tokens : int
 val max_keeper_context_tokens : int
 val alert_error_detail_max_chars : int

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -1,8 +1,8 @@
 val default_cascade_name : unit -> string
-val local_recovery_cascade_name : string
-val local_only_cascade_name : string
+val phase_recovery_cascade_name : string
+val phase_buffer_cascade_name : string
 val phase_routing_cascade_names : string list
-val tool_use_strict_cascade_name : string
+val tool_required_cascade_name : string
 val min_keeper_context_tokens : int
 val max_keeper_context_tokens : int
 val alert_error_detail_max_chars : int

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -1,8 +1,8 @@
 val default_cascade_name : unit -> string
-val local_recovery_cascade_name : string
-val local_only_cascade_name : string
+val phase_recovery_cascade_name : string
+val phase_buffer_cascade_name : string
 val phase_routing_cascade_names : string list
-val tool_use_strict_cascade_name : string
+val tool_required_cascade_name : string
 val min_keeper_context_tokens : int
 val max_keeper_context_tokens : int
 val alert_error_detail_max_chars : int

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -1,8 +1,8 @@
 val default_cascade_name : unit -> string
-val local_recovery_cascade_name : string
-val local_only_cascade_name : string
+val phase_recovery_cascade_name : string
+val phase_buffer_cascade_name : string
 val phase_routing_cascade_names : string list
-val tool_use_strict_cascade_name : string
+val tool_required_cascade_name : string
 val min_keeper_context_tokens : int
 val max_keeper_context_tokens : int
 val alert_error_detail_max_chars : int

--- a/lib/server/server_runtime_startup_maintenance.mli
+++ b/lib/server/server_runtime_startup_maintenance.mli
@@ -13,8 +13,6 @@ val load_current_room_or_default : string -> string -> string option
 val migrate_room_to_flat : Mcp_server.server_state -> unit
 val migrate_legacy_trace_dirs : Mcp_server.server_state -> unit
 val startup_prune_jsonl : Mcp_server.server_state -> unit
-val startup_prune_keeper_checkpoints :
-  Mcp_server.server_state -> unit
 val startup_prune_auth_archive : Mcp_server.server_state -> unit
 val startup_migrate_keeper_histories :
   Mcp_server.server_state -> unit


### PR DESCRIPTION
## Summary
- Cherry-pick of `4eb7e457` (build fix from local branch `fix/coord-split-build-repair-20260525`)
- Restores `include Coord_backlog`, `include Coord_agent`, and other split sub-module references in `coord.ml` facade
- Fixes 5 unbound value errors: `read_backlog`, `read_backlog_r`, `write_backlog`, `resolve_agent_name`, `ensure_room_bootstrap`, `generate_session_id`

## Why
Main branch build was broken — server binary couldn't compile. Blocking deployment of PR #18431 (open_prs work discovery source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)