### PR TITLE
refactor(keeper): drop stop response model compat arg

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-25 18:32:42 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-25 18:38:38 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -357,6 +357,12 @@
             <td><code>Keeper_unified_metrics</code> model-label compatibility args</td>
             <td><span class="status done">draft PR #18435</span></td>
             <td>Delete ignored <code>model_used</code> / <code>resolved_model_id</code> inputs from usage-trust and unified metric helpers, remove the public <code>provider_kind_of_model_used</code> compatibility helper, and keep metric labels on the redacted <code>runtime</code> lane.</td>
+            <td>Targeted compatibility grep is clean. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_oas_checkpoint.partial_response_of_stop</code> model-id arg</td>
+            <td><span class="status done">draft PR #18438</span></td>
+            <td>Remove the ignored <code>~model_id</code> compatibility argument from synthetic early-stop responses and update <code>Cascade_runner</code> callers to rely on the redacted runtime lane directly.</td>
             <td>Targeted compatibility grep is clean. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>
           <tr>

--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -638,7 +638,6 @@ let run
       let partial_response =
         partial_response_of_stop
           ~session_id
-          ~model_id:config.model_id
           ~text:(Printf.sprintf
             "[turn budget exhausted: %d/%d turns used]" r.turns r.limit)
       in
@@ -670,7 +669,6 @@ let run
         let partial_response =
           partial_response_of_stop
             ~session_id
-            ~model_id:config.model_id
             ~text:response_text
         in
         record_dashboard_oas_response ~config
@@ -698,8 +696,7 @@ let run
         enrich_idle_detail detail (Agent_sdk.Agent.state agent).messages
       in
       let error_response =
-        partial_response_of_stop ~session_id ~model_id:config.model_id
-          ~text:detail
+        partial_response_of_stop ~session_id ~text:detail
       in
       record_dashboard_oas_response ~config
         ~total_duration_ms:run_total_duration_ms
@@ -731,8 +728,7 @@ let run
       Printf.sprintf "execution exception: %s" (Printexc.to_string exn)
     in
     let error_response =
-      partial_response_of_stop ~session_id ~model_id:config.model_id
-        ~text:detail
+      partial_response_of_stop ~session_id ~text:detail
     in
     record_dashboard_oas_response ~config
       ~total_duration_ms:(run_duration_ms_since run_started_at)

--- a/lib/keeper/keeper_oas_checkpoint.ml
+++ b/lib/keeper/keeper_oas_checkpoint.ml
@@ -62,11 +62,9 @@ let build_checkpoint ~session_id ?checkpoint_sidecar (agent : Agent_sdk.Agent.t)
 
 let partial_response_of_stop
     ~(session_id : string)
-    ~(model_id : string)
     ~(text : string)
   : Agent_sdk.Types.api_response =
   (* RFC-0132 PR-2: api_response model surface = external boundary; redact via SSOT. *)
-  let _ = model_id in
   {
     id = session_id;
     model = Boundary_redaction.to_string Boundary_redaction.runtime_model_label;

--- a/lib/keeper/keeper_oas_checkpoint.mli
+++ b/lib/keeper/keeper_oas_checkpoint.mli
@@ -66,15 +66,13 @@ val build_checkpoint :
 
 val partial_response_of_stop :
   session_id:string ->
-  model_id:string ->
   text:string ->
   Agent_sdk.Types.api_response
 (** Synthesise an [Agent_sdk.Types.api_response] for the early-stop
     case (e.g. operator-side cancel before the model finishes).
     [stop_reason = EndTurn], single [Text] content block, no
-    usage / telemetry. [model_id] is accepted for legacy call sites but the
-    emitted response model is the neutral [runtime] lane; OAS owns concrete
-    provider/model identity. *)
+    usage / telemetry. The emitted response model is the neutral [runtime]
+    lane; OAS owns concrete provider/model identity. *)
 
 val enrich_idle_detail :
   string ->


### PR DESCRIPTION
## Summary
- remove the ignored ~model_id compatibility argument from Keeper_oas_checkpoint.partial_response_of_stop
- update Cascade_runner early-stop/error response call sites to rely on the redacted runtime lane directly
- keep synthetic stop responses model-redacted to runtime

## Validation
- targeted compatibility grep: clean
- ocamlformat --check touched OCaml files
- ocamlc -stop-after parsing touched OCaml files
- git diff --check origin/main...HEAD
- scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Known gap
- scripts/dune-local.sh build lib/cascade/cascade_runner.ml lib/keeper/keeper_oas_checkpoint.ml is blocked by the machine-wide bare Dune guard: existing bare dune build --root . processes 12446, 11674, 38246.