### PR TITLE
refactor(keeper): drop runtime contract model compat args

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-25 18:20:10 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-25 18:54:35 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -349,9 +349,27 @@
           </tr>
           <tr>
             <td><code>Keeper_generation_lineage</code> model compatibility args</td>
-            <td><span class="status done">draft PR #18429</span></td>
+            <td><span class="status done">merged #18429</span></td>
             <td>Remove unused <code>~model</code> compatibility arguments from the generation-lineage manifest, index-entry, and best-effort append helpers. Handoff and lineage JSON continue to emit the redacted <code>runtime</code> lane.</td>
             <td>Targeted compatibility grep is clean. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_unified_metrics</code> model compatibility args</td>
+            <td><span class="status now">open PR #18435</span></td>
+            <td>Remove compatibility <code>model_used</code> / <code>resolved_model_id</code> inputs from usage-trust classification, context-window observation, latency-bucket recording, and trusted-cost estimation. The public lane stays <code>runtime</code>.</td>
+            <td>Targeted compatibility grep is clean and tests now assert the runtime lane instead of preserving concrete model labels. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_oas_checkpoint.partial_response_of_stop</code> model id arg</td>
+            <td><span class="status now">draft PR #18438</span></td>
+            <td>Remove ignored <code>~model_id</code> from synthetic stop responses and update cascade early-stop/error call sites to build the response without pretending a model id is part of the checkpoint contract.</td>
+            <td>Targeted compatibility grep is clean. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_runtime_contract</code> provider/model compatibility inputs</td>
+            <td><span class="status now">draft PR #18440</span></td>
+            <td>Remove <code>?provider</code> / <code>?model</code> inputs from <code>runtime_contract_json_from_fields</code>, drop runtime-contract provider/model output fields, and remove the model passthrough shim from tool-call runtime-contract helpers.</td>
+            <td>Receipt regression now asserts the provider/model fields are absent, not merely null-compatible. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.mkdir_p</code> compatibility wrapper</td>

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -651,7 +651,6 @@ let make_hooks
            let runtime_contract =
              Keeper_tool_call_log.runtime_contract_json_for_call
                ~keeper_name
-               ~model
                ()
            in
            let action_radius =

--- a/lib/keeper/keeper_hooks_oas_gate_attempt.ml
+++ b/lib/keeper/keeper_hooks_oas_gate_attempt.ml
@@ -100,7 +100,6 @@ let record_pre_tool_gate_attempt
       let runtime_contract =
         Keeper_tool_call_log.runtime_contract_json_for_call
           ~keeper_name
-          ~model
           ()
       in
       let action_radius =

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -211,21 +211,11 @@ let nonempty_list = function
   | Some values -> values
   | None -> []
 
-(* RFC-0132 PR-2: contract surface label = external boundary; redact via SSOT. *)
-let runtime_lane_label =
-  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
-
-let runtime_lane_opt = function
-  | Some value when String.trim value <> "" -> Some runtime_lane_label
-  | _ -> None
-
 let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
     ?session_id ?generation ?keeper_turn_id ?task_id ?goal_ids
     ?sandbox_profile ?sandbox_root ?allowed_paths ?network_mode ?approval_mode ?tool_surface_class
-    ?visible_tool_count ?required_tools ?required_tool_candidates ?missing_required_tools ?provider ?model
+    ?visible_tool_count ?required_tools ?required_tool_candidates ?missing_required_tools
     ?cascade_profile () : Yojson.Safe.t =
-  let provider = runtime_lane_opt provider in
-  let model = runtime_lane_opt model in
   `Assoc
     [
       ("keeper_name", `String keeper_name);
@@ -248,8 +238,6 @@ let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
         Json_util.json_string_list (nonempty_list required_tool_candidates) );
       ( "missing_required_tools",
         Json_util.json_string_list (nonempty_list missing_required_tools) );
-      ("provider", string_opt_json provider);
-      ("model", string_opt_json model);
       ("cascade_profile", string_opt_json cascade_profile);
     ]
 

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -55,14 +55,10 @@ val runtime_contract_json_from_fields :
   ?required_tools:string list ->
   ?required_tool_candidates:string list ->
   ?missing_required_tools:string list ->
-  ?provider:string ->
-  ?model:string ->
   ?cascade_profile:string ->
   unit ->
   Yojson.Safe.t
-(** Build the runtime contract projection from turn-context fields. Optional
-    [provider] and [model] are compatibility inputs only; non-empty values are
-    redacted to the neutral runtime lane. *)
+(** Build the runtime contract projection from turn-context fields. *)
 
 val action_radius_json :
   tool_name:string ->

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -49,8 +49,6 @@ let get_turn_context_record =
   Keeper_tool_call_log_context.get_turn_context_record
 ;;
 
-let optional_model = Keeper_tool_call_log_context.optional_model
-
 let parse_tool_output_json_sanitized =
   Keeper_tool_call_log_route_evidence.parse_tool_output_json_sanitized
 ;;
@@ -688,7 +686,6 @@ let log_call
       let semantic_success, semantic_outcome =
         semantic_outcome_of_output ~success safe_output
       in
-      let model_opt = optional_model (Some model) in
       let runtime_contract =
         Keeper_runtime_contract.runtime_contract_json_from_fields
           ~keeper_name
@@ -709,7 +706,6 @@ let log_call
           ?required_tools
           ?required_tool_candidates
           ?missing_required_tools
-          ?model:model_opt
           ?cascade_profile
           ()
       in

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -68,10 +68,9 @@ val get_turn_context :
 
 val runtime_contract_json_for_call :
   keeper_name:string ->
-  ?model:string ->
   unit ->
   Yojson.Safe.t
-(** [runtime_contract_json_for_call ~keeper_name ?model ()] returns the
+(** [runtime_contract_json_for_call ~keeper_name ()] returns the
     canonical keeper runtime contract from the current turn context. *)
 
 val action_radius_json_for_call :

--- a/lib/keeper_tool_call_log_context.ml
+++ b/lib/keeper_tool_call_log_context.ml
@@ -139,13 +139,7 @@ let get_turn_context ~keeper_name () =
   , ctx.approval_mode )
 ;;
 
-let optional_model model =
-  match model with
-  | Some value when String.trim value <> "" -> Some value
-  | _ -> None
-;;
-
-let runtime_contract_json_for_call ~keeper_name ?model () =
+let runtime_contract_json_for_call ~keeper_name () =
   let ctx = get_turn_context_record ~keeper_name () in
   Keeper_runtime_contract.runtime_contract_json_from_fields
     ~keeper_name
@@ -166,7 +160,6 @@ let runtime_contract_json_for_call ~keeper_name ?model () =
     ?required_tools:ctx.required_tools
     ?required_tool_candidates:ctx.required_tool_candidates
     ?missing_required_tools:ctx.missing_required_tools
-    ?model:(optional_model model)
     ?cascade_profile:ctx.cascade_profile
     ()
 ;;

--- a/lib/keeper_tool_call_log_context.mli
+++ b/lib/keeper_tool_call_log_context.mli
@@ -79,11 +79,8 @@ val get_turn_context :
   * string option
   * string option
 
-val optional_model : string option -> string option
-
 val runtime_contract_json_for_call :
   keeper_name:string ->
-  ?model:string ->
   unit ->
   Yojson.Safe.t
 

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -412,7 +412,6 @@ let record_runtime_mcp_keeper_trajectory
       ?visible_tool_count:ctx.visible_tool_count
       ?required_tools:ctx.required_tools
       ?missing_required_tools:ctx.missing_required_tools
-      ?model:(Some ctx.model)
       ?cascade_profile:ctx.cascade_profile
       ()
   in

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -11,6 +11,11 @@ open Alcotest
 module R = Masc_mcp.Keeper_execution_receipt
 module U = Yojson.Safe.Util
 
+let object_has_member name = function
+  | `Assoc fields -> List.exists (fun (key, _) -> String.equal key name) fields
+  | _ -> false
+;;
+
 let mk_tool_surface
       ?(tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Required)
       ?(required_tools = [])
@@ -499,7 +504,7 @@ let operator_broadcast_event_count config =
   |> List.length
 ;;
 
-let test_receipt_json_redacts_provider_model_identity () =
+let test_receipt_json_omits_provider_model_identity () =
   let receipt =
     { (mk_receipt ())
       with
@@ -516,14 +521,14 @@ let test_receipt_json_redacts_provider_model_identity () =
     (json |> U.member "cascade" |> U.member "selected_model" = `Null);
   check
     bool
-    "runtime contract provider redacted"
-    true
-    (json |> U.member "runtime_contract" |> U.member "provider" = `Null);
+    "runtime contract provider omitted"
+    false
+    (json |> U.member "runtime_contract" |> object_has_member "provider");
   check
     bool
-    "runtime contract model redacted"
-    true
-    (json |> U.member "runtime_contract" |> U.member "model" = `Null)
+    "runtime contract model omitted"
+    false
+    (json |> U.member "runtime_contract" |> object_has_member "model")
 ;;
 
 let test_turn_livelock_broadcast_suppresses_duplicate_turn () =
@@ -920,9 +925,9 @@ let () =
             `Quick
             test_turn_livelock_broadcast_suppresses_duplicate_turn
         ; test_case
-            "receipt JSON redacts provider/model identity"
+            "receipt JSON omits provider/model identity"
             `Quick
-            test_receipt_json_redacts_provider_model_identity
+            test_receipt_json_omits_provider_model_identity
         ; test_case
             "broadcast payload carries turn diagnostics"
             `Quick


### PR DESCRIPTION
## Summary
- remove runtime_contract_json_from_fields provider/model compatibility inputs and output fields
- remove the model passthrough shim from keeper tool-call runtime-contract helpers
- update the receipt regression to assert provider/model are omitted from runtime_contract instead of relying on null-compatible access
- update the HTML legacy purge ledger with #18440 and the latest Keeper model-arg purge status

## Validation
- ocamlformat --check lib/keeper/keeper_runtime_contract.ml lib/keeper/keeper_runtime_contract.mli lib/keeper_tool_call_log_context.ml lib/keeper_tool_call_log_context.mli lib/keeper_tool_call_log.ml lib/keeper_tool_call_log.mli lib/mcp_server_eio_call_tool.ml lib/keeper/keeper_hooks_oas.ml lib/keeper/keeper_hooks_oas_gate_attempt.ml test/test_keeper_pause_broadcast.ml
- ocamlc -stop-after parsing lib/keeper/keeper_runtime_contract.ml lib/keeper/keeper_runtime_contract.mli lib/keeper_tool_call_log_context.ml lib/keeper_tool_call_log_context.mli lib/keeper_tool_call_log.ml lib/keeper_tool_call_log.mli lib/mcp_server_eio_call_tool.ml lib/keeper/keeper_hooks_oas.ml lib/keeper/keeper_hooks_oas_gate_attempt.ml test/test_keeper_pause_broadcast.ml
- git diff --check origin/main...HEAD
- scripts/lint-ignore-without-comment.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Not run
- scripts/dune-local.sh build ... touched targets: blocked by machine-wide bare Dune guard with live outside-wrapper dune processes (exit 75)