### PR TITLE
Derive code shell allowlist from Bin

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -522,6 +522,9 @@ let emit_of_simple buf spec =
     \            | Bin.Make\n\
     \            | Bin.Cmake\n\
     \            | Bin.Dune_local_sh\n\
+    \            | Bin.Diff\n\
+    \            | Bin.Patch\n\
+    \            | Bin.Mkdir\n\
     \            | Bin.Npm\n\
     \            | Bin.Node\n\
     \            | Bin.Npx\n\
@@ -534,6 +537,8 @@ let emit_of_simple buf spec =
     \            | Bin.Pyright\n\
     \            | Bin.Ruff\n\
     \            | Bin.Opam\n\
+    \            | Bin.Ocamlfind\n\
+    \            | Bin.Tsc\n\
     \            | Bin.Cargo\n\
     \            | Bin.Rustc\n\
     \            | Bin.Go\n\

--- a/docs/design/keeper-tool-runtime-boundary-plan.html
+++ b/docs/design/keeper-tool-runtime-boundary-plan.html
@@ -628,6 +628,13 @@
             <td data-label="Verification Method"><code>./_build/default/test/test_keeper_hooks_oas_telemetry.exe</code>, <code>./_build/default/test/test_keeper_sandbox_boundary_policy.exe</code></td>
             <td data-label="Exit Criteria">Telemetry recognizes public <code>Bash executable="gh"</code> typed argv for PR creation without local field maps in OAS output parsing.</td>
           </tr>
+          <tr>
+            <td data-label="Task">T29</td>
+            <td data-label="Goal">Code shell Bin axis</td>
+            <td data-label="Todo">Move <code>masc_code_shell</code> executable extras into typed <code>Masc_exec.Bin</code> constructors and derive its allowlist through <code>Dev_exec_allowlist.code_shell_bins</code>.</td>
+            <td data-label="Verification Method"><code>./_build/default/test/test_keeper_bash_safety.exe</code>, <code>./_build/default/test/test_tool_code_write_coverage.exe</code></td>
+            <td data-label="Exit Criteria"><code>tool_code_write_shell_validate</code> consumes <code>Dev_exec_allowlist.code_shell</code> and no longer owns a local raw string extension table.</td>
+          </tr>
         </tbody>
       </table>
     </section>
@@ -657,6 +664,8 @@
         <div class="command">./_build/default/test/test_ci_hardening_source.exe</div>
         <div class="command">./_build/default/test/test_keeper_hooks_oas_telemetry.exe</div>
         <div class="command">./_build/default/test/test_keeper_sandbox_boundary_policy.exe</div>
+        <div class="command">./_build/default/test/test_keeper_bash_safety.exe</div>
+        <div class="command">./_build/default/test/test_tool_code_write_coverage.exe</div>
         <div class="command">rg -n "visible shell/GitHub CLI path|visible shell/GitHub path|shell/GitHub CLI path" config/prompts docs/KEEPER-CAPABILITY-MATRIX.md docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh lib/keeper test</div>
         <div class="command">bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh</div>
         <div class="command">python3 -m py_compile scripts/audit-keeper-fleet-readiness.py</div>

--- a/docs/design/keeper-tool-runtime-boundary-plan.md
+++ b/docs/design/keeper-tool-runtime-boundary-plan.md
@@ -300,6 +300,14 @@ and public tool aliases.
    - `Keeper_hooks_oas_output_json` no longer maps shell-capable tool names
      to local command-field strings; PR-work metrics consume command
      candidates from the semantic capability axis.
+   Continued in slice 31:
+   - `Masc_exec.Bin` now knows the `masc_code_shell`-only executable extras
+     (`diff`, `patch`, `mkdir`, `ocamlfind`, `tsc`) instead of leaving them as
+     raw strings beside the keeper Bash allowlist.
+   - `Dev_exec_allowlist.code_shell_bins` and the derived
+     `Dev_exec_allowlist.code_shell` compatibility list now own the
+     `masc_code_shell` executable vocabulary; `tool_code_write_shell_validate`
+     consumes that axis and no longer builds a local extension table.
 
 ## Verification
 
@@ -393,3 +401,7 @@ and public tool aliases.
 - The boundary test now fails if OAS output command extraction reintroduces a
   local `keeper_bash`/`masc_code_shell` field map instead of using
   `Keeper_tool_capability_axis.shell_command_input_candidates`.
+- `test_keeper_bash_safety` now verifies the legacy `masc_code_shell`
+  allowlist is derived from typed `Bin` values through
+  `Dev_exec_allowlist.code_shell_bins`, matching the existing dev/read-only
+  allowlist ratchets.

--- a/lib/exec/bin.ml
+++ b/lib/exec/bin.ml
@@ -64,6 +64,9 @@ type known =
   | Make
   | Cmake
   | Dune_local_sh
+  | Diff
+  | Patch
+  | Mkdir
   | Npm
   | Node
   | Npx
@@ -76,6 +79,8 @@ type known =
   | Pyright
   | Ruff
   | Opam
+  | Ocamlfind
+  | Tsc
   | Cargo
   | Rustc
   | Go
@@ -148,6 +153,9 @@ let name_of_known : known -> string = function
   | Make -> "make"
   | Cmake -> "cmake"
   | Dune_local_sh -> "dune-local.sh"
+  | Diff -> "diff"
+  | Patch -> "patch"
+  | Mkdir -> "mkdir"
   | Npm -> "npm"
   | Node -> "node"
   | Npx -> "npx"
@@ -160,6 +168,8 @@ let name_of_known : known -> string = function
   | Pyright -> "pyright"
   | Ruff -> "ruff"
   | Opam -> "opam"
+  | Ocamlfind -> "ocamlfind"
+  | Tsc -> "tsc"
   | Cargo -> "cargo"
   | Rustc -> "rustc"
   | Go -> "go"
@@ -232,6 +242,9 @@ let risk_of_known : known -> risk_class = function
   | Make
   | Cmake
   | Dune_local_sh
+  | Diff
+  | Patch
+  | Mkdir
   | Npm
   | Node
   | Npx
@@ -244,6 +257,8 @@ let risk_of_known : known -> risk_class = function
   | Pyright
   | Ruff
   | Opam
+  | Ocamlfind
+  | Tsc
   | Cargo
   | Rustc
   | Go
@@ -310,6 +325,9 @@ let kind_of_known : known -> kind = function
   | Make
   | Cmake
   | Dune_local_sh
+  | Diff
+  | Patch
+  | Mkdir
   | Npm
   | Node
   | Npx
@@ -322,6 +340,8 @@ let kind_of_known : known -> kind = function
   | Pyright
   | Ruff
   | Opam
+  | Ocamlfind
+  | Tsc
   | Cargo
   | Rustc
   | Go
@@ -402,6 +422,9 @@ let known_of_string : string -> known option = function
   | "make" -> Some Make
   | "cmake" -> Some Cmake
   | "dune-local.sh" -> Some Dune_local_sh
+  | "diff" -> Some Diff
+  | "patch" -> Some Patch
+  | "mkdir" -> Some Mkdir
   | "npm" -> Some Npm
   | "node" -> Some Node
   | "npx" -> Some Npx
@@ -414,6 +437,8 @@ let known_of_string : string -> known option = function
   | "pyright" -> Some Pyright
   | "ruff" -> Some Ruff
   | "opam" -> Some Opam
+  | "ocamlfind" -> Some Ocamlfind
+  | "tsc" -> Some Tsc
   | "cargo" -> Some Cargo
   | "rustc" -> Some Rustc
   | "go" -> Some Go

--- a/lib/exec/bin.mli
+++ b/lib/exec/bin.mli
@@ -83,6 +83,9 @@ type known =
   | Make
   | Cmake
   | Dune_local_sh
+  | Diff
+  | Patch
+  | Mkdir
   | Npm
   | Node
   | Npx
@@ -95,6 +98,8 @@ type known =
   | Pyright
   | Ruff
   | Opam
+  | Ocamlfind
+  | Tsc
   | Cargo
   | Rustc
   | Go

--- a/lib/keeper/dev_exec_allowlist.ml
+++ b/lib/keeper/dev_exec_allowlist.ml
@@ -53,6 +53,12 @@ let dev_bins =
     ]
 ;;
 
+let code_shell_extra_bins =
+  Bin.[ Diff; Patch; Mkdir; Ocamlfind; Tsc ]
+;;
+
+let code_shell_bins = dev_bins @ code_shell_extra_bins
+
 let readonly_bins =
   Bin.
     [ Cat
@@ -79,6 +85,7 @@ let readonly_bins =
 ;;
 
 let dev = names dev_bins
+let code_shell = names code_shell_bins
 let readonly = names readonly_bins
 
 let is_dev_allowed name = List.mem name dev

--- a/lib/keeper/dev_exec_allowlist.mli
+++ b/lib/keeper/dev_exec_allowlist.mli
@@ -20,6 +20,14 @@ val dev : string list
     full dev presets (Coding/Full). Used by [Worker_dev_tools] when dispatching
     keeper_bash for keepers with elevated dev capability. *)
 
+val code_shell_bins : Masc_exec.Bin.known list
+(** Typed executable vocabulary for the legacy [masc_code_shell] surface. This
+    intentionally extends {!dev_bins} only through typed [Bin] constructors. *)
+
+val code_shell : string list
+(** [List.map Masc_exec.Bin.name_of_known code_shell_bins]. Compatibility string
+    list consumed by [masc_code_shell] validation. *)
+
 val readonly_bins : Masc_exec.Bin.known list
 (** Typed executable vocabulary for read-only presets. *)
 

--- a/lib/tool_code_write_shell_validate.ml
+++ b/lib/tool_code_write_shell_validate.ml
@@ -3,26 +3,14 @@
 
     Pure helpers — verbatim extract from [Tool_code_write]. Delegates
     to [Exec_policy.command_context_coding_with_allowlist] for
-    the heavy parsing; this module owns the tool-specific
-    [allowed_shell_commands] table (which extends [Dev_exec_allowlist.dev]
-    with [diff/patch/mkdir/ocamlfind/tsc]) and the
-    [classify_code_shell_exit] disposition over [code × last_stage_bin].
-
-    The [add_unique] helper that builds the allowlist also stays in
-    the parent (line 51) — duplicated here as a 2-line local because
-    it's used by exactly one site. *)
+    the heavy parsing; the [allowed_shell_commands] compatibility surface
+    is derived from [Dev_exec_allowlist.code_shell], keeping the executable
+    vocabulary owned by [Masc_exec.Bin]. This module owns only the
+    [classify_code_shell_exit] disposition over [code] and [last_stage_bin]. *)
 
 module Exec_shell_gate = Masc_exec_command_gate.Shell_command_gate
 
-let add_unique acc item =
-  if List.exists (String.equal item) acc then acc else acc @ [ item ]
-
-(* Shell command allowlist.  Keep this aligned with keeper_bash/dev shell so
-   safe coding probes do not fail only because they entered through
-   masc_code_shell.  Tool-specific extras are kept here. *)
-let allowed_shell_commands =
-  List.fold_left add_unique Dev_exec_allowlist.dev
-    [ "diff"; "patch"; "mkdir"; "ocamlfind"; "tsc" ]
+let allowed_shell_commands = Dev_exec_allowlist.code_shell
 
 let code_shell_command_context command =
   match Exec_policy.parse_string_to_ir ~mode:Coding command with

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -52,6 +52,10 @@ let test_allowlists_are_bin_derived () =
     (names Dev_exec_allowlist.dev_bins)
     Dev_exec_allowlist.dev;
   Alcotest.(check (list string))
+    "code shell allowlist is derived from Bin known values"
+    (names Dev_exec_allowlist.code_shell_bins)
+    Dev_exec_allowlist.code_shell;
+  Alcotest.(check (list string))
     "readonly allowlist is derived from Bin known values"
     (names Dev_exec_allowlist.readonly_bins)
     Dev_exec_allowlist.readonly;


### PR DESCRIPTION
## Summary
- add masc_code_shell-only executable extras to the typed Masc_exec.Bin registry
- derive Dev_exec_allowlist.code_shell from typed Bin constructors
- remove the local raw string extension table from tool_code_write_shell_validate
- update the keeper tool boundary plan with the code-shell Bin-axis slice

## Verification
- ocamlformat --check bin/gen_shell_ir_walkers.ml lib/exec/bin.ml lib/exec/bin.mli lib/keeper/dev_exec_allowlist.ml lib/keeper/dev_exec_allowlist.mli lib/tool_code_write_shell_validate.ml test/test_keeper_bash_safety.ml
- git diff --check
- rg -n "List\.fold_left add_unique Dev_exec_allowlist\.dev|\[ \"diff\"; \"patch\"; \"mkdir\"; \"ocamlfind\"; \"tsc\" \]|diff/patch/mkdir/ocamlfind/tsc" lib/tool_code_write_shell_validate.ml lib/keeper/dev_exec_allowlist.ml lib/keeper/dev_exec_allowlist.mli docs/design/keeper-tool-runtime-boundary-plan.md (no matches)
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_bash_safety.exe test/test_tool_code_write_coverage.exe (blocked by existing coord split compile errors: read_backlog / resolve_agent_name / generate_session_id)