### PR TITLE
fix(dashboard): document namespace runtime count authority

### DIFF
--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -834,6 +834,42 @@ let derive_readiness_and_attention ~execution_json ~execution_summary
       ],
     `List (take_n 10 (base_events @ keeper_events)) )
 
+let json_int_value_opt = function
+  | `Int value -> Some value
+  | `Intlit raw -> int_of_string_opt raw
+  | _ -> None
+
+let runtime_count_authority_json ~runtime_count ~shell_counts
+    ~configured_keepers =
+  let live_keepers = json_int_field "keepers" shell_counts ~default:0 in
+  let configured_keepers_count = json_int_value_opt configured_keepers in
+  let configured_minus_live =
+    Option.map
+      (fun configured -> max 0 (configured - live_keepers))
+      configured_keepers_count
+  in
+  `Assoc
+    [
+      ("source", `String namespace_truth_source);
+      ("authority", `String "root.counts");
+      ("configured_authority", `String "root.configured_keepers");
+      ( "fallback_policy",
+        `String "shell_last_good_only_when_namespace_unavailable" );
+      ("shell_arbitration_allowed", `Bool false);
+      ("live_total_runtimes", `Int runtime_count);
+      ("live_keepers", `Int live_keepers);
+      ("configured_keepers", json_int_opt configured_keepers_count);
+      ("configured_minus_live_keepers", json_int_opt configured_minus_live);
+      ( "count_roles",
+        `Assoc
+          [
+            ("root.counts", `String "authoritative_live_snapshot");
+            ("root.configured_keepers", `String "authoritative_inventory");
+            ("shell", `String "read_model_input");
+            ("execution", `String "diagnostic_summary_only");
+          ] );
+    ]
+
 let compose_namespace_truth_snapshot ~(config : Coord.config) ~initialized ~shell_json
     ~execution_json ~command_summary_json =
   let generated_at = Masc_domain.now_iso () in
@@ -881,6 +917,9 @@ let compose_namespace_truth_snapshot ~(config : Coord.config) ~initialized ~shel
         ("status", json_assoc_field "status" shell_json);
         ("counts", json_assoc_field "counts" shell_json);
         ("configured_keepers", configured_keepers);
+        ( "runtime_count_authority",
+          runtime_count_authority_json ~runtime_count ~shell_counts
+            ~configured_keepers );
         ("provenance", `String "truth");
       ]
   in

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -167,6 +167,13 @@ let test_dashboard_namespace_truth_empty_room () =
         check int "namespace counts expose total runtimes"
           0
           (json |> member "root" |> member "counts" |> member "total_runtimes" |> to_int);
+        check string "runtime count authority is namespace truth"
+          "namespace_truth_read_model"
+          (json |> member "root" |> member "runtime_count_authority" |> member "source" |> to_string);
+        check bool "runtime counts do not arbitrate through shell"
+          false
+          (json |> member "root" |> member "runtime_count_authority"
+           |> member "shell_arbitration_allowed" |> to_bool);
         check string "canonical dashboard surface"
           "/api/v1/dashboard/namespace-truth"
           (json |> member "dashboard_surface" |> to_string);
@@ -557,7 +564,15 @@ let test_dashboard_namespace_truth_warm_request_uses_stale_shell () =
           (json |> member "projection_diagnostics" |> member "cache_mode" |> to_string);
         check string "warm request shell source is last-good"
           "last_good_shell"
-          (json |> member "projection_diagnostics" |> member "shell_source" |> to_string)
+          (json |> member "projection_diagnostics" |> member "shell_source" |> to_string);
+        check string "runtime authority documents stale shell as fallback"
+          "shell_last_good_only_when_namespace_unavailable"
+          (json |> member "root" |> member "runtime_count_authority"
+           |> member "fallback_policy" |> to_string);
+        check int "authority reports configured/live keeper delta"
+          0
+          (json |> member "root" |> member "runtime_count_authority"
+           |> member "configured_minus_live_keepers" |> to_int)
       ))
 
 let test_dashboard_namespace_truth_cold_cache_falls_back_to_partial_truth () =


### PR DESCRIPTION
## Summary
- add a root.runtime_count_authority payload to namespace-truth snapshots
- document root.counts as the live authority, configured_keepers as inventory, and shell as fallback input only
- cover empty-room and stale-shell projections in namespace-truth tests

## Validation
- opam exec -- ocamlformat --check lib/server/server_dashboard_http_namespace_truth_support.ml test/test_dashboard_namespace_truth.ml
- git diff --check HEAD~1..HEAD
- MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_dashboard_namespace_truth.exe
- ./_build/default/test/test_dashboard_namespace_truth.exe