### PR TITLE
fix(build): re-export coord task id helpers

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -8,6 +8,7 @@ include Coord_utils
 include Coord_backlog
 include Coord_bootstrap
 include Coord_identity
+include Coord_task_id
 include Coord_state
 include Coord_bootstrap
 include Coord_identity

--- a/lib/coord.mli
+++ b/lib/coord.mli
@@ -9,6 +9,7 @@ include module type of Coord_utils
 include module type of Coord_backlog
 include module type of Coord_bootstrap
 include module type of Coord_identity
+include module type of Coord_task_id
 include module type of Coord_state
 include module type of Coord_bootstrap
 include module type of Coord_identity


### PR DESCRIPTION
## Summary
- re-export Coord_task_id from the public Coord facade
- restore Coord.task_id_to_int and archive/task-number helpers after the coord split repair landed on main

## Validation
- git diff --check origin/main..HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build . passed before the final rebase; final rebase reduced this branch to the 2-line Coord_task_id facade export because main absorbed the other split-build repairs
- final post-rebase focused rerun was blocked by another worktree holding /tmp/me-dune-local.lock
