### PR TITLE
fix(keeper): PR review tools use keeper-scoped gh credentials

### DIFF
--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -217,6 +217,14 @@ let with_pr_review_body_file ~(config : Coord.config) ~(meta : keeper_meta) ~bod
       | Sys_error _ -> ())
     (fun () -> f command_path)
 
+let resolve_pr_review_env
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+  =
+  match Keeper_gh_env.keeper_process_env config ~keeper_name:meta.name with
+  | Ok env -> env
+  | Error _ -> Keeper_gh_env.process_env config
+
 let run_pr_review_argv
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -231,7 +239,7 @@ let run_pr_review_argv
     ~timeout_sec
     ~actor:`Keeper_shell
     ~summary
-    ~env:(Keeper_gh_env.process_env config)
+    ~env:(resolve_pr_review_env ~config ~meta)
     ~host_cwd:root
     ~route_cwd:root
     ~backend_cwd:(fun () -> sandbox_pr_review_cwd ~config meta)


### PR DESCRIPTION
## Summary
- PR review tools (`keeper_pr_review_read`, `keeper_pr_review_comment`, `keeper_pr_review_reply`) always used `Keeper_gh_env.process_env` which resolves to root gh identity bundle (`~/me/.masc/github-identities/root/gh/`)
- When root bundle doesn't exist, all PR review ops fail with "gh auth login" error
- `keeper_pr_list` works because it uses `scoped_credential_or_error` → `keeper_process_env` (per-keeper credentials)
- Fix: try `keeper_process_env` first (keeper's `github_identity`), fall back to `process_env` (root bundle) if no identity configured

## Root cause
5-layer keeper PR review regression:
1. ~~cascade healthcheck → no_tool_capable_provider~~ (deferred)
2. ~~keeper paused state~~ (fixed, reset)
3. ~~prompt "repos you have cloned" gate~~ (fixed in prior session)
4. ~~work_discovery missing open_prs source~~ (fixed, PR #18431)
5. **gh CLI auth failure** (this PR) — `process_env` → non-existent root bundle

## Test plan
- [ ] Verify keepers with `github_identity` configured can now call `keeper_pr_review_read`
- [ ] Verify keepers without `github_identity` fall back to root bundle (existing behavior)
- [ ] Check system_log for `keeper_pr_review_repo_unresolved` errors before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)