### PR TITLE
refactor(keeper): remove remaining bash stages alias hints

### DIFF
--- a/docs/LEGENDARY-BASH-RUNBOOK.md
+++ b/docs/LEGENDARY-BASH-RUNBOOK.md
@@ -15,7 +15,7 @@ code_refs:
 
 This runbook documents the current operator surface for `keeper_bash` and
 adjacent structured shell routing. `keeper_bash` is typed-only: callers provide
-`executable`/`argv` or `pipeline`/`stages`. Raw command strings and the old
+`executable`/`argv` or `pipeline`. Raw command strings and the old
 background task lifecycle are not part of the callable surface.
 
 ## Related Documents
@@ -71,7 +71,7 @@ Pipeline:
 }
 ```
 
-Shell metacharacters inside `argv` are data. Use `pipeline`/`stages` for pipes
+Shell metacharacters inside `argv` are data. Use `pipeline` for pipes
 instead of embedding `|` in a string. For read-only observation prefer
 `keeper_shell`; for file edits use `keeper_fs_edit`.
 

--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-25 18:38:38 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-25 19:12:04 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -349,21 +349,33 @@
           </tr>
           <tr>
             <td><code>Keeper_generation_lineage</code> model compatibility args</td>
-            <td><span class="status done">draft PR #18429</span></td>
+            <td><span class="status done">merged #18429</span></td>
             <td>Remove unused <code>~model</code> compatibility arguments from the generation-lineage manifest, index-entry, and best-effort append helpers. Handoff and lineage JSON continue to emit the redacted <code>runtime</code> lane.</td>
             <td>Targeted compatibility grep is clean. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>
           <tr>
             <td><code>Keeper_unified_metrics</code> model-label compatibility args</td>
-            <td><span class="status done">draft PR #18435</span></td>
+            <td><span class="status done">merged #18435</span></td>
             <td>Delete ignored <code>model_used</code> / <code>resolved_model_id</code> inputs from usage-trust and unified metric helpers, remove the public <code>provider_kind_of_model_used</code> compatibility helper, and keep metric labels on the redacted <code>runtime</code> lane.</td>
             <td>Targeted compatibility grep is clean. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>
           <tr>
             <td><code>Keeper_oas_checkpoint.partial_response_of_stop</code> model-id arg</td>
-            <td><span class="status done">draft PR #18438</span></td>
+            <td><span class="status done">merged #18438</span></td>
             <td>Remove the ignored <code>~model_id</code> compatibility argument from synthetic early-stop responses and update <code>Cascade_runner</code> callers to rely on the redacted runtime lane directly.</td>
             <td>Targeted compatibility grep is clean. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_runtime_contract</code> provider/model compatibility inputs</td>
+            <td><span class="status done">merged #18440</span></td>
+            <td>Remove <code>?provider</code> / <code>?model</code> inputs from <code>runtime_contract_json_from_fields</code>, drop runtime-contract provider/model output fields, and remove the model passthrough shim from tool-call runtime-contract helpers.</td>
+            <td>Receipt regression now asserts the provider/model fields are absent, not merely null-compatible. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
+          </tr>
+          <tr>
+            <td><code>keeper_bash</code> <code>stages</code> alias hints</td>
+            <td><span class="status now">draft PR #18445</span></td>
+            <td>Remove the remaining public hints that treated top-level <code>stages</code> as a live <code>keeper_bash</code> pipeline alias: resource-axis classification, descriptor expectations, Docker-route error wording, and the Legendary Bash runbook.</td>
+            <td>Targeted grep is clean for the retired slash-form pipeline phrase, the old descriptor presence assertion, and the stale descriptor branch-count assertion. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.mkdir_p</code> compatibility wrapper</td>

--- a/lib/tool_resource_axis.ml
+++ b/lib/tool_resource_axis.ml
@@ -101,8 +101,8 @@ let typed_bash_args_class args =
   | `Assoc fields ->
     let direct = typed_bash_stage_class fields in
     let pipeline =
-      match List.assoc_opt "pipeline" fields, List.assoc_opt "stages" fields with
-      | Some (`List stages), _ | _, Some (`List stages) -> stages_class stages
+      match List.assoc_opt "pipeline" fields with
+      | Some (`List stages) -> stages_class stages
       | _ -> Shell
     in
     combine direct pipeline

--- a/test/test_keeper_bash_descriptor_variant.ml
+++ b/test/test_keeper_bash_descriptor_variant.ml
@@ -73,11 +73,11 @@ let test_descriptor_is_typed_only () =
     true
     (List.mem "pipeline" props);
   Alcotest.(check bool)
-    "stages present in properties"
-    true
+    "stages absent from properties"
+    false
     (List.mem "stages" props);
   let branches = one_of_required_names bash.input_schema in
-  Alcotest.(check int) "3 oneOf branches" 3 (List.length branches);
+  Alcotest.(check int) "2 oneOf branches" 2 (List.length branches);
   Alcotest.(check bool) "cmd branch absent" false (List.mem "cmd" branches);
   Alcotest.(check (option string))
     "no top-level required; oneOf owns branch selection"

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -1953,7 +1953,7 @@ let test_bash_blocks_file_redirect_before_docker () =
    | Some false | None -> ());
   Alcotest.(check (option string))
     "typed boundary error"
-    (Some "Typed Shell IR input is required. Provide executable/argv or pipeline/stages.")
+    (Some "Typed Shell IR input is required. Provide executable/argv or pipeline.")
     (parse_string_field raw "error");
   Alcotest.(check bool) "docker was not invoked" false
     (Sys.file_exists log_path)


### PR DESCRIPTION
## Summary
- stop resource-axis classification from treating top-level keeper_bash stages as a live pipeline alias
- update descriptor and docker-route tests to pin pipeline-only public wording
- remove pipeline/stages wording from the Legendary Bash runbook
- update the HTML legacy purge ledger with #18445 and the latest #18440 status

## Validation
- ocamlformat --check lib/tool_resource_axis.ml test/test_keeper_bash_descriptor_variant.ml test/test_keeper_sandbox_docker_route.ml
- ocamlc -stop-after parsing lib/tool_resource_axis.ml test/test_keeper_bash_descriptor_variant.ml test/test_keeper_sandbox_docker_route.ml
- git diff --check
- targeted rg for pipeline/stages, stages-present descriptor wording, 3 oneOf branch assertion, and old typed-boundary message
- scripts/lint-ignore-without-comment.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Not run
- scripts/dune-local.sh build ... touched targets: blocked by machine-wide bare Dune guard with live outside-wrapper dune processes (exit 75)