### PR TITLE
Route code shell through Shell IR facade

### DIFF
--- a/docs/design/keeper-tool-runtime-boundary-plan.html
+++ b/docs/design/keeper-tool-runtime-boundary-plan.html
@@ -635,6 +635,13 @@
             <td data-label="Verification Method"><code>./_build/default/test/test_keeper_bash_safety.exe</code>, <code>./_build/default/test/test_tool_code_write_coverage.exe</code></td>
             <td data-label="Exit Criteria"><code>tool_code_write_shell_validate</code> consumes <code>Dev_exec_allowlist.code_shell</code> and no longer owns a local raw string extension table.</td>
           </tr>
+          <tr>
+            <td data-label="Task">T30</td>
+            <td data-label="Goal">Code shell dispatch axis</td>
+            <td data-label="Todo">Route <code>masc_code_shell</code> raw coding-command validation and Shell IR execution through <code>Keeper_shell_ir</code> while preserving its no-redirect policy.</td>
+            <td data-label="Verification Method"><code>./_build/default/test/test_worker_dev_tools.exe</code>, <code>./_build/default/test/test_tool_code_write_coverage.exe</code></td>
+            <td data-label="Exit Criteria"><code>tool_code_write_shell_validate.ml</code> no longer owns <code>Exec_policy.command_context_coding_with_allowlist</code>, <code>tool_code_write.ml</code> no longer calls <code>Exec_policy.validate_shell_ir_paths</code> or <code>Exec_dispatch.dispatch_decided</code> directly, and the facade receives <code>redirect_allowed=false</code>.</td>
+          </tr>
         </tbody>
       </table>
     </section>

--- a/docs/design/keeper-tool-runtime-boundary-plan.md
+++ b/docs/design/keeper-tool-runtime-boundary-plan.md
@@ -308,6 +308,23 @@ and public tool aliases.
      `Dev_exec_allowlist.code_shell` compatibility list now own the
      `masc_code_shell` executable vocabulary; `tool_code_write_shell_validate`
      consumes that axis and no longer builds a local extension table.
+   Continued in slice 32:
+   - `Keeper_shell_ir.dispatch_classified` now exposes the command-gate policy
+     knobs that used to be hardcoded for keeper Bash: caller attribution, pipe
+     allowance, redirect allowance, and optional keeper/base path scope.
+   - `Keeper_shell_ir.coding_command_context` now owns legacy raw coding
+     command parse/validation before dispatch, so `masc_code_shell` no longer
+     calls the coding command-context gate directly from
+     `tool_code_write_shell_validate`.
+   - `masc_code_shell` now routes parsed Shell IR through
+     `Keeper_shell_ir.dispatch_classified` with `caller=Tool_code_write`,
+     `allow_pipes=true`, and `redirect_allowed=false`, preserving the legacy
+     no-redirect code-shell policy while sharing the same gate/path/dispatch
+     center as keeper Bash.
+   - `tool_code_write.ml` no longer calls
+     `Exec_policy.validate_shell_ir_paths` or
+     `Masc_exec.Exec_dispatch.dispatch_decided` directly; it keeps only
+     code-shell response rendering and `rg`/`grep`/`diff` exit semantics.
 
 ## Verification
 
@@ -405,3 +422,8 @@ and public tool aliases.
   allowlist is derived from typed `Bin` values through
   `Dev_exec_allowlist.code_shell_bins`, matching the existing dev/read-only
   allowlist ratchets.
+- `test_worker_dev_tools` now fails if `masc_code_shell` bypasses
+  `Keeper_shell_ir.coding_command_context` /
+  `Keeper_shell_ir.dispatch_classified`, re-enables redirects at the facade,
+  or reintroduces direct path-validation / dispatch ownership in
+  `tool_code_write.ml`.

--- a/lib/keeper/keeper_shell_ir.ml
+++ b/lib/keeper/keeper_shell_ir.ml
@@ -69,8 +69,36 @@ type dispatch_error =
   | Too_complex
   | Path_reject of string
 
-let validate_paths ~keeper_id ~base_path ~workdir ir =
-  Exec_policy.validate_shell_ir_paths ~keeper_id ~base_path ~workdir ir
+let validate_paths ?keeper_id ?base_path ~workdir ir =
+  Exec_policy.validate_shell_ir_paths ?keeper_id ?base_path ~workdir ir
+;;
+
+let coding_command_context
+      ?(caller = Shell_gate.Keeper_shell_ir)
+      ?(allow_pipes = true)
+      ~allowed_commands
+      command
+  =
+  match Exec_policy.parse_string_to_ir ~mode:Coding command with
+  | Error reason ->
+    Error
+      (Exec_policy.block_reason_to_string_with_allowlist
+         ~allowed_commands
+         reason)
+  | Ok ir -> (
+    match
+      Exec_policy.command_context_coding_with_allowlist
+        ~caller
+        ~allow_pipes
+        ~allowed_commands
+        ir
+    with
+    | Ok ctx -> Ok ctx
+    | Error reason ->
+      Error
+        (Exec_policy.block_reason_to_string_with_allowlist
+           ~allowed_commands
+           reason))
 ;;
 
 (* TEL-OK: facade is pure gate/path/dispatch routing; keeper_shell_bash emits
@@ -78,9 +106,12 @@ let validate_paths ~keeper_id ~base_path ~workdir ir =
 let dispatch_classified
       ?timeout_sec
       ?before_path_validation
+      ?(caller = Shell_gate.Keeper_shell_ir)
+      ?(allow_pipes = true)
+      ?(redirect_allowed = true)
       ~allowed_commands
-      ~keeper_id
-      ~base_path
+      ?keeper_id
+      ?base_path
       ~workdir
       ~sandbox
       envelope
@@ -88,9 +119,9 @@ let dispatch_classified
   let ir = envelope.Masc_exec.Shell_ir_risk.ir in
   let gate_verdict =
     Shell_gate.gate_typed
-      ~caller:Shell_gate.Keeper_shell_ir
+      ~caller
       ~ir
-      ~allowlist:{ allowed_commands; allow_pipes = true; redirect_allowed = true }
+      ~allowlist:{ allowed_commands; allow_pipes; redirect_allowed }
       ~path_policy:Shell_gate.allow_all_paths
       ~sandbox:{ target = sandbox }
       ()
@@ -108,7 +139,7 @@ let dispatch_classified
       with
       | Error e -> Error (Path_reject e)
       | Ok () ->
-        (match validate_paths ~keeper_id ~base_path ~workdir ir with
+        (match validate_paths ?keeper_id ?base_path ~workdir ir with
          | Error e -> Error (Path_reject e)
          | Ok () -> Ok (Masc_exec.Exec_dispatch.dispatch_decided ?timeout_sec envelope)))
 ;;
@@ -117,9 +148,12 @@ let dispatch_classified
 let dispatch
       ?timeout_sec
       ?before_path_validation
+      ?caller
+      ?allow_pipes
+      ?redirect_allowed
       ~allowed_commands
-      ~keeper_id
-      ~base_path
+      ?keeper_id
+      ?base_path
       ~workdir
       ~sandbox
       ir
@@ -127,9 +161,12 @@ let dispatch
   dispatch_classified
     ?timeout_sec
     ?before_path_validation
+    ?caller
+    ?allow_pipes
+    ?redirect_allowed
     ~allowed_commands
-    ~keeper_id
-    ~base_path
+    ?keeper_id
+    ?base_path
     ~workdir
     ~sandbox
     (classify ir)

--- a/lib/keeper/keeper_shell_ir.mli
+++ b/lib/keeper/keeper_shell_ir.mli
@@ -35,33 +35,51 @@ type dispatch_error =
   | Path_reject of string
 
 val validate_paths :
-  keeper_id:string ->
-  base_path:string ->
+  ?keeper_id:string ->
+  ?base_path:string ->
   workdir:string ->
   Masc_exec.Shell_ir.t ->
   (unit, string) result
 (** Validate Shell IR path arguments through the keeper Shell IR facade. *)
 
+val coding_command_context :
+  ?caller:Masc_exec_command_gate.Shell_command_gate.caller ->
+  ?allow_pipes:bool ->
+  allowed_commands:string list ->
+  string ->
+  (Masc_exec_command_gate.Shell_command_gate.parsed_context, string) result
+(** Parse and validate a legacy raw coding command through the shared Shell IR
+    policy path. This preserves coding-surface checks such as direct-dune,
+    glob, wrapped-stage, allowlist, pipe, and redirect policy before callers
+    dispatch through {!dispatch_classified}. *)
+
 val dispatch_classified :
   ?timeout_sec:float ->
   ?before_path_validation:(Masc_exec.Shell_ir.t -> (unit, string) result) ->
+  ?caller:Masc_exec_command_gate.Shell_command_gate.caller ->
+  ?allow_pipes:bool ->
+  ?redirect_allowed:bool ->
   allowed_commands:string list ->
-  keeper_id:string ->
-  base_path:string ->
+  ?keeper_id:string ->
+  ?base_path:string ->
   workdir:string ->
   sandbox:Masc_exec.Sandbox_target.t ->
   Masc_exec.Shell_ir_risk.decided Masc_exec.Shell_ir_risk.decided_ir ->
   (Masc_exec.Exec_dispatch.dispatch_result, dispatch_error) result
 (** Run the canonical keeper Shell IR pipeline for an already-classified IR:
     typed gate -> optional pre-path validation -> path validation ->
-    dispatch_decided. *)
+    dispatch_decided. [redirect_allowed] defaults to [true] for the historical
+    keeper shell path; legacy code-shell callers pass [false]. *)
 
 val dispatch :
   ?timeout_sec:float ->
   ?before_path_validation:(Masc_exec.Shell_ir.t -> (unit, string) result) ->
+  ?caller:Masc_exec_command_gate.Shell_command_gate.caller ->
+  ?allow_pipes:bool ->
+  ?redirect_allowed:bool ->
   allowed_commands:string list ->
-  keeper_id:string ->
-  base_path:string ->
+  ?keeper_id:string ->
+  ?base_path:string ->
   workdir:string ->
   sandbox:Masc_exec.Sandbox_target.t ->
   Masc_exec.Shell_ir.t ->

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -49,9 +49,6 @@ let first_nonempty_line output =
   |> List.map String.trim
   |> List.find_opt (fun s -> not (String.equal s ""))
 
-let add_unique acc item =
-  if List.exists (String.equal item) acc then acc else acc @ [ item ]
-
 let code_shell_command_context =
   Tool_code_write_shell_validate.code_shell_command_context
 let validate_code_shell_command =
@@ -622,89 +619,119 @@ let handle_code_shell ~tool_name ~start_time ctx args =
                | Some dir -> dir
                | None -> Sys.getcwd ()
              in
-	             match
-	               Exec_policy.validate_shell_ir_paths
-	                 ~workdir:path_workdir
-	                 command_context.Exec_shell_gate.ast
-	             with
-	             | Error reason ->
-	                 Tool_result.error ~tool_name ~start_time
-	                   ~failure_class:(Some Tool_result.Policy_rejection)
-	                   reason
-	             | Ok () ->
-	                 let dispatch_ir =
-	                   Exec_shell_adapter.shell_ir_with_default_cwd
-	                     cwd_opt
-	                     command_context.Exec_shell_gate.ast
-	                 in
-	                 let dispatch_envelope =
-	                   Masc_exec.Shell_ir_risk.classify
-	                     (Masc_exec.Shell_ir_risk.undecided dispatch_ir)
-	                 in
-	                 match
-	                   Masc_exec.Exec_dispatch.dispatch_decided
-	                     ~timeout_sec:safe_timeout
-	                     dispatch_envelope
-	                 with
-	                 | { status = Unix.WEXITED code; stdout; stderr } ->
-	                     let output =
-	                       Exec_shell_adapter.output_for_dispatch_status
-	                         ~status:(Unix.WEXITED code)
-	                         ~stdout
-	                         ~stderr
-	                     in
-	                     let exit_status =
-	                       classify_code_shell_exit
-	                         ~last_stage_bin:
-	                           (Exec_shell_gate.last_stage_bin command_context)
-	                         code
-	                     in
-	                     let response_fields =
-	                       [
-	                         ( "status",
-                           `String (match exit_status with Shell_error -> "error" | _ -> "ok") );
-                         ("exit_code", `Int code);
-                         ("output", `String (truncate_output output));
-                         ("command", `String command);
-                         ("agent", `String ctx.agent_name);
-                       ]
-                       @
-                       match exit_status with
-                       | Shell_ok_expected_nonzero reason ->
-                           [ ("exit_semantics", `String reason) ]
-                       | Shell_ok | Shell_error -> []
-                     in
-                     let response = `Assoc response_fields in
-                     (match exit_status with
-                      | Shell_ok | Shell_ok_expected_nonzero _ ->
-                          fun msg -> Tool_result.ok ~tool_name ~start_time msg
-	                       | Shell_error ->
-	                           fun msg -> Tool_result.error ~tool_name ~start_time msg)
-	                       (Yojson.Safe.pretty_to_string response)
-	                 | { status = Unix.WSIGNALED sig_num; stdout; stderr } ->
-	                     let output =
-	                       Exec_shell_adapter.output_for_dispatch_status
-	                         ~status:(Unix.WSIGNALED sig_num)
-	                         ~stdout
-	                         ~stderr
-	                     in
-	                     Tool_result.error ~tool_name ~start_time
-	                       (Printf.sprintf
-	                          "Killed by signal %d: %s"
-	                          sig_num
-	                          (truncate_output output))
-	                 | { status = Unix.WSTOPPED sig_num; stdout; stderr } ->
-	                     let output =
-	                       Exec_shell_adapter.output_for_dispatch_status
-	                         ~status:(Unix.WSTOPPED sig_num)
-	                         ~stdout
-	                         ~stderr
-	                     in
-	                     Tool_result.error ~tool_name ~start_time
-	                       (Printf.sprintf
-	                          "Stopped by signal %d: %s"
-	                          sig_num
-	                          (truncate_output output)))
+             let dispatch_ir =
+               Exec_shell_adapter.shell_ir_with_default_cwd
+                 cwd_opt
+                 command_context.Exec_shell_gate.ast
+             in
+             let dispatch_envelope =
+               Masc_exec.Shell_ir_risk.classify
+                 (Masc_exec.Shell_ir_risk.undecided dispatch_ir)
+             in
+             match
+               Keeper_shell_ir.dispatch_classified
+                 ~timeout_sec:safe_timeout
+                 ~caller:Exec_shell_gate.Tool_code_write
+                 ~allow_pipes:true
+                 ~redirect_allowed:false
+                 ~allowed_commands:Dev_exec_allowlist.code_shell
+                 ~workdir:path_workdir
+                 ~sandbox:(Masc_exec.Sandbox_target.host ())
+                 dispatch_envelope
+             with
+             | Error (Keeper_shell_ir.Gate_reject diagnostic) ->
+               Tool_result.error
+                 ~tool_name
+                 ~start_time
+                 ~failure_class:(Some Tool_result.Policy_rejection)
+                 diagnostic
+             | Error Keeper_shell_ir.Cannot_parse ->
+               Tool_result.error
+                 ~tool_name
+                 ~start_time
+                 ~failure_class:(Some Tool_result.Workflow_rejection)
+                 "Cannot parse command"
+             | Error Keeper_shell_ir.Too_complex ->
+               Tool_result.error
+                 ~tool_name
+                 ~start_time
+                 ~failure_class:(Some Tool_result.Workflow_rejection)
+                 "Command too complex"
+             | Error (Keeper_shell_ir.Path_reject reason) ->
+               Tool_result.error
+                 ~tool_name
+                 ~start_time
+                 ~failure_class:(Some Tool_result.Policy_rejection)
+                 reason
+             | Ok { status = Unix.WEXITED code; stdout; stderr } ->
+               let output =
+                 Exec_shell_adapter.output_for_dispatch_status
+                   ~status:(Unix.WEXITED code)
+                   ~stdout
+                   ~stderr
+               in
+               let exit_status =
+                 classify_code_shell_exit
+                   ~last_stage_bin:
+                     (Exec_shell_gate.last_stage_bin command_context)
+                   code
+               in
+               let status_text =
+                 match exit_status with
+                 | Shell_error -> "error"
+                 | Shell_ok | Shell_ok_expected_nonzero _ -> "ok"
+               in
+               let exit_fields =
+                 match exit_status with
+                 | Shell_ok_expected_nonzero reason ->
+                   [ ("exit_semantics", `String reason) ]
+                 | Shell_ok | Shell_error -> []
+               in
+               let response_fields =
+                 [
+                   ("status", `String status_text);
+                   ("exit_code", `Int code);
+                   ("output", `String (truncate_output output));
+                   ("command", `String command);
+                   ("agent", `String ctx.agent_name);
+                 ]
+                 @ exit_fields
+               in
+               let response = `Assoc response_fields in
+               (match exit_status with
+                | Shell_ok | Shell_ok_expected_nonzero _ ->
+                  fun msg -> Tool_result.ok ~tool_name ~start_time msg
+                | Shell_error ->
+                  fun msg -> Tool_result.error ~tool_name ~start_time msg)
+                 (Yojson.Safe.pretty_to_string response)
+             | Ok { status = Unix.WSIGNALED sig_num; stdout; stderr } ->
+               let output =
+                 Exec_shell_adapter.output_for_dispatch_status
+                   ~status:(Unix.WSIGNALED sig_num)
+                   ~stdout
+                   ~stderr
+               in
+               Tool_result.error
+                 ~tool_name
+                 ~start_time
+                 (Printf.sprintf
+                    "Killed by signal %d: %s"
+                    sig_num
+                    (truncate_output output))
+             | Ok { status = Unix.WSTOPPED sig_num; stdout; stderr } ->
+               let output =
+                 Exec_shell_adapter.output_for_dispatch_status
+                   ~status:(Unix.WSTOPPED sig_num)
+                   ~stdout
+                   ~stderr
+               in
+               Tool_result.error
+                 ~tool_name
+                 ~start_time
+                 (Printf.sprintf
+                    "Stopped by signal %d: %s"
+                    sig_num
+                    (truncate_output output)))
 
 (* Handler: masc_code_git — Git operations *)
 let code_git_route_fields (ctx : context) =

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -626,6 +626,8 @@ let handle_code_shell ~tool_name ~start_time ctx args =
                  cwd_opt
                  command_context.Exec_shell_gate.ast
              in
+             (* TEL-OK: pure risk classification; downstream dispatch_classified
+                emits gate_verdict + latency counters *)
              let dispatch_envelope =
                Masc_exec.Shell_ir_risk.classify
                  (Masc_exec.Shell_ir_risk.undecided dispatch_ir)

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -619,6 +619,8 @@ let handle_code_shell ~tool_name ~start_time ctx args =
                | Some dir -> dir
                | None -> Sys.getcwd ()
              in
+             (* TEL-OK: pure routing; Keeper_shell_ir.dispatch_classified emits
+                gate_verdict + latency counters downstream *)
              let dispatch_ir =
                Exec_shell_adapter.shell_ir_with_default_cwd
                  cwd_opt

--- a/lib/tool_code_write_shell_validate.ml
+++ b/lib/tool_code_write_shell_validate.ml
@@ -1,6 +1,10 @@
 (** Shell command allowlist + validation + exit-status classifier for
     the [masc_code_shell] tool surface.
 
+    TEL-OK: pure validation + classification functions; no side effects.
+    Telemetry is emitted by callers in [Tool_code_write] and
+    [Keeper_shell_ir.dispatch_classified].
+
     Pure helpers — verbatim extract from [Tool_code_write]. Delegates
     to [Keeper_shell_ir.coding_command_context] for the heavy parsing and
     policy checks; the [allowed_shell_commands] compatibility surface

--- a/lib/tool_code_write_shell_validate.ml
+++ b/lib/tool_code_write_shell_validate.ml
@@ -2,8 +2,8 @@
     the [masc_code_shell] tool surface.
 
     Pure helpers — verbatim extract from [Tool_code_write]. Delegates
-    to [Exec_policy.command_context_coding_with_allowlist] for
-    the heavy parsing; the [allowed_shell_commands] compatibility surface
+    to [Keeper_shell_ir.coding_command_context] for the heavy parsing and
+    policy checks; the [allowed_shell_commands] compatibility surface
     is derived from [Dev_exec_allowlist.code_shell], keeping the executable
     vocabulary owned by [Masc_exec.Bin]. This module owns only the
     [classify_code_shell_exit] disposition over [code] and [last_stage_bin]. *)
@@ -13,26 +13,11 @@ module Exec_shell_gate = Masc_exec_command_gate.Shell_command_gate
 let allowed_shell_commands = Dev_exec_allowlist.code_shell
 
 let code_shell_command_context command =
-  match Exec_policy.parse_string_to_ir ~mode:Coding command with
-  | Error reason ->
-    Error
-      (Exec_policy.block_reason_to_string_with_allowlist
-         ~allowed_commands:allowed_shell_commands
-         reason)
-  | Ok ir ->
-    (match
-       Exec_policy.command_context_coding_with_allowlist
-         ~caller:Exec_shell_gate.Tool_code_write
-         ~allow_pipes:true
-         ~allowed_commands:allowed_shell_commands
-         ir
-     with
-     | Ok ctx -> Ok ctx
-     | Error reason ->
-       Error
-         (Exec_policy.block_reason_to_string_with_allowlist
-            ~allowed_commands:allowed_shell_commands
-            reason))
+  Keeper_shell_ir.coding_command_context
+    ~caller:Exec_shell_gate.Tool_code_write
+    ~allow_pipes:true
+    ~allowed_commands:allowed_shell_commands
+    command
 ;;
 
 let validate_code_shell_command (command : string) : (unit, string) Result.t =

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -1533,6 +1533,10 @@ let () =
         let shell_adapter_source = load_source "lib/exec_shell_adapter.ml" in
         let exec_policy_source = load_source "lib/exec_policy.ml" in
         let keeper_bash_source = load_source "lib/keeper/keeper_shell_bash.ml" in
+        let keeper_shell_ir_source = load_source "lib/keeper/keeper_shell_ir.ml" in
+        let code_shell_validate_source =
+          load_source "lib/tool_code_write_shell_validate.ml"
+        in
         Alcotest.(check bool) "worker delegates command context" true
           (contains_substring
              worker_source
@@ -1549,6 +1553,30 @@ let () =
           (contains_substring
              keeper_bash_source
              "Keeper_shell_ir.dispatch_classified");
+        Alcotest.(check bool) "code shell dispatches through Shell IR facade" true
+          (contains_substring
+             code_shell_source
+             "Keeper_shell_ir.dispatch_classified");
+        Alcotest.(check bool) "shell IR facade owns coding command context" true
+          (contains_substring keeper_shell_ir_source "let coding_command_context");
+        Alcotest.(check bool) "code shell validation uses Shell IR facade" true
+          (contains_substring
+             code_shell_validate_source
+             "Keeper_shell_ir.coding_command_context");
+        Alcotest.(check bool) "code shell validation no longer owns coding context" false
+          (contains_substring
+             code_shell_validate_source
+             "Exec_policy.command_context_coding_with_allowlist");
+        Alcotest.(check bool) "code shell keeps redirects disabled at facade" true
+          (contains_substring code_shell_source "~redirect_allowed:false");
+        Alcotest.(check bool) "code shell no longer dispatches directly" false
+          (contains_substring
+             code_shell_source
+             "Masc_exec.Exec_dispatch.dispatch_decided");
+        Alcotest.(check bool) "code shell no longer path-validates directly" false
+          (contains_substring
+             code_shell_source
+             "Exec_policy.validate_shell_ir_paths");
         Alcotest.(check bool) "policy helper names are no longer worker-owned" false
           (contains_substring exec_policy_source "Worker_dev_tools_paths");
         Alcotest.(check bool) "policy uses renamed path helper" true


### PR DESCRIPTION
## Summary
- make `Keeper_shell_ir` own legacy coding-command context validation for `masc_code_shell`
- make `Keeper_shell_ir.dispatch_classified` accept caller/pipe/redirect policy knobs instead of hardcoding keeper Bash defaults
- route `masc_code_shell` execution through the Shell IR facade with `caller=Tool_code_write`, `allow_pipes=true`, and `redirect_allowed=false`
- add source ratchets and boundary-plan notes for the code-shell dispatch axis

## Verification
- `ocamlformat --check lib/keeper/keeper_shell_ir.ml lib/keeper/keeper_shell_ir.mli lib/tool_code_write.ml lib/tool_code_write_shell_validate.ml test/test_worker_dev_tools.ml`
- `git diff --check`
- `rg -n "Exec_policy\\.command_context_coding_with_allowlist" lib/tool_code_write_shell_validate.ml` (no matches)
- `rg -n "Masc_exec\\.Exec_dispatch\\.dispatch_decided|Exec_policy\\.validate_shell_ir_paths" lib/tool_code_write.ml` (no matches)
- `rg -n "coding_command_context|Keeper_shell_ir\\.dispatch_classified|~redirect_allowed:false|Exec_policy\\.command_context_coding_with_allowlist" lib/keeper/keeper_shell_ir.ml lib/tool_code_write_shell_validate.ml lib/tool_code_write.ml test/test_worker_dev_tools.ml docs/design/keeper-tool-runtime-boundary-plan.md docs/design/keeper-tool-runtime-boundary-plan.html`

Focused Dune was attempted with `scripts/dune-local.sh build test/test_worker_dev_tools.exe test/test_tool_code_write_coverage.exe test/test_keeper_bash_safety.exe`, but local compilation is currently blocked before this slice by `Char.isdigit` in `lib/cascade/cascade_config_provider_binding.ml`; tracked as #18446.