### PR TITLE
fix(build): repair main compile regressions

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -65,6 +65,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_exec_tools.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_voice.ml` - execution-dispatch
 - `lib/keeper/keeper_exec_voice.mli` - execution-dispatch
+- `lib/keeper/keeper_execution_receipt_types.ml` - execution-dispatch
+- `lib/keeper/keeper_execution_receipt_types.mli` - execution-dispatch
 - `lib/keeper/keeper_execution_receipt_failure_site.ml` - execution-dispatch
 - `lib/keeper/keeper_execution_receipt_failure_site.mli` - execution-dispatch
 - `lib/keeper/keeper_execution_receipt_outcome_kind.ml` - execution-dispatch
@@ -129,6 +131,10 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_sandbox_runner.mli` - sandbox-runtime
 - `lib/keeper/keeper_sandbox_runtime_classify.ml` - sandbox-runtime
 - `lib/keeper/keeper_sandbox_runtime_classify.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_runtime_setup.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_runtime_setup.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_runtime_setup_mount_failure.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_runtime_setup_mount_failure.mli` - sandbox-runtime
 - `lib/keeper/keeper_sandbox_runtime.ml` - sandbox-runtime
 - `lib/keeper/keeper_sandbox_runtime.mli` - sandbox-runtime
 - `lib/keeper/keeper_sandbox_session_executor.ml` - sandbox-runtime
@@ -155,6 +161,7 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_shell_op.mli` - shell-surface
 - `lib/keeper/keeper_shell_ops.ml` - shell-surface
 - `lib/keeper/keeper_shell_ops.mli` - shell-surface
+- `lib/keeper/keeper_shell_ops_setup.ml` - shell-surface
 - `lib/keeper/keeper_shell_path.ml` - shell-surface
 - `lib/keeper/keeper_shell_path.mli` - shell-surface
 - `lib/keeper/keeper_shell_readonly_policy.ml` - shell-surface
@@ -170,11 +177,14 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_bash_input.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_bash_input.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_boundary.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_capability_axis.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_boundary.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_deterministic_error.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_deterministic_error.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_disclosure_completion_contract.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_disclosure_completion_contract.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_disclosure_code_intent.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_disclosure_code_intent.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_disclosure.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_disclosure.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_diversity.ml` - tool-surface-policy

--- a/lib/cascade/cascade_config_provider_binding.ml
+++ b/lib/cascade/cascade_config_provider_binding.ml
@@ -126,12 +126,14 @@ let trim_trailing_slash path =
     String.sub path 0 (String.length path - 1)
   else path
 
+let is_digit c = c >= '0' && c <= '9'
+
 let is_version_segment s =
   let len = String.length s in
   len >= 2
   && s.[0] = 'v'
   && let rec all_digits i =
-       i >= len || (Char.isdigit s.[i] && all_digits (i + 1))
+       i >= len || (is_digit s.[i] && all_digits (i + 1))
      in
      all_digits 1
 
@@ -143,7 +145,7 @@ let last_path_segment path =
 let strip_leading_version request_path =
   let len = String.length request_path in
   if len >= 4 && request_path.[0] = '/' && request_path.[1] = 'v'
-     && Char.isdigit request_path.[2]
+     && is_digit request_path.[2]
   then
     let rec find_slash i =
       if i >= len then len
@@ -177,7 +179,7 @@ let normalize_openai_compat_request_path ~base_url ~request_path =
          && String.length request_path >= 4
          && request_path.[0] = '/'
          && request_path.[1] = 'v'
-         && Char.isdigit request_path.[2]
+         && is_digit request_path.[2]
     then
       strip_leading_version request_path
     else

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -613,7 +613,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                    ~observation:(direct_turn_observation ~config:ctx.config updated_meta)
                    ~result
                    ~latency_ms
-                   ~turn_cost:(turn_cost_for_result ~meta:updated_meta result)
+                   ~turn_cost:(turn_cost_for_result result)
                    ~turn_generation:lifecycle.turn_generation
                    ~channel:"turn"
                    ~snapshot_source:"keeper_turn_msg"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2415,7 +2415,7 @@ let test_prompt_includes_operational_tool_guidance () =
     bool
     "mentions Bash gh PR creation path"
     true
-    (contains_substring sys "Create or update PRs through `Bash` with `executable=\"gh\""));
+    (contains_substring sys "Create or update PRs through `Bash` with `executable=\"gh\"");
   check
     bool
     "warns passive discovery tools do not satisfy active turns"


### PR DESCRIPTION
## Summary
- fix malformed `contains_substring` assertion in `test_keeper_unified`
- replace unavailable `Char.isdigit` usage with a local ASCII digit helper
- align keeper turn cost call with the current helper signature

## Verification
- `opam exec -- ocamlc -stop-after parsing test/test_keeper_unified.ml lib/cascade/cascade_config_provider_binding.ml lib/keeper/keeper_turn.ml`
- `opam exec -- ocamlformat --check test/test_keeper_unified.ml lib/cascade/cascade_config_provider_binding.ml lib/keeper/keeper_turn.ml`
- `git diff --check`

Focused `scripts/dune-local.sh build ...` was attempted, but the host has multiple queued/bare Dune processes; wrapper returned/queued behind the machine-wide lock. This stays draft until CI or a clean local Dune slot confirms it.
