### PR TITLE
fix(cascade): use version-free /chat/completions for Provider_d_compat

### DIFF
--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -162,7 +162,7 @@ let request_path_for_http_provider ~provider ~registry_entry ~kind ~base_url =
   let request_path =
     match provider.api_format, kind with
     | Chat_completions_api, Llm_provider.Provider_config.Provider_d_compat ->
-      Llm_provider.Provider_config.request_path_default_for_kind kind
+      Masc_network_defaults.chat_completions_path
     | _ ->
       (match registry_entry with
        | Some entry -> entry.Llm_provider.Provider_registry.defaults.request_path

--- a/lib/cascade/cascade_phonebook_resolve.ml
+++ b/lib/cascade/cascade_phonebook_resolve.ml
@@ -31,10 +31,7 @@ let api_key_of_auth_env (auth_env : string option) : string =
 let request_path_of_flavor (base_url : string) (flavor : cascade_server_flavor) : string =
   match flavor with
   | Ollama -> "/api/chat"
-  | _ ->
-    Cascade_config_provider_binding.normalize_openai_compat_request_path
-      ~base_url
-      ~request_path:Masc_network_defaults.openai_chat_completions_path
+  | _ -> Masc_network_defaults.chat_completions_path
 
 let provider_config_of_phonebook
     ?(temperature = Llm_provider.Constants.Inference.default_temperature)

--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -24,6 +24,14 @@ let ollama_default_port = 11434
     if the provider ever versions the API (e.g. [/v2/...]). *)
 let openai_chat_completions_path = "/v1/chat/completions"
 
+(** Version-free chat completions path for [Provider_config.t] construction.
+
+    When [base_url] already carries a version segment (e.g. [/v1], [/v4]),
+    the request path should not repeat it — the concatenation [base_url ^
+    request_path] must produce exactly one version prefix.  This constant
+    matches what the OAS SDK's own [api_provider_d.ml] uses internally. *)
+let chat_completions_path = "/chat/completions"
+
 (** OpenAI-compatible model listing path.  See
     {!openai_chat_completions_path}. *)
 let openai_models_path = "/v1/models"

--- a/lib/config/masc_network_defaults.mli
+++ b/lib/config/masc_network_defaults.mli
@@ -41,6 +41,11 @@ val is_ollama_url : string -> bool
 (** [/v1/chat/completions]. *)
 val openai_chat_completions_path : string
 
+(** [/chat/completions] — version-free path for [Provider_config.t] where
+    [base_url] already includes the version segment.  Matches the OAS
+    SDK's internal default in [api_provider_d.ml]. *)
+val chat_completions_path : string
+
 (** [/v1/models]. *)
 val openai_models_path : string
 


### PR DESCRIPTION
## Summary

- Root cause fix for Z.ai HTTP 404: `cascade_declarative_adapter` hardcoded `request_path_default_for_kind(Provider_d_compat)` = `/v1/chat/completions`, then relied on post-hoc `normalize()` to strip version collisions
- The OAS SDK's own `api_provider_d.ml` uses `/chat/completions` directly — base_url always includes the version segment, so request_path should not
- Add `Masc_network_defaults.chat_completions_path` = `/chat/completions` and use it in both TOML adapter and phonebook resolver
- `normalize()` (from #18433) remains as safety net for `custom:model@url` path

## Before

```
base_url: https://api.z.ai/api/coding/paas/v4
request_path: /v1/chat/completions  (hardcoded kind default)
→ normalize strips /v1 → /chat/completions
→ URL: https://api.z.ai/api/coding/paas/v4/chat/completions ✓ (via heuristic)
```

## After

```
base_url: https://api.z.ai/api/coding/paas/v4
request_path: /chat/completions  (correct from the start)
→ normalize is no-op (safety net only)
→ URL: https://api.z.ai/api/coding/paas/v4/chat/completions ✓ (directly)
```

## Test plan

- [x] `dune build` passes for modified modules (pre-existing coord errors unrelated)
- [ ] `dune runtest` blocked by pre-existing coord library build errors on main
- [x] Existing `test_normalize_request_path.ml` tests still pass (normalize safety net)

🤖 Generated with [Claude Code](https://claude.com/claude-code)