### PR TITLE
refactor(keeper): drop oas env max token alias

### DIFF
--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -520,12 +520,11 @@ val metric_keeper_summarizer_state_blocks_removed : string
 val metric_keeper_oas_env_key_rejections : string
 (** Counter for [Keeper_types_profile.extract_oas_env_from_doc]
     entries dropped because the suffix did not match the
-    [OAS_(CLAUDE|CODEX|GEMINI)_] / [MASC_KEEPER_OAS_] prefix allowlist, apart
-    from a narrow legacy alias for the keeper unified max-token knob.  Each
-    rejected key increments by one and produces a warn line so operators can
-    spot configuration mistakes or attempted env-injection bypass.  Non-zero
-    counts at startup mean the keeper TOML contains [keeper.oas_env.<X>] keys
-    that the runtime silently ignored. *)
+    [OAS_<PROVIDER>_] / [MASC_KEEPER_OAS_] prefix allowlist.  Each rejected key
+    increments by one and produces a warn line so operators can spot
+    configuration mistakes or attempted env-injection bypass.  Non-zero counts
+    at startup mean the keeper TOML contains [keeper.oas_env.<X>] keys that the
+    runtime silently ignored. *)
 
 val metric_keeper_continuity_ts_recovered : string
 (** Counter for the synthetic-ts recovery branch in

--- a/lib/keeper/keeper_types_profile_oas_env.ml
+++ b/lib/keeper/keeper_types_profile_oas_env.ml
@@ -1,9 +1,7 @@
 (** Scan a flat TOML doc for keys under [[keeper.oas_env]].  Only provider
-    OAS prefixes and [MASC_KEEPER_OAS_*] are accepted.  The legacy
-    [MASC_KEEPER_UNIFIED_MAX_TOKENS] key remains accepted as a narrow migration
-    alias for the canonical [MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS].  Any other
-    entries are dropped.  This guards against arbitrary process env injection
-    via keeper TOML.  Values are coerced to strings via
+    OAS prefixes and [MASC_KEEPER_OAS_*] are accepted.  Any other entries are
+    dropped.  This guards against arbitrary process env injection via keeper
+    TOML.  Values are coerced to strings via
     [string_of_toml_value_for_env] (bool -> "1"/"0"), so integers and booleans
     in TOML map to the string shapes the OAS transport build_args already
     understand. *)
@@ -20,15 +18,8 @@ let oas_env_key_prefix = "keeper.oas_env."
 
 let keeper_unified_max_tokens_oas_env_key = "MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS"
 
-let legacy_keeper_unified_max_tokens_oas_env_key =
-  "MASC_KEEPER_UNIFIED_MAX_TOKENS"
-;;
-
-let oas_env_allowed_exact_keys = [ legacy_keeper_unified_max_tokens_oas_env_key ]
-
 let oas_env_key_is_allowed suffix =
-  List.mem suffix oas_env_allowed_exact_keys
-  || String.starts_with suffix ~prefix:"MASC_KEEPER_OAS_"
+  String.starts_with suffix ~prefix:"MASC_KEEPER_OAS_"
   || (String.starts_with suffix ~prefix:"OAS_"
       && (try
             let after_oas =
@@ -85,13 +76,8 @@ let extract_oas_env_from_doc (doc : Keeper_toml_loader.toml_doc)
 ;;
 
 let unified_max_tokens_override_of_oas_env ?keeper_name pairs =
-  let key, raw_opt =
-    match List.assoc_opt keeper_unified_max_tokens_oas_env_key pairs with
-    | Some raw -> keeper_unified_max_tokens_oas_env_key, Some raw
-    | None ->
-      ( legacy_keeper_unified_max_tokens_oas_env_key
-      , List.assoc_opt legacy_keeper_unified_max_tokens_oas_env_key pairs )
-  in
+  let key = keeper_unified_max_tokens_oas_env_key in
+  let raw_opt = List.assoc_opt key pairs in
   match raw_opt with
   | None -> None
   | Some raw ->

--- a/lib/keeper/keeper_types_profile_oas_env.mli
+++ b/lib/keeper/keeper_types_profile_oas_env.mli
@@ -3,8 +3,6 @@
 val string_of_toml_value_for_env : Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
-val legacy_keeper_unified_max_tokens_oas_env_key : string
-val oas_env_allowed_exact_keys : string list
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc : Keeper_toml_loader.toml_doc -> (string * string) list
 

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -253,8 +253,6 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
-val legacy_keeper_unified_max_tokens_oas_env_key : string
-val oas_env_allowed_exact_keys : string list
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -253,8 +253,6 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
-val legacy_keeper_unified_max_tokens_oas_env_key : string
-val oas_env_allowed_exact_keys : string list
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -253,8 +253,6 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
-val legacy_keeper_unified_max_tokens_oas_env_key : string
-val oas_env_allowed_exact_keys : string list
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1569,7 +1569,7 @@ MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS = 8192
         (Some 8192)
         (KTP.unified_max_tokens_override_of_oas_env d.oas_env)
 
-let test_oas_env_supports_legacy_unified_max_tokens_alias () =
+let test_oas_env_rejects_legacy_unified_max_tokens_alias () =
   let input = {|
 [keeper]
 persona_name = "analyst"
@@ -1582,11 +1582,11 @@ MASC_KEEPER_UNIFIED_MAX_TOKENS = 4096
     match KTP.profile_defaults_of_toml doc with
     | Error e -> fail e
     | Ok d ->
-      check int "legacy oas_env count" 1 (List.length d.oas_env);
-      check string "legacy unified max tokens value"
-        "4096" (List.assoc "MASC_KEEPER_UNIFIED_MAX_TOKENS" d.oas_env);
+      check int "legacy oas_env count" 0 (List.length d.oas_env);
+      check bool "legacy unified max tokens dropped" false
+        (List.mem_assoc "MASC_KEEPER_UNIFIED_MAX_TOKENS" d.oas_env);
       check (option int) "legacy unified max tokens override"
-        (Some 4096)
+        None
         (KTP.unified_max_tokens_override_of_oas_env d.oas_env)
 
 let test_keeper_oas_context_demotes_gemini_no_mcp_to_plan () =
@@ -2024,8 +2024,8 @@ let () =
         [
           test_case "parses allowed OAS_* keys" `Quick
             test_oas_env_parses_allowed_keys;
-          test_case "supports legacy unified max tokens alias" `Quick
-            test_oas_env_supports_legacy_unified_max_tokens_alias;
+          test_case "rejects legacy unified max tokens alias" `Quick
+            test_oas_env_rejects_legacy_unified_max_tokens_alias;
           test_case "demotes Provider_f no-MCP runs to plan approval mode" `Quick
             test_keeper_oas_context_demotes_gemini_no_mcp_to_plan;
           test_case "preserves explicit Provider_f approval mode" `Quick


### PR DESCRIPTION
## Summary
- reject legacy MASC_KEEPER_UNIFIED_MAX_TOKENS inside [keeper.oas_env]
- keep only canonical MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS for OAS transport max-token override
- replace alias-preservation coverage with rejection coverage and update the legacy purge ledger

## Validation
- ocamlformat --check lib/keeper/keeper_types_profile_oas_env.ml lib/keeper/keeper_types_profile_oas_env.mli lib/keeper/keeper_types_profile_toml.mli lib/keeper/keeper_types_profile_toml_io.mli lib/keeper/keeper_types_profile_toml_parser.mli lib/keeper/keeper_metrics.mli test/test_keeper_toml.ml
- ocamlc -stop-after parsing lib/keeper/keeper_types_profile_oas_env.ml lib/keeper/keeper_types_profile_oas_env.mli lib/keeper/keeper_types_profile_toml.mli lib/keeper/keeper_types_profile_toml_io.mli lib/keeper/keeper_types_profile_toml_parser.mli lib/keeper/keeper_metrics.mli test/test_keeper_toml.ml
- git diff --check
- rg legacy_keeper_unified_max_tokens_oas_env_key|oas_env_allowed_exact_keys|supports legacy unified max tokens alias|legacy unified max tokens value|narrow legacy alias lib test docs (no matches)
- scripts/lint-ignore-without-comment.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Local Dune
- scripts/dune-local.sh build ./test/test_keeper_toml.exe lib/keeper/keeper_types_profile_oas_env.ml lib/keeper/keeper_types_profile_oas_env.mli lib/keeper/keeper_types_profile_toml.mli lib/keeper/keeper_types_profile_toml_io.mli lib/keeper/keeper_types_profile_toml_parser.mli lib/keeper/keeper_metrics.mli returned exit 75 because machine-wide bare Dune processes were active; guard was not bypassed.