### PR TITLE
fix(keeper): PR review commitOID race — gh api REST instead of GraphQL

### DIFF
--- a/lib/keeper_gh_pr_review_cli.ml
+++ b/lib/keeper_gh_pr_review_cli.ml
@@ -24,10 +24,20 @@ let pr_diff ~repo_slug ~pr_number =
   [ "gh"; "pr"; "diff"; string_of_int pr_number ] @ repo_args repo_slug
 ;;
 
+let gh_review_event_of_flag = function
+  | "--comment" -> "COMMENT"
+  | "--approve" -> "APPROVE"
+  | "--request-changes" -> "REQUEST_CHANGES"
+  | other -> other
+
 let pr_review ~repo_slug ~pr_number ~body_file ~event_flag =
-  [ "gh"; "pr"; "review"; string_of_int pr_number ]
-  @ repo_args repo_slug
-  @ [ "--body-file"; body_file; event_flag ]
+  let endpoint =
+    Printf.sprintf "repos/%s/pulls/%d/reviews" repo_slug pr_number
+  in
+  let event = gh_review_event_of_flag event_flag in
+  [ "gh"; "api"; endpoint; "-F"; "body=@" ^ body_file; "-f"
+  ; "event=" ^ event
+  ]
 ;;
 
 let pr_comment_reply ~owner_repo ~pr_number ~comment_id ~body_file =


### PR DESCRIPTION
## Summary
- `keeper_pr_review_comment` always fails with `The commitOID is not part of the pull request` because `gh pr review` (GraphQL) binds reviews to a specific commit OID
- Keeper reads PR metadata, then by the time it posts a review comment, new pushes may have invalidated that commit OID
- Switch to `gh api POST /repos/{owner}/{repo}/pulls/{pr_number}/reviews` (REST) which auto-associates reviews with the latest head commit

## Root Cause
10-layer diagnostic of why keepers stopped leaving PR review comments. Layers 1-9 fixed in prior PRs (#18431, #18444, #18453). This is Layer 11 — the final runtime failure.

Layer stack:
1. cascade healthcheck → no_tool_capable_provider (deferred)
2. keeper paused state (FIXED)
3. prompt "repos you have cloned" gate (FIXED #18431)
4. work_discovery has no open_prs source (FIXED #18431)
5. gh CLI auth failure — credential bundle (FIXED #18444)
6. LLM routing — raw gh via Bash blocked by sandbox (FIXED #18453)
7. keeper JSON missing open_prs sources (FIXED batch update)
8. ALL keeper github_identity fields empty (FIXED manual JSON)
9. LLM prioritization — ignoring open_prs nudge (FIXED config reorder)
10. Server bug — TOML→JSON doesn't propagate github_identity (WORKAROUND)
11. **gh pr review GraphQL commitOID race** (THIS PR)

## Test plan
- [x] `gh api repos/{owner}/{repo}/pulls/{pr}/reviews -F body=@file -f event=COMMENT` verified working
- [x] Build compiles cleanly (`dune build lib/keeper_gh_pr_review_cli.ml`)
- [ ] Keeper calls `keeper_pr_review_comment` after deploy — verify in system_log

🤖 Generated with [Claude Code](https://claude.com/claude-code)