### PR TITLE
fix(keeper): suppress github_identity unknown-keys WARN (20K/day)

### DIFF
--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -298,6 +298,7 @@ let canonical_keeper_meta_key_names =
    the way to first re-write. *)
 let deprecated_keeper_meta_key_names =
   [ "last_blocker_class"
+  ; "github_identity"
   ]
 
 let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =


### PR DESCRIPTION
## Summary
- Add `github_identity` to `deprecated_keeper_meta_key_names` to suppress false-positive unknown-keys WARN
- 7 keeper JSON files carry this TOML-derived key, emitting 20,867 WARNs/day (31% of all system log)

## Why
`github_identity` is set in keeper TOML config and persisted to JSON, but `meta_to_json` doesn't serialize it (it's handled at the credential/identity layer). The unknown-keys check treats it as unrecognized, flooding the log.

## Test
- `dune build --root .` passes
- The key was already in the JSON files before this PR; no behavior change except WARN suppression

Closes #18464

🤖 Generated with [Claude Code](https://claude.com/claude-code)