### PR TITLE
fix(keeper): PR review REST API + state preflight guard

### DIFF
--- a/lib/keeper/keeper_run_tools_work_discovery.ml
+++ b/lib/keeper/keeper_run_tools_work_discovery.ml
@@ -109,13 +109,13 @@ let section_for_source ~config ~(meta : Keeper_types.keeper_meta) source =
     in
     Some
       (Printf.sprintf
-         "**Open PR review:** Use the MCP tools `keeper_pr_list`, `keeper_pr_review_read`, \
-          and `keeper_pr_review_comment` — do NOT use raw `gh` CLI via Bash (it is \
-          blocked by sandbox policy). Call `keeper_pr_list` with `repo=\"%s\"` to find \
-          PRs without review comments. For each unreviewed PR, use \
-          `keeper_pr_review_read` to read the diff, then `keeper_pr_review_comment` to \
-          leave a substantive review. Skip PRs with 3+ review comments or already \
-          approved. One thorough review per cycle is more valuable than skimming many."
+         "**Open PR review:** CRITICAL: Do NOT guess or hardcode PR numbers. Always call \
+          `keeper_pr_list` FIRST with `repo=\"%s\"` to discover which PRs are actually \
+          open. Then use `keeper_pr_review_read` to read the diff, and \
+          `keeper_pr_review_comment` to leave a substantive review. Do NOT use raw `gh` \
+          CLI via Bash (blocked by sandbox policy). Skip PRs with 3+ review comments or \
+          already approved. One thorough review per cycle is more valuable than skimming \
+          many."
          repos_text)
   | _ -> None
 ;;

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -332,6 +332,81 @@ let json_bool_member key = function
       | _ -> None)
   | _ -> None
 
+(** Check whether a PR is open before attempting a review. Avoids wasting
+    a turn on CLOSED/MERGED PRs (the most common hallucination target —
+    e.g. PR #1). Returns [Ok ()] if open, [Error json] otherwise. *)
+let pr_state_preflight ~(config : Coord.config) ~(meta : keeper_meta)
+    ~pr_number ~repo_slug =
+  let argv =
+    Keeper_gh_pr_review_cli.pr_view_json
+      ~repo_slug ~pr_number ~json_fields:"state"
+  in
+  let result =
+    run_pr_review_argv ~config ~meta
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Pr_review ())
+      ~summary:"keeper pr review state preflight"
+      ~argv
+  in
+  if not (status_ok result.status) then
+    if pr_not_found_in_output result.output then
+      Error
+        (`Assoc
+           [ "ok", `Bool false
+           ; "error", `String "pr_not_found"
+           ; "pr_number", `Int pr_number
+           ; "repo", `String repo_slug
+           ; ( "hint"
+             , `String
+                 "PR not found. Call keeper_pr_list to find open PRs before \
+                  reviewing." )
+           ])
+    else
+      Error
+        (`Assoc
+           [ "ok", `Bool false
+           ; "error", `String "pr_state_check_failed"
+           ; "pr_number", `Int pr_number
+           ; "repo", `String repo_slug
+           ; "output", `String result.output
+           ])
+  else
+    try
+      let json = Yojson.Safe.from_string result.output in
+      match json_string_member "state" json with
+      | Some "OPEN" -> Ok ()
+      | Some state ->
+          Error
+            (`Assoc
+               [ "ok", `Bool false
+               ; "error", `String "pr_not_open"
+               ; "pr_number", `Int pr_number
+               ; "repo", `String repo_slug
+               ; "state", `String state
+               ; ( "hint"
+                 , `String
+                     (Printf.sprintf
+                        "PR #%d is %s, not OPEN. Call keeper_pr_list to find \
+                         open PRs before reviewing."
+                        pr_number state) )
+               ])
+      | None ->
+          Error
+            (`Assoc
+               [ "ok", `Bool false
+               ; "error", `String "pr_state_check_no_state_field"
+               ; "pr_number", `Int pr_number
+               ; "repo", `String repo_slug
+               ])
+    with Yojson.Json_error _ ->
+      Error
+        (`Assoc
+           [ "ok", `Bool false
+           ; "error", `String "pr_state_check_parse_failed"
+           ; "pr_number", `Int pr_number
+           ; "repo", `String repo_slug
+           ; "output", `String result.output
+           ])
+
 let label_names = function
   | `Assoc fields -> (
       match List.assoc_opt "labels" fields with
@@ -581,6 +656,10 @@ let handle_keeper_pr_review_comment
              with
              | Some error -> error
              | None ->
+                 (match pr_state_preflight ~config ~meta ~pr_number ~repo_slug with
+                 | Error state_error ->
+                     Yojson.Safe.to_string state_error
+                 | Ok () ->
                  let approve_preflight_result =
                    match event with
                    | Approve ->
@@ -650,7 +729,7 @@ let handle_keeper_pr_review_comment
                       @
                       match approve_preflight_json with
                       | Some json -> [ "preflight", json ]
-                      | None -> []))))
+                      | None -> [])))))
 ;;
 
 let handle_keeper_pr_review_reply

--- a/lib/keeper_gh_pr_review_cli.ml
+++ b/lib/keeper_gh_pr_review_cli.ml
@@ -24,10 +24,20 @@ let pr_diff ~repo_slug ~pr_number =
   [ "gh"; "pr"; "diff"; string_of_int pr_number ] @ repo_args repo_slug
 ;;
 
+let gh_review_event_of_flag = function
+  | "--comment" -> "COMMENT"
+  | "--approve" -> "APPROVE"
+  | "--request-changes" -> "REQUEST_CHANGES"
+  | other -> other
+
 let pr_review ~repo_slug ~pr_number ~body_file ~event_flag =
-  [ "gh"; "pr"; "review"; string_of_int pr_number ]
-  @ repo_args repo_slug
-  @ [ "--body-file"; body_file; event_flag ]
+  let endpoint =
+    Printf.sprintf "repos/%s/pulls/%d/reviews" repo_slug pr_number
+  in
+  let event = gh_review_event_of_flag event_flag in
+  [ "gh"; "api"; endpoint; "-F"; "body=@" ^ body_file; "-f"
+  ; "event=" ^ event
+  ]
 ;;
 
 let pr_comment_reply ~owner_repo ~pr_number ~comment_id ~body_file =


### PR DESCRIPTION
## Summary

- **Layer 11**: Replace `gh pr review` (GraphQL) with `gh api repos/.../reviews` (REST) to avoid `commitOID does not match` errors when the PR head has advanced past the cached OID
- **Layer 13**: Add `pr_state_preflight` that validates PR state (`OPEN`) before any review attempt, returning structured error with hint for CLOSED/MERGED PRs
- Strengthen work_discovery nudge: "Do NOT guess or hardcode PR numbers. Always call keeper_pr_list FIRST"

## Root Cause

Keepers were attempting PR reviews on hallucinated PR numbers (PR #1 — CLOSED since January). The LLM skipped calling `keeper_pr_list` and went directly to `keeper_pr_review_comment` with PR #1, hitting either:
1. `commitOID does not match` (GraphQL race on Layer 11)
2. Wasted turn on a CLOSED PR (Layer 13)

## Changes

| File | Layer | Change |
|------|-------|--------|
| `lib/keeper_gh_pr_review_cli.ml` | 11 | `gh pr review` → `gh api repos/.../reviews` (REST) |
| `lib/keeper/keeper_tool_pr_review.ml` | 13 | `pr_state_preflight` before review attempt |
| `lib/keeper/keeper_run_tools_work_discovery.ml` | 13 | Nudge text: "Do NOT guess PR numbers" |

## Test plan

- [ ] `dune build` passes (lib only — test file has pre-existing syntax error unrelated to this PR)
- [ ] Keeper attempts review on CLOSED PR → gets `pr_not_open` error with hint
- [ ] Keeper attempts review on non-existent PR → gets `pr_not_found` error with hint
- [ ] Keeper attempts review on OPEN PR → proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)