### PR TITLE
fix(keeper): add Gh to dev_exec_allowlist for dev_full sandbox

### DIFF
--- a/lib/keeper/dev_exec_allowlist.ml
+++ b/lib/keeper/dev_exec_allowlist.ml
@@ -13,6 +13,7 @@ let dev_bins =
     ; Env
     ; File
     ; Find
+    ; Gh
     ; Git
     ; Go
     ; Gofmt


### PR DESCRIPTION
## Summary
- Add `Gh` (GitHub CLI) to `dev_bins` allowlist in `dev_exec_allowlist.ml`
- Keepers with `dev_full` tool_access can now execute `gh` commands (PR operations, issue management, etc.)

## Problem
`gh` CLI was blocked for all keepers using `dev_full` sandbox profile. `Git` was in the allowlist but `Gh` was missing, despite `Masc_exec.Bin.Gh` being a registered binary variant.

## Test plan
- [ ] Verify `Dev_exec_allowlist.is_dev_allowed "gh"` returns `true`
- [ ] Existing `dev_exec_allowlist` tests pass
- [ ] Keeper can execute `gh pr list` in dev_full sandbox

Closes #18452

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>