### PR TITLE
fix(cascade): exclude keeper-internal tools from pre-dispatch capability gate

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1165,10 +1165,23 @@ let run_named
          Resolves the candidate's effective tool surface and checks whether
          it can satisfy required_tools before acquiring capacity slot or
          dispatching to the provider. Falls through to [Capability_unknown]
-         when tool resolution fails (preserving Phase A routing). *)
+         when tool resolution fails (preserving Phase A routing).
+
+         Keeper-internal tools (keeper_bash, keeper_pr_list, etc.) are
+         handled locally by the keeper runtime — external providers never
+         execute them. Exclude from the capability check to prevent false
+         "missing_required_tools" rejections that block all providers. *)
       let pre_dispatch_blocked =
         match runtime_manifest_required_tool_names with
         | [] -> None (* no required tools — skip gate *)
+        | raw_required_tool_names ->
+        let required_tool_names =
+          List.filter (fun name ->
+            not (Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name))
+            raw_required_tool_names
+        in
+        match required_tool_names with
+        | [] -> None (* all required tools are keeper-internal — skip gate *)
         | required_tool_names ->
         let provider_label = Cascade_runtime_candidate.provider_label candidate in
         match


### PR DESCRIPTION
## Summary

- **Root cause**: `keeper_turn_driver.ml` pre-dispatch capability gate compares `runtime_manifest_required_tool_names` (which includes `keeper_bash`) against provider's `satisfying_tools`. When provider doesn't support runtime MCP, `keeper_bash` is absent from `satisfying_tools`, causing ALL providers to be rejected with `missing_required_tools=[keeper_bash]`.
- **Fix**: Filter keeper-internal tools (`Tool_catalog.is_on_surface Keeper_internal`) from `required_tool_names` before the capability check. If all required tools are keeper-internal, skip the gate entirely.
- **Impact**: Resolves `no_tool_capable_provider` errors that completely blocked keeper turns requiring keeper_bash (most task-bound turns). This is the reason keepers stopped leaving code review comments on GitHub.

Layer 15 of the keeper-PR-review root cause stack (layers 1-14 previously fixed or pending).

## How the fix works

Keeper-internal tools (47 tools including `keeper_bash`, `keeper_pr_list`, `keeper_pr_review_read`, `keeper_pr_review_comment`, etc.) are executed locally by the keeper runtime. External LLM providers never process them — they appear in the tool schema for LLM routing decisions but are intercepted at dispatch time. The pre-dispatch gate should only check tools that the provider actually needs to execute.

```
Before: required_tool_names = [keeper_bash, masc_board_post, ...]
         → provider has no keeper_bash → REJECTED

After:  required_tool_names = [masc_board_post, ...]  (keeper-internal filtered)
         → provider has masc_board_post → ACCEPTED
```

## Test plan

- [x] `make build` passes (no compile errors)
- [ ] Deploy to local runtime and verify keeper turns no longer hit `no_tool_capable_provider`
- [ ] Verify `keeper_pr_list` + `keeper_pr_review_comment` flow works end-to-end
- [ ] Verify proactive turns (no required tools) still skip the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)