### PR TITLE
fix(server): add Tool_task_schemas to local_worker schema resolution

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -111,6 +111,7 @@ let select_public_local_worker_schemas () =
     (Tool_board.tools
     @ Tool_schemas_coord_core.schemas
     @ Tool_schemas_coord_extra.schemas
+    @ Tool_task_schemas.schemas
     @ Tool_schemas_agent.schemas
     @ local_worker_code_schemas
     @ local_worker_worktree_schemas


### PR DESCRIPTION
## Summary
- Add `Tool_task_schemas.schemas` to `select_public_local_worker_schemas` union
- Fixes governance_judge schema resolution failure for `masc_tasks`
- Root cause: `Tool_task_schemas` was never included in the schema union, so `masc_tasks` (defined in `tool_task_schemas.ml`) was invisible to the judge

## Impact
- Before: `masc_tasks` schema resolution fails → governance judge cannot inspect task state → contributes to scope-blocked keepers (33/35 unclaimed)
- After: judge can resolve all 4 requested tools (masc_status, masc_tasks, masc_agents, masc_board_list)

## Test plan
- [ ] Build passes locally ✅
- [ ] CI Build and Test passes
- [ ] Server restart shows no `masc_tasks` schema resolution WARN

Closes #18478, Closes #18454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>