### PR TITLE
fix(governance): masc_keeper_reset risk override Medium (dead-end fix)

### DIFF
--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -92,6 +92,7 @@ let risk_overrides : (string * risk_level) list =
     ("masc_claim_next", Medium);
     ("masc_worktree_create", Medium); (* routine sandbox setup; removal stays Critical *)
     ("keeper_task_create", Medium); (* routine keeper backlog expansion; force/delete stays gated *)
+    ("masc_keeper_reset", Medium); (* usage counter zeroing only; keeper_clear stays Critical *)
   ]
 
 let critical_patterns =


### PR DESCRIPTION
## Summary

- Add `masc_keeper_reset` to `risk_overrides` as `Medium` in `governance_pipeline_risk.ml`
- The substring classifier matched "reset" → `Critical`, causing `require_confirm` with retired petitions → governance dead-end
- `masc_keeper_reset` only zeroes usage counters and clears `last_model_used` (see `tool_keeper.ml:269-280`)
- `masc_keeper_clear` (which is actually destructive, `destructive=true` in tool_catalog) stays `Critical`

## Evidence

```
seq:97035 tools/call: masc_keeper_reset (started)
seq:97037 high-risk tool=masc_keeper_reset (petition skipped; governance petitions retired)
seq:97038 risk=critical -> require_confirm
seq:97039 failure_class=workflow_rejection, timeout_hit=false
```

Root cause: `governance_pipeline_risk.ml:98` `critical_patterns` includes "reset" → substring match on "masc_keeper_reset".

## Test plan

- [x] Local `dune build` passes
- [ ] CI lint/meta guards pass
- [ ] Verify `masc_keeper_reset` now classifies as Medium via governance trace

Closes #18480

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>