### PR TITLE
fix(keeper): PR review nudge + runtime open-PR hints (Layer 18+19)

### DIFF
--- a/lib/keeper/keeper_run_tools_work_discovery.ml
+++ b/lib/keeper/keeper_run_tools_work_discovery.ml
@@ -109,13 +109,20 @@ let section_for_source ~config ~(meta : Keeper_types.keeper_meta) source =
     in
     Some
       (Printf.sprintf
-         "**Open PR review:** CRITICAL: Do NOT guess or hardcode PR numbers. Always call \
-          `keeper_pr_list` FIRST with `repo=\"%s\"` to discover which PRs are actually \
-          open. Then use `keeper_pr_review_read` to read the diff, and \
-          `keeper_pr_review_comment` to leave a substantive review. Do NOT use raw `gh` \
-          CLI via Bash (blocked by sandbox policy). Skip PRs with 3+ review comments or \
-          already approved. One thorough review per cycle is more valuable than skimming \
-          many."
+         "**Open PR review:** MANDATORY SEQUENCE — violations cause immediate tool error.\n\
+          Step 1: Call `keeper_pr_list` with `repo=\"%s\"`.\n\
+          Step 2: Read the response JSON. Extract PR numbers from the `pr_number` field \
+          ONLY.\n\
+          Step 3: Pick ONE open PR from the list. Call `keeper_pr_review_read`.\n\
+          Step 4: Read the full diff. Write a review. Call `keeper_pr_review_comment`.\n\
+          VIOLATIONS (each causes tool error and turn waste):\n\
+          - Calling `keeper_pr_review_comment` BEFORE `keeper_pr_list` (blocked by \
+          pr_state_preflight — you will get pr_not_open for guessed/closed PRs).\n\
+          - Using a PR number from your training data, memory, or any source other than \
+          the `keeper_pr_list` response (those PRs are almost certainly merged/closed).\n\
+          - Using raw `gh` CLI via Bash (blocked by sandbox policy).\n\
+          Skip PRs with 3+ review comments or already approved. One thorough review per \
+          cycle is more valuable than skimming many."
          repos_text)
   | _ -> None
 ;;

--- a/lib/keeper/keeper_run_tools_work_discovery.ml
+++ b/lib/keeper/keeper_run_tools_work_discovery.ml
@@ -127,23 +127,48 @@ let section_for_source ~config ~(meta : Keeper_types.keeper_meta) source =
   | _ -> None
 ;;
 
-let render_nudge ~interval sections =
+let render_nudge ~interval ~(pr_review_sections : string list) ~(other_sections : string list)
+  =
   let active_schema_guard =
     "Use only tool schemas currently shown by the runtime. If an execution tool is \
      absent from the active schema list, do not name or call it; emit [STATE] or use \
      a visible handoff/status tool."
   in
   let unknown_tool_guard = Keeper_tool_guidance.render_unknown_tool_guard () in
+  let pr_review_header =
+    match pr_review_sections with
+    | [] -> ""
+    | _ :: _ ->
+      let body = String.concat "\n\n" pr_review_sections in
+      Printf.sprintf
+        "## Discovered Work (auto, %ds interval) — PRIORITY ORDER\n\n\
+         ### BEFORE any other work: complete one PR review\n\
+         %s\n\n\
+         You MUST complete at least one PR review step (keeper_pr_list → \
+         keeper_pr_review_read → keeper_pr_review_comment) BEFORE touching tasks, \
+         board posts, or verification items. This is not optional.\n\n"
+        interval
+        body
+  in
+  let other_header =
+    match other_sections with
+    | [] -> ""
+    | _ :: _ ->
+      Printf.sprintf
+        "### After PR review: other discovered work\n\
+         %s\n\n"
+        (String.concat "\n\n" other_sections)
+  in
   Printf.sprintf
-    "## Discovered Work (auto, %ds interval)\n\n\
-     %s\n\n\
+    "%s\
+     %s\
      ### Use the smallest real action now\n\
      %s\n\n\
      %s\n\n\
      Do not print fenced pseudo-calls. Pick the smallest viable action and emit one \
      or more structured tool calls now."
-    interval
-    (String.concat "\n\n" sections)
+    pr_review_header
+    other_header
     active_schema_guard
     unknown_tool_guard
 ;;
@@ -173,14 +198,24 @@ let make ~(config : Coord.config) ~get_meta () () : string option =
           Some (Printf.sprintf "**Operator guidance:** %s" (String.trim g))
         | _ -> None
       in
-      let sections =
-        chunks
+      let pr_review_sections, other_sections =
+        List.partition
+          (fun s ->
+             String.length s > 0
+             && String.sub s 0
+                  (min (String.length s) 19)
+                  (* Starts with the "**Open PR review:**" prefix *)
+                  |> String.starts_with ~prefix:"**Open PR review:**")
+          chunks
+      in
+      let other_sections =
+        other_sections
         @
         match guidance_section with
         | Some s -> [ s ]
         | None -> []
       in
-      match sections with
+      match pr_review_sections @ other_sections with
       | [] -> None
-      | _ -> Some (render_nudge ~interval sections))
+      | _ -> Some (render_nudge ~interval ~pr_review_sections ~other_sections))
 ;;

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -335,6 +335,38 @@ let json_bool_member key = function
 (** Check whether a PR is open before attempting a review. Avoids wasting
     a turn on CLOSED/MERGED PRs (the most common hallucination target —
     e.g. PR #1). Returns [Ok ()] if open, [Error json] otherwise. *)
+let fetch_open_pr_numbers ~(config : Coord.config) ~(meta : keeper_meta)
+    ~repo_slug
+  =
+  let argv =
+    Keeper_gh_pr_review_cli.pr_list_open ~repo_slug ~limit:5
+  in
+  let result =
+    run_pr_review_argv ~config ~meta
+      ~timeout_sec:
+        (Env_config_exec_timeout.timeout_sec ~caller:Pr_review ())
+      ~summary:"keeper pr review open pr lookup"
+      ~argv
+  in
+  if status_ok result.status then
+    try
+      let json = Yojson.Safe.from_string result.output in
+      match json with
+      | `List items ->
+          List.filter_map
+            (fun item ->
+              match item with
+              | `Assoc fields -> (
+                  match List.assoc_opt "number" fields with
+                  | Some (`Int n) -> Some n
+                  | _ -> None )
+              | _ -> None)
+            items
+      | _ -> []
+    with _ -> []
+  else []
+;;
+
 let pr_state_preflight ~(config : Coord.config) ~(meta : keeper_meta)
     ~pr_number ~repo_slug =
   let argv =
@@ -349,16 +381,29 @@ let pr_state_preflight ~(config : Coord.config) ~(meta : keeper_meta)
   in
   if not (status_ok result.status) then
     if pr_not_found_in_output result.output then
+      let open_prs =
+        fetch_open_pr_numbers ~config ~meta ~repo_slug
+      in
+      let open_pr_hint =
+        match open_prs with
+        | [] -> "No open PRs found in this repo."
+        | prs ->
+            Printf.sprintf "Actual open PRs in %s: [%s]. Use one of THESE."
+              repo_slug
+              (String.concat ", " (List.map string_of_int prs))
+      in
       Error
         (`Assoc
            [ "ok", `Bool false
            ; "error", `String "pr_not_found"
            ; "pr_number", `Int pr_number
            ; "repo", `String repo_slug
+           ; "open_pr_numbers", `List (List.map (fun n -> `Int n) open_prs)
            ; ( "hint"
              , `String
-                 "PR not found. Call keeper_pr_list to find open PRs before \
-                  reviewing." )
+                 (Printf.sprintf
+                    "PR #%d not found in %s. %s" pr_number repo_slug open_pr_hint)
+             )
            ])
     else
       Error
@@ -375,6 +420,17 @@ let pr_state_preflight ~(config : Coord.config) ~(meta : keeper_meta)
       match json_string_member "state" json with
       | Some "OPEN" -> Ok ()
       | Some state ->
+          let open_prs =
+            fetch_open_pr_numbers ~config ~meta ~repo_slug
+          in
+          let open_pr_hint =
+            match open_prs with
+            | [] -> "No open PRs found in this repo."
+            | prs ->
+                Printf.sprintf "Actual open PRs in %s: [%s]. Use one of THESE."
+                  repo_slug
+                  (String.concat ", " (List.map string_of_int prs))
+          in
           Error
             (`Assoc
                [ "ok", `Bool false
@@ -382,12 +438,11 @@ let pr_state_preflight ~(config : Coord.config) ~(meta : keeper_meta)
                ; "pr_number", `Int pr_number
                ; "repo", `String repo_slug
                ; "state", `String state
+               ; "open_pr_numbers", `List (List.map (fun n -> `Int n) open_prs)
                ; ( "hint"
                  , `String
-                     (Printf.sprintf
-                        "PR #%d is %s, not OPEN. Call keeper_pr_list to find \
-                         open PRs before reviewing."
-                        pr_number state) )
+                     (Printf.sprintf "PR #%d is %s, not OPEN. %s"
+                        pr_number state open_pr_hint) )
                ])
       | None ->
           Error

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1165,10 +1165,23 @@ let run_named
          Resolves the candidate's effective tool surface and checks whether
          it can satisfy required_tools before acquiring capacity slot or
          dispatching to the provider. Falls through to [Capability_unknown]
-         when tool resolution fails (preserving Phase A routing). *)
+         when tool resolution fails (preserving Phase A routing).
+
+         Keeper-internal tools (keeper_bash, keeper_pr_list, etc.) are
+         handled locally by the keeper runtime — external providers never
+         execute them. Exclude from the capability check to prevent false
+         "missing_required_tools" rejections that block all providers. *)
       let pre_dispatch_blocked =
         match runtime_manifest_required_tool_names with
         | [] -> None (* no required tools — skip gate *)
+        | raw_required_tool_names ->
+        let required_tool_names =
+          List.filter (fun name ->
+            not (Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name))
+            raw_required_tool_names
+        in
+        match required_tool_names with
+        | [] -> None (* all required tools are keeper-internal — skip gate *)
         | required_tool_names ->
         let provider_label = Cascade_runtime_candidate.provider_label candidate in
         match

--- a/lib/keeper_gh_pr_review_cli.ml
+++ b/lib/keeper_gh_pr_review_cli.ml
@@ -40,6 +40,13 @@ let pr_review ~repo_slug ~pr_number ~body_file ~event_flag =
   ]
 ;;
 
+let pr_list_open ~repo_slug ~limit =
+  [ "gh"; "pr"; "list"; "-R"; repo_slug; "--state"; "open"; "--limit"
+  ; string_of_int limit
+  ; "--json"; "number,title"
+  ]
+;;
+
 let pr_comment_reply ~owner_repo ~pr_number ~comment_id ~body_file =
   let endpoint =
     Printf.sprintf


### PR DESCRIPTION
## Summary
- **Layer 18**: work_discovery `open_prs` prompt rewritten as mandatory numbered sequence with explicit violation consequences (turn waste, tool error)
- **Layer 19**: `pr_state_preflight` now injects actual open PR numbers into error responses via inline `gh pr list`, so LLM sees "Actual open PRs: [18477, 18457]" instead of generic "call keeper_pr_list first"
- Added `keeper_gh_pr_review_cli.pr_list_open` argv builder

## Context
Root cause stack for "keepers no longer do PR reviews" — 19 layers deep. Layers 1-15 already merged (#18431, #18444, #18453, #18466, #18467, #18477). This PR adds Layer 18 (prompt engineering) and Layer 19 (runtime guard).

## Test plan
- [ ] Verify work_discovery nudge contains mandatory sequence format
- [ ] Verify `keeper_pr_review_comment` on closed PR returns `open_pr_numbers` field
- [ ] Verify build passes with `dune build --root .`
- [ ] Monitor ramarama behavior with deployed binary

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>