### PR TITLE
fix(dashboard): expose FSM guard violation breakdown

### DIFF
--- a/dashboard/src/api/schemas/keeper-composite.test.ts
+++ b/dashboard/src/api/schemas/keeper-composite.test.ts
@@ -52,6 +52,26 @@ describe('parseKeeperCompositeSnapshot', () => {
     expect(result.fsm_guard_violations).toBe(3)
   })
 
+  it('parses fsm guard violation breakdown buckets', () => {
+    const result = parseKeeperCompositeSnapshot({
+      ...VALID_SNAPSHOT,
+      fsm_guard_violations: 3,
+      fsm_guard_violation_breakdown: [
+        { action: 'turn_phase_transition', stage: 'guard', count: 2 },
+        { action: 'completion_contract', stage: 'finalize', count: 1 },
+      ],
+    })
+    expect(result.fsm_guard_violation_breakdown).toEqual([
+      { action: 'turn_phase_transition', stage: 'guard', count: 2 },
+      { action: 'completion_contract', stage: 'finalize', count: 1 },
+    ])
+  })
+
+  it('defaults fsm guard violation breakdown to an empty list for old payloads', () => {
+    const result = parseKeeperCompositeSnapshot(VALID_SNAPSHOT)
+    expect(result.fsm_guard_violation_breakdown).toEqual([])
+  })
+
   it('throws CompositeSchemaDriftError when fsm_guard_violations is absent', () => {
     const { fsm_guard_violations: _, ...noViolations } = VALID_SNAPSHOT
     expect(() => parseKeeperCompositeSnapshot(noViolations)).toThrow(CompositeSchemaDriftError)

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -205,6 +205,12 @@ const OperatorRecommendedActionSchema = object({
   preview: optional(unknown()),
 })
 
+const FsmGuardViolationBucketSchema = object({
+  action: string(),
+  stage: string(),
+  count: number(),
+})
+
 export const KeeperCompositeSnapshotSchema = object({
   // Explicit registry identity from new backends. Optional so pinned older
   // backends keep rendering; UI falls back to canonical correlation_id parsing.
@@ -236,6 +242,7 @@ export const KeeperCompositeSnapshotSchema = object({
   measurement: KeeperCompositeMeasurementSchema,
   invariants: KeeperCompositeInvariantsSchema,
   fsm_guard_violations: number(),
+  fsm_guard_violation_breakdown: fallback(array(FsmGuardViolationBucketSchema), []),
   phase_diagnosis: optional(KeeperPhaseDiagnosisSchema),
   is_live: boolean(),
   live_turn: optional(nullable(KeeperLiveTurnSchema)),

--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -57,6 +57,7 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
       measurement: {} as KeeperCompositeSnapshot['measurement'],
       invariants: {} as KeeperCompositeSnapshot['invariants'],
       fsm_guard_violations: 0,
+      fsm_guard_violation_breakdown: [],
       is_live: false,
       last_outcome: null,
       recommended_actions: [],

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -72,6 +72,7 @@ function snapshot(
       ...overrides.violate,
     },
     fsm_guard_violations: 0,
+    fsm_guard_violation_breakdown: [],
     is_live: false,
     last_outcome: null,
     recommended_actions: [],
@@ -771,6 +772,26 @@ describe('FleetFsmMatrix streaming fallback', () => {
     const cell = await screen.findByText('가동 중 · 정체')
     expect(cell.getAttribute('data-axis')).toBe('phase')
     expect(cell.getAttribute('data-runtime-phase-conflict')).toBe('true')
+  })
+
+  it('adds the top FSM guard violation source to the strip tooltip', async () => {
+    fetchKeepersCompositeMock.mockResolvedValue(
+      fleetSnapshot([
+        snapshot({
+          name: 'guarded',
+          fsm_guard_violations: 3,
+          fsm_guard_violation_breakdown: [
+            { action: 'turn_phase_transition', stage: 'guard', count: 2 },
+            { action: 'completion_contract', stage: 'finalize', count: 1 },
+          ],
+        }),
+      ]),
+    )
+
+    render(html`<${FleetFsmMatrix} pollIntervalMs=${1000} />`)
+
+    const chip = await screen.findByTestId('fsm-guard-violation-chip')
+    expect(chip.title).toContain('turn_phase_transition/guard: 2')
   })
 
   it('requests supervised AI diagnosis with the row cause and evidence', async () => {

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -980,6 +980,18 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
     () => (data ? (data.snapshots[0]?.fsm_guard_violations ?? 0) : 0),
     [data],
   )
+  const fsmGuardViolationBreakdown = useMemo(
+    () => (data ? (data.snapshots[0]?.fsm_guard_violation_breakdown ?? []) : []),
+    [data],
+  )
+  const fsmGuardViolationTitle = useMemo(() => {
+    const total = fsmGuardViolationsTotal ?? 0
+    const top = fsmGuardViolationBreakdown[0]
+    if (total > 0 && top) {
+      return `전체 [@@fsm_guard] 런타임 assertion 위반 횟수 · 최다 ${top.action}/${top.stage}: ${top.count}`
+    }
+    return '전체 [@@fsm_guard] 런타임 assertion 위반 횟수'
+  }, [fsmGuardViolationBreakdown, fsmGuardViolationsTotal])
   const runtimeTallies = useMemo(
     () => (data ? tallyRuntimeAttention(data.snapshots, data.generated_at) : null),
     [data],
@@ -1104,7 +1116,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                       <span
                         data-testid="fsm-guard-violation-chip"
                         class="rounded-[var(--r-1)] border bg-[var(--bad-10)] px-2 py-0.5 text-xs text-[var(--bad-light)] border-[var(--bad-20)]"
-                        title="전체 [@@fsm_guard] 런타임 assertion 위반 횟수"
+                        title=${fsmGuardViolationTitle}
                       >
                         FSM guard 위반: ${fsmGuardViolationsTotal}
                       </span>
@@ -1113,7 +1125,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                       <span
                         data-testid="fsm-guard-violation-chip"
                         class="rounded-[var(--r-1)] border bg-[var(--ok-10)] px-2 py-0.5 text-xs text-[var(--color-status-ok)] border-[var(--ok-20)]"
-                        title="전체 [@@fsm_guard] 런타임 assertion 위반 횟수"
+                        title=${fsmGuardViolationTitle}
                       >
                         FSM guard 위반: 0
                       </span>

--- a/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
@@ -22,6 +22,7 @@ function makeSnapshot(overrides: Partial<KeeperCompositeSnapshot> = {}): KeeperC
       phase_derivation_agreement: true,
     },
     fsm_guard_violations: 0,
+    fsm_guard_violation_breakdown: [],
     is_live: true,
     last_outcome: null,
     recommended_actions: [],

--- a/dashboard/src/components/fsm-hub-types.test.ts
+++ b/dashboard/src/components/fsm-hub-types.test.ts
@@ -35,6 +35,7 @@ function snapshot(overrides: Partial<KeeperCompositeSnapshot> = {}): KeeperCompo
       phase_derivation_agreement: true,
     },
     fsm_guard_violations: 0,
+    fsm_guard_violation_breakdown: [],
     is_live: false,
     last_outcome: null,
     recommended_actions: [],

--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -56,6 +56,7 @@ const REAL_COMPOSITE_SHAPE: KeeperCompositeSnapshot = {
     phase_derivation_agreement: true,
   },
   fsm_guard_violations: 0,
+  fsm_guard_violation_breakdown: [],
   is_live: false,
   last_outcome: {
     turn_id: 353,
@@ -92,6 +93,7 @@ const REAL_COMPOSITE_PAYLOAD = {
     phase_derivation_agreement: true,
   },
   fsm_guard_violations: 0,
+  fsm_guard_violation_breakdown: [],
   is_live: false,
   last_outcome: null,
 }

--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -58,6 +58,7 @@ function snapshot(
       phase_derivation_agreement: true,
     },
     fsm_guard_violations: 0,
+    fsm_guard_violation_breakdown: [],
     is_live: false,
     last_outcome: null,
     recommended_actions: [],

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -751,6 +751,7 @@ describe('RuntimeLensSection', () => {
       },
       recommended_actions: [],
       fsm_guard_violations: 0,
+      fsm_guard_violation_breakdown: [],
     }
     return { ...base, ...overrides }
   }

--- a/dashboard/src/components/keeper-memory-tier-panel.test.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.test.ts
@@ -115,6 +115,7 @@ function mockMemoryTierFetches(
       phase_derivation_agreement: true,
     },
     fsm_guard_violations: 0,
+    fsm_guard_violation_breakdown: [],
     is_live: true,
     last_outcome: null,
     recommended_actions: [],

--- a/dashboard/src/components/turn-fsm-detail-panel.test.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.test.ts
@@ -34,6 +34,7 @@ function keeperCompositeSnapshot(
       phase_derivation_agreement: true,
     },
     fsm_guard_violations: 0,
+    fsm_guard_violation_breakdown: [],
     is_live: false,
     last_outcome: null,
     recommended_actions: [],

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -38,6 +38,7 @@ function makeComposite(
     measurement: {} as KeeperCompositeSnapshot['measurement'],
     invariants: {} as KeeperCompositeSnapshot['invariants'],
     fsm_guard_violations: 0,
+    fsm_guard_violation_breakdown: [],
     is_live: false,
     last_outcome: null,
     recommended_actions: [],

--- a/dashboard/src/lib/keeper-runtime-projection.test.ts
+++ b/dashboard/src/lib/keeper-runtime-projection.test.ts
@@ -38,6 +38,7 @@ function composite(overrides: Partial<KeeperCompositeSnapshot> = {}): KeeperComp
       phase_derivation_agreement: true,
     },
     fsm_guard_violations: 0,
+    fsm_guard_violation_breakdown: [],
     phase_diagnosis: {
       current_phase: 'Running',
       derived_phase: 'Running',

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -121,6 +121,12 @@ type live_turn = {
   last_progress_kind : string option;
 }
 
+type fsm_guard_violation_bucket = {
+  action : string;
+  stage : string;
+  count : int;
+}
+
 type snapshot = {
   keeper_name : string;
   correlation_id : string;
@@ -144,7 +150,38 @@ type snapshot = {
   idle_seconds : int;
   last_turn_ts : float;
   fsm_guard_violations : int;
+  fsm_guard_violation_breakdown : fsm_guard_violation_bucket list;
 }
+
+let take_fsm_guard_buckets limit buckets =
+  let rec loop remaining acc = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | bucket :: rest -> loop (remaining - 1) (bucket :: acc) rest
+  in
+  loop limit [] buckets
+;;
+
+let fsm_guard_violation_breakdown () =
+  Prometheus.snapshot ()
+  |> List.filter_map (fun (metric : Prometheus.metric) ->
+    if String.equal metric.name Prometheus.metric_fsm_guard_violation
+       && metric.value > 0.0
+    then
+      match List.assoc_opt "action" metric.labels, List.assoc_opt "stage" metric.labels with
+      | Some action, Some stage ->
+        Some { action; stage; count = int_of_float metric.value }
+      | _ -> None
+    else None)
+  |> List.sort (fun a b ->
+    match compare b.count a.count with
+    | 0 ->
+      (match String.compare a.action b.action with
+       | 0 -> String.compare a.stage b.stage
+       | by_action -> by_action)
+    | by_count -> by_count)
+  |> take_fsm_guard_buckets 8
+;;
 
 let turn_phase_to_string (tp : Keeper_registry.packed_turn_phase) =
   match tp with
@@ -508,6 +545,7 @@ let observe
     fsm_guard_violations =
       Prometheus.metric_total Prometheus.metric_fsm_guard_violation
       |> int_of_float;
+    fsm_guard_violation_breakdown = fsm_guard_violation_breakdown ();
   }
 
 (* Fleet fold — observe every currently-registered keeper under
@@ -705,4 +743,15 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
     "idle_seconds", `Int s.idle_seconds;
     "last_turn_ts", `Float s.last_turn_ts;
     "fsm_guard_violations", `Int s.fsm_guard_violations;
+    "fsm_guard_violation_breakdown",
+      `List
+        (List.map
+           (fun bucket ->
+              `Assoc
+                [
+                  "action", `String bucket.action;
+                  "stage", `String bucket.stage;
+                  "count", `Int bucket.count;
+                ])
+           s.fsm_guard_violation_breakdown);
   ]

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -180,6 +180,17 @@ type live_turn = {
           [last_progress_at]. *)
 }
 
+type fsm_guard_violation_bucket = {
+  action : string;
+      (** Low-cardinality [action] label from
+          [masc_fsm_guard_violation_total]. *)
+  stage : string;
+      (** Low-cardinality [stage] label from
+          [masc_fsm_guard_violation_total]. *)
+  count : int;
+      (** Current counter value for the [(action, stage)] label pair. *)
+}
+
 type snapshot = {
   keeper_name : string;
       (** Canonical keeper identity from the registry entry. This is separate
@@ -248,11 +259,17 @@ type snapshot = {
           in [Keeper_supervisor] reads this exact field. A value of [0.0]
           means the registry never recorded a completed turn. *)
   fsm_guard_violations : int;
-      (** Runtime [@@fsm_guard] assertion violations observed for this
-          keeper since process start. Bumped by
+      (** Runtime [@@fsm_guard] assertion violations observed fleet-wide
+          since process start. Bumped by
           [Keeper_fsm_guard_runtime.wrap_unit] on every invariant breach.
           Exposed in the dashboard FSM matrix top strip so operators can
           spot spec-drift without reading logs. *)
+  fsm_guard_violation_breakdown : fsm_guard_violation_bucket list;
+      (** Bounded fleet-wide breakdown of [fsm_guard_violations] by
+          [(action, stage)] label. The total is still fleet-wide because
+          [@@fsm_guard] call sites do not all carry a keeper label; this
+          field makes the runtime monitor actionable by identifying the
+          specific guard source that is currently firing. *)
 }
 
 (** Derive a composite snapshot from a live registry entry.

--- a/test/test_keeper_composite_observer.ml
+++ b/test/test_keeper_composite_observer.ml
@@ -214,6 +214,33 @@ let test_snapshot_reports_keeper_identity () =
       (Some keeper_name)
       (Json.member "keeper" snapshot |> Json.to_string_option))
 
+let test_snapshot_reports_fsm_guard_violation_breakdown () =
+  with_registry (fun () ->
+    let base_path = "/tmp/keeper-composite-fsm-guard-breakdown" in
+    let keeper_name = "guard-breakdown" in
+    let action = "CompositeObserverTest.TopGuard" in
+    let stage = "guard" in
+    P.inc_counter P.metric_fsm_guard_violation
+      ~labels:[("action", action); ("stage", stage)]
+      ~delta:4.0
+      ();
+    let entry = Reg.register ~base_path keeper_name (make_meta keeper_name) in
+    let snapshot = Obs.observe entry |> Obs.snapshot_to_json in
+    let rows = Json.member "fsm_guard_violation_breakdown" snapshot |> Json.to_list in
+    let row =
+      List.find_opt
+        (fun row ->
+           Json.member "action" row |> Json.to_string = action
+           && Json.member "stage" row |> Json.to_string = stage)
+        rows
+    in
+    match row with
+    | Some row ->
+      check int "breakdown carries labelled counter value"
+        4
+        (Json.member "count" row |> Json.to_int)
+    | None -> fail "expected fsm guard violation breakdown row")
+
 let test_snapshot_reports_phase_diagnosis () =
   with_registry (fun () ->
     let base_path = "/tmp/keeper-composite-phase-diagnosis" in
@@ -282,6 +309,8 @@ let () =
     [ test_case "stable phase exposes collapsed_from" `Quick test_snapshot_reports_collapsed_from_for_stable_phase
     ; test_case "active phase leaves collapsed_from null" `Quick test_snapshot_omits_collapsed_from_for_active_phase
     ; test_case "snapshot exposes keeper identity" `Quick test_snapshot_reports_keeper_identity
+    ; test_case "snapshot exposes fsm guard violation breakdown" `Quick
+        test_snapshot_reports_fsm_guard_violation_breakdown
     ; test_case "snapshot exposes phase diagnosis" `Quick test_snapshot_reports_phase_diagnosis
     ; test_case "phase derivation mismatch is visible" `Quick
         test_phase_derivation_agreement_detects_mismatch


### PR DESCRIPTION
## Summary

- add `fsm_guard_violation_breakdown` to keeper composite snapshots, derived from `masc_fsm_guard_violation_total{action,stage}`
- keep the existing fleet-wide total, but expose the top action/stage source in the Fleet FSM strip tooltip
- update dashboard schema/tests and composite observer coverage for the new payload field

## Why

The report-aligned monitor path could show that an FSM guard violated, but not which guard source was firing. This makes the runtime monitor actionable without changing the visible matrix layout.

## Validation

- `opam exec -- ocamlformat --check lib/keeper/keeper_composite_observer.ml lib/keeper/keeper_composite_observer.mli test/test_keeper_composite_observer.ml`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/schemas/keeper-composite.test.ts src/components/fleet-fsm-matrix.test.ts`
- `git diff --check origin/main...HEAD`
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`

## Not run

- `scripts/dune-local.sh build test/test_keeper_composite_observer.exe` was blocked by concurrent bare `dune build` processes on the host; the wrapper refused to start another local build.
