### PR TITLE
fix(board): stop silent data loss in judgment_arg and source_entries_arg

### DIFF
--- a/lib/tool_board_format.ml
+++ b/lib/tool_board_format.ml
@@ -413,7 +413,15 @@ let judgment_arg args =
     | `String _ as value -> Some value
     | `Assoc _ as value -> Some value
     | `List _ as value -> Some value
-    | `Bool _ | `Int _ | `Intlit _ | `Float _ -> None
+    | (`Bool _ | `Int _ | `Intlit _ | `Float _) as other ->
+      (* RFC-0093 Phase B Step 4: coerce scalar types to string instead of
+         silently dropping them.  LLMs occasionally send judgment: 42 or
+         judgment: true; coercing preserves the data. *)
+      let coerced = Yojson.Safe.to_string other in
+      Log.BoardLog.warn
+        "judgment_arg: coerced non-string/judgment %s to string for key %S"
+        (Yojson.Safe.to_string other) key;
+      Some (`String coerced)
   in
   match value_of "judgment" with
   | Some _ as value -> value
@@ -479,7 +487,19 @@ let source_entries_arg args =
     (match List.filter_map source_entry values with
      | [] -> None
      | entries -> Some entries)
-  | _ -> None
+  | `Assoc fields ->
+    (* Single Assoc sent instead of a List — wrap it. *)
+    (match source_entry (`Assoc fields) with
+     | Some entry ->
+       Log.BoardLog.warn
+         "source_entries_arg: wrapped single Assoc into List for sources";
+       Some [ entry ]
+     | None -> None)
+  | other ->
+    Log.BoardLog.warn
+      "source_entries_arg: ignoring non-List/non-Object sources: %s"
+      (Json_util.kind_name other);
+    None
 ;;
 
 let merge_sources_into_meta meta_json sources =

--- a/test/test_yojson_type_error_board.ml
+++ b/test/test_yojson_type_error_board.ml
@@ -161,6 +161,60 @@ let test_normalize_board_post_meta_list_meta () =
   in
   check bool "list meta must not raise Type_error" false raises
 
+(* ---- Test: judgment_arg coercion of scalar types ---- *)
+
+let test_judgment_int_coerced_to_string () =
+  let args = args_of_list [ "judgment", `Int 42 ] in
+  let result = Tool_board_format.judgment_arg args in
+  match result with
+  | Some (`String s) ->
+    check bool "int judgment coerced to string" true
+      (String.equal s "42" || String.length s > 0)
+  | Some _ -> fail "expected String from int coercion"
+  | None -> fail "int judgment should not be silently dropped"
+
+let test_judgment_bool_coerced_to_string () =
+  let args = args_of_list [ "judgment", `Bool true ] in
+  let result = Tool_board_format.judgment_arg args in
+  match result with
+  | Some (`String _) -> ()
+  | Some _ -> fail "expected String from bool coercion"
+  | None -> fail "bool judgment should not be silently dropped"
+
+let test_judgment_float_coerced_to_string () =
+  let args = args_of_list [ "judgment", `Float 3.14 ] in
+  let result = Tool_board_format.judgment_arg args in
+  match result with
+  | Some (`String _) -> ()
+  | Some _ -> fail "expected String from float coercion"
+  | None -> fail "float judgment should not be silently dropped"
+
+let test_judgment_null_returns_none () =
+  let args = args_of_list [ "judgment", `Null ] in
+  let result = Tool_board_format.judgment_arg args in
+  check (option yojson) "null judgment returns None" None result
+
+let test_judgement_spelling_fallback () =
+  let args = args_of_list [ "judgement", `String "good" ] in
+  let result = Tool_board_format.judgment_arg args in
+  check (option yojson) "judgement (UK spelling) fallback"
+    (Some (`String "good")) result
+
+(* ---- Test: source_entries_arg wraps single Assoc ---- *)
+
+let test_source_entries_single_assoc_wrapped () =
+  let args =
+    args_of_list
+      [ "sources", `Assoc [ "url", `String "https://example.com" ] ]
+  in
+  let result = Tool_board_format.source_entries_arg args in
+  match result with
+  | Some [ `Assoc fields ] ->
+    check string "url preserved" "https://example.com"
+      (Option.value ~default:"" (List.assoc_opt "url" fields |> function Some (`String s) -> Some s | _ -> None))
+  | Some _ -> fail "expected single-element list"
+  | None -> fail "single Assoc sources should be wrapped, not dropped"
+
 (* ---- Suite ---- *)
 
 let () =
@@ -182,6 +236,8 @@ let () =
             test_source_entries_missing_key;
           test_case "non-string url filtered out" `Quick
             test_source_entry_non_string_url;
+          test_case "single Assoc wrapped into list" `Quick
+            test_source_entries_single_assoc_wrapped;
         ] );
       ( "merge_sources_into_meta"
       , [
@@ -196,5 +252,18 @@ let () =
             test_normalize_board_post_meta_string_meta;
           test_case "list meta does not crash" `Quick
             test_normalize_board_post_meta_list_meta;
+        ] );
+      ( "judgment_arg coercion"
+      , [
+          test_case "int judgment coerced to string" `Quick
+            test_judgment_int_coerced_to_string;
+          test_case "bool judgment coerced to string" `Quick
+            test_judgment_bool_coerced_to_string;
+          test_case "float judgment coerced to string" `Quick
+            test_judgment_float_coerced_to_string;
+          test_case "null judgment returns None" `Quick
+            test_judgment_null_returns_none;
+          test_case "judgement spelling fallback" `Quick
+            test_judgement_spelling_fallback;
         ] );
     ]


### PR DESCRIPTION
## Summary
- `judgment_arg`: Coerce `Int`/`Bool`/`Float`/`Intlit` to string instead of silently dropping them. LLMs occasionally send `judgment: 42` or `judgment: true` — coercion preserves the data with a WARN log.
- `source_entries_arg`: Wrap single `Assoc` into a `List` instead of silently returning `None`. Warn on other non-List/non-Object types.
- Both changes follow RFC-0093 Phase B Step 3 pattern (typed arms + warn log).

## Context
- Closes #18474 (tool_board.ml silent data loss in judgment_arg and sources field parsing)
- Board analysis by nick0cave (task-304) identified the root cause: `_ -> None` catch-all patterns absorb valid data without warning.
- RFC-0093 Phase B Step 3 already fixed `normalize_board_post_meta` — this PR extends the same pattern to the remaining catch-alls.

## Test plan
- [x] 17 Alcotest tests pass (6 new + 11 existing)
- [x] `judgment_arg` coercion: Int→String, Bool→String, Float→String
- [x] `judgement` UK spelling fallback still works
- [x] `source_entries_arg` single Assoc wrapping
- [x] Existing tests for null/int/string/List sources still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)