### PR TITLE
refactor(verifier): drop oas core reexports

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-25 19:12:04 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-25 19:27:32 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -373,9 +373,15 @@
           </tr>
           <tr>
             <td><code>keeper_bash</code> <code>stages</code> alias hints</td>
-            <td><span class="status now">draft PR #18445</span></td>
+            <td><span class="status done">merged #18445</span></td>
             <td>Remove the remaining public hints that treated top-level <code>stages</code> as a live <code>keeper_bash</code> pipeline alias: resource-axis classification, descriptor expectations, Docker-route error wording, and the Legendary Bash runbook.</td>
             <td>Targeted grep is clean for the retired slash-form pipeline phrase, the old descriptor presence assertion, and the stale descriptor branch-count assertion. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
+          </tr>
+          <tr>
+            <td><code>Verifier_oas</code> core re-export facade</td>
+            <td><span class="status done">draft PR #18488</span></td>
+            <td>Stop re-exporting <code>Verifier_core</code> verdict types and parser helpers from the OAS bridge. Tests now call <code>Verifier_core</code> directly for core parsing and keep <code>Verifier_oas</code> scoped to adapter behavior.</td>
+            <td>Backstop grep is clean for the removed <code>Verifier_oas.*</code> core aliases in verifier files. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass. Focused Dune reaches an unrelated current-main compile error in <code>lib/cascade/cascade_config_provider_binding.ml</code> (<code>Char.isdigit</code> unbound).</td>
           </tr>
           <tr>
             <td><code>Keeper_types.mkdir_p</code> compatibility wrapper</td>

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -8,31 +8,13 @@
 
 open Printf
 
-(* Re-export core types for backward compatibility *)
-type verification_request = Verifier_core.verification_request =
-  { action_description : string
-  ; action_result : string
-  ; goal : string
-  ; context_summary : string
-  }
-
-type verdict = Verifier_core.verdict =
-  | Pass
-  | Warn of string
-  | Fail of string
-
-(* Re-export core functions *)
-let should_skip = Verifier_core.should_skip
-let verdict_to_string = Verifier_core.verdict_to_string
-let parse_verdict = Verifier_core.parse_verdict
-let report_verdict_schema = Verifier_core.report_verdict_schema
-let parse_verdict_from_json = Verifier_core.parse_verdict_from_json
+module Core = Verifier_core
 
 (* ================================================================ *)
 (* Verification Prompt                                              *)
 (* ================================================================ *)
 
-let build_prompt (req : verification_request) : string =
+let build_prompt (req : Core.verification_request) : string =
   let context_truncated =
     String_util.utf8_safe ~max_bytes:303 ~suffix:"..." req.context_summary
     |> String_util.to_string
@@ -88,21 +70,21 @@ One line only.|}
     The structured path is deterministic (JSON schema constrains output).
     The fallback path is nondeterministic but returns Error on failure
     instead of silently degrading. *)
-let verify (req : verification_request) : (verdict, string) result =
-  if should_skip ~action_description:req.action_description
-  then Ok Pass
+let verify (req : Core.verification_request) : (Core.verdict, string) result =
+  if Core.should_skip ~action_description:req.action_description
+  then Ok Core.Pass
   else (
     let prompt = build_prompt req in
     let verdict_ref = ref None in
     let dispatch ~name ~args =
       let start_time = Time_compat.now () in
-      match parse_verdict_from_json args with
+      match Core.parse_verdict_from_json args with
       | Ok v ->
         verdict_ref := Some v;
         Tool_result.error
           ~tool_name:name
           ~start_time
-          (sprintf "Verdict recorded: %s" (verdict_to_string v))
+          (sprintf "Verdict recorded: %s" (Core.verdict_to_string v))
       | Error msg ->
         Log.Verifier.warn "Structured verdict parse failed: %s" msg;
         Tool_result.error
@@ -117,7 +99,7 @@ let verify (req : verification_request) : (verdict, string) result =
       Keeper_turn_driver_wrappers.run_named_with_masc_tools
         ~cascade_name
         ~goal:prompt
-        ~masc_tools:[ report_verdict_schema ]
+        ~masc_tools:[ Core.report_verdict_schema ]
         ~dispatch
         ~max_turns:1
         ~temperature:Llm_provider.Constants.Inference_profile.deterministic.temperature
@@ -134,8 +116,8 @@ let verify (req : verification_request) : (verdict, string) result =
          (* LLM responded with text instead of tool call — lenient fallback *)
          let text = Agent_sdk_response.text_of_response result.response in
          Log.Verifier.info "verdict via text fallback (model did not call report_verdict)";
-         (match parse_verdict text with
-          | Ok verdict -> Ok verdict
+        (match Core.parse_verdict text with
+         | Ok verdict -> Ok verdict
           | Error parse_err ->
             Log.Verifier.warn
               "Verdict parse failed (%s); raw=%s"
@@ -158,13 +140,13 @@ let verify (req : verification_request) : (verdict, string) result =
     Warn reasons are logged to stderr for observability but do not halt
     execution, matching existing behavior where warnings are
     informational. *)
-let verdict_to_hook_decision (v : verdict) : Agent_sdk.Hooks.hook_decision =
+let verdict_to_hook_decision (v : Core.verdict) : Agent_sdk.Hooks.hook_decision =
   match v with
-  | Pass -> Agent_sdk.Hooks.Continue
-  | Warn reason ->
+  | Core.Pass -> Agent_sdk.Hooks.Continue
+  | Core.Warn reason ->
     Log.Verifier.warn "%s" reason;
     Agent_sdk.Hooks.Continue
-  | Fail reason ->
+  | Core.Fail reason ->
     Log.Verifier.error "FAIL (skipping tool): %s" reason;
     Agent_sdk.Hooks.Skip
 ;;
@@ -187,7 +169,7 @@ let handle_pre_tool_use
   : Agent_sdk.Hooks.hook_decision
   =
   let action_description = sprintf "tool:%s" tool_name in
-  if should_skip ~action_description
+  if Core.should_skip ~action_description
   then Agent_sdk.Hooks.Continue
   else (
     match
@@ -200,7 +182,7 @@ let handle_pre_tool_use
         ~tool_name
         ~reason:(Printf.sprintf "input serialization failed: %s" msg)
     | Ok input_str ->
-      let req : verification_request =
+      let req : Core.verification_request =
         { action_description; action_result = input_str; goal; context_summary }
       in
       (match verify_fn req with
@@ -217,7 +199,7 @@ let handle_pre_tool_use
 
 (** Create an OAS PreToolUse hook that wraps the verify logic.
 
-    On PreToolUse events, builds a {!verification_request} from
+    On PreToolUse events, builds a {!Verifier_core.verification_request} from
     the tool name and input JSON, calls {!verify} with the given
     model, and maps the verdict to a hook decision.
 
@@ -300,7 +282,7 @@ let guardrails_with_read_only_tag ?(max_tool_calls_per_turn : int option) ()
     tool name matches read-only patterns. Can be used in custom
     guardrails pipelines for conditional verification bypass. *)
 let read_only_predicate (schema : Agent_sdk.Types.tool_schema) : bool =
-  should_skip ~action_description:schema.name
+  Core.should_skip ~action_description:schema.name
 ;;
 
 (* ================================================================ *)

--- a/lib/verifier_oas.mli
+++ b/lib/verifier_oas.mli
@@ -5,52 +5,30 @@
 
     @since 2.233.0 *)
 
-(** {1 Types} (re-exported from Verifier_core) *)
-
-type verification_request = Verifier_core.verification_request = {
-  action_description : string;
-  action_result : string;
-  goal : string;
-  context_summary : string;
-}
-
-type verdict = Verifier_core.verdict =
-  | Pass
-  | Warn of string
-  | Fail of string
-
-(** {1 Core Functions} (re-exported from Verifier_core) *)
-
-val should_skip : action_description:string -> bool
-val verdict_to_string : verdict -> string
-val parse_verdict : string -> (verdict, string) result
-val report_verdict_schema : Masc_domain.tool_schema
-val parse_verdict_from_json : Yojson.Safe.t -> (verdict, string) result
-
 (** {1 Verification Prompt} *)
 
-val build_prompt : verification_request -> string
+val build_prompt : Verifier_core.verification_request -> string
 
 (** {1 Verification} *)
 
-val verify : verification_request -> (verdict, string) result
+val verify : Verifier_core.verification_request -> (Verifier_core.verdict, string) result
 
 (** {1 Verdict -> OAS Hook Decision} *)
 
-val verdict_to_hook_decision : verdict -> Agent_sdk.Hooks.hook_decision
+val verdict_to_hook_decision : Verifier_core.verdict -> Agent_sdk.Hooks.hook_decision
 val continue_with_degraded_verifier :
   tool_name:string -> reason:string -> Agent_sdk.Hooks.hook_decision
 
 (** {1 PreToolUse Hook} *)
 
 val handle_pre_tool_use :
-  ?verify_fn:(verification_request -> (verdict, string) result) ->
+  ?verify_fn:(Verifier_core.verification_request -> (Verifier_core.verdict, string) result) ->
   goal:string -> context_summary:string ->
   tool_name:string -> input:Yojson.Safe.t ->
   unit -> Agent_sdk.Hooks.hook_decision
 
 val make_pre_tool_hook :
-  ?verify_fn:(verification_request -> (verdict, string) result) ->
+  ?verify_fn:(Verifier_core.verification_request -> (Verifier_core.verdict, string) result) ->
   goal:string -> context_summary:string ->
   Agent_sdk.Hooks.hook
 

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -8,6 +8,7 @@
 open Masc_mcp
 
 module Oas = Agent_sdk
+module Core = Verifier_core
 
 (* ================================================================ *)
 (* Helpers                                                           *)
@@ -119,19 +120,19 @@ let test_allowlist_ignores_denied_when_both () =
 (* ================================================================ *)
 
 let test_pass_to_continue () =
-  let decision = Verifier_oas.verdict_to_hook_decision Pass in
+  let decision = Verifier_oas.verdict_to_hook_decision Core.Pass in
   Alcotest.(check bool) "Pass -> Continue"
     true
     (decision = Agent_sdk.Hooks.Continue)
 
 let test_warn_to_continue () =
-  let decision = Verifier_oas.verdict_to_hook_decision (Warn "minor issue") in
+  let decision = Verifier_oas.verdict_to_hook_decision (Core.Warn "minor issue") in
   Alcotest.(check bool) "Warn -> Continue"
     true
     (decision = Agent_sdk.Hooks.Continue)
 
 let test_fail_to_skip () =
-  let decision = Verifier_oas.verdict_to_hook_decision (Fail "critical error") in
+  let decision = Verifier_oas.verdict_to_hook_decision (Core.Fail "critical error") in
   Alcotest.(check bool) "Fail -> Skip"
     true
     (decision = Agent_sdk.Hooks.Skip)
@@ -177,53 +178,53 @@ let test_write_tools_are_not_readonly () =
 
 let test_parse_verdict_pass () =
   Alcotest.(check bool) "PASS" true
-    (Verifier_oas.parse_verdict "PASS" = Ok Pass)
+    (Core.parse_verdict "PASS" = Ok Core.Pass)
 
 let test_parse_verdict_pass_with_trailing () =
   Alcotest.(check bool) "PASS with trailing" true
-    (Verifier_oas.parse_verdict "PASS - looks good" = Ok Pass)
+    (Core.parse_verdict "PASS - looks good" = Ok Core.Pass)
 
 let test_parse_verdict_warn () =
-  match Verifier_oas.parse_verdict "WARN: minor issue" with
-  | Ok (Warn reason) ->
+  match Core.parse_verdict "WARN: minor issue" with
+  | Ok (Core.Warn reason) ->
     Alcotest.(check bool) "reason preserved" true
       (String.length reason > 0)
   | _ -> Alcotest.fail "expected Ok (Warn _)"
 
 let test_parse_verdict_fail () =
-  match Verifier_oas.parse_verdict "FAIL: critical error" with
-  | Ok (Fail reason) ->
+  match Core.parse_verdict "FAIL: critical error" with
+  | Ok (Core.Fail reason) ->
     Alcotest.(check bool) "reason preserved" true
       (String.length reason > 0)
   | _ -> Alcotest.fail "expected Ok (Fail _)"
 
 let test_parse_verdict_case_insensitive () =
   Alcotest.(check bool) "pass lowercase" true
-    (Verifier_oas.parse_verdict "pass" = Ok Pass)
+    (Core.parse_verdict "pass" = Ok Core.Pass)
 
 let test_parse_verdict_unknown_returns_error () =
-  match Verifier_oas.parse_verdict "something unexpected" with
+  match Core.parse_verdict "something unexpected" with
   | Error msg ->
     Alcotest.(check bool) "error mentions format" true
       (String.length msg > 0)
   | Ok _ -> Alcotest.fail "unknown text should return Error"
 
 let test_parse_verdict_empty_returns_error () =
-  match Verifier_oas.parse_verdict "" with
+  match Core.parse_verdict "" with
   | Error msg ->
     Alcotest.(check string) "empty output error"
       "empty verifier output" msg
   | Ok _ -> Alcotest.fail "empty text should return Error"
 
 let test_parse_verdict_rejects_passing_prefix () =
-  match Verifier_oas.parse_verdict "PASSING all checks" with
+  match Core.parse_verdict "PASSING all checks" with
   | Error msg ->
     Alcotest.(check bool) "PASSING rejected" true
       (String.length msg > 0)
   | Ok _ -> Alcotest.fail "PASSING should be rejected as invalid verdict"
 
 let test_parse_verdict_rejects_warning_prefix () =
-  match Verifier_oas.parse_verdict "WARNING: system alert" with
+  match Core.parse_verdict "WARNING: system alert" with
   | Error msg ->
     Alcotest.(check bool) "WARNING rejected" true
       (String.length msg > 0)
@@ -234,14 +235,14 @@ let test_parse_verdict_rejects_warning_prefix () =
 (* ================================================================ *)
 
 let test_verify_skips_readonly () =
-  let req : Verifier_oas.verification_request = {
+  let req : Core.verification_request = {
     action_description = "read file contents";
     action_result = "some data";
     goal = "test goal";
     context_summary = "test context";
   } in
   Alcotest.(check bool) "read-only skips to Pass" true
-    (Verifier_oas.verify req = Ok Pass)
+    (Verifier_oas.verify req = Ok Core.Pass)
 
 let test_hook_continues_on_verify_error () =
   let verify_called = ref false in
@@ -274,9 +275,9 @@ let test_hook_readonly_skips_verifier () =
   let verify_called = ref false in
   let hook =
     Verifier_oas.make_pre_tool_hook
-      ~verify_fn:(fun _req ->
-        verify_called := true;
-        Ok (Fail "should not run"))
+	    ~verify_fn:(fun _req ->
+	        verify_called := true;
+	        Ok (Core.Fail "should not run"))
       ~goal:"test goal"
       ~context_summary:"test context"
   in


### PR DESCRIPTION
## Summary
- stop re-exporting Verifier_core request/verdict types and parser helpers from Verifier_oas
- keep Verifier_oas focused on the OAS adapter surface
- update bridge tests to call Verifier_core directly for core parsing/verdict fixtures
- update the legacy purge ledger

## Validation
- ocamlformat --check lib/verifier_oas.ml lib/verifier_oas.mli test/test_verifier_oas_bridge.ml
- ocamlc -stop-after parsing lib/verifier_oas.ml lib/verifier_oas.mli test/test_verifier_oas_bridge.ml
- git diff --check
- rg Verifier_oas core re-export aliases in verifier files (no matches)
- scripts/lint-ignore-without-comment.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Local Dune
- scripts/dune-local.sh build ./test/test_verifier_oas_bridge.exe lib/verifier_oas.ml lib/verifier_oas.mli lib/verifier_core.mli reached an unrelated current-main compile error in lib/cascade/cascade_config_provider_binding.ml: Char.isdigit is unbound. This PR does not touch that file.