### PR TITLE
Center Exec_program metadata lookup

### DIFF
--- a/docs/design/keeper-agent-tool-boundary-audit-2026-05-25.md
+++ b/docs/design/keeper-agent-tool-boundary-audit-2026-05-25.md
@@ -5,7 +5,7 @@
 - Verified at: 2026-05-25T11:01:53+09:00
 - Scope: `keeper_gh*`, `keeper_hooks*`, `keeper_sandbox*`,
   `keeper_exec*`, `keeper_shell*`, `keeper_tool*`, `keeper_tools*`,
-  Shell IR walkers, `lib/exec/bin.ml`, `~/me` PR #814, local
+  Shell IR walkers, `lib/exec/exec_program.ml`, `~/me` PR #814, local
   `claude-code`, OpenClaw, Hermes Agent
 
 ## Cold Judgment
@@ -17,7 +17,7 @@ The healthy direction is real: public aliases are separated from internal
 keeper names; `keeper_bash` is typed argv/pipeline instead of raw `cmd`;
 `Keeper_shell_ir` is the center line for classify/gate/path/dispatch;
 `Keeper_gh_runner` owns GH sandbox routing; `Keeper_sandbox_runner` owns
-host-vs-Docker dispatch; `Masc_exec.Bin` is becoming the executable vocabulary
+host-vs-Docker dispatch; `Masc_exec.Exec_program` is becoming the executable vocabulary
 SSOT; generated Shell IR walkers replaced the earlier hand-written drift point.
 
 The remaining failure mode is also real: ownership is still distributed across
@@ -80,7 +80,7 @@ keeper tool, and MCP/OAS bridge consumes.
 | `keeper_gh*` | GH command parser, repo slug discovery, credentialed GH runner | Parser/repo/runner split exists; `Keeper_gh_command_parse` owns parser/risk adaptation and `Keeper_gh_runner.run_argv` owns sandbox routing | Correct. The module names now expose the parser/repo/runner axes directly |
 | `keeper_sandbox*` | OS/backend isolation, Docker runtime, mounts, credentials, containment, read runner | Docker no longer owns command semantics; runner selects host vs sandbox | Correct boundary. Must keep saying this is the load-bearing boundary, not IR heuristics |
 | `keeper_hooks*` | Post-tool/post-turn telemetry, PR metrics, cost/response events | Hooks observe tool IO and command semantics; they do not execute tools | Correct as observer layer. Must not grow execution policy |
-| `lib/exec/bin.ml` | Closed executable vocabulary and risk/kind classification | `Dev_exec_allowlist` derives names from `Masc_exec.Bin`; `bin.ml` has hand-maintained name/risk/kind/string maps | Necessary SSOT, but duplicate exhaustive maps need a generator or stronger ratchet |
+| `lib/exec/exec_program.ml` | Closed executable vocabulary and risk/kind classification | `Dev_exec_allowlist` derives names from `Masc_exec.Exec_program`; `exec_program.ml` now uses one exhaustive metadata function plus `all_known` for reverse lookup | Correct center. Keep the metadata/all-known ratchets strict so new executables cannot reintroduce parallel string maps |
 | `bin/gen_shell_ir_walkers.ml` | Build-time codegen for GADT walker boilerplate | Generates risk/sandbox/to_simple/of_simple; tests check count/order/round-trip | Justified after PPX failure, but treat as production codegen with drift budgets |
 
 ## External Comparison
@@ -162,12 +162,12 @@ mixed into keeper tool execution policy.
    target is stale after moving the call into `Keeper_shell_ir`, or the
    implementation regressed coverage. Leaving that ambiguous is not acceptable.
 
-5. `bin.ml` is conceptually correct and operationally fragile.
+5. `exec_program.ml` is now a stronger executable-vocabulary center.
    A closed executable vocabulary is exactly the right primitive for typed
-   keeper Bash. But `known`, `name_of_known`, `risk_of_known`, `kind_of_known`,
-   and `known_of_string` are hand-maintained in one 489-line module. Exhaustive
-   matches help, but string aliases and category intent still need golden tests
-   or generated tables.
+   keeper Bash. The prior separate `name_of_known`, `risk_of_known`,
+   `kind_of_known`, and `known_of_string` maps have been collapsed behind one
+   exhaustive metadata function. `all_known` drives reverse lookup and
+   round-trip tests now pin name uniqueness plus risk/kind coherence.
 
 6. `gen_shell_ir_walkers.ml` is justified, but it is now production
    infrastructure.
@@ -222,7 +222,7 @@ tool registries must not own backend routing.
 | Typed Bash legacy | Advertised `cmd` field in `keeper_bash` schema | 0 |
 | Typed Bash compatibility debt | Backward-only aliases such as `stages` documented with removal issue or accepted as permanent | 100% resolved |
 | GADT/codegen freshness | Constructor count/order/golden output checked in CI | 100% |
-| `Bin` SSOT drift | New executable constructor without name/risk/kind/string mapping test failure | 0 possible |
+| `Exec_program` SSOT drift | New executable constructor without name/risk/kind/string mapping test failure | 0 possible |
 | Module size | `keeper_shell_ops.ml`, `keeper_sandbox_docker.ml`, `keeper_exec_tools.ml` | each < 700 LoC or documented exception |
 | Security doctrine | Docs that mention sandbox/approval/allowlists state OS boundary vs heuristic distinction | 100% |
 
@@ -297,13 +297,13 @@ Exit criteria:
   API, or a long-term typed command DSL.
 - If it is long-term, add typed constructors only for commands with stable
   semantics; keep `Generic` fail-closed.
-- Generate or golden-check `Masc_exec.Bin` tables the same way Shell IR walkers
-  are checked.
+- Keep `Masc_exec.Exec_program` metadata and `all_known` golden checks strict; do not
+  reintroduce parallel string/risk/kind maps.
 - Add a freshness check for generated `Shell_ir_typed_walkers_gen`.
 
 Exit criteria:
-- New Shell IR constructor or new `Bin.known` constructor cannot merge without
-  updating every required generated/golden mapping.
+- New Shell IR constructor or new `Exec_program.known` constructor cannot merge without
+  updating every required generated/golden mapping or metadata ratchet.
 - No catch-all in risk/sandbox walkers except explicit `Generic`.
 
 ### P3: Security Boundary Doctrine

--- a/docs/design/keeper-tool-runtime-boundary-plan.md
+++ b/docs/design/keeper-tool-runtime-boundary-plan.md
@@ -127,15 +127,15 @@ and public tool aliases.
      `keeper_shell_ops.ml`.
    Continued in slice 11:
    - `Dev_exec_allowlist` now derives its dev/read-only string lists from
-     typed `Masc_exec.Bin.known` lists. The compatibility string lists remain
-     for existing gate APIs, but executable vocabulary is owned by `Bin`
+     typed `Masc_exec.Exec_program.known` lists. The compatibility string lists remain
+     for existing gate APIs, but executable vocabulary is owned by `Exec_program`
      instead of a parallel raw string table.
-   - `Masc_exec.Bin` now knows every executable admitted by the dev/read-only
+   - `Masc_exec.Exec_program` now knows every executable admitted by the dev/read-only
      keeper allowlists, and the generated Shell IR typed walker fallback was
      updated so adding known bins remains exhaustively checked by the compiler.
    - `test_keeper_bash_safety` now verifies that both keeper executable
-     allowlists are derived from `Bin.name_of_known` and that every allowlisted
-     executable resolves to a known `Bin`.
+     allowlists are derived from `Exec_program.name_of_known` and that every allowlisted
+     executable resolves to a known `Exec_program`.
    Continued in slice 12:
    - `Keeper_shell_ir` now also owns Shell IR construction for typed Bash
      input lowerers through `simple_bin` and `pipeline`, so
@@ -301,7 +301,7 @@ and public tool aliases.
      to local command-field strings; PR-work metrics consume command
      candidates from the semantic capability axis.
    Continued in slice 31:
-   - `Masc_exec.Bin` now knows the `masc_code_shell`-only executable extras
+   - `Masc_exec.Exec_program` now knows the `masc_code_shell`-only executable extras
      (`diff`, `patch`, `mkdir`, `ocamlfind`, `tsc`) instead of leaving them as
      raw strings beside the keeper Bash allowlist.
    - `Dev_exec_allowlist.code_shell_bins` and the derived
@@ -325,6 +325,13 @@ and public tool aliases.
      `Exec_policy.validate_shell_ir_paths` or
      `Masc_exec.Exec_dispatch.dispatch_decided` directly; it keeps only
      code-shell response rendering and `rg`/`grep`/`diff` exit semantics.
+   Continued in slice 33:
+   - `Masc_exec.Exec_program` now has one exhaustive `known_metadata` owner for
+     executable name, risk, and kind.
+   - `Exec_program.known_of_string` is derived from `all_known` plus that metadata
+     owner, removing the parallel string-to-constructor match table.
+   - `test_exec_types` round-trips every `Exec_program.all_known` entry and checks
+     name uniqueness, reverse lookup, risk, and kind coherence.
 
 ## Verification
 
@@ -365,7 +372,10 @@ and public tool aliases.
   `Keeper_shell_shared.run_argv_with_status_retry_eintr` execution instead of
   routing host structured ops through `Keeper_shell_ir`.
 - `test_keeper_bash_safety` now fails if `Dev_exec_allowlist.dev` or
-  `Dev_exec_allowlist.readonly` drifts away from the typed `Bin` vocabulary.
+  `Dev_exec_allowlist.readonly` drifts away from the typed `Exec_program` vocabulary.
+- The boundary test now fails if `Masc_exec.Exec_program` reintroduces separate
+  `risk_of_known`/`kind_of_known` pattern-match owners or a parallel
+  string reverse-lookup table instead of the `known_metadata` axis.
 - The boundary test now fails if `keeper_tool_bash_input.ml` reintroduces raw
   `Shell_ir` node construction instead of lowering via `Keeper_shell_ir`.
 - The boundary test now fails if PR work-action metrics bypass
@@ -419,7 +429,7 @@ and public tool aliases.
   local `keeper_bash`/`masc_code_shell` field map instead of using
   `Keeper_tool_capability_axis.shell_command_input_candidates`.
 - `test_keeper_bash_safety` now verifies the legacy `masc_code_shell`
-  allowlist is derived from typed `Bin` values through
+  allowlist is derived from typed `Exec_program` values through
   `Dev_exec_allowlist.code_shell_bins`, matching the existing dev/read-only
   allowlist ratchets.
 - `test_worker_dev_tools` now fails if `masc_code_shell` bypasses

--- a/lib/exec/exec_program.ml
+++ b/lib/exec/exec_program.ml
@@ -109,257 +109,194 @@ type known =
   | Dd
   | Mkfs
 
-let name_of_known : known -> string = function
-  | Ls -> "ls"
-  | Cat -> "cat"
-  | Pwd -> "pwd"
-  | Echo -> "echo"
-  | Head -> "head"
-  | Tail -> "tail"
-  | Rg -> "rg"
-  | Find -> "find"
-  | Which -> "which"
-  | Test -> "test"
-  | Basename -> "basename"
-  | Dirname -> "dirname"
-  | Stat -> "stat"
-  | Du -> "du"
-  | Df -> "df"
-  | Sort -> "sort"
-  | Uniq -> "uniq"
-  | Wc -> "wc"
-  | Cut -> "cut"
-  | Tr -> "tr"
-  | File -> "file"
-  | Printf -> "printf"
-  | Date -> "date"
-  | Env -> "env"
-  | Printenv -> "printenv"
-  | Hostname -> "hostname"
-  | Whoami -> "whoami"
-  | Uname -> "uname"
-  | Ps -> "ps"
-  | Tty -> "tty"
-  | Git -> "git"
-  | Docker -> "docker"
-  | Curl -> "curl"
-  | Wget -> "wget"
-  | Ssh -> "ssh"
-  | Scp -> "scp"
-  | Tar -> "tar"
-  | Rsync -> "rsync"
-  | Make -> "make"
-  | Cmake -> "cmake"
-  | Dune_local_sh -> "dune-local.sh"
-  | Diff -> "diff"
-  | Patch -> "patch"
-  | Mkdir -> "mkdir"
-  | Npm -> "npm"
-  | Node -> "node"
-  | Npx -> "npx"
-  | Yarn -> "yarn"
-  | Pnpm -> "pnpm"
-  | Pip -> "pip"
-  | Python -> "python"
-  | Python3 -> "python3"
-  | Pytest -> "pytest"
-  | Pyright -> "pyright"
-  | Ruff -> "ruff"
-  | Opam -> "opam"
-  | Ocamlfind -> "ocamlfind"
-  | Tsc -> "tsc"
-  | Cargo -> "cargo"
-  | Rustc -> "rustc"
-  | Go -> "go"
-  | Gofmt -> "gofmt"
-  | Gradle -> "gradle"
-  | Java -> "java"
-  | Javac -> "javac"
-  | Mvn -> "mvn"
-  | Ninja -> "ninja"
-  | Sed -> "sed"
-  | Uv -> "uv"
-  | Gh -> "gh"
-  | Glab -> "glab"
-  | Terminal_notifier -> "terminal-notifier"
-  | Osascript -> "osascript"
-  | Play -> "play"
-  | Rec -> "rec"
-  | Ffplay -> "ffplay"
-  | Mpg123 -> "mpg123"
-  | Open -> "open"
-  | Sudo -> "sudo"
-  | Su -> "su"
-  | Chmod -> "chmod"
-  | Chown -> "chown"
-  | Rm -> "rm"
-  | Dd -> "dd"
-  | Mkfs -> "mkfs"
+type known_metadata =
+  { name : string
+  ; risk : risk_class
+  ; kind : kind
+  }
+
+let known_metadata : known -> known_metadata = function
+  | Ls -> { name = "ls"; risk = `Safe; kind = `Safe_program }
+  | Cat -> { name = "cat"; risk = `Safe; kind = `Safe_program }
+  | Pwd -> { name = "pwd"; risk = `Safe; kind = `Safe_program }
+  | Echo -> { name = "echo"; risk = `Safe; kind = `Safe_program }
+  | Head -> { name = "head"; risk = `Safe; kind = `Safe_program }
+  | Tail -> { name = "tail"; risk = `Safe; kind = `Safe_program }
+  | Rg -> { name = "rg"; risk = `Safe; kind = `Safe_program }
+  | Find -> { name = "find"; risk = `Safe; kind = `Safe_program }
+  | Which -> { name = "which"; risk = `Safe; kind = `Safe_program }
+  | Test -> { name = "test"; risk = `Safe; kind = `Safe_program }
+  | Basename -> { name = "basename"; risk = `Safe; kind = `Safe_program }
+  | Dirname -> { name = "dirname"; risk = `Safe; kind = `Safe_program }
+  | Stat -> { name = "stat"; risk = `Safe; kind = `Safe_program }
+  | Du -> { name = "du"; risk = `Safe; kind = `Safe_program }
+  | Df -> { name = "df"; risk = `Safe; kind = `Safe_program }
+  | Sort -> { name = "sort"; risk = `Safe; kind = `Safe_program }
+  | Uniq -> { name = "uniq"; risk = `Safe; kind = `Safe_program }
+  | Wc -> { name = "wc"; risk = `Safe; kind = `Safe_program }
+  | Cut -> { name = "cut"; risk = `Safe; kind = `Safe_program }
+  | Tr -> { name = "tr"; risk = `Safe; kind = `Safe_program }
+  | File -> { name = "file"; risk = `Safe; kind = `Safe_program }
+  | Printf -> { name = "printf"; risk = `Safe; kind = `Safe_program }
+  | Date -> { name = "date"; risk = `Safe; kind = `Safe_program }
+  | Env -> { name = "env"; risk = `Safe; kind = `Safe_program }
+  | Printenv -> { name = "printenv"; risk = `Safe; kind = `Safe_program }
+  | Hostname -> { name = "hostname"; risk = `Safe; kind = `Safe_program }
+  | Whoami -> { name = "whoami"; risk = `Safe; kind = `Safe_program }
+  | Uname -> { name = "uname"; risk = `Safe; kind = `Safe_program }
+  | Ps -> { name = "ps"; risk = `Safe; kind = `Safe_program }
+  | Tty -> { name = "tty"; risk = `Safe; kind = `Safe_program }
+  | Git -> { name = "git"; risk = `Audited; kind = `Git }
+  | Docker -> { name = "docker"; risk = `Audited; kind = `Docker }
+  | Curl -> { name = "curl"; risk = `Audited; kind = `Curl }
+  | Wget -> { name = "wget"; risk = `Audited; kind = `Other_audited }
+  | Ssh -> { name = "ssh"; risk = `Audited; kind = `Ssh }
+  | Scp -> { name = "scp"; risk = `Audited; kind = `Other_audited }
+  | Tar -> { name = "tar"; risk = `Audited; kind = `Other_audited }
+  | Rsync -> { name = "rsync"; risk = `Audited; kind = `Other_audited }
+  | Make -> { name = "make"; risk = `Audited; kind = `Other_audited }
+  | Cmake -> { name = "cmake"; risk = `Audited; kind = `Other_audited }
+  | Dune_local_sh ->
+    { name = "dune-local.sh"; risk = `Audited; kind = `Other_audited }
+  | Diff -> { name = "diff"; risk = `Audited; kind = `Other_audited }
+  | Patch -> { name = "patch"; risk = `Audited; kind = `Other_audited }
+  | Mkdir -> { name = "mkdir"; risk = `Audited; kind = `Other_audited }
+  | Npm -> { name = "npm"; risk = `Audited; kind = `Other_audited }
+  | Node -> { name = "node"; risk = `Audited; kind = `Other_audited }
+  | Npx -> { name = "npx"; risk = `Audited; kind = `Other_audited }
+  | Yarn -> { name = "yarn"; risk = `Audited; kind = `Other_audited }
+  | Pnpm -> { name = "pnpm"; risk = `Audited; kind = `Other_audited }
+  | Pip -> { name = "pip"; risk = `Audited; kind = `Other_audited }
+  | Python -> { name = "python"; risk = `Audited; kind = `Other_audited }
+  | Python3 -> { name = "python3"; risk = `Audited; kind = `Other_audited }
+  | Pytest -> { name = "pytest"; risk = `Audited; kind = `Other_audited }
+  | Pyright -> { name = "pyright"; risk = `Audited; kind = `Other_audited }
+  | Ruff -> { name = "ruff"; risk = `Audited; kind = `Other_audited }
+  | Opam -> { name = "opam"; risk = `Audited; kind = `Other_audited }
+  | Ocamlfind -> { name = "ocamlfind"; risk = `Audited; kind = `Other_audited }
+  | Tsc -> { name = "tsc"; risk = `Audited; kind = `Other_audited }
+  | Cargo -> { name = "cargo"; risk = `Audited; kind = `Other_audited }
+  | Rustc -> { name = "rustc"; risk = `Audited; kind = `Other_audited }
+  | Go -> { name = "go"; risk = `Audited; kind = `Other_audited }
+  | Gofmt -> { name = "gofmt"; risk = `Audited; kind = `Other_audited }
+  | Gradle -> { name = "gradle"; risk = `Audited; kind = `Other_audited }
+  | Java -> { name = "java"; risk = `Audited; kind = `Other_audited }
+  | Javac -> { name = "javac"; risk = `Audited; kind = `Other_audited }
+  | Mvn -> { name = "mvn"; risk = `Audited; kind = `Other_audited }
+  | Ninja -> { name = "ninja"; risk = `Audited; kind = `Other_audited }
+  | Sed -> { name = "sed"; risk = `Audited; kind = `Other_audited }
+  | Uv -> { name = "uv"; risk = `Audited; kind = `Other_audited }
+  | Gh -> { name = "gh"; risk = `Audited; kind = `Other_audited }
+  | Glab -> { name = "glab"; risk = `Audited; kind = `Other_audited }
+  | Terminal_notifier ->
+    { name = "terminal-notifier"; risk = `Audited; kind = `Other_audited }
+  | Osascript -> { name = "osascript"; risk = `Audited; kind = `Other_audited }
+  | Play -> { name = "play"; risk = `Audited; kind = `Other_audited }
+  | Rec -> { name = "rec"; risk = `Audited; kind = `Other_audited }
+  | Ffplay -> { name = "ffplay"; risk = `Audited; kind = `Other_audited }
+  | Mpg123 -> { name = "mpg123"; risk = `Audited; kind = `Other_audited }
+  | Open -> { name = "open"; risk = `Audited; kind = `Other_audited }
+  | Sudo -> { name = "sudo"; risk = `Privileged; kind = `Privileged_program }
+  | Su -> { name = "su"; risk = `Privileged; kind = `Privileged_program }
+  | Chmod -> { name = "chmod"; risk = `Privileged; kind = `Privileged_program }
+  | Chown -> { name = "chown"; risk = `Privileged; kind = `Privileged_program }
+  | Rm -> { name = "rm"; risk = `Privileged; kind = `Privileged_program }
+  | Dd -> { name = "dd"; risk = `Privileged; kind = `Privileged_program }
+  | Mkfs -> { name = "mkfs"; risk = `Privileged; kind = `Privileged_program }
 ;;
 
-let risk_of_known : known -> risk_class = function
-  | Ls
-  | Cat
-  | Pwd
-  | Echo
-  | Head
-  | Tail
-  | Rg
-  | Find
-  | Which
-  | Test
-  | Basename
-  | Dirname
-  | Stat
-  | Du
-  | Df
-  | Sort
-  | Uniq
-  | Wc
-  | Cut
-  | Tr
-  | File
-  | Printf
-  | Date
-  | Env
-  | Printenv
-  | Hostname
-  | Whoami
-  | Uname
-  | Ps
-  | Tty -> `Safe
-  | Git
-  | Docker
-  | Curl
-  | Wget
-  | Ssh
-  | Scp
-  | Tar
-  | Rsync
-  | Make
-  | Cmake
-  | Dune_local_sh
-  | Diff
-  | Patch
-  | Mkdir
-  | Npm
-  | Node
-  | Npx
-  | Yarn
-  | Pnpm
-  | Pip
-  | Python
-  | Python3
-  | Pytest
-  | Pyright
-  | Ruff
-  | Opam
-  | Ocamlfind
-  | Tsc
-  | Cargo
-  | Rustc
-  | Go
-  | Gofmt
-  | Gradle
-  | Java
-  | Javac
-  | Mvn
-  | Ninja
-  | Sed
-  | Uv
-  | Gh
-  | Glab
-  | Terminal_notifier
-  | Osascript
-  | Play
-  | Rec
-  | Ffplay
-  | Mpg123
-  | Open -> `Audited
-  | Sudo | Su | Chmod | Chown | Rm | Dd | Mkfs -> `Privileged
+let all_known =
+  [ Ls
+  ; Cat
+  ; Pwd
+  ; Echo
+  ; Head
+  ; Tail
+  ; Rg
+  ; Find
+  ; Which
+  ; Test
+  ; Basename
+  ; Dirname
+  ; Stat
+  ; Du
+  ; Df
+  ; Sort
+  ; Uniq
+  ; Wc
+  ; Cut
+  ; Tr
+  ; File
+  ; Printf
+  ; Date
+  ; Env
+  ; Printenv
+  ; Hostname
+  ; Whoami
+  ; Uname
+  ; Ps
+  ; Tty
+  ; Git
+  ; Docker
+  ; Curl
+  ; Wget
+  ; Ssh
+  ; Scp
+  ; Tar
+  ; Rsync
+  ; Make
+  ; Cmake
+  ; Dune_local_sh
+  ; Diff
+  ; Patch
+  ; Mkdir
+  ; Npm
+  ; Node
+  ; Npx
+  ; Yarn
+  ; Pnpm
+  ; Pip
+  ; Python
+  ; Python3
+  ; Pytest
+  ; Pyright
+  ; Ruff
+  ; Opam
+  ; Ocamlfind
+  ; Tsc
+  ; Cargo
+  ; Rustc
+  ; Go
+  ; Gofmt
+  ; Gradle
+  ; Java
+  ; Javac
+  ; Mvn
+  ; Ninja
+  ; Sed
+  ; Uv
+  ; Gh
+  ; Glab
+  ; Terminal_notifier
+  ; Osascript
+  ; Play
+  ; Rec
+  ; Ffplay
+  ; Mpg123
+  ; Open
+  ; Sudo
+  ; Su
+  ; Chmod
+  ; Chown
+  ; Rm
+  ; Dd
+  ; Mkfs
+  ]
 ;;
 
-let kind_of_known : known -> kind = function
-  | Ls
-  | Cat
-  | Pwd
-  | Echo
-  | Head
-  | Tail
-  | Rg
-  | Find
-  | Which
-  | Test
-  | Basename
-  | Dirname
-  | Stat
-  | Du
-  | Df
-  | Sort
-  | Uniq
-  | Wc
-  | Cut
-  | Tr
-  | File
-  | Printf
-  | Date
-  | Env
-  | Printenv
-  | Hostname
-  | Whoami
-  | Uname
-  | Ps
-  | Tty -> `Safe_program
-  | Git -> `Git
-  | Docker -> `Docker
-  | Curl -> `Curl
-  | Ssh -> `Ssh
-  | Wget
-  | Scp
-  | Tar
-  | Rsync
-  | Make
-  | Cmake
-  | Dune_local_sh
-  | Diff
-  | Patch
-  | Mkdir
-  | Npm
-  | Node
-  | Npx
-  | Yarn
-  | Pnpm
-  | Pip
-  | Python
-  | Python3
-  | Pytest
-  | Pyright
-  | Ruff
-  | Opam
-  | Ocamlfind
-  | Tsc
-  | Cargo
-  | Rustc
-  | Go
-  | Gofmt
-  | Gradle
-  | Java
-  | Javac
-  | Mvn
-  | Ninja
-  | Sed
-  | Uv
-  | Gh
-  | Glab
-  | Terminal_notifier
-  | Osascript
-  | Play
-  | Rec
-  | Ffplay
-  | Mpg123
-  | Open -> `Other_audited
-  | Sudo | Su | Chmod | Chown | Rm | Dd | Mkfs -> `Privileged_program
-;;
+let name_of_known known = (known_metadata known).name
+let risk_of_known known = (known_metadata known).risk
+let kind_of_known known = (known_metadata known).kind
 
 type t =
   { name : string
@@ -370,98 +307,10 @@ type t =
 
 type unknown = [ `Unknown of string ]
 
-(** Reverse lookup: string name → [known] variant.
-
-    Uses an exhaustive match so that adding a new constructor to [known]
-    triggers a compile error here — the developer cannot forget to
-    register the string mapping. *)
-let known_of_string : string -> known option = function
-  | "ls" -> Some Ls
-  | "cat" -> Some Cat
-  | "pwd" -> Some Pwd
-  | "echo" -> Some Echo
-  | "head" -> Some Head
-  | "tail" -> Some Tail
-  | "rg" -> Some Rg
-  | "find" -> Some Find
-  | "which" -> Some Which
-  | "test" -> Some Test
-  | "basename" -> Some Basename
-  | "dirname" -> Some Dirname
-  | "stat" -> Some Stat
-  | "du" -> Some Du
-  | "df" -> Some Df
-  | "sort" -> Some Sort
-  | "uniq" -> Some Uniq
-  | "wc" -> Some Wc
-  | "cut" -> Some Cut
-  | "tr" -> Some Tr
-  | "file" -> Some File
-  | "printf" -> Some Printf
-  | "date" -> Some Date
-  | "env" -> Some Env
-  | "printenv" -> Some Printenv
-  | "hostname" -> Some Hostname
-  | "whoami" -> Some Whoami
-  | "uname" -> Some Uname
-  | "ps" -> Some Ps
-  | "tty" -> Some Tty
-  | "git" -> Some Git
-  | "docker" -> Some Docker
-  | "curl" -> Some Curl
-  | "wget" -> Some Wget
-  | "ssh" -> Some Ssh
-  | "scp" -> Some Scp
-  | "tar" -> Some Tar
-  | "rsync" -> Some Rsync
-  | "make" -> Some Make
-  | "cmake" -> Some Cmake
-  | "dune-local.sh" -> Some Dune_local_sh
-  | "diff" -> Some Diff
-  | "patch" -> Some Patch
-  | "mkdir" -> Some Mkdir
-  | "npm" -> Some Npm
-  | "node" -> Some Node
-  | "npx" -> Some Npx
-  | "yarn" -> Some Yarn
-  | "pnpm" -> Some Pnpm
-  | "pip" -> Some Pip
-  | "python" -> Some Python
-  | "python3" -> Some Python3
-  | "pytest" -> Some Pytest
-  | "pyright" -> Some Pyright
-  | "ruff" -> Some Ruff
-  | "opam" -> Some Opam
-  | "ocamlfind" -> Some Ocamlfind
-  | "tsc" -> Some Tsc
-  | "cargo" -> Some Cargo
-  | "rustc" -> Some Rustc
-  | "go" -> Some Go
-  | "gofmt" -> Some Gofmt
-  | "gradle" -> Some Gradle
-  | "java" -> Some Java
-  | "javac" -> Some Javac
-  | "mvn" -> Some Mvn
-  | "ninja" -> Some Ninja
-  | "sed" -> Some Sed
-  | "uv" -> Some Uv
-  | "gh" -> Some Gh
-  | "glab" -> Some Glab
-  | "terminal-notifier" -> Some Terminal_notifier
-  | "osascript" -> Some Osascript
-  | "play" -> Some Play
-  | "rec" -> Some Rec
-  | "ffplay" -> Some Ffplay
-  | "mpg123" -> Some Mpg123
-  | "open" -> Some Open
-  | "sudo" -> Some Sudo
-  | "su" -> Some Su
-  | "chmod" -> Some Chmod
-  | "chown" -> Some Chown
-  | "rm" -> Some Rm
-  | "dd" -> Some Dd
-  | "mkfs" -> Some Mkfs
-  | _ -> None
+(** Reverse lookup is derived from [all_known] and [known_metadata] so string
+    names cannot drift from risk/kind classification. *)
+let known_of_string name =
+  List.find_opt (fun known -> String.equal (name_of_known known) name) all_known
 ;;
 
 let of_string raw =

--- a/lib/exec/exec_program.mli
+++ b/lib/exec/exec_program.mli
@@ -36,10 +36,10 @@ type kind =
 
 (** Closed variant of every binary the exec gate knows about.
 
-    Each constructor maps to exactly one string name.  Adding a new
-    binary requires adding a constructor here AND updating the
-    string mapping in the implementation — the compiler enforces
-    completeness so no known binary can be silently dropped. *)
+    Each constructor maps to exactly one metadata entry in the implementation.
+    Adding a new binary requires adding a constructor here AND updating the
+    metadata function there; the compiler enforces completeness so no known
+    binary can silently miss name/risk/kind classification. *)
 type known =
   | Ls
   | Cat
@@ -126,6 +126,9 @@ type known =
   | Rm
   | Dd
   | Mkfs
+
+(** Closed registry used for reverse lookup and golden checks. *)
+val all_known : known list
 
 val name_of_known : known -> string
 val risk_of_known : known -> risk_class

--- a/lib/exec/test/test_exec_types.ml
+++ b/lib/exec/test/test_exec_types.ml
@@ -47,6 +47,24 @@ let test_bin_risk_of_known () =
   assert (Exec_program.risk_of_known Exec_program.Rm = `Privileged)
 ;;
 
+let test_bin_all_known_metadata_roundtrips () =
+  let seen_names = Hashtbl.create 128 in
+  List.iter
+    (fun known ->
+       let name = Exec_program.name_of_known known in
+       assert (not (String.equal name ""));
+       assert (not (Hashtbl.mem seen_names name));
+       Hashtbl.add seen_names name ();
+       match Exec_program.of_string name with
+       | Ok bin ->
+         assert (Exec_program.to_string bin = name);
+         assert (Exec_program.known bin = Some known);
+         assert (Exec_program.risk_class bin = Exec_program.risk_of_known known);
+         assert (Exec_program.kind bin = Exec_program.kind_of_known known)
+       | Error _ -> assert false)
+    Exec_program.all_known
+;;
+
 let test_bin_known_roundtrip () =
   match Exec_program.of_string "git" with
   | Ok b ->
@@ -203,6 +221,7 @@ let () =
   test_bin_of_known ();
   test_bin_name_of_known ();
   test_bin_risk_of_known ();
+  test_bin_all_known_metadata_roundtrips ();
   test_bin_known_roundtrip ();
   test_bin_unknown_has_no_known ();
   test_bin_unknown_is_privileged ();

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -77,6 +77,34 @@ let source_files_containing ~under needle =
   |> List.filter (fun rel -> contains (read_source rel) needle)
   |> List.sort String.compare
 
+let lines_between ~start_needle ~end_needle rel =
+  let rec loop collecting acc = function
+    | [] -> List.rev acc
+    | line :: rest ->
+      if collecting
+      then
+        if contains line end_needle
+        then List.rev acc
+        else loop true (line :: acc) rest
+      else if contains line start_needle
+      then loop true acc rest
+      else loop false acc rest
+  in
+  read_source rel |> String.split_on_char '\n' |> loop false []
+
+let token_after_prefix ~prefix line =
+  let line = String.trim line in
+  if String.starts_with ~prefix line
+  then
+    let rest =
+      String.sub line (String.length prefix) (String.length line - String.length prefix)
+      |> String.trim
+    in
+    match String.split_on_char ' ' rest with
+    | token :: _ when not (String.equal token "") -> Some token
+    | _ -> None
+  else None
+
 let assert_only_sources_contain ~under ~needle expected =
   Alcotest.(check (list string))
     (Printf.sprintf "%s owner for %S" under needle)
@@ -412,6 +440,32 @@ let test_tool_resource_gate_uses_resource_axis () =
   assert_contains axis "docker-compose";
   assert_not_contains axis "String_util.contains_substring_ci"
 
+let test_bin_metadata_axis_is_single_owner () =
+  let rel = "lib/exec/exec_program.ml" in
+  let known_constructors =
+    lines_between ~start_needle:"type known =" ~end_needle:"type known_metadata =" rel
+    |> List.filter_map (token_after_prefix ~prefix:"| ")
+  in
+  let all_known_entries =
+    lines_between ~start_needle:"let all_known =" ~end_needle:"]" rel
+    |> List.filter_map (fun line ->
+      match token_after_prefix ~prefix:"[ " line with
+      | Some token -> Some token
+      | None -> token_after_prefix ~prefix:"; " line)
+  in
+  assert_contains rel "let known_metadata : known -> known_metadata = function";
+  assert_contains rel "let all_known =";
+  assert_contains rel "let known_of_string name =";
+  assert_contains rel "List.find_opt";
+  Alcotest.(check (list string))
+    "Exec_program.all_known covers every Exec_program.known constructor"
+    known_constructors
+    all_known_entries;
+  assert_not_contains rel "let risk_of_known : known -> risk_class = function";
+  assert_not_contains rel "let kind_of_known : known -> kind = function";
+  assert_not_contains rel "| \"git\" -> Some Git";
+  assert_not_contains rel "| \"docker\" -> Some Docker"
+
 let test_keeper_semantic_capabilities_use_capability_axis () =
   let axis = "lib/keeper/keeper_tool_capability_axis.ml" in
   let agent_surface = "lib/keeper/keeper_agent_tool_surface.ml" in
@@ -613,6 +667,10 @@ let () =
             "tool resource gate uses resource axis"
             `Quick
             test_tool_resource_gate_uses_resource_axis;
+          Alcotest.test_case
+            "bin metadata axis is single owner"
+            `Quick
+            test_bin_metadata_axis_is_single_owner;
           Alcotest.test_case
             "keeper semantic capabilities use capability axis"
             `Quick


### PR DESCRIPTION
## Summary
- collapse Exec_program executable name/risk/kind classification behind one exhaustive known_metadata owner
- derive reverse lookup from all_known plus metadata instead of a parallel string match table
- add runtime/source ratchets for all_known coverage, reverse lookup round-trips, name uniqueness, and no legacy parallel maps
- update the touched boundary docs from Bin terminology to Exec_program

## Verification
- ocamlformat --check lib/exec/test/test_exec_types.ml lib/exec/exec_program.ml lib/exec/exec_program.mli lib/keeper/keeper_tag_dispatch.ml lib/mcp_server_eio_execute.ml test/test_keeper_sandbox_boundary_policy.ml
- git diff --check
- rg -n "Masc_exec\\.Bin|lib/exec/bin|\\bBin\\b" docs/design/keeper-agent-tool-boundary-audit-2026-05-25.md docs/design/keeper-tool-runtime-boundary-plan.md lib test (no matches)
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build lib/exec/test/test_exec_types.exe test/test_keeper_sandbox_boundary_policy.exe
- ./_build/default/lib/exec/test/test_exec_types.exe
- ./_build/default/test/test_keeper_sandbox_boundary_policy.exe