### PR TITLE
refactor(keeper): reject empty fs edit mode

### DIFF
--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -6,10 +6,8 @@ open Ide_region_tracker
    forces compilation in [fs_write_mode_to_string] and
    [fs_write_mode_dispatch] AND extends [valid_fs_write_mode_strings];
    the schema in [tool_shard.ml] mirrors the SSOT (cycle avoidance
-   per #8480/#8484 pattern). The previous code used 5 hardcoded sites
-   (parse default, validate, dispatch, label normalisation, schema)
-   with an empty-string-as-overwrite back-compat — now expressed
-   explicitly via [Option.value ~default:Overwrite]. *)
+   per #8480/#8484 pattern). The previous code used 5 hardcoded sites:
+   parse default, validate, dispatch, label normalisation, and schema. *)
 type fs_write_mode =
   | Overwrite
   | Append
@@ -24,13 +22,12 @@ let fs_write_mode_to_string = function
   | Patch -> "patch"
 ;;
 
-(* Sound partial parser: canonical strings AND the back-compat empty
-   string both decode to a real Variant. Whitespace-only treated as
-   empty for the same back-compat reason. Anything else returns None
-   so the caller decides the rejection message. *)
+(* Sound partial parser: only canonical mode strings decode to a real
+   variant. Missing mode defaults before this parser; explicit empty
+   strings are invalid input. *)
 let fs_write_mode_of_string_opt raw =
   match String.trim (String.lowercase_ascii raw) with
-  | "overwrite" | "" -> Some Overwrite
+  | "overwrite" -> Some Overwrite
   | "append" -> Some Append
   | "patch" -> Some Patch
   | _ -> None

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -284,6 +284,38 @@ let test_overwrite_unchanged_by_patch_addition () =
   Alcotest.(check string) "overwrite wrote bytes"
     "fresh" (Fs_compat.load_file path)
 
+let check_invalid_mode_is_rejected ~label ~mode ~expected_error =
+  setup @@ fun ~config ~meta ~playground ->
+  let path = Filename.concat playground (label ^ ".txt") in
+  let raw =
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config
+      ~keeper_name:meta.name
+      ~args:
+        (`Assoc
+          [
+            ("path", `String path);
+            ("mode", `String mode);
+            ("content", `String "fresh");
+          ])
+  in
+  Alcotest.(check bool) "ok=false" false (parse_ok raw);
+  Alcotest.(check (option string)) (label ^ " rejected")
+    (Some expected_error)
+    (parse_error raw);
+  Alcotest.(check bool) "file not written" false (Fs_compat.file_exists path)
+
+let test_empty_mode_is_rejected () =
+  check_invalid_mode_is_rejected ~label:"empty-mode" ~mode:""
+    ~expected_error:"mode must be one of [overwrite, append, patch], got \"\"."
+
+let test_spaces_only_mode_is_rejected () =
+  check_invalid_mode_is_rejected ~label:"spaces-only-mode" ~mode:"   "
+    ~expected_error:"mode must be one of [overwrite, append, patch], got \"   \"."
+
+let test_tab_only_mode_is_rejected () =
+  check_invalid_mode_is_rejected ~label:"tab-only-mode" ~mode:"\t"
+    ~expected_error:"mode must be one of [overwrite, append, patch], got \"\\t\"."
+
 let test_public_edit_file_maps_top_relative_single_repo_path () =
   setup @@ fun ~config ~meta ~playground ->
   let repo = seed_single_playground_repo ~config ~meta playground in
@@ -346,6 +378,12 @@ let () =
             test_patch_delete_via_empty_new_string;
           Alcotest.test_case "overwrite mode regression" `Quick
             test_overwrite_unchanged_by_patch_addition;
+          Alcotest.test_case "empty mode rejected" `Quick
+            test_empty_mode_is_rejected;
+          Alcotest.test_case "spaces-only mode rejected" `Quick
+            test_spaces_only_mode_is_rejected;
+          Alcotest.test_case "tab-only mode rejected" `Quick
+            test_tab_only_mode_is_rejected;
           Alcotest.test_case "public EditFile maps top-relative single repo path" `Quick
             test_public_edit_file_maps_top_relative_single_repo_path;
           Alcotest.test_case "public WriteFile maps top-relative single repo path" `Quick


### PR DESCRIPTION
## Summary
- Remove the compatibility path that treated explicit empty keeper_fs_edit.mode as overwrite.
- Keep missing mode defaulting to overwrite, but require caller-supplied mode values to be canonical.
- Add regression coverage proving mode="" is rejected and does not write a file.
- Qualify local-runtime context construction through Tool_local_runtime_core so this branch is not blocked by the post-#18496 facade removal compile error.
- Rebase over current main, preserving the newer public EditFile/WriteFile top-relative path tests and updating the legacy purge ledger.

## Verification
- ocamlformat --check lib/keeper/keeper_exec_fs.ml test/test_keeper_fs_edit_patch.ml
- ocamlc -stop-after parsing lib/keeper/keeper_exec_fs.ml test/test_keeper_fs_edit_patch.ml
- opam exec -- ocamlformat --check lib/mcp_server_eio_execute.ml lib/keeper/keeper_tag_dispatch.ml
- ocamlc -stop-after parsing lib/mcp_server_eio_execute.ml
- ocamlc -stop-after parsing lib/keeper/keeper_tag_dispatch.ml
- git diff --check
- rg -n "empty-string-as-overwrite|back-compat empty|\| \"overwrite\" \| \"\"|\| \"overwrite\" \| \" \"" lib/keeper/keeper_exec_fs.ml test/test_keeper_fs_edit_patch.ml (no matches)
- rg -n 'Tool_local_runtime\.config' lib test (no matches, exit 1)
- scripts/lint-ignore-without-comment.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

## Local Dune gap
- scripts/dune-local.sh build ./test/test_keeper_fs_edit_patch.exe ./test/test_mcp_server_eio.exe ./test/test_keeper_tag_dispatch.exe returned exit 75 because external bare Dune processes are active: dune build --root . and additional dune build --root . processes. I did not bypass the machine-wide Dune guard.
