### PR TITLE
fix(dashboard): expose runtime MCP tool call IO previews

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -305,6 +305,7 @@ let runtime_mcp_keeper_tool_call_sse_payload
     ~(tool_name : string)
     ~(duration_ms : int)
     ~(success : bool)
+    ~(arguments : Yojson.Safe.t)
     ~(message : string) : Yojson.Safe.t =
   let base_fields =
     [
@@ -320,7 +321,14 @@ let runtime_mcp_keeper_tool_call_sse_payload
     if success then []
     else [ ("error_text", `String (runtime_mcp_keeper_error_preview message)) ]
   in
-  `Assoc (base_fields @ error_fields)
+  let io_fields =
+    Keeper_tools_oas_handler_telemetry.tool_io_preview_fields
+      ~tool_name
+      ~input:arguments
+      ~output:message
+      ()
+  in
+  `Assoc (base_fields @ error_fields @ io_fields)
 
 let runtime_mcp_masc_root ~base_path =
   match Keeper_tool_call_log.configured_masc_root () with
@@ -517,6 +525,7 @@ let record_runtime_mcp_keeper_tool_trace
        ~tool_name
        ~duration_ms
        ~success
+       ~arguments
        ~message)
 
 let read_only_retry_limit () =

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -519,7 +519,11 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
       check bool "sse success" false
         (sse_payload |> U.member "success" |> U.to_bool);
       check string "sse error text" "command exited 1"
-        (sse_payload |> U.member "error_text" |> U.to_string))
+        (sse_payload |> U.member "error_text" |> U.to_string);
+      check string "sse args preview includes input" {|{"cmd":"false","session_id":"session-explicit"}|}
+        (sse_payload |> U.member "tool_args_preview" |> U.to_string);
+      check string "sse output preview includes result" "command exited 1"
+        (sse_payload |> U.member "tool_output_preview" |> U.to_string))
 
 let () =
   run "mcp_server_eio_call_tool"


### PR DESCRIPTION
## Summary
- Add redacted `tool_args_preview` and `tool_output_preview` fields to runtime-MCP `keeper_tool_call` SSE payloads.
- Reuse the existing keeper tool-call I/O preview helper so runtime-MCP and OAS handler paths feed the dashboard trace surface consistently.
- Extend the runtime-MCP trace regression to assert the SSE payload carries both input and output previews.

## Product impact
This advances the report's GOAL-TOOL-01 finding: operator dashboards should expose keeper tool I/O context, not just tool name/duration. The OAS handler path already emitted safe previews; runtime-MCP tool calls now do the same, so live traces no longer lose I/O detail depending on the execution path.

## Evidence
- `opam exec -- ocamlformat --check lib/mcp_server_eio_call_tool.ml test/test_mcp_server_eio_call_tool.ml` passed.
- `git diff --check origin/main...HEAD` passed.
- `opam exec -- ocamldep -modules lib/mcp_server_eio_call_tool.ml lib/keeper/keeper_tools_oas_handler_telemetry.ml` showed one-way dependency from `mcp_server_eio_call_tool` to `Keeper_tools_oas_handler_telemetry`; no direct reverse dependency.
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD` passed.
- `scripts/dune-local.sh build test/test_mcp_server_eio_call_tool.exe` was attempted twice and blocked by live bare `dune build --root .` processes outside `scripts/dune-local.sh`.

## Direct evidence
schema_version: 1
direct_ratio: 4/5
provenance: direct

Direct evidence is from local formatter, diff, ocamldep, and determinism checks. The focused Dune build evidence is not available because the repo wrapper refused to start while other sessions were bypassing the machine-wide Dune lock.

## Review evidence
- Regression test assertion added in `test/test_mcp_server_eio_call_tool.ml` for runtime-MCP SSE I/O previews.
- Existing dashboard SSE schema already accepts `tool_args_preview`, `tool_output_preview`, and `tool_io_redacted`.
- This PR does not add full raw I/O to SSE; full durable I/O remains in `keeper_tool_call_log`, while SSE carries bounded redacted previews.

## Linked issue
- Report finding: GOAL-TOOL-01 / `keeper_tool_call` dashboard I/O exposure.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/runtime-mcp-tool-call-io-preview-20260526` → `main` · 1 commit(s) · synced 2026-05-25T17:31:27Z

| sha | subject | date |
|---|---|---|
| `d68ccb565` | fix(dashboard): expose runtime MCP tool call IO previews | 2026-05-25 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->