### PR TITLE
fix(bridge): timeout overshoot detection and no-clock defensive warning (#18476)

### DIFF
--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -46,7 +46,14 @@ let run_safe ~caller ~timeout_s fn =
   let do_timeout fn =
     match clock_opt with
     | Some clock -> Eio.Time.with_timeout_exn clock timeout_s fn
-    | None -> fn ()
+    | None ->
+      (* #18476: defensive — server bootstrap always provides a clock,
+         but if reached without one, the timeout is unenforceable. *)
+      Log.Misc.warn
+        "masc_oas_bridge.run_safe: no Eio clock available, running \
+         without timeout enforcement (caller=%s, budget=%.1fs)"
+        caller timeout_s;
+      fn ()
   in
   try
     do_timeout fn
@@ -57,15 +64,29 @@ let run_safe ~caller ~timeout_s fn =
        lines alone collapsed all 27 [auto_responder] 60s-timeouts
        and the 1 [tool_deep_review] 180s-timeout into the same
        "after N.Ns" string. *)
+    let wall = elapsed () in
     Prometheus.inc_counter
       Prometheus.metric_oas_bridge_timeout
       ~labels:[
         ("caller", caller);
         ("timeout_s", Printf.sprintf "%.1f" timeout_s);
       ] ();
-    Log.Misc.warn
-      "masc_oas_bridge: OAS execution timed out after %.1fs (caller=%s)"
-      timeout_s caller;
+    (* #18476: wall-clock overshoot detection. Eio cancel propagation
+       through the cascade runner's nested Switch layers can take
+       significant time after the budget fires.  Log the overshoot
+       ratio so operators can distinguish "timeout fired at 45s" from
+       "timeout fired but cleanup took 121s". *)
+    let overshoot_ratio = wall /. timeout_s in
+    if overshoot_ratio > 2.0 then
+      Log.Misc.warn
+        "masc_oas_bridge: timeout overshoot — budget=%.1fs wall=%.1fs \
+         (ratio=%.1fx, caller=%s). Cancel propagation through cascade \
+         runner Switch hierarchy is delayed."
+        timeout_s wall overshoot_ratio caller
+    else
+      Log.Misc.warn
+        "masc_oas_bridge: OAS execution timed out after %.1fs (caller=%s, wall=%.1fs)"
+        timeout_s caller wall;
     Error (Agent_sdk.Error.Api (Timeout { message = Printf.sprintf "Execution timed out after %.1fs" timeout_s }))
   | Eio.Cancel.Cancelled inner_exn as exn ->
     (* Mirror of #10942 (keeper_llm_bridge) for masc_oas_bridge: same opaque


### PR DESCRIPTION
## Summary
- `run_safe`에 Eio clock 미가용 시 경고 로그 추가 (기존: silent skip)
- Timeout 발생 시 wall-clock elapsed 기록 + overshoot(2x 초과) 감지 로그 추가

## Context
Issue #18476: `governance_judge` `compute_judgments`가 121s 실행되며 45s budget 초과.
Timeout은 정상 발생하지만, cascade runner의 nested Switch 계층을 통한 cancel propagation 지연이 원인.

이 PR은 overshoot을 가시화하는 관측성 개선. 근본 원인(cancellation propagation latency)은 별도 PR에서 다룰 예정.

## Evidence
- `duration=121.231s > compute_timeout=45.0s` (ratio 2.7x, system_log 2026-05-25)
- 정상 케이스: `duration=45.379s ≈ 45.0s`

## Test plan
- [x] `dune build` 통과
- [ ] 서버 실행 후 governance_judge timeout 발생 시 overshoot 로그 확인
- [ ] clock 미가용 경로는 정상 서버에서 도달 불가 (bootstrap이 항상 `~clock` 전달)

Closes #18476