### PR TITLE
refactor(local-runtime): drop core facade include

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-25 19:27:32 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 02:31:33 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -379,9 +379,33 @@
           </tr>
           <tr>
             <td><code>Verifier_oas</code> core re-export facade</td>
-            <td><span class="status done">draft PR #18488</span></td>
-            <td>Stop re-exporting <code>Verifier_core</code> verdict types and parser helpers from the OAS bridge. Tests now call <code>Verifier_core</code> directly for core parsing and keep <code>Verifier_oas</code> scoped to adapter behavior.</td>
-            <td>Backstop grep is clean for the removed <code>Verifier_oas.*</code> core aliases in verifier files. Local OCaml format/parse, diff, ignore, godfile, code-smell, and determinism ratchets pass. Focused Dune reaches an unrelated current-main compile error in <code>lib/cascade/cascade_config_provider_binding.ml</code> (<code>Char.isdigit</code> unbound).</td>
+            <td><span class="status done">merged #18488</span></td>
+            <td>Remove the public <code>Verifier_core</code> type/helper re-exports from <code>Verifier_oas</code>; callers must use <code>Verifier_core</code> for generic verdict parsing and <code>Verifier_oas</code> for OAS adapter behavior.</td>
+            <td>Backstop grep is clean for the removed re-export symbols. Local OCaml format/parse and diff checks pass; the branch was merged into <code>origin/main</code>.</td>
+          </tr>
+          <tr>
+            <td><code>keeper.oas_env</code> unified max-token env alias</td>
+            <td><span class="status done">merged #18450</span></td>
+            <td>Remove the legacy <code>KEEPER_UNIFIED_MAX_TOKENS</code> alias from keeper OAS env parsing and keep only <code>MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS</code> plus provider-scoped <code>OAS_&lt;PROVIDER&gt;_*</code> keys.</td>
+            <td>The TOML test now rejects the old alias instead of preserving it. Targeted grep is clean for the removed helper and alias wording; focused Dune remained blocked by the machine-wide guard during local verification.</td>
+          </tr>
+          <tr>
+            <td><code>keeper_context_status</code> playground path aliases</td>
+            <td><span class="status now">draft PR #18490</span></td>
+            <td>Remove the one-release <code>playground_bundle</code>, <code>playground_mind</code>, <code>playground_repos</code>, and <code>tool_paths</code> aliases from memory/context status output. The canonical contract remains <code>sandbox_root</code>, <code>sandbox_mind</code>, <code>sandbox_repos</code>, and <code>sandbox_paths</code>.</td>
+            <td>Context-status tests assert the legacy keys are absent while canonical sandbox fields remain populated. Local OCaml format/parse, diff, grep, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
+          </tr>
+          <tr>
+            <td><code>keeper_fs_edit.mode</code> empty-string alias</td>
+            <td><span class="status now">draft PR #18492</span></td>
+            <td>Stop interpreting explicit empty or whitespace-only <code>mode</code> as <code>overwrite</code>. Missing <code>mode</code> still defaults before parsing, but caller-supplied values must be canonical <code>overwrite</code>, <code>append</code>, or <code>patch</code>.</td>
+            <td>The fs-edit regression test asserts <code>mode=""</code> is rejected and does not write a file. Local OCaml format/parse, diff, grep, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
+          </tr>
+          <tr>
+            <td><code>Tool_local_runtime</code> core facade include</td>
+            <td><span class="status now">draft PR #18496</span></td>
+            <td>Remove the top-level <code>include Tool_local_runtime_core</code> from <code>Tool_local_runtime</code>. Core process/model helpers remain owned by <code>Tool_local_runtime_core</code>; <code>Tool_local_runtime</code> keeps only deliberate runtime status/verify/probe/bench adapter exports plus MCP schemas/dispatch.</td>
+            <td>The only repo test that reached <code>split_ws</code> through the facade now calls <code>Tool_local_runtime_core.split_ws</code> directly. Local OCaml format/parse, diff, grep, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.mkdir_p</code> compatibility wrapper</td>
@@ -424,6 +448,20 @@
           </tr>
         </thead>
         <tbody>
+          <tr>
+            <td>P0</td>
+            <td><code>Tool_local_runtime</code> top-level core facade</td>
+            <td>The include cascade makes process-discovery helpers, parser helpers, and core record types look like part of the MCP adapter module. That slows ownership audits and lets tests preserve the wrong import path.</td>
+            <td>Delete the top-level <code>include Tool_local_runtime_core</code>; qualify internal calls through <code>Tool_local_runtime_core</code>; move any helper caller/test to the owner module.</td>
+            <td>Grep must prove <code>Tool_local_runtime.split_ws</code> and the top-level include are gone. Keep behavior tests on the owner module.</td>
+          </tr>
+          <tr>
+            <td>P0</td>
+            <td><code>keeper_board_delete</code> / <code>keeper_board_cleanup</code> hidden admin aliases</td>
+            <td>They are hidden from keeper/public discovery but still have keeper-prefixed schema, timeout, policy, search-keyword, and dispatch paths that forward to canonical board maintenance behavior. This keeps two names for one admin operation.</td>
+            <td>Next slice should delete the keeper-prefixed admin aliases and move any remaining policy/test intent to canonical <code>masc_board_delete</code> / board cleanup ownership. Do not delete canonical <code>masc_board_delete</code>.</td>
+            <td>Replace orphan-prevention tests with canonical admin-tool tests; grep for <code>keeper_board_delete</code> / <code>keeper_board_cleanup</code> must be limited to changelog or removed entirely from live code.</td>
+          </tr>
           <tr>
             <td>P0</td>
             <td><code>Cascade_legacy_runner</code></td>

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -28,8 +28,7 @@ module Float = Stdlib.Float
 
 open Masc_domain
 
-(* Re-export core types and helpers for backward compatibility *)
-include Tool_local_runtime_core
+module Core = Tool_local_runtime_core
 
 (* Re-export sub-module public values used by external callers *)
 let runtime_status_json = Tool_local_runtime_status.runtime_status_json
@@ -42,8 +41,8 @@ let ollama_loaded_models_of_ps_json = Tool_local_runtime_probe.ollama_loaded_mod
 let ollama_probe_run_of_generate_json = Tool_local_runtime_probe.ollama_probe_run_of_generate_json
 let kv_cache_assessment_json = Tool_local_runtime_probe.kv_cache_assessment_json
 
-let handle_models _ctx : tool_result =
-  match fetch_models () with
+let handle_models _ctx : Core.tool_result =
+  match Core.fetch_models () with
   | Error msg -> (false, Tool_args.error_response msg)
   | Ok (url, models) ->
       ( true,
@@ -60,7 +59,7 @@ let handle_models _ctx : tool_result =
                 ] );
           ] )
 
-let handle_runtime_status _ctx args : tool_result =
+let handle_runtime_status _ctx args : Core.tool_result =
   let include_models =
     match Yojson.Safe.Util.member "include_models" args with
     | `Bool flag -> flag
@@ -69,20 +68,20 @@ let handle_runtime_status _ctx args : tool_result =
   ( true,
     Tool_args.ok_response [ ("result", runtime_status_json ~include_models ()) ] )
 
-let handle_runtime_verify _ctx args : tool_result =
+let handle_runtime_verify _ctx args : Core.tool_result =
   let open Yojson.Safe.Util in
   let runtime_pool = member "runtime_pool" args |> to_string_option in
   let expected_model = member "expected_model" args |> to_string_option in
   let expected_slots =
     match member "expected_slots" args with
     | `Int value -> Some (max 1 value)
-    | `Intlit value -> parse_int_opt value
+    | `Intlit value -> Core.parse_int_opt value
     | _ -> None
   in
   let expected_ctx =
     match member "expected_ctx" args with
     | `Int value -> Some (max 1 value)
-    | `Intlit value -> parse_int_opt value
+    | `Intlit value -> Core.parse_int_opt value
     | _ -> None
   in
   ( true,
@@ -93,7 +92,7 @@ let handle_runtime_verify _ctx args : tool_result =
             ?expected_model () );
       ] )
 
-let handle_runtime_bench _ctx args : tool_result =
+let handle_runtime_bench _ctx args : Core.tool_result =
   let open Yojson.Safe.Util in
   let model_id = member "model" args |> to_string_option in
   let runtime_pool = member "runtime_pool" args |> to_string_option in
@@ -101,7 +100,7 @@ let handle_runtime_bench _ctx args : tool_result =
     match member "parallelism" args with
     | `Int value -> max 1 (min 128 value)
     | `Intlit value -> (
-        match parse_int_opt value with
+        match Core.parse_int_opt value with
         | Some parsed -> max 1 (min 128 parsed)
         | None -> 8)
     | _ -> 8
@@ -110,7 +109,7 @@ let handle_runtime_bench _ctx args : tool_result =
     match member "rounds" args with
     | `Int value -> max 1 (min 8 value)
     | `Intlit value -> (
-        match parse_int_opt value with
+        match Core.parse_int_opt value with
         | Some parsed -> max 1 (min 8 parsed)
         | None -> 1)
     | _ -> 1
@@ -119,7 +118,7 @@ let handle_runtime_bench _ctx args : tool_result =
     match member "max_tokens" args with
     | `Int value -> max 1 (min 128 value)
     | `Intlit value -> (
-        match parse_int_opt value with
+        match Core.parse_int_opt value with
         | Some parsed -> max 1 (min 128 parsed)
         | None -> 16)
     | _ -> 16
@@ -128,7 +127,7 @@ let handle_runtime_bench _ctx args : tool_result =
     match member "timeout_sec" args with
     | `Int value -> max 3 (min 120 value)
     | `Intlit value -> (
-        match parse_int_opt value with
+        match Core.parse_int_opt value with
         | Some parsed -> max 3 (min 120 parsed)
         | None -> 8)
     | _ -> 8
@@ -145,7 +144,7 @@ let handle_runtime_bench _ctx args : tool_result =
   | Ok json -> (true, Tool_args.ok_response [ ("result", json) ])
   | Error err -> (false, Tool_args.error_response err)
 
-let handle_runtime_ollama_probe _ctx args : tool_result =
+let handle_runtime_ollama_probe _ctx args : Core.tool_result =
   let open Yojson.Safe.Util in
   let server_url = member "server_url" args |> to_string_option in
   let model = member "model" args |> to_string_option in
@@ -154,21 +153,28 @@ let handle_runtime_ollama_probe _ctx args : tool_result =
   let probe_runs =
     match member "probe_runs" args with
     | `Int value -> value
-    | `Intlit value -> Option.value ~default:2 (parse_int_opt value)
+    | `Intlit value -> (
+        match Core.parse_int_opt value with
+        | Some parsed -> parsed
+        | None -> 2)
     | _ -> 2
   in
   let max_tokens =
     match member "max_tokens" args with
     | `Int value -> value
-    | `Intlit value -> Option.value ~default:16 (parse_int_opt value)
+    | `Intlit value -> (
+        match Core.parse_int_opt value with
+        | Some parsed -> parsed
+        | None -> 16)
     | _ -> 16
   in
   let timeout_sec =
     match member "timeout_sec" args with
     | `Int value -> value
     | `Intlit value ->
-        Option.value ~default:Tool_local_runtime_probe.default_probe_timeout_sec
-          (parse_int_opt value)
+        (match Core.parse_int_opt value with
+         | Some parsed -> parsed
+         | None -> Tool_local_runtime_probe.default_probe_timeout_sec)
     | _ -> Tool_local_runtime_probe.default_probe_timeout_sec
   in
   let think_mode =
@@ -207,7 +213,7 @@ let handle_runtime_ollama_probe _ctx args : tool_result =
                 ~generate_when_unloaded ~run_generate () );
           ] )
 
-let dispatch ctx ~name ~args : tool_result option =
+let dispatch ctx ~name ~args : Core.tool_result option =
   match name with
   (* Canonical names *)
   | "masc_runtime_verify" ->

--- a/lib/tool_local_runtime.mli
+++ b/lib/tool_local_runtime.mli
@@ -2,8 +2,9 @@
 (** Tool_local_runtime — local model runtime management and
     benchmarking tools.
 
-    Facade module that re-exports sub-modules and provides MCP
-    dispatch / schemas.  Implementation split across:
+    Facade module that provides MCP dispatch / schemas plus the
+    deliberate status / verify / probe / bench adapter exports below.
+    Implementation split across:
 
     - {!Tool_local_runtime_core}: types, helpers, process discovery,
       model fetching.
@@ -15,10 +16,9 @@
     - {!Tool_local_runtime_probe}: native Ollama timing / KV
       inference probe.
 
-    {b Include cascade:} starts with
-    [include Tool_local_runtime_core], so callers reaching this
-    module get the core types ([config] / [tool_result] / etc.) for
-    free.
+    Core types and cmdline/model-discovery helpers are intentionally
+    kept on {!Tool_local_runtime_core}; this top-level module no
+    longer re-exports that surface.
 
     Internal: 5 [handle_*] functions ([handle_models],
     [handle_runtime_status], [handle_runtime_verify],
@@ -26,10 +26,6 @@
     the [Tool_spec.register] side-effect block stay private.  The
     .mli pins the dispatch / schemas contract — handler bodies are
     free to refactor. *)
-
-include module type of struct
-  include Tool_local_runtime_core
-end
 
 (** {1 Status / verify / probe / bench re-exports} *)
 
@@ -124,7 +120,7 @@ val dispatch :
   'ctx ->
   name:string ->
   args:Yojson.Safe.t ->
-  tool_result option
+  Tool_local_runtime_core.tool_result option
 (** [dispatch ctx ~name ~args] dispatches the named MCP tool call.
 
     Recognised names:

--- a/test/test_tool_local_runtime_verify.ml
+++ b/test/test_tool_local_runtime_verify.ml
@@ -13,7 +13,7 @@ let test_split_ws_preserves_quoted_cmdline_values () =
     (list string)
     "quoted model path remains one argv"
     [ "llama-server"; "-m"; "/models/Provider_h_wire 3.5.gguf"; "--port"; "8080" ]
-    (Masc_mcp.Tool_local_runtime.split_ws
+    (Masc_mcp.Tool_local_runtime_core.split_ws
        {|/opt/bin/llama-server -m "/models/Provider_h_wire 3.5.gguf" --port 8080|})
 
 let test_classify_runtime_blocker_prefers_slot_count_when_health_ok () =


### PR DESCRIPTION
## Summary
- Remove the top-level `include Tool_local_runtime_core` from `Tool_local_runtime` so core process/model helpers stay owned by `Tool_local_runtime_core`.
- Keep deliberate runtime status/verify/probe/bench adapter exports plus MCP schemas/dispatch on `Tool_local_runtime`.
- Move the one split-ws test off the facade import path and onto `Tool_local_runtime_core.split_ws`.
- Update the HTML purge ledger and add the next `keeper_board_delete`/`keeper_board_cleanup` alias-removal plan.

## Verification
- `ocamlformat --check lib/tool_local_runtime.ml lib/tool_local_runtime.mli test/test_tool_local_runtime_verify.ml`
- `ocamlc -stop-after parsing lib/tool_local_runtime.ml lib/tool_local_runtime.mli test/test_tool_local_runtime_verify.ml`
- `git diff --check`
- `rg -n "include Tool_local_runtime_core|Tool_local_runtime\.split_ws|Tool_local_runtime\.(context|tool_result|llama_process|bench_sample|parse_int_opt|process_to_yojson|discover_processes|fetch_models_at|fetch_models)\b" lib/tool_local_runtime.ml lib/tool_local_runtime.mli test/test_tool_local_runtime_verify.ml` (no matches)
- `scripts/lint-ignore-without-comment.sh`
- `scripts/lint/godfile-size-regression.sh`
- `scripts/code-smell-ratchet.sh`
- `scripts/ci/check-determinism-contract.sh`

## Local Dune gap
- `scripts/dune-local.sh build ./test/test_tool_local_runtime_verify.exe lib/tool_local_runtime.ml lib/tool_local_runtime.mli lib/tool_local_runtime_core.ml lib/tool_local_runtime_core.mli` returned exit 75 because external bare `dune build --root .` processes are active. I did not bypass the machine-wide Dune guard.