### PR TITLE
fix(bridge): default oas event retention

### DIFF
--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -608,16 +608,19 @@ let deliver_pending_with
   | exn -> Retryable_failure (pending, Broadcast, exn)
 ;;
 
-let oas_event_retention_days () =
-  (* Opt-in: see lib/keeper_tool_call_log.ml retention_days. oas-events is the
-     largest JSONL hotspot (Context_window_usage telemetry-as-fix). Default
-     unset = unbounded growth pending RFC for typed event volume reduction. *)
-  match Sys.getenv_opt "MASC_OAS_EVENTS_RETENTION_DAYS" with
+let oas_event_retention_days_default = 30
+
+let resolve_oas_event_retention_days = function
   | Some raw ->
     (match int_of_string_opt (String.trim raw) with
      | Some days when days > 0 -> Some days
-     | _ -> None)
-  | None -> None
+     | Some _ -> None
+     | None -> Some oas_event_retention_days_default)
+  | None -> Some oas_event_retention_days_default
+;;
+
+let oas_event_retention_days () =
+  resolve_oas_event_retention_days (Sys.getenv_opt "MASC_OAS_EVENTS_RETENTION_DAYS")
 ;;
 
 let deliver_pending ?store_ref (pending : pending_relay) =
@@ -739,6 +742,7 @@ module For_testing = struct
 
   let make_pending json = { json; attempts = 0; appended = false }
   let relay_max_queue_depth = relay_max_queue_depth
+  let resolve_oas_event_retention_days = resolve_oas_event_retention_days
 
   let to_pending (pending : pending_relay) : bridge_pending_relay =
     { json = pending.json; attempts = pending.attempts; appended = pending.appended }

--- a/lib/cascade/cascade_event_bridge.mli
+++ b/lib/cascade/cascade_event_bridge.mli
@@ -55,6 +55,8 @@ module For_testing : sig
 
   val relay_max_queue_depth : int
 
+  val resolve_oas_event_retention_days : string option -> int option
+
   val should_drain_subscription : pending_relay list -> bool
 
   val deliver_pending_with :

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -1201,6 +1201,21 @@ let test_payload_kind_labels_match_envelope_event_type () =
       Alcotest.fail
         "expected Some `Assoc — explicit-arm AgentStarted serialization"
 
+let test_oas_event_bridge_retention_default_contract () =
+  let resolve =
+    Cascade_event_bridge.For_testing.resolve_oas_event_retention_days
+  in
+  Alcotest.(check (option int)) "unset uses documented default" (Some 30)
+    (resolve None);
+  Alcotest.(check (option int)) "malformed uses safe default" (Some 30)
+    (resolve (Some "not-an-int"));
+  Alcotest.(check (option int)) "positive override" (Some 7)
+    (resolve (Some " 7 "));
+  Alcotest.(check (option int)) "zero disables retention" None
+    (resolve (Some "0"));
+  Alcotest.(check (option int)) "negative disables retention" None
+    (resolve (Some "-1"))
+
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -1233,6 +1248,8 @@ let () =
         test_oas_event_bridge_drop_marker_on_exhausted_append_failure;
       Alcotest.test_case "sse bridge retry avoids duplicate append after broadcast failure" `Quick
         test_oas_event_bridge_broadcast_retry_does_not_duplicate_append;
+      Alcotest.test_case "sse bridge retention default contract" `Quick
+        test_oas_event_bridge_retention_default_contract;
       Alcotest.test_case "sse bridge retry queue backpressures instead of dropping head"
         `Quick
         test_oas_event_bridge_backpressures_when_retry_queue_full;


### PR DESCRIPTION
## Summary

- make `.masc/oas-events/` retention default to the documented 30 days when `MASC_OAS_EVENTS_RETENTION_DAYS` is unset
- keep non-positive env values as the explicit disable path
- treat malformed env values as the safe 30-day default instead of silently disabling retention
- add a regression test for the retention resolver contract

## Product impact

This closes a durable-log growth drift in the OAS event bridge. Operators get bounded `.masc/oas-events/` storage by default while still retaining an explicit override/disable knob.

## Evidence

- `opam exec -- ocamlformat --check lib/cascade/cascade_event_bridge.ml lib/cascade/cascade_event_bridge.mli test/test_oas_integration.ml` passed
- `git diff --check` passed
- `opam exec -- ocamldep -modules lib/cascade/cascade_event_bridge.ml test/test_oas_integration.ml` passed
- `scripts/dune-local.sh build test/test_oas_integration.exe` was attempted but refused to start because an external bare `dune build --root .` process is still holding/bypassing the machine-wide Dune guard

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/5
provenance: direct
stages:
  - name: ocamlformat
    status: pass
  - name: diff-check
    status: pass
  - name: ocamldep
    status: pass
  - name: dune-local
    status: blocked
    reason: external bare dune build --root . process
commit: b7086b99cb5c701a6106ce61eac89f9bf4173797
```

## GOAL LOOP ACT checklist

- [x] Observe — report highlighted opt-in bridge/recovery drift; code/doc audit found `.mli` promised default retention while `.ml` kept it unbounded.
- [x] Orient — mapped to `GOAL-FIX-01` automatic/operator-safe default direction.
- [x] Decide — small bridge-only scope reduces durable JSONL growth risk without changing event shape.
- [x] Act — changed only the OAS event retention resolver and its regression test.
- [ ] Verify — formatting and static checks passed; focused local build blocked by external bare Dune and CI is the build source of truth.
- [x] Loop — no standalone follow-up issue for this bounded slice.

## Report linkage

This follows the integrated MASC/OAS report's `GOAL-FIX-01` direction around replacing opt-in recovery/bridge behavior with automatic, operator-safe defaults.

## Linked issue

Report-backed maintenance slice. No standalone GitHub issue.

## Review evidence

Local focused build is intentionally left to CI because the repo-local Dune wrapper refused to run while a bare Dune process is active.

## Variant addition checklist

- [ ] **OCaml** — N/A, no variant added/removed.
- [ ] **TypeScript** — N/A, no dashboard union changed.
- [ ] **TLA+ spec** — N/A, no domain literal changed.
- [ ] **Event / JSON schema** — N/A, event shape unchanged.
- [ ] **`make check-variants` passes** — N/A, no variant/schema enum change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/oas-events-retention-default-20260526` → `main` · 1 commit(s) · synced 2026-05-25T17:42:55Z

| sha | subject | date |
|---|---|---|
| `b7086b99c` | fix(bridge): default oas event retention | 2026-05-25 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->