### PR TITLE
fix(log): serialize keeper_name=None as system instead of null (#18465)

### DIFF
--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -231,7 +231,7 @@ module Ring = struct
   let entry_to_json e =
     let keeper_name_json = match e.keeper_name with
       | Some s -> `String s
-      | None -> `Null
+      | None -> `String "system"
     in
     let turn_id_json = match e.turn_id with
       | Some i -> `Int i
@@ -568,7 +568,7 @@ module Ring = struct
             ( "keeper_name",
               (match e.keeper_name with
               | Some name -> `String name
-              | None -> `Null) );
+              | None -> `String "system") );
             ( "turn_id",
               (match e.turn_id with
               | Some turn_id -> `Int turn_id

--- a/test/test_masc_log.ml
+++ b/test/test_masc_log.ml
@@ -149,6 +149,45 @@ let test_oas_bridge_demotes_tool_choice_relaxation_to_debug () =
   Alcotest.(check string) "tool_choice fallback demoted" "DEBUG"
     (Log.level_to_string level)
 
+let test_entry_to_json_keeper_name_none_serializes_system () =
+  (* #18465: keeper_name=None must serialize as "system", not null *)
+  let entry : Log.Ring.entry = {
+    seq = 1;
+    ts = "2026-05-26T00:00:00Z";
+    level = Log.Info;
+    source = Log.Structured;
+    module_name = "test";
+    keeper_name = None;
+    turn_id = None;
+    message = "test message";
+    details = `Null;
+  } in
+  let json = Log.Ring.entry_to_json entry in
+  let keeper_name_val =
+    Yojson.Safe.Util.member "keeper_name" json
+    |> Yojson.Safe.Util.to_string
+  in
+  Alcotest.(check string) "keeper_name None → \"system\"" "system" keeper_name_val
+
+let test_entry_to_json_keeper_name_some_preserves () =
+  let entry : Log.Ring.entry = {
+    seq = 2;
+    ts = "2026-05-26T00:00:00Z";
+    level = Log.Info;
+    source = Log.Structured;
+    module_name = "test";
+    keeper_name = Some "my-keeper";
+    turn_id = None;
+    message = "test message";
+    details = `Null;
+  } in
+  let json = Log.Ring.entry_to_json entry in
+  let keeper_name_val =
+    Yojson.Safe.Util.member "keeper_name" json
+    |> Yojson.Safe.Util.to_string
+  in
+  Alcotest.(check string) "keeper_name Some preserved" "my-keeper" keeper_name_val
+
 let test_file_sink_reopens_when_log_path_is_deleted () =
   let dir = temp_dir () in
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () ->
@@ -196,5 +235,11 @@ let () =
         Alcotest.test_case
           "file sink reopens when current log path is deleted"
           `Quick test_file_sink_reopens_when_log_path_is_deleted;
+        Alcotest.test_case
+          "entry_to_json: keeper_name=None serializes as \"system\" (#18465)"
+          `Quick test_entry_to_json_keeper_name_none_serializes_system;
+        Alcotest.test_case
+          "entry_to_json: keeper_name=Some preserves value"
+          `Quick test_entry_to_json_keeper_name_some_preserves;
       ] );
   ]


### PR DESCRIPTION
## Summary
- Fixes #18465 — 98.9% of system log entries had `keeper_name: null`, making log filtering by keeper impossible
- Changes wire format: `keeper_name: null` → `keeper_name: "system"` for entries emitted outside keeper turn context
- Internal type remains `string option`; decode handles both old (`null`) and new (`"system"`) entries

## Changes
- `lib/masc_log/log.ml`: `entry_to_json` and `latest_metadata_json` serialize `None` as `"system"` instead of `null`
- `test/test_masc_log.ml`: 2 new tests verifying None→"system" and Some→preserved behavior

## Test plan
- [x] `test_entry_to_json_keeper_name_none_serializes_system` — PASS
- [x] `test_entry_to_json_keeper_name_some_preserves` — PASS
- [ ] CI green (Build and Test, Lint, Health)
- [ ] Dashboard log filtering works with new `"system"` sentinel

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>