### PR TITLE
fix(task): allow reclaim after missing worktree handoff

### DIFF
--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -35,6 +35,22 @@ let is_legacy_auto_cycle_do_not_reclaim_reason reason =
   parse_suffix " releases" || parse_suffix " cancellations"
 ;;
 
+let has_explicit_hard_stop_reclaim_marker reason =
+  let lower = String.trim reason |> String.lowercase_ascii in
+  let markers =
+    [ "do not reclaim"
+    ; "do-not-reclaim"
+    ; "do_not_reclaim"
+    ; "hard stop"
+    ; "hard-stop"
+    ; "operator review required before reclaim"
+    ]
+  in
+  List.exists
+    (fun marker -> String_util.contains_substring lower marker)
+    markers
+;;
+
 let is_routing_handoff_do_not_reclaim_reason reason =
   let lower = String.trim reason |> String.lowercase_ascii in
   let markers =
@@ -48,9 +64,14 @@ let is_routing_handoff_do_not_reclaim_reason reason =
     ; "no access to masc-mcp source"
     ; "routing warning"
     ; "tool-surface trap"
+    ; "worktree path not found"
+    ; "worktree not found"
+    ; "path resolution"
+    ; "releasing to unblock"
     ]
   in
-  List.exists
+  (not (has_explicit_hard_stop_reclaim_marker reason))
+  && List.exists
     (fun marker -> String_util.contains_substring lower marker)
     markers
 ;;

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1915,6 +1915,67 @@ let () = test "transition_claim_clears_stale_do_not_reclaim_reason" (fun () ->
     assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
 )
 
+let () = test "transition_claim_clears_missing_worktree_soft_block" (fun () ->
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    let ctx = make_test_ctx_with_agent "agent_code-mcp-client" in
+    let result =
+      Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+        (`Assoc
+          [
+            ("title", `String "Missing worktree recovery");
+            ("priority", `Int 1);
+          ])
+    in
+    if not result.Tool_result.success then failwith result.Tool_result.message;
+    set_only_task_do_not_reclaim_reason ctx
+      "worktree path not found, spinning on path resolution for multiple turns, \
+       releasing to unblock";
+    let claim_result =
+      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "claim");
+          ])
+    in
+    if not claim_result.Tool_result.success then failwith claim_result.Tool_result.message;
+    assert_task_claimed_by ctx "agent_code-mcp-client";
+    assert ((only_task ctx).do_not_reclaim_reason = None);
+    assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
+)
+
+let () = test "transition_claim_keeps_hard_stop_with_soft_markers" (fun () ->
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    let ctx = make_test_ctx_with_agent "agent_code-mcp-client" in
+    let result =
+      Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+        (`Assoc
+          [
+            ("title", `String "Hard-stop remains blocked");
+            ("priority", `Int 1);
+          ])
+    in
+    if not result.Tool_result.success then failwith result.Tool_result.message;
+    let reason =
+      "do not reclaim: worktree path not found during path resolution, releasing \
+       to unblock"
+    in
+    set_only_task_do_not_reclaim_reason ctx reason;
+    let claim_result =
+      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "claim");
+          ])
+    in
+    assert (not claim_result.Tool_result.success);
+    assert (str_contains claim_result.Tool_result.message "blocked from re-claim");
+    assert_task_todo ctx;
+    assert ((only_task ctx).do_not_reclaim_reason = Some reason);
+    assert (Planning_eio.get_current_task ctx.config = None))
+)
+
 let () = test "dispatch_transition_claim_uses_server_surface_not_payload_surface" (fun () ->
   let ctx = make_test_ctx () in
   add_task_requiring_tools ctx ~title:"Needs bash" [ "keeper_bash" ];


### PR DESCRIPTION
## Summary
- Treat missing-worktree/path-resolution handoff reasons as soft `do_not_reclaim` blocks so a later claim can clear them.
- Add regression coverage for claim recovery after a missing worktree release.
- Fix the broken `test_keeper_unified.ml` assertion string/paren that was causing a syntax error.

## Validation
- `ocamlformat --check lib/coord/coord_task_claim.ml test/test_tool_task_coverage.ml test/test_keeper_unified.ml`
- `git diff --check`

## Local Dune note
- `scripts/dune-local.sh build test/test_tool_task_coverage.exe` could not complete locally because the host already had active bare `dune build --root .` jobs and a held `/tmp/me-dune-local.lock`; this PR is draft so CI can provide the build signal without adding more local contention.
