### PR TITLE
fix(startup): backfill missing prompt seed files

### DIFF
--- a/lib/server/server_runtime_config_root_bootstrap.ml
+++ b/lib/server/server_runtime_config_root_bootstrap.ml
@@ -59,6 +59,33 @@ let copy_file_if_missing ~src ~dst =
     Fs_compat.save_file dst (Fs_compat.load_file src))
 ;;
 
+let rec copy_missing_tree_count ~src ~dst =
+  if Sys.is_directory src
+  then
+    if Sys.file_exists dst && not (Sys.is_directory dst)
+    then (
+      Log.Server.warn
+        "config bootstrap: refusing to replace file with directory (%s -> %s)"
+        src
+        dst;
+      0)
+    else (
+      Fs_compat.mkdir_p dst;
+      Sys.readdir src
+      |> Array.fold_left
+           (fun count name ->
+             count
+             + copy_missing_tree_count
+                 ~src:(Filename.concat src name)
+                 ~dst:(Filename.concat dst name))
+           0)
+  else if Sys.file_exists dst
+  then 0
+  else (
+    copy_file_if_missing ~src ~dst;
+    1)
+;;
+
 let rec copy_missing_tree ~src ~dst =
   if Sys.is_directory src
   then (
@@ -78,6 +105,14 @@ let rec copy_missing_tree ~src ~dst =
   else if Sys.file_exists dst
   then ()
   else copy_file_if_missing ~src ~dst
+;;
+
+let copy_missing_prompt_seed ~src_config_root ~dst_config_root =
+  let src = Filename.concat src_config_root "prompts" in
+  let dst = Filename.concat dst_config_root "prompts" in
+  if Sys.file_exists src && Sys.is_directory src
+  then copy_missing_tree_count ~src ~dst
+  else 0
 ;;
 
 let config_bootstrap_mode () =
@@ -124,9 +159,22 @@ let bootstrap_base_path_config_root ~base_path =
       if Sys.is_directory config_root
       then (
         ensure_config_root_scaffold config_root;
-        Log.Server.info
-          "preserved existing base-path config root without refilling missing entries: %s"
-          config_root)
+        let backfilled_prompts =
+          match versioned_config_root_candidates () |> List.find_opt Sys.file_exists with
+          | Some source -> copy_missing_prompt_seed ~src_config_root:source ~dst_config_root:config_root
+          | None -> 0
+        in
+        if backfilled_prompts > 0
+        then (
+          Log.Server.info
+            "backfilled %d missing prompt seed file(s) into existing base-path config root: %s"
+            backfilled_prompts
+            config_root;
+          Config_dir_resolver.reset ())
+        else
+          Log.Server.info
+            "preserved existing base-path config root without refilling non-prompt entries: %s"
+            config_root)
       else
         Log.Server.warn
           "base-path config root exists but is not a directory; skipping bootstrap: %s"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2415,7 +2415,7 @@ let test_prompt_includes_operational_tool_guidance () =
     bool
     "mentions Execute gh PR creation path"
     true
-    (contains_substring sys "Create or update PRs through `Execute` with `executable=\"gh\"");
+    (contains_substring sys "Create or update PRs through `Execute` with `executable=\"gh\"\"");
   check
     bool
     "warns passive discovery tools do not satisfy active turns"

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -611,7 +611,7 @@ let test_bootstrap_base_path_config_root_copies_shared_seed_but_not_keepers () =
       Alcotest.(check bool) "repo keeper TOML not copied" false
         (Sys.file_exists (Filename.concat config_root "keepers/example.toml")))
 
-let test_bootstrap_base_path_config_root_preserves_existing_root_without_refill () =
+let test_bootstrap_base_path_config_root_backfills_missing_prompts_only () =
   with_temp_dir "startup-config-preserve" (fun dir ->
       let repo = Filename.concat dir "repo" in
       mkdir_p repo;
@@ -632,9 +632,13 @@ let test_bootstrap_base_path_config_root_preserves_existing_root_without_refill 
         (Sys.is_directory (Filename.concat config_root "prompts"));
       Alcotest.(check bool) "versioned keeper not resurrected" false
         (Sys.file_exists (Filename.concat config_root "keepers/example.toml"));
-      Alcotest.(check bool) "versioned prompt not resurrected" false
+      Alcotest.(check bool) "versioned prompt backfilled" true
         (Sys.file_exists
            (Filename.concat config_root "prompts/keeper.unified.system.md"));
+      Alcotest.(check string) "backfilled prompt content" "prompt"
+        (read_file (Filename.concat config_root "prompts/keeper.unified.system.md"));
+      Alcotest.(check bool) "versioned persona not resurrected" false
+        (Sys.file_exists (Filename.concat config_root "personas/example.txt"));
       Alcotest.(check bool) "tool policy not backfilled" false
         (Sys.file_exists (Filename.concat config_root "tool_policy.toml")))
 
@@ -2969,9 +2973,9 @@ let () =
             `Quick
             test_bootstrap_base_path_config_root_copies_shared_seed_but_not_keepers;
           Alcotest.test_case
-            "bootstrap base-path config preserves existing root without refill"
+            "bootstrap base-path config backfills missing prompts only"
             `Quick
-            test_bootstrap_base_path_config_root_preserves_existing_root_without_refill;
+            test_bootstrap_base_path_config_root_backfills_missing_prompts_only;
           Alcotest.test_case
             "bootstrap base-path config skips explicit override"
             `Quick


### PR DESCRIPTION
## Summary

- Backfill missing prompt seed files into an existing base-path `.masc/config/prompts` directory during startup.
- Keep the existing safety boundary: do not resurrect `keepers/`, `personas/`, `tool_policy.toml`, or overwrite existing config files.
- Update the startup bootstrap test to prove only missing prompt files are filled.

## Evidence

- Runtime logs repeatedly emitted:
  `externalized prompt 'keeper.turn_intent.pr_review_guidance' resolved empty; using in-binary fallback`
- Repo seed exists:
  `config/prompts/keeper.turn_intent.pr_review_guidance.md`
- Live runtime config was missing the prompt file:
  `/Users/dancer/me/.masc/config/prompts/keeper.turn_intent.pr_review_guidance.md`
- Existing startup bootstrap preserved an existing `.masc/config` root without refilling missing entries, so newly added prompt markdown never reached the active config root.

## Verification

- `opam exec -- ocamlc -stop-after parsing lib/server/server_runtime_config_root_bootstrap.ml test/test_server_runtime_bootstrap.ml`
- `opam exec -- ocamlformat --check lib/server/server_runtime_config_root_bootstrap.ml test/test_server_runtime_bootstrap.ml`
- `git diff --check HEAD~1..HEAD`
- Focused Dune target `scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe` was attempted, but local host Dune contention made it impractically slow; CI should provide full target verification.
