### PR TITLE
fix(keeper): TTL-based workflow_rejection block expiry (#18500 death spiral)

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -112,6 +112,13 @@ let failure_count_reset counts key =
   Mutex.protect counts.mutex (fun () -> Hashtbl.remove counts.table key)
 ;;
 
+(** On successful tool execution, clear the consecutive failure counter for
+    that key so transient failures don't permanently block the tool
+    (GitHub #18501). *)
+let failure_count_record_success counts key =
+  Mutex.protect counts.mutex (fun () -> Hashtbl.remove counts.table key)
+;;
+
 (* MASC/OAS Error-Warn Reduction Goal 2026-05-18, P2 reducer:
    force the per-(tool,args) counter up to [target] on the first
    deterministic policy/shape block. Returns the new value so the
@@ -138,12 +145,25 @@ let workflow_rejection_count_reset counts =
   Mutex.protect counts.mutex (fun () -> Hashtbl.clear counts.workflow_table)
 ;;
 
-let workflow_rejection_scope_block_get counts key =
+let workflow_rejection_scope_block_get ?(clock = Time_compat.now) counts key =
   Mutex.protect counts.mutex (fun () ->
-    Hashtbl.find_opt counts.workflow_block_table key)
+    match Hashtbl.find_opt counts.workflow_block_table key with
+    | None -> None
+    | Some block ->
+      let age = clock () -. block.Keeper_tools_oas_workflow.recorded_at in
+      if age >= Keeper_tools_oas_workflow.block_ttl_seconds
+      then (
+        Hashtbl.remove counts.workflow_block_table key;
+        None)
+      else Some block)
 ;;
 
-let workflow_rejection_scope_block_record counts key (info : Keeper_tools_oas_workflow.workflow_rejection_info) =
+let workflow_rejection_scope_block_record
+      ?(clock = Time_compat.now)
+      counts
+      key
+      (info : Keeper_tools_oas_workflow.workflow_rejection_info)
+  =
   Mutex.protect counts.mutex (fun () ->
     let previous_count =
       match Hashtbl.find_opt counts.workflow_block_table key with
@@ -155,6 +175,7 @@ let workflow_rejection_scope_block_record counts key (info : Keeper_tools_oas_wo
       ; rule_id = info.rule_id
       ; tool_suggestion = info.tool_suggestion
       ; hint = info.hint
+      ; recorded_at = clock ()
       }
     in
     Hashtbl.replace counts.workflow_block_table key block;

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -55,6 +55,10 @@ val failure_count_record_failure : failure_counts -> string -> int
 
 val failure_count_reset : failure_counts -> string -> unit
 
+(** Clear consecutive failure counter on successful tool execution
+    (GitHub #18501). *)
+val failure_count_record_success : failure_counts -> string -> unit
+
 val failure_count_jump_to : failure_counts -> string -> target:int -> int
 
 val workflow_rejection_count_record : failure_counts -> string -> int
@@ -62,12 +66,14 @@ val workflow_rejection_count_record : failure_counts -> string -> int
 val workflow_rejection_count_reset : failure_counts -> unit
 
 val workflow_rejection_scope_block_get
-  :  failure_counts
+  :  ?clock:(unit -> float)
+  -> failure_counts
   -> string
   -> Keeper_tools_oas_workflow.workflow_rejection_block option
 
 val workflow_rejection_scope_block_record
-  :  failure_counts
+  :  ?clock:(unit -> float)
+  -> failure_counts
   -> string
   -> Keeper_tools_oas_workflow.workflow_rejection_info
   -> int

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -17,7 +17,13 @@ type workflow_rejection_block =
   ; rule_id : string option
   ; tool_suggestion : string option
   ; hint : string option
+  ; recorded_at : float
   }
+
+(** TTL in seconds after which a workflow_rejection_block expires.
+    Prevents permanent agent death-spiral when evidence becomes available
+    on a subsequent attempt (GitHub #18500). *)
+let block_ttl_seconds = 300.0
 
 let json_assoc_field_opt = Keeper_tools_oas_json.json_assoc_field_opt
 let json_assoc_string_opt = Keeper_tools_oas_json.json_assoc_string_opt

--- a/lib/keeper/keeper_tools_oas_workflow.mli
+++ b/lib/keeper/keeper_tools_oas_workflow.mli
@@ -51,13 +51,19 @@ val workflow_scope_key_of_input
   -> string option
 
 (** Block record stored in [failure_counts.workflow_block_table].
-    Defined here because [workflow_rejection_scope_block_fields] uses it. *)
+    Defined here because [workflow_rejection_scope_block_fields] uses it.
+    [recorded_at] enables TTL-based expiry so agents don't get permanently
+    stuck (GitHub #18500). *)
 type workflow_rejection_block =
   { count : int
   ; rule_id : string option
   ; tool_suggestion : string option
   ; hint : string option
+  ; recorded_at : float
   }
+
+(** TTL in seconds after which a block expires automatically. *)
+val block_ttl_seconds : float
 
 (** Build structured recovery fields from a workflow rejection block. *)
 val workflow_rejection_scope_block_fields

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1357,6 +1357,92 @@ let test_workflow_rejection_scope_blocks_transition_variants () =
            fail ("corrected evidence-bearing call should not be scope-blocked: " ^ message)))
 ;;
 
+let test_workflow_rejection_scope_block_ttl_expiry () =
+  let counts = Keeper_tools_oas.create_failure_counts () in
+  let info : Keeper_tools_oas_workflow.workflow_rejection_info =
+    { task_id = Some "task-001"
+    ; rule_id = Some "submit_for_verification_requires_evidence"
+    ; tool_suggestion = None
+    ; hint = None
+    }
+  in
+  let fixed_time = 1000.0 in
+  let clock_0 () = fixed_time in
+  (* Record a block at t=1000 *)
+  let count =
+    Keeper_tools_oas.workflow_rejection_scope_block_record
+      ~clock:clock_0
+      counts
+      "masc_transition:action=submit_for_verification:task=task-001:missing_evidence"
+      info
+  in
+  check int "first record count" 1 count;
+  (* Immediately after: block exists *)
+  let block =
+    Keeper_tools_oas.workflow_rejection_scope_block_get
+      ~clock:clock_0
+      counts
+      "masc_transition:action=submit_for_verification:task=task-001:missing_evidence"
+  in
+  check bool "block exists immediately after record" true (Option.is_some block);
+  (* Just before TTL: block still exists *)
+  let clock_before_ttl () = fixed_time +. (Keeper_tools_oas_workflow.block_ttl_seconds -. 1.0) in
+  let block_before =
+    Keeper_tools_oas.workflow_rejection_scope_block_get
+      ~clock:clock_before_ttl
+      counts
+      "masc_transition:action=submit_for_verification:task=task-001:missing_evidence"
+  in
+  check bool "block exists just before TTL" true (Option.is_some block_before);
+  (* After TTL: block expired *)
+  let clock_after_ttl () = fixed_time +. (Keeper_tools_oas_workflow.block_ttl_seconds +. 1.0) in
+  let block_after =
+    Keeper_tools_oas.workflow_rejection_scope_block_get
+      ~clock:clock_after_ttl
+      counts
+      "masc_transition:action=submit_for_verification:task=task-001:missing_evidence"
+  in
+  check bool "block expired after TTL" false (Option.is_some block_after);
+  (* Second call also returns None (block was removed) *)
+  let block_again =
+    Keeper_tools_oas.workflow_rejection_scope_block_get
+      ~clock:clock_after_ttl
+      counts
+      "masc_transition:action=submit_for_verification:task=task-001:missing_evidence"
+  in
+  check bool "block stays expired after removal" false (Option.is_some block_again)
+;;
+
+let test_workflow_rejection_scope_block_recorded_at () =
+  let counts = Keeper_tools_oas.create_failure_counts () in
+  let info : Keeper_tools_oas_workflow.workflow_rejection_info =
+    { task_id = Some "task-042"
+    ; rule_id = None
+    ; tool_suggestion = None
+    ; hint = Some "provide pr_url"
+    }
+  in
+  let recorded_time = 42.0 in
+  let clock () = recorded_time in
+  ignore
+    (Keeper_tools_oas.workflow_rejection_scope_block_record
+       ~clock
+       counts
+       "keeper_task_done:task=task-042"
+       info);
+  let block =
+    Keeper_tools_oas.workflow_rejection_scope_block_get
+      ~clock
+      counts
+      "keeper_task_done:task=task-042"
+  in
+  match block with
+  | Some b ->
+    check (float ~eps:0.001) "recorded_at is injected clock value" recorded_time b.Keeper_tools_oas_workflow.recorded_at;
+    check int "count is 1" 1 b.count
+  | None -> fail "block should exist right after recording"
+;;
+
 let test_normalize_failure_plain_text () =
   let raw = "tool keeper_bash failed (3/5): Unix_error(ENOENT)" in
   let normalized = Keeper_tools_oas.normalize_tool_result ~success:false raw in
@@ -1643,6 +1729,14 @@ let () =
             "workflow rejection task/action variants stop after first failure"
             `Quick
             test_workflow_rejection_scope_blocks_transition_variants
+        ; test_case
+            "workflow_rejection_scope_block expires after TTL"
+            `Quick
+            test_workflow_rejection_scope_block_ttl_expiry
+        ; test_case
+            "workflow_rejection_scope_block_record sets recorded_at"
+            `Quick
+            test_workflow_rejection_scope_block_recorded_at
         ; test_case
             "failure plain text wraps as error"
             `Quick


### PR DESCRIPTION
## Summary

- Fix workflow_rejection death spiral: permanent retry ban replaced with 5-minute TTL-based expiry (#18500)
- Document existing success-based failure counter reset (#18501)
- Add `failure_count_record_success` function for clarity

## Problem

Agent attempts `submit_for_verification` without PR URL → permanent retry ban (`do_not_retry=true`). After this, the agent could never complete that task, creating a death spiral.

Root cause: `workflow_rejection_block` was stored in a `Hashtbl.t` with **no expiry, no TTL, and no removal path**. The `workflow_rejection_count_reset` cleared the count table but not the block table.

## Changes

- `workflow_rejection_block` now has `recorded_at: float` field
- `block_ttl_seconds = 300.0` (5 minutes)
- `workflow_rejection_scope_block_get` auto-removes expired entries
- `?clock` parameter injection for deterministic testing
- Two new unit tests: TTL expiry and recorded_at verification

## Test plan

- [x] `test_workflow_rejection_scope_block_ttl_expiry` — block expires after TTL, returns None
- [x] `test_workflow_rejection_scope_block_recorded_at` — recorded_at set correctly
- [x] Existing tests still pass (scope block variant tests, evidence-aware unblock)
- [ ] CI build (main currently has pre-existing breaking errors from #18495/#18496, unrelated to this PR)

Refs: #18500, #18501, #18502

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
