### PR TITLE
fix(coord): add process-lifetime cache for resolved base path

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -678,6 +678,7 @@ let run_cmd host port base_path =
       base_path normalized_base_path;
   Unix.putenv "MASC_BASE_PATH_INPUT" raw_base_path;
   Unix.putenv "MASC_BASE_PATH" normalized_base_path;
+  Coord_utils_backend_setup.cache_resolved_base_path normalized_base_path;
   Unix.putenv "MASC_BASE_PATH_RESOLUTION_SOURCE" resolution_source;
   (* Persist logs inside .masc/logs/ — colocated with state, not a sibling.
      Previous code wrote to base_path/logs/ which diverged from .masc/ when

--- a/lib/coord/coord_utils_backend_setup.ml
+++ b/lib/coord/coord_utils_backend_setup.ml
@@ -164,33 +164,41 @@ let resolve_requested_base_path path =
       ignored unless it matches the requested path or the test explicitly opts
       in via [MASC_TEST_ALLOW_BASE_PATH_OVERRIDE]
     - otherwise resolve the requested path to its git root *)
+let resolved_base_path_cache : string option ref = ref None
+
+let cache_resolved_base_path path =
+  resolved_base_path_cache := Some path
+
 let resolve_masc_base_path path =
-  let requested = resolve_requested_base_path path in
-  match (Host_config.from_env ()).base_path with
-  | Some explicit
-    when running_under_test_executable ()
-         && not (test_base_path_override_enabled ()) ->
-      log_once_info
-        "Ignoring test MASC_BASE_PATH override=%s for requested path %s"
-        explicit path;
-      requested
-  | Some explicit
-    when running_under_test_executable ()
-         && not (test_base_path_override_enabled ())
-         && not (String.equal explicit requested) ->
-      log_once_info
-        "Ignoring test MASC_BASE_PATH override=%s for requested path %s"
-        explicit path;
-      requested
-  | Some explicit ->
-      log_once_info "MASC base: %s (explicit MASC_BASE_PATH)" explicit;
-      explicit
-  | None when running_under_test_executable () -> requested
+  match !resolved_base_path_cache with
+  | Some cached -> cached
   | None ->
-      Log.Backend.error
-        "MASC_BASE_PATH is not set. Set MASC_BASE_PATH to the project root \
-         containing the .masc/ directory.";
-      exit 1
+    let requested = resolve_requested_base_path path in
+    match (Host_config.from_env ()).base_path with
+    | Some explicit
+      when running_under_test_executable ()
+           && not (test_base_path_override_enabled ()) ->
+        log_once_info
+          "Ignoring test MASC_BASE_PATH override=%s for requested path %s"
+          explicit path;
+        requested
+    | Some explicit
+      when running_under_test_executable ()
+           && not (test_base_path_override_enabled ())
+           && not (String.equal explicit requested) ->
+        log_once_info
+          "Ignoring test MASC_BASE_PATH override=%s for requested path %s"
+          explicit path;
+        requested
+    | Some explicit ->
+        log_once_info "MASC base: %s (explicit MASC_BASE_PATH)" explicit;
+        explicit
+    | None when running_under_test_executable () -> requested
+    | None ->
+        Log.Backend.error
+          "MASC_BASE_PATH is not set. Set MASC_BASE_PATH to the project root \
+           containing the .masc/ directory.";
+        exit 1
 
 let resolve_server_default_base_path path = resolve_masc_base_path path
 

--- a/lib/coord/coord_utils_backend_setup.mli
+++ b/lib/coord/coord_utils_backend_setup.mli
@@ -27,6 +27,7 @@ val test_base_path_override_env : string
 val test_base_path_override_enabled : unit -> bool
 val sync_test_base_path_env : string -> unit
 val resolve_requested_base_path : string -> string
+val cache_resolved_base_path : string -> unit
 val resolve_masc_base_path : string -> string
 val resolve_server_default_base_path : string -> string
 val is_unresolved_template : string -> bool

--- a/test/dune
+++ b/test/dune
@@ -1525,6 +1525,7 @@
 (include stanzas/test_continuity_forward_filter.inc)
 
 (include stanzas/test_coord_bootstrap.inc)
+(include stanzas/test_coord_base_path_cache.inc)
 
 (include stanzas/test_credential_materializer_waitpid_eintr.inc)
 

--- a/test/stanzas/test_coord_base_path_cache.inc
+++ b/test/stanzas/test_coord_base_path_cache.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_coord_base_path_cache)
+ (modules test_coord_base_path_cache)
+ (libraries masc_test_deps))

--- a/test/test_coord_base_path_cache.ml
+++ b/test/test_coord_base_path_cache.ml
@@ -1,0 +1,12 @@
+let () =
+  let open Alcotest in
+  let module S = Coord_utils_backend_setup in
+  let tc =
+    test_case "cache_resolved_base_path short-circuits resolve" `Quick
+      (fun () ->
+        let cached_path = "/tmp/masc-test-cache-path" in
+        S.cache_resolved_base_path cached_path;
+        let result = S.resolve_masc_base_path "/some/other/path" in
+        check string "returns cached value" cached_path result)
+  in
+  run __FILE__ [ "coord base path cache", [ tc ] ]


### PR DESCRIPTION
## Summary
- `Unix.putenv "MASC_BASE_PATH"` in `main_eio.ml:run_cmd` was overwriting the env var after other modules already read the original value, causing HTTP sessions to resolve a different base path than the server startup path
- Add `resolved_base_path_cache` ref in `Coord_utils_backend_setup` — `run_cmd` caches the normalized path immediately after `putenv`, and `resolve_masc_base_path` returns the cached value on subsequent calls
- Includes minimal Alcotest verifying cache short-circuits resolve

## Root cause
```
[Coord] MASC base: /Users/dancer/me (explicit MASC_BASE_PATH)     ← first resolve (correct)
[Server] Normalizing --base-path from /Users/dancer/.masc to /Users/dancer
[Coord] MASC base: /Users/dancer (no git root found)               ← second resolve (wrong)
[egress_audit:skip] no keeper metas found at /Users/dancer/.masc/keepers
```

The `putenv` at line 680 overwrites `MASC_BASE_PATH` after `server_runtime_bootstrap` already resolved the correct path. Later HTTP session `default_base_path()` re-reads the mutated env var and gets a different result.

## Test plan
- [ ] `dune build` passes (blocked by pre-existing `Tool_local_runtime.config` error on main — not from this PR)
- [ ] `dune exec test/test_coord_base_path_cache.exe` passes
- [ ] Server restart with `--base-path /Users/dancer/me` produces consistent `[Coord] MASC base` lines
- [ ] `curl -s http://localhost:8935/health` shows correct base_path

🤖 Generated with [Claude Code](https://claude.com/claude-code)