### PR TITLE
fix(keeper): add TTL to workflow rejection scope blocks (#18500)

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -143,6 +143,12 @@ let failure_count_jump_to counts key ~target =
     target)
 ;;
 
+(* TTL for workflow rejection scope blocks (#18500).
+   After this many seconds, a scope block expires and the agent may
+   retry the same (tool, task, action) scope — e.g. after creating a PR
+   externally and re-submitting for verification. *)
+let workflow_block_ttl_seconds = 1800.
+
 let workflow_rejection_count_record counts key =
   Mutex.protect counts.mutex (fun () ->
     let next =
@@ -160,7 +166,15 @@ let workflow_rejection_count_reset counts =
 
 let workflow_rejection_scope_block_get counts key =
   Mutex.protect counts.mutex (fun () ->
-    Hashtbl.find_opt counts.workflow_block_table key)
+    match Hashtbl.find_opt counts.workflow_block_table key with
+    | None -> None
+    | Some block ->
+      let age = Unix.gettimeofday () -. block.blocked_at in
+      if age > workflow_block_ttl_seconds then begin
+        Hashtbl.remove counts.workflow_block_table key;
+        None
+      end else
+        Some block)
 ;;
 
 let workflow_rejection_scope_block_record counts key (info : Keeper_tools_oas_workflow.workflow_rejection_info) =
@@ -175,6 +189,7 @@ let workflow_rejection_scope_block_record counts key (info : Keeper_tools_oas_wo
       ; rule_id = info.rule_id
       ; tool_suggestion = info.tool_suggestion
       ; hint = info.hint
+      ; blocked_at = Unix.gettimeofday ()
       }
     in
     Hashtbl.replace counts.workflow_block_table key block;
@@ -190,6 +205,21 @@ let inject_stale_failure_count_for_test counts key count =
       (Time_compat.now () -. (failure_count_ttl_seconds +. 60.)))
 ;;
 
+(* Test-only: inject a scope block with a stale [blocked_at] timestamp
+   so the TTL expiry path in [workflow_rejection_scope_block_get]
+   can be exercised without sleeping. *)
+let inject_stale_workflow_block_for_test counts key =
+  let block : Keeper_tools_oas_workflow.workflow_rejection_block =
+    { count = 1
+    ; rule_id = None
+    ; tool_suggestion = None
+    ; hint = None
+    ; blocked_at = Time_compat.now () -. (workflow_block_ttl_seconds +. 60.)
+    }
+  in
+  Mutex.protect counts.mutex (fun () ->
+    Hashtbl.replace counts.workflow_block_table key block)
+;;
 open Keeper_tools_oas_workflow
 open Keeper_tools_oas_deterministic_error
 

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -169,7 +169,7 @@ let workflow_rejection_scope_block_get counts key =
     match Hashtbl.find_opt counts.workflow_block_table key with
     | None -> None
     | Some block ->
-      let age = Unix.gettimeofday () -. block.blocked_at in
+      let age = Time_compat.now () -. block.blocked_at in
       if age > workflow_block_ttl_seconds then begin
         Hashtbl.remove counts.workflow_block_table key;
         None
@@ -189,7 +189,7 @@ let workflow_rejection_scope_block_record counts key (info : Keeper_tools_oas_wo
       ; rule_id = info.rule_id
       ; tool_suggestion = info.tool_suggestion
       ; hint = info.hint
-      ; blocked_at = Unix.gettimeofday ()
+      ; blocked_at = Time_compat.now ()
       }
     in
     Hashtbl.replace counts.workflow_block_table key block;

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -83,6 +83,12 @@ val inject_stale_failure_count_for_test : failure_counts -> string -> int -> uni
     at ERROR. *)
 val reset_tool_retry_dedupe_for_testing : unit -> unit
 
+(** Test-only: inject a scope block with [blocked_at] set to
+    [workflow_block_ttl_seconds + 60] seconds in the past.
+    The next [workflow_rejection_scope_block_get] call for [key]
+    will treat it as expired and return [None]. *)
+val inject_stale_workflow_block_for_test : failure_counts -> string -> unit
+
 (** Normalize a raw tool result string into the canonical JSON
     envelope. Success → [{"ok":true,"result":...}]; failure →
     [{"ok":false,"error":...,"detail":...}], preserving structured

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -17,6 +17,7 @@ type workflow_rejection_block =
   ; rule_id : string option
   ; tool_suggestion : string option
   ; hint : string option
+  ; blocked_at : float
   }
 
 let json_assoc_field_opt = Keeper_tools_oas_json.json_assoc_field_opt

--- a/lib/keeper/keeper_tools_oas_workflow.mli
+++ b/lib/keeper/keeper_tools_oas_workflow.mli
@@ -57,6 +57,7 @@ type workflow_rejection_block =
   ; rule_id : string option
   ; tool_suggestion : string option
   ; hint : string option
+  ; blocked_at : float
   }
 
 (** Build structured recovery fields from a workflow rejection block. *)

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1375,6 +1375,16 @@ let test_workflow_rejection_scope_blocks_transition_variants () =
            fail ("corrected evidence-bearing call should not be scope-blocked: " ^ message)))
 ;;
 
+(* #18500: scope blocks must expire after TTL so agents can retry. *)
+let test_workflow_rejection_scope_block_ttl_expires () =
+  let counts = Keeper_tools_oas.create_failure_counts () in
+  let key = "masc_transition:action=submit_for_verification:task=test-001:missing_evidence" in
+  Keeper_tools_oas.inject_stale_workflow_block_for_test counts key;
+  match Keeper_tools_oas.workflow_rejection_scope_block_get counts key with
+  | None -> ()
+  | Some _ -> Alcotest.fail "stale scope block should have been expired"
+;;
+
 let test_normalize_failure_plain_text () =
   let raw = "tool keeper_bash failed (3/5): Unix_error(ENOENT)" in
   let normalized = Keeper_tools_oas.normalize_tool_result ~success:false raw in
@@ -1669,6 +1679,10 @@ let () =
             "workflow rejection task/action variants stop after first failure"
             `Quick
             test_workflow_rejection_scope_blocks_transition_variants
+        ; test_case
+            "workflow rejection scope block TTL expires (#18500)"
+            `Quick
+            test_workflow_rejection_scope_block_ttl_expires
         ; test_case
             "failure plain text wraps as error"
             `Quick


### PR DESCRIPTION
## Summary
- `workflow_rejection_block`에 `blocked_at: float` 필드 추가
- `workflow_rejection_scope_block_get`에서 30분 TTL 만료 체크 후 자동 제거
- 기존 영구 차단 → 30분 후 재시도 가능

## Problem
`submit_for_verification`를 evidence 없이 호출하면 scope block이 영구 생성.
Agent가 PR 생성 후 재시도해도 scope key 동일 → 절대 차단 해제 안 됨.

## Test plan
- [x] TTL 만료 테스트 추가
- [x] 기존 scope block 테스트 회귀 없음
- [ ] CI Build and Test 통과

Closes #18500

🤖 Generated with [Claude Code](https://claude.com/claude-code)