### PR TITLE
fix(task): type reclaim hard-stop policy

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -109,11 +109,11 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Masc_domain.masc_
                         let new_cycle = t.cycle_count + 1 in
                         (* Cancellation is terminal by status. Free-text cancel
                            reasons must not synthesize reclaim hard-stops. *)
-                        let auto_dnr =
-                          match t.do_not_reclaim_reason with
-                          | Some _ as existing ->
-                            do_not_reclaim_reason_blocks_claim existing
-                          | None -> None
+                        let reclaim_policy, do_not_reclaim_reason =
+                          match t.reclaim_policy with
+                          | Some Masc_domain.Block_reclaim ->
+                            Some Masc_domain.Block_reclaim, t.do_not_reclaim_reason
+                          | Some Masc_domain.Allow_reclaim | None -> None, None
                         in
                         { t with
                           task_status =
@@ -123,7 +123,8 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Masc_domain.masc_
                               ; reason = (if reason = "" then None else Some reason)
                               }
                         ; cycle_count = new_cycle
-                        ; do_not_reclaim_reason = auto_dnr
+                        ; reclaim_policy
+                        ; do_not_reclaim_reason
                         })
                       else t)
                    backlog.tasks

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -107,19 +107,13 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Masc_domain.masc_
                       if t.id = task_id
                       then (
                         let new_cycle = t.cycle_count + 1 in
-                        (* Set do_not_reclaim_reason only when the operator flags
-                     an explicit hard stop in the cancel reason. *)
+                        (* Cancellation is terminal by status. Free-text cancel
+                           reasons must not synthesize reclaim hard-stops. *)
                         let auto_dnr =
                           match t.do_not_reclaim_reason with
                           | Some _ as existing ->
                             do_not_reclaim_reason_blocks_claim existing
-                          | None ->
-                            let lower = String.lowercase_ascii reason in
-                            let flagged =
-                              String_util.contains_substring lower "do not reclaim"
-                              || String_util.contains_substring lower "scope mismatch"
-                            in
-                            if flagged && reason <> "" then Some reason else None
+                          | None -> None
                         in
                         { t with
                           task_status =

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -13,40 +13,21 @@ include Coord_broadcast
 open Coord_backlog
 open Coord_identity
 
-let is_legacy_auto_cycle_do_not_reclaim_reason reason =
-  let trimmed = String.trim reason in
-  let prefix = "auto: " in
-  let parse_suffix suffix =
-    let prefix_len = String.length prefix in
-    let suffix_len = String.length suffix in
-    let len = String.length trimmed in
-    if
-      len > prefix_len + suffix_len
-      && String.starts_with ~prefix trimmed
-      && String.ends_with ~suffix trimmed
-    then
-      let raw_count = String.sub trimmed prefix_len (len - prefix_len - suffix_len) in
-      match int_of_string_opt raw_count with
-      | Some count -> count >= 3
-      | None -> false
-    else
-      false
-  in
-  parse_suffix " releases" || parse_suffix " cancellations"
+let reclaim_policy_blocks_claim (task : Masc_domain.task) =
+  match task.reclaim_policy with
+  | Some Masc_domain.Block_reclaim ->
+    Some
+      (Option.value
+         task.do_not_reclaim_reason
+         ~default:"reclaim blocked by typed policy")
+  | Some Masc_domain.Allow_reclaim | None -> None
 ;;
 
-let do_not_reclaim_reason_blocks_claim = function
-  | Some reason when is_legacy_auto_cycle_do_not_reclaim_reason reason -> None
-  | Some _ as reason -> reason
-  | None -> None
-;;
-
-let clear_soft_do_not_reclaim_reason (task : Masc_domain.task) =
-  match task.do_not_reclaim_reason with
-  | Some reason
-    when is_legacy_auto_cycle_do_not_reclaim_reason reason ->
-    { task with do_not_reclaim_reason = None }
-  | Some _ | None -> task
+let clear_reclaim_decision (task : Masc_domain.task) =
+  match task.reclaim_policy with
+  | Some Masc_domain.Block_reclaim -> task
+  | Some Masc_domain.Allow_reclaim | None ->
+    { task with reclaim_policy = None; do_not_reclaim_reason = None }
 ;;
 
 let clear_stale_worktree_binding (task : Masc_domain.task) =
@@ -161,11 +142,10 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
          let* () =
            Coord_task_classify.required_tool_claim_guard config ~agent_name ?agent_tool_names task
          in
-         (* Cycle-prevention gate: refuse claim when do_not_reclaim_reason is set.
-         The reason can come from cancel/release hard-stop logic or be applied
-         directly by an operator. See PRs #7794 (schema), #7798 (cancel hook). *)
+         (* Cycle-prevention gate: reclaim is blocked only by typed policy.
+         do_not_reclaim_reason is an operator-facing explanation, not state. *)
          let* () =
-           match do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason with
+           match reclaim_policy_blocks_claim task with
            | None -> Ok ()
            | Some r ->
              Error
@@ -206,7 +186,7 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
                   | Todo ->
                     let t =
                       t
-                      |> clear_soft_do_not_reclaim_reason
+                      |> clear_reclaim_decision
                       |> clear_stale_worktree_binding
                     in
                     let t' =
@@ -339,32 +319,23 @@ let release_reclaim_policy = function
   | Some { reclaim_policy = None; _ } | None -> None
 ;;
 
-let release_cycle_oscillation_hard_stop_threshold = 15
-
-let release_cycle_oscillation_hard_stop_reason ~next_cycle =
-  Printf.sprintf
-    "auto: claim-release oscillation threshold reached (cycle=%d >= %d) - \
-     operator review required before reclaim"
-    next_cycle
-    release_cycle_oscillation_hard_stop_threshold
+let derive_release_do_not_reclaim_reason (task : Masc_domain.task) handoff_context =
+  if release_reclaim_policy handoff_context = Some Masc_domain.Block_reclaim
+  then (
+    match release_handoff_texts handoff_context with
+    | text :: _ -> Some text
+    | [] -> Some "release hard-stop requested")
+  else
+    match task.reclaim_policy with
+    | Some Masc_domain.Block_reclaim -> task.do_not_reclaim_reason
+    | Some Masc_domain.Allow_reclaim | None -> None
 ;;
 
-let derive_release_do_not_reclaim_reason (task : Masc_domain.task) handoff_context =
-  match do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason with
-  | Some _ as existing -> existing
-  | None ->
-    let first_text =
-      match release_handoff_texts handoff_context with
-      | text :: _ -> Some text
-      | [] -> None
-    in
-    if release_reclaim_policy handoff_context = Some Masc_domain.Block_reclaim
-    then
-      Some
-        (Option.value first_text ~default:"release hard-stop requested")
-    else
-      let next_cycle = task.cycle_count + 1 in
-      if next_cycle >= release_cycle_oscillation_hard_stop_threshold
-      then Some (release_cycle_oscillation_hard_stop_reason ~next_cycle)
-      else None
+let derive_release_reclaim_policy (task : Masc_domain.task) handoff_context =
+  match release_reclaim_policy handoff_context with
+  | Some policy -> Some policy
+  | None -> (
+    match task.reclaim_policy with
+    | Some Masc_domain.Block_reclaim -> Some Masc_domain.Block_reclaim
+    | Some Masc_domain.Allow_reclaim | None -> None)
 ;;

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -35,50 +35,8 @@ let is_legacy_auto_cycle_do_not_reclaim_reason reason =
   parse_suffix " releases" || parse_suffix " cancellations"
 ;;
 
-let has_explicit_hard_stop_reclaim_marker reason =
-  let lower = String.trim reason |> String.lowercase_ascii in
-  let markers =
-    [ "do not reclaim"
-    ; "do-not-reclaim"
-    ; "do_not_reclaim"
-    ; "hard stop"
-    ; "hard-stop"
-    ; "operator review required before reclaim"
-    ]
-  in
-  List.exists
-    (fun marker -> String_util.contains_substring lower marker)
-    markers
-;;
-
-let is_routing_handoff_do_not_reclaim_reason reason =
-  let lower = String.trim reason |> String.lowercase_ascii in
-  let markers =
-    [ "auto_goal_fallback"
-    ; "releasing for keeper"
-    ; "release for keeper"
-    ; "executor pickup"
-    ; "needs executor"
-    ; "preset blocks code-write"
-    ; "sandbox-isolated keeper"
-    ; "no access to masc-mcp source"
-    ; "routing warning"
-    ; "tool-surface trap"
-    ; "worktree path not found"
-    ; "worktree not found"
-    ; "path resolution"
-    ; "releasing to unblock"
-    ]
-  in
-  (not (has_explicit_hard_stop_reclaim_marker reason))
-  && List.exists
-    (fun marker -> String_util.contains_substring lower marker)
-    markers
-;;
-
 let do_not_reclaim_reason_blocks_claim = function
   | Some reason when is_legacy_auto_cycle_do_not_reclaim_reason reason -> None
-  | Some reason when is_routing_handoff_do_not_reclaim_reason reason -> None
   | Some _ as reason -> reason
   | None -> None
 ;;
@@ -86,8 +44,7 @@ let do_not_reclaim_reason_blocks_claim = function
 let clear_soft_do_not_reclaim_reason (task : Masc_domain.task) =
   match task.do_not_reclaim_reason with
   | Some reason
-    when is_legacy_auto_cycle_do_not_reclaim_reason reason
-         || is_routing_handoff_do_not_reclaim_reason reason ->
+    when is_legacy_auto_cycle_do_not_reclaim_reason reason ->
     { task with do_not_reclaim_reason = None }
   | Some _ | None -> task
 ;;
@@ -377,27 +334,9 @@ let release_handoff_texts handoff_context =
     fields
 ;;
 
-let release_hard_stop_markers =
-  [ "do not reclaim"
-  ; "not found"
-  ; "phantom"
-  ; "repo unavailable"
-  ; "already done"
-  ; "already completed"
-  ; "completed by another"
-  ; "invalid pr"
-  ; "invalid issue"
-  ]
-;;
-
-let release_should_block_reclaim handoff_context =
-  List.exists
-    (fun text ->
-       let lower = String.lowercase_ascii text in
-       List.exists
-         (fun marker -> String_util.contains_substring lower marker)
-         release_hard_stop_markers)
-    (release_handoff_texts handoff_context)
+let release_reclaim_policy = function
+  | Some { reclaim_policy = Some policy; _ } -> Some policy
+  | Some { reclaim_policy = None; _ } | None -> None
 ;;
 
 let release_cycle_oscillation_hard_stop_threshold = 15
@@ -419,7 +358,7 @@ let derive_release_do_not_reclaim_reason (task : Masc_domain.task) handoff_conte
       | text :: _ -> Some text
       | [] -> None
     in
-    if release_should_block_reclaim handoff_context
+    if release_reclaim_policy handoff_context = Some Masc_domain.Block_reclaim
     then
       Some
         (Option.value first_text ~default:"release hard-stop requested")

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -294,7 +294,7 @@ let claim_task config ~agent_name ~task_id =
 (** Unified task transition (single entrypoint).
     When [~force:true], release/cancel/done bypass the assignee guard.
     Used by keeper for orphan task cleanup. *)
-let release_handoff_texts handoff_context =
+let release_handoff_texts (handoff_context : Masc_domain.task_handoff_context option) =
   let fields =
     match handoff_context with
     | None -> []
@@ -314,12 +314,17 @@ let release_handoff_texts handoff_context =
     fields
 ;;
 
-let release_reclaim_policy = function
-  | Some { reclaim_policy = Some policy; _ } -> Some policy
-  | Some { reclaim_policy = None; _ } | None -> None
+let release_reclaim_policy (handoff_context : Masc_domain.task_handoff_context option) =
+  match handoff_context with
+  | Some ({ reclaim_policy = Some policy; _ } : Masc_domain.task_handoff_context) ->
+    Some policy
+  | Some ({ reclaim_policy = None; _ } : Masc_domain.task_handoff_context) | None -> None
 ;;
 
-let derive_release_do_not_reclaim_reason (task : Masc_domain.task) handoff_context =
+let derive_release_do_not_reclaim_reason
+      (task : Masc_domain.task)
+      (handoff_context : Masc_domain.task_handoff_context option)
+  =
   if release_reclaim_policy handoff_context = Some Masc_domain.Block_reclaim
   then (
     match release_handoff_texts handoff_context with
@@ -331,7 +336,10 @@ let derive_release_do_not_reclaim_reason (task : Masc_domain.task) handoff_conte
     | Some Masc_domain.Allow_reclaim | None -> None
 ;;
 
-let derive_release_reclaim_policy (task : Masc_domain.task) handoff_context =
+let derive_release_reclaim_policy
+      (task : Masc_domain.task)
+      (handoff_context : Masc_domain.task_handoff_context option)
+  =
   match release_reclaim_policy handoff_context with
   | Some policy -> Some policy
   | None -> (

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -13,16 +13,6 @@ include Coord_broadcast
 open Coord_backlog
 open Coord_identity
 
-let reclaim_policy_blocks_claim (task : Masc_domain.task) =
-  match task.reclaim_policy with
-  | Some Masc_domain.Block_reclaim ->
-    Some
-      (Option.value
-         task.do_not_reclaim_reason
-         ~default:"reclaim blocked by typed policy")
-  | Some Masc_domain.Allow_reclaim | None -> None
-;;
-
 let clear_reclaim_decision (task : Masc_domain.task) =
   match task.reclaim_policy with
   | Some Masc_domain.Block_reclaim -> task
@@ -142,12 +132,12 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
          let* () =
            Coord_task_classify.required_tool_claim_guard config ~agent_name ?agent_tool_names task
          in
-         (* Cycle-prevention gate: reclaim is blocked only by typed policy.
+         (* Reclaim gate: only typed policy blocks claiming.
          do_not_reclaim_reason is an operator-facing explanation, not state. *)
          let* () =
-           match reclaim_policy_blocks_claim task with
-           | None -> Ok ()
-           | Some r ->
+           match Masc_domain.task_reclaim_gate task with
+           | Reclaim_gate_open -> Ok ()
+           | Reclaim_gate_blocked_by_policy r ->
              Error
                (Masc_domain.Task (Masc_domain.Task_error.InvalidState
                   (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r)))

--- a/lib/coord/coord_task_claim.mli
+++ b/lib/coord/coord_task_claim.mli
@@ -9,10 +9,6 @@ include module type of Coord_state
 
 (** {1 Reclaim helpers} *)
 
-val reclaim_policy_blocks_claim : Masc_domain.task -> string option
-(** Returns [Some reason] only when a typed [Block_reclaim] policy blocks
-    claiming. Free-text [do_not_reclaim_reason] is diagnostic-only. *)
-
 val clear_reclaim_decision : Masc_domain.task -> Masc_domain.task
 (** Clears non-blocking reclaim policy metadata before a task is claimed. *)
 

--- a/lib/coord/coord_task_claim.mli
+++ b/lib/coord/coord_task_claim.mli
@@ -14,11 +14,10 @@ val is_legacy_auto_cycle_do_not_reclaim_reason : string -> bool
 val do_not_reclaim_reason_blocks_claim : string option -> string option
 (** Returns [Some reason] only when [reason] is an explicit hard-stop that
     should still block claiming. Legacy automatic cycle reasons such as
-    ["auto: 3 releases"] and routing handoff reasons such as tool-surface or
-    sandbox mismatch are treated as soft and return [None]. *)
+    ["auto: 3 releases"] are treated as soft and return [None]. *)
 
 val clear_soft_do_not_reclaim_reason : Masc_domain.task -> Masc_domain.task
-(** Clears soft cycle/routing reasons before a task is claimed. *)
+(** Clears soft legacy cycle reasons before a task is claimed. *)
 
 val clear_stale_worktree_binding : Masc_domain.task -> Masc_domain.task
 (** Clears per-claim worktree metadata before a new owner claims a task or a
@@ -51,9 +50,8 @@ val claim_task_r :
 
 val release_handoff_texts : Masc_domain.task_handoff_context option -> string list
 
-val release_hard_stop_markers : string list
-
-val release_should_block_reclaim : Masc_domain.task_handoff_context option -> bool
+val release_reclaim_policy :
+  Masc_domain.task_handoff_context option -> Masc_domain.task_reclaim_policy option
 
 val derive_release_do_not_reclaim_reason :
   Masc_domain.task -> Masc_domain.task_handoff_context option -> string option

--- a/lib/coord/coord_task_claim.mli
+++ b/lib/coord/coord_task_claim.mli
@@ -9,15 +9,12 @@ include module type of Coord_state
 
 (** {1 Reclaim helpers} *)
 
-val is_legacy_auto_cycle_do_not_reclaim_reason : string -> bool
+val reclaim_policy_blocks_claim : Masc_domain.task -> string option
+(** Returns [Some reason] only when a typed [Block_reclaim] policy blocks
+    claiming. Free-text [do_not_reclaim_reason] is diagnostic-only. *)
 
-val do_not_reclaim_reason_blocks_claim : string option -> string option
-(** Returns [Some reason] only when [reason] is an explicit hard-stop that
-    should still block claiming. Legacy automatic cycle reasons such as
-    ["auto: 3 releases"] are treated as soft and return [None]. *)
-
-val clear_soft_do_not_reclaim_reason : Masc_domain.task -> Masc_domain.task
-(** Clears soft legacy cycle reasons before a task is claimed. *)
+val clear_reclaim_decision : Masc_domain.task -> Masc_domain.task
+(** Clears non-blocking reclaim policy metadata before a task is claimed. *)
 
 val clear_stale_worktree_binding : Masc_domain.task -> Masc_domain.task
 (** Clears per-claim worktree metadata before a new owner claims a task or a
@@ -55,3 +52,8 @@ val release_reclaim_policy :
 
 val derive_release_do_not_reclaim_reason :
   Masc_domain.task -> Masc_domain.task_handoff_context option -> string option
+
+val derive_release_reclaim_policy :
+  Masc_domain.task ->
+  Masc_domain.task_handoff_context option ->
+  Masc_domain.task_reclaim_policy option

--- a/lib/coord/coord_task_create.ml
+++ b/lib/coord/coord_task_create.ml
@@ -106,6 +106,7 @@ let add_task
              ; contract
              ; handoff_context = None
              ; cycle_count = 0
+             ; reclaim_policy = None
              ; do_not_reclaim_reason = None
              }
            in
@@ -190,6 +191,7 @@ let batch_add_tasks_internal ?created_by config tasks =
                 ; contract
                 ; handoff_context = None
                 ; cycle_count = 0
+                ; reclaim_policy = None
                 ; do_not_reclaim_reason = None
                 })
              tasks

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -27,7 +27,9 @@ let task_status_label (status : Masc_domain.task_status) : string =
 let task_is_claim_pool_candidate (task : Masc_domain.task) =
   match task.task_status with
   | Todo ->
-    Option.is_none (Coord_task.reclaim_policy_blocks_claim task)
+    (match Masc_domain.task_reclaim_gate task with
+     | Reclaim_gate_open -> true
+     | Reclaim_gate_blocked_by_policy _ -> false)
   | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ -> false
 ;;
 
@@ -389,7 +391,9 @@ let claim_next_r
         let blocked_todo =
           List.filter
             (fun (t : Masc_domain.task) ->
-               Option.is_some (Coord_task.reclaim_policy_blocks_claim t))
+               match Masc_domain.task_reclaim_gate t with
+               | Reclaim_gate_open -> false
+               | Reclaim_gate_blocked_by_policy _ -> true)
             all_todo
         in
         let latest_verification_status = latest_verification_status_by_task config in

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -27,27 +27,8 @@ let task_status_label (status : Masc_domain.task_status) : string =
 let task_is_claim_pool_candidate (task : Masc_domain.task) =
   match task.task_status with
   | Todo ->
-    Option.is_none
-      (Coord_task.do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason)
+    Option.is_none (Coord_task.reclaim_policy_blocks_claim task)
   | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ -> false
-;;
-
-let task_is_primary_claim_pool_candidate (task : Masc_domain.task) =
-  match task.task_status with
-  | Todo -> Option.is_none task.do_not_reclaim_reason
-  | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ -> false
-;;
-
-let task_is_soft_reclaim_candidate (task : Masc_domain.task) =
-  match task.task_status, task.do_not_reclaim_reason with
-  | Todo, Some reason ->
-    Option.is_none (Coord_task.do_not_reclaim_reason_blocks_claim (Some reason))
-  | Todo, None
-  | Claimed _, _
-  | InProgress _, _
-  | AwaitingVerification _, _
-  | Done _, _
-  | Cancelled _, _ -> false
 ;;
 
 type verification_claim_state =
@@ -408,8 +389,7 @@ let claim_next_r
         let blocked_todo =
           List.filter
             (fun (t : Masc_domain.task) ->
-               Option.is_some
-                 (Coord_task.do_not_reclaim_reason_blocks_claim t.do_not_reclaim_reason))
+               Option.is_some (Coord_task.reclaim_policy_blocks_claim t))
             all_todo
         in
         let latest_verification_status = latest_verification_status_by_task config in
@@ -436,8 +416,6 @@ let claim_next_r
                 ; "blocked", `Int (List.length verification_blocked_todo)
                 ; "ts", `String (now_iso ())
                 ]);
-        let primary_unclaimed = List.filter task_is_primary_claim_pool_candidate sorted in
-        let soft_unclaimed = List.filter task_is_soft_reclaim_candidate sorted in
         let unclaimed = List.filter task_is_claim_pool_candidate sorted in
         (* Also exclude the just-released task: the agent is moving on,
          re-claiming the same task would be a no-op loop. *)
@@ -536,12 +514,7 @@ let claim_next_r
                (not (List.mem t.id all_excluded)) && effective_task_filter t)
             candidates
         in
-        let primary_eligible = eligible_from primary_unclaimed in
-        let eligible =
-          match primary_eligible with
-          | _ :: _ -> primary_eligible
-          | [] -> eligible_from soft_unclaimed
-        in
+        let eligible = eligible_from unclaimed in
         let explicit_excluded_count =
           List.length exclude_task_ids
           +
@@ -617,7 +590,7 @@ let claim_next_r
                   then (
                     let t =
                       t
-                      |> Coord_task.clear_soft_do_not_reclaim_reason
+                      |> Coord_task.clear_reclaim_decision
                       |> Coord_task.clear_stale_worktree_binding
                     in
                     { t with

--- a/lib/coord/coord_task_schedule.mli
+++ b/lib/coord/coord_task_schedule.mli
@@ -16,8 +16,6 @@ type verification_claim_state =
 
 val task_status_label : Masc_domain.task_status -> string
 val task_is_claim_pool_candidate : Masc_domain.task -> bool
-val task_is_primary_claim_pool_candidate : Masc_domain.task -> bool
-val task_is_soft_reclaim_candidate : Masc_domain.task -> bool
 
 val verification_claim_state_of_status
   :  Coord_verification_store.request_status

--- a/lib/coord/coord_task_transition_executor.ml
+++ b/lib/coord/coord_task_transition_executor.ml
@@ -30,7 +30,7 @@ let normalize_task_before_status ~action task =
   match action with
   | Masc_domain.Claim ->
     task
-    |> Coord_task_claim.clear_soft_do_not_reclaim_reason
+    |> Coord_task_claim.clear_reclaim_decision
     |> Coord_task_claim.clear_stale_worktree_binding
   | Masc_domain.Release -> Coord_task_claim.clear_stale_worktree_binding task
   | Masc_domain.Start
@@ -47,6 +47,7 @@ let release_counters ~action task handoff_context =
   match action with
   | Masc_domain.Release ->
     ( task.cycle_count + 1
+    , Coord_task_claim.derive_release_reclaim_policy task handoff_context
     , Coord_task_claim.derive_release_do_not_reclaim_reason task handoff_context )
   | Masc_domain.Claim
   | Masc_domain.Start
@@ -56,12 +57,12 @@ let release_counters ~action task handoff_context =
   | Masc_domain.Submit_pr_evidence
   | Masc_domain.Approve_verification
   | Masc_domain.Reject_verification ->
-    task.cycle_count, task.do_not_reclaim_reason
+    task.cycle_count, task.reclaim_policy, task.do_not_reclaim_reason
 ;;
 
 let update_task_for_transition ~action ~new_status ~handoff_context task =
   let task = normalize_task_before_status ~action task in
-  let cycle_count, do_not_reclaim_reason =
+  let cycle_count, reclaim_policy, do_not_reclaim_reason =
     release_counters ~action task handoff_context
   in
   { task with
@@ -69,6 +70,7 @@ let update_task_for_transition ~action ~new_status ~handoff_context task =
   ; handoff_context =
       (if action_persists_handoff_context action then handoff_context else None)
   ; cycle_count
+  ; reclaim_policy
   ; do_not_reclaim_reason
   }
 ;;

--- a/lib/coord/coord_task_transitions.ml
+++ b/lib/coord/coord_task_transitions.ml
@@ -76,13 +76,13 @@ let transition_task_r
           | Masc_domain.Cancel -> Ok ()
         in
         let* () =
-          match action, reclaim_policy_blocks_claim task with
-          | Masc_domain.Claim, Some r ->
+          match action, Masc_domain.task_reclaim_gate task with
+          | Masc_domain.Claim, Reclaim_gate_blocked_by_policy r ->
             Error
               (Masc_domain.Task
                  (Masc_domain.Task_error.InvalidState
                     (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r)))
-          | Masc_domain.Claim, None
+          | Masc_domain.Claim, Reclaim_gate_open
           | ( Masc_domain.Start | Masc_domain.Done_action | Masc_domain.Cancel
             | Masc_domain.Release | Masc_domain.Submit_for_verification
             | Masc_domain.Approve_verification | Masc_domain.Reject_verification

--- a/lib/coord/coord_task_transitions.ml
+++ b/lib/coord/coord_task_transitions.ml
@@ -76,7 +76,7 @@ let transition_task_r
           | Masc_domain.Cancel -> Ok ()
         in
         let* () =
-          match action, do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason with
+          match action, reclaim_policy_blocks_claim task with
           | Masc_domain.Claim, Some r ->
             Error
               (Masc_domain.Task

--- a/lib/coordination_product.ml
+++ b/lib/coordination_product.ml
@@ -238,15 +238,16 @@ let compare_turn_queue_entry left right =
 let visible_claim_queue tasks =
   tasks
   |> List.filter_map (fun (task : Masc_domain.task) ->
-    match task.task_status, task.do_not_reclaim_reason with
-    | Masc_domain.Todo, None ->
+    match task.task_status, task.reclaim_policy with
+    | Masc_domain.Todo, Some Masc_domain.Block_reclaim -> None
+    | Masc_domain.Todo, (Some Masc_domain.Allow_reclaim | None) ->
       Some { task_id = task.id; priority = task.priority; created_at = task.created_at }
-    | Masc_domain.Todo, Some _
     | Masc_domain.Claimed _, _
     | Masc_domain.InProgress _, _
     | Masc_domain.AwaitingVerification _, _
     | Masc_domain.Done _, _
-    | Masc_domain.Cancelled _, _ -> None)
+    | Masc_domain.Cancelled _, _ ->
+      None)
   |> List.sort compare_turn_queue_entry
 ;;
 

--- a/lib/coordination_product.ml
+++ b/lib/coordination_product.ml
@@ -238,9 +238,9 @@ let compare_turn_queue_entry left right =
 let visible_claim_queue tasks =
   tasks
   |> List.filter_map (fun (task : Masc_domain.task) ->
-    match task.task_status, task.reclaim_policy with
-    | Masc_domain.Todo, Some Masc_domain.Block_reclaim -> None
-    | Masc_domain.Todo, (Some Masc_domain.Allow_reclaim | None) ->
+    match task.task_status, Masc_domain.task_reclaim_gate task with
+    | Masc_domain.Todo, Masc_domain.Reclaim_gate_blocked_by_policy _ -> None
+    | Masc_domain.Todo, Masc_domain.Reclaim_gate_open ->
       Some { task_id = task.id; priority = task.priority; created_at = task.created_at }
     | Masc_domain.Claimed _, _
     | Masc_domain.InProgress _, _

--- a/lib/task_transition_state/task_transition_state.ml
+++ b/lib/task_transition_state/task_transition_state.ml
@@ -40,7 +40,7 @@ type family =
   | Already_done
   | Active_task_limit_exceeded
   | Submit_verification_missing_evidence
-  | Claim_oscillation_blocked
+  | Reclaim_policy_blocked
   | Other_invalid_state
 
 type threshold_silence_payload =
@@ -88,7 +88,7 @@ let family_to_string = function
   | Active_task_limit_exceeded -> "active_task_limit_exceeded"
   | Submit_verification_missing_evidence ->
     "submit_verification_missing_evidence"
-  | Claim_oscillation_blocked -> "claim_oscillation_blocked"
+  | Reclaim_policy_blocked -> "reclaim_policy_blocked"
   | Other_invalid_state -> "other_invalid_state"
 
 (* ── Exhaustive enumeration helpers ───────────────────────────────── *)
@@ -130,7 +130,7 @@ let all_families : family list =
     ; Already_done
     ; Active_task_limit_exceeded
     ; Submit_verification_missing_evidence
-    ; Claim_oscillation_blocked
+    ; Reclaim_policy_blocked
     ; Other_invalid_state
     ]
   in
@@ -262,9 +262,7 @@ let classify (msg : string) : family =
   else if contains_ci ~needle:"already done/cancelled" msg
   then Already_done
   else if contains_ci ~needle:"blocked from re-claim" msg
-  then Claim_oscillation_blocked
-  else if contains_ci ~needle:"claim-release oscillation" msg
-  then Claim_oscillation_blocked
+  then Reclaim_policy_blocked
   else if contains_ci ~needle:"active task limit" msg
   then Active_task_limit_exceeded
   else if contains_ci ~needle:"active_task_limit" msg

--- a/lib/task_transition_state/task_transition_state.mli
+++ b/lib/task_transition_state/task_transition_state.mli
@@ -124,9 +124,10 @@ type family =
   | Submit_verification_missing_evidence
       (** [Submit_for_verification] called without [pr_url] or
           explicit evidence reference. *)
-  | Claim_oscillation_blocked
-      (** Re-claim blocked because the [claim ↔ release] oscillation
-          threshold was reached. *)
+  | Reclaim_policy_blocked
+      (** Re-claim blocked because a typed [Block_reclaim] policy was
+          explicitly persisted on the task. Free-text handoff notes and
+          cycle counts do not produce this family. *)
   | Other_invalid_state
       (** Catch-net for [InvalidState] messages that do not match any
           of the families above. Kept as an explicit constructor —

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -296,6 +296,11 @@ Tasks created through %s normally route action='done' into awaiting_verification
               ("type", `String "string");
               ("description", `String "If released due to failure, describe the failure mode.");
             ]);
+            ("reclaim_policy", `Assoc [
+              ("type", `String "string");
+              ("enum", `List [ `String "allow_reclaim"; `String "block_reclaim" ]);
+              ("description", `String "Explicit reclaim policy. Omit or use allow_reclaim for normal handoff. Use block_reclaim only for deterministic terminal mismatches that must require operator review.");
+            ]);
             ("evidence_refs", `Assoc [
               ("type", `String "array");
               ("items", `Assoc [ ("type", `String "string") ]);

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -529,6 +529,26 @@ type task = {
   do_not_reclaim_reason: string option; [@default None]
 } [@@deriving show]
 
+type task_reclaim_gate =
+  | Reclaim_gate_open
+  | Reclaim_gate_blocked_by_policy of string
+
+let task_reclaim_gate (t : task) =
+  match t.reclaim_policy with
+  | Some Block_reclaim ->
+    Reclaim_gate_blocked_by_policy
+      (Option.value
+         t.do_not_reclaim_reason
+         ~default:"reclaim blocked by typed policy")
+  | Some Allow_reclaim | None -> Reclaim_gate_open
+;;
+
+let task_reclaim_gate_block_reason t =
+  match task_reclaim_gate t with
+  | Reclaim_gate_open -> None
+  | Reclaim_gate_blocked_by_policy reason -> Some reason
+;;
+
 (* Manual yojson for task *)
 let task_to_yojson t =
   let status_json = task_status_to_yojson t.task_status in

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -525,6 +525,7 @@ type task = {
   contract: task_contract option; [@default None]
   handoff_context: task_handoff_context option; [@default None]
   cycle_count: int; [@default 0]
+  reclaim_policy: task_reclaim_policy option; [@default None]
   do_not_reclaim_reason: string option; [@default None]
 } [@@deriving show]
 
@@ -575,9 +576,16 @@ let task_to_yojson t =
     if t.cycle_count = 0 then with_handoff_context
     else with_handoff_context @ [("cycle_count", `Int t.cycle_count)]
   in
-  let with_do_not_reclaim = match t.do_not_reclaim_reason with
+  let with_reclaim_policy =
+    match t.reclaim_policy with
     | None -> with_cycle_count
-    | Some r -> with_cycle_count @ [("do_not_reclaim_reason", `String r)]
+    | Some policy ->
+        with_cycle_count
+        @ [("reclaim_policy", task_reclaim_policy_to_yojson policy)]
+  in
+  let with_do_not_reclaim = match t.do_not_reclaim_reason with
+    | None -> with_reclaim_policy
+    | Some r -> with_reclaim_policy @ [("do_not_reclaim_reason", `String r)]
   in
   (* Merge status fields into task *)
   match status_json with
@@ -625,6 +633,14 @@ let task_of_yojson json =
     let cycle_count =
       json |> member "cycle_count" |> to_int_option |> Option.value ~default:0
     in
+    let reclaim_policy =
+      match json |> member "reclaim_policy" with
+      | `Null -> None
+      | reclaim_policy_json ->
+          (match task_reclaim_policy_of_yojson reclaim_policy_json with
+           | Ok policy -> Some policy
+           | Error _ -> None)
+    in
     let do_not_reclaim_reason =
       json |> member "do_not_reclaim_reason" |> to_string_option
     in
@@ -646,6 +662,7 @@ let task_of_yojson json =
             contract;
             handoff_context;
             cycle_count;
+            reclaim_policy;
             do_not_reclaim_reason;
           }
     | Error e -> Error e

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -477,11 +477,33 @@ type task_contract = {
 } [@@deriving show, yojson { strict = false }]
 
 (** Handoff context persisted across release/reclaim cycles *)
+type task_reclaim_policy =
+  | Allow_reclaim
+  | Block_reclaim
+[@@deriving show]
+
+let task_reclaim_policy_to_string = function
+  | Allow_reclaim -> "allow_reclaim"
+  | Block_reclaim -> "block_reclaim"
+
+let task_reclaim_policy_of_string = function
+  | "allow_reclaim" -> Ok Allow_reclaim
+  | "block_reclaim" -> Ok Block_reclaim
+  | value -> Error (Printf.sprintf "unknown task_reclaim_policy: %s" value)
+
+let task_reclaim_policy_to_yojson policy =
+  `String (task_reclaim_policy_to_string policy)
+
+let task_reclaim_policy_of_yojson = function
+  | `String value -> task_reclaim_policy_of_string value
+  | _ -> Error "task_reclaim_policy must be a string"
+
 type task_handoff_context = {
   summary : string; [@default ""]
   reason : string option; [@default None]
   next_step : string option; [@default None]
   failure_mode : string option; [@default None]
+  reclaim_policy : task_reclaim_policy option; [@default None]
   evidence_refs : string list; [@default []]
   updated_at : string option; [@default None]
   updated_by : string option; [@default None]

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -180,6 +180,7 @@ type task =
   ; contract : task_contract option [@default None]
   ; handoff_context : task_handoff_context option [@default None]
   ; cycle_count : int [@default 0]
+  ; reclaim_policy : task_reclaim_policy option [@default None]
   ; do_not_reclaim_reason : string option [@default None]
   }
 [@@deriving show]

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -143,11 +143,22 @@ type task_contract =
   }
 [@@deriving show, yojson { strict = false }]
 
+type task_reclaim_policy =
+  | Allow_reclaim
+  | Block_reclaim
+[@@deriving show]
+
+val task_reclaim_policy_to_string : task_reclaim_policy -> string
+val task_reclaim_policy_of_string : string -> (task_reclaim_policy, string) result
+val task_reclaim_policy_to_yojson : task_reclaim_policy -> Yojson.Safe.t
+val task_reclaim_policy_of_yojson : Yojson.Safe.t -> (task_reclaim_policy, string) result
+
 type task_handoff_context =
   { summary : string [@default ""]
   ; reason : string option [@default None]
   ; next_step : string option [@default None]
   ; failure_mode : string option [@default None]
+  ; reclaim_policy : task_reclaim_policy option [@default None]
   ; evidence_refs : string list [@default []]
   ; updated_at : string option [@default None]
   ; updated_by : string option [@default None]

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -188,6 +188,17 @@ type task =
 val task_to_yojson : task -> Yojson.Safe.t
 val task_of_yojson : Yojson.Safe.t -> (task, string) result
 
+type task_reclaim_gate =
+  | Reclaim_gate_open
+  | Reclaim_gate_blocked_by_policy of string
+
+val task_reclaim_gate : task -> task_reclaim_gate
+(** Deterministic reclaim gate derived only from typed [reclaim_policy].
+    Free-text [do_not_reclaim_reason] can explain a typed block, but cannot
+    close the gate by itself. *)
+
+val task_reclaim_gate_block_reason : task -> string option
+
 type message =
   { seq : int
   ; from_agent : string [@key "from"]

--- a/test/test_coordination_product.ml
+++ b/test/test_coordination_product.ml
@@ -42,6 +42,7 @@ let task ?goal_id ?(task_status = Masc_domain.Todo) ~id ~title () : Masc_domain.
   ; contract = None
   ; handoff_context = None
   ; cycle_count = 0
+  ; reclaim_policy = None
   ; do_not_reclaim_reason = None
   }
 ;;

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -276,6 +276,7 @@ let awaiting_verification_task ~id ~title ~verification_id =
    ; contract = None
    ; handoff_context = None
    ; cycle_count = 0
+   ; reclaim_policy = None
    ; do_not_reclaim_reason = None
    }
     : Masc_domain.task)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -10872,6 +10872,7 @@ let test_direct_keeper_msg_observation_keeps_durable_verification_signal () =
          ; contract = None
          ; handoff_context = None
          ; cycle_count = 0
+         ; reclaim_policy = None
          ; do_not_reclaim_reason = None
          }
        in

--- a/test/test_keeper_wip_admission.ml
+++ b/test/test_keeper_wip_admission.ml
@@ -23,6 +23,7 @@ let task ?worktree ?goal_id ?(status = Masc_domain.Todo) ?(title = "fix: task") 
   ; contract = None
   ; handoff_context = None
   ; cycle_count = 0
+  ; reclaim_policy = None
   ; do_not_reclaim_reason = None
   }
 

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -624,6 +624,10 @@ let test_release_hard_stop_blocks_future_claim_next () =
       "hard-stop reason persisted"
       (Some "PR #6561 belongs to a completed upstream scope")
       task_001.do_not_reclaim_reason;
+    Alcotest.(check (option string))
+      "typed hard-stop persisted"
+      (Some "block_reclaim")
+      (Option.map Masc_domain.task_reclaim_policy_to_string task_001.reclaim_policy);
     match Coord.claim_next_r config ~agent_name:agent_llm_a () with
     | Coord.Claim_next_claimed { task_id; _ } ->
       Alcotest.(check string) "claim_next skips blocked todo" "task-002" task_id
@@ -659,7 +663,7 @@ let test_release_hard_stop_blocks_direct_reclaim () =
     match Coord.claim_task_r config ~agent_name:agent_llm_a ~task_id:"task-001" () with
     | Error (Masc_domain.Task (Masc_domain.Task_error.InvalidState message)) ->
       Alcotest.(check bool)
-        "direct claim blocked by do_not_reclaim_reason"
+        "direct claim blocked by typed reclaim_policy"
         true
         (str_contains message "blocked from re-claim")
     | Error e ->
@@ -686,7 +690,7 @@ let task_by_id config task_id =
   | None -> Alcotest.failf "%s not found" task_id
 ;;
 
-let test_claim_next_uses_legacy_auto_cycle_as_fallback () =
+let test_claim_next_ignores_legacy_auto_cycle_text () =
   with_test_env (fun config ->
     let agent_llm_a = find_agent_name_by_prefix config "agent_llm_a" in
     let _ =
@@ -705,20 +709,20 @@ let test_claim_next_uses_legacy_auto_cycle_as_fallback () =
     write_tasks config tasks;
     match Coord.claim_next_r config ~agent_name:agent_llm_a () with
     | Coord.Claim_next_claimed { task_id; _ } ->
-      Alcotest.(check string) "fallback claim" "task-001" task_id;
+      Alcotest.(check string) "legacy text does not block claim" "task-001" task_id;
       let task = task_by_id config task_id in
       Alcotest.(check (option string))
-        "legacy soft block cleared"
+        "legacy text cleared after claim"
         None
         task.do_not_reclaim_reason
     | Coord.Claim_next_no_eligible _ ->
-      Alcotest.fail "legacy auto-cycle reason should be fallback claimable"
+      Alcotest.fail "legacy auto-cycle text should be claimable"
     | Coord.Claim_next_no_unclaimed ->
-      Alcotest.fail "expected one fallback-claimable task"
+      Alcotest.fail "expected one claimable task"
     | Coord.Claim_next_error msg -> Alcotest.fail msg)
 ;;
 
-let test_claim_next_does_not_parse_routing_handoff_string_as_soft () =
+let test_claim_next_ignores_routing_handoff_text () =
   with_test_env (fun config ->
     let agent_llm_a = find_agent_name_by_prefix config "agent_llm_a" in
     let _ =
@@ -746,7 +750,7 @@ let test_claim_next_does_not_parse_routing_handoff_string_as_soft () =
     write_tasks config tasks;
     match Coord.claim_next_r config ~agent_name:agent_llm_a () with
     | Coord.Claim_next_claimed { task_id; _ } ->
-      Alcotest.(check string) "free-text hard-stop remains blocked" "task-002" task_id
+      Alcotest.(check string) "free-text routing handoff remains claimable" "task-001" task_id
     | Coord.Claim_next_no_eligible _ ->
       Alcotest.fail "normal unblocked task should remain claimable"
     | Coord.Claim_next_no_unclaimed ->
@@ -754,7 +758,7 @@ let test_claim_next_does_not_parse_routing_handoff_string_as_soft () =
     | Coord.Claim_next_error msg -> Alcotest.fail msg)
 ;;
 
-let test_claim_next_prefers_unblocked_over_legacy_auto_cycle () =
+let test_claim_next_does_not_deprioritize_legacy_text () =
   with_test_env (fun config ->
     let agent_llm_a = find_agent_name_by_prefix config "agent_llm_a" in
     let _ =
@@ -784,7 +788,7 @@ let test_claim_next_prefers_unblocked_over_legacy_auto_cycle () =
     write_tasks config tasks;
     match Coord.claim_next_r config ~agent_name:agent_llm_a () with
     | Coord.Claim_next_claimed { task_id; _ } ->
-      Alcotest.(check string) "unblocked work is primary" "task-002" task_id
+      Alcotest.(check string) "priority still wins despite legacy text" "task-001" task_id
     | Coord.Claim_next_no_eligible _ ->
       Alcotest.fail "normal unblocked task should be claimed before fallback"
     | Coord.Claim_next_no_unclaimed -> Alcotest.fail "expected claimable tasks"
@@ -813,7 +817,7 @@ let test_release_cycles_do_not_create_auto_do_not_reclaim () =
         ("retryable task should remain claimable: " ^ Masc_domain.masc_error_to_string e))
 ;;
 
-let test_release_cycle_15_creates_auto_hard_stop () =
+let test_release_cycle_15_does_not_create_auto_hard_stop () =
   with_test_env (fun config ->
     let agent_llm_a = find_agent_name_by_prefix config "agent_llm_a" in
     let _ = Coord.add_task config ~title:"Oscillating task" ~priority:1 ~description:"" in
@@ -822,7 +826,7 @@ let test_release_cycle_15_creates_auto_hard_stop () =
       List.map
         (fun (t : Masc_domain.task) ->
            if String.equal t.id "task-001"
-           then { t with cycle_count = 14; do_not_reclaim_reason = None }
+           then { t with cycle_count = 14; reclaim_policy = None; do_not_reclaim_reason = None }
            else t)
         backlog.tasks
     in
@@ -834,24 +838,20 @@ let test_release_cycle_15_creates_auto_hard_stop () =
      | Ok _ -> ()
      | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e));
     let task = task_by_id config "task-001" in
-    Alcotest.(check int) "cycle count reaches hard-stop threshold" 15 task.cycle_count;
-    let reason =
-      match task.do_not_reclaim_reason with
-      | Some reason -> reason
-      | None -> Alcotest.fail "expected auto oscillation hard stop"
-    in
-    Alcotest.(check bool)
-      "reason names oscillation"
-      true
-      (str_contains reason "claim-release oscillation threshold");
+    Alcotest.(check int) "cycle count reaches former threshold" 15 task.cycle_count;
+    Alcotest.(check (option string))
+      "no auto typed hard-stop"
+      None
+      (Option.map Masc_domain.task_reclaim_policy_to_string task.reclaim_policy);
+    Alcotest.(check (option string))
+      "no auto hard-stop reason"
+      None
+      task.do_not_reclaim_reason;
     match Coord.claim_task_r config ~agent_name:agent_llm_a ~task_id:"task-001" () with
-    | Ok _ -> Alcotest.fail "oscillating task should be blocked from reclaim"
+    | Ok _ -> ()
     | Error e ->
-      let msg = Masc_domain.masc_error_to_string e in
-      Alcotest.(check bool)
-        "claim error carries hard-stop reason"
-        true
-        (str_contains msg "operator review required"))
+      Alcotest.fail
+        ("cycle count alone should not block reclaim: " ^ Masc_domain.masc_error_to_string e))
 ;;
 
 let test_claim_next_allows_failed_verification_repair () =
@@ -1829,6 +1829,7 @@ let test_append_archive_tasks () =
       ; contract = None
       ; handoff_context = None
       ; cycle_count = 0
+      ; reclaim_policy = None
       ; do_not_reclaim_reason = None
       }
     in
@@ -1903,25 +1904,25 @@ let () =
             `Quick
             test_release_hard_stop_blocks_direct_reclaim
         ; Alcotest.test_case
-            "legacy auto-cycle block is fallback claimable"
+            "legacy auto-cycle text is ignored"
             `Quick
-            test_claim_next_uses_legacy_auto_cycle_as_fallback
+            test_claim_next_ignores_legacy_auto_cycle_text
         ; Alcotest.test_case
-            "routing handoff string is not a soft fallback"
+            "routing handoff text is ignored"
             `Quick
-            test_claim_next_does_not_parse_routing_handoff_string_as_soft
+            test_claim_next_ignores_routing_handoff_text
         ; Alcotest.test_case
-            "unblocked tasks beat legacy auto-cycle fallback"
+            "legacy text does not alter priority"
             `Quick
-            test_claim_next_prefers_unblocked_over_legacy_auto_cycle
+            test_claim_next_does_not_deprioritize_legacy_text
         ; Alcotest.test_case
             "release cycles do not create auto block"
             `Quick
             test_release_cycles_do_not_create_auto_do_not_reclaim
         ; Alcotest.test_case
-            "cycle 15 release creates auto hard stop"
+            "cycle 15 release does not create auto hard stop"
             `Quick
-            test_release_cycle_15_creates_auto_hard_stop
+            test_release_cycle_15_does_not_create_auto_hard_stop
         ; Alcotest.test_case
             "failed verification stays repair-claimable"
             `Quick

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -586,10 +586,11 @@ let test_release_hard_stop_blocks_future_claim_next () =
     let _ = Coord.add_task config ~title:"Healthy task" ~priority:2 ~description:"" in
     let _ = Coord.claim_task config ~agent_name:agent_llm_a ~task_id:"task-001" in
     let handoff_context : Masc_domain.task_handoff_context =
-      { summary = "PR #6561 not found - do not reclaim"
+      { summary = "PR #6561 belongs to a completed upstream scope"
       ; reason = Some "phantom artifact"
       ; next_step = Some "cancel the stale task"
       ; failure_mode = Some "not_found"
+      ; reclaim_policy = Some Masc_domain.Block_reclaim
       ; evidence_refs = [ "PR#6561" ]
       ; updated_at = None
       ; updated_by = Some agent_llm_a
@@ -621,7 +622,7 @@ let test_release_hard_stop_blocks_future_claim_next () =
     Alcotest.(check int) "release increments cycle count" 1 task_001.cycle_count;
     Alcotest.(check (option string))
       "hard-stop reason persisted"
-      (Some "PR #6561 not found - do not reclaim")
+      (Some "PR #6561 belongs to a completed upstream scope")
       task_001.do_not_reclaim_reason;
     match Coord.claim_next_r config ~agent_name:agent_llm_a () with
     | Coord.Claim_next_claimed { task_id; _ } ->
@@ -635,10 +636,11 @@ let test_release_hard_stop_blocks_direct_reclaim () =
     let _ = Coord.add_task config ~title:"Phantom task" ~priority:1 ~description:"" in
     let _ = Coord.claim_task config ~agent_name:agent_llm_a ~task_id:"task-001" in
     let handoff_context : Masc_domain.task_handoff_context =
-      { summary = "PR #6561 not found - do not reclaim"
+      { summary = "PR #6561 belongs to a completed upstream scope"
       ; reason = Some "phantom artifact"
       ; next_step = Some "cancel the stale task"
       ; failure_mode = Some "not_found"
+      ; reclaim_policy = Some Masc_domain.Block_reclaim
       ; evidence_refs = [ "PR#6561" ]
       ; updated_at = None
       ; updated_by = Some agent_llm_a
@@ -716,11 +718,14 @@ let test_claim_next_uses_legacy_auto_cycle_as_fallback () =
     | Coord.Claim_next_error msg -> Alcotest.fail msg)
 ;;
 
-let test_claim_next_uses_routing_handoff_as_fallback () =
+let test_claim_next_does_not_parse_routing_handoff_string_as_soft () =
   with_test_env (fun config ->
     let agent_llm_a = find_agent_name_by_prefix config "agent_llm_a" in
     let _ =
       Coord.add_task config ~title:"Rerouted coding task" ~priority:1 ~description:""
+    in
+    let _ =
+      Coord.add_task config ~title:"Normal lower-priority work" ~priority:5 ~description:""
     in
     let backlog = Coord.read_backlog config in
     let tasks =
@@ -741,16 +746,11 @@ let test_claim_next_uses_routing_handoff_as_fallback () =
     write_tasks config tasks;
     match Coord.claim_next_r config ~agent_name:agent_llm_a () with
     | Coord.Claim_next_claimed { task_id; _ } ->
-      Alcotest.(check string) "fallback claim" "task-001" task_id;
-      let task = task_by_id config task_id in
-      Alcotest.(check (option string))
-        "routing handoff cleared"
-        None
-        task.do_not_reclaim_reason
+      Alcotest.(check string) "free-text hard-stop remains blocked" "task-002" task_id
     | Coord.Claim_next_no_eligible _ ->
-      Alcotest.fail "routing handoff reason should be fallback claimable"
+      Alcotest.fail "normal unblocked task should remain claimable"
     | Coord.Claim_next_no_unclaimed ->
-      Alcotest.fail "expected one fallback-claimable task"
+      Alcotest.fail "expected normal unblocked task"
     | Coord.Claim_next_error msg -> Alcotest.fail msg)
 ;;
 
@@ -1907,9 +1907,9 @@ let () =
             `Quick
             test_claim_next_uses_legacy_auto_cycle_as_fallback
         ; Alcotest.test_case
-            "routing handoff block is fallback claimable"
+            "routing handoff string is not a soft fallback"
             `Quick
-            test_claim_next_uses_routing_handoff_as_fallback
+            test_claim_next_does_not_parse_routing_handoff_string_as_soft
         ; Alcotest.test_case
             "unblocked tasks beat legacy auto-cycle fallback"
             `Quick

--- a/test/test_task_cache_invariant_13397.ml
+++ b/test/test_task_cache_invariant_13397.ml
@@ -96,6 +96,7 @@ let make_task ~id ~status =
   ; contract = None
   ; handoff_context = None
   ; cycle_count = 0
+  ; reclaim_policy = None
   ; do_not_reclaim_reason = None
   }
 

--- a/test/test_task_sandbox.ml
+++ b/test/test_task_sandbox.ml
@@ -271,6 +271,7 @@ let task ?worktree ?(files = []) ~id ~title ~description () : Masc_domain.task =
     contract = None;
     handoff_context = None;
     cycle_count = 0;
+    reclaim_policy = None;
     do_not_reclaim_reason = None;
   }
 

--- a/test/test_task_stage.ml
+++ b/test/test_task_stage.ml
@@ -74,7 +74,7 @@ let test_task_with_stage () =
     worktree = None;
     created_by = None;
     stage = Some Task_stage.Implement;
-    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
+    contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
   } in
   let json = Types_core.task_to_yojson task in
   match Types_core.task_of_yojson json with
@@ -92,7 +92,7 @@ let test_task_without_stage () =
     worktree = None;
     created_by = None;
     stage = None;
-    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
+    contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
   } in
   let json = Types_core.task_to_yojson task in
   match Types_core.task_of_yojson json with

--- a/test/test_tempo_coverage.ml
+++ b/test/test_tempo_coverage.ml
@@ -126,7 +126,7 @@ let make_task ~id ~status : Masc_domain.task = {
   worktree = None;
   created_by = None;
   stage = None;
-  contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
+  contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
 }
 
 let test_is_pending_task_todo () =
@@ -165,7 +165,7 @@ let make_task_with_priority ~id ~priority : Masc_domain.task = {
   worktree = None;
   created_by = None;
   stage = None;
-  contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
+  contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
 }
 
 let test_calculate_adaptive_tempo_empty () =

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1888,7 +1888,7 @@ let () = test "transition_submit_pr_evidence_accepts_todo_pr_evidence_without_re
     assert (Planning_eio.get_current_task ctx.config = None))
 )
 
-let () = test "transition_claim_clears_stale_do_not_reclaim_reason" (fun () ->
+let () = test "transition_claim_clears_legacy_cycle_do_not_reclaim_reason" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx_with_agent "agent_code-mcp-client" in
     let result =
@@ -1900,8 +1900,7 @@ let () = test "transition_claim_clears_stale_do_not_reclaim_reason" (fun () ->
           ])
     in
     if not result.Tool_result.success then failwith result.Tool_result.message;
-    set_only_task_do_not_reclaim_reason ctx
-      "Auto-claimed via auto_goal_fallback by issue_king without repo write tools";
+    set_only_task_do_not_reclaim_reason ctx "auto: 3 releases";
     let claim_result =
       Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
         (`Assoc
@@ -1915,7 +1914,7 @@ let () = test "transition_claim_clears_stale_do_not_reclaim_reason" (fun () ->
     assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
 )
 
-let () = test "transition_claim_clears_missing_worktree_soft_block" (fun () ->
+let () = test "transition_release_free_text_not_found_stays_reclaimable" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx_with_agent "agent_code-mcp-client" in
     let result =
@@ -1927,9 +1926,6 @@ let () = test "transition_claim_clears_missing_worktree_soft_block" (fun () ->
           ])
     in
     if not result.Tool_result.success then failwith result.Tool_result.message;
-    set_only_task_do_not_reclaim_reason ctx
-      "worktree path not found, spinning on path resolution for multiple turns, \
-       releasing to unblock";
     let claim_result =
       Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
         (`Assoc
@@ -1939,28 +1935,50 @@ let () = test "transition_claim_clears_missing_worktree_soft_block" (fun () ->
           ])
     in
     if not claim_result.Tool_result.success then failwith claim_result.Tool_result.message;
-    assert_task_claimed_by ctx "agent_code-mcp-client";
+    let release_result =
+      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "release");
+            ( "handoff_context",
+              `Assoc
+                [
+                  ( "summary",
+                    `String
+                      "worktree path not found, spinning on path resolution for \
+                       multiple turns, releasing to unblock" );
+                ] );
+          ])
+    in
+    if not release_result.Tool_result.success then failwith release_result.Tool_result.message;
+    assert_task_todo ctx;
     assert ((only_task ctx).do_not_reclaim_reason = None);
+    let reclaim_result =
+      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "claim");
+          ])
+    in
+    if not reclaim_result.Tool_result.success then failwith reclaim_result.Tool_result.message;
+    assert_task_claimed_by ctx "agent_code-mcp-client";
     assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
 )
 
-let () = test "transition_claim_keeps_hard_stop_with_soft_markers" (fun () ->
+let () = test "transition_release_block_reclaim_policy_blocks_claim" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx_with_agent "agent_code-mcp-client" in
     let result =
       Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
         (`Assoc
           [
-            ("title", `String "Hard-stop remains blocked");
+            ("title", `String "Terminal mismatch");
             ("priority", `Int 1);
           ])
     in
     if not result.Tool_result.success then failwith result.Tool_result.message;
-    let reason =
-      "do not reclaim: worktree path not found during path resolution, releasing \
-       to unblock"
-    in
-    set_only_task_do_not_reclaim_reason ctx reason;
     let claim_result =
       Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
         (`Assoc
@@ -1969,11 +1987,36 @@ let () = test "transition_claim_keeps_hard_stop_with_soft_markers" (fun () ->
             ("action", `String "claim");
           ])
     in
-    assert (not claim_result.Tool_result.success);
-    assert (str_contains claim_result.Tool_result.message "blocked from re-claim");
+    if not claim_result.Tool_result.success then failwith claim_result.Tool_result.message;
+    let release_result =
+      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "release");
+            ( "handoff_context",
+              `Assoc
+                [
+                  ("summary", `String "upstream PR already completed this scope");
+                  ("reclaim_policy", `String "block_reclaim");
+                ] );
+          ])
+    in
+    if not release_result.Tool_result.success then failwith release_result.Tool_result.message;
     assert_task_todo ctx;
-    assert ((only_task ctx).do_not_reclaim_reason = Some reason);
-    assert (Planning_eio.get_current_task ctx.config = None))
+    assert
+      ((only_task ctx).do_not_reclaim_reason
+       = Some "upstream PR already completed this scope");
+    let reclaim_result =
+      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "claim");
+          ])
+    in
+    assert (not reclaim_result.Tool_result.success);
+    assert (str_contains reclaim_result.Tool_result.message "blocked from re-claim"))
 )
 
 let () = test "dispatch_transition_claim_uses_server_surface_not_payload_surface" (fun () ->

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1967,7 +1967,7 @@ let () = test "transition_release_free_text_not_found_stays_reclaimable" (fun ()
     assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
 )
 
-let () = test "transition_release_block_reclaim_policy_blocks_claim" (fun () ->
+let () = test "transition_release_block_reclaim_policy_closes_gate" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx_with_agent "agent_code-mcp-client" in
     let result =

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -2007,6 +2007,7 @@ let () = test "transition_release_block_reclaim_policy_blocks_claim" (fun () ->
     assert
       ((only_task ctx).do_not_reclaim_reason
        = Some "upstream PR already completed this scope");
+    assert ((only_task ctx).reclaim_policy = Some Masc_domain.Block_reclaim);
     let reclaim_result =
       Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
         (`Assoc

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -1176,6 +1176,7 @@ let () =
             created_by = None;
             stage = None; contract = None; handoff_context = None;
             cycle_count = 0;
+            reclaim_policy = None;
             do_not_reclaim_reason = None; }
         in
         Alcotest.(check bool) "Todo -> claim pool" true

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -550,7 +550,7 @@ let test_backlog_to_yojson_with_tasks () =
     worktree = None;
     created_by = None;
     stage = None;
-    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
+    contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
   } in
   let b : Masc_domain.backlog = { tasks = [task]; last_updated = "2024-01-15T12:00:00Z"; version = 2 } in
   let json = Masc_domain.backlog_to_yojson b in
@@ -1322,7 +1322,7 @@ let test_task_to_yojson () =
     worktree = None;
     created_by = None;
     stage = None;
-    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
+    contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
   } in
   let json = Masc_domain.task_to_yojson t in
   match json with
@@ -1351,7 +1351,7 @@ let test_task_to_yojson_with_worktree () =
     worktree = Some wt;
     created_by = None;
     stage = None;
-    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
+    contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
   } in
   let json = Masc_domain.task_to_yojson t in
   match json with

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -1381,6 +1381,54 @@ let test_task_of_yojson_error () =
   | Error _ -> ()
   | Ok _ -> fail "expected Error (missing title)"
 
+let test_task_reclaim_gate_ignores_free_text_without_policy () =
+  let t : Masc_domain.task = {
+    id = "task-004";
+    title = "Retryable task";
+    description = "";
+    task_status = Masc_domain.Todo;
+    goal_id = None;
+    priority = 1;
+    files = [];
+    created_at = "2024-01-15T12:00:00Z";
+    worktree = None;
+    created_by = None;
+    stage = None;
+    contract = None;
+    handoff_context = None;
+    cycle_count = 9;
+    reclaim_policy = None;
+    do_not_reclaim_reason = Some "worktree path not found";
+  } in
+  match Masc_domain.task_reclaim_gate t with
+  | Masc_domain.Reclaim_gate_open -> ()
+  | Masc_domain.Reclaim_gate_blocked_by_policy reason ->
+    fail ("free text must not block reclaim: " ^ reason)
+
+let test_task_reclaim_gate_blocks_only_typed_policy () =
+  let t : Masc_domain.task = {
+    id = "task-005";
+    title = "Terminal task";
+    description = "";
+    task_status = Masc_domain.Todo;
+    goal_id = None;
+    priority = 1;
+    files = [];
+    created_at = "2024-01-15T12:00:00Z";
+    worktree = None;
+    created_by = None;
+    stage = None;
+    contract = None;
+    handoff_context = None;
+    cycle_count = 0;
+    reclaim_policy = Some Masc_domain.Block_reclaim;
+    do_not_reclaim_reason = Some "operator hard stop";
+  } in
+  match Masc_domain.task_reclaim_gate t with
+  | Masc_domain.Reclaim_gate_blocked_by_policy reason ->
+    check string "reason" "operator hard stop" reason
+  | Masc_domain.Reclaim_gate_open -> fail "typed block policy must close reclaim gate"
+
 (* ============================================================
    a2a_task_to/of_yojson Tests
    ============================================================ *)
@@ -1780,6 +1828,10 @@ let () =
       test_case "to_yojson with worktree" `Quick test_task_to_yojson_with_worktree;
       test_case "of_yojson ok" `Quick test_task_of_yojson_ok;
       test_case "of_yojson error" `Quick test_task_of_yojson_error;
+      test_case "reclaim gate ignores free text" `Quick
+        test_task_reclaim_gate_ignores_free_text_without_policy;
+      test_case "reclaim gate blocks typed policy" `Quick
+        test_task_reclaim_gate_blocks_only_typed_policy;
     ];
     "a2a_task_yojson", [
       test_case "to_yojson" `Quick test_a2a_task_to_yojson;

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -445,7 +445,7 @@ let test_task_roundtrip () =
     worktree = None;
     created_by = None;
     stage = None;
-    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
+    contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
   } in
   let json = Masc_domain.task_to_yojson task in
   let result = Masc_domain.task_of_yojson json in
@@ -469,7 +469,7 @@ let test_task_with_worktree () =
     };
     created_by = None;
     stage = None;
-    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
+    contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
   } in
   let json = Masc_domain.task_to_yojson task in
   let result = Masc_domain.task_of_yojson json in
@@ -487,13 +487,13 @@ let test_backlog_roundtrip () =
         created_at = "2024-01-01T00:00:00Z"; worktree = None;
         created_by = None;
         stage = None;
-        contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None };
+        contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None };
       { id = "t2"; title = "Task 2"; description = "Desc 2";
         task_status = Done { assignee = "a"; completed_at = "2024-01-02T00:00:00Z"; notes = None };
         goal_id = None; priority = 2; files = []; created_at = "2024-01-01T01:00:00Z"; worktree = None;
         created_by = None;
         stage = None;
-        contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None };
+        contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None };
     ];
     last_updated = "2024-01-02T00:00:00Z";
     version = 5;


### PR DESCRIPTION
## Summary
- Move reclaim blocking from free-text `do_not_reclaim_reason` into typed task state: `task.reclaim_policy`.
- Keep `do_not_reclaim_reason` as diagnostic text only; it no longer decides claimability.
- Persist hard stops only from explicit typed input: `handoff_context.reclaim_policy = "block_reclaim"`.
- Remove legacy soft/hard parsing paths for auto-cycle strings, routing handoff text, missing-worktree text, and the numeric release-count hard stop.
- Stop synthesizing reclaim hard-stops from free-text cancel reasons.

## Boundary
- Non-deterministic/free-text fields (`summary`, `reason`, `next_step`, `failure_mode`, `do_not_reclaim_reason`) do not decide hard reclaim blocking.
- Deterministic state (`task.reclaim_policy`) is the only reclaim hard-stop gate.
- Release cycles remain observable through `cycle_count`, but cycle count alone no longer seals a task.

## Validation
- `ocamlformat --check lib/types/types_core.ml lib/types/types_core.mli lib/coord/coord_task_claim.ml lib/coord/coord_task_claim.mli lib/coord/coord_task_transition_executor.ml lib/coord/coord_task_transitions.ml lib/coord/coord_task.ml lib/coord/coord_task_schedule.ml lib/coord/coord_task_schedule.mli lib/coordination_product.ml lib/coord/coord_task_create.ml test/test_room_coverage.ml test/test_tool_task_coverage.ml test/test_keeper_task_dispatch.ml test/test_keeper_unified.ml test/test_coordination_product.ml test/test_keeper_wip_admission.ml test/test_types.ml test/test_task_sandbox.ml test/test_task_cache_invariant_13397.ml test/test_tempo_coverage.ml test/test_types_coverage.ml test/test_types_utils_coverage.ml test/test_task_stage.ml`
- `git diff --check`

## Local Dune note
- `scripts/dune-local.sh build test/test_tool_task_coverage.exe test/test_room_coverage.exe` could not start locally because live bare `dune build --root .` processes are bypassing the machine-wide wrapper lock.
