### PR TITLE
fix(keeper): add TTL to failure counter entries (#18501)

### DIFF
--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -97,7 +97,7 @@ let dispatch
     (* ── Tier A: config + agent_name only ──────────────────────── *)
     | Mod_plan -> Tool_plan.dispatch { config } ~name ~args
     | Mod_local_runtime ->
-      Tool_local_runtime.dispatch { Tool_local_runtime.config; agent_name } ~name ~args
+      Tool_local_runtime.dispatch ({ Tool_local_runtime_core.config; agent_name } : Tool_local_runtime_core.context) ~name ~args
       |> Option.map (fun (success, message) ->
         if success then ok message else err message)
     | Mod_worktree ->

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -104,7 +104,7 @@ let failure_count_get counts key =
     match Hashtbl.find_opt counts.table key with
     | None -> 0
     | Some count ->
-      let now = Unix.gettimeofday () in
+      let now = Time_compat.now () in
       match Hashtbl.find_opt counts.failure_timestamps key with
       | Some ts when now -. ts <= failure_count_ttl_seconds -> count
       | _ ->
@@ -121,7 +121,7 @@ let failure_count_record_failure counts key =
       | None -> 1
     in
     Hashtbl.replace counts.table key next;
-    Hashtbl.replace counts.failure_timestamps key (Unix.gettimeofday ());
+    Hashtbl.replace counts.failure_timestamps key (Time_compat.now ());
     next)
 ;;
 
@@ -139,7 +139,7 @@ let failure_count_reset counts key =
 let failure_count_jump_to counts key ~target =
   Mutex.protect counts.mutex (fun () ->
     Hashtbl.replace counts.table key target;
-    Hashtbl.replace counts.failure_timestamps key (Unix.gettimeofday ());
+    Hashtbl.replace counts.failure_timestamps key (Time_compat.now ());
     target)
 ;;
 
@@ -187,7 +187,7 @@ let inject_stale_failure_count_for_test counts key count =
   Mutex.protect counts.mutex (fun () ->
     Hashtbl.replace counts.table key count;
     Hashtbl.replace counts.failure_timestamps key
-      (Unix.gettimeofday () -. (failure_count_ttl_seconds +. 60.)))
+      (Time_compat.now () -. (failure_count_ttl_seconds +. 60.)))
 ;;
 
 open Keeper_tools_oas_workflow

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -75,8 +75,14 @@ type workflow_rejection_block = Keeper_tools_oas_workflow.workflow_rejection_blo
 
 type workflow_rejection_info = Keeper_tools_oas_workflow.workflow_rejection_info
 
+(* TTL for per-(tool, args_hash) failure counters (#18501).
+   After this many seconds since the last failure, the counter
+   resets — transient errors no longer cause a permanent ban. *)
+let failure_count_ttl_seconds = 1800.
+
 type failure_counts =
   { table : (string, int) Hashtbl.t
+  ; failure_timestamps : (string, float) Hashtbl.t
   ; workflow_table : (string, int) Hashtbl.t
   ; workflow_block_table : (string, workflow_rejection_block) Hashtbl.t
   ; mutex : Mutex.t
@@ -84,6 +90,7 @@ type failure_counts =
 
 let create_failure_counts () =
   { table = Hashtbl.create 16
+  ; failure_timestamps = Hashtbl.create 16
   ; workflow_table = Hashtbl.create 16
   ; workflow_block_table = Hashtbl.create 16
   ; mutex = Mutex.create ()
@@ -94,7 +101,16 @@ let reset_tool_retry_dedupe_for_testing = Keeper_tool_retry_state.reset_for_test
 
 let failure_count_get counts key =
   Mutex.protect counts.mutex (fun () ->
-    Option.value ~default:0 (Hashtbl.find_opt counts.table key))
+    match Hashtbl.find_opt counts.table key with
+    | None -> 0
+    | Some count ->
+      let now = Unix.gettimeofday () in
+      match Hashtbl.find_opt counts.failure_timestamps key with
+      | Some ts when now -. ts <= failure_count_ttl_seconds -> count
+      | _ ->
+        Hashtbl.remove counts.table key;
+        Hashtbl.remove counts.failure_timestamps key;
+        0)
 ;;
 
 let failure_count_record_failure counts key =
@@ -105,11 +121,14 @@ let failure_count_record_failure counts key =
       | None -> 1
     in
     Hashtbl.replace counts.table key next;
+    Hashtbl.replace counts.failure_timestamps key (Unix.gettimeofday ());
     next)
 ;;
 
 let failure_count_reset counts key =
-  Mutex.protect counts.mutex (fun () -> Hashtbl.remove counts.table key)
+  Mutex.protect counts.mutex (fun () ->
+    Hashtbl.remove counts.table key;
+    Hashtbl.remove counts.failure_timestamps key)
 ;;
 
 (* MASC/OAS Error-Warn Reduction Goal 2026-05-18, P2 reducer:
@@ -120,6 +139,7 @@ let failure_count_reset counts key =
 let failure_count_jump_to counts key ~target =
   Mutex.protect counts.mutex (fun () ->
     Hashtbl.replace counts.table key target;
+    Hashtbl.replace counts.failure_timestamps key (Unix.gettimeofday ());
     target)
 ;;
 
@@ -159,6 +179,15 @@ let workflow_rejection_scope_block_record counts key (info : Keeper_tools_oas_wo
     in
     Hashtbl.replace counts.workflow_block_table key block;
     block.Keeper_tools_oas_workflow.count)
+;;
+
+(* Test-only: inject a failure counter with a stale timestamp so the
+   TTL expiry path in [failure_count_get] can be exercised. *)
+let inject_stale_failure_count_for_test counts key count =
+  Mutex.protect counts.mutex (fun () ->
+    Hashtbl.replace counts.table key count;
+    Hashtbl.replace counts.failure_timestamps key
+      (Unix.gettimeofday () -. (failure_count_ttl_seconds +. 60.)))
 ;;
 
 open Keeper_tools_oas_workflow

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -72,6 +72,12 @@ val workflow_rejection_scope_block_record
   -> Keeper_tools_oas_workflow.workflow_rejection_info
   -> int
 
+(** Test-only: inject a failure counter with [blocked_at] set to
+    [failure_count_ttl_seconds + 60] seconds in the past.
+    The next [failure_count_get] call for [key] will treat it as
+    expired and return 0. *)
+val inject_stale_failure_count_for_test : failure_counts -> string -> int -> unit
+
 (** Reset process-global retry-log dedupe state. Test-only entry point
     for suites that assert the first occurrence of a tool failure emits
     at ERROR. *)

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -571,7 +571,7 @@ let execute_tool_eio
                    Tool_operator.dispatch ctx ~name ~args:coerced_args
                  | Mod_local_runtime ->
                    Tool_local_runtime.dispatch
-                     { Tool_local_runtime.config; agent_name }
+                     ({ Tool_local_runtime_core.config; agent_name } : Tool_local_runtime_core.context)
                      ~name
                      ~args:coerced_args
                    |> Option.map (fun (ok, msg) ->

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1179,6 +1179,24 @@ let test_deterministic_recovery_plan_fields_promote_next_tool () =
     Yojson.Safe.Util.(member "next_args" plan |> member "pattern" |> to_string)
 ;;
 
+(* #18501: stale failure counts must expire after TTL. *)
+let test_failure_count_ttl_expires_stale_entries () =
+  let counts = Keeper_tools_oas.create_failure_counts () in
+  let key = "keeper_bash:123456789" in
+  Keeper_tools_oas.inject_stale_failure_count_for_test counts key 3;
+  Alcotest.(check int) "stale count returns 0" 0
+    (Keeper_tools_oas.failure_count_get counts key)
+;;
+
+let test_failure_count_ttl_fresh_entries_preserved () =
+  let counts = Keeper_tools_oas.create_failure_counts () in
+  let key = "keeper_bash:987654321" in
+  let n = Keeper_tools_oas.failure_count_record_failure counts key in
+  Alcotest.(check int) "recorded 1" 1 n;
+  Alcotest.(check int) "fresh count returns 1" 1
+    (Keeper_tools_oas.failure_count_get counts key)
+;;
+
 let test_workflow_rejection_same_args_short_circuits_after_first_failure () =
   let meta =
     make_test_meta
@@ -1635,6 +1653,14 @@ let () =
             "deterministic recovery plan promotes next tool"
             `Quick
             test_deterministic_recovery_plan_fields_promote_next_tool
+        ; test_case
+            "failure count TTL expires stale entries (#18501)"
+            `Quick
+            test_failure_count_ttl_expires_stale_entries
+        ; test_case
+            "failure count TTL preserves fresh entries (#18501)"
+            `Quick
+            test_failure_count_ttl_fresh_entries_preserved
         ; test_case
             "workflow rejection same args stops after first failure"
             `Quick


### PR DESCRIPTION
## Summary
- `failure_counts`에 `failure_timestamps` 테이블 추가
- `failure_count_get`에서 30분 TTL 만료 체크 후 자동 삭제
- Transient failure로 인한 영구 tool ban 방지

## Problem
per-(tool, args_hash) failure counter에 만료가 없어, transient failure
(네트워크 timeout, DNS blip) 3회 누적 시 해당 인수 조합이 세션 내
영구 차단됨. 성공 시 reset은 있지만 차단 후에는 실행 자체가 안 돼서
reset 불가.

## Test plan
- [x] TTL 만료 테스트 (`inject_stale_failure_count_for_test` → 0 반환)
- [x] TTL 내 fresh entry 보존 테스트
- [ ] CI Build and Test 통과

Closes #18501

🤖 Generated with [Claude Code](https://claude.com/claude-code)