### PR TITLE
fix(keeper): make active_goal_ids advisory, not hard gate

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -163,12 +163,12 @@ let active_goal_scope_json
 
 let claim_scope_context_suffix ~(meta : keeper_meta) claim_goal_scope =
   match claim_goal_scope.Keeper_runtime_contract.mode with
-  | "active_goal_ids" ->
+  | "active_goal_ids" | "active_goal_ids_advisory" ->
     (match meta.active_goal_ids with
      | [] -> " in active goal scope"
      | goal_ids ->
        Printf.sprintf
-         " within active_goal_ids=[%s]"
+         " preferring active_goal_ids=[%s] (advisory)"
          (String.concat ", " goal_ids))
   | "all_tasks" -> " across all tasks"
   | "auto_goal_fallback_all_tasks" -> " after auto-goal fallback to all tasks"
@@ -226,7 +226,7 @@ let missing_required_tools_for_claim_scope config ~agent_tool_names ~task_filter
 
 let required_tool_workflow_rejection config ~agent_tool_names claim_goal_scope =
   match claim_goal_scope.Keeper_runtime_contract.mode with
-  | "active_goal_ids" -> None
+  | "active_goal_ids" | "active_goal_ids_advisory" -> None
   | _ -> (
     match
       missing_required_tools_for_claim_scope

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -79,42 +79,43 @@ let resolve_claim_goal_scope ?agent_tool_names
         fallback_reason = None;
       }
   | goal_ids ->
-      let scoped_filter task = task_is_linked_to_keeper_goals goal_ids task in
-      if
-        not
-          (active_goal_ids_have_eligible_claim_task
-             ?agent_tool_names
-             config
-             goal_ids)
-      then
-        if allow_empty_goal_scope_fallback then
-          let is_auto_goal =
-            active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
-          in
-          {
-            task_filter = (fun (_task : Masc_domain.task) -> true);
-            mode =
-              (if is_auto_goal then "auto_goal_fallback_all_tasks"
-               else "empty_goal_scope_fallback_all_tasks");
-            effective_goal_ids = [];
-            fallback_reason =
-              Some
-                (if is_auto_goal then
-                   "auto keeper goal has no claimable linked tasks; falling back to all claimable tasks"
-                 else
-                   "active goal scope has no claimable linked tasks; falling back to all claimable tasks");
-          }
-        else
-          {
-            task_filter = scoped_filter;
-            mode = "active_goal_ids";
-            effective_goal_ids = goal_ids;
-            fallback_reason = None;
-          }
+      let has_scoped_tasks =
+        active_goal_ids_have_eligible_claim_task
+          ?agent_tool_names
+          config
+          goal_ids
+      in
+      let is_auto_goal =
+        active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
+      in
+      (* Advisory mode: active_goal_ids is a preference, not a hard gate.
+         Tasks outside the goal scope are claimable but the keeper receives
+         a warning in its context so it prefers goal-linked tasks. *)
+      if has_scoped_tasks then
+        {
+          task_filter = (fun (_task : Masc_domain.task) -> true);
+          mode = "active_goal_ids_advisory";
+          effective_goal_ids = goal_ids;
+          fallback_reason = None;
+        }
+      else if allow_empty_goal_scope_fallback || is_auto_goal then
+        {
+          task_filter = (fun (_task : Masc_domain.task) -> true);
+          mode =
+            (if is_auto_goal then "auto_goal_fallback_all_tasks"
+             else "empty_goal_scope_fallback_all_tasks");
+          effective_goal_ids = goal_ids;
+          fallback_reason =
+            Some
+              (if is_auto_goal then
+                 "auto keeper goal has no claimable linked tasks; preferring goal-linked but allowing all claimable tasks"
+               else
+                 "active goal scope has no claimable linked tasks; preferring goal-linked but allowing all claimable tasks");
+        }
       else
         {
-          task_filter = scoped_filter;
-          mode = "active_goal_ids";
+          task_filter = (fun (_task : Masc_domain.task) -> true);
+          mode = "active_goal_ids_advisory";
           effective_goal_ids = goal_ids;
           fallback_reason = None;
         }


### PR DESCRIPTION
## Summary
- `resolve_claim_goal_scope`의 `task_filter`가 `active_goal_ids`에 연결되지 않은 task를 hard block하던 것을 advisory로 전환
- keeper ramarama가 52/55 task에서 goal scope filter로 배제되던 문제 해결
- `task_filter`는 항상 `true`, goal scope 정보는 `mode="active_goal_ids_advisory"` + `effective_goal_ids`로 보존

## Changes
- `keeper_runtime_contract.ml`: `scoped_filter` 제거, 모든 분기에서 `task_filter = (fun _ -> true)`. 새 mode `"active_goal_ids_advisory"` 추가
- `keeper_exec_task.ml`: `claim_scope_context_suffix`에 advisory mode 추가 ("preferring ... (advisory)"). `required_tool_workflow_rejection`에 advisory mode 포함

## Design
사용자 지시: "허용은 하고 warn만 주입해서 알려줘야하는 거 아닌가?" — goal scope은 preference, not a gate. Task를 하다 보면 자연스럽게 goal에 연결되는 것이 정상.

## Test plan
- [x] `dune build --root .` 통과
- [ ] keeper ramarama restart 후 52/55 배제 현상 해소 확인
- [ ] advisory mode가 board log/runtime contract JSON에 정상 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)