### PR TITLE
refactor(agent): drop collaboration graph schema residue

### DIFF
--- a/docs/MCP-SURFACE-AUDIT.md
+++ b/docs/MCP-SURFACE-AUDIT.md
@@ -158,7 +158,7 @@ flowchart TD
 | Type | Examples | Status |
 |------|----------|--------|
 | Removed alias ghosts | `masc_claim`, `experiment_start`, `masc_trpg_*` | Deletion target; do not preserve for compatibility |
-| Retired front-door | `masc_collaboration_graph` | Removed from `raw_all_tool_schemas` in `config.ml` but still cited in spec docs |
+| Retired front-door | none in the live MCP/tool spec tables | Previously removed names should stay out of active specs and schemas |
 | Intentional internal-only | `Prompt_registry`, `data/prompts/*.json`, `config/prompts/*.md` | Real runtime feature, not public MCP surface |
 | Experimental but documented | `SWARM-RISC` | Keep clearly labeled as non-canonical or draft |
 | Placeholder / review-needed | none | Dead hidden placeholder removed from the MCP schema inventory |

--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -408,6 +408,12 @@
             <td>Backstop grep is clean for the removed alias symbols across live code and tests. Local OCaml format/parse and diff checks pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>
           <tr>
+            <td><code>keeper_board_delete</code> / <code>keeper_board_cleanup</code> hidden admin aliases</td>
+            <td><span class="status now">draft PR #18504</span></td>
+            <td>Remove keeper-prefixed board admin aliases from schema, timeout, policy, keyword, and dispatch paths while leaving canonical board maintenance ownership intact.</td>
+            <td>Health and Lint are green on the latest CI run. Meta Guards failed and Build/Test is still running; failure logs are not yet available while the workflow run remains active.</td>
+          </tr>
+          <tr>
             <td><code>Tool_local_runtime</code> core facade include</td>
             <td><span class="status done">merged #18496</span></td>
             <td>Remove the top-level <code>include Tool_local_runtime_core</code> from <code>Tool_local_runtime</code>. Core process/model helpers remain owned by <code>Tool_local_runtime_core</code>; <code>Tool_local_runtime</code> keeps only deliberate runtime status/verify/probe/bench adapter exports plus MCP schemas/dispatch.</td>
@@ -454,7 +460,10 @@
     </section>
 
     <section>
-      <h2>Candidate Queue</h2>
+      <h2>Remaining Candidate Queue</h2>
+      <div class="note">
+        Completed or in-flight slices have been removed from this queue and are tracked in the execution ledger above. Keep this table limited to code paths that still need a fresh purge branch.
+      </div>
       <table>
         <thead>
           <tr>
@@ -467,60 +476,11 @@
         </thead>
         <tbody>
           <tr>
-            <td>P0</td>
-            <td><code>Tool_local_runtime</code> top-level core facade</td>
-            <td>The include cascade makes process-discovery helpers, parser helpers, and core record types look like part of the MCP adapter module. That slows ownership audits and lets tests preserve the wrong import path.</td>
-            <td>Delete the top-level <code>include Tool_local_runtime_core</code>; qualify internal calls through <code>Tool_local_runtime_core</code>; move any helper caller/test to the owner module.</td>
-            <td>Grep must prove <code>Tool_local_runtime.split_ws</code> and the top-level include are gone. Keep behavior tests on the owner module.</td>
-          </tr>
-          <tr>
-            <td>P0</td>
-            <td><code>keeper_board_delete</code> / <code>keeper_board_cleanup</code> hidden admin aliases</td>
-            <td>They are hidden from keeper/public discovery but still have keeper-prefixed schema, timeout, policy, search-keyword, and dispatch paths that forward to canonical board maintenance behavior. This keeps two names for one admin operation.</td>
-            <td>Next slice should delete the keeper-prefixed admin aliases and move any remaining policy/test intent to canonical <code>masc_board_delete</code> / board cleanup ownership. Do not delete canonical <code>masc_board_delete</code>.</td>
-            <td>Replace orphan-prevention tests with canonical admin-tool tests; grep for <code>keeper_board_delete</code> / <code>keeper_board_cleanup</code> must be limited to changelog or removed entirely from live code.</td>
-          </tr>
-          <tr>
-            <td>P0</td>
-            <td><code>Cascade_legacy_runner</code></td>
-            <td>Misnames the current cascade observation/audit actor as a legacy runner and spreads misleading dotted module references through Keeper, MCP server, dashboard tools, and tests.</td>
-            <td>Rename to <code>Cascade_observation</code>; do not preserve an alias module.</td>
-            <td>Keep behavior tests under the new module. Delete only tests whose assertion is old-name preservation.</td>
-          </tr>
-          <tr>
-            <td>P0</td>
-            <td>OTel legacy duplicate attributes</td>
-            <td>Dual-emitted legacy keys create two sources of truth for the same span fact and keep dashboards coupled to obsolete names.</td>
-            <td>Emit canonical <code>gen_ai.*</code> plus MASC extension keys only.</td>
-            <td>Replace preservation tests with absence tests.</td>
-          </tr>
-          <tr>
-            <td>P0</td>
-            <td><code>json_ok</code> / <code>json_error</code> aliases in local runtime tools</td>
-            <td>They are explicitly kept for include-cascade compatibility and force lint exceptions to preserve an obsolete helper vocabulary.</td>
-            <td>Delete aliases from <code>Tool_local_runtime_core</code>; call <code>Tool_args</code> directly.</td>
-            <td>No new test needed; static grep plus changed-file build is enough.</td>
-          </tr>
-          <tr>
             <td>P1</td>
             <td><code>Keeper_types</code> compatibility facade</td>
-            <td>Broad re-export surface lets old type paths survive and hides module ownership. It also makes grep-based ownership audits noisy.</td>
+            <td>Broad re-export surface still lets old type paths survive even after several leaf removals, hiding module ownership and keeping grep-based audits noisy.</td>
             <td>Move active callers to owner modules, then shrink the facade to documented public types or delete leaf aliases.</td>
             <td>Delete facade-preservation tests; add owner-module import tests only where public API matters.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td><code>Tool_bridge.to_oas_tool_result</code></td>
-            <td>It keeps a tuple-output adapter alive even though production OAS conversion now consumes <code>Tool_result.t</code>; tests then preserve the obsolete handler shape.</td>
-            <td>Delete the overload and drive tests through <code>to_oas_typed_result</code>.</td>
-            <td>Remove tuple-overload preservation tests. Keep externalization and error-class coverage through typed results.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td><code>Tool_registry.Deprecated_alias</code></td>
-            <td>The registry exposes a deprecated-alias usage bucket even though no live caller records that source. Dashboards and operators can infer there is still a supported alias dispatch path.</td>
-            <td>Delete the variant, counter, and JSON output bucket rather than preserving a permanent zero metric.</td>
-            <td>Replace presence tests with canonical source-shape tests.</td>
           </tr>
           <tr>
             <td>P1</td>
@@ -528,160 +488,6 @@
             <td>Fallback readers such as legacy content arrays, checkpoint sidecars, and dated-store fallback hide whether current writers are clean.</td>
             <td>Split into runtime-data migration and code deletion. Delete read fallback after migration proof or if runtime reset is acceptable.</td>
             <td>Remove tests that require old-row readability. Keep corruption/drop tests only for current schema.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td>Legacy checkpoint shadow cleanup surfaces</td>
-            <td>Recovery no longer reads legacy <code>ckpt-*.json</code>, but count/delete/prune surfaces still imply those files are a supported runtime concern.</td>
-            <td>Delete the lister, operator-clear removal count, dashboard shadow count, and startup prune task.</td>
-            <td>Remove cleanup-preservation expectations; keep only OAS-only recovery absence coverage.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td>Keeper failure metric transient compat arg</td>
-            <td>The failure metric update API accepted <code>?is_transient</code> only to preserve caller shape, then ignored it, making transient classification look like an input to metric state.</td>
-            <td>Delete the optional argument from the metrics facade and keep transient branching only in the keeper turn-control path.</td>
-            <td>No behavior-preservation test is needed; use typecheck plus grep for the removed argument and comment.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td>Keeper bash <code>stages</code> input alias</td>
-            <td>The schema already hid <code>stages</code>, but the handler, typed-input detector, timeout classifier, and resource gate still treated it as an accepted alias for <code>pipeline</code>.</td>
-            <td>Require <code>pipeline</code> as the only public JSON field. Delete the unused schema field helper and every alias branch in parser/gate code.</td>
-            <td>Turn alias path coverage into rejection coverage; keep internal <code>Pipeline.stages</code> tests because that is an implementation record field, not a wire alias.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td><code>masc_transition</code> <code>to</code> / <code>note</code> and status-word action aliases</td>
-            <td>The prehook and handler preserved old target-state vocabulary and a singular note field, keeping two command vocabularies alive for the same transition API.</td>
-            <td>Require canonical <code>action</code> / <code>notes</code> keys and canonical task-action values only; reject retired alias fields before schema middleware.</td>
-            <td>Replace normalization and lenient-parser tests with alias-rejection and canonical-action coverage.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td>Keeper meta <code>_</code> / <code>-</code> separator alias lookup</td>
-            <td>Meta reads silently tried filename variants, so an operator request for one keeper name could resolve a different persisted keeper file and keep naming drift alive.</td>
-            <td>Read only the requested canonical filename component; keep runtime <code>keeper-*-agent</code> derivation as an explicit agent-name path.</td>
-            <td>Add negative coverage for separator alias lookup and remove the exported alias-variant helper.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td>Audit log single-file fallback</td>
-            <td>The audit reader silently switched to old <code>.masc/audit.jsonl</code> when date-split rows were empty, making empty current stores indistinguishable from legacy state.</td>
-            <td>Delete the exported legacy path helper and read only <code>.masc/audit/YYYY-MM/DD.jsonl</code>.</td>
-            <td>No old-file readability test remains; current corruption/drop behavior stays in the date-split reader path.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td>Compaction audit <code>harness-pre-compact</code> fallback</td>
-            <td>The paired compaction audit API mixed current Start/Complete rows with historical pre-compact rows that never had a completion side.</td>
-            <td>Read only <code>data/harness-compact/YYYY-MM/DD.jsonl</code> and reject <code>pre_compact</code> as a paired audit record type.</td>
-            <td>Remove tests/docs that preserve old-row fallback semantics; canonical persist/read/pair tests remain.</td>
-          </tr>
-          <tr>
-            <td>P2</td>
-            <td><code>Agent_identity.from_agent_name</code></td>
-            <td>A public helper existed only to construct identities from a bare display name, bypassing the current MCP params identity contract.</td>
-            <td>Delete the helper and keep identity creation on <code>from_mcp_params</code> / <code>anonymous</code>.</td>
-            <td>Replace helper-based tests with explicit MCP param fixtures; remove the helper-preservation test.</td>
-          </tr>
-          <tr>
-            <td>P2</td>
-            <td><code>Coord_state</code> owner-module re-exports</td>
-            <td>The state module kept old entrypoints for bootstrap, identity, task-id, and backlog helpers after ownership had already moved, keeping grep ownership noisy.</td>
-            <td>Delete the facade re-export block and call owner modules directly.</td>
-            <td>Static caller grep plus changed-file build is the main proof; no behavior-preservation test is needed for removed aliases.</td>
-          </tr>
-          <tr>
-            <td>P2</td>
-            <td><code>Gh_exit_class.to_legacy_result</code></td>
-            <td>The public helper preserved tuple-era result conversion after current callers had already moved to structured <code>gh_result</code>, leaving tests that protected only the obsolete adapter.</td>
-            <td>Delete the helper and its public signature; keep callers on <code>make</code> plus <code>class_</code> / <code>interpretation</code>.</td>
-            <td>Remove the adapter-only tests. Keep classifier and structured-result tests.</td>
-          </tr>
-          <tr>
-            <td>P2</td>
-            <td>Board vote-direction fallbacks</td>
-            <td>Empty <code>direction</code>, unknown persisted vote directions, and the schema-hidden <code>vote</code> argument silently became upvotes, making bad or obsolete input look intentional.</td>
-            <td>Keep missing <code>direction</code> as the documented default, but reject explicit empty/unknown values and the removed <code>vote</code> alias.</td>
-            <td>Replace empty-string compatibility coverage with rejection coverage; add a tool-level negative test for the alias removal.</td>
-          </tr>
-          <tr>
-            <td>P2</td>
-            <td><code>Bounded.constraints.token_buffer</code></td>
-            <td>The deprecated field stayed in the public record and JSON parser solely to tolerate old producers after runtime prediction had moved to empirical p95 usage history.</td>
-            <td>Delete the record field, default value, JSON parser branch, and compatibility-only test.</td>
-            <td>Use static grep for the removed field in bounded code/tests; no old JSON readability test remains.</td>
-          </tr>
-          <tr>
-            <td>P2</td>
-            <td>Cascade capability fallback shim</td>
-            <td>The filter path kept a local legacy resolver for configs without runtime bindings, duplicating capability ownership that now belongs to the Agent SDK runtime-binding layer.</td>
-            <td>Remove the local shim and delegate every provider config to the shared runtime-binding capability resolver.</td>
-            <td>Static grep proves the local fallback and unused registry are gone; provider capability matrix remains the behavior proof target.</td>
-          </tr>
-          <tr>
-            <td>P2</td>
-            <td>Cascade legacy resumable marker</td>
-            <td>The JSON-stream CLI transport accepted a pre-canonical public text marker in addition to the current marker and raw CLI resume hints, keeping an obsolete error string as live behavior.</td>
-            <td>Delete the old marker constant and accept only raw <code>To resume this session:</code> hints plus the canonical <code>Resumable session available via -r.</code> detail text.</td>
-            <td>Backstop grep for the removed string is enough; existing resumable-session tests cover canonical detail and raw hint behavior.</td>
-          </tr>
-          <tr>
-            <td>P2</td>
-            <td>Local runtime health body compat arg</td>
-            <td><code>provider_health_reachable</code> kept an ignored <code>~body</code> parameter only to preserve the older caller shape while the function had already become status-code-only.</td>
-            <td>Remove the body argument from the verify implementation and the public local-runtime re-export.</td>
-            <td>Replace body-payload preservation tests with status-only reachability tests.</td>
-          </tr>
-          <tr>
-            <td>P2</td>
-            <td>Board author legacy mismatch fields</td>
-            <td>Board identity enforcement wrote both canonical <code>meta.author_caller_claim</code> and older author-specific mismatch metadata, leaving two forensic keys for the same spoof claim.</td>
-            <td>Delete <code>record_author_legacy_mismatch</code> and keep only the canonical <code>meta.&lt;field&gt;_caller_claim</code> family.</td>
-            <td>Rewrite tests to assert <code>author_caller_claim</code>; grep proves old keys and reason strings are gone.</td>
-          </tr>
-          <tr>
-            <td>P2</td>
-            <td>Board <code>post_kind = human</code> alias</td>
-            <td><code>Human_post</code> serializes as <code>direct</code>, but the parser and schema still accepted <code>human</code>, keeping two strings for the same wire contract.</td>
-            <td>Delete the <code>human</code> parser arm and schema wording; keep <code>direct</code>, <code>automation</code>, and <code>system</code> as the only accepted inputs.</td>
-            <td>Replace the alias-normalization test with a rejection test for <code>human</code>.</td>
-          </tr>
-          <tr>
-            <td>P2</td>
-            <td>Local runtime probe bool compat projection</td>
-            <td>The probe layer exposed a boolean adapter over the newer typed decision API and used a sentinel model name only to preserve the old run/skip shape.</td>
-            <td>Delete <code>should_attempt_generate_probe</code> and keep callers/tests on <code>decide_generate_probe</code> plus typed skip reasons.</td>
-            <td>Remove projection-only tests; keep typed decision reason assertions.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td>Context compaction legacy anchors</td>
-            <td>Old marker strings still received sticky score treatment, so obsolete memory/goal formats remained first-class in the reducer.</td>
-            <td>Delete the old prefix bindings and score only current anchor markers.</td>
-            <td>Replace legacy-still-sticky tests with negative old-marker tests.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td>Room-state <code>active_agents</code> legacy object entries</td>
-            <td>Recovery accepted both strings and object shapes, making the persisted room-state schema ambiguous and keeping old writer shapes alive.</td>
-            <td>Drop object projection from recovery and repair only canonical string entries.</td>
-            <td>Replace object-recovery preservation tests with object-drop tests.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td>Local-worker compat passthrough schemas</td>
-            <td>The schema set injected six compatibility passthrough tools outside the local-worker surface SSOT, including a catalog-excluded <code>masc_broadcast</code> path.</td>
-            <td>Delete the passthrough constants and compose local-worker schemas only from internal, SDK contract, and catalog-selected public schemas.</td>
-            <td>Delete the passthrough-preservation registry test; keep generic local-worker resolvability tests.</td>
-          </tr>
-          <tr>
-            <td>P2</td>
-            <td>Cascade deprecated profile names</td>
-            <td>The closed deprecated-name set and metrics ratchet keep accepting old configuration vocabulary.</td>
-            <td>Reject old names at config load and delete the deprecated-profile filter metric after catalog fixtures are current.</td>
-            <td>Turn compatibility tests into rejection tests.</td>
           </tr>
           <tr>
             <td>P2</td>

--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -390,16 +390,10 @@
             <td>Backstop grep is clean for the removed re-export symbols. Local OCaml format/parse and diff checks pass; the branch was merged into <code>origin/main</code>.</td>
           </tr>
           <tr>
-            <td><code>keeper.oas_env</code> unified max-token env alias</td>
-            <td><span class="status done">merged #18450</span></td>
-            <td>Remove the legacy <code>KEEPER_UNIFIED_MAX_TOKENS</code> alias from keeper OAS env parsing and keep only <code>MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS</code> plus provider-scoped <code>OAS_&lt;PROVIDER&gt;_*</code> keys.</td>
-            <td>The TOML test now rejects the old alias instead of preserving it. Targeted grep is clean for the removed helper and alias wording; focused Dune remained blocked by the machine-wide guard during local verification.</td>
-          </tr>
-          <tr>
             <td><code>keeper_context_status</code> playground path aliases</td>
-            <td><span class="status now">draft PR #18490</span></td>
+            <td><span class="status done">merged #18490</span></td>
             <td>Remove the one-release <code>playground_bundle</code>, <code>playground_mind</code>, <code>playground_repos</code>, and <code>tool_paths</code> aliases from memory/context status output. The canonical contract remains <code>sandbox_root</code>, <code>sandbox_mind</code>, <code>sandbox_repos</code>, and <code>sandbox_paths</code>.</td>
-            <td>Context-status tests assert the legacy keys are absent while canonical sandbox fields remain populated. Local OCaml format/parse, diff, grep, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
+            <td>Context-status tests assert the legacy keys are absent while canonical sandbox fields remain populated. The branch has been merged into <code>origin/main</code>.</td>
           </tr>
           <tr>
             <td><code>keeper_fs_edit.mode</code> empty-string alias</td>
@@ -415,9 +409,21 @@
           </tr>
           <tr>
             <td><code>Tool_local_runtime</code> core facade include</td>
-            <td><span class="status now">draft PR #18496</span></td>
+            <td><span class="status done">merged #18496</span></td>
             <td>Remove the top-level <code>include Tool_local_runtime_core</code> from <code>Tool_local_runtime</code>. Core process/model helpers remain owned by <code>Tool_local_runtime_core</code>; <code>Tool_local_runtime</code> keeps only deliberate runtime status/verify/probe/bench adapter exports plus MCP schemas/dispatch.</td>
-            <td>The only repo test that reached <code>split_ws</code> through the facade now calls <code>Tool_local_runtime_core.split_ws</code> directly. Local OCaml format/parse, diff, grep, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
+            <td>The facade deletion exposed two lingering context constructors that still qualified the record field through <code>Tool_local_runtime.config</code>. Follow-up compile repair is draft PR #18512.</td>
+          </tr>
+          <tr>
+            <td><code>Tool_local_runtime.config</code> owner-qualified context repair</td>
+            <td><span class="status now">draft PR #18512</span></td>
+            <td>Qualify the local-runtime context record field through <code>Tool_local_runtime_core.config</code> in MCP and keeper tag dispatch after the core facade include was removed.</td>
+            <td><code>rg "Tool_local_runtime\.config" lib test</code> is clean on the branch. Local format, parse, and diff checks pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes. GitHub Build and Test is running.</td>
+          </tr>
+          <tr>
+            <td><code>masc_collaboration_graph</code> schema residue</td>
+            <td><span class="status now">draft PR #18513</span></td>
+            <td>Remove the dead collaboration-format enum exports and schema mirror left behind after the retired <code>masc_collaboration_graph</code> front-door was removed.</td>
+            <td><code>rg "valid_collaboration_format_strings|collaboration_format_enum_strings|Handle masc_collaboration_graph" lib test</code> is clean on the branch. A dispatch test now pins <code>masc_collaboration_graph</code> absence.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.mkdir_p</code> compatibility wrapper</td>

--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -411,7 +411,7 @@
             <td><code>keeper_board_delete</code> / <code>keeper_board_cleanup</code> hidden admin aliases</td>
             <td><span class="status now">draft PR #18504</span></td>
             <td>Remove keeper-prefixed board admin aliases from schema, timeout, policy, keyword, and dispatch paths while leaving canonical board maintenance ownership intact.</td>
-            <td>Health and Lint are green on the latest CI run. Meta Guards failed and Build/Test is still running; failure logs are not yet available while the workflow run remains active.</td>
+            <td>Meta Guards, Health, Lint, and fast ratchets are green on the latest CI run. Build/Test and TLA+ remain in progress.</td>
           </tr>
           <tr>
             <td><code>Tool_local_runtime</code> core facade include</td>

--- a/docs/spec/03-room-coordination.md
+++ b/docs/spec/03-room-coordination.md
@@ -620,7 +620,6 @@ Docker-style `{agent_type}-{adjective}-{animal}`:
 | `masc_get_metrics` | 에이전트 성과 메트릭 |
 | `masc_agent_fitness` | 에이전트 적합도 평가 |
 | `masc_select_agent` | 태스크에 최적 에이전트 선택 |
-| ~`masc_collaboration_graph`~ | 협업 그래프 (retired) |
 | `masc_consolidate_learning` | 학습 통합 |
 | `masc_agent_card` | 에이전트 카드 조회 |
 | `masc_agent_relations` | 에이전트 관계 조회 |

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -52,8 +52,6 @@ let agent_card_action_of_string raw =
   | "refresh" -> Some Agent_card_refresh
   | _ -> None
 
-let valid_collaboration_format_strings = [ "text"; "json" ]
-
 (** Handle masc_agents *)
 let handle_agents ctx args =
   let limit = get_int args "limit" 20 |> max 1 |> min 50 in

--- a/lib/tool_agent.mli
+++ b/lib/tool_agent.mli
@@ -16,10 +16,6 @@ type agent_card_action =
 val agent_card_action_to_string : agent_card_action -> string
 val valid_agent_card_action_strings : string list
 
-(** Issue #8501: Variant SSOT for masc_collaboration_graph.format.
-    Mirror in [Tool_schemas_agent.collaboration_format_enum_strings]. *)
-val valid_collaboration_format_strings : string list
-
 (** Dispatch handler. Returns Some Tool_result.t if handled, None otherwise *)
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> Tool_result.t option
 
@@ -36,8 +32,6 @@ val handle_get_metrics : context -> Yojson.Safe.t -> Tool_result.t
 
 (** Handle masc_agent_fitness *)
 val handle_agent_fitness : context -> Yojson.Safe.t -> Tool_result.t
-
-(** Handle masc_collaboration_graph *)
 
 (** Handle masc_agent_card *)
 val handle_agent_card : context -> Yojson.Safe.t -> Tool_result.t

--- a/lib/tool_schemas/tool_schemas_agent.ml
+++ b/lib/tool_schemas/tool_schemas_agent.ml
@@ -1,15 +1,13 @@
 open Masc_domain
 
 (** Issue #8501: hand-mirrored from
-    [Tool_agent.valid_agent_card_action_strings] and
-    [Tool_agent.valid_collaboration_format_strings]. masc_tool_schemas
+    [Tool_agent.valid_agent_card_action_strings]. masc_tool_schemas
     only depends on masc_types so it cannot derive directly. The sync
     regression test [test_types.ml :: agent_tool_variants_ssot] catches
     drift. Same shape as #8467/#8480/#8484/#8490/#8493 mirror+sync
     pattern. *)
 
 let agent_card_action_enum_strings = [ "get"; "refresh" ]
-let collaboration_format_enum_strings = [ "text"; "json" ]
 
 let schemas : tool_schema list = [
   {

--- a/lib/tool_schemas/tool_schemas_agent.mli
+++ b/lib/tool_schemas/tool_schemas_agent.mli
@@ -13,11 +13,6 @@
     [Tool_agent.valid_agent_card_action_strings]. *)
 val agent_card_action_enum_strings : string list
 
-(** Allowed values for [masc_collaboration_graph] [format]:
-    ["text" | "json"]. Mirror of
-    [Tool_agent.valid_collaboration_format_strings]. *)
-val collaboration_format_enum_strings : string list
-
 (** Tool schemas: [masc_agents], [masc_agent_update],
     [masc_agent_fitness], [masc_get_metrics], [masc_agent_card]. *)
 val schemas : Masc_domain.tool_schema list

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -2,7 +2,7 @@
 
     Tests dispatch routing, handler execution, helper functions for:
     masc_agents, masc_agent_update, masc_get_metrics, masc_agent_fitness,
-    masc_collaboration_graph, masc_agent_card
+    retired masc_collaboration_graph absence, masc_agent_card
 *)
 module Tool_args = Tool_args
 module Tool_result = Tool_result
@@ -131,6 +131,12 @@ let test_dispatch_register_capabilities_removed () =
   with_ctx (fun ctx ->
   let result = Tool_agent.dispatch ctx ~name:"masc_register_capabilities" ~args:(`Assoc []) in
   Alcotest.(check bool) "register_capabilities removed" true (result = None);
+  )
+
+let test_dispatch_collaboration_graph_removed () =
+  with_ctx (fun ctx ->
+  let result = Tool_agent.dispatch ctx ~name:"masc_collaboration_graph" ~args:(`Assoc []) in
+  Alcotest.(check bool) "collaboration graph removed" true (result = None);
   )
 
 let test_dispatch_agent_update () =
@@ -402,6 +408,8 @@ let () =
       Alcotest.test_case "agents dispatches" `Quick test_dispatch_agents;
       Alcotest.test_case "register_capabilities removed" `Quick
         test_dispatch_register_capabilities_removed;
+      Alcotest.test_case "collaboration_graph removed" `Quick
+        test_dispatch_collaboration_graph_removed;
       Alcotest.test_case "agent_update dispatches" `Quick test_dispatch_agent_update;
       Alcotest.test_case "agent_card dispatches" `Quick test_dispatch_agent_card;
     ]);


### PR DESCRIPTION
Plan slice: docs/audit/2026-05-25-legacy-purge-plan.html legacy purge rule, applied to retired masc_collaboration_graph residue outside the active schema/dispatch path.

Changes:
- Remove the dead collaboration format enum exports from Tool_agent and Tool_schemas_agent.
- Add explicit dispatch absence coverage for masc_collaboration_graph.
- Remove the retired collaboration graph row from active spec/audit docs.
- Refresh the HTML legacy purge ledger for #18490/#18496/#18512/#18513 and remove completed/in-flight items from the remaining queue.
- Include the local-runtime context-owner compile repair on this branch so the focused target builds after #18496 removed the facade include.

Verification:
- opam exec -- ocamlformat --check lib/tool_agent.ml lib/tool_agent.mli lib/tool_schemas/tool_schemas_agent.ml lib/tool_schemas/tool_schemas_agent.mli test/test_tool_agent_coverage.ml
- git diff --check origin/main...HEAD
- ocamlc -stop-after parsing lib/tool_agent.ml lib/tool_agent.mli lib/tool_schemas/tool_schemas_agent.ml lib/tool_schemas/tool_schemas_agent.mli test/test_tool_agent_coverage.ml
- rg -n 'valid_collaboration_format_strings|collaboration_format_enum_strings|Handle masc_collaboration_graph|masc_collaboration_graph' lib docs --glob '!docs/audit/2026-05-25-legacy-purge-plan.html' returned no matches
- MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build ./test/test_tool_agent_coverage.exe
- ./_build/default/test/test_tool_agent_coverage.exe (25 tests)