### PR TITLE
fix(local-runtime): update callers after config removal in #18496

### DIFF
--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -97,7 +97,7 @@ let dispatch
     (* ── Tier A: config + agent_name only ──────────────────────── *)
     | Mod_plan -> Tool_plan.dispatch { config } ~name ~args
     | Mod_local_runtime ->
-      Tool_local_runtime.dispatch { Tool_local_runtime.config; agent_name } ~name ~args
+      Tool_local_runtime.dispatch () ~name ~args
       |> Option.map (fun (success, message) ->
         if success then ok message else err message)
     | Mod_worktree ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -571,7 +571,7 @@ let execute_tool_eio
                    Tool_operator.dispatch ctx ~name ~args:coerced_args
                  | Mod_local_runtime ->
                    Tool_local_runtime.dispatch
-                     { Tool_local_runtime.config; agent_name }
+                     ()
                      ~name
                      ~args:coerced_args
                    |> Option.map (fun (ok, msg) ->


### PR DESCRIPTION
## Summary
- PR #18496 removed `Tool_local_runtime.config` but left 2 callers still constructing `{ Tool_local_runtime.config; agent_name }`
- Both `handle_runtime_verify` and `handle_runtime_ollama_probe` use `_ctx` (unused), so `dispatch` accepts any `'ctx` — pass `()` instead
- This breakage blocks ALL CI on every open PR

## Callers fixed
- `lib/mcp_server_eio_execute.ml:574`
- `lib/keeper/keeper_tag_dispatch.ml:100`

## Test plan
- [x] `dune build --root .` passes in worktree
- [ ] CI green (was broken on main due to this regression)

## N-of-M anti-pattern note
PR #18496 removed the type but didn't sweep all call sites — classic N-of-M pattern (anti-pattern §3). Future refactor PRs that remove types should grep all callers before merging.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>