### PR TITLE
Extract keeper shell read ops

### DIFF
--- a/docs/design/keeper-agent-tool-boundary-audit-2026-05-25.md
+++ b/docs/design/keeper-agent-tool-boundary-audit-2026-05-25.md
@@ -150,11 +150,14 @@ mixed into keeper tool execution policy.
    `keeper_hooks` 18, `keeper_gh` 8, and `keeper_tool*` 56 raw prefix matches.
    That is survivable only with a canonical ownership matrix and ratchets.
 
-3. `keeper_shell_ops.ml` remains too large.
-   It is 1047 LoC and owns history metrics, op normalization, read path checks,
-   sandbox read routing, host Shell IR fallbacks, and result rendering. It is no
-   longer the old boundary violation, but it is still too broad for a long-lived
-   tool substrate.
+3. `keeper_shell_ops.ml` is now reduced, but the read-side owner needs the next
+   split.
+   Slice 12 moves structured read/list/search operations into
+   `Keeper_shell_read_ops`, leaving `keeper_shell_ops.ml` as a 249 LoC public
+   dispatcher for alias normalization, read-op delegation, `git_diff`,
+   `git_worktree`, and unsupported-op reporting. The new read owner is still
+   large, so the next P4 slice should split read-file, git-read, and
+   listing/search groups out of `Keeper_shell_read_ops`.
 
 4. The Shell IR audit target and live value disagree.
    The audit reports keeper `gate_typed` refs as 2 while its printed target says
@@ -322,8 +325,10 @@ Exit criteria:
 
 ### P4: Reduce Module Load
 
-- Split `keeper_shell_ops.ml` by operation group:
-  read-file ops, git read ops, listing/search ops, result/history rendering.
+- Continue splitting shell operation groups:
+  `keeper_shell_ops.ml` is now the public dispatcher, and
+  `Keeper_shell_read_ops` should next split read-file ops, git read ops,
+  listing/search ops, and result/history rendering.
 - Keep `Keeper_gh_command_parse` as parser/risk adaptation only; do not let
   repo discovery or GH execution drift back into it.
 - Keep `keeper_exec_shell.ml` as facade only; prevent new logic from landing

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -164,6 +164,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_shell_ops_setup.ml` - shell-surface
 - `lib/keeper/keeper_shell_path.ml` - shell-surface
 - `lib/keeper/keeper_shell_path.mli` - shell-surface
+- `lib/keeper/keeper_shell_read_ops.ml` - shell-surface
+- `lib/keeper/keeper_shell_read_ops.mli` - shell-surface
 - `lib/keeper/keeper_shell_readonly_policy.ml` - shell-surface
 - `lib/keeper/keeper_shell_readonly_policy.mli` - shell-surface
 - `lib/keeper/keeper_shell_runtime_paths.ml` - shell-surface

--- a/docs/design/keeper-tool-runtime-boundary-plan.md
+++ b/docs/design/keeper-tool-runtime-boundary-plan.md
@@ -137,6 +137,16 @@ and public tool aliases.
      allowlists are derived from `Exec_program.name_of_known` and that every allowlisted
      executable resolves to a known `Exec_program`.
    Continued in slice 12:
+   - `Keeper_shell_read_ops` now owns structured read/list/search handlers
+     (`pwd`, `git_status`, `ls`, `cat`, `rg`, `git_log`, `find`, `head`,
+     `tail`, `wc`, and `tree`) plus their sandbox read-runner and host Shell IR
+     fallbacks.
+   - `keeper_shell_ops.ml` is now the public dispatcher/facade: it normalizes
+     aliases, delegates read operations to `Keeper_shell_read_ops`, and keeps
+     the remaining `git_diff` / `git_worktree` branches.
+   - Source-level guards now require the read runner/path/Shell IR assertions
+     to live on `keeper_shell_read_ops.ml` and reject `Keeper_sandbox_read_runner`
+     from returning to `keeper_shell_ops.ml`.
    - `Keeper_shell_ir` now also owns Shell IR construction for typed Bash
      input lowerers through `simple_bin` and `pipeline`, so
      `keeper_tool_bash_input.ml` no longer hand-builds `Shell_ir.Lit`,
@@ -186,7 +196,8 @@ and public tool aliases.
      or GH command parsing reintroduces direct `Exec_policy.parse_string_to_ir`.
    Continued in slice 17:
    - `test_keeper_sandbox_boundary_policy` now pins keeper-wide raw parser
-     ownership: under `lib/keeper`, only `Keeper_shell_command_parse` may call
+     ownership: under `lib/keeper`, only `Keeper_shell_command_parse` and the
+     `Keeper_shell_ir.coding_command_context` facade may call
      `Exec_policy.parse_string_to_ir`.
    - The same boundary test now pins keeper-wide command-word ownership: under
      `lib/keeper`, only `Keeper_shell_command_words` may call
@@ -346,7 +357,8 @@ and public tool aliases.
   `op=gh` or `op=git_clone` command semantics, or if active gate
   scripts name retired `keeper_shell_docker` files.
 - The boundary test now fails if structured shell read ops call
-  `Keeper_sandbox_read_backend` directly instead of `Keeper_sandbox_read_runner`.
+  `Keeper_sandbox_read_backend` directly instead of `Keeper_sandbox_read_runner`;
+  the read-runner owner is `keeper_shell_read_ops.ml`, not the public dispatcher.
 - The boundary test now fails if file tools call `Keeper_sandbox_read_backend`
   directly or hard-code Docker route labels instead of asking the
   sandbox runner facades.
@@ -368,7 +380,8 @@ and public tool aliases.
 - The boundary test now fails if concrete GH tool modules bypass
   `Keeper_gh_runner` and call `Keeper_sandbox_runner.run_command_with_status`
   directly.
-- The boundary test now fails if `keeper_shell_ops.ml` reintroduces direct
+- The boundary test now fails if `keeper_shell_ops.ml` or
+  `keeper_shell_read_ops.ml` reintroduces direct
   `Keeper_shell_shared.run_argv_with_status_retry_eintr` execution instead of
   routing host structured ops through `Keeper_shell_ir`.
 - `test_keeper_bash_safety` now fails if `Dev_exec_allowlist.dev` or

--- a/lib/dune
+++ b/lib/dune
@@ -151,7 +151,7 @@
    keeper_sandbox_docker
    keeper_task_worktree_lazy
    keeper_shell_op keeper_shell_timeout keeper_shell_runtime_paths keeper_shell_path
-   keeper_shell_readonly_policy keeper_shell_command_parse keeper_shell_command_words
+   keeper_shell_readonly_policy keeper_shell_command_parse keeper_shell_command_words keeper_shell_read_ops
    keeper_shell_bash
    keeper_shell_ops
    keeper_exec_shell

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -1,8 +1,8 @@
-(* keeper_shell_ops — shell operation handlers for keeper tools.
+(* keeper_shell_ops — public structured shell op dispatcher for keeper tools.
 
-   Setup (coreutils, Prometheus metric, history observation, process-result
-   renderer) extracted to Keeper_shell_ops_setup as part of godfile
-   near-threshold split. *)
+   Read/list/search operations live in Keeper_shell_read_ops. This facade keeps
+   alias parsing, remaining git mutation-ish helpers, and unsupported-op
+   reporting in one place. *)
 
 open Keeper_types
 open Keeper_exec_shared
@@ -19,7 +19,8 @@ let handle_keeper_shell
   let raw_op =
     Safe_ops.json_string ~default:"" "op" args |> String.trim |> String.lowercase_ascii
   in
-  let op = match raw_op with
+  let op =
+    match raw_op with
     | "git status" | "status" -> "git_status"
     | "git log" -> "git_log"
     | "git diff" -> "git_diff"
@@ -29,909 +30,236 @@ let handle_keeper_shell
     | "dir" | "list" -> "ls"
     | _ -> raw_op
   in
-  let root = Keeper_alerting_path.project_root_of_config config in
   let raw_path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
-  let containment_check target =
-    Keeper_sandbox_containment.check_read_target ~config ~meta ~target
-  in
-  let repo_check target =
-    Keeper_repo_mapping.validate_path_access ~keeper_id:meta.name
-      ~base_path:root ~path:target
-  in
-  let read_target () =
-    match Keeper_shell_path.resolve_keeper_shell_read_path ~config ~meta ~args with
-    | Error _ as e -> e
-    | Ok target ->
-      (match containment_check target with
-       | Error msg -> Error msg
-       | Ok () ->
-         match repo_check target with
-         | Error msg -> Error msg
-         | Ok () -> Ok target)
-  in
-  let cwd_target () =
-    match Keeper_shell_path.resolve_keeper_shell_read_cwd ~config ~meta ~args with
-    | Error _ as e -> e
-    | Ok cwd ->
-      (match containment_check cwd with
-       | Error msg -> Error msg
-       | Ok () ->
-         match repo_check cwd with
-       | Error msg -> Error msg
-       | Ok () -> Ok cwd)
-  in
-  let path_error e =
-    actionable_path_error ~op ~meta ~raw_path ~error:e
-  in
-  let dispatch_host_shell_ir
-        ?(allowed_commands = Dev_exec_allowlist.readonly)
-        ?timeout_sec
-        ~workdir
-        ir
-    =
-    Keeper_shell_ir.dispatch ~allowed_commands ~keeper_id:meta.name
-      ~base_path:root ~workdir ~sandbox:(Masc_exec.Sandbox_target.host ())
-      ?timeout_sec ir
-  in
-  let dispatch_error_message = function
-    | Keeper_shell_ir.Gate_reject diagnostic -> diagnostic
-    | Keeper_shell_ir.Cannot_parse -> "Cannot parse command"
-    | Keeper_shell_ir.Too_complex -> "Command too complex"
-    | Keeper_shell_ir.Path_reject e -> e
-  in
-  let run_host_shell_ir
-        ?(allowed_commands = Dev_exec_allowlist.readonly)
-        ?timeout_sec
-        ?path
-        ~workdir
-        ~cmd
-        ir
-        ~on_ok
-    =
-    let fields =
-      [ "typed", `Bool true; "cmd", `String cmd ]
-      @
-      match path with
-      | None -> []
-      | Some path -> [ "path", `String path ]
+  match
+    Keeper_shell_read_ops.try_handle ~turn_sandbox_factory ~config ~meta ~args
+      ~op ~raw_path
+  with
+  | Some response -> response
+  | None ->
+    let root = Keeper_alerting_path.project_root_of_config config in
+    let containment_check target =
+      Keeper_sandbox_containment.check_read_target ~config ~meta ~target
     in
-    match dispatch_host_shell_ir ~allowed_commands ?timeout_sec ~workdir ir with
-    | Error (Gate_reject diagnostic) -> error_json ~fields diagnostic
-    | Error Cannot_parse -> error_json ~fields "Cannot parse command"
-    | Error Too_complex -> error_json ~fields "Command too complex"
-    | Error (Path_reject e) -> error_json ~fields:[ "blocked_cmd", `String cmd ] e
-    | Ok result -> on_ok result
-  in
-  let dispatch_result_output (result : Masc_exec.Exec_dispatch.dispatch_result) =
-    if String.equal result.stderr "" then result.stdout else result.stdout ^ result.stderr
-  in
-  let sandbox_read_error ~target msg =
-    error_json ~fields:[ "op", `String op; "path", `String target ] msg
-  in
-  let hostify_turn_runtime_output out =
-    Keeper_shell_runtime_paths.rewrite_turn_runtime_paths_to_host ~config ~meta out
-  in
-  let run_readonly_in_sandbox ?(ok_exit_codes = [ 0 ]) ~target ~command_argv
-      ~max_bytes ~timeout_sec () =
-    let max_eintr_retries = 8 in
-    let rec loop attempts_left =
-      match
-        Keeper_sandbox_read_runner.container_path_of_host ~config ~meta ~host_path:target
-      with
-      | Error e -> Error (sandbox_read_error ~target e)
-      | Ok cpath -> (
-          match
-            Keeper_sandbox_read_runner.run_command_with_status
-              ?turn_sandbox_factory
-              ~ok_exit_codes ~config ~meta ~command_argv:(command_argv cpath)
-              ~max_bytes ~timeout_sec ()
-          with
-          | Error msg
-            when attempts_left > 0
-                 && String_util.contains_substring_ci msg
-                      "interrupted system call" ->
-              loop (attempts_left - 1)
-          | Error msg -> Error (sandbox_read_error ~target msg)
-          | Ok payload -> Ok payload)
+    let repo_check target =
+      Keeper_repo_mapping.validate_path_access ~keeper_id:meta.name
+        ~base_path:root ~path:target
     in
-    loop max_eintr_retries
-  in
-  let run_in_turn_runtime ?(ok_exit_codes = [ 0 ]) ~cwd ~cmd ~command_argv
-      ?host_ir ?(host_allowed_commands = Dev_exec_allowlist.readonly)
-      ~max_bytes ~timeout_sec ?(map_output = fun out -> out) ?(extra = []) () =
-    match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
-    | Some runtime ->
-      (match
-         Keeper_turn_sandbox_runtime.run_command_with_status
-           ~ok_exit_codes runtime ~cwd ~command_argv ~max_bytes ~timeout_sec ()
-       with
-       | Error msg ->
-         error_json
-           ~fields:([ "op", `String op; "cwd", `String cwd ] @ extra) msg
-       | Ok (st, out) ->
-         render_completed_process_result ~root ~keeper_name:meta.name ~op ~cwd ~cmd ~extra st (map_output out))
-    | None ->
-      (match host_ir with
-       | None ->
-         error_json
-           ~fields:[ "op", `String op; "cwd", `String cwd ]
-           "missing host Shell IR fallback"
-       | Some ir ->
-         run_host_shell_ir ~allowed_commands:host_allowed_commands ~timeout_sec
-           ~workdir:cwd ~cmd ~path:cwd ir
-           ~on_ok:(fun result ->
-             render_completed_process_result ~root ~keeper_name:meta.name ~op ~cwd ~cmd ~extra result.status
-               (map_output (dispatch_result_output result))))
-  in
-  let render_sandbox_process_result ~cwd ~cmd ~backend_cmd ~timeout_sec =
-    match
-      Keeper_sandbox_runner.run_shell_command_with_status ~config ~meta ~cwd ~timeout_sec
-        ~cmd:backend_cmd ~git_creds_enabled:false ~network_mode:Network_none
-    with
-    | Error msg -> error_json ~fields:[ "op", `String op; "cwd", `String cwd ] msg
-    | Ok result ->
-      (* PR #11080 sibling sweep: this helper always routes through the
-         sandbox backend, so the LLM-facing [cwd] field must hold the
-         in-container path.  Operator-side log fields above keep the
-         host path. *)
-      let cwd_response =
-        Keeper_cwd_response.docker ~host_cwd:cwd
-          ~container_cwd:
-            (Keeper_sandbox_runner.private_workspace_cwd ~config
-               ~meta cwd)
-      in
-      Yojson.Safe.to_string
-        (Exec_core.process_result_json
-           ~artifact_policy:Exec_core.Inline_only
-           ~base_path:root
-           ~keeper_name:meta.name
-           ~cmd
-           ~extra:
-             [
-               "op", `String op;
-               "cmd", `String cmd;
-               "cwd", Keeper_cwd_response.to_yojson_response cwd_response;
-               "via", `String Keeper_sandbox_read_runner.backend_via;
-             ]
-           ~status:result.status
-           ~output:result.output
-           ())
-  in
-  let sandbox_git_log_path host_path =
-    if String.trim host_path = "" then Ok ""
-    else if Filename.is_relative host_path then Ok host_path
-    else
-      Keeper_sandbox_read_runner.container_path_of_host ~config ~meta ~host_path
-  in
-  match op with
-  | "pwd" ->
-    (match cwd_target () with
-     | Error e -> path_error e
-     | Ok cwd ->
-       if Keeper_sandbox_read_runner.should_route_read ~meta then
-         render_sandbox_process_result ~cwd ~cmd:"pwd" ~backend_cmd:"pwd"
-           ~timeout_sec:Keeper_shell_timeout.io_timeout_sec
-       else
-         let host_ir =
-           Keeper_shell_ir.simple ~cwd_raw:cwd ~cwd_base:root Masc_exec.Exec_program.Pwd []
-         in
-         run_in_turn_runtime ~cwd ~cmd:"pwd" ~command_argv:[ coreutils.pwd ]
-           ~host_ir ~map_output:hostify_turn_runtime_output ~max_bytes:4096
-           ~timeout_sec:Keeper_shell_timeout.io_timeout_sec ())
-  | "git_status" ->
-    (match cwd_target () with
-     | Error e -> path_error e
-     | Ok cwd ->
-       if Keeper_sandbox_read_runner.should_route_read ~meta then
-         render_sandbox_process_result ~cwd
-           ~cmd:"git -C <cwd> --no-optional-locks status --short --branch"
-           ~backend_cmd:"git --no-optional-locks status --short --branch"
-           ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
-	 else
-	   let ir =
-	     Keeper_shell_ir.simple
-	       ~cwd_raw:cwd
-	       ~cwd_base:root
-	       Masc_exec.Exec_program.Git
-	       [ "--no-optional-locks"; "status"; "--short"; "--branch" ]
-	   in
-	   run_host_shell_ir
-	     ~allowed_commands:Dev_exec_allowlist.dev
-	     ~workdir:cwd
-	     ~cmd:"git status"
-	     ~path:cwd
-	     ir
-	     ~on_ok:(fun result ->
-	       render_completed_process_result ~root ~keeper_name:meta.name ~op
-	         ~cwd
-	         ~cmd:"git --no-optional-locks status --short --branch"
-	         ~extra:[]
-	         result.status
-	         result.stdout))
-  | "ls" ->
-    (match read_target () with
-     | Error e -> path_error e
-     | Ok target ->
-       let limit = shell_readonly_limit args in
-       (* RFC-0006 Phase B-3b: sandbox-backed keepers route ls through
-          the same backend read prelude as keeper_fs_read so the backend
-          mount is the load-bearing isolation. The host-side containment
-          guard above remains as defense in depth. *)
-       if Keeper_sandbox_read_runner.should_route_read ~meta then
-         (match
-            Keeper_sandbox_read_runner.container_path_of_host ~config ~meta
-              ~host_path:target
-          with
-          | Error e ->
-            error_json
-              ~fields:[ "op", `String op; "path", `String target ] e
-          | Ok cpath ->
-            (match
-               Keeper_sandbox_read_runner.run_command
-                 ?turn_sandbox_factory ~config ~meta
-                 ~command_argv:[ "ls"; "-la"; cpath ]
-                 ~max_bytes:1_000_000
-                 ~timeout_sec:Keeper_shell_timeout.io_timeout_sec
-                 ()
-             with
-             | Error msg ->
-               error_json
-                 ~fields:[ "op", `String op; "path", `String target ] msg
-             | Ok out ->
-               Yojson.Safe.to_string
-                 (`Assoc
-                     [ "ok", `Bool true
-                     ; "op", `String op
-                     ; "path", `String target
-                     ; "via", `String Keeper_sandbox_read_runner.backend_via
-                     ; "entries", lines_to_json ~limit out
-                     ])))
-	 else
-	   let ir = Keeper_shell_ir.simple Masc_exec.Exec_program.Ls [ "-la"; target ] in
-	   run_host_shell_ir
-	     ~workdir:target
-	     ~cmd:"ls -la"
-	     ~path:target
-	     ir
-	     ~on_ok:(fun result ->
-	       let output =
-	         if String.equal result.stderr ""
-	         then result.stdout
-	         else result.stdout ^ result.stderr
-	       in
-	       render_completed_process_result ~root ~keeper_name:meta.name ~op
-	         ~cmd:"ls -la"
-	         ~extra:[ "path", `String target; "entries", lines_to_json ~limit output ]
-	         result.status
-	         output))
-     | "cat" ->
-       (match read_target () with
-        | Error e -> path_error e
-        | Ok target ->
-          let max_bytes = shell_readonly_cat_max_bytes args in
-       (* RFC-0006 Phase B-3b: sandbox-backend route via the read-file helper.
-          Symmetry with keeper_fs_read's backend response field. *)
-       if Keeper_sandbox_read_runner.should_route_read ~meta then
-         (match
-            Keeper_sandbox_read_runner.read_file
-              ?turn_sandbox_factory ~config ~meta
-              ~host_path:target ~max_bytes
-              ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
-              ()
-          with
-          | Error msg ->
-            error_json
-              ~fields:[ "op", `String op; "path", `String target ] msg
-          | Ok body ->
-            let total = String.length body in
-            let truncated = total >= max_bytes in
-            Yojson.Safe.to_string
-              (`Assoc
-                  [ "ok", `Bool true
-                  ; "op", `String op
-                  ; "path", `String target
-                  ; "via", `String Keeper_sandbox_read_runner.backend_via
-                  ; "bytes", `Int total
-                  ; "truncated", `Bool truncated
-                  ; "content", `String body
-                  ]))
-	 else
-	   let ir = Keeper_shell_ir.simple Masc_exec.Exec_program.Cat [ target ] in
-	   run_host_shell_ir
-	     ~workdir:target
-	     ~cmd:"cat"
-	     ~path:target
-	     ir
-	     ~on_ok:(fun result ->
-	       let out = result.stdout in
-	       let body =
-	         if String.length out > max_bytes then String.sub out 0 max_bytes else out
-	       in
-	       Yojson.Safe.to_string
-	         (`Assoc
-	             [ "ok", `Bool (match result.status with Unix.WEXITED 0 -> true | _ -> false)
-	             ; "op", `String op
-	             ; "path", `String target
-	             ; "via", `String "host"
-	             ; "status", Keeper_alerting_path.process_status_to_json result.status
-	             ; "truncated", `Bool (String.length out > max_bytes)
-	             ; "content", `String body
-	             ])))
-  | "rg" ->
-    let pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
-    if pattern = ""
-    then error_json ~fields:[ "op", `String op ] "pattern is required for rg. Good: pattern='handle_request'. Bad: pattern=''."
-    else (
-      match read_target () with
-      | Error e -> path_error e
-      | Ok target ->
-        let limit = shell_readonly_limit args in
-        (* Optional file-type filter (e.g. "ml", "py") *)
-        let file_type = Safe_ops.json_string ~default:"" "type" args |> String.trim in
-        (* Optional glob filter (e.g. "*.ml", "lib/**/*.ml") *)
-        let glob = Safe_ops.json_string ~default:"" "glob" args |> String.trim in
-        if Keeper_sandbox_read_runner.should_route_read ~meta then
-          let base_argv = [ "rg"; "-n"; "-m"; string_of_int limit ] in
-          let type_argv = if file_type <> "" then [ "--type"; file_type ] else [] in
-          let glob_argv = if glob <> "" then [ "--glob"; glob ] else [] in
-          (match
-             run_readonly_in_sandbox ~target
-               ~command_argv:(fun cpath ->
-                 base_argv @ type_argv @ glob_argv @ [ pattern; cpath ])
-               ~ok_exit_codes:[ 0; 1 ]
-               ~max_bytes:1_000_000
-               ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
-               ()
-           with
-           | Error response -> response
-           | Ok (st, out) ->
-             Yojson.Safe.to_string
-               (`Assoc
-                   [ "ok", `Bool true
-                   ; "op", `String op
-                   ; "path", `String target
-                   ; "pattern", `String pattern
-                   ; "via", `String Keeper_sandbox_read_runner.backend_via
-                   ; "status", Keeper_alerting_path.process_status_to_json st
-                   ; "matches", lines_to_json ~limit out
-                   ]))
-        else
-          let rg_available = Keeper_shell_path.shell_command_available "rg" in
-          if not rg_available then
-            path_error "rg executable not found; SearchFiles requires rg"
-          else
-	        let argv =
-	          [ "-n"; "-m"; string_of_int limit ]
-	          @ (if file_type <> "" then [ "--type"; file_type ] else [])
-	          @ (if glob <> "" then [ "--glob"; glob ] else [])
-	          @ [ pattern; target ]
-	        in
-	        let ir = Keeper_shell_ir.simple Masc_exec.Exec_program.Rg argv in
-	        run_host_shell_ir
-	          ~workdir:target
-	          ~cmd:op
-	          ~path:target
-	          ir
-	          ~on_ok:(fun result ->
-	            (* rg exit codes: 0=matches found, 1=no matches (not an error), 2+=real error.
-	               Treat exit 1 as success with empty results — "no match" is a valid answer. *)
-	            let is_ok =
-	              match result.status with
-	              | Unix.WEXITED 0 | Unix.WEXITED 1 -> true
-	              | _ -> false
-	            in
-	            Yojson.Safe.to_string
-	              (`Assoc
-	                  [ "ok", `Bool is_ok
-	                  ; "op", `String op
-	                  ; "path", `String target
-	                  ; "pattern", `String pattern
-	                  ; "via", `String "host"
-	                  ; "status", Keeper_alerting_path.process_status_to_json result.status
-	                  ; "matches", lines_to_json ~limit result.stdout
-	                  ])))
-  | "git_log" ->
-    (match cwd_target () with
-     | Error e -> path_error e
-     | Ok cwd ->
-       let count = max 1 (min 50 (Safe_ops.json_int ~default:10 "count" args)) in
-       let format = Safe_ops.json_string ~default:"%h %s" "format" args in
-       let file_path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
-       let grep = Safe_ops.json_string ~default:"" "grep" args |> String.trim in
-       if Keeper_sandbox_read_runner.should_route_read ~meta then
-         (match sandbox_git_log_path file_path with
-          | Error err ->
-            error_json
-              ~fields:
-                [ "op", `String op; "cwd", `String cwd; "path", `String file_path ]
-              err
-          | Ok backend_file_path ->
-            let backend_cmd =
-              let base =
-                Printf.sprintf "git --no-optional-locks log --format=%s -%d%s"
-                  (Filename.quote format) count
-                  (if grep = "" then "" else " --grep=" ^ Filename.quote grep)
-              in
-              if backend_file_path = "" then
-                base
-              else
-                Printf.sprintf "%s -- %s" base (Filename.quote backend_file_path)
-            in
-            render_sandbox_process_result ~cwd
-              ~cmd:"git -C <cwd> --no-optional-locks log --format=<fmt> -<n>"
-              ~backend_cmd ~timeout_sec:Keeper_shell_timeout.read_timeout_sec)
-       else
-         (match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
-          | Some runtime ->
-            let argv =
-              let base_argv =
-                [ "git"; "--no-optional-locks"; "log";
-                  Printf.sprintf "--format=%s" format;
-                  Printf.sprintf "-%d" count ]
-              in
-              let base_argv =
-                if grep = "" then base_argv else base_argv @ [ "--grep=" ^ grep ]
-              in
-              if file_path = "" then
-                base_argv
-              else
-                let runtime_path =
-                  if Filename.is_relative file_path then file_path
-                  else
-                    match
-                      Keeper_turn_sandbox_runtime.container_path_of_host runtime
-                        ~host_path:file_path
-                    with
-                    | Ok mapped -> mapped
-                    | Error _ -> file_path
-                in
-                base_argv @ [ "--"; runtime_path ]
-            in
-            (match
-               Keeper_turn_sandbox_runtime.run_command_with_status runtime
-                 ~cwd ~command_argv:argv
-                 ~ok_exit_codes:[ 0 ]
-                 ~max_bytes:1_000_000
-                 ~timeout_sec:Keeper_shell_timeout.read_timeout_sec ()
-             with
-             | Error msg ->
-               error_json
-                 ~fields:[ "op", `String op; "cwd", `String cwd ] msg
-             | Ok (st, out) ->
-               (* PR #11080 sibling sweep: backend-route response uses the
-                  runtime cwd to keep the LLM aligned with the actual exec
-                  environment. *)
-               let cwd_response =
-                 Keeper_cwd_response.docker ~host_cwd:cwd
-                   ~container_cwd:
-                     (Keeper_turn_sandbox_runtime.container_cwd_of_host
-                        runtime ~host_cwd:cwd)
-               in
-               Yojson.Safe.to_string
-                 (`Assoc
-                     [ "ok", `Bool true
-                     ; "op", `String op
-                     ; "cwd", Keeper_cwd_response.to_yojson_response cwd_response
-                     ; "count", `Int count
-                     ; "grep", `String grep
-                     ; "via", `String Keeper_sandbox_read_runner.backend_via
-                     ; "status", Keeper_alerting_path.process_status_to_json st
-                     ; "entries", lines_to_json ~limit:50 out
-                     ]))
-	  | None ->
-	    let base_args =
-	      [ "--no-optional-locks"; "log"; Printf.sprintf "--format=%s" format; Printf.sprintf "-%d" count ]
-	    in
-	    let args_with_grep =
-	      if grep = "" then base_args
-	      else base_args @ [ "--grep=" ^ grep ]
-	    in
-	    let args =
-	      if file_path = "" then args_with_grep
-	      else
-	        args_with_grep
-	        @ [ "--"; file_path ]
-	    in
-	    let ir =
-	      Keeper_shell_ir.simple ~cwd_raw:cwd ~cwd_base:root Masc_exec.Exec_program.Git args
-	    in
-	    run_host_shell_ir
-	      ~allowed_commands:Dev_exec_allowlist.dev
-	      ~workdir:cwd
-	      ~cmd:"git log"
-	      ~path:cwd
-	      ir
-	      ~on_ok:(fun result ->
-	        render_completed_process_result ~root ~keeper_name:meta.name ~op
-	          ~cwd
-	          ~cmd:"git --no-optional-locks log --format=<fmt> -<n>"
-	          ~extra:[ "count", `Int count; "grep", `String grep ]
-	          result.status
-	          result.stdout)))
-  | "find" ->
-    let name_pattern =
-      let pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
-      if pattern <> ""
-      then pattern
-      else Safe_ops.json_string ~default:"" "name" args |> String.trim
-    in
-    if name_pattern = ""
-    then error_json ~fields:[ "op", `String op ] "pattern is required for find. Good: pattern='*.ml'. Bad: pattern=''."
-    else (
-      match read_target () with
-      | Error e -> path_error e
-      | Ok target ->
-        let limit = shell_readonly_limit args in
-        if Keeper_sandbox_read_runner.should_route_read ~meta then
-          (match
-             run_readonly_in_sandbox ~target
-               ~command_argv:(fun cpath ->
-                 [ "find"; cpath; "-maxdepth"; "5"; "-name"; name_pattern;
-                   "-not"; "-path"; "*/.git/*";
-                   "-not"; "-path"; "*/_build/*";
-                   "-not"; "-path"; "*/.masc/*" ])
-               ~max_bytes:1_000_000
-               ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
-               ()
-           with
-           | Error response -> response
-           | Ok (st, out) ->
-             Yojson.Safe.to_string
-               (`Assoc
-                   [ "ok", `Bool true
-                   ; "op", `String op
-                   ; "path", `String target
-                   ; "name", `String name_pattern
-                   ; "via", `String Keeper_sandbox_read_runner.backend_via
-                   ; "status", Keeper_alerting_path.process_status_to_json st
-	                   ; "files", lines_to_json ~limit out
-	                   ]))
-        else
-          let ir =
-            Keeper_shell_ir.simple
-              Masc_exec.Exec_program.Find
-              [ target
-              ; "-maxdepth"
-              ; "5"
-              ; "-name"
-              ; name_pattern
-              ; "-not"
-              ; "-path"
-              ; "*/.git/*"
-              ; "-not"
-              ; "-path"
-              ; "*/_build/*"
-              ; "-not"
-              ; "-path"
-              ; "*/.masc/*"
-              ]
-          in
-          run_host_shell_ir
-            ~workdir:target
-            ~cmd:"find"
-            ~path:target
-            ir
-            ~on_ok:(fun result ->
-              let out = dispatch_result_output result in
-              Yojson.Safe.to_string
-                (`Assoc
-                    [ "ok", `Bool (result.status = Unix.WEXITED 0)
-                    ; "op", `String op
-                    ; "path", `String target
-                    ; "name", `String name_pattern
-                    ; "via", `String "host"
-                    ; "status", Keeper_alerting_path.process_status_to_json result.status
-                    ; "files", lines_to_json ~limit out
-                    ])))
-  | "head" ->
-    (match read_target () with
-     | Error e -> path_error e
-     | Ok target ->
-       let n = Safe_ops.json_int ~default:20 "lines" args |> fun v -> max 1 (min 200 v) in
-       if Keeper_sandbox_read_runner.should_route_read ~meta then
-         (match
-            run_readonly_in_sandbox ~target
-              ~command_argv:(fun cpath ->
-                [ "head"; "-n"; string_of_int n; cpath ])
-              ~max_bytes:1_000_000
-              ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
-              ()
-          with
-          | Error response -> response
-          | Ok (st, out) ->
-            Yojson.Safe.to_string
-              (`Assoc
-                  [ "ok", `Bool true
-                  ; "op", `String op
-                  ; "path", `String target
-                  ; "lines", `Int n
-                  ; "via", `String Keeper_sandbox_read_runner.backend_via
-                  ; "status", Keeper_alerting_path.process_status_to_json st
-	                  ; "content", `String out
-	                  ]))
-	       else
-	         let ir =
-	           Keeper_shell_ir.simple
-	             Masc_exec.Exec_program.Head
-	             [ "-n"; string_of_int n; target ]
-	         in
-	         run_host_shell_ir
-	           ~workdir:target
-	           ~cmd:"head"
-	           ~path:target
-	           ir
-	           ~on_ok:(fun result ->
-	             let out = dispatch_result_output result in
-	             Yojson.Safe.to_string
-	               (`Assoc
-	                   [ "ok", `Bool (result.status = Unix.WEXITED 0)
-	                   ; "op", `String op
-	                   ; "path", `String target
-	                   ; "lines", `Int n
-	                   ; "via", `String "host"
-	                   ; "status", Keeper_alerting_path.process_status_to_json result.status
-	                   ; "content", `String out
-	                   ])))
-  | "tail" ->
-    (match read_target () with
-     | Error e -> path_error e
-     | Ok target ->
-       let n = Safe_ops.json_int ~default:20 "lines" args |> fun v -> max 1 (min 200 v) in
-       if Keeper_sandbox_read_runner.should_route_read ~meta then
-         (match
-            run_readonly_in_sandbox ~target
-              ~command_argv:(fun cpath ->
-                [ "tail"; "-n"; string_of_int n; cpath ])
-              ~max_bytes:1_000_000
-              ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
-              ()
-          with
-          | Error response -> response
-          | Ok (st, out) ->
-            Yojson.Safe.to_string
-              (`Assoc
-                  [ "ok", `Bool true
-                  ; "op", `String op
-                  ; "path", `String target
-                  ; "lines", `Int n
-                  ; "via", `String Keeper_sandbox_read_runner.backend_via
-                  ; "status", Keeper_alerting_path.process_status_to_json st
-	                  ; "content", `String out
-	                  ]))
-	       else
-	         let ir =
-	           Keeper_shell_ir.simple
-	             Masc_exec.Exec_program.Tail
-	             [ "-n"; string_of_int n; target ]
-	         in
-	         run_host_shell_ir
-	           ~workdir:target
-	           ~cmd:"tail"
-	           ~path:target
-	           ir
-	           ~on_ok:(fun result ->
-	             let out = dispatch_result_output result in
-	             Yojson.Safe.to_string
-	               (`Assoc
-	                   [ "ok", `Bool (result.status = Unix.WEXITED 0)
-	                   ; "op", `String op
-	                   ; "path", `String target
-	                   ; "lines", `Int n
-	                   ; "via", `String "host"
-	                   ; "status", Keeper_alerting_path.process_status_to_json result.status
-	                   ; "content", `String out
-	                   ])))
-  | "wc" ->
-    (match read_target () with
-     | Error e -> path_error e
-     | Ok target ->
-       if Keeper_sandbox_read_runner.should_route_read ~meta then
-         (match
-            run_readonly_in_sandbox ~target
-              ~command_argv:(fun cpath -> [ "wc"; "-l"; cpath ])
-              ~max_bytes:4096
-              ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
-              ()
-          with
-          | Error response -> response
-          | Ok (st, out) ->
-            Yojson.Safe.to_string
-              (Exec_core.process_result_json
-                 ~artifact_policy:Exec_core.Inline_only
-                 ~base_path:root
-                 ~keeper_name:meta.name
-                 ~cmd:"wc"
-                 ~extra:
-                   [
-                     "op", `String op;
-                     "cmd", `String "wc";
-                     "cwd", `Null;
-                     "path", `String target;
-                     "via", `String Keeper_sandbox_read_runner.backend_via;
-                   ]
-	                 ~status:st
-	                 ~output:out
-	                 ()))
-	       else
-	         let ir = Keeper_shell_ir.simple Masc_exec.Exec_program.Wc [ "-l"; target ] in
-	         run_host_shell_ir
-	           ~workdir:target
-	           ~cmd:"wc"
-	           ~path:target
-	           ir
-	           ~on_ok:(fun result ->
-	             render_completed_process_result ~root ~keeper_name:meta.name ~op
-	               ~cmd:"wc"
-	               result.status
-	               (dispatch_result_output result)))
-  | "tree" ->
-    (match read_target () with
-     | Error e -> path_error e
-     | Ok target ->
-       let limit = shell_readonly_limit args in
-       if Keeper_sandbox_read_runner.should_route_read ~meta then
-         (match
-            run_readonly_in_sandbox ~target
-              ~command_argv:(fun cpath ->
-                [ "find"; cpath; "-maxdepth"; "3"; "-print";
-                  "-not"; "-path"; "*/.git/*";
-                  "-not"; "-path"; "*/_build/*" ])
-              ~max_bytes:1_000_000
-              ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
-              ()
-          with
-           | Error response -> response
-           | Ok (st, out) ->
-             Yojson.Safe.to_string
-               (`Assoc
-                   [ "ok", `Bool true
-                   ; "op", `String op
-                   ; "path", `String target
-                   ; "via", `String Keeper_sandbox_read_runner.backend_via
-                   ; "status", Keeper_alerting_path.process_status_to_json st
-	                   ; "entries", lines_to_json ~limit out
-	                   ]))
-	       else
-	         let ir =
-	           Keeper_shell_ir.simple
-	             Masc_exec.Exec_program.Find
-	             [ target
-	             ; "-maxdepth"
-	             ; "3"
-	             ; "-print"
-	             ; "-not"
-	             ; "-path"
-	             ; "*/.git/*"
-	             ; "-not"
-	             ; "-path"
-	             ; "*/_build/*"
-	             ]
-	         in
-	         run_host_shell_ir
-	           ~workdir:target
-	           ~cmd:"find"
-	           ~path:target
-	           ir
-	           ~on_ok:(fun result ->
-	             let out = dispatch_result_output result in
-	             Yojson.Safe.to_string
-	               (`Assoc
-	                   [ "ok", `Bool (result.status = Unix.WEXITED 0)
-	                   ; "op", `String op
-	                   ; "path", `String target
-	                   ; "via", `String "host"
-	                   ; "status", Keeper_alerting_path.process_status_to_json result.status
-	                   ; "entries", lines_to_json ~limit out
-	                   ])))
-  | "git_diff" ->
-    (match cwd_target () with
-     | Error e -> path_error e
-     | Ok cwd ->
-       let host_ir =
-         Keeper_shell_ir.simple ~cwd_raw:cwd ~cwd_base:root Masc_exec.Exec_program.Git
-           [ "--no-optional-locks"; "diff"; "--stat" ]
-       in
-       run_in_turn_runtime ~cwd ~cmd:"git diff --stat"
-         ~command_argv:[ "git"; "--no-optional-locks"; "diff"; "--stat" ]
-         ~host_ir ~host_allowed_commands:Dev_exec_allowlist.dev ~max_bytes:1_000_000
-         ~timeout_sec:Keeper_shell_timeout.read_timeout_sec ())
-  | "git_worktree" ->
-    let action =
-      Safe_ops.json_string ~default:"list" "action" args
-      |> String.trim |> String.lowercase_ascii
-    in
-    begin match action with
-    | "list" ->
-     (match cwd_target () with
-      | Error e -> path_error e
+    let cwd_target () =
+      match Keeper_shell_path.resolve_keeper_shell_read_cwd ~config ~meta ~args with
+      | Error _ as e -> e
       | Ok cwd ->
-        let host_ir =
-          Keeper_shell_ir.simple ~cwd_raw:cwd ~cwd_base:root Masc_exec.Exec_program.Git
-            [ "worktree"; "list" ]
-        in
-         run_in_turn_runtime ~cwd ~cmd:"git worktree list"
-           ~map_output:hostify_turn_runtime_output
-           ~command_argv:[ "git"; "worktree"; "list" ] ~host_ir
-           ~host_allowed_commands:Dev_exec_allowlist.dev
-           ~max_bytes:1_000_000 ~timeout_sec:Keeper_shell_timeout.read_timeout_sec ())
-    | "add" ->
-      let branch = Safe_ops.json_string ~default:"" "branch" args |> String.trim in
-      let base = Safe_ops.json_string ~default:"origin/main" "base" args |> String.trim in
-      if branch = "" then
-        error_json ~fields:[ "op", `String op ]
-          "branch is required. Good: action='add', branch='feature/my-task'. Bad: branch=''."
-      else (
-        match cwd_target () with
-	        | Error e -> path_error e
-	        | Ok cwd ->
-	          let wt_out_result =
-	            let ir =
-	              Keeper_shell_ir.simple ~cwd_raw:cwd ~cwd_base:root Masc_exec.Exec_program.Git
-	                [ "worktree"; "list"; "--porcelain" ]
-	            in
-	            match
-	              dispatch_host_shell_ir ~allowed_commands:Dev_exec_allowlist.dev
-	                ~timeout_sec:Keeper_shell_timeout.git_meta_timeout_sec ~workdir:cwd ir
-	            with
-	            | Ok result -> Ok (dispatch_result_output result)
-	            | Error err -> Error (dispatch_error_message err)
+        (match containment_check cwd with
+         | Error msg -> Error msg
+         | Ok () ->
+           match repo_check cwd with
+           | Error msg -> Error msg
+           | Ok () -> Ok cwd)
+    in
+    let path_error e =
+      actionable_path_error ~op ~meta ~raw_path ~error:e
+    in
+    (* TEL-OK: adapter delegates to Keeper_shell_ir/Exec_dispatch; execution
+       telemetry stays with the delegated runtime path. *)
+    let dispatch_host_shell_ir
+          ?(allowed_commands = Dev_exec_allowlist.readonly)
+          ?timeout_sec
+          ~workdir
+          ir
+      =
+      Keeper_shell_ir.dispatch ~allowed_commands ~keeper_id:meta.name
+        ~base_path:root ~workdir ~sandbox:(Masc_exec.Sandbox_target.host ())
+        ?timeout_sec ir
+    in
+    let dispatch_error_message = function
+      | Keeper_shell_ir.Gate_reject diagnostic -> diagnostic
+      | Keeper_shell_ir.Cannot_parse -> "Cannot parse command"
+      | Keeper_shell_ir.Too_complex -> "Command too complex"
+      | Keeper_shell_ir.Path_reject e -> e
+    in
+    let run_host_shell_ir
+          ?(allowed_commands = Dev_exec_allowlist.readonly)
+          ?timeout_sec
+          ?path
+          ~workdir
+          ~cmd
+          ir
+          ~on_ok
+      =
+      let fields =
+        [ "typed", `Bool true; "cmd", `String cmd ]
+        @
+        match path with
+        | None -> []
+        | Some path -> [ "path", `String path ]
+      in
+      match dispatch_host_shell_ir ~allowed_commands ?timeout_sec ~workdir ir with
+      | Error (Gate_reject diagnostic) -> error_json ~fields diagnostic
+      | Error Cannot_parse -> error_json ~fields "Cannot parse command"
+      | Error Too_complex -> error_json ~fields "Command too complex"
+      | Error (Path_reject e) -> error_json ~fields:[ "blocked_cmd", `String cmd ] e
+      | Ok result -> on_ok result
+    in
+    let dispatch_result_output (result : Masc_exec.Exec_dispatch.dispatch_result) =
+      if String.equal result.stderr "" then result.stdout else result.stdout ^ result.stderr
+    in
+    let hostify_turn_runtime_output out =
+      Keeper_shell_runtime_paths.rewrite_turn_runtime_paths_to_host ~config ~meta out
+    in
+    let run_in_turn_runtime ?(ok_exit_codes = [ 0 ]) ~cwd ~cmd ~command_argv
+        ?host_ir ?(host_allowed_commands = Dev_exec_allowlist.readonly)
+        ~max_bytes ~timeout_sec ?(map_output = fun out -> out) ?(extra = []) () =
+      match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
+      | Some runtime ->
+        (match
+           Keeper_turn_sandbox_runtime.run_command_with_status
+             ~ok_exit_codes runtime ~cwd ~command_argv ~max_bytes ~timeout_sec ()
+         with
+         | Error msg ->
+           error_json
+             ~fields:([ "op", `String op; "cwd", `String cwd ] @ extra) msg
+         | Ok (st, out) ->
+           render_completed_process_result ~root ~keeper_name:meta.name ~op ~cwd
+             ~cmd ~extra st (map_output out))
+      | None ->
+        (match host_ir with
+         | None ->
+           error_json
+             ~fields:[ "op", `String op; "cwd", `String cwd ]
+             "missing host Shell IR fallback"
+         | Some ir ->
+           run_host_shell_ir ~allowed_commands:host_allowed_commands ~timeout_sec
+             ~workdir:cwd ~cmd ~path:cwd ir
+             ~on_ok:(fun result ->
+               render_completed_process_result ~root ~keeper_name:meta.name ~op
+                 ~cwd ~cmd ~extra result.status
+                 (map_output (dispatch_result_output result))))
+    in
+    (match op with
+     | "git_diff" ->
+       (match cwd_target () with
+        | Error e -> path_error e
+        | Ok cwd ->
+          let host_ir =
+            Keeper_shell_ir.simple ~cwd_raw:cwd ~cwd_base:root
+              Masc_exec.Exec_program.Git
+              [ "--no-optional-locks"; "diff"; "--stat" ]
           in
-          match wt_out_result with
-          | Error msg ->
-            error_json ~fields:[ "op", `String op; "cwd", `String cwd ] msg
-          | Ok wt_out ->
-          if String_util.contains_substring_ci wt_out branch then
-            let existing_path =
-              String.split_on_char '\n' wt_out
-              |> List.find_map (fun line ->
-                if String_util.contains_substring_ci line "worktree"
-                   && String_util.contains_substring_ci wt_out branch
-                then Some (String.trim line) else None)
-              |> Option.value ~default:"(unknown)"
-            in
-            Yojson.Safe.to_string
-              (`Assoc
-                  [ "ok", `Bool false
-                  ; "op", `String op
-                  ; "error", `String "branch_already_in_worktree"
-                  ; "branch", `String branch
-                  ; "existing_worktree", `String existing_path
-                  ; "hint", `String "Branch is already in a worktree. Use 'cd' to the existing path, or choose a different branch name."
-                  ])
-	          else
-	            let wt_path = Printf.sprintf ".worktrees/%s"
-	              (String.map (fun c -> if c = '/' then '-' else c) branch)
-	            in
-	            let ir =
-	              Keeper_shell_ir.simple ~cwd_raw:cwd ~cwd_base:root Masc_exec.Exec_program.Git
-	                [ "worktree"; "add"; wt_path; "-b"; branch; base ]
-	            in
-	            run_host_shell_ir ~allowed_commands:Dev_exec_allowlist.dev
-	              ~timeout_sec:Keeper_shell_timeout.io_timeout_sec ~workdir:cwd
-	              ~cmd:(Printf.sprintf "git worktree add %s -b %s %s" wt_path branch base)
-	              ~path:cwd ir
-	              ~on_ok:(fun result ->
-	                render_completed_process_result ~root ~keeper_name:meta.name ~op ~cwd
-	                  ~cmd:(Printf.sprintf "git worktree add %s -b %s %s" wt_path branch base)
-	                  result.status
-	                  (dispatch_result_output result))
-	      )
-    | other ->
-      error_json ~fields:[ "op", `String op ]
-        (Printf.sprintf "Unknown git_worktree action '%s'. Use: list, add." other)
-    end
-  | _ ->
-    Yojson.Safe.to_string
-      (`Assoc
-          [ "ok", `Bool false
-          ; "error", `String "unsupported_op"
-          ; "op", `String op
-          ; ( "supported_ops"
-              (* Issue #8524: derive from Variant SSOT instead of a
-                 hand-rolled duplicate. *)
-            , `List
-                (List.map
-                   (fun name -> `String name)
-                   Keeper_shell_op.valid_strings) )
-          ])
+          run_in_turn_runtime ~cwd ~cmd:"git diff --stat"
+            ~command_argv:[ "git"; "--no-optional-locks"; "diff"; "--stat" ]
+            ~host_ir ~host_allowed_commands:Dev_exec_allowlist.dev
+            ~max_bytes:1_000_000
+            ~timeout_sec:Keeper_shell_timeout.read_timeout_sec ())
+     | "git_worktree" ->
+       let action =
+         Safe_ops.json_string ~default:"list" "action" args
+         |> String.trim |> String.lowercase_ascii
+       in
+       (match action with
+        | "list" ->
+          (match cwd_target () with
+           | Error e -> path_error e
+           | Ok cwd ->
+             let host_ir =
+               Keeper_shell_ir.simple ~cwd_raw:cwd ~cwd_base:root
+                 Masc_exec.Exec_program.Git
+                 [ "worktree"; "list" ]
+             in
+             run_in_turn_runtime ~cwd ~cmd:"git worktree list"
+               ~map_output:hostify_turn_runtime_output
+               ~command_argv:[ "git"; "worktree"; "list" ] ~host_ir
+               ~host_allowed_commands:Dev_exec_allowlist.dev
+               ~max_bytes:1_000_000
+               ~timeout_sec:Keeper_shell_timeout.read_timeout_sec ())
+        | "add" ->
+          let branch = Safe_ops.json_string ~default:"" "branch" args |> String.trim in
+          let base = Safe_ops.json_string ~default:"origin/main" "base" args |> String.trim in
+          if branch = "" then
+            error_json ~fields:[ "op", `String op ]
+              "branch is required. Good: action='add', branch='feature/my-task'. Bad: branch=''."
+          else (
+            match cwd_target () with
+            | Error e -> path_error e
+            | Ok cwd ->
+              let wt_out_result =
+                let ir =
+                  Keeper_shell_ir.simple ~cwd_raw:cwd ~cwd_base:root
+                    Masc_exec.Exec_program.Git
+                    [ "worktree"; "list"; "--porcelain" ]
+                in
+                match
+                  dispatch_host_shell_ir ~allowed_commands:Dev_exec_allowlist.dev
+                    ~timeout_sec:Keeper_shell_timeout.git_meta_timeout_sec ~workdir:cwd ir
+                with
+                | Ok result -> Ok (dispatch_result_output result)
+                | Error err -> Error (dispatch_error_message err)
+              in
+              match wt_out_result with
+              | Error msg ->
+                error_json ~fields:[ "op", `String op; "cwd", `String cwd ] msg
+              | Ok wt_out ->
+                let existing_path =
+                  let branch_ref = "branch refs/heads/" ^ branch in
+                  let rec loop current_worktree = function
+                    | [] -> None
+                    | line :: rest ->
+                      let line = String.trim line in
+                      if String.starts_with ~prefix:"worktree " line then
+                        let prefix_len = String.length "worktree " in
+                        let path =
+                          String.sub line prefix_len (String.length line - prefix_len)
+                          |> String.trim
+                        in
+                        loop (Some path) rest
+                      else if String.equal line branch_ref then current_worktree
+                      else loop current_worktree rest
+                  in
+                  loop None (String.split_on_char '\n' wt_out)
+                in
+                (match existing_path with
+                 | Some existing_path ->
+                  Yojson.Safe.to_string
+                    (`Assoc
+                        [ "ok", `Bool false
+                        ; "op", `String op
+                        ; "error", `String "branch_already_in_worktree"
+                        ; "branch", `String branch
+                        ; "existing_worktree", `String existing_path
+                        ; "hint", `String "Branch is already in a worktree. Use 'cd' to the existing path, or choose a different branch name."
+                        ])
+                 | None ->
+                  let wt_path =
+                    Printf.sprintf ".worktrees/%s"
+                      (String.map (fun c -> if c = '/' then '-' else c) branch)
+                  in
+                  let ir =
+                    Keeper_shell_ir.simple ~cwd_raw:cwd ~cwd_base:root
+                      Masc_exec.Exec_program.Git
+                      [ "worktree"; "add"; wt_path; "-b"; branch; base ]
+                  in
+                  run_host_shell_ir ~allowed_commands:Dev_exec_allowlist.dev
+                    ~timeout_sec:Keeper_shell_timeout.io_timeout_sec ~workdir:cwd
+                    ~cmd:(Printf.sprintf "git worktree add %s -b %s %s" wt_path branch base)
+                    ~path:cwd ir
+                    ~on_ok:(fun result ->
+                      render_completed_process_result ~root ~keeper_name:meta.name ~op
+                        ~cwd
+                        ~cmd:(Printf.sprintf "git worktree add %s -b %s %s" wt_path branch base)
+                        result.status
+                        (dispatch_result_output result))))
+        | other ->
+          error_json ~fields:[ "op", `String op ]
+            (Printf.sprintf "Unknown git_worktree action '%s'. Use: list, add." other))
+     | _ ->
+       Yojson.Safe.to_string
+         (`Assoc
+             [ "ok", `Bool false
+             ; "error", `String "unsupported_op"
+             ; "op", `String op
+             ; ( "supported_ops"
+               , `List
+                   (List.map
+                      (fun name -> `String name)
+                      Keeper_shell_op.valid_strings) )
+             ]))
 ;;

--- a/lib/keeper/keeper_shell_read_ops.ml
+++ b/lib/keeper/keeper_shell_read_ops.ml
@@ -1,0 +1,814 @@
+(* Keeper_shell_read_ops — read-side operation handlers for keeper_shell.
+
+   This module owns structured read/list/search operations so
+   Keeper_shell_ops stays as the public dispatcher instead of reabsorbing
+   read-backend, path-resolution, and host Shell IR details. *)
+
+open Keeper_types
+open Keeper_exec_shared
+open Keeper_shell_ops_setup
+
+let try_handle
+      ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+      ~op
+      ~raw_path
+  =
+  let root = Keeper_alerting_path.project_root_of_config config in
+  let containment_check target =
+    Keeper_sandbox_containment.check_read_target ~config ~meta ~target
+  in
+  let repo_check target =
+    Keeper_repo_mapping.validate_path_access ~keeper_id:meta.name
+      ~base_path:root ~path:target
+  in
+  let read_target () =
+    match Keeper_shell_path.resolve_keeper_shell_read_path ~config ~meta ~args with
+    | Error _ as e -> e
+    | Ok target ->
+      (match containment_check target with
+       | Error msg -> Error msg
+       | Ok () ->
+         match repo_check target with
+         | Error msg -> Error msg
+         | Ok () -> Ok target)
+  in
+  let cwd_target () =
+    match Keeper_shell_path.resolve_keeper_shell_read_cwd ~config ~meta ~args with
+    | Error _ as e -> e
+    | Ok cwd ->
+      (match containment_check cwd with
+       | Error msg -> Error msg
+       | Ok () ->
+         match repo_check cwd with
+         | Error msg -> Error msg
+         | Ok () -> Ok cwd)
+  in
+  let path_error e =
+    actionable_path_error ~op ~meta ~raw_path ~error:e
+  in
+  (* TEL-OK: read-op adapter delegates to Keeper_shell_ir/Exec_dispatch or the
+     sandbox read runner; execution telemetry stays with those runtime paths. *)
+  let dispatch_host_shell_ir
+        ?(allowed_commands = Dev_exec_allowlist.readonly)
+        ?timeout_sec
+        ~workdir
+        ir
+    =
+    Keeper_shell_ir.dispatch ~allowed_commands ~keeper_id:meta.name
+      ~base_path:root ~workdir ~sandbox:(Masc_exec.Sandbox_target.host ())
+      ?timeout_sec ir
+  in
+  let run_host_shell_ir
+        ?(allowed_commands = Dev_exec_allowlist.readonly)
+        ?timeout_sec
+        ?path
+        ~workdir
+        ~cmd
+        ir
+        ~on_ok
+    =
+    let fields =
+      [ "typed", `Bool true; "cmd", `String cmd ]
+      @
+      match path with
+      | None -> []
+      | Some path -> [ "path", `String path ]
+    in
+    match dispatch_host_shell_ir ~allowed_commands ?timeout_sec ~workdir ir with
+    | Error (Gate_reject diagnostic) -> error_json ~fields diagnostic
+    | Error Cannot_parse -> error_json ~fields "Cannot parse command"
+    | Error Too_complex -> error_json ~fields "Command too complex"
+    | Error (Path_reject e) -> error_json ~fields:[ "blocked_cmd", `String cmd ] e
+    | Ok result -> on_ok result
+  in
+  let dispatch_result_output (result : Masc_exec.Exec_dispatch.dispatch_result) =
+    if String.equal result.stderr "" then result.stdout else result.stdout ^ result.stderr
+  in
+  let sandbox_read_error ~target msg =
+    error_json ~fields:[ "op", `String op; "path", `String target ] msg
+  in
+  let hostify_turn_runtime_output out =
+    Keeper_shell_runtime_paths.rewrite_turn_runtime_paths_to_host ~config ~meta out
+  in
+  let run_readonly_in_sandbox ?(ok_exit_codes = [ 0 ]) ~target ~command_argv
+      ~max_bytes ~timeout_sec () =
+    let max_eintr_retries = 8 in
+    let rec loop attempts_left =
+      match
+        Keeper_sandbox_read_runner.container_path_of_host ~config ~meta ~host_path:target
+      with
+      | Error e -> Error (sandbox_read_error ~target e)
+      | Ok cpath -> (
+          match
+            Keeper_sandbox_read_runner.run_command_with_status
+              ?turn_sandbox_factory
+              ~ok_exit_codes ~config ~meta ~command_argv:(command_argv cpath)
+              ~max_bytes ~timeout_sec ()
+          with
+          | Error msg
+            when attempts_left > 0
+                 && String_util.contains_substring_ci msg
+                      "interrupted system call" ->
+              loop (attempts_left - 1)
+          | Error msg -> Error (sandbox_read_error ~target msg)
+          | Ok payload -> Ok payload)
+    in
+    loop max_eintr_retries
+  in
+  let run_in_turn_runtime ?(ok_exit_codes = [ 0 ]) ~cwd ~cmd ~command_argv
+      ?host_ir ?(host_allowed_commands = Dev_exec_allowlist.readonly)
+      ~max_bytes ~timeout_sec ?(map_output = fun out -> out) ?(extra = []) () =
+    match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
+    | Some runtime ->
+      (match
+         Keeper_turn_sandbox_runtime.run_command_with_status
+           ~ok_exit_codes runtime ~cwd ~command_argv ~max_bytes ~timeout_sec ()
+       with
+       | Error msg ->
+         error_json
+           ~fields:([ "op", `String op; "cwd", `String cwd ] @ extra) msg
+       | Ok (st, out) ->
+         render_completed_process_result ~root ~keeper_name:meta.name ~op ~cwd
+           ~cmd ~extra st (map_output out))
+    | None ->
+      (match host_ir with
+       | None ->
+         error_json
+           ~fields:[ "op", `String op; "cwd", `String cwd ]
+           "missing host Shell IR fallback"
+       | Some ir ->
+         run_host_shell_ir ~allowed_commands:host_allowed_commands ~timeout_sec
+           ~workdir:cwd ~cmd ~path:cwd ir
+           ~on_ok:(fun result ->
+             render_completed_process_result ~root ~keeper_name:meta.name ~op
+               ~cwd ~cmd ~extra result.status
+               (map_output (dispatch_result_output result))))
+  in
+  let render_sandbox_process_result ~cwd ~cmd ~backend_cmd ~timeout_sec =
+    match
+      Keeper_sandbox_runner.run_shell_command_with_status ~config ~meta ~cwd ~timeout_sec
+        ~cmd:backend_cmd ~git_creds_enabled:false ~network_mode:Network_none
+    with
+    | Error msg -> error_json ~fields:[ "op", `String op; "cwd", `String cwd ] msg
+    | Ok result ->
+      let cwd_response =
+        Keeper_cwd_response.docker ~host_cwd:cwd
+          ~container_cwd:
+            (Keeper_sandbox_runner.private_workspace_cwd ~config
+               ~meta cwd)
+      in
+      Yojson.Safe.to_string
+        (Exec_core.process_result_json
+           ~artifact_policy:Exec_core.Inline_only
+           ~base_path:root
+           ~keeper_name:meta.name
+           ~cmd
+           ~extra:
+             [
+               "op", `String op;
+               "cmd", `String cmd;
+               "cwd", Keeper_cwd_response.to_yojson_response cwd_response;
+               "via", `String Keeper_sandbox_read_runner.backend_via;
+             ]
+           ~status:result.status
+           ~output:result.output
+           ())
+  in
+  let sandbox_git_log_path host_path =
+    if String.trim host_path = "" then Ok ""
+    else if Filename.is_relative host_path then Ok host_path
+    else
+      Keeper_sandbox_read_runner.container_path_of_host ~config ~meta ~host_path
+  in
+  match op with
+  | "pwd" ->
+    Some
+      (match cwd_target () with
+       | Error e -> path_error e
+       | Ok cwd ->
+         if Keeper_sandbox_read_runner.should_route_read ~meta then
+           render_sandbox_process_result ~cwd ~cmd:"pwd" ~backend_cmd:"pwd"
+             ~timeout_sec:Keeper_shell_timeout.io_timeout_sec
+         else
+           let host_ir =
+             Keeper_shell_ir.simple ~cwd_raw:cwd ~cwd_base:root Masc_exec.Exec_program.Pwd []
+           in
+           run_in_turn_runtime ~cwd ~cmd:"pwd" ~command_argv:[ coreutils.pwd ]
+             ~host_ir ~map_output:hostify_turn_runtime_output ~max_bytes:4096
+             ~timeout_sec:Keeper_shell_timeout.io_timeout_sec ())
+  | "git_status" ->
+    Some
+      (match cwd_target () with
+       | Error e -> path_error e
+       | Ok cwd ->
+         if Keeper_sandbox_read_runner.should_route_read ~meta then
+           render_sandbox_process_result ~cwd
+             ~cmd:"git -C <cwd> --no-optional-locks status --short --branch"
+             ~backend_cmd:"git --no-optional-locks status --short --branch"
+             ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
+         else
+           let ir =
+             Keeper_shell_ir.simple
+               ~cwd_raw:cwd
+               ~cwd_base:root
+               Masc_exec.Exec_program.Git
+               [ "--no-optional-locks"; "status"; "--short"; "--branch" ]
+           in
+           run_host_shell_ir
+             ~allowed_commands:Dev_exec_allowlist.dev
+             ~workdir:cwd
+             ~cmd:"git status"
+             ~path:cwd
+             ir
+             ~on_ok:(fun result ->
+               render_completed_process_result ~root ~keeper_name:meta.name ~op
+                 ~cwd
+                 ~cmd:"git --no-optional-locks status --short --branch"
+                 ~extra:[]
+                 result.status
+                 result.stdout))
+  | "ls" ->
+    Some
+      (match read_target () with
+       | Error e -> path_error e
+       | Ok target ->
+         let limit = shell_readonly_limit args in
+         if Keeper_sandbox_read_runner.should_route_read ~meta then
+           (match
+              Keeper_sandbox_read_runner.container_path_of_host ~config ~meta
+                ~host_path:target
+            with
+            | Error e ->
+              error_json
+                ~fields:[ "op", `String op; "path", `String target ] e
+            | Ok cpath ->
+              (match
+                 Keeper_sandbox_read_runner.run_command
+                   ?turn_sandbox_factory ~config ~meta
+                   ~command_argv:[ "ls"; "-la"; cpath ]
+                   ~max_bytes:1_000_000
+                   ~timeout_sec:Keeper_shell_timeout.io_timeout_sec
+                   ()
+               with
+               | Error msg ->
+                 error_json
+                   ~fields:[ "op", `String op; "path", `String target ] msg
+               | Ok out ->
+                 Yojson.Safe.to_string
+                   (`Assoc
+                       [ "ok", `Bool true
+                       ; "op", `String op
+                       ; "path", `String target
+                       ; "via", `String Keeper_sandbox_read_runner.backend_via
+                       ; "entries", lines_to_json ~limit out
+                       ])))
+         else
+           let ir = Keeper_shell_ir.simple Masc_exec.Exec_program.Ls [ "-la"; target ] in
+           run_host_shell_ir
+             ~workdir:target
+             ~cmd:"ls -la"
+             ~path:target
+             ir
+             ~on_ok:(fun result ->
+               let output =
+                 if String.equal result.stderr ""
+                 then result.stdout
+                 else result.stdout ^ result.stderr
+               in
+               render_completed_process_result ~root ~keeper_name:meta.name ~op
+                 ~cmd:"ls -la"
+                 ~extra:[ "path", `String target; "entries", lines_to_json ~limit output ]
+                 result.status
+                 output))
+  | "cat" ->
+    Some
+      (match read_target () with
+       | Error e -> path_error e
+       | Ok target ->
+         let max_bytes = shell_readonly_cat_max_bytes args in
+         if Keeper_sandbox_read_runner.should_route_read ~meta then
+           (match
+              Keeper_sandbox_read_runner.read_file
+                ?turn_sandbox_factory ~config ~meta
+                ~host_path:target ~max_bytes
+                ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
+                ()
+            with
+            | Error msg ->
+              error_json
+                ~fields:[ "op", `String op; "path", `String target ] msg
+            | Ok body ->
+              let total = String.length body in
+              let truncated = total >= max_bytes in
+              Yojson.Safe.to_string
+                (`Assoc
+                    [ "ok", `Bool true
+                    ; "op", `String op
+                    ; "path", `String target
+                    ; "via", `String Keeper_sandbox_read_runner.backend_via
+                    ; "bytes", `Int total
+                    ; "truncated", `Bool truncated
+                    ; "content", `String body
+                    ]))
+         else
+           let ir = Keeper_shell_ir.simple Masc_exec.Exec_program.Cat [ target ] in
+           run_host_shell_ir
+             ~workdir:target
+             ~cmd:"cat"
+             ~path:target
+             ir
+             ~on_ok:(fun result ->
+               let out = result.stdout in
+               let body =
+                 if String.length out > max_bytes then String.sub out 0 max_bytes else out
+               in
+               Yojson.Safe.to_string
+                 (`Assoc
+                     [ "ok", `Bool (match result.status with Unix.WEXITED 0 -> true | _ -> false)
+                     ; "op", `String op
+                     ; "path", `String target
+                     ; "via", `String "host"
+                     ; "status", Keeper_alerting_path.process_status_to_json result.status
+                     ; "truncated", `Bool (String.length out > max_bytes)
+                     ; "content", `String body
+                     ])))
+  | "rg" ->
+    Some
+      (let pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
+       if pattern = ""
+       then error_json ~fields:[ "op", `String op ] "pattern is required for rg. Good: pattern='handle_request'. Bad: pattern=''."
+       else (
+         match read_target () with
+         | Error e -> path_error e
+         | Ok target ->
+           let limit = shell_readonly_limit args in
+           let file_type = Safe_ops.json_string ~default:"" "type" args |> String.trim in
+           let glob = Safe_ops.json_string ~default:"" "glob" args |> String.trim in
+           if Keeper_sandbox_read_runner.should_route_read ~meta then
+             let base_argv = [ "rg"; "-n"; "-m"; string_of_int limit ] in
+             let type_argv = if file_type <> "" then [ "--type"; file_type ] else [] in
+             let glob_argv = if glob <> "" then [ "--glob"; glob ] else [] in
+             (match
+                run_readonly_in_sandbox ~target
+                  ~command_argv:(fun cpath ->
+                    base_argv @ type_argv @ glob_argv @ [ pattern; cpath ])
+                  ~ok_exit_codes:[ 0; 1 ]
+                  ~max_bytes:1_000_000
+                  ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
+                  ()
+              with
+              | Error response -> response
+              | Ok (st, out) ->
+                Yojson.Safe.to_string
+                  (`Assoc
+                      [ "ok", `Bool true
+                      ; "op", `String op
+                      ; "path", `String target
+                      ; "pattern", `String pattern
+                      ; "via", `String Keeper_sandbox_read_runner.backend_via
+                      ; "status", Keeper_alerting_path.process_status_to_json st
+                      ; "matches", lines_to_json ~limit out
+                      ]))
+           else
+             let rg_available = Keeper_shell_path.shell_command_available "rg" in
+             if not rg_available then
+               path_error "rg executable not found; SearchFiles requires rg"
+             else
+               let argv =
+                 [ "-n"; "-m"; string_of_int limit ]
+                 @ (if file_type <> "" then
+                      [ "--type"; file_type ]
+                    else [])
+                 @ (if glob <> "" then
+                      [ "--glob"; glob ]
+                    else [])
+                 @ [ pattern; target ]
+               in
+               let ir = Keeper_shell_ir.simple Masc_exec.Exec_program.Rg argv in
+               run_host_shell_ir
+                 ~workdir:target
+                 ~cmd:op
+                 ~path:target
+                 ir
+                 ~on_ok:(fun result ->
+                   let is_ok =
+                     match result.status with
+                     | Unix.WEXITED 0 | Unix.WEXITED 1 -> true
+                     | _ -> false
+                   in
+                   Yojson.Safe.to_string
+                     (`Assoc
+                         [ "ok", `Bool is_ok
+                         ; "op", `String op
+                         ; "path", `String target
+                         ; "pattern", `String pattern
+                         ; "via", `String "host"
+                         ; "status", Keeper_alerting_path.process_status_to_json result.status
+                         ; "matches", lines_to_json ~limit result.stdout
+                         ]))))
+  | "git_log" ->
+    Some
+      (match cwd_target () with
+       | Error e -> path_error e
+       | Ok cwd ->
+         let count = max 1 (min 50 (Safe_ops.json_int ~default:10 "count" args)) in
+         let format = Safe_ops.json_string ~default:"%h %s" "format" args in
+         let file_path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
+         let grep = Safe_ops.json_string ~default:"" "grep" args |> String.trim in
+         if Keeper_sandbox_read_runner.should_route_read ~meta then
+           (match sandbox_git_log_path file_path with
+            | Error err ->
+              error_json
+                ~fields:
+                  [ "op", `String op; "cwd", `String cwd; "path", `String file_path ]
+                err
+            | Ok backend_file_path ->
+              let backend_cmd =
+                let base =
+                  Printf.sprintf "git --no-optional-locks log --format=%s -%d%s"
+                    (Filename.quote format) count
+                    (if grep = "" then "" else " --grep=" ^ Filename.quote grep)
+                in
+                if backend_file_path = "" then
+                  base
+                else
+                  Printf.sprintf "%s -- %s" base (Filename.quote backend_file_path)
+              in
+              render_sandbox_process_result ~cwd
+                ~cmd:"git -C <cwd> --no-optional-locks log --format=<fmt> -<n>"
+                ~backend_cmd ~timeout_sec:Keeper_shell_timeout.read_timeout_sec)
+         else
+           (match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
+            | Some runtime ->
+              let argv =
+                let base_argv =
+                  [
+                    "git";
+                    "--no-optional-locks";
+                    "log";
+                    Printf.sprintf "--format=%s" format;
+                    Printf.sprintf "-%d" count;
+                  ]
+                in
+                let base_argv =
+                  if grep = "" then base_argv else base_argv @ [ "--grep=" ^ grep ]
+                in
+                if file_path = "" then
+                  base_argv
+                else
+                  let runtime_path =
+                    if Filename.is_relative file_path then file_path
+                    else
+                      match
+                        Keeper_turn_sandbox_runtime.container_path_of_host runtime
+                          ~host_path:file_path
+                      with
+                      | Ok mapped -> mapped
+                      | Error _ -> file_path
+                  in
+                  base_argv @ [ "--"; runtime_path ]
+              in
+              (match
+                 Keeper_turn_sandbox_runtime.run_command_with_status runtime
+                   ~cwd ~command_argv:argv
+                   ~ok_exit_codes:[ 0 ]
+                   ~max_bytes:1_000_000
+                   ~timeout_sec:Keeper_shell_timeout.read_timeout_sec ()
+               with
+               | Error msg ->
+                 error_json
+                   ~fields:[ "op", `String op; "cwd", `String cwd ] msg
+               | Ok (st, out) ->
+                 let cwd_response =
+                   Keeper_cwd_response.docker ~host_cwd:cwd
+                     ~container_cwd:
+                       (Keeper_turn_sandbox_runtime.container_cwd_of_host
+                          runtime ~host_cwd:cwd)
+                 in
+                 Yojson.Safe.to_string
+                   (`Assoc
+                       [ "ok", `Bool true
+                       ; "op", `String op
+                       ; "cwd", Keeper_cwd_response.to_yojson_response cwd_response
+                       ; "count", `Int count
+                       ; "grep", `String grep
+                       ; "via", `String Keeper_sandbox_read_runner.backend_via
+                       ; "status", Keeper_alerting_path.process_status_to_json st
+                       ; "entries", lines_to_json ~limit:50 out
+                       ]))
+            | None ->
+              let base_args =
+                [
+                  "--no-optional-locks";
+                  "log";
+                  Printf.sprintf "--format=%s" format;
+                  Printf.sprintf "-%d" count;
+                ]
+              in
+              let args_with_grep =
+                if grep = "" then base_args else base_args @ [ "--grep=" ^ grep ]
+              in
+              let args =
+                if file_path = "" then args_with_grep else args_with_grep @ [ "--"; file_path ]
+              in
+              let ir =
+                Keeper_shell_ir.simple ~cwd_raw:cwd ~cwd_base:root Masc_exec.Exec_program.Git args
+              in
+              run_host_shell_ir
+                ~allowed_commands:Dev_exec_allowlist.dev
+                ~workdir:cwd
+                ~cmd:"git log"
+                ~path:cwd
+                ir
+                ~on_ok:(fun result ->
+                  render_completed_process_result ~root ~keeper_name:meta.name ~op
+                    ~cwd
+                    ~cmd:"git --no-optional-locks log --format=<fmt> -<n>"
+                    ~extra:[ "count", `Int count; "grep", `String grep ]
+                    result.status
+                    result.stdout)))
+  | "find" ->
+    Some
+      (let name_pattern =
+         let pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
+         if pattern <> ""
+         then pattern
+         else Safe_ops.json_string ~default:"" "name" args |> String.trim
+       in
+       if name_pattern = ""
+       then error_json ~fields:[ "op", `String op ] "pattern is required for find. Good: pattern='*.ml'. Bad: pattern=''."
+       else (
+         match read_target () with
+         | Error e -> path_error e
+         | Ok target ->
+           let limit = shell_readonly_limit args in
+           if Keeper_sandbox_read_runner.should_route_read ~meta then
+             (match
+                run_readonly_in_sandbox ~target
+                  ~command_argv:(fun cpath ->
+                    [ "find"; cpath; "-maxdepth"; "5"; "-name"; name_pattern;
+                      "-not"; "-path"; "*/.git/*";
+                      "-not"; "-path"; "*/_build/*";
+                      "-not"; "-path"; "*/.masc/*" ])
+                  ~max_bytes:1_000_000
+                  ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
+                  ()
+              with
+              | Error response -> response
+              | Ok (st, out) ->
+                Yojson.Safe.to_string
+                  (`Assoc
+                      [ "ok", `Bool true
+                      ; "op", `String op
+                      ; "path", `String target
+                      ; "name", `String name_pattern
+                      ; "via", `String Keeper_sandbox_read_runner.backend_via
+                      ; "status", Keeper_alerting_path.process_status_to_json st
+                      ; "files", lines_to_json ~limit out
+                      ]))
+           else
+             let ir =
+               Keeper_shell_ir.simple
+                 Masc_exec.Exec_program.Find
+                 [ target
+                 ; "-maxdepth"
+                 ; "5"
+                 ; "-name"
+                 ; name_pattern
+                 ; "-not"
+                 ; "-path"
+                 ; "*/.git/*"
+                 ; "-not"
+                 ; "-path"
+                 ; "*/_build/*"
+                 ; "-not"
+                 ; "-path"
+                 ; "*/.masc/*"
+                 ]
+             in
+             run_host_shell_ir
+               ~workdir:target
+               ~cmd:"find"
+               ~path:target
+               ir
+               ~on_ok:(fun result ->
+                 let out = dispatch_result_output result in
+                 Yojson.Safe.to_string
+                   (`Assoc
+                       [ "ok", `Bool (result.status = Unix.WEXITED 0)
+                       ; "op", `String op
+                       ; "path", `String target
+                       ; "name", `String name_pattern
+                       ; "via", `String "host"
+                       ; "status", Keeper_alerting_path.process_status_to_json result.status
+                       ; "files", lines_to_json ~limit out
+                       ]))))
+  | "head" ->
+    Some
+      (match read_target () with
+       | Error e -> path_error e
+       | Ok target ->
+         let n = Safe_ops.json_int ~default:20 "lines" args |> fun v -> max 1 (min 200 v) in
+         if Keeper_sandbox_read_runner.should_route_read ~meta then
+           (match
+              run_readonly_in_sandbox ~target
+                ~command_argv:(fun cpath ->
+                  [ "head"; "-n"; string_of_int n; cpath ])
+                ~max_bytes:1_000_000
+                ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
+                ()
+            with
+            | Error response -> response
+            | Ok (st, out) ->
+              Yojson.Safe.to_string
+                (`Assoc
+                    [ "ok", `Bool true
+                    ; "op", `String op
+                    ; "path", `String target
+                    ; "lines", `Int n
+                    ; "via", `String Keeper_sandbox_read_runner.backend_via
+                    ; "status", Keeper_alerting_path.process_status_to_json st
+                    ; "content", `String out
+                    ]))
+         else
+           let ir =
+             Keeper_shell_ir.simple
+               Masc_exec.Exec_program.Head
+               [ "-n"; string_of_int n; target ]
+           in
+           run_host_shell_ir
+             ~workdir:target
+             ~cmd:"head"
+             ~path:target
+             ir
+             ~on_ok:(fun result ->
+               let out = dispatch_result_output result in
+               Yojson.Safe.to_string
+                 (`Assoc
+                     [ "ok", `Bool (result.status = Unix.WEXITED 0)
+                     ; "op", `String op
+                     ; "path", `String target
+                     ; "lines", `Int n
+                     ; "via", `String "host"
+                     ; "status", Keeper_alerting_path.process_status_to_json result.status
+                     ; "content", `String out
+                     ])))
+  | "tail" ->
+    Some
+      (match read_target () with
+       | Error e -> path_error e
+       | Ok target ->
+         let n = Safe_ops.json_int ~default:20 "lines" args |> fun v -> max 1 (min 200 v) in
+         if Keeper_sandbox_read_runner.should_route_read ~meta then
+           (match
+              run_readonly_in_sandbox ~target
+                ~command_argv:(fun cpath ->
+                  [ "tail"; "-n"; string_of_int n; cpath ])
+                ~max_bytes:1_000_000
+                ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
+                ()
+            with
+            | Error response -> response
+            | Ok (st, out) ->
+              Yojson.Safe.to_string
+                (`Assoc
+                    [ "ok", `Bool true
+                    ; "op", `String op
+                    ; "path", `String target
+                    ; "lines", `Int n
+                    ; "via", `String Keeper_sandbox_read_runner.backend_via
+                    ; "status", Keeper_alerting_path.process_status_to_json st
+                    ; "content", `String out
+                    ]))
+         else
+           let ir =
+             Keeper_shell_ir.simple
+               Masc_exec.Exec_program.Tail
+               [ "-n"; string_of_int n; target ]
+           in
+           run_host_shell_ir
+             ~workdir:target
+             ~cmd:"tail"
+             ~path:target
+             ir
+             ~on_ok:(fun result ->
+               let out = dispatch_result_output result in
+               Yojson.Safe.to_string
+                 (`Assoc
+                     [ "ok", `Bool (result.status = Unix.WEXITED 0)
+                     ; "op", `String op
+                     ; "path", `String target
+                     ; "lines", `Int n
+                     ; "via", `String "host"
+                     ; "status", Keeper_alerting_path.process_status_to_json result.status
+                     ; "content", `String out
+                     ])))
+  | "wc" ->
+    Some
+      (match read_target () with
+       | Error e -> path_error e
+       | Ok target ->
+         if Keeper_sandbox_read_runner.should_route_read ~meta then
+           (match
+              run_readonly_in_sandbox ~target
+                ~command_argv:(fun cpath -> [ "wc"; "-l"; cpath ])
+                ~max_bytes:4096
+                ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
+                ()
+            with
+            | Error response -> response
+            | Ok (st, out) ->
+              Yojson.Safe.to_string
+                (Exec_core.process_result_json
+                   ~artifact_policy:Exec_core.Inline_only
+                   ~base_path:root
+                   ~keeper_name:meta.name
+                   ~cmd:"wc"
+                   ~extra:
+                     [
+                       "op", `String op;
+                       "cmd", `String "wc";
+                       "cwd", `Null;
+                       "path", `String target;
+                       "via", `String Keeper_sandbox_read_runner.backend_via;
+                     ]
+                   ~status:st
+                   ~output:out
+                   ()))
+         else
+           let ir = Keeper_shell_ir.simple Masc_exec.Exec_program.Wc [ "-l"; target ] in
+           run_host_shell_ir
+             ~workdir:target
+             ~cmd:"wc"
+             ~path:target
+             ir
+             ~on_ok:(fun result ->
+               render_completed_process_result ~root ~keeper_name:meta.name ~op
+                 ~cmd:"wc"
+                 result.status
+                 (dispatch_result_output result)))
+  | "tree" ->
+    Some
+      (match read_target () with
+       | Error e -> path_error e
+       | Ok target ->
+         let limit = shell_readonly_limit args in
+         if Keeper_sandbox_read_runner.should_route_read ~meta then
+           (match
+              run_readonly_in_sandbox ~target
+                ~command_argv:(fun cpath ->
+                  [ "find"; cpath; "-maxdepth"; "3"; "-print";
+                    "-not"; "-path"; "*/.git/*";
+                    "-not"; "-path"; "*/_build/*" ])
+                ~max_bytes:1_000_000
+                ~timeout_sec:Keeper_shell_timeout.read_timeout_sec
+                ()
+            with
+            | Error response -> response
+            | Ok (st, out) ->
+              Yojson.Safe.to_string
+                (`Assoc
+                    [ "ok", `Bool true
+                    ; "op", `String op
+                    ; "path", `String target
+                    ; "via", `String Keeper_sandbox_read_runner.backend_via
+                    ; "status", Keeper_alerting_path.process_status_to_json st
+                    ; "entries", lines_to_json ~limit out
+                    ]))
+         else
+           let ir =
+             Keeper_shell_ir.simple
+               Masc_exec.Exec_program.Find
+               [ target
+               ; "-maxdepth"
+               ; "3"
+               ; "-print"
+               ; "-not"
+               ; "-path"
+               ; "*/.git/*"
+               ; "-not"
+               ; "-path"
+               ; "*/_build/*"
+               ]
+           in
+           run_host_shell_ir
+             ~workdir:target
+             ~cmd:"find"
+             ~path:target
+             ir
+             ~on_ok:(fun result ->
+               let out = dispatch_result_output result in
+               Yojson.Safe.to_string
+                 (`Assoc
+                     [ "ok", `Bool (result.status = Unix.WEXITED 0)
+                     ; "op", `String op
+                     ; "path", `String target
+                     ; "via", `String "host"
+                     ; "status", Keeper_alerting_path.process_status_to_json result.status
+                     ; "entries", lines_to_json ~limit out
+                     ])))
+  | _ -> None
+;;

--- a/lib/keeper/keeper_shell_read_ops.mli
+++ b/lib/keeper/keeper_shell_read_ops.mli
@@ -1,0 +1,10 @@
+(* Keeper_shell_read_ops — structured read-side keeper_shell operations. *)
+
+val try_handle :
+  turn_sandbox_factory:Keeper_sandbox_factory.t option ->
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  op:string ->
+  raw_path:string ->
+  string option

--- a/test/test_keeper_exec_shell_cwd_response.ml
+++ b/test/test_keeper_exec_shell_cwd_response.ml
@@ -1,9 +1,9 @@
 (** Integration pin for PR-3 of the [Keeper_cwd_response] series.
 
     PR-3 wires [Keeper_cwd_response.to_yojson_response] into the
-    sandbox-backend response builders inside [keeper_shell_ops.ml]:
+    sandbox-backend response builders inside [keeper_shell_read_ops.ml]:
 
-    - [render_sandbox_process_result] (op=pwd / git_status / git_diff / ...)
+    - [render_sandbox_process_result] (op=pwd / git_status / git_log / ...)
     - [op="git_log"] runtime branch (1 cwd-echo site under backend [via])
 
     All other [cwd] usages in the file are intentionally left
@@ -40,9 +40,9 @@ let read_source path =
 let find_source_path () =
   List.find_opt Sys.file_exists
     [
-      "lib/keeper/keeper_shell_ops.ml"
-    ; "../lib/keeper/keeper_shell_ops.ml"
-    ; "../../lib/keeper/keeper_shell_ops.ml"
+      "lib/keeper/keeper_shell_read_ops.ml"
+    ; "../lib/keeper/keeper_shell_read_ops.ml"
+    ; "../../lib/keeper/keeper_shell_read_ops.ml"
     ]
 
 let count_substring src needle =

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -179,12 +179,14 @@ let test_keeper_raw_command_parse_owner () =
     ~under:"lib/keeper"
     ~needle:"Exec_policy.parse_string_to_ir"
     [ "lib/keeper/keeper_shell_command_parse.ml"; "lib/keeper/keeper_shell_ir.ml" ];
-  assert_contains "lib/keeper/keeper_shell_command_parse.mli" "parse_cmd_to_ir_opt"
+  assert_contains "lib/keeper/keeper_shell_command_parse.mli" "parse_cmd_to_ir_opt";
+  assert_contains "lib/keeper/keeper_shell_ir.ml" "let coding_command_context"
 
 let test_keeper_command_word_classifier_owner () =
   let words_ml = "lib/keeper/keeper_shell_command_words.ml" in
   let semantics_ml = "lib/keeper/keeper_shell_command_semantics.ml" in
   let shell_ops_ml = "lib/keeper/keeper_shell_ops.ml" in
+  let setup_ml = "lib/keeper/keeper_shell_ops_setup.ml" in
   assert_only_sources_contain
     ~under:"lib/keeper"
     ~needle:"Exec_policy_mutation_classifier"
@@ -192,6 +194,7 @@ let test_keeper_command_word_classifier_owner () =
   assert_contains words_ml "let first_token_of_cmd";
   assert_contains words_ml "let cmd_prefix";
   assert_not_contains shell_ops_ml "Exec_policy_mutation_classifier";
+  assert_contains setup_ml "Keeper_shell_command_words.cmd_prefix";
   assert_not_contains semantics_ml "cmd_prefix"
 
 let test_nested_runtime_uses_shell_command_words () =
@@ -262,27 +265,37 @@ let test_gh_repo_owns_repo_slug_discovery () =
   assert_not_contains "lib/keeper/keeper_tool_pr_review.ml" "Keeper_gh_command_parse.repo_slug"
 
 let test_shell_read_ops_use_sandbox_read_runner () =
-  let rel = "lib/keeper/keeper_shell_ops.ml" in
-  assert_contains rel "Keeper_sandbox_read_runner.";
-  assert_contains rel "Keeper_sandbox_read_runner.backend_via";
-  assert_not_contains rel "Keeper_sandbox_read_backend.";
-  assert_not_contains rel "\"via\", `String \"docker\""
+  let read_ops_ml = "lib/keeper/keeper_shell_read_ops.ml" in
+  let shell_ops_ml = "lib/keeper/keeper_shell_ops.ml" in
+  assert_contains "lib/dune" "keeper_shell_read_ops";
+  assert_contains read_ops_ml "Keeper_sandbox_read_runner.";
+  assert_contains read_ops_ml "Keeper_sandbox_read_runner.backend_via";
+  assert_not_contains read_ops_ml "Keeper_sandbox_read_backend.";
+  assert_not_contains read_ops_ml "\"via\", `String \"docker\"";
+  assert_not_contains shell_ops_ml "Keeper_sandbox_read_runner.";
+  assert_not_contains shell_ops_ml "Keeper_sandbox_read_backend.";
+  assert_not_contains shell_ops_ml "\"via\", `String \"docker\""
 
 let test_shell_path_owner () =
   let path_ml = "lib/keeper/keeper_shell_path.ml" in
   let shell_ops_ml = "lib/keeper/keeper_shell_ops.ml" in
+  let read_ops_ml = "lib/keeper/keeper_shell_read_ops.ml" in
   let gh_pr_ml = "lib/keeper/keeper_tool_github_pr.ml" in
   assert_contains "lib/dune" "keeper_shell_path";
   assert_contains path_ml "let resolve_keeper_shell_read_cwd";
   assert_contains path_ml "let resolve_keeper_shell_write_cwd";
   assert_contains path_ml "let resolve_keeper_shell_read_path";
   assert_contains path_ml "let shell_command_available";
-  assert_contains shell_ops_ml "Keeper_shell_path.resolve_keeper_shell_read_path";
+  assert_contains read_ops_ml "Keeper_shell_path.resolve_keeper_shell_read_path";
+  assert_contains read_ops_ml "Keeper_shell_path.resolve_keeper_shell_read_cwd";
+  assert_contains read_ops_ml "Keeper_shell_path.shell_command_available";
   assert_contains shell_ops_ml "Keeper_shell_path.resolve_keeper_shell_read_cwd";
-  assert_contains shell_ops_ml "Keeper_shell_path.shell_command_available";
+  assert_not_contains shell_ops_ml "Keeper_shell_path.resolve_keeper_shell_read_path";
+  assert_not_contains shell_ops_ml "Keeper_shell_path.shell_command_available";
   assert_contains gh_pr_ml "Keeper_shell_path.resolve_keeper_shell_write_cwd";
   assert_contains gh_pr_ml "Keeper_shell_path.resolve_keeper_shell_read_cwd";
   assert_not_contains shell_ops_ml "Keeper_shell_shared.resolve_keeper_shell";
+  assert_not_contains read_ops_ml "Keeper_shell_shared.resolve_keeper_shell";
   assert_not_contains gh_pr_ml "Keeper_shell_shared.resolve_keeper_shell"
 
 let test_shell_shared_is_removed () =
@@ -300,31 +313,37 @@ let test_shell_shared_is_removed () =
       "keeper_shell_runtime_paths";
       "keeper_shell_path";
       "keeper_shell_readonly_policy";
+      "keeper_shell_read_ops";
     ];
   assert_contains exec_shell_ml "Keeper_shell_op.valid_strings";
   assert_contains exec_shell_ml "Keeper_shell_timeout.gh_min_timeout_sec";
   assert_contains exec_shell_ml "Keeper_shell_runtime_paths.rewrite_turn_runtime_paths_to_host";
   assert_contains exec_shell_ml "Keeper_shell_readonly_policy.readonly_hint_of_category";
-  assert_contains shell_ops_ml "Keeper_shell_timeout.read_timeout_sec";
+  assert_contains "lib/keeper/keeper_shell_read_ops.ml" "Keeper_shell_timeout.read_timeout_sec";
   assert_contains shell_ops_ml "Keeper_shell_runtime_paths.rewrite_turn_runtime_paths_to_host";
   assert_contains bash_ml "Keeper_shell_timeout.clamp_shell_timeout";
   assert_contains exec_tools_ml "Keeper_shell_op.valid_strings";
   assert_not_contains shell_ops_ml "Keeper_shell_shared.";
+  assert_not_contains "lib/keeper/keeper_shell_read_ops.ml" "Keeper_shell_shared.";
   assert_not_contains bash_ml "Keeper_shell_shared.";
   assert_not_contains exec_tools_ml "Keeper_shell_shared.";
   assert_not_contains exec_shell_ml "Keeper_shell_shared"
 
 let test_shell_ops_host_ir_uses_keeper_shell_ir_facade () =
-  let rel = "lib/keeper/keeper_shell_ops.ml" in
-  assert_contains rel "Keeper_shell_ir.simple";
-  assert_contains rel "Keeper_shell_ir.dispatch";
-  assert_not_contains rel "Shell_gate.gate_typed";
-  assert_not_contains rel "Exec_policy.validate_shell_ir_paths";
-  assert_not_contains rel "Exec_dispatch.dispatch_decided";
-  assert_not_contains rel "Shell_ir_risk.classify";
-  assert_not_contains rel "Masc_exec.Shell_ir.Simple";
-  assert_not_contains rel "Masc_exec.Shell_ir.Lit";
-  assert_not_contains rel "Keeper_shell_shared.run_argv_with_status_retry_eintr"
+  let shell_ops_ml = "lib/keeper/keeper_shell_ops.ml" in
+  let read_ops_ml = "lib/keeper/keeper_shell_read_ops.ml" in
+  List.iter
+    (fun rel ->
+       assert_contains rel "Keeper_shell_ir.simple";
+       assert_contains rel "Keeper_shell_ir.dispatch";
+       assert_not_contains rel "Shell_gate.gate_typed";
+       assert_not_contains rel "Exec_policy.validate_shell_ir_paths";
+       assert_not_contains rel "Exec_dispatch.dispatch_decided";
+       assert_not_contains rel "Shell_ir_risk.classify";
+       assert_not_contains rel "Masc_exec.Shell_ir.Simple";
+       assert_not_contains rel "Masc_exec.Shell_ir.Lit";
+       assert_not_contains rel "Keeper_shell_shared.run_argv_with_status_retry_eintr")
+    [ shell_ops_ml; read_ops_ml ]
 
 let test_keeper_bash_dispatch_uses_keeper_shell_ir_facade () =
   let rel = "lib/keeper/keeper_shell_bash.ml" in

--- a/test/test_pr_c_coreutils_migration.ml
+++ b/test/test_pr_c_coreutils_migration.ml
@@ -2,11 +2,11 @@ open Alcotest
 
 (** RFC-0084 host-config-cleanup-C — coreutils path migration.
 
-    PR-C migrates the 6 absolute binary path literals in
-    [lib/keeper/keeper_shell_ops.ml] (pwd / ls / cat / head / tail / wc)
+    PR-C migrated the 6 absolute binary path literals used by
+    keeper_shell read ops (pwd / ls / cat / head / tail / wc)
     to the typed [Host_config.coreutils] record field.  The single
     [let coreutils = (Host_config.host ()).coreutils]
-    binding at module-init time is the only [Host_config] call.
+    binding in [keeper_shell_ops_setup.ml] is the only [Host_config] call.
 
     Behaviour is byte-identical today; the migration establishes a
     single source of truth so a future PR can flip
@@ -15,9 +15,10 @@ open Alcotest
 
     Pins:
     - 0 occurrences of any of the 6 absolute literals in
-      [keeper_shell_ops.ml] (regression guard)
+      [keeper_shell_ops.ml], [keeper_shell_read_ops.ml], or
+      [keeper_shell_ops_setup.ml] (regression guard)
     - [Host_config.host] is invoked exactly once
-      from the module (positive assertion + no per-call-site
+      from the setup module (positive assertion + no per-call-site
       regression)
     - Byte-identical equality between the bound [coreutils] field
       and the typed surface (cross-check) *)
@@ -47,7 +48,16 @@ let count_substring ~haystack ~needle =
 ;;
 
 let test_no_coreutils_literals_in_shell_ops () =
-  let content = read_file "lib/keeper/keeper_shell_ops.ml" in
+  let content =
+    String.concat "\n"
+      (List.map
+         read_file
+         [
+           "lib/keeper/keeper_shell_ops.ml";
+           "lib/keeper/keeper_shell_read_ops.ml";
+           "lib/keeper/keeper_shell_ops_setup.ml";
+         ])
+  in
   let needles =
     [ {|"/bin/pwd"|}; {|"/bin/ls"|}; {|"/bin/cat"|}
     ; {|"/usr/bin/head"|}; {|"/usr/bin/tail"|}; {|"/usr/bin/wc"|}
@@ -60,19 +70,19 @@ let test_no_coreutils_literals_in_shell_ops () =
   in
   (check int)
     "literal occurrences of the 6 coreutils paths in \
-     lib/keeper/keeper_shell_ops.ml must be 0 after PR-C"
+     shell op modules must be 0 after PR-C"
     pinned_literal_count total
 ;;
 
 let test_single_host_config_invocation () =
-  let content = read_file "lib/keeper/keeper_shell_ops.ml" in
+  let content = read_file "lib/keeper/keeper_shell_ops_setup.ml" in
   let occurrences =
     count_substring ~haystack:content
       ~needle:"Host_config.host"
   in
   (check int)
     "Host_config.host must be invoked exactly once \
-     from lib/keeper/keeper_shell_ops.ml after PR-C"
+     from lib/keeper/keeper_shell_ops_setup.ml after PR-C"
     pinned_host_config_invocations occurrences
 ;;
 


### PR DESCRIPTION
## Summary
- extract structured keeper_shell read/list/search handlers into Keeper_shell_read_ops
- keep keeper_shell_ops as the public dispatcher for alias normalization, git_diff/git_worktree, and unsupported-op reporting
- update boundary/doc ratchets for the read-op owner and local-runtime facade caller fallout

## Verification
- ocamlformat --check lib/keeper/keeper_tag_dispatch.ml lib/mcp_server_eio_execute.ml lib/keeper/keeper_shell_ops.ml lib/keeper/keeper_shell_read_ops.ml lib/keeper/keeper_shell_read_ops.mli test/test_keeper_sandbox_boundary_policy.ml test/test_pr_c_coreutils_migration.ml test/test_keeper_exec_shell_cwd_response.ml
- git diff --check HEAD~1..HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_sandbox_boundary_policy.exe test/test_pr_c_coreutils_migration.exe test/test_keeper_exec_shell_cwd_response.exe test/test_keeper_shell_ops.exe
- ./_build/default/test/test_keeper_sandbox_boundary_policy.exe
- ./_build/default/test/test_pr_c_coreutils_migration.exe
- ./_build/default/test/test_keeper_exec_shell_cwd_response.exe
- ./_build/default/test/test_keeper_shell_ops.exe