### PR TITLE
fix(cascade): TTL-based auto-expire for disabled providers (#18502)

### DIFF
--- a/lib/cascade/cascade_preflight_state.ml
+++ b/lib/cascade/cascade_preflight_state.ml
@@ -23,6 +23,12 @@ type record_outcome =
 
 let default_threshold = 5
 
+(** TTL in seconds after which a disabled provider is automatically
+    re-enabled. Prevents permanent cascade death-spiral when the
+    underlying issue (network blip, cold start, rate-limit window)
+    resolves itself (GitHub #18502). *)
+let disabled_ttl_seconds = 600.0
+
 (* Stable kebab-case slug for log interpolation and metric labels. *)
 let reason_slug = function
   | Health_check_failed_repeatedly -> "health-check-failed-repeatedly"
@@ -72,7 +78,10 @@ end)
 
 type t = {
   counts : int FpTbl.t;
-  disabled : unit StrTbl.t;
+  disabled : (float * string) StrTbl.t;
+      (** Maps provider → (disabled_at_timestamp, tier_group).
+          The timestamp enables TTL-based auto-expiry so providers
+          don't stay disabled forever (GitHub #18502). *)
   mu : Stdlib.Mutex.t;
       (* Stdlib.Mutex selected per feedback_ocaml5-mutex-selection.md:
          cross-fiber, single-domain, no Eio effect dependency. The
@@ -98,7 +107,7 @@ let with_lock t f =
 
 (* ── Public API ─────────────────────────────────────────────────── *)
 
-let record t ~tier_group ~provider ~reason : record_outcome =
+let record ?(clock = Time_compat.now) t ~tier_group ~provider ~reason : record_outcome =
   let fp = { tier_group; provider; reason } in
   with_lock t (fun () ->
     (* Always tick the per-call counter so dashboards see absolute
@@ -120,7 +129,7 @@ let record t ~tier_group ~provider ~reason : record_outcome =
       then `First
       else if next >= t.threshold
       then (
-        StrTbl.replace t.disabled provider ();
+        StrTbl.replace t.disabled provider (clock (), tier_group);
         Prometheus.inc_counter metric_provider_disabled
           ~labels:
             [ ("cascade", tier_group)
@@ -132,13 +141,36 @@ let record t ~tier_group ~provider ~reason : record_outcome =
       else `Repeated next))
 ;;
 
-let is_disabled t ~provider =
-  with_lock t (fun () -> StrTbl.mem t.disabled provider)
+let is_disabled ?(clock = Time_compat.now) t ~provider =
+  with_lock t (fun () ->
+    match StrTbl.find_opt t.disabled provider with
+    | None -> false
+    | Some (disabled_at, _tier_group) ->
+      let age = clock () -. disabled_at in
+      if age >= disabled_ttl_seconds
+      then (
+        (* Auto-expire: provider has been disabled long enough that the
+           underlying issue may have resolved (GitHub #18502). *)
+        StrTbl.remove t.disabled provider;
+        (* Drop all fingerprints so next record starts from First. *)
+        let stale_keys =
+          FpTbl.fold
+            (fun fp _count acc ->
+              if String.equal fp.provider provider then fp :: acc else acc)
+            t.counts
+            []
+        in
+        List.iter (fun fp -> FpTbl.remove t.counts fp) stale_keys;
+        Prometheus.inc_counter metric_provider_re_enabled
+          ~labels:[ ("provider", provider); ("reason", "ttl_auto_expire") ]
+          ();
+        false)
+      else true)
 ;;
 
 let reset_on_health_recovery t ~provider =
   with_lock t (fun () ->
-    let was_disabled = StrTbl.mem t.disabled provider in
+    let was_disabled = Option.is_some (StrTbl.find_opt t.disabled provider) in
     StrTbl.remove t.disabled provider;
     (* Drop all fingerprints for this provider, regardless of reason. *)
     let stale_keys =
@@ -159,7 +191,7 @@ let reset_on_health_recovery t ~provider =
 
 let disabled_providers t =
   with_lock t (fun () ->
-    StrTbl.fold (fun provider () acc -> provider :: acc) t.disabled [])
+    StrTbl.fold (fun provider (_ts, _tg) acc -> provider :: acc) t.disabled [])
 ;;
 
 let reset_for_test t =

--- a/lib/cascade/cascade_preflight_state.mli
+++ b/lib/cascade/cascade_preflight_state.mli
@@ -70,6 +70,11 @@ type record_outcome =
     [`Threshold_disable]. *)
 val default_threshold : int
 
+(** TTL in seconds after which a disabled provider is automatically
+    re-enabled, even without an explicit [reset_on_health_recovery]
+    call (GitHub #18502). *)
+val disabled_ttl_seconds : float
+
 (** Opaque tracker handle. The module exposes a process-singleton
     [global], but creating local instances is supported for tests. *)
 type t
@@ -89,11 +94,14 @@ val global : t
     [masc_cascade_provider_disabled_total] (on the [`Threshold_disable]
     transition). *)
 val record :
+  ?clock:(unit -> float) ->
   t -> tier_group:string -> provider:string -> reason:reason -> record_outcome
 
 (** True iff the provider is currently in the disabled list (i.e. some
-    fingerprint crossed threshold and recovery has not happened yet). *)
-val is_disabled : t -> provider:string -> bool
+    fingerprint crossed threshold and recovery has not happened yet).
+    Disabled entries older than [disabled_ttl_seconds] are automatically
+    expired and re-enabled (returns [false]). *)
+val is_disabled : ?clock:(unit -> float) -> t -> provider:string -> bool
 
 (** Clear all fingerprints for the given provider and remove it from
     the disabled list. Returns [true] iff the provider was previously

--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -97,7 +97,7 @@ let dispatch
     (* ── Tier A: config + agent_name only ──────────────────────── *)
     | Mod_plan -> Tool_plan.dispatch { config } ~name ~args
     | Mod_local_runtime ->
-      Tool_local_runtime.dispatch { Tool_local_runtime.config; agent_name } ~name ~args
+      Tool_local_runtime.dispatch ({ Tool_local_runtime_core.config; agent_name } : Tool_local_runtime_core.context) ~name ~args
       |> Option.map (fun (success, message) ->
         if success then ok message else err message)
     | Mod_worktree ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -571,7 +571,7 @@ let execute_tool_eio
                    Tool_operator.dispatch ctx ~name ~args:coerced_args
                  | Mod_local_runtime ->
                    Tool_local_runtime.dispatch
-                     { Tool_local_runtime.config; agent_name }
+                     ({ Tool_local_runtime_core.config; agent_name } : Tool_local_runtime_core.context)
                      ~name
                      ~args:coerced_args
                    |> Option.map (fun (ok, msg) ->

--- a/test/cascade_preflight_state/test_cascade_preflight_state.ml
+++ b/test/cascade_preflight_state/test_cascade_preflight_state.ml
@@ -267,6 +267,62 @@ let test_default_threshold_is_5 () =
   Alcotest.(check int) "default threshold matches spec (5)" 5 S.default_threshold
 ;;
 
+(* ── TTL-based auto-expire of disabled providers (GitHub #18502) ── *)
+
+let test_disabled_provider_auto_expires_after_ttl () =
+  let t = S.create ~threshold:2 () in
+  let fixed_time = 1000.0 in
+  let clock_0 () = fixed_time in
+  (* Drive to threshold using fixed clock *)
+  let _ =
+    S.record ~clock:clock_0 t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  let _ =
+    S.record ~clock:clock_0 t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  (* Immediately after: disabled *)
+  Alcotest.(check bool) "disabled immediately after threshold" true
+    (S.is_disabled ~clock:clock_0 t ~provider:"http://a");
+  (* Just before TTL: still disabled *)
+  let clock_before () = fixed_time +. (S.disabled_ttl_seconds -. 1.0) in
+  Alcotest.(check bool) "still disabled just before TTL" true
+    (S.is_disabled ~clock:clock_before t ~provider:"http://a");
+  (* After TTL: auto-expired *)
+  let clock_after () = fixed_time +. (S.disabled_ttl_seconds +. 1.0) in
+  Alcotest.(check bool) "auto-expired after TTL" false
+    (S.is_disabled ~clock:clock_after t ~provider:"http://a");
+  (* Second call also returns false (entry was removed) *)
+  Alcotest.(check bool) "stays expired after removal" false
+    (S.is_disabled ~clock:clock_after t ~provider:"http://a")
+;;
+
+let test_ttl_disabled_provider_re_enables_then_re_thresholds () =
+  let t = S.create ~threshold:2 () in
+  let fixed_time = 1000.0 in
+  let clock_0 () = fixed_time in
+  (* Drive to threshold using fixed clock *)
+  let _ =
+    S.record ~clock:clock_0 t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  let _ =
+    S.record ~clock:clock_0 t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  (* Expire via TTL *)
+  let clock_after () = fixed_time +. S.disabled_ttl_seconds +. 1.0 in
+  Alcotest.(check bool) "expired" false
+    (S.is_disabled ~clock:clock_after t ~provider:"http://a");
+  (* New record after expiry starts fresh at First *)
+  let r =
+    S.record t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  Alcotest.(check outcome) "fresh start after TTL expiry" `First r
+;;
+
 let () =
   Alcotest.run "cascade_preflight_state"
     [ ( "first / repeated / threshold"
@@ -309,6 +365,12 @@ let () =
     ; ( "constants"
       , [ Alcotest.test_case "default threshold = 5" `Quick
             test_default_threshold_is_5
+        ] )
+    ; ( "TTL auto-expire (GitHub #18502)"
+      , [ Alcotest.test_case "disabled provider auto-expires after TTL" `Quick
+            test_disabled_provider_auto_expires_after_ttl
+        ; Alcotest.test_case "expired provider re-thresholds from scratch" `Quick
+            test_ttl_disabled_provider_re_enables_then_re_thresholds
         ] )
     ]
 ;;

--- a/test/cascade_preflight_state/time_compat.ml
+++ b/test/cascade_preflight_state/time_compat.ml
@@ -1,0 +1,3 @@
+(* Standalone test stub for Time_compat — mirrors the real module's
+   [now] signature using Unix.gettimeofday. *)
+let now () = Unix.gettimeofday ()

--- a/test/cascade_preflight_state/time_compat.mli
+++ b/test/cascade_preflight_state/time_compat.mli
@@ -1,0 +1,1 @@
+val now : unit -> float


### PR DESCRIPTION
## Summary
- Disabled providers were **permanently stuck** in the disabled set, causing cascade tier-group exhaustion when transient issues (network blip, cold start, rate-limit window) resolved themselves
- Added `disabled_ttl_seconds` (600s = 10min) auto-expiry with injectable clock for deterministic testing
- `is_disabled` now checks TTL and auto-expires stale entries, clearing fingerprint counts so next `record` starts from `First`
- Includes build fix for `Tool_local_runtime_core.context` type annotation (from PR #18496)

## Problem (GitHub #18502)
When all cascade tiers fail preflight health checks, providers get disabled with `Threshold_disable`. Previously, only `reset_on_health_recovery` (called on explicit health recovery) could re-enable them. If the upstream issue self-resolved (common for network blips and cold starts), the provider stayed permanently disabled, making the entire LLM path die permanently.

## Changes
| File | Change |
|------|--------|
| `cascade_preflight_state.ml` | `disabled` table stores `(float * string)` = (timestamp, tier_group). `is_disabled` checks TTL, auto-expires, clears fingerprint counts. `record` accepts `?clock`. |
| `cascade_preflight_state.mli` | Exports `disabled_ttl_seconds`, updated `record` and `is_disabled` signatures |
| `test_cascade_preflight_state.ml` | 2 new TTL tests: auto-expire after TTL, re-threshold from scratch |
| `time_compat.ml/mli` | Standalone test stubs |
| `keeper_tag_dispatch.ml` | Build fix: `Tool_local_runtime_core.context` |
| `mcp_server_eio_execute.ml` | Build fix: `Tool_local_runtime_core.context` |

## Test plan
- [x] 15/15 Alcotest standalone tests pass (including 2 new TTL tests)
- [x] `dune build lib/cascade/cascade_preflight_state.ml` succeeds
- [ ] CI full build passes
- [ ] Verify TTL auto-expire behavior in production logs (should see `masc_cascade_provider_re_enabled_total{reason="ttl_auto_expire"}`)

Closes #18502

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>