### PR TITLE
refactor(keeper): drop scheduled autonomous aliases

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 02:31:33 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 09:55:09 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -406,6 +406,12 @@
             <td><span class="status now">draft PR #18492</span></td>
             <td>Stop interpreting explicit empty or whitespace-only <code>mode</code> as <code>overwrite</code>. Missing <code>mode</code> still defaults before parsing, but caller-supplied values must be canonical <code>overwrite</code>, <code>append</code>, or <code>patch</code>.</td>
             <td>The fs-edit regression test asserts <code>mode=""</code> is rejected and does not write a file. Local OCaml format/parse, diff, grep, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
+          </tr>
+          <tr>
+            <td><code>scheduled_autonomous_*</code> Keeper type/function aliases</td>
+            <td><span class="status now">local branch</span></td>
+            <td>Delete compatibility aliases for <code>scheduled_autonomous_policy</code>, <code>scheduled_autonomous_cycle_outcome</code>, <code>scheduled_autonomous_runtime</code>, outcome string converters, and <code>map_scheduled_autonomous_rt</code>. Metrics code now types scheduled-autonomous outcomes as canonical <code>proactive_cycle_outcome</code> while preserving live channel and JSON field names.</td>
+            <td>Backstop grep is clean for the removed alias symbols across live code and tests. Local OCaml format/parse and diff checks pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>
           <tr>
             <td><code>Tool_local_runtime</code> core facade include</td>

--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -409,7 +409,7 @@
           </tr>
           <tr>
             <td><code>scheduled_autonomous_*</code> Keeper type/function aliases</td>
-            <td><span class="status now">local branch</span></td>
+            <td><span class="status now">draft PR #18525</span></td>
             <td>Delete compatibility aliases for <code>scheduled_autonomous_policy</code>, <code>scheduled_autonomous_cycle_outcome</code>, <code>scheduled_autonomous_runtime</code>, outcome string converters, and <code>map_scheduled_autonomous_rt</code>. Metrics code now types scheduled-autonomous outcomes as canonical <code>proactive_cycle_outcome</code> while preserving live channel and JSON field names.</td>
             <td>Backstop grep is clean for the removed alias symbols across live code and tests. Local OCaml format/parse and diff checks pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -40,8 +40,6 @@ type proactive_policy =
   ; cooldown_sec : int
   }
 
-type scheduled_autonomous_policy = proactive_policy
-
 type proactive_cycle_outcome =
   | Proactive_never_started
   | Proactive_unknown
@@ -50,8 +48,6 @@ type proactive_cycle_outcome =
   | Proactive_tool_use
   | Proactive_mixed_response
   | Proactive_error
-
-type scheduled_autonomous_cycle_outcome = proactive_cycle_outcome
 
 (* -- Runtime types (moved into agent_runtime_state) -- *)
 
@@ -86,8 +82,6 @@ type proactive_runtime =
           Used by [effective_scheduled_autonomous_cooldown] for exponential
           backoff: cooldown *= 2^min(n, 3), capping at 8x. *)
   }
-
-type scheduled_autonomous_runtime = proactive_runtime
 
 (* ── Structured blocker classification ──────────────────────── *)
 
@@ -629,9 +623,6 @@ let () =
     ]
 ;;
 
-let scheduled_autonomous_cycle_outcome_to_string = proactive_cycle_outcome_to_string
-let scheduled_autonomous_cycle_outcome_of_string = proactive_cycle_outcome_of_string
-
 (* -- Updater helpers for nested record updates -- *)
 
 let map_runtime (f : agent_runtime_state -> agent_runtime_state) (m : keeper_meta)
@@ -675,7 +666,6 @@ let map_proactive_rt (f : proactive_runtime -> proactive_runtime) (m : keeper_me
   { m with runtime = { m.runtime with proactive_rt = f m.runtime.proactive_rt } }
 ;;
 
-let map_scheduled_autonomous_rt = map_proactive_rt
 let now_iso () = Masc_domain.now_iso ()
 let keeper_legacy_model_arg_names = [ "models"; "allowed_models"; "active_model" ]
 

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -12,13 +12,10 @@
     {!Keeper_meta_contract.tool_preset} interchangeably (type
     identity preserved through the cascade).
 
-    Internal: ~5 helpers stay private —
+    Internal: ~3 helpers stay private —
     \[blocker_class_of_serialized_string] (deserializer used
-    only by JSON parsing), \[scheduled_autonomous_cycle_outcome_to_string]
-    / \[scheduled_autonomous_cycle_outcome_of_string] (aliases
-    of the proactive_cycle_outcome counterparts kept available
-    for the [include] cascade), \[map_compaction_rt] /
-    \[map_proactive_rt] / \[map_scheduled_autonomous_rt]
+    only by JSON parsing), \[map_compaction_rt] /
+    \[map_proactive_rt]
     (nested-record updaters that callers reach via the higher-level
     {!map_runtime} / {!map_usage}), \[keeper_legacy_model_arg_names]
     (data table consumed by the legacy-arg rejector in
@@ -65,10 +62,6 @@ type proactive_policy = {
   cooldown_sec : int;
 }
 
-type scheduled_autonomous_policy = proactive_policy
-(** Alias preserved for callers that reach the type via the
-    older name.  Drift would break legacy keeper persona files. *)
-
 type proactive_cycle_outcome =
   | Proactive_never_started
   | Proactive_unknown
@@ -83,8 +76,6 @@ type proactive_cycle_outcome =
     [proactive_cycle_outcome_of_string] must form a bijection)
     via an [assert_roundtrip] block — adding a variant fails
     compile until both directions are wired. *)
-
-type scheduled_autonomous_cycle_outcome = proactive_cycle_outcome
 
 (** {1 Runtime state types} *)
 
@@ -125,8 +116,6 @@ type proactive_runtime = {
           exponential backoff: cooldown *= 2^min(n, 3),
           capping at 8x.  Resets on any productive cycle. *)
 }
-
-type scheduled_autonomous_runtime = proactive_runtime
 
 type usage_metrics = {
   total_turns : int;
@@ -422,16 +411,6 @@ val proactive_cycle_outcome_of_string :
     [_to_string] is parsed back identically, so unknown means
     operator error, not silent variant drift. *)
 
-val scheduled_autonomous_cycle_outcome_to_string :
-  scheduled_autonomous_cycle_outcome -> string
-(** Alias of {!proactive_cycle_outcome_to_string} preserved for
-    callers that reach the symbol via the older name.  Same
-    canonical labels. *)
-
-val scheduled_autonomous_cycle_outcome_of_string :
-  string -> scheduled_autonomous_cycle_outcome
-(** Alias of {!proactive_cycle_outcome_of_string}. *)
-
 (** {1 Updater helpers} *)
 
 val now_iso : unit -> string
@@ -473,14 +452,6 @@ val map_proactive_rt :
   keeper_meta ->
   keeper_meta
 (** Nested update of [m.runtime.proactive_rt]. *)
-
-val map_scheduled_autonomous_rt :
-  (scheduled_autonomous_runtime ->
-   scheduled_autonomous_runtime) ->
-  keeper_meta ->
-  keeper_meta
-(** Alias of {!map_proactive_rt} preserved for the older
-    ([scheduled_autonomous_*]) call-site naming. *)
 
 (** {1 Legacy model-arg sentinel list} *)
 

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -78,8 +78,6 @@ type proactive_policy = {
   cooldown_sec: int;
 }
 
-type scheduled_autonomous_policy = proactive_policy
-
 type proactive_cycle_outcome =
   | Proactive_never_started
   | Proactive_unknown
@@ -88,8 +86,6 @@ type proactive_cycle_outcome =
   | Proactive_tool_use
   | Proactive_mixed_response
   | Proactive_error
-
-type scheduled_autonomous_cycle_outcome = proactive_cycle_outcome
 
 type tool_preset =
   | Minimal
@@ -142,8 +138,6 @@ type proactive_runtime = {
   work_discovery_count : int;
   consecutive_noop_count : int;
 }
-
-type scheduled_autonomous_runtime = proactive_runtime
 
 type usage_metrics = {
   total_turns: int;
@@ -360,10 +354,6 @@ val valid_tool_preset_strings : string list
 
 val proactive_cycle_outcome_to_string : proactive_cycle_outcome -> string
 val proactive_cycle_outcome_of_string : string -> proactive_cycle_outcome
-val scheduled_autonomous_cycle_outcome_to_string :
-  scheduled_autonomous_cycle_outcome -> string
-val scheduled_autonomous_cycle_outcome_of_string :
-  string -> scheduled_autonomous_cycle_outcome
 val tool_access_preset : tool_access -> tool_preset option
 val tool_access_custom_allowlist : tool_access -> string list option
 val tool_access_also_allowlist : tool_access -> string list
@@ -378,9 +368,6 @@ val zero_usage : usage_metrics
 val reset_runtime_state : keeper_meta -> keeper_meta
 val map_compaction_rt : (compaction_runtime -> compaction_runtime) -> keeper_meta -> keeper_meta
 val map_proactive_rt : (proactive_runtime -> proactive_runtime) -> keeper_meta -> keeper_meta
-val map_scheduled_autonomous_rt :
-  (scheduled_autonomous_runtime -> scheduled_autonomous_runtime) ->
-  keeper_meta -> keeper_meta
 
 (** {1 Runtime meta write sync hook} *)
 

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -160,7 +160,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
               | None -> "unified:validated_evidence(unreachable)")
            else if not has_text then
              "unified:"
-             ^ scheduled_autonomous_cycle_outcome_to_string Proactive_silent
+             ^ proactive_cycle_outcome_to_string Proactive_silent
             else if has_text then "unified:text_response"
             else rt.proactive_rt.last_reason);
         last_preview =

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -145,12 +145,12 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
         ( "scheduled_autonomous_outcome",
           match scheduled_autonomous_outcome with
           | Some outcome ->
-              `String (scheduled_autonomous_cycle_outcome_to_string outcome)
+              `String (proactive_cycle_outcome_to_string outcome)
           | None -> `Null );
         ( "proactive_outcome",
           match scheduled_autonomous_outcome with
           | Some outcome ->
-              `String (scheduled_autonomous_cycle_outcome_to_string outcome)
+              `String (proactive_cycle_outcome_to_string outcome)
           | None -> `Null );
         ("tool_call_count", `Int result.tool_calls_made);
         ("tools_used", `List (List.map (fun s -> `String s) result.tools_used));

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -58,7 +58,7 @@ let is_scheduled_autonomous_cycle_of_observation
 
 let scheduled_autonomous_outcome_of_result
     ~(has_text : bool) ~(has_tool_calls : bool) :
-    scheduled_autonomous_cycle_outcome =
+    proactive_cycle_outcome =
   match has_text, has_tool_calls with
   | false, false -> Proactive_silent
   | true, false -> Proactive_text_response
@@ -432,7 +432,7 @@ let accountability_evidence_refs
 
 let scheduled_autonomous_outcome_for_result
     (result : Keeper_agent_run.run_result) :
-    scheduled_autonomous_cycle_outcome =
+    proactive_cycle_outcome =
   scheduled_autonomous_outcome_of_result
     ~has_text:(String.trim result.response_text <> "")
     ~has_tool_calls:(has_visible_tool_signal result)

--- a/lib/keeper/keeper_unified_metrics_support.mli
+++ b/lib/keeper/keeper_unified_metrics_support.mli
@@ -92,10 +92,10 @@ val accountability_evidence_refs :
 val scheduled_autonomous_outcome_of_result :
   has_text:bool ->
   has_tool_calls:bool ->
-  Keeper_types.scheduled_autonomous_cycle_outcome
+  Keeper_types.proactive_cycle_outcome
 
 val scheduled_autonomous_outcome_for_result :
-  Keeper_agent_run.run_result -> Keeper_types.scheduled_autonomous_cycle_outcome
+  Keeper_agent_run.run_result -> Keeper_types.proactive_cycle_outcome
 
 val turn_mode_to_string : turn_mode -> string
 val turn_mode_of_string : string -> turn_mode option


### PR DESCRIPTION
## Summary

- delete the remaining `scheduled_autonomous_*` Keeper type/function compatibility aliases from `Keeper_meta_contract` and the `Keeper_types` facade
- type scheduled-autonomous metric outcomes with canonical `proactive_cycle_outcome`
- keep live external labels intact: the `"scheduled_autonomous"` channel and `scheduled_autonomous_outcome` JSON field still exist
- update the legacy purge HTML ledger with this slice

## Verification

- `rg -n "scheduled_autonomous_policy|scheduled_autonomous_cycle_outcome|scheduled_autonomous_runtime|scheduled_autonomous_cycle_outcome_to_string|scheduled_autonomous_cycle_outcome_of_string|map_scheduled_autonomous_rt" lib test scripts dashboard` exits 1
- `opam exec -- ocamlformat --check lib/keeper/keeper_meta_contract.ml lib/keeper/keeper_meta_contract.mli lib/keeper/keeper_types.mli lib/keeper/keeper_unified_metrics_support.ml lib/keeper/keeper_unified_metrics_support.mli lib/keeper/keeper_unified_metrics_snapshot.ml lib/keeper/keeper_unified_metrics_result.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_meta_contract.ml lib/keeper/keeper_meta_contract.mli lib/keeper/keeper_types.mli lib/keeper/keeper_unified_metrics_support.ml lib/keeper/keeper_unified_metrics_support.mli lib/keeper/keeper_unified_metrics_snapshot.ml lib/keeper/keeper_unified_metrics_result.ml`
- `git diff --check`

## Verification gap

- `scripts/dune-local.sh build ./test/test_keeper_unified.exe ./test/test_dashboard_keeper_feature_proof.exe` exits 75 because live bare `dune build --root .` processes are still bypassing the machine-wide Dune guard
