### PR TITLE
refactor(dashboard): drop execution session room alias

### DIFF
--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -29,44 +29,47 @@ function runtimeResolutionRaw(overrides: Record<string, unknown> = {}): Record<s
 }
 
 describe('normalizeExecutionSessionBrief', () => {
-  it('promotes legacy room-only payloads to namespace while keeping the room alias', () => {
-    expect(normalizeExecutionSessionBrief({
+  it('does not promote retired room-only payloads to namespace', () => {
+    const normalized = normalizeExecutionSessionBrief({
       session_id: 'session-1',
       goal: 'legacy payload',
       room: 'default',
-    })).toMatchObject({
+    })
+    expect(normalized).toMatchObject({
       session_id: 'session-1',
       goal: 'legacy payload',
-      namespace: 'default',
-      room: 'default',
+      namespace: null,
     })
+    expect(Object.prototype.hasOwnProperty.call(normalized ?? {}, 'room')).toBe(false)
   })
 
-  it('keeps namespace-only payloads canonical and mirrors the room alias', () => {
-    expect(normalizeExecutionSessionBrief({
+  it('keeps namespace-only payloads canonical without a room alias', () => {
+    const normalized = normalizeExecutionSessionBrief({
       session_id: 'session-2',
       goal: 'flattened payload',
       namespace: 'default',
-    })).toMatchObject({
+    })
+    expect(Object.prototype.hasOwnProperty.call(normalized ?? {}, 'room')).toBe(false)
+    expect(normalized).toMatchObject({
       session_id: 'session-2',
       goal: 'flattened payload',
       namespace: 'default',
-      room: 'default',
     })
   })
 
-  it('prefers namespace when both fields are present during rollout', () => {
-    expect(normalizeExecutionSessionBrief({
+  it('ignores retired room when namespace is present', () => {
+    const normalized = normalizeExecutionSessionBrief({
       session_id: 'session-3',
       goal: 'dual payload',
       namespace: 'default',
       room: 'legacy-room',
-    })).toMatchObject({
+    })
+    expect(normalized).toMatchObject({
       session_id: 'session-3',
       goal: 'dual payload',
       namespace: 'default',
-      room: 'default',
     })
+    expect(Object.prototype.hasOwnProperty.call(normalized ?? {}, 'room')).toBe(false)
   })
 })
 

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -268,13 +268,11 @@ export function normalizeExecutionSessionBrief(raw: unknown): DashboardExecution
   const sessionId = asString(raw.session_id)
   const goal = asString(raw.goal)
   if (!sessionId || !goal) return null
-  const namespace = asString(raw.namespace) ?? asString(raw.room) ?? null
+  const namespace = asString(raw.namespace) ?? null
   return {
     session_id: sessionId,
     goal,
     namespace,
-    // Keep `room` as a pure compatibility alias during namespace flattening.
-    room: namespace,
     status: asString(raw.status),
     health: asString(raw.health),
     member_names: asStringArray(raw.member_names),

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -495,7 +495,6 @@ export interface DashboardExecutionSessionBrief {
   session_id: string
   goal: string
   namespace?: string | null
-  room?: string | null
   status?: string
   health?: string
   member_names: string[]

--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -307,7 +307,7 @@
           </tr>
           <tr>
             <td>Dashboard execution session <code>room</code> alias</td>
-            <td><span class="status now">local branch</span></td>
+            <td><span class="status now">draft PR #18527</span></td>
             <td>Stop emitting the execution-session <code>room</code> mirror for canonical <code>namespace</code>, remove the frontend <code>DashboardExecutionSessionBrief.room</code> field, and stop promoting room-only payloads in the normalizer.</td>
             <td>Compatibility tests now assert room-only payloads are not promoted and normalized session briefs do not carry <code>room</code>. Local OCaml format/parse, dashboard typecheck, targeted Vitest, diff check, and targeted ESLint all pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>

--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -306,6 +306,12 @@
             <td>Tests and callers now import from SSOT modules directly. Dashboard typecheck passes; targeted Vitest covers 3 files / 87 tests. ESLint reports 0 errors, with ignored-file warnings from the existing config.</td>
           </tr>
           <tr>
+            <td>Dashboard execution session <code>room</code> alias</td>
+            <td><span class="status now">local branch</span></td>
+            <td>Stop emitting the execution-session <code>room</code> mirror for canonical <code>namespace</code>, remove the frontend <code>DashboardExecutionSessionBrief.room</code> field, and stop promoting room-only payloads in the normalizer.</td>
+            <td>Compatibility tests now assert room-only payloads are not promoted and normalized session briefs do not carry <code>room</code>. Local OCaml format/parse, dashboard typecheck, targeted Vitest, diff check, and targeted ESLint all pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
+          </tr>
+          <tr>
             <td><code>masc_transition</code> input/action compat aliases</td>
             <td><span class="status done">draft PR #18404</span></td>
             <td>Reject retired <code>to</code> / <code>note</code> transition fields in pre-dispatch validation and remove status-word task-action alias parsing from the handler path.</td>

--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -295,8 +295,6 @@ let build_session_contexts seeds operation_contexts : session_context list =
                  ("session_id", `String seed.session_id);
                  ("goal", `String seed.goal);
                  ("namespace", json_string_option seed.namespace);
-                 (* Legacy room alias now mirrors the flattened namespace. *)
-                 ("room", json_string_option seed.namespace);
                  ("status", `String seed.status);
                  ("health", `String seed.health);
                  ( "member_names",


### PR DESCRIPTION
## Summary

- stop emitting the dashboard execution-session `room` mirror for canonical `namespace`
- remove `DashboardExecutionSessionBrief.room` from the frontend type
- stop promoting room-only execution-session payloads in `normalizeExecutionSessionBrief`
- update the legacy purge HTML ledger with this slice

## Verification

- `opam exec -- ocamlformat --check lib/dashboard/dashboard_execution_sessions.ml`
- `ocamlc -stop-after parsing lib/dashboard/dashboard_execution_sessions.ml`
- `pnpm --dir dashboard install --offline --frozen-lockfile`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run src/store-normalizers.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec eslint src/store-normalizers.ts src/store-normalizers.test.ts src/types/dashboard-execution.ts` (0 errors; existing config reports ignored-file warnings)
- `git diff --check HEAD~1..HEAD`

## Verification gap

- `scripts/dune-local.sh build ./test/test_dashboard_execution.exe` exits 75 because live bare `dune build --root .` processes are bypassing the machine-wide Dune guard
