### PR TITLE
fix(keeper): resolve canonical directive agent aliases

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -46,7 +46,13 @@ let with_keeper_entry_by_identity ~identity ~on_missing f =
   | None ->
     (match Keeper_registry_lookup.find_by_name identity with
      | Some entry -> f entry
-     | None -> on_missing ())
+     | None ->
+       (match Keeper_identity.canonical_keeper_name_from_agent_name identity with
+        | Some keeper_name ->
+          (match Keeper_registry_lookup.find_by_name keeper_name with
+           | Some entry -> f entry
+           | None -> on_missing ())
+        | None -> on_missing ()))
 ;;
 
 let persist_directive_meta_update

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1703,6 +1703,18 @@ let test_directive_keeper_name_alias () =
   | Some e -> check bool "resumed via keeper name alias" false e.meta.paused
   | None -> fail "expected dra1"
 
+let test_directive_canonical_agent_alias () =
+  R.clear ();
+  let _entry = R.register ~base_path:bp "dra2" (make_meta "dra2") in
+  KK.process_directive ~agent_name:"keeper-dra2-agent" "pause";
+  (match R.get ~base_path:bp "dra2" with
+   | Some e -> check bool "paused via canonical keeper agent alias" true e.meta.paused
+   | None -> fail "expected dra2");
+  KK.process_directive ~agent_name:"keeper-dra2-agent" "resume";
+  match R.get ~base_path:bp "dra2" with
+  | Some e -> check bool "resumed via canonical keeper agent alias" false e.meta.paused
+  | None -> fail "expected dra2"
+
 let test_directive_claim () =
   R.clear ();
   let _entry = R.register ~base_path:bp "dc1" (make_meta "dc1") in
@@ -2572,6 +2584,8 @@ let () =
           eio_test "pause directive" test_directive_pause;
           eio_test "resume directive" test_directive_resume;
           eio_test "keeper-name directive alias" test_directive_keeper_name_alias;
+          eio_test "canonical keeper-agent directive alias"
+            test_directive_canonical_agent_alias;
           eio_test "claim directive" test_directive_claim;
           eio_test "pause directive persists meta" test_directive_pause_persists_meta;
           eio_test "claim directive persists meta" test_directive_claim_persists_meta;


### PR DESCRIPTION
## Summary
- Resolve gRPC directive identities like keeper-rondo-agent back to the registered keeper name before reporting not-in-registry.
- Keep existing exact agent-name and keeper-name lookup behavior unchanged.
- Add a regression test for pause/resume directives sent with canonical keeper-agent aliases.

## Evidence
- Log cluster: 14x directive resume: agent keeper-*-agent not in registry after 2026-05-25T18:00:00Z.
- opam exec -- ocamlformat --check lib/keeper/keeper_keepalive.ml test/test_keeper_registry.ml
- opam exec -- ocamlc -stop-after parsing lib/keeper/keeper_keepalive.ml test/test_keeper_registry.ml
- git diff --check origin/main...HEAD

## Local build note
- scripts/check-oas-pin.sh currently reports the process opam pin at fde41d76... while masc-mcp expects b85b84f....
- MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_registry.exe reaches compile but fails in unrelated OAS API drift: raw_trace_run_id missing and Agent_sdk.Orchestrator unbound.