### PR TITLE
refactor(keeper): drop name-only sandbox APIs

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 09:55:09 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 10:36:27 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -400,6 +400,12 @@
             <td><span class="status now">draft PR #18490</span></td>
             <td>Remove the one-release <code>playground_bundle</code>, <code>playground_mind</code>, <code>playground_repos</code>, and <code>tool_paths</code> aliases from memory/context status output. The canonical contract remains <code>sandbox_root</code>, <code>sandbox_mind</code>, <code>sandbox_repos</code>, and <code>sandbox_paths</code>.</td>
             <td>Context-status tests assert the legacy keys are absent while canonical sandbox fields remain populated. Local OCaml format/parse, diff, grep, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_sandbox</code> name-only sandbox APIs</td>
+            <td><span class="status now">local branch</span></td>
+            <td>Delete the unscoped <code>host_root_abs</code>, <code>allowed_root_rel</code>, <code>allowed_path_roots</code>, and <code>Keeper_alerting_path.sandbox_path_of_keeper</code> helpers. Callers and tests must derive sandbox roots from <code>keeper_meta</code> so <code>sandbox_profile</code> selects the backend-scoped path.</td>
+            <td>Targeted code grep is clean for the removed name-only helpers and the old legacy-unscoped sandbox wording. Local OCaml format/parse and diff checks pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
           </tr>
           <tr>
             <td><code>keeper_fs_edit.mode</code> empty-string alias</td>

--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 10:36:27 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 10:38:32 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -403,7 +403,7 @@
           </tr>
           <tr>
             <td><code>Keeper_sandbox</code> name-only sandbox APIs</td>
-            <td><span class="status now">local branch</span></td>
+            <td><span class="status now">draft PR #18530</span></td>
             <td>Delete the unscoped <code>host_root_abs</code>, <code>allowed_root_rel</code>, <code>allowed_path_roots</code>, and <code>Keeper_alerting_path.sandbox_path_of_keeper</code> helpers. Callers and tests must derive sandbox roots from <code>keeper_meta</code> so <code>sandbox_profile</code> selects the backend-scoped path.</td>
             <td>Targeted code grep is clean for the removed name-only helpers and the old legacy-unscoped sandbox wording. Local OCaml format/parse and diff checks pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
           </tr>

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -343,7 +343,6 @@ let playground_path_of_keeper = Playground_paths.bundle_root
 let playground_mind_path = Playground_paths.mind_path
 let playground_repos_path = Playground_paths.repos_path
 let playground_bundle_paths = Playground_paths.bundle_paths
-let sandbox_path_of_keeper name = Keeper_sandbox.allowed_root_rel ~name
 
 let sandbox_path_of_meta ~(meta : Keeper_types.keeper_meta) =
   Keeper_sandbox.allowed_root_rel_of_meta ~meta

--- a/lib/keeper/keeper_alerting_path.mli
+++ b/lib/keeper/keeper_alerting_path.mli
@@ -121,9 +121,6 @@ val playground_repos_path : string -> string
 (** Re-export of [Playground_paths.bundle_paths]. *)
 val playground_bundle_paths : string -> string list
 
-(** Sandbox host root path for [name]. *)
-val sandbox_path_of_keeper : string -> string
-
 (** Sandbox host root path for [meta]. *)
 val sandbox_path_of_meta : meta:Keeper_types.keeper_meta -> string
 

--- a/lib/keeper/keeper_sandbox.ml
+++ b/lib/keeper/keeper_sandbox.ml
@@ -71,18 +71,12 @@ let host_root_abs_of_config_agent ~config ~agent_name =
 let host_root_rel_of_meta ~(meta : Keeper_types.keeper_meta) =
   host_root_rel_of_profile meta.sandbox_profile meta.name
 
-let host_root_rel name =
-  Playground_paths.bundle_root name
-
 let host_root_abs_of_backend ~(config : Coord.config) ~(backend : backend) name =
   Filename.concat config.base_path (host_root_rel_of_backend ~backend name)
 
 let host_root_abs_of_meta ~(config : Coord.config)
     (meta : Keeper_types.keeper_meta) =
   Filename.concat config.base_path (host_root_rel_of_meta ~meta)
-
-let host_root_abs ~(config : Coord.config) name =
-  Filename.concat config.base_path (host_root_rel name)
 
 let container_root name =
   Keeper_sandbox_config.container_root_of_agent ~agent_name:name
@@ -136,14 +130,8 @@ let of_meta ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) : t =
   ; task_overlay_pattern = "repos/<repo>/.worktrees/<keeper>-<task_id>"
   }
 
-let allowed_root_rel ~(name : string) : string =
-  Playground_paths.bundle_root name
-
 let allowed_root_rel_of_meta ~(meta : Keeper_types.keeper_meta) : string =
   host_root_rel_of_meta ~meta
-
-let allowed_path_roots ~(name : string) : string list =
-  [ allowed_root_rel ~name ]
 
 let allowed_path_roots_of_meta ~(meta : Keeper_types.keeper_meta) : string list =
   [ allowed_root_rel_of_meta ~meta ]

--- a/lib/keeper/keeper_sandbox.mli
+++ b/lib/keeper/keeper_sandbox.mli
@@ -55,10 +55,6 @@ val host_root_abs_of_config_agent :
   agent_name:string ->
   string
 
-(** [host_root_abs ~config name] returns the absolute host-side
-    legacy unscoped sandbox root for [name] rooted at [config.base_path]. *)
-val host_root_abs : config:Coord.config -> string -> string
-
 (** [host_root_rel_of_profile sandbox_profile name] returns the
     backend-scoped relative sandbox root for the given profile/name. *)
 val host_root_rel_of_profile :
@@ -119,18 +115,11 @@ val of_meta :
 
 (** {1 Access control hints} *)
 
-(** Relative roots that tools may touch inside the keeper's
-    legacy unscoped sandbox. Currently a single-element list. *)
-val allowed_path_roots : name:string -> string list
-
 (** Relative roots that tools may touch inside [meta]'s backend-scoped
     sandbox. Currently a single-element list. *)
 val allowed_path_roots_of_meta :
   meta:Keeper_types.keeper_meta ->
   string list
-
-(** Single legacy unscoped relative root for [name] (convenience). *)
-val allowed_root_rel : name:string -> string
 
 (** Single backend-scoped relative root for [meta]. *)
 val allowed_root_rel_of_meta :

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -22,8 +22,8 @@ let make_meta ?(allowed_paths = []) ~name () =
   | Ok meta -> meta
   | Error err -> fail ("make_meta: " ^ err)
 
-let sandbox_roots name =
-  [ KAP.sandbox_path_of_keeper name ]
+let sandbox_roots meta =
+  [ KAP.sandbox_path_of_meta ~meta ]
 
 let with_temp_dir prefix f =
   let path = Filename.temp_file prefix "" in
@@ -80,14 +80,15 @@ let contains_substring s needle =
 
 let test_empty_paths_default_to_sandbox_root () =
   let meta = make_meta ~name:"keeper" () in
-  check (list string) "default read paths" (sandbox_roots "keeper")
+  let expected = sandbox_roots meta in
+  check (list string) "default read paths" expected
     (KAP.effective_allowed_paths ~meta);
-  check (list string) "default write paths" (sandbox_roots "keeper")
+  check (list string) "default write paths" expected
     (KAP.effective_write_allowed_paths ~meta)
 
 let test_explicit_paths_append_to_sandbox_root () =
   let meta = make_meta ~name:"keeper" ~allowed_paths:["src/"; "docs/"] () in
-  let expected = sandbox_roots "keeper" @ [ "src/"; "docs/" ] in
+  let expected = sandbox_roots meta @ [ "src/"; "docs/" ] in
   check (list string) "read paths append explicit entries" expected
     (KAP.effective_allowed_paths ~meta);
   check (list string) "write paths append explicit entries" expected


### PR DESCRIPTION
## Summary
- remove the legacy name-only Keeper_sandbox host_root_abs / allowed_root_rel / allowed_path_roots helpers
- remove Keeper_alerting_path.sandbox_path_of_keeper so sandbox roots are derived from keeper_meta
- update allowed-path tests and the legacy purge ledger to use the backend-scoped meta path

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_sandbox.ml lib/keeper/keeper_sandbox.mli lib/keeper/keeper_alerting_path.ml lib/keeper/keeper_alerting_path.mli test/test_keeper_allowed_paths.ml
- opam exec -- ocamlc -stop-after parsing lib/keeper/keeper_sandbox.ml
- opam exec -- ocamlc -stop-after parsing lib/keeper/keeper_alerting_path.ml
- opam exec -- ocamlc -stop-after parsing test/test_keeper_allowed_paths.ml
- opam exec -- ocamlc -stop-after parsing -intf lib/keeper/keeper_sandbox.mli
- opam exec -- ocamlc -stop-after parsing -intf lib/keeper/keeper_alerting_path.mli
- rg -n "Keeper_sandbox\.(host_root_abs|allowed_path_roots|allowed_root_rel)\b|sandbox_path_of_keeper\b|legacy unscoped sandbox" lib test -g '!_build'
- git diff --check

Blocked locally:
- scripts/dune-local.sh build ./test/test_keeper_allowed_paths.exe exits 75 because external bare `dune build --root .` processes are running.