### PR TITLE
fix(keeper): update no_eligible_action hint for advisory mode

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -188,8 +188,8 @@ let no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count =
   | None ->
     let scope_hint =
       match claim_goal_scope.Keeper_runtime_contract.mode with
-      | "active_goal_ids" ->
-        " Global backlog may be outside this keeper's active_goal_ids or blocked by its tool policy; update the goal scope or create/link an eligible scoped task before retrying."
+      | "active_goal_ids_advisory" ->
+        " All claimable tasks are blocked or already claimed (active_goal_ids is advisory, not a hard gate)."
       | _ -> ""
     in
     Printf.sprintf


### PR DESCRIPTION
## Summary
- Follow-up to #18511: `no_eligible_action_for_claim_scope` still matched the old `"active_goal_ids"` mode pattern which is no longer produced by `resolve_claim_goal_scope`
- Updated to `"active_goal_ids_advisory"` with an accurate hint text reflecting advisory behavior

## Context
PR #18511 changed the mode from `"active_goal_ids"` to `"active_goal_ids_advisory"` but missed the `scope_hint` pattern match at `keeper_exec_task.ml:191`. Without this fix, the `scope_hint` would always be `""` (from `_ -> ""` catch-all) when a keeper has no eligible tasks in advisory mode.

## Test plan
- [x] `dune build --root .` passes (pre-existing `Tool_local_runtime.config` errors on main are unrelated)
- [ ] CI ocamlformat-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)