### PR TITLE
refactor(cascade): drop no-agent runtime mcp fallback

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 10:38:32 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 10:44:38 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -400,6 +400,12 @@
             <td><span class="status now">draft PR #18530</span></td>
             <td>Delete the unscoped <code>host_root_abs</code>, <code>allowed_root_rel</code>, <code>allowed_path_roots</code>, and <code>Keeper_alerting_path.sandbox_path_of_keeper</code> helpers. Callers and tests must derive sandbox roots from <code>keeper_meta</code> so <code>sandbox_profile</code> selects the backend-scoped path.</td>
             <td>Targeted code grep is clean for the removed name-only helpers and the old legacy-unscoped sandbox wording. Local OCaml format/parse and diff checks pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
+          </tr>
+          <tr>
+            <td>Cascade runtime MCP no-agent bridge fallback</td>
+            <td><span class="status now">local branch</span></td>
+            <td>Remove the no-agent header-stripping fallback in <code>runtime_mcp_policy_for_provider</code>. Providers that require per-keeper bridging now fail closed when no <code>agent_name</code> is available, and the fallback-only metric/test are deleted.</td>
+            <td>Targeted grep is clean for the retired fallback metric, test name, and strip-all wording. Local OCaml format/parse and diff checks pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
           </tr>
           <tr>
             <td><code>keeper_fs_edit.mode</code> empty-string alias</td>

--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 10:44:38 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 10:47:24 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -403,7 +403,7 @@
           </tr>
           <tr>
             <td>Cascade runtime MCP no-agent bridge fallback</td>
-            <td><span class="status now">local branch</span></td>
+            <td><span class="status now">draft PR #18532</span></td>
             <td>Remove the no-agent header-stripping fallback in <code>runtime_mcp_policy_for_provider</code>. Providers that require per-keeper bridging now fail closed when no <code>agent_name</code> is available, and the fallback-only metric/test are deleted.</td>
             <td>Targeted grep is clean for the retired fallback metric, test name, and strip-all wording. Local OCaml format/parse and diff checks pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
           </tr>

--- a/lib/cascade/cascade_metrics.ml
+++ b/lib/cascade/cascade_metrics.ml
@@ -660,30 +660,6 @@ let metric_fallback_hint_invalid =
 let on_fallback_hint_invalid () =
   Prometheus.inc_counter metric_fallback_hint_invalid ()
 
-(* [Cascade_transport.runtime_mcp_policy_for_provider] has a
-   degraded branch when the provider requires per-keeper bridging
-   (e.g. agent_code CLI) but the caller has not supplied an
-   [agent_name]: the policy is silently passed through
-   [runtime_mcp_policy_without_http_headers] (strip-all legacy
-   behavior).  Auth-bearing headers like [Authorization: Bearer
-   ...] disappear, runtime MCP tools run unauthenticated, and the
-   only evidence in the previous code was a code comment ("preserve
-   the legacy strip-all behavior").
-
-   A non-zero rate signals a caller path that should be threading
-   keeper [agent_name] but isn't — usually a refactor regression
-   or a new call site that forgot the parameter.  Pairs with iter
-   12 [provider_filter_widening] and iter 18
-   [ordering_health_widening] as the third per-call "silent intent
-   broadening" counter at the runtime-MCP-policy layer.
-
-   Cardinality: 1 series. *)
-let metric_runtime_mcp_legacy_strip =
-  "masc_cascade_runtime_mcp_legacy_strip_total"
-
-let on_runtime_mcp_legacy_strip () =
-  Prometheus.inc_counter metric_runtime_mcp_legacy_strip ()
-
 (* [Cascade_runtime.refresh_local_discovery_if_possible] requires
    both [Eio.Switch.t] and [Eio.Net.t] to probe local providers.
    When only one of the two is available (partial Eio context —
@@ -697,10 +673,9 @@ let on_runtime_mcp_legacy_strip () =
    frequency information — operators can't tell whether the bug is
    a single startup race or a chronic caller-side regression.
 
-   Counter ticks on every hit (no dedup), pairing with iter 37
-   [fallback_hint_invalid] and iter 38 [runtime_mcp_legacy_strip]
-   as the third "WARN-once + per-hit counter" pattern this PR
-   adds to caller-contract observability.
+   Counter ticks on every hit (no dedup), continuing the
+   "WARN-once + per-hit counter" pattern for caller-contract
+   observability.
 
    Cardinality: 1 series. *)
 let metric_partial_eio_context =

--- a/lib/cascade/cascade_metrics.mli
+++ b/lib/cascade/cascade_metrics.mli
@@ -216,14 +216,6 @@ val on_fallback_hint_invalid : unit -> unit
     [capability_mismatch] which checks the same graph at
     catalog-build time. *)
 
-val on_runtime_mcp_legacy_strip : unit -> unit
-(** Tick the runtime-mcp-legacy-strip counter at
-    [Cascade_transport.runtime_mcp_policy_for_provider] when a
-    provider requires per-keeper bridging but the caller did not
-    supply [agent_name] and the function silently degrades to
-    strip-all-headers legacy behavior.  Non-zero rate signals a
-    caller path that should thread keeper [agent_name] but isn't. *)
-
 val on_partial_eio_context : unit -> unit
 (** Tick the partial-Eio-context counter at
     [Cascade_runtime.refresh_local_discovery_if_possible] when

--- a/lib/cascade/cascade_metrics_registry.ml
+++ b/lib/cascade/cascade_metrics_registry.ml
@@ -101,13 +101,6 @@ let all_cascade_counters : (string * string) list =
      the silent-fallback signal. *)
   ; ( "masc_cascade_fallback_hint_invalid_total"
     , "masc_cascade_fallback_hint_invalid_total" )
-  ; ( "masc_cascade_runtime_mcp_legacy_strip_total"
-    , "Total runtime_mcp_policy_for_provider invocations where a \
-       provider requires per-keeper bridging but the caller did not \
-       supply agent_name; auth-bearing headers are silently stripped \
-       and runtime MCP tools run unauthenticated. Caller-contract \
-       fault, not config - fix the calling code path to thread \
-       agent_name through." )
   ; ( "masc_cascade_partial_eio_context_total"
     , "Total [refresh_local_discovery_if_possible] calls where only \
        one of [Eio.Switch.t] / [Eio.Net.t] was available (caller \

--- a/lib/cascade/cascade_transport_runtime_policy_provider.ml
+++ b/lib/cascade/cascade_transport_runtime_policy_provider.ml
@@ -6,8 +6,9 @@
       local tool-delivery policy ([requires_per_keeper_bridging]),
       not by provider name. Resolves the policy through one of four
       branches based on the (policy, bridging_required, agent_name)
-      triple. Tracks legacy strip-all path via
-      [Cascade_metrics.on_runtime_mcp_legacy_strip].
+      triple. Missing [agent_name] with a provider that requires
+      per-keeper bridging now fails closed instead of preserving an
+      unauthenticated header-stripping path.
 
     - [cli_runtime_mcp_jsons] — merges a [~base] list of MCP JSON
       strings with the [cli_mcp_config_json_of_policy] projection of
@@ -56,14 +57,12 @@ let runtime_mcp_policy_for_provider
          plus the per-keeper [Authorization] header survive — so runtime MCP
          tools still authenticate without leaking secrets via argv. *)
     Some (Auth_bridging.bridged_runtime_mcp_policy_for_agent ~agent_name policy)
-  | Some policy, true, None ->
-    (* No agent_name to inject — preserve the legacy strip-all behavior.
-       Iter 38: tick a counter so a non-zero rate flags caller paths
-       that should be threading [agent_name] but aren't.  Strip-all
-       means auth-bearing headers (e.g. Authorization: Bearer ...)
-       disappear and runtime MCP tools run unauthenticated. *)
-    Cascade_metrics.on_runtime_mcp_legacy_strip ();
-    Some (Mcp_policy_helpers.runtime_mcp_policy_without_http_headers policy)
+  | Some _policy, true, None ->
+    (* No keeper identity means no safe per-keeper bridge. Returning
+       [None] makes the caller either fall back to inline tools (when
+       supported) or surface a tool-support error instead of running
+       runtime MCP tools unauthenticated. *)
+    None
   | Some policy, false, Some agent_name ->
     Some (Mcp_policy_helpers.runtime_mcp_policy_with_masc_agent_name ~agent_name policy)
   | Some policy, false, None -> Some policy
@@ -81,4 +80,3 @@ let cli_runtime_mcp_jsons
   in
   dedupe_preserve_order (base @ request_json)
 ;;
-

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -3875,10 +3875,11 @@ let test_runtime_mcp_policy_for_provider_cli_tool_a_preserves_identity_header ()
   | _ -> Alcotest.fail "expected masc runtime server headers"
 ;;
 
-let test_runtime_mcp_policy_for_provider_cli_tool_a_no_agent_strips_all () =
-  (* PR-F regression: when the caller has no agent_name to inject,
-     fall back to the legacy strip-all behavior so existing
-     ambient-env auth flows remain unaffected. *)
+let test_runtime_mcp_policy_for_provider_cli_tool_a_no_agent_fails_closed () =
+  (* Missing [agent_name] cannot build a safe per-keeper bridge for
+     agent_code-style runtime MCP. The previous header-stripping fallback kept the
+     policy alive with every auth header removed, so runtime MCP tools
+     reached the server unauthenticated. *)
   let policy =
     { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
       servers =
@@ -3894,28 +3895,14 @@ let test_runtime_mcp_policy_for_provider_cli_tool_a_no_agent_strips_all () =
     ; disable_builtin_tools = true
     }
   in
-  let find_masc_headers policy_opt =
-    match policy_opt with
-    | None -> Alcotest.fail "expected runtime MCP policy"
-    | Some (policy : Llm_provider.Llm_transport.runtime_mcp_policy) ->
-      List.find_map
-        (function
-          | Llm_provider.Llm_transport.Http_server server
-            when String.equal server.name "masc" -> Some server.headers
-          | _ -> None)
-        policy.servers
-  in
-  let result =
-    find_masc_headers
-      (Cascade_runner.runtime_mcp_policy_for_provider
-         ~provider_cfg:(make_cli_tool_a_provider_cfg ())
-         ~agent_name:""
-         (Some policy))
-  in
-  match result with
-  | Some headers ->
-    Alcotest.(check int) "no agent_name -> all headers stripped" 0 (List.length headers)
-  | None -> Alcotest.fail "expected masc runtime server headers"
+  Alcotest.(check bool)
+    "no agent_name -> no runtime MCP policy"
+    true
+    (Option.is_none
+       (Cascade_runner.runtime_mcp_policy_for_provider
+          ~provider_cfg:(make_cli_tool_a_provider_cfg ())
+          ~agent_name:""
+          (Some policy)))
 ;;
 
 let test_cli_runtime_mcp_jsons_include_request_policy () =
@@ -6326,10 +6313,10 @@ let () =
             `Quick
             test_runtime_mcp_policy_for_provider_cli_tool_a_preserves_identity_header
         ; Alcotest.test_case
-            "provider-aware runtime MCP policy strips all when cli_tool_a has no \
+            "provider-aware runtime MCP policy fails closed when cli_tool_a has no \
              agent_name"
             `Quick
-            test_runtime_mcp_policy_for_provider_cli_tool_a_no_agent_strips_all
+            test_runtime_mcp_policy_for_provider_cli_tool_a_no_agent_fails_closed
         ; Alcotest.test_case
             "CLI request runtime MCP config is merged"
             `Quick


### PR DESCRIPTION
## Summary
- fail closed when a provider requires per-keeper runtime MCP bridging but no agent_name is available
- remove the retired no-agent header-stripping metric from cascade metrics/registry
- replace the old strip-all regression with an absence assertion and update the purge ledger

## Verification
- opam exec -- ocamlformat --check lib/cascade/cascade_transport_runtime_policy_provider.ml lib/cascade/cascade_metrics.ml lib/cascade/cascade_metrics.mli lib/cascade/cascade_metrics_registry.ml test/test_oas_worker.ml
- opam exec -- ocamlc -stop-after parsing lib/cascade/cascade_transport_runtime_policy_provider.ml
- opam exec -- ocamlc -stop-after parsing lib/cascade/cascade_metrics.ml
- opam exec -- ocamlc -stop-after parsing lib/cascade/cascade_metrics_registry.ml
- opam exec -- ocamlc -stop-after parsing test/test_oas_worker.ml
- opam exec -- ocamlc -stop-after parsing -intf lib/cascade/cascade_metrics.mli
- rg -n "runtime_mcp_legacy_strip|on_runtime_mcp_legacy_strip|masc_cascade_runtime_mcp_legacy_strip_total|no_agent_strips_all|strip-all legacy|legacy strip-all|preserve the legacy strip-all|strips all when cli_tool_a has no|old strip-all" lib test docs -g '!_build'
- git diff --check HEAD~1..HEAD

Blocked locally:
- scripts/dune-local.sh build ./test/test_oas_worker.exe exits 75 because external bare `dune build --root .` processes are running.