### PR TITLE
fix(test): repair keeper unified PR guidance string

### DIFF
--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2415,7 +2415,7 @@ let test_prompt_includes_operational_tool_guidance () =
     bool
     "mentions Execute gh PR creation path"
     true
-    (contains_substring sys "Create or update PRs through `Execute` with `executable=\"gh\"\"");
+    (contains_substring sys "Create or update PRs through `Execute` with `executable=\"gh\"");
   check
     bool
     "warns passive discovery tools do not satisfy active turns"


### PR DESCRIPTION
Summary:
- Remove the duplicated escaped quote in test_keeper_unified.ml that breaks OCaml parsing on main.
- Keep the asserted guidance text otherwise unchanged.

Verification:
- opam exec -- ocamlformat --check test/test_keeper_unified.ml
- opam exec -- ocamlc -stop-after parsing test/test_keeper_unified.ml
- git diff --check

Note:
- Focused Dune build was started but is waiting behind an existing dune-local lock held by another worktree.