### PR TITLE
refactor(keeper): route identity helpers to owner module

### DIFF
--- a/lib/dashboard/dashboard_goals_types_health.ml
+++ b/lib/dashboard/dashboard_goals_types_health.ml
@@ -103,7 +103,7 @@ let keeper_name_matches_meta metas name =
   List.exists (fun (meta : Keeper_types.keeper_meta) -> String.equal meta.name name) metas
 
 let keeper_name_of_assignee metas assignee =
-  match Keeper_types.canonical_keeper_name_from_agent_name assignee with
+  match Keeper_identity.canonical_keeper_name_from_agent_name assignee with
   | Some keeper_name -> Some keeper_name
   | None ->
       if keeper_name_matches_meta metas assignee then Some assignee

--- a/lib/mcp_server_eio_caller_identity.ml
+++ b/lib/mcp_server_eio_caller_identity.ml
@@ -47,7 +47,7 @@ let resolve_owner_keeper_identity config owner_name =
   let candidates =
     [
       Keeper_types.canonical_keeper_name owner_name;
-      Keeper_types.canonical_keeper_name_from_agent_name owner_name;
+      Keeper_identity.canonical_keeper_name_from_agent_name owner_name;
     ]
     |> List.filter_map (function
          | Some value ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -261,7 +261,7 @@ let execute_tool_eio
        let keeper_tool_names =
          let candidates =
            [ Keeper_types.canonical_keeper_name agent_name
-           ; Keeper_types.canonical_keeper_name_from_agent_name agent_name
+           ; Keeper_identity.canonical_keeper_name_from_agent_name agent_name
            ]
            |> List.filter_map Fun.id
            |> List.sort_uniq String.compare
@@ -697,7 +697,7 @@ let execute_tool_eio
                 when String.equal entry.base_path config.base_path -> Ok entry.meta
               | Some _ | None ->
                 let candidates =
-                  [ Keeper_types.canonical_keeper_name_from_agent_name agent_name
+                  [ Keeper_identity.canonical_keeper_name_from_agent_name agent_name
                   ; Keeper_types.canonical_keeper_name agent_name
                   ]
                   |> List.filter_map (function

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -39,7 +39,7 @@ let resolve_keeper_name_for_action (ctx : 'a context) ~(name : string) =
         if List.mem requested_name configured then
           Ok requested_name
         else
-          match Keeper_types.keeper_name_from_agent_name requested_name with
+          match Keeper_identity.keeper_name_from_agent_name requested_name with
           | Some alias_name when List.mem alias_name configured -> Ok alias_name
           | _ -> Error (Printf.sprintf "keeper not found: %s" name)
 

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -81,7 +81,7 @@ let resolve_keeper_purge_target config requested_name =
   let candidates =
     [
       Some trimmed;
-      Keeper_types.canonical_keeper_name_from_agent_name trimmed;
+      Keeper_identity.canonical_keeper_name_from_agent_name trimmed;
       Keeper_types.canonical_keeper_name trimmed;
     ]
     |> List.filter_map (function

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -15,6 +15,7 @@ module Agent_tool_surfaces = Masc_mcp.Agent_tool_surfaces
 module Tool_shard = Masc_mcp.Tool_shard
 module Tool_catalog = Masc_mcp.Tool_catalog
 module Keeper_types = Masc_mcp.Keeper_types
+module Keeper_identity = Masc_mcp.Keeper_identity
 module Tool_code_write = Masc_mcp.Tool_code_write
 module Keeper_tool_registry = Masc_mcp.Keeper_tool_registry
 module Config = Masc_mcp.Config
@@ -284,28 +285,28 @@ let test_keeper_agent_name_prefixed () =
 let test_keeper_name_from_agent_name_roundtrip () =
   Alcotest.(check (option string))
     "agent alias resolves to keeper name" (Some "sangsu")
-    (Keeper_types.keeper_name_from_agent_name "keeper-sangsu-agent")
+    (Keeper_identity.keeper_name_from_agent_name "keeper-sangsu-agent")
 
 let test_keeper_name_from_generated_nickname () =
   Alcotest.(check (option string))
     "generated nickname resolves directly" (Some "agent_llm_a-swift-fox")
-    (Keeper_types.keeper_name_from_agent_name "agent_llm_a-swift-fox")
+    (Keeper_identity.keeper_name_from_agent_name "agent_llm_a-swift-fox")
 
 let test_keeper_name_from_agent_name_rejects_plain_name () =
   Alcotest.(check (option string))
     "plain keeper name is not treated as agent alias" None
-    (Keeper_types.keeper_name_from_agent_name "sangsu")
+    (Keeper_identity.keeper_name_from_agent_name "sangsu")
 
 let test_canonical_keeper_name_from_generated_nickname () =
   Alcotest.(check (option string))
     "generated nickname resolves to canonical keeper" (Some "agent_llm_a")
-    (Keeper_types.canonical_keeper_name_from_agent_name "agent_llm_a-swift-fox")
+    (Keeper_identity.canonical_keeper_name_from_agent_name "agent_llm_a-swift-fox")
 
 let test_canonical_keeper_name_from_keeper_agent_alias_preserves_full_name () =
   Alcotest.(check (option string))
     "keeper agent alias keeps hyphenated keeper name"
     (Some "provider_c-null-canary")
-    (Keeper_types.canonical_keeper_name_from_agent_name
+    (Keeper_identity.canonical_keeper_name_from_agent_name
        "keeper-provider_c-null-canary-agent")
 
 let test_canonical_keeper_name_from_legacy_keeper_name () =


### PR DESCRIPTION
## Summary
- continue docs/audit/2026-05-25-legacy-purge-plan.html P1 Keeper_types compatibility facade cleanup
- move active keeper alias identity helper callers from Keeper_types to Keeper_identity
- update identity helper tests to import the owner module directly

## Verification
- git diff --check
- rg -n 'Keeper_types\.(keeper_name_from_agent_name|canonical_keeper_name_from_agent_name)' lib test docs --glob '!docs/audit/2026-05-25-legacy-purge-plan.html' (no matches)
- opam exec -- ocamlformat --check changed OCaml files
- ocamlc -stop-after parsing changed OCaml files
- MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build ./test/test_keeper_agent_isolation.exe lib/masc_mcp.cmxa
- ./_build/default/test/test_keeper_agent_isolation.exe (26 tests)

Note: after the final rebase onto origin/main@480df791f, the rerun of the same focused build was queued behind another long Dune lock and was stopped before execution. The prior focused build/test passed after main's agent_sdk fix (#18533), and post-rebase static ratchets passed.