### PR TITLE
refactor(cascade): drop attempt liveness mode aliases

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 10:47:24 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 11:01:11 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -307,7 +307,7 @@
           </tr>
           <tr>
             <td>Dashboard execution session <code>room</code> alias</td>
-            <td><span class="status now">draft PR #18527</span></td>
+            <td><span class="status done">merged #18527</span></td>
             <td>Stop emitting the execution-session <code>room</code> mirror for canonical <code>namespace</code>, remove the frontend <code>DashboardExecutionSessionBrief.room</code> field, and stop promoting room-only payloads in the normalizer.</td>
             <td>Compatibility tests now assert room-only payloads are not promoted and normalized session briefs do not carry <code>room</code>. Local OCaml format/parse, dashboard typecheck, targeted Vitest, diff check, and targeted ESLint all pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>
@@ -403,15 +403,21 @@
           </tr>
           <tr>
             <td><code>Keeper_sandbox</code> name-only sandbox APIs</td>
-            <td><span class="status now">draft PR #18530</span></td>
+            <td><span class="status done">merged #18530</span></td>
             <td>Delete the unscoped <code>host_root_abs</code>, <code>allowed_root_rel</code>, <code>allowed_path_roots</code>, and <code>Keeper_alerting_path.sandbox_path_of_keeper</code> helpers. Callers and tests must derive sandbox roots from <code>keeper_meta</code> so <code>sandbox_profile</code> selects the backend-scoped path.</td>
             <td>Targeted code grep is clean for the removed name-only helpers and the old legacy-unscoped sandbox wording. Local OCaml format/parse and diff checks pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
           </tr>
           <tr>
             <td>Cascade runtime MCP no-agent bridge fallback</td>
-            <td><span class="status now">draft PR #18532</span></td>
+            <td><span class="status done">merged #18532</span></td>
             <td>Remove the no-agent header-stripping fallback in <code>runtime_mcp_policy_for_provider</code>. Providers that require per-keeper bridging now fail closed when no <code>agent_name</code> is available, and the fallback-only metric/test are deleted.</td>
             <td>Targeted grep is clean for the retired fallback metric, test name, and strip-all wording. Local OCaml format/parse and diff checks pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
+          </tr>
+          <tr>
+            <td>Cascade attempt-liveness mode aliases and config shadow</td>
+            <td><span class="status now">draft PR #18536</span></td>
+            <td>Remove the duplicate <code>Env_config_keeper.CascadeAttemptLiveness</code> parser/type, move the pure runtime decision helper to the actual <code>Cascade_attempt_liveness_config</code> type, and accept only canonical <code>off</code>, <code>observe</code>, and <code>enforce</code> values. Unset still defaults to <code>enforce</code>; explicit empty, boolean-style, rollout-era, uppercase, and unknown values now raise a config error instead of downgrading to observe mode.</td>
+            <td>Compatibility-preservation tests for <code>0</code>, <code>kill</code>, uppercase, empty, and unknown values were collapsed into rejection coverage. Local OCaml format/parse, diff check, unknown-permissive-default lint, comment-terminator lint, and godfile ratchet pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
           </tr>
           <tr>
             <td><code>keeper_fs_edit.mode</code> empty-string alias</td>

--- a/docs/rfc/RFC-0022-cascade-attempt-liveness.md
+++ b/docs/rfc/RFC-0022-cascade-attempt-liveness.md
@@ -416,7 +416,7 @@ The decision table in §4.5 is the source of truth. Tests:
 Phase A (historical observation rollout) — **wiring landed (PR-2)**:
 - FSM module + tests in PR-1 (`lib/cascade/cascade_attempt_liveness.{ml,mli}`).
 - Observer + tick fiber + `oas_worker_named.ml::try_provider` integration in PR-2 (`lib/cascade/cascade_attempt_liveness_observer.{ml,mli}`, `lib/cascade/cascade_attempt_liveness_config.{ml,mli}`).
-- Behind `MASC_CASCADE_ATTEMPT_LIVENESS=off|observe|enforce`. Current runtime default is `enforce` when the env var is unset; an empty or unknown value resolves to `observe`.
+- Behind `MASC_CASCADE_ATTEMPT_LIVENESS=off|observe|enforce`. Current runtime default is `enforce` when the env var is unset; explicit values must be canonical, and empty/unknown/boolean-style aliases raise a config error.
 - `observe`: liveness clock runs, kills emit `masc_cascade_attempt_liveness_kill_total{mode=observe}` and `masc_cascade_attempt_liveness_observed_total{outcome=...}` but no `Switch.fail`; cascade still advances on real wire errors.
 - 24h on dev base path; compare `diag-keeper-cycle.sh` MAX_S/P95.
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -98,12 +98,11 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 48 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 | `MASC_SSE_KEEPALIVE_SEC` | typed:float | unclassified | unclassified | 108 | SSE keepalive interval (seconds). Frequency of `: keepalive` frames on command-plane SSE streams. Clamped to >= 1.0 t... |
 
-## Env_config_keeper (87 knobs; typed classification 2/73)
+## Env_config_keeper (86 knobs; typed classification 2/72)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 226 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CASCADE_ATTEMPT_LIVENESS` | typed:string | unclassified | unclassified | 923 |  |
 | `MASC_CASCADE_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 821 | {1 Cascade Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Cascade_saturation_signal.t] emission alon... |
 | `MASC_CASCADE_TIER_ADMISSION_ENABLED` | feature_flag | n/a | n/a | 833 | {1 Cascade Tier Admission (RFC-0153 Phase B.2)} Runtime kill switch for per-tier inflight admission in the main keepe... |
 | `MASC_CASCADE_TIER_WAIT_ENABLED` | feature_flag | n/a | n/a | 838 |  |

--- a/lib/cascade/cascade_attempt_liveness_config.ml
+++ b/lib/cascade/cascade_attempt_liveness_config.ml
@@ -15,11 +15,17 @@ let mode_label = function
 let env_var_name = "MASC_CASCADE_ATTEMPT_LIVENESS"
 
 let parse_mode raw =
-  match String.lowercase_ascii (String.trim raw) with
-  | "off" | "0" | "false" | "disabled" -> Off
-  | "enforce" | "kill" | "on_kill" -> Enforce
-  | "" | "observe" | "default" | "1" | "true" | "shadow" -> Observe
-  | _ -> Observe (* unknown values default to Observe — never silently Off *)
+  match String.trim raw with
+  | "off" -> Off
+  | "observe" -> Observe
+  | "enforce" -> Enforce
+  | value ->
+    raise
+      (Env_config_core.Config_error
+         (Printf.sprintf
+            "%s must be one of off|observe|enforce, got %S"
+            env_var_name
+            value))
 
 (* Cached after first read so mid-attempt env edits do not split-brain the
    observer. *)

--- a/lib/cascade/cascade_attempt_liveness_config.mli
+++ b/lib/cascade/cascade_attempt_liveness_config.mli
@@ -9,7 +9,9 @@
                    on the first {!Cascade_attempt_liveness.Outcome}.
 
     When the env var is absent, current production default is [enforce].
-    Empty or unparseable values resolve to [observe].
+    Explicit values must be exactly [off], [observe], or [enforce]; empty,
+    boolean-like, rollout-era, and otherwise unparseable values raise
+    {!Env_config_core.Config_error}.
 
     The mode is read once and cached on first call so that mid-attempt env
     edits do not split-brain the observer.

--- a/lib/cascade/cascade_attempt_liveness_runtime.ml
+++ b/lib/cascade/cascade_attempt_liveness_runtime.ml
@@ -3,7 +3,7 @@
     Pure decision; see {!Cascade_attempt_liveness_runtime} mli for the
     decision table. *)
 
-module Mode = Env_config_keeper.CascadeAttemptLiveness
+module Mode = Cascade_attempt_liveness_config
 
 type verdict =
   | Continue_attempt

--- a/lib/cascade/cascade_attempt_liveness_runtime.mli
+++ b/lib/cascade/cascade_attempt_liveness_runtime.mli
@@ -60,6 +60,6 @@ type side_effect =
     decides what success means. *)
 
 val decide :
-  mode:Env_config_keeper.CascadeAttemptLiveness.mode ->
+  mode:Cascade_attempt_liveness_config.mode ->
   Cascade_attempt_liveness.output ->
   verdict * side_effect

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -898,44 +898,4 @@ end
     per-provider retry (3 attempts with its own backoff). *)
 module KeeperRetryBackoff = Env_config_keeper_retry_backoff
 
-(** RFC-0022 §9 rollout flag for the in-attempt streaming liveness gate.
-
-    Default {!CascadeAttemptLiveness.Observe} is *non-enforcing*: the
-    FSM runs, kills are logged and counted on
-    [masc_cascade_attempt_liveness_kill_total], but the cascade FSM
-    never sees them. Flip to [enforce] only after observation has
-    produced calibration data per §9 Phase B. *)
-module CascadeAttemptLiveness = struct
-  type mode =
-    | Off
-    | Observe
-    | Enforce
-
-  let mode_label = function
-    | Off -> "off"
-    | Observe -> "observe"
-    | Enforce -> "enforce"
-  ;;
-
-  let warned_unknown = ref false
-
-  let mode () : mode =
-    let raw = get_string ~default:"observe" "MASC_CASCADE_ATTEMPT_LIVENESS" in
-    match String.lowercase_ascii (String.trim raw) with
-    | "off" | "0" | "false" -> Off
-    | "" | "observe" -> Observe
-    | "enforce" | "on" | "1" | "true" -> Enforce
-    | other ->
-      if not !warned_unknown
-      then (
-        warned_unknown := true;
-        prerr_endline
-          (Printf.sprintf
-             "[env_config_keeper] WARN: MASC_CASCADE_ATTEMPT_LIVENESS=%s unrecognised, \
-              defaulting to observe"
-             other));
-      Observe
-  ;;
-end
-
 (** Print configuration summary for debugging *)

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -349,29 +349,3 @@ module KeeperRetryBackoff : sig
   val transient_backoff_sec : int -> float
   val degraded_retry_slot_phase_budget_sec : float
 end
-
-(** {1 Cascade attempt liveness — RFC-0022 §9 rollout flag} *)
-
-module CascadeAttemptLiveness : sig
-  type mode =
-    | Off
-    (** No FSM driving, no counter, no kills. Equivalent to the
-            world before RFC-0022. *)
-    | Observe
-    (** FSM runs alongside the existing cascade attempt; would-be
-            kills are logged and counted ([masc_cascade_attempt_liveness_kill_total]),
-            but the cascade FSM never sees them. Default. *)
-    | Enforce
-    (** FSM runs and would-be kills are reported back to the
-            cascade FSM as [Failed_attempt], advancing to the next
-            provider. Reserved for PR-3+ once observation has produced
-            calibration data per §9 Phase B. *)
-
-  (** Read [MASC_CASCADE_ATTEMPT_LIVENESS]. Unrecognised values fall
-      back to {!Observe} (with a one-time stderr warning). *)
-  val mode : unit -> mode
-
-  (** Stable string label for telemetry / log output:
-      [off | observe | enforce]. *)
-  val mode_label : mode -> string
-end

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -455,9 +455,9 @@ let keeper_cascade_entries =
   [
     entry ~default:"(none)" "MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST"
       "Comma-separated provider allowlist for cascade (None=unfiltered)";
-    entry ~default:"observe" "MASC_CASCADE_ATTEMPT_LIVENESS"
+    entry ~default:"enforce" "MASC_CASCADE_ATTEMPT_LIVENESS"
       "Cascade attempt-liveness gate mode (off|observe|enforce). RFC-0022 \
-       PR-2 §2 Phase A default observe — counters emit but no kill.";
+       Explicit values must be canonical; invalid values raise a config error.";
   ]
 
 let keeper_grpc_entries =

--- a/test/test_cascade_attempt_liveness_config.ml
+++ b/test/test_cascade_attempt_liveness_config.ml
@@ -1,7 +1,7 @@
 (** Tests for [Cascade_attempt_liveness_config] (RFC-0022 PR-2/4 §2).
 
-    Covers: env-flag parsing (unset defaults to Enforce; empty/unknown parse
-    as Observe), cache invalidation via reset_cache_for_test, and living
+    Covers: env-flag parsing (unset defaults to Enforce; explicit values are
+    canonical only), cache invalidation via reset_cache_for_test, and living
     success-history budget selection. *)
 
 open Masc_mcp
@@ -39,37 +39,29 @@ let test_unset_defaults_enforce () =
   with_env None (fun () ->
       check_mode "unset -> Enforce" Enforce (Cfg.current_mode ()))
 
-let test_empty_string_alias () =
-  with_env (Some "") (fun () ->
-      check_mode "empty string -> Observe" Observe (Cfg.current_mode ()))
-
-let test_observe_alias () =
+let test_observe () =
   with_env (Some "observe") (fun () ->
       check_mode "observe" Observe (Cfg.current_mode ()))
 
-let test_off_alias () =
+let test_off () =
   with_env (Some "off") (fun () ->
       check_mode "off" Off (Cfg.current_mode ()))
 
-let test_off_zero () =
-  with_env (Some "0") (fun () ->
-      check_mode "0 -> Off" Off (Cfg.current_mode ()))
-
-let test_enforce_alias () =
+let test_enforce () =
   with_env (Some "enforce") (fun () ->
       check_mode "enforce" Enforce (Cfg.current_mode ()))
 
-let test_enforce_kill () =
-  with_env (Some "kill") (fun () ->
-      check_mode "kill -> Enforce" Enforce (Cfg.current_mode ()))
+let expect_config_error raw =
+  with_env (Some raw) (fun () ->
+      match Cfg.current_mode () with
+      | _ -> Alcotest.failf "%S was accepted as a liveness mode" raw
+      | exception Env_config_core.Config_error _ -> ())
 
-let test_unknown_defaults_observe () =
-  with_env (Some "garbage") (fun () ->
-      check_mode "garbage -> Observe" Observe (Cfg.current_mode ()))
-
-let test_case_insensitive () =
-  with_env (Some "OFF") (fun () ->
-      check_mode "OFF -> Off" Off (Cfg.current_mode ()))
+let test_legacy_and_invalid_modes_rejected () =
+  List.iter
+    expect_config_error
+    [ ""; " "; "0"; "1"; "false"; "true"; "disabled"; "default"; "kill";
+      "on_kill"; "shadow"; "garbage"; "OFF" ]
 
 (* -- cache contract ------------------------------------------------- *)
 
@@ -184,16 +176,11 @@ let () =
         [
           Alcotest.test_case "unset -> enforce" `Quick
             test_unset_defaults_enforce;
-          Alcotest.test_case "empty string -> observe" `Quick
-            test_empty_string_alias;
-          Alcotest.test_case "observe" `Quick test_observe_alias;
-          Alcotest.test_case "off" `Quick test_off_alias;
-          Alcotest.test_case "off via 0" `Quick test_off_zero;
-          Alcotest.test_case "enforce" `Quick test_enforce_alias;
-          Alcotest.test_case "enforce via kill" `Quick test_enforce_kill;
-          Alcotest.test_case "unknown -> observe" `Quick
-            test_unknown_defaults_observe;
-          Alcotest.test_case "case insensitive" `Quick test_case_insensitive;
+          Alcotest.test_case "observe" `Quick test_observe;
+          Alcotest.test_case "off" `Quick test_off;
+          Alcotest.test_case "enforce" `Quick test_enforce;
+          Alcotest.test_case "legacy and invalid modes rejected" `Quick
+            test_legacy_and_invalid_modes_rejected;
         ] );
       ( "cache",
         [

--- a/test/test_cascade_attempt_liveness_runtime.ml
+++ b/test/test_cascade_attempt_liveness_runtime.ml
@@ -3,7 +3,7 @@
 open Masc_mcp
 module L = Cascade_attempt_liveness
 module R = Cascade_attempt_liveness_runtime
-module Mode = Env_config_keeper.CascadeAttemptLiveness
+module Mode = Cascade_attempt_liveness_config
 
 let pp_failure fmt f =
   Format.pp_print_string fmt (L.failure_kind_label f)


### PR DESCRIPTION
## Summary
- remove the duplicate Env_config_keeper.CascadeAttemptLiveness parser/type shadow
- make MASC_CASCADE_ATTEMPT_LIVENESS accept only canonical off/observe/enforce values
- collapse legacy alias-preservation tests into rejection coverage and update purge ledger/docs

## Verification
- opam exec -- ocamlformat --check lib/cascade/cascade_attempt_liveness_config.ml lib/cascade/cascade_attempt_liveness_config.mli lib/cascade/cascade_attempt_liveness_runtime.ml lib/cascade/cascade_attempt_liveness_runtime.mli lib/config/env_config_keeper.ml lib/config/env_config_keeper.mli lib/config/env_config_snapshot.ml test/test_cascade_attempt_liveness_config.ml test/test_cascade_attempt_liveness_runtime.ml
- opam exec -- ocamlc -stop-after parsing lib/cascade/cascade_attempt_liveness_config.ml lib/cascade/cascade_attempt_liveness_runtime.ml lib/config/env_config_keeper.ml lib/config/env_config_snapshot.ml test/test_cascade_attempt_liveness_config.ml test/test_cascade_attempt_liveness_runtime.ml
- opam exec -- ocamlc -stop-after parsing -intf lib/cascade/cascade_attempt_liveness_config.mli lib/cascade/cascade_attempt_liveness_runtime.mli lib/config/env_config_keeper.mli
- rg targeted legacy liveness aliases/symbols (clean)
- git diff --check
- scripts/lint/no-unknown-permissive-default.sh
- scripts/lint/no-ocaml-comment-terminator-trap.sh
- scripts/lint/godfile-size-regression.sh

Focused Dune note: scripts/dune-local.sh build ./test/test_cascade_attempt_liveness_config.exe ./test/test_cascade_attempt_liveness_runtime.exe is blocked by external bare dune build --root . processes (PIDs 3594, 50320).