### PR TITLE
test(cascade): reject empty liveness env in named worker smoke

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 11:01:11 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 11:06:50 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -415,9 +415,15 @@
           </tr>
           <tr>
             <td>Cascade attempt-liveness mode aliases and config shadow</td>
-            <td><span class="status now">draft PR #18536</span></td>
+            <td><span class="status done">merged #18536</span></td>
             <td>Remove the duplicate <code>Env_config_keeper.CascadeAttemptLiveness</code> parser/type, move the pure runtime decision helper to the actual <code>Cascade_attempt_liveness_config</code> type, and accept only canonical <code>off</code>, <code>observe</code>, and <code>enforce</code> values. Unset still defaults to <code>enforce</code>; explicit empty, boolean-style, rollout-era, uppercase, and unknown values now raise a config error instead of downgrading to observe mode.</td>
             <td>Compatibility-preservation tests for <code>0</code>, <code>kill</code>, uppercase, empty, and unknown values were collapsed into rejection coverage. Local OCaml format/parse, diff check, unknown-permissive-default lint, comment-terminator lint, and godfile ratchet pass; focused Dune is blocked by external bare <code>dune build --root .</code> processes.</td>
+          </tr>
+          <tr>
+            <td>Cascade named-worker liveness empty-env alias test</td>
+            <td><span class="status now">local branch</span></td>
+            <td>Remove the remaining integration smoke test that preserved empty <code>MASC_CASCADE_ATTEMPT_LIVENESS</code> as observe mode. The helper now truly unsets the env var for the default path, pins unset to <code>enforce</code>, and treats explicit empty string as a config error.</td>
+            <td>Targeted grep is clean for the removed empty-string observe test and stale alias labels. Local OCaml format/parse, diff check, unknown-permissive-default lint, and comment-terminator lint pass; focused Dune is blocked by external bare <code>dune build --root .</code> / <code>dune exec</code> processes.</td>
           </tr>
           <tr>
             <td><code>keeper_fs_edit.mode</code> empty-string alias</td>

--- a/test/test_oas_worker_named_liveness_integration.ml
+++ b/test/test_oas_worker_named_liveness_integration.ml
@@ -27,15 +27,17 @@ module Obs = Cascade_attempt_liveness_observer
 
 let env_var = "MASC_CASCADE_ATTEMPT_LIVENESS"
 
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
 let with_env value f =
   let prior = Sys.getenv_opt env_var in
   (match value with
-   | None -> Unix.putenv env_var ""
+   | None -> unsetenv env_var
    | Some v -> Unix.putenv env_var v);
   Cfg.reset_cache_for_test ();
   let restore () =
     (match prior with
-     | None -> Unix.putenv env_var ""
+     | None -> unsetenv env_var
      | Some v -> Unix.putenv env_var v);
     Cfg.reset_cache_for_test ()
   in
@@ -52,12 +54,18 @@ let test_env_off_short_circuits () =
         "off"
         (Cfg.mode_label (Cfg.current_mode ())))
 
-let test_env_observe_empty_string_alias () =
+let test_env_unset_defaults_enforce () =
   with_env None (fun () ->
       Alcotest.(check string)
-        "empty string -> Observe"
-        "observe"
+        "unset -> Enforce"
+        "enforce"
         (Cfg.mode_label (Cfg.current_mode ())))
+
+let test_env_empty_string_rejected () =
+  with_env (Some "") (fun () ->
+      match Cfg.current_mode () with
+      | _ -> Alcotest.fail "empty string was accepted as a liveness mode"
+      | exception Env_config_core.Config_error _ -> ())
 
 let test_env_enforce () =
   with_env (Some "enforce") (fun () ->
@@ -160,9 +168,11 @@ let () =
         [
           Alcotest.test_case "off short-circuits" `Quick
             test_env_off_short_circuits;
-          Alcotest.test_case "empty string observe" `Quick
-            test_env_observe_empty_string_alias;
-          Alcotest.test_case "enforce alias" `Quick test_env_enforce;
+          Alcotest.test_case "unset defaults enforce" `Quick
+            test_env_unset_defaults_enforce;
+          Alcotest.test_case "empty string rejected" `Quick
+            test_env_empty_string_rejected;
+          Alcotest.test_case "enforce" `Quick test_env_enforce;
         ] );
       ( "end to end",
         [


### PR DESCRIPTION
## Summary
- remove the remaining named-worker integration smoke coverage that preserved empty MASC_CASCADE_ATTEMPT_LIVENESS as observe mode
- make the test helper truly unset the env var for the default path
- pin unset to enforce and explicit empty string to Config_error
- update the legacy purge ledger after #18536 merged

## Verification
- opam exec -- ocamlformat --check test/test_oas_worker_named_liveness_integration.ml
- opam exec -- ocamlc -stop-after parsing test/test_oas_worker_named_liveness_integration.ml
- targeted rg for removed empty-string observe alias labels (clean)
- git diff --check
- scripts/lint/no-unknown-permissive-default.sh
- scripts/lint/no-ocaml-comment-terminator-trap.sh

Focused Dune note: scripts/dune-local.sh build ./test/test_oas_worker_named_liveness_integration.exe is blocked by external bare dune build --root . / dune exec processes (PIDs 3594, 17009, 50320).