### PR TITLE
fix(ci): add keeper interfaces for tool purge

### DIFF
--- a/lib/keeper/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper/keeper_approval_queue_rules_types.mli
@@ -1,0 +1,80 @@
+(** Approval queue rule types, conversions, and JSON serialization. *)
+
+type risk_level =
+  | Low
+  | Medium
+  | High
+  | Critical
+
+type pending_approval =
+  { id : string
+  ; keeper_name : string
+  ; tool_name : string
+  ; action_key : string
+  ; input_hash : string
+  ; sandbox_target : string
+  ; input : Yojson.Safe.t
+  ; risk_level : risk_level
+  ; requested_at : float
+  ; turn_id : int option
+  ; task_id : string option
+  ; goal_id : string option
+  ; goal_ids : string list
+  ; runtime_contract : Yojson.Safe.t option
+  ; selected_model : string option
+  ; disposition : string option
+  ; disposition_reason : string option
+  ; audit_base_path : string option
+  ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
+  ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
+  }
+
+type decision = Agent_sdk.Hooks.approval_decision
+
+type approval_audit_decision =
+  | Approval_resolved of decision
+  | Approval_expired of string
+
+type approval_rule =
+  { id : string
+  ; keeper_name : string
+  ; tool_name : string
+  ; sandbox_profile : string option
+  ; backend : string option
+  ; request_fingerprint : string
+  ; request_fingerprint_preview : string
+  ; max_risk : risk_level
+  ; created_at : float
+  ; created_by : string option
+  ; last_matched_at : float option
+  ; match_count : int
+  ; source_approval_id : string option
+  }
+
+type rule_match =
+  { rule_id : string
+  ; matched_by : string
+  }
+
+type resolution_result = { remembered_rule : approval_rule option }
+
+val risk_level_to_string : risk_level -> string
+val risk_level_to_int : risk_level -> int
+val risk_level_of_string : string -> risk_level option
+val approval_decision_to_string : decision -> string
+
+val record_queue_failure
+  :  keeper_name:string
+  -> site:string
+  -> ?id:string
+  -> ?event_type:string
+  -> exn
+  -> unit
+
+val approval_audit_decision_to_string : approval_audit_decision -> string
+val string_opt_of_json : Yojson.Safe.t -> string option
+val string_opt_member : string -> Yojson.Safe.t -> string option
+val bool_member : string -> Yojson.Safe.t -> default:bool -> bool
+val rule_match_to_yojson : rule_match -> Yojson.Safe.t
+val approval_rule_to_yojson : approval_rule -> Yojson.Safe.t
+val approval_rule_of_yojson : Yojson.Safe.t -> approval_rule option

--- a/lib/keeper/keeper_failure_circuit_breaker_types.mli
+++ b/lib/keeper/keeper_failure_circuit_breaker_types.mli
@@ -1,0 +1,30 @@
+(** Error classification and breaker state types. *)
+
+type error_class =
+  | Path_not_found
+  | Path_not_allowed
+  | Cwd_not_directory
+  | Shell_exit_nonzero
+  | Other
+
+module Path_check_error = Keeper_path_check_error
+
+val classify_path_check_prefix : string -> error_class option
+val classify_error : string -> error_class
+val error_class_to_string : error_class -> string
+
+type failure_signature =
+  { ts : float
+  ; cls : error_class
+  ; fingerprint : string
+  }
+
+val recent_failures_capacity : int
+
+type breaker_state =
+  { mutable consecutive_class : error_class
+  ; mutable consecutive_count : int
+  ; mutable total_tripped : int
+  ; mutable last_tripped_at : float option
+  ; mutable recent_failures : failure_signature list
+  }

--- a/lib/keeper/keeper_registry_types_cascade.mli
+++ b/lib/keeper/keeper_registry_types_cascade.mli
@@ -1,0 +1,148 @@
+(** Cascade and compaction FSM types and transitions. *)
+
+type cascade_state =
+  | Cascade_idle [@tla.idle]
+  | Cascade_selecting [@tla.active]
+  | Cascade_trying [@tla.active]
+  | Cascade_done [@tla.terminal]
+  | Cascade_exhausted [@tla.terminal]
+[@@deriving tla]
+
+type cascade_idle
+type cascade_selecting
+type cascade_trying
+type cascade_done
+type cascade_exhausted
+
+type 'a cascade_state_witness =
+  | Cascade_idle : cascade_idle cascade_state_witness
+  | Cascade_selecting : cascade_selecting cascade_state_witness
+  | Cascade_trying : cascade_trying cascade_state_witness
+  | Cascade_done : cascade_done cascade_state_witness
+  | Cascade_exhausted : cascade_exhausted cascade_state_witness
+
+type packed_cascade_state =
+  | Packed : 'a cascade_state_witness -> packed_cascade_state
+
+val cascade_state_to_witness : cascade_state -> packed_cascade_state
+val witness_to_cascade_state : packed_cascade_state -> cascade_state
+val packed_cascade_state_label : packed_cascade_state -> string
+
+module Cascade_transition : sig
+  type ('from, 'to_) t =
+    | Idle_to_selecting : (cascade_idle, cascade_selecting) t
+    | Selecting_to_idle : (cascade_selecting, cascade_idle) t
+    | Selecting_to_trying : (cascade_selecting, cascade_trying) t
+    | Trying_to_idle : (cascade_trying, cascade_idle) t
+    | Trying_to_selecting : (cascade_trying, cascade_selecting) t
+    | Trying_to_done : (cascade_trying, cascade_done) t
+    | Trying_to_exhausted : (cascade_trying, cascade_exhausted) t
+    | Done_to_idle : (cascade_done, cascade_idle) t
+    | Done_to_selecting : (cascade_done, cascade_selecting) t
+    | Done_to_trying : (cascade_done, cascade_trying) t
+    | Exhausted_to_idle : (cascade_exhausted, cascade_idle) t
+    | Exhausted_to_selecting : (cascade_exhausted, cascade_selecting) t
+    | Exhausted_to_trying : (cascade_exhausted, cascade_trying) t
+
+  type packed = Packed_transition : ('a, 'b) t -> packed
+
+  val to_tag : ('from, 'to_) t -> string
+end
+
+type cascade_transition_spec_violation =
+  | Idle_to_trying
+  | Idle_to_done
+  | Idle_to_exhausted
+  | Selecting_to_done
+  | Selecting_to_exhausted
+  | Done_to_exhausted
+  | Exhausted_to_done
+
+val cascade_transition_spec_violation_to_tag
+  :  cascade_transition_spec_violation
+  -> string
+
+exception
+  Cascade_transition_violation of
+    { where : string
+    ; from : packed_cascade_state
+    ; to_ : packed_cascade_state
+    ; violation : cascade_transition_spec_violation
+    }
+
+val cascade_transition_violation_message
+  :  where:string
+  -> from:packed_cascade_state
+  -> to_:packed_cascade_state
+  -> violation:cascade_transition_spec_violation
+  -> string
+
+val raise_cascade_transition_violation
+  :  where:string
+  -> from:packed_cascade_state
+  -> to_:packed_cascade_state
+  -> violation:cascade_transition_spec_violation
+  -> 'a
+
+type cascade_resolve_outcome =
+  | Resolved_transition of Cascade_transition.packed
+  | Resolved_idempotent
+  | Resolved_violation of cascade_transition_spec_violation
+
+val resolve_cascade_transition
+  :  from:packed_cascade_state
+  -> target:packed_cascade_state
+  -> cascade_resolve_outcome
+
+type compaction_stage =
+  | Compaction_accumulating [@tla.idle]
+  | Compaction_compacting [@tla.active]
+  | Compaction_done [@tla.terminal]
+[@@deriving tla]
+
+type compaction_accumulating
+type compaction_compacting
+type compaction_done
+
+type 'a compaction_stage_witness =
+  | Compaction_accumulating : compaction_accumulating compaction_stage_witness
+  | Compaction_compacting : compaction_compacting compaction_stage_witness
+  | Compaction_done : compaction_done compaction_stage_witness
+
+type packed_compaction_stage =
+  | Packed : 'a compaction_stage_witness -> packed_compaction_stage
+
+val compaction_stage_to_witness : compaction_stage -> packed_compaction_stage
+val witness_to_compaction_stage : packed_compaction_stage -> compaction_stage
+val packed_compaction_stage_label : packed_compaction_stage -> string
+
+type compaction_transition_spec_violation =
+  | Accumulating_to_done
+  | Done_to_accumulating
+  | Done_to_compacting
+
+val compaction_transition_spec_violation_to_tag
+  :  compaction_transition_spec_violation
+  -> string
+
+exception
+  Compaction_transition_violation of
+    { where : string
+    ; from : packed_compaction_stage
+    ; to_ : packed_compaction_stage
+    ; violation : compaction_transition_spec_violation
+    }
+
+val compaction_transition_violation_message
+  :  where:string
+  -> from:packed_compaction_stage
+  -> to_:packed_compaction_stage
+  -> violation:compaction_transition_spec_violation
+  -> string
+
+val raise_compaction_transition_violation
+  :  where:string
+  -> from:packed_compaction_stage
+  -> to_:packed_compaction_stage
+  -> violation:compaction_transition_spec_violation
+  -> 'a

--- a/lib/keeper/keeper_registry_types_decision.mli
+++ b/lib/keeper/keeper_registry_types_decision.mli
@@ -1,0 +1,60 @@
+(** Decision-stage FSM types and transitions. *)
+
+type decision_stage =
+  | Decision_undecided [@tla.idle]
+  | Decision_guard_ok [@tla.active]
+  | Decision_gate_rejected [@tla.terminal]
+  | Decision_tool_policy_selected [@tla.active]
+[@@deriving tla]
+
+type decision_undecided
+type decision_guard_ok
+type decision_gate_rejected
+type decision_tool_policy_selected
+
+type 'a decision_stage_witness =
+  | Decision_undecided : decision_undecided decision_stage_witness
+  | Decision_guard_ok : decision_guard_ok decision_stage_witness
+  | Decision_gate_rejected : decision_gate_rejected decision_stage_witness
+  | Decision_tool_policy_selected : decision_tool_policy_selected decision_stage_witness
+
+type packed_decision_stage = Packed : 'a decision_stage_witness -> packed_decision_stage
+
+val witness_to_stage : 'a decision_stage_witness -> decision_stage
+val stage_to_witness : decision_stage -> packed_decision_stage
+
+type decision_stage_active =
+  | Decision_active_guard_ok
+  | Decision_active_gate_rejected
+  | Decision_active_tool_policy_selected
+
+val decision_stage_active_to_packed
+  :  decision_stage_active
+  -> packed_decision_stage
+
+val packed_decision_stage_label : packed_decision_stage -> string
+
+module Decision_transition : sig
+  type ('from, 'to_) t =
+    | Undecided_to_guard_ok : (decision_undecided, decision_guard_ok) t
+    | Undecided_to_gate_rejected : (decision_undecided, decision_gate_rejected) t
+    | Undecided_to_tool_policy_selected :
+        (decision_undecided, decision_tool_policy_selected) t
+    | Guard_ok_to_gate_rejected : (decision_guard_ok, decision_gate_rejected) t
+    | Guard_ok_to_tool_policy_selected :
+        (decision_guard_ok, decision_tool_policy_selected) t
+    | Gate_rejected_to_guard_ok : (decision_gate_rejected, decision_guard_ok) t
+    | Gate_rejected_to_tool_policy_selected :
+        (decision_gate_rejected, decision_tool_policy_selected) t
+    | Tool_policy_selected_to_guard_ok :
+        (decision_tool_policy_selected, decision_guard_ok) t
+    | Tool_policy_selected_to_gate_rejected :
+        (decision_tool_policy_selected, decision_gate_rejected) t
+
+  val to_tag : ('from, 'to_) t -> string
+end
+
+val validate_decision_transition
+  :  from:decision_stage
+  -> to_:decision_stage_active
+  -> unit

--- a/lib/keeper/keeper_registry_types_turn_phase.mli
+++ b/lib/keeper/keeper_registry_types_turn_phase.mli
@@ -1,0 +1,124 @@
+(** Turn-phase FSM types and transitions. *)
+
+exception Keeper_fiber_crash
+
+type turn_phase =
+  | Turn_idle [@tla.idle]
+  | Turn_prompting [@tla.active]
+  | Turn_routing [@tla.active]
+  | Turn_executing [@tla.active]
+  | Turn_compacting [@tla.active]
+  | Turn_finalizing [@tla.active]
+  | Turn_exhausted [@tla.terminal]
+[@@deriving tla]
+
+type turn_idle
+type turn_prompting
+type turn_routing
+type turn_executing
+type turn_compacting
+type turn_finalizing
+type turn_exhausted
+
+type 'a turn_phase_witness =
+  | Turn_idle : turn_idle turn_phase_witness
+  | Turn_prompting : turn_prompting turn_phase_witness
+  | Turn_routing : turn_routing turn_phase_witness
+  | Turn_executing : turn_executing turn_phase_witness
+  | Turn_compacting : turn_compacting turn_phase_witness
+  | Turn_finalizing : turn_finalizing turn_phase_witness
+  | Turn_exhausted : turn_exhausted turn_phase_witness
+
+type packed_turn_phase = Packed : 'a turn_phase_witness -> packed_turn_phase
+
+val turn_phase_to_witness : turn_phase -> packed_turn_phase
+val witness_to_turn_phase : packed_turn_phase -> turn_phase
+val packed_turn_phase_label : packed_turn_phase -> string
+
+module Turn_phase_transition : sig
+  type ('from, 'to_) t =
+    | Idle_to_prompting : (turn_idle, turn_prompting) t
+    | Prompting_to_routing : (turn_prompting, turn_routing) t
+    | Prompting_to_executing : (turn_prompting, turn_executing) t
+    | Prompting_to_finalizing : (turn_prompting, turn_finalizing) t
+    | Prompting_to_exhausted : (turn_prompting, turn_exhausted) t
+    | Routing_to_prompting : (turn_routing, turn_prompting) t
+    | Routing_to_executing : (turn_routing, turn_executing) t
+    | Routing_to_exhausted : (turn_routing, turn_exhausted) t
+    | Executing_to_prompting : (turn_executing, turn_prompting) t
+    | Executing_to_routing : (turn_executing, turn_routing) t
+    | Executing_to_compacting : (turn_executing, turn_compacting) t
+    | Executing_to_finalizing : (turn_executing, turn_finalizing) t
+    | Executing_to_exhausted : (turn_executing, turn_exhausted) t
+    | Compacting_to_prompting : (turn_compacting, turn_prompting) t
+    | Compacting_to_finalizing : (turn_compacting, turn_finalizing) t
+    | Compacting_to_exhausted : (turn_compacting, turn_exhausted) t
+    | Finalizing_to_prompting : (turn_finalizing, turn_prompting) t
+    | Finalizing_to_routing : (turn_finalizing, turn_routing) t
+    | Finalizing_to_executing : (turn_finalizing, turn_executing) t
+    | Finalizing_to_exhausted : (turn_finalizing, turn_exhausted) t
+    | Exhausted_to_prompting : (turn_exhausted, turn_prompting) t
+    | Exhausted_to_routing : (turn_exhausted, turn_routing) t
+    | Exhausted_to_executing : (turn_exhausted, turn_executing) t
+
+  type packed = Packed_transition : ('a, 'b) t -> packed
+
+  val to_tag : ('from, 'to_) t -> string
+end
+
+type turn_phase_transition_spec_violation =
+  | Idle_to_routing
+  | Idle_to_executing
+  | Idle_to_compacting
+  | Idle_to_finalizing
+  | Idle_to_exhausted
+  | Prompting_to_idle
+  | Prompting_to_compacting
+  | Routing_to_idle
+  | Routing_to_compacting
+  | Routing_to_finalizing
+  | Executing_to_idle
+  | Compacting_to_idle
+  | Compacting_to_routing
+  | Compacting_to_executing
+  | Finalizing_to_idle
+  | Finalizing_to_compacting
+  | Exhausted_to_idle
+  | Exhausted_to_compacting
+  | Exhausted_to_finalizing
+
+val turn_phase_transition_spec_violation_to_tag
+  :  turn_phase_transition_spec_violation
+  -> string
+
+exception
+  Turn_phase_transition_violation of
+    { where : string
+    ; from : packed_turn_phase
+    ; to_ : packed_turn_phase
+    ; violation : turn_phase_transition_spec_violation
+    }
+
+val turn_phase_transition_violation_message
+  :  where:string
+  -> from:packed_turn_phase
+  -> to_:packed_turn_phase
+  -> violation:turn_phase_transition_spec_violation
+  -> string
+
+val raise_turn_phase_transition_violation
+  :  where:string
+  -> from:packed_turn_phase
+  -> to_:packed_turn_phase
+  -> violation:turn_phase_transition_spec_violation
+  -> 'a
+
+type turn_phase_resolve_outcome =
+  | Resolved_turn_transition of Turn_phase_transition.packed
+  | Resolved_turn_idempotent
+  | Resolved_turn_violation of turn_phase_transition_spec_violation
+
+val resolve_turn_phase_transition
+  :  from:packed_turn_phase
+  -> target:packed_turn_phase
+  -> turn_phase_resolve_outcome

--- a/lib/keeper/keeper_shell_ops_setup.mli
+++ b/lib/keeper/keeper_shell_ops_setup.mli
@@ -1,0 +1,21 @@
+(** Shared setup for SearchFiles shell operation handlers. *)
+
+val coreutils : Host_config.coreutils
+val metric_bash_history_append_failures : string
+
+val observe_history_append
+  :  root:string
+  -> keeper_name:string
+  -> Masc_exec.Bash_history.history_entry
+  -> unit
+
+val render_completed_process_result
+  :  root:string
+  -> keeper_name:string
+  -> op:string
+  -> ?cwd:string
+  -> cmd:string
+  -> ?extra:(string * Yojson.Safe.t) list
+  -> Unix.process_status
+  -> string
+  -> string

--- a/lib/keeper/keeper_tool_capability_axis.mli
+++ b/lib/keeper/keeper_tool_capability_axis.mli
@@ -1,0 +1,25 @@
+(** Semantic capability classification for keeper tool names. *)
+
+type t =
+  | Claim_task
+  | Board_activity
+  | Work_discovery
+  | Pr_work_action
+  | Pr_work_shell_command
+  | Pr_work_git_action
+  | Docker_route_pr_work_action
+
+val canonical_tool_name : string -> string
+val claim_task_tool_names : string list
+val board_activity_tool_names : string list
+val work_discovery_tool_names : string list
+val work_discovery_routing_tool_names : string list
+val preferred_work_discovery_tool_names : string list
+val inspect_worktree_delta_tool_names : string list
+val preferred_inspect_worktree_delta_tool_names : string list
+val pr_work_shell_command_tool_names : string list
+val pr_work_git_action_tool_names : string list
+val tool_names : t -> string list
+val supports : t -> string -> bool
+val supports_any : t -> string list -> bool
+val shell_command_input_candidates : string -> Yojson.Safe.t -> string list

--- a/lib/keeper/keeper_transition_audit_types.mli
+++ b/lib/keeper/keeper_transition_audit_types.mli
@@ -1,0 +1,61 @@
+(** Structured transition audit record types and JSON serializers. *)
+
+type transition_record =
+  { snapshot : Keeper_measurement.measurement_snapshot option
+  ; events_fired : Keeper_state_machine.event list
+  ; selected_event : Keeper_state_machine.event
+  ; prev_phase : Keeper_state_machine.phase
+  ; new_phase : Keeper_state_machine.phase
+  ; transition_outcome : string
+  ; wall_clock_at_decision : float
+  }
+
+type operator_signal =
+  { signal_class : string
+  ; severity : string
+  ; requires_operator_decision : bool
+  ; next_human_action : string option
+  ; summary : string
+  }
+
+val event_type_of_event : Keeper_state_machine.event -> string
+
+val operator_signal
+  :  ?next_human_action:string
+  -> signal_class:string
+  -> severity:string
+  -> requires_operator_decision:bool
+  -> string
+  -> operator_signal
+
+val operator_signal_to_json : operator_signal -> Yojson.Safe.t
+val operator_signal_of_transition : transition_record -> operator_signal
+val to_json : transition_record -> Yojson.Safe.t
+
+type completed_turn_outcome =
+  | Turn_substantive
+  | Turn_failed
+  | Turn_gate_rejected
+
+type completed_turn_record =
+  { turn_id : int
+  ; started_at : float
+  ; ended_at : float
+  ; outcome : completed_turn_outcome
+  }
+
+type turn_fsm_transition_record =
+  { turn_fsm_turn_id : int
+  ; turn_fsm_prev_state : string
+  ; turn_fsm_new_state : string
+  ; turn_fsm_action : string
+  ; turn_fsm_stop_signaled_before : bool option
+  ; turn_fsm_stop_signaled_after : bool option
+  ; turn_fsm_wall_clock_at : float
+  }
+
+val completed_turn_outcome_to_json : completed_turn_outcome -> Yojson.Safe.t
+val completed_turn_outcome_of_json : Yojson.Safe.t -> completed_turn_outcome option
+val completed_turn_to_json : completed_turn_record -> Yojson.Safe.t
+val turn_fsm_transition_to_json : turn_fsm_transition_record -> Yojson.Safe.t
+val completed_turn_of_json : Yojson.Safe.t -> completed_turn_record option

--- a/scripts/check-variants.sh
+++ b/scripts/check-variants.sh
@@ -77,9 +77,30 @@ extract_ocaml_all_list() {
 extract_ocaml_type() {
   local file="$1"
   local type_name="$2"
-  awk "/^type ${type_name}[[:space:]]*=/{found=1; next} found && /^[[:space:]]*\|/{print} found && /^[a-z]/{exit}" "$file" \
+  local variants
+  variants=$(awk "/^type ${type_name}[[:space:]]*=/{found=1; next} found && /^[[:space:]]*\|/{print} found && /^[a-z]/{exit}" "$file" \
     | rg '^[[:space:]]*\|[[:space:]]+([A-Z][a-zA-Z_0-9]*)' -o -r '$1' \
-    | sort -u || true
+    | sort -u || true)
+  if [ -n "$variants" ]; then
+    echo "$variants"
+    return
+  fi
+
+  local include_module snake_module candidate resolved
+  while IFS= read -r include_module; do
+    snake_module=$(echo "$include_module" | perl -pe 's/([A-Z])/_\L$1/g' | perl -pe 's/^_//')
+    for d in lib/keeper lib lib/coord lib/server lib/dashboard; do
+      candidate="${REPO_ROOT}/${d}/${snake_module}.ml"
+      if [ -f "$candidate" ]; then
+        resolved=$(extract_ocaml_type "$candidate" "$type_name")
+        if [ -n "$resolved" ]; then
+          echo "$resolved"
+          return
+        fi
+      fi
+    done
+  done < <(rg '^\s*include\s+([A-Z][a-zA-Z_0-9]*)\s*$' "$file" -o -r '$1' || true)
+  true
 }
 
 assert_contains_variant() {


### PR DESCRIPTION
Follow-up to #18520 after the legacy tool surface purge landed.\n\nChanges:\n- Adds explicit .mli files for eight keeper helper/type modules so ocaml-structure-ratchet returns to baseline.\n- Makes scripts/check-variants.sh follow extracted include modules when resolving OCaml variant types, so turn_phase/cascade_state checks survive the keeper type split.\n\nLocal checks:\n- ocamlformat --check on new .mli files\n- scripts/ocaml-structure-ratchet.sh\n- bash scripts/ci/check-tla-variant-sync.sh\n- scripts/ci/check-telemetry-coverage.sh\n- git diff --check\n\nLocal focused Dune build was not started because scripts/dune-local.sh refused while three bare Dune processes were already active on the host.