### PR TITLE
refactor(board): drop sort-order aliases

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 11:10:34 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 11:19:37 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -238,6 +238,12 @@
             <td><span class="status done">draft PR #18389</span></td>
             <td>Stop interpreting empty vote directions and the hidden legacy <code>vote</code> parameter as upvotes. Post votes, comment votes, and persisted vote-log loading now accept only canonical <code>up</code> / <code>down</code> values.</td>
             <td>The empty-string compatibility test became a rejection test, and tool coverage now pins rejection for both removed fallback paths. Local format, diff, grep, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
+          </tr>
+          <tr>
+            <td>Board sort-order query aliases</td>
+            <td><span class="status now">local branch</span></td>
+            <td>Remove the legacy <code>new</code>, <code>active</code>, and <code>comments</code> sort-order inputs from the shared Board parser. Tool and HTTP paths now accept only canonical <code>hot</code>, <code>trending</code>, <code>recent</code>, <code>updated</code>, and <code>discussed</code>.</td>
+            <td>The alias-preservation test is now rejection coverage, and the stale parser comments no longer document removed inputs. Local OCaml format/parse, diff, grep, unknown-permissive-default lint, comment-terminator lint, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune is blocked by external bare <code>dune build --root .</code> / <code>dune exec</code> processes.</td>
           </tr>
           <tr>
             <td><code>Bounded.constraints.token_buffer</code></td>

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -43,17 +43,14 @@ let sort_order_to_string = function
 
 let valid_sort_order_strings = List.map sort_order_to_string all_sort_orders
 
-(** Lenient parser: canonical names plus documented aliases that the
-    three pre-existing parsers (Tool_board.sort_order_of_string,
-    Tool_board.parse_sort_order, server_utils inline) all accept.
-    Aliases: new=Recent, active=Updated, comments=Discussed. *)
+(** Canonical parser shared by Tool_board and HTTP query-param handling. *)
 let sort_order_of_string_opt s =
   match String.lowercase_ascii (String.trim s) with
   | "hot" -> Some Hot
   | "trending" -> Some Trending
-  | "recent" | "new" -> Some Recent
-  | "updated" | "active" -> Some Updated
-  | "discussed" | "comments" -> Some Discussed
+  | "recent" -> Some Recent
+  | "updated" -> Some Updated
+  | "discussed" -> Some Discussed
   | _ -> None
 
 type board_backend =

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -30,10 +30,9 @@ let iso8601_of_unix ts =
     tm.tm_hour tm.tm_min tm.tm_sec
 
 (** Issue #8449 PR C: HTTP query-param sort_by parser. Delegates to
-    [Board_dispatch.sort_order_of_string_opt] (canonical + documented
-    aliases new/active/comments) instead of duplicating the inline
-    match. HTTP semantics keep the "default to Hot" fallback for
-    missing or invalid query params — graceful UI degradation, not
+    [Board_dispatch.sort_order_of_string_opt] instead of duplicating
+    the inline match. HTTP semantics keep the "default to Hot" fallback
+    for missing or invalid query params — graceful UI degradation, not
     silent data corruption. *)
 let board_sort_order_of_request request =
   match query_param request "sort_by" with

--- a/lib/server/server_utils.mli
+++ b/lib/server/server_utils.mli
@@ -57,8 +57,7 @@ val board_sort_order_of_request :
     param and resolves it through
     {!Board_dispatch.sort_order_of_string_opt}.  Missing or
     invalid values fall back to {!Board_dispatch.Hot} — graceful
-    UI degradation, not silent data corruption.  See issue #8449
-    PR C for the canonical aliases (new/active/comments). *)
+    UI degradation, not silent data corruption. *)
 
 val board_sort_label : Board_dispatch.sort_order -> string
 (** Thin alias over {!Board_dispatch.sort_order_to_string}. *)

--- a/lib/tool_board.mli
+++ b/lib/tool_board.mli
@@ -79,8 +79,7 @@ type sort_order = Board_dispatch.sort_order =
 
 val parse_sort_order : string -> (sort_order, string) Result.t
 (** Delegates to
-    {!Board_dispatch.sort_order_of_string_opt} (canonical
-    + documented aliases [new] / [active] / [comments]).
+    {!Board_dispatch.sort_order_of_string_opt} for canonical sort names.
     Error message lists
     {!Board_dispatch.valid_sort_order_strings} so adding
     a constructor automatically updates the user-facing

--- a/lib/tool_board_format.ml
+++ b/lib/tool_board_format.ml
@@ -375,8 +375,8 @@ let detect_truncated_markdown_with_reason (text : string) : truncation_signal op
     (type-alias with definition equality). Constructors are
     interchangeable across modules — no conversion needed.
     [parse_sort_order] delegates to
-    [Board_dispatch.sort_order_of_string_opt] (canonical + aliases
-    new/active/comments); error message derives from
+    [Board_dispatch.sort_order_of_string_opt] for canonical sort names;
+    error message derives from
     [Board_dispatch.valid_sort_order_strings] so adding a constructor
     automatically updates the user-facing list. *)
 type sort_order = Board_dispatch.sort_order =

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -69,17 +69,16 @@ let test_sort_order_witness_in_enum () =
   Alcotest.(check int) "count" 5
     (List.length D.valid_sort_order_strings)
 
-let test_sort_order_aliases () =
+let test_sort_order_legacy_aliases_rejected () =
   let module D = Masc_mcp.Board_dispatch in
-  Alcotest.(check (option string)) "new -> Recent" (Some "recent")
-    (Option.map D.sort_order_to_string (D.sort_order_of_string_opt "new"));
-  Alcotest.(check (option string)) "active -> Updated" (Some "updated")
-    (Option.map D.sort_order_to_string (D.sort_order_of_string_opt "active"));
-  Alcotest.(check (option string)) "comments -> Discussed" (Some "discussed")
-    (Option.map D.sort_order_to_string (D.sort_order_of_string_opt "comments"));
-  Alcotest.(check (option string)) "garbage rejected" None
-    (D.sort_order_of_string_opt "definitely-not-an-order"
-     |> Option.map D.sort_order_to_string)
+  let rejected label raw =
+    Alcotest.(check (option string)) label None
+      (D.sort_order_of_string_opt raw |> Option.map D.sort_order_to_string)
+  in
+  rejected "new rejected" "new";
+  rejected "active rejected" "active";
+  rejected "comments rejected" "comments";
+  rejected "garbage rejected" "definitely-not-an-order"
 
 let test_permanent_post () =
   let store = create_store () in
@@ -231,8 +230,8 @@ let () =
         [
           Alcotest.test_case "witness covers all 5 variants" `Quick
             test_sort_order_witness_in_enum;
-          Alcotest.test_case "aliases new/active/comments accepted" `Quick
-            test_sort_order_aliases;
+          Alcotest.test_case "legacy aliases rejected" `Quick
+            test_sort_order_legacy_aliases_rejected;
         ] );
       ( "post_kind",
         [


### PR DESCRIPTION
Summary
- remove legacy Board sort-order aliases new/active/comments from the shared parser
- update Tool_board/server_utils comments and flip the alias-preservation test into rejection coverage
- record the slice in docs/audit/2026-05-25-legacy-purge-plan.html

Verification
- opam exec -- ocamlformat --check lib/board_dispatch.ml lib/tool_board.mli lib/tool_board_format.ml lib/server/server_utils.ml lib/server/server_utils.mli test/test_board_ttl.ml
- opam exec -- ocamlc -stop-after parsing lib/board_dispatch.ml lib/tool_board_format.ml lib/server/server_utils.ml test/test_board_ttl.ml
- opam exec -- ocamlc -stop-after parsing -intf lib/board_dispatch.mli lib/tool_board.mli lib/server/server_utils.mli
- git diff --check origin/main...HEAD
- targeted rg for removed Board alias parser/test/comment patterns returns no matches
- scripts/lint/no-ocaml-comment-terminator-trap.sh ...
- scripts/lint/no-unknown-permissive-default.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh
- scripts/dune-local.sh build ./test/test_board_ttl.exe exits 75 because external bare Dune processes are already running; guard was not bypassed