### PR TITLE
fix(task): type claim readiness decisions

### DIFF
--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -132,15 +132,16 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
          let* () =
            Coord_task_classify.required_tool_claim_guard config ~agent_name ?agent_tool_names task
          in
-         (* Reclaim gate: only typed policy blocks claiming.
-         do_not_reclaim_reason is an operator-facing explanation, not state. *)
+         (* Claim gate: only typed policy blocks Todo reclaim.
+         do_not_reclaim_reason is an operator-facing explanation, not state;
+         workspace resolution is recoverable readiness, not a hard block. *)
          let* () =
-           match Masc_domain.task_reclaim_gate task with
-           | Reclaim_gate_open -> Ok ()
-           | Reclaim_gate_blocked_by_policy r ->
+           match Masc_domain.task_claim_decision task with
+           | Claim_unavailable (Claim_block_reclaim_policy r) ->
              Error
                (Masc_domain.Task (Masc_domain.Task_error.InvalidState
                   (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r)))
+           | Claim_available _ | Claim_unavailable (Claim_block_not_todo _) -> Ok ()
          in
          let (backlog, auto_released_ids) =
            auto_release_claimed_for_agent config ~agent_name ~exclude_task_id:task_id backlog

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -25,12 +25,7 @@ let task_status_label (status : Masc_domain.task_status) : string =
 ;;
 
 let task_is_claim_pool_candidate (task : Masc_domain.task) =
-  match task.task_status with
-  | Todo ->
-    (match Masc_domain.task_reclaim_gate task with
-     | Reclaim_gate_open -> true
-     | Reclaim_gate_blocked_by_policy _ -> false)
-  | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ -> false
+  Masc_domain.task_claim_decision_is_available task
 ;;
 
 type verification_claim_state =
@@ -391,9 +386,9 @@ let claim_next_r
         let blocked_todo =
           List.filter
             (fun (t : Masc_domain.task) ->
-               match Masc_domain.task_reclaim_gate t with
-               | Reclaim_gate_open -> false
-               | Reclaim_gate_blocked_by_policy _ -> true)
+               match Masc_domain.task_claim_decision t with
+               | Claim_unavailable (Claim_block_reclaim_policy _) -> true
+               | Claim_available _ | Claim_unavailable (Claim_block_not_todo _) -> false)
             all_todo
         in
         let latest_verification_status = latest_verification_status_by_task config in

--- a/lib/coord/coord_task_transitions.ml
+++ b/lib/coord/coord_task_transitions.ml
@@ -76,17 +76,23 @@ let transition_task_r
           | Masc_domain.Cancel -> Ok ()
         in
         let* () =
-          match action, Masc_domain.task_reclaim_gate task with
-          | Masc_domain.Claim, Reclaim_gate_blocked_by_policy r ->
+          match action with
+          | Masc_domain.Claim ->
+            (match Masc_domain.task_claim_decision task with
+             | Claim_unavailable (Claim_block_reclaim_policy r) ->
             Error
               (Masc_domain.Task
                  (Masc_domain.Task_error.InvalidState
                     (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r)))
-          | Masc_domain.Claim, Reclaim_gate_open
-          | ( Masc_domain.Start | Masc_domain.Done_action | Masc_domain.Cancel
-            | Masc_domain.Release | Masc_domain.Submit_for_verification
-            | Masc_domain.Approve_verification | Masc_domain.Reject_verification
-            | Masc_domain.Submit_pr_evidence ), _ -> Ok ()
+             | Claim_available _ | Claim_unavailable (Claim_block_not_todo _) -> Ok ())
+          | Masc_domain.Start
+          | Masc_domain.Done_action
+          | Masc_domain.Cancel
+          | Masc_domain.Release
+          | Masc_domain.Submit_for_verification
+          | Masc_domain.Approve_verification
+          | Masc_domain.Reject_verification
+          | Masc_domain.Submit_pr_evidence -> Ok ()
         in
         let* () =
           (match action, task.task_status with

--- a/lib/coordination_product.ml
+++ b/lib/coordination_product.ml
@@ -238,15 +238,10 @@ let compare_turn_queue_entry left right =
 let visible_claim_queue tasks =
   tasks
   |> List.filter_map (fun (task : Masc_domain.task) ->
-    match task.task_status, Masc_domain.task_reclaim_gate task with
-    | Masc_domain.Todo, Masc_domain.Reclaim_gate_blocked_by_policy _ -> None
-    | Masc_domain.Todo, Masc_domain.Reclaim_gate_open ->
+    match Masc_domain.task_claim_decision task with
+    | Masc_domain.Claim_available _ ->
       Some { task_id = task.id; priority = task.priority; created_at = task.created_at }
-    | Masc_domain.Claimed _, _
-    | Masc_domain.InProgress _, _
-    | Masc_domain.AwaitingVerification _, _
-    | Masc_domain.Done _, _
-    | Masc_domain.Cancelled _, _ ->
+    | Masc_domain.Claim_unavailable _ ->
       None)
   |> List.sort compare_turn_queue_entry
 ;;

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -549,6 +549,51 @@ let task_reclaim_gate_block_reason t =
   | Reclaim_gate_blocked_by_policy reason -> Some reason
 ;;
 
+type task_claim_readiness =
+  | Claim_ready
+  | Claim_needs_workspace_resolution of worktree_info
+
+type task_claim_block =
+  | Claim_block_not_todo of task_status
+  | Claim_block_reclaim_policy of string
+
+type task_claim_decision =
+  | Claim_available of task_claim_readiness
+  | Claim_unavailable of task_claim_block
+
+let task_claim_readiness ?worktree_exists (task : task) =
+  match task.worktree, worktree_exists with
+  | Some worktree, Some exists when not (exists worktree) ->
+    Claim_needs_workspace_resolution worktree
+  | Some _, Some _
+  | Some _, None
+  | None, Some _
+  | None, None ->
+    Claim_ready
+;;
+
+let task_claim_decision ?worktree_exists (task : task) =
+  match task.task_status with
+  | Todo ->
+    (match task_reclaim_gate task with
+     | Reclaim_gate_open ->
+       Claim_available (task_claim_readiness ?worktree_exists task)
+     | Reclaim_gate_blocked_by_policy reason ->
+       Claim_unavailable (Claim_block_reclaim_policy reason))
+  | Claimed _
+  | InProgress _
+  | AwaitingVerification _
+  | Done _
+  | Cancelled _ ->
+    Claim_unavailable (Claim_block_not_todo task.task_status)
+;;
+
+let task_claim_decision_is_available ?worktree_exists task =
+  match task_claim_decision ?worktree_exists task with
+  | Claim_available _ -> true
+  | Claim_unavailable _ -> false
+;;
+
 (* Manual yojson for task *)
 let task_to_yojson t =
   let status_json = task_status_to_yojson t.task_status in

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -199,6 +199,26 @@ val task_reclaim_gate : task -> task_reclaim_gate
 
 val task_reclaim_gate_block_reason : task -> string option
 
+type task_claim_readiness =
+  | Claim_ready
+  | Claim_needs_workspace_resolution of worktree_info
+
+type task_claim_block =
+  | Claim_block_not_todo of task_status
+  | Claim_block_reclaim_policy of string
+
+type task_claim_decision =
+  | Claim_available of task_claim_readiness
+  | Claim_unavailable of task_claim_block
+
+val task_claim_decision :
+  ?worktree_exists:(worktree_info -> bool) -> task -> task_claim_decision
+(** Deterministic claim decision for queue/admission surfaces.  A missing
+    workspace is modeled as recoverable readiness, not a hard claim block. *)
+
+val task_claim_decision_is_available :
+  ?worktree_exists:(worktree_info -> bool) -> task -> bool
+
 type message =
   { seq : int
   ; from_agent : string [@key "from"]

--- a/test/test_coordination_product.ml
+++ b/test/test_coordination_product.ml
@@ -190,6 +190,27 @@ let test_visible_claim_queue_is_deterministic () =
     (List.map (fun (entry : CP.turn_queue_entry) -> entry.task_id) queue)
 ;;
 
+let test_visible_claim_queue_uses_typed_claim_decision () =
+  let blocked =
+    { (task ~id:"blocked" ~title:"Blocked" ())
+      with
+      reclaim_policy = Some Masc_domain.Block_reclaim
+    ; do_not_reclaim_reason = Some "operator hard stop"
+    }
+  in
+  let recoverable =
+    { (task ~id:"recoverable" ~title:"Recoverable" ())
+      with
+      do_not_reclaim_reason = Some "worktree path not found"
+    }
+  in
+  let queue = CP.visible_claim_queue [ blocked; recoverable ] in
+  Alcotest.(check (list string))
+    "queue"
+    [ "recoverable" ]
+    (List.map (fun (entry : CP.turn_queue_entry) -> entry.task_id) queue)
+;;
+
 let test_duplicate_active_claim_violation () =
   let tasks =
     [ task
@@ -450,6 +471,10 @@ let () =
             "visible claim queue"
             `Quick
             test_visible_claim_queue_is_deterministic
+        ; Alcotest.test_case
+            "visible claim queue uses typed claim decision"
+            `Quick
+            test_visible_claim_queue_uses_typed_claim_decision
         ; Alcotest.test_case
             "duplicate active claim owners"
             `Quick

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -1429,6 +1429,76 @@ let test_task_reclaim_gate_blocks_only_typed_policy () =
     check string "reason" "operator hard stop" reason
   | Masc_domain.Reclaim_gate_open -> fail "typed block policy must close reclaim gate"
 
+let test_task_claim_decision_keeps_missing_workspace_claimable () =
+  let worktree : Masc_domain.worktree_info =
+    {
+      branch = "fix/missing-worktree";
+      path = ".worktrees/missing-worktree";
+      git_root = "/repo";
+      repo_name = "repo";
+    }
+  in
+  let t : Masc_domain.task = {
+    id = "task-006";
+    title = "Recover workspace";
+    description = "";
+    task_status = Masc_domain.Todo;
+    goal_id = None;
+    priority = 1;
+    files = [];
+    created_at = "2024-01-15T12:00:00Z";
+    worktree = Some worktree;
+    created_by = None;
+    stage = None;
+    contract = None;
+    handoff_context = None;
+    cycle_count = 0;
+    reclaim_policy = None;
+    do_not_reclaim_reason = Some "worktree path not found";
+  } in
+  match Masc_domain.task_claim_decision ~worktree_exists:(fun _ -> false) t with
+  | Masc_domain.Claim_available (Masc_domain.Claim_needs_workspace_resolution observed) ->
+    check string "workspace path" worktree.path observed.path
+  | Masc_domain.Claim_available Masc_domain.Claim_ready ->
+    fail "missing workspace should be surfaced as recoverable readiness"
+  | Masc_domain.Claim_unavailable _ ->
+    fail "missing workspace must not hard-block claim"
+
+let test_task_claim_decision_policy_block_wins_over_readiness () =
+  let worktree : Masc_domain.worktree_info =
+    {
+      branch = "fix/missing-worktree";
+      path = ".worktrees/missing-worktree";
+      git_root = "/repo";
+      repo_name = "repo";
+    }
+  in
+  let t : Masc_domain.task = {
+    id = "task-007";
+    title = "Operator stop";
+    description = "";
+    task_status = Masc_domain.Todo;
+    goal_id = None;
+    priority = 1;
+    files = [];
+    created_at = "2024-01-15T12:00:00Z";
+    worktree = Some worktree;
+    created_by = None;
+    stage = None;
+    contract = None;
+    handoff_context = None;
+    cycle_count = 0;
+    reclaim_policy = Some Masc_domain.Block_reclaim;
+    do_not_reclaim_reason = Some "operator hard stop";
+  } in
+  match Masc_domain.task_claim_decision ~worktree_exists:(fun _ -> false) t with
+  | Masc_domain.Claim_unavailable (Masc_domain.Claim_block_reclaim_policy reason) ->
+    check string "reason" "operator hard stop" reason
+  | Masc_domain.Claim_available _ ->
+    fail "typed reclaim policy must hard-block claim"
+  | Masc_domain.Claim_unavailable (Masc_domain.Claim_block_not_todo _) ->
+    fail "todo task should not be classified as not-todo"
+
 (* ============================================================
    a2a_task_to/of_yojson Tests
    ============================================================ *)
@@ -1832,6 +1902,10 @@ let () =
         test_task_reclaim_gate_ignores_free_text_without_policy;
       test_case "reclaim gate blocks typed policy" `Quick
         test_task_reclaim_gate_blocks_only_typed_policy;
+      test_case "claim decision keeps missing workspace claimable" `Quick
+        test_task_claim_decision_keeps_missing_workspace_claimable;
+      test_case "claim decision policy block wins over readiness" `Quick
+        test_task_claim_decision_policy_block_wins_over_readiness;
     ];
     "a2a_task_yojson", [
       test_case "to_yojson" `Quick test_a2a_task_to_yojson;


### PR DESCRIPTION
## Summary
- add a domain-level task_claim_decision ADT that separates claim availability from recoverable workspace readiness
- route direct claim, transition claim, claim_next, and visible claim queue through the same typed decision
- add regressions showing missing workspace/free-text remains claimable while typed reclaim_policy blocks

## Verification
- ocamlformat --check lib/types/types_core.ml lib/types/types_core.mli lib/coord/coord_task_claim.ml lib/coord/coord_task_schedule.ml lib/coord/coord_task_transitions.ml lib/coordination_product.ml test/test_types_coverage.ml test/test_coordination_product.ml
- git diff --check origin/main...HEAD
- rg guard for legacy free-text hard-gate helpers and worktree hard-block wording

## Local Dune
- Blocked locally by existing bare Dune processes outside scripts/dune-local.sh; wrapper refused to start another build.