### PR TITLE
refactor(mcp): drop join-state alias bridge

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 11:23:59 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 11:31:42 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -190,6 +190,12 @@
             <td><span class="status done">draft PR #18379</span></td>
             <td>Stop treating <code>[MASC_MEMORY_SUMMARY v1]</code> and <code>[MASC_GOAL]</code> as sticky context anchors; keep only current <code>[MEMORY_SUMMARY]</code> and <code>[GOAL]</code>.</td>
             <td>Compat-preservation tests were replaced with negative tests proving old MASC markers no longer receive anchor boost. Local static ratchets pass; focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
+          </tr>
+          <tr>
+            <td>MCP join-state identity alias bridge</td>
+            <td><span class="status now">draft PR #18544</span></td>
+            <td>Remove the secondary <code>Keeper_identity.normalize_all_names</code> lookup from <code>resolve_join_state</code>. Join-required tools now check only the caller's raw <code>agent_name</code> instead of recovering rotated keeper aliases through canonical keeper names.</td>
+            <td>The alias-recovery test is flipped to prove the canonical form is not retried. Local OCaml format/parse, diff, grep, unknown-permissive-default lint, comment-terminator lint, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune is blocked by external bare <code>dune build --root .</code> / <code>dune exec</code> processes.</td>
           </tr>
           <tr>
             <td>Room-state <code>active_agents</code> object recovery</td>

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -8,84 +8,12 @@
 let log_mcp_exn = Mcp_server_eio_helpers.log_mcp_exn
 let wait_for_message_eio = Mcp_server_eio_helpers.wait_for_message_eio
 
-(* #10699 Family A — "Join required" surfaces 28 / 24h events for
-   masc_transition + masc_claim_next while the underlying keeper had
-   joined under its canonical name at boot via
-   [ensure_keeper_room_presence]. Rotation aliases (e.g.
-   [nick0cave-happy-shark] vs canonical [keeper-nick0cave-agent])
-   carry the join entry under the canonical name only;
-   [Coord.is_agent_joined] does prefix matching against on-disk agent
-   files but cannot project an alias back to the canonical without
-   the [Keeper_identity] vocabulary that owns that mapping.
-
-   When the raw [agent_name] check fails, retry once using the
-   canonical [keeper_name] from
-   [Keeper_identity.normalize_all_names]. The normalisation is gated
-   by [canonical_keeper_name] inside [Keeper_identity], so an
-   unrelated external caller ("alice-fake-bear") returns
-   [Persona_not_found] and falls through to the original [false] —
-   the alias-bridge only fires when the input is recognisably a
-   keeper-form name.
-
-   [check_join] is now parameterised on the candidate name so we can
-   re-issue the lookup against the canonical form without rebuilding
-   the closure environment. *)
-let resolve_join_state ~room_initialized ~join_required ~agent_name ~base_path ~check_join
-  =
+let resolve_join_state ~room_initialized ~join_required ~agent_name ~check_join =
   if not (room_initialized && join_required)
   then false
   else if agent_name = "unknown"
   then false
-  else (
-    (* [try_candidate] probes an alias only when it differs from the
-       caller's own name, to avoid a redundant second lookup for the
-       common case where the caller IS already using the canonical name. *)
-    let try_candidate name = name <> agent_name && check_join name in
-    (* Primary check: the name as supplied by the caller. *)
-    if check_join agent_name
-    then true
-    else (
-      (* Secondary check: resolve through Keeper_identity to find aliases.
-         [normalize_all_names] may do filesystem I/O; we express the
-         result as [Result.t] and fold both paths to a plain [bool]. *)
-      let join_via_aliases () =
-        let ( let* ) = Result.bind in
-        let* bundle =
-          Keeper_identity.normalize_all_names
-            ~input_agent_name:agent_name
-            ~base_path
-            ~check_persona:false
-            ~check_credential:false
-            ()
-        in
-        (* Try the persona-level [keeper_name] first (e.g. [nick0cave]),
-           then the canonical agent-form alias that
-           [ensure_keeper_room_presence] writes to disk
-           (e.g. [keeper-nick0cave-agent]). *)
-        Ok
-          (try_candidate bundle.keeper_name
-           || try_candidate (Printf.sprintf "keeper-%s-agent" bundle.keeper_name))
-      in
-      match
-        (* Previously [Sys_error _ | Yojson.Json_error _ -> Ok false]
-           silently collapsed read-side failure modes from
-           [normalize_all_names] (missing agents file, malformed JSON)
-           into "not joined" — indistinguishable from a legitimate
-           [false] result. The MCP tool surface gates handlers on this
-           bool, so a silent false here is an unguarded negative cap.
-           [Cancelled] propagates unchanged. *)
-        try join_via_aliases () with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | (Sys_error _ | Yojson.Json_error _) as exn ->
-          Log.Mcp.warn
-            "[resolve_join_state] alias lookup failed for %s: %s; treating \
-             as not-joined"
-            agent_name
-            (Printexc.to_string exn);
-          Ok false
-      with
-      | Ok joined -> joined
-      | Error _ -> false))
+  else check_join agent_name
 ;;
 
 let caller_agent_name_from_arguments arguments =
@@ -360,13 +288,11 @@ let execute_tool_eio
               let is_joined =
                 if !room_init_cached
                 then (
-                  (* Same silent-false anti-pattern as resolve_join_state
-                     at line ~78. Auto-join gate hides the failure mode
-                     that distinguishes "agent really isn't joined yet"
-                     from "we can't read the join state". Invalid_argument
-                     is kept because [Coord.is_agent_joined] surface
-                     formerly raised it on malformed agent_name input;
-                     dropping it changes scope. *)
+                  (* Auto-join gate hides the failure mode that distinguishes
+                     "agent really isn't joined yet" from "we can't read the
+                     join state". Invalid_argument is kept because
+                     [Coord.is_agent_joined] surface formerly raised it on
+                     malformed agent_name input; dropping it changes scope. *)
                   try Coord.is_agent_joined config ~agent_name with
                   | Eio.Cancel.Cancelled _ as e -> raise e
                   | (Sys_error _ | Yojson.Json_error _ | Invalid_argument _) as exn
@@ -474,7 +400,6 @@ let execute_tool_eio
               ~room_initialized
               ~join_required
               ~agent_name
-              ~base_path:config.base_path
               ~check_join:(fun candidate ->
                 Coord.is_agent_joined config ~agent_name:candidate)
           in

--- a/lib/mcp_server_eio_execute.mli
+++ b/lib/mcp_server_eio_execute.mli
@@ -33,7 +33,6 @@ val resolve_join_state :
   room_initialized:bool ->
   join_required:bool ->
   agent_name:string ->
-  base_path:string ->
   check_join:(string -> bool) ->
   bool
 (** Returns [true] iff the request should be treated as a
@@ -43,9 +42,7 @@ val resolve_join_state :
     - [room_initialized = false] or [join_required = false]
       → [false] (no join check needed).
     - [agent_name = "unknown"] → [false] (sentinel name).
-    - Otherwise probes [check_join agent_name]; on miss,
-      tries an alias chain via {!Agent_name_kind.is_ephemeral}
-      and the [base_path]-derived identity aliases.
+    - Otherwise probes only [check_join agent_name].
 
     [check_join] is injected so tests can drive the
     resolver against a deterministic registry. *)

--- a/test/test_mcp_server_eio_join_state.ml
+++ b/test/test_mcp_server_eio_join_state.ml
@@ -5,7 +5,6 @@ let test_resolve_join_state_skips_read_only_lookup () =
       ~room_initialized:true
       ~join_required:false
       ~agent_name:"agent_code"
-      ~base_path:"/tmp/masc-test-resolve-join"
       ~check_join:(fun _candidate ->
         called := true;
         true)
@@ -20,7 +19,6 @@ let test_resolve_join_state_checks_join_required_tools () =
       ~room_initialized:true
       ~join_required:true
       ~agent_name:"agent_code"
-      ~base_path:"/tmp/masc-test-resolve-join"
       ~check_join:(fun _candidate ->
         called := true;
         true)
@@ -35,7 +33,6 @@ let test_resolve_join_state_skips_unknown_agent () =
       ~room_initialized:true
       ~join_required:true
       ~agent_name:"unknown"
-      ~base_path:"/tmp/masc-test-resolve-join"
       ~check_join:(fun _candidate ->
         called := true;
         true)
@@ -43,28 +40,23 @@ let test_resolve_join_state_skips_unknown_agent () =
   Alcotest.(check bool) "unknown agent skipped" false !called;
   Alcotest.(check bool) "unknown agent treated unjoined" false joined
 
-let test_resolve_join_state_alias_resolves_to_canonical () =
+let test_resolve_join_state_alias_does_not_probe_canonical () =
   let candidates = ref [] in
   let joined =
     Masc_mcp.Mcp_server_eio_execute.resolve_join_state
       ~room_initialized:true
       ~join_required:true
-      ~agent_name:"agent_code-happy-shark"
-      ~base_path:"/tmp/masc-test-resolve-join"
+      ~agent_name:"agent_code-rotated"
       ~check_join:(fun candidate ->
         candidates := candidate :: !candidates;
         candidate = "keeper-agent_code-agent")
   in
-  Alcotest.(check bool) "join recovered via canonical" true joined;
+  Alcotest.(check bool) "canonical alias not recovered" false joined;
   let recorded = List.rev !candidates in
-  Alcotest.(check bool)
-    "raw alias attempted first"
-    true
-    (List.length recorded >= 1 && List.hd recorded = "agent_code-happy-shark");
-  Alcotest.(check bool)
-    "canonical agent form considered"
-    true
-    (List.exists (String.equal "keeper-agent_code-agent") recorded)
+  Alcotest.(check (list string))
+    "only raw agent checked"
+    [ "agent_code-rotated" ]
+    recorded
 
 let test_resolve_join_state_unknown_alias_stays_false () =
   let joined =
@@ -72,7 +64,6 @@ let test_resolve_join_state_unknown_alias_stays_false () =
       ~room_initialized:true
       ~join_required:true
       ~agent_name:"a-b"
-      ~base_path:"/tmp/masc-test-resolve-join"
       ~check_join:(fun _candidate -> false)
   in
   Alcotest.(check bool) "non-keeper input stays unjoined" false joined
@@ -90,9 +81,9 @@ let () =
         ; ( "resolve_join_state skips unknown agent"
           , `Quick
           , test_resolve_join_state_skips_unknown_agent )
-        ; ( "resolve_join_state alias resolves to canonical"
+        ; ( "resolve_join_state alias does not probe canonical"
           , `Quick
-          , test_resolve_join_state_alias_resolves_to_canonical )
+          , test_resolve_join_state_alias_does_not_probe_canonical )
         ; ( "resolve_join_state unknown alias stays false"
           , `Quick
           , test_resolve_join_state_unknown_alias_stays_false )


### PR DESCRIPTION
Summary
- remove the secondary Keeper_identity.normalize_all_names lookup from resolve_join_state
- make join-required tool gating check only the caller's raw agent_name
- flip the join-state alias recovery test into rejection/no-retry coverage
- record the slice in docs/audit/2026-05-25-legacy-purge-plan.html

Verification
- opam exec -- ocamlformat --check lib/mcp_server_eio_execute.ml lib/mcp_server_eio_execute.mli test/test_mcp_server_eio_join_state.ml
- opam exec -- ocamlc -stop-after parsing lib/mcp_server_eio_execute.ml test/test_mcp_server_eio_join_state.ml
- opam exec -- ocamlc -stop-after parsing -intf lib/mcp_server_eio_execute.mli
- git diff --check origin/main...HEAD
- targeted rg for removed join-state alias bridge patterns returns no matches
- scripts/lint/no-ocaml-comment-terminator-trap.sh ...
- scripts/lint/no-unknown-permissive-default.sh
- scripts/lint-ignore-without-comment.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh
- scripts/dune-local.sh build ./test/test_mcp_server_eio_join_state.exe exits 75 because external bare Dune processes are already running; guard was not bypassed