### PR TITLE
refactor(keeper): drop identity helpers from types facade

### DIFF
--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -161,14 +161,6 @@ let persistent_agent_names config =
       None)
 ;;
 
-let keeper_name_from_agent_name = Keeper_identity.keeper_name_from_agent_name
-
-let canonical_keeper_name_from_agent_name =
-  Keeper_identity.canonical_keeper_name_from_agent_name
-;;
-
-let canonical_keeper_name = Keeper_identity.canonical_keeper_name
-
 let read_meta_resolved config name : ((string * keeper_meta) option, string) result =
   let requested_name = String.trim name in
   let read_candidate candidate =
@@ -182,7 +174,7 @@ let read_meta_resolved config name : ((string * keeper_meta) option, string) res
     | Ok (Some _) as ok -> ok
     | Error _ as err -> err
     | Ok None ->
-      (match keeper_name_from_agent_name requested_name with
+      (match Keeper_identity.keeper_name_from_agent_name requested_name with
        | Some alias_name when not (String.equal alias_name requested_name) ->
          read_candidate alias_name
        | _ -> Ok None)
@@ -239,7 +231,7 @@ let read_meta_if_changed config name ~(last_mtime : float) : (keeper_meta * floa
   match read_candidate requested_name with
   | Some _ as changed -> changed
   | None ->
-    (match keeper_name_from_agent_name requested_name with
+    (match Keeper_identity.keeper_name_from_agent_name requested_name with
      | Some alias_name when not (String.equal alias_name requested_name) ->
        read_candidate alias_name
      | _ -> None)

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -60,15 +60,9 @@ val keepalive_keeper_names : Coord.config -> string list
     rather than the keepalive fiber. *)
 val persistent_agent_names : Coord.config -> string list
 
-(** Re-exports from [Keeper_identity] kept on this module for the
-    [Keeper_types.*] facade. *)
-val keeper_name_from_agent_name : string -> string option
-val canonical_keeper_name_from_agent_name : string -> string option
-val canonical_keeper_name : string -> string option
-
 (** Read the keeper meta for [name]. Operator-facing lookups require
     the canonical keeper filename component; runtime agent names still
-    resolve through [keeper_name_from_agent_name]. *)
+    resolve through [Keeper_identity.keeper_name_from_agent_name]. *)
 val read_meta_resolved :
   Coord.config ->
   string ->

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -419,9 +419,6 @@ val is_version_conflict_error : string -> bool
 (** True when [write_meta] returned an error caused by CAS version
     mismatch (vs an actual I/O failure). Useful for callers that want
     to log conflicts at WARN and other failures at ERROR. *)
-val keeper_name_from_agent_name : string -> string option
-val canonical_keeper_name_from_agent_name : string -> string option
-val canonical_keeper_name : string -> string option
 val read_meta_resolved :
   Coord.config -> string -> ((string * keeper_meta) option, string) result
 val read_meta : Coord.config -> string -> (keeper_meta option, string) result

--- a/lib/mcp_server_eio_caller_identity.ml
+++ b/lib/mcp_server_eio_caller_identity.ml
@@ -46,7 +46,7 @@ let direct_call_block_message name =
 let resolve_owner_keeper_identity config owner_name =
   let candidates =
     [
-      Keeper_types.canonical_keeper_name owner_name;
+      Keeper_identity.canonical_keeper_name owner_name;
       Keeper_identity.canonical_keeper_name_from_agent_name owner_name;
     ]
     |> List.filter_map (function

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -260,7 +260,7 @@ let execute_tool_eio
        in
        let keeper_tool_names =
          let candidates =
-           [ Keeper_types.canonical_keeper_name agent_name
+           [ Keeper_identity.canonical_keeper_name agent_name
            ; Keeper_identity.canonical_keeper_name_from_agent_name agent_name
            ]
            |> List.filter_map Fun.id
@@ -698,7 +698,7 @@ let execute_tool_eio
               | Some _ | None ->
                 let candidates =
                   [ Keeper_identity.canonical_keeper_name_from_agent_name agent_name
-                  ; Keeper_types.canonical_keeper_name agent_name
+                  ; Keeper_identity.canonical_keeper_name agent_name
                   ]
                   |> List.filter_map (function
                     | Some value when String.trim value <> "" -> Some (String.trim value)

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -82,7 +82,7 @@ let resolve_keeper_purge_target config requested_name =
     [
       Some trimmed;
       Keeper_identity.canonical_keeper_name_from_agent_name trimmed;
-      Keeper_types.canonical_keeper_name trimmed;
+      Keeper_identity.canonical_keeper_name trimmed;
     ]
     |> List.filter_map (function
          | Some value when value <> "" -> Some value

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -312,13 +312,13 @@ let test_canonical_keeper_name_from_keeper_agent_alias_preserves_full_name () =
 let test_canonical_keeper_name_from_legacy_keeper_name () =
   Alcotest.(check (option string))
     "legacy keeper-prefixed name normalizes" (Some "sangsu")
-    (Keeper_types.canonical_keeper_name "keeper-sangsu")
+    (Keeper_identity.canonical_keeper_name "keeper-sangsu")
 
 let test_canonical_keeper_name_preserves_plain_hyphenated_name () =
   Alcotest.(check (option string))
     "plain hyphenated keeper name is preserved"
     (Some "masc-mcp-smoke")
-    (Keeper_types.canonical_keeper_name "masc-mcp-smoke")
+    (Keeper_identity.canonical_keeper_name "masc-mcp-smoke")
 
 (* ============================================================
    Test runner


### PR DESCRIPTION
## What changed

- Remove `keeper_name_from_agent_name`, `canonical_keeper_name_from_agent_name`, and `canonical_keeper_name` from the `Keeper_types` public facade.
- Remove the pass-through identity aliases from `Keeper_meta_store`; `read_meta_resolved` now calls `Keeper_identity` directly for runtime agent-name resolution.
- Move the remaining repo callers/tests to `Keeper_identity`.

## Why

This advances the P1 `Keeper_types` compatibility facade item in `docs/audit/2026-05-25-legacy-purge-plan.html`: identity normalization is owned by `Keeper_identity`, not the broad meta/types facade.

## Validation

- `rg 'Keeper_types\.(keeper_name_from_agent_name|canonical_keeper_name_from_agent_name|canonical_keeper_name)\b' lib test docs scripts config` returned no matches.
- `rg 'Keeper_meta_store\.(keeper_name_from_agent_name|canonical_keeper_name_from_agent_name|canonical_keeper_name)\b|\bval (keeper_name_from_agent_name|canonical_keeper_name_from_agent_name|canonical_keeper_name)\b|let (keeper_name_from_agent_name|canonical_keeper_name_from_agent_name|canonical_keeper_name) = Keeper_identity' lib/keeper/keeper_meta_store.ml lib/keeper/keeper_meta_store.mli lib/keeper/keeper_types.mli` returned no matches.
- `git diff --check`
- `opam exec -- ocamlformat --check lib/keeper/keeper_meta_store.ml lib/keeper/keeper_meta_store.mli lib/keeper/keeper_types.mli lib/mcp_server_eio_caller_identity.ml lib/mcp_server_eio_execute.ml lib/server/server_dashboard_http_delete_actions.ml test/test_keeper_agent_isolation.ml`
- `opam exec -- ocamlc -stop-after parsing lib/keeper/keeper_meta_store.ml lib/keeper/keeper_meta_store.mli lib/keeper/keeper_types.mli lib/mcp_server_eio_caller_identity.ml lib/mcp_server_eio_execute.ml lib/server/server_dashboard_http_delete_actions.ml test/test_keeper_agent_isolation.ml`

## Local Dune gap

- `scripts/dune-local.sh build test/test_keeper_agent_isolation.exe lib/masc_mcp.cmxa` exited 75 because live bare Dune processes were already running outside the wrapper. Per the plan's Immediate Verification Contract, I did not bypass the guard; PR CI should cover the focused build.
