### PR TITLE
fix(task): type claim recovery actions

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -25,7 +25,19 @@ let task_status_label (status : Masc_domain.task_status) : string =
 ;;
 
 let task_is_claim_pool_candidate (task : Masc_domain.task) =
-  Masc_domain.task_claim_decision_is_available task
+  Masc_domain.task_claim_next_action_is_claimable task
+;;
+
+let task_worktree_path (worktree : Masc_domain.worktree_info) =
+  if Filename.is_relative worktree.path
+  then Filename.concat worktree.git_root worktree.path
+  else worktree.path
+;;
+
+let task_worktree_exists worktree =
+  let path = task_worktree_path worktree in
+  try Sys.file_exists path && Sys.is_directory path with
+  | Sys_error _ -> false
 ;;
 
 type verification_claim_state =
@@ -386,9 +398,24 @@ let claim_next_r
         let blocked_todo =
           List.filter
             (fun (t : Masc_domain.task) ->
-               match Masc_domain.task_claim_decision t with
-               | Claim_unavailable (Claim_block_reclaim_policy _) -> true
-               | Claim_available _ | Claim_unavailable (Claim_block_not_todo _) -> false)
+               match
+                 Masc_domain.task_claim_next_action ~worktree_exists:task_worktree_exists t
+               with
+               | Skip_claim (Claim_block_reclaim_policy _) -> true
+               | Claim_now
+               | Claim_with_workspace_resolution _
+               | Skip_claim (Claim_block_not_todo _) ->
+                 false)
+            all_todo
+        in
+        let workspace_resolution_todo =
+          List.filter
+            (fun (t : Masc_domain.task) ->
+               match
+                 Masc_domain.task_claim_next_action ~worktree_exists:task_worktree_exists t
+               with
+               | Claim_with_workspace_resolution _ -> true
+               | Claim_now | Skip_claim _ -> false)
             all_todo
         in
         let latest_verification_status = latest_verification_status_by_task config in
@@ -405,6 +432,16 @@ let claim_next_r
                 ; "blocked", `Int (List.length blocked_todo)
                 ; "ts", `String (now_iso ())
                 ]);
+        if workspace_resolution_todo <> []
+        then
+          log_event
+            config
+            (`Assoc
+                [ "type", `String "task_claim_next_workspace_resolution"
+                ; "agent", `String agent_name
+                ; "recoverable", `Int (List.length workspace_resolution_todo)
+                ; "ts", `String (now_iso ())
+                ]);
         if verification_blocked_todo <> []
         then
           log_event
@@ -415,7 +452,12 @@ let claim_next_r
                 ; "blocked", `Int (List.length verification_blocked_todo)
                 ; "ts", `String (now_iso ())
                 ]);
-        let unclaimed = List.filter task_is_claim_pool_candidate sorted in
+        let unclaimed =
+          List.filter
+            (Masc_domain.task_claim_next_action_is_claimable
+               ~worktree_exists:task_worktree_exists)
+            sorted
+        in
         (* Also exclude the just-released task: the agent is moving on,
          re-claiming the same task would be a no-op loop. *)
         let blocked_ids =

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -594,6 +594,25 @@ let task_claim_decision_is_available ?worktree_exists task =
   | Claim_unavailable _ -> false
 ;;
 
+type task_claim_next_action =
+  | Claim_now
+  | Claim_with_workspace_resolution of worktree_info
+  | Skip_claim of task_claim_block
+
+let task_claim_next_action ?worktree_exists task =
+  match task_claim_decision ?worktree_exists task with
+  | Claim_available Claim_ready -> Claim_now
+  | Claim_available (Claim_needs_workspace_resolution worktree) ->
+    Claim_with_workspace_resolution worktree
+  | Claim_unavailable block -> Skip_claim block
+;;
+
+let task_claim_next_action_is_claimable ?worktree_exists task =
+  match task_claim_next_action ?worktree_exists task with
+  | Claim_now | Claim_with_workspace_resolution _ -> true
+  | Skip_claim _ -> false
+;;
+
 (* Manual yojson for task *)
 let task_to_yojson t =
   let status_json = task_status_to_yojson t.task_status in

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -219,6 +219,20 @@ val task_claim_decision :
 val task_claim_decision_is_available :
   ?worktree_exists:(worktree_info -> bool) -> task -> bool
 
+type task_claim_next_action =
+  | Claim_now
+  | Claim_with_workspace_resolution of worktree_info
+  | Skip_claim of task_claim_block
+
+val task_claim_next_action :
+  ?worktree_exists:(worktree_info -> bool) -> task -> task_claim_next_action
+(** Scheduler-facing claim action.  Recoverable readiness is explicit action
+    data, so callers can continue claiming while routing the follow-up
+    workspace recovery deterministically. *)
+
+val task_claim_next_action_is_claimable :
+  ?worktree_exists:(worktree_info -> bool) -> task -> bool
+
 type message =
   { seq : int
   ; from_agent : string [@key "from"]

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -1166,7 +1166,7 @@ let () =
          future regression that re-introduces a way to flip
          AwaitingVerification back into the pool fails compilation
          (witness exhaustive over [task_status]) or the assertion. *)
-      Alcotest.test_case "Todo is the only claim pool candidate" `Quick (fun () ->
+      Alcotest.test_case "claim pool respects status and typed policy" `Quick (fun () ->
         let module S = Coord_task_schedule in
         let dummy_task ts : Masc_domain.task =
           { id = "t-1"; title = "x"; description = ""; goal_id = None;
@@ -1181,6 +1181,12 @@ let () =
         in
         Alcotest.(check bool) "Todo -> claim pool" true
           (S.task_is_claim_pool_candidate (dummy_task Masc_domain.Todo));
+        Alcotest.(check bool) "Todo blocked by typed policy -> NOT claim pool" false
+          (S.task_is_claim_pool_candidate
+             { (dummy_task Masc_domain.Todo) with
+               reclaim_policy = Some Masc_domain.Block_reclaim
+             ; do_not_reclaim_reason = Some "operator hard stop"
+             });
         Alcotest.(check bool) "Claimed -> NOT claim pool" false
           (S.task_is_claim_pool_candidate
              (dummy_task (Masc_domain.Claimed { assignee = "a"; claimed_at = "t" })));

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -1499,6 +1499,71 @@ let test_task_claim_decision_policy_block_wins_over_readiness () =
   | Masc_domain.Claim_unavailable (Masc_domain.Claim_block_not_todo _) ->
     fail "todo task should not be classified as not-todo"
 
+let test_task_claim_next_action_routes_workspace_resolution () =
+  let worktree : Masc_domain.worktree_info =
+    {
+      branch = "fix/missing-worktree";
+      path = ".worktrees/missing-worktree";
+      git_root = "/repo";
+      repo_name = "repo";
+    }
+  in
+  let t : Masc_domain.task = {
+    id = "task-008";
+    title = "Recover workspace";
+    description = "";
+    task_status = Masc_domain.Todo;
+    goal_id = None;
+    priority = 1;
+    files = [];
+    created_at = "2024-01-15T12:00:00Z";
+    worktree = Some worktree;
+    created_by = None;
+    stage = None;
+    contract = None;
+    handoff_context = None;
+    cycle_count = 0;
+    reclaim_policy = None;
+    do_not_reclaim_reason = Some "worktree path not found";
+  } in
+  match Masc_domain.task_claim_next_action ~worktree_exists:(fun _ -> false) t with
+  | Masc_domain.Claim_with_workspace_resolution observed ->
+    check string "workspace path" worktree.path observed.path;
+    check bool "claimable" true
+      (Masc_domain.task_claim_next_action_is_claimable
+         ~worktree_exists:(fun _ -> false)
+         t)
+  | Masc_domain.Claim_now -> fail "missing workspace should route recovery action"
+  | Masc_domain.Skip_claim _ -> fail "workspace recovery action must remain claimable"
+
+let test_task_claim_next_action_policy_block_is_skip () =
+  let t : Masc_domain.task = {
+    id = "task-009";
+    title = "Operator stop";
+    description = "";
+    task_status = Masc_domain.Todo;
+    goal_id = None;
+    priority = 1;
+    files = [];
+    created_at = "2024-01-15T12:00:00Z";
+    worktree = None;
+    created_by = None;
+    stage = None;
+    contract = None;
+    handoff_context = None;
+    cycle_count = 0;
+    reclaim_policy = Some Masc_domain.Block_reclaim;
+    do_not_reclaim_reason = Some "operator hard stop";
+  } in
+  match Masc_domain.task_claim_next_action t with
+  | Masc_domain.Skip_claim (Masc_domain.Claim_block_reclaim_policy reason) ->
+    check string "reason" "operator hard stop" reason;
+    check bool "claimable" false (Masc_domain.task_claim_next_action_is_claimable t)
+  | Masc_domain.Claim_now | Masc_domain.Claim_with_workspace_resolution _ ->
+    fail "typed policy block must skip claim"
+  | Masc_domain.Skip_claim (Masc_domain.Claim_block_not_todo _) ->
+    fail "todo task should not be classified as not-todo"
+
 (* ============================================================
    a2a_task_to/of_yojson Tests
    ============================================================ *)
@@ -1906,6 +1971,10 @@ let () =
         test_task_claim_decision_keeps_missing_workspace_claimable;
       test_case "claim decision policy block wins over readiness" `Quick
         test_task_claim_decision_policy_block_wins_over_readiness;
+      test_case "claim next action routes workspace resolution" `Quick
+        test_task_claim_next_action_routes_workspace_resolution;
+      test_case "claim next action policy block is skip" `Quick
+        test_task_claim_next_action_policy_block_is_skip;
     ];
     "a2a_task_yojson", [
       test_case "to_yojson" `Quick test_a2a_task_to_yojson;


### PR DESCRIPTION
## Summary
- add scheduler-facing task_claim_next_action with Claim_now, Claim_with_workspace_resolution, and Skip_claim
- route claim_next candidate/block accounting through typed recovery actions with real worktree existence checks
- emit recoverable workspace-resolution telemetry without turning missing worktrees into hard claim blocks
- add regressions for workspace-resolution action, policy skip, and claim-pool policy exclusion

## Verification
- ocamlformat --check lib/types/types_core.ml lib/types/types_core.mli lib/coord/coord_task_schedule.ml test/test_types_coverage.ml test/test_types.ml
- git diff --check origin/main...HEAD
- rg guard for claim recovery action and absence of legacy free-text hard-gate helpers

## Local Dune
- Blocked locally by existing bare Dune processes outside scripts/dune-local.sh; wrapper refused to start another build.