### PR TITLE
fix(keeper): tolerate bare degraded retry cascade receipts

### DIFF
--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -8,6 +8,41 @@
 open Keeper_types
 open Keeper_agent_result
 
+let degraded_retry_cascade_of_wire ?(log_invalid = true) ~keeper_name raw =
+  let trimmed = String.trim raw in
+  if String.equal trimmed "" then None
+  else
+    let normalized_declared =
+      try Keeper_cascade_profile.normalize_declared_name trimmed with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | _ -> trimmed
+    in
+    let candidates =
+      [ trimmed
+      ; normalized_declared
+      ; "tier." ^ trimmed
+      ; "tier-group." ^ trimmed
+      ; "route." ^ trimmed
+      ]
+    in
+    let rec first_valid = function
+      | [] -> None
+      | candidate :: rest ->
+        (match Cascade_name.of_string candidate with
+         | Ok cascade -> Some cascade
+         | Error _ -> first_valid rest)
+    in
+    match first_valid candidates with
+    | Some _ as parsed -> parsed
+    | None ->
+      if log_invalid then
+        Log.Keeper.warn
+          "keeper:%s execution_receipt degraded_retry_cascade %S is not a \
+           qualified or re-qualifiable cascade name; dropping receipt field"
+          keeper_name
+          raw;
+      None
+
 let finalize
     ~config
     ~meta
@@ -178,7 +213,8 @@ let finalize
          | None -> false)
     ; degraded_retry_applied
     ; degraded_retry_cascade =
-        Option.map Cascade_name.of_string_exn degraded_retry_cascade
+        Option.bind degraded_retry_cascade
+          (degraded_retry_cascade_of_wire ~keeper_name:meta.name)
     ; fallback_reason
     ; cascade_rotation_attempts
     ; stop_reason = !receipt_stop_reason_ref

--- a/test/test_keeper_unified_turn_pipeline_records.ml
+++ b/test/test_keeper_unified_turn_pipeline_records.ml
@@ -6,6 +6,7 @@ module UT = Masc_mcp.Keeper_unified_turn
 module Rotation_attempt = Masc_mcp.Keeper_unified_turn_rotation_attempt
 module Receipt = Masc_mcp.Keeper_execution_receipt
 module EC = Masc_mcp.Keeper_error_classify
+module Run_receipt = Masc_mcp.Keeper_agent_run_receipt
 
 let test_turn_plan_phase_gate_records_typed_contract () =
   let open Yojson.Safe.Util in
@@ -184,7 +185,7 @@ let test_provider_attempt_records_manifest_decision_contract () =
 
 let test_rotation_attempt_builder_records_retry_decision () =
   let retry : EC.degraded_retry =
-    { next_cascade = "tool_required_fallback"
+    { next_cascade = "tier.tool_required_fallback"
     ; fallback_reason = EC.Required_tool_contract_violation
     }
   in
@@ -195,7 +196,7 @@ let test_rotation_attempt_builder_records_retry_decision () =
       ~slot_release_at_phase:Receipt.Retry_scheduled
       ~productive_phase_elapsed_ms:1234
       ~retry_phase_elapsed_ms:56
-      ~from_cascade:(Cascade_name.of_string_exn "default")
+      ~from_cascade:(Cascade_name.of_string_exn "tier.default")
       ~retry
       ~outcome:Receipt.Rotation_retry_scheduled
       err
@@ -203,12 +204,12 @@ let test_rotation_attempt_builder_records_retry_decision () =
   check
     string
     "from cascade"
-    "default"
+    "tier.default"
     (Cascade_name.to_string attempt.from_cascade);
   check
     string
     "to cascade"
-    "tool_required_fallback"
+    "tier.tool_required_fallback"
     (Cascade_name.to_string attempt.to_cascade);
   check
     string
@@ -244,6 +245,18 @@ let test_rotation_attempt_builder_records_retry_decision () =
   check string "recorded at" "2026-05-20T00:00:00Z" attempt.recorded_at
 ;;
 
+let test_receipt_degraded_retry_cascade_requalifies_bare_name () =
+  match
+    Run_receipt.degraded_retry_cascade_of_wire
+      ~log_invalid:false
+      ~keeper_name:"receipt-test"
+      "local_llama"
+  with
+  | None -> fail "expected bare degraded retry cascade to be re-qualified"
+  | Some cascade ->
+    check string "bare name re-qualified" "tier.local_llama" (Cascade_name.to_string cascade)
+;;
+
 let () =
   run
     "keeper_unified_turn_pipeline_records"
@@ -260,6 +273,10 @@ let () =
             "rotation attempt builder records degraded retry decision"
             `Quick
             test_rotation_attempt_builder_records_retry_decision
+        ; test_case
+            "execution receipt re-qualifies bare degraded retry cascade"
+            `Quick
+            test_receipt_degraded_retry_cascade_requalifies_bare_name
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Avoid `Cascade_name.of_string_exn` in execution receipt degraded retry cascade parsing.
- Re-qualify bare retry targets like `local_llama` to canonical cascade names before receipt serialization.
- Update the rotation/receipt pipeline test fixture to use canonical cascade names and cover bare retry receipt input.

## Verification
- `ocamlformat --check lib/keeper/keeper_agent_run_receipt.ml test/test_keeper_unified_turn_pipeline_records.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_agent_run_receipt.ml`
- `ocamlc -stop-after parsing test/test_keeper_unified_turn_pipeline_records.ml`
- `git diff --check`
- Blocked: `scripts/dune-local.sh build test/test_keeper_unified_turn_pipeline_records.exe` refused because machine-wide bare Dune processes are active.
