### PR TITLE
docs(audit): mark mcp join-state purge merged

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 11:31:42 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 11:42:16 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -193,9 +193,9 @@
           </tr>
           <tr>
             <td>MCP join-state identity alias bridge</td>
-            <td><span class="status now">draft PR #18544</span></td>
+            <td><span class="status done">merged #18544</span></td>
             <td>Remove the secondary <code>Keeper_identity.normalize_all_names</code> lookup from <code>resolve_join_state</code>. Join-required tools now check only the caller's raw <code>agent_name</code> instead of recovering rotated keeper aliases through canonical keeper names.</td>
-            <td>The alias-recovery test is flipped to prove the canonical form is not retried. Local OCaml format/parse, diff, grep, unknown-permissive-default lint, comment-terminator lint, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune is blocked by external bare <code>dune build --root .</code> / <code>dune exec</code> processes.</td>
+            <td>The alias-recovery test is flipped to prove the canonical form is not retried. Local OCaml format/parse, diff, grep, keeper tool-boundary matrix, structure, stringly-boundary, OAS-boundary, unknown-permissive-default lint, comment-terminator lint, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune is blocked by external bare <code>dune build --root .</code> / <code>dune exec</code> processes.</td>
           </tr>
           <tr>
             <td>Room-state <code>active_agents</code> object recovery</td>

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -162,6 +162,7 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_shell_ops.ml` - shell-surface
 - `lib/keeper/keeper_shell_ops.mli` - shell-surface
 - `lib/keeper/keeper_shell_ops_setup.ml` - shell-surface
+- `lib/keeper/keeper_shell_ops_setup.mli` - shell-surface
 - `lib/keeper/keeper_shell_path.ml` - shell-surface
 - `lib/keeper/keeper_shell_path.mli` - shell-surface
 - `lib/keeper/keeper_shell_read_ops.ml` - shell-surface
@@ -179,8 +180,9 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_bash_input.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_bash_input.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_boundary.ml` - tool-surface-policy
-- `lib/keeper/keeper_tool_capability_axis.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_boundary.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_capability_axis.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_capability_axis.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_deterministic_error.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_deterministic_error.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_disclosure_completion_contract.ml` - tool-surface-policy


### PR DESCRIPTION
Summary
- update the legacy purge ledger row for MCP join-state identity alias bridge to merged #18544
- add missing keeper tool-boundary matrix entries for keeper_shell_ops_setup.mli and keeper_tool_capability_axis.mli so the structure job's boundary matrix remains current

Verification
- git diff --check
- scripts/audit-keeper-tool-boundary-matrix.sh
- scripts/ocaml-structure-ratchet.sh
- scripts/stringly-boundary-ratchet.sh
- scripts/oas-boundary-ratchet.sh