### PR TITLE
docs(keeper): cover split mli boundary paths

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -162,6 +162,7 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_shell_ops.ml` - shell-surface
 - `lib/keeper/keeper_shell_ops.mli` - shell-surface
 - `lib/keeper/keeper_shell_ops_setup.ml` - shell-surface
+- `lib/keeper/keeper_shell_ops_setup.mli` - shell-surface
 - `lib/keeper/keeper_shell_path.ml` - shell-surface
 - `lib/keeper/keeper_shell_path.mli` - shell-surface
 - `lib/keeper/keeper_shell_read_ops.ml` - shell-surface
@@ -180,6 +181,7 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_bash_input.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_boundary.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_capability_axis.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_capability_axis.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_boundary.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_deterministic_error.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_deterministic_error.mli` - tool-surface-policy


### PR DESCRIPTION
## Summary

- Add the split `keeper_shell_ops_setup.mli` and `keeper_tool_capability_axis.mli` paths to the keeper tool boundary matrix.

## Product impact

- Keeps the keeper tool boundary matrix aligned with current split module surfaces.
- Repairs the post-merge Meta Guards failure where the matrix audit reported missing `.mli` source paths after PR #18529 merged.

## Evidence

- `scripts/audit-keeper-tool-boundary-matrix.sh`
- `bash scripts/check-doc-truth.sh`
- `bash scripts/sync-oas-pin-docs.sh --check`
- `git diff --check`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/4
provenance: direct
stages:
  - scripts/audit-keeper-tool-boundary-matrix.sh
  - bash scripts/check-doc-truth.sh
  - bash scripts/sync-oas-pin-docs.sh --check
  - git diff --check
```

- Local failure reproduced at merge commit `6c214fbce90686fe28c650a6a064dbb16230b0cb`:
  - missing `lib/keeper/keeper_shell_ops_setup.mli`
  - missing `lib/keeper/keeper_tool_capability_axis.mli`
- Current branch adds exactly those two matrix entries.

## GOAL LOOP ACT checklist

- [x] Observe — `main` CI run `26428535413` failed in Meta Guards.
- [x] Orient — failure is the keeper tool boundary matrix audit, not doc truth or pin sync.
- [x] Decide — docs-only matrix update is the smallest scope.
- [x] Act — added the two existing split `.mli` paths to the matrix.
- [x] Verify — local matrix audit, doc truth, pin-doc check, and diff check pass.
- [x] Loop — no follow-up known.

## Review evidence

- Change is docs-only and limited to `docs/design/keeper-tool-boundary-matrix.md`.
- The matrix audit now reports all scoped keeper files covered.

## Linked issue

- Relates #18529

## Variant addition checklist

- [ ] **OCaml** — N/A, docs-only matrix entry update.
- [ ] **TypeScript** — N/A.
- [ ] **TLA+ spec** — N/A.
- [ ] **Event / JSON schema** — N/A.
- [ ] **`make check-variants` passes** — N/A, no variant/schema change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/keeper-tool-boundary-matrix-mli-20260526` → `main` · 1 commit(s) · synced 2026-05-26T02:44:15Z

| sha | subject | date |
|---|---|---|
| `5d5199829` | docs(keeper): cover split mli boundary paths | 2026-05-26 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->