### PR TITLE
refactor(replay): drop provider alias canonicalization

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 11:42:16 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 11:56:24 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -196,6 +196,12 @@
             <td><span class="status done">merged #18544</span></td>
             <td>Remove the secondary <code>Keeper_identity.normalize_all_names</code> lookup from <code>resolve_join_state</code>. Join-required tools now check only the caller's raw <code>agent_name</code> instead of recovering rotated keeper aliases through canonical keeper names.</td>
             <td>The alias-recovery test is flipped to prove the canonical form is not retried. Local OCaml format/parse, diff, grep, keeper tool-boundary matrix, structure, stringly-boundary, OAS-boundary, unknown-permissive-default lint, comment-terminator lint, ignore, godfile, code-smell, and determinism ratchets pass; focused Dune is blocked by external bare <code>dune build --root .</code> / <code>dune exec</code> processes.</td>
+          </tr>
+          <tr>
+            <td>Tool-call replay snapshot provider aliases</td>
+            <td><span class="status now">draft PR #18554</span></td>
+            <td>Remove the replay harness dependency on <code>Agent_sdk.Provider_runtime_binding</code> for provider canonicalization. Snapshot provider names must now be present, but the harness no longer resolves legacy provider aliases before validating the OpenAI chat-completions envelope.</td>
+            <td>The stale unsupported-provider preservation test is replaced with empty-provider rejection coverage. Backstop grep is clean for the removed alias names and the replay-harness runtime-binding lookup. Local OCaml format/parse, diff, and static ratchets pass; the focused replay test is blocked by the machine-wide bare-Dune guard.</td>
           </tr>
           <tr>
             <td>Room-state <code>active_agents</code> object recovery</td>

--- a/lib/tool_call_replay_harness.ml
+++ b/lib/tool_call_replay_harness.ml
@@ -38,8 +38,6 @@ let errorf fmt =
 type response_format =
   | Openai_chat_completions
 
-module Runtime_binding = Agent_sdk.Provider_runtime_binding
-
 let assoc label = function
   | `Assoc fields -> Ok fields
   | _ -> errorf "%s: expected object" label
@@ -119,18 +117,6 @@ let load_snapshots_from_jsonl path =
       parse 0 [] rows
 
 let response_format_of_provider provider =
-  let canonical =
-    match Runtime_binding.find provider with
-    | Some binding -> binding.Runtime_binding.id
-    | None -> String.lowercase_ascii (String.trim provider)
-  in
-  (* RFC-0166: previously enumerated specific provider canonical
-     names. The server holds no closed roster — replay harness
-     accepts any non-empty canonical and treats it as
-     OpenAI-compatible chat-completions (the only envelope the seed
-     harness implements). Add an explicit envelope variant if a
-     future fixture deviates from that shape. *)
-  let _ = canonical in
   if String.trim provider = ""
   then errorf "snapshot provider must be non-empty"
   else Ok Openai_chat_completions

--- a/lib/tool_call_replay_harness.mli
+++ b/lib/tool_call_replay_harness.mli
@@ -14,10 +14,11 @@
        declared expectations and returns a list of human-readable
        error messages.
 
-    Provider gate: only providers whose canonical name matches the
-    OpenAI-compatible chat-completions envelope are supported
-    today.  Unsupported providers must add an explicit extractor
-    rather than silently reusing the OpenAI parser. *)
+    Provider gate: provider names must be present, but are not
+    canonicalized through runtime aliases. The seed harness validates
+    only the OpenAI-compatible chat-completions envelope; add an
+    explicit envelope variant if a future fixture deviates from that
+    shape. *)
 
 (** {1 Typed records} *)
 
@@ -78,12 +79,9 @@ val validate_snapshot : snapshot -> (unit, string list) Result.t
     1. Every [expected_tool_calls\[i\].name] must appear in
        [snapshot.tools] (otherwise:
        ["expected tool '<name>' is not declared in snapshot.tools"]).
-    2. Provider must be supported by
-       {!response_format_of_provider} (OAS canonical names:
-       [provider_d] / [provider_k] / [provider_k-coding] / [provider_c] / [openrouter] /
-       [ollama] / [llama], plus legacy snapshot aliases
-       [agent_code-api] / [provider_k-api] / [provider_c-api]; unsupported:
-       ["snapshot provider '<p>' (canonical '<c>') is not supported by replay harness yet"]).
+    2. [snapshot.provider] must be non-empty (otherwise:
+       ["snapshot provider must be non-empty"]). The harness no longer
+       calls the runtime binding registry while loading replay rows.
     3. Response must be the OpenAI Chat Completions shape with at
        least one [choices\[\]] entry containing
        [message.tool_calls\[\]] (errors trace the path:

--- a/test/test_tool_call_replay_harness.ml
+++ b/test/test_tool_call_replay_harness.ml
@@ -86,16 +86,15 @@ let test_validate_rejects_argument_mismatch () =
       check bool "argument mismatch surfaced" true
         (contains_substring joined "arguments mismatch for tool 'masc_add_task'")
 
-let test_validate_rejects_unsupported_provider () =
+let test_validate_rejects_empty_provider () =
   let snapshot = load_fixture () in
-  let bad_snapshot = { snapshot with provider = "provider_a" } in
+  let bad_snapshot = { snapshot with provider = "  " } in
   match Tool_call_replay_harness.validate_snapshot bad_snapshot with
-  | Ok () -> Alcotest.fail "expected unsupported provider validation to fail"
+  | Ok () -> Alcotest.fail "expected empty provider validation to fail"
   | Error errors ->
       let joined = String.concat " | " errors in
-      check bool "unsupported provider surfaced" true
-        (contains_substring joined
-           "snapshot provider 'provider_a' (canonical 'provider_a') is not supported")
+      check bool "empty provider surfaced" true
+        (contains_substring joined "snapshot provider must be non-empty")
 
 let test_load_rejects_malformed_jsonl () =
   let dir = Filename.temp_file "tool-call-replay" ".dir" in
@@ -130,8 +129,8 @@ let () =
             test_validate_rejects_undeclared_tool;
           Alcotest.test_case "reject argument mismatch" `Quick
             test_validate_rejects_argument_mismatch;
-          Alcotest.test_case "reject unsupported provider" `Quick
-            test_validate_rejects_unsupported_provider;
+          Alcotest.test_case "reject empty provider" `Quick
+            test_validate_rejects_empty_provider;
           Alcotest.test_case "reject malformed jsonl" `Quick
             test_load_rejects_malformed_jsonl;
         ] );


### PR DESCRIPTION
Summary
- remove replay-harness provider canonicalization through Agent_sdk.Provider_runtime_binding
- replace stale unsupported-provider preservation coverage with empty-provider rejection
- add the slice to the legacy purge HTML ledger after #18549 merged the join-state ledger update

Verification
- ocamlformat --check lib/tool_call_replay_harness.ml lib/tool_call_replay_harness.mli test/test_tool_call_replay_harness.ml
- rg -n "legacy snapshot aliases|agent_code-api|provider_k-api|provider_c-api|unsupported provider|canonical '<c>'|is not supported by replay harness" lib/tool_call_replay_harness.ml lib/tool_call_replay_harness.mli test/test_tool_call_replay_harness.ml (no matches)
- rg -n "Provider_runtime_binding" lib/tool_call_replay_harness.ml lib/tool_call_replay_harness.mli test/test_tool_call_replay_harness.ml (no matches)
- git diff --check origin/main..HEAD
- scripts/audit-keeper-tool-boundary-matrix.sh
- scripts/ocaml-structure-ratchet.sh
- scripts/stringly-boundary-ratchet.sh
- scripts/oas-boundary-ratchet.sh
- scripts/lint/no-unknown-permissive-default.sh
- scripts/lint/no-ocaml-comment-terminator-trap.sh
- scripts/lint-ignore-without-comment.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

Local Dune gap
- scripts/dune-local.sh exec ./test/test_tool_call_replay_harness.exe is blocked by the machine-wide bare-Dune guard. Current blockers include bare dune build / dune exec processes; I did not bypass the guard.