### PR TITLE
refactor(keeper): move agent-name helpers to identity owner

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -354,6 +354,12 @@
             <td>Backstop greps are clean for <code>Keeper_types.canonical_keeper_name*</code> / <code>Keeper_types.keeper_name_from_agent_name</code> and for <code>Keeper_meta_store</code> identity re-export declarations. Local OCaml format/parse and diff checks pass; focused Dune is blocked by external bare <code>dune build</code> / <code>dune exec</code> processes per the verification contract.</td>
           </tr>
           <tr>
+            <td><code>Keeper_types</code> agent-name facade leaves</td>
+            <td><span class="status now">draft PR #18555</span></td>
+            <td>Move <code>keeper_agent_name</code> to <code>Keeper_identity</code>, remove <code>strip_keeper_prefix</code> / <code>keeper_agent_name</code> from <code>Keeper_types_profile</code>, and route remaining production/test callers to the identity owner.</td>
+            <td>Backstop grep is clean for <code>Keeper_types.keeper_agent_name</code>, <code>Keeper_types.strip_keeper_prefix</code>, and <code>Keeper_types_profile</code> agent-name/prefix helper usage. Local OCaml format/parse and diff checks pass; focused Dune is blocked by external bare <code>dune build</code> / <code>dune exec</code> processes per the verification contract.</td>
+          </tr>
+          <tr>
             <td><code>Keeper_types.write_meta_with_retry</code> wrapper</td>
             <td><span class="status done">draft PR #18422</span></td>
             <td>Delete the payload-wins CAS retry wrapper from <code>Keeper_meta_store</code> and the public <code>Keeper_types</code> facade. Callers now use <code>write_meta_with_merge</code> with an explicit <code>Keeper_meta_merge.caller_wins</code> strategy.</td>

--- a/lib/cascade/cascade_oas_runner.ml
+++ b/lib/cascade/cascade_oas_runner.ml
@@ -60,7 +60,7 @@ let resolve_cascade_providers
 
 let keeper_agent_name_opt (keeper_name : string) =
   let keeper_name = String.trim keeper_name in
-  if keeper_name = "" then None else Some (Keeper_types.keeper_agent_name keeper_name)
+  if keeper_name = "" then None else Some (Keeper_identity.keeper_agent_name keeper_name)
 
 let runtime_mcp_policy_for_tools ~(keeper_name : string) (tools : Agent_sdk.Tool.t list) =
   let agent_name = keeper_agent_name_opt keeper_name in

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -554,7 +554,7 @@ let provider_forced_tool_rejection_label provider_cfg =
   | Some reason -> Provider_tool_support.rejection_reason_label reason
   | None -> "passes"
 
-let doctor_keeper_agent_name = Keeper_types.keeper_agent_name "config-doctor"
+let doctor_keeper_agent_name = Keeper_identity.keeper_agent_name "config-doctor"
 let required_keeper_internal_tool_name = "tool_execute"
 
 let required_keeper_internal_tool : Agent_sdk.Tool.t =

--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -129,6 +129,14 @@ let strip_keeper_prefix (s : string) : string option =
     Some (String.sub s plen (slen - plen))
   else None
 
+let keeper_agent_name name =
+  let stable =
+    match strip_keeper_prefix name with
+    | Some stripped -> stripped
+    | None -> name
+  in
+  Printf.sprintf "keeper-%s-agent" stable
+
 let canonical_keeper_name raw_name =
   let trimmed = String.trim raw_name in
   if trimmed = "" then None

--- a/lib/keeper/keeper_identity.mli
+++ b/lib/keeper/keeper_identity.mli
@@ -22,6 +22,11 @@ val strip_keeper_prefix : string -> string option
     "keeper-"] check so callers no longer embed the literal — Phase A F5
     of the bloodflow restoration plan. *)
 
+val keeper_agent_name : string -> string
+(** [keeper_agent_name name] returns the canonical runtime agent name
+    ["keeper-<name>-agent"], stripping one existing ["keeper-"] prefix first so
+    callers do not double-prefix keeper names. *)
+
 type parsed_identity = {
   keeper_name : string;
   agent_name : string;

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -112,9 +112,9 @@ let auto_recoverable_paused_keeper_names ?now config =
    scaffolded dual-identity is starved by callers always asking for
    the canonical form). *)
 let canonicalize_if_keeper config name =
-  let stable = Keeper_types_profile.strip_keeper_prefix name in
+  let stable = Option.value (Keeper_identity.strip_keeper_prefix name) ~default:name in
   if List.mem stable (configured_keeper_names config) then
-    Keeper_types_profile.keeper_agent_name stable
+    Keeper_identity.keeper_agent_name stable
   else
     name
 

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -500,7 +500,7 @@ let recommendation (meta : keeper_meta) ~preflight containers =
              meta.name)
 
 let identity_json (meta : keeper_meta) =
-  let expected_agent_name = Keeper_types.keeper_agent_name meta.name in
+  let expected_agent_name = Keeper_identity.keeper_agent_name meta.name in
   let agent_name_matches = String.equal expected_agent_name meta.agent_name in
   `Assoc
     [

--- a/lib/keeper/keeper_supervisor_liveness_recovery.ml
+++ b/lib/keeper/keeper_supervisor_liveness_recovery.ml
@@ -41,7 +41,7 @@ let has_suffix s suffix =
 let canonical_keeper_agent_name name =
   if has_prefix name "keeper-" && has_suffix name "-agent"
   then name
-  else Keeper_types_profile.keeper_agent_name name
+  else Keeper_identity.keeper_agent_name name
 ;;
 
 let credential_recovery_before_restart ~base_path

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -215,7 +215,7 @@ let run_named
                match runtime_mcp_policy, String.trim keeper_name with
                | Some policy, keeper_name when keeper_name <> "" ->
                  Cascade_runtime_candidate.runtime_mcp_policy_for_agent
-                   ~agent_name:(Keeper_types.keeper_agent_name keeper_name)
+                   ~agent_name:(Keeper_identity.keeper_agent_name keeper_name)
                    candidate
                    (Some policy)
                | _ -> runtime_mcp_policy

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -214,7 +214,7 @@ let run_try_provider
         match runtime_mcp_policy, String.trim ctx.keeper_name with
         | Some policy, keeper_name when keeper_name <> "" ->
           Cascade_runtime_candidate.runtime_mcp_policy_for_agent
-            ~agent_name:(Keeper_types.keeper_agent_name ctx.keeper_name)
+            ~agent_name:(Keeper_identity.keeper_agent_name ctx.keeper_name)
             candidate
             (Some policy)
         | _ -> runtime_mcp_policy

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -516,15 +516,3 @@ let keeper_meta_path config name =
 let session_base_dir (config : Coord.config) =
   let d = Filename.concat (Coord.masc_root_dir config) "traces" in
   ensure_dir d
-
-(** Strip "keeper-" prefix if already present to prevent double-prefixing.
-    E.g. "keeper-admin" -> "admin", "sangsu" -> "sangsu". *)
-let strip_keeper_prefix name =
-  let prefix = "keeper-" in
-  let plen = String.length prefix in
-  if String.length name > plen && String.sub name 0 plen = prefix
-  then String.sub name plen (String.length name - plen)
-  else name
-
-let keeper_agent_name name =
-  Printf.sprintf "keeper-%s-agent" (strip_keeper_prefix name)

--- a/lib/keeper/keeper_types_profile.mli
+++ b/lib/keeper/keeper_types_profile.mli
@@ -157,5 +157,3 @@ val list_persona_summaries : unit -> persona_summary list
 val keeper_dir : Coord.config -> string
 val keeper_meta_path : Coord.config -> string -> string
 val session_base_dir : Coord.config -> string
-val strip_keeper_prefix : string -> string
-val keeper_agent_name : string -> string

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -64,7 +64,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     ~base_path:state.room_config.base_path
     ~canonical_names_fn:(fun () ->
       Keeper_runtime.bootable_keeper_names state.room_config
-      |> List.map Keeper_types_profile.keeper_agent_name);
+      |> List.map Keeper_identity.keeper_agent_name);
   (* #9876: Hebbian consolidation fiber. Prior to this, the graph was
      write-only — strengthen/weaken populated synapses but decay +
      pruning never ran (zero production callers of [consolidate]).

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -111,7 +111,7 @@ let resolve_keeper_purge_target config requested_name =
           Some
             {
               keeper_name = candidate;
-              agent_name = Keeper_types.keeper_agent_name candidate;
+              agent_name = Keeper_identity.keeper_agent_name candidate;
               trace_id = None;
               toml_path = candidate_toml_path;
             }
@@ -126,7 +126,7 @@ let resolve_keeper_purge_target config requested_name =
           Some
             {
               keeper_name = candidate;
-              agent_name = Keeper_types.keeper_agent_name candidate;
+              agent_name = Keeper_identity.keeper_agent_name candidate;
               trace_id = None;
               toml_path = candidate_toml_path;
             })

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -531,7 +531,7 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
             | None -> (
                 match meta_opt with
                 | Some meta -> meta.agent_name
-                | None -> Keeper_types.keeper_agent_name name)
+                | None -> Keeper_identity.keeper_agent_name name)
           in
           Keeper_keepalive.process_directive
             ~agent_name:resolved_agent_name action_str;

--- a/lib/server/server_runtime_startup_credentials.ml
+++ b/lib/server/server_runtime_startup_credentials.ml
@@ -149,7 +149,7 @@ let sync_bootable_keeper_credentials (state : Mcp_server.server_state) =
     Keeper_runtime.autoboot_excluded_keeper_reasons state.Mcp_server.room_config
   in
   let keeper_agent_names =
-    List.map Keeper_types_profile.keeper_agent_name keeper_names
+    List.map Keeper_identity.keeper_agent_name keeper_names
   in
   let synced_count, failed =
     List.fold_left2

--- a/lib/tool_keeper_ops.ml
+++ b/lib/tool_keeper_ops.ml
@@ -102,7 +102,7 @@ let attach_assoc_field key value = function
   | `Assoc fields -> `Assoc ((key, value) :: fields)
   | other -> other
 let maybe_reseed_keeper_identity ctx (meta : keeper_meta) =
-  let expected_agent_name = Keeper_types.keeper_agent_name meta.name in
+  let expected_agent_name = Keeper_identity.keeper_agent_name meta.name in
   if String.equal expected_agent_name meta.agent_name then
     Ok (meta, None)
   else

--- a/test/test_config_doctor.ml
+++ b/test/test_config_doctor.ml
@@ -334,7 +334,7 @@ target = "tier-group.provider_k-coding-with-spark"
     config_root;
   write_per_keeper_token
     ~base_path
-    ~agent_name:(Keeper_types.keeper_agent_name "config-doctor")
+    ~agent_name:(Keeper_identity.keeper_agent_name "config-doctor")
     ~token:"doctor-test-token";
   with_config_dir config_root @@ fun () ->
   with_env "MASC_BASE_PATH" base_path @@ fun () ->

--- a/test/test_dashboard_safe_autonomy.ml
+++ b/test/test_dashboard_safe_autonomy.ml
@@ -117,7 +117,7 @@ let persist_docker_keeper config ~name =
   let meta =
     {
       (make_meta ~name ~trace_id:("trace-" ^ name) ()) with
-      agent_name = KT.keeper_agent_name name;
+      agent_name = Keeper_identity.keeper_agent_name name;
       sandbox_profile = KT.Docker;
       network_mode = KT.Network_none;
     }

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -245,19 +245,19 @@ let test_heuristic_has_fewer_tools_than_learned () =
    ============================================================ *)
 
 let test_strip_keeper_prefix_no_prefix () =
-  Alcotest.(check string)
-    "plain name unchanged" "sangsu"
-    (Keeper_types.strip_keeper_prefix "sangsu")
+  Alcotest.(check (option string))
+    "plain name has no keeper prefix" None
+    (Keeper_identity.strip_keeper_prefix "sangsu")
 
 let test_strip_keeper_prefix_has_prefix () =
-  Alcotest.(check string)
-    "strips single keeper- prefix" "admin"
-    (Keeper_types.strip_keeper_prefix "keeper-admin")
+  Alcotest.(check (option string))
+    "strips single keeper- prefix" (Some "admin")
+    (Keeper_identity.strip_keeper_prefix "keeper-admin")
 
 let test_strip_keeper_prefix_double () =
-  Alcotest.(check string)
-    "strips outer keeper- leaving keeper-admin" "keeper-admin"
-    (Keeper_types.strip_keeper_prefix "keeper-keeper-admin")
+  Alcotest.(check (option string))
+    "strips outer keeper- leaving keeper-admin" (Some "keeper-admin")
+    (Keeper_identity.strip_keeper_prefix "keeper-keeper-admin")
 
 let test_keeper_agent_sender_plain_name () =
   (* keeper_agent_sender now delegates to meta.agent_name (#5625) *)
@@ -275,12 +275,12 @@ let test_keeper_agent_sender_prefixed_name () =
 let test_keeper_agent_name_plain () =
   Alcotest.(check string)
     "keeper-sangsu-agent" "keeper-sangsu-agent"
-    (Keeper_types.keeper_agent_name "sangsu")
+    (Keeper_identity.keeper_agent_name "sangsu")
 
 let test_keeper_agent_name_prefixed () =
   Alcotest.(check string)
     "no double prefix in agent_name" "keeper-admin-agent"
-    (Keeper_types.keeper_agent_name "keeper-admin")
+    (Keeper_identity.keeper_agent_name "keeper-admin")
 
 let test_keeper_name_from_agent_name_roundtrip () =
   Alcotest.(check (option string))

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -1096,7 +1096,7 @@ let test_room_presence_syncs_capabilities () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let keeper_name = "room-presence-sync-test" in
-  let agent_name = Keeper_types.keeper_agent_name keeper_name in
+  let agent_name = Keeper_identity.keeper_agent_name keeper_name in
   let config = Coord.default_config room_dir in
   let _ = Coord.init config ~agent_name:None in
   let initial_meta =

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -77,7 +77,7 @@ let test_agent_identity ~uuid ~session_key : Masc_mcp.Agent_identity.t =
 let make_keeper_meta ?agent_name ?tool_access name =
   let agent_name =
     Option.value agent_name
-      ~default:(Keeper_types.keeper_agent_name name)
+      ~default:(Keeper_identity.keeper_agent_name name)
   in
   let tool_access_fields =
     match tool_access with
@@ -1812,7 +1812,7 @@ let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
       cleanup_dir base_path)
     (fun () ->
       let keeper_name = "sangsu" in
-      let keeper_agent_name = Keeper_types.keeper_agent_name keeper_name in
+      let keeper_agent_name = Keeper_identity.keeper_agent_name keeper_name in
       ignore
         (Keeper_registry.register ~base_path keeper_name
            (make_keeper_meta ~agent_name:keeper_agent_name keeper_name));
@@ -1938,7 +1938,7 @@ let test_handle_request_tools_call_internal_keeper_runtime_allows_keeper_interna
     (fun () ->
       Keeper_registry.clear ();
       let keeper_name = "sangsu" in
-      let keeper_agent_name = Keeper_types.keeper_agent_name keeper_name in
+      let keeper_agent_name = Keeper_identity.keeper_agent_name keeper_name in
       let tool_access =
         `Assoc
           [

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -37,7 +37,7 @@ let make_keeper_meta ?agent_name ?current_task_id ?(goal_ids = [])
     ?tool_access name =
   let agent_name =
     Option.value agent_name
-      ~default:(Masc_mcp.Keeper_types.keeper_agent_name name)
+      ~default:(Masc_mcp.Keeper_identity.keeper_agent_name name)
   in
   let fields =
     [
@@ -284,7 +284,7 @@ let test_runtime_mcp_keeper_log_context_uses_keeper_trace_and_current_turn () =
         (Some ("trace-test-" ^ keeper_name))
         ctx.trace_id;
       check (option string) "agent_name"
-        (Some (Masc_mcp.Keeper_types.keeper_agent_name keeper_name))
+        (Some (Masc_mcp.Keeper_identity.keeper_agent_name keeper_name))
         ctx.agent_name;
       check (option string) "session_id"
         (Some "session-explicit")
@@ -430,7 +430,7 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
         (row |> U.member "goal_ids" |> U.to_list |> List.length);
       let runtime_contract = row |> U.member "runtime_contract" in
       check string "runtime contract agent"
-        (Masc_mcp.Keeper_types.keeper_agent_name keeper_name)
+        (Masc_mcp.Keeper_identity.keeper_agent_name keeper_name)
         (runtime_contract |> U.member "agent_name" |> U.to_string);
       check bool "runtime contract has generation" true
         (match runtime_contract |> U.member "generation" with
@@ -493,7 +493,7 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
         (trajectory_json |> U.member "runtime_contract" |> U.member "keeper_name"
          |> U.to_string);
       check string "trajectory runtime agent"
-        (Masc_mcp.Keeper_types.keeper_agent_name keeper_name)
+        (Masc_mcp.Keeper_identity.keeper_agent_name keeper_name)
         (trajectory_json |> U.member "runtime_contract" |> U.member "agent_name"
          |> U.to_string);
       check string "trajectory runtime cascade profile"

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -78,7 +78,7 @@ let seed_keeper_meta_exn config keeper_name ~goal =
         (`Assoc
           [
             ("name", `String keeper_name);
-            ("agent_name", `String (Keeper_types.keeper_agent_name keeper_name));
+            ("agent_name", `String (Keeper_identity.keeper_agent_name keeper_name));
             ("trace_id", `String trace_id);
             ("goal", `String goal);
             ("cascade_name", `String (Keeper_config.default_cascade_name ()));
@@ -135,7 +135,7 @@ let check_keeper_identity_repaired config keeper_name previous_trace_id =
   let meta = read_keeper_meta_exn config keeper_name in
   let current_trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   Alcotest.(check string) "agent name restored to canonical"
-    (Keeper_types.keeper_agent_name keeper_name) meta.agent_name;
+    (Keeper_identity.keeper_agent_name keeper_name) meta.agent_name;
   Alcotest.(check bool) "trace id rotated" true
     (not (String.equal current_trace_id previous_trace_id));
   Alcotest.(check bool) "previous trace retained in history" true
@@ -1157,7 +1157,7 @@ let test_keeper_turn_sandbox_factory_reuses_playground_runtime () =
             (`Assoc
               [
                 ("name", `String keeper_name);
-                ("agent_name", `String (Keeper_types.keeper_agent_name keeper_name));
+                ("agent_name", `String (Keeper_identity.keeper_agent_name keeper_name));
                 ("trace_id", `String ("test-trace-" ^ keeper_name));
                 ("goal", `String "exercise turn sandbox runtime cache");
               ])
@@ -1858,7 +1858,7 @@ let test_keeper_up_reseeds_identity_drift () =
       let meta = read_keeper_meta_exn config keeper_name in
       let current_trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
       Alcotest.(check string) "agent name restored to canonical"
-        (Keeper_types.keeper_agent_name keeper_name) meta.agent_name;
+        (Keeper_identity.keeper_agent_name keeper_name) meta.agent_name;
       Alcotest.(check bool) "trace id rotated" true
         (not (String.equal current_trace_id previous_trace_id));
       Alcotest.(check bool) "previous trace retained in history" true
@@ -1975,7 +1975,7 @@ let test_keeper_sandbox_status_reseeds_separator_identity_drift () =
         (sandbox_json |> member "identity" |> member "agent_name_matches"
        |> to_bool);
       Alcotest.(check string) "sandbox expected canonical agent"
-        (Keeper_types.keeper_agent_name keeper_name)
+        (Keeper_identity.keeper_agent_name keeper_name)
         (sandbox_json |> member "identity" |> member "agent_name" |> to_string);
       check_keeper_identity_repaired config keeper_name previous_trace_id)
 
@@ -2042,7 +2042,7 @@ let test_keeper_repair_reseeds_identity_drift () =
       let meta_after = read_keeper_meta_exn config keeper_name in
       let current_trace_id = Keeper_id.Trace_id.to_string meta_after.runtime.trace_id in
       Alcotest.(check string) "repair restores canonical agent name"
-        (Keeper_types.keeper_agent_name keeper_name) meta_after.agent_name;
+        (Keeper_identity.keeper_agent_name keeper_name) meta_after.agent_name;
       Alcotest.(check bool) "repair rotates trace id" true
         (not (String.equal current_trace_id previous_trace_id)))
 

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -363,7 +363,7 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
             (`Assoc
               [
                 ("name", `String keeper_name);
-                ("agent_name", `String (Keeper_types.keeper_agent_name keeper_name));
+                ("agent_name", `String (Keeper_identity.keeper_agent_name keeper_name));
                 ("trace_id", `String "trace-paused-runtime-trust");
                 ("goal", `String "Expose paused keeper failure in summary");
                 ("short_goal", `String "Expose paused keeper failure in summary");

--- a/test/test_tool_control_coverage.ml
+++ b/test/test_tool_control_coverage.ml
@@ -15,7 +15,7 @@ let seed_keeper_meta (ctx : Tool_control.context) name ~paused =
         (`Assoc
           [
             ("name", `String name);
-            ("agent_name", `String (Keeper_types.keeper_agent_name name));
+            ("agent_name", `String (Keeper_identity.keeper_agent_name name));
             ("trace_id", `String ("trace-" ^ name));
             ("goal", `String "pause status fixture");
           ])


### PR DESCRIPTION
## What changed

- Move `keeper_agent_name` to `Keeper_identity`.
- Remove `strip_keeper_prefix` / `keeper_agent_name` from `Keeper_types_profile`, which also stops `Keeper_types` from re-exporting those owner-specific helpers through its broad profile include.
- Update remaining production and test callers to use `Keeper_identity` directly.

## Why

This continues the P1 `Keeper_types` compatibility facade work from `docs/audit/2026-05-25-legacy-purge-plan.html`. Keeper runtime agent-name construction is identity ownership, not profile/defaults ownership and not the broad `Keeper_types` facade.

## Validation

- `rg 'Keeper_types\.keeper_agent_name|Masc_mcp\.Keeper_types\.keeper_agent_name|Lib\.Keeper_types\.keeper_agent_name|Keeper_types_profile\.keeper_agent_name|Keeper_types_profile\.strip_keeper_prefix|Keeper_types\.strip_keeper_prefix|Masc_mcp\.Keeper_types\.strip_keeper_prefix|Lib\.Keeper_types\.strip_keeper_prefix|KT\.keeper_agent_name' lib test docs scripts config` returned no matches.
- `git diff --check`
- `opam exec -- ocamlformat --check ...` for all touched OCaml files.
- `opam exec -- ocamlc -stop-after parsing ...` for all touched OCaml files.

## Local Dune gap

- `scripts/dune-local.sh build test/test_keeper_agent_isolation.exe test/test_mcp_server_eio_call_tool.exe lib/masc_mcp.cmxa` exited 75 because live bare Dune processes were already running outside `scripts/dune-local.sh`. Per the plan verification contract, I did not bypass the guard; PR CI should cover the focused build.
