### PR TITLE
fix(keeper): clarify typed bash rewrite hints

### DIFF
--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -25,7 +25,7 @@ type validation_error =
       name : string;
       mode : allowlist_mode;
     }
-  | Empty_executable
+  | Empty_executable of { argv : string list }
   | Empty_argv of { executable : string }
   | Argv_contains_shell_metachar of {
       executable : string;
@@ -73,7 +73,7 @@ let reject_unknown_fields ~path ~allowed fields =
   let allowed key = List.exists (String.equal key) allowed in
   match List.find_opt (fun (key, _) -> not (allowed key)) fields with
   | None -> Ok ()
-  | Some (key, _) -> result_errorf "%s.%s is not a supported Execute field" path key
+  | Some (key, _) -> result_errorf "%s.%s is not a supported typed Bash field" path key
 ;;
 
 let required_string ~path fields key =
@@ -278,7 +278,7 @@ let check_wrapper_exec_target ~mode ~executable ~argv =
 let check_exec ~mode ~executable ~argv ~cwd ~env =
   let ( let* ) = Result.bind in
   let trimmed = String.trim executable in
-  if String.length trimmed = 0 then Error Empty_executable
+  if String.length trimmed = 0 then Error (Empty_executable { argv })
   else if not (is_allowed ~mode trimmed)
   then Error (Executable_not_allowlisted { name = trimmed; mode })
   else
@@ -311,7 +311,7 @@ let validate ~mode = function
 
 let shell_bin ~mode executable =
   let trimmed = String.trim executable in
-  if String.length trimmed = 0 then Error Empty_executable
+  if String.length trimmed = 0 then Error (Empty_executable { argv = [] })
   else
     match Masc_exec.Exec_program.of_string trimmed with
     | Ok bin -> Ok bin
@@ -371,7 +371,15 @@ let pp_mode ppf = function
 let pp_validation_error ppf = function
   | Executable_not_allowlisted { name; mode } ->
     Format.fprintf ppf "executable %S not in %a allowlist" name pp_mode mode
-  | Empty_executable ->
+  | Empty_executable { argv = first :: rest } ->
+    Format.fprintf
+      ppf
+      "executable is empty; argv[0]=%S looks like the command name. \
+       Rewrite as executable=%S argv=%s. Do not include the executable in argv."
+      first
+      first
+      (Yojson.Safe.to_string (`List (List.map (fun arg -> `String arg) rest)))
+  | Empty_executable { argv = [] } ->
     Format.pp_print_string ppf
       "executable is empty — provide a non-empty allowlisted command name, \
        e.g. executable=\"cat\" argv=[\"file.txt\"]"

--- a/lib/keeper/keeper_tool_bash_input.mli
+++ b/lib/keeper/keeper_tool_bash_input.mli
@@ -57,7 +57,7 @@ type validation_error =
       name : string;
       mode : allowlist_mode;
     }
-  | Empty_executable
+  | Empty_executable of { argv : string list }
   | Empty_argv of { executable : string }
   | Argv_contains_shell_metachar of {
       executable : string;

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -123,6 +123,24 @@ let unsupported_arg_names schema = function
   | _ -> []
 ;;
 
+let schema_has_property schema name = List.mem name (property_names schema)
+
+let typed_shell_unsupported_field_hint schema names =
+  let has_shell_fields =
+    schema_has_property schema "executable" && schema_has_property schema "argv"
+  in
+  let has_legacy_shell_string =
+    List.exists (fun name -> String.equal name "cmd" || String.equal name "command") names
+  in
+  if has_shell_fields && has_legacy_shell_string
+  then
+    Some
+      "typed shell execution has no cmd/command field; use executable/argv, \
+       e.g. executable=\"git\" argv=[\"status\",\"--short\"]. Do not include the \
+       executable again in argv"
+  else None
+;;
+
 type one_of_branch = {
   required : string list;
   consts : (string * Yojson.Safe.t) list;
@@ -218,8 +236,14 @@ let one_of_required_shape_error schema = function
 let schema_shape_error schema args =
   match unsupported_arg_names schema args with
   | name :: names ->
-    let names = String.concat ", " (name :: names) in
-    Some (Printf.sprintf "received unsupported field(s): %s" names)
+    let names = name :: names in
+    let names_text = String.concat ", " names in
+    let hint =
+      match typed_shell_unsupported_field_hint schema names with
+      | None -> ""
+      | Some hint -> "; " ^ hint
+    in
+    Some (Printf.sprintf "received unsupported field(s): %s%s" names_text hint)
   | [] -> one_of_required_shape_error schema args
 ;;
 

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -204,6 +204,31 @@ let test_standalone_env_rejected () =
   | Ok () -> Alcotest.fail "standalone env should not be accepted"
 ;;
 
+let test_empty_executable_with_argv_hints_rewrite () =
+  match Bash_input.validate ~mode:Bash_input.Dev_full (mk_exec "" [ "ls"; "-la" ]) with
+  | Error (Bash_input.Empty_executable { argv }) ->
+    Alcotest.(check (list string)) "argv preserved" [ "ls"; "-la" ] argv;
+    let msg = Format.asprintf "%a" Bash_input.pp_validation_error (Bash_input.Empty_executable { argv }) in
+    Alcotest.(check bool)
+      "error points at argv[0]"
+      true
+      (String_util.contains_substring_ci msg "argv[0]=\"ls\"");
+    Alcotest.(check bool)
+      "error suggests executable rewrite"
+      true
+      (String_util.contains_substring_ci msg "executable=\"ls\"");
+    Alcotest.(check bool)
+      "error removes duplicated executable from argv"
+      true
+      (String_util.contains_substring_ci msg "argv=[\"-la\"]")
+  | Error error ->
+    Alcotest.failf
+      "expected Empty_executable with argv, got %a"
+      Bash_input.pp_validation_error
+      error
+  | Ok () -> Alcotest.fail "empty executable should not be accepted"
+;;
+
 let test_of_json_exec () =
   let input =
     parse_json_exn
@@ -485,6 +510,10 @@ let suite =
           "standalone_env_rejected"
           `Quick
           test_standalone_env_rejected
+      ; Alcotest.test_case
+          "empty_executable_with_argv_hints_rewrite"
+          `Quick
+          test_empty_executable_with_argv_hints_rewrite
       ; Alcotest.test_case "of_json_exec" `Quick test_of_json_exec
       ; Alcotest.test_case "of_json_pipeline" `Quick test_of_json_pipeline
       ; Alcotest.test_case

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -585,10 +585,36 @@ let test_validate_args_tool_execute_rejects_cmd_string () =
   with
   | Ok _ -> Alcotest.fail "expected tool_execute cmd string to be rejected"
   | Error result ->
+    let msg = Yojson.Safe.to_string result.Tool_result.data in
     Alcotest.(check bool)
       "validation error returned"
       true
-      (String.length (Yojson.Safe.to_string result.Tool_result.data) > 0)
+      (String.length msg > 0);
+    Alcotest.(check bool)
+      "validation error points to typed argv"
+      true
+      (string_contains msg "executable=\\\"git\\\" argv=[\\\"status\\\",\\\"--short\\\"]")
+
+let test_validate_args_tool_execute_rejects_command_string () =
+  let args = `Assoc [ "command", `String "pwd" ] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:tool_execute_schema
+      ~name:"tool_execute"
+      ~args
+      ()
+  with
+  | Ok _ -> Alcotest.fail "expected tool_execute command string to be rejected"
+  | Error result ->
+    let msg = Yojson.Safe.to_string result.Tool_result.data in
+    Alcotest.(check bool)
+      "validation error mentions unsupported command field"
+      true
+      (string_contains msg "unsupported field(s): command");
+    Alcotest.(check bool)
+      "validation error says command field is unavailable"
+      true
+      (string_contains msg "no cmd/command field")
 
 let test_validate_args_tool_execute_rejects_background_flag () =
   let args =
@@ -1433,6 +1459,8 @@ let () =
         test_tool_execute_schema_exposes_typed_boundary;
       Alcotest.test_case "tool_execute rejects cmd string" `Quick
         test_validate_args_tool_execute_rejects_cmd_string;
+      Alcotest.test_case "tool_execute rejects command string" `Quick
+        test_validate_args_tool_execute_rejects_command_string;
       Alcotest.test_case "tool_execute rejects background flag" `Quick
         test_validate_args_tool_execute_rejects_background_flag;
       Alcotest.test_case "tool_execute accepts typed exec" `Quick


### PR DESCRIPTION
## Summary

- Preserve typed argv enforcement while making empty `executable` failures actionable when `argv[0]` contains the likely command name.
- Add a typed shell validation hint when callers send retired `cmd` / `command` string fields.
- Align unknown typed Bash field wording with the existing typed Bash parser test expectation.

## Evidence

- 2026-05-25 logs: `tool keeper_bash.*executable is empty` matched 26 entries.
- 2026-05-25 logs: `Tool 'keeper_bash' received unsupported field(s): command` matched 25 entries.
- 2026-05-25 logs include repeated examples like `cmd:"'' git log --oneline -20"` and `cmd:"'' find repos -name cascade.toml -type f"`, where the rejected payload can now tell the model to move `argv[0]` into `executable`.

## Validation

- `ocamlformat --check lib/keeper/keeper_tool_bash_input.ml lib/keeper/keeper_tool_bash_input.mli lib/tool_input_validation.ml test/test_keeper_bash_typed_input.ml test/test_tool_input_validation.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_tool_bash_input.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_tool_bash_input.mli`
- `ocamlc -stop-after parsing lib/tool_input_validation.ml`
- `ocamlc -stop-after parsing test/test_keeper_bash_typed_input.ml`
- `ocamlc -stop-after parsing test/test_tool_input_validation.ml`
- `git diff --check`

Focused Dune build was attempted twice:

- `scripts/dune-local.sh build test/test_keeper_bash_typed_input.exe test/test_tool_input_validation.exe`

It was blocked by machine-wide bare Dune processes outside `scripts/dune-local.sh`, so full type/test validation is left to CI.
