### PR TITLE
refactor(keeper): trim support helpers from types facade

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 11:56:24 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 12:11:40 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -355,15 +355,21 @@
           </tr>
           <tr>
             <td><code>Keeper_types</code> identity helper facade leaves</td>
-            <td><span class="status now">draft PR #18545</span></td>
+            <td><span class="status done">merged #18545</span></td>
             <td>Remove <code>keeper_name_from_agent_name</code>, <code>canonical_keeper_name_from_agent_name</code>, and <code>canonical_keeper_name</code> from the public <code>Keeper_types</code> facade, remove the pass-through aliases from <code>Keeper_meta_store</code>, and route remaining callers to <code>Keeper_identity</code>.</td>
             <td>Backstop greps are clean for <code>Keeper_types.canonical_keeper_name*</code> / <code>Keeper_types.keeper_name_from_agent_name</code> and for <code>Keeper_meta_store</code> identity re-export declarations. Local OCaml format/parse and diff checks pass; focused Dune is blocked by external bare <code>dune build</code> / <code>dune exec</code> processes per the verification contract.</td>
           </tr>
           <tr>
             <td><code>Keeper_types</code> agent-name facade leaves</td>
-            <td><span class="status now">draft PR #18555</span></td>
+            <td><span class="status done">merged #18555</span></td>
             <td>Move <code>keeper_agent_name</code> to <code>Keeper_identity</code>, remove <code>strip_keeper_prefix</code> / <code>keeper_agent_name</code> from <code>Keeper_types_profile</code>, and route remaining production/test callers to the identity owner.</td>
             <td>Backstop grep is clean for <code>Keeper_types.keeper_agent_name</code>, <code>Keeper_types.strip_keeper_prefix</code>, and <code>Keeper_types_profile</code> agent-name/prefix helper usage. Local OCaml format/parse and diff checks pass; focused Dune is blocked by external bare <code>dune build</code> / <code>dune exec</code> processes per the verification contract.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_types</code> support helper facade leaves</td>
+            <td><span class="status now">draft PR #18560</span></td>
+            <td>Stop exposing support-only JSONL append and history-source classification helpers through the broad <code>Keeper_types</code> facade. Callers now use <code>Keeper_types_support.append_jsonl_line</code> and <code>Keeper_types_support.is_internal_history_source</code> directly.</td>
+            <td>Backstop grep is clean for <code>Keeper_types.append_jsonl_line</code> and <code>Keeper_types.is_internal_history_source</code>. <code>Keeper_types.mli</code> now lists selected support re-exports instead of including the entire <code>Keeper_types_support</code> signature.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.write_meta_with_retry</code> wrapper</td>

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -559,7 +559,7 @@ Keeper turn에서 어떤 "skill" 경로를 사용할지 결정:
 
 ### 15.2 keeper_types.ml include chain
 
-`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 순환 의존 회피를 위한 구조이지만 가독성이 낮다.
+`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 support helper를 선별 re-export하지만 구현 include chain 자체는 남아 있어 가독성이 낮다.
 
 ### 15.3 keeper_memory 계층의 include chain
 

--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -363,7 +363,7 @@ let keeper_history_summary_json
           if ts0 > 0.0 then ts0 else Safe_ops.json_float ~default:0.0 "timestamp" j
         in
         if role = "" || content = ""
-           || Keeper_types.is_internal_history_source source
+           || Keeper_types_support.is_internal_history_source source
            || Keeper_context_core.has_world_state_signature content
         then
           (conv_acc, k2k_acc, raw_count, fragment_count, filtered_count)

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -548,9 +548,18 @@ let maybe_emit_interesting_alert
           ("reply_preview", `String (short_preview ~max_len:360 reply));
         ]
       in
-      (try append_jsonl_line (keeper_alerts_path ctx.config) alert_json with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-      Log.Keeper.error "alert JSONL write failed: %s" (Printexc.to_string exn);
-        Prometheus.inc_counter Keeper_metrics.metric_keeper_alert_persist_failures ~labels:[("kind", Keeper_alert_persist_kind.(to_label Alert))] ());
+      (try
+         Keeper_types_support.append_jsonl_line
+           (keeper_alerts_path ctx.config)
+           alert_json
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           Log.Keeper.error "alert JSONL write failed: %s" (Printexc.to_string exn);
+           Prometheus.inc_counter
+             Keeper_metrics.metric_keeper_alert_persist_failures
+             ~labels:[("kind", Keeper_alert_persist_kind.(to_label Alert))]
+             ());
       let board_result =
         run_alert_channel_with_retry ctx
           ~channel:"board"
@@ -611,7 +620,7 @@ let maybe_emit_interesting_alert
       let deadlettered = attempted_failures <> [] && not attempted_success in
       if retry_queued then
         (try
-           append_jsonl_line
+           Keeper_types_support.append_jsonl_line
              (keeper_alert_retry_path ctx.config)
              (`Assoc [
                 ("ts", `String (now_iso ()));
@@ -626,7 +635,7 @@ let maybe_emit_interesting_alert
            Prometheus.inc_counter Keeper_metrics.metric_keeper_alert_persist_failures ~labels:[("kind", Keeper_alert_persist_kind.(to_label Failed_channels))] ());
       if deadlettered then
         (try
-           append_jsonl_line
+           Keeper_types_support.append_jsonl_line
              (keeper_alert_deadletter_path ctx.config)
              (`Assoc [
                 ("ts", `String (now_iso ()));

--- a/lib/keeper/keeper_context_core_history.ml
+++ b/lib/keeper/keeper_context_core_history.ml
@@ -54,7 +54,7 @@ let classify_history_entry ~(source : string) ~(content : string) :
   ignore content;
   if Keeper_types.is_prompt_history_source source
   then Drop_line
-  else if Keeper_types.is_internal_history_source source
+  else if Keeper_types_support.is_internal_history_source source
   then Move_internal
   else Keep_main
 
@@ -189,7 +189,7 @@ let migrate_session_history_logs ~(session_dir : string) :
 let history_path_for_source ~(session_dir : string) ~(source : string option) :
     string =
   match source with
-  | Some source when Keeper_types.is_internal_history_source source ->
+  | Some source when Keeper_types_support.is_internal_history_source source ->
       Filename.concat session_dir "history.internal.jsonl"
   | _ -> Filename.concat session_dir "history.jsonl"
 

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -412,7 +412,9 @@ let keeper_memory_search_json
           | Some s -> [ "top_score", `Float s ]
           | None -> [])
      in
-     append_jsonl_line (keeper_decision_log_path config meta.name) log_entry
+     Keeper_types_support.append_jsonl_line
+       (keeper_decision_log_path config meta.name)
+       log_entry
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->

--- a/lib/keeper/keeper_generation_lineage.ml
+++ b/lib/keeper/keeper_generation_lineage.ml
@@ -232,7 +232,7 @@ let record_handoff_artifacts
   with
   | Ok () ->
       (try
-         append_jsonl_line index_path index_entry
+         Keeper_types_support.append_jsonl_line index_path index_entry
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -723,7 +723,7 @@ let append_memory_notes_from_reply
              Hashtbl.add seen_kinds kind ();
              kinds_acc := kind :: !kinds_acc
            end;
-           append_jsonl_line path
+           Keeper_types_support.append_jsonl_line path
              (`Assoc
                [
                  ("ts", `String (now_iso ()));
@@ -802,7 +802,7 @@ let append_memory_notes_from_tool_results
            let payload_preview = tool_result_payload_preview result in
            let text = tool_result_memory_text ~kind ~artifact_id ~payload_preview in
            if is_meaningful_memory_text text then begin
-             append_jsonl_line path
+             Keeper_types_support.append_jsonl_line path
                (`Assoc
                  [ ("ts", `String (now_iso ()))
                  ; ("ts_unix", `Float now_ts)

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -716,7 +716,7 @@ let history_user_messages_from_lines
                (Keeper_context_core.text_of_history_jsonl_json json)
            in
            if content = ""
-              || Keeper_types.is_internal_history_source source
+              || Keeper_types_support.is_internal_history_source source
            then None
            else Some content
          else None

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -442,7 +442,7 @@ let handle_keeper_status ctx args : tool_result =
                      let role_lc = String.lowercase_ascii role in
                      let is_internal =
                        ignore content;
-                       Keeper_types.is_internal_history_source source
+                       Keeper_types_support.is_internal_history_source source
                      in
                      let entry_kind =
                        match source, role_lc with

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -430,11 +430,64 @@ val read_meta_if_changed :
   Coord.config -> string -> last_mtime:float ->
   (keeper_meta * float) option
 
-(** {1 Re-exports from Keeper_types_support} *)
+(** {1 Selected re-exports from Keeper_types_support} *)
 
-include module type of struct
-  include Keeper_types_support
-end
+(** Resolve the keeper base directory ([.masc/keepers]) for [config],
+    creating it if missing. *)
+val keeper_dir_ : Coord.config -> string
+
+(** Resolve the trace base directory ([.masc/traces]) for [config],
+    creating it if missing. *)
+val session_base_dir_ : Coord.config -> string
+
+(** Check API key availability for the given model labels via
+    [Cascade_runtime]. *)
+val ensure_api_keys_for_labels : string list -> (unit, string) result
+
+(** Single-file metrics path kept for fallback reads. *)
+val keeper_metrics_path : Coord.config -> string -> string
+
+(** Date-split metrics store:
+    [.masc/keepers/<name>/metrics/YYYY-MM/DD.jsonl]. *)
+val keeper_metrics_store : Coord.config -> string -> Dated_jsonl.t
+
+(** Date-split sparse PR action metrics store:
+    [.masc/keepers/<name>/pr-action-metrics/YYYY-MM/DD.jsonl]. *)
+val keeper_pr_action_metrics_store : Coord.config -> string -> Dated_jsonl.t
+
+(** Date-split execution-receipt store:
+    [.masc/keepers/<name>/execution-receipts/YYYY-MM/DD.jsonl]. *)
+val keeper_execution_receipt_store : Coord.config -> string -> Dated_jsonl.t
+
+val keeper_memory_bank_path : Coord.config -> string -> string
+val keeper_progress_path : Coord.config -> string -> string
+val keeper_generation_index_path : Coord.config -> string -> string
+
+(** Per-trace session directory under [.masc/traces/<trace_id>]. *)
+val keeper_session_dir : Coord.config -> string -> string
+
+val keeper_generation_manifest_path : Coord.config -> string -> string
+val keeper_history_path : Coord.config -> string -> string
+val keeper_internal_history_path : Coord.config -> string -> string
+
+(** Trim + lowercase a history-source label. *)
+val normalize_history_source : string -> string
+
+(** Whether [source] denotes the world-state prompt history channel. *)
+val is_prompt_history_source : string -> bool
+
+val keeper_policy_log_path : Coord.config -> string -> string
+val keeper_decision_log_path : Coord.config -> string -> string
+val keeper_feedback_log_path : Coord.config -> string -> string
+val keeper_dataset_export_path : Coord.config -> string -> string
+val keeper_alerts_path : Coord.config -> string
+val keeper_alert_retry_path : Coord.config -> string
+val keeper_alert_deadletter_path : Coord.config -> string
+
+(** Rotate [path] if it exceeds the configured size threshold.
+    Keeps at most [Env_config.KeeperMetrics.max_rotated_files] numbered
+    backups (.1, .2, ...). *)
+val maybe_rotate_file : string -> unit
 
 (** {1 Fiber health (for keeper supervisor)} *)
 

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -440,7 +440,10 @@ let append_decision_record
       ]
       @ social_fields)
   in
-  try append_jsonl_line (keeper_decision_log_path config meta.name) json
+  try
+    Keeper_types_support.append_jsonl_line
+      (keeper_decision_log_path config meta.name)
+      json
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->

--- a/test/test_metrics_rotation.ml
+++ b/test/test_metrics_rotation.ml
@@ -2,6 +2,7 @@
 open Alcotest
 
 module Keeper_types = Masc_mcp.Keeper_types
+module Keeper_types_support = Masc_mcp.Keeper_types_support
 
 let tmpdir () =
   let dir = Filename.concat (Filename.get_temp_dir_name ())
@@ -70,7 +71,7 @@ let test_append_with_rotation () =
     (* Write exactly at threshold so rotation triggers on append *)
     write_bytes path 10_485_760;
     (* Append should trigger rotation then write to fresh file *)
-    Keeper_types.append_jsonl_line path (`Assoc [("test", `Bool true)]);
+    Keeper_types_support.append_jsonl_line path (`Assoc [("test", `Bool true)]);
     check bool "new current file exists" true (Sys.file_exists path);
     check bool ".1 (rotated) exists" true (Sys.file_exists (path ^ ".1"));
     (* New file should be small (just the appended line) *)


### PR DESCRIPTION
Summary
- stop exposing support-only JSONL append and internal-history source helpers through Keeper_types
- move callers to Keeper_types_support.append_jsonl_line and Keeper_types_support.is_internal_history_source
- update the legacy purge ledger and keeper-agent debt note to describe selected support re-exports

Verification
- ocamlformat --check lib/keeper/keeper_types.mli lib/keeper/keeper_alerting.ml lib/keeper/keeper_memory_bank.ml lib/keeper/keeper_unified_metrics_decision.ml lib/keeper/keeper_generation_lineage.ml lib/keeper/keeper_exec_memory.ml lib/dashboard/dashboard_http_keeper_metrics.ml lib/keeper/keeper_status_detail.ml lib/keeper/keeper_memory_recall.ml lib/keeper/keeper_context_core_history.ml test/test_metrics_rotation.ml
- rg -n "Keeper_types\\.(append_jsonl_line|is_internal_history_source)\\b" lib test docs --glob "!docs/audit/2026-05-25-legacy-purge-plan.html" (no matches)
- rg -n "val append_jsonl_line|val is_internal_history_source|include Keeper_types_support|Re-exports from Keeper_types_support|<<<<<<<|=======|>>>>>>>" lib/keeper/keeper_types.mli docs/audit/2026-05-25-legacy-purge-plan.html (no matches)
- git diff --check origin/main..HEAD
- scripts/audit-keeper-tool-boundary-matrix.sh
- scripts/ocaml-structure-ratchet.sh
- scripts/stringly-boundary-ratchet.sh
- scripts/oas-boundary-ratchet.sh
- scripts/lint/no-unknown-permissive-default.sh
- scripts/lint/no-ocaml-comment-terminator-trap.sh
- scripts/lint-ignore-without-comment.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

Local Dune gap
- scripts/dune-local.sh build test/test_metrics_rotation.exe exits 75 because live bare Dune processes are still bypassing the machine-wide wrapper. I did not set MASC_DUNE_ALLOW_BARE_DUNE=1.