### PR TITLE
fix(keeper): add typed bash allowlist hints

### DIFF
--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -368,9 +368,51 @@ let pp_mode ppf = function
   | Readonly -> Format.pp_print_string ppf "readonly"
 ;;
 
+let executable_not_allowlisted_hint ~name ~mode =
+  if String.starts_with ~prefix:"keeper_" name || String.starts_with ~prefix:"masc_" name
+  then
+    Some
+      "MASC tool names are not shell programs; call the visible JSON tool with \
+       arguments instead of running it through Execute."
+  else
+    match mode, name with
+    | Readonly, "gh" | Readonly, "git" ->
+      Some
+        "This preset is read-only. Prefer keeper_pr_status/keeper_pr_list or \
+         ReadFile/SearchFiles when visible; otherwise ask for a write-enabled \
+         preset before using git/gh."
+    | _, "bash" | _, "sh" | _, "zsh" ->
+      Some
+        "Shell interpreters are intentionally unavailable. Use typed \
+         executable/argv, or explicit pipeline stages, without shell syntax."
+    | _, "rm" | _, "chmod" | _, "chown" | _, "sudo" ->
+      Some
+        "This executable is privileged/destructive. Use a dedicated structured \
+         workflow, a non-destructive inspection command, or ask the operator."
+    | _, "jq" ->
+      Some
+        "jq is not part of keeper_bash. Use typed task/board tools for MASC \
+         state, or inspect files with ReadFile/SearchFiles and parse only the \
+         needed fields."
+    | _, "curl" ->
+      Some
+        "Network fetches are not available through keeper_bash. Use a dedicated \
+         structured integration/tool if one is visible."
+    | _ -> None
+;;
+
 let pp_validation_error ppf = function
   | Executable_not_allowlisted { name; mode } ->
-    Format.fprintf ppf "executable %S not in %a allowlist" name pp_mode mode
+    (match executable_not_allowlisted_hint ~name ~mode with
+     | None -> Format.fprintf ppf "executable %S not in %a allowlist" name pp_mode mode
+     | Some hint ->
+       Format.fprintf
+         ppf
+         "executable %S not in %a allowlist. %s"
+         name
+         pp_mode
+         mode
+         hint)
   | Empty_executable { argv = first :: rest } ->
     Format.fprintf
       ppf

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -229,6 +229,46 @@ let test_empty_executable_with_argv_hints_rewrite () =
   | Ok () -> Alcotest.fail "empty executable should not be accepted"
 ;;
 
+let validation_error_text error = Format.asprintf "%a" Bash_input.pp_validation_error error
+
+let check_not_allowlisted_hint ~name ~mode ~needle () =
+  let msg =
+    validation_error_text (Bash_input.Executable_not_allowlisted { name; mode })
+  in
+  Alcotest.(check bool)
+    (Printf.sprintf "%s hint" name)
+    true
+    (String_util.contains_substring_ci msg needle)
+;;
+
+let test_not_allowlisted_hints_self_correction () =
+  check_not_allowlisted_hint
+    ~name:"keeper_tasks_list"
+    ~mode:Bash_input.Dev_full
+    ~needle:"not shell programs"
+    ();
+  check_not_allowlisted_hint
+    ~name:"gh"
+    ~mode:Bash_input.Readonly
+    ~needle:"keeper_pr_status"
+    ();
+  check_not_allowlisted_hint
+    ~name:"bash"
+    ~mode:Bash_input.Dev_full
+    ~needle:"Shell interpreters"
+    ();
+  check_not_allowlisted_hint
+    ~name:"chmod"
+    ~mode:Bash_input.Dev_full
+    ~needle:"privileged/destructive"
+    ();
+  check_not_allowlisted_hint
+    ~name:"jq"
+    ~mode:Bash_input.Dev_full
+    ~needle:"typed task/board tools"
+    ()
+;;
+
 let test_of_json_exec () =
   let input =
     parse_json_exn
@@ -514,6 +554,10 @@ let suite =
           "empty_executable_with_argv_hints_rewrite"
           `Quick
           test_empty_executable_with_argv_hints_rewrite
+      ; Alcotest.test_case
+          "not_allowlisted_hints_self_correction"
+          `Quick
+          test_not_allowlisted_hints_self_correction
       ; Alcotest.test_case "of_json_exec" `Quick test_of_json_exec
       ; Alcotest.test_case "of_json_pipeline" `Quick test_of_json_pipeline
       ; Alcotest.test_case


### PR DESCRIPTION
## Summary

- Keep the keeper_bash allowlist unchanged.
- Add self-correction hints for common rejected executables seen in live logs:
  - MASC tool names sent through Execute
  - git/gh under readonly presets
  - shell interpreters
  - privileged/destructive commands
  - jq/curl
- Add focused typed bash formatter coverage for those hints.

## Evidence

Recent system logs still show repeated allowlist failures after excluding merged empty-executable fixes:

```text
52 empty executable allowlist failures
36 gh dev_full allowlist failures
12 rm dev_full allowlist failures
9 git readonly allowlist failures
9 chmod dev_full allowlist failures
6 keeper_tasks_list dev_full allowlist failures
6 keeper_board_list dev_full allowlist failures
6 gh readonly allowlist failures
6 bash dev_full allowlist failures
3 jq dev_full allowlist failures
3 curl dev_full allowlist failures
```

This PR does not expand the execution surface. It only makes the deterministic rejection actionable on the next retry.

## Validation

- `ocamlformat --check lib/keeper/keeper_tool_bash_input.ml test/test_keeper_bash_typed_input.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_tool_bash_input.ml`
- `ocamlc -stop-after parsing test/test_keeper_bash_typed_input.ml`
- `git diff --check`

Focused Dune build was attempted:

- `scripts/dune-local.sh build test/test_keeper_bash_typed_input.exe`

It was blocked by machine-wide bare Dune processes outside `scripts/dune-local.sh`, so full type/test validation is left to CI.
