### PR TITLE
refactor(exec): purge Bin vocabulary leftovers

### DIFF
--- a/docs/design/keeper-tool-runtime-boundary-plan.html
+++ b/docs/design/keeper-tool-runtime-boundary-plan.html
@@ -345,7 +345,7 @@
           </tr>
           <tr>
             <td data-label="ID">G10</td>
-            <td data-label="Goal">Stop keeping keeper executable allowlists as a parallel raw string vocabulary beside <code>Bin</code>.</td>
+            <td data-label="Goal">Stop keeping keeper executable allowlists as a parallel raw string vocabulary beside <code>Exec_program</code>.</td>
             <td data-label="Quantitative Gate"><code>Dev_exec_allowlist.dev</code> and <code>readonly</code> are derived from typed <code>Exec_program.known</code> lists, and tests prove every allowlisted executable resolves to a known <code>Exec_program</code>.</td>
             <td data-label="Status"><span class="status done">Done in slice 11</span></td>
           </tr>
@@ -490,10 +490,10 @@
           </tr>
           <tr>
             <td data-label="Task">T9</td>
-            <td data-label="Goal">Bin-owned executable vocabulary</td>
-            <td data-label="Todo">Expand <code>Masc_exec.Exec_program.known</code> to cover keeper dev/read-only executables and derive <code>Dev_exec_allowlist</code> from typed bin lists.</td>
+            <td data-label="Goal">Exec_program-owned executable vocabulary</td>
+            <td data-label="Todo">Expand <code>Masc_exec.Exec_program.known</code> to cover keeper dev/read-only executables and derive <code>Dev_exec_allowlist</code> from typed executable lists.</td>
             <td data-label="Verification Method"><code>./_build/default/test/test_keeper_bash_safety.exe</code>, <code>./_build/default/lib/exec/test/test_exec_types.exe</code>, <code>./_build/default/test/test_worker_dev_tools.exe</code></td>
-            <td data-label="Exit Criteria">Adding/removing a dev executable goes through the typed <code>Bin</code> registry and generated Shell IR walker exhaustiveness, not a standalone string table.</td>
+            <td data-label="Exit Criteria">Adding/removing a dev executable goes through the typed <code>Exec_program</code> registry and generated Shell IR walker exhaustiveness, not a standalone string table.</td>
           </tr>
           <tr>
             <td data-label="Task">T10</td>
@@ -630,8 +630,8 @@
           </tr>
           <tr>
             <td data-label="Task">T29</td>
-            <td data-label="Goal">Code shell Bin axis</td>
-            <td data-label="Todo">Move <code>masc_code_shell</code> executable extras into typed <code>Masc_exec.Exec_program</code> constructors and derive its allowlist through <code>Dev_exec_allowlist.code_shell_bins</code>.</td>
+            <td data-label="Goal">Code shell Exec_program axis</td>
+            <td data-label="Todo">Move <code>masc_code_shell</code> executable extras into typed <code>Masc_exec.Exec_program</code> constructors and derive its allowlist through <code>Dev_exec_allowlist.code_shell_programs</code>.</td>
             <td data-label="Verification Method"><code>./_build/default/test/test_keeper_bash_safety.exe</code>, <code>./_build/default/test/test_tool_code_write_coverage.exe</code></td>
             <td data-label="Exit Criteria"><code>tool_code_write_shell_validate</code> consumes <code>Dev_exec_allowlist.code_shell</code> and no longer owns a local raw string extension table.</td>
           </tr>
@@ -677,7 +677,7 @@
         <div class="command">bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh</div>
         <div class="command">python3 -m py_compile scripts/audit-keeper-fleet-readiness.py</div>
         <div class="command">rg -n "keeper_shell&quot;; &quot;keeper_bash&quot;; &quot;masc_code_shell|List\.mem tool_name \[ ?&quot;masc_code_git&quot;; &quot;keeper_bash&quot;; &quot;masc_code_shell&quot;" lib/keeper/keeper_contract_classifier.ml lib/keeper/keeper_hooks_oas_pr_metrics.ml</div>
-        <div class="command">rg -n "Tool_name\\.of_string|Keeper_tool_alias\\.route|Keeper_tool_alias\\.public_masc_to_internal|Masc_exec\\.Bin\\.of_string|typed_bash_stage_class|String_util\\.contains_substring_ci" lib/tool_resource_gate.ml</div>
+        <div class="command">rg -n "Tool_name\\.of_string|Keeper_tool_alias\\.route|Keeper_tool_alias\\.public_masc_to_internal|Masc_exec\\.Exec_program\\.of_string|typed_bash_stage_class|String_util\\.contains_substring_ci" lib/tool_resource_gate.ml</div>
         <div class="command">rg -n "String_util\\.contains_substring_ci" lib/tool_resource_axis.ml</div>
         <div class="command">./_build/default/test/test_keeper_github_pr.exe</div>
         <div class="command">./_build/default/test/test_keeper_bash_safety.exe</div>

--- a/docs/design/keeper-tool-runtime-boundary-plan.md
+++ b/docs/design/keeper-tool-runtime-boundary-plan.md
@@ -132,7 +132,7 @@ and public tool aliases.
      instead of a parallel raw string table.
    - `Masc_exec.Exec_program` now knows every executable admitted by the dev/read-only
      keeper allowlists, and the generated Shell IR typed walker fallback was
-     updated so adding known bins remains exhaustively checked by the compiler.
+     updated so adding known executables remains exhaustively checked by the compiler.
    - `test_keeper_bash_safety` now verifies that both keeper executable
      allowlists are derived from `Exec_program.name_of_known` and that every allowlisted
      executable resolves to a known `Exec_program`.
@@ -315,7 +315,7 @@ and public tool aliases.
    - `Masc_exec.Exec_program` now knows the `masc_code_shell`-only executable extras
      (`diff`, `patch`, `mkdir`, `ocamlfind`, `tsc`) instead of leaving them as
      raw strings beside the keeper Bash allowlist.
-   - `Dev_exec_allowlist.code_shell_bins` and the derived
+   - `Dev_exec_allowlist.code_shell_programs` and the derived
      `Dev_exec_allowlist.code_shell` compatibility list now own the
      `masc_code_shell` executable vocabulary; `tool_code_write_shell_validate`
      consumes that axis and no longer builds a local extension table.
@@ -443,7 +443,7 @@ and public tool aliases.
   `Keeper_tool_capability_axis.shell_command_input_candidates`.
 - `test_keeper_bash_safety` now verifies the legacy `masc_code_shell`
   allowlist is derived from typed `Exec_program` values through
-  `Dev_exec_allowlist.code_shell_bins`, matching the existing dev/read-only
+  `Dev_exec_allowlist.code_shell_programs`, matching the existing dev/read-only
   allowlist ratchets.
 - `test_worker_dev_tools` now fails if `masc_code_shell` bypasses
   `Keeper_shell_ir.coding_command_context` /

--- a/lib/exec/test/test_exec_types.ml
+++ b/lib/exec/test/test_exec_types.ml
@@ -6,7 +6,7 @@
 
 open Masc_exec
 
-let test_bin_safe () =
+let test_exec_program_safe () =
   match Exec_program.of_string "ls" with
   | Ok b ->
     assert (Exec_program.risk_class b = `Safe);
@@ -14,7 +14,7 @@ let test_bin_safe () =
   | Error _ -> assert false
 ;;
 
-let test_bin_of_known () =
+let test_exec_program_of_known () =
   let ls = Exec_program.of_known Exec_program.Ls in
   assert (Exec_program.risk_class ls = `Safe);
   assert (Exec_program.kind ls = `Safe_program);
@@ -30,7 +30,7 @@ let test_bin_of_known () =
   assert (Exec_program.known sudo = Some Exec_program.Sudo)
 ;;
 
-let test_bin_name_of_known () =
+let test_exec_program_name_of_known () =
   assert (Exec_program.name_of_known Exec_program.Ls = "ls");
   assert (Exec_program.name_of_known Exec_program.Git = "git");
   assert (Exec_program.name_of_known Exec_program.Curl = "curl");
@@ -38,7 +38,7 @@ let test_bin_name_of_known () =
   assert (Exec_program.name_of_known Exec_program.Sudo = "sudo")
 ;;
 
-let test_bin_risk_of_known () =
+let test_exec_program_risk_of_known () =
   assert (Exec_program.risk_of_known Exec_program.Ls = `Safe);
   assert (Exec_program.risk_of_known Exec_program.Rg = `Safe);
   assert (Exec_program.risk_of_known Exec_program.Git = `Audited);
@@ -47,7 +47,7 @@ let test_bin_risk_of_known () =
   assert (Exec_program.risk_of_known Exec_program.Rm = `Privileged)
 ;;
 
-let test_bin_all_known_metadata_roundtrips () =
+let test_exec_program_all_known_metadata_roundtrips () =
   let seen_names = Hashtbl.create 128 in
   List.iter
     (fun known ->
@@ -65,7 +65,7 @@ let test_bin_all_known_metadata_roundtrips () =
     Exec_program.all_known
 ;;
 
-let test_bin_known_roundtrip () =
+let test_exec_program_known_roundtrip () =
   match Exec_program.of_string "git" with
   | Ok b ->
     (match Exec_program.known b with
@@ -74,19 +74,19 @@ let test_bin_known_roundtrip () =
   | Error _ -> assert false
 ;;
 
-let test_bin_unknown_has_no_known () =
+let test_exec_program_unknown_has_no_known () =
   match Exec_program.of_string "wibble" with
   | Ok b -> assert (Exec_program.known b = None)
   | Error _ -> assert false
 ;;
 
-let test_bin_unknown_is_privileged () =
+let test_exec_program_unknown_is_privileged () =
   match Exec_program.of_string "wibble" with
   | Ok b -> assert (Exec_program.risk_class b = `Privileged)
   | Error _ -> assert false
 ;;
 
-let test_grep_is_not_known_bin () =
+let test_grep_is_not_known_exec_program () =
   match Exec_program.of_string "grep" with
   | Ok b ->
     assert (Exec_program.known b = None);
@@ -94,7 +94,7 @@ let test_grep_is_not_known_bin () =
   | Error _ -> assert false
 ;;
 
-let test_bin_empty_rejected () =
+let test_exec_program_empty_rejected () =
   match Exec_program.of_string "" with
   | Ok _ -> assert false
   | Error (`Unknown _) -> ()
@@ -217,16 +217,16 @@ let test_verdict_four_way () =
 ;;
 
 let () =
-  test_bin_safe ();
-  test_bin_of_known ();
-  test_bin_name_of_known ();
-  test_bin_risk_of_known ();
-  test_bin_all_known_metadata_roundtrips ();
-  test_bin_known_roundtrip ();
-  test_bin_unknown_has_no_known ();
-  test_bin_unknown_is_privileged ();
-  test_grep_is_not_known_bin ();
-  test_bin_empty_rejected ();
+  test_exec_program_safe ();
+  test_exec_program_of_known ();
+  test_exec_program_name_of_known ();
+  test_exec_program_risk_of_known ();
+  test_exec_program_all_known_metadata_roundtrips ();
+  test_exec_program_known_roundtrip ();
+  test_exec_program_unknown_has_no_known ();
+  test_exec_program_unknown_is_privileged ();
+  test_grep_is_not_known_exec_program ();
+  test_exec_program_empty_rejected ();
   test_git_op_destructive_detection ();
   test_git_op_read ();
   test_git_op_read_with_cwd_flag ();

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-25T03:28:41Z (HEAD: 6eb2659e0)
+Generated: 2026-05-26T03:15:05Z (HEAD: 90b902497)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -152,7 +152,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperTraceSpec.tla | KeeperTraceSpec | manual | 2 | 1 | clean={inv:TypeOK, inv:RunningRequiresFiber, inv:OfflineRequiresLaunchPending, inv:StoppedRequiresDrain, inv:DeadRequiresNoBudget, inv:DerivePhaseAgreement, prop:RestartCountMonotonic, prop:BudgetNeverRevives, prop:TransitionMatrixAgreement} buggy={inv:TypeOK, inv:DerivePhaseAgreementMustHold} | 733248761720 |
 | KeeperTurnCycle.tla | KeeperTurnCycle | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:SelectingRequiresToolPolicyMustHold} | 2e534fb9df8f |
 | KeeperTurnSlot.tla | KeeperTurnSlot | manual | 2 | 1 | clean={inv:Safety} buggy={inv:RetryPhaseRequiresReleased} | 6c970f9002bd |
-| KeeperWorkPipeline.tla | KeeperWorkPipeline | manual | 1 | 0 | clean={inv:TypeOK, inv:WorkspaceAlwaysBounded, inv:IdentityConsistent, inv:NoForcePush, inv:ReviewBeforeSubmit, prop:EventualCompletion, prop:NoOrphanWorkspace} | dd74f126c936 |
+| KeeperWorkPipeline.tla | KeeperWorkPipeline | manual | 1 | 0 | clean={inv:TypeOK, inv:WorkspaceAlwaysBounded, inv:IdentityConsistent, inv:NoForcePush, inv:ReviewBeforeSubmit, prop:EventualCompletion, prop:NoOrphanWorkspace} | 6c564260109d |
 | KeeperWorkingStateLifecycle.tla | KeeperWorkingStateLifecycle | manual | 2 | 1 | clean={inv:TypeOK, inv:LifecycleDisjoint, inv:WorkingLoopsHaveSixWAndEvidence, inv:ResolvedOnlyWithResolutionEvidence, inv:ActiveLoopsNoSilentLoss, inv:PromptDigestBounded, inv:PromptDigestCoversActive, inv:CompactionPreservesActive, inv:HandoffCarriesActive} buggy={inv:TypeOK, inv:LifecycleDisjoint, inv:WorkingLoopsHaveSixWAndEvidence, inv:ResolvedOnlyWithResolutionEvidence, inv:ActiveLoopsNoSilentLoss, inv:PromptDigestBounded, inv:PromptDigestCoversActive, inv:CompactionPreservesActive, inv:HandoffCarriesActive} | e7caa37d5578 |
 | OperatorPauseBroadcast.tla | OperatorPauseBroadcast | manual | 2 | 1 | clean={inv:TypeOK, inv:EmittedBeforeResolved, prop:PauseLeadsToBroadcast, prop:OperatorPauseEverHandled} buggy={inv:TypeOK, prop:PauseLeadsToBroadcast} | 8c678dba2425 |
 

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -460,7 +460,7 @@ let test_tool_resource_gate_uses_resource_axis () =
   assert_contains axis "docker-compose";
   assert_not_contains axis "String_util.contains_substring_ci"
 
-let test_bin_metadata_axis_is_single_owner () =
+let test_exec_program_metadata_axis_is_single_owner () =
   let rel = "lib/exec/exec_program.ml" in
   let known_constructors =
     lines_between ~start_needle:"type known =" ~end_needle:"type known_metadata =" rel
@@ -688,9 +688,9 @@ let () =
             `Quick
             test_tool_resource_gate_uses_resource_axis;
           Alcotest.test_case
-            "bin metadata axis is single owner"
+            "exec program metadata axis is single owner"
             `Quick
-            test_bin_metadata_axis_is_single_owner;
+            test_exec_program_metadata_axis_is_single_owner;
           Alcotest.test_case
             "keeper semantic capabilities use capability axis"
             `Quick


### PR DESCRIPTION
## Summary

- rename remaining test and design-plan `Bin` vocabulary to `Exec_program`
- refresh `specs/INDEX.md` so the TLA index hash matches current spec contents
- keep the already-merged PR-review wrapper deletion intact; the remaining `keeper_tool_pr_review` references are absence ratchets only

## Validation

- `ocamlformat --check lib/exec/test/test_exec_types.ml test/test_keeper_sandbox_boundary_policy.ml`
- `git diff --check`
- `diff -u <(grep -v '^Generated: ' specs/INDEX.md) <(bash scripts/gen-tla-index.sh | grep -v '^Generated: ')`
- `rg -n "\bBin\b|Masc_exec\.Bin|bin\.ml|test_bin_|known bins|typed bin|bin lists|code_shell_bins|bin metadata axis" lib test docs/design/keeper-tool-runtime-boundary-plan.md docs/design/keeper-tool-runtime-boundary-plan.html --glob '!_build/**' --glob '!docs/archive/**'` returned no matches
- `rg -n "keeper_tool_pr_review|keeper_gh_pr_review_cli|tool_shard_types_schemas_pr_review|test_keeper_pr_review" lib test docs/design docs/rfc specs --glob '!_build/**' --glob '!docs/archive/**'` only finds absence ratchets

## Not Run

- `scripts/dune-local.sh build lib/exec/test/test_exec_types.exe test/test_keeper_sandbox_boundary_policy.exe` was attempted, but refused to start because live bare Dune processes were already bypassing the machine-wide wrapper lock.