### PR TITLE
fix(keeper): type workflow rejection retry policy

### DIFF
--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -28,7 +28,19 @@ let tool_result_error_json (tr : Tool_result.t) =
     | Some cls ->
       [ "failure_class", `String (Tool_result.tool_failure_class_to_string cls) ]
   in
-  error_json ~fields (Tool_result.message tr)
+  match Tool_result.structured_payload_of_message (Tool_result.message tr) with
+  | Some (`Assoc payload_fields) ->
+    let payload_fields =
+      List.fold_left
+        (fun acc (key, value) ->
+           if has_json_field key acc then acc else acc @ [ key, value ])
+        payload_fields
+        fields
+    in
+    Yojson.Safe.to_string (`Assoc payload_fields)
+  | Some _
+  | None ->
+    error_json ~fields (Tool_result.message tr)
 ;;
 
 let tool_result_or_error (tr : Tool_result.t) =

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -20,13 +20,17 @@ let keeper_task_result_json ?(typed_outcome = (None : Keeper_tool_outcome.t opti
       (`Assoc ([ "ok", `Bool false; "error", `String (Masc_domain.masc_error_to_string e) ] @ typed_fields))
 ;;
 
-let workflow_rejection_error_json message =
-  error_json
-    ~fields:[ "failure_class", `String "workflow_rejection" ]
+let workflow_rejection_error_json ?(rule_id = "keeper_task_argument_rejected") message =
+  Tool_task_payloads.workflow_rejection_payload_json
+    ~rule_id
+    ~scope_policy:"block_scope"
     message
 ;;
 
 let keeper_tool_result_json ?(typed_outcome = (None : Keeper_tool_outcome.t option)) ~failure_class ~(ok : bool) ~(message : string) () =
+  let has_json_field name fields =
+    List.exists (fun (field, _) -> String.equal field name) fields
+  in
   let failure_class_fields =
     match failure_class with
     | Some cls when not ok ->
@@ -43,14 +47,24 @@ let keeper_tool_result_json ?(typed_outcome = (None : Keeper_tool_outcome.t opti
     | Some outcome -> [ "typed_outcome", Keeper_tool_outcome.to_json outcome ]
     | None -> []
   in
-  Yojson.Safe.to_string
-    (`Assoc
-       ([
-         "ok", `Bool ok;
-         ((if ok then "result" else "error"), `String message);
-       ]
-        @ failure_class_fields
-        @ typed_outcome_fields))
+  match (ok, Tool_result.structured_payload_of_message message) with
+  | false, Some (`Assoc payload_fields) ->
+    let payload_fields =
+      List.fold_left
+        (fun acc (key, value) ->
+           if has_json_field key acc then acc else acc @ [ key, value ])
+        payload_fields
+        (failure_class_fields @ typed_outcome_fields)
+    in
+    Yojson.Safe.to_string (`Assoc payload_fields)
+  | _ ->
+    Yojson.Safe.to_string
+      (`Assoc
+         ([ "ok", `Bool ok
+          ; (if ok then "result" else "error"), `String message
+          ]
+          @ failure_class_fields
+          @ typed_outcome_fields))
 ;;
 
 let validate_goal_id config goal_id =

--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -76,6 +76,12 @@ let assoc_int_opt key json =
   | _ -> None
 ;;
 
+let assoc_bool_opt key json =
+  match assoc_field_opt key json with
+  | Some (`Bool value) -> Some value
+  | _ -> None
+;;
+
 (* [error_or_detail key json] reads [key] at top level, falling back
    to a nested ["detail"] object. Mirrors the lookup pattern used in
    [keeper_tools_oas.workflow_rejection_info_of_raw]. *)
@@ -85,6 +91,15 @@ let error_or_detail_string key json =
   | None ->
     (match assoc_field_opt "detail" json with
      | Some detail -> assoc_string_opt key detail
+     | None -> None)
+;;
+
+let error_or_detail_bool key json =
+  match assoc_bool_opt key json with
+  | Some _ as v -> v
+  | None ->
+    (match assoc_field_opt "detail" json with
+     | Some detail -> assoc_bool_opt key detail
      | None -> None)
 ;;
 
@@ -121,7 +136,13 @@ let path_check_reason_of_explicit = function
 
 let classify_workflow_rejection json =
   match error_or_detail_string "failure_class" json with
-  | Some "workflow_rejection" -> Some Workflow_rejection_blocked
+  | Some "workflow_rejection" ->
+    (match
+       ( error_or_detail_string "error_class" json
+       , error_or_detail_bool "recoverable" json )
+     with
+     | Some "deterministic", Some false -> Some Workflow_rejection_blocked
+     | _ -> None)
   | Some _ | None -> None
 ;;
 

--- a/lib/keeper/keeper_tool_deterministic_error.mli
+++ b/lib/keeper/keeper_tool_deterministic_error.mli
@@ -45,8 +45,9 @@ type deterministic_reason =
       (** Raw shell rejected because a structured visible tool/native workflow is required. *)
   | Workflow_rejection_blocked
       (** typed workflow_rejection failure class — handled by a
-          separate counter in [Keeper_tools_oas], but still considered
-          deterministic so retry-skipped telemetry can be emitted. *)
+          separate counter in [Keeper_tools_oas]. It is considered
+          deterministic only when the payload explicitly carries
+          [error_class="deterministic"] and [recoverable=false]. *)
   | Git_ref_precondition_failed
       (** git three-dot/ref precondition failed: missing ref, unknown
           revision, ambiguous revision, or no merge base. Retrying the
@@ -63,8 +64,8 @@ type deterministic_reason =
     network/timeout failures, and any payload that fails to parse.
 
     Inputs are validated against a typed allow-list of [error] field
-    values plus the orthogonal [failure_class:"workflow_rejection"]
-    marker and a closed set of git exit-128 output patterns. There is
+    values plus explicit deterministic workflow-rejection markers
+    and a closed set of git exit-128 output patterns. There is
     no [_ ->] catch-all that admits new prefixes silently. *)
 val classify : Yojson.Safe.t -> deterministic_reason option
 

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -106,7 +106,7 @@ val tool_failure_class_of_wire_string
   :  string option
   -> Tool_result.tool_failure_class option
 
-(** Build top-level recovery hints for deterministic workflow rejections.
+(** Build top-level recovery hints for workflow rejections.
     These fields are intentionally outside [detail] so the LLM sees the
     required self-correction without parsing nested tool-specific payloads. *)
 

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -76,14 +76,16 @@ let execute_with_observers
           | Some info ->
             let family_key = workflow_rejection_family_key ~tool_name:name info in
             let count = workflow_rejection_count_record failure_counts family_key in
-            (match workflow_scope_key_of_input ~tool_name:name input with
-             | Some scope_key ->
-               ignore
-                 (workflow_rejection_scope_block_record
-                    failure_counts
-                    scope_key
-                    info)
-             | None -> ());
+            if workflow_rejection_should_scope_block info
+            then (
+              match workflow_scope_key_of_input ~tool_name:name input with
+              | Some scope_key ->
+                ignore
+                  (workflow_rejection_scope_block_record
+                     failure_counts
+                     scope_key
+                     info)
+              | None -> ());
             workflow_rejection_recovery_fields ~tool_name:name ~count raw_result
           | None -> [])
         else []
@@ -110,15 +112,15 @@ let execute_with_observers
       let recovery_fields =
         workflow_rejection_recovery_fields @ deterministic_recovery_fields
       in
-      (* Deterministic policy/shape blocks, including typed workflow
-         rejections: jump the per-(tool,args) failure counter to
+      (* Deterministic policy/shape blocks, including explicitly
+         deterministic workflow rejections: jump the per-(tool,args) failure counter to
          [max_consecutive_failures] on the first occurrence so the next
          invocation with the same args lands in the
          [prior_fails >= max_consecutive_failures] block branch at the
          top of the handler instead of executing the same rejected tool
-         again. The current call still emits once (with the
-         [retry_skipped*] / workflow recovery fields above) so the LLM
-         receives a single, self-correcting response. *)
+         again. Plain workflow rejections stay on the workflow recovery
+         path and do not become deterministic retry skips by class name
+         alone. *)
       let count =
         match deterministic_reason, is_workflow_rejection with
         | Some _, _ ->
@@ -178,21 +180,10 @@ let execute_with_observers
         Keeper_metrics.metric_keeper_tools_oas_failures
         ~labels:[ "tool", name; "site", "error_result" ]
         ();
-      (* Workflow rejections can arrive either through the
-         deterministic classifier or as a raw failure_class. Normalize
-         the WARN envelope so one root cause does not split across two
-         operator-visible signatures. *)
-      let unified_reason =
-        match deterministic_reason, is_workflow_rejection with
-        | Some _, _ -> deterministic_reason
-        | None, true ->
-          Some Keeper_tool_deterministic_error.Workflow_rejection_blocked
-        | None, false -> None
-      in
       Option.iter
         (record_deterministic_tool_failure_metric ~tool_name:name)
-        unified_reason;
-      (match unified_reason, is_workflow_rejection with
+        deterministic_reason;
+      (match deterministic_reason, is_workflow_rejection with
        | Some reason, _ ->
          Log.Keeper.warn
            "tool %s deterministic error (retry skipped, reason=%s): %s"
@@ -200,13 +191,9 @@ let execute_with_observers
            (Keeper_tool_deterministic_error.to_telemetry_key reason)
            detail
        | None, true ->
-         (* Unreachable by construction (see [unified_reason]
-            above); kept for exhaustiveness. *)
          Log.Keeper.warn
-           "tool %s deterministic error (retry skipped, reason=%s): %s"
+           "tool %s workflow rejection (self-correction required): %s"
            name
-           (Keeper_tool_deterministic_error.to_telemetry_key
-              Keeper_tool_deterministic_error.Workflow_rejection_blocked)
            detail
        | None, false ->
          (* MASC/OAS Error-Warn Reduction Goal §P3 adjacency

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -5,11 +5,28 @@
 
     @since P2 extraction *)
 
+type workflow_rejection_scope_policy =
+  | Observe_scope
+  | Block_scope
+
+let workflow_rejection_scope_policy_to_string = function
+  | Observe_scope -> "observe"
+  | Block_scope -> "block_scope"
+;;
+
+let workflow_rejection_scope_policy_of_string value =
+  match String.trim value with
+  | "observe" -> Some Observe_scope
+  | "block_scope" -> Some Block_scope
+  | _ -> None
+;;
+
 type workflow_rejection_info =
   { task_id : string option
   ; rule_id : string option
   ; tool_suggestion : string option
   ; hint : string option
+  ; scope_policy : workflow_rejection_scope_policy
   }
 
 type workflow_rejection_block =
@@ -51,17 +68,35 @@ let workflow_rejection_info_of_raw raw =
         | Some diagnosis -> json_assoc_string_opt "tool_suggestion" diagnosis
         | None -> None
       in
+      let scope_policy =
+        match
+          Option.bind diagnosis (fun diagnosis ->
+            json_assoc_string_opt "scope_policy" diagnosis)
+        with
+        | Some value ->
+          Option.value
+            ~default:Observe_scope
+            (workflow_rejection_scope_policy_of_string value)
+        | None -> Observe_scope
+      in
       Some
         { task_id
         ; rule_id
         ; tool_suggestion
         ; hint = json_or_detail_string_opt "hint" json
+        ; scope_policy
         }
     | Some _
     | None ->
       None
   with
   | Yojson.Json_error _ -> None
+;;
+
+let workflow_rejection_should_scope_block (info : workflow_rejection_info) =
+  match info.scope_policy with
+  | Block_scope -> true
+  | Observe_scope -> false
 ;;
 
 let workflow_rejection_family_key ~tool_name (info : workflow_rejection_info) =
@@ -113,6 +148,9 @@ let workflow_rejection_recovery_fields ~tool_name ~count raw =
       @ optional_string "rule_id" info.rule_id
       @ optional_string "tool_suggestion" info.tool_suggestion
       @ optional_string "hint" info.hint
+      @ [ ( "scope_policy"
+          , `String (workflow_rejection_scope_policy_to_string info.scope_policy) )
+        ]
     in
     [ "self_correction_required", `Bool true
     ; "do_not_retry_tool", `String tool_name
@@ -195,6 +233,7 @@ let workflow_rejection_scope_block_fields ~tool_name block =
               ; rule_id = block.rule_id
               ; tool_suggestion = block.tool_suggestion
               ; hint = block.hint
+              ; scope_policy = Block_scope
               } : workflow_rejection_info)
              )
     ]

--- a/lib/keeper/keeper_tools_oas_workflow.mli
+++ b/lib/keeper/keeper_tools_oas_workflow.mli
@@ -4,16 +4,32 @@
 
     @since P2 extraction *)
 
+(** Whether a workflow rejection should block the same task/action scope
+    before execution. Missing policy is deliberately observe-only. *)
+type workflow_rejection_scope_policy =
+  | Observe_scope
+  | Block_scope
+
+val workflow_rejection_scope_policy_to_string :
+  workflow_rejection_scope_policy -> string
+
+val workflow_rejection_scope_policy_of_string :
+  string -> workflow_rejection_scope_policy option
+
 (** Structured info extracted from a workflow-rejection tool result. *)
 type workflow_rejection_info =
   { task_id : string option
   ; rule_id : string option
   ; tool_suggestion : string option
   ; hint : string option
+  ; scope_policy : workflow_rejection_scope_policy
   }
 
 (** Extract [workflow_rejection_info] from a raw JSON string. *)
 val workflow_rejection_info_of_raw : string -> workflow_rejection_info option
+
+(** True only when the producing tool explicitly requested a scope block. *)
+val workflow_rejection_should_scope_block : workflow_rejection_info -> bool
 
 (** Build a stable family key for deduplication. *)
 val workflow_rejection_family_key
@@ -65,4 +81,3 @@ val workflow_rejection_scope_block_fields
   :  tool_name:string
   -> workflow_rejection_block
   -> (string * Yojson.Safe.t) list
-

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -328,11 +328,22 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
     | Masc_domain.Reject_verification ->
       None
   in
+  match submit_evidence_error with
+  | Some reason ->
+    Tool_result.error
+      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~tool_name
+      ~start_time
+      (workflow_rejection_payload_json
+         ~rule_id:"submit_verification_missing_evidence"
+         ~hint:verification_evidence_error_message
+         ~scope_policy:"block_scope"
+         reason)
+  | None ->
   let action =
-    match requested_action, task_opt, submit_evidence_error with
+    match requested_action, task_opt with
     | ( Masc_domain.Submit_for_verification
-      , Some ({ task_status = Masc_domain.Todo; _ } : Masc_domain.task)
-      , None ) ->
+      , Some ({ task_status = Masc_domain.Todo; _ } : Masc_domain.task) ) ->
       Log.Task.info
         "[verification-alias] treating todo submit_for_verification with evidence as submit_pr_evidence task=%s agent=%s"
         task_id
@@ -427,10 +438,6 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
     Tool_result.error ~tool_name ~start_time reason
   | None ->
   let rec try_transition attempt =
-    match submit_evidence_error with
-    | Some reason ->
-      Error (Masc_domain.Task (Masc_domain.Task_error.InvalidState reason))
-    | None ->
       let ev = if attempt = 0 then expected_version else None in
       let agent_tool_names =
         match agent_tool_names with

--- a/lib/tool_task_payloads.ml
+++ b/lib/tool_task_payloads.ml
@@ -36,6 +36,37 @@ let verifier_terminal_verdict_noop_message ~task_id ~action ~status =
     "Verifier stale verdict ignored: task %s is already %s, so masc_transition(action=%s) was treated as a no-op. Do not retry this verdict; inspect task history or list awaiting_verification tasks instead."
     task_id status action
 
+let nonempty_string_field key value =
+  match value with
+  | Some value when String.trim value <> "" -> [ key, `String (String.trim value) ]
+  | Some _
+  | None ->
+    []
+
+let workflow_rejection_payload_json
+      ?rule_id
+      ?tool_suggestion
+      ?hint
+      ?scope_policy
+      message
+  =
+  let diagnosis =
+    nonempty_string_field "rule_id" rule_id
+    @ nonempty_string_field "tool_suggestion" tool_suggestion
+    @ nonempty_string_field "scope_policy" scope_policy
+  in
+  let fields =
+    [ "ok", `Bool false
+    ; "error", `String message
+    ; "failure_class", `String "workflow_rejection"
+    ; "error_class", `String "deterministic"
+    ; "recoverable", `Bool false
+    ]
+    @ nonempty_string_field "hint" hint
+    @ if diagnosis = [] then [] else [ "diagnosis", `Assoc diagnosis ]
+  in
+  Yojson.Safe.to_string (`Assoc fields)
+
 let build_claim_observation_payload ~(now : float) ~(agent_name : string)
     ~(task_id : string) : Yojson.Safe.t =
   `Assoc

--- a/test/test_keeper_bash_retry_deterministic_close.ml
+++ b/test/test_keeper_bash_retry_deterministic_close.ml
@@ -121,22 +121,32 @@ let test_cwd_not_directory () =
 
 (* ── Deterministic — typed workflow_rejection ─────────────────── *)
 
-let test_workflow_rejection_failure_class () =
+let test_workflow_rejection_failure_class_only_is_observed () =
   let raw =
     {|{"ok":false,"error":"some_rule","failure_class":"workflow_rejection"}|}
   in
   check_classify
-    ~name:"failure_class=workflow_rejection"
+    ~name:"failure_class=workflow_rejection without deterministic marker"
+    ~expected:None
+    raw
+;;
+
+let test_workflow_rejection_explicit_deterministic () =
+  let raw =
+    {|{"ok":false,"error":"some_rule","failure_class":"workflow_rejection","error_class":"deterministic","recoverable":false}|}
+  in
+  check_classify
+    ~name:"explicit deterministic workflow_rejection"
     ~expected:(Some D.Workflow_rejection_blocked)
     raw
 ;;
 
 let test_workflow_rejection_nested_under_detail () =
   let raw =
-    {|{"ok":false,"detail":{"failure_class":"workflow_rejection"}}|}
+    {|{"ok":false,"detail":{"failure_class":"workflow_rejection","error_class":"deterministic","recoverable":false}}|}
   in
   check_classify
-    ~name:"detail.failure_class=workflow_rejection"
+    ~name:"detail deterministic workflow_rejection"
     ~expected:(Some D.Workflow_rejection_blocked)
     raw
 ;;
@@ -296,9 +306,13 @@ let () =
         ] )
     ; ( "classify_workflow_rejection"
       , [ Alcotest.test_case
-            "failure_class_top_level"
+            "failure_class_only_observed"
             `Quick
-            test_workflow_rejection_failure_class
+            test_workflow_rejection_failure_class_only_is_observed
+        ; Alcotest.test_case
+            "explicit_deterministic_top_level"
+            `Quick
+            test_workflow_rejection_explicit_deterministic
         ; Alcotest.test_case
             "failure_class_under_detail"
             `Quick

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1118,6 +1118,10 @@ let workflow_rejection_shape_block_raw =
   {|{"ok":false,"error":"tool_execute_command_shape_blocked","detail":{"ok":false,"error":"tool_execute_command_shape_blocked","hint":"Do not inspect task state by guessing .masc/backlog.json. Use keeper_tasks_list.","diagnosis":{"rule_id":"tool_execute_repo_wide_scan_blocked","tool_suggestion":"keeper_tasks_list"}},"failure_class":"workflow_rejection"}|}
 ;;
 
+let workflow_rejection_scope_block_raw =
+  {|{"ok":false,"error":"missing evidence","failure_class":"workflow_rejection","error_class":"deterministic","recoverable":false,"diagnosis":{"rule_id":"submit_verification_missing_evidence","scope_policy":"block_scope"}}|}
+;;
+
 let test_workflow_rejection_recovery_fields_expose_next_tool () =
   let recovery_fields =
     Keeper_tools_oas_workflow.workflow_rejection_recovery_fields
@@ -1143,7 +1147,8 @@ let test_workflow_rejection_recovery_fields_expose_next_tool () =
     "rule id"
     "tool_execute_repo_wide_scan_blocked"
     (json_string "rule_id" recovery);
-  check string "tool suggestion" "keeper_tasks_list" (json_string "tool_suggestion" recovery)
+  check string "tool suggestion" "keeper_tasks_list" (json_string "tool_suggestion" recovery);
+  check string "scope policy" "observe" (json_string "scope_policy" recovery)
 ;;
 
 let test_workflow_rejection_recovery_fields_mark_loop () =
@@ -1163,6 +1168,69 @@ let test_workflow_rejection_recovery_fields_mark_loop () =
   check bool "workflow rejection loop" true (json_bool "workflow_rejection_loop" json);
   let recovery = Yojson.Safe.Util.member "workflow_rejection_recovery" json in
   check int "workflow rejection count" 2 (json_int "count" recovery)
+;;
+
+let test_workflow_rejection_scope_policy_defaults_to_observe () =
+  match
+    Keeper_tools_oas_workflow.workflow_rejection_info_of_raw
+      workflow_rejection_shape_block_raw
+  with
+  | None -> fail "expected workflow rejection info"
+  | Some info ->
+    check
+      bool
+      "unmarked workflow rejection does not scope-block"
+      false
+      (Keeper_tools_oas_workflow.workflow_rejection_should_scope_block info);
+    check
+      string
+      "scope policy string"
+      "observe"
+      (Keeper_tools_oas_workflow.workflow_rejection_scope_policy_to_string
+         info.scope_policy)
+;;
+
+let test_workflow_rejection_scope_policy_block_scope () =
+  match
+    Keeper_tools_oas_workflow.workflow_rejection_info_of_raw
+      workflow_rejection_scope_block_raw
+  with
+  | None -> fail "expected workflow rejection info"
+  | Some info ->
+    check
+      bool
+      "explicit block_scope blocks scope"
+      true
+      (Keeper_tools_oas_workflow.workflow_rejection_should_scope_block info)
+;;
+
+let test_tool_result_error_json_preserves_structured_workflow_rejection () =
+  let message =
+    Tool_task_payloads.workflow_rejection_payload_json
+      ~rule_id:"submit_verification_missing_evidence"
+      ~scope_policy:"block_scope"
+      "missing evidence"
+  in
+  let tr =
+    Tool_result.error
+      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~tool_name:"masc_transition"
+      ~start_time:0.0
+      message
+  in
+  let json = parse (Keeper_exec_shared.tool_result_error_json tr) in
+  check string "error preserved" "missing evidence" (json_string "error" json);
+  check
+    string
+    "failure class preserved"
+    "workflow_rejection"
+    (json_string "failure_class" json);
+  let diagnosis = Yojson.Safe.Util.member "diagnosis" json in
+  check
+    string
+    "scope policy preserved"
+    "block_scope"
+    (json_string "scope_policy" diagnosis)
 ;;
 
 let test_deterministic_recovery_plan_fields_promote_next_tool () =
@@ -1684,6 +1752,18 @@ let () =
             "workflow rejection marks repeated loop"
             `Quick
             test_workflow_rejection_recovery_fields_mark_loop
+        ; test_case
+            "workflow rejection scope policy defaults to observe"
+            `Quick
+            test_workflow_rejection_scope_policy_defaults_to_observe
+        ; test_case
+            "workflow rejection scope policy block_scope"
+            `Quick
+            test_workflow_rejection_scope_policy_block_scope
+        ; test_case
+            "structured Tool_result workflow rejection stays structured"
+            `Quick
+            test_tool_result_error_json_preserves_structured_workflow_rejection
         ; test_case
             "deterministic recovery plan promotes next tool"
             `Quick


### PR DESCRIPTION
## Summary
- require explicit deterministic/recoverable markers before workflow_rejection becomes a deterministic retry skip
- add typed workflow rejection scope_policy; unmarked rejections are observe-only and do not install task/action scope blocks
- preserve structured Tool_result failure payloads so workflow policy fields survive keeper wrapping

## Verification
- ocamlformat --check lib/keeper/keeper_exec_shared.ml lib/keeper/keeper_exec_task.ml lib/keeper/keeper_tool_deterministic_error.ml lib/keeper/keeper_tool_deterministic_error.mli lib/keeper/keeper_tools_oas_handler_exec.ml lib/keeper/keeper_tools_oas_workflow.ml lib/keeper/keeper_tools_oas_workflow.mli lib/keeper/keeper_tools_oas.mli lib/tool_task.ml lib/tool_task_payloads.ml test/test_keeper_bash_retry_deterministic_close.ml test/test_keeper_tools_oas.ml
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_keeper_tools_oas.exe test/test_keeper_bash_retry_deterministic_close.exe (blocked by existing bare Dune processes outside scripts/dune-local.sh; wrapper refused to start another local build)
