### PR TITLE
refactor(keeper): route metrics stores to support owner

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 12:11:40 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 12:22:20 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -367,9 +367,15 @@
           </tr>
           <tr>
             <td><code>Keeper_types</code> support helper facade leaves</td>
-            <td><span class="status now">draft PR #18560</span></td>
+            <td><span class="status done">merged #18560</span></td>
             <td>Stop exposing support-only JSONL append and history-source classification helpers through the broad <code>Keeper_types</code> facade. Callers now use <code>Keeper_types_support.append_jsonl_line</code> and <code>Keeper_types_support.is_internal_history_source</code> directly.</td>
             <td>Backstop grep is clean for <code>Keeper_types.append_jsonl_line</code> and <code>Keeper_types.is_internal_history_source</code>. <code>Keeper_types.mli</code> now lists selected support re-exports instead of including the entire <code>Keeper_types_support</code> signature.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_types</code> metrics store facade leaves</td>
+            <td><span class="status now">draft PR #18566</span></td>
+            <td>Stop exposing metrics, PR-action metrics, and execution-receipt store helpers through the broad <code>Keeper_types</code> facade. Callers now use <code>Keeper_types_support</code> for dated metrics stores and legacy metrics fallback paths.</td>
+            <td>Backstop grep is clean for <code>Keeper_types.keeper_metrics_*</code>, <code>Keeper_types.keeper_pr_action_metrics_store</code>, and <code>Keeper_types.keeper_execution_receipt_store</code>. <code>Keeper_types.mli</code> no longer advertises those store helpers.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.write_meta_with_retry</code> wrapper</td>

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -559,7 +559,7 @@ Keeper turn에서 어떤 "skill" 경로를 사용할지 결정:
 
 ### 15.2 keeper_types.ml include chain
 
-`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 support helper를 선별 re-export하지만 구현 include chain 자체는 남아 있어 가독성이 낮다.
+`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history/metrics store helper를 `Keeper_types_support` 소유로 돌렸지만, 일부 support helper 선별 re-export와 구현 include chain 자체는 남아 있어 가독성이 낮다.
 
 ### 15.3 keeper_memory 계층의 include chain
 

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -479,7 +479,7 @@ let handoff_event_json (event : handoff_event) =
 ;;
 
 let read_keeper_metric_records ?since ?until (config : Coord.config) keeper_name =
-  let store = Keeper_types.keeper_metrics_store config keeper_name in
+  let store = Keeper_types_support.keeper_metrics_store config keeper_name in
   match since, until with
   | Some _, _ | _, Some _ ->
     let since, until = date_bounds ?since ?until () in

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -149,7 +149,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
             max 0 (m.runtime.compaction_rt.last_before_tokens - m.runtime.compaction_rt.last_after_tokens)
           in
 
-          let metrics_store = Keeper_types.keeper_metrics_store config m.name in
+          let metrics_store = Keeper_types_support.keeper_metrics_store config m.name in
           (* Cap metrics lines to avoid O(n) slowdown as keepers accumulate turns.
              series_points (120) suffices for the chart; 500 covers 24h summary.
              Previous value of 12000 caused 60K+ lines across 5 keepers. *)
@@ -160,7 +160,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
             let dated = Dated_jsonl.read_recent_lines metrics_store n in
             if dated <> [] then dated
             else
-              let metrics_path = Keeper_types.keeper_metrics_path config m.name in
+              let metrics_path = Keeper_types_support.keeper_metrics_path config m.name in
               Keeper_memory.read_file_tail_lines metrics_path
                 ~max_bytes:metrics_window_max_bytes ~max_lines:n
           in
@@ -170,7 +170,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
           in
           let pr_action_metrics_lines =
             let action_store =
-              Keeper_types.keeper_pr_action_metrics_store config m.name
+              Keeper_types_support.keeper_pr_action_metrics_store config m.name
             in
             Dated_jsonl.read_recent_lines action_store metrics_cap
           in

--- a/lib/dashboard/dashboard_http_keeper_feeds.ml
+++ b/lib/dashboard/dashboard_http_keeper_feeds.ml
@@ -20,13 +20,13 @@ let keeper_cost_aggregates_json
   let keeper_items =
     List.map
       (fun (m : Keeper_types.keeper_meta) ->
-        let metrics_store = Keeper_types.keeper_metrics_store config m.name in
+        let metrics_store = Keeper_types_support.keeper_metrics_store config m.name in
         let all_metrics_lines =
           let dated = Dated_jsonl.read_recent_lines metrics_store 500 in
           if dated <> []
           then dated
           else (
-            let metrics_path = Keeper_types.keeper_metrics_path config m.name in
+            let metrics_path = Keeper_types_support.keeper_metrics_path config m.name in
             Keeper_memory.read_file_tail_lines
               metrics_path
               ~max_bytes:200000

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -6,12 +6,12 @@ open Dashboard_http_keeper_types
 open Keeper_status_bridge
 
 let recent_keeper_metric_jsons (config : Coord.config) name =
-  let metrics_store = Keeper_types.keeper_metrics_store config name in
+  let metrics_store = Keeper_types_support.keeper_metrics_store config name in
   let lines =
     let dated = Dated_jsonl.read_recent_lines metrics_store 80 in
     if dated <> [] then dated
     else
-      let metrics_path = Keeper_types.keeper_metrics_path config name in
+      let metrics_path = Keeper_types_support.keeper_metrics_path config name in
       Keeper_memory.read_file_tail_lines metrics_path
         ~max_bytes:120000 ~max_lines:80
   in

--- a/lib/keeper/keeper_exec_status_metrics.ml
+++ b/lib/keeper/keeper_exec_status_metrics.ml
@@ -534,11 +534,11 @@ let json_iso_opt json =
       if ts_unix > 0.0 then Some (Dashboard_utils.iso_of_unix ts_unix) else None
 
 let read_recent_metrics_lines config keeper_name =
-  let store = Keeper_types.keeper_metrics_store config keeper_name in
+  let store = Keeper_types_support.keeper_metrics_store config keeper_name in
   let dated = Dated_jsonl.read_recent_lines store 8 in
   if dated <> [] then dated
   else
-    let metrics_path = Keeper_types.keeper_metrics_path config keeper_name in
+    let metrics_path = Keeper_types_support.keeper_metrics_path config keeper_name in
     Keeper_memory.read_file_tail_lines metrics_path ~max_bytes:40000 ~max_lines:8
 
 let latest_snapshot_of_lines lines ~parse_snapshot ~has_legacy_shape =
@@ -639,7 +639,7 @@ let latest_tool_audit_snapshot_from_decisions config keeper_name =
 
 let latest_tool_audit_snapshot_from_metrics config keeper_name =
   let lines = read_recent_metrics_lines config keeper_name in
-  let metrics_path = Keeper_types.keeper_metrics_path config keeper_name in
+  let metrics_path = Keeper_types_support.keeper_metrics_path config keeper_name in
   let report_drop ~reason ~detail =
     report_persistence_read_drop
       ~surface:metrics_tool_audit_persistence_surface

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -67,7 +67,9 @@ let write_heartbeat_snapshot
       ~(timing_filled : int)
   : unit
   =
-  let metrics_store = keeper_metrics_store ctx.config meta_current.name in
+  let metrics_store =
+    Keeper_types_support.keeper_metrics_store ctx.config meta_current.name
+  in
   let cascade_models =
     Cascade_runtime.models_of_cascade_name
       (Cascade_name.of_string_exn (Keeper_types.cascade_name_of_meta meta_current))

--- a/lib/keeper/keeper_hooks_oas_pr_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_pr_metrics.ml
@@ -153,7 +153,7 @@ let append_pr_work_action_metrics
   match events with
   | [] -> ()
   | _ ->
-      let store = Keeper_types.keeper_pr_action_metrics_store config meta.name in
+      let store = Keeper_types_support.keeper_pr_action_metrics_store config meta.name in
       List.iter
         (fun event ->
            let now = Time_compat.now () in

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -58,8 +58,8 @@ let handle_keeper_list ctx args : tool_result =
           let (compact_ratio_gate, compact_message_gate, compact_token_gate) =
             compaction_policy_of_keeper m
           in
-          let metrics_store = keeper_metrics_store ctx.config m.name in
-          let metrics_path = keeper_metrics_path ctx.config m.name in
+          let metrics_store = Keeper_types_support.keeper_metrics_store ctx.config m.name in
+          let metrics_path = Keeper_types_support.keeper_metrics_path ctx.config m.name in
           let metrics_window_lines =
             let dated = Dated_jsonl.read_recent_lines metrics_store 120 in
             if dated <> [] then dated

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -282,8 +282,8 @@ let handle_keeper_status ctx args : tool_result =
 
          let models_resolved = `List [] in
 
-         let metrics_store = keeper_metrics_store ctx.config m.name in
-         let metrics_path = keeper_metrics_path ctx.config m.name in
+         let metrics_store = Keeper_types_support.keeper_metrics_store ctx.config m.name in
+         let metrics_path = Keeper_types_support.keeper_metrics_path ctx.config m.name in
          let memory_bank_path = keeper_memory_bank_path ctx.config m.name in
          let generation_index_path =
            keeper_generation_index_path ctx.config m.name

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -14,8 +14,8 @@ include Keeper_meta_contract
    can focus on keeper meta store I/O and the public compatibility surface. *)
 include Keeper_meta_json
 
-(* Model selection, path utilities, and JSONL helpers
-   extracted to Keeper_types_support *)
+(* Support helpers are implemented in Keeper_types_support. The public
+   signature exposes only selected helpers while callers migrate to the owner. *)
 include Keeper_types_support
 
 (* Durable meta store I/O and CAS write helpers. *)

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -1,9 +1,8 @@
 (** Keeper_types -- shared keeper contract, registry/store helpers,
     path resolution, and model-selection utilities.
 
-    Re-exports everything from {!Keeper_types_profile} (context, schemas,
-    profile defaults, path helpers) and {!Keeper_types_support}
-    (model selection, JSONL helpers, metrics store).
+    Re-exports keeper profile contracts plus selected support helpers. Support
+    stores and JSONL helpers are owned by {!Keeper_types_support}.
 
     Spec navigation (OCaml -> TLA+) — plan §19 anchor pattern.  Sibling
     to #11612 (rollover) and #11614 (post_turn).  Authoritative spec
@@ -443,21 +442,6 @@ val session_base_dir_ : Coord.config -> string
 (** Check API key availability for the given model labels via
     [Cascade_runtime]. *)
 val ensure_api_keys_for_labels : string list -> (unit, string) result
-
-(** Single-file metrics path kept for fallback reads. *)
-val keeper_metrics_path : Coord.config -> string -> string
-
-(** Date-split metrics store:
-    [.masc/keepers/<name>/metrics/YYYY-MM/DD.jsonl]. *)
-val keeper_metrics_store : Coord.config -> string -> Dated_jsonl.t
-
-(** Date-split sparse PR action metrics store:
-    [.masc/keepers/<name>/pr-action-metrics/YYYY-MM/DD.jsonl]. *)
-val keeper_pr_action_metrics_store : Coord.config -> string -> Dated_jsonl.t
-
-(** Date-split execution-receipt store:
-    [.masc/keepers/<name>/execution-receipts/YYYY-MM/DD.jsonl]. *)
-val keeper_execution_receipt_store : Coord.config -> string -> Dated_jsonl.t
 
 val keeper_memory_bank_path : Coord.config -> string -> string
 val keeper_progress_path : Coord.config -> string -> string

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -42,7 +42,7 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
       Some (scheduled_autonomous_outcome_for_result result)
     else None
   in
-  let metrics_store = keeper_metrics_store config meta.name in
+  let metrics_store = Keeper_types_support.keeper_metrics_store config meta.name in
   let usage_json =
     if result.usage_reported then
       `Assoc

--- a/lib/operator/operator_control_context_snapshot.ml
+++ b/lib/operator/operator_control_context_snapshot.ml
@@ -47,12 +47,12 @@ let keeper_context_snapshot_from_metrics_json (json : Yojson.Safe.t) =
 
 let latest_keeper_context_snapshot_from_files config keeper_name =
   let metrics_lines =
-    let store = Keeper_types.keeper_metrics_store config keeper_name in
+    let store = Keeper_types_support.keeper_metrics_store config keeper_name in
     let dated = Dated_jsonl.read_recent_lines store 32 in
     if dated <> []
     then dated
     else (
-      let path = Keeper_types.keeper_metrics_path config keeper_name in
+      let path = Keeper_types_support.keeper_metrics_path config keeper_name in
       Keeper_memory.read_file_tail_lines path ~max_bytes:32000 ~max_lines:32)
   in
   let snapshots =

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -604,7 +604,7 @@ let keepers_json
                                  if include_recent_activity
                                  then (
                                    let store =
-                                     Keeper_types.keeper_metrics_store config name
+                                     Keeper_types_support.keeper_metrics_store config name
                                    in
                                    let lines =
                                      let dated = Dated_jsonl.read_recent_lines store 5 in
@@ -612,7 +612,7 @@ let keepers_json
                                      then dated
                                      else (
                                        let metrics_path =
-                                         Keeper_types.keeper_metrics_path config name
+                                         Keeper_types_support.keeper_metrics_path config name
                                        in
                                        Keeper_memory.read_file_tail_lines
                                          metrics_path

--- a/lib/operator/operator_control_snapshot_tool_audit.ml
+++ b/lib/operator/operator_control_snapshot_tool_audit.ml
@@ -39,12 +39,12 @@ let recent_tool_names_from_files config keeper_name =
     else []
   in
   let metrics_lines =
-    let store = Keeper_types.keeper_metrics_store config keeper_name in
+    let store = Keeper_types_support.keeper_metrics_store config keeper_name in
     let dated = Dated_jsonl.read_recent_lines store 120 in
     if dated <> []
     then dated
     else (
-      let path = Keeper_types.keeper_metrics_path config keeper_name in
+      let path = Keeper_types_support.keeper_metrics_path config keeper_name in
       Keeper_memory.read_file_tail_lines path ~max_bytes:120000 ~max_lines:120)
   in
   merge_tool_name_lists

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -273,7 +273,7 @@ let purge_keeper_artifacts config requested_name
     (remove_path_if_exists ~context:"keeper_purge")
     [
       Keeper_types.keeper_meta_path config keeper_name;
-      Keeper_types.keeper_metrics_path config keeper_name;
+      Keeper_types_support.keeper_metrics_path config keeper_name;
       Keeper_types.keeper_memory_bank_path config keeper_name;
       Keeper_types.keeper_generation_index_path config keeper_name;
       Keeper_types.keeper_policy_log_path config keeper_name;

--- a/lib/tool_keeper_ops.ml
+++ b/lib/tool_keeper_ops.ml
@@ -205,8 +205,8 @@ let keeper_brief_meta_json (meta : keeper_meta) =
       ("created_at", `String meta.created_at); ("updated_at", `String meta.updated_at);
     ]
 let keeper_list_skill_route_json config (meta : keeper_meta) =
-  let metrics_store = keeper_metrics_store config meta.name in
-  let metrics_path = keeper_metrics_path config meta.name in
+  let metrics_store = Keeper_types_support.keeper_metrics_store config meta.name in
+  let metrics_path = Keeper_types_support.keeper_metrics_path config meta.name in
   let lines =
     let dated = Dated_jsonl.read_recent_lines metrics_store 50 in
     if Stdlib.List.length dated > 0 then dated

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -6,6 +6,7 @@ module AR = Masc_mcp.Anti_rationalization
 module Coord = Masc_mcp.Coord
 module Reg = Masc_mcp.Keeper_registry
 module Keeper_types = Masc_mcp.Keeper_types
+module Keeper_types_support = Masc_mcp.Keeper_types_support
 
 let test_counter = ref 0
 
@@ -79,7 +80,7 @@ let record_handoff_metric ?(timestamp = Time_compat.now ()) ?(keeper_name = "kee
       | Some value -> [ ("to_model", `String value) ]
       | None -> [])
   in
-  let metrics_store = Keeper_types.keeper_metrics_store config keeper_name in
+  let metrics_store = Keeper_types_support.keeper_metrics_store config keeper_name in
   Dated_jsonl.append metrics_store
     (`Assoc
       [

--- a/test/test_dashboard_keeper_cost_aggregates.ml
+++ b/test/test_dashboard_keeper_cost_aggregates.ml
@@ -3,6 +3,7 @@ open Alcotest
 module Coord = Masc_mcp.Coord
 module Dashboard_http_keeper = Masc_mcp.Dashboard_http_keeper
 module Keeper_types = Masc_mcp.Keeper_types
+module Keeper_types_support = Masc_mcp.Keeper_types_support
 
 let test_counter = ref 0
 
@@ -36,7 +37,7 @@ let make_meta name =
 
 let append_metric config keeper_name fields =
   Dated_jsonl.append
-    (Keeper_types.keeper_metrics_store config keeper_name)
+    (Keeper_types_support.keeper_metrics_store config keeper_name)
     (`Assoc fields)
 
 let keeper_item json =

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -235,7 +235,7 @@ let test_tool_audit_counts_metrics_parse_drops () =
       let config = Coord.default_config base_path in
       let keeper_name = "keeper-tool-audit-metrics" in
       write_lines
-        (KT.keeper_metrics_path config keeper_name)
+        (KTS.keeper_metrics_path config keeper_name)
         [
           {|{"ts":"2026-05-07T00:00:00Z","tools_used":["masc_board_post"],"tool_call_count":1}|};
           "[]";

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4387,7 +4387,7 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
          (completed_before +. 1.0)
          completed_after;
        let metrics_store =
-         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+         Masc_mcp.Keeper_types_support.keeper_metrics_store config minimal_meta.name
        in
        let line =
          match Dated_jsonl.read_recent_lines metrics_store 1 with
@@ -4584,7 +4584,7 @@ let test_append_metrics_snapshot_treats_validated_evidence_as_tool_use () =
          ~handoff_json:None
          ();
        let metrics_store =
-         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+         Masc_mcp.Keeper_types_support.keeper_metrics_store config minimal_meta.name
        in
        let line =
          match Dated_jsonl.read_recent_lines metrics_store 1 with
@@ -4666,7 +4666,7 @@ let test_append_metrics_snapshot_counts_only_mode_violation_refs () =
          ~handoff_json:None
          ();
        let metrics_store =
-         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+         Masc_mcp.Keeper_types_support.keeper_metrics_store config minimal_meta.name
        in
        let line =
          match Dated_jsonl.read_recent_lines metrics_store 1 with
@@ -4734,7 +4734,7 @@ let test_append_metrics_snapshot_nulls_unreported_usage () =
          ~handoff_json:None
          ();
        let metrics_store =
-         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+         Masc_mcp.Keeper_types_support.keeper_metrics_store config minimal_meta.name
        in
        let line =
          match Dated_jsonl.read_recent_lines metrics_store 1 with
@@ -4835,7 +4835,7 @@ let test_append_metrics_snapshot_persists_cache_usage () =
          ~handoff_json:None
          ();
        let metrics_store =
-         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+         Masc_mcp.Keeper_types_support.keeper_metrics_store config minimal_meta.name
        in
        let line =
          match Dated_jsonl.read_recent_lines metrics_store 1 with
@@ -4945,7 +4945,7 @@ let test_append_metrics_snapshot_marks_untrusted_usage () =
          ~handoff_json:None
          ();
        let metrics_store =
-         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+         Masc_mcp.Keeper_types_support.keeper_metrics_store config minimal_meta.name
        in
        let line =
          match Dated_jsonl.read_recent_lines metrics_store 1 with

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -2084,7 +2084,7 @@ let test_keeper_status_exposes_model_observability () =
       in
       Alcotest.(check bool) "keeper up ok" true ok;
       Dated_jsonl.append
-        (Keeper_types.keeper_metrics_store config keeper_name)
+        (Keeper_types_support.keeper_metrics_store config keeper_name)
         (`Assoc
           [
             ("ts", `String (Masc_domain.now_iso ()));
@@ -2104,7 +2104,7 @@ let test_keeper_status_exposes_model_observability () =
                 ] );
           ]);
       Dated_jsonl.append
-        (Keeper_types.keeper_metrics_store config keeper_name)
+        (Keeper_types_support.keeper_metrics_store config keeper_name)
         (`Assoc
           [
             ("ts", `String (Masc_domain.now_iso ()));
@@ -2263,7 +2263,7 @@ let test_keeper_status_ignores_stale_cascade_observation () =
       in
       let stale_selected_model = "stale:old-path" in
       Dated_jsonl.append
-        (Keeper_types.keeper_metrics_store config keeper_name)
+        (Keeper_types_support.keeper_metrics_store config keeper_name)
         (`Assoc
           [
             ("ts", `String (Masc_domain.now_iso ()));

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -264,7 +264,7 @@ let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =
       (match Keeper_types.write_meta config updated_meta with
       | Ok () -> ()
       | Error err -> Alcotest.fail err);
-      let metrics_store = Keeper_types.keeper_metrics_store config keeper_name in
+      let metrics_store = Keeper_types_support.keeper_metrics_store config keeper_name in
       Dated_jsonl.append metrics_store
         (`Assoc
           [
@@ -914,7 +914,7 @@ let test_snapshot_lightweight_summary_keeps_tool_audit () =
       in
       Alcotest.(check bool) "keeper up ok" true ok;
       Keeper_keepalive.stop_keepalive keeper_name;
-      let metrics_store = Keeper_types.keeper_metrics_store config keeper_name in
+      let metrics_store = Keeper_types_support.keeper_metrics_store config keeper_name in
       let metrics_dir = Dated_jsonl.base_dir metrics_store in
       cleanup_dir metrics_dir;
       Fs_compat.mkdir_p metrics_dir;


### PR DESCRIPTION
## Summary
- remove `Keeper_types` public re-exports for metrics store/path, PR-action metrics store, and execution-receipt store helpers
- route production and test callers to `Keeper_types_support`
- update the legacy purge HTML ledger and keeper spec note

## Verification
- `ocamlformat --check` on changed OCaml files
- `rg` backstop for retired `Keeper_types.keeper_metrics_*` / PR-action / execution-receipt store paths
- `git diff --check`
- `scripts/audit-keeper-tool-boundary-matrix.sh`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/stringly-boundary-ratchet.sh`
- `scripts/oas-boundary-ratchet.sh`
- `scripts/lint/no-unknown-permissive-default.sh`
- `scripts/lint/no-ocaml-comment-terminator-trap.sh`
- `scripts/lint-ignore-without-comment.sh`
- `scripts/lint/godfile-size-regression.sh`
- `scripts/code-smell-ratchet.sh`
- `scripts/ci/check-determinism-contract.sh`

Focused Dune check attempted: `scripts/dune-local.sh build test/test_keeper_exec_status.exe test/test_dashboard_keeper_cost_aggregates.exe test/test_operator_control_snapshot.exe`, blocked with exit 75 by machine-wide bare Dune guard; did not bypass.