### PR TITLE
refactor(http): remove dead Http_server_eio.start + Shutdown exception (35 LoC)

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -778,38 +778,3 @@ let run ~sw ~net ~clock config routes =
         accept_loop ()
   in
   accept_loop ()
-
-(** Graceful shutdown exception *)
-exception Shutdown
-
-(** Convenience function to start server *)
-let start ?(config = default_config) ?(routes = default_routes) () =
-  Eio_main.run @@ fun env ->
-  Masc_runtime_events.start_listener ();
-  let net = Eio.Stdenv.net env in
-  let clock = Eio.Stdenv.clock env in
-
-  (* Graceful shutdown setup *)
-  let switch_ref = Atomic.make None in
-  let shutdown_initiated = Atomic.make false in
-  let initiate_shutdown signal_name =
-    if not (Atomic.get shutdown_initiated) then begin
-      Atomic.set shutdown_initiated true;
-      Log.Http.info "MASC MCP: Received %s, shutting down gracefully..." signal_name;
-      match Atomic.get switch_ref with
-      | Some sw -> Eio.Switch.fail sw Shutdown
-      | None -> ()
-    end
-  in
-  Sys.set_signal Sys.sigterm (Sys.Signal_handle (fun _ -> initiate_shutdown "SIGTERM"));
-  Sys.set_signal Sys.sigint (Sys.Signal_handle (fun _ -> initiate_shutdown "SIGINT"));
-
-  (try
-    Eio.Switch.run @@ fun sw ->
-    Atomic.set switch_ref (Some sw);
-    run ~sw ~net ~clock config routes
-  with
-  | Shutdown ->
-      Log.Http.info "MASC MCP: Shutdown complete."
-  | Eio.Cancel.Cancelled _ ->
-      Log.Http.info "MASC MCP: Shutdown complete.")


### PR DESCRIPTION
## Summary
First actual code improvement from the masc-mcp OCaml bestpractice plan
(see [me#1175](https://github.com/jeong-sik/me/pull/1175) Sprint 1 evidence).

Removes 35 LoC of confirmed dead code: `let start` convenience server
entry + its sole-use `exception Shutdown` from `lib/http_server_eio.ml`.

## 5-prong audit evidence (me#1175 commit `528f14bf`)

| Prong | Pattern | Result |
|---|---|---:|
| 1. qualified name | `Http_server_eio.start` in `lib/ bin/ test/` | **0** |
| 2. `open Module` + bare | `open Http_server_eio` files | **0** |
| 3. `include Module` | facade re-export | **0** |
| 4. module alias (43 sites) | `<alias>.start` across `Http`/`Http_eio`/`Http_server`/`Http_server_eio` | **0** |
| 5. test file references | `start` in `test_http_server_eio*.ml` | **0** (substring `String.starts_with` only) |
| +1. mli surface | `val start` in 298-LoC mli | **absent** — externally unreachable |
| +2. ml self-call | `start` elsewhere in 815-LoC ml | **0** — only definition site |

## Build verification (RFC-0056 G4 equivalent)

| | Baseline (origin/main `90b902497`) | After this change |
|---|---:|---:|
| `dune build @check` errors | 11 | 11 |
| Identical error set | — | **yes** (diff exit 0) |
| `masc_mcp__Http_server_eio.cmo` target | — | **clean compile** |

→ **build-delta-zero**. The 11 pre-existing errors live in `keeper_turn_up_create.ml`, `test_keeper_*.ml`, `test_mcp_server_eio.ml` — unrelated to this file. Existing main breakage matches memory `project_masc_mcp_loop_session_2026_05_24`.

## P0-2 baseline impact

After this PR, `lib/` has **0 production `Eio_main.run` invocations**. Only the inline-test idiom remains at `cdal_runtime/autonomy_exec.ml:364` (under `[@@@coverage off]`, approved test pattern per Sprint 1 evidence). This sets a strong P0-2 baseline invariant for the RFC-0178 family.

## Adjacent finding — NOT bundled (intentional)

`Masc_runtime_events.start_listener` loses its only production caller. Production was *already* silently uninitialized (`test/test_masc_runtime_events.ml` is the only other caller). Per evidence note guidance: **separate follow-up PR**, not bundled here, to avoid mixing concerns.

## Workaround signature self-check (CLAUDE.md `feedback_telemetry_as_fix_self_recurrence`)

| Signature | Status |
|---|---|
| Telemetry-as-fix | ❌ removes code, no counters added |
| String classifier | ❌ no |
| N-of-M | ❌ M-of-M cleanup, single block |
| Catch-all addition | ❌ removes catch-all `\| Eio.Cancel.Cancelled _` arm |
| Cap/cooldown | ❌ no |
| Test backdoor | ❌ no |
| N-site typo fix | ❌ single block |

All 7 pass → no Override path needed.

## Test plan
- [x] `dune build @check` baseline vs post diff (exit 0)
- [x] file-specific `masc_mcp__Http_server_eio.cmo` clean compile
- [x] 5-prong audit (me#1175 evidence)
- [ ] Reviewer-side spot check of mli surface (`val start` should not appear)

## Out of scope
- `Masc_runtime_events.start_listener` orphan-init investigation
- `default_routes` (line 605) cleanup — only caller was the dead `start`; follow-up sweep candidate
- Pre-existing main breakage in keeper/test modules — separate concern

## Related
- me#1175 — analysis + Sprint 1 evidence (5-prong audit lives in `memory/masc-mcp-ocaml-bestpractice-sprint-1-evidence-2026-05-26.md`)
- masc-mcp#18563 — RFC-0178 P0-1 typed sub-library scaffold (parallel track)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>