### PR TITLE
fix(dashboard): preserve execution enrich cancellation

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -235,6 +235,7 @@ let enrich_keeper_with_diagnostic ~(config : Coord.config) (keeper_json : Yojson
           in
           let trust =
             try compact_keeper_trust_json ~config ~meta with
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
             | exn ->
               Log.Dashboard.warn
                 "dashboard_execution trust enrich failed for keeper %s: %s"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -2234,6 +2234,12 @@ let test_http_cancel_response_contracts () =
        ~anchor:{|else dispatch_route ~routes ~request ~path reqd|}
        ~patterns:[ {|Eio.Cancel.Cancelled _ as exn|}; {|raise exn|} ]
        ~max_lines:8);
+  check bool "dashboard execution trust enrich preserves cancellation propagation" true
+    (file_contains_nearby_line_with_patterns
+       "lib/dashboard/dashboard_execution.ml"
+       ~anchor:{|try compact_keeper_trust_json ~config ~meta with|}
+       ~patterns:[ {|Eio.Cancel.Cancelled _ as exn|}; {|raise exn|} ]
+       ~max_lines:3);
   check bool "main_eio suppresses stale httpun response writes" true
     (file_contains_pattern "bin/main_eio.ml" {|let safe_reqd_respond|}
     && file_contains_pattern "bin/main_eio.ml"


### PR DESCRIPTION
## Summary
- re-raise Eio cancellation from dashboard execution trust enrich instead of logging it as per-keeper WARN noise
- add source guard so the cancellation arm stays ahead of the generic trust-enrich catch-all

## Evidence
- logs: 86 dashboard_execution slow renders, 21 render timeouts, and repeated trust enrich Cancelled Eio Fiber.Not_first WARNs in /Users/dancer/me/.masc/logs/system_log_2026-05-25.jsonl

## Verification
- ocamlformat --check lib/dashboard/dashboard_execution.ml test/test_ci_hardening_source.ml
- ocamlc -stop-after parsing lib/dashboard/dashboard_execution.ml
- ocamlc -stop-after parsing test/test_ci_hardening_source.ml
- git diff --check
- scripts/dune-local.sh build test/test_ci_hardening_source.exe (blocked by existing bare Dune processes outside wrapper; no code failure observed)