### PR TITLE
refactor(keeper): record descriptor route evidence

### DIFF
--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -90,10 +90,12 @@ val route_evidence_json_of_tool_io :
   input:Yojson.Safe.t ->
   output_text:string ->
   Yojson.Safe.t option
-(** [route_evidence_json_of_tool_io] extracts first-class route proof from
-    keeper git/gh tool I/O. The evidence includes redacted command/cwd/path
-    from the input plus route/status fields such as [via], [sandbox_profile],
-    [git_creds_enabled], [network_mode], [status], and PR URL when present. *)
+(** [route_evidence_json_of_tool_io] extracts first-class route proof from a
+    keeper tool call. Descriptor-backed calls always include descriptor route
+    fields such as [descriptor_id], [public_name], [canonical_name], [executor],
+    [backend], [sandbox], and policy labels. Runtime route/status fields such
+    as [via], [sandbox_profile], [git_creds_enabled], [network_mode], [status],
+    redacted command/cwd/path, and PR URL are added when present. *)
 
 val init : ?cluster_name:string -> base_path:string -> unit -> unit
 (** [init ?cluster_name ~base_path ()] creates the cluster-aware Dated_jsonl

--- a/lib/keeper_tool_call_log_route_evidence.ml
+++ b/lib/keeper_tool_call_log_route_evidence.ml
@@ -108,6 +108,30 @@ let parse_tool_output_json_sanitized text =
   | Yojson.Json_error msg -> Error msg
 ;;
 
+let assoc_fields = function
+  | `Assoc fields -> fields
+  | _ -> []
+;;
+
+let descriptor_for_tool_name tool_name =
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
+  match Agent_tool_descriptor.find_public stripped with
+  | Some descriptor -> Some descriptor
+  | None ->
+    (match Keeper_tool_alias.canonical_internal_name tool_name with
+     | None -> None
+     | Some internal_name ->
+       (match Agent_tool_descriptor.public_descriptors_for_internal internal_name with
+        | descriptor :: _ -> Some descriptor
+        | [] -> None))
+;;
+
+let descriptor_evidence_fields tool_name =
+  match descriptor_for_tool_name tool_name with
+  | None -> []
+  | Some descriptor -> Agent_tool_descriptor.route_evidence_json descriptor |> assoc_fields
+;;
+
 let route_evidence_json_of_tool_io ~max_output_len ~tool_name ~input ~output_text =
   let route_text = route_text_for_evidence output_text in
   let parsed_output =
@@ -146,11 +170,12 @@ let route_evidence_json_of_tool_io ~max_output_len ~tool_name ~input ~output_tex
     | Some json -> route_output_url json route_text
     | None -> github_pull_url_of_text route_text
   in
-  if Option.is_none route_json && Option.is_none pr_url
+  let descriptor_fields = descriptor_evidence_fields tool_name in
+  if descriptor_fields = [] && Option.is_none route_json && Option.is_none pr_url
   then None
   else (
     let safe_input_string = route_safe_input_string ~max_output_len in
-    let fields =
+    let dynamic_fields =
       []
       |> add_string "pr_url" pr_url
       |> add_json
@@ -170,7 +195,5 @@ let route_evidence_json_of_tool_io ~max_output_len ~tool_name ~input ~output_tex
       |> add_string "command" (safe_input_string command)
       |> add_string "tool_name" (Some tool_name)
     in
-    match fields with
-    | [ "tool_name", _ ] -> None
-    | _ -> Some (`Assoc (List.rev fields)))
+    Some (`Assoc (descriptor_fields @ List.rev dynamic_fields)))
 ;;

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -422,6 +422,15 @@ let test_route_evidence_stored_for_git_push () =
       Alcotest.(check (option string)) "tool name"
         (Some "tool_execute")
         (Safe_ops.json_string_opt "tool_name" evidence);
+      Alcotest.(check (option string)) "descriptor id"
+        (Some "agent.execute")
+        (Safe_ops.json_string_opt "descriptor_id" evidence);
+      Alcotest.(check (option string)) "public name"
+        (Some "Execute")
+        (Safe_ops.json_string_opt "public_name" evidence);
+      Alcotest.(check (option string)) "canonical name"
+        (Some "tool_execute")
+        (Safe_ops.json_string_opt "canonical_name" evidence);
       Alcotest.(check (option string)) "command captured"
         (Some "git push -u origin [REDACTED]")
         (Safe_ops.json_string_opt "command" evidence);
@@ -527,12 +536,12 @@ let test_route_evidence_stored_for_blob_backed_git_push () =
         (Safe_ops.json_string_opt "command" evidence)
     | _ -> Alcotest.fail "expected exactly one entry")
 
-let test_route_evidence_skips_unproven_filesystem_calls () =
+let test_route_evidence_records_descriptor_for_filesystem_calls () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
       ~keeper_name:"executor"
-      ~tool_name:"tool_read_file"
-      ~input:(`Assoc [ ("path", `String "README.md") ])
+      ~tool_name:"ReadFile"
+      ~input:(`Assoc [ ("file_path", `String "README.md") ])
       ~output_text:"file contents"
       ~success:true
       ~duration_ms:4.0
@@ -541,10 +550,28 @@ let test_route_evidence_skips_unproven_filesystem_calls () =
     Alcotest.(check int) "entry persisted" 1 (List.length entries);
     match entries with
     | [ entry ] ->
-      Alcotest.(check bool) "route evidence absent without proof" true
-        (match Yojson.Safe.Util.member "route_evidence" entry with
-         | `Null -> true
-         | _ -> false)
+      let evidence = Yojson.Safe.Util.member "route_evidence" entry in
+      Alcotest.(check (option string)) "tool name"
+        (Some "ReadFile")
+        (Safe_ops.json_string_opt "tool_name" evidence);
+      Alcotest.(check (option string)) "descriptor id"
+        (Some "agent.read_file")
+        (Safe_ops.json_string_opt "descriptor_id" evidence);
+      Alcotest.(check (option string)) "public name"
+        (Some "ReadFile")
+        (Safe_ops.json_string_opt "public_name" evidence);
+      Alcotest.(check (option string)) "canonical name"
+        (Some "tool_read_file")
+        (Safe_ops.json_string_opt "canonical_name" evidence);
+      Alcotest.(check (option string)) "executor"
+        (Some "filesystem")
+        (Safe_ops.json_string_opt "executor" evidence);
+      Alcotest.(check (option string)) "backend"
+        (Some "sandbox_process")
+        (Safe_ops.json_string_opt "backend" evidence);
+      Alcotest.(check (option string)) "sandbox"
+        (Some "backend_selected")
+        (Safe_ops.json_string_opt "sandbox" evidence)
     | _ -> Alcotest.fail "expected exactly one entry")
 
 let test_non_object_input_still_logs_action_radius () =
@@ -996,8 +1023,8 @@ let () =
             test_route_evidence_extracts_pr_url_from_gh_output
         ; eio_test "route evidence reads blob-backed git push preview"
             test_route_evidence_stored_for_blob_backed_git_push
-        ; eio_test "route evidence skips unproven filesystem calls"
-            test_route_evidence_skips_unproven_filesystem_calls
+        ; eio_test "route evidence records descriptor for filesystem calls"
+            test_route_evidence_records_descriptor_for_filesystem_calls
         ; eio_test "non-object input still logs action radius"
             test_non_object_input_still_logs_action_radius
         ; eio_test "dashboard aggregate groups runtime fields"


### PR DESCRIPTION
## Summary
- record Agent_tool_descriptor route evidence for descriptor-backed tool calls even when runtime output has no route JSON
- keep runtime fields like via/sandbox_profile/status/PR URL as additive evidence
- update tool-call log tests so ReadFile proves descriptor routing instead of suppressing evidence

## Verification
- ocamlformat --check lib/keeper_tool_call_log_route_evidence.ml lib/keeper_tool_call_log.mli test/test_keeper_tool_call_log.ml
- git diff --check
- blocked: scripts/dune-local.sh build test/test_keeper_tool_call_log.exe refused to start because multiple bare Dune processes are already running outside the repo wrapper