### PR TITLE
refactor(keeper): move runtime routing projection to resolution

### DIFF
--- a/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
+++ b/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
@@ -401,21 +401,21 @@ RFC-OAS-013 §2.1 v2의 `if meta.name = "imseonghan"` 패턴 거부. 대신 *con
 ### §6.2 Parity Test (PR-6)
 
 ```ocaml
-(* test/test_dispatch_disclosure_parity.ml *)
+(* test/test_tool_resolution_runtime_projection.ml *)
 let () = QCheck.Test.check_exn @@ QCheck.Test.make
   ~name:"boot_decision = runtime_decision"
   ~count:1000
   (QCheck.string)
   (fun tool_name ->
     let boot = Keeper_tool_policy_config.is_known_policy_tool_name tool_name in
-    let runtime = Keeper_tool_disclosure.runtime_decision tool_name in
+    let runtime = Keeper_tool_resolution.runtime_decision tool_name in
     Bool.equal boot (decision_to_bool runtime))
 ```
 
 ### §6.3 Shadow Mode (PR-6 → PR-7)
 
 PR-6 merge 후 24h:
-1. 새 unified resolver와 legacy disclosure routing 둘 다 실행
+1. 새 unified resolver와 previous runtime routing 둘 다 실행
 2. Result divergence를 `Audit_log.record ~event:Shadow_divergence`로 기록
 3. 24h 무 divergence 확인 후 PR-7 진행
 

--- a/lib/keeper/keeper_agent_run_tool_observation.ml
+++ b/lib/keeper/keeper_agent_run_tool_observation.ml
@@ -46,7 +46,7 @@ let analyze
       ~observed_tool_names
   in
   let canonical_tool_names =
-    List.map Keeper_tool_disclosure.canonical_tool_name_observed tool_names
+    List.map Keeper_tool_resolution.canonical_tool_name_observed tool_names
   in
   let unexpected_tool_names =
     Keeper_tool_disclosure.unexpected_tool_names

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -250,7 +250,7 @@ let tools_for_gated_affordance = function
 let satisfying_tools_for_turn ~(turn_affordances : string list) ~(allowed_tool_names : string list)
   : string list
   =
-  let canonicalize = Keeper_tool_disclosure.canonical_tool_name in
+  let canonicalize = Keeper_tool_resolution.canonical_tool_name in
   let allowed_set =
     List.fold_left
       (fun s n -> String_set.add (canonicalize n) s)
@@ -336,12 +336,12 @@ let tool_names_for_required_gate_surface
   in
   let canonical_required_tool_names =
     required_tool_names
-    |> List.map Keeper_tool_disclosure.canonical_tool_name
+    |> List.map Keeper_tool_resolution.canonical_tool_name
     |> Keeper_types.dedupe_keep_order
   in
   let is_explicit_required_tool_name name =
     List.mem
-      (Keeper_tool_disclosure.canonical_tool_name name)
+      (Keeper_tool_resolution.canonical_tool_name name)
       canonical_required_tool_names
   in
   let is_input_ambiguous_status_tool name =
@@ -386,7 +386,7 @@ let generic_required_actionable_tool_names ~(has_current_task : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
   let is_stay_silent name =
     String.equal
-      (Keeper_tool_disclosure.canonical_tool_name name)
+      (Keeper_tool_resolution.canonical_tool_name name)
       "keeper_stay_silent"
   in
   let can_recommend_tool name =
@@ -412,7 +412,7 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
   let is_stay_silent name =
     String.equal
-      (Keeper_tool_disclosure.canonical_tool_name name)
+      (Keeper_tool_resolution.canonical_tool_name name)
       "keeper_stay_silent"
   in
   let progress_tool_available name =
@@ -569,12 +569,12 @@ let outstanding_required_tool_names ~(required_tool_names : string list)
     ~(satisfied_tool_names : string list) =
   let satisfied =
     satisfied_tool_names
-    |> List.map Keeper_tool_disclosure.canonical_tool_name
+    |> List.map Keeper_tool_resolution.canonical_tool_name
     |> Keeper_types.dedupe_keep_order
   in
   required_tool_names
   |> List.filter (fun name ->
-    let canonical = Keeper_tool_disclosure.canonical_tool_name name in
+    let canonical = Keeper_tool_resolution.canonical_tool_name name in
     not (List.mem canonical satisfied))
   |> Keeper_types.dedupe_keep_order
 
@@ -598,7 +598,7 @@ let preferred_tool_choice_for_required_tool_names
     required_tool_names
     |> List.fold_left
          (fun acc name ->
-            let canonical = Keeper_tool_disclosure.canonical_tool_name name in
+            let canonical = Keeper_tool_resolution.canonical_tool_name name in
             if List.mem canonical allowed_tool_names
             then add_visible_required acc canonical canonical false
             else if List.mem name allowed_tool_names

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -238,7 +238,7 @@ let operator_disposition (receipt : t)
   else
     let canonical_names names =
       names
-      |> List.map Keeper_tool_disclosure.canonical_tool_name
+      |> List.map Keeper_tool_resolution.canonical_tool_name
       |> Keeper_types.dedupe_keep_order
     in
     let used_tool_names =

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -351,7 +351,7 @@ let enrich_contract_violation_reason (receipt : t) : string =
     else
       let canonical_names names =
         names
-        |> List.map Keeper_tool_disclosure.canonical_tool_name
+        |> List.map Keeper_tool_resolution.canonical_tool_name
         |> Keeper_types.dedupe_keep_order
       in
       let called =

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -193,7 +193,7 @@ let assemble_hooks
     in
     let meta_ref = ref acc.meta in
     let public_alias_pre_tool_use_guard ~tool_name ~input:_ =
-      Keeper_tool_disclosure.public_alias_guidance_for_internal_call
+      Keeper_tool_resolution.public_alias_guidance_for_internal_call
         ~visible_tool_names:acc.requested_tool_names
         tool_name
     in

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -478,7 +478,7 @@ let prepare_agent_setup
        && Keeper_tool_policy.StringSet.mem name allowed_exec_set
     then name
     else (
-      let canonical = Keeper_tool_disclosure.canonical_tool_name name in
+      let canonical = Keeper_tool_resolution.canonical_tool_name name in
       match Keeper_tool_name_projection.public_alias_for_internal canonical with
       | Some public
         when Keeper_tool_policy.StringSet.mem public universe_set
@@ -736,7 +736,7 @@ let prepare_agent_setup
       required_tool_names_for_turn
         ~current_task_required_tool_names:(current_task_required_tools ())
         ~per_call_required_tool_names:required_tool_names
-      |> List.map Keeper_tool_disclosure.canonical_tool_name
+      |> List.map Keeper_tool_resolution.canonical_tool_name
       |> Keeper_types.dedupe_keep_order
     in
     let required_tool_names =
@@ -883,13 +883,13 @@ let prepare_agent_setup
     in
     let allowed_canonical_tool_names =
       all_allowed
-      |> List.map Keeper_tool_disclosure.canonical_tool_name
+      |> List.map Keeper_tool_resolution.canonical_tool_name
       |> Keeper_types.dedupe_keep_order
     in
     let missing_required_tool_names =
       List.filter
         (fun name ->
-           let canonical = Keeper_tool_disclosure.canonical_tool_name name in
+           let canonical = Keeper_tool_resolution.canonical_tool_name name in
            not (List.mem canonical allowed_canonical_tool_names))
         required_tool_names
     in

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -25,78 +25,6 @@ let tool_usage_delta ~(before : (string * int) list) ~(after : (string * int) li
     List.init (max 0 (after_count - before_count)) (fun _ -> tool_name))
 ;;
 
-(* Three input surfaces feed this canonicalisation:
-   1. LLM-native public names (Execute/EditFile/...) — go through
-      [Keeper_tool_alias.route].
-   2. MCP protocol names ([mcp__masc__masc_board_post] etc.) — strip the
-      prefix then map via [public_masc_to_internal].
-   3. Already-internal names ([keeper_*], [masc_*]) — pass through.
-
-   Conflating them under a single [route] lookup loses (2) silently and
-   misattributes (3) as routing misses; see PR #14574 review. *)
-(* Three input surfaces, packed into an outcome variant so the pure
-   canonicalisation and the observation-emitting wrapper share one
-   decision tree. *)
-type canonicalisation_outcome = Keeper_tool_resolution.runtime_decision_outcome =
-  | Mcp_mapped of
-      { stripped : string
-      ; internal : string
-      }
-  | Route_hit of { internal : string }
-  | Already_internal of { canonical : string }
-  | Miss
-
-let canonicalise_outcome = Keeper_tool_resolution.runtime_decision
-
-(** Pure canonicalisation — no telemetry. Used by set-logic call sites
-    (required-tool canonicalisation, surface composition, satisfaction
-    checks) where every invocation should NOT count as an observation. *)
-let canonical_name name =
-  match canonicalise_outcome name with
-  | Mcp_mapped { internal; _ } -> internal
-  | Route_hit { internal } -> internal
-  | Already_internal { canonical } -> canonical
-  | Miss -> name
-;;
-
-(** Observation-emitting canonicalisation. Used at the keeper turn
-    observation site (keeper_agent_run) where each observed tool name
-    should produce exactly one [masc_keeper_tool_call_total] sample with
-    bounded labels.
-
-    Telemetry labels per branch:
-    - [Mcp_mapped]: tool = stripped (e.g. [masc_board_post]), routed_to = internal, result = ok
-    - [Route_hit]:  tool = name, routed_to = internal, result = ok
-    - [Already_internal]: tool = name, routed_to = name, result = ok
-    - [Miss]:       tool = name (normalised to "unknown" by safe_tool_label), routed_to = "none", result = miss *)
-let canonical_name_observed name =
-  (* Always strip the MCP prefix before recording [tool] so MCP-prefixed
-     descriptor public calls (e.g. [mcp__masc__Execute]) and MCP-prefixed
-     keeper internal calls (e.g. [mcp__masc__masc_board_post]) keep the
-     stripped form in the label. The stripped form is in
-     [is_known_public] or [is_known_internal] for any successful route,
-     so [safe_tool_label] preserves it. Self-review of PR #14585 caught
-     that the Route_hit branch was still recording the raw prefixed
-     name and collapsing to ["unknown"]. *)
-  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
-  match canonicalise_outcome name with
-  | Mcp_mapped { internal; _ } ->
-    Keeper_tool_alias.record_route_outcome ~tool:stripped ~routed_to:internal ~result:"ok";
-    internal
-  | Route_hit { internal } ->
-    Keeper_tool_alias.record_route_outcome ~tool:stripped ~routed_to:internal ~result:"ok";
-    internal
-  | Already_internal { canonical } ->
-    Keeper_tool_alias.record_route_outcome
-      ~tool:canonical
-      ~routed_to:canonical
-      ~result:"ok";
-    canonical
-  | Miss ->
-    Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:"none" ~result:"miss";
-    name
-;;
-
 let merge_observed_tool_names
       ~(registry_observed_tool_names : string list)
       ~(hook_observed_tool_names : string list)
@@ -149,12 +77,12 @@ let final_keeper_tool_names
   : string list
   =
   let allowed_tool_names =
-    allowed_tool_names |> List.map canonical_name |> Keeper_types.dedupe_keep_order
+    allowed_tool_names |> List.map Keeper_tool_resolution.canonical_tool_name |> Keeper_types.dedupe_keep_order
   in
   let allowed = Hashtbl.create (List.length allowed_tool_names) in
   List.iter (fun tool_name -> Hashtbl.replace allowed tool_name ()) allowed_tool_names;
-  let reported_tool_names = List.map canonical_name reported_tool_names in
-  let observed_tool_names = List.map canonical_name observed_tool_names in
+  let reported_tool_names = List.map Keeper_tool_resolution.canonical_tool_name reported_tool_names in
+  let observed_tool_names = List.map Keeper_tool_resolution.canonical_tool_name observed_tool_names in
   let tool_names =
     match observed_tool_names with
     | [] -> reported_tool_names
@@ -181,7 +109,7 @@ let result_text_for_progress_check output_text =
 let tool_result_has_material_progress ~(tool_name : string) ~(output_text : string)
   : bool
   =
-  let tool_name = canonical_name tool_name in
+  let tool_name = Keeper_tool_resolution.canonical_tool_name tool_name in
   let output_text = result_text_for_progress_check output_text |> String.trim in
   not
     (String.equal tool_name "masc_worktree_create"
@@ -192,16 +120,16 @@ let unexpected_tool_names ~(allowed_tool_names : string list) ~(tool_names : str
   : string list
   =
   let allowed_tool_names =
-    allowed_tool_names |> List.map canonical_name |> Keeper_types.dedupe_keep_order
+    allowed_tool_names |> List.map Keeper_tool_resolution.canonical_tool_name |> Keeper_types.dedupe_keep_order
   in
   let allowed = Hashtbl.create (List.length allowed_tool_names) in
   let seen = Hashtbl.create (List.length tool_names) in
   List.iter
-    (fun tool_name -> Hashtbl.replace allowed (canonical_name tool_name) ())
+    (fun tool_name -> Hashtbl.replace allowed (Keeper_tool_resolution.canonical_tool_name tool_name) ())
     allowed_tool_names;
   tool_names
   |> List.filter (fun tool_name ->
-    let canonical = canonical_name tool_name in
+    let canonical = Keeper_tool_resolution.canonical_tool_name tool_name in
     if Hashtbl.mem allowed canonical || Hashtbl.mem seen canonical
     then false
     else (
@@ -291,58 +219,6 @@ let effect_of_progress_class = function
   | Execution | Completion -> Streak_reset
 ;;
 
-let canonical_tool_name = canonical_name
-let canonical_tool_name_observed = canonical_name_observed
-
-let public_aliases_for_internal_name internal_name =
-  Keeper_tool_alias.public_names ()
-  |> List.filter (fun public ->
-    match Keeper_tool_alias.route public with
-    | Some route -> String.equal route.internal_name internal_name
-    | None -> false)
-;;
-
-let public_alias_guidance_for_internal_call
-      ~(visible_tool_names : string list)
-      (tool_name : string)
-  : string option
-  =
-  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
-  match Keeper_tool_alias.route stripped with
-  | Some _ -> None
-  | None ->
-    let canonical = canonical_tool_name stripped in
-    (match public_aliases_for_internal_name canonical with
-     | [] -> None
-     | aliases ->
-       let visible_aliases =
-         List.filter (fun alias -> List.mem alias visible_tool_names) aliases
-       in
-       let alias_words =
-         match visible_aliases with
-         | [] -> aliases
-         | _ -> visible_aliases
-       in
-       let alias_text = String.concat " or " alias_words in
-       let correction =
-         match visible_aliases with
-         | _ :: _ -> Printf.sprintf "Use %s instead." alias_text
-         | [] ->
-           Printf.sprintf
-             "No public alias for it is visible in this turn; do not invent \
-              internal tool names. Wait for a visible tool or report the blocker. \
-              Public alias%s: %s."
-             (if List.length aliases = 1 then "" else "es")
-             alias_text
-       in
-       Some
-         (Printf.sprintf
-            "%s is an internal keeper implementation tool name, not a \
-             model-facing tool. %s"
-            stripped
-            correction))
-;;
-
 let claim_context_tool_names : string list =
   Tool_name.[ Masc Claim_next; Keeper Task_claim ]
   |> List.map Tool_name.to_string
@@ -369,14 +245,14 @@ let completion_tool_names : string list =
 ;;
 
 let is_claim_tool_name name =
-  let name = canonical_tool_name name in
+  let name = Keeper_tool_resolution.canonical_tool_name name in
   match Tool_name.of_string name with
   | Some (Keeper Task_claim) | Some (Masc Claim_next) -> true
   | _ -> false
 ;;
 
 let is_claim_context_tool_name name =
-  let name = canonical_tool_name name in
+  let name = Keeper_tool_resolution.canonical_tool_name name in
   let canonical_name =
     match Tool_name.of_string name with
     | Some tool -> Tool_name.to_string tool
@@ -386,7 +262,7 @@ let is_claim_context_tool_name name =
 ;;
 
 let is_completion_tool_name name =
-  let name = canonical_tool_name name in
+  let name = Keeper_tool_resolution.canonical_tool_name name in
   let canonical_name =
     match Tool_name.of_string name with
     | Some tool -> Tool_name.to_string tool
@@ -396,7 +272,7 @@ let is_completion_tool_name name =
 ;;
 
 let is_stay_silent_tool_name name =
-  let name = canonical_tool_name name in
+  let name = Keeper_tool_resolution.canonical_tool_name name in
   match Tool_name.of_string name with
   | Some (Keeper Stay_silent) -> true
   | _ -> false
@@ -410,7 +286,7 @@ let is_keeper_observation_alias name =
 
 let tool_name_can_satisfy_required_contract name =
   let observation_alias = is_keeper_observation_alias name in
-  let name = canonical_tool_name name in
+  let name = Keeper_tool_resolution.canonical_tool_name name in
   (* Completion tools (stay_silent, release, done, etc.) intentionally
      satisfy the contract even though their effect_domain is Read_only.
      Without this exemption, analyst/janitor keepers that correctly
@@ -432,7 +308,7 @@ let tool_name_can_satisfy_required_contract name =
 ;;
 
 let is_keeper_observation_tool_name name =
-  let name = canonical_tool_name name in
+  let name = Keeper_tool_resolution.canonical_tool_name name in
   match Tool_name.of_string name with
   | Some
       (Keeper
@@ -463,7 +339,7 @@ let required_tool_satisfaction ?(satisfying_tools : string list = [])
   (call : Agent_sdk.Completion_contract.tool_call)
   : (unit, string) result
   =
-  let tool_name = canonical_tool_name call.name in
+  let tool_name = Keeper_tool_resolution.canonical_tool_name call.name in
   (* Generic Require_tool_use is a required-action contract at the keeper
      boundary. Passive read/status/search tools can support a later action,
      but they must not satisfy the action predicate by themselves. *)
@@ -501,9 +377,9 @@ let required_tool_satisfaction_for_required_names
   : (unit, string) result
   =
   let required_tool_names =
-    required_tool_names |> List.map canonical_tool_name |> Keeper_types.dedupe_keep_order
+    required_tool_names |> List.map Keeper_tool_resolution.canonical_tool_name |> Keeper_types.dedupe_keep_order
   in
-  let tool_name = canonical_tool_name call.name in
+  let tool_name = Keeper_tool_resolution.canonical_tool_name call.name in
   if List.mem tool_name required_tool_names
   then Ok ()
   else required_tool_satisfaction ~satisfying_tools call
@@ -545,7 +421,7 @@ let classify_tool_progress name =
   if is_keeper_observation_alias name
   then Passive_status
   else
-  let name = canonical_tool_name name in
+  let name = Keeper_tool_resolution.canonical_tool_name name in
   if is_completion_tool_name name
   then Completion
   else if is_claim_context_tool_name name
@@ -577,7 +453,7 @@ let classify_tool_progress_with_outcome name outcome =
 ;;
 
 let is_owned_task_coordination_progress_tool_name name =
-  let name = canonical_tool_name name in
+  let name = Keeper_tool_resolution.canonical_tool_name name in
   match Tool_name.of_string name with
   | Some (Tool_name.Keeper Tool_name.Keeper.Handoff) -> true
   | _ -> false
@@ -587,7 +463,7 @@ let is_owned_task_progress_tool_name name =
   if is_stay_silent_tool_name name
   then false
   else
-    let name = canonical_tool_name name in
+    let name = Keeper_tool_resolution.canonical_tool_name name in
     if is_completion_tool_name name || is_owned_task_coordination_progress_tool_name name
     then true
     else (

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -166,27 +166,6 @@ val effect_of_progress_class : tool_progress_class -> turn_effect
 val classify_tool_progress_with_outcome
   : string -> Keeper_tool_outcome.t option -> turn_effect
 
-(** Pure canonicalisation — no telemetry side-effect.
-
-    Used by set-logic call sites (required-tool canonicalisation, surface
-    composition, satisfaction checks) where every invocation should NOT
-    count as an observation event. *)
-val canonical_tool_name : string -> string
-
-(** Observation-emitting canonicalisation.
-
-    Emits exactly one [masc_keeper_tool_call_total] sample with bounded
-    [tool] / [routed_to] / [result] labels. Use only at the keeper turn
-    observation boundary (e.g. canonicalising LLM-reported tool calls in
-    [Keeper_agent_run]). Non-observation call sites should use
-    [canonical_tool_name] to avoid double-counting. *)
-val canonical_tool_name_observed : string -> string
-
-(** Return a model-facing correction when a tool call uses a keeper-internal
-    implementation name whose public alias is the supported LLM surface. *)
-val public_alias_guidance_for_internal_call
-  :  visible_tool_names:string list -> string -> string option
-
 (** Canonical names of claim-context tools (Task_claim, Claim_next). *)
 val claim_context_tool_names : string list
 

--- a/lib/keeper/keeper_tool_resolution.ml
+++ b/lib/keeper/keeper_tool_resolution.ml
@@ -176,14 +176,9 @@ type runtime_decision_outcome =
 
 (** Single-SSOT entry for runtime tool-name routing.
 
-    PR-6 moves the pure routing decision below [Keeper_tool_disclosure]
-    so runtime callers can converge on one low-dependency entry without
-    creating a module cycle. [Keeper_tool_disclosure] delegates its legacy
-    pure canonicalisation to this function for parity during migration.
-
-    PR-7~9 migrate keeper turn, MCP server, and tag-dispatch callers from
-    [Keeper_tool_disclosure.canonical_tool_name] to this entry. PR-11
-    removes the legacy wrapper in favour of this one. *)
+    Runtime callers should use this typed decision when they need provenance,
+    or [canonical_tool_name] / [canonical_tool_name_observed] when they only
+    need the pure or telemetry-emitting string projection. *)
 let runtime_decision name =
   match Keeper_tool_alias.canonical_resolution name with
   | Keeper_tool_alias.Public_mcp { stripped; internal } ->
@@ -191,3 +186,80 @@ let runtime_decision name =
   | Keeper_tool_alias.Public_alias { internal } -> Route_hit { internal }
   | Keeper_tool_alias.Internal { canonical } -> Already_internal { canonical }
   | Keeper_tool_alias.Unknown -> Miss
+
+let canonical_tool_name name =
+  match runtime_decision name with
+  | Mcp_mapped { internal; _ } -> internal
+  | Route_hit { internal } -> internal
+  | Already_internal { canonical } -> canonical
+  | Miss -> name
+;;
+
+let canonical_tool_name_observed name =
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
+  match runtime_decision name with
+  | Mcp_mapped { internal; _ } ->
+    Keeper_tool_alias.record_route_outcome ~tool:stripped ~routed_to:internal ~result:"ok";
+    internal
+  | Route_hit { internal } ->
+    Keeper_tool_alias.record_route_outcome ~tool:stripped ~routed_to:internal ~result:"ok";
+    internal
+  | Already_internal { canonical } ->
+    Keeper_tool_alias.record_route_outcome
+      ~tool:canonical
+      ~routed_to:canonical
+      ~result:"ok";
+    canonical
+  | Miss ->
+    Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:"none" ~result:"miss";
+    name
+;;
+
+let public_aliases_for_internal_name internal_name =
+  Keeper_tool_alias.public_names ()
+  |> List.filter (fun public ->
+    match Keeper_tool_alias.route public with
+    | Some route -> String.equal route.internal_name internal_name
+    | None -> false)
+;;
+
+let public_alias_guidance_for_internal_call
+      ~(visible_tool_names : string list)
+      (tool_name : string)
+  : string option
+  =
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
+  match Keeper_tool_alias.route stripped with
+  | Some _ -> None
+  | None ->
+    let canonical = canonical_tool_name stripped in
+    (match public_aliases_for_internal_name canonical with
+     | [] -> None
+     | aliases ->
+       let visible_aliases =
+         List.filter (fun alias -> List.mem alias visible_tool_names) aliases
+       in
+       let alias_words =
+         match visible_aliases with
+         | [] -> aliases
+         | _ -> visible_aliases
+       in
+       let alias_text = String.concat " or " alias_words in
+       let correction =
+         match visible_aliases with
+         | _ :: _ -> Printf.sprintf "Use %s instead." alias_text
+         | [] ->
+           Printf.sprintf
+             "No public alias for it is visible in this turn; do not invent \
+              internal tool names. Wait for a visible tool or report the blocker. \
+              Public alias%s: %s."
+             (if List.length aliases = 1 then "" else "es")
+             alias_text
+       in
+       Some
+         (Printf.sprintf
+            "%s is an internal keeper implementation tool name, not a \
+             model-facing tool. %s"
+            stripped
+            correction))
+;;

--- a/lib/keeper/keeper_tool_resolution.mli
+++ b/lib/keeper/keeper_tool_resolution.mli
@@ -52,16 +52,33 @@ type runtime_decision_outcome =
   | Miss
 
 (** [runtime_decision name] returns the pure routing decision for a
-    runtime-reported or model-reported tool name. PR-6 establishes this
-    as the low-dependency SSOT entry; [Keeper_tool_disclosure] delegates
-    to it for parity during migration. PR-7 (keeper turn), PR-8 (MCP
-    server), PR-9 (tag-dispatch) migrate runtime callers to this entry.
-    PR-11 removes the legacy disclosure wrapper.
+    runtime-reported or model-reported tool name. This module is the
+    low-dependency SSOT for runtime tool-name routing.
 
     Result variants:
     - [Mcp_mapped { stripped; internal }] — name was an MCP-prefixed
       public alias resolved to an internal canonical name.
     - [Route_hit { internal }] — alias-table hit; internal name returned.
     - [Already_internal { canonical }] — name is already in internal form.
-    - [Miss] — name does not resolve through any disclosure path. *)
+    - [Miss] — name does not resolve through any runtime route. *)
 val runtime_decision : string -> runtime_decision_outcome
+
+(** Pure canonicalisation — no telemetry side-effect.
+
+    Used by set-logic call sites (required-tool canonicalisation, surface
+    composition, satisfaction checks) where every invocation should NOT
+    count as an observation event. *)
+val canonical_tool_name : string -> string
+
+(** Observation-emitting canonicalisation.
+
+    Emits exactly one [masc_keeper_tool_call_total] sample with bounded
+    [tool] / [routed_to] / [result] labels. Use only at the keeper turn
+    observation boundary. Non-observation call sites should use
+    [canonical_tool_name] to avoid double-counting. *)
+val canonical_tool_name_observed : string -> string
+
+(** Return a model-facing correction when a tool call uses a keeper-internal
+    implementation name whose public alias is the supported LLM surface. *)
+val public_alias_guidance_for_internal_call
+  :  visible_tool_names:string list -> string -> string option

--- a/test/dune
+++ b/test/dune
@@ -216,7 +216,7 @@
   test_keeper_tool_policy_config
   test_keeper_tool_name_projection
   test_keeper_tool_resolution
-  test_dispatch_disclosure_parity
+  test_tool_resolution_runtime_projection
   test_coord_worktree_policy_path
   test_claim_post_provision_hook
   test_keeper_toml_config_validation
@@ -540,7 +540,7 @@
   test_keeper_tool_policy_config
   test_keeper_tool_name_projection
   test_keeper_tool_resolution
-  test_dispatch_disclosure_parity
+  test_tool_resolution_runtime_projection
   test_coord_worktree_policy_path
   test_claim_post_provision_hook
   test_keeper_toml_config_validation

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -7,6 +7,7 @@
 module Alias = Masc_mcp.Keeper_tool_alias
 module Descriptor = Masc_mcp.Agent_tool_descriptor
 module Disclosure = Masc_mcp.Keeper_tool_disclosure
+module Resolution = Masc_mcp.Keeper_tool_resolution
 
 let route_internal name =
   match Alias.route name with
@@ -142,7 +143,7 @@ let allowed_keeper_surface =
 
 let test_pure_alias_turn_no_longer_unexpected () =
   let observed = [ "Execute" ] in
-  let canonical = List.map Disclosure.canonical_tool_name observed in
+  let canonical = List.map Resolution.canonical_tool_name observed in
   let unexpected =
     Disclosure.unexpected_tool_names
       ~allowed_tool_names:allowed_keeper_surface
@@ -156,7 +157,7 @@ let test_pure_alias_turn_no_longer_unexpected () =
 
 let test_mixed_alias_and_internal_no_unexpected () =
   let observed = [ "ReadFile"; "keeper_board_post"; "EditFile"; "SearchWeb" ] in
-  let canonical = List.map Disclosure.canonical_tool_name observed in
+  let canonical = List.map Resolution.canonical_tool_name observed in
   let unexpected =
     Disclosure.unexpected_tool_names
       ~allowed_tool_names:allowed_keeper_surface
@@ -167,7 +168,7 @@ let test_mixed_alias_and_internal_no_unexpected () =
 
 let test_hallucinated_builtin_still_unexpected () =
   let observed = [ "Skill"; "Execute" ] in
-  let canonical = List.map Disclosure.canonical_tool_name observed in
+  let canonical = List.map Resolution.canonical_tool_name observed in
   let unexpected =
     Disclosure.unexpected_tool_names
       ~allowed_tool_names:allowed_keeper_surface
@@ -185,7 +186,7 @@ let test_mcp_prefixed_anthropic_alias_routes () =
      route lookup used the raw [name] instead of the stripped form,
      so MCP-prefixed Provider_a Code calls regressed into routing
      misses. *)
-  let canonical = Disclosure.canonical_tool_name "mcp__masc__Execute" in
+  let canonical = Resolution.canonical_tool_name "mcp__masc__Execute" in
   Alcotest.(check string)
     "mcp__masc__Execute routes through stripped form to tool_execute"
     "tool_execute"
@@ -205,7 +206,7 @@ let test_mcp_prefixed_anthropic_alias_telemetry_uses_stripped () =
       ~labels
       ()
   in
-  let _ = Disclosure.canonical_tool_name_observed "mcp__masc__Execute" in
+  let _ = Resolution.canonical_tool_name_observed "mcp__masc__Execute" in
   let after =
     Masc_mcp.Prometheus.metric_value_or_zero
       Masc_mcp.Keeper_metrics.metric_keeper_tool_call_total
@@ -224,7 +225,7 @@ let test_mcp_prefixed_keeper_internal_routes () =
      [is_known_internal stripped], not raw [name], so these are
      canonicalised to the stripped form instead of falling into [Miss]
      and being reported as unexpected. *)
-  let canonical = Disclosure.canonical_tool_name "mcp__masc__tool_execute" in
+  let canonical = Resolution.canonical_tool_name "mcp__masc__tool_execute" in
   Alcotest.(check string)
     "mcp__masc__tool_execute canonicalises to tool_execute (stripped)"
     "tool_execute"
@@ -269,7 +270,7 @@ let test_alias_canonical_internal_name_for_set_logic () =
 ;;
 
 let test_mcp_prefixed_public_masc_goal_tool_routes () =
-  let canonical = Disclosure.canonical_tool_name "mcp__masc__masc_goal_list" in
+  let canonical = Resolution.canonical_tool_name "mcp__masc__masc_goal_list" in
   Alcotest.(check string)
     "mcp__masc__masc_goal_list canonicalises to masc_goal_list"
     "masc_goal_list"
@@ -300,7 +301,7 @@ let test_mcp_prefixed_masc_public_telemetry_preserves_label () =
       ~labels
       ()
   in
-  let _ = Disclosure.canonical_tool_name_observed "mcp__masc__masc_board_post" in
+  let _ = Resolution.canonical_tool_name_observed "mcp__masc__masc_board_post" in
   let after =
     Masc_mcp.Prometheus.metric_value_or_zero
       Masc_mcp.Keeper_metrics.metric_keeper_tool_call_total
@@ -324,9 +325,9 @@ let test_canonical_tool_name_pure_does_not_increment_counter () =
       ~labels:labels_ok
       ()
   in
-  let _ = Disclosure.canonical_tool_name "Execute" in
-  let _ = Disclosure.canonical_tool_name "Execute" in
-  let _ = Disclosure.canonical_tool_name "Execute" in
+  let _ = Resolution.canonical_tool_name "Execute" in
+  let _ = Resolution.canonical_tool_name "Execute" in
+  let _ = Resolution.canonical_tool_name "Execute" in
   let after =
     Masc_mcp.Prometheus.metric_value_or_zero
       Masc_mcp.Keeper_metrics.metric_keeper_tool_call_total
@@ -341,7 +342,7 @@ let test_canonical_tool_name_pure_does_not_increment_counter () =
 
 let test_partial_tolerance_still_works () =
   let observed = [ "Skill"; "Execute" ] in
-  let canonical = List.map Disclosure.canonical_tool_name observed in
+  let canonical = List.map Resolution.canonical_tool_name observed in
   let unexpected =
     Disclosure.unexpected_tool_names
       ~allowed_tool_names:allowed_keeper_surface
@@ -358,7 +359,7 @@ let test_partial_tolerance_still_works () =
 
 let test_public_allowed_surface_accepts_canonical_alias () =
   let observed = [ "Execute" ] in
-  let canonical = List.map Disclosure.canonical_tool_name observed in
+  let canonical = List.map Resolution.canonical_tool_name observed in
   let unexpected =
     Disclosure.unexpected_tool_names
       ~allowed_tool_names:[ "Execute" ]

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -1,5 +1,6 @@
 open Alcotest
 module KTD = Masc_mcp.Keeper_tool_disclosure
+module Resolution = Masc_mcp.Keeper_tool_resolution
 
 let test_unexpected_tool_names_accepts_keeper_surface () =
   check
@@ -59,7 +60,7 @@ let test_public_alias_guidance_blocks_internal_bash () =
     (Some
        "tool_execute is an internal keeper implementation tool name, not a \
         model-facing tool. Use Execute instead.")
-    (KTD.public_alias_guidance_for_internal_call
+    (Resolution.public_alias_guidance_for_internal_call
        ~visible_tool_names:[ "Execute"; "ReadFile" ]
        "tool_execute")
 ;;
@@ -69,7 +70,7 @@ let test_public_alias_guidance_ignores_public_execute () =
     (option string)
     "public Execute is already model-facing"
     None
-    (KTD.public_alias_guidance_for_internal_call
+    (Resolution.public_alias_guidance_for_internal_call
        ~visible_tool_names:[ "Execute" ]
        "Execute")
 ;;
@@ -81,7 +82,7 @@ let test_public_alias_guidance_prefers_visible_write_alias () =
     (Some
        "tool_edit_file is an internal keeper implementation tool name, not a \
         model-facing tool. Use WriteFile instead.")
-    (KTD.public_alias_guidance_for_internal_call
+    (Resolution.public_alias_guidance_for_internal_call
        ~visible_tool_names:[ "WriteFile" ]
        "tool_edit_file")
 ;;
@@ -95,7 +96,7 @@ let test_public_alias_guidance_reports_alias_not_visible () =
         model-facing tool. No public alias for it is visible in this turn; do \
         not invent internal tool names. Wait for a visible tool or report the \
         blocker. Public alias: Execute.")
-    (KTD.public_alias_guidance_for_internal_call
+    (Resolution.public_alias_guidance_for_internal_call
        ~visible_tool_names:[ "keeper_tasks_list" ]
        "tool_execute")
 ;;

--- a/test/test_tool_resolution_runtime_projection.ml
+++ b/test/test_tool_resolution_runtime_projection.ml
@@ -2,16 +2,11 @@ open Alcotest
 
 module TR = Masc_mcp.Keeper_tool_resolution
 
-(** RFC-0084 §1.4, §6.2 — boot policy load vs runtime routing parity.
+(** RFC-0084 §1.4, §6.2 — runtime routing projection.
 
-    PR-6 introduces [Keeper_tool_resolution.runtime_decision] as the SSOT entry
-    for runtime tool-name routing. [Keeper_tool_disclosure.canonical_tool_name]
-    remains as the legacy public wrapper during migration and must preserve
-    the same canonical string result.
-
-    This test fixes that property in code so future refactors (PR-11
-    legacy removal, PR-9 migration) cannot accidentally diverge the two
-    entries without the parity test failing.
+    [Keeper_tool_resolution.runtime_decision] is the SSOT entry for runtime
+    tool-name routing. [Keeper_tool_resolution.canonical_tool_name] is the
+    pure string projection over that typed decision.
 
     Test corpus: a deterministic set of names covering the four outcome
     variants (Mcp_mapped, Route_hit, Already_internal, Miss) plus a few
@@ -19,7 +14,7 @@ module TR = Masc_mcp.Keeper_tool_resolution
 
     For each name, assert:
       canonical_string(Keeper_tool_resolution.runtime_decision name)
-        = Keeper_tool_disclosure.canonical_tool_name name
+        = Keeper_tool_resolution.canonical_tool_name name
 *)
 
 let names_to_probe =
@@ -51,8 +46,6 @@ let pp_outcome fmt o =
   | TR.Miss -> Format.fprintf fmt "Miss"
 ;;
 
-let outcome_testable = testable pp_outcome Stdlib.( = )
-
 let canonical_string name = function
   | TR.Mcp_mapped { internal; _ } -> internal
   | TR.Route_hit { internal } -> internal
@@ -63,10 +56,10 @@ let test_parity_each_name () =
   List.iter
     (fun name ->
       let by_resolution = TR.runtime_decision name in
-      let by_disclosure = Masc_mcp.Keeper_tool_disclosure.canonical_tool_name name in
+      let by_projection = TR.canonical_tool_name name in
       (check string)
-        (Printf.sprintf "runtime_decision %S = canonical_tool_name %S" name name)
-        by_disclosure
+        (Printf.sprintf "runtime_decision %S = canonical projection" name)
+        by_projection
         (canonical_string name by_resolution))
     names_to_probe
 ;;
@@ -100,7 +93,7 @@ let test_parity_mcp_prefix_strips () =
 
 let () =
   Alcotest.run
-    "RFC-0084 PR-6 dispatch ↔ disclosure parity"
+    "RFC-0084 runtime routing projection"
     [ ( "runtime-decision-parity"
       , [ test_case "parity-each-name" `Quick test_parity_each_name
         ; test_case "parity-unknown-is-miss" `Quick test_parity_unknown_is_miss


### PR DESCRIPTION
## Summary

- move pure and observed runtime tool-name canonicalization from `Keeper_tool_disclosure` to `Keeper_tool_resolution`
- move internal-tool public-alias guidance to `Keeper_tool_resolution`
- migrate runtime callers/tests off the disclosure-owned canonical routing API
- rename the old dispatch/disclosure parity test to `test_tool_resolution_runtime_projection`

## Why

`Keeper_tool_resolution` already owns the typed `runtime_decision` SSOT. Keeping `canonical_tool_name`, `canonical_tool_name_observed`, and public-alias guidance exported from `Keeper_tool_disclosure` preserved the legacy disclosure wrapper as a runtime routing owner.

## Validation

- `ocamlformat --check lib/keeper/keeper_tool_resolution.ml lib/keeper/keeper_tool_resolution.mli lib/keeper/keeper_tool_disclosure.ml lib/keeper/keeper_tool_disclosure.mli lib/keeper/keeper_run_tools_setup.ml lib/keeper/keeper_agent_tool_surface.ml lib/keeper/keeper_agent_run_tool_observation.ml lib/keeper/keeper_execution_receipt.ml lib/keeper/keeper_execution_receipt_types.ml lib/keeper/keeper_run_tools_hooks.ml test/test_tool_resolution_runtime_projection.ml test/test_keeper_tool_alias.ml test/test_keeper_tool_surface_guard.ml`
- `git diff --check origin/main..HEAD`
- `rg -n "Keeper_tool_disclosure\.canonical_tool_name|Keeper_tool_disclosure\.canonical_tool_name_observed|Keeper_tool_disclosure\.public_alias_guidance_for_internal_call|Disclosure\.canonical_tool_name|Disclosure\.canonical_tool_name_observed|KTD\.public_alias_guidance_for_internal_call|test_dispatch_disclosure_parity|dispatch_disclosure_parity|legacy disclosure wrapper|legacy public wrapper|legacy disclosure routing|\bBin\b|Masc_exec\.Bin|bin\.ml|test_bin_" lib test docs/rfc docs/design specs --glob '!_build/**' --glob '!docs/archive/**'` returned no matches

## Not Run

- `scripts/dune-local.sh build test/test_tool_resolution_runtime_projection.exe test/test_keeper_tool_alias.exe test/test_keeper_tool_surface_guard.exe lib/masc_mcp.cma` was attempted, but refused to start because multiple live bare Dune processes are bypassing the machine-wide wrapper lock.