### PR TITLE
refactor(keeper): drop api-key helper from types facade

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 12:22:20 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 12:32:49 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -373,9 +373,15 @@
           </tr>
           <tr>
             <td><code>Keeper_types</code> metrics store facade leaves</td>
-            <td><span class="status now">draft PR #18566</span></td>
+            <td><span class="status done">merged #18566</span></td>
             <td>Stop exposing metrics, PR-action metrics, and execution-receipt store helpers through the broad <code>Keeper_types</code> facade. Callers now use <code>Keeper_types_support</code> for dated metrics stores and legacy metrics fallback paths.</td>
             <td>Backstop grep is clean for <code>Keeper_types.keeper_metrics_*</code>, <code>Keeper_types.keeper_pr_action_metrics_store</code>, and <code>Keeper_types.keeper_execution_receipt_store</code>. <code>Keeper_types.mli</code> no longer advertises those store helpers.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_types.ensure_api_keys_for_labels</code> facade leaf</td>
+            <td><span class="status now">draft PR #18572</span></td>
+            <td>Stop exposing the support-owned API-key availability check through the broad <code>Keeper_types</code> facade. Keeper turn paths now call <code>Keeper_types_support.ensure_api_keys_for_labels</code> directly.</td>
+            <td>Backstop grep is clean for the removed <code>Keeper_types</code> signature value and unqualified keeper-turn calls. Existing cascade runtime tests already cover the canonical owner.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.write_meta_with_retry</code> wrapper</td>

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -559,7 +559,7 @@ Keeper turn에서 어떤 "skill" 경로를 사용할지 결정:
 
 ### 15.2 keeper_types.ml include chain
 
-`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history/metrics store helper를 `Keeper_types_support` 소유로 돌렸지만, 일부 support helper 선별 re-export와 구현 include chain 자체는 남아 있어 가독성이 낮다.
+`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history/metrics/API-key support helper를 `Keeper_types_support` 소유로 돌렸지만, 일부 support helper 선별 re-export와 구현 include chain 자체는 남아 있어 가독성이 낮다.
 
 ### 15.3 keeper_memory 계층의 include chain
 

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -159,7 +159,7 @@ let preflight_keeper_msg ctx args : (unit, string) result =
           else
             effective_model_labels_for_turn meta
         in
-        match ensure_api_keys_for_labels effective_models with
+        match Keeper_types_support.ensure_api_keys_for_labels effective_models with
         | Error e -> Error e
         | Ok () ->
           Keeper_turn_helpers.ensure_local_discovery_ready effective_models))))
@@ -255,7 +255,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
           effective_model_labels_for_turn meta
       in
       Progress.Tracker.step turn_tracker ~message:"Validating API keys" ();
-      (match ensure_api_keys_for_labels effective_models with
+      (match Keeper_types_support.ensure_api_keys_for_labels effective_models with
        | Error e ->
          Progress.stop_tracking turn_task_id;
          (false, "" ^ e)

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -439,10 +439,6 @@ val keeper_dir_ : Coord.config -> string
     creating it if missing. *)
 val session_base_dir_ : Coord.config -> string
 
-(** Check API key availability for the given model labels via
-    [Cascade_runtime]. *)
-val ensure_api_keys_for_labels : string list -> (unit, string) result
-
 val keeper_memory_bank_path : Coord.config -> string -> string
 val keeper_progress_path : Coord.config -> string -> string
 val keeper_generation_index_path : Coord.config -> string -> string

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -35,7 +35,7 @@ let build_cascade_execution
   let model_labels =
     Keeper_coordination.effective_model_labels_for_turn meta_for_cascade
   in
-  match ensure_api_keys_for_labels model_labels with
+  match Keeper_types_support.ensure_api_keys_for_labels model_labels with
   | Error e -> Error (Agent_sdk.Error.Internal e)
   | Ok () ->
     (match

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.mli
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.mli
@@ -23,7 +23,7 @@ val build_cascade_execution
     [meta]'s context.
 
     Failure modes (returned as [Error]):
-    - [ensure_api_keys_for_labels] missing required keys.
+    - [Keeper_types_support.ensure_api_keys_for_labels] missing required keys.
     - [ensure_local_discovery_ready] local-runtime discovery fail.
     - [validate_max_tokens_within_ceiling] raw_max_tokens exceeds the
       provider's [Cascade_runtime.max_output_tokens_ceiling].


### PR DESCRIPTION
## Summary
- remove `Keeper_types.ensure_api_keys_for_labels` from the public `Keeper_types` facade
- route keeper turn/pre-dispatch callers to `Keeper_types_support.ensure_api_keys_for_labels`
- update the purge ledger and keeper spec note

## Verification
- `ocamlformat --check lib/keeper/keeper_turn.ml lib/keeper/keeper_unified_turn_pre_dispatch.ml lib/keeper/keeper_unified_turn_pre_dispatch.mli lib/keeper/keeper_types.mli`
- `rg` backstop for `Keeper_types.ensure_api_keys_for_labels`, unqualified keeper-turn calls, and the removed facade signature
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/audit-keeper-tool-boundary-matrix.sh`
- `scripts/stringly-boundary-ratchet.sh`
- `scripts/oas-boundary-ratchet.sh`
- `scripts/lint/no-unknown-permissive-default.sh`
- `scripts/lint/no-ocaml-comment-terminator-trap.sh`
- `scripts/lint-ignore-without-comment.sh`
- `scripts/lint/godfile-size-regression.sh`
- `scripts/code-smell-ratchet.sh`
- `scripts/ci/check-determinism-contract.sh`

Focused Dune check attempted: `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_cascade_runtime.exe`, blocked with exit 75 by machine-wide bare Dune guard; did not bypass.