### PR TITLE
fix(bin): wire Masc_runtime_events.start_listener — orphan exposed by #18567

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -711,6 +711,13 @@ let run_cmd host port base_path =
      Dashboard_cache.now() reads from Time_compat directly. *)
   Time_compat.set_clock (Eio.Stdenv.clock env);
 
+  (* Wire Runtime_events listener. After masc-mcp#18567 removed dead
+     [Http_server_eio.start] (the only prior production caller), this
+     would have been silently uninitialized. Idempotent-safe per
+     [Masc_runtime_events] mli; consumed by Olly / custom callbacks
+     to bracket agent turn spans ([emit_turn_start]/[emit_turn_end]). *)
+  Masc_runtime_events.start_listener ();
+
   (* Signal handlers stay side-effect free. The Eio watcher fiber performs
      all shutdown work inside the event loop. *)
   let pending_shutdown_signal = Atomic.make None in


### PR DESCRIPTION
## Summary
Direct follow-up to #18567. After dead `Http_server_eio.start` was removed, production lost its only `Masc_runtime_events.start_listener ()` invocation. Test had its own call (`test/test_masc_runtime_events.ml:15`), but production was silently uninitialized for runtime events.

## What this PR does
Inserts a single call (`Masc_runtime_events.start_listener ();`) in `run_cmd_exit` at `bin/main_eio.ml:715`, between `Time_compat.set_clock` and the signal-handler block. Total diff: **+7 lines** (5 doc comment + 1 blank + 1 call).

## Why here, why now
`lib/core/masc_runtime_events.mli` line 30 contracts:
> "Should be called once, early inside the `Eio_main.run` entry."

The audit in [me#1175 commit `528f14bf`](https://github.com/jeong-sik/me/pull/1175) discovered this orphan while doing 5-prong dead-export analysis on `Http_server_eio.start`. The orphan was *exposed by* #18567, not *caused by* it — production was already silently uninitialized before #18567 merged.

## Module resolution
- `Masc_runtime_events` lives in `lib/core/masc_runtime_events.ml`
- `lib/core/dune` declares it under library `masc_core` (`public_name masc_mcp.masc_core`), `wrapped false`, with `masc_runtime_events` in modules list
- `bin/dune` `main_eio` already lists `masc_core` in libraries
- Same call shape as `Eio_guard.enable ()` on the line above

## Scope (intentional limits)
| Entry | Action |
|---|---|
| `run_cmd_exit` (line 703, main server) | **wired** ← this PR |
| `doctor_cmd_exit` (line 873) | out of scope — one-shot diagnostic |
| `doctor_keeper_report` (line 1222) | out of scope — one-shot |
| `doctor_all_json_exit` (line 1451) | out of scope — one-shot |

Doctor commands don't emit turn spans (`emit_turn_start`/`emit_turn_end`). Adding listener init to them would be cosmetic.

## Build verification
- **bin/main_eio.exe target**: 3 errors, all pre-existing in `lib/keeper/` (`keeper_meta_json_parse`, `keeper_heartbeat_loop_presence`, `keeper_turn_up_create` — `Unbound value keeper_agent_name`). Matches origin/main baseline.
- **My added line**: type-checks clean. No `Unbound module Masc_runtime_events` or `Unbound value start_listener` errors attributed to bin/main_eio.ml.
- **Idempotent**: `start_listener` is documented idempotent-safe per `Runtime_events` semantics, so double-call (test + this) is safe.

## Workaround signature self-check (CLAUDE.md `feedback_telemetry_as_fix_self_recurrence`)

| Signature | Status |
|---|---|
| Telemetry-as-fix | ❌ wires real listener, not a counter |
| String classifier | ❌ no |
| N-of-M | ✅ doctor commands intentionally out of scope (documented above) |
| Catch-all addition | ❌ no |
| Cap/cooldown | ❌ no |
| Test backdoor | ❌ no |
| N-site typo | ❌ no |

## Test plan
- [x] Module resolution verified via `bin/dune` deps + `lib/core/dune` modules list
- [x] No regression in `bin/main_eio.exe` build (same 3 pre-existing errors)
- [x] `Masc_runtime_events.mli` contract honored ("early inside Eio_main.run")
- [ ] Reviewer-side: confirm Olly/external runtime-events consumers see turn spans after deploy

## Out of scope
- Pre-existing `lib/keeper/` `keeper_agent_name` errors (separate)
- Adding listener to doctor commands
- `default_routes` cleanup (separate follow-up — me#1175 task #6)

## Related
- me#1175 — analysis + Sprint 1 evidence
- masc-mcp#18567 — dead-code removal (this PR's parent)
- masc-mcp#18563 — RFC-0178 P0-1 scaffold (parallel design track)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>