### PR TITLE
fix(test): align keeper test API drift

### DIFF
--- a/test/test_keeper_fs_edit_containment.ml
+++ b/test/test_keeper_fs_edit_containment.ml
@@ -117,7 +117,7 @@ let test_docker_write_blocks_project_root_even_if_allowlisted () =
   Keeper_registry.update_meta ~base_path:config.base_path meta.name meta;
   let path = Filename.concat config.base_path "root-write.txt" in
   let raw =
-    Keeper_exec_fs.handle_tool_edit_file
+    Keeper_exec_fs.handle_keeper_fs_edit
       ~turn_sandbox_factory:None
       ~config
       ~keeper_name:meta.name
@@ -145,7 +145,7 @@ let test_docker_write_allows_playground () =
   let path = Filename.concat playground "mind/allowed.txt" in
   ensure_dir (Filename.dirname path);
   let raw =
-    Keeper_exec_fs.handle_tool_edit_file
+    Keeper_exec_fs.handle_keeper_fs_edit
       ~turn_sandbox_factory:None
       ~config
       ~keeper_name:meta.name

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -1,4 +1,4 @@
-(** Tests for [Keeper_exec_fs.handle_tool_edit_file] mode=patch.
+(** Tests for [Keeper_exec_fs.handle_keeper_fs_edit] mode=patch.
 
     RFC-0006 Phase A.4 — string-replace edit mode added so the
     Provider_a Code [Edit] cognate can be wired through OAS dual
@@ -96,7 +96,7 @@ let parse_int raw field =
 
 let public_fs_edit_call ~public ~config ~(meta : Keeper_types.keeper_meta) args =
   let args = Keeper_tool_alias.translate_input ~public args in
-  Keeper_exec_fs.handle_tool_edit_file
+  Keeper_exec_fs.handle_keeper_fs_edit
     ~turn_sandbox_factory:None
     ~config
     ~keeper_name:meta.name
@@ -123,7 +123,7 @@ let test_patch_unique_match () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\nlet y = 2\n";
   let raw =
-    Keeper_exec_fs.handle_tool_edit_file ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -145,7 +145,7 @@ let test_patch_no_match_errors () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\n";
   let raw =
-    Keeper_exec_fs.handle_tool_edit_file ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -175,7 +175,7 @@ let test_patch_multiple_matches_without_replace_all_errors () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "x = 1\nx = 1\nx = 1\n";
   let raw =
-    Keeper_exec_fs.handle_tool_edit_file ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -195,7 +195,7 @@ let test_patch_replace_all () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "x = 1\nx = 1\nx = 1\n";
   let raw =
-    Keeper_exec_fs.handle_tool_edit_file ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -217,7 +217,7 @@ let test_patch_empty_old_string_errors () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\n";
   let raw =
-    Keeper_exec_fs.handle_tool_edit_file ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -235,7 +235,7 @@ let test_patch_missing_file_errors () =
   setup @@ fun ~config ~meta ~playground ->
   let path = Filename.concat playground "ghost.ml" in
   let raw =
-    Keeper_exec_fs.handle_tool_edit_file ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -252,7 +252,7 @@ let test_patch_delete_via_empty_new_string () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "keep me\nDELETE_ME\nkeep me too\n";
   let raw =
-    Keeper_exec_fs.handle_tool_edit_file ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -271,7 +271,7 @@ let test_overwrite_unchanged_by_patch_addition () =
   setup @@ fun ~config ~meta ~playground ->
   let path = Filename.concat playground "new.txt" in
   let raw =
-    Keeper_exec_fs.handle_tool_edit_file ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -11,6 +11,7 @@ module Mcp = Masc_mcp.Mcp_server
 module Config = Masc_mcp.Config
 module Tool_result = Tool_result
 module Keeper_types = Masc_mcp.Keeper_types
+module Keeper_identity = Masc_mcp.Keeper_identity
 module Keeper_registry = Masc_mcp.Keeper_registry
 module Masc_log = Log
 


### PR DESCRIPTION
## Summary
- Update keeper filesystem edit tests from the removed `Keeper_exec_fs.handle_tool_edit_file` helper to the surviving `handle_keeper_fs_edit` API.
- Add the missing `Masc_mcp.Keeper_identity` alias in `test_mcp_server_eio.ml`.

## Product impact
- Repairs current-main CI compile failures exposed in Health/Lint after the keeper identity/API split.
- Keeps the runtime code path unchanged; this is test surface alignment only.

## Evidence
- `opam exec -- ocamlformat --check test/test_keeper_fs_edit_patch.ml test/test_keeper_fs_edit_containment.ml test/test_mcp_server_eio.ml`
- `git diff --check`
- Attempted focused Dune build: `lockf -t 180 /tmp/me-dune-local.lock env MASC_DUNE_THROTTLE=0 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_fs_edit_patch.exe test/test_keeper_fs_edit_containment.exe test/test_mcp_server_eio.exe`
  - Result: blocked by the shared Dune lock after the full wait window.
- CI failure evidence from main run `26430113884`:
  - `Health`: `test/test_keeper_fs_edit_patch.ml` failed on unbound `Keeper_exec_fs.handle_tool_edit_file`.
  - `Health`: `test/test_mcp_server_eio.ml` failed on unbound module `Keeper_identity`.

## Direct evidence
```yaml
schema_version: 1
direct_ratio: 4/5
provenance: direct
checked:
  - local ocamlformat check passed
  - local diff whitespace check passed
  - GitHub Health log inspected directly
  - GitHub Lint/Health failure status inspected directly
blocked:
  - focused local Dune build could not acquire shared lock
```

## Review evidence
- No automated reviewer feedback yet.

## Linked issue
- N/A

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/current-main-test-api-drift-20260526` → `main` · 1 commit(s) · synced 2026-05-26T03:37:23Z

| sha | subject | date |
|---|---|---|
| `7a64f5012` | fix(test): align keeper test API drift | 2026-05-26 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->