### PR TITLE
fix(keeper): type workflow rejection retry policy

### DIFF
--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -76,12 +76,6 @@ let assoc_int_opt key json =
   | _ -> None
 ;;
 
-let assoc_bool_opt key json =
-  match assoc_field_opt key json with
-  | Some (`Bool value) -> Some value
-  | _ -> None
-;;
-
 (* [error_or_detail key json] reads [key] at top level, falling back
    to a nested ["detail"] object. Mirrors the lookup pattern used in
    [keeper_tools_oas.workflow_rejection_info_of_raw]. *)
@@ -91,15 +85,6 @@ let error_or_detail_string key json =
   | None ->
     (match assoc_field_opt "detail" json with
      | Some detail -> assoc_string_opt key detail
-     | None -> None)
-;;
-
-let error_or_detail_bool key json =
-  match assoc_bool_opt key json with
-  | Some _ as v -> v
-  | None ->
-    (match assoc_field_opt "detail" json with
-     | Some detail -> assoc_bool_opt key detail
      | None -> None)
 ;;
 
@@ -135,15 +120,13 @@ let path_check_reason_of_explicit = function
 (* ── Classifier ───────────────────────────────────────────────── *)
 
 let classify_workflow_rejection json =
-  match error_or_detail_string "failure_class" json with
-  | Some "workflow_rejection" ->
-    (match
-       ( error_or_detail_string "error_class" json
-       , error_or_detail_bool "recoverable" json )
-     with
-     | Some "deterministic", Some false -> Some Workflow_rejection_blocked
-     | _ -> None)
-  | Some _ | None -> None
+  match Keeper_tools_oas_workflow.workflow_rejection_payload_of_json json with
+  | Some payload
+    when Keeper_tools_oas_workflow.workflow_rejection_should_skip_retry payload
+    -> Some Workflow_rejection_blocked
+  | Some _
+  | None ->
+    None
 ;;
 
 let classify_error_code json =

--- a/lib/keeper/keeper_tools_oas_json.ml
+++ b/lib/keeper/keeper_tools_oas_json.ml
@@ -16,6 +16,12 @@ let json_assoc_string_opt key json =
   | _ -> None
 ;;
 
+let json_assoc_bool_opt key json =
+  match json_assoc_field_opt key json with
+  | Some (`Bool value) -> Some value
+  | _ -> None
+;;
+
 let detail_json_opt json =
   match json_assoc_field_opt "detail" json with
   | Some (`Assoc _ as detail) -> Some detail
@@ -28,6 +34,15 @@ let json_or_detail_string_opt key json =
   | None ->
     (match detail_json_opt json with
      | Some detail -> json_assoc_string_opt key detail
+     | None -> None)
+;;
+
+let json_or_detail_bool_opt key json =
+  match json_assoc_bool_opt key json with
+  | Some _ as value -> value
+  | None ->
+    (match detail_json_opt json with
+     | Some detail -> json_assoc_bool_opt key detail
      | None -> None)
 ;;
 

--- a/lib/keeper/keeper_tools_oas_json.mli
+++ b/lib/keeper/keeper_tools_oas_json.mli
@@ -2,6 +2,8 @@
 
 val json_assoc_field_opt : string -> Yojson.Safe.t -> Yojson.Safe.t option
 val json_assoc_string_opt : string -> Yojson.Safe.t -> string option
+val json_assoc_bool_opt : string -> Yojson.Safe.t -> bool option
 val detail_json_opt : Yojson.Safe.t -> Yojson.Safe.t option
 val json_or_detail_string_opt : string -> Yojson.Safe.t -> string option
+val json_or_detail_bool_opt : string -> Yojson.Safe.t -> bool option
 val diagnosis_json_opt : Yojson.Safe.t -> Yojson.Safe.t option

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -41,6 +41,7 @@ let json_assoc_field_opt = Keeper_tools_oas_json.json_assoc_field_opt
 let json_assoc_string_opt = Keeper_tools_oas_json.json_assoc_string_opt
 let detail_json_opt = Keeper_tools_oas_json.detail_json_opt
 let json_or_detail_string_opt = Keeper_tools_oas_json.json_or_detail_string_opt
+let json_or_detail_bool_opt = Keeper_tools_oas_json.json_or_detail_bool_opt
 let diagnosis_json_opt = Keeper_tools_oas_json.diagnosis_json_opt
 
 let json_nonempty_string_opt key json =
@@ -51,44 +52,111 @@ let json_nonempty_string_opt key json =
   | _ -> None
 ;;
 
+let workflow_rejection_info_of_json json =
+  let diagnosis = diagnosis_json_opt json in
+  let task_id = json_nonempty_string_opt "task_id" json in
+  let rule_id =
+    match diagnosis with
+    | Some diagnosis -> json_assoc_string_opt "rule_id" diagnosis
+    | None -> None
+  in
+  let tool_suggestion =
+    match diagnosis with
+    | Some diagnosis -> json_assoc_string_opt "tool_suggestion" diagnosis
+    | None -> None
+  in
+  let scope_policy =
+    match
+      Option.bind diagnosis (fun diagnosis ->
+        json_assoc_string_opt "scope_policy" diagnosis)
+    with
+    | Some value ->
+      Option.value
+        ~default:Observe_scope
+        (workflow_rejection_scope_policy_of_string value)
+    | None -> Observe_scope
+  in
+  { task_id
+  ; rule_id
+  ; tool_suggestion
+  ; hint = json_or_detail_string_opt "hint" json
+  ; scope_policy
+  }
+;;
+
+type workflow_rejection_error_class =
+  | Workflow_error_deterministic
+  | Workflow_error_transient
+  | Workflow_error_other of string
+
+let workflow_rejection_error_class_of_string value =
+  match String.trim value with
+  | "" -> None
+  | "deterministic" -> Some Workflow_error_deterministic
+  | "transient" -> Some Workflow_error_transient
+  | other -> Some (Workflow_error_other other)
+;;
+
+type workflow_rejection_recoverability =
+  | Workflow_recoverable
+  | Workflow_unrecoverable
+
+let workflow_rejection_recoverability_of_bool = function
+  | true -> Workflow_recoverable
+  | false -> Workflow_unrecoverable
+;;
+
+type workflow_rejection_retry_policy =
+  | Workflow_retry_observe
+  | Workflow_retry_skip_deterministic
+
+type workflow_rejection_payload =
+  { info : workflow_rejection_info
+  ; error_class : workflow_rejection_error_class option
+  ; recoverability : workflow_rejection_recoverability option
+  }
+
+let workflow_rejection_payload_of_json json =
+  match json_or_detail_string_opt "failure_class" json with
+  | Some "workflow_rejection" ->
+    Some
+      { info = workflow_rejection_info_of_json json
+      ; error_class =
+          Option.bind
+            (json_or_detail_string_opt "error_class" json)
+            workflow_rejection_error_class_of_string
+      ; recoverability =
+          Option.map
+            workflow_rejection_recoverability_of_bool
+            (json_or_detail_bool_opt "recoverable" json)
+      }
+  | Some _
+  | None ->
+    None
+;;
+
+let workflow_rejection_retry_policy payload =
+  match payload with
+  | { error_class = Some Workflow_error_deterministic
+    ; recoverability = Some Workflow_unrecoverable
+    ; _
+    } ->
+    Workflow_retry_skip_deterministic
+  | _ -> Workflow_retry_observe
+;;
+
+let workflow_rejection_should_skip_retry payload =
+  match workflow_rejection_retry_policy payload with
+  | Workflow_retry_skip_deterministic -> true
+  | Workflow_retry_observe -> false
+;;
+
 let workflow_rejection_info_of_raw raw =
   try
     let json = Yojson.Safe.from_string raw in
-    match json_or_detail_string_opt "failure_class" json with
-    | Some "workflow_rejection" ->
-      let diagnosis = diagnosis_json_opt json in
-      let task_id = json_nonempty_string_opt "task_id" json in
-      let rule_id =
-        match diagnosis with
-        | Some diagnosis -> json_assoc_string_opt "rule_id" diagnosis
-        | None -> None
-      in
-      let tool_suggestion =
-        match diagnosis with
-        | Some diagnosis -> json_assoc_string_opt "tool_suggestion" diagnosis
-        | None -> None
-      in
-      let scope_policy =
-        match
-          Option.bind diagnosis (fun diagnosis ->
-            json_assoc_string_opt "scope_policy" diagnosis)
-        with
-        | Some value ->
-          Option.value
-            ~default:Observe_scope
-            (workflow_rejection_scope_policy_of_string value)
-        | None -> Observe_scope
-      in
-      Some
-        { task_id
-        ; rule_id
-        ; tool_suggestion
-        ; hint = json_or_detail_string_opt "hint" json
-        ; scope_policy
-        }
-    | Some _
-    | None ->
-      None
+    match workflow_rejection_payload_of_json json with
+    | Some payload -> Some payload.info
+    | None -> None
   with
   | Yojson.Json_error _ -> None
 ;;
@@ -240,6 +308,7 @@ let workflow_rejection_scope_block_fields ~tool_name block =
     @ optional_string "rule_id" block.rule_id
     @ optional_string "tool_suggestion" block.tool_suggestion
     @ optional_string "hint" block.hint
+    @ [ "scope_policy", `String (workflow_rejection_scope_policy_to_string Block_scope) ]
   in
   [ "self_correction_required", `Bool true
   ; "do_not_retry_tool", `String tool_name

--- a/lib/keeper/keeper_tools_oas_workflow.mli
+++ b/lib/keeper/keeper_tools_oas_workflow.mli
@@ -25,6 +25,44 @@ type workflow_rejection_info =
   ; scope_policy : workflow_rejection_scope_policy
   }
 
+(** Typed [error_class] values carried by a workflow rejection. Unknown
+    strings stay data, but never imply deterministic retry-skip. *)
+type workflow_rejection_error_class =
+  | Workflow_error_deterministic
+  | Workflow_error_transient
+  | Workflow_error_other of string
+
+(** Typed recoverability marker carried by a workflow rejection. Missing
+    recoverability is observe-only. *)
+type workflow_rejection_recoverability =
+  | Workflow_recoverable
+  | Workflow_unrecoverable
+
+(** Retry policy derived from explicit workflow rejection fields. *)
+type workflow_rejection_retry_policy =
+  | Workflow_retry_observe
+  | Workflow_retry_skip_deterministic
+
+(** Structured workflow-rejection payload extracted from JSON. *)
+type workflow_rejection_payload =
+  { info : workflow_rejection_info
+  ; error_class : workflow_rejection_error_class option
+  ; recoverability : workflow_rejection_recoverability option
+  }
+
+(** Extract [workflow_rejection_payload] from parsed JSON. *)
+val workflow_rejection_payload_of_json
+  :  Yojson.Safe.t
+  -> workflow_rejection_payload option
+
+(** Derive the retry policy. Only explicit deterministic +
+    unrecoverable payloads can skip retry. *)
+val workflow_rejection_retry_policy
+  :  workflow_rejection_payload
+  -> workflow_rejection_retry_policy
+
+val workflow_rejection_should_skip_retry : workflow_rejection_payload -> bool
+
 (** Extract [workflow_rejection_info] from a raw JSON string. *)
 val workflow_rejection_info_of_raw : string -> workflow_rejection_info option
 

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1204,6 +1204,40 @@ let test_workflow_rejection_scope_policy_block_scope () =
       (Keeper_tools_oas_workflow.workflow_rejection_should_scope_block info)
 ;;
 
+let test_workflow_rejection_retry_policy_requires_explicit_markers () =
+  let should_skip raw =
+    match
+      Keeper_tools_oas_workflow.workflow_rejection_payload_of_json (parse raw)
+    with
+    | Some payload ->
+      Keeper_tools_oas_workflow.workflow_rejection_should_skip_retry payload
+    | None -> fail "expected workflow rejection payload"
+  in
+  check
+    bool
+    "failure_class only observes"
+    false
+    (should_skip
+       {|{"ok":false,"error":"some_rule","failure_class":"workflow_rejection"}|});
+  check
+    bool
+    "deterministic but recoverable observes"
+    false
+    (should_skip
+       {|{"ok":false,"error":"some_rule","failure_class":"workflow_rejection","error_class":"deterministic","recoverable":true}|});
+  check
+    bool
+    "transient nonrecoverable observes"
+    false
+    (should_skip
+       {|{"ok":false,"error":"some_rule","failure_class":"workflow_rejection","error_class":"transient","recoverable":false}|});
+  check
+    bool
+    "deterministic nonrecoverable skips"
+    true
+    (should_skip workflow_rejection_scope_block_raw)
+;;
+
 let test_tool_result_error_json_preserves_structured_workflow_rejection () =
   let message =
     Tool_task_payloads.workflow_rejection_payload_json
@@ -1760,6 +1794,10 @@ let () =
             "workflow rejection scope policy block_scope"
             `Quick
             test_workflow_rejection_scope_policy_block_scope
+        ; test_case
+            "workflow rejection retry policy requires explicit markers"
+            `Quick
+            test_workflow_rejection_retry_policy_requires_explicit_markers
         ; test_case
             "structured Tool_result workflow rejection stays structured"
             `Quick


### PR DESCRIPTION
## Summary
- move workflow rejection retry-skip classification behind a typed workflow rejection payload/policy parser
- make deterministic retry-skip require explicit deterministic + unrecoverable markers from that typed policy
- keep unmarked or recoverable workflow rejections observe-only, and expose block_scope in scope-block recovery fields

## Verification
- ocamlformat --check lib/keeper/keeper_tools_oas_json.ml lib/keeper/keeper_tools_oas_json.mli lib/keeper/keeper_tools_oas_workflow.ml lib/keeper/keeper_tools_oas_workflow.mli lib/keeper/keeper_tool_deterministic_error.ml test/test_keeper_tools_oas.ml
- git diff --check

## Local Dune
- scripts/dune-local.sh build test/test_keeper_tools_oas.exe test/test_keeper_bash_retry_deterministic_close.exe was blocked by pre-existing bare Dune processes outside scripts/dune-local.sh