### PR TITLE
refactor(keeper): drop history-source helpers from types facade

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 12:32:49 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 12:44:10 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -379,9 +379,15 @@
           </tr>
           <tr>
             <td><code>Keeper_types.ensure_api_keys_for_labels</code> facade leaf</td>
-            <td><span class="status now">draft PR #18572</span></td>
+            <td><span class="status done">merged #18572</span></td>
             <td>Stop exposing the support-owned API-key availability check through the broad <code>Keeper_types</code> facade. Keeper turn paths now call <code>Keeper_types_support.ensure_api_keys_for_labels</code> directly.</td>
             <td>Backstop grep is clean for the removed <code>Keeper_types</code> signature value and unqualified keeper-turn calls. Existing cascade runtime tests already cover the canonical owner.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_types</code> history-source facade leaves</td>
+            <td><span class="status now">draft PR #18578</span></td>
+            <td>Stop exposing <code>normalize_history_source</code> and <code>is_prompt_history_source</code> through the broad <code>Keeper_types</code> facade. History routing callers now use <code>Keeper_types_support.is_prompt_history_source</code> directly.</td>
+            <td>Backstop grep must stay clean for <code>Keeper_types.is_prompt_history_source</code>, <code>Keeper_types.normalize_history_source</code>, and the removed public signature values.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.write_meta_with_retry</code> wrapper</td>

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -559,7 +559,7 @@ Keeper turn에서 어떤 "skill" 경로를 사용할지 결정:
 
 ### 15.2 keeper_types.ml include chain
 
-`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history/metrics/API-key support helper를 `Keeper_types_support` 소유로 돌렸지만, 일부 support helper 선별 re-export와 구현 include chain 자체는 남아 있어 가독성이 낮다.
+`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history-source/metrics/API-key support helper를 `Keeper_types_support` 소유로 돌렸지만, 일부 support helper 선별 re-export와 구현 include chain 자체는 남아 있어 가독성이 낮다.
 
 ### 15.3 keeper_memory 계층의 include chain
 

--- a/lib/keeper/keeper_context_core_history.ml
+++ b/lib/keeper/keeper_context_core_history.ml
@@ -52,7 +52,7 @@ let classify_history_entry ~(source : string) ~(content : string) :
   (* World-state headings can appear in user-authored long-term memory.
      Only explicit prompt/internal sources control history routing. *)
   ignore content;
-  if Keeper_types.is_prompt_history_source source
+  if Keeper_types_support.is_prompt_history_source source
   then Drop_line
   else if Keeper_types_support.is_internal_history_source source
   then Move_internal

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -134,7 +134,7 @@ let write_heartbeat_snapshot
                  Safe_ops.json_string ~default:"" "content" json |> String.trim
                in
                ignore content;
-               if Keeper_types.is_prompt_history_source source then None
+               if Keeper_types_support.is_prompt_history_source source then None
                else Some (Keeper_context_core.message_of_json json)
              with
              | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -450,12 +450,6 @@ val keeper_generation_manifest_path : Coord.config -> string -> string
 val keeper_history_path : Coord.config -> string -> string
 val keeper_internal_history_path : Coord.config -> string -> string
 
-(** Trim + lowercase a history-source label. *)
-val normalize_history_source : string -> string
-
-(** Whether [source] denotes the world-state prompt history channel. *)
-val is_prompt_history_source : string -> bool
-
 val keeper_policy_log_path : Coord.config -> string -> string
 val keeper_decision_log_path : Coord.config -> string -> string
 val keeper_feedback_log_path : Coord.config -> string -> string


### PR DESCRIPTION
## Summary
- remove history-source helper declarations from the public Keeper_types facade
- route remaining history callers to Keeper_types_support.is_prompt_history_source directly
- refresh the legacy purge ledger/spec note for the support-owner migration

## Verification
- ocamlformat --check lib/keeper/keeper_types.mli lib/keeper/keeper_context_core_history.ml lib/keeper/keeper_heartbeat_snapshot.ml
- rg -n "Keeper_types\.(is_prompt_history_source|normalize_history_source)\b" lib test bin scripts (no matches)
- rg -n "val normalize_history_source|val is_prompt_history_source" lib/keeper/keeper_types.mli (no matches)
- git diff --check
- scripts/audit-keeper-tool-boundary-matrix.sh
- scripts/ocaml-structure-ratchet.sh
- scripts/stringly-boundary-ratchet.sh
- scripts/oas-boundary-ratchet.sh
- scripts/lint/no-unknown-permissive-default.sh
- scripts/lint/no-ocaml-comment-terminator-trap.sh
- scripts/lint-ignore-without-comment.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

Focused Dune attempted but blocked by the machine-wide bare-Dune guard: scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_memory.exe test/test_operator_control_snapshot.exe exited 75 because live bare dune processes were present. I did not bypass the guard.