### PR TITLE
refactor(http): remove dead default_routes binding (11 LoC)

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -601,17 +601,6 @@ let mcp_get_handler request reqd =
   | Error msg ->
       Response.text ~status:`Bad_request msg reqd
 
-(** Default routes for MCP server *)
-let default_routes =
-  Router.empty
-  |> Router.get "/health" health_handler
-  |> Router.get "/ready" ready_handler
-  |> Router.get "/metrics" metrics_handler
-  |> Router.post "/mcp" mcp_post_handler
-  |> Router.get "/mcp" mcp_get_handler
-  |> Router.get "/" (fun _req reqd ->
-      Response.text "MASC MCP Server" reqd)
-
 let with_streamable_mcp_request_handler ~request_handler routes =
   let replace_post_mcp route =
     if String.equal route.Router.path "/mcp" && List.mem `POST route.Router.methods then


### PR DESCRIPTION
## Summary
- Remove the now-dead `default_routes` binding from `lib/http_server_eio.ml`.
- Keep the scope intentionally narrow: no mli doc cleanup and no handler cascade sweep in this PR.

## Audit
- `rg -n "default_routes|Http_server_eio\\.default_routes" lib test bin scripts docs .github`
- Result: only `lib/http_server_eio.mli:13` remains, which is the known stale docstring reference and is out of scope here.

## Verification
- Rebased onto current `origin/main` (`afe499af2`, after #18564/#18574/#18575/#18576/#18577/#18578); no conflicts.
- `git diff --check origin/main...HEAD`
- `opam exec -- ocamlformat --check lib/http_server_eio.ml`

## Not Run
- `scripts/dune-local.sh build lib/masc_mcp.cmxa bin/main_eio.exe`: blocked locally by concurrent bare Dune processes outside `scripts/dune-local.sh`; not bypassed.

## Related
- #18567
- #18573
