### PR TITLE
refactor(keeper): centralize workflow rejection payload writer

### DIFF
--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -50,7 +50,7 @@ let to_string = function
   | Keeper_shell_op_required ->
     "raw shell rejected; caller must use the visible structured tool from the recovery plan"
   | Workflow_rejection_blocked ->
-    "typed workflow_rejection failure_class returned by the tool"
+    "workflow rejection explicitly marked deterministic and unrecoverable"
   | Git_ref_precondition_failed ->
     "git ref/precondition failure (missing ref, unknown revision, or no merge base)"
   | Git_command_usage_error ->

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -126,14 +126,11 @@ let make_keeper_tool_handler
             "tool %s workflow rejection retry skipped for same task/action scope"
             name;
           let raw_result =
-            Yojson.Safe.to_string
-              (`Assoc
-                  [ "ok", `Bool false
-                  ; "error", `String "workflow_rejection_open_loop_blocked"
-                  ; "failure_class", `String "workflow_rejection"
-                  ; "recoverable", `Bool false
-                  ; "error_class", `String "deterministic"
-                  ])
+            workflow_rejection_payload_json
+              ~scope_policy:Block_scope
+              ~error_class:Workflow_error_deterministic
+              ~recoverability:Workflow_unrecoverable
+              "workflow_rejection_open_loop_blocked"
           in
           let output_text =
             normalize_tool_result

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -97,6 +97,12 @@ let workflow_rejection_error_class_of_string value =
   | other -> Some (Workflow_error_other other)
 ;;
 
+let workflow_rejection_error_class_to_string = function
+  | Workflow_error_deterministic -> "deterministic"
+  | Workflow_error_transient -> "transient"
+  | Workflow_error_other value -> value
+;;
+
 type workflow_rejection_recoverability =
   | Workflow_recoverable
   | Workflow_unrecoverable
@@ -104,6 +110,11 @@ type workflow_rejection_recoverability =
 let workflow_rejection_recoverability_of_bool = function
   | true -> Workflow_recoverable
   | false -> Workflow_unrecoverable
+;;
+
+let workflow_rejection_recoverability_to_bool = function
+  | Workflow_recoverable -> true
+  | Workflow_unrecoverable -> false
 ;;
 
 type workflow_rejection_retry_policy =
@@ -149,6 +160,45 @@ let workflow_rejection_should_skip_retry payload =
   match workflow_rejection_retry_policy payload with
   | Workflow_retry_skip_deterministic -> true
   | Workflow_retry_observe -> false
+;;
+
+let optional_string_field key value =
+  match value with
+  | Some value ->
+    let value = String.trim value in
+    if String.equal value "" then [] else [ key, `String value ]
+  | None -> []
+;;
+
+let workflow_rejection_payload_json
+      ?rule_id
+      ?tool_suggestion
+      ?hint
+      ?scope_policy
+      ~error_class
+      ~recoverability
+      message
+  =
+  let diagnosis =
+    optional_string_field "rule_id" rule_id
+    @ optional_string_field "tool_suggestion" tool_suggestion
+    @
+    match scope_policy with
+    | Some scope_policy ->
+      [ "scope_policy", `String (workflow_rejection_scope_policy_to_string scope_policy) ]
+    | None -> []
+  in
+  let fields =
+    [ "ok", `Bool false
+    ; "error", `String message
+    ; "failure_class", `String "workflow_rejection"
+    ; "error_class", `String (workflow_rejection_error_class_to_string error_class)
+    ; "recoverable", `Bool (workflow_rejection_recoverability_to_bool recoverability)
+    ]
+    @ optional_string_field "hint" hint
+    @ if diagnosis = [] then [] else [ "diagnosis", `Assoc diagnosis ]
+  in
+  Yojson.Safe.to_string (`Assoc fields)
 ;;
 
 let workflow_rejection_info_of_raw raw =

--- a/lib/keeper/keeper_tools_oas_workflow.mli
+++ b/lib/keeper/keeper_tools_oas_workflow.mli
@@ -63,6 +63,17 @@ val workflow_rejection_retry_policy
 
 val workflow_rejection_should_skip_retry : workflow_rejection_payload -> bool
 
+(** Build a workflow-rejection payload with typed retry-policy fields. *)
+val workflow_rejection_payload_json
+  :  ?rule_id:string
+  -> ?tool_suggestion:string
+  -> ?hint:string
+  -> ?scope_policy:workflow_rejection_scope_policy
+  -> error_class:workflow_rejection_error_class
+  -> recoverability:workflow_rejection_recoverability
+  -> string
+  -> string
+
 (** Extract [workflow_rejection_info] from a raw JSON string. *)
 val workflow_rejection_info_of_raw : string -> workflow_rejection_info option
 

--- a/lib/tool_task_payloads.ml
+++ b/lib/tool_task_payloads.ml
@@ -36,13 +36,6 @@ let verifier_terminal_verdict_noop_message ~task_id ~action ~status =
     "Verifier stale verdict ignored: task %s is already %s, so masc_transition(action=%s) was treated as a no-op. Do not retry this verdict; inspect task history or list awaiting_verification tasks instead."
     task_id status action
 
-let nonempty_string_field key value =
-  match value with
-  | Some value when String.trim value <> "" -> [ key, `String (String.trim value) ]
-  | Some _
-  | None ->
-    []
-
 let workflow_rejection_payload_json
       ?rule_id
       ?tool_suggestion
@@ -50,22 +43,19 @@ let workflow_rejection_payload_json
       ?scope_policy
       message
   =
-  let diagnosis =
-    nonempty_string_field "rule_id" rule_id
-    @ nonempty_string_field "tool_suggestion" tool_suggestion
-    @ nonempty_string_field "scope_policy" scope_policy
+  let scope_policy =
+    Option.bind
+      scope_policy
+      Keeper_tools_oas_workflow.workflow_rejection_scope_policy_of_string
   in
-  let fields =
-    [ "ok", `Bool false
-    ; "error", `String message
-    ; "failure_class", `String "workflow_rejection"
-    ; "error_class", `String "deterministic"
-    ; "recoverable", `Bool false
-    ]
-    @ nonempty_string_field "hint" hint
-    @ if diagnosis = [] then [] else [ "diagnosis", `Assoc diagnosis ]
-  in
-  Yojson.Safe.to_string (`Assoc fields)
+  Keeper_tools_oas_workflow.workflow_rejection_payload_json
+    ?rule_id
+    ?tool_suggestion
+    ?hint
+    ?scope_policy
+    ~error_class:Keeper_tools_oas_workflow.Workflow_error_deterministic
+    ~recoverability:Keeper_tools_oas_workflow.Workflow_unrecoverable
+    message
 
 let build_claim_observation_payload ~(now : float) ~(agent_name : string)
     ~(task_id : string) : Yojson.Safe.t =


### PR DESCRIPTION
## Summary
- add a typed workflow-rejection payload writer next to the typed retry policy parser
- route synthetic scope-block results through the typed writer instead of inline JSON literals
- route Tool_task_payloads workflow rejection envelopes through the same typed writer

## Verification
- ocamlformat --check lib/tool_task_payloads.ml lib/keeper/keeper_tools_oas_workflow.ml lib/keeper/keeper_tools_oas_workflow.mli lib/keeper/keeper_tools_oas_handler.ml lib/keeper/keeper_tool_deterministic_error.ml
- git diff --cached --check
- scripts/dune-local.sh build test/test_keeper_tools_oas.exe test/test_keeper_bash_retry_deterministic_close.exe was blocked by pre-existing bare Dune processes outside scripts/dune-local.sh