### PR TITLE
refactor(keeper): route descriptor tools through runtime owner

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -138,7 +138,7 @@
  server_mcp_transport_http_agui
  server_mcp_streaming_tools
  mcp_server_eio_tool_timeout
-  agent_tool_descriptor keeper_tool_registry
+  agent_tool_descriptor agent_tool_runtime keeper_tool_registry
   keeper_tool_resolution
   keeper_tool_policy_config
   keeper_discovered_tools

--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -26,6 +26,14 @@ type approval =
   | Policy_selected
   | Human_required
 
+type runtime_handler =
+  | Tool_execute
+  | Tool_search_files
+  | Tool_read_file
+  | Tool_edit_file
+  | Tool_write_file
+  | Tool_remote_mcp
+
 type policy =
   { visibility : Tool_catalog.visibility
   ; readonly : bool option
@@ -46,6 +54,7 @@ type t =
   ; executor : executor
   ; backend : backend
   ; sandbox : sandbox
+  ; runtime_handler : runtime_handler
   ; translate : Yojson.Safe.t -> Yojson.Safe.t
   ; receipt_labels : (string * string) list
   }
@@ -78,6 +87,15 @@ let approval_to_string = function
   | No_approval -> "none"
   | Policy_selected -> "policy_selected"
   | Human_required -> "human_required"
+;;
+
+let runtime_handler_to_string = function
+  | Tool_execute -> "tool_execute"
+  | Tool_search_files -> "tool_search_files"
+  | Tool_read_file -> "tool_read_file"
+  | Tool_edit_file -> "tool_edit_file"
+  | Tool_write_file -> "tool_write_file"
+  | Tool_remote_mcp -> "tool_remote_mcp"
 ;;
 
 let policy ?readonly ?effect_domain ?(approval = Policy_selected) ?cwd_scope
@@ -270,7 +288,7 @@ let translate_search_files input =
 ;;
 
 let descriptor ~id ~public_name ~internal_name ~description ~input_schema ~policy
-      ~executor ~backend ~sandbox ~translate
+      ~executor ~backend ~sandbox ~runtime_handler ~translate
   =
   let receipt_labels =
     [ "descriptor_id", id
@@ -279,6 +297,7 @@ let descriptor ~id ~public_name ~internal_name ~description ~input_schema ~polic
     ; "executor", executor_to_string executor
     ; "backend", backend_to_string backend
     ; "sandbox", sandbox_to_string sandbox
+    ; "runtime_handler", runtime_handler_to_string runtime_handler
     ]
   in
   { id
@@ -290,6 +309,7 @@ let descriptor ~id ~public_name ~internal_name ~description ~input_schema ~polic
   ; executor
   ; backend
   ; sandbox
+  ; runtime_handler
   ; translate
   ; receipt_labels
   }
@@ -313,6 +333,7 @@ let public_descriptors =
       ~executor:Shell_ir
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
+      ~runtime_handler:Tool_execute
       ~translate:translate_identity
   ; descriptor
       ~id:"agent.search_files"
@@ -330,6 +351,7 @@ let public_descriptors =
       ~executor:Shell_ir
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
+      ~runtime_handler:Tool_search_files
       ~translate:translate_search_files
   ; descriptor
       ~id:"agent.read_file"
@@ -347,6 +369,7 @@ let public_descriptors =
       ~executor:Filesystem
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
+      ~runtime_handler:Tool_read_file
       ~translate:translate_read_file
   ; descriptor
       ~id:"agent.edit_file"
@@ -363,6 +386,7 @@ let public_descriptors =
       ~executor:Filesystem
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
+      ~runtime_handler:Tool_edit_file
       ~translate:translate_edit_file
   ; descriptor
       ~id:"agent.write_file"
@@ -379,6 +403,7 @@ let public_descriptors =
       ~executor:Filesystem
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
+      ~runtime_handler:Tool_write_file
       ~translate:translate_write_file
   ; descriptor
       ~id:"agent.search_web"
@@ -396,6 +421,7 @@ let public_descriptors =
       ~executor:Remote_mcp
       ~backend:Remote_service
       ~sandbox:No_sandbox
+      ~runtime_handler:Tool_remote_mcp
       ~translate:translate_identity
   ; descriptor
       ~id:"agent.fetch_web"
@@ -413,6 +439,7 @@ let public_descriptors =
       ~executor:Remote_mcp
       ~backend:Remote_service
       ~sandbox:No_sandbox
+      ~runtime_handler:Tool_remote_mcp
       ~translate:translate_identity
   ]
 ;;
@@ -471,6 +498,7 @@ let route_evidence_json d =
      ; "executor", `String (executor_to_string d.executor)
      ; "backend", `String (backend_to_string d.backend)
      ; "sandbox", `String (sandbox_to_string d.sandbox)
+     ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
      ; "approval", `String (approval_to_string policy.approval)
      ; "retryable", `Bool policy.retryable
      ; "cwd_scope", string_opt_to_json policy.cwd_scope

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -31,6 +31,14 @@ type approval =
   | Policy_selected
   | Human_required
 
+type runtime_handler =
+  | Tool_execute
+  | Tool_search_files
+  | Tool_read_file
+  | Tool_edit_file
+  | Tool_write_file
+  | Tool_remote_mcp
+
 type policy =
   { visibility : Tool_catalog.visibility
   ; readonly : bool option
@@ -51,6 +59,7 @@ type t =
   ; executor : executor
   ; backend : backend
   ; sandbox : sandbox
+  ; runtime_handler : runtime_handler
   ; translate : Yojson.Safe.t -> Yojson.Safe.t
   ; receipt_labels : (string * string) list
   }
@@ -59,6 +68,7 @@ val executor_to_string : executor -> string
 val backend_to_string : backend -> string
 val sandbox_to_string : sandbox -> string
 val approval_to_string : approval -> string
+val runtime_handler_to_string : runtime_handler -> string
 
 val public_descriptors : t list
 val public_names : unit -> string list

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -1,0 +1,72 @@
+(** Runtime dispatch for descriptor-backed agent tools. *)
+
+open Agent_tool_descriptor
+
+type context =
+  { config : Coord.config
+  ; meta : Keeper_types.keeper_meta
+  ; turn_sandbox_factory : Keeper_sandbox_factory.t option
+  ; turn_sandbox_factory_git : Keeper_sandbox_factory.t option
+  ; exec_cache : Masc_exec.Exec_cache.t option
+  }
+
+let descriptor_for_internal internal_name =
+  match Agent_tool_descriptor.public_descriptors_for_internal internal_name with
+  | descriptor :: _ -> Some descriptor
+  | [] -> None
+;;
+
+let handle_filesystem ctx descriptor args =
+  match descriptor.Agent_tool_descriptor.runtime_handler with
+  | Tool_read_file ->
+    Some
+      (Keeper_exec_fs.handle_keeper_fs_read
+         ~turn_sandbox_factory:ctx.turn_sandbox_factory
+         ~config:ctx.config
+         ~keeper_name:ctx.meta.name
+         ~args)
+  | Tool_edit_file | Tool_write_file ->
+    Some
+      (Keeper_exec_fs.handle_keeper_fs_edit
+         ~turn_sandbox_factory:ctx.turn_sandbox_factory
+         ~config:ctx.config
+         ~keeper_name:ctx.meta.name
+         ~args)
+  | Tool_execute | Tool_search_files | Tool_remote_mcp -> None
+;;
+
+let handle_shell_ir ctx descriptor args =
+  match descriptor.Agent_tool_descriptor.runtime_handler with
+  | Tool_execute ->
+    Some
+      (Keeper_exec_shell.handle_tool_execute
+         ~turn_sandbox_factory:ctx.turn_sandbox_factory
+         ~turn_sandbox_factory_git:ctx.turn_sandbox_factory_git
+         ~exec_cache:ctx.exec_cache
+         ~config:ctx.config
+         ~meta:ctx.meta
+         ~args
+         ())
+  | Tool_search_files ->
+    Some
+      (Keeper_exec_shell.handle_tool_search_files
+         ~turn_sandbox_factory:ctx.turn_sandbox_factory
+         ~exec_cache:ctx.exec_cache
+         ~config:ctx.config
+         ~meta:ctx.meta
+         ~args)
+  | Tool_read_file | Tool_edit_file | Tool_write_file | Tool_remote_mcp -> None
+;;
+
+let handle ctx ~descriptor ~args =
+  match descriptor.Agent_tool_descriptor.executor with
+  | Filesystem -> handle_filesystem ctx descriptor args
+  | Shell_ir -> handle_shell_ir ctx descriptor args
+  | Remote_mcp | In_process | Gh_cli | Oas_bridge -> None
+;;
+
+let handle_internal ctx ~name ~args =
+  match descriptor_for_internal name with
+  | None -> None
+  | Some descriptor -> handle ctx ~descriptor ~args
+;;

--- a/lib/keeper/agent_tool_runtime.mli
+++ b/lib/keeper/agent_tool_runtime.mli
@@ -1,0 +1,20 @@
+(** Runtime dispatch for descriptor-backed agent tools.
+
+    [Keeper_exec_tools] owns cross-cutting execution bookkeeping. This module
+    owns the descriptor-selected lowerer/handler route for first-class agent
+    tools such as [Execute], [ReadFile], and [SearchFiles]. *)
+
+type context =
+  { config : Coord.config
+  ; meta : Keeper_types.keeper_meta
+  ; turn_sandbox_factory : Keeper_sandbox_factory.t option
+  ; turn_sandbox_factory_git : Keeper_sandbox_factory.t option
+  ; exec_cache : Masc_exec.Exec_cache.t option
+  }
+
+val descriptor_for_internal : string -> Agent_tool_descriptor.t option
+
+val handle :
+  context -> descriptor:Agent_tool_descriptor.t -> args:Yojson.Safe.t -> string option
+
+val handle_internal : context -> name:string -> args:Yojson.Safe.t -> string option

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -412,7 +412,19 @@ let execute_keeper_tool_call_with_outcome
                 ; "hint", `String hint
                 ])))
      else (
-       match name with
+       let agent_tool_runtime_context =
+         Agent_tool_runtime.
+           { config
+           ; meta
+           ; turn_sandbox_factory
+           ; turn_sandbox_factory_git
+           ; exec_cache
+           }
+       in
+       match Agent_tool_runtime.handle_internal agent_tool_runtime_context ~name ~args with
+       | Some raw_output -> make_executed_tool_result raw_output
+       | None ->
+       (match name with
        | _ when is_keeper_board_tool_name name ->
          make_executed_tool_result
            (Keeper_exec_board.handle_keeper_board_tool ~meta ~name ~args)
@@ -463,43 +475,11 @@ let execute_keeper_tool_call_with_outcome
            Tool_library.handle_read ~tool_name:"keeper_library_read" ~start_time:0.0 Tool_library.{ agent_name = meta.name } args
          in
          if result.Tool_result.success then success_tool_result result.Tool_result.message else failure_tool_result (error_json result.Tool_result.message)
-       | "tool_read_file" ->
-         make_executed_tool_result
-           (Keeper_exec_fs.handle_keeper_fs_read
-              ~turn_sandbox_factory
-              ~config
-              ~keeper_name:meta.name
-              ~args)
-       | "tool_edit_file" | "tool_write_file" ->
-         make_executed_tool_result
-           (Keeper_exec_fs.handle_keeper_fs_edit
-              ~turn_sandbox_factory
-              ~config
-              ~keeper_name:meta.name
-              ~args)
        | "keeper_ide_annotate" ->
          make_executed_tool_result
            (Keeper_exec_ide.handle_keeper_ide_annotate
               ~config
               ~keeper_name:meta.name
-              ~args)
-       | "tool_execute" ->
-         make_executed_tool_result
-           (Keeper_exec_shell.handle_tool_execute
-              ~turn_sandbox_factory
-              ~turn_sandbox_factory_git
-              ~exec_cache
-              ~config
-              ~meta
-              ~args
-              ())
-       | "tool_search_files" ->
-         make_executed_tool_result
-           (Keeper_exec_shell.handle_tool_search_files
-              ~turn_sandbox_factory
-              ~exec_cache
-              ~config
-              ~meta
               ~args)
        | "keeper_voice_speak"
        | "keeper_voice_listen"
@@ -599,6 +579,7 @@ let execute_keeper_tool_call_with_outcome
                 ]
             in
             make_executed_tool_result (Yojson.Safe.to_string (`Assoc fields)))))
+       ))
 ;;
 
 let execute_keeper_tool_call

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -330,6 +330,21 @@ let test_shell_shared_is_removed () =
   assert_not_contains exec_tools_ml "Keeper_shell_shared.";
   assert_not_contains exec_shell_ml "Keeper_shell_shared"
 
+let test_descriptor_backed_dispatch_uses_agent_tool_runtime () =
+  let exec_tools_ml = "lib/keeper/keeper_exec_tools.ml" in
+  let runtime_ml = "lib/keeper/agent_tool_runtime.ml" in
+  assert_contains "lib/dune" "agent_tool_runtime";
+  assert_contains runtime_ml "Agent_tool_descriptor.public_descriptors_for_internal";
+  assert_contains runtime_ml "Keeper_exec_shell.handle_tool_execute";
+  assert_contains runtime_ml "Keeper_exec_shell.handle_tool_search_files";
+  assert_contains runtime_ml "Keeper_exec_fs.handle_keeper_fs_read";
+  assert_contains runtime_ml "Keeper_exec_fs.handle_keeper_fs_edit";
+  assert_contains exec_tools_ml "Agent_tool_runtime.handle_internal";
+  assert_not_contains exec_tools_ml "Keeper_exec_shell.handle_tool_execute";
+  assert_not_contains exec_tools_ml "Keeper_exec_shell.handle_tool_search_files";
+  assert_not_contains exec_tools_ml "Keeper_exec_fs.handle_keeper_fs_read";
+  assert_not_contains exec_tools_ml "Keeper_exec_fs.handle_keeper_fs_edit"
+
 let test_shell_ops_host_ir_uses_keeper_shell_ir_facade () =
   let shell_ops_ml = "lib/keeper/keeper_shell_ops.ml" in
   let read_ops_ml = "lib/keeper/keeper_shell_read_ops.ml" in
@@ -643,6 +658,10 @@ let () =
             "shell shared compatibility facade is removed"
             `Quick
             test_shell_shared_is_removed;
+          Alcotest.test_case
+            "descriptor-backed dispatch uses agent tool runtime"
+            `Quick
+            test_descriptor_backed_dispatch_uses_agent_tool_runtime;
           Alcotest.test_case
             "shell ops host IR uses keeper shell IR facade"
             `Quick

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -8,6 +8,7 @@ module Alias = Masc_mcp.Keeper_tool_alias
 module Descriptor = Masc_mcp.Agent_tool_descriptor
 module Disclosure = Masc_mcp.Keeper_tool_disclosure
 module Resolution = Masc_mcp.Keeper_tool_resolution
+module Runtime = Masc_mcp.Agent_tool_runtime
 
 let route_internal name =
   match Alias.route name with
@@ -439,6 +440,10 @@ let test_descriptor_route_evidence_names_policy_backend_sandbox_and_description 
     (Some "backend_selected")
     (yojson_string_field "sandbox" evidence);
   Alcotest.(check (option string))
+    "runtime handler"
+    (Some "tool_execute")
+    (yojson_string_field "runtime_handler" evidence);
+  Alcotest.(check (option string))
     "visibility"
     (Some "default")
     (yojson_string_field "visibility" evidence);
@@ -457,6 +462,24 @@ let test_descriptor_route_evidence_names_policy_backend_sandbox_and_description 
        true
        (String.starts_with ~prefix:"Execute one typed command" description)
    | None -> Alcotest.fail "description missing")
+;;
+
+let test_agent_tool_runtime_resolves_descriptor_handlers () =
+  let check_descriptor internal expected_id =
+    match Runtime.descriptor_for_internal internal with
+    | Some descriptor ->
+      Alcotest.(check string) (internal ^ " descriptor id") expected_id descriptor.id
+    | None -> Alcotest.failf "missing descriptor for %s" internal
+  in
+  check_descriptor "tool_execute" "agent.execute";
+  check_descriptor "tool_search_files" "agent.search_files";
+  check_descriptor "tool_read_file" "agent.read_file";
+  check_descriptor "tool_edit_file" "agent.edit_file";
+  check_descriptor "tool_write_file" "agent.write_file";
+  Alcotest.(check bool)
+    "unaliased keeper tool has no agent descriptor"
+    true
+    (Option.is_none (Runtime.descriptor_for_internal "keeper_board_post"))
 ;;
 
 let string_contains ~sub text =
@@ -974,6 +997,10 @@ let () =
             "descriptor evidence names policy route"
             `Quick
             test_descriptor_route_evidence_names_policy_backend_sandbox_and_description
+        ; Alcotest.test_case
+            "agent tool runtime resolves descriptor handlers"
+            `Quick
+            test_agent_tool_runtime_resolves_descriptor_handlers
         ; Alcotest.test_case
             "translate Execute input shape"
             `Quick


### PR DESCRIPTION
## Summary
- add Agent_tool_runtime as the descriptor-selected runtime owner for first-class agent tools
- add a runtime_handler axis to Agent_tool_descriptor and route evidence
- remove direct tool_execute/tool_search_files/file handler branches from Keeper_exec_tools
- add boundary tests that pin descriptor-backed dispatch outside Keeper_exec_tools

## Verification
- ocamlformat --check lib/keeper/agent_tool_descriptor.ml lib/keeper/agent_tool_descriptor.mli lib/keeper/agent_tool_runtime.ml lib/keeper/agent_tool_runtime.mli lib/keeper/keeper_exec_tools.ml test/test_keeper_sandbox_boundary_policy.ml test/test_keeper_tool_alias.ml
- git diff --check
- git diff --cached --check
- scripts/dune-local.sh build test/test_keeper_exec_tools.exe test/test_keeper_tool_alias.exe test/test_keeper_sandbox_boundary_policy.exe (blocked by live bare Dune processes; stuck >60m Dune processes were cleaned with scripts/check-stuck-dune.sh --kill, but other active bare Dune jobs still made the guard refuse)
