### PR TITLE
refactor(keeper): drop alert paths from types facade

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 12:44:10 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 12:46:43 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -385,9 +385,15 @@
           </tr>
           <tr>
             <td><code>Keeper_types</code> history-source facade leaves</td>
-            <td><span class="status now">draft PR #18578</span></td>
+            <td><span class="status done">merged #18578</span></td>
             <td>Stop exposing <code>normalize_history_source</code> and <code>is_prompt_history_source</code> through the broad <code>Keeper_types</code> facade. History routing callers now use <code>Keeper_types_support.is_prompt_history_source</code> directly.</td>
             <td>Backstop grep must stay clean for <code>Keeper_types.is_prompt_history_source</code>, <code>Keeper_types.normalize_history_source</code>, and the removed public signature values.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_types</code> alert path facade leaves</td>
+            <td><span class="status now">local branch</span></td>
+            <td>Stop exposing alert/retry/deadletter path helpers through the broad <code>Keeper_types</code> facade. The remaining dashboard summary caller now uses <code>Keeper_types_support.keeper_alerts_path</code> directly.</td>
+            <td>Backstop grep must stay clean for <code>Keeper_types.keeper_alerts_path</code>, <code>Keeper_types.keeper_alert_retry_path</code>, and <code>Keeper_types.keeper_alert_deadletter_path</code>.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.write_meta_with_retry</code> wrapper</td>

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -559,7 +559,7 @@ Keeper turn에서 어떤 "skill" 경로를 사용할지 결정:
 
 ### 15.2 keeper_types.ml include chain
 
-`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history-source/metrics/API-key support helper를 `Keeper_types_support` 소유로 돌렸지만, 일부 support helper 선별 re-export와 구현 include chain 자체는 남아 있어 가독성이 낮다.
+`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history-source/metrics/API-key/alert-path support helper를 `Keeper_types_support` 소유로 돌렸지만, 일부 support helper 선별 re-export와 구현 include chain 자체는 남아 있어 가독성이 낮다.
 
 ### 15.3 keeper_memory 계층의 include chain
 

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -839,7 +839,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
   let summaries = Array.to_list results |> List.filter_map Fun.id in
   (* H-9 fix: include recent alerts so BAD alerts are visible on dashboard *)
   let recent_alerts =
-    let alerts_path = Keeper_types.keeper_alerts_path config in
+    let alerts_path = Keeper_types_support.keeper_alerts_path config in
     let lines =
       Keeper_memory.read_file_tail_lines alerts_path ~max_bytes:50000 ~max_lines:10
     in

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -454,9 +454,6 @@ val keeper_policy_log_path : Coord.config -> string -> string
 val keeper_decision_log_path : Coord.config -> string -> string
 val keeper_feedback_log_path : Coord.config -> string -> string
 val keeper_dataset_export_path : Coord.config -> string -> string
-val keeper_alerts_path : Coord.config -> string
-val keeper_alert_retry_path : Coord.config -> string
-val keeper_alert_deadletter_path : Coord.config -> string
 
 (** Rotate [path] if it exceeds the configured size threshold.
     Keeps at most [Env_config.KeeperMetrics.max_rotated_files] numbered


### PR DESCRIPTION
## Summary
- remove alert, retry, and deadletter path declarations from the public Keeper_types facade
- route the remaining dashboard summary caller to Keeper_types_support.keeper_alerts_path
- refresh the legacy purge ledger/spec note for the support-owner migration

## Verification
- ocamlformat --check lib/keeper/keeper_types.mli lib/dashboard/dashboard_http_keeper.ml
- rg -n "Keeper_types\.(keeper_alerts_path|keeper_alert_retry_path|keeper_alert_deadletter_path)\b" lib test bin scripts (no matches)
- rg -n "val keeper_alerts_path|val keeper_alert_retry_path|val keeper_alert_deadletter_path" lib/keeper/keeper_types.mli (no matches)
- git diff --check
- scripts/audit-keeper-tool-boundary-matrix.sh
- scripts/ocaml-structure-ratchet.sh
- scripts/stringly-boundary-ratchet.sh
- scripts/oas-boundary-ratchet.sh
- scripts/lint/no-unknown-permissive-default.sh
- scripts/lint/no-ocaml-comment-terminator-trap.sh
- scripts/lint-ignore-without-comment.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

Focused Dune attempted but blocked by the machine-wide bare-Dune guard: scripts/dune-local.sh build test/test_dashboard_keeper_routes.exe test/test_dashboard_k2_feeds.exe test/test_keeper_unified.exe exited 75 because live bare dune processes were present. I did not bypass the guard.