### PR TITLE
fix(keeper): batch egress audit missing warnings

### DIFF
--- a/lib/keeper/keeper_egress_audit.ml
+++ b/lib/keeper/keeper_egress_audit.ml
@@ -99,6 +99,30 @@ let format_log_line (r : result) =
          orphan_at=%s"
         r.keeper_name profile expected_path orphan_path
 
+let format_missing_summary_line results =
+  let missing_entries =
+    results
+    |> List.filter_map (fun r ->
+      match r.status with
+      | Missing_at_expected { expected_path } ->
+          Some (r.keeper_name, expected_path)
+      | Ok_present | Stale_orphan _ -> None)
+    |> List.sort (fun (left, _) (right, _) -> String.compare left right)
+  in
+  match missing_entries with
+  | [] -> None
+  | entries ->
+      let keepers = entries |> List.map fst |> String.concat "," in
+      let expected =
+        entries
+        |> List.map (fun (keeper, path) -> Printf.sprintf "%s:%s" keeper path)
+        |> String.concat ","
+      in
+      Some
+        (Printf.sprintf
+           "[egress_audit:missing_summary] count=%d keepers=%s expected=%s"
+           (List.length entries) keepers expected)
+
 let inactive_missing_reason (meta : Keeper_types.keeper_meta) =
   if meta.paused then Some "paused"
   else if not meta.autoboot_enabled then Some "autoboot_disabled"

--- a/lib/keeper/keeper_egress_audit.mli
+++ b/lib/keeper/keeper_egress_audit.mli
@@ -37,6 +37,10 @@ val format_log_line : result -> string
 (** Grep-friendly one-line summary tagged
     [[egress_audit:ok|missing|stale_orphan]]. *)
 
+val format_missing_summary_line : result list -> string option
+(** Single WARN-line summary for active missing policies. Keeps boot logs
+    bounded while per-keeper metrics still preserve cardinality. *)
+
 val inactive_missing_reason : Keeper_types.keeper_meta -> string option
 (** [Some reason] when a missing egress policy should not page operators
     because the keeper is intentionally inactive. *)

--- a/lib/server/server_runtime_startup_credentials.ml
+++ b/lib/server/server_runtime_startup_credentials.ml
@@ -60,8 +60,10 @@ let audit_keeper_egress_policies (state : Mcp_server.server_state) =
     List.iter (fun r ->
       Log.Misc.info "%s" (Keeper_egress_audit.format_log_line r))
       oks;
+    (match Keeper_egress_audit.format_missing_summary_line active_missings with
+     | Some line -> Log.Misc.warn "%s" line
+     | None -> ());
     List.iter (fun r ->
-      Log.Misc.warn "%s" (Keeper_egress_audit.format_log_line r);
       Prometheus.inc_counter Prometheus.metric_egress_audit_missing
         ~labels:[("keeper", r.Keeper_egress_audit.keeper_name)] ())
       active_missings;

--- a/test/test_keeper_egress_audit.ml
+++ b/test/test_keeper_egress_audit.ml
@@ -150,6 +150,16 @@ let starts_with prefix s =
   String.length s >= String.length prefix
   && String.sub s 0 (String.length prefix) = prefix
 
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if i + needle_len > haystack_len then false
+    else if String.sub haystack i needle_len = needle then true
+    else loop (i + 1)
+  in
+  needle_len = 0 || loop 0
+
 let test_format_log_line_tags () =
   let config = make_config () in
   let m = make_meta ~name:"sangsu" ~sandbox:Keeper_types.Docker () in
@@ -165,6 +175,35 @@ let test_format_log_line_tags () =
     "ok line tagged [egress_audit:ok]" true
     (starts_with "[egress_audit:ok]"
        (Keeper_egress_audit.format_log_line r_ok))
+
+let test_missing_summary_line () =
+  let config = make_config () in
+  let analyst =
+    make_meta ~name:"analyst" ~sandbox:Keeper_types.Docker ()
+  in
+  let base = make_meta ~name:"base" ~sandbox:Keeper_types.Docker () in
+  let results =
+    [
+      Keeper_egress_audit.audit_one ~config ~meta:base;
+      Keeper_egress_audit.audit_one ~config ~meta:analyst;
+    ]
+  in
+  match Keeper_egress_audit.format_missing_summary_line results with
+  | None -> Alcotest.fail "expected missing summary line"
+  | Some line ->
+      Alcotest.(check bool)
+        "summary line tagged" true
+        (starts_with "[egress_audit:missing_summary]" line);
+      Alcotest.(check bool)
+        "summary has count" true
+        (contains_substring line "count=2");
+      Alcotest.(check bool)
+        "summary sorts keepers" true
+        (contains_substring line "keepers=analyst,base");
+      Alcotest.(check bool)
+        "summary has expected paths" true
+        (contains_substring line "analyst:"
+         && contains_substring line "base:")
 
 let test_inactive_missing_reason () =
   let reason meta =
@@ -209,6 +248,8 @@ let () =
       ( "log format",
         [
           Alcotest.test_case "tag prefixes" `Quick test_format_log_line_tags;
+          Alcotest.test_case "missing summary line" `Quick
+            test_missing_summary_line;
         ] );
       ( "warning suppression",
         [


### PR DESCRIPTION
## Summary

- Batch active egress-policy missing audit rows into one WARN line per startup.
- Keep per-keeper Prometheus increments for missing egress policies.
- Add a focused regression test for the missing-summary formatter.

## Log Evidence

- 2026-05-26 system log: 8 repeated WARN rows for the same active missing egress files across two startup audits:
  - analyst -> /Users/dancer/me/.masc/playground/docker/analyst/egress.json
  - verifier -> /Users/dancer/me/.masc/playground/docker/verifier/egress.json
  - albini -> /Users/dancer/me/.masc/playground/albini/egress.json
  - base -> /Users/dancer/me/.masc/playground/docker/base/egress.json
- 2026-05-25 system log shows the same pattern repeating across multiple boot/audit windows.

## Verification

- ocamlformat --check lib/keeper/keeper_egress_audit.ml lib/keeper/keeper_egress_audit.mli lib/server/server_runtime_startup_credentials.ml test/test_keeper_egress_audit.ml
- ocamlc -stop-after parsing lib/keeper/keeper_egress_audit.ml
- ocamlc -stop-after parsing lib/keeper/keeper_egress_audit.mli
- ocamlc -stop-after parsing lib/server/server_runtime_startup_credentials.ml
- ocamlc -stop-after parsing test/test_keeper_egress_audit.ml
- git diff --check

Focused Dune target attempted:

- scripts/dune-local.sh build test/test_keeper_egress_audit.exe

Result: blocked by live bare Dune processes outside scripts/dune-local.sh; wrapper refused to start another local build.
