### PR TITLE
refactor(keeper): drop rotation helper from types facade

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 12:46:43 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 12:57:54 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -391,9 +391,15 @@
           </tr>
           <tr>
             <td><code>Keeper_types</code> alert path facade leaves</td>
-            <td><span class="status now">local branch</span></td>
+            <td><span class="status done">merged #18582</span></td>
             <td>Stop exposing alert/retry/deadletter path helpers through the broad <code>Keeper_types</code> facade. The remaining dashboard summary caller now uses <code>Keeper_types_support.keeper_alerts_path</code> directly.</td>
             <td>Backstop grep must stay clean for <code>Keeper_types.keeper_alerts_path</code>, <code>Keeper_types.keeper_alert_retry_path</code>, and <code>Keeper_types.keeper_alert_deadletter_path</code>.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_types.maybe_rotate_file</code> facade leaf</td>
+            <td><span class="status now">draft PR #18584</span></td>
+            <td>Stop exposing the support-owned metrics rotation helper through the broad <code>Keeper_types</code> facade. Rotation tests now call <code>Keeper_types_support.maybe_rotate_file</code> directly.</td>
+            <td>Backstop grep must stay clean for <code>Keeper_types.maybe_rotate_file</code> and the removed public signature value.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.write_meta_with_retry</code> wrapper</td>

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -559,7 +559,7 @@ Keeper turn에서 어떤 "skill" 경로를 사용할지 결정:
 
 ### 15.2 keeper_types.ml include chain
 
-`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history-source/metrics/API-key/alert-path support helper를 `Keeper_types_support` 소유로 돌렸지만, 일부 support helper 선별 re-export와 구현 include chain 자체는 남아 있어 가독성이 낮다.
+`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history-source/metrics/API-key/alert-path/rotation support helper를 `Keeper_types_support` 소유로 돌렸지만, 일부 support helper 선별 re-export와 구현 include chain 자체는 남아 있어 가독성이 낮다.
 
 ### 15.3 keeper_memory 계층의 include chain
 

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -455,11 +455,6 @@ val keeper_decision_log_path : Coord.config -> string -> string
 val keeper_feedback_log_path : Coord.config -> string -> string
 val keeper_dataset_export_path : Coord.config -> string -> string
 
-(** Rotate [path] if it exceeds the configured size threshold.
-    Keeps at most [Env_config.KeeperMetrics.max_rotated_files] numbered
-    backups (.1, .2, ...). *)
-val maybe_rotate_file : string -> unit
-
 (** {1 Fiber health (for keeper supervisor)} *)
 
 type fiber_health =

--- a/test/test_metrics_rotation.ml
+++ b/test/test_metrics_rotation.ml
@@ -29,7 +29,7 @@ let test_no_rotation_under_threshold () =
   Fun.protect ~finally:(fun () -> cleanup dir) (fun () ->
     let path = Filename.concat dir "test.metrics.jsonl" in
     write_bytes path 100;
-    Keeper_types.maybe_rotate_file path;
+    Keeper_types_support.maybe_rotate_file path;
     check bool "original exists" true (Sys.file_exists path);
     check bool "no .1 file" false (Sys.file_exists (path ^ ".1")))
 
@@ -39,7 +39,7 @@ let test_rotation_at_threshold () =
     let path = Filename.concat dir "test.metrics.jsonl" in
     (* Write just at the default 10MB threshold *)
     write_bytes path 10_485_760;
-    Keeper_types.maybe_rotate_file path;
+    Keeper_types_support.maybe_rotate_file path;
     check bool "original removed (renamed)" false (Sys.file_exists path);
     check bool ".1 exists" true (Sys.file_exists (path ^ ".1"));
     check int ".1 has original size" 10_485_760 (file_size (path ^ ".1")))
@@ -52,7 +52,7 @@ let test_rotation_shifts_existing () =
     write_bytes (path ^ ".1") 50;
     (* Write large current file *)
     write_bytes path 10_485_760;
-    Keeper_types.maybe_rotate_file path;
+    Keeper_types_support.maybe_rotate_file path;
     check bool ".1 is the new rotation" true (Sys.file_exists (path ^ ".1"));
     check int ".1 is the big file" 10_485_760 (file_size (path ^ ".1")))
 
@@ -61,7 +61,7 @@ let test_nonexistent_file () =
   Fun.protect ~finally:(fun () -> cleanup dir) (fun () ->
     let path = Filename.concat dir "nonexistent.jsonl" in
     (* Should not raise *)
-    Keeper_types.maybe_rotate_file path;
+    Keeper_types_support.maybe_rotate_file path;
     check bool "no file created" false (Sys.file_exists path))
 
 let test_append_with_rotation () =


### PR DESCRIPTION
## Summary
- remove maybe_rotate_file from the public Keeper_types facade
- route metrics rotation tests to Keeper_types_support.maybe_rotate_file directly
- refresh the legacy purge ledger/spec note for the support-owner migration

## Verification
- ocamlformat --check lib/keeper/keeper_types.mli test/test_metrics_rotation.ml
- rg -n "Keeper_types\.maybe_rotate_file\b" lib test bin scripts (no matches)
- rg -n "val maybe_rotate_file" lib/keeper/keeper_types.mli (no matches)
- git diff --check
- scripts/audit-keeper-tool-boundary-matrix.sh
- scripts/ocaml-structure-ratchet.sh
- scripts/stringly-boundary-ratchet.sh
- scripts/oas-boundary-ratchet.sh
- scripts/lint/no-unknown-permissive-default.sh
- scripts/lint/no-ocaml-comment-terminator-trap.sh
- scripts/lint-ignore-without-comment.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

Focused Dune attempted but blocked by the machine-wide bare-Dune guard: scripts/dune-local.sh build test/test_metrics_rotation.exe exited 75 because live bare dune processes were present. I did not bypass the guard.