### PR TITLE
refactor(http): sweep 4 dead handlers cascaded from default_routes (35 LoC)

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -522,30 +522,6 @@ module Router = struct
     | `Method_not_allowed -> Response.method_not_allowed reqd
 end
 
-(** Health check endpoint - JSON response *)
-let health_handler _request reqd =
-  let json = Yojson.Safe.to_string (`Assoc [("status", `String "ok"); ("server", `String "masc-mcp"); ("version", `String Version.version)]) in
-  Response.json json reqd
-
-(** Readiness probe - Kubernetes *)
-let ready_handler _request reqd =
-  let body = Yojson.Safe.to_string (Server_startup_state.to_yojson ()) in
-  let status =
-    if (!Server_startup_state.state).state_ready then `OK
-    else `Service_unavailable
-  in
-  Response.json ~status body reqd
-
-(** Prometheus metrics endpoint *)
-let metrics_handler _request reqd =
-  let body = Prometheus.to_prometheus_text () in
-  let headers = Httpun.Headers.of_list [
-    ("content-type", "text/plain; version=0.0.4; charset=utf-8");
-    ("content-length", string_of_int (String.length body));
-  ] in
-  let response = Httpun.Response.create ~headers `OK in
-  safe_respond_with_string reqd response body
-
 let mcp_post_handler
     ?request_handler
     (request : Httpun.Request.t)
@@ -589,17 +565,6 @@ let mcp_post_handler
             | _ -> `Bad_request
           in
           Response.text ~status message reqd
-
-(** MCP Streamable HTTP handler (GET /mcp) - SSE stream *)
-let mcp_get_handler request reqd =
-  let session_id = Streamable_http.get_session_id request in
-  match Streamable_http.handle_get ?session_id () with
-  | Ok session ->
-      (* Return session info, actual SSE handled elsewhere *)
-      let json = Yojson.Safe.to_string (`Assoc [("session_id", `String session.id); ("transport", `String "streamable_http")]) in
-      Response.json json reqd
-  | Error msg ->
-      Response.text ~status:`Bad_request msg reqd
 
 let with_streamable_mcp_request_handler ~request_handler routes =
   let replace_post_mcp route =


### PR DESCRIPTION
## Summary
Follow-up to #18579 (default_routes removal, merged at `396b77d77`). The 4 handlers `default_routes` referenced are now dead.

| Handler | Ref count post-#18579 | Verdict |
|---|---:|---|
| `health_handler` | 1 (def only) | **DEAD** |
| `ready_handler` | 1 (def only) | **DEAD** |
| `metrics_handler` | 1 (def only) | **DEAD** |
| `mcp_get_handler` | 1 (def only) | **DEAD** |
| `mcp_post_handler` | 3 (def + 2 in `with_streamable_mcp_request_handler`) | **ALIVE** (kept) |

## Audit
5-prong (qualified / `open`+bare / include / 4-alias / test): all 0 for each removed handler. mli surface: none of the 4 exposed via `val`. See me#1175 commit `d5d69d013d` for full audit data.

## Removed (35 LoC, 0 additions)
- `health_handler` (lines 525-528) — /health JSON probe
- `ready_handler` (530-537) — Kubernetes readiness
- `metrics_handler` (539-547) — Prometheus metrics
- `mcp_get_handler` (593-602) — MCP HTTP GET

## Intentionally NOT in this PR
- `let run` (line 671) + `error_handler` (659) — bigger audit needed. `error_handler` is only used inside `run`, cascades dead iff `run` is dead.
- Stale mli docstring lines 10-20 — references removed `[Shutdown]`, `[start]`, plus the 4 handlers in this PR. Separate doc-only PR if desired.

## Build verification
- Base: origin/main HEAD `761821aaf` (post-#18579 merge)
- `dune build bin/main_eio.exe`: 3 pre-existing `lib/keeper/` errors (`keeper_agent_name`). No new errors.
- Diff: 35 deletions, 0 additions.

## Workaround signature self-check (CLAUDE.md `feedback_telemetry_as_fix_self_recurrence`)
| Signature | Status |
|---|---|
| Telemetry-as-fix | ❌ removes code |
| String classifier | ❌ no |
| N-of-M | ❌ 4-of-4 dead, single sweep |
| Catch-all addition | ❌ no |
| Cap/cooldown | ❌ no |
| Test backdoor | ❌ no |
| N-site typo | ❌ no |

## Related
- me#1175 — analysis + audit evidence
- masc-mcp#18579 — parent (default_routes removal, merged)
- masc-mcp#18567 — grandparent (Http_server_eio.start removal, merged)
- masc-mcp#18573 — sibling (Runtime_events wiring, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>