### PR TITLE
refactor(keeper): route remote descriptors through agent runtime

### DIFF
--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -58,11 +58,36 @@ let handle_shell_ir ctx descriptor args =
   | Tool_read_file | Tool_edit_file | Tool_write_file | Tool_remote_mcp -> None
 ;;
 
+let handle_remote_mcp ctx descriptor args =
+  match descriptor.Agent_tool_descriptor.runtime_handler with
+  | Tool_remote_mcp ->
+    Some
+      (match
+         Keeper_exec_masc.handle_registered_keeper_tool
+           ~config:ctx.config
+           ~keeper_name:ctx.meta.name
+           ~name:descriptor.internal_name
+           ~args
+       with
+       | Some raw_output -> raw_output
+       | None ->
+         Keeper_exec_shared.error_json
+           (Printf.sprintf
+              "descriptor remote tool handler is not registered: %s"
+              descriptor.internal_name))
+  | Tool_execute
+  | Tool_search_files
+  | Tool_read_file
+  | Tool_edit_file
+  | Tool_write_file -> None
+;;
+
 let handle ctx ~descriptor ~args =
   match descriptor.Agent_tool_descriptor.executor with
   | Filesystem -> handle_filesystem ctx descriptor args
   | Shell_ir -> handle_shell_ir ctx descriptor args
-  | Remote_mcp | In_process | Gh_cli | Oas_bridge -> None
+  | Remote_mcp -> handle_remote_mcp ctx descriptor args
+  | In_process | Gh_cli | Oas_bridge -> None
 ;;
 
 let handle_internal ctx ~name ~args =

--- a/lib/keeper/agent_tool_runtime.mli
+++ b/lib/keeper/agent_tool_runtime.mli
@@ -2,7 +2,7 @@
 
     [Keeper_exec_tools] owns cross-cutting execution bookkeeping. This module
     owns the descriptor-selected lowerer/handler route for first-class agent
-    tools such as [Execute], [ReadFile], and [SearchFiles]. *)
+    tools such as [Execute], [ReadFile], [SearchFiles], and [SearchWeb]. *)
 
 type context =
   { config : Coord.config

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -331,6 +331,9 @@ let test_descriptor_backed_dispatch_uses_agent_tool_runtime () =
   assert_contains runtime_ml "Keeper_exec_shell.handle_tool_search_files";
   assert_contains runtime_ml "Keeper_exec_fs.handle_keeper_fs_read";
   assert_contains runtime_ml "Keeper_exec_fs.handle_keeper_fs_edit";
+  assert_contains runtime_ml "let handle_remote_mcp";
+  assert_contains runtime_ml "Keeper_exec_masc.handle_registered_keeper_tool";
+  assert_contains runtime_ml "| Remote_mcp -> handle_remote_mcp";
   assert_contains exec_tools_ml "Agent_tool_runtime.handle_internal";
   assert_not_contains exec_tools_ml "Keeper_exec_shell.handle_tool_execute";
   assert_not_contains exec_tools_ml "Keeper_exec_shell.handle_tool_search_files";

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -476,6 +476,8 @@ let test_agent_tool_runtime_resolves_descriptor_handlers () =
   check_descriptor "tool_read_file" "agent.read_file";
   check_descriptor "tool_edit_file" "agent.edit_file";
   check_descriptor "tool_write_file" "agent.write_file";
+  check_descriptor "masc_web_search" "agent.search_web";
+  check_descriptor "masc_web_fetch" "agent.fetch_web";
   Alcotest.(check bool)
     "unaliased keeper tool has no agent descriptor"
     true


### PR DESCRIPTION
## Summary
- route Remote_mcp descriptor-backed tools through Agent_tool_runtime
- lower SearchWeb/FetchWeb descriptors to the registered MASC handler from the descriptor runtime owner
- fail closed inside the descriptor route when a remote descriptor has no registered handler
- extend boundary tests so remote descriptor dispatch stays out of Keeper_exec_tools fallback ownership

## Verification
- ocamlformat --check lib/keeper/agent_tool_runtime.ml lib/keeper/agent_tool_runtime.mli test/test_keeper_tool_alias.ml test/test_keeper_sandbox_boundary_policy.ml
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_keeper_tool_alias.exe test/test_keeper_sandbox_boundary_policy.exe test/test_keeper_exec_tools.exe (blocked by live bare Dune processes: dune build --root ., dune runtest --root . --force, dune exec test/test_keeper_tools_oas.exe)
