### PR TITLE
fix(keeper): emit typed deterministic retry evidence

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -132,7 +132,14 @@ let handle_keeper_shell_ir_typed
         let typed_error_fields =
           [ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
         in
-        let blocked_result ~error ~reason ~alternatives =
+        let blocked_result ?deterministic_reason ~error ~reason ~alternatives =
+          let deterministic_retry_fields =
+            match deterministic_reason with
+            | Some deterministic_reason ->
+              Keeper_tool_deterministic_error.deterministic_retry_fields
+                deterministic_reason
+            | None -> []
+          in
           Yojson.Safe.to_string
             (Exec_core.blocked_result_json
                ~classification:(Exec_core.classify_command_of_ir ir)
@@ -141,7 +148,12 @@ let handle_keeper_shell_ir_typed
                ~reason
                ~alternatives
                ~retryability:Exec_core.Operator_required
-               ~extra:[ "cmd", `String cmd_for_log; "typed", `Bool true; "execution_time_ms", `Int 0 ]
+               ~extra:
+                 (deterministic_retry_fields
+                  @ [ "cmd", `String cmd_for_log
+                    ; "typed", `Bool true
+                    ; "execution_time_ms", `Int 0
+                    ])
                ())
         in
         let envelope = Keeper_shell_ir.classify ir in
@@ -149,6 +161,8 @@ let handle_keeper_shell_ir_typed
         if Masc_exec.Shell_ir_risk.is_destructive envelope
         then
           blocked_result
+            ~deterministic_reason:
+              Keeper_tool_deterministic_error.Destructive_operation_blocked
             ~error:"destructive_operation_blocked"
             ~reason:"This typed command is destructive and is blocked for all presets."
             ~alternatives:[ "Use a non-destructive command or a dedicated structured tool." ]
@@ -157,6 +171,7 @@ let handle_keeper_shell_ir_typed
                 || Masc_exec.Shell_ir_risk.is_r2 envelope)
         then
           blocked_result
+            ~deterministic_reason:Keeper_tool_deterministic_error.Write_operation_gated
             ~error:"write_operation_gated"
             ~reason:"This typed command modifies state. A write-enabled preset is required."
             ~alternatives:

--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -8,6 +8,7 @@ type deterministic_reason =
   | Path_outside_sandbox
   | Cwd_not_directory
   | Policy_blocked
+  | Write_operation_gated
   | Completion_contract_violation
   | Keeper_shell_op_required
   | Workflow_rejection_blocked
@@ -24,6 +25,7 @@ let to_telemetry_key = function
   | Path_outside_sandbox -> "deterministic_error_path_outside_sandbox"
   | Cwd_not_directory -> "deterministic_error_cwd_not_directory"
   | Policy_blocked -> "deterministic_error_policy_blocked"
+  | Write_operation_gated -> "deterministic_error_write_operation_gated"
   | Completion_contract_violation ->
     "deterministic_error_completion_contract_violation"
   | Keeper_shell_op_required -> "deterministic_error_keeper_shell_op_required"
@@ -45,6 +47,8 @@ let to_string = function
   | Path_outside_sandbox -> "path argument outside keeper-allowed sandbox roots"
   | Cwd_not_directory -> "cwd argument is not a directory"
   | Policy_blocked -> "governance / preset policy rejected the call"
+  | Write_operation_gated ->
+    "write-capable Execute is required; retrying the same arguments cannot succeed"
   | Completion_contract_violation ->
     "keeper completion contract violated (e.g. require_tool_use)"
   | Keeper_shell_op_required ->
@@ -76,6 +80,15 @@ let assoc_int_opt key json =
   | _ -> None
 ;;
 
+let detail_assoc_field_opt key json =
+  match assoc_field_opt key json with
+  | Some _ as value -> value
+  | None ->
+    (match assoc_field_opt "detail" json with
+     | Some detail -> assoc_field_opt key detail
+     | None -> None)
+;;
+
 (* [error_or_detail key json] reads [key] at top level, falling back
    to a nested ["detail"] object. Mirrors the lookup pattern used in
    [keeper_tools_oas.workflow_rejection_info_of_raw]. *)
@@ -86,6 +99,48 @@ let error_or_detail_string key json =
     (match assoc_field_opt "detail" json with
      | Some detail -> assoc_string_opt key detail
      | None -> None)
+;;
+
+let reason_to_wire = function
+  | Command_blocked -> "command_blocked"
+  | Command_shape_blocked -> "command_shape_blocked"
+  | Task_state_probe_blocked -> "task_state_probe_blocked"
+  | Destructive_operation_blocked -> "destructive_operation_blocked"
+  | Path_outside_sandbox -> "path_outside_sandbox"
+  | Cwd_not_directory -> "cwd_not_directory"
+  | Policy_blocked -> "policy_blocked"
+  | Write_operation_gated -> "write_operation_gated"
+  | Completion_contract_violation -> "completion_contract_violation"
+  | Keeper_shell_op_required -> "keeper_shell_op_required"
+  | Workflow_rejection_blocked -> "workflow_rejection_blocked"
+  | Git_ref_precondition_failed -> "git_ref_precondition_failed"
+  | Git_command_usage_error -> "git_command_usage_error"
+;;
+
+let reason_of_wire = function
+  | "command_blocked" -> Some Command_blocked
+  | "command_shape_blocked" -> Some Command_shape_blocked
+  | "task_state_probe_blocked" -> Some Task_state_probe_blocked
+  | "destructive_operation_blocked" -> Some Destructive_operation_blocked
+  | "path_outside_sandbox" -> Some Path_outside_sandbox
+  | "cwd_not_directory" -> Some Cwd_not_directory
+  | "policy_blocked" -> Some Policy_blocked
+  | "write_operation_gated" -> Some Write_operation_gated
+  | "completion_contract_violation" -> Some Completion_contract_violation
+  | "keeper_shell_op_required" -> Some Keeper_shell_op_required
+  | "workflow_rejection_blocked" -> Some Workflow_rejection_blocked
+  | "git_ref_precondition_failed" -> Some Git_ref_precondition_failed
+  | "git_command_usage_error" -> Some Git_command_usage_error
+  | _ -> None
+;;
+
+let deterministic_retry_fields reason =
+  [ ( "deterministic_retry"
+    , `Assoc
+        [ "reason", `String (reason_to_wire reason)
+        ; "retry_same_args", `Bool false
+        ] )
+  ]
 ;;
 
 (* Closed mapping: [error] field value -> [deterministic_reason].
@@ -118,6 +173,17 @@ let path_check_reason_of_explicit = function
 ;;
 
 (* ── Classifier ───────────────────────────────────────────────── *)
+
+let classify_deterministic_retry json =
+  match detail_assoc_field_opt "deterministic_retry" json with
+  | Some (`Assoc _ as retry) ->
+    (match assoc_string_opt "reason" retry with
+     | Some reason -> reason_of_wire reason
+     | None -> None)
+  | Some _
+  | None ->
+    None
+;;
 
 let classify_workflow_rejection json =
   match Keeper_tools_oas_workflow.workflow_rejection_payload_of_json json with
@@ -188,19 +254,23 @@ let classify_path_check json =
 ;;
 
 let classify (json : Yojson.Safe.t) : deterministic_reason option =
-  (* Precedence: workflow_rejection > path_check > error_code.
+  (* Precedence: explicit deterministic_retry > workflow_rejection >
+     path_check > error_code.
      Workflow rejection is the most specific (already routed to a
      dedicated counter in [Keeper_tools_oas]). Path checks have their
      own typed surface. Generic [error] codes are the catch-up layer. *)
-  match classify_workflow_rejection json with
+  match classify_deterministic_retry json with
   | Some _ as v -> v
   | None ->
-    (match classify_path_check json with
+    (match classify_workflow_rejection json with
      | Some _ as v -> v
      | None ->
-       (match classify_error_code json with
+       (match classify_path_check json with
         | Some _ as v -> v
-        | None -> classify_git_exit_128 json))
+        | None ->
+          (match classify_error_code json with
+           | Some _ as v -> v
+           | None -> classify_git_exit_128 json)))
 ;;
 
 let classify_raw (raw : string) : deterministic_reason option =

--- a/lib/keeper/keeper_tool_deterministic_error.mli
+++ b/lib/keeper/keeper_tool_deterministic_error.mli
@@ -39,6 +39,8 @@ type deterministic_reason =
       (** cwd argument resolves but is not a directory. *)
   | Policy_blocked
       (** governance / preset policy rejected the call. *)
+  | Write_operation_gated
+      (** write-capable Execute is required before retrying the same operation. *)
   | Completion_contract_violation
       (** keeper completion contract (e.g. require_tool_use) failed. *)
   | Keeper_shell_op_required
@@ -68,6 +70,11 @@ type deterministic_reason =
     and a closed set of git exit-128 output patterns. There is
     no [_ ->] catch-all that admits new prefixes silently. *)
 val classify : Yojson.Safe.t -> deterministic_reason option
+
+(** Structured marker for tool producers that already know the same
+    arguments cannot succeed. Prefer this over adding more [error]
+    string fallbacks. *)
+val deterministic_retry_fields : deterministic_reason -> (string * Yojson.Safe.t) list
 
 (** Convenience wrapper: parse [raw] as JSON then [classify]. Returns
     [None] when [raw] is not valid JSON. *)

--- a/test/test_keeper_bash_retry_deterministic_close.ml
+++ b/test/test_keeper_bash_retry_deterministic_close.ml
@@ -38,7 +38,13 @@ let test_command_blocked () =
 
 let test_command_shape_blocked () =
   let raw =
-    {|{"ok":false,"error":"tool_execute_command_shape_blocked","reason":"pipes blocked"}|}
+    Yojson.Safe.to_string
+      (`Assoc
+          ([ "ok", `Bool false
+           ; "error", `String "tool_execute_command_shape_blocked"
+           ; "reason", `String "pipes blocked"
+           ]
+           @ D.deterministic_retry_fields D.Command_shape_blocked))
   in
   check_classify
     ~name:"tool_execute_command_shape_blocked"
@@ -92,11 +98,38 @@ let test_completion_contract_violation () =
 ;;
 
 let test_tool_search_files_op_required () =
-  let raw = {|{"ok":false,"error":"tool_execute_requires_git_cwd"}|} in
+  let raw =
+    Yojson.Safe.to_string
+      (`Assoc
+          ([ "ok", `Bool false
+           ; "error", `String "tool_execute_requires_git_cwd"
+           ]
+           @ D.deterministic_retry_fields D.Keeper_shell_op_required))
+  in
   check_classify
     ~name:"tool_execute_requires_git_cwd"
     ~expected:(Some D.Keeper_shell_op_required)
     raw
+;;
+
+let test_typed_deterministic_retry_marker_takes_precedence () =
+  let raw =
+    Yojson.Safe.to_string
+      (`Assoc
+          ([ "ok", `Bool false; "error", `String "timeout" ]
+           @ D.deterministic_retry_fields D.Write_operation_gated))
+  in
+  check_classify
+    ~name:"typed deterministic retry marker"
+    ~expected:(Some D.Write_operation_gated)
+    raw
+;;
+
+let test_unknown_typed_deterministic_retry_marker_observes () =
+  let raw =
+    {|{"ok":false,"error":"timeout","deterministic_retry":{"reason":"new_reason","retry_same_args":false}}|}
+  in
+  check_classify ~name:"unknown deterministic retry marker" ~expected:None raw
 ;;
 
 (* ── Deterministic — path-check path ──────────────────────────── *)
@@ -249,6 +282,7 @@ let test_to_string_non_empty_for_every_variant () =
     ; D.Path_outside_sandbox
     ; D.Cwd_not_directory
     ; D.Policy_blocked
+    ; D.Write_operation_gated
     ; D.Completion_contract_violation
     ; D.Keeper_shell_op_required
     ; D.Workflow_rejection_blocked
@@ -296,6 +330,14 @@ let () =
             "tool_search_files_op_required"
             `Quick
             test_tool_search_files_op_required
+        ; Alcotest.test_case
+            "typed_deterministic_retry_marker"
+            `Quick
+            test_typed_deterministic_retry_marker_takes_precedence
+        ; Alcotest.test_case
+            "unknown_typed_deterministic_retry_marker_observes"
+            `Quick
+            test_unknown_typed_deterministic_retry_marker_observes
         ] )
     ; ( "classify_path_check"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary
- add an explicit deterministic_retry payload marker owned by Keeper_tool_deterministic_error
- classify deterministic retry evidence before legacy error-code fallbacks
- emit typed deterministic retry evidence from Shell IR destructive/write-gated blocked results
- update focused classifier tests so command-shape/native-tool-required cases are proven by typed evidence instead of bare error strings

## Verification
- ocamlformat --check lib/keeper/keeper_tool_deterministic_error.ml lib/keeper/keeper_tool_deterministic_error.mli lib/keeper/keeper_shell_bash.ml test/test_keeper_bash_retry_deterministic_close.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_bash_retry_deterministic_close.exe test/test_keeper_tools_oas.exe was blocked by pre-existing bare Dune processes outside scripts/dune-local.sh