### PR TITLE
fix(dashboard): throttle repeated refresh failure warnings

### DIFF
--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -57,15 +57,34 @@ let timeout_exception ~config ~phase ~elapsed_s =
        ~timeout_s:config.timeout_s
        ~elapsed_s)
 
+let is_power_of_two n = n > 0 && n land (n - 1) = 0
+
+let should_warn_refresh_failure ~failure_threshold consecutive_failures =
+  consecutive_failures = 1
+  || consecutive_failures = failure_threshold
+  || (consecutive_failures > failure_threshold
+      && is_power_of_two consecutive_failures)
+
+let log_dashboard_refresh_failure ~warn message =
+  if warn then Log.Dashboard.warn "%s" message
+  else Log.Dashboard.debug "%s" message
+
 let log_refresh_failure ~config ~consecutive_failures ~current_interval ~dt exn =
   incr consecutive_failures;
   if !consecutive_failures >= config.failure_threshold then
     current_interval :=
       min config.max_backoff_s (!current_interval *. 2.0);
-  Log.Dashboard.warn
-    "%s refresh failed (%d consecutive, next in %.0fs, %.1fs): %s"
-    config.label !consecutive_failures !current_interval dt
-    (Printexc.to_string exn)
+  let message =
+    Printf.sprintf
+      "%s refresh failed (%d consecutive, next in %.0fs, %.1fs): %s"
+      config.label !consecutive_failures !current_interval dt
+      (Printexc.to_string exn)
+  in
+  log_dashboard_refresh_failure message
+    ~warn:
+      (should_warn_refresh_failure
+         ~failure_threshold:config.failure_threshold
+         !consecutive_failures)
 
 let notify_error config exn =
   match config.on_error with
@@ -131,9 +150,16 @@ let start ~sw ~clock ~config:raw_config ~compute ~on_result =
         if !consecutive_failures >= config.failure_threshold then
           current_interval :=
             min config.max_backoff_s (!current_interval *. 2.0);
-        Log.Dashboard.warn
-          "%s skipped: health gate failed (%d consecutive, next in %.0fs)"
-          config.label !consecutive_failures !current_interval
+        let message =
+          Printf.sprintf
+            "%s skipped: health gate failed (%d consecutive, next in %.0fs)"
+            config.label !consecutive_failures !current_interval
+        in
+        log_dashboard_refresh_failure message
+          ~warn:
+            (should_warn_refresh_failure
+               ~failure_threshold:config.failure_threshold
+               !consecutive_failures)
       end else
       let t0 = Time_compat.now () in
       (try
@@ -180,4 +206,5 @@ let start ~sw ~clock ~config:raw_config ~compute ~on_result =
 
 module For_testing = struct
   let timeout_failure_message = timeout_failure_message
+  let should_warn_refresh_failure = should_warn_refresh_failure
 end

--- a/lib/server/proactive_refresh.mli
+++ b/lib/server/proactive_refresh.mli
@@ -21,6 +21,9 @@ val default_config : label:string -> interval_s:float -> config
 module For_testing : sig
   val timeout_failure_message :
     label:string -> phase:string -> timeout_s:float -> elapsed_s:float -> string
+
+  val should_warn_refresh_failure :
+    failure_threshold:int -> int -> bool
 end
 
 val start :

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -29,6 +29,27 @@ let test_proactive_refresh_timeout_message_names_phase () =
      elapsed_s=33.2"
     msg
 
+let test_proactive_refresh_failure_warn_throttle () =
+  let should_warn =
+    Proactive_refresh.For_testing.should_warn_refresh_failure
+      ~failure_threshold:3
+  in
+  List.iter
+    (fun (count, expected) ->
+      Alcotest.(check bool)
+        (Printf.sprintf "failure %d warn decision" count)
+        expected (should_warn count))
+    [
+      (1, true);
+      (2, false);
+      (3, true);
+      (4, true);
+      (5, false);
+      (6, false);
+      (7, false);
+      (8, true);
+    ]
+
 let latest_log_seq () =
   match Log.Ring.recent ~limit:1 () with
   | [] -> -1
@@ -612,6 +633,8 @@ let () =
         [
           test_case "proactive refresh timeout names phase" `Quick
             test_proactive_refresh_timeout_message_names_phase;
+          test_case "proactive refresh failure WARN throttle" `Quick
+            test_proactive_refresh_failure_warn_throttle;
           test_case "compute timeout is not logged as error" `Quick
             (test_compute_timeout_not_logged_as_error ~clock);
           test_case "stale preserved on timeout" `Quick


### PR DESCRIPTION
## Summary

- Throttle repeated dashboard proactive-refresh failure WARN rows.
- Keep the refresh failure/backoff behavior unchanged.
- Log WARN for the first failure, the configured threshold, and later power-of-two counts; downgrade in-between repeated rows to debug.
- Apply the same policy to health-gate skip rows.

## Log Evidence

From `/Users/dancer/me/.masc/logs/system_log_2026-05-26.jsonl`:

- `full_health_snapshot refresh failed ... refresh_timeout` appears repeatedly during the same outage window.
- Dashboard WARN aggregation includes repeated refresh/profile timeout rows, with full-health refresh failures reaching 7 consecutive rows in the current sample.

This change keeps the operator-visible first/threshold/escalation rows while reducing identical WARN pressure during sustained refresh outages.

## Verification

- `ocamlformat --check lib/server/proactive_refresh.ml lib/server/proactive_refresh.mli test/test_dashboard_cache.ml`
- `ocamlc -stop-after parsing lib/server/proactive_refresh.ml`
- `ocamlc -stop-after parsing lib/server/proactive_refresh.mli`
- `ocamlc -stop-after parsing test/test_dashboard_cache.ml`
- `git diff --check`

Focused Dune target attempted:

- `scripts/dune-local.sh build test/test_dashboard_cache.exe`

Result: blocked by live bare Dune processes outside `scripts/dune-local.sh`; wrapper refused to start another local build.
