### PR TITLE
[codex] Relax keeper task claim intake gating

### DIFF
--- a/config/prompts/keeper.immediate_task_move.md
+++ b/config/prompts/keeper.immediate_task_move.md
@@ -1,8 +1,8 @@
 ---
-description: keeper user-prompt Immediate Task Move section (emitted when claimable backlog is visible and keeper holds no task)
+description: keeper user-prompt Claimable Work section (emitted when claimable backlog is visible and keeper holds no task)
 category: keeper
 ---
-- Call keeper_task_claim with {} to claim the next eligible unclaimed task.
-- For the routine claim flow, call keeper_task_claim directly; use keeper_tasks_list to inspect backlog state, diagnose missing work, or verify task lifecycle. Never substitute Execute probes (ls/cat/find against .masc/, backlog.json, or repo-local task files) for keeper_tasks_list — the runtime blocks those with `task_state_file_probe_blocked`.
-- Prefer keeper_task_claim before keeper_board_list or passive file/search tools when you have no claimed task.
-- If you need PR/GitHub context, claim first and then use the native PR tools shown in your active schema.
+- Claimable backlog exists. `keeper_task_claim {}` may claim the next eligible unclaimed task, but this is an intake option rather than a required move.
+- Use keeper_tasks_list to inspect backlog state, diagnose missing work, or verify task lifecycle before deciding. Never substitute Execute probes (ls/cat/find against .masc/, backlog.json, or repo-local task files) for keeper_tasks_list; the runtime blocks those with `task_state_file_probe_blocked`.
+- Prefer the strongest live signal: pending mention, board activity, active goal, or relevant PR context may be better than claiming unrelated work.
+- If you choose to take code-changing task work, claim first and then use Execute with scoped `gh pr list` / `gh pr view` from the repo worktree.

--- a/config/prompts/keeper.tool_workflow_gh_full.md
+++ b/config/prompts/keeper.tool_workflow_gh_full.md
@@ -3,4 +3,4 @@ description: keeper gh/code workflow guidance, full path (PR inspection + worktr
 category: keeper
 ---
 
-GitHub/code workflow: if you do not already hold a task, call `keeper_task_claim` first. Inspect PR state with `Execute` using `executable="gh"` and typed `argv` for `pr list` / `pr view` from a repo/worktree cwd. If code change is needed, `masc_worktree_create` -> edit -> sandboxed shell/code path inside the worktree -> `keeper_task_submit_for_verification` with notes and `pr_url`. Do not use hidden implementation tool names.
+GitHub/code workflow: inspect PR state with `Execute` using `executable="gh"` and typed `argv` for `pr list` / `pr view` from a repo/worktree cwd. If you decide to do code-changing task work and do not already hold that task, call `keeper_task_claim` first. Then `masc_worktree_create` -> edit -> sandboxed shell/code path inside the worktree -> `keeper_task_submit_for_verification` with notes and `pr_url`. Do not use hidden implementation tool names.

--- a/config/prompts/keeper.tool_workflow_gh_no_pr.md
+++ b/config/prompts/keeper.tool_workflow_gh_no_pr.md
@@ -3,4 +3,4 @@ description: keeper gh/code workflow guidance without a dedicated PR creation to
 category: keeper
 ---
 
-GitHub/code workflow: if you do not already hold a task, call `keeper_task_claim` first. Inspect PR state with `Execute` using `executable="gh"` and typed `argv` for `pr list` / `pr view` from a repo/worktree cwd. If code change is needed, `masc_worktree_create` -> edit -> sandboxed shell/code path inside the worktree, then submit evidence. Do not use hidden implementation tool names.
+GitHub/code workflow: inspect PR state with `Execute` using `executable="gh"` and typed `argv` for `pr list` / `pr view` from a repo/worktree cwd. If you decide to do code-changing task work and do not already hold that task, call `keeper_task_claim` first. Then `masc_worktree_create` -> edit -> sandboxed shell/code path inside the worktree, then submit evidence. Do not use hidden implementation tool names.

--- a/config/prompts/keeper.turn_intent.claim_guidance_a.md
+++ b/config/prompts/keeper.turn_intent.claim_guidance_a.md
@@ -2,4 +2,4 @@
 description: keeper turn-intent claim guidance bullet A (emitted when claimable backlog is visible)
 category: keeper
 ---
-- See unclaimed work and you do not already hold a task? Call keeper_task_claim with {}. It auto-claims the next eligible task; you do not need a task_id argument. keeper_tasks_list remains the canonical way to inspect backlog state — use it any time you need to diagnose what work exists, not just when the claim returns empty.
+- Claimable backlog is visible and you do not already hold a task. `keeper_task_claim {}` is available, not mandatory: claim only when the work fits your current goal, persona, and capacity. Use `keeper_tasks_list` when you need to inspect backlog state before deciding.

--- a/config/prompts/keeper.turn_intent.claim_guidance_b.md
+++ b/config/prompts/keeper.turn_intent.claim_guidance_b.md
@@ -2,4 +2,4 @@
 description: keeper turn-intent claim guidance bullet B (gh repo context via task worktree)
 category: keeper
 ---
-- Need GitHub or PR inspection? Claim first, then use the native PR tools shown in your active schema. Do not invent hidden shell tools when they are not listed.
+- GitHub or PR inspection can be read-only. If you decide to do code-changing task work, claim first, then use Execute with scoped `gh pr list` / `gh pr view` from the repo worktree. Do not invent hidden shell tools when they are not listed.

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -80,7 +80,7 @@ Decide what to do based on the current world state below.
 ### Tool-first principle
 - Read before concluding: if available, use `ReadFile`, `SearchFiles`, visible code tools, or `keeper_library_search` to gather facts before stating opinions. Consult the Keeper Tools section to confirm which tools are active under the current tool policy.
 - On actionable turns, do not stop after read/search/list/status tools. The same assistant response must include an active tool call, or explicitly use `SPEECH_ACT: request_help` with a concrete blocker when no active tool can be used.
-- Act before reporting: if available, call `keeper_task_claim`, `keeper_board_comment`, or `keeper_board_post` instead of just describing what you would do.
+- Act before reporting with the tool that fits the live signal: `keeper_board_comment`, `keeper_board_post`, `keeper_task_claim`, or another active tool. Claiming backlog work is optional unless you are actually taking that work.
 - A turn with zero tool calls is acceptable only when `SPEECH_ACT: stay_silent`.
 
 ### Research evidence
@@ -99,7 +99,7 @@ Use extend_turns only when a single coherent action genuinely requires more step
 
 ### Possible actions (pick one per turn)
 - Reply to a pending mention in the current namespace conversation
-- Claim and work on one task (`keeper_task_claim`, if available)
+- Claim and work on one fitting task (`keeper_task_claim`, if available)
 - Post a finding or status update (`keeper_board_post`, if available)
 - Respond to board activity (`keeper_board_comment`, if available)
 - Search knowledge library (`keeper_library_search` / `keeper_library_read`, if available)

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -201,12 +201,12 @@ let turn_affordance_to_string = function
   | Inspect_worktree_delta -> "inspect_worktree_delta"
 
 let should_tool_gate_affordance = function
+  | Task_claim
   | Work_discovery -> false
   | Board_curation
   | Board_post_or_comment
   | Message_sweep
   | Reply_in_room
-  | Task_claim
   | Task_audit
   | Task_verify
   | Inspect_worktree_delta -> true
@@ -223,8 +223,9 @@ let turn_affordances_require_tool_gate turn_affordances =
    Keepers without any matching tool cannot satisfy a [Require_tool_use]
    contract for that affordance and must be allowed to respond with text
    instead. [Work_discovery] remains listed for routing/search guidance, but it
-   does not hard-gate by itself; the concrete signals inside a discovery turn
-   (claimable tasks, board activity, worktree delta) own the strict contract. *)
+   does not hard-gate by itself. [Task_claim] is also advisory: visible
+   claimable backlog is an intake opportunity, not proof that this keeper
+   must take new work before responding to stronger live signals. *)
 let tools_for_gated_affordance = function
   | Board_curation ->
     [ "keeper_board_curation_submit" ]

--- a/lib/keeper/keeper_prompt_names.ml
+++ b/lib/keeper/keeper_prompt_names.ml
@@ -33,6 +33,6 @@ let turn_intent_board_curation_guidance = "keeper.turn_intent.board_curation_gui
 let turn_intent_broadcast_guidance = "keeper.turn_intent.broadcast_guidance"
 let turn_intent_pr_review_guidance = "keeper.turn_intent.pr_review_guidance"
 
-(** User-prompt "Immediate Task Move" section body, emitted when a
-    claimable backlog is visible and the keeper holds no task. *)
+(** User-prompt "Claimable Work" section body, emitted when a claimable backlog
+    is visible and the keeper holds no task. *)
 let immediate_task_move = "keeper.immediate_task_move"

--- a/lib/keeper/keeper_prompt_names.mli
+++ b/lib/keeper/keeper_prompt_names.mli
@@ -29,5 +29,5 @@ val turn_intent_board_curation_guidance : string
 val turn_intent_broadcast_guidance : string
 val turn_intent_pr_review_guidance : string
 
-(** User-prompt "Immediate Task Move" section template key. *)
+(** User-prompt "Claimable Work" section template key. *)
 val immediate_task_move : string

--- a/lib/keeper/keeper_tool_guidance.ml
+++ b/lib/keeper/keeper_tool_guidance.ml
@@ -125,20 +125,24 @@ let fallback_prose key =
   else if String.equal key Keeper_prompt_names.tool_workflow_gh_full
   then
     Some
-      "GitHub/code workflow: if you do not already hold a task, call \
-       `keeper_task_claim` first; inspect PR state with `Execute` using \
-       `executable=\"gh\"` and typed `argv` for `pr list` / `pr view`. If code change is needed, `masc_worktree_create` -> \
-       edit -> sandboxed shell/code path inside the worktree -> \
+      "GitHub/code workflow: inspect PR state with `Execute` using \
+       `executable=\"gh\"` and typed `argv` for `pr list` / `pr view` from a \
+       repo/worktree cwd. If you decide to do code-changing task work and do \
+       not already hold that task, call `keeper_task_claim` first. Then \
+       `masc_worktree_create` -> edit -> \
+       sandboxed shell/code path inside the worktree -> \
        `keeper_task_submit_for_verification` with notes and `pr_url`. \
        Hidden implementation tool names are not valid workflow tools."
   else if String.equal key Keeper_prompt_names.tool_workflow_gh_no_pr
   then
     Some
-      "GitHub/code workflow: if you do not already hold a task, call \
-       `keeper_task_claim` first; inspect PR state with `Execute` using \
-       `executable=\"gh\"` and typed `argv` for `pr list` / `pr view`. If code change is needed, `masc_worktree_create` -> \
-       edit -> sandboxed shell/code path inside the worktree, then submit \
-       evidence. Hidden implementation tool names are not valid workflow tools."
+      "GitHub/code workflow: inspect PR state with `Execute` using \
+       `executable=\"gh\"` and typed `argv` for `pr list` / `pr view` from a \
+       repo/worktree cwd. If you decide to do code-changing task work and do \
+       not already hold that task, call `keeper_task_claim` first. Then \
+       `masc_worktree_create` -> edit -> \
+       sandboxed shell/code path inside the worktree, then submit evidence. \
+       Hidden implementation tool names are not valid workflow tools."
   else if String.equal key Keeper_prompt_names.tool_workflow_gh_minimal
   then
     Some

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -214,16 +214,17 @@ let resolve_turn_intent_block substitutions =
 let fallback_externalized_bullet key =
   if String.equal key Keeper_prompt_names.turn_intent_claim_guidance_a then
     Some
-      "- See unclaimed work and you do not already hold a task? Call \
-       keeper_task_claim with {}. It auto-claims the next eligible task; \
-       you do not need a task_id argument. keeper_tasks_list remains the \
-       canonical way to inspect backlog state — use it any time you need to \
-       diagnose what work exists, not just when the claim returns empty."
+      "- Claimable backlog is visible and you do not already hold a task. \
+       `keeper_task_claim {}` is available, not mandatory: claim only when \
+       the work fits your current goal, persona, and capacity. Use \
+       `keeper_tasks_list` when you need to inspect backlog state before \
+       deciding."
   else if String.equal key Keeper_prompt_names.turn_intent_claim_guidance_b then
     Some
-      "- Need GitHub or PR inspection? Claim first, then use the native PR \
-       tools shown in your active schema. Do not invent `keeper_shell` when \
-       it is not listed."
+      "- GitHub or PR inspection can be read-only. If you decide to do \
+       code-changing task work, claim first, then use Execute with scoped \
+       `gh pr list` / `gh pr view` from the repo worktree. Do not invent \
+       hidden shell tools when they are not listed."
   else if String.equal key Keeper_prompt_names.turn_intent_board_activity_guidance then
     Some
       "- See board activity? Use the listed post_id. If the preview is \
@@ -254,18 +255,20 @@ let fallback_externalized_bullet key =
        normal sandboxed code path."
   else if String.equal key Keeper_prompt_names.immediate_task_move then
     Some
-      "- Call keeper_task_claim with {} to claim the next eligible \
-       unclaimed task.\n\
-       - For the routine claim flow, call keeper_task_claim directly; use \
-       keeper_tasks_list to inspect backlog state, diagnose missing work, \
-       or verify task lifecycle. Never substitute Execute probes (ls/cat/find \
-       against .masc/, backlog.json, or repo-local task files) for \
-       keeper_tasks_list — the runtime blocks those with \
-       `task_state_file_probe_blocked`.\n\
-       - Prefer keeper_task_claim before keeper_board_list or passive \
-       file/search tools when you have no claimed task.\n\
-       - If you need PR/GitHub context, claim first and then use Execute with \
-       scoped `gh pr list` / `gh pr view` from the repo worktree."
+      "- Claimable backlog exists. `keeper_task_claim {}` may claim the next \
+       eligible unclaimed task, but this is an intake option rather than a \
+       required move.\n\
+       - Use keeper_tasks_list to inspect backlog state, diagnose missing \
+       work, or verify task lifecycle before deciding. Never substitute \
+       Execute probes (ls/cat/find against .masc/, backlog.json, or \
+       repo-local task files) for keeper_tasks_list; the runtime blocks \
+       those with `task_state_file_probe_blocked`.\n\
+       - Prefer the strongest live signal: pending mention, board activity, \
+       active goal, or relevant PR context may be better than claiming \
+       unrelated work.\n\
+       - If you choose to take code-changing task work, claim first and then \
+       use Execute with scoped `gh pr list` / `gh pr view` from the repo \
+       worktree."
   else None
 
 (** Load a turn-intent or user-prompt bullet from [config/prompts/].
@@ -577,13 +580,13 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     Buffer.add_string ubuf
       (format_scope_messages observation.pending_scope_messages);
     Buffer.add_string ubuf "\n\n");
-  (* 8. Immediate task move — reactive operational guidance.
+  (* 8. Claimable work — advisory operational guidance.
      Body lives at config/prompts/keeper.immediate_task_move.md. The OCaml
      side only owns the section header and the trailing blank line; the
      bullet prose stays in the markdown file alongside the other keeper
      prompts (see fallback_externalized_bullet for the in-binary mirror). *)
   if show_claim_guidance then (
-    Buffer.add_string ubuf "### Immediate Task Move\n";
+    Buffer.add_string ubuf "### Claimable Work\n";
     Buffer.add_string ubuf
       (load_externalized_bullet
          ~enabled:true

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3035,7 +3035,7 @@ let test_prompt_surfaces_provider_capacity_blocked_backlog () =
     bool
     "provider-blocked backlog suppresses immediate claim guidance"
     false
-    (contains_substring user "### Immediate Task Move")
+    (contains_substring user "### Claimable Work")
 ;;
 
 let test_prompt_includes_claim_first_guidance () =
@@ -3051,20 +3051,20 @@ let test_prompt_includes_claim_first_guidance () =
   in
   check
     bool
-    "system prompt explains auto-claim"
+    "system prompt frames claim as optional intake"
     true
-    (contains_substring sys "Call keeper_task_claim with {}");
+    (contains_substring sys "`keeper_task_claim {}` is available, not mandatory");
   check
     bool
-    "user prompt adds immediate task move section"
+    "user prompt adds claimable work section"
     true
-    (contains_substring user "### Immediate Task Move");
+    (contains_substring user "### Claimable Work");
   check
     bool
     "user prompt keeps keeper_tasks_list as canonical backlog inspection"
     true
     (contains_substring user
-       "use keeper_tasks_list to inspect backlog state");
+       "Use keeper_tasks_list to inspect backlog state");
   check
     bool
     "user prompt blocks Execute probes against task state files"
@@ -3072,20 +3072,18 @@ let test_prompt_includes_claim_first_guidance () =
     (contains_substring user "task_state_file_probe_blocked");
   check
     bool
-    "user prompt prefers claim before browsing"
+    "user prompt keeps live-signal choice open"
     true
     (contains_substring
        user
-       "Prefer keeper_task_claim before keeper_board_list or passive \
-        file/search tools");
+       "Prefer the strongest live signal");
   check
     bool
-    "user prompt explains PR context requires claim first"
+    "user prompt requires claim only for chosen code-changing task work"
     true
     (contains_substring
        user
-       "If you need PR/GitHub context, claim first and then use the native PR \
-        tools")
+       "If you choose to take code-changing task work, claim first")
 ;;
 
 let test_prompt_omits_claim_first_guidance_when_no_claimable_tasks () =
@@ -3103,12 +3101,12 @@ let test_prompt_omits_claim_first_guidance_when_no_claimable_tasks () =
     bool
     "system prompt omits auto-claim for unclaimable backlog"
     false
-    (contains_substring sys "Call keeper_task_claim with {}");
+    (contains_substring sys "`keeper_task_claim {}` is available, not mandatory");
   check
     bool
     "user prompt omits immediate task move for unclaimable backlog"
     false
-    (contains_substring user "### Immediate Task Move");
+    (contains_substring user "### Claimable Work");
   check
     bool
     "namespace exposes zero matched availability"
@@ -3135,7 +3133,7 @@ let test_prompt_omits_claim_first_guidance_when_task_claimed () =
     bool
     "no immediate task move section once task claimed"
     false
-    (contains_substring user "### Immediate Task Move")
+    (contains_substring user "### Claimable Work")
 ;;
 
 let test_prompt_omits_claim_first_guidance_when_claim_tool_unavailable () =
@@ -3153,12 +3151,12 @@ let test_prompt_omits_claim_first_guidance_when_claim_tool_unavailable () =
     bool
     "system prompt omits auto-claim when tool unavailable"
     false
-    (contains_substring sys "Call keeper_task_claim with {}");
+    (contains_substring sys "`keeper_task_claim {}` is available, not mandatory");
   check
     bool
     "user prompt omits immediate task move when tool unavailable"
     false
-    (contains_substring user "### Immediate Task Move")
+    (contains_substring user "### Claimable Work")
 ;;
 
 let test_prompt_omits_claim_first_guidance_when_paused () =
@@ -3175,12 +3173,12 @@ let test_prompt_omits_claim_first_guidance_when_paused () =
     bool
     "system prompt omits auto-claim while paused"
     false
-    (contains_substring sys "Call keeper_task_claim with {}");
+    (contains_substring sys "`keeper_task_claim {}` is available, not mandatory");
   check
     bool
     "user prompt omits immediate task move while paused"
     false
-    (contains_substring user "### Immediate Task Move")
+    (contains_substring user "### Claimable Work")
 ;;
 
 let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
@@ -3262,7 +3260,7 @@ let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
     (source_file_contains "lib/keeper/keeper_agent_run.ml" "NO_TOOL_CHANNEL");
   check
     bool
-    "work discovery nudge uses native PR tools"
+    "work discovery nudge uses scoped gh Execute"
     true
     (contains_substring
        (Option.value
@@ -9985,6 +9983,13 @@ let test_should_require_tools_for_initial_turn_matches_first_turn_gate () =
        ~turn_affordances:[ "work_discovery" ]);
   check
     bool
+    "claimable backlog alone stays optional"
+    false
+    (KAR.should_require_tools_for_initial_turn
+       ~max_turns:3
+       ~turn_affordances:[ "task_claim" ]);
+  check
+    bool
     "worktree delta inspection requires an action tool"
     true
     (KAR.should_require_tools_for_initial_turn
@@ -10052,8 +10057,8 @@ let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
   in
   check
     bool
-    "task_claim affordance with claim tool present -> gate fires"
-    true
+    "task_claim affordance with claim tool present stays advisory"
+    false
     (gate ~tools:[ "keeper_task_claim" ] [ "task_claim" ]);
   check
     bool
@@ -10082,11 +10087,9 @@ let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
     (gate ~tools:[ "keeper_board_post"; "keeper_board_comment" ] [ "board_curation" ]);
   check
     bool
-    "any matching affordance is enough"
+    "task_claim alone is not enough, but task_audit keeps the gate active"
     true
-    (gate
-       ~tools:[ "masc_claim_next" ]
-       [ "task_claim"; "task_audit"; "board_post_or_comment" ]);
+    (gate ~tools:[ "keeper_tasks_audit" ] [ "task_claim"; "task_audit" ]);
   check
     bool
     "task_audit with only passive audit/list tools -> gate suppressed"
@@ -10119,8 +10122,8 @@ let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
     (gate ~tools:[ "tool_search_files" ] [ "inspect_worktree_delta" ]);
   check
     bool
-    "work_discovery can accompany another concrete gated affordance"
-    true
+    "work_discovery plus task_claim stays advisory without stronger signal"
+    false
     (gate ~tools:[ "keeper_task_claim" ] [ "work_discovery"; "task_claim" ]);
   check
     bool
@@ -10174,12 +10177,12 @@ let test_turn_affordance_gate_suppression_metric () =
   let claim_before = metric "task_claim" in
   check
     bool
-    "claim tool present keeps gate active"
-    true
+    "claim tool present keeps advisory claim gate inactive"
+    false
     (gate ~tools:[ "keeper_task_claim" ] [ "task_claim" ]);
   check
     (float 0.0)
-    "successful gate does not increment suppression metric"
+    "advisory task_claim does not count as a suppressed gate"
     claim_before
     (metric "task_claim")
 ;;


### PR DESCRIPTION
## Summary

- make `task_claim` an advisory turn affordance instead of a required-tool gate
- rewrite keeper claim guidance so `keeper_task_claim` remains available without forcing backlog intake before stronger live signals
- update prompt tests to assert claimable backlog alone stays optional

## Root Cause

Claimable backlog visibility was being treated like a hard action contract. That conflated tool permission with autonomous intake pressure and made keepers claim coding work even when the better next move was to observe, inspect PR/board context, or respond to another live signal.

## Validation

- `git diff --check`
- Blocked: `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_unified_required_tools.exe test/test_keeper_unified_verification_surface.exe`
  - wrapper refused to start because existing bare Dune processes are already running on the machine
  - refusal code: 75
