### PR TITLE
refactor(keeper): drop delete path helpers from types facade

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 12:57:54 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 13:04:59 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -397,9 +397,15 @@
           </tr>
           <tr>
             <td><code>Keeper_types.maybe_rotate_file</code> facade leaf</td>
-            <td><span class="status now">draft PR #18584</span></td>
+            <td><span class="status done">merged #18584</span></td>
             <td>Stop exposing the support-owned metrics rotation helper through the broad <code>Keeper_types</code> facade. Rotation tests now call <code>Keeper_types_support.maybe_rotate_file</code> directly.</td>
             <td>Backstop grep must stay clean for <code>Keeper_types.maybe_rotate_file</code> and the removed public signature value.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_types</code> delete-action path facade leaves</td>
+            <td><span class="status now">draft PR #18590</span></td>
+            <td>Stop exposing generation-index, policy, feedback, dataset-export, and orphan generation-manifest path helpers through the broad <code>Keeper_types</code> facade. Keeper purge cleanup now calls the support owner directly for those filesystem paths.</td>
+            <td>Backstop grep must stay clean for the removed public signature values and for <code>Keeper_types.keeper_generation_index_path</code>, <code>Keeper_types.keeper_policy_log_path</code>, <code>Keeper_types.keeper_feedback_log_path</code>, and <code>Keeper_types.keeper_dataset_export_path</code>.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.write_meta_with_retry</code> wrapper</td>

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -559,7 +559,7 @@ Keeper turn에서 어떤 "skill" 경로를 사용할지 결정:
 
 ### 15.2 keeper_types.ml include chain
 
-`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history-source/metrics/API-key/alert-path/rotation support helper를 `Keeper_types_support` 소유로 돌렸지만, 일부 support helper 선별 re-export와 구현 include chain 자체는 남아 있어 가독성이 낮다.
+`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history-source/metrics/API-key/alert-path/rotation/delete-action support helper를 `Keeper_types_support` 소유로 돌렸지만, 일부 support helper 선별 re-export와 구현 include chain 자체는 남아 있어 가독성이 낮다.
 
 ### 15.3 keeper_memory 계층의 include chain
 

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -441,19 +441,14 @@ val session_base_dir_ : Coord.config -> string
 
 val keeper_memory_bank_path : Coord.config -> string -> string
 val keeper_progress_path : Coord.config -> string -> string
-val keeper_generation_index_path : Coord.config -> string -> string
 
 (** Per-trace session directory under [.masc/traces/<trace_id>]. *)
 val keeper_session_dir : Coord.config -> string -> string
 
-val keeper_generation_manifest_path : Coord.config -> string -> string
 val keeper_history_path : Coord.config -> string -> string
 val keeper_internal_history_path : Coord.config -> string -> string
 
-val keeper_policy_log_path : Coord.config -> string -> string
 val keeper_decision_log_path : Coord.config -> string -> string
-val keeper_feedback_log_path : Coord.config -> string -> string
-val keeper_dataset_export_path : Coord.config -> string -> string
 
 (** {1 Fiber health (for keeper supervisor)} *)
 

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -275,11 +275,11 @@ let purge_keeper_artifacts config requested_name
       Keeper_types.keeper_meta_path config keeper_name;
       Keeper_types_support.keeper_metrics_path config keeper_name;
       Keeper_types.keeper_memory_bank_path config keeper_name;
-      Keeper_types.keeper_generation_index_path config keeper_name;
-      Keeper_types.keeper_policy_log_path config keeper_name;
+      Keeper_types_support.keeper_generation_index_path config keeper_name;
+      Keeper_types_support.keeper_policy_log_path config keeper_name;
       Keeper_types.keeper_decision_log_path config keeper_name;
-      Keeper_types.keeper_feedback_log_path config keeper_name;
-      Keeper_types.keeper_dataset_export_path config keeper_name;
+      Keeper_types_support.keeper_feedback_log_path config keeper_name;
+      Keeper_types_support.keeper_dataset_export_path config keeper_name;
     ];
   remove_path_if_exists ~context:"keeper_purge" keeper_runtime_dir;
   Option.iter


### PR DESCRIPTION
## Summary
- remove generation-index, policy-log, feedback-log, dataset-export, and generation-manifest path helpers from the public Keeper_types facade
- route keeper purge cleanup path resolution to Keeper_types_support for those support-owned paths
- refresh the legacy purge ledger/spec note for the support-owner migration

## Verification
- ocamlformat --check lib/keeper/keeper_types.mli lib/server/server_dashboard_http_delete_actions.ml
- rg -n "Keeper_types\.(keeper_generation_index_path|keeper_generation_manifest_path|keeper_policy_log_path|keeper_feedback_log_path|keeper_dataset_export_path)\b" lib test bin scripts (no matches)
- rg -n "val keeper_generation_index_path|val keeper_generation_manifest_path|val keeper_policy_log_path|val keeper_feedback_log_path|val keeper_dataset_export_path" lib/keeper/keeper_types.mli (no matches)
- git diff --check origin/main...HEAD
- scripts/audit-keeper-tool-boundary-matrix.sh
- scripts/ocaml-structure-ratchet.sh
- scripts/stringly-boundary-ratchet.sh
- scripts/oas-boundary-ratchet.sh
- scripts/lint/no-unknown-permissive-default.sh
- scripts/lint/no-ocaml-comment-terminator-trap.sh
- scripts/lint-ignore-without-comment.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

Focused Dune attempted before rebase and was blocked by the machine-wide bare-Dune guard: scripts/dune-local.sh build test/test_dashboard_keeper_routes.exe test/test_mcp_server_eio.exe exited 75 because live bare dune processes were present. I did not bypass the guard.