### PR TITLE
refactor(keeper): drop log path helpers from types facade

### DIFF
--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -431,29 +431,16 @@ val read_meta_if_changed :
 
 (** {1 Selected re-exports from Keeper_types_support} *)
 
-(** Resolve the keeper base directory ([.masc/keepers]) for [config],
-    creating it if missing. *)
-val keeper_dir_ : Coord.config -> string
-
-(** Resolve the trace base directory ([.masc/traces]) for [config],
-    creating it if missing. *)
-val session_base_dir_ : Coord.config -> string
-
 val keeper_memory_bank_path : Coord.config -> string -> string
 val keeper_progress_path : Coord.config -> string -> string
-val keeper_generation_index_path : Coord.config -> string -> string
 
 (** Per-trace session directory under [.masc/traces/<trace_id>]. *)
 val keeper_session_dir : Coord.config -> string -> string
 
-val keeper_generation_manifest_path : Coord.config -> string -> string
 val keeper_history_path : Coord.config -> string -> string
 val keeper_internal_history_path : Coord.config -> string -> string
 
-val keeper_policy_log_path : Coord.config -> string -> string
 val keeper_decision_log_path : Coord.config -> string -> string
-val keeper_feedback_log_path : Coord.config -> string -> string
-val keeper_dataset_export_path : Coord.config -> string -> string
 
 (** {1 Fiber health (for keeper supervisor)} *)
 

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -275,11 +275,11 @@ let purge_keeper_artifacts config requested_name
       Keeper_types.keeper_meta_path config keeper_name;
       Keeper_types_support.keeper_metrics_path config keeper_name;
       Keeper_types.keeper_memory_bank_path config keeper_name;
-      Keeper_types.keeper_generation_index_path config keeper_name;
-      Keeper_types.keeper_policy_log_path config keeper_name;
+      Keeper_types_support.keeper_generation_index_path config keeper_name;
+      Keeper_types_support.keeper_policy_log_path config keeper_name;
       Keeper_types.keeper_decision_log_path config keeper_name;
-      Keeper_types.keeper_feedback_log_path config keeper_name;
-      Keeper_types.keeper_dataset_export_path config keeper_name;
+      Keeper_types_support.keeper_feedback_log_path config keeper_name;
+      Keeper_types_support.keeper_dataset_export_path config keeper_name;
     ];
   remove_path_if_exists ~context:"keeper_purge" keeper_runtime_dir;
   Option.iter


### PR DESCRIPTION
## Summary
- Drop delete/log path helpers from the broad `Keeper_types` compatibility facade.
- Route the keeper purge delete-action path to the owner module, `Keeper_types_support`.
- Hide unused `Keeper_types` trace/base helper leaves that already have no repo callers.

## Plan Link
- Implements the P1 `Keeper_types` compatibility facade cleanup from `docs/audit/2026-05-25-legacy-purge-plan.html`.

## Verification
- `git diff --check origin/main...HEAD`
- `opam exec -- ocamlformat --check lib/keeper/keeper_types.mli lib/server/server_dashboard_http_delete_actions.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_types.mli`
- `ocamlc -stop-after parsing lib/server/server_dashboard_http_delete_actions.ml`
- `rg -n "Keeper_types\\.(keeper_generation_index_path|keeper_policy_log_path|keeper_feedback_log_path|keeper_dataset_export_path|keeper_generation_manifest_path|keeper_dir_|session_base_dir_)" lib test` returns no matches
- `rg -n "val (keeper_generation_index_path|keeper_policy_log_path|keeper_feedback_log_path|keeper_dataset_export_path|keeper_generation_manifest_path|keeper_dir_|session_base_dir_)" lib/keeper/keeper_types.mli` returns no matches

## Not Run
- `scripts/dune-local.sh build lib/masc_mcp.cmxa`: blocked locally by concurrent bare Dune processes outside `scripts/dune-local.sh`; not bypassed.
