### PR TITLE
refactor(keeper): rename filesystem tool runtime owner

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -39,8 +39,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_exec_board.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_context.ml` - execution-dispatch
 - `lib/keeper/keeper_exec_context.mli` - execution-dispatch
-- `lib/keeper/keeper_exec_fs.ml` - execution-dispatch
-- `lib/keeper/keeper_exec_fs.mli` - execution-dispatch
+- `lib/keeper/agent_tool_filesystem_runtime.ml` - execution-dispatch
+- `lib/keeper/agent_tool_filesystem_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_ide.ml` - execution-dispatch
 - `lib/keeper/keeper_exec_ide.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_masc.ml` - execution-dispatch

--- a/docs/design/keeper-tool-runtime-boundary-plan.html
+++ b/docs/design/keeper-tool-runtime-boundary-plan.html
@@ -322,7 +322,7 @@
           <tr>
             <td data-label="ID">G6</td>
             <td data-label="Goal">Keep file read/edit tools out of concrete Docker backend selection.</td>
-            <td data-label="Quantitative Gate"><code>keeper_exec_fs.ml</code> has <code>0</code> direct <code>Keeper_sandbox_read_backend</code> calls and <code>0</code> hard-coded <code>via=docker</code> literals.</td>
+            <td data-label="Quantitative Gate"><code>agent_tool_filesystem_runtime.ml</code> has <code>0</code> direct <code>Keeper_sandbox_read_backend</code> calls and <code>0</code> hard-coded <code>via=docker</code> literals.</td>
             <td data-label="Status"><span class="status next">Started in slice 7</span></td>
           </tr>
           <tr>
@@ -656,7 +656,7 @@
         <div class="command">./_build/default/test/test_keeper_sandbox_read_runner.exe</div>
         <div class="command">./_build/default/test/test_keeper_sandbox_read_backend.exe</div>
         <div class="command">rg -n "Keeper_sandbox_read_backend\\.|&quot;via&quot;, `String &quot;docker&quot;" lib/keeper/keeper_shell_ops.ml</div>
-        <div class="command">rg -n "Keeper_sandbox_read_backend\\.|&quot;via&quot;, `String &quot;docker&quot;" lib/keeper/keeper_exec_fs.ml</div>
+        <div class="command">rg -n "Keeper_sandbox_read_backend\\.|&quot;via&quot;, `String &quot;docker&quot;" lib/keeper/agent_tool_filesystem_runtime.ml</div>
         <div class="command">test ! -e lib/keeper/keeper_docker_read.ml &amp;&amp; test ! -e lib/keeper/keeper_docker_read.mli &amp;&amp; test ! -e test/test_keeper_docker_read.ml</div>
         <div class="command">rg -n "~actor:`Keeper_shell|actor = `Keeper_shell" lib/keeper/keeper_sandbox_docker.ml lib/keeper/keeper_sandbox_read_backend.ml lib/keeper/keeper_docker_client_real.ml</div>
         <div class="command">rg -n "Keeper_shell_shared\\.run_argv_with_status_retry_eintr|Shell_gate\\.gate_typed|Exec_policy\\.validate_shell_ir_paths|Exec_dispatch\\.dispatch_decided" lib/keeper/keeper_shell_ops.ml lib/keeper/keeper_shell_bash.ml</div>

--- a/docs/rfc/RFC-0071-inventory.csv
+++ b/docs/rfc/RFC-0071-inventory.csv
@@ -414,7 +414,7 @@ lib/keeper/keeper_exec_board.ml,31,None,unclassified
 lib/keeper/keeper_exec_board.ml,56,None,unclassified
 lib/keeper/keeper_exec_board.ml,130,false,unclassified
 lib/keeper/keeper_exec_board.ml,159,false,unclassified
-lib/keeper/keeper_exec_fs.ml,37,None,unclassified
+lib/keeper/agent_tool_filesystem_runtime.ml,37,None,unclassified
 lib/keeper/keeper_exec_memory.ml,34,None,unclassified
 lib/keeper/keeper_exec_memory.ml,368,None,unclassified
 lib/keeper/keeper_exec_memory.ml,523,None,unclassified

--- a/docs/rfc/RFC-0128-ide-canonical-url-partitioning.md
+++ b/docs/rfc/RFC-0128-ide-canonical-url-partitioning.md
@@ -26,7 +26,7 @@ implementation_prs: [16028, 16036, 16040, 16044, 16049, 16053, 16055, 16058, 160
 | 경로 | base_dir 해결 | 코드 위치 | 결과 |
 |------|--------------|----------|------|
 | HTTP `/api/v1/ide/annotations?repo_id=X` 읽기 | `resolve_workspace_base` → `repo.local_path` (repo-aware) | `lib/server/server_ide_http.ml:92,129,223,260,266` | repo 별 partitioning **인지함** |
-| Keeper file edit → region 기록 쓰기 | `Keeper_alerting_path.project_root_of_config config` → **서버 base_path flat** | `lib/keeper/keeper_exec_fs.ml:230`, `lib/keeper/keeper_alerting_path.ml:69` | repo 모름. 항상 `<server-base>/.masc-ide/regions.jsonl` |
+| Keeper file edit → region 기록 쓰기 | `Keeper_alerting_path.project_root_of_config config` → **서버 base_path flat** | `lib/keeper/agent_tool_filesystem_runtime.ml:230`, `lib/keeper/keeper_alerting_path.ml:69` | repo 모름. 항상 `<server-base>/.masc-ide/regions.jsonl` |
 
 읽기는 repo_id 인자를 보고 정확한 repo 디렉토리를 찾지만, 쓰기는 그 모델을 모른 채 서버 base 에 평면적으로 쌓는다. 결과: keeper 가 sandbox 안 repo clone 에 annotation 을 만들어도 사용자가 working tree 로 IDE 를 열면 **항상 빈 결과**.
 
@@ -191,7 +191,7 @@ val find_canonical_url_by_repo_id
 - `Ide_paths.canonical_url_of_remote` 구현 + 단위 테스트.
 - `Repo_store.find_canonical_url_by_*` 두 함수 추가.
 - `Ide_annotations.create` / `Ide_region_tracker.append_region` 시그니처에 `canonical_url:string option` 추가.
-- 모든 caller (`server_ide_http.ml`, `keeper_exec_fs.ml`, `keeper_exec_ide.ml`) 업데이트.
+- 모든 caller (`server_ide_http.ml`, `agent_tool_filesystem_runtime.ml`, `keeper_exec_ide.ml`) 업데이트.
 - 기존 store path (`<base>/.masc-ide/{annotations,regions}.jsonl`) 는 *읽기 전용* 으로 유지. 새 record 는 `by-url/<slug>/` 또는 `_orphan/` 으로만.
 
 Acceptance:
@@ -283,7 +283,7 @@ test/test_ide_canonical_url_join.ml
 - RFC-0036 — Multi-keeper docker orchestration (sandbox path 형태의 출처).
 - `lib/ide/ide_paths.ml`, `lib/ide/ide_annotations.ml`, `lib/ide/ide_region_tracker.ml`, `lib/ide/ide_meta_sync.ml`.
 - `lib/server/server_ide_http.ml`, `lib/server/server_routes_http_routes_workspace.ml`.
-- `lib/keeper/keeper_exec_fs.ml:230` (write entry point), `lib/keeper/keeper_alerting_path.ml:69` (현재 base 해결).
+- `lib/keeper/agent_tool_filesystem_runtime.ml:230` (write entry point), `lib/keeper/keeper_alerting_path.ml:69` (현재 base 해결).
 - `lib/repo_manager/repo_store.ml` — repository.toml 모델.
 
 ## 10. Implementation summary (2026-05-18)

--- a/lib/capability_registry.mli
+++ b/lib/capability_registry.mli
@@ -122,7 +122,7 @@ val spawned_agent_prefixed_tools : string list
 
 val privileged_keeper_tool_names : string list
 (** The hardcoded set of keeper tools that route to the privileged
-    executor surface ([keeper_bash] / [keeper_fs_edit] /
+    executor surface ([keeper_bash] / [tool_edit_file] /
     [masc_worktree_create]). *)
 
 val keeper_privileged_tool_names : string list

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -29,7 +29,7 @@ let raw_all_tool_schemas : Masc_domain.tool_schema list =
         dispatcher handling it correctly.  #9912 plugged only
         [Tool_shard.base_tools] (5 always-present tools); #10101
         observed 11 other shard categories still missing
-        (keeper_task_claim, keeper_fs_edit, keeper_board_*, ...).
+        (keeper_task_claim, tool_edit_file, keeper_board_*, ...).
         [Tool_shard.all_keeper_tool_schemas] is the SSOT that
         pulls from [all_shards] plus the non-shard
         [keeper_preflight_tools] list, so future shard categories flow through without

--- a/lib/config/env_config_exec_timeout.ml
+++ b/lib/config/env_config_exec_timeout.ml
@@ -15,7 +15,7 @@
 
 type caller =
   | Shell                     (** keeper_exec_shell hot-path subprocess (60s) *)
-  | Fs                        (** keeper_exec_fs file ops (30s) *)
+  | Fs                        (** agent_tool_filesystem_runtime file ops (30s) *)
   | Preflight                 (** keeper_exec_preflight checks (10s) *)
   | Repo_readiness            (** keeper_repo_readiness git status (10s) *)
   | Sandbox                   (** keeper_sandbox_control / keeper_sandbox_docker probes (2s) *)

--- a/lib/dune
+++ b/lib/dune
@@ -146,7 +146,7 @@
   keeper_exec_shared
    keeper_path_check_error
    keeper_exec_board
-   keeper_exec_fs
+   agent_tool_filesystem_runtime
    keeper_exec_ide
    keeper_sandbox_docker
    keeper_task_worktree_lazy

--- a/lib/governance_pipeline_risk.mli
+++ b/lib/governance_pipeline_risk.mli
@@ -57,6 +57,6 @@ val combinatorial_risk_escalation :
     {- [masc_transition] action pattern matching}
     {- substring pattern matching over [tool_name]}
     {- keeper mutation floor ([High] minimum for
-       [keeper_fs_edit] / non-read-only [keeper_shell])}} *)
+       [tool_edit_file] / non-read-only [keeper_shell])}} *)
 val assess_risk :
   tool_name:string -> input:Yojson.Safe.t -> risk_level

--- a/lib/ide/ide_migration.ml
+++ b/lib/ide/ide_migration.ml
@@ -23,7 +23,7 @@ let zero_report =
 
 (* Resolve a record's [file_path] to its target partition using the
    exact same lookup chain as the keeper write path
-   ([Keeper_exec_fs.resolve_partition_for_write]). Centralising the
+   ([Agent_tool_filesystem_runtime.resolve_partition_for_write]). Centralising the
    logic here keeps PR-1c and PR-3 in lock-step — a divergence would
    route post-cut-over writes and pre-cut-over backlogged records to
    different buckets. *)

--- a/lib/keeper/agent_tool_filesystem_runtime.ml
+++ b/lib/keeper/agent_tool_filesystem_runtime.ml
@@ -2,11 +2,11 @@ open Keeper_types
 open Keeper_exec_shared
 open Ide_region_tracker
 
-(* Issue #8490: Variant SSOT for fs write mode. Adding a constructor
+(* Issue #8490: Variant SSOT for filesystem write mode. Adding a constructor
    forces compilation in [fs_write_mode_to_string] and
    [fs_write_mode_dispatch] AND extends [valid_fs_write_mode_strings];
-   the schema in [tool_shard.ml] mirrors the SSOT (cycle avoidance
-   per #8480/#8484 pattern). The previous code used 5 hardcoded sites:
+   the schema mirrors the SSOT through [Tool_shard_types] (cycle
+   avoidance per #8480/#8484 pattern). The previous code used 5 hardcoded sites:
    parse default, validate, dispatch, label normalisation, and schema. *)
 type fs_write_mode =
   | Overwrite
@@ -36,16 +36,16 @@ let fs_write_mode_of_string_opt raw =
 let all_fs_write_modes = [ Overwrite; Append; Patch ]
 let valid_fs_write_mode_strings = List.map fs_write_mode_to_string all_fs_write_modes
 
-(** keeper_fs_read max_bytes clamp. [fs_read_default_max_bytes] is the
-    canonical default; [Tool_shard_limits.keeper_fs_read_default_max_bytes]
+(** ReadFile max_bytes clamp. [read_file_default_max_bytes] is the
+    canonical default; [Tool_shard_limits.read_file_default_max_bytes]
     re-exports it at a leaf module so the tool schema in tool_shard.ml
     can reference the same value without creating a dependency cycle. *)
-let fs_read_default_max_bytes = Tool_shard_limits.keeper_fs_read_default_max_bytes
+let read_file_default_max_bytes = Tool_shard_limits.read_file_default_max_bytes
 
-let fs_read_min_max_bytes = 512
-let fs_read_max_max_bytes = 200_000
+let read_file_min_max_bytes = 512
+let read_file_max_max_bytes = 200_000
 
-let handle_keeper_fs_read
+let handle_read_file
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Coord.config)
       ~(keeper_name : string)
@@ -55,8 +55,8 @@ let handle_keeper_fs_read
   @@ fun meta ->
   let path = Safe_ops.json_string ~default:"" "path" args in
   let max_bytes =
-    Safe_ops.json_int ~default:fs_read_default_max_bytes "max_bytes" args
-    |> fun n -> max fs_read_min_max_bytes (min fs_read_max_max_bytes n)
+    Safe_ops.json_int ~default:read_file_default_max_bytes "max_bytes" args
+    |> fun n -> max read_file_min_max_bytes (min read_file_max_max_bytes n)
   in
   let fallback_dir = keeper_default_read_root ~config ~meta in
   match playground_relative_unless_allowed_root ~config ~meta path with
@@ -85,7 +85,7 @@ let handle_keeper_fs_read
        (* RFC-0006 Phase B-1: Docker keepers are always contained to their
        playground bundle on the host before any read-side I/O proceeds.
        The resolver-level allowed_paths check is augmented by this
-       strict containment so host FS cannot leak through keeper_fs_read
+       strict containment so host FS cannot leak through ReadFile
        while keeper_bash is container-isolated. *)
        (match Keeper_sandbox_containment.check_read_target ~config ~meta ~target with
         | Error e -> error_json ~fields:[ "path", `String target ] e
@@ -372,7 +372,7 @@ let check_invariant_sandbox_isolation
          ~sandbox_paths:[ target ])
 ;;
 
-let handle_keeper_fs_edit
+let handle_file_write
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Coord.config)
       ~(keeper_name : string)

--- a/lib/keeper/agent_tool_filesystem_runtime.mli
+++ b/lib/keeper/agent_tool_filesystem_runtime.mli
@@ -1,4 +1,4 @@
-(** Keeper filesystem tool handlers — read and edit. *)
+(** Filesystem runtime handlers for descriptor-backed ReadFile/EditFile/WriteFile tools. *)
 
 val resolve_partition_for_write
   :  base_dir:string
@@ -22,8 +22,8 @@ val resolve_partition_for_write
 
     [kind] selects the metric label ([annotation] or [region]). *)
 
-(** Issue #8490: Variant SSOT for fs write mode. Mirror in
-    [Tool_shard.fs_write_mode_enum_strings] (cycle avoidance, sync
+(** Issue #8490: Variant SSOT for filesystem write mode. Mirror in
+    [Tool_shard_types.fs_write_mode_enum_strings] (cycle avoidance, sync
     regression test catches drift). *)
 type fs_write_mode = Overwrite | Append | Patch
 
@@ -32,14 +32,14 @@ val fs_write_mode_of_string_opt : string -> fs_write_mode option
 val all_fs_write_modes : fs_write_mode list
 val valid_fs_write_mode_strings : string list
 
-val handle_keeper_fs_read :
+val handle_read_file :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   config:Coord.config ->
   keeper_name:string ->
   args:Yojson.Safe.t ->
   string
 
-val handle_keeper_fs_edit :
+val handle_file_write :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   config:Coord.config ->
   keeper_name:string ->

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -20,14 +20,14 @@ let handle_filesystem ctx descriptor args =
   match descriptor.Agent_tool_descriptor.runtime_handler with
   | Tool_read_file ->
     Some
-      (Keeper_exec_fs.handle_keeper_fs_read
+      (Agent_tool_filesystem_runtime.handle_read_file
          ~turn_sandbox_factory:ctx.turn_sandbox_factory
          ~config:ctx.config
          ~keeper_name:ctx.meta.name
          ~args)
   | Tool_edit_file | Tool_write_file ->
     Some
-      (Keeper_exec_fs.handle_keeper_fs_edit
+      (Agent_tool_filesystem_runtime.handle_file_write
          ~turn_sandbox_factory:ctx.turn_sandbox_factory
          ~config:ctx.config
          ~keeper_name:ctx.meta.name

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -353,7 +353,7 @@ let prepare_agent_setup
 
      Order matters: compute [aliased_public_names] against the UNFILTERED
      internal allowlist, because tool_policy.toml / presets still express
-     allowlists in internal names (keeper_bash, keeper_fs_read, ...).
+     allowlists in internal names (keeper_bash, tool_read_file, ...).
      Stripping internals before the alias-expansion check would leave
      [aliased_public_names] empty and drop "Execute"/"ReadFile"/... from the
      visible surface. See PR #14596 review. *)
@@ -468,11 +468,11 @@ let prepare_agent_setup
   in
   let visible_policy_name name =
     (* Preserve names that are already valid public surface entries.
-       keeper_fs_edit has two public aliases (EditFile, WriteFile) with different
+       tool_edit_file has two public aliases (EditFile, WriteFile) with different
        schemas; round-tripping through public_name_for_internal always
        picks EditFile, so any WriteFile entry would be coerced to Edit and then
        deduped. Only canonicalize names that are not themselves valid
-       public entries (e.g., internal names like keeper_fs_edit, or
+       public entries (e.g., internal names like tool_edit_file, or
        unrecognized inputs). *)
     if Keeper_tool_policy.StringSet.mem name universe_set
        && Keeper_tool_policy.StringSet.mem name allowed_exec_set

--- a/lib/keeper/keeper_sandbox_containment.mli
+++ b/lib/keeper/keeper_sandbox_containment.mli
@@ -3,7 +3,7 @@
 
     The keeper sandbox boundary historically followed the tool name:
     [keeper_bash] for [sandbox_profile=Docker] keepers ran in a
-    container, but [keeper_fs_read] / [keeper_fs_edit] / [keeper_shell]
+    container, but [ReadFile] / [EditFile/WriteFile] / [keeper_shell]
     could touch the host directly. The result was a cross-tool leak:
     different tools enforced different boundaries for the same keeper.
 

--- a/lib/keeper/keeper_sandbox_read_backend.ml
+++ b/lib/keeper/keeper_sandbox_read_backend.ml
@@ -204,12 +204,12 @@ let read_file ?turn_sandbox_factory ~config ~(meta : keeper_meta) ~host_path
       Error
         (Printf.sprintf
            "docker_cat_failed: path_not_found: %s (host path does not exist; verify the \
-            relative path under your playground before calling keeper_fs_read)"
+            relative path under your playground before calling ReadFile)"
            host_path)
     else if Sys.is_directory host_path then
       Error
         (Printf.sprintf
-           "docker_cat_failed: path_is_directory: %s (keeper_fs_read requires a file, \
+           "docker_cat_failed: path_is_directory: %s (ReadFile requires a file, \
             not a directory; use Execute executable='ls' argv=['<path>'] or a visible file-listing \
             tool for directory listings)"
            host_path)

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -43,7 +43,7 @@ val public_names : unit -> string list
 (** [public_name_for_internal internal_name] returns the preferred
     LLM-native public name for an internal routed tool, when one exists.
     The result follows [public_names] order, so ambiguous internals such
-    as [keeper_fs_edit] pick a stable primary public surface. *)
+    as [tool_edit_file] pick a stable primary public surface. *)
 val public_name_for_internal : string -> string option
 
 (** {1 Result-based telemetry} *)

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -90,12 +90,12 @@ let normalize_tool_names ~scope tools =
             match raw with
             | "keeper_fs_write" ->
                 dropped_notes :=
-                  "keeper_fs_write removed; use keeper_fs_edit or WriteFile"
+                  "keeper_fs_write removed; use tool_edit_file or WriteFile"
                   :: !dropped_notes;
                 None
             | "keeper_fs_delete" ->
                 dropped_notes :=
-                  "keeper_fs_delete removed; use keeper_fs_edit patch/write or masc_code_delete"
+                  "keeper_fs_delete removed; use tool_edit_file patch/write or masc_code_delete"
                   :: !dropped_notes;
                 None
             | name -> Some name

--- a/lib/keeper_invariant/dune
+++ b/lib/keeper_invariant/dune
@@ -2,7 +2,7 @@
 ; lib/keeper/. Second lib/keeper/ leaf after Phase 1I keeper_event_queue.
 ;
 ; 119+77 LoC. Pure stdlib-only module (List, Printf, Set, String,
-; StringSet, Result). Fan-in: 1 lib (keeper_exec_fs) + 1 test +
+; StringSet, Result). Fan-in: 1 lib (agent_tool_filesystem_runtime) + 1 test +
 ; 1 wrapped-pattern test caller.
 ;
 ; (include_subdirs no) opts out of parent's (include_subdirs unqualified).

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -27,7 +27,7 @@ val memory_search_source_enum_strings : string list
 val memory_kind_enum_strings : string list
 
 (** Issue #8490: hand-mirrored from
-    [Keeper_exec_fs.valid_fs_write_mode_strings]. Sync regression test
+    [Agent_tool_filesystem_runtime.valid_fs_write_mode_strings]. Sync regression test
     in [test_types.ml :: fs_write_mode_ssot] catches drift. *)
 val fs_write_mode_enum_strings : string list
 

--- a/lib/tool_shard_limits.ml
+++ b/lib/tool_shard_limits.ml
@@ -16,11 +16,11 @@ module Int = Stdlib.Int
 module Float = Stdlib.Float
 
 (** SSOT constants for tool schemas and runtime handlers that would
-    otherwise form a dependency cycle (Tool_shard ↔ Keeper_exec_fs).
+    otherwise form a dependency cycle (Tool_shard ↔ Agent_tool_filesystem_runtime).
 
     These integers live in a leaf module with no dependencies so both
     sides can import the same value. *)
 
-let keeper_fs_read_default_max_bytes = 20_000
-let keeper_fs_read_default_max_bytes_string =
-  Int.to_string keeper_fs_read_default_max_bytes
+let read_file_default_max_bytes = 20_000
+let read_file_default_max_bytes_string =
+  Int.to_string read_file_default_max_bytes

--- a/lib/tool_shard_limits.mli
+++ b/lib/tool_shard_limits.mli
@@ -1,26 +1,26 @@
 
 (** Tool_shard_limits — SSOT integer constants shared between
-    [Tool_shard] (the MCP tool surface) and [Keeper_exec_fs]
+    [Tool_shard] (the MCP tool surface) and [Agent_tool_filesystem_runtime]
     (the runtime handler).
 
     Lives in a leaf module with no dependencies so both sides can
     import the same value without forming the
-    [Tool_shard ↔ Keeper_exec_fs] dependency cycle that motivated
+    [Tool_shard ↔ Agent_tool_filesystem_runtime] dependency cycle that motivated
     the extraction in the first place. *)
 
-val keeper_fs_read_default_max_bytes : int
-(** Default byte budget for [keeper_fs_read] when the caller
+val read_file_default_max_bytes : int
+(** Default byte budget for [ReadFile] when the caller
     omits [max_bytes]. Currently 20_000.
 
     Pinned at the contract seam because the value appears in
-    two unrelated places: the JSON schema for [keeper_fs_read]'s
+    two unrelated places: the JSON schema for [ReadFile]'s
     [max_bytes] parameter (where it is rendered into the
     [description] string for the LLM) and the runtime guard in
-    [Keeper_exec_fs]. Surfacing it here keeps both consumers
+    [Agent_tool_filesystem_runtime]. Surfacing it here keeps both consumers
     locked to the same number. *)
 
-val keeper_fs_read_default_max_bytes_string : string
-(** [string_of_int keeper_fs_read_default_max_bytes]. Pre-rendered
+val read_file_default_max_bytes_string : string
+(** [string_of_int read_file_default_max_bytes]. Pre-rendered
     so the schema description string can include it without a
     per-schema-render allocation, and so the schema stays a
     structural constant rather than a function call result. *)

--- a/lib/tool_shard_types.mli
+++ b/lib/tool_shard_types.mli
@@ -22,7 +22,7 @@ val memory_kind_enum_strings : string list
     (#8527). *)
 
 val fs_write_mode_enum_strings : string list
-(** Hand-mirrored from [Keeper_exec_fs.valid_fs_write_mode_strings]
+(** Hand-mirrored from [Agent_tool_filesystem_runtime.valid_fs_write_mode_strings]
     (#8490). *)
 
 val vote_direction_enum_strings : string list

--- a/lib/tool_shard_types_enum_mirrors.ml
+++ b/lib/tool_shard_types_enum_mirrors.ml
@@ -17,7 +17,7 @@
       - [memory_kind_enum_strings]
           mirrors [Keeper_memory_policy.valid_memory_kind_strings] (#8527)
       - [fs_write_mode_enum_strings]
-          mirrors [Keeper_exec_fs.valid_fs_write_mode_strings] (#8490)
+          mirrors [Agent_tool_filesystem_runtime.valid_fs_write_mode_strings] (#8490)
       - [vote_direction_enum_strings]
           mirrors [Board_votes.valid_vote_direction_strings] (#8506)
 

--- a/lib/tool_shard_types_schemas_filesystem.ml
+++ b/lib/tool_shard_types_schemas_filesystem.ml
@@ -26,7 +26,7 @@ let filesystem_tools : Masc_domain.tool_schema list =
                       ; ( "description"
                         , `String
                             ("Max bytes to return (default: "
-                             ^ Tool_shard_limits.keeper_fs_read_default_max_bytes_string
+                             ^ Tool_shard_limits.read_file_default_max_bytes_string
                              ^ ")") )
                       ] )
                 ] )
@@ -73,7 +73,7 @@ let filesystem_tools : Masc_domain.tool_schema list =
                       ; "description", `String "Patch every occurrence instead of exactly one"
                       ] )
                 ; (* Issue #8490: derive from local mirror that tracks
-           [Keeper_exec_fs.valid_fs_write_mode_strings]. *)
+           [Agent_tool_filesystem_runtime.valid_fs_write_mode_strings]. *)
                   ( "mode"
                   , `Assoc
                       [ "type", `String "string"

--- a/scripts/lint/exhaustive-guard.allowlist
+++ b/scripts/lint/exhaustive-guard.allowlist
@@ -421,7 +421,7 @@ lib/keeper/keeper_exec_board.ml:31
 lib/keeper/keeper_exec_board.ml:56
 lib/keeper/keeper_exec_board.ml:130
 lib/keeper/keeper_exec_board.ml:159
-lib/keeper/keeper_exec_fs.ml:37
+lib/keeper/agent_tool_filesystem_runtime.ml:37
 lib/keeper/keeper_exec_memory.ml:34
 lib/keeper/keeper_exec_memory.ml:368
 lib/keeper/keeper_exec_memory.ml:523

--- a/test/test_ide_canonical_url_join.ml
+++ b/test/test_ide_canonical_url_join.ml
@@ -96,14 +96,14 @@ let test_sandbox_write_joins_with_worktree_read () =
     (* 3. resolve_partition_for_write at a sandbox path. *)
     let sandbox_file = Filename.concat sandbox_root "lib/foo.ml" in
     let sandbox_partition, sandbox_rel =
-      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+      Masc_mcp.Agent_tool_filesystem_runtime.resolve_partition_for_write
         ~base_dir
         ~kind:"region"
         ~file_path:sandbox_file
     in
     let worktree_file = Filename.concat worktree_root "lib/foo.ml" in
     let worktree_partition, worktree_rel =
-      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+      Masc_mcp.Agent_tool_filesystem_runtime.resolve_partition_for_write
         ~base_dir
         ~kind:"region"
         ~file_path:worktree_file
@@ -132,7 +132,7 @@ let test_unregistered_path_lands_in_orphan () =
   with_temp_base_dir (fun base_dir ->
     let elsewhere = Filename.concat base_dir "elsewhere/foo.ml" in
     let partition, original =
-      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+      Masc_mcp.Agent_tool_filesystem_runtime.resolve_partition_for_write
         ~base_dir
         ~kind:"region"
         ~file_path:elsewhere
@@ -168,7 +168,7 @@ let test_blank_url_lands_in_orphan () =
      | Error msg -> failf "save_all: %s" msg);
     let file = Filename.concat local "lib/foo.ml" in
     let partition, _ =
-      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+      Masc_mcp.Agent_tool_filesystem_runtime.resolve_partition_for_write
         ~base_dir
         ~kind:"region"
         ~file_path:file
@@ -217,13 +217,13 @@ let test_sandbox_playground_path_joins_with_worktree () =
     in
     let worktree_file = Filename.concat worktree "lib/foo.ml" in
     let sandbox_partition, sandbox_rel =
-      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+      Masc_mcp.Agent_tool_filesystem_runtime.resolve_partition_for_write
         ~base_dir
         ~kind:"region"
         ~file_path:sandbox_file
     in
     let worktree_partition, worktree_rel =
-      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+      Masc_mcp.Agent_tool_filesystem_runtime.resolve_partition_for_write
         ~base_dir
         ~kind:"region"
         ~file_path:worktree_file
@@ -275,7 +275,7 @@ let test_docker_playground_path_also_resolves () =
         ".masc/playground/docker/tech_glutton/repos/masc/lib/foo.ml"
     in
     let partition, rel =
-      Masc_mcp.Keeper_exec_fs.resolve_partition_for_write
+      Masc_mcp.Agent_tool_filesystem_runtime.resolve_partition_for_write
         ~base_dir
         ~kind:"region"
         ~file_path:docker_file

--- a/test/test_keeper_fs_edit_containment.ml
+++ b/test/test_keeper_fs_edit_containment.ml
@@ -6,7 +6,7 @@
 module Coord = Masc_mcp.Coord
 module Fs_compat = Fs_compat
 module Json = Yojson.Safe.Util
-module Keeper_exec_fs = Masc_mcp.Keeper_exec_fs
+module Agent_tool_filesystem_runtime = Masc_mcp.Agent_tool_filesystem_runtime
 module Keeper_registry = Masc_mcp.Keeper_registry
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_types = Masc_mcp.Keeper_types
@@ -117,7 +117,7 @@ let test_docker_write_blocks_project_root_even_if_allowlisted () =
   Keeper_registry.update_meta ~base_path:config.base_path meta.name meta;
   let path = Filename.concat config.base_path "root-write.txt" in
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit
+    Agent_tool_filesystem_runtime.handle_file_write
       ~turn_sandbox_factory:None
       ~config
       ~keeper_name:meta.name
@@ -145,7 +145,7 @@ let test_docker_write_allows_playground () =
   let path = Filename.concat playground "mind/allowed.txt" in
   ensure_dir (Filename.dirname path);
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit
+    Agent_tool_filesystem_runtime.handle_file_write
       ~turn_sandbox_factory:None
       ~config
       ~keeper_name:meta.name

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -1,11 +1,11 @@
-(** Tests for [Keeper_exec_fs.handle_keeper_fs_edit] mode=patch.
+(** Tests for [Agent_tool_filesystem_runtime.handle_file_write] mode=patch.
 
     RFC-0006 Phase A.4 — string-replace edit mode added so the
     Provider_a Code [Edit] cognate can be wired through OAS dual
     registration. *)
 
 module Coord = Masc_mcp.Coord
-module Keeper_exec_fs = Masc_mcp.Keeper_exec_fs
+module Agent_tool_filesystem_runtime = Masc_mcp.Agent_tool_filesystem_runtime
 module Keeper_registry = Masc_mcp.Keeper_registry
 module Keeper_tool_alias = Masc_mcp.Keeper_tool_alias
 module Keeper_types = Masc_mcp.Keeper_types
@@ -96,7 +96,7 @@ let parse_int raw field =
 
 let public_fs_edit_call ~public ~config ~(meta : Keeper_types.keeper_meta) args =
   let args = Keeper_tool_alias.translate_input ~public args in
-  Keeper_exec_fs.handle_keeper_fs_edit
+  Agent_tool_filesystem_runtime.handle_file_write
     ~turn_sandbox_factory:None
     ~config
     ~keeper_name:meta.name
@@ -123,7 +123,7 @@ let test_patch_unique_match () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\nlet y = 2\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Agent_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -145,7 +145,7 @@ let test_patch_no_match_errors () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Agent_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -175,7 +175,7 @@ let test_patch_multiple_matches_without_replace_all_errors () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "x = 1\nx = 1\nx = 1\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Agent_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -195,7 +195,7 @@ let test_patch_replace_all () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "x = 1\nx = 1\nx = 1\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Agent_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -217,7 +217,7 @@ let test_patch_empty_old_string_errors () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Agent_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -235,7 +235,7 @@ let test_patch_missing_file_errors () =
   setup @@ fun ~config ~meta ~playground ->
   let path = Filename.concat playground "ghost.ml" in
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Agent_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -252,7 +252,7 @@ let test_patch_delete_via_empty_new_string () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "keep me\nDELETE_ME\nkeep me too\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Agent_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -271,7 +271,7 @@ let test_overwrite_unchanged_by_patch_addition () =
   setup @@ fun ~config ~meta ~playground ->
   let path = Filename.concat playground "new.txt" in
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Agent_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
       ~args:
         (`Assoc
           [
@@ -288,7 +288,7 @@ let check_invalid_mode_is_rejected ~label ~mode ~expected_error =
   setup @@ fun ~config ~meta ~playground ->
   let path = Filename.concat playground (label ^ ".txt") in
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory:None ~config
+    Agent_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config
       ~keeper_name:meta.name
       ~args:
         (`Assoc

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -329,16 +329,16 @@ let test_descriptor_backed_dispatch_uses_agent_tool_runtime () =
   assert_contains runtime_ml "Agent_tool_descriptor.public_descriptors_for_internal";
   assert_contains runtime_ml "Keeper_exec_shell.handle_tool_execute";
   assert_contains runtime_ml "Keeper_exec_shell.handle_tool_search_files";
-  assert_contains runtime_ml "Keeper_exec_fs.handle_keeper_fs_read";
-  assert_contains runtime_ml "Keeper_exec_fs.handle_keeper_fs_edit";
+  assert_contains runtime_ml "Agent_tool_filesystem_runtime.handle_read_file";
+  assert_contains runtime_ml "Agent_tool_filesystem_runtime.handle_file_write";
   assert_contains runtime_ml "let handle_remote_mcp";
   assert_contains runtime_ml "Keeper_exec_masc.handle_registered_keeper_tool";
   assert_contains runtime_ml "| Remote_mcp -> handle_remote_mcp";
   assert_contains exec_tools_ml "Agent_tool_runtime.handle_internal";
   assert_not_contains exec_tools_ml "Keeper_exec_shell.handle_tool_execute";
   assert_not_contains exec_tools_ml "Keeper_exec_shell.handle_tool_search_files";
-  assert_not_contains exec_tools_ml "Keeper_exec_fs.handle_keeper_fs_read";
-  assert_not_contains exec_tools_ml "Keeper_exec_fs.handle_keeper_fs_edit"
+  assert_not_contains exec_tools_ml "Agent_tool_filesystem_runtime.handle_read_file";
+  assert_not_contains exec_tools_ml "Agent_tool_filesystem_runtime.handle_file_write"
 
 let test_shell_ops_host_ir_uses_keeper_shell_ir_facade () =
   let shell_ops_ml = "lib/keeper/keeper_shell_ops.ml" in
@@ -407,7 +407,7 @@ let test_approval_queue_uses_shell_command_words () =
   assert_not_contains rel "Exec_policy_mutation_classifier.flat_stage_words"
 
 let test_fs_tools_use_sandbox_read_runner () =
-  let rel = "lib/keeper/keeper_exec_fs.ml" in
+  let rel = "lib/keeper/agent_tool_filesystem_runtime.ml" in
   assert_contains rel "Keeper_sandbox_read_runner.";
   assert_contains rel "Keeper_sandbox_read_runner.backend_via";
   assert_contains rel "Keeper_sandbox_runner.route_label";

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -629,7 +629,7 @@ let () =
          hand-mirrored enum stays in lock-step with the SSOT
          (cycle-avoidance pattern from #8467/#8480/#8484). *)
       Alcotest.test_case "witness covers both variants" `Quick (fun () ->
-        let module F = Masc_mcp.Keeper_exec_fs in
+        let module F = Masc_mcp.Agent_tool_filesystem_runtime in
         let witness m =
           let actual = F.fs_write_mode_to_string m in
           if not (List.mem actual F.valid_fs_write_mode_strings) then
@@ -638,7 +638,7 @@ let () =
         witness F.Overwrite; witness F.Append; witness F.Patch;
         Alcotest.(check int) "count" 3 (List.length F.valid_fs_write_mode_strings));
       Alcotest.test_case "of_string_opt sound partial + empty back-compat" `Quick (fun () ->
-        let module F = Masc_mcp.Keeper_exec_fs in
+        let module F = Masc_mcp.Agent_tool_filesystem_runtime in
         Alcotest.(check bool) "overwrite" true (F.fs_write_mode_of_string_opt "overwrite" <> None);
         Alcotest.(check bool) "APPEND (case)" true (F.fs_write_mode_of_string_opt "APPEND" <> None);
         Alcotest.(check bool) "  empty -> Overwrite (back-compat)" true
@@ -649,7 +649,7 @@ let () =
           (F.fs_write_mode_of_string_opt "definitely-not-a-mode" = None));
       Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
         Alcotest.(check (list string)) "tool_shard mirror == SSOT"
-          Masc_mcp.Keeper_exec_fs.valid_fs_write_mode_strings
+          Masc_mcp.Agent_tool_filesystem_runtime.valid_fs_write_mode_strings
           Masc_mcp.Tool_shard.fs_write_mode_enum_strings);
     ];
     "vote_direction_ssot", [


### PR DESCRIPTION
## Summary
- rename Keeper_exec_fs to Agent_tool_filesystem_runtime
- rename filesystem descriptor handlers to handle_read_file and handle_file_write
- update descriptor runtime, tests, docs, and schema comments to use the new owner
- rename read-file byte-budget constants away from keeper_fs_read naming

## Verification
- ocamlformat --check on changed OCaml interfaces/implementations/tests
- git diff --check origin/main...HEAD
- residue scan: no Keeper_exec_fs / keeper_exec_fs / handle_keeper_fs_read / handle_keeper_fs_edit / keeper_fs_read_default_max_bytes references remain
- scripts/dune-local.sh build test/test_keeper_fs_edit_patch.exe test/test_keeper_fs_edit_containment.exe test/test_keeper_sandbox_boundary_policy.exe test/test_types.exe test/test_ide_canonical_url_join.exe (blocked by live bare Dune jobs; none exceeded the stuck-Dune threshold)
