### PR TITLE
refactor(keeper): drop trace path helpers from types facade

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 13:04:59 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 13:13:45 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -403,9 +403,15 @@
           </tr>
           <tr>
             <td><code>Keeper_types</code> delete-action path facade leaves</td>
-            <td><span class="status now">draft PR #18590</span></td>
+            <td><span class="status done">merged #18590</span></td>
             <td>Stop exposing generation-index, policy, feedback, dataset-export, and orphan generation-manifest path helpers through the broad <code>Keeper_types</code> facade. Keeper purge cleanup now calls the support owner directly for those filesystem paths.</td>
             <td>Backstop grep must stay clean for the removed public signature values and for <code>Keeper_types.keeper_generation_index_path</code>, <code>Keeper_types.keeper_policy_log_path</code>, <code>Keeper_types.keeper_feedback_log_path</code>, and <code>Keeper_types.keeper_dataset_export_path</code>.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_types</code> trace path facade leaves</td>
+            <td><span class="status now">draft PR #18595</span></td>
+            <td>Stop exposing per-trace session, public history, and internal-history path helpers through the broad <code>Keeper_types</code> facade. Dashboard, heartbeat, API, and memory tests now call <code>Keeper_types_support</code> directly.</td>
+            <td>Backstop grep must stay clean for <code>Keeper_types.keeper_session_dir</code>, <code>Keeper_types.keeper_history_path</code>, and <code>Keeper_types.keeper_internal_history_path</code>.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.write_meta_with_retry</code> wrapper</td>

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -559,7 +559,7 @@ Keeper turn에서 어떤 "skill" 경로를 사용할지 결정:
 
 ### 15.2 keeper_types.ml include chain
 
-`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history-source/metrics/API-key/alert-path/rotation/delete-action support helper를 `Keeper_types_support` 소유로 돌렸지만, 일부 support helper 선별 re-export와 구현 include chain 자체는 남아 있어 가독성이 낮다.
+`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history-source/metrics/API-key/alert-path/rotation/delete-action/trace-path support helper를 `Keeper_types_support` 소유로 돌렸지만, 일부 support helper 선별 re-export와 구현 include chain 자체는 남아 있어 가독성이 낮다.
 
 ### 15.3 keeper_memory 계층의 include chain
 

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -324,7 +324,7 @@ let classify_audit_trail ~(config : Coord.config) ~(meta : keeper_meta)
   let evidence_refs =
     [
       base_evidence_ref "path" "trace_history"
-        (Keeper_types.keeper_history_path config trace_id);
+        (Keeper_types_support.keeper_history_path config trace_id);
       base_evidence_ref "route" "workspace_evidence" "#workspace?section=evidence";
     ]
   in
@@ -572,7 +572,7 @@ let keeper_snapshot_json
                  (Keeper_types.keeper_meta_path config meta.name));
             evidence_ref_json
               (base_evidence_ref "path" "history"
-                 (Keeper_types.keeper_history_path config trace_id));
+                 (Keeper_types_support.keeper_history_path config trace_id));
           ] );
     ]
 

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -100,11 +100,11 @@ let write_heartbeat_snapshot
     | Some c -> Keeper_exec_context.messages_of_context c
     | None ->
       let history_path =
-        Keeper_types.keeper_history_path ctx.config
+        Keeper_types_support.keeper_history_path ctx.config
           (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)
       in
       let internal_history_path =
-        Keeper_types.keeper_internal_history_path ctx.config
+        Keeper_types_support.keeper_internal_history_path ctx.config
           (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)
       in
       (let parse_errors = ref 0 in

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -434,12 +434,6 @@ val read_meta_if_changed :
 val keeper_memory_bank_path : Coord.config -> string -> string
 val keeper_progress_path : Coord.config -> string -> string
 
-(** Per-trace session directory under [.masc/traces/<trace_id>]. *)
-val keeper_session_dir : Coord.config -> string -> string
-
-val keeper_history_path : Coord.config -> string -> string
-val keeper_internal_history_path : Coord.config -> string -> string
-
 val keeper_decision_log_path : Coord.config -> string -> string
 
 (** {1 Fiber health (for keeper supervisor)} *)

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -285,7 +285,7 @@ let purge_keeper_artifacts config requested_name
   Option.iter
     (fun keeper_trace_id ->
        remove_path_if_exists ~context:"keeper_purge"
-         (Keeper_types.keeper_session_dir config keeper_trace_id))
+         (Keeper_types_support.keeper_session_dir config keeper_trace_id))
     trace_id;
   Option.iter (remove_path_if_exists ~context:"keeper_purge") toml_path;
   { keeper_pending_confirms_removed; agent_cleanup_results }

--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
@@ -56,7 +56,7 @@ let inventory_json (config : Coord.config) (name : string)
     , `Assoc [ "error", `String (Printf.sprintf "keeper %S not found" name) ] )
   | Ok (Some (_, meta)) ->
     let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
-    let session_dir = Keeper_types.keeper_session_dir config trace_id in
+    let session_dir = Keeper_types_support.keeper_session_dir config trace_id in
     let current_path =
       Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id:trace_id
     in

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -318,7 +318,7 @@ let handle_keeper_checkpoints_post state req reqd body_str =
                       (String.escaped msg))
                    reqd
              | Ok trace_id ->
-                 let session_dir = Keeper_types.keeper_session_dir config trace_id in
+                 let session_dir = Keeper_types_support.keeper_session_dir config trace_id in
                  let (deleted, missing) =
                    Keeper_checkpoint_store.delete_oas_history_files
                      ~session_dir ~snapshot_ids

--- a/lib/server/server_dashboard_http_keeper_api_trace.ml
+++ b/lib/server/server_dashboard_http_keeper_api_trace.ml
@@ -31,7 +31,7 @@ let dedupe_thinking_lines (lines : Trajectory.trajectory_line list)
 let read_internal_history_lines ~(config : Coord.config) ~(trace_id : string)
   : Trajectory.trajectory_line list
   =
-  let path = Keeper_types.keeper_internal_history_path config trace_id in
+  let path = Keeper_types_support.keeper_internal_history_path config trace_id in
   (* Streaming filter: avoid materialising the full JSONL list when only a
      subset of lines decode to [trajectory_line]. *)
   Fs_compat.fold_jsonl_lines

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -1298,7 +1298,7 @@ let test_agent_purge_route_removes_keeper_artifacts_and_toml () =
        (Filename.concat (Masc_mcp.Keeper_types.keeper_dir config) keeper_name));
   check bool "keeper session trace removed" false
     (Sys.file_exists
-       (Masc_mcp.Keeper_types.keeper_session_dir config
+       (Masc_mcp.Keeper_types_support.keeper_session_dir config
           (Masc_mcp.Keeper_id.Trace_id.to_string meta.runtime.trace_id)))
 ;;
 
@@ -2088,7 +2088,7 @@ let test_merge_keeper_trace_lines_includes_internal_history () =
   ignore (Masc_mcp.Coord.init config ~agent_name:(Some "bootstrap-admin"));
   let trace_id = "trace-route-shadow-demo-seed" in
   let internal_history_path =
-    Masc_mcp.Keeper_types.keeper_internal_history_path config trace_id
+    Masc_mcp.Keeper_types_support.keeper_internal_history_path config trace_id
   in
   Fs_compat.mkdir_p (Filename.dirname internal_history_path);
   write_file

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -1002,7 +1002,7 @@ let test_memory_search_cross_generation () =
     let meta = keeper_meta ~name:"cross-gen-keeper" ~mention_targets:["cross-gen-keeper"] () in
     let trace_id = meta.runtime.trace_id in
     (* Write history.jsonl with messages from previous generations *)
-    let history_path = Keeper_types.keeper_history_path config (Masc_mcp.Keeper_id.Trace_id.to_string trace_id) in
+    let history_path = Keeper_types_support.keeper_history_path config (Masc_mcp.Keeper_id.Trace_id.to_string trace_id) in
     write_lines history_path [
       history_json_line "user" "deploy the canary release";
       history_json_line "assistant" "deploying now";
@@ -1051,7 +1051,7 @@ let test_memory_search_dedup () =
     let config = make_test_room_config dir in
     let meta = keeper_meta ~name:"dedup-keeper" ~mention_targets:["dedup-keeper"] () in
     let trace_id = meta.runtime.trace_id in
-    let history_path = Keeper_types.keeper_history_path config (Masc_mcp.Keeper_id.Trace_id.to_string trace_id) in
+    let history_path = Keeper_types_support.keeper_history_path config (Masc_mcp.Keeper_id.Trace_id.to_string trace_id) in
     write_lines history_path [
       history_json_line "user" "unique needle from history";
       history_json_line "user" "shared needle message";
@@ -1082,13 +1082,13 @@ let test_memory_search_prev_generation () =
       ~mention_targets:["multi-gen-keeper"]
       () in
     (* Previous generation's history — different trace_id directory *)
-    let prev_history_path = Keeper_types.keeper_history_path config prev_trace in
+    let prev_history_path = Keeper_types_support.keeper_history_path config prev_trace in
     write_lines prev_history_path [
       history_json_line "user" "migrate the postgres schema to v3";
       history_json_line "user" "rollback the failed deployment";
     ];
     (* Current generation's history — empty (just started) *)
-    let curr_history_path = Keeper_types.keeper_history_path config curr_trace in
+    let curr_history_path = Keeper_types_support.keeper_history_path config curr_trace in
     write_lines curr_history_path [
       history_json_line "user" "check cluster health";
     ];
@@ -1516,7 +1516,7 @@ let test_memory_search_source_history () =
     let config = make_test_room_config dir in
     let meta = keeper_meta ~name:"hist-keeper" ~mention_targets:["hist-keeper"] () in
     let trace_id = meta.runtime.trace_id in
-    let history_path = Keeper_types.keeper_history_path config (Masc_mcp.Keeper_id.Trace_id.to_string trace_id) in
+    let history_path = Keeper_types_support.keeper_history_path config (Masc_mcp.Keeper_id.Trace_id.to_string trace_id) in
     write_lines history_path [
       history_json_line "user" "deploy the legacy service";
     ];
@@ -1543,7 +1543,7 @@ let test_memory_search_source_all () =
     ];
     (* History has raw message *)
     let trace_id = meta.runtime.trace_id in
-    let history_path = Keeper_types.keeper_history_path config (Masc_mcp.Keeper_id.Trace_id.to_string trace_id) in
+    let history_path = Keeper_types_support.keeper_history_path config (Masc_mcp.Keeper_id.Trace_id.to_string trace_id) in
     write_lines history_path [
       history_json_line "user" "alpha from history";
     ];


### PR DESCRIPTION
## Summary
- remove per-trace session, history, and internal-history path helpers from the public Keeper_types facade
- route dashboard, heartbeat, server API, delete cleanup, and memory/route tests to Keeper_types_support directly
- refresh the legacy purge ledger/spec note for the support-owner migration

## Verification
- ocamlformat --check lib/keeper/keeper_types.mli lib/server/server_dashboard_http_keeper_api_post.ml lib/server/server_dashboard_http_keeper_api_trace.ml lib/server/server_dashboard_http_keeper_api_checkpoints.ml lib/server/server_dashboard_http_delete_actions.ml lib/dashboard/dashboard_safe_autonomy.ml lib/keeper/keeper_heartbeat_snapshot.ml test/test_keeper_memory.ml test/test_dashboard_keeper_routes.ml
- rg -n "Keeper_types\.(keeper_session_dir|keeper_history_path|keeper_internal_history_path)\b|Masc_mcp\.Keeper_types\.(keeper_session_dir|keeper_history_path|keeper_internal_history_path)\b" lib test bin scripts (no matches)
- rg -n "val keeper_session_dir|val keeper_history_path|val keeper_internal_history_path" lib/keeper/keeper_types.mli (no matches)
- git diff --check origin/main...HEAD
- scripts/audit-keeper-tool-boundary-matrix.sh
- scripts/ocaml-structure-ratchet.sh
- scripts/stringly-boundary-ratchet.sh
- scripts/oas-boundary-ratchet.sh
- scripts/lint/no-unknown-permissive-default.sh
- scripts/lint/no-ocaml-comment-terminator-trap.sh
- scripts/lint-ignore-without-comment.sh
- scripts/lint/godfile-size-regression.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-determinism-contract.sh

Focused Dune attempted before rebase and was blocked by the machine-wide bare-Dune guard: scripts/dune-local.sh build test/test_keeper_memory.exe test/test_dashboard_keeper_routes.exe test/test_mcp_server_eio.exe exited 75 because live bare dune processes were present. I did not bypass the guard.