### PR TITLE
fix(keeper): require explicit retry boundary marker

### DIFF
--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -80,6 +80,12 @@ let assoc_int_opt key json =
   | _ -> None
 ;;
 
+let assoc_bool_opt key json =
+  match assoc_field_opt key json with
+  | Some (`Bool value) -> Some value
+  | _ -> None
+;;
+
 let detail_assoc_field_opt key json =
   match assoc_field_opt key json with
   | Some _ as value -> value
@@ -177,9 +183,11 @@ let path_check_reason_of_explicit = function
 let classify_deterministic_retry json =
   match detail_assoc_field_opt "deterministic_retry" json with
   | Some (`Assoc _ as retry) ->
-    (match assoc_string_opt "reason" retry with
-     | Some reason -> reason_of_wire reason
-     | None -> None)
+    (match assoc_bool_opt "retry_same_args" retry, assoc_string_opt "reason" retry with
+     | Some false, Some reason -> reason_of_wire reason
+     | (Some true | None), _
+     | _, None ->
+       None)
   | Some _
   | None ->
     None

--- a/lib/keeper/keeper_tool_deterministic_error.mli
+++ b/lib/keeper/keeper_tool_deterministic_error.mli
@@ -72,8 +72,10 @@ type deterministic_reason =
 val classify : Yojson.Safe.t -> deterministic_reason option
 
 (** Structured marker for tool producers that already know the same
-    arguments cannot succeed. Prefer this over adding more [error]
-    string fallbacks. *)
+    arguments cannot succeed. The classifier only accepts this marker
+    when [retry_same_args=false] is present, so producers must state
+    the retry boundary explicitly. Prefer this over adding more
+    [error] string fallbacks. *)
 val deterministic_retry_fields : deterministic_reason -> (string * Yojson.Safe.t) list
 
 (** Convenience wrapper: parse [raw] as JSON then [classify]. Returns

--- a/test/test_keeper_bash_retry_deterministic_close.ml
+++ b/test/test_keeper_bash_retry_deterministic_close.ml
@@ -132,6 +132,26 @@ let test_unknown_typed_deterministic_retry_marker_observes () =
   check_classify ~name:"unknown deterministic retry marker" ~expected:None raw
 ;;
 
+let test_typed_deterministic_retry_marker_requires_no_same_args_retry () =
+  let raw =
+    {|{"ok":false,"error":"timeout","deterministic_retry":{"reason":"write_operation_gated","retry_same_args":true}}|}
+  in
+  check_classify
+    ~name:"deterministic retry marker with retry_same_args=true"
+    ~expected:None
+    raw
+;;
+
+let test_typed_deterministic_retry_marker_requires_retry_same_args_field () =
+  let raw =
+    {|{"ok":false,"error":"timeout","deterministic_retry":{"reason":"write_operation_gated"}}|}
+  in
+  check_classify
+    ~name:"deterministic retry marker without retry_same_args"
+    ~expected:None
+    raw
+;;
+
 (* ── Deterministic — path-check path ──────────────────────────── *)
 
 let test_path_outside_sandbox_via_path_check_block () =
@@ -338,6 +358,14 @@ let () =
             "unknown_typed_deterministic_retry_marker_observes"
             `Quick
             test_unknown_typed_deterministic_retry_marker_observes
+        ; Alcotest.test_case
+            "typed_deterministic_retry_marker_requires_no_same_args_retry"
+            `Quick
+            test_typed_deterministic_retry_marker_requires_no_same_args_retry
+        ; Alcotest.test_case
+            "typed_deterministic_retry_marker_requires_retry_same_args_field"
+            `Quick
+            test_typed_deterministic_retry_marker_requires_retry_same_args_field
         ] )
     ; ( "classify_path_check"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary
- require deterministic_retry markers to carry retry_same_args=false before they classify as deterministic
- keep unknown, missing, and retry_same_args=true markers in observe/None path
- document the marker contract and add regression tests

## Verification
- ocamlformat --check lib/keeper/keeper_tool_deterministic_error.ml lib/keeper/keeper_tool_deterministic_error.mli test/test_keeper_bash_retry_deterministic_close.ml
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_keeper_bash_retry_deterministic_close.exe (blocked: live bare dune exec test/test_keeper_tools_oas.exe outside scripts/dune-local.sh)