### PR TITLE
fix(keeper): promote empty Execute argv command

### DIFF
--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -171,6 +171,14 @@ let parse_pipeline ~path (json : Yojson.Safe.t) =
     result_errorf "%s must be array, got %s" path (json_type_name value)
 ;;
 
+let normalize_stage { executable; argv } =
+  let executable = String.trim executable in
+  match executable, argv with
+  | "", first :: rest when not (String.equal (String.trim first) "") ->
+    { executable = String.trim first; argv = rest }
+  | _ -> { executable; argv }
+;;
+
 let of_json (json : Yojson.Safe.t) =
   let ( let* ) = Result.bind in
   let* fields = assoc_fields ~path:"$" json in
@@ -202,10 +210,11 @@ let of_json (json : Yojson.Safe.t) =
        this is the typed-input contract advertised in the schema. *)
     let* executable = required_string ~path:"$" fields "executable" in
     let* argv = optional_string_list ~path:"$" fields "argv" in
-    Ok (Exec { executable; argv; cwd; env })
+    let stage = normalize_stage { executable; argv } in
+    Ok (Exec { executable = stage.executable; argv = stage.argv; cwd; env })
   | false, Some (path, value) ->
     let* stages = parse_pipeline ~path value in
-    Ok (Pipeline { stages; cwd; env })
+    Ok (Pipeline { stages = List.map normalize_stage stages; cwd; env })
   | false, None -> Error "$.executable or $.pipeline is required"
 ;;
 

--- a/lib/keeper/keeper_tool_bash_input.mli
+++ b/lib/keeper/keeper_tool_bash_input.mli
@@ -76,7 +76,9 @@ val of_json : Yojson.Safe.t -> (bash_input, string) result
     [{stages = ...}] is accepted as an equivalent structured pipeline key.
     [timeout_sec] is accepted at this layer and consumed by the caller. Raw
     command-string fields and other unsupported fields are intentionally rejected
-    here. *)
+    here.  Compatibility normalization promotes [{executable = ""; argv =
+    command :: rest}] to [{executable = command; argv = rest}] before allowlist
+    validation, so malformed typed calls still cross the same executable gate. *)
 
 val validate : mode:allowlist_mode -> bash_input -> (unit, validation_error) result
 (** Run all structural checks against [input].  Returns [Ok ()] on

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -288,6 +288,24 @@ let test_of_json_exec () =
   | Bash_input.Pipeline _ -> Alcotest.fail "expected Exec"
 ;;
 
+let test_of_json_promotes_empty_exec_from_argv0 () =
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ "executable", `String ""
+          ; "argv", `List [ `String "gh"; `String "pr"; `String "list" ]
+          ; "cwd", `String "/tmp"
+          ])
+  in
+  match input with
+  | Bash_input.Exec { executable; argv; cwd; env } ->
+    Alcotest.(check string) "promoted executable" "gh" executable;
+    Alcotest.(check (list string)) "argv without command duplicate" [ "pr"; "list" ] argv;
+    Alcotest.(check (option string)) "cwd" (Some "/tmp") cwd;
+    Alcotest.(check (list (pair string string))) "env" [] env
+  | Bash_input.Pipeline _ -> Alcotest.fail "expected Exec"
+;;
+
 let test_of_json_pipeline () =
   let input =
     parse_json_exn
@@ -317,6 +335,36 @@ let test_of_json_pipeline () =
        Alcotest.(check (list string)) "first argv" [ "hello" ] first.argv;
        Alcotest.(check string) "second executable" "wc" second.executable;
        Alcotest.(check (list string)) "second argv" [ "-c" ] second.argv
+     | _ -> Alcotest.fail "expected exactly two stages")
+  | Bash_input.Exec _ -> Alcotest.fail "expected Pipeline"
+;;
+
+let test_of_json_promotes_empty_pipeline_stage_from_argv0 () =
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ ( "pipeline"
+            , `List
+                [ `Assoc
+                    [ "executable", `String ""
+                    ; "argv", `List [ `String "rg"; `String "--files"; `String "lib" ]
+                    ]
+                ; `Assoc
+                    [ "executable", `String "head"; "argv", `List [ `String "-20" ] ]
+                ] )
+          ; "cwd", `String "/tmp"
+          ])
+  in
+  match input with
+  | Bash_input.Pipeline { stages; cwd; env } ->
+    Alcotest.(check (option string)) "cwd" (Some "/tmp") cwd;
+    Alcotest.(check (list (pair string string))) "env" [] env;
+    (match stages with
+     | [ first; second ] ->
+       Alcotest.(check string) "first executable" "rg" first.executable;
+       Alcotest.(check (list string)) "first argv" [ "--files"; "lib" ] first.argv;
+       Alcotest.(check string) "second executable" "head" second.executable;
+       Alcotest.(check (list string)) "second argv" [ "-20" ] second.argv
      | _ -> Alcotest.fail "expected exactly two stages")
   | Bash_input.Exec _ -> Alcotest.fail "expected Pipeline"
 ;;
@@ -559,7 +607,15 @@ let suite =
           `Quick
           test_not_allowlisted_hints_self_correction
       ; Alcotest.test_case "of_json_exec" `Quick test_of_json_exec
+      ; Alcotest.test_case
+          "of_json_promotes_empty_exec_from_argv0"
+          `Quick
+          test_of_json_promotes_empty_exec_from_argv0
       ; Alcotest.test_case "of_json_pipeline" `Quick test_of_json_pipeline
+      ; Alcotest.test_case
+          "of_json_promotes_empty_pipeline_stage_from_argv0"
+          `Quick
+          test_of_json_promotes_empty_pipeline_stage_from_argv0
       ; Alcotest.test_case
           "of_json_rejects_cmd_string_only"
           `Quick


### PR DESCRIPTION
## Summary
- normalize malformed typed Execute calls with empty executable and command in argv[0]
- apply the same compatibility normalization to pipeline stages
- add regression coverage for exec and pipeline forms

## Evidence
- log evidence after #18589 merge: 2026-05-26T04:11:15Z and 04:11:18Z showed Execute errors with cmd="'' gh pr list ..."

## Verification
- ocamlformat --check lib/keeper/keeper_tool_bash_input.ml lib/keeper/keeper_tool_bash_input.mli test/test_keeper_bash_typed_input.ml
- ocamlc -stop-after parsing lib/keeper/keeper_tool_bash_input.ml lib/keeper/keeper_tool_bash_input.mli test/test_keeper_bash_typed_input.ml
- git diff --check

## Not run
- scripts/dune-local.sh build test/test_keeper_bash_typed_input.exe: blocked by live bare Dune processes outside scripts/dune-local.sh (dune build --root ., dune exec test/test_keeper_tools_oas.exe)