### PR TITLE
refactor(keeper): drop progress path helper from types facade

### DIFF
--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -432,7 +432,6 @@ val read_meta_if_changed :
 (** {1 Selected re-exports from Keeper_types_support} *)
 
 val keeper_memory_bank_path : Coord.config -> string -> string
-val keeper_progress_path : Coord.config -> string -> string
 
 (** Per-trace session directory under [.masc/traces/<trace_id>]. *)
 val keeper_session_dir : Coord.config -> string -> string

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -820,7 +820,9 @@ let test_read_continuity_summary_prefers_progress_log () =
   Fun.protect ~finally:(fun () -> cleanup_tmpdir_recursive dir) (fun () ->
     let config = make_test_room_config dir in
     let meta = keeper_meta ~name:"progress-pref-keeper" ~mention_targets:["progress-pref-keeper"] () in
-    let progress_path = Keeper_types.keeper_progress_path config "progress-pref-keeper" in
+    let progress_path =
+      Keeper_types_support.keeper_progress_path config "progress-pref-keeper"
+    in
     let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname progress_path) in
     (match
        Fs_compat.save_file_atomic progress_path
@@ -842,7 +844,7 @@ let test_read_continuity_summary_caps_progress_log () =
     let config = make_test_room_config dir in
     let keeper = "progress-cap-keeper" in
     let meta = keeper_meta ~name:keeper ~mention_targets:[keeper] () in
-    let progress_path = Keeper_types.keeper_progress_path config keeper in
+    let progress_path = Keeper_types_support.keeper_progress_path config keeper in
     let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname progress_path) in
     let max_chars =
       Masc_mcp.Keeper_memory_policy.default_continuity_summary_max_chars
@@ -869,7 +871,9 @@ let test_keeper_context_status_reports_recovery_source_and_tiers () =
   Fun.protect ~finally:(fun () -> cleanup_tmpdir_recursive dir) (fun () ->
     let config = make_test_room_config dir in
     let meta = keeper_meta ~name:"status-keeper" ~mention_targets:["status-keeper"] () in
-    let progress_path = Keeper_types.keeper_progress_path config "status-keeper" in
+    let progress_path =
+      Keeper_types_support.keeper_progress_path config "status-keeper"
+    in
     let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname progress_path) in
     (match
        Fs_compat.save_file_atomic progress_path

--- a/test/test_keeper_meta_unknown_keys_warn.ml
+++ b/test/test_keeper_meta_unknown_keys_warn.ml
@@ -71,7 +71,9 @@ let test_progress_updated_line_failure_is_observable () =
   Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
     let config = Coord.default_config dir in
     let keeper_name = "progress-refresh-failure" in
-    let progress_path = Keeper_types.keeper_progress_path config keeper_name in
+    let progress_path =
+      Keeper_types_support.keeper_progress_path config keeper_name
+    in
     let (_ : string) = Keeper_fs.ensure_dir progress_path in
     let before =
       Prometheus.metric_total


### PR DESCRIPTION
Summary:
- Remove keeper_progress_path from the Keeper_types selected support facade.
- Route progress-log tests directly to Keeper_types_support, which remains the owner module.
- Continues the P1 Keeper_types facade cleanup from docs/audit/2026-05-25-legacy-purge-plan.html.

Verification:
- git diff --check
- opam exec -- ocamlformat --check lib/keeper/keeper_types.mli test/test_keeper_memory.ml test/test_keeper_meta_unknown_keys_warn.ml
- opam exec -- ocamlc -stop-after parsing lib/keeper/keeper_types.mli
- opam exec -- ocamlc -stop-after parsing test/test_keeper_memory.ml
- opam exec -- ocamlc -stop-after parsing test/test_keeper_meta_unknown_keys_warn.ml
- rg -n "Keeper_types\.keeper_progress_path" lib test # no matches
- rg -n "val keeper_progress_path" lib/keeper/keeper_types.mli lib/keeper/keeper_types_support.mli # only Keeper_types_support.mli remains

Not run:
- scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_keeper_memory.exe test/test_keeper_meta_unknown_keys_warn.exe returned 75 because live bare Dune processes were already bypassing the machine-wide Dune lock; not bypassed.