### PR TITLE
fix(dashboard): carry structured keeper tool IO over SSE

### DIFF
--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -90,6 +90,8 @@ describe('SSEMessageSchema', () => {
       tool_name: 'bash',
       duration_ms: 1234,
       success: true,
+      tool_args: { path: '/tmp/a' },
+      tool_result: { ok: true },
       tool_args_preview: '{"path":"/tmp/a"}',
       tool_output_preview: '{"ok":true}',
       tool_io_redacted: false,

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -38,6 +38,24 @@ function loadOasRuntimeStore(): Promise<typeof OasRuntimeStore> {
   return oasRuntimeStorePromise
 }
 
+function traceValueString(value: unknown): string | null {
+  if (typeof value === 'string') return value
+  if (value == null) return null
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function traceToolArgs(value: unknown): string | Record<string, unknown> | null {
+  if (typeof value === 'string') return value
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  return traceValueString(value)
+}
+
 // --- Signals ---
 
 export const connected = signal(false)
@@ -569,14 +587,16 @@ function handleEvent(event: SSEEvent): void {
       )
       // Push to live trace if session trace is open for this keeper
       if (event.name) {
+        const toolArgs = traceToolArgs(event.tool_args) ?? event.tool_args_preview ?? null
+        const toolResult = traceValueString(event.tool_result) ?? event.tool_output_preview ?? null
         appendLiveToolCall(event.name, {
           toolName,
           durationMs,
           success: event.success !== false,
           error: event.error_text ?? null,
           tsUnix: typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000,
-          toolArgs: event.tool_args_preview ?? null,
-          toolResult: event.tool_output_preview ?? null,
+          toolArgs,
+          toolResult,
           toolIoRedacted: event.tool_io_redacted === true,
         })
       }

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -178,6 +178,8 @@ export interface SSEEvent {
   duration_ms?: number
   success?: boolean
   error_text?: string
+  tool_args?: unknown
+  tool_result?: unknown
   tool_args_preview?: string
   tool_output_preview?: string
   tool_io_redacted?: boolean

--- a/lib/keeper/keeper_tools_oas_handler_telemetry.ml
+++ b/lib/keeper/keeper_tools_oas_handler_telemetry.ml
@@ -35,6 +35,11 @@ let string_preview_field key = function
   | Some _ | None -> []
 ;;
 
+let json_field key = function
+  | Some value -> [ key, value ]
+  | None -> []
+;;
+
 let tool_io_preview_fields ~tool_name ~input ?output () =
   let input_preview = Observability_redact.redact_tool_input ~tool_name input in
   let output_preview =
@@ -42,9 +47,17 @@ let tool_io_preview_fields ~tool_name ~input ?output () =
     | Some output -> Observability_redact.redact_tool_output ~tool_name output
     | None -> None
   in
+  let input_json = Observability_redact.redacted_tool_input_json ~tool_name input in
+  let output_json =
+    match output with
+    | Some output -> Observability_redact.redacted_tool_output_json ~tool_name output
+    | None -> None
+  in
   (if Observability_redact.is_denied_tool ~tool_name
    then [ "tool_io_redacted", `Bool true ]
    else [])
+  @ json_field "tool_args" input_json
+  @ json_field "tool_result" output_json
   @ string_preview_field "tool_args_preview" input_preview
   @ string_preview_field "tool_output_preview" output_preview
 ;;

--- a/lib/keeper/keeper_tools_oas_handler_telemetry.mli
+++ b/lib/keeper/keeper_tools_oas_handler_telemetry.mli
@@ -12,10 +12,10 @@ val keeper_tool_call_event_json
   -> unit
   -> Yojson.Safe.t
 
-(** Redacted, bounded live-preview fields for keeper tool-call SSE payloads.
-    Full I/O remains in [Keeper_tool_call_log]; SSE carries only operator-safe
-    previews so live traces can show immediate context without leaking secrets
-    or large outputs. *)
+(** Redacted, bounded live I/O fields for keeper tool-call SSE payloads.
+    SSE carries structured [tool_args]/[tool_result] plus compatibility
+    previews. Secret-bearing tools omit I/O entirely and set
+    [tool_io_redacted]. *)
 val tool_io_preview_fields
   :  tool_name:string
   -> input:Yojson.Safe.t

--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -93,6 +93,20 @@ let redact_tool_output ~tool_name (output : string) : string option =
   if is_denied_tool ~tool_name then None
   else Some (redact_preview output)
 
+let redacted_tool_input_json ~tool_name input =
+  if is_denied_tool ~tool_name then None
+  else Some (input |> redact_json_value |> preview_json_strings)
+
+let redacted_tool_output_json ~tool_name output =
+  if is_denied_tool ~tool_name then None
+  else
+    let redacted =
+      try Yojson.Safe.from_string output |> redact_json_value |> preview_json_strings
+      with
+      | Yojson.Json_error _ -> `String (redact_preview output)
+    in
+    Some redacted
+
 let build_tool_call_trace_json ?tool_use_id ~tool_name ~input
     ~(output : string option) ~(is_error : bool option) () : Yojson.Safe.t =
   let input_preview = redact_tool_input ~tool_name input in

--- a/lib/observability_redact.mli
+++ b/lib/observability_redact.mli
@@ -35,6 +35,14 @@ val redact_tool_output : tool_name:string -> string -> string option
 (** Produce a redacted preview of tool output text.
     Returns [None] for tools on the deny list. *)
 
+val redacted_tool_input_json : tool_name:string -> Yojson.Safe.t -> Yojson.Safe.t option
+(** Produce a redacted structured copy of tool input JSON.
+    Returns [None] for tools on the deny list. *)
+
+val redacted_tool_output_json : tool_name:string -> string -> Yojson.Safe.t option
+(** Produce a redacted structured copy of tool output when it is JSON,
+    otherwise a redacted string. Returns [None] for tools on the deny list. *)
+
 val build_tool_call_trace_json :
   ?tool_use_id:string ->
   tool_name:string ->

--- a/test/test_keeper_tool_call_sse_io_preview.ml
+++ b/test/test_keeper_tool_call_sse_io_preview.ml
@@ -29,6 +29,8 @@ let test_tool_io_preview_fields_are_redacted () =
   let json = `Assoc fields in
   let args_preview = Option.get (string_member "tool_args_preview" json) in
   let output_preview = Option.get (string_member "tool_output_preview" json) in
+  let tool_args = member "tool_args" json in
+  let tool_result = member "tool_result" json in
   Alcotest.(check bool)
     "sensitive input redacted"
     true
@@ -36,7 +38,19 @@ let test_tool_io_preview_fields_are_redacted () =
   Alcotest.(check bool)
     "sensitive output redacted"
     true
-    (String_util.contains_substring output_preview "[REDACTED]")
+    (String_util.contains_substring output_preview "[REDACTED]");
+  Alcotest.(check string)
+    "structured input keeps safe field"
+    "echo ok"
+    (tool_args |> member "cmd" |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string)
+    "structured input redacts sensitive field"
+    "[REDACTED]"
+    (tool_args |> member "api_key" |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string)
+    "structured output redacts sensitive value"
+    "result token [REDACTED]"
+    (Yojson.Safe.Util.to_string tool_result)
 ;;
 
 let test_denied_tool_omits_io_previews () =
@@ -59,7 +73,15 @@ let test_denied_tool_omits_io_previews () =
   Alcotest.(check bool)
     "output preview omitted"
     true
-    (Option.is_none (string_member "tool_output_preview" json))
+    (Option.is_none (string_member "tool_output_preview" json));
+  Alcotest.(check bool)
+    "structured input omitted"
+    true
+    (member "tool_args" json = `Null);
+  Alcotest.(check bool)
+    "structured output omitted"
+    true
+    (member "tool_result" json = `Null)
 ;;
 
 let () =

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -518,6 +518,10 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
         (sse_payload |> U.member "success" |> U.to_bool);
       check string "sse error text" "command exited 1"
         (sse_payload |> U.member "error_text" |> U.to_string);
+      check string "sse args structured input" "false"
+        (sse_payload |> U.member "tool_args" |> U.member "cmd" |> U.to_string);
+      check string "sse result structured text" "command exited 1"
+        (sse_payload |> U.member "tool_result" |> U.to_string);
       check string "sse args preview includes input" {|{"cmd":"false","session_id":"session-explicit"}|}
         (sse_payload |> U.member "tool_args_preview" |> U.to_string);
       check string "sse output preview includes result" "command exited 1"


### PR DESCRIPTION
## Summary

- Address the report-backed `GOAL-TOOL-01` gap for `keeper_tool_call` SSE payloads.
- Add redacted structured `tool_args` and `tool_result` fields while preserving existing `tool_args_preview` and `tool_output_preview` compatibility fields.
- Keep secret-bearing tool categories redacted: they omit both previews and structured I/O and emit `tool_io_redacted=true`.

## Product impact

Operators no longer have to parse preview strings to inspect live keeper tool I/O in the dashboard trace. Live SSE consumers can now use structured redacted data directly, while existing preview-only clients continue to work.

## Evidence

- `opam exec -- ocamlformat --check lib/observability_redact.ml lib/observability_redact.mli lib/keeper/keeper_tools_oas_handler_telemetry.ml lib/keeper/keeper_tools_oas_handler_telemetry.mli test/test_keeper_tool_call_sse_io_preview.ml test/test_mcp_server_eio_call_tool.ml`
- `git diff --check`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run src/schemas/sse.test.ts src/components/session-trace/session-trace-state.test.ts` (49 tests passed)

## Deferred local evidence

Focused Dune build was attempted but the wrapper refused because other live sessions were running bare Dune outside `scripts/dune-local.sh`:

```text
[dune-local] live Dune process outside scripts/dune-local.sh detected:
[dune-local]   41928 41902 dune build --root .
[dune-local]   17009 16988 dune exec test/test_keeper_tools_oas.exe
[dune-local]   26872 22162 dune build .
[dune-local]   9217 9208 dune build --root .
[dune-local]   79737 79690 dune build
[dune-local] refusing to start another local build while the machine-wide Dune lock is bypassed
```

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/5
provenance: mixed
source_report:
  file: /Users/dancer/Downloads/Kimi_Agent_대시보드검토리스트/masc_oas_통합_분석_보고서.docx
  finding: keeper_tool_call SSE lacked tool input/result visibility
implemented:
  server:
    - lib/observability_redact.ml
    - lib/keeper/keeper_tools_oas_handler_telemetry.ml
  dashboard:
    - dashboard/src/sse.ts
    - dashboard/src/types/sse.ts
  tests:
    - test/test_keeper_tool_call_sse_io_preview.ml
    - test/test_mcp_server_eio_call_tool.ml
    - dashboard/src/schemas/sse.test.ts
verification:
  ocamlformat: passed
  whitespace: passed
  dashboard_tsc: passed
  dashboard_vitest: passed
  dune_focused: blocked_by_existing_bare_dune_processes
```

## Review evidence

- Report item reviewed against current `origin/main`: the old TLA+ missing-directory finding is stale, but the live `keeper_tool_call` SSE contract still only exposed previews.
- This PR keeps redaction centralized in `Observability_redact` and keeps denied tools fully omitted from live I/O payloads.
- Dashboard live trace now prefers structured fields and falls back to existing preview fields for older events.

## Linked issue

- Report-backed local objective: `/Users/dancer/Downloads/Kimi_Agent_대시보드검토리스트/masc_oas_통합_분석_보고서.docx`

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/keeper-tool-call-structured-io-20260526` → `main` · 1 commit(s) · synced 2026-05-26T04:19:46Z

| sha | subject | date |
|---|---|---|
| `24400653e` | fix(dashboard): carry structured keeper tool IO over SSE | 2026-05-26 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->