### PR TITLE
fix(keeper): quiet force-released slot finalizers

### DIFF
--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -45,7 +45,7 @@ let release_recorded_holder
     in
     if force_released
     then
-      Log.Keeper.warn
+      Log.Keeper.debug
         "release_keeper_turn_slot: %s holder for %s was already force-released"
         label_str
         keeper_name

--- a/test/test_keeper_turn_slot_release_cancel_safe.ml
+++ b/test/test_keeper_turn_slot_release_cancel_safe.ml
@@ -128,6 +128,10 @@ let () =
     ~label:"drop_holder metrics exception"
     src
     {|~op:("drop_holder " ^ label) ~kind:"exception"|};
+  assert_contains
+    ~label:"force-release finalizer marker is debug"
+    src
+    "Log.Keeper.debug\n        \"release_keeper_turn_slot: %s holder for %s was already force-released\"";
   (* All three semaphore releases must remain reachable
      (turn / autonomous / reactive). *)
   let count_substring ~needle s =


### PR DESCRIPTION
## Summary
- lower late finalizer force-release marker consumption from WARN to DEBUG
- keep the original stale-watchdog force-release ERROR as the actionable signal
- add a structural regression check so the marker-consumption path stays debug-only

## Evidence
- after #18597 merge, logs showed stale watchdog force-releasing four keepers, then late finalizers emitted repeated WARN rows:
  - release_keeper_turn_slot: turn holder for umberto/qa-king/analyst/verifier was already force-released
  - release_keeper_turn_slot: reactive holder for umberto/qa-king/analyst/verifier was already force-released

## Verification
- ocamlformat --check lib/keeper/keeper_turn_slot.ml test/test_keeper_turn_slot_release_cancel_safe.ml
- ocamlc -stop-after parsing lib/keeper/keeper_turn_slot.ml test/test_keeper_turn_slot_release_cancel_safe.ml
- git diff --check

## Not run
- scripts/dune-local.sh build test/test_keeper_turn_slot_release_cancel_safe.exe test/test_keeper_turn_slot_holders.exe: blocked by live bare Dune processes outside scripts/dune-local.sh (dune exec test/test_keeper_tools_oas.exe, dune build --root ., dune build --root . -j 4)