### PR TITLE
refactor(keeper): drop memory bank path helper from types facade

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_feeds.ml
+++ b/lib/dashboard/dashboard_http_keeper_feeds.ml
@@ -459,7 +459,7 @@ let keeper_memory_log_json
   let all_entries =
     List.concat_map
       (fun (m : Keeper_types.keeper_meta) ->
-        let path = Keeper_types.keeper_memory_bank_path config m.name in
+        let path = Keeper_types_support.keeper_memory_bank_path config m.name in
         if not (Fs_compat.file_exists path)
         then []
         else (

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -431,8 +431,6 @@ val read_meta_if_changed :
 
 (** {1 Selected re-exports from Keeper_types_support} *)
 
-val keeper_memory_bank_path : Coord.config -> string -> string
-
 val keeper_decision_log_path : Coord.config -> string -> string
 
 (** {1 Fiber health (for keeper supervisor)} *)

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -274,7 +274,7 @@ let purge_keeper_artifacts config requested_name
     [
       Keeper_types.keeper_meta_path config keeper_name;
       Keeper_types_support.keeper_metrics_path config keeper_name;
-      Keeper_types.keeper_memory_bank_path config keeper_name;
+      Keeper_types_support.keeper_memory_bank_path config keeper_name;
       Keeper_types_support.keeper_generation_index_path config keeper_name;
       Keeper_types_support.keeper_policy_log_path config keeper_name;
       Keeper_types.keeper_decision_log_path config keeper_name;

--- a/test/test_dashboard_k2_feeds.ml
+++ b/test/test_dashboard_k2_feeds.ml
@@ -282,7 +282,7 @@ let test_memory_log_ids_distinguish_same_timestamp_rows () =
   with_config
   @@ fun config ->
   let meta = keeper_meta "k2-memory" in
-  let path = Keeper_types.keeper_memory_bank_path config meta.name in
+  let path = Keeper_types_support.keeper_memory_bank_path config meta.name in
   append_jsonl path (memory_row ~ts:2_000.0 "Ship K2 memory feed row alpha");
   append_jsonl path (memory_row ~ts:2_000.0 "Ship K2 memory feed row beta");
   let json = Dash.keeper_memory_log_json ~config ~keepers:[ meta ] ~limit:999 () in
@@ -299,7 +299,7 @@ let test_memory_log_kind_mapping () =
   with_config
   @@ fun config ->
   let meta = keeper_meta "k2-memory-kind" in
-  let path = Keeper_types.keeper_memory_bank_path config meta.name in
+  let path = Keeper_types_support.keeper_memory_bank_path config meta.name in
   (* progress -> episode *)
   append_jsonl
     path

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -572,7 +572,9 @@ let test_read_memory_horizon_counts_result_error_on_directory_path () =
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
     let config = make_test_room_config dir in
-    let memory_path = Keeper_types.keeper_memory_bank_path config "bad-keeper" in
+    let memory_path =
+      Keeper_types_support.keeper_memory_bank_path config "bad-keeper"
+    in
     (* Pre-create the parent directory structure, then a *directory*
        (not a file) at the memory.jsonl path. *)
     let parent = Filename.dirname memory_path in
@@ -594,7 +596,9 @@ let test_read_recent_memory_texts_result_error_on_directory_path () =
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
     let config = make_test_room_config dir in
-    let memory_path = Keeper_types.keeper_memory_bank_path config "bad-keeper" in
+    let memory_path =
+      Keeper_types_support.keeper_memory_bank_path config "bad-keeper"
+    in
     let parent = Filename.dirname memory_path in
     (try Unix.mkdir parent 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
     Unix.mkdir memory_path 0o755;
@@ -694,7 +698,7 @@ let test_memory_write_then_recall_meta_fallback () =
     check bool "recall finds fallback notes" true (summary.total_notes > 0))
 
 let read_memory_bank_entries config name =
-  let path = Keeper_types.keeper_memory_bank_path config name in
+  let path = Keeper_types_support.keeper_memory_bank_path config name in
   if not (Sys.file_exists path) then []
   else
     let ic = open_in path in
@@ -881,7 +885,9 @@ let test_keeper_context_status_reports_recovery_source_and_tiers () =
      with
      | Ok () -> ()
      | Error err -> fail ("failed to seed progress log: " ^ err));
-    let bank_path = Keeper_types.keeper_memory_bank_path config "status-keeper" in
+    let bank_path =
+      Keeper_types_support.keeper_memory_bank_path config "status-keeper"
+    in
     (match
        Fs_compat.save_file_atomic bank_path
          (Yojson.Safe.to_string
@@ -1127,7 +1133,7 @@ let test_memory_search_prev_generation () =
 
 (** Helper: write memory bank JSONL lines for a keeper. *)
 let write_memory_bank config name lines =
-  let path = Keeper_types.keeper_memory_bank_path config name in
+  let path = Keeper_types_support.keeper_memory_bank_path config name in
   write_lines path lines
 
 let persistence_read_drop_total ~surface ~reason =
@@ -1829,7 +1835,7 @@ let test_compaction_records_consolidation_metrics () =
     let keeper = "metric-memory-keeper" in
     let config = make_test_room_config dir in
     let meta = keeper_meta ~name:keeper ~mention_targets:[keeper] () in
-    let bank_path = Keeper_types.keeper_memory_bank_path config keeper in
+    let bank_path = Keeper_types_support.keeper_memory_bank_path config keeper in
     let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname bank_path) in
     let progress_rows =
       List.init 3 (fun i ->
@@ -1940,7 +1946,7 @@ let test_compaction_runs_on_note_pressure_under_byte_trigger () =
     let keeper = "note-pressure-memory-keeper" in
     let config = make_test_room_config dir in
     let meta = keeper_meta ~name:keeper ~mention_targets:[ keeper ] () in
-    let bank_path = Keeper_types.keeper_memory_bank_path config keeper in
+    let bank_path = Keeper_types_support.keeper_memory_bank_path config keeper in
     let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname bank_path) in
     let target_notes = Keeper_memory_bank.memory_compaction_target_notes () in
     let rows =


### PR DESCRIPTION
Summary:
- Remove keeper_memory_bank_path from the Keeper_types selected support facade.
- Route memory-bank path callers directly to Keeper_types_support, the owner module.
- Continues the P1 Keeper_types facade cleanup from docs/audit/2026-05-25-legacy-purge-plan.html.

Verification:
- git diff --check
- opam exec -- ocamlformat --check lib/keeper/keeper_types.mli lib/server/server_dashboard_http_delete_actions.ml lib/dashboard/dashboard_http_keeper_feeds.ml test/test_keeper_memory.ml test/test_dashboard_k2_feeds.ml
- opam exec -- ocamlc -stop-after parsing lib/keeper/keeper_types.mli
- opam exec -- ocamlc -stop-after parsing lib/server/server_dashboard_http_delete_actions.ml
- opam exec -- ocamlc -stop-after parsing lib/dashboard/dashboard_http_keeper_feeds.ml
- opam exec -- ocamlc -stop-after parsing test/test_keeper_memory.ml
- opam exec -- ocamlc -stop-after parsing test/test_dashboard_k2_feeds.ml
- rg -n "Keeper_types\.keeper_memory_bank_path" lib test # no matches
- rg -n "val keeper_memory_bank_path" lib/keeper/keeper_types.mli lib/keeper/keeper_types_support.mli # only Keeper_types_support.mli remains

Not run:
- scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_keeper_memory.exe test/test_dashboard_k2_feeds.exe returned 75 because live bare Dune processes were already bypassing the machine-wide Dune lock; not bypassed.