### PR TITLE
fix(keeper): expose deterministic classification source

### DIFF
--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -15,6 +15,26 @@ type deterministic_reason =
   | Git_ref_precondition_failed
   | Git_command_usage_error
 
+type classification_source =
+  | Deterministic_retry_marker
+  | Workflow_rejection_marker
+  | Path_check_marker
+  | Legacy_error_code
+  | Git_exit_128
+
+type classification =
+  { reason : deterministic_reason
+  ; source : classification_source
+  }
+
+let classification_source_to_string = function
+  | Deterministic_retry_marker -> "deterministic_retry_marker"
+  | Workflow_rejection_marker -> "workflow_rejection_marker"
+  | Path_check_marker -> "path_check_marker"
+  | Legacy_error_code -> "legacy_error_code"
+  | Git_exit_128 -> "git_exit_128"
+;;
+
 let to_telemetry_key = function
   | Command_blocked -> "deterministic_error_command_blocked"
   | Command_shape_blocked -> "deterministic_error_command_shape_blocked"
@@ -261,28 +281,44 @@ let classify_path_check json =
      | None -> None)
 ;;
 
-let classify (json : Yojson.Safe.t) : deterministic_reason option =
+let classify_with_source (json : Yojson.Safe.t) : classification option =
   (* Precedence: explicit deterministic_retry > workflow_rejection >
      path_check > error_code.
      Workflow rejection is the most specific (already routed to a
      dedicated counter in [Keeper_tools_oas]). Path checks have their
-     own typed surface. Generic [error] codes are the catch-up layer. *)
+     own typed surface. Generic [error] codes are the legacy catch-up
+     layer and stay visible through [classification_source]. *)
   match classify_deterministic_retry json with
-  | Some _ as v -> v
+  | Some reason -> Some { reason; source = Deterministic_retry_marker }
   | None ->
     (match classify_workflow_rejection json with
-     | Some _ as v -> v
+     | Some reason -> Some { reason; source = Workflow_rejection_marker }
      | None ->
        (match classify_path_check json with
-        | Some _ as v -> v
+        | Some reason -> Some { reason; source = Path_check_marker }
         | None ->
           (match classify_error_code json with
-           | Some _ as v -> v
-           | None -> classify_git_exit_128 json)))
+           | Some reason -> Some { reason; source = Legacy_error_code }
+           | None ->
+             (match classify_git_exit_128 json with
+              | Some reason -> Some { reason; source = Git_exit_128 }
+              | None -> None))))
+;;
+
+let classify (json : Yojson.Safe.t) : deterministic_reason option =
+  match classify_with_source json with
+  | Some classification -> Some classification.reason
+  | None -> None
 ;;
 
 let classify_raw (raw : string) : deterministic_reason option =
   match Yojson.Safe.from_string raw with
   | exception Yojson.Json_error _ -> None
   | json -> classify json
+;;
+
+let classify_raw_with_source (raw : string) : classification option =
+  match Yojson.Safe.from_string raw with
+  | exception Yojson.Json_error _ -> None
+  | json -> classify_with_source json
 ;;

--- a/lib/keeper/keeper_tool_deterministic_error.mli
+++ b/lib/keeper/keeper_tool_deterministic_error.mli
@@ -59,6 +59,23 @@ type deterministic_reason =
       (** git command-line usage is invalid, for example an unsupported
           flag. Retrying the same command cannot succeed. *)
 
+type classification_source =
+  | Deterministic_retry_marker
+      (** Producer emitted the explicit [deterministic_retry] contract. *)
+  | Workflow_rejection_marker
+      (** Workflow rejection carried deterministic/unrecoverable typed fields. *)
+  | Path_check_marker
+      (** Path-check surface carried a closed typed reason. *)
+  | Legacy_error_code
+      (** Legacy [error] code fallback. Kept visible so it can be retired. *)
+  | Git_exit_128
+      (** Git command/output fallback for exit-128 precondition failures. *)
+
+type classification =
+  { reason : deterministic_reason
+  ; source : classification_source
+  }
+
 (** Classify a raw tool-result JSON payload (as returned by
     [Keeper_exec_tools]) into a [deterministic_reason] when the
     error field matches a known closed set of policy/shape block
@@ -71,6 +88,8 @@ type deterministic_reason =
     no [_ ->] catch-all that admits new prefixes silently. *)
 val classify : Yojson.Safe.t -> deterministic_reason option
 
+val classify_with_source : Yojson.Safe.t -> classification option
+
 (** Structured marker for tool producers that already know the same
     arguments cannot succeed. The classifier only accepts this marker
     when [retry_same_args=false] is present, so producers must state
@@ -82,9 +101,13 @@ val deterministic_retry_fields : deterministic_reason -> (string * Yojson.Safe.t
     [None] when [raw] is not valid JSON. *)
 val classify_raw : string -> deterministic_reason option
 
+val classify_raw_with_source : string -> classification option
+
 (** Stable lowercase identifier used for telemetry / log labels.
     Format: [deterministic_error_<reason>]. *)
 val to_telemetry_key : deterministic_reason -> string
+
+val classification_source_to_string : classification_source -> string
 
 (** Human-readable summary suitable for short error log lines. *)
 val to_string : deterministic_reason -> string

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -66,8 +66,14 @@ let execute_with_observers
          1/3 -> 2/3 -> 3/3 retry loop short-circuits at the first
          attempt. Transient errors and shell exit-nonzero results
          are intentionally outside this surface (None branch). *)
+      let deterministic_classification =
+        Keeper_tool_deterministic_error.classify_raw_with_source raw_result
+      in
       let deterministic_reason =
-        Keeper_tool_deterministic_error.classify_raw raw_result
+        Option.map
+          (fun (classification : Keeper_tool_deterministic_error.classification) ->
+             classification.reason)
+          deterministic_classification
       in
       let workflow_rejection_recovery_fields =
         if is_workflow_rejection
@@ -107,6 +113,15 @@ let execute_with_observers
             , `String
                 (Keeper_tool_deterministic_error.to_string reason) )
           ]
+          @
+          (match deterministic_classification with
+           | Some classification ->
+             [ ( "retry_skipped_source"
+               , `String
+                   (Keeper_tool_deterministic_error.classification_source_to_string
+                      classification.source) )
+             ]
+           | None -> [])
           @ deterministic_recovery_plan_fields raw_result
       in
       let recovery_fields =
@@ -286,6 +301,15 @@ let execute_with_observers
             , `String
                 (Keeper_tool_deterministic_error.to_telemetry_key reason) )
           ]
+          @
+          (match deterministic_classification with
+           | Some classification ->
+             [ ( "retry_skipped_source"
+               , `String
+                   (Keeper_tool_deterministic_error.classification_source_to_string
+                      classification.source) )
+             ]
+           | None -> [])
       in
       append_tool_exec_decision_log
         ~config

--- a/test/test_keeper_bash_retry_deterministic_close.ml
+++ b/test/test_keeper_bash_retry_deterministic_close.ml
@@ -16,12 +16,27 @@ let reason_testable =
   Alcotest.testable pp ( = )
 ;;
 
+let source_testable =
+  let pp ppf source =
+    Format.pp_print_string ppf (D.classification_source_to_string source)
+  in
+  Alcotest.testable pp ( = )
+;;
+
 let check_classify ~name ~expected raw =
   Alcotest.check
     Alcotest.(option reason_testable)
     name
     expected
     (D.classify_raw raw)
+;;
+
+let check_classify_source ~name ~expected_reason ~expected_source raw =
+  match D.classify_raw_with_source raw with
+  | None -> Alcotest.fail (name ^ ": expected classified deterministic result")
+  | Some classification ->
+    Alcotest.check reason_testable (name ^ ": reason") expected_reason classification.reason;
+    Alcotest.check source_testable (name ^ ": source") expected_source classification.source
 ;;
 
 (* ── Deterministic — error code path ──────────────────────────── *)
@@ -122,6 +137,31 @@ let test_typed_deterministic_retry_marker_takes_precedence () =
   check_classify
     ~name:"typed deterministic retry marker"
     ~expected:(Some D.Write_operation_gated)
+    raw
+;;
+
+let test_typed_deterministic_retry_marker_reports_source () =
+  let raw =
+    Yojson.Safe.to_string
+      (`Assoc
+          ([ "ok", `Bool false; "error", `String "timeout" ]
+           @ D.deterministic_retry_fields D.Write_operation_gated))
+  in
+  check_classify_source
+    ~name:"typed deterministic retry marker source"
+    ~expected_reason:D.Write_operation_gated
+    ~expected_source:D.Deterministic_retry_marker
+    raw
+;;
+
+let test_legacy_error_code_reports_source () =
+  let raw =
+    {|{"ok":false,"error":"command_blocked","reason":"Shell injection syntax blocked"}|}
+  in
+  check_classify_source
+    ~name:"legacy error code source"
+    ~expected_reason:D.Command_blocked
+    ~expected_source:D.Legacy_error_code
     raw
 ;;
 
@@ -354,6 +394,14 @@ let () =
             "typed_deterministic_retry_marker"
             `Quick
             test_typed_deterministic_retry_marker_takes_precedence
+        ; Alcotest.test_case
+            "typed_deterministic_retry_marker_reports_source"
+            `Quick
+            test_typed_deterministic_retry_marker_reports_source
+        ; Alcotest.test_case
+            "legacy_error_code_reports_source"
+            `Quick
+            test_legacy_error_code_reports_source
         ; Alcotest.test_case
             "unknown_typed_deterministic_retry_marker_observes"
             `Quick


### PR DESCRIPTION
## Summary
- add typed deterministic classification source metadata
- expose whether a skip came from deterministic_retry, workflow rejection, path check, legacy error code, or git exit fallback
- include retry_skipped_source in normalized error fields and decision logs so legacy string fallbacks are measurable retirement targets

## Verification
- ocamlformat --check lib/keeper/keeper_tool_deterministic_error.ml lib/keeper/keeper_tool_deterministic_error.mli lib/keeper/keeper_tools_oas_handler_exec.ml test/test_keeper_bash_retry_deterministic_close.ml
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_keeper_bash_retry_deterministic_close.exe test/test_keeper_tools_oas.exe (blocked: live bare dune processes outside scripts/dune-local.sh)