### PR TITLE
[codex] Fix keeper exec tools syntax

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -572,7 +572,7 @@ let execute_keeper_tool_call_with_outcome
                 ; "hint", `String "Call one of these tools with the correct parameters."
                 ]
             in
-            make_executed_tool_result (Yojson.Safe.to_string (`Assoc fields)))))
+            make_executed_tool_result (Yojson.Safe.to_string (`Assoc fields))))
        ))
 ;;
 


### PR DESCRIPTION
## Summary

- fix the extra closing parenthesis in `keeper_exec_tools.ml`
- restore parsing for the keeper tool dispatch fallback path

## Root Cause

`execute_keeper_tool_call_with_outcome` had one extra `)` after the unknown-tool fallback result, which made `dune build .` fail on `lib/keeper/keeper_exec_tools.ml:576`.

## Validation

- `git diff --check origin/main...HEAD`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/keeper/keeper_exec_tools.ml` passed before the final rebase
- Re-run of the same focused Dune command after final rebase was blocked by another long-running wrapper lock on `/tmp/me-dune-local.lock`
- `dune build .` was attempted, but also remained blocked behind the same unrelated Dune lock and was stopped
