### PR TITLE
refactor(keeper): move response helpers out of disclosure

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -649,7 +649,7 @@ let compute_judgments
       let prompt = prompt_for_facts factual_json in
       Keeper_turn_driver_wrappers.run_named_with_masc_tools ~cascade_name
         ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
-        ~accept:Keeper_tool_disclosure.response_has_text_or_tool_progress
+        ~accept:Keeper_tool_response.response_has_text_or_tool_progress
         ~approval:Approval_callbacks.auto_approve
         ()
     )

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -231,7 +231,7 @@ let compute_judgments
       ~caller:Env_config_oas_bridge.Operator_judge (fun () ->
       Keeper_turn_driver_wrappers.run_named_with_masc_tools ~cascade_name
         ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
-        ~accept:Keeper_tool_disclosure.response_has_text_or_tool_progress
+        ~accept:Keeper_tool_response.response_has_text_or_tool_progress
         ~approval:Approval_callbacks.auto_approve
         ()
     )

--- a/lib/dune
+++ b/lib/dune
@@ -192,6 +192,7 @@
   keeper_post_turn
   keeper_tool_progress
   keeper_tool_observation
+  keeper_tool_response
   keeper_tool_disclosure
   keeper_tool_capability_axis
   keeper_turn_telemetry

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -667,7 +667,7 @@ let run_turn
                     ?max_cost_usd
                     ?wait_timeout_sec:admission_wait_timeout_sec
                     ~accept:
-                      Keeper_tool_disclosure.response_has_text_or_tool_progress
+                      Keeper_tool_response.response_has_text_or_tool_progress
                     ?guardrails
                     ?on_event
                     ?on_yield
@@ -935,7 +935,7 @@ let run_turn
                    | Error e -> Error e
                    | Ok (`Provider_text text) ->
                      (match
-                        Keeper_tool_disclosure.normalize_response_text
+                        Keeper_tool_response.normalize_response_text
                           ~text
                           ~tool_names:actual_keeper_tool_names
                           ()

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -1,41 +1,8 @@
-(** Keeper_tool_disclosure - tool selection and response normalization.
+(** Keeper_tool_disclosure - tool selection and query filtering.
 
     Extracted from keeper_agent_run.ml as part of #5732 god-module split.
-    Contains helpers for response validation, query text extraction, and tool
-    selection boundary merging. *)
-
-let normalize_response_text ~(text : string) ~(tool_names : string list) ()
-  : (string, string) result
-  =
-  let trimmed = String.trim text in
-  if trimmed <> ""
-  then Ok text
-  else (
-    match tool_names with
-    | [] -> Error "keeper turn completed with no textual reply"
-    | _ ->
-      Ok
-        (Printf.sprintf
-           "Completed without a textual reply. Tools used: %s."
-           (String.concat ", " tool_names)))
-;;
-
-let response_has_text_or_tool_progress (response : Agent_sdk.Types.api_response) =
-  let text = Agent_sdk.Types.text_of_content response.content |> String.trim in
-  text <> ""
-  || List.exists
-       (function
-         | Agent_sdk.Types.ToolUse _ -> true
-         | Agent_sdk.Types.Text _
-         | Agent_sdk.Types.Thinking _
-         | Agent_sdk.Types.RedactedThinking _
-         | Agent_sdk.Types.ToolResult _
-         | Agent_sdk.Types.Image _
-         | Agent_sdk.Types.Document _
-         | Agent_sdk.Types.Audio _ -> false)
-       response.content
-  || response.stop_reason <> Agent_sdk.Types.EndTurn
-;;
+    Contains helpers for query text extraction and tool selection boundary
+    merging. *)
 
 let tool_query_text_of_user_message (text : string) : string =
   let allowed_sections =

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -1,23 +1,8 @@
-(** Keeper_tool_disclosure - tool selection and response normalization.
+(** Keeper_tool_disclosure - tool selection and query filtering.
 
     Extracted from keeper_agent_run.ml as part of #5732 god-module
-    split. Helpers for response validation, query text extraction, and tool
-    selection boundary merging. *)
-
-(** Keep [text] when non-blank; otherwise synthesize a
-    "Completed without a textual reply. Tools used: ..." line if
-    [tool_names] is non-empty, else error. *)
-val normalize_response_text
-  :  text:string
-  -> tool_names:string list
-  -> unit
-  -> (string, string) result
-
-(** [true] when a provider response carries usable keeper progress for
-    cascade accept/reject: non-blank text, ToolUse, or a non-terminal
-    stop reason. Empty [end_turn] responses are rejected so cascade can
-    try the next candidate instead of failing later as "no textual reply". *)
-val response_has_text_or_tool_progress : Agent_sdk.Types.api_response -> bool
+    split. Helpers for query text extraction and tool selection boundary
+    merging. *)
 
 (** Project a user-message text to the BM25 query text by keeping
     only the world-state header and a curated set of subsections. *)

--- a/lib/keeper/keeper_tool_response.ml
+++ b/lib/keeper/keeper_tool_response.ml
@@ -1,0 +1,35 @@
+(** Keeper_tool_response - provider response acceptance and keeper reply text
+    normalization. *)
+
+let normalize_response_text ~(text : string) ~(tool_names : string list) ()
+  : (string, string) result
+  =
+  let trimmed = String.trim text in
+  if trimmed <> ""
+  then Ok text
+  else (
+    match tool_names with
+    | [] -> Error "keeper turn completed with no textual reply"
+    | _ ->
+      Ok
+        (Printf.sprintf
+           "Completed without a textual reply. Tools used: %s."
+           (String.concat ", " tool_names)))
+;;
+
+let response_has_text_or_tool_progress (response : Agent_sdk.Types.api_response) =
+  let text = Agent_sdk.Types.text_of_content response.content |> String.trim in
+  text <> ""
+  || List.exists
+       (function
+         | Agent_sdk.Types.ToolUse _ -> true
+         | Agent_sdk.Types.Text _
+         | Agent_sdk.Types.Thinking _
+         | Agent_sdk.Types.RedactedThinking _
+         | Agent_sdk.Types.ToolResult _
+         | Agent_sdk.Types.Image _
+         | Agent_sdk.Types.Document _
+         | Agent_sdk.Types.Audio _ -> false)
+       response.content
+  || response.stop_reason <> Agent_sdk.Types.EndTurn
+;;

--- a/lib/keeper/keeper_tool_response.mli
+++ b/lib/keeper/keeper_tool_response.mli
@@ -1,0 +1,17 @@
+(** Keeper_tool_response - provider response acceptance and keeper reply text
+    normalization. *)
+
+(** Keep [text] when non-blank; otherwise synthesize a
+    "Completed without a textual reply. Tools used: ..." line if [tool_names]
+    is non-empty, else error. *)
+val normalize_response_text
+  :  text:string
+  -> tool_names:string list
+  -> unit
+  -> (string, string) result
+
+(** [true] when a provider response carries usable keeper progress for cascade
+    accept/reject: non-blank text, ToolUse, or a non-terminal stop reason.
+    Empty [end_turn] responses are rejected so cascade can try the next
+    candidate instead of failing later as "no textual reply". *)
+val response_has_text_or_tool_progress : Agent_sdk.Types.api_response -> bool

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -400,7 +400,7 @@ let apply_output_to_result ~(meta : keeper_meta)
   | _ ->
       let response_text =
         match
-          Keeper_tool_disclosure.normalize_response_text
+          Keeper_tool_response.normalize_response_text
             ~text:visible_response_body
             ~tool_names:result.tools_used ()
         with

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -12,6 +12,7 @@ module KRun = Masc_mcp.Keeper_turn_driver
 module KCC = Masc_mcp.Keeper_contract_classifier
 module KTCL = Masc_mcp.Keeper_tool_call_log
 module KTD = Masc_mcp.Keeper_tool_disclosure
+module KTR = Masc_mcp.Keeper_tool_response
 module KEC = Masc_mcp.Keeper_exec_context
 module KSM = Masc_mcp.Keeper_social_model
 module KP = Masc_mcp.Keeper_state_machine
@@ -8826,14 +8827,14 @@ let test_metrics_mixed_response () =
 ;;
 
 let test_normalize_response_text_passthrough () =
-  match KTD.normalize_response_text ~text:"All good." ~tool_names:[] () with
+  match KTR.normalize_response_text ~text:"All good." ~tool_names:[] () with
   | Ok text -> check string "keeps text" "All good." text
   | Error e -> fail ("unexpected error: " ^ e)
 ;;
 
 let test_normalize_response_text_tool_only_synthesizes () =
   match
-    KTD.normalize_response_text
+    KTR.normalize_response_text
       ~text:""
       ~tool_names:[ "keeper_board_post"; "keeper_board_comment" ]
       ()
@@ -8860,7 +8861,7 @@ let test_normalize_response_text_tool_only_synthesizes () =
 ;;
 
 let test_normalize_response_text_empty_without_tools_errors () =
-  match KTD.normalize_response_text ~text:"" ~tool_names:[] () with
+  match KTR.normalize_response_text ~text:"" ~tool_names:[] () with
   | Ok text -> fail ("expected error, got: " ^ text)
   | Error e ->
     check
@@ -8892,7 +8893,7 @@ let test_response_has_text_or_tool_progress_rejects_empty_end_turn () =
     bool
     "empty end_turn rejected"
     false
-    (KTD.response_has_text_or_tool_progress (response []))
+    (KTR.response_has_text_or_tool_progress (response []))
 ;;
 
 let test_response_has_text_or_tool_progress_accepts_text () =
@@ -8900,7 +8901,7 @@ let test_response_has_text_or_tool_progress_accepts_text () =
     bool
     "text accepted"
     true
-    (KTD.response_has_text_or_tool_progress
+    (KTR.response_has_text_or_tool_progress
        (response [ Agent_sdk.Types.Text "ok" ]))
 ;;
 
@@ -8909,7 +8910,7 @@ let test_response_has_text_or_tool_progress_accepts_tool_use () =
     bool
     "tool use accepted"
     true
-    (KTD.response_has_text_or_tool_progress
+    (KTR.response_has_text_or_tool_progress
        (response
           [ Agent_sdk.Types.ToolUse
               { id = "call-1"; name = "tool_execute"; input = `Assoc [] }

--- a/test/test_keeper_unified_inline_skip.ml
+++ b/test/test_keeper_unified_inline_skip.ml
@@ -1,7 +1,7 @@
 open Alcotest
 
 module KG = Masc_mcp.Keeper_guards
-module KTD = Masc_mcp.Keeper_tool_disclosure
+module KTR = Masc_mcp.Keeper_tool_response
 
 let str_contains s sub =
   try
@@ -75,7 +75,7 @@ let test_normalize_override_passthrough () =
      reason=tool%20is%20on%20the%20keeper%20deny%20list"
   in
   match
-    KTD.normalize_response_text ~text:override_text ~tool_names:[ "tool_execute" ] ()
+    KTR.normalize_response_text ~text:override_text ~tool_names:[ "tool_execute" ] ()
   with
   | Ok text -> check string "passes through" override_text text
   | Error e -> fail ("unexpected error: " ^ e)


### PR DESCRIPTION
## Summary
- add Keeper_tool_response as the owner for response normalization and response progress acceptance
- remove response helper exports from Keeper_tool_disclosure so disclosure only owns query/filter/selection helpers
- repoint keeper run, dashboard judges, BDI speech, and response tests to the new module

## Validation
- ocamlformat --check on touched OCaml files
- git diff --check origin/main..HEAD
- rg residue: no Keeper_tool_disclosure response/observation helper calls
- rg legacy file scan: no keeper_tool_pr_review/bin.ml legacy files under lib/test/docs/specs
- focused Dune blocked locally by external bare Dune processes; scripts/dune-local.sh exited 75 before starting