### PR TITLE
fix(keeper): throttle self-preservation warning cadence

### DIFF
--- a/lib/keeper/keeper_supervisor_self_preservation.ml
+++ b/lib/keeper/keeper_supervisor_self_preservation.ml
@@ -18,6 +18,10 @@ let probe_after_n_suppressions = 10
    the circuit breaker/probe path. *)
 let partial_stale_recovery_max_ratio = 0.50
 
+let should_warn_partial_suppression_streak ~streak =
+  streak = 1 || streak = probe_after_n_suppressions - 1
+;;
+
 let reset_for_test () =
   escape_state.last_dominant_cohort <- "";
   escape_state.consecutive_suppressions <- 0
@@ -94,7 +98,10 @@ let log_suppression ~ratio ~n_total ~dominant_key ~suppressed_count =
       dominant_key
       escape_state.consecutive_suppressions
       probe_after_n_suppressions)
-  else
+  else if
+    should_warn_partial_suppression_streak
+      ~streak:escape_state.consecutive_suppressions
+  then
     Log.Keeper.warn
       "self-preservation: suppressing %d/%d restarts (ratio=%.2f, cohort=%s, \
        streak=%d)"
@@ -103,7 +110,22 @@ let log_suppression ~ratio ~n_total ~dominant_key ~suppressed_count =
       ratio
       dominant_key
       escape_state.consecutive_suppressions
+  else
+    Log.Keeper.debug
+      "self-preservation: suppressing %d/%d restarts (ratio=%.2f, cohort=%s, \
+       streak=%d)"
+      suppressed_count
+      n_total
+      ratio
+      dominant_key
+      escape_state.consecutive_suppressions
 ;;
+
+module For_testing = struct
+  let should_warn_partial_suppression_streak =
+    should_warn_partial_suppression_streak
+  ;;
+end
 
 let apply ~keepers_dir ~publish_lifecycle ~total_keepers to_restart =
   let sp_ratio = Env_config.KeeperSupervisor.self_preservation_ratio in

--- a/lib/keeper/keeper_supervisor_self_preservation.mli
+++ b/lib/keeper/keeper_supervisor_self_preservation.mli
@@ -2,6 +2,10 @@
 
 val reset_for_test : unit -> unit
 
+module For_testing : sig
+  val should_warn_partial_suppression_streak : streak:int -> bool
+end
+
 val apply
   :  keepers_dir:string
   -> publish_lifecycle:

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -13,6 +13,7 @@ module KLH = Masc_mcp.Keeper_lifecycle_hooks
 module FD = Masc_mcp.Keeper_fd_pressure
 module KA = Masc_mcp.Keeper_keepalive
 module KFP = Masc_mcp.Keeper_failure_policy
+module KSP = Masc_mcp.Keeper_supervisor_self_preservation
 
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_supervisor_" "" in
@@ -634,6 +635,15 @@ let test_self_preservation_suppresses_universal_stale_recovery () =
   check int "universal stale cohort suppressed" 0 (List.length result);
   Sup.reset_self_preservation_escape_state_for_test ();
   Reg.clear ()
+
+let test_self_preservation_partial_suppression_warn_cadence () =
+  let should_warn streak =
+    KSP.For_testing.should_warn_partial_suppression_streak ~streak
+  in
+  check bool "first partial suppression warns" true (should_warn 1);
+  check bool "middle partial suppression is debug" false (should_warn 2);
+  check bool "pre-probe partial suppression warns" true (should_warn 9);
+  check bool "probe path logs separately" false (should_warn 10)
 
 (* ── Runtime override: fiber_health_of ─────────────────── *)
 
@@ -2015,6 +2025,8 @@ let () =
         test_self_preservation_suppresses_large_partial_stale_recovery;
       test_case "universal stale recovery cohort suppressed" `Quick
         test_self_preservation_suppresses_universal_stale_recovery;
+      test_case "partial suppression warns on cadence" `Quick
+        test_self_preservation_partial_suppression_warn_cadence;
     ];
     "runtime_override", [
       test_case "fiber_health_of respects max_restarts override" `Quick


### PR DESCRIPTION
## Summary
- Warn only on the first partial self-preservation suppression and the pre-probe cadence; repeated middle streaks are debug-level.
- Preserve universal suppression ERRORs, probe WARNs, lifecycle events, and crash-persistence events.
- Add a focused cadence regression test.

## Verification
- `ocamlformat --check lib/keeper/keeper_supervisor_self_preservation.ml lib/keeper/keeper_supervisor_self_preservation.mli test/test_keeper_supervisor.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_supervisor_self_preservation.mli lib/keeper/keeper_supervisor_self_preservation.ml test/test_keeper_supervisor.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_supervisor.exe` blocked locally because live bare Dune processes were already running (`dune build .`, `dune build --root . -j 4`, `dune exec test/test_keeper_tools_oas.exe`, `dune runtest --root . --force`, `dune build --root .`).