### PR TITLE
[codex] Fix keeper tool policy config syntax

### DIFF
--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -342,6 +342,7 @@ let load ~base_path : (t, string) result =
               Log.Keeper.info "tool_policy_config: loaded %d groups, %d masc_groups, %d presets from %s"
                 (Hashtbl.length groups) (Hashtbl.length masc_groups) (Hashtbl.length presets) path;
               Ok { groups; masc_groups; presets; gh_cache; git_clone })
+        )
 
 (* ── Resolution ───────────────────────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary

- close the `match all_errors` block in `keeper_tool_policy_config.ml`
- restore parsing past `resolve_group_source`

## Root Cause

`load` opened `(match all_errors with ...)` and then nested another `(match fatal_tool_errors with ...)`, but only the inner match was closed before the next top-level `let`. That made `dune build .` fail with `Syntax error: ) expected` at `resolve_group_source`.

## Validation

- `git diff --check origin/main...HEAD`
- `ocamlc -dparsetree -impl lib/keeper/keeper_tool_policy_config.ml` parsed through the file; it then failed on expected standalone module resolution (`Unbound module Keeper_toml_loader`)
- Focused Dune target was attempted with `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/keeper/keeper_tool_policy_config.ml`, but remained blocked behind an unrelated long-running `/tmp/me-dune-local.lock` holder and was stopped
