### PR TITLE
refactor(keeper): rename remote mcp tool runtime

### DIFF
--- a/docs/audits/2026-05-11-autoresearch-removal-audit.md
+++ b/docs/audits/2026-05-11-autoresearch-removal-audit.md
@@ -46,7 +46,7 @@
 - `lib/dashboard/dashboard_surface_readiness.ml`: `masc_autoresearch_status` 1 reference
 - `lib/dashboard/dashboard_http_autoresearch.ml(.mli)`: dedicated HTTP routes module (start/stop + GET loops/detail/CSV + POST retry/delete) — module 통째 삭제
 - `lib/keeper/keeper_agent_tool_surface.ml`: 4 도구 label (status/stop/cycle + 1) — 4 라인 제거
-- `lib/keeper/keeper_exec_masc.ml(.mli)`: `handle_keeper_autoresearch_tool` + dispatch arm `Some Tool_dispatch.Mod_autoresearch ->` — module 삭제 + 한 분기 제거
+- `lib/keeper/agent_tool_remote_mcp_runtime.ml(.mli)`: `handle_keeper_autoresearch_tool` + dispatch arm `Some Tool_dispatch.Mod_autoresearch ->` — module 삭제 + 한 분기 제거
 - `lib/keeper/keeper_tool_policy.ml`: `@ Tool_shard.autoresearch_keeper_tools` (line 594) — 한 줄 제거
 - `lib/tool_dispatch.ml(.mli)`: `Mod_autoresearch` closed-variant + 2 dispatch arms (line 208, 248) — variant + 매치 제거
 - `lib/mcp_server_eio_execute.ml`: `| Mod_autoresearch ->` 분기 (line 849) — 매치 제거

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -43,8 +43,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/agent_tool_filesystem_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_ide.ml` - execution-dispatch
 - `lib/keeper/keeper_exec_ide.mli` - execution-dispatch
-- `lib/keeper/keeper_exec_masc.ml` - execution-dispatch
-- `lib/keeper/keeper_exec_masc.mli` - execution-dispatch
+- `lib/keeper/agent_tool_remote_mcp_runtime.ml` - execution-dispatch
+- `lib/keeper/agent_tool_remote_mcp_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_memory.ml` - execution-dispatch
 - `lib/keeper/keeper_exec_memory.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_persona.ml` - execution-dispatch

--- a/docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md
+++ b/docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md
@@ -2,7 +2,7 @@
 status: runbook
 last_verified: 2026-04-17
 code_refs:
-  - lib/keeper/keeper_exec_masc.ml
+  - lib/keeper/agent_tool_remote_mcp_runtime.ml
   - lib/cascade/
   - lib/mcp_server.ml
 ---

--- a/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
+++ b/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
@@ -111,8 +111,8 @@ let dispatch_structured ~(token : Tool_token.t) ~args : Tool_result.t option =
 
 | Caller | Entry | Pre-hook | Post-hook | Capability gate | Trace span |
 |---|---|---|---|---|---|
-| `keeper_exec_masc.ml:164` (keeper turn) | Entry 1 (`dispatch`) | ✗ bypass | ~ if result≠None | ✗ unrestricted¹ | ✗ |
-| `keeper_exec_masc.ml:218` (keeper turn) | Entry 1 (`dispatch`) | ✗ bypass | ~ if result≠None | ✗ | ✗ |
+| `agent_tool_remote_mcp_runtime.ml:164` (keeper turn) | Entry 1 (`dispatch`) | ✗ bypass | ~ if result≠None | ✗ unrestricted¹ | ✗ |
+| `agent_tool_remote_mcp_runtime.ml:218` (keeper turn) | Entry 1 (`dispatch`) | ✗ bypass | ~ if result≠None | ✗ | ✗ |
 | `mcp_server_eio_execute.ml:817` (MCP) | manual `run_pre_hooks` + `dispatch` | ✓ manual | ~ if result≠None | ‖ profile filter² | ✗ |
 | `mcp_server_eio_execute.ml:999` (MCP) | manual `run_pre_hooks` + `dispatch` | ✓ manual | ~ if result≠None | ‖ profile filter² | ✗ |
 | `keeper_tag_dispatch.ml` (fallback) | Entry 3 | ✗ | ? | ✗ | ✗ |
@@ -123,7 +123,7 @@ let dispatch_structured ~(token : Tool_token.t) ~args : Tool_result.t option =
 
 ### §1.2 Telemetry 4-Tuple Emission Gap
 
-`Tracing.with_span`은 oas `lib/agent/agent_tools.ml:161 invoke_hook`에서 hook 호출을 wrap하지만, **masc-mcp `lib/tool_dispatch.ml`이나 `lib/keeper/keeper_exec_masc.ml`에 0건** (verify: `rg -n 'Tracing\.with_span' lib/tool_dispatch.ml lib/keeper/keeper_exec_masc.ml` = 0 매치).
+`Tracing.with_span`은 oas `lib/agent/agent_tools.ml:161 invoke_hook`에서 hook 호출을 wrap하지만, **masc-mcp `lib/tool_dispatch.ml`이나 `lib/keeper/agent_tool_remote_mcp_runtime.ml`에 0건** (verify: `rg -n 'Tracing\.with_span' lib/tool_dispatch.ml lib/keeper/agent_tool_remote_mcp_runtime.ml` = 0 매치).
 
 | Tuple slot | 현재 상태 |
 |---|---|
@@ -376,7 +376,7 @@ RFC-OAS-013 §2.1 v2의 `if meta.name = "imseonghan"` 패턴 거부. 대신 *con
 | PR-4 | parity test: 기존 5 set 모든 admit이 typed Capability로 동일 결과 | single-PR revert |
 | PR-5 | boot warn 540 → 0 측정 | revert + 4-variant 복귀 |
 | PR-6 | **24h shadow mode**: both paths 동시 실행, divergence log. 0 divergence면 PR-7 진행 | single-PR revert |
-| PR-7 | **Pre-hook log-only mode 1 deploy cycle** → enforce. Capability gate advisory mode 처음 24h | `keeper_exec_masc.ml` 2-line revert |
+| PR-7 | **Pre-hook log-only mode 1 deploy cycle** → enforce. Capability gate advisory mode 처음 24h | `agent_tool_remote_mcp_runtime.ml` 2-line revert |
 | PR-8~9 | 동일 path 적용 | single-PR revert |
 | PR-10 | post-hook signature 변경 5 site 일제 (compile-time 강제) | single-PR revert |
 | PR-11 | dead code 제거 (PR-7~10 후) | single-PR revert (cherrry-pick) |
@@ -480,7 +480,7 @@ let () = QCheck.Test.check_exn @@ QCheck.Test.make
 - `lib/keeper/tool_resolution.ml:56-103` — `resolve` 13-source short-circuit
 - `lib/keeper/tool_resolution.ml:81-86, 143-149` — `surfaces_to_check` 4 variants
 - `lib/keeper/keeper_tool_disclosure.ml` (842 lines) — runtime routing
-- `lib/keeper/keeper_exec_masc.ml:164, 218` — keeper turn `dispatch` direct
+- `lib/keeper/agent_tool_remote_mcp_runtime.ml:164, 218` — keeper turn `dispatch` direct
 - `lib/keeper/capability_registry.ml:358-362` — "Internal dispatch unrestricted" 코멘트
 - `lib/mcp_server_eio_execute.ml:817, 999` — manual `run_pre_hooks` + `dispatch`
 - `lib/keeper/keeper_tag_dispatch.ml` — Entry 3 fallback

--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -361,7 +361,7 @@ let public_raw_tool_schemas_from (public_tool_source_schemas : Masc_domain.tool_
    RFC-0084 §1.1 + §2.2 (PR-7) — Internal dispatch now flows through
    [Tool_dispatch.guarded_dispatch] which wraps [dispatch_structured]
    (pre-hook + handler + post-hook) with [Tool_telemetry.with_span].
-   The keeper turn loop in [keeper_exec_masc.ml:164,218] routes through
+   The keeper turn loop in [agent_tool_remote_mcp_runtime.ml:164,218] routes through
    the guarded entry so pre-hook chain ([governance_pipeline:203],
    [tool_input_validation:217]) covers keeper-originated calls.
    PR-8 wires the MCP server; PR-9 wires tag-dispatch fallback.

--- a/lib/dune
+++ b/lib/dune
@@ -147,6 +147,7 @@
    keeper_path_check_error
    keeper_exec_board
    agent_tool_filesystem_runtime
+   agent_tool_remote_mcp_runtime
    keeper_exec_ide
    keeper_sandbox_docker
    keeper_task_worktree_lazy
@@ -164,7 +165,6 @@
    keeper_exec_preflight
    keeper_exec_task
    keeper_exec_voice
-   keeper_exec_masc
    keeper_exec_tools
   keeper_exec_status_metrics
   keeper_exec_status

--- a/lib/keeper/agent_tool_remote_mcp_runtime.ml
+++ b/lib/keeper/agent_tool_remote_mcp_runtime.ml
@@ -1,6 +1,7 @@
 open Keeper_types
 open Keeper_exec_shared
-open Keeper_types
+
+(** Runtime adapter for descriptor-backed Remote_mcp agent tools. *)
 
 (* Read-only masc_code_* tools (search, read, symbols) are path-bearing but
    should NOT go through the strict write resolver. The write resolver
@@ -15,7 +16,7 @@ open Keeper_types
    2026-04-17/18 showed ~240 masc_code_* failures with [path_not_in_
    allowed_paths] that would have resolved under the read walker.
    See memory/handoff-2026-04-18-masc-tool-failure-investigation.md R1. *)
-let keeper_masc_path_blocked
+let masc_path_blocked
       ~(config : Coord.config)
       ~(keeper_name : string)
       ~(name : string)
@@ -57,7 +58,7 @@ let keeper_masc_path_blocked
 
 (* Pipeline lives in [Tool_code_read_core] (SSOT shared with the
    agent-side handler [Tool_code.handle_code_read]). *)
-let handle_keeper_masc_code_read
+let handle_masc_code_read
       ~(config : Coord.config)
       ~(meta : Keeper_types.keeper_meta)
       ~(args : Yojson.Safe.t)
@@ -83,14 +84,14 @@ let handle_keeper_masc_code_read
            (Tool_code_read_core.read_error_to_json err)))
 ;;
 
-let handle_keeper_masc_tool
+let handle_masc_tool
       ~(config : Coord.config)
       ~(keeper_name : string)
       ~(name : string)
       ~(args : Yojson.Safe.t)
   =
   with_registry_meta ~keeper_name ~source_layer:"masc_path_resolver" @@ fun meta ->
-  match keeper_masc_path_blocked ~config ~keeper_name ~name ~args with
+  match masc_path_blocked ~config ~keeper_name ~name ~args with
   | Some err -> error_json err
   | None ->
     (match Tool_dispatch.mint_token ~name with
@@ -103,7 +104,7 @@ let handle_keeper_masc_tool
              ])
      | Ok token ->
        if name = "masc_code_read"
-       then handle_keeper_masc_code_read ~config ~meta ~args
+       then handle_masc_code_read ~config ~meta ~args
        else (
          (* RFC-0084 §1.1 + §2.2 — keeper turn now routes through
             guarded_dispatch so pre-hook chain + telemetry 4-tuple
@@ -171,7 +172,7 @@ let handle_keeper_masc_tool
                      [ "error", `String "unregistered_masc_tool"; "tool", `String name ]))))
 ;;
 
-let handle_registered_keeper_tool
+let handle_registered_remote_tool
       ~(config : Coord.config)
       ~(keeper_name : string)
       ~(name : string)
@@ -196,9 +197,9 @@ let handle_registered_keeper_tool
     begin
       match Tool_dispatch.lookup_tag name with
       | Some _ ->
-        Some (handle_keeper_masc_tool ~config ~keeper_name ~name ~args)
+        Some (handle_masc_tool ~config ~keeper_name ~name ~args)
       | None when Tool_dispatch.is_registered name ->
-        Some (handle_keeper_masc_tool ~config ~keeper_name ~name ~args)
+        Some (handle_masc_tool ~config ~keeper_name ~name ~args)
       | None -> None
     end
 ;;

--- a/lib/keeper/agent_tool_remote_mcp_runtime.mli
+++ b/lib/keeper/agent_tool_remote_mcp_runtime.mli
@@ -1,13 +1,13 @@
-(** Keeper MASC coordination tool handlers. *)
+(** Runtime adapter for descriptor-backed Remote_mcp agent tools. *)
 
-val handle_keeper_masc_tool :
+val handle_masc_tool :
   config:Coord.config ->
   keeper_name:string ->
   name:string ->
   args:Yojson.Safe.t ->
   string
 
-val handle_registered_keeper_tool :
+val handle_registered_remote_tool :
   config:Coord.config ->
   keeper_name:string ->
   name:string ->

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -63,7 +63,7 @@ let handle_remote_mcp ctx descriptor args =
   | Tool_remote_mcp ->
     Some
       (match
-         Keeper_exec_masc.handle_registered_keeper_tool
+         Agent_tool_remote_mcp_runtime.handle_registered_remote_tool
            ~config:ctx.config
            ~keeper_name:ctx.meta.name
            ~name:descriptor.internal_name

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -509,7 +509,11 @@ let execute_keeper_tool_call_with_outcome
            (Keeper_exec_task.handle_keeper_task_tool ~config ~meta ~name ~args)
        | other ->
          (match
-            Keeper_exec_masc.handle_registered_keeper_tool ~config ~keeper_name:meta.name ~name:other ~args
+            Agent_tool_remote_mcp_runtime.handle_registered_remote_tool
+              ~config
+              ~keeper_name:meta.name
+              ~name:other
+              ~args
           with
           | Some raw_output -> make_executed_tool_result raw_output
           | None ->

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -499,7 +499,7 @@ let handle_code_symbols ~tool_name ~start_time ctx args =
 
 (* Handler: masc_code_read - Read file with offset/limit.
    Pipeline lives in [Tool_code_read_core] (SSOT shared with the
-   keeper-side handler [Keeper_exec_masc.handle_keeper_masc_code_read]). *)
+   keeper-side handler [Agent_tool_remote_mcp_runtime.handle_masc_code_read]). *)
 let handle_code_read ~tool_name ~start_time ctx args =
   let path = get_string args "path" "" in
   let offset = get_int args "offset" 0 in

--- a/lib/tool_code_read_core.mli
+++ b/lib/tool_code_read_core.mli
@@ -1,7 +1,7 @@
 (** Tool_code_read_core — SSOT for [masc_code_read] file pagination.
 
     Both the agent-side handler ([Tool_code.handle_code_read]) and the
-    keeper-side handler ([Keeper_exec_masc.handle_keeper_masc_code_read])
+    keeper-side handler ([Agent_tool_remote_mcp_runtime.handle_masc_code_read])
     share the same read-with-pagination pipeline. Previously each
     handler open-coded the same six-step sequence
     (file_exists → binary check → size check → load → split → slice)

--- a/lib/tool_telemetry.mli
+++ b/lib/tool_telemetry.mli
@@ -13,7 +13,7 @@
 
     PR-3 establishes the wrapper skeleton; no callers migrate to
     [Tool_dispatch.guarded_dispatch] in this PR. Migration:
-    - PR-7: keeper turn loop [keeper_exec_masc.ml:164,218]
+    - PR-7: keeper turn loop [agent_tool_remote_mcp_runtime.ml:164,218]
     - PR-8: MCP server [mcp_server_eio_execute.ml:817,999]
     - PR-9: tag-dispatch fallback [keeper_tag_dispatch.ml] *)
 

--- a/test/test_dispatch_telemetry_gap.ml
+++ b/test/test_dispatch_telemetry_gap.ml
@@ -6,7 +6,7 @@ open Alcotest
     Verified at PR-1 author time:
 
     {v
-    rg -n 'Tracing\.with_span' lib/tool_dispatch.ml lib/keeper/keeper_exec_masc.ml
+    rg -n 'Tracing\.with_span' lib/tool_dispatch.ml lib/keeper/agent_tool_remote_mcp_runtime.ml
     # 0 matches
     v}
 

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -722,7 +722,7 @@ let test_registered_tool_dispatch_without_masc_prefix () =
   with_exec_fixture "keeper_exec_registered_dispatch"
     (fun ~config ~meta ~ctx_work:_ ->
       match
-        Masc_mcp.Keeper_exec_masc.handle_registered_keeper_tool
+        Masc_mcp.Agent_tool_remote_mcp_runtime.handle_registered_remote_tool
           ~config
           ~keeper_name:meta.name
           ~name:registered_dispatch_probe_tool
@@ -741,7 +741,7 @@ let test_registered_dispatch_preserves_workflow_failure_class () =
   with_exec_fixture "keeper_exec_registered_workflow_rejection"
     (fun ~config ~meta ~ctx_work:_ ->
       match
-        Masc_mcp.Keeper_exec_masc.handle_registered_keeper_tool
+        Masc_mcp.Agent_tool_remote_mcp_runtime.handle_registered_remote_tool
           ~config
           ~keeper_name:meta.name
           ~name:workflow_rejection_probe_tool

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -632,7 +632,7 @@ let test_approval_pending_bridge_uses_keeper_safe_inline_dispatch () =
       in
       with_registered_keeper ~config meta (fun () ->
           let raw =
-            Masc_mcp.Keeper_exec_masc.handle_keeper_masc_tool
+            Masc_mcp.Agent_tool_remote_mcp_runtime.handle_masc_tool
               ~config
               ~keeper_name:meta.name
               ~name:"masc_approval_pending"
@@ -669,7 +669,7 @@ let test_read_only_preflight_accepts_sandbox_relative_repo_path () =
         in
         with_registered_keeper ~config meta (fun () ->
             let raw =
-              Masc_mcp.Keeper_exec_masc.handle_keeper_masc_tool
+              Masc_mcp.Agent_tool_remote_mcp_runtime.handle_masc_tool
                 ~config
                 ~keeper_name:meta.name
                 ~name:"masc_code_read"
@@ -728,7 +728,7 @@ let test_write_preflight_accepts_docker_container_repo_path () =
         in
         with_registered_keeper ~config meta (fun () ->
           let raw =
-            Masc_mcp.Keeper_exec_masc.handle_keeper_masc_tool
+            Masc_mcp.Agent_tool_remote_mcp_runtime.handle_masc_tool
               ~config
               ~keeper_name:meta.name
               ~name:"masc_code_edit"
@@ -795,7 +795,7 @@ let test_write_preflight_accepts_sandbox_relative_repo_path () =
         in
         ignore (Masc_mcp.Keeper_registry.register ~base_path:dir keeper_name meta);
         let raw =
-          Masc_mcp.Keeper_exec_masc.handle_keeper_masc_tool
+          Masc_mcp.Agent_tool_remote_mcp_runtime.handle_masc_tool
             ~config
             ~keeper_name
             ~name:"masc_code_edit"

--- a/test/test_keeper_prehook_gap.ml
+++ b/test/test_keeper_prehook_gap.ml
@@ -2,7 +2,7 @@ open Alcotest
 
 (** RFC-0084 §1.1 — Keeper Turn Pre-hook (post-PR-7 state)
 
-    PR-7 switched [lib/keeper/keeper_exec_masc.ml:164,218] from
+    PR-7 switched [lib/keeper/agent_tool_remote_mcp_runtime.ml:164,218] from
     [Tool_dispatch.dispatch] to [Tool_dispatch.guarded_dispatch]. The
     [guarded_dispatch] entry wraps [dispatch_structured] (pre-hook +
     handler + post-hook) with [Tool_telemetry.with_span], so every
@@ -44,7 +44,7 @@ let pinned_dispatch_structured_callers = 0
 let test_keeper_prehook_runs () =
   (check int)
     "keeper turn pre-hook invocation count per turn \
-     (RFC-0084 §1.1 PR-7; keeper_exec_masc.ml:164,218 → guarded_dispatch)"
+     (RFC-0084 §1.1 PR-7; agent_tool_remote_mcp_runtime.ml:164,218 → guarded_dispatch)"
     1
     pinned_keeper_prehook_invocations_per_turn
 

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -332,7 +332,7 @@ let test_descriptor_backed_dispatch_uses_agent_tool_runtime () =
   assert_contains runtime_ml "Agent_tool_filesystem_runtime.handle_read_file";
   assert_contains runtime_ml "Agent_tool_filesystem_runtime.handle_file_write";
   assert_contains runtime_ml "let handle_remote_mcp";
-  assert_contains runtime_ml "Keeper_exec_masc.handle_registered_keeper_tool";
+  assert_contains runtime_ml "Agent_tool_remote_mcp_runtime.handle_registered_remote_tool";
   assert_contains runtime_ml "| Remote_mcp -> handle_remote_mcp";
   assert_contains exec_tools_ml "Agent_tool_runtime.handle_internal";
   assert_not_contains exec_tools_ml "Keeper_exec_shell.handle_tool_execute";

--- a/test/test_rfc_0085_pr14_dispatch_inline.ml
+++ b/test/test_rfc_0085_pr14_dispatch_inline.ml
@@ -33,11 +33,11 @@ let test_guarded_dispatch_binding_present () =
 let test_guarded_dispatch_callers_intact () =
   let n =
     Ast_grep.count_calls
-      ~module_path:"lib/keeper/keeper_exec_masc.ml"
+      ~module_path:"lib/keeper/agent_tool_remote_mcp_runtime.ml"
       ~callee:"Tool_dispatch.guarded_dispatch"
   in
   if n < 1
-  then failf "keeper_exec_masc.ml must call guarded_dispatch ≥ 1; got %d" n
+  then failf "agent_tool_remote_mcp_runtime.ml must call guarded_dispatch ≥ 1; got %d" n
 ;;
 
 let () =

--- a/test/test_tag_dispatch_typed.ml
+++ b/test/test_tag_dispatch_typed.ml
@@ -4,7 +4,7 @@ open Alcotest
 
     PR-7 wrapped the primary keeper-turn dispatch sites; PR-8 wrapped the
     MCP server tag-dispatch caller sites. PR-9 closes the remaining
-    fallback path inside [keeper_exec_masc.ml:180-190] where
+    fallback path inside [agent_tool_remote_mcp_runtime.ml:180-190] where
     [Tool_dispatch.lookup_tag] + [Keeper_exec_shared.tag_dispatch_fn]
     handle tools that didn't resolve through the handler registry.
 
@@ -20,9 +20,9 @@ let pinned_tag_dispatch_outcome_labels = [ "handled"; "no_handler" ]
 
 let pinned_total_telemetry_wrap_sites_across_entries = 5
 (** Cumulative wrap sites after PR-9:
-    - PR-7 keeper turn: keeper_exec_masc.ml:164 + :218     (2 sites)
+    - PR-7 keeper turn: agent_tool_remote_mcp_runtime.ml:164 + :218     (2 sites)
     - PR-8 MCP server: mcp_server_eio_execute.ml:1065 + :1083 (2 sites)
-    - PR-9 tag-dispatch fallback: keeper_exec_masc.ml:180+   (1 site)
+    - PR-9 tag-dispatch fallback: agent_tool_remote_mcp_runtime.ml:180+   (1 site)
     Total: 5 wrap sites covering all three dispatch entries. *)
 
 let pinned_dispatch_entries_covered = 3


### PR DESCRIPTION
## Summary
- rename keeper_exec_masc to Agent_tool_remote_mcp_runtime
- route descriptor Remote_mcp dispatch and fallback registered-tool dispatch through handle_registered_remote_tool
- update tests/docs so the old keeper_exec_masc module surface is gone

## Verification
- ocamlformat --check lib/keeper/agent_tool_remote_mcp_runtime.ml lib/keeper/agent_tool_remote_mcp_runtime.mli lib/keeper/agent_tool_runtime.ml lib/keeper/keeper_exec_tools.ml lib/capability_registry.ml lib/tool_code.ml lib/tool_code_read_core.mli lib/tool_telemetry.mli test/test_dispatch_telemetry_gap.ml test/test_keeper_exec_tools.ml test/test_keeper_masc_bridge.ml test/test_keeper_prehook_gap.ml test/test_keeper_sandbox_boundary_policy.ml test/test_rfc_0085_pr14_dispatch_inline.ml test/test_tag_dispatch_typed.ml
- git diff --check origin/main...HEAD
- rg -n "Keeper_exec_masc|keeper_exec_masc|handle_registered_keeper_tool|handle_keeper_masc_tool|handle_keeper_masc_code_read|keeper_masc_path_blocked" lib test docs scripts config (no matches)
- test ! -e lib/keeper/keeper_exec_masc.ml && test ! -e lib/keeper/keeper_exec_masc.mli
- scripts/dune-local.sh build test/test_keeper_exec_tools.exe test/test_keeper_masc_bridge.exe test/test_keeper_sandbox_boundary_policy.exe test/test_rfc_0085_pr14_dispatch_inline.exe test/test_dispatch_telemetry_gap.exe test/test_keeper_prehook_gap.exe test/test_tag_dispatch_typed.exe (blocked: live bare Dune processes; check-stuck-dune reports none older than 60m)