### PR TITLE
[codex] Add goal completion transition actions

### DIFF
--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { cleanup, render, screen, waitFor } from '@testing-library/preact'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type {
   DashboardGoalDetailResponse,
@@ -11,6 +11,8 @@ import { hydrateGoalTreeSnapshot } from '../../goal-tree-state'
 const mocks = vi.hoisted(() => ({
   fetchDashboardGoalDetail: vi.fn(),
   fetchDashboardGoalsTree: vi.fn(),
+  callMcpTool: vi.fn(),
+  currentDashboardActor: vi.fn(() => 'dashboard-test'),
   route: {
     value: {
       tab: 'workspace',
@@ -24,6 +26,14 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../../api/dashboard', () => ({
   fetchDashboardGoalDetail: mocks.fetchDashboardGoalDetail,
   fetchDashboardGoalsTree: mocks.fetchDashboardGoalsTree,
+}))
+
+vi.mock('../../api/core', () => ({
+  currentDashboardActor: mocks.currentDashboardActor,
+}))
+
+vi.mock('../../api/mcp', () => ({
+  callMcpTool: mocks.callMcpTool,
 }))
 
 vi.mock('../../router', () => ({
@@ -145,6 +155,9 @@ describe('GoalTree', () => {
 
   afterEach(() => {
     cleanup()
+    mocks.callMcpTool.mockReset()
+    mocks.currentDashboardActor.mockReset()
+    mocks.currentDashboardActor.mockReturnValue('dashboard-test')
     mocks.fetchDashboardGoalDetail.mockReset()
     mocks.fetchDashboardGoalsTree.mockReset()
   })
@@ -182,5 +195,73 @@ describe('GoalTree', () => {
     await waitFor(() => {
       expect(mocks.fetchDashboardGoalDetail).toHaveBeenCalledWith('goal-child')
     })
+  })
+
+  it('requests goal completion through the goal transition tool and refreshes goal data', async () => {
+    const goal = {
+      ...makeGoal('goal-ready', 'Ready goal'),
+      task_count: 1,
+      task_done_count: 1,
+      completion_summary: {
+        state: 'ready_for_completion',
+        pct: 100,
+        pct_source: 'linked_tasks',
+        attainment_state: 'attained',
+        attainment_basis: 'linked_tasks',
+        task_total: 1,
+        task_done: 1,
+        task_open: 0,
+        is_complete: false,
+        is_terminal: false,
+        ready_to_request_completion: true,
+        gate: 'none',
+        requires_verifier: false,
+        requires_completion_approval: false,
+        active_verification_request: false,
+        blocking_source: 'none',
+        blocking_reason: '',
+      },
+    } satisfies GoalTreeNode
+    const treePayload: DashboardGoalsTreeResponse = {
+      tree: [goal],
+      summary: { ...emptySummary(), total_goals: 1, active_goals: 1, total_tasks: 1, done_tasks: 1 },
+    }
+    const detailPayload: DashboardGoalDetailResponse = {
+      goal,
+      linked_tasks: [],
+      linked_keepers: [],
+      approvals: [],
+      execution_receipts: [],
+      timeline: [],
+    }
+    mocks.fetchDashboardGoalsTree.mockResolvedValue(treePayload)
+    mocks.fetchDashboardGoalDetail.mockResolvedValue(detailPayload)
+    mocks.callMcpTool.mockResolvedValue('{"ok":true}')
+
+    render(html`<${GoalTree} />`)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('goal-detail-panel').getAttribute('data-selected-goal-id'))
+        .toBe('goal-ready')
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Request completion' }))
+
+    await waitFor(() => {
+      expect(mocks.callMcpTool).toHaveBeenCalledWith('masc_goal_transition', {
+        goal_id: 'goal-ready',
+        action: 'request_complete',
+        actor: {
+          kind: 'operator',
+          id: 'dashboard-test',
+          display_name: 'dashboard-test',
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(mocks.fetchDashboardGoalsTree.mock.calls.length).toBeGreaterThanOrEqual(2)
+      expect(mocks.fetchDashboardGoalDetail.mock.calls.length).toBeGreaterThanOrEqual(2)
+    })
+    expect(screen.getByTestId('goal-lifecycle-action-status').textContent)
+      .toContain('requested completion')
   })
 })

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -2,9 +2,11 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { useEffect, useMemo } from 'preact/hooks'
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
 import { SECONDS_PER_HOUR } from '../../lib/format-time'
 import { fetchDashboardGoalDetail, fetchDashboardGoalsTree } from '../../api/dashboard'
+import { currentDashboardActor } from '../../api/core'
+import { callMcpTool } from '../../api/mcp'
 import { route } from '../../router'
 import {
   goalTreeData as treeData,
@@ -64,6 +66,7 @@ import {
 } from './goal-completion-summary'
 
 type GoalDetailTab = 'summary' | 'tasks' | 'evidence'
+type GoalTransitionAction = 'request_complete' | 'approve_completion' | 'reject_completion'
 
 const CARD_BOX = 'rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3'
 const DECK_LABEL = 'font-mono text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]'
@@ -820,6 +823,128 @@ function GoalTaskRelationStrip({
   `
 }
 
+function goalTransitionLabel(action: GoalTransitionAction): string {
+  switch (action) {
+    case 'request_complete': return 'Request completion'
+    case 'approve_completion': return 'Approve completion'
+    case 'reject_completion': return 'Reject completion'
+  }
+}
+
+function goalTransitionStatusLabel(action: GoalTransitionAction): string {
+  switch (action) {
+    case 'request_complete': return 'requested completion'
+    case 'approve_completion': return 'approved completion'
+    case 'reject_completion': return 'rejected completion'
+  }
+}
+
+function lifecycleActionsForGoal(node: GoalTreeNode): Array<{
+  action: GoalTransitionAction
+  variant: 'primary' | 'ok' | 'danger'
+}> {
+  const summary = goalCompletionSummaryForNode(node)
+  const actions: Array<{
+    action: GoalTransitionAction
+    variant: 'primary' | 'ok' | 'danger'
+  }> = []
+
+  if (summary.ready_to_request_completion) {
+    actions.push({ action: 'request_complete', variant: 'primary' })
+  }
+  if (node.phase === 'awaiting_approval') {
+    actions.push({ action: 'approve_completion', variant: 'ok' })
+    actions.push({ action: 'reject_completion', variant: 'danger' })
+  }
+  return actions
+}
+
+function GoalLifecycleActionPanel({ node }: { node: GoalTreeNode }) {
+  const actions = lifecycleActionsForGoal(node)
+  const [pendingAction, setPendingAction] = useState<GoalTransitionAction | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [lastAction, setLastAction] = useState<GoalTransitionAction | null>(null)
+
+  useEffect(() => {
+    setPendingAction(null)
+    setError(null)
+    setLastAction(null)
+  }, [node.id])
+
+  const runAction = useCallback((action: GoalTransitionAction) => {
+    const actorId = currentDashboardActor()
+    setPendingAction(action)
+    setError(null)
+    setLastAction(null)
+    void (async () => {
+      try {
+        await callMcpTool('masc_goal_transition', {
+          goal_id: node.id,
+          action,
+          actor: {
+            kind: 'operator',
+            id: actorId,
+            display_name: actorId,
+          },
+        })
+        setLastAction(action)
+        await Promise.all([
+          refreshTree(),
+          refreshGoalDetail(node.id),
+        ])
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        setPendingAction(null)
+      }
+    })()
+  }, [node.id])
+
+  if (actions.length === 0) return null
+
+  return html`
+    <div class=${CARD_BOX} data-goal-lifecycle-actions>
+      <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <div class="text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-text-muted">Goal lifecycle</div>
+          <div class="mt-1 text-sm text-text-body">${goalCompletionLabel(goalCompletionSummaryForNode(node))}</div>
+        </div>
+        <span class="${DECK_CHIP} text-[var(--color-fg-secondary)]">${node.phase}</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        ${actions.map(({ action, variant }) => {
+          const label = goalTransitionLabel(action)
+          const isPending = pendingAction === action
+          return html`
+            <${ActionButton}
+              key=${action}
+              variant=${variant}
+              size="sm"
+              disabled=${pendingAction !== null}
+              ariaBusy=${isPending}
+              ariaLabel=${label}
+              title=${label}
+              onClick=${() => runAction(action)}
+            >
+              ${isPending ? 'Working...' : label}
+            <//>
+          `
+        })}
+      </div>
+      ${lastAction ? html`
+        <div class="mt-3 rounded-[var(--r-1)] border border-[var(--ok-25)] bg-[var(--ok-10)] px-3 py-2 text-xs text-[var(--color-status-ok)]" data-testid="goal-lifecycle-action-status">
+          ${goalTransitionStatusLabel(lastAction)}
+        </div>
+      ` : null}
+      ${error ? html`
+        <div class="mt-3 rounded-[var(--r-1)] border border-[var(--err-25)] bg-[var(--err-10)] px-3 py-2 text-xs text-[var(--color-status-err)]" data-testid="goal-lifecycle-action-error">
+          ${error}
+        </div>
+      ` : null}
+    </div>
+  `
+}
+
 function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
   const isExpanded = expandedNodes.value.has(node.id)
   const hasContent = node.children.length > 0 || node.tasks.length > 0
@@ -1313,6 +1438,7 @@ function GoalDetailPanel({
 
       <${GoalCompletionStrip} node=${selectedNode} />
       <${GoalTaskRelationStrip} node=${selectedNode} />
+      <${GoalLifecycleActionPanel} node=${selectedNode} />
 
       <${DetailTabs} active=${activeTab} />
 


### PR DESCRIPTION
## Summary

- Add Goal Detail lifecycle actions for ready-to-complete goals.
- Wire `Request completion`, `Approve completion`, and `Reject completion` to the existing `masc_goal_transition` MCP contract with the current dashboard actor as an operator principal.
- Refresh Goal Tree and Goal Detail data after a successful transition.

## Product impact

This closes the dashboard-side gap where Goal Manager showed completion readiness but did not let an operator advance the goal lifecycle from the same surface.

## Evidence

- `git diff --check`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run src/components/goals/goal-tree.test.ts src/components/goals/goal-completion-summary.test.ts src/components/goals/goal-task-summary.test.ts`

## Deferred local evidence

- OCaml/Dune validation was not run because this change only touches dashboard TypeScript and Vitest coverage.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/4
provenance: direct
```

## Review evidence

- Added a GoalTree regression test that clicks `Request completion`, verifies the `masc_goal_transition` payload, and checks tree/detail refresh.

## Linked issue

- Kimi dashboard review report item `GOAL-UI-01`.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/goal-completion-actions-20260526` → `main` · 1 commit(s) · synced 2026-05-26T04:33:58Z

| sha | subject | date |
|---|---|---|
| `5c2f578aa` | fix(dashboard): add goal completion transition actions | 2026-05-26 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->