### PR TITLE
refactor(keeper): rename ide tool runtime

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -39,8 +39,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_exec_board.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_context.ml` - execution-dispatch
 - `lib/keeper/keeper_exec_context.mli` - execution-dispatch
-- `lib/keeper/keeper_exec_ide.ml` - execution-dispatch
-- `lib/keeper/keeper_exec_ide.mli` - execution-dispatch
+- `lib/keeper/agent_tool_ide_runtime.ml` - execution-dispatch
+- `lib/keeper/agent_tool_ide_runtime.mli` - execution-dispatch
 - `lib/keeper/agent_tool_remote_mcp_runtime.ml` - execution-dispatch
 - `lib/keeper/agent_tool_remote_mcp_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_memory.ml` - execution-dispatch

--- a/docs/rfc/RFC-0128-ide-canonical-url-partitioning.md
+++ b/docs/rfc/RFC-0128-ide-canonical-url-partitioning.md
@@ -191,7 +191,7 @@ val find_canonical_url_by_repo_id
 - `Ide_paths.canonical_url_of_remote` 구현 + 단위 테스트.
 - `Repo_store.find_canonical_url_by_*` 두 함수 추가.
 - `Ide_annotations.create` / `Ide_region_tracker.append_region` 시그니처에 `canonical_url:string option` 추가.
-- 모든 caller (`server_ide_http.ml`, `agent_tool_filesystem_runtime.ml`, `keeper_exec_ide.ml`) 업데이트.
+- 모든 caller (`server_ide_http.ml`, `agent_tool_filesystem_runtime.ml`, `agent_tool_ide_runtime.ml`) 업데이트.
 - 기존 store path (`<base>/.masc-ide/{annotations,regions}.jsonl`) 는 *읽기 전용* 으로 유지. 새 record 는 `by-url/<slug>/` 또는 `_orphan/` 으로만.
 
 Acceptance:

--- a/lib/dune
+++ b/lib/dune
@@ -148,7 +148,7 @@
    keeper_exec_board
    agent_tool_filesystem_runtime
    agent_tool_remote_mcp_runtime
-   keeper_exec_ide
+   agent_tool_ide_runtime
    keeper_sandbox_docker
    keeper_task_worktree_lazy
    keeper_shell_op keeper_shell_timeout keeper_shell_runtime_paths keeper_shell_path

--- a/lib/keeper/agent_tool_ide_runtime.ml
+++ b/lib/keeper/agent_tool_ide_runtime.ml
@@ -1,4 +1,4 @@
-(** Keeper_exec_ide — MCP tool handler for keeper_ide_annotate.
+(** Runtime adapter for IDE annotation agent tools.
 
     Allows keepers to leave line-bound annotations on code files,
     stored in [.masc-ide/annotations.jsonl] and surfaced by the
@@ -10,7 +10,7 @@ open Keeper_types
 open Keeper_exec_shared
 open Ide_annotation_types
 
-let handle_keeper_ide_annotate
+let handle_ide_annotate
       ~(config : Coord.config)
       ~(keeper_name : string)
       ~(args : Yojson.Safe.t)

--- a/lib/keeper/agent_tool_ide_runtime.mli
+++ b/lib/keeper/agent_tool_ide_runtime.mli
@@ -1,8 +1,8 @@
-(** Keeper_exec_ide — MCP tool handler for keeper_ide_annotate.
+(** Runtime adapter for IDE annotation agent tools.
 
     @since 0.6.0 — observational IDE Phase 1 *)
 
-val handle_keeper_ide_annotate :
+val handle_ide_annotate :
   config:Coord.config ->
   keeper_name:string ->
   args:Yojson.Safe.t ->

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -477,7 +477,7 @@ let execute_keeper_tool_call_with_outcome
          if result.Tool_result.success then success_tool_result result.Tool_result.message else failure_tool_result (error_json result.Tool_result.message)
        | "keeper_ide_annotate" ->
          make_executed_tool_result
-           (Keeper_exec_ide.handle_keeper_ide_annotate
+           (Agent_tool_ide_runtime.handle_ide_annotate
               ~config
               ~keeper_name:meta.name
               ~args)

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -63,7 +63,7 @@ let test_events_json_derives_ide_context () =
            ~actor:(Activity_graph.entity ~kind:"keeper" "sangsu")
            ~subject:(Activity_graph.entity ~kind:"log" "turn-9")
            ~tags:[
-             "file:lib/keeper/keeper_exec_ide.ml:27";
+             "file:lib/keeper/agent_tool_ide_runtime.ml:27";
              "task:task-42";
              "board:post-1";
              "comment:comment-7";
@@ -87,7 +87,7 @@ let test_events_json_derives_ide_context () =
           fail (Printf.sprintf "expected one event, got %d" (List.length events))
       in
       let context = event |> member "context" in
-      check string "context file path" "lib/keeper/keeper_exec_ide.ml"
+      check string "context file path" "lib/keeper/agent_tool_ide_runtime.ml"
         (context |> member "file_path" |> to_string);
       check int "context line" 27 (context |> member "line" |> to_int);
       check string "context goal" "goal-ide"

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -15,7 +15,7 @@ let () = Random.self_init ()
 
 let route_annotation : Types.annotation =
   { id = "ann-route"
-  ; file_path = "lib/keeper/keeper_exec_ide.ml"
+  ; file_path = "lib/keeper/agent_tool_ide_runtime.ml"
   ; line_start = 12
   ; line_end = 14
   ; keeper_id = "sangsu"
@@ -130,7 +130,7 @@ let test_create_lists_route_context () =
       Store.create
         ~base_dir
         ~keeper_id:"sangsu"
-        ~file_path:"lib/keeper/keeper_exec_ide.ml"
+        ~file_path:"lib/keeper/agent_tool_ide_runtime.ml"
         ~line_start:12
         ~line_end:14
         ~kind:Types.Question
@@ -151,7 +151,7 @@ let test_create_lists_route_context () =
     | Ok created ->
       check (option string) "created pr" (Some "15035") created.pr_id;
       let filter =
-        { Types.file_path = Some "lib/keeper/keeper_exec_ide.ml"
+        { Types.file_path = Some "lib/keeper/agent_tool_ide_runtime.ml"
         ; keeper_id = None
         ; goal_id = None
         ; task_id = None
@@ -172,7 +172,7 @@ let test_lsp_overlay_exposes_route_context () =
       Store.create
         ~base_dir
         ~keeper_id:"sangsu"
-        ~file_path:"lib/keeper/keeper_exec_ide.ml"
+        ~file_path:"lib/keeper/agent_tool_ide_runtime.ml"
         ~line_start:12
         ~line_end:14
         ~kind:Types.Question
@@ -193,7 +193,7 @@ let test_lsp_overlay_exposes_route_context () =
     | Ok _ ->
       Lsp.clear_cache ();
       let codelenses =
-        Lsp.codelenses ~base_dir ~file_path:"lib/keeper/keeper_exec_ide.ml"
+        Lsp.codelenses ~base_dir ~file_path:"lib/keeper/agent_tool_ide_runtime.ml"
       in
       (match codelenses with
        | [ codelens ] ->
@@ -202,7 +202,7 @@ let test_lsp_overlay_exposes_route_context () =
          check_contains "codelens carries log route" "log:turn-9" title
        | rows -> failf "expected one codelens, got %d" (List.length rows));
       let inlay_hints =
-        Lsp.inlay_hints ~base_dir ~file_path:"lib/keeper/keeper_exec_ide.ml"
+        Lsp.inlay_hints ~base_dir ~file_path:"lib/keeper/agent_tool_ide_runtime.ml"
       in
       (match inlay_hints with
        | [ hint ] ->
@@ -215,7 +215,7 @@ let test_lsp_overlay_exposes_route_context () =
       let diagnostics =
         Lsp.diagnostics
           ~base_dir
-          ~file_path:"lib/keeper/keeper_exec_ide.ml"
+          ~file_path:"lib/keeper/agent_tool_ide_runtime.ml"
           ~lsp_diagnostics:[]
       in
       (match diagnostics with
@@ -226,7 +226,7 @@ let test_lsp_overlay_exposes_route_context () =
       let hover =
         Lsp.enrich_hover
           ~base_dir
-          ~file_path:"lib/keeper/keeper_exec_ide.ml"
+          ~file_path:"lib/keeper/agent_tool_ide_runtime.ml"
           ~line:11
           (`Assoc
              [ "contents"


### PR DESCRIPTION
## Summary
- rename keeper_exec_ide to Agent_tool_ide_runtime
- route keeper_ide_annotate through handle_ide_annotate
- update docs and IDE annotation test fixtures to the new runtime file path

## Verification
- ocamlformat --check lib/keeper/agent_tool_ide_runtime.ml lib/keeper/agent_tool_ide_runtime.mli lib/keeper/keeper_exec_tools.ml test/test_ide_annotations.ml test/test_activity_graph.ml
- git diff --check origin/main...HEAD
- rg -n "Keeper_exec_ide|keeper_exec_ide|handle_keeper_ide_annotate|lib/keeper/keeper_exec_ide\.ml|lib/keeper/keeper_exec_ide\.mli" lib test docs scripts config (no matches)
- test ! -e lib/keeper/keeper_exec_ide.ml && test ! -e lib/keeper/keeper_exec_ide.mli
- scripts/dune-local.sh build test/test_ide_annotations.exe test/test_activity_graph.exe test/test_keeper_exec_tools.exe (blocked: live bare Dune processes; check-stuck-dune reports none older than 60m)