### PR TITLE
docs(keeper): repair boundary matrix after purge merges

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 13:29:50 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 13:39:02 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -415,9 +415,9 @@
           </tr>
           <tr>
             <td><code>Keeper_types</code> final support path facade leaves</td>
-            <td><span class="status now">draft PR #18608</span></td>
+            <td><span class="status done">merged #18608</span></td>
             <td>Stop exposing the remaining support-owned memory-bank, progress, and decision-log path helpers through the broad <code>Keeper_types</code> facade. Production and tests now use <code>Keeper_types_support</code> directly.</td>
-            <td>Backstop grep must stay clean for <code>Keeper_types.keeper_memory_bank_path</code>, <code>Keeper_types.keeper_progress_path</code>, and <code>Keeper_types.keeper_decision_log_path</code>.</td>
+            <td>Backstop grep is clean for <code>Keeper_types.keeper_memory_bank_path</code>, <code>Keeper_types.keeper_progress_path</code>, and <code>Keeper_types.keeper_decision_log_path</code>. The branch has been merged into <code>origin/main</code>.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.write_meta_with_retry</code> wrapper</td>

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -39,10 +39,6 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_exec_board.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_context.ml` - execution-dispatch
 - `lib/keeper/keeper_exec_context.mli` - execution-dispatch
-- `lib/keeper/agent_tool_ide_runtime.ml` - execution-dispatch
-- `lib/keeper/agent_tool_ide_runtime.mli` - execution-dispatch
-- `lib/keeper/agent_tool_remote_mcp_runtime.ml` - execution-dispatch
-- `lib/keeper/agent_tool_remote_mcp_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_memory.ml` - execution-dispatch
 - `lib/keeper/keeper_exec_memory.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_persona.ml` - execution-dispatch
@@ -211,6 +207,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_progress.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_registry.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_registry.mli` - tool-surface-policy
+- `lib/keeper/keeper_tool_response.ml` - tool-surface-policy
+- `lib/keeper/keeper_tool_response.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_resolution.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_resolution.mli` - tool-surface-policy
 - `lib/keeper/keeper_tools_oas_bundle.ml` - oas-tool-bridge


### PR DESCRIPTION
## Summary
- remove out-of-scope agent_tool_remote_mcp_runtime entries from the keeper tool-boundary matrix
- add the keeper_tool_response files extracted by #18606
- mark #18608 as merged in the legacy purge ledger

## Verification
- scripts/audit-keeper-tool-boundary-matrix.sh
- git diff --check