### PR TITLE
fix(keeper): qualify owners after facade purge

### DIFF
--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -550,7 +550,7 @@ let maybe_emit_interesting_alert
       in
       (try
          Keeper_types_support.append_jsonl_line
-           (keeper_alerts_path ctx.config)
+           (Keeper_types_support.keeper_alerts_path ctx.config)
            alert_json
        with
        | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -90,7 +90,7 @@ let search_memory_bank
       ~(limit : int)
   : memory_match list * int
   =
-  let path = keeper_memory_bank_path config meta.name in
+  let path = Keeper_types_support.keeper_memory_bank_path config meta.name in
   let lines =
     Keeper_memory_recall.read_file_tail_lines path ~max_bytes:(256 * 1024) ~max_lines:500
   in
@@ -413,7 +413,7 @@ let keeper_memory_search_json
           | None -> [])
      in
      Keeper_types_support.append_jsonl_line
-       (keeper_decision_log_path config meta.name)
+       (Keeper_types_support.keeper_decision_log_path config meta.name)
        log_entry
    with
    | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_generation_lineage.ml
+++ b/lib/keeper/keeper_generation_lineage.ml
@@ -214,7 +214,7 @@ let record_handoff_artifacts
     ~(context_ratio : float) =
   let child_trace_id = Keeper_id.Trace_id.to_string child.runtime.trace_id in
   let manifest_path =
-    keeper_generation_manifest_path config child_trace_id
+    Keeper_types_support.keeper_generation_manifest_path config child_trace_id
   in
   let index_path = keeper_generation_index_path config child.name in
   let manifest =
@@ -300,7 +300,7 @@ let rec take n xs =
 
 let surface_json (config : Coord.config) (meta : keeper_meta) ~recent_limit =
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
-  let manifest_path = keeper_generation_manifest_path config trace_id in
+  let manifest_path = Keeper_types_support.keeper_generation_manifest_path config trace_id in
   let index_path = keeper_generation_index_path config meta.name in
   let manifest = load_json_file_opt manifest_path in
   let index_entries = load_jsonl_file index_path in

--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -29,7 +29,7 @@ let effective_keepalive_meta
 let repair_identity_drift_for_keepalive ~(ctx : _ context) (meta : keeper_meta)
   : keeper_meta option
   =
-  let expected_agent_name = keeper_agent_name meta.name in
+  let expected_agent_name = Keeper_identity.keeper_agent_name meta.name in
   if String.equal expected_agent_name meta.agent_name
   then Some meta
   else (

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -474,7 +474,7 @@ let compact_memory_bank_if_needed
     (config : Coord.config)
     (meta : keeper_meta) : memory_bank_compaction =
   let target_notes = memory_compaction_target_notes () in
-  let path = keeper_memory_bank_path config meta.name in
+  let path = Keeper_types_support.keeper_memory_bank_path config meta.name in
   if not (Fs_compat.file_exists path) then
     { no_memory_bank_compaction with
       target_notes;
@@ -712,7 +712,7 @@ let append_memory_notes_from_reply
     (0, [])
   else
     let now_ts = Time_compat.now () in
-    let path = keeper_memory_bank_path config meta.name in
+    let path = Keeper_types_support.keeper_memory_bank_path config meta.name in
     let kinds_acc = ref [] in
     let seen_kinds : (string, unit) Hashtbl.t = Hashtbl.create 8 in
     with_memory_bank_lock path (fun () ->
@@ -784,7 +784,7 @@ let append_memory_notes_from_tool_results
     ~(turn : int)
     ~(results : Yojson.Safe.t list) : int =
   let now_ts = Time_compat.now () in
-  let path = keeper_memory_bank_path config meta.name in
+  let path = Keeper_types_support.keeper_memory_bank_path config meta.name in
   let seen_artifacts : (string, unit) Hashtbl.t = Hashtbl.create 16 in
   let written = ref 0 in
   with_memory_bank_lock path (fun () ->

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -603,7 +603,7 @@ let prompt_memory_sections_of_snapshot
 let read_progress_snapshot ~(config : Coord.config) ~(name : string)
     : keeper_state_snapshot option =
   match
-    let path = keeper_progress_path config name in
+    let path = Keeper_types_support.keeper_progress_path config name in
     if not (Fs_compat.file_exists path) then
       None
     else
@@ -617,7 +617,7 @@ let read_progress_snapshot ~(config : Coord.config) ~(name : string)
 
 let read_progress_snapshot_cache ~(config : Coord.config) ~(name : string)
     : progress_snapshot_cache option =
-  let path = keeper_progress_path config name in
+  let path = Keeper_types_support.keeper_progress_path config name in
   if not (Fs_compat.file_exists path) then
     None
   else

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -132,7 +132,7 @@ let read_keeper_memory_summary_result
     (keeper_memory_summary, Keeper_memory_recall_exn_class.t) result =
   match
     read_file_tail_lines_result
-      (keeper_memory_bank_path config name)
+      (Keeper_types_support.keeper_memory_bank_path config name)
       ~max_bytes
       ~max_lines
   with
@@ -174,7 +174,7 @@ let read_memory_horizon_counts_result
     ((string * int) list, Keeper_memory_recall_exn_class.t) result =
   match
     read_file_tail_lines_result
-      (keeper_memory_bank_path config name)
+      (Keeper_types_support.keeper_memory_bank_path config name)
       ~max_bytes
       ~max_lines
   with
@@ -224,7 +224,7 @@ let read_recent_memory_texts_result
     (string list, Keeper_memory_recall_exn_class.t) result =
   match
     read_file_tail_lines_result
-      (keeper_memory_bank_path config name)
+      (Keeper_types_support.keeper_memory_bank_path config name)
       ~max_bytes
       ~max_lines
   with

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -629,7 +629,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                    ; name = identity.pk_name
                    ; agent_name =
                        (if identity.pk_agent_name = ""
-                        then keeper_agent_name identity.pk_name
+                        then Keeper_identity.keeper_agent_name identity.pk_name
                         else identity.pk_agent_name)
                    ; goal = identity.pk_goal
                    ; short_goal = identity.pk_short_goal

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -132,7 +132,7 @@ let handle_keeper_shell_ir_typed
         let typed_error_fields =
           [ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
         in
-        let blocked_result ?deterministic_reason ~error ~reason ~alternatives =
+        let blocked_result ?deterministic_reason ~error ~reason ~alternatives () =
           let deterministic_retry_fields =
             match deterministic_reason with
             | Some deterministic_reason ->
@@ -166,6 +166,7 @@ let handle_keeper_shell_ir_typed
             ~error:"destructive_operation_blocked"
             ~reason:"This typed command is destructive and is blocked for all presets."
             ~alternatives:[ "Use a non-destructive command or a dedicated structured tool." ]
+            ()
         else if (not write_enabled)
              && (Masc_exec.Shell_ir_risk.is_r1 envelope
                 || Masc_exec.Shell_ir_risk.is_r2 envelope)
@@ -178,6 +179,7 @@ let handle_keeper_shell_ir_typed
               [ "Use read-only commands such as rg, cat, ls, git status, or git log."
               ; "Ask the operator for a write-enabled preset."
               ]
+            ()
         else
           let allowed_commands =
             match mode with

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -278,7 +278,7 @@ let handle_keeper_list ctx args : tool_result =
                 ("meta", `String (keeper_meta_path ctx.config m.name));
                 ("metrics", `String (Dated_jsonl.base_dir metrics_store));
                 ("metrics_single_file", `String metrics_path);
-                ("memory_bank", `String (keeper_memory_bank_path ctx.config m.name));
+                ("memory_bank", `String (Keeper_types_support.keeper_memory_bank_path ctx.config m.name));
                 ("policy", `String (keeper_policy_log_path ctx.config m.name));
                 ("feedback", `String (keeper_feedback_log_path ctx.config m.name));
                 ("dataset_export", `String (keeper_dataset_export_path ctx.config m.name));

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -284,13 +284,13 @@ let handle_keeper_status ctx args : tool_result =
 
          let metrics_store = Keeper_types_support.keeper_metrics_store ctx.config m.name in
          let metrics_path = Keeper_types_support.keeper_metrics_path ctx.config m.name in
-         let memory_bank_path = keeper_memory_bank_path ctx.config m.name in
+         let memory_bank_path = Keeper_types_support.keeper_memory_bank_path ctx.config m.name in
          let generation_index_path =
            keeper_generation_index_path ctx.config m.name
          in
          let session_dir = keeper_session_dir ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id) in
          let generation_manifest_path =
-           keeper_generation_manifest_path ctx.config
+           Keeper_types_support.keeper_generation_manifest_path ctx.config
              (Keeper_id.Trace_id.to_string m.runtime.trace_id)
          in
          let history_path = keeper_history_path ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id) in
@@ -903,7 +903,7 @@ let handle_keeper_status ctx args : tool_result =
              ("metrics_single_file", `String metrics_path);
              ("memory_bank", `String memory_bank_path);
              ("generation_index", `String generation_index_path);
-             ("decisions", `String (keeper_decision_log_path ctx.config m.name));
+             ("decisions", `String (Keeper_types_support.keeper_decision_log_path ctx.config m.name));
              ("policy", `String (keeper_policy_log_path ctx.config m.name));
              ("feedback", `String (keeper_feedback_log_path ctx.config m.name));
              ("dataset_export", `String (keeper_dataset_export_path ctx.config m.name));

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -433,7 +433,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       let meta = {
         id = None;
         name = p.name;
-        agent_name = keeper_agent_name p.name;
+        agent_name = Keeper_identity.keeper_agent_name p.name;
         goal;
         short_goal;
         mid_goal;
@@ -608,7 +608,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         Log.Keeper.debug "create_keeper: metadata written for name=%s trace_id=%s"
           p.name (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
         (* Auto-generate credential file if missing (#A10) *)
-        let agent_name = keeper_agent_name p.name in
+        let agent_name = Keeper_identity.keeper_agent_name p.name in
         (match Auth.ensure_keeper_credential ctx.config.base_path ~agent_name with
          | Ok _ ->
              Log.Keeper.debug "create_keeper: credential ensured for %s" agent_name

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -442,7 +442,7 @@ let append_decision_record
   in
   try
     Keeper_types_support.append_jsonl_line
-      (keeper_decision_log_path config meta.name)
+      (Keeper_types_support.keeper_decision_log_path config meta.name)
       json
   with
   | Eio.Cancel.Cancelled _ as e -> raise e


### PR DESCRIPTION
Summary:
- Qualify post-facade-purge keeper path helpers through Keeper_types_support.
- Qualify keeper_agent_name through Keeper_identity.
- Add a unit terminator to the typed shell blocked_result helper so warning 16 no longer fires.

Build errors addressed from main:
- Unbound keeper_agent_name
- Unbound keeper_generation_manifest_path
- Unbound keeper_progress_path
- Unbound keeper_memory_bank_path
- Unbound keeper_alerts_path
- Unbound keeper_decision_log_path
- keeper_shell_bash warning 16 on deterministic_reason

Verification:
- git diff --check origin/main...HEAD
- opam exec -- ocamlformat --check lib/keeper/keeper_meta_json_parse.ml lib/keeper/keeper_generation_lineage.ml lib/keeper/keeper_memory_policy.ml lib/keeper/keeper_memory_bank.ml lib/keeper/keeper_memory_recall.ml lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_exec_memory.ml lib/keeper/keeper_heartbeat_loop_presence.ml lib/keeper/keeper_status.ml lib/keeper/keeper_alerting.ml lib/keeper/keeper_status_detail.ml lib/keeper/keeper_turn_up_create.ml lib/keeper/keeper_unified_metrics_decision.ml
- opam exec -- ocamlc -w +a -warn-error +16 -stop-after parsing lib/keeper/keeper_shell_bash.ml
- opam exec -- ocamlc -stop-after parsing lib/keeper/keeper_meta_json_parse.ml lib/keeper/keeper_generation_lineage.ml lib/keeper/keeper_memory_policy.ml lib/keeper/keeper_memory_bank.ml lib/keeper/keeper_memory_recall.ml lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_exec_memory.ml lib/keeper/keeper_heartbeat_loop_presence.ml lib/keeper/keeper_status.ml lib/keeper/keeper_alerting.ml lib/keeper/keeper_status_detail.ml lib/keeper/keeper_turn_up_create.ml lib/keeper/keeper_unified_metrics_decision.ml

Not run:
- scripts/dune-local.sh build lib/masc_mcp.cmxa returned 75 because live bare Dune processes were already bypassing the machine-wide Dune lock; not bypassed.