### PR TITLE
[codex] Pin composite FSM TLA spec paths

### DIFF
--- a/dashboard/src/components/composite-fsm-flowchart.test.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.test.ts
@@ -1,9 +1,25 @@
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, it, expect } from 'vitest'
 
-import { buildCompositeFsmMermaid } from './composite-fsm-flowchart'
+import {
+  COMPOSITE_FSM_TLA_SPEC_PATHS,
+  buildCompositeFsmMermaid,
+} from './composite-fsm-flowchart'
+
+function repoRoot(): string {
+  const cwd = process.cwd()
+  return cwd.endsWith('/dashboard') ? resolve(cwd, '..') : cwd
+}
 
 describe('buildCompositeFsmMermaid', () => {
   const src = buildCompositeFsmMermaid()
+
+  it('pins every documented TLA+ source to an existing spec file', () => {
+    for (const specPath of COMPOSITE_FSM_TLA_SPEC_PATHS) {
+      expect(existsSync(resolve(repoRoot(), specPath)), specPath).toBe(true)
+    }
+  })
 
   it('is a flowchart with a top-to-bottom direction', () => {
     expect(src.startsWith('flowchart TB')).toBe(true)

--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -12,13 +12,8 @@
  * covers the "순서도까지 맵핑" ("map the flowcharts") portion of the
  * user's brief — this panel is the flowchart companion to the matrix.
  *
- * The transitions below are hand-extracted from:
- *   specs/keeper-state-machine/KeeperStateMachine.tla
- *   specs/keeper-state-machine/KeeperTurnCycle.tla
- *   specs/keeper-state-machine/KeeperDecisionPipeline.tla
- *   specs/keeper-state-machine/KeeperCascadeLifecycle.tla
- *   specs/keeper-state-machine/KeeperCompactionLifecycle.tla
- *   specs/keeper-state-machine/KeeperCircuitBreaker.tla
+ * The transitions below are hand-extracted from
+ * COMPOSITE_FSM_TLA_SPEC_PATHS.
  *
  * Only the common-case edges are rendered — a full enumeration of
  * every guarded transition would be unreadable and is what the TLA+
@@ -29,6 +24,15 @@
 import { html } from 'htm/preact'
 
 import { MermaidGraph } from './common/mermaid-graph'
+
+export const COMPOSITE_FSM_TLA_SPEC_PATHS = [
+  'specs/keeper-state-machine/KeeperStateMachine.tla',
+  'specs/keeper-state-machine/KeeperTurnCycle.tla',
+  'specs/keeper-state-machine/KeeperDecisionPipeline.tla',
+  'specs/keeper-state-machine/KeeperCascadeLifecycle.tla',
+  'specs/keeper-state-machine/KeeperCompactionLifecycle.tla',
+  'specs/keeper-state-machine/KeeperCircuitBreaker.tla',
+] as const
 
 // Every node ID carries an axis prefix so Mermaid's global-id rule
 // does not collapse e.g. two "idle" nodes (KTC and KCL both have one).


### PR DESCRIPTION
## Summary

- Promote the composite FSM dashboard's documented TLA+ source list into `COMPOSITE_FSM_TLA_SPEC_PATHS`.
- Add a Vitest guard that every documented source path resolves to an existing spec file.

## Product impact

This prevents the dashboard from regressing into the stale report state where composite FSM UI references TLA+ specs that do not physically exist.

## Evidence

- `git diff --check`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run src/components/composite-fsm-flowchart.test.ts`
- `bash scripts/ci/check-tla-harness-coverage.sh`

## Deferred local evidence

- Full TLC model checking was not run locally; this PR adds a lightweight dashboard/spec-path guard and reuses the existing harness coverage check.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/4
provenance: direct
```

## Review evidence

- The test now fails if any composite FSM TLA+ source path is renamed, deleted, or left as a stale comment-only reference.

## Linked issue

- Kimi dashboard review report item `GOAL-TLA-01`.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/composite-fsm-tla-spec-paths-20260526` → `main` · 1 commit(s) · synced 2026-05-26T04:42:38Z

| sha | subject | date |
|---|---|---|
| `30a81762a` | test(dashboard): pin composite FSM TLA spec paths | 2026-05-26 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->