### PR TITLE
refactor(keeper): purge checkpoint sidecar read fallbacks

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -39,16 +39,17 @@ let max_oas_history_retained = 12
 let oas_history_path ~(session_dir : string) ~(snapshot_id : string) =
   Filename.concat session_dir snapshot_id
 
+let keeper_generation_of_context (context : Agent_sdk.Context.t) : int =
+  match
+    Agent_sdk.Context.get_scoped context Agent_sdk.Context.Session
+      "keeper_generation"
+  with
+  | Some (`Int n) -> n
+  | Some (`Intlit raw) -> Option.value ~default:0 (int_of_string_opt raw)
+  | _ -> 0
+
 let oas_history_snapshot_id_of_checkpoint (ckpt : Agent_sdk.Checkpoint.t) : string =
-  let generation =
-    match ckpt.working_context with
-    | Some (`Assoc fields) -> (
-        match List.assoc_opt "keeper_generation" fields with
-        | Some (`Int n) -> n
-        | Some (`Intlit raw) -> Option.value ~default:0 (int_of_string_opt raw)
-        | _ -> 0)
-    | _ -> 0
-  in
+  let generation = keeper_generation_of_context ckpt.context in
   let created_ms = max 0 (int_of_float (ckpt.created_at *. 1000.0)) in
   Printf.sprintf "%s%013d-g%d%s"
     oas_history_prefix created_ms generation oas_history_suffix

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -505,15 +505,9 @@ let resume_checkpoint_of_context
   }
 
 let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
-  let open Yojson.Safe.Util in
   match cp.max_total_tokens with
   | Some value -> value
-  | None -> (
-      match cp.working_context with
-      | Some (`Assoc _ as sidecar) ->
-          sidecar |> member "max_tokens" |> to_int_option
-      |> Option.value ~default:fallback
-      | _ -> fallback)
+  | None -> fallback
 
 let context_of_oas_checkpoint
     ?(repair_orphans = true)
@@ -579,19 +573,13 @@ let save_oas_checkpoint
   | Error e -> Error e
 
 let checkpoint_generation (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
-  let open Yojson.Safe.Util in
   match
     Agent_sdk.Context.get_scoped cp.context Agent_sdk.Context.Session
       checkpoint_generation_key
   with
   | Some (`Int value) -> value
   | Some (`Intlit raw) -> Option.value ~default:fallback (int_of_string_opt raw)
-  | _ -> (
-      match cp.working_context with
-      | Some (`Assoc _ as sidecar) ->
-          sidecar |> member "generation" |> to_int_option
-          |> Option.value ~default:fallback
-      | _ -> fallback)
+  | _ -> fallback
 
 (* ================================================================ *)
 (* Checkpoint Loading                                                *)

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -219,6 +219,41 @@ let test_load_context_prefers_live_primary_max_tokens_over_checkpoint_limit () =
             (KEC.max_tokens_of_context loaded)
       | None -> fail "expected checkpoint context to load")
 
+let checkpoint_context_with_generation generation =
+  let context = Agent_sdk.Context.create () in
+  Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
+    "keeper_generation" (`Int generation);
+  context
+
+let test_checkpoint_helpers_ignore_legacy_working_context_sidecar () =
+  let checkpoint =
+    KEC.create ~system_prompt:"sidecar" ~max_tokens:2048
+    |> KEC.checkpoint_of_context
+  in
+  let legacy_sidecar =
+    Some (`Assoc [ ("max_tokens", `Int 4096); ("generation", `Int 99) ])
+  in
+  let legacy_only =
+    {
+      checkpoint with
+      max_total_tokens = None;
+      context = Agent_sdk.Context.create ();
+      working_context = legacy_sidecar;
+    }
+  in
+  check int "legacy sidecar max_tokens ignored" 1234
+    (KEC.checkpoint_max_tokens legacy_only ~fallback:1234);
+  check int "legacy sidecar generation ignored" 7
+    (KCC.checkpoint_generation legacy_only ~fallback:7);
+  let canonical =
+    {
+      legacy_only with
+      context = checkpoint_context_with_generation 42;
+    }
+  in
+  check int "canonical context generation preserved" 42
+    (KCC.checkpoint_generation canonical ~fallback:7)
+
 let test_apply_post_turn_lifecycle_no_state_advances_cooldown_ts () =
   let base_dir = temp_dir "keeper_lifecycle_no_state" in
   Fun.protect
@@ -2668,6 +2703,8 @@ let () =
             test_apply_post_turn_lifecycle_without_checkpoint_records_skip;
           test_case "restore prefers live primary max tokens" `Quick
             test_load_context_prefers_live_primary_max_tokens_over_checkpoint_limit;
+          test_case "checkpoint helpers ignore legacy sidecar" `Quick
+            test_checkpoint_helpers_ignore_legacy_working_context_sidecar;
           test_case "no STATE still advances cooldown ts + counter" `Quick
             test_apply_post_turn_lifecycle_no_state_advances_cooldown_ts;
           test_case "compaction persists checkpoint and continuity" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -5121,6 +5121,13 @@ let make_oas_checkpoint
   }
 ;;
 
+let checkpoint_context_with_generation generation =
+  let context = Agent_sdk.Context.create () in
+  Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
+    "keeper_generation" (`Int generation);
+  context
+;;
+
 let tool_result_msg ?(id = "tool-1") text : Agent_sdk.Types.message =
   { Agent_sdk.Types.role = Agent_sdk.Types.Tool
   ; content =
@@ -5151,12 +5158,10 @@ let test_keeper_checkpoint_store_oas_roundtrip () =
     (fun () ->
        Fs_compat.clear_fs ();
        let session_dir = Filename.concat base_dir "trace-store" in
-       let sidecar = Some (`Assoc [ "max_tokens", `Int 4096 ]) in
        let checkpoint =
          make_oas_checkpoint
            ~session_id:"trace-store"
            ~messages:[ Agent_sdk.Types.user_msg "roundtrip" ]
-           ~working_context:sidecar
            ()
        in
        (match Keeper_checkpoint_store.save_oas ~session_dir checkpoint with
@@ -5169,14 +5174,10 @@ let test_keeper_checkpoint_store_oas_roundtrip () =
            checkpoint.created_at
            loaded.created_at;
          Alcotest.(check int) "message count preserved" 1 (List.length loaded.messages);
-         let sidecar_max_tokens =
-           Option.bind loaded.working_context (fun json ->
-             Yojson.Safe.Util.(json |> member "max_tokens" |> to_int_option))
-         in
-         Alcotest.(check (option int))
-           "sidecar max_tokens preserved"
-           (Some 4096)
-           sidecar_max_tokens
+         Alcotest.(check bool)
+           "legacy sidecar absent"
+           false
+           (Option.is_some loaded.working_context)
        | Error _ -> Alcotest.fail "expected OAS checkpoint roundtrip")
 ;;
 
@@ -5219,11 +5220,16 @@ let test_keeper_checkpoint_store_writes_oas_history () =
            ()
        in
        let checkpoint2 =
-         make_oas_checkpoint
-           ~session_id:"trace-history"
-           ~messages:[ Agent_sdk.Types.user_msg "second" ]
-           ~created_at:1711234560.0
-           ()
+         let sidecar = Some (`Assoc [ "keeper_generation", `Int 99 ]) in
+         {
+           (make_oas_checkpoint
+              ~session_id:"trace-history"
+              ~messages:[ Agent_sdk.Types.user_msg "second" ]
+              ~created_at:1711234560.0
+              ~working_context:sidecar
+              ()) with
+           context = checkpoint_context_with_generation 7;
+         }
        in
        (match Keeper_checkpoint_store.save_oas ~session_dir checkpoint1 with
         | Ok () -> ()
@@ -5238,6 +5244,10 @@ let test_keeper_checkpoint_store_writes_oas_history () =
          | latest :: _ -> latest
          | [] -> Alcotest.fail "expected OAS snapshot history file"
        in
+       Alcotest.(check string)
+         "latest history snapshot uses canonical context generation"
+         "oas-snapshot-1711234560000-g7.json"
+         latest_snapshot_id;
        let canonical_stat =
          Unix.stat
            (Keeper_checkpoint_store.oas_checkpoint_path


### PR DESCRIPTION
## Summary
- stop reading legacy checkpoint working_context sidecars for max_tokens and generation recovery
- make OAS history snapshot generation derive from canonical checkpoint context instead of keeper_generation sidecars
- flip checkpoint tests to prove legacy sidecars are ignored/absent while canonical context generation still works

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_context_core.ml lib/keeper/keeper_checkpoint_store.ml test/test_keeper_lifecycle.ml test/test_oas_worker.ml
- opam exec -- ocamlc -stop-after parsing lib/keeper/keeper_context_core.ml lib/keeper/keeper_checkpoint_store.ml test/test_keeper_lifecycle.ml test/test_oas_worker.ml
- git diff --check origin/main...HEAD
- rg -n 'member "max_tokens"|member "generation"|List\.assoc_opt "keeper_generation"|sidecar max_tokens preserved|sidecar generation' lib/keeper test/test_keeper_lifecycle.ml test/test_oas_worker.ml

Focused Dune gap: scripts/dune-local.sh build test/test_keeper_lifecycle.exe test/test_oas_worker.exe returned exit 75 because live bare Dune processes are already running on this host.