### PR TITLE
fix(keeper): allow safe grep execute searches

### DIFF
--- a/lib/exec/exec_program.ml
+++ b/lib/exec/exec_program.ml
@@ -28,6 +28,7 @@ type known =
   | Head
   | Tail
   | Rg
+  | Grep
   | Find
   | Which
   | Test
@@ -123,6 +124,7 @@ let known_metadata : known -> known_metadata = function
   | Head -> { name = "head"; risk = `Safe; kind = `Safe_program }
   | Tail -> { name = "tail"; risk = `Safe; kind = `Safe_program }
   | Rg -> { name = "rg"; risk = `Safe; kind = `Safe_program }
+  | Grep -> { name = "grep"; risk = `Safe; kind = `Safe_program }
   | Find -> { name = "find"; risk = `Safe; kind = `Safe_program }
   | Which -> { name = "which"; risk = `Safe; kind = `Safe_program }
   | Test -> { name = "test"; risk = `Safe; kind = `Safe_program }
@@ -213,6 +215,7 @@ let all_known =
   ; Head
   ; Tail
   ; Rg
+  ; Grep
   ; Find
   ; Which
   ; Test

--- a/lib/exec/exec_program.mli
+++ b/lib/exec/exec_program.mli
@@ -48,6 +48,7 @@ type known =
   | Head
   | Tail
   | Rg
+  | Grep
   | Find
   | Which
   | Test

--- a/lib/exec/test/test_exec_types.ml
+++ b/lib/exec/test/test_exec_types.ml
@@ -33,6 +33,7 @@ let test_exec_program_of_known () =
 let test_exec_program_name_of_known () =
   assert (Exec_program.name_of_known Exec_program.Ls = "ls");
   assert (Exec_program.name_of_known Exec_program.Git = "git");
+  assert (Exec_program.name_of_known Exec_program.Grep = "grep");
   assert (Exec_program.name_of_known Exec_program.Curl = "curl");
   assert (Exec_program.name_of_known Exec_program.Rm = "rm");
   assert (Exec_program.name_of_known Exec_program.Sudo = "sudo")
@@ -41,6 +42,7 @@ let test_exec_program_name_of_known () =
 let test_exec_program_risk_of_known () =
   assert (Exec_program.risk_of_known Exec_program.Ls = `Safe);
   assert (Exec_program.risk_of_known Exec_program.Rg = `Safe);
+  assert (Exec_program.risk_of_known Exec_program.Grep = `Safe);
   assert (Exec_program.risk_of_known Exec_program.Git = `Audited);
   assert (Exec_program.risk_of_known Exec_program.Docker = `Audited);
   assert (Exec_program.risk_of_known Exec_program.Sudo = `Privileged);
@@ -86,11 +88,11 @@ let test_exec_program_unknown_is_privileged () =
   | Error _ -> assert false
 ;;
 
-let test_grep_is_not_known_exec_program () =
+let test_grep_is_known_safe_exec_program () =
   match Exec_program.of_string "grep" with
   | Ok b ->
-    assert (Exec_program.known b = None);
-    assert (Exec_program.risk_class b = `Privileged)
+    assert (Exec_program.known b = Some Exec_program.Grep);
+    assert (Exec_program.risk_class b = `Safe)
   | Error _ -> assert false
 ;;
 
@@ -225,7 +227,7 @@ let () =
   test_exec_program_known_roundtrip ();
   test_exec_program_unknown_has_no_known ();
   test_exec_program_unknown_is_privileged ();
-  test_grep_is_not_known_exec_program ();
+  test_grep_is_known_safe_exec_program ();
   test_exec_program_empty_rejected ();
   test_git_op_destructive_detection ();
   test_git_op_read ();

--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -523,6 +523,15 @@ let command_pattern_arg_flags cmd =
     ; "--type-not", false
     ; "-T", false
     ]
+  | "grep" ->
+    [ "-e", true
+    ; "--regexp", true
+    ; "-f", true
+    ; "--file", true
+    ; "--include", false
+    ; "--exclude", false
+    ; "--exclude-dir", false
+    ]
   | "sed" -> [ "-e", true; "--expression", true ]
   | "gh" ->
     [ "-R", false
@@ -631,6 +640,15 @@ let path_argument_values command_name args =
                    rest
                | None when command_name = "rg"
                            && (not rg_files_mode)
+                           && (not seen_primary_pattern)
+                           && not (rg_token_is_option_value token) ->
+                 loop
+                   ~skip_next_pattern:None
+                   ~redirect_target:false
+                   ~seen_primary_pattern:true
+                   acc
+                   rest
+               | None when command_name = "grep"
                            && (not seen_primary_pattern)
                            && not (rg_token_is_option_value token) ->
                  loop

--- a/lib/keeper/dev_exec_allowlist.ml
+++ b/lib/keeper/dev_exec_allowlist.ml
@@ -38,6 +38,7 @@ let dev_programs =
     ; Python
     ; Python3
     ; Rg
+    ; Grep
     ; Ruff
     ; Rustc
     ; Sed
@@ -72,6 +73,7 @@ let readonly_programs =
     ; Printf
     ; Pwd
     ; Rg
+    ; Grep
     ; Sed
     ; Sort
     ; Stat

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -32,6 +32,7 @@ let test_allowed_commands () =
     "git status";
     "git log --oneline -5";
     "rg 'pattern' lib/";
+    "grep -rn pattern lib --include=*.ml";
     "make test";
     "python3 script.py";
     "npm run build";

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -43,6 +43,16 @@ let cases : case list =
     ; expect_typed = true
     ; rationale = "allowlisted executable + plain argv"
     }
+  ; { name = "grep_recursive_logged_shape"
+    ; sample_cmd = "grep -rn try_acquire repos/masc-mcp/lib --include=*.ml"
+    ; typed =
+        mk_exec
+          "grep"
+          [ "-rn"; "try_acquire"; "repos/masc-mcp/lib"; "--include=*.ml" ]
+    ; expect_typed = true
+    ; rationale =
+        "safe grep search shape observed in keeper Execute logs stays allowlisted"
+    }
   ; { name = "ls_flag"
     ; sample_cmd = "ls -la"
     ; typed = mk_exec "ls" [ "-la" ]


### PR DESCRIPTION
## Summary
- add grep to the typed Exec_program registry as a safe search binary
- include grep in dev/read-only Execute allowlists so logged recursive search shapes do not fail before dispatch
- teach path validation about grep pattern/include arguments and pin the logged shape in tests

## Verification
- ocamlformat --check lib/exec/exec_program.ml lib/exec/exec_program.mli lib/keeper/dev_exec_allowlist.ml lib/exec_policy.ml lib/exec/test/test_exec_types.ml test/test_keeper_bash_safety.ml test/test_keeper_bash_typed_input.ml
- ocamlc -stop-after parsing lib/exec/exec_program.mli lib/exec/exec_program.ml lib/keeper/dev_exec_allowlist.ml lib/exec_policy.ml lib/exec/test/test_exec_types.ml test/test_keeper_bash_safety.ml test/test_keeper_bash_typed_input.ml
- git diff --check

## Local Dune
- scripts/dune-local.sh build test/test_keeper_bash_safety.exe test/test_keeper_bash_typed_input.exe lib/exec/test/test_exec_types.exe was blocked by live bare Dune processes outside the repo wrapper