### PR TITLE
fix(keeper): close workflow rejection deterministic fallback

### DIFF
--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -621,7 +621,7 @@ let maybe_emit_interesting_alert
       if retry_queued then
         (try
            Keeper_types_support.append_jsonl_line
-             (keeper_alert_retry_path ctx.config)
+             (Keeper_types_support.keeper_alert_retry_path ctx.config)
              (`Assoc [
                 ("ts", `String (now_iso ()));
                 ("ts_unix", `Float now_ts);
@@ -636,7 +636,7 @@ let maybe_emit_interesting_alert
       if deadlettered then
         (try
            Keeper_types_support.append_jsonl_line
-             (keeper_alert_deadletter_path ctx.config)
+             (Keeper_types_support.keeper_alert_deadletter_path ctx.config)
              (`Assoc [
                 ("ts", `String (now_iso ()));
                 ("ts_unix", `Float now_ts);

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -245,7 +245,9 @@ let search_history
     match
       Keeper_memory_recall.load_history_user_messages_result
         ~path:
-          (keeper_history_path config (Keeper_id.Trace_id.to_string meta.runtime.trace_id))
+          (Keeper_types_support.keeper_history_path
+             config
+             (Keeper_id.Trace_id.to_string meta.runtime.trace_id))
         ~max_n:50
     with
     | Ok msgs -> msgs
@@ -256,7 +258,7 @@ let search_history
     |> List.concat_map (fun old_trace_id ->
       match
         Keeper_memory_recall.load_history_user_messages_result
-          ~path:(keeper_history_path config old_trace_id)
+          ~path:(Keeper_types_support.keeper_history_path config old_trace_id)
           ~max_n:20
       with
       | Ok msgs -> msgs

--- a/lib/keeper/keeper_generation_lineage.ml
+++ b/lib/keeper/keeper_generation_lineage.ml
@@ -216,7 +216,7 @@ let record_handoff_artifacts
   let manifest_path =
     Keeper_types_support.keeper_generation_manifest_path config child_trace_id
   in
-  let index_path = keeper_generation_index_path config child.name in
+  let index_path = Keeper_types_support.keeper_generation_index_path config child.name in
   let manifest =
     manifest_json
       ~parent ~child ~parent_trace_id ~trigger_reason ~context_ratio
@@ -301,7 +301,7 @@ let rec take n xs =
 let surface_json (config : Coord.config) (meta : keeper_meta) ~recent_limit =
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   let manifest_path = Keeper_types_support.keeper_generation_manifest_path config trace_id in
-  let index_path = keeper_generation_index_path config meta.name in
+  let index_path = Keeper_types_support.keeper_generation_index_path config meta.name in
   let manifest = load_json_file_opt manifest_path in
   let index_entries = load_jsonl_file index_path in
   let recent =

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -278,13 +278,27 @@ let handle_keeper_list ctx args : tool_result =
                 ("meta", `String (keeper_meta_path ctx.config m.name));
                 ("metrics", `String (Dated_jsonl.base_dir metrics_store));
                 ("metrics_single_file", `String metrics_path);
-                ("memory_bank", `String (Keeper_types_support.keeper_memory_bank_path ctx.config m.name));
-                ("policy", `String (keeper_policy_log_path ctx.config m.name));
-                ("feedback", `String (keeper_feedback_log_path ctx.config m.name));
-                ("dataset_export", `String (keeper_dataset_export_path ctx.config m.name));
+                ( "memory_bank"
+                , `String (Keeper_types_support.keeper_memory_bank_path ctx.config m.name) );
+                ( "policy"
+                , `String (Keeper_types_support.keeper_policy_log_path ctx.config m.name) );
+                ( "feedback"
+                , `String (Keeper_types_support.keeper_feedback_log_path ctx.config m.name) );
+                ( "dataset_export"
+                , `String
+                    (Keeper_types_support.keeper_dataset_export_path ctx.config m.name)
+                );
                 ("session_dir", `String (keeper_session_dir ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id)));
-                ("history", `String (keeper_history_path ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id)));
-                ("history_internal", `String (keeper_internal_history_path ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id)));
+                ( "history"
+                , `String
+                    (Keeper_types_support.keeper_history_path
+                       ctx.config
+                       (Keeper_id.Trace_id.to_string m.runtime.trace_id)) );
+                ( "history_internal"
+                , `String
+                    (Keeper_types_support.keeper_internal_history_path
+                       ctx.config
+                       (Keeper_id.Trace_id.to_string m.runtime.trace_id)) );
               ]);
             ]))
         ) keeper_names

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -284,18 +284,24 @@ let handle_keeper_status ctx args : tool_result =
 
          let metrics_store = Keeper_types_support.keeper_metrics_store ctx.config m.name in
          let metrics_path = Keeper_types_support.keeper_metrics_path ctx.config m.name in
-         let memory_bank_path = Keeper_types_support.keeper_memory_bank_path ctx.config m.name in
+         let memory_bank_path =
+           Keeper_types_support.keeper_memory_bank_path ctx.config m.name
+         in
          let generation_index_path =
-           keeper_generation_index_path ctx.config m.name
+           Keeper_types_support.keeper_generation_index_path ctx.config m.name
          in
          let session_dir = keeper_session_dir ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id) in
          let generation_manifest_path =
            Keeper_types_support.keeper_generation_manifest_path ctx.config
              (Keeper_id.Trace_id.to_string m.runtime.trace_id)
          in
-         let history_path = keeper_history_path ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id) in
+         let history_path =
+           Keeper_types_support.keeper_history_path
+             ctx.config
+             (Keeper_id.Trace_id.to_string m.runtime.trace_id)
+         in
          let internal_history_path =
-           keeper_internal_history_path ctx.config
+           Keeper_types_support.keeper_internal_history_path ctx.config
              (Keeper_id.Trace_id.to_string m.runtime.trace_id)
          in
          let generation_lineage =
@@ -901,13 +907,19 @@ let handle_keeper_status ctx args : tool_result =
              ("meta", `String (keeper_meta_path ctx.config m.name));
              ("metrics", `String (Dated_jsonl.base_dir metrics_store));
              ("metrics_single_file", `String metrics_path);
-             ("memory_bank", `String memory_bank_path);
-             ("generation_index", `String generation_index_path);
-             ("decisions", `String (Keeper_types_support.keeper_decision_log_path ctx.config m.name));
-             ("policy", `String (keeper_policy_log_path ctx.config m.name));
-             ("feedback", `String (keeper_feedback_log_path ctx.config m.name));
-             ("dataset_export", `String (keeper_dataset_export_path ctx.config m.name));
-             ("session_dir", `String session_dir);
+           ("memory_bank", `String memory_bank_path);
+           ("generation_index", `String generation_index_path);
+           ( "decisions"
+           , `String (Keeper_types_support.keeper_decision_log_path ctx.config m.name) );
+           ( "policy"
+             , `String (Keeper_types_support.keeper_policy_log_path ctx.config m.name) );
+             ( "feedback"
+             , `String (Keeper_types_support.keeper_feedback_log_path ctx.config m.name) );
+           ( "dataset_export"
+           , `String
+               (Keeper_types_support.keeper_dataset_export_path ctx.config m.name)
+           );
+           ("session_dir", `String session_dir);
              ("generation_manifest", `String generation_manifest_path);
              ("history", `String history_path);
              ("history_internal", `String internal_history_path);

--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -213,14 +213,18 @@ let classify_deterministic_retry json =
     None
 ;;
 
+type workflow_rejection_classification =
+  | Workflow_rejection_absent
+  | Workflow_rejection_observed
+  | Workflow_rejection_deterministic of deterministic_reason
+
 let classify_workflow_rejection json =
   match Keeper_tools_oas_workflow.workflow_rejection_payload_of_json json with
   | Some payload
     when Keeper_tools_oas_workflow.workflow_rejection_should_skip_retry payload
-    -> Some Workflow_rejection_blocked
-  | Some _
-  | None ->
-    None
+    -> Workflow_rejection_deterministic Workflow_rejection_blocked
+  | Some _ -> Workflow_rejection_observed
+  | None -> Workflow_rejection_absent
 ;;
 
 let classify_error_code json =
@@ -285,15 +289,20 @@ let classify_with_source (json : Yojson.Safe.t) : classification option =
   (* Precedence: explicit deterministic_retry > workflow_rejection >
      path_check > error_code.
      Workflow rejection is the most specific (already routed to a
-     dedicated counter in [Keeper_tools_oas]). Path checks have their
-     own typed surface. Generic [error] codes are the legacy catch-up
-     layer and stay visible through [classification_source]. *)
+     dedicated counter in [Keeper_tools_oas]). Once observed, it must
+     not fall through to legacy [error] string fallbacks; only explicit
+     deterministic workflow markers may short-circuit retry. Path
+     checks have their own typed surface. Generic [error] codes are the
+     legacy catch-up layer and stay visible through
+     [classification_source]. *)
   match classify_deterministic_retry json with
   | Some reason -> Some { reason; source = Deterministic_retry_marker }
   | None ->
     (match classify_workflow_rejection json with
-     | Some reason -> Some { reason; source = Workflow_rejection_marker }
-     | None ->
+     | Workflow_rejection_deterministic reason ->
+       Some { reason; source = Workflow_rejection_marker }
+     | Workflow_rejection_observed -> None
+     | Workflow_rejection_absent ->
        (match classify_path_check json with
         | Some reason -> Some { reason; source = Path_check_marker }
         | None ->

--- a/test/test_keeper_bash_retry_deterministic_close.ml
+++ b/test/test_keeper_bash_retry_deterministic_close.ml
@@ -224,6 +224,16 @@ let test_workflow_rejection_failure_class_only_is_observed () =
     raw
 ;;
 
+let test_workflow_rejection_legacy_error_code_is_observed () =
+  let raw =
+    {|{"ok":false,"error":"task_state_file_probe_blocked","failure_class":"workflow_rejection"}|}
+  in
+  check_classify
+    ~name:"workflow_rejection does not fall through to legacy error code"
+    ~expected:None
+    raw
+;;
+
 let test_workflow_rejection_explicit_deterministic () =
   let raw =
     {|{"ok":false,"error":"some_rule","failure_class":"workflow_rejection","error_class":"deterministic","recoverable":false}|}
@@ -427,6 +437,10 @@ let () =
             "failure_class_only_observed"
             `Quick
             test_workflow_rejection_failure_class_only_is_observed
+        ; Alcotest.test_case
+            "legacy_error_code_observed"
+            `Quick
+            test_workflow_rejection_legacy_error_code_is_observed
         ; Alcotest.test_case
             "explicit_deterministic_top_level"
             `Quick


### PR DESCRIPTION
Summary:
- stop observed workflow_rejection payloads from falling through to legacy error-code deterministic classification
- keep explicit deterministic workflow markers and deterministic_retry markers as the only workflow rejection retry short-circuits
- qualify remaining keeper path owner calls after latest facade purge so the focused target can compile once the Dune lock clears

Validation:
- ocamlformat --check changed files
- git diff --check origin/main..HEAD
- scripts/dune-local.sh build test/test_keeper_bash_retry_deterministic_close.exe: blocked locally by live bare Dune processes / wrapper lock contention; PR CI should run the target cleanly