### PR TITLE
refactor(keeper): drop registry config resolver shim

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 13:44:46 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 13:49:15 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -202,6 +202,12 @@
             <td><span class="status done">merged #18554</span></td>
             <td>Remove the replay harness dependency on <code>Agent_sdk.Provider_runtime_binding</code> for provider canonicalization. Snapshot provider names must now be present, but the harness no longer resolves legacy provider aliases before validating the OpenAI chat-completions envelope.</td>
             <td>The stale unsupported-provider preservation test is replaced with empty-provider rejection coverage. Backstop grep is clean for the removed alias names and the replay-harness runtime-binding lookup. Local OCaml format/parse, diff, and static ratchets pass; the focused replay test is blocked by the machine-wide bare-Dune guard.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_registry_lookup.resolve_config</code> no-op shim</td>
+            <td><span class="status now">draft PR #18620</span></td>
+            <td>Delete the no-op config resolver that only preserved the removed cross-<code>base_path</code> retargeting API. Keeper tool dispatch now keeps config ownership at the caller instead of routing through a compatibility pass-through.</td>
+            <td>Remove the resolver-preservation tests and backstop with <code>rg "resolve_config" lib/keeper test/test_keeper_registry.ml</code>.</td>
           </tr>
           <tr>
             <td>Room-state <code>active_agents</code> object recovery</td>

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -35,8 +35,6 @@ Scope:
 
 Each path below must appear exactly once and use one owner from the table above.
 
-- `lib/keeper/agent_tool_board_runtime.ml` - execution-dispatch
-- `lib/keeper/agent_tool_board_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_context.ml` - execution-dispatch
 - `lib/keeper/keeper_exec_context.mli` - execution-dispatch
 - `lib/keeper/keeper_exec_memory.ml` - execution-dispatch

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -539,8 +539,7 @@ let tool_usage_of ~base_path name =
 ;;
 
 (* Lookup API (find_by_name / find_by_agent_name / find_by_id /
-   tool_usage_of_by_name / resolve_config) moved to
-   Keeper_registry_lookup.
+   tool_usage_of_by_name) moved to Keeper_registry_lookup.
 
    Tool usage persistence (tool_usage_path / flush_tool_usage /
    restore_tool_usage) moved to Keeper_registry_tool_usage_persistence;

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -377,7 +377,7 @@ val tool_usage_of : base_path:string -> string ->
 
 (* Lookup API moved to Keeper_registry_lookup:
    find_by_name / find_by_agent_name / find_by_id /
-   tool_usage_of_by_name / resolve_config. *)
+   tool_usage_of_by_name. *)
 
 (* Tool usage persistence (flush_tool_usage / restore_tool_usage /
    tool_usage_path) moved to Keeper_registry_tool_usage_persistence.

--- a/lib/keeper/keeper_registry_lookup.ml
+++ b/lib/keeper/keeper_registry_lookup.ml
@@ -37,15 +37,3 @@ let tool_usage_of_by_name name =
                       (_, (b : Keeper_types.tool_call_entry)) ->
          Int.compare b.count a.count)
 ;;
-
-let resolve_config (config : Coord_utils_backend_setup.config) keeper_name
-  : Coord_utils_backend_setup.config
-  =
-  if keeper_name = ""
-  then config
-  else
-    (* Keeper config resolution is scoped to the caller's current base_path.
-       Do not retarget requests across other base_path registries. *)
-    match Keeper_registry.get ~base_path:config.base_path keeper_name with
-    | Some _ | None -> config
-;;

--- a/lib/keeper/keeper_registry_lookup.mli
+++ b/lib/keeper/keeper_registry_lookup.mli
@@ -17,10 +17,3 @@ val find_by_id : Keeper_id.Uid.t -> registry_entry option
     call count descending. *)
 val tool_usage_of_by_name : string ->
   (string * Keeper_types.tool_call_entry) list
-
-(** Resolve config for a keeper tool dispatch.
-    Currently a no-op pass-through — the legacy fallback that
-    retargeted across base_path registries has been removed; this
-    function preserves the public API surface for callers. *)
-val resolve_config :
-  Coord_utils_backend_setup.config -> string -> Coord_utils_backend_setup.config

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 15,
   "coord_mli_missing": 2,
   "godsplit_count": 0,
-  "lib_dune_lines": 658,
+  "lib_dune_lines": 660,
   "inferred_dump_headers": 0,
   "lib_other_mli_missing": 2
 }

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1610,11 +1610,9 @@ let test_find_by_agent_name () =
   check bool "not found returns None" true
     (Option.is_none (Masc_mcp.Keeper_registry_lookup.find_by_agent_name "agent-nonexistent"))
 
-(* ── resolve_config tests ────────────────────────────────── *)
-
 module Coord_setup = Coord_utils_backend_setup
 
-(** Minimal in-memory config for testing resolve_config.
+(** Minimal in-memory config for registry tests that need Coord config shape.
     Only base_path matters; backend is a throwaway Memory instance. *)
 let make_test_config base_path : Coord_setup.config =
   let backend_config : Backend_types.config = {
@@ -1631,33 +1629,6 @@ let make_test_config base_path : Coord_setup.config =
     backend_config;
     backend = Coord_setup.Memory (Backend.Memory.create ());
   }
-
-let test_resolve_config_scoped_hit () =
-  R.clear ();
-  let _entry = R.register ~base_path:bp "rc1" (make_meta "rc1") in
-  let config = make_test_config bp in
-  let resolved = Masc_mcp.Keeper_registry_lookup.resolve_config config "rc1" in
-  check string "scoped hit keeps base_path" bp resolved.base_path
-
-let test_resolve_config_cross_base_path () =
-  R.clear ();
-  let bp2 = "/tmp/other" in
-  let _entry = R.register ~base_path:bp2 "rc2" (make_meta "rc2") in
-  let config = make_test_config bp in
-  let resolved = Masc_mcp.Keeper_registry_lookup.resolve_config config "rc2" in
-  check string "cross-base_path keeps original scope" bp resolved.base_path
-
-let test_resolve_config_not_found () =
-  R.clear ();
-  let config = make_test_config bp in
-  let resolved = Masc_mcp.Keeper_registry_lookup.resolve_config config "nonexistent" in
-  check string "unknown keeper keeps original" bp resolved.base_path
-
-let test_resolve_config_empty_name () =
-  R.clear ();
-  let config = make_test_config bp in
-  let resolved = Masc_mcp.Keeper_registry_lookup.resolve_config config "" in
-  check string "empty name keeps original" bp resolved.base_path
 
 (* ── Directive processing tests ─────────────────────────── *)
 
@@ -2571,13 +2542,6 @@ let () =
             test_meta_write_sync_updates_registered_only;
           eio_test "missing turn observation updates are silent"
             test_missing_turn_observation_updates_are_silent;
-        ] );
-      ( "resolve_config",
-        [
-          eio_test "scoped hit" test_resolve_config_scoped_hit;
-          eio_test "cross base_path" test_resolve_config_cross_base_path;
-          eio_test "not found" test_resolve_config_not_found;
-          eio_test "empty name" test_resolve_config_empty_name;
         ] );
       ( "directives",
         [


### PR DESCRIPTION
## Summary
- delete `Keeper_registry_lookup.resolve_config`, a no-op compatibility pass-through left after cross-base_path retargeting was removed
- remove tests that only preserved that no-op API
- record the purge in the legacy purge HTML ledger
- repair keeper tool-boundary matrix drift from the latest agent-tool runtime rename and regenerate the structure baseline for current main (`lib_dune_lines` 660); follow-up structural debt issue: #18623

## Verification
- `ocamlformat --check lib/keeper/keeper_registry_lookup.mli lib/keeper/keeper_registry_lookup.ml lib/keeper/keeper_registry.mli lib/keeper/keeper_registry.ml test/test_keeper_registry.ml`
- `rg -n '\\bresolve_config\\b|Keeper_registry_lookup\\.resolve_config' lib/keeper test/test_keeper_registry.ml` (no matches)\n- `git diff --check origin/main...HEAD`\n- `scripts/audit-keeper-tool-boundary-matrix.sh`\n- `scripts/ocaml-structure-ratchet.sh`\n- `scripts/lint/no-unknown-permissive-default.sh`\n- `scripts/lint/no-ocaml-comment-terminator-trap.sh`\n\n## Verification gap\n- `scripts/dune-local.sh build test/test_keeper_registry.exe` is blocked by the machine-wide bare-Dune guard (exit 75); not bypassed.