### PR TITLE
fix(dashboard): preserve runtime count authority

### DIFF
--- a/dashboard/src/namespace-truth-normalizers.test.ts
+++ b/dashboard/src/namespace-truth-normalizers.test.ts
@@ -193,6 +193,48 @@ describe('normalizeNamespaceTruth', () => {
     expect(result.root.provenance).toBe('filesystem')
   })
 
+  it('preserves runtime count authority metadata', () => {
+    const result = normalizeNamespaceTruth({
+      root: {
+        runtime_count_authority: {
+          source: 'namespace_truth_read_model',
+          authority: 'root.counts',
+          configured_authority: 'root.configured_keepers',
+          fallback_policy: 'shell_last_good_only_when_namespace_unavailable',
+          shell_arbitration_allowed: false,
+          live_total_runtimes: 3,
+          live_keepers: 2,
+          configured_keepers: 4,
+          configured_minus_live_keepers: 2,
+          count_roles: {
+            'root.counts': 'authoritative_live_snapshot',
+            'root.configured_keepers': 'authoritative_inventory',
+            shell: 'read_model_input',
+            execution: 'diagnostic_summary_only',
+          },
+        },
+      },
+    })
+
+    expect(result.root.runtime_count_authority).toEqual({
+      source: 'namespace_truth_read_model',
+      authority: 'root.counts',
+      configured_authority: 'root.configured_keepers',
+      fallback_policy: 'shell_last_good_only_when_namespace_unavailable',
+      shell_arbitration_allowed: false,
+      live_total_runtimes: 3,
+      live_keepers: 2,
+      configured_keepers: 4,
+      configured_minus_live_keepers: 2,
+      count_roles: {
+        'root.counts': 'authoritative_live_snapshot',
+        'root.configured_keepers': 'authoritative_inventory',
+        shell: 'read_model_input',
+        execution: 'diagnostic_summary_only',
+      },
+    })
+  })
+
   it('defaults root.provenance to null', () => {
     const result = normalizeNamespaceTruth({ root: {} })
     expect(result.root.provenance).toBeNull()

--- a/dashboard/src/namespace-truth-normalizers.ts
+++ b/dashboard/src/namespace-truth-normalizers.ts
@@ -17,6 +17,7 @@ import type {
   DashboardReadinessSummary,
   DashboardNamespaceTruthRecommendationSummary,
   DashboardNamespaceTruthResponse,
+  DashboardRuntimeCountAuthority,
 } from './types'
 
 // normalizePendingConfirmSummary imported from pending-confirm.ts (SSOT)
@@ -132,6 +133,32 @@ function normalizeReadiness(raw: unknown): DashboardReadinessSummary | null {
   }
 }
 
+function normalizeRuntimeCountAuthority(raw: unknown): DashboardRuntimeCountAuthority | undefined {
+  if (!isRecord(raw)) return undefined
+  const countRoles = isRecord(raw.count_roles)
+    ? Object.fromEntries(
+        Object.entries(raw.count_roles)
+          .map(([key, value]) => {
+            const text = asString(value)
+            return text ? [key, text] : null
+          })
+          .filter((entry): entry is [string, string] => entry !== null),
+      )
+    : undefined
+  return {
+    source: asString(raw.source),
+    authority: asString(raw.authority),
+    configured_authority: asString(raw.configured_authority),
+    fallback_policy: asString(raw.fallback_policy),
+    shell_arbitration_allowed: asBoolean(raw.shell_arbitration_allowed),
+    live_total_runtimes: asNumber(raw.live_total_runtimes),
+    live_keepers: asNumber(raw.live_keepers),
+    configured_keepers: asNumber(raw.configured_keepers),
+    configured_minus_live_keepers: asNumber(raw.configured_minus_live_keepers),
+    count_roles: countRoles,
+  }
+}
+
 function normalizeAttentionEvent(raw: unknown): DashboardAttentionEvent | null {
   if (!isRecord(raw)) return null
   const severity = asString(raw.severity)
@@ -187,6 +214,7 @@ export function normalizeNamespaceTruth(raw: unknown): DashboardNamespaceTruthRe
           }
         : undefined,
       configured_keepers: asNumber(namespaceBlock.configured_keepers),
+      runtime_count_authority: normalizeRuntimeCountAuthority(namespaceBlock.runtime_count_authority),
       provenance: asString(namespaceBlock.provenance) ?? null,
     },
     execution: {

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -65,6 +65,21 @@ describe('resolveRuntimeCounts', () => {
     })
   })
 
+  it('keeps namespace zero counts authoritative over stale shell counts', () => {
+    expect(resolveRuntimeCounts({
+      executionLoaded: false,
+      agentsCount: 0,
+      keepersCount: 0,
+      namespaceTruthCounts: { agents: 0, keepers: 0, tasks: 0, total_runtimes: 0 },
+      shellCounts: { agents: 3, keepers: 2, tasks: 9, total_runtimes: 5 },
+      shellConfiguredKeepers: 2,
+    })).toEqual({
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      configured: { keepers: 0, totalRuntimes: 0, source: 'namespace-truth' },
+      source: 'project-snapshot',
+    })
+  })
+
   it('exposes both live and configured views simultaneously when execution has hydrated', () => {
     expect(resolveRuntimeCounts({
       executionLoaded: true,

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -64,12 +64,14 @@ function normalizeCounts(
 }
 
 function resolveConfiguredView({
+  namespaceCountsAvailable,
   namespaceTotalRuntimes,
   namespaceKeepers,
   namespaceConfiguredKeepers,
   shellTotalRuntimes,
   shellConfiguredKeepers,
 }: {
+  namespaceCountsAvailable: boolean
   namespaceTotalRuntimes: number
   namespaceKeepers: number
   namespaceConfiguredKeepers: number | null
@@ -83,7 +85,7 @@ function resolveConfiguredView({
       source: 'namespace-truth',
     }
   }
-  if (namespaceTotalRuntimes > 0) {
+  if (namespaceCountsAvailable) {
     return {
       keepers: namespaceKeepers,
       totalRuntimes: namespaceTotalRuntimes,
@@ -150,6 +152,7 @@ export function resolveRuntimeCounts({
     shellConfiguredKeepers != null ? normalizeCount(shellConfiguredKeepers) : null
 
   const configured = resolveConfiguredView({
+    namespaceCountsAvailable: namespace !== null,
     namespaceTotalRuntimes: namespace?.totalRuntimes ?? 0,
     namespaceKeepers: namespace?.keepers ?? 0,
     namespaceConfiguredKeepers,

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -392,6 +392,19 @@ export interface DashboardNamespaceTruthRetention {
   cache_policy?: string
 }
 
+export interface DashboardRuntimeCountAuthority {
+  source?: string
+  authority?: string
+  configured_authority?: string
+  fallback_policy?: string
+  shell_arbitration_allowed?: boolean
+  live_total_runtimes?: number
+  live_keepers?: number
+  configured_keepers?: number
+  configured_minus_live_keepers?: number
+  count_roles?: Record<string, string>
+}
+
 export interface DashboardNamespaceTruthResponse {
   generated_at?: string
   generated_at_iso?: string
@@ -403,6 +416,7 @@ export interface DashboardNamespaceTruthResponse {
     status?: ServerStatus | null
     counts?: DashboardShellResponse['counts']
     configured_keepers?: number
+    runtime_count_authority?: DashboardRuntimeCountAuthority
     provenance?: string | null
   }
   execution?: {


### PR DESCRIPTION
## Summary

- Preserve `root.runtime_count_authority` from namespace-truth responses in dashboard types and normalization.
- Treat namespace-truth zero runtime counts as authoritative, so stale shell counts cannot revive active runtime totals when namespace truth explicitly says zero.

## Product impact

- Dashboard runtime count labels keep active runtime truth and configured inventory distinct during cold start and stale shell fallback.
- Operators no longer see stale shell runtime totals override a namespace-truth zero-count snapshot.

## Report mapping

- Addresses `GOAL-SSOT-01`: runtime count roles stay single-sourced as `root.counts` for active runtime truth and `root.configured_keepers` for configured inventory.
- Keeps shell counts as fallback-only input when namespace truth is unavailable.

## Evidence

- `git diff --check`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run src/runtime-counts.test.ts src/namespace-truth-normalizers.test.ts`

## Review evidence

- Focused dashboard tests cover namespace zero-count authority over stale shell counts.
- Normalizer tests cover preservation of `runtime_count_authority` fields and count role metadata.

## Linked issue

- Report-backed follow-up: `GOAL-SSOT-01` from `masc_oas_통합_분석_보고서.docx`.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 3/3
provenance: direct
report_item: GOAL-SSOT-01
changed_files:
  - dashboard/src/runtime-counts.ts
  - dashboard/src/runtime-counts.test.ts
  - dashboard/src/namespace-truth-normalizers.ts
  - dashboard/src/namespace-truth-normalizers.test.ts
  - dashboard/src/types/dashboard-execution.ts
authority_contract:
  active_runtime_truth: root.counts
  configured_inventory: root.configured_keepers
  shell_policy: fallback_only_when_namespace_truth_unavailable
local_checks:
  - command: git diff --check
    result: pass
  - command: pnpm --dir dashboard exec tsc --noEmit --pretty
    result: pass
  - command: pnpm --dir dashboard exec vitest run src/runtime-counts.test.ts src/namespace-truth-normalizers.test.ts
    result: pass
```

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/runtime-count-authority-normalizer-20260526` → `main` · 1 commit(s) · synced 2026-05-26T04:59:03Z

| sha | subject | date |
|---|---|---|
| `e2455bbbe` | fix(dashboard): preserve runtime count authority | 2026-05-26 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->