### PR TITLE
refactor(keeper): reject flat message content rows

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 13:53:33 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 14:02:44 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -570,6 +570,12 @@
             <td>Tests now cover canonical blocks and negative old-row behavior. Heavy CI still has long-running checks in progress as of this snapshot.</td>
           </tr>
           <tr>
+            <td>Message JSON flat-content decode fallback</td>
+            <td><span class="status now">draft PR #18630</span></td>
+            <td>Close the leftover direct <code>message_of_json</code> path that still accepted flat legacy <code>content</code> rows by turning them into empty or downgraded messages.</td>
+            <td><code>message_of_json</code> now raises on missing/invalid <code>content_blocks</code>. Tests assert canonical rows still decode and flat legacy tool rows are rejected.</td>
+          </tr>
+          <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
             <td><span class="status done">merged #18369</span></td>
             <td>Remove <code>ckpt-*.json</code> recovery, checkpoint writer/reader public APIs, state-snapshot sidecar hydration, migration wording, and obsolete fallback tests.</td>
@@ -611,8 +617,8 @@
           <tr>
             <td>P1</td>
             <td>Memory/context legacy read fallbacks</td>
-            <td>Fallback readers such as legacy content arrays and dated-store fallback hide whether current writers are clean. Checkpoint sidecar runtime readers were removed in #18622.</td>
-            <td>Split into runtime-data migration and code deletion. Delete read fallback after migration proof or if runtime reset is acceptable; do not preserve legacy checkpoint sidecar behavior.</td>
+            <td>Remaining dated-store and old-row fallback readers hide whether current writers are clean. Checkpoint sidecar runtime readers were removed in #18622; direct flat message-content decode is in-flight in #18630.</td>
+            <td>Split into runtime-data migration and code deletion. Delete read fallback after migration proof or if runtime reset is acceptable; do not preserve legacy checkpoint sidecar or flat-content behavior.</td>
             <td>Remove tests that require old-row readability. Keep corruption/drop tests only for current schema.</td>
           </tr>
           <tr>

--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -93,7 +93,8 @@ let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
   let content =
     match content_blocks_of_json json with
     | Some blocks -> blocks
-    | None -> []
+    | None ->
+        invalid_arg "keeper_context_core: missing or invalid content_blocks"
   in
   Inference_utils.sanitize_message_utf8
     {

--- a/lib/keeper/keeper_context_core_message_json.mli
+++ b/lib/keeper/keeper_context_core_message_json.mli
@@ -10,5 +10,9 @@ val content_blocks_of_json :
 val string_field_opt : string -> string option -> (string * Yojson.Safe.t) list
 val metadata_of_json : Yojson.Safe.t -> (string * Yojson.Safe.t) list
 val message_to_json : Agent_sdk.Types.message -> Yojson.Safe.t
+
+(** Decode a persisted keeper message. Only canonical [content_blocks] are
+    accepted; flat legacy [content] rows raise [Invalid_argument]. *)
 val message_of_json : Yojson.Safe.t -> Agent_sdk.Types.message
+
 val text_of_history_jsonl_json : Yojson.Safe.t -> string

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -64,6 +64,20 @@ let test_message_of_json_rejects_unknown_role () =
     (Invalid_argument "keeper_context_core: unknown role \"operator\"")
     (fun () -> C.message_of_json json |> ignore)
 
+let test_message_of_json_rejects_flat_content () =
+  let json : Yojson.Safe.t =
+    `Assoc
+      [
+        ("role", `String "tool");
+        ("content", `String "legacy tool output");
+        ("tool_call_id", `String "call_old");
+      ]
+  in
+  Alcotest.check_raises
+    "flat content rejected"
+    (Invalid_argument "keeper_context_core: missing or invalid content_blocks")
+    (fun () -> C.message_of_json json |> ignore)
+
 (* --- text_of_history_jsonl_json --- *)
 
 let test_history_jsonl_text_uses_blocks_first () =
@@ -171,6 +185,8 @@ let () =
             test_message_of_json_new_content_blocks_only;
           Alcotest.test_case "unknown role rejected" `Quick
             test_message_of_json_rejects_unknown_role;
+          Alcotest.test_case "flat legacy content rejected" `Quick
+            test_message_of_json_rejects_flat_content;
           Alcotest.test_case "round-trip text preserved" `Quick
             test_roundtrip_text_preserved;
         ] );

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -5355,7 +5355,7 @@ let test_keeper_checkpoint_ignores_legacy_shadow_without_oas () =
          (Option.is_none loaded_opt))
 ;;
 
-let test_keeper_checkpoint_legacy_old_tool_messages_degrade_to_text () =
+let test_keeper_checkpoint_legacy_old_tool_messages_are_rejected () =
   let json =
     `Assoc
       [ "role", `String "tool"
@@ -5363,12 +5363,10 @@ let test_keeper_checkpoint_legacy_old_tool_messages_degrade_to_text () =
       ; "tool_call_id", `String "call_old"
       ]
   in
-  match Masc_mcp.Keeper_exec_context.message_of_json json with
-  | { Agent_sdk.Types.role = Agent_sdk.Types.Tool
-    ; content = [ Agent_sdk.Types.Text text ]
-    ; _
-    } -> Alcotest.(check string) "legacy tool text preserved" "legacy tool output" text
-  | _ -> Alcotest.fail "expected legacy tool message to degrade to plain text"
+  Alcotest.check_raises
+    "legacy tool content rejected"
+    (Invalid_argument "keeper_context_core: missing or invalid content_blocks")
+    (fun () -> Masc_mcp.Keeper_exec_context.message_of_json json |> ignore)
 ;;
 
 let test_keeper_oas_handoff_rollover_increments_generation () =
@@ -6454,9 +6452,9 @@ let () =
             `Quick
             test_keeper_checkpoint_ignores_legacy_shadow_without_oas
         ; Alcotest.test_case
-            "legacy old tool messages degrade to text"
+            "legacy old tool messages are rejected"
             `Quick
-            test_keeper_checkpoint_legacy_old_tool_messages_degrade_to_text
+            test_keeper_checkpoint_legacy_old_tool_messages_are_rejected
         ; Alcotest.test_case
             "OAS handoff rollover increments generation"
             `Quick
@@ -6496,9 +6494,9 @@ let () =
             `Quick
             test_keeper_checkpoint_ignores_legacy_shadow_without_oas
         ; Alcotest.test_case
-            "legacy old tool messages degrade to text"
+            "legacy old tool messages are rejected"
             `Quick
-            test_keeper_checkpoint_legacy_old_tool_messages_degrade_to_text
+            test_keeper_checkpoint_legacy_old_tool_messages_are_rejected
         ; Alcotest.test_case
             "OAS handoff rollover increments generation"
             `Quick


### PR DESCRIPTION
## Summary
- make keeper message JSON decoding fail closed when canonical content_blocks are missing or invalid
- replace the legacy flat tool-content preservation test with rejection coverage
- update the legacy purge ledger and remaining memory/context queue

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_context_core_message_json.ml lib/keeper/keeper_context_core_message_json.mli test/test_keeper_context_core_dedup.ml test/test_oas_worker.ml
- opam exec -- ocamlc -stop-after parsing lib/keeper/keeper_context_core_message_json.ml lib/keeper/keeper_context_core_message_json.mli test/test_keeper_context_core_dedup.ml test/test_oas_worker.ml
- git diff --check origin/main...HEAD
- rg -n 'legacy old tool messages degrade|degrade to text|legacy tool text preserved|expected legacy tool message|flat legacy content rejected|missing or invalid content_blocks' lib/keeper test/test_keeper_context_core_dedup.ml test/test_oas_worker.ml

Focused Dune gap: scripts/dune-local.sh build test/test_keeper_context_core_dedup.exe test/test_oas_worker.exe returned exit 75 because live bare Dune processes are already running on this host.