### PR TITLE
fix(keeper): clarify sandbox clone conflict recovery

### DIFF
--- a/lib/coord/coord_worktree_sandbox_clone.ml
+++ b/lib/coord/coord_worktree_sandbox_clone.ml
@@ -187,8 +187,11 @@ let auto_provision_sandbox_clone ~config ~agent_name ~repos_dir ~repo_name =
             (System (System_error.IoError
                (Printf.sprintf
                   "sandbox_clone_conflict: %s already exists under %s but is not \
-                   a git clone. Remove or repair it before continuing."
-                  repo_name repos_dir)))
+                   a git clone. This is an operator repair condition: stop \
+                   retrying, ask the operator to repair or replace repos/%s, \
+                   then call masc_worktree_create again. Do not try shell \
+                   cleanup from the keeper."
+                  repo_name repos_dir repo_name)))
       else
         (match Coord_worktree_repo_discovery.git_origin_url source_root with
          | None ->

--- a/test/test_sandbox_clone_conflict.ml
+++ b/test/test_sandbox_clone_conflict.ml
@@ -79,7 +79,14 @@ let test_auto_provision_rejects_plain_dir_clone_conflict () =
   | Error (Masc_domain.System (Masc_domain.System_error.IoError msg)) ->
       check_contains "message mentions sandbox_clone_conflict"
         "sandbox_clone_conflict" msg;
-      check_contains "message mentions not a git clone" "not a git clone" msg
+      check_contains "message mentions not a git clone" "not a git clone" msg;
+      check_contains "message routes to operator repair"
+        "operator repair condition" msg;
+      check_contains "message says stop retrying" "stop retrying" msg;
+      check_contains "message blocks keeper shell cleanup"
+        "Do not try shell cleanup from the keeper" msg;
+      check bool "message no longer says Remove or repair" false
+        (contains msg "Remove or repair")
   | Error err ->
       fail (Printf.sprintf "expected IoError, got: %s" (Masc_domain.masc_error_to_string err))
 


### PR DESCRIPTION
## Summary
- change sandbox clone conflict recovery from vague remove/repair wording to an operator-repair stop condition
- explicitly tell keepers not to try shell cleanup from the keeper after this deterministic conflict
- pin the recovery wording so it does not steer future runs toward disallowed rm-style Execute attempts

## Verification
- ocamlformat --check lib/coord/coord_worktree_sandbox_clone.ml test/test_sandbox_clone_conflict.ml
- ocamlc -stop-after parsing lib/coord/coord_worktree_sandbox_clone.ml test/test_sandbox_clone_conflict.ml
- git diff --check

## Local Dune
- scripts/dune-local.sh build test/test_sandbox_clone_conflict.exe was blocked by live bare Dune processes outside scripts/dune-local.sh