### PR TITLE
fix(keeper): honor typed retryability in deterministic classifier

### DIFF
--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -19,6 +19,7 @@ type classification_source =
   | Deterministic_retry_marker
   | Workflow_rejection_marker
   | Path_check_marker
+  | Retryability_marker
   | Legacy_error_code
   | Git_exit_128
 
@@ -31,6 +32,7 @@ let classification_source_to_string = function
   | Deterministic_retry_marker -> "deterministic_retry_marker"
   | Workflow_rejection_marker -> "workflow_rejection_marker"
   | Path_check_marker -> "path_check_marker"
+  | Retryability_marker -> "retryability_marker"
   | Legacy_error_code -> "legacy_error_code"
   | Git_exit_128 -> "git_exit_128"
 ;;
@@ -233,6 +235,21 @@ let classify_error_code json =
   | None -> None
 ;;
 
+type retryability_classification =
+  | Retryability_absent
+  | Retryability_observed
+  | Retryability_deterministic of deterministic_reason
+
+let classify_retryability json =
+  match error_or_detail_string "retryability" json, classify_error_code json with
+  | Some ("self_correct" | "operator_required"), Some reason ->
+    Retryability_deterministic reason
+  | Some _, Some _ -> Retryability_observed
+  | Some _, None
+  | None, _ ->
+    Retryability_absent
+;;
+
 let classify_git_exit_128 json =
   match assoc_int_opt "exit_code" json with
   | Some 128 ->
@@ -287,13 +304,16 @@ let classify_path_check json =
 
 let classify_with_source (json : Yojson.Safe.t) : classification option =
   (* Precedence: explicit deterministic_retry > workflow_rejection >
-     path_check > error_code.
+     path_check > retryability > error_code.
      Workflow rejection is the most specific (already routed to a
      dedicated counter in [Keeper_tools_oas]). Once observed, it must
      not fall through to legacy [error] string fallbacks; only explicit
      deterministic workflow markers may short-circuit retry. Path
-     checks have their own typed surface. Generic [error] codes are the
-     legacy catch-up layer and stay visible through
+     checks have their own typed surface. Exec_core blocked results can
+     carry a typed [retryability] marker; once present, it decides
+     whether replaying the same arguments should short-circuit rather
+     than falling back to legacy [error] strings. Generic [error] codes
+     are the legacy catch-up layer and stay visible through
      [classification_source]. *)
   match classify_deterministic_retry json with
   | Some reason -> Some { reason; source = Deterministic_retry_marker }
@@ -306,12 +326,17 @@ let classify_with_source (json : Yojson.Safe.t) : classification option =
        (match classify_path_check json with
         | Some reason -> Some { reason; source = Path_check_marker }
         | None ->
-          (match classify_error_code json with
-           | Some reason -> Some { reason; source = Legacy_error_code }
-           | None ->
-             (match classify_git_exit_128 json with
-              | Some reason -> Some { reason; source = Git_exit_128 }
-              | None -> None))))
+          (match classify_retryability json with
+           | Retryability_deterministic reason ->
+             Some { reason; source = Retryability_marker }
+           | Retryability_observed -> None
+           | Retryability_absent ->
+             (match classify_error_code json with
+              | Some reason -> Some { reason; source = Legacy_error_code }
+              | None ->
+                (match classify_git_exit_128 json with
+                 | Some reason -> Some { reason; source = Git_exit_128 }
+                 | None -> None)))))
 ;;
 
 let classify (json : Yojson.Safe.t) : deterministic_reason option =

--- a/lib/keeper/keeper_tool_deterministic_error.mli
+++ b/lib/keeper/keeper_tool_deterministic_error.mli
@@ -66,6 +66,8 @@ type classification_source =
       (** Workflow rejection carried deterministic/unrecoverable typed fields. *)
   | Path_check_marker
       (** Path-check surface carried a closed typed reason. *)
+  | Retryability_marker
+      (** Exec_core blocked-result retryability carried the same-args boundary. *)
   | Legacy_error_code
       (** Legacy [error] code fallback. Kept visible so it can be retired. *)
   | Git_exit_128

--- a/test/test_keeper_bash_retry_deterministic_close.ml
+++ b/test/test_keeper_bash_retry_deterministic_close.ml
@@ -165,6 +165,27 @@ let test_legacy_error_code_reports_source () =
     raw
 ;;
 
+let test_retryability_marker_reports_source () =
+  let raw =
+    {|{"ok":false,"error":"command_blocked","retryability":"self_correct","reason":"Shell injection syntax blocked"}|}
+  in
+  check_classify_source
+    ~name:"retryability marker source"
+    ~expected_reason:D.Command_blocked
+    ~expected_source:D.Retryability_marker
+    raw
+;;
+
+let test_retryability_none_does_not_fall_through_to_legacy_error_code () =
+  let raw =
+    {|{"ok":false,"error":"command_blocked","retryability":"none","reason":"already classified non-retryable"}|}
+  in
+  check_classify
+    ~name:"retryability=none blocks legacy error-code fallback"
+    ~expected:None
+    raw
+;;
+
 let test_unknown_typed_deterministic_retry_marker_observes () =
   let raw =
     {|{"ok":false,"error":"timeout","deterministic_retry":{"reason":"new_reason","retry_same_args":false}}|}
@@ -263,6 +284,17 @@ let test_git_diff_no_merge_base_is_deterministic () =
   check_classify
     ~name:"git diff no merge base"
     ~expected:(Some D.Git_ref_precondition_failed)
+    raw
+;;
+
+let test_git_diff_no_merge_base_with_retryability_none_is_deterministic () =
+  let raw =
+    {|{"status":"error","exit_code":128,"retryability":"none","output":"fatal: main...keeper-verifier-agent/task-259: no merge base\n","command":"git diff main...keeper-verifier-agent/task-259","agent":"keeper-verifier-agent"}|}
+  in
+  check_classify_source
+    ~name:"git diff no merge base with retryability none"
+    ~expected_reason:D.Git_ref_precondition_failed
+    ~expected_source:D.Git_exit_128
     raw
 ;;
 
@@ -413,6 +445,14 @@ let () =
             `Quick
             test_legacy_error_code_reports_source
         ; Alcotest.test_case
+            "retryability_marker_reports_source"
+            `Quick
+            test_retryability_marker_reports_source
+        ; Alcotest.test_case
+            "retryability_none_blocks_legacy_error_code"
+            `Quick
+            test_retryability_none_does_not_fall_through_to_legacy_error_code
+        ; Alcotest.test_case
             "unknown_typed_deterministic_retry_marker_observes"
             `Quick
             test_unknown_typed_deterministic_retry_marker_observes
@@ -459,6 +499,10 @@ let () =
             "git_diff_unknown_revision"
             `Quick
             test_git_diff_unknown_revision_is_deterministic
+        ; Alcotest.test_case
+            "git_diff_no_merge_base_with_retryability_none"
+            `Quick
+            test_git_diff_no_merge_base_with_retryability_none_is_deterministic
         ; Alcotest.test_case
             "git_unrecognized_argument"
             `Quick


### PR DESCRIPTION
Summary:
- classify Exec_core blocked results through typed retryability before legacy error-code fallback
- prevent retryability=none/unknown with known legacy error codes from falling through to deterministic legacy classification
- preserve git exit-128 precondition fallback even when executed-result retryability=none is present

Validation:
- ocamlformat --check changed files
- git diff --check origin/main..HEAD
- scripts/dune-local.sh build test/test_keeper_bash_retry_deterministic_close.exe: blocked locally by live bare Dune processes bypassing the wrapper