### PR TITLE
fix(keeper): smooth stale claims and find handling

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -489,6 +489,7 @@ let emit_of_simple buf spec =
     \            | Exec_program.Echo\n\
     \            | Exec_program.Head\n\
     \            | Exec_program.Tail\n\
+    \            | Exec_program.Grep\n\
     \            | Exec_program.Find\n\
     \            | Exec_program.Which\n\
     \            | Exec_program.Test\n\

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -776,6 +776,18 @@ let claim_next config ~agent_name =
 let release_stale_claims config ~ttl_seconds =
   ensure_initialized config;
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
+  let transient_lock_contention = function
+    | System system_err -> (
+      match system_err with
+      | System_error.IoError msg ->
+        String_util.contains_substring msg "transient contention"
+        && String_util.contains_substring msg "Failed to acquire distributed lock"
+      | NotInitialized | AlreadyInitialized | InvalidJson _ | InvalidFilePath _
+      | StorageError _ | ValidationError _ | WorktreeNotFound _ ->
+        false)
+    | Task _ | Agent _ | Auth _ | Portal _ | RateLimitExceeded _ | CacheError _ ->
+      false
+  in
   let release_under_lock () =
     match read_backlog_r config with
     | Error msg ->
@@ -865,6 +877,11 @@ let release_stale_claims config ~ttl_seconds =
   in
   match with_file_lock_r config backlog_path release_under_lock with
   | Ok released -> released
+  | Error err when transient_lock_contention err ->
+    Log.Orchestrator.debug
+      "[stale-claims] skipped best-effort sweep due to transient lock contention: %s"
+      (Masc_domain.masc_error_to_string err);
+    []
   | Error err ->
     Log.Orchestrator.warn
       "[stale-claims] skipping backlog mutation due to lock failure: %s"

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -288,7 +288,11 @@ let handle_keeper_list ctx args : tool_result =
                 , `String
                     (Keeper_types_support.keeper_dataset_export_path ctx.config m.name)
                 );
-                ("session_dir", `String (keeper_session_dir ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id)));
+                ( "session_dir"
+                , `String
+                    (Keeper_types_support.keeper_session_dir
+                       ctx.config
+                       (Keeper_id.Trace_id.to_string m.runtime.trace_id)) );
                 ( "history"
                 , `String
                     (Keeper_types_support.keeper_history_path

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -290,7 +290,11 @@ let handle_keeper_status ctx args : tool_result =
          let generation_index_path =
            Keeper_types_support.keeper_generation_index_path ctx.config m.name
          in
-         let session_dir = keeper_session_dir ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id) in
+         let session_dir =
+           Keeper_types_support.keeper_session_dir
+             ctx.config
+             (Keeper_id.Trace_id.to_string m.runtime.trace_id)
+         in
          let generation_manifest_path =
            Keeper_types_support.keeper_generation_manifest_path ctx.config
              (Keeper_id.Trace_id.to_string m.runtime.trace_id)

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -173,10 +173,44 @@ let parse_pipeline ~path (json : Yojson.Safe.t) =
 
 let normalize_stage { executable; argv } =
   let executable = String.trim executable in
-  match executable, argv with
-  | "", first :: rest when not (String.equal (String.trim first) "") ->
-    { executable = String.trim first; argv = rest }
-  | _ -> { executable; argv }
+  let stage =
+    match executable, argv with
+    | "", first :: rest when not (String.equal (String.trim first) "") ->
+      { executable = String.trim first; argv = rest }
+    | _ -> { executable; argv }
+  in
+  let executable = stage.executable in
+  let argv =
+    let is_find_executable name =
+      String.equal (Filename.basename (String.trim name)) "find"
+    in
+    let is_find_global_option = function
+      | "-E" | "-H" | "-L" | "-P" | "-X" | "-d" | "-s" | "-x" -> true
+      | _ -> false
+    in
+    let is_find_expression_start = function
+      | "!" | "(" | "-and" | "-or" | "-not" | "-name" | "-iname" | "-path"
+      | "-ipath" | "-regex" | "-iregex" | "-type" | "-empty" | "-perm"
+      | "-user" | "-group" | "-size" | "-mtime" | "-mmin" | "-newer"
+      | "-maxdepth" | "-mindepth" | "-prune" | "-print" | "-print0" ->
+        true
+      | _ -> false
+    in
+    let normalize_find_argv argv =
+      let rec split_global_options acc = function
+        | option :: rest when is_find_global_option option ->
+          split_global_options (option :: acc) rest
+        | rest -> List.rev acc, rest
+      in
+      let global_options, rest = split_global_options [] argv in
+      match rest with
+      | first :: _ when is_find_expression_start first ->
+        global_options @ ("." :: rest)
+      | _ -> argv
+    in
+    if is_find_executable executable then normalize_find_argv stage.argv else stage.argv
+  in
+  { executable; argv }
 ;;
 
 let of_json (json : Yojson.Safe.t) =

--- a/lib/keeper/keeper_tool_bash_input.mli
+++ b/lib/keeper/keeper_tool_bash_input.mli
@@ -18,6 +18,9 @@
       shell operators.  For example, the typed schema accepts
       [find . -name *.ml] because [*.ml] is a [find]-internal pattern,
       not a shell glob.
+    - **Portable find default path**.  Compatibility normalization rewrites
+      [find -type f] style calls to [find . -type f].  GNU find accepts the
+      missing path, but BSD/macOS find reports [illegal option -- t].
     - **Pipelines are explicit**.  [Pipeline.stages] enumerates each
       [exec_stage] separately; [|]-delimited strings are never parsed.
     - **Forbidden in argv tokens**: only control characters that

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -145,6 +145,7 @@ let make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_con
     Runs Coord.cleanup_zombies and logs if zombies were found. *)
 let make_zero_zombie_consumer ~sw ~room_config
     : (module Pulse.Consumer) =
+  let cleanup_running = Atomic.make false in
   (module struct
     let name = "zero-zombie-cleanup"
     let should_act _beat = true
@@ -185,50 +186,58 @@ let make_zero_zombie_consumer ~sw ~room_config
         | [] -> Stale_claim_outcome.Empty
         | released -> Stale_claim_outcome.Released released
       in
-      Eio.Fiber.fork ~sw (fun () ->
-        try
-          let zombie_result = Coord.cleanup_zombies room_config in
-          (* Explicit variant match — no catch-all.  Adding a new
-             [cleanup_zombie_result] constructor must surface as a
-             compile error here, not a silent debug. *)
-          (match zombie_result with
-           | Coord.Cleaned { count = 0; _ } ->
-               Log.Orchestrator.debug "[zombie] no zombies to clean"
-           | Coord.Cleaned { count; names; _ } ->
-               let status =
-                 Printf.sprintf "Cleaned up %d zombie agent(s): %s"
-                   count (String.concat ", " names)
-               in
-               Log.Orchestrator.info "[zombie] %s" status
-           | Coord.No_zombies ->
-               Log.Orchestrator.debug "[zombie] no zombies to clean"
-           | Coord.No_agents_dir ->
-               (* Misconfiguration signal: room has no agents/ directory.
-                  Distinct from No_zombies — operators should know GC
-                  ran against a missing target. *)
-               Log.Orchestrator.warn
-                 "[zombie] skipped: agents directory missing for room");
-          (match release_stale_claims_typed () with
-           | Stale_claim_outcome.Empty ->
-               Log.Orchestrator.debug "[stale-claims] no stale claims to release"
-           | Stale_claim_outcome.Released released ->
-               Log.Orchestrator.info "[stale-claims] released %d stale task(s): %s"
-                 (List.length released)
-                 (String.concat ", " (List.map (fun (tid, agent) ->
-                   Printf.sprintf "%s(%s)" tid agent) released))
-           | Stale_claim_outcome.Failed { benign = true; reason } ->
-               (* Same policy as zombie-loop benign-error filter:
-                  startup FS races / MASC-not-initialized should not
-                  page operators. *)
-               Log.Orchestrator.debug "[stale-claims] benign: %s" reason
-           | Stale_claim_outcome.Failed { benign = false; reason } ->
-               (* Real failure — not silent.  Promoted from .warn to
-                  .error so it surfaces past the default WARN→DEBUG
-                  demote of repeated lines. *)
-               Log.Orchestrator.error "[stale-claims] non-benign failure: %s" reason)
-        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-          if not (Coord_resilience.ZeroZombie.is_benign_error exn) then
-            Log.Orchestrator.warn "[zombie] error: %s" (Printexc.to_string exn));
+      if not (Atomic.compare_and_set cleanup_running false true)
+      then Log.Orchestrator.debug "[zombie] cleanup already running; skipping beat"
+      else
+        Eio.Fiber.fork ~sw (fun () ->
+          Fun.protect
+            ~finally:(fun () -> Atomic.set cleanup_running false)
+            (fun () ->
+              try
+                let zombie_result = Coord.cleanup_zombies room_config in
+                (* Explicit variant match — no catch-all.  Adding a new
+                   [cleanup_zombie_result] constructor must surface as a
+                   compile error here, not a silent debug. *)
+                (match zombie_result with
+                 | Coord.Cleaned { count = 0; _ } ->
+                     Log.Orchestrator.debug "[zombie] no zombies to clean"
+                 | Coord.Cleaned { count; names; _ } ->
+                     let status =
+                       Printf.sprintf "Cleaned up %d zombie agent(s): %s"
+                         count (String.concat ", " names)
+                     in
+                     Log.Orchestrator.info "[zombie] %s" status
+                 | Coord.No_zombies ->
+                     Log.Orchestrator.debug "[zombie] no zombies to clean"
+                 | Coord.No_agents_dir ->
+                     (* Misconfiguration signal: room has no agents/ directory.
+                        Distinct from No_zombies — operators should know GC
+                        ran against a missing target. *)
+                     Log.Orchestrator.warn
+                       "[zombie] skipped: agents directory missing for room");
+                (match release_stale_claims_typed () with
+                 | Stale_claim_outcome.Empty ->
+                     Log.Orchestrator.debug "[stale-claims] no stale claims to release"
+                 | Stale_claim_outcome.Released released ->
+                     Log.Orchestrator.info "[stale-claims] released %d stale task(s): %s"
+                       (List.length released)
+                       (String.concat ", " (List.map (fun (tid, agent) ->
+                         Printf.sprintf "%s(%s)" tid agent) released))
+                 | Stale_claim_outcome.Failed { benign = true; reason } ->
+                     (* Same policy as zombie-loop benign-error filter:
+                        startup FS races / MASC-not-initialized should not
+                        page operators. *)
+                     Log.Orchestrator.debug "[stale-claims] benign: %s" reason
+                 | Stale_claim_outcome.Failed { benign = false; reason } ->
+                     (* Real failure — not silent.  Promoted from .warn to
+                        .error so it surfaces past the default WARN→DEBUG
+                        demote of repeated lines. *)
+                     Log.Orchestrator.error
+                       "[stale-claims] non-benign failure: %s"
+                       reason)
+              with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+                if not (Coord_resilience.ZeroZombie.is_benign_error exn) then
+                  Log.Orchestrator.warn "[zombie] error: %s" (Printexc.to_string exn)));
       Ok ()
   end)
 

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -688,6 +688,80 @@ let test_validate_args_tool_execute_accepts_typed_pipeline () =
       "expected typed tool_execute pipeline to pass validation, got %s"
       (Yojson.Safe.to_string result.Tool_result.data)
 
+let tool_execute_exec_argv args =
+  match Keeper_tool_bash_input.of_json args with
+  | Ok (Keeper_tool_bash_input.Exec { argv; _ }) -> argv
+  | Ok (Keeper_tool_bash_input.Pipeline _) ->
+    Alcotest.fail "expected exec input"
+  | Error msg ->
+    Alcotest.failf "expected typed tool_execute parse to pass, got %s" msg
+
+let test_tool_execute_find_expression_gets_default_path () =
+  let argv =
+    tool_execute_exec_argv
+      (`Assoc
+        [ "executable", `String "find"
+        ; "argv", `List [ `String "-type"; `String "f"; `String "-name"; `String "*.ml" ]
+        ])
+  in
+  Alcotest.(check (list string))
+    "find expression gets explicit cwd path"
+    [ "."; "-type"; "f"; "-name"; "*.ml" ]
+    argv
+
+let test_tool_execute_find_global_option_keeps_option_first () =
+  let argv =
+    tool_execute_exec_argv
+      (`Assoc
+        [ "executable", `String "find"
+        ; "argv", `List [ `String "-E"; `String "-type"; `String "f" ]
+        ])
+  in
+  Alcotest.(check (list string))
+    "find global option stays before default path"
+    [ "-E"; "."; "-type"; "f" ]
+    argv
+
+let test_tool_execute_promoted_find_expression_gets_default_path () =
+  let argv =
+    tool_execute_exec_argv
+      (`Assoc
+        [ "executable", `String ""
+        ; "argv", `List [ `String "find"; `String "-type"; `String "f" ]
+        ])
+  in
+  Alcotest.(check (list string))
+    "promoted find expression gets explicit cwd path"
+    [ "."; "-type"; "f" ]
+    argv
+
+let test_tool_execute_pipeline_find_expression_gets_default_path () =
+  match
+    Keeper_tool_bash_input.of_json
+      (`Assoc
+        [ ( "pipeline"
+          , `List
+              [ `Assoc
+                  [ "executable", `String "find"
+                  ; "argv", `List [ `String "-type"; `String "f" ]
+                  ]
+              ; `Assoc [ "executable", `String "head"; "argv", `List [ `String "-5" ] ]
+              ] )
+        ])
+  with
+  | Ok
+      (Keeper_tool_bash_input.Pipeline
+        { stages = { Keeper_tool_bash_input.argv = argv; _ } :: _; _ }) ->
+    Alcotest.(check (list string))
+      "pipeline find stage gets default path"
+      [ "."; "-type"; "f" ]
+      argv
+  | Ok (Keeper_tool_bash_input.Pipeline { stages = []; _ }) ->
+    Alcotest.fail "expected non-empty pipeline"
+  | Ok (Keeper_tool_bash_input.Exec _) -> Alcotest.fail "expected pipeline input"
+  | Error msg ->
+    Alcotest.failf "expected typed tool_execute pipeline parse to pass, got %s" msg
+
 let test_validate_args_tool_execute_rejects_bad_argv_type () =
   let args =
     `Assoc [ "executable", `String "rg"; "argv", `String "--files lib" ]
@@ -1467,6 +1541,14 @@ let () =
         test_validate_args_tool_execute_accepts_typed_exec;
       Alcotest.test_case "tool_execute accepts typed pipeline" `Quick
         test_validate_args_tool_execute_accepts_typed_pipeline;
+      Alcotest.test_case "tool_execute find expression default path" `Quick
+        test_tool_execute_find_expression_gets_default_path;
+      Alcotest.test_case "tool_execute find global option default path" `Quick
+        test_tool_execute_find_global_option_keeps_option_first;
+      Alcotest.test_case "tool_execute promoted find default path" `Quick
+        test_tool_execute_promoted_find_expression_gets_default_path;
+      Alcotest.test_case "tool_execute pipeline find default path" `Quick
+        test_tool_execute_pipeline_find_expression_gets_default_path;
       Alcotest.test_case "tool_execute rejects bad typed argv" `Quick
         test_validate_args_tool_execute_rejects_bad_argv_type;
       Alcotest.test_case "tool_execute exec + empty pipeline" `Quick


### PR DESCRIPTION
## Summary
- Normalize typed Execute find calls like `find -type f` to `find . -type f` so BSD/macOS find does not fail with illegal option -- t.
- Prevent overlapping zero-zombie/stale-claim sweeps and demote best-effort transient backlog lock contention to debug.
- Fix current main compile blockers for generated Shell IR Grep fallback and keeper session-dir references.

## Validation
- `ocamlformat --check bin/gen_shell_ir_walkers.ml lib/keeper/keeper_status.ml lib/keeper/keeper_status_detail.ml lib/keeper/keeper_tool_bash_input.ml lib/keeper/keeper_tool_bash_input.mli lib/coord/coord_task_schedule.ml lib/orchestrator.ml test/test_tool_input_validation.ml`
- `git diff --check origin/main..HEAD`
- `env DUNE_BUILD_DIR=/tmp/masc-mcp-check-fix-keeper-stale-claims-search-recovery MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_OPAM_LOCK=1 scripts/dune-local.sh exec test/test_tool_input_validation.exe` (64 tests)