### PR TITLE
fix(dashboard): back off governance judge timeouts

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -38,6 +38,7 @@ type state = {
   mutable last_compute_timeout_sec : float option;
   mutable last_compute_outcome : string option;
   mutable last_compute_reason : string option;
+  mutable next_compute_after_unix : float option;
   mutable last_disk_load_unix : float option;
   mutable judgments : (string, Yojson.Safe.t) Hashtbl.t;
 }
@@ -145,6 +146,10 @@ let interval_sec () = Env_config.Dashboard_config.governance_judge_interval_sec
 let cache_ttl_sec () =
   float_of_int (max (interval_sec () * 4) 600)
 
+let timeout_failure_backoff_sec () =
+  let interval = float_of_int (interval_sec ()) in
+  Float.min 300.0 (Float.max 60.0 (interval *. 5.0))
+
 let empty_judgment_reload_cooldown_sec = 30.0
 
 let enabled () = Env_config.Dashboard_config.governance_judge_enabled
@@ -215,7 +220,8 @@ let mark_fresh_cache_served (st : state) =
   if st.runtime_status <> status_stale_visible then begin
     st.runtime_status <- status_online;
     st.degraded_reason <- None;
-    st.last_error <- None
+    st.last_error <- None;
+    st.next_compute_after_unix <- None
   end
 
 let mark_refresh_failure ~now_ts (st : state) ~message =
@@ -224,11 +230,25 @@ let mark_refresh_failure ~now_ts (st : state) ~message =
      or timing-out judge should degrade to stale-but-visible rather than
      immediately flipping the dashboard offline. *)
   let cache_fresh = cached_judgments_still_fresh ~now_ts st in
+  let degraded_reason = degraded_reason_of_error message in
   st.judge_online <- cache_fresh;
   st.runtime_status <-
     (if cache_fresh then status_stale_visible else status_offline);
-  st.degraded_reason <- Some (degraded_reason_of_error message);
-  st.last_error <- Some message
+  st.degraded_reason <- Some degraded_reason;
+  st.last_error <- Some message;
+  st.next_compute_after_unix <-
+    (if String.equal degraded_reason "timeout"
+     then Some (now_ts +. timeout_failure_backoff_sec ())
+     else None)
+
+let timeout_backoff_remaining_sec ~now_ts (st : state) =
+  match st.next_compute_after_unix with
+  | Some next when next > now_ts -> Some (next -. now_ts)
+  | Some _ ->
+    st.next_compute_after_unix <- None;
+    None
+  | None ->
+    None
 
 let get_state base_path =
   with_outer_rw (fun () ->
@@ -254,6 +274,7 @@ let get_state base_path =
             last_compute_timeout_sec = None;
             last_compute_outcome = None;
             last_compute_reason = None;
+            next_compute_after_unix = None;
             last_disk_load_unix = None;
           judgments = Hashtbl.create 32;
         }
@@ -797,7 +818,21 @@ let refresh_once ~sw ~net
   in
   if served_from_cache then
     Log.Governance.routine "refresh_once: fresh cached result; skipping compute"
-  else if should_backoff ~sw ~net then begin
+  else (
+    let timeout_backoff_remaining =
+      let now_ts = Unix.gettimeofday () in
+      with_lock st (fun () ->
+          st.refreshing <- false;
+          timeout_backoff_remaining_sec ~now_ts st)
+    in
+    match timeout_backoff_remaining with
+    | Some remaining_sec ->
+      Log.Governance.routine
+        "refresh_once: timeout backoff active; skipping compute for %.0fs"
+        remaining_sec
+    | None ->
+      if should_backoff ~sw ~net
+      then begin
     let was_online =
       with_lock st (fun () ->
           let was_online = st.judge_online in
@@ -811,9 +846,9 @@ let refresh_once ~sw ~net
     if was_online then
       Log.Governance.info "backoff: local slots saturated, skipping cycle"
     else
-      Log.Governance.routine "backoff: local slots saturated (first cycle)"
-  end
-  else begin
+        Log.Governance.routine "backoff: local slots saturated (first cycle)"
+      end
+      else begin
     with_lock st (fun () ->
         st.refreshing <- true;
         st.runtime_status <- status_refreshing;
@@ -862,6 +897,7 @@ let refresh_once ~sw ~net
             st.expires_at_unix <- Some (Masc_domain.parse_iso8601 expires_at);
             st.model_used <- Some model_used;
             st.last_error <- None;
+            st.next_compute_after_unix <- None;
             st.last_disk_load_unix <- Some (Unix.gettimeofday ());
             List.iter
               (fun json -> Hashtbl.replace st.judgments (judgment_key json) json)
@@ -886,7 +922,7 @@ let refresh_once ~sw ~net
           in_flight;
         with_lock st (fun () ->
             mark_refresh_failure ~now_ts:(Unix.gettimeofday ()) st ~message)
-  end
+      end)
 
 let start ~sw ~clock ~net ~base_path
     ~(masc_tools : Masc_domain.tool_schema list)

--- a/lib/dashboard/dashboard_governance_judge.mli
+++ b/lib/dashboard/dashboard_governance_judge.mli
@@ -99,6 +99,7 @@ type state = {
   mutable last_compute_timeout_sec : float option;
   mutable last_compute_outcome : string option;
   mutable last_compute_reason : string option;
+  mutable next_compute_after_unix : float option;
   mutable last_disk_load_unix : float option;
   mutable judgments : (string, Yojson.Safe.t) Hashtbl.t;
 }
@@ -114,7 +115,8 @@ type state = {
     them for the same reason.  The compute telemetry fields
     expose #11079 measurement state: current in-flight count,
     last duration, resolved timeout budget, outcome, and
-    reason.  Every other reader goes
+    reason.  [next_compute_after_unix] records timeout
+    backoff for advisory judge retries.  Every other reader goes
     through {!runtime_status} / {!fresh_judgments_json}. *)
 
 (** {1 Response-model classification} *)

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -582,6 +582,47 @@ let test_refresh_failure_marks_expired_cache_offline () =
       check (option string) "last_error recorded"
         (Some "Execution timed out after 60.0s") status.last_error)
 
+let test_refresh_failure_sets_timeout_backoff () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      with_test_fs env @@ fun () ->
+      let st = Lib.Dashboard_governance_judge.get_state dir in
+      let now = Unix.gettimeofday () in
+      let next_compute_after =
+        Lib.Dashboard_governance_judge.with_lock st (fun () ->
+          Lib.Dashboard_governance_judge.mark_refresh_failure
+            ~now_ts:now st ~message:"Execution timed out after 45.0s";
+          st.next_compute_after_unix)
+      in
+      match next_compute_after with
+      | Some next ->
+          check bool "timeout backoff is in the future" true (next > now);
+          check bool "timeout backoff is capped" true (next <= now +. 300.1)
+      | None -> fail "expected timeout backoff deadline")
+
+let test_refresh_failure_clears_timeout_backoff_for_non_timeout () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      with_test_fs env @@ fun () ->
+      let st = Lib.Dashboard_governance_judge.get_state dir in
+      let now = Unix.gettimeofday () in
+      let next_compute_after =
+        Lib.Dashboard_governance_judge.with_lock st (fun () ->
+          st.next_compute_after_unix <- Some (now +. 60.0);
+          Lib.Dashboard_governance_judge.mark_refresh_failure
+            ~now_ts:now st
+            ~message:"Governance judge returned invalid JSON: malformed";
+          st.next_compute_after_unix)
+      in
+      check (option (float 0.001)) "non-timeout clears timeout backoff" None
+        next_compute_after)
+
 let test_refresh_failure_marks_judge_output_invalid () =
   let dir = test_dir () in
   Fun.protect
@@ -684,6 +725,48 @@ let test_refresh_once_skips_fresh_cached_result () =
       check bool "refreshing cleared" false status.refreshing;
       check string "runtime status is online" "online" status.status;
       check (option string) "last_error stays clear" None status.last_error)
+
+let test_refresh_once_skips_timeout_backoff () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      with_test_fs env @@ fun () ->
+      let st = Lib.Dashboard_governance_judge.get_state dir in
+      let now = Unix.gettimeofday () in
+      Lib.Dashboard_governance_judge.with_lock st (fun () ->
+        st.refreshing <- false;
+        st.judge_online <- false;
+        st.runtime_status <- "offline";
+        st.degraded_reason <- Some "timeout";
+        st.last_error <- Some "Execution timed out after 45.0s";
+        st.next_compute_after_unix <- Some (now +. 3600.0));
+      let build_called = ref false in
+      Eio.Switch.run @@ fun sw ->
+      Lib.Dashboard_governance_judge.refresh_once ~sw
+        ~net:(Eio.Stdenv.net env)
+        ~masc_tools:[]
+        ~dispatch:(fun ~name ~args:_ ->
+          {
+            Tool_result.success = false;
+            data = `String "unused";
+            message = "unused";
+            tool_name = name;
+            duration_ms = 0.0;
+            failure_class = None;
+          })
+        ~base_path:dir
+        ~build_facts:(fun () ->
+          build_called := true;
+          `Assoc []);
+      check bool "timeout backoff skips build_facts" false !build_called;
+      let status =
+        Lib.Dashboard_governance_judge.runtime_status_at
+          ~now_ts:(Unix.gettimeofday ()) dir
+      in
+      check (option string) "last timeout remains visible"
+        (Some "Execution timed out after 45.0s") status.last_error)
 
 let test_backoff_runtime_status_is_structured () =
   let dir = test_dir () in
@@ -995,12 +1078,18 @@ let () =
             test_refresh_failure_keeps_fresh_cache_online;
           test_case "refresh failure marks expired cache offline" `Quick
             test_refresh_failure_marks_expired_cache_offline;
+          test_case "refresh failure sets timeout backoff" `Quick
+            test_refresh_failure_sets_timeout_backoff;
+          test_case "non-timeout failure clears timeout backoff" `Quick
+            test_refresh_failure_clears_timeout_backoff_for_non_timeout;
           test_case "refresh failure marks judge output invalid" `Quick
             test_refresh_failure_marks_judge_output_invalid;
           test_case "refresh failure marks invalid JSON invalid" `Quick
             test_refresh_failure_marks_invalid_json_as_judge_output_invalid;
           test_case "refresh_once skips fresh cached result" `Quick
             test_refresh_once_skips_fresh_cached_result;
+          test_case "refresh_once skips timeout backoff" `Quick
+            test_refresh_once_skips_timeout_backoff;
           test_case "backoff runtime status is structured" `Quick
             test_backoff_runtime_status_is_structured;
           test_case "monitoring uses live runtime" `Quick


### PR DESCRIPTION
## Summary
- add a timeout retry backoff deadline to the governance judge daemon state
- skip advisory governance compute while timeout backoff is active instead of repeating the same OAS timeout every refresh cycle
- keep timeout state visible in runtime status and clear the backoff on success/non-timeout failures

## Evidence
- repeated live WARN pairs at 2026-05-26T04:04:39Z, 04:06:33Z, 04:08:26Z, 04:32:14Z, and 05:16:14Z: governance_judge OAS execution timed out after 45s plus refresh_once compute_judgments failed

## Verification
- ocamlformat --check lib/dashboard/dashboard_governance_judge.ml lib/dashboard/dashboard_governance_judge.mli test/test_dashboard_governance.ml
- ocamlc -stop-after parsing lib/dashboard/dashboard_governance_judge.ml lib/dashboard/dashboard_governance_judge.mli test/test_dashboard_governance.ml
- git diff --check

## Local Dune
- scripts/dune-local.sh build test/test_dashboard_governance.exe was blocked by live bare Dune processes outside scripts/dune-local.sh