### PR TITLE
fix(keeper): purge legacy error-code deterministic fallback

### DIFF
--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -19,8 +19,6 @@ type classification_source =
   | Deterministic_retry_marker
   | Workflow_rejection_marker
   | Path_check_marker
-  | Retryability_marker
-  | Legacy_error_code
   | Git_exit_128
 
 type classification =
@@ -32,8 +30,6 @@ let classification_source_to_string = function
   | Deterministic_retry_marker -> "deterministic_retry_marker"
   | Workflow_rejection_marker -> "workflow_rejection_marker"
   | Path_check_marker -> "path_check_marker"
-  | Retryability_marker -> "retryability_marker"
-  | Legacy_error_code -> "legacy_error_code"
   | Git_exit_128 -> "git_exit_128"
 ;;
 
@@ -171,24 +167,6 @@ let deterministic_retry_fields reason =
   ]
 ;;
 
-(* Closed mapping: [error] field value -> [deterministic_reason].
-   New error codes added in [Exec_core.blocked_result_json] callers
-   must be wired here explicitly; an unmapped value returns [None]
-   so transient/runtime errors stay outside the short-circuit. *)
-let reason_of_error_code = function
-  | "command_blocked" -> Some Command_blocked
-  | "keeper_bash_command_shape_blocked" -> Some Command_shape_blocked
-  | "task_state_file_probe_blocked" | "task_state_http_probe_blocked" ->
-    Some Task_state_probe_blocked
-  | "destructive_operation_blocked" -> Some Destructive_operation_blocked
-  | "policy_blocked" -> Some Policy_blocked
-  | "policy_not_loaded" -> Some Policy_blocked
-  | "gh_command_blocked" -> Some Policy_blocked
-  | "gh_irreversible_blocked" -> Some Policy_blocked
-  | "completion_contract_violation" -> Some Completion_contract_violation
-  | _ -> None
-;;
-
 (* Path-prefixed sentinel string (no substring search): path checks
    compare the *full* value of the [error] field — or, when the
    payload nests the reason in [detail.path_check.reason], that field
@@ -227,27 +205,6 @@ let classify_workflow_rejection json =
     -> Workflow_rejection_deterministic Workflow_rejection_blocked
   | Some _ -> Workflow_rejection_observed
   | None -> Workflow_rejection_absent
-;;
-
-let classify_error_code json =
-  match error_or_detail_string "error" json with
-  | Some code -> reason_of_error_code code
-  | None -> None
-;;
-
-type retryability_classification =
-  | Retryability_absent
-  | Retryability_observed
-  | Retryability_deterministic of deterministic_reason
-
-let classify_retryability json =
-  match error_or_detail_string "retryability" json, classify_error_code json with
-  | Some ("self_correct" | "operator_required"), Some reason ->
-    Retryability_deterministic reason
-  | Some _, Some _ -> Retryability_observed
-  | Some _, None
-  | None, _ ->
-    Retryability_absent
 ;;
 
 let classify_git_exit_128 json =
@@ -304,17 +261,14 @@ let classify_path_check json =
 
 let classify_with_source (json : Yojson.Safe.t) : classification option =
   (* Precedence: explicit deterministic_retry > workflow_rejection >
-     path_check > retryability > error_code.
+     path_check > git exit-128.
      Workflow rejection is the most specific (already routed to a
      dedicated counter in [Keeper_tools_oas]). Once observed, it must
-     not fall through to legacy [error] string fallbacks; only explicit
+     not fall through to [error] string fallbacks; only explicit
      deterministic workflow markers may short-circuit retry. Path
-     checks have their own typed surface. Exec_core blocked results can
-     carry a typed [retryability] marker; once present, it decides
-     whether replaying the same arguments should short-circuit rather
-     than falling back to legacy [error] strings. Generic [error] codes
-     are the legacy catch-up layer and stay visible through
-     [classification_source]. *)
+     checks have their own typed surface. Generic [error] codes and
+     retryability-only fields are observational metadata, not a
+     deterministic reason. *)
   match classify_deterministic_retry json with
   | Some reason -> Some { reason; source = Deterministic_retry_marker }
   | None ->
@@ -326,17 +280,9 @@ let classify_with_source (json : Yojson.Safe.t) : classification option =
        (match classify_path_check json with
         | Some reason -> Some { reason; source = Path_check_marker }
         | None ->
-          (match classify_retryability json with
-           | Retryability_deterministic reason ->
-             Some { reason; source = Retryability_marker }
-           | Retryability_observed -> None
-           | Retryability_absent ->
-             (match classify_error_code json with
-              | Some reason -> Some { reason; source = Legacy_error_code }
-              | None ->
-                (match classify_git_exit_128 json with
-                 | Some reason -> Some { reason; source = Git_exit_128 }
-                 | None -> None)))))
+          (match classify_git_exit_128 json with
+           | Some reason -> Some { reason; source = Git_exit_128 }
+           | None -> None)))
 ;;
 
 let classify (json : Yojson.Safe.t) : deterministic_reason option =

--- a/lib/keeper/keeper_tool_deterministic_error.mli
+++ b/lib/keeper/keeper_tool_deterministic_error.mli
@@ -66,10 +66,6 @@ type classification_source =
       (** Workflow rejection carried deterministic/unrecoverable typed fields. *)
   | Path_check_marker
       (** Path-check surface carried a closed typed reason. *)
-  | Retryability_marker
-      (** Exec_core blocked-result retryability carried the same-args boundary. *)
-  | Legacy_error_code
-      (** Legacy [error] code fallback. Kept visible so it can be retired. *)
   | Git_exit_128
       (** Git command/output fallback for exit-128 precondition failures. *)
 
@@ -79,15 +75,17 @@ type classification =
   }
 
 (** Classify a raw tool-result JSON payload (as returned by
-    [Keeper_exec_tools]) into a [deterministic_reason] when the
-    error field matches a known closed set of policy/shape block
-    codes. Returns [None] for transient errors, shell exit-nonzero,
-    network/timeout failures, and any payload that fails to parse.
+    [Keeper_exec_tools]) into a [deterministic_reason] only when the
+    payload carries an explicit typed marker: [deterministic_retry],
+    deterministic workflow-rejection fields, a typed path-check
+    reason, or a closed git exit-128 precondition pattern. Returns
+    [None] for transient errors, shell exit-nonzero, retryability-only
+    payloads, plain [error] strings, network/timeout failures, and
+    any payload that fails to parse.
 
-    Inputs are validated against a typed allow-list of [error] field
-    values plus explicit deterministic workflow-rejection markers
-    and a closed set of git exit-128 output patterns. There is
-    no [_ ->] catch-all that admits new prefixes silently. *)
+    There is no [error] string fallback and no [_ ->] catch-all that
+    admits new prefixes silently. Producers that know same-argument
+    retry cannot succeed must emit [deterministic_retry_fields]. *)
 val classify : Yojson.Safe.t -> deterministic_reason option
 
 val classify_with_source : Yojson.Safe.t -> classification option

--- a/test/test_keeper_bash_retry_deterministic_close.ml
+++ b/test/test_keeper_bash_retry_deterministic_close.ml
@@ -39,16 +39,13 @@ let check_classify_source ~name ~expected_reason ~expected_source raw =
     Alcotest.check source_testable (name ^ ": source") expected_source classification.source
 ;;
 
-(* ── Deterministic — error code path ──────────────────────────── *)
+(* ── Deterministic — explicit typed markers ───────────────────── *)
 
-let test_command_blocked () =
-  let raw =
-    {|{"ok":false,"error":"command_blocked","reason":"Shell injection syntax blocked"}|}
-  in
-  check_classify
-    ~name:"command_blocked"
-    ~expected:(Some D.Command_blocked)
-    raw
+let deterministic_marker_raw ?(error = "timeout") reason =
+  Yojson.Safe.to_string
+    (`Assoc
+       ([ "ok", `Bool false; "error", `String error ]
+        @ D.deterministic_retry_fields reason))
 ;;
 
 let test_command_shape_blocked () =
@@ -69,7 +66,9 @@ let test_command_shape_blocked () =
 
 let test_task_state_file_probe_blocked () =
   let raw =
-    {|{"ok":false,"error":"task_state_file_probe_blocked","reason":"Do not inspect task files"}|}
+    deterministic_marker_raw
+      ~error:"task_state_file_probe_blocked"
+      D.Task_state_probe_blocked
   in
   check_classify
     ~name:"task_state_file_probe_blocked"
@@ -79,7 +78,9 @@ let test_task_state_file_probe_blocked () =
 
 let test_destructive_operation_blocked () =
   let raw =
-    {|{"ok":false,"error":"destructive_operation_blocked","reason":"rm -rf"}|}
+    deterministic_marker_raw
+      ~error:"destructive_operation_blocked"
+      D.Destructive_operation_blocked
   in
   check_classify
     ~name:"destructive_operation_blocked"
@@ -88,13 +89,13 @@ let test_destructive_operation_blocked () =
 ;;
 
 let test_policy_blocked () =
-  let raw = {|{"ok":false,"error":"policy_blocked"}|} in
+  let raw = deterministic_marker_raw ~error:"policy_blocked" D.Policy_blocked in
   check_classify ~name:"policy_blocked" ~expected:(Some D.Policy_blocked) raw
 ;;
 
 let test_policy_blocked_gh_irreversible () =
   let raw =
-    {|{"ok":false,"error":"gh_irreversible_blocked","reason":"gh pr merge"}|}
+    deterministic_marker_raw ~error:"gh_irreversible_blocked" D.Policy_blocked
   in
   check_classify
     ~name:"gh_irreversible_blocked"
@@ -104,7 +105,9 @@ let test_policy_blocked_gh_irreversible () =
 
 let test_completion_contract_violation () =
   let raw =
-    {|{"ok":false,"error":"completion_contract_violation","detail":"require_tool_use"}|}
+    deterministic_marker_raw
+      ~error:"completion_contract_violation"
+      D.Completion_contract_violation
   in
   check_classify
     ~name:"completion_contract_violation"
@@ -128,12 +131,7 @@ let test_tool_search_files_op_required () =
 ;;
 
 let test_typed_deterministic_retry_marker_takes_precedence () =
-  let raw =
-    Yojson.Safe.to_string
-      (`Assoc
-          ([ "ok", `Bool false; "error", `String "timeout" ]
-           @ D.deterministic_retry_fields D.Write_operation_gated))
-  in
+  let raw = deterministic_marker_raw D.Write_operation_gated in
   check_classify
     ~name:"typed deterministic retry marker"
     ~expected:(Some D.Write_operation_gated)
@@ -141,12 +139,7 @@ let test_typed_deterministic_retry_marker_takes_precedence () =
 ;;
 
 let test_typed_deterministic_retry_marker_reports_source () =
-  let raw =
-    Yojson.Safe.to_string
-      (`Assoc
-          ([ "ok", `Bool false; "error", `String "timeout" ]
-           @ D.deterministic_retry_fields D.Write_operation_gated))
-  in
+  let raw = deterministic_marker_raw D.Write_operation_gated in
   check_classify_source
     ~name:"typed deterministic retry marker source"
     ~expected_reason:D.Write_operation_gated
@@ -154,34 +147,36 @@ let test_typed_deterministic_retry_marker_reports_source () =
     raw
 ;;
 
-let test_legacy_error_code_reports_source () =
-  let raw =
-    {|{"ok":false,"error":"command_blocked","reason":"Shell injection syntax blocked"}|}
+let test_plain_error_codes_are_observed_only () =
+  let cases =
+    [ "command_blocked"
+    ; "task_state_file_probe_blocked"
+    ; "destructive_operation_blocked"
+    ; "policy_blocked"
+    ; "gh_irreversible_blocked"
+    ; "completion_contract_violation"
+    ]
   in
-  check_classify_source
-    ~name:"legacy error code source"
-    ~expected_reason:D.Command_blocked
-    ~expected_source:D.Legacy_error_code
-    raw
+  List.iter
+    (fun error ->
+      let raw =
+        Yojson.Safe.to_string
+          (`Assoc
+             [ "ok", `Bool false
+             ; "error", `String error
+             ; "reason", `String "plain deterministic-looking error code"
+             ])
+      in
+      check_classify ~name:("plain error code observed: " ^ error) ~expected:None raw)
+    cases
 ;;
 
-let test_retryability_marker_reports_source () =
+let test_retryability_without_deterministic_reason_is_observed_only () =
   let raw =
-    {|{"ok":false,"error":"command_blocked","retryability":"self_correct","reason":"Shell injection syntax blocked"}|}
-  in
-  check_classify_source
-    ~name:"retryability marker source"
-    ~expected_reason:D.Command_blocked
-    ~expected_source:D.Retryability_marker
-    raw
-;;
-
-let test_retryability_none_does_not_fall_through_to_legacy_error_code () =
-  let raw =
-    {|{"ok":false,"error":"command_blocked","retryability":"none","reason":"already classified non-retryable"}|}
+    {|{"ok":false,"error":"command_blocked","retryability":"self_correct","reason":"retryable but no typed deterministic reason"}|}
   in
   check_classify
-    ~name:"retryability=none blocks legacy error-code fallback"
+    ~name:"retryability without deterministic reason"
     ~expected:None
     raw
 ;;
@@ -245,12 +240,12 @@ let test_workflow_rejection_failure_class_only_is_observed () =
     raw
 ;;
 
-let test_workflow_rejection_legacy_error_code_is_observed () =
+let test_workflow_rejection_plain_error_code_is_observed () =
   let raw =
     {|{"ok":false,"error":"task_state_file_probe_blocked","failure_class":"workflow_rejection"}|}
   in
   check_classify
-    ~name:"workflow_rejection does not fall through to legacy error code"
+    ~name:"workflow_rejection does not fall through to plain error code"
     ~expected:None
     raw
 ;;
@@ -405,9 +400,8 @@ let test_to_string_non_empty_for_every_variant () =
 let () =
   Alcotest.run
     "tool_execute_retry_deterministic_close"
-    [ ( "classify_error_code"
-      , [ Alcotest.test_case "command_blocked" `Quick test_command_blocked
-        ; Alcotest.test_case
+    [ ( "classify_typed_markers"
+      , [ Alcotest.test_case
             "command_shape_blocked"
             `Quick
             test_command_shape_blocked
@@ -441,17 +435,13 @@ let () =
             `Quick
             test_typed_deterministic_retry_marker_reports_source
         ; Alcotest.test_case
-            "legacy_error_code_reports_source"
+            "plain_error_codes_observed_only"
             `Quick
-            test_legacy_error_code_reports_source
+            test_plain_error_codes_are_observed_only
         ; Alcotest.test_case
-            "retryability_marker_reports_source"
+            "retryability_without_deterministic_reason_observed_only"
             `Quick
-            test_retryability_marker_reports_source
-        ; Alcotest.test_case
-            "retryability_none_blocks_legacy_error_code"
-            `Quick
-            test_retryability_none_does_not_fall_through_to_legacy_error_code
+            test_retryability_without_deterministic_reason_is_observed_only
         ; Alcotest.test_case
             "unknown_typed_deterministic_retry_marker_observes"
             `Quick
@@ -478,9 +468,9 @@ let () =
             `Quick
             test_workflow_rejection_failure_class_only_is_observed
         ; Alcotest.test_case
-            "legacy_error_code_observed"
+            "plain_error_code_observed"
             `Quick
-            test_workflow_rejection_legacy_error_code_is_observed
+            test_workflow_rejection_plain_error_code_is_observed
         ; Alcotest.test_case
             "explicit_deterministic_top_level"
             `Quick


### PR DESCRIPTION
Summary:
- remove Legacy_error_code and Retryability_marker classifier sources
- stop mapping plain error strings or retryability-only payloads into deterministic retry skips
- keep deterministic skip limited to explicit deterministic_retry, typed workflow rejection, typed path-check, and git exit-128 precondition signals

Validation:
- ocamlformat --check changed files
- git diff --check
- rg removed Legacy_error_code/Retryability_marker/classify_error_code/classify_retryability symbols: no matches
- scripts/dune-local.sh build test/test_keeper_bash_retry_deterministic_close.exe: blocked locally by live bare Dune processes bypassing the wrapper