### PR TITLE
Align Docker PR harness with public aliases

### DIFF
--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -1348,18 +1348,18 @@ prompt_for_keeper_create() {
   visibility="$(repo_visibility_for_keeper "$keeper")"
   if keeper_uses_fork_pr_route "$keeper"; then
     head_ref="$account:$branch"
-    git_route_rule="- You may use Bash for gh repo fork / git remote setup only to prepare your own fork branch for this proof. Do not run gh pr review or other review/close/merge mutations through Bash."
+    git_route_rule="- You may use Execute for gh repo fork / git remote setup only to prepare your own fork branch for this proof. Do not run gh pr review or other review/close/merge mutations through Execute."
     push_step="$(cat <<EOF
-5. Commit and push exactly branch $branch with Bash using the fork PR route because your upstream repo permission is $permission:
+5. Commit and push exactly branch $branch with Execute using the fork PR route because your upstream repo permission is $permission:
    - Confirm your GitHub account login is $account.
-   - Ensure the fork $account/${REPO_SLUG#*/} exists. If needed, run gh repo fork $REPO_SLUG --remote=false with Bash; if GitHub blocks fork creation, stop and report blocker="fork_create_blocked" with the exact output.
+   - Ensure the fork $account/${REPO_SLUG#*/} exists. If needed, run gh repo fork $REPO_SLUG --remote=false with Execute; if GitHub blocks fork creation, stop and report blocker="fork_create_blocked" with the exact output.
    - Add or update a remote named keeper-fork pointing at https://github.com/$account/${REPO_SLUG#*/}.git in the returned proof worktree.
    - Push with git push keeper-fork HEAD:$branch.
    - The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
 EOF
 )"
     pr_step="$(cat <<EOF
-6. Create a draft PR from your fork branch through visible Bash with
+6. Create a draft PR from your fork branch through visible Execute with
    executable="gh" and typed argv for pr create. The command must include repo "$REPO_SLUG", head
    "$head_ref", base "main", and cwd set to the returned proof worktree path.
    Do not leave head/base empty and do not use the base repo path if the proof
@@ -1369,13 +1369,13 @@ EOF
 )"
   else
     head_ref="$branch"
-    git_route_rule="- Use visible Bash with executable=\"gh\" and typed argv for GitHub PR creation after the branch is pushed."
+    git_route_rule="- Use visible Execute with executable=\"gh\" and typed argv for GitHub PR creation after the branch is pushed."
     push_step="$(cat <<EOF
-5. Commit and git push exactly branch $branch with Bash. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
+5. Commit and git push exactly branch $branch with Execute. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
 EOF
 )"
     pr_step="$(cat <<EOF
-6. Create a draft PR for that branch through visible Bash with executable="gh"
+6. Create a draft PR for that branch through visible Execute with executable="gh"
    and typed argv for pr create. The command must include repo "$REPO_SLUG", head
    "$head_ref", base "main", and cwd set to the returned proof worktree path.
    Do not leave head/base empty and do not use the base repo path if the proof
@@ -1418,7 +1418,7 @@ Required create lane:
    - Do not reuse any branch, worktree, or proof file from another run id.
    - Do not remove this run's worktree during the proof attempt. If Git says
      the branch/worktree already exists, stop and report blocker="branch_collision".
-4. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with Bash from inside the Docker playground. The file content must include run_id=$RUN_ID and branch=$branch.
+4. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with Execute from inside the Docker playground. The file content must include run_id=$RUN_ID and branch=$branch.
 $push_step
 $pr_step
 7. Reply with one compact JSON object:
@@ -1711,7 +1711,7 @@ create_result_has_tool_evidence() {
 
   if ! jq -e '
       any(.result.tool_call_evidence[]?;
-        ((.tool_name == "Bash") or (.tool_name == "tool_execute"))
+        ((.tool_name == "Execute") or (.tool_name == "tool_execute"))
         and ((.outcome // "") == "ok")
         and (((.route_evidence.via // "") == "docker")
              or ((.route_evidence.via // "") == "brokered")
@@ -1727,7 +1727,7 @@ create_result_has_tool_evidence() {
 
   if ! jq -e '
       any(.result.tool_call_evidence[]?;
-        ((.tool_name == "Bash") or (.tool_name == "tool_execute"))
+        ((.tool_name == "Execute") or (.tool_name == "tool_execute"))
         and ((.outcome // "") == "ok")
         and (((.route_evidence.via // "") == "docker")
              or ((.route_evidence.via // "") == "brokered")
@@ -1745,7 +1745,7 @@ create_result_has_tool_evidence() {
     jq -r '
       [
         .result.tool_call_evidence[]?
-        | select(((.tool_name == "Bash") or (.tool_name == "tool_execute")) and ((.outcome // "") == "ok"))
+        | select(((.tool_name == "Execute") or (.tool_name == "tool_execute")) and ((.outcome // "") == "ok"))
         | .route_evidence.pr_url // empty
       ]
       | last // empty

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1392,19 +1392,19 @@ let test_keeper_docker_multikeeper_isolation_contracts () =
 let test_keeper_required_tool_contracts () =
   let tool_choice_anchor = "let tool_choice =" in
   let required_first =
-    file_pattern_position_after "lib/keeper/keeper_run_tools.ml"
+    file_pattern_position_after "lib/keeper/keeper_run_tools_hooks.ml"
       ~anchor:tool_choice_anchor
       "if computed_surface.required_tool_names <> []"
   in
   let preferred_required_after =
-    file_pattern_position_after "lib/keeper/keeper_run_tools.ml"
+    file_pattern_position_after "lib/keeper/keeper_run_tools_hooks.ml"
       ~anchor:tool_choice_anchor
       "preferred_tool_choice_for_required_tool_names"
   in
   let last_turn_after =
-    file_pattern_position_after "lib/keeper/keeper_run_tools.ml"
+    file_pattern_position_after "lib/keeper/keeper_run_tools_hooks.ml"
       ~anchor:tool_choice_anchor
-      "else if computed_surface.is_last_turn"
+      "not computed_surface.is_last_turn"
   in
   check bool "required_tools force tool_choice before last-turn relaxation" true
     (match required_first, preferred_required_after, last_turn_after with
@@ -1412,13 +1412,13 @@ let test_keeper_required_tool_contracts () =
          required_pos < preferred_pos && preferred_pos < last_turn_pos
      | _ -> false);
   check bool "last-turn relaxation no longer bypasses required_tools" true
-    (file_not_contains_pattern "lib/keeper/keeper_run_tools.ml"
+    (file_not_contains_pattern "lib/keeper/keeper_run_tools_hooks.ml"
        "let tool_choice =\n                 if computed_surface.is_last_turn\n                 then current_params.tool_choice\n                 else if computed_surface.required_tool_names <> []");
   check bool "final-turn required tool prompt matches all-tools enforcement" true
-    (file_contains_pattern "lib/keeper/keeper_run_tools.ml"
+    (file_contains_pattern "lib/keeper/keeper_run_tools_hooks.ml"
        "You MUST either use every");
   check bool "final-turn required tool prompt does not allow one-tool partial success" true
-    (file_not_contains_pattern "lib/keeper/keeper_run_tools.ml"
+    (file_not_contains_pattern "lib/keeper/keeper_run_tools_hooks.ml"
        "call at least one");
   check bool "docker PR lifecycle harness default splits create/review tools" true
     (file_contains_pattern
@@ -1428,24 +1428,37 @@ let test_keeper_required_tool_contracts () =
           "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
           {|CREATE_REQUIRED_TOOLS="${CREATE_REQUIRED_TOOLS:-${REQUIRED_TOOLS_DEFAULT:-SearchWeb,Execute}}"|}
      && file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       {|REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_DEFAULT:-Execute}}"|});
+  check bool "docker PR lifecycle harness cuts legacy Bash/WebSearch aliases" true
+    (file_not_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       "WebSearch"
+     && file_not_contains_pattern
           "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
-          {|REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_DEFAULT:-Execute}}"|});
+          {|tool_name == "Bash"|}
+     && file_not_contains_pattern
+          "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
+          "WebSearch"
+     && file_not_contains_pattern
+          "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
+          "`Bash`");
   check bool "runbook documents docker PR lifecycle split phases" true
     (file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
        "The create phase"
      && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
           "PR creation uses visible `Execute` with"
      && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
-          "the review phase requires `Execute` and"
+          "the review phase requires `Execute`"
      && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
-          "second required tool keeps target inspection mandatory");
+          "keeps target inspection mandatory");
   check bool "taskboard schema documents PR required_tools preflight" true
     (file_contains_pattern "lib/tool_shard_types_schemas_taskboard.ml"
        "keeper_preflight_check"
      && file_contains_pattern "lib/tool_shard_types_schemas_taskboard.ml"
-          "tool_search_files"
+          "SearchFiles"
      && file_contains_pattern "lib/tool_shard_types_schemas_taskboard.ml"
-          "dedicated review wrappers"
+          "review wrappers"
      && file_contains_pattern "lib/tool_shard_types_schemas_taskboard.ml"
           "sandboxed");
   check bool "docker PR lifecycle prompt accepts brokered route proof" true
@@ -1515,7 +1528,7 @@ let test_keeper_required_tool_contracts () =
 let test_keeper_msg_timeout_contracts () =
   check bool "keeper msg schema exposes timeout_sec" true
     (file_contains_pattern "lib/keeper/keeper_schema.ml"
-       "Optional: overall cascade timeout (sec) for this keeper message call");
+       "Optional: overall timeout (sec) for this async keeper message request and its cascade turn");
   check bool "keeper msg parses timeout_sec override" true
     (file_contains_pattern "lib/keeper/keeper_turn.ml"
        "get_float_opt args \"timeout_sec\"");
@@ -1553,7 +1566,7 @@ let test_keeper_msg_timeout_contracts () =
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
        "server_incarnation_changed");
-  check bool "docker PR lifecycle prompt routes mutating git through docker bash" true
+  check bool "docker PR lifecycle prompt routes mutating git through Execute" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
        "Use the visible Execute tool inside your Docker playground for proof-file creation and git add/commit/push");


### PR DESCRIPTION
## Summary
- align Docker PR lifecycle reprobe with public SearchWeb/Execute aliases and current review Execute requirement
- remove public Bash/WebSearch guidance from prompt/evidence checks while still accepting internal tool_execute route evidence
- update source guards for current keeper required-tool and public Execute guidance owners

## Verification
- bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
- ocamlformat --check test/test_ci_hardening_source.ml
- git diff --check origin/main...HEAD
- rg no-residue check for WebSearch/Bash in harness/runbook
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_ci_hardening_source.exe
- ./_build/default/test/test_ci_hardening_source.exe test source_guard 20,21,28,29 --show-errors