### PR TITLE
fix(dashboard): cache runtime git upstream status

### DIFF
--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -205,6 +205,15 @@ type git_upstream_status =
 let empty_git_upstream_status =
   Server_dashboard_http_runtime_info_json.empty_git_upstream_status
 
+let git_upstream_status_ttl_sec = 60.0
+
+let git_upstream_status_cache : (string, git_upstream_status option * float) Hashtbl.t =
+  Hashtbl.create 4
+;;
+
+let git_upstream_status_in_flight : (string, unit) Hashtbl.t = Hashtbl.create 4
+let git_upstream_status_mu = Stdlib.Mutex.create ()
+
 let git_upstream_status_probe_hook_for_tests :
   (string -> git_upstream_status option) option Atomic.t
   =
@@ -217,6 +226,51 @@ let set_git_upstream_status_probe_hook_for_tests hook =
 
 let clear_git_upstream_status_probe_hook_for_tests () =
   Atomic.set git_upstream_status_probe_hook_for_tests None
+;;
+
+let git_upstream_status_cached_lookup dir ~now =
+  Stdlib.Mutex.lock git_upstream_status_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_upstream_status_mu)
+    (fun () ->
+       match Hashtbl.find_opt git_upstream_status_cache dir with
+       | Some (value, ts) when now -. ts <= git_upstream_status_ttl_sec -> Some value
+       | _ -> None)
+;;
+
+let git_upstream_status_cached_any dir =
+  Stdlib.Mutex.lock git_upstream_status_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_upstream_status_mu)
+    (fun () -> Hashtbl.find_opt git_upstream_status_cache dir |> Option.map fst)
+;;
+
+let git_upstream_status_try_begin_refresh dir =
+  Stdlib.Mutex.lock git_upstream_status_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_upstream_status_mu)
+    (fun () ->
+       if Hashtbl.mem git_upstream_status_in_flight dir
+       then false
+       else (
+         Hashtbl.replace git_upstream_status_in_flight dir ();
+         true))
+;;
+
+let git_upstream_status_finish_refresh dir value ~now =
+  Stdlib.Mutex.lock git_upstream_status_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_upstream_status_mu)
+    (fun () ->
+       Hashtbl.replace git_upstream_status_cache dir (value, now);
+       Hashtbl.remove git_upstream_status_in_flight dir)
+;;
+
+let git_upstream_status_cancel_refresh dir =
+  Stdlib.Mutex.lock git_upstream_status_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_upstream_status_mu)
+    (fun () -> Hashtbl.remove git_upstream_status_in_flight dir)
 ;;
 
 let git_probe_trimmed dir args =
@@ -253,54 +307,96 @@ let git_default_origin_head dir =
   git_probe_trimmed dir [ "symbolic-ref"; "--short"; "refs/remotes/origin/HEAD" ]
 ;;
 
-let git_upstream_status path =
+let git_upstream_status_probe dir =
   match Atomic.get git_upstream_status_probe_hook_for_tests with
-  | Some hook -> hook path
+  | Some hook -> hook dir
   | None ->
-    (match String_util.trim_to_option path with
-     | None -> None
-     | Some dir when not (Sys.file_exists dir) -> None
-     | Some dir ->
-       let branch =
-         git_probe_trimmed dir [ "rev-parse"; "--abbrev-ref"; "HEAD" ]
-       in
-       let upstream_ref =
-         match
+    let branch = git_probe_trimmed dir [ "rev-parse"; "--abbrev-ref"; "HEAD" ] in
+    let upstream_ref =
+      match
+        git_probe_trimmed
+          dir
+          [ "rev-parse"; "--abbrev-ref"; "--symbolic-full-name"; "@{upstream}" ]
+      with
+      | Some upstream -> Some upstream
+      | None -> git_default_origin_head dir
+    in
+    let upstream_head_commit =
+      Option.bind upstream_ref (fun ref_name ->
+        git_probe_trimmed dir [ "rev-parse"; "--short"; ref_name ])
+    in
+    let ahead_count, behind_count =
+      match upstream_ref with
+      | None -> None, None
+      | Some ref_name ->
+        (match
            git_probe_trimmed
              dir
-             [ "rev-parse"; "--abbrev-ref"; "--symbolic-full-name"; "@{upstream}" ]
+             [ "rev-list"; "--left-right"; "--count"; "HEAD..." ^ ref_name ]
          with
-         | Some upstream -> Some upstream
-         | None -> git_default_origin_head dir
-       in
-       let upstream_head_commit =
-         Option.bind upstream_ref (fun ref_name ->
-           git_probe_trimmed dir [ "rev-parse"; "--short"; ref_name ])
-       in
-       let ahead_count, behind_count =
-         match upstream_ref with
-         | None -> None, None
-         | Some ref_name ->
-           (match
-              git_probe_trimmed
-                dir
-                [ "rev-list"; "--left-right"; "--count"; "HEAD..." ^ ref_name ]
-            with
-            | Some raw ->
-              (match parse_ahead_behind raw with
-               | Some (ahead, behind) -> Some ahead, Some behind
-               | None -> None, None)
+         | Some raw ->
+           (match parse_ahead_behind raw with
+            | Some (ahead, behind) -> Some ahead, Some behind
             | None -> None, None)
-       in
-       if branch = None
-          && upstream_ref = None
-          && upstream_head_commit = None
-          && ahead_count = None
-          && behind_count = None
-       then None
-       else
-         Some
-           { branch; upstream_ref; upstream_head_commit; ahead_count; behind_count })
+         | None -> None, None)
+    in
+    if branch = None
+       && upstream_ref = None
+       && upstream_head_commit = None
+       && ahead_count = None
+       && behind_count = None
+    then None
+    else Some { branch; upstream_ref; upstream_head_commit; ahead_count; behind_count }
+;;
+
+let git_upstream_status_refresh dir =
+  try
+    let value = git_upstream_status_probe dir in
+    git_upstream_status_finish_refresh dir value ~now:(Time_compat.now ());
+    value
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    git_upstream_status_cancel_refresh dir;
+    raise exn
+;;
+
+let maybe_refresh_git_upstream_status_in_background dir =
+  match Eio_context.get_switch_opt () with
+  | None -> ()
+  | Some sw ->
+    if git_upstream_status_try_begin_refresh dir
+    then
+      Eio.Fiber.fork ~sw (fun () ->
+        try
+          let _ = git_upstream_status_refresh dir in
+          ()
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Dashboard.warn
+            "dashboard runtime git upstream refresh failed for %s: %s"
+            dir
+            (Printexc.to_string exn))
+;;
+
+let git_upstream_status path =
+  match String_util.trim_to_option path with
+  | None -> None
+  | Some dir when not (Sys.file_exists dir) -> None
+  | Some dir ->
+    let now = Time_compat.now () in
+    (match git_upstream_status_cached_lookup dir ~now with
+     | Some value -> value
+     | None ->
+       (match git_upstream_status_cached_any dir with
+        | Some stale ->
+          maybe_refresh_git_upstream_status_in_background dir;
+          stale
+        | None ->
+          if git_upstream_status_try_begin_refresh dir
+          then git_upstream_status_refresh dir
+          else git_upstream_status_cached_any dir |> Option.value ~default:None))
 ;;
 
 let deployment_state_json
@@ -448,6 +544,24 @@ let seed_git_rev_parse_short_cache_for_tests dir value ~refreshed_at =
     (fun () ->
        Hashtbl.replace git_rev_parse_short_cache dir (value, refreshed_at);
        Hashtbl.remove git_rev_parse_short_in_flight dir)
+;;
+
+let clear_git_upstream_status_cache_for_tests () =
+  Stdlib.Mutex.lock git_upstream_status_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_upstream_status_mu)
+    (fun () ->
+       Hashtbl.clear git_upstream_status_cache;
+       Hashtbl.clear git_upstream_status_in_flight)
+;;
+
+let seed_git_upstream_status_cache_for_tests dir value ~refreshed_at =
+  Stdlib.Mutex.lock git_upstream_status_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_upstream_status_mu)
+    (fun () ->
+       Hashtbl.replace git_upstream_status_cache dir (value, refreshed_at);
+       Hashtbl.remove git_upstream_status_in_flight dir)
 ;;
 
 let path_item_json ~source path =

--- a/lib/server/server_dashboard_http_runtime_info.mli
+++ b/lib/server/server_dashboard_http_runtime_info.mli
@@ -158,7 +158,8 @@ type git_upstream_status = {
 val git_upstream_status : string -> git_upstream_status option
 (** Returns local tracking-ref status for [path].  Detached checkouts fall back
     to [refs/remotes/origin/HEAD] when [@{upstream}] is unavailable, still
-    without fetching from the network. *)
+    without fetching from the network.  Cached for 60 s per directory; stale
+    values are served while a background refresh is in flight. *)
 
 val set_git_upstream_status_probe_hook_for_tests :
   (string -> git_upstream_status option) -> unit
@@ -167,3 +168,12 @@ val set_git_upstream_status_probe_hook_for_tests :
 val clear_git_upstream_status_probe_hook_for_tests : unit -> unit
 (** Removes the hook installed by
     {!set_git_upstream_status_probe_hook_for_tests}. *)
+
+val clear_git_upstream_status_cache_for_tests : unit -> unit
+(** Drops cached upstream-status lookups AND the in-flight refresh set under
+    the cache mutex. *)
+
+val seed_git_upstream_status_cache_for_tests :
+  string -> git_upstream_status option -> refreshed_at:float -> unit
+(** Seeds the upstream-status cache for [path] so tests can exercise stale-first
+    refresh behavior without waiting for wall-clock TTL expiry. *)

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -578,6 +578,69 @@ let test_runtime_git_cache_returns_stale_and_refreshes ~clock () =
           Alcotest.(check int) "single background probe" 1
             (Atomic.get probes)))
 
+let test_runtime_git_upstream_cache_returns_stale_and_refreshes ~clock () =
+  let module Runtime = Server_dashboard_http_runtime_info in
+  let old_status =
+    { Runtime.branch = Some "main"
+    ; upstream_ref = Some "origin/main"
+    ; upstream_head_commit = Some "old"
+    ; ahead_count = Some 0
+    ; behind_count = Some 1
+    }
+  in
+  let new_status = { old_status with upstream_head_commit = Some "new"; behind_count = Some 0 } in
+  let check_status label expected actual =
+    match expected, actual with
+    | None, None -> ()
+    | Some expected, Some actual ->
+      Alcotest.(check (option string))
+        (label ^ " branch")
+        expected.Runtime.branch
+        actual.Runtime.branch;
+      Alcotest.(check (option string))
+        (label ^ " upstream ref")
+        expected.upstream_ref
+        actual.upstream_ref;
+      Alcotest.(check (option string))
+        (label ^ " upstream head")
+        expected.upstream_head_commit
+        actual.upstream_head_commit;
+      Alcotest.(check (option int))
+        (label ^ " ahead")
+        expected.ahead_count
+        actual.ahead_count;
+      Alcotest.(check (option int))
+        (label ^ " behind")
+        expected.behind_count
+        actual.behind_count
+    | _ -> Alcotest.failf "%s status mismatch" label
+  in
+  Runtime.clear_git_upstream_status_cache_for_tests ();
+  with_temp_dir "runtime-git-upstream-cache" (fun dir ->
+      Runtime.seed_git_upstream_status_cache_for_tests dir (Some old_status)
+        ~refreshed_at:(Time_compat.now () -. 120.0);
+      let probes = Atomic.make 0 in
+      Runtime.set_git_upstream_status_probe_hook_for_tests (fun _ ->
+          Atomic.incr probes;
+          Eio.Time.sleep clock 0.05;
+          Some new_status);
+      Fun.protect
+        ~finally:(fun () ->
+          Runtime.clear_git_upstream_status_probe_hook_for_tests ();
+          Runtime.clear_git_upstream_status_cache_for_tests ())
+        (fun () ->
+          check_status
+            "expired cache returns stale immediately"
+            (Some old_status)
+            (Runtime.git_upstream_status dir);
+          Eio.Time.sleep clock 0.15;
+          check_status
+            "background refresh stores fresh value"
+            (Some new_status)
+            (Runtime.git_upstream_status dir);
+          Alcotest.(check int) "single background probe" 1
+            (Atomic.get probes)))
+
 let test_runtime_git_probe_argv_disables_optional_locks () =
   let module Runtime = Server_dashboard_http_runtime_info in
   Alcotest.(check (list string))
@@ -626,6 +689,8 @@ let () =
           test_case "stampede protection" `Quick test_stampede;
           test_case "runtime git cache stale-first refresh" `Quick
             (test_runtime_git_cache_returns_stale_and_refreshes ~clock);
+          test_case "runtime git upstream cache stale-first refresh" `Quick
+            (test_runtime_git_upstream_cache_returns_stale_and_refreshes ~clock);
           test_case "runtime git probe disables optional locks" `Quick
             test_runtime_git_probe_argv_disables_optional_locks;
         ] );

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -50,6 +50,7 @@ let run_git_exn repo args =
 
 let with_stubbed_git_probe f =
   Lib.Server_dashboard_http.clear_git_rev_parse_short_cache_for_tests ();
+  Lib.Server_dashboard_http.clear_git_upstream_status_cache_for_tests ();
   Lib.Server_dashboard_http.set_git_rev_parse_short_probe_hook_for_tests
     (fun _ -> Some "test");
   Lib.Server_dashboard_http.set_git_upstream_status_probe_hook_for_tests
@@ -65,7 +66,8 @@ let with_stubbed_git_probe f =
     ~finally:(fun () ->
       Lib.Server_dashboard_http.clear_git_rev_parse_short_probe_hook_for_tests ();
       Lib.Server_dashboard_http.clear_git_upstream_status_probe_hook_for_tests ();
-      Lib.Server_dashboard_http.clear_git_rev_parse_short_cache_for_tests ())
+      Lib.Server_dashboard_http.clear_git_rev_parse_short_cache_for_tests ();
+      Lib.Server_dashboard_http.clear_git_upstream_status_cache_for_tests ())
     f
 
 let seed_git_probe_cache config =
@@ -87,9 +89,12 @@ let with_dashboard_eio f =
   f ()
 
 let test_git_upstream_status_uses_origin_head_for_detached_checkout () =
+  Lib.Server_dashboard_http.clear_git_upstream_status_cache_for_tests ();
   let dir = test_dir () in
   Fun.protect
-    ~finally:(fun () -> cleanup_dir dir)
+    ~finally:(fun () ->
+      Lib.Server_dashboard_http.clear_git_upstream_status_cache_for_tests ();
+      cleanup_dir dir)
     (fun () ->
       with_dashboard_eio @@ fun () ->
       ignore (run_git_exn dir [ "init"; "-q"; "-b"; "main" ]);


### PR DESCRIPTION
## Summary
- add a stale-first 60s cache plus in-flight guard for runtime git upstream status probes
- keep stale upstream status serving while background refresh runs, matching git rev-parse short behavior
- add test seams and regression coverage for stale-first upstream refresh

## Verification
- ocamlformat --check lib/server/server_dashboard_http_runtime_info.ml lib/server/server_dashboard_http_runtime_info.mli test/test_dashboard_cache.ml test/test_dashboard_tools.ml
- ocamlc -stop-after parsing lib/server/server_dashboard_http_runtime_info.ml lib/server/server_dashboard_http_runtime_info.mli test/test_dashboard_cache.ml test/test_dashboard_tools.ml
- git diff --check
- scripts/dune-local.sh build test/test_dashboard_cache.exe test/test_dashboard_tools.exe blocked by live bare Dune processes outside scripts/dune-local.sh