### PR TITLE
refactor(keeper): reject legacy blocker meta sidecars

### DIFF
--- a/dashboard/src/components/fleet-health-panel.test.ts
+++ b/dashboard/src/components/fleet-health-panel.test.ts
@@ -164,8 +164,10 @@ describe('FleetHealthPanel', () => {
             auto_resume_source: 'explicit',
             paused_elapsed_sec: 12,
             auto_resume_remaining_sec: 48,
-            last_blocker_class: 'turn_timeout',
-            last_blocker_detail: 'turn exceeded budget',
+            last_blocker: {
+              klass: 'turn_timeout',
+              detail: 'turn exceeded budget',
+            },
             missing_pause_root_cause: false,
           }],
         },

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -303,10 +303,21 @@ function cdalTone(cdal: DashboardCdalHealth | null): 'crit' | 'warn' | 'ok' | un
   return cdal.writer_status === 'active' ? 'ok' : 'warn'
 }
 
+function blockerClassText(row: DashboardPausedKeeperDetail): string | null {
+  const klass = row.last_blocker?.klass
+  if (typeof klass === 'string') return klass
+  return klass?.name ?? null
+}
+
+function blockerDetailText(row: DashboardPausedKeeperDetail): string | null {
+  return row.last_blocker?.detail ?? null
+}
+
 function pausedKindText(row: DashboardPausedKeeperDetail): string {
+  const blockerClass = blockerClassText(row)
   const parts = [
     row.pause_kind ?? 'unknown',
-    row.last_blocker_class ? `blocker=${row.last_blocker_class}` : null,
+    blockerClass ? `blocker=${blockerClass}` : null,
     row.auto_resume_source ? `resume=${row.auto_resume_source}` : null,
   ].filter((part): part is string => part != null)
   return parts.join(' · ')
@@ -337,7 +348,7 @@ function RuntimePausedKeeperTable({ fleetSafety }: { fleetSafety: DashboardFleet
           ${details.map(row => html`
             <tr class="border-b border-[var(--color-border-default)]/30 last:border-b-0">
               <td class="px-3 py-2 font-mono text-[var(--color-fg-primary)]">${row.name}</td>
-              <td class="px-3 py-2 text-[var(--color-fg-secondary)]" title=${row.last_blocker_detail ?? undefined}>${pausedKindText(row)}</td>
+              <td class="px-3 py-2 text-[var(--color-fg-secondary)]" title=${blockerDetailText(row) ?? undefined}>${pausedKindText(row)}</td>
               <td class="px-3 py-2 text-right font-mono text-[var(--color-fg-muted)]">${secondsText(row.paused_elapsed_sec)}</td>
               <td class="px-3 py-2 text-right font-mono text-[var(--color-fg-muted)]">${secondsText(row.auto_resume_remaining_sec)}</td>
             </tr>

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -195,8 +195,10 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
           auto_resume_source: 'explicit',
           paused_elapsed_sec: 12,
           auto_resume_remaining_sec: 48,
-          last_blocker_class: 'turn_timeout',
-          last_blocker_detail: 'turn exceeded budget',
+          last_blocker: {
+            klass: 'turn_timeout',
+            detail: 'turn exceeded budget',
+          },
           missing_pause_root_cause: false,
         }],
         read_error_count: 0,
@@ -261,7 +263,9 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
           name: 'analyst',
           pause_kind: 'auto_recoverable',
           auto_resume_source: 'explicit',
-          last_blocker_class: 'turn_timeout',
+          last_blocker: {
+            klass: 'turn_timeout',
+          },
         }],
       },
       keeper_fd_pressure: {

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -15,6 +15,8 @@ import type {
   DashboardCdalTaskScopeHealth,
   DashboardFleetPressureHealth,
   DashboardFleetSafetyHealth,
+  DashboardBlockerClassObject,
+  DashboardBlockerInfo,
   DashboardKeeperReactionLedgerHealth,
   DashboardKeeperReactionLedgerPendingKeeper,
   DashboardPausedKeeperDetail,
@@ -619,6 +621,25 @@ function normalizeDashboardFdAccountant(raw: unknown): DashboardRuntimeResolutio
   }
 }
 
+function normalizeDashboardBlockerClass(raw: unknown): DashboardBlockerInfo['klass'] {
+  const name = asString(raw)
+  if (name) return name
+  if (!isRecord(raw)) return null
+  const objectName = asString(raw.name)
+  if (!objectName) return null
+  const result: DashboardBlockerClassObject = { name: objectName }
+  if ('reason' in raw) result.reason = raw.reason
+  return result
+}
+
+function normalizeDashboardBlockerInfo(raw: unknown): DashboardBlockerInfo | null {
+  if (!isRecord(raw)) return null
+  const klass = normalizeDashboardBlockerClass(raw.klass)
+  const detail = asString(raw.detail) ?? null
+  if (klass == null && detail == null) return null
+  return { klass, detail }
+}
+
 function normalizeDashboardPausedKeeperDetail(raw: unknown): DashboardPausedKeeperDetail | null {
   if (!isRecord(raw)) return null
   const name = asString(raw.name)
@@ -632,8 +653,7 @@ function normalizeDashboardPausedKeeperDetail(raw: unknown): DashboardPausedKeep
     auto_resume_source: asString(raw.auto_resume_source) ?? null,
     paused_elapsed_sec: asNumber(raw.paused_elapsed_sec) ?? null,
     auto_resume_remaining_sec: asNumber(raw.auto_resume_remaining_sec) ?? null,
-    last_blocker_class: asString(raw.last_blocker_class) ?? null,
-    last_blocker_detail: asString(raw.last_blocker_detail) ?? null,
+    last_blocker: normalizeDashboardBlockerInfo(raw.last_blocker),
     missing_pause_root_cause: asBoolean(raw.missing_pause_root_cause) ?? null,
   }
 }

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -137,6 +137,18 @@ export interface DashboardFleetSafetyHealth {
   keeper_reaction_ledger: DashboardKeeperReactionLedgerHealth | null
 }
 
+export interface DashboardBlockerClassObject {
+  name: string
+  reason?: unknown
+}
+
+export type DashboardBlockerClass = string | DashboardBlockerClassObject
+
+export interface DashboardBlockerInfo {
+  klass: DashboardBlockerClass | null
+  detail: string | null
+}
+
 export interface DashboardPausedKeeperDetail {
   name: string
   autoboot_enabled: boolean | null
@@ -146,8 +158,7 @@ export interface DashboardPausedKeeperDetail {
   auto_resume_source: string | null
   paused_elapsed_sec: number | null
   auto_resume_remaining_sec: number | null
-  last_blocker_class: string | null
-  last_blocker_detail: string | null
+  last_blocker: DashboardBlockerInfo | null
   missing_pause_root_cause: boolean | null
 }
 

--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 14:07:28 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 14:40:26 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -576,6 +576,12 @@
             <td><code>message_of_json</code> now raises on missing/invalid <code>content_blocks</code>. Tests assert canonical rows still decode and flat legacy tool rows are rejected.</td>
           </tr>
           <tr>
+            <td><code>keeper_meta</code> blocker and identity sidecars</td>
+            <td><span class="status now">draft PR #18640</span></td>
+            <td>Stop treating old <code>last_blocker</code>/<code>last_blocker_class</code> pairs and embedded meta <code>github_identity</code> as readable keeper state. <code>github_identity</code> belongs to keeper TOML + credential mapping + playground credential env, not runtime meta. Health output moves to the structured <code>last_blocker</code> object instead of class/detail sidecar fields.</td>
+            <td>Roundtrip tests keep only structured blocker JSON. Legacy blocker string/pair and meta <code>github_identity</code> rows are rejection tests; existing sandbox tests keep proving TOML/mapping-driven <code>github_identity</code> env injection.</td>
+          </tr>
+          <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
             <td><span class="status done">merged #18369</span></td>
             <td>Remove <code>ckpt-*.json</code> recovery, checkpoint writer/reader public APIs, state-snapshot sidecar hydration, migration wording, and obsolete fallback tests.</td>
@@ -617,7 +623,7 @@
           <tr>
             <td>P1</td>
             <td>Memory/context legacy read fallbacks</td>
-            <td>Remaining dated-store and old-row fallback readers hide whether current writers are clean. Checkpoint sidecar runtime readers were removed in #18622; direct flat message-content decode was removed in #18630.</td>
+            <td>Remaining dated-store and old-row fallback readers hide whether current writers are clean. Checkpoint sidecar runtime readers were removed in #18622; direct flat message-content decode was removed in #18630. The keeper_meta blocker/identity sidecar purge is in draft PR #18640.</td>
             <td>Split into runtime-data migration and code deletion. Delete read fallback after migration proof or if runtime reset is acceptable; do not preserve legacy checkpoint sidecar or flat-content behavior.</td>
             <td>Remove tests that require old-row readability. Keep corruption/drop tests only for current schema.</td>
           </tr>

--- a/docs/rfc/RFC-0062-typed-tool-result-and-blocker-class.md
+++ b/docs/rfc/RFC-0062-typed-tool-result-and-blocker-class.md
@@ -14,7 +14,7 @@ Two adjacent silent-failure surfaces shared a root cause — strings used where 
 
 ### 1.1 Agent SDK error → keeper `blocker_class` stamp gap
 
-`keeper_status_bridge.ml :: blocker_class_of_sdk_error` had a `_ -> None` catch-all that silently dropped 9 `Agent_sdk.Error.Agent` constructors (`MaxTurnsExceeded`, `TokenBudgetExceeded`, `CostBudgetExceeded`, `UnrecognizedStopReason`, `IdleDetected`, `ToolRetryExhausted`, `GuardrailViolation`, `TripwireViolation`, `ExitConditionMet`). Result: `last_blocker_class = null` while the surface text *was* stamped — dashboards and Prometheus showed zero counts for these classes even though they were occurring.
+`keeper_status_bridge.ml :: blocker_class_of_sdk_error` had a `_ -> None` catch-all that silently dropped 9 `Agent_sdk.Error.Agent` constructors (`MaxTurnsExceeded`, `TokenBudgetExceeded`, `CostBudgetExceeded`, `UnrecognizedStopReason`, `IdleDetected`, `ToolRetryExhausted`, `GuardrailViolation`, `TripwireViolation`, `ExitConditionMet`). Result: structured blocker class state stayed null while the surface text *was* stamped — dashboards and Prometheus showed zero counts for these classes even though they were occurring.
 
 ### 1.2 Tool dispatch return: `(bool * string)` with substring classifier
 
@@ -117,7 +117,7 @@ This RFC chooses the structural fix: **closed sum types + exhaustive match**. Ne
 
 ## 7. Observability
 
-Dashboards and Prometheus exporters that already consumed `last_blocker_class` automatically gained visibility into the 9 previously-dropped SDK variants once Phase 0 landed. No new counter or label was introduced — the structural fix made existing telemetry correct (the inverse of workaround signature #1, which would have added new counters without fixing the underlying drop).
+Dashboards and Prometheus exporters that already consumed keeper blocker-class state automatically gained visibility into the 9 previously-dropped SDK variants once Phase 0 landed. The current dashboard/health surface reads that state from structured `last_blocker.klass`; the old class/detail sidecar fields are no longer a runtime contract. No new counter or label was introduced — the structural fix made existing telemetry correct (the inverse of workaround signature #1, which would have added new counters without fixing the underlying drop).
 
 ## 8. Risks
 

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -131,11 +131,11 @@ type blocker_class =
         Maps to [Keeper_registry.Stale_turn_timeout _] cohort.  Like
         [Fiber_unresolved], this path runs through
         [force_unresolved_watchdog_crash] and never visits
-        [handle_crash_auto_pause], so PR #12889's [last_blocker_class]
-        stamp does not apply.  Without this variant, dashboards and
-        per-keeper meta read [last_blocker_class = null] for the
-        majority cohort during a fleet stall (observed: 6/14 keepers
-        in cohort=stale_turn_timeout, every meta showing null). *)
+        [handle_crash_auto_pause], so historical string-only blocker
+        stamping did not apply. Without this variant, dashboards and
+        per-keeper meta lacked a structured blocker class for the majority
+        cohort during a fleet stall (observed: 6/14 keepers in
+        cohort=stale_turn_timeout). *)
   | Stale_fleet_batch
     (** Legacy blocker class for pre-existing fleet-batch state. Current
         fleet-batch detection is observation-only and should not stamp keeper
@@ -301,14 +301,13 @@ let cascade_exhaustion_reason_from_message msg =
 ;;
 
 (* ── Unified blocker_info: typed klass + free-form detail ───────
-   Replaces the historic [last_blocker: string] +
-   [last_blocker_class: blocker_class option] pair.  The string-only
-   field was used by [blocker_class_of_string] (substring classifier)
-   to recover a typed class — exactly the workaround pattern called
-   out in CLAUDE.md "워크어라운드 거부 기준 #2 String/Substring
-   분류기 보강".  Making [blocker_class] the only authoritative class
-   eliminates that recovery path; [detail] carries free-form context
-   for UI / Prometheus labels (no classification semantics). *)
+   Replaces the historic split blocker fields. The string-only field was used
+   by [blocker_class_of_string] (substring classifier) to recover a typed
+   class — exactly the workaround pattern called out in CLAUDE.md
+   "워크어라운드 거부 기준 #2 String/Substring 분류기 보강". Making
+   [blocker_class] the only authoritative class eliminates that recovery path;
+   [detail] carries free-form context for UI / Prometheus labels (no
+   classification semantics). *)
 type blocker_info = {
   klass : blocker_class;
   detail : string;

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -237,12 +237,11 @@ type blocker_info = {
 }
 (** Authoritative blocker representation: a typed [blocker_class]
     paired with optional free-form [detail] (UI / Prometheus label).
-    Replaces the deprecated [last_blocker: string] +
-    [last_blocker_class: blocker_class option] pair so substring
-    classification (the [blocker_class_of_string] workaround) is
-    no longer load-bearing.  When there is no blocker, the runtime
-    state holds [None]; when there is a blocker, [klass] is always
-    populated and [detail] may be ["" ]. *)
+    Replaces the deprecated split blocker fields, so substring
+    classification (the [blocker_class_of_string] workaround) is no
+    longer load-bearing for persisted keeper_meta.  When there is no
+    blocker, the runtime state holds [None]; when there is a blocker,
+    [klass] is always populated and [detail] may be ["" ]. *)
 
 val blocker_info_of_class : ?detail:string -> blocker_class -> blocker_info
 (** [blocker_info_of_class ?detail klass] constructs a [blocker_info]

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -292,15 +292,6 @@ let canonical_keeper_meta_key_names =
     fallback_canonical_keeper_meta_key_names
 ;;
 
-(* Keys that the writer no longer emits but legacy on-disk JSON may
-   still carry.  The reader handles them (one-shot migration); we
-   suppress the unknown-keys warning so legacy reads stay quiet on
-   the way to first re-write. *)
-let deprecated_keeper_meta_key_names =
-  [ "last_blocker_class"
-  ; "github_identity"
-  ]
-
 let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
@@ -308,7 +299,6 @@ let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
       fields
       |> List.filter_map (fun (key, _) ->
         if List.mem key canonical_keeper_meta_key_names
-           || List.mem key deprecated_keeper_meta_key_names
         then None
         else Some key)
       |> dedupe_keep_order

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -493,27 +493,13 @@ let parse_keeper_state
      masc_oas_error_max_chars and falls through to the narrative
      budget for plain text. Symmetric with the write side in
      Keeper_social_model_types.cap_social_state. *)
-  (* New format: last_blocker is a structured object (blocker_info_to_json
-     output) or `Null.  Legacy format had two fields: last_blocker:string
-     and last_blocker_class:string|null.  We accept both shapes for one-shot
-     read migration; the next write upgrades to the new format. *)
+  (* Canonical format: last_blocker is a structured object
+     (blocker_info_to_json output) or `Null. *)
   let last_blocker =
     let raw_field = Yojson.Safe.Util.member "last_blocker" json in
     match raw_field with
     | `Null -> None
     | `Assoc _ -> blocker_info_of_json raw_field
-    | `String legacy_text ->
-      let detail =
-        Keeper_social_model_types.cap_blocker (String.trim legacy_text)
-      in
-      let klass_from_pair =
-        match Safe_ops.json_string_opt "last_blocker_class" json with
-        | Some raw -> blocker_class_of_serialized_string raw
-        | None -> None
-      in
-      (match klass_from_pair with
-       | Some klass -> Some { klass; detail }
-       | None -> None)
     | _ -> None
 	  in
 	  let last_need = cap_loaded (Safe_ops.json_string ~default:"" "last_need" json) in
@@ -574,6 +560,18 @@ let parse_keeper_state
   }
 ;;
 
+let reject_legacy_keeper_meta_shapes (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "last_blocker" fields with
+     | Some (`String _) ->
+       Error
+         "legacy keeper meta field shape is no longer supported: \
+          last_blocker:string. Use structured last_blocker object."
+     | Some _ | None -> Ok ())
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> Ok ()
+;;
+
 let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
   try
     match reject_removed_keeper_meta_fields json with
@@ -582,6 +580,9 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
       (match reject_legacy_keeper_meta_fields json with
        | Error e -> Error e
        | Ok () ->
+         (match reject_legacy_keeper_meta_shapes json with
+          | Error e -> Error e
+          | Ok () ->
          (match parse_keeper_identity json with
           | Error _ as e -> e
           | Ok identity ->
@@ -720,7 +721,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                        (match Safe_ops.json_int_opt "meta_version" json with
                         | Some v -> v
                         | None -> 0)
-                   }))))
+                   })))))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -25,7 +25,8 @@ let legacy_keeper_meta_tool_policy_key_names =
 ;;
 
 let legacy_keeper_meta_key_names =
-  "allowed_providers" :: legacy_keeper_meta_tool_policy_key_names
+  [ "allowed_providers"; "last_blocker_class"; "github_identity" ]
+  @ legacy_keeper_meta_tool_policy_key_names
 ;;
 
 let reject_legacy_keeper_meta_fields (json : Yojson.Safe.t) =

--- a/lib/keeper/keeper_meta_json_scrub.mli
+++ b/lib/keeper/keeper_meta_json_scrub.mli
@@ -16,7 +16,8 @@ val reject_removed_keeper_meta_fields :
 (** Legacy tool-policy keys that are no longer supported. *)
 val legacy_keeper_meta_tool_policy_key_names : string list
 
-(** Combined legacy key names (allowed_providers + tool-policy keys). *)
+(** Combined legacy key names (allowed_providers, retired meta sidecars,
+    and tool-policy keys). *)
 val legacy_keeper_meta_key_names : string list
 
 (** Returns [Error msg] if any legacy key is present. *)

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -58,8 +58,8 @@ let blocker_class_of_string (reason : string) : blocker_class option =
   then Some Turn_livelock_blocked
   else if
     (* 2026-05-05: Completion contract violations (e.g. require_tool_use)
-       were text-stamped to runtime.last_blocker but left
-       runtime.last_blocker_class null because [blocker_class_of_sdk_error]
+       were text-stamped to runtime.last_blocker without a structured class
+       because [blocker_class_of_sdk_error]
        returned None on the [Agent_sdk.Error.Agent
        (CompletionContractViolation _)] path and the fallthrough to
        [blocker_class_of_string] had no matching substring.  Variant

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -210,11 +210,11 @@ val cascade_exhaustion_reason_from_message :
     [Keeper_meta_contract.cascade_exhaustion_reason_from_message]. *)
 
 (** Authoritative blocker representation: typed [klass] + free-form
-    [detail].  Replaces the historic [last_blocker: string] +
-    [last_blocker_class: blocker_class option] pair so substring
-    classification is no longer load-bearing.  Re-exported via type
-    equation from [Keeper_meta_contract] so values flow without
-    coercion across the facade boundary. *)
+    [detail].  The historic split blocker fields are no longer a
+    supported keeper_meta shape, so substring classification is not
+    load-bearing.  Re-exported via type equation from
+    [Keeper_meta_contract] so values flow without coercion across the
+    facade boundary. *)
 type blocker_info = Keeper_meta_contract.blocker_info = {
   klass : blocker_class;
   detail : string;

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -267,12 +267,12 @@ let should_dedupe_request_help ~(meta : keeper_meta) ~(blocker : string option) 
   match blocker with
   | None -> false
   | Some blocker ->
-      let last_blocker_detail =
+      let previous_blocker_detail =
         match meta.runtime.last_blocker with
         | Some info -> String.trim info.detail
         | None -> ""
       in
-      String.equal blocker last_blocker_detail
+      String.equal blocker previous_blocker_detail
       && String.equal meta.runtime.last_speech_act "request_help"
       && meta.runtime.proactive_rt.last_ts > 0.0
       && Time_compat.now () -. meta.runtime.proactive_rt.last_ts

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -320,8 +320,7 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
        run turns, and auto-paused keepers may no longer have a live registry
        entry. The dashboard "깨우기" button now auto-resumes paused keepers,
        but ops still need a quick count without scraping /metrics. List names
-       so an operator can correlate with the cause encoded in their
-       last_blocker_class. *)
+       so an operator can correlate with the structured blocker cause. *)
     (key_paused_keepers, paused_keepers_json);
     ("cdal", cdal_health_json);
     ("keeper_config_parse_error_count",

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -32,21 +32,6 @@ let effective_autoboot_enabled name (meta : Keeper_types.keeper_meta) =
   | Some value -> value
   | None -> meta.autoboot_enabled
 
-let blocker_class_string (info : Keeper_types.blocker_info option) =
-  match info with
-  | Some info ->
-      let surface =
-        Keeper_status_bridge.runtime_blocker_surface_of_typed_class
-          ~summary:info.detail info.klass
-      in
-      Some surface.blocker_class
-  | None -> None
-
-let blocker_detail (info : Keeper_types.blocker_info option) =
-  match info with
-  | Some { detail; _ } when String.trim detail <> "" -> Some detail
-  | Some _ | None -> None
-
 let pause_elapsed_sec now (meta : Keeper_types.keeper_meta) =
   match Coord_resilience.Time.parse_iso8601_opt meta.updated_at with
   | Some updated_ts when updated_ts > 0.0 -> Some (max 0.0 (now -. updated_ts))
@@ -85,8 +70,10 @@ let paused_keeper_detail_json ~now ~name ~(autoboot_enabled : bool)
     ("auto_resume_source", json_string_opt (pause_auto_resume_source meta));
     ("paused_elapsed_sec", json_float_opt elapsed);
     ("auto_resume_remaining_sec", json_float_opt remaining);
-    ("last_blocker_class", json_string_opt (blocker_class_string last_blocker));
-    ("last_blocker_detail", json_string_opt (blocker_detail last_blocker));
+    ( "last_blocker"
+    , match last_blocker with
+      | Some info -> Keeper_types.blocker_info_to_json info
+      | None -> `Null );
     ( "missing_pause_root_cause",
       `Bool
         (Option.is_some meta.auto_resume_after_sec

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -1,9 +1,9 @@
-(** #12683 — pin that auto-pause paths write [last_blocker] and
-    [last_blocker_class] into keeper_meta so the blocker survives
+(** #12683 — pin that auto-pause paths write structured [last_blocker]
+    into keeper_meta so the blocker survives
     supervisor unregister/restart.
 
     Structural fact this test pins: a meta JSON written with
-    [last_blocker] and [last_blocker_class] round-trips through
+    structured [last_blocker] round-trips through
     serialization/deserialization without loss, so the blocker survives
     server restart.
 
@@ -115,6 +115,69 @@ let test_meta_json_roundtrip_with_stale_storm_blocker () =
       | _ -> fail "blocker klass not Turn_timeout after roundtrip")
    | None -> fail "last_blocker should be Some after roundtrip")
 
+let legacy_base_json name =
+  `Assoc
+    [
+      "name", `String name;
+      "agent_name", `String (name ^ "-agent");
+      "trace_id", `String ("trace-" ^ name);
+      "goal", `String "test";
+      "sandbox_profile", `String "local";
+      "network_mode", `String "inherit";
+    ]
+
+let test_legacy_last_blocker_pair_rejected () =
+  let legacy_json =
+    match legacy_base_json "legacy-blocker-pair" with
+    | `Assoc fields ->
+      `Assoc
+        (fields
+         @ [
+           "last_blocker", `String "turn wall-clock timeout exceeded";
+           "last_blocker_class", `String "turn_timeout";
+         ])
+    | json -> json
+  in
+  match KT.meta_of_json legacy_json with
+  | Ok _ -> fail "legacy blocker pair should be rejected"
+  | Error msg ->
+    check string
+      "rejects legacy blocker class"
+      "legacy keeper meta fields are no longer supported: last_blocker_class"
+      msg
+
+let test_legacy_last_blocker_string_rejected () =
+  let legacy_json =
+    match legacy_base_json "legacy-blocker-string" with
+    | `Assoc fields ->
+      `Assoc
+        (fields @ [ "last_blocker", `String "turn wall-clock timeout exceeded" ])
+    | json -> json
+  in
+  match KT.meta_of_json legacy_json with
+  | Ok _ -> fail "legacy string last_blocker should be rejected"
+  | Error msg ->
+    check string
+      "rejects string last_blocker"
+      "legacy keeper meta field shape is no longer supported: \
+       last_blocker:string. Use structured last_blocker object."
+      msg
+
+let test_github_identity_runtime_meta_rejected () =
+  let legacy_json =
+    match legacy_base_json "legacy-github-identity" with
+    | `Assoc fields ->
+      `Assoc (fields @ [ "github_identity", `String "anyang-keepers" ])
+    | json -> json
+  in
+  match KT.meta_of_json legacy_json with
+  | Ok _ -> fail "runtime meta github_identity field should be rejected"
+  | Error msg ->
+    check string
+      "rejects github_identity"
+      "legacy keeper meta fields are no longer supported: github_identity"
+      msg
+
 let () =
   run "keeper_auto_pause_blocker_persist_12683"
     [
@@ -133,5 +196,11 @@ let () =
             test_meta_json_roundtrip_with_auto_pause_blocker;
           test_case "stale storm blocker survives serialization" `Quick
             test_meta_json_roundtrip_with_stale_storm_blocker;
+          test_case "legacy blocker pair rejected" `Quick
+            test_legacy_last_blocker_pair_rejected;
+          test_case "legacy blocker string rejected" `Quick
+            test_legacy_last_blocker_string_rejected;
+          test_case "github_identity stays out of runtime meta" `Quick
+            test_github_identity_runtime_meta_rejected;
         ] );
     ]

--- a/test/test_keeper_blocker_class_completion_contract.ml
+++ b/test/test_keeper_blocker_class_completion_contract.ml
@@ -5,7 +5,7 @@
 
     Pre-fix bug: 4/14 production keepers had
     [last_blocker = "Completion contract [require_tool_use] violated: …"]
-    but [last_blocker_class = null], causing the dashboard "차단된 키퍼"
+    but no structured blocker class, causing the dashboard "차단된 키퍼"
     card and Prometheus blocker-class series to silently drop this
     failure mode.  Variant existed in [Keeper_types.blocker_class] but
     the bridge had no mapping. *)

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1931,7 +1931,7 @@ let test_persisted_blocker_survives_unregister () =
            (match m.runtime.last_blocker with
             | Some b ->
                 check string "meta.runtime.last_blocker" "test-blocker" b.detail;
-                check bool "meta.runtime.last_blocker_class" true (b.klass = KT.Turn_timeout)
+                check bool "meta.runtime.last_blocker.klass" true (b.klass = KT.Turn_timeout)
             | None -> fail "expected blocker after storm pause");
        | Ok None -> fail "meta missing after storm pause"
        | Error err -> fail ("read_meta failed: " ^ err));
@@ -1945,7 +1945,7 @@ let test_persisted_blocker_survives_unregister () =
            (match m.runtime.last_blocker with
             | Some b ->
                 check string "meta.runtime.last_blocker after unregister" "test-blocker" b.detail;
-                check bool "meta.runtime.last_blocker_class after unregister" true (b.klass = KT.Turn_timeout)
+                check bool "meta.runtime.last_blocker.klass after unregister" true (b.klass = KT.Turn_timeout)
             | None -> fail "expected blocker after unregister")
        | Ok None -> fail "meta missing after unregister"
        | Error err -> fail ("read_meta failed: " ^ err)))

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -1541,11 +1541,11 @@ let test_keeper_up_keeps_paused_keeper_with_continue_gate_blocker () =
           runtime =
             {
               meta.runtime with
-              (* Pre-refactor this test stamped only [last_blocker = blocker_text]
-                 with [last_blocker_class = None] and relied on the substring
-                 [blocker_class_of_string] matcher to recover the typed class.
-                 After the unified [blocker_info] migration the typed class is
-                 the only authoritative source — set it directly. *)
+              (* Pre-refactor this test stamped only [last_blocker =
+                 blocker_text] and relied on a substring matcher to recover
+                 the typed class. After the unified [blocker_info] migration
+                 the typed class is the only authoritative source — set it
+                 directly. *)
               last_blocker =
                 Some (Keeper_types.blocker_info_of_class
                         ~detail:blocker_text

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1187,7 +1187,7 @@ let test_health_json_keeps_timeout_pause_without_policy_manual () =
         Alcotest.(check bool) "auto resume source is absent" true
           (Yojson.Safe.Util.member "auto_resume_source" detail = `Null);
         Alcotest.(check string) "last blocker class" "turn_timeout"
-          (detail |> member "last_blocker_class" |> to_string)))
+          (detail |> member "last_blocker" |> member "klass" |> to_string)))
 
 let test_health_json_degrades_when_reaction_capacity_below_target () =
   with_temp_dir "health-reaction-capacity-below-target" (fun dir ->


### PR DESCRIPTION
## Summary
- reject legacy runtime keeper_meta blocker sidecars: last_blocker:string, last_blocker_class, and runtime-meta github_identity
- move paused keeper health/dashboard to structured last_blocker instead of last_blocker_class/detail sidecars
- keep github_identity on the canonical keeper TOML + credential mapping + playground credential env path, not in runtime meta
- update the legacy purge HTML ledger and RFC wording so active docs no longer teach the old dashboard field

## Validation
- ocamlformat --check on touched OCaml files
- git diff --check
- pnpm --dir dashboard typecheck
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/store-normalizers.test.ts src/components/fleet-health-panel.test.ts
- pnpm --dir dashboard lint
- scripts/audit-keeper-tool-boundary-matrix.sh
- scripts/lint/no-ocaml-comment-terminator-trap.sh
- scripts/lint/no-unknown-permissive-default.sh
- rg -n "last_blocker_class|last_blocker_detail" lib dashboard/src test docs/audit/2026-05-25-legacy-purge-plan.html docs/rfc/RFC-0062-typed-tool-result-and-blocker-class.md

## Dune
- scripts/dune-local.sh build test/test_keeper_auto_pause_blocker_persist_12683.exe test/test_server_runtime_bootstrap.exe test/test_operator_control_keeper.exe test/test_keeper_blocker_class_completion_contract.exe test/test_keeper_supervisor.exe is currently blocked by machine-wide bare Dune processes; wrapper exits 75 as intended, and I did not bypass it with MASC_DUNE_ALLOW_BARE_DUNE=1.
