### PR TITLE
[codex] fix keeper support split test refs

### DIFF
--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -3,6 +3,7 @@ open Masc_mcp
 
 module Coord = Masc_mcp.Coord
 module KT = Masc_mcp.Keeper_types
+module KTS = Masc_mcp.Keeper_types_support
 
 let counter = ref 0
 
@@ -184,7 +185,7 @@ let log_tool_execute_with_identity ?(keeper_name = "alpha") () =
     ()
 
 let write_decision_lines config keeper_name rows =
-  let path = KT.keeper_decision_log_path config keeper_name in
+  let path = KTS.keeper_decision_log_path config keeper_name in
   Fs_compat.mkdir_p (Filename.dirname path);
   Fs_compat.save_file path
     (String.concat "\n" (List.map Yojson.Safe.to_string rows) ^ "\n")

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -199,7 +199,7 @@ let test_tool_audit_counts_decision_log_parse_drops () =
       let config = Coord.default_config base_path in
       let keeper_name = "keeper-tool-audit-decisions" in
       write_lines
-        (KT.keeper_decision_log_path config keeper_name)
+        (KTS.keeper_decision_log_path config keeper_name)
         [
           {|{"ts":"2026-05-07T00:00:00Z","tools_used":["masc_task_status"],"tool_call_count":1}|};
           "[]";

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -7,6 +7,7 @@ module KHB = Masc_mcp.Keeper_heartbeat_snapshot
 module KHS = Masc_mcp.Keeper_keepalive_signal
 module KST = Masc_mcp.Keeper_state_machine
 module KFS = Masc_mcp.Keeper_fs
+module KTS = Masc_mcp.Keeper_types_support
 module P = Masc_mcp.Prometheus
 
 let temp_dir prefix =
@@ -291,7 +292,7 @@ let test_heartbeat_history_fallback_counts_malformed_rows () =
       let trace_id =
         Masc_mcp.Keeper_id.Trace_id.to_string meta.runtime.trace_id
       in
-      let history_path = KT.keeper_history_path config trace_id in
+      let history_path = KTS.keeper_history_path config trace_id in
       write_lines history_path
         [
           {|{"role":"user","content":"keep continuity","source":"user"}|};

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -9,6 +9,7 @@ module Keeper_world_observation = Masc_mcp.Keeper_world_observation
 module Meas = Masc_mcp.Keeper_measurement
 module Keeper_fs = Masc_mcp.Keeper_fs
 module Keeper_types = Masc_mcp.Keeper_types
+module Keeper_types_support = Masc_mcp.Keeper_types_support
 module Keeper_memory_policy = Masc_mcp.Keeper_memory_policy
 module KET = Masc_mcp.Keeper_exec_tools
 module KEC = Masc_mcp.Keeper_exec_context

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -26,6 +26,7 @@ module OMR = Masc_mcp.Cascade_runtime
 module AQ = Masc_mcp.Keeper_approval_queue
 module Keeper_fs = Masc_mcp.Keeper_fs
 module Keeper_types = Masc_mcp.Keeper_types
+module Keeper_types_support = Masc_mcp.Keeper_types_support
 
 let oas_error_cascade_name raw =
   let normalized = Masc_mcp.Keeper_cascade_profile.normalize_declared_name raw in


### PR DESCRIPTION
## Summary
- point keeper path helper test calls at Keeper_types_support after the support split
- add missing Keeper_types_support aliases in keeper memory/unified tests
- cover the same stale helper pattern in dashboard keeper feature proof

## Root cause
The support split removed path helper exposure from Keeper_types, but several tests still referenced the old facade or lacked an alias for Keeper_types_support.

## Validation
- ocamlformat --check test/test_keeper_exec_status.ml test/test_keeper_lifecycle_registry_dispatch.ml test/test_dashboard_keeper_feature_proof.ml test/test_keeper_memory.ml test/test_keeper_unified.ml
- env DUNE_BUILD_DIR=/tmp/masc-mcp-check-fix-main-keeper-types-support-test-refs MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_OPAM_LOCK=1 scripts/dune-local.sh build test/test_keeper_exec_status.exe test/test_keeper_lifecycle_registry_dispatch.exe test/test_keeper_memory.exe test/test_keeper_unified.exe test/test_dashboard_keeper_feature_proof.exe