### PR TITLE
fix(keeper): move git exit deterministic marker to producer

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -41,4 +41,6 @@ include Keeper_shell_ops
 
 module For_testing = struct
   let elapsed_duration_ms = Keeper_shell_bash.For_testing.elapsed_duration_ms
+  let deterministic_retry_fields_for_process_result =
+    Keeper_shell_bash.For_testing.deterministic_retry_fields_for_process_result
 end

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -72,6 +72,10 @@ val handle_tool_execute :
 
 module For_testing : sig
   val elapsed_duration_ms : start_time:float -> end_time:float -> int
+  val deterministic_retry_fields_for_process_result :
+    classification:Exec_core.classification ->
+    status:Unix.process_status ->
+    (string * Yojson.Safe.t) list
 end
 
 val handle_tool_search_files :

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -9,8 +9,21 @@ let elapsed_duration_ms ~start_time ~end_time =
   | _ when elapsed_ms < 1. -> 1
   | _ -> int_of_float elapsed_ms
 
+let deterministic_retry_fields_for_process_result
+      ~(classification : Exec_core.classification)
+      ~status
+  =
+  match status, classification.Exec_core.family with
+  | Unix.WEXITED 128, (Exec_core.Git_read | Exec_core.Git_write) ->
+    Keeper_tool_deterministic_error.deterministic_retry_fields
+      Keeper_tool_deterministic_error.Git_precondition_failed
+  | _ -> []
+;;
+
 module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
+  let deterministic_retry_fields_for_process_result =
+    deterministic_retry_fields_for_process_result
 end
 
 (* Typed keeper_bash input projections extracted to
@@ -232,15 +245,22 @@ let handle_keeper_shell_ir_typed
               then result.stdout
               else result.stdout ^ result.stderr
             in
+            let classification = Exec_core.classify_command_of_ir ir in
             let runtime_failure_fields = docker_runtime_failure_fields output in
+            let deterministic_retry_fields =
+              deterministic_retry_fields_for_process_result
+                ~classification
+                ~status:result.status
+            in
             Yojson.Safe.to_string
               (Exec_core.process_result_json
-                 ~classification:(Exec_core.classify_command_of_ir ir)
+                 ~classification
                  ~base_path:root
                  ~keeper_name:meta.name
                  ~cmd
                  ~extra:
                    (runtime_failure_fields
+                    @ deterministic_retry_fields
                     @ sandbox_extra_fields
                     @ [ "cwd", `String cwd
                       ; "typed", `Bool true

--- a/lib/keeper/keeper_shell_bash.mli
+++ b/lib/keeper/keeper_shell_bash.mli
@@ -15,4 +15,8 @@ val handle_keeper_shell_ir :
 
 module For_testing : sig
   val elapsed_duration_ms : start_time:float -> end_time:float -> int
+  val deterministic_retry_fields_for_process_result :
+    classification:Exec_core.classification ->
+    status:Unix.process_status ->
+    (string * Yojson.Safe.t) list
 end

--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -12,14 +12,12 @@ type deterministic_reason =
   | Completion_contract_violation
   | Keeper_shell_op_required
   | Workflow_rejection_blocked
-  | Git_ref_precondition_failed
-  | Git_command_usage_error
+  | Git_precondition_failed
 
 type classification_source =
   | Deterministic_retry_marker
   | Workflow_rejection_marker
   | Path_check_marker
-  | Git_exit_128
 
 type classification =
   { reason : deterministic_reason
@@ -30,7 +28,6 @@ let classification_source_to_string = function
   | Deterministic_retry_marker -> "deterministic_retry_marker"
   | Workflow_rejection_marker -> "workflow_rejection_marker"
   | Path_check_marker -> "path_check_marker"
-  | Git_exit_128 -> "git_exit_128"
 ;;
 
 let to_telemetry_key = function
@@ -48,9 +45,7 @@ let to_telemetry_key = function
     "deterministic_error_completion_contract_violation"
   | Keeper_shell_op_required -> "deterministic_error_keeper_shell_op_required"
   | Workflow_rejection_blocked -> "deterministic_error_workflow_rejection_blocked"
-  | Git_ref_precondition_failed ->
-    "deterministic_error_git_ref_precondition_failed"
-  | Git_command_usage_error -> "deterministic_error_git_command_usage_error"
+  | Git_precondition_failed -> "deterministic_error_git_precondition_failed"
 ;;
 
 let to_string = function
@@ -73,10 +68,8 @@ let to_string = function
     "raw shell rejected; caller must use the visible structured tool from the recovery plan"
   | Workflow_rejection_blocked ->
     "workflow rejection explicitly marked deterministic and unrecoverable"
-  | Git_ref_precondition_failed ->
-    "git ref/precondition failure (missing ref, unknown revision, or no merge base)"
-  | Git_command_usage_error ->
-    "git command usage error; change flags or command shape before retrying"
+  | Git_precondition_failed ->
+    "git command failed a process precondition; inspect repository/ref state or change the command"
 ;;
 
 (* ── JSON helpers ─────────────────────────────────────────────── *)
@@ -137,8 +130,7 @@ let reason_to_wire = function
   | Completion_contract_violation -> "completion_contract_violation"
   | Keeper_shell_op_required -> "keeper_shell_op_required"
   | Workflow_rejection_blocked -> "workflow_rejection_blocked"
-  | Git_ref_precondition_failed -> "git_ref_precondition_failed"
-  | Git_command_usage_error -> "git_command_usage_error"
+  | Git_precondition_failed -> "git_precondition_failed"
 ;;
 
 let reason_of_wire = function
@@ -153,8 +145,7 @@ let reason_of_wire = function
   | "completion_contract_violation" -> Some Completion_contract_violation
   | "keeper_shell_op_required" -> Some Keeper_shell_op_required
   | "workflow_rejection_blocked" -> Some Workflow_rejection_blocked
-  | "git_ref_precondition_failed" -> Some Git_ref_precondition_failed
-  | "git_command_usage_error" -> Some Git_command_usage_error
+  | "git_precondition_failed" -> Some Git_precondition_failed
   | _ -> None
 ;;
 
@@ -207,37 +198,6 @@ let classify_workflow_rejection json =
   | None -> Workflow_rejection_absent
 ;;
 
-let classify_git_exit_128 json =
-  match assoc_int_opt "exit_code" json with
-  | Some 128 ->
-    let command =
-      assoc_string_opt "command" json
-      |> Option.map String.trim
-      |> Option.value ~default:""
-    in
-    let output =
-      assoc_string_opt "output" json
-      |> Option.map String.lowercase_ascii
-      |> Option.value ~default:""
-    in
-    if String.starts_with ~prefix:"git " command
-       && String_util.contains_substring output "no merge base"
-    then Some Git_ref_precondition_failed
-    else if String.starts_with ~prefix:"git " command
-            && String_util.contains_substring output "ambiguous argument"
-            && String_util.contains_substring output "unknown revision"
-    then Some Git_ref_precondition_failed
-    else if String.starts_with ~prefix:"git " command
-            && String_util.contains_substring output "unknown revision or path"
-    then Some Git_ref_precondition_failed
-    else if String.starts_with ~prefix:"git " command
-            && String_util.contains_substring output "fatal: unrecognized argument:"
-    then Some Git_command_usage_error
-    else None
-  | Some _
-  | None -> None
-;;
-
 let classify_path_check json =
   (* Some path-check failures surface as a discriminated [error] code
      directly; others nest the typed reason under
@@ -261,14 +221,15 @@ let classify_path_check json =
 
 let classify_with_source (json : Yojson.Safe.t) : classification option =
   (* Precedence: explicit deterministic_retry > workflow_rejection >
-     path_check > git exit-128.
+     path_check.
      Workflow rejection is the most specific (already routed to a
      dedicated counter in [Keeper_tools_oas]). Once observed, it must
      not fall through to [error] string fallbacks; only explicit
      deterministic workflow markers may short-circuit retry. Path
      checks have their own typed surface. Generic [error] codes and
      retryability-only fields are observational metadata, not a
-     deterministic reason. *)
+     deterministic reason. Git process failures must be marked by
+     their typed producer instead of re-parsed from stderr here. *)
   match classify_deterministic_retry json with
   | Some reason -> Some { reason; source = Deterministic_retry_marker }
   | None ->
@@ -279,10 +240,7 @@ let classify_with_source (json : Yojson.Safe.t) : classification option =
      | Workflow_rejection_absent ->
        (match classify_path_check json with
         | Some reason -> Some { reason; source = Path_check_marker }
-        | None ->
-          (match classify_git_exit_128 json with
-           | Some reason -> Some { reason; source = Git_exit_128 }
-           | None -> None)))
+        | None -> None))
 ;;
 
 let classify (json : Yojson.Safe.t) : deterministic_reason option =

--- a/lib/keeper/keeper_tool_deterministic_error.mli
+++ b/lib/keeper/keeper_tool_deterministic_error.mli
@@ -50,14 +50,12 @@ type deterministic_reason =
           separate counter in [Keeper_tools_oas]. It is considered
           deterministic only when the payload explicitly carries
           [error_class="deterministic"] and [recoverable=false]. *)
-  | Git_ref_precondition_failed
-      (** git three-dot/ref precondition failed: missing ref, unknown
-          revision, ambiguous revision, or no merge base. Retrying the
-          same command is deterministic noise; verify/fetch refs or
-          change diff strategy first. *)
-  | Git_command_usage_error
-      (** git command-line usage is invalid, for example an unsupported
-          flag. Retrying the same command cannot succeed. *)
+  | Git_precondition_failed
+      (** git process precondition failed. Typed shell producers may
+          emit this for git exit 128 from structured command
+          classification plus process status; the deterministic
+          classifier intentionally does not re-parse stderr/output to
+          split missing refs from command usage. *)
 
 type classification_source =
   | Deterministic_retry_marker
@@ -66,8 +64,6 @@ type classification_source =
       (** Workflow rejection carried deterministic/unrecoverable typed fields. *)
   | Path_check_marker
       (** Path-check surface carried a closed typed reason. *)
-  | Git_exit_128
-      (** Git command/output fallback for exit-128 precondition failures. *)
 
 type classification =
   { reason : deterministic_reason
@@ -78,14 +74,15 @@ type classification =
     [Keeper_exec_tools]) into a [deterministic_reason] only when the
     payload carries an explicit typed marker: [deterministic_retry],
     deterministic workflow-rejection fields, a typed path-check
-    reason, or a closed git exit-128 precondition pattern. Returns
+    reason. Returns
     [None] for transient errors, shell exit-nonzero, retryability-only
     payloads, plain [error] strings, network/timeout failures, and
     any payload that fails to parse.
 
     There is no [error] string fallback and no [_ ->] catch-all that
     admits new prefixes silently. Producers that know same-argument
-    retry cannot succeed must emit [deterministic_retry_fields]. *)
+    retry cannot succeed, including typed shell producers handling git
+    process failures, must emit [deterministic_retry_fields]. *)
 val classify : Yojson.Safe.t -> deterministic_reason option
 
 val classify_with_source : Yojson.Safe.t -> classification option

--- a/test/test_keeper_bash_retry_deterministic_close.ml
+++ b/test/test_keeper_bash_retry_deterministic_close.ml
@@ -270,47 +270,38 @@ let test_workflow_rejection_nested_under_detail () =
     raw
 ;;
 
-(* ── Deterministic — git exit 128 precondition/usage errors ───── *)
+(* ── Deterministic — typed git process markers ────────────────── *)
 
-let test_git_diff_no_merge_base_is_deterministic () =
+let test_git_precondition_marker_is_deterministic () =
   let raw =
-    {|{"status":"error","exit_code":128,"output":"fatal: main...keeper-verifier-agent/task-259: no merge base\n","command":"git diff main...keeper-verifier-agent/task-259","agent":"keeper-verifier-agent"}|}
+    deterministic_marker_raw
+      ~error:"git_exit_128"
+      D.Git_precondition_failed
   in
   check_classify
-    ~name:"git diff no merge base"
-    ~expected:(Some D.Git_ref_precondition_failed)
+    ~name:"git precondition marker"
+    ~expected:(Some D.Git_precondition_failed)
     raw
 ;;
 
-let test_git_diff_no_merge_base_with_retryability_none_is_deterministic () =
+let test_git_precondition_marker_reports_source () =
+  let raw =
+    deterministic_marker_raw
+      ~error:"git_exit_128"
+      D.Git_precondition_failed
+  in
+  check_classify_source
+    ~name:"git precondition marker source"
+    ~expected_reason:D.Git_precondition_failed
+    ~expected_source:D.Deterministic_retry_marker
+    raw
+;;
+
+let test_plain_git_exit_128_is_observed_only () =
   let raw =
     {|{"status":"error","exit_code":128,"retryability":"none","output":"fatal: main...keeper-verifier-agent/task-259: no merge base\n","command":"git diff main...keeper-verifier-agent/task-259","agent":"keeper-verifier-agent"}|}
   in
-  check_classify_source
-    ~name:"git diff no merge base with retryability none"
-    ~expected_reason:D.Git_ref_precondition_failed
-    ~expected_source:D.Git_exit_128
-    raw
-;;
-
-let test_git_diff_unknown_revision_is_deterministic () =
-  let raw =
-    {|{"status":"error","exit_code":128,"output":"fatal: ambiguous argument 'origin/main...keeper-verifier-agent/task-314': unknown revision or path not in the working tree.\n","command":"git diff origin/main...keeper-verifier-agent/task-314","agent":"keeper-verifier-agent"}|}
-  in
-  check_classify
-    ~name:"git diff unknown revision"
-    ~expected:(Some D.Git_ref_precondition_failed)
-    raw
-;;
-
-let test_git_unrecognized_argument_is_deterministic () =
-  let raw =
-    {|{"status":"error","exit_code":128,"output":"fatal: unrecognized argument: --no-stat\n","command":"git show f2f396316 --no-stat","agent":"keeper-analyst-agent"}|}
-  in
-  check_classify
-    ~name:"git unrecognized argument"
-    ~expected:(Some D.Git_command_usage_error)
-    raw
+  check_classify ~name:"plain git exit 128" ~expected:None raw
 ;;
 
 (* ── Negative — transient / runtime / shell exit ──────────────── *)
@@ -383,8 +374,7 @@ let test_to_string_non_empty_for_every_variant () =
     ; D.Completion_contract_violation
     ; D.Keeper_shell_op_required
     ; D.Workflow_rejection_blocked
-    ; D.Git_ref_precondition_failed
-    ; D.Git_command_usage_error
+    ; D.Git_precondition_failed
     ]
   in
   List.iter
@@ -480,23 +470,19 @@ let () =
             `Quick
             test_workflow_rejection_nested_under_detail
         ] )
-    ; ( "classify_git_exit_128"
+    ; ( "classify_git_markers"
       , [ Alcotest.test_case
-            "git_diff_no_merge_base"
+            "git_precondition_marker"
             `Quick
-            test_git_diff_no_merge_base_is_deterministic
+            test_git_precondition_marker_is_deterministic
         ; Alcotest.test_case
-            "git_diff_unknown_revision"
+            "git_precondition_marker_reports_source"
             `Quick
-            test_git_diff_unknown_revision_is_deterministic
+            test_git_precondition_marker_reports_source
         ; Alcotest.test_case
-            "git_diff_no_merge_base_with_retryability_none"
+            "plain_git_exit_128_observed_only"
             `Quick
-            test_git_diff_no_merge_base_with_retryability_none_is_deterministic
-        ; Alcotest.test_case
-            "git_unrecognized_argument"
-            `Quick
-            test_git_unrecognized_argument_is_deterministic
+            test_plain_git_exit_128_is_observed_only
         ] )
     ; ( "negative_transient"
       , [ Alcotest.test_case

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -7,6 +7,7 @@
     4. Empty commands are rejected *)
 
 module Coord = Masc_mcp.Coord
+module Exec_core = Masc_mcp.Exec_core
 module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
 module Keeper_registry = Masc_mcp.Keeper_registry
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
@@ -352,6 +353,39 @@ let test_tool_execute_elapsed_duration_preserves_positive_sub_ms () =
     (elapsed ~start_time:10.0 ~end_time:9.999);
   Alcotest.(check int) "nan duration is zero" 0
     (elapsed ~start_time:Float.nan ~end_time:10.0)
+
+let classification family =
+  { Exec_core.family = family
+  ; reversibility = Exec_core.Read_only
+  ; risk = Exec_core.Low
+  ; risk_class = Masc_exec.Shell_ir_risk.R0_Read
+  }
+;;
+
+let test_git_exit_128_emits_typed_deterministic_retry_marker () =
+  let fields =
+    Keeper_exec_shell.For_testing.deterministic_retry_fields_for_process_result
+      ~classification:(classification Exec_core.Git_read)
+      ~status:(Unix.WEXITED 128)
+  in
+  let json = `Assoc fields in
+  let marker = json |> Json.member "deterministic_retry" in
+  Alcotest.(check string)
+    "reason"
+    "git_precondition_failed"
+    (marker |> Json.member "reason" |> Json.to_string);
+  Alcotest.(check bool)
+    "retry_same_args=false"
+    false
+    (marker |> Json.member "retry_same_args" |> Json.to_bool)
+
+let test_non_git_exit_128_has_no_deterministic_retry_marker () =
+  let fields =
+    Keeper_exec_shell.For_testing.deterministic_retry_fields_for_process_result
+      ~classification:(classification Exec_core.Build)
+      ~status:(Unix.WEXITED 128)
+  in
+  Alcotest.(check int) "no fields" 0 (List.length fields)
 
 let test_tool_search_files_ir_timeout_floor_is_not_sub_io_latency () =
   let args = `Assoc [ "timeout_sec", `Float 1.0 ] in
@@ -1098,6 +1132,14 @@ let () =
             "tool_search_files_ir load-bearing timeout floor"
             `Quick
             test_tool_search_files_ir_load_bearing_timeout_floor
+        ; Alcotest.test_case
+            "git exit 128 emits typed deterministic retry marker"
+            `Quick
+            test_git_exit_128_emits_typed_deterministic_retry_marker
+        ; Alcotest.test_case
+            "non-git exit 128 has no deterministic retry marker"
+            `Quick
+            test_non_git_exit_128_has_no_deterministic_retry_marker
         ; Alcotest.test_case
             "nested runtime detector ignores commit messages"
             `Quick


### PR DESCRIPTION
Summary:
- remove the git exit-128 stderr/output parser from Keeper_tool_deterministic_error
- have typed keeper_shell_bash emit deterministic_retry for git Shell IR exit 128 from structured command classification + process status
- collapse the removed output-derived git sub-reasons into one producer-owned git_precondition_failed marker, so unsupported command-usage parsing is not preserved as legacy surface
- keep plain git exit-128 payloads observational unless a producer emits deterministic_retry

Validation:
- ocamlformat --check changed files
- git diff --check
- rg removed Legacy_error_code/Git_exit_128/Git_ref_precondition_failed/Git_command_usage_error/classify_git_exit_128/classify_error_code/Retryability_marker patterns: no matches
- scripts/dune-local.sh build test/test_keeper_bash_retry_deterministic_close.exe test/test_keeper_bash_safety.exe: blocked by live bare Dune processes bypassing the wrapper
- forced focused Dune attempt with MASC_DUNE_ALLOW_BARE_DUNE=1 was stopped after several minutes without diagnostics due host Dune contention