### PR TITLE
fix(keeper): require typed egress failure class

### DIFF
--- a/lib/exec/egress_policy.ml
+++ b/lib/exec/egress_policy.ml
@@ -99,9 +99,9 @@ let check_command policy cmd =
     consumer — empty allowlist points operator at "seed this file",
     non-empty-but-unmatched allowlist points at "extend this file".
 
-    Without [expected_policy_path], the legacy schema is preserved so
-    callers that have no path context (tests, generic utilities) keep
-    working unchanged. *)
+    The payload always carries [failure_class="policy_rejection"] so
+    downstream retry/log classification does not have to infer policy
+    semantics from the [error] string. *)
 let blocked_to_json ?expected_policy_path (blocked : check_result) =
   let json : Yojson.Safe.t =
     match blocked with
@@ -111,6 +111,7 @@ let blocked_to_json ?expected_policy_path (blocked : check_result) =
           [
             ("ok", `Bool false);
             ("error", `String "egress_blocked");
+            ("failure_class", `String "policy_rejection");
             ("attempted", `String attempted);
             ("allowed", `List (List.map (fun d -> `String d) allowed));
           ]

--- a/lib/exec/test/test_egress_policy.ml
+++ b/lib/exec/test/test_egress_policy.ml
@@ -101,6 +101,9 @@ let test_blocked_json_format () =
       (match List.assoc_opt "error" kv with
        | Some (`String "egress_blocked") -> ()
        | _ -> assert false);
+      (match List.assoc_opt "failure_class" kv with
+       | Some (`String "policy_rejection") -> ()
+       | _ -> assert false);
       (match List.assoc_opt "attempted" kv with
        | Some (`String "evil.com") -> ()
        | _ -> assert false)
@@ -229,9 +232,7 @@ let test_blocked_json_with_path_unmatched_domain () =
       assert (string_contains reason "not in egress allowlist")
   | None -> assert false
 
-let test_blocked_json_without_path_preserves_legacy_schema () =
-  (* Backward compat: callers without path context get the old
-     two-field schema unchanged. *)
+let test_blocked_json_without_path_keeps_typed_failure_class () =
   let policy = Egress_policy.empty in
   let result =
     Egress_policy.check_command policy "curl https://evil.com"
@@ -241,6 +242,7 @@ let test_blocked_json_without_path_preserves_legacy_schema () =
   match parsed with
   | `Assoc kv ->
       assert (List.assoc_opt "error" kv = Some (`String "egress_blocked"));
+      assert (List.assoc_opt "failure_class" kv = Some (`String "policy_rejection"));
       assert (List.assoc_opt "attempted" kv = Some (`String "evil.com"));
       assert (List.assoc_opt "expected_policy_path" kv = None);
       assert (List.assoc_opt "reason" kv = None)
@@ -266,5 +268,5 @@ let () =
   test_of_file_missing_blocks_git_url_command ();
   test_blocked_json_with_path_empty_allowlist ();
   test_blocked_json_with_path_unmatched_domain ();
-  test_blocked_json_without_path_preserves_legacy_schema ();
+  test_blocked_json_without_path_keeps_typed_failure_class ();
   print_endline "[test_egress_policy] all tests passed"

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -249,11 +249,7 @@ let failure_class_of_tool_result_payload payload =
     else (
       match Safe_ops.json_string_opt "failure_class" json with
       | Some _ as failure_class -> failure_class
-      | None ->
-        (match Safe_ops.json_string_opt "error" json with
-         | Some "egress_blocked" -> Some "policy_rejection"
-         | Some _
-         | None -> None))
+      | None -> None)
   | Error _ -> None
 ;;
 

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -90,20 +90,7 @@ let failure_class_of_tool_error_json json =
   in
   match direct with
   | Some _ -> direct
-  | None ->
-    (match nested with
-     | Some _ -> nested
-     | None ->
-       let direct_error = Safe_ops.json_string_opt "error" json in
-       let nested_error =
-         match Yojson.Safe.Util.member "detail" json with
-         | `Assoc _ as detail -> Safe_ops.json_string_opt "error" detail
-         | _ -> None
-       in
-       match direct_error, nested_error with
-       | Some "egress_blocked", _
-       | _, Some "egress_blocked" -> Some "policy_rejection"
-       | _ -> None)
+  | None -> nested
 
 let failure_class_of_tool_error_text error =
   try

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -26,21 +26,33 @@ let contains_casefold haystack needle =
   String.length needle = 0
   || String_util.contains_substring_ci haystack needle
 
+let structured_failure_class_of_message message =
+  match Tool_result.structured_payload_of_message message with
+  | Some (`Assoc fields) ->
+    (match List.assoc_opt "failure_class" fields with
+     | Some (`String value) -> Tool_result.tool_failure_class_of_string value
+     | _ -> None)
+  | Some _
+  | None -> None
+;;
+
 (* Failure classification delegates to [Tool_result] — the SSOT closed-sum
    type with compiler-enforced exhaustive handling at every match site.
    See {!Tool_result.tool_failure_class} for the 4 constructors.
 
    Local heuristic for classifying failure messages at the MCP protocol
    level where only the message string is available (not a [Tool_result.t]).
+   Structured [failure_class] payloads are decoded before this fallback.
    Mirrors the logic that was in [Tool_result.classify_from_dispatch_failure]
    before it was made internal in Phase 2. *)
 let classify_failure_message (message : string) : Tool_result.tool_failure_class =
+  match structured_failure_class_of_message message with
+  | Some failure_class -> failure_class
+  | None ->
   if contains_casefold message "awaiting_approval"
      || contains_casefold message "join required"
   then Tool_result.Workflow_rejection
-  else if
-    contains_casefold message "egress_blocked"
-    || contains_casefold message "path_outside_sandbox"
+  else if contains_casefold message "path_outside_sandbox"
   then Tool_result.Policy_rejection
   else if contains_casefold message "Tool timed out" then
     Tool_result.Runtime_failure

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -99,9 +99,7 @@ let classify_from_dispatch_failure (message : string) : tool_failure_class =
     || contains_casefold message "Self-approval not allowed"
     || contains_casefold message "Self-rejection not allowed"
   then Workflow_rejection
-  else if
-    contains_casefold message "egress_blocked"
-    || contains_casefold message "path_outside_sandbox"
+  else if contains_casefold message "path_outside_sandbox"
   then Policy_rejection
   else if contains_casefold message "Tool timed out"
   then

--- a/lib/tool_types/tool_result.mli
+++ b/lib/tool_types/tool_result.mli
@@ -26,6 +26,7 @@ val pp_tool_failure_class : Format.formatter -> tool_failure_class -> unit
 val show_tool_failure_class : tool_failure_class -> string
 
 val tool_failure_class_to_string : tool_failure_class -> string
+val tool_failure_class_of_string : string -> tool_failure_class option
 
 (** [Transient_error] is the only retryable class. *)
 val is_retryable : tool_failure_class -> bool

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -626,6 +626,9 @@ let test_workflow_rejection_payload_skips_circuit_breaker () =
       workflow_rejection_message
   in
   let egress_payload =
+    {|{"ok":false,"error":"egress_blocked","failure_class":"policy_rejection","attempted":"localhost","allowed":["*.github.com"]}|}
+  in
+  let legacy_egress_payload =
     {|{"ok":false,"error":"egress_blocked","attempted":"localhost","allowed":["*.github.com"]}|}
   in
   let runtime_payload =
@@ -637,10 +640,14 @@ let test_workflow_rejection_payload_skips_circuit_breaker () =
     (KET.failure_class_of_tool_result_payload workflow_payload);
   check bool "workflow rejection does not trip circuit breaker" false
     (KET.should_apply_circuit_breaker_to_failure_payload workflow_payload);
-  check (option string) "infers egress policy class" (Some "policy_rejection")
+  check (option string) "extracts egress policy class" (Some "policy_rejection")
     (KET.failure_class_of_tool_result_payload egress_payload);
   check bool "egress policy rejection does not trip circuit breaker" false
     (KET.should_apply_circuit_breaker_to_failure_payload egress_payload);
+  check (option string) "legacy egress has no inferred class" None
+    (KET.failure_class_of_tool_result_payload legacy_egress_payload);
+  check bool "legacy egress still trips circuit breaker" true
+    (KET.should_apply_circuit_breaker_to_failure_payload legacy_egress_payload);
   check bool "runtime failure still trips circuit breaker" true
     (KET.should_apply_circuit_breaker_to_failure_payload runtime_payload)
 

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -1111,7 +1111,7 @@ let test_on_tool_error_egress_blocked_logs_policy_warn_without_callback_failure
   let before = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
   let before_seq = latest_log_seq () in
   let error =
-    {|{"ok":false,"error":"egress_blocked","attempted":"localhost","allowed":["*.github.com"]}|}
+    {|{"ok":false,"error":"egress_blocked","failure_class":"policy_rejection","attempted":"localhost","allowed":["*.github.com"]}|}
   in
   check_continue
     "on_tool_error egress blocked"
@@ -1129,6 +1129,26 @@ let test_on_tool_error_egress_blocked_logs_policy_warn_without_callback_failure
   with
   | Some entry -> check string "log level" "WARN" (Log.level_to_string entry.level)
   | None -> fail "expected egress block to be logged as keeper policy WARN"
+;;
+
+let test_on_tool_error_legacy_egress_blocked_records_callback_failure
+    () =
+  let keeper = "callback-on-tool-legacy-egress-blocked-keeper" in
+  let hooks = make_test_hooks keeper in
+  let hook = require_hook "on_tool_error" hooks.on_tool_error in
+  let before = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  let error =
+    {|{"ok":false,"error":"egress_blocked","attempted":"localhost","allowed":["*.github.com"]}|}
+  in
+  check_continue
+    "on_tool_error legacy egress blocked"
+    (hook (Agent_sdk.Hooks.OnToolError { tool_name = "Execute"; error }));
+  let after = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  check
+    (float 0.001)
+    "legacy egress increments callback failures"
+    1.0
+    (after -. before)
 ;;
 
 let test_on_tool_error_blob_workflow_rejection_logs_warn_without_callback_failure
@@ -1651,6 +1671,10 @@ let () =
             "on_tool_error egress block logs policy warn"
             `Quick
             test_on_tool_error_egress_blocked_logs_policy_warn_without_callback_failure
+        ; test_case
+            "on_tool_error legacy egress block records callback failure"
+            `Quick
+            test_on_tool_error_legacy_egress_blocked_records_callback_failure
         ; test_case
             "on_tool_error blob workflow rejection logs warn"
             `Quick

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -177,6 +177,24 @@ let test_contains_casefold_keeps_semantics () =
   check bool "needle longer than haystack" false (contains "short" "shorter");
   check bool "absent substring" false (contains "Invalid JSON" "timeout")
 
+let test_failure_message_uses_structured_failure_class () =
+  let classify = Masc_mcp.Mcp_server_eio_call_tool.classify_failure_message in
+  check
+    (testable
+       Masc_mcp.Tool_result.pp_tool_failure_class
+       ( = ))
+    "structured egress policy class"
+    Masc_mcp.Tool_result.Policy_rejection
+    (classify
+       {|{"ok":false,"error":"egress_blocked","failure_class":"policy_rejection"}|});
+  check
+    (testable
+       Masc_mcp.Tool_result.pp_tool_failure_class
+       ( = ))
+    "legacy egress is not inferred"
+    Masc_mcp.Tool_result.Runtime_failure
+    (classify {|{"ok":false,"error":"egress_blocked"}|})
+
 let test_transition_has_no_fixed_timeout () =
   check bool "masc_transition has no fixed timeout"
     true
@@ -539,6 +557,8 @@ let () =
             test_activity_payload_sanitizes_invalid_utf8;
           test_case "contains casefold keeps semantics" `Quick
             test_contains_casefold_keeps_semantics;
+          test_case "failure message uses structured failure_class" `Quick
+            test_failure_message_uses_structured_failure_class;
           test_case "transition has no fixed timeout" `Quick test_transition_has_no_fixed_timeout;
           test_case "persona generate timeout exceeds OAS budget" `Quick
             test_persona_generate_timeout_exceeds_oas_budget;


### PR DESCRIPTION
Summary:
- emit failure_class="policy_rejection" from egress_blocked producer payloads
- remove egress_blocked -> policy_rejection inference from keeper tool-result and hook consumers
- make MCP failure classification prefer structured failure_class before remaining message fallback
- add regression coverage that legacy egress_blocked without failure_class is not inferred as policy rejection

Validation:
- ocamlformat --check changed files
- git diff --check origin/main...HEAD
- rg removed egress_blocked policy inference patterns: no matches
- scripts/dune-local.sh build lib/exec/test/test_egress_policy.exe test/test_keeper_exec_tools.exe test/test_keeper_hooks_oas_telemetry.exe test/test_mcp_server_eio_call_tool.exe test/test_tool_result.exe: blocked by live bare Dune processes bypassing the wrapper