### PR TITLE
fix(exec): remove duplicate Grep in walker codegen

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -550,7 +550,6 @@ let emit_of_simple buf spec =
     \            | Exec_program.Ninja\n\
     \            | Exec_program.Sed\n\
     \            | Exec_program.Uv\n\
-    \            | Exec_program.Grep\n\
     \            | Exec_program.Gh\n\
     \            | Exec_program.Glab\n\
     \            | Exec_program.Terminal_notifier\n\


### PR DESCRIPTION
## Summary
- Remove duplicate `Exec_program.Grep` entry from `bin/gen_shell_ir_walkers.ml` catch-all block
- Introduced by PR #18637 — Grep was already present at line 492, the addition at line 553 was redundant
- Caused `warning 12 [redundant-subpat]` promoted to error

## Test plan
- [x] `dune build _build/default/lib/exec/shell_ir_typed_walkers_gen.ml` succeeds
- [x] Generated file contains exactly 1 `Exec_program.Grep` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)