### PR TITLE
refactor(keeper): purge memory tail silent fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ External 채널 어댑터의 경계는 Channel Gate:
 - context lens — keeper tool call 이 만진 코드 위치로 routing back
 - audit log / telemetry / planning / board / git graph route 가 같은 focus context 로 묶임
 
-핵심 모듈: `lib/ide/ide_region_tracker.ml`, `ide_annotations.ml`, `ide_annotation_types.ml`, `ide_paths.ml`. backend 쪽 region write 진입점은 `lib/keeper/keeper_exec_fs.ml` 의 write 흐름이 `Ide_region_tracker.ingest_tool_call` 로 전달되는 지점.
+핵심 모듈: `lib/ide/ide_region_tracker.ml`, `ide_annotations.ml`, `ide_annotation_types.ml`, `ide_paths.ml`. backend 쪽 region write 진입점은 `lib/keeper/agent_tool_filesystem_runtime.ml` 의 filesystem write 흐름이 `Ide_region_tracker.ingest_tool_call` 로 전달되는 지점.
 
 상태: 활발히 churn 중. RFC-0071 §3.4 의 fragile-match warning 4 가 이 sub-lib 에 켜져 있어서 (`dune` 의 `-w +4`) 새 코드는 exhaustive match 을 강제합니다.
 

--- a/config/keepers/base.toml
+++ b/config/keepers/base.toml
@@ -20,7 +20,7 @@ instructions = """
 MASC 기본 소양 — 모든 keeper의 공통 행동 기반. persona instructions는 이 위에 stack.
 
 1. 코드 변경 라우팅: ReadFile, SearchFiles, EditFile/WriteFile, Execute를 사용한다. Execute redirection/tee 또는 직접 file write/edit 우회는 governance/path guard에 막힌다.
-2. Worktree 격리: repo-local `.worktrees/` 아래에서 작업한다. 루트 checkout/main에서 직접 feature work를 시작하지 않는다.
+2. Worktree 격리: sandbox clone 내부의 `repos/<REPO_NAME>/.worktrees/<branch-or-task>/` 아래에서 작업한다. 루트 checkout/main에서 직접 feature work를 시작하지 않는다.
 3. PR 생성 흐름: 코드 작업 완료 후 GitHub CLI 경로로 PR을 열거나 갱신한다. 이어서 keeper_task_submit_for_verification으로 검증을 요청한다. Ready 전환은 사용자/verifier 권한이다.
 4. Task 상태 조회: keeper_tasks_list 또는 masc_tasks를 사용한다. .task.json, task-*.json, .masc, backlog JSON을 find/grep/rg/ls로 찾지 않는다.
 5. Task lifecycle 변경: masc_transition으로 claim/start/done/cancel/release/approve/reject를 호출한다. expected_version으로 CAS 충돌을 회피한다.

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -99,7 +99,7 @@ Sandbox layout (NOT `/workspace` — that path does not exist; see <world> WRONG
 
 Repo setup:
 1. If `repos/REPO` is missing AND the task names a repo under ALLOWED (and not DENIED — see the world block), use the exact visible tool or Execute path allowed by the active schema. If no such path is visible, report the missing clone as a blocker.
-2. Work in the repo-local `.worktrees/` path. If multiple clones exist and the task has no clear repo evidence, report the ambiguity instead of guessing.
+2. Work in `repos/{repo}/.worktrees/{your-name}-{task_id}/`. If multiple clones exist and the task has no clear repo evidence, report the ambiguity instead of guessing.
 3. If setup returns `ok: false`, STOP. Read `detail.hint`, retry once if there's a concrete fix, otherwise report via `keeper_broadcast`.
 
 PR workflow (Coding/Delivery/Full preset required):
@@ -108,7 +108,7 @@ PR workflow (Coding/Delivery/Full preset required):
    start PR work. Report the blocker from `checks` /
    `cascade_resilience.hint` / `autonomous_activation.hint` instead of treating
    a coding preset as active-fleet readiness.
-1. Work inside the repo-local `.worktrees/` path for an isolated branch.
+1. Work inside `repos/{repo}/.worktrees/{your-name}-{task_id}/` for an isolated branch.
 2. `ReadFile`/`SearchFiles` → `EditFile`/`WriteFile` — read first, then edit
 3. `Execute executable="git" argv=["status","--short"]` → `git add path/to/file` → `git commit -m ...` → `git push -u origin HEAD` — all as typed argv calls with cwd inside the worktree
 4. `Execute executable="gh" argv=["pr","create",...]` or `Execute executable="gh" argv=["pr","edit",...]` — open or update the PR after push.

--- a/config/prompts/keeper.tool_workflow_gh_full.md
+++ b/config/prompts/keeper.tool_workflow_gh_full.md
@@ -3,4 +3,4 @@ description: keeper gh/code workflow guidance, full path (PR inspection + worktr
 category: keeper
 ---
 
-GitHub/code workflow: inspect PR state with `Execute` using `executable="gh"` and typed `argv` for `pr list` / `pr view` from a repo/worktree cwd. If you decide to do code-changing task work and do not already hold that task, call `keeper_task_claim` first. Work inside the repo-local `.worktrees/` path, edit with EditFile/WriteFile, use Execute for git/gh, then call `keeper_task_submit_for_verification` with notes and `pr_url`. Do not use hidden implementation tool names.
+GitHub/code workflow: inspect PR state with `Execute` using `executable="gh"` and typed `argv` for `pr list` / `pr view` from a repo/worktree cwd. If you decide to do code-changing task work and do not already hold that task, call `keeper_task_claim` first. Work inside `repos/<REPO_NAME>/.worktrees/<branch-or-task>/`, edit with EditFile/WriteFile, use Execute for git/gh, then call `keeper_task_submit_for_verification` with notes and `pr_url`. Do not use hidden implementation tool names.

--- a/config/prompts/keeper.tool_workflow_gh_no_pr.md
+++ b/config/prompts/keeper.tool_workflow_gh_no_pr.md
@@ -3,4 +3,4 @@ description: keeper gh/code workflow guidance without a dedicated PR creation to
 category: keeper
 ---
 
-GitHub/code workflow: inspect PR state with `Execute` using `executable="gh"` and typed `argv` for `pr list` / `pr view` from a repo/worktree cwd. If you decide to do code-changing task work and do not already hold that task, call `keeper_task_claim` first. Work inside the repo-local `.worktrees/` path, edit with EditFile/WriteFile, use Execute for git/gh, then submit evidence. Do not use hidden implementation tool names.
+GitHub/code workflow: inspect PR state with `Execute` using `executable="gh"` and typed `argv` for `pr list` / `pr view` from a repo/worktree cwd. If you decide to do code-changing task work and do not already hold that task, call `keeper_task_claim` first. Work inside `repos/<REPO_NAME>/.worktrees/<branch-or-task>/`, edit with EditFile/WriteFile, use Execute for git/gh, then submit evidence. Do not use hidden implementation tool names.

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -15,7 +15,7 @@ local directory, Docker, a VM, or a cloud service, but tool paths stay the same:
 Repo worktrees live *inside* your sandbox clone at `repos/<REPO_NAME>/.worktrees/<branch-or-task>/` (typically `{your-name}-<task_id>`).
 - Directory name: `{your-name}-<task_id>` (e.g. `sangsu-fix-bug`)
 - Git branch: `{your-name}/<task_id>` (e.g. `sangsu/fix-bug`)
-- Use the repo-local `.worktrees/` directory for isolated code work.
+- Use `repos/<REPO_NAME>/.worktrees/<branch-or-task>/` for isolated code work.
 - If multiple clones exist and the task has no clear repo evidence, ask for the target repo instead of guessing.
 - The returned path always starts with `repos/<REPO_NAME>/.worktrees/`.
 - Never use a server-root-relative worktree path — the harness rejects it as outside your sandbox.

--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 14:54:00 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 15:30:46 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -583,9 +583,39 @@
           </tr>
           <tr>
             <td><code>Keeper_types</code> hidden support include</td>
-            <td><span class="status now">draft PR #18643</span></td>
+            <td><span class="status done">merged #18643</span></td>
             <td>Remove the implementation-only <code>include Keeper_types_support</code> from <code>Keeper_types</code>. The public signature already sends support/path/JSONL callers to <code>Keeper_types_support</code>, so the hidden include only kept a misleading compatibility surface alive.</td>
             <td><code>Keeper_types</code> now exposes only its documented profile/meta/health contract. Grep verifies no live <code>Keeper_types.</code> caller depends on support-only helpers.</td>
+          </tr>
+          <tr>
+            <td>Legacy code/worktree tool surfaces</td>
+            <td><span class="status done">merged #18644</span></td>
+            <td>Delete the obsolete code-shell and worktree tool implementation stack, tool descriptors, schemas, workflow guide, coordination product snapshots, and compatibility-only coverage that kept those old surfaces alive.</td>
+            <td>Merged as <code>556b45c21</code>. Follow-up fallout fixes #18645, #18646, and #18647 are now on <code>origin/main</code>.</td>
+          </tr>
+          <tr>
+            <td>Typed egress failure class</td>
+            <td><span class="status done">merged #18645</span></td>
+            <td>Require structured egress failure classification instead of preserving the older untyped fallback path.</td>
+            <td>Merged as <code>fa393df28</code>; the purge queue should treat egress failure fallback compatibility as closed.</td>
+          </tr>
+          <tr>
+            <td>Dashboard execution reuse snapshot enrichment</td>
+            <td><span class="status done">merged #18646</span></td>
+            <td>Keep the dashboard execution surface on the reusable enriched snapshot path after the tool-surface purge, avoiding duplicate compatibility reconstruction.</td>
+            <td>Merged as <code>d6deeeafb</code>.</td>
+          </tr>
+          <tr>
+            <td>Exec walker duplicate <code>Grep</code> variant</td>
+            <td><span class="status done">merged #18647</span></td>
+            <td>Remove the generated duplicate <code>Exec_program.Grep</code> catch-all fallout from the tool purge.</td>
+            <td>Merged as <code>90e02e9dd</code>; local main is fast-forwarded to this commit.</td>
+          </tr>
+          <tr>
+            <td>Memory tail silent fallback facade</td>
+            <td><span class="status now">draft PR #18650</span></td>
+            <td>Delete the public <code>Keeper_memory_recall.read_file_tail_lines</code> silent-fallback facade. Callers now consume <code>read_file_tail_lines_result</code> and must choose any degraded empty-list behavior explicitly with a site label.</td>
+            <td><code>rg "\bread_file_tail_lines\b" lib test</code> is expected to stay clean on this branch.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
@@ -622,15 +652,15 @@
           <tr>
             <td>P1</td>
             <td><code>Keeper_types</code> compatibility facade</td>
-            <td>Broad re-export surface still lets old type paths survive even after several leaf removals, hiding module ownership and keeping grep-based audits noisy. The hidden support include is being removed in draft PR #18643.</td>
+            <td>Broad re-export surface still lets old type paths survive even after several leaf removals, hiding module ownership and keeping grep-based audits noisy. The hidden support include was removed in merged #18643.</td>
             <td>Continue moving active callers to owner modules, then shrink the facade to documented public types or delete leaf aliases.</td>
-            <td>Delete facade-preservation tests; add owner-module import tests only where public API matters. For the support include slice, grep for support-only helper calls through <code>Keeper_types.</code>.</td>
+            <td>Delete facade-preservation tests; add owner-module import tests only where public API matters.</td>
           </tr>
           <tr>
             <td>P1</td>
             <td>Memory/context legacy read fallbacks</td>
-            <td>Remaining dated-store and old-row fallback readers hide whether current writers are clean. Checkpoint sidecar runtime readers were removed in #18622; direct flat message-content decode was removed in #18630. The keeper_meta blocker/identity sidecar purge merged in #18640.</td>
-            <td>Split into runtime-data migration and code deletion. Delete read fallback after migration proof or if runtime reset is acceptable; do not preserve legacy checkpoint sidecar or flat-content behavior.</td>
+            <td>Remaining dated-store and old-row fallback readers hide whether current writers are clean. Checkpoint sidecar runtime readers were removed in #18622; direct flat message-content decode was removed in #18630. The keeper_meta blocker/identity sidecar purge merged in #18640. The current branch removes the global tail-read silent fallback.</td>
+            <td>Split into runtime-data migration and code deletion. Delete read fallback after migration proof or if runtime reset is acceptable; do not preserve legacy checkpoint sidecar, flat-content, or silent empty-list behavior.</td>
             <td>Remove tests that require old-row readability. Keep corruption/drop tests only for current schema.</td>
           </tr>
           <tr>

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -175,8 +175,6 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_deterministic_error.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_completion_contract.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_completion_contract.mli` - tool-surface-policy
-- `lib/keeper/keeper_tool_code_intent.ml` - tool-surface-policy
-- `lib/keeper/keeper_tool_code_intent.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_query.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_query.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_selection.ml` - tool-surface-policy

--- a/docs/spec/00-glossary.md
+++ b/docs/spec/00-glossary.md
@@ -46,16 +46,16 @@ MASC Room에 참여하는 AI 에이전트. 고유 이름, 에이전트 타입(ag
 Room 내 모든 에이전트에게 전달되는 메시지. @mention으로 특정 에이전트를 호출할 수 있다. MASC 협업에서 상태 공유의 기본 수단이다. `-> lib/types/types_core.ml`
 
 **Portal**
-두 에이전트 간의 직접 통신 링크. Broadcast가 전체 공개라면, Portal은 1:1 비공개 채널이다. `-> lib/tool_portal.mli`, `-> lib/types/types_auth.ml`
+두 에이전트 간의 직접 통신 링크. Broadcast가 전체 공개라면, Portal은 1:1 비공개 채널이다. `-> lib/coord/coord_portal.ml`, `-> lib/types/types_auth.ml`
 
 **Worktree**
-에이전트별로 격리된 git 작업 공간. 각 에이전트가 독립적인 브랜치에서 작업하여 충돌을 방지한다. 경로 패턴: `.worktrees/{agent}-{task}/`. `-> lib/types/types_core.ml`, `-> lib/tool_worktree.mli`
+에이전트별로 격리된 git 작업 공간. 각 에이전트가 독립적인 브랜치에서 작업하여 충돌을 방지한다. 경로 패턴: `.worktrees/{agent}-{task}/`. `-> lib/types/types_core.ml`, `-> lib/coord/coord_worktree.mli`, `-> lib/task_sandbox.mli`
 
 **Handoff**
 Keeper post-turn lifecycle에서 같은 keeper를 새 `trace_id` / 새 session으로 이어붙이는 rollover. 성공 시 `generation`이 증가하고 이전 `trace_id`가 `trace_history`에 추가된다. 세션 handoff 문서와는 다른 개념이다. `-> lib/keeper/keeper_post_turn.ml`, `-> lib/keeper/keeper_rollover.ml`
 
 **Capsule**
-에이전트 컨텍스트의 압축된 표현. 현재 목표, 진행 상황, 완료/대기 단계, 핵심 결정과 근거, 수정된 파일 목록 등을 포함한다. Handoff 시 후임 에이전트에게 전달된다. (구 명칭: DNA) `-> lib/tool_relay.mli`
+에이전트 컨텍스트의 압축된 표현. 현재 목표, 진행 상황, 완료/대기 단계, 핵심 결정과 근거, 수정된 파일 목록 등을 포함한다. Handoff 시 후임 에이전트에게 전달된다. (구 명칭: DNA) `-> lib/relay.mli`
 
 **Usage**
 에이전트의 컨텍스트 윈도우 소비율(%). keeper에서는 compaction gate와 handoff gate를 평가하는 입력값이다. 현재 owner는 OAS reducer + keeper compact/handoff path다.

--- a/docs/spec/03-room-coordination.md
+++ b/docs/spec/03-room-coordination.md
@@ -7,8 +7,9 @@ code_refs:
   - lib/goal/
   - lib/tool_task.ml
   - lib/tool_agent.ml
-  - lib/tool_worktree.ml
   - lib/tool_control.ml
+  - lib/coord/coord_worktree.ml
+  - lib/task_sandbox.ml
   - lib/tool_schemas/tool_schemas_coord_extra.ml
 ---
 
@@ -22,7 +23,7 @@ code_refs:
 | Dependencies | 02-types-and-invariants |
 | Modules | 20 (.ml) + 4 (.mli) |
 | LOC | ~7,653 |
-| MCP Tools | `tool_task`, `tool_agent`, `tool_worktree`, `tool_control` |
+| MCP Tools | `tool_task`, `tool_agent`, `Coord_worktree`-backed worktree lifecycle, `tool_control` |
 
 ---
 
@@ -73,7 +74,7 @@ graph TB
     TT[tool_task] --> RT
     TA[tool_agent] --> RA
     TH[tool_heartbeat] --> HB
-    TW[tool_worktree] --> RWT
+    TW[worktree lifecycle surface] --> RWT
     TC[tool_control<br>pause/resume] --> RI
     TS[tool_social<br>vote] --> RV
   end
@@ -633,7 +634,7 @@ Docker-style `{agent_type}-{adjective}-{animal}`:
 | `masc_heartbeat_stop` | 하트비트 중단 |
 | `masc_heartbeat_list` | 활성 하트비트 목록 |
 
-### 14.5 Worktree (`tool_worktree`)
+### 14.5 Worktree (`Coord_worktree` / `Task_sandbox`)
 
 | Tool | 동작 |
 |------|------|

--- a/lib/dashboard/dashboard_http_helpers.ml
+++ b/lib/dashboard/dashboard_http_helpers.ml
@@ -119,6 +119,13 @@ let safe_age_seconds_opt ~(now_ts : float) ~(event_ts : float) : int option =
 
 let safe_member = Safe_ops.safe_member
 
+let keeper_tail_lines_or_empty ~site path ~max_bytes ~max_lines =
+  match Keeper_memory.read_file_tail_lines_result path ~max_bytes ~max_lines with
+  | Ok lines -> lines
+  | Error exn_class ->
+      Keeper_memory.record_memory_recall_read_error ~site path exn_class;
+      []
+
 (* RFC-0142 PR-4: lift the silent [| _ -> default] catch-all through
    [Json_field.{list,string,assoc} |> to_option] so a Wrong_shape
    payload disappears with the same default (preserving caller

--- a/lib/dashboard/dashboard_http_helpers.mli
+++ b/lib/dashboard/dashboard_http_helpers.mli
@@ -56,6 +56,13 @@ val safe_age_seconds_opt :
   now_ts:float -> event_ts:float -> int option
 (** Bounded non-negative age in seconds; [None] for NaN/Inf inputs. *)
 
+val keeper_tail_lines_or_empty :
+  site:string -> string -> max_bytes:int -> max_lines:int -> string list
+(** Dashboard-local degraded tail read.  The caller must name the
+    dashboard site so memory read failures are counted and logged
+    explicitly instead of flowing through the removed global silent
+    fallback. *)
+
 (** {1 JSON field accessors (sentinel-tolerant)} *)
 
 val json_list_field : string -> Yojson.Safe.t -> Yojson.Safe.t list

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -161,7 +161,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
             if dated <> [] then dated
             else
               let metrics_path = Keeper_types_support.keeper_metrics_path config m.name in
-              Keeper_memory.read_file_tail_lines metrics_path
+              keeper_tail_lines_or_empty ~site:"dashboard_keeper_metrics" metrics_path
                 ~max_bytes:metrics_window_max_bytes ~max_lines:n
           in
           let (metrics_24h, metrics_24h_summary) =
@@ -841,7 +841,8 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
   let recent_alerts =
     let alerts_path = Keeper_types_support.keeper_alerts_path config in
     let lines =
-      Keeper_memory.read_file_tail_lines alerts_path ~max_bytes:50000 ~max_lines:10
+      keeper_tail_lines_or_empty ~site:"dashboard_keeper_alerts" alerts_path
+        ~max_bytes:50000 ~max_lines:10
     in
     List.filter_map (fun line ->
       try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None

--- a/lib/dashboard/dashboard_http_keeper_feeds.ml
+++ b/lib/dashboard/dashboard_http_keeper_feeds.ml
@@ -27,7 +27,7 @@ let keeper_cost_aggregates_json
           then dated
           else (
             let metrics_path = Keeper_types_support.keeper_metrics_path config m.name in
-            Keeper_memory.read_file_tail_lines
+            keeper_tail_lines_or_empty ~site:"dashboard_keeper_cost_metrics"
               metrics_path
               ~max_bytes:200000
               ~max_lines:500)
@@ -149,7 +149,7 @@ let keeper_decisions_json
         then []
         else (
           let lines =
-            Keeper_memory.read_file_tail_lines
+            keeper_tail_lines_or_empty ~site:"dashboard_keeper_decisions"
               path
               ~max_bytes:500_000
               ~max_lines:per_keeper_limit
@@ -327,7 +327,7 @@ let keeper_decisions_log_json
         then []
         else (
           let lines =
-            Keeper_memory.read_file_tail_lines
+            keeper_tail_lines_or_empty ~site:"dashboard_keeper_turn_spans"
               path
               ~max_bytes:500_000
               ~max_lines:per_keeper_limit
@@ -464,7 +464,7 @@ let keeper_memory_log_json
         then []
         else (
           let lines =
-            Keeper_memory.read_file_tail_lines
+            keeper_tail_lines_or_empty ~site:"dashboard_keeper_memory_log"
               path
               ~max_bytes:500_000
               ~max_lines:per_keeper_limit

--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -5,7 +5,7 @@
     database — the helpers here are pure parsers / aggregators over
     JSONL lines.  The actual feed lives in [Dashboard_http_keeper]:
     [Dated_jsonl.read_recent_lines] (current-day metrics window) with
-    [Keeper_memory.read_file_tail_lines] as a tail fallback when the
+    [keeper_tail_lines_or_empty] as an explicit tail degradation path when the
     dated store is empty (see [dashboard_http_keeper.ml], e.g.
     around lines 591 / 1717 / 1839 / 1952 / 2054).  No relational
     store sits on this path, so proposals to "use a single SQL batch
@@ -344,10 +344,8 @@ let keeper_history_summary_json
     ~(filter_fragments : bool)
   : Yojson.Safe.t * Yojson.Safe.t * Yojson.Safe.t * int * int * int =
   let history_lines =
-    Keeper_memory.read_file_tail_lines
-      history_path
-      ~max_bytes:120000
-      ~max_lines:80
+    keeper_tail_lines_or_empty ~site:"dashboard_keeper_history_summary"
+      history_path ~max_bytes:120000 ~max_lines:80
   in
   let mention_counts : (string, int) Hashtbl.t = Hashtbl.create 16 in
   let (conversation_rev, k2k_rev, raw_count, fragment_count, filtered_count) =

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -12,7 +12,7 @@ let recent_keeper_metric_jsons (config : Coord.config) name =
     if dated <> [] then dated
     else
       let metrics_path = Keeper_types_support.keeper_metrics_path config name in
-      Keeper_memory.read_file_tail_lines metrics_path
+      keeper_tail_lines_or_empty ~site:"dashboard_keeper_snapshot_metrics" metrics_path
         ~max_bytes:120000 ~max_lines:80
   in
   List.filter_map parse_json_line_opt lines

--- a/lib/dashboard/dashboard_keeper_decision_log_proof.ml
+++ b/lib/dashboard/dashboard_keeper_decision_log_proof.ml
@@ -27,9 +27,16 @@ let fold_keeper_decision_log ~config keeper_name ~init ~f =
   let path = Keeper_types_support.keeper_decision_log_path config keeper_name in
   if not (Sys.file_exists path) then init
   else
-    Keeper_memory.read_file_tail_lines path
-      ~max_bytes:decision_tail_max_bytes
-      ~max_lines:decision_tail_max_lines
+    (match
+       Keeper_memory.read_file_tail_lines_result path
+         ~max_bytes:decision_tail_max_bytes
+         ~max_lines:decision_tail_max_lines
+     with
+     | Ok lines -> lines
+     | Error exn_class ->
+         Keeper_memory.record_memory_recall_read_error
+           ~site:"dashboard_decision_log_proof" path exn_class;
+         [])
     |> List.fold_left
          (fun acc line ->
             let line = String.trim line in

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -372,8 +372,9 @@ let mkdir_p_memoized path = Mkdir_memo.mkdir_p_memoized ~mkdir_p path
 let reset_mkdir_memo_for_testing () = Mkdir_memo.reset_for_testing ()
 
 (** Parse pre-read string lines as JSONL.
-    Use when lines come from [Keeper_memory.read_file_tail_lines] or
-    other non-file sources.  Logs malformed lines with [source] tag.
+    Use when lines come from typed tail readers such as
+    [Keeper_memory.read_file_tail_lines_result] or other non-file
+    sources.  Logs malformed lines with [source] tag.
 
     Matches [fold_jsonl]'s line-tracking semantics: [line_no] is
     1-based, increments only on non-blank lines so it tracks the
@@ -554,4 +555,3 @@ let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =
     Stdlib.output_string oc line;
     Stdlib.flush oc)
 ;;
-

--- a/lib/keeper/agent_tool_persona_runtime.ml
+++ b/lib/keeper/agent_tool_persona_runtime.ml
@@ -17,11 +17,18 @@ let persona_summary_to_json (persona : persona_summary) : Yojson.Safe.t =
 
 let string_list_to_json = Json_util.json_string_list
 
+let read_tail_lines_or_empty ~site path ~max_bytes ~max_lines =
+  match read_file_tail_lines_result path ~max_bytes ~max_lines with
+  | Ok lines -> lines
+  | Error exn_class ->
+      record_memory_recall_read_error ~site path exn_class;
+      []
+
 let read_jsonl_rows path ~max_bytes ~max_lines : Yojson.Safe.t list =
   if not (Fs_compat.file_exists path) then
     []
   else
-    read_file_tail_lines path ~max_bytes ~max_lines
+    read_tail_lines_or_empty ~site:"persona_metrics" path ~max_bytes ~max_lines
     |> Fs_compat.parse_jsonl_lines ~source:"persona_metrics"
     |> fst
 

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -40,7 +40,7 @@ let keeper_decision_log_path (config : Coord_query.config) name =
   Filename.concat keepers_dir (name ^ ".decisions.jsonl")
 ;;
 
-let read_file_tail_lines path ~max_bytes ~max_lines =
+let tail_decision_log_lines_or_empty path ~max_bytes ~max_lines =
   if max_lines <= 0 || (not (Sys.file_exists path)) || Sys.is_directory path
   then []
   else (
@@ -79,7 +79,7 @@ let recent_decision_timestamps config ~keeper_name ~now =
   candidate_decision_keeper_names keeper_name
   |> List.concat_map (fun candidate ->
     let path = keeper_decision_log_path config candidate in
-    read_file_tail_lines path ~max_bytes:500000 ~max_lines:128)
+    tail_decision_log_lines_or_empty path ~max_bytes:500000 ~max_lines:128)
   |> List.filter_map (fun line ->
     try Yojson.Safe.from_string line |> decision_ts_unix_opt with
     | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -92,7 +92,15 @@ let search_memory_bank
   =
   let path = Keeper_types_support.keeper_memory_bank_path config meta.name in
   let lines =
-    Keeper_memory_recall.read_file_tail_lines path ~max_bytes:(256 * 1024) ~max_lines:500
+    match
+      Keeper_memory_recall.read_file_tail_lines_result path
+        ~max_bytes:(256 * 1024) ~max_lines:500
+    with
+    | Ok lines -> lines
+    | Error exn_class ->
+        Keeper_memory_recall.record_memory_recall_read_error
+          ~site:"keeper_memory_search" path exn_class;
+        []
   in
   let now_ts = Time_compat.now () in
   let parsed =

--- a/lib/keeper/keeper_exec_status_metrics.ml
+++ b/lib/keeper/keeper_exec_status_metrics.ml
@@ -539,7 +539,15 @@ let read_recent_metrics_lines config keeper_name =
   if dated <> [] then dated
   else
     let metrics_path = Keeper_types_support.keeper_metrics_path config keeper_name in
-    Keeper_memory.read_file_tail_lines metrics_path ~max_bytes:40000 ~max_lines:8
+    match
+      Keeper_memory.read_file_tail_lines_result metrics_path
+        ~max_bytes:40000 ~max_lines:8
+    with
+    | Ok lines -> lines
+    | Error exn_class ->
+        Keeper_memory.record_memory_recall_read_error
+          ~site:"keeper_exec_status_metrics" metrics_path exn_class;
+        []
 
 let latest_snapshot_of_lines lines ~parse_snapshot ~has_legacy_shape =
   let ordered = List.rev lines in
@@ -575,7 +583,17 @@ let latest_tool_audit_snapshot_from_decisions config keeper_name =
   let path = Keeper_types_support.keeper_decision_log_path config keeper_name in
   if not (Fs_compat.file_exists path) then None
   else
-    let lines = Keeper_memory.read_file_tail_lines path ~max_bytes:40000 ~max_lines:12 in
+    let lines =
+      match
+        Keeper_memory.read_file_tail_lines_result path
+          ~max_bytes:40000 ~max_lines:12
+      with
+      | Ok lines -> lines
+      | Error exn_class ->
+          Keeper_memory.record_memory_recall_read_error
+            ~site:"keeper_exec_status_tool_audit" path exn_class;
+          []
+    in
     let report_drop ~reason ~detail =
       report_persistence_read_drop
         ~surface:decision_log_tool_audit_persistence_surface

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -40,6 +40,14 @@ let report_heartbeat_history_drop ~reason ~path ~detail =
     ~detail
 ;;
 
+let read_tail_lines_or_empty ~site path ~max_bytes ~max_lines =
+  match read_file_tail_lines_result path ~max_bytes ~max_lines with
+  | Ok lines -> lines
+  | Error exn_class ->
+      record_memory_recall_read_error ~site path exn_class;
+      []
+;;
+
 let status_tick_usage_json () =
   `Assoc
     [
@@ -112,7 +120,7 @@ let write_heartbeat_snapshot
          try
            [ history_path; internal_history_path ]
            |> List.concat_map (fun path ->
-                read_file_tail_lines path
+                read_tail_lines_or_empty ~site:"keeper_heartbeat_history" path
                   ~max_bytes:max_history_read_bytes
                   ~max_lines:max_history_read_lines
                 |> List.filter_map (fun line ->

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -82,30 +82,6 @@ let read_file_tail_lines_result path ~max_bytes ~max_lines :
     | (Sys_error _ | Unix.Unix_error _ | End_of_file) as exn ->
         Error (Keeper_memory_recall_exn_class.classify exn)
 
-let read_file_tail_lines path ~max_bytes ~max_lines : string list =
-  match read_file_tail_lines_result path ~max_bytes ~max_lines with
-  | Ok lines -> lines
-  | Error exn_class ->
-    (* WORKAROUND: RFC-0149 §3.1 sunset target.  Counter + WARN remain
-       in this legacy entry point only; the Result-returning helper
-       above surfaces the typed exception class so the caller can
-       branch on [Error] directly.
-
-       Removal: once every caller migrates to
-       [read_file_tail_lines_result], delete this Error arm together
-       with the counter/WARN per RFC-0149 §3.1 sunset criterion.  The
-       counter itself can be retained for long-tail trend analysis
-       (cardinality already bounded by [exn_class]). *)
-    let exn_label = Keeper_memory_recall_exn_class.to_label exn_class in
-    Log.Keeper.warn
-      "read_file_tail_lines: dropping read of %s: <error class=%s>"
-      path exn_label;
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_memory_recall_read_errors
-      ~labels:[ ("exception_class", exn_label) ]
-      ();
-    []
-
 let record_memory_recall_read_error ~site path exn_class =
   let exn_label = Keeper_memory_recall_exn_class.to_label exn_class in
   Log.Keeper.warn

--- a/lib/keeper/keeper_memory_recall.mli
+++ b/lib/keeper/keeper_memory_recall.mli
@@ -29,13 +29,12 @@ val read_file_tail_lines_result :
 
     @since RFC-0149 Phase 1 *)
 
-val read_file_tail_lines : string -> max_bytes:int -> max_lines:int -> string list
-(** Silent-fallback tail reader: classifies IO/parse failures, emits
-    the [keeper_memory_recall_read_errors] counter + a WARN-once log
-    line, and returns [[]] on any [Error] class.  Retained as a facade
-    over {!read_file_tail_lines_result} during the RFC-0149 §3.1
-    sunset window; new callers should prefer the Result-returning
-    helper. *)
+val record_memory_recall_read_error :
+  site:string -> string -> Keeper_memory_recall_exn_class.t -> unit
+(** Emit the bounded read-failure metric and WARN line for call sites
+    that intentionally degrade after consuming
+    {!read_file_tail_lines_result}.  This is logging only; callers must
+    choose their own degraded value explicitly. *)
 
 val read_keeper_memory_summary_result :
   Coord.config ->

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -645,15 +645,13 @@ val metric_keeper_session_cleanup_failures : string
     masking as "no history". *)
 val metric_keeper_memory_bank_load_history_swallowed_exceptions : string
 
-(** Counter for IO / read failures swallowed by the silent
-    [try ... with Sys_error _ | Unix.Unix_error _ | End_of_file -> []]
-    catch-all in [Keeper_memory_recall.read_file_tail_lines]. Without this
-    counter a corrupt or missing memory bank file is indistinguishable
-    from a keeper with no recorded memory — the recall code returns
-    [[]] in both cases. The counter uses the same
+(** Counter for IO / read failures observed by callers of
+    [Keeper_memory_recall.read_file_tail_lines_result] that intentionally
+    degrade after consuming [Error class]. Without this counter a corrupt
+    memory bank file can look like an empty one in read-only dashboard
+    surfaces. The counter uses the same
     [Keeper_memory_recall_exn_class] closed-sum [exception_class] label
-    as the load-history counter so cardinality is bounded. Behavior is
-    unchanged (read still returns [[]] on failure). *)
+    as the load-history counter so cardinality is bounded. *)
 val metric_keeper_memory_recall_read_errors : string
 
 (** Counter for probe responses dropped by the silent JSON parse catch-all

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -349,7 +349,15 @@ let latest_decision_json ~(config : Coord.config) ~(keeper_name : string) :
   let path = Keeper_types_support.keeper_decision_log_path config keeper_name in
   if not (Fs_compat.file_exists path) then None
   else
-    Keeper_memory.read_file_tail_lines path ~max_bytes:40000 ~max_lines:20
+    (match
+       Keeper_memory.read_file_tail_lines_result path
+         ~max_bytes:40000 ~max_lines:20
+     with
+     | Ok lines -> lines
+     | Error exn_class ->
+         Keeper_memory.record_memory_recall_read_error
+           ~site:"keeper_runtime_trust_decisions" path exn_class;
+         [])
     |> List.rev
     |> List.find_map (fun line ->
            match Yojson.Safe.from_string line with

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -15,6 +15,13 @@ include Keeper_status_bridge
 (* Re-export handle_keeper_status from the detail module *)
 let handle_keeper_status = Keeper_status_detail.handle_keeper_status
 
+let read_tail_lines_or_empty ~site path ~max_bytes ~max_lines =
+  match read_file_tail_lines_result path ~max_bytes ~max_lines with
+  | Ok lines -> lines
+  | Error exn_class ->
+      record_memory_recall_read_error ~site path exn_class;
+      []
+
 let handle_keeper_list ctx args : tool_result =
   let limit = max 0 (get_int args "limit" 50) in
   let detailed = get_bool args "detailed" false in
@@ -63,7 +70,9 @@ let handle_keeper_list ctx args : tool_result =
           let metrics_window_lines =
             let dated = Dated_jsonl.read_recent_lines metrics_store 120 in
             if dated <> [] then dated
-            else read_file_tail_lines metrics_path ~max_bytes:120000 ~max_lines:120
+            else
+              read_tail_lines_or_empty ~site:"keeper_status_metrics" metrics_path
+                ~max_bytes:120000 ~max_lines:120
           in
           let last_metrics =
             match List.rev metrics_window_lines with

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -17,6 +17,13 @@ open Keeper_status_bridge
 
 type tool_result = Keeper_types.tool_result
 
+let read_tail_lines_or_empty ~site path ~max_bytes ~max_lines =
+  match read_file_tail_lines_result path ~max_bytes ~max_lines with
+  | Ok lines -> lines
+  | Error exn_class ->
+      record_memory_recall_read_error ~site path exn_class;
+      []
+
 (* ── Response cache ──────────────────────────────────── *)
 
 type cache_entry = {
@@ -316,8 +323,9 @@ let handle_keeper_status ctx args : tool_result =
            let lines =
              let dated = Dated_jsonl.read_recent_lines metrics_store tail_turns in
              if dated <> [] then dated
-             else read_file_tail_lines metrics_path
-                    ~max_bytes:tail_bytes ~max_lines:tail_turns
+             else
+               read_tail_lines_or_empty ~site:"keeper_status_detail_metrics_tail"
+                 metrics_path ~max_bytes:tail_bytes ~max_lines:tail_turns
            in
            let (parsed, _) =
              Fs_compat.parse_jsonl_lines ~source:"keeper_metrics" lines
@@ -329,8 +337,9 @@ let handle_keeper_status ctx args : tool_result =
              let n = max tail_turns 200 in
              let dated = Dated_jsonl.read_recent_lines metrics_store n in
              if dated <> [] then dated
-             else read_file_tail_lines metrics_path
-                    ~max_bytes:tail_bytes ~max_lines:n
+             else
+               read_tail_lines_or_empty ~site:"keeper_status_detail_metrics_window"
+                 metrics_path ~max_bytes:tail_bytes ~max_lines:n
            else
              []
          in
@@ -428,9 +437,8 @@ let handle_keeper_status ctx args : tool_result =
              (`List [], 0, 0, 0)
            else
              let lines =
-               read_file_tail_lines history_path
-                 ~max_bytes:tail_bytes
-                 ~max_lines:tail_messages
+               read_tail_lines_or_empty ~site:"keeper_status_detail_history"
+                 history_path ~max_bytes:tail_bytes ~max_lines:tail_messages
              in
              let (items_rev, raw_count, fragment_count, filtered_count) =
                List.fold_left
@@ -515,8 +523,10 @@ let handle_keeper_status ctx args : tool_result =
              let lines =
                let dated = Dated_jsonl.read_recent_lines metrics_store n in
                if dated <> [] then dated
-               else read_file_tail_lines metrics_path
-                      ~max_bytes:tail_bytes ~max_lines:n
+               else
+                 read_tail_lines_or_empty
+                   ~site:"keeper_status_detail_compaction_history" metrics_path
+                   ~max_bytes:tail_bytes ~max_lines:n
              in
              let events_rev =
                List.fold_left

--- a/lib/keeper/keeper_status_detail_observability.ml
+++ b/lib/keeper/keeper_status_detail_observability.ml
@@ -42,10 +42,16 @@ let latest_metrics_json ~metrics_store ~metrics_path ~tail_bytes =
     if dated <> []
     then dated
     else
-      Keeper_memory.read_file_tail_lines
-        metrics_path
-        ~max_bytes:tail_bytes
-        ~max_lines:8
+      (match
+         Keeper_memory.read_file_tail_lines_result metrics_path
+           ~max_bytes:tail_bytes
+           ~max_lines:8
+       with
+       | Ok lines -> lines
+       | Error exn_class ->
+           Keeper_memory.record_memory_recall_read_error
+             ~site:"keeper_status_detail_observability" metrics_path exn_class;
+           [])
   in
   let parsed, _ =
     Fs_compat.parse_jsonl_lines ~source:"keeper_metrics_latest" lines

--- a/lib/operator/operator_control_context_snapshot.ml
+++ b/lib/operator/operator_control_context_snapshot.ml
@@ -53,7 +53,15 @@ let latest_keeper_context_snapshot_from_files config keeper_name =
     then dated
     else (
       let path = Keeper_types_support.keeper_metrics_path config keeper_name in
-      Keeper_memory.read_file_tail_lines path ~max_bytes:32000 ~max_lines:32)
+      match
+        Keeper_memory.read_file_tail_lines_result path
+          ~max_bytes:32000 ~max_lines:32
+      with
+      | Ok lines -> lines
+      | Error exn_class ->
+          Keeper_memory.record_memory_recall_read_error
+            ~site:"operator_context_snapshot_metrics" path exn_class;
+          [])
   in
   let snapshots =
     List.rev metrics_lines

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -614,10 +614,18 @@ let keepers_json
                                        let metrics_path =
                                          Keeper_types_support.keeper_metrics_path config name
                                        in
-                                       Keeper_memory.read_file_tail_lines
-                                         metrics_path
-                                         ~max_bytes:8000
-                                         ~max_lines:5)
+                                       match
+                                         Keeper_memory.read_file_tail_lines_result
+                                           metrics_path
+                                           ~max_bytes:8000
+                                           ~max_lines:5
+                                       with
+                                       | Ok lines -> lines
+                                       | Error exn_class ->
+                                           Keeper_memory.record_memory_recall_read_error
+                                             ~site:"operator_recent_activity_metrics"
+                                             metrics_path exn_class;
+                                           [])
                                    in
                                    `List
                                      (List.filter_map

--- a/lib/operator/operator_control_snapshot_tool_audit.ml
+++ b/lib/operator/operator_control_snapshot_tool_audit.ml
@@ -35,7 +35,16 @@ let recent_tool_names_from_files config keeper_name =
   let decision_lines =
     let path = Keeper_types_support.keeper_decision_log_path config keeper_name in
     if Fs_compat.file_exists path
-    then Keeper_memory.read_file_tail_lines path ~max_bytes:120000 ~max_lines:120
+    then
+      match
+        Keeper_memory.read_file_tail_lines_result path
+          ~max_bytes:120000 ~max_lines:120
+      with
+      | Ok lines -> lines
+      | Error exn_class ->
+          Keeper_memory.record_memory_recall_read_error
+            ~site:"operator_tool_audit_decisions" path exn_class;
+          []
     else []
   in
   let metrics_lines =
@@ -45,7 +54,15 @@ let recent_tool_names_from_files config keeper_name =
     then dated
     else (
       let path = Keeper_types_support.keeper_metrics_path config keeper_name in
-      Keeper_memory.read_file_tail_lines path ~max_bytes:120000 ~max_lines:120)
+      match
+        Keeper_memory.read_file_tail_lines_result path
+          ~max_bytes:120000 ~max_lines:120
+      with
+      | Ok lines -> lines
+      | Error exn_class ->
+          Keeper_memory.record_memory_recall_read_error
+            ~site:"operator_tool_audit_metrics" path exn_class;
+          [])
   in
   merge_tool_name_lists
     (collect_recent_tool_names decision_lines)

--- a/lib/tool_keeper_ops.ml
+++ b/lib/tool_keeper_ops.ml
@@ -210,7 +210,16 @@ let keeper_list_skill_route_json config (meta : keeper_meta) =
   let lines =
     let dated = Dated_jsonl.read_recent_lines metrics_store 50 in
     if Stdlib.List.length dated > 0 then dated
-    else Keeper_memory.read_file_tail_lines metrics_path ~max_bytes:16_000 ~max_lines:50
+    else
+      match
+        Keeper_memory.read_file_tail_lines_result metrics_path
+          ~max_bytes:16_000 ~max_lines:50
+      with
+      | Ok lines -> lines
+      | Error exn_class ->
+          Keeper_memory.record_memory_recall_read_error
+            ~site:"tool_keeper_ops_skill_route_metrics" metrics_path exn_class;
+          []
   in
   let open Yojson.Safe.Util in
   let rec find_latest = function

--- a/specs/state-product/CoordinationProduct.tla
+++ b/specs/state-product/CoordinationProduct.tla
@@ -1,7 +1,11 @@
 --------------------------- MODULE CoordinationProduct ---------------------------
 \* Advisory Goal x Task x Board x Reward orthogonal product.
 \*
-\* Mirrors: lib/coordination_product.ml
+\* Mirrors:
+\*
+\* Advisory product spec only. There is no current OCaml
+\* coordination_product module; keep this spec detached until a new
+\* implementation owner is introduced.
 \*
 \* This model checks cross-axis safety only. Each axis can evolve
 \* independently, but terminal goal/reward states require evidence from

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -407,7 +407,7 @@ let test_load_history_user_messages_ignores_internal_prompt_entries () =
       check string "second real" "second real question" (List.nth result 2))
 
 (* RFC-0149 §3.1 PR-11: typed Error path for the user-history reader.
-   A directory path (which [read_file_tail_lines] cannot tail) must
+   A directory path (which [read_file_tail_lines_result] cannot tail) must
    surface as [Error io_error] rather than collapsing to [Ok []]
    indistinguishable from "no user messages recorded". *)
 let test_load_history_user_messages_result_error_on_directory_path () =
@@ -424,7 +424,7 @@ let test_load_history_user_messages_result_error_on_directory_path () =
         "io_error"
         (Keeper_memory_recall_exn_class.to_label exn_class))
 
-let test_read_file_tail_lines_reads_tail_without_byte_cap () =
+let test_read_file_tail_lines_result_reads_tail_without_byte_cap () =
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
     let path = Filename.concat dir "large-history.jsonl" in
@@ -433,29 +433,40 @@ let test_read_file_tail_lines_reads_tail_without_byte_cap () =
       output_string oc (Printf.sprintf "line-%04d\n" i)
     done;
     close_out oc;
-    let lines =
-      Keeper_memory_recall.read_file_tail_lines path ~max_bytes:0 ~max_lines:3
-    in
-    check (list string) "last three lines"
-      [ "line-0998"; "line-0999"; "line-1000" ]
-      lines)
+    match
+      Keeper_memory_recall.read_file_tail_lines_result path
+        ~max_bytes:0 ~max_lines:3
+    with
+    | Error exn_class ->
+        fail
+          ( "unexpected tail read error: "
+          ^ Keeper_memory_recall_exn_class.to_label exn_class )
+    | Ok lines ->
+        check (list string) "last three lines"
+          [ "line-0998"; "line-0999"; "line-1000" ]
+          lines)
 
-let test_read_file_tail_lines_drops_partial_byte_cap_line () =
+let test_read_file_tail_lines_result_drops_partial_byte_cap_line () =
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
     let path = Filename.concat dir "capped-history.jsonl" in
     let oc = open_out path in
     output_string oc "first\nsecond\nthird\n";
     close_out oc;
-    let lines =
-      Keeper_memory_recall.read_file_tail_lines path ~max_bytes:8 ~max_lines:3
-    in
-    check (list string) "partial first capped line dropped" [ "third" ] lines)
+    match
+      Keeper_memory_recall.read_file_tail_lines_result path
+        ~max_bytes:8 ~max_lines:3
+    with
+    | Error exn_class ->
+        fail
+          ( "unexpected tail read error: "
+          ^ Keeper_memory_recall_exn_class.to_label exn_class )
+    | Ok lines ->
+        check (list string) "partial first capped line dropped" [ "third" ] lines)
 
 (* RFC-0149 §3.1 — direct unit tests for the Result-returning helper.
-   The legacy facade tests above exercise the [Ok] path indirectly;
-   these cases pin the [Ok] / [Ok []] / [Error _] tri-state contract
-   so a caller migration cannot silently regress the typed boundary. *)
+   These cases pin the [Ok] / [Ok []] / [Error _] tri-state contract
+   so caller code cannot silently regress the typed boundary. *)
 
 let exn_class_testable =
   let module E = Keeper_memory_recall_exn_class in
@@ -566,7 +577,7 @@ let make_test_room_config dir =
 
 (* RFC-0149 §3.1: typed Error path for the horizon-counts reader.
    A keeper whose memory.jsonl path resolves to a directory (which
-   [read_file_tail_lines] cannot tail) must surface as
+   [read_file_tail_lines_result] cannot tail) must surface as
    [Error io_error] rather than collapsing to [Ok []]
    indistinguishable from "no rows recorded". *)
 let test_read_memory_horizon_counts_result_error_on_directory_path () =
@@ -2011,10 +2022,10 @@ let () =
             test_read_memory_horizon_counts_result_error_on_directory_path;
           test_case "read_recent_memory_texts_result Error on directory path" `Quick
             test_read_recent_memory_texts_result_error_on_directory_path;
-          test_case "read_file_tail_lines reads tail without byte cap" `Quick
-            test_read_file_tail_lines_reads_tail_without_byte_cap;
-          test_case "read_file_tail_lines drops partial byte-cap line" `Quick
-            test_read_file_tail_lines_drops_partial_byte_cap_line;
+          test_case "read_file_tail_lines_result reads tail without byte cap" `Quick
+            test_read_file_tail_lines_result_reads_tail_without_byte_cap;
+          test_case "read_file_tail_lines_result drops partial byte-cap line" `Quick
+            test_read_file_tail_lines_result_drops_partial_byte_cap_line;
           test_case "read_file_tail_lines_result Ok on normal read" `Quick
             test_read_file_tail_lines_result_ok_on_normal_read;
           test_case "read_file_tail_lines_result Ok [] on missing file" `Quick


### PR DESCRIPTION
## Summary
- delete the public `Keeper_memory_recall.read_file_tail_lines` silent-fallback facade
- move callers to `read_file_tail_lines_result` with explicit degraded handling and site labels where empty-list fallback is intentional
- update the legacy purge HTML ledger for #18643-#18647 and remove stale keeper tool-boundary matrix entries left by the tool-surface purge

## Verification
- `rg -n "\bread_file_tail_lines\b" lib test -g '*.ml' -g '*.mli'` -> no matches
- `ocamlformat --check ...` on touched OCaml files
- `git diff --check`
- `scripts/audit-keeper-tool-boundary-matrix.sh`
- `scripts/lint/no-ocaml-comment-terminator-trap.sh`
- `scripts/lint/no-unknown-permissive-default.sh`

## Gap
- `scripts/dune-local.sh build test/test_keeper_memory.exe` was blocked by the machine-wide bare-Dune guard (exit 75). I did not bypass it with `MASC_DUNE_ALLOW_BARE_DUNE=1`.