### PR TITLE
fix: resolve 3 build errors from module purge fallout

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -170,6 +170,7 @@ let activity_tool_called_payload ~tool_name ~success ~duration_ms ~source
 
 module For_testing = struct
   let activity_tool_called_payload = activity_tool_called_payload
+  let classify_failure_message = classify_failure_message
 end
 
 let nonempty_string_opt = function

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -73,6 +73,9 @@ module For_testing : sig
     ?tool_args_preview:string ->
     Yojson.Safe.t ->
     Yojson.Safe.t
+
+  val classify_failure_message :
+    string -> Tool_result.tool_failure_class
 end
 
 (** {1 Per-tool timeout} *)

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -32,6 +32,13 @@ let effective_autoboot_enabled name (meta : Keeper_types.keeper_meta) =
   | Some value -> value
   | None -> meta.autoboot_enabled
 
+let blocker_class_string (info : Keeper_types.blocker_info option) =
+  Option.map (fun (info : Keeper_types.blocker_info) ->
+    Keeper_meta_contract.blocker_class_to_string info.klass) info
+
+let blocker_detail (info : Keeper_types.blocker_info option) =
+  Option.map (fun (info : Keeper_types.blocker_info) -> info.detail) info
+
 let pause_elapsed_sec now (meta : Keeper_types.keeper_meta) =
   match Coord_resilience.Time.parse_iso8601_opt meta.updated_at with
   | Some updated_ts when updated_ts > 0.0 -> Some (max 0.0 (now -. updated_ts))

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -30,10 +30,7 @@ val paused_keeper_detail_json :
   name:string ->
   autoboot_enabled:bool ->
   Server_routes_http_common.Keeper_types.keeper_meta ->
-  [> `Assoc of
-       (string *
-        [> `Bool of bool | `Float of float | `Null | `String of string ])
-       list ]
+  [> `Assoc of (string * Yojson.Safe.t) list ]
 val running_paused_keeper_names : unit -> String.t list
 val durable_paused_keeper_scan :
   ?include_details:bool -> Coord.config -> paused_keeper_scan

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -47,31 +47,6 @@ let test_allowed_commands () =
     Alcotest.(check bool) (Printf.sprintf "allowed: %s" cmd) true (is_ok (validate cmd))
   ) allowed
 
-let test_allowlists_are_bin_derived () =
-  let names = List.map Exec_program.name_of_known in
-  Alcotest.(check (list string))
-    "dev allowlist is derived from Exec_program known values"
-    (names Dev_exec_allowlist.dev_programs)
-    Dev_exec_allowlist.dev;
-  Alcotest.(check (list string))
-    "code shell allowlist is derived from Exec_program known values"
-    (names Dev_exec_allowlist.code_shell_programs)
-    Dev_exec_allowlist.code_shell;
-  Alcotest.(check (list string))
-    "readonly allowlist is derived from Exec_program known values"
-    (names Dev_exec_allowlist.readonly_programs)
-    Dev_exec_allowlist.readonly;
-  List.iter
-    (fun name ->
-       match Exec_program.of_string name with
-       | Ok bin ->
-         Alcotest.(check bool)
-           (Printf.sprintf "%s is a known Exec_program" name)
-           true
-           (Option.is_some (Exec_program.known bin))
-       | Error _ -> Alcotest.failf "%s rejected by Exec_program.of_string" name)
-    Dev_exec_allowlist.dev
-
 let test_blocked_commands () =
   let blocked = [
     "dune build";
@@ -1073,10 +1048,6 @@ let () =
     "Keeper bash safety"
     [ ( "allowlist"
       , [ Alcotest.test_case "allowed dev commands pass" `Quick test_allowed_commands
-        ; Alcotest.test_case
-            "allowlists are Exec_program-derived"
-            `Quick
-            test_allowlists_are_bin_derived
         ; Alcotest.test_case "dangerous commands blocked" `Quick test_blocked_commands
         ] )
     ; ( "metachar"

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -178,21 +178,21 @@ let test_contains_casefold_keeps_semantics () =
   check bool "absent substring" false (contains "Invalid JSON" "timeout")
 
 let test_failure_message_uses_structured_failure_class () =
-  let classify = Masc_mcp.Mcp_server_eio_call_tool.classify_failure_message in
+  let classify = Masc_mcp.Mcp_server_eio_call_tool.For_testing.classify_failure_message in
   check
     (testable
-       Masc_mcp.Tool_result.pp_tool_failure_class
+       Tool_result.pp_tool_failure_class
        ( = ))
     "structured egress policy class"
-    Masc_mcp.Tool_result.Policy_rejection
+    Tool_result.Policy_rejection
     (classify
        {|{"ok":false,"error":"egress_blocked","failure_class":"policy_rejection"}|});
   check
     (testable
-       Masc_mcp.Tool_result.pp_tool_failure_class
+       Tool_result.pp_tool_failure_class
        ( = ))
     "legacy egress is not inferred"
-    Masc_mcp.Tool_result.Runtime_failure
+    Tool_result.Runtime_failure
     (classify {|{"ok":false,"error":"egress_blocked"}|})
 
 let test_transition_has_no_fixed_timeout () =


### PR DESCRIPTION
## Summary
- `server_routes_http_runtime_fleet_scan`: add `blocker_class_string`/`blocker_detail` implementations required by `.mli`; widen `paused_keeper_detail_json` return type to `Yojson.Safe.t`
- `mcp_server_eio_call_tool`: expose `classify_failure_message` via `For_testing` module (test-only helper behind `.mli` boundary)
- `test_keeper_bash_safety`: remove `test_allowlists_are_bin_derived` (references deleted `Dev_exec_allowlist` module)
- `test_mcp_server_eio_call_tool`: fix `Tool_result` references from `Masc_mcp.Tool_result` to bare `Tool_result` (`wrapped false` sub-lib)

## Test plan
- [x] `dune build --root .` passes with 0 errors
- [ ] `dune runtest` (blocked by dune lock contention from parallel session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)