### PR TITLE
fix(dashboard): throttle full health refresh warning noise

### DIFF
--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -14,6 +14,7 @@ type config = {
   on_error : (exn -> unit) option;
   health_check : (unit -> bool) option;
   warm_delay_s : float;
+  warn_first_failure : bool;
 }
 
 let default_config ~label ~interval_s =
@@ -26,6 +27,7 @@ let default_config ~label ~interval_s =
     on_error = None;
     health_check = None;
     warm_delay_s = 0.0;
+    warn_first_failure = true;
   }
 
 let is_internal_race_cancel exn =
@@ -59,8 +61,9 @@ let timeout_exception ~config ~phase ~elapsed_s =
 
 let is_power_of_two n = n > 0 && n land (n - 1) = 0
 
-let should_warn_refresh_failure ~failure_threshold consecutive_failures =
-  consecutive_failures = 1
+let should_warn_refresh_failure ?(warn_first_failure = true) ~failure_threshold
+    consecutive_failures =
+  (warn_first_failure && consecutive_failures = 1)
   || consecutive_failures = failure_threshold
   || (consecutive_failures > failure_threshold
       && is_power_of_two consecutive_failures)
@@ -84,6 +87,7 @@ let log_refresh_failure ~config ~consecutive_failures ~current_interval ~dt exn 
     ~warn:
       (should_warn_refresh_failure
          ~failure_threshold:config.failure_threshold
+         ~warn_first_failure:config.warn_first_failure
          !consecutive_failures)
 
 let notify_error config exn =
@@ -159,6 +163,7 @@ let start ~sw ~clock ~config:raw_config ~compute ~on_result =
           ~warn:
             (should_warn_refresh_failure
                ~failure_threshold:config.failure_threshold
+               ~warn_first_failure:config.warn_first_failure
                !consecutive_failures)
       end else
       let t0 = Time_compat.now () in

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -797,6 +797,7 @@ let start_full_health_snapshot_refresh_loop ~sw ~clock =
         timeout_s = full_health_refresh_timeout_sec;
         on_error = Some mark_full_health_snapshot_error;
         warm_delay_s = 0.5;
+        warn_first_failure = false;
       }
     ~compute:(fun () -> compute_full_health_snapshot_for_refresh request)
     ~on_result:store_full_health_snapshot

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -50,6 +50,26 @@ let test_proactive_refresh_failure_warn_throttle () =
       (8, true);
     ]
 
+let test_proactive_refresh_failure_can_suppress_first_warn () =
+  let should_warn =
+    Proactive_refresh.For_testing.should_warn_refresh_failure
+      ~warn_first_failure:false
+      ~failure_threshold:3
+  in
+  List.iter
+    (fun (count, expected) ->
+      Alcotest.(check bool)
+        (Printf.sprintf "failure %d warn decision" count)
+        expected (should_warn count))
+    [
+      (1, false);
+      (2, false);
+      (3, true);
+      (4, true);
+      (5, false);
+      (8, true);
+    ]
+
 let latest_log_seq () =
   match Log.Ring.recent ~limit:1 () with
   | [] -> -1
@@ -700,6 +720,8 @@ let () =
             test_proactive_refresh_timeout_message_names_phase;
           test_case "proactive refresh failure WARN throttle" `Quick
             test_proactive_refresh_failure_warn_throttle;
+          test_case "proactive refresh can suppress first WARN" `Quick
+            test_proactive_refresh_failure_can_suppress_first_warn;
           test_case "compute timeout is not logged as error" `Quick
             (test_compute_timeout_not_logged_as_error ~clock);
           test_case "stale preserved on timeout" `Quick


### PR DESCRIPTION
## Summary
- add a per-surface Proactive_refresh option to keep first refresh failures at DEBUG
- use it for full_health_snapshot, which already preserves last-good payloads and emits threshold/power-of-two WARNs
- add a regression test for first-WARN suppression while preserving threshold WARN behavior

## Log evidence
- 2026-05-26 system log has 64 WARN rows matching full_health_snapshot refresh failed / refresh_timeout timeout_s=20.0
- /health reports logs active under /Users/dancer/me/.masc/logs with recent WARN/ERROR state

## Verification
- ocamlformat --check lib/server/proactive_refresh.ml lib/server/server_routes_http_runtime.ml test/test_dashboard_cache.ml
- ocamlc -stop-after parsing lib/server/proactive_refresh.ml lib/server/server_routes_http_runtime.ml test/test_dashboard_cache.ml
- git diff --check
- scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_dashboard_cache.exe test/test_server_runtime_bootstrap.exe attempted, blocked by existing bare Dune processes (exit 75)