### PR TITLE
fix(config): annotate sandbox env getters for classification guard

### DIFF
--- a/lib/config/env_config_sandbox.ml
+++ b/lib/config/env_config_sandbox.ml
@@ -87,9 +87,13 @@ module Runtime = struct
   let docker_playground_enabled () =
     get_bool ~default:false "MASC_KEEPER_DOCKER_PLAYGROUND"
 
+  (** @category Sandbox
+      @ops_class operator *)
   let docker_playground_container_name () =
     get_string ~default:"keeper-playground" "MASC_KEEPER_DOCKER_CONTAINER"
 
+  (** @category Sandbox
+      @ops_class operator *)
   let docker_playground_container_root () =
     get_string ~default:"/home/keeper/playground"
       "MASC_KEEPER_DOCKER_PLAYGROUND_ROOT"


### PR DESCRIPTION
## Summary

PR #18662 introduced two new typed env getters in `Env_config_sandbox.Runtime` but omitted the `@category` / `@ops_class` annotations that `scripts/ci/check-env-knob-classification.py` requires for every typed env getter in `lib/config/env_config_*.ml`. The guard flagged the two lines as `missing @category, missing @ops_class` and #18662 was admin-merged with the failure outstanding.

This PR backfills the metadata.

## Classification rationale

Both knobs are sandbox container identity values controlled by the operator (not algorithm-determined):
- `MASC_KEEPER_DOCKER_CONTAINER` — container name to attach to
- `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT` — container-side mount root

So: `@category Sandbox` + `@ops_class operator`.

## Verification

- `python3 scripts/ci/check-env-knob-classification.py --base origin/main^ --head HEAD` → `Env knob classification guard passed`.
- `dune build --root . lib/config/` → 0 error / 0 warning.

## Out of scope

- Meta Guards FAILURE on #18662 was a *separate* pre-existing finding (`main-worktree boundary still uses local tool-name allowlist`, `Tool_name.[ Keeper Context_status; ... ]`) unrelated to the alias-layer retirement.

Related: #18662 (Env_config_keeper alias layer retirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)