### PR TITLE
fix(build): sync post-18659 cleanup fallout

### DIFF
--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -212,7 +212,7 @@ let is_host_repo_boundary_exempt_with_input
   if is_read_only_with_input ~tool_name ~input
   then true
   else (
-    match Tool_catalog.is_host_repo_boundary_exempt tool_name with
+    match Tool_catalog.is_main_worktree_boundary_exempt tool_name with
     | Some exempt -> exempt
     | None -> false)
 ;;

--- a/lib/server/proactive_refresh.mli
+++ b/lib/server/proactive_refresh.mli
@@ -12,6 +12,7 @@ type config = {
   on_error : (exn -> unit) option;  (** Called on timeout or exception. *)
   health_check : (unit -> bool) option;  (** Pre-compute gate. If [Some f] and [f ()] returns [false], the cycle is skipped and backoff applied. *)
   warm_delay_s : float;    (** Delay before cold-start warm-cache compute (0.0 = immediate). *)
+  warn_first_failure : bool;  (** Emit WARN on first failure in a consecutive-failure streak. *)
 }
 
 val default_config : label:string -> interval_s:float -> config
@@ -23,7 +24,7 @@ module For_testing : sig
     label:string -> phase:string -> timeout_s:float -> elapsed_s:float -> string
 
   val should_warn_refresh_failure :
-    failure_threshold:int -> int -> bool
+    ?warn_first_failure:bool -> failure_threshold:int -> int -> bool
 end
 
 val start :

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -427,7 +427,7 @@ let requires_actor_binding name =
   | Some value -> value
   | None -> false
 
-let is_host_repo_boundary_exempt name =
+let is_main_worktree_boundary_exempt name =
   match effect_domain name with
   | Some Read_only | Some Masc_coordination | Some Playground_write -> Some true
   | Some Host_repo_write -> Some false

--- a/lib/tool_catalog.mli
+++ b/lib/tool_catalog.mli
@@ -79,7 +79,7 @@ val metadata : string -> metadata
 val implementation_status : string -> implementation_status
 val effect_domain : string -> effect_domain option
 val requires_actor_binding : string -> bool
-val is_host_repo_boundary_exempt : string -> bool option
+val is_main_worktree_boundary_exempt : string -> bool option
 val tool_group : string -> tool_group option
 val canonical_tool_name : string -> string
 val is_placeholder : string -> bool

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -9848,13 +9848,6 @@ let test_should_require_tools_for_initial_turn_matches_first_turn_gate () =
        ~turn_affordances:[ "task_claim" ]);
   check
     bool
-    "worktree delta inspection requires an action tool"
-    true
-    (KAR.should_require_tools_for_initial_turn
-       ~max_turns:3
-       ~turn_affordances:[ "inspect_worktree_delta" ]);
-  check
-    bool
     "no tool-required affordance stays optional"
     false
     (KAR.should_require_tools_for_initial_turn
@@ -9871,11 +9864,7 @@ let test_should_require_tools_for_initial_turn_covers_actionable_affordances () 
   check bool "reply requires tool gate" true (require "reply_in_room");
   check bool "verification requires tool gate" true (require "task_verify");
   check bool "board curation requires tool gate" true (require "board_curation");
-  check
-    bool
-    "worktree inspection requires tool gate"
-    true
-    (require "inspect_worktree_delta")
+  ()
 ;;
 
 let test_actionable_observation_requires_provider_tool_choice_filter () =
@@ -9970,9 +9959,14 @@ let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
     (gate ~tools:[ "masc_transition" ] [ "task_verify" ]);
   check
     bool
-    "worktree delta with tool_search_files -> gate fires"
-    true
-    (gate ~tools:[ "tool_search_files" ] [ "inspect_worktree_delta" ]);
+    "timer-only work_discovery does not hard-gate even with progress tools"
+    false
+    (gate ~tools:[ "keeper_board_post"; "keeper_task_create" ] [ "work_discovery" ]);
+  check
+    bool
+    "work_discovery plus task_claim stays advisory without stronger signal"
+    false
+    (gate ~tools:[ "keeper_task_claim" ] [ "work_discovery"; "task_claim" ]);
   check
     bool
     "all gated affordances missing tools -> gate suppressed"
@@ -10117,7 +10111,6 @@ let test_tools_for_gated_affordance_covers_each_variant () =
   nonempty "Task_claim" Surface.Task_claim;
   nonempty "Task_audit" Surface.Task_audit;
   nonempty "Task_verify" Surface.Task_verify;
-  nonempty "Inspect_worktree_delta" Surface.Inspect_worktree_delta;
   check
     bool
     "board_curation force-includes submit tool"
@@ -10142,18 +10135,7 @@ let test_tools_for_gated_affordance_covers_each_variant () =
     true
     (Masc_mcp.Keeper_tool_progress.tool_name_can_satisfy_required_contract
        "keeper_board_comment");
-  check
-    bool
-    "worktree delta includes tool_search_files"
-    true
-    (List.mem
-       "tool_search_files"
-       (Surface.tools_for_gated_affordance Surface.Inspect_worktree_delta));
-  check
-    (list string)
-    "worktree delta prefers keeper shell path"
-    [ "tool_search_files"; "tool_execute" ]
-    (Surface.preferred_tool_names_for_turn_affordances [ "inspect_worktree_delta" ])
+  ()
 ;;
 
 let test_preferred_tool_choice_for_required_turn_claims_first () =
@@ -10518,34 +10500,6 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
       (Printf.sprintf
          "expected Any for active-task keeper (must make progress), got %s"
          (Agent_sdk.Types.show_tool_choice other)));
-  (match
-     choose
-       ~has_current_task:true
-       ~turn_affordances:[ "inspect_worktree_delta" ]
-       ~allowed_tool_names:[ "Execute"; "keeper_tasks_list" ]
-       ()
-   with
-   | Agent_sdk.Types.Tool "Execute" -> ()
-   | other ->
-     fail
-       (Printf.sprintf
-          "expected exact public Execute for single public generic required candidate, got \
-           %s"
-          (Agent_sdk.Types.show_tool_choice other)));
-  (match
-     choose
-       ~has_current_task:true
-       ~turn_affordances:[ "inspect_worktree_delta" ]
-       ~allowed_tool_names:[ "tool_search_files"; "keeper_tasks_list" ]
-       ()
-   with
-   | Agent_sdk.Types.Any -> ()
-   | other ->
-     fail
-       (Printf.sprintf
-          "expected Any for single internal generic required candidate to avoid MCP \
-           raw-name mismatches, got %s"
-          (Agent_sdk.Types.show_tool_choice other)));
   check
     (list string)
     "generic required candidates exclude claim after owned task"

--- a/test/test_keeper_wip_admission.ml
+++ b/test/test_keeper_wip_admission.ml
@@ -8,7 +8,7 @@ let scope ?goal_id ?(category = Admission.Fix) repo =
 let item ?goal_id ?(category = Admission.Fix) repo id =
   { Admission.id; scope = scope ?goal_id ~category repo }
 
-let task ?worktree ?goal_id ?(status = Masc_domain.Todo) ?(title = "fix: task") id =
+let task ?goal_id ?(status = Masc_domain.Todo) ?(title = "fix: task") id =
   { Masc_domain.id
   ; title
   ; description = ""
@@ -17,7 +17,6 @@ let task ?worktree ?goal_id ?(status = Masc_domain.Todo) ?(title = "fix: task") 
   ; files = []
   ; created_at = "2026-05-21T00:00:00Z"
   ; created_by = None
-  ; worktree
   ; goal_id
   ; stage = None
   ; contract = None
@@ -25,13 +24,6 @@ let task ?worktree ?goal_id ?(status = Masc_domain.Todo) ?(title = "fix: task") 
   ; cycle_count = 0
   ; reclaim_policy = None
   ; do_not_reclaim_reason = None
-  }
-
-let worktree repo_name =
-  { Masc_domain.branch = "branch"
-  ; path = "/tmp/worktree"
-  ; git_root = "/tmp/repo"
-  ; repo_name
   }
 
 let caps =


### PR DESCRIPTION
Follow-up after #18659 was squash-merged before the final local build/test fallout landed.\n\nChanges:\n- remove stale inspect_worktree_delta/worktree test expectations\n- sync proactive_refresh.mli and renamed Tool_catalog boundary API\n\nVerification:\n- ocamlformat --check on touched OCaml files\n- ocamlc -stop-after parsing on touched OCaml files\n- git diff --check\n- scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_keeper_unified.exe test/test_keeper_wip_admission.exe blocked by existing bare Dune processes (exit 75)