### PR TITLE
refactor(keeper): purge stale boundary metadata affordances

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -199,6 +199,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tools_oas_bundle.mli` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_deterministic_error.ml` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_deterministic_error.mli` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_failure_boundary.ml` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_failure_boundary.mli` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_handler_exec.ml` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_handler_exec.mli` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_handler_telemetry.ml` - oas-tool-bridge

--- a/docs/spec/12-memory-systems.md
+++ b/docs/spec/12-memory-systems.md
@@ -374,10 +374,8 @@ Heuristic 분류는 ~80% 정확도를 보인다 (개발자 추정).
 | `Recent_broadcasts` | 방 내 최근 N개 broadcast |
 | `File_context` | 최근 수정 파일 (mtime scan 기반 구현 완료) |
 
-Keeper turn path는 이것과 별도로 `git status --porcelain` delta를 추적한다.
-즉:
-- `File_context` = 최근 파일 내용을 recall source로 가져오는 것
-- live worktree delta = 지난 keeper turn 이후 바뀐 파일 목록을 다음 turn에 직접 주입하는 것
+Keeper turn path는 이것과 별도로 현재 backlog와 scheduled autonomous trigger를
+live world state로 재확인한다.
 
 ### 8.3 Configuration
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -195,7 +195,7 @@ let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : boo
 
 (* ── Input-aware mutation-boundary bypass ────────────────────
    Some tools do mutate state, but they should not open the
-   host-repo checkpoint boundary because they either:
+   main-worktree checkpoint boundary because they either:
    - only touch MASC coordination state (tasks, board, broadcast), or
    - operate inside an explicit playground sandbox.
 
@@ -204,7 +204,7 @@ let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : boo
 
    The effect-domain tag is resolved through [Tool_catalog], so this boundary
    no longer has to mirror tool names or infer semantics from prefixes. *)
-let is_host_repo_boundary_exempt_with_input
+let is_main_worktree_boundary_exempt_with_input
       ~(tool_name : string)
       ~(input : Yojson.Safe.t)
   : bool

--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -65,8 +65,8 @@ val is_read_only_with_input :
   tool_name:string -> input:Yojson.Safe.t -> bool
 
 (** Whether the tool, given its input, is exempt from the per-turn
-    host-repo boundary block. *)
-val is_host_repo_boundary_exempt_with_input :
+    main-worktree boundary block. *)
+val is_main_worktree_boundary_exempt_with_input :
   tool_name:string -> input:Yojson.Safe.t -> bool
 
 (** Tools whose mutations are safe to leave un-reconciled after

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -141,8 +141,8 @@ let turn_intent_fallback_block =
        blindly repeat prior \"stay silent\", \"wait for new work\", or stale \
        repo/blocker claims without re-checking the live world state.";
       "- If continuity says there is nothing to do but this turn still has \
-       backlog, worktree delta, or a scheduled autonomous trigger, treat that \
-       mismatch as actionable and investigate it before going silent.";
+       backlog or a scheduled autonomous trigger, treat that mismatch as \
+       actionable and investigate it before going silent.";
       "- Nothing genuinely actionable after checking? End your turn with the \
        [STATE] block.";
       "";

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -487,8 +487,6 @@ let test_keeper_semantic_capabilities_use_capability_axis () =
   assert_contains contract_classifier "Keeper_tool_capability_axis.supports_any";
   assert_not_contains contract_classifier
     "\"tool_search_files\"; \"tool_execute\"; \"masc_code_shell\"";
-  assert_contains agent_surface
-    "Keeper_tool_capability_axis.inspect_worktree_delta_tool_names";
   assert_not_contains agent_surface
     "\"tool_search_files\"; \"tool_execute\"; \"masc_code_shell\"; \"tool_edit_file\"";
   assert_contains pr_metrics "Keeper_tool_capability_axis.supports";


### PR DESCRIPTION
## Summary
- Rename the active main-worktree boundary predicate to match the Tool_catalog effect-domain metadata boundary.
- Remove stale `inspect_worktree_delta` / worktree-delta prompt, docs, and boundary-test references after the work-discovery purge.
- Sync the keeper tool boundary matrix for the current OAS failure-boundary modules.

## Verification
- `ocamlformat --check` on changed OCaml files
- `git diff --check origin/main...HEAD`
- stale boundary/worktree-delta residue sweep with `rg`
- `scripts/audit-hardcoding-truth.sh`
- `scripts/audit-keeper-tool-boundary-matrix.sh`
- `bash scripts/check-doc-truth.sh`
- `scripts/check-spec-truth.sh`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD --recent-main 50 --duplicate-policy warn`
- `scripts/ocaml-structure-ratchet.sh`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD` (warn-only pending release tag)
- `scripts/ci/check-determinism-contract.sh` (passes with existing warnings)
- `scripts/ci/check-enum-string-safety.sh` (passes with existing warnings)
- `scripts/dune-local.sh build ...` attempted; refused with exit 75 due machine-wide bare Dune processes, not bypassed