### PR TITLE
fix(ci): update keeper tool boundary matrix

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -199,6 +199,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tools_oas_bundle.mli` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_deterministic_error.ml` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_deterministic_error.mli` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_failure_boundary.ml` - oas-tool-bridge
+- `lib/keeper/keeper_tools_oas_failure_boundary.mli` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_handler_exec.ml` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_handler_exec.mli` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_handler_telemetry.ml` - oas-tool-bridge


### PR DESCRIPTION
Follow-up after #18666 was squash-merged before the matrix ratchet fix landed.\n\nChanges:\n- add keeper_tools_oas_failure_boundary ml/mli to docs/design/keeper-tool-boundary-matrix.md with oas-tool-bridge owner\n\nVerification:\n- scripts/audit-keeper-tool-boundary-matrix.sh\n- git diff --check