### PR TITLE
feat(lint): add legacy tool surface name ratchet (RFC-0064 follow-up)

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -100,6 +100,16 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/no-provider-name-hardcoding.sh --fail
 
+  no-legacy-tool-surface-name:
+    name: Legacy tool surface name ratchet (RFC-0064)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
+      - name: Run lint
+        run: bash scripts/lint/no-legacy-tool-surface-name.sh --fail
+
   no-tool-result-error-printexc:
     name: RFC-0148 backsliding guard (no Tool_result.error + Printexc.to_string)
     runs-on: ubuntu-latest

--- a/scripts/lint/no-legacy-tool-surface-name.allowlist
+++ b/scripts/lint/no-legacy-tool-surface-name.allowlist
@@ -1,0 +1,6 @@
+# no-legacy-tool-surface-name allowlist
+#
+# Format: `path:line:literal` keys. Empty file = baseline 0 occurrences.
+# Add only when the descriptor refactor genuinely needs to mention the legacy
+# name (e.g. backwards-compat shim documentation). Each entry should cite the
+# PR that introduced it.

--- a/scripts/lint/no-legacy-tool-surface-name.sh
+++ b/scripts/lint/no-legacy-tool-surface-name.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Guard against re-emergence of pre-RFC-0064 public tool names in the
+# descriptor-backed tool surface.
+#
+# After the ToolDescriptor spine landed (#18570, #18581, #18586, #18654), the
+# only LLM-native public names are:
+#   Execute, SearchFiles, ReadFile, EditFile, WriteFile, SearchWeb, FetchWeb
+#
+# The legacy names — Bash, Grep, Read, Edit, Write, WebSearch, WebFetch — must
+# not reappear as quoted string literals in active tool-surface modules. This
+# script is intentionally narrow: it only scans files that declare or route
+# public tool names. Identifiers and code symbols (e.g. OCaml `Read` modules)
+# are untouched.
+#
+# Baseline = 0 occurrences. Allowlist is a debt ledger; entries are exact
+# `path:line:literal` keys that drift with line numbers, forcing same-PR
+# cleanup if anchors move.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ALLOWLIST="${ROOT}/scripts/lint/no-legacy-tool-surface-name.allowlist"
+
+MODE="--fail"
+case "${1:---fail}" in
+  --fail|"") MODE="--fail" ;;
+  --print) MODE="--print" ;;
+  -h|--help)
+    sed -n '2,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *)
+    echo "Usage: $0 [--fail|--print]" >&2
+    exit 2
+    ;;
+esac
+
+for tool in rg sed sort mktemp comm wc; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "[no-legacy-tool-surface-name] required tool missing: $tool" >&2
+    exit 2
+  }
+done
+
+cd "$ROOT"
+
+SCAN_GLOBS=(
+  "lib/keeper/agent_tool_descriptor.ml"
+  "lib/keeper/agent_tool_descriptor.mli"
+  "lib/keeper/agent_tool_runtime.ml"
+  "lib/keeper/agent_tool_runtime.mli"
+  "lib/keeper/keeper_tool_alias.ml"
+  "lib/keeper/keeper_tool_alias.mli"
+  "lib/keeper/keeper_tool_registry.ml"
+  "lib/keeper/keeper_tool_registry.mli"
+  "lib/keeper/keeper_tool_policy.ml"
+  "lib/keeper/keeper_tool_policy.mli"
+  "lib/keeper_tool_call_log_route_evidence.ml"
+  "lib/keeper_tool_call_log_route_evidence.mli"
+  "lib/tool_catalog.ml"
+  "lib/tool_catalog.mli"
+  "lib/tool_catalog_surfaces.ml"
+  "lib/tool_catalog_surfaces.mli"
+)
+
+LITERAL_PATTERN='"(Bash|Grep|Read|Edit|Write|WebSearch|WebFetch)"'
+
+current_tmp="$(mktemp -t legacy-tool-surface-name.current.XXXXXX)"
+allow_tmp="$(mktemp -t legacy-tool-surface-name.allow.XXXXXX)"
+new_tmp="$(mktemp -t legacy-tool-surface-name.new.XXXXXX)"
+stale_tmp="$(mktemp -t legacy-tool-surface-name.stale.XXXXXX)"
+trap 'rm -f "$current_tmp" "$allow_tmp" "$new_tmp" "$stale_tmp"' EXIT
+
+for file in "${SCAN_GLOBS[@]}"; do
+  [[ -f "$file" ]] || continue
+  while IFS=: read -r path line content; do
+    [[ -n "${path:-}" && -n "${line:-}" ]] || continue
+    while IFS= read -r literal; do
+      [[ -n "$literal" ]] || continue
+      printf '%s:%s:%s\n' "$path" "$line" "$literal"
+    done < <(printf '%s\n' "$content" | rg -o --replace '$1' "$LITERAL_PATTERN" || true)
+  done < <(rg --with-filename --no-heading --line-number --color=never "$LITERAL_PATTERN" "$file" || true)
+done | sort -u >"$current_tmp"
+
+if [[ -f "$ALLOWLIST" ]]; then
+  sed -E 's/#.*//; s/[[:space:]]//g; /^$/d' "$ALLOWLIST" | sort -u >"$allow_tmp"
+else
+  : >"$allow_tmp"
+fi
+
+comm -13 "$allow_tmp" "$current_tmp" >"$new_tmp"
+comm -23 "$allow_tmp" "$current_tmp" >"$stale_tmp"
+
+current_count="$(wc -l <"$current_tmp" | tr -d ' ')"
+allow_count="$(wc -l <"$allow_tmp" | tr -d ' ')"
+new_count="$(wc -l <"$new_tmp" | tr -d ' ')"
+stale_count="$(wc -l <"$stale_tmp" | tr -d ' ')"
+
+printf "%-40s %8s\n" "metric" "count"
+echo "------------------------------------------------"
+printf "%-40s %8s\n" "legacy_tool_name_literals_current" "$current_count"
+printf "%-40s %8s\n" "legacy_tool_name_allowlist_entries" "$allow_count"
+printf "%-40s %8s\n" "legacy_tool_name_new_literals" "$new_count"
+printf "%-40s %8s\n" "legacy_tool_name_stale_allowlist" "$stale_count"
+
+if [[ "$MODE" = "--print" ]]; then
+  echo
+  echo "[no-legacy-tool-surface-name] current keys:"
+  sed 's/^/  - /' "$current_tmp"
+  exit 0
+fi
+
+fail=0
+
+if [[ -s "$new_tmp" ]]; then
+  echo
+  echo "[no-legacy-tool-surface-name] DRIFT UP: legacy public tool name re-emerged in active surface" >&2
+  sed 's/^/  - /' "$new_tmp" >&2
+  echo "  Use the descriptor-owned name (Execute, SearchFiles, ReadFile, EditFile, WriteFile, SearchWeb, FetchWeb)." >&2
+  echo "  See lib/keeper/agent_tool_descriptor.ml for the canonical surface." >&2
+  fail=1
+fi
+
+if [[ -s "$stale_tmp" ]]; then
+  echo
+  echo "[no-legacy-tool-surface-name] STALE ALLOWLIST: entries no longer match source" >&2
+  sed 's/^/  - /' "$stale_tmp" >&2
+  echo "  Remove these from $ALLOWLIST in the same PR." >&2
+  fail=1
+fi
+
+exit $fail


### PR DESCRIPTION
## Summary

ToolDescriptor spine (#18570 / #18581 / #18586 / #18654) 작업 후 PR4 단계의 ratchet을 추가합니다. RFC-0064 two-surface 모델에서 legacy public tool name이 active surface에 재등장하지 못하도록 막습니다.

## Why

RFC-0064는 LLM-native public 이름을 descriptor가 소유하는 7개로 hard-cut했습니다:

- `Execute`, `SearchFiles`, `ReadFile`, `EditFile`, `WriteFile`, `SearchWeb`, `FetchWeb`

cut 이전 이름(`Bash`, `Grep`, `Read`, `Edit`, `Write`, `WebSearch`, `WebFetch`)은 `lib/keeper/`, `lib/keeper_tool*`, `lib/agent_tool*`, `lib/tool_shard*`, `bin/`, `config/tool_policy.toml` 어디에도 quoted string literal 형태로 0건입니다. 본 PR은 그 0 baseline을 ratchet으로 잠급니다.

근거: CLAUDE.md "Workaround Rejection Bar"의 self-fulfilling spiral 패턴. legacy 이름이 한 번 string literal로 main에 다시 들어오면 AI 에이전트가 그걸 합리적 선례로 학습해 누적시킵니다.

## Changes

- `scripts/lint/no-legacy-tool-surface-name.sh` — descriptor/routing/catalog 모듈만 좁게 스캔. `"<name>"` quoted literal 패턴 매칭으로 OCaml `Read` module 같은 identifier는 미터치.
- `scripts/lint/no-legacy-tool-surface-name.allowlist` — 빈 파일 (debt ledger). 항목은 `path:line:literal` 키이므로 라인 드리프트 발생 시 동일 PR에서 정리 강제.
- `.github/workflows/fundamental-check.yml` — `no-legacy-tool-surface-name` job 추가 (provider-name-hardcoding 옆).

## Scan scope

ratchet이 검사하는 파일:

- `lib/keeper/agent_tool_descriptor.{ml,mli}`
- `lib/keeper/agent_tool_runtime.{ml,mli}`
- `lib/keeper/keeper_tool_alias.{ml,mli}`
- `lib/keeper/keeper_tool_registry.{ml,mli}`
- `lib/keeper/keeper_tool_policy.{ml,mli}`
- `lib/keeper_tool_call_log_route_evidence.{ml,mli}`
- `lib/tool_catalog.{ml,mli}`
- `lib/tool_catalog_surfaces.{ml,mli}`

scope를 좁게 잡은 이유: legacy 이름은 영어 일반 단어와 겹쳐 broad scan은 false positive 폭증. descriptor가 ownership을 가진 모듈에만 한정하면 의미 있는 거짓양성 가능성이 사실상 0.

## Verification

Baseline (clean tree):

```
$ bash scripts/lint/no-legacy-tool-surface-name.sh
metric                                      count
------------------------------------------------
legacy_tool_name_literals_current               0
legacy_tool_name_allowlist_entries              0
legacy_tool_name_new_literals                   0
legacy_tool_name_stale_allowlist                0
EXIT=0
```

Negative test (inject `let _ = "Bash"` into agent_tool_descriptor.ml):

```
legacy_tool_name_literals_current               1
legacy_tool_name_new_literals                   1
[no-legacy-tool-surface-name] DRIFT UP: legacy public tool name re-emerged in active surface
  - lib/keeper/agent_tool_descriptor.ml:505:Bash
EXIT=1
```

Revert → back to EXIT=0. YAML lint OK on workflow change.

## Out of scope

- `keeper_shell_*` (28 modules) / `keeper_exec_*` (18 modules) module boundary rename = plan PR3 잔여 작업, 별도 PR.
- `bin/main_eio.ml` descriptor wiring 확인 = 별도 추적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
