### PR TITLE
refactor(tool): remove dispatch message failure classifier

### DIFF
--- a/docs/rfc/RFC-0062-typed-tool-result-and-blocker-class.md
+++ b/docs/rfc/RFC-0062-typed-tool-result-and-blocker-class.md
@@ -60,12 +60,11 @@ type tool_failure_class =
   | Workflow_rejection   (* HITL reject, gate refusal *)
 
 val classify_from_exception     : exn -> tool_failure_class option
-val classify_from_dispatch_failure : message:string -> tool_failure_class
 val is_retryable                : tool_failure_class -> bool
 val log_level_of_failure_class  : tool_failure_class -> [ `Warn | `Error ]
 ```
 
-`classify_from_exception` matches on exception **constructors** (typed). `classify_from_dispatch_failure` is the Phase 1 SSOT for the legacy string surface — it will be eliminated as Phase 4 finishes (§5).
+`classify_from_exception` matches on exception **constructors** (typed). The Phase 1 `classify_from_dispatch_failure` string fallback has been removed from the generic `Tool_result.error` path; callers must now pass `failure_class` explicitly or emit structured JSON with a `failure_class` field.
 
 ### 3.3 `Tool_result.t` — structured record (Phase 1→3)
 

--- a/lib/keeper/sandbox_error.mli
+++ b/lib/keeper/sandbox_error.mli
@@ -12,8 +12,8 @@
     dispatch error string. That allowed [Exec_timeout],
     [Daemon_unreachable], and OCI mount failures to be miscounted as
     image-missing when their messages happened to share tokens — exactly
-    the [classify_from_dispatch_failure] substring match collapse
-    documented in the Phase 4.1 prep audit
+    the legacy dispatch-message substring match collapse documented in
+    the Phase 4.1 prep audit
     (2026-05-12, iter 34 of cron 7493fe21).
 
     This module defines the closed sum so downstream callers

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -87,42 +87,6 @@ let classify_from_exception (exn : exn) : tool_failure_class =
   | _ -> Runtime_failure
 ;;
 
-(** Classify a tool failure from a [(false, message)] dispatch result.
-    SSOT for Phase 1: single classification point replacing the
-    duplicated [is_retryable_message] and [classify_tool_failure_class]. *)
-let classify_from_dispatch_failure (message : string) : tool_failure_class =
-  if
-    contains_casefold message "awaiting_approval"
-    || contains_casefold message "join required"
-    || contains_casefold message "Invalid task state"
-    || contains_casefold message "Invalid transition"
-    || contains_casefold message "Self-approval not allowed"
-    || contains_casefold message "Self-rejection not allowed"
-  then Workflow_rejection
-  else if contains_casefold message "path_outside_sandbox"
-  then Policy_rejection
-  else if contains_casefold message "Tool timed out"
-  then
-    (* Tool-level timeouts are NOT retryable — retrying a 30s timeout
-       causes 60-90s total wait, amplifying the original issue. *)
-    Runtime_failure
-  else if
-    contains_casefold message "timeout"
-    || contains_casefold message "temporary"
-    || contains_casefold message "temporarily"
-    || contains_casefold message "econn"
-    || contains_casefold message "connection"
-    || contains_casefold message "unavailable"
-    || contains_casefold message "rate limit"
-    || contains_casefold message "Failed to acquire distributed lock"
-    || contains_casefold message "distributed lock"
-    || contains_casefold message "lock contention"
-    || contains_casefold message "502"
-    || contains_casefold message "503"
-  then Transient_error
-  else Runtime_failure
-;;
-
 let classify_from_structured_failure_message message =
   try
     match Yojson.Safe.from_string message with
@@ -233,7 +197,7 @@ let error ?(failure_class = None) ~tool_name ~start_time message =
       Some
         (match classify_from_structured_failure_message message with
          | Some cls -> cls
-         | None -> classify_from_dispatch_failure message)
+         | None -> Runtime_failure)
   in
   { success = false
   ; data

--- a/lib/tool_types/tool_result.mli
+++ b/lib/tool_types/tool_result.mli
@@ -69,8 +69,9 @@ val failure_class : t -> tool_failure_class option
 (** Successful result. [failure_class] is [None]. *)
 val ok : tool_name:string -> start_time:float -> string -> t
 
-(** Failure result.  When [failure_class] is not provided,
-    the message is classified by an internal heuristic. *)
+(** Failure result.  When [failure_class] is not provided, only a structured
+    JSON [failure_class] payload is honored; free-form message text defaults to
+    [Runtime_failure]. *)
 val error
   :  ?failure_class:tool_failure_class option
   -> tool_name:string

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1663,23 +1663,26 @@ let test_docker_config_storage_contracts () =
 
 let test_tool_failure_classification_contracts () =
   check bool "tool failure classification uses typed class" true
-    (file_contains_pattern "lib/mcp_server_eio_call_tool.ml"
+    (file_contains_pattern "lib/tool_types/tool_result.ml"
        "type tool_failure_class =");
   check bool "workflow rejection class exists" true
-    (file_contains_pattern "lib/mcp_server_eio_call_tool.ml"
+    (file_contains_pattern "lib/tool_types/tool_result.ml"
        "| Workflow_rejection");
   check bool "policy rejection class exists" true
-    (file_contains_pattern "lib/mcp_server_eio_call_tool.ml"
+    (file_contains_pattern "lib/tool_types/tool_result.ml"
        "| Policy_rejection");
   check bool "runtime failure class exists" true
-    (file_contains_pattern "lib/mcp_server_eio_call_tool.ml"
+    (file_contains_pattern "lib/tool_types/tool_result.ml"
        "| Runtime_failure");
   check bool "log details expose failure class" true
     (file_contains_pattern "lib/mcp_server_eio_call_tool.ml"
        {|"failure_class"|});
-  check bool "call path classifies once before log emit" true
+  check bool "call path consumes typed failure class before log emit" true
     (file_contains_pattern "lib/mcp_server_eio_call_tool.ml"
-       "let failure_class = classify_tool_failure_class error_detail");
+       "match Tool_result.failure_class result with");
+  check bool "generic tool result has no dispatch-message classifier" false
+    (file_contains_pattern "lib/tool_types/tool_result.ml"
+       "classify_from_dispatch_failure");
   check bool "deterministic tool failures have reason metric" true
     (file_contains_pattern "lib/keeper/keeper_metrics.ml"
        "masc_keeper_tools_oas_deterministic_failures_total"

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -529,7 +529,7 @@ let test_preflight_reports_paused_activation_blocker_first () =
 let workflow_rejection_message =
   "Invalid task state: Self-approval not allowed: verifier must be a different agent"
 
-let test_tool_result_classifies_task_fsm_rejections_as_workflow () =
+let test_tool_result_does_not_infer_task_fsm_rejections_from_message () =
   let result =
     Tool_result.error
       ~tool_name:"masc_transition"
@@ -537,11 +537,11 @@ let test_tool_result_classifies_task_fsm_rejections_as_workflow () =
       workflow_rejection_message
   in
   match Tool_result.failure_class result with
-  | Some Tool_result.Workflow_rejection -> ()
+  | Some Tool_result.Runtime_failure -> ()
   | Some cls ->
     fail
       (Printf.sprintf
-         "expected workflow_rejection, got %s"
+         "expected runtime_failure, got %s"
          (Tool_result.tool_failure_class_to_string cls))
   | None -> fail "expected failure_class"
 
@@ -860,8 +860,8 @@ let () =
         test_preflight_reports_proactive_disabled_activation_blocker;
       test_case "preflight reports paused activation blocker first" `Quick
         test_preflight_reports_paused_activation_blocker_first;
-      test_case "task FSM errors classify as workflow rejection" `Quick
-        test_tool_result_classifies_task_fsm_rejections_as_workflow;
+      test_case "task FSM errors require explicit failure_class" `Quick
+        test_tool_result_does_not_infer_task_fsm_rejections_from_message;
       test_case "tool_result_or_error preserves failure_class" `Quick
         test_tool_result_or_error_preserves_failure_class;
       test_case "workflow rejection skips circuit breaker" `Quick

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -41,12 +41,29 @@ let test_error_plain_string () =
   | _ -> Alcotest.fail "expected String for non-JSON input"
 ;;
 
-let test_distributed_lock_dispatch_failure_is_transient () =
+let test_plain_dispatch_failure_does_not_infer_from_message () =
   let r =
     Tool_result.error
       ~tool_name:"masc_transition"
       ~start_time:0.0
       "[SystemError] IO error: Failed to acquire distributed lock for key: tasks:.backlog (50 attempts exhausted)"
+  in
+  Alcotest.(check bool) "failure" false r.success;
+  Alcotest.(check string)
+    "failure class"
+    "runtime_failure"
+    (match Tool_result.failure_class r with
+     | Some cls -> Tool_result.tool_failure_class_to_string cls
+     | None -> "none")
+;;
+
+let test_plain_dispatch_failure_honors_explicit_failure_class () =
+  let r =
+    Tool_result.error
+      ~failure_class:(Some Tool_result.Transient_error)
+      ~tool_name:"masc_transition"
+      ~start_time:0.0
+      "[SystemError] IO error: Failed to acquire distributed lock for key: tasks:.backlog"
   in
   Alcotest.(check bool) "failure" false r.success;
   Alcotest.(check string)
@@ -177,9 +194,13 @@ let () =
       , [ Alcotest.test_case "json response" `Quick test_ok_json_response
         ; Alcotest.test_case "plain string" `Quick test_error_plain_string
         ; Alcotest.test_case
-            "distributed lock dispatch failure is transient"
+            "plain dispatch failure does not infer from message"
             `Quick
-            test_distributed_lock_dispatch_failure_is_transient
+            test_plain_dispatch_failure_does_not_infer_from_message
+        ; Alcotest.test_case
+            "plain dispatch failure honors explicit failure_class"
+            `Quick
+            test_plain_dispatch_failure_honors_explicit_failure_class
         ; Alcotest.test_case
             "distributed lock exception is transient"
             `Quick


### PR DESCRIPTION
## Summary
- remove the generic `Tool_result.error` free-form dispatch-message classifier
- keep typed behavior: explicit `~failure_class` and structured JSON `failure_class` are still honored
- update tests/docs so task FSM and distributed-lock messages no longer gain retry/workflow semantics from substring matches alone

## Why
This is the next step after #18663: OAS failures were moved to a typed boundary there, but the shared `Tool_result.error` constructor still had a hidden Phase-1 substring fallback. This PR makes the generic tool-result boundary structured-only instead of message-text driven.

## Verification
- `ocamlformat --check lib/tool_types/tool_result.ml lib/tool_types/tool_result.mli lib/keeper/sandbox_error.mli test/test_tool_result.ml test/test_keeper_exec_tools.ml test/test_ci_hardening_source.ml`
- `git diff --check`
- `rg -n "classify_from_dispatch_failure" lib/tool_types/tool_result.ml` returned no matches

## Local build note
- Attempted `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build ./test/test_tool_result.exe`; the command stayed silent for several minutes while other long-running `dune build` jobs were already active on the host, so I terminated only my focused build process and left CI to run the compile/test gate.