### PR TITLE
refactor(cascade): purge max-turns string fallback

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -2,14 +2,14 @@
 
     Extracted from oas_worker_named.ml (God file decomposition).
     Converts OAS SDK errors into Cascade_fsm provider outcomes,
-    classifies CLI-wrapped error patterns (hard quota, max turns,
-    resumable sessions), and enriches errors with provider-specific hints.
+    classifies CLI-wrapped error patterns (hard quota, resumable sessions),
+    and enriches errors with provider-specific hints.
 
     @since God file decomposition *)
 
 (* DEPRECATED (RFC-0057 Phase 2): These string classifiers will be
    replaced by typed Provider_error variants. The new dispatch path
-   receives CliWrapped { kind = Hard_quota | Max_turns | ... }
+   receives CliWrapped { kind = Hard_quota | ... }
    directly from the provider adapter, eliminating the need for
    substring reconstruction.
 
@@ -362,21 +362,6 @@ let message_looks_like_cli_wrapped_hard_quota (message : string) : bool =
   (contains "exited with code 1"
    && contains "\"api_error_status\":429"
    && contains "you've hit your limit")
-
-let cli_wrapped_max_turns_indicators = [
-  "\"subtype\":\"error_max_turns\"";
-  "error_max_turns";
-  "\"terminal_reason\":\"max_turns\"";
-  "terminal_reason\":\"max_turns";
-  "reached maximum number of turns";
-  "max turns exceeded";
-]
-
-let message_looks_like_cli_wrapped_max_turns (message : string) : bool =
-  let contains needle =
-    String_util.contains_substring_ci message needle
-  in
-  List.exists contains cli_wrapped_max_turns_indicators
 
 let capacity_backpressure_indicators = [
   "client capacity";
@@ -896,10 +881,6 @@ let sdk_error_is_max_turns_exceeded (err : Agent_sdk.Error.sdk_error) : bool =
       (Cascade_error_classify.Cascade_exhausted
          { reason = Keeper_types.Max_turns_exceeded; _ }) ->
       true
-  | Some
-      (Cascade_error_classify.Cascade_exhausted
-         { reason = Keeper_types.Other_detail detail; _ }) ->
-      message_looks_like_cli_wrapped_max_turns detail
   | Some (Cascade_error_classify.Cascade_exhausted _)
   | Some (Cascade_error_classify.Capacity_backpressure _)
   | Some (Cascade_error_classify.Resumable_cli_session _)
@@ -921,26 +902,9 @@ let sdk_error_is_max_turns_exceeded (err : Agent_sdk.Error.sdk_error) : bool =
   | None -> (
       match err with
       | Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _) -> true
-      | Agent_sdk.Error.Api
-          (Llm_provider.Retry.NetworkError { message; _ }
-          | Llm_provider.Retry.Overloaded { message }
-          | Llm_provider.Retry.ServerError { message; _ }
-          | Llm_provider.Retry.InvalidRequest { message }
-          | Llm_provider.Retry.Timeout { message }) ->
-          message_looks_like_cli_wrapped_max_turns message
-      | Agent_sdk.Error.Api
-          (Llm_provider.Retry.RateLimited _
-          | Llm_provider.Retry.AuthError _
-          | Llm_provider.Retry.NotFound _
-          | Llm_provider.Retry.ContextOverflow _) ->
-          false
-      | Agent_sdk.Error.Provider
-          (Llm_provider.Error.ProviderTerminal { reason; detail; _ }) ->
-          message_looks_like_cli_wrapped_max_turns reason
-          || message_looks_like_cli_wrapped_max_turns detail
+      | Agent_sdk.Error.Api _ -> false
       | Agent_sdk.Error.Provider _ -> false
-      | Agent_sdk.Error.Internal message ->
-          message_looks_like_cli_wrapped_max_turns message
+      | Agent_sdk.Error.Internal _ -> false
       | _ -> false)
 
 let sdk_error_cascade_fallback_class (err : Agent_sdk.Error.sdk_error) :

--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -2,8 +2,8 @@
 
     Extracted from oas_worker_named.ml (God file decomposition).
     Converts OAS SDK errors into Cascade_fsm provider outcomes,
-    classifies CLI-wrapped error patterns (hard quota, max turns,
-    resumable sessions), and enriches errors with provider-specific hints.
+    classifies CLI-wrapped error patterns (hard quota, resumable sessions),
+    and enriches errors with provider-specific hints.
 
     This module is [include]d by {!Keeper_turn_driver}; all bindings are
     re-exported by the facade.  @since God file decomposition *)
@@ -30,9 +30,6 @@ val enrich_sdk_error :
 val message_looks_like_cli_wrapped_hard_quota : string -> bool
 (** Detect hard-quota indicators in CLI-wrapped error messages. *)
 
-val message_looks_like_cli_wrapped_max_turns : string -> bool
-(** Detect max-turns indicators in CLI-wrapped error messages. *)
-
 val message_looks_like_capacity_backpressure : string -> bool
 (** Detect capacity-backpressure indicators in error messages. *)
 
@@ -41,9 +38,6 @@ val message_looks_like_resumable_cli_session : string -> bool
 
 val cli_wrapped_hard_quota_indicators : string list
 (** List of substring indicators for CLI-wrapped hard quota. *)
-
-val cli_wrapped_max_turns_indicators : string list
-(** List of substring indicators for CLI-wrapped max turns. *)
 
 (** {1 Resumable CLI session helpers} *)
 

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -194,14 +194,6 @@ let is_provider_timeout_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) -> true
   | _ -> false
 
-let message_looks_like_gateway_backpressure detail =
-  let lower = String.lowercase_ascii detail in
-  string_contains_substring ~needle:"server error 524" lower
-  || string_contains_substring ~needle:"error code: 524" lower
-  || string_contains_substring ~needle:"status 524" lower
-  || string_contains_substring ~needle:"status=524" lower
-  || string_contains_substring ~needle:"cloudflare gateway timeout" lower
-
 (* 524 is Cloudflare's "origin responded too slowly" timeout. At keeper
    orchestration level this means the current provider lane is saturated or
    unhealthy enough that rotating/cooling it as backpressure is more useful
@@ -218,13 +210,6 @@ let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error
       (Keeper_turn_driver.Cascade_exhausted
          { reason = Keeper_types.Max_turns_exceeded; _ }) ->
       true
-  | Some
-      (Keeper_turn_driver.Cascade_exhausted
-         { reason = Keeper_types.Other_detail detail; _ }) ->
-      Keeper_turn_driver.message_looks_like_cli_wrapped_hard_quota detail
-      || Keeper_turn_driver.message_looks_like_cli_wrapped_max_turns detail
-      || message_looks_like_gateway_backpressure detail
-      || Keeper_turn_driver.message_looks_like_capacity_backpressure detail
   | Some (Keeper_turn_driver.Capacity_backpressure _) ->
       true
   | Some (Keeper_turn_driver.Cascade_exhausted _) ->
@@ -389,21 +374,6 @@ let degraded_retry_after_recoverable_error
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Max_turns_exceeded; _ }) ->
         phase_recovery_retry Max_turns
-    | Some
-        (Keeper_turn_driver.Cascade_exhausted
-           { reason = Keeper_types.Other_detail detail; _ })
-      when Keeper_turn_driver.message_looks_like_cli_wrapped_hard_quota detail ->
-        phase_recovery_retry Hard_quota
-    | Some
-        (Keeper_turn_driver.Cascade_exhausted
-           { reason = Keeper_types.Other_detail detail; _ })
-      when message_looks_like_gateway_backpressure detail ->
-        phase_recovery_retry Capacity_backpressure
-    | Some
-        (Keeper_turn_driver.Cascade_exhausted
-           { reason = Keeper_types.Other_detail detail; _ })
-      when Keeper_turn_driver.message_looks_like_capacity_backpressure detail ->
-        phase_recovery_retry Capacity_backpressure
     | Some (Keeper_turn_driver.Cascade_exhausted _)
     | Some (Keeper_turn_driver.No_tool_capable_provider _)
     | Some (Keeper_turn_driver.Accept_rejected _)
@@ -448,21 +418,6 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Max_turns_exceeded; _ }) ->
         Some Max_turns
-    | Some
-        (Keeper_turn_driver.Cascade_exhausted
-           { reason = Keeper_types.Other_detail detail; _ })
-      when Keeper_turn_driver.message_looks_like_cli_wrapped_hard_quota detail ->
-        Some Hard_quota
-    | Some
-        (Keeper_turn_driver.Cascade_exhausted
-           { reason = Keeper_types.Other_detail detail; _ })
-      when message_looks_like_gateway_backpressure detail ->
-        Some Capacity_backpressure
-    | Some
-        (Keeper_turn_driver.Cascade_exhausted
-           { reason = Keeper_types.Other_detail detail; _ })
-      when Keeper_turn_driver.message_looks_like_capacity_backpressure detail ->
-        Some Capacity_backpressure
     | Some (Keeper_turn_driver.Cascade_exhausted _) ->
         (* Generic cascade exhaustion: all candidates failed without a more
            specific reason. Treat as recoverable so declarative

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -26,8 +26,6 @@ val sdk_error_to_cascade_outcome :
 
 val message_looks_like_cli_wrapped_hard_quota : string -> bool
 
-val message_looks_like_cli_wrapped_max_turns : string -> bool
-
 val message_looks_like_capacity_backpressure : string -> bool
 
 val message_looks_like_resumable_cli_session : string -> bool

--- a/lib/keeper/keeper_turn_driver_try_cascade.ml
+++ b/lib/keeper/keeper_turn_driver_try_cascade.ml
@@ -180,29 +180,18 @@ let rec run
             Keeper_types.Connection_refused
           else if kind = Llm_provider.Http_client.Dns_failure then
             Keeper_types.Dns_failure
-          else if message_looks_like_cli_wrapped_max_turns message then
-            Keeper_types.Max_turns_exceeded
           else
             Keeper_types.cascade_exhaustion_reason_from_message
               (Cascade_fsm.to_user_message last_err)
-      | Some (Llm_provider.Http_client.TimeoutError { message; _ }) ->
-          if message_looks_like_cli_wrapped_max_turns message then
-            Keeper_types.Max_turns_exceeded
-          else
-            Keeper_types.cascade_exhaustion_reason_from_message
-              (Cascade_fsm.to_user_message last_err)
-      | Some (Llm_provider.Http_client.HttpError { body; _ }) ->
-          if message_looks_like_cli_wrapped_max_turns body then
-            Keeper_types.Max_turns_exceeded
-          else
-            Keeper_types.cascade_exhaustion_reason_from_message
-              (Cascade_fsm.to_user_message last_err)
-      | Some (Llm_provider.Http_client.AcceptRejected { reason = r }) ->
-          if message_looks_like_cli_wrapped_max_turns r then
-            Keeper_types.Max_turns_exceeded
-          else
-            Keeper_types.cascade_exhaustion_reason_from_message
-              (Cascade_fsm.to_user_message last_err)
+      | Some (Llm_provider.Http_client.TimeoutError _) ->
+          Keeper_types.cascade_exhaustion_reason_from_message
+            (Cascade_fsm.to_user_message last_err)
+      | Some (Llm_provider.Http_client.HttpError _) ->
+          Keeper_types.cascade_exhaustion_reason_from_message
+            (Cascade_fsm.to_user_message last_err)
+      | Some (Llm_provider.Http_client.AcceptRejected _) ->
+          Keeper_types.cascade_exhaustion_reason_from_message
+            (Cascade_fsm.to_user_message last_err)
       | Some (Llm_provider.Http_client.CliTransportRequired _) ->
           Keeper_types.cascade_exhaustion_reason_from_message
               (Cascade_fsm.to_user_message last_err)
@@ -215,10 +204,7 @@ let rec run
               (Cascade_fsm.to_user_message last_err)
       | Some (Llm_provider.Http_client.ProviderFailure _ as err) ->
           let message = Cascade_fsm.to_user_message (Some err) in
-          if message_looks_like_cli_wrapped_max_turns message then
-            Keeper_types.Max_turns_exceeded
-          else
-            Keeper_types.cascade_exhaustion_reason_from_message message
+          Keeper_types.cascade_exhaustion_reason_from_message message
       | None -> Keeper_types.No_providers_available
     in
     let observation =

--- a/test/test_cascade_attempt_fsm_response_pins.ml
+++ b/test/test_cascade_attempt_fsm_response_pins.ml
@@ -1,11 +1,10 @@
 (** Pin tests for CLI-wrapped error response classifiers.
 
     These tests lock the current behavior of
-    [message_looks_like_cli_wrapped_hard_quota] and
-    [message_looks_like_cli_wrapped_max_turns] against known provider
-    response fixtures.  If a provider changes error message phrasing,
-    the corresponding test fails — catching silent classification
-    drift before it reaches production.
+    [message_looks_like_cli_wrapped_hard_quota] against known provider response
+    fixtures.  If a provider changes error message phrasing, the corresponding
+    test fails — catching silent classification drift before it reaches
+    production.
 
     Each test case is a real (or representative) response body observed
     in production.  The test name encodes the provider + scenario for
@@ -64,39 +63,6 @@ let test_hard_quota_pins () =
        in
        check_bool name expected result)
     hard_quota_fixtures
-;;
-
-(* ── Max turns pin tests ───────────────────────────────────────── *)
-
-let max_turns_fixtures =
-  [ ( "cli_tool_d_error_max_turns"
-    , {|{"subtype":"error_max_turns","cost_usd":0.05,"duration_ms":120000}|}
-    , true )
-  ; ( "cli_tool_d_terminal_reason_max_turns"
-    , {|{"terminal_reason":"max_turns","is_error":true}|}
-    , true )
-  ; "text_max_turns_exceeded", {|Error: max turns exceeded for this session.|}, true
-  ; ( "text_reached_maximum"
-    , {|You have reached maximum number of turns allowed in this conversation.|}
-    , true )
-  ; "negative_normal_completion", {|{"subtype":"success","cost_usd":0.03}|}, false
-  ; ( "negative_auth_error"
-    , {|{"type":"error","error":{"type":"authentication_error","message":"Invalid token"}}|}
-    , false )
-  ; ( "negative_hard_quota_not_max_turns"
-    , {|{"error":{"message":"You've hit your limit for this model"}}|}
-    , false )
-  ]
-;;
-
-let test_max_turns_pins () =
-  List.iter
-    (fun (name, message, expected) ->
-       let result =
-         Cascade_attempt_fsm.message_looks_like_cli_wrapped_max_turns message
-       in
-       check_bool name expected result)
-    max_turns_fixtures
 ;;
 
 (* ── Case-insensitivity check ──────────────────────────────────── *)
@@ -160,7 +126,6 @@ let () =
   Alcotest.run
     "cascade_attempt_fsm_response_pins"
     [ "hard_quota", [ Alcotest.test_case "pin fixtures" `Quick test_hard_quota_pins ]
-    ; "max_turns", [ Alcotest.test_case "pin fixtures" `Quick test_max_turns_pins ]
     ; "case_insensitive", [ Alcotest.test_case "ci check" `Quick test_case_insensitive ]
     ; ( "required_tool_contract"
       , [ Alcotest.test_case

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6216,12 +6216,12 @@ let wrapped_claude_max_turns_error () =
        })
 ;;
 
-let wrapped_cascade_max_turns_error () =
+let structured_cascade_max_turns_error () =
   Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
     (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
        { cascade_name =
            oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
-       ; reason = Keeper_types.Other_detail wrapped_claude_max_turns_message
+       ; reason = Keeper_types.Max_turns_exceeded
        })
 ;;
 
@@ -6346,7 +6346,7 @@ let test_degraded_retry_after_recoverable_error_includes_max_turns () =
     EC.degraded_retry_after_recoverable_error
       ~effective_cascade:"underdog"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
-      (wrapped_cascade_max_turns_error ())
+      (structured_cascade_max_turns_error ())
   in
   expect_degraded_retry
     "max turns degraded retry"
@@ -7842,32 +7842,12 @@ let test_auto_recoverable_turn_error_excludes_persistent_errors () =
   check bool "auth error is persistent" false (EC.is_auto_recoverable_turn_error err)
 ;;
 
-let test_auto_recoverable_turn_error_includes_wrapped_cascade_exhausted_hard_quota () =
-  let err =
-    Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
-      (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
-         { cascade_name =
-             oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
-         ; reason =
-             Keeper_types.Other_detail
-               "agent_llm_a exited with code 1: \
-                {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've \
-                hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}"
-         })
-  in
+let test_auto_recoverable_turn_error_includes_structured_cascade_max_turns () =
   check
     bool
-    "wrapped cascade hard quota is auto-recoverable"
+    "structured cascade max-turns is auto-recoverable"
     true
-    (EC.is_auto_recoverable_turn_error err)
-;;
-
-let test_auto_recoverable_turn_error_includes_wrapped_cascade_max_turns () =
-  check
-    bool
-    "wrapped cascade max-turns is auto-recoverable"
-    true
-    (EC.is_auto_recoverable_turn_error (wrapped_cascade_max_turns_error ()))
+    (EC.is_auto_recoverable_turn_error (structured_cascade_max_turns_error ()))
 ;;
 
 let test_auto_recoverable_turn_error_includes_filtered_candidates_cascade_exhaustion () =
@@ -11597,13 +11577,9 @@ let () =
             `Quick
             test_auto_recoverable_turn_error_excludes_persistent_errors
         ; test_case
-            "auto-recoverable includes wrapped cascade hard quota"
+            "auto-recoverable includes structured cascade max turns"
             `Quick
-            test_auto_recoverable_turn_error_includes_wrapped_cascade_exhausted_hard_quota
-        ; test_case
-            "auto-recoverable includes wrapped cascade max turns"
-            `Quick
-            test_auto_recoverable_turn_error_includes_wrapped_cascade_max_turns
+            test_auto_recoverable_turn_error_includes_structured_cascade_max_turns
         ; test_case
             "auto-recoverable includes filtered candidates cascade exhaustion"
             `Quick

--- a/test/test_oas_worker_sdk_error.ml
+++ b/test/test_oas_worker_sdk_error.ml
@@ -99,27 +99,6 @@ let test_sdk_error_is_hard_quota_detects_anthropic_invalid_request_specified_lim
     (Keeper_turn_driver.sdk_error_is_hard_quota err)
 ;;
 
-let test_sdk_error_is_max_turns_detects_claude_cli_wrapper () =
-  let err =
-    Agent_sdk.Error.Api
-      (Llm_provider.Retry.NetworkError
-         { message =
-             "agent_llm_a exited with code 1: \
-              {\"type\":\"result\",\"subtype\":\"error_max_turns\",\"is_error\":true,\"terminal_reason\":\"max_turns\",\"errors\":[\"Reached \
-              maximum number of turns (10)\"]}"
-         ; kind = Llm_provider.Http_client.Unknown
-         })
-  in
-  Alcotest.(check bool)
-    "Claude CLI max turns counts as max-turns"
-    true
-    (Keeper_turn_driver.sdk_error_is_max_turns_exceeded err);
-  Alcotest.(check bool)
-    "Claude CLI max turns is not hard quota"
-    false
-    (Keeper_turn_driver.sdk_error_is_hard_quota err)
-;;
-
 let test_sdk_error_is_hard_quota_keeps_transient_network_errors_false () =
   let err =
     Agent_sdk.Error.Api
@@ -364,10 +343,6 @@ let cases =
       "sdk_error_is_hard_quota detects Provider_a direct InvalidRequest specified-limit"
       `Quick
       test_sdk_error_is_hard_quota_detects_anthropic_invalid_request_specified_limit
-  ; Alcotest.test_case
-      "sdk_error_is_max_turns detects Claude CLI wrapper"
-      `Quick
-      test_sdk_error_is_max_turns_detects_claude_cli_wrapper
   ; Alcotest.test_case
       "sdk_error_is_hard_quota keeps transient network errors false"
       `Quick


### PR DESCRIPTION
## Summary
- Remove CLI max-turns substring classifiers from the cascade attempt FSM public surface.
- Stop promoting free-form `Other_detail` cascade-exhaustion text into hard-quota, max-turns, or backpressure recovery decisions.
- Keep max-turns handling on typed `MaxTurnsExceeded` / `Cascade_exhausted { reason = Max_turns_exceeded }` signals and delete the legacy pin tests that protected string fallback behavior.

## Verification
- `ocamlformat --check` on changed OCaml files
- `git diff --check`
- stale max-turns fallback residue sweep with `rg`
- `scripts/ci/check-enum-string-safety.sh` (passes with existing warnings)
- `scripts/ci/check-determinism-contract.sh` (passes with existing warnings)
- `scripts/check-spec-truth.sh`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD --recent-main 50 --duplicate-policy warn`
- `scripts/ocaml-structure-ratchet.sh` (passes; baseline can be lowered)
- `bash scripts/check-doc-truth.sh`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD` (warn-only pending release tag)
- `scripts/audit-hardcoding-truth.sh`
- `scripts/dune-local.sh build lib/masc_mcp.cma test/test_cascade_attempt_fsm_response_pins.exe test/test_oas_worker_sdk_error.exe test/test_keeper_unified.exe` attempted; refused with exit 75 due machine-wide bare Dune processes, not bypassed