### PR TITLE
refactor(tool): stop classifying exception message text

### DIFF
--- a/docs/rfc/RFC-0062-typed-tool-result-and-blocker-class.md
+++ b/docs/rfc/RFC-0062-typed-tool-result-and-blocker-class.md
@@ -59,12 +59,12 @@ type tool_failure_class =
   | Runtime_failure      (* internal exception, unexpected error path *)
   | Workflow_rejection   (* HITL reject, gate refusal *)
 
-val classify_from_exception     : exn -> tool_failure_class option
+val classify_from_exception     : exn -> tool_failure_class
 val is_retryable                : tool_failure_class -> bool
 val log_level_of_failure_class  : tool_failure_class -> [ `Warn | `Error ]
 ```
 
-`classify_from_exception` matches on exception **constructors** (typed). The Phase 1 `classify_from_dispatch_failure` string fallback has been removed from the generic `Tool_result.error` path; callers must now pass `failure_class` explicitly or emit structured JSON with a `failure_class` field.
+`classify_from_exception` matches on exception **constructors** only. The Phase 1 `classify_from_dispatch_failure` string fallback has been removed from the generic `Tool_result.error` path, and `Tool_result.of_exn` no longer reads `Failure` / `Invalid_argument` message text for semantic classification. Callers must now pass `failure_class` explicitly at the catch boundary or emit structured JSON with a `failure_class` field.
 
 ### 3.3 `Tool_result.t` — structured record (Phase 1→3)
 

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -49,41 +49,15 @@ let log_level_of_failure_class = function
   | Runtime_failure -> Log.Error
 ;;
 
-(** Case-insensitive substring check for classification heuristics.
-    Phase 1 bridge: string-based heuristics at catch boundaries.
-    Phase 2 replaces this with typed propagation from Tool_*.dispatch. *)
-let contains_casefold haystack needle =
-  String.length needle = 0 || String_util.contains_substring_ci haystack needle
-;;
-
 (** Classify a tool failure from an exception raised during execution.
-    Typed exception inspection — no string matching on exception messages
-    except for [Failure] where the message carries the diagnostic. *)
+    Constructor-only fallback.  Semantic classes from exception messages must
+    be passed explicitly at the catch boundary. *)
 let classify_from_exception (exn : exn) : tool_failure_class =
   match exn with
   | Eio.Time.Timeout -> Transient_error
   | Eio.Cancel.Cancelled _ -> Transient_error
-  | Invalid_argument msg ->
-    if contains_casefold msg "Failed to acquire distributed lock"
-       || contains_casefold msg "distributed lock"
-    then Transient_error
-    else Policy_rejection
-  | Failure msg ->
-    if
-      (* Some Failure messages carry diagnostic content worth classifying.
-         This is the Phase 1 bridge — Phase 2 pushes classification into
-         each Tool_*.dispatch handler where the error originates. *)
-      contains_casefold msg "MASC not initialized"
-    then Policy_rejection
-    else if contains_casefold msg "not found"
-    then Policy_rejection
-    else if contains_casefold msg "unknown tool"
-    then Policy_rejection
-    else if contains_casefold msg "timeout"
-    then Transient_error
-    else if contains_casefold msg "connection"
-    then Transient_error
-    else Runtime_failure
+  | Invalid_argument _ -> Runtime_failure
+  | Failure _ -> Runtime_failure
   | _ -> Runtime_failure
 ;;
 
@@ -208,10 +182,14 @@ let error ?(failure_class = None) ~tool_name ~start_time message =
   }
 ;;
 
-let of_exn ~tool_name ~start_time exn =
+let of_exn ?failure_class ~tool_name ~start_time exn =
   let end_time = Time_compat.now () in
   let duration_ms = (end_time -. start_time) *. 1000.0 in
-  let cls = classify_from_exception exn in
+  let cls =
+    match failure_class with
+    | Some cls -> cls
+    | None -> classify_from_exception exn
+  in
   let message =
     Printf.sprintf
       "dispatch handler error for %s: %s"

--- a/lib/tool_types/tool_result.mli
+++ b/lib/tool_types/tool_result.mli
@@ -35,8 +35,8 @@ val is_retryable : tool_failure_class -> bool
 val log_level_of_failure_class : tool_failure_class -> Log.level
 
 (** Classify a tool failure from an exception raised during execution.
-    Typed exception inspection — no string matching on exception messages
-    except for [Failure] where the message carries the diagnostic. *)
+    Constructor-only fallback.  Semantic classes from exception messages must
+    be passed explicitly at the catch boundary. *)
 val classify_from_exception : exn -> tool_failure_class
 
 (** {1 Structured result} *)
@@ -79,9 +79,11 @@ val error
   -> string
   -> t
 
-(** Build a failure result from an exception caught during dispatch.
-    Uses {!classify_from_exception} for typed classification. *)
-val of_exn : tool_name:string -> start_time:float -> exn -> t
+(** Build a failure result from an exception caught during dispatch.  When
+    [failure_class] is provided, it is trusted as the catch boundary's typed
+    decision; otherwise {!classify_from_exception} supplies a constructor-only
+    fallback. *)
+val of_exn : ?failure_class:tool_failure_class -> tool_name:string -> start_time:float -> exn -> t
 
 (** {1 Test helpers}
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1683,6 +1683,14 @@ let test_tool_failure_classification_contracts () =
   check bool "generic tool result has no dispatch-message classifier" false
     (file_contains_pattern "lib/tool_types/tool_result.ml"
        "classify_from_dispatch_failure");
+  check bool "generic tool result has no exception-message substring helper" false
+    (file_contains_pattern "lib/tool_types/tool_result.ml"
+       "contains_casefold");
+  check bool "generic tool result does not classify Invalid_argument text" false
+    (file_contains_pattern "lib/tool_types/tool_result.ml"
+       "Invalid_argument msg");
+  check bool "generic tool result does not classify Failure text" false
+    (file_contains_pattern "lib/tool_types/tool_result.ml" "Failure msg");
   check bool "deterministic tool failures have reason metric" true
     (file_contains_pattern "lib/keeper/keeper_metrics.ml"
        "masc_keeper_tools_oas_deterministic_failures_total"

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -74,9 +74,27 @@ let test_plain_dispatch_failure_honors_explicit_failure_class () =
      | None -> "none")
 ;;
 
-let test_distributed_lock_exception_is_transient () =
+let test_exception_message_does_not_infer_failure_class () =
   let r =
     Tool_result.of_exn
+      ~tool_name:"masc_transition"
+      ~start_time:0.0
+      (Invalid_argument
+         "Failed to acquire distributed lock for key: tasks:.backlog (50 attempts exhausted)")
+  in
+  Alcotest.(check bool) "failure" false r.success;
+  Alcotest.(check string)
+    "failure class"
+    "runtime_failure"
+    (match Tool_result.failure_class r with
+     | Some cls -> Tool_result.tool_failure_class_to_string cls
+     | None -> "none")
+;;
+
+let test_exception_boundary_honors_explicit_failure_class () =
+  let r =
+    Tool_result.of_exn
+      ~failure_class:Tool_result.Transient_error
       ~tool_name:"masc_transition"
       ~start_time:0.0
       (Invalid_argument
@@ -202,9 +220,13 @@ let () =
             `Quick
             test_plain_dispatch_failure_honors_explicit_failure_class
         ; Alcotest.test_case
-            "distributed lock exception is transient"
+            "exception message does not infer failure_class"
             `Quick
-            test_distributed_lock_exception_is_transient
+            test_exception_message_does_not_infer_failure_class
+        ; Alcotest.test_case
+            "exception boundary honors explicit failure_class"
+            `Quick
+            test_exception_boundary_honors_explicit_failure_class
         ; Alcotest.test_case
             "structured failure_class is honored"
             `Quick


### PR DESCRIPTION
## Summary
- remove generic `Tool_result.classify_from_exception` substring matching over `Failure` / `Invalid_argument` message text
- keep constructor-only defaults for `Eio.Time.Timeout` and `Eio.Cancel.Cancelled`; otherwise default to `runtime_failure`
- add `Tool_result.of_exn ?failure_class` so catch boundaries can pass a typed decision explicitly when they have real semantic context
- update tests and RFC text to pin the new boundary

## Why
#18672 removed free-form dispatch-message classification. This follows through on the same boundary for exception catch paths: exception message text should remain diagnostic text, not retry/workflow semantics.

## Verification
- `ocamlformat --check lib/tool_types/tool_result.ml lib/tool_types/tool_result.mli test/test_tool_result.ml test/test_ci_hardening_source.ml`
- `git diff --check`
- `rg -n "contains_casefold|Invalid_argument msg|Failure msg|classify_from_dispatch_failure" lib/tool_types/tool_result.ml` returned no matches

## Local build note
- Attempted `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build ./test/test_tool_result.exe`; it was blocked by another repo-local `dune-local` lock held by `keeper-meta-retired-key-scrub-20260526`, so I terminated only my waiting process and left CI to run the compile/test gate.