### PR TITLE
docs(agent_tool_runtime): document dispatch asymmetry rationale

### DIFF
--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -35,6 +35,17 @@ let handle_filesystem ctx descriptor args =
   | Tool_execute | Tool_search_files | Tool_remote_mcp -> None
 ;;
 
+(* Dispatch asymmetry: Filesystem and Remote_mcp go through Agent_tool_* runtime
+   wrappers (handle_filesystem / handle_remote_mcp above), but Shell_ir
+   dispatches directly into Keeper_exec_shell. This is intentional: Shell IR
+   mechanics (Keeper_shell_ir / Keeper_shell_command_* / Keeper_shell_path /
+   Keeper_shell_readonly_policy etc.) legitimately live in the keeper
+   namespace as the typed Bash lowering and exec pipeline. A thin
+   Agent_tool_shell_runtime wrapper that only renames Keeper_exec_shell
+   functions would be substitution, not abstraction — it would preserve the
+   coupling while reducing readability. Re-evaluate only if Shell IR
+   substantive logic moves out of keeper_shell_* into a descriptor-owned
+   module. *)
 let handle_shell_ir ctx descriptor args =
   match descriptor.Agent_tool_descriptor.runtime_handler with
   | Tool_execute ->


### PR DESCRIPTION
## Summary

`lib/keeper/agent_tool_runtime.ml`의 dispatch에 존재하는 *의도된* asymmetry를 docstring으로 고정합니다. 코드 변경 없음 — 11 LOC docstring만 추가.

## Asymmetry

```
handle ctx ~descriptor ~args =
  match descriptor.executor with
  | Filesystem  → handle_filesystem   → Agent_tool_filesystem_runtime.handle_*   (descriptor-side wrapper)
  | Remote_mcp  → handle_remote_mcp   → Agent_tool_remote_mcp_runtime.handle_*   (descriptor-side wrapper)
  | Shell_ir    → handle_shell_ir     → Keeper_exec_shell.handle_*                ← keeper-side direct
```

3개 dispatch path 중 2개는 `Agent_tool_*` wrapper module 경유, Shell_ir만 `Keeper_exec_shell` 직접 호출.

## Why not symmetric

미래 reader(특히 AI 에이전트가 패턴 학습할 때)가 "symmetry fix"로 `Agent_tool_shell_runtime` thin wrapper를 추가하려 할 가능성이 큽니다. 그러나 그것은 *vendor-brand-substitution-as-abstraction* 안티패턴이에요:

- `Agent_tool_filesystem_runtime` (606 LOC) 은 `fs_write_mode` SSOT, `track_write_region` 등 *substantive logic*을 owning. 진짜 모듈.
- Shell_ir mechanics(`Keeper_shell_ir`, `Keeper_shell_command_parse`/`_words`/`_semantics`, `Keeper_shell_path`, `Keeper_shell_readonly_policy`)는 typed Bash lowering + exec pipeline 자체로 keeper 네임스페이스에 정당하게 속함.
- `Agent_tool_shell_runtime`를 만들어 `Keeper_exec_shell.handle_tool_execute`만 wrap하면 coupling 그대로 + 가독성 감소 + indirection 비용. abstraction이 아니라 *암호화*.

re-evaluation 조건: Shell IR substantive logic이 `keeper_shell_*` 밖 descriptor-owned 모듈로 이동할 때만.

## Context

ToolDescriptor spine (#18570/#18581/#18586/#18654) + ratchet (#18671) 작업 후 PR3 module rename 단계 재평가의 산물. 명목적 28+18 모듈 전면 rename은 over-scoped이며, 본 docstring이 그 결론을 코드 옆에 고정합니다.

## Verification

- `dune build --root . lib/keeper/` EXIT=0 (worktree)
- 변경: `agent_tool_runtime.ml` +11 LOC docstring only, 동작 변경 없음

## Out of scope

- 진짜 Shell IR substantive logic migration = 별도 ~200+ LOC RFC 필요.
- `keeper_shell_*` (28) / `keeper_exec_*` (18) 모듈 rename = 본 docstring으로 잘못된 방향 차단했으므로 별도 PR 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
