### PR TITLE
fix(keeper): scrub retired persisted meta fields

### DIFF
--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -29,6 +29,18 @@ let legacy_keeper_meta_key_names =
   @ legacy_keeper_meta_tool_policy_key_names
 ;;
 
+let persisted_retired_keeper_meta_key_names =
+  [
+    "github_identity";
+    "last_work_discovery_ts";
+    "work_discovery_count";
+    "work_discovery_enabled";
+    "work_discovery_sources";
+    "work_discovery_interval_sec";
+    "work_discovery_guidance";
+  ]
+;;
+
 let reject_legacy_keeper_meta_fields (json : Yojson.Safe.t) =
   let present = present_json_keys legacy_keeper_meta_key_names json in
   match present with
@@ -43,14 +55,19 @@ let reject_legacy_keeper_meta_fields (json : Yojson.Safe.t) =
 let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) : Yojson.Safe.t * bool =
   match json with
   | `Assoc fields ->
+    let scrub_candidate_key_names =
+      removed_keeper_meta_key_names @ persisted_retired_keeper_meta_key_names
+    in
     let removed_present =
       fields
       |> List.filter_map (fun (key, _) ->
-        if List.mem key removed_keeper_meta_key_names then Some key else None)
+        if List.mem key scrub_candidate_key_names then Some key else None)
     in
     let removed_to_scrub =
       removed_present
-      |> List.filter (fun key -> not (List.mem key legacy_keeper_meta_key_names))
+      |> List.filter (fun key ->
+        (not (List.mem key legacy_keeper_meta_key_names))
+        || List.mem key persisted_retired_keeper_meta_key_names)
     in
     if removed_to_scrub = []
     then json, false

--- a/lib/keeper/keeper_meta_json_scrub.mli
+++ b/lib/keeper/keeper_meta_json_scrub.mli
@@ -16,8 +16,8 @@ val reject_removed_keeper_meta_fields :
 (** Legacy tool-policy keys that are no longer supported. *)
 val legacy_keeper_meta_tool_policy_key_names : string list
 
-(** Combined legacy key names (allowed_providers, retired meta sidecars,
-    and tool-policy keys). *)
+(** Combined legacy key names that remain rejected by strict runtime
+    meta decoding. *)
 val legacy_keeper_meta_key_names : string list
 
 (** Returns [Error msg] if any legacy key is present. *)
@@ -25,11 +25,12 @@ val reject_legacy_keeper_meta_fields :
   Yojson.Safe.t -> (unit, string) result
 
 (** [scrub_persisted_keeper_meta_json ~path json] migrates persisted
-    keeper meta to the current schema for removed non-tool fields
-    (including presence_keepalive=false→paused=true) and writes the
-    scrubbed content back to [path] when changes were needed. Legacy
-    tool policy fields are intentionally not rewritten. Returns the
-    scrubbed JSON and a [bool] indicating whether the file was
-    rewritten. *)
+    keeper meta to the current schema for removed non-tool fields and
+    stale persisted-only runtime fields (including
+    presence_keepalive=false→paused=true) and writes the scrubbed
+    content back to [path] when changes were needed. Legacy tool policy
+    fields and other strict legacy fields are intentionally not
+    rewritten. Returns the scrubbed JSON and a [bool] indicating whether
+    the file was rewritten. *)
 val scrub_persisted_keeper_meta_json :
   path:string -> Yojson.Safe.t -> Yojson.Safe.t * bool

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -178,6 +178,45 @@ let test_github_identity_runtime_meta_rejected () =
       "legacy keeper meta fields are no longer supported: github_identity"
       msg
 
+let has_key key = function
+  | `Assoc fields -> List.mem_assoc key fields
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> false
+
+let test_persisted_retired_runtime_meta_fields_scrubbed () =
+  let retired_fields =
+    [
+      "github_identity", `String "anyang-keepers";
+      "last_work_discovery_ts", `String "2026-05-24T16:29:11Z";
+      "work_discovery_count", `Int 12;
+      "work_discovery_enabled", `Bool true;
+      "work_discovery_sources", `List [ `String "taskboard" ];
+      "work_discovery_interval_sec", `Int 60;
+      "work_discovery_guidance", `String "legacy guidance";
+    ]
+  in
+  let legacy_json =
+    match legacy_base_json "persisted-retired-fields" with
+    | `Assoc fields -> `Assoc (fields @ retired_fields)
+    | json -> json
+  in
+  let path = Filename.temp_file "keeper-retired-meta-" ".json" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+       Yojson.Safe.to_file path legacy_json;
+       let scrubbed, changed = KT.scrub_persisted_keeper_meta_json ~path legacy_json in
+       check bool "scrubbed" true changed;
+       List.iter
+         (fun (key, _) -> check bool (key ^ " removed") false (has_key key scrubbed))
+         retired_fields;
+       (match KT.meta_of_json scrubbed with
+        | Ok _ -> ()
+        | Error err -> fail ("scrubbed meta should parse: " ^ err));
+       let persisted = Yojson.Safe.from_file path in
+       List.iter
+         (fun (key, _) -> check bool (key ^ " persisted removed") false (has_key key persisted))
+         retired_fields)
+
 let () =
   run "keeper_auto_pause_blocker_persist_12683"
     [
@@ -202,5 +241,7 @@ let () =
             test_legacy_last_blocker_string_rejected;
           test_case "github_identity stays out of runtime meta" `Quick
             test_github_identity_runtime_meta_rejected;
+          test_case "retired persisted runtime fields are scrubbed" `Quick
+            test_persisted_retired_runtime_meta_fields_scrubbed;
         ] );
     ]


### PR DESCRIPTION
## Summary
- scrub stale persisted runtime-only keeper meta keys before strict meta parse and unknown-key warning
- keep direct runtime meta decoding strict for legacy fields like github_identity
- add regression coverage for persisted github_identity and work_discovery_* cleanup

## Verification
- ocamlformat --enable-outside-detected-project --check lib/keeper/keeper_meta_json_scrub.ml lib/keeper/keeper_meta_json_scrub.mli test/test_keeper_auto_pause_blocker_persist_12683.ml
- scripts/dune-local.sh build test/test_keeper_auto_pause_blocker_persist_12683.exe
- ./_build/default/test/test_keeper_auto_pause_blocker_persist_12683.exe