### PR TITLE
refactor(agent_tool_descriptor): purge dead executor enum cases (YAGNI)

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -1,12 +1,9 @@
 (** Agent-facing tool descriptor spine. *)
 
 type executor =
-  | In_process
   | Shell_ir
-  | Gh_cli
   | Filesystem
   | Remote_mcp
-  | Oas_bridge
 
 type backend =
   | Ocaml_runtime
@@ -60,12 +57,9 @@ type t =
   }
 
 let executor_to_string = function
-  | In_process -> "in_process"
   | Shell_ir -> "shell_ir"
-  | Gh_cli -> "gh_cli"
   | Filesystem -> "filesystem"
   | Remote_mcp -> "remote_mcp"
-  | Oas_bridge -> "oas_bridge"
 ;;
 
 let backend_to_string = function

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -6,12 +6,9 @@
     executor/backend/sandbox route. *)
 
 type executor =
-  | In_process
   | Shell_ir
-  | Gh_cli
   | Filesystem
   | Remote_mcp
-  | Oas_bridge
 
 type backend =
   | Ocaml_runtime

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -87,7 +87,6 @@ let handle ctx ~descriptor ~args =
   | Filesystem -> handle_filesystem ctx descriptor args
   | Shell_ir -> handle_shell_ir ctx descriptor args
   | Remote_mcp -> handle_remote_mcp ctx descriptor args
-  | In_process | Gh_cli | Oas_bridge -> None
 ;;
 
 let handle_internal ctx ~name ~args =


### PR DESCRIPTION
## Summary

`Agent_tool_descriptor.executor` enum에서 dead case 3종(`In_process`/`Gh_cli`/`Oas_bridge`)을 제거합니다. -10 lines, 동작 변경 없음.

## Why

현재 7개 LLM-native descriptor는 다음 3 executor만 사용:

| Executor | Count | Tools |
|---|---|---|
| `Shell_ir` | 2 | Execute, SearchFiles |
| `Filesystem` | 3 | ReadFile, EditFile, WriteFile |
| `Remote_mcp` | 2 | SearchWeb, FetchWeb |
| `In_process` | **0** | (dead) |
| `Gh_cli` | **0** | (dead) |
| `Oas_bridge` | **0** | (dead) |

3 dead case는 `executor_to_string`과 `Agent_tool_runtime.handle`의 `| In_process | Gh_cli | Oas_bridge -> None` catch-all 두 곳에만 등장. 어떤 descriptor도 declare하지 않음. CLAUDE.md "Don't design for hypothetical future requirements" + "Simplicity First" 적용 대상.

## Structural benefit

dead arm 제거 후 `Agent_tool_runtime.handle`의 `match descriptor.executor with` 가 **구조적으로 exhaustive** (3 case 모두 real handler). 새 executor case 추가 시 OCaml type checker가 dispatch 누락을 *컴파일 타임에* 강제. 옛 코드는 새 case 추가해도 silent `None` dispatch로 갈 수 있었음.

## Out of scope (broader tool ecosystem audit)

이 PR은 *7 LLM-native descriptor*의 executor enum만 정리. 별도 axis로 남아있는 작업:

- `~226 masc_* MCP tools`: 대다수가 legacy string-match chain (`Keeper_exec_tools.execute_keeper_tool_call`) 경유, descriptor 미적용
- `~53 keeper_* internal tools`: 동일
- 즉 현재 descriptor backing 비율: **~7/280 ≈ 2.5%** (LLM-native만)

확장 RFC 후보 — 별도 PR/RFC로 추적.

## Important non-touch

`Timeout_policy.Layer.Oas_bridge` (lib/timeout_policy.{ml,mli})는 **별도의 live enum** 이며 `keeper_llm_bridge.ml:231`에서 실제 사용. 본 PR은 미터치.

## Verification

- `dune build --root . lib/` EXIT=0
- `test_keeper_tool_alias` 40/40 PASS (descriptor public_names invariant 포함)
- `test_cdal_tool_id` clean build (7 public name + 7 retired opaque)
- `test_tool_surface_ssot` clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
