### PR TITLE
chore(masc-mcp): purge #18652 worktree-policy axis residue

### DIFF
--- a/docs/spec/00-glossary.md
+++ b/docs/spec/00-glossary.md
@@ -49,7 +49,7 @@ Room 내 모든 에이전트에게 전달되는 메시지. @mention으로 특정
 두 에이전트 간의 직접 통신 링크. Broadcast가 전체 공개라면, Portal은 1:1 비공개 채널이다. `-> lib/coord/coord_portal.ml`, `-> lib/types/types_auth.ml`
 
 **Worktree**
-에이전트별로 격리된 git 작업 공간. 각 에이전트가 독립적인 브랜치에서 작업하여 충돌을 방지한다. 경로 패턴: `.worktrees/{agent}-{task}/`. `-> lib/types/types_core.ml`, `-> lib/coord/coord_worktree.mli`, `-> lib/task_sandbox.mli`
+에이전트별로 격리된 git 작업 공간. 각 에이전트가 독립적인 브랜치에서 작업하여 충돌을 방지한다. 경로 패턴: `.worktrees/{agent}-{task}/`. `-> lib/types/types_core.ml`
 
 **Handoff**
 Keeper post-turn lifecycle에서 같은 keeper를 새 `trace_id` / 새 session으로 이어붙이는 rollover. 성공 시 `generation`이 증가하고 이전 `trace_id`가 `trace_history`에 추가된다. 세션 handoff 문서와는 다른 개념이다. `-> lib/keeper/keeper_post_turn.ml`, `-> lib/keeper/keeper_rollover.ml`

--- a/lib/keeper/keeper_tool_policy_failure_site.ml
+++ b/lib/keeper/keeper_tool_policy_failure_site.ml
@@ -1,8 +1,3 @@
-type t =
-  | Github_clone_policy_load_failed
-  | Policy_config_not_loaded
+type t = Policy_config_not_loaded
 
-let to_label = function
-  | Github_clone_policy_load_failed -> "github_clone_policy_load_failed"
-  | Policy_config_not_loaded -> "policy_config_not_loaded"
-;;
+let to_label = function Policy_config_not_loaded -> "policy_config_not_loaded"

--- a/lib/keeper/keeper_tool_policy_failure_site.mli
+++ b/lib/keeper/keeper_tool_policy_failure_site.mli
@@ -1,11 +1,9 @@
 (** Keeper_tool_policy_failure_site — closed sum for the [site] label on
     [metric_keeper_tool_policy_failures].
 
-    Both sites surface failures of the tool-policy TOML load path. *)
+    The site surfaces failures of the tool-policy TOML load path. *)
 
 type t =
-  | Github_clone_policy_load_failed
-  (** tool_policy.toml load failed inside keeper GitHub clone validation. *)
   | Policy_config_not_loaded (** Policy config absent or empty at preset lookup time. *)
 
 val to_label : t -> string

--- a/test/dune
+++ b/test/dune
@@ -1786,8 +1786,6 @@
 
 (include stanzas/test_require_tool_use_violation_counter_10091.inc)
 
-(include stanzas/test_sandbox_clone_conflict.inc)
-
 (include stanzas/test_server_state_product.inc)
 
 (include stanzas/test_shell_parse_site_ratchet.inc)

--- a/test/stanzas/test_sandbox_clone_conflict.inc
+++ b/test/stanzas/test_sandbox_clone_conflict.inc
@@ -1,4 +1,0 @@
-(test
- (name test_sandbox_clone_conflict)
- (modules test_sandbox_clone_conflict)
- (libraries masc_test_deps))

--- a/test/test_sandbox_clone_conflict.ml
+++ b/test/test_sandbox_clone_conflict.ml
@@ -1,4 +1,0 @@
-(* test_sandbox_clone_conflict.ml — disabled: Coord.auto_provision_sandbox_clone
-   removed during worktree policy purge (#18652). *)
-
-let () = ()


### PR DESCRIPTION
## Summary
Cleans up dead residue left after #18652 ("Purge keeper GH and worktree policy axes"):

- Drop empty test stub `test/test_sandbox_clone_conflict.ml` + its dune `(include stanzas/...)` slot. Function `Coord.auto_provision_sandbox_clone` was removed in #18652; the file was reduced to `let () = ()`.
- Narrow `Keeper_tool_policy_failure_site.t` to its single live variant `Policy_config_not_loaded`. The `Github_clone_policy_load_failed` constructor was never raised after the keeper_gh modules were purged in #18652; sole consumer (`lib/keeper/keeper_tool_policy.ml:377`) uses `Policy_config_not_loaded` only. Closed-sum doc updated to reflect single-site cardinality.
- Drop two stale `-> lib/...mli` links from the **Worktree** entry in `docs/spec/00-glossary.md`. `coord_worktree.mli` and `task_sandbox.mli` were both purged in #18652; the `types_core.ml` link remains.

## Audit trail
| Check | Command | Result |
|---|---|---|
| Variant constructor live? | `rg -n "Github_clone_policy_load_failed" lib/ bin/ test/` | 0 hits outside defining `.ml/.mli` |
| Closed-sum consumer? | `rg -n "Keeper_tool_policy_failure_site\." lib/ bin/ test/` | 1 site: `keeper_tool_policy.ml:377` (`Policy_config_not_loaded`) |
| Label string locked by test? | `rg -n '"github_clone_policy_load_failed"' test/` | 0 hits |
| Glossary link targets? | `ls lib/coord/coord_worktree.mli lib/task_sandbox.mli` | both PURGED |
| Build | `dune build @check` | PASS |

## Out of scope
The P12 shell parse-site ratchet baseline (`test/shell_parse_site_baseline.txt`) carries 11 lines that reference PURGED files (`coord_worktree_exec`, `coord_worktree_lifecycle`, `keeper_gh_repo`, `sandbox`, `tool_code`, `tool_code_write`, `worktree_live_context`). It also exhibits line-number drift for many alive sites — locally the ratchet reports 31 new sites even against the unmodified main baseline. Baseline refresh belongs in a Shell IR P10/P11 axis PR, not in this purge-residue cleanup.

## Workaround gate self-check (CLAUDE.md §워크어라운드 거부 기준)
- Telemetry-as-fix: N/A — this PR *removes* a dead label arm rather than adding a counter.
- String/substring classifier: N/A — *removes* a closed-sum arm, no new substring matching.
- N-of-M sweep self-admission: N/A — single-axis closure of #18652 residue.
- Catch-all `_ ->`: not introduced; OCaml exhaustive match on single-variant type.
- Cap/cooldown/dedup/repair: N/A.
- Test backdoor: N/A.

RFC-WAIVED: residue cleanup of a previously merged purge PR (#18652). No new subsystem behavior introduced; net deletion of dead code paths.

## Test plan
- [x] `dune build @check` passes from a clean worktree.
- [x] No `test/` file locks the removed variant constructor or its prometheus label string.
- [x] Sole live consumer (`keeper_tool_policy.ml:377`) builds clean against the narrowed type.
- [ ] CI: required checks green before Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
