### PR TITLE
refactor(keeper): remove dead [groups.optional] opt-in indirection

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -338,12 +338,6 @@ let resolve_policy_group ~(fallback : string list) (group_name : string) : strin
           group_name (List.length fallback);
         fallback)
 
-(** Optional tools that require explicit opt-in via also_allow.
-    Reads [groups.optional] from tool_policy.toml; falls back to
-    hardcoded list when config is absent. *)
-let keeper_optional_tool_names () =
-  resolve_policy_group ~fallback:[] "optional"
-
 (** Tools allowed on the keeper's last turn.
     Reads [groups.last_turn_safe] from tool_policy.toml. *)
 let last_turn_safe_tool_names () =
@@ -354,17 +348,6 @@ let last_turn_safe_tool_names () =
                 "keeper_broadcast"; "keeper_task_done";
                 "masc_web_search" ]
     "last_turn_safe"
-
-let explicit_optional_candidate_tool_names (meta : keeper_meta) =
-  let requested =
-    match meta.tool_access with
-    | Preset { also_allow; _ } -> also_allow
-    | Custom allowlist -> allowlist
-  in
-  let optional = keeper_optional_tool_names () in
-  requested
-  |> List.filter (fun name -> List.mem name optional)
-  |> dedupe_tool_names
 
 (* ── Presets (config-driven) ───────────────────────────────────── *)
 
@@ -426,10 +409,7 @@ let tool_access_lookup_of_meta (meta : keeper_meta) =
      tool_policy.toml via all_group_tools — voice tools are present iff
      the keeper's preset includes the voice group. No per-keeper gate. *)
   let base = keeper_base_candidate_tool_names () in
-  let candidate_names =
-    dedupe_tool_names
-      (base @ explicit_optional_candidate_tool_names meta)
-  in
+  let candidate_names = dedupe_tool_names base in
   let candidate_set = tool_name_set candidate_names in
   let allow_names =
     Tool_access_policy.resolve


### PR DESCRIPTION
## Summary

`.masc/config/tool_policy.toml` 에서 `[groups.optional]` 이 의도적으로 제거되었지만 OCaml 측은 계속 그 그룹을 읽으려고 시도 → 매 keeper boot 마다 `tool_policy group "optional" not found, using fallback (0 tools)` warn 양산 + 해당 indirection 이 silent no-op 상태로 잔존.

본 PR 은 그 dead path 를 surgical 하게 청소한다.

## Diagnosis

- `keeper_optional_tool_names ()` (`keeper_tool_policy.ml:344`) → `resolve_policy_group ~fallback:[] "optional"` 로 config 미정의 시 `[]` fallback + warn
- 유일 caller: `explicit_optional_candidate_tool_names` (module-internal, mli 미export)
- `tool_policy_of_meta` (ml:399) 는 `also_allow` 를 allow-set 에 합치지만, `tool_access_lookup_of_meta` (ml:438) 가 candidate set 으로 다시 필터링 → optional 풀이 비면 `also_allow` 는 도달 못 함 = **silent no-op**

> "function looks wired but is ignored" — 다음 reader 에게 디버깅 시간 비용이 누적되는 형태.

## Changes (`lib/keeper/keeper_tool_policy.ml`, +1/-21)

1. `keeper_optional_tool_names ()` 함수 + doc 제거
2. `explicit_optional_candidate_tool_names meta` 함수 제거
3. `tool_access_lookup_of_meta` 에서 candidate 합산을 `base @ explicit_…` → `base` 단독으로 단순화

## Not in scope

- `keeper_meta.tool_access.Preset { also_allow }` 필드 자체 — JSON 디시리얼라이즈 + 타입정의 광범위 의존성. 이번 PR 이후 *dead field* 가 되지만 별도 cleanup scope.
- `.masc/config/tool_policy.toml` 의 다른 삭제된 groups (`shell`/`filesystem`/`github`/`coding` 등) 는 OCaml 코드 grep 결과 *참조 0* — 본 PR 범위 밖.
- autoboot retry "gave up after 5 retries" race (별도 진단 완료, cosmetic noise → fix 보류).

## Test plan

- [x] `dune build @lib/keeper/check` exit=0 (worktree)
- [ ] CI: full build + test suite
- [ ] manual: keeper boot 시 `tool_policy group "optional" not found` warn 미발생 확인

## Reference

- Config 제거 commit: `b77786ab7a chore(masc): config cleanup + ignore .masc going forward (#1107)` (직접 origin 은 아니나 cleanup intent 명시 commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
