### PR TITLE
feat(agent_tool_descriptor): RFC-0179 PR-1 list bifurcation

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -432,6 +432,14 @@ let public_descriptors =
   ]
 ;;
 
+(* RFC-0179 list bifurcation. [internal_descriptors] hosts descriptor-backed
+   coordination tools (keeper_* / masc_* clusters). Starts empty in PR-1; each
+   cluster migration PR adds entries here. The LLM-native [public_descriptors]
+   contract (RFC-0064 hard-cut, 7 entries) is preserved unchanged. *)
+let internal_descriptors : t list = []
+
+let all_descriptors () = public_descriptors @ internal_descriptors
+
 let public_names () = List.map (fun d -> d.public_name) public_descriptors
 
 let find_public name =
@@ -440,6 +448,14 @@ let find_public name =
 
 let public_descriptors_for_internal internal_name =
   List.filter (fun d -> String.equal d.internal_name internal_name) public_descriptors
+;;
+
+(* Walks [all_descriptors ()]. Used by the runtime dispatcher to resolve any
+   descriptor-backed tool by its internal name, including coordination tools
+   that live in [internal_descriptors]. While [internal_descriptors = []], this
+   returns the same result as [public_descriptors_for_internal]. *)
+let descriptors_for_internal internal_name =
+  List.filter (fun d -> String.equal d.internal_name internal_name) (all_descriptors ())
 ;;
 
 let public_name_for_internal internal_name =

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -67,11 +67,31 @@ val sandbox_to_string : sandbox -> string
 val approval_to_string : approval -> string
 val runtime_handler_to_string : runtime_handler -> string
 
+(** [public_descriptors] is the LLM-native public surface (RFC-0064 hard-cut, 7
+    entries pinned by [test_alias_table_is_stable]). *)
 val public_descriptors : t list
+
+(** [internal_descriptors] is the descriptor-backed coordination surface
+    (RFC-0179). Starts empty; each cluster migration PR adds entries that map
+    [keeper_*] / [masc_*] coordination tools to a typed handler. Not part of
+    the LLM-native public-name contract. *)
+val internal_descriptors : t list
+
+(** [all_descriptors ()] is [public_descriptors @ internal_descriptors]. The
+    runtime dispatcher walks this list to resolve [internal_name] for any
+    descriptor-backed tool, regardless of LLM-native vs coordination origin. *)
+val all_descriptors : unit -> t list
+
 val public_names : unit -> string list
 val find_public : string -> t option
 val public_name_for_internal : string -> string option
 val public_descriptors_for_internal : string -> t list
+
+(** [descriptors_for_internal name] walks [all_descriptors ()]. Use this from
+    the runtime dispatcher to support descriptor-backed coordination tools
+    alongside the seven LLM-native descriptors. *)
+val descriptors_for_internal : string -> t list
+
 val public_input_schema : string -> Yojson.Safe.t option
 val translate_input : public:string -> Yojson.Safe.t -> Yojson.Safe.t
 val route_evidence_json : t -> Yojson.Safe.t

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -11,7 +11,7 @@ type context =
   }
 
 let descriptor_for_internal internal_name =
-  match Agent_tool_descriptor.public_descriptors_for_internal internal_name with
+  match Agent_tool_descriptor.descriptors_for_internal internal_name with
   | descriptor :: _ -> Some descriptor
   | [] -> None
 ;;


### PR DESCRIPTION
## Summary

RFC-0179 Option A 스캐폴딩. `Agent_tool_descriptor`에 `internal_descriptors` (시작 empty) + `all_descriptors`/`descriptors_for_internal` 추가. behavior change 0 — 후속 cluster migration PR에서 coordination tool이 `internal_descriptors`에 추가되기 전까지 모든 walker가 동일한 list를 본다.

## Why now

직전 audit (`memory/project_masc_mcp_tool_ecosystem_descriptor_coverage_2026_05_26.md`):
- descriptor-backed 7/286 (~2.5%)
- 26 legacy match arms in `Keeper_exec_tools:427-503` 가 keeper_* coordination tool dispatch

RFC-0179 (#18682 merged) 가 architectural choice를 Option A (bifurcate)로 확정. 이 PR이 그 stub.

## Changes

- `lib/keeper/agent_tool_descriptor.mli` (+20 LOC)
  - `val internal_descriptors : t list` (RFC-0179 coordination surface, growing)
  - `val all_descriptors : unit -> t list` (public ++ internal)
  - `val descriptors_for_internal : string -> t list` (runtime dispatcher entry)
- `lib/keeper/agent_tool_descriptor.ml` (+16 LOC)
  - `let internal_descriptors : t list = []`
  - `let all_descriptors () = public_descriptors @ internal_descriptors`
  - `let descriptors_for_internal` filters `all_descriptors ()`
- `lib/keeper/agent_tool_runtime.ml` (1 LOC change)
  - `descriptor_for_internal` 가 `public_descriptors_for_internal` → `descriptors_for_internal` 사용

## Invariant preservation

| Function | Walks | RFC-0064 contract |
|---|---|---|
| `public_descriptors` | 7 entries (불변) | ✅ |
| `public_names ()` | `public_descriptors` only | ✅ pinned 7 |
| `find_public` | `public_descriptors` only | ✅ |
| `public_descriptors_for_internal` | `public_descriptors` only | ✅ legacy callers 동일 |
| `public_input_schema` / `translate_input` | `public_descriptors` only (via find_public) | ✅ |
| `descriptors_for_internal` (new) | `all_descriptors ()` | runtime dispatch entry |

`internal_descriptors = []` 동안 `all_descriptors () = public_descriptors` → 모든 walker behavior 동일.

## Verification

- `dune build --root . lib/` EXIT=0
- `test_keeper_tool_alias` 40/40 PASS (`test_alias_table_is_stable` 7 pin 유지)
- `test_cdal_tool_id` 9/9 PASS (7 public + 7 retired opaque)

## Next

RFC-0179 PR-2: `keeper_time_now` migration with `In_process` executor (re-introduces enum case removed in #18677, with concrete consumer this time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
