### PR TITLE
fix(tool_execute): strengthen description against empty-executable retry storm

### DIFF
--- a/lib/tool_shard_types_schemas_bash.ml
+++ b/lib/tool_shard_types_schemas_bash.ml
@@ -122,7 +122,13 @@ let tool_execute_description =
    from the sandbox root means you forgot the cwd. For read-only search/listing \
    use SearchFiles when visible; for file edits use EditFile. Long-running commands must \
    be split or run through a dedicated structured workflow; this tool no longer \
-   exposes background task lifecycle tools."
+   exposes background task lifecycle tools. \
+   COMMON REJECTIONS: 'executable' must be a non-empty allowlisted command name \
+   (e.g. 'cat', 'ls', 'gh'); never the empty string ''. Never collapse the entire \
+   command into a single string like \"'' -c 'ls -la'\" — that is shell-style and \
+   will be rejected by the typed gate with Empty_executable. The validation gate \
+   emits Empty_executable for any missing or empty 'executable' field; do not \
+   retry the same empty payload — restructure to executable='X' argv=['arg1',...]."
 ;;
 
 let tool_execute_schema : Masc_domain.tool_schema =


### PR DESCRIPTION
## Summary

24h system_log 분석 결과 `keeper_bash` ERROR 의 #1 패턴 (24h 26회) 이 `executable is empty` + 5-retry threshold-silence — LLM 이 typed input 의 `executable` 필드를 빈 문자열 `""` 로 호출 + argv 도 empty 또는 shell-style cmd (`'' -c 'ls -la'`) 로 collapse.

영향 keeper: `tech_glutton`, `executor` (active 운영).

본 PR 은 `tool_execute_description` (lib/tool_shard_types_schemas_bash.ml:106-126) 끝에 **COMMON REJECTIONS** 절 추가 — LLM-facing prompt 강화로 typed correctness 유도.

## What this changes

- `lib/tool_shard_types_schemas_bash.ml:125` 끝에 6-line common-rejection 절 추가
- schema 변경 0 (JSON Schema `minLength: 1` 이미 존재)
- 동작 변경 0 (description 만)

## 24h evidence

```
{"cmd":"'' -c 'ls -la .masc/state/'","cwd":"/Users/dancer/me/.masc/playground/tech_glutton/","error":"executable is empty — provide a non-empty allowlisted command name, e.g. executable=\"cat\" argv=[\"file.txt\"]","typed":true}
```

26 ERROR/24h × ~5 retry per attempt (Keeper_tool_retry_state.default_silence_threshold=5) = ~130 wasted production cycles.

## Workaround Sig 검증 (CLAUDE.md §Workaround Sig)

- #1 telemetry-as-fix: ❌ (counter 추가 없음)
- #2 string classifier: ❌ (typed gate 강화 아닌 LLM prompt)
- #3 N-of-M: ❌
- #4 cap/cooldown/dedup/repair: ❌
- #5 typed boundary positive: ✅ (LLM-facing correctness 안내 강화)

→ Override 3-요건 불필요, positive change.

## Related RFCs

- **RFC-0064** (LLM-native two-surface tool model) — Execute tool 의 description SSOT
- **RFC-0179** (ToolDescriptor ecosystem extension, Draft) — 자매 RFC

본 PR 은 RFC-0064 후속 prompt 강화 — 새 RFC 불필요.

`RFC-WAIVED: tool description prompt strengthening, no schema/contract change, surface unchanged; no credential/identity/operator/sandbox/hooks/workflow subsystem touched.`

## Verification (post-merge)

- 24h log query: `keeper_bash` `executable is empty` ERROR count
- 목표: 26/24h → ≤8/24h (-70%)
- 사용자 active keeper (tech_glutton, executor) 의 *empty payload retry storm* 0건

## Test plan

- [ ] dune build (main HEAD eb52cdd5d 자체 broken state 일 가능 — `test_tool_shard_coverage.ml` 의 `Tool_shard_types_schemas_bash` unbound module — 본 PR 무관)
- [ ] 24h 후 ERROR delta 측정

🤖 Generated with [Claude Code](https://claude.com/claude-code)