### PR TITLE
docs(rfc): promote RFC-0008 Active -> Implemented after live-surface check

### DIFF
--- a/docs/rfc/RFC-0008-credential-provider.md
+++ b/docs/rfc/RFC-0008-credential-provider.md
@@ -1,6 +1,6 @@
 # RFC-0008: `CredentialProvider` Trait (Minimum Viable)
 
-- **Status**: Active (PR-1 `Credential_provider trait + Host_config_provider` merged via #10660; subsequent module rename RFC-0085 Phase 2.A via #15472. Body field-evidence chain F-1/F-2/F-4 — verify Phase 2 + finalize/teardown surface still pending.)
+- **Status**: Implemented (PR-1 `Credential_provider trait + Host_config_provider` via #10660. PR-2 `binding.metadata` field + `Invalid_token`/`Finalize_failed`/`Tear_down_failed` error variants live in `lib/keeper/keeper_credential_provider.mli`. PR-3 Option B `lib/keeper/keeper_in_container_login_provider.{ml,mli}` — `include Keeper_credential_provider.S` + F-1 `provider_gate` — present and matches §3 spec 1:1. Module renamed under RFC-0085 Phase 2.A (#15472/#15474/#15478). Caller wire-up of `finalize` from `keeper_sandbox_docker` is RFC-0019 PR-C scope.)
 - **Author**: vincent (with Agent-LLM-A)
 - **Created**: 2026-04-24
 - **Revised**: 2026-04-30 — root credential fallback added and ambient operator credential fallback removed; §3 binding.env is composed **inside** `Host_config_provider.resolve` from the selected root/keeper bundle paths + `Env_git_noninteractive.env`.


### PR DESCRIPTION
## Summary
Re-promotes RFC-0008 from `Active` to `Implemented` after live-surface verification. Follow-up to #18684 (which conservatively set it to `Active`); a deeper read of the implementing modules shows all three PR phases have landed.

## What changed
One frontmatter line in `docs/rfc/RFC-0008-credential-provider.md` — `**Status**` field.

## Live surface evidence

| RFC §3 phase | Spec | Live code |
|---|---|---|
| PR-1 | `Credential_provider` trait + `Host_config_provider.resolve` (~150 LoC) | `lib/keeper/keeper_credential_provider.{ml,mli}` (86-line .mli, `module type S`, `resolve`/`finalize`/`tear_down`) — merged via **#10660**, renamed under RFC-0085 Phase 2.A (#15472) |
| PR-2 | `binding.metadata` field + `provider_gate` error variants | `keeper_credential_provider.mli` defines `metadata : (string * string) list`, `Invalid_token`, `Finalize_failed`, `Tear_down_failed` |
| PR-3 | `In_container_login_provider` + F-1 token-SHA gate | `lib/keeper/keeper_in_container_login_provider.{ml,mli}` — `include Keeper_credential_provider.S` + `provider_gate : keeper_token: -> operator_token: -> identity: -> (unit, error) result` + `For_testing.provider_gate` test surface. `@since 2.90.0` tag |

The `keeper_in_container_login_provider.mli` body matches RFC-0008 §3 PR-3 spec 1:1 (`provider_gate` argv shape, SHA-256 hash + hex compare, `Invalid_token` on match).

## Why `Implemented` not `Active`
In the previous closeout sweep (#18684), I conservatively set RFC-0008 to `Active` because the survey only spot-checked PR-1 (#10660). On the next pass for the "implement Phase 2 + finalize/teardown" task, a direct read of `lib/keeper/keeper_credential_provider.mli` and the parallel `keeper_in_container_login_provider.mli` showed the Phase 2 (`binding.metadata`) and Phase 3 (`In_container_login_provider`) surfaces both already exist and match spec — the conservative `Active` label understated the state.

## Out of scope
- `credential_materializer.ml:16` carries a comment "PR-C can wire `Keeper_credential_provider.finalize`" indicating the `finalize` call site at `keeper_sandbox_docker` is not yet wired. That is **RFC-0019 PR-C** scope, not RFC-0008 leftover — the trait/provider surface this RFC defines is complete.

## Workaround gate self-check
- Telemetry-as-fix / substring classifier / N-of-M / catch-all / cap-cooldown / test backdoor — all N/A. Docs-only frontmatter relabel.

RFC-WAIVED: docs-only frontmatter update; no code or wire-format change.

## Test plan
- [x] Surface verified by reading the two .mli files (paths cited above).
- [x] Spec § cross-referenced against current code (PR-3 `provider_gate` signature matches §3).
- [x] Caller wire-up explicitly excluded; RFC-0019 PR-C scope cited.
- [ ] CI: required docs checks before Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
