### PR TITLE
feat(agent_tool_descriptor): RFC-0179 PR-2 migrate keeper_time_now to In_process

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -4,6 +4,7 @@ type executor =
   | Shell_ir
   | Filesystem
   | Remote_mcp
+  | In_process
 
 type backend =
   | Ocaml_runtime
@@ -30,6 +31,7 @@ type runtime_handler =
   | Tool_edit_file
   | Tool_write_file
   | Tool_remote_mcp
+  | Tool_time_now
 
 type policy =
   { visibility : Tool_catalog.visibility
@@ -60,6 +62,7 @@ let executor_to_string = function
   | Shell_ir -> "shell_ir"
   | Filesystem -> "filesystem"
   | Remote_mcp -> "remote_mcp"
+  | In_process -> "in_process"
 ;;
 
 let backend_to_string = function
@@ -90,12 +93,14 @@ let runtime_handler_to_string = function
   | Tool_edit_file -> "tool_edit_file"
   | Tool_write_file -> "tool_write_file"
   | Tool_remote_mcp -> "tool_remote_mcp"
+  | Tool_time_now -> "tool_time_now"
 ;;
 
-let policy ?readonly ?effect_domain ?(approval = Policy_selected) ?cwd_scope
-      ?credential_profile ?(retryable = false) ()
+let policy ?(visibility = Tool_catalog.Default) ?readonly ?effect_domain
+      ?(approval = Policy_selected) ?cwd_scope ?credential_profile
+      ?(retryable = false) ()
   =
-  { visibility = Tool_catalog.Default
+  { visibility
   ; readonly
   ; effect_domain
   ; approval
@@ -433,10 +438,38 @@ let public_descriptors =
 ;;
 
 (* RFC-0179 list bifurcation. [internal_descriptors] hosts descriptor-backed
-   coordination tools (keeper_* / masc_* clusters). Starts empty in PR-1; each
-   cluster migration PR adds entries here. The LLM-native [public_descriptors]
-   contract (RFC-0064 hard-cut, 7 entries) is preserved unchanged. *)
-let internal_descriptors : t list = []
+   coordination tools (keeper_* / masc_* clusters). Each cluster migration PR
+   adds entries here. The LLM-native [public_descriptors] contract (RFC-0064
+   hard-cut, 7 entries) is preserved unchanged. *)
+let internal_descriptors : t list =
+  [ descriptor
+      ~id:"keeper.time.now"
+      ~public_name:"keeper_time_now"
+      ~internal_name:"keeper_time_now"
+      ~description:
+        "Return the current wall-clock time as ISO 8601 and Unix epoch \
+         seconds. No arguments."
+      ~input_schema:
+        (`Assoc
+           [ "type", `String "object"
+           ; "properties", `Assoc []
+           ; "additionalProperties", `Bool false
+           ])
+      ~policy:
+        (policy
+           ~visibility:Tool_catalog.Hidden
+           ~readonly:true
+           ~effect_domain:Tool_catalog.Read_only
+           ~approval:No_approval
+           ~retryable:true
+           ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_time_now
+      ~translate:translate_identity
+  ]
+;;
 
 let all_descriptors () = public_descriptors @ internal_descriptors
 

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -9,6 +9,7 @@ type executor =
   | Shell_ir
   | Filesystem
   | Remote_mcp
+  | In_process
 
 type backend =
   | Ocaml_runtime
@@ -35,6 +36,7 @@ type runtime_handler =
   | Tool_edit_file
   | Tool_write_file
   | Tool_remote_mcp
+  | Tool_time_now
 
 type policy =
   { visibility : Tool_catalog.visibility

--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -1,0 +1,8 @@
+(** In-process runtime handlers for descriptor-backed coordination tools. *)
+
+let handle_time_now ~args:_ =
+  let now_unix = Time_compat.now () in
+  let now_iso = Masc_domain.now_iso () in
+  Yojson.Safe.to_string
+    (`Assoc [ "now_iso", `String now_iso; "now_unix", `Float now_unix ])
+;;

--- a/lib/keeper/agent_tool_in_process_runtime.mli
+++ b/lib/keeper/agent_tool_in_process_runtime.mli
@@ -1,0 +1,12 @@
+(** In-process runtime handlers for descriptor-backed coordination tools.
+
+    RFC-0179 PR-2 onwards. This module hosts handlers for descriptors whose
+    executor is [In_process] — pure OCaml-runtime functions with no sandbox,
+    no host process spawn, no remote MCP. Each handler returns the raw output
+    JSON string; the caller in [Keeper_exec_tools] wraps it via
+    [make_executed_tool_result]. *)
+
+val handle_time_now : args:Yojson.Safe.t -> string
+(** [handle_time_now ~args] ignores [args] (the descriptor schema mandates an
+    empty object) and returns
+    [{ "now_iso": <ISO-8601 UTC>, "now_unix": <epoch seconds float> }]. *)

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -32,7 +32,7 @@ let handle_filesystem ctx descriptor args =
          ~config:ctx.config
          ~keeper_name:ctx.meta.name
          ~args)
-  | Tool_execute | Tool_search_files | Tool_remote_mcp -> None
+  | Tool_execute | Tool_search_files | Tool_remote_mcp | Tool_time_now -> None
 ;;
 
 (* Dispatch asymmetry: Filesystem and Remote_mcp go through Agent_tool_* runtime
@@ -66,7 +66,8 @@ let handle_shell_ir ctx descriptor args =
          ~config:ctx.config
          ~meta:ctx.meta
          ~args)
-  | Tool_read_file | Tool_edit_file | Tool_write_file | Tool_remote_mcp -> None
+  | Tool_read_file | Tool_edit_file | Tool_write_file | Tool_remote_mcp
+  | Tool_time_now -> None
 ;;
 
 let handle_remote_mcp ctx descriptor args =
@@ -90,7 +91,19 @@ let handle_remote_mcp ctx descriptor args =
   | Tool_search_files
   | Tool_read_file
   | Tool_edit_file
-  | Tool_write_file -> None
+  | Tool_write_file
+  | Tool_time_now -> None
+;;
+
+let handle_in_process _ctx descriptor args =
+  match descriptor.Agent_tool_descriptor.runtime_handler with
+  | Tool_time_now -> Some (Agent_tool_in_process_runtime.handle_time_now ~args)
+  | Tool_execute
+  | Tool_search_files
+  | Tool_read_file
+  | Tool_edit_file
+  | Tool_write_file
+  | Tool_remote_mcp -> None
 ;;
 
 let handle ctx ~descriptor ~args =
@@ -98,6 +111,7 @@ let handle ctx ~descriptor ~args =
   | Filesystem -> handle_filesystem ctx descriptor args
   | Shell_ir -> handle_shell_ir ctx descriptor args
   | Remote_mcp -> handle_remote_mcp ctx descriptor args
+  | In_process -> handle_in_process ctx descriptor args
 ;;
 
 let handle_internal ctx ~name ~args =

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -319,7 +319,6 @@ let execute_keeper_tool_call_with_outcome
   : executed_tool_result
   =
   let args = input in
-  let now_ts = Time_compat.now () in
   let meta =
     match Keeper_registry.get ~base_path:config.base_path meta.name with
     | Some entry -> entry.meta
@@ -445,10 +444,8 @@ let execute_keeper_tool_call_with_outcome
            (Yojson.Safe.to_string (`Assoc [ "status", `String "silent" ]))
        | "keeper_tools_list" ->
          success_tool_result (Keeper_exec_shared.keeper_tools_list_json ~meta)
-       | "keeper_time_now" ->
-         success_tool_result
-           (Yojson.Safe.to_string
-              (`Assoc [ "now_iso", `String (now_iso ()); "now_unix", `Float now_ts ]))
+       (* "keeper_time_now" migrated to Agent_tool_in_process_runtime via
+          descriptor dispatch (RFC-0179 PR-2). *)
        | "keeper_context_status" ->
          success_tool_result
            (Keeper_exec_memory.keeper_context_status_json ~config ~meta ~ctx_work)


### PR DESCRIPTION
## Summary

RFC-0179 §4 PR-2 — descriptor spine 위에 첫 coordination tool 마이그레이션. `keeper_time_now`를 legacy string-match chain (`Keeper_exec_tools:448-451`)에서 `internal_descriptors`로 옮깁니다. PR #18677가 YAGNI로 제거한 `In_process` executor가 *구체적 consumer*와 함께 재도입됩니다.

## Why

`memory/project_masc_mcp_tool_ecosystem_descriptor_coverage_2026_05_26.md` audit 기준 descriptor backing 7/286 (~2.5%). 본 PR이 그 비율을 8/286으로 올리고 *cluster migration template*을 확립합니다.

PR #18677은 In_process 등 3 executor enum case를 YAGNI로 제거했지만 — 본 PR이 그 결정이 *narrow audit으로 인한 prematurity*였음을 실증. 동일 case를 즉시 재도입.

## Changes

- `lib/keeper/agent_tool_descriptor.ml/mli`
  - `executor`: `+ In_process` (재도입, supersedes #18677 YAGNI 근거)
  - `runtime_handler`: `+ Tool_time_now`
  - `policy`: `+ ?visibility` 옵셔널 (default `Default`)
  - `internal_descriptors`: 첫 entry `keeper.time.now` 추가
  - 기존 `handle_filesystem`/`handle_shell_ir`/`handle_remote_mcp` exhaustive match에 `Tool_time_now -> None` 추가
- `lib/keeper/agent_tool_in_process_runtime.{ml,mli}` (신규 모듈)
  - `handle_time_now : args:Yojson.Safe.t -> string`
- `lib/keeper/agent_tool_runtime.ml`
  - `handle_in_process` 추가
  - `handle`의 executor match에 `| In_process -> handle_in_process ...` 추가
- `lib/keeper/keeper_exec_tools.ml`
  - `keeper_time_now` match arm 제거 (lines 448-451), comment marker 남김
  - 미사용 `let now_ts = Time_compat.now ()` (line 322) 제거

## JSON output parity

legacy:
```json
{"now_iso": "...ISO...", "now_unix": ...float...}
```

new (Agent_tool_in_process_runtime.handle_time_now): 동일 — 같은 필드, 같은 타입, 같은 순서. agent-visible behavior 변경 0. dispatch path만 바뀜.

## Receipt evidence

call 시 route_evidence_json 에 다음 필드 자동 기록:
- `descriptor_id`: `"keeper.time.now"`
- `public_name` / `canonical_name`: `"keeper_time_now"`
- `executor`: `"in_process"`
- `backend`: `"ocaml_runtime"`
- `sandbox`: `"none"`
- `runtime_handler`: `"tool_time_now"`
- `visibility`: `"hidden"`
- `readonly`: `true`
- `effect_domain`: `"read_only"`
- `approval`: `"none"`
- `retryable`: `true`

legacy chain은 receipt evidence 없었음. 본 PR로 observability 추가.

## Invariants preserved

| Invariant | Status |
|---|---|
| `public_descriptors` 7 entries | ✅ 불변 |
| `test_alias_table_is_stable` 7 pin | ✅ 통과 |
| `test_cdal_tool_id` 7 public + 7 retired opaque | ✅ 통과 |
| `Agent_tool_runtime.handle` executor exhaustive | ✅ `In_process` arm 추가로 *구조적* exhaustive 유지 |

## Verification

- `dune build --root . lib/` EXIT=0
- `test_keeper_tool_alias` 40/40 PASS
- `test_cdal_tool_id` 9/9 PASS
- 새 모듈 `agent_tool_in_process_runtime` 컴파일 clean

## Stacked on

#18683 (PR-1 list bifurcation) — merged 2026-05-26.

## Next

RFC-0179 PR-3..N: cluster migrations (task / board / voice / memory / library). 각 cluster 별 PR. 동일 패턴.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
