### PR TITLE
test(keeper): ratchet blocker string classifier removal

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -261,12 +261,6 @@ let runtime_blocker_surface_of_progress_narrative config (meta : keeper_meta) =
      | None -> None)
 ;;
 
-let proactive_runtime_reason_is_current (meta : keeper_meta) =
-  let proactive_ts = meta.runtime.proactive_rt.last_ts in
-  let last_turn_ts = meta.runtime.usage.last_turn_ts in
-  proactive_ts > 0.0 && (last_turn_ts <= 0.0 || proactive_ts >= last_turn_ts)
-;;
-
 let runtime_blocker_surface_opt (config : Coord_utils.config) (meta : keeper_meta) =
   let derived =
     match meta.runtime.last_blocker with
@@ -283,8 +277,6 @@ let runtime_blocker_surface_opt (config : Coord_utils.config) (meta : keeper_met
   let derived =
     match derived with
     | Some blocker -> Some blocker
-    | None when proactive_runtime_reason_is_current meta ->
-      runtime_blocker_surface_of_progress_narrative config meta
     | None -> runtime_blocker_surface_of_progress_narrative config meta
   in
   derived

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1693,6 +1693,12 @@ let test_tool_failure_classification_contracts () =
        "Invalid_argument msg");
   check bool "generic tool result does not classify Failure text" false
     (file_contains_pattern "lib/tool_types/tool_result.ml" "Failure msg");
+  check bool "keeper blocker bridge has no raw string classifier" false
+    (file_contains_pattern "lib/keeper/keeper_status_bridge_blocker.ml"
+       "blocker_class_of_string");
+  check bool "status bridge does not parse proactive last_reason text" false
+    (file_contains_pattern "lib/keeper/keeper_status_bridge.ml"
+       "proactive_rt.last_reason");
   check bool "deterministic tool failures have reason metric" true
     (file_contains_pattern "lib/keeper/keeper_metrics.ml"
        "masc_keeper_tools_oas_deterministic_failures_total"


### PR DESCRIPTION
## Summary
- remove the now-dead proactive timestamp branch whose both arms returned the same progress narrative fallback
- add source ratchets that keep blocker classification from reintroducing raw string parsing or proactive last_reason parsing

## Verification
- `ocamlformat --check lib/keeper/keeper_status_bridge.ml test/test_ci_hardening_source.ml`
- `git diff --check`
- `rg -n "blocker_class_of_string|proactive_runtime_reason_is_current|proactive_rt\.last_reason" lib/keeper/keeper_status_bridge_blocker.ml lib/keeper/keeper_status_bridge.ml test/test_ci_hardening_source.ml` returned only source-ratchet strings in `test/test_ci_hardening_source.ml`
- `env DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build ./test/test_ci_hardening_source.exe` passed before the final rebase; latest local rerun was blocked by concurrent bare Dune processes
- GitHub checks for #18691 pass after rerun; skipped jobs are path-filtered/intentional for this PR