### PR TITLE
docs(rfc): promote RFC-0009 Active -> Implemented after live-surface check

### DIFF
--- a/docs/rfc/RFC-0009-cascade-trust-phase2.md
+++ b/docs/rfc/RFC-0009-cascade-trust-phase2.md
@@ -1,6 +1,6 @@
 # RFC-0009 — Cascade Trust Phase 2: Operator Recommendations + Opt-in Persist
 
-**Status**: Active (Phase 0a/0b merged via #10292/#10331. Phase 1 first landed via #10365, reverted, then reinstated as `cascade_trust` module via #12589. Phase 2 — operator recommendations + opt-in persist — still pending implementation.)
+**Status**: Implemented (Phase 0a/0b via #10292/#10331. Phase 1 first via #10365, reverted, reinstated as `cascade_trust` module via #12589. Phase 2a operator recommendations live in `lib/dashboard_cascade_recommendations.ml` (action variants `Reduce_weight | Disable | Investigate`); Phase 2b opt-in persist live in `lib/cascade/cascade_trust_persist.{ml,mli}` (JSONL snapshot + hydrate, gated by `MASC_CASCADE_TRUST_PERSIST`).)
 **Depends on**: #10292 (Phase 0a), #10331 (Phase 0b), #10365 (Phase 1 — reverted), #12589 (Phase 1 reinstated)
 **Author**: vincent (jeong-sik)
 


### PR DESCRIPTION
## Summary
Re-promotes RFC-0009 from `Active` to `Implemented` after live-surface verification. Follow-up to #18684 (which set it to `Active` because Phase 2 looked unimplemented) and #18688 (which applied the same pattern to RFC-0008). On the next pass, both Phase 2a and Phase 2b surfaces turn out to be live.

## What changed
One frontmatter line in `docs/rfc/RFC-0009-cascade-trust-phase2.md` — `**Status**` field.

## Live surface evidence

| RFC body component | Live code | Status |
|---|---|---|
| Phase 0a — fingerprint counter | `Cascade_health_tracker` (merged via #10292) | ✓ |
| Phase 0b — JSONL snapshot every minute | (merged via #10331) | ✓ |
| Phase 1 — `trust_score` auto-rotation, kill switch | `lib/cascade/cascade_trust.{ml,mli}` (`trust_score` API + `For_testing.modulated_weight`). First via #10365 → reverted → reinstated via #12589. | ✓ |
| **Phase 2a — operator recommendations** | `lib/dashboard_cascade_recommendations.ml`, first line: *"Phase 2a low-trust operator recommendations"*. Action variants `Reduce_weight \| Disable \| Investigate`. | ✓ |
| **Phase 2b — opt-in persist** | `lib/cascade/cascade_trust_persist.{ml,mli}` — `snapshot_now`, `hydrate_latest`, `start_snapshot_fiber`. `MASC_CASCADE_TRUST_PERSIST` flag referenced from `dashboard_cascade_recommendations.ml:6` as the Phase 2b gate. | ✓ |

The wording in `dashboard_cascade_recommendations.ml:1-6` matches the RFC body's Phase 2a/2b split exactly:

> Phase 2a low-trust operator recommendations. Surfaces a dashboard nudge when [trust_score] indicates a provider is dragging the cascade. Observation only — the user runs the suggested config edit themselves. Phase 2b is what would make these self-applying, and it is gated by [MASC_CASCADE_TRUST_PERSIST].

## Why `Implemented` not `Active`
In the earlier closeout sweep (#18684) I set RFC-0009 to `Active` with the note "Phase 2 — operator recommendations + opt-in persist — still pending implementation." That label was based on a surface scan that missed the `dashboard_cascade_recommendations.ml` module (it lives outside `lib/cascade/`) and treated `cascade_trust_persist.ml` only as Phase 0b's persistence companion. A re-read of both modules + the `MASC_CASCADE_TRUST_PERSIST` flag wiring shows Phase 2a + 2b are both already present.

## Workaround gate self-check
- Telemetry-as-fix / substring classifier / N-of-M / catch-all / cap-cooldown / test backdoor — all N/A. Docs-only frontmatter relabel.

RFC-WAIVED: docs-only frontmatter update; no code or wire-format change.

## Test plan
- [x] Each Phase 2 component verified by reading the corresponding `.mli`/`.ml` header.
- [x] `MASC_CASCADE_TRUST_PERSIST` env flag (RFC §"Opt-in by default") confirmed present.
- [x] Phase 1 revert→reinstate chain (#10365 → #10412 → #12589) confirmed via `git log --all`.
- [ ] CI: required docs checks before Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
