### PR TITLE
refactor(keeper): remove git clone policy axis

### DIFF
--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -1,7 +1,7 @@
 ---
 description: MASC world description (keeper system prompt <world> block)
 category: keeper
-template_variables: [allowed_orgs, denied_repos]
+template_variables: []
 ---
 
 ## Paths and Identity
@@ -74,28 +74,6 @@ When invoking Execute, supply `cwd: "repos/<REPO_NAME>"` (or the
 worktree path) instead of relying on the sandbox-root default cwd.  This
 is the most common cause of `sandbox docker exec failed` events in the
 fleet log (#10424: 9x increase from 2 to 56 events/day across 04-24..26).
-
-## Project
-
-Clone targets are controlled by `config/tool_policy.toml` `[git_clone]`.
-Two lists combine as **ALLOWED minus DENIED** — read both carefully.
-
-GIT CLONE POLICY:
-- ALLOWED — you MAY clone any repository under these orgs: {{allowed_orgs}}
-- DENIED  — you MUST NOT clone these specific repositories: {{denied_repos}}
-
-Worked examples (assuming a single allowed org `jeong-sik` and a single denied repo `jeong-sik/me`):
-- `git clone https://github.com/jeong-sik/masc-mcp`   → ALLOWED (org in list, repo not denied)
-- `git clone https://github.com/jeong-sik/daw-mcp`    → ALLOWED (same reason)
-- `git clone https://github.com/jeong-sik/me`         → DENIED (repo explicitly denied)
-- `git clone https://github.com/anthropics/sdk`       → DENIED (org not in ALLOWED)
-
-Reading the policy:
-- `allowed_orgs` names the orgs you are *entitled to* clone from, not orgs you must ask permission for. If the task you claim names a repo under ALLOWED (and not in DENIED), clone it directly.
-- Only ask the board when the task does not name a repo and you cannot infer one from context. Do NOT post a "may I clone?" board question when the task already names a repo that passes the ALLOWED/DENIED check.
-- Never infer the GitHub owner from local workspace folders such as `workspace/<name>/...`; only trust the actual clone URL or a confirmed remote origin slug.
-
-Never invent an org or repo that is not in ALLOWED.
 
 ## Environment
 

--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -143,29 +143,6 @@ max_alternatives = 20
 # truncated to prevent context window overflow (65KB observed).
 max_output_bytes = 8192
 
-# ── Git Clone Policy ────────────────────────────────────────────────
-# GitHub org names allowed for keeper-managed clone validation.
-# URLs not matching any org here are rejected.
-
-[git_clone]
-# Org allowlist for keeper-managed GitHub clone validation. Empty list = skip check; the
-# keeper may clone any repo reachable through the operator's gh credential
-# (subject to denied_repos below).  This matches the operator intent that
-# repo/org gating is a soft secondary control — the primary boundary is
-# the gh credential surface itself plus denied_repos.  Earlier values
-# (#9783: ["jeong-sik", "yousleepwhen"]) only listed the operator's two
-# self-owned namespaces and blocked clones referenced from upstream
-# workspace trees.
-allowed_orgs = []
-# Repos blocked even if org is allowed. Format: "org/repo" (lowercase).
-denied_repos = ["jeong-sik/me"]
-# Clone depth: 0 = full clone, N = shallow --depth N.
-default_depth = 0
-# Timeouts for git network operations (seconds).
-clone_timeout_sec = 120
-push_timeout_sec = 60
-pr_create_timeout_sec = 30
-
 # ── Keeper Identity ────────────────────────────────────────────────
 # Git author/committer identity for keeper operations.
 # {name} is replaced with the sanitized keeper name at runtime.

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -215,20 +215,12 @@ let keeper_config_json (config : Coord.config) (name : string)
       let runtime_trust =
         Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta:m
       in
-      let git_clone_allowed_orgs =
-        Keeper_tool_policy.git_clone_allowed_orgs ()
-      in
-      let git_clone_denied_repos =
-        Keeper_tool_policy.git_clone_denied_repos ()
-      in
       let effective_system_prompt =
         Keeper_prompt.build_keeper_system_prompt
           ~goal:m.goal ~short_goal:m.short_goal ~mid_goal:m.mid_goal
           ~long_goal:m.long_goal ~will:m.will
           ~needs:m.needs ~desires:m.desires ~instructions:m.instructions
           ~persona_extended ~keeper_name:m.name
-          ~allowed_orgs:(Option.value git_clone_allowed_orgs ~default:[])
-          ~denied_repos:(Option.value git_clone_denied_repos ~default:[])
           ~active_goals
           ()
       in

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -318,8 +318,6 @@ val build_keeper_system_prompt
   -> instructions:string
   -> ?persona_extended:string
   -> ?keeper_name:string
-  -> ?allowed_orgs:string list
-  -> ?denied_repos:string list
   -> ?active_goals:(string * string * string) list
   -> unit
   -> string

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -74,8 +74,6 @@ val build_keeper_system_prompt :
   instructions:string ->
   ?persona_extended:string ->
   ?keeper_name:string ->
-  ?allowed_orgs:string list ->
-  ?denied_repos:string list ->
   ?active_goals:(string * string * string) list ->
   unit ->
   string

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -132,43 +132,11 @@ let ensure_critical_prompt_anchors prompt =
         (String.concat "," missing);
       prompt ^ "\n\n" ^ critical_prompt_recovery_block ()
 
-(** Format an *allowlist* for prompt rendering.  An empty allowlist means
-    the gate is OFF (any account-accessible repo is permitted), so we
-    render that intent explicitly — otherwise the LLM sees the literal
-    "(none)" produced by a generic empty-list formatter and reads the
-    allowlist as "no orgs allowed", which is the inverse of the operator
-    intent behind an empty list.
-
-    Replaces the earlier [format_list_for_prompt] which collapsed both
-    semantics to "(none)". *)
-let format_allowlist_for_prompt (items : string list) : string =
-  match items with
-  | [] -> "(any — allowlist gate is OFF, the operator's gh credential surface is the only repo boundary)"
-  | xs -> String.concat ", " xs
-
-(** Format a *denylist* for prompt rendering.  An empty denylist means
-    no repo is explicitly blocked, so "(none)" reads correctly here. *)
-let format_denylist_for_prompt (items : string list) : string =
-  match items with
-  | [] -> "(none)"
-  | xs -> String.concat ", " xs
-
-(** Resolve the <world> prompt with git_clone allow/deny lists injected
-    as template variables.  The caller supplies the lists (pulled from
-    [Keeper_tool_policy]); keeping them as arguments avoids a dependency
-    cycle between [Keeper_prompt] and [Keeper_tool_policy].  Falls back
-    to the raw template text if rendering fails so that prompt wiring
-    bugs do not brick keepers — but the fallback is now logged loudly so
-    the silent-degradation case documented in #9893 becomes observable. *)
-let render_world_prompt ~allowed_orgs ~denied_repos : string =
-  let vars =
-    [
-      ("allowed_orgs", format_allowlist_for_prompt allowed_orgs);
-      ("denied_repos", format_denylist_for_prompt denied_repos);
-    ]
-  in
+(** Resolve the <world> prompt. Falls back to the raw template text if
+    rendering fails so prompt wiring bugs do not brick keepers. *)
+let render_world_prompt () : string =
   match
-    Prompt_registry.render_prompt_template Keeper_prompt_names.world vars
+    Prompt_registry.render_prompt_template Keeper_prompt_names.world []
   with
   | Ok rendered -> rendered
   | Error msg ->
@@ -229,7 +197,6 @@ let log_missing_personality_fields missing_fields =
 let build_keeper_system_prompt
     ~goal ~short_goal ~mid_goal ~long_goal ~will ~needs ~desires
     ~instructions ?(persona_extended = "") ?(keeper_name = "")
-    ?(allowed_orgs = []) ?(denied_repos = [])
     ?(active_goals = []) () =
   let goal = normalize_goal_horizon_text goal in
   let short_goal, mid_goal, long_goal =
@@ -320,8 +287,7 @@ let build_keeper_system_prompt
        </continuity>\n\
        \n\
        <world>\n";
-      substitute_keeper_name
-        (render_world_prompt ~allowed_orgs ~denied_repos);
+      substitute_keeper_name (render_world_prompt ());
       "\n</world>\n\
        \n\
        <capabilities>\n";

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -40,24 +40,9 @@ val build_keeper_system_prompt :
   instructions:string ->
   ?persona_extended:string ->
   ?keeper_name:string ->
-  ?allowed_orgs:string list ->
-  ?denied_repos:string list ->
   ?active_goals:(string * string * string) list ->
   unit ->
   string
-(** [allowed_orgs] / [denied_repos] are surfaced in the <world> block so
-    the keeper sees the live git_clone allow/deny lists without having
-    to query [tool_policy.toml].  Callers should pass the values from
-    [Keeper_tool_policy.git_clone_allowed_orgs] /
-    [Keeper_tool_policy.git_clone_denied_repos].
-
-    Empty-list semantics differ between the two once policy is loaded:
-    - Empty [allowed_orgs] = "gate OFF, any account-accessible repo is
-      permitted".
-    - Empty [denied_repos] = "no repos blocked" (renders as "(none)").
-
-    Earlier revisions collapsed both to "(none)", which led the LLM to
-    read an empty allowlist as "no orgs allowed" — the inverse of intent. *)
 
 val append_direct_reply_mode_prompt :
   base_prompt:string ->

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -137,12 +137,6 @@ let prepare_run_context
          | None -> None)
       meta.active_goal_ids
   in
-  let git_clone_allowed_orgs =
-    Keeper_tool_policy.git_clone_allowed_orgs ()
-  in
-  let git_clone_denied_repos =
-    Keeper_tool_policy.git_clone_denied_repos ()
-  in
   let base_system_prompt =
     Keeper_prompt.build_keeper_system_prompt
       ~goal:meta.goal
@@ -155,8 +149,6 @@ let prepare_run_context
       ~instructions:meta.instructions
       ~persona_extended
       ~keeper_name:meta.name
-      ~allowed_orgs:(Option.value git_clone_allowed_orgs ~default:[])
-      ~denied_repos:(Option.value git_clone_denied_repos ~default:[])
       ~active_goals
       ()
   in

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -143,32 +143,6 @@ let allows_workflow_for_preset (preset : tool_preset) : bool =
 let allows_shell_write_for_preset (preset : tool_preset) : bool =
   preset_allows_privileged_operations preset
 
-(* ── Git clone config accessors (config-driven) ──────────────── *)
-
-let git_clone_allowed_orgs () : string list option =
-  with_policy_config_or ~accessor:"git_clone_allowed_orgs" ~default:None
-    (fun cfg -> Some (Keeper_tool_policy_config.git_clone_allowed_orgs cfg))
-
-let git_clone_denied_repos () : string list option =
-  with_policy_config_or ~accessor:"git_clone_denied_repos" ~default:None
-    (fun cfg -> Some (Keeper_tool_policy_config.git_clone_denied_repos cfg))
-
-let clone_depth () : int =
-  require_policy_config ~accessor:"clone_depth"
-  |> Keeper_tool_policy_config.clone_depth
-
-let clone_timeout_sec () : float =
-  require_policy_config ~accessor:"clone_timeout_sec"
-  |> Keeper_tool_policy_config.clone_timeout_sec
-
-let push_timeout_sec () : float =
-  require_policy_config ~accessor:"push_timeout_sec"
-  |> Keeper_tool_policy_config.push_timeout_sec
-
-let pr_create_timeout_sec () : float =
-  require_policy_config ~accessor:"pr_create_timeout_sec"
-  |> Keeper_tool_policy_config.pr_create_timeout_sec
-
 (* ── GH cache config accessors (config-driven) ─────────────── *)
 
 let gh_cache_ttl_sec () : float =

--- a/lib/keeper/keeper_tool_policy.mli
+++ b/lib/keeper/keeper_tool_policy.mli
@@ -42,26 +42,6 @@ val preset_can_satisfy :
 val allows_workflow_for_preset : tool_preset -> bool
 val allows_shell_write_for_preset : tool_preset -> bool
 
-(** {1 Git Clone Config} *)
-
-val git_clone_allowed_orgs : unit -> string list option
-(** [None] if policy config has not been loaded; [Some []] if loaded
-    with an explicitly empty allowlist (any GitHub org is permitted);
-    [Some orgs] if specific orgs are configured. *)
-val git_clone_denied_repos : unit -> string list option
-(** [None] if policy config has not been loaded; [Some repos] otherwise
-    (empty list means no repos are denied). *)
-
-(** Numeric tool-policy accessors require [init_policy_config] to have
-    loaded [config/tool_policy.toml]. They raise [Invalid_argument] when
-    queried before policy initialization instead of silently using
-    permissive runtime defaults. Missing TOML keys still use the parser
-    defaults in {!Keeper_tool_policy_config} after the config is loaded. *)
-val clone_depth : unit -> int
-val clone_timeout_sec : unit -> float
-val push_timeout_sec : unit -> float
-val pr_create_timeout_sec : unit -> float
-
 (** {1 GH Cache Config} *)
 
 (** These accessors follow the same loaded-policy requirement as the

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -29,21 +29,11 @@ type gh_cache_config = {
   max_output_bytes : int;
 }
 
-type git_clone_config = {
-  allowed_orgs : string list;
-  denied_repos : string list;
-  default_depth : int;
-  clone_timeout_sec : float;
-  push_timeout_sec : float;
-  pr_create_timeout_sec : float;
-}
-
 type t = {
   groups : (string, group_source) Hashtbl.t;
   masc_groups : (string, string list) Hashtbl.t;
   presets : (string, preset_def) Hashtbl.t;
   gh_cache : gh_cache_config;
-  git_clone : git_clone_config;
 }
 
 (* ── TOML parsing helpers ─────────────────────────────────────────── *)
@@ -172,27 +162,6 @@ let parse_gh_cache (doc : Keeper_toml_loader.toml_doc) : gh_cache_config =
   in
   { cache_ttl_sec; fetch_page_size; fetch_timeout_sec;
     max_alternatives; max_output_bytes }
-
-let parse_git_clone (doc : Keeper_toml_loader.toml_doc) : git_clone_config =
-  let allowed_orgs = toml_string_list_at doc "git_clone" "allowed_orgs" in
-  let denied_repos = toml_string_list_at doc "git_clone" "denied_repos" in
-  let default_depth =
-    Option.value ~default:0 (toml_int_at doc "git_clone" "default_depth")
-  in
-  let clone_timeout_sec =
-    Option.value ~default:120 (toml_int_at doc "git_clone" "clone_timeout_sec")
-    |> Float.of_int
-  in
-  let push_timeout_sec =
-    Option.value ~default:60 (toml_int_at doc "git_clone" "push_timeout_sec")
-    |> Float.of_int
-  in
-  let pr_create_timeout_sec =
-    Option.value ~default:30 (toml_int_at doc "git_clone" "pr_create_timeout_sec")
-    |> Float.of_int
-  in
-  { allowed_orgs; denied_repos; default_depth;
-    clone_timeout_sec; push_timeout_sec; pr_create_timeout_sec }
 
 let unresolved_tool_message ~label ~name =
   match Keeper_tool_resolution.resolve name with
@@ -338,10 +307,9 @@ let load ~base_path : (t, string) result =
                    (String.concat "; " fatal_tool_errors))
           | [] ->
               let gh_cache = parse_gh_cache doc in
-              let git_clone = parse_git_clone doc in
               Log.Keeper.info "tool_policy_config: loaded %d groups, %d masc_groups, %d presets from %s"
                 (Hashtbl.length groups) (Hashtbl.length masc_groups) (Hashtbl.length presets) path;
-              Ok { groups; masc_groups; presets; gh_cache; git_clone })
+              Ok { groups; masc_groups; presets; gh_cache })
         )
 
 (* ── Resolution ───────────────────────────────────────────────────── *)
@@ -449,23 +417,3 @@ let gh_cache_max_alternatives (config : t) : int =
 
 let gh_cache_max_output_bytes (config : t) : int =
   config.gh_cache.max_output_bytes
-
-(* ── Git clone config accessors ──────────────────────────────────── *)
-
-let git_clone_allowed_orgs (config : t) : string list =
-  config.git_clone.allowed_orgs
-
-let git_clone_denied_repos (config : t) : string list =
-  config.git_clone.denied_repos
-
-let clone_depth (config : t) : int =
-  config.git_clone.default_depth
-
-let clone_timeout_sec (config : t) : float =
-  config.git_clone.clone_timeout_sec
-
-let push_timeout_sec (config : t) : float =
-  config.git_clone.push_timeout_sec
-
-let pr_create_timeout_sec (config : t) : float =
-  config.git_clone.pr_create_timeout_sec

--- a/lib/keeper/keeper_tool_policy_config.mli
+++ b/lib/keeper/keeper_tool_policy_config.mli
@@ -65,26 +65,4 @@ val gh_cache_max_alternatives : t -> int
 (** Max gh output bytes before truncation. From [gh_cache.max_output_bytes], default 8192. *)
 val gh_cache_max_output_bytes : t -> int
 
-(** Git clone allowed GitHub org names from [git_clone.allowed_orgs]. *)
-val git_clone_allowed_orgs : t -> string list
-
-(** Repos blocked even if org is allowed, from [git_clone.denied_repos]. *)
-val git_clone_denied_repos : t -> string list
-
-(** Clone depth: 0 = full clone, N = shallow --depth N.
-    From [git_clone.default_depth], default 0. *)
-val clone_depth : t -> int
-
-(** Timeout in seconds for git clone operations.
-    From [git_clone.clone_timeout_sec], default 120.0. *)
-val clone_timeout_sec : t -> float
-
-(** Timeout in seconds for git push operations.
-    From [git_clone.push_timeout_sec], default 60.0. *)
-val push_timeout_sec : t -> float
-
-(** Timeout in seconds for PR creation operations.
-    From [git_clone.pr_create_timeout_sec], default 30.0. *)
-val pr_create_timeout_sec : t -> float
-
 val resolve_group : t -> string -> string list option

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -401,12 +401,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                | None -> None)
             active_goal_ids
         in
-        let git_clone_allowed_orgs =
-          Keeper_tool_policy.git_clone_allowed_orgs ()
-        in
-        let git_clone_denied_repos =
-          Keeper_tool_policy.git_clone_denied_repos ()
-        in
         let system_prompt =
           build_keeper_system_prompt
             ~goal
@@ -419,8 +413,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             ~instructions
             ~persona_extended
             ~keeper_name:p.name
-            ~allowed_orgs:(Option.value git_clone_allowed_orgs ~default:[])
-            ~denied_repos:(Option.value git_clone_denied_repos ~default:[])
             ~active_goals
             ()
       in

--- a/test/test_keeper_repo_readiness.ml
+++ b/test/test_keeper_repo_readiness.ml
@@ -43,15 +43,6 @@ let mkdir_p path =
   in
   ensure path
 
-let write_tool_policy ~base_path =
-  let config_dir = Filename.concat base_path "config" in
-  mkdir_p config_dir;
-  let path = Filename.concat config_dir "tool_policy.toml" in
-  let oc = open_out path in
-  output_string oc
-    "[git_clone]\nallowed_orgs = [\"jeong-sik\"]\ndepth = 1\ndenied_repos = [\"jeong-sik/me\"]\n";
-  close_out oc
-
 let json_bool key json =
   Yojson.Safe.Util.(json |> member key |> to_bool)
 
@@ -178,7 +169,6 @@ let set_workspace_origin_to_github ~repo =
 
 let test_auto_provisionable_workspace_repo () =
   let base_path = temp_dir "masc-repo-readiness" in
-  write_tool_policy ~base_path;
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
   let remote = Filename.concat base_path ".remote-masc-mcp.git" in
   mkdir_p (Filename.dirname repo);
@@ -213,7 +203,6 @@ let test_auto_provisionable_workspace_repo () =
 
 let test_missing_clone_skips_workspace_discovery () =
   let base_path = temp_dir "masc-repo-readiness" in
-  write_tool_policy ~base_path;
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
   let remote = Filename.concat base_path ".remote-masc-mcp.git" in
   mkdir_p (Filename.dirname repo);
@@ -240,7 +229,6 @@ let test_missing_clone_skips_workspace_discovery () =
 
 let test_auto_provisionable_workspace_repo_after_file_storm () =
   let base_path = temp_dir "masc-repo-readiness" in
-  write_tool_policy ~base_path;
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
   let remote = Filename.concat base_path ".remote-masc-mcp.git" in
   create_file_storm ~base_path ~count:4005;
@@ -270,7 +258,6 @@ let test_auto_provisionable_workspace_repo_after_file_storm () =
 
 let test_auto_provisionable_workspace_repo_before_hidden_dir_storm () =
   let base_path = temp_dir "masc-repo-readiness" in
-  write_tool_policy ~base_path;
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
   let remote = Filename.concat base_path ".remote-masc-mcp.git" in
   create_hidden_dir_storm ~base_path ~count:4005;
@@ -300,7 +287,6 @@ let test_auto_provisionable_workspace_repo_before_hidden_dir_storm () =
 
 let test_auto_provisionable_workspace_repo_before_wide_workspace_storm () =
   let base_path = temp_dir "masc-repo-readiness" in
-  write_tool_policy ~base_path;
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
   let remote = Filename.concat base_path ".remote-masc-mcp.git" in
   create_wide_workspace_storm ~base_path ~count:4005;

--- a/test/test_keeper_shell_containment.ml
+++ b/test/test_keeper_shell_containment.ml
@@ -18,11 +18,8 @@ module Keeper_tool_policy = Masc_mcp.Keeper_tool_policy
 module Fs_compat = Fs_compat
 module Json = Yojson.Safe.Util
 
-(* P0-1 fix: tool_policy.toml must be loaded before GitHub command dispatch
-   can execute.  Previously the policy_config ref started as None and
-   git_clone_allowed_orgs/git_clone_denied_repos returned [] (fail-open),
-   letting any org through the gh command org check even when a policy
-   was configured.  Initialise here so gh tests see the real policy. *)
+(* Load tool_policy.toml before exercising the shared search-file policy
+   paths so this test observes the same registry state as runtime. *)
 let () =
   let base_path = Masc_test_deps.find_project_root () in
   ignore (Result.get_ok (Keeper_tool_policy.init_policy_config ~base_path))

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -276,25 +276,8 @@ let check_policy_not_loaded_raises accessor call =
 
 let test_tool_policy_unloaded_accessors_emit_metric () =
   Keeper_tool_policy.reset_policy_config_for_test ();
-  let allowed_orgs_before =
-    tool_policy_unloaded_metric "git_clone_allowed_orgs"
-  in
-  check bool "pre-init allowed_orgs remains fail-closed" true
-    (Option.is_none (Keeper_tool_policy.git_clone_allowed_orgs ()));
-  let allowed_orgs_after =
-    tool_policy_unloaded_metric "git_clone_allowed_orgs"
-  in
-  check bool "allowed_orgs pre-init query increments metric" true
-    (allowed_orgs_after >= allowed_orgs_before +. 1.0);
   let strict_accessors =
     [
-      ("clone_depth", fun () -> ignore (Keeper_tool_policy.clone_depth ()));
-      ( "clone_timeout_sec",
-        fun () -> ignore (Keeper_tool_policy.clone_timeout_sec ()) );
-      ( "push_timeout_sec",
-        fun () -> ignore (Keeper_tool_policy.push_timeout_sec ()) );
-      ( "pr_create_timeout_sec",
-        fun () -> ignore (Keeper_tool_policy.pr_create_timeout_sec ()) );
       ( "gh_cache_ttl_sec",
         fun () -> ignore (Keeper_tool_policy.gh_cache_ttl_sec ()) );
       ( "gh_cache_fetch_page_size",


### PR DESCRIPTION
## Summary

- Remove the `[git_clone]` policy section from `config/tool_policy.toml` and the keeper policy config/parser API.
- Stop injecting clone allow/deny lists into the keeper world prompt.
- Update tests so repo readiness and unloaded-policy checks no longer depend on the removed policy axis.

## Rationale

Clone behavior should not be a separate hard-coded keeper policy axis. It should be ordinary execution/runtime behavior rather than a global allow/deny prompt and policy constraint.

## Validation

- `ocamlformat --check` on touched OCaml files
- `git diff --check origin/main..HEAD`
- residue scan: no `git_clone_allowed_orgs`, `git_clone_denied_repos`, clone timeout/depth accessors, or `[git_clone]` policy section in `lib`, `test`, `config`, `docs`, `scripts`

Focused Dune was not started because `/tmp/me-dune-local.lock` is currently held by another Dune run on this host.