### PR TITLE
fix(cascade): route judge calls to tier-group.governance

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -868,16 +868,16 @@ target = "tier-group.primary"
 target = "tier-group.primary"
 
 [routes.governance_judge]
-target = "tier-group.primary"
+target = "tier-group.governance"
 
 [routes.operator_judge]
-target = "tier-group.primary"
+target = "tier-group.governance"
 
 [routes.cross_verifier]
-target = "tier-group.primary"
+target = "tier-group.governance"
 
 [routes.verifier]
-target = "tier-group.primary"
+target = "tier-group.governance"
 
 [routes.adversarial_reviewer]
 target = "tier-group.primary"


### PR DESCRIPTION
## 문제

`Dashboard_governance_judge.refresh_once`가 매 cycle마다 OAS 호출에서 45s timeout으로 실패. 로그 시그니처:

```
WARN Governance refresh_once: compute_judgments failed: Timeout: Execution timed out after 45.0s
     (duration=46.054s compute_timeout=45.0s in_flight=0)
WARN Misc masc_oas_bridge: OAS execution timed out after 45.0s (caller=governance_judge, wall=46.1s)
```

증상 자체는 의도된 backoff (`#18635`)로 빈도가 줄긴 하지만, 매 cycle WARN 1회는 여전히 발생. 사용자 질문: "왜 fallback해서 다른 걸 안 도는가?"

## Root cause

`config/cascade.toml`의 4개 judge route가 `tier-group.primary`를 가리킴.

- `tier-group.primary`는 `tiers = ["primary"]` 단일 tier — tier-간 cross-fallback 경로가 없음
- `tier.primary` 멤버는 keeper-turn용 풀 모델 5종 (`runpod_mtp.qwen-runpod.keeper`, `local_mtp.qwen-local.keeper`, `glm-coding.glm-5-turbo`, `glm-coding.glm-flashx`, `cli_tool_a.codex-spark.for-keeper-turn`). p50 latency가 advisory judge용 45s budget을 초과하는 모델 위주
- 같은 파일에 `tier-group.governance`(line 817-821)가 이미 정의되어 있음. `tiers = ["governance", "__safe_lane"]`, fallback chain 구성. 멤버는 flash 모델 (`glm-flashx`, `deepseek-v4-flash`) — judge용으로 적합
- 그러나 어느 route도 `tier-group.governance`를 사용하지 않아 orphan 정의 상태였음

`task_use_of_logical_use`(`lib/cascade/cascade_routes.ml:240-250`)에서 governance_judge / operator_judge / cross_verifier / verifier 4개를 같은 `Cascade_routing_policy.Code_review` task_use로 묶고 있어 routing 의도상 동일 그룹임이 명시적. routes.toml에서 4개가 모두 `tier-group.primary`로 향한 것은 의도된 routing intent와 모순.

## 변경

```diff
 [routes.governance_judge]
-target = "tier-group.primary"
+target = "tier-group.governance"

 [routes.operator_judge]
-target = "tier-group.primary"
+target = "tier-group.governance"

 [routes.cross_verifier]
-target = "tier-group.primary"
+target = "tier-group.governance"

 [routes.verifier]
-target = "tier-group.primary"
+target = "tier-group.governance"
```

orphan이었던 `tier-group.governance`를 활성화. 4개 route는 이제 `tier.governance`(flash 모델) → `tier.__safe_lane`(codex-spark + deepseek-flash) fallback 체인을 탐.

## 검증

- TOML semantic check: routes target 4개, tier-group.governance.tiers, tier.governance.members 확인
- `dune build lib/cascade lib/dashboard lib/config lib/keeper`: pass
- `dune exec test/test_dashboard_governance.exe`: 26/26 pass
- `dune exec test/test_cascade_declarative_parser.exe`: 63/63 pass
- `dune exec test/test_cascade_routes_decoder.exe`: 4/4 pass

전체 `dune build --root .`는 `test/test_tool_shard_coverage.ml`의 `Unbound module Tool_shard_types_schemas_bash` 회귀로 fail하나, 이 회귀는 본 PR의 cascade.toml 변경과 무관 (별도 main HEAD 회귀).

## 미해결 (follow-up RFC 예고)

본 PR은 4개 judge route의 mis-target만 수정. 더 깊은 정리는 별도 RFC로 분리:

- `[routes.*]` legacy 시스템 자체를 phonebook SSOT로 컷오버
- phonebook이 cascade.toml 안에 데이터를 갖지 못한 상태 (test/fixtures/cascade-phonebook.toml만 풀스펙) — production phonebook 데이터 마이그레이션 필요
- RFC-0177 (`phonebook-internal-vendor-purge`)의 1:1 vendor substitution 방향이 capability/intent 기반 abstraction과 양립 불가 — 별도 RFC로 재설계 예정
- `lib/cascade/cascade_routing_policy.ml:67-70`의 `Code_review → primary_tier_group = "cross-verify"` dangling reference 해소도 위 RFC와 함께

RFC-WAIVED: cascade subsystem이지만 `agent_delegation` 영역 직접 매치는 없음. 4-line config fix 범위. 더 큰 cascade SSOT 작업은 별도 RFC로 진행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
