### PR TITLE
feat(agent_tool_descriptor): RFC-0179 PR-4 batch 8 tools (memory_write + ide_annotate + voice_*6)

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -34,6 +34,9 @@ type runtime_handler =
   | Tool_time_now
   | Tool_stay_silent
   | Tool_tools_list
+  | Tool_memory_write
+  | Tool_ide_annotate
+  | Tool_voice
 
 type policy =
   { visibility : Tool_catalog.visibility
@@ -98,6 +101,9 @@ let runtime_handler_to_string = function
   | Tool_time_now -> "tool_time_now"
   | Tool_stay_silent -> "tool_stay_silent"
   | Tool_tools_list -> "tool_tools_list"
+  | Tool_memory_write -> "tool_memory_write"
+  | Tool_ide_annotate -> "tool_ide_annotate"
+  | Tool_voice -> "tool_voice"
 ;;
 
 let policy ?(visibility = Tool_catalog.Default) ?readonly ?effect_domain
@@ -463,6 +469,25 @@ let read_only_in_process_policy () =
     ()
 ;;
 
+let coordination_write_in_process_policy () =
+  policy
+    ~visibility:Tool_catalog.Hidden
+    ~readonly:false
+    ~effect_domain:Tool_catalog.Masc_coordination
+    ~approval:Policy_selected
+    ~retryable:false
+    ()
+;;
+
+let voice_external_in_process_policy () =
+  policy
+    ~visibility:Tool_catalog.Hidden
+    ~readonly:false
+    ~approval:Policy_selected
+    ~retryable:false
+    ()
+;;
+
 let internal_descriptors : t list =
   [ descriptor
       ~id:"keeper.time.now"
@@ -505,6 +530,106 @@ let internal_descriptors : t list =
       ~backend:Ocaml_runtime
       ~sandbox:No_sandbox
       ~runtime_handler:Tool_tools_list
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.memory.write"
+      ~public_name:"keeper_memory_write"
+      ~internal_name:"keeper_memory_write"
+      ~description:
+        "Append an entry to the keeper memory store. Body fields define \
+         the entry payload."
+      ~input_schema:empty_object_schema
+      ~policy:(coordination_write_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_memory_write
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.ide.annotate"
+      ~public_name:"keeper_ide_annotate"
+      ~internal_name:"keeper_ide_annotate"
+      ~description:
+        "Create a line-bound annotation in the .masc-ide store. \
+         Returns the created record's id and coordinates."
+      ~input_schema:empty_object_schema
+      ~policy:(coordination_write_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_ide_annotate
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.voice.speak"
+      ~public_name:"keeper_voice_speak"
+      ~internal_name:"keeper_voice_speak"
+      ~description:"Speak the given text via the configured voice service."
+      ~input_schema:empty_object_schema
+      ~policy:(voice_external_in_process_policy ())
+      ~executor:In_process
+      ~backend:Remote_service
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_voice
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.voice.listen"
+      ~public_name:"keeper_voice_listen"
+      ~internal_name:"keeper_voice_listen"
+      ~description:"Listen for voice input via the configured voice service."
+      ~input_schema:empty_object_schema
+      ~policy:(voice_external_in_process_policy ())
+      ~executor:In_process
+      ~backend:Remote_service
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_voice
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.voice.agent"
+      ~public_name:"keeper_voice_agent"
+      ~internal_name:"keeper_voice_agent"
+      ~description:"Run a voice agent turn via the configured voice service."
+      ~input_schema:empty_object_schema
+      ~policy:(voice_external_in_process_policy ())
+      ~executor:In_process
+      ~backend:Remote_service
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_voice
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.voice.sessions"
+      ~public_name:"keeper_voice_sessions"
+      ~internal_name:"keeper_voice_sessions"
+      ~description:"List ongoing voice sessions for this keeper."
+      ~input_schema:empty_object_schema
+      ~policy:(read_only_in_process_policy ())
+      ~executor:In_process
+      ~backend:Remote_service
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_voice
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.voice.session.start"
+      ~public_name:"keeper_voice_session_start"
+      ~internal_name:"keeper_voice_session_start"
+      ~description:"Start a new voice session for this keeper."
+      ~input_schema:empty_object_schema
+      ~policy:(voice_external_in_process_policy ())
+      ~executor:In_process
+      ~backend:Remote_service
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_voice
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.voice.session.end"
+      ~public_name:"keeper_voice_session_end"
+      ~internal_name:"keeper_voice_session_end"
+      ~description:"End an ongoing voice session for this keeper."
+      ~input_schema:empty_object_schema
+      ~policy:(voice_external_in_process_policy ())
+      ~executor:In_process
+      ~backend:Remote_service
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_voice
       ~translate:translate_identity
   ]
 ;;

--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -32,6 +32,8 @@ type runtime_handler =
   | Tool_write_file
   | Tool_remote_mcp
   | Tool_time_now
+  | Tool_stay_silent
+  | Tool_tools_list
 
 type policy =
   { visibility : Tool_catalog.visibility
@@ -94,6 +96,8 @@ let runtime_handler_to_string = function
   | Tool_write_file -> "tool_write_file"
   | Tool_remote_mcp -> "tool_remote_mcp"
   | Tool_time_now -> "tool_time_now"
+  | Tool_stay_silent -> "tool_stay_silent"
+  | Tool_tools_list -> "tool_tools_list"
 ;;
 
 let policy ?(visibility = Tool_catalog.Default) ?readonly ?effect_domain
@@ -441,6 +445,24 @@ let public_descriptors =
    coordination tools (keeper_* / masc_* clusters). Each cluster migration PR
    adds entries here. The LLM-native [public_descriptors] contract (RFC-0064
    hard-cut, 7 entries) is preserved unchanged. *)
+let empty_object_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc []
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let read_only_in_process_policy () =
+  policy
+    ~visibility:Tool_catalog.Hidden
+    ~readonly:true
+    ~effect_domain:Tool_catalog.Read_only
+    ~approval:No_approval
+    ~retryable:true
+    ()
+;;
+
 let internal_descriptors : t list =
   [ descriptor
       ~id:"keeper.time.now"
@@ -449,24 +471,40 @@ let internal_descriptors : t list =
       ~description:
         "Return the current wall-clock time as ISO 8601 and Unix epoch \
          seconds. No arguments."
-      ~input_schema:
-        (`Assoc
-           [ "type", `String "object"
-           ; "properties", `Assoc []
-           ; "additionalProperties", `Bool false
-           ])
-      ~policy:
-        (policy
-           ~visibility:Tool_catalog.Hidden
-           ~readonly:true
-           ~effect_domain:Tool_catalog.Read_only
-           ~approval:No_approval
-           ~retryable:true
-           ())
+      ~input_schema:empty_object_schema
+      ~policy:(read_only_in_process_policy ())
       ~executor:In_process
       ~backend:Ocaml_runtime
       ~sandbox:No_sandbox
       ~runtime_handler:Tool_time_now
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.stay.silent"
+      ~public_name:"keeper_stay_silent"
+      ~internal_name:"keeper_stay_silent"
+      ~description:
+        "Yield the turn without taking action. Returns {\"status\":\"silent\"}. \
+         No arguments."
+      ~input_schema:empty_object_schema
+      ~policy:(read_only_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_stay_silent
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.tools.list"
+      ~public_name:"keeper_tools_list"
+      ~internal_name:"keeper_tools_list"
+      ~description:
+        "List the tools available to the current keeper, with descriptions \
+         and policy notes. No arguments."
+      ~input_schema:empty_object_schema
+      ~policy:(read_only_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_tools_list
       ~translate:translate_identity
   ]
 ;;

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -37,6 +37,8 @@ type runtime_handler =
   | Tool_write_file
   | Tool_remote_mcp
   | Tool_time_now
+  | Tool_stay_silent
+  | Tool_tools_list
 
 type policy =
   { visibility : Tool_catalog.visibility

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -39,6 +39,9 @@ type runtime_handler =
   | Tool_time_now
   | Tool_stay_silent
   | Tool_tools_list
+  | Tool_memory_write
+  | Tool_ide_annotate
+  | Tool_voice
 
 type policy =
   { visibility : Tool_catalog.visibility

--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -14,3 +14,18 @@ let handle_stay_silent ~args:_ =
 let handle_tools_list ~meta ~args:_ =
   Keeper_exec_shared.keeper_tools_list_json ~meta
 ;;
+
+let handle_memory_write ~config ~meta ~args =
+  Keeper_exec_memory.keeper_memory_write_json ~config ~meta ~args
+;;
+
+let handle_ide_annotate ~config ~meta ~args =
+  Agent_tool_ide_runtime.handle_ide_annotate
+    ~config
+    ~keeper_name:meta.Keeper_types.name
+    ~args
+;;
+
+let handle_voice ~meta ~name ~args =
+  Agent_tool_voice_runtime.handle_voice_tool ~meta ~name ~args
+;;

--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -6,3 +6,11 @@ let handle_time_now ~args:_ =
   Yojson.Safe.to_string
     (`Assoc [ "now_iso", `String now_iso; "now_unix", `Float now_unix ])
 ;;
+
+let handle_stay_silent ~args:_ =
+  Yojson.Safe.to_string (`Assoc [ "status", `String "silent" ])
+;;
+
+let handle_tools_list ~meta ~args:_ =
+  Keeper_exec_shared.keeper_tools_list_json ~meta
+;;

--- a/lib/keeper/agent_tool_in_process_runtime.mli
+++ b/lib/keeper/agent_tool_in_process_runtime.mli
@@ -21,3 +21,27 @@ val handle_tools_list
   -> string
 (** [handle_tools_list ~meta ~args] ignores [args] and returns the
     keeper-visible tool list JSON via [Keeper_exec_shared.keeper_tools_list_json]. *)
+
+val handle_memory_write
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> args:Yojson.Safe.t
+  -> string
+(** [handle_memory_write] delegates to [Keeper_exec_memory.keeper_memory_write_json]. *)
+
+val handle_ide_annotate
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> args:Yojson.Safe.t
+  -> string
+(** [handle_ide_annotate] delegates to [Agent_tool_ide_runtime.handle_ide_annotate]. *)
+
+val handle_voice
+  :  meta:Keeper_types.keeper_meta
+  -> name:string
+  -> args:Yojson.Safe.t
+  -> string
+(** [handle_voice] delegates to [Agent_tool_voice_runtime.handle_voice_tool].
+    The [name] is the descriptor's [internal_name]; the voice runtime
+    name-dispatches across the six voice tools (speak / listen / agent /
+    sessions / session_start / session_end). *)

--- a/lib/keeper/agent_tool_in_process_runtime.mli
+++ b/lib/keeper/agent_tool_in_process_runtime.mli
@@ -10,3 +10,14 @@ val handle_time_now : args:Yojson.Safe.t -> string
 (** [handle_time_now ~args] ignores [args] (the descriptor schema mandates an
     empty object) and returns
     [{ "now_iso": <ISO-8601 UTC>, "now_unix": <epoch seconds float> }]. *)
+
+val handle_stay_silent : args:Yojson.Safe.t -> string
+(** [handle_stay_silent ~args] ignores [args] and returns
+    [{ "status": "silent" }]. *)
+
+val handle_tools_list
+  :  meta:Keeper_types.keeper_meta
+  -> args:Yojson.Safe.t
+  -> string
+(** [handle_tools_list ~meta ~args] ignores [args] and returns the
+    keeper-visible tool list JSON via [Keeper_exec_shared.keeper_tools_list_json]. *)

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -33,7 +33,8 @@ let handle_filesystem ctx descriptor args =
          ~keeper_name:ctx.meta.name
          ~args)
   | Tool_execute | Tool_search_files | Tool_remote_mcp | Tool_time_now
-  | Tool_stay_silent | Tool_tools_list -> None
+  | Tool_stay_silent | Tool_tools_list | Tool_memory_write | Tool_ide_annotate
+  | Tool_voice -> None
 ;;
 
 (* Dispatch asymmetry: Filesystem and Remote_mcp go through Agent_tool_* runtime
@@ -68,7 +69,8 @@ let handle_shell_ir ctx descriptor args =
          ~meta:ctx.meta
          ~args)
   | Tool_read_file | Tool_edit_file | Tool_write_file | Tool_remote_mcp
-  | Tool_time_now | Tool_stay_silent | Tool_tools_list -> None
+  | Tool_time_now | Tool_stay_silent | Tool_tools_list | Tool_memory_write
+  | Tool_ide_annotate | Tool_voice -> None
 ;;
 
 let handle_remote_mcp ctx descriptor args =
@@ -95,7 +97,10 @@ let handle_remote_mcp ctx descriptor args =
   | Tool_write_file
   | Tool_time_now
   | Tool_stay_silent
-  | Tool_tools_list -> None
+  | Tool_tools_list
+  | Tool_memory_write
+  | Tool_ide_annotate
+  | Tool_voice -> None
 ;;
 
 let handle_in_process ctx descriptor args =
@@ -105,6 +110,24 @@ let handle_in_process ctx descriptor args =
     Some (Agent_tool_in_process_runtime.handle_stay_silent ~args)
   | Tool_tools_list ->
     Some (Agent_tool_in_process_runtime.handle_tools_list ~meta:ctx.meta ~args)
+  | Tool_memory_write ->
+    Some
+      (Agent_tool_in_process_runtime.handle_memory_write
+         ~config:ctx.config
+         ~meta:ctx.meta
+         ~args)
+  | Tool_ide_annotate ->
+    Some
+      (Agent_tool_in_process_runtime.handle_ide_annotate
+         ~config:ctx.config
+         ~meta:ctx.meta
+         ~args)
+  | Tool_voice ->
+    Some
+      (Agent_tool_in_process_runtime.handle_voice
+         ~meta:ctx.meta
+         ~name:descriptor.internal_name
+         ~args)
   | Tool_execute
   | Tool_search_files
   | Tool_read_file

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -32,7 +32,8 @@ let handle_filesystem ctx descriptor args =
          ~config:ctx.config
          ~keeper_name:ctx.meta.name
          ~args)
-  | Tool_execute | Tool_search_files | Tool_remote_mcp | Tool_time_now -> None
+  | Tool_execute | Tool_search_files | Tool_remote_mcp | Tool_time_now
+  | Tool_stay_silent | Tool_tools_list -> None
 ;;
 
 (* Dispatch asymmetry: Filesystem and Remote_mcp go through Agent_tool_* runtime
@@ -67,7 +68,7 @@ let handle_shell_ir ctx descriptor args =
          ~meta:ctx.meta
          ~args)
   | Tool_read_file | Tool_edit_file | Tool_write_file | Tool_remote_mcp
-  | Tool_time_now -> None
+  | Tool_time_now | Tool_stay_silent | Tool_tools_list -> None
 ;;
 
 let handle_remote_mcp ctx descriptor args =
@@ -92,12 +93,18 @@ let handle_remote_mcp ctx descriptor args =
   | Tool_read_file
   | Tool_edit_file
   | Tool_write_file
-  | Tool_time_now -> None
+  | Tool_time_now
+  | Tool_stay_silent
+  | Tool_tools_list -> None
 ;;
 
-let handle_in_process _ctx descriptor args =
+let handle_in_process ctx descriptor args =
   match descriptor.Agent_tool_descriptor.runtime_handler with
   | Tool_time_now -> Some (Agent_tool_in_process_runtime.handle_time_now ~args)
+  | Tool_stay_silent ->
+    Some (Agent_tool_in_process_runtime.handle_stay_silent ~args)
+  | Tool_tools_list ->
+    Some (Agent_tool_in_process_runtime.handle_tools_list ~meta:ctx.meta ~args)
   | Tool_execute
   | Tool_search_files
   | Tool_read_file

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -439,13 +439,9 @@ let execute_keeper_tool_call_with_outcome
              | None -> search_tools
            in
            success_tool_result (Yojson.Safe.to_string (fn ~query ~max_results)))
-       | "keeper_stay_silent" ->
-         success_tool_result
-           (Yojson.Safe.to_string (`Assoc [ "status", `String "silent" ]))
-       | "keeper_tools_list" ->
-         success_tool_result (Keeper_exec_shared.keeper_tools_list_json ~meta)
-       (* "keeper_time_now" migrated to Agent_tool_in_process_runtime via
-          descriptor dispatch (RFC-0179 PR-2). *)
+       (* "keeper_stay_silent", "keeper_tools_list", "keeper_time_now"
+          migrated to Agent_tool_in_process_runtime via descriptor dispatch
+          (RFC-0179 PR-2 + PR-3). *)
        | "keeper_context_status" ->
          success_tool_result
            (Keeper_exec_memory.keeper_context_status_json ~config ~meta ~ctx_work)

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -448,9 +448,8 @@ let execute_keeper_tool_call_with_outcome
        | "keeper_memory_search" ->
          success_tool_result
            (Keeper_exec_memory.keeper_memory_search_json ~config ~meta ~ctx_work ~args)
-       | "keeper_memory_write" ->
-         success_tool_result
-           (Keeper_exec_memory.keeper_memory_write_json ~config ~meta ~args)
+       (* "keeper_memory_write" migrated to Agent_tool_in_process_runtime
+          via descriptor dispatch (RFC-0179 PR-4). *)
        | "keeper_library_search" ->
          let result =
            Tool_library.handle_search ~tool_name:"keeper_library_search" ~start_time:0.0 Tool_library.{ agent_name = meta.name } args
@@ -464,20 +463,12 @@ let execute_keeper_tool_call_with_outcome
            Tool_library.handle_read ~tool_name:"keeper_library_read" ~start_time:0.0 Tool_library.{ agent_name = meta.name } args
          in
          if result.Tool_result.success then success_tool_result result.Tool_result.message else failure_tool_result (error_json result.Tool_result.message)
-       | "keeper_ide_annotate" ->
-         make_executed_tool_result
-           (Agent_tool_ide_runtime.handle_ide_annotate
-              ~config
-              ~keeper_name:meta.name
-              ~args)
-       | "keeper_voice_speak"
-       | "keeper_voice_listen"
-       | "keeper_voice_agent"
-       | "keeper_voice_sessions"
-       | "keeper_voice_session_start"
-       | "keeper_voice_session_end" ->
-         make_executed_tool_result
-           (Agent_tool_voice_runtime.handle_voice_tool ~meta ~name ~args)
+       (* "keeper_ide_annotate" and the keeper_voice_* cluster (6 tools)
+          migrated to Agent_tool_in_process_runtime via descriptor dispatch
+          (RFC-0179 PR-4). The voice descriptors all route through the
+          single Tool_voice runtime_handler; handle_voice forwards the
+          descriptor's internal_name into Agent_tool_voice_runtime, which
+          performs the per-tool name dispatch. *)
        | "keeper_tasks_list"
        | "keeper_tasks_audit"
        | "keeper_task_force_release"


### PR DESCRIPTION
## Summary

RFC-0179 PR-4 — coordination tool 8개 batch migration. descriptor coverage **10/286 → 18/286** (~3.5% → ~6.3%). 가장 큰 batch.

## Migrated tools (8)

| Tool | runtime_handler | Backend | Effect |
|---|---|---|---|
| `keeper_memory_write` | `Tool_memory_write` | Ocaml_runtime | Masc_coordination |
| `keeper_ide_annotate` | `Tool_ide_annotate` | Ocaml_runtime | Masc_coordination |
| `keeper_voice_speak` | `Tool_voice` | Remote_service | (external) |
| `keeper_voice_listen` | `Tool_voice` | Remote_service | (external) |
| `keeper_voice_agent` | `Tool_voice` | Remote_service | (external) |
| `keeper_voice_sessions` | `Tool_voice` | Remote_service | Read_only |
| `keeper_voice_session_start` | `Tool_voice` | Remote_service | (external) |
| `keeper_voice_session_end` | `Tool_voice` | Remote_service | (external) |

## Voice cluster: shared variant pattern

6 voice tool은 *단일* `Tool_voice` runtime_handler variant 공유. `Agent_tool_voice_runtime.handle_voice_tool ~meta ~name ~args`가 이미 name-dispatch 함. `handle_voice`가 descriptor의 `internal_name`을 forward.

→ runtime_handler enum 작게 유지하면서 descriptor list는 per-tool 성장 (각 voice tool이 독립 policy / schema / receipt evidence).

## Policy helpers extracted

PR-3의 `read_only_in_process_policy`에 이어 2개 추가:
- `coordination_write_in_process_policy` — memory_write / ide_annotate (Masc_coordination, writable, Policy_selected)
- `voice_external_in_process_policy` — voice_* (external service, no effect_domain pin, Remote_service backend)

## JSON output parity

각 migrated handler가 legacy chain이 호출한 *동일한* underlying 함수에 위임:
- `keeper_memory_write` → `Keeper_exec_memory.keeper_memory_write_json`
- `keeper_ide_annotate` → `Agent_tool_ide_runtime.handle_ide_annotate`
- `keeper_voice_*` → `Agent_tool_voice_runtime.handle_voice_tool`

agent-visible behavior 변경 0.

## Receipt observability

이전: legacy chain → receipt evidence 0건
이후: 8 tool 모두 route_evidence_json 자동 부착 (descriptor_id, executor=in_process, backend (ocaml_runtime/remote_service), visibility=hidden, effect_domain 등)

## Invariants

| Invariant | Status |
|---|---|
| `public_descriptors` 7 entries | ✅ 불변 |
| `internal_descriptors` | 3 → 10 (7 entries added, 6 voice share Tool_voice variant) |
| `Agent_tool_runtime.handle` executor exhaustive | ✅ |
| `test_alias_table_is_stable` 7 pin | ✅ 통과 |
| `test_cdal_tool_id` | ✅ 9/9 통과 |

## Verification

- `dune build --root . lib/` EXIT=0
- `test_keeper_tool_alias` 40/40 PASS
- `test_cdal_tool_id` 9/9 PASS

## Stacked on

#18693 (PR-3, open).

## Remaining (RFC-0179 잔여)

남은 legacy match arms (~18 tool):
- `keeper_tool_search` (1)
- `keeper_preflight_check` (1)
- `keeper_context_status` (needs ctx_work → context 확장 필요)
- `keeper_memory_search` (needs ctx_work)
- `keeper_library_search` / `keeper_library_read` (typed Tool_result.t branching)
- `keeper_task_*` cluster (9)
- `keeper_board_*` cluster (별도 dispatch path: `is_keeper_board_tool_name`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
