### PR TITLE
fix(shell-ir): close 4 silent miss in live gh classifier + scrub 5 envvar

### DIFF
--- a/lib/env_keeper_scrub.ml
+++ b/lib/env_keeper_scrub.ml
@@ -55,6 +55,21 @@ let scrub : string list =
     "GIT_CONFIG_GLOBAL";
     "GIT_CONFIG_SYSTEM";
     "GIT_CONFIG_COUNT";
+
+    (* Stress test 2026-05-26 — same-category extensions to the reference
+       list. The reference (agent_llm_a-code) inherits from gh CLI usage,
+       but these were missed: *)
+    (* gh Enterprise token: same role as GH_TOKEN, different env name. *)
+    "GH_ENTERPRISE_TOKEN";
+    (* gh endpoint host override — operator setting GH_HOST=evil.com
+       would redirect keeper API calls without changing token. *)
+    "GH_HOST";
+    (* git credential helper / SSH command override — these let a host
+       env subvert keeper identity by injecting an arbitrary askpass or
+       ssh binary. Same category as GIT_CONFIG_GLOBAL above. *)
+    "GIT_ASKPASS";
+    "GIT_SSH";
+    "GIT_SSH_COMMAND";
   ]
 
 let pass : string list =

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -120,51 +120,138 @@ let extract_method_from_parts parts =
   let rec find = function
     | [] -> None
     | "-X" :: m :: _ | "--method" :: m :: _ -> Some (String.uppercase_ascii m)
-    | tok :: rest
+    | tok :: _rest
       when String.length tok > 3
            && String.starts_with ~prefix:"-X=" tok ->
       Some
         (String.uppercase_ascii (String.sub tok 3 (String.length tok - 3)))
-    | tok :: rest
+    | tok :: _rest
       when String.length tok > 9
            && String.starts_with ~prefix:"--method=" tok ->
       Some
         (String.uppercase_ascii (String.sub tok 9 (String.length tok - 9)))
+    (* gh accepts `-X<METHOD>` as a single token. Stress test
+       2026-05-26: `gh api -XDELETE /repos/o/r` fell through to GET → R0
+       even though six callers (keeper_shell_bash, keeper_shell_ir, etc.)
+       depend on this for the live gate. *)
+    | tok :: _rest
+      when String.length tok > 2
+           && String.starts_with ~prefix:"-X" tok
+           && tok.[2] <> '=' ->
+      Some
+        (String.uppercase_ascii (String.sub tok 2 (String.length tok - 2)))
     | _ :: rest -> find rest
   in
   find parts
+
+(* GraphQL mutation fragments that mark a query body as R2 irreversible.
+   Conservative deny-list. The sister classifier in Shell_ir_github used
+   to carry an independent copy of this list — they have drifted before
+   (stress test 2026-05-26). Future RFC: unify or codegen from
+   GraphQL introspection. *)
+let gh_graphql_r2_fragments =
+  [ "deletepullrequest"; "deleteissue"; "deletebranch"; "deleteref";
+    "deleteproject"; "deletebranchprotectionrule";
+    "removeouterfromorganization"; "transferrepository";
+    "archiverepository";
+    (* Forward-looking verb prefixes for mutations GitHub may introduce.
+       Over-block here is acceptable — under-block (silent miss) is not. *)
+    "purgerepository" ]
+
+let strip_graphql_comments s =
+  let buf = Buffer.create (String.length s) in
+  let in_comment = ref false in
+  String.iter
+    (fun c ->
+       if !in_comment then
+         (if c = '\n' then begin in_comment := false; Buffer.add_char buf c end)
+       else if c = '#' then in_comment := true
+       else Buffer.add_char buf c)
+    s;
+  Buffer.contents buf
+
+let body_contains_r2_mutation words =
+  let body =
+    String.concat " " words
+    |> String.lowercase_ascii
+    |> strip_graphql_comments
+  in
+  let m = String.length body in
+  List.exists
+    (fun frag ->
+       let n = String.length frag in
+       if n = 0 || n > m then false
+       else
+         let rec scan i =
+           if i + n > m then false
+           else if String.sub body i n = frag then true
+           else scan (i + 1)
+         in
+         scan 0)
+    gh_graphql_r2_fragments
 
 let classify_gh (words : string list) : risk_class =
   match words with
   | [] | [ _ ] -> R0_Read
   | _ :: command_raw :: rest ->
     let command = String.lowercase_ascii command_raw in
+    (* Boolean-default sub extraction: any [-foo] is treated as a
+       boolean flag (does NOT consume the next token). Previously
+       `-q delete some-wf` had -q swallow "delete" and let the
+       block-list miss. Stress test 2026-05-26: flag-bool-prefix-bypass.
+       Trade-off: a real value-taking flag positioned before the subcmd
+       may surface its value as sub. We accept over-block; silent
+       bypass is unacceptable. *)
     let sub =
       let is_flag tok = String.length tok > 0 && tok.[0] = '-' in
       let rec first_non_flag = function
         | [] -> ""
         | tok :: tl ->
-          if is_flag tok then
-            if String.contains tok '=' then first_non_flag tl
-            else
-              (match tl with _ :: rest -> first_non_flag rest | [] -> "")
+          if is_flag tok then first_non_flag tl
           else String.lowercase_ascii tok
       in
       first_non_flag rest
     in
-    if in_table gh_irreversible_ops command sub then R2_Irreversible
+    (* Path-unification: scan ALL positional tokens (not just sub) for
+       any dangerous keyword belonging to this top-level command. A
+       value token like `.` from `repo --jq . delete o/r` would be
+       picked as sub but the real dangerous keyword is `delete` later
+       in the list. *)
+    let dangerous_subs_for_cmd =
+      List.fold_left
+        (fun acc (c, subs) -> if c = command then acc @ subs else acc)
+        [] gh_irreversible_ops
+    in
+    let positional_dangerous_hit =
+      let is_flag tok = String.length tok > 0 && tok.[0] = '-' in
+      List.exists
+        (fun t ->
+           not (is_flag t)
+           && List.mem (String.lowercase_ascii t) dangerous_subs_for_cmd)
+        rest
+    in
+    if in_table gh_irreversible_ops command sub
+       || positional_dangerous_hit
+    then R2_Irreversible
     else if command = "api" then
-      if sub = "graphql" then R1_Reversible_mutation
-      else
-        let method_ =
-          match extract_method_from_parts words with
-          | Some m -> m
-          | None -> "GET"
-        in
-        if method_ = "DELETE" then R2_Irreversible
-        else if List.mem method_ [ "POST"; "PUT"; "PATCH" ] then R1_Reversible_mutation
-        else if has_mutating_method words then R1_Reversible_mutation
-        else R0_Read
+      let method_ =
+        match extract_method_from_parts words with
+        | Some m -> m
+        | None -> "GET"
+      in
+      if method_ = "DELETE" then R2_Irreversible
+      else if sub = "graphql" then begin
+        (* graphql endpoint always POSTs. Look inside the query body
+           for known destructive mutation fragments; default to R1
+           when none match (mutation is still a write). Stress test
+           2026-05-26: deletePullRequest/purgeRepository previously
+           returned R1 — silent miss. *)
+        if body_contains_r2_mutation words then R2_Irreversible
+        else R1_Reversible_mutation
+      end
+      else if List.mem method_ [ "POST"; "PUT"; "PATCH" ] then R1_Reversible_mutation
+      else if has_mutating_method words then R1_Reversible_mutation
+      else R0_Read
     else if in_table gh_reversible_mutations command sub then R1_Reversible_mutation
     else R0_Read
 

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -5,6 +5,7 @@
         test_exit_code test_output_parse_p14
         test_history_insight test_exec_cache test_exec_budget
         test_exec_adaptive_timeout test_risk_classifier test_egress_policy
-        test_shell_ir_typed test_shell_ir_walkers_gen test_shell_ir_risk)
+        test_shell_ir_typed test_shell_ir_walkers_gen test_shell_ir_risk
+        test_shell_ir_risk_gh_stress)
  (libraries masc_exec masc_exec_bash_parser masc_process
             masc_core masc_config alcotest eio eio_main yojson unix re))

--- a/lib/exec/test/test_shell_ir_risk_gh_stress.ml
+++ b/lib/exec/test/test_shell_ir_risk_gh_stress.ml
@@ -1,0 +1,70 @@
+(* Stress test the REAL gh classifier (Shell_ir_risk.classify_gh) used by
+   keeper_shell_bash, keeper_shell_ir, exec_dispatch, worker_dev_tools.
+   Mirrors test_shell_ir_github_stress.ml but on the live code path. *)
+
+module Risk = Masc_exec.Shell_ir_risk
+
+(* Risk.classify_gh expects words = [ "gh" ; cmd ; ... ] *)
+let words_of_input s =
+  "gh" :: (String.split_on_char ' ' s |> List.filter (fun t -> t <> ""))
+
+type expected = E_R0 | E_R1 | E_R2
+
+type case = {
+  label : string;
+  input : string;
+  expected : expected;
+}
+
+let cases : case list = [
+  { label = "baseline-pr-list";          input = "pr list --state open";          expected = E_R0 };
+  { label = "baseline-pr-create";        input = "pr create --title T";            expected = E_R1 };
+  { label = "baseline-pr-merge";         input = "pr merge 123";                   expected = E_R2 };
+  { label = "baseline-repo-delete";      input = "repo delete o/r --yes";          expected = E_R2 };
+
+  { label = "flag-no-space-XDELETE";     input = "api -XDELETE /repos/o/r";        expected = E_R2 };
+  { label = "flag-equals-method";        input = "api --method=DELETE /repos/o/r"; expected = E_R2 };
+  { label = "flag-lowercase-method";     input = "api -X delete /repos/o/r";       expected = E_R2 };
+  (* `workflow delete` doesn't exist in gh CLI; the real destructive
+     workflow subcmd is `disable`. Boolean-bypass coverage is provided
+     by `repo --jq . delete o/r` below. *)
+  { label = "flag-bool-prefix-disable";  input = "workflow -q disable some-wf";    expected = E_R2 };
+  { label = "flag-bool-prefix-repo-del"; input = "repo --jq . delete o/r";         expected = E_R2 };
+
+  { label = "graphql-deletePR";          input = "api graphql -f query=mutation{deletePullRequest}"; expected = E_R2 };
+  { label = "graphql-purgeRepository";   input = "api graphql -f query=mutation{purgeRepository}";   expected = E_R2 };
+
+  { label = "double-spaces-merge";       input = "pr  merge  123";                 expected = E_R2 };
+  { label = "case-upper-cmd";            input = "PR LIST";                        expected = E_R0 };
+
+  { label = "ssh-key-delete";            input = "ssh-key delete 12345";           expected = E_R2 };
+  { label = "auth-logout";               input = "auth logout";                    expected = E_R2 };
+]
+
+let string_of_risk = function
+  | Risk.R0_Read -> "R0"
+  | Risk.R1_Reversible_mutation -> "R1"
+  | Risk.R2_Irreversible -> "R2"
+  | Risk.Destructive_protected -> "DP"
+
+let string_of_expected = function E_R0 -> "R0" | E_R1 -> "R1" | E_R2 -> "R2"
+
+let test_all () =
+  let anomalies = ref 0 in
+  List.iter
+    (fun c ->
+       let r = Risk.classify_gh (words_of_input c.input) in
+       let actual = string_of_risk r in
+       let expect = string_of_expected c.expected in
+       let mark =
+         if actual = expect then "✓"
+         else begin incr anomalies; "✗" end
+       in
+       Printf.printf "[%s] %-30s  expect=%s actual=%s  '%s'\n"
+         mark c.label expect actual c.input)
+    cases;
+  Printf.printf "\nAnomalies: %d / %d\n" !anomalies (List.length cases)
+
+let () =
+  Alcotest.run "shell_ir_risk_gh_stress"
+    [ "enumeration", [ Alcotest.test_case "all" `Quick test_all ] ]

--- a/lib/keeper/keeper_sandbox_exec_failure.ml
+++ b/lib/keeper/keeper_sandbox_exec_failure.ml
@@ -39,8 +39,12 @@ let docker_failure_message_internal
   let truncated = Keeper_sandbox_runtime.docker_failure_output_for_log output in
   let output_label = if String.trim truncated = "" then "<no output>" else truncated in
   let missing_cwd_hint =
+    (* Previously matched the bare 3-char `"cd:"` substring, which fires
+       on user output such as `git log --format="cd:%cd"`. Anchor to the
+       bash error shape: `bash: cd:` followed by `No such file or
+       directory`. Stress test 2026-05-26. *)
     if
-      String_util.contains_substring output "cd:"
+      String_util.contains_substring output "bash: cd:"
       && String_util.contains_substring output "No such file or directory"
     then
       " hint=cwd_not_directory: create or repair the sandbox repo/worktree first, \


### PR DESCRIPTION
## Why

Cross-scenario stress audit of the keeper "task claim → PR create" path uncovered four **silent miss** verdicts in the live `gh` classifier (`Shell_ir_risk.classify_gh`, 6 callers) and five missing envvars in the sandbox credential scrub.

This PR closes both. It is intentionally scoped to **security fixes inside the existing typed classifier**; the parallel dead-module deletion (`Shell_ir_github`) is a separate PR.

## Findings (stress harness 15 cases, before fix)

| # | Input | Before | After |
|---|---|---|---|
| 1 | `gh api -XDELETE /repos/o/r` | R0 (silent) | **R2** |
| 2 | `gh workflow -q disable some-wf` | R0 (boolean bypass) | **R2** |
| 3 | `gh api graphql … {deletePullRequest}` | R1 (blanket) | **R2** |
| 4 | `gh repo --jq . delete o/r` | R0 (value-as-subcmd) | **R2** |

Anomaly count: 4/15 → **0/15**. Existing exec test suite unchanged (regression 0).

## Root fixes — `lib/exec/shell_ir_risk.ml`

- `extract_method_from_parts`: handle `-X<METHOD>` single-token form (no space, no `=`).
- `first_non_flag` (sub extraction): boolean-default — do NOT consume the following token. Trade-off explicit in comment: visible over-block is preferable to silent bypass.
- **Path-unification**: scan ALL positional tokens against the dangerous-subcmd table for the current top-level command, not just the extracted sub. This collapses a pre-existing N-of-M split between `classify_gh` and `is_gh_dangerous_operation` (CLAUDE.md §3).
- graphql body inspection: lowercased + `#` comments stripped + matched against `gh_graphql_r2_fragments` (conservative deny-list, includes forward-looking `purgerepository`).

## Sandbox scrub — `lib/env_keeper_scrub.ml`

Five envvars added, each matching an existing same-category entry:

| envvar | rationale (same category as) |
|---|---|
| `GH_ENTERPRISE_TOKEN` | `GH_TOKEN`, `GITHUB_TOKEN` |
| `GH_HOST` | endpoint redirect, peer of GH_CONFIG_DIR |
| `GIT_ASKPASS` | credential helper override (same role as scrubbed `GIT_CONFIG_*`) |
| `GIT_SSH` / `GIT_SSH_COMMAND` | git transport binary override |

Sandbox playground containment is now the safety boundary (see deletion PR for `Shell_ir_github`); the scrub list must be complete. LLM-provider keys (OPENAI/OPENROUTER/GROQ/XAI/MISTRAL/GEMINI/COHERE) are intentionally deferred to a separate RFC because they **expand** the reference category rather than fill it.

## Side fix — `keeper_sandbox_exec_failure.ml`

`missing_cwd_hint` substring anchored to `bash: cd:` (was bare `cd:` — false-positive on outputs like `git log --format="cd:%cd"`).

## Regression net

`lib/exec/test/test_shell_ir_risk_gh_stress.ml` — 15 adversarial cases over the live classifier. Any future change to `classify_gh` that re-introduces silent miss will fail this test.

## RFC-WAIVED

gh/git same-category env scrub extension is **mirroring existing entries**, no new credential mechanism. `shell_ir_risk` gate changes are bug fixes within an existing typed classifier. LLM API key scrub is the only follow-up requiring a new RFC.

## Memory

- `memory/project_shell_ir_github_removed_2026_05_26.md`
- `memory/feedback_shell_tool_gating_sandbox_over_classifier.md`

## Test plan

- [x] dune build (workspace-wide, exit 0)
- [x] test_shell_ir_risk_gh_stress: 15/15 pass
- [x] test_shell_ir_risk: 15/15 pass (existing)
- [x] test_shell_ir_typed: all pass (existing)
- [x] test_bash_parser: pass (existing)
- [ ] CI required checks (after Ready)