### PR TITLE
fix(keeper): reserve provider retry budget

### DIFF
--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -55,6 +55,11 @@ val provider_timeout_guard_sec : float
 val min_provider_timeout_budget_sec : float
 (** Minimum provider timeout budget (seconds). *)
 
+val first_attempt_degraded_retry_reserve_sec : float
+(** Wall-clock reserve kept from non-retry attempts so one degraded
+    retry can still satisfy [provider_timeout_guard_sec] +
+    [min_provider_timeout_budget_sec]. *)
+
 val sdk_error_kind : Agent_sdk.Error.sdk_error -> string
 
 type provider_timeout_budget = {
@@ -77,12 +82,10 @@ val resolve_bounded_provider_timeout_budget_with_turn_budget :
   max_turns:int ->
   remaining_turn_budget_s:float ->
   provider_timeout_budget option
-(** RFC-0129: the [reserve_degraded_retry_budget] knob was removed
-    (2026-05-18). The first-attempt branch now hands the full usable
-    budget to [max_execution_time_s]; the keeper turn timeout still
-    bounds the outer loop, and OAS 0.195.0+ enforces a per-HTTP cap
-    via [body_timeout_s] / per-stream-line cap via
-    [stream_idle_timeout_s]. *)
+(** Resolves the per-provider timeout inside the outer keeper turn
+    budget. Non-retry attempts keep a small degraded-retry reserve when
+    the remaining wall-clock budget is large enough; retry attempts use
+    the remaining per-attempt or one-shot degraded wall-clock budget. *)
 
 val allow_wall_clock_retry_budget_for_attempt :
   is_retry:bool ->

--- a/lib/keeper/keeper_turn_cascade_budget_provider_timeout.ml
+++ b/lib/keeper/keeper_turn_cascade_budget_provider_timeout.ml
@@ -35,6 +35,10 @@ let provider_timeout_guard_sec = 15.0
 
 let min_provider_timeout_budget_sec = 15.0
 
+let first_attempt_degraded_retry_reserve_sec =
+  provider_timeout_guard_sec +. min_provider_timeout_budget_sec
+;;
+
 type provider_timeout_budget = {
   effective_timeout_sec : float;
   adaptive_timeout_sec : float;
@@ -105,8 +109,15 @@ let resolve_bounded_provider_timeout_budget_with_turn_budget
     if usable_budget < min_provider_timeout_budget_sec
     then None
     else
+      let effective_budget_ceiling =
+        if
+          usable_budget
+          >= min_provider_timeout_budget_sec +. first_attempt_degraded_retry_reserve_sec
+        then usable_budget -. first_attempt_degraded_retry_reserve_sec
+        else usable_budget
+      in
       let effective_timeout_sec =
-        Float.min adaptive_timeout_sec usable_budget
+        Float.min adaptive_timeout_sec effective_budget_ceiling
       in
       let capped_by_turn_budget =
         effective_timeout_sec < adaptive_timeout_sec

--- a/lib/keeper/keeper_turn_cascade_budget_provider_timeout.mli
+++ b/lib/keeper/keeper_turn_cascade_budget_provider_timeout.mli
@@ -1,5 +1,6 @@
 val provider_timeout_guard_sec : float
 val min_provider_timeout_budget_sec : float
+val first_attempt_degraded_retry_reserve_sec : float
 
 type provider_timeout_budget = {
   effective_timeout_sec : float;

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -25,8 +25,8 @@ val resolve_bounded_provider_timeout_budget_with_turn_budget
   -> max_turns:int
   -> remaining_turn_budget_s:float
   -> provider_timeout_budget option
-(** RFC-0129: see [Keeper_turn_cascade_budget] for the rationale
-    behind removing the [reserve_degraded_retry_budget] knob. *)
+(** See [Keeper_turn_cascade_budget] for first-attempt retry reserve and
+    retry-attempt budget semantics. *)
 
 (** Per-attempt watchdog used around the OAS call. It fires before the
     enclosing keeper-turn wall-clock timeout so recoverable provider stalls can

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7934,7 +7934,11 @@ let test_bounded_oas_timeout_caps_to_remaining_turn_budget () =
       ~remaining_turn_budget_s:235.7
   with
   | Some timeout_s ->
-    check (float 0.01) "remaining budget cap leaves finalization guard" 220.7 timeout_s
+    check
+      (float 0.01)
+      "remaining budget cap leaves finalization guard and degraded retry reserve"
+      190.7
+      timeout_s
   | None -> fail "expected bounded timeout"
 ;;
 
@@ -7960,14 +7964,7 @@ let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
   | None -> fail "expected bounded timeout"
 ;;
 
-(* RFC-0129 (2026-05-18): renamed from
-   [test_bounded_oas_timeout_reserves_degraded_retry_budget]. The
-   reserve_fraction band-aid was halving the first-attempt budget.
-   With the knob removed, the first attempt now receives the full
-   [Float.min adaptive_timeout_sec usable_budget]. The default adaptive
-   cap is 300s inside the 600s keeper turn envelope so cascade fallback
-   still has headroom. *)
-let test_bounded_oas_timeout_first_attempt_uses_full_usable_budget () =
+let test_bounded_oas_timeout_first_attempt_preserves_degraded_retry_budget () =
   match
     UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
@@ -7979,8 +7976,8 @@ let test_bounded_oas_timeout_first_attempt_uses_full_usable_budget () =
   | Some budget ->
     check
       (float 0.01)
-      "first attempt receives usable_budget (remaining - guard) after RFC-0156"
-      485.0
+      "first attempt reserves one degraded retry floor"
+      455.0
       budget.effective_timeout_sec;
     check
       (float 0.01)
@@ -7992,6 +7989,29 @@ let test_bounded_oas_timeout_first_attempt_uses_full_usable_budget () =
       "source records turn_budget_capped when usable_budget < adaptive after RFC-0156"
       "turn_budget_capped"
       budget.source
+  | None -> fail "expected bounded timeout"
+;;
+
+let test_bounded_oas_timeout_near_turn_limit_preserves_retry_tail () =
+  match
+    UT.resolve_bounded_provider_timeout_budget_with_turn_budget
+      ~allow_wall_clock_retry_budget:false
+      ~is_retry:false
+      ~estimated_input_tokens:8_287
+      ~max_turns:4
+      ~remaining_turn_budget_s:600.0
+  with
+  | Some budget ->
+    check
+      (float 0.01)
+      "600s turn leaves 30s retry tail after first attempt watchdog"
+      555.0
+      budget.effective_timeout_sec;
+    check
+      (float 0.01)
+      "watchdog fires with retry tail left"
+      570.0
+      (UT.attempt_watchdog_timeout_sec ~remaining_turn_budget_s:600.0 budget)
   | None -> fail "expected bounded timeout"
 ;;
 
@@ -8112,12 +8132,7 @@ let test_rfc_0156_effective_tracks_remaining_budget () =
       budget.effective_timeout_sec
 ;;
 
-(* RFC-0129: renamed from [test_attempt_watchdog_preserves_degraded_retry_reserve].
-   With the reserve_fraction gone, the watchdog now bounds the full
-   effective attempt timeout plus the OAS guard — capped by
-   remaining_turn_budget_s - 1s outer reserve, not by a halved retry
-   slice. *)
-let test_attempt_watchdog_uses_full_usable_budget () =
+let test_attempt_watchdog_preserves_degraded_retry_reserve () =
   match
     UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
@@ -8129,9 +8144,8 @@ let test_attempt_watchdog_uses_full_usable_budget () =
   | Some budget ->
     check
       (float 0.01)
-      "attempt watchdog = min(effective+guard, remaining-outer_reserve) \
-       = min(500, 499) = 499 after RFC-0156 (effective = usable_budget)"
-      499.0
+      "attempt watchdog leaves degraded retry reserve"
+      470.0
       (UT.attempt_watchdog_timeout_sec ~remaining_turn_budget_s:500.0 budget)
   | None -> fail "expected bounded timeout"
 ;;
@@ -11593,15 +11607,18 @@ let () =
             "bounded OAS timeout respects channel turn budget override"
             `Quick
             test_bounded_oas_timeout_uses_channel_turn_budget_override
-        ; test_case
-            "bounded OAS timeout first attempt uses full usable budget \
-             (RFC-0129: no reserve_fraction)"
-            `Quick
-            test_bounded_oas_timeout_first_attempt_uses_full_usable_budget
-        ; test_case
-            "attempt watchdog uses full usable budget (RFC-0129)"
-            `Quick
-            test_attempt_watchdog_uses_full_usable_budget
+          ; test_case
+              "bounded OAS timeout first attempt preserves degraded retry reserve"
+              `Quick
+              test_bounded_oas_timeout_first_attempt_preserves_degraded_retry_budget
+          ; test_case
+              "bounded OAS timeout near turn limit preserves retry tail"
+              `Quick
+              test_bounded_oas_timeout_near_turn_limit_preserves_retry_tail
+          ; test_case
+              "attempt watchdog preserves degraded retry reserve"
+              `Quick
+              test_attempt_watchdog_preserves_degraded_retry_reserve
         ; test_case
             "attempt watchdog fires before outer turn timeout"
             `Quick


### PR DESCRIPTION
## Summary
- reserve one degraded retry floor before non-retry provider attempts consume the keeper turn budget
- keep 600s turns from spending ~599s on the first attempt and skipping degraded fallback
- update bounded provider-timeout/watchdog regression tests

## Verification
- ocamlformat --enable-outside-detected-project --check lib/keeper/keeper_turn_cascade_budget_provider_timeout.ml lib/keeper/keeper_turn_cascade_budget_provider_timeout.mli lib/keeper/keeper_turn_cascade_budget.mli lib/keeper/keeper_unified_turn.mli test/test_keeper_unified.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_unified.exe test --color=never --quick-tests transient_network_error 50-54