### PR TITLE
fix(test): alias Masc_mcp.Tool_shard_types_schemas_bash

### DIFF
--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -7,6 +7,7 @@
     Pure synchronous tests — no Eio or network required. *)
 
 module Tool_shard = Masc_mcp.Tool_shard
+module Tool_shard_types_schemas_bash = Masc_mcp.Tool_shard_types_schemas_bash
 module Types = Masc_domain
 
 let get_json_assoc key = function


### PR DESCRIPTION
## Problem

`dune build --root .` from main fails:

```
File "test/test_tool_shard_coverage.ml", line 130, characters 6-35:
130 |     @ Tool_shard_types_schemas_bash.typed_execute_tools
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound module Tool_shard_types_schemas_bash
```

## Root cause

`lib/dune` declares `(library (name masc_mcp))` without `(wrapped false)`, so externally the modules must be referenced as `Masc_mcp.X`. The test file uses explicit aliasing for that wrapping:

```ocaml
module Tool_shard = Masc_mcp.Tool_shard      (* line 9 *)
module Types = Masc_domain                    (* line 10 *)
```

Two call sites reference `Tool_shard_types_schemas_bash.typed_execute_tools` (line 130 and line 418), but no matching `module Tool_shard_types_schemas_bash = Masc_mcp.Tool_shard_types_schemas_bash` alias exists at the top of the file.

Recent refactor history on this test (`#18681`, `#18520`) reshaped neighbouring assertions without updating the alias list. The `Tool_shard_types_schemas_bash` references survived without being aliased.

## Change

```diff
 module Tool_shard = Masc_mcp.Tool_shard
+module Tool_shard_types_schemas_bash = Masc_mcp.Tool_shard_types_schemas_bash
 module Types = Masc_domain
```

One line — same explicit-alias pattern as the existing `Tool_shard` line directly above it.

## Verification

- `dune build --root .` (full tree): exit 0
- The previously-failing test executable compiles
- No other changes (1 file, 1 insertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
