### PR TITLE
feat(agent-tool): log internal descriptor route evidence

### DIFF
--- a/lib/keeper_tool_call_log_route_evidence.ml
+++ b/lib/keeper_tool_call_log_route_evidence.ml
@@ -121,7 +121,7 @@ let descriptor_for_tool_name tool_name =
     (match Keeper_tool_alias.canonical_internal_name tool_name with
      | None -> None
      | Some internal_name ->
-       (match Agent_tool_descriptor.public_descriptors_for_internal internal_name with
+       (match Agent_tool_descriptor.descriptors_for_internal internal_name with
         | descriptor :: _ -> Some descriptor
         | [] -> None))
 ;;

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -574,6 +574,48 @@ let test_route_evidence_records_descriptor_for_filesystem_calls () =
         (Safe_ops.json_string_opt "sandbox" evidence)
     | _ -> Alcotest.fail "expected exactly one entry")
 
+let test_route_evidence_records_internal_descriptor () =
+  with_tmp_log (fun () ->
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"executor"
+      ~tool_name:"keeper_time_now"
+      ~input:(`Assoc [])
+      ~output_text:
+        {|{"ok":true,"iso":"2026-05-26T00:00:00Z","epoch":1780000000}|}
+      ~success:true
+      ~duration_ms:1.0
+      ();
+    let entries = Keeper_tool_call_log.read_recent ~n:1 () in
+    Alcotest.(check int) "entry persisted" 1 (List.length entries);
+    match entries with
+    | [ entry ] ->
+      let evidence = Yojson.Safe.Util.member "route_evidence" entry in
+      Alcotest.(check (option string)) "tool name"
+        (Some "keeper_time_now")
+        (Safe_ops.json_string_opt "tool_name" evidence);
+      Alcotest.(check (option string)) "descriptor id"
+        (Some "keeper.time.now")
+        (Safe_ops.json_string_opt "descriptor_id" evidence);
+      Alcotest.(check (option string)) "public name"
+        (Some "keeper_time_now")
+        (Safe_ops.json_string_opt "public_name" evidence);
+      Alcotest.(check (option string)) "canonical name"
+        (Some "keeper_time_now")
+        (Safe_ops.json_string_opt "canonical_name" evidence);
+      Alcotest.(check (option string)) "executor"
+        (Some "in_process")
+        (Safe_ops.json_string_opt "executor" evidence);
+      Alcotest.(check (option string)) "backend"
+        (Some "ocaml_runtime")
+        (Safe_ops.json_string_opt "backend" evidence);
+      Alcotest.(check (option string)) "sandbox"
+        (Some "none")
+        (Safe_ops.json_string_opt "sandbox" evidence);
+      Alcotest.(check (option string)) "runtime handler"
+        (Some "tool_time_now")
+        (Safe_ops.json_string_opt "runtime_handler" evidence)
+    | _ -> Alcotest.fail "expected exactly one entry")
+
 let test_non_object_input_still_logs_action_radius () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
@@ -1025,6 +1067,8 @@ let () =
             test_route_evidence_stored_for_blob_backed_git_push
         ; eio_test "route evidence records descriptor for filesystem calls"
             test_route_evidence_records_descriptor_for_filesystem_calls
+        ; eio_test "route evidence records internal descriptor"
+            test_route_evidence_records_internal_descriptor
         ; eio_test "non-object input still logs action radius"
             test_non_object_input_still_logs_action_radius
         ; eio_test "dashboard aggregate groups runtime fields"


### PR DESCRIPTION
## Summary
- resolve tool-call route evidence through all Agent_tool_descriptor entries, not only public descriptor aliases
- record descriptor route evidence for internal descriptor-backed tools such as keeper_time_now
- add regression coverage for descriptor id, executor, backend, sandbox, and runtime handler in tool-call JSONL

## Verification
- ocamlformat --check lib/keeper_tool_call_log_route_evidence.ml test/test_keeper_tool_call_log.ml
- git diff --check origin/main...HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build ./test/test_keeper_tool_call_log.exe
- ./_build/default/test/test_keeper_tool_call_log.exe