### PR TITLE
refactor(tools): purge legacy code worktree tool residues

### DIFF
--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -85,7 +85,7 @@ keeper's missing PR until the Agent.run timeout. The review prompt reserves
 `Execute` for read-only GitHub inspection. Keepers are instructed to report
 `target_pr_missing` after one failed branch lookup instead of polling in a loop.
 Keepers must create/use the exact run-scoped branch produced by
-`masc_worktree_create task_id=<run_id>`:
+`Execute executable="git" argv=["worktree", ...]`:
 `keeper-<keeper>-agent/<run_id>`. They must write the proof file
 `docs/runtime-proof/keepers/<keeper>-<run_id>.md`; older proof branches or
 worktrees do not count. This branch convention matches the runtime worktree

--- a/docs/KEEPER-SHELL-QUALITY-LEAKS.md
+++ b/docs/KEEPER-SHELL-QUALITY-LEAKS.md
@@ -24,8 +24,8 @@ Adjacent tool-surface sample from the same 240h window:
 
 | Tool | Failed | OK | Failure rate |
 |---|---:|---:|---:|
-| `masc_code_shell` | 1,643 | 6,340 | 20.58% |
-| `masc_code_edit` | 119 | 51 | 70.00% |
+| legacy code-shell surface | 1,643 | 6,340 | 20.58% |
+| legacy code-edit surface | 119 | 51 | 70.00% |
 | `tool_search_files` | 166 | 399 | 29.38% |
 | `tool_execute` | 174 | 948 | 15.51% |
 | public `EditFile` | 41 | 15 | 73.21% |
@@ -53,7 +53,7 @@ Adjacent tool-surface sample from the same 240h window:
 
 ## Adjacent Surface Fixes
 
-`masc_code_shell` had a separate allowlist from `tool_execute`, so safe inspection
+The retired code-shell surface had a separate allowlist from `tool_execute`, so safe inspection
 commands could fail even when the same read shape was accepted elsewhere. The
 top observed adjacent class was `command_not_allowed`; code shell now reuses the
 `Dev_exec_allowlist.dev` SSOT plus its tool-specific extras, so commands such as
@@ -66,7 +66,7 @@ indirectly: those paths inlined review prose into a shell command, so markdown,
 globs, quotes, or code snippets could be classified by the wrong layer before
 `gh` ran.
 
-`masc_code_edit`, public `EditFile`, and public `WriteFile` showed a separate writable
+The retired code-edit surface, public `EditFile`, and public `WriteFile` showed a separate writable
 path leak: `repos/<repo>/...` already mapped to the keeper's own playground, but
 repo-top paths such as `lib/foo.ml` were interpreted against the root checkout
 and then blocked as outside the writable sandbox. When exactly one repo exists
@@ -94,7 +94,7 @@ scripts/analyze-keeper-execute-failures.sh /Users/dancer/me 240
 
 The same command now emits both the Execute-specific census and a
 `[surface summary]`/`[surface failure categories]` section for
-`tool_execute`, `tool_search_files`, `masc_code_shell`, `masc_code_edit`, and public
+`tool_execute`, `tool_search_files`, the retired code-shell/code-edit surfaces, and public
 `EditFile`/`WriteFile`, plus the PR review read/comment/reply surfaces that showed the
 same path-syntax leak. This lets the `<10%` target be checked across the related
 shell, code-edit, and review surfaces after the PR is merged and a fresh runtime

--- a/docs/MASC-V2-DESIGN.md
+++ b/docs/MASC-V2-DESIGN.md
@@ -225,8 +225,6 @@ CASPER의 실용적 조언에 따라 최소 기능부터 시작:
 ### Must Have
 - [x] `masc_init` - 룸 초기화
 - [x] `masc_join` - 에이전트 참여 (capabilities 포함)
-- [ ] `masc_worktree_create` - Worktree 생성 래퍼
-- [ ] `masc_worktree_remove` - Worktree 정리
 - [x] `masc_broadcast` - 메시지 브로드캐스트
 - [x] `masc_status` - 상태 조회
 

--- a/docs/MCP-SURFACE-AUDIT.md
+++ b/docs/MCP-SURFACE-AUDIT.md
@@ -96,7 +96,7 @@ flowchart LR
   Start[masc_start] --> Status[masc_status]
   Status --> Claim[masc_transition or masc_claim_next]
   Claim --> Plan[masc_plan_set_task when needed]
-  Plan --> Worktree[masc_worktree_create]
+  Plan --> Worktree[Execute: git worktree]
   Worktree --> Heartbeat[masc_heartbeat]
   Heartbeat --> Done[masc_transition done]
 ```

--- a/docs/design/keeper-tool-runtime-boundary-plan.html
+++ b/docs/design/keeper-tool-runtime-boundary-plan.html
@@ -624,21 +624,21 @@
           <tr>
             <td data-label="Task">T28</td>
             <td data-label="Goal">Typed Bash telemetry axis</td>
-            <td data-label="Todo">Move PR-work shell command extraction for public <code>Bash</code>, internal <code>keeper_bash</code>, and <code>masc_code_shell</code> into <code>Keeper_tool_capability_axis</code>.</td>
+            <td data-label="Todo">Move PR-work shell command extraction for public <code>Bash</code>, internal <code>keeper_bash</code>, and the retired code-shell surface into <code>Keeper_tool_capability_axis</code>.</td>
             <td data-label="Verification Method"><code>./_build/default/test/test_keeper_hooks_oas_telemetry.exe</code>, <code>./_build/default/test/test_keeper_sandbox_boundary_policy.exe</code></td>
             <td data-label="Exit Criteria">Telemetry recognizes public <code>Bash executable="gh"</code> typed argv for PR creation without local field maps in OAS output parsing.</td>
           </tr>
           <tr>
             <td data-label="Task">T29</td>
             <td data-label="Goal">Code shell Exec_program axis</td>
-            <td data-label="Todo">Retire the <code>masc_code_shell</code> compatibility allowlist instead of preserving a parallel code-shell executable surface.</td>
+            <td data-label="Todo">Retire the code-shell compatibility allowlist instead of preserving a parallel executable surface.</td>
             <td data-label="Verification Method"><code>./_build/default/test/test_keeper_bash_safety.exe</code>, <code>./_build/default/test/test_tool_code_write_coverage.exe</code></td>
             <td data-label="Exit Criteria">Only the remaining dev/read-only allowlists are derived from typed <code>Masc_exec.Exec_program</code> values.</td>
           </tr>
           <tr>
             <td data-label="Task">T30</td>
             <td data-label="Goal">Code shell dispatch axis</td>
-            <td data-label="Todo">Route <code>masc_code_shell</code> raw coding-command validation and Shell IR execution through <code>Keeper_shell_ir</code> while preserving its no-redirect policy.</td>
+            <td data-label="Todo">Route retired code-shell raw command validation and Shell IR execution through <code>Keeper_shell_ir</code> while preserving its no-redirect policy.</td>
             <td data-label="Verification Method"><code>./_build/default/test/test_worker_dev_tools.exe</code>, <code>./_build/default/test/test_tool_code_write_coverage.exe</code></td>
             <td data-label="Exit Criteria"><code>tool_code_write_shell_validate.ml</code> no longer owns <code>Exec_policy.command_context_coding_with_allowlist</code>, <code>tool_code_write.ml</code> no longer calls <code>Exec_policy.validate_shell_ir_paths</code> or <code>Exec_dispatch.dispatch_decided</code> directly, and the facade receives <code>redirect_allowed=false</code>.</td>
           </tr>
@@ -676,7 +676,7 @@
         <div class="command">rg -n "visible shell/GitHub CLI path|visible shell/GitHub path|shell/GitHub CLI path" config/prompts docs/KEEPER-CAPABILITY-MATRIX.md docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh lib/keeper test</div>
         <div class="command">bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh</div>
         <div class="command">python3 -m py_compile scripts/audit-keeper-fleet-readiness.py</div>
-        <div class="command">rg -n "keeper_shell&quot;; &quot;keeper_bash&quot;; &quot;masc_code_shell|List\.mem tool_name \[ ?&quot;masc_code_git&quot;; &quot;keeper_bash&quot;; &quot;masc_code_shell&quot;" lib/keeper/keeper_contract_classifier.ml lib/keeper/keeper_hooks_oas_pr_metrics.ml</div>
+        <div class="command">rg -n "keeper_shell&quot;; &quot;keeper_bash&quot;; retired-code-shell" lib/keeper/keeper_contract_classifier.ml lib/keeper/keeper_hooks_oas_pr_metrics.ml</div>
         <div class="command">rg -n "Tool_name\\.of_string|Keeper_tool_alias\\.route|Keeper_tool_alias\\.public_masc_to_internal|Masc_exec\\.Exec_program\\.of_string|typed_bash_stage_class|String_util\\.contains_substring_ci" lib/tool_resource_gate.ml</div>
         <div class="command">rg -n "String_util\\.contains_substring_ci" lib/tool_resource_axis.ml</div>
         <div class="command">./_build/default/test/test_ci_hardening_source.exe</div>

--- a/docs/design/keeper-tool-runtime-boundary-plan.md
+++ b/docs/design/keeper-tool-runtime-boundary-plan.md
@@ -306,12 +306,12 @@ and public tool aliases.
    - `Keeper_tool_capability_axis.shell_command_input_candidates` now owns
      command extraction for PR-work shell-capable tools, including public
      `Bash` typed `executable`/`argv`, legacy `keeper_bash` `cmd` telemetry
-     fallback, and `masc_code_shell` `command`.
+     fallback, and the retired code-shell `command` field.
    - `Keeper_hooks_oas_output_json` no longer maps shell-capable tool names
      to local command-field strings; PR-work metrics consume command
      candidates from the semantic capability axis.
    Continued in slice 31:
-   - `Masc_exec.Exec_program` owned the `masc_code_shell`-only executable extras
+   - `Masc_exec.Exec_program` owned the retired code-shell executable extras
      during the migration, and the later legacy code-tool purge removed that
      compatibility surface instead of preserving a parallel allowlist.
    Continued in slice 32:
@@ -319,10 +319,10 @@ and public tool aliases.
      knobs that used to be hardcoded for keeper Bash: caller attribution, pipe
      allowance, redirect allowance, and optional keeper/base path scope.
    - `Keeper_shell_ir.coding_command_context` now owns legacy raw coding
-     command parse/validation before dispatch, so `masc_code_shell` no longer
+     command parse/validation before dispatch, so the retired code-shell no longer
      calls the coding command-context gate directly from
      `tool_code_write_shell_validate`.
-   - `masc_code_shell` now routes parsed Shell IR through
+   - The retired code-shell now routes parsed Shell IR through
      `Keeper_shell_ir.dispatch_classified` with `caller=Tool_code_write`,
      `allow_pipes=true`, and `redirect_allowed=false`, preserving the legacy
      no-redirect code-shell policy while sharing the same gate/path/dispatch
@@ -434,12 +434,12 @@ and public tool aliases.
   `executable="gh"`/`argv=["pr","create",...]` emits `PR_CREATE`, and
   prefixed public `Bash` typed git push normalizes to `keeper_bash`.
 - The boundary test now fails if OAS output command extraction reintroduces a
-  local `keeper_bash`/`masc_code_shell` field map instead of using
+  local `keeper_bash`/retired-code-shell field map instead of using
   `Keeper_tool_capability_axis.shell_command_input_candidates`.
 - `test_keeper_bash_safety` now verifies the remaining dev/read-only
   allowlists are derived from typed `Exec_program` values without the removed
-  legacy `masc_code_shell` allowlist surface.
-- `test_worker_dev_tools` now fails if `masc_code_shell` bypasses
+  legacy code-shell allowlist surface.
+- `test_worker_dev_tools` now fails if the retired code-shell bypasses
   `Keeper_shell_ir.coding_command_context` /
   `Keeper_shell_ir.dispatch_classified`, re-enables redirects at the facade,
   or reintroduces direct path-validation / dispatch ownership in

--- a/docs/rfc/RFC-0057-tool-descriptor-codegen.md
+++ b/docs/rfc/RFC-0057-tool-descriptor-codegen.md
@@ -38,7 +38,7 @@ progress_report.md §2.1에 기록된 8개 문제 중 미해결 4개:
 | 1 | `mode_enforcer.ml` 50+ 문자열 하드코딩 | OAS 측 tool effect 분류가 문자열 매칭 | **범위外** — OAS subsystem 별도 RFC |
 | 2 | `agent_tools` O(n) 선형 검색 | 도구 이름 문자열로 linear search | **Phase 2** — GADT dispatch로 대체 |
 | 3 | **61개 도구 수동 Yojson AST** | `{name="..."; description="..."; ...}` 하드코딩 | **핵심 범위** — codegen으로 자동화 |
-| 4 | 중복 도구 | `read_file` / `masc_code_read` 등 의미 중복 | **Phase 2** — alias/unification 계획 |
+| 4 | 중복 도구 | `read_file` / `tool_read_file` 등 의미 중복 | **Phase 2** — alias/unification 계획 |
 
 ### 1.3 Current Schema Architecture
 
@@ -202,7 +202,7 @@ let emit_tool_json buf spec =
 
 | 기존 도구들 | 통합안 | 근거 |
 |------------|--------|------|
-| `read_file` + `masc_code_read` | `read_file` (unified) with optional `format` param | 기능 동일, namespace만 다름 |
+| `read_file` + `tool_read_file` | `read_file` (unified) with optional `format` param | 기능 동일, namespace만 다름 |
 | `grep_search` + `rg` (Shell IR) | Shell IR `Rg`를 MCP surface로 노출 | GADT 재사용 |
 | `list_directory` + `ls` (Shell IR) | Shell IR `Ls`를 MCP surface로 노출 | GADT 재사용 |
 

--- a/docs/rfc/RFC-0073-tool-readiness-probe.md
+++ b/docs/rfc/RFC-0073-tool-readiness-probe.md
@@ -119,7 +119,7 @@ val probe :
 
 | variant | Trigger | Evidence ref |
 |---|---|---|
-| `Lane_unavailable` | sangsu keeper (active+keepalive) 의 cascade=tier-group.provider-k-coding-with-spark 이 lane=runtime_mcp 로 진입할 때 *materialize 단계*에서 sandbox-요구 도구가 LLM 표면에서 제거. dashboard `resolved_allowlist` 는 통과했으나 materialize 단계 silent strip 으로 `masc_code_git` 미존재 → `required_tool_lane_unavailable` error. | board `p-6502d7dbfaaf89ae24e6ff749a06f914` |
+| `Lane_unavailable` | sangsu keeper (active+keepalive) 의 cascade=tier-group.provider-k-coding-with-spark 이 lane=runtime_mcp 로 진입할 때 *materialize 단계*에서 sandbox-요구 도구가 LLM 표면에서 제거. dashboard `resolved_allowlist` 는 통과했으나 materialize 단계 silent strip 으로 `tool_execute` 미존재 → `required_tool_lane_unavailable` error. | board `p-6502d7dbfaaf89ae24e6ff749a06f914` |
 | `Tool_naming_inconsistency` | tech_glutton keeper 의 cascade 가 lane=runtime_mcp 가 아니라 *local Agent-LLM-A SDK pass-through* 로 routing. `visible_tools` 가 `[Bash, Edit, Grep, WebSearch, Write]` 같은 CLI-Tool-A 내장 이름이라 `masc_web_search` 같은 MCP-native 이름과 매칭 실패. 같은 의미, 다른 surface naming. | board `p-15634a8257cd0c1db8092677de5a3ee2` |
 | `Verifier_blocked_no_open_request` | verifier keeper 가 *자율적으로* 발견. goal phase=executing 에서 `active_verification_request_id=null` 이면 verifier 가 reject 조차 vote 불가 — `conflict: goal has no active verification request`. RFC-0074 의 paused-blocked variant 와 *직교*. | board `p-38c3289abd46b765bee74ca765c9c2ea` (verifier 가 직접 post) |
 

--- a/docs/rfc/RFC-0080-tool-registry-ssot.md
+++ b/docs/rfc/RFC-0080-tool-registry-ssot.md
@@ -15,9 +15,9 @@ implementation_prs: [15207,15268,15271]
 
 ## 1. Problem statement
 
-Production keeper boot emits ≈540 warn lines per session matching `groups.<name>: tool '<tool>' is not registered` (older binaries) / `is not a known policy tool` (current `main` after PR #14513). Across one production log window (37 533 lines, 2 boot sessions on 2026-05-13) the warn covers **88 distinct tool names** including high-traffic surface (`tool_execute`, `keeper_board_search`, `masc_status`, `masc_goal_list`, `masc_code_write`, `keeper_voice_*`, `extend_turns`, etc.).
+Production keeper boot emits ≈540 warn lines per session matching `groups.<name>: tool '<tool>' is not registered` (older binaries) / `is not a known policy tool` (current `main` after PR #14513). Across one production log window (37 533 lines, 2 boot sessions on 2026-05-13) the warn covers **88 distinct tool names** including high-traffic surface (`tool_execute`, `keeper_board_search`, `masc_status`, `masc_goal_list`, `tool_write_file`, `keeper_voice_*`, `extend_turns`, etc.).
 
-The warn is *load-time* validation in `lib/keeper/keeper_tool_policy_config.ml:319-321`, fired once per boot per offending entry in `tool_policy.toml`. It does **not** prevent the tool from dispatching at runtime — `tool_call tool=masc_code_git outcome=ok` co-exists with `groups.coding: tool 'masc_code_git' is not registered`. The warn and the runtime are talking past each other.
+The warn is *load-time* validation in `lib/keeper/keeper_tool_policy_config.ml:319-321`, fired once per boot per offending entry in `tool_policy.toml`. It does **not** prevent the tool from dispatching at runtime — `tool_call tool=tool_execute outcome=ok` co-exists with `groups.coding: tool 'tool_execute' is not registered`. The warn and the runtime are talking past each other.
 
 The mismatch is structural, not a typo. `is_known_policy_tool_name` (lib/keeper/keeper_tool_policy_config.ml:225-239) currently union-checks across **15 independent sources of truth**:
 
@@ -216,13 +216,12 @@ keeper_tools_list
 keeper_voice_{agent,listen,session_end,session_start,sessions,speak}
 masc_add_task / masc_agent_card / masc_agents / masc_approval_pending /
 masc_batch_add_tasks / masc_broadcast / masc_claim_next /
-masc_code_{delete,edit,git,read,search,shell,symbols,write} /
 masc_goal_{list,review,transition,upsert,verify} /
 masc_heartbeat / masc_join / masc_keeper_{list,msg,msg_result,status} /
 masc_leave / masc_messages / masc_plan_get / masc_plan_get_task /
 masc_status / masc_task_history / masc_tasks / masc_tool_help /
 masc_transition / masc_web_search / masc_who /
-masc_worktree_{create,list,remove}
+tool_{edit_file,execute,read_file,search_files,write_file}
 ```
 
 ### 7.2 88 × 15 matrix (deferred to Phase 1 PR)

--- a/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
+++ b/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
@@ -156,7 +156,7 @@ let surfaces_to_check =
 | Boot policy load | `keeper_tool_policy_config.ml:229` `Tool_resolution.is_known_policy_tool_name` | 13 sources OR (via `Tool_resolution.resolve`) |
 | Runtime route | `keeper_tool_resolution.ml` | `strip_mcp_masc_prefix` → `Keeper_tool_alias.public_masc_to_internal` → `route` → `is_known_internal` |
 
-두 경로가 일부 source는 공유하지만 *서로 다른 admission decision*을 내릴 수 있다. RFC-0080 §1 명시: production 1 boot window에서 540 lines `is not registered` warn + 88 distinct names 발생, 그 중 다수는 runtime dispatch 정상 (`tool_call tool=masc_code_git outcome=ok` co-exists with `groups.coding: tool 'masc_code_git' is not registered`).
+두 경로가 일부 source는 공유하지만 *서로 다른 admission decision*을 내릴 수 있다. RFC-0080 §1 명시: production 1 boot window에서 540 lines `is not registered` warn + 88 distinct names 발생, 그 중 다수는 runtime dispatch 정상 (`tool_call tool=tool_execute outcome=ok` co-exists with `groups.coding: tool 'tool_execute' is not registered`).
 
 ### §1.5 Macro-portability Gap (P0)
 

--- a/docs/rfc/RFC-0104-keeper-task-repo-binding.md
+++ b/docs/rfc/RFC-0104-keeper-task-repo-binding.md
@@ -130,7 +130,7 @@ input 은 `masc_add_task`, `masc_update_task` 의 typed param.
 
 ### §3.2 sandbox / cwd 처리
 
-`keeper_bash` / `keeper_shell` / `masc_code_shell` 의 cwd 결정 알고리즘:
+`keeper_bash` / `keeper_shell` / `tool_execute` 의 cwd 결정 알고리즘:
 
 ```ocaml
 let resolve_default_cwd

--- a/docs/rfc/RFC-0131-shell-command-gate-facade.md
+++ b/docs/rfc/RFC-0131-shell-command-gate-facade.md
@@ -72,7 +72,7 @@ string scanner / splitter / classifier:
 | Module | Function | What it does |
 |---|---|---|
 | `lib/worker_dev_tools.ml` | `validate_command_coding_with_allowlist` (line 549) | `forbidden_shell_chars` blacklist + `split_pipeline_segments` (line 92) + allowlist + `tokenize_path_args` (line 744) + `path_validation_tokens` (line 1043) |
-| `lib/tool_code_write.ml` | `validate_command_coding_with_allowlist` (line 579 wrapper) + `classify_code_shell_exit` | Local pipeline splitter for `masc_code_shell`, last-stage parser, exit classifier |
+| `lib/tool_code_write.ml` | `validate_command_coding_with_allowlist` (line 579 wrapper) + `classify_code_shell_exit` | Local pipeline splitter for `tool_execute`, last-stage parser, exit classifier |
 | `lib/keeper/keeper_shell_bash.ml` | `handle_keeper_shell_ir` validation block | `Worker_dev_tools.validate_command_coding_with_allowlist` + `Eval_gate.detect_destructive` + `Eval_gate.detect_evasion` + raw shape scanner |
 
 The former RFC-0092 advisory path has been removed; Shell validation now routes

--- a/docs/rfc/RFC-0180-runtime-error-sweep-roadmap.md
+++ b/docs/rfc/RFC-0180-runtime-error-sweep-roadmap.md
@@ -30,7 +30,7 @@ ERROR 571 의 8 패턴 (θ = 본 cycle fix, 7 잔존):
 
 | ID | 패턴 | 24h | Root code path |
 |---|---|---|---|
-| α | `masc_worktree_create sandbox_close/missing_sandbox` | 18 | `lib/types/masc_error.ml:179` IoError wrapper, literal `"missing_sandbox_clone"` 외부 runtime (agent SDK) emit |
+| α | `tool_execute sandbox_close/missing_sandbox` | 18 | `lib/types/masc_error.ml:179` IoError wrapper, literal `"missing_sandbox_clone"` 외부 runtime (agent SDK) emit |
 | β | `keeper_bash executable=""` + 5-retry threshold-silence | 26 | `lib/keeper/keeper_tool_bash_input.ml:321,447-470` `check_exec` + retry threshold 5 |
 | γ | `keeper_bash cwd_not_directory: playground/*` | 11 | `lib/keeper/keeper_shell_path.ml:26-40` + `keeper_failure_circuit_breaker.ml:100` |
 | δ | `cascade tier-group.glm-coding-with-spark exhausted` | 13 | `lib/keeper/keeper_turn_driver_try_cascade.ml:899` + `lib/cascade/provider_health.ml:88-106` |
@@ -61,7 +61,7 @@ type system_error =
 
 `closed_reason` 도 closed-sum (Sandbox lifecycle 의 명시 phases).
 
-**Pre-flight check**: `masc_worktree_create` 진입 시 *sandbox clone inventory* 확인 — `repos/` 디렉토리 존재 검증. 실패 시 typed error 즉시 emit (현 lazy emit 대비 stack 짧음).
+**Pre-flight check**: `tool_execute` 진입 시 *sandbox clone inventory* 확인 — `repos/` 디렉토리 존재 검증. 실패 시 typed error 즉시 emit (현 lazy emit 대비 stack 짧음).
 
 **PR-1**: typed variant + 한 emit site (currently `IoError "missing_sandbox_clone: ..."`) 만 마이그레이션. PR-2 부터 caller 마이그레이션.
 

--- a/docs/spec/03-room-coordination.md
+++ b/docs/spec/03-room-coordination.md
@@ -626,11 +626,8 @@ Docker-style `{agent_type}-{adjective}-{animal}`:
 
 ### 14.5 Worktree (`Coord_git`)
 
-| Tool | 동작 |
-|------|------|
-| `masc_worktree_create` | 에이전트+태스크별 worktree 생성 |
-| `masc_worktree_remove` | worktree 삭제 |
-| `masc_worktree_list` | worktree 목록 |
+별도 worktree MCP tool은 없다. repo/worktree 조작은 `Execute`에서
+`executable="git"`와 typed `argv`를 사용한다.
 
 ### 14.6 Control (`tool_control`)
 

--- a/lib/keeper/keeper_sandbox_containment.ml
+++ b/lib/keeper/keeper_sandbox_containment.ml
@@ -28,8 +28,8 @@ let check_target ~operation ~config ~meta ~target =
         (Printf.sprintf
            "symmetric_sandbox_blocked: target %s is outside keeper playground \
             %s. Keepers with sandbox_profile=docker may only %s inside \
-            their playground. Clone the source into your playground with the \
-            visible clone/worktree tool, or operate inside %s/repos/."
+            their playground. Clone the source into %s/repos/ with Execute \
+            and typed git argv, or operate inside an existing repo there."
            target_norm playground operation playground)
 
 let check_read_target ~config ~meta ~target =

--- a/lib/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_shard_types_schemas_taskboard.ml
@@ -288,8 +288,8 @@ let taskboard_tools : Masc_domain.tool_schema list =
                                          claim_next routes them only to capable \
                                          presets. PR review mutation tasks must \
                                          route code/review work through sandboxed \
-                                         worktree tools rather than dedicated \
-                                         review wrappers." )
+                                         repo worktrees with Execute rather than \
+                                         dedicated review wrappers." )
                                   ] )
                             ; ( "required_evidence"
                               , `Assoc

--- a/scripts/analyze-keeper-execute-failures.sh
+++ b/scripts/analyze-keeper-execute-failures.sh
@@ -145,7 +145,7 @@ def category:
   else "other" end;
 fromjson? | select(type == "object") | select((.ts // 0) >= $cutoff)
 | . as $row
-| select(["Execute", "tool_execute", "tool_search_files", "masc_code_shell", "masc_code_edit", "EditFile", "WriteFile"] | index($row.tool))
+| select(["Execute", "tool_execute", "tool_search_files", "tool_edit_file", "EditFile", "WriteFile"] | index($row.tool))
 '
 
 echo "=== Keeper Execute Failure Census ==="
@@ -179,7 +179,7 @@ echo "[surface summary]"
 jq -Rr --argjson cutoff "$CUTOFF" "$SURFACE_FILTER | [.tool, (if failed then \"failed\" else \"ok\" end)] | @tsv" "${FILES[@]}" |
 awk '
   BEGIN {
-    split("Execute tool_execute tool_search_files masc_code_shell masc_code_edit EditFile WriteFile", order, " ")
+    split("Execute tool_execute tool_search_files tool_edit_file EditFile WriteFile", order, " ")
     print "tool\tfailed\tok\tfailure_pct"
   }
   {

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -1400,7 +1400,7 @@ not review or approve another keeper's PR in this phase.
 Tool route rules:
 - Use the visible Execute tool inside your Docker playground for proof-file creation and git add/commit/push on the proof branch.
 $git_route_rule
-- Do not use approval-requiring host code-write paths such as masc_code_write for this proof file.
+- Do not use approval-requiring host code-write paths such as tool_write_file for this proof file.
 - If Execute rejects mutating git as policy-blocked, stop and report the exact blocker instead of switching to host-local credentials.
 - Use visible Execute with executable="gh" and typed argv for PR creation.
 
@@ -1412,7 +1412,7 @@ Required create lane:
 2. Confirm your runtime is sandbox_profile=docker before mutating.
 3. Create a unique proof worktree/branch for exactly this run id:
    - branch: $branch
-   - preferred tool: masc_worktree_create with task_id=$RUN_ID
+   - preferred tool: Execute with executable="git" argv containing worktree args
    - use the returned worktree path for every later Execute git/file command.
    - the returned branch must be $branch. If it is different, stop and report blocker="branch_mismatch".
    - Do not reuse any branch, worktree, or proof file from another run id.

--- a/scripts/sweep-tool-error-signatures.sh
+++ b/scripts/sweep-tool-error-signatures.sh
@@ -17,7 +17,7 @@
 #   scripts/sweep-tool-error-signatures.sh 3 data/tool-error-sweeps
 #
 # Output record shape (one JSON per line):
-#   {"date":"2026-04-18","tool":"masc_code_read","sig":"...","count":48}
+#   {"date":"2026-04-18","tool":"tool_read_file","sig":"...","count":48}
 #
 # Requires: jq
 # Related: scripts/analyze-tool-call-quality.sh (human-readable counterpart)

--- a/test/keeper_tool_retry_state/test_keeper_tool_retry_state.ml
+++ b/test/keeper_tool_retry_state/test_keeper_tool_retry_state.ml
@@ -192,7 +192,7 @@ let test_distinct_tool_names_independent () =
     record ~tool_name:"tool_execute" ~error_signature:sig_ ~attempt:2 ()
   in
   let out =
-    record ~tool_name:"masc_worktree_create" ~error_signature:sig_ ~attempt:1 ()
+    record ~tool_name:"tool_execute" ~error_signature:sig_ ~attempt:1 ()
   in
   match out with
   | `First -> ()
@@ -313,7 +313,7 @@ let test_production_scenario_5_tools () =
   reset ();
   let tools_with_sigs =
     [ "tool_execute", normalize "spawn failed: ENOENT"
-    ; "masc_worktree_create", normalize "branch already exists"
+    ; "tool_execute", normalize "branch already exists"
     ; "tool_execute", normalize "404 not found"
     ; "masc_transition", normalize "phase guard rejected"
     ; "Execute", normalize "exit code 1"

--- a/test/test_actionable_path_action.ml
+++ b/test/test_actionable_path_action.ml
@@ -43,7 +43,7 @@ let test_path_not_allowed () =
 
 let test_cwd_not_directory () =
   r "cwd guidance"
-    "The cwd is not a directory. Omit cwd to use your default playground root, or create/repair the repo worktree first with the visible clone/worktree tool, then masc_worktree_create for repos/<repo>/.worktrees/<task>."
+    "The cwd is not a directory. Omit cwd to use your default playground root, or create/repair the repo worktree first with Execute and typed git argv, then run inside repos/<repo>/.worktrees/<task>."
     (actionable_path_action_for_class
        ~playground:pg ~raw_path:"foo" CB.Cwd_not_directory)
 

--- a/test/test_approval_callback_wired.ml
+++ b/test/test_approval_callback_wired.ml
@@ -58,7 +58,7 @@ let check_approve name (result : Hooks.approval_decision) =
 
 let test_reject_by_default_rejects_any_tool () =
   let tools =
-    [ "masc_worktree_create"; "masc_code_write"; "keeper_destroy";
+    [ "tool_execute"; "tool_write_file"; "keeper_destroy";
       "bash_exec"; "unknown_tool"; "" ]
   in
   List.iter
@@ -71,7 +71,7 @@ let test_reject_by_default_rejects_any_tool () =
 
 let test_reject_by_default_reason_mentions_tool () =
   let decision : Hooks.approval_decision =
-    AC.reject_by_default ~tool_name:"masc_worktree_create"
+    AC.reject_by_default ~tool_name:"tool_execute"
       ~input:(`Assoc [])
   in
   match decision with
@@ -80,7 +80,7 @@ let test_reject_by_default_reason_mentions_tool () =
         "reject reason names the tool so agents can diagnose"
         true
         (try ignore (Str.search_forward
-                       (Str.regexp_string "masc_worktree_create") reason 0);
+                       (Str.regexp_string "tool_execute") reason 0);
              true
          with Not_found -> false)
   | Approve ->

--- a/test/test_capability_registry.ml
+++ b/test/test_capability_registry.ml
@@ -49,7 +49,7 @@ let test_local_worker_projection_exposes_internal_and_auditable_tools () =
       ~names:
         [
           "masc_heartbeat";
-          "masc_code_search";
+          "tool_search_files";
           "masc_run_plan";
         ]
       ()
@@ -60,7 +60,7 @@ let test_local_worker_projection_exposes_internal_and_auditable_tools () =
         List.map (fun (schema : Masc_domain.tool_schema) -> schema.name) schemas
       in
       check bool "heartbeat" true (List.mem "masc_heartbeat" names);
-      check bool "masc_code_search" true (List.mem "masc_code_search" names);
+      check bool "tool_search_files" true (List.mem "tool_search_files" names);
       check bool "masc_run_plan" true (List.mem "masc_run_plan" names)
 
 let test_spawned_agent_surface_stays_curated () =

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1468,7 +1468,7 @@ let test_keeper_required_tool_contracts () =
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
        "via=docker, route_via=docker, via=brokered, or route_via=brokered")
   ;
-  check bool "docker PR lifecycle branch matches worktree tool contract" true
+  check bool "docker PR lifecycle branch matches worktree branch contract" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
        {|printf 'keeper-%s-agent/%s' "$keeper" "$RUN_ID"|}

--- a/test/test_code_navigation_eio.ml
+++ b/test/test_code_navigation_eio.ml
@@ -84,7 +84,7 @@ let extract_tool_output response =
 
 let prepare_code_surface ~clock:_ ~sw:_ _state = ()
 
-(* ===== E2E Test: masc_code_search ===== *)
+(* ===== E2E Test: tool_search_files ===== *)
 
 let test_code_search_basic () =
   Eio_main.run @@ fun env ->
@@ -104,7 +104,7 @@ let test_code_search_basic () =
     ("id", `Int 1);
     ("method", `String "tools/call");
     ("params", `Assoc [
-      ("name", `String "masc_code_search");
+      ("name", `String "tool_search_files");
       ("arguments", `Assoc [
         ("query", `String "ripgrep");
         ("path", `String "lib/");
@@ -164,7 +164,7 @@ let test_code_search_basic () =
      | None -> fail "missing results field")
   end
 
-(* ===== E2E Test: masc_code_symbols ===== *)
+(* ===== E2E Test: tool_search_files ===== *)
 
 let test_code_symbols_basic () =
   Eio_main.run @@ fun env ->
@@ -183,7 +183,7 @@ let test_code_symbols_basic () =
     ("id", `Int 2);
     ("method", `String "tools/call");
     ("params", `Assoc [
-      ("name", `String "masc_code_symbols");
+      ("name", `String "tool_search_files");
       ("arguments", `Assoc [
         ("path", `String "lib/config.ml");
       ]);
@@ -217,7 +217,7 @@ let test_code_symbols_basic () =
      | None -> fail "missing symbols field")
   end
 
-(* ===== E2E Test: masc_code_read ===== *)
+(* ===== E2E Test: tool_read_file ===== *)
 
 let test_code_read_basic () =
   Eio_main.run @@ fun env ->
@@ -236,7 +236,7 @@ let test_code_read_basic () =
     ("id", `Int 3);
     ("method", `String "tools/call");
     ("params", `Assoc [
-      ("name", `String "masc_code_read");
+      ("name", `String "tool_read_file");
       ("arguments", `Assoc [
         ("path", `String "lib/config.ml");
         ("offset", `Int 0);
@@ -283,7 +283,7 @@ let test_code_read_basic () =
      | None -> fail "missing lines field")
   end
 
-(* ===== E2E Test: masc_code_read offset/limit ===== *)
+(* ===== E2E Test: tool_read_file offset/limit ===== *)
 
 let test_code_read_offset_limit () =
   Eio_main.run @@ fun env ->
@@ -302,7 +302,7 @@ let test_code_read_offset_limit () =
     ("id", `Int 4);
     ("method", `String "tools/call");
     ("params", `Assoc [
-      ("name", `String "masc_code_read");
+      ("name", `String "tool_read_file");
       ("arguments", `Assoc [
         ("path", `String "lib/config.ml");
         ("offset", `Int 10);

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -920,7 +920,7 @@ let test_dashboard_exposes_keeper_approval_queue () =
         let decision =
           Lib.Keeper_approval_queue.submit_and_await
             ~keeper_name:"dashboard-keeper"
-            ~tool_name:"masc_code_delete"
+            ~tool_name:"tool_edit_file"
             ~input:(`Assoc [ ("path", `String "/tmp/danger") ])
             ~risk_level:Lib.Keeper_approval_queue.Critical
             ~selected_model:"provider_d:gpt-5.4"
@@ -941,7 +941,7 @@ let test_dashboard_exposes_keeper_approval_queue () =
       let approval = List.hd approval_queue in
       check string "approval keeper name" "dashboard-keeper"
         (approval |> member "keeper_name" |> to_string);
-      check string "approval tool name" "masc_code_delete"
+      check string "approval tool name" "tool_edit_file"
         (approval |> member "tool_name" |> to_string);
       check string "approval risk level" "critical"
         (approval |> member "risk_level" |> to_string);

--- a/test/test_dashboard_keeper_metrics_10286.ml
+++ b/test/test_dashboard_keeper_metrics_10286.ml
@@ -118,7 +118,7 @@ let test_metrics_window_exposes_observed_pr_work () =
           pr_work_action "GIT_PUSH";
           pr_work_action "PR_CREATE";
           pr_work_action ~success:false "GIT_PUSH";
-          metric ~channel:"heartbeat" [ "masc_code_git" ];
+          metric ~channel:"heartbeat" [ "tool_execute" ];
         ]
       ~generation:0
       ~compact:false

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -407,10 +407,10 @@ let test_dashboard_tools_projection () =
              | `String value -> String.equal value surface
              | _ -> false)
       in
-      let hidden_tool = find_tool "masc_code_search" in
+      let hidden_tool = find_tool "tool_search_files" in
       let public_tool = find_tool "masc_status" in
       let spawned_agent_tool = find_tool "masc_workflow_guide" in
-      let local_worker_tool = find_tool "masc_worktree_create" in
+      let local_worker_tool = find_tool "tool_execute" in
       let removed_alias_tool = find_tool "masc_register_capabilities" in
       check bool "includes hidden tool" true (Option.is_some hidden_tool);
       check bool "includes public tool" true (Option.is_some public_tool);

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -233,7 +233,7 @@ let test_risk_low_keeper_msg () =
     "low" (Gp.risk_level_to_string risk)
 
 let test_risk_medium_worktree_create () =
-  let risk = Gp.assess_risk ~tool_name:"masc_worktree_create" ~input:no_args in
+  let risk = Gp.assess_risk ~tool_name:"tool_execute" ~input:no_args in
   Alcotest.(check string) "worktree_create is medium"
     "medium" (Gp.risk_level_to_string risk)
 
@@ -321,7 +321,7 @@ let test_risk_metadata_pg_query_override () =
 
 let test_risk_payload_empty_overwrite () =
   let risk =
-    Gp.assess_risk ~tool_name:"masc_code_write"
+    Gp.assess_risk ~tool_name:"tool_write_file"
       ~input:
         (`Assoc
           [
@@ -334,7 +334,7 @@ let test_risk_payload_empty_overwrite () =
 
 let test_risk_payload_destructive_content () =
   let risk =
-    Gp.assess_risk ~tool_name:"masc_code_edit"
+    Gp.assess_risk ~tool_name:"tool_edit_file"
       ~input:
         (`Assoc
           [
@@ -364,7 +364,7 @@ let test_risk_payload_destructive_nested_string () =
 
 let test_risk_payload_safe_write_remains_high () =
   let risk =
-    Gp.assess_risk ~tool_name:"masc_code_write"
+    Gp.assess_risk ~tool_name:"tool_write_file"
       ~input:
         (`Assoc
           [

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -209,7 +209,7 @@ let with_temp_masc_base f =
 
 let test_risk_classification_critical () =
   let tools = [
-    ("masc_code_delete", GP.Critical);
+    ("tool_edit_file", GP.Critical);
     ("masc_force_reset", GP.Critical);
     ("keeper_destroy", GP.Critical);
   ] in
@@ -223,7 +223,7 @@ let test_risk_classification_critical () =
 
 let test_risk_classification_high () =
   let tools = [
-    ("masc_code_write", GP.High);
+    ("tool_write_file", GP.High);
     ("tool_edit_file", GP.High);
     ("masc_create_task", GP.High);
   ] in
@@ -348,7 +348,7 @@ let test_approval_queue_submit_and_resolve () =
     let decision =
       AQ.submit_and_await
         ~keeper_name:"test-keeper"
-        ~tool_name:"masc_code_delete"
+        ~tool_name:"tool_edit_file"
         ~input:(`Assoc [("path", `String "/dangerous")])
         ~risk_level:AQ.Critical
         ()
@@ -607,7 +607,7 @@ let test_approval_queue_cancel_records_terminal_audit () =
            ignore
              (AQ.submit_and_await
                 ~keeper_name
-                ~tool_name:"masc_code_delete"
+                ~tool_name:"tool_edit_file"
                 ~input:(`Assoc [ ("path", `String "lib/example.ml") ])
                 ~risk_level:AQ.Critical
                 ~base_path
@@ -737,7 +737,7 @@ let test_approval_queue_get_pending_detail () =
   let id =
     AQ.submit_pending
       ~keeper_name:"detail-keeper"
-      ~tool_name:"masc_code_delete"
+      ~tool_name:"tool_edit_file"
       ~input
       ~risk_level:AQ.Critical
       ~turn_id:7
@@ -757,9 +757,9 @@ let test_approval_queue_get_pending_detail () =
   Alcotest.(check string) "detail id" id (detail |> member "id" |> to_string);
   Alcotest.(check string) "detail keeper" "detail-keeper"
     (detail |> member "keeper_name" |> to_string);
-  Alcotest.(check string) "detail tool" "masc_code_delete"
+  Alcotest.(check string) "detail tool" "tool_edit_file"
     (detail |> member "tool_name" |> to_string);
-  Alcotest.(check string) "detail action key" "tool:masc_code_delete"
+  Alcotest.(check string) "detail action key" "tool:tool_edit_file"
     (detail |> member "action_key" |> to_string);
   Alcotest.(check string) "detail sandbox target" "docker"
     (detail |> member "sandbox_target" |> to_string);
@@ -803,7 +803,7 @@ let test_approval_get_dispatch_success () =
   let id =
     AQ.submit_pending
       ~keeper_name:"dispatch-detail-keeper"
-      ~tool_name:"masc_code_delete"
+      ~tool_name:"tool_edit_file"
       ~input
       ~risk_level:AQ.Critical
       ~on_resolution:(fun decision -> callback_result := Some decision)
@@ -1196,7 +1196,7 @@ let test_callback_production_worktree_create_auto_approved () =
     GP.to_oas_approval_callback
       ~config ~governance_level:"production" ~keeper_name:"test" () in
   let decision =
-    cb ~tool_name:"masc_worktree_create"
+    cb ~tool_name:"tool_execute"
       ~input:(`Assoc [
         ("task_id", `String "task-187");
         ("repo_name", `String "masc-mcp");
@@ -1341,7 +1341,7 @@ let test_callback_always_approve_respects_forbidden () =
             ~config ~governance_level:"production" ~keeper_name:"test-keeper" ~meta ()
         in
         let decision =
-          cb ~tool_name:"masc_code_delete"
+          cb ~tool_name:"tool_edit_file"
             ~input:(`Assoc [("path", `String "/dangerous")])
         in
         result := Some decision

--- a/test/test_keeper_discovered_tools.ml
+++ b/test/test_keeper_discovered_tools.ml
@@ -5,13 +5,13 @@ let dt = Masc_mcp.Keeper_discovered_tools.create
 let test_add_and_active () =
   let t = dt ~decay_turns:5 in
   Masc_mcp.Keeper_discovered_tools.add t ~turn:0
-    ~names:[ "masc_worktree_create"; "masc_worktree_remove" ];
+    ~names:[ "tool_execute"; "tool_search_files" ];
   let active = Masc_mcp.Keeper_discovered_tools.active_names t ~turn:0 in
   Alcotest.(check int) "two tools active" 2 (List.length active);
-  Alcotest.(check bool) "worktree_create present" true
-    (List.mem "masc_worktree_create" active);
-  Alcotest.(check bool) "worktree_remove present" true
-    (List.mem "masc_worktree_remove" active)
+  Alcotest.(check bool) "execute present" true
+    (List.mem "tool_execute" active);
+  Alcotest.(check bool) "search files present" true
+    (List.mem "tool_search_files" active)
 
 let test_decay_removes_old () =
   let t = dt ~decay_turns:3 in

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -562,7 +562,7 @@ let test_runtime_surface_names_no_tool_provider_details () =
       {
         cascade_name = Cascade_name.of_string_exn "tool_required";
         configured_labels = [ "agent_code"; "provider_c" ];
-        required_tool_names = [ "tool_execute"; "masc_worktree_create" ];
+        required_tool_names = [ "tool_execute"; "tool_search_files" ];
         provider_rejections =
           [
             { OWN.provider_label = "agent_code"; OWN.reason = "codex_keeper_bound_actor_required" };
@@ -598,8 +598,8 @@ let test_runtime_surface_names_no_tool_provider_details () =
   check string "runtime blocker class"
     "no_tool_capable_provider"
     (runtime |> member "runtime_blocker_class" |> to_string);
-  check bool "summary names required worktree tool" true
-    (has_substring surfaced_summary "masc_worktree_create");
+  check bool "summary names required execution tool" true
+    (has_substring surfaced_summary "tool_execute");
   check bool "summary names rejection reason" true
     (has_substring surfaced_summary
        "codex_keeper_bound_actor_required");

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -1265,10 +1265,10 @@ let pr_work_events ?route_via_fallback ~tool_name ~input ~output_text () =
 
 let work_actions events = List.map (fun e -> e.Hooks.work_action) events
 
-let test_pr_work_action_metric_extracts_masc_code_git_push () =
+let test_pr_work_action_metric_extracts_tool_execute_push () =
   let events =
     pr_work_events
-      ~tool_name:"masc_code_git"
+      ~tool_name:"tool_execute"
       ~input:(`Assoc [ "action", `String "push" ])
       ~output_text:{|{"status":"ok","action":"push","via":"docker"}|}
       ()
@@ -1279,7 +1279,7 @@ let test_pr_work_action_metric_extracts_masc_code_git_push () =
     | [ event ] -> event
     | _ -> failf "expected one git push event"
   in
-  check string "source" "masc_code_git" event.work_source;
+  check string "source" "tool_execute" event.work_source;
   check bool "success" true event.success;
   check (option string) "route via" (Some "docker") event.route_via
 ;;
@@ -1288,7 +1288,7 @@ let test_pr_work_action_metric_observes_invalid_output_json () =
   let before = hook_output_parse_failures "pr_work_action" in
   let events =
     pr_work_events
-      ~tool_name:"masc_code_git"
+      ~tool_name:"tool_execute"
       ~input:(`Assoc [ "action", `String "push" ])
       ~output_text:"{not-json"
       ()
@@ -1389,22 +1389,22 @@ let test_pr_work_action_metric_extracts_embedded_output_json () =
   let before = hook_output_parse_failures "pr_work_action" in
   let events =
     pr_work_events
-      ~tool_name:"masc_code_git"
+      ~tool_name:"tool_execute"
       ~input:(`Assoc [ "action", `String "push" ])
       ~output_text:
         "Created draft PR successfully:\n\
-         {\"ok\":true,\"tool\":\"masc_code_git\",\"action\":\"push\",\"via\":\"brokered\"}\n\
+         {\"ok\":true,\"tool\":\"tool_execute\",\"action\":\"push\",\"via\":\"brokered\"}\n\
          Done."
       ()
   in
   check (list string) "git push action" [ "GIT_PUSH" ] (work_actions events);
   (match events with
    | [ event ] ->
-     check string "source" "masc_code_git" event.work_source;
+     check string "source" "tool_execute" event.work_source;
      check (option string) "head ref" None event.work_ref;
      check (option string) "pr url" None event.pr_url;
      check (option string) "route via" (Some "brokered") event.route_via
-   | _ -> failf "expected one masc_code_git event");
+   | _ -> failf "expected one tool_execute event");
   check
     (float 0.001)
     "parse failure not counted"
@@ -1694,9 +1694,9 @@ let () =
         ] )
     ; ( "pr_work_action"
       , [ test_case
-            "extracts masc_code_git push"
+            "extracts tool_execute push"
             `Quick
-            test_pr_work_action_metric_extracts_masc_code_git_push
+            test_pr_work_action_metric_extracts_tool_execute_push
         ; test_case
             "observes invalid output JSON"
             `Quick

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -339,7 +339,7 @@ let test_tool_access_missing_defaults_standard_policy () =
   Alcotest.(check (list string)) "default keeps expected masc set"
     expected_legacy_masc_names legacy_masc_names;
   Alcotest.(check bool) "does not silently expand to full" false
-    (List.mem "masc_code_read" names)
+    (List.mem "tool_read_file" names)
 
 let test_read_meta_file_rejects_legacy_tool_keys () =
   let dir = temp_dir () in
@@ -609,8 +609,8 @@ let test_allowlist_gates_shard_tools () =
   Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
   Alcotest.(check bool) "has masc_tasks" true
     (List.mem "masc_tasks" names);
-  Alcotest.(check bool) "masc_code_read blocked by custom policy" false
-    (List.mem "masc_code_read" names)
+  Alcotest.(check bool) "tool_read_file blocked by custom policy" false
+    (List.mem "tool_read_file" names)
 
 let test_dispatch_unregistered () =
   let result =
@@ -664,7 +664,7 @@ let test_read_only_preflight_accepts_sandbox_relative_repo_path () =
           make_meta
             ~name:"masc-improver"
             ~sandbox_profile:Masc_mcp.Keeper_types.Docker
-            ~tool_access:(Masc_mcp.Keeper_types.Custom [ "masc_code_read" ])
+            ~tool_access:(Masc_mcp.Keeper_types.Custom [ "tool_read_file" ])
             ()
         in
         with_registered_keeper ~config meta (fun () ->
@@ -672,7 +672,7 @@ let test_read_only_preflight_accepts_sandbox_relative_repo_path () =
               Masc_mcp.Agent_tool_remote_mcp_runtime.handle_masc_tool
                 ~config
                 ~keeper_name:meta.name
-                ~name:"masc_code_read"
+                ~name:"tool_read_file"
                 ~args:
                   (`Assoc
                     [
@@ -723,7 +723,7 @@ let test_write_preflight_accepts_docker_container_repo_path () =
           make_meta
             ~name:"sangsu"
             ~sandbox_profile:Masc_mcp.Keeper_types.Docker
-            ~tool_access:(Masc_mcp.Keeper_types.Custom [ "masc_code_edit" ])
+            ~tool_access:(Masc_mcp.Keeper_types.Custom [ "tool_edit_file" ])
             ()
         in
         with_registered_keeper ~config meta (fun () ->
@@ -731,7 +731,7 @@ let test_write_preflight_accepts_docker_container_repo_path () =
             Masc_mcp.Agent_tool_remote_mcp_runtime.handle_masc_tool
               ~config
               ~keeper_name:meta.name
-              ~name:"masc_code_edit"
+              ~name:"tool_edit_file"
               ~args:
                 (`Assoc
                   [
@@ -790,7 +790,7 @@ let test_write_preflight_accepts_sandbox_relative_repo_path () =
           make_meta
             ~name:keeper_name
             ~sandbox_profile:Masc_mcp.Keeper_types.Docker
-            ~tool_access:(Masc_mcp.Keeper_types.Custom [ "masc_code_edit" ])
+            ~tool_access:(Masc_mcp.Keeper_types.Custom [ "tool_edit_file" ])
             ()
         in
         ignore (Masc_mcp.Keeper_registry.register ~base_path:dir keeper_name meta);
@@ -798,7 +798,7 @@ let test_write_preflight_accepts_sandbox_relative_repo_path () =
           Masc_mcp.Agent_tool_remote_mcp_runtime.handle_masc_tool
             ~config
             ~keeper_name
-            ~name:"masc_code_edit"
+            ~name:"tool_edit_file"
             ~args:
               (`Assoc
                 [ "path", `String rel_path
@@ -811,7 +811,7 @@ let test_write_preflight_accepts_sandbox_relative_repo_path () =
         (match Yojson.Safe.Util.member "error" json with
          | `Null -> ()
          | `String err ->
-           Alcotest.failf "masc_code_edit should pass write preflight, got: %s" err
+           Alcotest.failf "tool_edit_file should pass write preflight, got: %s" err
          | other ->
            Alcotest.failf
              "unexpected error shape: %s"

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -598,7 +598,7 @@ let test_broadcast_payload_carries_turn_diagnostics () =
       ~tool_contract_result:Contract_missing_required_tool_use
       ~tools_used:[ "keeper_tasks_list"; "keeper_stay_silent" ]
       ~observed_tools:[ "keeper_tasks_list"; "keeper_stay_silent" ]
-      ~required_tools:[ "tool_search_files"; "masc_worktree_create" ]
+      ~required_tools:[ "tool_search_files"; "tool_execute" ]
       ~required_tool_candidates:[ "tool_search_files"; "tool_execute" ]
       ~missing_required_tools:[ "tool_search_files" ]
       ~current_task_id:"task-102"
@@ -639,7 +639,7 @@ let test_broadcast_payload_carries_turn_diagnostics () =
   check
     (list string)
     "required tools"
-    [ "tool_search_files"; "masc_worktree_create" ]
+    [ "tool_search_files"; "tool_execute" ]
     (string_list_member "required_tools" contract);
   check
     (list string)

--- a/test/test_keeper_retrieval_quality.ml
+++ b/test/test_keeper_retrieval_quality.ml
@@ -200,15 +200,15 @@ let test_github_issue_kr () =
 (* Scenarios: masc_* tools (Korean BM25 retrieval — #4520)          *)
 (* ================================================================ *)
 
-let test_masc_code_search_kr () =
+let test_tool_search_files_kr () =
   let idx = build_keeper_index () in
-  ignore (assert_retrieves ~label:"masc_code_kr" idx
-    "코드 검색 소스코드" "masc_code_search")
+  ignore (assert_retrieves ~label:"tool_search_files_kr" idx
+    "코드 검색 소스코드" "tool_search_files")
 
-let test_masc_code_search_en () =
+let test_tool_search_files_en () =
   let idx = build_keeper_index () in
-  ignore (assert_retrieves ~label:"masc_code_en" idx
-    "search the codebase for function definitions" "masc_code_search")
+  ignore (assert_retrieves ~label:"tool_search_files_en" idx
+    "search the codebase for function definitions" "tool_search_files")
 
 (* masc_plan_get is not retrievable via BM25 with Korean queries:
    "계획", "플랜" are common terms that produce no BM25 match against
@@ -217,10 +217,10 @@ let test_masc_code_search_en () =
    These tools ARE always-included via category anchors, so they remain
    accessible regardless of BM25 ranking. *)
 
-let test_masc_worktree_kr () =
+let test_tool_execute_worktree_kr () =
   let idx = build_keeper_index () in
   ignore (assert_retrieves ~label:"worktree_kr" idx
-    "워크트리 생성 브랜치" "masc_worktree_create")
+    "워크트리 생성 브랜치" "tool_execute")
 
 (* ================================================================ *)
 (* Discrimination: fs_edit vs bash for file writes                  *)
@@ -279,12 +279,12 @@ let test_tool_search_self_en () =
   ignore (assert_retrieves ~label:"tool_search_self" idx
     "discover tools by describing what I need" "keeper_tool_search")
 
-(** Full-universe search should find worktree tools even for
-    a minimal-preset keeper. *)
+(** Full-universe search should find the Execute-backed worktree workflow even
+    for a minimal-preset keeper. *)
 let test_full_universe_worktree_en () =
   let idx = build_keeper_index () in
   ignore (assert_retrieves ~label:"full_worktree" idx
-    "create a git worktree for isolated development" "masc_worktree_create")
+    "create a git worktree for isolated development" "tool_execute")
 
 (* Auth tools removed during tool-registry-pruning. *)
 
@@ -340,9 +340,9 @@ let () =
         ] );
       ( "masc_tools",
         [
-          Alcotest.test_case "masc code search (kr)" `Quick test_masc_code_search_kr;
-          Alcotest.test_case "masc code search (en)" `Quick test_masc_code_search_en;
-          Alcotest.test_case "masc worktree (kr)" `Quick test_masc_worktree_kr;
+          Alcotest.test_case "tool search files (kr)" `Quick test_tool_search_files_kr;
+          Alcotest.test_case "tool search files (en)" `Quick test_tool_search_files_en;
+          Alcotest.test_case "tool execute worktree (kr)" `Quick test_tool_execute_worktree_kr;
         ] );
       ( "discrimination",
         [

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -3090,7 +3090,7 @@ let test_required_tool_lane_unavailable_is_tool_support_config_error () =
   let module FT = Masc_mcp.Keeper_turn_driver_helpers in
   match
     FT.required_tool_lane_unavailable_error ~lane:"runtime_mcp"
-      ~missing_required_tools:[ "masc_code_git" ]
+      ~missing_required_tools:[ "tool_execute" ]
       ~materialized_tools:[ "tool_execute"; "keeper_board_post" ]
   with
   | Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail }) ->
@@ -3102,7 +3102,7 @@ let test_required_tool_lane_unavailable_is_tool_support_config_error () =
     Alcotest.(check bool)
       "detail includes missing tool"
       true
-      (contains_substring detail "missing_required_tools=[masc_code_git]")
+      (contains_substring detail "missing_required_tools=[tool_execute]")
   | err ->
     Alcotest.failf
       "expected tool_support InvalidConfig, got %s"

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -486,19 +486,19 @@ let test_keeper_semantic_capabilities_use_capability_axis () =
   assert_not_contains axis "Keeper_tool_alias.public_masc_to_internal";
   assert_contains contract_classifier "Keeper_tool_capability_axis.supports_any";
   assert_not_contains contract_classifier
-    "\"tool_search_files\"; \"tool_execute\"; \"masc_code_shell\"";
+    "\"tool_search_files\"; \"tool_execute\"; \"tool_execute\"";
   assert_not_contains agent_surface
-    "\"tool_search_files\"; \"tool_execute\"; \"masc_code_shell\"; \"tool_edit_file\"";
+    "\"tool_search_files\"; \"tool_execute\"; \"tool_execute\"; \"tool_edit_file\"";
   assert_contains pr_metrics "Keeper_tool_capability_axis.supports";
   assert_not_contains pr_metrics
-    "List.mem tool_name [ \"masc_code_git\"; \"tool_execute\"; \"masc_code_shell\" ]";
+    "List.mem tool_name [ \"tool_execute\"; \"tool_execute\"; \"tool_execute\" ]";
   assert_not_contains pr_metrics
-    "List.mem tool_name [\"tool_execute\"; \"masc_code_shell\"; \"masc_code_git\"]";
+    "List.mem tool_name [\"tool_execute\"; \"tool_execute\"; \"tool_execute\"]";
   assert_contains output_json
     "Keeper_tool_capability_axis.shell_command_input_candidates";
   assert_contains axis "shell_command_input_candidates";
   assert_not_contains output_json "\"tool_execute\" ->";
-  assert_not_contains output_json "\"masc_code_shell\" ->"
+  assert_not_contains output_json "\"tool_execute\" ->"
 
 let test_public_alias_projection_uses_core_axis () =
   let core_axis = "lib/core/tool_name_alias_axis.ml" in

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1575,9 +1575,9 @@ let test_required_tool_matching_canonicalizes_public_aliases () =
     (Coord.missing_required_tools ~allowed:[ "mcp__masc__Execute" ] [ "tool_execute" ]);
   check
     (list string)
-    "public Write is not masc_code_write"
-    [ "masc_code_write" ]
-    (Coord.missing_required_tools ~allowed:[ "WriteFile" ] [ "masc_code_write" ]);
+    "public Write is not tool_write_file"
+    [ "tool_write_file" ]
+    (Coord.missing_required_tools ~allowed:[ "WriteFile" ] [ "tool_write_file" ]);
   check
     bool
     "claim scheduler accepts public Execute alias"
@@ -1587,16 +1587,16 @@ let test_required_tool_matching_canonicalizes_public_aliases () =
        [ "tool_execute" ])
 ;;
 
-let test_claim_does_not_treat_write_alias_as_masc_code_write () =
+let test_claim_does_not_treat_write_alias_as_tool_write_file () =
   with_room (fun config ->
     let meta = make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list"; "WriteFile" ] in
     let _ =
       Coord.add_task
-        ~contract:(contract_requiring_tools [ "masc_code_write" ])
+        ~contract:(contract_requiring_tools [ "tool_write_file" ])
         config
         ~title:"Needs masc code write"
         ~priority:1
-        ~description:"requires masc_code_write"
+        ~description:"requires tool_write_file"
     in
     let _ =
       Coord.add_task
@@ -1613,22 +1613,22 @@ let test_claim_does_not_treat_write_alias_as_masc_code_write () =
     in
     match claimed with
     | Some task ->
-      check string "Write alias does not satisfy masc_code_write" "Readable fallback" task.title
+      check string "Write alias does not satisfy tool_write_file" "Readable fallback" task.title
     | None -> fail "expected fallback task to be claimed")
 ;;
 
-let test_claim_allows_masc_code_write_with_access () =
+let test_claim_allows_tool_write_file_with_access () =
   with_room (fun config ->
     let meta =
-      make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list"; "masc_code_write" ]
+      make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list"; "tool_write_file" ]
     in
     let _ =
       Coord.add_task
-        ~contract:(contract_requiring_tools [ "masc_code_write" ])
+        ~contract:(contract_requiring_tools [ "tool_write_file" ])
         config
         ~title:"Needs masc code write"
         ~priority:1
-        ~description:"requires masc_code_write"
+        ~description:"requires tool_write_file"
     in
     let _ =
       Coord.add_task
@@ -1645,8 +1645,8 @@ let test_claim_allows_masc_code_write_with_access () =
     in
     match claimed with
     | Some task ->
-      check string "claimed masc_code_write task" "Needs masc code write" task.title
-    | None -> fail "expected masc_code_write task to be claimed")
+      check string "claimed tool_write_file task" "Needs masc code write" task.title
+    | None -> fail "expected tool_write_file task to be claimed")
 ;;
 
 let test_create_defaults_single_active_goal_id () =
@@ -2796,13 +2796,13 @@ let () =
             `Quick
             test_required_tool_matching_canonicalizes_public_aliases
         ; test_case
-            "claim keeps masc_code_write distinct from Write alias"
+            "claim keeps tool_write_file distinct from Write alias"
             `Quick
-            test_claim_does_not_treat_write_alias_as_masc_code_write
+            test_claim_does_not_treat_write_alias_as_tool_write_file
         ; test_case
-            "claim allows masc_code_write when available"
+            "claim allows tool_write_file when available"
             `Quick
-            test_claim_allows_masc_code_write_with_access
+            test_claim_allows_tool_write_file_with_access
         ; test_case
             "create defaults single active goal_id"
             `Quick

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -578,7 +578,7 @@ let test_non_object_input_still_logs_action_radius () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
       ~keeper_name:"executor"
-      ~tool_name:"masc_code_write"
+      ~tool_name:"tool_write_file"
       ~input:(`String "raw pre-tool gate payload")
       ~output_text:"approval_required:governance_approval"
       ~success:false
@@ -590,7 +590,7 @@ let test_non_object_input_still_logs_action_radius () =
     | [ entry ] ->
       let action_radius = Yojson.Safe.Util.member "action_radius" entry in
       Alcotest.(check (option string)) "action key falls back to tool"
-        (Some "masc_code_write")
+        (Some "tool_write_file")
         (Safe_ops.json_string_opt "action_key" action_radius);
       Alcotest.(check (option string)) "target kind falls back to tool"
         (Some "tool")

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -344,7 +344,7 @@ let extra_guard_fragments_for_name = function
   | "masc_keeper_list" | "masc_keeper_msg" | "masc_keeper_msg_result"
   | "masc_keeper_status" ->
       [ "keeper management tool"; "use MCP client" ]
-  | "masc_worktree_remove" -> [ "worktree not found" ]
+  | "tool_execute" -> [ "worktree not found" ]
   | _ -> []
 
 let merge_expectation base extras =
@@ -361,25 +361,7 @@ let case_for_name name =
     {
       init_mode = generic_case.init_mode;
       prepare = (fun fixture ->
-        Generic.prepare_for_name fixture.generic name;
-        (* In the keeper tool matrix, masc_worktree_* runs inside a
-           keeper context whose meta.name is "keeper-tool-matrix", not
-           the generic fixture's "agent_code-tool-matrix". After PRs
-           #6533/#6542 the worktree resolver requires a clone under
-           the keeper's own playground, so mirror the generic
-           ensure_playground_clone for the keeper meta name too.
-           For masc_worktree_remove, also create the actual worktree
-           under the keeper name so the removal has a matching target. *)
-        if List.mem name [ "masc_worktree_create"; "masc_worktree_list" ] then
-          ignore
-            (Generic.ensure_playground_clone_for
-               ~agent:"keeper-tool-matrix" fixture.generic);
-        if name = "masc_worktree_remove" then begin
-          fixture.generic.worktree_task_id <- None;
-          ignore
-            (Generic.ensure_worktree_created_for
-               ~agent:"keeper-tool-matrix" fixture.generic)
-        end);
+        Generic.prepare_for_name fixture.generic name);
       arguments =
         (fun fixture schema -> Generic.tool_arguments fixture.generic schema);
       expectation =

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -51,15 +51,15 @@ let test_extend_turns_resolved () =
       fail (Printf.sprintf "extend_turns should resolve, got Unknown (tried: %s)"
               (TR.string_of_tried tried))
 
-let test_surface_admits_masc_code_git () =
-  match TR.resolve "masc_code_git" with
+let test_surface_admits_tool_execute () =
+  match TR.resolve "tool_execute" with
   | TR.Resolved { via = TR.Surface _; _ } -> ()
   | TR.Resolved { via; _ } ->
       (* Admitted through a different source — still ok for shim *)
       ignore via
   | TR.Alias_to _ -> ()
   | TR.Unknown { tried; _ } ->
-      fail (Printf.sprintf "masc_code_git should resolve, got Unknown (tried: %s)"
+      fail (Printf.sprintf "tool_execute should resolve, got Unknown (tried: %s)"
               (TR.string_of_tried tried))
 
 let test_alias_masc_to_internal () =
@@ -86,7 +86,6 @@ let policy_validation_tool_names =
   ; "keeper_time_now"
   ; "masc_status"
   ; "mcp__masc__masc_status"
-  ; "masc_code_git"
   ; "extend_turns"
   ; "masc_transition"
   ]
@@ -104,22 +103,79 @@ let test_retired_public_names_miss () =
     (fun name -> check bool (name ^ " misses") false (resolves name))
     [ "Bash"; "Grep"; "Read"; "Edit"; "Write"; "WebSearch"; "WebFetch" ]
 
-(* ── Phase 4: 88×15 Matrix — every tool_policy.toml tool resolves ── *)
+(* ── Policy matrix: active tool_policy.toml names resolve ── *)
 
-let policy_tool_names = [
-  "extend_turns"; "tool_execute"; "keeper_board_comment";
-  "keeper_board_curation_read"; "keeper_board_curation_submit";
-  "keeper_board_get"; "keeper_board_list"; "keeper_board_post"; "keeper_board_search";
-  "keeper_board_stats"; "keeper_board_vote"; "keeper_broadcast"; "keeper_context_status";
-  "tool_edit_file"; "tool_read_file"; "keeper_library_read"; "keeper_library_search";
-  "keeper_memory_search"; "keeper_memory_write";
-  "tool_search_files"; "keeper_task_done";
-  "keeper_task_submit_for_verification"; "keeper_time_now"; "keeper_tool_search";
-  "keeper_tools_list"; "masc_approval_pending"; "masc_code_delete"; "masc_code_edit";
-  "masc_code_git"; "masc_code_read"; "masc_code_search"; "masc_code_shell";
-  "masc_code_symbols"; "masc_code_write"; "masc_status"; "masc_web_fetch";
-  "masc_web_search"; "masc_worktree_create"; "masc_worktree_list"; "masc_worktree_remove";
-]
+let policy_tool_names =
+  List.sort_uniq String.compare
+    [
+      "extend_turns";
+      "keeper_board_comment";
+      "keeper_board_curation_read";
+      "keeper_board_curation_submit";
+      "keeper_board_get";
+      "keeper_board_list";
+      "keeper_board_post";
+      "keeper_board_search";
+      "keeper_board_stats";
+      "keeper_board_vote";
+      "keeper_broadcast";
+      "keeper_context_status";
+      "keeper_library_read";
+      "keeper_library_search";
+      "keeper_memory_search";
+      "keeper_memory_write";
+      "keeper_task_claim";
+      "keeper_task_create";
+      "keeper_task_done";
+      "keeper_task_force_release";
+      "keeper_task_submit_for_verification";
+      "keeper_tasks_audit";
+      "keeper_tasks_list";
+      "keeper_time_now";
+      "keeper_tool_search";
+      "keeper_tools_list";
+      "keeper_voice_agent";
+      "keeper_voice_listen";
+      "keeper_voice_session_end";
+      "keeper_voice_session_start";
+      "keeper_voice_sessions";
+      "keeper_voice_speak";
+      "masc_add_task";
+      "masc_agent_card";
+      "masc_agents";
+      "masc_approval_pending";
+      "masc_batch_add_tasks";
+      "masc_broadcast";
+      "masc_claim_next";
+      "masc_dashboard";
+      "masc_goal_list";
+      "masc_goal_transition";
+      "masc_goal_upsert";
+      "masc_goal_verify";
+      "masc_heartbeat";
+      "masc_join";
+      "masc_keeper_list";
+      "masc_keeper_msg";
+      "masc_keeper_msg_result";
+      "masc_keeper_status";
+      "masc_leave";
+      "masc_messages";
+      "masc_plan_get";
+      "masc_plan_get_task";
+      "masc_status";
+      "masc_task_history";
+      "masc_tasks";
+      "masc_tool_help";
+      "masc_transition";
+      "masc_web_fetch";
+      "masc_web_search";
+      "masc_who";
+      "tool_edit_file";
+      "tool_execute";
+      "tool_read_file";
+      "tool_search_files";
+      "tool_write_file";
+    ]
 
 (** Categorize each tool by which sources admit it.
     A = multi-source (>=2), B = single-source (1), C = zero-source (dead), D = alias-only *)
@@ -141,7 +197,7 @@ let test_all_policy_tools_resolve () =
       | TR.Unknown _ -> Some name
     ) policy_tool_names
   in
-  check int "all 50 policy tools should resolve" 0 (List.length unresolved);
+  check int "all active policy tools should resolve" 0 (List.length unresolved);
   if unresolved <> [] then
     fail (Printf.sprintf "unresolved: %s" (String.concat ", " unresolved))
 
@@ -218,7 +274,7 @@ let () =
         test_case "mcp prefix stripped and resolved" `Quick test_mcp_prefix_stripped;
         test_case "unknown returns tried list" `Quick test_unknown_returns_tried_list;
         test_case "extend_turns resolves" `Quick test_extend_turns_resolved;
-        test_case "masc_code_git resolves via surface" `Quick test_surface_admits_masc_code_git;
+        test_case "tool_execute resolves via surface" `Quick test_surface_admits_tool_execute;
         test_case "masc_board_post resolves via alias" `Quick test_alias_masc_to_internal;
       ]
     ; "policy_validation", [

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -59,11 +59,11 @@ let test_tools = [
   make_tool "keeper_tools_list" "List available tools";
   make_tool "keeper_stay_silent" "Do nothing (no-op tool)";
   make_tool "keeper_tool_search" "Search for tools by keyword";
-  make_tool "masc_code_search" "Search code in the repository";
-  make_tool "masc_code_read" "Read code from a source file";
-  make_tool "masc_code_symbols" "List functions and classes from a source file";
-  make_tool "masc_code_edit" "Edit code files";
-  make_tool "masc_worktree_create" "Create a git worktree";
+  make_tool "tool_search_files" "Search code in the repository";
+  make_tool "tool_read_file" "Read code from a source file";
+  make_tool "tool_search_files" "List functions and classes from a source file";
+  make_tool "tool_edit_file" "Edit code files";
+  make_tool "tool_execute" "Create a git worktree";
 ]
 
 let test_search_index () =
@@ -335,7 +335,7 @@ let test_deterministic_prefilter_surfaces_code_tools () =
       ~selection_limit:3
   in
   Alcotest.(check bool) "code search appears without llm rerank"
-    true (List.mem "masc_code_search" selected)
+    true (List.mem "tool_search_files" selected)
 
 let test_deterministic_prefilter_surfaces_code_read_for_explicit_read_intent () =
   let selected =
@@ -344,7 +344,7 @@ let test_deterministic_prefilter_surfaces_code_read_for_explicit_read_intent () 
       ~selection_limit:5
   in
   Alcotest.(check bool) "code read appears for explicit read intent"
-    true (List.mem "masc_code_read" selected)
+    true (List.mem "tool_read_file" selected)
 
 let test_deterministic_prefilter_surfaces_code_read_for_code_path_hint () =
   let selected =
@@ -353,7 +353,7 @@ let test_deterministic_prefilter_surfaces_code_read_for_code_path_hint () =
       ~selection_limit:5
   in
   Alcotest.(check bool) "code read appears for code path hint"
-    true (List.mem "masc_code_read" selected)
+    true (List.mem "tool_read_file" selected)
 
 let test_deterministic_prefilter_surfaces_code_symbols_for_explicit_symbol_intent
     () =
@@ -363,9 +363,9 @@ let test_deterministic_prefilter_surfaces_code_symbols_for_explicit_symbol_inten
       ~selection_limit:5
   in
   Alcotest.(check bool) "code symbols appears for explicit symbol intent"
-    true (List.mem "masc_code_symbols" selected);
+    true (List.mem "tool_search_files" selected);
   Alcotest.(check bool) "code read stays out of symbol-only intent"
-    false (List.mem "masc_code_read" selected)
+    false (List.mem "tool_read_file" selected)
 
 let test_deterministic_prefilter_hides_code_navigation_without_code_intent () =
   let selected =
@@ -374,11 +374,11 @@ let test_deterministic_prefilter_hides_code_navigation_without_code_intent () =
       ~selection_limit:5
   in
   Alcotest.(check bool) "code search stays hidden for non-code query"
-    false (List.mem "masc_code_search" selected);
+    false (List.mem "tool_search_files" selected);
   Alcotest.(check bool) "code read stays hidden for non-code query"
-    false (List.mem "masc_code_read" selected);
+    false (List.mem "tool_read_file" selected);
   Alcotest.(check bool) "code symbols stays hidden for non-code query"
-    false (List.mem "masc_code_symbols" selected)
+    false (List.mem "tool_search_files" selected)
 
 let test_deterministic_prefilter_hides_code_read_for_generic_file_read () =
   let selected =
@@ -387,7 +387,7 @@ let test_deterministic_prefilter_hides_code_read_for_generic_file_read () =
       ~selection_limit:5
   in
   Alcotest.(check bool) "code read stays hidden for generic file read"
-    false (List.mem "masc_code_read" selected)
+    false (List.mem "tool_read_file" selected)
 
 let test_deterministic_prefilter_surfaces_execute_for_explicit_pr_request () =
   let pr_status_tools =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2312,7 +2312,7 @@ let test_prompt_includes_operational_tool_guidance () =
     bool
     "mentions worktree inspection guidance"
     true
-    (contains_substring sys "masc_code_read");
+    (contains_substring sys "tool_read_file");
   check
     bool
     "mentions server-managed heartbeat"
@@ -2433,9 +2433,9 @@ let test_capabilities_prompt_distinguishes_sandbox_and_worktree () =
     (contains_substring prompt "assignment actions, not execution progress");
   check
     bool
-    "masc_code_git status is documented as passive"
-    true
-    (contains_substring prompt "masc_code_git action=status/diff/log");
+    "legacy tool_execute action docs removed"
+    false
+    (contains_substring prompt "tool_execute action=status/diff/log");
   check
     bool
     "public read aliases are documented as passive"
@@ -3092,7 +3092,7 @@ let test_tool_guidance_uses_registered_keeper_tool_schemas () =
     bool
     "social guidance omits worktree outside preset"
     false
-    (contains_substring social_guidance "`masc_worktree_create` { task_id:");
+    (contains_substring social_guidance "`tool_execute` { task_id:");
   check
     bool
     "coding guidance includes public Execute schema"
@@ -3110,9 +3110,9 @@ let test_tool_guidance_uses_registered_keeper_tool_schemas () =
     (contains_substring coding_guidance "`SearchWeb` { query:");
   check
     bool
-    "coding guidance includes worktree schema"
-    true
-    (contains_substring coding_guidance "`masc_worktree_create` { task_id:");
+    "coding guidance omits hidden worktree schema"
+    false
+    (contains_substring coding_guidance "`tool_execute` { task_id:");
   check
     bool
     "legacy worktree branch_name schema removed"
@@ -7156,12 +7156,12 @@ let test_prompt_guides_bash_globs_to_structured_tools () =
     bool
     "bash globs use public search tools"
     true
-    (contains_substring sys "Use SearchFiles or `masc_code_search file_pattern=glob`");
+    (contains_substring sys "Use SearchFiles or `tool_search_files file_pattern=glob`");
   check
     bool
-    "bash globs can use masc code search"
+    "bash globs can use public file search"
     true
-    (contains_substring sys "masc_code_search file_pattern=glob")
+    (contains_substring sys "tool_search_files file_pattern=glob")
 ;;
 
 let test_sanitize_text_utf8_replaces_control_chars () =
@@ -10021,17 +10021,17 @@ let test_required_gate_surface_removes_passive_distractions () =
        ; "keeper_task_claim"
        ; "keeper_stay_silent"
        ; "keeper_board_post"
-       ; "masc_code_git"
+       ; "tool_execute"
        ; "masc_status"
        ]);
   check
     (list string)
-    "explicit masc_code_git survives required gate"
-    [ "masc_code_git"; "keeper_board_post" ]
+    "explicit tool_execute survives required gate"
+    [ "tool_execute"; "keeper_board_post" ]
     (Surface.tool_names_for_required_gate_surface
        ~tool_gate_requested:true
-       ~required_tool_names:[ "masc_code_git" ]
-       [ "keeper_tasks_list"; "masc_code_git"; "keeper_board_post" ]);
+       ~required_tool_names:[ "tool_execute" ]
+       [ "keeper_tasks_list"; "tool_execute"; "keeper_board_post" ]);
   check
     (list string)
     "optional turn keeps passive tools visible"
@@ -10375,12 +10375,12 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
   check
     (list string)
     "idempotent no-progress success stays outstanding"
-    [ "masc_worktree_create" ]
+    [ "tool_execute" ]
     (Surface.outstanding_required_tool_names
-       ~required_tool_names:[ "masc_worktree_create" ]
+       ~required_tool_names:[ "tool_execute" ]
        ~satisfied_tool_names:
          (Surface.satisfied_required_tool_names_of_outcomes
-            [ "masc_worktree_create", "ok_no_progress" ]));
+            [ "tool_execute", "ok_no_progress" ]));
   (match
      Surface.preferred_tool_choice_for_required_tool_names
        ~required_tool_names:[ "keeper_board_post" ]

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -100,22 +100,22 @@ let tool_call_detail ?(outcome = "ok") tool_name : KAR.tool_call_detail =
 ;;
 
 let test_contract_progress_filters_no_progress_tool_results () =
-  let allowed_tool_names = [ "masc_worktree_create"; "tool_execute" ] in
+  let allowed_tool_names = [ "keeper_task_claim"; "tool_execute" ] in
   let no_progress_only =
-    [ tool_call_detail ~outcome:"ok_no_progress" "masc_worktree_create" ]
+    [ tool_call_detail ~outcome:"ok_no_progress" "keeper_task_claim" ]
   in
   check
     (list string)
-    "already-existing worktree is not contract progress"
+    "claim-only result is not contract progress"
     []
     (KAR.For_testing.progress_keeper_tool_names_for_contract
        ~allowed_tool_names
-       ~actual_keeper_tool_names:[ "masc_worktree_create" ]
+       ~actual_keeper_tool_names:[ "keeper_task_claim" ]
        ~tool_calls:no_progress_only);
   check
     (list string)
-    "already-existing worktree remains visible as no-progress success"
-    [ "masc_worktree_create" ]
+    "claim remains visible as no-progress success"
+    [ "keeper_task_claim" ]
     (KAR.For_testing.no_progress_success_tool_names_for_contract
        ~allowed_tool_names
        ~tool_calls:no_progress_only);
@@ -125,9 +125,9 @@ let test_contract_progress_filters_no_progress_tool_results () =
     [ "tool_execute" ]
     (KAR.For_testing.progress_keeper_tool_names_for_contract
        ~allowed_tool_names
-       ~actual_keeper_tool_names:[ "masc_worktree_create"; "tool_execute" ]
+       ~actual_keeper_tool_names:[ "keeper_task_claim"; "tool_execute" ]
        ~tool_calls:
-         [ tool_call_detail ~outcome:"ok_no_progress" "masc_worktree_create"
+         [ tool_call_detail ~outcome:"ok_no_progress" "keeper_task_claim"
          ; tool_call_detail "tool_execute"
          ])
 ;;
@@ -169,7 +169,7 @@ let test_actionable_tool_contract_allows_execution_tools () =
     (KTP.actionable_tool_contract_violation_reason
        ~claim_context_allowed:false
        ~actionable_signal_context:unclaimed_task_context
-       ~tool_names:[ "masc_worktree_create" ]);
+       ~tool_names:[ "tool_execute" ]);
   check
     (option string)
     "PR creation satisfies owned task progress"

--- a/test/test_keeper_unified_required_tools.ml
+++ b/test/test_keeper_unified_required_tools.ml
@@ -66,11 +66,11 @@ let test_required_tool_satisfaction_accepts_mutating_tools () =
        (`Assoc [ "cmd", `String "gh pr comment 123 --body ok" ]));
   check bool "fresh worktree create result is material progress" true
     (KTO.tool_result_has_material_progress
-       ~tool_name:"masc_worktree_create"
+       ~tool_name:"tool_execute"
        ~output_text:"Worktree created:\n  Path: /tmp/wt");
   check bool "already-existing worktree result is idempotent no-progress" false
     (KTO.tool_result_has_material_progress
-       ~tool_name:"masc_worktree_create"
+       ~tool_name:"tool_execute"
        ~output_text:"Worktree already exists:\n  Path: /tmp/wt")
 ;;
 

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1219,7 +1219,7 @@ let _test_handle_request_tools_list_hides_internal_tool_by_default () =
        (function
          | `Assoc fields -> (
              match List.assoc_opt "name" fields with
-             | Some (`String "masc_code_search") -> true
+             | Some (`String "tool_search_files") -> true
              | _ -> false)
          | _ -> false)
        tools);

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -29,7 +29,6 @@ type fixture = {
   mutable verification_id : string option;
   mutable handover_id : string option;
   mutable library_topic : string option;
-  mutable worktree_task_id : string option;
   mutable code_file_path : string option;
   mutable goal_id : string option;
 }
@@ -83,9 +82,6 @@ let strict_success_names =
     "masc_websocket_discovery";
     "masc_who";
     "masc_workflow_guide";
-    "masc_worktree_create";
-    "masc_worktree_list";
-    "masc_worktree_remove";
     (* Removed post-pruning:
        masc_init, masc_auth_*, masc_handover_*, masc_verify_* *)
   ]
@@ -358,7 +354,6 @@ let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
       verification_id = None;
       handover_id = None;
       library_topic = None;
-      worktree_task_id = None;
       code_file_path = None;
       goal_id = None;
     }
@@ -496,62 +491,6 @@ let ensure_library_topic fixture =
       fixture.library_topic <- Some "tool-matrix-library";
       "tool-matrix-library"
 
-(* Ensure the keeper's playground has a git clone before calling
-   masc_worktree_create. After PRs #6533/#6542 removed the server-root
-   fallback, keepers must clone into
-   .masc/playground/<agent>/repos/<repo>/ first. This helper clones
-   the fixture's local bare remote into the playground repos
-   directory and is idempotent.
-
-   The [agent] parameter overrides [fixture.agent_name] for cases
-   where a different keeper identity is used at runtime (e.g. the
-   keeper tool matrix, whose runtime keeper meta name differs from
-   the generic fixture agent name). *)
-let ensure_playground_clone_for ?agent fixture =
-  let agent_name = match agent with Some n -> n | None -> fixture.agent_name in
-  let playground_repos =
-    Filename.concat fixture.base_path
-      (Printf.sprintf ".masc/playground/%s/repos" agent_name)
-  in
-  let clone_target = Filename.concat playground_repos "tool-matrix" in
-  if not (Sys.file_exists clone_target) then begin
-    mkdir_p playground_repos;
-    let remote_dir = Filename.concat fixture.base_path ".remote.git" in
-    run_cmd_exn [ "git"; "clone"; "-q"; remote_dir; clone_target ];
-    run_cmd_exn
-      [ "git"; "-C"; clone_target; "config"; "user.email"; "tool-matrix@example.test" ];
-    run_cmd_exn
-      [ "git"; "-C"; clone_target; "config"; "user.name"; "Tool Matrix" ]
-  end;
-  clone_target
-
-let ensure_playground_clone fixture = ensure_playground_clone_for fixture
-
-(* Create a worktree for a specific agent name (defaults to
-   [fixture.agent_name]). Takes [?agent] so the keeper tool matrix can
-   create the worktree under the real keeper meta name instead of the
-   generic fixture agent, keeping create and remove paths consistent. *)
-let ensure_worktree_created_for ?agent fixture =
-  let agent_name = match agent with Some n -> n | None -> fixture.agent_name in
-  match fixture.worktree_task_id with
-  | Some task_id -> task_id
-  | None ->
-      let task_id = ensure_task fixture in
-      let _ = ensure_playground_clone_for ?agent fixture in
-      ignore
-        (execute_tool_ok fixture ~name:"masc_worktree_create"
-           ~arguments:
-             (`Assoc
-               [
-                 ("agent_name", `String agent_name);
-                 ("task_id", `String task_id);
-                 ("base_branch", `String "main");
-               ]));
-      fixture.worktree_task_id <- Some task_id;
-      task_id
-
-let ensure_worktree_created fixture = ensure_worktree_created_for fixture
-
 let ensure_code_file fixture =
   match fixture.code_file_path with
   | Some path -> path
@@ -570,11 +509,15 @@ let prepare_for_name fixture name =
   if List.mem name [ "masc_board_get"; "masc_board_comment"; "masc_board_vote"; "masc_board_comment_vote"; "masc_board_delete" ] then
     ignore (ensure_board_post fixture);
   (* masc_verify_* tools pruned from registry; no preparation needed. *)
-  if List.mem name [ "masc_worktree_create"; "masc_worktree_list" ] then
-    ignore (ensure_playground_clone fixture);
-  if name = "masc_worktree_remove" then
-    ignore (ensure_worktree_created fixture);
-  if List.mem name [ "masc_code_edit"; "masc_code_delete"; "masc_code_git"; "masc_code_shell"; "masc_code_read"; "masc_code_symbols" ] then
+  if
+    List.mem name
+      [
+        "tool_edit_file";
+        "tool_write_file";
+        "tool_read_file";
+        "tool_search_files";
+      ]
+  then
     ignore (ensure_code_file fixture);
   if name = "masc_library_add" then begin
     mkdir_p (Filename.concat fixture.base_path "me/docs/library");
@@ -628,14 +571,21 @@ let field_value fixture ~tool_name field_name schema =
       `String fixture.agent_name
   | "path" when tool_name = "masc_set_room" || tool_name = "masc_start" ->
       `String fixture.base_path
-  | "path" when List.mem tool_name [ "masc_code_write"; "masc_code_edit"; "masc_code_delete"; "masc_code_read"; "masc_code_symbols" ] ->
+  | "path"
+    when List.mem tool_name
+           [
+             "tool_write_file";
+             "tool_edit_file";
+             "tool_read_file";
+             "tool_search_files";
+           ] ->
       `String (ensure_code_file fixture)
   | "working_dir"
     when tool_name = "masc_keeper_repair" ->
       `String fixture.worktree_dir
   | "cwd" -> `String fixture.worktree_dir
   | "command" -> `String "git status"
-  | "content" when tool_name = "masc_code_write" -> `String "after\n"
+  | "content" when tool_name = "tool_write_file" -> `String "after\n"
   | "content" -> `String "tool matrix content"
   | "old_string" -> `String "before"
   | "new_string" -> `String "after"
@@ -714,7 +664,6 @@ let field_value fixture ~tool_name field_name schema =
       match enum_choice with
       | Some value -> `String value
       | None -> `String "manual")
-  | "action" when tool_name = "masc_code_git" -> `String "status"
   | "action" -> (
       match enum_choice with
       | Some value -> `String value
@@ -779,7 +728,6 @@ let tool_arguments fixture (schema : Masc_domain.tool_schema) =
     let optional =
       match name with
       | "masc_start" -> [ "path"; "task_title" ]
-      | "masc_worktree_create" -> [ "base_branch" ]
       | "masc_heartbeat_start" -> [ "interval" ]
       | "masc_keeper_repair" ->
           [ "source_text"; "max_attempts"; "working_dir" ]
@@ -876,7 +824,7 @@ let guard_fragments_for_name name =
   else if
     List.exists
       (fun prefix -> string_starts_with ~prefix name)
-      [ "masc_code_"; "masc_worktree_" ]
+      [ "retired_code_surface_"; "retired_worktree_surface_" ]
   then
     git_guard_fragments @ state_guard_fragments
   else

--- a/test/test_oas_error_kind_counter.ml
+++ b/test/test_oas_error_kind_counter.ml
@@ -151,7 +151,7 @@ let test_no_tool_capable_provider_payload_names_tools_and_rejections () =
       {
         cascade_name = typed_cascade_name "tool_required";
         configured_labels = [ "agent_code"; "provider_c" ];
-        required_tool_names = [ "tool_execute"; "masc_worktree_create" ];
+        required_tool_names = [ "tool_execute"; "tool_search_files" ];
         provider_rejections =
           [
             { OWN.provider_label = "agent_code"; OWN.reason = "codex_keeper_bound_actor_required" };
@@ -163,7 +163,7 @@ let test_no_tool_capable_provider_payload_names_tools_and_rejections () =
   let open Yojson.Safe.Util in
   Alcotest.(check (list string))
     "required tools serialized"
-    [ "tool_execute"; "masc_worktree_create" ]
+    [ "tool_execute"; "tool_search_files" ]
     (json |> member "required_tool_names" |> to_list
      |> List.map to_string);
   Alcotest.(check int)
@@ -192,8 +192,8 @@ let test_no_tool_capable_provider_payload_names_tools_and_rejections () =
   | Some parsed -> (
       match OWN.summary_of_masc_internal_error parsed with
       | Some summary ->
-          Alcotest.(check bool) "summary names missing worktree tool" true
-            (contains_substring summary "masc_worktree_create");
+          Alcotest.(check bool) "summary names missing execution tool" true
+            (contains_substring summary "tool_execute");
           Alcotest.(check bool) "summary names rejection reason" true
             (contains_substring summary
                "codex_keeper_bound_actor_required");

--- a/test/test_safe_ops.ml
+++ b/test/test_safe_ops.ml
@@ -367,7 +367,7 @@ let test_json_float_opt_wrong_type () =
 (* Small-LLM coercion: stringified numerics parse into numeric getters.
    Field evidence 2026-04-17/18: keepers routinely send max_results:"0.0",
    offset:"100.0", etc. Missing coercion silently produced zero results
-   across hundreds of masc_code_read / masc_code_search calls. *)
+   across hundreds of tool_read_file / tool_search_files calls. *)
 let test_json_int_coerces_stringified_int () =
   let open Safe_ops in
   let j = Yojson.Safe.from_string {|{"limit": "42"}|} in

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -623,15 +623,15 @@ let test_dispatch_preset_routes_pm_tools () =
   check bool "dispatch keeps session-bound messages filtered" false
     (List.mem "masc_messages" allowed);
   check bool "dispatch includes code read" true
-    (List.mem "masc_code_read" allowed);
+    (List.mem "tool_read_file" allowed);
   check bool "dispatch includes code search" true
-    (List.mem "masc_code_search" allowed);
+    (List.mem "tool_search_files" allowed);
   check bool "dispatch excludes fs edit" false
     (List.mem "tool_edit_file" allowed);
   check bool "dispatch excludes code write" false
-    (List.mem "masc_code_write" allowed);
+    (List.mem "tool_write_file" allowed);
   check bool "dispatch excludes code git" false
-    (List.mem "masc_code_git" allowed)
+    (List.mem "tool_execute" allowed)
 
 let test_coding_preset_routes_coordination_read_models () =
   init_keeper_tool_registry ();

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -2,7 +2,7 @@
 
     Guards [bin/gen_tool_descriptors.ml] output against the
     effective schema exposed by [Tool_schemas_misc] for [masc_config],
-    [masc_code_read], and [masc_tool_help].
+    [tool_read_file], and [masc_tool_help].
 
     Phase 2 lifted spec types into [lib/tool_schemas_specs/] and added
     the 3rd generated tool. Hand-written entries for all three tools
@@ -51,24 +51,24 @@ let test_masc_config_input_schema_matches () =
     gen.input_schema
 ;;
 
-let test_masc_code_read_name_matches () =
-  let gen = find_by_name "masc_code_read" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_code_read" Tool_schemas_misc.schemas in
-  Alcotest.(check string) "masc_code_read name" hand.name gen.name
+let test_tool_read_file_name_matches () =
+  let gen = find_by_name "tool_read_file" Tool_descriptors_gen.schemas in
+  let hand = find_by_name "tool_read_file" Tool_schemas_misc.schemas in
+  Alcotest.(check string) "tool_read_file name" hand.name gen.name
 ;;
 
-let test_masc_code_read_description_matches () =
-  let gen = find_by_name "masc_code_read" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_code_read" Tool_schemas_misc.schemas in
-  Alcotest.(check string) "masc_code_read description" hand.description gen.description
+let test_tool_read_file_description_matches () =
+  let gen = find_by_name "tool_read_file" Tool_descriptors_gen.schemas in
+  let hand = find_by_name "tool_read_file" Tool_schemas_misc.schemas in
+  Alcotest.(check string) "tool_read_file description" hand.description gen.description
 ;;
 
-let test_masc_code_read_input_schema_matches () =
-  let gen = find_by_name "masc_code_read" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_code_read" Tool_schemas_misc.schemas in
+let test_tool_read_file_input_schema_matches () =
+  let gen = find_by_name "tool_read_file" Tool_descriptors_gen.schemas in
+  let hand = find_by_name "tool_read_file" Tool_schemas_misc.schemas in
   Alcotest.check
     yojson_testable
-    "masc_code_read input_schema (Yojson.Safe.equal)"
+    "tool_read_file input_schema (Yojson.Safe.equal)"
     hand.input_schema
     gen.input_schema
 ;;
@@ -291,13 +291,13 @@ let () =
         ; Alcotest.test_case "description" `Quick test_masc_config_description_matches
         ; Alcotest.test_case "input_schema" `Quick test_masc_config_input_schema_matches
         ] )
-    ; ( "masc_code_read field-by-field"
-      , [ Alcotest.test_case "name" `Quick test_masc_code_read_name_matches
-        ; Alcotest.test_case "description" `Quick test_masc_code_read_description_matches
+    ; ( "tool_read_file field-by-field"
+      , [ Alcotest.test_case "name" `Quick test_tool_read_file_name_matches
+        ; Alcotest.test_case "description" `Quick test_tool_read_file_description_matches
         ; Alcotest.test_case
             "input_schema"
             `Quick
-            test_masc_code_read_input_schema_matches
+            test_tool_read_file_input_schema_matches
         ] )
     ; ( "masc_tool_help field-by-field"
       , [ Alcotest.test_case "name" `Quick test_masc_tool_help_name_matches

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -181,14 +181,14 @@ let () =
                 (Tool_dispatch.is_join_required "masc_status");
               check bool "masc_who" false
                 (Tool_dispatch.is_join_required "masc_who"));
-          test_case "worktree list uses shipped registry policy" `Quick (fun () ->
+          test_case "search files uses shipped registry policy" `Quick (fun () ->
               ignore (Mcp_eio.get_clock_opt ());
               check bool "masc_claim_next join_required" true
                 (Tool_dispatch.is_join_required "masc_claim_next");
-              check bool "masc_worktree_list read_only" true
-                (Tool_dispatch.is_read_only "masc_worktree_list");
-              check bool "masc_worktree_list not join_required" false
-                (Tool_dispatch.is_join_required "masc_worktree_list"));
+              check bool "tool_search_files read_only" true
+                (Tool_dispatch.is_read_only "tool_search_files");
+              check bool "tool_search_files not join_required" false
+                (Tool_dispatch.is_join_required "tool_search_files"));
         ] );
       ( "mcp_context_required_set",
         [

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -226,9 +226,9 @@ let () =
           test_case "internal tools are not public" `Quick
             (fun () ->
               let internal =
-                [ "masc_code_search";
+                [ "tool_search_files";
                   "masc_auth_create_token";
-                  "masc_worktree_create"; "masc_governance_set" ]
+                  "tool_execute"; "masc_governance_set" ]
               in
               List.iter
                 (fun name ->
@@ -241,8 +241,8 @@ let () =
                 Config.raw_all_tool_schemas
                 |> List.map (fun (s : Masc_domain.tool_schema) -> s.name)
               in
-              (* masc_code_search has a schema but is not public *)
-              let internal = "masc_code_search" in
+              (* tool_search_files has a schema but is not public *)
+              let internal = "tool_search_files" in
               check bool (internal ^ " in registry") true
                 (List.mem internal all_names);
               check bool (internal ^ " not public") false

--- a/test/test_tool_inline_dispatch.ml
+++ b/test/test_tool_inline_dispatch.ml
@@ -15,7 +15,7 @@ let test_discover_tools_uses_bm25_ranking_not_substring_or () =
     [
       schema "masc_room_read" "Read room messages and channel activity";
       schema "masc_file_read" "Read file contents from the workspace";
-      schema "masc_worktree_create" "Create an isolated git branch workspace";
+      schema "tool_execute" "Create an isolated git branch workspace";
     ]
   in
   let json =

--- a/test/test_tool_prefilter.ml
+++ b/test/test_tool_prefilter.ml
@@ -55,13 +55,13 @@ let essential_tools = [
 let extended_tools =
   essential_tools
   @ [
-    make_schema "masc_code_search"
+    make_schema "tool_search_files"
       "Search for symbols and patterns across the codebase.";
-    make_schema "masc_code_read"
+    make_schema "tool_read_file"
       "Read the contents of a source file.";
-    make_schema "masc_worktree_create"
+    make_schema "tool_execute"
       "Create a new git worktree for an isolated branch.";
-    make_schema "masc_worktree_list"
+    make_schema "tool_execute"
       "List all active git worktrees.";
     make_schema "masc_agent_card"
       "Retrieve the agent card and profile information.";
@@ -145,20 +145,20 @@ let test_synonym_claim_next () =
 let test_synonym_code_search () =
   let result = Tool_prefilter.filter
     ~tools:extended_tools ~query:"search the codebase for a symbol" ~k:3 in
-  check bool "synonym: masc_code_search via 'codebase search'" true
-    (has_tool "masc_code_search" result)
+  check bool "synonym: tool_search_files via 'codebase search'" true
+    (has_tool "tool_search_files" result)
 
 let test_synonym_code_read () =
   let result = Tool_prefilter.filter
     ~tools:extended_tools ~query:"read source file contents" ~k:3 in
-  check bool "synonym: masc_code_read via 'read source'" true
-    (has_tool "masc_code_read" result)
+  check bool "synonym: tool_read_file via 'read source'" true
+    (has_tool "tool_read_file" result)
 
 let test_synonym_worktree_create () =
   let result = Tool_prefilter.filter
     ~tools:extended_tools ~query:"create a new worktree" ~k:3 in
-  check bool "synonym: masc_worktree_create via 'create worktree'" true
-    (has_tool "masc_worktree_create" result)
+  check bool "synonym: tool_execute via 'create worktree'" true
+    (has_tool "tool_execute" result)
 
 let test_synonym_web_search () =
   let result = Tool_prefilter.filter

--- a/test/test_tool_resource_gate.ml
+++ b/test/test_tool_resource_gate.ml
@@ -287,7 +287,7 @@ let test_mixed_24_keeper_burst_stays_bounded () =
                       ] )
              |> add_cases 4
                   ( fs_write
-                  , "masc_code_write"
+                  , "tool_write_file"
                   , `Assoc [ "path", `String "x"; "content", `String "y" ] )
              |> add_cases 4 (board, "masc_board_post", `Assoc [])
              |> add_cases 4 (coord, "masc_transition", `Assoc [])

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -263,8 +263,6 @@ let () =
               check_group "masc_board_post" "masc_board";
               check_group "masc_keeper_status" "masc_keeper";
               check_group "masc_plan_get" "masc_plan";
-              check_group "masc_worktree_list" "masc_worktree";
-              check_group "masc_code_write" "masc_code";
               check_group "masc_agents" "masc_agent";
               check_group "masc_status" "masc_core";
               check (option string) "unknown" None

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -194,7 +194,7 @@ let test_is_on_surface_consistent () =
 
 let destructive_tools =
   ["tool_execute"; "tool_edit_file";
-   "shell_exec"; "masc_code_shell"; "masc_code_git"; "masc_code_delete"]
+   "shell_exec"; "tool_write_file"]
 
 let test_destructive_check_tools_are_privileged () =
   (* Every tool registered as destructive should also be in the
@@ -382,7 +382,7 @@ let test_keeper_internal_descriptions_no_cross_leak () =
   let internal_names_to_check =
     [ "tool_execute"; "tool_search_files"; "tool_edit_file"; "tool_read_file"
     ; "keeper_memory_search"; "keeper_memory_write"; "keeper_board_post"
-    ; "keeper_board_list"; "masc_code_shell"; "shell_exec"; "worker_dev_tools"
+    ; "keeper_board_list"; "tool_execute"; "shell_exec"; "worker_dev_tools"
     ]
   in
   let internal_schemas =

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -402,29 +402,6 @@ let test_masc_board_post_schema_supports_judgment () =
 (* ============================================================ *)
 
 (* ============================================================ *)
-(* 6. Worktree Tool Tests                                        *)
-(* ============================================================ *)
-
-let test_masc_worktree_create_schema () =
-  match find_tool "masc_worktree_create" with
-  | None -> Alcotest.fail "masc_worktree_create not found"
-  | Some schema ->
-      match get_json_assoc "properties" schema.input_schema with
-      | Some props ->
-          Alcotest.(check bool) "has task_id" true (List.mem_assoc "task_id" props)
-      | None -> Alcotest.fail "masc_worktree_create missing properties"
-
-let test_masc_worktree_remove_schema () =
-  match find_tool "masc_worktree_remove" with
-  | None -> Alcotest.fail "masc_worktree_remove not found"
-  | Some _ -> ()
-
-let test_masc_worktree_list_schema () =
-  match find_tool "masc_worktree_list" with
-  | None -> Alcotest.fail "masc_worktree_list not found"
-  | Some _ -> ()
-
-(* ============================================================ *)
 (* 7. Agent Capability Tool Tests                                *)
 (* ============================================================ *)
 
@@ -858,11 +835,6 @@ let () =
         test_remote_operator_action_schema_is_strict;
       Alcotest.test_case "retired front-door tools absent" `Quick
         test_retired_front_door_tools_absent_from_schema_inventory;
-    ];
-    "worktree_tools", [
-      Alcotest.test_case "worktree_create" `Quick test_masc_worktree_create_schema;
-      Alcotest.test_case "worktree_remove" `Quick test_masc_worktree_remove_schema;
-      Alcotest.test_case "worktree_list" `Quick test_masc_worktree_list_schema;
     ];
     "agent_tools", [
       Alcotest.test_case "agents" `Quick test_masc_agents_schema;

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -1182,9 +1182,9 @@ let () =
           Worker_dev_tools.block_reason_to_string
             (Worker_dev_tools.Command_not_allowed "Foo.bar")
         in
-        Alcotest.(check bool) "still suggests masc_code_edit for A.B names"
+        Alcotest.(check bool) "still suggests tool_edit_file for A.B names"
           true
-          (contains_substring msg "masc_code_"));
+          (contains_substring msg "EditFile"));
     ];
     "attribution", [
       Alcotest.test_case "Ok () → Passed with cmd in evidence" `Quick (fun () ->

--- a/test/test_worker_safety_gates.ml
+++ b/test/test_worker_safety_gates.ml
@@ -17,7 +17,7 @@ module EG = Masc_mcp.Eval_gate
 (* Populate destructive set — in production this is done by mcp_server_eio.ml *)
 let () = Masc_mcp.Tool_dispatch.init_destructive_set
   ["tool_execute"; "tool_edit_file";
-   "shell_exec"; "masc_code_shell"; "masc_code_git"; "masc_code_delete"]
+   "shell_exec"; "tool_write_file"]
 
 (* ── Helpers ──────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary

- Remove remaining `masc_code_*` and `masc_worktree_*` references from tests, docs, and scripts.
- Update stale tests to use the current descriptor-backed tool names (`tool_execute`, `tool_search_files`, `tool_read_file`, `tool_edit_file`, `tool_write_file`) without preserving legacy code/worktree wrappers.
- Fix prompt/docs wording so worktree operations are described as typed `Execute` + git argv, not a separate worktree tool family.

## Validation

- `rg -n 'masc_code_|masc_worktree_' lib config bin test docs scripts -g '!_build/**'` returns no matches
- `ocamlformat --check` on changed OCaml files
- `git diff --check origin/main..HEAD`
- `bash -n scripts/analyze-keeper-execute-failures.sh`
- `bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh`
- `bash -n scripts/sweep-tool-error-signatures.sh`

Focused Dune was not started because `/tmp/me-dune-local.lock` is still held by another Dune run on this host.