### PR TITLE
refactor(cascade): purge P1 string recovery

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 19:09:43 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 19:40:17 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -667,9 +667,15 @@
           </tr>
           <tr>
             <td>Keeper status-bridge summary recovery</td>
-            <td><span class="status now">active branch</span></td>
+            <td><span class="status done">merged #18687</span></td>
             <td>Stop reparsing typed blocker summaries as <code>[masc_oas_error]</code> payloads and stop projecting <code>Resumable_cli_session</code> into <code>Cascade_exhausted (Other_detail ...)</code>.</td>
-            <td>This branch changes <code>Keeper_status_bridge_blocker</code> and flips tests to prove no status blocker is fabricated from the resumable-session typed error.</td>
+            <td>Merged as <code>f8b48d4a4</code>. Status bridge blockers now derive only from typed blocker values; summaries remain display text.</td>
+          </tr>
+          <tr>
+            <td>Cascade/OAS string recovery purge</td>
+            <td><span class="status now">active branch</span></td>
+            <td>Remove the remaining P1 string recovery paths: raw resumable CLI hint promotion, <code>cascade_exhaustion_reason_from_message</code>, and <code>max_execution_time_s</code> substring-based timeout/saturation promotion.</td>
+            <td>This branch keeps structured <code>Resumable_cli_session</code>, <code>Provider_timeout</code>, and typed <code>Structural_attempt_timeout</code> envelopes, but free-form text stays opaque. Raw CLI resume hints are redacted at the transport boundary and no longer promoted to typed cascade errors.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
@@ -703,27 +709,6 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>P1</td>
-            <td>Status bridge typed-blocker summary recovery</td>
-            <td><code>runtime_blocker_surface_of_typed_class</code> still treats a free-form summary as a hidden parse boundary, so a typed blocker can be rewritten by an embedded <code>[masc_oas_error]</code> string.</td>
-            <td>Current branch: keep <code>summary</code> as opaque display text and derive class/continue-gate only from the already-typed <code>blocker_class</code>.</td>
-            <td>Flip tests to assert summaries are not reparsed and <code>Resumable_cli_session</code> does not stamp a cascade blocker.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td>Cascade/OAS timeout substring source</td>
-            <td><code>cascade_exhaustion_reason_from_message</code>, <code>timeout_source_label</code>, and saturation-signal classification still infer <code>max_execution_time_s</code> from message text.</td>
-            <td>Replace with a typed timeout source from the provider/OAS boundary. If upstream cannot provide it yet, stop promoting the string to <code>Structural_attempt_timeout</code> and treat it as opaque <code>Other_detail</code>.</td>
-            <td>Delete tests that construct structural timeouts by embedding <code>max_execution_time_s</code> in a string; keep typed constructor tests only.</td>
-          </tr>
-          <tr>
-            <td>P1</td>
-            <td>Resumable CLI raw-hint classifier</td>
-            <td><code>message_looks_like_resumable_cli_session</code> and related helpers still detect session resumability from raw CLI output text, which keeps a parser-shaped safety net around a provider/transport contract.</td>
-            <td>Keep only structured <code>Resumable_cli_session</code> envelopes from the CLI transport. Remove raw text hint detection from SDK error helpers and degraded-retry classification.</td>
-            <td>Delete raw-hint preservation tests; keep structured envelope tests and redaction tests.</td>
-          </tr>
           <tr>
             <td>P2</td>
             <td>Memory/context legacy read fallbacks</td>

--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -2,7 +2,7 @@
 
     Extracted from oas_worker_named.ml (God file decomposition).
     Converts OAS SDK errors into Cascade_fsm provider outcomes,
-    classifies CLI-wrapped error patterns (hard quota, resumable sessions),
+    classifies CLI-wrapped hard-quota patterns,
     and enriches errors with provider-specific hints.
 
     @since God file decomposition *)
@@ -31,12 +31,8 @@ let label_cascade = "cascade"
 let label_source = "source"
 let fallback_class_hard_quota = "hard_quota"
 let fallback_class_max_turns = "max_turns"
-let fallback_class_resumable_cli_session = "resumable_cli_session"
 let fallback_class_required_tool_contract_violation =
   "required_tool_contract_violation"
-
-let provider_label_max_execution_time = "max_execution_time"
-
 
 let retry_message_looks_like_model_access_denied (message : string) : bool =
   String_util.contains_substring_ci message "permission to access"
@@ -399,57 +395,10 @@ let exit_code_of_message (message : string) : int option =
               in
               int_of_string_opt raw
 
-let message_looks_like_resumable_cli_session (message : string) : bool =
-  Cascade_transport.Json_stream_cli_transport_local.text_looks_like_resumable_session
-    message
-
-let resumable_cli_session_detail (message : string) : string =
-  Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail_of_text
-    message
-
-let resumable_cli_session_exit_code (message : string) : int option =
-  Cascade_transport.Json_stream_cli_transport_local.resumable_session_exit_code_of_text
-    message
-
-let sdk_error_to_resumable_cli_session ~cascade_name
-    (err : Agent_sdk.Error.sdk_error) =
-  match Cascade_error_classify.classify_masc_internal_error err with
-  | Some (Cascade_error_classify.Resumable_cli_session _) -> Some err
-  | _ ->
-      let message = Agent_sdk.Error.to_string err in
-      if message_looks_like_resumable_cli_session message then
-        Some
-          (Cascade_error_classify.sdk_error_of_masc_internal_error
-             (Cascade_error_classify.Resumable_cli_session
-                {
-                  cascade_name =
-                    cascade_name;
-                  detail = resumable_cli_session_detail message;
-                  exit_code = resumable_cli_session_exit_code message;
-                }))
-      else None
-
 let sdk_error_is_resumable_cli_session (err : Agent_sdk.Error.sdk_error) : bool =
   match Cascade_error_classify.classify_masc_internal_error err with
   | Some (Cascade_error_classify.Resumable_cli_session _) -> true
-  | _ ->
-      let direct_api_message =
-        match err with
-        | Agent_sdk.Error.Api
-            (Llm_provider.Retry.NetworkError { message; _ }
-            | Llm_provider.Retry.Overloaded { message }
-            | Llm_provider.Retry.ServerError { message; _ }
-            | Llm_provider.Retry.InvalidRequest { message }
-            | Llm_provider.Retry.RateLimited { message; _ }
-            | Llm_provider.Retry.AuthError { message }
-            | Llm_provider.Retry.NotFound { message }
-            | Llm_provider.Retry.ContextOverflow { message; _ }
-            | Llm_provider.Retry.Timeout { message }) ->
-            message_looks_like_resumable_cli_session message
-        | _ -> false
-      in
-      direct_api_message
-      || message_looks_like_resumable_cli_session (Agent_sdk.Error.to_string err)
+  | _ -> false
 
 let message_looks_like_terminal_provider_runtime_failure message =
   let contains needle = String_util.contains_substring_ci message needle in
@@ -732,23 +681,57 @@ let emit_provider_error_metric ~cascade_name ~provider error =
       ]
     ()
 
-(* #13923 / #13933: when the agent_sdk [with_optional_timeout] wrapper
-   fires it produces a [Retry.Timeout] whose message starts with
-   "Agent execution exceeded max_execution_time_s". Distinguish that
-   from a transport-level provider timeout by substring so dashboards
-   can tell whether our per-OAS-call ceiling actually engaged versus
-   the upstream socket deadline. *)
-let timeout_source_label (err : Agent_sdk.Error.sdk_error) : string =
-  let is_max_execution_time =
+let timeout_phase_label_of_sdk_error (err : Agent_sdk.Error.sdk_error) : string =
+  match err with
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.Timeout { timeout_phase = Some phase; _ })
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.NetworkError { timeout_phase = Some phase; _ }) ->
+      Llm_provider.Http_client.timeout_phase_to_label phase
+  | _ -> label_provider
+
+let emit_oas_run_timeout_metric ~cascade_name ~provider:_ err =
+  match err with
+  | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _) ->
+      let cascade_name = provider_label (cascade_name_to_string cascade_name) in
+      Prometheus.inc_counter Keeper_metrics.metric_keeper_oas_run_timeout
+        ~labels:
+          [
+            (label_cascade, cascade_name);
+            (label_provider, public_runtime_provider_label);
+            (label_source, timeout_phase_label_of_sdk_error err);
+          ]
+        ()
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.Timeout _
+      | Llm_provider.Error.NetworkError { timeout_phase = Some _; _ }) ->
+      let cascade_name = provider_label (cascade_name_to_string cascade_name) in
+      Prometheus.inc_counter Keeper_metrics.metric_keeper_oas_run_timeout
+        ~labels:
+          [
+            (label_cascade, cascade_name);
+            (label_provider, public_runtime_provider_label);
+            (label_source, timeout_phase_label_of_sdk_error err);
+          ]
+        ()
+  | _ -> ()
+
+let classify_saturation_signal_kind
+    (err : Agent_sdk.Error.sdk_error) :
+    Cascade_saturation_signal.kind option =
+  let typed_kind =
+    match Cascade_error_classify.classify_masc_internal_error err with
+    | Some (Cascade_error_classify.Provider_timeout _) ->
+        Some Cascade_saturation_signal.K_time_cap_fired
+    | _ -> None
+  in
+  match typed_kind with
+  | Some _ as kind -> kind
+  | None -> (
     match err with
-    | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout { message }) ->
-        String_util.contains_substring_ci message "max_execution_time_s"
-    | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout { detail; _ }) ->
-        String_util.contains_substring_ci detail "max_execution_time_s"
-    | Agent_sdk.Error.Provider
-        (Llm_provider.Error.NetworkError { timeout_phase = Some _; _ }) ->
-        false
-    | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _) ->
+        Some Cascade_saturation_signal.K_provider_rate_limited
+    | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _)
     | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _)
     | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
     | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError _)
@@ -764,87 +747,7 @@ let timeout_source_label (err : Agent_sdk.Error.sdk_error) : string =
     | Agent_sdk.Error.Io _
     | Agent_sdk.Error.Orchestration _
     | Agent_sdk.Error.A2a _
-    | Agent_sdk.Error.Internal _ -> false
-  in
-  if is_max_execution_time
-  then provider_label_max_execution_time
-  else
-    match err with
-    | Agent_sdk.Error.Provider
-        (Llm_provider.Error.Timeout { timeout_phase = Some phase; _ })
-    | Agent_sdk.Error.Provider
-        (Llm_provider.Error.NetworkError { timeout_phase = Some phase; _ }) ->
-        Llm_provider.Http_client.timeout_phase_to_label phase
-    | _ -> label_provider
-
-let emit_oas_run_timeout_metric ~cascade_name ~provider:_ err =
-  match err with
-  | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _) ->
-      let cascade_name = provider_label (cascade_name_to_string cascade_name) in
-      Prometheus.inc_counter Keeper_metrics.metric_keeper_oas_run_timeout
-        ~labels:
-          [
-            (label_cascade, cascade_name);
-            (label_provider, public_runtime_provider_label);
-            (label_source, timeout_source_label err);
-          ]
-        ()
-  | Agent_sdk.Error.Provider
-      (Llm_provider.Error.Timeout _
-      | Llm_provider.Error.NetworkError { timeout_phase = Some _; _ }) ->
-      let cascade_name = provider_label (cascade_name_to_string cascade_name) in
-      Prometheus.inc_counter Keeper_metrics.metric_keeper_oas_run_timeout
-        ~labels:
-          [
-            (label_cascade, cascade_name);
-            (label_provider, public_runtime_provider_label);
-            (label_source, timeout_source_label err);
-          ]
-        ()
-  | _ -> ()
-
-(* RFC-0153 Phase A.2: when [MASC_CASCADE_SATURATION_SIGNAL_ENABLED] is
-   set, emit a typed [Cascade_saturation_signal.t] alongside the
-   existing string-based [timeout_source_label] metric. Phase A.2 is
-   additive — the counter is new ([metric_keeper_cascade_saturation_signal]),
-   no existing wire format or label is altered. Phase B (tier admission)
-   and Phase C (adaptive throttling) consume this counter to make
-   admission/throttle decisions.
-
-   The match below classifies the same [sdk_error] shape that
-   [timeout_source_label] classifies by substring, but emits a typed
-   [kind] from {!Cascade_saturation_signal.kind} instead. The substring
-   path is preserved for backwards-compatible label drift detection. *)
-let classify_saturation_signal_kind
-    (err : Agent_sdk.Error.sdk_error) :
-    Cascade_saturation_signal.kind option =
-  match err with
-  | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout { message }) ->
-      if String_util.contains_substring_ci message "max_execution_time_s"
-      then Some Cascade_saturation_signal.K_time_cap_fired
-      else None
-  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout { detail; _ }) ->
-      if String_util.contains_substring_ci detail "max_execution_time_s"
-      then Some Cascade_saturation_signal.K_time_cap_fired
-      else None
-  | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _) ->
-      Some Cascade_saturation_signal.K_provider_rate_limited
-  | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _)
-  | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
-  | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError _)
-  | Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest _)
-  | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
-  | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)
-  | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError _)
-  | Agent_sdk.Error.Provider _
-  | Agent_sdk.Error.Agent _
-  | Agent_sdk.Error.Mcp _
-  | Agent_sdk.Error.Config _
-  | Agent_sdk.Error.Serialization _
-  | Agent_sdk.Error.Io _
-  | Agent_sdk.Error.Orchestration _
-  | Agent_sdk.Error.A2a _
-  | Agent_sdk.Error.Internal _ -> None
+    | Agent_sdk.Error.Internal _ -> None)
 
 let maybe_emit_cascade_saturation_signal ~cascade_name ~provider:_ err =
   if Env_config_keeper.CascadeSaturationSignal.enabled () then
@@ -911,8 +814,6 @@ let sdk_error_cascade_fallback_class (err : Agent_sdk.Error.sdk_error) :
     string option =
   if sdk_error_is_hard_quota err then Some fallback_class_hard_quota
   else if sdk_error_is_max_turns_exceeded err then Some fallback_class_max_turns
-  else if sdk_error_is_resumable_cli_session err then
-    Some fallback_class_resumable_cli_session
   else if sdk_error_is_required_tool_contract_violation err then
     Some fallback_class_required_tool_contract_violation
   else None

--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -2,7 +2,7 @@
 
     Extracted from oas_worker_named.ml (God file decomposition).
     Converts OAS SDK errors into Cascade_fsm provider outcomes,
-    classifies CLI-wrapped error patterns (hard quota, resumable sessions),
+    classifies CLI-wrapped hard-quota patterns,
     and enriches errors with provider-specific hints.
 
     This module is [include]d by {!Keeper_turn_driver}; all bindings are
@@ -33,17 +33,8 @@ val message_looks_like_cli_wrapped_hard_quota : string -> bool
 val message_looks_like_capacity_backpressure : string -> bool
 (** Detect capacity-backpressure indicators in error messages. *)
 
-val message_looks_like_resumable_cli_session : string -> bool
-(** Detect resumable-session indicators in CLI-wrapped error messages. *)
-
 val cli_wrapped_hard_quota_indicators : string list
 (** List of substring indicators for CLI-wrapped hard quota. *)
-
-(** {1 Resumable CLI session helpers} *)
-
-val resumable_cli_session_detail : string -> string
-
-val resumable_cli_session_exit_code : string -> int option
 
 val exit_code_of_message : string -> int option
 (** Extract an exit code from a CLI error message string. *)
@@ -53,14 +44,9 @@ val retry_message_looks_like_not_found : string -> bool
 
 (** {1 SDK error predicates} *)
 
-val sdk_error_to_resumable_cli_session :
-  cascade_name:Cascade_name.t ->
-  Agent_sdk.Error.sdk_error ->
-  Agent_sdk.Error.sdk_error option
-(** If the error looks like a resumable CLI session, convert it into the
-    structured [Resumable_cli_session] form. *)
-
 val sdk_error_is_resumable_cli_session : Agent_sdk.Error.sdk_error -> bool
+(** [true] only for typed [Resumable_cli_session] envelopes. Raw CLI output
+    is transport-local text and is not promoted at this boundary. *)
 
 val sdk_error_is_terminal_provider_runtime_failure :
   Agent_sdk.Error.sdk_error -> bool

--- a/lib/cascade/cascade_error_classify.mli
+++ b/lib/cascade/cascade_error_classify.mli
@@ -1,4 +1,4 @@
-(** Cascade_error_classify — SDK error parser, substring classifier, and the
+(** Cascade_error_classify — SDK typed-envelope parser and the
     {!admission_wait_timeout_error} construction helper.
 
     RFC-0142 Phase 2 PR-1: the [masc_internal_error] ADT, its JSON codec, the

--- a/lib/cascade/cascade_internal_error.ml
+++ b/lib/cascade/cascade_internal_error.ml
@@ -3,8 +3,8 @@
 
     RFC-0142 Phase 2 PR-1: this module was extracted from
     [cascade_error_classify.ml] (lines 12-474 of the original file) without
-    behavioural change.  The parser, the substring classifier, and the CLI
-    preflight stayed behind in {!Cascade_error_classify}.  That file now
+    behavioural change.  The parser and CLI preflight stayed behind in
+    {!Cascade_error_classify}.  That file now
     re-exports this surface via [include Cascade_internal_error] so callers
     that reference [Cascade_error_classify.masc_internal_error],
     [Cascade_error_classify.Cascade_exhausted], etc. continue to compile

--- a/lib/cascade/cascade_internal_error.mli
+++ b/lib/cascade/cascade_internal_error.mli
@@ -3,9 +3,8 @@
 
     This module owns the *typed envelope* that the cascade layer uses to carry
     structured failures across the [Agent_sdk.Error.Internal _] boundary.  The
-    sibling {!Cascade_error_classify} module owns the *parser* that turns SDK
-    errors back into this type and the *substring classifier* that maps
-    unstructured upstream text into typed variants.
+    sibling {!Cascade_error_classify} module owns the parser that turns SDK
+    errors carrying the structured prefix back into this type.
 
     RFC-0142 Phase 2 PR-1 extraction: this module was carved out of
     [cascade_error_classify.ml] so that the parser and classifier no longer

--- a/lib/cascade/cascade_transport.mli
+++ b/lib/cascade/cascade_transport.mli
@@ -270,27 +270,13 @@ module Json_stream_cli_transport_local : sig
       stderr logger.  Drops the [resume hint] lines, which are noise. *)
   val should_log_stderr_line : string -> bool
 
-  (** Constant detail string used when the CLI reports a resumable session
-      without an embedded exit code. *)
+  (** Constant detail string used for typed resumable-session reports. *)
   val resumable_session_detail : string
-
-  (** Whether [text] looks like a resumable-session report from the CLI. *)
-  val text_looks_like_resumable_session : string -> bool
-
-  (** Render the resumable-session detail message for [text].  Includes the
-      embedded exit code when one can be parsed; otherwise returns
-      {!resumable_session_detail}. *)
-  val resumable_session_detail_of_text : string -> string
-
-  (** Parse the embedded exit code from a resumable-session [text].  Returns
-      [Some 75] for the canonical case and [Some 1] when the payload only
-      carries the resume hint. *)
-  val resumable_session_exit_code_of_text : string -> int option
 
   (** Reclassify a [NetworkError] from the CLI into [AcceptRejected] when
       the message indicates a permanent per-provider error
-      (auth/config/model), a local CLI startup crash, or a resumable-session
-      report.  Other variants pass through. *)
+      (auth/config/model), a local CLI startup crash, or an exit-75
+      resumable-session process status.  Other variants pass through. *)
   val classify_cli_error :
     ('a, Llm_provider.Http_client.http_error) result ->
     ('a, Llm_provider.Http_client.http_error) result

--- a/lib/cascade/cascade_transport_json_stream_cli_local.ml
+++ b/lib/cascade/cascade_transport_json_stream_cli_local.ml
@@ -319,7 +319,6 @@ let resumable_session_detail =
 ;;
 
 let resume_hint_marker = "to resume this session:"
-let resumable_session_public_marker = "resumable session available via -r."
 
 let is_resume_hint_line line =
   let trimmed = String.trim line in
@@ -369,28 +368,6 @@ let exit_code_of_message message =
   Option.map fst (exit_code_span_of_message message)
 ;;
 
-let exit_code_marker_of_text text =
-  let marker = "(exit " in
-  let lower = String.lowercase_ascii text in
-  let marker_len = String.length marker in
-  let text_len = String.length lower in
-  let rec find_marker index =
-    if index + marker_len > text_len
-    then None
-    else if String.sub lower index marker_len = marker
-    then (
-      let number_start = index + marker_len in
-      match String.index_from_opt lower number_start ')' with
-      | Some number_end when number_end > number_start ->
-        String.sub lower number_start (number_end - number_start)
-        |> String.trim
-        |> int_of_string_opt
-      | _ -> None)
-    else find_marker (index + 1)
-  in
-  find_marker 0
-;;
-
 let exit_payload_of_message message =
   match exit_code_span_of_message message with
   | None -> None
@@ -400,54 +377,34 @@ let exit_payload_of_message message =
        |> String.trim)
 ;;
 
-let payload_has_only_resume_hint payload =
-  payload
+let resumable_session_detail_for_exit_code code =
+  Printf.sprintf
+    "CLI JSON-stream transport reported a resumable session (exit %d). \
+     Resumable session available via -r."
+    code
+;;
+
+let redact_resume_hint_lines text =
+  text
   |> String.split_on_char '\n'
   |> List.map String.trim
-  |> List.filter (fun line -> line <> "")
-  |> fun lines -> lines <> [] && List.for_all is_resume_hint_line lines
+  |> List.filter (fun line -> line <> "" && not (is_resume_hint_line line))
+  |> String.concat "\n"
+  |> String.trim
 ;;
 
-let text_looks_like_resumable_session text =
-  let trimmed = String.trim text in
-  let has_raw_resume_hint =
-    match exit_code_of_message trimmed with
-    | Some 75 -> is_resume_hint_line trimmed
-    | Some 1 ->
-      (match exit_payload_of_message trimmed with
-       | Some payload -> payload_has_only_resume_hint payload
-       | None -> false)
-    | _ -> false
+let cli_reject_reason ~code message =
+  let payload =
+    match exit_payload_of_message message with
+    | Some payload -> redact_resume_hint_lines payload
+    | None -> redact_resume_hint_lines message
   in
-  trimmed <> ""
-  && (has_raw_resume_hint
-      || String_util.contains_substring_ci trimmed resumable_session_public_marker)
-;;
-
-let resumable_session_detail_of_text text =
-  if text_looks_like_resumable_session text
-  then (
-    let trimmed = String.trim text in
-    match
-      match exit_code_of_message trimmed with
-      | Some code -> Some code
-      | None -> exit_code_marker_of_text trimmed
-    with
-    | Some code ->
-      Printf.sprintf
-        "CLI JSON-stream transport reported a resumable session (exit %d). \
-         Resumable session available via -r."
-        code
-    | None -> resumable_session_detail)
-  else String.trim text
-;;
-
-let resumable_session_exit_code_of_text text =
-  match exit_code_of_message text with
-  | Some (75 as code) -> Some code
-  | Some (1 as code) when text_looks_like_resumable_session text -> Some code
-  | _ when text_looks_like_resumable_session text -> exit_code_marker_of_text text
-  | _ -> None
+  let detail = if payload = "" then "" else " " ^ payload in
+  Printf.sprintf
+    "provider CLI rejected the request (exit %d). This is usually a permanent \
+     auth/config/model error rather than a transient transport failure.%s"
+    code
+    detail
 ;;
 
 let text_looks_like_process_title_unicode_crash text =
@@ -457,12 +414,7 @@ let text_looks_like_process_title_unicode_crash text =
 
 let classify_cli_error = function
   | Error (Llm_provider.Http_client.NetworkError { message; _ }) as err ->
-    if text_looks_like_resumable_session message
-    then
-      Error
-        (Llm_provider.Http_client.AcceptRejected
-           { reason = resumable_session_detail_of_text message })
-    else if text_looks_like_process_title_unicode_crash message
+    if text_looks_like_process_title_unicode_crash message
     then
       Error
         (Llm_provider.Http_client.AcceptRejected
@@ -478,16 +430,11 @@ let classify_cli_error = function
       | Some 1 ->
         Error
           (Llm_provider.Http_client.AcceptRejected
-             { reason =
-                 "provider CLI rejected the request (exit 1). "
-                 ^ "This is usually a permanent auth/config/model error rather "
-                 ^ "than a transient transport failure. "
-                 ^ message
-             })
+             { reason = cli_reject_reason ~code:1 message })
       | Some 75 ->
         Error
           (Llm_provider.Http_client.AcceptRejected
-             { reason = resumable_session_detail_of_text message })
+             { reason = resumable_session_detail_for_exit_code 75 })
       | _ -> err)
   | other -> other
 ;;

--- a/lib/cascade/cascade_transport_json_stream_cli_local.mli
+++ b/lib/cascade/cascade_transport_json_stream_cli_local.mli
@@ -23,9 +23,6 @@ val build_args
 
 val should_log_stderr_line : string -> bool
 val resumable_session_detail : string
-val text_looks_like_resumable_session : string -> bool
-val resumable_session_detail_of_text : string -> string
-val resumable_session_exit_code_of_text : string -> int option
 
 val classify_cli_error
   :  ('a, Llm_provider.Http_client.http_error) result

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -731,15 +731,13 @@ end
 
 (** {1 Cascade Saturation Signal (RFC-0153 Phase A.2)}
 
-    Feature flag for typed [Cascade_saturation_signal.t] emission alongside
-    the existing string-based [timeout_source_label] classification in
-    [cascade_attempt_fsm.ml]. The signal is consumed by Phase B (tier
-    admission semaphore) and Phase C (adaptive throttling).
+    Feature flag for typed [Cascade_saturation_signal.t] emission from
+    structured cascade/provider errors. The signal is consumed by Phase B
+    (tier admission semaphore) and Phase C (adaptive throttling).
 
     Default off. Phase A.2 emit is purely additive — it increments a new
     Prometheus counter ([masc_keeper_cascade_saturation_signal_total])
-    with a typed [kind] label sourced from {!Cascade_saturation_signal.kind}.
-    No existing behaviour, wire format, or string label is altered. *)
+    with a typed [kind] label sourced from {!Cascade_saturation_signal.kind}. *)
 module CascadeSaturationSignal = struct
   let enabled () =
     get_bool ~default:false "MASC_CASCADE_SATURATION_SIGNAL_ENABLED"

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -285,19 +285,6 @@ let cascade_exhaustion_reason_of_json = function
   | _ -> None
 ;;
 
-let cascade_exhaustion_reason_from_message msg =
-  (* SSOT: the only place that decides whether a free-form cascade-exhaustion
-     message names a structural per-OAS-call ceiling.  Producers call this
-     instead of writing [Other_detail msg] directly so downstream consumers
-     can pattern-match the typed [Structural_attempt_timeout] case.
-     Substring is unavoidable here (the upstream message is a raw SDK
-     string), but it is contained to a single function — replacing the
-     prior N-of-M classifier with one source of truth. *)
-  if String_util.contains_substring_ci msg "max_execution_time_s"
-  then Structural_attempt_timeout { detail = msg }
-  else Other_detail msg
-;;
-
 (* ── Unified blocker_info: typed klass + free-form detail ───────
    Replaces the historic split blocker fields. The string-only field was used
    by substring classifiers to recover a typed class — exactly the workaround

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -147,10 +147,8 @@ type cascade_exhaustion_reason =
   | Structural_attempt_timeout of { detail : string }
       (** Agent SDK [with_optional_timeout] wrapper fired its per-OAS-call
           ceiling ([max_execution_time_s]). Distinct from transport-level
-          provider timeouts. [detail] preserves the upstream message for
-          diagnostics. Replaces substring-tagged [Other_detail] payloads
-          that downstream consumers had to re-parse with
-          [contains_substring_ci ... "max_execution_time_s"]. *)
+          provider timeouts. This variant is accepted only from typed
+          envelopes; free-form messages stay [Other_detail]. *)
   | Other_detail of string
 
 type blocker_class =
@@ -202,18 +200,6 @@ val cascade_exhaustion_reason_to_json :
 
 val cascade_exhaustion_reason_of_json :
   Yojson.Safe.t -> cascade_exhaustion_reason option
-
-val cascade_exhaustion_reason_from_message :
-  string -> cascade_exhaustion_reason
-(** SSOT for the {b only} substring-based classification of cascade
-    exhaustion messages. Returns
-    [Structural_attempt_timeout { detail = msg }] when [msg] contains
-    "max_execution_time_s" (case-insensitive), otherwise
-    [Other_detail msg]. Producers that previously wrote
-    [Other_detail (Cascade_fsm.to_user_message err)] should call this
-    so downstream consumers can [match] typed cases instead of
-    re-parsing the string. Removes the N-of-M substring classifier
-    pattern (RFC-0088 §1) that previously lived in three call sites. *)
 
 val blocker_class_of_serialized_string :
   string -> blocker_class option

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -161,11 +161,10 @@ let degraded_retry_slot_phase_available ~(time_spent_in_turn_s : float) : bool =
 
 let cascade_reason_is_structural_attempt_timeout
     (reason : Keeper_types.cascade_exhaustion_reason) : bool =
-  (* Typed match — no substring re-parsing. Producers route structural
-     OAS-ceiling messages into [Structural_attempt_timeout] via
-     [cascade_exhaustion_reason_from_message] (SSOT). Enumerate every
-     constructor so a new reason variant fails to compile here rather
-     than silently falling through to [false]. *)
+  (* Typed match only. Producers must construct [Structural_attempt_timeout]
+     explicitly; free-form OAS-ceiling-looking text remains [Other_detail].
+     Enumerate every constructor so a new reason variant fails to compile here
+     rather than silently falling through to [false]. *)
   match reason with
   | Keeper_types.Structural_attempt_timeout _ -> true
   | Keeper_types.Connection_refused

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -28,14 +28,8 @@ val message_looks_like_cli_wrapped_hard_quota : string -> bool
 
 val message_looks_like_capacity_backpressure : string -> bool
 
-val message_looks_like_resumable_cli_session : string -> bool
-
-val sdk_error_to_resumable_cli_session :
-  cascade_name:Cascade_name.t ->
-  Agent_sdk.Error.sdk_error ->
-  Agent_sdk.Error.sdk_error option
-
 val sdk_error_is_resumable_cli_session : Agent_sdk.Error.sdk_error -> bool
+(** [true] only for typed [Resumable_cli_session] envelopes. *)
 
 val sdk_error_is_terminal_provider_runtime_failure :
   Agent_sdk.Error.sdk_error -> bool

--- a/lib/keeper/keeper_turn_driver_try_cascade.ml
+++ b/lib/keeper/keeper_turn_driver_try_cascade.ml
@@ -181,30 +181,24 @@ let rec run
           else if kind = Llm_provider.Http_client.Dns_failure then
             Keeper_types.Dns_failure
           else
-            Keeper_types.cascade_exhaustion_reason_from_message
-              (Cascade_fsm.to_user_message last_err)
+            Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
       | Some (Llm_provider.Http_client.TimeoutError _) ->
-          Keeper_types.cascade_exhaustion_reason_from_message
-            (Cascade_fsm.to_user_message last_err)
+          Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
       | Some (Llm_provider.Http_client.HttpError _) ->
-          Keeper_types.cascade_exhaustion_reason_from_message
-            (Cascade_fsm.to_user_message last_err)
+          Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
       | Some (Llm_provider.Http_client.AcceptRejected _) ->
-          Keeper_types.cascade_exhaustion_reason_from_message
-            (Cascade_fsm.to_user_message last_err)
+          Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
       | Some (Llm_provider.Http_client.CliTransportRequired _) ->
-          Keeper_types.cascade_exhaustion_reason_from_message
-              (Cascade_fsm.to_user_message last_err)
+          Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
       | Some (Llm_provider.Http_client.ProviderTerminal
           { kind = Llm_provider.Http_client.Max_turns _; _ }) ->
           Keeper_types.Max_turns_exceeded
       | Some (Llm_provider.Http_client.ProviderTerminal
           { kind = Llm_provider.Http_client.Other _; _ }) ->
-          Keeper_types.cascade_exhaustion_reason_from_message
-              (Cascade_fsm.to_user_message last_err)
+          Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
       | Some (Llm_provider.Http_client.ProviderFailure _ as err) ->
           let message = Cascade_fsm.to_user_message (Some err) in
-          Keeper_types.cascade_exhaustion_reason_from_message message
+          Keeper_types.Other_detail message
       | None -> Keeper_types.No_providers_available
     in
     let observation =
@@ -218,47 +212,22 @@ let rec run
       ~cascade_name:ctx.error_cascade_name
       ~outcome:`Failure ~observation:(Some observation) ();
     let terminal_error =
-      match last_err with
-      | Some (Llm_provider.Http_client.NetworkError { message; _ })
-        when message_looks_like_resumable_cli_session message ->
-          sdk_error_of_masc_internal_error
-            (Resumable_cli_session
-               {
-                 cascade_name = ctx.error_cascade_name;
-                 detail = resumable_cli_session_detail message;
-                 exit_code = resumable_cli_session_exit_code message;
-               })
-      | Some (Llm_provider.Http_client.AcceptRejected { reason })
-        when message_looks_like_resumable_cli_session reason ->
-          sdk_error_of_masc_internal_error
-            (Resumable_cli_session
-               {
-                 cascade_name = ctx.error_cascade_name;
-                 detail = resumable_cli_session_detail reason;
-                 exit_code = resumable_cli_session_exit_code reason;
-               })
-      | _ ->
-        (match
-           match
-             capacity_backpressure_of_http_error ctx
-               ?source:last_capacity_source last_err
-           with
-           | Some _ as capacity_error -> capacity_error
+      match
+        match
+          capacity_backpressure_of_http_error ctx ?source:last_capacity_source
+            last_err
+        with
+        | Some _ as capacity_error -> capacity_error
+        | None -> capacity_backpressure_of_pending ctx last_capacity_backpressure
+      with
+      | Some capacity_error -> sdk_error_of_masc_internal_error capacity_error
+      | None ->
+        sdk_error_of_masc_internal_error
+          (match pre_dispatch_no_tool_capable with
+           | Some internal_error -> internal_error
            | None ->
-             capacity_backpressure_of_pending ctx last_capacity_backpressure
-         with
-         | Some capacity_error ->
-           sdk_error_of_masc_internal_error capacity_error
-         | None ->
-           sdk_error_of_masc_internal_error
-             (match pre_dispatch_no_tool_capable with
-              | Some internal_error -> internal_error
-              | None ->
-                Cascade_exhausted
-                  {
-                    cascade_name = ctx.error_cascade_name;
-                    reason;
-                  }))
+             Cascade_exhausted
+               { cascade_name = ctx.error_cascade_name; reason })
     in
     Error terminal_error
   | candidate :: rest ->
@@ -799,14 +768,6 @@ let rec run
                  on_success ~provider_key:(Cascade_runtime_candidate.health_key candidate);
                  Ok result)
     | Error sdk_err ->
-      let sdk_err =
-        match
-          sdk_error_to_resumable_cli_session
-            ~cascade_name:ctx.error_cascade_name sdk_err
-        with
-        | Some err -> err
-        | None -> sdk_err
-      in
       let err_str = Agent_sdk.Error.to_string sdk_err in
       record_candidate_health_error candidate sdk_err;
       let provider_error =

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -200,13 +200,6 @@ val blocker_class_continue_gate : blocker_class -> bool
 val cascade_exhaustion_reason_to_json : cascade_exhaustion_reason -> Yojson.Safe.t
 val cascade_exhaustion_reason_of_json : Yojson.Safe.t -> cascade_exhaustion_reason option
 
-val cascade_exhaustion_reason_from_message :
-  string -> cascade_exhaustion_reason
-(** SSOT helper for tagging free-form cascade-exhaustion messages with
-    [Structural_attempt_timeout] when the upstream SDK fired its
-    per-OAS-call ceiling ([max_execution_time_s]). See
-    [Keeper_meta_contract.cascade_exhaustion_reason_from_message]. *)
-
 (** Authoritative blocker representation: typed [klass] + free-form
     [detail].  The historic split blocker fields are no longer a
     supported keeper_meta shape, so substring classification is not

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -292,17 +292,9 @@ include module type of Prometheus_transport_metric_names
 
 (** [masc_keeper_oas_run_timeout_total] counter incremented in the
     cascade FSM each time an [Agent.run] / [run_stream] returns
-    [Llm_provider.Retry.Timeout]. The [source] label distinguishes the
-    timeout origin so dashboards can attribute hangs to root cause:
-
-    - [source="max_execution_time"] — agent_sdk's
-      [with_optional_timeout] fired because the per-OAS-call ceiling
-      ([max_execution_time_s], wired in PR #13923/#13933) was reached.
-      This is the canonical signal for OAS call timeout enforcement.
-    - [source="provider"] — transport-level timeout from the upstream
-      provider (HTTP read deadline, gRPC deadline, etc.). The agent
-      did not have [max_execution_time_s] set, or the timeout fired
-      below the wrapper.
+    [Llm_provider.Retry.Timeout]. The [source] label is typed provider
+    timeout phase when OAS exposes one, otherwise [provider]. Free-form
+    timeout messages are not reparsed into [max_execution_time] labels.
 
     Labels: cascade, provider, source. *)
 (* Centralized metric constants for inline string replacement. *)

--- a/lib/prometheus_builtin_metric_names.mli
+++ b/lib/prometheus_builtin_metric_names.mli
@@ -234,17 +234,9 @@ include module type of Prometheus_transport_metric_names
 
 (** [masc_keeper_oas_run_timeout_total] counter incremented in the
     cascade FSM each time an [Agent.run] / [run_stream] returns
-    [Llm_provider.Retry.Timeout]. The [source] label distinguishes the
-    timeout origin so dashboards can attribute hangs to root cause:
-
-    - [source="max_execution_time"] — agent_sdk's
-      [with_optional_timeout] fired because the per-OAS-call ceiling
-      ([max_execution_time_s], wired in PR #13923/#13933) was reached.
-      This is the canonical signal for OAS call timeout enforcement.
-    - [source="provider"] — transport-level timeout from the upstream
-      provider (HTTP read deadline, gRPC deadline, etc.). The agent
-      did not have [max_execution_time_s] set, or the timeout fired
-      below the wrapper.
+    [Llm_provider.Retry.Timeout]. The [source] label is typed provider
+    timeout phase when OAS exposes one, otherwise [provider]. Free-form
+    timeout messages are not reparsed into [max_execution_time] labels.
 
     Labels: cascade, provider, source. *)
 (* Centralized metric constants for inline string replacement. *)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6944,7 +6944,7 @@ let test_metrics_failure_timeout_increments_proactive_backoff () =
     updated.runtime.proactive_rt.consecutive_noop_count
 ;;
 
-let test_metrics_failure_response_redacts_resumable_cli_session_detail () =
+let test_metrics_failure_response_redacts_resumable_cli_session_payload () =
   let raw_reason =
     "cli-tool exited with code 75: \n\
      To resume this session: cli-tool -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
@@ -8315,46 +8315,6 @@ let test_degraded_retry_slot_phase_allows_provider_timeout_local_recovery () =
       (EC.degraded_retry_reason_to_string retry.fallback_reason)
   | UT.Degraded_retry_slot_phase_exhausted _ ->
     fail "expected provider timeout budget to bypass slot phase for local recovery"
-  | UT.Degraded_retry_budget_exhausted _ -> fail "expected retry budget to remain"
-  | UT.No_degraded_retry -> fail "expected recoverable retry candidate"
-;;
-
-let max_execution_time_cascade_exhausted_error () =
-  let detail = "Agent execution exceeded max_execution_time_s (276.561292)" in
-  Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
-    (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
-       {
-         cascade_name = oas_error_cascade_name "strict_tool_candidates";
-         reason = Keeper_types.cascade_exhaustion_reason_from_message detail;
-       })
-;;
-
-let test_degraded_retry_slot_phase_allows_max_execution_time_cascade_exhausted () =
-  match
-    UT.next_fail_open_cascade_for_turn_with_budget
-      ~base_cascade:"strict_tool_candidates"
-      ~effective_cascade:"strict_tool_candidates"
-      ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Required
-      ~attempted_cascades:[ "strict_tool_candidates"; "tier-group.provider_k-coding-with-spark" ]
-      ~estimated_input_tokens:2_000
-      ~max_turns:4
-      ~time_spent_in_turn_s:(UT.degraded_retry_slot_phase_budget_sec +. 1.0)
-      ~remaining_turn_budget_s:300.0
-      (max_execution_time_cascade_exhausted_error ())
-  with
-  | UT.Degraded_retry_allowed retry ->
-    check
-      string
-      "retry cascade candidate"
-      (tool_required_cascade_name ())
-      retry.next_cascade;
-    check
-      string
-      "fallback reason"
-      "cascade_exhausted"
-      (EC.degraded_retry_reason_to_string retry.fallback_reason)
-  | UT.Degraded_retry_slot_phase_exhausted _ ->
-    fail "expected max_execution_time_s cascade exhaustion to bypass slot phase"
   | UT.Degraded_retry_budget_exhausted _ -> fail "expected retry budget to remain"
   | UT.No_degraded_retry -> fail "expected recoverable retry candidate"
 ;;
@@ -11209,7 +11169,7 @@ let () =
         ; test_case
             "failure response redacts resumable session detail"
             `Quick
-            test_metrics_failure_response_redacts_resumable_cli_session_detail
+            test_metrics_failure_response_redacts_resumable_cli_session_payload
         ; test_case "mixed response" `Quick test_metrics_mixed_response
         ; test_case
             "normalize passthrough"
@@ -11666,10 +11626,6 @@ let () =
             "provider timeout budget can still rotate to local recovery after slot phase"
             `Quick
             test_degraded_retry_slot_phase_allows_provider_timeout_local_recovery
-        ; test_case
-            "max_execution_time_s cascade exhaustion can still rotate after slot phase"
-            `Quick
-            test_degraded_retry_slot_phase_allows_max_execution_time_cascade_exhausted
         ; test_case
             "contract retry gets first rotation after slot phase (#12888)"
             `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -4399,9 +4399,6 @@ let test_json_stream_cli_classify_cli_error_redacts_resumable_session_detail () 
     "cli-tool exited with code 75: \n\
      To resume this session: cli-tool -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
   in
-  let canonical_detail =
-    Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail_of_text raw_message
-  in
   match
     Cascade_transport.Json_stream_cli_transport_local.classify_cli_error
       (Error
@@ -4409,7 +4406,7 @@ let test_json_stream_cli_classify_cli_error_redacts_resumable_session_detail () 
             { message = raw_message; kind = Llm_provider.Http_client.Unknown }))
   with
   | Error (Llm_provider.Http_client.AcceptRejected { reason }) ->
-    Alcotest.(check string) "canonical detail" canonical_detail reason;
+    Alcotest.(check bool) "exit code named" true (contains_substring ~needle:"exit 75" reason);
     Alcotest.(check bool)
       "raw resume hint removed"
       false
@@ -4418,27 +4415,14 @@ let test_json_stream_cli_classify_cli_error_redacts_resumable_session_detail () 
       "raw session id removed"
       false
       (contains_substring ~needle:"ff37febe-2adb-4ac6-9dc6-cae23e672fbc" reason)
-  | _ -> Alcotest.fail "expected resumable session to map to AcceptRejected"
+  | _ -> Alcotest.fail "expected exit 75 to map to AcceptRejected"
 ;;
 
-let test_json_stream_cli_classify_cli_error_treats_exit_1_resume_hint_as_resumable () =
+let test_json_stream_cli_classify_cli_error_keeps_exit_1_resume_hint_as_plain_reject () =
   let raw_message =
     "cli-tool exited with code 1: \n\
      To resume this session: cli-tool -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
   in
-  let canonical_detail =
-    Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail_of_text raw_message
-  in
-  Alcotest.(check bool)
-    "exit 1 resume hint is resumable"
-    true
-    (Cascade_transport.Json_stream_cli_transport_local.text_looks_like_resumable_session
-       raw_message);
-  Alcotest.(check (option int))
-    "exit code preserved"
-    (Some 1)
-    (Cascade_transport.Json_stream_cli_transport_local.resumable_session_exit_code_of_text
-       raw_message);
   match
     Cascade_transport.Json_stream_cli_transport_local.classify_cli_error
       (Error
@@ -4446,11 +4430,14 @@ let test_json_stream_cli_classify_cli_error_treats_exit_1_resume_hint_as_resumab
             { message = raw_message; kind = Llm_provider.Http_client.Unknown }))
   with
   | Error (Llm_provider.Http_client.AcceptRejected { reason }) ->
-    Alcotest.(check string) "canonical detail" canonical_detail reason;
     Alcotest.(check bool)
-      "does not claim exit 75"
+      "plain exit 1 reject"
+      true
+      (contains_substring ~needle:"provider CLI rejected the request (exit 1)" reason);
+    Alcotest.(check bool)
+      "does not claim resumable session"
       false
-      (contains_substring ~needle:"exit 75" reason);
+      (contains_substring ~needle:"Resumable session available via -r" reason);
     Alcotest.(check bool)
       "raw resume hint removed"
       false
@@ -4459,38 +4446,7 @@ let test_json_stream_cli_classify_cli_error_treats_exit_1_resume_hint_as_resumab
       "raw session id removed"
       false
       (contains_substring ~needle:"5de0f199-6bd7-4509-bfa6-3308e0ebd97f" reason)
-  | _ -> Alcotest.fail "expected exit 1 resume hint to map to resumable session"
-;;
-
-let test_json_stream_cli_resumable_invalid_request_reclassifies_as_structured () =
-  let raw_message =
-    "cli-tool exited with code 1: \n\
-     To resume this session: cli-tool -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
-  in
-  let detail =
-    Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail_of_text raw_message
-  in
-  let sdk_error =
-    Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest { message = detail })
-  in
-  match
-    Keeper_turn_driver.sdk_error_to_resumable_cli_session
-      ~cascade_name:(internal_cascade_name "json_stream_cli_keeper")
-      sdk_error
-  with
-  | Some structured ->
-    (match Keeper_turn_driver.classify_masc_internal_error structured with
-     | Some
-         (Keeper_turn_driver.Resumable_cli_session
-            { cascade_name; detail = structured_detail; exit_code }) ->
-       Alcotest.(check string)
-         "cascade"
-         "json_stream_cli_keeper"
-         (internal_cascade_name_to_string cascade_name);
-       Alcotest.(check string) "detail" detail structured_detail;
-       Alcotest.(check (option int)) "exit code" (Some 1) exit_code
-     | _ -> Alcotest.fail "expected structured resumable CLI session")
-  | None -> Alcotest.fail "expected InvalidRequest detail to reclassify"
+  | _ -> Alcotest.fail "expected exit 1 resume hint to stay a plain reject"
 ;;
 
 let test_json_stream_cli_classify_cli_error_keeps_exit_1_with_error_as_reject () =
@@ -4499,11 +4455,6 @@ let test_json_stream_cli_classify_cli_error_keeps_exit_1_with_error_as_reject ()
      Authentication failed\n\
      To resume this session: cli-tool -r ff37febe"
   in
-  Alcotest.(check bool)
-    "exit 1 with real stderr is not resumable"
-    false
-    (Cascade_transport.Json_stream_cli_transport_local.text_looks_like_resumable_session
-       raw_message);
   match
     Cascade_transport.Json_stream_cli_transport_local.classify_cli_error
       (Error
@@ -4518,7 +4469,11 @@ let test_json_stream_cli_classify_cli_error_keeps_exit_1_with_error_as_reject ()
     Alcotest.(check bool)
       "stderr detail preserved"
       true
-      (contains_substring ~needle:"Authentication failed" reason)
+      (contains_substring ~needle:"Authentication failed" reason);
+    Alcotest.(check bool)
+      "raw resume hint removed"
+      false
+      (contains_substring ~needle:"To resume this session:" reason)
   | _ -> Alcotest.fail "expected exit 1 with real stderr to stay rejected"
 ;;
 
@@ -6382,13 +6337,9 @@ let () =
             `Quick
             test_json_stream_cli_classify_cli_error_redacts_resumable_session_detail
         ; Alcotest.test_case
-            "CLI exit 1 resume hint is resumable"
+            "CLI exit 1 resume hint is plain reject"
             `Quick
-            test_json_stream_cli_classify_cli_error_treats_exit_1_resume_hint_as_resumable
-        ; Alcotest.test_case
-            "CLI resumable InvalidRequest is structured"
-            `Quick
-            test_json_stream_cli_resumable_invalid_request_reclassifies_as_structured
+            test_json_stream_cli_classify_cli_error_keeps_exit_1_resume_hint_as_plain_reject
         ; Alcotest.test_case
             "CLI exit 1 with stderr remains rejected"
             `Quick

--- a/test/test_oas_worker_sdk_error.ml
+++ b/test/test_oas_worker_sdk_error.ml
@@ -232,32 +232,21 @@ let test_sdk_error_to_cascade_outcome_cascades_runtime_mcp_auth_config () =
 ;;
 
 let test_sdk_error_to_cascade_outcome_cascades_resumable_cli_session () =
-  let raw_message =
-    "cli-tool exited with code 1: \n\
-     To resume this session: cli-tool -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
-  in
   let detail =
-    Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail_of_text raw_message
-  in
-  let sdk_error =
-    Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest { message = detail })
+    Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail
   in
   let structured =
-    match
-      Keeper_turn_driver.sdk_error_to_resumable_cli_session
-        ~cascade_name:(Cascade_name.of_string_exn "tool_use_strict")
-        sdk_error
-    with
-    | Some structured -> structured
-    | None -> Alcotest.fail "expected structured resumable CLI session"
+    Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Keeper_turn_driver.Resumable_cli_session
+         { cascade_name = Cascade_name.of_string_exn "tool_use_strict"
+         ; detail
+         ; exit_code = Some 75
+         })
   in
   match Keeper_turn_driver.sdk_error_to_cascade_outcome structured with
   | Some (Cascade_fsm.Call_err (Llm_provider.Http_client.NetworkError { message; kind }))
     ->
-    Alcotest.(check bool)
-      "detail remains resumable marker"
-      true
-      (Keeper_turn_driver.message_looks_like_resumable_cli_session message);
+    Alcotest.(check string) "detail remains typed marker" detail message;
     Alcotest.(check bool)
       "unknown network kind"
       true
@@ -300,12 +289,12 @@ let test_sdk_error_is_resumable_cli_session_detects_raw_cli_hint () =
          { message = raw_message; kind = Llm_provider.Http_client.Unknown })
   in
   Alcotest.(check bool)
-    "raw CLI resume hint detected"
-    true
+    "raw CLI resume hint ignored"
+    false
     (Keeper_turn_driver.sdk_error_is_resumable_cli_session err)
 ;;
 
-let test_fallback_class_labels_resumable_cli_session () =
+let test_fallback_class_does_not_label_resumable_cli_session () =
   let err =
     Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Keeper_turn_driver.Resumable_cli_session
@@ -317,8 +306,8 @@ let test_fallback_class_labels_resumable_cli_session () =
          })
   in
   Alcotest.(check (option string))
-    "resumable session fallback class"
-    (Some "resumable_cli_session")
+    "resumable session has no string fallback class"
+    None
     (Keeper_turn_driver.sdk_error_cascade_fallback_class err)
 ;;
 
@@ -384,12 +373,12 @@ let cases =
       `Quick
       test_sdk_error_is_resumable_cli_session_detects_structured_error
   ; Alcotest.test_case
-      "sdk_error_is_resumable_cli_session detects raw CLI hint"
+      "sdk_error_is_resumable_cli_session ignores raw CLI hint"
       `Quick
       test_sdk_error_is_resumable_cli_session_detects_raw_cli_hint
   ; Alcotest.test_case
-      "fallback class labels resumable CLI session"
+      "fallback class ignores resumable CLI session"
       `Quick
-      test_fallback_class_labels_resumable_cli_session
+      test_fallback_class_does_not_label_resumable_cli_session
   ]
 ;;


### PR DESCRIPTION
## Summary
- remove raw resumable CLI hint promotion from cascade/keeper SDK error classification
- stop promoting free-form max_execution_time_s text into Structural_attempt_timeout or saturation signals
- keep structured Resumable_cli_session / Provider_timeout envelopes and update the legacy purge HTML plan

## Verification
- ocamlformat --check on touched OCaml files
- git diff --check origin/main...HEAD
- rg backstop for removed string-recovery helpers: clean
- bash scripts/check-doc-truth.sh
- scripts/ci/check-enum-string-safety.sh
- scripts/check-pr-hygiene.sh --base origin/main --head HEAD --recent-main 50 --duplicate-policy warn
- bash scripts/check-release-train-guard.sh --base origin/main --head HEAD (warn only: pending release tag)
- scripts/audit-hardcoding-truth.sh

## Local Dune
- scripts/dune-local.sh build lib/masc_mcp.cma test/test_oas_worker_sdk_error.exe test/test_oas_worker.exe test/test_keeper_unified.exe test/test_cascade_error_classify_decoder.exe
- blocked with exit 75 by machine-wide bare Dune processes; guard was not bypassed