### PR TITLE
feat(agent_tool_descriptor): RFC-0179 PR-5 task cluster migration (9 tools)

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -34,6 +34,9 @@ type runtime_handler =
   | Tool_time_now
   | Tool_stay_silent
   | Tool_tools_list
+  | Tool_memory_write
+  | Tool_ide_annotate
+  | Tool_voice
 
 type policy =
   { visibility : Tool_catalog.visibility
@@ -98,6 +101,9 @@ let runtime_handler_to_string = function
   | Tool_time_now -> "tool_time_now"
   | Tool_stay_silent -> "tool_stay_silent"
   | Tool_tools_list -> "tool_tools_list"
+  | Tool_memory_write -> "tool_memory_write"
+  | Tool_ide_annotate -> "tool_ide_annotate"
+  | Tool_voice -> "tool_voice"
 ;;
 
 let policy ?(visibility = Tool_catalog.Default) ?readonly ?effect_domain
@@ -463,6 +469,25 @@ let read_only_in_process_policy () =
     ()
 ;;
 
+let coordination_write_in_process_policy () =
+  policy
+    ~visibility:Tool_catalog.Hidden
+    ~readonly:false
+    ~effect_domain:Tool_catalog.Masc_coordination
+    ~approval:Policy_selected
+    ~retryable:false
+    ()
+;;
+
+let voice_external_in_process_policy () =
+  policy
+    ~visibility:Tool_catalog.Hidden
+    ~readonly:false
+    ~approval:Policy_selected
+    ~retryable:false
+    ()
+;;
+
 let internal_descriptors : t list =
   [ descriptor
       ~id:"keeper.time.now"
@@ -505,6 +530,106 @@ let internal_descriptors : t list =
       ~backend:Ocaml_runtime
       ~sandbox:No_sandbox
       ~runtime_handler:Tool_tools_list
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.memory.write"
+      ~public_name:"keeper_memory_write"
+      ~internal_name:"keeper_memory_write"
+      ~description:
+        "Append an entry to the keeper memory store. Body fields define \
+         the entry payload."
+      ~input_schema:empty_object_schema
+      ~policy:(coordination_write_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_memory_write
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.ide.annotate"
+      ~public_name:"keeper_ide_annotate"
+      ~internal_name:"keeper_ide_annotate"
+      ~description:
+        "Create a line-bound annotation in the .masc-ide store. \
+         Returns the created record's id and coordinates."
+      ~input_schema:empty_object_schema
+      ~policy:(coordination_write_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_ide_annotate
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.voice.speak"
+      ~public_name:"keeper_voice_speak"
+      ~internal_name:"keeper_voice_speak"
+      ~description:"Speak the given text via the configured voice service."
+      ~input_schema:empty_object_schema
+      ~policy:(voice_external_in_process_policy ())
+      ~executor:In_process
+      ~backend:Remote_service
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_voice
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.voice.listen"
+      ~public_name:"keeper_voice_listen"
+      ~internal_name:"keeper_voice_listen"
+      ~description:"Listen for voice input via the configured voice service."
+      ~input_schema:empty_object_schema
+      ~policy:(voice_external_in_process_policy ())
+      ~executor:In_process
+      ~backend:Remote_service
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_voice
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.voice.agent"
+      ~public_name:"keeper_voice_agent"
+      ~internal_name:"keeper_voice_agent"
+      ~description:"Run a voice agent turn via the configured voice service."
+      ~input_schema:empty_object_schema
+      ~policy:(voice_external_in_process_policy ())
+      ~executor:In_process
+      ~backend:Remote_service
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_voice
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.voice.sessions"
+      ~public_name:"keeper_voice_sessions"
+      ~internal_name:"keeper_voice_sessions"
+      ~description:"List ongoing voice sessions for this keeper."
+      ~input_schema:empty_object_schema
+      ~policy:(read_only_in_process_policy ())
+      ~executor:In_process
+      ~backend:Remote_service
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_voice
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.voice.session.start"
+      ~public_name:"keeper_voice_session_start"
+      ~internal_name:"keeper_voice_session_start"
+      ~description:"Start a new voice session for this keeper."
+      ~input_schema:empty_object_schema
+      ~policy:(voice_external_in_process_policy ())
+      ~executor:In_process
+      ~backend:Remote_service
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_voice
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.voice.session.end"
+      ~public_name:"keeper_voice_session_end"
+      ~internal_name:"keeper_voice_session_end"
+      ~description:"End an ongoing voice session for this keeper."
+      ~input_schema:empty_object_schema
+      ~policy:(voice_external_in_process_policy ())
+      ~executor:In_process
+      ~backend:Remote_service
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_voice
       ~translate:translate_identity
   ]
 ;;

--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -32,6 +32,8 @@ type runtime_handler =
   | Tool_write_file
   | Tool_remote_mcp
   | Tool_time_now
+  | Tool_stay_silent
+  | Tool_tools_list
 
 type policy =
   { visibility : Tool_catalog.visibility
@@ -94,6 +96,8 @@ let runtime_handler_to_string = function
   | Tool_write_file -> "tool_write_file"
   | Tool_remote_mcp -> "tool_remote_mcp"
   | Tool_time_now -> "tool_time_now"
+  | Tool_stay_silent -> "tool_stay_silent"
+  | Tool_tools_list -> "tool_tools_list"
 ;;
 
 let policy ?(visibility = Tool_catalog.Default) ?readonly ?effect_domain
@@ -441,6 +445,24 @@ let public_descriptors =
    coordination tools (keeper_* / masc_* clusters). Each cluster migration PR
    adds entries here. The LLM-native [public_descriptors] contract (RFC-0064
    hard-cut, 7 entries) is preserved unchanged. *)
+let empty_object_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc []
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let read_only_in_process_policy () =
+  policy
+    ~visibility:Tool_catalog.Hidden
+    ~readonly:true
+    ~effect_domain:Tool_catalog.Read_only
+    ~approval:No_approval
+    ~retryable:true
+    ()
+;;
+
 let internal_descriptors : t list =
   [ descriptor
       ~id:"keeper.time.now"
@@ -449,24 +471,40 @@ let internal_descriptors : t list =
       ~description:
         "Return the current wall-clock time as ISO 8601 and Unix epoch \
          seconds. No arguments."
-      ~input_schema:
-        (`Assoc
-           [ "type", `String "object"
-           ; "properties", `Assoc []
-           ; "additionalProperties", `Bool false
-           ])
-      ~policy:
-        (policy
-           ~visibility:Tool_catalog.Hidden
-           ~readonly:true
-           ~effect_domain:Tool_catalog.Read_only
-           ~approval:No_approval
-           ~retryable:true
-           ())
+      ~input_schema:empty_object_schema
+      ~policy:(read_only_in_process_policy ())
       ~executor:In_process
       ~backend:Ocaml_runtime
       ~sandbox:No_sandbox
       ~runtime_handler:Tool_time_now
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.stay.silent"
+      ~public_name:"keeper_stay_silent"
+      ~internal_name:"keeper_stay_silent"
+      ~description:
+        "Yield the turn without taking action. Returns {\"status\":\"silent\"}. \
+         No arguments."
+      ~input_schema:empty_object_schema
+      ~policy:(read_only_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_stay_silent
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.tools.list"
+      ~public_name:"keeper_tools_list"
+      ~internal_name:"keeper_tools_list"
+      ~description:
+        "List the tools available to the current keeper, with descriptions \
+         and policy notes. No arguments."
+      ~input_schema:empty_object_schema
+      ~policy:(read_only_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_tools_list
       ~translate:translate_identity
   ]
 ;;

--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -37,6 +37,7 @@ type runtime_handler =
   | Tool_memory_write
   | Tool_ide_annotate
   | Tool_voice
+  | Tool_task
 
 type policy =
   { visibility : Tool_catalog.visibility
@@ -104,6 +105,7 @@ let runtime_handler_to_string = function
   | Tool_memory_write -> "tool_memory_write"
   | Tool_ide_annotate -> "tool_ide_annotate"
   | Tool_voice -> "tool_voice"
+  | Tool_task -> "tool_task"
 ;;
 
 let policy ?(visibility = Tool_catalog.Default) ?readonly ?effect_domain
@@ -488,6 +490,17 @@ let voice_external_in_process_policy () =
     ()
 ;;
 
+let task_read_in_process_policy () =
+  policy
+    ~visibility:Tool_catalog.Hidden
+    ~readonly:true
+    ~effect_domain:Tool_catalog.Read_only
+    ~approval:No_approval
+    ~retryable:true
+    ()
+;;
+
+
 let internal_descriptors : t list =
   [ descriptor
       ~id:"keeper.time.now"
@@ -630,6 +643,121 @@ let internal_descriptors : t list =
       ~backend:Remote_service
       ~sandbox:No_sandbox
       ~runtime_handler:Tool_voice
+      ~translate:translate_identity
+  (* Task cluster (RFC-0179 PR-5). All 9 descriptors share the
+     Tool_task runtime_handler variant. Agent_tool_in_process_runtime
+     forwards descriptor.internal_name into
+     Keeper_exec_task.handle_keeper_task_tool, which name-dispatches
+     across the cluster. Policy: tasks_list / tasks_audit are
+     read-only; the rest mutate coordination state. *)
+  ; descriptor
+      ~id:"keeper.tasks.list"
+      ~public_name:"keeper_tasks_list"
+      ~internal_name:"keeper_tasks_list"
+      ~description:"List tasks visible to this keeper."
+      ~input_schema:empty_object_schema
+      ~policy:(task_read_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_task
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.tasks.audit"
+      ~public_name:"keeper_tasks_audit"
+      ~internal_name:"keeper_tasks_audit"
+      ~description:"Audit task state for this keeper's namespace."
+      ~input_schema:empty_object_schema
+      ~policy:(task_read_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_task
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.task.force.release"
+      ~public_name:"keeper_task_force_release"
+      ~internal_name:"keeper_task_force_release"
+      ~description:"Force-release a task back to the backlog."
+      ~input_schema:empty_object_schema
+      ~policy:(coordination_write_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_task
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.task.force.done"
+      ~public_name:"keeper_task_force_done"
+      ~internal_name:"keeper_task_force_done"
+      ~description:"Force-mark a task as done."
+      ~input_schema:empty_object_schema
+      ~policy:(coordination_write_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_task
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.broadcast"
+      ~public_name:"keeper_broadcast"
+      ~internal_name:"keeper_broadcast"
+      ~description:
+        "Broadcast a message visible to other keepers in this namespace."
+      ~input_schema:empty_object_schema
+      ~policy:(coordination_write_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_task
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.task.claim"
+      ~public_name:"keeper_task_claim"
+      ~internal_name:"keeper_task_claim"
+      ~description:"Claim the next eligible task into the active turn."
+      ~input_schema:empty_object_schema
+      ~policy:(coordination_write_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_task
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.task.create"
+      ~public_name:"keeper_task_create"
+      ~internal_name:"keeper_task_create"
+      ~description:"Create a new backlog task with keeper-native evidence."
+      ~input_schema:empty_object_schema
+      ~policy:(coordination_write_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_task
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.task.done"
+      ~public_name:"keeper_task_done"
+      ~internal_name:"keeper_task_done"
+      ~description:"Mark the current task as done."
+      ~input_schema:empty_object_schema
+      ~policy:(coordination_write_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_task
+      ~translate:translate_identity
+  ; descriptor
+      ~id:"keeper.task.submit.for.verification"
+      ~public_name:"keeper_task_submit_for_verification"
+      ~internal_name:"keeper_task_submit_for_verification"
+      ~description:"Submit the current task for verification."
+      ~input_schema:empty_object_schema
+      ~policy:(coordination_write_in_process_policy ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_task
       ~translate:translate_identity
   ]
 ;;

--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -4,6 +4,7 @@ type executor =
   | Shell_ir
   | Filesystem
   | Remote_mcp
+  | In_process
 
 type backend =
   | Ocaml_runtime
@@ -30,6 +31,7 @@ type runtime_handler =
   | Tool_edit_file
   | Tool_write_file
   | Tool_remote_mcp
+  | Tool_time_now
 
 type policy =
   { visibility : Tool_catalog.visibility
@@ -60,6 +62,7 @@ let executor_to_string = function
   | Shell_ir -> "shell_ir"
   | Filesystem -> "filesystem"
   | Remote_mcp -> "remote_mcp"
+  | In_process -> "in_process"
 ;;
 
 let backend_to_string = function
@@ -90,12 +93,14 @@ let runtime_handler_to_string = function
   | Tool_edit_file -> "tool_edit_file"
   | Tool_write_file -> "tool_write_file"
   | Tool_remote_mcp -> "tool_remote_mcp"
+  | Tool_time_now -> "tool_time_now"
 ;;
 
-let policy ?readonly ?effect_domain ?(approval = Policy_selected) ?cwd_scope
-      ?credential_profile ?(retryable = false) ()
+let policy ?(visibility = Tool_catalog.Default) ?readonly ?effect_domain
+      ?(approval = Policy_selected) ?cwd_scope ?credential_profile
+      ?(retryable = false) ()
   =
-  { visibility = Tool_catalog.Default
+  { visibility
   ; readonly
   ; effect_domain
   ; approval
@@ -433,10 +438,38 @@ let public_descriptors =
 ;;
 
 (* RFC-0179 list bifurcation. [internal_descriptors] hosts descriptor-backed
-   coordination tools (keeper_* / masc_* clusters). Starts empty in PR-1; each
-   cluster migration PR adds entries here. The LLM-native [public_descriptors]
-   contract (RFC-0064 hard-cut, 7 entries) is preserved unchanged. *)
-let internal_descriptors : t list = []
+   coordination tools (keeper_* / masc_* clusters). Each cluster migration PR
+   adds entries here. The LLM-native [public_descriptors] contract (RFC-0064
+   hard-cut, 7 entries) is preserved unchanged. *)
+let internal_descriptors : t list =
+  [ descriptor
+      ~id:"keeper.time.now"
+      ~public_name:"keeper_time_now"
+      ~internal_name:"keeper_time_now"
+      ~description:
+        "Return the current wall-clock time as ISO 8601 and Unix epoch \
+         seconds. No arguments."
+      ~input_schema:
+        (`Assoc
+           [ "type", `String "object"
+           ; "properties", `Assoc []
+           ; "additionalProperties", `Bool false
+           ])
+      ~policy:
+        (policy
+           ~visibility:Tool_catalog.Hidden
+           ~readonly:true
+           ~effect_domain:Tool_catalog.Read_only
+           ~approval:No_approval
+           ~retryable:true
+           ())
+      ~executor:In_process
+      ~backend:Ocaml_runtime
+      ~sandbox:No_sandbox
+      ~runtime_handler:Tool_time_now
+      ~translate:translate_identity
+  ]
+;;
 
 let all_descriptors () = public_descriptors @ internal_descriptors
 

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -37,6 +37,8 @@ type runtime_handler =
   | Tool_write_file
   | Tool_remote_mcp
   | Tool_time_now
+  | Tool_stay_silent
+  | Tool_tools_list
 
 type policy =
   { visibility : Tool_catalog.visibility

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -42,6 +42,7 @@ type runtime_handler =
   | Tool_memory_write
   | Tool_ide_annotate
   | Tool_voice
+  | Tool_task
 
 type policy =
   { visibility : Tool_catalog.visibility

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -9,6 +9,7 @@ type executor =
   | Shell_ir
   | Filesystem
   | Remote_mcp
+  | In_process
 
 type backend =
   | Ocaml_runtime
@@ -35,6 +36,7 @@ type runtime_handler =
   | Tool_edit_file
   | Tool_write_file
   | Tool_remote_mcp
+  | Tool_time_now
 
 type policy =
   { visibility : Tool_catalog.visibility

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -39,6 +39,9 @@ type runtime_handler =
   | Tool_time_now
   | Tool_stay_silent
   | Tool_tools_list
+  | Tool_memory_write
+  | Tool_ide_annotate
+  | Tool_voice
 
 type policy =
   { visibility : Tool_catalog.visibility

--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -29,3 +29,7 @@ let handle_ide_annotate ~config ~meta ~args =
 let handle_voice ~meta ~name ~args =
   Agent_tool_voice_runtime.handle_voice_tool ~meta ~name ~args
 ;;
+
+let handle_task ~config ~meta ~name ~args =
+  Keeper_exec_task.handle_keeper_task_tool ~config ~meta ~name ~args
+;;

--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -1,0 +1,8 @@
+(** In-process runtime handlers for descriptor-backed coordination tools. *)
+
+let handle_time_now ~args:_ =
+  let now_unix = Time_compat.now () in
+  let now_iso = Masc_domain.now_iso () in
+  Yojson.Safe.to_string
+    (`Assoc [ "now_iso", `String now_iso; "now_unix", `Float now_unix ])
+;;

--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -14,3 +14,18 @@ let handle_stay_silent ~args:_ =
 let handle_tools_list ~meta ~args:_ =
   Keeper_exec_shared.keeper_tools_list_json ~meta
 ;;
+
+let handle_memory_write ~config ~meta ~args =
+  Keeper_exec_memory.keeper_memory_write_json ~config ~meta ~args
+;;
+
+let handle_ide_annotate ~config ~meta ~args =
+  Agent_tool_ide_runtime.handle_ide_annotate
+    ~config
+    ~keeper_name:meta.Keeper_types.name
+    ~args
+;;
+
+let handle_voice ~meta ~name ~args =
+  Agent_tool_voice_runtime.handle_voice_tool ~meta ~name ~args
+;;

--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -6,3 +6,11 @@ let handle_time_now ~args:_ =
   Yojson.Safe.to_string
     (`Assoc [ "now_iso", `String now_iso; "now_unix", `Float now_unix ])
 ;;
+
+let handle_stay_silent ~args:_ =
+  Yojson.Safe.to_string (`Assoc [ "status", `String "silent" ])
+;;
+
+let handle_tools_list ~meta ~args:_ =
+  Keeper_exec_shared.keeper_tools_list_json ~meta
+;;

--- a/lib/keeper/agent_tool_in_process_runtime.mli
+++ b/lib/keeper/agent_tool_in_process_runtime.mli
@@ -1,0 +1,12 @@
+(** In-process runtime handlers for descriptor-backed coordination tools.
+
+    RFC-0179 PR-2 onwards. This module hosts handlers for descriptors whose
+    executor is [In_process] — pure OCaml-runtime functions with no sandbox,
+    no host process spawn, no remote MCP. Each handler returns the raw output
+    JSON string; the caller in [Keeper_exec_tools] wraps it via
+    [make_executed_tool_result]. *)
+
+val handle_time_now : args:Yojson.Safe.t -> string
+(** [handle_time_now ~args] ignores [args] (the descriptor schema mandates an
+    empty object) and returns
+    [{ "now_iso": <ISO-8601 UTC>, "now_unix": <epoch seconds float> }]. *)

--- a/lib/keeper/agent_tool_in_process_runtime.mli
+++ b/lib/keeper/agent_tool_in_process_runtime.mli
@@ -21,3 +21,27 @@ val handle_tools_list
   -> string
 (** [handle_tools_list ~meta ~args] ignores [args] and returns the
     keeper-visible tool list JSON via [Keeper_exec_shared.keeper_tools_list_json]. *)
+
+val handle_memory_write
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> args:Yojson.Safe.t
+  -> string
+(** [handle_memory_write] delegates to [Keeper_exec_memory.keeper_memory_write_json]. *)
+
+val handle_ide_annotate
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> args:Yojson.Safe.t
+  -> string
+(** [handle_ide_annotate] delegates to [Agent_tool_ide_runtime.handle_ide_annotate]. *)
+
+val handle_voice
+  :  meta:Keeper_types.keeper_meta
+  -> name:string
+  -> args:Yojson.Safe.t
+  -> string
+(** [handle_voice] delegates to [Agent_tool_voice_runtime.handle_voice_tool].
+    The [name] is the descriptor's [internal_name]; the voice runtime
+    name-dispatches across the six voice tools (speak / listen / agent /
+    sessions / session_start / session_end). *)

--- a/lib/keeper/agent_tool_in_process_runtime.mli
+++ b/lib/keeper/agent_tool_in_process_runtime.mli
@@ -10,3 +10,14 @@ val handle_time_now : args:Yojson.Safe.t -> string
 (** [handle_time_now ~args] ignores [args] (the descriptor schema mandates an
     empty object) and returns
     [{ "now_iso": <ISO-8601 UTC>, "now_unix": <epoch seconds float> }]. *)
+
+val handle_stay_silent : args:Yojson.Safe.t -> string
+(** [handle_stay_silent ~args] ignores [args] and returns
+    [{ "status": "silent" }]. *)
+
+val handle_tools_list
+  :  meta:Keeper_types.keeper_meta
+  -> args:Yojson.Safe.t
+  -> string
+(** [handle_tools_list ~meta ~args] ignores [args] and returns the
+    keeper-visible tool list JSON via [Keeper_exec_shared.keeper_tools_list_json]. *)

--- a/lib/keeper/agent_tool_in_process_runtime.mli
+++ b/lib/keeper/agent_tool_in_process_runtime.mli
@@ -45,3 +45,15 @@ val handle_voice
     The [name] is the descriptor's [internal_name]; the voice runtime
     name-dispatches across the six voice tools (speak / listen / agent /
     sessions / session_start / session_end). *)
+
+val handle_task
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> name:string
+  -> args:Yojson.Safe.t
+  -> string
+(** [handle_task] delegates to [Keeper_exec_task.handle_keeper_task_tool].
+    The [name] is the descriptor's [internal_name]; the task runtime
+    name-dispatches across the nine task tools (tasks_list, tasks_audit,
+    task_force_release, task_force_done, broadcast, task_claim,
+    task_create, task_done, task_submit_for_verification). *)

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -34,7 +34,7 @@ let handle_filesystem ctx descriptor args =
          ~args)
   | Tool_execute | Tool_search_files | Tool_remote_mcp | Tool_time_now
   | Tool_stay_silent | Tool_tools_list | Tool_memory_write | Tool_ide_annotate
-  | Tool_voice -> None
+  | Tool_voice | Tool_task -> None
 ;;
 
 (* Dispatch asymmetry: Filesystem and Remote_mcp go through Agent_tool_* runtime
@@ -70,7 +70,7 @@ let handle_shell_ir ctx descriptor args =
          ~args)
   | Tool_read_file | Tool_edit_file | Tool_write_file | Tool_remote_mcp
   | Tool_time_now | Tool_stay_silent | Tool_tools_list | Tool_memory_write
-  | Tool_ide_annotate | Tool_voice -> None
+  | Tool_ide_annotate | Tool_voice | Tool_task -> None
 ;;
 
 let handle_remote_mcp ctx descriptor args =
@@ -100,7 +100,8 @@ let handle_remote_mcp ctx descriptor args =
   | Tool_tools_list
   | Tool_memory_write
   | Tool_ide_annotate
-  | Tool_voice -> None
+  | Tool_voice
+  | Tool_task -> None
 ;;
 
 let handle_in_process ctx descriptor args =
@@ -125,6 +126,13 @@ let handle_in_process ctx descriptor args =
   | Tool_voice ->
     Some
       (Agent_tool_in_process_runtime.handle_voice
+         ~meta:ctx.meta
+         ~name:descriptor.internal_name
+         ~args)
+  | Tool_task ->
+    Some
+      (Agent_tool_in_process_runtime.handle_task
+         ~config:ctx.config
          ~meta:ctx.meta
          ~name:descriptor.internal_name
          ~args)

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -32,7 +32,7 @@ let handle_filesystem ctx descriptor args =
          ~config:ctx.config
          ~keeper_name:ctx.meta.name
          ~args)
-  | Tool_execute | Tool_search_files | Tool_remote_mcp -> None
+  | Tool_execute | Tool_search_files | Tool_remote_mcp | Tool_time_now -> None
 ;;
 
 (* Dispatch asymmetry: Filesystem and Remote_mcp go through Agent_tool_* runtime
@@ -66,7 +66,8 @@ let handle_shell_ir ctx descriptor args =
          ~config:ctx.config
          ~meta:ctx.meta
          ~args)
-  | Tool_read_file | Tool_edit_file | Tool_write_file | Tool_remote_mcp -> None
+  | Tool_read_file | Tool_edit_file | Tool_write_file | Tool_remote_mcp
+  | Tool_time_now -> None
 ;;
 
 let handle_remote_mcp ctx descriptor args =
@@ -90,7 +91,19 @@ let handle_remote_mcp ctx descriptor args =
   | Tool_search_files
   | Tool_read_file
   | Tool_edit_file
-  | Tool_write_file -> None
+  | Tool_write_file
+  | Tool_time_now -> None
+;;
+
+let handle_in_process _ctx descriptor args =
+  match descriptor.Agent_tool_descriptor.runtime_handler with
+  | Tool_time_now -> Some (Agent_tool_in_process_runtime.handle_time_now ~args)
+  | Tool_execute
+  | Tool_search_files
+  | Tool_read_file
+  | Tool_edit_file
+  | Tool_write_file
+  | Tool_remote_mcp -> None
 ;;
 
 let handle ctx ~descriptor ~args =
@@ -98,6 +111,7 @@ let handle ctx ~descriptor ~args =
   | Filesystem -> handle_filesystem ctx descriptor args
   | Shell_ir -> handle_shell_ir ctx descriptor args
   | Remote_mcp -> handle_remote_mcp ctx descriptor args
+  | In_process -> handle_in_process ctx descriptor args
 ;;
 
 let handle_internal ctx ~name ~args =

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -33,7 +33,8 @@ let handle_filesystem ctx descriptor args =
          ~keeper_name:ctx.meta.name
          ~args)
   | Tool_execute | Tool_search_files | Tool_remote_mcp | Tool_time_now
-  | Tool_stay_silent | Tool_tools_list -> None
+  | Tool_stay_silent | Tool_tools_list | Tool_memory_write | Tool_ide_annotate
+  | Tool_voice -> None
 ;;
 
 (* Dispatch asymmetry: Filesystem and Remote_mcp go through Agent_tool_* runtime
@@ -68,7 +69,8 @@ let handle_shell_ir ctx descriptor args =
          ~meta:ctx.meta
          ~args)
   | Tool_read_file | Tool_edit_file | Tool_write_file | Tool_remote_mcp
-  | Tool_time_now | Tool_stay_silent | Tool_tools_list -> None
+  | Tool_time_now | Tool_stay_silent | Tool_tools_list | Tool_memory_write
+  | Tool_ide_annotate | Tool_voice -> None
 ;;
 
 let handle_remote_mcp ctx descriptor args =
@@ -95,7 +97,10 @@ let handle_remote_mcp ctx descriptor args =
   | Tool_write_file
   | Tool_time_now
   | Tool_stay_silent
-  | Tool_tools_list -> None
+  | Tool_tools_list
+  | Tool_memory_write
+  | Tool_ide_annotate
+  | Tool_voice -> None
 ;;
 
 let handle_in_process ctx descriptor args =
@@ -105,6 +110,24 @@ let handle_in_process ctx descriptor args =
     Some (Agent_tool_in_process_runtime.handle_stay_silent ~args)
   | Tool_tools_list ->
     Some (Agent_tool_in_process_runtime.handle_tools_list ~meta:ctx.meta ~args)
+  | Tool_memory_write ->
+    Some
+      (Agent_tool_in_process_runtime.handle_memory_write
+         ~config:ctx.config
+         ~meta:ctx.meta
+         ~args)
+  | Tool_ide_annotate ->
+    Some
+      (Agent_tool_in_process_runtime.handle_ide_annotate
+         ~config:ctx.config
+         ~meta:ctx.meta
+         ~args)
+  | Tool_voice ->
+    Some
+      (Agent_tool_in_process_runtime.handle_voice
+         ~meta:ctx.meta
+         ~name:descriptor.internal_name
+         ~args)
   | Tool_execute
   | Tool_search_files
   | Tool_read_file

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -32,7 +32,8 @@ let handle_filesystem ctx descriptor args =
          ~config:ctx.config
          ~keeper_name:ctx.meta.name
          ~args)
-  | Tool_execute | Tool_search_files | Tool_remote_mcp | Tool_time_now -> None
+  | Tool_execute | Tool_search_files | Tool_remote_mcp | Tool_time_now
+  | Tool_stay_silent | Tool_tools_list -> None
 ;;
 
 (* Dispatch asymmetry: Filesystem and Remote_mcp go through Agent_tool_* runtime
@@ -67,7 +68,7 @@ let handle_shell_ir ctx descriptor args =
          ~meta:ctx.meta
          ~args)
   | Tool_read_file | Tool_edit_file | Tool_write_file | Tool_remote_mcp
-  | Tool_time_now -> None
+  | Tool_time_now | Tool_stay_silent | Tool_tools_list -> None
 ;;
 
 let handle_remote_mcp ctx descriptor args =
@@ -92,12 +93,18 @@ let handle_remote_mcp ctx descriptor args =
   | Tool_read_file
   | Tool_edit_file
   | Tool_write_file
-  | Tool_time_now -> None
+  | Tool_time_now
+  | Tool_stay_silent
+  | Tool_tools_list -> None
 ;;
 
-let handle_in_process _ctx descriptor args =
+let handle_in_process ctx descriptor args =
   match descriptor.Agent_tool_descriptor.runtime_handler with
   | Tool_time_now -> Some (Agent_tool_in_process_runtime.handle_time_now ~args)
+  | Tool_stay_silent ->
+    Some (Agent_tool_in_process_runtime.handle_stay_silent ~args)
+  | Tool_tools_list ->
+    Some (Agent_tool_in_process_runtime.handle_tools_list ~meta:ctx.meta ~args)
   | Tool_execute
   | Tool_search_files
   | Tool_read_file

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -439,13 +439,9 @@ let execute_keeper_tool_call_with_outcome
              | None -> search_tools
            in
            success_tool_result (Yojson.Safe.to_string (fn ~query ~max_results)))
-       | "keeper_stay_silent" ->
-         success_tool_result
-           (Yojson.Safe.to_string (`Assoc [ "status", `String "silent" ]))
-       | "keeper_tools_list" ->
-         success_tool_result (Keeper_exec_shared.keeper_tools_list_json ~meta)
-       (* "keeper_time_now" migrated to Agent_tool_in_process_runtime via
-          descriptor dispatch (RFC-0179 PR-2). *)
+       (* "keeper_stay_silent", "keeper_tools_list", "keeper_time_now"
+          migrated to Agent_tool_in_process_runtime via descriptor dispatch
+          (RFC-0179 PR-2 + PR-3). *)
        | "keeper_context_status" ->
          success_tool_result
            (Keeper_exec_memory.keeper_context_status_json ~config ~meta ~ctx_work)

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -319,7 +319,6 @@ let execute_keeper_tool_call_with_outcome
   : executed_tool_result
   =
   let args = input in
-  let now_ts = Time_compat.now () in
   let meta =
     match Keeper_registry.get ~base_path:config.base_path meta.name with
     | Some entry -> entry.meta
@@ -445,10 +444,8 @@ let execute_keeper_tool_call_with_outcome
            (Yojson.Safe.to_string (`Assoc [ "status", `String "silent" ]))
        | "keeper_tools_list" ->
          success_tool_result (Keeper_exec_shared.keeper_tools_list_json ~meta)
-       | "keeper_time_now" ->
-         success_tool_result
-           (Yojson.Safe.to_string
-              (`Assoc [ "now_iso", `String (now_iso ()); "now_unix", `Float now_ts ]))
+       (* "keeper_time_now" migrated to Agent_tool_in_process_runtime via
+          descriptor dispatch (RFC-0179 PR-2). *)
        | "keeper_context_status" ->
          success_tool_result
            (Keeper_exec_memory.keeper_context_status_json ~config ~meta ~ctx_work)

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -469,17 +469,15 @@ let execute_keeper_tool_call_with_outcome
           single Tool_voice runtime_handler; handle_voice forwards the
           descriptor's internal_name into Agent_tool_voice_runtime, which
           performs the per-tool name dispatch. *)
-       | "keeper_tasks_list"
-       | "keeper_tasks_audit"
-       | "keeper_task_force_release"
-       | "keeper_task_force_done"
-       | "keeper_broadcast"
-       | "keeper_task_claim"
-       | "keeper_task_create"
-       | "keeper_task_done"
-       | "keeper_task_submit_for_verification" ->
-         make_executed_tool_result
-           (Keeper_exec_task.handle_keeper_task_tool ~config ~meta ~name ~args)
+       (* keeper_task_* cluster (9 tools: tasks_list, tasks_audit,
+          task_force_release, task_force_done, broadcast, task_claim,
+          task_create, task_done, task_submit_for_verification)
+          migrated to Agent_tool_in_process_runtime via descriptor
+          dispatch (RFC-0179 PR-5). All 9 descriptors share the
+          Tool_task runtime_handler; handle_task forwards the
+          descriptor's internal_name into
+          Keeper_exec_task.handle_keeper_task_tool, which performs the
+          per-tool name dispatch. *)
        | other ->
          (match
             Agent_tool_remote_mcp_runtime.handle_registered_remote_tool

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -448,9 +448,8 @@ let execute_keeper_tool_call_with_outcome
        | "keeper_memory_search" ->
          success_tool_result
            (Keeper_exec_memory.keeper_memory_search_json ~config ~meta ~ctx_work ~args)
-       | "keeper_memory_write" ->
-         success_tool_result
-           (Keeper_exec_memory.keeper_memory_write_json ~config ~meta ~args)
+       (* "keeper_memory_write" migrated to Agent_tool_in_process_runtime
+          via descriptor dispatch (RFC-0179 PR-4). *)
        | "keeper_library_search" ->
          let result =
            Tool_library.handle_search ~tool_name:"keeper_library_search" ~start_time:0.0 Tool_library.{ agent_name = meta.name } args
@@ -464,20 +463,12 @@ let execute_keeper_tool_call_with_outcome
            Tool_library.handle_read ~tool_name:"keeper_library_read" ~start_time:0.0 Tool_library.{ agent_name = meta.name } args
          in
          if result.Tool_result.success then success_tool_result result.Tool_result.message else failure_tool_result (error_json result.Tool_result.message)
-       | "keeper_ide_annotate" ->
-         make_executed_tool_result
-           (Agent_tool_ide_runtime.handle_ide_annotate
-              ~config
-              ~keeper_name:meta.name
-              ~args)
-       | "keeper_voice_speak"
-       | "keeper_voice_listen"
-       | "keeper_voice_agent"
-       | "keeper_voice_sessions"
-       | "keeper_voice_session_start"
-       | "keeper_voice_session_end" ->
-         make_executed_tool_result
-           (Agent_tool_voice_runtime.handle_voice_tool ~meta ~name ~args)
+       (* "keeper_ide_annotate" and the keeper_voice_* cluster (6 tools)
+          migrated to Agent_tool_in_process_runtime via descriptor dispatch
+          (RFC-0179 PR-4). The voice descriptors all route through the
+          single Tool_voice runtime_handler; handle_voice forwards the
+          descriptor's internal_name into Agent_tool_voice_runtime, which
+          performs the per-tool name dispatch. *)
        | "keeper_tasks_list"
        | "keeper_tasks_audit"
        | "keeper_task_force_release"


### PR DESCRIPTION
## Summary

RFC-0179 PR-5 — task cluster 9 tool 일괄 migration. **shared Tool_task runtime_handler variant** + 9 descriptor entries. coverage **18/286 → 27/286** (~6.3% → ~9.4%).

## Migrated tools (9)

모두 `Tool_task` runtime_handler 공유. `Keeper_exec_task.handle_keeper_task_tool ~config ~meta ~name ~args` 가 name-dispatch.

| Tool | Policy |
|---|---|
| `keeper_tasks_list` | read-only |
| `keeper_tasks_audit` | read-only |
| `keeper_task_force_release` | coordination write |
| `keeper_task_force_done` | coordination write |
| `keeper_broadcast` | coordination write |
| `keeper_task_claim` | coordination write |
| `keeper_task_create` | coordination write |
| `keeper_task_done` | coordination write |
| `keeper_task_submit_for_verification` | coordination write |

## Shared-variant pattern (PR-4 voice_* 검증, PR-5 task_* 확장)

cluster의 backing handler가 이미 name-dispatched면 — descriptor list는 per-tool 성장 + runtime_handler enum은 single variant 유지 가능. enum size 통제 + per-tool observability 보존.

총 누적: 6 voice + 9 task = 15 tool / 2 variant. 다음 후보 `keeper_board_*` cluster도 동일 패턴 적용 가능 (별도 `is_keeper_board_tool_name` 분기 통해).

## Policy helper 4종 (누적)

| Helper | Use |
|---|---|
| `read_only_in_process_policy` | time_now / stay_silent / tools_list / voice_sessions / tasks_list / tasks_audit |
| `coordination_write_in_process_policy` | memory_write / ide_annotate / task_* (7 entries) |
| `voice_external_in_process_policy` | voice_speak / listen / agent / session_start / session_end |
| `task_read_in_process_policy` (신규) | tasks_list / tasks_audit (Read_only effect) |

## Invariants

| Invariant | Status |
|---|---|
| `public_descriptors` 7 entries | ✅ 불변 |
| `internal_descriptors` | 10 → 19 (+9) |
| `Agent_tool_runtime.handle` exhaustive | ✅ |
| `test_alias_table_is_stable` | ✅ 40/40 |
| `test_cdal_tool_id` | ✅ 9/9 |

## JSON output parity

모든 9 task tool이 legacy chain과 동일한 `Keeper_exec_task.handle_keeper_task_tool` 호출. agent-visible behavior 변경 0.

## Receipt observability

이전: legacy chain → receipt evidence 0건
이후: 9 task tool 모두 route_evidence_json 자동 부착

## Verification

- `dune build --root . lib/` EXIT=0
- `test_keeper_tool_alias` 40/40 PASS
- `test_cdal_tool_id` 9/9 PASS

## Stacked on

#18698 (PR-4, open).

## Remaining legacy match arms

- `keeper_tool_search` (1)
- `keeper_preflight_check` (1)
- `keeper_context_status` (ctx_work 의존)
- `keeper_memory_search` (ctx_work 의존)
- `keeper_library_*` (2, Tool_result.t branching)
- `is_keeper_board_tool_name` cluster (separate dispatch path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
