### PR TITLE
refactor(keeper): remove gh cache policy axis

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -121,28 +121,6 @@ tools = [
   "masc_goal_verify",
 ]
 
-# ── GitHub Cache ───────────────────────────────────────────────────
-# Pre-execution hallucination gate: validates PR/issue numbers
-# against a cached list before executing gh CLI commands.
-# See lib/keeper/keeper_exec_github.ml for implementation.
-
-[gh_cache]
-# Time-to-live for cached PR/issue number lists (seconds).
-# 120s keeps entries fresh enough that newly-created PRs appear within
-# ~2 minutes, while avoiding a subprocess per validation call.
-cache_ttl_sec = 120
-# Page size for the gh API REST call (pulls?per_page=N).
-# Repos with >N open PRs will miss older numbers — those fall to
-# Unknown (fail-open), which is safer than a hard rejection.
-fetch_page_size = 100
-# Subprocess timeout for the gh API fetch call (seconds).
-fetch_timeout_sec = 10
-# Maximum number of valid alternatives shown in rejection response.
-max_alternatives = 20
-# Maximum gh output size in bytes. Responses exceeding this are
-# truncated to prevent context window overflow (65KB observed).
-max_output_bytes = 8192
-
 # ── Keeper Identity ────────────────────────────────────────────────
 # Git author/committer identity for keeper operations.
 # {name} is replaced with the sanitized keeper name at runtime.

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -92,17 +92,6 @@ let with_policy_config_or ?(on_none = fun () -> ()) ~accessor ~default f =
     default
   | Some cfg -> f cfg
 
-let require_policy_config ~accessor =
-  match !policy_config with
-  | Some cfg -> cfg
-  | None ->
-    observe_unloaded_policy_config ~accessor
-      ~outcome:"raising Invalid_argument";
-    invalid_arg
-      (Printf.sprintf
-         "tool_policy.%s requires init_policy_config; config/tool_policy.toml is not loaded"
-         accessor)
-
 let reset_policy_config_for_test () =
   policy_config := None;
   Stdlib.Mutex.lock policy_config_unloaded_mutex;
@@ -142,28 +131,6 @@ let allows_workflow_for_preset (preset : tool_preset) : bool =
 
 let allows_shell_write_for_preset (preset : tool_preset) : bool =
   preset_allows_privileged_operations preset
-
-(* ── GH cache config accessors (config-driven) ─────────────── *)
-
-let gh_cache_ttl_sec () : float =
-  require_policy_config ~accessor:"gh_cache_ttl_sec"
-  |> Keeper_tool_policy_config.gh_cache_ttl_sec
-
-let gh_cache_fetch_page_size () : int =
-  require_policy_config ~accessor:"gh_cache_fetch_page_size"
-  |> Keeper_tool_policy_config.gh_cache_fetch_page_size
-
-let gh_cache_fetch_timeout_sec () : float =
-  require_policy_config ~accessor:"gh_cache_fetch_timeout_sec"
-  |> Keeper_tool_policy_config.gh_cache_fetch_timeout_sec
-
-let gh_cache_max_alternatives () : int =
-  require_policy_config ~accessor:"gh_cache_max_alternatives"
-  |> Keeper_tool_policy_config.gh_cache_max_alternatives
-
-let gh_cache_max_output_bytes () : int =
-  require_policy_config ~accessor:"gh_cache_max_output_bytes"
-  |> Keeper_tool_policy_config.gh_cache_max_output_bytes
 
 (* ── Preset subsumption (config-driven) ──────────────────────── *)
 

--- a/lib/keeper/keeper_tool_policy.mli
+++ b/lib/keeper/keeper_tool_policy.mli
@@ -42,16 +42,6 @@ val preset_can_satisfy :
 val allows_workflow_for_preset : tool_preset -> bool
 val allows_shell_write_for_preset : tool_preset -> bool
 
-(** {1 GH Cache Config} *)
-
-(** These accessors follow the same loaded-policy requirement as the
-    numeric git/gh timeout accessors above. *)
-val gh_cache_ttl_sec : unit -> float
-val gh_cache_fetch_page_size : unit -> int
-val gh_cache_fetch_timeout_sec : unit -> float
-val gh_cache_max_alternatives : unit -> int
-val gh_cache_max_output_bytes : unit -> int
-
 (** {1 MASC Schema Injection} *)
 
 (** Inline MCP-runtime tools that are safe for keepers without an MCP session

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -21,19 +21,10 @@ type preset_def = {
   all_candidates : bool;         (** true = include all candidate tools *)
 }
 
-type gh_cache_config = {
-  cache_ttl_sec : float;
-  fetch_page_size : int;
-  fetch_timeout_sec : float;
-  max_alternatives : int;
-  max_output_bytes : int;
-}
-
 type t = {
   groups : (string, group_source) Hashtbl.t;
   masc_groups : (string, string list) Hashtbl.t;
   presets : (string, preset_def) Hashtbl.t;
-  gh_cache : gh_cache_config;
 }
 
 (* ── TOML parsing helpers ─────────────────────────────────────────── *)
@@ -46,9 +37,6 @@ let toml_string_opt_at doc prefix key =
 
 let toml_bool_at doc prefix key =
   Keeper_toml_loader.toml_bool_opt doc (prefix ^ "." ^ key)
-
-let toml_int_at doc prefix key =
-  Keeper_toml_loader.toml_int_opt doc (prefix ^ "." ^ key)
 
 (** Collect all table prefixes matching a dotted prefix pattern.
     E.g., for prefix "groups" in a doc with "groups.base.tools",
@@ -141,27 +129,6 @@ let parse_presets
     Hashtbl.replace tbl name { groups; masc_groups; masc_tools; all_candidates }
   ) names;
   tbl
-
-let parse_gh_cache (doc : Keeper_toml_loader.toml_doc) : gh_cache_config =
-  let cache_ttl_sec =
-    Option.value ~default:120 (toml_int_at doc "gh_cache" "cache_ttl_sec")
-    |> Float.of_int
-  in
-  let fetch_page_size =
-    Option.value ~default:100 (toml_int_at doc "gh_cache" "fetch_page_size")
-  in
-  let fetch_timeout_sec =
-    Option.value ~default:10 (toml_int_at doc "gh_cache" "fetch_timeout_sec")
-    |> Float.of_int
-  in
-  let max_alternatives =
-    Option.value ~default:20 (toml_int_at doc "gh_cache" "max_alternatives")
-  in
-  let max_output_bytes =
-    Option.value ~default:8192 (toml_int_at doc "gh_cache" "max_output_bytes")
-  in
-  { cache_ttl_sec; fetch_page_size; fetch_timeout_sec;
-    max_alternatives; max_output_bytes }
 
 let unresolved_tool_message ~label ~name =
   match Keeper_tool_resolution.resolve name with
@@ -306,10 +273,9 @@ let load ~base_path : (t, string) result =
                 (Printf.sprintf "in %s: %s" path
                    (String.concat "; " fatal_tool_errors))
           | [] ->
-              let gh_cache = parse_gh_cache doc in
               Log.Keeper.info "tool_policy_config: loaded %d groups, %d masc_groups, %d presets from %s"
                 (Hashtbl.length groups) (Hashtbl.length masc_groups) (Hashtbl.length presets) path;
-              Ok { groups; masc_groups; presets; gh_cache })
+              Ok { groups; masc_groups; presets })
         )
 
 (* ── Resolution ───────────────────────────────────────────────────── *)
@@ -400,20 +366,3 @@ let preset_can_satisfy (config : t) ~(agent_preset : string) ~(required_preset :
     | _, `Full -> false                    (* required is full, agent isn't *)
     | `Tools agent_tools, `Tools req_tools ->
       List.for_all (fun t -> List.mem t agent_tools) req_tools
-
-(* ── GH cache config accessors ───────────────────────────────────── *)
-
-let gh_cache_ttl_sec (config : t) : float =
-  config.gh_cache.cache_ttl_sec
-
-let gh_cache_fetch_page_size (config : t) : int =
-  config.gh_cache.fetch_page_size
-
-let gh_cache_fetch_timeout_sec (config : t) : float =
-  config.gh_cache.fetch_timeout_sec
-
-let gh_cache_max_alternatives (config : t) : int =
-  config.gh_cache.max_alternatives
-
-let gh_cache_max_output_bytes (config : t) : int =
-  config.gh_cache.max_output_bytes

--- a/lib/keeper/keeper_tool_policy_config.mli
+++ b/lib/keeper/keeper_tool_policy_config.mli
@@ -50,19 +50,4 @@ val group_names : t -> string list
     Config-derived — no hardcoded hierarchy. *)
 val preset_can_satisfy : t -> agent_preset:string -> required_preset:string -> bool
 
-(** GH cache TTL in seconds. From [gh_cache.cache_ttl_sec], default 120.0. **)
-val gh_cache_ttl_sec : t -> float
-
-(** Page size for gh API fetch. From [gh_cache.fetch_page_size], default 100. *)
-val gh_cache_fetch_page_size : t -> int
-
-(** Timeout for gh API fetch subprocess. From [gh_cache.fetch_timeout_sec], default 10.0. *)
-val gh_cache_fetch_timeout_sec : t -> float
-
-(** Max valid alternatives in rejection response. From [gh_cache.max_alternatives], default 20. *)
-val gh_cache_max_alternatives : t -> int
-
-(** Max gh output bytes before truncation. From [gh_cache.max_output_bytes], default 8192. *)
-val gh_cache_max_output_bytes : t -> int
-
 val resolve_group : t -> string -> string list option

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -256,48 +256,27 @@ let tool_policy_unloaded_metric accessor =
     ~labels:[("accessor", accessor)]
     ()
 
-let string_contains text needle =
-  try
-    ignore (Str.search_forward (Str.regexp_string needle) text 0);
-    true
-  with Not_found -> false
-
-let check_policy_not_loaded_raises accessor call =
-  match call () with
-  | () -> failf "%s should raise when tool_policy config is unloaded" accessor
-  | exception Invalid_argument msg ->
-      check bool (accessor ^ " error names accessor") true
-        (string_contains msg accessor);
-      check bool (accessor ^ " error names init_policy_config") true
-        (string_contains msg "init_policy_config")
-  | exception exn ->
-      failf "%s raised unexpected exception: %s" accessor
-        (Printexc.to_string exn)
-
 let test_tool_policy_unloaded_accessors_emit_metric () =
   Keeper_tool_policy.reset_policy_config_for_test ();
-  let strict_accessors =
+  let fallback_accessors =
     [
-      ( "gh_cache_ttl_sec",
-        fun () -> ignore (Keeper_tool_policy.gh_cache_ttl_sec ()) );
-      ( "gh_cache_fetch_page_size",
-        fun () -> ignore (Keeper_tool_policy.gh_cache_fetch_page_size ()) );
-      ( "gh_cache_fetch_timeout_sec",
-        fun () -> ignore (Keeper_tool_policy.gh_cache_fetch_timeout_sec ()) );
-      ( "gh_cache_max_alternatives",
-        fun () -> ignore (Keeper_tool_policy.gh_cache_max_alternatives ()) );
-      ( "gh_cache_max_output_bytes",
-        fun () -> ignore (Keeper_tool_policy.gh_cache_max_output_bytes ()) );
+      ( "preset_can_satisfy",
+        fun () ->
+          ignore
+            (Keeper_tool_policy.preset_can_satisfy ~agent_preset:"coding"
+               ~required_preset:"minimal") );
+      ( "configured_preset_names",
+        fun () -> ignore (Keeper_tool_policy.configured_preset_names ()) );
     ]
   in
   List.iter
     (fun (accessor, call) ->
       let before = tool_policy_unloaded_metric accessor in
-      check_policy_not_loaded_raises accessor call;
+      call ();
       let after = tool_policy_unloaded_metric accessor in
       check bool (accessor ^ " pre-init query increments metric") true
         (after >= before +. 1.0))
-    strict_accessors;
+    fallback_accessors;
   init_registry ()
 
 let tool_policy_init_failed_metric base_path =


### PR DESCRIPTION
## Summary
- remove the `[gh_cache]` policy table from `config/tool_policy.toml`
- remove GH cache config parsing/accessors from `Keeper_tool_policy_config` and `Keeper_tool_policy`
- update the unloaded-policy metric regression to cover remaining fallback policy accessors instead of removed strict GH cache accessors

## Why
`gh_cache` was another GH-specific policy axis in the tool policy layer. GH behavior should stay behind typed `Execute` / Shell IR handling, not as a dedicated keeper policy branch.

## Validation
- `rg -n 'gh_cache|gh_cache_ttl_sec|gh_cache_fetch_page_size|gh_cache_fetch_timeout_sec|gh_cache_max_alternatives|gh_cache_max_output_bytes|\\[gh_cache\\]' lib test config docs scripts -g '!_build/**'` returns no matches
- `ocamlformat --check lib/keeper/keeper_tool_policy_config.ml lib/keeper/keeper_tool_policy_config.mli lib/keeper/keeper_tool_policy.ml lib/keeper/keeper_tool_policy.mli test/test_warn_root_causes.ml`
- `git diff --check`

Focused Dune build was skipped because `/tmp/me-dune-local.lock` is currently held by another Dune run.