### PR TITLE
refactor(keeper): rename gh timeout floor

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -22,7 +22,7 @@ let all_shell_ops = Keeper_shell_op.all
 let valid_shell_op_strings = Keeper_shell_op.valid_strings
 let readonly_hint_of_category = Keeper_shell_readonly_policy.readonly_hint_of_category
 let diagnosis_of_block_reason = Keeper_shell_readonly_policy.diagnosis_of_block_reason
-let gh_min_timeout_sec = Keeper_shell_timeout.gh_min_timeout_sec
+let tool_dispatch_min_timeout_sec = Keeper_shell_timeout.tool_dispatch_min_timeout_sec
 let keeper_shell_ir_native_min_timeout_sec = Keeper_shell_timeout.keeper_shell_ir_native_min_timeout_sec
 let rewrite_turn_runtime_paths_to_host =
   Keeper_shell_runtime_paths.rewrite_turn_runtime_paths_to_host

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -30,10 +30,10 @@ val diagnosis_of_block_reason :
     entry point used by tests and callers; implementation lives in
     [Keeper_shell_readonly_policy]. *)
 
-val gh_min_timeout_sec : float
-(** Minimum timeout_sec floor applied to GitHub CLI dispatch. Exposed so
+val tool_dispatch_min_timeout_sec : float
+(** Minimum timeout_sec floor applied to load-bearing tool dispatch. Exposed so
     regression tests can lock the floor against drift back to
-    sub-network-latency values. See #8688. *)
+    sub-I/O-latency values. *)
 
 val keeper_shell_ir_native_min_timeout_sec : float
 (** Minimum timeout_sec floor applied to keeper_shell_ir on the *native*

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -185,12 +185,12 @@ let docker_result_pair = function
    were timing out at 5s because the cold-start path alone (image pull
    + container creation + shell init) can take 10-60s on a cold host.
 
-   #8688 raised the gh-cli floor to [gh_min_timeout_sec = 15s] for the
-   same class of failure (sub-network-latency timeouts cascading into
-   401 retries); the docker path was left at 5s — an N-of-M between
-   sibling timeout floors. This restores parity (15s gh + 5s headroom
-   for container creation) and exposes an env override so operators
-   can tune for slow-pull fleets without rebuilding.
+   Load-bearing tool dispatch uses a 15s floor for the same class of
+   failure (sub-I/O-latency timeouts cascading into retries); the docker
+   path was left at 5s — an N-of-M between sibling timeout floors. This
+   restores parity (15s dispatch + 5s headroom for container creation) and
+   exposes an env override so operators can tune for slow-pull fleets without
+   rebuilding.
 
    This minimum applies only to the [docker run] path, not to
    [docker exec] against a warm container. *)

--- a/lib/keeper/keeper_sandbox_docker.mli
+++ b/lib/keeper/keeper_sandbox_docker.mli
@@ -92,8 +92,8 @@ type docker_shell_result =
 
 (** Cold-start floor (seconds) for [docker run --rm].  The wall-clock
     budget covers slot_wait + spawn + container cold start + actual
-    cmd + drain; the default ([20.0]) matches the [gh] CLI floor
-    ([gh_min_timeout_sec = 15s], #8688) plus 5s headroom for image
+    cmd + drain; the default ([20.0]) matches the tool dispatch floor
+    ([tool_dispatch_min_timeout_sec = 15s]) plus 5s headroom for image
     pull and container creation.  Operators can override via
     [MASC_KEEPER_DOCKER_RUN_MIN_TIMEOUT_SEC] (read once at module
     load, clamped to [Timeout_floor.Docker_run]). *)

--- a/lib/keeper/keeper_shell_timeout.ml
+++ b/lib/keeper/keeper_shell_timeout.ml
@@ -7,7 +7,7 @@ let io_timeout_sec = env_float "MASC_KEEPER_IO_TIMEOUT_SEC" 30.0
 let read_timeout_sec = env_float "MASC_KEEPER_READ_TIMEOUT_SEC" 15.0
 let user_timeout_max_sec = env_float "MASC_KEEPER_USER_TIMEOUT_MAX_SEC" 180.0
 
-let gh_min_timeout_sec =
+let tool_dispatch_min_timeout_sec =
   Timeout_floor.default_sec Timeout_floor.Tool_dispatch
 ;;
 
@@ -72,7 +72,7 @@ let rec keeper_shell_ir_args_need_tool_dispatch_floor = function
 
 let keeper_shell_ir_min_timeout_sec_for_args args =
   if keeper_shell_ir_args_need_tool_dispatch_floor args
-  then Timeout_floor.default_sec Timeout_floor.Tool_dispatch
+  then tool_dispatch_min_timeout_sec
   else keeper_shell_ir_native_min_timeout_sec
 ;;
 

--- a/lib/keeper/keeper_shell_timeout.mli
+++ b/lib/keeper/keeper_shell_timeout.mli
@@ -5,7 +5,7 @@ val env_float : string -> float -> float
 val io_timeout_sec : float
 val read_timeout_sec : float
 val user_timeout_max_sec : float
-val gh_min_timeout_sec : float
+val tool_dispatch_min_timeout_sec : float
 val keeper_shell_ir_native_min_timeout_sec : float
 val keeper_shell_ir_min_timeout_sec_for_args : Yojson.Safe.t -> float
 val git_meta_timeout_sec : float

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -374,14 +374,14 @@ let test_tool_search_files_ir_load_bearing_timeout_floor () =
        [ "executable", `String "git"
        ; "argv", `List [ `String "log"; `String "--oneline"; `String "-5" ]
        ])
-    Masc_mcp.Keeper_shell_timeout.gh_min_timeout_sec;
+    Masc_mcp.Keeper_shell_timeout.tool_dispatch_min_timeout_sec;
   check
     "recursive grep uses tool dispatch floor"
     (`Assoc
        [ "executable", `String "grep"
        ; "argv", `List [ `String "-rn"; `String "Yojson"; `String "." ]
        ])
-    Masc_mcp.Keeper_shell_timeout.gh_min_timeout_sec;
+    Masc_mcp.Keeper_shell_timeout.tool_dispatch_min_timeout_sec;
   check
     "pipeline inherits load-bearing floor"
     (`Assoc
@@ -391,7 +391,7 @@ let test_tool_search_files_ir_load_bearing_timeout_floor () =
              ; `Assoc [ "executable", `String "head"; "argv", `List [ `String "-5" ] ]
              ] )
        ])
-    Masc_mcp.Keeper_shell_timeout.gh_min_timeout_sec
+    Masc_mcp.Keeper_shell_timeout.tool_dispatch_min_timeout_sec
 ;;
 
 let test_nested_runtime_detector_ignores_git_commit_message () =

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -288,7 +288,7 @@ let test_shell_shared_is_removed () =
       "keeper_shell_read_ops";
     ];
   assert_contains exec_shell_ml "Keeper_shell_op.valid_strings";
-  assert_contains exec_shell_ml "Keeper_shell_timeout.gh_min_timeout_sec";
+  assert_contains exec_shell_ml "Keeper_shell_timeout.tool_dispatch_min_timeout_sec";
   assert_contains exec_shell_ml "Keeper_shell_runtime_paths.rewrite_turn_runtime_paths_to_host";
   assert_contains exec_shell_ml "Keeper_shell_readonly_policy.readonly_hint_of_category";
   assert_contains "lib/keeper/keeper_shell_read_ops.ml" "Keeper_shell_timeout.read_timeout_sec";


### PR DESCRIPTION
## Summary
- rename `gh_min_timeout_sec` to `tool_dispatch_min_timeout_sec`
- remove GH-specific timeout-floor comments from shell and sandbox boundaries
- update regression tests to lock the generic load-bearing dispatch floor instead

## Why
The timeout floor is already implemented as `Timeout_floor.Tool_dispatch`; keeping a `gh_*` name made it look like GitHub CLI was a first-class execution axis. This keeps the policy generic and leaves command semantics to typed `Execute` / Shell IR.

## Validation
- `rg -n 'gh_min_timeout_sec|gh-cli floor|gh CLI floor|GitHub CLI dispatch' lib test config docs scripts -g '!_build/**'` returns no matches
- `ocamlformat --check lib/keeper/keeper_exec_shell.ml lib/keeper/keeper_exec_shell.mli lib/keeper/keeper_sandbox_docker.ml lib/keeper/keeper_sandbox_docker.mli lib/keeper/keeper_shell_timeout.ml lib/keeper/keeper_shell_timeout.mli test/test_keeper_bash_safety.ml test/test_keeper_sandbox_boundary_policy.ml`
- `git diff --check`

Focused Dune build was skipped because `/tmp/me-dune-local.lock` is currently held by another Dune run.