### PR TITLE
feat(cdal): RFC-0109 Phase D — Cdal_evidence_gate layered decision (stacked on #18709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## [Unreleased]
 
 ### Added
+- RFC-0109 Phase D: introduced `Cdal_evidence_gate` layered decision
+  module that consults `Cdal_verdict_gate.lookup_latest_verdict` before
+  falling back to the legacy substring shim in
+  `Tool_task_completion_review`. Analysis-only tasks (no contract)
+  bypass the evidence gate — the operator-visible
+  `keeper_task_done` open-loop block no longer fires when the keeper
+  has nothing to attest beyond completion. Violated/Inconclusive
+  verdicts now reject with typed `findings[]` and
+  `completeness_gaps[]` in the workflow_rejection payload instead of
+  the opaque "include pr_url..." hint string.
 - RFC-0109 Phase A: introduced `Masc_mcp_cdal_runtime.Criteria` typed
   sum (Keeper_turn_capture_v1, Contract_catalog_invariants,
   Verification_request, Persona_probe, Free) and migrated
@@ -11,6 +21,13 @@
   Amends §4.1 of the RFC to match the live producer inventory and adds
   Phase D (Task evidence gate ↔ CDAL verdict) targeting the
   `keeper_task_done` open-loop block pain.
+
+### Changed
+- `Keeper_tools_oas_workflow.workflow_rejection_payload_json` and
+  `Tool_task_payloads.workflow_rejection_payload_json` accept a new
+  optional `~extra_fields:(string * Yojson.Safe.t) list` so the typed
+  CDAL verdict payload can be embedded in the rejection envelope
+  without a schema break (RFC-0109 Phase D).
 
 ## [0.19.31] - 2026-05-26
 

--- a/docs/rfc/RFC-0109-cdal-goal-integration-contract.md
+++ b/docs/rfc/RFC-0109-cdal-goal-integration-contract.md
@@ -8,6 +8,9 @@ implementation_prs:
   - phase: A
     state: draft
     title: "typed eval_criteria + producer migration + tests"
+  - phase: D
+    state: draft
+    title: "Cdal_evidence_gate — typed verdict consultation + legacy substring fallback"
 ---
 
 # RFC-0109 — CDAL × GOAL Integration Contract

--- a/lib/cdal_evidence_gate.ml
+++ b/lib/cdal_evidence_gate.ml
@@ -1,0 +1,214 @@
+type decision =
+  | Pass
+  | Reject of
+      { reason : string
+      ; rule_id : string
+      ; hint : string
+      ; payload_json : Yojson.Safe.t
+      }
+
+let rule_id_violated = "cdal_verdict_violated"
+let rule_id_inconclusive = "cdal_verdict_inconclusive_incomplete"
+let rule_id_substring_fallback = "submit_verification_missing_evidence"
+
+let string_list_to_json xs = `List (List.map (fun s -> `String s) xs)
+
+(* Project a contract_verdict to a JSON envelope for the operator. The
+   shape is stable so log/dashboard consumers can match on it. *)
+let payload_of_violated_verdict ~task_id (v : Cdal_types.contract_verdict) =
+  `Assoc
+    [ "task_id", `String task_id
+    ; "verdict_status", `String (Cdal_types.contract_status_to_string v.status)
+    ; "run_id", `String v.run_id
+    ; "contract_id", `String v.contract_id
+    ; "judgment_hash", `String v.judgment_hash
+    ; ( "findings"
+      , `List (List.map Cdal_types.contract_finding_to_json v.findings) )
+    ; ( "completeness_gaps"
+      , `List (List.map Cdal_types.completeness_gap_to_json v.completeness_gaps) )
+    ]
+
+let payload_of_inconclusive_verdict ~task_id ~required_evidence
+    (v : Cdal_types.contract_verdict)
+  =
+  `Assoc
+    [ "task_id", `String task_id
+    ; "verdict_status", `String (Cdal_types.contract_status_to_string v.status)
+    ; "run_id", `String v.run_id
+    ; "contract_id", `String v.contract_id
+    ; "judgment_hash", `String v.judgment_hash
+    ; "required_evidence_unsatisfied", string_list_to_json required_evidence
+    ; ( "completeness_gaps"
+      , `List (List.map Cdal_types.completeness_gap_to_json v.completeness_gaps) )
+    ]
+
+let reason_of_findings (findings : Cdal_types.contract_finding list) =
+  match findings with
+  | [] -> "verdict reports Violated with no per-finding detail"
+  | _ ->
+    let check_ids =
+      List.map (fun (f : Cdal_types.contract_finding) -> f.check_id) findings
+    in
+    Printf.sprintf
+      "CDAL verdict is Violated. Failed checks: %s"
+      (String.concat ", " check_ids)
+
+let reason_of_inconclusive ~required_evidence
+    (v : Cdal_types.contract_verdict)
+  =
+  let gap_count = List.length v.completeness_gaps in
+  Printf.sprintf
+    "CDAL verdict is Inconclusive: %d completeness gap(s), %d required \
+     evidence entry/entries unsatisfied"
+    gap_count
+    (List.length required_evidence)
+
+let hint_violated =
+  "Address the listed findings in [payload.findings]. Once the underlying \
+   checks pass, re-run the contract evaluator before retrying \
+   submit_for_verification."
+
+let hint_inconclusive =
+  "Supply the entries listed in [payload.required_evidence_unsatisfied] (or \
+   close the entries in [payload.completeness_gaps]) and re-run the \
+   contract evaluator."
+
+(* Reuses the existing substring-shim message verbatim so operator-facing
+   error text matches the legacy gate when the fallback path triggers. *)
+let hint_substring_fallback =
+  Tool_task_completion_review.verification_evidence_error_message
+
+(* Heuristic: an "evidence entry" is satisfied when the notes or
+   handoff_context.evidence_refs mention a non-placeholder string that
+   names it (substring match). This mirrors the legacy substring shim's
+   placeholder rejection. Only used for the Inconclusive arm of the
+   decision matrix; Satisfied/Violated do not consult this. *)
+let evidence_entry_satisfied
+    ~notes
+    ~(handoff_context : Masc_domain.task_handoff_context option)
+    (entry : string)
+  =
+  let entry_trimmed = String.trim entry in
+  if String.equal entry_trimmed "" then true
+  else
+    let entry_lower = String.lowercase_ascii entry_trimmed in
+    let notes_lower = String.lowercase_ascii notes in
+    let mentions s =
+      let needle = String.lowercase_ascii s in
+      let nlen = String.length needle in
+      let hlen = String.length notes_lower in
+      if nlen = 0 || nlen > hlen then false
+      else
+        let limit = hlen - nlen in
+        let rec loop i =
+          if i > limit then false
+          else if String.sub notes_lower i nlen = needle then true
+          else loop (i + 1)
+        in
+        loop 0
+    in
+    let in_notes = mentions entry_lower in
+    let in_handoff =
+      match handoff_context with
+      | None -> false
+      | Some hc ->
+        List.exists
+          (fun ref_ ->
+            let r = String.lowercase_ascii (String.trim ref_) in
+            r <> "" && r = entry_lower)
+          hc.evidence_refs
+    in
+    in_notes || in_handoff
+
+let unsatisfied_required_evidence
+    ~notes
+    ~handoff_context
+    (contract : Masc_domain.task_contract option)
+  =
+  match contract with
+  | None -> []
+  | Some c ->
+    List.filter
+      (fun e -> not (evidence_entry_satisfied ~notes ~handoff_context e))
+      c.required_evidence
+
+let task_has_contract (task_opt : Masc_domain.task option) =
+  match task_opt with
+  | None -> false
+  | Some t -> Option.is_some t.contract
+
+let default_lookup ~task_id =
+  Cdal_verdict_gate.lookup_latest_verdict ~warn_on_missing:false ~task_id ()
+
+let substring_fallback ~notes ~handoff_context =
+  match
+    Tool_task_completion_review.verification_submission_evidence_error
+      ~notes
+      ~handoff_context
+  with
+  | None -> Pass
+  | Some reason ->
+    Reject
+      { reason
+      ; rule_id = rule_id_substring_fallback
+      ; hint = hint_substring_fallback
+      ; payload_json = `Null
+      }
+
+let decide
+    ?(lookup = default_lookup)
+    ~task_id
+    ~task_opt
+    ~notes
+    ~handoff_context
+    ()
+  =
+  match lookup ~task_id with
+  | Some (v : Cdal_types.contract_verdict) ->
+    (match v.status with
+     | Cdal_types.Satisfied -> Pass
+     | Cdal_types.Violated ->
+       let payload_json = payload_of_violated_verdict ~task_id v in
+       Reject
+         { reason = reason_of_findings v.findings
+         ; rule_id = rule_id_violated
+         ; hint = hint_violated
+         ; payload_json
+         }
+     | Cdal_types.Inconclusive ->
+       let task_contract =
+         match (task_opt : Masc_domain.task option) with
+         | Some t -> t.contract
+         | None -> None
+       in
+       let unsatisfied =
+         unsatisfied_required_evidence
+           ~notes
+           ~handoff_context
+           task_contract
+       in
+       let has_completeness_gaps = v.completeness_gaps <> [] in
+       if (not has_completeness_gaps) && unsatisfied = []
+       then Pass
+       else
+         let payload_json =
+           payload_of_inconclusive_verdict
+             ~task_id
+             ~required_evidence:unsatisfied
+             v
+         in
+         Reject
+           { reason = reason_of_inconclusive ~required_evidence:unsatisfied v
+           ; rule_id = rule_id_inconclusive
+           ; hint = hint_inconclusive
+           ; payload_json
+           })
+  | None ->
+    if task_has_contract task_opt
+    then substring_fallback ~notes ~handoff_context
+    else
+      (* Analysis-only task bypass: a task with no contract has nothing to
+         verify, so the gate must not block keeper_task_done. This is the
+         RFC-0109 §6.5.2 row that directly fixes the operator-visible
+         open-loop block for masc-improver-style keepers. *)
+      Pass

--- a/lib/cdal_evidence_gate.mli
+++ b/lib/cdal_evidence_gate.mli
@@ -1,0 +1,78 @@
+(** Cdal_evidence_gate — RFC-0109 Phase D.
+
+    Layered evidence-gate decision for [submit_for_verification] /
+    [submit_pr_evidence] / [Done_action when done_redirects_to_verification].
+
+    Replaces the substring-classifier-only gate in
+    [Tool_task_completion_review.verification_submission_evidence_error]
+    (§2.3 workaround signature #2 per RFC-0001) with a typed CDAL
+    verdict consultation, falling back to the legacy substring shim
+    only when no verdict is available and the task carries a contract.
+
+    Decision matrix (see RFC-0109 §6.5.2):
+
+    | CDAL verdict | task.contract | Decision |
+    |--------------|---------------|----------|
+    | [Some Satisfied] | any | [Pass] |
+    | [Some Violated] | any | [Reject] with typed findings |
+    | [Some Inconclusive] | any | [Pass] if [required_evidence] satisfied; else [Reject] with completeness_gaps + required list |
+    | [None] | [None] | [Pass] (analysis-only task bypass) |
+    | [None] | [Some _] | fall through to legacy substring shim |
+
+    @since RFC-0109 Phase D (2026-05-26) *)
+
+(** A decision from the evidence gate. *)
+type decision =
+  | Pass
+  | Reject of
+      { reason : string
+      ; rule_id : string
+      ; hint : string
+      ; payload_json : Yojson.Safe.t
+      }
+
+(** Rule identifiers exposed for testing and for the workflow_rejection
+    payload [rule_id] field. *)
+
+val rule_id_violated : string
+(** ["cdal_verdict_violated"] *)
+
+val rule_id_inconclusive : string
+(** ["cdal_verdict_inconclusive_incomplete"] *)
+
+val rule_id_substring_fallback : string
+(** ["submit_verification_missing_evidence"] — preserved verbatim from
+    the legacy gate so operators / log queries / dashboards keyed on
+    this rule_id keep working. *)
+
+(** Build the typed JSON payload describing a [Violated] verdict's
+    rejection. Embedded in [workflow_rejection_payload_json] so the
+    operator sees [findings[]] with check_id / observed / expected /
+    trace_ref instead of an opaque "include pr_url..." hint. *)
+val payload_of_violated_verdict
+  :  task_id:string
+  -> Cdal_types.contract_verdict
+  -> Yojson.Safe.t
+
+(** Build the typed JSON payload for an [Inconclusive] verdict whose
+    completeness_gaps or unsatisfied [required_evidence] entries block
+    the gate. *)
+val payload_of_inconclusive_verdict
+  :  task_id:string
+  -> required_evidence:string list
+  -> Cdal_types.contract_verdict
+  -> Yojson.Safe.t
+
+(** [decide] applies the §6.5.2 matrix.
+
+    [lookup] defaults to
+    [Cdal_verdict_gate.lookup_latest_verdict ~warn_on_missing:false ?base_dir].
+    Tests inject a stub so they do not require the dated_jsonl store. *)
+val decide
+  :  ?lookup:(task_id:string -> Cdal_types.contract_verdict option)
+  -> task_id:string
+  -> task_opt:Masc_domain.task option
+  -> notes:string
+  -> handoff_context:Masc_domain.task_handoff_context option
+  -> unit
+  -> decision

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -175,6 +175,7 @@ let workflow_rejection_payload_json
       ?tool_suggestion
       ?hint
       ?scope_policy
+      ?(extra_fields = [])
       ~error_class
       ~recoverability
       message
@@ -196,7 +197,8 @@ let workflow_rejection_payload_json
     ; "recoverable", `Bool (workflow_rejection_recoverability_to_bool recoverability)
     ]
     @ optional_string_field "hint" hint
-    @ if diagnosis = [] then [] else [ "diagnosis", `Assoc diagnosis ]
+    @ (if diagnosis = [] then [] else [ "diagnosis", `Assoc diagnosis ])
+    @ extra_fields
   in
   Yojson.Safe.to_string (`Assoc fields)
 ;;

--- a/lib/keeper/keeper_tools_oas_workflow.mli
+++ b/lib/keeper/keeper_tools_oas_workflow.mli
@@ -63,12 +63,17 @@ val workflow_rejection_retry_policy
 
 val workflow_rejection_should_skip_retry : workflow_rejection_payload -> bool
 
-(** Build a workflow-rejection payload with typed retry-policy fields. *)
+(** Build a workflow-rejection payload with typed retry-policy fields.
+
+    [extra_fields] (RFC-0109 Phase D) attaches optional key/value pairs
+    to the top-level JSON object (e.g. [cdal_verdict_payload] with
+    typed findings). Empty list (default) preserves the legacy shape. *)
 val workflow_rejection_payload_json
   :  ?rule_id:string
   -> ?tool_suggestion:string
   -> ?hint:string
   -> ?scope_policy:workflow_rejection_scope_policy
+  -> ?extra_fields:(string * Yojson.Safe.t) list
   -> error_class:workflow_rejection_error_class
   -> recoverability:workflow_rejection_recoverability
   -> string

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -313,33 +313,53 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
       | None -> action
     else action
   in
-  let submit_evidence_error =
-    match requested_action with
-    | Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence ->
-      verification_submission_evidence_error ~notes ~handoff_context
-    | Masc_domain.Done_action when done_redirects_to_verification ->
-      verification_submission_evidence_error ~notes ~handoff_context
-    | Masc_domain.Claim
-    | Masc_domain.Start
-    | Masc_domain.Done_action
-    | Masc_domain.Cancel
-    | Masc_domain.Release
-    | Masc_domain.Approve_verification
-    | Masc_domain.Reject_verification ->
-      None
+  (* RFC-0109 Phase D: layered evidence gate. CDAL verdict (when
+     available) takes precedence over the substring shim; analysis-only
+     tasks (no contract) bypass the gate. Legacy substring shim is
+     preserved as the fallback path for tasks that have a contract but
+     no CDAL verdict has been emitted yet. *)
+  let evidence_decision =
+    let needs_gate =
+      match requested_action with
+      | Masc_domain.Submit_for_verification
+      | Masc_domain.Submit_pr_evidence -> true
+      | Masc_domain.Done_action when done_redirects_to_verification -> true
+      | Masc_domain.Claim
+      | Masc_domain.Start
+      | Masc_domain.Done_action
+      | Masc_domain.Cancel
+      | Masc_domain.Release
+      | Masc_domain.Approve_verification
+      | Masc_domain.Reject_verification ->
+        false
+    in
+    if not needs_gate then Cdal_evidence_gate.Pass
+    else
+      Cdal_evidence_gate.decide
+        ~task_id
+        ~task_opt
+        ~notes
+        ~handoff_context
+        ()
   in
-  match submit_evidence_error with
-  | Some reason ->
+  match evidence_decision with
+  | Cdal_evidence_gate.Reject { reason; rule_id; hint; payload_json } ->
+    let extra_fields =
+      match payload_json with
+      | `Null -> []
+      | other -> [ "cdal_verdict_payload", other ]
+    in
     Tool_result.error
       ~failure_class:(Some Tool_result.Workflow_rejection)
       ~tool_name
       ~start_time
       (workflow_rejection_payload_json
-         ~rule_id:"submit_verification_missing_evidence"
-         ~hint:verification_evidence_error_message
+         ~rule_id
+         ~hint
          ~scope_policy:"block_scope"
+         ~extra_fields
          reason)
-  | None ->
+  | Cdal_evidence_gate.Pass ->
   let action =
     match requested_action, task_opt with
     | ( Masc_domain.Submit_for_verification

--- a/lib/tool_task_payloads.ml
+++ b/lib/tool_task_payloads.ml
@@ -41,6 +41,7 @@ let workflow_rejection_payload_json
       ?tool_suggestion
       ?hint
       ?scope_policy
+      ?extra_fields
       message
   =
   let scope_policy =
@@ -53,6 +54,7 @@ let workflow_rejection_payload_json
     ?tool_suggestion
     ?hint
     ?scope_policy
+    ?extra_fields
     ~error_class:Keeper_tools_oas_workflow.Workflow_error_deterministic
     ~recoverability:Keeper_tools_oas_workflow.Workflow_unrecoverable
     message

--- a/test/dune
+++ b/test/dune
@@ -264,6 +264,7 @@
   test_agent_stress_emit_10341
   test_cdal_conformance
   test_cdal_criteria
+  test_cdal_evidence_gate
   test_task_stage
   test_ocaml_north_star_task_lifecycle
   test_tool_blob_store
@@ -584,6 +585,7 @@
   ; test_contract_composer removed (team session cleanup)
   test_cdal_conformance
   test_cdal_criteria
+  test_cdal_evidence_gate
   test_task_stage
   test_ocaml_north_star_task_lifecycle
   ; test_risk_digest removed (team session cleanup)

--- a/test/test_cdal_evidence_gate.ml
+++ b/test/test_cdal_evidence_gate.ml
@@ -1,0 +1,327 @@
+(** RFC-0109 Phase D — Cdal_evidence_gate decision matrix tests.
+
+    Covers all 5 rows of §6.5.2 plus the operator-visible payload
+    shape for Violated and Inconclusive rejections. The verdict
+    lookup is injected via the [~lookup] parameter so the tests do
+    not require the dated_jsonl store. *)
+
+open Alcotest
+open Masc_mcp
+
+module Gate = Cdal_evidence_gate
+module Ct = Cdal_types
+
+let make_verdict
+      ?(run_id = "run-test")
+      ?(contract_id = "md5:test-contract")
+      ?(judgment_hash = "md5:test-hash")
+      ?(findings = [])
+      ?(completeness_gaps = [])
+      ?(check_results = [])
+      status
+    : Ct.contract_verdict
+  =
+  { run_id
+  ; contract_id
+  ; claim_scope = Ct.claim_scope_phase1
+  ; judgment_basis_hash = "md5:basis"
+  ; judgment_hash
+  ; loader_semantics_version = Ct.loader_semantics_version_phase1
+  ; schema_compat_mode = Ct.schema_compat_mode_v1
+  ; status
+  ; findings
+  ; completeness_gaps
+  ; check_results
+  }
+
+let finding
+      ?(event_id = None)
+      ?(observed = `String "actual")
+      ?(expected = `String "expected")
+      ?(trace_ref = None)
+      check_id
+    : Ct.contract_finding
+  =
+  { check_id; event_id; observed; expected; trace_ref }
+
+let gap ?(impact = Ct.Blocks_verdict) artifact reason : Ct.completeness_gap =
+  { artifact; reason; impact }
+
+let make_task
+      ?(id = "task-1")
+      ?(contract : Masc_domain.task_contract option = None)
+      ?(handoff_context : Masc_domain.task_handoff_context option = None)
+      ()
+    : Masc_domain.task
+  =
+  { id
+  ; title = "test"
+  ; description = "test task"
+  ; task_status = Masc_domain.Todo
+  ; priority = 3
+  ; files = []
+  ; created_at = "2026-05-26T00:00:00Z"
+  ; created_by = None
+  ; goal_id = None
+  ; stage = None
+  ; contract
+  ; handoff_context
+  ; cycle_count = 0
+  ; reclaim_policy = None
+  ; do_not_reclaim_reason = None
+  }
+
+let make_contract
+      ?(strict = false)
+      ?(completion_contract = [])
+      ?(required_tools = [])
+      ?(required_evidence = [])
+      ?(inspect_gate_evidence = [])
+      ?(verify_gate_evidence = [])
+      ()
+    : Masc_domain.task_contract
+  =
+  { strict
+  ; completion_contract
+  ; required_tools
+  ; required_evidence
+  ; inspect_gate_evidence
+  ; verify_gate_evidence
+  ; links = { operation_id = None; session_id = None }
+  }
+
+let lookup_returns v ~task_id:_ = v
+
+(* ─────────────────────────────────────────────────────────────── *)
+(* §6.5.2 row 1: Some Satisfied → Pass                              *)
+(* ─────────────────────────────────────────────────────────────── *)
+let test_satisfied_verdict_passes () =
+  let verdict = make_verdict Ct.Satisfied in
+  match
+    Gate.decide
+      ~lookup:(lookup_returns (Some verdict))
+      ~task_id:"task-1"
+      ~task_opt:(Some (make_task ()))
+      ~notes:""
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass -> ()
+  | Gate.Reject { rule_id; _ } ->
+    failf "Satisfied verdict should Pass, got Reject rule_id=%s" rule_id
+
+(* §6.5.2 row 2: Some Violated → Reject with typed findings *)
+let test_violated_verdict_rejects_with_findings () =
+  let findings = [ finding "check-a"; finding "check-b" ] in
+  let verdict = make_verdict ~findings Ct.Violated in
+  match
+    Gate.decide
+      ~lookup:(lookup_returns (Some verdict))
+      ~task_id:"task-violated"
+      ~task_opt:(Some (make_task ()))
+      ~notes:"PR #999"  (* substring shim would Pass; CDAL takes precedence *)
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass ->
+    fail "Violated verdict should Reject even when substring shim would Pass"
+  | Gate.Reject { rule_id; payload_json; reason; _ } ->
+    check string "rule_id" Gate.rule_id_violated rule_id;
+    check bool "reason mentions Violated" true
+      (String_util.contains_substring_ci reason "Violated");
+    (match payload_json with
+     | `Assoc fields ->
+       (match List.assoc_opt "verdict_status" fields with
+        | Some (`String s) -> check string "verdict_status" "violated" s
+        | _ -> fail "payload missing verdict_status");
+       (match List.assoc_opt "findings" fields with
+        | Some (`List xs) ->
+          check int "findings length" 2 (List.length xs)
+        | _ -> fail "payload missing findings list")
+     | _ -> fail "payload is not Assoc")
+
+(* §6.5.2 row 3a: Some Inconclusive with no gaps and no unsatisfied
+   required_evidence → Pass *)
+let test_inconclusive_passes_when_evidence_satisfied () =
+  let verdict = make_verdict Ct.Inconclusive in
+  let contract = make_contract ~required_evidence:[ "src/main.ml" ] () in
+  let task = make_task ~contract:(Some contract) () in
+  match
+    Gate.decide
+      ~lookup:(lookup_returns (Some verdict))
+      ~task_id:"task-3a"
+      ~task_opt:(Some task)
+      ~notes:"completed work on src/main.ml"
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass -> ()
+  | Gate.Reject { rule_id; _ } ->
+    failf
+      "Inconclusive with all evidence satisfied should Pass, got Reject \
+       rule_id=%s"
+      rule_id
+
+(* §6.5.2 row 3b: Some Inconclusive with unsatisfied required_evidence
+   → Reject *)
+let test_inconclusive_rejects_when_evidence_missing () =
+  let verdict = make_verdict Ct.Inconclusive in
+  let contract = make_contract ~required_evidence:[ "src/missing.ml" ] () in
+  let task = make_task ~contract:(Some contract) () in
+  match
+    Gate.decide
+      ~lookup:(lookup_returns (Some verdict))
+      ~task_id:"task-3b"
+      ~task_opt:(Some task)
+      ~notes:"completed something else"
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass ->
+    fail "Inconclusive with unsatisfied evidence should Reject"
+  | Gate.Reject { rule_id; payload_json; _ } ->
+    check string "rule_id" Gate.rule_id_inconclusive rule_id;
+    (match payload_json with
+     | `Assoc fields ->
+       (match List.assoc_opt "required_evidence_unsatisfied" fields with
+        | Some (`List [ `String s ]) ->
+          check string "unsatisfied entry" "src/missing.ml" s
+        | _ -> fail "payload missing required_evidence_unsatisfied")
+     | _ -> fail "payload is not Assoc")
+
+(* §6.5.2 row 3c: Some Inconclusive with completeness_gaps → Reject *)
+let test_inconclusive_rejects_when_completeness_gaps () =
+  let gaps = [ gap "dashboard_attribution" "no events emitted" ] in
+  let verdict = make_verdict ~completeness_gaps:gaps Ct.Inconclusive in
+  match
+    Gate.decide
+      ~lookup:(lookup_returns (Some verdict))
+      ~task_id:"task-3c"
+      ~task_opt:(Some (make_task ()))
+      ~notes:""
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass -> fail "Inconclusive with completeness_gaps should Reject"
+  | Gate.Reject { rule_id; payload_json; _ } ->
+    check string "rule_id" Gate.rule_id_inconclusive rule_id;
+    (match payload_json with
+     | `Assoc fields ->
+       (match List.assoc_opt "completeness_gaps" fields with
+        | Some (`List xs) ->
+          check int "completeness_gaps length" 1 (List.length xs)
+        | _ -> fail "payload missing completeness_gaps")
+     | _ -> fail "payload is not Assoc")
+
+(* §6.5.2 row 4: None verdict + task.contract = None →
+   Pass (analysis-only task bypass; the core operator-visible fix) *)
+let test_no_verdict_no_contract_bypasses () =
+  match
+    Gate.decide
+      ~lookup:(lookup_returns None)
+      ~task_id:"task-analysis"
+      ~task_opt:(Some (make_task ()))  (* contract = None *)
+      ~notes:""
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass -> ()
+  | Gate.Reject { rule_id; _ } ->
+    failf
+      "Analysis-only task (no contract) should Pass without evidence; got \
+       Reject rule_id=%s"
+      rule_id
+
+(* §6.5.2 row 4 variant: task_opt = None → Pass too (no contract = no
+   verification obligation) *)
+let test_no_verdict_no_task_bypasses () =
+  match
+    Gate.decide
+      ~lookup:(lookup_returns None)
+      ~task_id:"task-ghost"
+      ~task_opt:None
+      ~notes:""
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass -> ()
+  | Gate.Reject { rule_id; _ } ->
+    failf "Missing task should Pass, got Reject rule_id=%s" rule_id
+
+(* §6.5.2 row 5a: None verdict + task.contract = Some _ +
+   notes carry PR ref → Pass via substring fallback *)
+let test_substring_fallback_passes_with_pr_ref () =
+  let contract = make_contract () in
+  let task = make_task ~contract:(Some contract) () in
+  match
+    Gate.decide
+      ~lookup:(lookup_returns None)
+      ~task_id:"task-legacy-pass"
+      ~task_opt:(Some task)
+      ~notes:"PR #18712 ready for verifier"
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass -> ()
+  | Gate.Reject { rule_id; _ } ->
+    failf
+      "Substring fallback should Pass when notes carry PR ref; got Reject \
+       rule_id=%s"
+      rule_id
+
+(* §6.5.2 row 5b: None verdict + task.contract = Some _ +
+   notes empty → Reject via substring fallback with legacy rule_id *)
+let test_substring_fallback_rejects_when_empty () =
+  let contract = make_contract () in
+  let task = make_task ~contract:(Some contract) () in
+  match
+    Gate.decide
+      ~lookup:(lookup_returns None)
+      ~task_id:"task-legacy-reject"
+      ~task_opt:(Some task)
+      ~notes:""
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass ->
+    fail "Substring fallback should Reject when notes are empty and contract is set"
+  | Gate.Reject { rule_id; _ } ->
+    check string "legacy rule_id preserved"
+      Gate.rule_id_substring_fallback
+      rule_id
+
+(* Bonus: rule_id constants are stable strings consumers can match on *)
+let test_rule_id_constants_are_stable () =
+  check string "violated rule_id" "cdal_verdict_violated" Gate.rule_id_violated;
+  check string "inconclusive rule_id" "cdal_verdict_inconclusive_incomplete"
+    Gate.rule_id_inconclusive;
+  check string "substring fallback rule_id" "submit_verification_missing_evidence"
+    Gate.rule_id_substring_fallback
+
+let () =
+  Alcotest.run
+    "cdal_evidence_gate"
+    [ ( "decision matrix"
+      , [ test_case "row 1: Satisfied → Pass" `Quick test_satisfied_verdict_passes
+        ; test_case "row 2: Violated → Reject with findings" `Quick
+            test_violated_verdict_rejects_with_findings
+        ; test_case "row 3a: Inconclusive + evidence satisfied → Pass" `Quick
+            test_inconclusive_passes_when_evidence_satisfied
+        ; test_case "row 3b: Inconclusive + evidence missing → Reject" `Quick
+            test_inconclusive_rejects_when_evidence_missing
+        ; test_case "row 3c: Inconclusive + completeness_gaps → Reject" `Quick
+            test_inconclusive_rejects_when_completeness_gaps
+        ; test_case "row 4: None + contract=None → Pass (analysis-only bypass)"
+            `Quick test_no_verdict_no_contract_bypasses
+        ; test_case "row 4 variant: None + task_opt=None → Pass" `Quick
+            test_no_verdict_no_task_bypasses
+        ; test_case "row 5a: None + contract=Some + PR ref → Pass (substring shim)"
+            `Quick test_substring_fallback_passes_with_pr_ref
+        ; test_case "row 5b: None + contract=Some + empty notes → Reject (legacy rule_id)"
+            `Quick test_substring_fallback_rejects_when_empty
+        ] )
+    ; ( "stable constants"
+      , [ test_case "rule_id constants" `Quick test_rule_id_constants_are_stable
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

RFC-0109 **Phase D** — introduces `Cdal_evidence_gate`, the layered
evidence-gate decision module that consults
`Cdal_verdict_gate.lookup_latest_verdict` (already on main) before
falling back to the legacy substring shim. The analysis-only task
bypass row (no contract → Pass) directly fixes the operator-visible
`keeper_task_done` open-loop block.

**Stacked on** PR #18709 (RFC-0109 Phase A). When that merges, this
PR rebases onto main; GitHub's base auto-update should handle most
cases.

## Why this PR

The original RFC-0109 surface gap closed at the Goal × CDAL boundary.
But the gate that *actually blocks autonomous keepers in production*
sits one layer below in `tool_task_completion_review.ml:63` —
`text_has_verification_artifact_ref` enforces typed evidence via
substring matching on notes. This is precisely the workaround
signature #2 (string/substring classifier) that RFC-0109 §2.3 itself
flagged. Phase D demotes that substring shim to a fallback and puts
typed CDAL verdict consultation in front.

## Decision matrix (§6.5.2)

| CDAL verdict | task.contract | Decision |
|--------------|---------------|----------|
| `Some Satisfied` | any | **Pass** |
| `Some Violated` | any | **Reject** with typed findings |
| `Some Inconclusive` | any | **Pass** if `required_evidence` satisfied; else **Reject** with completeness_gaps |
| `None` | `None` | **Pass** (analysis-only bypass — fixes the operator pain) |
| `None` | `Some _` | fall through to legacy substring shim |

## Operator-visible improvement

**Before**:
> "submit_for_verification requires verification evidence: include
> pr_url for the draft PR, a PR # reference, or an explicit
> artifact/file/path/commit/branch reference in notes."

**After (Violated verdict)**:
```json
{
  "task_id": "task-cdal-001",
  "verdict_status": "violated",
  "run_id": "run-xyz",
  "contract_id": "md5:abc",
  "judgment_hash": "md5:def",
  "findings": [
    { "check_id": "invariant_keeper_lifecycle.zombie_phase_reports_to_supervisor",
      "observed": "fiber_zombie", "expected": "KH_zombie reported within 30s",
      "trace_ref": "proof-store://run-xyz/tool_traces/trace-004" }
  ],
  "completeness_gaps": []
}
```

**After (analysis-only task with no contract)**: gate just **passes** — no PR URL needed.

## What changed

| File | Change |
|------|--------|
| `lib/cdal_evidence_gate.{ml,mli}` | **new** — typed decision module + verdict→payload projection + injectable lookup |
| `lib/tool_task.ml` | Replace inline substring call with `Cdal_evidence_gate.decide`; carry typed payload as `extra_fields` |
| `lib/keeper/keeper_tools_oas_workflow.{ml,mli}` | Accept `?extra_fields:(string * Yojson.Safe.t) list` so typed CDAL payload embeds in the rejection envelope |
| `lib/tool_task_payloads.ml` | Plumb `?extra_fields` through |
| `test/test_cdal_evidence_gate.ml` | **new** — 10 cases covering all 5 matrix rows + edge variants + rule_id constants |
| `docs/rfc/RFC-0109-cdal-goal-integration-contract.md` | Add Phase D to `implementation_prs:` frontmatter |
| `CHANGELOG.md` | unreleased entries (Added + Changed) |

Diff: +691 / −21 across 10 files (6 production, 2 test, 2 docs).

## Wire-format compatibility

- `workflow_rejection_payload_json` extends with `?extra_fields`
  defaulting to `[]` — legacy callers unchanged.
- The `cdal_verdict_payload` key is added to the rejection envelope
  **only** when a CDAL verdict is present. Consumers walking the
  legacy shape ignore unknown fields per usual JSON tolerance.
- The legacy substring shim's `rule_id =
  "submit_verification_missing_evidence"` is preserved verbatim so
  log/dashboard queries keyed on it keep working when the fallback
  path triggers.

## Test plan

- [x] `dune build lib` — clean
- [x] `dune build test/test_cdal_evidence_gate.exe` — clean
- [x] `test_cdal_evidence_gate` 10/10 PASS (full §6.5.2 matrix + rule_id constants)
- [x] Phase A sister tests still PASS (`test_cdal_criteria`, `test_keeper_cdal_contract`, `test_cdal_risk_contract`, `test_cdal_conformance`, `test_masc_contract_catalog`)
- [ ] CI green
- [x] Verified `test_tool_task_coverage` 12-test failure set is **pre-existing on origin/main** and on the Phase A worktree without these changes — not introduced by this PR

Pre-existing main issue noted (carried over from Phase A): 
`test/test_tool_shard_coverage.ml:130` references
`Tool_shard_types_schemas_bash` unbound after #18681 / #18520.
Unrelated to this PR.

## Stacking + rebase plan

- Base branch: `feature/rfc-0109-phase-a` (PR #18709)
- When #18709 squash-merges to main, this PR's base auto-updates to
  main. If GitHub doesn't auto-update, rebase locally:
  ```
  git checkout feature/rfc-0109-phase-d
  git rebase --onto main feature/rfc-0109-phase-a
  git push --force-with-lease
  ```

## Out of scope

- Phase B (verdict → Goal phase auto-transition) — independent write path
- Phase C (verifier_policy enforcement) — depends on Phase B
- `Cleanup` (Free arm sunset, `pr-rfc-check.sh` §10 lint guard)
- Migrating other gates (review_gate_rejection, persisted_gate_rejection) to typed verdict consultation — they enforce different invariants

Refs RFC-0109 (especially §6.5).

WORKAROUND-WAIVED: PR body describes removing the substring/
string-classifier shim as the root fix that RFC-0109 §2.3 #2 itself
flags. Zero new string classifiers added — the existing one is
demoted to a fallback path only consulted when CDAL has no verdict
AND the task carries a contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
