### PR TITLE
refactor(memory): purge legacy context fallbacks

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 19:40:17 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 20:06:32 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -673,9 +673,15 @@
           </tr>
           <tr>
             <td>Cascade/OAS string recovery purge</td>
-            <td><span class="status now">active branch</span></td>
+            <td><span class="status done">merged #18707</span></td>
             <td>Remove the remaining P1 string recovery paths: raw resumable CLI hint promotion, <code>cascade_exhaustion_reason_from_message</code>, and <code>max_execution_time_s</code> substring-based timeout/saturation promotion.</td>
-            <td>This branch keeps structured <code>Resumable_cli_session</code>, <code>Provider_timeout</code>, and typed <code>Structural_attempt_timeout</code> envelopes, but free-form text stays opaque. Raw CLI resume hints are redacted at the transport boundary and no longer promoted to typed cascade errors.</td>
+            <td>Merged as <code>e88d5758e</code>. Structured <code>Resumable_cli_session</code>, <code>Provider_timeout</code>, and typed <code>Structural_attempt_timeout</code> envelopes remain, but free-form text stays opaque. Raw CLI resume hints are redacted at the transport boundary and no longer promoted to typed cascade errors.</td>
+          </tr>
+          <tr>
+            <td>Memory/context canonical row purge</td>
+            <td><span class="status now">active branch</span></td>
+            <td>Remove memory search source fallback to <code>memory</code>, drop old memory-bank rows without current schema/horizon/provenance fields, and stop rewriting legacy duplicate procedural records during OAS flush.</td>
+            <td>Branch <code>refactor/purge-memory-context-fallbacks-20260526</code>. Compatibility-preservation tests for legacy procedure dedupe are deleted; current-schema tests now seed canonical rows only.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
@@ -709,13 +715,6 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>P2</td>
-            <td>Memory/context legacy read fallbacks</td>
-            <td>Remaining dated-store and old-row fallback readers hide whether current writers are clean. Checkpoint sidecar runtime readers, flat message-content decode, meta sidecars, and global tail silent fallback are already removed.</td>
-            <td>Continue deleting old-row readers and migration-only dedupe paths after runtime reset/migration proof, especially procedure-memory legacy dedupe fixtures.</td>
-            <td>Remove tests that require old-row readability. Keep corruption/drop tests only for current schema.</td>
-          </tr>
           <tr>
             <td>P2</td>
             <td>Tool catalog fallback tables</td>

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -11,9 +11,8 @@ module StringSet = Set_util.StringSet
    Keeper_exec_memory -> ... -> Tool_shard prevented via local mirror,
    sync test catches drift). The previous code used a string match
    with a wildcard `_ -> memory` branch which silently routed any
-   unknown source to memory — anti-pattern from CLAUDE.md "Unknown ->
-   Permissive Default". Now [of_string_opt] returns [None] for
-   unknown values and the caller decides the fallback explicitly. *)
+   unknown source to memory. Now unknown values are rejected at the
+   tool boundary. *)
 type memory_search_source =
   | Memory
   | History
@@ -52,22 +51,6 @@ type memory_match =
   }
 
 let memory_bank_persistence_surface = "keeper_exec_memory_bank"
-
-let memory_horizon_of_kind_with_fallback kind =
-  match Keeper_memory_policy.memory_horizon_of_kind_opt kind with
-  | Some horizon -> horizon
-  | None ->
-      Log.Memory.warn
-        "keeper_exec_memory: unknown memory kind %S -> mid_term (drift; see #8826)"
-        kind;
-      Keeper_memory_policy.mid_term_horizon
-;;
-
-let memory_horizon_of_json_with_fallback ~kind json =
-  match Keeper_memory_policy.memory_horizon_of_json_opt json with
-  | Some horizon -> horizon
-  | None -> memory_horizon_of_kind_with_fallback kind
-;;
 
 let report_memory_bank_read_drop ~path ~reason ~detail =
   Safe_ops.report_persistence_read_drop
@@ -115,27 +98,54 @@ let search_memory_bank
         None
       | `Assoc _ as j ->
         (try
+           let schema_version = Safe_ops.json_int ~default:0 "schema_version" j in
            let kind = Safe_ops.json_string ~default:"" "kind" j |> String.trim in
-           let horizon = memory_horizon_of_json_with_fallback ~kind j in
+           let horizon = Keeper_memory_policy.memory_horizon_of_json_opt j in
+           let expected_horizon =
+             Keeper_memory_policy.memory_horizon_of_kind_opt kind
+           in
            let source = Safe_ops.json_string ~default:"" "source" j |> String.trim in
+           let trace_id = Safe_ops.json_string ~default:"" "trace_id" j |> String.trim in
            let text = Safe_ops.json_string ~default:"" "text" j |> String.trim in
            let priority = Safe_ops.json_int ~default:0 "priority" j in
            let generation = Safe_ops.json_int ~default:0 "generation" j in
            let turn = Safe_ops.json_int ~default:0 "turn" j in
            let ts = Safe_ops.json_string ~default:"" "ts" j in
            let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" j in
-           if kind = "" || text = ""
+           if schema_version <> Keeper_memory_policy.keeper_memory_schema_version
            then (
              report_memory_bank_read_drop
                ~path
                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
-               ~detail:"memory bank row is missing required kind or text";
+               ~detail:"memory bank row has unsupported schema_version";
+             None)
+           else if kind = "" || text = "" || source = "" || trace_id = ""
+           then (
+             report_memory_bank_read_drop
+               ~path
+               ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+               ~detail:
+                 "memory bank row is missing required kind, text, source, or trace_id";
+             None)
+           else if expected_horizon = None || horizon = None
+           then (
+             report_memory_bank_read_drop
+               ~path
+               ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+               ~detail:"memory bank row has unknown kind or missing horizon";
+             None)
+           else if not (String.equal (Option.get expected_horizon) (Option.get horizon))
+           then (
+             report_memory_bank_read_drop
+               ~path
+               ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+               ~detail:"memory bank row kind/horizon mismatch";
              None)
            else
              Some
                { kind
-               ; horizon
-               ; source = (if source = "" then None else Some source)
+               ; horizon = Option.get horizon
+               ; source = Some source
                ; text
                ; priority
                ; generation
@@ -232,7 +242,7 @@ let memory_match_to_json (m : memory_match) : Yojson.Safe.t =
     ]
 ;;
 
-(* --- History search (cross-generation, retained for backward compat) --- *)
+(* --- History search (checkpoint + trace history) --- *)
 
 let search_history
       ~(config : Coord.config)
@@ -316,15 +326,20 @@ let keeper_memory_search_json
   let query = Safe_ops.json_string ~default:"" "query" args |> String.trim in
   let limit = max 1 (min 10 (Safe_ops.json_int ~default:5 "limit" args)) in
   let source_raw = Safe_ops.json_string ~default:"memory" "source" args in
-  (* Issue #8484: explicit fallback to Memory for back-compat with the
-     prior wildcard branch — but unknown values are now visibly mapped,
-     not silently absorbed. *)
-  let source =
-    memory_search_source_of_string_opt source_raw |> Option.value ~default:Memory
-  in
-  let source_label = memory_search_source_to_string source in
-  let kind_filter = Safe_ops.json_string ~default:"" "kind" args |> String.trim in
-  let result =
+  match memory_search_source_of_string_opt source_raw with
+  | None ->
+    error_json
+      ~fields:
+        [ "error_kind", `String "invalid_memory_search_source"
+        ; "provided_source", `String source_raw
+        ; ( "supported_sources"
+          , `List (List.map (fun s -> `String s) valid_memory_search_source_strings) )
+        ]
+      "invalid keeper_memory_search source"
+  | Some source ->
+    let source_label = memory_search_source_to_string source in
+    let kind_filter = Safe_ops.json_string ~default:"" "kind" args |> String.trim in
+    let result =
     match source with
     | History ->
       let matches = search_history ~config ~meta ~ctx_work ~query ~limit in

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -62,16 +62,23 @@ type keeper_memory_row_raw = {
 type memory_consolidation_summarizer =
   trace_id:string -> texts:string list -> string option
 
+let memory_horizon_of_kind_exn kind =
+  match memory_horizon_of_kind_opt kind with
+  | Some horizon -> horizon
+  | None -> invalid_arg ("unknown memory kind: " ^ kind)
+
 let parse_memory_bank_row (line : string) : keeper_memory_row_raw option =
   try
     let j = Yojson.Safe.from_string line in
     let schema_version = Safe_ops.json_int ~default:0 "schema_version" j in
-    if schema_version <> 0 && schema_version <> keeper_memory_schema_version then
+    if schema_version <> keeper_memory_schema_version then
       None
     else
     let kind = Safe_ops.json_string ~default:"" "kind" j |> String.trim in
-    let horizon = memory_horizon_of_json_with_fallback ~kind j in
+    let horizon = memory_horizon_of_json_opt j in
+    let expected_horizon = memory_horizon_of_kind_opt kind in
     let source = Safe_ops.json_string ~default:"" "source" j |> String.trim in
+    let trace_id = Safe_ops.json_string ~default:"" "trace_id" j |> String.trim in
     let generation = Safe_ops.json_int ~default:0 "generation" j in
     let text = Safe_ops.json_string ~default:"" "text" j |> String.trim in
     let priority =
@@ -79,10 +86,16 @@ let parse_memory_bank_row (line : string) : keeper_memory_row_raw option =
       if raw < 1 then 1 else if raw > 100 then 100 else raw
     in
     let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" j in
-    if kind = "" || text = "" || not (is_meaningful_memory_text text) then
-      None
-    else
+    match expected_horizon, horizon with
+    | Some expected_horizon, Some horizon
+      when String.equal expected_horizon horizon
+           && kind <> ""
+           && source <> ""
+           && trace_id <> ""
+           && text <> ""
+           && is_meaningful_memory_text text ->
       Some { json = j; kind; horizon; source; generation; text; priority; ts_unix }
+    | _ -> None
   with Yojson.Json_error _ ->
     None
 
@@ -718,7 +731,7 @@ let append_memory_notes_from_reply
     with_memory_bank_lock path (fun () ->
       List.iter
         (fun (kind, text, priority) ->
-           let horizon = memory_horizon_of_kind_with_fallback kind in
+           let horizon = memory_horizon_of_kind_exn kind in
            if not (Hashtbl.mem seen_kinds kind) then begin
              Hashtbl.add seen_kinds kind ();
              kinds_acc := kind :: !kinds_acc
@@ -834,18 +847,13 @@ let summarize_memory_bank_lines
     ~(recent_limit : int) : keeper_memory_summary =
   let parsed =
     lines
-    |> List.filter_map (fun line ->
-         try
-           let j = Yojson.Safe.from_string line in
-           let kind = Safe_ops.json_string ~default:"" "kind" j in
-           let text = Safe_ops.json_string ~default:"" "text" j in
-           let priority = Safe_ops.json_int ~default:0 "priority" j in
-           let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" j in
-           let kind = String.trim kind in
-           let text = String.trim text in
-           if kind = "" || text = "" || not (is_meaningful_memory_text text) then None
-           else Some { kind; text; priority; ts_unix }
-         with Yojson.Json_error _ -> None)
+    |> List.filter_map parse_memory_bank_row
+    |> List.map (fun (row : keeper_memory_row_raw) ->
+         { kind = row.kind
+         ; text = row.text
+         ; priority = row.priority
+         ; ts_unix = row.ts_unix
+         })
   in
   let total_notes = List.length parsed in
   let last_ts_unix =

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -298,8 +298,8 @@ type memory_consolidation_summarizer =
     falls back to the deterministic summary. *)
 
 val parse_memory_bank_row : string -> keeper_memory_row_raw option
-(** Parse a single JSONL line; [None] when the row is malformed or
-    missing required fields. *)
+(** Parse a single JSONL line; [None] when the row is malformed,
+    non-current schema, or missing canonical horizon/provenance fields. *)
 
 val row_trace_id : keeper_memory_row_raw -> string
 (** Stable identifier used by trace / dedup paths. *)

--- a/lib/keeper/keeper_memory_bank_selection.ml
+++ b/lib/keeper/keeper_memory_bank_selection.ml
@@ -6,22 +6,6 @@ open Keeper_types
 
 include Keeper_memory_policy
 
-let memory_horizon_of_kind_with_fallback kind =
-  match memory_horizon_of_kind_opt kind with
-  | Some horizon -> horizon
-  | None ->
-      Log.Memory.warn
-        "memory_horizon_of_kind_with_fallback: unknown kind %S -> mid_term (drift; see #8826)"
-        kind;
-      mid_term_horizon
-;;
-
-let memory_horizon_of_json_with_fallback ~kind json =
-  match memory_horizon_of_json_opt json with
-  | Some horizon -> horizon
-  | None -> memory_horizon_of_kind_with_fallback kind
-;;
-
 let with_stdlib_mutex mutex f =
   Stdlib.Mutex.lock mutex;
   Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock mutex) f

--- a/lib/keeper/keeper_memory_bank_selection.mli
+++ b/lib/keeper/keeper_memory_bank_selection.mli
@@ -177,9 +177,6 @@ val synthesize_state_from_run_result :
   tools_used:string list ->
   stop_reason:string -> response_text:string -> keeper_state_snapshot
 val render_state_block : keeper_state_snapshot -> string
-val memory_horizon_of_kind_with_fallback : string -> string
-val memory_horizon_of_json_with_fallback :
-  kind:string -> Yojson.Safe.t -> string
 val with_stdlib_mutex : Mutex.t -> (unit -> 'a) -> 'a
 val memory_bank_locks_mu : Mutex.t
 val memory_bank_locks : (string, Mutex.t) Hashtbl.t

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -232,8 +232,7 @@ let memory_horizon_of_kind_opt (kind : string) : string option =
   | _ -> None
 
 (* Strict JSON horizon parser: returns [None] for missing or unknown
-   horizon strings so callers can decide whether to consult [kind] or
-   reject the row. *)
+   horizon strings so callers can reject non-canonical rows. *)
 let memory_horizon_of_json_opt (json : Yojson.Safe.t) : string option =
   match
     Safe_ops.json_string ~default:"" "horizon" json

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -658,19 +658,14 @@ let record_failure_lesson ~(memory : Agent_sdk.Memory.t)
          metadata;
        })
 
-let dedupe_procedures_by_id (procs : Procedural_memory.procedure list) =
-  let latest_by_id = Hashtbl.create (max 16 (List.length procs)) in
-  List.iter (fun (p : Procedural_memory.procedure) ->
-    Hashtbl.replace latest_by_id p.id p
-  ) procs;
-  let seen = Hashtbl.create (Hashtbl.length latest_by_id) in
-  List.filter_map (fun (p : Procedural_memory.procedure) ->
-    if Hashtbl.mem seen p.id then None
-    else begin
-      Hashtbl.add seen p.id ();
-      Hashtbl.find_opt latest_by_id p.id
-    end
-  ) procs
+let replace_first_procedure_by_id id updated procs =
+  let rec go = function
+    | [] -> []
+    | (p : Procedural_memory.procedure) :: rest when String.equal p.id id ->
+      updated :: rest
+    | p :: rest -> p :: go rest
+  in
+  go procs
 
 (** Flush OAS procedures back to [Procedural_memory].
 
@@ -682,9 +677,8 @@ let flush_procedures ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) : int
     Agent_sdk.Memory.matching_procedures memory
       ~pattern:"" ()
   in
-  let existing_raw = load_procedures_cached ~agent_name in
-  let procedures = ref (dedupe_procedures_by_id existing_raw) in
-  let needs_rewrite = ref (List.length existing_raw <> List.length !procedures) in
+  let procedures = ref (load_procedures_cached ~agent_name) in
+  let needs_rewrite = ref false in
   let flushed = ref 0 in
   List.iter (fun (op : Agent_sdk.Memory.procedure) ->
     let updated =
@@ -701,9 +695,7 @@ let flush_procedures ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) : int
             confidence = op.confidence;
             last_applied = op.last_used;
           } in
-          procedures := List.map (fun (p : Procedural_memory.procedure) ->
-            if p.id = old_p.id then updated_p else p
-          ) !procedures;
+          procedures := replace_first_procedure_by_id old_p.id updated_p !procedures;
           needs_rewrite := true;
           true
         end else false

--- a/lib/memory_oas_bridge.mli
+++ b/lib/memory_oas_bridge.mli
@@ -13,8 +13,8 @@
       {!load_episodes_text} / {!load_procedures_text} /
       {!load_institution_text}.
 
-    The .ml is 825 lines with many internal helpers
-    (file-stamp caching, episode / procedure dedup,
+    The .ml has many internal helpers
+    (file-stamp caching, episode dedup,
     metadata accessors, error-kind normalisation, stress
     metric emission).  External callers reach 14 dotted
     symbols; everything else stays private at this
@@ -160,10 +160,8 @@ val flush_episodes :
 val flush_procedures :
   memory:Agent_sdk.Memory.t -> agent_name:string -> int
 (** Drains every procedure held in [memory] that has
-    changed since the last flush.  Dedup happens by
-    [Procedural_memory.procedure.id] keeping the entry
-    with the latest [last_applied] timestamp.  Returns the
-    number of rows written. *)
+    changed since the last flush.  Returns the number of
+    rows written. *)
 
 val flush_incremental :
   memory:Agent_sdk.Memory.t -> agent_name:string -> int * int

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -908,11 +908,12 @@ let test_keeper_context_status_reports_recovery_source_and_tiers () =
                  "kind", `String "long_term";
                  "horizon", `String "long_term";
                  "source", `String "cross_trace_recurrence";
-                 "schema_version", `Int 2;
+                 "schema_version", `Int Keeper_memory_bank.keeper_memory_schema_version;
                  "text", `String "durable note";
                  "priority", `Int 95;
                  "generation", `Int 1;
                  "turn", `Int 1;
+                 "trace_id", `String "status-trace";
                  "ts_unix", `Float 1000.0;
                  "ts", `String "2026-01-01T00:00:00Z";
                ])
@@ -1288,29 +1289,41 @@ let test_keeper_agent_run_wires_memory_llm_summarizer () =
     (Astring.String.is_infix
        ~affix:"?summarizer:memory_summarizer" source)
 
-let memory_note ?horizon ?source ~kind ~text ~priority ~generation ~turn ~ts_unix () =
-  let extra_fields =
-    (match horizon with
-     | Some value -> [ ("horizon", `String value) ]
-     | None -> [])
-    @
-    (match source with
-     | Some value -> [ ("source", `String value) ]
-     | None -> [])
+let memory_note
+      ?(schema_version = Keeper_memory_bank.keeper_memory_schema_version)
+      ?horizon
+      ?(source = "test_seed")
+      ?(trace_id = "t1")
+      ~kind
+      ~text
+      ~priority
+      ~generation
+      ~turn
+      ~ts_unix
+      ()
+  =
+  let horizon =
+    match horizon with
+    | Some value -> value
+    | None ->
+      Keeper_memory_bank.memory_horizon_of_kind_opt kind
+      |> Option.value ~default:""
   in
   Yojson.Safe.to_string
     (`Assoc
-      ([
-         ("ts", `String "2026-04-06T00:00:00Z");
-         ("ts_unix", `Float ts_unix);
-         ("name", `String "test");
-         ("trace_id", `String "t1");
-         ("generation", `Int generation);
-         ("turn", `Int turn);
-         ("kind", `String kind);
-         ("priority", `Int priority);
-         ("text", `String text);
-       ] @ extra_fields))
+       [ ("schema_version", `Int schema_version)
+       ; ("ts", `String "2026-04-06T00:00:00Z")
+       ; ("ts_unix", `Float ts_unix)
+       ; ("name", `String "test")
+       ; ("trace_id", `String trace_id)
+       ; ("generation", `Int generation)
+       ; ("turn", `Int turn)
+       ; ("kind", `String kind)
+       ; ("horizon", `String horizon)
+       ; ("source", `String source)
+       ; ("priority", `Int priority)
+       ; ("text", `String text)
+       ])
 
 (** Test: memory bank search returns structured results with scoring. *)
 let test_memory_search_bank_basic () =
@@ -1580,6 +1593,26 @@ let test_memory_search_source_all () =
     let match_count = Yojson.Safe.Util.(json |> member "match_count" |> to_int) in
     check bool "found matches from both sources" true (match_count >= 2))
 
+let test_memory_search_invalid_source_rejected () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir_r dir) (fun () ->
+    let config = make_test_room_config dir in
+    let meta = keeper_meta ~name:"bad-source-keeper" ~mention_targets:["bad-source-keeper"] () in
+    let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
+    let result =
+      KET.execute_keeper_tool_call
+        ~config
+        ~meta
+        ~ctx_work
+        ~exec_cache:None
+        ~name:"keeper_memory_search"
+        ~input:(`Assoc [ ("query", `String "alpha"); ("source", `String "bogus") ])
+        ()
+    in
+    let json = Yojson.Safe.from_string result in
+    check string "invalid source rejected" "invalid_memory_search_source"
+      Yojson.Safe.Util.(json |> member "error_kind" |> to_string))
+
 (* ── Memory Quality Filter Tests ────────────────────────── *)
 
 let test_quality_rejects_empty () =
@@ -1644,7 +1677,14 @@ let test_quality_accepts_meaningful () =
 
 let test_priority_clamp_low () =
   let line =
-    {|{"kind":"goal","text":"test","priority":-5,"ts_unix":1.0,"schema_version":2}|}
+    memory_note
+      ~kind:"goal"
+      ~text:"test"
+      ~priority:(-5)
+      ~generation:1
+      ~turn:1
+      ~ts_unix:1.0
+      ()
   in
   match Keeper_memory_bank.parse_memory_bank_row line with
   | Some row -> check int "clamped to 1" 1 row.priority
@@ -1652,7 +1692,14 @@ let test_priority_clamp_low () =
 
 let test_priority_clamp_high () =
   let line =
-    {|{"kind":"goal","text":"test","priority":999,"ts_unix":1.0,"schema_version":2}|}
+    memory_note
+      ~kind:"goal"
+      ~text:"test"
+      ~priority:999
+      ~generation:1
+      ~turn:1
+      ~ts_unix:1.0
+      ()
   in
   match Keeper_memory_bank.parse_memory_bank_row line with
   | Some row -> check int "clamped to 100" 100 row.priority
@@ -1660,7 +1707,14 @@ let test_priority_clamp_high () =
 
 let test_priority_valid_preserved () =
   let line =
-    {|{"kind":"goal","text":"test","priority":42,"ts_unix":1.0,"schema_version":2}|}
+    memory_note
+      ~kind:"goal"
+      ~text:"test"
+      ~priority:42
+      ~generation:1
+      ~turn:1
+      ~ts_unix:1.0
+      ()
   in
   match Keeper_memory_bank.parse_memory_bank_row line with
   | Some row -> check int "preserved 42" 42 row.priority
@@ -1668,13 +1722,28 @@ let test_priority_valid_preserved () =
 
 let test_schema_version_mismatch () =
   let line =
-    {|{"kind":"goal","text":"test","priority":1,"ts_unix":1.0,"schema_version":99}|}
+    memory_note
+      ~schema_version:99
+      ~kind:"goal"
+      ~text:"test"
+      ~priority:1
+      ~generation:1
+      ~turn:1
+      ~ts_unix:1.0
+      ()
   in
   check bool "mismatch rejected" true (Keeper_memory_bank.parse_memory_bank_row line = None)
 
 let test_schema_version_match () =
   let line =
-    {|{"kind":"goal","text":"test","priority":1,"ts_unix":1.0,"schema_version":2}|}
+    memory_note
+      ~kind:"goal"
+      ~text:"test"
+      ~priority:1
+      ~generation:1
+      ~turn:1
+      ~ts_unix:1.0
+      ()
   in
   check bool "match accepted" true (Keeper_memory_bank.parse_memory_bank_row line <> None)
 
@@ -2113,10 +2182,12 @@ let () =
             test_memory_search_decision_log_failure_is_observable;
           test_case "no matching query returns no_match" `Quick
             test_memory_search_bank_no_match;
-          test_case "source=history uses legacy search" `Quick
+          test_case "source=history searches history" `Quick
             test_memory_search_source_history;
           test_case "source=all merges bank and history" `Quick
             test_memory_search_source_all;
+          test_case "invalid source is rejected" `Quick
+            test_memory_search_invalid_source_rejected;
         ] );
       ( "memory_quality_filter",
         [

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -222,53 +222,6 @@ let test_procedural_record_success () =
    | None -> Alcotest.fail "expected procedure after success");
   cleanup_tmp_dir dir
 
-let test_flush_procedures_dedupes_legacy_records () =
-  let dir = setup_tmp_dir () in
-  let agent_name = "test-pr-flush" in
-  let existing_old : Procedural_memory.procedure = {
-    id = "proc-legacy";
-    agent_name;
-    pattern = "deploy failure";
-    evidence = ["old"];
-    success_count = 1;
-    failure_count = 0;
-    confidence = 1.0;
-    created_at = 100.0;
-    last_applied = 110.0;
-  } in
-  let existing_latest = {
-    existing_old with
-    evidence = ["latest"];
-    success_count = 2;
-    created_at = 200.0;
-    last_applied = 210.0;
-  } in
-  Procedural_memory.save_procedure ~agent_name existing_old;
-  Procedural_memory.save_procedure ~agent_name existing_latest;
-  let memory = Memory_oas_bridge.create_memory ~agent_name () in
-  let oas_proc : Agent_sdk.Memory.procedure = {
-    id = "proc-legacy";
-    pattern = "deploy failure";
-    action = "rollback";
-    success_count = 2;
-    failure_count = 0;
-    confidence = 1.0;
-    last_used = 210.0;
-    metadata = [];
-  } in
-  ignore (Agent_sdk.Memory.store_procedure memory oas_proc);
-  let flushed = Memory_oas_bridge.flush_procedures ~memory ~agent_name in
-  Alcotest.(check int) "no flush when latest record already matches" 0 flushed;
-  let persisted = Procedural_memory.load_procedures ~agent_name in
-  Alcotest.(check int) "legacy duplicates rewritten away" 1
-    (List.length persisted);
-  let final = List.hd persisted in
-  Alcotest.(check string) "id preserved" "proc-legacy" final.id;
-  Alcotest.(check int) "latest success count preserved" 2 final.success_count;
-  Alcotest.(check string) "latest evidence preserved" "latest"
-    (List.hd final.evidence);
-  cleanup_tmp_dir dir
-
 let contains_substring haystack needle =
   let nlen = String.length needle in
   let hlen = String.length haystack in
@@ -678,8 +631,6 @@ let () =
     ("procedural", [
       Alcotest.test_case "store and recall" `Quick test_procedural_store_recall;
       Alcotest.test_case "record success" `Quick test_procedural_record_success;
-      Alcotest.test_case "flush dedupes legacy records" `Quick
-        test_flush_procedures_dedupes_legacy_records;
       Alcotest.test_case "load_procedures_text refreshes after append" `Quick
         test_load_procedures_text_refreshes_after_external_append;
       Alcotest.test_case "flush updates cache for immediate reload" `Quick


### PR DESCRIPTION
## Summary
- Reject invalid `keeper_memory_search.source` values instead of defaulting them to `memory`.
- Require canonical memory-bank rows with current `schema_version`, valid `horizon`, and provenance fields before search, summary, or horizon-count readers consume them.
- Remove the legacy procedural-memory duplicate rewrite path from OAS flush and delete the compatibility-preservation test.
- Update `docs/audit/2026-05-25-legacy-purge-plan.html` with #18707 merged state and this active Memory/context purge slice.

## Validation
- `ocamlformat --check lib/keeper/keeper_exec_memory.ml lib/keeper/keeper_memory_bank.ml lib/keeper/keeper_memory_bank.mli lib/keeper/keeper_memory_bank_selection.ml lib/keeper/keeper_memory_bank_selection.mli lib/keeper/keeper_memory_policy.ml lib/memory_oas_bridge.ml lib/memory_oas_bridge.mli test/test_keeper_memory.ml test/test_memory_oas_5tier.ml`
- `git diff --check origin/main..HEAD`
- `bash scripts/check-doc-truth.sh`
- `scripts/ci/check-enum-string-safety.sh` (PASS; pre-existing warnings only)
- `bash scripts/lint/no-unknown-permissive-default.sh`
- `scripts/ci/check-determinism-contract.sh` (PASS; pre-existing warnings only)
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD --recent-main 50 --duplicate-policy warn`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD` (OK with pending-release warning)

## Not run
- `scripts/dune-local.sh build ./lib ./test/test_keeper_memory.exe ./test/test_memory_oas_5tier.exe` is blocked locally by the machine-wide guard because external bare Dune processes are running outside `scripts/dune-local.sh` (exit 75).