### PR TITLE
feat(tool_types): RFC-0189 typed Tool_result.result variant (PR-1a additive)

### DIFF
--- a/docs/rfc/RFC-0189-typed-tool-result-variant.md
+++ b/docs/rfc/RFC-0189-typed-tool-result-variant.md
@@ -1,0 +1,273 @@
+---
+rfc: "0189"
+title: "Typed Tool_result.result variant — eliminating boolean blindness in tool dispatch"
+status: Draft
+created: 2026-05-26
+updated: 2026-05-26
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0062", "0044", "0077", "0088", "0179"]
+implementation_prs: []
+---
+
+# RFC-0189 — Typed `Tool_result.result` variant
+
+## 0. tl;dr
+
+`Tool_result.t` is a structured record with `success : bool` and
+`failure_class : tool_failure_class option`. That shape makes four
+illegal states representable that the compiler cannot rule out, and
+forces 285 call sites to thread a substring/JSON classifier
+(`classify_from_structured_failure_message`, anti-pattern §2) to recover
+information the type system should have carried.
+
+This RFC introduces `(success_payload, failure_payload) Stdlib.Result.t`
+as the new SSOT. PR-1a (companion to this RFC) lands the new surface +
+converters with **zero call-site changes**. PR-1b migrates the 285
+constructor sites category-by-category. PR-2 drops the legacy record and
+the substring classifier.
+
+## 1. Problem
+
+### 1.1 Illegal states representable
+
+The legacy record:
+
+```ocaml
+type t =
+  { success : bool
+  ; data : Yojson.Safe.t
+  ; message : string
+  ; tool_name : string
+  ; duration_ms : float
+  ; failure_class : tool_failure_class option
+  }
+```
+
+permits four configurations the type system cannot rule out:
+
+| # | Configuration | Why illegal |
+|---|---|---|
+| 1 | `{success=true; failure_class=Some _}` | success-with-failure contradiction |
+| 2 | `{success=false; failure_class=None}` | silent failure; caller has no typed reason |
+| 3 | caller does `if r.success then ... else ...` | boolean blindness — message body must be parsed to recover class |
+| 4 | `error ?failure_class:tool_failure_class option ...` | option-of-option in API surface |
+
+Each is `software-development.md` §AI 코드 생성 안티패턴 §2
+(string/substring classifier) — typed sum type was already in the
+codebase (`tool_failure_class`), but the *shape* of `t` forced callers
+back into stringly-typed reasoning.
+
+### 1.2 Substring classifier in the failure path
+
+`lib/tool_types/tool_result.ml:64-74`:
+
+```ocaml
+let classify_from_structured_failure_message message =
+  try
+    match Yojson.Safe.from_string message with
+    | `Assoc fields ->
+      (match List.assoc_opt "failure_class" fields with
+       | Some (`String value) -> tool_failure_class_of_string value
+       | _ -> None)
+    | _ -> None
+  with
+  | Yojson.Json_error _ -> None
+;;
+```
+
+This is the *exact* pattern RFC-0062 §3.2 said it would remove
+("Phase 1 `classify_from_dispatch_failure` string fallback has been
+removed"). It is still here. Cause: the record permits `failure_class =
+None`, so `error` must guess on the caller's behalf.
+
+### 1.3 Blast radius
+
+Constructor distribution (`rg "Tool_result\.(ok|error|of_exn|quick_)" lib/`):
+
+| File | Calls |
+|------|------:|
+| `tool_board_handlers.ml` | 26 |
+| `tool_task_handlers.ml` | 19 |
+| `tool_plan.ml` | 19 |
+| `tool_library.ml` | 18 |
+| `tool_run.ml` | 16 |
+| `tool_board_post.ml` | 16 |
+| `mcp_server_eio_execute.ml` | 16 |
+| `tool_task.ml` | 14 |
+| `tool_types/tool_args.ml` | 13 |
+| `tool_inline_dispatch.ml` | 13 |
+| ... (remaining) | 115 |
+| **Total** | **285** |
+
+Field accessors (`.success / .message / Tool_result.{...`) appear at
+**407 sites across 64 files** — the accessor-side surface is wider and
+will be migrated in PR-1b clusters.
+
+## 2. Non-goals
+
+- New typed sum types parallel to `Read_drop_reason.t` (RFC-0044) or
+  `Write_failure_reason.t` (RFC-0077). Reuse the existing
+  `tool_failure_class`.
+- Per-tool typed input/output payloads (success_payload.data,
+  failure_payload.data stay `Yojson.Safe.t` for now). RFC-0179 descriptor
+  migration is the natural vehicle for that "Full ambition" step
+  (deferred 6-month track).
+- Cross-process wire format changes. The legacy `to_json` projection
+  stays identical so MCP consumers see no change.
+- Changing `tool_failure_class` (4-variant closed sum already shipped via
+  RFC-0062).
+
+## 3. Design
+
+### 3.1 New surface (added in PR-1a)
+
+```ocaml
+type success_payload =
+  { data : Yojson.Safe.t
+  ; tool_name : string
+  ; duration_ms : float
+  }
+
+type failure_payload =
+  { class_ : tool_failure_class    (* REQUIRED, not option *)
+  ; message : string
+  ; data : Yojson.Safe.t
+  ; tool_name : string
+  ; duration_ms : float
+  }
+
+type result = (success_payload, failure_payload) Stdlib.Result.t
+
+val make_ok      : tool_name:string -> start_time:float -> ?data:Yojson.Safe.t -> unit -> result
+val make_err     : tool_name:string -> class_:tool_failure_class -> start_time:float -> ?data:Yojson.Safe.t -> string -> result
+val make_err_of_exn : ?class_:tool_failure_class -> tool_name:string -> start_time:float -> exn -> result
+
+val to_legacy : result -> t
+val of_legacy : t -> result   (* coerces illegal states #1, #2 to Error with Log.warn *)
+```
+
+Notes:
+- `class_` on `failure_payload` is **required, not `option`**. Eliminates
+  illegal states #1, #2, #4 by construction.
+- `make_err`'s `~class_` is **labelled and required** — caller cannot
+  silently default. Eliminates illegal state #4.
+- `result` is a *type alias* for `Stdlib.Result.t`, so `Result.map`,
+  `Result.bind`, `Result.fold` all compose without wrappers.
+- `of_legacy` emits `Log.warn` with `~ctx:"tool_result"` when it
+  encounters illegal state #1 or #2 in legacy callers. The warn is
+  observable in logs during PR-1b migration and disappears in PR-2.
+
+### 3.2 Migration plan
+
+| Phase | Scope | Diff size | Risk |
+|-------|-------|----------:|------|
+| **PR-1a** (this RFC) | Add `result` + converters + 7 unit tests | ~200 LoC | ⭐ zero — no caller touched |
+| **PR-1b.1** | Migrate `tool_board_*` cluster (26 + 16 + 9 + 7 = 58 calls, 4 files) | ~120 LoC | ★ low |
+| **PR-1b.2** | Migrate `tool_task*` cluster (19 + 14 = 33 calls, 2 files) | ~70 LoC | ★ low |
+| **PR-1b.3** | Migrate `tool_library` + `tool_plan` (18 + 19 = 37 calls, 2 files) | ~80 LoC | ★ low |
+| **PR-1b.4** | Migrate `tool_run` + `tool_misc*` (16 + 20 calls, 4 files) | ~80 LoC | ★ low |
+| **PR-1b.5** | Migrate `mcp_server_eio_execute` + `tool_inline_*` (16 + 27 calls, 4 files) | ~100 LoC | ★★ medium (server edge) |
+| **PR-1b.6** | Migrate remaining (~115 calls, ~18 files) | ~200 LoC | ★ low |
+| **PR-1c** | Migrate 407 accessor sites in 64 files (pattern match instead of `.success`/`.failure_class`) | ~800 LoC | ★★★ high — big-bang per [feedback_radical_improvement_over_diff_size] |
+| **PR-2** | Drop legacy `t`, `to_legacy`, `of_legacy`, `classify_from_structured_failure_message`, legacy `ok`/`error`/`of_exn`/`quick_*` | ~250 LoC removed | ★★ medium — dead-code sweep, [feedback_dead_export_audit_must_trace_include_facade] applies |
+
+Each PR-1b step is independently mergeable. Order is intentional:
+boards/tasks first (most call sites, most concrete failure semantics),
+server edge last (highest blast radius).
+
+### 3.3 What's *not* changing in PR-1a
+
+- The legacy record `t` and all its constructors (`ok`, `error`, `of_exn`,
+  `quick_ok`, `quick_error`) remain. Behaviour unchanged.
+- `classify_from_structured_failure_message` is annotated as "scheduled
+  for removal in PR-2" but kept live so the legacy `error` constructor
+  observes its current behaviour.
+- `to_json` projection unchanged → MCP wire format identical.
+- 285 constructor sites and 407 accessor sites untouched.
+
+This is what makes PR-1a zero-regression: it is purely *additive*.
+
+## 4. Verification
+
+### 4.1 PR-1a (this commit)
+
+- `dune build --root . lib/` → exit 0 (verified)
+- `dune exec --root . test/test_tool_result.exe` → 20/20 PASS (verified)
+  - 13 pre-existing tests (round-trip, structured failure_class honor, exception classification)
+  - 7 new RFC-0189 tests:
+    1. `make_ok round-trip` (Ok → to_legacy → of_legacy → Ok)
+    2. `make_err required class` (compile-time + run-time class preservation)
+    3. `make_err round-trip preserves class` (Error → to_legacy → of_legacy → Error)
+    4. `of_legacy coerces illegal state #1` (success=true + class=Some → Error)
+    5. `of_legacy coerces illegal state #2` (success=false + class=None → Error + Runtime_failure)
+    6. `make_err_of_exn classifies by constructor` (Eio.Time.Timeout → Transient_error)
+    7. `result aliases Stdlib.Result.t` (Result.map composes)
+
+### 4.2 PR-1b (per-step)
+
+Each PR-1b step must:
+1. `dune build --root . lib/` → exit 0
+2. `dune exec --root . test/test_tool_result.exe` → 20/20 PASS
+3. `dune build @runtest` → no new regression (sandbox config caveat per
+   `reference_masc_mcp_sandbox_config_unresolved_runtest`)
+4. Migrated file's `dune` `(libraries ...)` unchanged → no new dependency
+5. `Log.warn` count from `of_legacy` measured before/after each step — should
+   trend toward zero as PR-1b lands
+
+### 4.3 PR-2
+
+Once `to_legacy`/`of_legacy`/`t` are removed:
+1. Full `rg "Tool_result\.t\b" lib/`  → 0 hits
+2. Full `rg "\.success\b" lib/` → 0 hits on Tool_result records
+3. Full `rg "classify_from_structured_failure_message" lib/` → 0 hits
+4. 5-prong dead-export audit per
+   `feedback_dead_export_dead_export_sweep_2026_05_23_anti_pattern`:
+   - direct grep, facade re-export, `include` re-export,
+     opener-unqualified, paired test file
+
+## 5. Workaround Signature Gate compliance
+
+Per `software-development.md` §워크어라운드 거부 기준:
+
+- **§1 Telemetry-as-fix**: ❌ does not apply — RFC removes a classifier,
+  adds none.
+- **§2 String/substring classifier**: ✅ explicitly removes
+  `classify_from_structured_failure_message` in PR-2.
+- **§3 N-of-M patch**: ❌ does not apply — PR-1a is *additive*; PR-1b is
+  a planned, staged caller migration with explicit per-step verification
+  per RFC §4.2.
+- **Override clause**: not invoked.
+
+This RFC *closes* an existing workaround rather than introducing one.
+
+## 6. Open questions
+
+| # | Question | Default | Decision deadline |
+|---|---|---|---|
+| Q1 | Should PR-2 also drop `tool_failure_class_of_string`? It exists for parsing JSON-encoded `failure_class` fields, which become unnecessary once the typed payload owns the field. | Yes — drop in PR-2 alongside `classify_from_structured_failure_message` | PR-2 review |
+| Q2 | Should `failure_payload.data` be narrowed beyond `Yojson.Safe.t` (per-tool GADT)? | No — defer to "Full ambition" follow-up RFC tied to RFC-0179 descriptor migration | After RFC-0179 PR-7 lands |
+| Q3 | Should `make_err_of_exn` keep `?class_:tool_failure_class` optional? It is a *single* option (not option-of-option), so it does not fall into illegal state #4. | Yes — keep, but document that `Some` is preferred at every catch boundary | PR-1a review |
+
+## 7. Related work
+
+- **RFC-0062** — Typed `Tool_result.t` + typed `Sdk_*` blocker class
+  (Implemented). Introduced `tool_failure_class` 4-variant closed sum.
+  RFC-0189 picks up where RFC-0062 §3.3 stopped: the `option` wrapping
+  remained, and §3.2's promise to remove the substring classifier was
+  partially undone by `classify_from_structured_failure_message`.
+- **RFC-0044** — Typed persistence read-drop reason (Active). Sibling
+  pattern for read-side silent failures.
+- **RFC-0077** — Write-side silent failure typed propagation
+  (Implemented). The closest precedent in shape: PR #15054 migrated
+  ~13 keeper write sites to typed `Write_failure_reason.t`.
+- **RFC-0088** — Counter-as-fix → Result propagation umbrella (Active).
+  RFC-0189 falls under the umbrella's category "Result propagation in
+  tool dispatch" (not enumerated in 0088 §3 inventory because 0088 is
+  scoped to counter-paired silent failures; this RFC handles the
+  classifier-paired analogue).
+- **RFC-0179** — ToolDescriptor ecosystem coverage (PR-7 merged 2026-05-26
+  as #18710). Now that 286 tools route through descriptors, the natural
+  next step is for descriptors to *speak* `(success, failure) Result.t`
+  natively. PR-1c (accessor migration) is what unlocks that.

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -224,3 +224,160 @@ let quick_error ?(tool_name = "") message =
   ; failure_class = Some Runtime_failure
   }
 ;;
+
+(* ─────────────────────────────────────────────────────────────────────────
+   RFC-0189 — Typed Result variant (SSOT-in-progress)
+
+   Adds [(success_payload, failure_payload) Stdlib.Result.t] alongside the
+   legacy record [t]. New code should use [result] + [make_ok]/[make_err]
+   and [of_legacy]/[to_legacy] at boundaries with un-migrated callers.
+
+   Why: the legacy [t] makes four illegal states representable that the
+   compiler cannot rule out:
+
+     1. {success = true;  failure_class = Some _}        — contradiction
+     2. {success = false; failure_class = None}          — silent failure
+     3. caller does [if r.success then ... else ...]     — boolean blindness
+        and must re-parse [r.message] (JSON) to recover [failure_class]
+     4. [error ?(failure_class = None)] (option of option) — confusing API
+
+   The [result] variant collapses (1) and (2) by construction (the [Error]
+   carries a typed [class_] field, no [option]), eliminates (3) by forcing
+   callers to pattern-match on [Ok | Error], and dissolves (4) by giving
+   [make_err] a required (non-optional) [~class_] parameter.
+
+   Migration plan:
+     - PR-1a (this commit): introduce [result], converters, and
+       [make_ok]/[make_err]. Legacy [t] and 285 constructor call sites
+       unchanged. Zero compile-time regression.
+     - PR-1b: migrate 285 [Tool_result.ok / .error / .of_exn / .quick_*]
+       call sites to [make_ok / make_err], category by category
+       (board → task → library → plan → run → ...).
+     - PR-2: drop legacy [t], [to_legacy], [of_legacy],
+       [classify_from_structured_failure_message]. Make [result] the SSOT.
+
+   Related: RFC-0062 (typed Tool_result.t, original design), RFC-0044/0077
+   (sibling typed-reason patterns on read/write side), RFC-0088 (umbrella).
+   ───────────────────────────────────────────────────────────────────── *)
+
+type success_payload =
+  { data : Yojson.Safe.t
+  ; tool_name : string
+  ; duration_ms : float
+  }
+
+type failure_payload =
+  { class_ : tool_failure_class
+  ; message : string
+  ; data : Yojson.Safe.t
+  ; tool_name : string
+  ; duration_ms : float
+  }
+
+type result = (success_payload, failure_payload) Result.t
+
+(** [to_legacy r] projects the typed variant onto the legacy record [t].
+    Lossless. Used at boundaries with un-migrated callers. Removed in PR-2. *)
+let to_legacy : result -> t = function
+  | Ok { data; tool_name; duration_ms } ->
+    { success = true
+    ; data
+    ; message =
+        (match data with
+         | `String s -> s
+         | other -> Yojson.Safe.to_string other)
+    ; tool_name
+    ; duration_ms
+    ; failure_class = None
+    }
+  | Error { class_; message; data; tool_name; duration_ms } ->
+    { success = false
+    ; data
+    ; message
+    ; tool_name
+    ; duration_ms
+    ; failure_class = Some class_
+    }
+;;
+
+(** [of_legacy t] reconstructs a typed variant from the legacy record.
+
+    Defensive in two corners: the legacy record permits
+    [{success=true; failure_class=Some _}] and [{success=false; failure_class=None}]
+    — illegal states the new variant rules out by construction. We coerce
+    those into the closest meaningful [Error] and emit a [Log.warn] so the
+    illegal state is observable. This branch fires only while legacy callers
+    remain. Removed in PR-2 along with [t]. *)
+let of_legacy (t : t) : result =
+  match t.success, t.failure_class with
+  | true, None ->
+    Ok { data = t.data; tool_name = t.tool_name; duration_ms = t.duration_ms }
+  | false, Some class_ ->
+    Error
+      { class_
+      ; message = t.message
+      ; data = t.data
+      ; tool_name = t.tool_name
+      ; duration_ms = t.duration_ms
+      }
+  | true, Some cls ->
+    Log.warn
+      ~ctx:"tool_result"
+      "illegal legacy state #1: success=true with failure_class=%s on tool=%s; \
+       coercing to Error (RFC-0189)"
+      (tool_failure_class_to_string cls)
+      t.tool_name;
+    Error
+      { class_ = cls
+      ; message = t.message
+      ; data = t.data
+      ; tool_name = t.tool_name
+      ; duration_ms = t.duration_ms
+      }
+  | false, None ->
+    Log.warn
+      ~ctx:"tool_result"
+      "illegal legacy state #2: success=false with failure_class=None on tool=%s; \
+       defaulting class to Runtime_failure (RFC-0189)"
+      t.tool_name;
+    Error
+      { class_ = Runtime_failure
+      ; message = t.message
+      ; data = t.data
+      ; tool_name = t.tool_name
+      ; duration_ms = t.duration_ms
+      }
+;;
+
+(** [make_ok] — typed success constructor. *)
+let make_ok ~tool_name ~start_time ?(data = `Null) () : result =
+  let duration_ms = (Time_compat.now () -. start_time) *. 1000.0 in
+  Ok { data; tool_name; duration_ms }
+;;
+
+(** [make_err] — typed failure constructor. [~class_] is REQUIRED (not an
+    option); callers must commit to a typed classification at the catch
+    boundary rather than deferring to string parsing. *)
+let make_err ~tool_name ~class_ ~start_time ?(data = `Null) message : result =
+  let duration_ms = (Time_compat.now () -. start_time) *. 1000.0 in
+  Error { class_; message; data; tool_name; duration_ms }
+;;
+
+(** [make_err_of_exn] — typed failure constructor from a caught exception.
+    Uses [classify_from_exception] for the constructor-only fallback when
+    [~class_] is not supplied. *)
+let make_err_of_exn ?class_ ~tool_name ~start_time exn : result =
+  let duration_ms = (Time_compat.now () -. start_time) *. 1000.0 in
+  let class_ =
+    match class_ with
+    | Some c -> c
+    | None -> classify_from_exception exn
+  in
+  let message =
+    Printf.sprintf
+      "dispatch handler error for %s: %s"
+      tool_name
+      (Stdlib.Printexc.to_string exn)
+  in
+  Error { class_; message; data = `String message; tool_name; duration_ms }
+;;

--- a/lib/tool_types/tool_result.mli
+++ b/lib/tool_types/tool_result.mli
@@ -94,3 +94,86 @@ val of_exn : ?failure_class:tool_failure_class -> tool_name:string -> start_time
 
 val quick_ok : ?tool_name:string -> string -> t
 val quick_error : ?tool_name:string -> string -> t
+
+(** {1 RFC-0189 — Typed Result variant (SSOT-in-progress)}
+
+    Adds [(success_payload, failure_payload) Stdlib.Result.t] alongside the
+    legacy record {!t}. New code should use {!result} + {!make_ok} /
+    {!make_err} and {!of_legacy} / {!to_legacy} at boundaries with
+    un-migrated callers.
+
+    The legacy {!t} makes four illegal states representable that the
+    compiler cannot rule out:
+
+      - [{success = true;  failure_class = Some _}]  — contradiction
+      - [{success = false; failure_class = None}]    — silent failure
+      - caller does [if r.success then ... else ...] — boolean blindness
+      - {!error}'s [?failure_class:tool_failure_class option] — option-of-option
+
+    {!result} collapses all four by construction.
+
+    Migration plan:
+      - PR-1a (this commit): introduce surface, no caller changes
+      - PR-1b: migrate 285 constructor sites to {!make_ok} / {!make_err}
+      - PR-2: drop legacy {!t} and converters; {!result} becomes SSOT
+
+    Related: RFC-0062, RFC-0044, RFC-0077, RFC-0088.
+
+    @since 2.262.0 *)
+
+(** Payload carried by a successful tool invocation. *)
+type success_payload =
+  { data : Yojson.Safe.t
+  ; tool_name : string
+  ; duration_ms : float
+  }
+
+(** Payload carried by a failed tool invocation.  [class_] is required
+    (not an [option]): callers must commit to a typed classification at
+    the catch boundary. *)
+type failure_payload =
+  { class_ : tool_failure_class
+  ; message : string
+  ; data : Yojson.Safe.t
+  ; tool_name : string
+  ; duration_ms : float
+  }
+
+(** Typed result of a tool invocation.  Pattern-match on [Ok] / [Error]
+    rather than reading [.success] + [.failure_class] off the legacy
+    record. *)
+type result = (success_payload, failure_payload) Stdlib.Result.t
+
+(** Lossless projection onto the legacy record. *)
+val to_legacy : result -> t
+
+(** Lift the legacy record into the typed variant.  Illegal states (#1, #2
+    above) are coerced to [Error] with a [Log.warn]. *)
+val of_legacy : t -> result
+
+(** Typed success constructor.  [data] defaults to [`Null]. *)
+val make_ok
+  :  tool_name:string
+  -> start_time:float
+  -> ?data:Yojson.Safe.t
+  -> unit
+  -> result
+
+(** Typed failure constructor.  [~class_] is REQUIRED. *)
+val make_err
+  :  tool_name:string
+  -> class_:tool_failure_class
+  -> start_time:float
+  -> ?data:Yojson.Safe.t
+  -> string
+  -> result
+
+(** Typed failure constructor from a caught exception.  When [~class_] is
+    not provided, {!classify_from_exception} supplies the
+    constructor-only fallback. *)
+val make_err_of_exn
+  :  ?class_:tool_failure_class
+  -> tool_name:string
+  -> start_time:float
+  -> exn
+  -> result

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -205,6 +205,155 @@ let test_dispatch_structured_unknown () =
   | Ok _ -> Alcotest.fail "mint_token should return Error for unknown tool"
 ;;
 
+(* ─── RFC-0189 — typed result variant ──────────────────────────────────── *)
+
+let test_make_ok_roundtrip () =
+  let r =
+    Tool_result.make_ok
+      ~tool_name:"masc_test"
+      ~start_time:0.0
+      ~data:(`Assoc [ "k", `String "v" ])
+      ()
+  in
+  match r with
+  | Ok s ->
+    Alcotest.(check string) "tool_name preserved" "masc_test" s.tool_name;
+    Alcotest.(check bool) "duration_ms >= 0" true (s.duration_ms >= 0.0);
+    (* round-trip via legacy *)
+    let legacy = Tool_result.to_legacy r in
+    Alcotest.(check bool) "legacy.success = true" true legacy.success;
+    Alcotest.(check bool)
+      "legacy.failure_class = None"
+      true
+      (legacy.failure_class = None);
+    (match Tool_result.of_legacy legacy with
+     | Ok s' ->
+       Alcotest.(check string) "round-trip tool_name" s.tool_name s'.tool_name
+     | Error _ -> Alcotest.fail "Ok round-trip lost the Ok shape")
+  | Error _ -> Alcotest.fail "make_ok produced Error"
+;;
+
+let test_make_err_required_class () =
+  (* This test exists to document the API: ~class_ is required, not optional.
+     The compiler enforces this at every call site of make_err — there's no
+     [?class_:tool_failure_class option] pattern to defer to. *)
+  let r =
+    Tool_result.make_err
+      ~tool_name:"masc_test"
+      ~class_:Tool_result.Policy_rejection
+      ~start_time:0.0
+      "rejected"
+  in
+  match r with
+  | Error f ->
+    Alcotest.(check string) "tool_name" "masc_test" f.tool_name;
+    Alcotest.(check string) "message" "rejected" f.message;
+    Alcotest.(check string)
+      "class_"
+      "policy_rejection"
+      (Tool_result.tool_failure_class_to_string f.class_)
+  | Ok _ -> Alcotest.fail "make_err produced Ok"
+;;
+
+let test_make_err_roundtrip_preserves_class () =
+  let r =
+    Tool_result.make_err
+      ~tool_name:"keeper_task_done"
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time:0.0
+      ~data:(`Assoc [ "reason", `String "pr_url missing" ])
+      "pr_url is required"
+  in
+  let legacy = Tool_result.to_legacy r in
+  Alcotest.(check bool) "legacy.success = false" false legacy.success;
+  Alcotest.(check (option string))
+    "legacy.failure_class = Some workflow_rejection"
+    (Some "workflow_rejection")
+    (Option.map Tool_result.tool_failure_class_to_string legacy.failure_class);
+  match Tool_result.of_legacy legacy with
+  | Error f ->
+    Alcotest.(check string)
+      "round-trip class_"
+      "workflow_rejection"
+      (Tool_result.tool_failure_class_to_string f.class_);
+    Alcotest.(check string) "round-trip message" "pr_url is required" f.message
+  | Ok _ -> Alcotest.fail "Error round-trip lost the Error shape"
+;;
+
+let test_of_legacy_coerces_illegal_state_1 () =
+  (* Illegal: success=true with failure_class=Some _.
+     of_legacy should coerce to Error (logs a warning, observable in stderr). *)
+  let legacy : Tool_result.t =
+    { success = true
+    ; data = `Null
+    ; message = "weird"
+    ; tool_name = "test_tool"
+    ; duration_ms = 0.0
+    ; failure_class = Some Tool_result.Transient_error
+    }
+  in
+  match Tool_result.of_legacy legacy with
+  | Error f ->
+    Alcotest.(check string)
+      "coerced class_ preserved"
+      "transient_error"
+      (Tool_result.tool_failure_class_to_string f.class_)
+  | Ok _ -> Alcotest.fail "illegal state #1 should coerce to Error"
+;;
+
+let test_of_legacy_coerces_illegal_state_2 () =
+  (* Illegal: success=false with failure_class=None.
+     of_legacy should default class_ to Runtime_failure. *)
+  let legacy : Tool_result.t =
+    { success = false
+    ; data = `Null
+    ; message = "silent fail"
+    ; tool_name = "test_tool"
+    ; duration_ms = 0.0
+    ; failure_class = None
+    }
+  in
+  match Tool_result.of_legacy legacy with
+  | Error f ->
+    Alcotest.(check string)
+      "defaulted class_"
+      "runtime_failure"
+      (Tool_result.tool_failure_class_to_string f.class_)
+  | Ok _ -> Alcotest.fail "illegal state #2 should coerce to Error"
+;;
+
+let test_make_err_of_exn_classifies_constructor () =
+  let r =
+    Tool_result.make_err_of_exn
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      Eio.Time.Timeout
+  in
+  match r with
+  | Error f ->
+    Alcotest.(check string)
+      "Timeout classified as transient"
+      "transient_error"
+      (Tool_result.tool_failure_class_to_string f.class_)
+  | Ok _ -> Alcotest.fail "make_err_of_exn returned Ok"
+;;
+
+let test_result_is_stdlib_result_alias () =
+  (* Documents that [result] is [(success_payload, failure_payload) Stdlib.Result.t]
+     so all stdlib combinators (map, bind, fold) compose with it. *)
+  let r =
+    Tool_result.make_ok ~tool_name:"x" ~start_time:0.0 ~data:(`Int 1) ()
+  in
+  let mapped =
+    Stdlib.Result.map
+      (fun (s : Tool_result.success_payload) -> { s with tool_name = "y" })
+      r
+  in
+  match mapped with
+  | Ok s -> Alcotest.(check string) "Stdlib.Result.map composes" "y" s.tool_name
+  | Error _ -> Alcotest.fail "Stdlib.Result.map should preserve Ok"
+;;
+
 let () =
   Alcotest.run
     "Tool_result"
@@ -244,6 +393,30 @@ let () =
     ; ( "dispatch_structured"
       , [ Alcotest.test_case "registered tool" `Quick test_dispatch_structured
         ; Alcotest.test_case "unknown tool" `Quick test_dispatch_structured_unknown
+        ] )
+    ; ( "rfc-0189 typed result"
+      , [ Alcotest.test_case "make_ok round-trip" `Quick test_make_ok_roundtrip
+        ; Alcotest.test_case "make_err required class" `Quick test_make_err_required_class
+        ; Alcotest.test_case
+            "make_err round-trip preserves class"
+            `Quick
+            test_make_err_roundtrip_preserves_class
+        ; Alcotest.test_case
+            "of_legacy coerces illegal state #1 (success=true + class=Some)"
+            `Quick
+            test_of_legacy_coerces_illegal_state_1
+        ; Alcotest.test_case
+            "of_legacy coerces illegal state #2 (success=false + class=None)"
+            `Quick
+            test_of_legacy_coerces_illegal_state_2
+        ; Alcotest.test_case
+            "make_err_of_exn classifies by constructor"
+            `Quick
+            test_make_err_of_exn_classifies_constructor
+        ; Alcotest.test_case
+            "result aliases Stdlib.Result.t"
+            `Quick
+            test_result_is_stdlib_result_alias
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

Add `(success_payload, failure_payload) Stdlib.Result.t` as the new SSOT for tool dispatch results, alongside the legacy `Tool_result.t` record. **PR-1a is purely additive — 0 caller touched, 0 compile regression**.

Full design in [`docs/rfc/RFC-0189-typed-tool-result-variant.md`](docs/rfc/RFC-0189-typed-tool-result-variant.md).

## Why

The legacy record `{success: bool; failure_class: tool_failure_class option}` makes four illegal states representable that the compiler cannot rule out:

| # | Configuration | Illegal because |
|---|---|---|
| 1 | `{success=true; failure_class=Some _}` | success-with-failure contradiction |
| 2 | `{success=false; failure_class=None}` | silent failure, no typed reason |
| 3 | `if r.success then ... else ...` | boolean blindness; caller must re-parse `r.message` JSON |
| 4 | `error ?failure_class:tool_failure_class option ...` | option-of-option API |

The new `result` variant collapses all four by construction:
- `failure_payload.class_` is **required, not option**
- `make_err`'s `~class_` is **labelled-required** (no silent default)
- `Ok | Error` pattern match replaces the boolean

## What's in this PR

```
 lib/tool_types/tool_result.ml  | +157 (all additive)
 lib/tool_types/tool_result.mli |  +83 (new surface documented)
 test/test_tool_result.ml       | +173 (7 new tests, all PASS)
 docs/rfc/RFC-0189-…md          | +273 (full RFC)
 4 files changed, 686 insertions(+), 0 deletions
```

### New surface

```ocaml
type success_payload = { data : Yojson.Safe.t; tool_name : string; duration_ms : float }
type failure_payload = { class_ : tool_failure_class;       (* REQUIRED, not option *)
                         message : string; data : Yojson.Safe.t;
                         tool_name : string; duration_ms : float }
type result = (success_payload, failure_payload) Stdlib.Result.t

val make_ok          : tool_name:string -> start_time:float -> ?data:Yojson.Safe.t -> unit -> result
val make_err         : tool_name:string -> class_:tool_failure_class -> start_time:float -> ?data:Yojson.Safe.t -> string -> result
val make_err_of_exn  : ?class_:tool_failure_class -> tool_name:string -> start_time:float -> exn -> result
val to_legacy        : result -> t          (* lossless *)
val of_legacy        : t -> result          (* coerces illegal states #1/#2 to Error + Log.warn *)
```

### What's *not* changing

- Legacy `Tool_result.t` and all its constructors (`ok`, `error`, `of_exn`, `quick_*`) remain. Behaviour unchanged.
- 285 constructor call sites untouched.
- 407 accessor sites in 64 files untouched.
- `to_json` wire projection unchanged → MCP consumers see no diff.

This is what makes PR-1a zero-regression: it is purely *additive*.

## Verification

- ✅ `dune build --root . lib/` → exit 0
- ✅ `dune exec --root . test/test_tool_result.exe` → **20/20 PASS** (13 pre-existing + 7 new)

New tests under `rfc-0189 typed result`:
1. `make_ok round-trip` (Ok → to_legacy → of_legacy → Ok preserved)
2. `make_err required class` (compile-time + run-time)
3. `make_err round-trip preserves class` (Error → to_legacy → of_legacy → Error preserved)
4. `of_legacy coerces illegal state #1` (success=true + class=Some → Error)
5. `of_legacy coerces illegal state #2` (success=false + class=None → Error + Runtime_failure)
6. `make_err_of_exn classifies by constructor` (Eio.Time.Timeout → Transient_error)
7. `result aliases Stdlib.Result.t` (Stdlib.Result.map composes natively)

## Migration plan (per RFC-0189 §3.2)

| Phase | Scope | LoC | Risk |
|---|---|---:|:---:|
| **PR-1a** (this) | Additive surface + 7 tests | ~200 | ⭐ zero |
| **PR-1b.1** | `tool_board_*` cluster (58 calls, 4 files) | ~120 | ★ low |
| **PR-1b.2** | `tool_task*` (33 calls, 2 files) | ~70 | ★ low |
| **PR-1b.3** | `tool_library` + `tool_plan` (37 calls, 2 files) | ~80 | ★ low |
| **PR-1b.4** | `tool_run` + `tool_misc*` (36 calls, 4 files) | ~80 | ★ low |
| **PR-1b.5** | `mcp_server_eio_execute` + `tool_inline_*` (43 calls, 4 files) | ~100 | ★★ medium (server edge) |
| **PR-1b.6** | Remaining (~115 calls, ~18 files) | ~200 | ★ low |
| **PR-1c** | 407 accessor sites (big-bang per [feedback_radical_improvement_over_diff_size]) | ~800 | ★★★ high |
| **PR-2** | Drop legacy `t`, converters, `classify_from_structured_failure_message`, legacy ok/error/of_exn/quick_* | -250 | ★★ medium |

## Workaround Signature Gate compliance

Per `software-development.md` §워크어라운드 거부 기준:

- §1 telemetry-as-fix: ❌ N/A — no counter added
- §2 substring classifier: ✅ this RFC **explicitly removes** `classify_from_structured_failure_message` in PR-2 (the existing classifier was the workaround that survived RFC-0062 §3.2's promise; RFC-0189 closes it)
- §3 N-of-M patch: ❌ N/A — PR-1a is purely additive; PR-1b is a planned staged migration with per-step verification per RFC §4.2

**This RFC *closes* an existing workaround rather than introducing one.**

## Related

- **RFC-0062** (Implemented) — typed `Tool_result.t` + `Sdk_*` blocker; introduced `tool_failure_class` 4-variant. RFC-0189 picks up where §3.3 stopped (option-wrap remained) and re-keeps §3.2's promise.
- **RFC-0044** (Active) — typed persistence read-drop reason. Sibling pattern.
- **RFC-0077** (Implemented #15054) — write-side typed `Write_failure_reason.t`. Closest precedent in shape.
- **RFC-0088** (Active) — counter-as-fix → Result propagation umbrella.
- **RFC-0179** — descriptor ecosystem coverage (full keeper_* coverage merged 2026-05-26 #18710). With descriptors now routing 286 tools, the natural next step is for them to *speak* `(success, failure) result` natively. PR-1c unlocks that.

## Test plan

- [x] `dune build --root . lib/` passes
- [x] `dune exec --root . test/test_tool_result.exe` 20/20 PASS
- [ ] Reviewer: confirm `Log.warn` emission from `of_legacy` is acceptable on illegal-state legacy callers (alternative: silent default with a metric; RFC §4.2 traces the warn count as PR-1b lands)
- [ ] Reviewer: confirm PR-1b cluster ordering (boards → tasks → library/plan → run/misc → server → remaining) matches risk preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)