### PR TITLE
fix(dashboard): hide wake action for paused keepers

### DIFF
--- a/dashboard/src/components/keeper-action-panel.test.ts
+++ b/dashboard/src/components/keeper-action-panel.test.ts
@@ -59,6 +59,19 @@ describe('keeperActionVisibility', () => {
       const v = keeperActionVisibility(k)
       expect(v.canResume).toBe(true)
       expect(v.canPause).toBe(false)
+      expect(v.canWake).toBe(false)
+    })
+
+    it('does not show wake while paused even if a recoverable blocker is latched', () => {
+      const k = makeKeeper({
+        status: 'active',
+        phase: 'Paused',
+        paused: true,
+        runtime_blocker_class: 'turn_timeout',
+      })
+      const v = keeperActionVisibility(k)
+      expect(v.canResume).toBe(true)
+      expect(v.canWake).toBe(false)
     })
   })
 

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -35,7 +35,7 @@ import {
   isKeeperOperatorTargetable,
   isKeeperPaused,
   isKeeperRunningExcludingRestarting,
-  keeperIsStuckOnRecoverableBlocker,
+  keeperCanWakeup,
 } from '../lib/keeper-predicates'
 
 // ── Shared helpers ────────────────────────────────────────────────────────
@@ -101,14 +101,11 @@ export function keeperActionVisibility(keeper: Keeper): {
   const isPaused = isKeeperPaused(keeper)
   const isOffline = isKeeperOffline(keeper)
   const isRunning = isKeeperRunningExcludingRestarting(keeper)
-  // `restarting` is a kicked-but-not-yet-running state — treat as stuck
-  // so the wakeup action stays visible until the keeper resumes ticks.
-  const isStuck = keeper.phase === 'Restarting' || keeperIsStuckOnRecoverableBlocker(keeper)
 
   return {
     canPause:    isRunning && !isPaused,
     canResume:   isPaused,
-    canWake:     isStuck || (isRunning && !isPaused),
+    canWake:     keeperCanWakeup(keeper),
     canBoot:     isOffline,
     canShutdown: isRunning || isPaused,
   }

--- a/dashboard/src/lib/keeper-predicates.test.ts
+++ b/dashboard/src/lib/keeper-predicates.test.ts
@@ -145,6 +145,9 @@ describe('keeperCanWakeup', () => {
   it('paused keeper ⇒ cannot wake', () => {
     expect(keeperCanWakeup(k({ paused: true }))).toBe(false)
   })
+  it('paused keeper with recoverable blocker ⇒ cannot wake', () => {
+    expect(keeperCanWakeup(k({ paused: true, runtime_blocker_class: 'turn_timeout' }))).toBe(false)
+  })
   it('offline keeper ⇒ cannot wake', () => {
     expect(keeperCanWakeup(k({ phase: 'Crashed' }))).toBe(false)
   })

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -151,8 +151,9 @@ export function keeperIsStuckOnRecoverableBlocker(keeper: Keeper): boolean {
  *  recoverable blocker classes *or* it is in a non-paused, non-offline
  *  state where the operator may want to kick the next turn. */
 export function keeperCanWakeup(keeper: Keeper): boolean {
+  if (isKeeperPaused(keeper) || isKeeperOffline(keeper)) return false
   if (keeperIsStuckOnRecoverableBlocker(keeper)) return true
-  return !isKeeperPaused(keeper) && !isKeeperOffline(keeper)
+  return true
 }
 
 /** Operator-facing target lists must keep paused keepers selectable so


### PR DESCRIPTION
## Summary
- make paused/offline keepers ineligible for the wake action before checking recoverable blockers
- route keeper action visibility through keeperCanWakeup so paused rows consistently show resume/shutdown only
- add regression coverage for paused keepers with latched recoverable blockers

## Verification
- git diff --check
- pnpm --dir dashboard exec vitest run src/components/keeper-action-panel.test.ts src/lib/keeper-predicates.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty