### PR TITLE
refactor(keeper): remove unwired phantom deliberation actions

### DIFF
--- a/config/prompts/keeper.deliberation.md
+++ b/config/prompts/keeper.deliberation.md
@@ -21,13 +21,9 @@ Available actions (pick exactly one):
 - board_post: Post to the community board. Requires content and optional hearth.
 - board_comment: Comment on a board post. Requires post_id and content.
 - board_vote: Vote on a board post. Requires post_id and direction (up/down).
-- start_discussion: Start a new discussion thread on the board. Requires topic and context.
-- share_finding: Share a discovery or insight on the board. Requires finding and source.
-- create_task: Create a new task for the team. Requires title, description, and priority (1-5).
-- create_issue: Create a GitHub issue. Requires title, body, and labels array.
 - propose_spawn: Propose spawning a new agent. Requires topic and reason.{{multi_step_line}}
 
-When self_directed_explore triggers, prefer actions that create value: share_finding, start_discussion, board_post, or create_task. Avoid noop unless truly nothing is worth doing.
+When self_directed_explore triggers, prefer actions that create value: board_post, board_comment, or broadcast. Avoid noop unless truly nothing is worth doing. (To create a task, call the `keeper_task_create` tool directly in your next turn — it is not a deliberation action.)
 
 Respond with ONLY the tool input object for schema `keeper_deliberation_decision` in this exact shape:
 {"action":"<action_name>","params":{<action_specific_params>},"reasoning":"<brief_explanation>","confidence":<0.0_to_1.0>}
@@ -37,5 +33,4 @@ Examples:
 {"action":"reply_in_room","params":{"room_id":"default","content":"I see a new task available."},"reasoning":"Direct mention in the namespace conversation needs a reply","confidence":0.8}
 {"action":"task_claim","params":{"task_id":"task-123","reason":"Matches my goal"},"reasoning":"Unclaimed task aligns with keeper goal","confidence":0.7}
 {"action":"broadcast","params":{"message":"Status update: monitoring active goals"},"reasoning":"Team needs coordination update","confidence":0.6}
-{"action":"share_finding","params":{"finding":"Noticed recurring pattern in board posts about memory search quality","source":"board_scan"},"reasoning":"Self-directed exploration found a pattern worth sharing","confidence":0.65}
-{"action":"start_discussion","params":{"topic":"Should we add proactive code review to keeper capabilities?","context":"Multiple keepers have coding presets but rarely use them autonomously"},"reasoning":"Board activity suggests this is a relevant topic","confidence":0.6}{{multi_step_example}}
+{"action":"board_post","params":{"content":"Noticed recurring pattern in board posts about memory search quality","hearth":"observation"},"reasoning":"Self-directed exploration found a pattern worth sharing","confidence":0.65}{{multi_step_example}}

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -48,8 +48,6 @@ type deliberation_action =
   | TaskClaim of { task_id: string; reason: string }
   | Broadcast of { message: string }
   | ProposeSpawn of { topic: string; reason: string }
-  | StartDiscussion of { topic: string; context: string }
-  | ShareFinding of { finding: string; source: string }
   | MultiStep of deliberation_action list
 
 let rec deliberation_action_to_string = function
@@ -61,8 +59,6 @@ let rec deliberation_action_to_string = function
   | TaskClaim _ -> "task_claim"
   | Broadcast _ -> "broadcast"
   | ProposeSpawn _ -> "propose_spawn"
-  | StartDiscussion { topic; _ } -> "start_discussion:" ^ topic
-  | ShareFinding { finding; _ } -> "share_finding:" ^ finding
   | MultiStep actions ->
       "multi_step:["
       ^ String.concat "," (List.map deliberation_action_to_string actions)
@@ -78,8 +74,6 @@ let deliberation_action_to_policy_label = function
   | TaskClaim _ -> "task_claim"
   | Broadcast _ -> "broadcast"
   | ProposeSpawn _ -> "propose_spawn"
-  | StartDiscussion _ -> "start_discussion"
-  | ShareFinding _ -> "share_finding"
   | MultiStep _ -> "multi_step"
 
 let rec deliberation_action_to_json = function
@@ -131,20 +125,6 @@ let rec deliberation_action_to_json = function
           ("type", `String "propose_spawn");
           ("topic", `String topic);
           ("reason", `String reason);
-        ]
-  | StartDiscussion { topic; context } ->
-      `Assoc
-        [
-          ("type", `String "start_discussion");
-          ("topic", `String topic);
-          ("context", `String context);
-        ]
-  | ShareFinding { finding; source } ->
-      `Assoc
-        [
-          ("type", `String "share_finding");
-          ("finding", `String finding);
-          ("source", `String source);
         ]
   | MultiStep actions ->
       `Assoc
@@ -481,14 +461,6 @@ let rec legality_error (obs : world_observation) = function
       if obs.failed_task_count > 0 || obs.unclaimed_task_count > 0
          || obs.active_goal_count > 0 then None
       else Some "propose_spawn requires failed tasks, unclaimed tasks, or active goals"
-  | StartDiscussion _ ->
-      if has_board_signal obs || obs.active_goal_count > 0
-         || is_self_directed obs then None
-      else Some "start_discussion requires board activity, active goals, or self-directed context"
-  | ShareFinding _ ->
-      if has_board_signal obs || obs.active_goal_count > 0
-         || is_self_directed obs then None
-      else Some "share_finding requires board activity, active goals, or self-directed context"
   | MultiStep actions -> (
       match actions with
       | [] -> Some "multi_step requires non-empty steps"
@@ -720,7 +692,7 @@ let structured_result_schema : structured_result Agent_sdk.Structured.schema =
       [
         {
           Agent_sdk.Types.name = "action";
-          description = "One of: noop, reply_in_room, task_claim, broadcast, board_post, board_comment, board_vote, propose_spawn, start_discussion, share_finding, multi_step.";
+          description = "One of: noop, reply_in_room, task_claim, broadcast, board_post, board_comment, board_vote, propose_spawn, multi_step.";
           param_type = Agent_sdk.Types.String;
           required = true;
         };

--- a/lib/keeper/keeper_deliberation.mli
+++ b/lib/keeper/keeper_deliberation.mli
@@ -31,8 +31,6 @@ type deliberation_action =
   | TaskClaim of { task_id: string; reason: string }
   | Broadcast of { message: string }
   | ProposeSpawn of { topic: string; reason: string }
-  | StartDiscussion of { topic: string; context: string }
-  | ShareFinding of { finding: string; source: string }
   | MultiStep of deliberation_action list
 
 val deliberation_action_to_string : deliberation_action -> string

--- a/test/test_autonomy_liberation.ml
+++ b/test/test_autonomy_liberation.ml
@@ -185,31 +185,6 @@ let test_compose_available_tools () =
   Alcotest.(check bool) "has tool_a" true (contains_s result "tool_a");
   Alcotest.(check bool) "has tool_b" true (contains_s result "tool_b")
 
-(* ── Phase 5: Autonomous Collaboration ────────────────────────── *)
-
-let test_start_discussion_action () =
-  let action =
-    Keeper_deliberation.StartDiscussion
-      { topic = "architecture"; context = "reviewing module X" }
-  in
-  let s = Keeper_deliberation.deliberation_action_to_string action in
-  Alcotest.(check bool) "contains topic" true (contains_s s "architecture");
-  let policy_label = Keeper_deliberation.deliberation_action_to_policy_label action in
-  Alcotest.(check string) "policy label" "start_discussion" policy_label
-
-let test_share_finding_action () =
-  let action =
-    Keeper_deliberation.ShareFinding
-      { finding = "module Y has a race condition"; source = "code review" }
-  in
-  let json = Keeper_deliberation.deliberation_action_to_json action in
-  let open Yojson.Safe.Util in
-  let typ = json |> member "type" |> to_string in
-  Alcotest.(check string) "json type" "share_finding" typ;
-  let finding_val = json |> member "finding" |> to_string in
-  Alcotest.(check bool) "json finding" true
-    (contains_s finding_val "race condition")
-
 (* ── Phase 2 Integration: End-to-End Wiring ─────────────────── *)
 
 let test_autonomous_tool_count () =
@@ -334,12 +309,6 @@ let () =
             test_compose_empty_sections_omitted;
           Alcotest.test_case "available tools" `Quick
             test_compose_available_tools;
-        ] );
-      ( "phase5_collaboration",
-        [
-          Alcotest.test_case "start discussion" `Quick
-            test_start_discussion_action;
-          Alcotest.test_case "share finding" `Quick test_share_finding_action;
         ] );
       ( "phase2_integration",
         [

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -996,32 +996,6 @@ let test_legality_self_directed_allows_board_post () =
   | D.Legal -> ()
   | D.Illegal msg -> fail ("board_post should be legal in self-directed: " ^ msg)
 
-let test_legality_self_directed_allows_share_finding () =
-  let obs =
-    { base_obs with
-      active_goal_count = 0;
-      idle_seconds = 1300;
-      idle_gate = 300;
-    }
-  in
-  match D.legality_verdict obs
-    (D.ShareFinding { finding = "test"; source = "board_scan" }) with
-  | D.Legal -> ()
-  | D.Illegal msg -> fail ("share_finding should be legal in self-directed: " ^ msg)
-
-let test_legality_self_directed_allows_start_discussion () =
-  let obs =
-    { base_obs with
-      active_goal_count = 0;
-      idle_seconds = 1300;
-      idle_gate = 300;
-    }
-  in
-  match D.legality_verdict obs
-    (D.StartDiscussion { topic = "test topic"; context = "exploring" }) with
-  | D.Legal -> ()
-  | D.Illegal msg -> fail ("start_discussion should be legal in self-directed: " ^ msg)
-
 let test_legality_not_self_directed_rejects_board_post () =
   (* Without self-directed context (idle too short), board_post is still illegal *)
   let obs =
@@ -1239,10 +1213,6 @@ let () =
         [
           test_case "self-directed allows board_post" `Quick
             test_legality_self_directed_allows_board_post;
-          test_case "self-directed allows share_finding" `Quick
-            test_legality_self_directed_allows_share_finding;
-          test_case "self-directed allows start_discussion" `Quick
-            test_legality_self_directed_allows_start_discussion;
           test_case "not self-directed rejects board_post" `Quick
             test_legality_not_self_directed_rejects_board_post;
         ] );


### PR DESCRIPTION
## Summary

The deliberation prompt advertised four actions (`start_discussion`, `share_finding`, `create_task`, `create_issue`) that the JSON parser silently rejected with `unknown action type`. Runtime evidence across **17 keeper decision logs in `~/me/.masc`** confirms **0 selections** for all four vs **400+** for `board_post` — they were dead intent the whole time, and `board_post` is the working semantic equivalent in practice.

## What changed

- **Variants removed** from `keeper_deliberation.{ml,mli}`: `StartDiscussion`, `ShareFinding` (type, `deliberation_action_to_string`, `deliberation_action_to_policy_label`, JSON emission, legality check, schema description)
- **Prompt** `config/prompts/keeper.deliberation.md`: removed 4 phantom actions + 2 example entries; updated `self_directed_explore` recommendation to point at actually-handled actions; added one-line redirect for task creation
- **Tests**: removed `test_legality_self_directed_allows_share_finding`, `test_legality_self_directed_allows_start_discussion` (test_keeper_deliberation.ml) and `test_start_discussion_action`, `test_share_finding_action` (test_autonomy_liberation.ml) plus their registrations

Net: **5 files changed, +3/-99 lines**.

## Why this is the right cleanup

The four phantom actions were a textbook §2 unknown→permissive default pattern (CLAUDE.md): prompt told the LLM to use them, parser rejected with logged error, turn continued via baseline fallback — so 0-selection was invisible to operators. `create_task` was structurally wrong anyway because `keeper_task_create` is already a real MCP tool; `create_issue` had no equivalent at any layer.

Activating the two variants that *had* full wiring (`StartDiscussion`/`ShareFinding`) was considered but rejected: the runtime data shows `board_post` is already absorbing 100% of "share to community board" intent across 17 keepers. Adding two more semantically-overlapping actions with 0 historical selections would create new drift surface without operational gain.

## Test plan

- [x] `dune build --root .` clean (test/ + lib/keeper/)
- [x] `_build/default/test/test_keeper_deliberation.exe` — 81 OK (was 83, removed 2 now-impossible legality cases)
- [x] `_build/default/test/test_autonomy_liberation.exe` — 14 OK (was 16, removed 2 now-impossible phase5 cases)
- [x] Sweep `StartDiscussion|ShareFinding` across `lib/ test/ dashboard/ bin/` → 0 references after change
- [ ] CI green

## Drift origin analysis

Prompt and parser were authored separately without an enforcement loop — the verifier/anti-rationalization paths have tight reject/retry that forces prompt-code co-evolution, but deliberation's unknown-action handler just logged and continued. This made the drift cost-free in practice but the phantom advertisements remained for the LLM to keep trying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)