### PR TITLE
feat(agent-tool): summarize descriptors in execution receipts

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -77,6 +77,110 @@ let string_contains_ci haystack needle =
   loop 0
 ;;
 
+let descriptor_for_tool_name tool_name =
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
+  match Agent_tool_descriptor.find_public stripped with
+  | Some descriptor -> Some descriptor
+  | None ->
+    let internal_name =
+      match Keeper_tool_alias.canonical_internal_name tool_name with
+      | Some internal_name -> internal_name
+      | None -> stripped
+    in
+    (match Agent_tool_descriptor.descriptors_for_internal internal_name with
+     | descriptor :: _ -> Some descriptor
+     | [] -> None)
+;;
+
+let dedupe_descriptors descriptors =
+  descriptors
+  |> List.fold_left
+       (fun (seen, acc) (descriptor : Agent_tool_descriptor.t) ->
+          if List.mem descriptor.id seen
+          then seen, acc
+          else descriptor.id :: seen, descriptor :: acc)
+       ([], [])
+  |> snd
+  |> List.rev
+;;
+
+let bump_count name counts =
+  let rec loop prefix = function
+    | [] -> List.rev ((name, 1) :: prefix)
+    | (existing, count) :: rest when String.equal existing name ->
+      List.rev_append prefix ((existing, count + 1) :: rest)
+    | item :: rest -> loop (item :: prefix) rest
+  in
+  loop [] counts
+;;
+
+let count_json values =
+  values
+  |> List.map (fun (name, count) ->
+    `Assoc [ "name", `String name; "count", `Int count ])
+  |> fun values -> `List values
+;;
+
+let count_descriptors ~f descriptors =
+  descriptors
+  |> List.fold_left
+       (fun counts descriptor -> bump_count (f descriptor) counts)
+       []
+  |> count_json
+;;
+
+let policy_decision_failed receipt =
+  let candidates =
+    [ receipt.terminal_reason_code
+    ; Option.value
+        (Option.map error_kind_to_string receipt.error_kind)
+        ~default:""
+    ; Option.value receipt.error_message ~default:""
+    ]
+  in
+  List.exists
+    (fun value ->
+       string_contains_ci value "policy_denied"
+       || string_contains_ci value "denied_by_policy"
+       || string_contains_ci value "approval_required"
+       || string_contains_ci value "governance_approval")
+    candidates
+;;
+
+let tool_descriptor_summary_json receipt =
+  let descriptors =
+    receipt.observed_tools
+    @ receipt.canonical_tools
+    @ receipt.tools_used
+    @ receipt.reported_tools
+    |> List.filter_map descriptor_for_tool_name
+    |> dedupe_descriptors
+  in
+  `Assoc
+    [ "source", `String "receipt_tool_sets"
+    ; ( "observed_descriptor_ids"
+      , list_json (List.map (fun (d : Agent_tool_descriptor.t) -> d.id) descriptors) )
+    ; "descriptor_count", `Int (List.length descriptors)
+    ; ( "executor_counts"
+      , count_descriptors
+          ~f:(fun (d : Agent_tool_descriptor.t) ->
+            Agent_tool_descriptor.executor_to_string d.executor)
+          descriptors )
+    ; ( "backend_counts"
+      , count_descriptors
+          ~f:(fun (d : Agent_tool_descriptor.t) ->
+            Agent_tool_descriptor.backend_to_string d.backend)
+          descriptors )
+    ; ( "sandbox_counts"
+      , count_descriptors
+          ~f:(fun (d : Agent_tool_descriptor.t) ->
+            Agent_tool_descriptor.sandbox_to_string d.sandbox)
+          descriptors )
+    ; ( "failed_policy_decision_count"
+      , `Int (if policy_decision_failed receipt then 1 else 0) )
+    ]
+;;
+
 (* Cycle 51 observability: alert when [operator_disposition] cannot
    classify a receipt and falls through to the catch-all
    [(Disp_unknown, Reason_unmapped_cascade_state)].
@@ -472,6 +576,7 @@ let to_json (receipt : t) =
     ; "canonical_tools", list_json receipt.canonical_tools
     ; "unexpected_tools", list_json receipt.unexpected_tools
     ; "tools_used", list_json receipt.tools_used
+    ; "tool_descriptor_summary", tool_descriptor_summary_json receipt
     ; ( "tool_contract_result"
       , `String (tool_contract_result_to_string receipt.tool_contract_result) )
     ; ( "tool_surface"

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -7,6 +7,7 @@
 module Alias = Masc_mcp.Keeper_tool_alias
 module Descriptor = Masc_mcp.Agent_tool_descriptor
 module Observation = Masc_mcp.Keeper_tool_observation
+module Receipt = Masc_mcp.Keeper_execution_receipt
 module Resolution = Masc_mcp.Keeper_tool_resolution
 module Runtime = Masc_mcp.Agent_tool_runtime
 
@@ -399,6 +400,23 @@ let yojson_bool_field name j =
   | _ -> None
 ;;
 
+let yojson_int_field name j =
+  match yojson_field name j with
+  | Some (`Int n) -> Some n
+  | Some (`Intlit s) -> (try Some (int_of_string s) with _ -> None)
+  | _ -> None
+;;
+
+let count_bucket name json =
+  match
+    json
+    |> Yojson.Safe.Util.to_list
+    |> List.find_opt (fun item -> yojson_string_field "name" item = Some name)
+  with
+  | Some item -> yojson_int_field "count" item
+  | None -> None
+;;
+
 let test_descriptor_route_evidence_names_policy_backend_sandbox_and_description () =
   let execute =
     match Descriptor.find_public "Execute" with
@@ -462,6 +480,123 @@ let test_descriptor_route_evidence_names_policy_backend_sandbox_and_description 
        true
        (String.starts_with ~prefix:"Execute one typed command" description)
    | None -> Alcotest.fail "description missing")
+;;
+
+let test_execution_receipt_descriptor_summary_projects_descriptors () =
+  let receipt : Receipt.t =
+    { keeper_name = "descriptor_keeper"
+    ; agent_name = "descriptor_agent"
+    ; trace_id = "trace-descriptor-summary"
+    ; generation = 1
+    ; turn_count = Some 7
+    ; oas_turn_count = None
+    ; oas_dispatch_mode = None
+    ; oas_internal_cascade_disabled = false
+    ; current_task_id = None
+    ; goal_ids = []
+    ; outcome = `Error
+    ; terminal_reason_code = "policy_denied:approval_required"
+    ; response_text_present = false
+    ; model_used = None
+    ; requested_tools = [ "ReadFile"; "Execute"; "keeper_time_now" ]
+    ; reported_tools = [ "ReadFile" ]
+    ; observed_tools = [ "tool_read_file"; "keeper_time_now" ]
+    ; canonical_tools = [ "tool_read_file"; "tool_execute"; "keeper_time_now" ]
+    ; unexpected_tools = []
+    ; tools_used = [ "tool_execute" ]
+    ; tool_contract_result = Receipt.Contract_violated
+    ; tool_surface =
+        { turn_lane = Masc_mcp.Keeper_agent_tool_surface.Lane_tool_required
+        ; tool_surface_class = Masc_mcp.Keeper_agent_tool_surface.Surface_mixed
+        ; tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Required
+        ; visible_tool_count = 3
+        ; tool_gate_enabled = true
+        ; tool_surface_fallback_used = false
+        ; required_tools = [ "tool_execute" ]
+        ; required_tool_candidates = [ "tool_execute" ]
+        ; missing_required_tools = []
+        ; materialized_tools = [ "tool_read_file"; "tool_execute"; "keeper_time_now" ]
+        }
+    ; sandbox_kind = Masc_mcp.Keeper_types.Local
+    ; sandbox_root = None
+    ; network_mode = Masc_mcp.Keeper_types.Network_none
+    ; approval_profile = Some "manual"
+    ; approval_profile_derived = false
+    ; cascade_name = Cascade_name.of_string_exn "tier.test"
+    ; cascade_selected_model = None
+    ; cascade_attempt_count = 0
+    ; cascade_fallback_applied = false
+    ; cascade_outcome = Receipt.Cascade_not_dispatched
+    ; oas_internal_cascade_allowed = false
+    ; degraded_retry_applied = false
+    ; degraded_retry_cascade = None
+    ; fallback_reason = None
+    ; cascade_rotation_attempts = []
+    ; stop_reason = None
+    ; error_kind = Some (Receipt.error_kind_of_string "policy")
+    ; error_message = None
+    ; started_at = "2026-05-26T00:00:00Z"
+    ; ended_at = "2026-05-26T00:00:01Z"
+    ; extra_system_context_digest = None
+    ; extra_system_context_injected_size = None
+    ; extra_system_context_computed_size = None
+    ; pre_dispatch_compacted = false
+    ; pre_dispatch_compaction_trigger = None
+    ; pre_dispatch_compaction_before_tokens = None
+    ; pre_dispatch_compaction_after_tokens = None
+    }
+  in
+  let summary =
+    Receipt.to_json receipt
+    |> Yojson.Safe.Util.member "tool_descriptor_summary"
+  in
+  Alcotest.(check (option string))
+    "summary source"
+    (Some "receipt_tool_sets")
+    (yojson_string_field "source" summary);
+  Alcotest.(check (list string))
+    "observed descriptor ids"
+    [ "agent.read_file"; "keeper.time.now"; "agent.execute" ]
+    Yojson.Safe.Util.(
+      summary |> member "observed_descriptor_ids" |> to_list |> List.map to_string);
+  Alcotest.(check (option int))
+    "descriptor count"
+    (Some 3)
+    (yojson_int_field "descriptor_count" summary);
+  Alcotest.(check (option int))
+    "filesystem executor count"
+    (Some 1)
+    Yojson.Safe.Util.(summary |> member "executor_counts" |> count_bucket "filesystem");
+  Alcotest.(check (option int))
+    "in-process executor count"
+    (Some 1)
+    Yojson.Safe.Util.(summary |> member "executor_counts" |> count_bucket "in_process");
+  Alcotest.(check (option int))
+    "shell executor count"
+    (Some 1)
+    Yojson.Safe.Util.(summary |> member "executor_counts" |> count_bucket "shell_ir");
+  Alcotest.(check (option int))
+    "sandbox backend count"
+    (Some 2)
+    Yojson.Safe.Util.(
+      summary |> member "backend_counts" |> count_bucket "sandbox_process");
+  Alcotest.(check (option int))
+    "ocaml backend count"
+    (Some 1)
+    Yojson.Safe.Util.(summary |> member "backend_counts" |> count_bucket "ocaml_runtime");
+  Alcotest.(check (option int))
+    "backend-selected sandbox count"
+    (Some 2)
+    Yojson.Safe.Util.(
+      summary |> member "sandbox_counts" |> count_bucket "backend_selected");
+  Alcotest.(check (option int))
+    "no sandbox count"
+    (Some 1)
+    Yojson.Safe.Util.(summary |> member "sandbox_counts" |> count_bucket "none");
+  Alcotest.(check (option int))
+    "failed policy decision count"
+    (Some 1)
+    (yojson_int_field "failed_policy_decision_count" summary)
 ;;
 
 let test_agent_tool_runtime_resolves_descriptor_handlers () =
@@ -1003,6 +1138,10 @@ let () =
             "descriptor evidence names policy route"
             `Quick
             test_descriptor_route_evidence_names_policy_backend_sandbox_and_description
+        ; Alcotest.test_case
+            "execution receipt descriptor summary projects descriptors"
+            `Quick
+            test_execution_receipt_descriptor_summary_projects_descriptors
         ; Alcotest.test_case
             "agent tool runtime resolves descriptor handlers"
             `Quick


### PR DESCRIPTION
## Summary
- add a descriptor-backed `tool_descriptor_summary` projection to keeper execution receipts
- summarize observed descriptor ids plus executor/backend/sandbox counts from receipt tool sets
- surface a receipt-level failed policy decision count from terminal policy/approval denial signals

## Verification
- ocamlformat --check lib/keeper/keeper_execution_receipt.ml test/test_keeper_tool_alias.ml
- git diff --check origin/main...HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_keeper_tool_alias.exe
- ./_build/default/test/test_keeper_tool_alias.exe
