### PR TITLE
refactor(auth): purge tool permission fallback table

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 20:06:32 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 20:30:30 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -679,9 +679,15 @@
           </tr>
           <tr>
             <td>Memory/context canonical row purge</td>
-            <td><span class="status now">active branch</span></td>
+            <td><span class="status done">merged #18717</span></td>
             <td>Remove memory search source fallback to <code>memory</code>, drop old memory-bank rows without current schema/horizon/provenance fields, and stop rewriting legacy duplicate procedural records during OAS flush.</td>
-            <td>Branch <code>refactor/purge-memory-context-fallbacks-20260526</code>. Compatibility-preservation tests for legacy procedure dedupe are deleted; current-schema tests now seed canonical rows only.</td>
+            <td>Merged as <code>45728f4c0</code>. Compatibility-preservation tests for legacy procedure dedupe are deleted; current-schema tests now seed canonical rows only.</td>
+          </tr>
+          <tr>
+            <td>Tool catalog fallback tables</td>
+            <td><span class="status now">active branch</span></td>
+            <td>Delete the auth fallback permission table and promote live tool permissions into catalog-owned metadata and schema registration.</td>
+            <td>Branch <code>refactor/purge-tool-catalog-fallbacks-20260526</code>. Deleted-only names such as <code>masc_policy_approve</code> and <code>masc_observe_*</code> are not reintroduced as catalog permissions.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
@@ -717,13 +723,20 @@
         <tbody>
           <tr>
             <td>P2</td>
-            <td>Tool catalog fallback tables</td>
-            <td>Tool permission/help/catalog fallbacks still let deleted or unmodeled tool metadata survive outside the canonical catalog, making surface audits noisy.</td>
-            <td>Move remaining callers to catalog-owned structured metadata and delete fallback rows that only preserve old names or inferred descriptions.</td>
-            <td>Replace fallback-preservation tests with catalog absence checks and explicit unknown-tool rejection tests.</td>
+            <td>SDK/transport command-plane operation residue</td>
+            <td>Deleted command-plane names such as <code>masc_policy_*</code>, <code>masc_observe_*</code>, <code>decision_*</code>, and <code>masc_execution_orders</code> still appear in SDK/transport contract lists and old docs without matching active tool schemas.</td>
+            <td>Remove dead operation names from SDK/transport contract expansion and rewrite command-plane docs around the active operator/goal surfaces.</td>
+            <td>Contract tests should assert deleted names are absent instead of preserving remote-operation compatibility.</td>
           </tr>
           <tr>
-            <td>P3</td>
+            <td>P2</td>
+            <td>Dashboard meta-cognition last-good fallback cache</td>
+            <td>The dashboard summary cache still describes last-good fallback tables, which can mask failed summary generation and keep stale shell state looking intentional.</td>
+            <td>Replace fallback reuse with explicit stale/error states, or delete the cache if current callers can tolerate direct failure reporting.</td>
+            <td>Replace last-good fallback tests with stale/error-state assertions.</td>
+          </tr>
+          <tr>
+            <td>P4</td>
             <td>Docs/comments for deleted facades</td>
             <td>Comments that describe removed compatibility layers make readers think the old path still exists and cause false positives in audits.</td>
             <td>Rewrite as current-contract notes or delete. Keep this separate from runtime purges unless a stale comment directly blocks a guard.</td>

--- a/lib/tool_access_role.ml
+++ b/lib/tool_access_role.ml
@@ -18,8 +18,7 @@ module Float = Stdlib.Float
 (** Tool_access_role — Role-based tool access policy builder.
 
     Derived mechanically from Tool_permission_map.permission_for_tool, which
-    already respects Tool_catalog-declared required_permission metadata before
-    falling back to auth fallback mappings.
+    reads Tool_catalog-declared required_permission metadata.
 
     Each tool's required permission determines which role tier it belongs to:
     - Worker tier: CanReadState, CanJoin, CanLeave, CanAddTask, CanClaimTask,

--- a/lib/tool_access_role.mli
+++ b/lib/tool_access_role.mli
@@ -5,8 +5,7 @@
     Tool_access_policy.t that determines which tools the role can invoke.
 
     The role policy is derived from [Tool_permission_map.permission_for_tool], so
-    Tool_catalog-declared required_permission metadata and auth-layer
-    fallbacks stay aligned instead of maintaining a second hardcoded tool list.
+    Tool_catalog-declared required_permission metadata is the role-policy SSOT.
 
     @since 2.204.0 — Phase 0 of Tool Gate architecture (#4381) *)
 

--- a/lib/tool_board_dispatch.ml
+++ b/lib/tool_board_dispatch.ml
@@ -123,7 +123,9 @@ let register () =
     | "masc_board_search"
     | "masc_board_profile"
     | "masc_board_hearths"
-    | "masc_board_curation_read" -> Some Masc_domain.CanReadState
+    | "masc_board_curation_read"
+    | "masc_board_sub_board_list"
+    | "masc_board_sub_board_get" -> Some Masc_domain.CanReadState
     | "masc_board_post"
     | "masc_board_comment"
     | "masc_board_vote"

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -170,6 +170,42 @@ let masc_coordination_tool =
 let actor_bound_masc_coordination_tool =
   with_semantic_flags ~requires_actor_binding:true masc_coordination_tool
 
+let with_required_permission permission meta =
+  { meta with required_permission = Some permission }
+
+let read_state_tool =
+  with_required_permission Masc_domain.CanReadState readonly_tool
+
+let broadcast_tool =
+  with_required_permission Masc_domain.CanBroadcast masc_coordination_tool
+
+let actor_broadcast_tool =
+  with_required_permission Masc_domain.CanBroadcast actor_bound_masc_coordination_tool
+
+let add_task_tool =
+  with_required_permission Masc_domain.CanAddTask masc_coordination_tool
+
+let claim_task_tool =
+  with_required_permission Masc_domain.CanClaimTask actor_bound_masc_coordination_tool
+
+let complete_task_tool =
+  with_required_permission Masc_domain.CanCompleteTask actor_bound_masc_coordination_tool
+
+let join_tool =
+  with_required_permission Masc_domain.CanJoin actor_bound_masc_coordination_tool
+
+let leave_tool =
+  with_required_permission Masc_domain.CanLeave actor_bound_masc_coordination_tool
+
+let admin_tool =
+  with_required_permission Masc_domain.CanAdmin destructive_tool
+
+let admin_read_tool =
+  with_required_permission Masc_domain.CanAdmin readonly_tool
+
+let reset_tool =
+  with_required_permission Masc_domain.CanReset destructive_tool
+
 (* ================================================================ *)
 (* Explicit metadata registry                                       *)
 (* ================================================================ *)
@@ -184,47 +220,37 @@ let explicit_metadata : (string * metadata) list =
        #4709/#4734), operator_judgment_latest, hat_wear, hat_status,
        encryption_*, generate_key, tempo*, cost_log, cost_report (#4709/#4757). *)
     (* Semantic annotations for governance risk classification. *)
-    ("masc_status", readonly_tool);
-    ("masc_tasks", readonly_tool);
-    ("masc_messages", readonly_tool);
-    ("masc_who", readonly_tool);
-    ("masc_agents", readonly_tool);
-    ( "masc_agent_card",
-      { readonly_tool with required_permission = Some Masc_domain.CanReadState } );
-    ("masc_dashboard", readonly_tool);
-    ("masc_board_list", readonly_tool);
-    ("masc_board_get", readonly_tool);
-    ( "masc_board_curation_read",
-      { readonly_tool with required_permission = Some Masc_domain.CanReadState } );
+    ("masc_status", read_state_tool);
+    ("masc_tasks", read_state_tool);
+    ("masc_messages", read_state_tool);
+    ("masc_who", read_state_tool);
+    ("masc_agents", read_state_tool);
+    ("masc_agent_card", read_state_tool);
+    ("masc_dashboard", read_state_tool);
+    ("masc_board_list", read_state_tool);
+    ("masc_board_get", read_state_tool);
+    ("masc_board_curation_read", read_state_tool);
     ( "masc_board_curation_submit",
-      { actor_bound_masc_coordination_tool with required_permission = Some Masc_domain.CanBroadcast } );
-    ("masc_tool_help", readonly_tool);
-    ("masc_keeper_list", readonly_tool);
-    ("masc_keeper_status", readonly_tool);
-    ("masc_keeper_persona_audit", readonly_tool);
-    ("masc_plan_get", readonly_tool);
-    ( "masc_join",
-      { actor_bound_masc_coordination_tool with required_permission = Some Masc_domain.CanJoin } );
-    ( "masc_leave",
-      { actor_bound_masc_coordination_tool with required_permission = Some Masc_domain.CanLeave } );
-    ("masc_claim_next", actor_bound_masc_coordination_tool);
-    ("masc_transition", actor_bound_masc_coordination_tool);
-    ("masc_plan_set_task", actor_bound_masc_coordination_tool);
-    ( "masc_broadcast",
-      { masc_coordination_tool with required_permission = Some Masc_domain.CanBroadcast } );
-    ( "masc_messages",
-      { readonly_tool with required_permission = Some Masc_domain.CanReadState } );
-    ( "masc_who",
-      { readonly_tool with required_permission = Some Masc_domain.CanReadState } );
-    ( "channel_gate",
-      { masc_coordination_tool with required_permission = Some Masc_domain.CanBroadcast } );
+      actor_broadcast_tool );
+    ("masc_tool_help", read_state_tool);
+    ("masc_keeper_list", read_state_tool);
+    ("masc_keeper_status", read_state_tool);
+    ("masc_keeper_persona_audit", read_state_tool);
+    ("masc_plan_get", read_state_tool);
+    ("masc_join", join_tool);
+    ("masc_leave", leave_tool);
+    ("masc_claim_next", claim_task_tool);
+    ("masc_transition", complete_task_tool);
+    ("masc_plan_set_task", actor_broadcast_tool);
+    ("masc_broadcast", broadcast_tool);
+    ("channel_gate", broadcast_tool);
     ( "masc_portal_open",
       { masc_coordination_tool with required_permission = Some Masc_domain.CanOpenPortal } );
     ( "masc_portal_close",
       { masc_coordination_tool with required_permission = Some Masc_domain.CanOpenPortal } );
     ( "masc_portal_send",
       { masc_coordination_tool with required_permission = Some Masc_domain.CanSendPortal } );
-    (* masc_run_get, masc_run_list: migrated to Tool_spec.register (tool_run.ml) *)
+    (* Run schemas register from tool_run.ml; catalog still owns early auth metadata. *)
     ("masc_execute_dry_run", readonly_tool);
     ( "masc_admin_cleanup",
       with_semantic_flags ~destructive:true
@@ -243,7 +269,9 @@ let explicit_metadata : (string * metadata) list =
         (hidden_active "Forced membership removal mutates namespace state and should be treated as destructive.") );
     ( "masc_operator_action",
       with_semantic_flags ~destructive:true
-        (hidden_active "Operator actions can execute privileged side effects and should be treated as destructive.") );
+        { (hidden_active "Operator actions can execute privileged side effects and should be treated as destructive.") with
+          required_permission = Some Masc_domain.CanBroadcast;
+        } );
     ( "masc_set_param",
       {
         (with_semantic_flags ~destructive:true
@@ -255,15 +283,90 @@ let explicit_metadata : (string * metadata) list =
     ( "masc_execute",
       with_semantic_flags ~destructive:true
         (hidden_active "Direct execution can apply privileged side effects and should be treated as destructive.") );
-    ("masc_tool_grant", destructive_tool);
-    ("masc_tool_revoke", destructive_tool);
-    ( "masc_keeper_reset",
-      { masc_coordination_tool with required_permission = Some Masc_domain.CanBroadcast } );
-    ( "masc_keeper_compact",
-      { masc_coordination_tool with required_permission = Some Masc_domain.CanBroadcast } );
+    ("masc_tool_grant", admin_tool);
+    ("masc_tool_revoke", admin_tool);
+    ("masc_keeper_reset", broadcast_tool);
+    ("masc_keeper_compact", broadcast_tool);
     ( "masc_keeper_clear",
       with_semantic_flags ~destructive:true
-        { masc_coordination_tool with required_permission = Some Masc_domain.CanBroadcast } );
+        broadcast_tool );
+    (* Catalog-owned permissions for split/lazily registered tool modules. *)
+    ("masc_reset", reset_tool);
+    ("masc_start", join_tool);
+    ("masc_task_history", read_state_tool);
+    ("masc_add_task", add_task_tool);
+    ("masc_batch_add_tasks", add_task_tool);
+    ("masc_update_priority", complete_task_tool);
+    ("masc_heartbeat", actor_broadcast_tool);
+    ("masc_goal_list", read_state_tool);
+    ("masc_goal_upsert", broadcast_tool);
+    ("masc_goal_transition", broadcast_tool);
+    ("masc_goal_verify", broadcast_tool);
+    ("masc_plan_init", broadcast_tool);
+    ("masc_plan_update", broadcast_tool);
+    ("masc_plan_get_task", read_state_tool);
+    ("masc_plan_clear_task", actor_broadcast_tool);
+    ("masc_note_add", broadcast_tool);
+    ("masc_deliver", broadcast_tool);
+    ("masc_config", read_state_tool);
+    ("masc_check", read_state_tool);
+    ("masc_web_search", read_state_tool);
+    ("masc_web_fetch", read_state_tool);
+    ("masc_approval_pending", read_state_tool);
+    ("masc_approval_get", admin_read_tool);
+    ("masc_approval_resolve", admin_tool);
+    ("masc_agent_fitness", read_state_tool);
+    ("masc_agent_timeline", read_state_tool);
+    ("masc_agent_update", broadcast_tool);
+    ("masc_spawn", broadcast_tool);
+    ("masc_get_metrics", read_state_tool);
+    ("masc_operator_snapshot", read_state_tool);
+    ("masc_operator_digest", read_state_tool);
+    ("masc_operator_confirm", actor_broadcast_tool);
+    ("masc_surface_audit", read_state_tool);
+    ("masc_persona_list", read_state_tool);
+    ("masc_persona_schema", read_state_tool);
+    ("masc_persona_generate", broadcast_tool);
+    ("masc_persona_save", broadcast_tool);
+    ("masc_keeper_create_from_persona", broadcast_tool);
+    ("masc_keeper_up", broadcast_tool);
+    ("masc_keeper_down", broadcast_tool);
+    ("masc_keeper_msg", broadcast_tool);
+    ("masc_keeper_msg_result", broadcast_tool);
+    ("masc_keeper_repair", broadcast_tool);
+    ("masc_keeper_sandbox_status", read_state_tool);
+    ("masc_keeper_sandbox_start", broadcast_tool);
+    ("masc_keeper_sandbox_stop", broadcast_tool);
+    ("masc_runtime_verify", read_state_tool);
+    ("masc_runtime_ollama_probe", read_state_tool);
+    ("masc_cleanup_zombies", broadcast_tool);
+    ("masc_board_hearths", read_state_tool);
+    ("masc_board_search", read_state_tool);
+    ("masc_board_profile", read_state_tool);
+    ("masc_board_stats", read_state_tool);
+    ("masc_board_sub_board_list", read_state_tool);
+    ("masc_board_sub_board_get", read_state_tool);
+    ("masc_board_post", broadcast_tool);
+    ("masc_board_comment", broadcast_tool);
+    ("masc_board_vote", broadcast_tool);
+    ("masc_board_comment_vote", broadcast_tool);
+    ("masc_board_reaction", broadcast_tool);
+    ("masc_board_sub_board_create", broadcast_tool);
+    ("masc_board_sub_board_update", broadcast_tool);
+    ("masc_board_sub_board_delete", broadcast_tool);
+    ("masc_board_delete", admin_tool);
+    ("masc_tool_stats", read_state_tool);
+    ("masc_tool_list", read_state_tool);
+    ("masc_tool_admin_snapshot", admin_read_tool);
+    ("masc_tool_admin_update", admin_tool);
+    ("masc_pause", broadcast_tool);
+    ("masc_resume", broadcast_tool);
+    ("masc_run_get", read_state_tool);
+    ("masc_run_list", read_state_tool);
+    ("masc_run_init", broadcast_tool);
+    ("masc_run_plan", broadcast_tool);
+    ("masc_run_log", broadcast_tool);
+    ("masc_run_deliverable", broadcast_tool);
     ( "sidecar",
       {
         destructive_tool with

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -17,113 +17,10 @@ module Float = Stdlib.Float
 
 (** Tool_permission_map — Shared tool→permission resolution. *)
 
-open Masc_domain
-
 let declared_permission_for_tool tool_name =
   match Tool_catalog.registered_metadata tool_name with
   | Some meta -> meta.required_permission
   | None -> None
-;;
-
-let fallback_permission_entries : (string * permission) list =
-  [ "masc_reset", CanReset
-  ; "masc_start", CanJoin
-  ; "masc_status", CanReadState
-  ; "masc_tasks", CanReadState
-  ; "masc_agents", CanReadState
-  ; "masc_task_history", CanReadState
-  ; "masc_operator_snapshot", CanReadState
-  ; "masc_operator_digest", CanReadState
-  ; "masc_surface_audit", CanReadState
-  ; "masc_persona_schema", CanReadState
-  ; "masc_keeper_status", CanReadState
-  ; "masc_keeper_list", CanReadState
-  ; "masc_keeper_persona_audit", CanReadState
-  ; "masc_runtime_verify", CanReadState
-  ; "masc_runtime_ollama_probe", CanReadState
-  ; "masc_observe_operations", CanReadState
-  ; "masc_observe_capacity", CanReadState
-  ; "masc_observe_traces", CanReadState
-  ; "masc_agent_fitness", CanReadState
-  ; "masc_agent_timeline", CanReadState
-  ; "masc_dashboard", CanReadState
-  ; "masc_check", CanReadState
-  ; "masc_approval_pending", CanReadState
-  ; "masc_approval_get", CanAdmin
-  ; "masc_get_metrics", CanReadState
-  ; "masc_plan_get_task", CanReadState
-  ; "masc_plan_get", CanReadState
-  ; "masc_plan_init", CanBroadcast
-  ; "masc_plan_update", CanBroadcast
-  ; "masc_plan_set_task", CanBroadcast
-  ; "masc_plan_clear_task", CanBroadcast
-  ; "masc_note_add", CanBroadcast
-  ; "masc_deliver", CanBroadcast
-  ; "masc_config", CanReadState
-  ; "masc_add_task", CanAddTask
-  ; "masc_claim_next", CanClaimTask
-  ; "masc_update_priority", CanCompleteTask
-  ; "masc_transition", CanCompleteTask
-  ; "masc_heartbeat", CanBroadcast
-  ; "masc_goal_transition", CanBroadcast
-  ; "masc_goal_verify", CanBroadcast
-  ; "masc_agent_update", CanBroadcast
-  ; "masc_spawn", CanBroadcast
-  ; "masc_operator_action", CanBroadcast
-  ; "masc_keeper_up", CanBroadcast
-  ; "masc_keeper_down", CanBroadcast
-  ; "masc_keeper_msg", CanBroadcast
-  ; "masc_keeper_msg_result", CanBroadcast
-  ; "masc_keeper_repair", CanBroadcast
-  ; "masc_persona_generate", CanBroadcast
-  ; "masc_persona_save", CanBroadcast
-  ; "masc_keeper_create_from_persona", CanBroadcast
-  ; "masc_approval_resolve", CanAdmin
-  ; "masc_operator_confirm", CanBroadcast
-  ; "masc_policy_approve", CanBroadcast
-  ; "masc_cleanup_zombies", CanBroadcast
-  ; "masc_board_list", CanReadState
-  ; "masc_board_get", CanReadState
-  ; "masc_board_hearths", CanReadState
-  ; "masc_board_search", CanReadState
-  ; "masc_board_profile", CanReadState
-  ; "masc_board_stats", CanReadState
-  ; "masc_board_sub_board_list", CanReadState
-  ; "masc_board_sub_board_get", CanReadState
-  ; "masc_board_post", CanBroadcast
-  ; "masc_board_comment", CanBroadcast
-  ; "masc_board_vote", CanBroadcast
-  ; "masc_board_comment_vote", CanBroadcast
-  ; "masc_board_delete", CanAdmin
-  ; "masc_tool_stats", CanReadState
-  ; "masc_tool_help", CanReadState
-  ; "masc_tool_list", CanReadState
-  ; "masc_tool_grant", CanAdmin
-  ; "masc_tool_revoke", CanAdmin
-  ; "masc_tool_admin_snapshot", CanAdmin
-  ; "masc_tool_admin_update", CanAdmin
-  ; "masc_run_get", CanReadState
-  ; "masc_run_list", CanReadState
-  ; "masc_run_init", CanBroadcast
-  ; "masc_run_plan", CanBroadcast
-  ; "masc_run_log", CanBroadcast
-  ; "masc_run_deliverable", CanBroadcast
-  ]
-;;
-
-(* O(1) lookup table for tools that do not yet declare
-   [required_permission] in Tool_catalog metadata.  The fallback table is not a
-   second SSOT: metadata wins, and promoted entries should be removed here. *)
-let fallback_permission_table : (string, permission) Hashtbl.t =
-  let table = Hashtbl.create (List.length fallback_permission_entries * 2) in
-  List.iter
-    (fun (tool_name, perm) -> Hashtbl.replace table tool_name perm)
-    fallback_permission_entries;
-  table
-;;
-
-let fallback_permission_for_tool tool_name =
-  Hashtbl.find_opt fallback_permission_table tool_name
 ;;
 
 let known_tool_names =
@@ -131,12 +28,8 @@ let known_tool_names =
     Tool_catalog.all_surfaces |> List.concat_map Tool_catalog.tools_for_surface
   in
   let explicit_tools = List.map fst Tool_catalog.explicit_metadata in
-  let known = metadata_tools @ explicit_tools @ List.map fst fallback_permission_entries in
+  let known = metadata_tools @ explicit_tools in
   List.sort_uniq String.compare known
 ;;
 
-let permission_for_tool tool_name =
-  match declared_permission_for_tool tool_name with
-  | Some _ as permission -> permission
-  | None -> fallback_permission_for_tool tool_name
-;;
+let permission_for_tool tool_name = declared_permission_for_tool tool_name

--- a/lib/tool_permission_map.mli
+++ b/lib/tool_permission_map.mli
@@ -6,10 +6,9 @@
     lists. *)
 
 val known_tool_names : string list
-(** Tool names covered by either Tool_catalog metadata or the fallback table.
-    Useful for policy derivation that must include permission-mapped tools even
-    when they are not on a public surface. *)
+(** Tool names covered by Tool_catalog surfaces or explicit metadata. Useful
+    for policy derivation that must include permission-mapped tools even when
+    they are not on a public surface. *)
 
 val permission_for_tool : string -> Masc_domain.permission option
-(** Effective required permission for a tool:
-    Tool_catalog metadata first, fallback table second. *)
+(** Effective required permission for a tool from Tool_catalog metadata. *)

--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -223,6 +223,12 @@ After recording, the run shows as completed in masc_run_list and masc_run_get.";
 
 let read_only_tools = [ "masc_run_get"; "masc_run_list" ]
 
+let tool_required_permission = function
+  | "masc_run_get" | "masc_run_list" -> Some Masc_domain.CanReadState
+  | "masc_run_init" | "masc_run_plan" | "masc_run_log"
+  | "masc_run_deliverable" -> Some Masc_domain.CanBroadcast
+  | _ -> None
+
 let () =
   List.iter
     (fun (s : Masc_domain.tool_schema) ->
@@ -236,5 +242,6 @@ let () =
            ~handler_binding:Tag_dispatch
            ~is_read_only:is_ro
            ~is_idempotent:is_ro
+           ?required_permission:(tool_required_permission s.name)
            ()))
     schemas

--- a/lib/tool_spec.ml
+++ b/lib/tool_spec.ml
@@ -141,6 +141,13 @@ let register (spec : t) =
         Option.bind existing (fun (meta : Tool_catalog.metadata) ->
           meta.requires_actor_binding)
   in
+  let required_permission =
+    match spec.required_permission with
+    | Some _ as value -> value
+    | None ->
+        Option.bind existing (fun (meta : Tool_catalog.metadata) ->
+          meta.required_permission)
+  in
   Tool_catalog.register_metadata spec.name
     { Tool_catalog.visibility = effective_visibility;
       lifecycle = Tool_catalog.Active;
@@ -152,7 +159,7 @@ let register (spec : t) =
       readonly = Some spec.is_read_only;
       destructive = Some spec.is_destructive;
       idempotent = Some spec.is_idempotent;
-      required_permission = spec.required_permission;
+      required_permission;
       effect_domain = spec.effect_domain;
       requires_actor_binding };
   (* 5. Handler binding — auto-register Direct/Shared into Tool_dispatch *)

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -183,8 +183,8 @@ let test_permission_for_tool_status () =
   | _ -> fail "expected CanReadState"
 
 let test_permission_for_tool_runtime_verify () =
-  (* Tool schema was pruned but the permission map still maps the name
-     to CanReadState. Keep the legacy permission contract. *)
+  (* Runtime verification is an admin-surface tool with catalog-owned auth
+     metadata. *)
   match Auth.permission_for_tool "masc_runtime_verify" with
   | Some Masc_domain.CanReadState -> ()
   | _ -> fail "expected CanReadState"


### PR DESCRIPTION
## Summary
- Delete the `Tool_permission_map` fallback permission table so auth resolves only catalog metadata.
- Promote live tool permissions into `Tool_catalog` metadata and schema registration, including run/sub-board tools that previously relied on fallback rows.
- Update the legacy purge audit HTML with #18717 merge status and the active Tool catalog slice.

## Validation
- `ocamlformat --check lib/tool_catalog.ml lib/tool_permission_map.ml lib/tool_permission_map.mli lib/tool_access_role.ml lib/tool_access_role.mli lib/tool_spec.ml lib/tool_run.ml lib/tool_board_dispatch.ml test/test_auth_coverage.ml`
- `git diff --check origin/main..HEAD`
- `bash scripts/check-doc-truth.sh`
- `scripts/ci/check-enum-string-safety.sh` (PASS, pre-existing warnings only)
- `bash scripts/lint/no-unknown-permissive-default.sh`
- `scripts/ci/check-determinism-contract.sh` (PASS, pre-existing warnings only)
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD --recent-main 50 --duplicate-policy warn`
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD` (OK with pending-release warning)

## Local Dune Gap
- `scripts/dune-local.sh build ./lib ./test/test_auth_coverage.exe ./test/test_tool_access_role.exe ./test/test_tool_surface_ssot.exe` returned exit 75 because live bare Dune processes are bypassing the repo wrapper guard. I did not bypass the guard.