### PR TITLE
fix(dashboard): share keeper action visibility

### DIFF
--- a/dashboard/src/components/keeper-action-panel.test.ts
+++ b/dashboard/src/components/keeper-action-panel.test.ts
@@ -18,7 +18,7 @@ vi.mock('../store', () => ({
   refreshDashboard: vi.fn(async () => undefined),
 }))
 
-import { keeperActionVisibility } from './keeper-action-panel'
+import { keeperActionVisibility } from '../lib/keeper-predicates'
 import type { Keeper } from '../types'
 
 function makeKeeper(overrides: Partial<Keeper>): Keeper {

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -31,11 +31,8 @@ import {
 import { invalidateDashboardCache, refreshDashboard, keepers } from '../store'
 import type { Keeper } from '../types'
 import {
-  isKeeperOffline,
+  keeperActionVisibility,
   isKeeperOperatorTargetable,
-  isKeeperPaused,
-  isKeeperRunningExcludingRestarting,
-  keeperCanWakeup,
 } from '../lib/keeper-predicates'
 
 // ── Shared helpers ────────────────────────────────────────────────────────
@@ -80,34 +77,6 @@ async function runKeeperAction(
     }
   } catch {
     showToast(`${labels[action]} 실패`, 'error')
-  }
-}
-
-// ── Visibility helpers ────────────────────────────────────────────────────
-
-/** Determine which action buttons are relevant for a keeper's current state. */
-export function keeperActionVisibility(keeper: Keeper): {
-  canPause: boolean
-  canResume: boolean
-  canWake: boolean
-  canBoot: boolean
-  canShutdown: boolean
-} {
-  // RFC-0135 PR-11: every visibility axis routes through SSOT predicates
-  // in `lib/keeper-predicates.ts`. The previous 10-literal inline OR
-  // chain for `isRunning` (with self-doc admitting the duplication) was
-  // promoted to `isKeeperRunningExcludingRestarting` so a new lifecycle
-  // phase added to the running cluster updates every consumer at once.
-  const isPaused = isKeeperPaused(keeper)
-  const isOffline = isKeeperOffline(keeper)
-  const isRunning = isKeeperRunningExcludingRestarting(keeper)
-
-  return {
-    canPause:    isRunning && !isPaused,
-    canResume:   isPaused,
-    canWake:     keeperCanWakeup(keeper),
-    canBoot:     isOffline,
-    canShutdown: isRunning || isPaused,
   }
 }
 

--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -234,4 +234,36 @@ describe('KeeperRuntimeAlertStrip', () => {
     expect(container.textContent).not.toContain('런타임 차단')
     expect(container.textContent).not.toContain('주의 사유 · paused')
   })
+
+  it('uses lifecycle action visibility SSOT for phase-only paused keepers', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        phase: 'Paused',
+        paused: false,
+        needs_attention: true,
+        runtime_blocker_class: 'turn_timeout',
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('재개하기')
+    expect(text).not.toContain('일시정지하기')
+    expect(text).not.toContain('깨우기')
+  })
+
+  it('uses lifecycle action visibility SSOT to show wake for non-paused blocked keepers', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        phase: 'Running',
+        paused: false,
+        needs_attention: true,
+        runtime_blocker_class: 'turn_timeout',
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('일시정지하기')
+    expect(text).toContain('깨우기')
+    expect(text).not.toContain('재개하기')
+  })
 })

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -6,7 +6,7 @@ import {
   keeperRuntimeBlockerLabel,
   keeperRuntimeBlockerHint,
 } from '../lib/keeper-runtime-display'
-import { isKeeperPaused } from '../lib/keeper-predicates'
+import { isKeeperPaused, keeperActionVisibility } from '../lib/keeper-predicates'
 import { TimeAgo } from './common/time-ago'
 import { formatDuration } from './mission-utils'
 import type { Keeper } from '../types'
@@ -439,6 +439,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
       : null
   if (!needsAttention && !hasActivitySignal && !hasRuntimeIdentitySignal && !hasExecutionEvidenceSignal) return null
 
+  const actionVisibility = keeperActionVisibility(keeper)
   const directiveLoading = signal(false)
   const handleDirective = async (action: 'pause' | 'resume' | 'wakeup') => {
     directiveLoading.value = true
@@ -465,7 +466,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
     }
   }
 
-  const toneClass = keeper.paused || socialFallbackActive || runtimeBlocker || blocker || hbStale
+  const toneClass = isPaused || socialFallbackActive || runtimeBlocker || blocker || hbStale
     ? 'border-[var(--warn-24)] bg-[var(--warn-8)]'
     : 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)]'
   const runtimeBlockerLabelText = keeperRuntimeBlockerLabel(runtimeBlockerClass)
@@ -484,7 +485,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="px-6 pt-4">
       <div class="rounded-[var(--r-1)] border ${toneClass} px-4 py-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-[var(--color-fg-primary)]">
-        ${keeper.paused
+        ${actionVisibility.canResume
           ? html`<${RuntimeBadge} tone="warn">일시정지</${RuntimeBadge}>
             ${hasActivitySignal ? html`<span class="text-[var(--color-fg-muted)]">${renderActivitySignal()}</span>` : null}
             <${ActionButton}
@@ -495,7 +496,8 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
               onClick=${() => handleDirective('resume')}
               title="재개: 일시정지된 keeper 를 다시 실행합니다 (paused → running)"
             >재개하기<//>`
-          : html`<${ActionButton}
+          : html`${actionVisibility.canPause
+            ? html`<${ActionButton}
               variant="ghost"
               size="sm"
               class="!py-0.5 !bg-[var(--color-bg-hover)] !text-[var(--color-fg-secondary)] inline-flex items-center"
@@ -503,19 +505,20 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
               onClick=${() => handleDirective('pause')}
               title="일시정지: 실행 중인 keeper 를 일시 멈춥니다 (running → paused, 현재 turn 은 정상 종료)"
             >일시정지하기<//>
-            ${(hbStale || runtimeBlockerClass === 'cascade_exhausted' || runtimeBlockerClass === 'turn_timeout')
+            ` : null}
+            ${actionVisibility.canWake
               ? html`<${ActionButton}
                   variant="warn"
                   size="sm"
                   class="!py-0.5 inline-flex items-center"
                   disabled=${directiveLoading.value}
                   onClick=${() => handleDirective('wakeup')}
-                  title="자고 있는 keeper의 sleep을 깨워 다음 turn을 시도합니다. fiber가 살아 있을 때만 효과가 있습니다."
+                  title="깨우기: idle 또는 stuck 상태에서 다음 turn 을 즉시 시도합니다. 실행 중이어도 노출되는 이유는 cascade/oas/turn timeout 같은 stuck signal 이 backend 보다 먼저 frontend 에 보이는 케이스를 다루기 위함입니다."
                 >깨우기<//>`
               : null}`}
-        ${keeper.paused && keeper.keepalive_running && continueGate
+        ${isPaused && keeper.keepalive_running && continueGate
           ? html`<span>하트비트는 유지되지만 승인 전까지 자동 재개하지 않습니다.</span>`
-          : keeper.paused && keeper.keepalive_running
+          : isPaused && keeper.keepalive_running
             ? html`<span>하트비트는 유지되지만 자율 행동은 멈춰 있습니다.</span>`
           : null}
         ${hbStale

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -6,7 +6,7 @@
 //   - agent-roster.ts:rosterStateNote        (flat runtime_blocker_class read)
 //   - keeper-detail-runtime.ts:deriveKeeperLiveTruth
 //                                            (composite-aware conditioning)
-//   - keeper-action-panel.ts:keeperActionVisibility
+//   - keeper-predicates.ts:keeperActionVisibility
 //                                            (status/phase/paused OR-chain)
 // will all call `deriveKeeperOperationalState` instead (PR-3 ~ PR-6).
 //

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -156,6 +156,31 @@ export function keeperCanWakeup(keeper: Keeper): boolean {
   return true
 }
 
+export interface KeeperActionVisibility {
+  canPause: boolean
+  canResume: boolean
+  canWake: boolean
+  canBoot: boolean
+  canShutdown: boolean
+}
+
+/** Determine which lifecycle actions are relevant for a keeper's
+ *  current state. Keep this in the predicate SSOT so command and
+ *  detail surfaces do not drift. */
+export function keeperActionVisibility(keeper: Keeper): KeeperActionVisibility {
+  const isPaused = isKeeperPaused(keeper)
+  const isOffline = isKeeperOffline(keeper)
+  const isRunning = isKeeperRunningExcludingRestarting(keeper)
+
+  return {
+    canPause:    isRunning && !isPaused,
+    canResume:   isPaused,
+    canWake:     keeperCanWakeup(keeper),
+    canBoot:     isOffline,
+    canShutdown: isRunning || isPaused,
+  }
+}
+
 /** Operator-facing target lists must keep paused keepers selectable so
  *  the operator can message/probe/resume them even if another axis still
  *  reports an offline-ish status. */


### PR DESCRIPTION
## Summary
- move keeper lifecycle action visibility into the keeper predicate SSOT
- make Command Actions and Keeper Detail alert strip use the same pause/resume/wake gates
- add detail-strip regression coverage for phase-only paused keepers and non-paused blocked wake actions

## Verification
- git diff --check
- pnpm --dir dashboard exec vitest run src/components/keeper-action-panel.test.ts src/components/keeper-detail-alert-strip.test.ts src/lib/keeper-predicates.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty