### PR TITLE
fix(keeper/shell): preserve argv through shell_bin so empty-executable hint reaches LLM

### DIFF
--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -352,9 +352,9 @@ let validate ~mode = function
     each stages
 ;;
 
-let shell_bin ~mode executable =
+let shell_bin ~mode ~argv executable =
   let trimmed = String.trim executable in
-  if String.length trimmed = 0 then Error (Empty_executable { argv = [] })
+  if String.length trimmed = 0 then Error (Empty_executable { argv })
   else
     match Masc_exec.Exec_program.of_string trimmed with
     | Ok bin -> Ok bin
@@ -369,7 +369,7 @@ let strip_leading_executable executable = function
 
 let shell_simple ~mode ?(sandbox = Masc_exec.Sandbox_target.host ()) ?cwd ?(env = []) { executable; argv } =
   let ( let* ) = Result.bind in
-  let* bin = shell_bin ~mode executable in
+  let* bin = shell_bin ~mode ~argv executable in
   let normalized_argv = strip_leading_executable executable argv in
   Ok
     (Keeper_shell_ir.simple_bin

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -239,6 +239,42 @@ let test_empty_executable_with_argv_hints_rewrite () =
   | Ok () -> Alcotest.fail "empty executable should not be accepted"
 ;;
 
+(* Regression: validate-bypass paths (to_shell_ir_unvalidated /
+   shell_simple) must preserve argv so the helpful "argv[0] looks like
+   the command name" hint is reachable. Before the fix shell_bin
+   fabricated [argv = []], which collapsed the diagnostic into the
+   generic catch-all and kept the LLM in a self-correction deadlock.
+   Live reproducer: keeper-qa-king sent
+     Exec { executable=""; argv=["gh";"pr";"list";...] }
+   from resolve_typed_git_cwd, hit shell_bin, and got the wrong
+   message in 2026-05-26 logs. *)
+let test_unvalidated_path_preserves_argv_in_error () =
+  let input = mk_exec "" [ "gh"; "pr"; "list"; "--state"; "open" ] in
+  match Bash_input.to_shell_ir_unvalidated ~mode:Bash_input.Dev_full input with
+  | Error (Bash_input.Empty_executable { argv }) ->
+    Alcotest.(check (list string))
+      "argv preserved through shell_simple/shell_bin"
+      [ "gh"; "pr"; "list"; "--state"; "open" ]
+      argv;
+    let msg =
+      Format.asprintf
+        "%a"
+        Bash_input.pp_validation_error
+        (Bash_input.Empty_executable { argv })
+    in
+    Alcotest.(check bool)
+      "rewrite hint points at argv[0]"
+      true
+      (String_util.contains_substring_ci msg "argv[0]=\"gh\"")
+  | Error error ->
+    Alcotest.failf
+      "expected Empty_executable with preserved argv, got %a"
+      Bash_input.pp_validation_error
+      error
+  | Ok _ ->
+    Alcotest.fail "empty executable should not produce a Shell IR"
+;;
+
 let validation_error_text error = Format.asprintf "%a" Bash_input.pp_validation_error error
 
 let check_not_allowlisted_hint ~name ~mode ~needle () =
@@ -612,6 +648,10 @@ let suite =
           "empty_executable_with_argv_hints_rewrite"
           `Quick
           test_empty_executable_with_argv_hints_rewrite
+      ; Alcotest.test_case
+          "unvalidated_path_preserves_argv_in_error"
+          `Quick
+          test_unvalidated_path_preserves_argv_in_error
       ; Alcotest.test_case
           "not_allowlisted_hints_self_correction"
           `Quick


### PR DESCRIPTION
## Summary
Fixes `shell_bin` discarding argv on the IR-construction path so the helpful "argv[0] looks like the command name" hint actually reaches the LLM. Unblocks the today-observed deadlock where keepers send `Exec { executable=""; argv=[...] }`, get an unhelpful generic error, never self-correct, and stall before they can `gh pr create`.

## Why this matters (live evidence)
2026-05-26 `~/me/.masc/logs/system_log_2026-05-26.jsonl`:

| Time (UTC) | Keeper | cmd (from log) |
|---|---|---|
| 04:11:15 | qa-king | `'' gh pr list --repo kidsnote/... --state open --json ...` |
| 04:11:18 | qa-king | (same retry 2/3) |
| 04:45:43 | rondo | `'' ls -la repos/masc-mcp` |

The leading `''` is `shell_quote_for_policy ""` — i.e. the LLM sent `executable=""` with the real command in argv. `typed_input_command_text` preserved it for the log, but the validation error path lost it.

Downstream consequence: `task-501` was claimed three times today (echo → imseonghan → qa-king), each keeper stalled at this same call site, each was stale-released ~1h later by the orchestrator. The verifier-gate requires `pr_url_or_artifact_ref` evidence which keepers cannot produce while their shell tool is blocked.

## Root cause
`lib/keeper/keeper_tool_bash_input.ml`:

- `check_exec` (used by `validate`): receives argv, emits `Empty_executable { argv }` — helpful hint reachable.
- `shell_bin` (used by `shell_simple` → `to_shell_ir_unvalidated`): does **not** receive argv, hardcodes `Empty_executable { argv = [] }` — collapses into the generic catch-all branch.

The IR-construction path runs without `validate` (it's invoked by `resolve_typed_git_cwd` to resolve cwd before tokenisation), so the dead-coded helpful branch was the only difference between the two paths — silent UX regression.

## Fix
- `shell_bin` now takes `~argv` and threads it into `Empty_executable`.
- `shell_simple` (the sole caller; private, not exposed in `.mli`) passes argv through.
- 1-line signature change, 1-line caller update, no breaking change for external code.

## Workaround signature gate self-check (CLAUDE.md §워크어라운드 거부 기준)
- **§1 Telemetry-as-fix**: N/A. Real data-flow correction; no counter, no demote, no dedup.
- **§2 String/substring classifier**: N/A. Touches typed argv plumbing only.
- **§3 N-of-M sweep**: N/A. `shell_bin` has exactly one caller; both sites updated atomically in this PR.
- **§4 Catch-all**: N/A. The change *removes reachability of* a dead generic catch-all by routing data to the existing rich branch — it does not add a new catch-all.
- **§5 Cap/cooldown/dedup/repair**: N/A.
- **§6 Test backdoor**: N/A.
- **§7 Codemod-needed typo**: N/A.

RFC-WAIVED: Not in the credential / identity / sandbox / dashboard-credential / hooks / workflow scopes that require RFC discovery. `keeper_tool_bash_input` is the typed shell-input parser; this is a UX correction to its error reporting.

## Test plan
- [x] New regression test `test_unvalidated_path_preserves_argv_in_error` directly exercises `to_shell_ir_unvalidated` (the validate-bypass path) with the qa-king live shape `Exec { executable=""; argv=["gh";"pr";"list";"--state";"open"] }` and asserts both argv preservation and "argv[0]=\"gh\"" in the rendered hint.
- [x] Existing `test_empty_executable_with_argv_hints_rewrite` (validate path) still passes.
- [x] `dune exec test/test_keeper_bash_typed_input.exe` — **31/31 OK**.
- [x] `dune build @check` clean.
- [ ] CI: required checks green before Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
