### PR TITLE
refactor(agent-tool): share descriptor route resolution

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -137,7 +137,7 @@
  server_mcp_transport_http_agui
  server_mcp_streaming_tools
  mcp_server_eio_tool_timeout
-  agent_tool_descriptor agent_tool_runtime keeper_tool_registry
+  agent_tool_descriptor agent_tool_descriptor_resolution agent_tool_runtime keeper_tool_registry
   keeper_tool_resolution
   keeper_tool_policy_config
   keeper_discovered_tools

--- a/lib/keeper/agent_tool_descriptor_resolution.ml
+++ b/lib/keeper/agent_tool_descriptor_resolution.ml
@@ -1,0 +1,27 @@
+let descriptor_for_tool_name tool_name =
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
+  match Agent_tool_descriptor.find_public stripped with
+  | Some descriptor -> Some descriptor
+  | None ->
+    let internal_name =
+      match Keeper_tool_alias.canonical_internal_name tool_name with
+      | Some internal_name -> internal_name
+      | None -> stripped
+    in
+    (match Agent_tool_descriptor.descriptors_for_internal internal_name with
+     | descriptor :: _ -> Some descriptor
+     | [] -> None)
+;;
+
+let descriptors_for_tool_names tool_names =
+  let add_descriptor (seen, acc) descriptor =
+    if List.mem descriptor.Agent_tool_descriptor.id seen
+    then seen, acc
+    else descriptor.id :: seen, descriptor :: acc
+  in
+  tool_names
+  |> List.filter_map descriptor_for_tool_name
+  |> List.fold_left add_descriptor ([], [])
+  |> snd
+  |> List.rev
+;;

--- a/lib/keeper/agent_tool_descriptor_resolution.mli
+++ b/lib/keeper/agent_tool_descriptor_resolution.mli
@@ -1,0 +1,10 @@
+(** Shared descriptor lookup for tool names observed at runtime.
+
+    This module is the projection boundary from model/MCP/internal tool strings
+    back to [Agent_tool_descriptor]. Keep receipt and tool-call evidence lookup
+    here so descriptor route evidence does not grow parallel name-resolution
+    rules. *)
+
+val descriptor_for_tool_name : string -> Agent_tool_descriptor.t option
+
+val descriptors_for_tool_names : string list -> Agent_tool_descriptor.t list

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -77,33 +77,6 @@ let string_contains_ci haystack needle =
   loop 0
 ;;
 
-let descriptor_for_tool_name tool_name =
-  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
-  match Agent_tool_descriptor.find_public stripped with
-  | Some descriptor -> Some descriptor
-  | None ->
-    let internal_name =
-      match Keeper_tool_alias.canonical_internal_name tool_name with
-      | Some internal_name -> internal_name
-      | None -> stripped
-    in
-    (match Agent_tool_descriptor.descriptors_for_internal internal_name with
-     | descriptor :: _ -> Some descriptor
-     | [] -> None)
-;;
-
-let dedupe_descriptors descriptors =
-  descriptors
-  |> List.fold_left
-       (fun (seen, acc) (descriptor : Agent_tool_descriptor.t) ->
-          if List.mem descriptor.id seen
-          then seen, acc
-          else descriptor.id :: seen, descriptor :: acc)
-       ([], [])
-  |> snd
-  |> List.rev
-;;
-
 let bump_count name counts =
   let rec loop prefix = function
     | [] -> List.rev ((name, 1) :: prefix)
@@ -153,8 +126,7 @@ let tool_descriptor_summary_json receipt =
     @ receipt.canonical_tools
     @ receipt.tools_used
     @ receipt.reported_tools
-    |> List.filter_map descriptor_for_tool_name
-    |> dedupe_descriptors
+    |> Agent_tool_descriptor_resolution.descriptors_for_tool_names
   in
   `Assoc
     [ "source", `String "receipt_tool_sets"

--- a/lib/keeper_tool_call_log_route_evidence.ml
+++ b/lib/keeper_tool_call_log_route_evidence.ml
@@ -113,21 +113,8 @@ let assoc_fields = function
   | _ -> []
 ;;
 
-let descriptor_for_tool_name tool_name =
-  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
-  match Agent_tool_descriptor.find_public stripped with
-  | Some descriptor -> Some descriptor
-  | None ->
-    (match Keeper_tool_alias.canonical_internal_name tool_name with
-     | None -> None
-     | Some internal_name ->
-       (match Agent_tool_descriptor.descriptors_for_internal internal_name with
-        | descriptor :: _ -> Some descriptor
-        | [] -> None))
-;;
-
 let descriptor_evidence_fields tool_name =
-  match descriptor_for_tool_name tool_name with
+  match Agent_tool_descriptor_resolution.descriptor_for_tool_name tool_name with
   | None -> []
   | Some descriptor -> Agent_tool_descriptor.route_evidence_json descriptor |> assoc_fields
 ;;

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -6,6 +6,7 @@
 
 module Alias = Masc_mcp.Keeper_tool_alias
 module Descriptor = Masc_mcp.Agent_tool_descriptor
+module Descriptor_resolution = Masc_mcp.Agent_tool_descriptor_resolution
 module Observation = Masc_mcp.Keeper_tool_observation
 module Receipt = Masc_mcp.Keeper_execution_receipt
 module Resolution = Masc_mcp.Keeper_tool_resolution
@@ -417,6 +418,12 @@ let count_bucket name json =
   | None -> None
 ;;
 
+let descriptor_id_for_tool_name name =
+  Option.map
+    (fun (descriptor : Descriptor.t) -> descriptor.id)
+    (Descriptor_resolution.descriptor_for_tool_name name)
+;;
+
 let test_descriptor_route_evidence_names_policy_backend_sandbox_and_description () =
   let execute =
     match Descriptor.find_public "Execute" with
@@ -480,6 +487,37 @@ let test_descriptor_route_evidence_names_policy_backend_sandbox_and_description 
        true
        (String.starts_with ~prefix:"Execute one typed command" description)
    | None -> Alcotest.fail "description missing")
+;;
+
+let test_descriptor_resolution_handles_public_prefixed_internal_and_dedupe () =
+  Alcotest.(check (option string))
+    "public ReadFile resolves"
+    (Some "agent.read_file")
+    (descriptor_id_for_tool_name "ReadFile");
+  Alcotest.(check (option string))
+    "internal tool_read_file resolves"
+    (Some "agent.read_file")
+    (descriptor_id_for_tool_name "tool_read_file");
+  Alcotest.(check (option string))
+    "internal coordination tool resolves"
+    (Some "keeper.time.now")
+    (descriptor_id_for_tool_name "keeper_time_now");
+  Alcotest.(check (option string))
+    "mcp-prefixed internal coordination tool resolves"
+    (Some "keeper.time.now")
+    (descriptor_id_for_tool_name "mcp__masc__keeper_time_now");
+  Alcotest.(check (list string))
+    "descriptor list dedupes by descriptor id"
+    [ "agent.read_file"; "keeper.time.now"; "agent.execute" ]
+    (Descriptor_resolution.descriptors_for_tool_names
+       [ "ReadFile"
+       ; "tool_read_file"
+       ; "keeper_time_now"
+       ; "mcp__masc__keeper_time_now"
+       ; "Execute"
+       ; "unknown_tool"
+       ]
+     |> List.map (fun (descriptor : Descriptor.t) -> descriptor.id))
 ;;
 
 let test_execution_receipt_descriptor_summary_projects_descriptors () =
@@ -1138,6 +1176,10 @@ let () =
             "descriptor evidence names policy route"
             `Quick
             test_descriptor_route_evidence_names_policy_backend_sandbox_and_description
+        ; Alcotest.test_case
+            "descriptor resolution handles public internal prefixed dedupe"
+            `Quick
+            test_descriptor_resolution_handles_public_prefixed_internal_and_dedupe
         ; Alcotest.test_case
             "execution receipt descriptor summary projects descriptors"
             `Quick


### PR DESCRIPTION
## Summary
- add `Agent_tool_descriptor_resolution` as the shared tool-name to descriptor projection
- switch tool-call route evidence and execution receipt descriptor summary to the shared resolver
- cover public, internal, MCP-prefixed, unknown, and dedupe resolution behavior

## Verification
- ocamlformat --check lib/keeper/agent_tool_descriptor_resolution.mli lib/keeper/agent_tool_descriptor_resolution.ml lib/keeper_tool_call_log_route_evidence.ml lib/keeper/keeper_execution_receipt.ml test/test_keeper_tool_alias.ml
- git diff --check origin/main...HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_keeper_tool_alias.exe ./test/test_keeper_tool_call_log.exe
- ./_build/default/test/test_keeper_tool_alias.exe
- ./_build/default/test/test_keeper_tool_call_log.exe
