### PR TITLE
test(cascade): pin judge-route intent + tier-group existence (A1+A2)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -299,6 +299,8 @@
   test_cascade_phonebook
   test_cascade_phonebook_resolve
   test_cascade_routing_policy
+  test_cascade_routing_policy_targets_exist
+  test_cascade_judge_route_intent_golden
   test_cascade_server_flavor
   test_cascade_phonebook_integration
   test_keeper_cascade_profile_partial
@@ -621,6 +623,8 @@
   test_cascade_phonebook
   test_cascade_phonebook_resolve
   test_cascade_routing_policy
+  test_cascade_routing_policy_targets_exist
+  test_cascade_judge_route_intent_golden
   test_cascade_server_flavor
   test_cascade_phonebook_integration
   test_keeper_cascade_profile_partial

--- a/test/test_cascade_judge_route_intent_golden.ml
+++ b/test/test_cascade_judge_route_intent_golden.ml
@@ -1,0 +1,66 @@
+(** Golden test pinning judge-route intent in [config/cascade.toml].
+
+    The four judge routes (governance_judge, operator_judge,
+    cross_verifier, verifier) must target [tier-group.governance],
+    not [tier-group.primary] or any other production lane.
+
+    Regression bar for PR #18695 — a re-introduction of the mis-route
+    that caused governance_judge to time out at 45s every refresh cycle
+    by routing advisory dashboards through full-size code-gen models.
+
+    Out of scope: capability-driven semantic checking. That is
+    RFC-0181 territory and deferred per §9. This test only guards the
+    *string equality* of route targets against an architect-pinned
+    map. *)
+
+open Alcotest
+
+let cascade_toml_path = "config/cascade.toml"
+
+let expected_judge_routes : (string * string) list =
+  [ "governance_judge", "tier-group.governance"
+  ; "operator_judge", "tier-group.governance"
+  ; "cross_verifier", "tier-group.governance"
+  ; "verifier", "tier-group.governance"
+  ]
+
+let read_route_target ~route_key (toml : Otoml.t) : string option =
+  match Otoml.find_opt toml Fun.id [ "routes"; route_key; "target" ] with
+  | Some node ->
+    (match Otoml.get_string node with
+     | exception Otoml.Type_error _ -> None
+     | s -> Some s)
+  | None -> None
+
+let test_judge_routes_target_governance_tier_group () =
+  let toml = Otoml.Parser.from_file cascade_toml_path in
+  List.iter
+    (fun (route_key, expected_target) ->
+      match read_route_target ~route_key toml with
+      | None ->
+        Alcotest.failf
+          "[routes.%s] missing or has no [target] in %s — judge routes \
+           must be present"
+          route_key
+          cascade_toml_path
+      | Some actual ->
+        check
+          string
+          (Printf.sprintf
+             "[routes.%s].target must equal %S (PR #18695 regression bar)"
+             route_key
+             expected_target)
+          expected_target
+          actual)
+    expected_judge_routes
+
+let () =
+  Alcotest.run
+    "cascade_judge_route_intent_golden"
+    [ ( "judge_route_targets"
+      , [ test_case
+            "all four judge routes target tier-group.governance"
+            `Quick
+            test_judge_routes_target_governance_tier_group
+        ] )
+    ]

--- a/test/test_cascade_routing_policy_targets_exist.ml
+++ b/test/test_cascade_routing_policy_targets_exist.ml
@@ -1,0 +1,76 @@
+(** Pin every [Cascade_routing_policy.default_routing_policies] entry to
+    a defined [tier-groups.X] section in the canonical phonebook fixture.
+
+    Catches three classes of drift:
+    - typo'd policy strings ("cross_verify" vs "cross-verify")
+    - removal of a tier-group from the fixture while a policy still
+      references it
+    - addition of a new policy entry without adding the fixture section
+
+    Out of scope: production [config/cascade.toml] currently has no
+    phonebook sections at all (RFC-0181 §9 — implementation deferred).
+    A separate gate would be needed to assert that. *)
+
+open Alcotest
+open Masc_mcp.Cascade_routing_policy
+
+let fixture_path = "test/fixtures/cascade-phonebook.toml"
+
+(* Read [tier-groups.*] table keys directly via otoml.
+
+   We intentionally bypass [Cascade_phonebook_parser.parse_phonebook]
+   here. The parser performs full cross-reference validation
+   (providers ↔ models ↔ tier-groups) and currently rejects the
+   fixture due to in-flight RFC-0177 vendor-substitution desync —
+   unrelated to the policy/tier-group binding we are guarding here.
+
+   This test asks one question: do the tier-group string literals in
+   [default_routing_policies] match section names actually present in
+   the canonical fixture? Section-key presence is sufficient signal. *)
+let load_fixture_tier_group_names () : string list =
+  let toml = Otoml.Parser.from_file fixture_path in
+  match Otoml.find_opt toml Fun.id [ "tier-groups" ] with
+  | Some tg_tbl ->
+    (match Otoml.get_table tg_tbl with
+     | exception Otoml.Type_error _ -> []
+     | entries -> List.map fst entries)
+  | None -> []
+
+let test_all_policies_target_existing_tier_groups () =
+  let defined = load_fixture_tier_group_names () in
+  List.iter
+    (fun (p : task_routing_policy) ->
+      if not (List.mem p.primary_tier_group defined)
+      then
+        Alcotest.failf
+          "default_routing_policies entry for %s references tier-group %S, \
+           but no [tier-groups.%s] section in %s (defined: %s)"
+          (task_use_to_string p.task)
+          p.primary_tier_group
+          p.primary_tier_group
+          fixture_path
+          (String.concat ", " defined))
+    default_routing_policies
+
+let test_fixture_has_at_least_one_tier_group () =
+  let defined = load_fixture_tier_group_names () in
+  if defined = []
+  then
+    Alcotest.failf
+      "fixture %s parsed but yielded zero tier-groups — fixture corrupted"
+      fixture_path
+
+let () =
+  Alcotest.run
+    "cascade_routing_policy_targets_exist"
+    [ ( "intent_to_fixture"
+      , [ test_case
+            "fixture has tier-groups"
+            `Quick
+            test_fixture_has_at_least_one_tier_group
+        ; test_case
+            "every default_routing_policies entry targets a defined tier-group"
+            `Quick
+            test_all_policies_target_existing_tier_groups
+        ] )
+    ]


### PR DESCRIPTION
## Why

PR #18695 fixed four cascade judge routes (governance_judge, operator_judge,
cross_verifier, verifier) that had been incorrectly aimed at
`tier-group.primary` (production code-gen models) instead of
`tier-group.governance` (advisory dashboard judges). That mis-route caused
`Dashboard_governance_judge.refresh_once` to time out at 45s every cycle,
turning a budget into a guaranteed wall clock.

The fix itself was four lines of TOML. No test would have caught the
re-introduction of the same drift. This PR closes that gap with two
small additive Alcotest cases — both pure-additive, no production code
changed, no schema migration.

## What

### A1 — `test_cascade_routing_policy_targets_exist.ml`

Asserts every `Cascade_routing_policy.default_routing_policies` entry's
`primary_tier_group` string corresponds to an actual `[tier-groups.X]`
section in `test/fixtures/cascade-phonebook.toml`.

Catches:

- typo'd policy strings (`cross_verify` vs `cross-verify`)
- removal of a tier-group from the fixture while a policy still
  references it
- addition of a new policy entry without adding the fixture section

Bypasses `Cascade_phonebook_parser.parse_phonebook` and reads
`[tier-groups]` keys directly via `Otoml`. The parser currently rejects
the fixture due to an in-flight RFC-0177 vendor-substitution desync
(`Unknown protocol: provider-d-http`) that is unrelated to the
policy↔tier-group binding this test guards. Surfaced finding worth a
separate follow-up.

### A2 — `test_cascade_judge_route_intent_golden.ml`

Golden test pinning the four judge routes in `config/cascade.toml`:

```
governance_judge → tier-group.governance
operator_judge   → tier-group.governance
cross_verifier   → tier-group.governance
verifier         → tier-group.governance
```

Re-introducing the PR #18695 regression — pointing any of these at
`tier-group.primary` — fails this test.

## Out of scope

- Capability-driven semantic checking (RFC-0181 §9, deferred — full
  replacement of the dual-SSOT structure).
- Asserting that production `config/cascade.toml` actually carries
  populated `[providers.*]`/`[models.*]`/`[tier-groups.*]` sections —
  the production file is intentionally empty under the deferred
  RFC-0181 plan.
- RFC-0177 fixture/parser desync (surfaced by A1 development, separate
  follow-up).
- B1 keeper descriptor invocation coverage probe (separate work, queued
  in TaskList).

## Verification

```
dune exec test/test_cascade_routing_policy_targets_exist.exe --root .
# Test Successful in 0.002s. 2 tests run.

dune exec test/test_cascade_judge_route_intent_golden.exe --root .
# Test Successful in 0.003s. 1 test run.
```

Sibling cascade tests (`test_cascade_routing_policy`, `test_cascade_phonebook`,
`test_cascade_phonebook_resolve`) still build clean.

## Risk profile

Pure additive. Two new test files + two lines added to `test/dune`. No
production code path touched. Reverts are one-PR clean.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
