### PR TITLE
fix(build): repair main HEAD compile regressions (#18730 + #18733 followup)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -744,7 +744,6 @@
   test_tui_decode
   test_dashboard_governance
   test_dashboard_labels
-  test_dashboard_safe_autonomy
   test_dashboard_keeper_feature_proof
   test_dashboard_surface_readiness
   test_activity_graph
@@ -965,7 +964,6 @@
   test_tui_decode
   test_dashboard_governance
   test_dashboard_labels
-  test_dashboard_safe_autonomy
   test_dashboard_keeper_feature_proof
   test_dashboard_surface_readiness
   test_activity_graph

--- a/test/test_transport_coverage.ml
+++ b/test/test_transport_coverage.ml
@@ -14,6 +14,7 @@
 open Alcotest
 
 module Transport = Masc_mcp.Transport
+module Sdk_tool_contract = Masc_mcp.Sdk_tool_contract
 
 (* ============================================================
    protocol Tests


### PR DESCRIPTION
## Problem

`dune build --root .` from main HEAD fails with two unrelated regressions
from recently-merged PRs:

### 1. `Sdk_tool_contract` unbound (introduced by #18733)

```
File "test/test_transport_coverage.ml", line 703, characters 11-28:
703 |            Sdk_tool_contract.core_remote_operation_names);
                 ^^^^^^^^^^^^^^^^^
Error: Unbound module Sdk_tool_contract
```

PR #18733 added a reference to `Sdk_tool_contract.core_remote_operation_names`
at line 703 but missed the matching `module Sdk_tool_contract = Masc_mcp.Sdk_tool_contract`
alias at the top of the file. Same pattern as PR #18703 (`Tool_shard_types_schemas_bash`):
wrapped library `masc_mcp` requires explicit aliasing for external test access.

### 2. `Test_dashboard_safe_autonomy` module doesn't exist (introduced by #18730)

```
File "test/dune", line 968, characters 2-30:
Error: Module Test_dashboard_safe_autonomy doesn't exist.
```

PR #18730 (`chore(dashboard): retire Safe Autonomy surface (safety theater)`)
deleted `test/test_dashboard_safe_autonomy.ml` but left two `test/dune`
entries (lines 747 and 968) referring to it.

## Change

- `test/test_transport_coverage.ml`: add the missing alias next to the
  existing `module Transport = Masc_mcp.Transport` declaration.
- `test/dune`: remove the two dangling `test_dashboard_safe_autonomy`
  entries from `(names ...)` and `(modules ...)` of the main test stanza.

```diff
 module Transport = Masc_mcp.Transport
+module Sdk_tool_contract = Masc_mcp.Sdk_tool_contract
```

```diff
   test_dashboard_labels
-  test_dashboard_safe_autonomy
   test_dashboard_keeper_feature_proof
```
(applied to both `(names ...)` and `(modules ...)` blocks)

## Verification

- `dune build test/test_transport_coverage.exe --root .` — exit 0
- `dune build --root .` (full tree) — exit 0
- No production code touched, only test wiring.

## Pattern note

This is the second instance of the wrapped-library alias miss (after #18703)
and another instance of the partial-sweep miss recorded in
`feedback_partial_module_orphan_check_all_exports`. Both are test/dune
hygiene problems. A linter that verifies every `(names ...)`/`(modules ...)`
entry has a corresponding `.ml` file would close this class entirely,
but is out of scope here.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
