### PR TITLE
test(agent_tool_descriptor): registry integrity regression bar (B1)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -301,6 +301,7 @@
   test_cascade_routing_policy
   test_cascade_routing_policy_targets_exist
   test_cascade_judge_route_intent_golden
+  test_agent_tool_descriptor_registry_integrity
   test_cascade_server_flavor
   test_cascade_phonebook_integration
   test_keeper_cascade_profile_partial
@@ -625,6 +626,7 @@
   test_cascade_routing_policy
   test_cascade_routing_policy_targets_exist
   test_cascade_judge_route_intent_golden
+  test_agent_tool_descriptor_registry_integrity
   test_cascade_server_flavor
   test_cascade_phonebook_integration
   test_keeper_cascade_profile_partial

--- a/test/dune
+++ b/test/dune
@@ -744,7 +744,6 @@
   test_tui_decode
   test_dashboard_governance
   test_dashboard_labels
-  test_dashboard_safe_autonomy
   test_dashboard_keeper_feature_proof
   test_dashboard_surface_readiness
   test_activity_graph
@@ -965,7 +964,6 @@
   test_tui_decode
   test_dashboard_governance
   test_dashboard_labels
-  test_dashboard_safe_autonomy
   test_dashboard_keeper_feature_proof
   test_dashboard_surface_readiness
   test_activity_graph

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -1,0 +1,108 @@
+(** Registry integrity checks that the OCaml type system cannot enforce.
+
+    [Agent_tool_descriptor.runtime_handler] is a closed variant and
+    every in-process dispatch site pattern-matches against it
+    exhaustively, so the "descriptor registered without a dispatch
+    handler" case is already caught at compile time. What is NOT
+    caught:
+
+    - duplicate [public_name] strings across descriptors
+    - duplicate [internal_name] strings across descriptors
+    - empty / whitespace-only name fields
+    - [internal_name] format drift (non-snake_case, embedded spaces,
+      etc.)
+
+    These are exactly the failures a big-bang descriptor-add merge
+    (e.g., RFC-0179 #18710, 38 descriptors) is most likely to
+    introduce: typos in name fields propagate silently until a caller
+    looks them up by string. *)
+
+open Alcotest
+module Descriptor = Masc_mcp.Agent_tool_descriptor
+
+let all_descriptors () : Descriptor.t list = Descriptor.all_descriptors ()
+
+let find_duplicates ~key (xs : Descriptor.t list) : (string * int) list =
+  let counts = Hashtbl.create 64 in
+  List.iter
+    (fun d ->
+      let k = key d in
+      let prev = Option.value (Hashtbl.find_opt counts k) ~default:0 in
+      Hashtbl.replace counts k (prev + 1))
+    xs;
+  Hashtbl.fold
+    (fun k count acc -> if count > 1 then (k, count) :: acc else acc)
+    counts
+    []
+
+let test_public_name_uniqueness () =
+  let dups = find_duplicates ~key:(fun d -> d.Descriptor.public_name) (all_descriptors ()) in
+  if dups <> []
+  then
+    Alcotest.failf
+      "duplicate public_name(s) across Agent_tool_descriptor.all_descriptors: %s"
+      (String.concat ", "
+         (List.map (fun (n, c) -> Printf.sprintf "%S×%d" n c) dups))
+
+let test_internal_name_uniqueness () =
+  let dups = find_duplicates ~key:(fun d -> d.Descriptor.internal_name) (all_descriptors ()) in
+  if dups <> []
+  then
+    Alcotest.failf
+      "duplicate internal_name(s) across Agent_tool_descriptor.all_descriptors: %s"
+      (String.concat ", "
+         (List.map (fun (n, c) -> Printf.sprintf "%S×%d" n c) dups))
+
+let is_blank s = String.trim s = ""
+
+let test_no_blank_names () =
+  List.iter
+    (fun d ->
+      if is_blank d.Descriptor.public_name
+      then
+        Alcotest.failf
+          "descriptor with internal_name=%S has blank public_name"
+          d.Descriptor.internal_name;
+      if is_blank d.Descriptor.internal_name
+      then
+        Alcotest.failf
+          "descriptor with public_name=%S has blank internal_name"
+          d.Descriptor.public_name)
+    (all_descriptors ())
+
+let internal_name_charset_ok c =
+  (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c = '_'
+
+let test_internal_name_snake_case () =
+  List.iter
+    (fun d ->
+      let n = d.Descriptor.internal_name in
+      String.iter
+        (fun c ->
+          if not (internal_name_charset_ok c)
+          then
+            Alcotest.failf
+              "internal_name %S contains non-snake_case character %C \
+               (allowed: a-z, 0-9, _)"
+              n
+              c)
+        n)
+    (all_descriptors ())
+
+let test_registry_not_empty () =
+  if all_descriptors () = []
+  then Alcotest.failf "Agent_tool_descriptor.all_descriptors () returned []"
+
+let () =
+  Alcotest.run
+    "agent_tool_descriptor_registry_integrity"
+    [ ( "uniqueness"
+      , [ test_case "registry not empty" `Quick test_registry_not_empty
+        ; test_case "public_name is unique" `Quick test_public_name_uniqueness
+        ; test_case "internal_name is unique" `Quick test_internal_name_uniqueness
+        ] )
+    ; ( "format"
+      , [ test_case "no blank name fields" `Quick test_no_blank_names
+        ; test_case "internal_name is snake_case" `Quick test_internal_name_snake_case
+        ] )
+    ]

--- a/test/test_transport_coverage.ml
+++ b/test/test_transport_coverage.ml
@@ -14,6 +14,7 @@
 open Alcotest
 
 module Transport = Masc_mcp.Transport
+module Sdk_tool_contract = Masc_mcp.Sdk_tool_contract
 
 (* ============================================================
    protocol Tests


### PR DESCRIPTION
## Why

`Agent_tool_descriptor.t` carries two string fields (`public_name`,
`internal_name`) that the OCaml type system cannot enforce as unique
or well-formed. A big-bang descriptor-add merge — exemplified by
RFC-0179 #18710, which added 38 descriptors in a single PR — is
precisely the situation where a copy-paste typo, a duplicated name,
or a stray whitespace lands silently.

The closed `runtime_handler` variant already protects against
"descriptor registered without a dispatch handler" because every
in-process dispatcher exhaustive-pattern-matches against it. That
class of drift is caught at compile time. String-field drift is not.

## What

`test/test_agent_tool_descriptor_registry_integrity.ml` — five
assertions over `Agent_tool_descriptor.all_descriptors ()`:

1. **registry not empty** — sanity floor
2. **public_name uniqueness** — catches duplicated user-facing tool names
3. **internal_name uniqueness** — catches duplicated canonical lookup keys
4. **no blank name fields** — catches accidental empty strings
5. **internal_name is snake_case** — catches casing/space drift
   (allowed charset: `a-z0-9_`)

All five pass today against the post-RFC-0179 registry, so this PR
introduces the test as a forward-going regression bar, not a fix.

## Out of scope

- Cross-process / external dispatch handler integrity: descriptors
  whose in-process handler returns `None` (`Tool_voice_dispatch`,
  `Tool_task_dispatch`, `Tool_board_dispatch`) are dispatched
  elsewhere. Verifying the external dispatcher knows about them is a
  separate test that would need to locate those dispatchers — out of
  scope here.
- Runtime invocation coverage (whether a registered descriptor is
  ever actually called). That would require Prometheus
  instrumentation on the dispatch hot path. Evaluated and held off
  because it touches production code.

## Risk profile

Pure additive. One new test file + one line in `test/dune`. No
production code touched.

## Stack

This PR is stacked on top of `fix/test-transport-coverage-alias`
(PR #18737). It cannot build against current main HEAD without that
fix because the broken `Sdk_tool_contract` reference and the
dangling `test_dashboard_safe_autonomy` dune entry block the whole
test stanza. Once #18737 merges, rebase this PR onto main.

## Verification

```
dune build test/test_agent_tool_descriptor_registry_integrity.exe --root .
# exit 0

dune exec test/test_agent_tool_descriptor_registry_integrity.exe --root .
# Test Successful in 0.001s. 5 tests run.
```

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
