### PR TITLE
fix(test): remove safe autonomy dune entry

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -744,7 +744,6 @@
   test_tui_decode
   test_dashboard_governance
   test_dashboard_labels
-  test_dashboard_safe_autonomy
   test_dashboard_keeper_feature_proof
   test_dashboard_surface_readiness
   test_activity_graph
@@ -965,7 +964,6 @@
   test_tui_decode
   test_dashboard_governance
   test_dashboard_labels
-  test_dashboard_safe_autonomy
   test_dashboard_keeper_feature_proof
   test_dashboard_surface_readiness
   test_activity_graph


### PR DESCRIPTION
## Summary
- remove stale test_dashboard_safe_autonomy from test/dune names and modules lists
- keep the removed Safe Autonomy test out of Dune rule generation after the dashboard surface was retired

## Verification
- rg -n "test_dashboard_safe_autonomy" test/dune test -S (no matches)
- git diff --check

## Notes
- Focused Dune verification was attempted via scripts/dune-local.sh, but local verification was blocked by active machine-wide Dune work from other sessions. CI should exercise the full Dune graph.