### PR TITLE
feat(tool_board_post): RFC-0189 PR-1b.2 — typed result for post + format helper + cache

### DIFF
--- a/lib/tool_board_cache.ml
+++ b/lib/tool_board_cache.ml
@@ -6,17 +6,22 @@
 
     Stage 10 split of lib/tool_board.ml. *)
 
-(* Cache only the rendered payload (success flag + message string) — never
-   the full [Tool_result.t]. Storing the whole record would let cache
-   hits reuse the *original* [duration_ms] and [start_time], so a 50 ms
-   reading 30 s later would still report the 250 ms it took the first
-   caller — and any other per-call telemetry baked into the record would
-   leak the same way. Copilot review #14662 thread 3. Each hit rebuilds
-   a fresh [Tool_result] with the current caller's [~start_time]. *)
+(* Cache only the rendered payload — never the full result record.
+   Storing the whole record would let cache hits reuse the *original*
+   [duration_ms] and [start_time], so a 50 ms reading 30 s later would
+   still report the 250 ms it took the first caller. Copilot review
+   #14662 thread 3. Each hit rebuilds a fresh result with the current
+   caller's [~start_time].
+
+   RFC-0189 PR-1b.2 — typed payload variant: [Ok message] vs
+   [Error (class_, message)]. The [class_] survives across the cache
+   boundary so a cached failure rebuilds with the same typed
+   classification it had on first call (no [classify_from_*] re-parse,
+   no [Runtime_failure] default). *)
 type cached_payload =
-  { success : bool
-  ; message : string
-  }
+  ( string
+  , Tool_result.tool_failure_class * string )
+    Stdlib.Result.t
 
 type board_list_cache =
   { mutable key : string option
@@ -33,28 +38,40 @@ let invalidate_board_list_cache () =
   board_list_cache.expires_at <- 0.0
 ;;
 
-let cached_board_list ~key ~tool_name ~start_time compute =
+let cached_board_list ~key ~tool_name ~start_time compute : Tool_result.result =
   let now = Time_compat.now () in
   let ttl_s = board_list_cache_ttl_s () in
-  let rebuild (payload : cached_payload) : Tool_result.t =
-    if payload.success
-    then Tool_result.ok ~tool_name ~start_time payload.message
-    else Tool_result.error ~tool_name ~start_time payload.message
+  let rebuild (payload : cached_payload) : Tool_result.result =
+    match payload with
+    | Ok message ->
+      Tool_result.make_ok
+        ~tool_name
+        ~start_time
+        ~data:(`String message)
+        ()
+    | Error (class_, message) ->
+      Tool_result.make_err ~tool_name ~class_ ~start_time message
+  in
+  let store_and_return (result : Tool_result.result) =
+    let payload : cached_payload =
+      match result with
+      | Ok s ->
+        (match s.data with
+         | `String msg -> Ok msg
+         | other -> Ok (Yojson.Safe.to_string other))
+      | Error f -> Error (f.class_, f.message)
+    in
+    board_list_cache.key <- Some key;
+    board_list_cache.value <- Some payload;
+    board_list_cache.expires_at <- now +. ttl_s;
+    result
   in
   match board_list_cache.key, board_list_cache.value with
   | Some cached_key, Some payload
     when String.equal cached_key key
          && Stdlib.Float.compare now board_list_cache.expires_at < 0 ->
     rebuild payload
-  | _ ->
-    let result : Tool_result.t = compute () in
-    let payload =
-      { success = result.success; message = Tool_result.message result }
-    in
-    board_list_cache.key <- Some key;
-    board_list_cache.value <- Some payload;
-    board_list_cache.expires_at <- now +. ttl_s;
-    result
+  | _ -> store_and_return (compute ())
 ;;
 
 (** Deterministic cache key from board_list args. Serializes the

--- a/lib/tool_board_dispatch.ml
+++ b/lib/tool_board_dispatch.ml
@@ -15,27 +15,34 @@
 let handle_tool name args =
   let start_time = Time_compat.now () in
   match name with
+  (* RFC-0189 PR-1b.2 — Tool_board_post + Tool_board_format helpers +
+     Tool_board_cache now all return [Tool_result.result]. Project to
+     legacy [Tool_result.t] at the dispatch boundary. *)
   | "masc_board_post" ->
     let result =
       Tool_board_format.with_yojson_boundary ~tool_name:name ~start_time (fun () ->
         Tool_board_post.handle_post_create ~tool_name:name ~start_time args)
+      |> Tool_result.to_legacy
     in
     Tool_board_cache.invalidate_board_list_cache ();
     result
   | "masc_board_list" ->
     Tool_board_post.handle_post_list ~tool_name:name ~start_time args
+    |> Tool_result.to_legacy
   | "masc_board_get" ->
     Tool_board_post.handle_post_get ~tool_name:name ~start_time args
+    |> Tool_result.to_legacy
   | "masc_board_comment" ->
     let result =
       Tool_board_format.with_yojson_boundary ~tool_name:name ~start_time (fun () ->
         Tool_board_post.handle_comment_add ~tool_name:name ~start_time args)
+      |> Tool_result.to_legacy
     in
     Tool_board_cache.invalidate_board_list_cache ();
     result
   (* RFC-0189 PR-1b.1 — Tool_board_handlers returns the typed
      [Tool_result.result] variant. Lift to legacy [Tool_result.t] at this
-     boundary while other board modules (post / curation / sub_board) are
+     boundary while other board modules (curation / sub_board) are
      still on the legacy surface. The to_legacy projection is lossless. *)
   | "masc_board_vote" ->
     let result =

--- a/lib/tool_board_format.ml
+++ b/lib/tool_board_format.ml
@@ -97,14 +97,20 @@ let board_error_to_string = function
 
 let board_error_failure_class = function
   | Board.Post_not_found _ | Board.Comment_not_found _ ->
-    Some Tool_result.Workflow_rejection
-  | _ -> None
+    Tool_result.Workflow_rejection
+  | _ -> Tool_result.Runtime_failure
 ;;
 
-let error_of_board_error ~tool_name ~start_time e =
-  Tool_result.error
-    ~failure_class:(board_error_failure_class e)
+(* RFC-0189 PR-1b.2 — typed helper. Returns [Tool_result.result] directly
+   so the [~class_] decision is committed at the catch boundary instead
+   of going through [classify_from_structured_failure_message]. Pre-RFC
+   version returned legacy [t] with [?failure_class:option] — the new
+   shape collapses two illegal states (None-on-failure, Some-on-success)
+   by construction. *)
+let error_of_board_error ~tool_name ~start_time e : Tool_result.result =
+  Tool_result.make_err
     ~tool_name
+    ~class_:(board_error_failure_class e)
     ~start_time
     (board_error_to_string e)
 ;;
@@ -593,15 +599,20 @@ let provenance_arg args =
     broadcast 2026-05-15T10:51:20Z). Diagnostic, not a workaround: the
     offending value field points the next triager at the failing
     field. *)
-let with_yojson_boundary ~tool_name ~start_time handler =
+let with_yojson_boundary ~tool_name ~start_time handler : Tool_result.result =
   try handler () with
   | Yojson.Safe.Util.Type_error (msg, bad_value) ->
     let value_repr =
       let s = Yojson.Safe.to_string bad_value in
       if String.length s > 120 then String.sub s 0 120 ^ "…" else s
     in
-    Tool_result.error
+    (* RFC-0189 — JSON type error is caller-input shape violation.
+       Workflow_rejection (not Runtime_failure) because the request itself
+       was malformed at the JSON layer; retrying with the same args won't
+       succeed. *)
+    Tool_result.make_err
       ~tool_name
+      ~class_:Tool_result.Workflow_rejection
       ~start_time
       (Printf.sprintf
          "JSON arg type error: %s. Offending value: %s. Likely cause: an \

--- a/lib/tool_board_handlers.ml
+++ b/lib/tool_board_handlers.ml
@@ -190,9 +190,7 @@ let handle_vote ~tool_name ~start_time args =
                ~data:(`String "Already voted (idempotent). Score unchanged.")
                ())
         | Error e ->
-          (* Legacy helper still returns Tool_result.t — lift via of_legacy. *)
-          Tool_result.of_legacy
-            (Tool_board_format.error_of_board_error ~tool_name ~start_time e)))
+          Tool_board_format.error_of_board_error ~tool_name ~start_time e))
 ;;
 
 let handle_stats ~tool_name ~start_time _args : Tool_result.result =
@@ -286,8 +284,7 @@ let handle_comment_vote ~tool_name ~start_time args : Tool_result.result =
                   (if String.equal direction_str "down" then "👎" else "👍")))
           ()
       | Error e ->
-        Tool_result.of_legacy
-          (Tool_board_format.error_of_board_error ~tool_name ~start_time e))
+        Tool_board_format.error_of_board_error ~tool_name ~start_time e)
 ;;
 
 let handle_reaction ~tool_name ~start_time args : Tool_result.result =
@@ -331,8 +328,7 @@ let handle_reaction ~tool_name ~start_time args : Tool_result.result =
                   (Board.reaction_toggle_result_to_yojson result)))
           ()
       | Error e ->
-        Tool_result.of_legacy
-          (Tool_board_format.error_of_board_error ~tool_name ~start_time e))
+        Tool_board_format.error_of_board_error ~tool_name ~start_time e)
 ;;
 
 (** Agent profile. *)

--- a/lib/tool_board_post.ml
+++ b/lib/tool_board_post.ml
@@ -24,12 +24,20 @@ module Float = Stdlib.Float
 
 open Tool_args
 
-let handle_post_create ~tool_name ~start_time args =
+(* RFC-0189 PR-1b.2 — handlers in this module return the typed
+   [Tool_result.result] variant directly. Boundary back to
+   [Tool_result.t] is in [Tool_board_dispatch] via [to_legacy]. *)
+
+let handle_post_create ~tool_name ~start_time args : Tool_result.result =
   let title = get_string_opt args "title" in
   (* Reject empty or whitespace-only titles. *)
   match title with
   | Some t when String.equal (String.trim t) "" ->
-    Tool_result.error ~tool_name ~start_time "Title must not be empty or whitespace-only"
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      "Title must not be empty or whitespace-only"
   | _ ->
     let body_arg =
       get_string_opt args "body" |> Option.map Tool_board_format.strip_state_blocks_text
@@ -79,16 +87,27 @@ let handle_post_create ~tool_name ~start_time args =
       | None -> false
     in
     if title_is_empty
-    then Tool_result.error ~tool_name ~start_time "title is required"
+    then
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Workflow_rejection
+        ~start_time
+        "title is required"
     else if
       Option.is_none author
       || Option.equal String.equal author (Some "")
       || Option.equal String.equal author (Some "anonymous")
-    then Tool_result.error ~tool_name ~start_time "author is required"
+    then
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Workflow_rejection
+        ~start_time
+        "author is required"
     else if String.length content > Board.Limits.max_content_length
     then
-      Tool_result.error
+      Tool_result.make_err
         ~tool_name
+        ~class_:Tool_result.Workflow_rejection
         ~start_time
         (Printf.sprintf
            "Content exceeds max length (%d > %d chars)"
@@ -115,7 +134,12 @@ let handle_post_create ~tool_name ~start_time args =
         | None -> Board.Internal
       in
       match Tool_board_handlers.resolve_board_post_kind ~author raw_post_kind with
-      | Error msg -> Tool_result.error ~tool_name ~start_time ("" ^ msg)
+      | Error msg ->
+        Tool_result.make_err
+          ~tool_name
+          ~class_:Tool_result.Workflow_rejection
+          ~start_time
+          msg
       | Ok post_kind ->
         (match
            Board_dispatch.create_post
@@ -133,15 +157,20 @@ let handle_post_create ~tool_name ~start_time args =
          with
          | Ok post ->
            let json = Board.post_to_yojson post in
-           Tool_result.ok
+           Tool_result.make_ok
              ~tool_name
              ~start_time
-             (Printf.sprintf "Post created:\n%s" (Yojson.Safe.pretty_to_string json))
+             ~data:
+               (`String
+                  (Printf.sprintf
+                     "Post created:\n%s"
+                     (Yojson.Safe.pretty_to_string json)))
+             ()
          | Error e ->
            Tool_board_format.error_of_board_error ~tool_name ~start_time e))
 ;;
 
-let handle_post_list_uncached ~tool_name ~start_time args =
+let handle_post_list_uncached ~tool_name ~start_time args : Tool_result.result =
   let limit = get_int args "limit" 20 |> max 1 |> min 100 in
   let compact = get_bool args "compact" true in
   let visibility_str = get_string_opt args "visibility" in
@@ -174,7 +203,12 @@ let handle_post_list_uncached ~tool_name ~start_time args =
     | Some value -> Tool_board_format.parse_sort_order value
   in
   match sort_by_result with
-  | Error msg -> Tool_result.error ~tool_name ~start_time (Printf.sprintf "%s" msg)
+  | Error msg ->
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      msg
   | Ok sort_by ->
     (* Fetch exactly what we need: offset posts to skip + limit posts to show.
        Board_dispatch.list_posts already applies visibility/hearth/author filters. *)
@@ -207,7 +241,12 @@ let handle_post_list_uncached ~tool_name ~start_time args =
       else List.filteri (fun i _ -> i < limit) sorted_posts
     in
     if Stdlib.List.length posts = 0
-    then Tool_result.ok ~tool_name ~start_time "No posts found."
+    then
+      Tool_result.make_ok
+        ~tool_name
+        ~start_time
+        ~data:(`String "No posts found.")
+        ()
     else (
       (* Check for new activity since timestamp. *)
       let has_new_activity (p : Board.post) =
@@ -241,10 +280,11 @@ let handle_post_list_uncached ~tool_name ~start_time args =
       let header =
         Printf.sprintf "Posts (%d) — %s%s:" (List.length posts) sort_label mode_label
       in
-      Tool_result.ok
+      Tool_result.make_ok
         ~tool_name
         ~start_time
-        (header ^ "\n" ^ String.concat separator formatted))
+        ~data:(`String (header ^ "\n" ^ String.concat separator formatted))
+        ())
 ;;
 
 let handle_post_list ~tool_name ~start_time args =
@@ -258,17 +298,20 @@ let handle_post_list ~tool_name ~start_time args =
       handle_post_list_uncached ~tool_name ~start_time args))
 ;;
 
-let handle_post_get ~tool_name ~start_time args =
+let handle_post_get ~tool_name ~start_time args : Tool_result.result =
   let post_id = get_string args "post_id" "" in
   match Board_dispatch.get_post_and_comments ~post_id with
   | Error (Board.Post_not_found _) ->
     (* Idempotent: post no longer exists (deleted/expired/TTL).
        Return success so keeper tool metrics don't count this as failure.
        The LLM still sees a clear message that the post is gone. *)
-    Tool_result.ok
+    Tool_result.make_ok
       ~tool_name
       ~start_time
-      (Printf.sprintf "Post %s no longer exists (deleted or expired)." post_id)
+      ~data:
+        (`String
+           (Printf.sprintf "Post %s no longer exists (deleted or expired)." post_id))
+      ()
   | Error e ->
     Tool_board_format.error_of_board_error ~tool_name ~start_time e
   | Ok (post, comments) ->
@@ -283,28 +326,48 @@ let handle_post_get ~tool_name ~start_time args =
           (List.length comments)
           (String.concat "\n" formatted))
     in
-    Tool_result.ok ~tool_name ~start_time (post_str ^ comments_str)
+    Tool_result.make_ok
+      ~tool_name
+      ~start_time
+      ~data:(`String (post_str ^ comments_str))
+      ()
 ;;
 
-let handle_comment_add ~tool_name ~start_time args =
+let handle_comment_add ~tool_name ~start_time args : Tool_result.result =
   let post_id = get_string args "post_id" "" in
   let content = get_string args "content" "" in
   let author = get_string_opt args "author" |> Option.map String.trim in
   let parent_id = get_string_opt args "parent_id" in
   let ttl_hours = get_int args "ttl_hours" Board.Limits.default_ttl_hours in
   if String.equal (String.trim post_id) ""
-  then Tool_result.error ~tool_name ~start_time "post_id is required"
+  then
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      "post_id is required"
   else if String.equal (String.trim content) ""
-  then Tool_result.error ~tool_name ~start_time "Content must not be empty"
+  then
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      "Content must not be empty"
   else if
     Option.is_none author
     || Option.equal String.equal author (Some "")
     || Option.equal String.equal author (Some "anonymous")
-  then Tool_result.error ~tool_name ~start_time "author is required"
+  then
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      "author is required"
   else if String.length content > Board.Limits.max_content_length
   then
-    Tool_result.error
+    Tool_result.make_err
       ~tool_name
+      ~class_:Tool_result.Workflow_rejection
       ~start_time
       (Printf.sprintf
          "Content exceeds max length (%d > %d chars)"
@@ -322,10 +385,15 @@ let handle_comment_add ~tool_name ~start_time args =
     with
     | Ok comment ->
       let json = Board.comment_to_yojson comment in
-      Tool_result.ok
+      Tool_result.make_ok
         ~tool_name
         ~start_time
-        (Printf.sprintf "Comment added:\n%s" (Yojson.Safe.pretty_to_string json))
+        ~data:
+          (`String
+             (Printf.sprintf
+                "Comment added:\n%s"
+                (Yojson.Safe.pretty_to_string json)))
+        ()
     | Error e ->
       Tool_board_format.error_of_board_error ~tool_name ~start_time e)
 ;;


### PR DESCRIPTION
## Summary

**Follow-up to merged #18736 (RFC-0189 PR-1b.1).** Cluster 2 of 6 of the RFC-0189 §3.2 staged migration. Promotes 3 modules to typed `Tool_result.result`:

- `Tool_board_post` — 5 handlers, 16 calls migrated
- `Tool_board_format` — `error_of_board_error` + `with_yojson_boundary` helpers
- `Tool_board_cache` — `cached_payload` + `cached_board_list` (the typed payload now survives cache TTL)

Plus cleanup in `Tool_board_handlers`: removed 3 `of_legacy` wraps from PR-1b.1 that became unnecessary once `error_of_board_error` returned typed result.

## Why this matters beyond \"another cluster\"

**The cache boundary**. Previously, `cached_payload = { success: bool; message: string }` lost the typed `failure_class` on every cache write. On a cache hit, the rebuild called `Tool_result.error ~tool_name ~start_time payload.message` which then re-invoked `classify_from_structured_failure_message` to recover the class from the JSON string. **The typed information died and was string-reparsed on every cache hit.**

This PR makes the cache typed:
```ocaml
type cached_payload =
  (string, Tool_result.tool_failure_class * string) Stdlib.Result.t
```

The `class_` survives across the 30s TTL window. Cache hits rebuild with the same typed classification the first call committed to.

## What's in this PR

```
 lib/tool_board_format.ml   |  +18  -7
 lib/tool_board_cache.ml    |  +43 -22
 lib/tool_board_post.ml     |  +96 -20
 lib/tool_board_handlers.ml |   +5  -5  (3 of_legacy wraps removed)
 lib/tool_board_dispatch.ml |   +8  -1
 5 files changed, +170 -55
```

### `make_err` class assignments

All in `Tool_board_post`:

| Site | class |
|---|---|
| `handle_post_create` title empty/whitespace | Workflow_rejection |
| `handle_post_create` title is required | Workflow_rejection |
| `handle_post_create` author is required | Workflow_rejection |
| `handle_post_create` content exceeds max length | Workflow_rejection |
| `handle_post_create` resolve_board_post_kind error | Workflow_rejection |
| `handle_post_list_uncached` sort_by parse error | Workflow_rejection |
| `handle_comment_add` post_id is required | Workflow_rejection |
| `handle_comment_add` Content must not be empty | Workflow_rejection |
| `handle_comment_add` author is required | Workflow_rejection |
| `handle_comment_add` content exceeds max length | Workflow_rejection |

In `Tool_board_format.with_yojson_boundary`:

| Site | class |
|---|---|
| `Yojson.Safe.Util.Type_error` | Workflow_rejection (caller-input shape violation; retrying with same args won't succeed) |

In `Tool_board_format.board_error_failure_class` (was `_ -> None`):

| Pattern | class |
|---|---|
| `Post_not_found _` \\| `Comment_not_found _` | Workflow_rejection |
| All other Board.board_error variants | Runtime_failure (was implicit None → string-reparsed at runtime) |

## Boundary contract after this PR

```
Tool_board_handlers       → Tool_result.result   (PR-1b.1)
Tool_board_post           → Tool_result.result   (this PR)
Tool_board_format.helpers → Tool_result.result   (this PR)
Tool_board_cache          → Tool_result.result   (this PR)
Tool_board_curation       → Tool_result.t   (legacy, PR-1b.3)
Tool_board_sub_board      → Tool_result.t   (legacy, PR-1b.3)
Tool_board_dispatch.handle_tool → Tool_result.t  (boundary, unchanged)
```

After PR-1b.3 the board cluster will be fully typed; PR-1b.4 then promotes `dispatch.handle_tool` itself (boundary moves one level out).

## Verification

- ✅ `dune build --root . lib/` → exit 0
- ⚠️ `dune exec test/test_tool_result.exe` and `test_tool_board_coverage.exe` fail to start with `Module Test_dashboard_safe_autonomy doesn't exist`. This is a **pre-existing main breakage** from #18730 (Safe Autonomy retire) leaving a dangling entry in `test/dune`. Reproduces on the PR-1b.1 base. Unrelated to this commit — a separate cleanup PR should restore `test/dune`.

## Workaround Signature Gate

- §2 substring classifier: this PR *removes* the `_ -> None` pattern from `board_error_failure_class` (a precursor that drove `classify_from_*` re-parsing on cache hits). Replaces with a **total** typed map.
- §3 N-of-M: cluster 2 of 6 of the RFC-documented migration. Each cluster is independently mergeable.

## Related

- merged **#18736** (PR-1b.1, board handlers)
- merged **#18718** (PR-1a, typed surface)
- **RFC-0189 §3.2** migration plan, PR-1b.2 cluster (this)

## Test plan

- [x] `dune build lib/` passes
- [ ] Reviewer: confirm `Workflow_rejection` for `with_yojson_boundary` JSON Type_error (vs `Runtime_failure`) — chose Workflow because the request itself was structurally invalid; retrying with the same args is guaranteed to fail. Open to flipping if "operator should see the original exception class" wins.
- [ ] Reviewer: confirm `Runtime_failure` default in `board_error_failure_class` for non-`Post_not_found`/`Comment_not_found` Board errors — previously `None` (which became `Runtime_failure` after string-reparse anyway).
- [ ] Follow-up: separate PR to clean up `test_dashboard_safe_autonomy` dangling reference in `test/dune` (blocks both `test_tool_result.exe` and `test_tool_board_coverage.exe` from running on current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)