### PR TITLE
chore(dashboard): purge Safe Autonomy residue (test/dune + preview)

### DIFF
--- a/dashboard/design-system/preview/scope-phase2.html
+++ b/dashboard/design-system/preview/scope-phase2.html
@@ -646,31 +646,6 @@
         </div>
       </div>
 
-      <div class="zone" id="o3">
-        <div class="zhead">
-          <span class="zid">O3</span>
-          <h3 class="ztitle">Safe Autonomy Scoreboard</h3>
-          <span class="zkind">observability</span>
-        </div>
-        <p class="lead">시스템 안전성 게이지 — 점수, status, finding 분포, 시계열.</p>
-        <p class="lbl">Real data</p>
-        <p class="data">
-          <b>.masc/audits/safe_autonomy/latest.json</b> (5444 lines급)<br/>
-          fields: <em>global_score</em>, <em>status</em> (pass|fail), <em>findings_total</em>, <em>keeper_count</em><br/>
-          <b>history.jsonl</b> · 시계열
-        </p>
-        <p class="lbl">Variants</p>
-        <ul class="vars">
-          <li><span><b>A · Score Gauge</b>global_score + status 큰 패널</span></li>
-          <li><span><b>B · Findings Table</b>severity / keeper / 카테고리별</span></li>
-          <li><span><b>C · Score Sparkline</b>history 추이</span></li>
-        </ul>
-        <div class="ide">
-          <p class="lbl">IDE Hook</p>
-          finding의 file:line → IDE에서 directly highlight.
-        </div>
-      </div>
-
       <div class="zone" id="o4">
         <div class="zhead">
           <span class="zid">O4</span>

--- a/dashboard/design-system/preview/snippets.jsx
+++ b/dashboard/design-system/preview/snippets.jsx
@@ -403,7 +403,7 @@ const SNIPPETS = [
     desc: 'Compact switch — track + thumb. Brass glow when on.',
     html:
 `<div style="display:flex;flex-direction:column;gap:10px">
-  <label class="toggle"><input type="checkbox" checked /><span class="track"></span>safe autonomy</label>
+  <label class="toggle"><input type="checkbox" checked /><span class="track"></span>auto-merge</label>
   <label class="toggle"><input type="checkbox" checked /><span class="track"></span>broadcast to #ops</label>
   <label class="toggle"><input type="checkbox" /><span class="track"></span>experimental cascade-v3</label>
 </div>`,

--- a/test/dune
+++ b/test/dune
@@ -744,7 +744,6 @@
   test_tui_decode
   test_dashboard_governance
   test_dashboard_labels
-  test_dashboard_safe_autonomy
   test_dashboard_keeper_feature_proof
   test_dashboard_surface_readiness
   test_activity_graph
@@ -965,7 +964,6 @@
   test_tui_decode
   test_dashboard_governance
   test_dashboard_labels
-  test_dashboard_safe_autonomy
   test_dashboard_keeper_feature_proof
   test_dashboard_surface_readiness
   test_activity_graph


### PR DESCRIPTION
## Summary

PR #18730 (Safe Autonomy retire) 의 *post-merge residue cleanup*. 머지 후 `rg` 로 잡힌 잔존 reference 3개 정리. Live source (test/dune) + live UI preview (snippets.jsx + scope-phase2.html O3 zone).

## 변경 사항

| File | 변경 | 이유 |
|---|---|---|
| `test/dune` | `test_dashboard_safe_autonomy` entry 2 stanza 제거 | #18730 이 test file 만 delete, dune executable list 잔존 → build/CI fail risk |
| `dashboard/design-system/preview/scope-phase2.html` | O3 "Safe Autonomy Scoreboard" zone block (25 LoC) 제거 | live design preview UI 의 dead surface description |
| `dashboard/design-system/preview/snippets.jsx` | toggle row label `safe autonomy` → `auto-merge` | retire 후 의미 잃은 generic UI example label 교체 |

## Scope 결정

**Historical 보존**: `dashboard/design-system/audits/2026-04-29-*.md` 및 `RFC/0017-solidjs-migration-measurement.md` 의 잔존 reference 는 *dated snapshot of past state* 이라 *historical accuracy* 정합으로 유지. 다른 PR 안 만든다.

**Regression marker 보존**: `dashboard/src/config/navigation.test.ts:167` `not.toContain('safe-autonomy')` 는 nav 재추가 막는 *regression test* — 유지.

**Disk artifact 별도**: `~/.masc/audits/safe_autonomy/` (42MB+ history.jsonl, 225KB latest.json) 는 server runtime artifact. 본 PR scope 밖. 서버 runtime owner 진단 후 별도 정리.

## Verification

- `dune build --root . lib/ test/` 진행 (commit 직전 확인)
- diff stat: 3 files, +1 / -28 LoC

🤖 Generated with [Claude Code](https://claude.com/claude-code)
