### PR TITLE
feat(agent-tool): project descriptor receipt labels

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -848,6 +848,10 @@ let bool_opt_to_json = function
   | None -> `Null
 ;;
 
+let receipt_labels_json d =
+  `Assoc (List.map (fun (key, value) -> key, `String value) d.receipt_labels)
+;;
+
 let route_evidence_json d =
   let policy = d.policy in
   let policy_fields =
@@ -867,6 +871,7 @@ let route_evidence_json d =
      ; "backend", `String (backend_to_string d.backend)
      ; "sandbox", `String (sandbox_to_string d.sandbox)
      ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
+     ; "receipt_labels", receipt_labels_json d
      ; "approval", `String (approval_to_string policy.approval)
      ; "retryable", `Bool policy.retryable
      ; "cwd_scope", string_opt_to_json policy.cwd_scope

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -108,4 +108,5 @@ val descriptors_for_internal : string -> t list
 
 val public_input_schema : string -> Yojson.Safe.t option
 val translate_input : public:string -> Yojson.Safe.t -> Yojson.Safe.t
+val receipt_labels_json : t -> Yojson.Safe.t
 val route_evidence_json : t -> Yojson.Safe.t

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -102,6 +102,16 @@ let count_descriptors ~f descriptors =
   |> count_json
 ;;
 
+let descriptor_receipt_labels_json descriptors =
+  descriptors
+  |> List.map (fun (descriptor : Agent_tool_descriptor.t) ->
+    `Assoc
+      [ "descriptor_id", `String descriptor.id
+      ; "labels", Agent_tool_descriptor.receipt_labels_json descriptor
+      ])
+  |> fun values -> `List values
+;;
+
 let policy_decision_failed receipt =
   let candidates =
     [ receipt.terminal_reason_code
@@ -133,6 +143,7 @@ let tool_descriptor_summary_json receipt =
     ; ( "observed_descriptor_ids"
       , list_json (List.map (fun (d : Agent_tool_descriptor.t) -> d.id) descriptors) )
     ; "descriptor_count", `Int (List.length descriptors)
+    ; "receipt_labels_by_descriptor", descriptor_receipt_labels_json descriptors
     ; ( "executor_counts"
       , count_descriptors
           ~f:(fun (d : Agent_tool_descriptor.t) ->

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -468,6 +468,19 @@ let test_descriptor_route_evidence_names_policy_backend_sandbox_and_description 
     "runtime handler"
     (Some "tool_execute")
     (yojson_string_field "runtime_handler" evidence);
+  let receipt_labels = Yojson.Safe.Util.(evidence |> member "receipt_labels") in
+  Alcotest.(check (option string))
+    "receipt label descriptor id"
+    (Some "agent.execute")
+    (yojson_string_field "descriptor_id" receipt_labels);
+  Alcotest.(check (option string))
+    "receipt label executor"
+    (Some "shell_ir")
+    (yojson_string_field "executor" receipt_labels);
+  Alcotest.(check (option string))
+    "receipt label canonical name"
+    (Some "tool_execute")
+    (yojson_string_field "canonical_name" receipt_labels);
   Alcotest.(check (option string))
     "visibility"
     (Some "default")
@@ -597,6 +610,33 @@ let test_execution_receipt_descriptor_summary_projects_descriptors () =
     [ "agent.read_file"; "keeper.time.now"; "agent.execute" ]
     Yojson.Safe.Util.(
       summary |> member "observed_descriptor_ids" |> to_list |> List.map to_string);
+  let receipt_labels_for descriptor_id =
+    Yojson.Safe.Util.(
+      summary
+      |> member "receipt_labels_by_descriptor"
+      |> to_list
+      |> List.find_opt (fun item ->
+        yojson_string_field "descriptor_id" item = Some descriptor_id)
+      |> Option.map (fun item -> item |> member "labels"))
+  in
+  (match receipt_labels_for "agent.execute" with
+   | Some labels ->
+     Alcotest.(check (option string))
+       "execute receipt label public name"
+       (Some "Execute")
+       (yojson_string_field "public_name" labels);
+     Alcotest.(check (option string))
+       "execute receipt label backend"
+       (Some "sandbox_process")
+       (yojson_string_field "backend" labels)
+   | None -> Alcotest.fail "missing execute receipt labels");
+  (match receipt_labels_for "keeper.time.now" with
+   | Some labels ->
+     Alcotest.(check (option string))
+       "time receipt label runtime handler"
+       (Some "tool_time_now")
+       (yojson_string_field "runtime_handler" labels)
+   | None -> Alcotest.fail "missing time receipt labels");
   Alcotest.(check (option int))
     "descriptor count"
     (Some 3)


### PR DESCRIPTION
## Summary

- emit descriptor `receipt_labels` in per-tool route evidence
- aggregate descriptor receipt labels in turn-level `tool_descriptor_summary`
- pin route-evidence and execution-receipt projection tests

## Verification

- `ocamlformat --check lib/keeper/agent_tool_descriptor.mli lib/keeper/agent_tool_descriptor.ml lib/keeper/keeper_execution_receipt.ml test/test_keeper_tool_alias.ml`
- `git diff --check origin/main...HEAD`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_keeper_tool_alias.exe ./test/test_keeper_tool_call_log.exe`
- `./_build/default/test/test_keeper_tool_alias.exe`
- `./_build/default/test/test_keeper_tool_call_log.exe`
