### PR TITLE
feat(tool_board): RFC-0189 PR-1b.3 — typed result for curation + sub_board (board cluster COMPLETE)

### DIFF
--- a/lib/tool_board_curation.ml
+++ b/lib/tool_board_curation.ml
@@ -58,21 +58,39 @@ let curation_health_components_arg args =
 
 (** {1 Handlers} *)
 
-let handle_board_curation_read ~tool_name ~start_time _args =
+(* RFC-0189 PR-1b.3 — handlers in this module return typed
+   [Tool_result.result]. Boundary in [Tool_board_dispatch] via
+   [to_legacy]. Curation snapshots are passed as typed JSON [~data]
+   directly instead of round-tripping through a string message
+   (legacy [Tool_result.ok] re-parsed JSON-shaped messages back into
+   [`Assoc] via [structured_payload_of_message] — typed [~data] skips
+   that intermediate step entirely). *)
+
+let handle_board_curation_read ~tool_name ~start_time _args : Tool_result.result =
   match Board_dispatch.latest_curation_snapshot () with
-  | None -> Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string `Null)
+  | None -> Tool_result.make_ok ~tool_name ~start_time ~data:`Null ()
   | Some snap ->
     let json = Board_curation.snapshot_to_yojson snap in
-    Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string json)
+    Tool_result.make_ok ~tool_name ~start_time ~data:json ()
 ;;
 
-let handle_board_curation_submit ~tool_name ~start_time args =
+let handle_board_curation_submit ~tool_name ~start_time args : Tool_result.result =
   let submitted_by = get_string args "submitted_by" "" |> String.trim in
   let rationale = get_string args "rationale" "" |> String.trim in
   if String.equal submitted_by ""
-  then Tool_result.error ~tool_name ~start_time "submitted_by required"
+  then
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      "submitted_by required"
   else if String.equal rationale ""
-  then Tool_result.error ~tool_name ~start_time "rationale required"
+  then
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      "rationale required"
   else (
     let model = Tool_board_format.string_opt_arg args "model" in
     let summary = Tool_board_format.string_opt_arg args "summary" in
@@ -83,7 +101,12 @@ let handle_board_curation_submit ~tool_name ~start_time args =
     let health_score = get_float_opt args "health_score" in
     let health_components = curation_health_components_arg args in
     match Tool_board_format.provenance_arg args with
-    | Error msg -> Tool_result.error ~tool_name ~start_time msg
+    | Error msg ->
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Workflow_rejection
+        ~start_time
+        msg
     | Ok provenance ->
       (try
          let snap =
@@ -101,10 +124,16 @@ let handle_board_curation_submit ~tool_name ~start_time args =
              ~provenance
              ()
          in
-         Tool_result.ok
+         Tool_result.make_ok
            ~tool_name
            ~start_time
-           (Yojson.Safe.to_string (Board_curation.snapshot_to_yojson snap))
+           ~data:(Board_curation.snapshot_to_yojson snap)
+           ()
        with
-       | Invalid_argument msg -> Tool_result.error ~tool_name ~start_time msg))
+       | Invalid_argument msg ->
+         Tool_result.make_err
+           ~tool_name
+           ~class_:Tool_result.Workflow_rejection
+           ~start_time
+           msg))
 ;;

--- a/lib/tool_board_dispatch.ml
+++ b/lib/tool_board_dispatch.ml
@@ -77,10 +77,17 @@ let handle_tool name args =
   | "masc_board_hearths" ->
     Tool_board_handlers.handle_hearth_list ~tool_name:name ~start_time args
     |> Tool_result.to_legacy
+  (* RFC-0189 PR-1b.3 — Tool_board_curation + Tool_board_sub_board now
+     return typed [Tool_result.result]. Project to legacy at boundary.
+     After this PR the entire board cluster is typed; PR-1b.4 will
+     promote [handle_tool] itself to result, moving the boundary one
+     level out. *)
   | "masc_board_curation_read" ->
     Tool_board_curation.handle_board_curation_read ~tool_name:name ~start_time args
+    |> Tool_result.to_legacy
   | "masc_board_curation_submit" ->
     Tool_board_curation.handle_board_curation_submit ~tool_name:name ~start_time args
+    |> Tool_result.to_legacy
   | "masc_board_delete" ->
     let result =
       Tool_board_handlers.handle_delete ~tool_name:name ~start_time args
@@ -98,22 +105,27 @@ let handle_tool name args =
   | "masc_board_sub_board_create" ->
     let result =
       Tool_board_sub_board.handle_sub_board_create ~tool_name:name ~start_time args
+      |> Tool_result.to_legacy
     in
     Tool_board_cache.invalidate_board_list_cache ();
     result
   | "masc_board_sub_board_list" ->
     Tool_board_sub_board.handle_sub_board_list ~tool_name:name ~start_time args
+    |> Tool_result.to_legacy
   | "masc_board_sub_board_get" ->
     Tool_board_sub_board.handle_sub_board_get ~tool_name:name ~start_time args
+    |> Tool_result.to_legacy
   | "masc_board_sub_board_update" ->
     let result =
       Tool_board_sub_board.handle_sub_board_update ~tool_name:name ~start_time args
+      |> Tool_result.to_legacy
     in
     Tool_board_cache.invalidate_board_list_cache ();
     result
   | "masc_board_sub_board_delete" ->
     let result =
       Tool_board_sub_board.handle_sub_board_delete ~tool_name:name ~start_time args
+      |> Tool_result.to_legacy
     in
     Tool_board_cache.invalidate_board_list_cache ();
     result

--- a/lib/tool_board_sub_board.ml
+++ b/lib/tool_board_sub_board.ml
@@ -7,7 +7,16 @@
 
 open Tool_args
 
-let handle_sub_board_create ~tool_name ~start_time args =
+(* RFC-0189 PR-1b.3 — handlers return typed [Tool_result.result].
+   Boundary to legacy [Tool_result.t] in [Tool_board_dispatch] via
+   [to_legacy]. Sub-board Board_dispatch errors (slug already exists,
+   owner not found, sub_board not found, etc.) are predominantly
+   caller-input violations → [Workflow_rejection]. A future RFC may
+   route through [Tool_board_format.board_error_failure_class] for
+   per-variant routing, but for the current sub_board error vocabulary
+   a uniform Workflow_rejection matches observed semantics. *)
+
+let handle_sub_board_create ~tool_name ~start_time args : Tool_result.result =
   let slug = get_string_opt args "slug" |> Option.value ~default:"" in
   let name = get_string_opt args "name" |> Option.value ~default:"" in
   let description = get_string_opt args "description" |> Option.value ~default:"" in
@@ -31,14 +40,22 @@ let handle_sub_board_create ~tool_name ~start_time args =
       ()
   with
   | Ok sb ->
-    Tool_result.ok
+    Tool_result.make_ok
       ~tool_name
       ~start_time
-      (Printf.sprintf "SubBoard created: %s (/%s)" sb.Board.name sb.Board.slug)
-  | Error e -> Tool_result.error ~tool_name ~start_time (Board.show_board_error e)
+      ~data:
+        (`String
+           (Printf.sprintf "SubBoard created: %s (/%s)" sb.Board.name sb.Board.slug))
+      ()
+  | Error e ->
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      (Board.show_board_error e)
 ;;
 
-let handle_sub_board_list ~tool_name ~start_time _args =
+let handle_sub_board_list ~tool_name ~start_time _args : Tool_result.result =
   let boards = Board_dispatch.list_sub_boards () in
   let lines =
     List.map
@@ -53,32 +70,44 @@ let handle_sub_board_list ~tool_name ~start_time _args =
            sb.post_count)
       boards
   in
-  Tool_result.ok ~tool_name ~start_time (String.concat "\n" lines)
+  Tool_result.make_ok
+    ~tool_name
+    ~start_time
+    ~data:(`String (String.concat "\n" lines))
+    ()
 ;;
 
-let handle_sub_board_get ~tool_name ~start_time args =
+let handle_sub_board_get ~tool_name ~start_time args : Tool_result.result =
   let sub_board_id = get_string_opt args "sub_board_id" |> Option.value ~default:"" in
   match Board_dispatch.get_sub_board ~sub_board_id with
   | Ok sb ->
     let members =
       List.map Board.Agent_id.to_string sb.Board.members |> String.concat ", "
     in
-    Tool_result.ok
+    Tool_result.make_ok
       ~tool_name
       ~start_time
-      (Printf.sprintf
-         "%s (/%s)\nDescription: %s\nOwner: %s\nAccess: %s\nMembers: %s\nPosts: %d"
-         sb.name
-         sb.slug
-         sb.description
-         (Board.Agent_id.to_string sb.owner)
-         (Board.sub_board_access_to_string sb.access)
-         members
-         sb.post_count)
-  | Error e -> Tool_result.error ~tool_name ~start_time (Board.show_board_error e)
+      ~data:
+        (`String
+           (Printf.sprintf
+              "%s (/%s)\nDescription: %s\nOwner: %s\nAccess: %s\nMembers: %s\nPosts: %d"
+              sb.name
+              sb.slug
+              sb.description
+              (Board.Agent_id.to_string sb.owner)
+              (Board.sub_board_access_to_string sb.access)
+              members
+              sb.post_count))
+      ()
+  | Error e ->
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      (Board.show_board_error e)
 ;;
 
-let handle_sub_board_update ~tool_name ~start_time args =
+let handle_sub_board_update ~tool_name ~start_time args : Tool_result.result =
   let sub_board_id = get_string_opt args "sub_board_id" |> Option.value ~default:"" in
   let name = get_string_opt args "name" in
   let description = get_string_opt args "description" in
@@ -102,20 +131,34 @@ let handle_sub_board_update ~tool_name ~start_time args =
       ()
   with
   | Ok sb ->
-    Tool_result.ok
+    Tool_result.make_ok
       ~tool_name
       ~start_time
-      (Printf.sprintf "SubBoard updated: %s (/%s)" sb.Board.name sb.Board.slug)
-  | Error e -> Tool_result.error ~tool_name ~start_time (Board.show_board_error e)
+      ~data:
+        (`String
+           (Printf.sprintf "SubBoard updated: %s (/%s)" sb.Board.name sb.Board.slug))
+      ()
+  | Error e ->
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      (Board.show_board_error e)
 ;;
 
-let handle_sub_board_delete ~tool_name ~start_time args =
+let handle_sub_board_delete ~tool_name ~start_time args : Tool_result.result =
   let sub_board_id = get_string_opt args "sub_board_id" |> Option.value ~default:"" in
   match Board_dispatch.delete_sub_board ~sub_board_id with
   | Ok () ->
-    Tool_result.ok
+    Tool_result.make_ok
       ~tool_name
       ~start_time
-      (Printf.sprintf "SubBoard deleted: %s" sub_board_id)
-  | Error e -> Tool_result.error ~tool_name ~start_time (Board.show_board_error e)
+      ~data:(`String (Printf.sprintf "SubBoard deleted: %s" sub_board_id))
+      ()
+  | Error e ->
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      (Board.show_board_error e)
 ;;


### PR DESCRIPTION
## Summary

**Cluster 3 of 6 of the RFC-0189 §3.2 migration.** Promotes `Tool_board_curation` (2 handlers, 7 calls) and `Tool_board_sub_board` (5 handlers, 9 calls) to typed `Tool_result.result`.

**This completes the board cluster** — every board module now returns `Tool_result.result`. PR-1b.4 can promote `Tool_board_dispatch.handle_tool` itself to result, moving the boundary one level out.

## Board cluster status after this PR

```
✅ Tool_board_handlers       (PR-1b.1 #18736)
✅ Tool_board_post           (PR-1b.2 #18740)
✅ Tool_board_format.helpers (PR-1b.2 #18740)
✅ Tool_board_cache          (PR-1b.2 #18740)
✅ Tool_board_curation       (this PR)
✅ Tool_board_sub_board      (this PR)

→ PR-1b.4 unlocks: Tool_board_dispatch.handle_tool itself to typed result
```

## What's in this PR

```
 lib/tool_board_curation.ml  | +38 -11
 lib/tool_board_sub_board.ml | +71 -24
 lib/tool_board_dispatch.ml  | +11  -1
 3 files changed, +120 -36
```

### `make_err` class assignments

All `Workflow_rejection` — both modules' errors are caller-input violations:

| Module / site | class |
|---|---|
| curation: submitted_by required | Workflow_rejection |
| curation: rationale required | Workflow_rejection |
| curation: provenance parse error | Workflow_rejection |
| curation: Invalid_argument from Board_dispatch | Workflow_rejection |
| sub_board: 4× Board errors (create/get/update/delete) | Workflow_rejection |

Sub_board Board error notes: errors include slug-exists, owner-not-found, sub_board-not-found — all caller-input issues. A future RFC may route through `Tool_board_format.board_error_failure_class` for per-variant routing; current vocabulary maps uniformly to Workflow_rejection.

### Curation: typed payload skipped legacy reparse

Previously `handle_board_curation_read`/`_submit` returned snapshot JSON as `Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string json)`. Legacy `ok` then re-invoked `structured_payload_of_message` to re-parse the JSON string back into `\`Assoc`. The new code passes `~data:json` directly — typed JSON survives without the round-trip.

## Verification

- ✅ `dune build --root . lib/` → exit 0
- ✅ `dune exec --root . test/test_tool_result.exe` → **20/20 PASS** (all PR-1a illegal-state tests still pass)

## Why PR-1b.4 is the natural next

After this PR every board cluster module returns `Tool_result.result`. The 18 per-arm `|> to_legacy` calls in `Tool_board_dispatch.handle_tool` can collapse into one at the dispatch entry by promoting `handle_tool` itself:

```ocaml
val handle_tool : string -> Yojson.Safe.t -> Tool_result.result
```

Then `to_legacy` lifts at `Tool_spec.create ~handler_binding` instead of inside each match arm. **Boundary moves from inside dispatch to the registration edge** — one canonical handoff point instead of 18.

## Workaround Signature Gate

- §2 substring classifier: no new classifier. Each `make_err` declares `~class_` at the catch site.
- §3 N-of-M: cluster 3 of 6 of the RFC-documented migration. Each cluster independently mergeable.

## Related

- merged **#18740** (PR-1b.2, board_post + format + cache)
- merged **#18736** (PR-1b.1, board_handlers)
- merged **#18718** (PR-1a, typed surface)
- **RFC-0189 §3.2** PR-1b.3 (this) — completes board cluster

## Test plan

- [x] `dune build lib/` passes
- [x] `dune exec test/test_tool_result.exe` 20/20 PASS
- [ ] Reviewer: confirm `Workflow_rejection` for all sub_board Board errors (uniform mapping vs per-variant routing through `board_error_failure_class`)
- [ ] Reviewer: confirm `Workflow_rejection` for `Invalid_argument` from `Board_dispatch.submit_curation_snapshot` (could argue `Runtime_failure` if "validation lives downstream"; chose Workflow given the exn carries a human-readable validation message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)