### PR TITLE
feat(tool_plan): RFC-0189 PR-1b.5 — typed result for 8 plan handlers (boundary at dispatch)

### DIFF
--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -29,9 +29,24 @@ type context = {
 
 open Tool_args
 
+(* RFC-0189 PR-1b.5 — handlers in this module return typed
+   [Tool_result.result]. Boundary back to [Tool_result.t] lives in
+   [dispatch] below via [Tool_result.to_legacy]. External callers
+   (mcp_server_eio_execute, keeper_tag_dispatch) see no signature
+   change because [dispatch] still returns [Tool_result.t option].
+
+   Failure class assignments:
+   - Planning_eio internal "Failed to ..." errors → Runtime_failure
+     (Planning_eio is the persistence boundary; the error is opaque
+      to the caller and not retryable with different args).
+   - "task_id is required" / "content is required" / resolve_task_id
+     parse errors / "not found" lookups / set_current_task validation
+     → Workflow_rejection (caller-input violations; same args won't
+      succeed on retry). *)
+
 (** {1 Individual Handlers} *)
 
-let handle_plan_init ~tool_name ~start_time ctx args =
+let handle_plan_init ~tool_name ~start_time ctx args : Tool_result.result =
   let task_id = get_string args "task_id" "" in
   let result = Planning_eio.init ctx.config ~task_id in
   match result with
@@ -41,11 +56,15 @@ let handle_plan_init ~tool_name ~start_time ctx args =
         ("task_id", `String task_id);
         ("message", `String (Printf.sprintf "Planning context created for %s" task_id));
       ] in
-      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
+      Tool_result.make_ok ~tool_name ~start_time ~data:response ()
   | Error e ->
-      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to init planning: %s" e)
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Runtime_failure
+        ~start_time
+        (Printf.sprintf "Failed to init planning: %s" e)
 
-let handle_plan_update ~tool_name ~start_time ctx args =
+let handle_plan_update ~tool_name ~start_time ctx args : Tool_result.result =
   let task_id = get_string args "task_id" "" in
   let content = get_string args "content" "" in
   let result = Planning_eio.update_plan ctx.config ~task_id ~content in
@@ -56,11 +75,15 @@ let handle_plan_update ~tool_name ~start_time ctx args =
         ("task_id", `String task_id);
         ("updated_at", `String plan_ctx.Planning_eio.updated_at);
       ] in
-      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
+      Tool_result.make_ok ~tool_name ~start_time ~data:response ()
   | Error e ->
-      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to update plan: %s" e)
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Runtime_failure
+        ~start_time
+        (Printf.sprintf "Failed to update plan: %s" e)
 
-let handle_note_add ~tool_name ~start_time ctx args =
+let handle_note_add ~tool_name ~start_time ctx args : Tool_result.result =
   let task_id = get_string args "task_id" "" in
   let note = get_string args "note" "" in
   let result = Planning_eio.add_note ctx.config ~task_id ~note in
@@ -71,18 +94,31 @@ let handle_note_add ~tool_name ~start_time ctx args =
         ("task_id", `String task_id);
         ("note_count", `Int (List.length plan_ctx.Planning_eio.notes));
       ] in
-      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
+      Tool_result.make_ok ~tool_name ~start_time ~data:response ()
   | Error e ->
-      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to add note: %s" e)
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Runtime_failure
+        ~start_time
+        (Printf.sprintf "Failed to add note: %s" e)
 
-let handle_deliver ~tool_name ~start_time ctx args =
+let handle_deliver ~tool_name ~start_time ctx args : Tool_result.result =
   let task_id_input = get_string args "task_id" "" in
   match Planning_eio.resolve_task_id ctx.config ~task_id:task_id_input with
-  | Error e -> Tool_result.error ~tool_name ~start_time (Printf.sprintf "%s" e)
+  | Error e ->
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Workflow_rejection
+        ~start_time
+        e
   | Ok task_id ->
   let content = get_string args "content" "" in
   if String.equal (String.trim content) "" then
-    Tool_result.error ~tool_name ~start_time "content is required for masc_deliver"
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      "content is required for masc_deliver"
   else
   let result = Planning_eio.set_deliverable ctx.config ~task_id ~content in
   match result with
@@ -92,14 +128,23 @@ let handle_deliver ~tool_name ~start_time ctx args =
         ("task_id", `String task_id);
         ("updated_at", `String plan_ctx.Planning_eio.updated_at);
       ] in
-      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
+      Tool_result.make_ok ~tool_name ~start_time ~data:response ()
   | Error e ->
-      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to set deliverable: %s" e)
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Runtime_failure
+        ~start_time
+        (Printf.sprintf "Failed to set deliverable: %s" e)
 
-let handle_plan_get ~tool_name ~start_time ctx args =
+let handle_plan_get ~tool_name ~start_time ctx args : Tool_result.result =
   let task_id_input = get_string args "task_id" "" in
   match Planning_eio.resolve_task_id ctx.config ~task_id:task_id_input with
-  | Error e -> Tool_result.error ~tool_name ~start_time (Printf.sprintf "%s" e)
+  | Error e ->
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Workflow_rejection
+        ~start_time
+        e
   | Ok task_id ->
       let result = Planning_eio.load ctx.config ~task_id in
       match result with
@@ -110,58 +155,78 @@ let handle_plan_get ~tool_name ~start_time ctx args =
             ("context", Planning_eio.planning_context_to_yojson plan_ctx);
             ("markdown", `String markdown);
           ] in
-          Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
+          Tool_result.make_ok ~tool_name ~start_time ~data:response ()
       | Error e ->
-          Tool_result.error ~tool_name ~start_time (Printf.sprintf "Planning context not found: %s" e)
+          Tool_result.make_err
+            ~tool_name
+            ~class_:Tool_result.Workflow_rejection
+            ~start_time
+            (Printf.sprintf "Planning context not found: %s" e)
 
-let handle_plan_set_task ~tool_name ~start_time ctx args =
+let handle_plan_set_task ~tool_name ~start_time ctx args : Tool_result.result =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    Tool_result.error ~tool_name ~start_time "task_id is required"
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      "task_id is required"
   else match Planning_eio.set_current_task ctx.config ~task_id with
-  | Error e -> Tool_result.error ~tool_name ~start_time e
+  | Error e ->
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Workflow_rejection
+        ~start_time
+        e
   | Ok () ->
     let response = `Assoc [
       Plan_action_outcome.(status_field Set);
       ("current_task", `String task_id);
     ] in
-    Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
+    Tool_result.make_ok ~tool_name ~start_time ~data:response ()
 
-let handle_plan_get_task ~tool_name ~start_time ctx _args =
+let handle_plan_get_task ~tool_name ~start_time ctx _args : Tool_result.result =
   match Planning_eio.get_current_task ctx.config with
   | Some task_id ->
       let response = `Assoc [
         ("current_task", `String task_id);
       ] in
-      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
+      Tool_result.make_ok ~tool_name ~start_time ~data:response ()
   | None ->
       let response = `Assoc [
         ("current_task", `Null);
         ("message", `String "No current task set. Use masc_plan_set_task first.");
       ] in
-      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
+      Tool_result.make_ok ~tool_name ~start_time ~data:response ()
 
-let handle_plan_clear_task ~tool_name ~start_time ctx _args =
+let handle_plan_clear_task ~tool_name ~start_time ctx _args : Tool_result.result =
   Planning_eio.clear_current_task ctx.config;
   let response = `Assoc [
     Plan_action_outcome.(status_field Cleared);
     ("message", `String "Current task cleared");
   ] in
-  Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
+  Tool_result.make_ok ~tool_name ~start_time ~data:response ()
 
 (** {1 Dispatcher} *)
 
+(* RFC-0189 PR-1b.5 — dispatch is the external boundary. Handlers above
+   return typed [Tool_result.result]; this function projects to legacy
+   [Tool_result.t option] for un-migrated callers
+   (mcp_server_eio_execute, keeper_tag_dispatch). After PR-1c the
+   external surface itself can move to result, and this [to_legacy]
+   bridge disappears. *)
 let dispatch ctx ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
+  let lift r = Some (Tool_result.to_legacy r) in
   match name with
-  | "masc_plan_init" -> Some (handle_plan_init ~tool_name:name ~start_time:start ctx args)
-  | "masc_plan_update" -> Some (handle_plan_update ~tool_name:name ~start_time:start ctx args)
-  | "masc_note_add" -> Some (handle_note_add ~tool_name:name ~start_time:start ctx args)
-  | "masc_deliver" -> Some (handle_deliver ~tool_name:name ~start_time:start ctx args)
-  | "masc_plan_get" -> Some (handle_plan_get ~tool_name:name ~start_time:start ctx args)
-  | "masc_plan_set_task" -> Some (handle_plan_set_task ~tool_name:name ~start_time:start ctx args)
-  | "masc_plan_get_task" -> Some (handle_plan_get_task ~tool_name:name ~start_time:start ctx args)
-  | "masc_plan_clear_task" -> Some (handle_plan_clear_task ~tool_name:name ~start_time:start ctx args)
+  | "masc_plan_init" -> lift (handle_plan_init ~tool_name:name ~start_time:start ctx args)
+  | "masc_plan_update" -> lift (handle_plan_update ~tool_name:name ~start_time:start ctx args)
+  | "masc_note_add" -> lift (handle_note_add ~tool_name:name ~start_time:start ctx args)
+  | "masc_deliver" -> lift (handle_deliver ~tool_name:name ~start_time:start ctx args)
+  | "masc_plan_get" -> lift (handle_plan_get ~tool_name:name ~start_time:start ctx args)
+  | "masc_plan_set_task" -> lift (handle_plan_set_task ~tool_name:name ~start_time:start ctx args)
+  | "masc_plan_get_task" -> lift (handle_plan_get_task ~tool_name:name ~start_time:start ctx args)
+  | "masc_plan_clear_task" -> lift (handle_plan_clear_task ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 
 (* RFC-0057 PR-2: schemas binding removed; plan tools now emitted via

--- a/lib/tool_plan.mli
+++ b/lib/tool_plan.mli
@@ -13,14 +13,14 @@ type context = {
 
 (** {1 Individual Handlers} *)
 
-val handle_plan_init : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
-val handle_plan_update : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
-val handle_note_add : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
-val handle_deliver : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
-val handle_plan_get : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
-val handle_plan_set_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
-val handle_plan_get_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
-val handle_plan_clear_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_plan_init : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_plan_update : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_note_add : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_deliver : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_plan_get : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_plan_set_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_plan_get_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_plan_clear_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 
 (** {1 Dispatcher} *)
 


### PR DESCRIPTION
## Summary

**Cluster 4 of 6 of the RFC-0189 §3.2 migration.** Promotes 8 plan handlers in `Tool_plan` to typed `Tool_result.result`. Dispatch boundary collapsed inside `Tool_plan.dispatch` via a single `lift` helper — **external callers (`mcp_server_eio_execute`, `keeper_tag_dispatch`) see no signature change**.

Out-of-order with PR-1b.4 (board boundary collapse) which is deferred until PR-1b.3 (#18743) merges to avoid stack risk per [feedback_draft_pr_stack_squash_race]. Plan cluster is independent of board, so they can advance in parallel.

## Why tool_plan as next cluster (vs task)

Boundary count comparison:

| Cluster | External callers | Verdict |
|---|---:|---|
| **tool_plan** | **2** (mcp_server, keeper_tag_dispatch) | ✅ this PR |
| tool_run | 3 | next |
| tool_library | 4 | later |
| tool_task | 10+ (server/h2_gateway, agent_tool_*, keeper/*) | separate RFC scope (multi-PR fan-out) |

Plan cluster has the same shape as board (single dispatch, internal handlers) so the established pattern applies cleanly. Task cluster's fan-out makes it a multi-PR migration of its own.

## What's in this PR

```
 lib/tool_plan.ml  | +89 -27   (handler bodies migrated + lift helper)
 lib/tool_plan.mli | +8 -8     (handler val signatures updated; dispatch unchanged)
 2 files changed, 108 insertions(+), 43 deletions(-)
```

### `make_err` class assignments

10 catch sites:

| Site | class | rationale |
|---|---|---|
| plan_init: Failed to init planning | Runtime_failure | Planning_eio internal |
| plan_update: Failed to update plan | Runtime_failure | Planning_eio internal |
| note_add: Failed to add note | Runtime_failure | Planning_eio internal |
| deliver: resolve_task_id Error | Workflow_rejection | caller task_id |
| deliver: content is required | Workflow_rejection | caller-input |
| deliver: Failed to set deliverable | Runtime_failure | Planning_eio internal |
| plan_get: resolve_task_id Error | Workflow_rejection | caller task_id |
| plan_get: Planning context not found | Workflow_rejection | caller-specified missing |
| plan_set_task: task_id is required | Workflow_rejection | caller-input |
| plan_set_task: set_current_task Error | Workflow_rejection | caller validation |

### Boundary

```
External callers (unchanged)
        │
        │  Tool_plan.dispatch ctx ~name ~args
        │  : Tool_result.t option       ← external surface preserved
        ▼
let lift r = Some (Tool_result.to_legacy r)
        │
        ▼
handle_plan_*  : ... -> Tool_result.result    ← typed payload flows inside
```

Single `lift` helper makes the boundary obvious (vs board cluster's per-arm pipes). After PR-1c (accessor migration) the external surface itself moves to `result` and this bridge disappears.

### Typed JSON payloads

Plan handlers' JSON responses (`response = \`Assoc [...]`) now flow as typed `~data:response` directly. Pre-RFC they were serialized to string and re-parsed inside legacy `Tool_result.ok` via `structured_payload_of_message`. Skipping the round-trip on the new path; legacy serialization still happens at `to_legacy`.

## Verification

- ✅ `dune build --root . lib/` → exit 0
- ✅ `dune exec --root . test/test_tool_result.exe` → 20/20 PASS

## RFC-0189 §3.2 progress after this PR

```
✅ PR-1a       MERGED  #18718  typed surface
✅ PR-1b.1     MERGED  #18736  board_handlers
✅ PR-1b.2     MERGED  #18740  board_post + format + cache
🟦 PR-1b.3     Draft   #18743  board curation + sub_board
🟦 PR-1b.5     Draft   <this>  tool_plan       ← parallel to PR-1b.3
░░ PR-1b.4     Next    board dispatch.handle_tool → result (after PR-1b.3)
░░ PR-1b.6     Next    tool_run + tool_misc*
░░ PR-1b.7     Next    tool_library
░░ task        Future  separate RFC (multi-PR fan-out)
░░ PR-1c       Future  407 accessor sites
░░ PR-2        Final   legacy + classifier removal
```

## Workaround Signature Gate

- §2 substring classifier: no new classifier. Each `make_err` declares `~class_` at catch site.
- §3 N-of-M: cluster of 6 (RFC-0189 §3.2). Independently mergeable.

## Test plan

- [x] `dune build lib/` passes
- [x] `dune exec test/test_tool_result.exe` 20/20 PASS
- [ ] Reviewer: confirm `Runtime_failure` for `Planning_eio.init/update_plan/add_note/set_deliverable` Error cases. Argument: these are persistence-layer opaque errors, not caller-input violations.
- [ ] Reviewer: confirm `Workflow_rejection` for `Planning_eio.set_current_task` Error. Argument: this is task_id validation, caller-correctable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)