### PR TITLE
fix(keeper): sanitize retired tool names in prompts

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -113,6 +113,92 @@ let line_block label value =
   if value = "" then ""
   else Printf.sprintf "%s: %s\n" label value
 
+let replace_all ~needle ~replacement input =
+  let needle_len = String.length needle in
+  if needle_len = 0 || input = "" then input
+  else
+    let input_len = String.length input in
+    let buf = Buffer.create input_len in
+    let rec loop pos =
+      if pos >= input_len then ()
+      else if
+        pos + needle_len <= input_len
+        && String.sub input pos needle_len = needle
+      then (
+        Buffer.add_string buf replacement;
+        loop (pos + needle_len))
+      else (
+        Buffer.add_char buf input.[pos];
+        loop (pos + 1))
+    in
+    loop 0;
+    Buffer.contents buf
+
+let is_tool_token_char = function
+  | 'A' .. 'Z'
+  | 'a' .. 'z'
+  | '0' .. '9'
+  | '_'
+  | '-'
+  | '*' ->
+      true
+  | _ -> false
+
+let remove_tool_tokens_with_prefix ~prefix input =
+  let prefix_len = String.length prefix in
+  if prefix_len = 0 || input = "" then input
+  else
+    let input_len = String.length input in
+    let buf = Buffer.create input_len in
+    let rec skip_token pos =
+      if pos < input_len && is_tool_token_char input.[pos]
+      then skip_token (pos + 1)
+      else pos
+    in
+    let rec loop pos =
+      if pos >= input_len then ()
+      else if
+        pos + prefix_len <= input_len
+        && String.sub input pos prefix_len = prefix
+        && (pos = 0 || not (is_tool_token_char input.[pos - 1]))
+      then loop (skip_token (pos + prefix_len))
+      else (
+        Buffer.add_char buf input.[pos];
+        loop (pos + 1))
+    in
+    loop 0;
+    Buffer.contents buf
+
+let sanitize_retired_tool_names text =
+  List.fold_left
+    (fun acc (needle, replacement) -> replace_all ~needle ~replacement acc)
+    text
+    [
+      ("masc_code_read", "ReadFile");
+      ("masc_code_search", "SearchFiles");
+      ("masc_code_write", "WriteFile");
+      ("masc_code_edit", "EditFile");
+      ("masc_code_delete", "EditFile");
+      ("masc_code_shell", "Execute");
+      ("masc_code_git", "Execute");
+      ("masc_code_*", "legacy helper family");
+      ("keeper_bash_command_shape_blocked", "execute_command_shape_blocked");
+      ("keeper_bash", "Execute");
+      ("keeper_shell op=ls", "SearchFiles/ReadFile");
+      ("keeper_shell", "SearchFiles");
+      ("keeper_fs_read", "ReadFile");
+      ("keeper_fs_edit", "EditFile");
+      ("keeper_task_submit_for_verification", "verification handoff");
+      ("keeper_preflight_check", "legacy preflight helper");
+      ("keeper_github", "GitHub CLI");
+      ("github_cli_", "GitHub CLI ");
+      ("Masc_code", "Legacy helper family");
+      ("Bash", "Execute");
+      ("Grep", "SearchFiles");
+    ]
+  |> remove_tool_tokens_with_prefix ~prefix:"keeper_pr"
+  |> replace_all ~needle:"``" ~replacement:""
+
 let state_block_instruction_text = Keeper_state_block_prompt.instruction_text
 
 (* In-binary mirror of config/prompts/keeper.turn_intent.md (minus the
@@ -607,4 +693,5 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
   let user_message =
     Buffer.contents ubuf
   in
-  (system_prompt, user_message)
+  ( sanitize_retired_tool_names system_prompt,
+    sanitize_retired_tool_names user_message )

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2687,6 +2687,63 @@ let test_prompt_continuity_drops_stale_tool_surface_claims () =
     (contains_substring user "keeper_task_claim")
 ;;
 
+let test_prompt_sanitizes_retired_tool_names () =
+  let meta =
+    { minimal_meta with
+      instructions =
+        "Use masc_code_shell, keeper_bash, keeper_shell, keeper_fs_read, \
+         keeper_pr_list, keeper_github, github_cli_status, Bash, and Grep \
+         from old state."
+    }
+  in
+  let obs =
+    { base_observation with
+      continuity_summary =
+         "Goal: restore tool routing\n\
+         Next plan: call masc_code_read then keeper_fs_edit\n\
+         Constraints: avoid keeper_pr_status, keeper_task_submit_for_verification, \
+         keeper_pr_*, and masc_code_*"
+    ; pending_mentions =
+        [
+          ( "alice",
+            "old hint: masc_code_git via keeper_bash_command_shape_blocked" );
+        ]
+    }
+  in
+  let sys, user = UP.build_prompt ~base_path:"/test" ~meta ~observation:obs () in
+  List.iter
+    (fun retired ->
+      check
+        bool
+        ("system prompt hides " ^ retired)
+        false
+        (contains_substring sys retired);
+      check
+        bool
+        ("user prompt hides " ^ retired)
+        false
+        (contains_substring user retired))
+    [
+      "masc_code_";
+      "keeper_bash";
+      "keeper_shell";
+      "keeper_fs_";
+      "keeper_pr_";
+      "keeper_github";
+      "github_cli_";
+      "Bash";
+      "Grep";
+    ];
+  check bool "system keeps Execute" true (contains_substring sys "Execute");
+  check bool "user keeps ReadFile" true (contains_substring user "ReadFile");
+  check bool "user keeps EditFile" true (contains_substring user "EditFile");
+  check
+    bool
+    "user keeps command-shape diagnostic without retired prefix"
+    true
+    (contains_substring user "execute_command_shape_blocked")
+;;
+
 let test_prompt_includes_mentions_section () =
   let obs = { base_observation with pending_mentions = [ "alice", "hello keeper" ] } in
   let _sys, user =
@@ -11040,6 +11097,10 @@ let () =
             "guides bash globs to structured tools"
             `Quick
             test_prompt_guides_bash_globs_to_structured_tools
+        ; test_case
+            "sanitizes retired tool names"
+            `Quick
+            test_prompt_sanitizes_retired_tool_names
         ; test_case
             "sanitize_text_utf8 replaces control chars"
             `Quick


### PR DESCRIPTION
## Summary
- sanitize retired keeper/tool names at the unified prompt boundary before system/user prompts reach the model
- cover stale meta, continuity, and pending-message leaks for masc_code_*, keeper_bash/shell/fs, keeper_pr_*, keeper_github, Bash, and Grep
- add a regression test for persisted old-state contamination

## Validation
- scripts/dune-local.sh build test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_unified.exe test unified_prompt 36 --show-errors
- git diff --check

Note: full ./_build/default/test/test_keeper_unified.exe still has unrelated pre-existing failures in world_observation/phase_gate/tool_classification and prompt config expectations; the new regression case passes.