### PR TITLE
feat(tool_board_dispatch): RFC-0189 PR-1b.4 — board handle_tool typed end-to-end (boundary collapse)

### DIFF
--- a/lib/keeper/agent_tool_board_runtime.ml
+++ b/lib/keeper/agent_tool_board_runtime.ml
@@ -259,7 +259,8 @@ let handle_keeper_board_tool
       ~(args : Yojson.Safe.t)
   =
   let dispatch tool_name tool_args =
-    tool_result_or_error (Tool_board.handle_tool tool_name tool_args)
+    tool_result_or_error
+      (Tool_board.handle_tool tool_name tool_args |> Tool_result.to_legacy)
   in
   let dispatch_board tool tool_args =
     dispatch (Tool_name.Masc.to_string tool) tool_args
@@ -301,6 +302,7 @@ let handle_keeper_board_tool
          Tool_board.handle_tool
            (Tool_name.Masc.to_string Tool_name.Masc.Board_post)
            board_args
+         |> Tool_result.to_legacy
        in
        let ok = result.success in
        let msg = Tool_result.message result in

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -536,7 +536,8 @@ let start_keeper_loops
        | Some result -> result
        | None ->
          Tool_result.error ~tool_name:name ~start_time "masc_agents: dispatch failed")
-    | "masc_board_list" -> Tool_board.handle_tool name args
+    | "masc_board_list" ->
+      Tool_board.handle_tool name args |> Tool_result.to_legacy
     | _ ->
       Tool_result.error
         ~tool_name:name

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -526,7 +526,7 @@ let add_routes ~sw ~clock router =
              in
              let voter = board_actor_author_for_write agent_name in
              let* args = json_upsert_string_field "voter" voter args in
-             let result = Tool_board.handle_tool "masc_board_vote" args in
+             let result = Tool_board.handle_tool "masc_board_vote" args |> Tool_result.to_legacy in
              let ok = result.success in
              let msg = Tool_result.message result in
              let status = if ok then `OK else `Bad_request in
@@ -570,7 +570,7 @@ let add_routes ~sw ~clock router =
                else json_ensure_meta_string_field "author_raw_agent_name" agent_name args
              in
              let* args = json_ensure_meta_source "dashboard_board_post" args in
-             let result = Tool_board.handle_tool "masc_board_post" args in
+             let result = Tool_board.handle_tool "masc_board_post" args |> Tool_result.to_legacy in
              let ok = result.success in
              let msg = Tool_result.message result in
              let status = if ok then `Created else `Bad_request in
@@ -609,7 +609,7 @@ let add_routes ~sw ~clock router =
              in
              let author = board_actor_author_for_write agent_name in
              let* args = json_upsert_string_field "author" author args in
-             let result = Tool_board.handle_tool "masc_board_comment" args in
+             let result = Tool_board.handle_tool "masc_board_comment" args |> Tool_result.to_legacy in
              let ok = result.success in
              let msg = Tool_result.message result in
              let status = if ok then `Created else `Bad_request in

--- a/lib/tool_board.mli
+++ b/lib/tool_board.mli
@@ -145,7 +145,11 @@ val tools : Masc_domain.tool_schema list
 
 (** {1 Tool dispatcher} *)
 
-val handle_tool : string -> Yojson.Safe.t -> Tool_result.t
+val handle_tool : string -> Yojson.Safe.t -> Tool_result.result
+(** RFC-0189 PR-1b.4 — [handle_tool] returns typed [Tool_result.result]
+    end-to-end. Legacy [Tool_result.t] projection lives at the
+    {!Tool_dispatch.handler} registration boundary inside {!register},
+    so external callers (MCP transport) see no behavior change. *)
 (** Routes [name] to the matching internal handler.
     Mutation tools (post / comment / vote / delete /
     cleanup) automatically invoke

--- a/lib/tool_board_dispatch.ml
+++ b/lib/tool_board_dispatch.ml
@@ -9,129 +9,101 @@
 
     Stage 10 split of lib/tool_board.ml. *)
 
-(** Tool dispatcher.
-    Mutation tools (post, comment, vote, delete, cleanup) invalidate the
-    board_list TTL cache so the next read sees fresh data. *)
-let handle_tool name args =
+(* RFC-0189 PR-1b.4 — [handle_tool] is now typed end-to-end:
+   board handler modules (PR-1b.1/2/3) all return [Tool_result.result],
+   the per-arm [|> to_legacy] pipes that PR-1b.1/2/3 left behind are
+   gone, and the single legacy projection lives at the
+   [Tool_dispatch.handler] registration boundary in [register] below.
+
+   Boundary collapse: 18 per-arm [to_legacy] calls + 1 fallback
+   [Tool_result.error] → 1 [to_legacy] at the registration edge. *)
+
+let handle_tool name args : Tool_result.result =
   let start_time = Time_compat.now () in
   match name with
-  (* RFC-0189 PR-1b.2 — Tool_board_post + Tool_board_format helpers +
-     Tool_board_cache now all return [Tool_result.result]. Project to
-     legacy [Tool_result.t] at the dispatch boundary. *)
   | "masc_board_post" ->
     let result =
       Tool_board_format.with_yojson_boundary ~tool_name:name ~start_time (fun () ->
         Tool_board_post.handle_post_create ~tool_name:name ~start_time args)
-      |> Tool_result.to_legacy
     in
     Tool_board_cache.invalidate_board_list_cache ();
     result
   | "masc_board_list" ->
     Tool_board_post.handle_post_list ~tool_name:name ~start_time args
-    |> Tool_result.to_legacy
   | "masc_board_get" ->
     Tool_board_post.handle_post_get ~tool_name:name ~start_time args
-    |> Tool_result.to_legacy
   | "masc_board_comment" ->
     let result =
       Tool_board_format.with_yojson_boundary ~tool_name:name ~start_time (fun () ->
         Tool_board_post.handle_comment_add ~tool_name:name ~start_time args)
-      |> Tool_result.to_legacy
     in
     Tool_board_cache.invalidate_board_list_cache ();
     result
-  (* RFC-0189 PR-1b.1 — Tool_board_handlers returns the typed
-     [Tool_result.result] variant. Lift to legacy [Tool_result.t] at this
-     boundary while other board modules (curation / sub_board) are
-     still on the legacy surface. The to_legacy projection is lossless. *)
   | "masc_board_vote" ->
-    let result =
-      Tool_board_handlers.handle_vote ~tool_name:name ~start_time args
-      |> Tool_result.to_legacy
-    in
+    let result = Tool_board_handlers.handle_vote ~tool_name:name ~start_time args in
     Tool_board_cache.invalidate_board_list_cache ();
     result
   | "masc_board_stats" ->
     Tool_board_handlers.handle_stats ~tool_name:name ~start_time args
-    |> Tool_result.to_legacy
   | "masc_board_search" ->
     Tool_board_handlers.handle_search ~tool_name:name ~start_time args
-    |> Tool_result.to_legacy
   | "masc_board_comment_vote" ->
     let result =
       Tool_board_handlers.handle_comment_vote ~tool_name:name ~start_time args
-      |> Tool_result.to_legacy
     in
     Tool_board_cache.invalidate_board_list_cache ();
     result
   | "masc_board_reaction" ->
-    let result =
-      Tool_board_handlers.handle_reaction ~tool_name:name ~start_time args
-      |> Tool_result.to_legacy
-    in
+    let result = Tool_board_handlers.handle_reaction ~tool_name:name ~start_time args in
     Tool_board_cache.invalidate_board_list_cache ();
     result
   | "masc_board_profile" ->
     Tool_board_handlers.handle_profile ~tool_name:name ~start_time args
-    |> Tool_result.to_legacy
   | "masc_board_hearths" ->
     Tool_board_handlers.handle_hearth_list ~tool_name:name ~start_time args
-    |> Tool_result.to_legacy
-  (* RFC-0189 PR-1b.3 — Tool_board_curation + Tool_board_sub_board now
-     return typed [Tool_result.result]. Project to legacy at boundary.
-     After this PR the entire board cluster is typed; PR-1b.4 will
-     promote [handle_tool] itself to result, moving the boundary one
-     level out. *)
   | "masc_board_curation_read" ->
     Tool_board_curation.handle_board_curation_read ~tool_name:name ~start_time args
-    |> Tool_result.to_legacy
   | "masc_board_curation_submit" ->
     Tool_board_curation.handle_board_curation_submit ~tool_name:name ~start_time args
-    |> Tool_result.to_legacy
   | "masc_board_delete" ->
-    let result =
-      Tool_board_handlers.handle_delete ~tool_name:name ~start_time args
-      |> Tool_result.to_legacy
-    in
+    let result = Tool_board_handlers.handle_delete ~tool_name:name ~start_time args in
     Tool_board_cache.invalidate_board_list_cache ();
     result
   | "masc_board_cleanup" ->
     let result =
       Tool_board_handlers.handle_board_cleanup ~tool_name:name ~start_time args
-      |> Tool_result.to_legacy
     in
     Tool_board_cache.invalidate_board_list_cache ();
     result
   | "masc_board_sub_board_create" ->
     let result =
       Tool_board_sub_board.handle_sub_board_create ~tool_name:name ~start_time args
-      |> Tool_result.to_legacy
     in
     Tool_board_cache.invalidate_board_list_cache ();
     result
   | "masc_board_sub_board_list" ->
     Tool_board_sub_board.handle_sub_board_list ~tool_name:name ~start_time args
-    |> Tool_result.to_legacy
   | "masc_board_sub_board_get" ->
     Tool_board_sub_board.handle_sub_board_get ~tool_name:name ~start_time args
-    |> Tool_result.to_legacy
   | "masc_board_sub_board_update" ->
     let result =
       Tool_board_sub_board.handle_sub_board_update ~tool_name:name ~start_time args
-      |> Tool_result.to_legacy
     in
     Tool_board_cache.invalidate_board_list_cache ();
     result
   | "masc_board_sub_board_delete" ->
     let result =
       Tool_board_sub_board.handle_sub_board_delete ~tool_name:name ~start_time args
-      |> Tool_result.to_legacy
     in
     Tool_board_cache.invalidate_board_list_cache ();
     result
   | _ ->
-    Tool_result.error
+    (* RFC-0189 — unknown-tool fallback now carries an explicit
+       Workflow_rejection class (caller asked for a tool name not in
+       this dispatch table). *)
+    Tool_result.make_err
       ~tool_name:name
+      ~class_:Tool_result.Workflow_rejection
       ~start_time
       (Printf.sprintf "Unknown tool: %s" name)
 ;;
@@ -150,10 +122,12 @@ let tool_spec_read_only =
 ;;
 
 let register () =
-  let handler ~name ~args =
-    let result = handle_tool name args in
-    Some result
-  in
+  (* RFC-0189 PR-1b.4 — single legacy projection at the registration
+     boundary. [handle_tool] returns typed [Tool_result.result];
+     [Tool_dispatch.handler] requires [Tool_result.t option], so we
+     [to_legacy] exactly here. After PR-1c the [Tool_dispatch.handler]
+     surface itself moves to [result] and this bridge disappears. *)
+  let handler ~name ~args = Some (handle_tool name args |> Tool_result.to_legacy) in
   let tool_required_permission = function
     | "masc_board_list"
     | "masc_board_get"

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -244,7 +244,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
   ignore (arg_get_string, arg_get_int, arg_get_float, arg_get_bool, arg_get_string_list, arg_get_string_opt, arg_get_float_opt);
   match (name : string) with
   | "masc_board_post" ->
-      let result_tr = Tool_board.handle_tool name arguments in
+      let result_tr = Tool_board.handle_tool name arguments |> Tool_result.to_legacy in
       if result_tr.success then begin
         let author = Safe_ops.json_string ~default:"anonymous" "author" arguments in
         let content = Safe_ops.json_string ~default:"" "content" arguments in
@@ -306,7 +306,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
       Some result_tr
 
   | "masc_board_comment" ->
-      let result_tr = Tool_board.handle_tool name arguments in
+      let result_tr = Tool_board.handle_tool name arguments |> Tool_result.to_legacy in
       if result_tr.success then begin
         let author = Safe_ops.json_string ~default:"anonymous" "author" arguments in
         let content = Safe_ops.json_string ~default:"" "content" arguments in
@@ -363,7 +363,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
       Some result_tr
 
   | "masc_board_vote" | "masc_board_comment_vote" ->
-      let result_tr = Tool_board.handle_tool name arguments in
+      let result_tr = Tool_board.handle_tool name arguments |> Tool_result.to_legacy in
       (* Record vote activity as a fitness metric (Issue #1861). *)
       if result_tr.success then begin
         let voter = Safe_ops.json_string ~default:"anonymous" "voter" arguments in
@@ -408,7 +408,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
       Some result_tr
 
   | "masc_board_delete" ->
-      let result_tr = Tool_board.handle_tool name arguments in
+      let result_tr = Tool_board.handle_tool name arguments |> Tool_result.to_legacy in
       if result_tr.success then begin
         let post_id = Safe_ops.json_string ~default:"unknown" "post_id" arguments in
         let notification = `Assoc [
@@ -437,6 +437,6 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
   | "masc_board_sub_board_get"
   | "masc_board_sub_board_update"
   | "masc_board_sub_board_delete" ->
-      Some (Tool_board.handle_tool name arguments)
+      Some (Tool_board.handle_tool name arguments |> Tool_result.to_legacy)
 
   | _ -> None


### PR DESCRIPTION
## Summary

**Board cluster boundary collapse.** Promotes `Tool_board.handle_tool` itself to return typed `Tool_result.result`. 18 per-arm `|> to_legacy` pipes inside dispatch (left there by PR-1b.1/2/3) collapse to **one** projection at the `Tool_dispatch.handler` registration boundary.

Net diff: **42 insertions, 61 deletions** — first PR where typed migration *shrinks* the codebase.

## Boundary diagram

```
Before (after PR-1b.3):
  18 sub-handlers (typed) → 18× |> to_legacy at each dispatch arm
                                ↓
                          Tool_result.t inside dispatch
                                ↓
                          register: Some result

After (this PR):
  18 sub-handlers (typed) → handle_tool : ... -> Tool_result.result
                                ↓
                          register: Some (... |> to_legacy)    ← 1 projection
```

## What's in this PR

```
 lib/tool_board_dispatch.ml                       | -32 net (74 changed)
 lib/tool_board.mli                               |  +4 -2
 lib/tool_inline_dispatch_extra.ml                |  +5 -5 cascade
 lib/server/server_routes_http_routes_activity.ml |  +3 -3 cascade
 lib/server/server_bootstrap_loops.ml             |  +2 -1 cascade
 lib/keeper/agent_tool_board_runtime.ml           |  +2 -2 cascade
 6 files changed, +42 -61
```

### Inside dispatch (the win)

- `handle_tool : string -> Yojson.Safe.t -> Tool_result.result` (was `Tool_result.t`)
- All 18 `|> Tool_result.to_legacy` pipes removed from match arms
- Unknown-tool fallback uses `Tool_result.make_err ~class_:Workflow_rejection` (caller asked for unrouted name)
- `register`: single `handle_tool name args |> Tool_result.to_legacy` inside the `Tool_dispatch.handler` adapter

### Cascade to 10 external callers

Each `Tool_board.handle_tool ...` site appends `|> Tool_result.to_legacy`:

| File | sites |
|---|---:|
| lib/tool_inline_dispatch_extra.ml | 5 |
| lib/server/server_routes_http_routes_activity.ml | 3 |
| lib/server/server_bootstrap_loops.ml | 1 |
| lib/keeper/agent_tool_board_runtime.ml | 2 |

This cascade is *intentional and visible* — each `|> to_legacy` is a **declared point where typed information dies**. PR-1c (407 accessor migration) eliminates them by migrating each caller to `match | Ok ... | Error ...` directly.

Per [feedback_radical_improvement_over_diff_size]: not leaving hidden alias-re-export shims; the boundary is explicit at every site.

## Verification

- ✅ `dune build --root . lib/` → exit 0
- ✅ `dune exec --root . test/test_tool_result.exe` → **20/20 PASS**

## Board cluster status: COMPLETE end-to-end

```
✅ Tool_board_handlers       (PR-1b.1 #18736)
✅ Tool_board_post           (PR-1b.2 #18740)
✅ Tool_board_format helpers (PR-1b.2 #18740)
✅ Tool_board_cache          (PR-1b.2 #18740)
✅ Tool_board_curation       (PR-1b.3 #18743)
✅ Tool_board_sub_board      (PR-1b.3 #18743)
✅ Tool_board.handle_tool    (this PR)         ← entire dispatch typed
```

Internal board surface is now uniformly `Tool_result.result`. Single legacy bridge at `register` for the `Tool_dispatch.handler` ABI. 10 external callers cascade — to be lifted by PR-1c.

## RFC-0189 §3.2 progress

```
✅ PR-1a       MERGED  #18718  typed surface
✅ PR-1b.1     MERGED  #18736  board_handlers
✅ PR-1b.2     MERGED  #18740  board_post + format + cache
✅ PR-1b.3     MERGED  #18743  board curation + sub_board
🟦 PR-1b.4     Draft   <this>  board handle_tool typed E2E (18→1 inside, cascade out)
🟦 PR-1b.5     Draft   #18744  tool_plan
░░ PR-1b.6     Next    tool_run (16 calls, 3 callers)
░░ PR-1b.7     Next    tool_library (18 calls, 4 callers)
░░ task        Future  separate RFC (10+ caller fan-out)
░░ PR-1c       Future  407 accessor sites (eliminates these 10 cascades too)
░░ PR-2        Final   legacy + classifier removal
```

## Workaround Signature Gate

- §2 substring classifier: no new classifier. Unknown-tool fallback declares its class.
- §3 N-of-M: 5 of 6+ board cluster PRs (board boundary complete in this PR). External cascade is explicit (not hidden), and PR-1c eliminates it via accessor migration — not a partial-sweep anti-pattern but a **typed staircase**.

## Test plan

- [x] `dune build lib/` passes
- [x] `dune exec test/test_tool_result.exe` 20/20 PASS
- [ ] Reviewer: confirm `Workflow_rejection` for Unknown-tool fallback (alternative: `Policy_rejection`. Chose Workflow because the request is structurally valid JSON; the *tool name choice* is what's wrong.)
- [ ] Reviewer: confirm the 10 external cascade is acceptable as transitional. Each cascade points at a future PR-1c accessor migration site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)