### PR TITLE
docs: purge deleted facade compatibility wording

### DIFF
--- a/docs/ARCHITECTURE-COMPLEXITY-ANALYSIS.md
+++ b/docs/ARCHITECTURE-COMPLEXITY-ANALYSIS.md
@@ -51,7 +51,7 @@ Modules that deliver real value in daily operation.
 | Module | Lines | Role | Necessity |
 |--------|-------|------|-----------|
 | tool_operator | 856 | dispatch/assign/rebalance | High |
-| tool_command_plane* | ~960 | command-plane truth layer | High |
+| retired command-plane tools | removed | former command-plane truth layer | Removed |
 | tool_keeper | 624 | persistent agent runtime | High |
 | tool_perpetual | 643 | autonomous agent loops | Medium |
 | tool_plan | 186 | planning context | High |

--- a/docs/BENCHMARK-RUNBOOK.md
+++ b/docs/BENCHMARK-RUNBOOK.md
@@ -109,8 +109,8 @@ baseline/fleet fixture answers는 `test/fixtures/repo_synthesis_benchmark/`에 �
 
 ## 첫 smoke는 18+ keeper fleet evidence로 한다
 
-`team-session`/public `swarm` read surface와 compatibility entrypoint는
-retired 되었다. Canonical gate는 read-only keeper fleet readiness만 실행한다.
+`team-session`/public `swarm` read surface와 old entrypoint는 retired 되었다.
+Canonical gate는 read-only keeper fleet readiness만 실행한다.
 
 ```bash
 scripts/harness/workload/agent_swarm_live.sh

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -15,7 +15,7 @@ last_verified: 2026-04-23
 
 Historical Command Plane usage note.
 
-이 문서는 `어떤 MCP tool을 어떤 순서로 써야 하는가`를 정리한다. 기본 delivery 경로는 namespace/task hygiene와 supervisor-driven supervised execution이고, managed operation은 benchmark/compatibility용 보조 경로다.
+이 문서는 retired Command Plane 흐름의 역사적 사용 순서를 정리한다. 기본 delivery 경로는 namespace/task hygiene와 supervisor-driven supervised execution이고, managed operation은 current implementation path가 아니다.
 
 merged 기준 전체 구조 요약은 [spec/SPEC-INDEX.md](./spec/SPEC-INDEX.md)와 [spec/01-system-overview.md](./spec/01-system-overview.md)를 본다.
 
@@ -26,7 +26,7 @@ merged 기준 전체 구조 요약은 [spec/SPEC-INDEX.md](./spec/SPEC-INDEX.md)
 - `task`
   - backlog item. `masc_transition(action="claim")`은 backlog 소유권만 바꾸고 planning `current_task`는 자동으로 안 잡힌다. `masc_claim_next`는 current builds에서 planning `current_task`를 함께 맞춘다.
 - `operation`
-  - managed-operation compatibility lane의 관리 단위. default delivery path는 아니다.
+  - retired managed-operation ledger의 관리 단위. default delivery path는 아니다.
 - `session`
   - historical supervised implementation execution unit. current coordination truth is board posts + keeper FSM, not CP session/detachment state.
 - `detachment`
@@ -101,9 +101,9 @@ Step-by-step:
 - `masc_plan_get_task`가 `task-058` 반환
 - dashboard에서 claimed task와 current_task가 같은 값으로 보임
 
-## Auxiliary Lane 2. Managed Operation / Benchmark Compatibility
+## Historical Lane 2. Managed Operation / Benchmark Reference
 
-이 경로는 benchmark topology proof와 command-plane compatibility coverage를 위한 보조 경로다. 기본 구현 경로로 취급하지 않는다.
+이 경로는 benchmark topology history를 읽기 위한 보조 기록이다. 기본 구현 경로로 취급하지 않는다.
 
 transport truth를 빠르게 분리하고 싶으면 먼저 `./benchmarks/quick-bench.sh` 또는 `./benchmarks/benchmark.sh`를 쓴다.
 이 두 스크립트는 반드시 `initialize -> notifications/initialized -> Mcp-Session-Id 재사용` 순서를 포함하고, `mcp_session_init`과 runtime lane을 분리해서 기록한다.
@@ -121,13 +121,13 @@ transport truth를 빠르게 분리하고 싶으면 먼저 `./benchmarks/quick-b
 
 ### Repo Synthesis
 
-repo-synthesis는 새 front-door tool을 만들지 않고, command-plane truth
-surfaces와 proof/report artifacts를 읽는 방향으로만 유지한다.
+repo-synthesis는 새 front-door tool을 만들지 않고, dashboard proof/report
+artifacts를 읽는 방향으로만 유지한다.
 
 - read path:
   - dashboard는 `/api/v1/dashboard/repo-synthesis`와 proof/report artifact를 읽는 read-only surface
 - raw escape hatch:
-  - 이후 세부 조율은 `masc_operator_digest`, command-plane truth surfaces로 내려간다.
+  - 이후 세부 조율은 `masc_operator_digest`와 keeper/runtime surfaces로 내려간다.
 
 ### 첫 번째 concrete example: 18+ keeper fleet evidence
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -933,7 +933,7 @@ dir-local 실행에서 shared keeper 상태가 보이지 않는 것은 정상이
 | [CONFIG-DOCTOR.md](./CONFIG-DOCTOR.md) | active config/init 진단 |
 | [GLOSSARY.md](./GLOSSARY.md) | 용어 정의 |
 | [QUICK-START.md](./QUICK-START.md) | repo coordination 시작 경로 |
-| [COMMAND-PLANE-RUNBOOK.md](./COMMAND-PLANE-RUNBOOK.md) | historical compatibility lane |
+| [COMMAND-PLANE-RUNBOOK.md](./COMMAND-PLANE-RUNBOOK.md) | retired command-plane reference |
 | [SPEC-INDEX.md](./spec/SPEC-INDEX.md) + [01-system-overview.md](./spec/01-system-overview.md) | 아키텍처 SSOT |
 | [EXECUTE-RUNBOOK.md](./EXECUTE-RUNBOOK.md) | Execute flag matrix + dark-launch observer 절차 |
 | [ENV-CONTRACT.md](./ENV-CONTRACT.md) | 환경변수 reload class + Execute §4 |

--- a/docs/MCP-SURFACE-AUDIT.md
+++ b/docs/MCP-SURFACE-AUDIT.md
@@ -11,7 +11,7 @@ code_refs:
 
 Current-state audit of `masc-mcp` MCP exposure, public design, and documentation boundaries.
 
-As of `2026-04-16`, the supported front door is repo coordination plus keeper/runtime visibility. Operator remains a reduced supporting surface; team-session and command-plane are historical compatibility lanes.
+As of `2026-04-16`, the supported front door is repo coordination plus keeper/runtime visibility. Operator remains a reduced supporting surface; team-session and command-plane are retired historical surfaces.
 
 ## Evidence
 
@@ -129,7 +129,7 @@ flowchart TD
   Coordination --> Keeper[OAS-backed keeper runtime]
   Coordination --> Orchestration[Native chain plane]
 
-  Secondary[Retired compatibility lanes] -. not supported front door .-> Orchestration
+  Secondary[Retired historical surfaces] -. not supported front door .-> Orchestration
 ```
 
 ## Findings
@@ -151,7 +151,7 @@ flowchart TD
 ### What this change fixes
 
 - Front-door docs point to repo coordination and keeper runtime first.
-- Team-session/command-plane compatibility paths are no longer treated as canonical.
+- Team-session/command-plane paths are no longer treated as canonical.
 
 ## Orphan Classification
 

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -32,7 +32,7 @@ Promise stack:
 2. Keeper runtime and supervised delivery
 3. Dashboard and operator visibility
 
-The front-door promise is level 1. Levels 2-3 are supported surfaces. Retired compatibility lanes and proposal-only research material are deletion targets, not product promises.
+The front-door promise is level 1. Levels 2-3 are supported surfaces. Retired surfaces and proposal-only research material are deletion targets, not product promises.
 
 ## Capability Posture
 

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -194,7 +194,7 @@ masc_claim_next()
 - repo coordination: `masc_start`, `masc_status`, `masc_transition`, `masc_plan_set_task`, `masc_heartbeat`
 - keeper runtime: `masc_keeper_up`, `masc_keeper_msg`, `masc_keeper_status`, `masc_keeper_down`
 
-retired compatibility lane은 historical only다. 새 사용자는 repo coordination과 keeper runtime에서 시작하고, read visibility가 필요할 때만 dashboard/operator surface로 내려간다.
+retired orchestration surfaces are historical only. 새 사용자는 repo coordination과 keeper runtime에서 시작하고, read visibility가 필요할 때만 dashboard/operator surface로 내려간다.
 
 ## 6. Tool Surface
 
@@ -310,7 +310,7 @@ Config/init diagnosis: `docs/CONFIG-DOCTOR.md`
 
 ## References
 
-- `docs/COMMAND-PLANE-RUNBOOK.md` — managed-operation compatibility lane
+- `docs/COMMAND-PLANE-RUNBOOK.md` — retired managed-operation reference
 - `docs/BENCHMARK-RUNBOOK.md` — benchmark recipes
 - `docs/INTEGRATED-BENCHMARK-RUNBOOK.md` — control/search wrapper
 - `docs/SUPERVISOR-MODE.md` — supervised execution path

--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 20:48:47 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 21:06:02 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -691,15 +691,21 @@
           </tr>
           <tr>
             <td>SDK/transport command-plane operation residue</td>
-            <td><span class="status now">active branch</span></td>
+            <td><span class="status done">merged #18733</span></td>
             <td>Remove deleted command-plane operation names from SDK remote-operation discovery, transport OpenAPI tags, dashboard recommendations, fixtures, and stale runbook/spec text.</td>
-            <td>Branch <code>refactor/purge-command-plane-contract-residue-20260526</code>. Tests assert the deleted operation names are absent from the SDK core operation list and OpenAPI catalog.</td>
+            <td>Merged as <code>22544f845</code>. Tests assert the deleted operation names are absent from the SDK core operation list and OpenAPI catalog.</td>
           </tr>
           <tr>
             <td>Dashboard meta-cognition last-good fallback cache</td>
             <td><span class="status now">active branch</span></td>
             <td>Delete the meta-cognition summary last-good table and stale seeding path so a cold or failed warm reports <code>null</code> instead of silently reusing stale summary state.</td>
-            <td>Same branch as the command-plane residue purge. Shell-level last-good cache remains separate; this cut only removes the meta-cognition summary fallback table.</td>
+            <td>Branch <code>refactor/purge-meta-cognition-fallback-20260526</code> in draft PR #18735. Shell-level last-good cache remains separate; this cut only removes the meta-cognition summary fallback table.</td>
+          </tr>
+          <tr>
+            <td>Docs/comments for deleted facades</td>
+            <td><span class="status now">active branch</span></td>
+            <td>Rewrite stale references that described removed command-plane, governance, and runtime-verify compatibility surfaces as if they were still live.</td>
+            <td>Folded into #18735. Remaining references are explicit retired-surface history or negative tests for deleted names.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
@@ -734,11 +740,7 @@
         </thead>
         <tbody>
           <tr>
-            <td>P4</td>
-            <td>Docs/comments for deleted facades</td>
-            <td>Comments that describe removed compatibility layers make readers think the old path still exists and cause false positives in audits.</td>
-            <td>Rewrite as current-contract notes or delete. Keep this separate from runtime purges unless a stale comment directly blocks a guard.</td>
-            <td>Doc grep is enough unless the stale text drives generated metadata.</td>
+            <td colspan="5">No fresh purge candidate remains in this queue after the docs/comments sweep. Future findings should be added only when they point to a live code path or a misleading current-contract document.</td>
           </tr>
         </tbody>
       </table>

--- a/docs/design/canonical-architecture-cleanup-rfc.md
+++ b/docs/design/canonical-architecture-cleanup-rfc.md
@@ -56,7 +56,7 @@ The canonical front door is:
 Everything else must be classified explicitly as one of:
 
 - advanced workflow
-- compatibility lane
+- explicitly retired migration-only surface
 - experimental surface
 - removed / retired surface
 

--- a/docs/spec/01-system-overview.md
+++ b/docs/spec/01-system-overview.md
@@ -151,7 +151,7 @@ MASC의 현재 canonical front door는 3가지다.
 
 - **대상**: keeper lifecycle, long-running execution, OAS-backed autonomy
 - **핵심 도구**: `masc_keeper_up`, `masc_keeper_msg`, `masc_keeper_status`, `masc_keeper_down`
-- **설명**: keeper는 OAS `Agent.run` 기반으로 실행되며, historical compatibility lane과 독립적으로 동작한다.
+- **설명**: keeper는 OAS `Agent.run` 기반으로 실행되며, retired orchestration surfaces와 독립적으로 동작한다.
 
 ### 7.3 Dashboard and Operator Read Visibility
 
@@ -162,7 +162,7 @@ MASC의 현재 canonical front door는 3가지다.
 - **핵심 surface**: `/api/v1/dashboard/*`, `/api/v1/operator*`, `/api/v1/activity/*`
 - **설명**: write-heavy orchestration을 새 front door로 약속하지 않고, 운영자가 현재 runtime truth를 읽고 제한된 개입을 하는 surface다.
 
-Historical compatibility lane(team-session / command-plane HTTP)은 migration context로만 남아 있으며, supported front door로 취급하지 않는다.
+Retired team-session / command-plane HTTP surfaces는 migration context로만 남아 있으며, supported front door로 취급하지 않는다.
 
 ## 8. External Integrations
 

--- a/docs/spec/06-command-plane.md
+++ b/docs/spec/06-command-plane.md
@@ -1,21 +1,21 @@
-# Command Plane (CPv2)
+# Command Plane Historical Reference (Retired)
 
 | 항목 | 값 |
 |------|-----|
-| Status | Historical Reference |
+| Status | Retired Historical Reference |
 | Team | Foundation |
-| Maps to | `lib/command_plane_v2.ml`, `lib/command_plane/*.ml`, `lib/command_plane_orchestra.ml` |
+| Maps to | Retired subsystem; former `lib/command_plane_v2.ml`, `lib/command_plane/*.ml`, and `lib/command_plane_orchestra.ml` files are removed |
 | Dependencies | 02-types-and-invariants, 03-room-coordination |
-| LOC | ~10.3K (core ~8.2K + tool surface ~2.1K) |
-| MCP Tools | 40 (unit 4, intent 4, operation 7, dispatch 6, detachment 2, policy 5, observe 6, chain 2, extra 4) |
+| LOC | N/A for current codebase |
+| MCP Tools | 0 active Command Plane tools |
 
 ---
 
 ## 1. Purpose
 
-Command Plane V2(CPv2)는 MASC의 현재 supported front door가 아닌 internal/historical reference subsystem이다. 남아 있는 code path, migration context, retained read-model vocabulary를 설명하기 위해 보존하며, 새 caller onboarding은 repo coordination, keeper runtime, dashboard/operator read visibility를 기준으로 한다.
+Command Plane V2(CPv2)는 삭제된 subsystem의 historical reference다. 이 문서는 migration context와 retired read-model vocabulary만 설명하며, 새 caller onboarding은 repo coordination, keeper runtime, dashboard/operator read visibility를 기준으로 한다.
 
-핵심 역할:
+삭제된 설계가 맡았던 역할:
 
 - **조직 위계 관리**: Company > Platoon > Squad > Agent_unit 4단계 트리 구조
 - **작전 생명주기**: Planned -> Active -> Paused -> Completed/Failed/Cancelled 상태 전이
@@ -25,7 +25,7 @@ Command Plane V2(CPv2)는 MASC의 현재 supported front door가 아닌 internal
 
 ---
 
-## 2. Module Dependency Chain
+## 2. Removed Module Dependency Chain
 
 ```
 Cp_types -> Cp_paths -> Cp_serde -> Cp_io
@@ -36,9 +36,9 @@ Cp_types -> Cp_paths -> Cp_serde -> Cp_io
   -> Cp_lifecycle -> Cp_lifecycle_policy
 ```
 
-`Command_plane_v2`는 `Cp_lifecycle_policy`를 `include`하는 backward-compatible facade이다. 외부 모듈(`tool_command_plane`, `operator_control`, `swarm_status`)은 이 facade를 통해 접근한다.
+위 graph는 삭제된 구현의 마지막 형태를 설명하는 역사적 기록이다. 현재 코드에는 `Command_plane_v2` facade, `tool_command_plane` entrypoint, `swarm_status` bridge, 또는 `Cp_*` implementation chain이 없다.
 
-`Command_plane_orchestra`는 별도 모듈로, CPv2 snapshot + Swarm status + Operator state를 node-edge-signal 그래프로 합성한다.
+`Command_plane_orchestra` 역시 삭제됐다. 현재 read visibility는 dashboard/operator projection과 keeper/runtime state를 통해 제공한다.
 
 ---
 

--- a/docs/spec/10-dashboard.md
+++ b/docs/spec/10-dashboard.md
@@ -245,10 +245,10 @@ type attention_item = {
 
 ### 3.5. Governance Surface (`dashboard_governance.ml`)
 
-현재 `dashboard_governance.ml`은 빈 호환성 payload를 반환하는 compatibility stub이다. Governance case tracking은 retire되었고, 대시보드 endpoint는 0 요약치와 empty list를 반환한다.
+현재 `dashboard_governance.ml`은 retired governance case tracking의 read-only projection이다. 대시보드 endpoint는 live case engine을 가장하지 않고 0 요약치와 empty list를 반환한다.
 
 주요 함수:
-- `dashboard_json`: governance summary + judge 상태의 빈 호환 응답
+- `dashboard_json`: governance summary + judge 상태의 empty projection
 - `cases_json`: 빈 case 목록 (pagination 유지)
 - `case_detail_json`: 단일 case 조회 시 not-found 응답
 - `factual_snapshot_json`: judge 입력용 빈 팩트 스냅샷
@@ -460,7 +460,7 @@ dashboard/
       core.ts                  -- Agent, Task, Message, Keeper, BoardPost, ...
       dashboard-execution.ts   -- Execution response types
       dashboard-mission.ts     -- Mission response types
-      command-plane.ts         -- Historical compatibility types
+      command-plane.ts         -- Retired command-plane type snapshots
       governance.ts            -- Governance types
       oas.ts                   -- OAS types
       sse.ts                   -- SSE event types
@@ -675,7 +675,7 @@ dashboard prefix:
 | `/api/v1/chains/summary` | GET | Chain summary |
 | `/api/v1/chains/runs/:runId` | GET | Chain run detail |
 
-`/api/v1/command-plane/*` HTTP compatibility lane is retired. Current servers answer those paths with a removed-surface response instead of a live read/write contract.
+`/api/v1/command-plane/*` HTTP paths are retired. Current servers answer those paths with a removed-surface response instead of a live read/write contract.
 
 ### Governance
 

--- a/docs/spec/C-implementation-status.md
+++ b/docs/spec/C-implementation-status.md
@@ -104,7 +104,7 @@ code_refs:
 
 ### 06-Command Plane (RETIRED)
 
-전체 Command Plane 서브시스템(`lib/command_plane/`, `cp_lifecycle.ml`, `cp_search_fabric.ml`, `cp_snapshot_core.ml`, `cp_cleanup.ml`, `command_plane_orchestra.ml`, `cp_lifecycle_policy.ml`, `cp_types.ml`, `command_plane_v2.ml`)와 HTTP compatibility lane은 retired surface다. 역사적 맥락은 `docs/spec/06-command-plane.md`의 "Historical Reference" status와 `docs/spec/00-glossary.md`의 Command Plane 항목을 참고한다. 현재 coordination truth는 `board_posts` + keeper FSM으로 대체됐다.
+전체 Command Plane 서브시스템(`lib/command_plane/`, `cp_lifecycle.ml`, `cp_search_fabric.ml`, `cp_snapshot_core.ml`, `cp_cleanup.ml`, `command_plane_orchestra.ml`, `cp_lifecycle_policy.ml`, `cp_types.ml`, `command_plane_v2.ml`)와 HTTP paths는 retired surface다. 역사적 맥락은 `docs/spec/06-command-plane.md`의 "Retired Historical Reference" status와 `docs/spec/00-glossary.md`의 Command Plane 항목을 참고한다. 현재 coordination truth는 `board_posts` + keeper FSM으로 대체됐다.
 
 ### 07-Team Session (RETIRED)
 

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -13,7 +13,7 @@ code_refs:
 > Last Updated: 2026-05-24
 > Snapshot baseline: `dune-project` version `0.19.31`
 
-MASC (Multi-Agent Streaming Coordination)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Agent-LLM-A, Provider-F, Agent-Code, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Room 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, dashboard/operator read visibility를 제공하며, MCP JSON-RPC 프로토콜을 통해 주요 AI IDE/CLI와 통합된다. Historical compatibility lane과 internal orchestration reference는 migration context로만 남긴다.
+MASC (Multi-Agent Streaming Coordination)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Agent-LLM-A, Provider-F, Agent-Code, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Room 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, dashboard/operator read visibility를 제공하며, MCP JSON-RPC 프로토콜을 통해 주요 AI IDE/CLI와 통합된다. Retired orchestration surfaces and internal references remain only as migration context.
 
 ## Snapshot Metadata
 

--- a/scripts/check-doc-truth.sh
+++ b/scripts/check-doc-truth.sh
@@ -109,7 +109,7 @@ require_not_contains README.md 'dashboard#monitoring/sessions'
 require_not_contains README.md 'dashboard#command/intervene'
 
 require_contains docs/PRODUCT-OPERATING-PLAN.md 'Release evidence and local proof'
-require_contains docs/PRODUCT-OPERATING-PLAN.md 'Retired compatibility lanes and proposal-only research material are deletion targets'
+require_contains docs/PRODUCT-OPERATING-PLAN.md 'Retired surfaces and proposal-only research material are deletion targets'
 
 require_contains docs/DASHBOARD-INTEGRATION.md '- `monitoring`'
 require_contains docs/DASHBOARD-INTEGRATION.md '- `connectors`'
@@ -121,16 +121,16 @@ require_not_contains docs/DASHBOARD-INTEGRATION.md '- `intervene`: mutating oper
 require_contains docs/spec/A-existing-doc-index.md '`docs/RELEASE-EVIDENCE.md` | Canonical'
 require_not_contains docs/spec/A-existing-doc-index.md '`docs/COMMAND-PLANE-RUNBOOK.md` | Canonical'
 
-require_contains docs/spec/SPEC-INDEX.md 'Historical compatibility lane과 internal orchestration reference는 migration context로만 남긴다.'
+require_contains docs/spec/SPEC-INDEX.md 'Retired orchestration surfaces and internal references remain only as migration context.'
 require_contains docs/spec/SPEC-INDEX.md '`06-command-plane.md` | Command Plane v2 | Internal command-plane reference and migration context | Historical |'
 require_not_contains docs/spec/SPEC-INDEX.md 'Keeper 자율 에이전트, Command Plane 오케스트레이션을 제공하며'
 
-require_contains docs/spec/06-command-plane.md '| Status | Historical Reference |'
-require_contains docs/spec/06-command-plane.md '현재 supported front door가 아닌 internal/historical reference subsystem'
+require_contains docs/spec/06-command-plane.md '| Status | Retired Historical Reference |'
+require_contains docs/spec/06-command-plane.md '삭제된 subsystem의 historical reference'
 
 require_contains docs/spec/01-system-overview.md 'MASC의 현재 canonical front door는 3가지다.'
 require_contains docs/spec/01-system-overview.md '### 7.3 Dashboard and Operator Read Visibility'
-require_contains docs/spec/01-system-overview.md 'Historical compatibility lane(team-session / command-plane HTTP)은 migration context로만 남아 있으며, supported front door로 취급하지 않는다.'
+require_contains docs/spec/01-system-overview.md 'Retired team-session / command-plane HTTP surfaces는 migration context로만 남아 있으며, supported front door로 취급하지 않는다.'
 
 require_contains docs/spec/09-server-transport.md 'GET /api/v1/activity/events'
 require_contains docs/spec/09-server-transport.md '`MASC_USE_H2` | `auto`'
@@ -141,7 +141,7 @@ require_not_contains docs/spec/09-server-transport.md '| Room | `/api/v1/room/*`
 require_not_contains docs/spec/09-server-transport.md '| Command Plane (R) |'
 
 require_contains docs/spec/10-dashboard.md '| `/api/v1/keepers/:name/config` | POST | Keeper config 수정 (PATCH semantic) |'
-require_contains docs/spec/10-dashboard.md 'command-plane.ts         -- Historical compatibility types'
+require_contains docs/spec/10-dashboard.md 'command-plane.ts         -- Retired command-plane type snapshots'
 require_contains docs/spec/10-dashboard.md '#monitoring?section=journey'
 require_contains docs/spec/10-dashboard.md '#command?section=operations'
 require_contains docs/spec/10-dashboard.md '#connectors?section=connector-status'

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -852,10 +852,10 @@ let test_local_dune_fd_containment_contracts () =
 let test_doc_truth_guard_contracts () =
   check bool "doc truth script protects spec index front door wording" true
     (file_contains_pattern "scripts/check-doc-truth.sh"
-       "Historical compatibility lane과 internal orchestration reference는 migration context로만 남긴다.");
+       "Retired orchestration surfaces and internal references remain only as migration context.");
   check bool "doc truth script protects command plane downgrade" true
     (file_contains_pattern "scripts/check-doc-truth.sh"
-       "| Status | Historical Reference |");
+       "| Status | Retired Historical Reference |");
   check bool "doc truth script protects system overview front door wording" true
     (file_contains_pattern "scripts/check-doc-truth.sh"
        "### 7.3 Dashboard and Operator Read Visibility");
@@ -864,7 +864,7 @@ let test_doc_truth_guard_contracts () =
        "require_not_contains docs/spec/09-server-transport.md '| `server_command_plane_http.ml` |'");
   check bool "doc truth script forbids old dashboard command-plane type wording" true
     (file_contains_pattern "scripts/check-doc-truth.sh"
-       "command-plane.ts         -- Command plane types")
+      "command-plane.ts         -- Command plane types")
 
 let test_storage_truth_guard_contracts () =
   check bool "bootstrap enforces filesystem-only storage" true

--- a/test/test_tool_contract_truth.ml
+++ b/test/test_tool_contract_truth.ml
@@ -89,7 +89,7 @@ let test_selected_tools_report_contract_status () =
   let base_path = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      (* masc_runtime_verify and masc_verify_handoff removed: tools pruned *)
+      (* masc_verify_handoff remains removed; runtime verify is covered by the admin surface. *)
       let tools =
         tools_list_response ~clock ~sw ~include_hidden:true
           ~names:

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -476,7 +476,7 @@ let test_masc_spawn_schema () =
           Alcotest.(check bool) "has prompt" true (List.mem_assoc "prompt" props)
       | None -> Alcotest.fail "masc_spawn missing properties"
 
-(* test_masc_runtime_verify_schema removed: tool pruned *)
+(* Dedicated runtime-verify schema coverage moved to runtime admin coverage. *)
 
 (* test_masc_persona_list_schema removed: persona list coverage is trivial. *)
 
@@ -879,7 +879,7 @@ let () =
       Alcotest.test_case "tool-admin-update" `Quick
         test_masc_tool_admin_update_schema;
     ];
-    (* runtime_verify_tools removed: masc_runtime_verify pruned *)
+    (* Runtime verify stays on the runtime admin surface; no separate public group. *)
     "legacy_swarm_removed", [
       Alcotest.test_case "removed_from_public_schemas" `Quick
         test_legacy_swarm_tools_removed;


### PR DESCRIPTION
## Summary
- Rewrite stale docs/comments that described deleted command-plane, governance, and runtime-verify compatibility surfaces as live.
- Update the doc-truth guard and its source test to pin the retired/current wording.
- Update the legacy purge HTML ledger: #18733 is merged and the docs/comments queue is closed by this slice.

## Validation
- `ocamlformat --check test/test_ci_hardening_source.ml test/test_tool_contract_truth.ml test/test_tools_coverage.ml`
- `git diff --check origin/main..HEAD`
- `bash scripts/check-doc-truth.sh`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD --recent-main 50 --duplicate-policy warn`
- `scripts/ci/check-enum-string-safety.sh` (PASS, pre-existing warnings only)
- `bash scripts/lint/no-unknown-permissive-default.sh`
- `scripts/ci/check-determinism-contract.sh` (PASS, pre-existing warnings only)
- `bash scripts/check-release-train-guard.sh --base origin/main --head HEAD` (OK with pending-release warning)
- `rg -n "Historical compatibility lane|compatibility entrypoint|compatibility coverage|compatibility stub|Historical compatibility types|managed-operation compatibility|masc_runtime_verify.*pruned|runtime_verify_tools removed|test_masc_runtime_verify_schema removed|tool_command_plane\\*|HTTP compatibility lane" docs scripts test lib/server -g'*.md' -g'*.html' -g'*.sh' -g'*.ml' -g'*.mli'` returns no matches

## Local Dune Gap
- `scripts/dune-local.sh build ./test/test_ci_hardening_source.exe ./test/test_tool_contract_truth.exe ./test/test_tools_coverage.exe` returned exit 75 because live bare Dune processes are bypassing the repo wrapper guard. I did not bypass the guard.

## CI Status
- GitHub Actions currently fails before repo checkout on multiple jobs with `remote: Your account is suspended` / HTTP 403, and `ocamlformat-check` also hit a codeload action-download failure. These failures happen before project checks execute and are not caused by this diff.
