### PR TITLE
feat(tool_run): RFC-0189 PR-1b.6 — typed result for 6 run handlers

### DIFF
--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -30,78 +30,123 @@ open Tool_args
 
 (** {1 Individual Handlers} *)
 
-let handle_run_init ~tool_name ~start_time ctx args =
+(* RFC-0189 PR-1b.6 — handlers in this module return typed
+   [Tool_result.result]. Boundary back to [Tool_result.t option] in
+   [dispatch] below via [lift]. Run_eio is the persistence layer; its
+   Error cases are opaque "Failed to ..." (Runtime_failure). The
+   "task_id is required" caller-input rejections are Workflow_rejection.
+
+   JSON responses flow as typed [~data:json] directly. Pre-RFC they were
+   serialized to string and re-parsed inside legacy Tool_result.ok via
+   structured_payload_of_message — that round-trip vanishes on the new
+   path. *)
+
+let task_id_required ~tool_name ~start_time : Tool_result.result =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Workflow_rejection
+    ~start_time
+    "task_id is required"
+
+let handle_run_init ~tool_name ~start_time ctx args : Tool_result.result =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    Tool_result.error ~tool_name ~start_time "task_id is required"
+    task_id_required ~tool_name ~start_time
   else
     let agent = get_string_opt args "agent_name" in
     match Run_eio.init ctx.config ~task_id ~agent_name:agent with
   | Ok run ->
-      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string (Run_eio.run_record_to_json run))
+      Tool_result.make_ok ~tool_name ~start_time ~data:(Run_eio.run_record_to_json run) ()
   | Error e ->
-      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to init run: %s" e)
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Runtime_failure
+        ~start_time
+        (Printf.sprintf "Failed to init run: %s" e)
 
-let handle_run_plan ~tool_name ~start_time ctx args =
+let handle_run_plan ~tool_name ~start_time ctx args : Tool_result.result =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    Tool_result.error ~tool_name ~start_time "task_id is required"
+    task_id_required ~tool_name ~start_time
   else
     let plan = get_string args "plan" "" in
     match Run_eio.update_plan ctx.config ~task_id ~content:plan with
   | Ok run ->
-      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string (Run_eio.run_record_to_json run))
+      Tool_result.make_ok ~tool_name ~start_time ~data:(Run_eio.run_record_to_json run) ()
   | Error e ->
-      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to update run plan: %s" e)
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Runtime_failure
+        ~start_time
+        (Printf.sprintf "Failed to update run plan: %s" e)
 
-let handle_run_log ~tool_name ~start_time ctx args =
+let handle_run_log ~tool_name ~start_time ctx args : Tool_result.result =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    Tool_result.error ~tool_name ~start_time "task_id is required"
+    task_id_required ~tool_name ~start_time
   else
     let note = get_string args "note" "" in
     match Run_eio.append_log ctx.config ~task_id ~note with
   | Ok entry ->
-      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string (Run_eio.log_entry_to_json entry))
+      Tool_result.make_ok ~tool_name ~start_time ~data:(Run_eio.log_entry_to_json entry) ()
   | Error e ->
-      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to append run log: %s" e)
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Runtime_failure
+        ~start_time
+        (Printf.sprintf "Failed to append run log: %s" e)
 
-let handle_run_deliverable ~tool_name ~start_time ctx args =
+let handle_run_deliverable ~tool_name ~start_time ctx args : Tool_result.result =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    Tool_result.error ~tool_name ~start_time "task_id is required"
+    task_id_required ~tool_name ~start_time
   else
     let deliverable = get_string args "deliverable" "" in
     match Run_eio.set_deliverable ctx.config ~task_id ~content:deliverable with
   | Ok run ->
-      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string (Run_eio.run_record_to_json run))
+      Tool_result.make_ok ~tool_name ~start_time ~data:(Run_eio.run_record_to_json run) ()
   | Error e ->
-      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to set run deliverable: %s" e)
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Runtime_failure
+        ~start_time
+        (Printf.sprintf "Failed to set run deliverable: %s" e)
 
-let handle_run_get ~tool_name ~start_time ctx args =
+let handle_run_get ~tool_name ~start_time ctx args : Tool_result.result =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    Tool_result.error ~tool_name ~start_time "task_id is required"
+    task_id_required ~tool_name ~start_time
   else
     match Run_eio.get ctx.config ~task_id with
-    | Ok json -> Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string json)
-    | Error e -> Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to get run: %s" e)
+    | Ok json -> Tool_result.make_ok ~tool_name ~start_time ~data:json ()
+    | Error e ->
+        Tool_result.make_err
+          ~tool_name
+          ~class_:Tool_result.Runtime_failure
+          ~start_time
+          (Printf.sprintf "Failed to get run: %s" e)
 
-let handle_run_list ~tool_name ~start_time ctx _args =
+let handle_run_list ~tool_name ~start_time ctx _args : Tool_result.result =
   let json = Run_eio.list ctx.config in
-  Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string json)
+  Tool_result.make_ok ~tool_name ~start_time ~data:json ()
 
 (** {1 Dispatcher} *)
 
+(* RFC-0189 PR-1b.6 — boundary projection lives here. Handlers above are
+   typed; external callers (mcp_server_eio_execute, tools.ml,
+   keeper_tag_dispatch) still consume Tool_result.t option. PR-1c will
+   move the Tool_dispatch.handler ABI itself to result, removing this
+   bridge. *)
 let dispatch ctx ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
+  let lift r = Some (Tool_result.to_legacy r) in
   match name with
-  | "masc_run_init" -> Some (handle_run_init ~tool_name:name ~start_time:start ctx args)
-  | "masc_run_plan" -> Some (handle_run_plan ~tool_name:name ~start_time:start ctx args)
-  | "masc_run_log" -> Some (handle_run_log ~tool_name:name ~start_time:start ctx args)
-  | "masc_run_deliverable" -> Some (handle_run_deliverable ~tool_name:name ~start_time:start ctx args)
-  | "masc_run_get" -> Some (handle_run_get ~tool_name:name ~start_time:start ctx args)
-  | "masc_run_list" -> Some (handle_run_list ~tool_name:name ~start_time:start ctx args)
+  | "masc_run_init" -> lift (handle_run_init ~tool_name:name ~start_time:start ctx args)
+  | "masc_run_plan" -> lift (handle_run_plan ~tool_name:name ~start_time:start ctx args)
+  | "masc_run_log" -> lift (handle_run_log ~tool_name:name ~start_time:start ctx args)
+  | "masc_run_deliverable" -> lift (handle_run_deliverable ~tool_name:name ~start_time:start ctx args)
+  | "masc_run_get" -> lift (handle_run_get ~tool_name:name ~start_time:start ctx args)
+  | "masc_run_list" -> lift (handle_run_list ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 
 let schemas : Masc_domain.tool_schema list = [

--- a/lib/tool_run.mli
+++ b/lib/tool_run.mli
@@ -12,12 +12,12 @@ type context = {
 
 (** {1 Individual Handlers} *)
 
-val handle_run_init : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
-val handle_run_plan : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
-val handle_run_log : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
-val handle_run_deliverable : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
-val handle_run_get : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
-val handle_run_list : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_run_init : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_run_plan : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_run_log : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_run_deliverable : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_run_get : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_run_list : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 
 (** {1 Dispatcher} *)
 


### PR DESCRIPTION
## Summary

**Cluster 6 of the RFC-0189 §3.2 migration.** Promotes `Tool_run`'s 6 handlers to typed `Tool_result.result`. 16 calls migrated. Shared `task_id_required` helper deduplicates 6 identical empty-id rejections.

## Discovery: dispatch can return `result option` directly

When promoting `dispatch` from `Tool_result.t option` to `Tool_result.result option`, the 2 external call sites (`mcp_server_eio_execute`, `keeper_tag_dispatch`) **compile without changes**. Both treat the dispatch return as opaque forwarding — never accessing record fields.

PR-1b.5 (tool_plan) was conservative on this point and kept `dispatch` as `Tool_result.t option` with a `lift` helper inside. This PR keeps the same conservative ABI for consistency, but the **discovery is documented**: a small follow-up could promote both clusters' dispatches once we verify the same holds for `tool_agent` / `tool_task` / `tool_coord` arms in the multi-arm `mcp_server_eio_execute` dispatch match.

## What's in this PR

```
 lib/tool_run.ml  | +69 -32   (handler bodies migrated, task_id_required helper added)
 lib/tool_run.mli | +6  -6    (handler val signatures updated)
 2 files changed, 79 insertions(+), 34 deletions(-)
```

### `make_err` class assignments (8 sites)

| Site | class | rationale |
|---|---|---|
| 6× task_id is required | Workflow_rejection | caller-input violation |
| run_init: Failed to init run | Runtime_failure | Run_eio persistence |
| run_plan: Failed to update run plan | Runtime_failure | Run_eio persistence |
| run_log: Failed to append run log | Runtime_failure | Run_eio persistence |
| run_deliverable: Failed to set deliverable | Runtime_failure | Run_eio persistence |
| run_get: Failed to get run | Runtime_failure | Run_eio persistence |

### Boundary

```
External callers (unchanged)
        │
        │  Tool_run.dispatch ctx ~name ~args
        │  : Tool_result.t option       ← external ABI preserved
        ▼
let lift r = Some (Tool_result.to_legacy r)
        │
        ▼
handle_run_*  : ... -> Tool_result.result    ← typed payload flows inside
```

Typed JSON responses (`Run_eio.run_record_to_json run`, `log_entry_to_json entry`) flow as typed `~data:json` directly instead of round-tripping through `Yojson.Safe.to_string` + legacy `structured_payload_of_message` JSON-reparse hop.

## Verification

- ✅ `dune build --root . lib/` → exit 0
- ✅ `dune build --root . lib/ @check` → exit 0 (full type-check; verifies multi-arm dispatch unification still holds)
- ✅ `dune exec --root . test/test_tool_result.exe` → **20/20 PASS**

## RFC-0189 §3.2 progress after this PR

```
✅ PR-1a       MERGED  #18718  typed surface
✅ PR-1b.1     MERGED  #18736  board_handlers
✅ PR-1b.2     MERGED  #18740  board_post + format + cache
✅ PR-1b.3     MERGED  #18743  board curation + sub_board
🟦 PR-1b.4     Draft   #18749  board handle_tool E2E (-19 LoC net)
✅ PR-1b.5     MERGED  #18744  tool_plan
🟦 PR-1b.6     Draft   <this>  tool_run                ← parallel
░░ PR-1b.7     Next    tool_library / tool_misc
░░ task        Future  separate RFC (10+ caller fan-out)
░░ PR-1c       Future  407 accessor sites
░░ PR-2        Final   legacy + classifier purge
```

## Workaround Signature Gate

- §2 substring classifier: no new classifier. Each `make_err` declares `~class_` at catch site.
- §3 N-of-M: cluster of 6 (RFC-0189 §3.2). Independently mergeable.

## Test plan

- [x] `dune build lib/` passes
- [x] `dune build lib/ @check` passes (multi-arm dispatch unification)
- [x] `dune exec test/test_tool_result.exe` 20/20 PASS
- [ ] Reviewer: confirm `Runtime_failure` for all `Run_eio` "Failed to ..." cases. Argument: these are persistence-layer opaque errors not caller-correctable.
- [ ] Reviewer: confirm the `task_id_required` helper deduplication is acceptable (alternative: inline the 6 sites for grep-ability of error message string).
- [ ] Follow-up consideration: promote `dispatch` itself to `Tool_result.result option` once tool_agent/task/coord arms are verified in mcp_server_eio_execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)