### PR TITLE
feat(agent-tool): project masc board descriptors

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -44,6 +44,7 @@ type runtime_handler =
   | Tool_voice_dispatch
   | Tool_task_dispatch
   | Tool_board_dispatch
+  | Tool_masc_board_dispatch
 
 type policy =
   { visibility : Tool_catalog.visibility
@@ -118,6 +119,7 @@ let runtime_handler_to_string = function
   | Tool_voice_dispatch -> "tool_voice_dispatch"
   | Tool_task_dispatch -> "tool_task_dispatch"
   | Tool_board_dispatch -> "tool_board_dispatch"
+  | Tool_masc_board_dispatch -> "tool_masc_board_dispatch"
 ;;
 
 let policy ?(visibility = Tool_catalog.Default) ?readonly ?effect_domain
@@ -563,6 +565,42 @@ let board_descriptor name description ~readonly =
     ~readonly
 ;;
 
+let masc_board_descriptor (schema : Masc_domain.tool_schema) =
+  let name = schema.name in
+  let suffix =
+    String.sub
+      name
+      (String.length "masc_board_")
+      (String.length name - String.length "masc_board_")
+  in
+  let metadata = Tool_catalog.metadata name in
+  let readonly =
+    match metadata.readonly with
+    | Some readonly -> readonly
+    | None -> List.mem name Tool_board_dispatch.tool_spec_read_only
+  in
+  let policy =
+    policy
+      ~visibility:metadata.visibility
+      ~readonly
+      ?effect_domain:metadata.effect_domain
+      ~approval:No_approval
+      ~retryable:readonly
+      ()
+  in
+  in_process_descriptor
+    ~id:("masc.board." ^ suffix)
+    ~name
+    ~description:schema.description
+    ~input_schema:schema.input_schema
+    ~policy
+    ~handler:Tool_masc_board_dispatch
+;;
+
+let masc_board_descriptors =
+  List.map masc_board_descriptor Tool_board_registry.tools
+;;
+
 let voice_descriptor name description ~readonly =
   cluster_descriptor
     ~id:("keeper.voice." ^ String.sub name (String.length "keeper_voice_")
@@ -800,6 +838,7 @@ let internal_descriptors : t list =
       "Vote on a board entry."
       ~readonly:false
   ]
+  @ masc_board_descriptors
 ;;
 
 let all_descriptors () = public_descriptors @ internal_descriptors

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -49,6 +49,7 @@ type runtime_handler =
   | Tool_voice_dispatch
   | Tool_task_dispatch
   | Tool_board_dispatch
+  | Tool_masc_board_dispatch
 
 type policy =
   { visibility : Tool_catalog.visibility

--- a/lib/keeper/agent_tool_descriptor_resolution.ml
+++ b/lib/keeper/agent_tool_descriptor_resolution.ml
@@ -3,14 +3,17 @@ let descriptor_for_tool_name tool_name =
   match Agent_tool_descriptor.find_public stripped with
   | Some descriptor -> Some descriptor
   | None ->
-    let internal_name =
-      match Keeper_tool_alias.canonical_internal_name tool_name with
-      | Some internal_name -> internal_name
-      | None -> stripped
-    in
-    (match Agent_tool_descriptor.descriptors_for_internal internal_name with
+    (match Agent_tool_descriptor.descriptors_for_internal stripped with
      | descriptor :: _ -> Some descriptor
-     | [] -> None)
+     | [] ->
+       let internal_name =
+         match Keeper_tool_alias.canonical_internal_name tool_name with
+         | Some internal_name -> internal_name
+         | None -> stripped
+       in
+       (match Agent_tool_descriptor.descriptors_for_internal internal_name with
+        | descriptor :: _ -> Some descriptor
+        | [] -> None))
 ;;
 
 let descriptors_for_tool_names tool_names =

--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -99,3 +99,15 @@ let handle_task ~config ~(meta : keeper_meta) ~name ~args =
 let handle_board ~(meta : keeper_meta) ~name ~args =
   Agent_tool_board_runtime.handle_keeper_board_tool ~meta ~name ~args
 ;;
+
+let handle_masc_board ~name ~args =
+  let result = Tool_board_dispatch.handle_tool name args in
+  if result.Tool_result.success
+  then result.Tool_result.message
+  else
+    Yojson.Safe.to_string
+      (`Assoc
+         [ "error", `String result.Tool_result.message
+         ; "tool", `String name
+         ])
+;;

--- a/lib/keeper/agent_tool_in_process_runtime.mli
+++ b/lib/keeper/agent_tool_in_process_runtime.mli
@@ -77,3 +77,8 @@ val handle_board
   -> name:string
   -> args:Yojson.Safe.t
   -> string
+
+(** [handle_masc_board] dispatches public MCP [masc_board_*] tools through
+    the existing board dispatcher while allowing descriptor route evidence
+    and receipt summaries to resolve the tool. *)
+val handle_masc_board : name:string -> args:Yojson.Safe.t -> string

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -49,7 +49,8 @@ let handle_filesystem ctx descriptor args =
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch
-  | Tool_board_dispatch -> None
+  | Tool_board_dispatch
+  | Tool_masc_board_dispatch -> None
 ;;
 
 (* Dispatch asymmetry: Filesystem, Remote_mcp, and In_process all go through
@@ -99,7 +100,8 @@ let handle_shell_ir ctx descriptor args =
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch
-  | Tool_board_dispatch -> None
+  | Tool_board_dispatch
+  | Tool_masc_board_dispatch -> None
 ;;
 
 let handle_remote_mcp ctx descriptor args =
@@ -136,7 +138,8 @@ let handle_remote_mcp ctx descriptor args =
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch
-  | Tool_board_dispatch -> None
+  | Tool_board_dispatch
+  | Tool_masc_board_dispatch -> None
 ;;
 
 let handle_in_process ctx descriptor args =
@@ -198,6 +201,8 @@ let handle_in_process ctx descriptor args =
   | Tool_board_dispatch ->
     Some
       (Agent_tool_in_process_runtime.handle_board ~meta:ctx.meta ~name ~args)
+  | Tool_masc_board_dispatch ->
+    Some (Agent_tool_in_process_runtime.handle_masc_board ~name ~args)
   | Tool_execute
   | Tool_search_files
   | Tool_read_file

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -19,6 +19,7 @@
 
 open Alcotest
 module Descriptor = Masc_mcp.Agent_tool_descriptor
+module Tool_board_registry = Masc_mcp.Tool_board_registry
 
 let all_descriptors () : Descriptor.t list = Descriptor.all_descriptors ()
 
@@ -93,6 +94,33 @@ let test_registry_not_empty () =
   if all_descriptors () = []
   then Alcotest.failf "Agent_tool_descriptor.all_descriptors () returned []"
 
+let test_masc_board_registry_has_descriptor_projection () =
+  List.iter
+    (fun (schema : Masc_domain.tool_schema) ->
+       match Descriptor.descriptors_for_internal schema.name with
+       | [ descriptor ] ->
+         let suffix =
+           String.sub
+             schema.name
+             (String.length "masc_board_")
+             (String.length schema.name - String.length "masc_board_")
+         in
+         Alcotest.(check string)
+           (schema.name ^ " descriptor id")
+           ("masc.board." ^ suffix)
+           descriptor.Descriptor.id;
+         Alcotest.(check string)
+           (schema.name ^ " runtime handler")
+           "tool_masc_board_dispatch"
+           (Descriptor.runtime_handler_to_string descriptor.runtime_handler);
+         Alcotest.(check bool)
+           (schema.name ^ " schema projected")
+           true
+           (descriptor.input_schema = schema.input_schema)
+       | [] -> Alcotest.failf "missing descriptor for %s" schema.name
+       | _ :: _ :: _ -> Alcotest.failf "duplicate descriptor for %s" schema.name)
+    Tool_board_registry.tools
+
 let () =
   Alcotest.run
     "agent_tool_descriptor_registry_integrity"
@@ -104,5 +132,11 @@ let () =
     ; ( "format"
       , [ test_case "no blank name fields" `Quick test_no_blank_names
         ; test_case "internal_name is snake_case" `Quick test_internal_name_snake_case
+        ] )
+    ; ( "masc-board"
+      , [ test_case
+            "Tool_board_registry has descriptor projection"
+            `Quick
+            test_masc_board_registry_has_descriptor_projection
         ] )
     ]

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -519,15 +519,20 @@ let test_descriptor_resolution_handles_public_prefixed_internal_and_dedupe () =
     "mcp-prefixed internal coordination tool resolves"
     (Some "keeper.time.now")
     (descriptor_id_for_tool_name "mcp__masc__keeper_time_now");
+  Alcotest.(check (option string))
+    "mcp-prefixed masc board tool resolves to exact masc descriptor"
+    (Some "masc.board.post")
+    (descriptor_id_for_tool_name "mcp__masc__masc_board_post");
   Alcotest.(check (list string))
     "descriptor list dedupes by descriptor id"
-    [ "agent.read_file"; "keeper.time.now"; "agent.execute" ]
+    [ "agent.read_file"; "keeper.time.now"; "agent.execute"; "masc.board.post" ]
     (Descriptor_resolution.descriptors_for_tool_names
        [ "ReadFile"
        ; "tool_read_file"
        ; "keeper_time_now"
        ; "mcp__masc__keeper_time_now"
        ; "Execute"
+       ; "mcp__masc__masc_board_post"
        ; "unknown_tool"
        ]
      |> List.map (fun (descriptor : Descriptor.t) -> descriptor.id))
@@ -694,6 +699,9 @@ let test_agent_tool_runtime_resolves_descriptor_handlers () =
   (* RFC-0179 PR-3 migrated coordination tools into internal_descriptors.
      keeper_board_post now resolves to its descriptor (Tool_board_dispatch). *)
   check_descriptor "keeper_board_post" "keeper.board.post";
+  check_descriptor "masc_board_post" "masc.board.post";
+  check_descriptor "masc_board_list" "masc.board.list";
+  check_descriptor "masc_board_sub_board_get" "masc.board.sub_board_get";
   check_descriptor "keeper_time_now" "keeper.time.now";
   check_descriptor "keeper_stay_silent" "keeper.stay_silent";
   check_descriptor "keeper_tools_list" "keeper.tools_list";

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -616,6 +616,44 @@ let test_route_evidence_records_internal_descriptor () =
         (Safe_ops.json_string_opt "runtime_handler" evidence)
     | _ -> Alcotest.fail "expected exactly one entry")
 
+let test_route_evidence_records_masc_board_descriptor () =
+  with_tmp_log (fun () ->
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"executor"
+      ~tool_name:"mcp__masc__masc_board_post"
+      ~input:(`Assoc [ "body", `String "descriptor evidence test" ])
+      ~output_text:{|{"ok":true,"post_id":"post-1"}|}
+      ~success:true
+      ~duration_ms:2.0
+      ();
+    let entries = Keeper_tool_call_log.read_recent ~n:1 () in
+    Alcotest.(check int) "entry persisted" 1 (List.length entries);
+    match entries with
+    | [ entry ] ->
+      let evidence = Yojson.Safe.Util.member "route_evidence" entry in
+      Alcotest.(check (option string)) "tool name"
+        (Some "mcp__masc__masc_board_post")
+        (Safe_ops.json_string_opt "tool_name" evidence);
+      Alcotest.(check (option string)) "descriptor id"
+        (Some "masc.board.post")
+        (Safe_ops.json_string_opt "descriptor_id" evidence);
+      Alcotest.(check (option string)) "public name"
+        (Some "masc_board_post")
+        (Safe_ops.json_string_opt "public_name" evidence);
+      Alcotest.(check (option string)) "canonical name"
+        (Some "masc_board_post")
+        (Safe_ops.json_string_opt "canonical_name" evidence);
+      Alcotest.(check (option string)) "executor"
+        (Some "in_process")
+        (Safe_ops.json_string_opt "executor" evidence);
+      Alcotest.(check (option string)) "effect domain"
+        (Some "masc_coordination")
+        (Safe_ops.json_string_opt "effect_domain" evidence);
+      Alcotest.(check (option string)) "runtime handler"
+        (Some "tool_masc_board_dispatch")
+        (Safe_ops.json_string_opt "runtime_handler" evidence)
+    | _ -> Alcotest.fail "expected exactly one entry")
+
 let test_non_object_input_still_logs_action_radius () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
@@ -1069,6 +1107,8 @@ let () =
             test_route_evidence_records_descriptor_for_filesystem_calls
         ; eio_test "route evidence records internal descriptor"
             test_route_evidence_records_internal_descriptor
+        ; eio_test "route evidence records masc board descriptor"
+            test_route_evidence_records_masc_board_descriptor
         ; eio_test "non-object input still logs action radius"
             test_non_object_input_still_logs_action_radius
         ; eio_test "dashboard aggregate groups runtime fields"


### PR DESCRIPTION
## Summary

- project every `Tool_board_registry.tools` entry into `Agent_tool_descriptor.internal_descriptors`
- add `Tool_masc_board_dispatch` and route it through the existing `Tool_board_dispatch.handle_tool`
- prefer exact descriptor resolution before legacy alias canonicalization so `mcp__masc__masc_board_post` resolves to `masc.board.post`
- pin registry and route-evidence tests for the new `masc_board_*` descriptor coverage

## Verification

- `ocamlformat --check lib/keeper/agent_tool_descriptor.mli lib/keeper/agent_tool_descriptor.ml lib/keeper/agent_tool_descriptor_resolution.ml lib/keeper/agent_tool_runtime.ml lib/keeper/agent_tool_in_process_runtime.mli lib/keeper/agent_tool_in_process_runtime.ml test/test_keeper_tool_alias.ml test/test_agent_tool_descriptor_registry_integrity.ml test/test_keeper_tool_call_log.ml`
- `git diff --check origin/main...HEAD`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_keeper_tool_alias.exe ./test/test_agent_tool_descriptor_registry_integrity.exe ./test/test_keeper_tool_call_log.exe`
- `./_build/default/test/test_agent_tool_descriptor_registry_integrity.exe`
- `./_build/default/test/test_keeper_tool_alias.exe`
- `./_build/default/test/test_keeper_tool_call_log.exe`
