### PR TITLE
feat(dashboard): bulk keeper action button + vitest coverage

### DIFF
--- a/dashboard/src/api/keeper-bulk.test.ts
+++ b/dashboard/src/api/keeper-bulk.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { bulkKeeperDirective } from './keeper'
+
+const mockFetch = vi.fn()
+
+afterEach(() => {
+  mockFetch.mockClear()
+  vi.unstubAllGlobals()
+})
+
+function stubFetch(response: unknown, init: { ok?: boolean; status?: number } = {}): void {
+  mockFetch.mockResolvedValue({
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: 'OK',
+    headers: new Headers(),
+    json: () => Promise.resolve(response),
+    text: () => Promise.resolve(JSON.stringify(response)),
+    clone() { return this },
+  } as Response)
+  vi.stubGlobal('fetch', mockFetch)
+}
+
+describe('bulkKeeperDirective', () => {
+  it('posts names and action to the bulk endpoint and returns the parsed response', async () => {
+    const expected = {
+      ok: true,
+      action: 'resume',
+      requested: 2,
+      succeeded: 2,
+      results: [
+        { name: 'rondo', ok: true },
+        { name: 'qa-king', ok: true },
+      ],
+    }
+    stubFetch(expected)
+
+    const res = await bulkKeeperDirective(['rondo', 'qa-king'], 'resume')
+
+    const call = mockFetch.mock.calls[0]!
+    const init = call[1] as RequestInit
+    expect(call[0]).toBe('/api/v1/keepers_bulk/directive')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({
+      names: ['rondo', 'qa-king'],
+      action: 'resume',
+    })
+    expect(res).toEqual(expected)
+  })
+
+  it('surfaces per-keeper failures from the results array on partial success', async () => {
+    stubFetch({
+      ok: true,
+      action: 'resume',
+      requested: 2,
+      succeeded: 1,
+      results: [
+        { name: 'rondo', ok: true },
+        { name: 'ghost', ok: false, error: 'keeper meta not found' },
+      ],
+    })
+
+    const res = await bulkKeeperDirective(['rondo', 'ghost'], 'resume')
+
+    expect(res.ok).toBe(true)
+    expect(res.succeeded).toBe(1)
+    expect(res.results[1]!.ok).toBe(false)
+    expect(res.results[1]!.error).toBe('keeper meta not found')
+  })
+
+  it('returns a synthetic all-failed response when the HTTP call fails', async () => {
+    stubFetch({ error: 'unauthorized' }, { ok: false, status: 401 })
+
+    const res = await bulkKeeperDirective(['rondo', 'qa-king'], 'pause')
+
+    expect(res.ok).toBe(false)
+    expect(res.action).toBe('pause')
+    expect(res.requested).toBe(2)
+    expect(res.succeeded).toBe(0)
+    expect(res.results).toHaveLength(2)
+    expect(res.results.every(r => r.ok === false)).toBe(true)
+  })
+
+  it('returns a synthetic all-failed response when fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('network down'))
+    vi.stubGlobal('fetch', mockFetch)
+
+    const res = await bulkKeeperDirective(['rondo'], 'wakeup')
+
+    expect(res.ok).toBe(false)
+    expect(res.action).toBe('wakeup')
+    expect(res.results[0]!.error).toBe('network down')
+  })
+})

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -23,11 +23,13 @@ import { showToast } from './common/toast'
 import { KeeperPhaseBadge } from './keeper-phase-indicator'
 import {
   bootKeeper,
+  bulkKeeperDirective,
   pauseKeeper,
   resumeKeeper,
   shutdownKeeper,
   wakeKeeper,
 } from '../api/keeper'
+import type { BulkKeeperDirectiveAction } from '../api/keeper'
 import { invalidateDashboardCache, refreshDashboard, keepers } from '../store'
 import type { Keeper } from '../types'
 import {
@@ -175,6 +177,40 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
   `
 }
 
+// ── Bulk action helpers ───────────────────────────────────────────────────
+
+/** Apply a directive to N keepers in one round-trip via the bulk endpoint
+    and surface the result as a single toast (with partial-failure detail). */
+async function runBulkKeeperDirective(
+  names: string[],
+  action: BulkKeeperDirectiveAction,
+): Promise<void> {
+  if (names.length === 0) return
+  const labels: Record<BulkKeeperDirectiveAction, string> = {
+    pause: '일시정지',
+    resume: '재개',
+    wakeup: '깨우기',
+  }
+  try {
+    const res = await bulkKeeperDirective(names, action)
+    if (res.ok && res.succeeded === res.requested) {
+      showToast(`${res.succeeded}개 keeper ${labels[action]}됨`, 'success')
+      afterAction()
+    } else if (res.ok && res.succeeded > 0) {
+      const failed = res.results.filter(r => !r.ok).map(r => r.name).join(', ')
+      showToast(
+        `${res.succeeded}/${res.requested} ${labels[action]}됨 — 실패: ${failed}`,
+        'warning',
+      )
+      afterAction()
+    } else {
+      showToast(`전체 ${labels[action]} 실패`, 'error')
+    }
+  } catch {
+    showToast(`전체 ${labels[action]} 실패`, 'error')
+  }
+}
+
 // ── Public panel ──────────────────────────────────────────────────────────
 
 /**
@@ -189,6 +225,30 @@ export function KeeperActionPanel() {
   // chain — paused keepers should still appear (so operator can resume)
   // even when their status appears offline.
   const online = keeperList.filter(isKeeperOperatorTargetable)
+  const bulkBusy = useSignal(false)
+
+  // Partition online keepers by which bulk action is applicable. The
+  // typed predicate is authoritative — never derive bulk eligibility from
+  // a status string.
+  const pausableNames = online
+    .filter(k => keeperActionVisibility(k).canPause)
+    .map(k => k.name)
+  const resumableNames = online
+    .filter(k => keeperActionVisibility(k).canResume)
+    .map(k => k.name)
+
+  const runBulk = async (
+    names: string[],
+    action: BulkKeeperDirectiveAction,
+  ): Promise<void> => {
+    if (bulkBusy.value || names.length === 0) return
+    bulkBusy.value = true
+    try {
+      await runBulkKeeperDirective(names, action)
+    } finally {
+      bulkBusy.value = false
+    }
+  }
 
   if (keeperList.length === 0) {
     return null
@@ -200,11 +260,47 @@ export function KeeperActionPanel() {
       data-testid="keeper-action-panel"
       aria-label="키퍼 액션 패널"
     >
-      <div>
-        <h3 class="text-sm font-semibold text-[var(--color-fg-secondary)]">Keeper Actions</h3>
-        <p class="mt-1 text-xs leading-[1.45] text-[var(--color-fg-muted)]">
-          Fleet-level lifecycle controls. Pause, resume, wake, boot, or shut down individual keepers.
-        </p>
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <h3 class="text-sm font-semibold text-[var(--color-fg-secondary)]">Keeper Actions</h3>
+          <p class="mt-1 text-xs leading-[1.45] text-[var(--color-fg-muted)]">
+            Fleet-level lifecycle controls. Pause, resume, wake, boot, or shut down individual keepers.
+          </p>
+        </div>
+        <div class="flex gap-1.5" data-testid="keeper-action-panel-bulk">
+          ${resumableNames.length > 0
+            ? html`<${ActionButton}
+                variant="ok"
+                size="sm"
+                disabled=${bulkBusy.value}
+                onClick=${async () => {
+                  const ok = await requestConfirm({
+                    title: `${resumableNames.length}개 keeper 전체 재개`,
+                    message: 'paused → running 으로 전환합니다.',
+                    confirmText: '재개',
+                  })
+                  if (ok) await runBulk(resumableNames, 'resume')
+                }}
+                title="현재 paused 인 ${resumableNames.length}개 keeper 를 한 번에 재개합니다."
+              >전체 재개 (${resumableNames.length})<//>`
+            : null}
+          ${pausableNames.length > 0
+            ? html`<${ActionButton}
+                variant="ghost"
+                size="sm"
+                disabled=${bulkBusy.value}
+                onClick=${async () => {
+                  const ok = await requestConfirm({
+                    title: `${pausableNames.length}개 keeper 전체 일시정지`,
+                    message: 'running → paused 로 전환합니다. 현재 turn 은 정상 종료됩니다.',
+                    confirmText: '일시정지',
+                  })
+                  if (ok) await runBulk(pausableNames, 'pause')
+                }}
+                title="현재 running 인 ${pausableNames.length}개 keeper 를 한 번에 일시정지합니다."
+              >전체 일시정지 (${pausableNames.length})<//>`
+            : null}
+        </div>
       </div>
       ${online.length === 0
         ? html`<div class="text-2xs text-[var(--color-fg-muted)]">온라인 키퍼 없음</div>`


### PR DESCRIPTION
## Summary

Wires the **KeeperActionPanel** header to the bulk endpoint merged in #18745: `전체 재개 (N)` / `전체 일시정지 (N)` buttons in the Ops/Actions surface so an operator can resume/pause every applicable keeper in **one round-trip with a single batch cache invalidate**.

## Why a follow-up

#18745 landed the server endpoint + `bulkKeeperDirective` API to let curl smoke-test independently. This PR closes the loop: a single click in the dashboard now does what 16 sequential per-keeper clicks did before. Resolves the "재개하기 누르면 존나 느림" report.

## Changes

- `dashboard/src/components/keeper-action-panel.ts`
  - Header now hosts two bulk buttons. Eligibility uses the same typed predicate (`keeperActionVisibility`) as the per-row buttons — `canPause` keepers feed pause, `canResume` keepers feed resume. Buttons hide when zero keepers are eligible (no no-op clicks).
  - `requestConfirm` re-used (await pattern, same as `KeeperActionRow` shutdown confirm).
  - `bulkBusy` signal locks both buttons during the round-trip to prevent double-fire.
  - Partial-success surfaces as a `warning` toast listing failed keeper names so an operator can chase failing entries via per-row controls.
- `dashboard/src/api/keeper-bulk.test.ts` — new vitest coverage:
  - payload shape (endpoint URL, method, JSON body)
  - partial-success results array
  - HTTP failure → synthetic all-failed response
  - thrown fetch → synthetic all-failed response with error message

## What this PR does **not** do

- No optimistic UI yet — click still awaits the server response. Click-to-phase-change perceived latency is a separate PR.
- OCaml side still has no dedicated alcotest case for `handle_keeper_bulk_directive_post` because `handle_keeper_directive_post` has none either — both gaps tracked separately rather than expanding the patch here.

## Verification

- vitest `keeper-bulk.test.ts` — 4 cases (payload / partial success / HTTP failure / thrown fetch)
- `requestConfirm` field names verified against `confirm-dialog.ts` source (`title`, `message`, `confirmText`)
- `keeperActionVisibility` predicate matches per-row button gating exactly, so `bulk eligible` always implies `per-row click would succeed`

## Relationship

Builds on #18745 (server endpoint + frontend API, already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)