### PR TITLE
fix(test,keeper): migrate Tool_board.handle_tool callers to typed result via to_legacy

### DIFF
--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -101,7 +101,9 @@ let handle_board ~(meta : keeper_meta) ~name ~args =
 ;;
 
 let handle_masc_board ~name ~args =
-  let result = Tool_board_dispatch.handle_tool name args in
+  let result =
+    Tool_board_dispatch.handle_tool name args |> Tool_result.to_legacy
+  in
   if result.Tool_result.success
   then result.Tool_result.message
   else

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -36,10 +36,11 @@ let cleanup () =
   Board_dispatch.init_jsonl ()
 
 let dispatch name args =
-  let result = Tool_board.handle_tool name args in
+  let result = Tool_board.handle_tool name args |> Tool_result.to_legacy in
   (result.success, Tool_result.message result)
 
-let dispatch_result name args = Tool_board.handle_tool name args
+let dispatch_result name args =
+  Tool_board.handle_tool name args |> Tool_result.to_legacy
 
 let check_failure_class name expected result =
   let actual =


### PR DESCRIPTION
## Summary
Unblocks `dune build .` on main. Two callers still read `.success` / `.Tool_result.success` directly off the new RFC-0189 typed result variant, hitting the OCaml error `This expression has type Tool_result.result which is not a record type`.

## Repro on main (acdd7d7ee)
```
$ dune build .
File "test/test_tool_board_coverage.ml", line 40, characters 3-9:
40 |   (result.success, Tool_result.message result)
        ^^^^^^
Error: This expression has type Tool_result.result
       which is not a record type.
```
After fixing the test caller, the same error surfaces in `lib/keeper/agent_tool_in_process_runtime.ml:105`.

## Fix
Bridge both call sites through `Tool_result.to_legacy` (the explicit boundary helper introduced by RFC-0189 PR-1a precisely for un-migrated callers — `tool_result.mli` lines 100–103, 147–148).

- `test/test_tool_board_coverage.ml` — `dispatch` + `dispatch_result` now `|> Tool_result.to_legacy` before reading record fields.
- `lib/keeper/agent_tool_in_process_runtime.ml` — `handle_masc_board` same pattern.

No other behavior changes; `to_legacy` is a lossless projection.

## Why not migrate to typed `Ok` / `Error` here
The RFC-0189 plan in `tool_result.mli` schedules that as PR-1b ("migrate 285 constructor sites"), which is out of this PR's scope. Bridging at the boundary preserves the typed-result invariants downstream while keeping this PR's diff to a 1-line touch per caller.

## Out of scope (confirmed not affected)
- `test/test_tool_library_coverage.ml` — consumes `Tool_library.dispatch : ... -> Tool_result.t option` (legacy `t`, not the new variant).
- `test/test_tool_input_validation.ml` — `Error result` payload here is `Tool_result.t` (the existing record), not `Tool_result.result`.

## Workaround signature gate self-check (CLAUDE.md §워크어라운드 거부 기준)
- **§1 Telemetry-as-fix**: N/A. Real type-level fix.
- **§2 String/substring classifier**: N/A.
- **§3 N-of-M sweep**: **considered**. Two call sites updated atomically; the broader 285-site migration is RFC-0189 PR-1b and intentionally a separate PR per the mli's own staging plan.
- **§4 Catch-all**: N/A.
- **§5 Cap/cooldown/dedup/repair**: N/A.
- **§6 Test backdoor**: N/A.
- **§7 Codemod-needed typo**: N/A.

RFC-WAIVED: not in credential/identity/sandbox/hooks/workflow scope. RFC-0189 already governs the underlying refactor; this PR is a follow-up caller migration along the path it defines.

## Test plan
- [x] `dune build .` — exits 0 with the fix applied.
- [x] No semantic change verified: `to_legacy` is the lossless projection documented in `tool_result.mli` line 147.
- [ ] CI: required checks green before Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
