### PR TITLE
fix(agent-tool): bridge masc board typed results

### DIFF
--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -101,7 +101,7 @@ let handle_board ~(meta : keeper_meta) ~name ~args =
 ;;
 
 let handle_masc_board ~name ~args =
-  let result = Tool_board_dispatch.handle_tool name args in
+  let result = Tool_board_dispatch.handle_tool name args |> Tool_result.to_legacy in
   if result.Tool_result.success
   then result.Tool_result.message
   else


### PR DESCRIPTION
## Summary

Fixes the keeper descriptor runtime boundary for `masc_board_*` tools after `Tool_board_dispatch.handle_tool` moved to the typed `Tool_result.result` API.

The merged descriptor projection expected the legacy record shape at `Agent_tool_in_process_runtime.handle_masc_board`, so latest `main` fails to compile when the typed board dispatch result reaches that keeper runtime boundary. This PR converts the typed result back through `Tool_result.to_legacy` at the boundary.

## Validation

- `ocamlformat --check lib/keeper/agent_tool_in_process_runtime.ml`
- `git diff --check HEAD~1..HEAD`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_keeper_tool_alias.exe ./test/test_agent_tool_descriptor_registry_integrity.exe ./test/test_keeper_tool_call_log.exe`
- `./_build/default/test/test_agent_tool_descriptor_registry_integrity.exe`
- `./_build/default/test/test_keeper_tool_alias.exe`
- `./_build/default/test/test_keeper_tool_call_log.exe`
