### PR TITLE
feat(dashboard): optimistic UI for keeper pause/resume/wakeup

### DIFF
--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -30,7 +30,13 @@ import {
   wakeKeeper,
 } from '../api/keeper'
 import type { BulkKeeperDirectiveAction } from '../api/keeper'
-import { invalidateDashboardCache, refreshDashboard, keepers } from '../store'
+import {
+  applyOptimisticKeeperDirective,
+  applyOptimisticKeeperDirectives,
+  invalidateDashboardCache,
+  refreshDashboard,
+  keepers,
+} from '../store'
 import type { Keeper } from '../types'
 import {
   keeperActionVisibility,
@@ -41,7 +47,11 @@ import {
 
 function afterAction(): void {
   invalidateDashboardCache()
-  void refreshDashboard({ force: true }).catch(err => {
+  // Reconcile the optimistic patch against the authoritative server
+  // snapshot. `force: true` was a dead signal in the bootstrap path of
+  // `refreshDashboard` (only consumed by the fallback) — drop it so we
+  // don't lie about what the call does.
+  void refreshDashboard().catch(err => {
     const message = err instanceof Error ? err.message : 'dashboard refresh failed'
     showToast(message, 'warning')
   })
@@ -62,6 +72,14 @@ async function runKeeperAction(
     shutdown: '종료',
   }
 
+  // Optimistic UI: pause/resume/wakeup mutate `paused` + phase locally
+  // before the POST returns so the row's button set flips instantly. On
+  // failure we revert. Boot/shutdown stay server-driven (richer state
+  // transitions).
+  const revert =
+    action === 'pause' || action === 'resume' || action === 'wakeup'
+      ? applyOptimisticKeeperDirective(name, action)
+      : null
   try {
     let res: { ok: boolean; error?: string }
     switch (action) {
@@ -75,9 +93,11 @@ async function runKeeperAction(
       showToast(`${name} ${labels[action]}됨`, 'success')
       afterAction()
     } else {
+      revert?.()
       showToast(res.error ?? `${labels[action]} 실패`, 'error')
     }
   } catch {
+    revert?.()
     showToast(`${labels[action]} 실패`, 'error')
   }
 }
@@ -191,22 +211,32 @@ async function runBulkKeeperDirective(
     resume: '재개',
     wakeup: '깨우기',
   }
+  // Optimistic: apply patch to every requested name. If the server
+  // reports partial failure we revert only the failed names.
+  const reverts = applyOptimisticKeeperDirectives(names, action)
+  const revertAll = (): void => {
+    for (const revert of reverts.values()) revert()
+  }
   try {
     const res = await bulkKeeperDirective(names, action)
     if (res.ok && res.succeeded === res.requested) {
       showToast(`${res.succeeded}개 keeper ${labels[action]}됨`, 'success')
       afterAction()
     } else if (res.ok && res.succeeded > 0) {
-      const failed = res.results.filter(r => !r.ok).map(r => r.name).join(', ')
+      const failedRows = res.results.filter(r => !r.ok)
+      for (const row of failedRows) reverts.get(row.name)?.()
+      const failed = failedRows.map(r => r.name).join(', ')
       showToast(
         `${res.succeeded}/${res.requested} ${labels[action]}됨 — 실패: ${failed}`,
         'warning',
       )
       afterAction()
     } else {
+      revertAll()
       showToast(`전체 ${labels[action]} 실패`, 'error')
     }
   } catch {
+    revertAll()
     showToast(`전체 ${labels[action]} 실패`, 'error')
   }
 }

--- a/dashboard/src/store-optimistic-keeper.test.ts
+++ b/dashboard/src/store-optimistic-keeper.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  applyOptimisticKeeperDirective,
+  applyOptimisticKeeperDirectives,
+  keepers,
+} from './store'
+import type { Keeper } from './types'
+
+const baseKeeper = (overrides: Partial<Keeper> & { name: string }): Keeper => ({
+  status: 'idle',
+  ...overrides,
+})
+
+describe('applyOptimisticKeeperDirective', () => {
+  beforeEach(() => {
+    keepers.value = [
+      baseKeeper({ name: 'rondo', paused: false, phase: 'Running', pipeline_stage: 'idle', status: 'idle' }),
+      baseKeeper({ name: 'qa-king', paused: false, phase: 'Running', pipeline_stage: 'idle', status: 'idle' }),
+    ]
+  })
+
+  afterEach(() => {
+    keepers.value = []
+  })
+
+  it('flips paused/phase locally on pause and reverts on failure', () => {
+    const revert = applyOptimisticKeeperDirective('rondo', 'pause')
+
+    const after = keepers.value.find(k => k.name === 'rondo')!
+    expect(after.paused).toBe(true)
+    expect(after.phase).toBe('Paused')
+    expect(after.pipeline_stage).toBe('paused')
+    // Other keepers untouched.
+    expect(keepers.value.find(k => k.name === 'qa-king')!.paused).toBe(false)
+
+    revert()
+    const reverted = keepers.value.find(k => k.name === 'rondo')!
+    expect(reverted.paused).toBe(false)
+    expect(reverted.phase).toBe('Running')
+    expect(reverted.pipeline_stage).toBe('idle')
+  })
+
+  it('flips paused/phase locally on resume and reverts on failure', () => {
+    keepers.value = [
+      baseKeeper({ name: 'rondo', paused: true, phase: 'Paused', pipeline_stage: 'paused', status: 'paused' }),
+    ]
+    const original = keepers.value[0]!
+
+    const revert = applyOptimisticKeeperDirective('rondo', 'resume')
+    const after = keepers.value[0]!
+    expect(after.paused).toBe(false)
+    expect(after.phase).toBe('Running')
+
+    revert()
+    expect(keepers.value[0]).toEqual(original)
+  })
+
+  it('wakeup behaves like resume (paused → running) for the optimistic patch', () => {
+    keepers.value = [baseKeeper({ name: 'rondo', paused: true, phase: 'Paused' })]
+    applyOptimisticKeeperDirective('rondo', 'wakeup')
+    expect(keepers.value[0]!.paused).toBe(false)
+    expect(keepers.value[0]!.phase).toBe('Running')
+  })
+
+  it('returns a no-op revert when the keeper is not in the local list', () => {
+    const before = keepers.value
+    const revert = applyOptimisticKeeperDirective('ghost', 'pause')
+    expect(keepers.value).toBe(before)
+    revert()
+    expect(keepers.value).toBe(before)
+  })
+
+  it('revert is keyed by name so a subsequent unrelated mutation is preserved', () => {
+    const revert = applyOptimisticKeeperDirective('rondo', 'pause')
+    // Simulate an unrelated update arriving from the snapshot stream
+    // (e.g. qa-king's status field changes).
+    keepers.value = keepers.value.map(k =>
+      k.name === 'qa-king' ? { ...k, status: 'busy' } : k,
+    )
+    revert()
+    expect(keepers.value.find(k => k.name === 'rondo')!.paused).toBe(false)
+    expect(keepers.value.find(k => k.name === 'qa-king')!.status).toBe('busy')
+  })
+})
+
+describe('applyOptimisticKeeperDirectives (bulk)', () => {
+  beforeEach(() => {
+    keepers.value = [
+      baseKeeper({ name: 'a', paused: false, phase: 'Running' }),
+      baseKeeper({ name: 'b', paused: false, phase: 'Running' }),
+      baseKeeper({ name: 'c', paused: false, phase: 'Running' }),
+    ]
+  })
+
+  it('applies the patch to every requested name and returns per-name reverts', () => {
+    const reverts = applyOptimisticKeeperDirectives(['a', 'b'], 'pause')
+    expect(reverts.size).toBe(2)
+    expect(keepers.value.find(k => k.name === 'a')!.paused).toBe(true)
+    expect(keepers.value.find(k => k.name === 'b')!.paused).toBe(true)
+    expect(keepers.value.find(k => k.name === 'c')!.paused).toBe(false)
+  })
+
+  it('reverting only one entry leaves the others optimistically patched', () => {
+    const reverts = applyOptimisticKeeperDirectives(['a', 'b'], 'pause')
+    reverts.get('a')!()
+    expect(keepers.value.find(k => k.name === 'a')!.paused).toBe(false)
+    expect(keepers.value.find(k => k.name === 'b')!.paused).toBe(true)
+  })
+})

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -107,6 +107,72 @@ export function toggleKeeperInFilter(name: string): void {
   selectedKeeperFilter.value = next
 }
 
+// --- Optimistic keeper directive patching ---
+//
+// Server's `refresh_keeper_execution_surfaces` invalidates the
+// projection cache prefix, so the next dashboard fetch recomputes
+// from scratch (hundreds of ms+). The operator perceives this as
+// "재개하기 누르면 느림" even though the directive POST itself
+// returns in <50ms — the row keeps showing the old state until the
+// projection refetch completes.
+//
+// To close the gap we mutate the local `keepers` signal immediately
+// on click. The action button's `keeperActionVisibility` predicate
+// flips, the phase badge updates, and the next reconciling snapshot
+// from WS/SSE or `refreshDashboard` confirms (or corrects) the
+// optimistic state. Restricted to pause/resume/wakeup — boot and
+// shutdown have non-trivial lifecycle transitions that should wait
+// on the authoritative server response.
+
+export type OptimisticKeeperDirective = 'pause' | 'resume' | 'wakeup'
+
+function patchForDirective(action: OptimisticKeeperDirective): Partial<Keeper> {
+  switch (action) {
+    case 'pause':
+      return { paused: true, phase: 'Paused', pipeline_stage: 'paused', status: 'paused' }
+    case 'resume':
+    case 'wakeup':
+      return { paused: false, phase: 'Running', pipeline_stage: 'idle', status: 'idle' }
+  }
+}
+
+/** Optimistically apply a directive's expected state to the local
+ *  `keepers` signal. Returns a `revert` thunk the caller must invoke
+ *  on failure. If the keeper isn't in the local list the call is a
+ *  no-op and `revert` is a no-op too. */
+export function applyOptimisticKeeperDirective(
+  name: string,
+  action: OptimisticKeeperDirective,
+): () => void {
+  const before = keepers.value
+  const idx = before.findIndex(k => k.name === name)
+  if (idx === -1) return () => {}
+  const original = before[idx]!
+  const patch = patchForDirective(action)
+  const updated: Keeper = { ...original, ...patch }
+  keepers.value = [...before.slice(0, idx), updated, ...before.slice(idx + 1)]
+  return () => {
+    const current = keepers.value
+    const cIdx = current.findIndex(k => k.name === name)
+    if (cIdx === -1) return
+    keepers.value = [...current.slice(0, cIdx), original, ...current.slice(cIdx + 1)]
+  }
+}
+
+/** Bulk variant: apply the patch to each name, returning a per-name
+ *  revert map so a caller seeing partial-failure can revert only the
+ *  keepers the server reported failed. */
+export function applyOptimisticKeeperDirectives(
+  names: readonly string[],
+  action: OptimisticKeeperDirective,
+): Map<string, () => void> {
+  const reverts = new Map<string, () => void>()
+  for (const name of names) {
+    reverts.set(name, applyOptimisticKeeperDirective(name, action))
+  }
+  return reverts
+}
+
 export function clearKeeperFilter(): void {
   selectedKeeperFilter.value = new Set()
 }


### PR DESCRIPTION
## 문제

\"재개하기 누르면 존나 느림\" — 서버 슬로우 root cause 트레이싱.

| Layer | Cost |
|---|---|
| Disk: read_meta + write_meta | ~5-15ms |
| Keeper_keepalive.process_directive (in-memory) | <1ms |
| refresh_keeper_execution_surfaces cache invalidate | ~5ms |
| **POST 응답 자체** | ~25ms |
| **이후 client \`refreshDashboard\` → projection 전체 재계산** | **수백 ms ~ 1s+** |

서버가 느린 게 아니라 *클릭 직후 client 가 full dashboard bootstrap 재요청* + *server 가 projection cache prefix 를 invalidate 했으니 재계산* 의 합. 사용자는 row 가 paused 상태로 계속 보이는 동안 \"느림\" 으로 체감.

## 수정

Optimistic UI — 클릭 즉시 local \`keepers\` signal 의 \`paused/phase/pipeline_stage/status\` 를 패치. \`keeperActionVisibility\` predicate 가 즉시 flip → button set 갱신. 이후 \`refreshDashboard()\` 가 authoritative snapshot 으로 reconcile. 실패 시 per-keeper revert.

### scope
- pause / resume / wakeup 만 — boot/shutdown 은 fiber lifecycle 변화가 커서 server 응답 대기.
- 단일 row + bulk 양쪽 path 모두 적용. bulk 는 partial-failure 시 *실패한 이름만* revert.
- \`refreshDashboard({force: true})\` → \`refreshDashboard()\` — \`force\` 는 bootstrap happy path 에서 사용되지 않는 dead signal (fallback path 만 forward). 거짓말 안 하도록 정리.

## 변경 요약

| 파일 | LoC |
|---|---|
| \`dashboard/src/store.ts\` | +66 |
| \`dashboard/src/components/keeper-action-panel.ts\` | +33 -3 |
| \`dashboard/src/store-optimistic-keeper.test.ts\` (NEW) | +109 |

신규 SSOT helper:
- \`applyOptimisticKeeperDirective(name, action)\` → revert thunk
- \`applyOptimisticKeeperDirectives(names, action)\` → \`Map<name, revert>\`
- \`patchForDirective\` private — pause/resume/wakeup → \`{paused, phase, pipeline_stage, status}\` 패치

## 검증

- 7 vitest cases — pause/resume/wakeup 패치 shape, revert, name-keyed revert (다른 keeper 의 unrelated mutation 보존), unknown name no-op, bulk partial revert.
- \`tsc --noEmit\` clean.
- 7/7 PASS (\`npx vitest run src/store-optimistic-keeper.test.ts\`).

## Self-review (best-programmer)

- 목표: 서버 latency root cause 트레이싱 → fix path 결정 → optimistic UI 적용.
- 변경 파일: store.ts (helper) / keeper-action-panel.ts (wire-in) / store-optimistic-keeper.test.ts (NEW).
- 로컬 검증: vitest 7/7 PASS, tsc --noEmit clean.
- 미검증: 실제 production 서버에서 single resume click → instant visual feedback 시각 확인. CI 통과 후 사용자 확인 필요.

## Workaround Gate

비-워크어라운드. UI 가 server-state 와 잠시 drift 하더라도 \`refreshDashboard\` 가 reconcile, 실패 시 revert. typed predicate (\`keeperActionVisibility\`) 통해 derived view 만 flip, 별도 분류기 신설 X.

🤖 Generated with [Claude Code](https://claude.com/claude-code)