### PR TITLE
feat(tool_misc_web_fetch): RFC-0189 PR-1b.8 — typed result + first Transient_error use (source-typed, no substring classifier)

### DIFF
--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -123,8 +123,12 @@ let handle_tool_help ~tool_name ~start_time _ctx args =
 let handle_web_search ~tool_name ~start_time _ctx args =
   Tool_misc_web_search.handle ~tool_name ~start_time args
 
+(* RFC-0189 PR-1b.8 — web_fetch handler is typed at the source;
+   project back to legacy [Tool_result.t] at this dispatch boundary
+   until [Tool_misc.dispatch] itself promotes to [result] (PR-1c). *)
 let handle_web_fetch ~tool_name ~start_time _ctx args =
   Tool_misc_web_fetch.handle ~tool_name ~start_time args
+  |> Tool_result.to_legacy
 
 (* ================================================================ *)
 (* Public re-exports from sub-modules                               *)

--- a/lib/tool_misc_web_fetch.ml
+++ b/lib/tool_misc_web_fetch.ml
@@ -147,6 +147,28 @@ let redact_transport_error_detail message =
   | Some idx -> String.sub message 0 idx
   | None -> message
 
+(* RFC-0189 PR-1b.8 — typed fetch-failure variant. Each arm carries
+   the data needed to render an operator-facing message AND a
+   [tool_failure_class] tag. This SSOT keeps message formatting (in
+   [fetch_failure_to_string]) and class assignment (in
+   [fetch_failure_class]) co-located with construction — no
+   substring re-classification downstream. *)
+type fetch_failure =
+  | Transport_error of string   (* raw transport-layer detail, already redacted *)
+  | Http_status of int          (* upstream returned a non-2xx HTTP status *)
+  | No_http_status              (* protocol level: status line missing *)
+
+let fetch_failure_to_string = function
+  | Transport_error detail -> Printf.sprintf "fetch failed: %s" detail
+  | Http_status status -> Printf.sprintf "HTTP %d" status
+  | No_http_status -> "no HTTP status received"
+
+let fetch_failure_class : fetch_failure -> Tool_result.tool_failure_class =
+  function
+  | Transport_error _ -> Tool_result.Transient_error
+  | Http_status _ -> Tool_result.Runtime_failure
+  | No_http_status -> Tool_result.Runtime_failure
+
 (** Main fetch implementation *)
 let fetch_impl ~url ~timeout_sec =
   let headers =
@@ -157,9 +179,7 @@ let fetch_impl ~url ~timeout_sec =
       ~timeout_sec ~headers url
   with
   | Error detail ->
-      Error
-        (Printf.sprintf "fetch failed: %s"
-           (redact_transport_error_detail detail))
+      Error (Transport_error (redact_transport_error_detail detail))
   | Ok (Some status, payload) when status >= 200 && status < 300 ->
       let title = extract_title payload in
       let description = extract_description payload in
@@ -171,22 +191,52 @@ let fetch_impl ~url ~timeout_sec =
         else cleaned
       in
       Ok (status, title, description, text)
-  | Ok (Some status, _) -> Error (Printf.sprintf "HTTP %d" status)
-  | Ok (None, _) -> Error "no HTTP status received"
+  | Ok (Some status, _) -> Error (Http_status status)
+  | Ok (None, _) -> Error No_http_status
 
-let handle ~tool_name ~start_time args =
+(* RFC-0189 PR-1b.8 — typed result.
+   Failure-class assignments live with construction:
+   - [Workflow_rejection]: caller-input violation (invalid URL).
+   - [Transient_error]:    rate-limit hit + transport-level failure
+                           ([fetch_failure_class] for transport).
+                           Both retry-friendly by nature; clients can
+                           now back off automatically based on the
+                           tag instead of pattern-matching the message
+                           string.
+   - [Runtime_failure]:    upstream HTTP non-2xx or missing status —
+                           server-side or malformed, retry is not
+                           always safe.
+
+   Note: no substring classifier downstream. Each [fetch_failure]
+   variant carries its own [fetch_failure_class], assigned at the
+   call site that constructs it. Avoids the workaround signature
+   §2 anti-pattern (string-based classification). *)
+
+let handle ~tool_name ~start_time args : Tool_result.result =
   let url = get_string args "url" "" in
   let timeout = max 1 (min 60 (get_int args "timeout" default_timeout_sec)) in
   if not (valid_url url) then
-    Tool_result.error ~tool_name ~start_time "url must be a valid http or https URL"
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      "url must be a valid http or https URL"
   else
     let now = Unix.gettimeofday () in
     let key = url ^ "|" ^ Int.to_string timeout in
     match cache_lookup key now with
-    | Some cached -> Tool_result.ok ~tool_name ~start_time cached
+    | Some cached ->
+        Tool_result.make_ok ~tool_name ~start_time
+          ~data:(`Assoc [ "text", `String cached ])
+          ()
     | None -> (
         match enforce_rate_limit now with
-        | Error message -> Tool_result.error ~tool_name ~start_time message
+        | Error message ->
+            Tool_result.make_err
+              ~tool_name
+              ~class_:Tool_result.Transient_error
+              ~start_time
+              message
         | Ok () -> (
             match fetch_impl ~url ~timeout_sec:timeout with
             | Ok (http_status, title, description, text) ->
@@ -207,5 +257,12 @@ let handle ~tool_name ~start_time args =
                 in
                 let json = Tool_args.ok_response fields in
                 cache_store key json now;
-                Tool_result.ok ~tool_name ~start_time json
-            | Error message -> Tool_result.error ~tool_name ~start_time message))
+                Tool_result.make_ok ~tool_name ~start_time
+                  ~data:(`Assoc [ "text", `String json ])
+                  ()
+            | Error failure ->
+                Tool_result.make_err
+                  ~tool_name
+                  ~class_:(fetch_failure_class failure)
+                  ~start_time
+                  (fetch_failure_to_string failure)))

--- a/lib/tool_misc_web_fetch.mli
+++ b/lib/tool_misc_web_fetch.mli
@@ -11,12 +11,14 @@
 val default_timeout_sec : int
 (** Default timeout for HTTP fetch operations (seconds). *)
 
-val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_result.t
+val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_result.result
 (** [handle ~tool_name ~start_time args] handles [masc_web_fetch] tool dispatch.
     Required: [url] (string, http/https only).
     Optional: [timeout] (int, clamped to [\[1, 60\]], default {!default_timeout_sec}).
 
-    Returns [Tool_result.ok] with fields:
+    On success the payload [data] is wrapped as
+    [`Assoc [ "text", `String json ]] where [json] is the serialized
+    [Tool_args.ok_response] envelope holding:
     - [url]: the requested URL
     - [http_status]: HTTP status code
     - [text]: cleaned text content (HTML tags stripped, entities decoded,
@@ -25,5 +27,8 @@ val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_resul
     - [description]: optional, extracted from [<meta name="description">]
       or [og:description]
 
-    Returns [Tool_result.error] on validation failure, rate limit,
-    transport error, or non-2xx HTTP status. *)
+    Failure classes (RFC-0189):
+    - [Workflow_rejection]: invalid URL — caller-input violation.
+    - [Transient_error]:    rate-limit hit + transport-layer failure;
+                            both retry-friendly.
+    - [Runtime_failure]:    upstream HTTP non-2xx or missing status. *)


### PR DESCRIPTION
## Summary

RFC-0189 PR-1b.8 — `tool_misc_web_fetch` migration (single `handle` function, 5 calls).

**First use of `Transient_error`** in the RFC-0189 cluster work. Earlier PRs (board/plan/run/library) had no genuinely retry-friendly errors. Rate-limit hits and transport-level failures are tagged `Transient_error` so clients can implement automatic backoff based on the tag instead of substring-matching the opaque message blob.

## Source-typed fetch failure (not substring classifier)

I started this PR with an inline `classify_fetch_failure : string -> tool_failure_class` substring matcher. That is exactly the **CLAUDE.md Workaround Signature §2 (String/Substring classifier)** anti-pattern (RFC-0042 territory). **Reverted before commit.** Each variant declares its class at construction:

```ocaml
type fetch_failure =
  | Transport_error of string   (* network/transport, redacted *)
  | Http_status of int          (* non-2xx from server *)
  | No_http_status              (* protocol-level missing status *)

let fetch_failure_class = function
  | Transport_error _ -> Tool_result.Transient_error
  | Http_status _     -> Tool_result.Runtime_failure
  | No_http_status    -> Tool_result.Runtime_failure
```

Adding a 4th variant fails compilation in `fetch_failure_class`. No downstream message re-parsing.

## Failure-class mapping

| Site | Class | Why |
|---|---|---|
| `"url must be a valid http or https URL"` | `Workflow_rejection` | Caller-input violation |
| `"web fetch rate limit exceeded; retry shortly"` | `Transient_error` | Retry after window |
| `Transport_error _` | `Transient_error` | Network retry-friendly |
| `Http_status _` | `Runtime_failure` | Server-side, unsafe to blind-retry |
| `No_http_status` | `Runtime_failure` | Protocol-level error |

## Caller cascade

- `lib/tool_misc.ml :handle_web_fetch` — single-line `|> Tool_result.to_legacy` until `Tool_misc.dispatch` itself promotes (deferred to PR-1c).

## Verification

- `dune build --root . lib/` exit 0
- `dune build --root . @check` exit 0
- `_build/default/test/test_tool_result.exe`: **20/20 PASS**
- Pre-existing `test_tool_board_coverage.exe :post_crud.004` failure unchanged (unrelated to RFC-0189).

## RFC-0189 cluster progress

| PR | Status |
|---|---|
| PR-1a | ✅ #18718 |
| PR-1b.1..7 | ✅ #18736 #18740 #18743 #18749 #18744 #18751 #18756 |
| **PR-1b.8** | 🟦 this |
| PR-1b.9+ | tool_misc_web_search, tool_misc/admin, coord, operator, agent |
| task cluster | separate RFC (10+ caller fan-out) |
| PR-1c | accessor migration |
| PR-2 | legacy `t` + classifier removal |

## Test plan

- [x] `dune build --root . lib/`
- [x] `dune build --root . @check`
- [x] `test_tool_result.exe` 20/20
- [ ] CI green (Draft — awaiting CI)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
