### PR TITLE
feat(coord_goals): RFC-0189 PR-1b.8 — typed result for 4 goal handlers (boundary at Tool_coord.dispatch)

### DIFF
--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -20,22 +20,40 @@ module Float = Stdlib.Float
 open Coord_types
 open Tool_args
 
-(* Local helpers: build Tool_result.t from response helpers.
-   ~tool_name and ~start_time are threaded through from dispatch. *)
-let ok_result ~tool_name ~start_time fields =
-  Tool_result.ok ~tool_name ~start_time (ok_response fields)
+(* Local helpers: build typed [Tool_result.result] from response helpers.
+   ~tool_name and ~start_time are threaded through from dispatch.
+
+   RFC-0189 PR-1b.8: handlers return [Tool_result.result]; the dispatch
+   boundary in [Tool_coord] keeps the [Tool_result.t option] ABI for
+   external callers via [Tool_result.to_legacy]. Failure class is
+   [Workflow_rejection] for every error path: all call sites here surface
+   caller-input rejections (typed codes [Validation_error] / [Not_found] /
+   [Conflict], or [validation_error_response] from [Tool_args]) — none
+   originate from internal-state failures. The plain [error_result] helper
+   was dead (0 callers) and removed. *)
+let ok_result ~tool_name ~start_time fields : Tool_result.result =
+  Tool_result.make_ok ~tool_name ~start_time ~data:(ok_assoc fields) ()
 ;;
 
-let error_result ~tool_name ~start_time msg =
-  Tool_result.error ~tool_name ~start_time (error_response msg)
+let error_result_typed ~tool_name ~start_time ~code msg : Tool_result.result =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Workflow_rejection
+    ~start_time
+    (error_response_typed ~code msg)
 ;;
 
-let error_result_typed ~tool_name ~start_time ~code msg =
-  Tool_result.error ~tool_name ~start_time (error_response_typed ~code msg)
-;;
-
-let validation_error_result ~tool_name ~start_time errors =
-  Tool_result.error ~tool_name ~start_time (validation_error_response errors)
+let validation_error_result
+      ~tool_name
+      ~start_time
+      (errors : field_error list)
+  : Tool_result.result
+  =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Workflow_rejection
+    ~start_time
+    (validation_error_response errors)
 ;;
 
 let goal_horizon_strings = [ "short"; "mid"; "long" ]
@@ -367,7 +385,7 @@ let update_goal_phase = Coord_goals_verification.update_goal_phase
 
 let emit_goal_event = Coord_goals_verification.emit_goal_event
 
-let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.t =
+let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.result =
   match
     ( reject_retired_goal_list_status args
     , parse_optional_horizon args "horizon"
@@ -388,7 +406,7 @@ let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.t
       ]
 ;;
 
-let handle_goal_upsert ~tool_name ~start_time (ctx : context) args : Tool_result.t =
+let handle_goal_upsert ~tool_name ~start_time (ctx : context) args : Tool_result.result =
   match
     ( parse_optional_horizon args "horizon"
     , parse_optional_goal_status args "status"
@@ -463,7 +481,7 @@ let handle_goal_upsert ~tool_name ~start_time (ctx : context) args : Tool_result
             ]))
 ;;
 
-let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_result.t =
+let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_result.result =
   match
     ( validate_string_required args "goal_id"
     , parse_optional_transition_action args "action"
@@ -770,7 +788,7 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
       ]
 ;;
 
-let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result.t =
+let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result.result =
   match
     ( validate_string_required args "goal_id"
     , parse_optional_principal args "principal"

--- a/lib/coord_goals.mli
+++ b/lib/coord_goals.mli
@@ -34,7 +34,7 @@ val handle_goal_list
   -> start_time:float
   -> Coord_types.context
   -> Yojson.Safe.t
-  -> Tool_result.t
+  -> Tool_result.result
 
 (** [handle_goal_upsert ctx args] handles [masc_goal_upsert] —
     create-or-update a goal record.  Validates horizon /
@@ -47,7 +47,7 @@ val handle_goal_upsert
   -> start_time:float
   -> Coord_types.context
   -> Yojson.Safe.t
-  -> Tool_result.t
+  -> Tool_result.result
 
 (** [handle_goal_transition ctx args] handles
     [masc_goal_transition].  Required arg: [action] (one of
@@ -62,7 +62,7 @@ val handle_goal_transition
   -> start_time:float
   -> Coord_types.context
   -> Yojson.Safe.t
-  -> Tool_result.t
+  -> Tool_result.result
 
 (** [handle_goal_verify ctx args] handles [masc_goal_verify] —
     record an operator/keeper verification vote (approve /
@@ -74,4 +74,4 @@ val handle_goal_verify
   -> start_time:float
   -> Coord_types.context
   -> Yojson.Safe.t
-  -> Tool_result.t
+  -> Tool_result.result

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -702,14 +702,30 @@ let dispatch ctx ~name ~args : Tool_result.t option =
   match name with
   | "masc_status" -> Some (handle_status ~tool_name:name ~start_time ctx args)
   | "masc_heartbeat" -> Some (handle_heartbeat ~tool_name:name ~start_time ctx args)
+  (* RFC-0189 PR-1b.8: Coord_goals handlers return Tool_result.result.
+     Boundary collapse: lift via to_legacy so external callers
+     (mcp_server_eio_execute, keeper_tag_dispatch, etc.) see the
+     unchanged Tool_result.t option ABI. *)
   | "masc_goal_list" ->
-    Some (Coord_goals.handle_goal_list ~tool_name:name ~start_time ctx args)
+    Some
+      (Tool_result.to_legacy
+         (Coord_goals.handle_goal_list ~tool_name:name ~start_time ctx args))
   | "masc_goal_upsert" ->
-    Some (Coord_goals.handle_goal_upsert ~tool_name:name ~start_time ctx args)
+    Some
+      (Tool_result.to_legacy
+         (Coord_goals.handle_goal_upsert ~tool_name:name ~start_time ctx args))
   | "masc_goal_transition" ->
-    Some (Coord_goals.handle_goal_transition ~tool_name:name ~start_time ctx args)
+    Some
+      (Tool_result.to_legacy
+         (Coord_goals.handle_goal_transition
+            ~tool_name:name
+            ~start_time
+            ctx
+            args))
   | "masc_goal_verify" ->
-    Some (Coord_goals.handle_goal_verify ~tool_name:name ~start_time ctx args)
+    Some
+      (Tool_result.to_legacy
+         (Coord_goals.handle_goal_verify ~tool_name:name ~start_time ctx args))
   | "masc_reset" -> Some (handle_reset ~tool_name:name ~start_time ctx args)
   | "masc_check" ->
     let inspect ctx =


### PR DESCRIPTION
## Summary

**Cluster 7 of N of the RFC-0189 §3.2 migration.** Promotes the four `Coord_goals` goal handlers and their three local helpers to typed `Tool_result.result`. Same boundary-collapse pattern as PR-1b.5 (#18744 plan) / PR-1b.6 (#18751 run) / PR-1b.7 (#18756 library): handlers return `Tool_result.result`, the dispatch site in `Tool_coord` wraps each call in `Tool_result.to_legacy` so external callers (`mcp_server_eio_execute`, `keeper_tag_dispatch`, two test suites) see the unchanged `Tool_result.t option` ABI.

## Why coord_goals as the next cluster

- 4 handlers, 12 legacy-helper call sites, 1 internal dispatch boundary — same shape and roughly the same size as PR-1b.5's `tool_plan` (8 handlers).
- External callers are limited to `Tool_coord.dispatch`; no fan-out to keeper / server / agent_tool, unlike `tool_task`.
- Dead `error_result` helper (zero call sites) removed at the same time.

## What's in this PR

```
 lib/coord_goals.ml  | +33 -16   (helpers retyped via make_ok/make_err; handler annotations; dead helper removed)
 lib/coord_goals.mli | +4 -4     (handler val signatures: Tool_result.t -> Tool_result.result)
 lib/tool_coord.ml   | +21 -4    (4 goal dispatch arms wrapped in Tool_result.to_legacy)
 3 files changed, 58 insertions(+), 24 deletions(-)
```

### Failure-class mapping

All `Coord_goals` error paths surface caller-input rejections, so every site maps to `Workflow_rejection`:

| Site | helper | class | rationale |
|---|---|---|---|
| 4 sites (line 395, 405, 473, 781) | `validation_error_result` | `Workflow_rejection` | `field_error list` from `validate_*` field-shape parsers |
| 4 typed-code sites (line 440, 488, 495, 505) | `error_result_typed` | `Workflow_rejection` | `Validation_error` / `Not_found` / `Conflict` are caller-state codes |

No `Runtime_failure` paths exist here: `Goal_store` operations return `Result.t` and propagate through the typed-code branches above. Internal exceptions, if any, hit the dispatch-boundary exception barrier (handled by the surrounding `try ... with` in callers, not in this module).

## Boundary

```
External callers (unchanged)
        │
        │  Tool_coord.dispatch ctx ~name ~args : Tool_result.t option
        ▼
┌───────────────────────────────────────────────────────────────┐
│ tool_coord.ml dispatch:                                        │
│   "masc_goal_*" -> Some (Tool_result.to_legacy                │
│                            (Coord_goals.handle_goal_* ...))   │
└───────────────────────────────────────────────────────────────┘
        │
        │  Tool_result.result  ◄── new
        ▼
┌───────────────────────────────────────────────────────────────┐
│ coord_goals.ml handlers:                                       │
│   ok_result / error_result_typed / validation_error_result    │
│     -> Tool_result.make_ok / make_err                         │
└───────────────────────────────────────────────────────────────┘
```

`Tool_result.to_legacy` is the lossless projection documented in `tool_result.mli:147–148`; it exists precisely for these dispatch-boundary collapses and is removed in RFC-0189 PR-2 once the legacy `t` record is dropped.

## Workaround signature gate self-check (CLAUDE.md §워크어라운드 거부 기준)

- **§1 Telemetry-as-fix**: N/A. Type-level migration, no counters.
- **§2 String/substring classifier**: N/A.
- **§3 N-of-M sweep**: **considered**. This is part of an RFC-staged migration (`tool_result.mli:115–118` schedules PR-1b across multiple clusters). Cluster boundary respected, no half-migrated state inside `Coord_goals`.
- **§4 Catch-all**: N/A.
- **§5 Cap/cooldown/dedup/repair**: N/A.
- **§6 Test backdoor**: N/A.
- **§7 Codemod-needed typo**: N/A.

RFC-WAIVED: not in credential / identity / sandbox / hooks / workflow scope. Tracked under RFC-0189 staged plan.

## Test plan

- [x] `dune build @check` clean.
- [x] `dune build .` (full) green.
- [x] No external-caller signature change (verified `Tool_coord.dispatch` still returns `Tool_result.t option`).
- [x] No new `Tool_result.t` constructors in `Coord_goals`; dead helper removed.
- [ ] CI: required checks green before Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
