### PR TITLE
refactor(voice): typed voice_command variant + descriptor parity gate (ZZ)

### DIFF
--- a/lib/keeper/agent_tool_voice_runtime.ml
+++ b/lib/keeper/agent_tool_voice_runtime.ml
@@ -1,103 +1,154 @@
 open Keeper_types
 open Keeper_exec_shared
 
-(** Runtime adapter for client-intercepted voice agent tools. *)
+(** Runtime adapter for client-intercepted voice agent tools.
+
+    The string [name] arriving from the descriptor dispatch layer is
+    parsed into a typed [voice_command] at the module boundary; every
+    branch downstream operates on the variant. The OCaml type checker
+    then forces every new variant to update [command_to_string] and
+    the dispatch match in [handle], eliminating the silent-drift
+    failure mode of an open string-classifier. *)
+
+type voice_command =
+  | Speak
+  | Listen
+  | Agent
+  | Sessions
+  | Session_start
+  | Session_end
+
+(** Canonical enumeration. Must list every constructor of
+    [voice_command]; adding a variant without appending here is the
+    one remaining drift vector — guarded by
+    [test_voice_command_descriptor_parity], which compares this list
+    against the registered [keeper_voice_*] descriptors. *)
+let all_commands : voice_command list =
+  [ Speak; Listen; Agent; Sessions; Session_start; Session_end ]
+
+let command_to_string = function
+  | Speak -> "keeper_voice_speak"
+  | Listen -> "keeper_voice_listen"
+  | Agent -> "keeper_voice_agent"
+  | Sessions -> "keeper_voice_sessions"
+  | Session_start -> "keeper_voice_session_start"
+  | Session_end -> "keeper_voice_session_end"
+
+(** Derived from [all_commands] + [command_to_string] so that adding a
+    variant requires only the [command_to_string] branch + the
+    [all_commands] entry — never a separate string-literal match. *)
+let command_of_string (s : string) : voice_command option =
+  List.find_opt (fun c -> String.equal (command_to_string c) s) all_commands
+
+let handle_speak ~(meta : keeper_meta) ~(args : Yojson.Safe.t) =
+  let message = Safe_ops.json_string ~default:"" "message" args |> String.trim in
+  let provider =
+    Safe_ops.json_string_opt "provider" args
+    |> Option.map String.trim
+    |> function
+    | Some p when p <> "" -> Some p
+    | _ -> None
+  in
+  let priority = max 1 (Safe_ops.json_int ~default:1 "priority" args) in
+  if message = ""
+  then error_json "message is required. Good: message='Hello team.'. Bad: message=''."
+  else (
+    match
+      ( Eio_context.get_switch_opt ()
+      , Eio_context.get_clock_opt ()
+      , Eio_context.get_net_opt () )
+    with
+    | Some sw, Some clock, Some net ->
+      (match
+         Voice_bridge.agent_speak
+           ~sw
+           ~clock
+           ~net
+           ~agent_id:meta.name
+           ~message
+           ?provider
+           ~priority
+           ()
+       with
+       | Ok json -> Yojson.Safe.to_string json
+       | Error err ->
+         Tool_args.error_response_with
+           [ "agent_id", `String meta.name
+           ; "message", `String err
+           ])
+    | _ ->
+      Yojson.Safe.to_string (keeper_text_fallback_json ~agent_id:meta.name ~message))
+
+let handle_listen ~(meta : keeper_meta) ~(args : Yojson.Safe.t) =
+  let timeout_sec = Safe_ops.json_float ~default:15.0 "timeout_seconds" args in
+  let language_code = Safe_ops.json_string_opt "language_code" args in
+  match
+    Voice_bridge.record_and_transcribe
+      ~agent_id:meta.name
+      ~timeout_sec
+      ?language_code
+      ()
+  with
+  | Ok json -> Yojson.Safe.to_string json
+  | Error err ->
+    Tool_args.error_response_with
+      [ "error", `String err
+      ; "agent_id", `String meta.name
+      ]
+
+let handle_agent ~(meta : keeper_meta) =
+  match Voice_bridge.get_agent_voice ~agent_id:meta.name with
+  | Ok json -> Yojson.Safe.to_string json
+  | Error err ->
+    Tool_args.error_response_with
+      [ "agent_id", `String meta.name
+      ; "message", `String err
+      ]
+
+let handle_sessions () =
+  let mgr = Keeper_voice_local.get_session_manager () in
+  let sessions = Voice_session_manager.list_sessions mgr in
+  Yojson.Safe.to_string
+    (`Assoc
+        [ "session_count", `Int (List.length sessions)
+        ; "sessions", `List (List.map Voice_session_manager.session_to_json sessions)
+        ])
+
+let handle_session_start ~(meta : keeper_meta) ~(args : Yojson.Safe.t) =
+  let voice =
+    Safe_ops.json_string_opt "session_name" args
+    |> Option.map String.trim
+    |> function
+    | Some s when s <> "" -> Some s
+    | _ -> None
+  in
+  let mgr = Keeper_voice_local.get_session_manager () in
+  let session = Voice_session_manager.start_session mgr ~agent_id:meta.name ?voice () in
+  Yojson.Safe.to_string (Voice_session_manager.session_to_json session)
+
+let handle_session_end ~(meta : keeper_meta) =
+  let mgr = Keeper_voice_local.get_session_manager () in
+  let ended = Voice_session_manager.end_session mgr ~agent_id:meta.name in
+  Yojson.Safe.to_string
+    (`Assoc
+        [ "status", `String (if ended then "ended" else "no_active_session")
+        ; "agent_id", `String meta.name
+        ])
+
+let handle ~(meta : keeper_meta) ~(command : voice_command) ~(args : Yojson.Safe.t) =
+  match command with
+  | Speak -> handle_speak ~meta ~args
+  | Listen -> handle_listen ~meta ~args
+  | Agent -> handle_agent ~meta
+  | Sessions -> handle_sessions ()
+  | Session_start -> handle_session_start ~meta ~args
+  | Session_end -> handle_session_end ~meta
 
 let handle_voice_tool
       ~(meta : keeper_meta)
       ~(name : string)
       ~(args : Yojson.Safe.t)
   =
-  match name with
-  | "keeper_voice_speak" ->
-    let message = Safe_ops.json_string ~default:"" "message" args |> String.trim in
-    let provider =
-      Safe_ops.json_string_opt "provider" args
-      |> Option.map String.trim
-      |> function
-      | Some p when p <> "" -> Some p
-      | _ -> None
-    in
-    let priority = max 1 (Safe_ops.json_int ~default:1 "priority" args) in
-    if message = ""
-    then error_json "message is required. Good: message='Hello team.'. Bad: message=''."
-
-    else (
-      match
-        ( Eio_context.get_switch_opt ()
-        , Eio_context.get_clock_opt ()
-        , Eio_context.get_net_opt () )
-      with
-      | Some sw, Some clock, Some net ->
-        (match
-           Voice_bridge.agent_speak
-             ~sw
-             ~clock
-             ~net
-             ~agent_id:meta.name
-             ~message
-             ?provider
-             ~priority
-             ()
-         with
-         | Ok json -> Yojson.Safe.to_string json
-         | Error err ->
-           Tool_args.error_response_with
-             [ "agent_id", `String meta.name
-             ; "message", `String err
-             ])
-      | _ ->
-        Yojson.Safe.to_string (keeper_text_fallback_json ~agent_id:meta.name ~message))
-  | "keeper_voice_listen" ->
-    let timeout_sec = Safe_ops.json_float ~default:15.0 "timeout_seconds" args in
-    let language_code = Safe_ops.json_string_opt "language_code" args in
-    (match
-       Voice_bridge.record_and_transcribe
-         ~agent_id:meta.name
-         ~timeout_sec
-         ?language_code
-         ()
-     with
-     | Ok json -> Yojson.Safe.to_string json
-     | Error err ->
-       Tool_args.error_response_with
-         [ "error", `String err
-         ; "agent_id", `String meta.name
-         ])
-  | "keeper_voice_agent" ->
-    (match Voice_bridge.get_agent_voice ~agent_id:meta.name with
-     | Ok json -> Yojson.Safe.to_string json
-     | Error err ->
-       Tool_args.error_response_with
-         [ "agent_id", `String meta.name
-         ; "message", `String err
-         ])
-  | "keeper_voice_sessions" ->
-    let mgr = Keeper_voice_local.get_session_manager () in
-    let sessions = Voice_session_manager.list_sessions mgr in
-    Yojson.Safe.to_string
-      (`Assoc
-          [ "session_count", `Int (List.length sessions)
-          ; "sessions", `List (List.map Voice_session_manager.session_to_json sessions)
-          ])
-  | "keeper_voice_session_start" ->
-    let voice =
-      Safe_ops.json_string_opt "session_name" args
-      |> Option.map String.trim
-      |> function
-      | Some s when s <> "" -> Some s
-      | _ -> None
-    in
-    let mgr = Keeper_voice_local.get_session_manager () in
-    let session = Voice_session_manager.start_session mgr ~agent_id:meta.name ?voice () in
-    Yojson.Safe.to_string (Voice_session_manager.session_to_json session)
-  | "keeper_voice_session_end" ->
-    let mgr = Keeper_voice_local.get_session_manager () in
-    let ended = Voice_session_manager.end_session mgr ~agent_id:meta.name in
-    Yojson.Safe.to_string
-      (`Assoc
-          [ "status", `String (if ended then "ended" else "no_active_session")
-          ; "agent_id", `String meta.name
-          ])
-  | other -> error_json ~fields:[ "tool", `String other ] "unknown_voice_tool"
-;;
+  match command_of_string name with
+  | Some command -> handle ~meta ~command ~args
+  | None -> error_json ~fields:[ "tool", `String name ] "unknown_voice_tool"

--- a/lib/keeper/agent_tool_voice_runtime.mli
+++ b/lib/keeper/agent_tool_voice_runtime.mli
@@ -1,4 +1,24 @@
-(** Runtime adapter for client-intercepted voice agent tools. *)
+(** Runtime adapter for client-intercepted voice agent tools.
+
+    The [voice_command] type is the canonical closed enumeration of
+    supported subcommands. [command_to_string] is the SSOT mapping;
+    [command_of_string] is derived from it and [all_commands], so that
+    new variants only require adding an entry in two places (the type
+    + the [command_to_string] match), both compiler-checked. *)
+
+type voice_command =
+  | Speak
+  | Listen
+  | Agent
+  | Sessions
+  | Session_start
+  | Session_end
+
+val all_commands : voice_command list
+
+val command_to_string : voice_command -> string
+
+val command_of_string : string -> voice_command option
 
 val handle_voice_tool :
   meta:Keeper_types.keeper_meta ->

--- a/test/dune
+++ b/test/dune
@@ -302,6 +302,7 @@
   test_cascade_routing_policy_targets_exist
   test_cascade_judge_route_intent_golden
   test_agent_tool_descriptor_registry_integrity
+  test_voice_command_descriptor_parity
   test_cascade_server_flavor
   test_cascade_phonebook_integration
   test_keeper_cascade_profile_partial
@@ -627,6 +628,7 @@
   test_cascade_routing_policy_targets_exist
   test_cascade_judge_route_intent_golden
   test_agent_tool_descriptor_registry_integrity
+  test_voice_command_descriptor_parity
   test_cascade_server_flavor
   test_cascade_phonebook_integration
   test_keeper_cascade_profile_partial

--- a/test/test_voice_command_descriptor_parity.ml
+++ b/test/test_voice_command_descriptor_parity.ml
@@ -1,0 +1,95 @@
+(** Parity gate between [Agent_tool_voice_runtime.voice_command]
+    enumeration and the [keeper_voice_*] entries registered in
+    [Agent_tool_descriptor.all_descriptors].
+
+    The previous string-classifier wiring (raw [match name with
+    "keeper_voice_speak" -> ...]) had no compiler-level link between
+    descriptor registration and handler dispatch — adding one without
+    the other was a silent dispatch hole.
+
+    This test pins both sides against each other so that a future
+    addition of a [keeper_voice_*] descriptor without a matching
+    [voice_command] variant (or vice versa) is rejected at test
+    time. *)
+
+open Alcotest
+module Descriptor = Masc_mcp.Agent_tool_descriptor
+module Voice = Masc_mcp.Agent_tool_voice_runtime
+
+let voice_prefix = "keeper_voice_"
+
+let registered_voice_internal_names () : string list =
+  Descriptor.all_descriptors ()
+  |> List.filter_map (fun d ->
+       let n = d.Descriptor.internal_name in
+       if String.length n >= String.length voice_prefix
+          && String.sub n 0 (String.length voice_prefix) = voice_prefix
+       then Some n
+       else None)
+  |> List.sort String.compare
+
+let enumerated_command_strings () : string list =
+  List.map Voice.command_to_string Voice.all_commands |> List.sort String.compare
+
+let pp_list xs = "[" ^ String.concat "; " xs ^ "]"
+
+let test_descriptor_set_equals_enumeration () =
+  let registered = registered_voice_internal_names () in
+  let enumerated = enumerated_command_strings () in
+  if registered <> enumerated
+  then
+    Alcotest.failf
+      "voice descriptor/variant parity broken.\n  descriptors: %s\n  variants:    %s"
+      (pp_list registered)
+      (pp_list enumerated)
+
+let test_command_round_trip () =
+  List.iter
+    (fun c ->
+      let s = Voice.command_to_string c in
+      match Voice.command_of_string s with
+      | Some c' when c' = c -> ()
+      | Some _ ->
+        Alcotest.failf
+          "round-trip mismatch for variant rendered as %S — \
+           command_of_string returned different variant"
+          s
+      | None ->
+        Alcotest.failf
+          "round-trip failed: command_of_string %S = None (must be Some _)"
+          s)
+    Voice.all_commands
+
+let test_unknown_command_is_none () =
+  match Voice.command_of_string "keeper_voice_does_not_exist" with
+  | None -> ()
+  | Some _ ->
+    Alcotest.failf
+      "command_of_string accepted an unknown string as a variant"
+
+let test_enumeration_nonempty () =
+  if Voice.all_commands = []
+  then
+    Alcotest.failf "Voice.all_commands is empty — expected at least one variant"
+
+let () =
+  Alcotest.run
+    "voice_command_descriptor_parity"
+    [ ( "parity"
+      , [ test_case "enumeration nonempty" `Quick test_enumeration_nonempty
+        ; test_case
+            "descriptor set equals voice_command enumeration"
+            `Quick
+            test_descriptor_set_equals_enumeration
+        ] )
+    ; ( "round_trip"
+      , [ test_case
+            "command_of_string ∘ command_to_string = Some"
+            `Quick
+            test_command_round_trip
+        ; test_case
+            "unknown string yields None"
+            `Quick
+            test_unknown_command_is_none
+        ] )
+    ]


### PR DESCRIPTION
## Why

`Agent_tool_voice_runtime.handle_voice_tool` previously dispatched on
the raw string `name` arriving from the descriptor layer:

```ocaml
match name with
| "keeper_voice_speak" -> ...
| "keeper_voice_listen" -> ...
...
| other -> error_json ~fields:[ "tool", `String other ] "unknown_voice_tool"
```

There was no compiler-level link between the registered
`voice_descriptor "keeper_voice_X"` entries in
`Agent_tool_descriptor` and the strings handled in this match.
Adding a new `keeper_voice_*` descriptor without the matching
handler branch (or vice versa) was a silent dispatch hole — exactly
the string-classifier pattern flagged by CLAUDE.md software-development.md
§AI Code Generation Antipatterns #4 (Sparse Match) and the
workaround-rejection bar §2 (String/Substring classifier).

Voice today registers 6 descriptors and handles 6 names; parity
is intact. This PR pins it as a forward-going contract.

## What

### Refactor: typed `voice_command` variant in `agent_tool_voice_runtime.ml`

```ocaml
type voice_command =
  | Speak | Listen | Agent | Sessions | Session_start | Session_end

let all_commands : voice_command list = [ Speak; Listen; ... ]
let command_to_string = function Speak -> "keeper_voice_speak" | ...

let command_of_string s =
  List.find_opt (fun c -> String.equal (command_to_string c) s) all_commands
```

- `command_to_string` is an exhaustive match — the compiler now
  forces every new variant to add a string rendering.
- `command_of_string` is **derived** from `all_commands` +
  `command_to_string`, eliminating the parallel hand-written string
  table that was the original drift surface.
- `handle ~meta ~command ~args` matches on the typed variant; the
  six per-command handlers are extracted into named functions
  (`handle_speak`, `handle_listen`, ...).
- `handle_voice_tool ~meta ~name ~args` parses `name` →
  `command_of_string` → `Some _ : handle_*` or `None :
  error_json "unknown_voice_tool"`. Same semantic surface, typed
  internals.

### Surfaced API (`agent_tool_voice_runtime.mli`)

New exports for test cross-check:

```ocaml
type voice_command = Speak | Listen | Agent | Sessions | Session_start | Session_end
val all_commands : voice_command list
val command_to_string : voice_command -> string
val command_of_string : string -> voice_command option
```

(`handle_voice_tool` signature unchanged — caller `handle_voice` in
`agent_tool_in_process_runtime.ml` needs no edit.)

### Parity test: `test_voice_command_descriptor_parity.ml`

Four assertions:

1. `all_commands` non-empty (sanity floor)
2. `Set (descriptor.internal_name | starts_with "keeper_voice_") ==
   Set (List.map command_to_string all_commands)` — the parity gate
3. Round-trip `command_of_string ∘ command_to_string = Some`
4. Unknown string yields `None`

All four pass against current main.

## Out of scope

- Equivalent typed refactor for `task` (8 descriptors,
  `Keeper_exec_task.handle_keeper_task_tool`), `board` (~20
  descriptors, `Agent_tool_board_runtime.handle_keeper_board_tool`),
  and `masc_board` (dynamic, `Tool_board_dispatch.handle_tool`).
  Voice is the smallest of the four runtimes — validates the pattern
  before broader application.
- RFC-0189 typed `Tool_result.result` migration. The previously
  build-blocking sites have already landed via #18756.

## Pre-existing baseline

`test_tool_board_coverage.ml::post_crud.004 "scalar judgment ignored (null)"`
fails on `origin/main` head independent of this PR (1/87 failures
either way). Reproducible without any of the voice changes. Not
addressed here.

## Verification

```
dune build --root .
# exit 0

dune exec test/test_voice_command_descriptor_parity.exe --root .
# Test Successful in 0.000s. 4 tests run.
```

## Risk profile

Replacement-style refactor in a *single small module* (104 LoC →
~170 LoC, all internal to `agent_tool_voice_runtime`). Caller surface
unchanged; the new exports are additive on `.mli`. Revert is one
file diff. Consumer count for the surface API: 1
(`agent_tool_in_process_runtime.handle_voice`), unchanged.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
