### PR TITLE
refactor(tool_name): rename Keeper.Shell variant to Search_files

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -637,7 +637,7 @@ let fallback_floor_tool_names =
     ]
 
 let fallback_repo_probe_tool_names =
-  tool_names Tool_name.[ Keeper Fs_read; Keeper Shell; Keeper Execute ]
+  tool_names Tool_name.[ Keeper Fs_read; Keeper Search_files; Keeper Execute ]
 
 let is_claim_tool_name name =
   Keeper_tool_progress.is_claim_tool_name name
@@ -662,7 +662,7 @@ let keeper_selection_bm25_prefilter_n = 30
 
    Entries stay keyed by canonical handler names. LLM-visible public aliases
    such as Execute/SearchFiles project through Keeper_tool_alias below, so retrieval
-   shares one public-alias axis instead of carrying duplicate Execute/Shell rows. *)
+   shares one public-alias axis instead of carrying duplicate Execute/SearchFiles rows. *)
 let tool_search_alias_entries =
   [ "keeper_board_post", "게시판 글 작성 올리기 포스트"
   ; "keeper_board_get", "게시판 글 읽기 조회 확인"

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -584,7 +584,7 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
     | Tool_name.Keeper.Task_submit_for_verification
     | Tool_name.Keeper.Tasks_audit
     | Tool_name.Keeper.Tasks_list -> "coordination"
-    | Tool_name.Keeper.Execute | Tool_name.Keeper.Shell -> "shell"
+    | Tool_name.Keeper.Execute | Tool_name.Keeper.Search_files -> "shell"
     | Tool_name.Keeper.Fs_edit
     | Tool_name.Keeper.Fs_read
     | Tool_name.Keeper.Ide_annotate -> "fs"

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -15,7 +15,7 @@ let has_mutating_side_effect_with_input ~(tool_name : string) ~(input : Yojson.S
   : bool
   =
   match Tool_name.of_string tool_name with
-  | Some (Keeper Shell) ->
+  | Some (Keeper Search_files) ->
     let op =
       match input with
       | `Assoc fields ->

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -184,7 +184,7 @@ let keeper_shell_op (input : Yojson.Safe.t) : string option =
 
 let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : bool =
   match Tool_name.of_string tool_name with
-  | Some (Keeper Shell) ->
+  | Some (Keeper Search_files) ->
     (match keeper_shell_op input with
      | Some op -> List.mem op keeper_shell_read_only_ops
      | None -> false)

--- a/lib/tool_catalog_inference.ml
+++ b/lib/tool_catalog_inference.ml
@@ -54,7 +54,7 @@ module TM = Tool_name.Masc
 module TMK = Tool_name.Masc_keeper
 
 let inferred_effect_domain_of_typed_tool_name = function
-  | TN.Keeper TK.Execute | TN.Keeper TK.Shell -> Some Host_repo_write
+  | TN.Keeper TK.Execute | TN.Keeper TK.Search_files -> Some Host_repo_write
   | TN.Keeper TK.Board_get
   | TN.Keeper TK.Board_list
   | TN.Keeper TK.Board_curation_read
@@ -246,7 +246,7 @@ let tool_group_of_typed_tool_name = function
       | TK.Voice_speak ) ->
       Some Voice
   | TN.Keeper
-      (TK.Execute | TK.Fs_edit | TK.Fs_read | TK.Ide_annotate | TK.Shell) ->
+      (TK.Execute | TK.Fs_edit | TK.Fs_read | TK.Ide_annotate | TK.Search_files) ->
       Some Filesystem
   | TN.Keeper
       ( TK.Broadcast

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -50,7 +50,7 @@ module Keeper = struct
     | Library_search
     | Memory_search
     | Memory_write
-    | Shell
+    | Search_files
     | Stay_silent
     | Task_claim
     | Task_create
@@ -98,7 +98,7 @@ module Keeper = struct
     | Library_search -> "keeper_library_search"
     | Memory_search -> "keeper_memory_search"
     | Memory_write -> "keeper_memory_write"
-    | Shell -> "tool_search_files"
+    | Search_files -> "tool_search_files"
     | Stay_silent -> "keeper_stay_silent"
     | Task_claim -> "keeper_task_claim"
     | Task_create -> "keeper_task_create"
@@ -147,7 +147,7 @@ module Keeper = struct
     | "keeper_library_search" -> Some Library_search
     | "keeper_memory_search" -> Some Memory_search
     | "keeper_memory_write" -> Some Memory_write
-    | "tool_search_files" -> Some Shell
+    | "tool_search_files" -> Some Search_files
     | "keeper_stay_silent" -> Some Stay_silent
     | "keeper_task_claim" -> Some Task_claim
     | "keeper_task_create" -> Some Task_create

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -32,7 +32,7 @@ module Keeper : sig
     | Library_search
     | Memory_search
     | Memory_write
-    | Shell
+    | Search_files
     | Stay_silent
     | Task_claim
     | Task_create

--- a/lib/tool_resource_axis.ml
+++ b/lib/tool_resource_axis.ml
@@ -139,7 +139,7 @@ let classify_keeper_tool (tool : Tool_name.Keeper.t) args =
   let open Tool_name.Keeper in
   match tool with
   | Tool_name.Keeper.Execute -> typed_bash_args_class args
-  | Shell -> classify_keeper_shell_op args
+  | Search_files -> classify_keeper_shell_op args
   | Fs_edit -> Filesystem_write
   | Fs_read | Tool_search -> Filesystem_read
   | Memory_write | Handoff -> Filesystem_write


### PR DESCRIPTION
## Summary

PR #18520 (`refactor(keeper): purge legacy tool ids`, `8922ae75a`) 가 `Tool_name.Keeper.Shell` variant 의 string serialization 만 `"keeper_shell"` → `"tool_search_files"` 로 정렬했고 *variant 이름은 그대로* 두었다. 결과:

- typed identifier `Tool_name.Keeper.Shell` 이 자기 정체를 거짓말함 — 코드에 `Keeper Shell` 로 적히지만 실제 도구는 `tool_search_files`
- exhaustive match 는 통과하므로 컴파일러가 drift 를 감지 못 함
- 새 callsite 가 `Keeper Shell` 을 *shell 도구* 로 오해할 위험

본 PR 은 PR #18520 의 *논리적 완성* — variant 이름을 string serialization 과 일치시킨다.

## 변경 사항

| File | 변경 |
|---|---|
| `lib/tool_name.mli` | type variant `Shell` → `Search_files` |
| `lib/tool_name.ml` | type variant + `to_string` + `of_string` 3 arm |
| `lib/tool_catalog_inference.ml` | 2 match arm (`TK.Shell` → `TK.Search_files`) |
| `lib/tool_resource_axis.ml` | 1 match arm |
| `lib/keeper/keeper_exec_shared.ml` | 1 match arm |
| `lib/keeper/keeper_agent_tool_surface.ml` | repo probe surface + 주석 1줄 (`Execute/Shell` → `Execute/SearchFiles`) |
| `lib/keeper/keeper_tool_registry.ml` | `is_read_only_with_input` 분기 |
| `lib/keeper/keeper_exec_tools.ml` | `has_mutating_side_effect_with_input` 분기 |

8 file, +12 / -12 LoC. 동작 변경 없음 — 순수 typed identifier rename.

## Scope 결정 (별 사이클 후보, 본 PR 범위 밖)

- `tool_search_files` 의 schema (`lib/tool_shard_types_schemas_shell.ml`) 가 *legacy `keeper_shell` 의 multi-op enum* (op = `ls`/`cat`/`rg`/`git_status`/`git_log`/`git_diff`/...) 을 그대로 유지 — 이름은 "search_files" 인데 의미는 broader workspace_ops. 별 RFC 후보.
- `keeper_shell_op` + `keeper_shell_read_only_ops` helper (`keeper_tool_registry.ml:160-200`) 는 *legacy `keeper_shell`* 의 op-based 분기 — 도구 schema 가 multi-op 인 한 살아있음. schema 정리와 함께 후속.
- `lib/keeper/keeper_exec_shared.ml:587` 의 `"shell"` resource label — `Execute` + `Search_files` 모두 shell-execute backend 경유이므로 의미 정합. 유지.

## Workaround Signature Gate

본 PR 은 *positive typed boundary 강화*:
- variant 이름 ↔ string serialization 의 drift 제거
- CLAUDE.md §1 (Hardcoded scatter) 시그니처 위반 *해소*
- counter / cap / cooldown / dedup / repair 추가 0
- string classifier 추가 0
- catch-all 추가 0

Override 불필요.

## Verification

- `dune build --root . lib/` clean (이미 통과)
- `dune build --root . test/` clean (background build exit 0)
- `rg -nw 'Tool_name\.Keeper\.Shell|TK\.Shell|Keeper Shell|Keeper\.Shell' lib/ test/` → 0 hits
- 동작 변경 없음 — variant rename + caller migration 만

## 관련

- PR #18520 (`8922ae75a`, "refactor(keeper): purge legacy tool ids") 완성
- 본 PR 직전 검증 conversation:  `Tool_name.Shell` variant 가 `tool_search_files` 로 매핑된 drift 발견 (사용자 "Tool Name 제대로 나오는건지?" → grep 으로 직접 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)