### PR TITLE
RFC-0182: legacy purge (Phase 1) + masc_board cluster projection (Phase 2 proof)

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -94,10 +94,7 @@ let local_worker_internal_schemas : Masc_domain.tool_schema list =
 let local_worker_run_schemas : Masc_domain.tool_schema list =
   Tool_schemas_run.schemas
 
-let local_worker_spawn_schemas : Masc_domain.tool_schema list =
-  List.filter
-    (fun (schema : Masc_domain.tool_schema) -> String.equal schema.name "masc_spawn")
-    Tool_schemas_inline_infra.schemas
+(* RFC-0182: local_worker_spawn_schemas removed — masc_spawn is dead. *)
 
 let select_public_local_worker_schemas () =
   let wanted_set = name_set local_worker_public_tool_names in
@@ -107,8 +104,7 @@ let select_public_local_worker_schemas () =
     @ Tool_schemas_coord_extra.schemas
     @ Tool_task_schemas.schemas
     @ Tool_schemas_agent.schemas
-    @ local_worker_run_schemas
-    @ local_worker_spawn_schemas)
+    @ local_worker_run_schemas)
   |> List.filter (fun (schema : Masc_domain.tool_schema) ->
          Hashtbl.mem wanted_set schema.name)
 

--- a/lib/agent_tool_surfaces.mli
+++ b/lib/agent_tool_surfaces.mli
@@ -88,8 +88,7 @@ val local_worker_internal_schemas : Masc_domain.tool_schema list
     Filtered from {!Tool_schemas_coord_core.schemas}. *)
 
 val local_worker_run_schemas : Masc_domain.tool_schema list
-val local_worker_spawn_schemas : Masc_domain.tool_schema list
-(** Domain-grouped schema bundles (run / spawn)
+(** Domain-grouped schema bundle (run)
     used by {!select_public_local_worker_schemas} and the
     autonomous catalogue resolver. *)
 

--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -167,8 +167,10 @@ let local_worker_public_tool_names : string list =
 let local_worker_internal_schemas : Masc_domain.tool_schema list =
   Agent_tool_surfaces.local_worker_internal_schemas
 
-let privileged_public_tool_names : string list =
-  [ "masc_spawn" ]
+(* RFC-0182: masc_spawn removed (dead). privileged_public_tool_names is
+   currently empty — no remaining public tool requires Privileged
+   risk_class. Kept as extension point. *)
+let privileged_public_tool_names : string list = []
 
 let privileged_keeper_tool_names : string list =
   [ "tool_execute"; "tool_edit_file"; "tool_write_file" ]

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -472,8 +472,7 @@ let normalize_allowed_tool_name value =
 let allowed_tool tool =
   List.mem (normalize_allowed_tool_name tool)
     [
-      "masc_execute_dry_run";
-      "masc_execute";
+      (* RFC-0182: masc_execute / masc_execute_dry_run removed (dead). *)
       "masc_operator_action";
       "masc_operator_confirm";
       "masc_operator_snapshot";

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -250,23 +250,10 @@ let explicit_metadata : (string * metadata) list =
       { masc_coordination_tool with required_permission = Some Masc_domain.CanOpenPortal } );
     ( "masc_portal_send",
       { masc_coordination_tool with required_permission = Some Masc_domain.CanSendPortal } );
-    (* Run schemas register from tool_run.ml; catalog still owns early auth metadata. *)
-    ("masc_execute_dry_run", readonly_tool);
-    ( "masc_admin_cleanup",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Administrative cleanup mutates persisted namespace state and should be treated as destructive.") );
-    ( "masc_admin_reset",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Administrative reset clears namespace state and should be treated as destructive.") );
-    ( "masc_gc_force",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Forced garbage collection removes persisted artifacts and should be treated as destructive.") );
-    ( "masc_room_delete",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Namespace deletion removes persisted state and should be treated as destructive.") );
-    ( "masc_force_leave",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Forced membership removal mutates namespace state and should be treated as destructive.") );
+    (* Run schemas register from tool_run.ml; catalog still owns early auth metadata.
+       RFC-0182: 7 dead admin tools (masc_execute_dry_run, masc_admin_cleanup,
+       masc_admin_reset, masc_gc_force, masc_room_delete, masc_force_leave,
+       masc_execute) removed — no dispatch path, no schema, no caller. *)
     ( "masc_operator_action",
       with_semantic_flags ~destructive:true
         { (hidden_active "Operator actions can execute privileged side effects and should be treated as destructive.") with
@@ -280,9 +267,6 @@ let explicit_metadata : (string * metadata) list =
         with
         required_permission = Some Masc_domain.CanAdmin;
       } );
-    ( "masc_execute",
-      with_semantic_flags ~destructive:true
-        (hidden_active "Direct execution can apply privileged side effects and should be treated as destructive.") );
     ("masc_tool_grant", admin_tool);
     ("masc_tool_revoke", admin_tool);
     ("masc_keeper_reset", broadcast_tool);
@@ -318,7 +302,6 @@ let explicit_metadata : (string * metadata) list =
     ("masc_agent_fitness", read_state_tool);
     ("masc_agent_timeline", read_state_tool);
     ("masc_agent_update", broadcast_tool);
-    ("masc_spawn", broadcast_tool);
     ("masc_get_metrics", read_state_tool);
     ("masc_operator_snapshot", read_state_tool);
     ("masc_operator_digest", read_state_tool);

--- a/lib/tool_catalog_inference.ml
+++ b/lib/tool_catalog_inference.ml
@@ -106,7 +106,6 @@ let inferred_effect_domain_of_typed_tool_name = function
       Some Masc_coordination
   | TN.Masc TM.Deliver
   | TN.Masc TM.Operator_action
-  | TN.Masc TM.Spawn
   | TN.Masc TM.Start ->
       Some Host_repo_write
   | TN.Masc TM.Agent_fitness
@@ -322,7 +321,6 @@ let tool_group_of_typed_tool_name = function
       | TM.Pause
       | TM.Reset
       | TM.Resume
-      | TM.Spawn
       | TM.Start
       | TM.Status
       | TM.Task_history

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -244,7 +244,6 @@ let spawned_agent_surface_tools =
   ; "masc_tool_help"
   ; "masc_web_search"
   ; "masc_web_fetch"
-  ; "masc_spawn"
   ; (* Phase 2: surface SSOT *)
     "masc_deliver"
   ; "masc_plan_clear_task"
@@ -334,7 +333,6 @@ let keeper_internal_surface_tools = keeper_internal_tools
 
 let keeper_denied_surface_tools =
   [ "masc_reset"
-  ; "masc_spawn"
   ; (* Admin surface — [CanAdmin]-gated, keepers cannot execute these.
        Log evidence (2026-04-16 /loop): ~49 Forbidden errors per ~3MB
        window from keepers (ani1999, etc.) trying to call these. They
@@ -409,7 +407,6 @@ let coordination_role_tools : string list =
   ; "masc_board_sub_board_get"
   ; "masc_claim_next"
   ; "masc_transition"
-  ; "masc_spawn"
   ]
 ;;
 

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -336,7 +336,6 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
     | Leave
     | Mcp_session
     | Messages
-    | Spawn
     | Start
     | Who -> Some Mod_inline
     | Check

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -282,11 +282,7 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.t option =
        | Error e -> Some (Tool_result.error ~tool_name:name ~start_time:start e)))
 
   (* Infrastructure tools: cancellation, subscription, progress,
-     governance_set removed — pruned from surfaces *)
-
-  | "masc_spawn" ->
-      Some (Tool_result.error ~tool_name:name ~start_time:start
-        "masc_spawn removed: vendor-specific agent spawning belongs to OAS domain")
+     governance_set, masc_spawn removed — pruned from surfaces *)
 
   (* ── Tool discovery ─────────────────────────────────────────── *)
   | "masc_discover_tools" ->

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -302,3 +302,72 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.t option =
   (* ── Fallthrough to extra dispatch ──────────────────────────── *)
   | _ ->
       Tool_inline_dispatch_extra.dispatch ~config ~agent_name ~arguments ~state ~sw ~clock ~name ~start_time:start
+
+(* ================================================================ *)
+(* Tool_spec registration (RFC-0182 §3.2)                           *)
+(* ================================================================ *)
+
+(* Migrates the inline-dispatched coord + approval tools from the legacy
+   register_module_tag + init_*_set bootstrap (mcp_server_eio.ml) to the
+   Tool_spec single-call SSOT. Scope: 6 of 10 §3.2 live tools.
+
+   Excluded (deferred, semantic-widening would be required):
+   - [masc_approval_resolve], [masc_set_param], [channel_gate] —
+     no Masc_domain.tool_schema record exists. They are dispatched via
+     HTTP routes / inline arms but never advertised to MCP. Promoting
+     them to Tool_spec.register requires authoring new input schemas
+     (and for [masc_set_param] / [channel_gate], deciding visibility
+     semantics for MCP exposure). Tracked as RFC-0182 follow-up scope.
+   - [masc_tool_revoke] — already registered via Tool_shard schemas
+     (lib/tool_shard.ml:348). Audit row was a false positive. *)
+
+let inline_register_targets =
+  [ "masc_join"; "masc_leave"; "masc_broadcast"; "masc_messages"
+  ; "masc_approval_get"; "masc_approval_pending" ]
+
+let inline_tool_required_permission name : Masc_domain.permission option =
+  match name with
+  | "masc_join" -> Some Masc_domain.CanJoin
+  | "masc_leave" -> Some Masc_domain.CanLeave
+  | "masc_broadcast" -> Some Masc_domain.CanBroadcast
+  | "masc_messages" -> Some Masc_domain.CanReadState
+  | "masc_approval_get" -> Some Masc_domain.CanAdmin
+  | "masc_approval_pending" -> Some Masc_domain.CanReadState
+  | _ -> None
+
+let inline_tool_read_only =
+  [ "masc_messages"; "masc_approval_get"; "masc_approval_pending" ]
+
+let inline_tool_requires_join = [ "masc_leave"; "masc_broadcast" ]
+
+let inline_tool_requires_actor_binding = [ "masc_join"; "masc_leave" ]
+
+let inline_tool_effect_domain name : Tool_catalog.effect_domain =
+  if List.mem name inline_tool_read_only then Tool_catalog.Read_only
+  else Tool_catalog.Masc_coordination
+
+let () =
+  inline_register_targets
+  |> List.iter (fun name ->
+    match
+      List.find_opt
+        (fun (s : Masc_domain.tool_schema) -> String.equal s.name name)
+        Tool_schemas_inline.schemas
+    with
+    | None -> ()
+    | Some (schema : Masc_domain.tool_schema) ->
+      let is_read_only = List.mem name inline_tool_read_only in
+      Tool_spec.register
+        (Tool_spec.create
+           ~name:schema.name
+           ~description:schema.description
+           ~module_tag:Tool_dispatch.Mod_inline
+           ~input_schema:schema.input_schema
+           ~handler_binding:Tag_dispatch
+           ~is_read_only
+           ~is_idempotent:is_read_only
+           ~requires_join:(List.mem name inline_tool_requires_join)
+           ~requires_actor_binding:(List.mem name inline_tool_requires_actor_binding)
+           ~effect_domain:(inline_tool_effect_domain name)
+           ?required_permission:(inline_tool_required_permission name)
+           ()))

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -281,7 +281,6 @@ module Masc = struct
     | Mcp_session
     | Pause
     | Resume
-    | Spawn
     | Start
     | Tool_admin_snapshot
     | Tool_admin_update
@@ -360,7 +359,6 @@ module Masc = struct
     | Mcp_session -> "masc_mcp_session"
     | Pause -> "masc_pause"
     | Resume -> "masc_resume"
-    | Spawn -> "masc_spawn"
     | Start -> "masc_start"
     | Tool_admin_snapshot -> "masc_tool_admin_snapshot"
     | Tool_admin_update -> "masc_tool_admin_update"
@@ -440,7 +438,6 @@ module Masc = struct
     | "masc_mcp_session" -> Some Mcp_session
     | "masc_pause" -> Some Pause
     | "masc_resume" -> Some Resume
-    | "masc_spawn" -> Some Spawn
     | "masc_start" -> Some Start
     | "masc_tool_admin_snapshot" -> Some Tool_admin_snapshot
     | "masc_tool_admin_update" -> Some Tool_admin_update

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -136,7 +136,6 @@ module Masc : sig
     | Mcp_session
     | Pause
     | Resume
-    | Spawn
     | Start
     | Tool_admin_snapshot
     | Tool_admin_update

--- a/lib/tool_resource_axis.ml
+++ b/lib/tool_resource_axis.ml
@@ -247,7 +247,6 @@ let classify_masc_tool (tool : Tool_name.Masc.t) =
   | Plan_get
   | Plan_get_task
   | Resume
-  | Spawn
   | Start
   | Status
   | Task_history

--- a/lib/tool_schemas/tool_schemas_inline_infra.ml
+++ b/lib/tool_schemas/tool_schemas_inline_infra.ml
@@ -20,7 +20,7 @@ let mcp_session_action_enum_strings =
    Tool_schemas_inline.schemas continue to see all inline_infra
    tools. *)
 let codegen_inline_infra_names =
-  [ "masc_approval_pending"; "masc_approval_get"; "masc_spawn" ]
+  [ "masc_approval_pending"; "masc_approval_get" ]
 
 let inline_infra_from_codegen =
   List.filter
@@ -54,16 +54,6 @@ let manual_inline_infra_schemas : tool_schema list =
                       ] )
                 ] )
           ; "required", `List [ `String "id" ]
-          ; "additionalProperties", `Bool false
-          ];
-    };
-    {
-      name = "masc_spawn";
-      description = "Removed tool stub; vendor-specific spawning belongs to OAS.";
-      input_schema =
-        `Assoc
-          [ "type", `String "object"
-          ; "properties", `Assoc []
           ; "additionalProperties", `Bool false
           ];
     };

--- a/lib/tool_spec.ml
+++ b/lib/tool_spec.ml
@@ -25,7 +25,6 @@ type handler_binding =
   | Direct of Tool_dispatch.handler
   | Shared of Tool_dispatch.handler
   | Tag_dispatch
-  | Match_chain
 
 type t = {
   name : string;
@@ -167,7 +166,7 @@ let register (spec : t) =
    | Direct h | Shared h ->
      Tool_dispatch.register ~tool_name:spec.name ~handler:h;
      Hashtbl.replace expects_handler spec.name ()
-   | Tag_dispatch | Match_chain -> ())
+   | Tag_dispatch -> ())
 
 let register_all (specs : t list) =
   List.iter register specs

--- a/lib/tool_spec.mli
+++ b/lib/tool_spec.mli
@@ -28,7 +28,6 @@ type handler_binding =
   | Direct of Tool_dispatch.handler
   | Shared of Tool_dispatch.handler
   | Tag_dispatch
-  | Match_chain
 
 type t = {
   name : string;
@@ -104,7 +103,7 @@ val to_tool_schema : t -> Masc_domain.tool_schema
 val verify_handler_coverage : unit -> string list
 (** Returns tool names that were registered via [register] with [Direct] or
     [Shared] binding but have no handler in [Tool_dispatch]. [Tag_dispatch]
-    and [Match_chain] bindings are excluded. Call after server initialization
-    completes. Empty list means full coverage. *)
+    bindings are excluded. Call after server initialization completes.
+    Empty list means full coverage. *)
 
 val all_registered_names : unit -> string list

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -308,9 +308,11 @@ let test_risk_precedence_critical_over_high () =
     "critical" (Gp.risk_level_to_string risk)
 
 let test_risk_metadata_admin_cleanup_override () =
+  (* masc_admin_cleanup removed in RFC-0182; assess_risk for unknown tool
+     defaults to low. *)
   let risk = Gp.assess_risk ~tool_name:"masc_admin_cleanup" ~input:no_args in
-  Alcotest.(check string) "admin_cleanup metadata marks destructive"
-    "critical" (Gp.risk_level_to_string risk)
+  Alcotest.(check string) "admin_cleanup unknown defaults to low"
+    "low" (Gp.risk_level_to_string risk)
 
 let test_risk_metadata_pg_query_override () =
   (* masc_pg_query removed — no handler, no catalog metadata.

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -855,11 +855,9 @@ let test_denied_tools_excluded_from_injection () =
     denied
 
 let test_is_keeper_denied () =
-  (* Post-pruning: keeper_denied surface is [masc_reset; masc_spawn]. *)
+  (* RFC-0182: keeper_denied surface is [masc_reset] after masc_spawn removal. *)
   Alcotest.(check bool) "masc_reset is denied" true
     (KET.is_keeper_denied "masc_reset");
-  Alcotest.(check bool) "masc_spawn is denied" true
-    (KET.is_keeper_denied "masc_spawn");
   Alcotest.(check bool) "masc_status is not denied" false
     (KET.is_keeper_denied "masc_status");
   Alcotest.(check bool) "keeper_time_now is not denied" false

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -1393,7 +1393,7 @@ let () =
             let dl = Keeper_hooks_oas.keeper_denied_tools in
             List.iter
               (fun name -> check bool (name ^ " denied") true (List.mem name dl))
-              [ "masc_reset"; "masc_spawn" ])
+              [ "masc_reset" ])
         ; test_case "safe tools not denied" `Quick (fun () ->
             let dl = Keeper_hooks_oas.keeper_denied_tools in
             List.iter

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -815,8 +815,7 @@ let guard_fragments_for_name name =
         "masc_relay_";
         "masc_repo_synthesis_";
         "masc_runtime_";
-        "masc_spawn";
-
+        (* masc_spawn removed in RFC-0182 *)
         "masc_voice_";
       ]
   then

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -32,7 +32,7 @@ let all_masc : Tool_name.Masc.t list =
   ; Status; Task_history; Tasks; Tool_grant; Tool_help
   ; Tool_list; Tool_revoke; Transition; Update_priority; Web_search; Who
   ; Approval_pending; Approval_get; Config; Gc; Get_metrics; Mcp_session
-  ; Pause; Resume; Spawn; Start; Tool_admin_snapshot; Tool_admin_update
+  ; Pause; Resume; Start; Tool_admin_snapshot; Tool_admin_update
   ; Tool_stats ]
 
 let all_masc_keeper : Tool_name.Masc_keeper.t list =

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -292,20 +292,6 @@ let () =
             let missing = Tool_spec.verify_handler_coverage () in
             check bool "Tag_dispatch not in missing" false
               (List.mem "__test_spec_tag_dispatch" missing));
-          test_case "Match_chain binding not in verify missing" `Quick (fun () ->
-            let spec =
-              Tool_spec.create
-                ~name:"__test_spec_match_chain"
-                ~description:"match chain test"
-                ~module_tag:Tool_dispatch.Mod_misc
-                ~input_schema:empty_schema
-                ~handler_binding:Match_chain
-                ()
-            in
-            Tool_spec.register spec;
-            let missing = Tool_spec.verify_handler_coverage () in
-            check bool "Match_chain not in missing" false
-              (List.mem "__test_spec_match_chain" missing));
           test_case "Direct binding registers handler" `Quick (fun () ->
             let name = "__test_spec_direct_handler" in
             let spec =

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -465,16 +465,7 @@ let test_masc_deliver_schema () =
 
 (* masc_poll_events and masc_heartbeat_result schema tests removed: tools pruned *)
 
-let test_masc_spawn_schema () =
-  match find_tool "masc_spawn" with
-  | None -> Alcotest.fail "masc_spawn not found"
-  | Some schema ->
-      match get_json_assoc "properties" schema.input_schema with
-      | Some props ->
-          Alcotest.(check bool) "has agent_name" true (List.mem_assoc "agent_name" props);
-          Alcotest.(check bool) "has model" true (List.mem_assoc "model" props);
-          Alcotest.(check bool) "has prompt" true (List.mem_assoc "prompt" props)
-      | None -> Alcotest.fail "masc_spawn missing properties"
+(* test_masc_spawn_schema removed: masc_spawn deleted in RFC-0182. *)
 
 (* Dedicated runtime-verify schema coverage moved to runtime admin coverage. *)
 
@@ -858,9 +849,7 @@ let () =
     ];
     (* auth_tools, a2a_tools (poll_events/heartbeat_result), handover_tools,
        bounded_run removed: pruned from registry *)
-    "spawn_runtime_tools", [
-      Alcotest.test_case "spawn" `Quick test_masc_spawn_schema;
-    ];
+    (* spawn_runtime_tools group removed: masc_spawn deleted in RFC-0182. *)
     "keeper_runtime_tools", [
       Alcotest.test_case "persona-authoring" `Quick
         test_masc_persona_authoring_schemas;


### PR DESCRIPTION
## Summary

RFC-0182 in-progress. **Phase 1 (legacy purge) complete + Phase 2 (descriptor projection) board cluster as proof of pattern**.

| Phase | Commits | Status |
|---|---|---|
| 1. Match_chain dead enum | `a519601e1` | ✅ |
| 1. 8 dead masc_* tool purge | `7e7a6c646` | ✅ |
| 1. 6 Tool_spec.register migrations | `637538d73` | ✅ |
| **2. masc_board_* cluster (19 tools)** | **`56687e033`** | **✅ Proof** |
| 2. 13 remaining clusters + ~25 singletons | — | 🟡 Architectural decision required |

Net diff: **+225 / -104 LoC, 27 files**.

## Phase 2 architectural finding

Board cluster worked end-to-end because `Tool_board.handle_tool` has a context-free signature (`string -> Yojson.Safe.t -> Tool_result.result`). The handler routes by name directly from the descriptor layer.

The remaining 12 cluster dispatchers (`Tool_task.dispatch`, `Tool_plan.dispatch`, `Tool_run.dispatch`, `Tool_operator.dispatch`, `Tool_agent.dispatch`, `Tool_coord.dispatch`, etc.) require a `context` argument that is not available inside `Agent_tool_in_process_runtime`. The keeper-side bridges (`Keeper_exec_task.handle_keeper_task_tool` and siblings) only match `keeper_*` names, not `masc_*` — they cannot be reused.

Three resolution options for the next iteration:

| Option | Description | Tradeoff |
|---|---|---|
| A | Construct context inside each `handle_masc_*` via global state | Couples descriptor layer to runtime state |
| B | Add context-free wrappers in lib/ for each cluster | New stable API surface, ~12 new functions, mirrors `Tool_board.handle_tool` |
| C | Extend keeper bridges to also accept `masc_*` names | Bridges become non-keeper-canonical |

This decision is not pre-baked in RFC-0182 body §3.1 — it assumed "the In_process handler for each cluster routes to the existing typed dispatcher" uniformly, which is true for board but not for context-bound dispatchers. RFC body amendment required.

## Audit findings during this session (6 cumulative)

| # | RFC body claim | Actual | Resolution |
|---|---|---|---|
| 1 | `tool_inline_dispatch.ml` is the `Tool_spec.register` call site | File has 0 register calls; dispatch-only | Add new register block |
| 2 | 10 tools to migrate to `Tool_spec.register` | `masc_tool_revoke` already registered via `Tool_shard_schemas` | 9 → 6 after #3+#4 |
| 3 | `masc_approval_resolve` / `masc_set_param` / `channel_gate` are "metadata-only live tools" | No `Masc_domain.tool_schema` record exists | Excluded — promoting requires schemas (semantic widening) |
| 4 | `Tool_catalog.tools_for_surface(Keeper_denied)` reads catalog rows (blocking 8 dead delete) | False positive — hardcoded list at `tool_catalog_surfaces.ml:335` | 8 dead delete safe and complete |
| 5 | RFC §3.1 cluster counts (~20 board / ~6 operator / ~5 agent / ~3 control / ~2 shard / ~2 local_runtime) | Actual: 19/5/4/0/0/0 — 6+ mismatches | Cluster table needs amendment |
| 6 | RFC §3.1 "each cluster's typed dispatcher routes uniformly" | Tool_board is context-free; the other 12 are context-bound | Architectural decision required (see above) |

## Test plan

- [x] `dune build --root . @lib/check` — clean
- [x] `dune build --root . test/test_tool_name.exe test/test_tools_coverage.exe test/test_keeper_tool_exposure.exe test/test_governance_pipeline.exe test/test_keeper_masc_bridge.exe test/test_mcp_tool_matrix.exe test/test_agent_tool_descriptor_registry_integrity.exe test/test_tool_descriptors_gen.exe` — clean
- [ ] CI (expected pre-existing `test/test_tool_board_coverage.ml:40` error from RFC-0189 PR-1b.7 #18756 unrelated to this branch)
- [ ] CodeRabbit review

## RFC compliance status

| § | Item | Status |
|---|---|---|
| 3.2 | 10 Tool_spec migrations | **6/10** (4 deferred — see #2-3) |
| 3.3 | 8 dead delete | **✅ complete** |
| 3.x | Match_chain removal | **✅ complete** |
| 3.1 | 113 descriptor entries | **19/113** (board only, awaiting cluster routing decision) |
| 3.1 | ~39 runtime_handler variants | **1/~39** (Tool_masc_board_dispatch only) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
