### PR TITLE
feat(tool_misc_web_search): RFC-0189 PR-1b.9 — typed result for handle + simulate_for_test (source-typed, JSON-envelope preserving)

### DIFF
--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -120,12 +120,14 @@ let handle_tool_help ~tool_name ~start_time _ctx args =
     | Some entry ->
         Tool_result.ok ~tool_name ~start_time:start_time (Yojson.Safe.to_string (Tool_help_registry.entry_json entry))
 
+(* RFC-0189 PR-1b.8 / PR-1b.9 — both web_* handlers are typed at the
+   source; project back to legacy [Tool_result.t] at this dispatch
+   boundary until [Tool_misc.dispatch] itself promotes to [result]
+   (PR-1c). *)
 let handle_web_search ~tool_name ~start_time _ctx args =
   Tool_misc_web_search.handle ~tool_name ~start_time args
+  |> Tool_result.to_legacy
 
-(* RFC-0189 PR-1b.8 — web_fetch handler is typed at the source;
-   project back to legacy [Tool_result.t] at this dispatch boundary
-   until [Tool_misc.dispatch] itself promotes to [result] (PR-1c). *)
 let handle_web_fetch ~tool_name ~start_time _ctx args =
   Tool_misc_web_fetch.handle ~tool_name ~start_time args
   |> Tool_result.to_legacy
@@ -212,4 +214,10 @@ let parse_exa_json = Tool_misc_web_search.parse_exa_json
 let parse_bing_search_json = Tool_misc_web_search.parse_bing_search_json
 let redact_transport_error_detail = Tool_misc_web_search.redact_transport_error_detail
 let web_search_provider_plan = Tool_misc_web_search.provider_plan
-let web_search_simulate_for_test = Tool_misc_web_search.simulate_for_test
+(* RFC-0189 PR-1b.9 — simulate_for_test is typed at source; keep the
+   re-export at legacy [Tool_result.t] for test consumers that
+   destructure [result.success] directly. PR-2 sweeps tests to the
+   typed form. *)
+let web_search_simulate_for_test ~query ~limit outcomes =
+  Tool_misc_web_search.simulate_for_test ~query ~limit outcomes
+  |> Tool_result.to_legacy

--- a/lib/tool_misc_web_search.ml
+++ b/lib/tool_misc_web_search.ml
@@ -776,19 +776,76 @@ let search_impl ~query ~limit =
   in
   loop [] (provider_order ())
 
-let handle ~tool_name ~start_time args =
+(* RFC-0189 PR-1b.9 — typed result. Failure-class mapping at the
+   handle boundary (source-typed at each construction site; no
+   substring matching):
+
+   - [Workflow_rejection]: [validate_query] rejection — caller
+     violated query rules (empty, > 500 chars, secret-like
+     pattern). Caller controls the input.
+   - [Transient_error]:    rate-limit hit ("retry shortly"
+     semantics). Retry after window unlocks.
+   - [Runtime_failure]:    [search_impl] aggregate ("all web
+     search providers failed: ..."). The 7-provider fallback
+     chain exhausted; per-provider transport vs server
+     distinction is collapsed in the aggregate string today.
+     Lifting fetch_provider / per-fetcher errors to typed
+     variants is the natural PR-2 follow-up — the aggregate
+     boundary remains [Runtime_failure] for now because
+     blind-retry is not guaranteed safe (some providers may
+     have returned 4xx).
+
+   [simulate_for_test] uses the same boundary: empty outcomes
+   list or aggregate failure → [Runtime_failure]. *)
+
+(* When [body] is a JSON envelope string (from
+   [Tool_args.ok_response] / [result_json]) we parse-and-store the
+   structured payload so [to_legacy] regenerates the same
+   [result.message] envelope clients (and tests) expect.  Plain
+   strings fall back to [`String body], matching the legacy
+   [Tool_result.ok] auto-detection. *)
+let text_ok ~tool_name ~start_time body : Tool_result.result =
+  let data =
+    match Tool_result.structured_payload_of_message body with
+    | Some json -> json
+    | None -> `String body
+  in
+  Tool_result.make_ok ~tool_name ~start_time ~data ()
+
+let workflow_err ~tool_name ~start_time msg : Tool_result.result =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Workflow_rejection
+    ~start_time
+    msg
+
+let transient_err ~tool_name ~start_time msg : Tool_result.result =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Transient_error
+    ~start_time
+    msg
+
+let runtime_err ~tool_name ~start_time msg : Tool_result.result =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Runtime_failure
+    ~start_time
+    msg
+
+let handle ~tool_name ~start_time args : Tool_result.result =
   let query = get_string args "query" "" in
   match validate_query query with
-  | Error message -> Tool_result.error ~tool_name ~start_time message
+  | Error message -> workflow_err ~tool_name ~start_time message
   | Ok query ->
       let limit = max 1 (min 10 (get_int args "limit" 5)) in
       let now = Unix.gettimeofday () in
       let key = cache_key ~query ~limit in
       match cache_lookup key now with
-      | Some cached -> Tool_result.ok ~tool_name ~start_time cached
+      | Some cached -> text_ok ~tool_name ~start_time cached
       | None -> (
           match enforce_rate_limit now with
-          | Error message -> Tool_result.error ~tool_name ~start_time message
+          | Error message -> transient_err ~tool_name ~start_time message
           | Ok () -> (
               match search_impl ~query ~limit with
               | Ok response ->
@@ -797,22 +854,22 @@ let handle ~tool_name ~start_time args =
                       ~engine:response.engine response.hits
                   in
                   cache_store key json now;
-                  Tool_result.ok ~tool_name ~start_time json
-              | Error message -> Tool_result.error ~tool_name ~start_time message))
+                  text_ok ~tool_name ~start_time json
+              | Error message -> runtime_err ~tool_name ~start_time message))
 
-let simulate_for_test ~query ~limit outcomes =
+let simulate_for_test ~query ~limit outcomes : Tool_result.result =
   let normalize source tuples =
     tuples |> take_results limit |> normalize_hits ~source
   in
   let rec loop errors = function
     | [] ->
-        Tool_result.error ~tool_name:"masc_web_search" ~start_time:0.0
+        runtime_err ~tool_name:"masc_web_search" ~start_time:0.0
           (if Stdlib.List.length errors = 0 then "all web search providers failed"
            else String.concat "; " (List.rev errors))
     | (provider_name, outcome) :: rest -> (
         match outcome with
         | `Hits hits when Stdlib.List.length hits > 0 ->
-            Tool_result.ok ~tool_name:"masc_web_search" ~start_time:0.0
+            text_ok ~tool_name:"masc_web_search" ~start_time:0.0
               (result_json ~query
                  ~search_url:("test://" ^ provider_name)
                  ~engine:provider_name

--- a/lib/tool_misc_web_search.mli
+++ b/lib/tool_misc_web_search.mli
@@ -139,23 +139,30 @@ val clean_search_text : string -> string
 
 (** {1 Tool dispatch + simulation} *)
 
-val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_result.t
+val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_result.result
 (** [handle ~tool_name ~start_time args] handles [masc_web_search] tool dispatch.
     Required: [query] (string).  Optional: [limit] (int,
     clamped to [\[1, 10\]], default 5).
 
-    Returns [Tool_result.ok] with search hits on success,
-    [Tool_result.error] when validation fails, the query is
-    rate-limited, or all providers fail.  Cache hit returns
-    early before rate-limit check.  The cache + rate-limit
-    state is module-level (process-wide) — operator-visible
-    counters live in [Env_config.Tools.web_search_*]. *)
+    On success the payload [data] is wrapped as
+    [`Assoc [ "text", `String json ]] where [json] is the
+    serialized search result envelope.
+
+    Failure classes (RFC-0189):
+    - [Workflow_rejection]: [validate_query] rejection (empty /
+      length / secret-like — caller-input violation).
+    - [Transient_error]:    rate-limit hit (retry after window).
+    - [Runtime_failure]:    aggregate "all web search providers
+      failed: ..." — provider fallback chain exhausted.
+      Per-provider transport/server distinction is collapsed in
+      the aggregate today; a future PR may lift fetch_provider
+      to typed variants. *)
 
 val simulate_for_test :
   query:string ->
   limit:int ->
   (string * simulated_provider_outcome) list ->
-  Tool_result.t
+  Tool_result.result
 (** [simulate_for_test ~query ~limit outcomes] is a pure
     deterministic projection of {!handle}'s fallback chain for
     unit tests.  [outcomes] maps provider names to


### PR DESCRIPTION
## Summary

RFC-0189 PR-1b.9 — `tool_misc_web_search` migration (`handle` + `simulate_for_test`, 7 calls). Sister cluster to PR-1b.8 web_fetch.

**Same `Transient_error` pattern** as PR-1b.8: rate-limit + transient signal. **Same source-typed discipline** — no substring classifier downstream. Each error tag assigned at construction site.

## Failure-class mapping

| Site | Class | Why |
|---|---|---|
| `validate_query` rejection ("query is required" / length / secret-like) | `Workflow_rejection` | Caller-input violation |
| `enforce_rate_limit` ("web fetch rate limit exceeded; retry shortly") | `Transient_error` | Retry after window |
| `search_impl` aggregate ("all web search providers failed: …") | `Runtime_failure` | 7-provider chain exhausted — collapsed aggregate (per-provider lift = PR-2) |
| `simulate_for_test` aggregate | `Runtime_failure` | Same boundary semantics |

## `text_ok` JSON-envelope special case

`tool_library` / `tool_misc_web_fetch` patterns previously wrapped success bodies as `{"text": body}`. For tools whose body is already a `Tool_args.ok_response`-serialized JSON envelope (web_search's `result_json`), this corrupts `result.message` for existing `parse_json result.message` test assertions.

This PR parses the body with `Tool_result.structured_payload_of_message` and stores the parsed `Yojson.Safe.t` directly, so the `to_legacy` boundary regenerates the envelope clients depend on. Plain text bodies fall through to `` `String body``, matching the legacy `Tool_result.ok` auto-detection.

**Out-of-scope but worth noting** — same `{"text": body}` wrapping bug exists in tool_library (#18756) and tool_misc_web_fetch (#18759). Those tools don't yet have `parse_json result.message` tests so the bug is latent, but a sweep PR is worthwhile.

## Caller cascade

```ocaml
let handle_web_search ~tool_name ~start_time _ctx args =
  Tool_misc_web_search.handle ~tool_name ~start_time args
  |> Tool_result.to_legacy

let web_search_simulate_for_test ~query ~limit outcomes =
  Tool_misc_web_search.simulate_for_test ~query ~limit outcomes
  |> Tool_result.to_legacy
```

`tool_misc.ml :handle_web_search` (1 line) + `web_search_simulate_for_test` re-export (1 line). PR-1c sweeps tests to the typed form.

## Verification

- `dune build --root . --cache=disabled lib/` exit 0
- `test_tool_result.exe`: **20/20 PASS**
- `test_tool_misc_coverage.exe`: **36/40 PASS**
  - 4 pre-existing failures (#8 requires_query, #9 rejects_long_query, #10 rejects_secret_like, #24 simulate_reports_all_failures) all reproduce on `origin/main fbdba3e9f` — they expect `result.message` to be a JSON envelope when the underlying error is a raw string. Legacy `Tool_result.error` does not envelope raw strings either. Separate latent bug, separate fix.
- `dune build --root . @check`: 1 unrelated failure `test/test_tool_name.ml:13 ; Shell;` — post-#18763 cascade gap (Tool_name.Keeper.Shell renamed to Search_files but test not updated). Out of RFC-0189 scope; **separate fix recommended**.

## Operational hazard noted

`dune` shared-cache staleness after lib `.mli` signature changes — incremental rebuild produced spurious "inconsistent assumptions" errors on `Tool_misc_web_search`. Worked around with `--cache=disabled`. Recording in [feedback_dune_shared_cache_stale_on_mli_change] memory.

## RFC-0189 progress

| PR | Status |
|---|---|
| PR-1a, 1b.1..8 | ✅ all merged (#18718 #18736 #18740 #18743 #18749 #18744 #18751 #18756 #18759) |
| PR-1b.8' coord_goals | ✅ #18760 (parallel author) |
| **PR-1b.9** | 🟦 this |
| PR-1b.10+ | tool_misc / admin / coord / operator / agent |
| task RFC | separate (10+ caller fan-out) |
| PR-1c | accessor migration |
| PR-2 | legacy `t` + classifier removal + `{"text": body}` sweep |

## Test plan

- [x] `dune build --root . --cache=disabled lib/`
- [x] `test_tool_result.exe` 20/20
- [x] `test_tool_misc_coverage.exe` 36/40 (4 pre-existing fails)
- [ ] CI green (Draft — awaiting CI)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
