### PR TITLE
fix(rfc-0189): preserve Tool_result.t message round-trip in text_ok helpers (PR-1b.7 + PR-1b.8 follow-up)

### DIFF
--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -207,12 +207,30 @@ let query_required ~tool_name ~start_time =
 let missing_required ~tool_name ~start_time field =
   workflow_err ~tool_name ~start_time (sprintf "%s is required" field)
 
+(* RFC-0189 follow-up — preserve the legacy [Tool_result.ok] message
+   round-trip contract.
+
+   The original PR-1b.7 [text_ok] wrapped [body] as
+   [`Assoc [ "text", `String body ]].  That works only when callers
+   read [result.data]; clients (and tests) that read
+   [result.message] receive [Yojson.Safe.to_string] of the wrapped
+   object — i.e. [{"text":"...escaped body..."}] — instead of the
+   raw Markdown / JSON envelope they expect.
+
+   Legacy [Tool_result.ok body] called
+   [structured_payload_of_message]: when [body] parses as JSON it
+   becomes [data], otherwise [data = `String body].  In both cases
+   [to_legacy] regenerates [result.message] as the original [body]
+   string (round-trip safe).  Replicating that behaviour here keeps
+   every accessor — [data] *and* [message] — compatible with the
+   pre-RFC-0189 contract. *)
 let text_ok ~tool_name ~start_time body : Tool_result.result =
-  Tool_result.make_ok
-    ~tool_name
-    ~start_time
-    ~data:(`Assoc [ "text", `String body ])
-    ()
+  let data =
+    match Tool_result.structured_payload_of_message body with
+    | Some json -> json
+    | None -> `String body
+  in
+  Tool_result.make_ok ~tool_name ~start_time ~data ()
 
 let handle_list ~tool_name ~start_time _ctx args : Tool_result.result =
   let include_candidates =

--- a/lib/tool_misc_web_fetch.ml
+++ b/lib/tool_misc_web_fetch.ml
@@ -222,13 +222,27 @@ let handle ~tool_name ~start_time args : Tool_result.result =
       ~start_time
       "url must be a valid http or https URL"
   else
+    (* RFC-0189 follow-up — store the parsed JSON envelope in
+       [~data] instead of wrapping as [`Assoc [ "text", `String body ]].
+       The wrapped form corrupted [result.message] for callers (and
+       tests) that round-tripped through [parse_json result.message],
+       since [to_legacy] serialised the wrapper rather than the
+       envelope.  Both the cache and fresh paths produce
+       [Tool_args.ok_response] strings, so both go through
+       [structured_payload_of_message]; plain-text fallback retained
+       only for defence in depth. *)
+    let ok_from_envelope body =
+      let data =
+        match Tool_result.structured_payload_of_message body with
+        | Some json -> json
+        | None -> `String body
+      in
+      Tool_result.make_ok ~tool_name ~start_time ~data ()
+    in
     let now = Unix.gettimeofday () in
     let key = url ^ "|" ^ Int.to_string timeout in
     match cache_lookup key now with
-    | Some cached ->
-        Tool_result.make_ok ~tool_name ~start_time
-          ~data:(`Assoc [ "text", `String cached ])
-          ()
+    | Some cached -> ok_from_envelope cached
     | None -> (
         match enforce_rate_limit now with
         | Error message ->
@@ -257,9 +271,7 @@ let handle ~tool_name ~start_time args : Tool_result.result =
                 in
                 let json = Tool_args.ok_response fields in
                 cache_store key json now;
-                Tool_result.make_ok ~tool_name ~start_time
-                  ~data:(`Assoc [ "text", `String json ])
-                  ()
+                ok_from_envelope json
             | Error failure ->
                 Tool_result.make_err
                   ~tool_name


### PR DESCRIPTION
## Summary

Bug-fix PR — restores `Tool_result.t message` round-trip contract for two helpers introduced earlier in the RFC-0189 cluster work.

The `text_ok` pattern from PR-1b.7 (#18756 tool_library) and PR-1b.8 (#18759 tool_misc_web_fetch):

```ocaml
let text_ok ~tool_name ~start_time body =
  Tool_result.make_ok ~tool_name ~start_time
    ~data:(`Assoc [ "text", `String body ]) ()
```

…wraps the success body before `to_legacy` serialises it back to `message`. Callers that round-trip through `parse_json result.message` (existing pattern, see test_tool_misc_coverage and `web_search_simulate_for_test_falls_back_after_error`) get `{"text":"...escaped body..."}` instead of the original envelope / Markdown.

Legacy `Tool_result.ok body` called `structured_payload_of_message` so that JSON-string bodies became the parsed envelope and plain text fell through as `` `String body``. Either way `to_legacy.message` regenerated the original `body`. PR-1b.9 (#18766) discovered this when its simulate test broke; it fixed its own `text_ok` but the same bug stayed latent here.

## Fix (2 files, surgical)

### `lib/tool_library.ml`

```ocaml
let text_ok ~tool_name ~start_time body =
  let data =
    match Tool_result.structured_payload_of_message body with
    | Some json -> json
    | None -> `String body
  in
  Tool_result.make_ok ~tool_name ~start_time ~data ()
```

tool_library handlers produce Markdown → fail JSON parse → `` `String body``. `to_legacy.message` is the raw Markdown — operator-facing renderers work again.

### `lib/tool_misc_web_fetch.ml`

Cache hit + fresh fetch paths now share a local `ok_from_envelope` closure with the same pattern. Bodies are `Tool_args.ok_response`-serialised JSON → parses → stored as `` `Assoc envelope`` → `to_legacy.message` is the original envelope string clients expect.

## No behaviour change to

- `Tool_result` core construction or `to_legacy`
- failure-class assignments
- handler signatures or `.mli` contracts
- cache schema or rate-limit semantics

## Verification

- `dune build --root . --cache=disabled lib/` exit 0
- `test_tool_result.exe`: **20/20 PASS**
- `test_keeper_tools_oas.exe`: **54/54 PASS** (includes `library_tools` suite end-to-end exercising `Tool_library.handle_search` / `handle_read`)

## Out of scope

- Dedicated `text_ok` round-trip regression test — PR-1b.9's `web_search_simulate_for_test_falls_back_after_error` is the natural canary; a unit test for `text_ok` belongs in a separate test-hardening PR.
- 4 pre-existing `test_tool_misc_coverage` failures (#8/9/10/24) expecting JSON envelopes for raw-string errors — unrelated, legacy bug in test expectations.
- `test/test_tool_name.ml:13` `Shell` post-#18763 cascade gap — unrelated to RFC-0189.

## Memory

[`feedback_text_ok_json_envelope_preservation`](memory/feedback_text_ok_json_envelope_preservation.md) — the catch + pattern + sweep responsibility recorded.

## Test plan

- [x] `dune build --root . --cache=disabled lib/`
- [x] `test_tool_result.exe` 20/20
- [x] `test_keeper_tools_oas.exe` 54/54
- [ ] CI green (Draft — awaiting CI)

Refs RFC-0189, follow-up to #18756 / #18759 / #18766.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
