### PR TITLE
fix(test): update test_tool_name Keeper coverage list — Shell renamed to Search_files (#18763 cascade)

### DIFF
--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -10,7 +10,7 @@ let all_keeper : Tool_name.Keeper.t list =
   ; Board_get; Board_list; Board_post; Board_search; Board_stats; Board_vote
   ; Broadcast; Context_status; Discovery; Fs_edit; Fs_read
   ; Handoff; Library_read; Library_search; Memory_search
-  ; Shell; Stay_silent
+  ; Search_files; Stay_silent
   ; Task_claim; Task_create; Task_done; Task_submit_for_verification
   ; Task_force_done; Task_force_release
   ; Tasks_audit; Tasks_list; Time_now; Tool_search; Tools_list


### PR DESCRIPTION
## Summary

Single-line cascade fix.

PR #18763 renamed the `Tool_name.Keeper.Shell` variant to `Search_files` but missed the coverage-list mirror in `test/test_tool_name.ml:13`. `dune build @check` fails on `origin/main` right now:

```
File "test/test_tool_name.ml", line 13, characters 5-10:
13 |   ; Shell; Stay_silent
         ^^^^^
Error: This variant expression is expected to have type Tool_name.Keeper.t
       There is no constructor Shell within type Tool_name.Keeper.t
```

`all_keeper` is the canonical "every-variant-touched" witness used by Tool_name invariant tests. Substituting the new name in the same position keeps coverage 1:1 with the variant decl.

## Diff

```diff
-  ; Shell; Stay_silent
+  ; Search_files; Stay_silent
```

## Verification

- `dune build --root . --cache=disabled test/test_tool_name.exe` exit 0 (was failing on `origin/main`)
- `test_tool_name.exe`: 14/15 PASS
  - 1 pre-existing failure (`tool_execute starts with keeper_`) reproduces on `origin/main fbdba3e9f`, unrelated, separate bug in the prefix-invariant assertion.

## Test plan

- [x] `dune build --root . --cache=disabled test/test_tool_name.exe`
- [x] `_build/default/test/test_tool_name.exe` 14/15 (1 pre-existing fail)
- [ ] CI green (Draft — awaiting CI)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
