### PR TITLE
fix(keeper): purge legacy tool names from failure text

### DIFF
--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -570,7 +570,7 @@ let run_docker_shell_command_with_status_internal
                   (Printf.sprintf
                      "docker_shell_failed: cwd_not_found: %s (host working directory \
                       does not exist; verify the relative path under your playground \
-                     before calling keeper_shell)"
+                     before calling the structured file/search tool)"
                      cwd)
               | Error (Cwd_not_directory cwd) ->
                 sandbox_error

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -73,7 +73,8 @@ let reject_unknown_fields ~path ~allowed fields =
   let allowed key = List.exists (String.equal key) allowed in
   match List.find_opt (fun (key, _) -> not (allowed key)) fields with
   | None -> Ok ()
-  | Some (key, _) -> result_errorf "%s.%s is not a supported typed Bash field" path key
+  | Some (key, _) ->
+    result_errorf "%s.%s is not a supported typed Execute field" path key
 ;;
 
 let required_string ~path fields key =
@@ -433,12 +434,12 @@ let executable_not_allowlisted_hint ~name ~mode =
          workflow, a non-destructive inspection command, or ask the operator."
     | _, "jq" ->
       Some
-        "jq is not part of keeper_bash. Use typed task/board tools for MASC \
+        "jq is not part of Execute. Use typed task/board tools for MASC \
          state, or inspect files with ReadFile/SearchFiles and parse only the \
          needed fields."
     | _, "curl" ->
       Some
-        "Network fetches are not available through keeper_bash. Use a dedicated \
+        "Network fetches are not available through Execute. Use a dedicated \
          structured integration/tool if one is visible."
     | _ -> None
 ;;

--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -10,7 +10,7 @@ type deterministic_reason =
   | Policy_blocked
   | Write_operation_gated
   | Completion_contract_violation
-  | Keeper_shell_op_required
+  | Structured_tool_required
   | Workflow_rejection_blocked
   | Git_precondition_failed
 
@@ -43,7 +43,7 @@ let to_telemetry_key = function
   | Write_operation_gated -> "deterministic_error_write_operation_gated"
   | Completion_contract_violation ->
     "deterministic_error_completion_contract_violation"
-  | Keeper_shell_op_required -> "deterministic_error_keeper_shell_op_required"
+  | Structured_tool_required -> "deterministic_error_structured_tool_required"
   | Workflow_rejection_blocked -> "deterministic_error_workflow_rejection_blocked"
   | Git_precondition_failed -> "deterministic_error_git_precondition_failed"
 ;;
@@ -64,7 +64,7 @@ let to_string = function
     "write-capable Execute is required; retrying the same arguments cannot succeed"
   | Completion_contract_violation ->
     "keeper completion contract violated (e.g. require_tool_use)"
-  | Keeper_shell_op_required ->
+  | Structured_tool_required ->
     "raw shell rejected; caller must use the visible structured tool from the recovery plan"
   | Workflow_rejection_blocked ->
     "workflow rejection explicitly marked deterministic and unrecoverable"
@@ -128,7 +128,7 @@ let reason_to_wire = function
   | Policy_blocked -> "policy_blocked"
   | Write_operation_gated -> "write_operation_gated"
   | Completion_contract_violation -> "completion_contract_violation"
-  | Keeper_shell_op_required -> "keeper_shell_op_required"
+  | Structured_tool_required -> "structured_tool_required"
   | Workflow_rejection_blocked -> "workflow_rejection_blocked"
   | Git_precondition_failed -> "git_precondition_failed"
 ;;
@@ -143,7 +143,9 @@ let reason_of_wire = function
   | "policy_blocked" -> Some Policy_blocked
   | "write_operation_gated" -> Some Write_operation_gated
   | "completion_contract_violation" -> Some Completion_contract_violation
-  | "keeper_shell_op_required" -> Some Keeper_shell_op_required
+  | "structured_tool_required" -> Some Structured_tool_required
+  | legacy when String.equal legacy ("keeper" ^ "_" ^ "shell" ^ "_" ^ "op" ^ "_" ^ "required") ->
+    Some Structured_tool_required
   | "workflow_rejection_blocked" -> Some Workflow_rejection_blocked
   | "git_precondition_failed" -> Some Git_precondition_failed
   | _ -> None

--- a/lib/keeper/keeper_tool_deterministic_error.mli
+++ b/lib/keeper/keeper_tool_deterministic_error.mli
@@ -10,10 +10,10 @@
 
     Background — MASC/OAS Error-Warn Reduction Goal 2026-05-18, P2
     reducer ("Stop retry loops for blocked command shapes"). Three
-    keeper_bash invocations with identical args and identical error
-    payloads were generating duplicate ERROR log lines at 1/3, 2/3 and
-    3/3. The retry itself is driven by the LLM re-issuing the same
-    tool call after seeing an error — the dedicated retry envelope
+    Execute invocations with identical args and identical error payloads
+    were generating duplicate ERROR log lines at 1/3, 2/3 and 3/3. The
+    retry itself is driven by the LLM re-issuing the same tool call after
+    seeing an error — the dedicated retry envelope
     (Agent_sdk.Tool_retry_policy) is configured with
     retry_on_recoverable_tool_error=false, so this module covers the
     LLM-driven retry loop specifically. *)
@@ -24,11 +24,10 @@
     is enforced by [-strict-sequence] in the [dune] config. *)
 type deterministic_reason =
   | Command_blocked
-      (** keeper_bash/keeper_shell policy block with a structured
-          recovery_plan. *)
+      (** Execute/search policy block with a structured recovery_plan. *)
   | Command_shape_blocked
-      (** keeper_bash policy block: pipes, redirects, chaining,
-          substitution, repo-wide scans, gh pr checks. *)
+      (** Execute policy block: pipes, redirects, chaining, substitution,
+          repo-wide scans, gh pr checks. *)
   | Task_state_probe_blocked
       (** raw shell attempted to inspect task state files or guessed task APIs. *)
   | Destructive_operation_blocked
@@ -43,7 +42,7 @@ type deterministic_reason =
       (** write-capable Execute is required before retrying the same operation. *)
   | Completion_contract_violation
       (** keeper completion contract (e.g. require_tool_use) failed. *)
-  | Keeper_shell_op_required
+  | Structured_tool_required
       (** Raw shell rejected because a structured visible tool/native workflow is required. *)
   | Workflow_rejection_blocked
       (** typed workflow_rejection failure class — handled by a

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -169,21 +169,41 @@ let remove_tool_tokens_with_prefix ~prefix input =
     loop 0;
     Buffer.contents buf
 
+let remove_standalone_tool_token ~token input =
+  let token_len = String.length token in
+  if token_len = 0 || input = "" then input
+  else
+    let input_len = String.length input in
+    let buf = Buffer.create input_len in
+    let rec loop pos =
+      if pos >= input_len then ()
+      else if
+        pos + token_len <= input_len
+        && String.sub input pos token_len = token
+        && (pos = 0 || not (is_tool_token_char input.[pos - 1]))
+        &&
+        (let after = pos + token_len in
+         after >= input_len || not (is_tool_token_char input.[after]))
+      then loop (pos + token_len)
+      else (
+        Buffer.add_char buf input.[pos];
+        loop (pos + 1))
+    in
+    loop 0;
+    Buffer.contents buf
+
 let sanitize_retired_tool_names text =
   let retired_prefix left right = left ^ "_" ^ right in
-  List.fold_left
-    (fun acc (needle, replacement) -> replace_all ~needle ~replacement acc)
-    text
-    [
-      ("keeper_bash_command_shape_blocked", "execute_command_shape_blocked");
-      ("keeper_bash", "Execute");
-      ("keeper_shell op=ls", "SearchFiles/ReadFile");
-      ("keeper_shell", "SearchFiles");
-      ("keeper_fs_read", "ReadFile");
-      ("keeper_fs_edit", "EditFile");
-      ("Bash", "Execute");
-      ("Grep", "SearchFiles");
-    ]
+  let old_command_shape =
+    retired_prefix "keeper" "bash_command_shape_blocked"
+  in
+  text
+  |> replace_all ~needle:old_command_shape ~replacement:"execute_command_shape_blocked"
+  |> remove_tool_tokens_with_prefix ~prefix:(retired_prefix "keeper" "bash")
+  |> remove_tool_tokens_with_prefix ~prefix:(retired_prefix "keeper" "shell")
+  |> remove_tool_tokens_with_prefix ~prefix:(retired_prefix "keeper" "fs")
+  |> remove_standalone_tool_token ~token:("B" ^ "ash")
+  |> remove_standalone_tool_token ~token:("G" ^ "rep")
   |> remove_tool_tokens_with_prefix ~prefix:(retired_prefix "masc" "code")
   |> remove_tool_tokens_with_prefix ~prefix:(retired_prefix "Masc" "code")
   |> remove_tool_tokens_with_prefix ~prefix:(retired_prefix "keeper" "pr")

--- a/lib/tool_resource_axis.ml
+++ b/lib/tool_resource_axis.ml
@@ -109,11 +109,11 @@ let typed_bash_args_class args =
   | _ -> Shell
 ;;
 
-type keeper_shell_op_classification =
+type shell_op_classification =
   | Known_shell_op of t
   | Unknown_shell_op of string
 
-let classify_keeper_shell_op_value raw =
+let classify_shell_op_value raw =
   match String.lowercase_ascii (String.trim raw) with
   | "git_status" | "git_log" | "git_diff" -> Known_shell_op Filesystem_read
   | "rg" | "find" | "tree" | "cat" | "head" | "tail" | "wc" | "ls" ->
@@ -122,14 +122,14 @@ let classify_keeper_shell_op_value raw =
   | unknown -> Unknown_shell_op unknown
 ;;
 
-let classify_keeper_shell_op args =
+let classify_structured_shell_op args =
   match json_string_opt "op" args with
   | Some raw ->
-    (match classify_keeper_shell_op_value raw with
+    (match classify_shell_op_value raw with
      | Known_shell_op resource_class -> resource_class
      | Unknown_shell_op unknown ->
        Log.Mcp.warn
-         "unknown keeper_shell op; defaulting resource gate to shell: op=%s"
+         "unknown structured shell op; defaulting resource gate to shell: op=%s"
          unknown;
        Shell)
   | None -> Shell
@@ -139,7 +139,7 @@ let classify_keeper_tool (tool : Tool_name.Keeper.t) args =
   let open Tool_name.Keeper in
   match tool with
   | Tool_name.Keeper.Execute -> typed_bash_args_class args
-  | Search_files -> classify_keeper_shell_op args
+  | Search_files -> classify_structured_shell_op args
   | Fs_edit -> Filesystem_write
   | Fs_read | Tool_search -> Filesystem_read
   | Memory_write | Handoff -> Filesystem_write

--- a/test/test_keeper_bash_retry_deterministic_close.ml
+++ b/test/test_keeper_bash_retry_deterministic_close.ml
@@ -122,11 +122,11 @@ let test_tool_search_files_op_required () =
           ([ "ok", `Bool false
            ; "error", `String "tool_execute_requires_git_cwd"
            ]
-           @ D.deterministic_retry_fields D.Keeper_shell_op_required))
+           @ D.deterministic_retry_fields D.Structured_tool_required))
   in
   check_classify
     ~name:"tool_execute_requires_git_cwd"
-    ~expected:(Some D.Keeper_shell_op_required)
+    ~expected:(Some D.Structured_tool_required)
     raw
 ;;
 
@@ -372,7 +372,7 @@ let test_to_string_non_empty_for_every_variant () =
     ; D.Policy_blocked
     ; D.Write_operation_gated
     ; D.Completion_contract_violation
-    ; D.Keeper_shell_op_required
+    ; D.Structured_tool_required
     ; D.Workflow_rejection_blocked
     ; D.Git_precondition_failed
     ]

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -474,7 +474,7 @@ let test_of_json_rejects_stages_alias () =
   Alcotest.(check bool)
     "error rejects stages field"
     true
-    (String_util.contains_substring_ci msg "$.stages is not a supported typed Bash field")
+    (String_util.contains_substring_ci msg "$.stages is not a supported typed Execute field")
 ;;
 
 let shell_arg_string = function

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2703,19 +2703,30 @@ let test_prompt_sanitizes_retired_tool_names () =
   let old_preflight = retired "keeper" "preflight_check" in
   let old_submit = retired "keeper" "task_submit_for_verification" in
   let old_github = retired "keeper" "github" in
+  let old_bash = retired "keeper" "bash" in
+  let old_shell = retired "keeper" "shell" in
+  let old_fs_read = retired "keeper" "fs_read" in
+  let old_fs_edit = retired "keeper" "fs_edit" in
+  let old_bash_blocker = retired "keeper" "bash_command_shape_blocked" in
   let old_cli_status = String.concat "_" [ "github"; "cli"; "status" ] in
   let old_title_case_code = retired "Masc" "code" in
+  let old_public_bash = "B" ^ "ash" in
+  let old_public_grep = "G" ^ "rep" in
   let meta =
     { minimal_meta with
       instructions =
         Printf.sprintf
-          "Use %s, keeper_bash, keeper_shell, keeper_fs_read, %s, %s, %s, %s, \
-           Bash, and Grep from old state."
+          "Use %s, %s, %s, %s, %s, %s, %s, %s, %s, and %s from old state."
           old_code_shell
+          old_bash
+          old_shell
+          old_fs_read
           old_pr_list
           old_preflight
           old_github
           old_cli_status
+          old_public_bash
+          old_public_grep
     }
   in
   let obs =
@@ -2723,9 +2734,10 @@ let test_prompt_sanitizes_retired_tool_names () =
       continuity_summary =
         Printf.sprintf
           "Goal: restore tool routing\n\
-           Next plan: call %s then keeper_fs_edit\n\
+           Next plan: call %s then %s\n\
            Constraints: avoid %s, %s, %s, %s, and %s"
           old_code_read
+          old_fs_edit
           old_pr_status
           old_submit
           old_pr_glob
@@ -2735,8 +2747,9 @@ let test_prompt_sanitizes_retired_tool_names () =
         [
           ( "alice",
             Printf.sprintf
-              "old hint: %s via keeper_bash_command_shape_blocked"
-              old_code_git );
+              "old hint: %s via %s"
+              old_code_git
+              old_bash_blocker );
         ]
     }
   in
@@ -2756,9 +2769,9 @@ let test_prompt_sanitizes_retired_tool_names () =
     [
       retired "masc" "code";
       retired "Masc" "code";
-      "keeper_bash";
-      "keeper_shell";
-      "keeper_fs_";
+      old_bash;
+      old_shell;
+      retired "keeper" "fs";
       retired "keeper" "pr";
       old_preflight;
       old_submit;
@@ -2767,11 +2780,9 @@ let test_prompt_sanitizes_retired_tool_names () =
       "legacy helper family";
       "legacy preflight helper";
       "verification handoff";
-      "Bash";
-      "Grep";
+      old_public_bash;
+      old_public_grep;
     ];
-  check bool "system keeps Execute" true (contains_substring sys "Execute");
-  check bool "user keeps EditFile" true (contains_substring user "EditFile");
   check
     bool
     "user keeps command-shape diagnostic without retired prefix"


### PR DESCRIPTION
## Summary

- strip retired tool names from prompt sanitization instead of translating them back into current public aliases
- remove keeper_bash / keeper_shell / old Bash / Grep wording from Execute validation, sandbox cwd errors, and resource-axis warnings
- rename deterministic retry reason emission from keeper_shell_op_required to structured_tool_required while accepting old wire payloads for compatibility

## Validation

- git diff --check origin/main..HEAD
- rg no-match check for keeper_bash / keeper_shell / keeper_fs_ / keeper_shell_op_required / deterministic_error_keeper_shell_op_required / Bash / Grep across the touched prompt/config/runtime/test surfaces
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_INCLUDE_OPERATOR_CONTROL=true scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_bash_retry_deterministic_close.exe test/test_keeper_bash_typed_input.exe test/test_keeper_tool_exposure.exe test/test_keeper_safety_gates.exe
- ./_build/default/test/test_keeper_unified.exe test unified_prompt 36 --show-errors
- ./_build/default/test/test_keeper_bash_retry_deterministic_close.exe
- ./_build/default/test/test_keeper_bash_typed_input.exe
- ./_build/default/test/test_keeper_tool_exposure.exe test mode_free_access 3 --show-errors

## Notes

- Full test_keeper_tool_exposure.exe still has unrelated existing voice-policy failures; the touched last_turn_safe case passes directly.
