### PR TITLE
chore(tool_name): purge dead Keeper.Discovery variant

### DIFF
--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -594,7 +594,6 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
     | Tool_name.Keeper.Memory_write -> "memory"
     | Tool_name.Keeper.Broadcast | Tool_name.Keeper.Handoff -> "coordination"
     | Tool_name.Keeper.Context_status
-    | Tool_name.Keeper.Discovery
     | Tool_name.Keeper.Stay_silent
     | Tool_name.Keeper.Time_now
     | Tool_name.Keeper.Tool_search

--- a/lib/tool_catalog_inference.ml
+++ b/lib/tool_catalog_inference.ml
@@ -63,7 +63,6 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Keeper TK.Board_sub_board_get
   | TN.Keeper TK.Board_sub_board_list
   | TN.Keeper TK.Context_status
-  | TN.Keeper TK.Discovery
   | TN.Keeper TK.Fs_read
   | TN.Keeper TK.Library_read
   | TN.Keeper TK.Library_search
@@ -250,7 +249,6 @@ let tool_group_of_typed_tool_name = function
   | TN.Keeper
       ( TK.Broadcast
       | TK.Context_status
-      | TK.Discovery
       | TK.Handoff
       | TK.Stay_silent
       | TK.Time_now

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -41,7 +41,6 @@ module Keeper = struct
     | Board_vote
     | Broadcast
     | Context_status
-    | Discovery
     | Fs_edit
     | Fs_read
     | Ide_annotate
@@ -89,7 +88,6 @@ module Keeper = struct
     | Board_vote -> "keeper_board_vote"
     | Broadcast -> "keeper_broadcast"
     | Context_status -> "keeper_context_status"
-    | Discovery -> "keeper_discovery"
     | Fs_edit -> "tool_edit_file"
     | Fs_read -> "tool_read_file"
     | Ide_annotate -> "keeper_ide_annotate"
@@ -138,7 +136,6 @@ module Keeper = struct
     | "keeper_board_sub_board_update" -> Some Board_sub_board_update
     | "keeper_broadcast" -> Some Broadcast
     | "keeper_context_status" -> Some Context_status
-    | "keeper_discovery" -> Some Discovery
     | "tool_edit_file" | "tool_write_file" -> Some Fs_edit
     | "tool_read_file" -> Some Fs_read
     | "keeper_ide_annotate" -> Some Ide_annotate

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -23,7 +23,6 @@ module Keeper : sig
     | Board_vote
     | Broadcast
     | Context_status
-    | Discovery
     | Fs_edit
     | Fs_read
     | Ide_annotate

--- a/lib/tool_resource_axis.ml
+++ b/lib/tool_resource_axis.ml
@@ -167,7 +167,6 @@ let classify_keeper_tool (tool : Tool_name.Keeper.t) args =
   | Board_sub_board_get
   | Board_sub_board_list
   | Context_status
-  | Discovery
   | Ide_annotate
   | Stay_silent
   | Tasks_audit

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -8,7 +8,7 @@ let all_keeper : Tool_name.Keeper.t list =
   [ Execute; Board_comment; Board_comment_vote
   ; Board_curation_read; Board_curation_submit
   ; Board_get; Board_list; Board_post; Board_search; Board_stats; Board_vote
-  ; Broadcast; Context_status; Discovery; Fs_edit; Fs_read
+  ; Broadcast; Context_status; Fs_edit; Fs_read
   ; Handoff; Library_read; Library_search; Memory_search
   ; Search_files; Stay_silent
   ; Task_claim; Task_create; Task_done; Task_submit_for_verification


### PR DESCRIPTION
## Summary

`Tool_name.Keeper.Discovery` variant 가 `"keeper_discovery"` string 으로 mapping 되어 있지만, 그 string 은 *오직 `Tool_name.ml` 의 `to_string`/`of_string` arm 내부에서만* 등장. 어떤 tool descriptor / schema / handler / registry / dashboard / test fixture 도 `keeper_discovery` 를 사용하지 않음 → *pure tombstone*.

본 PR 은 variant 와 그 5 callsite (exhaustive match arm) 를 제거.

## Verification (deadness)

```bash
$ rg -n '"keeper_discovery"' lib/ test/
lib/tool_name.ml:92:    | Discovery -> "keeper_discovery"
lib/tool_name.ml:141:    | "keeper_discovery" -> Some Discovery
# (only inside Tool_name.ml — no descriptor/schema/handler/registry/dashboard/fixture)
```

## 변경 사항

| File | 변경 |
|---|---|
| `lib/tool_name.mli` | `Discovery` 1 line |
| `lib/tool_name.ml` | type variant + `to_string` + `of_string` 3 arm |
| `lib/tool_catalog_inference.ml` | 2 match arm |
| `lib/tool_resource_axis.ml` | 1 match arm |
| `lib/keeper/keeper_exec_shared.ml` | 1 match arm |
| `test/test_tool_name.ml` | exhaustive list 1 entry |

6 file, +1 / -9 LoC. Pure dead-code removal — no behavior change.

## Workaround Signature Gate

- counter / cap / cooldown / dedup / repair 추가 0
- string classifier 추가 0
- catch-all 추가 0
- *positive*: dead variant 제거로 exhaustive match 의 *진짜 의미 명확화*

Override 불필요.

## 관련

- PR #18763 (Tool_name.Shell rename) 직후 이어지는 Tool_name 정리 sweep
- Tool_name 후속 후보: `tool_search_files` schema 의 multi-op enum drift (이름 ↔ 실제 의미) — 사용자 결정 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)