### PR TITLE
refactor(keeper): purge coordination exec relay

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 22:30:10 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 23:10:26 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -715,9 +715,15 @@
           </tr>
           <tr>
             <td>Generic GitHub identity operator actions</td>
-            <td><span class="status now">draft PR #18764</span></td>
+            <td><span class="status done">merged #18764</span></td>
             <td>Remove <code>github_identity_login_prepare</code> / <code>github_identity_status</code> from the generic operator action enum, available-action catalog, approval policy, execution handlers, and current RFC text. GitHub credentials should be bootstrap/config materialization, not a runtime operator-control workaround.</td>
-            <td>PR #18764 branch <code>refactor/purge-github-identity-operator-actions-20260526</code>. Static grep is clean for the live tool/action names outside negative tests.</td>
+            <td>Merged as <code>b3e993c70</code>. Static grep is clean for the live tool/action names outside negative tests, and the branch is included in <code>origin/main</code>.</td>
+          </tr>
+          <tr>
+            <td><code>Keeper_coordination</code> exec-context relay facade</td>
+            <td><span class="status now">draft PR #18773</span></td>
+            <td>Remove the checkpoint, compaction, trace-id, board-write, and model-label re-export relay from <code>Keeper_coordination</code>. <code>Keeper_execution</code> now binds those public helpers directly to <code>Keeper_exec_context</code>, while <code>Keeper_coordination</code> keeps only room/cursor ownership.</td>
+            <td>PR #18773 branch <code>refactor/purge-keeper-coordination-facade-20260526</code>. Backstop grep is clean for the removed <code>Keeper_coordination</code> relay symbols and the old <code>include Keeper_coordination</code> path.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>

--- a/lib/keeper/keeper_coordination.ml
+++ b/lib/keeper/keeper_coordination.ml
@@ -1,25 +1,6 @@
-(** Keeper_coordination — Coord presence, model selection, and room cursor management.
-
-    Checkpoint/compaction/logging functions are delegated to {!Keeper_exec_context}
-    (single source of truth) and re-exported here for backward compatibility
-    with [include Keeper_coordination] in {!Keeper_execution}. *)
+(** Keeper_coordination — Coord presence and room cursor management. *)
 
 open Keeper_types
-
-(* ================================================================ *)
-(* Re-exports from Keeper_exec_context — single source of truth     *)
-(* ================================================================ *)
-
-let log_keeper_exn = Keeper_exec_context.log_keeper_exn
-let load_context_from_checkpoint = Keeper_exec_context.load_context_from_checkpoint
-let compaction_policy_of_keeper = Keeper_exec_context.compaction_policy_of_keeper
-let generate_trace_id = Keeper_exec_context.generate_trace_id
-let keeper_board_write_tool_names = Keeper_exec_context.keeper_board_write_tool_names
-let keeper_write_done = Keeper_exec_context.keeper_write_done
-let keeper_action_kind_of_tool_names = Keeper_exec_context.keeper_action_kind_of_tool_names
-
-let effective_model_labels_for_turn (m : keeper_meta) : string list =
-  Keeper_exec_context.effective_model_labels_for_turn m
 
 let room_cursor_for meta room_id =
   meta.last_seen_seq_by_room

--- a/lib/keeper/keeper_coordination.mli
+++ b/lib/keeper/keeper_coordination.mli
@@ -1,27 +1,6 @@
-(** Keeper_coordination — Coord presence, compaction policy, checkpoint persistence, and error logging for keeper agents. MASC coordination domain. *)
+(** Keeper_coordination — Coord presence and room cursor management. *)
 
 open Keeper_types
-
-val log_keeper_exn : label:string -> exn -> unit
-
-val load_context_from_checkpoint :
-  max_checkpoint_messages:int ->
-  trace_id:string ->
-  primary_model_max_tokens:int ->
-  base_dir:string ->
-  Keeper_exec_context.session_context * Keeper_exec_context.working_context option
-
-val compaction_policy_of_keeper : keeper_meta -> float * int * int
-
-val generate_trace_id : ?now:float -> unit -> string
-
-val keeper_board_write_tool_names : string list
-
-val keeper_write_done : string list -> bool
-
-val keeper_action_kind_of_tool_names : string list -> string
-
-val effective_model_labels_for_turn : keeper_meta -> string list
 
 val room_cursor_for : keeper_meta -> string -> int
 

--- a/lib/keeper/keeper_execution.ml
+++ b/lib/keeper/keeper_execution.ml
@@ -2,14 +2,22 @@
     compaction, and keepalive runtime.
 
     Delegates to sub-modules:
-    - Keeper_coordination: checkpoint, room presence, compaction
+    - Keeper_exec_context: checkpoint, compaction, model labels
+    - Keeper_coordination: room presence
     - Keeper_prompt: system prompts, mention detection, text processing
 
     Proactive emission and autonomous goal turns are now handled by
     Keeper_unified_turn via the unified keeper loop. *)
 
 
-include Keeper_coordination
 include Keeper_prompt
 
+let log_keeper_exn = Keeper_exec_context.log_keeper_exn
+let load_context_from_checkpoint = Keeper_exec_context.load_context_from_checkpoint
+let compaction_policy_of_keeper = Keeper_exec_context.compaction_policy_of_keeper
+let generate_trace_id = Keeper_exec_context.generate_trace_id
+let effective_model_labels_for_turn = Keeper_exec_context.effective_model_labels_for_turn
+let ensure_keeper_room_presence = Keeper_coordination.ensure_keeper_room_presence
+let room_cursor_for = Keeper_coordination.room_cursor_for
+let set_room_cursor = Keeper_coordination.set_room_cursor
 let memory_check_default_json = Keeper_exec_context.memory_check_default_json

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -33,7 +33,7 @@ let build_cascade_execution
   let cascade_name_string = Cascade_name.to_string cascade_name in
   let meta_for_cascade = set_cascade_name cascade_name_string meta in
   let model_labels =
-    Keeper_coordination.effective_model_labels_for_turn meta_for_cascade
+    Keeper_exec_context.effective_model_labels_for_turn meta_for_cascade
   in
   match Keeper_types_support.ensure_api_keys_for_labels model_labels with
   | Error e -> Error (Agent_sdk.Error.Internal e)


### PR DESCRIPTION
## Summary

- remove the `Keeper_coordination` compatibility relay for checkpoint, compaction, trace-id, board-write, and model-label helpers
- bind `Keeper_execution` directly to `Keeper_exec_context` for those helpers while keeping room/cursor ownership in `Keeper_coordination`
- update the legacy purge HTML ledger, including the merged #18764 status

## Verification

- `ocamlformat --check lib/keeper/keeper_coordination.ml lib/keeper/keeper_coordination.mli lib/keeper/keeper_execution.ml lib/keeper/keeper_unified_turn_pre_dispatch.ml`
- `git diff --check`
- `rg -n "Keeper_coordination\.(log_keeper_exn|load_context_from_checkpoint|compaction_policy_of_keeper|generate_trace_id|keeper_board_write_tool_names|keeper_write_done|keeper_action_kind_of_tool_names|effective_model_labels_for_turn)|include Keeper_coordination|backward compatibility\s+with \[include Keeper_coordination\]|Checkpoint/compaction/logging" lib test docs -S -g "!docs/audit/2026-05-25-legacy-purge-plan.html"` returned no matches
- `scripts/dune-local.sh build lib/masc_mcp.cmxa` did not run: wrapper exited 75 because existing bare Dune processes are active on the host