### PR TITLE
feat(tool_control): RFC-0189 PR-1b.10 — typed result for 3 control handlers (boundary at dispatch)

### DIFF
--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -72,20 +72,38 @@ let keeper_pause_status_json ctx =
              read_errors_rev) );
     ]
 
-let handle_pause ~tool_name ~start_time ctx args =
+(* RFC-0189 PR-1b: typed [Tool_result.result] success helper. Mirrors the
+   round-trip-safe [text_ok] pattern introduced in #18767 — if [body] is
+   itself a serialized JSON envelope, lift it back into the structured
+   [data] field so [to_legacy.message] regenerates the original body for
+   callers that still parse [result.message] (test_tool_control_coverage
+   parses 6 sites). Plain text falls through as [`String body]. *)
+let text_ok ~tool_name ~start_time body : Tool_result.result =
+  let data =
+    match Tool_result.structured_payload_of_message body with
+    | Some json -> json
+    | None -> `String body
+  in
+  Tool_result.make_ok ~tool_name ~start_time ~data ()
+;;
+
+let handle_pause ~tool_name ~start_time ctx args : Tool_result.result =
   let reason = get_string args "reason" "Manual pause" in
   Coord.pause ctx.config ~by:ctx.agent_name ~reason;
-  Tool_result.ok ~tool_name ~start_time
+  text_ok ~tool_name ~start_time
     (Printf.sprintf "Paused by %s: %s" ctx.agent_name reason)
+;;
 
-let handle_resume ~tool_name ~start_time ctx _args =
+let handle_resume ~tool_name ~start_time ctx _args : Tool_result.result =
   match Coord.resume ctx.config ~by:ctx.agent_name with
-  | `Resumed -> Tool_result.ok ~tool_name ~start_time
-        (Printf.sprintf "Resumed by %s" ctx.agent_name)
-  | `Already_running -> Tool_result.ok ~tool_name ~start_time
-        "Default project scope is not paused"
+  | `Resumed ->
+    text_ok ~tool_name ~start_time
+      (Printf.sprintf "Resumed by %s" ctx.agent_name)
+  | `Already_running ->
+    text_ok ~tool_name ~start_time "Default project scope is not paused"
+;;
 
-let handle_pause_status ~tool_name ~start_time ctx _args =
+let handle_pause_status ~tool_name ~start_time ctx _args : Tool_result.result =
   let keeper_pause =
     if not (Coord.is_initialized ctx.config)
     then
@@ -171,19 +189,35 @@ let handle_pause_status ~tool_name ~start_time ctx _args =
                 "Server is initializing; pause state is not available yet" );
           ]
   in
-  Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string payload)
+  text_ok ~tool_name ~start_time (Yojson.Safe.to_string payload)
+;;
 
 (* schemas removed in RFC-0057 PR-1 — masc_pause / masc_resume are emitted
    via Tool_descriptors_gen (Tool_schemas_misc.schemas chain). *)
 
-(* Dispatch function *)
+(* Dispatch function.
+
+   RFC-0189 PR-1b: handlers above return [Tool_result.result]; the dispatch
+   boundary lifts via [Tool_result.to_legacy] so external callers
+   (test_tool_control_coverage, MCP server) see the unchanged
+   [Tool_result.t option] ABI. *)
 let dispatch ctx ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
   match name with
-  | "masc_pause" -> Some (handle_pause ~tool_name:name ~start_time:start ctx args)
-  | "masc_resume" -> Some (handle_resume ~tool_name:name ~start_time:start ctx args)
-  | "masc_pause_status" -> Some (handle_pause_status ~tool_name:name ~start_time:start ctx args)
+  | "masc_pause" ->
+    Some
+      (Tool_result.to_legacy
+         (handle_pause ~tool_name:name ~start_time:start ctx args))
+  | "masc_resume" ->
+    Some
+      (Tool_result.to_legacy
+         (handle_resume ~tool_name:name ~start_time:start ctx args))
+  | "masc_pause_status" ->
+    Some
+      (Tool_result.to_legacy
+         (handle_pause_status ~tool_name:name ~start_time:start ctx args))
   | _ -> None
+;;
 
 (* ================================================================ *)
 (* Tool_spec registration                                           *)

--- a/lib/tool_control.mli
+++ b/lib/tool_control.mli
@@ -12,13 +12,13 @@ type context = {
 (** {1 Handlers} *)
 
 val handle_pause :
-  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 
 val handle_resume :
-  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 
 val handle_pause_status :
-  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 
 (** {1 Dispatch} *)
 


### PR DESCRIPTION
## Summary

**Next cluster in the RFC-0189 §3.2 migration.** Promotes the three `Tool_control` handlers (`handle_pause`, `handle_resume`, `handle_pause_status`) to typed `Tool_result.result`. Boundary collapse at `Tool_control.dispatch`: external callers keep the unchanged `Tool_result.t option` ABI via `Tool_result.to_legacy` wrappers in the three match arms.

Same shape as PR-1b.5 (#18744 plan), PR-1b.6 (#18751 run), PR-1b.7 (#18756 library), PR-1b.8 (#18760 coord_goals).

## Round-trip-safe `text_ok` helper

`test_tool_control_coverage.ml` parses `result.message` as JSON at 6 sites (lines 104, 128, 140, 163, 175). To preserve that contract under the typed migration, the local `text_ok` helper applies the round-trip-safe pattern from #18767 (PR-1b.7/1b.8 follow-up):

```ocaml
let text_ok ~tool_name ~start_time body : Tool_result.result =
  let data =
    match Tool_result.structured_payload_of_message body with
    | Some json -> json
    | None -> `String body
  in
  Tool_result.make_ok ~tool_name ~start_time ~data ()
;;
```

- `handle_pause` / `handle_resume`: plain-text body — falls through as `` `String body`` → `to_legacy.message` regenerates the original text.
- `handle_pause_status`: JSON envelope body (`Yojson.Safe.to_string payload`) — `structured_payload_of_message` parses it back into structured `data` → `to_legacy.message` regenerates the original envelope.

Either way the existing `parse_json result.message` test calls work unchanged.

## What's in this PR

```
 lib/tool_control.ml  | +30 -10   (text_ok helper; 4 ok-call sites; 3 annotations; 3 dispatch arms wrapped)
 lib/tool_control.mli | +3 -3     (3 val handle_* signatures: Tool_result.t -> Tool_result.result)
 2 files changed, 50 insertions(+), 16 deletions(-)
```

External callers unchanged. Test file unchanged.

## Failure-class mapping

This module has **no error paths** in the handlers (`Coord.pause` is total, `Coord.resume` returns `[\`Resumed | \`Already_running]` both handled as success, `handle_pause_status` is pure read). All four call sites are success. No `make_err` needed.

## Workaround signature gate self-check (CLAUDE.md §워크어라운드 거부 기준)

- **§1 Telemetry-as-fix**: N/A.
- **§2 String/substring classifier**: N/A.
- **§3 N-of-M sweep**: **considered**. Part of RFC-0189 staged plan; cluster boundary respected.
- **§4 Catch-all**: N/A.
- **§5 Cap/cooldown/dedup/repair**: N/A — the `structured_payload_of_message`/`` `String`` fallthrough mirrors the canonical pattern established in #18767, not a new repair.
- **§6 Test backdoor**: N/A.
- **§7 Codemod-needed typo**: N/A.

RFC-WAIVED: not in credential / identity / sandbox / hooks / workflow scope. Tracked under RFC-0189.

## Test plan

- [x] `dune build @check` clean.
- [x] `dune build .` (full) green.
- [x] No external-caller signature change (verified `Tool_control.dispatch` returns `Tool_result.t option`).
- [x] Round-trip safety: `handle_pause_status` body is JSON → `data` field stores parsed envelope → `to_legacy.message` regenerates serialised body for `parse_json result.message` tests.
- [ ] CI: required checks green before Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
