### PR TITLE
feat(tool_misc_admin): RFC-0189 PR-1b.12 — typed result for 3 admin handlers (lift at Tool_misc.dispatch)

### DIFF
--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -194,7 +194,7 @@ let dispatch ctx ~name ~args : Tool_result.t option =
     { config = ctx.config; agent_name = ctx.agent_name }
   in
   match name with
-  | "masc_config" -> Some (Tool_misc_admin.handle_config ~tool_name:name ~start_time:start args)
+  | "masc_config" -> lift (Tool_misc_admin.handle_config ~tool_name:name ~start_time:start args)
   | "masc_dashboard" -> lift (handle_dashboard ~tool_name:name ~start_time:start ctx args)
   | "masc_gc" -> lift (handle_gc ~tool_name:name ~start_time:start ctx args)
   | "masc_cleanup_zombies" -> lift (handle_cleanup_zombies ~tool_name:name ~start_time:start ctx args)
@@ -202,8 +202,8 @@ let dispatch ctx ~name ~args : Tool_result.t option =
   | "masc_tool_help" -> lift (handle_tool_help ~tool_name:name ~start_time:start ctx args)
   | "masc_web_search" -> lift (handle_web_search ~tool_name:name ~start_time:start ctx args)
   | "masc_web_fetch" -> lift (handle_web_fetch ~tool_name:name ~start_time:start ctx args)
-  | "masc_tool_admin_snapshot" -> Some (Tool_misc_admin.handle_tool_admin_snapshot ~tool_name:name ~start_time:start admin_ctx args)
-  | "masc_tool_admin_update" -> Some (Tool_misc_admin.handle_tool_admin_update ~tool_name:name ~start_time:start admin_ctx args)
+  | "masc_tool_admin_snapshot" -> lift (Tool_misc_admin.handle_tool_admin_snapshot ~tool_name:name ~start_time:start admin_ctx args)
+  | "masc_tool_admin_update" -> lift (Tool_misc_admin.handle_tool_admin_update ~tool_name:name ~start_time:start admin_ctx args)
   | "masc_deep_review" -> Some (Tool_deep_review.handle_deep_review ~tool_name:name ~start_time:start ctx.config args)
   | _ -> None
 

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -27,7 +27,45 @@ open Tool_args
 
 module U = Yojson.Safe.Util
 
-type tool_result = Tool_result.t
+type tool_result = Tool_result.result
+
+(* RFC-0189: typed [Tool_result.result] helpers, scoped to this module.
+
+   - [ok_result_typed]: structured success — uses [data] field directly,
+     mirroring the [Tool_args.ok_response]/[ok_assoc] envelope.  Callers
+     that round-trip through [result.message] receive the serialised
+     envelope via [Tool_result.to_legacy].
+   - [text_ok]: success carrying a free-form (often JSON-string) body.
+     Falls back to [`String body] when [structured_payload_of_message]
+     can't parse — same pattern as #18767.
+   - [error_workflow]: caller-input rejection (auth section unknown,
+     deprecated field, validation failure).  All three error paths
+     here surface caller-side issues, so they share
+     [Workflow_rejection]. *)
+let ok_result_typed ~tool_name ~start_time fields : Tool_result.result =
+  Tool_result.make_ok
+    ~tool_name
+    ~start_time
+    ~data:(Tool_args.ok_assoc fields)
+    ()
+;;
+
+let text_ok ~tool_name ~start_time body : Tool_result.result =
+  let data =
+    match Tool_result.structured_payload_of_message body with
+    | Some json -> json
+    | None -> `String body
+  in
+  Tool_result.make_ok ~tool_name ~start_time ~data ()
+;;
+
+let error_workflow ~tool_name ~start_time msg : Tool_result.result =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Workflow_rejection
+    ~start_time
+    msg
+;;
 
 (** SSOT for canonical `section` values accepted by
     [masc_tool_admin_update]. Adding a new section requires:
@@ -191,19 +229,21 @@ let tool_inventory_json _ctx ~include_hidden =
 let handle_config ~tool_name ~start_time args : tool_result =
   let cat = get_string_opt args "category" in
   let json = Env_config_introspect.to_json_filtered ?cat () in
-  Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string json)
+  text_ok ~tool_name ~start_time (Yojson.Safe.to_string json)
+;;
 
-let handle_tool_admin_snapshot ~tool_name ~start_time ctx args =
+let handle_tool_admin_snapshot ~tool_name ~start_time ctx args : tool_result =
   let include_hidden = get_bool args "include_hidden" true in
-  Tool_args.ok_result ~tool_name ~start_time
+  ok_result_typed ~tool_name ~start_time
     [
       ("generated_at", `String (Masc_domain.now_iso ()));
       ("auth", auth_snapshot_json ctx);
       ( "tool_inventory",
         tool_inventory_json ctx ~include_hidden );
     ]
+;;
 
-let handle_tool_admin_update ~tool_name ~start_time ctx args =
+let handle_tool_admin_update ~tool_name ~start_time ctx args : tool_result =
   let section =
     get_string args "section" "" |> String.trim |> String.lowercase_ascii
   in
@@ -211,7 +251,7 @@ let handle_tool_admin_update ~tool_name ~start_time ctx args =
   | "auth" ->
       let current = Auth.load_auth_config ctx.config.base_path in
       if not ((=) (U.member "default_role" args) `Null) then
-        Tool_result.error ~tool_name ~start_time "default_role is no longer supported"
+        error_workflow ~tool_name ~start_time "default_role is no longer supported"
       else
       let require_token =
         match bool_arg_opt args "require_token" with
@@ -226,7 +266,7 @@ let handle_tool_admin_update ~tool_name ~start_time ctx args =
         | None -> Ok current.token_expiry_hours
       in
       (match expiry_hours with
-      | Error err -> Tool_result.error ~tool_name ~start_time err
+      | Error err -> error_workflow ~tool_name ~start_time err
       | Ok token_expiry_hours ->
           let room_secret =
             match enabled_opt with
@@ -251,13 +291,14 @@ let handle_tool_admin_update ~tool_name ~start_time ctx args =
             }
           in
           Auth.save_auth_config ctx.config.base_path updated;
-          Tool_args.ok_result ~tool_name ~start_time
+          ok_result_typed ~tool_name ~start_time
             [
               ("section", `String "auth");
               ("room_secret", json_string_option room_secret);
               ("result", auth_snapshot_json ctx);
             ])
   | _ ->
-      Tool_result.error ~tool_name ~start_time
+      error_workflow ~tool_name ~start_time
         (Printf.sprintf "section must be one of: %s"
            (String.concat " | " valid_admin_section_strings))
+;;

--- a/lib/tool_misc_admin.mli
+++ b/lib/tool_misc_admin.mli
@@ -18,7 +18,11 @@
 
 (** {1 Types} *)
 
-type tool_result = Tool_result.t
+(** RFC-0189: [tool_result] aliases the typed [Tool_result.result]
+    variant.  The dispatch boundary in {!Tool_misc} lifts back to
+    [Tool_result.t option] via [Tool_result.to_legacy] for external
+    callers. *)
+type tool_result = Tool_result.result
 
 type context = {
   config : Coord.config;


### PR DESCRIPTION
## Summary

**Next cluster in the RFC-0189 §3.2 migration.** Promotes the three `Tool_misc_admin` handlers (`handle_config`, `handle_tool_admin_snapshot`, `handle_tool_admin_update`) to typed `Tool_result.result`. The dispatch boundary in `Tool_misc.dispatch` already exposes a `lift` closure (introduced by PR-1b.11 #18775); this PR switches the three admin match arms from `Some (Tool_misc_admin.handle_*)` to `lift (...)` so external callers keep the unchanged `Tool_result.t option` ABI.

Same boundary-collapse shape as PR-1b.5/6/7/8/10/11 (#18774).

## Type alias retypes the whole module surface

```ocaml
(* lib/tool_misc_admin.mli *)
type tool_result = Tool_result.result   (* was Tool_result.t *)
```

This is the canonical handle for all three `val handle_*` signatures, so a single line in the `.mli` propagates the typed return through every public entry — no per-handler signature edits needed.

## Local typed helpers (3 patterns)

| Helper | Use | Round-trip safety |
|---|---|---|
| `ok_result_typed` | structured success (Yojson assoc fields) | `data` = `Tool_args.ok_assoc fields`; `to_legacy.message` regenerates the canonical envelope |
| `text_ok` | free-form body, often a serialised JSON string | `structured_payload_of_message` fallback (matches #18767's fix) — JSON envelopes lift back into `data`, plain strings fall through as `` `String body`` |
| `error_workflow` | caller-input rejection | `~class_:Workflow_rejection` for all three error paths |

### Failure-class mapping

All three error paths in this module surface caller-side issues, so each maps to `Workflow_rejection`:

| Site | Trigger | class |
|---|---|---|
| `handle_tool_admin_update` (line 214) | `default_role` field is no longer supported | `Workflow_rejection` |
| `handle_tool_admin_update` (line 229) | `token_expiry_hours` <= 0 | `Workflow_rejection` |
| `handle_tool_admin_update` (line 261) | unknown `section` | `Workflow_rejection` |

No `Runtime_failure` paths exist here: `Auth.load_auth_config` / `Auth.save_auth_config` / `Auth.enable_auth` are total over the input space, and `Env_config_introspect.to_json_filtered` is a pure read.

## What's in this PR

```
 lib/tool_misc_admin.ml  | +44 -13   (3 local helpers + 4 site swap + handler annotations)
 lib/tool_misc_admin.mli | +5 -1     (tool_result alias: Tool_result.t -> Tool_result.result)
 lib/tool_misc.ml        | +3 -3     (3 admin dispatch arms: Some -> lift)
```

Test file unchanged.

## Workaround signature gate self-check (CLAUDE.md §워크어라운드 거부 기준)

- **§1 Telemetry-as-fix**: N/A.
- **§2 String/substring classifier**: N/A.
- **§3 N-of-M sweep**: **considered**. RFC-0189 staged plan; cluster boundary respected.
- **§4 Catch-all**: N/A.
- **§5 Cap/cooldown/dedup/repair**: N/A — the `structured_payload_of_message` fallback mirrors the canonical pattern from #18767.
- **§6 Test backdoor**: N/A.
- **§7 Codemod-needed typo**: N/A.

RFC-WAIVED: not in credential / identity / sandbox / hooks / workflow scope. Tracked under RFC-0189.

## Test plan

- [x] `dune build @check` clean.
- [x] `dune build .` (full) green.
- [x] External callers unchanged (`Tool_misc.dispatch` returns `Tool_result.t option`).
- [x] Round-trip safety verified for both helpers.
- [ ] CI: required checks green before Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
