### PR TITLE
feat(tool_misc_admin): RFC-0189 PR-1b.12 — typed result for 3 admin handlers + dispatch lift simplification

### DIFF
--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -181,12 +181,16 @@ let tool_inventory_json ctx ~include_hidden =
 (* Dispatch (facade)                                                *)
 (* ================================================================ *)
 
-(* RFC-0189 PR-1b.10 — boundary projection. Facade handlers
-   (dashboard / gc / cleanup_zombies / tool_stats / tool_help) and
-   the web_* delegates are all typed; lift through [to_legacy] at
-   one place. External module handlers ([Tool_misc_admin.*],
-   [Tool_deep_review.*]) still return legacy [Tool_result.t] and
-   skip the lift. PR-1c will promote the dispatch ABI itself. *)
+(* RFC-0189 PR-1b.10 + PR-1b.12 — boundary projection.
+
+   All facade handlers (dashboard / gc / cleanup_zombies / tool_stats
+   / tool_help), the web_* delegates, and the Tool_misc_admin
+   handlers (config / tool_admin_snapshot / tool_admin_update) are
+   typed; a single [lift] handles the [Tool_result.t option]
+   projection. [Tool_deep_review.handle_deep_review] is the only
+   remaining legacy [Tool_result.t]-returning arm — promoting it
+   stays out of scope until its module is migrated. PR-1c will
+   promote the dispatch ABI itself, removing the lift entirely. *)
 let dispatch ctx ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
   let lift r = Some (Tool_result.to_legacy r) in
@@ -194,7 +198,7 @@ let dispatch ctx ~name ~args : Tool_result.t option =
     { config = ctx.config; agent_name = ctx.agent_name }
   in
   match name with
-  | "masc_config" -> Some (Tool_misc_admin.handle_config ~tool_name:name ~start_time:start args)
+  | "masc_config" -> lift (Tool_misc_admin.handle_config ~tool_name:name ~start_time:start args)
   | "masc_dashboard" -> lift (handle_dashboard ~tool_name:name ~start_time:start ctx args)
   | "masc_gc" -> lift (handle_gc ~tool_name:name ~start_time:start ctx args)
   | "masc_cleanup_zombies" -> lift (handle_cleanup_zombies ~tool_name:name ~start_time:start ctx args)
@@ -202,8 +206,8 @@ let dispatch ctx ~name ~args : Tool_result.t option =
   | "masc_tool_help" -> lift (handle_tool_help ~tool_name:name ~start_time:start ctx args)
   | "masc_web_search" -> lift (handle_web_search ~tool_name:name ~start_time:start ctx args)
   | "masc_web_fetch" -> lift (handle_web_fetch ~tool_name:name ~start_time:start ctx args)
-  | "masc_tool_admin_snapshot" -> Some (Tool_misc_admin.handle_tool_admin_snapshot ~tool_name:name ~start_time:start admin_ctx args)
-  | "masc_tool_admin_update" -> Some (Tool_misc_admin.handle_tool_admin_update ~tool_name:name ~start_time:start admin_ctx args)
+  | "masc_tool_admin_snapshot" -> lift (Tool_misc_admin.handle_tool_admin_snapshot ~tool_name:name ~start_time:start admin_ctx args)
+  | "masc_tool_admin_update" -> lift (Tool_misc_admin.handle_tool_admin_update ~tool_name:name ~start_time:start admin_ctx args)
   | "masc_deep_review" -> Some (Tool_deep_review.handle_deep_review ~tool_name:name ~start_time:start ctx.config args)
   | _ -> None
 

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -188,14 +188,50 @@ let tool_inventory_json _ctx ~include_hidden =
 (* Handlers                                                         *)
 (* ================================================================ *)
 
-let handle_config ~tool_name ~start_time args : tool_result =
+(* RFC-0189 PR-1b.12 — typed result.
+
+   [json_ok] / [ok_envelope] keep the structured payload first-class
+   (no [Yojson.Safe.to_string] round-trip here). For envelope-string
+   bodies the [#18767]-pattern parse-and-store keeps
+   [to_legacy.message] regenerating the original envelope.
+
+   Failure classes — all caller-input violations:
+   - [Workflow_rejection]: removed-feature alias
+     ([default_role is no longer supported]), invalid bound
+     ([token_expiry_hours must be > 0]), unknown section
+     ([section must be one of: ...]).
+
+   No runtime / transient sites — [Env_config_introspect.to_json_filtered]
+   / [Auth.load_auth_config] / [Auth.save_auth_config] assume-success
+   or raise. *)
+
+let json_ok ~tool_name ~start_time (json : Yojson.Safe.t) : Tool_result.result =
+  Tool_result.make_ok ~tool_name ~start_time ~data:json ()
+
+let ok_envelope ~tool_name ~start_time fields : Tool_result.result =
+  let envelope = Tool_args.ok_response fields in
+  let data =
+    match Tool_result.structured_payload_of_message envelope with
+    | Some json -> json
+    | None -> `String envelope
+  in
+  Tool_result.make_ok ~tool_name ~start_time ~data ()
+
+let workflow_err ~tool_name ~start_time msg : Tool_result.result =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Workflow_rejection
+    ~start_time
+    msg
+
+let handle_config ~tool_name ~start_time args : Tool_result.result =
   let cat = get_string_opt args "category" in
   let json = Env_config_introspect.to_json_filtered ?cat () in
-  Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string json)
+  json_ok ~tool_name ~start_time json
 
-let handle_tool_admin_snapshot ~tool_name ~start_time ctx args =
+let handle_tool_admin_snapshot ~tool_name ~start_time ctx args : Tool_result.result =
   let include_hidden = get_bool args "include_hidden" true in
-  Tool_args.ok_result ~tool_name ~start_time
+  ok_envelope ~tool_name ~start_time
     [
       ("generated_at", `String (Masc_domain.now_iso ()));
       ("auth", auth_snapshot_json ctx);
@@ -203,7 +239,7 @@ let handle_tool_admin_snapshot ~tool_name ~start_time ctx args =
         tool_inventory_json ctx ~include_hidden );
     ]
 
-let handle_tool_admin_update ~tool_name ~start_time ctx args =
+let handle_tool_admin_update ~tool_name ~start_time ctx args : Tool_result.result =
   let section =
     get_string args "section" "" |> String.trim |> String.lowercase_ascii
   in
@@ -211,7 +247,8 @@ let handle_tool_admin_update ~tool_name ~start_time ctx args =
   | "auth" ->
       let current = Auth.load_auth_config ctx.config.base_path in
       if not ((=) (U.member "default_role" args) `Null) then
-        Tool_result.error ~tool_name ~start_time "default_role is no longer supported"
+        workflow_err ~tool_name ~start_time
+          "default_role is no longer supported"
       else
       let require_token =
         match bool_arg_opt args "require_token" with
@@ -226,7 +263,7 @@ let handle_tool_admin_update ~tool_name ~start_time ctx args =
         | None -> Ok current.token_expiry_hours
       in
       (match expiry_hours with
-      | Error err -> Tool_result.error ~tool_name ~start_time err
+      | Error err -> workflow_err ~tool_name ~start_time err
       | Ok token_expiry_hours ->
           let room_secret =
             match enabled_opt with
@@ -251,13 +288,13 @@ let handle_tool_admin_update ~tool_name ~start_time ctx args =
             }
           in
           Auth.save_auth_config ctx.config.base_path updated;
-          Tool_args.ok_result ~tool_name ~start_time
+          ok_envelope ~tool_name ~start_time
             [
               ("section", `String "auth");
               ("room_secret", json_string_option room_secret);
               ("result", auth_snapshot_json ctx);
             ])
   | _ ->
-      Tool_result.error ~tool_name ~start_time
+      workflow_err ~tool_name ~start_time
         (Printf.sprintf "section must be one of: %s"
            (String.concat " | " valid_admin_section_strings))

--- a/lib/tool_misc_admin.mli
+++ b/lib/tool_misc_admin.mli
@@ -67,11 +67,11 @@ val tool_inventory_json :
     for the snapshot/update handlers because they read from the
     base path. *)
 
-val handle_config : tool_name:string -> start_time:float -> Yojson.Safe.t -> tool_result
+val handle_config : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_result.result
 (** [handle_config ~tool_name ~start_time args] returns the auth-config
     snapshot filtered by [args.category] (optional string).  Read-only. *)
 
-val handle_tool_admin_snapshot : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> tool_result
+val handle_tool_admin_snapshot : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 (** [handle_tool_admin_snapshot ~tool_name ~start_time ctx args] returns the tool
     inventory + auth config + feature-flag summary for the admin
     dashboard.  Optional args:
@@ -79,7 +79,7 @@ val handle_tool_admin_snapshot : tool_name:string -> start_time:float -> context
     - [include_hidden] (bool, default [true]). *)
 
 val handle_tool_admin_update :
-  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> tool_result
+  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 (** [handle_tool_admin_update ~tool_name ~start_time ctx args] writes a new auth config.
     Required args:
 


### PR DESCRIPTION
## Summary

RFC-0189 PR-1b.12 — `tool_misc_admin.ml` cluster (3 handlers, 5 calls). Now-unblocked sister to PR-1b.10 (merged #18770).

## Failure-class mapping (all Workflow_rejection)

| Site | Class |
|---|---|
| `"default_role is no longer supported"` (removed-feature alias) | `Workflow_rejection` |
| `"token_expiry_hours must be > 0"` (invalid bound) | `Workflow_rejection` |
| `"section must be one of: ..."` (unknown section enum) | `Workflow_rejection` |

No `Runtime_failure` / `Transient_error` — `Env_config_introspect.to_json_filtered` / `Auth.load_auth_config` / `Auth.save_auth_config` assume-success-or-raise.

## New helpers in this module

```ocaml
let json_ok ~tool_name ~start_time (json : Yojson.Safe.t) : Tool_result.result =
  Tool_result.make_ok ~tool_name ~start_time ~data:json ()

let ok_envelope ~tool_name ~start_time fields : Tool_result.result =
  let envelope = Tool_args.ok_response fields in
  let data =
    match Tool_result.structured_payload_of_message envelope with
    | Some json -> json
    | None -> `String envelope
  in
  Tool_result.make_ok ~tool_name ~start_time ~data ()
```

- `json_ok` drops the `Yojson.Safe.to_string` round-trip for `handle_config` (backend already returns `Yojson.Safe.t`).
- `ok_envelope` replaces `Tool_args.ok_result` in this module, applying the #18767-corrected `structured_payload_of_message` pattern so `to_legacy.message` preserves the original envelope.

## Caller cascade (`lib/tool_misc.ml :dispatch`)

3 admin arms migrate from `Some (...)` to `lift (...)`:

```diff
-  | "masc_config" -> Some (Tool_misc_admin.handle_config ...)
+  | "masc_config" -> lift (Tool_misc_admin.handle_config ...)
   ...
-  | "masc_tool_admin_snapshot" -> Some (Tool_misc_admin.handle_tool_admin_snapshot ...)
+  | "masc_tool_admin_snapshot" -> lift (Tool_misc_admin.handle_tool_admin_snapshot ...)
   ...
-  | "masc_tool_admin_update" -> Some (Tool_misc_admin.handle_tool_admin_update ...)
+  | "masc_tool_admin_update" -> lift (Tool_misc_admin.handle_tool_admin_update ...)
```

Boundary comment updated: only `Tool_deep_review.handle_deep_review` remains as the lone legacy-returning arm.

## Verification

- `dune build --root . --cache=disabled lib/` exit 0
- `test_tool_result.exe`: **20/20 PASS**
- `test_tool_misc_coverage.exe`: **36/40 PASS** (4 pre-existing failures #8/9/10/24, all reproduce on `origin/main`)

## RFC-0189 progress

| Item | Status |
|---|---|
| PR-1a..1b.11 + supporting | ✅ 17 merged |
| **PR-1b.12** (this) | 🟦 Draft |
| PR-1b.13+ | tool_coord (7 callers, fan-out risk) / tool_agent (5 handlers) / tool_agent_timeline (1 handler) |
| task RFC | separate (10+ caller fan-out) |
| PR-1c | accessor migration |
| PR-2 | legacy purge |

## Test plan

- [x] `dune build --root . --cache=disabled lib/`
- [x] `test_tool_result.exe` 20/20
- [x] `test_tool_misc_coverage.exe` 36/40 (4 pre-existing fails)
- [ ] CI green (Draft)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
