### PR TITLE
refactor(tool-registry): project descriptor readonly policy

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -996,6 +996,15 @@ let descriptors_for_internal internal_name =
   List.filter (fun d -> String.equal d.internal_name internal_name) (all_descriptors ())
 ;;
 
+let readonly_internal_names () =
+  all_descriptors ()
+  |> List.filter_map (fun d ->
+    match d.policy.readonly with
+    | Some true -> Some d.internal_name
+    | Some false | None -> None)
+  |> List.sort_uniq String.compare
+;;
+
 let public_name_for_internal internal_name =
   match public_descriptors_for_internal internal_name with
   | [] -> None

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -112,6 +112,10 @@ val public_descriptors_for_internal : string -> t list
     alongside the seven LLM-native descriptors. *)
 val descriptors_for_internal : string -> t list
 
+(** Descriptor-owned read-only projection. The returned names are internal
+    handler names whose descriptor policy declares [readonly = Some true]. *)
+val readonly_internal_names : unit -> string list
+
 val public_input_schema : string -> Yojson.Safe.t option
 val translate_input : public:string -> Yojson.Safe.t -> Yojson.Safe.t
 val receipt_labels_json : t -> Yojson.Safe.t

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -112,21 +112,16 @@ let is_core_always_tool (name : string) : bool = Hashtbl.mem core_always_set nam
 
 (* ── Read-only keeper tools ───────────────────────────────────── *)
 
-(** Derived from [Tool_shard.shard.read_only_tools] metadata.
-    Each shard declares which of its tools are read-only at the
-    definition site, eliminating drift between tool schemas and
-    read-only classification.
+(** Descriptor-projected read-only tools. This covers non-shard tools and
+    descriptor-backed public/coordination tools without adding new string
+    mirrors to the registry. *)
+let descriptor_read_only_tools = Agent_tool_descriptor.readonly_internal_names ()
 
-    Non-shard tools (injected outside Tool_shard, e.g. keeper_tool_search)
-    are listed explicitly below. *)
-let non_shard_read_only_tools =
-  List.map Tool_name.to_string Tool_name.[ Keeper Tool_search ]
-;;
-
-(* injected by Keeper_tool_policy, not in any shard *)
+(* Historical export name retained for callers that still import it. *)
+let non_shard_read_only_tools = descriptor_read_only_tools
 
 let keeper_read_only_tools =
-  Tool_shard.all_read_only_keeper_tools () @ non_shard_read_only_tools
+  Tool_shard.all_read_only_keeper_tools () @ descriptor_read_only_tools
   |> List.sort_uniq String.compare
 ;;
 

--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -40,12 +40,15 @@ val core_always_set : (string, unit) Hashtbl.t
 
 val is_core_always_tool : string -> bool
 
-(** Read-only tools that live outside any [Tool_shard]
-    (e.g. [keeper_tool_search]). *)
+(** Descriptor-projected read-only tools. Kept under the historical
+    [non_shard_read_only_tools] name for callers that still import it. *)
 val non_shard_read_only_tools : string list
 
-(** All read-only keeper tools — shard read-only tools plus
-    [non_shard_read_only_tools], sorted/deduped. *)
+(** Descriptor-projected read-only tools. *)
+val descriptor_read_only_tools : string list
+
+(** All read-only keeper tools — shard read-only tools plus descriptor
+    projections, sorted/deduped. *)
 val keeper_read_only_tools : string list
 
 val keeper_read_only_set : (string, unit) Hashtbl.t

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -345,7 +345,7 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
     | Goal_verify
     | Heartbeat
     | Reset
-    | Status
+    | Status -> Some Mod_room
     | Config
     | Cleanup_zombies
     | Dashboard

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -19,6 +19,7 @@
 
 open Alcotest
 module Descriptor = Masc_mcp.Agent_tool_descriptor
+module Registry = Masc_mcp.Keeper_tool_registry
 module Tool_board_registry = Masc_mcp.Tool_board_registry
 
 let all_descriptors () : Descriptor.t list = Descriptor.all_descriptors ()
@@ -121,6 +122,27 @@ let test_masc_board_registry_has_descriptor_projection () =
        | _ :: _ :: _ -> Alcotest.failf "duplicate descriptor for %s" schema.name)
     Tool_board_registry.tools
 
+let test_readonly_policy_projects_to_registry () =
+  let projected = Descriptor.readonly_internal_names () in
+  List.iter
+    (fun d ->
+      match d.Descriptor.policy.readonly with
+      | Some true ->
+        Alcotest.(check bool)
+          (d.Descriptor.internal_name ^ " is in descriptor readonly projection")
+          true
+          (List.mem d.Descriptor.internal_name projected);
+        Alcotest.(check bool)
+          (d.Descriptor.internal_name ^ " is effectively read-only")
+          true
+          (Registry.is_effectively_read_only_tool d.Descriptor.internal_name)
+      | Some false | None -> ())
+    (all_descriptors ());
+  Alcotest.(check bool)
+    "tool_write_file is not descriptor read-only"
+    false
+    (List.mem "tool_write_file" projected)
+
 let () =
   Alcotest.run
     "agent_tool_descriptor_registry_integrity"
@@ -138,5 +160,11 @@ let () =
             "Tool_board_registry has descriptor projection"
             `Quick
             test_masc_board_registry_has_descriptor_projection
+        ] )
+    ; ( "policy-projection"
+      , [ test_case
+            "descriptor read-only policy projects to registry"
+            `Quick
+            test_readonly_policy_projects_to_registry
         ] )
     ]

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -118,6 +118,12 @@ let () =
               check bool "masc_status -> Mod_room" true
                 (Tool_dispatch.lookup_tag "masc_status"
                  = Some Tool_dispatch.Mod_room);
+              check bool "masc_check -> Mod_room" true
+                (Tool_dispatch.lookup_tag "masc_check"
+                 = Some Tool_dispatch.Mod_room);
+              check bool "masc_goal_list -> Mod_room" true
+                (Tool_dispatch.lookup_tag "masc_goal_list"
+                 = Some Tool_dispatch.Mod_room);
               check bool "tool_execute -> Mod_shard" true
                 (Tool_dispatch.lookup_tag "tool_execute"
                  = Some Tool_dispatch.Mod_shard));


### PR DESCRIPTION
## Summary
- add descriptor-owned read-only projection for internal handler names
- feed Keeper_tool_registry read-only classification from Agent_tool_descriptor instead of a local non-shard string mirror
- add registry integrity coverage that every descriptor readonly policy projects into the effective read-only helper
- fix static tag routing for coord-core tools so masc_status/masc_check/masc_goal_list route to Mod_room instead of Mod_misc

## Validation
- ocamlformat --check lib/tool_dispatch.ml test/test_tool_dispatch.ml lib/keeper/agent_tool_descriptor.ml lib/keeper/agent_tool_descriptor.mli lib/keeper/keeper_tool_registry.ml lib/keeper/keeper_tool_registry.mli test/test_agent_tool_descriptor_registry_integrity.ml
- git diff --check HEAD~2..HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_agent_tool_descriptor_registry_integrity.exe ./test/test_tool_dispatch.exe ./test/test_keeper_tool_alias.exe
- ./_build/default/test/test_agent_tool_descriptor_registry_integrity.exe
- ./_build/default/test/test_tool_dispatch.exe
- ./_build/default/test/test_keeper_tool_alias.exe