### PR TITLE
chore(keeper): purge legacy tool wording from runtime docs

### DIFF
--- a/lib/config/env_config_sandbox.mli
+++ b/lib/config/env_config_sandbox.mli
@@ -92,14 +92,14 @@ module Runtime : sig
       ["masc-keeper-sandbox:local"]. *)
 
   val git_dispatch : unit -> bool
-  (** When true, keeper_bash commands beginning with ["git "] or
+  (** When true, Execute commands beginning with ["git "] or
       ["gh "] run in a dedicated container with network egress and
       read-only mounts from the selected root/keeper GitHub identity
       bundle.
       Env: [MASC_KEEPER_SANDBOX_GIT_DISPATCH].  Default: [true]. *)
 
   val docker_playground_enabled : unit -> bool
-  (** Route keeper_bash through a Docker container instead of local
+  (** Route Execute through a Docker container instead of local
       subprocess.
       Env: [MASC_KEEPER_DOCKER_PLAYGROUND].  Default: [false]. *)
 
@@ -166,7 +166,7 @@ module Shell_timeout : sig
             cause cascading 401 retries (see #8688).  15s. *)
     | User_max
         (** Upper bound for user-provided [timeout_sec] in
-            keeper_bash.  180s. *)
+            Execute.  180s. *)
     | Cleanup_rm
         (** [docker rm -f] timeout used by turn-scoped cleanup.
             Currently hardcoded 5.0 in

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -321,7 +321,7 @@ let docker_playground_entries =
     entry ~default:"keeper-playground" "MASC_KEEPER_DOCKER_CONTAINER"
       "Docker container name for keeper playground";
     entry ~default:"(none)" "MASC_KEEPER_DOCKER_PLAYGROUND"
-      "Route keeper_bash through Docker container (feature flag)";
+      "Route Execute through Docker container (feature flag)";
   ]
 
 let keeper_sandbox_entries =

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -146,7 +146,7 @@ let all_flags : flag list = [
     lifecycle = Active; since = "2.214.0" };
 
   { env_name = "MASC_KEEPER_DOCKER_PLAYGROUND";
-    description = "Route keeper_bash commands through Docker container";
+    description = "Route Execute commands through Docker container";
     default = false; category = "keeper";
     lifecycle = Active; since = "2.233.0" };
 

--- a/lib/exec/exec_semantic.ml
+++ b/lib/exec/exec_semantic.ml
@@ -140,7 +140,7 @@ let enabled () =
      to default-on.  They are purely additive JSON keys, so no
      downstream consumer parses them as required — turning the
      flag on by default surfaces the typed exit classification to
-     every [keeper_bash] response without an operator opt-in.
+     every Execute response without an operator opt-in.
      [MASC_BASH_SEMANTIC_EXIT=0] remains the explicit off switch
      for the rare caller that wants the pre-P1 byte-identical
      shape.  A later minor bump will remove the flag entirely. *)

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -131,9 +131,9 @@ let extract_method_from_parts parts =
       Some
         (String.uppercase_ascii (String.sub tok 9 (String.length tok - 9)))
     (* gh accepts `-X<METHOD>` as a single token. Stress test
-       2026-05-26: `gh api -XDELETE /repos/o/r` fell through to GET → R0
-       even though six callers (keeper_shell_bash, keeper_shell_ir, etc.)
-       depend on this for the live gate. *)
+       2026-05-26: `gh api -XDELETE /repos/o/r` fell through to GET -> R0
+       even though Execute, Shell IR, and worker-dev dispatch paths depend on
+       this for the live gate. *)
     | tok :: _rest
       when String.length tok > 2
            && String.starts_with ~prefix:"-X" tok

--- a/lib/exec/test/test_shell_ir_risk_gh_stress.ml
+++ b/lib/exec/test/test_shell_ir_risk_gh_stress.ml
@@ -1,5 +1,5 @@
 (* Stress test the REAL gh classifier (Shell_ir_risk.classify_gh) used by
-   keeper_shell_bash, keeper_shell_ir, exec_dispatch, worker_dev_tools.
+   Execute, Shell IR, exec_dispatch, worker_dev_tools.
    Mirrors test_shell_ir_github_stress.ml but on the live code path. *)
 
 module Risk = Masc_exec.Shell_ir_risk

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -381,7 +381,7 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
          the soft-forbidden check.  A routine match is the operator's
          pre-blessed exception to the substring-based
          [destructive_tool_or_op] filter (which today blocks every
-         keeper_shell call regardless of op).  The hard-forbidden
+         structured search call regardless of op).  The hard-forbidden
          component (Critical risk or a runtime blocker) is still
          evaluated, so a routine match cannot bypass real safety
          walls — only the pattern-matching overlay. *)

--- a/lib/keeper/agent_tool_filesystem_runtime.ml
+++ b/lib/keeper/agent_tool_filesystem_runtime.ml
@@ -86,7 +86,7 @@ let handle_read_file
        playground bundle on the host before any read-side I/O proceeds.
        The resolver-level allowed_paths check is augmented by this
        strict containment so host FS cannot leak through ReadFile
-       while keeper_bash is container-isolated. *)
+       while Execute is container-isolated. *)
        (match Keeper_sandbox_containment.check_read_target ~config ~meta ~target with
         | Error e -> error_json ~fields:[ "path", `String target ] e
         | Ok () ->

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -67,7 +67,7 @@ let handle_filesystem ctx descriptor args =
    Agent_tool_shell_runtime wrapper that only renames Keeper_exec_shell
    functions would be substitution, not abstraction — it would preserve the
    coupling while reducing readability. Re-evaluate only if Shell IR
-   substantive logic moves out of keeper_shell_* into a descriptor-owned
+   substantive logic moves out of legacy shell modules into a descriptor-owned
    module. *)
 let handle_shell_ir ctx descriptor args =
   match descriptor.Agent_tool_descriptor.runtime_handler with

--- a/lib/keeper/dev_exec_allowlist.mli
+++ b/lib/keeper/dev_exec_allowlist.mli
@@ -18,7 +18,7 @@ val dev_programs : Masc_exec.Exec_program.known list
 val dev : string list
 (** [List.map Masc_exec.Exec_program.name_of_known dev_programs]. Executables permitted for
     full dev presets (Coding/Full). Used by [Worker_dev_tools] when dispatching
-    keeper_bash for keepers with elevated dev capability. *)
+    Execute for keepers with elevated dev capability. *)
 
 val readonly_programs : Masc_exec.Exec_program.known list
 (** Typed executable vocabulary for read-only presets. *)

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -604,7 +604,7 @@ let preferred_tool_choice_for_required_tool_names
   | _ :: _ ->
     (* Use the provider-level "some tool is required" contract here, even
        for a single explicit required tool. Runtime MCP transports may return
-       names such as [mcp__masc__keeper_shell]; OAS exact-tool contracts
+       legacy internal MCP names; OAS exact-tool contracts
        compare raw names before MASC can canonicalize them, so exact Tool(name)
        can reject a correct call. MASC still validates the specific required
        names after execution via [outstanding_required_tool_names]. *)

--- a/lib/keeper/keeper_cli_mcp_config.ml
+++ b/lib/keeper/keeper_cli_mcp_config.ml
@@ -4,7 +4,7 @@
 
    Without this fallback, affected CLI providers launch with no [mcpServers]
    entry and the keeper cannot reach the masc-mcp HTTP
-   endpoint; tool calls surface as "keeper_shell not in session's tool
+   endpoint; tool calls surface as "tool not in session's tool
    registry". See #10049 for the full root-cause analysis and the
    cli_tool_a sibling path in [server_runtime_bootstrap.sync_codex_mcp_config].
 

--- a/lib/keeper/keeper_exec_shared.mli
+++ b/lib/keeper/keeper_exec_shared.mli
@@ -150,7 +150,7 @@ val keeper_agent_sender : meta:Keeper_types.keeper_meta -> string
 val shell_readonly_limit : Yojson.Safe.t -> int
 
 (** Clamp [args.max_bytes] to [256..100000] (default 4000) for
-    [keeper_shell op=cat]. *)
+    the structured [cat] read operation. *)
 val shell_readonly_cat_max_bytes : Yojson.Safe.t -> int
 
 (** Project [text] to a JSON array of lines, capped by [limit]

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -32,7 +32,7 @@ let rewrite_docker_host_paths_to_container =
 
 include Keeper_shell_bash
 
-(* TEL-OK: facade alias only; Keeper_shell_bash.handle_keeper_shell_ir owns
+(* TEL-OK: facade alias only; the Execute handler owns
    execution telemetry and history recording. *)
 let handle_tool_execute = Keeper_shell_bash.handle_keeper_shell_ir
 

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -36,7 +36,7 @@ val tool_dispatch_min_timeout_sec : float
     sub-I/O-latency values. *)
 
 val keeper_shell_ir_native_min_timeout_sec : float
-(** Minimum timeout_sec floor applied to keeper_shell_ir on the *native*
+(** Minimum timeout_sec floor applied to Shell IR on the *native*
     executor path. Exposed so regression tests can lock the floor
     against drift back to sub-I/O-latency values.  Container-backed
     dispatch paths re-clamp independently inside their backend. *)

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -35,20 +35,20 @@ let ensure_dir (path : string) : string =
               Keeper_metrics.metric_keeper_fs_failures
               ~labels:[("path", path); ("site", Keeper_fs_failure_site.(to_label Ensure_dir_cancelled))]
               ();
-            Log.Keeper.warn "keeper_fs: ensure_dir cancelled path=%s" path;
+            Log.Keeper.warn "filesystem_runtime: ensure_dir cancelled path=%s" path;
             Error (exn, Printexc.get_raw_backtrace ())
         | exn ->
             Keeper_fd_pressure.note_exception
-              ~site:"keeper_fs.ensure_dir"
+              ~site:"filesystem_runtime.ensure_dir"
               exn;
             Keeper_disk_pressure.note_exception
-              ~site:"keeper_fs.ensure_dir"
+              ~site:"filesystem_runtime.ensure_dir"
               exn;
             Prometheus.inc_counter
               Keeper_metrics.metric_keeper_fs_failures
               ~labels:[("path", path); ("site", Keeper_fs_failure_site.(to_label Ensure_dir_failed))]
               ();
-            Log.Keeper.warn "keeper_fs: ensure_dir failed path=%s: %s"
+            Log.Keeper.warn "filesystem_runtime: ensure_dir failed path=%s: %s"
               path (Printexc.to_string exn);
             Error (exn, Printexc.get_raw_backtrace ())
       with
@@ -84,32 +84,32 @@ let save_atomic (path : string) (content : string) : (unit, string) result =
     | Ok () -> Ok ()
     | Error msg ->
         Keeper_fd_pressure.note_if_fd_exhaustion
-          ~site:"keeper_fs.save_atomic"
+          ~site:"filesystem_runtime.save_atomic"
           msg;
         Keeper_disk_pressure.note_if_disk_exhaustion
-          ~site:"keeper_fs.save_atomic"
+          ~site:"filesystem_runtime.save_atomic"
           msg;
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_fs_failures
           ~labels:[("path", path); ("site", Keeper_fs_failure_site.(to_label Save_atomic_failed))]
           ();
-        Log.Keeper.warn "keeper_fs: save_atomic failed path=%s error=%s" path msg;
+        Log.Keeper.warn "filesystem_runtime: save_atomic failed path=%s error=%s" path msg;
         Error msg
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
       let msg = Printexc.to_string exn in
       Keeper_fd_pressure.note_exception
-        ~site:"keeper_fs.save_atomic"
+        ~site:"filesystem_runtime.save_atomic"
         exn;
       Keeper_disk_pressure.note_exception
-        ~site:"keeper_fs.save_atomic"
+        ~site:"filesystem_runtime.save_atomic"
         exn;
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_fs_failures
         ~labels:[("path", path); ("site", Keeper_fs_failure_site.(to_label Save_atomic_raised))]
         ();
-      Log.Keeper.warn "keeper_fs: save_atomic raised path=%s error=%s" path msg;
+      Log.Keeper.warn "filesystem_runtime: save_atomic raised path=%s error=%s" path msg;
       Error msg
 
 (** Atomically save a Yojson value as pretty-printed JSON. *)

--- a/lib/keeper/keeper_fs_failure_site.mli
+++ b/lib/keeper/keeper_fs_failure_site.mli
@@ -1,7 +1,6 @@
-(** Keeper_fs_failure_site — closed sum for the [site] label on
-    [metric_keeper_fs_failures].
+(** Filesystem runtime failure-site labels.
 
-    Replaces 4 hardcoded literals in [keeper_fs.ml].  Each value names
+    Replaces hardcoded literals in the filesystem runtime.  Each value names
     a distinct failure path in keeper-side filesystem helpers. *)
 
 type t =

--- a/lib/keeper/keeper_routine_allowlist.ml
+++ b/lib/keeper/keeper_routine_allowlist.ml
@@ -7,12 +7,12 @@ module RL = Keeper_approval_queue
 
 (** Extract a routine action from a tool input JSON.
 
-    Tools in the allowlist use either an [op] key (keeper_shell,
-    keeper_bash) or an [action] key (masc_transition family); we
+    Tools in the allowlist use either an [op] key (structured search /
+    Execute family) or an [action] key (masc_transition family); we
     accept both so a single rule type can describe both surfaces.
     Prefer [op] when it is present because shell execution semantics
     come from [op], and an unrelated [action] key must not be able to
-    mask a dangerous shell op. *)
+      mask a dangerous command op. *)
 let action_of_input (input : Yojson.Safe.t) : string option =
   let trimmed_lc raw =
     let s = String.trim raw in

--- a/lib/keeper/keeper_routine_allowlist.mli
+++ b/lib/keeper/keeper_routine_allowlist.mli
@@ -29,7 +29,7 @@
     - [keeper_board_post]: any post at risk Low or Medium.
     - [keeper_task_claim], [keeper_task_done],
       [keeper_task_submit_for_verification]: standard autonomous flow.
-    - [keeper_shell] has no routine auto-approval rule.
+    - Structured search has no routine auto-approval rule.
 
     These rules are not persisted; they are part of the policy code surface
     and require code review to change. Operator-managed rules continue to

--- a/lib/keeper/keeper_run_tools_search.ml
+++ b/lib/keeper/keeper_run_tools_search.ml
@@ -6,7 +6,7 @@ type tool_search_hit_partition =
 
 let partition_tool_search_hits ~core ~core_always ~allowed ~retrieved ~max_results =
   (* PR #14574 review #1/#7: only expose a public alias (e.g. "Execute") when
-     its routed internal handler (e.g. [keeper_bash]) is actually in the
+     its routed internal handler is actually in the
      incoming [allowed] set for this preset. Adding all [public_names ()]
      unconditionally let [keeper_tool_search] return aliases even when
      their backing tool was not permitted for the turn, which would invite

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -353,7 +353,7 @@ let prepare_agent_setup
 
      Order matters: compute [aliased_public_names] against the UNFILTERED
      internal allowlist, because tool_policy.toml / presets still express
-     allowlists in internal names (keeper_bash, tool_read_file, ...).
+     allowlists in descriptor/internal names (tool_execute, tool_read_file, ...).
      Stripping internals before the alias-expansion check would leave
      [aliased_public_names] empty and drop "Execute"/"ReadFile"/... from the
      visible surface. See PR #14596 review. *)

--- a/lib/keeper/keeper_sandbox_containment.mli
+++ b/lib/keeper/keeper_sandbox_containment.mli
@@ -2,8 +2,8 @@
     keepers (RFC-0006 Phase B-1).
 
     The keeper sandbox boundary historically followed the tool name:
-    [keeper_bash] for [sandbox_profile=Docker] keepers ran in a
-    container, but [ReadFile] / [EditFile/WriteFile] / [keeper_shell]
+    Execute for [sandbox_profile=Docker] keepers ran in a
+    container, but [ReadFile] / [EditFile/WriteFile] / structured search
     could touch the host directly. The result was a cross-tool leak:
     different tools enforced different boundaries for the same keeper.
 

--- a/lib/keeper/keeper_sandbox_docker_nested_runtime.ml
+++ b/lib/keeper/keeper_sandbox_docker_nested_runtime.ml
@@ -1,4 +1,4 @@
-(* Nested-container runtime detection for keeper_bash sandboxing.
+(* Nested-container runtime detection for Execute sandboxing.
 
    When the sandbox profile forbids spawning Docker/Podman/nerdctl/
    buildah from inside a sandboxed keeper, this module statically

--- a/lib/keeper/keeper_sandbox_docker_nested_runtime.mli
+++ b/lib/keeper/keeper_sandbox_docker_nested_runtime.mli
@@ -1,4 +1,4 @@
-(** Nested-container runtime detection for keeper_bash sandboxing.
+(** Nested-container runtime detection for Execute sandboxing.
 
     Statically detects whether a shell command would spawn a nested
     Docker/Podman/nerdctl/buildah runtime (or touch a container daemon

--- a/lib/keeper/keeper_sandbox_exec_failure.ml
+++ b/lib/keeper/keeper_sandbox_exec_failure.ml
@@ -1,7 +1,7 @@
 (** Sandbox backend exec failure formatting + recording.
 
     Owns backend failure messages and keeper-registry recording. The
-    command surface ([keeper_bash], [keeper_shell], PR tools, etc.) is
+    command surface (Execute, structured search, PR tools, etc.) is
     intentionally not part of this module name because the same sandbox
     backend failure can be reached through multiple tools.
 

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -26,7 +26,7 @@ module For_testing = struct
     deterministic_retry_fields_for_process_result
 end
 
-(* Typed keeper_bash input projections extracted to
+(* Typed Execute input projections extracted to
    [Keeper_shell_bash_typed_input] (godfile decomp). *)
 let has_typed_bash_input_key = Keeper_shell_bash_typed_input.has_typed_bash_input_key
 let assoc_upsert = Keeper_shell_bash_typed_input.assoc_upsert
@@ -234,7 +234,7 @@ let handle_keeper_shell_ir_typed
               elapsed_duration_ms ~start_time:t0 ~end_time:(Unix.gettimeofday ())
             in
             Log.Keeper.info
-              "keeper_shell_ir dispatch keeper=%s sandbox=%s status=%s elapsed_ms=%d"
+              "shell_ir dispatch keeper=%s sandbox=%s status=%s elapsed_ms=%d"
               meta.name
               (Keeper_types.sandbox_profile_to_string sandbox_profile)
               (Keeper_sandbox_exec_failure.status_label result.status)

--- a/lib/keeper/keeper_shell_bash_typed_input.ml
+++ b/lib/keeper/keeper_shell_bash_typed_input.ml
@@ -1,4 +1,4 @@
-(* Typed keeper_bash input projections.
+(* Typed Execute input projections.
 
    Static helpers around [Keeper_tool_bash_input] - quote a token for
    policy strings, render an [Exec]/[Pipeline] back to a shell-command

--- a/lib/keeper/keeper_shell_bash_typed_input.mli
+++ b/lib/keeper/keeper_shell_bash_typed_input.mli
@@ -1,4 +1,4 @@
-(** Typed keeper_bash input projections (quote, render, validate). *)
+(** Typed Execute input projections (quote, render, validate). *)
 
 val has_typed_bash_input_key : Yojson.Safe.t -> bool
 val assoc_upsert : string -> Yojson.Safe.t -> Yojson.Safe.t -> Yojson.Safe.t

--- a/lib/keeper/keeper_shell_ir.ml
+++ b/lib/keeper/keeper_shell_ir.ml
@@ -101,8 +101,8 @@ let coding_command_context
            reason))
 ;;
 
-(* TEL-OK: facade is pure gate/path/dispatch routing; keeper_shell_bash emits
-   keeper_shell_ir dispatch telemetry with keeper, sandbox, status, elapsed_ms. *)
+(* TEL-OK: facade is pure gate/path/dispatch routing; the Execute handler emits
+   Shell IR dispatch telemetry with keeper, sandbox, status, elapsed_ms. *)
 let dispatch_classified
       ?timeout_sec
       ?before_path_validation

--- a/lib/keeper/keeper_shell_op.mli
+++ b/lib/keeper/keeper_shell_op.mli
@@ -1,4 +1,4 @@
-(** Shell operation vocabulary for the structured [keeper_shell] surface. *)
+(** Shell operation vocabulary for the structured SearchFiles surface. *)
 
 type t =
   | Pwd

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -1,4 +1,4 @@
-(* keeper_shell_ops - SearchFiles operation handlers.
+(* SearchFiles operation handlers.
 
    Read/list/search operations live in Keeper_shell_read_ops. This facade keeps
    alias parsing, remaining git mutation-ish helpers, and unsupported-op

--- a/lib/keeper/keeper_shell_ops_setup.ml
+++ b/lib/keeper/keeper_shell_ops_setup.ml
@@ -1,8 +1,8 @@
-(* keeper_shell_ops_setup — module-level setup for keeper_shell_ops:
+(* SearchFiles operation setup:
     coreutils resolution, Prometheus metric, history observation,
     and the shared process-result renderer.
 
-    Extracted from keeper_shell_ops.ml as part of godfile near-threshold split. *)
+    Extracted from the SearchFiles dispatcher as part of godfile near-threshold split. *)
 
 open Keeper_types
 open Keeper_exec_shared
@@ -28,7 +28,7 @@ let () =
     ~name:metric_bash_history_append_failures
     ~help:
       "Total bash-history audit append failures observed at \
-       keeper_shell_ops. Bash_history.append returned Error (Sys_error \
+       SearchFiles setup. Bash_history.append returned Error (Sys_error \
        from open/write/close). Decoupled from tool-call success/failure. \
        No labels."
     ()

--- a/lib/keeper/keeper_shell_read_ops.ml
+++ b/lib/keeper/keeper_shell_read_ops.ml
@@ -1,7 +1,7 @@
-(* Keeper_shell_read_ops — read-side operation handlers for keeper_shell.
+(* Keeper_shell_read_ops — read-side operation handlers for SearchFiles.
 
    This module owns structured read/list/search operations so
-   Keeper_shell_ops stays as the public dispatcher instead of reabsorbing
+   the SearchFiles facade stays as the public dispatcher instead of reabsorbing
    read-backend, path-resolution, and host Shell IR details. *)
 
 open Keeper_types

--- a/lib/keeper/keeper_shell_read_ops.mli
+++ b/lib/keeper/keeper_shell_read_ops.mli
@@ -1,4 +1,4 @@
-(* Keeper_shell_read_ops — structured read-side keeper_shell operations. *)
+(* Keeper_shell_read_ops — structured read-side SearchFiles operations. *)
 
 val try_handle :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->

--- a/lib/keeper/keeper_tool_bash_input.mli
+++ b/lib/keeper/keeper_tool_bash_input.mli
@@ -1,4 +1,4 @@
-(** Typed argv schema for the keeper_bash tool.
+(** Typed argv schema for Execute.
 
     Introduced by RFC-0091 PR-1 (§5.1.1) to replace raw
     command-string parsing with a structured executable/argv boundary.
@@ -73,7 +73,7 @@ type validation_error =
   | Env_key_invalid of string
 
 val of_json : Yojson.Safe.t -> (bash_input, string) result
-(** Parse the typed keeper_bash JSON boundary.  Accepts either
+(** Parse the typed Execute JSON boundary.  Accepts either
     [{executable, argv?, cwd?, env?, timeout_sec?}] for [Exec] or
     [{pipeline = [{executable, argv?}, ...], cwd?, env?}] for [Pipeline].
     [{stages = ...}] is accepted as an equivalent structured pipeline key.

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -340,7 +340,7 @@ let transient_mutex_contention_tool_error
 (** RFC-0006 Phase A.2: build the per-tool handler closure.
 
     Extracted from the original anonymous closure inside [make_tools] so
-    that alias [Tool.t] entries (e.g. [Execute] -> [keeper_bash]) can reuse
+    that alias [Tool.t] entries (e.g. [Execute]) can reuse
     the exact same telemetry/circuit-breaker/decision-log pipeline by
     instantiating this helper with the INTERNAL name as [~name].
 

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -46,7 +46,7 @@ let make_tool_bundle
   let universe_names = Keeper_exec_tools.keeper_universe_tool_names meta in
   let tool_defs = Keeper_exec_tools.keeper_universe_model_tools meta in
   (* RFC-0064 Phase 2 (Copilot review #14662 threads 5/6): aliased internal
-     names (e.g. keeper_bash backing public alias Execute) must NOT appear on
+     names backing public aliases must NOT appear on
      the LLM-visible surface alongside their public alias.  Mirrors the
      pattern already established in [keeper_run_tools.ml] PRs #14574/#14596. *)
   let aliased_internal_names =

--- a/lib/tool_shard_types.mli
+++ b/lib/tool_shard_types.mli
@@ -66,10 +66,10 @@ val board_tools : Masc_domain.tool_schema list
 (** Pure: keeper_board tool schemas. *)
 
 val filesystem_tools : Masc_domain.tool_schema list
-(** Pure: keeper_fs tool schemas. *)
+(** Pure: file tool schemas. *)
 
 val shell_tools : Masc_domain.tool_schema list
-(** Pure: keeper_shell tool schemas. *)
+(** Pure: structured search tool schemas. *)
 
 val typed_execute_tools : Masc_domain.tool_schema list
 (** Pure: typed execution tool schemas. *)


### PR DESCRIPTION
## Summary

- replace remaining legacy `keeper_bash` / `keeper_shell` / `keeper_fs` wording in runtime docs, env descriptions, and tool-surface comments with Execute, SearchFiles, or filesystem runtime terminology
- remove legacy names from user-visible logs/site labels for filesystem helper failures and Shell IR dispatch telemetry
- keep metric identifiers and internal function names unchanged for this slice; those are compatibility/ABI surfaces and should be handled in a dedicated rename PR

## Validation

- `git diff --check origin/main..HEAD`
- no-match `rg` check for legacy public/tool family names across `config`, prompt/tool surface config, env config, and OAS/tool-surface files
- `opam exec -- ocamlformat --check <changed ml/mli files>`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_INCLUDE_OPERATOR_CONTROL=true scripts/dune-local.sh build test/test_keeper_bash_safety.exe test/test_keeper_bash_typed_input.exe test/test_keeper_sandbox_boundary_policy.exe lib/exec/test/test_shell_ir_risk_gh_stress.exe`
- `./_build/default/test/test_keeper_bash_typed_input.exe`
- `./_build/default/lib/exec/test/test_shell_ir_risk_gh_stress.exe`
- `./_build/default/test/test_keeper_bash_safety.exe test edge 1 --show-errors`
