### PR TITLE
feat(tool_agent_timeline): RFC-0189 PR-1b.13 — typed result for handle_agent_timeline + dispatch lift

### DIFF
--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -644,11 +644,23 @@ let schemas : Masc_domain.tool_schema list =
     };
   ]
 
-(* Handler *)
-let handle_agent_timeline ~tool_name ~start_time (ctx : context) args : tool_result =
+(* RFC-0189 PR-1b.13 — typed result. Caller-input violation
+   ("agent_name is required") tagged [Workflow_rejection]; success
+   carries the [build_timeline] [Yojson.Safe.t] envelope as
+   [~data:json] first-class (drops the [Yojson.Safe.to_string]
+   round-trip). [dispatch] keeps [Tool_result.t option] ABI for the
+   4 external callers via the single [lift] closure. *)
+
+let handle_agent_timeline ~tool_name ~start_time (ctx : context) args
+  : Tool_result.result
+  =
   let agent_name = get_string args "agent_name" "" in
   if String.length agent_name = 0 then
-    Tool_result.error ~tool_name ~start_time "agent_name is required"
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      "agent_name is required"
   else
     let since_hours = get_float args "since_hours" 24.0 in
     let limit = get_int args "limit" 50 in
@@ -659,13 +671,14 @@ let handle_agent_timeline ~tool_name ~start_time (ctx : context) args : tool_res
       build_timeline ctx.config ~agent_name ~since_hours ~limit ~include_tasks
         ~include_board ~include_tool_calls
     in
-    Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string json)
+    Tool_result.make_ok ~tool_name ~start_time ~data:json ()
 
-(* Dispatch *)
 let dispatch (ctx : context) ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
+  let lift r = Some (Tool_result.to_legacy r) in
   match name with
-  | "masc_agent_timeline" -> Some (handle_agent_timeline ~tool_name:name ~start_time:start ctx args)
+  | "masc_agent_timeline" ->
+      lift (handle_agent_timeline ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 
 (* ================================================================ *)


### PR DESCRIPTION
## Summary

RFC-0189 PR-1b.13 — `tool_agent_timeline.ml` (1 handler, 4 calls, 4 external callers). Smallest independent cluster left in RFC-0189 work.

## Migration

```ocaml
let handle_agent_timeline ~tool_name ~start_time (ctx : context) args
  : Tool_result.result
  =
  let agent_name = get_string args "agent_name" "" in
  if String.length agent_name = 0 then
    Tool_result.make_err
      ~tool_name ~class_:Tool_result.Workflow_rejection
      ~start_time "agent_name is required"
  else
    ...
    let json = build_timeline ctx.config ~agent_name ... in
    Tool_result.make_ok ~tool_name ~start_time ~data:json ()
```

`build_timeline` already returns `Yojson.Safe.t` — dropping the `Yojson.Safe.to_string` round-trip keeps the structured envelope first-class until `to_legacy` regenerates the serialized form at the boundary.

## Failure-class mapping

| Site | Class |
|---|---|
| `"agent_name is required"` | `Workflow_rejection` (only error site) |

No `Runtime_failure` / `Transient_error` — `build_timeline` reads 6 event sources and assumes-success or raises.

## Dispatch boundary

`Tool_result.t option` ABI preserved via single `lift` closure. External callers (`mcp_server_eio_execute`, `server_dashboard_http_agent_api` via `build_timeline`, `config.ml` schemas, `keeper_tag_dispatch`) unchanged.

## Verification

- `dune build --root . --cache=disabled lib/` exit 0
- `test_tool_result.exe`: **20/20 PASS**

## RFC-0189 progress

| Item | Status |
|---|---|
| PR-1a..PR-1b.11 + supporting | ✅ 20 merged |
| PR-1b.12 tool_misc_admin | 🟦 #18778 in review |
| **PR-1b.13** (this) | 🟦 Draft |
| PR-1b.14+ | tool_agent (5h) / Tool_deep_review / tool_coord (7 callers, fan-out) |
| task RFC | separate |
| PR-1c | accessor migration |
| PR-2 | legacy purge |

## Test plan

- [x] `dune build --root . --cache=disabled lib/`
- [x] `test_tool_result.exe` 20/20
- [ ] CI green (Draft)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
