### PR TITLE
feat(tool_inline_dispatch): RFC-0189 PR-1b.14 — typed result for 12 inline dispatch match arms

### DIFF
--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -118,6 +118,39 @@ module For_testing = struct
   let discover_tools_json = discover_tools_json
 end
 
+(* RFC-0189 PR-1b: typed [Tool_result.result] constructors lifted to
+   [Tool_result.t] at the dispatch boundary so [dispatch]'s
+   [Tool_result.t option] return type stays compatible with the sole
+   external caller [Mcp_server_eio_execute].  Two patterns:
+
+   - [inline_ok] handles both plain-text and JSON-string success bodies.
+     [structured_payload_of_message] lifts JSON envelopes into [data];
+     plain strings fall through as [`String body].  Matches the canonical
+     pattern from #18767 so callers that round-trip through
+     [result.message] still see the original body.
+   - [inline_err_workflow] commits caller-input rejections to
+     [Workflow_rejection]: every error path in this dispatch
+     ("id is required", unknown enum action, "query is required",
+     not-found lookups, approval-resolve errors) is caller-side. *)
+let inline_ok ~tool_name ~start_time body : Tool_result.t =
+  let data =
+    match Tool_result.structured_payload_of_message body with
+    | Some json -> json
+    | None -> `String body
+  in
+  Tool_result.to_legacy
+    (Tool_result.make_ok ~tool_name ~start_time ~data ())
+;;
+
+let inline_err_workflow ~tool_name ~start_time msg : Tool_result.t =
+  Tool_result.to_legacy
+    (Tool_result.make_err
+       ~tool_name
+       ~class_:Tool_result.Workflow_rejection
+       ~start_time
+       msg)
+;;
+
 (** Dispatch a tool call.
     Returns [Some (Tool_result.t)] if the tool name is handled,
     [None] if the tool name is not recognized by this module. *)
@@ -176,22 +209,22 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.t option =
   (* ── Approval queue (#5907) ─────────────────────────────────── *)
   | "masc_approval_pending" ->
       let json = Keeper_approval_queue.list_pending_json () in
-      Some (Tool_result.ok ~tool_name:name ~start_time:start (Yojson.Safe.to_string json))
+      Some (inline_ok ~tool_name:name ~start_time:start (Yojson.Safe.to_string json))
   | "masc_approval_get" ->
       let id = arg_get_string "id" "" in
-      if String.equal id "" then Some (Tool_result.error ~tool_name:name ~start_time:start "id is required")
+      if String.equal id "" then Some (inline_err_workflow ~tool_name:name ~start_time:start "id is required")
       else
         (match Keeper_approval_queue.get_pending_json ~id with
-         | Some json -> Some (Tool_result.ok ~tool_name:name ~start_time:start (Yojson.Safe.to_string json))
+         | Some json -> Some (inline_ok ~tool_name:name ~start_time:start (Yojson.Safe.to_string json))
          | None ->
-           Some (Tool_result.error ~tool_name:name ~start_time:start
+           Some (inline_err_workflow ~tool_name:name ~start_time:start
              (Printf.sprintf
                "approval %s is no longer pending or was not found. Refresh with masc_approval_pending before approving/rejecting."
                id)))
   | "masc_approval_resolve" ->
       let id = arg_get_string "id" "" in
       let decision_str = arg_get_string "decision" "approve" in
-      if String.equal id "" then Some (Tool_result.error ~tool_name:name ~start_time:start "id is required")
+      if String.equal id "" then Some (inline_err_workflow ~tool_name:name ~start_time:start "id is required")
       else
         let decision = match String.lowercase_ascii decision_str with
           | "approve" -> Agent_sdk.Hooks.Approve
@@ -202,10 +235,10 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.t option =
         in
         (match Keeper_approval_queue.resolve ~id ~decision with
          | Ok () ->
-           Some (Tool_result.ok ~tool_name:name ~start_time:start
+           Some (inline_ok ~tool_name:name ~start_time:start
              (Printf.sprintf "{\"resolved\":\"%s\",\"decision\":\"%s\"}" id decision_str))
          | Error err ->
-           Some (Tool_result.error ~tool_name:name ~start_time:start
+           Some (inline_err_workflow ~tool_name:name ~start_time:start
              (Keeper_approval_queue.resolve_error_to_string err)))
 
   (* Verification tools removed: pruned *)
@@ -218,7 +251,7 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.t option =
       let raw = arg_get_string "action" "" in
       (match Mcp_session.action_of_string_opt raw with
        | None ->
-         Some (Tool_result.error ~tool_name:name ~start_time:start
+         Some (inline_err_workflow ~tool_name:name ~start_time:start
            (Printf.sprintf
              "action must be one of [%s]; got %S"
              (String.concat "|" Mcp_session.valid_action_strings) raw))
@@ -278,8 +311,8 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.t option =
             end
       in
       (match response with
-       | Ok json -> Some (Tool_result.ok ~tool_name:name ~start_time:start (Yojson.Safe.to_string json))
-       | Error e -> Some (Tool_result.error ~tool_name:name ~start_time:start e)))
+       | Ok json -> Some (inline_ok ~tool_name:name ~start_time:start (Yojson.Safe.to_string json))
+       | Error e -> Some (inline_err_workflow ~tool_name:name ~start_time:start e)))
 
   (* Infrastructure tools: cancellation, subscription, progress,
      governance_set, masc_spawn removed — pruned from surfaces *)
@@ -289,11 +322,11 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.t option =
       let query = arg_get_string "query" "" in
       let limit = arg_get_int "limit" 20 in
       if String.equal (String.trim query) "" then
-        Some (Tool_result.error ~tool_name:name ~start_time:start "query is required")
+        Some (inline_err_workflow ~tool_name:name ~start_time:start "query is required")
       else
         let all_schemas = Config.visible_tool_schemas ~include_hidden:true () in
         let payload = discover_tools_json ~query ~limit all_schemas in
-        Some (Tool_result.ok ~tool_name:name ~start_time:start (Yojson.Safe.to_string payload))
+        Some (inline_ok ~tool_name:name ~start_time:start (Yojson.Safe.to_string payload))
 
   (* ── Fallthrough to extra dispatch ──────────────────────────── *)
   | _ ->


### PR DESCRIPTION
## Summary

**Next cluster in the RFC-0189 §3.2 migration.** Promotes the 12 legacy `Tool_result.ok` / `Tool_result.error` call sites in `Tool_inline_dispatch.dispatch` to typed constructors. Unlike PR-1b.5/6/7/8/10/12 which migrated handler-function returns, this module has no exposed `handle_*` — all 12 sites live inline inside the dispatch match arms, so the boundary lift happens at each site via two module-local helpers that return `Tool_result.t` directly through `Tool_result.to_legacy`.

External caller (`Mcp_server_eio_execute` at `mcp_server_eio_execute.ml:582`) still receives `Tool_result.t option`. Identical argument lists at every site; the only diff is `Tool_result.ok`/`Tool_result.error` → `inline_ok`/`inline_err_workflow`.

## Local helpers (2 patterns)

```ocaml
let inline_ok ~tool_name ~start_time body : Tool_result.t =
  let data =
    match Tool_result.structured_payload_of_message body with
    | Some json -> json
    | None -> `String body
  in
  Tool_result.to_legacy
    (Tool_result.make_ok ~tool_name ~start_time ~data ())

let inline_err_workflow ~tool_name ~start_time msg : Tool_result.t =
  Tool_result.to_legacy
    (Tool_result.make_err
       ~tool_name
       ~class_:Tool_result.Workflow_rejection
       ~start_time
       msg)
```

`inline_ok` uses the canonical `structured_payload_of_message` fallback from #18767 — JSON envelopes from `Yojson.Safe.to_string` lift into `data`, plain text falls through as `` `String body``; `to_legacy.message` regenerates the original body for callers that round-trip through `result.message`.

## Failure-class mapping (all Workflow_rejection)

| Site | Trigger |
|---|---|
| `masc_approval_get` (line 215) | "id is required" |
| `masc_approval_get` (line 220-223) | "approval ... no longer pending or was not found" |
| `masc_approval_resolve` (line 227) | "id is required" |
| `masc_approval_resolve` (line 241-242) | `Keeper_approval_queue.resolve_error_to_string` (caller validation) |
| `masc_mcp_session` (line 254-257) | unknown enum action |
| `masc_mcp_session` (line 315) | not-found session_id |
| `masc_discover_tools` (line 325) | "query is required" |

All 7 error sites are caller-input rejections. No `Runtime_failure` paths in this dispatcher (`Keeper_approval_queue`, `Mcp_session`, and `Mcp_server_eio_governance` operations are total over the parsed input space; storage failures would surface through the wrapping exception barrier in `Mcp_server_eio_execute`, not here).

## What's in this PR

```
 lib/tool_inline_dispatch.ml | +45 -12   (2 local helpers + 12 site swap)
 1 file changed, 45 insertions(+), 12 deletions(-)
```

External caller (`mcp_server_eio_execute.ml:582`), `.mli`, and `Tool_inline_dispatch_types` are unchanged. Test file unchanged.

## Workaround signature gate self-check (CLAUDE.md §워크어라운드 거부 기준)

- **§1 Telemetry-as-fix**: N/A.
- **§2 String/substring classifier**: N/A.
- **§3 N-of-M sweep**: **considered**. RFC-0189 staged plan; cluster boundary respected.
- **§4 Catch-all**: N/A.
- **§5 Cap/cooldown/dedup/repair**: N/A — `structured_payload_of_message` mirror canonical pattern from #18767.
- **§6 Test backdoor**: N/A.
- **§7 Codemod-needed typo**: N/A.

RFC-WAIVED: not in credential / identity / sandbox / hooks / workflow scope. Tracked under RFC-0189.

## Test plan

- [x] `dune build @check` clean.
- [x] `dune build .` (full) green.
- [x] External caller `Mcp_server_eio_execute.dispatch` unchanged.
- [x] Round-trip safety verified — `Yojson.Safe.to_string` outputs lift into `data` via `structured_payload_of_message`.
- [ ] CI: required checks green before Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
