### PR TITLE
refactor(dashboard): purge dev-token legacy file fallback

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 23:37:16 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-26 23:57:25 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -730,6 +730,12 @@
             <td><span class="status done">merged #18780</span></td>
             <td>Delete <code>Keeper_metrics_legacy</code> and <code>Keeper_metrics_constants</code>, remove public string-constant vals from <code>Keeper_metrics.mli</code>, and move all keeper metric call sites to <code>Keeper_metrics.(to_string &lt;Variant&gt;)</code>. The 26 constants that had never been typed are now first-class metric variants.</td>
             <td>Merged as <code>7028f2d61</code>. Backstop grep is clean for <code>Keeper_metrics.metric_</code>, <code>Keeper_metrics_legacy</code>, <code>Keeper_metrics_constants</code>, and compatibility-string wording outside this audit ledger.</td>
+          </tr>
+          <tr>
+            <td>Dashboard dev-token legacy file fallback</td>
+            <td><span class="status now">draft PR #18788</span></td>
+            <td>Stop reading, migrating, or deleting legacy <code>.masc/auth/dashboard-dev.token</code>. The runtime now only accepts the canonical <code>.masc/auth/dashboard.token</code> dev-token file, and doctor reports only that canonical file as present.</td>
+            <td>PR #18788 branch <code>refactor/purge-dashboard-dev-token-legacy-20260526</code>. Tests assert the old file is ignored and left untouched while <code>ensure_dashboard_dev_token</code> mints/reuses only the canonical dashboard token.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>

--- a/docs/rfc/RFC-0088-counter-as-fix-result-propagation.md
+++ b/docs/rfc/RFC-0088-counter-as-fix-result-propagation.md
@@ -44,7 +44,7 @@ This RFC's purpose is **not** to introduce a new pattern. It is to:
 | 4 | `lib/coord.ml:101-105` | `metric_coord_telemetry_drop` + `warn_telemetry_drop` | Coord — telemetry emission from non-Eio context. Caller is the failing telemetry path itself; no `Result.t` chain to propagate to. | **Unowned — §4 of this RFC or fold into RFC-0044** |
 | 5 | `lib/telemetry_eio.ml:149` | `Safe_ops.report_persistence_read_drop` (typed `Read_drop_reason.t`) | Already-migrated read-side | RFC-0044 (active path) |
 | 6 | `lib/telemetry_eio.ml:166-173` | `Safe_ops.report_persistence_read_drop` (typed) | Already-migrated read-side | RFC-0044 (active path) |
-| 7 | retired | `[identity_drift:alias_fallback]` WARN-only credential alias fallback | Runtime credential alias fallback removed; dashboard-dev tokens must be migrated through the dashboard dev-token route. | Closed |
+| 7 | retired | `[identity_drift:alias_fallback]` WARN-only credential alias fallback | Runtime credential alias fallback removed; old dashboard-dev token files are ignored and the dashboard dev-token route only mints or reuses the canonical dashboard token. | Closed |
 | 8 | `lib/dashboard.ml:460-475` | reads `metric_total` to format a *display title* | Aggregation reader, not a counter-as-fix emitter | Out of scope (false positive) |
 | 9-12 | `lib/keeper/keeper_alerting.ml:553-642` (3 sites) | `Log.Keeper.error "... JSONL write failed: %s"` + no counter, drop record | Write-side silent failure | RFC-0077 (cohort C) |
 | 13-15 | `lib/keeper/keeper_checkpoint_store.ml:55, 91, 195, 238, 256` | `Log.Keeper.warn "... failed"` + drop archive | Write-side / cleanup silent failure | RFC-0077 (cohort B) |

--- a/lib/auth_doctor.ml
+++ b/lib/auth_doctor.ml
@@ -211,7 +211,7 @@ let analyze ~base_path_input ~default_base_path () =
     bind_is_loopback && not http_auth_strict
   in
   let dashboard_dev_token_file_present =
-    file_exists (Filename.concat auth_dir "dashboard-dev.token")
+    file_exists (Filename.concat auth_dir "dashboard.token")
   in
   let admin_bearer_sources =
     admin_bearer_sources ~base_path ~auth_dir

--- a/lib/server/server_routes_http_dashboard_dev_token.ml
+++ b/lib/server/server_routes_http_dashboard_dev_token.ml
@@ -1,6 +1,6 @@
 (** Dashboard dev-token cluster, extracted from
     [server_routes_http_routes_dashboard.ml]. Wraps the on-disk dev-token
-    files (current + legacy), classifies stored candidates, mints when
+    file, classifies stored candidates, mints when
     missing, and exposes the high-level [ensure_dashboard_dev_token]
     that the dashboard route handlers depend on. *)
 
@@ -10,19 +10,6 @@ let dashboard_dev_token_path base_path =
   Filename.concat
     (Filename.concat (Common.masc_dir_from_base_path ~base_path) "auth")
     "dashboard.token"
-
-let legacy_dashboard_dev_token_path base_path =
-  Filename.concat
-    (Filename.concat (Common.masc_dir_from_base_path ~base_path) "auth")
-    "dashboard-dev.token"
-
-let remove_dashboard_dev_token_file_if_exists path =
-  if Fs_compat.file_exists path then
-    try Sys.remove path
-    with exn ->
-      Log.Server.warn
-        "dashboard dev-token cleanup skipped for %s: %s"
-        path (Printexc.to_string exn)
 
 type dashboard_dev_token_candidate =
   | Reusable of string
@@ -65,10 +52,8 @@ let read_reusable_dashboard_dev_token ~base_path path :
 
 let persist_dashboard_dev_token ~base_path raw : (unit, string) result =
   let token_path = dashboard_dev_token_path base_path in
-  let legacy_path = legacy_dashboard_dev_token_path base_path in
   try
     Auth.save_private_text_file token_path raw;
-    remove_dashboard_dev_token_file_if_exists legacy_path;
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -89,18 +74,7 @@ let mint_dashboard_dev_token base_path : (string, string) result =
 
 let ensure_dashboard_dev_token base_path : (string, string) result =
   let token_path = dashboard_dev_token_path base_path in
-  let legacy_path = legacy_dashboard_dev_token_path base_path in
   match read_reusable_dashboard_dev_token ~base_path token_path with
   | Error msg -> Error msg
-  | Ok (Some raw) ->
-      remove_dashboard_dev_token_file_if_exists legacy_path;
-      Ok raw
-  | Ok None ->
-      (match read_reusable_dashboard_dev_token ~base_path legacy_path with
-       | Error msg -> Error msg
-       | Ok (Some raw) ->
-           (match persist_dashboard_dev_token ~base_path raw with
-            | Ok () -> Ok raw
-            | Error msg -> Error msg)
-       | Ok None -> mint_dashboard_dev_token base_path)
-
+  | Ok (Some raw) -> Ok raw
+  | Ok None -> mint_dashboard_dev_token base_path

--- a/lib/server/server_routes_http_dashboard_dev_token.mli
+++ b/lib/server/server_routes_http_dashboard_dev_token.mli
@@ -1,28 +1,4 @@
 (** Dashboard dev-token file and minting helpers for dashboard routes. *)
 
-val dashboard_dev_actor_name : string
 val dashboard_dev_token_path : string -> string
-val legacy_dashboard_dev_token_path : string -> string
-val remove_dashboard_dev_token_file_if_exists : string -> unit
-
-type dashboard_dev_token_candidate =
-  | Reusable of string
-  | Rotate
-
-val classify_dashboard_dev_token_candidate
-  :  base_path:string
-  -> string
-  -> (dashboard_dev_token_candidate, string) result
-
-val read_reusable_dashboard_dev_token
-  :  base_path:string
-  -> string
-  -> (string option, string) result
-
-val persist_dashboard_dev_token
-  :  base_path:string
-  -> string
-  -> (unit, string) result
-
-val mint_dashboard_dev_token : string -> (string, string) result
 val ensure_dashboard_dev_token : string -> (string, string) result

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -94,9 +94,7 @@ let rec add_routes ~sw ~clock router =
      server binds to loopback and strict-auth env overrides are disabled, so
      that a LAN deployment never hands out a token over the wire. The token is
      canonicalized to the [dashboard] actor and persisted at
-     [.masc/auth/dashboard.token]. Legacy [.masc/auth/dashboard-dev.token]
-     files are rotated or migrated automatically so restarts do not reintroduce
-     the dashboard/dashboard-dev auth mismatch. *)
+     [.masc/auth/dashboard.token]. *)
   |> Http.Router.get "/api/v1/dashboard/dev-token" (fun request reqd ->
        if (not (http_auth_bind_is_loopback ()))
           || http_auth_strict_enabled () then

--- a/lib/server/server_routes_http_routes_dashboard.mli
+++ b/lib/server/server_routes_http_routes_dashboard.mli
@@ -24,15 +24,8 @@ val dashboard_dev_token_path : string -> string
 (** [<base_path>/.masc/auth/dashboard.token] — the canonical
     dashboard dev-token file written on boot. *)
 
-val legacy_dashboard_dev_token_path : string -> string
-(** [<base_path>/.masc/auth/dashboard-dev.token]. Exposed so the
-    dashboard-keeper-routes test can locate (and clean up) the legacy
-    file the runtime now removes on boot. *)
-
 val ensure_dashboard_dev_token : string -> (string, string) result
 (** Idempotent boot helper: returns the canonical dashboard dev token
     string, generating + persisting one to {!dashboard_dev_token_path}
-    on first call and removing the legacy file at
-    {!legacy_dashboard_dev_token_path} when present. [Error msg] when
-    the auth dir is unwritable. Exposed so the dashboard-keeper-routes
-    test can drive the boot path directly. *)
+    on first call. [Error msg] when the auth dir is unwritable. Exposed
+    so the dashboard-keeper-routes test can drive the boot path directly. *)

--- a/lib/server/server_routes_http_routes_dashboard_setup.ml
+++ b/lib/server/server_routes_http_routes_dashboard_setup.ml
@@ -65,19 +65,7 @@ let sync_keeper_cascade_meta = Server_routes_http_routes_dashboard_cascade_meta.
 (* Dashboard dev-token cluster extracted to
    [Server_routes_http_dashboard_dev_token] (godfile decomp). *)
 
-let dashboard_dev_actor_name = Server_routes_http_dashboard_dev_token.dashboard_dev_actor_name
 let dashboard_dev_token_path = Server_routes_http_dashboard_dev_token.dashboard_dev_token_path
-let legacy_dashboard_dev_token_path = Server_routes_http_dashboard_dev_token.legacy_dashboard_dev_token_path
-let remove_dashboard_dev_token_file_if_exists = Server_routes_http_dashboard_dev_token.remove_dashboard_dev_token_file_if_exists
-
-type dashboard_dev_token_candidate = Server_routes_http_dashboard_dev_token.dashboard_dev_token_candidate =
-  | Reusable of string
-  | Rotate
-
-let classify_dashboard_dev_token_candidate = Server_routes_http_dashboard_dev_token.classify_dashboard_dev_token_candidate
-let read_reusable_dashboard_dev_token = Server_routes_http_dashboard_dev_token.read_reusable_dashboard_dev_token
-let persist_dashboard_dev_token = Server_routes_http_dashboard_dev_token.persist_dashboard_dev_token
-let mint_dashboard_dev_token = Server_routes_http_dashboard_dev_token.mint_dashboard_dev_token
 let ensure_dashboard_dev_token = Server_routes_http_dashboard_dev_token.ensure_dashboard_dev_token
 
 let executable_file_exists path =

--- a/test/test_auth_doctor.ml
+++ b/test/test_auth_doctor.ml
@@ -127,6 +127,32 @@ let test_ignores_stale_admin_raw_token_file () =
        ~needle:"No usable admin bearer source was detected"
        report.warnings)
 
+let test_ignores_old_dashboard_dev_token_file () =
+  with_temp_dir "auth-doctor-old-dashboard-dev-token" @@ fun base_path ->
+  let auth_cfg =
+    Masc_domain.
+      {
+        enabled = true;
+        room_secret_hash = None;
+        require_token = true;
+        token_expiry_hours = 24;
+      }
+  in
+  Auth.save_auth_config base_path auth_cfg;
+  Auth.save_private_text_file
+    (Filename.concat (Auth.auth_dir base_path) "dashboard-dev.token")
+    "old-dashboard-dev-token";
+  with_env "MASC_HOST" "127.0.0.1" @@ fun () ->
+  with_env "MASC_HTTP_AUTH_STRICT" "" @@ fun () ->
+  with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  let report =
+    Auth_doctor.analyze ~base_path_input:base_path
+      ~default_base_path:base_path ()
+  in
+  check bool "old dashboard-dev token file ignored" false
+    report.dashboard_dev_token_file_present
+
 (* The previous test "reports Claude and Provider_f MCP client identities"
    was removed: the per-client diagnostic that it locked is gone.
    The server is now MCP-client-agnostic, so it holds no list of
@@ -176,6 +202,8 @@ let () =
             test_errors_when_no_admin_bearer_source_exists;
           test_case "ignores stale admin raw token file" `Quick
             test_ignores_stale_admin_raw_token_file;
+          test_case "ignores old dashboard-dev token file" `Quick
+            test_ignores_old_dashboard_dev_token_file;
           test_case "json omits mcp_clients field" `Quick
             test_json_no_longer_emits_mcp_clients_field;
         ] );

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -2052,7 +2052,11 @@ let dashboard_dev_token_test_dir () =
   path
 ;;
 
-let test_ensure_dashboard_dev_token_rotates_legacy_dashboard_dev_owner () =
+let old_dashboard_dev_token_path base_path =
+  Filename.concat (Filename.concat base_path ".masc/auth") "dashboard-dev.token"
+;;
+
+let test_ensure_dashboard_dev_token_ignores_old_dashboard_dev_file () =
   let base_path = dashboard_dev_token_test_dir () in
   mkdir_p (Filename.concat base_path ".masc/auth");
   Fun.protect
@@ -2061,21 +2065,21 @@ let test_ensure_dashboard_dev_token_rotates_legacy_dashboard_dev_owner () =
        let legacy_raw =
          match Auth.create_token base_path ~agent_name:"dashboard-dev"
                  ~role:Masc_domain.Admin with
-         | Ok (raw, _cred) -> raw
-         | Error err -> fail (Masc_domain.masc_error_to_string err)
+       | Ok (raw, _cred) -> raw
+       | Error err -> fail (Masc_domain.masc_error_to_string err)
        in
-       let legacy_path = Routes.legacy_dashboard_dev_token_path base_path in
+       let old_path = old_dashboard_dev_token_path base_path in
        let canonical_path = Routes.dashboard_dev_token_path base_path in
-       Auth.save_private_text_file legacy_path legacy_raw;
+       Auth.save_private_text_file old_path legacy_raw;
        match Routes.ensure_dashboard_dev_token base_path with
        | Error msg -> fail msg
        | Ok raw ->
-           check bool "legacy token rotates to canonical owner" true
+           check bool "old dashboard-dev token ignored" true
              (not (String.equal raw legacy_raw));
            check bool "canonical token file written" true
              (Sys.file_exists canonical_path);
-           check bool "legacy token file removed" false
-             (Sys.file_exists legacy_path);
+           check bool "old dashboard-dev token file untouched" true
+             (Sys.file_exists old_path);
            (match Auth.verify_token base_path ~agent_name:"dashboard" ~token:raw with
             | Ok cred ->
                 check string "canonical credential owner" "dashboard"
@@ -2096,22 +2100,12 @@ let test_ensure_dashboard_dev_token_reuses_canonical_dashboard_token () =
          | Ok (raw, _cred) -> raw
          | Error err -> fail (Masc_domain.masc_error_to_string err)
        in
-       let legacy_raw =
-         match Auth.create_token base_path ~agent_name:"dashboard-dev"
-                 ~role:Masc_domain.Admin with
-         | Ok (raw, _cred) -> raw
-         | Error err -> fail (Masc_domain.masc_error_to_string err)
-       in
-       let legacy_path = Routes.legacy_dashboard_dev_token_path base_path in
        let canonical_path = Routes.dashboard_dev_token_path base_path in
        Auth.save_private_text_file canonical_path canonical_raw;
-       Auth.save_private_text_file legacy_path legacy_raw;
        match Routes.ensure_dashboard_dev_token base_path with
        | Error msg -> fail msg
        | Ok raw ->
            check string "canonical token reused" canonical_raw raw;
-           check bool "legacy token file cleaned up" false
-             (Sys.file_exists legacy_path);
            check bool "canonical token file kept" true
              (Sys.file_exists canonical_path))
 ;;
@@ -2193,9 +2187,9 @@ let () =
             `Slow
             test_tool_stats_route_surfaces_coverage_gap_rows
         ; test_case
-            "dashboard dev token rotates legacy dashboard-dev owner"
+            "dashboard dev token ignores old dashboard-dev file"
             `Quick
-            test_ensure_dashboard_dev_token_rotates_legacy_dashboard_dev_owner
+            test_ensure_dashboard_dev_token_ignores_old_dashboard_dev_file
         ; test_case
             "dashboard dev token reuses canonical dashboard token"
             `Quick


### PR DESCRIPTION
## Summary
- stop reading, migrating, or deleting legacy .masc/auth/dashboard-dev.token
- keep dashboard dev-token behavior canonical on .masc/auth/dashboard.token only
- update doctor/tests/docs/legacy purge ledger so old dashboard-dev files are ignored, not preserved as a compatibility path

## Verification
- ocamlformat --check lib/auth_doctor.ml lib/server/server_routes_http_dashboard_dev_token.ml lib/server/server_routes_http_dashboard_dev_token.mli lib/server/server_routes_http_routes_dashboard.ml lib/server/server_routes_http_routes_dashboard.mli lib/server/server_routes_http_routes_dashboard_setup.ml test/test_dashboard_keeper_routes.ml test/test_auth_doctor.ml
- git diff --check origin/main...HEAD
- rg backstop for removed legacy dev-token helpers and migration wording
- scripts/dune-local.sh build ./test/test_dashboard_keeper_routes.exe ./test/test_auth_doctor.exe (blocked: exit 75, machine-wide bare Dune processes detected; did not bypass guard)