### PR TITLE
refactor(keeper): rename keeper_shell_read_ops to keeper_workspace_read_ops

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -150,7 +150,7 @@
    agent_tool_ide_runtime
    keeper_sandbox_docker
    keeper_workspace_op keeper_shell_timeout keeper_shell_runtime_paths keeper_shell_path
-   keeper_shell_readonly_policy keeper_shell_command_parse keeper_shell_command_words keeper_shell_read_ops
+   keeper_shell_readonly_policy keeper_shell_command_parse keeper_shell_command_words keeper_workspace_read_ops
    keeper_shell_bash
    keeper_workspace_ops
    keeper_exec_shell

--- a/lib/keeper/keeper_workspace_ops.ml
+++ b/lib/keeper/keeper_workspace_ops.ml
@@ -1,6 +1,6 @@
 (* SearchFiles operation handlers.
 
-   Read/list/search operations live in Keeper_shell_read_ops. This facade keeps
+   Read/list/search operations live in Keeper_workspace_read_ops. This facade keeps
    alias parsing, remaining git mutation-ish helpers, and unsupported-op
    reporting in one place. *)
 
@@ -33,7 +33,7 @@ let handle_tool_search_files
   in
   let raw_path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
   match
-    Keeper_shell_read_ops.try_handle ~turn_sandbox_factory ~config ~meta ~args
+    Keeper_workspace_read_ops.try_handle ~turn_sandbox_factory ~config ~meta ~args
       ~op ~raw_path
   with
   | Some response -> response

--- a/lib/keeper/keeper_workspace_read_ops.ml
+++ b/lib/keeper/keeper_workspace_read_ops.ml
@@ -1,4 +1,4 @@
-(* Keeper_shell_read_ops — read-side operation handlers for SearchFiles.
+(* Keeper_workspace_read_ops — read-side operation handlers for SearchFiles.
 
    This module owns structured read/list/search operations so
    the SearchFiles facade stays as the public dispatcher instead of reabsorbing

--- a/lib/keeper/keeper_workspace_read_ops.mli
+++ b/lib/keeper/keeper_workspace_read_ops.mli
@@ -1,4 +1,4 @@
-(* Keeper_shell_read_ops — structured read-side SearchFiles operations. *)
+(* Keeper_workspace_read_ops — structured read-side SearchFiles operations. *)
 
 val try_handle :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->

--- a/test/test_keeper_exec_shell_cwd_response.ml
+++ b/test/test_keeper_exec_shell_cwd_response.ml
@@ -1,7 +1,7 @@
 (** Integration pin for PR-3 of the [Keeper_cwd_response] series.
 
     PR-3 wires [Keeper_cwd_response.to_yojson_response] into the
-    sandbox-backend response builders inside [keeper_shell_read_ops.ml]:
+    sandbox-backend response builders inside [keeper_workspace_read_ops.ml]:
 
     - [render_sandbox_process_result] (op=pwd / git_status / git_log / ...)
     - [op="git_log"] runtime branch (1 cwd-echo site under backend [via])
@@ -40,9 +40,9 @@ let read_source path =
 let find_source_path () =
   List.find_opt Sys.file_exists
     [
-      "lib/keeper/keeper_shell_read_ops.ml"
-    ; "../lib/keeper/keeper_shell_read_ops.ml"
-    ; "../../lib/keeper/keeper_shell_read_ops.ml"
+      "lib/keeper/keeper_workspace_read_ops.ml"
+    ; "../lib/keeper/keeper_workspace_read_ops.ml"
+    ; "../../lib/keeper/keeper_workspace_read_ops.ml"
     ]
 
 let count_substring src needle =

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -241,9 +241,9 @@ let test_retired_remote_repo_helpers_absent () =
   assert_source_absent ("lib/keeper/" ^ "keeper_tool_" ^ "pr_review.mli")
 
 let test_shell_read_ops_use_sandbox_read_runner () =
-  let read_ops_ml = "lib/keeper/keeper_shell_read_ops.ml" in
+  let read_ops_ml = "lib/keeper/keeper_workspace_read_ops.ml" in
   let shell_ops_ml = "lib/keeper/keeper_workspace_ops.ml" in
-  assert_contains "lib/dune" "keeper_shell_read_ops";
+  assert_contains "lib/dune" "keeper_workspace_read_ops";
   assert_contains read_ops_ml "Keeper_sandbox_read_runner.";
   assert_contains read_ops_ml "Keeper_sandbox_read_runner.backend_via";
   assert_not_contains read_ops_ml "Keeper_sandbox_read_backend.";
@@ -255,7 +255,7 @@ let test_shell_read_ops_use_sandbox_read_runner () =
 let test_shell_path_owner () =
   let path_ml = "lib/keeper/keeper_shell_path.ml" in
   let shell_ops_ml = "lib/keeper/keeper_workspace_ops.ml" in
-  let read_ops_ml = "lib/keeper/keeper_shell_read_ops.ml" in
+  let read_ops_ml = "lib/keeper/keeper_workspace_read_ops.ml" in
   assert_contains "lib/dune" "keeper_shell_path";
   assert_contains path_ml "let resolve_tool_read_cwd";
   assert_contains path_ml "let resolve_tool_write_cwd";
@@ -287,18 +287,18 @@ let test_shell_shared_is_removed () =
       "keeper_shell_runtime_paths";
       "keeper_shell_path";
       "keeper_shell_readonly_policy";
-      "keeper_shell_read_ops";
+      "keeper_workspace_read_ops";
     ];
   assert_contains exec_shell_ml "Keeper_workspace_op.valid_strings";
   assert_contains exec_shell_ml "Keeper_shell_timeout.tool_dispatch_min_timeout_sec";
   assert_contains exec_shell_ml "Keeper_shell_runtime_paths.rewrite_turn_runtime_paths_to_host";
   assert_contains exec_shell_ml "Keeper_shell_readonly_policy.readonly_hint_of_category";
-  assert_contains "lib/keeper/keeper_shell_read_ops.ml" "Keeper_shell_timeout.read_timeout_sec";
+  assert_contains "lib/keeper/keeper_workspace_read_ops.ml" "Keeper_shell_timeout.read_timeout_sec";
   assert_contains shell_ops_ml "Keeper_shell_runtime_paths.rewrite_turn_runtime_paths_to_host";
   assert_contains bash_ml "Keeper_shell_timeout.clamp_shell_timeout";
   assert_contains exec_tools_ml "Keeper_workspace_op.valid_strings";
   assert_not_contains shell_ops_ml "Keeper_shell_shared.";
-  assert_not_contains "lib/keeper/keeper_shell_read_ops.ml" "Keeper_shell_shared.";
+  assert_not_contains "lib/keeper/keeper_workspace_read_ops.ml" "Keeper_shell_shared.";
   assert_not_contains bash_ml "Keeper_shell_shared.";
   assert_not_contains exec_tools_ml "Keeper_shell_shared.";
   assert_not_contains exec_shell_ml "Keeper_shell_shared"
@@ -323,7 +323,7 @@ let test_descriptor_backed_dispatch_uses_agent_tool_runtime () =
 
 let test_shell_ops_host_ir_uses_keeper_shell_ir_facade () =
   let shell_ops_ml = "lib/keeper/keeper_workspace_ops.ml" in
-  let read_ops_ml = "lib/keeper/keeper_shell_read_ops.ml" in
+  let read_ops_ml = "lib/keeper/keeper_workspace_read_ops.ml" in
   List.iter
     (fun rel ->
        assert_contains rel "Keeper_shell_ir.simple";

--- a/test/test_pr_c_coreutils_migration.ml
+++ b/test/test_pr_c_coreutils_migration.ml
@@ -15,7 +15,7 @@ open Alcotest
 
     Pins:
     - 0 occurrences of any of the 6 absolute literals in
-      [keeper_workspace_ops.ml], [keeper_shell_read_ops.ml], or
+      [keeper_workspace_ops.ml], [keeper_workspace_read_ops.ml], or
       [keeper_shell_ops_setup.ml] (regression guard)
     - [Host_config.host] is invoked exactly once
       from the setup module (positive assertion + no per-call-site
@@ -54,7 +54,7 @@ let test_no_coreutils_literals_in_shell_ops () =
          read_file
          [
            "lib/keeper/keeper_workspace_ops.ml";
-           "lib/keeper/keeper_shell_read_ops.ml";
+           "lib/keeper/keeper_workspace_read_ops.ml";
            "lib/keeper/keeper_shell_ops_setup.ml";
          ])
   in


### PR DESCRIPTION
## Summary

`keeper_shell_read_ops` 모듈 docstring 가 *"structured read-side SearchFiles operations"* 라 본인이 SearchFiles helper 임을 인정. `keeper_shell_` prefix 는 legacy `keeper_shell` 도구 잔재 — PR #18787 와 같은 misnomer 패턴.

본 PR 은 #18787 의 *연장*: SearchFiles 측에 남은 마지막 `keeper_shell_*` helper 를 `keeper_workspace_read_ops` 로 정렬.

## 변경 사항

| Path | 변경 |
|---|---|
| `lib/keeper/keeper_shell_read_ops.{ml,mli}` | `keeper_workspace_read_ops.{ml,mli}` |
| `lib/dune` + 3 lib caller + 3 test caller | reference 정렬 |

7 file, +18 / -18 LoC.

## Why not 다른 `keeper_shell_*` modules

진단 결과 — 나머지 8 sibling module 은 의도된 의미:

| Module | docstring 요지 | 결정 |
|---|---|---|
| `keeper_shell_bash` | "typed Shell IR execution pipeline" | **유지** (Execute) |
| `keeper_shell_command_parse` | "raw shell command parsing into Shell IR" | **유지** (Execute) |
| `keeper_shell_command_words` | "raw shell command word extraction" | **유지** (Execute) |
| `keeper_shell_command_semantics` | "command-shape and cwd policy helpers shared by Local/Docker shell" | **유지** (Execute) |
| `keeper_shell_containment` | (semantics 와 동일 시그니처) | **유지** (Execute) |
| `keeper_shell_runtime_paths` | "Runtime path rewrites for keeper shell responses and Docker commands" | **유지** (Execute) |
| `keeper_shell_readonly_policy` | "Readonly shell rejection hints" | **유지** (Execute raw-shell reject) |
| `keeper_shell_path` | `resolve_tool_read_cwd` + `resolve_tool_write_cwd` 둘 다 | **유지** (양측 shared) |
| `keeper_shell_timeout` | "keeper shell surfaces" 양측 | **유지** (양측 shared) |

→ misnamed 만 cherry-pick.

## Workaround Signature Gate

- counter / cap / cooldown / dedup / repair 추가 0
- string classifier 추가 0
- catch-all 추가 0
- *positive*: SearchFiles 측 helper 의 마지막 shell drift 해소

Override 불필요.

## Verification

- `dune build --root . lib/ test/` clean
- `rg -nw 'Keeper_shell_read_ops|keeper_shell_read_ops' lib/ test/` → 0 hits
- `git mv` history 유지

## 관련 PR

- #18787 (keeper_shell_op*/ops*/ops_setup* → workspace_op*) 의 *연장 / 마무리*
- #18779 (tool_search_files → tool_workspace_inspect surface rename) 의 *backing helper* 정렬 완성

🤖 Generated with [Claude Code](https://claude.com/claude-code)