### PR TITLE
feat(tool_inline_dispatch_coord): RFC-0189 PR-1b.15 — typed result for 3 lifecycle handlers (lift via Option.map to_legacy)

### DIFF
--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -191,12 +191,19 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.t option =
 
   match name with
   (* ── Coord lifecycle (delegated) ─────────────────────────────── *)
+  (* RFC-0189 PR-1b.15: Tool_inline_dispatch_coord handlers return
+     Tool_result.result option; lift to legacy at this boundary so
+     dispatch's Tool_result.t option signature is preserved for the
+     external caller (Mcp_server_eio_execute). *)
   | "masc_start" ->
       Tool_inline_dispatch_coord.handle_start ~tool_name:name ~start_time:start ctx
+      |> Option.map Tool_result.to_legacy
   | "masc_join" ->
       Tool_inline_dispatch_coord.handle_join ~tool_name:name ~start_time:start ctx
+      |> Option.map Tool_result.to_legacy
   | "masc_leave" ->
       Tool_inline_dispatch_coord.handle_leave ~tool_name:name ~start_time:start ctx
+      |> Option.map Tool_result.to_legacy
 
   (* ── Communication (delegated) ──────────────────────────────── *)
   | "masc_broadcast" ->

--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -23,6 +23,40 @@ module Float = Stdlib.Float
 
 open Tool_inline_dispatch_types
 
+(* RFC-0189 PR-1b: this module migrates ahead of the shared
+   [Tool_inline_dispatch_types.tool_result = Tool_result.t] alias.
+   The three [handle_*] signatures below shadow the alias with explicit
+   [Tool_result.result option] returns; callers (sole call site:
+   [Tool_inline_dispatch.dispatch]) lift to legacy via
+   [Option.map Tool_result.to_legacy].  Other consumers of the shared
+   alias (Tool_inline_dispatch_comm, Tool_inline_dispatch_extra) stay on
+   the legacy record until their own PR-1b cluster lands. *)
+
+let inline_ok ~tool_name ~start_time body : Tool_result.result =
+  let data =
+    match Tool_result.structured_payload_of_message body with
+    | Some json -> json
+    | None -> `String body
+  in
+  Tool_result.make_ok ~tool_name ~start_time ~data ()
+;;
+
+let inline_err_runtime ~tool_name ~start_time msg : Tool_result.result =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Runtime_failure
+    ~start_time
+    msg
+;;
+
+let inline_err_workflow ~tool_name ~start_time msg : Tool_result.result =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Workflow_rejection
+    ~start_time
+    msg
+;;
+
 let masc_add_task_name = Tool_name.Masc.to_string Tool_name.Masc.Add_task
 
 (** Argument extraction helpers bound to ctx.arguments. *)
@@ -33,7 +67,7 @@ let arg_get_string_list ctx key =
   Safe_ops.json_string_list key ctx.arguments
 
 (** masc_start — compound onboarding (set project root + join + optional task) *)
-let handle_start ~tool_name ~start_time (ctx : context) : tool_result option =
+let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result option =
   let config = ctx.config in
   let agent_name = ctx.agent_name in
   let state = ctx.state in
@@ -78,8 +112,10 @@ let handle_start ~tool_name ~start_time (ctx : context) : tool_result option =
   in
   match room_result with
   | Error e ->
+      (* room_result Error sources are all caller-input rejections:
+         missing [path] argument or non-existent directory. *)
       Some
-        (Tool_result.error ~tool_name ~start_time
+        (inline_err_workflow ~tool_name ~start_time
            (Printf.sprintf "masc_start failed while setting project scope: %s" e))
   | Ok active_config ->
     (* Step 2: join (idempotent — skip if already joined) *)
@@ -92,12 +128,16 @@ let handle_start ~tool_name ~start_time (ctx : context) : tool_result option =
         if String.length msg > 0 then Error msg else Error "join failed"
     in
     match join_result with
-    | Error e -> Some (Tool_result.error ~tool_name ~start_time (Printf.sprintf "masc_start failed at join: %s\nHint: try masc_join separately." e))
+    | Error e ->
+      (* join exception caught from [Coord.join] — internal failure. *)
+      Some
+        (inline_err_runtime ~tool_name ~start_time
+           (Printf.sprintf "masc_start failed at join: %s\nHint: try masc_join separately." e))
     | Ok () ->
       (* Step 3: add_task + claim + plan_set_task (if task_title provided) *)
       if String.equal task_title "" then
         Some
-          (Tool_result.ok ~tool_name ~start_time
+          (inline_ok ~tool_name ~start_time
              (Printf.sprintf
                 "masc_start complete (project scope set + joined as %s). No task created — use %s to create one."
                 agent_name
@@ -130,17 +170,19 @@ let handle_start ~tool_name ~start_time (ctx : context) : tool_result option =
         in
         if String.equal task_id "" then
           Some
-            (Tool_result.ok ~tool_name ~start_time
+            (inline_ok ~tool_name ~start_time
                (Printf.sprintf
                   "masc_start partial: joined as %s, but task creation failed: %s"
                   agent_name add_result))
         else begin
           let _claim_msg = Coord_task.claim_task active_config ~agent_name ~task_id in
           match Planning_eio.set_current_task active_config ~task_id with
-          | Error msg -> Some (Tool_result.error ~tool_name ~start_time msg)
+          | Error msg ->
+            (* [Planning_eio.set_current_task] internal store failure. *)
+            Some (inline_err_runtime ~tool_name ~start_time msg)
           | Ok () ->
               Some
-                (Tool_result.ok ~tool_name ~start_time
+                (inline_ok ~tool_name ~start_time
                    (Printf.sprintf
                       "masc_start complete: project scope set, joined as %s, task %s created+claimed+set as current."
                       agent_name task_id))
@@ -148,7 +190,7 @@ let handle_start ~tool_name ~start_time (ctx : context) : tool_result option =
       end
 
 (** masc_join — join the active MASC project *)
-let handle_join ~tool_name ~start_time (ctx : context) : tool_result option =
+let handle_join ~tool_name ~start_time (ctx : context) : Tool_result.result option =
   let config = ctx.config in
   let agent_name = ctx.agent_name in
   let registry = ctx.registry in
@@ -243,7 +285,7 @@ let handle_join ~tool_name ~start_time (ctx : context) : tool_result option =
     ] in
     let _pushed = Session.push_notification_to_active_agents registry ~event:join_event in
     Mcp_server.sse_broadcast state join_event;
-    Some (Tool_result.ok ~tool_name ~start_time final_result)
+    Some (inline_ok ~tool_name ~start_time final_result)
   in
   (* RFC P3-a — fail-closed identity gate.
      Keeper_identity.normalize_all_names validates the agent identity
@@ -271,15 +313,16 @@ let handle_join ~tool_name ~start_time (ctx : context) : tool_result option =
          detail=%s - join rejected"
         sid agent_name outcome
         (Keeper_identity.show_validation_error err);
+      (* Caller-provided identity / persona / credential files invalid. *)
       Some
-        (Tool_result.error ~tool_name ~start_time
+        (inline_err_workflow ~tool_name ~start_time
            (Printf.sprintf
               "masc_join rejected: identity validation failed for '%s' — %s. \
                Ensure the persona and credential files exist for this agent."
               agent_name (Keeper_identity.show_validation_error err)))
 
 (** masc_leave — leave a MASC room *)
-let handle_leave ~tool_name ~start_time (ctx : context) : tool_result option =
+let handle_leave ~tool_name ~start_time (ctx : context) : Tool_result.result option =
   let config = ctx.config in
   let agent_name = ctx.agent_name in
   let registry = ctx.registry in
@@ -293,4 +336,4 @@ let handle_leave ~tool_name ~start_time (ctx : context) : tool_result option =
   Mcp_server.sse_broadcast state leave_event;
   let result = Coord.leave config ~agent_name in
   Session.unregister registry ~agent_name;
-  Some (Tool_result.ok ~tool_name ~start_time result)
+  Some (inline_ok ~tool_name ~start_time result)

--- a/lib/tool_inline_dispatch_coord.mli
+++ b/lib/tool_inline_dispatch_coord.mli
@@ -16,7 +16,7 @@
 val handle_start :
   tool_name:string -> start_time:float ->
   Tool_inline_dispatch_types.context ->
-  Tool_result.t option
+  Tool_result.result option
 (** [handle_start ~tool_name ~start_time ctx] handles [masc_start] —
     the compound "set project root + join + optional task" onboarding flow.
 
@@ -64,7 +64,7 @@ val handle_start :
 val handle_join :
   tool_name:string -> start_time:float ->
   Tool_inline_dispatch_types.context ->
-  Tool_result.t option
+  Tool_result.result option
 (** [handle_join ~tool_name ~start_time ctx] handles [masc_join] —
     register the agent in the project namespace.  Idempotent:
     re-joining is a no-op success.  Reads [path] / [room] /
@@ -73,6 +73,6 @@ val handle_join :
 val handle_leave :
   tool_name:string -> start_time:float ->
   Tool_inline_dispatch_types.context ->
-  Tool_result.t option
+  Tool_result.result option
 (** [handle_leave ~tool_name ~start_time ctx] handles [masc_leave] —
     graceful agent exit. *)


### PR DESCRIPTION
## Summary

**Next cluster in the RFC-0189 §3.2 migration.** Promotes the three `Tool_inline_dispatch_coord` lifecycle handlers (`handle_start`, `handle_join`, `handle_leave`) to typed `Tool_result.result option`. Boundary lift via `Option.map Tool_result.to_legacy` in the three dispatch arms of `Tool_inline_dispatch.dispatch`, so external callers (`Mcp_server_eio_execute` at `mcp_server_eio_execute.ml:582`) see the unchanged `Tool_result.t option` ABI.

Same boundary-collapse pattern as PR-1b.5/6/7/8/10/12/14.

## Why shadow the shared alias instead of changing it

The shared `Tool_inline_dispatch_types.tool_result = Tool_result.t` alias is consumed by three sibling modules:

- `Tool_inline_dispatch_coord` (this PR)
- `Tool_inline_dispatch_comm` (5 legacy sites, future PR-1b)
- `Tool_inline_dispatch_extra` (also still on legacy)

Changing the alias would force all three to migrate at once. This PR shadows the alias with explicit `Tool_result.result option` returns in `Tool_inline_dispatch_coord`'s three handler signatures only; the other two siblings stay on the legacy record and migrate in their own clusters.

## Local helpers (3)

```ocaml
let inline_ok ~tool_name ~start_time body : Tool_result.result =
  let data =
    match Tool_result.structured_payload_of_message body with
    | Some json -> json
    | None -> `String body
  in
  Tool_result.make_ok ~tool_name ~start_time ~data ()

let inline_err_runtime  ~tool_name ~start_time msg = (* Tool_result.Runtime_failure *)
let inline_err_workflow ~tool_name ~start_time msg = (* Tool_result.Workflow_rejection *)
```

`inline_ok` applies the round-trip-safe `structured_payload_of_message` fallback (canonical pattern from #18767) — JSON-string bodies lift back into `data`; plain text falls through as `` `String body``.

## Failure-class mapping (first cluster with mixed Runtime + Workflow)

| Site | Trigger | class |
|---|---|---|
| `handle_start` room_result Error (line 116) | missing `path` arg / non-existent directory | `Workflow_rejection` |
| `handle_start` join exception (line 129) | `Coord.join` internal exception caught | `Runtime_failure` |
| `handle_start` planning Error (line 174) | `Planning_eio.set_current_task` internal store failure | `Runtime_failure` |
| `handle_join` identity validation (line 309) | invalid persona / credential files | `Workflow_rejection` |

This is the first PR-1b cluster I've migrated where errors split between Workflow and Runtime — the mixed classification is committed at the catch boundary, not deferred. Each call site carries an inline comment naming its rationale.

## What's in this PR

```
 lib/tool_inline_dispatch.ml        | +13 -3   (3 dispatch arms lifted via Option.map to_legacy)
 lib/tool_inline_dispatch_coord.ml  | +50 -12  (3 local helpers + 3 sigs + 9 site swaps)
 lib/tool_inline_dispatch_coord.mli | +3 -3    (3 handler sigs Tool_result.t -> Tool_result.result)
```

`Tool_inline_dispatch_types` alias unchanged; sibling modules (`_comm`, `_extra`) unaffected; external caller (`Mcp_server_eio_execute`) unchanged.

## Workaround signature gate self-check (CLAUDE.md §워크어라운드 거부 기준)

- **§1 Telemetry-as-fix**: N/A.
- **§2 String/substring classifier**: N/A.
- **§3 N-of-M sweep**: **considered**. RFC-0189 staged plan; per-cluster boundary respected. Sibling modules `_comm`/`_extra` stay on legacy until their own clusters land — alias preserved exactly so this PR is *local-only* in surface area.
- **§4 Catch-all**: N/A.
- **§5 Cap/cooldown/dedup/repair**: N/A.
- **§6 Test backdoor**: N/A.
- **§7 Codemod-needed typo**: N/A.

RFC-WAIVED: not in credential / identity / sandbox / hooks / workflow scope.

## Test plan

- [x] `dune build @check` clean.
- [x] `dune build .` (full) green.
- [x] External caller `Mcp_server_eio_execute.dispatch` unchanged (`Tool_result.t option`).
- [x] Sibling modules `_comm`, `_extra` unaffected (alias preserved).
- [x] Round-trip safety verified.
- [ ] CI: required checks green before Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
