### PR TITLE
fix(voice): honor config.tts.default_voice instead of hardcoded "Sarah" (F)

### DIFF
--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -297,12 +297,24 @@ let start_local_playback ~sw ~agent_id ~audio_file =
     (run_local_playback ~sw ~agent_id ~audio_file ()
       : [ `Dedup_hit | `Failed of string | `Played of float | `Skipped of string ])
 
-(** Get voice for agent, defaults to "Sarah" if config is unavailable *)
+(** Voice used when [load_voice_config ()] itself fails. This is the
+    only remaining hardcoded fallback; the normal "agent not listed"
+    path now reads [config.tts.default_voice] via {!default_voice}. *)
+let last_resort_voice = "Sarah"
+
+let default_voice () =
+  match load_voice_config () with
+  | Ok config -> config.tts.default_voice
+  | Error _ -> last_resort_voice
+
+(** Pick the voice for [agent_id]: the explicit per-agent mapping in
+    [config.tts.agent_voices] when present, otherwise
+    [config.tts.default_voice], otherwise [last_resort_voice]. *)
 let get_voice_for_agent agent_id =
   let voices = agent_voices () in
   match List.assoc_opt agent_id voices with
   | Some voice -> voice
-  | None -> "Sarah"
+  | None -> default_voice ()
 
 (** ============================================
     TTS Adapters


### PR DESCRIPTION
## Why

`Voice_bridge_core.get_voice_for_agent` hardcoded `"Sarah"` as the
fallback when `agent_id` was not present in `config.tts.agent_voices`,
silently ignoring `config.tts.default_voice` from `voice_config.json`.

Today's repro:

```
$ probe agent_id=vincent      # not listed in agent_voices
returned voice: "Sarah"        # got the hardcoded fallback
```

User's `voice_config.json`:

```json
"tts": {
  "default_voice": "Roger",        # this is what the user configured
  ...
  "agent_voices": {
    "nick0cave": "Roger",
    "codex": "George",
    "claude": "Sarah",
    ...
  }
}
```

`vincent` is not in the map, so the configured default `"Roger"`
should win. The hardcode skipped right past it.

Matches CLAUDE.md `software-development.md` §AI Code Generation
Antipattern #1 (scattered hardcoded defaults) — a config field
existed but a literal in a sibling file was preferred.

## Change

`lib/voice/voice_bridge_core.ml:300-305` →

```ocaml
let last_resort_voice = "Sarah"   (* only when load_voice_config fails *)

let default_voice () =
  match load_voice_config () with
  | Ok config -> config.tts.default_voice
  | Error _ -> last_resort_voice

let get_voice_for_agent agent_id =
  let voices = agent_voices () in
  match List.assoc_opt agent_id voices with
  | Some voice -> voice
  | None -> default_voice ()
```

The `"Sarah"` literal moves from "applied any time the agent is
unlisted" to "applied only when even the config file itself fails to
load." That collapses the bug surface from ~hundreds of agent ids
to a true edge case.

## What it does NOT change

- `last_resort_voice` is still a string literal. Removing the final
  fallback would force the return type to `string option` and ripple
  through every caller — out of scope here. The intent of this PR is
  the *config-aware default*, not a full string-fallback purge.
- Test coverage. `get_voice_for_agent` reads through `load_voice_config
  ()` which goes via the global config search path; hermetic unit
  testing requires a refactor that takes the config explicitly. End-to-end
  verification done via the `bin/voice_probe` smoke binary instead
  (not committed — kept locally as a diagnostic).

## Risk profile

Single function body in one .ml file, no .mli change, no caller
needs to know about `default_voice` (it's an internal helper).
Behaviour is strictly more correct on the unmapped-agent path; the
mapped-agent path is unchanged.

## Verification

- `dune build --root .` exits 0
- `dune exec test/test_voice_config.exe --root .` — existing config
  tests still pass
- `dune exec test/test_voice_command_descriptor_parity.exe --root .` —
  voice command parity test still passes
- E2E: with user's config (`default_voice: "Roger"`), invoking
  `Voice_bridge.agent_speak ~agent_id:"vincent"` now returns voice
  `"Roger"` instead of `"Sarah"`.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
