### PR TITLE
refactor(turn_mode_codec): cycle break — activate 12 stubbed descriptors

### DIFF
--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -161,16 +161,13 @@ let handle_masc_agent ~(config : Coord.config) ~(meta : keeper_meta) ~name ~args
   Tool_agent.dispatch ctx ~name ~args |> dispatch_option_to_string ~name
 ;;
 
-(* RFC-0182 §3.1 — masc_coord_ cluster (status / heartbeat / check /
-   reset / goal_ tools). [Tool_coord.dispatch] cannot be called directly
-   from here: it transitively depends on [Keeper_runtime →
-   Keeper_exec_tools → Agent_tool_runtime → Agent_tool_in_process_runtime],
-   so importing it would form a dependency cycle. Resolution options for
-   the follow-up PR: (a) split [Tool_coord] into a pure dispatch leaf,
-   (b) move keeper-coupled handlers out of [Tool_coord], or (c) lift the
-   cluster handler out of [lib/keeper/] into a layer above. For now the
-   descriptor entries route via this stub which surfaces the constraint
-   to callers instead of silently failing. *)
+(* RFC-0182 §3.1 — masc_coord_ cluster. Separate cycle from Tool_misc/
+   Tool_agent_timeline: Tool_coord → Keeper_runtime → Keeper_agent_error
+   → Keeper_agent_tool_surface → Keeper_tool_progress → Keeper_exec_tools
+   → Agent_tool_runtime → here. The Turn_mode_codec extraction did not
+   touch the Tool_coord ↔ Keeper_runtime edge. Still stubbed pending a
+   follow-up that splits Tool_coord or removes its Keeper_runtime
+   dependency. *)
 let handle_masc_coord ~config:_ ~meta:_ ~name ~args:_ =
   Yojson.Safe.to_string
     (`Assoc
@@ -178,58 +175,29 @@ let handle_masc_coord ~config:_ ~meta:_ ~name ~args:_ =
        , `String
            (Printf.sprintf
               "%s descriptor projection is pending: Tool_coord cycle resolution \
-               (see RFC-0182 §3.1 cycle audit note)."
+               (Tool_coord -> Keeper_runtime back edge, separate from \
+               Turn_mode_codec cycle break)."
               name)
        ])
 ;;
 
-(* RFC-0182 §3.1 — masc_misc cluster. Tool_misc transitively depends on
-   Config → Transport → Transport_read_model, and via Config also reaches
-   Tool_agent_timeline → Keeper_agent_error → ... → Agent_tool_runtime.
-   Importing it here would form a cycle. Same constraint as masc_coord
-   and masc_agent_timeline — stub until cycle is broken by upstream
-   refactor (see RFC-0182 §3.1 cycle audit notes). *)
-let handle_masc_misc ~config:_ ~meta:_ ~name ~args:_ =
-  Yojson.Safe.to_string
-    (`Assoc
-       [ "error"
-       , `String
-           (Printf.sprintf
-              "%s descriptor projection is pending: Tool_misc cycle resolution \
-               (Config -> Transport -> Transport_read_model)."
-              name)
-       ])
+(* RFC-0182 §3.1 — masc_misc cluster. Active after Turn_mode_codec
+   extraction (2026-05-27) broke the Tool_agent_timeline → Keeper_*
+   back edge that previously cycled Config → ... →
+   Agent_tool_in_process_runtime. *)
+let handle_masc_misc ~(config : Coord.config) ~(meta : keeper_meta) ~name ~args =
+  let ctx : Tool_misc.context = { config; agent_name = meta.name } in
+  Tool_misc.dispatch ctx ~name ~args |> dispatch_option_to_string ~name
 ;;
 
-(* RFC-0182 §3.1 — masc_control cluster. Tool_control may also cycle via
-   Config; stubbed for consistency with masc_misc / masc_agent_timeline /
-   masc_coord. To re-enable: confirm cycle and break upstream, or move
-   the handler to a layer above lib/keeper/. *)
-let handle_masc_control ~config:_ ~meta:_ ~name ~args:_ =
-  Yojson.Safe.to_string
-    (`Assoc
-       [ "error"
-       , `String
-           (Printf.sprintf
-              "%s descriptor projection is pending: Tool_control cycle resolution \
-               (likely shares Config-mediated cycle with Tool_misc)."
-              name)
-       ])
+let handle_masc_control ~(config : Coord.config) ~(meta : keeper_meta) ~name ~args =
+  let ctx : Tool_control.context = { config; agent_name = meta.name } in
+  Tool_control.dispatch ctx ~name ~args |> dispatch_option_to_string ~name
 ;;
 
-(* RFC-0182 §3.1 — masc_agent_timeline singleton. Same dependency-cycle
-   constraint as masc_coord (Tool_agent_timeline transitively depends on
-   Keeper_agent_error). Stub for now. *)
-let handle_masc_agent_timeline ~config:_ ~meta:_ ~name ~args:_ =
-  Yojson.Safe.to_string
-    (`Assoc
-       [ "error"
-       , `String
-           (Printf.sprintf
-              "%s descriptor projection is pending: Tool_agent_timeline cycle \
-               resolution (same constraint as masc_coord cluster)."
-              name)
-       ])
+let handle_masc_agent_timeline ~(config : Coord.config) ~(meta : keeper_meta) ~name ~args =
+  let ctx : Tool_agent_timeline.context = { config; agent_name = meta.name } in
+  Tool_agent_timeline.dispatch ctx ~name ~args |> dispatch_option_to_string ~name
 ;;
 
 let handle_masc_local_runtime ~name ~args =

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -65,7 +65,13 @@ let scheduled_autonomous_outcome_of_result
   | false, true -> Proactive_tool_use
   | true, true -> Proactive_mixed_response
 
-type turn_mode =
+(* RFC-0182 §3.1 cycle break (2026-05-27) — [turn_mode] and its
+   codec functions were extracted to [Turn_mode_codec] in lib/ so
+   [Tool_agent_timeline] can parse keeper turn payloads without
+   importing this module (which would form a Config-mediated dependency
+   cycle with [Agent_tool_in_process_runtime]). The local re-export
+   keeps existing callers source-compatible. *)
+type turn_mode = Turn_mode_codec.turn_mode =
   | Tool_use
   | Text_response
   | Skip_text
@@ -281,24 +287,10 @@ let record_keeper_idle_seconds ~keeper_name ~idle_seconds =
     ~labels:[ ("keeper_name", keeper_name) ]
     (float_of_int (max 0 idle_seconds))
 
-let turn_mode_to_string = function
-  | Tool_use -> "tool_use"
-  | Text_response -> "text_response"
-  | Skip_text -> "skip_text"
-  | Noop -> "noop"
-
-let turn_mode_of_string (raw : string) : turn_mode option =
-  match String.trim raw with
-  | "tool_use" -> Some Tool_use
-  | "text_response" -> Some Text_response
-  | "skip_text" -> Some Skip_text
-  | "noop" -> Some Noop
-  | _ -> None
-
-let work_kind_of_turn_mode = function
-  | Tool_use -> "tool_use"
-  | Noop -> "noop"
-  | Text_response | Skip_text -> "text_turn"
+(* RFC-0182 §3.1 cycle break — codecs live in [Turn_mode_codec]. *)
+let turn_mode_to_string = Turn_mode_codec.turn_mode_to_string
+let turn_mode_of_string = Turn_mode_codec.turn_mode_of_string
+let work_kind_of_turn_mode = Turn_mode_codec.work_kind_of_turn_mode
 
 let is_observation_only_tool_name name =
   not (Keeper_tool_progress.is_execution_progress_tool_name name)
@@ -444,28 +436,8 @@ let turn_mode_of_result (result : Keeper_agent_run.run_result) : turn_mode =
   else if String.starts_with ~prefix:"SKIP:" text then Skip_text
   else Text_response
 
-let turn_mode_of_json (json : Yojson.Safe.t) : turn_mode option =
-  match Safe_ops.json_string_opt "turn_mode" json with
-  | Some raw -> turn_mode_of_string raw
-  | None ->
-      (match Safe_ops.json_string_opt "selected_mode" json with
-       | Some raw -> turn_mode_of_string raw
-       | None ->
-           match Safe_ops.json_string_opt "work_kind" json with
-           | Some "tool_use" -> Some Tool_use
-           | Some "noop" -> Some Noop
-           | Some "text_turn" -> Some Text_response
-           | _ -> None)
-
-let work_kind_of_json (json : Yojson.Safe.t) : string option =
-  match turn_mode_of_json json with
-  | Some mode -> Some (work_kind_of_turn_mode mode)
-  | None ->
-      (match Safe_ops.json_string_opt "work_kind" json with
-       | Some raw ->
-           let value = String.trim raw in
-           if value = "" then None else Some value
-       | None -> None)
+let turn_mode_of_json = Turn_mode_codec.turn_mode_of_json
+let work_kind_of_json = Turn_mode_codec.work_kind_of_json
 
 let observed_triggers_of_observation
     ?meta

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -378,7 +378,9 @@ let turn_completed_events (config : Coord.config) ~agent_name ~limit :
        let latency_ms = Safe_ops.json_int_opt "latency_ms" e.payload in
        let model_used = Safe_ops.json_string ~default:"unknown" "model_used" e.payload in
        let work_kind =
-         Keeper_unified_metrics.work_kind_of_json e.payload
+         (* RFC-0182 §3.1 cycle break — codec moved to lib/Turn_mode_codec
+            (was Keeper_unified_metrics.work_kind_of_json in lib/keeper/). *)
+         Turn_mode_codec.work_kind_of_json e.payload
          |> Option.value ~default:"unknown"
        in
        let context_ratio = Safe_ops.json_float_opt "context_ratio" e.payload in

--- a/lib/turn_mode_codec.ml
+++ b/lib/turn_mode_codec.ml
@@ -1,0 +1,54 @@
+(** See [turn_mode_codec.mli] for documentation.
+
+    RFC-0182 §3.1 cycle break: pure codec extracted from
+    [Keeper_unified_metrics_support] so [Tool_agent_timeline] can parse
+    keeper turn payloads without importing [lib/keeper], which previously
+    formed a cycle with [Agent_tool_in_process_runtime]. *)
+
+type turn_mode =
+  | Tool_use
+  | Text_response
+  | Skip_text
+  | Noop
+
+let turn_mode_to_string = function
+  | Tool_use -> "tool_use"
+  | Text_response -> "text_response"
+  | Skip_text -> "skip_text"
+  | Noop -> "noop"
+
+let turn_mode_of_string (raw : string) : turn_mode option =
+  match String.trim raw with
+  | "tool_use" -> Some Tool_use
+  | "text_response" -> Some Text_response
+  | "skip_text" -> Some Skip_text
+  | "noop" -> Some Noop
+  | _ -> None
+
+let work_kind_of_turn_mode = function
+  | Tool_use -> "tool_use"
+  | Noop -> "noop"
+  | Text_response | Skip_text -> "text_turn"
+
+let turn_mode_of_json (json : Yojson.Safe.t) : turn_mode option =
+  match Safe_ops.json_string_opt "turn_mode" json with
+  | Some raw -> turn_mode_of_string raw
+  | None ->
+      (match Safe_ops.json_string_opt "selected_mode" json with
+       | Some raw -> turn_mode_of_string raw
+       | None ->
+           match Safe_ops.json_string_opt "work_kind" json with
+           | Some "tool_use" -> Some Tool_use
+           | Some "noop" -> Some Noop
+           | Some "text_turn" -> Some Text_response
+           | _ -> None)
+
+let work_kind_of_json (json : Yojson.Safe.t) : string option =
+  match turn_mode_of_json json with
+  | Some mode -> Some (work_kind_of_turn_mode mode)
+  | None ->
+      (match Safe_ops.json_string_opt "work_kind" json with
+       | Some raw ->
+           let value = String.trim raw in
+           if value = "" then None else Some value
+       | None -> None)

--- a/lib/turn_mode_codec.mli
+++ b/lib/turn_mode_codec.mli
@@ -1,0 +1,38 @@
+(** Pure codec for the [turn_mode] enum and its [work_kind] projection.
+
+    Extracted from [Keeper_unified_metrics_support] (RFC-0182 §3.1 cycle
+    break audit, 2026-05-27): the previous owner module lived in
+    [lib/keeper], which created a [Tool_agent_timeline -> Keeper_*] back
+    edge through [work_kind_of_json]. That back edge formed a dependency
+    cycle when [Agent_tool_in_process_runtime] (in [lib/keeper]) tried
+    to call [Tool_misc.dispatch] / [Tool_control.dispatch] /
+    [Tool_agent_timeline.dispatch] through descriptor projection.
+
+    Moving the pure parsing helpers into [lib] (above [lib/keeper] in
+    the dependency graph) is sufficient to dissolve the cycle. The
+    semantic functions in [Keeper_unified_metrics_support] continue to
+    live in [lib/keeper] and re-use these primitives. *)
+
+type turn_mode =
+  | Tool_use
+  | Text_response
+  | Skip_text
+  | Noop
+
+val turn_mode_to_string : turn_mode -> string
+val turn_mode_of_string : string -> turn_mode option
+
+val work_kind_of_turn_mode : turn_mode -> string
+(** Returns the broader "work kind" bucket for a turn mode:
+    [Tool_use -> "tool_use"], [Noop -> "noop"],
+    [Text_response | Skip_text -> "text_turn"]. *)
+
+val turn_mode_of_json : Yojson.Safe.t -> turn_mode option
+(** Reads [turn_mode] or [selected_mode] string fields from the JSON
+    payload, falling back to a legacy [work_kind] field for backwards
+    compatibility with older keeper turn records. *)
+
+val work_kind_of_json : Yojson.Safe.t -> string option
+(** First tries [turn_mode_of_json] then projects via
+    [work_kind_of_turn_mode]; falls back to a literal [work_kind]
+    string when no typed mode is present. Empty strings are rejected. *)


### PR DESCRIPTION
## Summary

RFC-0182 §3.1 cycle break. Extracts pure codec from `lib/keeper/` to
`lib/` so descriptor projection can route through `Tool_misc` /
`Tool_control` / `Tool_agent_timeline` without forming a dependency
cycle.

## Background

PR #18785 (Phase 3) registered 14 descriptor entries but had to stub
12 of them. The cycle was:

```
Config → Tool_agent_timeline → Keeper_unified_metrics.work_kind_of_json
      → Keeper_unified_metrics_support → Keeper_* chain
      → Agent_tool_runtime → Agent_tool_in_process_runtime
      → Tool_misc / Tool_control / Tool_agent_timeline → Config
```

The single back edge that pulled `lib/keeper` into `Config`'s
downstream was at `lib/tool_agent_timeline.ml:381`:

```ocaml
Keeper_unified_metrics.work_kind_of_json e.payload
```

## Change

New module `lib/turn_mode_codec` with the pure codec primitives. Both
`Keeper_unified_metrics_support` and `Tool_agent_timeline` re-use it.
Source-compatible re-export: `type turn_mode = Turn_mode_codec.turn_mode = Tool_use | ...`.

## Newly-active descriptors

| Cluster | Tools | Was | Now |
|---|---|---|---|
| `masc_misc_*` | 9 | 🟡 stub | ✅ active |
| `masc_control_*` | 2 | 🟡 stub | ✅ active |
| `masc_agent_timeline` | 1 | 🟡 stub | ✅ active |

After merge: **58 / 105** non-portal tools actively routed (55%).

## Still stubbed

`masc_coord_*` (8 tools) — separate cycle through
`Tool_coord → Keeper_runtime → ...`. Not addressed by this refactor.

## Test plan

- [x] `dune build --root . @lib/check` — clean
- [ ] CI build
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
