### PR TITLE
refactor(cdal): purge substring evidence fallback

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-26 23:57:25 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-27 00:04:47 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -733,9 +733,15 @@
           </tr>
           <tr>
             <td>Dashboard dev-token legacy file fallback</td>
-            <td><span class="status now">draft PR #18788</span></td>
+            <td><span class="status done">merged #18788</span></td>
             <td>Stop reading, migrating, or deleting legacy <code>.masc/auth/dashboard-dev.token</code>. The runtime now only accepts the canonical <code>.masc/auth/dashboard.token</code> dev-token file, and doctor reports only that canonical file as present.</td>
-            <td>PR #18788 branch <code>refactor/purge-dashboard-dev-token-legacy-20260526</code>. Tests assert the old file is ignored and left untouched while <code>ensure_dashboard_dev_token</code> mints/reuses only the canonical dashboard token.</td>
+            <td>Merged as <code>c0691f6c7</code>. Tests assert the old file is ignored and left untouched while <code>ensure_dashboard_dev_token</code> mints/reuses only the canonical dashboard token.</td>
+          </tr>
+          <tr>
+            <td>CDAL evidence-gate substring fallback</td>
+            <td><span class="status now">local branch</span></td>
+            <td>Remove the legacy PR/artifact substring fallback from <code>Cdal_evidence_gate</code>. Contracted verification submissions now fail closed with <code>cdal_verdict_missing</code> until a typed CDAL verdict exists.</td>
+            <td>Branch <code>refactor/purge-cdal-substring-fallback-20260526</code>. Decision-matrix tests flip the old “PR ref passes without verdict” case to a missing-verdict rejection.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>

--- a/docs/rfc/RFC-0109-cdal-goal-integration-contract.md
+++ b/docs/rfc/RFC-0109-cdal-goal-integration-contract.md
@@ -10,7 +10,7 @@ implementation_prs:
     title: "typed eval_criteria + producer migration + tests"
   - phase: D
     state: draft
-    title: "Cdal_evidence_gate — typed verdict consultation + legacy substring fallback"
+    title: "Cdal_evidence_gate — typed verdict consultation"
 ---
 
 # RFC-0109 — CDAL × GOAL Integration Contract
@@ -398,7 +398,7 @@ queryable via `Cdal_verdict_gate.lookup_latest_verdict ~task_id`:
 | `Some Violated` | **Reject** with typed `findings[]` in error payload | Skipped |
 | `Some Inconclusive` | **Pass** only if `contract.required_evidence` satisfied; else `Reject` with completeness_gaps | Skipped |
 | `None` AND `task.contract = None` | **Pass** (analysis-only task; current gate bypass behavior preserved) | Skipped |
-| `None` AND `task.contract = Some _` | **Fall through** to current substring shim (legacy behavior) | Active |
+| `None` AND `task.contract = Some _` | **Reject** with missing-verdict payload | Removed |
 
 ### 6.5.3 Wiring sketch
 
@@ -411,29 +411,27 @@ let submit_evidence_error =
     (match Cdal_verdict_gate.lookup_latest_verdict ~task_id with
      | Some { status = Satisfied; _ } -> None
      | Some ({ status = Violated; _ } as v) ->
-       Some (Cdal_evidence_error.of_verdict v)
+       Some (workflow_rejection_of_violated_verdict v)
      | Some ({ status = Inconclusive; _ } as v) ->
-       Cdal_evidence_error.inconclusive_with_required_evidence v task
+       workflow_rejection_of_inconclusive_verdict v task
      | None when task_opt |> Option.bind (fun t -> t.contract) |> Option.is_none ->
        None  (* analysis-only task: gate bypass *)
      | None ->
-       (* legacy substring shim, preserved *)
-       Tool_task_completion_review.verification_submission_evidence_error
-         ~notes ~handoff_context)
+       Some (workflow_rejection ~rule_id:"cdal_verdict_missing" task_id))
   | _ -> None
 ```
 
-`Cdal_evidence_error` is a new helper that projects typed findings
-to the operator-readable error payload, replacing the current
-hint-string-only feedback.
+`Cdal_evidence_gate` projects typed findings and missing-verdict
+state into the operator-readable workflow-rejection payload, replacing
+the old hint-string-only feedback.
 
 ### 6.5.4 Phase D PR — call sites
 
 | File | Change |
 |------|--------|
-| `lib/cdal_runtime/cdal_evidence_error.{ml,mli}` | New — verdict → workflow_rejection payload projection with findings |
-| `lib/tool_task.ml` | Replace inline substring-only call with the layered Cdal-first decision |
-| `lib/tool_task_completion_review.ml` | Demote `verification_submission_evidence_error` to fallback; keep public surface for `task.contract = Some _` legacy path |
+| `lib/cdal_evidence_gate.{ml,mli}` | Verdict → workflow_rejection payload projection with findings, completeness gaps, and missing-verdict state |
+| `lib/tool_task.ml` | Replace inline substring-only call with the typed CDAL evidence decision |
+| `lib/tool_task_completion_review.ml` | Delete the fallback-only verification-evidence helper path |
 | `lib/keeper/keeper_tools_oas_handler.ml` | Carry typed findings through `workflow_rejection_payload_json` so the operator sees verdict.findings, not just a hint string |
 | `test/test_tool_task_evidence_gate.ml` | New — 5-case decision matrix (table above) |
 | `test/test_tool_task_completion_review.ml` | Update — gate bypass for task.contract = None |
@@ -528,7 +526,7 @@ block" pain that triggered this amendment.
 | Unit (Phase B) | `Goal_phase_bridge.maybe_react` decision matrix |
 | Integration (Phase B) | Temp Goal Store + Cdal_eval_v1 + bridge; verify phase advances |
 | Integration (Phase C) | `Coord_goals.handle_goal_transition` calls `Cdal_runtime.Triggers.evaluate_for_goal` once |
-| Unit (Phase D) | 5-case decision matrix from §6.5.2: Satisfied → pass; Violated → reject with findings; Inconclusive → required_evidence check; None + contract=None → bypass; None + contract=Some → substring fallback |
+| Unit (Phase D) | 5-case decision matrix from §6.5.2: Satisfied → pass; Violated → reject with findings; Inconclusive → required_evidence check; None + contract=None → bypass; None + contract=Some → missing-verdict rejection |
 | Integration (Phase D) | End-to-end keeper_task_done with a bound Cdal verdict; assert workflow_rejection payload carries typed `findings[]` not just hint string |
 | Property | Bridge idempotence — re-applying same verdict yields no second transition |
 | Live | 1-day live observation post-Phase-B: `cdal_goal_phase_transitions_total{}` counter > 0 if any CDAL evaluator emits Violated |

--- a/lib/cdal_evidence_gate.ml
+++ b/lib/cdal_evidence_gate.ml
@@ -9,7 +9,7 @@ type decision =
 
 let rule_id_violated = "cdal_verdict_violated"
 let rule_id_inconclusive = "cdal_verdict_inconclusive_incomplete"
-let rule_id_substring_fallback = "submit_verification_missing_evidence"
+let rule_id_missing_verdict = "cdal_verdict_missing"
 
 let string_list_to_json xs = `List (List.map (fun s -> `String s) xs)
 
@@ -73,16 +73,18 @@ let hint_inconclusive =
    close the entries in [payload.completeness_gaps]) and re-run the \
    contract evaluator."
 
-(* Reuses the existing substring-shim message verbatim so operator-facing
-   error text matches the legacy gate when the fallback path triggers. *)
-let hint_substring_fallback =
-  Tool_task_completion_review.verification_evidence_error_message
+let reason_missing_verdict =
+  "CDAL verdict is missing for a contracted task; submit_for_verification \
+   requires a typed verdict before workflow evidence is accepted."
+
+let hint_missing_verdict =
+  "Run the contract evaluator for this task and retry after a Satisfied, \
+   Violated, or Inconclusive CDAL verdict is recorded."
 
 (* Heuristic: an "evidence entry" is satisfied when the notes or
    handoff_context.evidence_refs mention a non-placeholder string that
-   names it (substring match). This mirrors the legacy substring shim's
-   placeholder rejection. Only used for the Inconclusive arm of the
-   decision matrix; Satisfied/Violated do not consult this. *)
+   names it. Only used for the Inconclusive arm of the decision matrix;
+   Satisfied/Violated/missing-verdict decisions do not consult this. *)
 let evidence_entry_satisfied
     ~notes
     ~(handoff_context : Masc_domain.task_handoff_context option)
@@ -140,21 +142,6 @@ let task_has_contract (task_opt : Masc_domain.task option) =
 let default_lookup ~task_id =
   Cdal_verdict_gate.lookup_latest_verdict ~warn_on_missing:false ~task_id ()
 
-let substring_fallback ~notes ~handoff_context =
-  match
-    Tool_task_completion_review.verification_submission_evidence_error
-      ~notes
-      ~handoff_context
-  with
-  | None -> Pass
-  | Some reason ->
-    Reject
-      { reason
-      ; rule_id = rule_id_substring_fallback
-      ; hint = hint_substring_fallback
-      ; payload_json = `Null
-      }
-
 let decide
     ?(lookup = default_lookup)
     ~task_id
@@ -205,7 +192,18 @@ let decide
            })
   | None ->
     if task_has_contract task_opt
-    then substring_fallback ~notes ~handoff_context
+    then
+      Reject
+        { reason = reason_missing_verdict
+        ; rule_id = rule_id_missing_verdict
+        ; hint = hint_missing_verdict
+        ; payload_json =
+            `Assoc
+              [ "task_id", `String task_id
+              ; "contract_required", `Bool true
+              ; "verdict_status", `String "missing"
+              ]
+        }
     else
       (* Analysis-only task bypass: a task with no contract has nothing to
          verify, so the gate must not block keeper_task_done. This is the

--- a/lib/cdal_evidence_gate.mli
+++ b/lib/cdal_evidence_gate.mli
@@ -3,11 +3,9 @@
     Layered evidence-gate decision for [submit_for_verification] /
     [submit_pr_evidence] / [Done_action when done_redirects_to_verification].
 
-    Replaces the substring-classifier-only gate in
-    [Tool_task_completion_review.verification_submission_evidence_error]
-    (§2.3 workaround signature #2 per RFC-0001) with a typed CDAL
-    verdict consultation, falling back to the legacy substring shim
-    only when no verdict is available and the task carries a contract.
+    Replaces the old substring-classifier-only verification gate with a
+    typed CDAL verdict consultation. Contracted tasks now fail closed
+    when no verdict is available.
 
     Decision matrix (see RFC-0109 §6.5.2):
 
@@ -17,7 +15,7 @@
     | [Some Violated] | any | [Reject] with typed findings |
     | [Some Inconclusive] | any | [Pass] if [required_evidence] satisfied; else [Reject] with completeness_gaps + required list |
     | [None] | [None] | [Pass] (analysis-only task bypass) |
-    | [None] | [Some _] | fall through to legacy substring shim |
+    | [None] | [Some _] | [Reject] with missing-verdict payload |
 
     @since RFC-0109 Phase D (2026-05-26) *)
 
@@ -40,10 +38,9 @@ val rule_id_violated : string
 val rule_id_inconclusive : string
 (** ["cdal_verdict_inconclusive_incomplete"] *)
 
-val rule_id_substring_fallback : string
-(** ["submit_verification_missing_evidence"] — preserved verbatim from
-    the legacy gate so operators / log queries / dashboards keyed on
-    this rule_id keep working. *)
+val rule_id_missing_verdict : string
+(** ["cdal_verdict_missing"] — a contracted task tried to submit
+    verification evidence before a typed CDAL verdict existed. *)
 
 (** Build the typed JSON payload describing a [Violated] verdict's
     rejection. Embedded in [workflow_rejection_payload_json] so the

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -313,11 +313,9 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
       | None -> action
     else action
   in
-  (* RFC-0109 Phase D: layered evidence gate. CDAL verdict (when
-     available) takes precedence over the substring shim; analysis-only
-     tasks (no contract) bypass the gate. Legacy substring shim is
-     preserved as the fallback path for tasks that have a contract but
-     no CDAL verdict has been emitted yet. *)
+  (* RFC-0109 Phase D hard cut: contracted verification submissions
+     require a typed CDAL verdict. Analysis-only tasks (no contract)
+     bypass the gate. *)
   let evidence_decision =
     let needs_gate =
       match requested_action with

--- a/lib/tool_task_completion_review.ml
+++ b/lib/tool_task_completion_review.ml
@@ -122,21 +122,6 @@ let handoff_context_has_verification_artifact_ref = function
       List.exists evidence_ref_has_verification_artifact_ref refs
   | None -> false
 
-let verification_submission_evidence_error ~notes ~handoff_context =
-  if notes_have_verification_artifact_ref notes
-     || handoff_context_has_verification_artifact_ref handoff_context
-  then None
-  else
-    Some
-      "submit_for_verification requires verification evidence: include pr_url \
-       for the draft PR, a PR # reference, or an explicit \
-       artifact/file/path/commit/branch reference in notes."
-
-let verification_evidence_error_message =
-  "submit_for_verification requires verification evidence: include pr_url \
-   for the draft PR, a PR # reference, or an explicit \
-   artifact/file/path/commit/branch reference in notes."
-
 let concrete_verification_evidence_refs ?(notes = "") ?handoff_context
     (task : Masc_domain.task) =
   let contract_refs =

--- a/test/test_cdal_evidence_gate.ml
+++ b/test/test_cdal_evidence_gate.ml
@@ -119,12 +119,12 @@ let test_violated_verdict_rejects_with_findings () =
       ~lookup:(lookup_returns (Some verdict))
       ~task_id:"task-violated"
       ~task_opt:(Some (make_task ()))
-      ~notes:"PR #999"  (* substring shim would Pass; CDAL takes precedence *)
+      ~notes:"PR #999"
       ~handoff_context:None
       ()
   with
   | Gate.Pass ->
-    fail "Violated verdict should Reject even when substring shim would Pass"
+    fail "Violated verdict should Reject even when notes contain a PR ref"
   | Gate.Reject { rule_id; payload_json; reason; _ } ->
     check string "rule_id" Gate.rule_id_violated rule_id;
     check bool "reason mentions Violated" true
@@ -249,8 +249,8 @@ let test_no_verdict_no_task_bypasses () =
     failf "Missing task should Pass, got Reject rule_id=%s" rule_id
 
 (* §6.5.2 row 5a: None verdict + task.contract = Some _ +
-   notes carry PR ref → Pass via substring fallback *)
-let test_substring_fallback_passes_with_pr_ref () =
+   notes carry PR ref → Reject; substring fallback is gone. *)
+let test_missing_verdict_rejects_even_with_pr_ref () =
   let contract = make_contract () in
   let task = make_task ~contract:(Some contract) () in
   match
@@ -262,16 +262,20 @@ let test_substring_fallback_passes_with_pr_ref () =
       ~handoff_context:None
       ()
   with
-  | Gate.Pass -> ()
-  | Gate.Reject { rule_id; _ } ->
-    failf
-      "Substring fallback should Pass when notes carry PR ref; got Reject \
-       rule_id=%s"
-      rule_id
+  | Gate.Pass ->
+    fail "Missing CDAL verdict should Reject even when notes carry PR ref"
+  | Gate.Reject { rule_id; payload_json; _ } ->
+    check string "rule_id" Gate.rule_id_missing_verdict rule_id;
+    (match payload_json with
+     | `Assoc fields ->
+       (match List.assoc_opt "verdict_status" fields with
+        | Some (`String s) -> check string "verdict_status" "missing" s
+        | _ -> fail "payload missing verdict_status")
+     | _ -> fail "payload is not Assoc")
 
 (* §6.5.2 row 5b: None verdict + task.contract = Some _ +
-   notes empty → Reject via substring fallback with legacy rule_id *)
-let test_substring_fallback_rejects_when_empty () =
+   notes empty → Reject with missing-verdict rule_id *)
+let test_missing_verdict_rejects_when_empty () =
   let contract = make_contract () in
   let task = make_task ~contract:(Some contract) () in
   match
@@ -284,19 +288,17 @@ let test_substring_fallback_rejects_when_empty () =
       ()
   with
   | Gate.Pass ->
-    fail "Substring fallback should Reject when notes are empty and contract is set"
+    fail "Missing CDAL verdict should Reject when contract is set"
   | Gate.Reject { rule_id; _ } ->
-    check string "legacy rule_id preserved"
-      Gate.rule_id_substring_fallback
-      rule_id
+    check string "rule_id" Gate.rule_id_missing_verdict rule_id
 
 (* Bonus: rule_id constants are stable strings consumers can match on *)
 let test_rule_id_constants_are_stable () =
   check string "violated rule_id" "cdal_verdict_violated" Gate.rule_id_violated;
   check string "inconclusive rule_id" "cdal_verdict_inconclusive_incomplete"
     Gate.rule_id_inconclusive;
-  check string "substring fallback rule_id" "submit_verification_missing_evidence"
-    Gate.rule_id_substring_fallback
+  check string "missing verdict rule_id" "cdal_verdict_missing"
+    Gate.rule_id_missing_verdict
 
 let () =
   Alcotest.run
@@ -315,10 +317,10 @@ let () =
             `Quick test_no_verdict_no_contract_bypasses
         ; test_case "row 4 variant: None + task_opt=None → Pass" `Quick
             test_no_verdict_no_task_bypasses
-        ; test_case "row 5a: None + contract=Some + PR ref → Pass (substring shim)"
-            `Quick test_substring_fallback_passes_with_pr_ref
-        ; test_case "row 5b: None + contract=Some + empty notes → Reject (legacy rule_id)"
-            `Quick test_substring_fallback_rejects_when_empty
+        ; test_case "row 5a: None + contract=Some + PR ref → Reject"
+            `Quick test_missing_verdict_rejects_even_with_pr_ref
+        ; test_case "row 5b: None + contract=Some + empty notes → Reject"
+            `Quick test_missing_verdict_rejects_when_empty
         ] )
     ; ( "stable constants"
       , [ test_case "rule_id constants" `Quick test_rule_id_constants_are_stable


### PR DESCRIPTION
## Summary
- remove the Cdal_evidence_gate PR/artifact substring fallback for contracted tasks without a verdict
- reject contracted verification submissions with cdal_verdict_missing until a typed CDAL verdict exists
- delete the fallback-only Tool_task_completion_review evidence helper and flip the decision-matrix tests
- update the purge ledger and RFC-0109 docs

## Verification
- ocamlformat --check lib/cdal_evidence_gate.ml lib/cdal_evidence_gate.mli lib/tool_task.ml lib/tool_task_completion_review.ml test/test_cdal_evidence_gate.ml
- git diff --check origin/main...HEAD
- rg backstop for removed substring-fallback symbols and wording
- scripts/dune-local.sh build ./test/test_cdal_evidence_gate.exe (blocked: exit 75, machine-wide bare Dune processes detected; did not bypass guard)