### PR TITLE
fix(dashboard): unify keeper pause SSOT display

### DIFF
--- a/dashboard/src/components/keeper-action-panel.test.ts
+++ b/dashboard/src/components/keeper-action-panel.test.ts
@@ -62,6 +62,27 @@ describe('keeperActionVisibility', () => {
       expect(v.canWake).toBe(false)
     })
 
+    it('detects paused via status even if phase is missing', () => {
+      const k = makeKeeper({ status: 'paused', phase: null, paused: false })
+      const v = keeperActionVisibility(k)
+      expect(v.canResume).toBe(true)
+      expect(v.canPause).toBe(false)
+      expect(v.canWake).toBe(false)
+    })
+
+    it('detects paused via pipeline_stage even if status is active', () => {
+      const k = makeKeeper({
+        status: 'active',
+        phase: 'Running',
+        paused: false,
+        pipeline_stage: 'paused',
+      })
+      const v = keeperActionVisibility(k)
+      expect(v.canResume).toBe(true)
+      expect(v.canPause).toBe(false)
+      expect(v.canWake).toBe(false)
+    })
+
     it('does not show wake while paused even if a recoverable blocker is latched', () => {
       const k = makeKeeper({
         status: 'active',

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -16,6 +16,7 @@
 
 import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
 import { CARD_STANDARD } from './common/card'
 import { ActionButton } from './common/button'
 import { requestConfirm } from './common/confirm-dialog'
@@ -35,6 +36,9 @@ import {
   applyOptimisticKeeperDirectives,
   invalidateDashboardCache,
   refreshDashboard,
+  refreshExecution,
+  executionLoaded,
+  executionLoading,
   keepers,
 } from '../store'
 import type { Keeper } from '../types'
@@ -42,6 +46,7 @@ import {
   keeperActionVisibility,
   isKeeperOperatorTargetable,
 } from '../lib/keeper-predicates'
+import { keeperPauseDisplay } from '../lib/keeper-runtime-display'
 
 // ── Shared helpers ────────────────────────────────────────────────────────
 
@@ -107,6 +112,7 @@ async function runKeeperAction(
 function KeeperActionRow({ keeper }: { keeper: Keeper }) {
   const busy = useSignal(false)
   const vis = keeperActionVisibility(keeper)
+  const pauseDisplay = keeperPauseDisplay(keeper)
 
   async function handle(action: KeeperActionKey) {
     if (busy.value) return
@@ -128,23 +134,35 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
 
   return html`
     <article
-      class="flex flex-wrap items-center gap-2 px-3 py-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
+      class="flex flex-wrap items-start gap-2 px-3 py-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
       data-testid="keeper-action-row"
-      aria-label="${keeper.name} 액션"
+      aria-label="${keeper.name} 액션${pauseDisplay ? `: ${pauseDisplay.detail}` : ''}"
     >
-      <div class="flex items-center gap-2 min-w-0 flex-1">
-        <span class="text-xs font-semibold text-[var(--color-fg-secondary)] truncate max-w-28">${keeper.name}</span>
-        <${KeeperPhaseBadge} phase=${keeper.phase} compact />
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-2 min-w-0">
+          <span class="text-xs font-semibold text-[var(--color-fg-secondary)] truncate max-w-28">${keeper.name}</span>
+          <${KeeperPhaseBadge} phase=${keeper.phase} compact />
+        </div>
         <!--
           RFC-0135 §1.2: the previous auxiliary "일시정지" <span> at this
           position duplicated KeeperPhaseBadge's "⏸ 일시정지" output and
           colocated the *state noun* "일시정지" with the *verb button*
           "일시정지" later in the row — the user reported this as
           confusing on 2026-05-19. The badge already renders the state;
-          this slot is intentionally empty so the action buttons own the
-          verb meaning. PR-7 will further disambiguate by appending "하기"
-          to verb-button labels.
+          the line below carries reason/next-action evidence, not a
+          second paused-state noun. Verb buttons keep the "하기" suffix.
         -->
+        ${pauseDisplay
+          ? html`
+            <div
+              class="mt-1 max-w-full truncate text-3xs leading-[1.35] text-[var(--color-fg-muted)]"
+              title=${pauseDisplay.title}
+              data-testid="keeper-pause-detail"
+            >
+              ${pauseDisplay.detail}
+            </div>
+          `
+          : null}
       </div>
       <div class="flex items-center gap-1 shrink-0">
         ${vis.canBoot
@@ -250,6 +268,17 @@ async function runBulkKeeperDirective(
  */
 export function KeeperActionPanel() {
   const keeperList = keepers.value
+  const loaded = executionLoaded.value
+  const loading = executionLoading.value
+
+  useEffect(() => {
+    if (loaded || loading) return
+    void refreshExecution({ force: true }).catch(err => {
+      const message = err instanceof Error ? err.message : 'execution refresh failed'
+      showToast(message, 'warning')
+    })
+  }, [loaded, loading])
+
   // RFC-0135 PR-9b: route the "should we show this keeper in the action
   // panel?" filter through the typed predicates instead of an inline OR
   // chain — paused keepers should still appear (so operator can resume)
@@ -280,7 +309,7 @@ export function KeeperActionPanel() {
     }
   }
 
-  if (keeperList.length === 0) {
+  if (keeperList.length === 0 && loaded) {
     return null
   }
 
@@ -297,11 +326,12 @@ export function KeeperActionPanel() {
             Fleet-level lifecycle controls. Pause, resume, wake, boot, or shut down individual keepers.
           </p>
         </div>
-        <div class="flex gap-1.5" data-testid="keeper-action-panel-bulk">
+        <div class="flex flex-wrap justify-end gap-1.5" data-testid="keeper-action-panel-bulk">
           ${resumableNames.length > 0
             ? html`<${ActionButton}
                 variant="ok"
                 size="sm"
+                class="whitespace-nowrap"
                 disabled=${bulkBusy.value}
                 onClick=${async () => {
                   const ok = await requestConfirm({
@@ -318,6 +348,7 @@ export function KeeperActionPanel() {
             ? html`<${ActionButton}
                 variant="ghost"
                 size="sm"
+                class="whitespace-nowrap"
                 disabled=${bulkBusy.value}
                 onClick=${async () => {
                   const ok = await requestConfirm({
@@ -332,8 +363,10 @@ export function KeeperActionPanel() {
             : null}
         </div>
       </div>
-      ${online.length === 0
-        ? html`<div class="text-2xs text-[var(--color-fg-muted)]">온라인 키퍼 없음</div>`
+      ${keeperList.length === 0
+        ? html`<div class="text-2xs text-[var(--color-fg-muted)]">Execution SSOT 로딩 중</div>`
+        : online.length === 0
+          ? html`<div class="text-2xs text-[var(--color-fg-muted)]">온라인 키퍼 없음</div>`
         : html`
           <div class="flex flex-col gap-1.5" role="list">
             ${online.map(k => html`<${KeeperActionRow} keeper=${k} key=${k.name} />`)}

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -70,7 +70,7 @@ describe('deriveKeeperOperationalState — paused branch', () => {
     expect(state).toMatchObject({
       kind: 'paused',
       attention: 'clean',
-      cause: 'unknown',
+      cause: 'operator',
     })
   })
 
@@ -105,6 +105,47 @@ describe('deriveKeeperOperationalState — paused branch', () => {
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({ pause_state: 'paused' }),
       composite: null,
+    })
+    expect(state).toMatchObject({
+      kind: 'paused',
+      attention: 'clean',
+      cause: 'operator',
+    })
+  })
+
+  it('paused operator cause when only status === paused', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ status: 'paused', phase: null, paused: false }),
+      composite: null,
+    })
+    expect(state).toMatchObject({
+      kind: 'paused',
+      attention: 'clean',
+      cause: 'operator',
+    })
+  })
+
+  it('paused operator cause when only pipeline_stage === paused', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({
+        status: 'active',
+        phase: 'Running',
+        paused: false,
+        pipeline_stage: 'paused',
+      }),
+      composite: null,
+    })
+    expect(state).toMatchObject({
+      kind: 'paused',
+      attention: 'clean',
+      cause: 'operator',
+    })
+  })
+
+  it('paused operator cause when composite phase is paused', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ phase: 'Running', status: 'active', paused: false }),
+      composite: makeComposite({ phase: 'paused' }),
     })
     expect(state).toMatchObject({
       kind: 'paused',

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -47,6 +47,10 @@ import type {
 } from '../api/schemas/keeper-composite'
 import { deriveBlockerReason } from './keeper-blocker-reason'
 import { keeperDisplayStatus } from './keeper-runtime-display'
+import {
+  isKeeperOffline,
+  isKeeperPaused,
+} from './keeper-predicates'
 
 export type OfflineCause = 'unbooted' | 'shutdown' | 'crashed' | 'dead' | 'unknown'
 export type PausedCause = 'operator' | 'supervisor' | 'auto_recover' | 'unknown'
@@ -120,8 +124,8 @@ export function deriveKeeperOperationalState(
   // callers don't need to keep parallel composite/flat fallback chains.
   const axes = computeKeeperOperationalAxes(keeper, composite)
 
-  if (isPaused(keeper)) {
-    return { kind: 'paused', ...axes, cause: derivePausedCause(keeper) }
+  if (isPaused(keeper, composite)) {
+    return { kind: 'paused', ...axes, cause: derivePausedCause(keeper, composite) }
   }
   if (isOffline(keeper, composite)) {
     return { kind: 'offline', ...axes, cause: deriveOfflineCause(keeper) }
@@ -163,35 +167,28 @@ function computeKeeperOperationalAxes(
   }
 }
 
-function isPaused(k: Keeper): boolean {
-  if (k.paused === true) return true
-  if (k.phase === 'Paused') return true
-  if (k.pause_state === 'paused') return true
+function isPaused(k: Keeper, c: KeeperCompositeSnapshot | null): boolean {
+  if (isKeeperPaused(k)) return true
+  if (toKeeperPhase(c?.phase) === 'Paused') return true
+  if (toKeeperPhase(c?.collapsed_from) === 'Paused') return true
+  if (c?.phase_diagnosis?.conditions.operator_paused === true) return true
   return false
 }
 
-function derivePausedCause(k: Keeper): PausedCause {
+function derivePausedCause(k: Keeper, c: KeeperCompositeSnapshot | null): PausedCause {
   if (k.runtime_blocker_class === 'supervisor_paused') return 'supervisor'
+  if (c?.phase_diagnosis?.conditions.operator_paused === true) return 'operator'
   if (k.pause_state === 'paused') return 'operator'
   if (k.phase === 'Paused') return 'operator'
+  if (isKeeperPaused(k)) return 'operator'
+  if (toKeeperPhase(c?.phase) === 'Paused') return 'operator'
+  if (toKeeperPhase(c?.collapsed_from) === 'Paused') return 'operator'
   return 'unknown'
 }
 
 function isOffline(k: Keeper, c: KeeperCompositeSnapshot | null): boolean {
   if (c !== null && (c.phase === 'Stopped' || c.phase === 'Dead')) return true
-  if (
-    k.phase === 'Offline'
-    || k.phase === 'Stopped'
-    || k.phase === 'Dead'
-    || k.phase === 'Crashed'
-    || k.phase === 'Zombie'
-  ) return true
-  const normalizedStatus = (k.status ?? '').toLowerCase()
-  return (
-    normalizedStatus === 'offline'
-    || normalizedStatus === 'inactive'
-    || normalizedStatus === 'unbooted'
-  )
+  return isKeeperOffline(k)
 }
 
 function deriveOfflineCause(k: Keeper): OfflineCause {

--- a/dashboard/src/lib/keeper-predicates.test.ts
+++ b/dashboard/src/lib/keeper-predicates.test.ts
@@ -32,6 +32,9 @@ describe('isKeeperPaused — RFC-0135 PR-3 SSOT', () => {
   it('returns true on pipeline_stage paused', () => {
     expect(isKeeperPaused(k({ pipeline_stage: 'paused' }))).toBe(true)
   })
+  it('returns true on pause_state paused', () => {
+    expect(isKeeperPaused(k({ pause_state: 'paused' }))).toBe(true)
+  })
   it('returns true on lowercased status paused', () => {
     expect(isKeeperPaused(k({ status: 'paused' }))).toBe(true)
   })

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -36,6 +36,7 @@ export interface KeeperPausedInput {
   paused?: boolean | null
   phase?: Keeper['phase'] | string | null
   pipeline_stage?: Keeper['pipeline_stage'] | string | null
+  pause_state?: Keeper['pause_state'] | string | null
   status?: string | null
 }
 
@@ -46,6 +47,7 @@ export function isKeeperPaused(keeper: KeeperPausedInput): boolean {
   if (keeper.paused === true) return true
   if (lowerToken(keeper.phase) === PAUSED_PHASE_LOWER) return true
   if (lowerToken(keeper.pipeline_stage) === PAUSED_LOWER_TOKEN) return true
+  if (lowerToken(keeper.pause_state) === PAUSED_LOWER_TOKEN) return true
   if (lowerToken(keeper.status) === PAUSED_LOWER_TOKEN) return true
   return false
 }

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -5,6 +5,7 @@ import {
   keeperActivityDisplay,
   keeperDisplayModel,
   keeperDisplayStatus,
+  keeperPauseDisplay,
   keeperRuntimeBlockerHint,
   keeperRuntimeBlockerLabel,
 } from './keeper-runtime-display'
@@ -157,6 +158,41 @@ describe('keeperDisplayModel', () => {
         ],
       }),
     ).toBeNull()
+  })
+})
+
+describe('keeperPauseDisplay', () => {
+  it('returns null for active keepers', () => {
+    expect(keeperPauseDisplay(makeKeeper({ status: 'active', phase: 'Running' }))).toBeNull()
+  })
+
+  it('surfaces blocker, next action, diagnostic, and raw axes for paused keepers', () => {
+    const display = keeperPauseDisplay(makeKeeper({
+      status: 'paused',
+      phase: 'Paused',
+      pipeline_stage: 'paused',
+      paused: true,
+      runtime_blocker_class: 'fiber_unresolved',
+      attention_reason: 'paused',
+      next_human_action: 'inspect_blocker_before_resume',
+      diagnostic: {
+        health_state: 'offline',
+        next_action_path: 'recover',
+        last_reply_status: 'unknown',
+        continuity_state: 'not_running',
+      },
+    }))
+
+    expect(display).toMatchObject({
+      reason: 'Fiber 미해결',
+      nextAction: 'inspect blocker before resume',
+      diagnostic: 'offline/not running',
+    })
+    expect(display?.detail).toContain('원인 Fiber 미해결')
+    expect(display?.detail).toContain('다음 inspect blocker before resume')
+    expect(display?.detail).toContain('진단 offline/not running')
+    expect(display?.title).toContain('paused=true')
+    expect(display?.title).toContain('status=paused')
   })
 })
 

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -26,6 +26,14 @@ interface KeeperModelDisplay {
   value: string
 }
 
+export interface KeeperPauseDisplay {
+  reason: string
+  nextAction: string | null
+  diagnostic: string | null
+  detail: string
+  title: string
+}
+
 type KeeperModelDisplaySource = {
   last_model_used_label?: string | null
   last_model_used?: string | null
@@ -133,6 +141,76 @@ export function keeperDisplayStatus(keeper: Keeper | null | undefined, fallbackS
   }
 
   return status && status.trim() !== '' ? status : 'unknown'
+}
+
+function firstNonEmpty(...values: Array<string | null | undefined>): string | null {
+  for (const value of values) {
+    const text = trimmed(value)
+    if (text) return text
+  }
+  return null
+}
+
+function codeLabel(value: string | null | undefined): string | null {
+  const text = trimmed(value)
+  return text ? text.replace(/_/g, ' ') : null
+}
+
+function attentionReasonForPause(value: string | null | undefined): string | null {
+  const text = trimmed(value)
+  if (!text || text === 'paused') return null
+  return codeLabel(text)
+}
+
+function diagnosticStateLabel(keeper: Keeper): string | null {
+  const health = codeLabel(keeper.diagnostic?.health_state)
+  const continuity = codeLabel(keeper.diagnostic?.continuity_state)
+  if (health && continuity && health !== continuity) return `${health}/${continuity}`
+  return health ?? continuity
+}
+
+export function keeperPauseDisplay(keeper: Keeper): KeeperPauseDisplay | null {
+  if (!isKeeperPaused(keeper)) return null
+  const trust = keeper.trust
+  const blockerLabel = keeperRuntimeBlockerLabel(keeper.runtime_blocker_class)
+  const reason =
+    blockerLabel
+    ?? attentionReasonForPause(keeper.attention_reason)
+    ?? attentionReasonForPause(trust?.attention_reason)
+    ?? firstNonEmpty(
+      keeper.runtime_blocker_summary,
+      trust?.latest_terminal_reason?.summary,
+      keeper.diagnostic?.continuity_summary,
+      keeper.diagnostic?.summary,
+    )
+    ?? '운영자 일시정지'
+  const nextAction = firstNonEmpty(
+    codeLabel(keeper.next_human_action),
+    codeLabel(trust?.next_human_action),
+    codeLabel(trust?.latest_next_action),
+    codeLabel(trust?.latest_terminal_reason?.next_action),
+    codeLabel(keeper.diagnostic?.next_action_path),
+  )
+  const diagnostic = diagnosticStateLabel(keeper)
+  const detail = [
+    `원인 ${reason}`,
+    nextAction ? `다음 ${nextAction}` : null,
+    diagnostic ? `진단 ${diagnostic}` : null,
+  ].filter((part): part is string => part !== null).join(' · ')
+  const title = [
+    detail,
+    `paused=${keeper.paused === true ? 'true' : 'false'}`,
+    `phase=${keeper.phase ?? 'unknown'}`,
+    `status=${keeper.status ?? 'unknown'}`,
+    `pipeline=${keeper.pipeline_stage ?? 'unknown'}`,
+  ].join(' · ')
+  return {
+    reason,
+    nextAction,
+    diagnostic,
+    detail,
+    title,
+  }
 }
 
 /** Distinguish "never booted" from "was running but stopped" keepers.


### PR DESCRIPTION
## Summary
- route keeper paused detection through the shared predicate, including pause_state/status/pipeline_stage/composite phase signals
- show paused keeper reason, next action, and diagnostic state in Keeper Actions rows
- make Keeper Actions request the execution SSOT instead of showing stale operator fallback data while execution is loading

## Verification
- pnpm exec vitest run --config vitest.config.ts src/components/keeper-action-panel.test.ts src/lib/keeper-predicates.test.ts src/lib/keeper-operational-state.test.ts src/lib/keeper-runtime-display.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- Playwright screenshot against http://127.0.0.1:5179/dashboard/#command?section=operations