### PR TITLE
refactor(tool_workspace_inspect): align schema description and docstrings

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -376,7 +376,7 @@ let public_descriptors =
       ~id:"agent.workspace_inspect"
       ~public_name:"SearchFiles"
       ~internal_name:"tool_workspace_inspect"
-      ~description:"Search file contents with ripgrep through the structured file-search tool."
+      ~description:"Inspect the project workspace through a structured op (ls, cat, find, rg, head, tail, wc, tree, git_status, git_log, git_diff, pwd)."
       ~input_schema:search_files_schema
       ~policy:
         (policy

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -1,8 +1,8 @@
-(** Tool execution handlers — command execution and structured file search ops.
+(** Tool execution handlers — command execution and structured workspace inspection ops.
 
     Handles [Execute] (arbitrary commands with blocklist) and
-    [SearchFiles] (structured ops: ls, cat, find, rg, head, tail, wc, tree,
-    git-log, git-diff, git-status).
+    [SearchFiles] / [tool_workspace_inspect] (structured ops: ls, cat, find, rg,
+    head, tail, wc, tree, git-log, git-diff, git-status, pwd).
 
     Both tools default to the keeper playground unless an explicit
     allowed [cwd] is provided. *)

--- a/lib/tool_shard_types_schemas_shell.ml
+++ b/lib/tool_shard_types_schemas_shell.ml
@@ -1,11 +1,15 @@
-(** Tool_shard_types_schemas_shell — [shell_tools] tool_workspace_inspect schema. *)
+(** Tool_shard_types_schemas_shell — [shell_tools] tool_workspace_inspect schema.
+
+    Module file name retains the [_shell] suffix because [shell_tools] is the
+    canonical shard handle in [Tool_shard]. The tool surface itself is
+    tool_workspace_inspect; the shard name is a separate axis. *)
 
 open Tool_shard_types_enum_mirrors
 
 let shell_tools : Masc_domain.tool_schema list =
   [ { name = "tool_workspace_inspect"
     ; description =
-        "Run a structured project shell operation. ops: pwd, ls, cat, rg, git_status, \
+        "Inspect the project workspace via a structured op. ops: pwd, ls, cat, rg, git_status, \
          find, head, tail, wc, tree, git_log, git_diff. \
          Structured ops default to the keeper sandbox. IMPORTANT: paths resolve \
          automatically — use 'repos/X' or 'mind/X'. Never include host paths like \


### PR DESCRIPTION
## Summary

#18779 / #18787 / #18789 가 internal id 와 helper module 을 `keeper_shell_*` → `tool_workspace_inspect` / `keeper_workspace_op*` 로 rename 한 후에도, 3 free-form description string 이 *여전히* 도구를 *shell* 또는 *file-search* surface 로 묘사:

| File | 이전 표현 | 이후 표현 | Audience |
|---|---|---|---|
| `lib/tool_shard_types_schemas_shell.ml` | "Run a structured project shell operation" | "Inspect the project workspace via a structured op" | **LLM (JSON schema description)** |
| `lib/keeper/keeper_exec_shell.mli` | "structured file search ops" | "structured workspace inspection ops" | dev (module docstring) |
| `lib/keeper/agent_tool_descriptor.ml` | "Search file contents with ripgrep through the structured file-search tool" | "Inspect the project workspace through a structured op (ls, cat, find, rg, head, tail, wc, tree, git_status, git_log, git_diff, pwd)" | **LLM (SearchFiles descriptor body)** |

`SearchFiles` LLM-native public name (RFC-0064 hard-cut) 는 *유지* — 외부 LLM contract 변경 아님. 단 *description 표현* 만 정확화 → LLM 이 도구의 broader workspace ops 인식.

또 `tool_shard_types_schemas_shell.ml` 의 파일 이름이 `_shell` 인 이유 (`shell_tools` 가 `Tool_shard` 의 canonical shard handle, tool surface 이름과 별 axis) 를 docstring 에 명시.

## 변경 사항

3 file, +10 / -6 LoC.

## Why LLM-facing description 변경이 contract 변경 아닌가

- *Tool 이름* (`SearchFiles`) = contract — *유지*
- *Schema 구조* (op enum, parameters) = contract — *유지*
- *Description string* = *LLM 의 의미 추론 input* — *정확화는 contract 강화*

LLM 이 `SearchFiles` 를 *file content search* 로 narrow 인식하면 `git_log`/`git_diff` 같은 op 안 부름. 정확한 description 으로 *schema 의 broad ops 를 LLM 에 노출* → 실제 사용 패턴 정합.

## Workaround Signature Gate

- counter / cap / cooldown / dedup / repair 추가 0
- string classifier 추가 0
- catch-all 추가 0
- *positive*: schema description ↔ 도구 실제 의미 drift 해소

Override 불필요.

## Verification

- `dune build --root . lib/ test/` clean
- `rg -n 'structured project shell|structured file search|structured file-search' lib/` → 0 hits

## 관련 PR

- #18779 (`tool_search_files` → `tool_workspace_inspect`) → 본 PR 이 *description string* 마무리
- #18787 + #18789 (`keeper_shell_op*` / `keeper_shell_read_ops` → workspace) → backing module 정렬 마무리
- *Out of scope*: `Tool_shard_types_schemas_shell` module 파일 이름 — `shell_tools` shard handle 와 *별 axis*, 본 PR 에서 의식적 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)