### PR TITLE
feat(tool_deep_review): RFC-0189 PR-1b.16 — typed result for handle_deep_review (lift at Tool_misc.dispatch)

### DIFF
--- a/lib/tool_deep_review.ml
+++ b/lib/tool_deep_review.ml
@@ -96,8 +96,38 @@ FILES:
 If you find concerns, list each with file:line and a brief explanation.
 If the code looks correct, respond with exactly: NO_ISSUES_FOUND|} question files_str)
 
-(** Run the adversarial review via OAS. Returns (ok, result_json). *)
-let handle_deep_review ~tool_name ~start_time (config : Coord.config) args : Tool_result.t =
+(* RFC-0189 PR-1b: typed [Tool_result.result] helpers.  Both error
+   sites surface caller-input rejections (missing required args, target
+   file unreadable) → [Workflow_rejection].  The two success sites
+   carry JSON envelope payloads as [data]; [Tool_result.to_legacy]
+   regenerates the original serialised body for callers that read
+   [result.message]. *)
+let ok_json ~tool_name ~start_time (json : Yojson.Safe.t) : Tool_result.result =
+  Tool_result.make_ok ~tool_name ~start_time ~data:json ()
+;;
+
+let error_workflow_json
+      ~tool_name
+      ~start_time
+      (json : Yojson.Safe.t)
+  : Tool_result.result
+  =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Workflow_rejection
+    ~start_time
+    ~data:json
+    (Yojson.Safe.to_string json)
+;;
+
+(** Run the adversarial review via OAS. Returns the typed result. *)
+let handle_deep_review
+      ~tool_name
+      ~start_time
+      (config : Coord.config)
+      args
+  : Tool_result.result
+  =
   let target_files =
     match Yojson.Safe.Util.(member "target_files" args) with
     | `List files ->
@@ -110,17 +140,18 @@ let handle_deep_review ~tool_name ~start_time (config : Coord.config) args : Too
     | _ -> ""
   in
   if Stdlib.List.length target_files = 0 || String.equal question "" then
-    Tool_result.error ~tool_name ~start_time
-      (Yojson.Safe.to_string (`Assoc [
-        ("error", `String "target_files (non-empty array) and question (string) are required")
-      ]))
+    error_workflow_json ~tool_name ~start_time
+      (`Assoc
+         [ ( "error"
+           , `String
+               "target_files (non-empty array) and question (string) are \
+                required" )
+         ])
   else
     match build_prompt ~target_files ~question ~base_path:config.base_path with
     | Error msg ->
-        Tool_result.error ~tool_name ~start_time
-          (Yojson.Safe.to_string (`Assoc [
-            ("error", `String msg)
-          ]))
+        error_workflow_json ~tool_name ~start_time
+          (`Assoc [ ("error", `String msg) ])
     | Ok prompt ->
         let cascade_name =
           Keeper_cascade_profile.cascade_name_for_use
@@ -146,20 +177,26 @@ let handle_deep_review ~tool_name ~start_time (config : Coord.config) args : Too
               then "no_issues"
               else "concern"
             in
-            Tool_result.ok ~tool_name ~start_time
-              (Yojson.Safe.to_string (`Assoc [
+            ok_json ~tool_name ~start_time
+              (`Assoc [
                 ("verdict", `String verdict);
                 ("review", `String text);
                 ("files_reviewed", `Int (List.length target_files));
-              ]))
+              ])
         | Error err ->
             let msg = Agent_sdk.Error.to_string err in
             Log.Misc.warn "adversarial review failed: %s" msg;
-            Tool_result.ok ~tool_name ~start_time
-              (Yojson.Safe.to_string (`Assoc [
+            (* Provider failure is surfaced as a successful tool call with
+               verdict="unavailable" — the original handler returned
+               [Tool_result.ok] in this branch, preserved as
+               [make_ok] so [success=true] and the verdict carries the
+               failure signal in [data], not in [failure_class]. *)
+            ok_json ~tool_name ~start_time
+              (`Assoc [
                 ("verdict", `String "unavailable");
                 ("error", `String msg);
-              ]))
+              ])
+;;
 
 (** Tool schema for MCP registration. *)
 let tool_definitions = [

--- a/lib/tool_deep_review.mli
+++ b/lib/tool_deep_review.mli
@@ -13,7 +13,7 @@
     review as described by [args]. Returns [Tool_result.t] — error on
     validation or dispatch failure, ok with the review output otherwise. *)
 val handle_deep_review :
-  tool_name:string -> start_time:float -> Coord.config -> Yojson.Safe.t -> Tool_result.t
+  tool_name:string -> start_time:float -> Coord.config -> Yojson.Safe.t -> Tool_result.result
 
 (** Build the isolated review prompt. Returns [Ok prompt] or
     [Error reason] when no target files could be read or inputs

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -181,12 +181,12 @@ let tool_inventory_json ctx ~include_hidden =
 (* Dispatch (facade)                                                *)
 (* ================================================================ *)
 
-(* RFC-0189 PR-1b.10 — boundary projection. Facade handlers
-   (dashboard / gc / cleanup_zombies / tool_stats / tool_help) and
-   the web_* delegates are all typed; lift through [to_legacy] at
-   one place. External module handlers ([Tool_misc_admin.*],
-   [Tool_deep_review.*]) still return legacy [Tool_result.t] and
-   skip the lift. PR-1c will promote the dispatch ABI itself. *)
+(* RFC-0189 PR-1b — boundary projection. Facade handlers
+   (dashboard / gc / cleanup_zombies / tool_stats / tool_help), the
+   web_* delegates, [Tool_misc_admin.*] (PR-1b.12), and
+   [Tool_deep_review.*] (PR-1b.16) are all typed; lift through
+   [to_legacy] at one place. PR-1c will promote the dispatch ABI
+   itself. *)
 let dispatch ctx ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
   let lift r = Some (Tool_result.to_legacy r) in
@@ -204,7 +204,7 @@ let dispatch ctx ~name ~args : Tool_result.t option =
   | "masc_web_fetch" -> lift (handle_web_fetch ~tool_name:name ~start_time:start ctx args)
   | "masc_tool_admin_snapshot" -> lift (Tool_misc_admin.handle_tool_admin_snapshot ~tool_name:name ~start_time:start admin_ctx args)
   | "masc_tool_admin_update" -> lift (Tool_misc_admin.handle_tool_admin_update ~tool_name:name ~start_time:start admin_ctx args)
-  | "masc_deep_review" -> Some (Tool_deep_review.handle_deep_review ~tool_name:name ~start_time:start ctx.config args)
+  | "masc_deep_review" -> lift (Tool_deep_review.handle_deep_review ~tool_name:name ~start_time:start ctx.config args)
   | _ -> None
 
 let schemas = Tool_schemas_misc.schemas


### PR DESCRIPTION
## Summary

**Next cluster in the RFC-0189 §3.2 migration.** Promotes `Tool_deep_review.handle_deep_review` to typed `Tool_result.result`. The deep-review dispatch arm in `Tool_misc.dispatch` (line 207) switches from `Some (Tool_deep_review.handle_deep_review ...)` to the existing `lift` closure — same pattern PR-1b.12 (#18776) introduced for `Tool_misc_admin.*`. External caller (`Tool_misc.dispatch` return signature `Tool_result.t option`) is unchanged.

## Local helpers

```ocaml
let ok_json ~tool_name ~start_time (json : Yojson.Safe.t) : Tool_result.result =
  Tool_result.make_ok ~tool_name ~start_time ~data:json ()

let error_workflow_json ~tool_name ~start_time (json : Yojson.Safe.t)
  : Tool_result.result =
  Tool_result.make_err
    ~tool_name ~class_:Tool_result.Workflow_rejection ~start_time
    ~data:json
    (Yojson.Safe.to_string json)
```

`ok_json` stores the JSON envelope directly in `data`. The non-`` `String`` branch of `Tool_result.to_legacy` (tool_result.ml:288) regenerates the body via `Yojson.Safe.to_string data`, so callers that read `result.message` see the same string as before.

`error_workflow_json` carries the JSON in both `data` and `message` for symmetry — the original handler put the serialised JSON into the message string, so both legacy and typed read paths preserve the contract.

## Failure-class mapping (all Workflow_rejection)

The two error sites are caller-input rejections:

| Site | Trigger |
|---|---|
| line 113 | "target_files (non-empty array) and question (string) are required" — missing required args |
| line 120 | `build_prompt` Error — caller-specified file not readable / missing |

The two success sites include a `verdict="unavailable"` branch (line 158) when the underlying OAS provider fails to deliver a response. The original handler used `Tool_result.ok` there (`success=true`), treating cascade failure as data carried in the verdict rather than as an internal error. That contract is preserved exactly — `make_ok` keeps `success=true`, the verdict surfaces the failure signal as caller-readable data.

## What's in this PR

```
 lib/tool_deep_review.ml  | +50 -23   (2 helpers + 4 site swaps + handler annotation)
 lib/tool_deep_review.mli | +1 -1     (handler val signature: Tool_result.t -> Tool_result.result)
 lib/tool_misc.ml         | +6 -6     (deep_review arm: Some -> lift; dispatch comment refresh)
 3 files changed, 57 insertions(+), 30 deletions(-)
```

`Tool_misc.dispatch` comment refreshed to remove the stale claim that `Tool_deep_review.*` still returns the legacy record.

## Workaround signature gate self-check (CLAUDE.md §워크어라운드 거부 기준)

- **§1 Telemetry-as-fix**: N/A.
- **§2 String/substring classifier**: N/A.
- **§3 N-of-M sweep**: **considered**. RFC-0189 staged plan; cluster boundary respected.
- **§4 Catch-all**: N/A.
- **§5 Cap/cooldown/dedup/repair**: N/A.
- **§6 Test backdoor**: N/A.
- **§7 Codemod-needed typo**: N/A.

RFC-WAIVED: not in credential / identity / sandbox / hooks / workflow scope.

## Test plan

- [x] `dune build @check` clean.
- [x] `dune build .` (full) green.
- [x] `Tool_misc.dispatch` external signature unchanged (`Tool_result.t option`).
- [x] Round-trip safety verified for both `ok_json` (data → message via `to_legacy`) and `error_workflow_json` (data+message symmetric).
- [x] `verdict="unavailable"` branch preserves `success=true` contract.
- [ ] CI: required checks green before Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
