### PR TITLE
refactor(keeper): purge registry tombstones

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -744,6 +744,12 @@
             <td>Merged as <code>f07ba9075</code>. Decision-matrix tests flip the old “PR ref passes without verdict” case to a missing-verdict rejection.</td>
           </tr>
           <tr>
+            <td>Keeper registry compatibility tombstones</td>
+            <td><span class="status done">draft PR #18799</span></td>
+            <td>Delete the empty <code>keeper_admin_dispatched_tools</code> admission source and the unused <code>non_shard_read_only_tools</code> read-only alias.</td>
+            <td>The policy/runtime resolver no longer reports the empty admin-dispatched source, registration validation no longer unions the tombstone, and RFC-0080 no longer teaches the removed source as live architecture.</td>
+          </tr>
+          <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
             <td><span class="status done">merged #18369</span></td>
             <td>Remove <code>ckpt-*.json</code> recovery, checkpoint writer/reader public APIs, state-snapshot sidecar hydration, migration wording, and obsolete fallback tests.</td>
@@ -776,7 +782,11 @@
         </thead>
         <tbody>
           <tr>
-            <td colspan="5">No fresh purge candidate remains in this queue after the docs/comments sweep. Future findings should be added only when they point to a live code path or a misleading current-contract document.</td>
+            <td>1</td>
+            <td><code>Tool_capability</code> legacy set bridge</td>
+            <td><code>Tool_capability.has</code> still reads <code>Tool_dispatch.is_*</code>, but <code>requires_join</code> and <code>mcp_context_required</code> do not yet have a 1:1 typed catalog metadata field.</td>
+            <td>Add/derive explicit typed metadata for the two missing capability kinds, then switch <code>Tool_capability</code> away from dispatch sets and remove the stale PR-4/PR-11 wording.</td>
+            <td>Keep existing Set/check tests, add parity/absence tests for the new metadata path, and delete tests that assume empty dispatch sets define <code>Tool_capability</code>.</td>
           </tr>
         </tbody>
       </table>

--- a/docs/rfc/RFC-0080-tool-registry-ssot.md
+++ b/docs/rfc/RFC-0080-tool-registry-ssot.md
@@ -1,6 +1,6 @@
 ---
 rfc: "0080"
-title: "Tool registry SSOT — collapse 15-fold OR membership into typed Tool_name boundary"
+title: "Tool registry SSOT — collapse multi-source membership into typed Tool_name boundary"
 status: Implemented
 created: 2026-05-14
 updated: 2026-05-22
@@ -19,7 +19,7 @@ Production keeper boot emits ≈540 warn lines per session matching `groups.<nam
 
 The warn is *load-time* validation in `lib/keeper/keeper_tool_policy_config.ml:319-321`, fired once per boot per offending entry in `tool_policy.toml`. It does **not** prevent the tool from dispatching at runtime — `tool_call tool=tool_execute outcome=ok` co-exists with `groups.coding: tool 'tool_execute' is not registered`. The warn and the runtime are talking past each other.
 
-The mismatch is structural, not a typo. `is_known_policy_tool_name` (lib/keeper/keeper_tool_policy_config.ml:225-239) currently union-checks across **15 independent sources of truth**:
+The mismatch is structural, not a typo. `is_known_policy_tool_name` (lib/keeper/keeper_tool_policy_config.ml:225-239) historically union-checked across many independent sources of truth:
 
 ```ocaml
 let is_known_policy_tool_name name =
@@ -31,12 +31,11 @@ let is_known_policy_tool_name name =
   || Option.is_some (Keeper_tool_alias.public_masc_to_internal n)     (* 5  *)
   || List.mem normalized (Keeper_tool_registry.keeper_internal_…)     (* 6  *)
   || List.mem normalized (Keeper_tool_registry.effective_core_tools ()) (* 7 *)
-  || List.mem normalized Keeper_tool_registry.keeper_admin_dispatched (* 8  *)
-  || List.mem normalized (tool_schema_names …all_keeper_tool_schemas) (* 9  *)
-  || Tool_catalog_surfaces.is_on_surface Public_mcp     normalized    (* 10 *)
-  || Tool_catalog_surfaces.is_on_surface Spawned_agent  normalized    (* 11 *)
-  || Tool_catalog_surfaces.is_on_surface Local_worker   normalized    (* 12 *)
-  || Tool_catalog_surfaces.is_on_surface Admin          normalized    (* 13 *)
+  || List.mem normalized (tool_schema_names …all_keeper_tool_schemas) (* 8  *)
+  || Tool_catalog_surfaces.is_on_surface Public_mcp     normalized    (* 9  *)
+  || Tool_catalog_surfaces.is_on_surface Spawned_agent  normalized    (* 10 *)
+  || Tool_catalog_surfaces.is_on_surface Local_worker   normalized    (* 11 *)
+  || Tool_catalog_surfaces.is_on_surface Admin          normalized    (* 12 *)
 ```
 
 Symptoms this produces:
@@ -60,15 +59,15 @@ Symptoms this produces:
                     │         route (7 entries) / is_known_internal /
                     │         public_masc_to_internal / strip_mcp_masc_prefix
                     │
-keeper preset       │── S6-8. Keeper_tool_registry (lib/keeper/keeper_tool_registry.ml)
-in tool_policy.toml │         3 list APIs derived from tool_catalog_surfaces
+keeper preset       │── S6-7. Keeper_tool_registry (lib/keeper/keeper_tool_registry.ml)
+in tool_policy.toml │         2 list APIs derived from tool_catalog_surfaces
        │            │         + hardcoded core_always list
        │            │
-       ▼            │── S9. Tool_shard.all_keeper_tool_schemas               ── per-shard name extraction
+       ▼            │── S8. Tool_shard.all_keeper_tool_schemas               ── per-shard name extraction
    is_known_policy_tool_name ──────────────────┐
                     │                          │
                     │                          ▼
-                    │     ┌─ S10-13. Tool_catalog_surfaces.is_on_surface     ── 8 surface variants total:
+                    │     ┌─ S9-12. Tool_catalog_surfaces.is_on_surface      ── 8 surface variants total:
                     │     │      Public_mcp                                   ── only 4 checked at policy boundary;
                     │     │      Spawned_agent                                ── Session_min / Keeper_internal /
                     │     │      Local_worker                                 ── Keeper_denied / System_internal
@@ -76,14 +75,14 @@ in tool_policy.toml │         3 list APIs derived from tool_catalog_surfaces
                     │     └──────────────────────────────────────────────
                     │
                     ▼
-        15-fold OR → "known" / "unknown" boolean
+        multi-source OR → "known" / "unknown" boolean
 ```
 
 Split-brain: policy validation and runtime routing use **separate code paths**:
 
 ```
   Policy load (boot-time):
-    is_known_policy_tool_name   ── 15 sources OR ──→ bool
+    is_known_policy_tool_name   ── multi-source OR ──→ bool
     called at keeper_tool_policy_config.ml:319,328,336
 
   Runtime tool dispatch (call-time):
@@ -101,7 +100,7 @@ There is no single point of truth for *"this tool name resolves to that handler"
 
 ### 3.1 Direction
 
-Collapse the 15-fold OR into **typed conversion at the policy load boundary**:
+Collapse the multi-source OR into **typed conversion at the policy load boundary**:
 
 ```ocaml
 (* lib/keeper/tool_resolution.ml — new *)
@@ -113,9 +112,8 @@ type tried_source =
   | Alias_masc_to_internal                   (* S5 *)
   | Registry_internal_candidate              (* S6 *)
   | Registry_core_tools                      (* S7 *)
-  | Registry_admin_dispatched                (* S8 *)
-  | Shard_schema                             (* S9 *)
-  | Surface of Tool_catalog_surfaces.surface (* S10-13 *)
+  | Shard_schema                             (* S8 *)
+  | Surface of Tool_catalog_surfaces.surface (* S9-12 *)
 
 type resolution =
   | Resolved of { canonical : string ; via : tried_source ;
@@ -127,7 +125,7 @@ val resolve : string -> resolution
 (* Parse, don't validate. *)
 ```
 
-The 15 sources become *implementations of the resolution rule* hidden behind the `resolve` API. Callers (policy loader, dispatch table, catalog surfaces) stop touching the sources directly and call `resolve`. Boot-time validation becomes:
+The source checks become *implementations of the resolution rule* hidden behind the `resolve` API. Callers (policy loader, dispatch table, catalog surfaces) stop touching the sources directly and call `resolve`. Boot-time validation becomes:
 
 ```ocaml
 List.iter (fun raw ->
@@ -142,9 +140,9 @@ List.iter (fun raw ->
 
 ### 3.2 Three-step migration
 
-1. **`tool_resolution.ml` shim.** Wrap the existing 15-fold OR behind `resolve`, returning a uniform `resolution` value. **No behaviour change** — same admit/reject decisions, but every call site is now expressible as one of three typed outcomes. Single PR. Worktree: `rfc/0080/phase-1-shim`.
+1. **`tool_resolution.ml` shim.** Wrap the existing source checks behind `resolve`, returning a uniform `resolution` value. **No behaviour change** — same admit/reject decisions, but every call site is now expressible as one of three typed outcomes. Single PR. Worktree: `rfc/0080/phase-1-shim`.
 2. **Caller migration.** Replace each direct source check (`Tool_dispatch.is_registered`, `Tool_catalog_surfaces.is_on_surface`, …) at *policy validation* call sites with `resolve`. Other domains (runtime dispatch, schema export) keep their direct calls — they are not part of the SSOT collapse. Per-call-site PR pattern to keep diffs small; CI smoke retains 88-warn baseline ± 0 after each PR. Worktree: `rfc/0080/phase-2-callers/<call-site>`.
-3. **Source pruning.** Once `resolve` is the only policy gate, walk the 15 sources to identify dead entries (admitted by exactly 0 sources after PR #14513/#15051/#15092 already trimmed several). Per-domain PR (alias, registry list, catalog surface) with explicit removal evidence in body. Worktree: `rfc/0080/phase-3-prune/<domain>`.
+3. **Source pruning.** Once `resolve` is the only policy gate, walk the source checks to identify dead entries (admitted by exactly 0 sources after PR #14513/#15051/#15092 already trimmed several). Per-domain PR (alias, registry list, catalog surface) with explicit removal evidence in body. Worktree: `rfc/0080/phase-3-prune/<domain>`.
 
 ### 3.3 Non-goals
 
@@ -224,9 +222,9 @@ masc_transition / masc_web_search / masc_who /
 tool_{edit_file,execute,read_file,search_files,write_file}
 ```
 
-### 7.2 88 × 15 matrix (deferred to Phase 1 PR)
+### 7.2 88 × source matrix (deferred to Phase 1 PR)
 
-Mechanical static analysis: for each of the 88 names, grep against each of the 15 sources and record hit/miss. Categorise into:
+Mechanical static analysis: for each of the 88 names, grep against each source and record hit/miss. Categorise into:
 
 | Category | Definition |
 |---|---|

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -41,12 +41,6 @@ val core_discovery_tools : string list
 (** Returns [core_discovery_tools].  Discovery mode is the default. *)
 val effective_core_tools : unit -> string list
 
-(** Keeper tools dispatched by the server but withheld from the visible
-    keeper tool set (admin/opt-in only — see [optional] group in
-    [config/tool_policy.toml]).  Exported so startup validators can
-    recognise them as runtime rather than orphan config. *)
-val keeper_admin_dispatched_tools : string list
-
 (** Keeper-local read-only tools that do not always flow through Tool_spec. *)
 val keeper_read_only_tools : string list
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -95,13 +95,6 @@ let core_discovery_tools =
 
 let effective_core_tools () = core_discovery_tools
 
-(** Keeper-prefixed board maintenance aliases were removed; canonical
-    board maintenance stays on the public/admin [masc_board_*] surface.
-    TEL-OK: this empty alias tombstone performs no runtime action; telemetry
-    remains on the canonical [masc_board_*] handlers. *)
-let keeper_admin_dispatched_tools : string list = []
-;;
-
 let core_always_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create (List.length core_always_tools) in
   List.iter (fun name -> Hashtbl.replace tbl name ()) core_always_tools;
@@ -116,9 +109,6 @@ let is_core_always_tool (name : string) : bool = Hashtbl.mem core_always_set nam
     descriptor-backed public/coordination tools without adding new string
     mirrors to the registry. *)
 let descriptor_read_only_tools = Agent_tool_descriptor.readonly_internal_names ()
-
-(* Historical export name retained for callers that still import it. *)
-let non_shard_read_only_tools = descriptor_read_only_tools
 
 let keeper_read_only_tools =
   Tool_shard.all_read_only_keeper_tools () @ descriptor_read_only_tools

--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -29,20 +29,10 @@ val core_discovery_tools : string list
 
 val effective_core_tools : unit -> string list
 
-(** Keeper tools the dispatcher accepts but withholds from the
-    visible/core set; served only when a keeper opts in via
-    policy_config.also_allow. Exported so [Tool_registration_check]
-    does not flag them as orphan toml entries (#7696). *)
-val keeper_admin_dispatched_tools : string list
-
 (** Lookup hashtable for [core_always_tools]. *)
 val core_always_set : (string, unit) Hashtbl.t
 
 val is_core_always_tool : string -> bool
-
-(** Descriptor-projected read-only tools. Kept under the historical
-    [non_shard_read_only_tools] name for callers that still import it. *)
-val non_shard_read_only_tools : string list
 
 (** Descriptor-projected read-only tools. *)
 val descriptor_read_only_tools : string list

--- a/lib/keeper/keeper_tool_resolution.ml
+++ b/lib/keeper/keeper_tool_resolution.ml
@@ -3,7 +3,7 @@
     RFC-0080 Phase 2. Wraps the existing policy admission sources behind a
     single [resolve] function that returns a typed [resolution].
 
-    Behaviour: preserve the short-circuit order of the original policy
+    Behaviour: preserve the short-circuit order of the current policy
     admission chain. The first source that admits the name determines the
     [tried_source] tag. If none admit, all tried sources are collected in
     [Unknown.tried].
@@ -20,9 +20,8 @@ type tried_source =
   | Alias_masc_to_internal      (** S5: Keeper_tool_alias.public_masc_to_internal *)
   | Registry_internal_candidate (** S6: Keeper_tool_registry.keeper_internal_candidate_tool_names *)
   | Registry_core_tools         (** S7: Keeper_tool_registry.effective_core_tools *)
-  | Registry_admin_dispatched   (** S8: Keeper_tool_registry.keeper_admin_dispatched_tools *)
-  | Shard_schema                (** S9: Tool_shard.all_keeper_tool_schemas name extraction *)
-  | Surface of Tool_catalog_surfaces.surface  (** S10-13: Tool_catalog_surfaces.is_on_surface *)
+  | Shard_schema                (** S8: Tool_shard.all_keeper_tool_schemas name extraction *)
+  | Surface of Tool_catalog_surfaces.surface  (** S9-12: Tool_catalog_surfaces.is_on_surface *)
 
 type resolution =
   | Resolved of { canonical : string ; via : tried_source ;
@@ -43,7 +42,6 @@ let string_of_tried_source = function
   | Alias_masc_to_internal -> "alias_masc_to_internal"
   | Registry_internal_candidate -> "registry_internal_candidate"
   | Registry_core_tools -> "registry_core_tools"
-  | Registry_admin_dispatched -> "registry_admin_dispatched"
   | Shard_schema -> "shard_schema"
   | Surface s -> Printf.sprintf "surface:%s" (Tool_catalog_surfaces.surface_to_string s)
 
@@ -72,8 +70,6 @@ let resolve name =
         Resolved { canonical = normalized; via = Registry_internal_candidate; surface = None }
       else if List.mem normalized (Keeper_tool_registry.effective_core_tools ()) then
         Resolved { canonical = normalized; via = Registry_core_tools; surface = None }
-      else if List.mem normalized Keeper_tool_registry.keeper_admin_dispatched_tools then
-        Resolved { canonical = normalized; via = Registry_admin_dispatched; surface = None }
       else if List.mem normalized (tool_schema_names Tool_shard.all_keeper_tool_schemas) then
         Resolved { canonical = normalized; via = Shard_schema; surface = None }
       else begin
@@ -103,7 +99,7 @@ let resolve name =
                 [ Dispatch_table; Tool_name_variant; Alias_route
                 ; Alias_internal; Alias_masc_to_internal
                 ; Registry_internal_candidate; Registry_core_tools
-                ; Registry_admin_dispatched; Shard_schema
+                ; Shard_schema
                 ]
                 @ List.map (fun s -> Surface s) surfaces_to_check
               in
@@ -121,7 +117,7 @@ let resolve name =
 (* ── Phase 5: full-probe (no short-circuit) ────────────────────────── *)
 
 (** Return every source that would admit [name], in resolution order.
-    Unlike [resolve] which short-circuits, this checks all 13 sources.
+    Unlike [resolve] which short-circuits, this checks every current source.
     Used for source-overlap analysis only. *)
 let all_admitting_sources name =
   let normalized = Keeper_tool_alias.strip_mcp_masc_prefix name in
@@ -141,8 +137,6 @@ let all_admitting_sources name =
     sources := Registry_internal_candidate :: !sources;
   if List.mem normalized (Keeper_tool_registry.effective_core_tools ()) then
     sources := Registry_core_tools :: !sources;
-  if List.mem normalized Keeper_tool_registry.keeper_admin_dispatched_tools then
-    sources := Registry_admin_dispatched :: !sources;
   if List.mem normalized (tool_schema_names Tool_shard.all_keeper_tool_schemas) then
     sources := Shard_schema :: !sources;
   (* RFC-0084 §1.3 + §6 D2 — admit-only surfaces (Keeper_denied excluded). *)

--- a/lib/keeper/keeper_tool_resolution.mli
+++ b/lib/keeper/keeper_tool_resolution.mli
@@ -1,7 +1,7 @@
 (** Keeper_tool_resolution — typed resolution for policy tool name validation.
 
-    RFC-0080 Phase 2. Replaces the 15-fold OR boolean check with a typed
-    [resolve] function that returns provenance information.
+    RFC-0080 Phase 2. Replaces the legacy multi-source OR boolean check with
+    a typed [resolve] function that returns provenance information.
 
     @since 2.219.0 *)
 
@@ -14,7 +14,6 @@ type tried_source =
   | Alias_masc_to_internal      (** Keeper_tool_alias.public_masc_to_internal *)
   | Registry_internal_candidate (** keeper_internal_candidate_tool_names *)
   | Registry_core_tools         (** effective_core_tools *)
-  | Registry_admin_dispatched   (** keeper_admin_dispatched_tools *)
   | Shard_schema                (** Tool_shard.all_keeper_tool_schemas *)
   | Surface of Tool_catalog_surfaces.surface
 
@@ -26,7 +25,7 @@ type resolution =
   | Unknown of { name : string; tried : tried_source list }
 
 (** Resolve a tool name through the source chain.
-    Short-circuits on first hit, same order as the original 15-fold OR. *)
+    Short-circuits on first hit, same order as the current source chain. *)
 val resolve : string -> resolution
 
 (** Human-readable label for a single source. *)
@@ -36,8 +35,7 @@ val string_of_tried_source : tried_source -> string
 val string_of_tried : tried_source list -> string
 
 (** Full-probe analysis: return every source that would admit [name].
-    Unlike [resolve] which short-circuits, checks all 13 sources.
-    For source-overlap analysis (Phase 5). *)
+    Unlike [resolve] which short-circuits, checks every current source. *)
 val all_admitting_sources : string -> tried_source list
 
 (** RFC-0084 §1.4 — Single-SSOT entry for runtime tool-name routing. *)

--- a/lib/tool_registration_check.ml
+++ b/lib/tool_registration_check.ml
@@ -40,7 +40,6 @@ let runtime_keeper_tool_names () =
   Hashtbl.create 512
   |> add_names Keeper_exec_tools.keeper_internal_candidate_tool_names
   |> add_names (Keeper_exec_tools.effective_core_tools ())
-  |> add_names Keeper_exec_tools.keeper_admin_dispatched_tools
   |> add_names (raw_masc_tool_names ())
 
 let validate () : validation_result =


### PR DESCRIPTION
## Summary
- delete the empty keeper_admin_dispatched_tools admission source and resolver provenance arm
- delete the unused non_shard_read_only_tools read-only alias
- update RFC-0080/audit ledger and leave Tool_capability legacy-set bridge as the next explicit candidate

## Verification
- ocamlformat --check lib/keeper/keeper_tool_registry.ml lib/keeper/keeper_tool_registry.mli lib/keeper/keeper_exec_tools.mli lib/tool_registration_check.ml lib/keeper/keeper_tool_resolution.ml lib/keeper/keeper_tool_resolution.mli
- git diff --check origin/main...HEAD
- rg -n "non_shard_read_only_tools|keeper_admin_dispatched_tools|Registry_admin_dispatched|admin_dispatched|empty alias tombstone|still import it" lib test docs/rfc/RFC-0080-tool-registry-ssot.md -S (no matches)
- scripts/dune-local.sh build ./lib/masc_mcp_lib.a ./test/test_tool_registration_consistency.exe (blocked: exit 75, live bare Dune processes outside scripts/dune-local.sh)