### PR TITLE
refactor(tool-registry): honor descriptor readonly for inputs

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -1030,10 +1030,10 @@ let internal_descriptors : t list =
       "Read tool-usage statistics." ~readonly:true
   ; masc_misc_descriptor "tool_help" "masc_tool_help"
       "Read help text for a tool name." ~readonly:true
-  ; masc_misc_descriptor "web_search" "masc_web_search"
-      "Run a web search query." ~readonly:true
-  ; masc_misc_descriptor "web_fetch" "masc_web_fetch"
-      "Fetch a web URL." ~readonly:true
+  (* [masc_web_search] / [masc_web_fetch] are already owned by the
+     LLM-native SearchWeb / FetchWeb descriptors above. Do not add
+     duplicate internal descriptors here; that would make runtime receipt
+     projection depend on list order. *)
   ; masc_misc_descriptor "tool_admin_snapshot" "masc_tool_admin_snapshot"
       "Read tool-admin inventory snapshot." ~readonly:true
   ; masc_misc_descriptor "tool_admin_update" "masc_tool_admin_update"

--- a/lib/keeper/agent_tool_descriptor_resolution.ml
+++ b/lib/keeper/agent_tool_descriptor_resolution.ml
@@ -16,6 +16,12 @@ let descriptor_for_tool_name tool_name =
         | [] -> None))
 ;;
 
+let readonly_for_tool_name tool_name =
+  match descriptor_for_tool_name tool_name with
+  | Some descriptor -> descriptor.Agent_tool_descriptor.policy.readonly
+  | None -> None
+;;
+
 let descriptors_for_tool_names tool_names =
   let add_descriptor (seen, acc) descriptor =
     if List.mem descriptor.Agent_tool_descriptor.id seen

--- a/lib/keeper/agent_tool_descriptor_resolution.mli
+++ b/lib/keeper/agent_tool_descriptor_resolution.mli
@@ -7,4 +7,6 @@
 
 val descriptor_for_tool_name : string -> Agent_tool_descriptor.t option
 
+val readonly_for_tool_name : string -> bool option
+
 val descriptors_for_tool_names : string list -> Agent_tool_descriptor.t list

--- a/lib/keeper/keeper_tool_observation.ml
+++ b/lib/keeper/keeper_tool_observation.ml
@@ -111,9 +111,13 @@ let result_text_for_progress_check output_text =
 let tool_result_has_material_progress ~(tool_name : string) ~(output_text : string)
   : bool
   =
-  let _ = Keeper_tool_resolution.canonical_tool_name tool_name in
+  let tool_name = Keeper_tool_resolution.canonical_tool_name tool_name in
   let output_text = result_text_for_progress_check output_text |> String.trim in
-  not (String.equal output_text "")
+  let idempotent_worktree_noop =
+    String.equal tool_name "tool_execute"
+    && String.starts_with ~prefix:"Worktree already exists:" output_text
+  in
+  (not (String.equal output_text "")) && not idempotent_worktree_noop
 ;;
 
 let unexpected_tool_names ~(allowed_tool_names : string list) ~(tool_names : string list)

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -152,22 +152,6 @@ let has_mutating_side_effect (name : string) : bool =
    tool name. This function inspects JSON input where a live tool has
    such a contract. *)
 
-let keeper_workspace_read_only_ops =
-  [ "pwd"
-  ; "ls"
-  ; "cat"
-  ; "rg"
-  ; "git_status"
-  ; "find"
-  ; "head"
-  ; "tail"
-  ; "wc"
-  ; "tree"
-  ; "git_log"
-  ; "git_diff"
-  ]
-;;
-
 let keeper_workspace_op (input : Yojson.Safe.t) : string option =
   match input with
   | `Assoc fields ->
@@ -178,12 +162,15 @@ let keeper_workspace_op (input : Yojson.Safe.t) : string option =
 ;;
 
 let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : bool =
-  match Tool_name.of_string tool_name with
-  | Some (Keeper Workspace_inspect) ->
-    (match keeper_workspace_op input with
-     | Some op -> List.mem op keeper_workspace_read_only_ops
-     | None -> false)
-  | _ -> is_effectively_read_only_tool tool_name
+  match Agent_tool_descriptor_resolution.readonly_for_tool_name tool_name with
+  | Some readonly -> readonly
+  | None ->
+    (match Tool_name.of_string tool_name with
+     | Some (Keeper Workspace_inspect) ->
+       (match keeper_workspace_op input with
+        | Some op -> List.mem op Keeper_workspace_op.valid_strings
+        | None -> false)
+     | _ -> is_effectively_read_only_tool tool_name)
 ;;
 
 (* ── Input-aware mutation-boundary bypass ────────────────────

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -143,6 +143,41 @@ let test_readonly_policy_projects_to_registry () =
     false
     (List.mem "tool_write_file" projected)
 
+let test_readonly_policy_projects_to_input_aware_registry () =
+  let search_input = `Assoc [ "pattern", `String "Agent_tool_descriptor" ] in
+  Alcotest.(check bool)
+    "SearchFiles public alias is input-aware read-only"
+    true
+    (Registry.is_read_only_with_input ~tool_name:"SearchFiles" ~input:search_input);
+  Alcotest.(check bool)
+    "MCP-prefixed SearchFiles is input-aware read-only"
+    true
+    (Registry.is_read_only_with_input
+       ~tool_name:"mcp__masc__SearchFiles"
+       ~input:search_input);
+  Alcotest.(check bool)
+    "tool_workspace_inspect is descriptor read-only without legacy op"
+    true
+    (Registry.is_read_only_with_input ~tool_name:"tool_workspace_inspect" ~input:search_input);
+  Alcotest.(check bool)
+    "ReadFile public alias is input-aware read-only"
+    true
+    (Registry.is_read_only_with_input
+       ~tool_name:"ReadFile"
+       ~input:(`Assoc [ "file_path", `String "lib/keeper/keeper_tool_registry.ml" ]));
+  Alcotest.(check bool)
+    "WriteFile public alias remains mutating"
+    false
+    (Registry.is_read_only_with_input
+       ~tool_name:"WriteFile"
+       ~input:(`Assoc [ "file_path", `String "x"; "content", `String "y" ]));
+  Alcotest.(check bool)
+    "tool_write_file remains mutating"
+    false
+    (Registry.is_read_only_with_input
+       ~tool_name:"tool_write_file"
+       ~input:(`Assoc [ "path", `String "x"; "content", `String "y" ]))
+
 let () =
   Alcotest.run
     "agent_tool_descriptor_registry_integrity"
@@ -166,5 +201,9 @@ let () =
             "descriptor read-only policy projects to registry"
             `Quick
             test_readonly_policy_projects_to_registry
+        ; test_case
+            "descriptor read-only policy projects to input-aware registry"
+            `Quick
+            test_readonly_policy_projects_to_input_aware_registry
         ] )
     ]


### PR DESCRIPTION
## Summary

- Project descriptor read-only policy into Keeper_tool_registry.is_read_only_with_input for public, internal, and MCP-prefixed tool names.
- Replace the local workspace read-only op mirror with Keeper_workspace_op.valid_strings.
- Remove duplicate masc_web_search / masc_web_fetch descriptor ownership so SearchWeb / FetchWeb remain the single descriptor route source.
- Preserve no-progress observation for tool_execute worktree already-exists output.

## Validation

- ocamlformat --check lib/keeper/agent_tool_descriptor.ml lib/keeper/keeper_tool_observation.ml lib/keeper/agent_tool_descriptor_resolution.ml lib/keeper/agent_tool_descriptor_resolution.mli lib/keeper/keeper_tool_registry.ml test/test_agent_tool_descriptor_registry_integrity.ml
- git diff --check HEAD~1..HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_agent_tool_descriptor_registry_integrity.exe ./test/test_keeper_unified_required_tools.exe
- ./_build/default/test/test_agent_tool_descriptor_registry_integrity.exe
- ./_build/default/test/test_keeper_unified_required_tools.exe