### PR TITLE
refactor(tool-capability): use catalog metadata

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -745,9 +745,15 @@
           </tr>
           <tr>
             <td>Keeper registry compatibility tombstones</td>
-            <td><span class="status done">draft PR #18799</span></td>
+            <td><span class="status done">merged #18799</span></td>
             <td>Delete the empty <code>keeper_admin_dispatched_tools</code> admission source and the unused <code>non_shard_read_only_tools</code> read-only alias.</td>
-            <td>The policy/runtime resolver no longer reports the empty admin-dispatched source, registration validation no longer unions the tombstone, and RFC-0080 no longer teaches the removed source as live architecture.</td>
+            <td>Merged as <code>de8487000</code>. The policy/runtime resolver no longer reports the empty admin-dispatched source, registration validation no longer unions the tombstone, and RFC-0080 no longer teaches the removed source as live architecture.</td>
+          </tr>
+          <tr>
+            <td><code>Tool_capability</code> legacy set bridge</td>
+            <td><span class="status done">draft PR #18805</span></td>
+            <td>Add typed catalog metadata for <code>requires_join</code> and <code>mcp_context_required</code>, derive static inline/destructive capability flags in <code>Tool_catalog</code>, and switch <code>Tool_capability.has</code> away from <code>Tool_dispatch.is_*</code>.</td>
+            <td>Tests now assert dispatch-only set writes no longer grant <code>Tool_capability</code>, while catalog metadata and catalog inference do grant the typed capabilities.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
@@ -783,10 +789,10 @@
         <tbody>
           <tr>
             <td>1</td>
-            <td><code>Tool_capability</code> legacy set bridge</td>
-            <td><code>Tool_capability.has</code> still reads <code>Tool_dispatch.is_*</code>, but <code>requires_join</code> and <code>mcp_context_required</code> do not yet have a 1:1 typed catalog metadata field.</td>
-            <td>Add/derive explicit typed metadata for the two missing capability kinds, then switch <code>Tool_capability</code> away from dispatch sets and remove the stale PR-4/PR-11 wording.</td>
-            <td>Keep existing Set/check tests, add parity/absence tests for the new metadata path, and delete tests that assume empty dispatch sets define <code>Tool_capability</code>.</td>
+            <td><code>Tool_dispatch.is_*</code> runtime capability gates</td>
+            <td>Capability truth still has multiple direct runtime readers in MCP annotations/icons, execution admission, bridge classification, eval gates, and keeper policy helpers.</td>
+            <td>Move call sites one subsystem at a time to <code>Tool_catalog</code> / <code>Tool_capability</code>, then delete the mutable capability-set initialization APIs when no runtime reader remains.</td>
+            <td>Add parity tests per migrated subsystem and remove tests that populate <code>Tool_dispatch.init_*_set</code> only to preserve old capability authority.</td>
           </tr>
         </tbody>
       </table>

--- a/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
+++ b/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
@@ -277,7 +277,10 @@ val required_for_keeper : Keeper_id.t -> t list
 val gate : required:t list -> granted:Set.t -> [`Pass | `Reject of string]
 ```
 
-5개 `(string, unit) Hashtbl.t`를 collapse. 결정 D1 (plan §6)에 따라 hybrid (per-domain + per-tool override).
+Current implementation: [Tool_capability.kind] is the closed capability
+alphabet, and [Tool_capability.has] reads [Tool_catalog.metadata]. The older
+[Tool_dispatch] capability sets remain only for runtime gates that have not yet
+been cut over, not as the [Tool_capability] authority.
 
 ### §3.3 `Dispatch_outcome.t` (PR-10)
 
@@ -475,7 +478,8 @@ let () = QCheck.Test.check_exn @@ QCheck.Test.make
 - `lib/tool_dispatch.ml:79-80` — `pre_hooks` / `post_hooks` refs
 - `lib/tool_dispatch.ml:127-129` — handler `None` → silent skip
 - `lib/tool_dispatch.ml:149` — `MASC_DISPATCH_V2` flag
-- `lib/tool_dispatch.ml:159-163` — 5 `(string, unit) Hashtbl.t` capability sets
+- `lib/tool_capability.ml` / `lib/tool_catalog.ml` — typed capability metadata
+  authority
 - `lib/tool_dispatch.ml:197-213+` — `module_tag` typed sum + `static_tag_of_tool_name`
 - `lib/keeper/tool_resolution.ml:56-103` — `resolve` 13-source short-circuit
 - `lib/keeper/tool_resolution.ml:81-86, 143-149` — `surfaces_to_check` 4 variants

--- a/lib/tool_capability.ml
+++ b/lib/tool_capability.ml
@@ -39,12 +39,29 @@ module Set = Stdlib.Set.Make (struct
   end)
 
 let has kind tool_name =
+  let metadata = Tool_catalog.metadata tool_name in
   match kind with
-  | Read_only -> Tool_dispatch.is_read_only tool_name
-  | Requires_join -> Tool_dispatch.is_join_required tool_name
-  | Mcp_context_required -> Tool_dispatch.is_mcp_context_required tool_name
-  | Destructive -> Tool_dispatch.is_destructive tool_name
-  | Idempotent -> Tool_dispatch.is_idempotent tool_name
+  | Read_only ->
+    (match metadata.readonly, metadata.effect_domain with
+     | Some true, _ | _, Some Tool_catalog.Read_only -> true
+     | Some false, _ | None, _ -> false)
+  | Requires_join ->
+    (match metadata.requires_join with
+     | Some true -> true
+     | Some false | None -> false)
+  | Mcp_context_required ->
+    (match metadata.mcp_context_required with
+     | Some true -> true
+     | Some false | None -> false)
+  | Destructive ->
+    (match metadata.destructive with
+     | Some true -> true
+     | Some false | None -> false)
+  | Idempotent ->
+    (match metadata.idempotent with
+     | Some true -> true
+     | Some false -> false
+     | None -> has Read_only tool_name)
 ;;
 
 let granted tool_name =

--- a/lib/tool_capability.mli
+++ b/lib/tool_capability.mli
@@ -1,14 +1,9 @@
-(** RFC-0084 §3.2 — Typed tool dispatch capability.
+(** RFC-0084 §3.2 — Typed tool capability.
 
-    Replaces the five string-keyed [(string, unit) Hashtbl.t] capability
-    sets at [Tool_dispatch.{read_only_set, requires_join_set,
-    mcp_context_required_set, destructive_set, idempotent_set}]
-    with a closed-sum [kind] and a [Set]-based granted/required model.
-
-    PR-4 is *additive* — the legacy sets remain authoritative and this
-    module bridges through [Tool_dispatch.is_*] queries. PR-7 wires
-    [check] into [Tool_dispatch.guarded_dispatch] to enforce gating on
-    keeper-originated calls. PR-11 removes the legacy sets.
+    The closed-sum [kind] and [Set]-based granted/required model reads
+    capability truth from [Tool_catalog.metadata]. [Tool_dispatch]'s
+    mutable capability sets remain only for older runtime gates that have
+    not yet been cut over; they are no longer authoritative here.
 
     The module is named [Tool_capability] (not [Capability]) because
     [lib/exec/capability.ml] already owns the [Capability] name for the
@@ -29,15 +24,12 @@ val all_kinds : kind list
 (** Ordered Set of capability kinds. *)
 module Set : Stdlib.Set.S with type elt = kind
 
-(** [has kind tool_name] returns [true] when [tool_name] is registered
-    in the legacy [Tool_dispatch] set corresponding to [kind].
-
-    Bridges through [Tool_dispatch.is_read_only] / [is_join_required] /
-    [is_mcp_context_required] / [is_destructive] / [is_idempotent]. *)
+(** [has kind tool_name] returns [true] when [Tool_catalog.metadata]
+    grants [kind] for [tool_name]. *)
 val has : kind -> string -> bool
 
 (** [granted tool_name] returns every capability kind currently granted
-    to [tool_name] by the legacy sets. *)
+    to [tool_name] by catalog metadata. *)
 val granted : string -> Set.t
 
 (** [check ~required ~granted] returns [Ok ()] when [granted ⊇ required],

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -82,6 +82,8 @@ type metadata = {
   reason : string option;
   allow_direct_call_when_hidden : bool;
   readonly : bool option;
+  requires_join : bool option;
+  mcp_context_required : bool option;
   destructive : bool option;
   idempotent : bool option;
   required_permission : Masc_domain.permission option;
@@ -103,6 +105,8 @@ let default_metadata =
     reason = None;
     allow_direct_call_when_hidden = false;
     readonly = None;
+    requires_join = None;
+    mcp_context_required = None;
     destructive = None;
     idempotent = None;
     required_permission = None;
@@ -130,6 +134,8 @@ let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden =
     reason = Some reason;
     allow_direct_call_when_hidden;
     readonly = None;
+    requires_join = None;
+    mcp_context_required = None;
     destructive = None;
     idempotent = None;
     required_permission = None;
@@ -137,12 +143,20 @@ let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden =
     requires_actor_binding = None;
   }
 
-let with_semantic_flags ?readonly ?destructive ?idempotent ?effect_domain
-    ?requires_actor_binding meta =
+let with_semantic_flags ?readonly ?requires_join ?mcp_context_required
+    ?destructive ?idempotent ?effect_domain ?requires_actor_binding meta =
   {
     meta with
     readonly =
       (match readonly with Some value -> Some value | None -> meta.readonly);
+    requires_join =
+      (match requires_join with
+      | Some value -> Some value
+      | None -> meta.requires_join);
+    mcp_context_required =
+      (match mcp_context_required with
+      | Some value -> Some value
+      | None -> meta.mcp_context_required);
     destructive =
       (match destructive with Some value -> Some value | None -> meta.destructive);
     idempotent =
@@ -205,6 +219,30 @@ let admin_read_tool =
 
 let reset_tool =
   with_required_permission Masc_domain.CanReset destructive_tool
+
+let static_requires_join_tool_names =
+  [ "masc_broadcast"; "masc_leave" ]
+
+let static_mcp_context_required_tool_names =
+  [ "masc_start"
+  ; "masc_join"
+  ; "masc_leave"
+  ; "masc_broadcast"
+  ; "masc_messages"
+  ; "masc_who"
+  ; "masc_approval_get"
+  ; "masc_mcp_session"
+  ]
+
+let static_destructive_tool_names =
+  [ "tool_execute"
+  ; "tool_edit_file"
+  ; "tool_write_file"
+  ; "shell_exec"
+  ]
+
+let force_true_if_member name names current =
+  if List.mem name names then Some true else current
 
 (* ================================================================ *)
 (* Explicit metadata registry                                       *)
@@ -452,6 +490,20 @@ let attach_inferred_effect_domain name (meta : metadata) =
   | Some _ -> meta
   | None -> { meta with effect_domain = inferred_effect_domain name }
 
+let attach_static_capabilities name (meta : metadata) =
+  {
+    meta with
+    requires_join =
+      force_true_if_member name static_requires_join_tool_names meta.requires_join;
+    mcp_context_required =
+      force_true_if_member
+        name
+        static_mcp_context_required_tool_names
+        meta.mcp_context_required;
+    destructive =
+      force_true_if_member name static_destructive_tool_names meta.destructive;
+  }
+
 let metadata name =
   (* Hot path: called from MCP execute, tool list, OAS bridge, capability
      registry, keeper guards, help registry, governance risk, etc.  Cache
@@ -498,7 +550,9 @@ let metadata name =
     else
       base
   in
-  attach_inferred_effect_domain name with_surface_visibility
+  with_surface_visibility
+  |> attach_inferred_effect_domain name
+  |> attach_static_capabilities name
 
 let implementation_status name =
   let meta = metadata name in
@@ -590,10 +644,20 @@ let metadata_to_fields name =
         ("toolGroup", `String (tool_group_to_string group)) :: with_effect_domain
     | None -> with_effect_domain
   in
+  let with_requires_join =
+    match meta.requires_join with
+    | Some value -> ("requiresJoin", `Bool value) :: with_tool_group
+    | None -> with_tool_group
+  in
+  let with_mcp_context_required =
+    match meta.mcp_context_required with
+    | Some value -> ("mcpContextRequired", `Bool value) :: with_requires_join
+    | None -> with_requires_join
+  in
   let with_actor_binding =
     match meta.requires_actor_binding with
-    | Some value -> ("requiresActorBinding", `Bool value) :: with_tool_group
-    | None -> with_tool_group
+    | Some value -> ("requiresActorBinding", `Bool value) :: with_mcp_context_required
+    | None -> with_mcp_context_required
   in
   match meta.required_permission with
   | Some permission ->
@@ -621,9 +685,19 @@ let public_contract_fields name =
     | Some value -> ("requiresActorBinding", `Bool value) :: with_effect_domain
     | None -> with_effect_domain
   in
+  let with_requires_join =
+    match meta.requires_join with
+    | Some value -> ("requiresJoin", `Bool value) :: with_actor_binding
+    | None -> with_actor_binding
+  in
+  let with_mcp_context_required =
+    match meta.mcp_context_required with
+    | Some value -> ("mcpContextRequired", `Bool value) :: with_requires_join
+    | None -> with_requires_join
+  in
   match meta.canonical_name with
-  | Some canonical_name -> ("canonicalName", `String canonical_name) :: with_actor_binding
-  | None -> with_actor_binding
+  | Some canonical_name -> ("canonicalName", `String canonical_name) :: with_mcp_context_required
+  | None -> with_mcp_context_required
 
 let allow_direct_call name =
   let meta = metadata name in

--- a/lib/tool_catalog.mli
+++ b/lib/tool_catalog.mli
@@ -43,6 +43,8 @@ type metadata = {
   reason : string option;
   allow_direct_call_when_hidden : bool;
   readonly : bool option;
+  requires_join : bool option;
+  mcp_context_required : bool option;
   destructive : bool option;
   idempotent : bool option;
   required_permission : Masc_domain.permission option;

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -378,6 +378,9 @@ let inline_tool_requires_join = [ "masc_leave"; "masc_broadcast" ]
 
 let inline_tool_requires_actor_binding = [ "masc_join"; "masc_leave" ]
 
+let inline_tool_mcp_context_required =
+  [ "masc_join"; "masc_leave"; "masc_broadcast"; "masc_messages"; "masc_approval_get" ]
+
 let inline_tool_effect_domain name : Tool_catalog.effect_domain =
   if List.mem name inline_tool_read_only then Tool_catalog.Read_only
   else Tool_catalog.Masc_coordination
@@ -403,6 +406,7 @@ let () =
            ~is_read_only
            ~is_idempotent:is_read_only
            ~requires_join:(List.mem name inline_tool_requires_join)
+           ~mcp_context_required:(List.mem name inline_tool_mcp_context_required)
            ~requires_actor_binding:(List.mem name inline_tool_requires_actor_binding)
            ~effect_domain:(inline_tool_effect_domain name)
            ?required_permission:(inline_tool_required_permission name)

--- a/lib/tool_spec.ml
+++ b/lib/tool_spec.ml
@@ -34,6 +34,7 @@ type t = {
   handler_binding : handler_binding;
   is_read_only : bool;
   requires_join : bool;
+  mcp_context_required : bool;
   is_destructive : bool;
   is_idempotent : bool;
   visibility : Tool_catalog.visibility;
@@ -60,6 +61,7 @@ let create
     ~handler_binding
     ?(is_read_only = false)
     ?(requires_join = false)
+    ?(mcp_context_required = false)
     ?(is_destructive = false)
     ?(is_idempotent = false)
     ?(visibility = Tool_catalog.Default)
@@ -74,7 +76,7 @@ let create
     ?requires_actor_binding
     () =
   { name; description; module_tag; input_schema; handler_binding;
-    is_read_only; requires_join; is_destructive; is_idempotent;
+    is_read_only; requires_join; mcp_context_required; is_destructive; is_idempotent;
     visibility; implementation_status;
     canonical_name; replacement; reason;
     allow_direct_call_when_hidden; title; required_permission; effect_domain;
@@ -114,6 +116,8 @@ let register (spec : t) =
   (* 3. Requires-join set *)
   if spec.requires_join then
     Tool_dispatch.init_requires_join_set [ spec.name ];
+  if spec.mcp_context_required then
+    Tool_dispatch.init_mcp_context_required_set [ spec.name ];
   (* Add destructive and idempotent sets *)
   if spec.is_destructive then
     Tool_dispatch.init_destructive_set [ spec.name ];
@@ -156,6 +160,8 @@ let register (spec : t) =
       reason = spec.reason;
       allow_direct_call_when_hidden = effective_allow_direct;
       readonly = Some spec.is_read_only;
+      requires_join = Some spec.requires_join;
+      mcp_context_required = Some spec.mcp_context_required;
       destructive = Some spec.is_destructive;
       idempotent = Some spec.is_idempotent;
       required_permission;

--- a/lib/tool_spec.mli
+++ b/lib/tool_spec.mli
@@ -37,6 +37,7 @@ type t = {
   handler_binding : handler_binding;
   is_read_only : bool;
   requires_join : bool;
+  mcp_context_required : bool;
   is_destructive : bool;
   is_idempotent : bool;
   visibility : Tool_catalog.visibility;
@@ -61,6 +62,7 @@ val create :
   handler_binding:handler_binding ->
   ?is_read_only:bool ->
   ?requires_join:bool ->
+  ?mcp_context_required:bool ->
   ?is_destructive:bool ->
   ?is_idempotent:bool ->
   ?visibility:Tool_catalog.visibility ->
@@ -86,6 +88,7 @@ val register : t -> unit
     - [Tool_dispatch.register_module_tag] (tag + schema)
     - [Tool_dispatch.init_read_only_set] (if [is_read_only])
     - [Tool_dispatch.init_requires_join_set] (if [requires_join])
+    - [Tool_dispatch.init_mcp_context_required_set] (if [mcp_context_required])
     - [Tool_catalog.register_metadata] (visibility and semantic flags)
 
     @raise Invalid_argument if [name] is empty. *)

--- a/test/dune
+++ b/test/dune
@@ -1948,7 +1948,7 @@
 
 ; RFC-0084 PR-4 — Tool_capability typed sum + Set tests. Verifies typed
 ; round-trip, all_kinds cardinality, check ~required ~granted semantics,
-; and the bridge to legacy Tool_dispatch.is_* queries.
+; and catalog metadata as the capability source.
 
 (test
  (name test_tool_capability_typed)

--- a/test/test_tool_capability_typed.ml
+++ b/test/test_tool_capability_typed.ml
@@ -6,9 +6,7 @@ open Alcotest
     - All 5 [kind] variants round-trip through [to_string] / [of_string]
     - [all_kinds] enumerates exactly 5 variants
     - [Set.diff] semantics for [check]
-    - Bridge to legacy [Tool_dispatch] sets via [has] returns [false] for
-      an unknown tool name (the legacy sets are empty at test boot — no
-      [init_*_set] is called from [masc_test_deps] env setup)
+    - [has] reads [Tool_catalog] metadata, not legacy [Tool_dispatch] sets
     - [granted] of an unknown tool returns the empty set
     - [check ~required:empty ~granted:empty] returns [Ok ()]
     - [check] with disjoint required + granted returns [Error required] *)
@@ -41,11 +39,52 @@ let test_of_string_unknown_returns_none () =
 ;;
 
 let test_has_unknown_tool_returns_false () =
-  (* The legacy Tool_dispatch sets are empty at test boot. *)
   (check bool)
     "has Read_only on an unregistered tool name returns false"
     false
     (Masc_mcp.Tool_capability.has Read_only "__nonexistent_tool__")
+;;
+
+let test_has_ignores_legacy_dispatch_set () =
+  Masc_mcp.Tool_dispatch.init_read_only_set [ "__cap_dispatch_only_ro" ];
+  (check bool)
+    "dispatch-only read-only set no longer grants Tool_capability"
+    false
+    (Masc_mcp.Tool_capability.has Read_only "__cap_dispatch_only_ro")
+;;
+
+let test_has_catalog_metadata () =
+  let name = "__cap_catalog_tool" in
+  Masc_mcp.Tool_catalog.register_metadata name
+    { Masc_mcp.Tool_catalog.default_metadata with
+      readonly = Some true;
+      requires_join = Some true;
+      mcp_context_required = Some true;
+      destructive = Some true;
+      idempotent = Some true;
+    };
+  List.iter
+    (fun kind ->
+      (check bool)
+        ("catalog metadata grants " ^ Masc_mcp.Tool_capability.to_string kind)
+        true
+        (Masc_mcp.Tool_capability.has kind name))
+    Masc_mcp.Tool_capability.all_kinds
+;;
+
+let test_has_catalog_inferred_capabilities () =
+  (check bool)
+    "effect_domain=Read_only grants Read_only"
+    true
+    (Masc_mcp.Tool_capability.has Read_only "tool_read_file");
+  (check bool)
+    "static inline metadata grants Mcp_context_required"
+    true
+    (Masc_mcp.Tool_capability.has Mcp_context_required "masc_who");
+  (check bool)
+    "static destructive metadata grants Destructive"
+    true
+    (Masc_mcp.Tool_capability.has Destructive "shell_exec")
 ;;
 
 let test_granted_unknown_tool_is_empty () =
@@ -105,6 +144,9 @@ let () =
         ; test_case "all-kinds-cardinality" `Quick test_all_kinds_cardinality
         ; test_case "of-string-unknown-returns-none" `Quick test_of_string_unknown_returns_none
         ; test_case "has-unknown-tool-returns-false" `Quick test_has_unknown_tool_returns_false
+        ; test_case "has-ignores-legacy-dispatch-set" `Quick test_has_ignores_legacy_dispatch_set
+        ; test_case "has-catalog-metadata" `Quick test_has_catalog_metadata
+        ; test_case "has-catalog-inferred-capabilities" `Quick test_has_catalog_inferred_capabilities
         ; test_case "granted-unknown-tool-is-empty" `Quick test_granted_unknown_tool_is_empty
         ; test_case "check-empty-required-is-ok" `Quick test_check_empty_required_is_ok
         ; test_case "check-missing-capability-returns-error" `Quick test_check_missing_capability_returns_error

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -29,6 +29,8 @@ let () =
             check string "description" "test required only" spec.description;
             check bool "is_read_only default" false spec.is_read_only;
             check bool "requires_join default" false spec.requires_join;
+            check bool "mcp_context_required default" false
+              spec.mcp_context_required;
             check bool "is_destructive default" false spec.is_destructive;
             check bool "is_idempotent default" false spec.is_idempotent;
             check bool "allow_direct_call default" false spec.allow_direct_call_when_hidden;
@@ -144,8 +146,27 @@ let () =
             check bool "is_join_required" true
               (Tool_dispatch.is_join_required "__test_spec_join");
             let meta = Tool_catalog.metadata "__test_spec_join" in
+            check bool "catalog requires_join" true
+              (meta.requires_join = Some true);
             check bool "requires_join implies actor binding" true
               (meta.requires_actor_binding = Some true));
+          test_case "register sets mcp context required" `Quick (fun () ->
+            let spec =
+              Tool_spec.create
+                ~name:"__test_spec_mcp_context"
+                ~description:"mcp context test"
+                ~module_tag:Tool_dispatch.Mod_misc
+                ~input_schema:empty_schema
+                ~handler_binding:Tag_dispatch
+                ~mcp_context_required:true
+                ()
+            in
+            Tool_spec.register spec;
+            check bool "is_mcp_context_required" true
+              (Tool_dispatch.is_mcp_context_required "__test_spec_mcp_context");
+            let meta = Tool_catalog.metadata "__test_spec_mcp_context" in
+            check bool "catalog mcp_context_required" true
+              (meta.mcp_context_required = Some true));
           test_case "register sets catalog metadata" `Quick (fun () ->
             let spec =
               Tool_spec.create


### PR DESCRIPTION
## Summary
- add typed catalog metadata for requires_join and mcp_context_required capabilities
- derive inline MCP-context and destructive capability facts from Tool_catalog static metadata instead of Tool_dispatch sets
- switch Tool_capability.has/granted to Tool_catalog metadata and update tests/docs/audit ledger

## Verification
- ocamlformat --check lib/tool_catalog.ml lib/tool_catalog.mli lib/tool_spec.ml lib/tool_spec.mli lib/tool_inline_dispatch.ml lib/tool_capability.ml lib/tool_capability.mli test/test_tool_capability_typed.ml test/test_tool_spec.ml
- git diff --check origin/main...HEAD
- rg -n "Tool_dispatch\.is_(read_only|join_required|mcp_context_required|destructive|idempotent)|init_.*_set" lib/tool_capability.ml lib/tool_capability.mli test/test_tool_capability_typed.ml test/dune -S (only the negative dispatch-set test remains)
- scripts/dune-local.sh build ./test/test_tool_capability_typed.exe ./test/test_tool_spec.exe (blocked: exit 75, live bare Dune processes outside scripts/dune-local.sh)