### PR TITLE
refactor(tool-registry): delegate mutation policy to descriptors

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -14,21 +14,7 @@ include Keeper_tool_policy
 let has_mutating_side_effect_with_input ~(tool_name : string) ~(input : Yojson.Safe.t)
   : bool
   =
-  match Tool_name.of_string tool_name with
-  | Some (Keeper Workspace_inspect) ->
-    let op =
-      match input with
-      | `Assoc fields ->
-        (match List.assoc_opt "op" fields with
-         | Some (`String value) -> Some (String.lowercase_ascii (String.trim value))
-         | _ -> None)
-      | _ -> None
-    in
-    (match op with
-     | Some op when List.mem op Keeper_workspace_op.valid_strings ->
-       not (Keeper_tool_registry.is_read_only_with_input ~tool_name ~input)
-     | Some _ | None -> false)
-  | _ -> not (Keeper_tool_registry.is_read_only_with_input ~tool_name ~input)
+  not (Keeper_tool_registry.is_read_only_with_input ~tool_name ~input)
 ;;
 
 type keeper_tool_call_recorder =

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -19,6 +19,7 @@
 
 open Alcotest
 module Descriptor = Masc_mcp.Agent_tool_descriptor
+module Exec = Masc_mcp.Keeper_exec_tools
 module Registry = Masc_mcp.Keeper_tool_registry
 module Tool_board_registry = Masc_mcp.Tool_board_registry
 
@@ -178,6 +179,31 @@ let test_readonly_policy_projects_to_input_aware_registry () =
        ~tool_name:"tool_write_file"
        ~input:(`Assoc [ "path", `String "x"; "content", `String "y" ]))
 
+let test_mutation_boundary_delegates_to_descriptor_policy () =
+  let search_input = `Assoc [ "pattern", `String "Agent_tool_descriptor" ] in
+  Alcotest.(check bool)
+    "SearchFiles public alias is not mutating"
+    false
+    (Exec.has_mutating_side_effect_with_input ~tool_name:"SearchFiles" ~input:search_input);
+  Alcotest.(check bool)
+    "MCP-prefixed SearchFiles is not mutating"
+    false
+    (Exec.has_mutating_side_effect_with_input
+       ~tool_name:"mcp__masc__SearchFiles"
+       ~input:search_input);
+  Alcotest.(check bool)
+    "tool_workspace_inspect without legacy op is not mutating"
+    false
+    (Exec.has_mutating_side_effect_with_input
+       ~tool_name:"tool_workspace_inspect"
+       ~input:search_input);
+  Alcotest.(check bool)
+    "WriteFile public alias remains mutating"
+    true
+    (Exec.has_mutating_side_effect_with_input
+       ~tool_name:"WriteFile"
+       ~input:(`Assoc [ "file_path", `String "x"; "content", `String "y" ]))
+
 let () =
   Alcotest.run
     "agent_tool_descriptor_registry_integrity"
@@ -205,5 +231,9 @@ let () =
             "descriptor read-only policy projects to input-aware registry"
             `Quick
             test_readonly_policy_projects_to_input_aware_registry
+        ; test_case
+            "mutation boundary delegates to descriptor policy"
+            `Quick
+            test_mutation_boundary_delegates_to_descriptor_policy
         ] )
     ]


### PR DESCRIPTION
## Summary

- Remove workspace-inspect op parsing from Keeper_exec_tools.has_mutating_side_effect_with_input.
- Delegate mutation classification to Keeper_tool_registry.is_read_only_with_input, which now resolves descriptor-backed public, MCP-prefixed, and internal names.
- Add regression coverage that SearchFiles / mcp__masc__SearchFiles / tool_workspace_inspect are non-mutating while WriteFile remains mutating.

## Validation

- ocamlformat --check lib/keeper/keeper_exec_tools.ml test/test_agent_tool_descriptor_registry_integrity.ml
- git diff --check HEAD~1..HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_agent_tool_descriptor_registry_integrity.exe ./test/test_keeper_unified_required_tools.exe
- ./_build/default/test/test_agent_tool_descriptor_registry_integrity.exe
- ./_build/default/test/test_keeper_unified_required_tools.exe