### PR TITLE
chore(keeper): purge stale shell ops setup refs

### DIFF
--- a/docs/design/keeper-tool-runtime-boundary-plan.md
+++ b/docs/design/keeper-tool-runtime-boundary-plan.md
@@ -136,16 +136,16 @@ and public tool aliases.
      allowlists are derived from `Exec_program.name_of_known` and that every allowlisted
      executable resolves to a known `Exec_program`.
    Continued in slice 12:
-   - `Keeper_shell_read_ops` now owns structured read/list/search handlers
+   - `Keeper_workspace_read_ops` now owns structured read/list/search handlers
      (`pwd`, `git_status`, `ls`, `cat`, `rg`, `git_log`, `find`, `head`,
      `tail`, `wc`, and `tree`) plus their sandbox read-runner and host Shell IR
      fallbacks.
-   - `keeper_shell_ops.ml` is now the public dispatcher/facade: it normalizes
-     aliases, delegates read operations to `Keeper_shell_read_ops`, and keeps
+   - `keeper_workspace_ops.ml` is now the public dispatcher/facade: it normalizes
+     aliases, delegates read operations to `Keeper_workspace_read_ops`, and keeps
      the remaining `git_diff` branch.
    - Source-level guards now require the read runner/path/Shell IR assertions
-     to live on `keeper_shell_read_ops.ml` and reject `Keeper_sandbox_read_runner`
-     from returning to `keeper_shell_ops.ml`.
+     to live on `keeper_workspace_read_ops.ml` and reject `Keeper_sandbox_read_runner`
+     from returning to `keeper_workspace_ops.ml`.
    - `Keeper_shell_ir` now also owns Shell IR construction for typed Bash
      input lowerers through `simple_bin` and `pipeline`, so
      `keeper_tool_bash_input.ml` no longer hand-builds `Shell_ir.Lit`,
@@ -348,12 +348,12 @@ and public tool aliases.
   delegates user-shell and trusted-tool commands without invoking Docker.
 - The boundary test now fails if PR/GitHub tool modules select the
   concrete Docker backend directly.
-- The boundary test now fails if `keeper_shell_ops.ml` reabsorbs
+- The boundary test now fails if `keeper_workspace_ops.ml` reabsorbs
   `op=gh` or `op=git_clone` command semantics, or if active gate
   scripts name retired `keeper_shell_docker` files.
 - The boundary test now fails if structured shell read ops call
   `Keeper_sandbox_read_backend` directly instead of `Keeper_sandbox_read_runner`;
-  the read-runner owner is `keeper_shell_read_ops.ml`, not the public dispatcher.
+  the read-runner owner is `keeper_workspace_read_ops.ml`, not the public dispatcher.
 - The boundary test now fails if file tools call `Keeper_sandbox_read_backend`
   directly or hard-code Docker route labels instead of asking the
   sandbox runner facades.
@@ -375,8 +375,8 @@ and public tool aliases.
 - The boundary test now fails if concrete GH tool modules bypass
   `Shell_ir_dispatch` and call `Keeper_sandbox_runner.run_command_with_status`
   directly.
-- The boundary test now fails if `keeper_shell_ops.ml` or
-  `keeper_shell_read_ops.ml` reintroduces direct
+- The boundary test now fails if `keeper_workspace_ops.ml` or
+  `keeper_workspace_read_ops.ml` reintroduces direct
   `Keeper_shell_shared.run_argv_with_status_retry_eintr` execution instead of
   routing host structured ops through `Keeper_shell_ir`.
 - `test_keeper_bash_safety` now fails if `Dev_exec_allowlist.dev` or

--- a/lib/keeper/keeper_shell_path.mli
+++ b/lib/keeper/keeper_shell_path.mli
@@ -30,7 +30,7 @@ val resolve_tool_read_path :
     [cwd] and [path] independently include the playground prefix. *)
 
 val shell_command_available : string -> bool
-(** PATH executable probe for keeper shell read fallback selection.
+(** PATH executable probe for workspace read fallback selection.
     This intentionally avoids [/bin/sh -c] and does not treat empty
     PATH entries as the current directory. *)
 

--- a/lib/tool_capability.ml
+++ b/lib/tool_capability.ml
@@ -38,7 +38,7 @@ module Set = Stdlib.Set.Make (struct
     ;;
   end)
 
-let has kind tool_name =
+let rec has kind tool_name =
   let metadata = Tool_catalog.metadata tool_name in
   match kind with
   | Read_only ->

--- a/test/test_pr_c_coreutils_migration.ml
+++ b/test/test_pr_c_coreutils_migration.ml
@@ -3,10 +3,10 @@ open Alcotest
 (** RFC-0084 host-config-cleanup-C — coreutils path migration.
 
     PR-C migrated the 6 absolute binary path literals used by
-    keeper_shell read ops (pwd / ls / cat / head / tail / wc)
+    workspace read ops (pwd / ls / cat / head / tail / wc)
     to the typed [Host_config.coreutils] record field.  The single
     [let coreutils = (Host_config.host ()).coreutils]
-    binding in [keeper_shell_ops_setup.ml] is the only [Host_config] call.
+    binding in [keeper_workspace_ops_setup.ml] is the only [Host_config] call.
 
     Behaviour is byte-identical today; the migration establishes a
     single source of truth so a future PR can flip
@@ -16,7 +16,7 @@ open Alcotest
     Pins:
     - 0 occurrences of any of the 6 absolute literals in
       [keeper_workspace_ops.ml], [keeper_workspace_read_ops.ml], or
-      [keeper_shell_ops_setup.ml] (regression guard)
+      [keeper_workspace_ops_setup.ml] (regression guard)
     - [Host_config.host] is invoked exactly once
       from the setup module (positive assertion + no per-call-site
       regression)
@@ -55,7 +55,7 @@ let test_no_coreutils_literals_in_shell_ops () =
          [
            "lib/keeper/keeper_workspace_ops.ml";
            "lib/keeper/keeper_workspace_read_ops.ml";
-           "lib/keeper/keeper_shell_ops_setup.ml";
+           "lib/keeper/keeper_workspace_ops_setup.ml";
          ])
   in
   let needles =
@@ -75,14 +75,14 @@ let test_no_coreutils_literals_in_shell_ops () =
 ;;
 
 let test_single_host_config_invocation () =
-  let content = read_file "lib/keeper/keeper_shell_ops_setup.ml" in
+  let content = read_file "lib/keeper/keeper_workspace_ops_setup.ml" in
   let occurrences =
     count_substring ~haystack:content
       ~needle:"Host_config.host"
   in
   (check int)
     "Host_config.host must be invoked exactly once \
-     from lib/keeper/keeper_shell_ops_setup.ml after PR-C"
+     from lib/keeper/keeper_workspace_ops_setup.ml after PR-C"
     pinned_host_config_invocations occurrences
 ;;
 


### PR DESCRIPTION
## Summary

- replace stale `keeper_shell_ops_setup` / `keeper_shell_read_ops` references with the current workspace module names
- update the coreutils migration ratchet to read `keeper_workspace_ops_setup.ml`
- fix the latest main build break by making `Tool_capability.has` explicitly recursive

## Validation

- `git diff --check`
- no-match `rg` for `keeper_shell_ops_setup|keeper_shell_read_ops|keeper_shell read ops|keeper shell read`
- `opam exec -- ocamlformat --check lib/tool_capability.ml test/test_pr_c_coreutils_migration.ml lib/keeper/keeper_shell_path.mli`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_INCLUDE_OPERATOR_CONTROL=true scripts/dune-local.sh build test/test_pr_c_coreutils_migration.exe`
- `./_build/default/test/test_pr_c_coreutils_migration.exe`
