### PR TITLE
refactor(tool-capability): purge runtime dispatch gates

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -751,9 +751,15 @@
           </tr>
           <tr>
             <td><code>Tool_capability</code> legacy set bridge</td>
-            <td><span class="status done">draft PR #18805</span></td>
+            <td><span class="status done">merged #18805</span></td>
             <td>Add typed catalog metadata for <code>requires_join</code> and <code>mcp_context_required</code>, derive static inline/destructive capability flags in <code>Tool_catalog</code>, and switch <code>Tool_capability.has</code> away from <code>Tool_dispatch.is_*</code>.</td>
-            <td>Tests now assert dispatch-only set writes no longer grant <code>Tool_capability</code>, while catalog metadata and catalog inference do grant the typed capabilities.</td>
+            <td>Merged as <code>06df8be18</code>. Tests assert dispatch-only set writes no longer grant <code>Tool_capability</code>, while catalog metadata and catalog inference do grant the typed capabilities.</td>
+          </tr>
+          <tr>
+            <td><code>Tool_dispatch.is_*</code> runtime capability gates</td>
+            <td><span class="status now">draft PR #18809</span></td>
+            <td>Move MCP annotations/icons, execution admission, bridge classification, eval gates, worker gates, and keeper policy helpers from mutable <code>Tool_dispatch.is_*</code> readers to catalog-backed <code>Tool_capability.has</code>.</td>
+            <td>The <code>lib/</code> backstop grep is clean for direct <code>Tool_dispatch.is_*</code> readers. <code>Tool_dispatch.init_*_set</code> remains only as the compatibility/bootstrap surface for the next deletion slice.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
@@ -789,10 +795,10 @@
         <tbody>
           <tr>
             <td>1</td>
-            <td><code>Tool_dispatch.is_*</code> runtime capability gates</td>
-            <td>Capability truth still has multiple direct runtime readers in MCP annotations/icons, execution admission, bridge classification, eval gates, and keeper policy helpers.</td>
-            <td>Move call sites one subsystem at a time to <code>Tool_catalog</code> / <code>Tool_capability</code>, then delete the mutable capability-set initialization APIs when no runtime reader remains.</td>
-            <td>Add parity tests per migrated subsystem and remove tests that populate <code>Tool_dispatch.init_*_set</code> only to preserve old capability authority.</td>
+            <td><code>Tool_dispatch.init_*_set</code> compatibility API and tests</td>
+            <td>Mutable capability sets are no longer runtime authority after the active branch, but registration/bootstrap code and tests still teach the old mental model.</td>
+            <td>Move remaining dynamic registration expectations into <code>Tool_catalog.register_metadata</code> / <code>Tool_spec.register</code> metadata assertions, then delete the set tables and <code>init_*_set</code> APIs.</td>
+            <td>Remove tests that populate <code>Tool_dispatch.init_*_set</code> solely to preserve old capability authority; keep only dispatch-registration tests that are actually about handler routing.</td>
           </tr>
         </tbody>
       </table>

--- a/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
+++ b/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
@@ -279,8 +279,8 @@ val gate : required:t list -> granted:Set.t -> [`Pass | `Reject of string]
 
 Current implementation: [Tool_capability.kind] is the closed capability
 alphabet, and [Tool_capability.has] reads [Tool_catalog.metadata]. The older
-[Tool_dispatch] capability sets remain only for runtime gates that have not yet
-been cut over, not as the [Tool_capability] authority.
+[Tool_dispatch] capability sets remain only for bootstrap/test compatibility,
+not as runtime capability authority.
 
 ### §3.3 `Dispatch_outcome.t` (PR-10)
 

--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -310,7 +310,7 @@ let pre_check
           | None ->
               (* 6. Destructive pattern check (bash tools only) *)
               if config.destructive_check_enabled
-                 && Tool_dispatch.is_destructive tool_name then
+                 && Tool_capability.has Tool_capability.Destructive tool_name then
                 let cmd_str = extract_all_strings_from_json args_json
                 in
                 begin match detect_destructive cmd_str with
@@ -325,7 +325,7 @@ let pre_check
     | None ->
         (* No trajectory accumulator — skip entropy and turn-limit checks *)
         if config.destructive_check_enabled
-           && Tool_dispatch.is_destructive tool_name then
+           && Tool_capability.has Tool_capability.Destructive tool_name then
           let cmd_str =
             try
               let rec extract_strings = function

--- a/lib/keeper/agent_tool_remote_mcp_runtime.ml
+++ b/lib/keeper/agent_tool_remote_mcp_runtime.ml
@@ -12,7 +12,7 @@ let masc_path_blocked
   | None ->
     Some (error_json (Printf.sprintf "keeper not found in registry: %s" keeper_name))
   | Some meta ->
-    let is_read_only = Tool_dispatch.is_read_only name in
+    let is_read_only = Tool_capability.has Tool_capability.Read_only name in
     let effective_paths =
       if is_read_only
       then keeper_effective_allowed_paths ~meta
@@ -70,7 +70,7 @@ let handle_masc_tool
            let msg = Tool_result.message tr in
            if ok then msg else tool_result_error_json tr
          | None ->
-           if Tool_dispatch.is_mcp_context_required name
+           if Tool_capability.has Tool_capability.Mcp_context_required name
            then
              error_json
                (Printf.sprintf

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -48,8 +48,8 @@ val keeper_read_only_tools : string list
 val is_keeper_read_only_tool : string -> bool
 
 (** [true] when [name] is read-only or idempotent (safe to retry).
-    Keeper-local fast-path (no mutex), then Tool_dispatch.is_read_only,
-    then Tool_dispatch.is_idempotent. Prefer {!has_mutating_side_effect}
+    Keeper-local fast-path (no mutex), then catalog-backed
+    {!Tool_capability.has}. Prefer {!has_mutating_side_effect}
     at call sites for positive-sense readability. *)
 val is_effectively_read_only_tool : string -> bool
 

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -646,7 +646,7 @@ let cost_guard
 
 (** Destructive pattern detection for bash/edit style tools.
     Only applies when [enabled] is [true] and the tool is flagged by
-    [Tool_dispatch.is_destructive]. *)
+    [Tool_capability.has Destructive]. *)
 let destructive_guard
     ~(meta_ref : Keeper_types.keeper_meta ref)
     ~on_gate_decision
@@ -657,7 +657,7 @@ let destructive_guard
     | Agent_sdk.Hooks.PreToolUse
         { tool_name; input; accumulated_cost_usd; turn; _ } ->
       if not enabled then Agent_sdk.Hooks.Continue
-      else if not (Tool_dispatch.is_destructive tool_name) then
+      else if not (Tool_capability.has Tool_capability.Destructive tool_name) then
         Agent_sdk.Hooks.Continue
       else
         let t0 = Time_compat.now () in

--- a/lib/keeper/keeper_guards.mli
+++ b/lib/keeper/keeper_guards.mli
@@ -184,7 +184,7 @@ val cost_guard :
   Agent_sdk.Hooks.hooks
 
 (** Destructive-pattern detection for tools flagged by
-    [Tool_dispatch.is_destructive]; runs only when [enabled]. *)
+    {!Tool_capability.has}; runs only when [enabled]. *)
 val destructive_guard :
   meta_ref:Keeper_types.keeper_meta ref ->
   on_gate_decision:(gate_decision_event -> unit) ->

--- a/lib/keeper/keeper_hooks_oas_introspection.ml
+++ b/lib/keeper/keeper_hooks_oas_introspection.ml
@@ -25,7 +25,7 @@ let hook_slot_json ?(features = []) ?(gates = []) ?(effects = []) ?reason
 let hook_introspection_json ~denied_tools ?(max_cost_usd : float option)
     ?(destructive_check : bool = true) () : Yojson.Safe.t =
   let denied_json = `List (List.map (fun s -> `String s) denied_tools) in
-  let destructive_json = `String "dynamic_boundary (Tool_dispatch.is_destructive)" in
+  let destructive_json = `String "dynamic_boundary (Tool_capability.Destructive)" in
   let slot ?features ?gates ?effects ?reason ~active ~source name =
     let features = Option.value features ~default:[] in
     let gates = Option.value gates ~default:[] in

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -176,15 +176,9 @@ let keeper_safe_inline_tools =
 let is_keeper_safe_inline_tool name =
   List.mem name keeper_safe_inline_tools
 
-let keeper_mcp_context_required_tools =
-  Tool_schemas_inline.schemas
-  |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
-  |> List.filter (fun name -> not (is_keeper_safe_inline_tool name))
-
 let is_keeper_mcp_context_required name =
   not (is_keeper_safe_inline_tool name)
-  && (List.mem name keeper_mcp_context_required_tools
-      || Tool_dispatch.is_mcp_context_required name)
+  && Tool_capability.has Tool_capability.Mcp_context_required name
 
 let keeper_supported_keeper_masc_tools =
   [ "masc_keeper_list"

--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -137,7 +137,7 @@ let tool_name_can_satisfy_required_contract name =
         ( Tool_catalog.Masc_coordination
         | Tool_catalog.Playground_write
         | Tool_catalog.Host_repo_write ) -> true
-    | None -> not (Tool_dispatch.is_read_only name))
+    | None -> not (Tool_capability.has Tool_capability.Read_only name))
 ;;
 
 let required_tool_satisfaction ?(satisfying_tools : string list = [])

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -127,10 +127,10 @@ let is_keeper_read_only_tool (name : string) : bool =
 
 let is_effectively_read_only_tool (name : string) : bool =
   (* Keeper-local check first (bare Hashtbl, no mutex) before
-     Tool_dispatch (requires Eio.Mutex acquire). *)
+     catalog-backed capability lookup. *)
   is_keeper_read_only_tool name
-  || Tool_dispatch.is_read_only name
-  || Tool_dispatch.is_idempotent name
+  || Tool_capability.has Tool_capability.Read_only name
+  || Tool_capability.has Tool_capability.Idempotent name
 ;;
 
 let has_mutating_side_effect (name : string) : bool =

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -566,7 +566,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     | Full | Operator_remote ->
         (params |> U.member "name" |> U.to_string, params |> U.member "arguments")
   in
-  let is_read_only = Tool_dispatch.is_read_only name in
+  let is_read_only = Tool_capability.has Tool_capability.Read_only name in
 
   (* Measure execution time for telemetry *)
   let start_time = Eio.Time.now clock in

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -231,7 +231,9 @@ let execute_tool_eio
        (* Auto-init/auto-join for better UX.
      - Auto-init only when auth is disabled (avoid side effects in secured rooms).
      - Auto-join when allowed by auth (and safe for token-based auth). *)
-       let join_required = Tool_dispatch.is_join_required name in
+       let join_required =
+         Tool_capability.has Tool_capability.Requires_join name
+       in
        let init_error =
          if (not auth_enabled) && join_required && not !room_init_cached
          then (
@@ -251,7 +253,9 @@ let execute_tool_eio
        (match init_error with
         | Some msg -> with_system_internal_audit ~agent_name (Tool_result.quick_error msg)
         | None ->
-          let is_read_only = Tool_dispatch.is_read_only name in
+          let is_read_only =
+            Tool_capability.has Tool_capability.Read_only name
+          in
           let can_auto_join =
             if (not join_required) || agent_name = "unknown"
             then false

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -135,7 +135,7 @@ let affected_resource_ids_for_tool = function
 ;;
 
 let maybe_emit_resource_notifications ~success ~tool_name =
-  if success && not (Tool_dispatch.is_read_only tool_name)
+  if success && not (Tool_capability.has Tool_capability.Read_only tool_name)
   then (
     let affected_ids = affected_resource_ids_for_tool tool_name in
     with_resource_subscription_lock (fun () ->

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -142,21 +142,14 @@ let tool_allowed_in_profile ?(internal_keeper_runtime = false) state profile
   | Operator_remote -> List.mem tool_name Tool_operator.remote_tool_names
 
 let tool_annotations_for_profile _profile tool_name =
-  let meta = Tool_catalog.metadata tool_name in
   let read_only =
-    match meta.readonly with
-    | Some v -> v
-    | None -> Tool_dispatch.is_read_only tool_name
+    Tool_capability.has Tool_capability.Read_only tool_name
   in
   let destructive =
-    match meta.destructive with
-    | Some v -> v
-    | None -> Tool_dispatch.is_destructive tool_name
+    Tool_capability.has Tool_capability.Destructive tool_name
   in
   let idempotent =
-    match meta.idempotent with
-    | Some v -> v
-    | None -> Tool_dispatch.is_idempotent tool_name || read_only
+    Tool_capability.has Tool_capability.Idempotent tool_name
   in
   (* MCP 2025-03-26: [openWorldHint] signals whether the tool can
      interact with systems outside the server's closed world.
@@ -273,7 +266,7 @@ let tool_title_of_name name =
 
 let tool_icons_for_name name =
   let icon =
-    if Tool_dispatch.is_read_only name then
+    if Tool_capability.has Tool_capability.Read_only name then
       Mcp_server.themed_icon ~label:"RD" ~bg:"#0F766E" ~fg:"#F0FDFA"
     else
       Mcp_server.themed_icon ~label:"WR" ~bg:"#9A3412" ~fg:"#FFF7ED"

--- a/lib/mcp_server_eio_tool_profile.mli
+++ b/lib/mcp_server_eio_tool_profile.mli
@@ -109,9 +109,7 @@ val tool_annotations_for_profile :
 (** [tool_annotations_for_profile profile tool_name] returns the
     MCP 2025-03-26 [annotations] object — [readOnlyHint],
     [destructiveHint], [idempotentHint], [openWorldHint] — derived
-    from {!Tool_catalog.metadata} with fallback to
-    {!Tool_dispatch.is_read_only} / [is_destructive] /
-    [is_idempotent].
+    from {!Tool_capability.has}.
 
     Returns [None] when the field set would be empty.
     [openWorldHint] is emitted only when the tool is unambiguously

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -230,8 +230,10 @@ let oas_permission_of_masc_tool name =
   | Some true, _ -> Some Agent_sdk.Tool.Destructive
   | _, Some true -> Some Agent_sdk.Tool.ReadOnly
   | _, Some false -> Some Agent_sdk.Tool.Write
-  | _ when Tool_dispatch.is_destructive name -> Some Agent_sdk.Tool.Destructive
-  | _ when Tool_dispatch.is_read_only name -> Some Agent_sdk.Tool.ReadOnly
+  | _ when Tool_capability.has Tool_capability.Destructive name ->
+    Some Agent_sdk.Tool.Destructive
+  | _ when Tool_capability.has Tool_capability.Read_only name ->
+    Some Agent_sdk.Tool.ReadOnly
   | _ -> None
 
 let oas_descriptor_of_masc_tool name =

--- a/lib/tool_capability.mli
+++ b/lib/tool_capability.mli
@@ -2,8 +2,8 @@
 
     The closed-sum [kind] and [Set]-based granted/required model reads
     capability truth from [Tool_catalog.metadata]. [Tool_dispatch]'s
-    mutable capability sets remain only for older runtime gates that have
-    not yet been cut over; they are no longer authoritative here.
+    mutable capability sets remain only for bootstrap/test compatibility;
+    they are no longer runtime capability authority.
 
     The module is named [Tool_capability] (not [Capability]) because
     [lib/exec/capability.ml] already owns the [Capability] name for the

--- a/lib/tool_unified.ml
+++ b/lib/tool_unified.ml
@@ -20,7 +20,8 @@ module Float = Stdlib.Float
     Combines:
     - Tool_catalog: visibility, lifecycle, metadata
     - Tool_registry: call statistics (count, success, failure, duration)
-    - Tool_dispatch: registration status, read_only, join_required
+    - Tool_dispatch: registration status
+    - Tool_capability: read_only, join_required
 *)
 
 type tool_info = {
@@ -44,8 +45,8 @@ let tool_info name : tool_info =
     visibility = meta.visibility;
     lifecycle = meta.lifecycle;
     is_registered = Tool_dispatch.is_registered name;
-    is_read_only = Tool_dispatch.is_read_only name;
-    is_join_required = Tool_dispatch.is_join_required name;
+    is_read_only = Tool_capability.has Tool_capability.Read_only name;
+    is_join_required = Tool_capability.has Tool_capability.Requires_join name;
     call_stats = stats;
   }
 

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -383,7 +383,7 @@ let make_tool_tracking_hooks ?gate_config ?context () =
                  else if
                    (* Gate 2: Destructive pattern detection *)
                    gate.destructive_check_enabled
-                   && Tool_dispatch.is_destructive tool_name
+                   && Tool_capability.has Tool_capability.Destructive tool_name
                  then (
                    let cmd = extract_command_from_input input in
                    match Eval_gate.detect_destructive cmd with

--- a/test/dune
+++ b/test/dune
@@ -1741,6 +1741,8 @@
 
 (include stanzas/test_mcp_post_sse_e2e.inc)
 
+(include stanzas/test_mcp_server_eio_tool_profile_capability.inc)
+
 (include stanzas/test_mcp_tool_matrix.inc)
 
 (include stanzas/test_meta_cognition_snapshot.inc)

--- a/test/stanzas/test_mcp_server_eio_tool_profile_capability.inc
+++ b/test/stanzas/test_mcp_server_eio_tool_profile_capability.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_mcp_server_eio_tool_profile_capability)
+ (modules test_mcp_server_eio_tool_profile_capability)
+ (libraries masc_test_deps))

--- a/test/test_mcp_server_eio_tool_profile_capability.ml
+++ b/test/test_mcp_server_eio_tool_profile_capability.ml
@@ -1,0 +1,74 @@
+open Alcotest
+
+let annotation_fields tool_name =
+  match
+    Masc_mcp.Mcp_server_eio_tool_profile.tool_annotations_for_profile
+      Masc_mcp.Mcp_server_eio_tool_profile.Full
+      tool_name
+  with
+  | Some (`Assoc fields) -> fields
+  | Some _ -> failf "annotations for %s was not an object" tool_name
+  | None -> failf "annotations missing for %s" tool_name
+;;
+
+let annotation_field name tool_name =
+  List.assoc_opt name (annotation_fields tool_name)
+;;
+
+let bool_annotation name tool_name =
+  match annotation_field name tool_name with
+  | Some (`Bool value) -> value
+  | Some other ->
+    failf "annotation %s for %s was %s" name tool_name (Yojson.Safe.to_string other)
+  | None -> failf "annotation %s missing for %s" name tool_name
+;;
+
+let test_annotations_ignore_dispatch_only_read_only () =
+  let name = "__profile_dispatch_only_ro" in
+  Masc_mcp.Tool_dispatch.init_read_only_set [ name ];
+  check bool "dispatch-only readOnlyHint ignored" false (bool_annotation "readOnlyHint" name);
+  check
+    (option string)
+    "dispatch-only openWorldHint absent"
+    None
+    (Option.map Yojson.Safe.to_string (annotation_field "openWorldHint" name))
+;;
+
+let test_annotations_use_catalog_capabilities () =
+  check
+    bool
+    "tool_read_file readOnlyHint from catalog capability"
+    true
+    (bool_annotation "readOnlyHint" "tool_read_file");
+  check
+    bool
+    "tool_read_file openWorldHint closed"
+    false
+    (bool_annotation "openWorldHint" "tool_read_file");
+  check
+    bool
+    "shell_exec destructiveHint from catalog capability"
+    true
+    (bool_annotation "destructiveHint" "shell_exec");
+  check
+    bool
+    "shell_exec openWorldHint open"
+    true
+    (bool_annotation "openWorldHint" "shell_exec")
+;;
+
+let () =
+  run
+    "mcp-server-eio-tool-profile-capability"
+    [ ( "annotations"
+      , [ test_case
+            "ignore-dispatch-only-read-only"
+            `Quick
+            test_annotations_ignore_dispatch_only_read_only
+        ; test_case
+            "use-catalog-capabilities"
+            `Quick
+            test_annotations_use_catalog_capabilities
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- moved lib runtime capability readers from `Tool_dispatch.is_*` to catalog-backed `Tool_capability.has`
- covered MCP annotations/icons, execute/call retry gates, bridge classification, eval/worker destructive gates, and keeper policy helpers
- updated the purge ledger HTML/RFC text and added a regression test proving dispatch-only read-only sets no longer affect tool profile annotations

## Verification

- `ocamlformat --check lib/mcp_server_eio_tool_profile.ml lib/mcp_server_eio_tool_profile.mli lib/mcp_server_eio_execute.ml lib/mcp_server_eio_call_tool.ml lib/mcp_server_eio_protocol.ml lib/tool_bridge.ml lib/eval_gate.ml lib/worker_oas.ml lib/tool_unified.ml lib/tool_capability.mli lib/keeper/keeper_tool_policy.ml lib/keeper/agent_tool_remote_mcp_runtime.ml lib/keeper/keeper_tool_progress.ml lib/keeper/keeper_guards.ml lib/keeper/keeper_tool_registry.ml lib/keeper/keeper_hooks_oas_introspection.ml lib/keeper/keeper_exec_tools.mli lib/keeper/keeper_guards.mli test/test_mcp_server_eio_tool_profile_capability.ml`
- `git diff --check origin/main...HEAD`
- `rg -n "Tool_dispatch\\.is_(read_only|join_required|mcp_context_required|destructive|idempotent)|keeper_mcp_context_required_tools" lib -S` returned no matches
- `scripts/dune-local.sh build ./test/test_mcp_server_eio_tool_profile_capability.exe ./test/test_tool_capability_typed.exe ./test/test_tool_spec.exe ./test/test_mcp_server_eio_join_state.exe ./test/test_mcp_server_eio_call_tool.exe ./test/test_eval_gate.exe ./test/test_worker_safety_gates.exe ./test/test_keeper_safety_gates.exe` blocked with exit 75 because machine-wide bare Dune processes are active; not bypassed

## Notes

`Tool_dispatch.init_*_set` is intentionally left for the next deletion slice. This PR removes direct lib runtime readers of those sets.
