### PR TITLE
fix(tool-capability): make has recursive — restore main build

### DIFF
--- a/lib/tool_capability.ml
+++ b/lib/tool_capability.ml
@@ -38,7 +38,7 @@ module Set = Stdlib.Set.Make (struct
     ;;
   end)
 
-let has kind tool_name =
+let rec has kind tool_name =
   let metadata = Tool_catalog.metadata tool_name in
   match kind with
   | Read_only ->


### PR DESCRIPTION
## 증상

`origin/main` (post `06df8be18` / PR #18805) 에서 fresh worktree `dune build --root . @lib/all` 즉시 실패:

```
File "lib/tool_capability.ml", line 64, characters 15-18:
64 |      | None -> has Read_only tool_name)
                    ^^^
Error: Unbound value has
Hint: If this is a recursive definition,
you should add the rec keyword on line 41
```

## 원인

PR #18805 (`refactor(tool-capability): use catalog metadata`) 가 `has` 함수 본문 안에서 자기 자신을 호출 (`None -> has Read_only tool_name`, Idempotent fallthrough) 하면서 `let rec` 가 아닌 `let` 으로 선언함. OCaml 은 `let` 본문 안에서 자기 자신을 unbind 으로 처리 → 컴파일 실패.

main CI 가 머지 시점에 still in_progress 상태였기 때문에 merge gate 가 검출하지 못함.

## 변경

`lib/tool_capability.ml:41` — `let has` → `let rec has`. 1자 변경.

## 검증

- `dune build --root . @lib/all` PASS (worktree `.worktrees/fix-tool-capability-rec`)
- 다른 변경 없음

## Workaround 게이트

해당 없음 — 직접 root fix (PR 본문에 documented). signature 3종 / 체크리스트 7항목 비해당.