### PR TITLE
refactor(coord): dependency-inversion ref breaks Tool_coord cycle — 8 masc_coord_* descriptors active (RFC-0182 Phase 5)

### DIFF
--- a/lib/coord_dispatch_ref.ml
+++ b/lib/coord_dispatch_ref.ml
@@ -1,0 +1,28 @@
+(** RFC-0182 §3.1 — coord dispatch dependency inversion ref.
+
+    [Agent_tool_in_process_runtime] is compiled very early in module
+    order (transitively imported by [Keeper_exec_tools]). [Tool_coord]
+    is compiled late (it depends on [Keeper_runtime] which depends on
+    most of the keeper layer). A direct import from
+    [Agent_tool_in_process_runtime] to [Tool_coord] would close a
+    cycle.
+
+    Resolution: register [Tool_coord.dispatch] into this ref from a
+    late-compiled bootstrap module ([Mcp_server_eio_execute]).
+    [Agent_tool_in_process_runtime.handle_masc_coord] reads the ref.
+    Until registered the ref is a no-op returning [None] (the same
+    behavior the descriptor projection stub had).
+
+    The ref is process-global mutable — acceptable because masc-mcp is
+    a single-process server with a single coord dispatcher. *)
+
+let dispatch
+  : (config:Coord.config
+     -> agent_name:string
+     -> name:string
+     -> args:Yojson.Safe.t
+     -> Tool_result.t option)
+      ref
+  =
+  ref (fun ~config:_ ~agent_name:_ ~name:_ ~args:_ -> None)
+;;

--- a/lib/coord_dispatch_ref.mli
+++ b/lib/coord_dispatch_ref.mli
@@ -1,0 +1,11 @@
+(** RFC-0182 §3.1 — coord dispatch dependency inversion ref.
+
+    See [coord_dispatch_ref.ml] for the rationale. *)
+
+val dispatch
+  : (config:Coord.config
+     -> agent_name:string
+     -> name:string
+     -> args:Yojson.Safe.t
+     -> Tool_result.t option)
+      ref

--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -161,24 +161,21 @@ let handle_masc_agent ~(config : Coord.config) ~(meta : keeper_meta) ~name ~args
   Tool_agent.dispatch ctx ~name ~args |> dispatch_option_to_string ~name
 ;;
 
-(* RFC-0182 §3.1 — masc_coord_ cluster. Separate cycle from Tool_misc/
-   Tool_agent_timeline: Tool_coord → Keeper_runtime → Keeper_agent_error
-   → Keeper_agent_tool_surface → Keeper_tool_progress → Keeper_exec_tools
-   → Agent_tool_runtime → here. The Turn_mode_codec extraction did not
-   touch the Tool_coord ↔ Keeper_runtime edge. Still stubbed pending a
-   follow-up that splits Tool_coord or removes its Keeper_runtime
-   dependency. *)
-let handle_masc_coord ~config:_ ~meta:_ ~name ~args:_ =
-  Yojson.Safe.to_string
-    (`Assoc
-       [ "error"
-       , `String
-           (Printf.sprintf
-              "%s descriptor projection is pending: Tool_coord cycle resolution \
-               (Tool_coord -> Keeper_runtime back edge, separate from \
-               Turn_mode_codec cycle break)."
-              name)
-       ])
+(* RFC-0182 §3.1 — masc_coord_ cluster. Tool_coord lies LATE in module
+   order (depends on Keeper_runtime which depends on much of the keeper
+   layer). Agent_tool_in_process_runtime is EARLY (transitively imported
+   by Keeper_exec_tools). A direct static import here closes a cycle.
+
+   Resolution: dispatch through [Coord_dispatch_ref.dispatch]. A late
+   bootstrap module ([Mcp_server_eio_execute]) registers
+   [Tool_coord.dispatch] into the ref. Until registered the ref returns
+   [None], surfacing a clear projection error rather than silently
+   succeeding with stale state. *)
+let handle_masc_coord ~(config : Coord.config) ~(meta : keeper_meta) ~name ~args =
+  let dispatched =
+    !Coord_dispatch_ref.dispatch ~config ~agent_name:meta.name ~name ~args
+  in
+  dispatch_option_to_string ~name dispatched
 ;;
 
 (* RFC-0182 §3.1 — masc_misc cluster. Active after Turn_mode_codec

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -775,3 +775,13 @@ let execute_tool_eio
                          ~tool_name:name
                          (Printf.sprintf "Unknown tool: %s (registry inconsistency)" name)))))))
 ;;
+
+(* RFC-0182 §3.1 — register Tool_coord.dispatch with the dependency
+   inversion ref so [Agent_tool_in_process_runtime.handle_masc_coord]
+   (compiled early) can dispatch coord tools without statically
+   importing [Tool_coord] (compiled late). *)
+let () =
+  Coord_dispatch_ref.dispatch
+  := fun ~config ~agent_name ~name ~args ->
+    Tool_coord.dispatch { config; agent_name } ~name ~args
+;;


### PR DESCRIPTION
## 요약

RFC-0182 Phase 4 PR #18792 후 마지막 stubbed cluster (`masc_coord_*` 8개) 의 cycle 해소. **dependency inversion** 패턴으로 Tool_coord 의 type/시그니처/테스트 0 변경.

| 항목 | 값 |
|---|---|
| New files | `lib/coord_dispatch_ref.ml`, `lib/coord_dispatch_ref.mli` |
| Modified | `lib/keeper/agent_tool_in_process_runtime.ml`, `lib/mcp_server_eio_execute.ml` |
| Diff size | `+64/-18` |
| Build | `dune build --root . --cache=disabled` PASS |
| Active routing | 58 → 66 / 105 non-portal tools (55% → **63%**) |
| Stubbed coord | 8 → **0** |

## Cycle 해소 메커니즘

```
[Before]  Agent_tool_in_process_runtime → Tool_coord → Keeper_runtime → ... → Keeper_exec_tools → Agent_tool_runtime → here  (closed cycle)
[After]   Agent_tool_in_process_runtime → Coord_dispatch_ref (only Coord + Tool_result deps)
          Mcp_server_eio_execute (late) → Tool_coord
                                       → Coord_dispatch_ref.dispatch := wrapper
                                       (registration at module load)
```

## 활성화된 8 tools

`masc_status`, `masc_heartbeat`, `masc_check`, `masc_reset`,
`masc_goal_list`, `masc_goal_upsert`, `masc_goal_transition`, `masc_goal_verify`

## Trade-offs

(+) Tool_coord 타입/dispatch 시그니처 0 변경 → 기존 ~30 test 0 영향
(+) 작은 blast radius — 4 파일, 1 신규 모듈 (~30 LoC)
(-) Process-global mutable ref — masc-mcp 가 single-process 라 수용
(-) MCP server 미실행 테스트가 직접 `handle_masc_coord` 호출 시 None fallthrough. 현재 그런 테스트 없음 (전부 `Tool_coord.dispatch` 직접 호출).

## Co-located dependency

상속된 #18811 cherry-pick 1자 fix (`let rec has`). main 이 `06df8be18` 머지 후 fresh build 깨진 상태였음. PR #18811 머지 시 rebase 로 자동 흡수.

## Workaround Signature Gate

해당 없음. 직접 root fix (dependency inversion). 시그니처 3종 + 체크리스트 7항목 비해당. detail 은 commit message 참조.

## 검증

- `dune build --root . --cache=disabled @lib/all` PASS
- `dune build --root . --cache=disabled` (full incl. tests + bin) PASS
- Cycle 정적 해소 confirmed (Agent_tool_in_process_runtime 의 import 목록에서 Tool_coord 부재)