### PR TITLE
feat(tool_inline_dispatch_comm): tag explicit failure_class on broadcast errors (RFC-0189 small-step)

### DIFF
--- a/lib/tool_inline_dispatch_comm.ml
+++ b/lib/tool_inline_dispatch_comm.ml
@@ -44,11 +44,27 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
   let message = arg_get_string ctx "message" "" in
   let trimmed = String.trim message in
   if String.equal trimmed "" then
-    Some (Tool_result.error ~tool_name ~start_time "Broadcast message cannot be empty")
+    (* RFC-0189: caller-input violation (empty broadcast message).
+       Explicit [Workflow_rejection] avoids the auto-classify path's
+       Runtime_failure default. PR-2 compatible — only the
+       [?failure_class] optional argument is added, [error] signature
+       preserved. *)
+    Some (Tool_result.error
+            ~failure_class:(Some Tool_result.Workflow_rejection)
+            ~tool_name ~start_time
+            "Broadcast message cannot be empty")
   else
   let allowed, wait_secs = Session.check_rate_limit registry ~agent_name in
   if not allowed then
-    Some (Tool_result.error ~tool_name ~start_time (Printf.sprintf "Rate limited. %d sec remaining." wait_secs))
+    (* RFC-0189: rate-limit hit — caller should retry after [wait_secs].
+       [Transient_error] is the closest existing variant for
+       retry-friendly failure, mirroring the same tag used by
+       [tool_misc_web_fetch] / [tool_misc_web_search] for rate
+       limits. *)
+    Some (Tool_result.error
+            ~failure_class:(Some Tool_result.Transient_error)
+            ~tool_name ~start_time
+            (Printf.sprintf "Rate limited. %d sec remaining." wait_secs))
   else begin
     let message =
       Coord_task_cache_invariant.rewrite_broadcast_content


### PR DESCRIPTION
## Summary

Micro-migration: 2 error sites in `handle_broadcast` gain explicit `~failure_class` arguments instead of relying on the auto-classify path's `Runtime_failure` default.

| Site | Class | Rationale |
|---|---|---|
| `"Broadcast message cannot be empty"` | `Workflow_rejection` | Caller-input violation (mirrors tool_library / tool_misc / tool_misc_admin missing-required-field tags) |
| `"Rate limited. N sec remaining."` | `Transient_error` | Retry after window (mirrors tool_misc_web_fetch / tool_misc_web_search rate-limit tags) |

## Why this PR shape

- **Pure `?failure_class` addition.** `Tool_result.error` signature preserved. No new helper modules, no `to_legacy` cascade, no handler signature change.
- **PR-2 (#18793) compatible.** PR-2 drops `Tool_result.t` but keeps the `error` constructor — this change applies cleanly on either side of the PR-2 merge.
- **Zero supersession risk** vs the parallel RFC-0189 PR-1b.* stream — no caller boundary, no handler signature, no helper introduced.

## Out of scope

- `handle_messages` / `handle_who` success paths — no failure branch to tag.
- Migrating `tool_inline_dispatch_comm` to typed `Tool_result.result` return — that belongs in PR-1c / post-PR-2 work since it would touch `Tool_inline_dispatch_types.tool_result` (cluster-wide alias).

## Verification

- `dune build --root . --cache=disabled lib/` exit 0

## Test plan

- [x] lib build
- [ ] CI green (Draft)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
