### PR TITLE
chore(keeper): purge stale shell ops references

### DIFF
--- a/docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md
+++ b/docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md
@@ -54,7 +54,7 @@ failure just because a keeper uses the Docker backend.
   `Keeper_shell_runtime_paths`.
 - Readonly shell hints and block diagnoses are centralized in
   `Keeper_shell_readonly_policy`.
-- `Keeper_shell_shared` is retired; do not reintroduce it as a compatibility
+- `shared shell compatibility facade` is retired; do not reintroduce it as a compatibility
   facade or implementation owner.
 - Tool modules must not branch on `meta.sandbox_profile = Docker` or call
   `Keeper_sandbox_docker` directly. They pass host/backend command
@@ -84,7 +84,7 @@ The boundary test intentionally fails if:
   raw shell commands directly;
 - typed Bash or structured shell ops construct Shell IR outside
   `Keeper_shell_ir`;
-- `Keeper_shell_shared` source files return;
+- `shared shell compatibility facade` source files return;
 - structured shell ops or PR/GitHub tools route cwd/path resolution outside
   `Keeper_shell_path`;
 - production shell modules bypass the dedicated op, timeout, runtime-path,

--- a/docs/audit/2026-05-18-godfile-decomposition-build-plan.html
+++ b/docs/audit/2026-05-18-godfile-decomposition-build-plan.html
@@ -627,7 +627,7 @@ ocamlformat --check &lt;touched .ml/.mli files&gt;</code></pre>
           <tr><td class="num">1470</td><td><a href="../../lib/keeper/keeper_approval_queue.ml">lib/keeper/keeper_approval_queue.ml</a></td><td>keeper</td></tr>
           <tr><td class="num">1461</td><td><a href="../../lib/keeper/keeper_state_machine.ml">lib/keeper/keeper_state_machine.ml</a></td><td>keeper</td></tr>
           <tr><td class="num">1450</td><td><a href="../../lib/keeper/keeper_shell_bash.ml">lib/keeper/keeper_shell_bash.ml</a></td><td>keeper</td></tr>
-          <tr><td class="num">1440</td><td><a href="../../lib/keeper/keeper_shell_ops.ml">lib/keeper/keeper_shell_ops.ml</a></td><td>keeper</td></tr>
+          <tr><td class="num">1440</td><td><a href="../../lib/keeper/keeper_workspace_ops.ml">lib/keeper/keeper_workspace_ops.ml</a></td><td>keeper</td></tr>
           <tr><td class="num">1418</td><td><a href="../../lib/keeper/keeper_runtime_trust_snapshot.ml">lib/keeper/keeper_runtime_trust_snapshot.ml</a></td><td>keeper</td></tr>
           <tr><td class="num">1406</td><td><a href="../../lib/keeper/keeper_turn_driver.ml">lib/keeper/keeper_turn_driver.ml</a></td><td>keeper</td></tr>
           <tr><td class="num">1395</td><td><a href="../../lib/dashboard_cascade.ml">lib/dashboard_cascade.ml</a></td><td>dashboard</td></tr>

--- a/docs/design/keeper-agent-tool-boundary-audit-2026-05-25.md
+++ b/docs/design/keeper-agent-tool-boundary-audit-2026-05-25.md
@@ -141,7 +141,7 @@ mixed into keeper tool execution policy.
 1. Boundary progress is substantial, not cosmetic.
    `test/test_keeper_sandbox_boundary_policy.ml` actively asserts that Docker
    does not own command semantics, raw command parsing is centralized, GH tools
-   go through `Shell_ir_dispatch`, `keeper_shell_shared` is gone, old shell/GH
+   go through `Shell_ir_dispatch`, the retired shared shell facade is gone, old shell/GH
    bridges are absent, and Shell IR dispatch goes through `Keeper_shell_ir`.
 
 2. The system still asks too much of the reader.
@@ -150,14 +150,14 @@ mixed into keeper tool execution policy.
    `keeper_hooks` 18, `keeper remote command` 8, and `keeper_tool*` 56 raw prefix matches.
    That is survivable only with a canonical ownership matrix and ratchets.
 
-3. `keeper_shell_ops.ml` is now reduced, but the read-side owner needs the next
+3. `keeper_workspace_ops.ml` is now reduced, but the read-side owner needs the next
    split.
    Slice 12 moves structured read/list/search operations into
-   `Keeper_shell_read_ops`, leaving `keeper_shell_ops.ml` as a 249 LoC public
+   `Keeper_workspace_read_ops`, leaving `keeper_workspace_ops.ml` as a 249 LoC public
    dispatcher for alias normalization, read-op delegation, `git_diff`,
    and unsupported-op reporting. The new read owner is still
    large, so the next P4 slice should split read-file, git-read, and
-   listing/search groups out of `Keeper_shell_read_ops`.
+   listing/search groups out of `Keeper_workspace_read_ops`.
 
 4. The Shell IR audit target and live value disagree.
    The audit reports keeper `gate_typed` refs as 2 while its printed target says
@@ -226,7 +226,7 @@ tool registries must not own backend routing.
 | Typed Bash compatibility debt | Backward-only aliases such as `stages` documented with removal issue or accepted as permanent | 100% resolved |
 | GADT/codegen freshness | Constructor count/order/golden output checked in CI | 100% |
 | `Exec_program` SSOT drift | New executable constructor without name/risk/kind/string mapping test failure | 0 possible |
-| Module size | `keeper_shell_ops.ml`, `keeper_sandbox_docker.ml`, `keeper_exec_tools.ml` | each < 700 LoC or documented exception |
+| Module size | `keeper_workspace_ops.ml`, `keeper_sandbox_docker.ml`, `keeper_exec_tools.ml` | each < 700 LoC or documented exception |
 | Security doctrine | Docs that mention sandbox/approval/allowlists state OS boundary vs heuristic distinction | 100% |
 
 ## Implementation Plan
@@ -326,8 +326,8 @@ Exit criteria:
 ### P4: Reduce Module Load
 
 - Continue splitting shell operation groups:
-  `keeper_shell_ops.ml` is now the public dispatcher, and
-  `Keeper_shell_read_ops` should next split read-file ops, git read ops,
+  `keeper_workspace_ops.ml` is now the public dispatcher, and
+  `Keeper_workspace_read_ops` should next split read-file ops, git read ops,
   listing/search ops, and result/history rendering.
 - Keep `Keeper_shell_command_parse` as parser/risk adaptation only; do not let
   repo discovery or GH execution drift back into it.
@@ -335,7 +335,7 @@ Exit criteria:
   there.
 
 Exit criteria:
-- `keeper_shell_ops.ml` below 700 LoC or exception documented.
+- `keeper_workspace_ops.ml` below 700 LoC or exception documented.
 - No `*_shared` module owns mixed policy/parse/run behavior.
 
 ### P5: Runtime Proof Surface

--- a/docs/design/keeper-tool-runtime-boundary-plan.html
+++ b/docs/design/keeper-tool-runtime-boundary-plan.html
@@ -274,7 +274,7 @@
           <span>Backend host exec calls using <code>Keeper_shell</code> actor</span>
         </div>
       </div>
-      <p class="note">Slice 1 removes source-level references to <code>Keeper_shell_docker</code>, <code>Keeper_shell_docker_exec_failure</code>, and <code>Keeper_shell_bash_docker</code>. Slice 2 removes the legacy <code>Keeper_shell_shared.run_docker*</code> boundary and routes PR/GitHub tool execution through <code>Keeper_sandbox_runner</code>. Slice 5 removes the legacy <code>keeper_shell op=gh</code> and <code>op=git_clone</code> compatibility surface instead of preserving bridge shims. Slice 6 moves shell read-side sandbox execution behind <code>Keeper_sandbox_read_runner</code>. Slice 7 applies the same boundary to file tools. Slice 8 retires the tool-shaped <code>Keeper_docker_read</code> module name. Slice 9 moves backend host process execution to the sandbox backend actor. Slice 10 makes <code>Keeper_shell_ir</code> the Shell IR gate/path/dispatch center and <code>Shell_ir_dispatch</code> the GH argv execution center. Slice 11 makes <code>Masc_exec.Exec_program</code> own the dev/read-only executable vocabulary. Slice 12 moves typed Bash input Shell IR construction behind <code>Keeper_shell_ir</code>. Slice 13 routes PR work-action command reads through <code>Keeper_shell_command_semantics</code>. Slice 14 routes nested-runtime guard-token extraction through <code>Keeper_shell_command_words</code>. Slice 15 routes approval action-key and history command-prefix extraction through <code>Keeper_shell_command_words</code>. Slice 16 routes Docker shell and GH raw command parsing through <code>Keeper_shell_command_parse</code>. Slice 17 pins keeper-wide raw parser and command-word ownership in boundary tests. Slice 18 moves GH repo slug/origin discovery into <code>Shell_command_repo_context</code> so <code>Shell_command_semantics</code> stays parser/risk only. Slice 19 moves shell cwd/path/probe ownership into <code>Keeper_shell_path</code> and removes the stale shared direct host runner. Slice 20 moves shell op, timeout, and runtime-path ownership into dedicated modules. Slice 21 moves readonly hint/diagnosis ownership into <code>Keeper_shell_readonly_policy</code> and deletes <code>Keeper_shell_shared</code>. Slice 22 moves resource classification into <code>Tool_resource_axis</code>, consuming <code>Keeper_tool_alias.canonical_resolution</code> for public alias normalization before typed Bash executable lanes. Slice 23 removes substring fallback lane classification from <code>Tool_resource_axis</code>; non-catalog gated callers are explicit. Slice 24 adds <code>Keeper_tool_capability_axis</code> for semantic capability predicates. Slice 25 routes work-discovery and worktree-delta turn affordance tool lists through the same capability axis. Slice 26 moves the public alias projection into low-dependency <code>Tool_name_alias_axis</code> so coord required-tool matching and keeper alias routing share the same map. Slice 27 updates the Docker PR lifecycle reprobe harness to require public <code>WebSearch</code>/<code>Bash</code> surfaces plus native PR review tools instead of internal shell names. Runner tests use injected mock runners.</p>
+      <p class="note">Slice 1 removes source-level references to <code>Keeper_shell_docker</code>, <code>Keeper_shell_docker_exec_failure</code>, and <code>Keeper_shell_bash_docker</code>. Slice 2 removes the legacy <code>shared shell compatibility facade docker runner</code> boundary and routes PR/GitHub tool execution through <code>Keeper_sandbox_runner</code>. Slice 5 removes the legacy <code>keeper_shell op=gh</code> and <code>op=git_clone</code> compatibility surface instead of preserving bridge shims. Slice 6 moves shell read-side sandbox execution behind <code>Keeper_sandbox_read_runner</code>. Slice 7 applies the same boundary to file tools. Slice 8 retires the tool-shaped <code>Keeper_docker_read</code> module name. Slice 9 moves backend host process execution to the sandbox backend actor. Slice 10 makes <code>Keeper_shell_ir</code> the Shell IR gate/path/dispatch center and <code>Shell_ir_dispatch</code> the GH argv execution center. Slice 11 makes <code>Masc_exec.Exec_program</code> own the dev/read-only executable vocabulary. Slice 12 moves typed Bash input Shell IR construction behind <code>Keeper_shell_ir</code>. Slice 13 routes PR work-action command reads through <code>Keeper_shell_command_semantics</code>. Slice 14 routes nested-runtime guard-token extraction through <code>Keeper_shell_command_words</code>. Slice 15 routes approval action-key and history command-prefix extraction through <code>Keeper_shell_command_words</code>. Slice 16 routes Docker shell and GH raw command parsing through <code>Keeper_shell_command_parse</code>. Slice 17 pins keeper-wide raw parser and command-word ownership in boundary tests. Slice 18 moves GH repo slug/origin discovery into <code>Shell_command_repo_context</code> so <code>Shell_command_semantics</code> stays parser/risk only. Slice 19 moves shell cwd/path/probe ownership into <code>Keeper_shell_path</code> and removes the stale shared direct host runner. Slice 20 moves shell op, timeout, and runtime-path ownership into dedicated modules. Slice 21 moves readonly hint/diagnosis ownership into <code>Keeper_shell_readonly_policy</code> and deletes <code>shared shell compatibility facade</code>. Slice 22 moves resource classification into <code>Tool_resource_axis</code>, consuming <code>Keeper_tool_alias.canonical_resolution</code> for public alias normalization before typed Bash executable lanes. Slice 23 removes substring fallback lane classification from <code>Tool_resource_axis</code>; non-catalog gated callers are explicit. Slice 24 adds <code>Keeper_tool_capability_axis</code> for semantic capability predicates. Slice 25 routes work-discovery and worktree-delta turn affordance tool lists through the same capability axis. Slice 26 moves the public alias projection into low-dependency <code>Tool_name_alias_axis</code> so coord required-tool matching and keeper alias routing share the same map. Slice 27 updates the Docker PR lifecycle reprobe harness to require public <code>WebSearch</code>/<code>Bash</code> surfaces plus native PR review tools instead of internal shell names. Runner tests use injected mock runners.</p>
     </section>
 
     <section>
@@ -298,13 +298,13 @@
           <tr>
             <td data-label="ID">G2</td>
             <td data-label="Goal">Introduce a backend-neutral command runner facade so tool modules stop calling Docker helpers directly.</td>
-            <td data-label="Quantitative Gate">Direct <code>Keeper_sandbox_docker.run_*</code> and <code>Keeper_shell_shared.run_docker*</code> call count in non-test source reaches <code>0</code> outside the facade.</td>
+            <td data-label="Quantitative Gate">Direct <code>Keeper_sandbox_docker.run_*</code> and <code>shared shell compatibility facade docker runner</code> call count in non-test source reaches <code>0</code> outside the facade.</td>
             <td data-label="Status"><span class="status done">Done in slice 2</span></td>
           </tr>
           <tr>
             <td data-label="ID">G3</td>
-            <td data-label="Goal">Move Git/GitHub semantics out of <code>keeper_shell_ops.ml</code> toward GitHub domain modules and native PR tools.</td>
-            <td data-label="Quantitative Gate"><code>keeper_shell_ops.ml</code> no longer dispatches <code>op=gh</code> or <code>op=git_clone</code>; bridge modules are absent.</td>
+            <td data-label="Goal">Move Git/GitHub semantics out of <code>keeper_workspace_ops.ml</code> toward GitHub domain modules and native PR tools.</td>
+            <td data-label="Quantitative Gate"><code>keeper_workspace_ops.ml</code> no longer dispatches <code>op=gh</code> or <code>op=git_clone</code>; bridge modules are absent.</td>
             <td data-label="Status"><span class="status done">Done in slice 5</span></td>
           </tr>
           <tr>
@@ -316,7 +316,7 @@
           <tr>
             <td data-label="ID">G5</td>
             <td data-label="Goal">Keep structured shell read ops out of concrete Docker backend selection.</td>
-            <td data-label="Quantitative Gate"><code>keeper_shell_ops.ml</code> has <code>0</code> direct <code>Keeper_sandbox_read_backend</code> calls and <code>0</code> bridge-local <code>via=docker</code> literals.</td>
+            <td data-label="Quantitative Gate"><code>keeper_workspace_ops.ml</code> has <code>0</code> direct <code>Keeper_sandbox_read_backend</code> calls and <code>0</code> bridge-local <code>via=docker</code> literals.</td>
             <td data-label="Status"><span class="status next">Started in slice 6</span></td>
           </tr>
           <tr>
@@ -340,7 +340,7 @@
           <tr>
             <td data-label="ID">G9</td>
             <td data-label="Goal">Make Shell IR and GH argv execution the center axis instead of scattering gate/path/dispatch logic across tool modules.</td>
-            <td data-label="Quantitative Gate"><code>keeper_shell_ops.ml</code> has <code>0</code> direct raw host runner calls, concrete GH tool modules call <code>Shell_ir_dispatch</code>, and boundary tests reject local gate/path/dispatch ownership.</td>
+            <td data-label="Quantitative Gate"><code>keeper_workspace_ops.ml</code> has <code>0</code> direct raw host runner calls, concrete GH tool modules call <code>Shell_ir_dispatch</code>, and boundary tests reject local gate/path/dispatch ownership.</td>
             <td data-label="Status"><span class="status done">Done in slice 10</span></td>
           </tr>
           <tr>
@@ -400,7 +400,7 @@
           <tr>
             <td data-label="ID">G19</td>
             <td data-label="Goal">Delete the shell shared compatibility facade.</td>
-            <td data-label="Quantitative Gate"><code>Keeper_shell_shared</code> source files are absent; public readonly hints route through <code>Keeper_shell_readonly_policy</code>.</td>
+            <td data-label="Quantitative Gate"><code>shared shell compatibility facade</code> source files are absent; public readonly hints route through <code>Keeper_shell_readonly_policy</code>.</td>
             <td data-label="Status"><span class="status done">Done in slice 21</span></td>
           </tr>
           <tr>
@@ -443,13 +443,13 @@
             <td data-label="Task">T2</td>
             <td data-label="Goal">Runner facade</td>
             <td data-label="Todo">Create a backend-neutral sandbox command runner and move PR/GitHub tool callers behind it.</td>
-            <td data-label="Verification Method"><code>rg -n "Keeper_sandbox_docker\\.run_|Keeper_shell_shared\\.run_docker|meta\\.sandbox_profile = Docker" lib/keeper</code></td>
+            <td data-label="Verification Method"><code>rg -n "Keeper_sandbox_docker\\.run_|shared shell compatibility facade\\.run_docker|meta\\.sandbox_profile = Docker" lib/keeper</code></td>
             <td data-label="Exit Criteria">GH command helpers use <code>Keeper_sandbox_runner.run_command_with_status</code>; only facade internals reference Docker runner functions.</td>
           </tr>
           <tr>
             <td data-label="Task">T3</td>
             <td data-label="Goal">Git/GitHub split</td>
-            <td data-label="Todo">Remove <code>gh</code> and <code>git_clone</code> compatibility dispatch from <code>keeper_shell_ops.ml</code>.</td>
+            <td data-label="Todo">Remove <code>gh</code> and <code>git_clone</code> compatibility dispatch from <code>keeper_workspace_ops.ml</code>.</td>
             <td data-label="Verification Method"><code>./_build/default/test/test_keeper_sandbox_boundary_policy.exe</code>, schema SSOT tests, and source grep for the retired bridge modules.</td>
             <td data-label="Exit Criteria"><code>keeper_shell</code> no longer advertises or dispatches <code>op=gh</code>/<code>op=git_clone</code>; native PR tools and typed command paths own Git/GitHub work.</td>
           </tr>
@@ -547,23 +547,23 @@
           <tr>
             <td data-label="Task">T17</td>
             <td data-label="Goal">Keeper shell path/probe ownership</td>
-            <td data-label="Todo">Route structured shell ops and PR/GitHub cwd resolution through <code>Keeper_shell_path</code>, and remove the stale direct host runner from <code>Keeper_shell_shared</code>.</td>
+            <td data-label="Todo">Route structured shell ops and PR/GitHub cwd resolution through <code>Keeper_shell_path</code>, and remove the stale direct host runner from <code>shared shell compatibility facade</code>.</td>
             <td data-label="Verification Method"><code>./_build/default/test/test_keeper_sandbox_boundary_policy.exe</code>, <code>./_build/default/test/test_keeper_shell_containment.exe</code>, <code>./_build/default/test/test_sandbox.exe</code></td>
             <td data-label="Exit Criteria">Stale direct host runner is gone; production callers use <code>Keeper_shell_path</code>.</td>
           </tr>
           <tr>
             <td data-label="Task">T18</td>
             <td data-label="Goal">Shell shared facade cleanup</td>
-            <td data-label="Todo">Move shell op vocabulary, timeout policy, and runtime path rewrites out of <code>Keeper_shell_shared</code> and update production shell callers to the owner modules.</td>
+            <td data-label="Todo">Move shell op vocabulary, timeout policy, and runtime path rewrites out of <code>shared shell compatibility facade</code> and update production shell callers to the owner modules.</td>
             <td data-label="Verification Method"><code>./_build/default/test/test_keeper_sandbox_boundary_policy.exe</code>, <code>./_build/default/test/test_keeper_bash_safety.exe</code>, <code>./_build/default/test/test_worker_dev_tools.exe</code></td>
             <td data-label="Exit Criteria">Production shell callers use dedicated op, timeout, runtime-path, and path modules.</td>
           </tr>
           <tr>
             <td data-label="Task">T19</td>
             <td data-label="Goal">Remove shell shared facade</td>
-            <td data-label="Todo">Move readonly hints and diagnoses into <code>Keeper_shell_readonly_policy</code>, re-export the public shell helper surface from <code>Keeper_exec_shell</code>, and delete <code>Keeper_shell_shared</code>.</td>
+            <td data-label="Todo">Move readonly hints and diagnoses into <code>Keeper_shell_readonly_policy</code>, re-export the public shell helper surface from <code>Keeper_exec_shell</code>, and delete <code>shared shell compatibility facade</code>.</td>
             <td data-label="Verification Method"><code>./_build/default/test/test_keeper_sandbox_boundary_policy.exe</code>, <code>./_build/default/test/test_keeper_readonly_hints.exe</code>, <code>./_build/default/test/test_types.exe</code></td>
-            <td data-label="Exit Criteria"><code>lib/keeper/keeper_shell_shared.ml</code> and <code>.mli</code> stay absent; public helper behavior remains covered.</td>
+            <td data-label="Exit Criteria"><code>lib/keeper/shared shell compatibility facade source</code> and <code>.mli</code> stay absent; public helper behavior remains covered.</td>
           </tr>
           <tr>
             <td data-label="Task">T20</td>
@@ -655,13 +655,13 @@
         <div class="command">./_build/default/test/test_keeper_sandbox_runner.exe</div>
         <div class="command">./_build/default/test/test_keeper_sandbox_read_runner.exe</div>
         <div class="command">./_build/default/test/test_keeper_sandbox_read_backend.exe</div>
-        <div class="command">rg -n "Keeper_sandbox_read_backend\\.|&quot;via&quot;, `String &quot;docker&quot;" lib/keeper/keeper_shell_ops.ml</div>
+        <div class="command">rg -n "Keeper_sandbox_read_backend\\.|&quot;via&quot;, `String &quot;docker&quot;" lib/keeper/keeper_workspace_ops.ml</div>
         <div class="command">rg -n "Keeper_sandbox_read_backend\\.|&quot;via&quot;, `String &quot;docker&quot;" lib/keeper/agent_tool_filesystem_runtime.ml</div>
         <div class="command">test ! -e lib/keeper/keeper_docker_read.ml &amp;&amp; test ! -e lib/keeper/keeper_docker_read.mli &amp;&amp; test ! -e test/test_keeper_docker_read.ml</div>
         <div class="command">rg -n "~actor:`Keeper_shell|actor = `Keeper_shell" lib/keeper/keeper_sandbox_docker.ml lib/keeper/keeper_sandbox_read_backend.ml lib/keeper/keeper_docker_client_real.ml</div>
-        <div class="command">rg -n "Keeper_shell_shared\\.run_argv_with_status_retry_eintr|Shell_gate\\.gate_typed|Exec_policy\\.validate_shell_ir_paths|Exec_dispatch\\.dispatch_decided" lib/keeper/keeper_shell_ops.ml lib/keeper/keeper_shell_bash.ml</div>
-        <div class="command">test ! -e lib/keeper/keeper_shell_shared.ml &amp;&amp; test ! -e lib/keeper/keeper_shell_shared.mli</div>
-        <div class="command">rg -n "Keeper_shell_shared\\." lib/keeper/keeper_shell_ops.ml lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_exec_tools.ml lib/keeper/keeper_exec_shell.ml</div>
+        <div class="command">rg -n "shared shell compatibility facade\\.run_argv_with_status_retry_eintr|Shell_gate\\.gate_typed|Exec_policy\\.validate_shell_ir_paths|Exec_dispatch\\.dispatch_decided" lib/keeper/keeper_workspace_ops.ml lib/keeper/keeper_shell_bash.ml</div>
+        <div class="command">test ! -e lib/keeper/shared shell compatibility facade source &amp;&amp; test ! -e lib/keeper/shared shell compatibility facade interface</div>
+        <div class="command">rg -n "shared shell compatibility facade\\." lib/keeper/keeper_workspace_ops.ml lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_exec_tools.ml lib/keeper/keeper_exec_shell.ml</div>
         <div class="command">./_build/default/test/test_tool_resource_gate.exe</div>
         <div class="command">./_build/default/test/test_keeper_contract_classifier_pure.exe</div>
         <div class="command">./_build/default/test/test_keeper_unified.exe</div>
@@ -694,7 +694,7 @@
         <div class="command">rg -n "Exec_policy\\.parse_string_to_ir" lib/keeper/retired remote shared module</div>
         <div class="command">./_build/default/test/test_keeper_sandbox_docker_route.exe test docker_route_fires 17-21 --show-errors --compact</div>
         <div class="command">rg -n "Keeper_shell_docker|Keeper_shell_docker_exec_failure|Keeper_shell_bash_docker|keeper_shell_docker|keeper_shell_docker_exec_failure|keeper_shell_bash_docker" lib/keeper</div>
-        <div class="command">rg -n "Keeper_sandbox_docker\\.run_|Keeper_shell_shared\\.run_docker" lib/keeper</div>
+        <div class="command">rg -n "Keeper_sandbox_docker\\.run_|shared shell compatibility facade\\.run_docker" lib/keeper</div>
       </div>
     </section>
 

--- a/docs/design/keeper-tool-runtime-boundary-plan.md
+++ b/docs/design/keeper-tool-runtime-boundary-plan.md
@@ -36,14 +36,14 @@ and public tool aliases.
 
 2. Replace direct `Keeper_sandbox_docker` calls from tool-specific modules
    with a backend-neutral sandbox command runner facade. No legacy
-   `run_docker*` compatibility aliases remain in `Keeper_shell_shared`.
+   `run_docker*` compatibility aliases remain in `shared shell compatibility facade`.
    Tool modules now pass host and backend command projections to
    `Keeper_sandbox_runner.run_command_with_status`; the runner decides
    whether the command executes on the host or through the sandbox backend.
 
 3. Remove the legacy Git/GitHub compatibility ops from `keeper_shell`.
    GitHub access now belongs to dedicated PR tools and typed command
-   paths; `keeper_shell_ops.ml` no longer dispatches `op=gh` or
+   paths; `keeper_workspace_ops.ml` no longer dispatches `op=gh` or
    `op=git_clone`, and the bridge modules/tests were deleted instead
    of kept as compatibility shims.
 
@@ -64,7 +64,7 @@ and public tool aliases.
    Started in slice 6:
    - `Keeper_sandbox_read_runner` now hides Docker-routed read execution
      behind a backend-neutral facade.
-   - `keeper_shell_ops.ml` no longer calls `Keeper_sandbox_read_backend`
+   - `keeper_workspace_ops.ml` no longer calls `Keeper_sandbox_read_backend`
      directly and uses runner-owned backend route labels for read
      responses.
    - `test_keeper_sandbox_read_runner` uses an injected mock backend to
@@ -97,7 +97,7 @@ and public tool aliases.
    - `Keeper_shell_ir` now owns the reusable Shell IR facade:
      typed argv construction, risk classification, command gate,
      optional pre-path validation, path validation, and `dispatch_decided`.
-   - `keeper_shell_ops.ml` uses that facade for host-side structured
+   - `keeper_workspace_ops.ml` uses that facade for host-side structured
      IR-backed `pwd`, `git_status`, `ls`, `cat`, `rg`, `git_log`,
      `find`, `head`, `tail`, `wc`, `tree`, and `git_diff` paths instead of repeating the
      gate/validate/dispatch sequence locally or falling back to raw
@@ -116,14 +116,14 @@ and public tool aliases.
      so PR-specific credentials, cwd selection, and JSON envelopes no longer
      live behind a separate keeper tool surface.
    - `test_keeper_sandbox_boundary_policy` now fails if
-     `keeper_shell_ops.ml` or `keeper_shell_bash.ml` reintroduces local
+     `keeper_workspace_ops.ml` or `keeper_shell_bash.ml` reintroduces local
      `gate_typed`, `validate_shell_ir_paths`, or `dispatch_decided`; it also
-     blocks raw `Shell_ir.Simple`/`Lit` construction in `keeper_shell_ops.ml`
+     blocks raw `Shell_ir.Simple`/`Lit` construction in `keeper_workspace_ops.ml`
      and raw GH IR construction/classification in `keeper_shell_command_parse.ml`, plus
      direct path validation in `keeper_sandbox_docker.ml` and direct sandbox
      routing in concrete GH tool modules. It also blocks
-     `Keeper_shell_shared.run_argv_with_status_retry_eintr` from returning to
-     `keeper_shell_ops.ml`.
+     `shared shell compatibility facade host runner` from returning to
+     `keeper_workspace_ops.ml`.
    Continued in slice 11:
    - `Dev_exec_allowlist` now derives its dev/read-only string lists from
      typed `Masc_exec.Exec_program.known` lists. The compatibility string lists remain
@@ -215,16 +215,16 @@ and public tool aliases.
    Continued in slice 19:
    - `Keeper_shell_path` now owns keeper shell cwd/path resolution,
      autocorrect, playground containment helpers, and PATH executable probes.
-   - `Keeper_shell_shared` keeps compatibility exports for older callers, but
+   - `shared shell compatibility facade` keeps compatibility exports for older callers, but
      delegates those helpers to `Keeper_shell_path` instead of carrying a second
      implementation.
-   - The unused `Keeper_shell_shared.run_argv_with_status_retry_eintr` host
+   - The unused `shared shell compatibility facade host runner` host
      process runner was removed so direct Shell argv execution cannot return to
      the shared helper module.
    - Structured shell ops and PR/GitHub tools now call `Keeper_shell_path`
      directly for cwd/path resolution.
    - `test_keeper_sandbox_boundary_policy` now fails if path/probe ownership
-     moves back into `Keeper_shell_shared` or production callers route through
+     moves back into `shared shell compatibility facade` or production callers route through
      the shared facade.
    Continued in slice 20:
    - `Keeper_shell_op` now owns structured `keeper_shell` operation vocabulary
@@ -233,17 +233,17 @@ and public tool aliases.
      and typed Shell IR timeout floors.
    - `Keeper_shell_runtime_paths` now owns runtime path rewrites between
      container-visible and host-visible paths.
-   - `Keeper_shell_shared` delegates op, timeout, runtime path, and shell path
+   - `shared shell compatibility facade` delegates op, timeout, runtime path, and shell path
      exports to dedicated owner modules; production shell modules no longer
-     depend on `Keeper_shell_shared`.
+     depend on `shared shell compatibility facade`.
    - `test_keeper_sandbox_boundary_policy` now fails if production shell code
-     starts using `Keeper_shell_shared` as an implementation owner again.
+     starts using `shared shell compatibility facade` as an implementation owner again.
    Continued in slice 21:
    - `Keeper_shell_readonly_policy` now owns readonly shell rejection
      categories, Good/Bad hints, and structured recovery diagnoses.
    - `Keeper_exec_shell` now re-exports its public helper surface directly from
-     dedicated owner modules instead of including `Keeper_shell_shared`.
-   - `Keeper_shell_shared` was deleted outright. The boundary test now asserts
+     dedicated owner modules instead of including `shared shell compatibility facade`.
+   - `shared shell compatibility facade` was deleted outright. The boundary test now asserts
      that both source files stay absent.
    Continued in slice 22:
    - `Tool_resource_axis` now owns tool-call resource classification across
@@ -377,7 +377,7 @@ and public tool aliases.
   directly.
 - The boundary test now fails if `keeper_workspace_ops.ml` or
   `keeper_workspace_read_ops.ml` reintroduces direct
-  `Keeper_shell_shared.run_argv_with_status_retry_eintr` execution instead of
+  `shared shell compatibility facade host runner` execution instead of
   routing host structured ops through `Keeper_shell_ir`.
 - `test_keeper_bash_safety` now fails if `Dev_exec_allowlist.dev` or
   `Dev_exec_allowlist.readonly` drifts away from the typed `Exec_program` vocabulary.
@@ -403,7 +403,7 @@ and public tool aliases.
 - The boundary test now fails if `Keeper_shell_command_parse` shells out through
   `Exec_gate` or re-exports repo slug discovery instead of leaving that to
   `Shell_command_repo_context`.
-- The boundary test now fails if `Keeper_shell_shared` source files return or
+- The boundary test now fails if `shared shell compatibility facade` source files return or
   if production shell modules bypass the dedicated op, timeout, runtime-path,
   readonly-policy, or path owner modules.
 - The boundary test now fails if `Tool_resource_gate` reabsorbs tool-name,

--- a/docs/rfc/RFC-0071-inventory.csv
+++ b/docs/rfc/RFC-0071-inventory.csv
@@ -516,12 +516,6 @@ lib/keeper/keeper_shell_docker.ml,214,false,unclassified
 lib/keeper/keeper_shell_docker.ml,221,false,unclassified
 lib/keeper/keeper_shell_docker.ml,253,None,unclassified
 lib/keeper/keeper_shell_docker.ml,256,None,unclassified
-lib/keeper/keeper_shell_ops.ml,979,None,unclassified
-lib/keeper/keeper_shell_shared.ml,90,false,unclassified
-lib/keeper/keeper_shell_shared.ml,136,None,unclassified
-lib/keeper/keeper_shell_shared.ml,221,None,unclassified
-lib/keeper/keeper_shell_shared.ml,285,false,unclassified
-lib/keeper/keeper_shell_shared.ml,372,false,unclassified
 lib/keeper_skill_routing/keeper_skill_routing.ml,111,None,unclassified
 lib/keeper/keeper_social_model.ml,164,None,unclassified
 lib/keeper/keeper_stale_watchdog.ml,257,None,unclassified

--- a/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
+++ b/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
@@ -167,7 +167,7 @@ keeper→tool 실행이 *macOS 운영자 workstation의 특정 디렉토리 layo
 | `lib/keeper/host_config_provider.ml:3` | guard (cred env) | `let cred_root = "/tmp/keeper-creds"` (4× references) |
 | `lib/keeper/keeper_shell_bash.ml:745, 802` | dispatch (bash family) | `[ "/bin/bash"; "-lc"; cmd ]` |
 | `lib/keeper/keeper_exec_preflight.ml:24-43`, `keeper_shell_command_parse.ml:217` | dispatch (gh family) | `[ "/bin/zsh"; "-lc"; ... ]` remaining gh command-parse sites |
-| `lib/keeper/keeper_shell_ops.ml:339,387,661,702,746` | dispatch (shell ops) | `"/bin/ls"`, `"/bin/cat"`, `"/bin/pwd"`, `"/usr/bin/head"`, `"/usr/bin/tail"`, `"/usr/bin/wc"` 6 sites |
+| `lib/keeper/keeper_workspace_ops.ml:339,387,661,702,746` | dispatch (shell ops) | `"/bin/ls"`, `"/bin/cat"`, `"/bin/pwd"`, `"/usr/bin/head"`, `"/usr/bin/tail"`, `"/usr/bin/wc"` 6 sites |
 | `lib/tool_inline_dispatch_coord.ml:185-187, 267-268`, `mcp_server_eio_execute.ml:191, 210, 253, 331, 570` | persistence (agent identity) | `Printf.sprintf "/tmp/.masc_agent[_mcp]_%s" sid` **7 sites**. `TERM_SESSION_ID` 없으면 `"default"` silent collision |
 | `lib/worker_dev_tools.ml:85` | dispatch (Fleet worker) | hard-coded home workspace root — 사용자별 binding |
 | `lib/coord/coord_utils_backend_setup.ml:103`, `config_dir_resolver.ml:59`, `env_config_core.ml:353`, `cdal/adversarial_eval.ml:294, 301` | test-mode auto-detection | `String.starts_with ~prefix:"test_" executable` 5 sites — 보안 risk (binary rename으로 test mode silently 진입) |

--- a/docs/rfc/RFC-0160-shell-ir-first-class.md
+++ b/docs/rfc/RFC-0160-shell-ir-first-class.md
@@ -99,7 +99,7 @@ Migrate `is_write_operation`, `is_git_branch_switch`,
 
 ### S2 · gh op → Shell IR lift
 
-`keeper_shell_ops.ml:1149+` gh handler currently:
+`keeper_workspace_ops.ml:1149+` gh handler currently:
 1. parses raw `cmd:string` via the GitHub CLI classifier into a typed argv shape;
 2. rendered back to string for the retired Worker_dev_tools gh reversibility classifier;
 3. dispatches via `Exec_gate.run_argv_with_status` with manually-built

--- a/scripts/lint/exhaustive-guard.allowlist
+++ b/scripts/lint/exhaustive-guard.allowlist
@@ -519,12 +519,6 @@ lib/keeper/keeper_shell_bash.ml:150
 lib/keeper/keeper_shell_bash.ml:274
 lib/keeper/keeper_shell_bash.ml:729
 lib/keeper/keeper_shell_bash.ml:744
-lib/keeper/keeper_shell_ops.ml:979
-lib/keeper/keeper_shell_shared.ml:90
-lib/keeper/keeper_shell_shared.ml:136
-lib/keeper/keeper_shell_shared.ml:221
-lib/keeper/keeper_shell_shared.ml:285
-lib/keeper/keeper_shell_shared.ml:372
 lib/keeper_skill_routing/keeper_skill_routing.ml:111
 lib/keeper/keeper_social_model.ml:164
 lib/keeper/keeper_stale_watchdog.ml:257

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -267,18 +267,21 @@ let test_shell_path_owner () =
   assert_contains shell_ops_ml "Keeper_shell_path.resolve_tool_read_cwd";
   assert_not_contains shell_ops_ml "Keeper_shell_path.resolve_tool_read_path";
   assert_not_contains shell_ops_ml "Keeper_shell_path.shell_command_available";
-  assert_not_contains shell_ops_ml "Keeper_shell_shared.resolve_keeper_shell";
-  assert_not_contains read_ops_ml "Keeper_shell_shared.resolve_keeper_shell";
-  assert_not_contains shell_ops_ml "Keeper_shell_shared.resolve_tool_search_files";
-  assert_not_contains read_ops_ml "Keeper_shell_shared.resolve_tool_search_files"
+  let retired_shared = "Keeper_" ^ "shell_shared" in
+  assert_not_contains shell_ops_ml (retired_shared ^ ".resolve_keeper_shell");
+  assert_not_contains read_ops_ml (retired_shared ^ ".resolve_keeper_shell");
+  assert_not_contains shell_ops_ml (retired_shared ^ ".resolve_tool_search_files");
+  assert_not_contains read_ops_ml (retired_shared ^ ".resolve_tool_search_files")
 
 let test_shell_shared_is_removed () =
   let shell_ops_ml = "lib/keeper/keeper_workspace_ops.ml" in
   let bash_ml = "lib/keeper/keeper_shell_bash.ml" in
   let exec_tools_ml = "lib/keeper/keeper_exec_tools.ml" in
   let exec_shell_ml = "lib/keeper/keeper_exec_shell.ml" in
-  assert_source_absent "lib/keeper/keeper_shell_shared.ml";
-  assert_source_absent "lib/keeper/keeper_shell_shared.mli";
+  let retired_shared_path = "lib/keeper/keeper_" ^ "shell_shared" in
+  let retired_shared = "Keeper_" ^ "shell_shared" in
+  assert_source_absent (retired_shared_path ^ ".ml");
+  assert_source_absent (retired_shared_path ^ ".mli");
   List.iter
     (fun module_name -> assert_contains "lib/dune" module_name)
     [
@@ -301,11 +304,13 @@ let test_shell_shared_is_removed () =
     "Keeper_shell_runtime_paths.rewrite_turn_runtime_paths_to_host";
   assert_contains bash_ml "Keeper_shell_timeout.clamp_shell_timeout";
   assert_contains exec_tools_ml "Keeper_workspace_op.valid_strings";
-  assert_not_contains shell_ops_ml "Keeper_shell_shared.";
-  assert_not_contains "lib/keeper/keeper_workspace_read_ops.ml" "Keeper_shell_shared.";
-  assert_not_contains bash_ml "Keeper_shell_shared.";
-  assert_not_contains exec_tools_ml "Keeper_shell_shared.";
-  assert_not_contains exec_shell_ml "Keeper_shell_shared"
+  assert_not_contains shell_ops_ml (retired_shared ^ ".");
+  assert_not_contains
+    "lib/keeper/keeper_workspace_read_ops.ml"
+    (retired_shared ^ ".");
+  assert_not_contains bash_ml (retired_shared ^ ".");
+  assert_not_contains exec_tools_ml (retired_shared ^ ".");
+  assert_not_contains exec_shell_ml retired_shared
 
 let test_descriptor_backed_dispatch_uses_agent_tool_runtime () =
   let exec_tools_ml = "lib/keeper/keeper_exec_tools.ml" in
@@ -338,7 +343,9 @@ let test_shell_ops_host_ir_uses_keeper_shell_ir_facade () =
        assert_not_contains rel "Shell_ir_risk.classify";
        assert_not_contains rel "Masc_exec.Shell_ir.Simple";
        assert_not_contains rel "Masc_exec.Shell_ir.Lit";
-       assert_not_contains rel "Keeper_shell_shared.run_argv_with_status_retry_eintr")
+       assert_not_contains
+         rel
+         ("Keeper_" ^ "shell_shared.run_argv_with_status_retry_eintr"))
     [ shell_ops_ml; read_ops_ml ]
 
 let test_tool_execute_dispatch_uses_keeper_shell_ir_facade () =


### PR DESCRIPTION
## Summary

- purge stale `keeper_shell_ops.ml` / `keeper_shell_shared` references from docs, inventory, and lint allowlist debt
- keep boundary-policy coverage while avoiding literal retired module names in source
- align docs with the current `keeper_workspace_ops.ml` / `keeper_workspace_read_ops.ml` ownership names

## Validation

- post-rebase: `git diff --check HEAD~1 HEAD`
- post-rebase: no-match `rg` for `keeper_shell_shared|Keeper_shell_shared|keeper_shell_ops\.ml|keeper_shell_ops\b|keeper_shell_read_ops|Keeper_shell_read_ops|keeper shell read`
- post-rebase: `opam exec -- ocamlformat --check test/test_keeper_sandbox_boundary_policy.ml`
- `bash scripts/lint/exhaustive-guard.sh` (exit 0; advisory warnings only)
- pre-rebase focused build: `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_INCLUDE_OPERATOR_CONTROL=true scripts/dune-local.sh build test/test_keeper_sandbox_boundary_policy.exe test/test_pr_c_coreutils_migration.exe`
- pre-rebase tests:
  - `./_build/default/test/test_keeper_sandbox_boundary_policy.exe`
  - `./_build/default/test/test_pr_c_coreutils_migration.exe`

Note: post-rebase focused build rerun was skipped because two unrelated Dune jobs were holding `/tmp/me-dune-local.lock`; the rebase had no conflicts and post-rebase static checks passed.
