### PR TITLE
refactor(tool-dispatch): drop capability set APIs

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -757,9 +757,15 @@
           </tr>
           <tr>
             <td><code>Tool_dispatch.is_*</code> runtime capability gates</td>
-            <td><span class="status now">draft PR #18809</span></td>
+            <td><span class="status done">merged #18809</span></td>
             <td>Move MCP annotations/icons, execution admission, bridge classification, eval gates, worker gates, and keeper policy helpers from mutable <code>Tool_dispatch.is_*</code> readers to catalog-backed <code>Tool_capability.has</code>.</td>
-            <td>The <code>lib/</code> backstop grep is clean for direct <code>Tool_dispatch.is_*</code> readers. <code>Tool_dispatch.init_*_set</code> remains only as the compatibility/bootstrap surface for the next deletion slice.</td>
+            <td>Merged as <code>53c54fa05</code>. The <code>lib/</code> backstop grep is clean for direct runtime <code>Tool_dispatch.is_*</code> readers.</td>
+          </tr>
+          <tr>
+            <td><code>Tool_dispatch.init_*_set</code> capability API</td>
+            <td><span class="status now">draft PR #18815</span></td>
+            <td>Delete the old mutable capability tables plus <code>init_*_set</code> / <code>is_*</code> APIs from <code>Tool_dispatch</code>. <code>Tool_spec.register</code> now writes capability truth only to <code>Tool_catalog</code>.</td>
+            <td>The <code>lib/</code> and test backstop greps are clean for direct <code>Tool_dispatch.is_*</code> and <code>Tool_dispatch.init_*_set</code> usage. Dispatch now owns routing only; capability truth is catalog-backed.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
@@ -795,10 +801,10 @@
         <tbody>
           <tr>
             <td>1</td>
-            <td><code>Tool_dispatch.init_*_set</code> compatibility API and tests</td>
-            <td>Mutable capability sets are no longer runtime authority after the active branch, but registration/bootstrap code and tests still teach the old mental model.</td>
-            <td>Move remaining dynamic registration expectations into <code>Tool_catalog.register_metadata</code> / <code>Tool_spec.register</code> metadata assertions, then delete the set tables and <code>init_*_set</code> APIs.</td>
-            <td>Remove tests that populate <code>Tool_dispatch.init_*_set</code> solely to preserve old capability authority; keep only dispatch-registration tests that are actually about handler routing.</td>
+            <td>Post-#18815 capability contract sweep</td>
+            <td>After dispatch capability sets are removed, any remaining capability tests should assert <code>Tool_catalog</code> / <code>Tool_capability</code> directly instead of routing through dispatch terminology.</td>
+            <td>Audit stale docs/test names for <code>read_only_set</code>, <code>requires_join_set</code>, and other retired dispatch-capability vocabulary; keep dispatch tests only about routing, hooks, tokens, schemas, and handlers.</td>
+            <td>Use grep backstops plus focused metadata/capability tests; delete redundant compatibility-only tests rather than preserving old mental models.</td>
           </tr>
         </tbody>
       </table>

--- a/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
+++ b/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
@@ -279,8 +279,8 @@ val gate : required:t list -> granted:Set.t -> [`Pass | `Reject of string]
 
 Current implementation: [Tool_capability.kind] is the closed capability
 alphabet, and [Tool_capability.has] reads [Tool_catalog.metadata]. The older
-[Tool_dispatch] capability sets remain only for bootstrap/test compatibility,
-not as runtime capability authority.
+[Tool_dispatch] capability sets have been removed; [Tool_dispatch] owns routing,
+not capability authority.
 
 ### §3.3 `Dispatch_outcome.t` (PR-10)
 

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -76,52 +76,6 @@ type mcp_session_record = Mcp_server_eio_governance.mcp_session_record =
 let mcp_session_to_json = Mcp_server_eio_governance.mcp_session_to_json
 let mcp_session_of_json = Mcp_server_eio_governance.mcp_session_of_json
 
-(** {1 Tool Lists — inline sub-library tools plus keeper read-only fallback}
-
-    Most tools register read_only/requires_join via Tool_spec.register
-    in their own modules. These lists cover only tools from
-    Tool_schemas_inline (lib/tool_schemas/ sub-library) which cannot
-    depend on Tool_spec, plus keeper read-only tools declared via
-    Tool_shard schemas. *)
-
-let read_only_tools_inline =
-  List.map Tool_name.Masc.to_string Tool_name.Masc.[ Status; Who; Messages ]
-;;
-
-let requires_join_tools_inline =
-  List.map Tool_name.Masc.to_string Tool_name.Masc.[ Broadcast; Leave ]
-;;
-
-let mcp_context_required_tools_inline =
-  Tool_schemas_inline.schemas
-  |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
-  |> List.filter (fun name -> not (Keeper_tool_policy.is_keeper_safe_inline_tool name))
-;;
-
-let () =
-  (* [Keeper_exec_tools.keeper_read_only_tools] is the keeper SSOT.
-     Server bootstrap mirrors that list into Tool_dispatch so protocol
-     annotations and non-keeper callers see the same read-only metadata. *)
-  Tool_dispatch.init_read_only_set
-    (read_only_tools_inline @ Keeper_exec_tools.keeper_read_only_tools)
-;;
-
-let () = Tool_dispatch.init_requires_join_set requires_join_tools_inline
-let () = Tool_dispatch.init_mcp_context_required_set mcp_context_required_tools_inline
-
-(* Tools whose arguments contain executable commands subject to
-   destructive pattern scanning (eval_gate step 6).
-   Covers: keeper tools (eval_gate), OAS hooks (keeper_hooks_oas),
-   and worker tools (worker_oas). *)
-let () =
-  Tool_dispatch.init_destructive_set
-    [ "tool_execute"
-    ; "tool_edit_file"
-    ; "tool_write_file"
-    ; "shell_exec"
-    ]
-;;
-
 (* Tag registry initialization.
    Most modules register via Tool_spec.register at module load time.
    Only Tool_schemas_inline (sub-library) and Board remain here. *)

--- a/lib/tool_capability.mli
+++ b/lib/tool_capability.mli
@@ -2,8 +2,8 @@
 
     The closed-sum [kind] and [Set]-based granted/required model reads
     capability truth from [Tool_catalog.metadata]. [Tool_dispatch]'s
-    mutable capability sets remain only for bootstrap/test compatibility;
-    they are no longer runtime capability authority.
+    mutable capability sets have been removed; dispatch owns routing,
+    not capability authority.
 
     The module is named [Tool_capability] (not [Capability]) because
     [lib/exec/capability.ml] already owns the [Capability] name for the

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -239,41 +239,6 @@ let registered_count () = Hashtbl.length registry
 (** Check whether a tool name is registered. *)
 let is_registered name = Hashtbl.mem registry name
 
-(** --- Hashtbl sets for dispatch capability checks --- *)
-
-let read_only_set : (string, unit) Hashtbl.t = Hashtbl.create 32
-let requires_join_set : (string, unit) Hashtbl.t = Hashtbl.create 64
-let mcp_context_required_set : (string, unit) Hashtbl.t = Hashtbl.create 64
-let destructive_set : (string, unit) Hashtbl.t = Hashtbl.create 16
-let idempotent_set : (string, unit) Hashtbl.t = Hashtbl.create 32
-
-let init_read_only_set (names : string list) =
-  with_dispatch_rw (fun () ->
-    List.iter (fun name -> Hashtbl.replace read_only_set name ()) names)
-
-let init_requires_join_set (names : string list) =
-  with_dispatch_rw (fun () ->
-    List.iter (fun name -> Hashtbl.replace requires_join_set name ()) names)
-
-let init_mcp_context_required_set (names : string list) =
-  with_dispatch_rw (fun () ->
-    List.iter (fun name -> Hashtbl.replace mcp_context_required_set name ()) names)
-
-let init_destructive_set (names : string list) =
-  with_dispatch_rw (fun () ->
-    List.iter (fun name -> Hashtbl.replace destructive_set name ()) names)
-
-let init_idempotent_set (names : string list) =
-  with_dispatch_rw (fun () ->
-    List.iter (fun name -> Hashtbl.replace idempotent_set name ()) names)
-
-let is_read_only name = with_dispatch_ro (fun () -> Hashtbl.mem read_only_set name)
-let is_join_required name = with_dispatch_ro (fun () -> Hashtbl.mem requires_join_set name)
-let is_mcp_context_required name =
-  with_dispatch_ro (fun () -> Hashtbl.mem mcp_context_required_set name)
-let is_destructive name = with_dispatch_ro (fun () -> Hashtbl.mem destructive_set name)
-let is_idempotent name = with_dispatch_ro (fun () -> Hashtbl.mem idempotent_set name)
-
 (** {2 Module Tag Dispatch}
 
     Known tool names map to module tags through a compile-time match.

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -148,19 +148,6 @@ val registered_count : unit -> int
 val is_registered : string -> bool
 (** Check whether a tool name is registered. *)
 
-(** {1 Read-only and Join-required Sets} *)
-
-val init_read_only_set : string list -> unit
-val init_requires_join_set : string list -> unit
-val init_mcp_context_required_set : string list -> unit
-val init_destructive_set : string list -> unit
-val init_idempotent_set : string list -> unit
-val is_read_only : string -> bool
-val is_join_required : string -> bool
-val is_mcp_context_required : string -> bool
-val is_destructive : string -> bool
-val is_idempotent : string -> bool
-
 (** {2 Module Tag Dispatch}
 
     Known tool names map to module tags through a compile-time match.

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -344,8 +344,8 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.t option =
 (* ================================================================ *)
 
 (* Migrates the inline-dispatched coord + approval tools from the legacy
-   register_module_tag + init_*_set bootstrap (mcp_server_eio.ml) to the
-   Tool_spec single-call SSOT. Scope: 6 of 10 §3.2 live tools.
+   register_module_tag bootstrap (mcp_server_eio.ml) to the Tool_spec
+   single-call SSOT. Scope: 6 of 10 §3.2 live tools.
 
    Excluded (deferred, semantic-widening would be required):
    - [masc_approval_resolve], [masc_set_param], [channel_gate] —

--- a/lib/tool_schemas/tool_schemas_inline.ml
+++ b/lib/tool_schemas/tool_schemas_inline.ml
@@ -3,12 +3,10 @@
 
 (* RFC-0057 PR-2d: inline_coord tools (masc_start/join/leave/broadcast/
    messages/who) moved to Tool_descriptors_gen. They flow through
-   Tool_schemas_misc.schemas, but downstream consumers
-   (Tool_dispatch.mcp_context_required_set,
-    Keeper_tool_policy.is_keeper_mcp_context_required) identify
-   inline-dispatched tools by membership in this list — so we
-   re-include them here by filtering Tool_schemas_misc.schemas to the
-   six inline_coord names. *)
+   Tool_schemas_misc.schemas, but downstream consumers still identify
+   inline-dispatched tools by membership in this list — so we re-include
+   them here by filtering Tool_schemas_misc.schemas to the six inline_coord
+   names. *)
 let inline_coord_codegen_names =
   [ "masc_start"
   ; "masc_join"

--- a/lib/tool_schemas/tool_schemas_inline_infra.ml
+++ b/lib/tool_schemas/tool_schemas_inline_infra.ml
@@ -14,11 +14,9 @@ let mcp_session_action_enum_strings =
    to [mcp_session_action_enum_strings] above by the SSOT regression
    test; codegen needs a shared enum source RFC before it can swap.
 
-   The three codegen-emitted tools are re-included in this list so
-   downstream consumers (Tool_dispatch.mcp_context_required_set,
-   Keeper_tool_policy.is_keeper_mcp_context_required) that read
-   Tool_schemas_inline.schemas continue to see all inline_infra
-   tools. *)
+   The three codegen-emitted tools are re-included in this list so downstream
+   consumers that read Tool_schemas_inline.schemas continue to see all
+   inline_infra tools. *)
 let codegen_inline_infra_names =
   [ "masc_approval_pending"; "masc_approval_get" ]
 

--- a/lib/tool_spec.ml
+++ b/lib/tool_spec.ml
@@ -110,20 +110,7 @@ let register (spec : t) =
   (* 1. Tag + schema registry *)
   Tool_dispatch.register_module_tag
     ~schemas:[ to_tool_schema spec ] ~tag:spec.module_tag;
-  (* 2. Read-only set *)
-  if spec.is_read_only then
-    Tool_dispatch.init_read_only_set [ spec.name ];
-  (* 3. Requires-join set *)
-  if spec.requires_join then
-    Tool_dispatch.init_requires_join_set [ spec.name ];
-  if spec.mcp_context_required then
-    Tool_dispatch.init_mcp_context_required_set [ spec.name ];
-  (* Add destructive and idempotent sets *)
-  if spec.is_destructive then
-    Tool_dispatch.init_destructive_set [ spec.name ];
-  if spec.is_idempotent then
-    Tool_dispatch.init_idempotent_set [ spec.name ];
-  (* 4. Catalog metadata — enforce Hidden for System_internal tools *)
+  (* 2. Catalog metadata — enforce Hidden for System_internal tools *)
   let is_system_internal =
     Tool_catalog_surfaces.is_on_surface System_internal spec.name
   in
@@ -167,7 +154,7 @@ let register (spec : t) =
       required_permission;
       effect_domain = spec.effect_domain;
       requires_actor_binding };
-  (* 5. Handler binding — auto-register Direct/Shared into Tool_dispatch *)
+  (* 3. Handler binding — auto-register Direct/Shared into Tool_dispatch *)
   (match spec.handler_binding with
    | Direct h | Shared h ->
      Tool_dispatch.register ~tool_name:spec.name ~handler:h;

--- a/lib/tool_spec.mli
+++ b/lib/tool_spec.mli
@@ -86,9 +86,6 @@ val create :
 val register : t -> unit
 (** Register a tool spec into all dispatch subsystems atomically:
     - [Tool_dispatch.register_module_tag] (tag + schema)
-    - [Tool_dispatch.init_read_only_set] (if [is_read_only])
-    - [Tool_dispatch.init_requires_join_set] (if [requires_join])
-    - [Tool_dispatch.init_mcp_context_required_set] (if [mcp_context_required])
     - [Tool_catalog.register_metadata] (visibility and semantic flags)
 
     @raise Invalid_argument if [name] is empty. *)

--- a/test/test_eval_gate.ml
+++ b/test/test_eval_gate.ml
@@ -21,10 +21,6 @@ let make_acc dir =
 
 let default_config = Eval_gate.default_config
 
-(* Ensure destructive set is populated for tests that use
-   Tool_dispatch.is_destructive (populated by mcp_server_eio.ml in production). *)
-let () = Tool_dispatch.init_destructive_set ["tool_execute"; "tool_edit_file"]
-
 (* ================================================================ *)
 (* Test: detect_destructive                                          *)
 (* ================================================================ *)

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -298,10 +298,14 @@ let test_extract_non_string_command () =
 (* ================================================================ *)
 
 let test_destructive_check_tools_membership () =
-  check bool "tool_execute is destructive" true (Tool_dispatch.is_destructive "tool_execute");
-  check bool "tool_edit_file is destructive" true (Tool_dispatch.is_destructive "tool_edit_file");
-  check bool "tool_read_file not destructive" false (Tool_dispatch.is_destructive "tool_read_file");
-  check bool "keeper_board_post not destructive" false (Tool_dispatch.is_destructive "keeper_board_post")
+  check bool "tool_execute is destructive" true
+    (Tool_capability.has Tool_capability.Destructive "tool_execute");
+  check bool "tool_edit_file is destructive" true
+    (Tool_capability.has Tool_capability.Destructive "tool_edit_file");
+  check bool "tool_read_file not destructive" false
+    (Tool_capability.has Tool_capability.Destructive "tool_read_file");
+  check bool "keeper_board_post not destructive" false
+    (Tool_capability.has Tool_capability.Destructive "keeper_board_post")
 
 (* ================================================================ *)
 (* Group 5: Integration — extract + detect combined                  *)

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -152,8 +152,7 @@ let test_has_valid_tool_call_false_when_empty () =
 
 (* Use real canonical tool names. Passive_status tools must have
    Tool_catalog.effect_domain = Some Read_only so classify_tool_progress
-   classifies them correctly even when Tool_dispatch.read_only_set is
-   uninitialised (test environment). *)
+   classifies them correctly without dispatch-owned capability sets. *)
 
 let passive_tool = "keeper_tasks_list"
 let passive_tool_alt = "keeper_context_status"

--- a/test/test_mcp_server_eio_tool_profile_capability.ml
+++ b/test/test_mcp_server_eio_tool_profile_capability.ml
@@ -23,13 +23,12 @@ let bool_annotation name tool_name =
   | None -> failf "annotation %s missing for %s" name tool_name
 ;;
 
-let test_annotations_ignore_dispatch_only_read_only () =
-  let name = "__profile_dispatch_only_ro" in
-  Masc_mcp.Tool_dispatch.init_read_only_set [ name ];
-  check bool "dispatch-only readOnlyHint ignored" false (bool_annotation "readOnlyHint" name);
+let test_annotations_do_not_invent_read_only () =
+  let name = "__profile_unknown_tool" in
+  check bool "unknown readOnlyHint false" false (bool_annotation "readOnlyHint" name);
   check
     (option string)
-    "dispatch-only openWorldHint absent"
+    "unknown openWorldHint absent"
     None
     (Option.map Yojson.Safe.to_string (annotation_field "openWorldHint" name))
 ;;
@@ -62,9 +61,9 @@ let () =
     "mcp-server-eio-tool-profile-capability"
     [ ( "annotations"
       , [ test_case
-            "ignore-dispatch-only-read-only"
+            "do-not-invent-read-only"
             `Quick
-            test_annotations_ignore_dispatch_only_read_only
+            test_annotations_do_not_invent_read_only
         ; test_case
             "use-catalog-capabilities"
             `Quick

--- a/test/test_tool_capability_typed.ml
+++ b/test/test_tool_capability_typed.ml
@@ -6,7 +6,7 @@ open Alcotest
     - All 5 [kind] variants round-trip through [to_string] / [of_string]
     - [all_kinds] enumerates exactly 5 variants
     - [Set.diff] semantics for [check]
-    - [has] reads [Tool_catalog] metadata, not legacy [Tool_dispatch] sets
+    - [has] reads [Tool_catalog] metadata
     - [granted] of an unknown tool returns the empty set
     - [check ~required:empty ~granted:empty] returns [Ok ()]
     - [check] with disjoint required + granted returns [Error required] *)
@@ -43,14 +43,6 @@ let test_has_unknown_tool_returns_false () =
     "has Read_only on an unregistered tool name returns false"
     false
     (Masc_mcp.Tool_capability.has Read_only "__nonexistent_tool__")
-;;
-
-let test_has_ignores_legacy_dispatch_set () =
-  Masc_mcp.Tool_dispatch.init_read_only_set [ "__cap_dispatch_only_ro" ];
-  (check bool)
-    "dispatch-only read-only set no longer grants Tool_capability"
-    false
-    (Masc_mcp.Tool_capability.has Read_only "__cap_dispatch_only_ro")
 ;;
 
 let test_has_catalog_metadata () =
@@ -144,7 +136,6 @@ let () =
         ; test_case "all-kinds-cardinality" `Quick test_all_kinds_cardinality
         ; test_case "of-string-unknown-returns-none" `Quick test_of_string_unknown_returns_none
         ; test_case "has-unknown-tool-returns-false" `Quick test_has_unknown_tool_returns_false
-        ; test_case "has-ignores-legacy-dispatch-set" `Quick test_has_ignores_legacy_dispatch_set
         ; test_case "has-catalog-metadata" `Quick test_has_catalog_metadata
         ; test_case "has-catalog-inferred-capabilities" `Quick test_has_catalog_inferred_capabilities
         ; test_case "granted-unknown-tool-is-empty" `Quick test_granted_unknown_tool_is_empty

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -2,8 +2,6 @@
 
 module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Tool_result = Tool_result
-module Mcp_eio = Masc_mcp.Mcp_server_eio
-module KE = Masc_mcp.Keeper_exec_tools
 module Types = Masc_domain
 
 (** Helper: create a minimal tool_schema for registration. *)
@@ -138,78 +136,6 @@ let () =
               check bool "complete_task mint fails" true
                 (Result.is_error
                    (Tool_dispatch.mint_token ~name:"masc_complete_task")));
-        ] );
-      ( "read_only_set",
-        [
-          test_case "init and query read_only" `Quick (fun () ->
-              (* Simulate server init: populate the read_only set *)
-              Tool_dispatch.init_read_only_set
-                [ "masc_status"; "masc_who"; "masc_dashboard" ];
-              check bool "masc_status is read_only" true
-                (Tool_dispatch.is_read_only "masc_status");
-              check bool "masc_who is read_only" true
-                (Tool_dispatch.is_read_only "masc_who");
-              check bool "masc_dashboard is read_only" true
-                (Tool_dispatch.is_read_only "masc_dashboard"));
-          test_case "non-read-only tool returns false" `Quick (fun () ->
-              check bool "masc_broadcast not read_only" false
-                (Tool_dispatch.is_read_only "masc_broadcast");
-              check bool "masc_add_task not read_only" false
-                (Tool_dispatch.is_read_only "masc_add_task"));
-          test_case "keeper read-only tools use shipped registry policy" `Quick (fun () ->
-              ignore (Mcp_eio.get_clock_opt ());
-              check bool "keeper_tasks_list read_only" true
-                (Tool_dispatch.is_read_only "keeper_tasks_list");
-              check bool "keeper_memory_search read_only" true
-                (Tool_dispatch.is_read_only "keeper_memory_search"));
-          test_case "keeper read-only helper matches canonical list" `Quick (fun () ->
-              check bool "tasks_list helper" true
-                (KE.is_keeper_read_only_tool "keeper_tasks_list");
-              check bool "memory_search helper" true
-                (KE.is_keeper_read_only_tool "keeper_memory_search");
-              check bool "fs_edit helper false" false
-                (KE.is_keeper_read_only_tool "tool_edit_file");
-              check bool "effective helper keeps mutating false" false
-                (KE.is_effectively_read_only_tool "tool_edit_file"));
-        ] );
-      ( "requires_join_set",
-        [
-          test_case "known join-required tools" `Quick (fun () ->
-              (* Simulate server init: populate the requires_join set *)
-              Tool_dispatch.init_requires_join_set
-                [ "masc_broadcast"; "masc_transition" ];
-              check bool "masc_broadcast" true
-                (Tool_dispatch.is_join_required "masc_broadcast");
-              check bool "masc_transition" true
-                (Tool_dispatch.is_join_required "masc_transition"));
-          test_case "non-join-required tool returns false" `Quick (fun () ->
-              check bool "masc_status" false
-                (Tool_dispatch.is_join_required "masc_status");
-              check bool "masc_who" false
-                (Tool_dispatch.is_join_required "masc_who"));
-          test_case "search files uses shipped registry policy" `Quick (fun () ->
-              ignore (Mcp_eio.get_clock_opt ());
-              check bool "masc_claim_next join_required" true
-                (Tool_dispatch.is_join_required "masc_claim_next");
-              check bool "tool_workspace_inspect read_only" true
-                (Tool_dispatch.is_read_only "tool_workspace_inspect");
-              check bool "tool_workspace_inspect not join_required" false
-                (Tool_dispatch.is_join_required "tool_workspace_inspect"));
-        ] );
-      ( "mcp_context_required_set",
-        [
-          test_case "inline tools can be marked as requiring mcp context" `Quick (fun () ->
-              Tool_dispatch.init_mcp_context_required_set
-                [ "masc_join"; "masc_messages" ];
-              check bool "masc_join" true
-                (Tool_dispatch.is_mcp_context_required "masc_join");
-              check bool "masc_messages" true
-                (Tool_dispatch.is_mcp_context_required "masc_messages"));
-          test_case "non-inline tool returns false" `Quick (fun () ->
-              check bool "masc_status" false
-                (Tool_dispatch.is_mcp_context_required "masc_status");
-              check bool "masc_board_list" false
-                (Tool_dispatch.is_mcp_context_required "masc_board_list"));
         ] );
       ( "handler_receives_args",
         [

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -302,16 +302,16 @@ let test_board_delete_tag_registered () =
 let test_board_read_only_metadata_registered () =
   ignore (Masc_mcp.Mcp_server_eio.create_state ~test_mode:true ~base_path:"/tmp/masc-pr5973-board-meta" ());
   let meta = Masc_mcp.Tool_catalog.metadata "masc_board_list" in
-  Alcotest.(check bool) "board list is read-only in dispatch"
-    true (Masc_mcp.Tool_dispatch.is_read_only "masc_board_list");
-  Alcotest.(check bool) "board list is idempotent in dispatch"
-    true (Masc_mcp.Tool_dispatch.is_idempotent "masc_board_list");
+  Alcotest.(check bool) "board list is read-only capability"
+    true (Masc_mcp.Tool_capability.has Masc_mcp.Tool_capability.Read_only "masc_board_list");
+  Alcotest.(check bool) "board list is idempotent capability"
+    true (Masc_mcp.Tool_capability.has Masc_mcp.Tool_capability.Idempotent "masc_board_list");
   Alcotest.(check (option bool)) "board list metadata readonly"
     (Some true) meta.readonly;
   Alcotest.(check (option bool)) "board list metadata idempotent"
     (Some true) meta.idempotent;
   Alcotest.(check bool) "board post stays mutable"
-    false (Masc_mcp.Tool_dispatch.is_read_only "masc_board_post")
+    false (Masc_mcp.Tool_capability.has Masc_mcp.Tool_capability.Read_only "masc_board_post")
 
 (* ── Test: keeper alias SSOT — capability_registry derives from surfaces ── *)
 

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -5,6 +5,7 @@ module Types = Masc_domain
 module Tool_spec = Masc_mcp.Tool_spec
 module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Tool_catalog = Masc_mcp.Tool_catalog
+module Tool_capability = Masc_mcp.Tool_capability
 
 (** Helper: minimal input_schema for test tools. *)
 let empty_schema = `Assoc [ ("type", `String "object") ]
@@ -104,7 +105,7 @@ let () =
             Tool_spec.register spec;
             check bool "schema registered" true
               (Option.is_some (Tool_dispatch.lookup_schema "__test_spec_schema_reg")));
-          test_case "register sets read_only" `Quick (fun () ->
+          test_case "register sets read_only metadata" `Quick (fun () ->
             let spec =
               Tool_spec.create
                 ~name:"__test_spec_ro"
@@ -117,8 +118,8 @@ let () =
             in
             Tool_spec.register spec;
             check bool "is_read_only" true
-              (Tool_dispatch.is_read_only "__test_spec_ro"));
-          test_case "register non-read_only stays out of set" `Quick (fun () ->
+              (Tool_capability.has Tool_capability.Read_only "__test_spec_ro"));
+          test_case "register non-read_only stays mutable" `Quick (fun () ->
             let spec =
               Tool_spec.create
                 ~name:"__test_spec_rw"
@@ -130,8 +131,8 @@ let () =
             in
             Tool_spec.register spec;
             check bool "not read_only" false
-              (Tool_dispatch.is_read_only "__test_spec_rw"));
-          test_case "register sets requires_join" `Quick (fun () ->
+              (Tool_capability.has Tool_capability.Read_only "__test_spec_rw"));
+          test_case "register sets requires_join metadata" `Quick (fun () ->
             let spec =
               Tool_spec.create
                 ~name:"__test_spec_join"
@@ -144,7 +145,7 @@ let () =
             in
             Tool_spec.register spec;
             check bool "is_join_required" true
-              (Tool_dispatch.is_join_required "__test_spec_join");
+              (Tool_capability.has Tool_capability.Requires_join "__test_spec_join");
             let meta = Tool_catalog.metadata "__test_spec_join" in
             check bool "catalog requires_join" true
               (meta.requires_join = Some true);
@@ -163,7 +164,7 @@ let () =
             in
             Tool_spec.register spec;
             check bool "is_mcp_context_required" true
-              (Tool_dispatch.is_mcp_context_required "__test_spec_mcp_context");
+              (Tool_capability.has Tool_capability.Mcp_context_required "__test_spec_mcp_context");
             let meta = Tool_catalog.metadata "__test_spec_mcp_context" in
             check bool "catalog mcp_context_required" true
               (meta.mcp_context_required = Some true));

--- a/test/test_worker_safety_gates.ml
+++ b/test/test_worker_safety_gates.ml
@@ -14,11 +14,6 @@ open Alcotest
 module WO = Masc_mcp.Worker_oas
 module EG = Masc_mcp.Eval_gate
 
-(* Populate destructive set — in production this is done by mcp_server_eio.ml *)
-let () = Masc_mcp.Tool_dispatch.init_destructive_set
-  ["tool_execute"; "tool_edit_file";
-   "shell_exec"; "tool_write_file"]
-
 (* ── Helpers ──────────────────────────────────── *)
 
 let dummy_schedule : Agent_sdk.Hooks.tool_schedule = {


### PR DESCRIPTION
## Summary

- remove `Tool_dispatch` capability set tables plus `init_*_set` / `is_*` APIs
- stop server bootstrap and `Tool_spec.register` from mirroring capability metadata into dispatch
- delete/convert compatibility tests so capability assertions target `Tool_catalog` / `Tool_capability` directly
- update the purge ledger and RFC wording: dispatch owns routing only, not capability authority

## Verification

- `ocamlformat --check lib/tool_dispatch.ml lib/tool_dispatch.mli lib/tool_spec.ml lib/tool_spec.mli lib/mcp_server_eio.ml test/test_tool_capability_typed.ml test/test_mcp_server_eio_tool_profile_capability.ml test/test_eval_gate.ml test/test_worker_safety_gates.ml test/test_tool_registration_consistency.ml test/test_tool_spec.ml test/test_keeper_safety_gates.ml test/test_tool_dispatch.ml lib/tool_capability.mli test/test_keeper_tool_surface_guard.ml lib/tool_schemas/tool_schemas_inline.ml lib/tool_schemas/tool_schemas_inline_infra.ml lib/tool_inline_dispatch.ml`
- `git diff --check`
- `rg -n "Tool_dispatch\\.(init_(read_only|requires_join|mcp_context_required|destructive|idempotent)_set|is_(read_only|join_required|mcp_context_required|destructive|idempotent))" lib test -S` returned no matches
- `scripts/dune-local.sh build ./test/test_mcp_server_eio_tool_profile_capability.exe ./test/test_tool_capability_typed.exe ./test/test_tool_spec.exe ./test/test_tool_dispatch.exe ./test/test_tool_registration_consistency.exe ./test/test_mcp_server_eio_join_state.exe ./test/test_mcp_server_eio_call_tool.exe ./test/test_eval_gate.exe ./test/test_worker_safety_gates.exe ./test/test_keeper_safety_gates.exe ./test/test_keeper_tool_surface_guard.exe` blocked with exit 75 because machine-wide bare Dune processes are active; not bypassed
