### PR TITLE
feat(cdal-evidence-gate): evidence-based fallback for missing verdict — close keeper_task_done dead-end (RFC-0109 Phase E-1)

### DIFF
--- a/lib/cdal_evidence_gate.ml
+++ b/lib/cdal_evidence_gate.ml
@@ -78,8 +78,14 @@ let reason_missing_verdict =
    requires a typed verdict before workflow evidence is accepted."
 
 let hint_missing_verdict =
-  "Run the contract evaluator for this task and retry after a Satisfied, \
-   Violated, or Inconclusive CDAL verdict is recorded."
+  "Two recovery paths: (1) retry keeper_task_done with notes >= 20 chars \
+   summarising what changed AND every contract.required_evidence entry \
+   mentioned verbatim (this triggers the evidence-based fallback in \
+   Cdal_evidence_gate); (2) retry with handoff_context.evidence_refs \
+   listing at least one concrete artefact reference (file path, PR \
+   number, commit hash, trace id).  Pure-placeholder notes ('done', \
+   'ok', etc.) with no required_evidence mention and no handoff \
+   evidence_refs keep this gate closed."
 
 (* Heuristic: an "evidence entry" is satisfied when the notes or
    handoff_context.evidence_refs mention a non-placeholder string that
@@ -139,6 +145,84 @@ let task_has_contract (task_opt : Masc_domain.task option) =
   | None -> false
   | Some t -> Option.is_some t.contract
 
+(* Placeholder note bodies that {!evidence_is_substantive} treats as
+   "keeper supplied nothing".  Compared on the trimmed lowercase form.
+   This is deliberately conservative: the goal is to recognise clearly
+   empty / null-equivalent done messages, not to second-guess substantive
+   prose. *)
+let placeholder_note_bodies =
+  [ ""
+  ; "done"
+  ; "ok"
+  ; "complete"
+  ; "completed"
+  ; "draft"
+  ; "pending"
+  ; "n/a"
+  ; "na"
+  ; "tbd"
+  ; "todo"
+  ]
+
+let notes_are_substantive (notes : string) : bool =
+  let trimmed = String.trim notes |> String.lowercase_ascii in
+  if List.exists (String.equal trimmed) placeholder_note_bodies then false
+  else String.length trimmed >= 20
+
+let handoff_supplies_evidence
+    (handoff_context : Masc_domain.task_handoff_context option) : bool =
+  match handoff_context with
+  | None -> false
+  | Some hc ->
+    List.exists
+      (fun ref_ -> String.trim ref_ |> String.length > 0)
+      hc.evidence_refs
+
+(* Evidence-based fallback (RFC-0109 Phase E-1 / B-lite): when the CDAL
+   verdict ledger has no entry for a contracted task but the keeper has
+   supplied substantive evidence (all required_evidence entries mentioned,
+   plus either non-placeholder notes or a handoff pr_url / evidence_refs),
+   treat the gate as Pass.  Rationale: the upstream LLM may have failed
+   to emit a typed [Cdal_proof.t] in the turn result (the only path that
+   triggers [Cdal_eval_v1.persist] in {!Keeper_agent_run_finalize_response}),
+   but the human-readable evidence the keeper *did* attach is sufficient
+   for the verifier keeper / human reviewer to inspect downstream.  This
+   replaces the prior dead-end where keeper_task_done → Submit redirect
+   → verdict missing Reject formed an unrecoverable loop with no
+   keeper-actionable path forward (logged 2026-05-27 fleet runtime).
+
+   Returns [true] only when *every* required_evidence entry from the
+   contract is mentioned in notes/handoff AND the keeper supplied at
+   least one of: substantive notes, handoff.pr_url, handoff.evidence_refs.
+   Empty notes with empty required_evidence still rejects, since that
+   carries no evidence at all. *)
+let evidence_is_substantive
+    ~notes
+    ~(handoff_context : Masc_domain.task_handoff_context option)
+    (contract : Masc_domain.task_contract option) : bool =
+  match contract with
+  | None -> false
+  | Some c ->
+    let required_evidence_satisfied =
+      unsatisfied_required_evidence ~notes ~handoff_context (Some c) = []
+    in
+    let any_evidence_supplied =
+      notes_are_substantive notes || handoff_supplies_evidence handoff_context
+    in
+    required_evidence_satisfied && any_evidence_supplied
+
+let evidence_summary_payload
+    ~(notes : string)
+    ~(handoff_context : Masc_domain.task_handoff_context option) : Yojson.Safe.t =
+  `Assoc
+    [ "notes_length", `Int (String.length (String.trim notes))
+    ; ( "handoff_evidence_refs_count"
+      , `Int
+          (match handoff_context with
+           | None -> 0
+           | Some hc -> List.length hc.evidence_refs) )
+    ]
+
 let default_lookup ~task_id =
   Cdal_verdict_gate.lookup_latest_verdict ~warn_on_missing:false ~task_id ()
 
@@ -191,22 +275,27 @@ let decide
            ; payload_json
            })
   | None ->
-    if task_has_contract task_opt
-    then
-      Reject
-        { reason = reason_missing_verdict
-        ; rule_id = rule_id_missing_verdict
-        ; hint = hint_missing_verdict
-        ; payload_json =
-            `Assoc
-              [ "task_id", `String task_id
-              ; "contract_required", `Bool true
-              ; "verdict_status", `String "missing"
-              ]
-        }
-    else
-      (* Analysis-only task bypass: a task with no contract has nothing to
-         verify, so the gate must not block keeper_task_done. This is the
-         RFC-0109 §6.5.2 row that directly fixes the operator-visible
-         open-loop block for masc-improver-style keepers. *)
-      Pass
+    (match (task_opt : Masc_domain.task option) with
+     | Some t when Option.is_some t.contract ->
+       if evidence_is_substantive ~notes ~handoff_context t.contract
+       then Pass
+       else
+         Reject
+           { reason = reason_missing_verdict
+           ; rule_id = rule_id_missing_verdict
+           ; hint = hint_missing_verdict
+           ; payload_json =
+               `Assoc
+                 [ "task_id", `String task_id
+                 ; "contract_required", `Bool true
+                 ; "verdict_status", `String "missing"
+                 ; ( "evidence_summary"
+                   , evidence_summary_payload ~notes ~handoff_context )
+                 ]
+           }
+     | _ ->
+       (* Analysis-only task bypass: a task with no contract has nothing to
+          verify, so the gate must not block keeper_task_done. This is the
+          RFC-0109 §6.5.2 row that directly fixes the operator-visible
+          open-loop block for masc-improver-style keepers. *)
+       Pass)

--- a/test/test_cdal_evidence_gate.ml
+++ b/test/test_cdal_evidence_gate.ml
@@ -248,49 +248,121 @@ let test_no_verdict_no_task_bypasses () =
   | Gate.Reject { rule_id; _ } ->
     failf "Missing task should Pass, got Reject rule_id=%s" rule_id
 
-(* §6.5.2 row 5a: None verdict + task.contract = Some _ +
-   notes carry PR ref → Reject; substring fallback is gone. *)
-let test_missing_verdict_rejects_even_with_pr_ref () =
+(* §6.5.2 row 5a (RFC-0109 Phase E-1, 2026-05-27): None verdict +
+   task.contract = Some _ + substantive notes → Pass via evidence-based
+   fallback.  Prior policy rejected even with a PR ref; Phase E-1 opens
+   a recovery path when the contract has no [required_evidence] entries
+   to enforce and the keeper supplied non-placeholder notes.  This
+   closes the production dead-end where keeper_task_done →
+   verifier-gate redirect → cdal_verdict_missing Reject formed an
+   unrecoverable loop (logged in 2026-05-27 fleet runtime). *)
+let test_missing_verdict_passes_with_substantive_notes () =
   let contract = make_contract () in
   let task = make_task ~contract:(Some contract) () in
   match
     Gate.decide
       ~lookup:(lookup_returns None)
-      ~task_id:"task-legacy-pass"
+      ~task_id:"task-evidence-pass"
       ~task_opt:(Some task)
-      ~notes:"PR #18712 ready for verifier"
+      ~notes:"PR #18712 ready for verifier — see commit abc123 for the typed CDAL bridge fix"
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass -> ()
+  | Gate.Reject { rule_id; _ } ->
+    failf
+      "Missing CDAL verdict should Pass via evidence-based fallback when \
+       notes are substantive and no required_evidence is enforced, got \
+       Reject rule_id=%s"
+      rule_id
+
+(* RFC-0109 Phase E-1: evidence fallback closes when the contract
+   *does* enforce required_evidence and the keeper failed to mention
+   the entries verbatim — Phase E-1 must not be a blanket bypass. *)
+let test_missing_verdict_rejects_when_required_evidence_unsatisfied () =
+  let contract =
+    make_contract ~required_evidence:[ "test_results"; "coverage_report" ] ()
+  in
+  let task = make_task ~contract:(Some contract) () in
+  match
+    Gate.decide
+      ~lookup:(lookup_returns None)
+      ~task_id:"task-missing-evidence"
+      ~task_opt:(Some task)
+      ~notes:"finished the work, see PR"
       ~handoff_context:None
       ()
   with
   | Gate.Pass ->
-    fail "Missing CDAL verdict should Reject even when notes carry PR ref"
+    fail
+      "Missing CDAL verdict must Reject when contract.required_evidence \
+       entries are not mentioned in notes/handoff"
   | Gate.Reject { rule_id; payload_json; _ } ->
     check string "rule_id" Gate.rule_id_missing_verdict rule_id;
     (match payload_json with
      | `Assoc fields ->
-       (match List.assoc_opt "verdict_status" fields with
-        | Some (`String s) -> check string "verdict_status" "missing" s
-        | _ -> fail "payload missing verdict_status")
+       (match List.assoc_opt "evidence_summary" fields with
+        | Some (`Assoc _) -> ()
+        | _ -> fail "payload missing evidence_summary diagnostic")
      | _ -> fail "payload is not Assoc")
 
-(* §6.5.2 row 5b: None verdict + task.contract = Some _ +
-   notes empty → Reject with missing-verdict rule_id *)
-let test_missing_verdict_rejects_when_empty () =
+(* RFC-0109 Phase E-1: handoff_context.evidence_refs alone (no
+   substantive notes, contract.required_evidence = []) counts as
+   "evidence supplied". *)
+let test_missing_verdict_passes_with_handoff_evidence_refs () =
   let contract = make_contract () in
+  let handoff : Masc_domain.task_handoff_context =
+    { summary = "submitted"
+    ; reason = None
+    ; next_step = None
+    ; failure_mode = None
+    ; reclaim_policy = None
+    ; evidence_refs = [ "https://github.com/jeong-sik/masc-mcp/pull/18712" ]
+    ; updated_at = None
+    ; updated_by = None
+    }
+  in
   let task = make_task ~contract:(Some contract) () in
   match
     Gate.decide
       ~lookup:(lookup_returns None)
-      ~task_id:"task-legacy-reject"
+      ~task_id:"task-handoff-evidence"
       ~task_opt:(Some task)
       ~notes:""
-      ~handoff_context:None
+      ~handoff_context:(Some handoff)
       ()
   with
-  | Gate.Pass ->
-    fail "Missing CDAL verdict should Reject when contract is set"
+  | Gate.Pass -> ()
   | Gate.Reject { rule_id; _ } ->
-    check string "rule_id" Gate.rule_id_missing_verdict rule_id
+    failf
+      "Missing CDAL verdict should Pass when handoff.evidence_refs is \
+       non-empty, got Reject rule_id=%s"
+      rule_id
+
+(* Phase E-1 must reject pure-placeholder notes (kept from old §6.5.2
+   row 5b but expanded: also rejects single-word placeholders like
+   "done" / "ok" even though they pass the length=0 check). *)
+let test_missing_verdict_rejects_with_placeholder_notes () =
+  let contract = make_contract () in
+  let task = make_task ~contract:(Some contract) () in
+  List.iter
+    (fun placeholder ->
+       match
+         Gate.decide
+           ~lookup:(lookup_returns None)
+           ~task_id:"task-placeholder"
+           ~task_opt:(Some task)
+           ~notes:placeholder
+           ~handoff_context:None
+           ()
+       with
+       | Gate.Pass ->
+         failf
+           "Placeholder note %S should not pass evidence-based fallback"
+           placeholder
+       | Gate.Reject { rule_id; _ } ->
+         check string "rule_id" Gate.rule_id_missing_verdict rule_id)
+    [ ""; "done"; "ok"; "n/a"; "pending"; "draft" ]
 
 (* Bonus: rule_id constants are stable strings consumers can match on *)
 let test_rule_id_constants_are_stable () =
@@ -317,10 +389,21 @@ let () =
             `Quick test_no_verdict_no_contract_bypasses
         ; test_case "row 4 variant: None + task_opt=None → Pass" `Quick
             test_no_verdict_no_task_bypasses
-        ; test_case "row 5a: None + contract=Some + PR ref → Reject"
-            `Quick test_missing_verdict_rejects_even_with_pr_ref
-        ; test_case "row 5b: None + contract=Some + empty notes → Reject"
-            `Quick test_missing_verdict_rejects_when_empty
+        ; test_case
+            "row 5a (Phase E-1): None + contract=Some + substantive notes \
+             → Pass via evidence fallback"
+            `Quick test_missing_verdict_passes_with_substantive_notes
+        ; test_case
+            "row 5a' (Phase E-1): None + contract=Some + \
+             handoff.evidence_refs → Pass via evidence fallback"
+            `Quick test_missing_verdict_passes_with_handoff_evidence_refs
+        ; test_case
+            "row 5b (Phase E-1): None + contract.required_evidence \
+             unsatisfied → Reject"
+            `Quick test_missing_verdict_rejects_when_required_evidence_unsatisfied
+        ; test_case
+            "row 5c (Phase E-1): None + placeholder notes → Reject"
+            `Quick test_missing_verdict_rejects_with_placeholder_notes
         ] )
     ; ( "stable constants"
       , [ test_case "rule_id constants" `Quick test_rule_id_constants_are_stable


### PR DESCRIPTION
## Summary

RFC-0109 Phase E-1. Opens an evidence-based fallback in `Cdal_evidence_gate.decide`'s `None` arm so contracted-task `keeper_task_done` calls with substantive evidence stop hitting the `cdal_verdict_missing` dead-end.

## Triggering symptom

Captured from 2026-05-27 fleet runtime log:

```
[verifier-gate] redirecting Done→Submit_for_verification task=task-579 contract_items=5
[Keeper] tool keeper_task_done deterministic error (retry skipped):
  {"error":"CDAL verdict is missing for a contracted task; submit_for_verification
            requires a typed verdict before workflow evidence is accepted.",
   "do_not_retry_tool":"keeper_task_done","retry_skipped":true}
```

Multiple keepers (analyst on kimi-k2.6, umberto on glm-5-turbo) hit the same trap, with no path to finish or release the task.

## Root cause

`Cdal_eval_v1.persist` only fires when the LLM emits a typed `Cdal_proof.t` in the turn result (`Keeper_agent_run_finalize_response:207`, via `select_cdal_proof`). Local-runtime keepers (qwen3.5, glm-5-turbo, kimi-k2.6) do not emit proof bundles. Result: the CDAL verdict ledger stays empty for the entire task lifetime, and `Cdal_evidence_gate` could never see a verdict to act on.

Phase D §6.5.2 row 4 already opened a bypass for `contract = None` tasks. Row 5 (the `contract = Some + verdict = None` case) was strict by design — but in practice it produces an unrecoverable dead-end for the keeper because there is no SDK-level surface to retroactively trigger evaluator dispatch.

## What changes

Evidence-based fallback in `Cdal_evidence_gate.decide`'s `None` arm:

| Contract | Verdict | Evidence | Decision |
|---|---|---|---|
| `None` | — | — | Pass (Phase D, unchanged) |
| `Some`, no `required_evidence` | `None` | substantive notes OR `handoff.evidence_refs` non-empty | **Pass (Phase E-1, new)** |
| `Some`, `required_evidence` non-empty | `None` | all entries mentioned in notes/handoff AND substantive notes/refs | **Pass (Phase E-1, new)** |
| `Some`, `required_evidence` non-empty | `None` | any entry unmentioned | Reject (unchanged) |
| `Some`, anything else | `None` | placeholder notes ('done', 'ok', '', etc.), no `evidence_refs` | Reject (unchanged) |

"Substantive notes" = trimmed lowercase length ≥ 20 AND not a placeholder ('', 'done', 'ok', 'complete', 'draft', 'pending', 'n/a', 'na', 'tbd', 'todo', 'completed').

## Rejection hint rewrite

Old hint was operator-friendly but keeper-actionable-zero:
> "Run the contract evaluator for this task and retry after a Satisfied, Violated, or Inconclusive CDAL verdict is recorded."

There is no `keeper_run_contract_evaluator` tool; the keeper had no way to act on this hint. Replaced with two concrete recovery paths:
- **Path 1**: retry `keeper_task_done` with notes ≥ 20 chars + every `required_evidence` entry mentioned verbatim
- **Path 2**: retry with `handoff_context.evidence_refs` listing artefact references

The Reject payload now embeds an `evidence_summary` diagnostic (`notes_length`, `handoff_evidence_refs_count`) so operators can see why the gate still rejected.

## What's NOT in this PR

- LLM proof-emission training / response-schema enforcement (Phase E-2, separate RFC). Would let evidence become *typed* rather than text-mentioned.
- `Cdal_eval_v1.evaluate` synthesis from notes/handoff. Verified to be infeasible without a `Cdal_proof.t` bundle, which requires `Cdal_loader` infrastructure not addressable in this scope.
- `keeper_task_run_contract_evaluator` explicit tool. Considered, deferred: same dead-end risk if the keeper forgets to call it. Evidence-based fallback is a more robust default because it operates on data the keeper is already supplying.

## Test changes

Old `test_missing_verdict_rejects_even_with_pr_ref` and `test_missing_verdict_rejects_when_empty` (asserting strict Reject regardless of notes content, "substring fallback is gone") are replaced by 4 Phase E-1 row tests:

- `row 5a (Phase E-1): substantive notes → Pass`
- `row 5a' (Phase E-1): handoff.evidence_refs → Pass`
- `row 5b (Phase E-1): required_evidence unsatisfied → Reject`
- `row 5c (Phase E-1): placeholder notes → Reject` (broader than old empty-notes row — covers 'done', 'ok', 'n/a', 'pending', 'draft', '')

12/12 alcotest cases pass.

## Verification

- `dune build --root . @check` — exit 0
- `dune runtest --root . test/test_cdal_evidence_gate.exe` — 12/12 PASS
- Decision matrix unchanged for rows 1–4; row 5 expanded per table above

## Risk

- Behaviour change in `Cdal_evidence_gate.decide` for the `None`-arm with substantive evidence. Operator-visible: contracted tasks with notes/evidence will now Pass where they previously Rejected. **This is the intended fix**.
- Pre-existing `keeper_task_done` strict path (line 256-261 `tool_task.ml`) is *upstream* of this gate and continues to enforce its own checks (`persisted_contract_rejection`, `review_completion_notes` LLM judge). Phase E-1 does not bypass those.
- `verifier-gate` redirect (Done→Submit_for_verification) is upstream of this gate too; the change only affects the gate result, not the redirect.

## Test plan

- [ ] CI green on `dune build @all` + `dune runtest`
- [ ] Replay the captured fleet log scenario (contract = 5 items, substantive notes, no evidence): expect `Pass` instead of `cdal_verdict_missing` Reject
- [ ] Verify placeholder-only attempts still reject — `keeper_task_done(notes="done")` must not slip through
- [ ] Spot-check that `evidence_summary` diagnostic surfaces in the rejection payload for operator triage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
