### PR TITLE
refactor(board): typed Result for persistence loaders

### DIFF
--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -425,7 +425,8 @@ let quarantine_enabled () =
 
 let load_persisted_votes store =
   let path = vote_log_path () in
-  if Fs_compat.file_exists path then begin
+  if not (Fs_compat.file_exists path) then Ok 0
+  else begin
     try
       let loaded = ref 0 in
       let quarantined = ref 0 in
@@ -479,16 +480,17 @@ let load_persisted_votes store =
       if !loaded > 0 then
         Log.BoardLog.info "loaded %d vote entries from %s" !loaded path
       else
-        Log.BoardLog.debug "loaded 0 vote entries from %s" path
+        Log.BoardLog.debug "loaded 0 vote entries from %s" path;
+      Ok !loaded
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | e ->
-      Log.BoardLog.error "load votes failed: %s" (Printexc.to_string e)
+    | e -> Error (path, e)
   end
 
 let load_persisted_reactions store =
   let path = reactions_path () in
-  if Fs_compat.file_exists path then begin
+  if not (Fs_compat.file_exists path) then Ok 0
+  else begin
     try
       let loaded = ref 0 in
       let lines = Fs_compat.load_jsonl path in
@@ -509,16 +511,17 @@ let load_persisted_reactions store =
       if !loaded > 0 then
         Log.BoardLog.info "loaded %d reactions from %s" !loaded path
       else
-        Log.BoardLog.debug "loaded 0 reactions from %s" path
+        Log.BoardLog.debug "loaded 0 reactions from %s" path;
+      Ok !loaded
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | e ->
-        Log.BoardLog.error "load reactions failed: %s" (Printexc.to_string e)
+    | e -> Error (path, e)
   end
 
 let load_persisted_sub_boards store =
   let path = sub_boards_path () in
-  if Fs_compat.file_exists path then begin
+  if not (Fs_compat.file_exists path) then Ok 0
+  else begin
     try
       let loaded = ref 0 in
       let lines = Fs_compat.load_jsonl path in
@@ -535,11 +538,11 @@ let load_persisted_sub_boards store =
       if !loaded > 0 then
         Log.BoardLog.info "loaded %d sub-boards from %s" !loaded path
       else
-        Log.BoardLog.debug "loaded 0 sub-boards from %s" path
+        Log.BoardLog.debug "loaded 0 sub-boards from %s" path;
+      Ok !loaded
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | e ->
-        Log.BoardLog.error "load sub-boards failed: %s" (Printexc.to_string e)
+    | e -> Error (path, e)
   end
 
 (** {1 Hearth (topic) operations} *)
@@ -682,15 +685,28 @@ let delete_post store ~post_id : (unit, board_error) Result.t =
     [cancel:`Protect] ensures store creation completes even if the
     forcing fiber is cancelled. *)
 
+(* Loaders return [(int, string * exn) result] so the caller is forced to
+   acknowledge persistence-load failures.  Best-effort semantics live here
+   at the call site, not hidden inside the loader bodies. *)
+let log_persistence_result ~kind = function
+  | Ok _ -> ()
+  | Error (path, e) ->
+    Log.BoardLog.error
+      "load %s failed: path=%s reason=%s (continuing with best-effort partial state)"
+      kind path (Printexc.to_string e)
+
+let load_all_persisted store =
+  log_persistence_result ~kind:"posts" (load_persisted_posts store);
+  log_persistence_result ~kind:"comments" (load_persisted_comments store);
+  recalculate_reply_counts store;
+  log_persistence_result ~kind:"votes" (load_persisted_votes store);
+  log_persistence_result ~kind:"reactions" (load_persisted_reactions store);
+  log_persistence_result ~kind:"sub-boards" (load_persisted_sub_boards store)
+
 let global_lazy : store Eio.Lazy.t ref =
   ref (Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
     let store = create_store () in
-    load_persisted_posts store;
-    load_persisted_comments store;
-    recalculate_reply_counts store;
-    load_persisted_votes store;
-    load_persisted_reactions store;
-    load_persisted_sub_boards store;
+    load_all_persisted store;
     store))
 
 let global () = Eio.Lazy.force !global_lazy
@@ -701,12 +717,7 @@ let reset_global_for_test () =
   reset_comment_rate_tracker ();
   global_lazy := Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
     let store = create_store () in
-    load_persisted_posts store;
-    load_persisted_comments store;
-    recalculate_reply_counts store;
-    load_persisted_votes store;
-    load_persisted_reactions store;
-    load_persisted_sub_boards store;
+    load_all_persisted store;
     store)
 
 (** Flush any dirty state to disk. Call on shutdown to prevent data loss.

--- a/lib/board_votes_json.ml
+++ b/lib/board_votes_json.ml
@@ -166,8 +166,9 @@ let comment_of_yojson (json : Yojson.Safe.t) : comment option =
 
 let load_persisted_posts store =
   let path = persist_path () in
-  if Fs_compat.file_exists path
-  then
+  if not (Fs_compat.file_exists path)
+  then Ok 0
+  else
     try
       let now = Time_compat.now () in
       let loaded = ref 0 in
@@ -185,16 +186,18 @@ let load_persisted_posts store =
       store.post_count := Hashtbl.length store.posts;
       if !loaded > 0
       then Log.BoardLog.info "loaded %d posts from %s" !loaded path
-      else Log.BoardLog.debug "loaded 0 posts from %s" path
+      else Log.BoardLog.debug "loaded 0 posts from %s" path;
+      Ok !loaded
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | e -> Log.BoardLog.error "load posts failed: %s" (Printexc.to_string e)
+    | e -> Error (path, e)
 ;;
 
 let load_persisted_comments store =
   let path = comments_path () in
-  if Fs_compat.file_exists path
-  then
+  if not (Fs_compat.file_exists path)
+  then Ok 0
+  else
     try
       let now = Time_compat.now () in
       let loaded = ref 0 in
@@ -207,7 +210,6 @@ let load_persisted_comments store =
                   || Float.compare c.expires_at now > 0 ->
              let cid = Comment_id.to_string c.id in
              Hashtbl.replace store.comments cid c;
-             (* Build comments_by_post index *)
              let post_key = Post_id.to_string c.post_id in
              let existing =
                Hashtbl.find_opt store.comments_by_post post_key
@@ -222,8 +224,9 @@ let load_persisted_comments store =
         lines;
       if !loaded > 0
       then Log.BoardLog.info "loaded %d comments from %s" !loaded path
-      else Log.BoardLog.debug "loaded 0 comments from %s" path
+      else Log.BoardLog.debug "loaded 0 comments from %s" path;
+      Ok !loaded
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | e -> Log.BoardLog.error "load comments failed: %s" (Printexc.to_string e)
+    | e -> Error (path, e)
 ;;

--- a/lib/board_votes_json.mli
+++ b/lib/board_votes_json.mli
@@ -7,5 +7,14 @@ end
 val visibility_of_string : string -> visibility option
 val post_of_yojson : Yojson.Safe.t -> post option
 val comment_of_yojson : Yojson.Safe.t -> comment option
-val load_persisted_posts : store -> unit
-val load_persisted_comments : store -> unit
+val load_persisted_posts : store -> (int, string * exn) result
+(** Load posts from disk into [store].  Returns [Ok loaded_count] on success
+    (including when the persistence file is absent: [Ok 0]).  Returns
+    [Error (path, cause)] when the file existed but could not be parsed or
+    read.  Caller decides how to surface the failure — earlier behaviour
+    swallowed the exception inside this function, leaving a partially loaded
+    store undistinguishable from a clean one.  [Eio.Cancel.Cancelled] is
+    propagated unchanged. *)
+
+val load_persisted_comments : store -> (int, string * exn) result
+(** See {!load_persisted_posts}. *)

--- a/test/dune
+++ b/test/dune
@@ -1418,6 +1418,8 @@
 
 (include stanzas/test_board_api_e2e.inc)
 
+(include stanzas/test_board_persistence_load_contract.inc)
+
 (include stanzas/test_board_sse_canonical_event_type.inc)
 
 (include stanzas/test_briefing_compactors.inc)

--- a/test/stanzas/test_board_persistence_load_contract.inc
+++ b/test/stanzas/test_board_persistence_load_contract.inc
@@ -1,0 +1,6 @@
+; Board persistence loader Result.t contract (load_persisted_{posts,comments})
+
+(test
+ (name test_board_persistence_load_contract)
+ (modules test_board_persistence_load_contract)
+ (libraries masc_test_deps))

--- a/test/test_board_persistence_load_contract.ml
+++ b/test/test_board_persistence_load_contract.ml
@@ -1,0 +1,68 @@
+(** Contract test for {!Board_votes_json.load_persisted_posts} and
+    {!Board_votes_json.load_persisted_comments}.
+
+    Prior to this contract change, the loaders had signature
+    [store -> unit] and swallowed any [exn] from the JSONL read into an
+    in-function [Log.BoardLog.error].  Callers could not distinguish a
+    successful "no file" load from a partially-loaded store after an IO
+    failure.
+
+    The current contract returns [(int, string * exn) result] and forces
+    callers to acknowledge failure.  These tests pin the [Ok 0] branch
+    that is exercised on every fresh server start (no persistence file
+    yet). *)
+
+open Masc_mcp
+
+let fresh_test_base_path () =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-board-loader-%06x" (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir;
+  dir
+;;
+
+let test_load_persisted_posts_missing_file () =
+  let _dir = fresh_test_base_path () in
+  let store = Board_core.create_store () in
+  match Board_votes_json.load_persisted_posts store with
+  | Ok 0 -> ()
+  | Ok n -> Alcotest.failf "expected Ok 0 for missing file, got Ok %d" n
+  | Error (path, e) ->
+    Alcotest.failf
+      "expected Ok 0 for missing file, got Error (%s, %s)"
+      path
+      (Printexc.to_string e)
+;;
+
+let test_load_persisted_comments_missing_file () =
+  let _dir = fresh_test_base_path () in
+  let store = Board_core.create_store () in
+  match Board_votes_json.load_persisted_comments store with
+  | Ok 0 -> ()
+  | Ok n -> Alcotest.failf "expected Ok 0 for missing file, got Ok %d" n
+  | Error (path, e) ->
+    Alcotest.failf
+      "expected Ok 0 for missing file, got Error (%s, %s)"
+      path
+      (Printexc.to_string e)
+;;
+
+let () =
+  Random.self_init ();
+  Alcotest.run
+    "board_persistence_load_contract"
+    [ ( "loader_contract"
+      , [ Alcotest.test_case
+            "posts loader returns Ok 0 when file absent"
+            `Quick
+            test_load_persisted_posts_missing_file
+        ; Alcotest.test_case
+            "comments loader returns Ok 0 when file absent"
+            `Quick
+            test_load_persisted_comments_missing_file
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

Replace silent catch-and-log in five board persistence loaders with a typed
`(int, string * exn) result` contract.  Loaders no longer hide IO failures
inside their own bodies; the global store builder (`load_all_persisted`,
called from `global_lazy` and `reset_global_for_test`) is now the single
site that decides whether to keep the best-effort "log and continue" policy.

Affected loaders:

- `Board_votes_json.load_persisted_posts`
- `Board_votes_json.load_persisted_comments`
- `Board_votes.load_persisted_votes`
- `Board_votes.load_persisted_reactions`
- `Board_votes.load_persisted_sub_boards`

## Motivation

Each loader previously had signature `store -> unit` and ended with

```ocaml
| Eio.Cancel.Cancelled _ as e -> raise e
| e -> Log.BoardLog.error "load X failed: %s" (Printexc.to_string e)
```

Callers could not distinguish a clean load from a partially loaded store
following a transient IO failure (`load_jsonl` raising mid-read, broken
permissions, etc.).  `load_jsonl` already drops malformed JSON lines
silently at the parser layer, so the only path into the catch arm is a
real storage-layer failure — exactly the case where downstream readers
proceeding against a half-populated `Hashtbl` is most dangerous.

The new signature is `store -> (int, string * exn) result`:

- `Ok loaded_count` when the file is absent (`Ok 0`) or fully read.
- `Error (path, exn)` when an exception escaped the read loop;
  `Eio.Cancel.Cancelled` is still re-raised unchanged.

Loaders still emit `Log.BoardLog.info`/`debug` for the success path
(unchanged from before); only the failure path moves to the call site.

## Why this is not a workaround

Per `CLAUDE.md` workaround-rejection bar, self-checked the three
signatures:

1. **Counter-as-Fix** — No Prometheus counter is introduced.  The fix is
   a typed contract change.  Operator visibility (if needed) belongs in a
   follow-up that observes the now-typed `Error` branch from the call
   site, not inside the loader.
2. **String/substring classifier** — N/A.
3. **N-of-M partial sweep** — All five loaders in the board persistence
   surface change in this PR; no caller migration is deferred.  The two
   call sites (`global_lazy` + `reset_global_for_test`) both route
   through the new `load_all_persisted` helper.

## Test plan

- [x] `dune build @check --root . --cache=disabled` clean
       (`feedback_dune_shared_cache_stale_on_mli_change.md` guarded)
- [x] `_build/default/test/test_board_karma_ledger.exe` — 18/18 OK
- [x] `_build/default/test/test_vote_ts_preservation_10086.exe` — 2/2 OK
- [x] `_build/default/test/test_board_persistence_load_contract.exe`
       (new, 2/2 OK) — pins `Ok 0` for absent file on both
       posts/comments loaders
- [x] `test_types` 3 failures (`fs_write_mode_ssot`,
       `tool_search_files_op_ssot`, `assertion_kind_ssot`) reproduce
       on `origin/main` without this change — pre-existing,
       unrelated; false-attribution avoided.
- [x] `ocamlformat --check` on all touched files — pass.

## Out of scope

- Adding Prometheus counters or other observability for the typed
  `Error` branch.
- Promoting `load_all_persisted` to a stricter "abort startup on
  Error" policy.  Current behaviour (log + continue) is preserved
  intentionally so this PR is a pure contract widening.
- The two `tool_board_format.ml` WARN sites flagged in the initial
  audit are RFC-0093 Phase B intended preservation/visibility paths
  (coerce-rather-than-drop + typed `_ -> []` arm split) and are NOT
  changed.