### PR TITLE
fix(coord): RFC-0109 Phase E — sunset legacy substring evidence gate

### DIFF
--- a/lib/coord/coord_task_transitions.ml
+++ b/lib/coord/coord_task_transitions.ml
@@ -228,30 +228,30 @@ let transition_task_r
             , _
             , Masc_domain.AwaitingVerification { assignee; verification_id; _ }
             , prepare_opt ) ->
+            (* RFC-0109 Phase E: gating is owned by Cdal_evidence_gate (called
+               from tool_task.ml before transition_task_r). Here we only
+               collect typed evidence refs as observability metadata for
+               the verifier request output. Empty list is valid for
+               analysis-only / no-contract tasks — Phase D's decision
+               matrix row 5 already passed them. *)
             let evidence_refs =
               Coord_task_verification.verification_submission_evidence_refs task ~notes handoff_context
             in
-            if evidence_refs = [] then
-              Error
-                (Masc_domain.Task
-                   (Masc_domain.Task_error.InvalidState
-                      Coord_task_verification.verification_evidence_error_message))
-            else
-              (match prepare_opt with
-               | None -> Ok ()
-               | Some prepare ->
-                 (match prepare ~task ~assignee ~verification_id ~evidence_refs with
-                  | Ok () -> Ok ()
-                  | Error e ->
-                    Error
-                      (Masc_domain.System
-                         (Masc_domain.System_error.IoError
-                            (Printf.sprintf
-                               "verification request creation failed before status transition \
-                                (task=%s vrf=%s): %s"
-                               task_id
-                               verification_id
-                               e)))))
+            (match prepare_opt with
+             | None -> Ok ()
+             | Some prepare ->
+               (match prepare ~task ~assignee ~verification_id ~evidence_refs with
+                | Ok () -> Ok ()
+                | Error e ->
+                  Error
+                    (Masc_domain.System
+                       (Masc_domain.System_error.IoError
+                          (Printf.sprintf
+                             "verification request creation failed before status transition \
+                              (task=%s vrf=%s): %s"
+                             task_id
+                             verification_id
+                             e)))))
           | ( (Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence)
             , _
             , _

--- a/lib/coord/coord_task_verification.ml
+++ b/lib/coord/coord_task_verification.ml
@@ -1,8 +1,16 @@
 (** Verification-evidence helpers for coord task lifecycle,
     extracted from coord_task.ml.
 
-    Pure string/JSON predicates and a small messaging helper used by
-    [transition_task_r] when validating submission/verification flows. *)
+    Phase D (RFC-0109 #18715) routed contracted submissions through the
+    typed [Cdal_evidence_gate] decision. Phase E (this module rewrite)
+    retires the legacy substring-classifier predicates that used to
+    reject empty/analysis-only submissions at the transition layer.
+
+    Evidence refs are now collected by typed concat from contract
+    metadata, handoff context, and a non-empty/non-placeholder notes
+    string. They are forwarded to [Verification_protocol.create_submit_request]
+    as observability metadata only — the gating decision lives in
+    [Cdal_evidence_gate]. *)
 
 open Masc_domain
 include Coord_state
@@ -11,49 +19,12 @@ let flatten_lock_result = function
   | Ok result -> result
   | Error e -> Error e
 
-
 let is_placeholder_verification_evidence value =
   let value = value |> String.trim |> String.lowercase_ascii in
   let placeholders =
     [ ""; "-"; "draft"; "n/a"; "na"; "none"; "null"; "pending"; "tbd"; "todo"; "unknown" ]
   in
   List.mem value placeholders
-
-let text_has_verification_artifact_ref text =
-  let text = String.trim text in
-  let has_github_pull =
-    String_util.contains_substring_ci text "github.com/"
-    && String_util.contains_substring_ci text "/pull/"
-  in
-  let has_pr_shorthand =
-    String_util.contains_substring_ci text "#"
-    && (String_util.contains_substring_ci text "pr "
-        || String_util.contains_substring_ci text "pr:"
-        || String_util.contains_substring_ci text "pull request")
-  in
-  let has_explicit_artifact =
-    [ "artifact:"; "artifact://"; "file:"; "path:"; "commit:"; "branch:" ]
-    |> List.exists (String_util.contains_substring_ci text)
-  in
-  has_github_pull || has_pr_shorthand || has_explicit_artifact
-
-let evidence_ref_has_verification_artifact_ref value =
-  let value = String.trim value in
-  (not (is_placeholder_verification_evidence value))
-  && (text_has_verification_artifact_ref value
-      || String_util.contains_substring_ci value "github.com/"
-      || String.contains value '/'
-      || String.contains value '.')
-
-let notes_have_verification_artifact_ref notes =
-  let notes = String.trim notes in
-  (not (is_placeholder_verification_evidence notes))
-  && text_has_verification_artifact_ref notes
-
-let verification_evidence_error_message =
-  "submit_for_verification requires verification evidence: include pr_url \
-   for the draft PR, a PR # reference, or an explicit \
-   artifact/file/path/commit/branch reference in notes."
 
 let verification_submission_evidence_refs task ~notes handoff_context =
   let contract_refs =
@@ -68,12 +39,22 @@ let verification_submission_evidence_refs task ~notes handoff_context =
       | None -> task.handoff_context
     with
     | Some (hc : Masc_domain.task_handoff_context) ->
-      ( hc.evidence_refs
-      , if notes_have_verification_artifact_ref hc.summary then [ hc.summary ] else [] )
+      let summary_trimmed = String.trim hc.summary in
+      let summary_keep =
+        if String.equal summary_trimmed ""
+           || is_placeholder_verification_evidence summary_trimmed
+        then []
+        else [ summary_trimmed ]
+      in
+      (hc.evidence_refs, summary_keep)
     | None -> ([], [])
   in
   let notes_refs =
-    if notes_have_verification_artifact_ref notes then [ notes ] else []
+    let trimmed = String.trim notes in
+    if String.equal trimmed ""
+       || is_placeholder_verification_evidence trimmed
+    then []
+    else [ trimmed ]
   in
   Coord_state.normalized_string_list (contract_refs @ handoff_refs @ summary_refs @ notes_refs)
-  |> List.filter evidence_ref_has_verification_artifact_ref
+  |> List.filter (fun s -> not (is_placeholder_verification_evidence s))

--- a/lib/coord/coord_task_verification.mli
+++ b/lib/coord/coord_task_verification.mli
@@ -1,14 +1,22 @@
-(** Verification-evidence helpers for coord task lifecycle. *)
+(** Verification-evidence helpers for coord task lifecycle.
+
+    Substring-classifier predicates were retired in Phase E (RFC-0109
+    closeout). The legacy [text_has_verification_artifact_ref] /
+    [evidence_ref_has_verification_artifact_ref] /
+    [notes_have_verification_artifact_ref] /
+    [verification_evidence_error_message] are gone — gating decisions
+    live in [Cdal_evidence_gate] only. *)
 
 val flatten_lock_result : (('a, 'b) result, 'b) result -> ('a, 'b) result
+
 val is_placeholder_verification_evidence : string -> bool
-val text_has_verification_artifact_ref : string -> bool
-val evidence_ref_has_verification_artifact_ref : string -> bool
-val notes_have_verification_artifact_ref : string -> bool
-val verification_evidence_error_message : string
+(** True for trimmed lowercase placeholders like ["draft"], ["tbd"],
+    [""]. Used to keep the typed concat free of trash entries. *)
 
 val verification_submission_evidence_refs :
   Masc_domain.task ->
   notes:string ->
   Masc_domain.task_handoff_context option ->
   string list
+(** Typed concat of evidence sources for the verifier request output.
+    Pure observability metadata — no gating semantics. *)

--- a/lib/tool_task_completion_review.ml
+++ b/lib/tool_task_completion_review.ml
@@ -60,24 +60,11 @@ let is_placeholder_evidence_ref value =
   let value = value |> String.trim |> String.lowercase_ascii in
   value = "" || List.mem value placeholder_evidence_refs
 
-let text_has_verification_artifact_ref text =
-  let text = String.trim text in
-  let has_github_pull =
-    String_util.contains_substring_ci text "github.com/"
-    && String_util.contains_substring_ci text "/pull/"
-  in
-  let has_pr_shorthand =
-    String_util.contains_substring_ci text "#"
-    && (String_util.contains_substring_ci text "pr "
-        || String_util.contains_substring_ci text "pr:"
-        || String_util.contains_substring_ci text "pull request")
-  in
-  let has_explicit_artifact =
-    [ "artifact:"; "artifact://"; "file:"; "path:"; "commit:"; "branch:" ]
-    |> List.exists (String_util.contains_substring_ci text)
-  in
-  has_github_pull || has_pr_shorthand || has_explicit_artifact
-
+(* [pr_url_has_pull_ref] validates an explicit typed [pr_url] field
+   handed to [keeper_task_done] (see keeper_exec_task.ml:800). The
+   substring shape match is a thin guard on a typed input — distinct
+   from the retired transition-layer substring gate (RFC-0109 Phase E,
+   2026-05-27). *)
 let pr_url_has_pull_ref pr_url =
   let pr_url = String.trim pr_url in
   (not (is_placeholder_evidence_ref pr_url))
@@ -88,27 +75,6 @@ let pr_url_has_pull_ref pr_url =
               || String_util.contains_substring_ci pr_url "pr:"
               || String_util.contains_substring_ci pr_url "pull request")))
 
-let artifact_like_ref value =
-  let value = String.trim value in
-  String_util.contains_substring_ci value "artifact://"
-  || String_util.contains_substring_ci value "file:"
-  || String_util.contains_substring_ci value "path:"
-  || String_util.contains_substring_ci value "commit:"
-  || String_util.contains_substring_ci value "branch:"
-  || String_util.contains_substring_ci value "github.com/"
-  || String.contains value '/'
-  || String.contains value '.'
-
-let evidence_ref_has_verification_artifact_ref value =
-  let value = String.trim value in
-  (not (is_placeholder_evidence_ref value))
-  && (text_has_verification_artifact_ref value || artifact_like_ref value)
-
-let notes_have_verification_artifact_ref notes =
-  let notes = String.trim notes in
-  (not (is_placeholder_evidence_ref notes))
-  && text_has_verification_artifact_ref notes
-
 let non_empty_trimmed_strings values =
   values
   |> List.filter_map (fun value ->
@@ -116,12 +82,10 @@ let non_empty_trimmed_strings values =
          if String.equal value "" then None else Some value)
   |> List.sort_uniq String.compare
 
-let handoff_context_has_verification_artifact_ref = function
-  | Some (handoff_context : Masc_domain.task_handoff_context) ->
-      handoff_context.evidence_refs |> non_empty_trimmed_strings |> fun refs ->
-      List.exists evidence_ref_has_verification_artifact_ref refs
-  | None -> false
-
+(* Typed concat for the verifier request output (observability only).
+   Phase E (RFC-0109 closeout) replaced the substring-classifier filter
+   with placeholder-only filtering. Gating decisions belong to
+   [Cdal_evidence_gate]. *)
 let concrete_verification_evidence_refs ?(notes = "") ?handoff_context
     (task : Masc_domain.task) =
   let contract_refs =
@@ -129,31 +93,34 @@ let concrete_verification_evidence_refs ?(notes = "") ?handoff_context
     | Some contract -> contract.verify_gate_evidence @ contract.required_evidence
     | None -> []
   in
+  let resolved_handoff_context =
+    match handoff_context with
+    | Some _ -> handoff_context
+    | None -> task.handoff_context
+  in
   let handoff_refs =
-    match
-      match handoff_context with
-      | Some _ -> handoff_context
-      | None -> task.handoff_context
-    with
-    | Some handoff_context -> handoff_context.evidence_refs
+    match resolved_handoff_context with
+    | Some hc -> hc.evidence_refs
     | None -> []
   in
   let summary_refs =
-    match
-      match handoff_context with
-      | Some _ -> handoff_context
-      | None -> task.handoff_context
-    with
-    | Some handoff_context when notes_have_verification_artifact_ref handoff_context.summary ->
-      [ handoff_context.summary ]
-    | _ -> []
+    match resolved_handoff_context with
+    | Some hc ->
+      let trimmed = String.trim hc.summary in
+      if String.equal trimmed "" || is_placeholder_evidence_ref trimmed
+      then []
+      else [ trimmed ]
+    | None -> []
   in
   let notes_refs =
-    if notes_have_verification_artifact_ref notes then [ notes ] else []
+    let trimmed = String.trim notes in
+    if String.equal trimmed "" || is_placeholder_evidence_ref trimmed
+    then []
+    else [ trimmed ]
   in
   contract_refs @ handoff_refs @ summary_refs @ notes_refs
   |> non_empty_trimmed_strings
-  |> List.filter evidence_ref_has_verification_artifact_ref
+  |> List.filter (fun s -> not (is_placeholder_evidence_ref s))
 
 let verification_evidence_refs_for_task (task : Masc_domain.task) =
   concrete_verification_evidence_refs task

--- a/test/dune
+++ b/test/dune
@@ -859,6 +859,7 @@
   test_board_karma_ledger
   test_task_dispatch
   test_coord_task_lifecycle
+  test_coord_task_verification_phase_e
   test_drift_guard_core
   test_verify_handoff_tool
   test_memory_horizon_classifier
@@ -1079,6 +1080,7 @@
   test_board_karma_ledger
   test_task_dispatch
   test_coord_task_lifecycle
+  test_coord_task_verification_phase_e
   test_drift_guard_core
   test_verify_handoff_tool
   test_memory_horizon_classifier

--- a/test/test_coord_task_verification_phase_e.ml
+++ b/test/test_coord_task_verification_phase_e.ml
@@ -1,0 +1,121 @@
+(* RFC-0109 Phase E regression guard.
+
+   Before Phase E, [coord_task_verification.ml] applied a substring
+   classifier (`pr_url` / `/pull/` / `commit:` / `branch:` / `file:` ...
+   token matching) inside the transition layer's
+   [verification_submission_evidence_refs]. Analysis-only tasks (no
+   contract, no handoff_context, plain prose notes) had no way to pass.
+
+   Phase E retired the substring filter — only placeholder filtering
+   remains. These tests pin that behavior so a future refactor doesn't
+   silently re-introduce a Counter-as-Fix style substring gate. *)
+
+module V = Coord_task_verification
+
+let dummy_task ?contract ?handoff_context () : Masc_domain.task =
+  { id = "t-phase-e"
+  ; title = "phase e regression"
+  ; description = ""
+  ; goal_id = None
+  ; files = []
+  ; created_at = "2026-05-27T00:00:00Z"
+  ; task_status = Masc_domain.Todo
+  ; priority = 5
+  ; created_by = None
+  ; stage = None
+  ; contract
+  ; handoff_context
+  ; cycle_count = 0
+  ; reclaim_policy = None
+  ; do_not_reclaim_reason = None
+  }
+
+let test_analysis_only_with_plain_notes_keeps_notes () =
+  (* Pre Phase-E: empty result because notes had no substring tokens.
+     Phase E: notes survive when non-empty / non-placeholder. *)
+  let task = dummy_task () in
+  let refs =
+    V.verification_submission_evidence_refs task ~notes:"investigated 24h log audit" None
+  in
+  Alcotest.(check (list string))
+    "plain prose notes survive Phase E"
+    [ "investigated 24h log audit" ]
+    refs
+
+let test_analysis_only_with_empty_notes_returns_empty () =
+  let task = dummy_task () in
+  let refs = V.verification_submission_evidence_refs task ~notes:"" None in
+  Alcotest.(check (list string)) "empty notes -> empty refs" [] refs
+
+let test_placeholder_notes_filtered () =
+  let task = dummy_task () in
+  let refs = V.verification_submission_evidence_refs task ~notes:"tbd" None in
+  Alcotest.(check (list string)) "placeholder notes filtered" [] refs;
+  let refs2 = V.verification_submission_evidence_refs task ~notes:"  DRAFT  " None in
+  Alcotest.(check (list string)) "case/whitespace placeholders filtered" [] refs2
+
+let test_contracted_task_includes_contract_refs () =
+  let contract : Masc_domain.task_contract =
+    { strict = false
+    ; completion_contract = []
+    ; required_tools = []
+    ; required_evidence = [ "test_keeper_lifecycle PASS" ]
+    ; inspect_gate_evidence = []
+    ; verify_gate_evidence = [ "PR #18810 merged" ]
+    ; links = { operation_id = None; session_id = None }
+    }
+  in
+  let task = dummy_task ~contract () in
+  let refs = V.verification_submission_evidence_refs task ~notes:"" None in
+  Alcotest.(check bool)
+    "verify_gate_evidence included"
+    true
+    (List.mem "PR #18810 merged" refs);
+  Alcotest.(check bool)
+    "required_evidence included"
+    true
+    (List.mem "test_keeper_lifecycle PASS" refs)
+
+let test_handoff_context_evidence_refs_survive_plain_string () =
+  (* Pre Phase-E: handoff_context.evidence_refs were substring-filtered
+     and a plain string like "see retro" would be dropped. Phase E: as
+     long as it is not placeholder/empty, it survives. *)
+  let handoff_context : Masc_domain.task_handoff_context =
+    { summary = "investigated repeat failure"
+    ; reason = None
+    ; next_step = None
+    ; failure_mode = None
+    ; reclaim_policy = None
+    ; evidence_refs = [ "see retro"; "n/a"; "  " ]
+    ; updated_at = None
+    ; updated_by = None
+    }
+  in
+  let task = dummy_task ~handoff_context () in
+  let refs = V.verification_submission_evidence_refs task ~notes:"" None in
+  Alcotest.(check bool)
+    "plain handoff evidence_ref survives" true
+    (List.mem "see retro" refs);
+  Alcotest.(check bool)
+    "n/a placeholder filtered" false
+    (List.mem "n/a" refs);
+  Alcotest.(check bool)
+    "summary survives non-empty / non-placeholder" true
+    (List.mem "investigated repeat failure" refs)
+
+let () =
+  Alcotest.run
+    "coord_task_verification_phase_e"
+    [ ( "phase_e_regression"
+      , [ Alcotest.test_case "analysis-only plain notes" `Quick
+            test_analysis_only_with_plain_notes_keeps_notes
+        ; Alcotest.test_case "empty notes" `Quick
+            test_analysis_only_with_empty_notes_returns_empty
+        ; Alcotest.test_case "placeholder filtering" `Quick
+            test_placeholder_notes_filtered
+        ; Alcotest.test_case "contract refs included" `Quick
+            test_contracted_task_includes_contract_refs
+        ; Alcotest.test_case "handoff plain string survives" `Quick
+            test_handoff_context_evidence_refs_survive_plain_string
+        ] )
+    ]

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -291,32 +291,42 @@ let test_submit_prepare_failure_keeps_task_in_progress () =
       in
       Alcotest.(check int) "no orphan request" 0 (List.length reqs))
 
-let test_submit_rejects_placeholder_evidence_before_request () =
+let test_submit_phase_e_no_substring_reject_at_transition () =
+  (* RFC-0109 Phase E (2026-05-27): the transition layer no longer
+     applies a substring classifier to reject submissions with
+     "placeholder-only" notes. Gating for contracted tasks lives in
+     [Cdal_evidence_gate.decide] (see test/test_cdal_evidence_gate.ml).
+     transition_task_r called directly forwards typed evidence refs as
+     observability metadata and lets the verifier protocol observe what
+     the keeper actually wrote. *)
   with_temp_config ~fsm_enabled:true (fun config ->
     let task_id = add_placeholder_evidence_task config in
     claim_and_start config "worker" task_id;
     let prepare_called = ref false in
+    let captured_refs = ref [] in
     let result =
       Coord.transition_task_r config ~agent_name:"worker"
         ~task_id ~action:Masc_domain.Submit_for_verification
         ~notes:"implementation complete"
         ~prepare_verification_request:
-          (fun ~task:_ ~assignee:_ ~verification_id:_ ~evidence_refs:_ ->
+          (fun ~task:_ ~assignee:_ ~verification_id:_ ~evidence_refs ->
              prepare_called := true;
+             captured_refs := evidence_refs;
              Ok ())
         ()
     in
     match result with
-    | Ok _ -> Alcotest.fail "submit should reject placeholder-only evidence"
     | Error e ->
-      Alcotest.(check bool) "prepare not called" false !prepare_called;
-      Alcotest.(check string) "status remains in_progress" "in_progress"
-        (status_string config task_id);
-      let msg = Masc_domain.show_masc_error e in
-      Alcotest.(check bool) "error mentions evidence" true
-        (Astring.String.is_infix
-           ~affix:"requires verification evidence"
-           msg))
+      Alcotest.fail ("submit should pass at transition layer in Phase E: "
+                     ^ Masc_domain.show_masc_error e)
+    | Ok _ ->
+      Alcotest.(check bool) "prepare called" true !prepare_called;
+      Alcotest.(check string) "status moved to awaiting_verification"
+        "awaiting_verification" (status_string config task_id);
+      Alcotest.(check bool) "contract spec strings carried as observability"
+        true
+        (List.mem "pr_url_or_artifact_ref" !captured_refs
+         && List.mem "completion_notes" !captured_refs))
 
 let test_submit_retry_records_request_created_backlog_orphan_policy () =
   with_temp_config ~fsm_enabled:true (fun config ->
@@ -472,9 +482,13 @@ let test_submit_uses_required_evidence_when_verify_refs_empty () =
      | Error e ->
        Alcotest.fail
          (Printf.sprintf "submit failed: %s" (Masc_domain.show_masc_error e)));
+    (* Phase E (2026-05-27): notes survives the typed concat alongside
+       the contract's required_evidence. Pre-Phase-E the substring
+       classifier would have dropped "implementation complete" — now
+       observability metadata reflects what the keeper actually wrote. *)
     Alcotest.(check (list string))
-      "required_evidence carried to verification refs"
-      ["artifact://coverage.json"]
+      "required_evidence + notes carried to verification refs"
+      ["artifact://coverage.json"; "implementation complete"]
       (Option.value ~default:[] !captured_refs))
 
 let test_submit_marks_conflict_triage_when_deliverable_claims_completion () =
@@ -1086,8 +1100,8 @@ let () =
         `Quick test_submit_for_verification_from_claimed_moves_to_awaiting;
       Alcotest.test_case "submit prepare failure keeps task in_progress"
         `Quick test_submit_prepare_failure_keeps_task_in_progress;
-      Alcotest.test_case "submit rejects placeholder evidence before request"
-        `Quick test_submit_rejects_placeholder_evidence_before_request;
+      Alcotest.test_case "phase E: transition layer no longer substring-rejects submit"
+        `Quick test_submit_phase_e_no_substring_reject_at_transition;
       Alcotest.test_case
         "submit retry records request-created backlog orphan policy"
         `Quick


### PR DESCRIPTION
## Summary

Closes #18810. Removes the legacy substring-classifier evidence gate that was still active in `coord_task_transitions.ml` despite RFC-0109 Phase D (#18715) introducing a typed `Cdal_evidence_gate` as the declared SSOT.

## Relationship to RFC-0109 Phase E-1 (#18816)

PR #18816 (merged 2026-05-27) opened an evidence-based fallback for **contracted** tasks (Phase D decision matrix row 5: `contract=Some + verdict=None`) at the typed `Cdal_evidence_gate` layer.

This PR (Phase E **closeout**) targets the *other* facet of the same N-of-M problem: the **transition-layer substring gate** that still rejected `Submit_for_verification` regardless of what Phase D decided. Symptom log (`coord_task_transitions.ml`-side error message: _"requires verification evidence: include pr_url..."_) was distinct from Phase E-1's `cdal_verdict_missing` error and is not fixed by #18816 alone. Both fixes are required; they are complementary, not redundant.

## Root cause (double-gate wiring)

Phase D's `lib/cdal_evidence_gate.mli` states: _"Replaces the old substring-classifier-only verification gate with a typed CDAL verdict consultation."_ Phase D runs in `lib/tool_task.ml:334` *before* `Coord.transition_task_r`. But Phase D's PR didn't remove the legacy gate from the transition path — `coord_task_transitions.ml:232-238` still called `Coord_task_verification.verification_submission_evidence_refs` and raised `InvalidState` on empty refs.

Result: analysis-only tasks (`task.contract = None`, Phase D decision matrix row 5 → `Pass`) were rejected at the second gate.

24h audit symptom:
```
[Keeper] keeper:sangsu tool_error: keeper_task_done —
  Invalid task state: submit_for_verification requires verification
  evidence: include pr_url for the draft PR, a PR # reference, or an
  explicit artifact/file/path/commit/branch reference in notes.
  failure_class: runtime_failure
```

Reproduced per-turn for multiple keepers (sangsu, albini, keeper-analyst-agent).

## Anti-pattern hits (CLAUDE.md)

- §1 hardcoded scattering — same substring helpers re-defined in `tool_task_completion_review.ml:95-110`
- §2 substring classifier preserved past its typed replacement
- §3 Phase D merge as N-of-M (legacy sunset deferred)

## Changes

1. `coord_task_transitions.ml` — remove empty-refs raise. evidence_refs still computed for `prepare_verification_request` (observability metadata only).
2. `coord_task_verification.{ml,mli}` — drop substring-classifier helpers. `is_placeholder_*` kept for trash filtering. `verification_submission_evidence_refs` simplified to typed concat.
3. `tool_task_completion_review.ml` — same sunset for duplicates. `pr_url_has_pull_ref` retained (used by `keeper_exec_task.ml:800` to validate typed `pr_url` field, distinct surface).
4. New `test/test_coord_task_verification_phase_e.ml` (5 cases) pins Phase E semantics.
5. `test/test_verification_fsm.ml` — two tests updated for Phase E semantics (gating moved to `Cdal_evidence_gate`; covered by `test/test_cdal_evidence_gate.ml`).

## Local verification

- New `test_coord_task_verification_phase_e` 5/5 PASS
- `test_verification_fsm` 26/26 PASS
- `test_cdal_evidence_gate` 10/10 PASS
- `test_coord_task_lifecycle` PASS
- `test_task_dispatch` 6/6 PASS
- `test_verify_handoff_tool` 1/1 PASS

### `test_tool_task_coverage` baseline diff (2026-05-27 main = 6ef9b2cb8)

| | Baseline (main) | Phase E PR | Delta |
|---|---:|---:|---|
| Total | 98 | 98 | — |
| Fails | 24 | 23 | **-1** |
| New regressions | — | — | **0** |
| Incidental fixes | — | — | **2** (`handle_done_redirects_to_verification_b`, `handle_transition_approve_enforces_stri`) |

Earlier draft of this PR body claimed ~11 new regressions; that was based on a stale memory note and not on a baseline diff. Corrected: zero new regressions, two incidental fixes. The remaining 22 baseline fails are unrelated and out of scope.

## Test plan

- [ ] Reviewer confirms baseline diff above (run `dune exec test/test_tool_task_coverage.exe` on `main` for comparison)
- [ ] Stage rollout: deploy → watch 24h audit dashboard for `submit_for_verification requires verification evidence` ERROR count → expect drop to 0

## RFC scope

Change touches `lib/coord/` only — outside `agent_delegation` RFC-required subsystems (credential / repo_manager / operator / dashboard credential / hooks / workflow). No RFC waiver needed under existing policy. This PR is itself an RFC-0109 Phase E closeout; long-form RFC body deferred to keep PR surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)