### PR TITLE
feat(rfc-0182): tool_shard + approval + persona + keeper + surface_audit (21 descriptors)

### DIFF
--- a/docs/rfc/RFC-0182-masc-descriptor-projection.md
+++ b/docs/rfc/RFC-0182-masc-descriptor-projection.md
@@ -250,6 +250,95 @@ The original §11 had three open architectural questions. The post-merge audit (
 - **Q2 (`channel_gate` rename)** — *resolved*: keep as-is. The audit (§2a) confirmed `channel_gate` is live with HTTP subsystem dispatch (`server_routes_http_routes_channel_gate.ml`). Renaming would force prompt/persona/config updates with no architectural benefit; the unconventional name is preserved for backward compatibility. Migration is to `Tool_spec.register` only.
 - **Q3 (`masc_set_param` visibility)** — *resolved*: keep `Hidden`. The audit confirmed live HTTP dispatch with admin auth (`server_routes_http_routes_activity.ml:with_tool_auth`). Visibility-level isolation reflects the original design intent (internal HTTP runtime-parameter mutation route). Registered as `Tool_spec.create ~visibility:Hidden ~required_permission:(Some CanAdmin)`.
 
+## 12. Phase 5 — Eio plumbing for remaining 10 tools (post-#18823)
+
+After PR #18823 (21 descriptors via dispatch-ref pattern, 83% non-portal coverage), the remaining 10 unprojected tools all require Eio resources (`sw`, `clock`, `proc_mgr`, `net`, `mcp_session_id`) that are not present in the current `Keeper_dispatch_ref.dispatch` / `Coord_dispatch_ref.dispatch` / `Persona_dispatch_ref.dispatch` signatures.
+
+### 12.1 Tools blocked on Eio context
+
+| Tool | Eio dependency | Backing function |
+|---|---|---|
+| `masc_keeper_up` | `start_keepalive ~sw ~clock` | `Keeper_keepalive.start_keepalive` (lib/keeper/keeper_keepalive.ml:451) |
+| `masc_keeper_msg` | `Keeper_msg_async.submit ~clock ~sw` + Turn dispatch | `Tool_keeper_ops.handle_keeper_msg` (lib/tool_keeper_ops.ml:438) |
+| `masc_keeper_sandbox_status` | `load_or_materialize_boot_meta` (clock-aware) | `Tool_keeper.handle_keeper_sandbox_status` |
+| `masc_keeper_create_from_persona` | `execute_keeper_up` → Turn lifecycle | `Tool_keeper_ops.handle_keeper_create_from_persona` |
+| `masc_persona_generate` | LLM call via Eio fiber | `Keeper_persona_authoring.handle_persona_generate` (line 812) |
+| `masc_operator_snapshot` | `Operator_control.context` (sw/clock/proc_mgr/net/mcp_session_id) | `Tool_operator.dispatch` |
+| `masc_operator_digest` | same | same |
+| `masc_operator_action` | same | same |
+| `masc_operator_confirm` | same | same |
+| `masc_operator_judgment_write` | same | same |
+
+### 12.2 Decision: signature extension OR ctx record extension
+
+**Option A — Per-ref signature extension** (incremental):
+- Extend `Keeper_dispatch_ref.dispatch` from `(~config ~agent_name ~name ~args)` to also accept `~sw ~clock ~proc_mgr ~net ~mcp_session_id`.
+- Create `Operator_dispatch_ref` mirroring the full operator ctx.
+- Existing registrations accept-and-ignore the new params.
+- Pro: localized per-cluster.  Con: each new field forces every existing registration to accept-and-ignore — N×M edit pressure.
+
+**Option B — `Agent_tool_runtime.ctx` Eio extension** (recommended):
+- Add fields to `Agent_tool_runtime.context`:
+  ```ocaml
+  ; sw : Eio.Switch.t
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t
+  ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
+  ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
+  ; mcp_session_id : string option
+  ```
+- Caller (`Keeper_exec_tools.execute_keeper_tool_call_with_outcome`) constructs the full ctx from the existing keeper Eio context.
+- `Agent_tool_in_process_runtime.handle_masc_keeper` (and new `handle_masc_operator`) receive these via the existing handler signature pattern: `~config ~meta ~sw ~clock ~proc_mgr ~net ~name ~args`.
+- Cycle-safety preserved: `Agent_tool_runtime.ctx` already imports Eio types — adding fields adds no new module deps.
+- Pro: one structural change unlocks 10 tools.  Con: signature ripple across all 11 handler dispatch arms in `Agent_tool_runtime.handle_in_process`.
+
+**Recommendation: Option B.**  Single ctx extension, hits OCaml record-update sites once.  Persona_generate and operator cluster naturally use this without dispatch-ref indirection (their backing modules are in lib/ late enough to import directly).
+
+### 12.3 Per-cluster wiring after ctx extension
+
+| Cluster | Mechanism | Notes |
+|---|---|---|
+| `masc_keeper_{up,msg,sandbox_status,create_from_persona}` | Keeper_dispatch_ref signature extension (Tool_keeper-side registration) | Same dispatch-ref pattern; ref signature adds `~sw ~clock ~proc_mgr ~net` |
+| `masc_persona_generate` | Persona_dispatch_ref signature extension OR direct extraction of generate body to ctx-free | LLM call via Eio fiber — natural choice is dispatch-ref since LLM provider sits late |
+| `masc_operator_*` (5) | New `Operator_dispatch_ref` OR direct `Tool_operator.dispatch` import | Tool_operator is in lib/, sits LATE.  Direct import from Agent_tool_in_process_runtime closes cycle (Tool_operator → Operator_control → Keeper_runtime → ...).  Use dispatch-ref. |
+
+### 12.4 Estimated PR sizes
+
+| Phase 5 sub-PR | LoC estimate | Files | Risk |
+|---|---|---|---|
+| PR-A: ctx Eio extension | ~50 | 2 (agent_tool_runtime.ml/.mli + Keeper_exec_tools caller) | low (compile-error-driven ripple) |
+| PR-B: keeper Eio cluster (4 tools) | ~150 | 4 (Keeper_dispatch_ref sig extend + Tool_keeper register + handler + descriptor) | medium |
+| PR-C: persona_generate | ~80 | 3 (Persona_dispatch_ref extend + Tool_keeper register + descriptor) | medium |
+| PR-D: operator cluster (5 tools) | ~200 | 4 (Operator_dispatch_ref new + Tool_operator register + handler + 5 descriptors) | medium |
+
+Each sub-PR independently mergeable, gated by PR-A.
+
+### 12.5 Coverage target
+
+| Stage | Active routing |
+|---|---|
+| Phase 5 base (PR #18823 merged) | 87/105 (83%) |
+| After PR-A + PR-B | 91/105 (87%) |
+| After PR-C | 92/105 (88%) |
+| After PR-D | 97/105 (92%) |
+| Remaining 8 | 6 MCP-surface only + 2 public_descriptors (architecturally not internal-callable) |
+
+**Effective ceiling: ~92%** without RFC-0183 (portal trio).  6 MCP-surface tools (broadcast/join/leave/messages/start/who) are by design only callable from the MCP transport surface, not from inside a keeper's tool dispatch loop.  2 public_descriptors (web_search/web_fetch) are already projected via the LLM-native surface (RFC-0064).
+
+### 12.6 Audit findings record (Phase 5 prereqs)
+
+From the 17-iter /loop session that built PR #18823:
+
+1. `Eio_guard.with_mutex` (Eio.Mutex.create) — pure inside [`Keeper_status_detail`](../../lib/keeper/keeper_status_detail.ml).  Did NOT block status projection.
+2. `Keeper_persona_authoring → Keeper_turn_driver` transitive cycle (line 880) — resolved via [`Persona_dispatch_ref`](../../lib/persona_dispatch_ref.ml).
+3. `Keeper_turn_up.handle_keeper_up` surface ctx.config-only BUT `start_keepalive` transitively requires Eio.  Cannot ctx-free.
+4. `handle_keeper_repair` carried `ignore (ctx.sw, ctx.clock, ctx.config)` warning-suppression scaffolding — was phantom dependency, real body returns stub.
+
+### 12.7 Out of Phase 5 scope
+
+- RFC-0183 (portal trio): protocol-level dispatch design.
+- `masc_set_param` (HTTP route only — not internal-callable).
+- `masc_mcp_session` (Tool_inline_dispatch with `load/save_mcp_sessions` callbacks — caller-injected closures, not ctx Eio fields).
+
 ---
 
 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -16,7 +16,7 @@ the categorization roadmap. Newly-added typed getters in
 
 **Total**: 381 unique knobs across 10 modules.
 
-**Typed getter classification**: 26/234 tagged (`operator`: 26, `algorithm`: 0, `unclassified`: 208).
+**Typed getter classification**: 28/234 tagged (`operator`: 28, `algorithm`: 0, `unclassified`: 206).
 
 ## Env_config_core (29 knobs; typed classification 0/7)
 
@@ -56,7 +56,7 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_EXEC_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 151 |  |
+| `MASC_EXEC_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 147 |  |
 
 ## Env_config_governance (35 knobs; typed classification 0/25)
 
@@ -103,11 +103,11 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 226 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CASCADE_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 745 | {1 Cascade Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Cascade_saturation_signal.t] emission alon... |
-| `MASC_CASCADE_TIER_ADMISSION_ENABLED` | feature_flag | n/a | n/a | 757 | {1 Cascade Tier Admission (RFC-0153 Phase B.2)} Runtime kill switch for per-tier inflight admission in the main keepe... |
-| `MASC_CASCADE_TIER_WAIT_ENABLED` | feature_flag | n/a | n/a | 762 |  |
-| `MASC_CASCADE_TIER_WAIT_MAX_RETRIES` | typed:string | unclassified | unclassified | 768 |  |
-| `MASC_CASCADE_TIER_WAIT_TIMEOUT_S` | typed:float | unclassified | unclassified | 765 |  |
+| `MASC_CASCADE_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 743 | {1 Cascade Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Cascade_saturation_signal.t] emission from... |
+| `MASC_CASCADE_TIER_ADMISSION_ENABLED` | feature_flag | n/a | n/a | 755 | {1 Cascade Tier Admission (RFC-0153 Phase B.2)} Runtime kill switch for per-tier inflight admission in the main keepe... |
+| `MASC_CASCADE_TIER_WAIT_ENABLED` | feature_flag | n/a | n/a | 760 |  |
+| `MASC_CASCADE_TIER_WAIT_MAX_RETRIES` | typed:string | unclassified | unclassified | 766 |  |
+| `MASC_CASCADE_TIER_WAIT_TIMEOUT_S` | typed:float | unclassified | unclassified | 763 |  |
 | `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 670 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
 | `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 705 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
 | `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 706 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
@@ -145,7 +145,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 801 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
+| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 799 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
 | `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 510 | Stdout-idle timeout for CLI subprocess transports (Provider_c CLI today; Claude Code / Provider_f CLI / Codex CLI nee... |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 163 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 182 | Enable keeper debug logging. Default: false. |
@@ -347,13 +347,13 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_ZOMBIE_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 14 | Cleanup loop interval (seconds) |
 | `MASC_ZOMBIE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 6 | Threshold for considering a resource as zombie (seconds) |
 
-## Env_config_sandbox (18 knobs; typed classification 0/17)
+## Env_config_sandbox (18 knobs; typed classification 2/17)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_KEEPER_DOCKER_CONTAINER` | typed:string | unclassified | unclassified | 91 |  |
+| `MASC_KEEPER_DOCKER_CONTAINER` | typed:string | Sandbox | operator | 93 | @category Sandbox @ops_class operator |
 | `MASC_KEEPER_DOCKER_PLAYGROUND` | typed:bool | unclassified | unclassified | 88 |  |
-| `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT` | typed:string | unclassified | unclassified | 95 |  |
+| `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT` | typed:string | Sandbox | operator | 99 | @category Sandbox @ops_class operator |
 | `MASC_KEEPER_SANDBOX_CLEANUP_ENABLED` | typed:bool | unclassified | unclassified | 59 |  |
 | `MASC_KEEPER_SANDBOX_CLEANUP_INTERVAL_SEC` | typed:int | unclassified | unclassified | 69 |  |
 | `MASC_KEEPER_SANDBOX_CLEANUP_STALE_AFTER_SEC` | typed:int | unclassified | unclassified | 64 |  |
@@ -362,13 +362,13 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_SANDBOX_MEMORY` | typed:string | unclassified | unclassified | 27 |  |
 | `MASC_KEEPER_SANDBOX_NOFILE_LIMIT` | typed:int | unclassified | unclassified | 24 |  |
 | `MASC_KEEPER_SANDBOX_PIDS_LIMIT` | typed:int | unclassified | unclassified | 21 |  |
-| `MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED` | typed:bool | unclassified | unclassified | 104 |  |
+| `MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED` | typed:bool | unclassified | unclassified | 108 |  |
 | `MASC_KEEPER_SANDBOX_RELAX_FS` | typed:bool | unclassified | unclassified | 33 |  |
 | `MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS` | typed:bool | unclassified | unclassified | 47 |  |
 | `MASC_KEEPER_SANDBOX_REQUIRE_USERNS` | typed:bool | unclassified | unclassified | 50 |  |
 | `MASC_KEEPER_SANDBOX_SECCOMP_PROFILE` | typed:string | unclassified | unclassified | 44 |  |
 | `MASC_KEEPER_SANDBOX_TMPFS_SIZE` | typed:string | unclassified | unclassified | 30 |  |
-| `MASC_KEEPER_SHELL_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 186 |  |
+| `MASC_KEEPER_SHELL_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 190 |  |
 
 ## Env_config_snapshot (74 knobs; typed classification 0/0)
 

--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -54,6 +54,11 @@ type runtime_handler =
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
   | Tool_masc_local_runtime_dispatch
+  | Tool_masc_tool_shard_dispatch
+  | Tool_masc_approval_dispatch
+  | Tool_masc_persona_dispatch
+  | Tool_masc_keeper_dispatch
+  | Tool_masc_surface_audit
 
 type policy =
   { visibility : Tool_catalog.visibility
@@ -138,6 +143,11 @@ let runtime_handler_to_string = function
   | Tool_masc_control_dispatch -> "tool_masc_control_dispatch"
   | Tool_masc_agent_timeline_dispatch -> "tool_masc_agent_timeline_dispatch"
   | Tool_masc_local_runtime_dispatch -> "tool_masc_local_runtime_dispatch"
+  | Tool_masc_tool_shard_dispatch -> "tool_masc_tool_shard_dispatch"
+  | Tool_masc_approval_dispatch -> "tool_masc_approval_dispatch"
+  | Tool_masc_persona_dispatch -> "tool_masc_persona_dispatch"
+  | Tool_masc_keeper_dispatch -> "tool_masc_keeper_dispatch"
+  | Tool_masc_surface_audit -> "tool_masc_surface_audit"
 ;;
 
 let policy ?(visibility = Tool_catalog.Default) ?readonly ?effect_domain
@@ -729,6 +739,42 @@ let masc_local_runtime_descriptor id name description ~readonly =
     ~readonly
 ;;
 
+let masc_tool_shard_descriptor id name description ~readonly =
+  cluster_descriptor
+    ~id:("masc.tool_shard." ^ id)
+    ~name
+    ~description
+    ~handler:Tool_masc_tool_shard_dispatch
+    ~readonly
+;;
+
+let masc_approval_descriptor id name description ~readonly =
+  cluster_descriptor
+    ~id:("masc.approval." ^ id)
+    ~name
+    ~description
+    ~handler:Tool_masc_approval_dispatch
+    ~readonly
+;;
+
+let masc_persona_descriptor id name description ~readonly =
+  cluster_descriptor
+    ~id:("masc.persona." ^ id)
+    ~name
+    ~description
+    ~handler:Tool_masc_persona_dispatch
+    ~readonly
+;;
+
+let masc_keeper_descriptor id name description ~readonly =
+  cluster_descriptor
+    ~id:("masc.keeper." ^ id)
+    ~name
+    ~description
+    ~handler:Tool_masc_keeper_dispatch
+    ~readonly
+;;
+
 let internal_descriptors : t list =
   [ (* ── time / silence / catalog (RFC-0179 PR-2 + PR-3) ────────── *)
     in_process_descriptor
@@ -1051,6 +1097,62 @@ let internal_descriptors : t list =
       "Verify provider/runtime contract for swarm / benchmark." ~readonly:true
   ; masc_local_runtime_descriptor "ollama_probe" "masc_runtime_ollama_probe"
       "Probe Ollama runtime endpoint for diagnostics." ~readonly:true
+  (* ── RFC-0182 §3.1 — masc_tool_shard_* cluster (3 entries) ───── *)
+  ; masc_tool_shard_descriptor "list" "masc_tool_list"
+      "List installed tool shards plus the active set for an agent." ~readonly:true
+  ; masc_tool_shard_descriptor "grant" "masc_tool_grant"
+      "Grant an agent a named tool shard." ~readonly:false
+  ; masc_tool_shard_descriptor "revoke" "masc_tool_revoke"
+      "Revoke a previously-granted tool shard from an agent." ~readonly:false
+  (* ── RFC-0182 §3.1 — masc_approval_* cluster (3 entries) ─────── *)
+  ; masc_approval_descriptor "pending" "masc_approval_pending"
+      "List pending operator approval requests." ~readonly:true
+  ; masc_approval_descriptor "get" "masc_approval_get"
+      "Read a single pending approval by id." ~readonly:true
+  ; masc_approval_descriptor "resolve" "masc_approval_resolve"
+      "Resolve a pending approval (approve / reject)." ~readonly:false
+  (* ── RFC-0182 §3.1 — masc_persona_* cluster (3 entries) ──────── *)
+  (* masc_persona_generate is omitted — its handler uses the keeper
+     Eio context and is gated on Phase 5 Eio plumbing scope. *)
+  ; masc_persona_descriptor "list" "masc_persona_list"
+      "List configured personas plus summary metadata." ~readonly:true
+  ; masc_persona_descriptor "schema" "masc_persona_schema"
+      "Read the persona JSON schema (optionally with examples)." ~readonly:true
+  ; masc_persona_descriptor "save" "masc_persona_save"
+      "Persist a persona profile JSON (supports overwrite/dry-run)." ~readonly:false
+  (* ── RFC-0182 §3.1 — masc_keeper cluster (1 entry today) ──── *)
+  (* Other masc_keeper_ tools (status, msg, clear, compact, repair,
+     sandbox lifecycle) use the keeper Eio context and are gated on
+     Phase 5 Eio plumbing scope. *)
+  ; masc_keeper_descriptor "list" "masc_keeper_list"
+      "List configured keepers with optional detailed metadata." ~readonly:true
+  ; masc_keeper_descriptor "msg_result" "masc_keeper_msg_result"
+      "Poll an async keeper_msg dispatch by request_id." ~readonly:true
+  ; masc_keeper_descriptor "compact" "masc_keeper_compact"
+      "Run operator-requested context compaction on a keeper." ~readonly:false
+  ; masc_keeper_descriptor "clear" "masc_keeper_clear"
+      "Last-resort context clear (drops conversation, requires reason)." ~readonly:false
+  ; masc_keeper_descriptor "sandbox_start" "masc_keeper_sandbox_start"
+      "Start the managed sandbox container for a keeper." ~readonly:false
+  ; masc_keeper_descriptor "sandbox_stop" "masc_keeper_sandbox_stop"
+      "Stop the managed sandbox container(s) for a keeper or fleet." ~readonly:false
+  ; masc_keeper_descriptor "reset" "masc_keeper_reset"
+      "Reset a keeper's runtime state (usage counters, last_model_used)." ~readonly:false
+  ; masc_keeper_descriptor "persona_audit" "masc_keeper_persona_audit"
+      "Audit configured keepers vs personas (optional goal repair pass)." ~readonly:false
+  ; masc_keeper_descriptor "status" "masc_keeper_status"
+      "Detailed single-keeper status (defaults to self when name is empty)." ~readonly:true
+  ; masc_keeper_descriptor "repair" "masc_keeper_repair"
+      "Validate keeper repair inputs (execution path currently unsupported)." ~readonly:false
+  ; masc_keeper_descriptor "down" "masc_keeper_down"
+      "Stop keeper keepalive, optionally remove meta and session directory." ~readonly:false
+  (* ── RFC-0182 §3.1 — masc_surface_audit singleton ────────────── *)
+  ; cluster_descriptor
+      ~id:"masc.surface.audit"
+      ~name:"masc_surface_audit"
+      ~description:"Read dashboard surface readiness snapshot (optionally for a single surface)."
+      ~handler:Tool_masc_surface_audit
+      ~readonly:true
   ]
   @ masc_board_descriptors
 ;;

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -59,6 +59,11 @@ type runtime_handler =
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
   | Tool_masc_local_runtime_dispatch
+  | Tool_masc_tool_shard_dispatch
+  | Tool_masc_approval_dispatch
+  | Tool_masc_persona_dispatch
+  | Tool_masc_keeper_dispatch
+  | Tool_masc_surface_audit
 
 type policy =
   { visibility : Tool_catalog.visibility

--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -197,6 +197,167 @@ let handle_masc_agent_timeline ~(config : Coord.config) ~(meta : keeper_meta) ~n
   Tool_agent_timeline.dispatch ctx ~name ~args |> dispatch_option_to_string ~name
 ;;
 
+(* RFC-0182 §3.1 — masc_tool_shard cluster.  [Tool_shard.execute]
+   returns the older [(bool * Yojson.Safe.t)] tuple (predates RFC-0189
+   typed-result migration), same shape as Tool_local_runtime.  Tool_shard
+   has no Keeper/Coord deps so no cycle concern.
+
+   TEL-OK: descriptor projection — telemetry lives in [Tool_shard.execute]
+   and the upstream [Keeper_exec_tools] dispatch wrapper. *)
+let handle_masc_tool_shard ~name ~args =
+  let ok, payload = Tool_shard.execute name args in
+  if ok
+  then Yojson.Safe.to_string payload
+  else Yojson.Safe.to_string (`Assoc [ "error", payload ])
+;;
+
+(* RFC-0182 §3.1 — masc_surface_audit singleton.  Body is pure
+   ([Dashboard_surface_readiness.json ?surface_id ()]) with no ctx
+   requirements; direct import is cycle-safe.
+
+   TEL-OK: read-only dashboard surface snapshot, telemetry lives in
+   [Dashboard_surface_readiness]. *)
+let handle_masc_surface_audit ~args =
+  let surface_id = Safe_ops.json_string_opt "surface_id" args in
+  Yojson.Safe.to_string (Dashboard_surface_readiness.json ?surface_id ())
+;;
+
+(* RFC-0182 §3.1 — masc_keeper cluster.  [Tool_keeper] lives in lib/
+   (late) but exposes keeper coordination tools.  A direct import here
+   closes a cycle, so we dispatch through [Keeper_dispatch_ref].  Today
+   only [masc_keeper_list] is registered; remaining keeper tools depend
+   on the Eio context and await Phase 5 Eio plumbing.
+
+   TEL-OK: descriptor projection — telemetry lives in the underlying
+   [Tool_keeper] / [Tool_keeper_ops] / [Keeper_status_detail] handlers
+   that the registered ref delegates to. *)
+let handle_masc_keeper ~(config : Coord.config) ~(meta : keeper_meta) ~name ~args =
+  let tuple =
+    !Keeper_dispatch_ref.dispatch
+      ~config
+      ~agent_name:meta.agent_name
+      ~name
+      ~args
+  in
+  match tuple with
+  | Some (true, body) -> body
+  | Some (false, body) ->
+    Yojson.Safe.to_string (`Assoc [ "error", `String body ])
+  | None ->
+    Yojson.Safe.to_string
+      (`Assoc
+         [ "error"
+         , `String
+             (Printf.sprintf
+                "descriptor projection: masc_keeper cluster did not \
+                 recognise %S (Keeper_dispatch_ref not registered, or \
+                 tool gated on Phase 5 Eio plumbing)"
+                name)
+         ])
+;;
+
+(* RFC-0182 §3.1 — masc_persona cluster.  [Keeper_persona] /
+   [Keeper_persona_authoring] transitively pull in [Keeper_turn_driver],
+   which closes a cycle if imported here.  Resolution: dispatch
+   through [Persona_dispatch_ref].  Tool_keeper (lib/, late) registers
+   the ctx-free entry points at module load.
+
+   TEL-OK: descriptor projection — telemetry lives in [Keeper_persona] /
+   [Keeper_persona_authoring] backing handlers. *)
+let handle_masc_persona ~name ~args =
+  let tuple = !Persona_dispatch_ref.dispatch ~name ~args in
+  match tuple with
+  | Some (true, body) -> body
+  | Some (false, body) ->
+    Yojson.Safe.to_string (`Assoc [ "error", `String body ])
+  | None ->
+    Yojson.Safe.to_string
+      (`Assoc
+         [ "error"
+         , `String
+             (Printf.sprintf
+                "descriptor projection: masc_persona cluster did not \
+                 recognise %S (Persona_dispatch_ref not registered?)"
+                name)
+         ])
+;;
+
+(* RFC-0182 §3.1 — masc_approval cluster.  Ports the same dispatch logic
+   used by [Tool_inline_dispatch] for [masc_approval_pending/get/resolve]
+   so keepers can reach the approval queue via descriptor projection.
+
+   Cycle safety: [Keeper_approval_queue] is a lib/keeper module with no
+   reverse deps on [Agent_tool_*].  Importing here introduces no
+   late-dependency cycle.
+
+   TEL-OK: descriptor projection — telemetry lives in
+   [Keeper_approval_queue] (queue mutation events + Prometheus counters
+   in the resolve path). *)
+let handle_masc_approval ~name ~args =
+  match name with
+  | "masc_approval_pending" ->
+    Yojson.Safe.to_string (Keeper_approval_queue.list_pending_json ())
+  | "masc_approval_get" ->
+    let id = Safe_ops.json_string ~default:"" "id" args |> String.trim in
+    if String.equal id ""
+    then Yojson.Safe.to_string (`Assoc [ "error", `String "id is required" ])
+    else (
+      match Keeper_approval_queue.get_pending_json ~id with
+      | Some json -> Yojson.Safe.to_string json
+      | None ->
+        Yojson.Safe.to_string
+          (`Assoc
+             [ "error"
+             , `String
+                 (Printf.sprintf
+                    "approval %s is no longer pending or was not found. \
+                     Refresh with masc_approval_pending before \
+                     approving/rejecting."
+                    id)
+             ]))
+  | "masc_approval_resolve" ->
+    let id = Safe_ops.json_string ~default:"" "id" args |> String.trim in
+    let decision_str = Safe_ops.json_string ~default:"approve" "decision" args in
+    if String.equal id ""
+    then Yojson.Safe.to_string (`Assoc [ "error", `String "id is required" ])
+    else (
+      let decision =
+        match String.lowercase_ascii decision_str with
+        | "approve" -> Agent_sdk.Hooks.Approve
+        | "reject" ->
+          let reason =
+            Safe_ops.json_string ~default:"operator rejected" "reason" args
+          in
+          Agent_sdk.Hooks.Reject reason
+        | _ ->
+          Agent_sdk.Hooks.Reject
+            (Printf.sprintf "unknown decision: %s" decision_str)
+      in
+      match Keeper_approval_queue.resolve ~id ~decision with
+      | Ok () ->
+        Yojson.Safe.to_string
+          (`Assoc
+             [ "resolved", `String id
+             ; "decision", `String decision_str
+             ])
+      | Error err ->
+        Yojson.Safe.to_string
+          (`Assoc
+             [ "error"
+             , `String (Keeper_approval_queue.resolve_error_to_string err)
+             ]))
+  | other ->
+    Yojson.Safe.to_string
+      (`Assoc
+         [ "error"
+         , `String
+             (Printf.sprintf
+                "descriptor projection: masc_approval cluster did not \
+                 recognise %S"
+                other)
+         ])
+;;
+
 let handle_masc_local_runtime ~name ~args =
   (* Tool_local_runtime.dispatch is polymorphic in ctx (handlers ignore it).
      The result type is the older [bool * string] tuple from

--- a/lib/keeper/agent_tool_in_process_runtime.mli
+++ b/lib/keeper/agent_tool_in_process_runtime.mli
@@ -181,3 +181,47 @@ val handle_masc_local_runtime
   :  name:string
   -> args:Yojson.Safe.t
   -> string
+
+(** RFC-0182 §3.1 — [handle_masc_tool_shard] is the descriptor-projection
+    cluster handler for [masc_tool_list] / [masc_tool_grant] /
+    [masc_tool_revoke].  [Tool_shard.execute] is pure (no Keeper/Coord
+    deps) and returns a [(bool * Yojson.Safe.t)] tuple. *)
+val handle_masc_tool_shard
+  :  name:string
+  -> args:Yojson.Safe.t
+  -> string
+
+(** RFC-0182 §3.1 — [handle_masc_approval] is the descriptor-projection
+    cluster handler for [masc_approval_pending] / [masc_approval_get] /
+    [masc_approval_resolve].  Reads from [Keeper_approval_queue]
+    directly; mirrors the logic in [Tool_inline_dispatch]. *)
+val handle_masc_approval
+  :  name:string
+  -> args:Yojson.Safe.t
+  -> string
+
+(** RFC-0182 §3.1 — [handle_masc_persona] is the descriptor-projection
+    cluster handler for [masc_persona_list] / [masc_persona_schema] /
+    [masc_persona_save].  Dispatches via [Persona_dispatch_ref] —
+    [Tool_keeper] registers the ctx-free persona handlers at module
+    load to avoid a static cycle through [Keeper_turn_driver]. *)
+val handle_masc_persona
+  :  name:string
+  -> args:Yojson.Safe.t
+  -> string
+
+(** RFC-0182 §3.1 — [handle_masc_keeper] is the descriptor-projection
+    cluster handler for the [masc_keeper_*] ctx-free tool surface.
+    Dispatches via [Keeper_dispatch_ref] registered by [Tool_keeper] at
+    module load.  Receives [meta] so callers like [masc_keeper_status]
+    can resolve the "self" target when the [name] argument is empty. *)
+val handle_masc_keeper
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> name:string
+  -> args:Yojson.Safe.t
+  -> string
+
+(** RFC-0182 §3.1 — [masc_surface_audit] singleton.  Pure pass-through
+    to [Dashboard_surface_readiness.json]. *)
+val handle_masc_surface_audit : args:Yojson.Safe.t -> string

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -59,7 +59,12 @@ let handle_filesystem ctx descriptor args =
   | Tool_masc_misc_dispatch
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
-  | Tool_masc_local_runtime_dispatch -> None
+  | Tool_masc_local_runtime_dispatch
+  | Tool_masc_tool_shard_dispatch
+  | Tool_masc_approval_dispatch
+  | Tool_masc_persona_dispatch
+  | Tool_masc_keeper_dispatch
+  | Tool_masc_surface_audit -> None
 ;;
 
 (* Dispatch asymmetry: Filesystem, Remote_mcp, and In_process all go through
@@ -119,7 +124,12 @@ let handle_shell_ir ctx descriptor args =
   | Tool_masc_misc_dispatch
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
-  | Tool_masc_local_runtime_dispatch -> None
+  | Tool_masc_local_runtime_dispatch
+  | Tool_masc_tool_shard_dispatch
+  | Tool_masc_approval_dispatch
+  | Tool_masc_persona_dispatch
+  | Tool_masc_keeper_dispatch
+  | Tool_masc_surface_audit -> None
 ;;
 
 let handle_remote_mcp ctx descriptor args =
@@ -166,7 +176,12 @@ let handle_remote_mcp ctx descriptor args =
   | Tool_masc_misc_dispatch
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
-  | Tool_masc_local_runtime_dispatch -> None
+  | Tool_masc_local_runtime_dispatch
+  | Tool_masc_tool_shard_dispatch
+  | Tool_masc_approval_dispatch
+  | Tool_masc_persona_dispatch
+  | Tool_masc_keeper_dispatch
+  | Tool_masc_surface_audit -> None
 ;;
 
 let handle_in_process ctx descriptor args =
@@ -286,6 +301,21 @@ let handle_in_process ctx descriptor args =
          ~args)
   | Tool_masc_local_runtime_dispatch ->
     Some (Agent_tool_in_process_runtime.handle_masc_local_runtime ~name ~args)
+  | Tool_masc_tool_shard_dispatch ->
+    Some (Agent_tool_in_process_runtime.handle_masc_tool_shard ~name ~args)
+  | Tool_masc_approval_dispatch ->
+    Some (Agent_tool_in_process_runtime.handle_masc_approval ~name ~args)
+  | Tool_masc_persona_dispatch ->
+    Some (Agent_tool_in_process_runtime.handle_masc_persona ~name ~args)
+  | Tool_masc_keeper_dispatch ->
+    Some
+      (Agent_tool_in_process_runtime.handle_masc_keeper
+         ~config:ctx.config
+         ~meta:ctx.meta
+         ~name
+         ~args)
+  | Tool_masc_surface_audit ->
+    Some (Agent_tool_in_process_runtime.handle_masc_surface_audit ~args)
   | Tool_execute
   | Tool_workspace_inspect
   | Tool_read_file

--- a/lib/keeper/keeper_persona.ml
+++ b/lib/keeper/keeper_persona.ml
@@ -8,7 +8,13 @@ module Turn = Keeper_turn
 module Authoring = Keeper_persona_authoring
 type tool_result = Keeper_types.tool_result
 
-let handle_persona_list _ctx args : tool_result =
+(* RFC-0182 §3.1 — ctx-free body shared with the persona dispatch ref
+   path.  Keeper_persona / Keeper_persona_authoring transitively touch
+   Keeper_turn_driver, so static import from
+   Agent_tool_in_process_runtime closes a cycle.  These [_handler]
+   entry points let Tool_keeper register the persona surface into
+   Persona_dispatch_ref at module load. *)
+let persona_list_handler args : tool_result =
   let detailed = get_bool args "detailed" true in
   let personas = list_persona_summaries () in
   let payload =
@@ -26,11 +32,18 @@ let handle_persona_list _ctx args : tool_result =
   in
   (true, Yojson.Safe.to_string json)
 
+(* TEL-OK: thin wrapper — telemetry stays in [persona_list_handler]. *)
+let handle_persona_list _ctx args : tool_result = persona_list_handler args
+
 let handle_persona_schema = Authoring.handle_persona_schema
+let persona_schema_handler args : tool_result =
+  Authoring.handle_persona_schema_no_ctx args
 
 let handle_persona_generate = Authoring.handle_persona_generate
 
 let handle_persona_save = Authoring.handle_persona_save
+let persona_save_handler args : tool_result =
+  Authoring.handle_persona_save_no_ctx args
 
 let handle_keeper_create_from_persona ctx args : tool_result =
   match resolved_keeper_args_from_persona args with

--- a/lib/keeper/keeper_persona.mli
+++ b/lib/keeper/keeper_persona.mli
@@ -14,6 +14,15 @@ val handle_persona_generate :
 val handle_persona_save :
   _ Keeper_types.context -> Yojson.Safe.t -> tool_result
 
+(** RFC-0182 §3.1 — ctx-free entry points for the persona dispatch
+    ref.  [Tool_keeper] registers these into [Persona_dispatch_ref]
+    at module load so [Agent_tool_in_process_runtime] (compiled
+    early) can reach the persona surface without a static import that
+    closes a cycle through [Keeper_turn_driver]. *)
+val persona_list_handler : Yojson.Safe.t -> tool_result
+val persona_schema_handler : Yojson.Safe.t -> tool_result
+val persona_save_handler : Yojson.Safe.t -> tool_result
+
 (** Create a keeper from a persona definition. Honors a [dry_run] arg
     that returns a preview without invoking [handle_keeper_up]. Applies
     per-persona shard configuration after successful creation. *)

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -344,10 +344,13 @@ let schema_json ?(include_examples = false) () =
      @ examples)
 ;;
 
-let handle_persona_schema _ctx args =
+(* RFC-0182 §3.1 — ctx-free body shared with Persona_dispatch_ref path. *)
+let handle_persona_schema_no_ctx args =
   let include_examples = get_bool args "include_examples" false in
   true, Yojson.Safe.to_string (schema_json ~include_examples ())
 ;;
+
+let handle_persona_schema _ctx args = handle_persona_schema_no_ctx args
 
 let validate_unknown_keeper_fields keeper_json =
   assoc_keys keeper_json
@@ -618,7 +621,8 @@ let save_result_to_json ?(dry_run = false) result =
     ]
 ;;
 
-let handle_persona_save _ctx args =
+(* RFC-0182 §3.1 — ctx-free body shared with Persona_dispatch_ref path. *)
+let handle_persona_save_no_ctx args =
   let handle = get_string args "handle" "" |> String.trim in
   let overwrite = get_bool args "overwrite" false in
   let dry_run = get_bool args "dry_run" false in
@@ -629,6 +633,8 @@ let handle_persona_save _ctx args =
      | Error msg -> false, error_response_typed ~code:Validation_error msg
      | Ok result -> true, Yojson.Safe.to_string (save_result_to_json ~dry_run result))
 ;;
+
+let handle_persona_save _ctx args = handle_persona_save_no_ctx args
 
 let handle_from_concept = Keeper_persona_authoring_slug.handle_from_concept
 

--- a/lib/keeper/keeper_persona_authoring.mli
+++ b/lib/keeper/keeper_persona_authoring.mli
@@ -67,6 +67,9 @@ val schema_json : ?include_examples:bool -> unit -> Yojson.Safe.t
 val handle_persona_schema :
   _ Keeper_types.context -> Yojson.Safe.t -> bool * string
 
+(** RFC-0182 §3.1 — ctx-free body for Persona_dispatch_ref path. *)
+val handle_persona_schema_no_ctx : Yojson.Safe.t -> bool * string
+
 (** {1 Persona save / normalize} *)
 
 (** Normalize a raw profile JSON for [handle]; rejects invalid
@@ -96,6 +99,9 @@ val save_result_to_json :
 (** Tool-handler entry for [keeper_persona_save]. *)
 val handle_persona_save :
   _ Keeper_types.context -> Yojson.Safe.t -> bool * string
+
+(** RFC-0182 §3.1 — ctx-free body for Persona_dispatch_ref path. *)
+val handle_persona_save_no_ctx : Yojson.Safe.t -> bool * string
 
 (** {1 Persona generation (LLM-assisted)} *)
 

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -111,10 +111,14 @@ let cached_docker_preflight_status_json ~timeout_sec =
           docker_preflight_status_cache := Some { key; observed_at = now; value };
           value)
 
-let effective_status_name (ctx : _ context) args =
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let effective_status_name_config ~(agent_name : string) args =
   match normalize_status_name (get_string args "name" "") with
-  | "" -> normalize_status_name ctx.agent_name
+  | "" -> normalize_status_name agent_name
   | value -> value
+
+let effective_status_name (ctx : _ context) args =
+  effective_status_name_config ~agent_name:ctx.agent_name args
 
 type tail_order =
   | Oldest_first
@@ -145,8 +149,9 @@ let apply_tail_order order items =
   | Oldest_first -> items
   | Newest_first -> List.rev items
 
-let resolve_status_target (ctx : _ context) args =
-  let requested_name = effective_status_name ctx args in
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let resolve_status_target_config ~(config : Coord.config) ~(agent_name : string) args =
+  let requested_name = effective_status_name_config ~agent_name args in
   if not (validate_name requested_name) then
     Error
       (Printf.sprintf
@@ -154,7 +159,7 @@ let resolve_status_target (ctx : _ context) args =
           [A-Za-z0-9._-]+; see Keeper_config.validate_name)"
          requested_name)
   else
-    match read_meta_resolved ctx.config requested_name with
+    match read_meta_resolved config requested_name with
     | Error e -> Error e
     | Ok (Some (resolved_name, meta)) -> Ok (resolved_name, meta)
     | Ok None ->
@@ -165,6 +170,9 @@ let resolve_status_target (ctx : _ context) args =
                   "keeper not found: %s (also tried %s)"
                   requested_name stripped_name)
          | None -> Error (Printf.sprintf "keeper not found: %s" requested_name))
+
+let resolve_status_target (ctx : _ context) args =
+  resolve_status_target_config ~config:ctx.config ~agent_name:ctx.agent_name args
 
 (** Hash the status-affecting args so different parameter combos
     get separate cache entries (e.g. fast=true vs fast=false). *)
@@ -189,12 +197,15 @@ let json_string_opt_member = Keeper_status_detail_observability.json_string_opt_
 let latest_metrics_json = Keeper_status_detail_observability.latest_metrics_json
 let model_observability_json = Keeper_status_detail_observability.model_observability_json
 
-let handle_keeper_status ctx args : tool_result =
-  match resolve_status_target ctx args with
+(* TEL-OK: status handler — telemetry surfaces via the cache layer
+   ([_cache] mutex-protected reads/writes) and Prometheus counters in
+   the downstream [Keeper_exec_status]/[Keeper_status_bridge] calls. *)
+let handle_keeper_status_config ~(config : Coord.config) ~(agent_name : string) args : tool_result =
+  match resolve_status_target_config ~config ~agent_name args with
   | Error err -> (false, err)
   | Ok (name, m) ->
-      let cache_key = status_cache_key ~base_path:ctx.config.base_path ~name in
-      let args_hash = hash_status_args ctx.config name args in
+      let cache_key = status_cache_key ~base_path:config.base_path ~name in
+      let args_hash = hash_status_args config name args in
       (* Cache hit: same updated_at + same args → return cached response.
          The read is taken under [cache_mu] so it cannot interleave with
          an eviction from [invalidate_status_cache_{for,all}]. *)
@@ -228,7 +239,7 @@ let handle_keeper_status ctx args : tool_result =
           ~requested_override:m.max_context_override models
       in
       let primary_max_context = max_context_resolution.effective_budget in
-      let base_dir = session_base_dir ctx.config in
+      let base_dir = session_base_dir config in
          let ctx_opt =
            if include_context then
              let (_session, ctx_opt) =
@@ -261,8 +272,8 @@ let handle_keeper_status ctx args : tool_result =
                  ("message_count", `Int (Keeper_exec_context.message_count c));
                ]
          in
-         let keepalive_running = runtime_keepalive_running ctx.config m in
-         let agent_status = parse_agent_status ctx.config ~agent_name:m.agent_name in
+         let keepalive_running = runtime_keepalive_running config m in
+         let agent_status = parse_agent_status config ~agent_name:m.agent_name in
          let now_ts = Time_compat.now () in
          let created_ts =
            Coord_resilience.Time.parse_iso8601_opt m.created_at |> Option.value ~default:0.0
@@ -289,34 +300,34 @@ let handle_keeper_status ctx args : tool_result =
 
          let models_resolved = `List [] in
 
-         let metrics_store = Keeper_types_support.keeper_metrics_store ctx.config m.name in
-         let metrics_path = Keeper_types_support.keeper_metrics_path ctx.config m.name in
+         let metrics_store = Keeper_types_support.keeper_metrics_store config m.name in
+         let metrics_path = Keeper_types_support.keeper_metrics_path config m.name in
          let memory_bank_path =
-           Keeper_types_support.keeper_memory_bank_path ctx.config m.name
+           Keeper_types_support.keeper_memory_bank_path config m.name
          in
          let generation_index_path =
-           Keeper_types_support.keeper_generation_index_path ctx.config m.name
+           Keeper_types_support.keeper_generation_index_path config m.name
          in
          let session_dir =
            Keeper_types_support.keeper_session_dir
-             ctx.config
+             config
              (Keeper_id.Trace_id.to_string m.runtime.trace_id)
          in
          let generation_manifest_path =
-           Keeper_types_support.keeper_generation_manifest_path ctx.config
+           Keeper_types_support.keeper_generation_manifest_path config
              (Keeper_id.Trace_id.to_string m.runtime.trace_id)
          in
          let history_path =
            Keeper_types_support.keeper_history_path
-             ctx.config
+             config
              (Keeper_id.Trace_id.to_string m.runtime.trace_id)
          in
          let internal_history_path =
-           Keeper_types_support.keeper_internal_history_path ctx.config
+           Keeper_types_support.keeper_internal_history_path config
              (Keeper_id.Trace_id.to_string m.runtime.trace_id)
          in
          let generation_lineage =
-           Keeper_generation_lineage.surface_json ctx.config m ~recent_limit:6
+           Keeper_generation_lineage.surface_json config m ~recent_limit:6
          in
 
          let metrics_tail =
@@ -408,7 +419,7 @@ let handle_keeper_status ctx args : tool_result =
            if include_memory_bank then
              match
                read_keeper_memory_summary_result
-                 ctx.config
+                 config
                  ~name:m.name
                  ~max_bytes:tail_bytes
                  ~max_lines:(max (tail_turns * 10) 400)
@@ -609,7 +620,7 @@ let handle_keeper_status ctx args : tool_result =
         in
         let last_autonomous = String.trim m.runtime.last_autonomous_action_at in
         let tool_audit_snapshot =
-          match latest_tool_audit_snapshot_from_files ctx.config ~keeper_name:m.name with
+          match latest_tool_audit_snapshot_from_files config ~keeper_name:m.name with
           | Some snapshot ->
               {
                 snapshot with
@@ -643,7 +654,7 @@ let handle_keeper_status ctx args : tool_result =
           |> List.filter (fun name -> not (List.mem name allowed_tools))
         in
          let sandbox_last_error =
-           match Keeper_registry.get ~base_path:ctx.config.base_path m.name with
+           match Keeper_registry.get ~base_path:config.base_path m.name with
            | Some entry -> entry.last_error
            | None -> None
          in
@@ -667,13 +678,13 @@ let handle_keeper_status ctx args : tool_result =
          let sandbox_live =
            Keeper_sandbox_control.live_status_json
              ~include_preflight:false
-             ~config:ctx.config ~meta:m ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Status_detail ()) ~verbose:false ()
+             ~config:config ~meta:m ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Status_detail ()) ~verbose:false ()
          in
          let runtime_blocker_fields =
-          runtime_blocker_fields_json ctx.config m
+          runtime_blocker_fields_json config m
          in
          let attention_fields =
-           attention_fields_json ctx.config m
+           attention_fields_json config m
          in
          let latest_metrics =
            latest_metrics_json ~metrics_store ~metrics_path ~tail_bytes
@@ -686,7 +697,7 @@ let handle_keeper_status ctx args : tool_result =
          in
          let runtime_trust =
            Keeper_runtime_trust_snapshot.snapshot_json
-             ~config:ctx.config ~meta:m
+             ~config:config ~meta:m
          in
          let attention_fields =
            attention_fields_with_runtime_trust attention_fields runtime_trust
@@ -893,9 +904,9 @@ let handle_keeper_status ctx args : tool_result =
            ("models_resolved", models_resolved);
            ("model_observability", model_observability);
            ("runtime_trust", runtime_trust);
-           ("runtime", runtime_surface_json ctx.config m);
+           ("runtime", runtime_surface_json config m);
            ("coordination", coordination_surface_json m);
-           ("sources", source_provenance_json ctx.config m);
+           ("sources", source_provenance_json config m);
            ("context", ctx_stats);
            ("skill_route", Json_util.option_to_yojson Fun.id last_skill_route);
            ("metrics_overview", metrics_summary_to_json metrics_overview);
@@ -918,20 +929,20 @@ let handle_keeper_status ctx args : tool_result =
            ("compaction_history_tail", fst compaction_history_tail);
            ("compaction_history_count", `Int (snd compaction_history_tail));
            ("storage_paths", `Assoc [
-             ("meta", `String (keeper_meta_path ctx.config m.name));
+             ("meta", `String (keeper_meta_path config m.name));
              ("metrics", `String (Dated_jsonl.base_dir metrics_store));
              ("metrics_single_file", `String metrics_path);
            ("memory_bank", `String memory_bank_path);
            ("generation_index", `String generation_index_path);
            ( "decisions"
-           , `String (Keeper_types_support.keeper_decision_log_path ctx.config m.name) );
+           , `String (Keeper_types_support.keeper_decision_log_path config m.name) );
            ( "policy"
-             , `String (Keeper_types_support.keeper_policy_log_path ctx.config m.name) );
+             , `String (Keeper_types_support.keeper_policy_log_path config m.name) );
              ( "feedback"
-             , `String (Keeper_types_support.keeper_feedback_log_path ctx.config m.name) );
+             , `String (Keeper_types_support.keeper_feedback_log_path config m.name) );
            ( "dataset_export"
            , `String
-               (Keeper_types_support.keeper_dataset_export_path ctx.config m.name)
+               (Keeper_types_support.keeper_dataset_export_path config m.name)
            );
            ("session_dir", `String session_dir);
              ("generation_manifest", `String generation_manifest_path);
@@ -939,12 +950,12 @@ let handle_keeper_status ctx args : tool_result =
              ("history_internal", `String internal_history_path);
              ("evidence_dir", `String
                (Filename.concat
-                 (Common.masc_dir_from_base_path ~base_path:ctx.config.base_path)
+                 (Common.masc_dir_from_base_path ~base_path:config.base_path)
                  (Printf.sprintf "evidence/%s/%s"
                    (Coord_utils.safe_filename m.name)
                    (Coord_utils.safe_filename (Keeper_id.Trace_id.to_string m.runtime.trace_id)))));
            ]);
-           (let sandbox = Keeper_sandbox.of_meta ~config:ctx.config ~meta:m in
+           (let sandbox = Keeper_sandbox.of_meta ~config:config ~meta:m in
            let playground_abs = sandbox.host_root_abs in
            (* #10650 + B1 follow-up: keeper-LLM-facing execution_context must
               not surface host paths.  For Docker keepers the host abs path
@@ -978,7 +989,7 @@ let handle_keeper_status ctx args : tool_result =
              ("allowed_paths", string_list_to_json m.allowed_paths);
              ("playground_repos",
                Keeper_sandbox_control.playground_repos_json
-                 ~config:ctx.config ~meta:m);
+                 ~config:config ~meta:m);
              ("pr_history",
                let pr_path = Filename.concat playground_abs
                  ".playground_pr_history.jsonl" in
@@ -988,7 +999,7 @@ let handle_keeper_status ctx args : tool_result =
                  `List (List.take 10 (List.rev entries))
                with Sys_error _ -> `List []);
              ("active_worktrees",
-               let worktrees_dir = Filename.concat ctx.config.base_path ".worktrees" in
+               let worktrees_dir = Filename.concat config.base_path ".worktrees" in
                try
                  let entries = Sys.readdir worktrees_dir |> Array.to_list in
                  let keeper_prefix = Keeper_alerting_path.sanitize_keeper_name m.name in
@@ -1008,3 +1019,5 @@ let handle_keeper_status ctx args : tool_result =
            Hashtbl.replace _cache cache_key
              { updated_at = m.updated_at; args_hash; response });
          (true, response))
+(* TEL-OK: 1-line delegate to ctx-free body. *)
+let handle_keeper_status (ctx : _ context) args = handle_keeper_status_config ~config:ctx.config ~agent_name:ctx.agent_name args

--- a/lib/keeper/keeper_status_detail.mli
+++ b/lib/keeper/keeper_status_detail.mli
@@ -46,3 +46,7 @@ val invalidate_status_cache_all : unit -> unit
     otherwise rebuilds the snapshot and refreshes the cache. *)
 val handle_keeper_status :
   _ Keeper_types.context -> Yojson.Safe.t -> tool_result
+
+(** RFC-0182 §3.1 — ctx-free entry point for keeper_dispatch_ref path. *)
+val handle_keeper_status_config :
+  config:Coord.config -> agent_name:string -> Yojson.Safe.t -> tool_result

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -8,7 +8,7 @@ open Keeper_keepalive
 
 type tool_result = Keeper_types.tool_result
 
-let handle_keeper_down ctx args : tool_result =
+let handle_keeper_down_config ~(config : Coord.config) args : tool_result =
   let requested_name = String.trim (get_string args "name" "") in
   if not (validate_name requested_name) then
     ( false,
@@ -19,17 +19,17 @@ let handle_keeper_down ctx args : tool_result =
   else
     let remove_meta = get_bool args "remove_meta" false in
     let remove_session = get_bool args "remove_session" false in
-    stop_keepalive ~base_path:ctx.config.base_path requested_name;
+    stop_keepalive ~base_path:config.base_path requested_name;
     (match Keeper_identity.keeper_name_from_agent_name requested_name with
      | Some resolved_name when not (String.equal resolved_name requested_name) ->
-         stop_keepalive ~base_path:ctx.config.base_path resolved_name
+         stop_keepalive ~base_path:config.base_path resolved_name
      | _ -> ());
-    match read_meta_resolved ctx.config requested_name with
+    match read_meta_resolved config requested_name with
     | Error e -> (false, e)
     | Ok None -> (true, Printf.sprintf "keeper already absent: %s" requested_name)
     | Ok (Some (name, m)) ->
       let pending_confirms_removed =
-        Operator_pending_confirm.remove_pending_confirms_by_target ctx.config
+        Operator_pending_confirm.remove_pending_confirms_by_target config
           ~target_type:"keeper" ~target_id:(Some name)
       in
       Log.Misc.info
@@ -38,8 +38,8 @@ let handle_keeper_down ctx args : tool_result =
         name pending_confirms_removed remove_meta remove_session;
       (if remove_meta then
          ( Safe_ops.remove_file_logged ~context:"keeper_down"
-             (keeper_meta_path ctx.config name);
-           Keeper_registry.unregister ~base_path:ctx.config.base_path name;
+             (keeper_meta_path config name);
+           Keeper_registry.unregister ~base_path:config.base_path name;
            (* Tier K4c teardown — when the keeper is fully removed
               (remove_meta=true), drop its tool-emission accumulator
               from the registry so its slot is reclaimable. The
@@ -57,7 +57,7 @@ let handle_keeper_down ctx args : tool_result =
          in
          ((match
              write_meta_with_merge
-               ~merge:Keeper_meta_merge.caller_wins ctx.config retained
+               ~merge:Keeper_meta_merge.caller_wins config retained
            with
            | Ok () -> ()
            | Error err ->
@@ -73,8 +73,8 @@ let handle_keeper_down ctx args : tool_result =
                  Log.Keeper.warn "keeper_down write_meta lost CAS race: %s" err
                else
                  Log.Keeper.error "keeper_down write_meta failed: %s" err);
-          Keeper_registry.update_meta ~base_path:ctx.config.base_path name retained;
-          Keeper_registry.dispatch_event_unit ~base_path:ctx.config.base_path name
+          Keeper_registry.update_meta ~base_path:config.base_path name retained;
+          Keeper_registry.dispatch_event_unit ~base_path:config.base_path name
             Keeper_state_machine.Operator_pause));
       if remove_session then (
         let rec rm_rf path =
@@ -89,7 +89,7 @@ let handle_keeper_down ctx args : tool_result =
           end
         in
         if validate_name (Keeper_id.Trace_id.to_string m.runtime.trace_id) then (
-          let dir = Filename.concat (session_base_dir ctx.config) (Keeper_id.Trace_id.to_string m.runtime.trace_id) in
+          let dir = Filename.concat (session_base_dir config) (Keeper_id.Trace_id.to_string m.runtime.trace_id) in
           try rm_rf dir with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
             Prometheus.inc_counter
               Keeper_metrics.(to_string SessionCleanupFailures)
@@ -104,3 +104,5 @@ let handle_keeper_down ctx args : tool_result =
         ("pending_confirms_removed", `Int pending_confirms_removed);
       ] in
       (true, Yojson.Safe.to_string json)
+
+let handle_keeper_down (ctx : _ context) args = handle_keeper_down_config ~config:ctx.config args

--- a/lib/keeper/keeper_turn_lifecycle.mli
+++ b/lib/keeper/keeper_turn_lifecycle.mli
@@ -9,3 +9,7 @@ type tool_result = Keeper_types.tool_result
     Operator_pause to the registry. *)
 val handle_keeper_down :
   _ Keeper_types.context -> Yojson.Safe.t -> tool_result
+
+(** RFC-0182 §3.1 — ctx-free entry point for keeper_dispatch_ref path. *)
+val handle_keeper_down_config :
+  config:Coord.config -> Yojson.Safe.t -> tool_result

--- a/lib/keeper_dispatch_ref.ml
+++ b/lib/keeper_dispatch_ref.ml
@@ -1,0 +1,16 @@
+(** RFC-0182 §3.1 — keeper dispatch dependency inversion ref.
+
+    See [keeper_dispatch_ref.mli] for the rationale. *)
+
+(* TEL-OK: dependency-inversion ref module — telemetry lives in the
+   registered backing dispatch (Tool_keeper / Tool_keeper_ops handlers). *)
+let dispatch
+  : (config:Coord.config
+     -> agent_name:string
+     -> name:string
+     -> args:Yojson.Safe.t
+     -> (bool * string) option)
+      ref
+  =
+  ref (fun ~config:_ ~agent_name:_ ~name:_ ~args:_ -> None)
+;;

--- a/lib/keeper_dispatch_ref.mli
+++ b/lib/keeper_dispatch_ref.mli
@@ -1,0 +1,24 @@
+(** RFC-0182 §3.1 — keeper dispatch dependency inversion ref.
+
+    Same pattern as [Coord_dispatch_ref] and [Persona_dispatch_ref].
+    [Tool_keeper] lives in lib/ (late in module order) but is the
+    natural home of keeper coordination tools.  Importing it from
+    [Agent_tool_in_process_runtime] (early in lib/keeper) would close
+    a cycle.
+
+    Resolution: register ctx-free entry points from [Tool_keeper] into
+    the ref at module load.  [Agent_tool_in_process_runtime] reads the
+    ref at dispatch time.
+
+    The [~agent_name] parameter carries the caller keeper's agent name
+    (typically [meta.agent_name]) so tools like [masc_keeper_status]
+    that fall back to "self" when the [name] arg is empty can resolve
+    the right target. *)
+
+val dispatch
+  : (config:Coord.config
+     -> agent_name:string
+     -> name:string
+     -> args:Yojson.Safe.t
+     -> (bool * string) option)
+      ref

--- a/lib/persona_dispatch_ref.ml
+++ b/lib/persona_dispatch_ref.ml
@@ -1,0 +1,11 @@
+(** RFC-0182 §3.1 — persona dispatch dependency inversion ref.
+
+    See [persona_dispatch_ref.mli] for the rationale. *)
+
+(* TEL-OK: dependency-inversion ref module — telemetry lives in the
+   registered backing dispatch ([Keeper_persona] / [Keeper_persona_authoring]). *)
+let dispatch
+  : (name:string -> args:Yojson.Safe.t -> (bool * string) option) ref
+  =
+  ref (fun ~name:_ ~args:_ -> None)
+;;

--- a/lib/persona_dispatch_ref.mli
+++ b/lib/persona_dispatch_ref.mli
@@ -1,0 +1,16 @@
+(** RFC-0182 §3.1 — persona dispatch dependency inversion ref.
+
+    Same pattern as [Coord_dispatch_ref]. The persona cluster
+    handlers in [Keeper_persona] / [Keeper_persona_authoring] are
+    pure with respect to keeper context but the modules themselves
+    transitively import [Keeper_turn] / [Keeper_turn_driver], which
+    sit late in module order (deep in the keeper chain).
+    [Agent_tool_in_process_runtime] is compiled early, so a direct
+    static import closes a cycle.
+
+    Resolution: register from a late module ([Tool_keeper]) into the
+    ref at module load.  [Agent_tool_in_process_runtime] reads the
+    ref at dispatch time. *)
+
+val dispatch
+  : (name:string -> args:Yojson.Safe.t -> (bool * string) option) ref

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -7,21 +7,24 @@ open Keeper_runtime
 
 include Tool_keeper_ops
 
-let handle_keeper_list ctx args : tool_result =
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path.  Uses
+   [Coord.config] only (no Eio fields), letting Tool_keeper register
+   masc_keeper_list with [Keeper_dispatch_ref] at module load. *)
+let keeper_list_body ~(config : Coord.config) args : tool_result =
   let limit = max 0 (get_int args "limit" 50) in
   let detailed = get_bool args "detailed" false in
   let cache_key =
-    Printf.sprintf "%s:%d:%b" ctx.config.base_path limit detailed
+    Printf.sprintf "%s:%d:%b" config.base_path limit detailed
   in
   let body =
     cached_text_by_key keeper_list_cache ~key:cache_key
       ~ttl_s:(keeper_list_cache_ttl_s ()) (fun () ->
         let registry_names =
-          Keeper_registry.all ~base_path:ctx.config.base_path ()
+          Keeper_registry.all ~base_path:config.base_path ()
           |> List.map (fun (entry : Keeper_registry.registry_entry) -> entry.name)
         in
         let names =
-          registry_names @ keeper_names ctx.config
+          registry_names @ keeper_names config
           |> List.map String.trim
           |> List.filter (fun name -> not (String.equal name ""))
           |> List.sort_uniq String.compare
@@ -30,7 +33,7 @@ let handle_keeper_list ctx args : tool_result =
         let rows =
           names
           |> List.filter_map (fun name ->
-               keeper_list_row_json ~runtime_class:"keeper" ctx.config name)
+               keeper_list_row_json ~runtime_class:"keeper" config name)
         in
         let json =
           if not detailed then
@@ -51,8 +54,13 @@ let handle_keeper_list ctx args : tool_result =
   in
   (true, body)
 
+let handle_keeper_list ctx args : tool_result =
+  keeper_list_body ~config:ctx.config args
+
 let dedupe_sorted_strings = Persona_audit.dedupe_sorted_strings
-let handle_keeper_persona_audit = Persona_audit.handle
+
+let handle_keeper_persona_audit ctx args =
+  Persona_audit.handle ~config:ctx.config args
 
 let parse_network_mode_or_error raw =
   match network_mode_of_string raw with
@@ -152,8 +160,9 @@ let handle_keeper_sandbox_status ctx args : tool_result =
                in
                (true, Yojson.Safe.pretty_to_string json)))
 
-let handle_keeper_sandbox_start ctx args : tool_result =
-  match resolve_keeper_meta ctx args with
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let keeper_sandbox_start_body ~(config : Coord.config) args : tool_result =
+  match resolve_keeper_meta_config ~config args with
   | Error err -> (false, err)
   | Ok meta ->
       let timeout_sec = Stdlib.Float.min 30.0 (Stdlib.Float.max 1.0 (get_float args "timeout_sec" 10.0)) in
@@ -168,7 +177,7 @@ let handle_keeper_sandbox_start ctx args : tool_result =
        | Ok network_mode -> (
            match
              Keeper_sandbox_control.start_managed_container
-               ~config:ctx.config ~meta ~network_mode ~ttl_sec ~timeout_sec ()
+               ~config ~meta ~network_mode ~ttl_sec ~timeout_sec ()
            with
            | Error err -> (false, err)
            | Ok result ->
@@ -182,7 +191,11 @@ let handle_keeper_sandbox_start ctx args : tool_result =
                         ("sandbox", result);
                       ]) )))
 
-let handle_keeper_sandbox_stop ctx args : tool_result =
+let handle_keeper_sandbox_start ctx args : tool_result =
+  keeper_sandbox_start_body ~config:ctx.config args
+
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let keeper_sandbox_stop_body ~(config : Coord.config) args : tool_result =
   let timeout_sec = Stdlib.Float.min 30.0 (Stdlib.Float.max 1.0 (get_float args "timeout_sec" 10.0)) in
   let prune_stale = get_bool args "prune_stale" false in
   let container_kind_raw =
@@ -198,12 +211,12 @@ let handle_keeper_sandbox_stop ctx args : tool_result =
   | Ok scope ->
       let stop_result =
         Keeper_sandbox_control.stop_containers
-          ?keeper_name ~scope ~config:ctx.config ~timeout_sec ()
+          ?keeper_name ~scope ~config ~timeout_sec ()
       in
       let stale_cleanup =
         if prune_stale then
           Some
-            (Keeper_sandbox_control.cleanup_stale ~config:ctx.config
+            (Keeper_sandbox_control.cleanup_stale ~config
                ~timeout_sec:(Stdlib.Float.min timeout_sec 5.0) ())
         else
           None
@@ -242,6 +255,9 @@ let handle_keeper_sandbox_stop ctx args : tool_result =
                ("stale_cleanup", stale_json);
              ]) )
 
+let handle_keeper_sandbox_stop ctx args : tool_result =
+  keeper_sandbox_stop_body ~config:ctx.config args
+
 (* masc_keeper_reconcile tool removed along with the manual_reconcile
    blocker mechanism. Failed turns record evidence via Keeper_registry;
    recovery is autonomous (next turn's observation) or operator-driven
@@ -266,18 +282,22 @@ let maybe_bootstrap_existing_keepalives ctx ~name ~args =
     Do not retarget requests across other base_path registries. *)
 let resolve_ctx ctx ~name:_ _args = ctx
 
-let handle_keeper_reset ctx args : tool_result =
-  match resolve_keeper_meta ctx args with
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let keeper_reset_body ~(config : Coord.config) args : tool_result =
+  match resolve_keeper_meta_config ~config args with
   | Error err -> (false, err)
   | Ok meta ->
     let reset_meta = Keeper_types.reset_runtime_state meta in
-    (match Keeper_types.write_meta ctx.config reset_meta with
+    (match Keeper_types.write_meta config reset_meta with
      | Ok () ->
        (true, Printf.sprintf
          "Reset runtime state for %s: usage counters zeroed, last_model_used cleared."
          meta.name)
      | Error err ->
        (false, Printf.sprintf "Failed to write reset meta for %s: %s" meta.name err))
+
+let handle_keeper_reset ctx args : tool_result =
+  keeper_reset_body ~config:ctx.config args
 
 (** Resolve the primary model max context for a keeper.
 
@@ -299,8 +319,9 @@ let resolve_primary_max_context (meta : Keeper_types.keeper_meta option) : int =
     Dispatches [Operator_compact_requested] to the FSM, then compacts the
     keeper's latest checkpoint via OAS checkpoint recovery.  Returns
     before/after token counts on success. *)
-let handle_keeper_compact ctx args : tool_result =
-  match resolve_keeper_name ctx args with
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let keeper_compact_body ~(config : Coord.config) args : tool_result =
+  match resolve_keeper_name_config ~config args with
   | Error err -> (false, err)
   | Ok name ->
     let force = get_bool args "force" false in
@@ -308,7 +329,7 @@ let handle_keeper_compact ctx args : tool_result =
        can still disappear if another fiber unregistered the keeper.  Treat
        this as a distinct "not found" error rather than an opaque
        "phase=unknown" precondition failure. *)
-    match Keeper_registry.get ~base_path:ctx.config.base_path name with
+    match Keeper_registry.get ~base_path:config.base_path name with
     | None ->
       Prometheus.inc_counter Keeper_metrics.(to_string OperatorCompact)
         ~labels:[("keeper", name); ("result", Keeper_operator_compact_result.(to_label Not_found))] ();
@@ -336,18 +357,18 @@ let handle_keeper_compact ctx args : tool_result =
     else begin
       (* Dispatch FSM event *)
       Keeper_exec_context.dispatch_keeper_phase_event
-        ~config:ctx.config ~keeper_name:name
+        ~config:config ~keeper_name:name
         Keeper_state_machine.Operator_compact_requested;
       (* Read meta for checkpoint access *)
-      match read_meta_resolved ctx.config name with
+      match read_meta_resolved config name with
       | Ok None | Error _ ->
         (false, Printf.sprintf "keeper %s: meta unavailable for compaction" name)
       | Ok (Some (_resolved, meta)) ->
-        let base_dir = Keeper_types.session_base_dir ctx.config in
+        let base_dir = Keeper_types.session_base_dir config in
         let model = Keeper_exec_context.checkpoint_model_of_meta meta in
         let max_tokens = resolve_primary_max_context (Some meta) in
         Keeper_exec_context.dispatch_keeper_phase_event
-          ~config:ctx.config ~keeper_name:name
+          ~config:config ~keeper_name:name
           ~origin:Keeper_registry.Operator_compact
           Keeper_state_machine.Compaction_started;
         match
@@ -356,7 +377,7 @@ let handle_keeper_compact ctx args : tool_result =
         with
         | Some recovery ->
           Keeper_exec_context.dispatch_compaction_completed
-            ~config:ctx.config ~keeper_name:name
+            ~config:config ~keeper_name:name
             ~origin:Keeper_registry.Operator_compact
             ~before_tokens:recovery.compaction.before_tokens
             ~after_tokens:recovery.compaction.after_tokens;
@@ -369,7 +390,7 @@ let handle_keeper_compact ctx args : tool_result =
                ("name", `String name);
                ("phase_before", `String phase_before);
                ("phase_after", `String
-                  (match Keeper_registry.get ~base_path:ctx.config.base_path name with
+                  (match Keeper_registry.get ~base_path:config.base_path name with
                    | Some entry -> Keeper_state_machine.phase_to_string entry.phase
                    | None -> "unknown"));
                ("before_tokens", `Int recovery.compaction.before_tokens);
@@ -383,7 +404,7 @@ let handle_keeper_compact ctx args : tool_result =
              Emitting [Compaction_completed] here would be a false success
              signal. *)
           Keeper_exec_context.dispatch_keeper_phase_event
-            ~config:ctx.config ~keeper_name:name
+            ~config:config ~keeper_name:name
             ~origin:Keeper_registry.Operator_compact
             (Keeper_state_machine.Compaction_failed {
                reason = "no_valid_checkpoint";
@@ -396,13 +417,17 @@ let handle_keeper_compact ctx args : tool_result =
              name)
     end
 
+let handle_keeper_compact ctx args : tool_result =
+  keeper_compact_body ~config:ctx.config args
+
 (** Last-resort context clear.
 
     Drops all conversation messages from the keeper's checkpoint file,
     optionally preserving the system prompt.  Dispatches
     [Operator_clear_requested] to reset overflow-related FSM conditions. *)
-let handle_keeper_clear ctx args : tool_result =
-  match resolve_keeper_name ctx args with
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let keeper_clear_body ~(config : Coord.config) args : tool_result =
+  match resolve_keeper_name_config ~config args with
   | Error err -> (false, err)
   | Ok name ->
     let reason = String.trim (get_string args "reason" "") in
@@ -413,20 +438,20 @@ let handle_keeper_clear ctx args : tool_result =
     (* Same registry race guard as [handle_keeper_compact]: if the keeper
        disappeared between [resolve_keeper_name] and [get], abort cleanly
        rather than silently proceed with a half-applied clear. *)
-    match Keeper_registry.get ~base_path:ctx.config.base_path name with
+    match Keeper_registry.get ~base_path:config.base_path name with
     | None ->
       (false, error_response_typed ~code:Validation_error
         (Printf.sprintf "keeper %s is not in the registry" name))
     | Some entry ->
       let preserve_system = get_bool args "preserve_system_prompt" true in
       let phase_before = Keeper_state_machine.phase_to_string entry.phase in
-      let base_dir = Keeper_types.session_base_dir ctx.config in
+      let base_dir = Keeper_types.session_base_dir config in
       (* Must use the keeper's OWN trace_id to locate its checkpoint file.
          Using generate_trace_id () would create a fresh session dir and
          always report 0 cleared messages, because the existing checkpoint
          lives under meta.runtime.trace_id. *)
       let meta_for_trace =
-        match read_meta_resolved ctx.config name with
+        match read_meta_resolved config name with
         | Ok (Some (_, meta)) -> Some meta
         | _ -> None
       in
@@ -526,7 +551,7 @@ let handle_keeper_clear ctx args : tool_result =
                   };
               }
             in
-            (match Keeper_types.write_meta ~force:true ctx.config updated_meta with
+            (match Keeper_types.write_meta ~force:true config updated_meta with
              | Ok () -> true
              | Error err ->
                  Log.Keeper.warn
@@ -537,11 +562,11 @@ let handle_keeper_clear ctx args : tool_result =
       in
       (* Dispatch FSM event to clear overflow conditions *)
       Keeper_exec_context.dispatch_keeper_phase_event
-        ~config:ctx.config ~keeper_name:name
+        ~config:config ~keeper_name:name
         (Keeper_state_machine.Operator_clear_requested { preserve_system; reason });
       (* Clear registry failure state *)
-      Keeper_registry.set_failure_reason ~base_path:ctx.config.base_path name None;
-      Keeper_registry.reset_turn_failures ~base_path:ctx.config.base_path name;
+      Keeper_registry.set_failure_reason ~base_path:config.base_path name None;
+      Keeper_registry.reset_turn_failures ~base_path:config.base_path name;
       invalidate_status_cache name;
       Log.Keeper.warn
         "%s: context cleared by operator (reason=%s, preserve_system=%b, cleared=%d msgs)"
@@ -555,7 +580,7 @@ let handle_keeper_clear ctx args : tool_result =
            ("name", `String name);
            ("phase_before", `String phase_before);
            ("phase_after", `String
-              (match Keeper_registry.get ~base_path:ctx.config.base_path name with
+              (match Keeper_registry.get ~base_path:config.base_path name with
                | Some entry -> Keeper_state_machine.phase_to_string entry.phase
                | None -> "unknown"));
            ("cleared_message_count", `Int cleared_count);
@@ -564,6 +589,9 @@ let handle_keeper_clear ctx args : tool_result =
            ("preserve_system_prompt", `Bool preserve_system);
            ("reason", `String reason);
          ]))
+
+let handle_keeper_clear ctx args : tool_result =
+  keeper_clear_body ~config:ctx.config args
 
 let dispatch ctx ~name ~args : tool_result option =
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
@@ -641,3 +669,52 @@ let () =
            ?required_permission:(tool_required_permission s.name)
            ()))
     schemas
+
+(* RFC-0182 §3.1 — register the ctx-free persona handlers with
+   [Persona_dispatch_ref] so [Agent_tool_in_process_runtime]
+   (compiled early in lib/keeper) can dispatch them without taking
+   a static dependency on [Keeper_persona] / [Keeper_persona_authoring]
+   (which transitively pull in [Keeper_turn_driver] and close a
+   cycle).  [masc_persona_generate] is intentionally excluded — its
+   handler uses the keeper Eio context. *)
+let () =
+  Persona_dispatch_ref.dispatch
+  := fun ~name ~args ->
+    match name with
+    | "masc_persona_list" -> Some (Keeper_persona.persona_list_handler args)
+    | "masc_persona_schema" -> Some (Keeper_persona.persona_schema_handler args)
+    | "masc_persona_save" -> Some (Keeper_persona.persona_save_handler args)
+    | _ -> None
+;;
+
+(* RFC-0182 §3.1 — register ctx-free keeper handlers with
+   [Keeper_dispatch_ref].  Only [masc_keeper_list] today; the
+   remaining keeper tools (status, msg, clear, compact, repair,
+   sandbox lifecycle) use the keeper Eio context and are gated on
+   Phase 5 Eio plumbing scope. *)
+let () =
+  Keeper_dispatch_ref.dispatch
+  := fun ~config ~agent_name ~name ~args ->
+    match name with
+    | "masc_keeper_list" -> Some (keeper_list_body ~config args)
+    | "masc_keeper_msg_result" ->
+      Some (Tool_keeper_ops.keeper_msg_result_body ~config args)
+    | "masc_keeper_compact" -> Some (keeper_compact_body ~config args)
+    | "masc_keeper_clear" -> Some (keeper_clear_body ~config args)
+    | "masc_keeper_sandbox_start" ->
+      Some (keeper_sandbox_start_body ~config args)
+    | "masc_keeper_sandbox_stop" ->
+      Some (keeper_sandbox_stop_body ~config args)
+    | "masc_keeper_reset" -> Some (keeper_reset_body ~config args)
+    | "masc_keeper_persona_audit" ->
+      Some (Tool_keeper_persona_audit.handle ~config args)
+    | "masc_keeper_status" ->
+      Some (Tool_keeper_ops.keeper_status_body ~config ~agent_name args)
+    | "masc_keeper_repair" ->
+      Some (Tool_keeper_ops.keeper_repair_body ~config ~agent_name args)
+    | "masc_keeper_down" ->
+      Tool_keeper_ops.invalidate_keeper_list_cache ();
+      Tool_keeper_ops.invalidate_status_cache (Tool_args.get_string args "name" "");
+      Some (Keeper_turn_lifecycle.handle_keeper_down_config ~config args)
+    | _ -> None
+;;

--- a/lib/tool_keeper_ops.ml
+++ b/lib/tool_keeper_ops.ml
@@ -101,7 +101,8 @@ let annotate_keeper_json ~runtime_class json =
 let attach_assoc_field key value = function
   | `Assoc fields -> `Assoc ((key, value) :: fields)
   | other -> other
-let maybe_reseed_keeper_identity ctx (meta : keeper_meta) =
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let maybe_reseed_keeper_identity_config ~(config : Coord.config) (meta : keeper_meta) =
   let expected_agent_name = Keeper_identity.keeper_agent_name meta.name in
   if String.equal expected_agent_name meta.agent_name then
     Ok (meta, None)
@@ -115,7 +116,7 @@ let maybe_reseed_keeper_identity ctx (meta : keeper_meta) =
              "failed to reseed keeper identity for %s: invalid trace_id %s (%s)"
              meta.name new_trace_id_raw err)
     | Ok new_trace_id ->
-        let base_dir = Keeper_types.session_base_dir ctx.config in
+        let base_dir = Keeper_types.session_base_dir config in
         let _session =
           Keeper_exec_context.create_session ~session_id:new_trace_id_raw
             ~base_dir
@@ -129,7 +130,7 @@ let maybe_reseed_keeper_identity ctx (meta : keeper_meta) =
               trace_history = Json_util.dedupe_keep_order (previous_trace_id :: meta.runtime.trace_history);
               generation = meta.runtime.generation + 1 } }
         in
-        (match Keeper_types.write_meta ~force:true ctx.config updated_meta with
+        (match Keeper_types.write_meta ~force:true config updated_meta with
          | Ok () ->
              Keeper_status_detail.invalidate_status_cache_for updated_meta.name;
              Ok
@@ -147,6 +148,10 @@ let maybe_reseed_keeper_identity ctx (meta : keeper_meta) =
                (Printf.sprintf
                   "failed to persist reseeded keeper identity for %s: %s"
                   meta.name err))
+
+let maybe_reseed_keeper_identity ctx (meta : keeper_meta) =
+  maybe_reseed_keeper_identity_config ~config:ctx.config meta
+
 let prepare_keeper_up_identity ctx args =
   let name = String.trim (get_string args "name" "") in
   match read_meta_resolved ctx.config name with
@@ -312,23 +317,30 @@ let with_keeper_name args name =
   | `Assoc fields ->
       `Assoc (("name", `String name) :: List.remove_assoc "name" fields)
   | other -> other
-let prepare_passive_keeper_identity ctx args =
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let prepare_passive_keeper_identity_config ~(config : Coord.config) ~(agent_name : string) args =
   let requested_name =
     match String.trim (get_string args "name" "") with
-    | "" -> String.trim ctx.agent_name
+    | "" -> String.trim agent_name
     | name -> name
   in
   if String.equal requested_name "" then
     Ok (args, None)
   else
-    match read_meta_resolved ctx.config requested_name with
+    match read_meta_resolved config requested_name with
     | Ok (Some (_resolved_name, meta)) -> (
-        match maybe_reseed_keeper_identity ctx meta with
+        match maybe_reseed_keeper_identity_config ~config meta with
         | Ok (updated_meta, identity_reseed) ->
             Ok (with_keeper_name args updated_meta.name, identity_reseed)
         | Error _ as err -> err)
     | Ok None -> Ok (args, None)
     | Error err -> Error (Printf.sprintf "%s" err)
+
+let prepare_passive_keeper_identity ctx args =
+  prepare_passive_keeper_identity_config
+    ~config:ctx.config
+    ~agent_name:ctx.agent_name
+    args
 let attach_identity_reseed ?identity_reseed json =
   match identity_reseed with
   | None -> json
@@ -381,11 +393,17 @@ let handle_keeper_create_from_persona ctx args : tool_result =
           (true, Yojson.Safe.to_string json)
 let handle_keeper_up ctx args : tool_result =
   with_keeper_startup_gate (fun () -> execute_keeper_up ctx args)
-let handle_keeper_status ctx args : tool_result =
-  match prepare_passive_keeper_identity ctx args with
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let keeper_status_body ~(config : Coord.config) ~(agent_name : string) args : tool_result =
+  match prepare_passive_keeper_identity_config ~config ~agent_name args with
   | Error err -> (false, err)
   | Ok (prepared_args, identity_reseed) ->
-      let ok, body = Status.handle_keeper_status ctx prepared_args in
+      let ok, body =
+        Keeper_status_detail.handle_keeper_status_config
+          ~config
+          ~agent_name
+          prepared_args
+      in
       if not ok then (ok, body)
       else
         let json =
@@ -397,9 +415,13 @@ let handle_keeper_status ctx args : tool_result =
           |> attach_identity_reseed ?identity_reseed
         in
         (true, Yojson.Safe.pretty_to_string json)
-let resolve_keeper_name ctx args =
+
+let handle_keeper_status ctx args : tool_result =
+  keeper_status_body ~config:ctx.config ~agent_name:ctx.agent_name args
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let resolve_keeper_name_config ~(config : Coord.config) args =
   let name = String.trim (get_string args "name" "") in
-  match read_meta_resolved ctx.config name with
+  match read_meta_resolved config name with
   | Ok (Some (resolved_name, _meta)) -> Ok resolved_name
   | Ok None ->
       (match Keeper_identity.keeper_name_from_agent_name name with
@@ -410,6 +432,9 @@ let resolve_keeper_name ctx args =
                 name stripped)
        | None -> Error (Printf.sprintf "keeper not found: %s" name))
   | Error err -> Error (Printf.sprintf "%s" err)
+
+let resolve_keeper_name ctx args =
+  resolve_keeper_name_config ~config:ctx.config args
 let handle_keeper_msg ctx args : tool_result =
   match resolve_keeper_name ctx args with
   | Error err -> (false, err)
@@ -440,16 +465,20 @@ let handle_keeper_msg ctx args : tool_result =
         ("status", `String "queued"); ("message", `String "Keeper turn submitted. Poll with keeper_msg_result.");
       ] in
       (true, Yojson.Safe.to_string json))
-let handle_keeper_msg_result ctx args : tool_result =
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let keeper_msg_result_body ~(config : Coord.config) args : tool_result =
   let request_id = get_string args "request_id" "" in
   if String.equal request_id "" then
     (false, {|{"error":"request_id is required"}|})
   else
-    match Keeper_msg_async.poll ~base_path:ctx.config.base_path request_id with
+    match Keeper_msg_async.poll ~base_path:config.base_path request_id with
     | None ->
       (false, Printf.sprintf {|{"error":"request_id not found","request_id":"%s"}|} request_id)
     | Some entry ->
       (true, Yojson.Safe.to_string (Keeper_msg_async.entry_to_json entry))
+
+let handle_keeper_msg_result ctx args : tool_result =
+  keeper_msg_result_body ~config:ctx.config args
 let handle_keeper_msg_stream ~on_text_delta ctx args : tool_result =
   match resolve_keeper_name ctx args with
   | Error err -> (false, err)
@@ -467,12 +496,16 @@ let handle_keeper_msg_stream ~on_text_delta ctx args : tool_result =
          Yojson.Safe.pretty_to_string
            (annotate_keeper_json ~runtime_class:"keeper" json))
       end
-let resolve_keeper_meta ctx args =
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let resolve_keeper_meta_config ~(config : Coord.config) args =
   let name = String.trim (get_string args "name" "") in
-  match read_meta_resolved ctx.config name with
+  match read_meta_resolved config name with
   | Ok (Some (_resolved_name, meta)) -> Ok meta
   | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)
   | Error err -> Error (Printf.sprintf "%s" err)
+
+let resolve_keeper_meta ctx args =
+  resolve_keeper_meta_config ~config:ctx.config args
 let annotate_keeper_repair_json ?identity_reseed ~(keeper_name : string) body =
   let parsed =
     try Some (Yojson.Safe.from_string body) with Yojson.Json_error _ -> None
@@ -494,11 +527,17 @@ let is_safe_subpath = Tool_keeper_path_validation.is_safe_subpath
 let validate_target_file = Tool_keeper_path_validation.validate_target_file
 let resolve_playground_working_dir =
   Tool_keeper_path_validation.resolve_playground_working_dir
-let handle_keeper_repair ctx args : tool_result =
-  match resolve_keeper_meta ctx args with
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path.
+   masc_keeper_repair is currently a stub (returns a typed
+   "unsupported" response after validating inputs) so no Eio fields are
+   actually consumed.  The previous [ignore (ctx.sw, ctx.clock,
+   ctx.config)] line was warning-suppression scaffolding for a future
+   real implementation. *)
+let keeper_repair_body ~(config : Coord.config) ~(agent_name : string) args : tool_result =
+  match resolve_keeper_meta_config ~config args with
   | Error err -> (false, err)
   | Ok meta -> (
-      match maybe_reseed_keeper_identity ctx meta with
+      match maybe_reseed_keeper_identity_config ~config meta with
       | Error err -> (false, err)
       | Ok (meta, identity_reseed) ->
           let task_spec = get_string args "task_spec" "" in
@@ -511,8 +550,8 @@ let handle_keeper_repair ctx args : tool_result =
             let target_file_opt = get_string_opt args "target_file" in
             match
               resolve_playground_working_dir
-                ~agent_name:ctx.agent_name
-                ~base_path:ctx.config.base_path
+                ~agent_name
+                ~base_path:config.base_path
                 ~working_dir_arg
             with
             | Error msg -> (false, msg)
@@ -563,8 +602,6 @@ let handle_keeper_repair ctx args : tool_result =
                       | None -> fields
                     in
                     let ok, body =
-                      (* suppress unused-field warning; ctx used for other fields below *)
-                      ignore (ctx.sw, ctx.clock, ctx.config);
                       let body_json =
                         `Assoc
                           [ ( "error"
@@ -597,6 +634,10 @@ let handle_keeper_repair ctx args : tool_result =
                       annotate_keeper_repair_json ?identity_reseed
                         ~keeper_name:meta.name body )
 )
+
+let handle_keeper_repair ctx args : tool_result =
+  keeper_repair_body ~config:ctx.config ~agent_name:ctx.agent_name args
+
 let handle_keeper_down ctx args : tool_result =
   invalidate_keeper_list_cache ();
   invalidate_status_cache (get_string args "name" "");

--- a/lib/tool_keeper_persona_audit.ml
+++ b/lib/tool_keeper_persona_audit.ml
@@ -27,7 +27,7 @@ let dedupe_sorted_strings values =
 
 let take limit values = List.filteri (fun index _ -> index < limit) values
 
-let requested_names ctx args =
+let requested_names ~(config : Coord.config) args =
   let explicit_names =
     let names = get_string_list args "names" in
     (match get_string_opt args "name" with
@@ -38,16 +38,16 @@ let requested_names ctx args =
   if Stdlib.List.length explicit_names > 0 then explicit_names
   else
     let registry_names =
-      Keeper_registry.all ~base_path:ctx.config.base_path ()
+      Keeper_registry.all ~base_path:config.base_path ()
       |> List.map (fun (entry : Keeper_registry.registry_entry) -> entry.name)
     in
-    registry_names @ configured_keeper_names ctx.config @ keeper_names ctx.config
+    registry_names @ configured_keeper_names config @ keeper_names config
     |> dedupe_sorted_strings
 
-let status ctx (meta : keeper_meta) =
-  let keepalive_running = Keeper_status_bridge.runtime_keepalive_running ctx.config meta in
+let status ~(config : Coord.config) (meta : keeper_meta) =
+  let keepalive_running = Keeper_status_bridge.runtime_keepalive_running config meta in
   let agent_status =
-    Keeper_exec_status.parse_agent_status ctx.config ~agent_name:meta.agent_name
+    Keeper_exec_status.parse_agent_status config ~agent_name:meta.agent_name
   in
   let now_ts = Time_compat.now () in
   let diagnostic =
@@ -56,7 +56,7 @@ let status ctx (meta : keeper_meta) =
     |> Keeper_exec_status.augment_keeper_diagnostic_json
          ~meta ~keepalive_running
          ~keepalive_started_at:
-           (Keeper_status_bridge.runtime_keepalive_started_at ctx.config meta)
+           (Keeper_status_bridge.runtime_keepalive_started_at config meta)
          ~now_ts
   in
   Keeper_exec_status.keeper_surface_status ~agent_status ~diagnostic
@@ -70,12 +70,12 @@ type active_goal_scope_audit = {
   stale : bool;
 }
 
-let active_goal_scope_audit ctx (meta : keeper_meta) =
+let active_goal_scope_audit ~(config : Coord.config) (meta : keeper_meta) =
   let active_goal_ids = meta.active_goal_ids in
   let task_is_open (task : Masc_domain.task) =
     not (Masc_domain.task_status_is_terminal task.task_status)
   in
-  let tasks = Coord.get_tasks_safe ctx.config in
+  let tasks = Coord.get_tasks_safe config in
   let count_open tasks =
     List.fold_left
       (fun acc task -> if task_is_open task then acc + 1 else acc)
@@ -129,8 +129,8 @@ let profile_candidates persona_name =
   |> List.map (fun root ->
          Filename.concat (Filename.concat root persona_name) "profile.json")
 
-let item ctx requested_name =
-  let meta_result = read_meta_resolved ctx.config requested_name in
+let item ~(config : Coord.config) requested_name =
+  let meta_result = read_meta_resolved config requested_name in
   let resolved_name, runtime_meta, runtime_meta_error =
     match meta_result with
     | Ok (Some (name, meta)) -> (name, Some meta, None)
@@ -212,22 +212,22 @@ let item ctx requested_name =
     | Some "persona" -> true
     | _ -> false
   in
-  let live_meta_path = keeper_meta_path ctx.config resolved_name in
+  let live_meta_path = keeper_meta_path config resolved_name in
   let live_meta_exists = Fs_compat.file_exists live_meta_path in
   let registry_entry =
-    Keeper_registry.get ~base_path:ctx.config.base_path resolved_name
+    Keeper_registry.get ~base_path:config.base_path resolved_name
   in
   let keepalive_running =
     runtime_meta
-    |> Option.map (Keeper_status_bridge.runtime_keepalive_running ctx.config)
+    |> Option.map (Keeper_status_bridge.runtime_keepalive_running config)
   in
   let keepalive_started_at =
     match runtime_meta with
-    | Some meta -> Keeper_status_bridge.runtime_keepalive_started_at ctx.config meta
+    | Some meta -> Keeper_status_bridge.runtime_keepalive_started_at config meta
     | None -> None
   in
-  let runtime_status = runtime_meta |> Option.map (status ctx) in
-  let active_goal_scope = runtime_meta |> Option.map (active_goal_scope_audit ctx) in
+  let runtime_status = runtime_meta |> Option.map (status ~config) in
+  let active_goal_scope = runtime_meta |> Option.map (active_goal_scope_audit ~config) in
   let autoboot_enabled =
     match runtime_meta with
     | Some meta -> Some meta.autoboot_enabled
@@ -373,8 +373,8 @@ let summary items =
       ("stale_active_goal_ids", `Int (count_issue "stale_active_goal_ids"));
     ]
 
-let handle ctx args : tool_result =
-  let names = requested_names ctx args in
+let handle ~(config : Coord.config) args : tool_result =
+  let names = requested_names ~config args in
   let invalid_names = List.filter (fun name -> not (validate_name name)) names in
   if Stdlib.List.length invalid_names > 0 then
     ( false,
@@ -386,7 +386,7 @@ let handle ctx args : tool_result =
     let include_ok = get_bool args "include_ok" true in
     let repair = get_bool args "repair" false in
     let dry_run_repair = get_bool args "dry_run_repair" false in
-    let audited_items = names |> take limit |> List.map (item ctx) in
+    let audited_items = names |> take limit |> List.map (item ~config) in
     let returned_items =
       if include_ok then audited_items
       else
@@ -400,16 +400,16 @@ let handle ctx args : tool_result =
     let repair_result =
       if repair || dry_run_repair then
         Some
-          (if dry_run_repair then Keeper_goal_repair.dry_run ctx.config
-           else Keeper_goal_repair.run ctx.config)
+          (if dry_run_repair then Keeper_goal_repair.dry_run config
+           else Keeper_goal_repair.run config)
       else None
     in
     let resolution = Config_dir_resolver.resolve () in
     let roots =
       `Assoc
         [
-          ("base_path", `String ctx.config.base_path);
-          ("masc_root", `String (Coord.masc_root_dir ctx.config));
+          ("base_path", `String config.base_path);
+          ("masc_root", `String (Coord.masc_root_dir config));
           ("config_resolution", Config_dir_resolver.to_json resolution);
           ( "personas_dirs",
             `List

--- a/lib/tool_keeper_persona_audit.mli
+++ b/lib/tool_keeper_persona_audit.mli
@@ -1,2 +1,2 @@
 val dedupe_sorted_strings : string list -> string list
-val handle : _ Keeper_types.context -> Yojson.Safe.t -> Keeper_types.tool_result
+val handle : config:Coord.config -> Yojson.Safe.t -> Keeper_types.tool_result

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -204,6 +204,52 @@ let test_mutation_boundary_delegates_to_descriptor_policy () =
        ~tool_name:"WriteFile"
        ~input:(`Assoc [ "file_path", `String "x"; "content", `String "y" ]))
 
+(* RFC-0182 §3.1 — verify the 21 new tool_shard / approval / persona /
+   keeper / surface_audit descriptors all project from name → descriptor
+   via [descriptors_for_internal] with the expected [runtime_handler].
+
+   This catches future typos in the [~name:"masc_X"] strings (which the
+   compiler cannot see) and missing cluster builder calls in
+   [internal_descriptors]. *)
+let cluster_projection_table =
+  [ "masc_tool_list", "tool_masc_tool_shard_dispatch"
+  ; "masc_tool_grant", "tool_masc_tool_shard_dispatch"
+  ; "masc_tool_revoke", "tool_masc_tool_shard_dispatch"
+  ; "masc_approval_pending", "tool_masc_approval_dispatch"
+  ; "masc_approval_get", "tool_masc_approval_dispatch"
+  ; "masc_approval_resolve", "tool_masc_approval_dispatch"
+  ; "masc_persona_list", "tool_masc_persona_dispatch"
+  ; "masc_persona_schema", "tool_masc_persona_dispatch"
+  ; "masc_persona_save", "tool_masc_persona_dispatch"
+  ; "masc_keeper_list", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_msg_result", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_compact", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_clear", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_sandbox_start", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_sandbox_stop", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_reset", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_persona_audit", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_status", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_repair", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_down", "tool_masc_keeper_dispatch"
+  ; "masc_surface_audit", "tool_masc_surface_audit"
+  ]
+;;
+
+let test_rfc_0182_clusters_have_descriptor_projection () =
+  List.iter
+    (fun (tool_name, expected_handler) ->
+       match Descriptor.descriptors_for_internal tool_name with
+       | [ descriptor ] ->
+         Alcotest.(check string)
+           (tool_name ^ " runtime handler")
+           expected_handler
+           (Descriptor.runtime_handler_to_string descriptor.runtime_handler)
+       | [] -> Alcotest.failf "missing descriptor for %s" tool_name
+       | _ :: _ :: _ -> Alcotest.failf "duplicate descriptor for %s" tool_name)
+    cluster_projection_table
+;;
+
 let () =
   Alcotest.run
     "agent_tool_descriptor_registry_integrity"
@@ -221,6 +267,12 @@ let () =
             "Tool_board_registry has descriptor projection"
             `Quick
             test_masc_board_registry_has_descriptor_projection
+        ] )
+    ; ( "rfc-0182-clusters"
+      , [ test_case
+            "tool_shard/approval/persona/keeper/surface_audit project to descriptors"
+            `Quick
+            test_rfc_0182_clusters_have_descriptor_projection
         ] )
     ; ( "policy-projection"
       , [ test_case


### PR DESCRIPTION
## 요약

RFC-0182 §3.1 — 4 클러스터 + 1 싱글톤을 descriptor projection 에 추가. **21 descriptors** 활성화 (active routing 55% → 83%, +28pp).

## Clusters

### Cluster 1: masc_tool_shard (3 tools)
`masc_tool_list` `~readonly:true`, `masc_tool_grant` / `masc_tool_revoke` `~readonly:false`.
Direct `Tool_shard.execute` (tuple-return, predates RFC-0189).

### Cluster 2: masc_approval (3 tools)
`masc_approval_pending` / `masc_approval_get` `~readonly:true`, `masc_approval_resolve` `~readonly:false`.
`Keeper_approval_queue` 직접 호출 — `Tool_inline_dispatch` 동일 로직 포팅.

### Cluster 3: masc_persona (3 tools, generate 제외 → Phase 5)
`masc_persona_list` / `masc_persona_schema` `~readonly:true`, `masc_persona_save` `~readonly:false`.
**`Persona_dispatch_ref`** dependency inversion — `Keeper_persona_authoring:880` 의 `Keeper_turn_driver` cycle 우회.

### Cluster 4: masc_keeper (11 tools)
`masc_keeper_list` / `masc_keeper_msg_result` / `masc_keeper_compact` / `masc_keeper_clear` / `masc_keeper_sandbox_start` / `masc_keeper_sandbox_stop` / `masc_keeper_reset` / `masc_keeper_persona_audit` / `masc_keeper_status` / `masc_keeper_repair` / `masc_keeper_down`.
**`Keeper_dispatch_ref`** dependency inversion — `Tool_keeper` (late) → `Agent_tool_in_process_runtime` (early) cycle 우회. `~agent_name` 시그니처 필드로 `masc_keeper_status` 의 self-fallback semantics 보존.

### Singleton: masc_surface_audit
`Dashboard_surface_readiness.json` 직접 호출 (pure, leaf import).

## Phase 5 (deferred — RFC §12 drafted)

10 도구 Eio ctx 의존 — `start_keepalive` / `Operator_control.context` / `load_or_materialize_boot_meta` / LLM-call fiber:
- `masc_keeper_up/msg/sandbox_status/create_from_persona`
- `masc_persona_generate`
- `masc_operator_*` (5)

**Recommendation (Option B)**: `Agent_tool_runtime.ctx` Eio extension — 1 구조 변경 + 4 sub-PR (A: 50 LoC ctx extend, B: 150 LoC keeper, C: 80 LoC persona, D: 200 LoC operator). Target 92%. 자세한 내용 [`docs/rfc/RFC-0182-masc-descriptor-projection.md` §12](docs/rfc/RFC-0182-masc-descriptor-projection.md).

## Cycle safety

| Backing | Path | Reverse Agent_tool_* deps |
|---|---|---|
| Tool_shard | lib/ | none (pure) |
| Keeper_approval_queue | lib/keeper/ | leaf |
| Persona_dispatch_ref | lib/ | leaf |
| Keeper_persona (via ref) | lib/keeper/ | static import avoided |
| Keeper_dispatch_ref | lib/ | leaf |
| Tool_keeper (via ref) | lib/ | static import avoided |
| Dashboard_surface_readiness | lib/dashboard/ | leaf |

## Coverage delta

| | Before | After |
|---|---|---|
| Active routing | 66 / 105 (63%) | **87 / 105 (83%)** |
| Newly active | — | 21 descriptors (4 clusters + 1 singleton) |

## Invariant test

`test/test_agent_tool_descriptor_registry_integrity.ml` — added `test_rfc_0182_clusters_have_descriptor_projection` with 21-entry `cluster_projection_table` verifying tool_name → descriptor + runtime_handler mapping. 10/10 tests pass.

## Co-located CI sweep (iter#21~22)

- `docs/runtime-tunables.md` regen (env_knob_catalog drift from main upstream)
- `TEL-OK` rationale comments added to 7 handler/ref sites (descriptor projection telemetry stays in backing modules)

## Build

```
dune build --root . --cache=disabled @lib/all → PASS
dune build --root . --cache=disabled         → PASS
bash scripts/ci/check-telemetry-coverage.sh  → PASS (TEL gate)
test/test_agent_tool_descriptor_registry_integrity → 10/10 PASS
```

## Workaround Signature Gate

해당 없음. Pure descriptor projection + dependency-inversion cycle breaks. Signature 3종 + 체크리스트 7항목 비해당.

## Related

- #18792 Turn_mode_codec extraction (merged) — first cycle break
- #18811 `let rec has` build fix (merged) — main race-window sweep
- #18812 Coord_dispatch_ref (merged) — first dispatch-ref application