### PR TITLE
feat(tool_coord): tag explicit failure_class on 2 caller-input rejection sites (RFC-0189 small-step)

### DIFF
--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -616,7 +616,11 @@ let handle_reset ~tool_name ~start_time ctx args =
   let confirm = get_bool args "confirm" false in
   if not confirm
   then
+    (* RFC-0189: missing required [confirm=true] safety gate.
+       [Workflow_rejection] — operator can address by passing the
+       expected argument. *)
     Tool_result.error
+      ~failure_class:(Some Tool_result.Workflow_rejection)
       ~tool_name
       ~start_time
       "This will DELETE the entire .masc/ folder!\nCall with confirm=true to proceed."
@@ -694,7 +698,14 @@ let handle_heartbeat ~tool_name ~start_time ctx _args =
   in
   if success
   then Tool_result.ok ~tool_name ~start_time message
-  else Tool_result.error ~tool_name ~start_time message
+  else
+    (* RFC-0189: heartbeat failure stems from agent-state issues
+       ("agent not found", "invalid file") that the caller can
+       resolve (join the room, refresh credentials).
+       [Workflow_rejection]. *)
+    Tool_result.error
+      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~tool_name ~start_time message
 ;;
 
 let dispatch ctx ~name ~args : Tool_result.t option =


### PR DESCRIPTION
## Summary

Continues the explicit `~failure_class` micro-tagging pattern (#18813 / #18817 / #18820). PR-2 (#18793) closed without merge — the pattern lands clean either way.

| Site | Class | Why |
|---|---|---|
| `handle_reset` missing `confirm=true` | `Workflow_rejection` | Caller missed required safety gate |
| `handle_heartbeat` backend failure | `Workflow_rejection` | `Coord.heartbeat` returns warning-prefixed string when agent lookup fails — caller can resolve by joining room / refreshing credentials |

After this PR: **tool_coord has 0 untagged `Tool_result.error` sites**.

## Out of scope

- Migrating tool_coord handlers to typed `Tool_result.result` signature (8 ext callers — fuller cluster PR after post-#18812 rebase needs settle).
- `typed_tool_masc.ml` SDK error / `mcp_server_eio_*.ml` dispatch boundaries — those carry mixed semantics (SDK validation vs transport vs runtime) needing typed upstream errors first.

## Why this PR shape

- Pure `?failure_class` addition. `Tool_result.error` signature preserved.
- Zero supersession risk vs parallel RFC-0189 stream — no caller boundary, no helper.

## Verification

- `dune build --root . --cache=disabled lib/` exit 0

## Test plan

- [x] lib build
- [ ] CI green (Draft)

Refs RFC-0189. Stack with #18813 / #18817 / #18820.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
