### PR TITLE
fix(anti_rationalization): persist excuse_patterns migration to disk

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -136,18 +136,26 @@ let same_pattern_list a b =
   | Invalid_argument _ -> false
 ;;
 
+(** Migrate disk-loaded patterns to current built-in defaults when they
+    exactly match the legacy English-only default.  Returns the migrated
+    list and a [bool] flag indicating whether migration occurred so the
+    caller can persist the new state back to disk; persisting prevents
+    every subsequent boot from re-running the migration (and emitting
+    the same INFO log) against an unchanged stale config file. *)
 let migrate_loaded_excuse_patterns patterns =
   if same_pattern_list patterns legacy_english_excuse_patterns
   then (
     Log.Misc.info
       "excuse_patterns: legacy default config detected; applying current built-in \
        defaults at runtime";
-    default_excuse_patterns)
-  else patterns
+    default_excuse_patterns, true)
+  else patterns, false
 ;;
 
 (** Cached patterns. Loaded once from disk; invalidated by [save_excuse_patterns]. *)
 let cached_patterns : (string * string) list option ref = ref None
+
+let reset_cache_for_tests () = cached_patterns := None
 
 let excuse_patterns_path () =
   let config_dir = (Config_dir_resolver.resolve ()).config_root.path in
@@ -203,27 +211,6 @@ let parse_excuse_patterns_json (json : Yojson.Safe.t)
          (Json_util.kind_name other))
 ;;
 
-(** Load excuse patterns from config/excuse_patterns.json.
-    Returns cached value if available. Falls back to defaults on missing file. *)
-let load_excuse_patterns () : (string * string) list =
-  match !cached_patterns with
-  | Some p -> p
-  | None ->
-    let patterns =
-      let path = excuse_patterns_path () in
-      match Safe_ops.read_json_file_safe path with
-      | Error _ -> default_excuse_patterns
-      | Ok json ->
-        (match parse_excuse_patterns_json json with
-         | Ok p -> migrate_loaded_excuse_patterns p
-         | Error msg ->
-           Log.Misc.warn "excuse_patterns: parse error, using defaults: %s" msg;
-           default_excuse_patterns)
-    in
-    cached_patterns := Some patterns;
-    patterns
-;;
-
 (** Save excuse patterns to config/excuse_patterns.json.
     Uses atomic write (write-to-temp + rename) to prevent corruption.
     Invalidates the in-memory cache on success. *)
@@ -244,6 +231,46 @@ let save_excuse_patterns (patterns : (string * string) list) : (unit, string) re
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
     Error (Printf.sprintf "Failed to save excuse patterns: %s" (Printexc.to_string exn))
+;;
+
+(** Load excuse patterns from config/excuse_patterns.json.
+    Returns cached value if available. Falls back to defaults on missing file.
+
+    When the on-disk file exactly matches the historical English-only
+    default (the only stale snapshot we still see in the wild), the
+    migrated list is written back to disk so subsequent boots load the
+    current defaults directly without re-running the migration step or
+    re-emitting the INFO log line.  A write-back failure is non-fatal:
+    the in-memory result is still returned, and the next boot will
+    retry the migration. *)
+let load_excuse_patterns () : (string * string) list =
+  match !cached_patterns with
+  | Some p -> p
+  | None ->
+    let patterns =
+      let path = excuse_patterns_path () in
+      match Safe_ops.read_json_file_safe path with
+      | Error _ -> default_excuse_patterns
+      | Ok json ->
+        (match parse_excuse_patterns_json json with
+         | Ok p ->
+           let migrated, did_migrate = migrate_loaded_excuse_patterns p in
+           if did_migrate then begin
+             match save_excuse_patterns migrated with
+             | Ok () -> ()
+             | Error msg ->
+               Log.Misc.warn
+                 "excuse_patterns: in-memory migration succeeded but disk \
+                  write-back failed (%s); next boot will repeat the migration"
+                 msg
+           end;
+           migrated
+         | Error msg ->
+           Log.Misc.warn "excuse_patterns: parse error, using defaults: %s" msg;
+           default_excuse_patterns)
+    in
+    cached_patterns := Some patterns;
+    patterns
 ;;
 
 let min_notes_length = 10

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -94,6 +94,12 @@ val parse_excuse_patterns_json : Yojson.Safe.t -> ((string * string) list, strin
     Exposed for dashboard administration. *)
 val save_excuse_patterns : (string * string) list -> (unit, string) result
 
+(** Drop the in-memory pattern cache so the next [load_excuse_patterns]
+    re-reads the on-disk file.  Exposed for tests that swap
+    [MASC_CONFIG_DIR] between cases — the cache is otherwise process-
+    lifetime and would mask later loads. *)
+val reset_cache_for_tests : unit -> unit
+
 (** Check notes for known excuse patterns (local, no LLM).
     Returns [Some (pattern, reason)] if a match is found.
     Exposed for testing. *)

--- a/test/dune
+++ b/test/dune
@@ -1408,6 +1408,8 @@
 
 (include stanzas/test_anti_rationalization_korean_10385.inc)
 
+(include stanzas/test_anti_rationalization_excuse_patterns_writeback.inc)
+
 (include stanzas/test_auth_bearer_mismatch_9786.inc)
 
 (include stanzas/test_auth_rotate_shared_tokens_10304.inc)

--- a/test/stanzas/test_anti_rationalization_excuse_patterns_writeback.inc
+++ b/test/stanzas/test_anti_rationalization_excuse_patterns_writeback.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_anti_rationalization_excuse_patterns_writeback)
+ (modules test_anti_rationalization_excuse_patterns_writeback)
+ (libraries masc_mcp masc_mcp.config_dir_resolver alcotest unix yojson))

--- a/test/test_anti_rationalization_excuse_patterns_writeback.ml
+++ b/test/test_anti_rationalization_excuse_patterns_writeback.ml
@@ -1,0 +1,115 @@
+(** [excuse_patterns_writeback] — pin the disk write-back contract for
+    [load_excuse_patterns].
+
+    Before this fix the migration from legacy English-only patterns to
+    the current built-in defaults happened in memory only.  Every boot
+    re-read the same stale on-disk file, re-ran the migration, and
+    re-emitted the INFO log line.  The dashboard administrator surface
+    that lets operators see the active patterns ([GET
+    /api/v1/dashboard/config/excuse-patterns]) returned the migrated
+    list while the file on disk continued to advertise the legacy
+    snapshot — a quiet divergence between operator-visible state and
+    the persisted source of truth.
+
+    This test fixes that contract: after one [load_excuse_patterns]
+    call the on-disk file must reflect the migrated list, so a second
+    boot (or a fresh process) loads the current defaults directly with
+    no migration step at all. *)
+
+open Alcotest
+
+module A = Masc_mcp.Anti_rationalization
+
+let legacy_english_only_json =
+  {|[
+  ["pre-existing", "claiming the problem already existed"],
+  ["out of scope", "declaring work out of scope"],
+  ["beyond the scope", "declaring work beyond scope"],
+  ["will do later", "deferring work to later"],
+  ["will fix later", "deferring fix to later"],
+  ["will address later", "deferring to later"],
+  ["follow-up", "deferring to a follow-up"],
+  ["follow up", "deferring to a follow-up"],
+  ["works on my end", "unverifiable claim"],
+  ["works on my machine", "unverifiable claim"],
+  ["not reproducible", "dismissing without investigation"],
+  ["not my responsibility", "responsibility deflection"],
+  ["cannot reproduce", "dismissing without investigation"]
+]|}
+
+let write_legacy_config dir =
+  let path = Filename.concat dir "excuse_patterns.json" in
+  let oc = open_out path in
+  output_string oc legacy_english_only_json;
+  close_out oc;
+  path
+
+let isolated_config_dir tag =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "anti_rat_writeback_%s_%d_%.0f"
+         tag (Unix.getpid ()) (Unix.gettimeofday ()))
+  in
+  Unix.mkdir dir 0o700;
+  dir
+
+let count_entries_in_disk_file path =
+  let json = Yojson.Safe.from_file path in
+  match json with
+  | `List items -> List.length items
+  | _ ->
+      failf "expected JSON array on disk, got %s"
+        (Yojson.Safe.to_string json)
+
+let test_writeback_after_migration () =
+  let dir = isolated_config_dir "after-migration" in
+  let path = write_legacy_config dir in
+  Unix.putenv "MASC_CONFIG_DIR" dir;
+  Config_dir_resolver.reset ();
+  let in_memory = A.load_excuse_patterns () in
+  let on_disk_after = count_entries_in_disk_file path in
+  check int "in-memory pattern count matches migrated defaults"
+    23 (List.length in_memory);
+  check int
+    "on-disk file is rewritten with the migrated pattern list \
+     (next boot sees the current defaults directly, no migration)"
+    23 on_disk_after
+
+let test_no_writeback_when_not_legacy () =
+  let dir = isolated_config_dir "no-migration" in
+  let path = Filename.concat dir "excuse_patterns.json" in
+  let custom =
+    {|[
+  ["operator-custom-marker", "custom rationalization phrase"]
+]|}
+  in
+  let oc = open_out path in
+  output_string oc custom;
+  close_out oc;
+  let mtime_before = (Unix.stat path).st_mtime in
+  Unix.putenv "MASC_CONFIG_DIR" dir;
+  Config_dir_resolver.reset ();
+  A.reset_cache_for_tests ();
+  let in_memory = A.load_excuse_patterns () in
+  let mtime_after = (Unix.stat path).st_mtime in
+  check int "custom single-entry config is loaded verbatim"
+    1 (List.length in_memory);
+  check (float 0.0)
+    "on-disk mtime unchanged (no spurious write-back for non-legacy \
+     configs)"
+    mtime_before mtime_after
+
+let () =
+  run "anti_rationalization_excuse_patterns_writeback"
+    [
+      ( "migration-writeback",
+        [
+          test_case
+            "legacy-only on-disk → write-back persists migrated defaults"
+            `Quick test_writeback_after_migration;
+          test_case
+            "custom on-disk → no write-back, file mtime preserved" `Quick
+            test_no_writeback_when_not_legacy;
+        ] );
+    ]


### PR DESCRIPTION
## 문제

\`migrate_loaded_excuse_patterns\`은 disk에서 로드한 패턴이 *legacy English-only default* (13개)와 정확히 일치할 때 in-memory만 현재 built-in default (EN 13 + KO 10 = 23개)로 swap. **disk write-back 없음** → 매 부팅 동일 file 로드 → 동일 migrate 반복 → 동일 INFO log 반복 emit.

### 부작용

1. **operator-visible state divergence**: dashboard admin endpoint (\`GET /api/v1/dashboard/config/excuse-patterns\`)이 in-memory 23개 패턴 반환. 그러나 disk file은 여전히 legacy 13개. 운영자가 본 것과 *persisted source of truth*가 silent하게 다름.
2. **log noise**: 매 부팅 INFO \`excuse_patterns: legacy default config detected; applying current built-in defaults at runtime\`. 정상 동작인데 매번 출력.
3. **Self-irony**: anti_rationalization 모듈이 *자기 자신*의 config drift를 silent migration으로 흡수.

## 변경

- \`migrate_loaded_excuse_patterns\` 시그니처: \`(string * string) list -> (string * string) list * bool\` (둘째: did_migrate 플래그)
- \`load_excuse_patterns\`이 \`did_migrate = true\`일 때 \`save_excuse_patterns migrated\` 호출. 실패는 non-fatal (WARN log 후 in-memory 값 유지, 다음 부팅 재시도)
- \`reset_cache_for_tests\` 노출 — \`MASC_CONFIG_DIR\` 스왑하는 test 격리용 (process-lifetime cache 우회)

## 검증

새 test (\`test_anti_rationalization_excuse_patterns_writeback\`): 2/2 PASS
- legacy on-disk → load 후 disk file이 23 entries로 rewrite됨
- custom on-disk → file mtime 변경 없음 (불필요한 write 회피)

기존 anti_rationalization test 5개 전부 회귀 없음 (Korean / English / coverage / empty_liveness / fail_mode / gate2_advisory).

\`dune build lib/\` clean.

## Workaround Signature Self-Check

| § | 항목 | 평가 |
|---|---|---|
| 1 | counter-as-fix | N/A — disk write-back은 actual state convergence, instrumentation 아님 |
| 2 | substring/prefix classifier | N/A |
| 3 | "K of M sites" | N/A — single function fix |
| 4 | catch-all 추가 | N/A |
| 5 | cap/cooldown/dedup/repair | **boundary** — log dedup같이 보일 수 있으나 root cause(silent state divergence)를 fix함. log noise 감소는 downstream 효과 |
| 6 | test backdoor | \`reset_cache_for_tests\` 추가. production-bypass 아닌 *cache invalidation entry*. suffix/docstring으로 intent 명시 |
| 7 | codemod 미수행 | N/A |

§5 §6 명시적 self-disclosure. RFC-WAIVED: 단일 모듈 root fix, RFC 불필요.

## 영향 범위

\`grep load_excuse_patterns\`: 3 caller (h2_gateway, http_routes_dashboard, find_excuse_pattern). 모두 시그니처 변경 없는 외부 함수 호출 → 무영향.

RFC-WAIVED: 단일 함수 silent-migration root fix, RFC 불필요.