### PR TITLE
refactor(tools): purge retired workspace inspect op residue

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -52,7 +52,7 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0004 | OCaml ↔ TypeScript shared contract — SSE + gRPC-web | Active | cea4acd3f3 2026-05-21 | - |
 | 0005 | Typed Capability Substrate for Local Exec Core | Draft | f0075c3611 2026-05-17 | - |
 | 0006 | Keeper Tool Surface Realignment & Symmetric Sandbox | Draft | b799d75cb4 2026-05-21 | - |
-| 0007 | Pragmatic `keeper_shell op=gh` Hardening | Draft | f0075c3611 2026-05-17 | - |
+| 0007 | Pragmatic `keeper_shell op=gh` Hardening | Superseded | f0075c3611 2026-05-17 | - |
 | 0008 | `CredentialProvider` Trait (Minimum Viable) | Draft | f0075c3611 2026-05-17 | - |
 | 0009 | Cascade Trust Phase 2: Operator Recommendations + Opt-in Persist | Draft | f0075c3611 2026-05-17 | - |
 | 0010 | ocamlformat config reconciliation | Implemented | 77bbbf3455 2026-05-22 | - |

--- a/lib/tool_resource_axis.ml
+++ b/lib/tool_resource_axis.ml
@@ -118,7 +118,6 @@ let classify_shell_op_value raw =
   | "git_status" | "git_log" | "git_diff" -> Known_shell_op Filesystem_read
   | "rg" | "find" | "tree" | "cat" | "head" | "tail" | "wc" | "ls" ->
     Known_shell_op Filesystem_read
-  | "bash" | "exec" | "shell" | "sh" -> Known_shell_op Shell
   | unknown -> Unknown_shell_op unknown
 ;;
 
@@ -129,10 +128,10 @@ let classify_structured_shell_op args =
      | Known_shell_op resource_class -> resource_class
      | Unknown_shell_op unknown ->
        Log.Mcp.warn
-         "unknown structured shell op; defaulting resource gate to shell: op=%s"
+         "unknown structured workspace op; skipping resource gate for unsupported op=%s"
          unknown;
-       Shell)
-  | None -> Shell
+       Ungated)
+  | None -> Ungated
 ;;
 
 let classify_keeper_tool (tool : Tool_name.Keeper.t) args =

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -1018,8 +1018,13 @@ let test_approval_queue_surfaces_action_key_and_sandbox_target () =
       let id =
         Lib.Keeper_approval_queue.submit_pending
           ~keeper_name:"governance-judge"
-          ~tool_name:"tool_workspace_inspect"
-          ~input:(`Assoc [("op", `String "gh"); ("cmd", `String "pr view 123")])
+          ~tool_name:"tool_execute"
+          ~input:
+            (`Assoc
+              [ ("action", `String "pr_view")
+              ; ("executable", `String "gh")
+              ; ("argv", `List [ `String "pr"; `String "view"; `String "123" ])
+              ])
           ~risk_level:Lib.Keeper_approval_queue.Medium
           ~runtime_contract:
             (`Assoc [("backend", `String "docker"); ("sandbox_target", `String "docker")])
@@ -1042,7 +1047,7 @@ let test_approval_queue_surfaces_action_key_and_sandbox_target () =
           let approval =
             json |> member "approval_queue" |> to_list |> List.hd
           in
-          check string "action key surfaced" "op:gh"
+          check string "action key surfaced" "action:pr_view"
             (approval |> member "action_key" |> to_string);
           check string "sandbox target surfaced" "docker"
             (approval |> member "sandbox_target" |> to_string)))

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -885,30 +885,6 @@ let test_escalation_non_state_mod_unchanged () =
   Alcotest.(check string) "read-only stays low"
     "low" (Gp.risk_level_to_string unchanged)
 
-let test_escalation_retired_tool_search_files_gh_stays_low () =
-  let unchanged =
-    Gp.combinatorial_risk_escalation
-      ~trifecta_active:true
-      ~tool_name:"tool_workspace_inspect"
-      ~input:(`Assoc [("op", `String "gh"); ("cmd", `String "pr view 123")])
-      ~base_risk:Gp.Low
-  in
-  Alcotest.(check string) "retired tool_workspace_inspect op=gh stays low"
-    "low" (Gp.risk_level_to_string unchanged);
-  let typed_unchanged =
-    Gp.combinatorial_risk_escalation
-      ~trifecta_active:true
-      ~tool_name:"tool_workspace_inspect"
-      ~input:
-        (`Assoc
-          [ ("op", `String "gh")
-          ; ("argv", `List [ `String "pr"; `String "view"; `String "123" ])
-          ])
-      ~base_risk:Gp.Low
-  in
-  Alcotest.(check string) "retired tool_workspace_inspect op=gh argv stays low"
-    "low" (Gp.risk_level_to_string typed_unchanged)
-
 let test_tool_capabilities_known () =
   let caps = Gp.tool_capabilities "tool_execute" in
   Alcotest.(check int) "bash has 3 capabilities" 3 (List.length caps)
@@ -1028,8 +1004,6 @@ let () =
         test_escalation_no_trifecta_no_change;
       Alcotest.test_case "escalation: non-state_mod unchanged" `Quick
         test_escalation_non_state_mod_unchanged;
-      Alcotest.test_case "escalation: retired tool_workspace_inspect op=gh unchanged" `Quick
-        test_escalation_retired_tool_search_files_gh_stays_low;
       Alcotest.test_case "capabilities: known tool" `Quick
         test_tool_capabilities_known;
       Alcotest.test_case "capabilities: unknown tool" `Quick

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -251,57 +251,6 @@ let test_risk_classification_low () =
       (GP.risk_level_to_string actual)
   ) tools
 
-let test_tool_search_files_retired_gh_stays_low () =
-  let actual =
-    GP.assess_risk
-      ~tool_name:"tool_workspace_inspect"
-      ~input:(`Assoc [("op", `String "gh"); ("cmd", `String "pr view 123")])
-  in
-  check "retired tool_workspace_inspect op=gh pr view → low"
-    (GP.risk_level_to_string GP.Low)
-    (GP.risk_level_to_string actual);
-  let typed_actual =
-    GP.assess_risk
-      ~tool_name:"tool_workspace_inspect"
-      ~input:
-        (`Assoc
-          [ ("op", `String "gh")
-          ; ("argv", `List [ `String "pr"; `String "view"; `String "123" ])
-          ])
-  in
-  check "retired tool_workspace_inspect op=gh argv pr view → low"
-    (GP.risk_level_to_string GP.Low)
-    (GP.risk_level_to_string typed_actual)
-
-let test_tool_search_files_retired_gh_mutation_stays_low () =
-  let actual =
-    GP.assess_risk
-      ~tool_name:"tool_workspace_inspect"
-      ~input:(`Assoc [("op", `String "gh"); ("cmd", `String "pr comment 123 --body hi")])
-  in
-  check "retired tool_workspace_inspect op=gh pr comment → low"
-    (GP.risk_level_to_string GP.Low)
-    (GP.risk_level_to_string actual);
-  let typed_actual =
-    GP.assess_risk
-      ~tool_name:"tool_workspace_inspect"
-      ~input:
-        (`Assoc
-          [ ("op", `String "gh")
-          ; ( "argv"
-            , `List
-                [ `String "pr"
-                ; `String "comment"
-                ; `String "123"
-                ; `String "--body"
-                ; `String "hi"
-                ] )
-          ])
-  in
-  check "retired tool_workspace_inspect op=gh argv pr comment → low"
-    (GP.risk_level_to_string GP.Low)
-    (GP.risk_level_to_string typed_actual)
-
 (* ── 2. Threshold decisions ──────────────────────────────── *)
 
 let test_development_allows_all () =
@@ -700,8 +649,12 @@ let test_background_pending_distinct_inputs_do_not_reuse_entry () =
   let id1 =
     AQ.submit_pending
       ~keeper_name:"gate-keeper"
-      ~tool_name:"tool_workspace_inspect"
-      ~input:(`Assoc [("op", `String "gh"); ("cmd", `String "pr view 123")])
+      ~tool_name:"tool_execute"
+      ~input:
+        (`Assoc
+          [ "executable", `String "git"
+          ; "argv", `List [ `String "status"; `String "--short" ]
+          ])
       ~risk_level:AQ.Medium
       ~on_resolution:(fun decision -> callback_result := decision :: !callback_result)
       ()
@@ -709,8 +662,12 @@ let test_background_pending_distinct_inputs_do_not_reuse_entry () =
   let id2 =
     AQ.submit_pending
       ~keeper_name:"gate-keeper"
-      ~tool_name:"tool_workspace_inspect"
-      ~input:(`Assoc [("op", `String "gh"); ("cmd", `String "pr comment 123 --body hi")])
+      ~tool_name:"tool_execute"
+      ~input:
+        (`Assoc
+          [ "executable", `String "git"
+          ; "argv", `List [ `String "log"; `String "--oneline"; `String "-1" ]
+          ])
       ~risk_level:AQ.High
       ~on_resolution:(fun decision -> callback_result := decision :: !callback_result)
       ()
@@ -1450,14 +1407,10 @@ let test_runtime_trust_approval_read_model_filters_after_wide_scan () =
 let () =
   Alcotest.run "HITL Approval" [
     ("risk_classification", [
-      Alcotest.test_case "critical tools" `Quick test_risk_classification_critical;
-      Alcotest.test_case "high-risk tools" `Quick test_risk_classification_high;
-      Alcotest.test_case "low-risk tools" `Quick test_risk_classification_low;
-      Alcotest.test_case "retired tool_workspace_inspect op=gh stays low" `Quick
-        test_tool_search_files_retired_gh_stays_low;
-      Alcotest.test_case "retired tool_workspace_inspect op=gh mutation stays low" `Quick
-        test_tool_search_files_retired_gh_mutation_stays_low;
-    ]);
+	      Alcotest.test_case "critical tools" `Quick test_risk_classification_critical;
+	      Alcotest.test_case "high-risk tools" `Quick test_risk_classification_high;
+	      Alcotest.test_case "low-risk tools" `Quick test_risk_classification_low;
+	    ]);
     ("threshold_decisions", [
       Alcotest.test_case "development allows all" `Quick test_development_allows_all;
       Alcotest.test_case "paranoid blocks medium+" `Quick test_paranoid_blocks_medium;

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -1412,30 +1412,6 @@ let test_pr_work_action_metric_extracts_embedded_output_json () =
     (hook_output_parse_failures "pr_work_action")
 ;;
 
-let test_pr_work_action_metric_extracts_gh_pr_create () =
-  let events =
-    pr_work_events
-      ~tool_name:"tool_workspace_inspect"
-      ~input:(`Assoc [ "op", `String "gh"; "cmd", `String "pr create --draft --title t" ])
-      ~output_text:
-        {|{"ok":true,"op":"gh","command":"gh pr create --draft","route":{"via":"docker"}}|}
-      ()
-  in
-  check (list string) "legacy tool_workspace_inspect gh ignored" [] (work_actions events)
-;;
-
-let test_pr_work_action_metric_extracts_quoted_output_gh_pr_create () =
-  let events =
-    pr_work_events
-      ~tool_name:"tool_workspace_inspect"
-      ~input:(`Assoc [ "op", `String "gh"; "cmd", `String "pr status" ])
-      ~output_text:
-        {|{"ok":true,"op":"gh","command":"gh 'pr' 'create' '--draft' '--base' 'main' '--head' 'keeper/proof'","via":"docker"}|}
-      ()
-  in
-  check (list string) "legacy tool_workspace_inspect gh output ignored" [] (work_actions events)
-;;
-
 let test_pr_work_action_metric_extracts_bash_git_push_with_redirection () =
   let events =
     pr_work_events
@@ -1490,18 +1466,7 @@ let test_pr_work_action_metric_ignores_quoted_command_words () =
     "quoted command words do not add actions"
     [ "GIT_COMMIT" ]
     (work_actions bash_events);
-  let gh_events =
-    pr_work_events
-      ~tool_name:"tool_workspace_inspect"
-      ~input:
-        (`Assoc
-            [ "op", `String "gh"
-            ; "cmd", `String "issue comment 1 --body \"please pr create later\""
-            ])
-      ~output_text:{|{"ok":true}|}
-      ()
-  in
-  check (list string) "quoted pr create is not a command" [] (work_actions gh_events)
+  ()
 ;;
 
 let test_pr_work_action_metric_skips_shell_control_flow_segments () =
@@ -1721,14 +1686,6 @@ let () =
             "extracts embedded output JSON"
             `Quick
             test_pr_work_action_metric_extracts_embedded_output_json
-        ; test_case
-            "ignores legacy tool_workspace_inspect gh pr create"
-            `Quick
-            test_pr_work_action_metric_extracts_gh_pr_create
-        ; test_case
-            "ignores legacy tool_workspace_inspect gh output pr create"
-            `Quick
-            test_pr_work_action_metric_extracts_quoted_output_gh_pr_create
         ; test_case
             "extracts bash git push with redirection"
             `Quick

--- a/test/test_keeper_routine_allowlist.ml
+++ b/test/test_keeper_routine_allowlist.ml
@@ -220,11 +220,11 @@ let test_tool_search_files_arbitrary_action_does_not_match () =
        ~input:(`Assoc [ ("action", `String "ls") ])
        ~risk_level:RL.Low)
 
-let test_tool_search_files_git_clone_does_not_match () =
-  Alcotest.(check bool) "tool_workspace_inspect op=git_clone is not auto-approved"
+let test_tool_search_files_unknown_op_does_not_match () =
+  Alcotest.(check bool) "tool_workspace_inspect unknown op is not auto-approved"
     false
     (RA.matches ~tool_name:"tool_workspace_inspect"
-       ~input:(`Assoc [ ("op", `String "git_clone") ])
+       ~input:(`Assoc [ ("op", `String "future_repo_op") ])
        ~risk_level:RL.Medium)
 
 let test_tool_search_files_force_op_does_not_match () =
@@ -236,23 +236,23 @@ let test_tool_search_files_force_op_does_not_match () =
 
 let test_tool_search_files_op_takes_precedence_over_action () =
   Alcotest.(check bool)
-    "tool_workspace_inspect op=force_push wins over action=git_clone"
+    "tool_workspace_inspect op=force_push wins over action"
     false
     (RA.matches ~tool_name:"tool_workspace_inspect"
        ~input:
          (`Assoc
            [
-             ("action", `String "git_clone");
+             ("action", `String "routine");
              ("op", `String "force_push");
            ])
        ~risk_level:RL.Medium)
 
-let test_tool_search_files_git_clone_critical_rejected () =
+let test_tool_search_files_unknown_op_critical_rejected () =
   Alcotest.(check bool)
-    "tool_workspace_inspect op=git_clone at Critical does NOT auto-approve"
+    "tool_workspace_inspect unknown op at Critical does NOT auto-approve"
     false
     (RA.matches ~tool_name:"tool_workspace_inspect"
-       ~input:(`Assoc [ ("op", `String "git_clone") ])
+       ~input:(`Assoc [ ("op", `String "future_repo_op") ])
        ~risk_level:RL.Critical)
 
 let test_tool_edit_file_does_not_match () =
@@ -422,16 +422,16 @@ let () =
           Alcotest.test_case "unknown tool" `Quick
             test_unknown_tool_does_not_match;
         ] );
-      ( "tool_search_files_legacy_ops_not_allowlisted",
+      ( "tool_search_files_unknown_ops_not_allowlisted",
         [
-          Alcotest.test_case "op=git_clone rejected" `Quick
-            test_tool_search_files_git_clone_does_not_match;
+          Alcotest.test_case "unknown op rejected" `Quick
+            test_tool_search_files_unknown_op_does_not_match;
           Alcotest.test_case "op=force_push rejected" `Quick
             test_tool_search_files_force_op_does_not_match;
           Alcotest.test_case "op takes precedence over action" `Quick
             test_tool_search_files_op_takes_precedence_over_action;
           Alcotest.test_case "Critical risk overrides routine" `Quick
-            test_tool_search_files_git_clone_critical_rejected;
+            test_tool_search_files_unknown_op_critical_rejected;
         ] );
       ( "rule_label",
         [

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -617,7 +617,7 @@ let test_rg_no_match_remains_successful_in_docker_route () =
   Alcotest.(check int) "rg no-match returns empty matches" 0
     (parse_field raw "matches" |> Json.to_list |> List.length)
 
-let test_git_clone_is_unsupported_before_docker () =
+let test_unknown_workspace_op_is_unsupported_before_docker () =
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground:_ ->
   let raw =
@@ -627,15 +627,15 @@ let test_git_clone_is_unsupported_before_docker () =
       ~args:
         (`Assoc
           [
-            ("op", `String "git_clone");
+            ("op", `String "future_repo_op");
             ("url", `String "https://github.com/jeong-sik/masc-mcp.git");
           ])
   in
-  Alcotest.(check (option bool)) "git_clone is unsupported" (Some false)
+  Alcotest.(check (option bool)) "unknown op is unsupported" (Some false)
     (parse_bool_field raw "ok");
   Alcotest.(check (option string)) "error" (Some "unsupported_op")
     (parse_string_field raw "error");
-  Alcotest.(check (option string)) "unsupported op" (Some "git_clone")
+  Alcotest.(check (option string)) "unsupported op" (Some "future_repo_op")
     (parse_string_field raw "op")
 
 let test_turn_sandbox_file_write_uses_host_bind_mount () =
@@ -1217,28 +1217,6 @@ let test_bash_git_push_routes_through_git_creds_docker () =
   in
   Alcotest.(check bool) "generic typed push does not mount GH identity bundle" false
     (contains_substring log (gh_config_mount_spec root_gh_dir))
-
-let test_tool_search_files_gh_pr_review_is_unsupported () =
-  with_tool_policy_config @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
-  @@ fun ~config ~meta ~playground ->
-  let raw =
-    Keeper_exec_shell.handle_tool_search_files
-      ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
-      ~args:
-        (`Assoc
-           [ ("op", `String "gh")
-           ; ("cmd", `String "pr review 123 --approve --body ok")
-           ; ("cwd", `String playground)
-           ])
-  in
-  Alcotest.(check (option bool)) "blocked" (Some false)
-    (parse_bool_field raw "ok");
-  Alcotest.(check (option string)) "error"
-    (Some "unsupported_op")
-    (parse_string_field raw "error");
-  Alcotest.(check (option string)) "unsupported op" (Some "gh")
-    (parse_string_field raw "op")
 
 let docker_run_line log_path =
   read_file log_path
@@ -2108,9 +2086,6 @@ let () =
             "docker keeper git push routes through git-creds docker"
             `Quick test_bash_git_push_routes_through_git_creds_docker;
           Alcotest.test_case
-            "tool_workspace_inspect gh pr review is unsupported"
-            `Quick test_tool_search_files_gh_pr_review_is_unsupported;
-          Alcotest.test_case
             "docker keeper bash executes through fake docker"
             `Quick test_bash_fake_docker_executes;
           Alcotest.test_case
@@ -2158,8 +2133,8 @@ let () =
         [
           Alcotest.test_case "rg no-match remains successful" `Quick
             test_rg_no_match_remains_successful_in_docker_route;
-          Alcotest.test_case "git_clone is unsupported before docker" `Quick
-            test_git_clone_is_unsupported_before_docker;
+          Alcotest.test_case "unknown workspace op is unsupported before docker" `Quick
+            test_unknown_workspace_op_is_unsupported_before_docker;
           Alcotest.test_case
             "turn sandbox file writes use bind-mounted host path"
             `Quick test_turn_sandbox_file_write_uses_host_bind_mount;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2448,11 +2448,6 @@ let test_capabilities_prompt_distinguishes_sandbox_and_worktree () =
        "Read/observe aliases are passive: SearchFiles, ReadFile");
   check
     bool
-    "gh pr create path not documented"
-    false
-    (contains_substring prompt "tool_workspace_inspect op=gh cmd='pr create --draft");
-  check
-    bool
     "legacy pr workflow removed from prompt"
     false
     (contains_substring prompt "github_pr_workflow")

--- a/test/test_keeper_unified_required_tools.ml
+++ b/test/test_keeper_unified_required_tools.ml
@@ -48,11 +48,7 @@ let test_required_tool_satisfaction_rejects_passive_tools () =
   check bool "ReadFile alias remains passive progress" true
     (KTP.is_passive_status_tool_name "ReadFile");
   check bool "SearchFiles alias remains passive progress" true
-    (KTP.is_passive_status_tool_name "SearchFiles");
-  check bool "legacy tool_workspace_inspect gh does not satisfy required-action contract" false
-    (satisfies_required_tool
-       "tool_workspace_inspect"
-       (`Assoc [ "op", `String "gh"; "cmd", `String "pr view 123" ]))
+    (KTP.is_passive_status_tool_name "SearchFiles")
 ;;
 
 let test_required_tool_satisfaction_accepts_mutating_tools () =

--- a/test/test_tool_resource_gate.ml
+++ b/test/test_tool_resource_gate.ml
@@ -83,20 +83,25 @@ let test_classifies_host_local_bottlenecks () =
     (classify "SearchWeb" ~args:(`Assoc [ "query", `String "masc" ]));
   check
     string
-    "tool_workspace_inspect legacy git_clone defaults visibly to shell"
-    "shell"
+    "tool_workspace_inspect unsupported op skips shell gate"
+    "ungated"
     (classify
        "tool_workspace_inspect"
        ~is_read_only:true
-       ~args:(`Assoc [ "op", `String "git_clone" ]));
+       ~args:(`Assoc [ "op", `String "future_repo_op" ]));
   check
     string
-    "tool_workspace_inspect unknown op defaults visibly to shell"
-    "shell"
+    "tool_workspace_inspect missing op skips shell gate"
+    "ungated"
+    (classify "tool_workspace_inspect" ~is_read_only:true ~args:(`Assoc []));
+  check
+    string
+    "tool_workspace_inspect shell-looking op is not a shell fallback"
+    "ungated"
     (classify
        "tool_workspace_inspect"
        ~is_read_only:true
-       ~args:(`Assoc [ "op", `String "future_op" ]));
+       ~args:(`Assoc [ "op", `String "bash" ]));
   check string "board write" "board_write" (classify "masc_board_post");
   check string "transition" "coordination_write" (classify "masc_transition");
   check string "worker shell_exec" "shell" (classify "shell_exec");


### PR DESCRIPTION
## Summary
- stop routing unsupported tool_workspace_inspect ops through the shell resource gate
- remove tests that preserved retired tool_workspace_inspect op=gh/git_clone compatibility behavior
- mark RFC-0007 as Superseded in the RFC index

## Validation
- rg residue scan for tool_workspace_inspect op=gh/git_clone markers in lib/test/docs/rfc README
- ocamlformat --check touched OCaml files
- git diff --check HEAD~1..HEAD
- ./_build/default/test/test_tool_resource_gate.exe
- ./_build/default/test/test_keeper_unified_required_tools.exe
- ./_build/default/test/test_keeper_routine_allowlist.exe