### PR TITLE
refactor(tool-registry): evaluate readonly policy from descriptors

### DIFF
--- a/lib/core/tool_name_alias_axis.ml
+++ b/lib/core/tool_name_alias_axis.ml
@@ -10,10 +10,18 @@ let public_aliases =
   ; { public_name = "EditFile"; internal_name = "tool_edit_file" }
   ; { public_name = "FetchWeb"; internal_name = "masc_web_fetch" }
   ; { public_name = "ReadFile"; internal_name = "tool_read_file" }
-  ; { public_name = "SearchFiles"; internal_name = "tool_workspace_inspect" }
+  ; { public_name = "SearchFiles"; internal_name = "tool_search_files" }
   ; { public_name = "SearchWeb"; internal_name = "masc_web_search" }
   ; { public_name = "WriteFile"; internal_name = "tool_write_file" }
   ]
+;;
+
+let legacy_internal_aliases = [ "tool_workspace_inspect", "tool_search_files" ]
+
+let primary_internal_name internal_name =
+  match List.assoc_opt internal_name legacy_internal_aliases with
+  | Some primary -> primary
+  | None -> internal_name
 ;;
 
 let public_names () =
@@ -27,6 +35,7 @@ let internal_name_of_public public_name =
 ;;
 
 let public_name_for_internal internal_name =
+  let internal_name = primary_internal_name internal_name in
   public_aliases
   |> List.find_opt (fun alias -> String.equal alias.internal_name internal_name)
   |> Option.map (fun alias -> alias.public_name)

--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -410,8 +410,11 @@ let public_descriptors =
   ; descriptor
       ~id:"agent.workspace_inspect"
       ~public_name:"SearchFiles"
-      ~internal_name:"tool_workspace_inspect"
-      ~description:"Inspect the project workspace through a structured op (ls, cat, find, rg, head, tail, wc, tree, git_status, git_log, git_diff, pwd)."
+      ~internal_name:"tool_search_files"
+      ~description:
+        "Inspect the project workspace through structured read-only operations \
+         including ripgrep search, file reads, directory listings, and scoped \
+         git status/log/diff views."
       ~input_schema:search_files_schema
       ~policy:
         (policy
@@ -1187,12 +1190,24 @@ let all_descriptors () = public_descriptors @ internal_descriptors
 
 let public_names () = List.map (fun d -> d.public_name) public_descriptors
 
+let legacy_internal_names (d : t) =
+  match d.id with
+  | "agent.workspace_inspect" -> [ "tool_workspace_inspect" ]
+  | _ -> []
+;;
+
+let internal_names d =
+  d.internal_name :: legacy_internal_names d |> List.sort_uniq String.compare
+;;
+
 let find_public name =
   List.find_opt (fun d -> String.equal d.public_name name) public_descriptors
 ;;
 
 let public_descriptors_for_internal internal_name =
-  List.filter (fun d -> String.equal d.internal_name internal_name) public_descriptors
+  List.filter
+    (fun d -> List.exists (String.equal internal_name) (internal_names d))
+    public_descriptors
 ;;
 
 (* Walks [all_descriptors ()]. Used by the runtime dispatcher to resolve any
@@ -1200,7 +1215,9 @@ let public_descriptors_for_internal internal_name =
    that live in [internal_descriptors]. While [internal_descriptors = []], this
    returns the same result as [public_descriptors_for_internal]. *)
 let descriptors_for_internal internal_name =
-  List.filter (fun d -> String.equal d.internal_name internal_name) (all_descriptors ())
+  List.filter
+    (fun d -> List.exists (String.equal internal_name) (internal_names d))
+    (all_descriptors ())
 ;;
 
 let readonly_static_hint d = d.policy.readonly_hint
@@ -1208,10 +1225,10 @@ let readonly_for_input d ~input = d.policy.readonly_of_input input
 
 let readonly_internal_names () =
   all_descriptors ()
-  |> List.filter_map (fun d ->
+  |> List.concat_map (fun d ->
     match readonly_static_hint d with
-    | Some true -> Some d.internal_name
-    | Some false | None -> None)
+    | Some true -> internal_names d
+    | Some false | None -> [])
   |> List.sort_uniq String.compare
 ;;
 

--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -24,6 +24,8 @@ type approval =
   | Policy_selected
   | Human_required
 
+type readonly_of_input = Yojson.Safe.t -> bool option
+
 type runtime_handler =
   | Tool_execute
   | Tool_workspace_inspect
@@ -62,7 +64,8 @@ type runtime_handler =
 
 type policy =
   { visibility : Tool_catalog.visibility
-  ; readonly : bool option
+  ; readonly_of_input : readonly_of_input
+  ; readonly_hint : bool option
   ; effect_domain : Tool_catalog.effect_domain option
   ; approval : approval
   ; retryable : bool
@@ -150,12 +153,18 @@ let runtime_handler_to_string = function
   | Tool_masc_surface_audit -> "tool_masc_surface_audit"
 ;;
 
-let policy ?(visibility = Tool_catalog.Default) ?readonly ?effect_domain
-      ?(approval = Policy_selected) ?cwd_scope ?credential_profile
+let policy ?(visibility = Tool_catalog.Default) ?readonly ?readonly_of_input
+      ?effect_domain ?(approval = Policy_selected) ?cwd_scope ?credential_profile
       ?(retryable = false) ()
   =
+  let readonly_of_input =
+    match readonly_of_input with
+    | Some readonly_of_input -> readonly_of_input
+    | None -> fun _input -> readonly
+  in
   { visibility
-  ; readonly
+  ; readonly_of_input
+  ; readonly_hint = readonly
   ; effect_domain
   ; approval
   ; retryable
@@ -334,6 +343,22 @@ let translate_search_files input =
   | _ -> input
 ;;
 
+let workspace_inspect_op (input : Yojson.Safe.t) : string option =
+  match input with
+  | `Assoc fields ->
+    (match List.assoc_opt "op" fields with
+     | Some (`String s) -> Some (String.lowercase_ascii (String.trim s))
+     | _ -> None)
+  | _ -> None
+;;
+
+let workspace_inspect_readonly_of_input input =
+  match workspace_inspect_op input with
+  | Some op when List.mem op Keeper_workspace_op.valid_strings -> Some true
+  | Some _ -> None
+  | None -> None
+;;
+
 let descriptor ~id ~public_name ~internal_name ~description ~input_schema ~policy
       ~executor ~backend ~sandbox ~runtime_handler ~translate
   =
@@ -391,6 +416,7 @@ let public_descriptors =
       ~policy:
         (policy
            ~readonly:true
+           ~readonly_of_input:workspace_inspect_readonly_of_input
            ~effect_domain:Tool_catalog.Read_only
            ~cwd_scope:"keeper_sandbox_or_allowed_path"
            ~retryable:true
@@ -1177,10 +1203,13 @@ let descriptors_for_internal internal_name =
   List.filter (fun d -> String.equal d.internal_name internal_name) (all_descriptors ())
 ;;
 
+let readonly_static_hint d = d.policy.readonly_hint
+let readonly_for_input d ~input = d.policy.readonly_of_input input
+
 let readonly_internal_names () =
   all_descriptors ()
   |> List.filter_map (fun d ->
-    match d.policy.readonly with
+    match readonly_static_hint d with
     | Some true -> Some d.internal_name
     | Some false | None -> None)
   |> List.sort_uniq String.compare
@@ -1230,7 +1259,7 @@ let route_evidence_json d =
      ; "canonical_name", `String d.internal_name
      ; "description", `String d.description
      ; "visibility", `String (Tool_catalog.visibility_to_string policy.visibility)
-     ; "readonly", bool_opt_to_json policy.readonly
+     ; "readonly", bool_opt_to_json policy.readonly_hint
      ; "executor", `String (executor_to_string d.executor)
      ; "backend", `String (backend_to_string d.backend)
      ; "sandbox", `String (sandbox_to_string d.sandbox)

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -115,6 +115,7 @@ val internal_descriptors : t list
 val all_descriptors : unit -> t list
 
 val public_names : unit -> string list
+val internal_names : t -> string list
 val find_public : string -> t option
 val public_name_for_internal : string -> string option
 val public_descriptors_for_internal : string -> t list

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -29,6 +29,8 @@ type approval =
   | Policy_selected
   | Human_required
 
+type readonly_of_input = Yojson.Safe.t -> bool option
+
 type runtime_handler =
   | Tool_execute
   | Tool_workspace_inspect
@@ -67,7 +69,8 @@ type runtime_handler =
 
 type policy =
   { visibility : Tool_catalog.visibility
-  ; readonly : bool option
+  ; readonly_of_input : readonly_of_input
+  ; readonly_hint : bool option
   ; effect_domain : Tool_catalog.effect_domain option
   ; approval : approval
   ; retryable : bool
@@ -121,8 +124,11 @@ val public_descriptors_for_internal : string -> t list
     alongside the seven LLM-native descriptors. *)
 val descriptors_for_internal : string -> t list
 
+val readonly_static_hint : t -> bool option
+val readonly_for_input : t -> input:Yojson.Safe.t -> bool option
+
 (** Descriptor-owned read-only projection. The returned names are internal
-    handler names whose descriptor policy declares [readonly = Some true]. *)
+    handler names whose descriptor policy declares a static read-only hint. *)
 val readonly_internal_names : unit -> string list
 
 val public_input_schema : string -> Yojson.Safe.t option

--- a/lib/keeper/agent_tool_descriptor_resolution.ml
+++ b/lib/keeper/agent_tool_descriptor_resolution.ml
@@ -16,6 +16,43 @@ let descriptor_for_tool_name tool_name =
         | [] -> None))
 ;;
 
+let canonical_internal_name_for_tool_name tool_name =
+  match descriptor_for_tool_name tool_name with
+  | Some descriptor -> Some descriptor.Agent_tool_descriptor.internal_name
+  | None -> Keeper_tool_alias.canonical_internal_name tool_name
+;;
+
+let effect_domain_for_tool_name tool_name =
+  match descriptor_for_tool_name tool_name with
+  | Some descriptor -> descriptor.Agent_tool_descriptor.policy.effect_domain
+  | None ->
+    (match canonical_internal_name_for_tool_name tool_name with
+     | Some internal_name -> Tool_catalog.effect_domain internal_name
+     | None -> Tool_catalog.effect_domain tool_name)
+;;
+
+let capability_has kind tool_name =
+  let descriptor = descriptor_for_tool_name tool_name in
+  let descriptor_readonly_hint =
+    match descriptor with
+    | Some descriptor -> Agent_tool_descriptor.readonly_static_hint descriptor
+    | None -> None
+  in
+  match kind, descriptor_readonly_hint with
+  | Tool_capability.Read_only, Some readonly -> readonly
+  | Tool_capability.Idempotent, Some true -> true
+  | _ ->
+    Tool_capability.has kind tool_name
+    ||
+    match descriptor with
+    | Some descriptor -> Tool_capability.has kind descriptor.internal_name
+    | None ->
+      (match canonical_internal_name_for_tool_name tool_name with
+       | Some internal_name when not (String.equal internal_name tool_name) ->
+         Tool_capability.has kind internal_name
+       | _ -> false)
+;;
+
 let descriptor_and_input_for_tool_call ~tool_name ~input =
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
   match Agent_tool_descriptor.find_public stripped with

--- a/lib/keeper/agent_tool_descriptor_resolution.ml
+++ b/lib/keeper/agent_tool_descriptor_resolution.ml
@@ -16,9 +16,36 @@ let descriptor_for_tool_name tool_name =
         | [] -> None))
 ;;
 
+let descriptor_and_input_for_tool_call ~tool_name ~input =
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
+  match Agent_tool_descriptor.find_public stripped with
+  | Some descriptor -> Some (descriptor, descriptor.Agent_tool_descriptor.translate input)
+  | None ->
+    (match Agent_tool_descriptor.descriptors_for_internal stripped with
+     | descriptor :: _ -> Some (descriptor, input)
+     | [] ->
+       let internal_name =
+         match Keeper_tool_alias.canonical_internal_name tool_name with
+         | Some internal_name -> internal_name
+         | None -> stripped
+       in
+       (match Agent_tool_descriptor.descriptors_for_internal internal_name with
+        | descriptor :: _ -> Some (descriptor, input)
+        | [] -> None))
+;;
+
 let readonly_for_tool_name tool_name =
   match descriptor_for_tool_name tool_name with
-  | Some descriptor -> descriptor.Agent_tool_descriptor.policy.readonly
+  | Some descriptor -> Agent_tool_descriptor.readonly_static_hint descriptor
+  | None -> None
+;;
+
+let readonly_for_tool_call ~tool_name ~input =
+  match descriptor_and_input_for_tool_call ~tool_name ~input with
+  | Some (descriptor, input) ->
+    (match Agent_tool_descriptor.readonly_for_input descriptor ~input with
+     | Some _ as decision -> decision
+     | None -> Agent_tool_descriptor.readonly_static_hint descriptor)
   | None -> None
 ;;
 

--- a/lib/keeper/agent_tool_descriptor_resolution.mli
+++ b/lib/keeper/agent_tool_descriptor_resolution.mli
@@ -7,6 +7,12 @@
 
 val descriptor_for_tool_name : string -> Agent_tool_descriptor.t option
 
+val canonical_internal_name_for_tool_name : string -> string option
+
+val effect_domain_for_tool_name : string -> Tool_catalog.effect_domain option
+
+val capability_has : Tool_capability.kind -> string -> bool
+
 val readonly_for_tool_name : string -> bool option
 
 val readonly_for_tool_call : tool_name:string -> input:Yojson.Safe.t -> bool option

--- a/lib/keeper/agent_tool_descriptor_resolution.mli
+++ b/lib/keeper/agent_tool_descriptor_resolution.mli
@@ -9,4 +9,6 @@ val descriptor_for_tool_name : string -> Agent_tool_descriptor.t option
 
 val readonly_for_tool_name : string -> bool option
 
+val readonly_for_tool_call : tool_name:string -> input:Yojson.Safe.t -> bool option
+
 val descriptors_for_tool_names : string list -> Agent_tool_descriptor.t list

--- a/lib/keeper/agent_tool_remote_mcp_runtime.ml
+++ b/lib/keeper/agent_tool_remote_mcp_runtime.ml
@@ -12,7 +12,9 @@ let masc_path_blocked
   | None ->
     Some (error_json (Printf.sprintf "keeper not found in registry: %s" keeper_name))
   | Some meta ->
-    let is_read_only = Tool_capability.has Tool_capability.Read_only name in
+    let is_read_only =
+      Agent_tool_descriptor_resolution.capability_has Tool_capability.Read_only name
+    in
     let effective_paths =
       if is_read_only
       then keeper_effective_allowed_paths ~meta
@@ -70,7 +72,10 @@ let handle_masc_tool
            let msg = Tool_result.message tr in
            if ok then msg else tool_result_error_json tr
          | None ->
-           if Tool_capability.has Tool_capability.Mcp_context_required name
+           if
+             Agent_tool_descriptor_resolution.capability_has
+               Tool_capability.Mcp_context_required
+               name
            then
              error_json
                (Printf.sprintf

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -645,8 +645,8 @@ let cost_guard
     | _ -> Agent_sdk.Hooks.Continue)
 
 (** Destructive pattern detection for bash/edit style tools.
-    Only applies when [enabled] is [true] and the tool is flagged by
-    [Tool_capability.has Destructive]. *)
+    Only applies when [enabled] is [true] and descriptor/catalog capability
+    lookup flags the observed tool name as destructive. *)
 let destructive_guard
     ~(meta_ref : Keeper_types.keeper_meta ref)
     ~on_gate_decision
@@ -657,7 +657,12 @@ let destructive_guard
     | Agent_sdk.Hooks.PreToolUse
         { tool_name; input; accumulated_cost_usd; turn; _ } ->
       if not enabled then Agent_sdk.Hooks.Continue
-      else if not (Tool_capability.has Tool_capability.Destructive tool_name) then
+      else if
+        not
+          (Agent_tool_descriptor_resolution.capability_has
+             Tool_capability.Destructive
+             tool_name)
+      then
         Agent_sdk.Hooks.Continue
       else
         let t0 = Time_compat.now () in

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -53,7 +53,12 @@ let is_known_public name = Hashtbl.mem routing_table name
     time series. *)
 let known_internal_names_tbl : (string, unit) Hashtbl.t =
   let t = Hashtbl.create 128 in
-  Hashtbl.iter (fun _ r -> Hashtbl.replace t r.internal_name ()) routing_table;
+  Hashtbl.iter
+    (fun _ r ->
+       List.iter
+         (fun internal_name -> Hashtbl.replace t internal_name ())
+         (Agent_tool_descriptor.internal_names r.descriptor))
+    routing_table;
   List.iter
     (fun internal ->
        Hashtbl.replace t internal ();

--- a/lib/keeper/keeper_tool_name_projection.ml
+++ b/lib/keeper/keeper_tool_name_projection.ml
@@ -33,7 +33,10 @@ let public_aliases_for_internal_name internal_name =
   Keeper_tool_alias.public_names ()
   |> List.filter (fun public_name ->
     match Keeper_tool_alias.route public_name with
-    | Some route -> String.equal route.internal_name internal_name
+    | Some route ->
+      List.exists
+        (String.equal internal_name)
+        (Agent_tool_descriptor.internal_names route.descriptor)
     | None -> false)
 ;;
 
@@ -126,9 +129,9 @@ let blocker_guidance ~visible_tool_names internal_name =
 let filter_model_visible_suggestions names =
   names
   |> List.filter_map (fun name ->
-    if String.starts_with ~prefix:"keeper_" name then
-      Keeper_tool_alias.public_name_for_internal name
-    else
-      Some name)
+    match public_alias_for_internal name with
+    | Some public -> Some public
+    | None when String.starts_with ~prefix:"keeper_" name -> None
+    | None -> Some name)
   |> Keeper_types.dedupe_keep_order
 ;;

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -142,25 +142,10 @@ let has_mutating_side_effect (name : string) : bool =
    tool name. This function inspects JSON input where a live tool has
    such a contract. *)
 
-let keeper_workspace_op (input : Yojson.Safe.t) : string option =
-  match input with
-  | `Assoc fields ->
-    (match List.assoc_opt "op" fields with
-     | Some (`String s) -> Some (String.lowercase_ascii (String.trim s))
-     | _ -> None)
-  | _ -> None
-;;
-
 let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : bool =
-  match Agent_tool_descriptor_resolution.readonly_for_tool_name tool_name with
+  match Agent_tool_descriptor_resolution.readonly_for_tool_call ~tool_name ~input with
   | Some readonly -> readonly
-  | None ->
-    (match Tool_name.of_string tool_name with
-     | Some (Keeper Workspace_inspect) ->
-       (match keeper_workspace_op input with
-        | Some op -> List.mem op Keeper_workspace_op.valid_strings
-        | None -> false)
-     | _ -> is_effectively_read_only_tool tool_name)
+  | None -> is_effectively_read_only_tool tool_name
 ;;
 
 (* ── Input-aware mutation-boundary bypass ────────────────────

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -157,8 +157,9 @@ let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : boo
    Keep these tools mutating for reconcile/error handling; this predicate
    only controls whether the per-turn boundary blocks follow-up tools.
 
-   The effect-domain tag is resolved through [Tool_catalog], so this boundary
-   no longer has to mirror tool names or infer semantics from prefixes. *)
+   The effect-domain tag is resolved through the descriptor projection first,
+   so this boundary no longer has to mirror tool names or infer semantics from
+   prefixes. *)
 let is_main_worktree_boundary_exempt_with_input
       ~(tool_name : string)
       ~(input : Yojson.Safe.t)
@@ -167,8 +168,14 @@ let is_main_worktree_boundary_exempt_with_input
   if is_read_only_with_input ~tool_name ~input
   then true
   else (
-    match Tool_catalog.is_main_worktree_boundary_exempt tool_name with
-    | Some exempt -> exempt
+    let exempt_for_effect_domain = function
+      | Tool_catalog.Read_only
+      | Tool_catalog.Masc_coordination
+      | Tool_catalog.Playground_write -> true
+      | Tool_catalog.Host_repo_write -> false
+    in
+    match Agent_tool_descriptor_resolution.effect_domain_for_tool_name tool_name with
+    | Some domain -> exempt_for_effect_domain domain
     | None -> false)
 ;;
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -148,6 +148,28 @@ let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : boo
   | None -> is_effectively_read_only_tool tool_name
 ;;
 
+let descriptor_boundary_exempt tool_name =
+  match Agent_tool_descriptor_resolution.descriptor_for_tool_name tool_name with
+  | None -> None
+  | Some descriptor ->
+    (match descriptor.Agent_tool_descriptor.policy.effect_domain with
+     | Some Tool_catalog.Read_only
+     | Some Tool_catalog.Masc_coordination
+     | Some Tool_catalog.Playground_write -> Some true
+     | Some Tool_catalog.Host_repo_write -> Some false
+     | None -> None)
+;;
+
+let catalog_boundary_exempt tool_name =
+  match Tool_catalog.is_main_worktree_boundary_exempt tool_name with
+  | Some _ as decision -> decision
+  | None ->
+    (match Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name tool_name with
+     | Some internal_name when not (String.equal internal_name tool_name) ->
+       Tool_catalog.is_main_worktree_boundary_exempt internal_name
+     | _ -> None)
+;;
+
 (* ── Input-aware mutation-boundary bypass ────────────────────
    Some tools do mutate state, but they should not open the
    main-worktree checkpoint boundary because they either:
@@ -168,15 +190,12 @@ let is_main_worktree_boundary_exempt_with_input
   if is_read_only_with_input ~tool_name ~input
   then true
   else (
-    let exempt_for_effect_domain = function
-      | Tool_catalog.Read_only
-      | Tool_catalog.Masc_coordination
-      | Tool_catalog.Playground_write -> true
-      | Tool_catalog.Host_repo_write -> false
-    in
-    match Agent_tool_descriptor_resolution.effect_domain_for_tool_name tool_name with
-    | Some domain -> exempt_for_effect_domain domain
-    | None -> false)
+    match descriptor_boundary_exempt tool_name with
+    | Some decision -> decision
+    | None ->
+      (match catalog_boundary_exempt tool_name with
+       | Some decision -> decision
+       | None -> false))
 ;;
 
 (* ── Reconcile-safe tools (mutating but idempotent enough) ─── *)

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -242,6 +242,36 @@ let normalize_tool_result
       (raw : string)
   : string
   =
+  let metadata_from_assoc fields =
+    fields
+    |> List.filter (fun (key, _) ->
+      not
+        (List.mem
+           key
+           [ "ok"; "error"; "detail"; "result"; "output"; "message"; "status" ]))
+  in
+  let structured_error_payload error_msg =
+    try
+      match Yojson.Safe.from_string error_msg with
+      | `Assoc fields -> Some fields
+      | _ -> None
+    with
+    | Yojson.Json_error _ -> None
+  in
+  let merge_metadata primary secondary =
+    let primary_keys = List.map fst primary in
+    primary
+    @ List.filter
+        (fun (key, _) -> not (List.mem key primary_keys))
+        secondary
+  in
+  let ensure_workflow_self_correction fields =
+    match List.assoc_opt "failure_class" fields with
+    | Some (`String "workflow_rejection")
+      when not (List.mem_assoc "self_correction_required" fields) ->
+      fields @ [ "self_correction_required", `Bool true ]
+    | _ -> fields
+  in
   try
     let json = Yojson.Safe.from_string raw in
     if success
@@ -268,13 +298,22 @@ let normalize_tool_result
                    "tool returned error status"
                  | _ -> "tool call failed")))
       in
+      let error_msg, nested_fields =
+        match structured_error_payload error_msg with
+        | Some fields ->
+          let nested_error =
+            match List.assoc_opt "error" fields with
+            | Some (`String msg) when String.trim msg <> "" -> msg
+            | _ -> error_msg
+          in
+          nested_error, metadata_from_assoc fields
+        | None -> error_msg, []
+      in
       let preserved_fields =
-        [ "failure_class"; "recoverable"; "error_class" ]
-        |> List.filter_map (fun key ->
-          match Yojson.Safe.Util.member key json with
-          | `String _ as value -> Some (key, value)
-          | `Bool _ as value -> Some (key, value)
-          | _ -> None)
+        (match json with
+         | `Assoc fields -> merge_metadata (metadata_from_assoc fields) nested_fields
+         | _ -> nested_fields)
+        |> ensure_workflow_self_correction
       in
       Yojson.Safe.to_string
         (`Assoc

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -53,15 +53,19 @@ let make_tool_bundle
     List.filter_map
       (fun public ->
          match Keeper_tool_alias.route public with
-         | Some r -> Some r.internal_name
+         | Some r -> Some (Agent_tool_descriptor.internal_names r.descriptor)
          | None -> None)
       (Keeper_tool_alias.public_names ())
+    |> List.concat
   in
   let alias_public_names_in_surface =
     List.filter
       (fun public ->
          match Keeper_tool_alias.route public with
-         | Some r -> List.mem r.internal_name universe_names
+         | Some r ->
+           List.exists
+             (fun internal_name -> List.mem internal_name universe_names)
+             (Agent_tool_descriptor.internal_names r.descriptor)
          | None -> false)
       (Keeper_tool_alias.public_names ())
   in

--- a/lib/keeper/keeper_tools_oas_failure_boundary.ml
+++ b/lib/keeper/keeper_tools_oas_failure_boundary.ml
@@ -30,19 +30,47 @@ let failure_class_of_json json =
       Tool_result.tool_failure_class_of_string
 ;;
 
+let structured_error_json = function
+  | `Assoc fields ->
+    (match List.assoc_opt "error" fields with
+     | Some (`String raw) ->
+       (try
+          match Yojson.Safe.from_string raw with
+          | `Assoc _ as json -> Some json
+          | _ -> None
+        with
+        | Yojson.Json_error _ -> None)
+     | _ -> None)
+  | _ -> None
+;;
+
 let classify_raw_failure raw =
   let json =
     try Some (Yojson.Safe.from_string raw) with
     | Yojson.Json_error _ -> None
   in
+  let classification_json =
+    match json with
+    | Some json ->
+      (match failure_class_of_json json with
+       | Some _ -> Some json
+       | None ->
+         (match structured_error_json json with
+          | Some nested -> Some nested
+          | None -> Some json))
+    | None -> None
+  in
   let failure_class =
-    Option.bind json failure_class_of_json
+    Option.bind classification_json failure_class_of_json
     |> Option.value ~default:Tool_result.Runtime_failure
   in
   let deterministic_classification =
     if Tool_result.is_retryable failure_class
     then None
-    else Option.bind json Keeper_tool_deterministic_error.classify_with_source
+    else
+      Option.bind
+        classification_json
+        Keeper_tool_deterministic_error.classify_with_source
   in
   { failure_class
   ; is_workflow_rejection = (failure_class = Tool_result.Workflow_rejection)

--- a/lib/keeper/keeper_tools_oas_failure_boundary.mli
+++ b/lib/keeper/keeper_tools_oas_failure_boundary.mli
@@ -13,8 +13,9 @@ type t =
 
 (** Classify a failed raw tool payload.
 
-    Missing or malformed [failure_class] defaults to [Runtime_failure] instead
-    of parsing [error] text. A deterministic retry-skip is honored only when
-    the structured payload is not retryable, so contradictory
+    Missing or malformed [failure_class] defaults to [Runtime_failure] unless
+    [error] itself is a structured JSON object serialized as a string. A
+    deterministic retry-skip is honored only when the structured payload is not
+    retryable, so contradictory
     [failure_class="transient_error"] payloads stay non-deterministic. *)
 val classify_raw_failure : string -> t

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -128,6 +128,7 @@ type workflow_rejection_payload =
   }
 
 let workflow_rejection_payload_of_json json =
+  let payload_from_json json =
   match json_or_detail_string_opt "failure_class" json with
   | Some "workflow_rejection" ->
     Some
@@ -144,6 +145,19 @@ let workflow_rejection_payload_of_json json =
   | Some _
   | None ->
     None
+  in
+  match payload_from_json json with
+  | Some _ as payload -> payload
+  | None ->
+    (match json_assoc_string_opt "error" json with
+     | Some raw ->
+       (try
+          match Yojson.Safe.from_string raw with
+          | `Assoc _ as nested -> payload_from_json nested
+          | _ -> None
+        with
+        | Yojson.Json_error _ -> None)
+     | None -> None)
 ;;
 
 let workflow_rejection_retry_policy payload =

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -566,7 +566,9 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     | Full | Operator_remote ->
         (params |> U.member "name" |> U.to_string, params |> U.member "arguments")
   in
-  let is_read_only = Tool_capability.has Tool_capability.Read_only name in
+  let is_read_only =
+    Agent_tool_descriptor_resolution.capability_has Tool_capability.Read_only name
+  in
 
   (* Measure execution time for telemetry *)
   let start_time = Eio.Time.now clock in

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -232,7 +232,9 @@ let execute_tool_eio
      - Auto-init only when auth is disabled (avoid side effects in secured rooms).
      - Auto-join when allowed by auth (and safe for token-based auth). *)
        let join_required =
-         Tool_capability.has Tool_capability.Requires_join name
+         Agent_tool_descriptor_resolution.capability_has
+           Tool_capability.Requires_join
+           name
        in
        let init_error =
          if (not auth_enabled) && join_required && not !room_init_cached
@@ -252,10 +254,12 @@ let execute_tool_eio
        in
        (match init_error with
         | Some msg -> with_system_internal_audit ~agent_name (Tool_result.quick_error msg)
-        | None ->
-          let is_read_only =
-            Tool_capability.has Tool_capability.Read_only name
-          in
+          | None ->
+            let is_read_only =
+              Agent_tool_descriptor_resolution.capability_has
+                Tool_capability.Read_only
+                name
+            in
           let can_auto_join =
             if (not join_required) || agent_name = "unknown"
             then false

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -135,7 +135,12 @@ let affected_resource_ids_for_tool = function
 ;;
 
 let maybe_emit_resource_notifications ~success ~tool_name =
-  if success && not (Tool_capability.has Tool_capability.Read_only tool_name)
+  if
+    success
+    && not
+         (Agent_tool_descriptor_resolution.capability_has
+            Tool_capability.Read_only
+            tool_name)
   then (
     let affected_ids = affected_resource_ids_for_tool tool_name in
     with_resource_subscription_lock (fun () ->

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -143,13 +143,13 @@ let tool_allowed_in_profile ?(internal_keeper_runtime = false) state profile
 
 let tool_annotations_for_profile _profile tool_name =
   let read_only =
-    Tool_capability.has Tool_capability.Read_only tool_name
+    Agent_tool_descriptor_resolution.capability_has Tool_capability.Read_only tool_name
   in
   let destructive =
-    Tool_capability.has Tool_capability.Destructive tool_name
+    Agent_tool_descriptor_resolution.capability_has Tool_capability.Destructive tool_name
   in
   let idempotent =
-    Tool_capability.has Tool_capability.Idempotent tool_name
+    Agent_tool_descriptor_resolution.capability_has Tool_capability.Idempotent tool_name
   in
   (* MCP 2025-03-26: [openWorldHint] signals whether the tool can
      interact with systems outside the server's closed world.
@@ -266,7 +266,7 @@ let tool_title_of_name name =
 
 let tool_icons_for_name name =
   let icon =
-    if Tool_capability.has Tool_capability.Read_only name then
+    if Agent_tool_descriptor_resolution.capability_has Tool_capability.Read_only name then
       Mcp_server.themed_icon ~label:"RD" ~bg:"#0F766E" ~fg:"#F0FDFA"
     else
       Mcp_server.themed_icon ~label:"WR" ~bg:"#9A3412" ~fg:"#FFF7ED"

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -175,6 +175,44 @@ let tool_annotations_for_profile _profile tool_name =
   in
   if fields = [] then None else Some (`Assoc fields)
 
+let metadata_key_present key fields =
+  List.exists (fun (existing, _) -> String.equal existing key) fields
+;;
+
+let add_metadata_field_if_absent key value fields =
+  if metadata_key_present key fields then fields else fields @ [ key, value ]
+;;
+
+let descriptor_metadata_fields tool_name fields =
+  match Agent_tool_descriptor_resolution.descriptor_for_tool_name tool_name with
+  | None -> fields
+  | Some descriptor ->
+    let fields =
+      match descriptor.policy.effect_domain with
+      | Some effect_domain ->
+        add_metadata_field_if_absent
+          "effectDomain"
+          (`String (Tool_catalog.effect_domain_to_string effect_domain))
+          fields
+      | None -> fields
+    in
+    fields
+    |> add_metadata_field_if_absent "descriptorId" (`String descriptor.id)
+    |> add_metadata_field_if_absent "descriptorPublicName" (`String descriptor.public_name)
+    |> add_metadata_field_if_absent
+         "descriptorCanonicalName"
+         (`String descriptor.internal_name)
+    |> add_metadata_field_if_absent
+         "descriptorExecutor"
+         (`String (Agent_tool_descriptor.executor_to_string descriptor.executor))
+    |> add_metadata_field_if_absent
+         "descriptorBackend"
+         (`String (Agent_tool_descriptor.backend_to_string descriptor.backend))
+    |> add_metadata_field_if_absent
+         "descriptorSandbox"
+         (`String (Agent_tool_descriptor.sandbox_to_string descriptor.sandbox))
+;;
+
 let label_words_from_identifier ident =
   ident
   |> String.split_on_char '_'
@@ -286,6 +324,10 @@ let tool_output_schema_field _ =
   None
 
 let tool_json_for_profile ?usage_summary profile (schema : Masc_domain.tool_schema) =
+  let metadata_fields =
+    Tool_catalog.metadata_to_fields schema.name
+    |> descriptor_metadata_fields schema.name
+  in
   let base =
     [
       ("name", `String schema.name);
@@ -296,7 +338,7 @@ let tool_json_for_profile ?usage_summary profile (schema : Masc_domain.tool_sche
           (List.map Mcp_server.icon_to_json (tool_icons_for_name schema.name)) );
       ("inputSchema", schema.input_schema);
     ]
-    @ Tool_catalog.metadata_to_fields schema.name
+    @ metadata_fields
     @ maybe_assoc_field "outputSchema" (tool_output_schema_field schema.name)
     @ maybe_assoc_field "annotations" (tool_annotations_for_profile profile schema.name)
     @

--- a/lib/mcp_server_eio_tool_profile.mli
+++ b/lib/mcp_server_eio_tool_profile.mli
@@ -141,8 +141,9 @@ val tool_json_for_profile :
 (** [tool_json_for_profile ?usage_summary profile schema] renders
     a tool descriptor object: [name], [title], [description],
     [icons], [inputSchema], catalog metadata fields,
-    [outputSchema] (currently always omitted), [annotations],
-    plus optional usage telemetry from [?usage_summary]. *)
+    descriptor metadata fields when a descriptor owns the tool name,
+    [outputSchema] (currently always omitted), [annotations], plus optional
+    usage telemetry from [?usage_summary]. *)
 
 (** {1 JSON helpers} *)
 

--- a/lib/mcp_server_eio_tool_profile.mli
+++ b/lib/mcp_server_eio_tool_profile.mli
@@ -109,7 +109,7 @@ val tool_annotations_for_profile :
 (** [tool_annotations_for_profile profile tool_name] returns the
     MCP 2025-03-26 [annotations] object — [readOnlyHint],
     [destructiveHint], [idempotentHint], [openWorldHint] — derived
-    from {!Tool_capability.has}.
+    from descriptor-aware capability resolution.
 
     Returns [None] when the field set would be empty.
     [openWorldHint] is emitted only when the tool is unambiguously

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -96,7 +96,7 @@ module Keeper = struct
     | Library_search -> "keeper_library_search"
     | Memory_search -> "keeper_memory_search"
     | Memory_write -> "keeper_memory_write"
-    | Workspace_inspect -> "tool_workspace_inspect"
+    | Workspace_inspect -> "tool_search_files"
     | Stay_silent -> "keeper_stay_silent"
     | Task_claim -> "keeper_task_claim"
     | Task_create -> "keeper_task_create"
@@ -144,7 +144,7 @@ module Keeper = struct
     | "keeper_library_search" -> Some Library_search
     | "keeper_memory_search" -> Some Memory_search
     | "keeper_memory_write" -> Some Memory_write
-    | "tool_workspace_inspect" -> Some Workspace_inspect
+    | "tool_search_files" | "tool_workspace_inspect" -> Some Workspace_inspect
     | "keeper_stay_silent" -> Some Stay_silent
     | "keeper_task_claim" -> Some Task_claim
     | "keeper_task_create" -> Some Task_create

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -90,7 +90,7 @@ let shard_filesystem : shard =
 let shard_shell : shard =
   { name = "shell"
   ; tools = shell_tools
-  ; read_only_tools = [ "tool_workspace_inspect" ]
+  ; read_only_tools = [ "tool_search_files"; "tool_workspace_inspect" ]
   ; removable = true
   ; description = "Structured shell search tools"
   }

--- a/lib/tool_shard_types_schemas_shell.ml
+++ b/lib/tool_shard_types_schemas_shell.ml
@@ -1,14 +1,15 @@
-(** Tool_shard_types_schemas_shell — [shell_tools] tool_workspace_inspect schema.
+(** Tool_shard_types_schemas_shell — [shell_tools] SearchFiles schemas.
 
     Module file name retains the [_shell] suffix because [shell_tools] is the
-    canonical shard handle in [Tool_shard]. The tool surface itself is
-    tool_workspace_inspect; the shard name is a separate axis. *)
+    canonical shard handle in [Tool_shard]. [tool_search_files] is the
+    descriptor-owned canonical internal name; [tool_workspace_inspect] remains
+    as a legacy internal alias during the staged rename. *)
 
 open Tool_shard_types_enum_mirrors
 
-let shell_tools : Masc_domain.tool_schema list =
-  [ { name = "tool_workspace_inspect"
-    ; description =
+let tool_search_files_schema : Masc_domain.tool_schema =
+  { name = "tool_search_files"
+  ; description =
         "Inspect the project workspace via a structured op. ops: pwd, ls, cat, rg, git_status, \
          find, head, tail, wc, tree, git_log, git_diff. \
          Structured ops default to the keeper sandbox. IMPORTANT: paths resolve \
@@ -18,7 +19,7 @@ let shell_tools : Masc_domain.tool_schema list =
          pattern=\"*.ml\"). No generic bash execution: use Execute for command \
          execution. Use rg for pattern search, find for path discovery, head/tail for \
          line ranges, and git_log/git_diff for repo history."
-    ; input_schema =
+  ; input_schema =
         `Assoc
           [ "type", `String "object"
           ; ( "properties"
@@ -79,6 +80,13 @@ let shell_tools : Masc_domain.tool_schema list =
                 ] )
           ; "required", `List [ `String "op" ]
           ]
-    }
-  ]
+  }
+;;
+
+let legacy_tool_workspace_inspect_schema =
+  { tool_search_files_schema with name = "tool_workspace_inspect" }
+;;
+
+let shell_tools : Masc_domain.tool_schema list =
+  [ tool_search_files_schema; legacy_tool_workspace_inspect_schema ]
 ;;

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -21,6 +21,7 @@ open Alcotest
 module Descriptor = Masc_mcp.Agent_tool_descriptor
 module Exec = Masc_mcp.Keeper_exec_tools
 module Registry = Masc_mcp.Keeper_tool_registry
+module Resolution = Masc_mcp.Agent_tool_descriptor_resolution
 module Tool_board_registry = Masc_mcp.Tool_board_registry
 
 let all_descriptors () : Descriptor.t list = Descriptor.all_descriptors ()
@@ -127,7 +128,7 @@ let test_readonly_policy_projects_to_registry () =
   let projected = Descriptor.readonly_internal_names () in
   List.iter
     (fun d ->
-      match d.Descriptor.policy.readonly with
+      match Descriptor.readonly_static_hint d with
       | Some true ->
         Alcotest.(check bool)
           (d.Descriptor.internal_name ^ " is in descriptor readonly projection")
@@ -143,6 +144,41 @@ let test_readonly_policy_projects_to_registry () =
     "tool_write_file is not descriptor read-only"
     false
     (List.mem "tool_write_file" projected)
+
+let test_readonly_policy_is_descriptor_input_aware () =
+  let public_input =
+    `Assoc [ "pattern", `String "Agent_tool_descriptor"; "op", `String "rm" ]
+  in
+  let internal_input = `Assoc [ "op", `String "rm"; "pattern", `String "x" ] in
+  let descriptor =
+    match Descriptor.find_public "SearchFiles" with
+    | Some descriptor -> descriptor
+    | None -> Alcotest.fail "missing SearchFiles descriptor"
+  in
+  Alcotest.(check (option bool))
+    "static readonly hint stays available for schema/evidence"
+    (Some true)
+    (Descriptor.readonly_static_hint descriptor);
+  Alcotest.(check (option bool))
+    "raw public-shaped input is not an internal readonly decision"
+    None
+    (Descriptor.readonly_for_input descriptor ~input:public_input);
+  Alcotest.(check (option bool))
+    "public input is translated before readonly policy evaluation"
+    (Some true)
+    (Resolution.readonly_for_tool_call ~tool_name:"SearchFiles" ~input:public_input);
+  Alcotest.(check (option bool))
+    "MCP-prefixed public input follows the same descriptor policy"
+    (Some true)
+    (Resolution.readonly_for_tool_call
+       ~tool_name:"mcp__masc__SearchFiles"
+       ~input:public_input);
+  Alcotest.(check (option bool))
+    "unknown internal op falls back to static read-only hint"
+    (Some true)
+    (Resolution.readonly_for_tool_call
+       ~tool_name:"tool_workspace_inspect"
+       ~input:internal_input)
 
 let test_readonly_policy_projects_to_input_aware_registry () =
   let search_input = `Assoc [ "pattern", `String "Agent_tool_descriptor" ] in
@@ -160,6 +196,12 @@ let test_readonly_policy_projects_to_input_aware_registry () =
     "tool_workspace_inspect is descriptor read-only without legacy op"
     true
     (Registry.is_read_only_with_input ~tool_name:"tool_workspace_inspect" ~input:search_input);
+  Alcotest.(check bool)
+    "tool_workspace_inspect invalid op remains passive instead of mutating"
+    true
+    (Registry.is_read_only_with_input
+       ~tool_name:"tool_workspace_inspect"
+       ~input:(`Assoc [ "op", `String "rm"; "pattern", `String "x" ]));
   Alcotest.(check bool)
     "ReadFile public alias is input-aware read-only"
     true
@@ -279,6 +321,10 @@ let () =
             "descriptor read-only policy projects to registry"
             `Quick
             test_readonly_policy_projects_to_registry
+        ; test_case
+            "descriptor read-only policy evaluates tool input"
+            `Quick
+            test_readonly_policy_is_descriptor_input_aware
         ; test_case
             "descriptor read-only policy projects to input-aware registry"
             `Quick

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -244,7 +244,19 @@ let test_mutation_boundary_delegates_to_descriptor_policy () =
     true
     (Exec.has_mutating_side_effect_with_input
        ~tool_name:"WriteFile"
-       ~input:(`Assoc [ "file_path", `String "x"; "content", `String "y" ]))
+       ~input:(`Assoc [ "file_path", `String "x"; "content", `String "y" ]));
+  Alcotest.(check bool)
+    "WriteFile public alias is playground-boundary exempt from descriptor effect"
+    true
+    (Registry.is_main_worktree_boundary_exempt_with_input
+       ~tool_name:"WriteFile"
+       ~input:(`Assoc [ "file_path", `String "x"; "content", `String "y" ]));
+  Alcotest.(check bool)
+    "Execute public alias is playground-boundary exempt from descriptor effect"
+    true
+    (Registry.is_main_worktree_boundary_exempt_with_input
+       ~tool_name:"Execute"
+       ~input:(`Assoc [ "executable", `String "git"; "argv", `List [ `String "status" ] ]))
 
 (* RFC-0182 §3.1 — verify the 21 new tool_shard / approval / persona /
    keeper / surface_audit descriptors all project from name → descriptor

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -196,17 +196,14 @@ let test_all_keepers_get_full_toolset () =
   check bool "has tool_read_file" true (List.mem "tool_read_file" tools);
   check bool "has keeper_board_list" true (List.mem "keeper_board_list" tools);
   check bool "has keeper_board_get" true (List.mem "keeper_board_get" tools);
-  check bool "has tool_workspace_inspect" true (List.mem "tool_workspace_inspect" tools)
+  check bool "has tool_search_files" true (List.mem "tool_search_files" tools)
 
 let test_all_keepers_have_research_tools () =
   let meta = make_meta ~preset:Keeper_types.Research  () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  let has_any_research = List.exists (fun t ->
-    String.length t > 5 &&
-    (try ignore (Str.search_forward (Str.regexp_string "research") t 0); true
-     with Not_found -> false)
-  ) tools in
-  check bool "has research tools" true has_any_research
+  check bool "research has library search" true (List.mem "keeper_library_search" tools);
+  check bool "research has web search" true (List.mem "masc_web_search" tools);
+  check bool "research has file search" true (List.mem "tool_search_files" tools)
 
 let test_heuristic_mode_tools () =
   let meta = make_meta ~preset:Keeper_types.Minimal () in
@@ -218,12 +215,12 @@ let test_messaging_preset_tools () =
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "has board tools" true (List.mem "keeper_board_post" tools);
   check bool "has tool_read_file" true (List.mem "tool_read_file" tools);
-  check bool "has tool_workspace_inspect" true (List.mem "tool_workspace_inspect" tools)
+  check bool "has tool_search_files" true (List.mem "tool_search_files" tools)
 
 let test_all_keepers_have_shell_and_coding () =
   let meta = make_meta ~preset:Keeper_types.Coding () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  check bool "tool_workspace_inspect included" true (List.mem "tool_workspace_inspect" tools);
+  check bool "tool_search_files included" true (List.mem "tool_search_files" tools);
   check bool "tool_read_file included" true (List.mem "tool_read_file" tools);
   check bool "keeper_board_get included" true (List.mem "keeper_board_get" tools)
 

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -278,6 +278,8 @@ let test_shell_shared_is_removed () =
   let bash_ml = "lib/keeper/keeper_shell_bash.ml" in
   let exec_tools_ml = "lib/keeper/keeper_exec_tools.ml" in
   let exec_shell_ml = "lib/keeper/keeper_exec_shell.ml" in
+  let registry_ml = "lib/keeper/keeper_tool_registry.ml" in
+  let descriptor_resolution_ml = "lib/keeper/agent_tool_descriptor_resolution.ml" in
   let retired_shared_path = "lib/keeper/keeper_" ^ "shell_shared" in
   let retired_shared = "Keeper_" ^ "shell_shared" in
   assert_source_absent (retired_shared_path ^ ".ml");
@@ -303,14 +305,16 @@ let test_shell_shared_is_removed () =
     "lib/keeper/keeper_workspace_read_ops.ml"
     "Keeper_shell_runtime_paths.rewrite_turn_runtime_paths_to_host";
   assert_contains bash_ml "Keeper_shell_timeout.clamp_shell_timeout";
-  assert_contains exec_tools_ml "Keeper_workspace_op.valid_strings";
+  assert_contains descriptor_resolution_ml "readonly_for_tool_call";
   assert_not_contains shell_ops_ml (retired_shared ^ ".");
   assert_not_contains
     "lib/keeper/keeper_workspace_read_ops.ml"
     (retired_shared ^ ".");
   assert_not_contains bash_ml (retired_shared ^ ".");
   assert_not_contains exec_tools_ml (retired_shared ^ ".");
-  assert_not_contains exec_shell_ml retired_shared
+  assert_not_contains exec_shell_ml retired_shared;
+  assert_not_contains exec_tools_ml "Keeper_workspace_op.valid_strings";
+  assert_not_contains registry_ml "Keeper_workspace_op.valid_strings"
 
 let test_descriptor_backed_dispatch_uses_agent_tool_runtime () =
   let exec_tools_ml = "lib/keeper/keeper_exec_tools.ml" in

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -36,8 +36,8 @@ let test_known_aliases_resolve () =
     (Some "tool_write_file")
     (route_internal "WriteFile");
   Alcotest.(check (option string))
-    "SearchFiles -> tool_workspace_inspect"
-    (Some "tool_workspace_inspect")
+    "SearchFiles -> tool_search_files"
+    (Some "tool_search_files")
     (route_internal "SearchFiles");
   Alcotest.(check (option string))
     "SearchWeb -> masc_web_search"
@@ -54,6 +54,10 @@ let test_internal_names_resolve_to_preferred_public_alias () =
     "tool_workspace_inspect -> SearchFiles"
     (Some "SearchFiles")
     (Alias.public_name_for_internal "tool_workspace_inspect");
+  Alcotest.(check (option string))
+    "tool_search_files -> SearchFiles"
+    (Some "SearchFiles")
+    (Alias.public_name_for_internal "tool_search_files");
   Alcotest.(check (option string))
     "tool_edit_file primary public alias is EditFile"
     (Some "EditFile")
@@ -255,8 +259,8 @@ let test_alias_canonical_internal_name_for_set_logic () =
     (Some "tool_execute")
     (Alias.canonical_internal_name "Execute");
   Alcotest.(check (option string))
-    "public SearchFiles canonicalises to tool_workspace_inspect"
-    (Some "tool_workspace_inspect")
+    "public SearchFiles canonicalises to tool_search_files"
+    (Some "tool_search_files")
     (Alias.canonical_internal_name "SearchFiles");
   Alcotest.(check (option string))
     "MCP-prefixed public MASC name canonicalises to internal keeper tool"
@@ -690,6 +694,7 @@ let test_agent_tool_runtime_resolves_descriptor_handlers () =
     | None -> Alcotest.failf "missing descriptor for %s" internal
   in
   check_descriptor "tool_execute" "agent.execute";
+  check_descriptor "tool_search_files" "agent.workspace_inspect";
   check_descriptor "tool_workspace_inspect" "agent.workspace_inspect";
   check_descriptor "tool_read_file" "agent.read_file";
   check_descriptor "tool_edit_file" "agent.edit_file";

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1369,6 +1369,7 @@ let test_failure_count_ttl_fresh_entries_preserved () =
 ;;
 
 let test_workflow_rejection_same_args_short_circuits_after_first_failure () =
+  with_env "MASC_TOOL_EXTERNALIZE" "0" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" "true" (fun () ->
     let meta =
       make_test_meta
@@ -1456,10 +1457,11 @@ let test_workflow_rejection_same_args_short_circuits_after_first_failure () =
              "same deterministic workflow rejection is blocked"
              true
              (is_guardrail_message message)
-         | Ok _ -> fail "same workflow rejection should be blocked before execution"))
+         | Ok _ -> fail "same workflow rejection should be blocked before execution")))
 ;;
 
 let test_workflow_rejection_scope_blocks_transition_variants () =
+  with_env "MASC_TOOL_EXTERNALIZE" "0" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" "true" (fun () ->
     let meta =
       make_test_meta
@@ -1551,14 +1553,17 @@ let test_workflow_rejection_scope_blocks_transition_variants () =
              [ "agent_name", `String meta.agent_name
              ; "task_id", `String "task-001"
              ; "action", `String "submit_for_verification"
-             ; "notes", `String "Implementation complete with PR evidence."
+             ; ( "notes"
+               , `String
+                   "completion_notes: Implementation complete. \
+                    pr_url_or_artifact_ref: PR evidence attached." )
              ; "pr_url", `String "https://github.com/jeong-sik/masc-mcp/pull/12345"
              ]
          in
          match Tool.execute transition corrected_args with
          | Ok _ -> ()
          | Error { Agent_sdk.Types.message; _ } ->
-           fail ("corrected evidence-bearing call should not be scope-blocked: " ^ message)))
+           fail ("corrected evidence-bearing call should not be scope-blocked: " ^ message))))
 ;;
 
 (* #18500: scope blocks must expire after TTL so agents can retry. *)

--- a/test/test_mcp_server_eio_tool_profile_capability.ml
+++ b/test/test_mcp_server_eio_tool_profile_capability.ml
@@ -132,6 +132,44 @@ let test_tool_json_projects_descriptor_metadata_for_public_aliases () =
     "WriteFile descriptor executor"
     "filesystem"
     (json_string_field "descriptorExecutor" write_file)
+  ;
+  let search_files = tool_json "SearchFiles" in
+  check
+    string
+    "SearchFiles canonical descriptor name"
+    "tool_search_files"
+    (json_string_field "descriptorCanonicalName" search_files)
+;;
+
+let test_descriptor_resolution_capabilities_for_public_aliases () =
+  let capability_has =
+    Masc_mcp.Agent_tool_descriptor_resolution.capability_has
+  in
+  check
+    bool
+    "ReadFile read-only via descriptor resolution"
+    true
+    (capability_has Masc_mcp.Tool_capability.Read_only "ReadFile");
+  check
+    bool
+    "SearchFiles read-only via descriptor resolution"
+    true
+    (capability_has Masc_mcp.Tool_capability.Read_only "SearchFiles");
+  check
+    bool
+    "WriteFile destructive via descriptor resolution"
+    true
+    (capability_has Masc_mcp.Tool_capability.Destructive "WriteFile");
+  check
+    bool
+    "Execute destructive via descriptor resolution"
+    true
+    (capability_has Masc_mcp.Tool_capability.Destructive "Execute");
+  check
+    bool
+    "ReadFile not destructive via descriptor resolution"
+    false
+    (capability_has Masc_mcp.Tool_capability.Destructive "ReadFile")
 ;;
 
 let () =
@@ -154,6 +192,10 @@ let () =
             "tool-json-projects-descriptor-metadata-for-public-aliases"
             `Quick
             test_tool_json_projects_descriptor_metadata_for_public_aliases
+        ; test_case
+            "descriptor-resolution-capabilities-for-public-aliases"
+            `Quick
+            test_descriptor_resolution_capabilities_for_public_aliases
         ] )
     ]
 ;;

--- a/test/test_mcp_server_eio_tool_profile_capability.ml
+++ b/test/test_mcp_server_eio_tool_profile_capability.ml
@@ -56,6 +56,39 @@ let test_annotations_use_catalog_capabilities () =
     (bool_annotation "openWorldHint" "shell_exec")
 ;;
 
+let test_annotations_use_descriptor_public_alias_capabilities () =
+  check
+    bool
+    "ReadFile readOnlyHint from descriptor"
+    true
+    (bool_annotation "readOnlyHint" "ReadFile");
+  check
+    bool
+    "ReadFile openWorldHint closed"
+    false
+    (bool_annotation "openWorldHint" "ReadFile");
+  check
+    bool
+    "SearchFiles readOnlyHint from descriptor"
+    true
+    (bool_annotation "readOnlyHint" "SearchFiles");
+  check
+    bool
+    "WriteFile readOnlyHint false from descriptor"
+    false
+    (bool_annotation "readOnlyHint" "WriteFile");
+  check
+    bool
+    "WriteFile destructiveHint from canonical internal capability"
+    true
+    (bool_annotation "destructiveHint" "WriteFile");
+  check
+    bool
+    "Execute destructiveHint from canonical internal capability"
+    true
+    (bool_annotation "destructiveHint" "Execute")
+;;
+
 let () =
   run
     "mcp-server-eio-tool-profile-capability"
@@ -68,6 +101,10 @@ let () =
             "use-catalog-capabilities"
             `Quick
             test_annotations_use_catalog_capabilities
+        ; test_case
+            "use-descriptor-public-alias-capabilities"
+            `Quick
+            test_annotations_use_descriptor_public_alias_capabilities
         ] )
     ]
 ;;

--- a/test/test_mcp_server_eio_tool_profile_capability.ml
+++ b/test/test_mcp_server_eio_tool_profile_capability.ml
@@ -23,6 +23,21 @@ let bool_annotation name tool_name =
   | None -> failf "annotation %s missing for %s" name tool_name
 ;;
 
+let tool_json name =
+  Masc_mcp.Mcp_server_eio_tool_profile.tool_json_for_profile
+    Masc_mcp.Mcp_server_eio_tool_profile.Full
+    { Masc_domain.name
+    ; description = "test schema"
+    ; input_schema = `Assoc [ "type", `String "object" ]
+    }
+;;
+
+let json_string_field key json =
+  match Yojson.Safe.Util.member key json with
+  | `String value -> value
+  | other -> failf "field %s was %s" key (Yojson.Safe.to_string other)
+;;
+
 let test_annotations_do_not_invent_read_only () =
   let name = "__profile_unknown_tool" in
   check bool "unknown readOnlyHint false" false (bool_annotation "readOnlyHint" name);
@@ -89,6 +104,36 @@ let test_annotations_use_descriptor_public_alias_capabilities () =
     (bool_annotation "destructiveHint" "Execute")
 ;;
 
+let test_tool_json_projects_descriptor_metadata_for_public_aliases () =
+  let read_file = tool_json "ReadFile" in
+  check
+    string
+    "ReadFile descriptor id"
+    "agent.read_file"
+    (json_string_field "descriptorId" read_file);
+  check
+    string
+    "ReadFile canonical descriptor name"
+    "tool_read_file"
+    (json_string_field "descriptorCanonicalName" read_file);
+  check
+    string
+    "ReadFile effect domain"
+    "read_only"
+    (json_string_field "effectDomain" read_file);
+  let write_file = tool_json "WriteFile" in
+  check
+    string
+    "WriteFile effect domain"
+    "playground_write"
+    (json_string_field "effectDomain" write_file);
+  check
+    string
+    "WriteFile descriptor executor"
+    "filesystem"
+    (json_string_field "descriptorExecutor" write_file)
+;;
+
 let () =
   run
     "mcp-server-eio-tool-profile-capability"
@@ -105,6 +150,10 @@ let () =
             "use-descriptor-public-alias-capabilities"
             `Quick
             test_annotations_use_descriptor_public_alias_capabilities
+        ; test_case
+            "tool-json-projects-descriptor-metadata-for-public-aliases"
+            `Quick
+            test_tool_json_projects_descriptor_metadata_for_public_aliases
         ] )
     ]
 ;;

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -84,7 +84,7 @@ let test_roundtrip_toplevel () =
    These are shared-surface tools whose canonical string id starts
    with "tool_" rather than "keeper_" (see PR #18520, #18779). *)
 let keeper_shared_surface_prefixes =
-  [ "tool_execute"; "tool_edit_file"; "tool_read_file"; "tool_workspace_inspect" ]
+  [ "tool_execute"; "tool_edit_file"; "tool_read_file"; "tool_search_files" ]
 
 let test_keeper_prefix () =
   List.iter (fun k ->


### PR DESCRIPTION
## Summary

- Move descriptor read-only policy from a static `bool option` into descriptor-owned `readonly_of_input` evaluation with a static hint for schema/evidence projection.
- Route runtime read-only checks through `Agent_tool_descriptor_resolution.readonly_for_tool_call`, including public-name input translation before policy evaluation.
- Remove the `Workspace_inspect` / `Keeper_workspace_op.valid_strings` interpretation from `Keeper_tool_registry`, and keep invalid legacy workspace-inspect ops passive rather than mutating.

## Validation

- `ocamlformat --check lib/keeper/agent_tool_descriptor.mli lib/keeper/agent_tool_descriptor.ml lib/keeper/agent_tool_descriptor_resolution.mli lib/keeper/agent_tool_descriptor_resolution.ml lib/keeper/keeper_tool_registry.ml test/test_agent_tool_descriptor_registry_integrity.ml test/test_keeper_sandbox_boundary_policy.ml`
- `git diff --check HEAD~1..HEAD`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_agent_tool_descriptor_registry_integrity.exe ./test/test_keeper_sandbox_boundary_policy.exe ./test/test_keeper_unified_required_tools.exe`
- `./_build/default/test/test_agent_tool_descriptor_registry_integrity.exe`
- `./_build/default/test/test_keeper_sandbox_boundary_policy.exe`
- `./_build/default/test/test_keeper_unified_required_tools.exe`