### PR TITLE
feat(keeper_tag_dispatch): tag explicit failure_class on 4 caller-misuse rejection sites (RFC-0189 small-step)

### DIFF
--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -85,6 +85,18 @@ let dispatch
   let start_time = Time_compat.now () in
   let ok msg = Tool_result.ok ~tool_name:name ~start_time msg in
   let err msg = Tool_result.error ~tool_name:name ~start_time msg in
+  (* RFC-0189: separate *deliberate caller-misuse rejections* (wrong
+     client, wrong surface, deprecated tool) from *runtime/dispatch
+     errors* (Tool_local_runtime non-zero exit, try-catch fallback).
+     The [workflow_err] sites below answer caller-misuse: keeper
+     used a tool from the wrong surface or context.  [err] retains
+     auto-classify for branches where the upstream message lacks a
+     typed failure variant. *)
+  let workflow_err msg =
+    Tool_result.error
+      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~tool_name:name ~start_time msg
+  in
   (* Wrap dispatch in try-catch to normalize exceptions into error results.
      Tool_*.dispatch functions may raise on unexpected JSON shapes or
      backend failures. Without this, exceptions escape to the keeper loop
@@ -130,11 +142,11 @@ let dispatch
         ~args
     | Mod_keeper ->
       Some
-        (err
+        (workflow_err
            (Printf.sprintf "tool '%s' is a keeper management tool (use MCP client)" name))
     | Mod_operator ->
       Some
-        (err
+        (workflow_err
            (Printf.sprintf
               "tool '%s' belongs to the removed operator surface; keeper runtime stays \
                on OAS Agent.run"
@@ -145,14 +157,14 @@ let dispatch
       Some (ok (Yojson.Safe.to_string json))
     | Mod_inline ->
       Some
-        (err
+        (workflow_err
            (Printf.sprintf
               "tool '%s' requires MCP session context (not available in keeper)"
               name))
     (* ── Tier D: Cycle-breaking — modules that back-reference Keeper_exec_* *)
     | Mod_compact ->
       Some
-        (err
+        (workflow_err
            (Printf.sprintf "tool '%s' is an internal context tool (use MCP client)" name))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e


### PR DESCRIPTION
## Summary

Continues the explicit failure_class micro-tagging pattern (#18813 / #18817 / #18820 / #18824) for the keeper tag-dispatch router.

The router has a shared `err` closure used across both caller-misuse and runtime-error paths. This PR introduces a sibling `workflow_err` closure that pins `Workflow_rejection` for the **4 sites that reject keeper deliberate caller-misuse**:

| Tag | Message | Why |
|---|---|---|
| `Mod_keeper` | `"tool '%s' is a keeper management tool (use MCP client)"` | Caller-misuse: wrong client |
| `Mod_operator` | `"tool '%s' belongs to the removed operator surface ..."` | Caller-misuse: deprecated surface |
| `Mod_inline` | `"tool '%s' requires MCP session context (not available in keeper)"` | Caller-misuse: wrong context |
| `Mod_compact` | `"tool '%s' is an internal context tool (use MCP client)"` | Caller-misuse: wrong client |

The original `err` closure is **retained** for:
- **Tool_local_runtime** (success/error from a coprocess; the string carries the upstream command's stderr — semantically mixed, no typed source).
- **try-catch fallback** (genuine OCaml exception from the dispatch path — auto-classify covers it via the message pattern; a future PR may move that to `of_exn`).

Pattern matches the iteration-22 `tool_coord` split: caller-misuse = explicit `Workflow_rejection`; transient / runtime-error = retain auto-classify until upstream typed errors exist.

## Why this PR shape

- Pure `?failure_class` addition on a new `workflow_err` closure. `Tool_result.error` signature preserved.
- **Zero supersession risk** vs the parallel RFC-0189 stream. Even though PR-2 (#18793) closed without merge, the pattern remains stable.

## Verification

- `dune build --root . --cache=disabled lib/` exit 0

## Test plan

- [x] lib build
- [ ] CI green (Draft)

Refs RFC-0189.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
