### PR TITLE
fix(types_core): derive task_status schema enum from to_string function

### DIFF
--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -353,28 +353,52 @@ let task_status_is_done = function
   | Done _ -> true
   | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _ -> false
 
-(** Issue #8354: schema enums for [task_status] used to be hand-rolled in
-    [tool_shard.ml] and [mcp_server.ml], dropping [awaiting_verification].
-    [task_status] carries record payloads so we cannot enumerate dummy
-    values like [task_action]. Instead, this helper uses an exhaustive
-    [match] driven by a witness function: adding a 7th constructor to
-    [task_status] forces this match to be updated by the compiler, so
-    schema enums cannot silently drift again.
+(** Issue #8354 + 2026-05-27 follow-up: schema enums for [task_status]
+    used to be hand-rolled in [tool_shard.ml] and [mcp_server.ml],
+    dropping [awaiting_verification].  The first fix introduced a
+    [witness] [function] inside [all_task_status_names] whose
+    exhaustiveness pinned *constructor coverage* but whose return
+    [string list] was a separate literal — renaming an arm in
+    [task_status_to_string] (e.g. "in_progress" -> "running") would
+    not propagate to the published schema, leaving a silent
+    string-identity drift.
+
+    This version closes that gap by deriving the schema enum directly
+    from [task_status_to_string] over a witness list with placeholder
+    payloads.  [task_status] carries record payloads but the schema
+    cares only about the constructor tag, so zero-valued placeholder
+    fields are safe — only [task_status_to_string]'s constructor arm
+    is consulted.  Now both axes are guarded:
+
+    - Constructor coverage: adding a constructor breaks
+      [task_status_to_string]'s exhaustive [match] at compile time.
+    - String identity: schema enum is the actual function image, so
+      renames cannot desync.
+
+    The remaining hand-coded axis is the witness list's length —
+    [test_types.ml] pins it at 6, so adding a constructor without
+    adding a witness here breaks that test.
 
     Order matches the FSM lifecycle (Todo -> Claimed -> InProgress ->
     AwaitingVerification -> Done | Cancelled) for readable schema docs. *)
+let task_status_schema_witnesses : task_status list =
+  let placeholder = "" in
+  [ Todo
+  ; Claimed { assignee = placeholder; claimed_at = placeholder }
+  ; InProgress { assignee = placeholder; started_at = placeholder }
+  ; AwaitingVerification
+      { assignee = placeholder
+      ; submitted_at = placeholder
+      ; verification_id = placeholder
+      ; deadline = None
+      }
+  ; Done { assignee = placeholder; completed_at = placeholder; notes = None }
+  ; Cancelled
+      { cancelled_by = placeholder; cancelled_at = placeholder; reason = None }
+  ]
+
 let all_task_status_names : string list =
-  let witness =
-    function
-    | Todo -> "todo"
-    | Claimed _ -> "claimed"
-    | InProgress _ -> "in_progress"
-    | AwaitingVerification _ -> "awaiting_verification"
-    | Done _ -> "done"
-    | Cancelled _ -> "cancelled"
-  in
-  let _ = witness in
-  [ "todo"; "claimed"; "in_progress"; "awaiting_verification"; "done"; "cancelled" ]
+  List.map task_status_to_string task_status_schema_witnesses
 
 let valid_task_status_strings = all_task_status_names
 


### PR DESCRIPTION
## 문제

\`all_task_status_names\` (types_core.ml:366) 은 issue #8354 fix로 도입됐는데 **불완전**:

\`\`\`ocaml
let all_task_status_names : string list =
  let witness = function
    | Todo -> \"todo\" | Claimed _ -> \"claimed\" | ...
  in
  let _ = witness in
  [ \"todo\"; \"claimed\"; \"in_progress\"; \"awaiting_verification\"; \"done\"; \"cancelled\" ]
\`\`\`

- ✅ Witness function의 exhaustive match — 새 constructor 추가 시 compile fail (*constructor coverage* 보장)
- ❌ Return value는 *hardcoded literal* — \`task_status_to_string\`에서 \`\"in_progress\" -> \"running\"\` 변경해도 schema enum 그대로 (*string identity drift 가능*)

## Drift 영향

Schema enum은 두 caller에서 외부로 노출:
- \`mcp_server.ml:454\` — MCP \`task_statuses\` 필드
- \`tool_shard_types_schemas_taskboard.ml:22\` — Tool schema

Client는 published enum에 의존. 함수와 enum이 desync되면 client side parse error 또는 silent state mismatch.

## Fix

Schema enum을 \`task_status_to_string\` 함수의 *actual image*로 도출:

\`\`\`ocaml
let task_status_schema_witnesses : task_status list =
  let placeholder = \"\" in
  [ Todo
  ; Claimed { assignee = placeholder; claimed_at = placeholder }
  ; ...
  ]

let all_task_status_names : string list =
  List.map task_status_to_string task_status_schema_witnesses
\`\`\`

Placeholder fields는 안전 — schema는 constructor tag만 신경 씀, payload 무관. 두 축 모두 guarded:

| 축 | Guard |
|---|---|
| Constructor coverage | \`task_status_to_string\` exhaustive match (compile-time) |
| String identity | Schema enum = function image (rename 자동 전파) |
| Witness list length | \`test_types.ml:156\` hardcoded \`6\` (test-time) |

## 검증

- \`dune build lib/\` clean
- 기존 \`test_types\` task_status group 3/3 PASS, \`test_status_strings_match_variant_witness\` (count=6) PASS, \`test_awaiting_verification_in_enum\` PASS
- 다른 3 fail은 task_status와 무관한 pre-existing main baseline (\`fs_write_mode_ssot\`, \`tool_search_files_op_ssot\`, \`assertion_kind_ssot\`)
- \`.mli\` 변경 없음 — 두 caller 시그니처 그대로

## Anti-pattern Self-Check

| § | 항목 | 평가 |
|---|---|---|
| 1 | counter-as-fix | N/A — actual derivation, instrumentation 아님 |
| 2 | substring/prefix classifier | N/A |
| 3 | \"K of M sites\" | N/A — 단일 함수 |
| 4 | catch-all 추가 | N/A — exhaustive 그대로 |
| 5 | cap/cooldown/dedup/repair | N/A — drift root close |
| 6 | test backdoor | N/A |
| 7 | codemod 미수행 | N/A |

전 항목 N/A. RFC-WAIVED: 단일 함수 root fix.

## 관련

Keeper 로그 분석 P2#10 (task state schema enumeration). Issue #8354 partial fix의 closure.