### PR TITLE
refactor(keeper): remove post-turn lifecycle facade

### DIFF
--- a/docs/compaction/COMPACTION-LIFECYCLE.md
+++ b/docs/compaction/COMPACTION-LIFECYCLE.md
@@ -71,7 +71,7 @@ stateDiagram-v2
 **Post-turn lifecycle contract**
 ([`keeper_state_machine.mli:110-138`](../../lib/keeper/keeper_state_machine.mli)):
 `Compaction_started`/`Compaction_completed`/`Compaction_failed` MUST
-be dispatched only from `Keeper_post_turn.apply_post_turn_lifecycle`.
+be dispatched only from `Keeper_post_turn.apply_post_turn_lifecycle_with_resilience_handles`.
 Violations reopen the
 [`KeepalivePhaseConsistency.tla`](../../specs/bug-models/KeepalivePhaseConsistency.tla)
 bug — `NoDrainTransition` / `GhostDispatch` invariants would catch it.

--- a/docs/rfc/RFC-0003-keeper-composite-lifecycle.md
+++ b/docs/rfc/RFC-0003-keeper-composite-lifecycle.md
@@ -50,7 +50,7 @@ code_refs:
 세 spec은 각자 영역에서 유효하지만, **한 turn 안에서 여러 FSM이 순서를 지키며 전이하는 joint property**는 아무도 검사하지 않는다. 근거:
 
 - `Keeper_state_machine.mli:131-136` `Context_measured` 이벤트는 Decision, Compaction, Cascade, Recovery의 분기 조건을 공통으로 공급하지만 이 공유 측정의 존재를 joint spec으로 명시한 곳이 없다.
-- `keeper_post_turn.ml:45-232` `apply_post_turn_lifecycle`는 `Compaction_started/completed`, `Handoff_started/completed`를 한 turn 안에 atomic하게 emit하지만, 이 atomic 경계를 TLC로 검증할 수 있는 spec이 없다.
+- `keeper_post_turn.ml:45-232` `apply_post_turn_lifecycle_with_resilience_handles`는 `Compaction_started/completed`, `Handoff_started/completed`를 한 turn 안에 atomic하게 emit하지만, 이 atomic 경계를 TLC로 검증할 수 있는 spec이 없다.
 - `docs/tla-audit/state-fsm-gap-2026-04-13.md` Bug #1(PR #6834, `keeper_keepalive.ml:774-836`)은 **data record 스토어와 FSM condition 스토어 간 비동기**가 만든 one-way trap이었다. 이 RFC의 live observer contract에서는 그 two-store 축을 더 이상 ownership 대상으로 두지 않는다. `KeeperRecoveryOrchestration.tla`는 historical audit model로만 남는다.
 - 대시보드 관점에서 각 FSM이 `dashboard/src/components/keeper-*.ts`의 개별 위젯으로 흩어져 있어 "이 keeper의 현재 상태가 invariants를 만족하는가"를 한눈에 볼 수 없다.
 
@@ -228,7 +228,7 @@ L2는 `WF_vars(ClearFailing)`이 fairness에 포함되어야만 성립한다. fa
 
 ### 관찰 hook 위치
 
-- `lib/keeper/keeper_post_turn.ml:45-232` `apply_post_turn_lifecycle` — `Compaction_started/completed`, `Handoff_started/completed` 각 emit 직후 `Keeper_event_bus` 브로드캐스트.
+- `lib/keeper/keeper_post_turn.ml:45-232` `apply_post_turn_lifecycle_with_resilience_handles` — `Compaction_started/completed`, `Handoff_started/completed` 각 emit 직후 `Keeper_event_bus` 브로드캐스트.
 - `lib/keeper/keeper_unified_turn.ml` — phase gate 입출.
 - Topic: `keeper.composite.tick`.
 - Envelope: OAS event_bus envelope `{correlation_id, run_id, ts}` (PR OAS#845, `project_oas-event-bus-envelope-2026-04-12.md`).

--- a/docs/rfc/RFC-0094-compact-cooldown-semantics-split.md
+++ b/docs/rfc/RFC-0094-compact-cooldown-semantics-split.md
@@ -223,7 +223,7 @@ cadence pattern).
 
 ### 6.2 Lifecycle (Phase 2)
 
-- Reuse [test_apply_post_turn_lifecycle_no_state_advances_cooldown_ts]
+- Reuse [test_post_turn_lifecycle_no_state_advances_cooldown_ts]
   (added by #15682) but assert it advances [last_compact_check_ts],
   not [last_continuity_update_ts].
 - New test: post-turn with no snapshot leaves

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -193,7 +193,7 @@ stateDiagram-v2
 3. **AgentRun**: `keeper_agent_run.run_turn`이 OAS `Agent.run`에 위임. tools + hooks + context_reducer + memory 전달
 4. **ToolExecution**: Agent가 tool을 호출하면 `keeper_tools_oas`가 `keeper_exec_tools.execute_keeper_tool_call`로 디스패치
 5. **UpdateMetrics**: `keeper_unified_turn.update_metrics_from_result`가 turn count, token 사용량, cost 등을 keeper_meta에 반영하고 `observation.idle_seconds`를 `masc_keeper_idle_seconds{keeper_name}` Prometheus gauge로 노출
-6. **PostTurnLifecycle**: `keeper_post_turn.apply_post_turn_lifecycle`가 compaction, handoff rollover, continuity summary를 single-writer로 처리
+6. **PostTurnLifecycle**: `keeper_post_turn.apply_post_turn_lifecycle_with_resilience_handles`가 compaction, handoff rollover, continuity summary를 single-writer로 처리
 7. **Checkpoint / Compact / Handoff**: checkpoint 저장 후 gate에 따라 compaction 또는 handoff rollover를 실행
 8. **MemoryWrite**: `keeper_agent_run` tail에서 memory bank note append와 episodic flush를 수행. hebbian은 task lifecycle에서만 기록
 

--- a/docs/tla-audit/kpto-r10-post-turn-lineref-symbol-anchor-2026-05-12.md
+++ b/docs/tla-audit/kpto-r10-post-turn-lineref-symbol-anchor-2026-05-12.md
@@ -3,7 +3,7 @@
 **Date**: 2026-05-12 · **Iteration**: 84 (`/loop` FSM/TLA+/OCaml drift hunt) · **Phase**: R (line-ref sweep, cluster #3)
 **Spec**: `specs/keeper-state-machine/KeeperPostTurnOrchestration.tla` (401 LOC, bug-model paired)
 **OCaml**: `lib/keeper/keeper_post_turn.ml` — `apply_post_turn_lifecycle_with_resilience_handles` (the post-turn lifecycle body the spec models) · `lib/keeper/keeper_unified_turn.ml` — the `current_turn_blocker_info` stamp
-**Verdict**: **9 line-ref citations symbol-anchored; the ~8 `keeper_post_turn.ml:NNN` ones (lines 600-656) were still roughly accurate but converted preventively, the 1 `keeper_unified_turn.ml:1640` had genuinely drifted (the stamp site is near line 1810, the ref-decl near 789), and the enclosing-function name in the `phase` row was slightly wrong (`apply_post_turn_lifecycle` → `apply_post_turn_lifecycle_with_resilience_handles`).** Model body unchanged; TLC re-verified (clean = no error, depth 11; buggy = `SafetyInvariant` violated).
+**Verdict**: **9 line-ref citations symbol-anchored; the ~8 `keeper_post_turn.ml:NNN` ones (lines 600-656) were still roughly accurate but converted preventively, the 1 `keeper_unified_turn.ml:1640` had genuinely drifted (the stamp site is near line 1810, the ref-decl near 789), and the enclosing-function name in the `phase` row was corrected to `apply_post_turn_lifecycle_with_resilience_handles`.** Model body unchanged; TLC re-verified (clean = no error, depth 11; buggy = `SafetyInvariant` violated).
 
 ## Why this cluster (line-ref sweep #3, the last big one)
 
@@ -13,7 +13,7 @@ iter 81's corpus survey flagged KeeperPostTurnOrchestration as the third cluster
 
 | Spec citation | Actual 2026-05-12 | Drift | Action |
 |---|---|---|---|
-| `keeper_post_turn.ml:600-656` — `phase` row ("control-flow position inside apply_post_turn_lifecycle") | the post-compaction → rollover → wirein-chain tail of `apply_post_turn_lifecycle_with_resilience_handles` (function @361, tail @~595-656); `apply_post_turn_lifecycle` itself (@658) is a 5-line wrapper | ~0 (line band still right) but the *function name* was wrong | → `keeper_post_turn.ml — apply_post_turn_lifecycle_with_resilience_handles (post-compaction → rollover → wirein-chain tail)`; semantic column corrected to name the real function |
+| `keeper_post_turn.ml:600-656` — `phase` row ("control-flow position inside the post-turn lifecycle") | the post-compaction → rollover → wirein-chain tail of `apply_post_turn_lifecycle_with_resilience_handles` (function @361, tail @~595-656) | ~0 (line band still right) but the *function name* was wrong | → `keeper_post_turn.ml — apply_post_turn_lifecycle_with_resilience_handles (post-compaction → rollover → wirein-chain tail)`; semantic column corrected to name the real function |
 | `keeper_post_turn.ml:622-632` — `compaction_decision` | the `compaction = { attempted; applied; failure_reason; trigger; ... }` record @~625-637 | ~0..+5 | → symbol anchor (the record construction in `apply_post_turn_lifecycle_with_resilience_handles`) |
 | `keeper_post_turn.ml:600-608` — `rollover_decision` (×2, incl. inline at line 187) | `Keeper_rollover.maybe_rollover_oas_handoff` call @601 | ~0 | → symbol anchor |
 | `keeper_post_turn.ml:648-656` — `wirein_order` (×3: mapping row + lines 80, 295) | the `apply_*_wirein` chain (`apply_autonomous_wirein`@648 → `apply_resilience_wirein` → `apply_tool_emission_wirein` → `apply_multimodal_wirein`@656) | ~0 (exact) | → symbol anchor (the chain) |

--- a/lib/autonomous/wirein_helpers.mli
+++ b/lib/autonomous/wirein_helpers.mli
@@ -6,16 +6,13 @@
     These helpers live in [lib/autonomous/] (rather than directly
     inside [lib/keeper/keeper_post_turn]) so they can be unit-tested
     without pulling the entire [masc_mcp] library into the test
-    closure. The keeper-side [apply_post_turn_lifecycle] dispatches
-    to {!masc_autonomous_enabled} and {!upsert_autonomous_meta} from
-    here. *)
+    closure. The keeper post-turn lifecycle dispatches to
+    {!masc_autonomous_enabled} and {!upsert_autonomous_meta} from here. *)
 
 val masc_autonomous_enabled : unit -> bool
 (** [true] iff the [MASC_AUTONOMOUS] environment variable is set
     to one of ["1"], ["true"], ["yes"], or ["on"] (case-sensitive).
-    The default ([false]) keeps the autonomous wire-in inert —
-    calling [Keeper_post_turn.apply_post_turn_lifecycle] is
-    identical to its pre-A5 behaviour. *)
+    The default ([false]) keeps the autonomous wire-in inert. *)
 
 val upsert_autonomous_meta :
   Yojson.Safe.t option -> Yojson.Safe.t -> Yojson.Safe.t option

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -149,7 +149,6 @@ type max_context_resolution = {
   effective_budget : int;
 }
 
-let apply_post_turn_lifecycle = Keeper_post_turn.apply_post_turn_lifecycle
 let apply_post_turn_lifecycle_with_resilience_handles =
   Keeper_post_turn.apply_post_turn_lifecycle_with_resilience_handles
 let recover_latest_checkpoint_for_overflow_retry =

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -195,17 +195,6 @@ type compaction_decision = Keeper_compact_policy.compaction_decision =
 val compaction_decision_to_string : compaction_decision -> string
 val compaction_decision_applied : compaction_decision -> bool
 
-val apply_post_turn_lifecycle
-  :  on_compaction_started:(unit -> unit)
-  -> on_handoff_started:(unit -> unit)
-  -> base_dir:string
-  -> meta:keeper_meta
-  -> model:string
-  -> primary_model_max_tokens:int
-  -> current_turn_blocker_info:blocker_info option
-  -> checkpoint:Agent_sdk.Checkpoint.t option
-  -> post_turn_lifecycle
-
 val apply_post_turn_lifecycle_with_resilience_handles
   :  resilience_audit_store:Shared_audit.Store.t option
   -> resilience_strategy_executor:Resilience.Recovery.strategy_executor option

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -684,27 +684,6 @@ let apply_post_turn_lifecycle_with_resilience_handles
   let body = apply_tool_emission_wirein ~now:now_ts body in
   apply_multimodal_wirein ~now:now_ts body
 
-let apply_post_turn_lifecycle
-    ~(on_compaction_started : unit -> unit)
-    ~(on_handoff_started : unit -> unit)
-    ~(base_dir : string)
-    ~(meta : keeper_meta)
-    ~(model : string)
-    ~(primary_model_max_tokens : int)
-    ~(current_turn_blocker_info : blocker_info option)
-    ~(checkpoint : Agent_sdk.Checkpoint.t option) : post_turn_lifecycle =
-  apply_post_turn_lifecycle_with_resilience_handles
-    ~resilience_audit_store:None
-    ~resilience_strategy_executor:None
-    ~on_compaction_started
-    ~on_handoff_started
-    ~base_dir
-    ~meta
-    ~model
-    ~primary_model_max_tokens
-    ~current_turn_blocker_info
-    ~checkpoint
-
 let forced_overflow_retry_meta
     (meta : keeper_meta)
     ~(turn_generation : int)

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -66,17 +66,6 @@ type overflow_retry_recovery =
     is enriched with an ["autonomous_meta"] sub-tree carrying the
     suspended {!Autonomous_bridge} state. Off-mode behaviour is
     unchanged (zero impact). *)
-val apply_post_turn_lifecycle :
-  on_compaction_started:(unit -> unit) ->
-  on_handoff_started:(unit -> unit) ->
-  base_dir:string ->
-  meta:Keeper_types.keeper_meta ->
-  model:string ->
-  primary_model_max_tokens:int ->
-  current_turn_blocker_info:Keeper_types.blocker_info option ->
-  checkpoint:Agent_sdk.Checkpoint.t option ->
-  post_turn_lifecycle
-
 val apply_post_turn_lifecycle_with_resilience_handles :
   resilience_audit_store:Shared_audit.Store.t option ->
   resilience_strategy_executor:Resilience.Recovery.strategy_executor option ->
@@ -89,12 +78,10 @@ val apply_post_turn_lifecycle_with_resilience_handles :
   current_turn_blocker_info:Keeper_types.blocker_info option ->
   checkpoint:Agent_sdk.Checkpoint.t option ->
   post_turn_lifecycle
-(** Variant of {!apply_post_turn_lifecycle} for callers that own
-    concrete resilience recovery handles.
+(** Apply the keeper post-turn lifecycle with explicit resilience handles.
 
-    Valid combinations of the two new arguments are:
-    - both [None]: equivalent to {!apply_post_turn_lifecycle}; no
-      audit envelope, no recovery side effect (legacy path).
+    Valid combinations of the two resilience arguments are:
+    - both [None]: no audit envelope, no recovery side effect.
     - both [Some]: the feature-flagged resilience wire-in writes a
       durable [RecoveryAttempted] envelope through the audit store
       before invoking the executor, preserving auditability.

--- a/lib/resilience/keeper_bridge.mli
+++ b/lib/resilience/keeper_bridge.mli
@@ -50,9 +50,7 @@
 val masc_resilience_enabled : unit -> bool
 (** [true] iff the [MASC_RESILIENCE] environment variable is set
     to one of ["1"], ["true"], ["yes"], or ["on"] (lowercase only).
-    The default ([false]) keeps the resilience wire-in inert —
-    calling [Keeper_post_turn.apply_post_turn_lifecycle] is
-    identical to its pre-A6 behaviour. *)
+    The default ([false]) keeps the resilience wire-in inert. *)
 
 val upsert_resilience_meta :
   Yojson.Safe.t option -> Yojson.Safe.t -> Yojson.Safe.t option

--- a/test/autonomous/test_autonomous_wirein.ml
+++ b/test/autonomous/test_autonomous_wirein.ml
@@ -7,7 +7,7 @@
      keys when adding the ["autonomous_meta"] sub-tree, and replaces
      a prior ["autonomous_meta"] entry without duplicating it.
 
-   The full apply_post_turn_lifecycle integration is observed by an
+   The full keeper post-turn lifecycle integration is observed by an
    e2e test in lib/keeper's existing harness; this suite covers the
    wire-in's storage discipline and the env-flag predicate directly. *)
 

--- a/test/test_k2_pipeline_e2e.ml
+++ b/test/test_k2_pipeline_e2e.ml
@@ -27,8 +27,8 @@
    network I/O. If any stage drops or duplicates artifacts the
    final assertion fails.
 
-   The test does NOT call apply_post_turn_lifecycle — that brings
-   in the entire keeper FSM including OAS Checkpoint construction.
+   The test does NOT call the keeper post-turn lifecycle — that
+   brings in the entire keeper FSM including OAS Checkpoint construction.
    The pieces excerpted here are the same modules
    apply_multimodal_wirein dispatches to, so the chain is identical
    from the artifact's point of view. *)

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -15,6 +15,27 @@ module TCG = Masc_mcp.Telemetry_coverage_gap
 let ctx_messages = KEC.messages_of_context
 let ctx_system_prompt = KEC.system_prompt_of_context
 
+let post_turn_lifecycle_no_resilience
+    ~on_compaction_started
+    ~on_handoff_started
+    ~base_dir
+    ~meta
+    ~model
+    ~primary_model_max_tokens
+    ~current_turn_blocker_info
+    ~checkpoint =
+  KEC.apply_post_turn_lifecycle_with_resilience_handles
+    ~resilience_audit_store:None
+    ~resilience_strategy_executor:None
+    ~on_compaction_started
+    ~on_handoff_started
+    ~base_dir
+    ~meta
+    ~model
+    ~primary_model_max_tokens
+    ~current_turn_blocker_info
+    ~checkpoint
+
 let temp_dir prefix =
   let dir = Filename.temp_file prefix "" in
   Unix.unlink dir;
@@ -164,7 +185,7 @@ let load_context ~base_dir ~trace_id ~max_tokens =
   in
   loaded_opt
 
-let test_apply_post_turn_lifecycle_without_checkpoint_records_skip () =
+let test_post_turn_lifecycle_without_checkpoint_records_skip () =
   let base_dir = temp_dir "keeper_lifecycle_none" in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
@@ -172,7 +193,7 @@ let test_apply_post_turn_lifecycle_without_checkpoint_records_skip () =
       Fs_compat.clear_fs ();
       let meta = make_keeper_meta () in
       let lifecycle =
-        KEC.apply_post_turn_lifecycle
+        post_turn_lifecycle_no_resilience
           ~on_compaction_started:(fun () -> ())
           ~on_handoff_started:(fun () -> ())
           ~base_dir ~meta
@@ -254,7 +275,7 @@ let test_checkpoint_helpers_ignore_legacy_working_context_sidecar () =
   check int "canonical context generation preserved" 42
     (KCC.checkpoint_generation canonical ~fallback:7)
 
-let test_apply_post_turn_lifecycle_no_state_advances_cooldown_ts () =
+let test_post_turn_lifecycle_no_state_advances_cooldown_ts () =
   let base_dir = temp_dir "keeper_lifecycle_no_state" in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
@@ -298,7 +319,7 @@ let test_apply_post_turn_lifecycle_no_state_advances_cooldown_ts () =
         |> Option.value ~default:0.0
       in
       let lifecycle =
-        KEC.apply_post_turn_lifecycle
+        post_turn_lifecycle_no_resilience
           ~on_compaction_started:(fun () -> ())
           ~on_handoff_started:(fun () -> ())
           ~base_dir ~meta
@@ -321,7 +342,7 @@ let test_apply_post_turn_lifecycle_no_state_advances_cooldown_ts () =
       check bool "skipped_no_state counter incremented" true
         (after -. before >= 1.0))
 
-let test_apply_post_turn_lifecycle_compacts_and_updates_continuity () =
+let test_post_turn_lifecycle_compacts_and_updates_continuity () =
   let base_dir = temp_dir "keeper_lifecycle_compact" in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
@@ -360,7 +381,7 @@ let test_apply_post_turn_lifecycle_compacts_and_updates_continuity () =
       let checkpoint = save_checkpoint ~base_dir ~meta ~ctx:original_ctx in
       let compaction_started = ref 0 in
       let lifecycle =
-        KEC.apply_post_turn_lifecycle
+        post_turn_lifecycle_no_resilience
           ~on_handoff_started:(fun () -> ())
           ~base_dir ~meta
           ~on_compaction_started:(fun () -> incr compaction_started)
@@ -446,7 +467,7 @@ let test_compaction_callback_failure_records_coverage_gap () =
           ()
       in
       let lifecycle =
-        KEC.apply_post_turn_lifecycle
+        post_turn_lifecycle_no_resilience
           ~on_handoff_started:(fun () -> ())
           ~base_dir ~meta
           ~on_compaction_started:(fun () ->
@@ -485,7 +506,7 @@ let test_compaction_callback_failure_records_coverage_gap () =
              "synthetic callback failure")
       | _ -> fail "expected one telemetry coverage gap row")
 
-let test_apply_post_turn_lifecycle_keeps_checkpoint_when_compaction_skips () =
+let test_post_turn_lifecycle_keeps_checkpoint_when_compaction_skips () =
   let base_dir = temp_dir "keeper_lifecycle_skip_compaction" in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
@@ -521,7 +542,7 @@ let test_apply_post_turn_lifecycle_keeps_checkpoint_when_compaction_skips () =
       let original_count = List.length (ctx_messages original_ctx) in
       let checkpoint = save_checkpoint ~base_dir ~meta ~ctx:original_ctx in
       let lifecycle =
-        KEC.apply_post_turn_lifecycle
+        post_turn_lifecycle_no_resilience
           ~on_compaction_started:(fun () -> ())
           ~on_handoff_started:(fun () -> ())
           ~base_dir ~meta
@@ -543,7 +564,7 @@ let test_apply_post_turn_lifecycle_keeps_checkpoint_when_compaction_skips () =
             (List.length (ctx_messages loaded))
       | None -> fail "expected original checkpoint to remain available")
 
-let test_apply_post_turn_lifecycle_no_state_advances_continuity_cooldown ()
+let test_post_turn_lifecycle_no_state_advances_continuity_cooldown ()
     =
   let base_dir = temp_dir "keeper_lifecycle_no_state_cooldown" in
   Fun.protect
@@ -592,7 +613,7 @@ let test_apply_post_turn_lifecycle_no_state_advances_continuity_cooldown ()
           ()
       in
       let lifecycle =
-        KEC.apply_post_turn_lifecycle
+        post_turn_lifecycle_no_resilience
           ~on_compaction_started:(fun () -> ())
           ~on_handoff_started:(fun () -> ())
           ~base_dir ~meta
@@ -616,7 +637,7 @@ let test_apply_post_turn_lifecycle_no_state_advances_continuity_cooldown ()
            ~labels
            ()))
 
-let test_apply_post_turn_lifecycle_handoffs_after_compaction () =
+let test_post_turn_lifecycle_handoffs_after_compaction () =
   let base_dir = temp_dir "keeper_lifecycle_handoff" in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
@@ -656,7 +677,7 @@ let test_apply_post_turn_lifecycle_handoffs_after_compaction () =
       let compaction_started = ref 0 in
       let handoff_started = ref 0 in
       let lifecycle =
-        KEC.apply_post_turn_lifecycle ~base_dir ~meta
+        post_turn_lifecycle_no_resilience ~base_dir ~meta
           ~on_compaction_started:(fun () -> incr compaction_started)
           ~on_handoff_started:(fun () -> incr handoff_started)
           ~model:"llama:auto"
@@ -740,7 +761,7 @@ let test_handoff_callback_failure_records_coverage_gap () =
           ()
       in
       let lifecycle =
-        KEC.apply_post_turn_lifecycle
+        post_turn_lifecycle_no_resilience
           ~on_compaction_started:(fun () -> ())
           ~on_handoff_started:(fun () ->
             failwith "synthetic handoff callback failure")
@@ -780,7 +801,7 @@ let test_handoff_callback_failure_records_coverage_gap () =
              "synthetic handoff callback failure")
       | _ -> fail "expected one telemetry coverage gap row")
 
-let test_apply_post_turn_lifecycle_handoffs_on_current_turn_overflow_signal ()
+let test_post_turn_lifecycle_handoffs_on_current_turn_overflow_signal ()
     =
   let base_dir = temp_dir "keeper_lifecycle_overflow_signal_handoff" in
   Fun.protect
@@ -815,7 +836,7 @@ let test_apply_post_turn_lifecycle_handoffs_on_current_turn_overflow_signal ()
         |> fun ctx -> save_checkpoint ~base_dir ~meta ~ctx
       in
       let lifecycle =
-        KEC.apply_post_turn_lifecycle ~base_dir ~meta
+        post_turn_lifecycle_no_resilience ~base_dir ~meta
           ~on_compaction_started:(fun () -> ())
           ~on_handoff_started:(fun () -> ())
           ~model:"llama:auto"
@@ -835,7 +856,7 @@ let test_apply_post_turn_lifecycle_handoffs_on_current_turn_overflow_signal ()
       check int "generation advanced" 1
         lifecycle.updated_meta.runtime.generation)
 
-let test_apply_post_turn_lifecycle_passes_resilience_handles () =
+let test_post_turn_lifecycle_passes_resilience_handles () =
   let base_dir = temp_dir "keeper_lifecycle_resilience" in
   let audit_dir = temp_dir "keeper_lifecycle_resilience_audit" in
   Fun.protect
@@ -935,49 +956,11 @@ let test_apply_post_turn_lifecycle_passes_resilience_handles () =
           | _ -> fail "expected assoc working context")
       | None -> fail "expected checkpoint")
 
-(* Reviewer #13214: pin the legacy compatibility guarantee that
-   apply_post_turn_lifecycle (which forwards to the resilience-handle
-   variant with both arguments [None]) does not invoke any recovery
-   side effect, even when the meta has handoff thresholds tripped.
-   Without this, a future change that accidentally activates
-   recovery from the legacy seam would slip past the existing tests
-   (which only exercise the fully wired Some/Some path). *)
-let test_apply_post_turn_lifecycle_legacy_path_skips_executor () =
-  let base_dir = temp_dir "keeper_lifecycle_legacy_skip_executor" in
-  Fun.protect
-    ~finally:(fun () -> cleanup_dir base_dir)
-    (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let now_ts = Time_compat.now () in
-      let meta =
-        let base = make_keeper_meta () in
-        {
-          base with
-          auto_handoff = false;
-          runtime =
-            { base.runtime with last_continuity_update_ts = now_ts -. 60.0 };
-        }
-      in
-      let lifecycle =
-        KEC.apply_post_turn_lifecycle
-          ~base_dir ~meta
-          ~on_compaction_started:(fun () -> ())
-          ~on_handoff_started:(fun () -> ())
-          ~model:"llama:auto"
-          ~primary_model_max_tokens:4096
-          ~current_turn_blocker_info:None
-          ~checkpoint:None
-      in
-      check bool "no handoff attempted" false lifecycle.handoff_attempted;
-      check (option string) "no handoff failure" None
-        lifecycle.handoff_failure_reason)
-
 (* Reviewer #13214: pin the invariant that an executor without an
    audit store is rejected at the seam, not silently allowed (which
    would skip the RecoveryAttempted envelope and break durable
    auditability). *)
-let test_apply_post_turn_lifecycle_rejects_executor_without_audit () =
+let test_post_turn_lifecycle_rejects_executor_without_audit () =
   let base_dir = temp_dir "keeper_lifecycle_executor_without_audit" in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
@@ -2698,33 +2681,31 @@ let () =
       ( "post_turn_lifecycle",
         [
           test_case "no checkpoint records skip state" `Quick
-            test_apply_post_turn_lifecycle_without_checkpoint_records_skip;
+            test_post_turn_lifecycle_without_checkpoint_records_skip;
           test_case "restore prefers live primary max tokens" `Quick
             test_load_context_prefers_live_primary_max_tokens_over_checkpoint_limit;
           test_case "checkpoint helpers ignore legacy sidecar" `Quick
             test_checkpoint_helpers_ignore_legacy_working_context_sidecar;
           test_case "no STATE still advances cooldown ts + counter" `Quick
-            test_apply_post_turn_lifecycle_no_state_advances_cooldown_ts;
+            test_post_turn_lifecycle_no_state_advances_cooldown_ts;
           test_case "compaction persists checkpoint and continuity" `Quick
-            test_apply_post_turn_lifecycle_compacts_and_updates_continuity;
+            test_post_turn_lifecycle_compacts_and_updates_continuity;
           test_case "compaction callback failure records coverage gap" `Quick
             test_compaction_callback_failure_records_coverage_gap;
           test_case "skip compaction keeps checkpoint" `Quick
-            test_apply_post_turn_lifecycle_keeps_checkpoint_when_compaction_skips;
+            test_post_turn_lifecycle_keeps_checkpoint_when_compaction_skips;
           test_case "no STATE advances continuity cooldown" `Quick
-            test_apply_post_turn_lifecycle_no_state_advances_continuity_cooldown;
+            test_post_turn_lifecycle_no_state_advances_continuity_cooldown;
           test_case "handoff runs after compaction" `Quick
-            test_apply_post_turn_lifecycle_handoffs_after_compaction;
+            test_post_turn_lifecycle_handoffs_after_compaction;
           test_case "handoff callback failure records coverage gap" `Quick
             test_handoff_callback_failure_records_coverage_gap;
           test_case "handoff runs on current-turn overflow signal" `Quick
-            test_apply_post_turn_lifecycle_handoffs_on_current_turn_overflow_signal;
+            test_post_turn_lifecycle_handoffs_on_current_turn_overflow_signal;
           test_case "resilience handles reach bridge" `Quick
-            test_apply_post_turn_lifecycle_passes_resilience_handles;
-          test_case "legacy path skips executor side effects" `Quick
-            test_apply_post_turn_lifecycle_legacy_path_skips_executor;
+            test_post_turn_lifecycle_passes_resilience_handles;
           test_case "executor without audit store rejected" `Quick
-            test_apply_post_turn_lifecycle_rejects_executor_without_audit;
+            test_post_turn_lifecycle_rejects_executor_without_audit;
           test_case "runtime executor pauses handoff" `Quick
             test_post_turn_resilience_runtime_executor_pauses_handoff;
           test_case "rollover aborts on save failure" `Quick

--- a/test/test_keeper_ocaml_tla_correspondence.ml
+++ b/test/test_keeper_ocaml_tla_correspondence.ml
@@ -30,7 +30,7 @@
  *     a TLC trace and replays each (state, action, state') tuple
  *     through OCaml.  Current phases ship parity + spot transitions.
  *   - B2/B3 in-process replay.  The compute_tool_surface and
- *     apply_post_turn_lifecycle pipelines need keeper-runtime
+ *     keeper post-turn lifecycle pipelines need keeper-runtime
  *     fixtures (acc / meta / switch); the TLC layer is the
  *     load-bearing check for invariants.
  *)


### PR DESCRIPTION
## Summary
- remove the no-handle Keeper post-turn lifecycle facade and its Keeper_exec_context re-export
- route tests through the explicit handle-aware lifecycle entrypoint with None/None handles
- delete the migration-only test that pinned the old facade behavior
- refresh active docs/comments to name the handle-aware lifecycle owner

## Validation
- ocamlformat --check on modified OCaml sources/tests
- rg backstop for the removed facade symbol and legacy seam wording across active lib/test/docs/specs: no matches
- git diff --check
- scripts/dune-local.sh build test/test_keeper_lifecycle.exe test/test_keeper_post_turn_wirein_order.exe test/test_k2_pipeline_e2e.exe test/test_keeper_ocaml_tla_correspondence.exe test/autonomous/test_autonomous_wirein.exe attempted, but wrapper refused because unrelated bare Dune processes are active machine-wide