### PR TITLE
feat(server_bootstrap_loops): tag explicit failure_class on judge dispatch errors — Runtime + Workflow split (RFC-0189 small-step)

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -525,21 +525,35 @@ let start_keeper_loops
       (match Tool_coord.dispatch ctx_room ~name ~args with
        | Some result -> result
        | None ->
-         Tool_result.error ~tool_name:name ~start_time "masc_status: dispatch failed")
+         (* RFC-0189: [Tool_*.dispatch] returning [None] when the
+            name is hard-coded here is a server-side invariant
+            violation (registry says the name routes here).
+            [Runtime_failure] — not caller-actionable. *)
+         Tool_result.error
+           ~failure_class:(Some Tool_result.Runtime_failure)
+           ~tool_name:name ~start_time "masc_status: dispatch failed")
     | "masc_tasks" ->
       (match Tool_task.dispatch ctx_task ~name ~args with
        | Some result -> result
        | None ->
-         Tool_result.error ~tool_name:name ~start_time "masc_tasks: dispatch failed")
+         Tool_result.error
+           ~failure_class:(Some Tool_result.Runtime_failure)
+           ~tool_name:name ~start_time "masc_tasks: dispatch failed")
     | "masc_agents" ->
       (match Tool_agent.dispatch ctx_agent ~name ~args with
        | Some result -> result
        | None ->
-         Tool_result.error ~tool_name:name ~start_time "masc_agents: dispatch failed")
+         Tool_result.error
+           ~failure_class:(Some Tool_result.Runtime_failure)
+           ~tool_name:name ~start_time "masc_agents: dispatch failed")
     | "masc_board_list" ->
       Tool_board.handle_tool name args |> Tool_result.to_legacy
     | _ ->
+      (* RFC-0189: judge dispatch caller (governance / operator
+         judge runner) requested a tool outside the allow-list.
+         Caller-misuse = [Workflow_rejection]. *)
       Tool_result.error
+        ~failure_class:(Some Tool_result.Workflow_rejection)
         ~tool_name:name
         ~start_time
         (Printf.sprintf "judge: tool '%s' not allowed" name)


### PR DESCRIPTION
## Summary

The judge-dispatch closure carries **two distinct failure semantics** that the previous auto-classify path collapsed into `Runtime_failure`:

| Site | Class | Why |
|---|---|---|
| `"masc_status: dispatch failed"` | `Runtime_failure` | `Tool_coord.dispatch` returned `None` for a hard-coded name = server-side invariant violation |
| `"masc_tasks: dispatch failed"` | `Runtime_failure` | Same — registry says name routes here but `Tool_task.dispatch` doesn't recognise it |
| `"masc_agents: dispatch failed"` | `Runtime_failure` | Same — `Tool_agent.dispatch` invariant violation |
| `"judge: tool '%s' not allowed"` (catch-all) | `Workflow_rejection` | Judge dispatch allow-list rejection — caller (governance / operator judge runner) requested a tool outside the permitted set |

Mirrors the iteration-23 `keeper_tag_dispatch` split (#18831): **selective tagging that preserves the original semantics** rather than blanket-tagging.

## Why this PR shape

- Pure `?failure_class` addition. `Tool_result.error` signature preserved.
- **Zero supersession risk** vs the parallel RFC-0189 stream. PR-2 (#18793) closed without merge — pattern remains stable.
- Mixed Runtime/Workflow classification — first PR in the micro-step series to add `Runtime_failure` tags (previous PRs were all `Workflow_rejection`).

## Verification

- `dune build --root . --cache=disabled lib/` exit 0

## Test plan

- [x] lib build
- [ ] CI green (Draft)

Refs RFC-0189. Stack with #18813 / #18817 / #18820 / #18824 / #18831.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
