### PR TITLE
fix(anti_rationalization): apply excuse-advisory safety net in cascade-dead branch

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -778,26 +778,78 @@ let review
               ~labels:[ "mode", mode_str; "cascade", evaluator_cascade ]
               ();
             if cascade_permanently_dead
-            then (
-              Log.Task.error
-                "[anti-rationalization] cascade %s has zero callable providers — ALL \
-                 keepers using this evaluator are blocked from task completion.  \
-                 Approving by liveness; OPERATOR ACTION REQUIRED: fix the cascade \
-                 definition (provider capabilities, MCP policy, or tool requirements).  \
-                 See #10474.  err=%s"
-                evaluator_cascade
-                msg;
-              emit
-                { verdict = Approve
-                ; evaluator_cascade
-                ; generator_cascade
-                ; gate = Fallback
-                ; fallback_reason =
-                    Some
-                      (sprintf
-                         "cascade %s has no callable providers (#10474)"
-                         evaluator_cascade)
-                })
+            then
+              (* 2026-05-27: cascade-dead liveness approve previously fired
+                 unconditionally, so an active gate-2 substring advisory
+                 (a phrase that the LLM evaluator was supposed to judge
+                 in context) was silently laundered through.  The sibling
+                 branch below (lines 812-837) already applies an
+                 advisory-driven safety-net reject when the LLM is
+                 transiently unavailable; cascade-dead is just a
+                 longer-lived form of the same condition, so the two
+                 branches must agree on the excuse-advisory case.
+
+                 The original liveness rationale (#10474: do not block
+                 every keeper waiting for a cascade fix) is preserved for
+                 the [None] case — the vast majority of tasks have no
+                 active substring advisory and continue to approve. *)
+              match excuse_advisory with
+              | Some (pattern, reason) ->
+                Prometheus.inc_counter
+                  Prometheus.metric_anti_rationalization_excuse_pattern
+                  ~labels:
+                    [ "pattern", pattern
+                    ; "decision", "advisory_safety_net_reject_cascade_dead"
+                    ]
+                  ();
+                Log.Task.error
+                  "[anti-rationalization] cascade %s permanently dead AND gate-2 \
+                   advisory pattern=%s active: rejecting (safety net) rather than \
+                   laundering excuse phrase through liveness.  OPERATOR ACTION \
+                   REQUIRED: fix the cascade definition.  See #10474.  err=%s"
+                  evaluator_cascade
+                  pattern
+                  msg;
+                emit
+                  { verdict =
+                      Reject
+                        (sprintf
+                           "cascade %s has no callable providers AND avoidance \
+                            pattern \"%s\" detected (%s); rejecting as fail-closed \
+                            safety net (#10474). Revise notes or wait for cascade \
+                            repair."
+                           evaluator_cascade
+                           pattern
+                           reason)
+                  ; evaluator_cascade
+                  ; generator_cascade
+                  ; gate = Fallback
+                  ; fallback_reason =
+                      Some
+                        (sprintf
+                           "cascade %s has no callable providers (#10474)"
+                           evaluator_cascade)
+                  }
+              | None ->
+                Log.Task.error
+                  "[anti-rationalization] cascade %s has zero callable providers — \
+                   ALL keepers using this evaluator are blocked from task \
+                   completion.  Approving by liveness; OPERATOR ACTION REQUIRED: \
+                   fix the cascade definition (provider capabilities, MCP policy, \
+                   or tool requirements).  See #10474.  err=%s"
+                  evaluator_cascade
+                  msg;
+                emit
+                  { verdict = Approve
+                  ; evaluator_cascade
+                  ; generator_cascade
+                  ; gate = Fallback
+                  ; fallback_reason =
+                      Some
+                        (sprintf
+                           "cascade %s has no callable providers (#10474)"
+                           evaluator_cascade)
+                  }
             else (
               (* #10113: when an excuse pattern was detected at gate 2 AND
           the LLM evaluator is unavailable, the advisory is upgraded


### PR DESCRIPTION
## 문제 — 두 fallback 분기 비대칭

\`lib/anti_rationalization.ml\` 의 evaluator-unavailable 처리 분기 두 개:

| 분기 | 조건 | excuse_advisory 처리 |
|---|---|---|
| **L780-800** \`cascade_permanently_dead\` | cascade 모든 provider 영구 dead (#10474) | ❌ 무조건 Approve (silent slip-through) |
| **L812-837** 그 외 transient | LLM 일시 실패 | ✅ excuse pattern 시 advisory_safety_net_reject |

즉 cascade가 영구 dead일 때 substring matcher가 \"will do later\" 같은 avoidance phrase 잡았어도 silent으로 통과. LLM 일시 down일 때는 같은 patten reject.

## 결함의 본질

- Cascade dead = 더 긴 형태의 LLM unavailable
- 두 분기 모두 \"LLM이 판단 불가능\" 상태 — 같은 안전망 적용해야 align
- 현재는 *liveness 우선* 정당화만 적용 (모든 keeper block 회피) — 그러나 #10113 advisory mode 자체가 \"LLM 없을 때 substring matcher가 safety net 역할\"로 설계됨. 그 의도가 cascade dead 케이스에서만 빠짐

## Fix — 분기 symmetry

\`\`\`ocaml
if cascade_permanently_dead
then
  match excuse_advisory with
  | Some (pattern, reason) ->
    (* L812-837 sibling 패턴 isomorphic copy *)
    Prometheus.inc_counter ~labels:[\"decision\",\"advisory_safety_net_reject_cascade_dead\"]...
    emit { verdict = Reject ...; gate = Fallback; ... }
  | None ->
    (* #10474 liveness 정당화 그대로 *)
    Log.Task.error ...
    emit { verdict = Approve; gate = Fallback; ... }
\`\`\`

### 동작 매트릭스

| excuse_advisory | mode | cascade dead | LLM transient |
|---|---|---|---|
| Some | open | **Reject (변경)** | Reject (기존) |
| Some | closed | **Reject (변경)** | Reject (기존) |
| None | open | Approve (#10474 보존) | Approve |
| None | closed | Approve (보존) | Reject |

#10474 liveness 정당화는 \`None\` 케이스에 보존 — 대부분의 task에 substring advisory가 없으므로 cascade fix 동안 keeper block 회피 효과 유지. advisory 발생한 task만 reject — 정확히 substring detector가 설계된 목적.

Operator distinguishability: 새 Prometheus label \`decision=advisory_safety_net_reject_cascade_dead\` 가 cascade config 버그 vs 모델 outage를 구분.

## 검증

- 기존 anti_rationalization test 5 file 23 tests 전부 PASS, 회귀 zero
- 새 통합 test (cascade-dead + advisory 경로)은 cascade dispatch + LLM provider mock harness 필요 — 본 PR에 미포함. **정확성 보장 방식**: L812-837 sibling branch의 *structural isomorphism* — 동일 변수 (\`pattern\`, \`reason\`, \`evaluator_cascade\`, \`generator_cascade\`, \`Fallback\`, \`fallback_reason\`), 동일 verdict 형태 (\`Reject (sprintf ...)\`), 동일 metric pattern (label만 \`_cascade_dead\` suffix). sibling은 [#10113 fix](https://github.com/jeong-sik/masc-mcp/pull/9986) 에서 test 커버됨

## Anti-pattern Self-Check

| § | 항목 | 평가 |
|---|---|---|
| 1 | counter-as-fix | **boundary** — Prometheus label은 incidental; verdict 변경이 real fix |
| 2 | substring/prefix classifier | N/A — 새 classifier 아닌 *기존* excuse_advisory 값 재사용 |
| 3 | \"K of M sites\" | N/A — 단일 분기 |
| 4 | catch-all 추가 | N/A — match arms 명시 |
| 5 | cap/cooldown/dedup/repair | **boundary** — branch symmetry closure, cap 아님. 두 분기를 같은 contract으로 align |
| 6 | test backdoor | N/A |
| 7 | codemod 미수행 | N/A — 단일 site root fix |

§1 §5 boundary case 명시. RFC-WAIVED: 단일 함수 분기 symmetry root fix.

## 관련

Keeper 로그 P2#7 (anti-rationalization silent-success). #10474 cascade liveness 정당화 + #10113 advisory safety net 두 prior fix의 *intersection*에서 비대칭이 silent slip-through 생성. 본 PR은 두 fix의 contract을 align.