### PR TITLE
feat(mcp_server_eio_call_tool): tag explicit failure_class on 3 dispatch boundary errors — Transient + Runtime split (RFC-0189 small-step)

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -604,7 +604,13 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
                  | Some source -> Printf.sprintf " (timeout source: %s)" source
                  | None -> ""
                in
-               Tool_result.error ~tool_name:name ~start_time
+               (* RFC-0189: timeout = retry-friendly transient
+                  failure.  Caller can retry with a longer
+                  [timeout_sec] or wait for the slow upstream to
+                  finish. *)
+               Tool_result.error
+                 ~failure_class:(Some Tool_result.Transient_error)
+                 ~tool_name:name ~start_time
                  (Printf.sprintf "Tool timed out after %.0fs: %s%s"
                     timeout_sec name source))
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
@@ -613,11 +619,23 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
        let trace = Printexc.get_backtrace () in
        let err_detail = if String.length trace > 0 then err ^ "\n" ^ trace else err in
        if contains_casefold err "Invalid_argument(\"MASC not initialized" then
-         Tool_result.error ~tool_name:name ~start_time
+         (* RFC-0189: server bootstrap incomplete — Masc_domain
+            System NotInitialized.  [Runtime_failure] (caller
+            cannot fix; the operator must initialise MASC). *)
+         Tool_result.error
+           ~failure_class:(Some Tool_result.Runtime_failure)
+           ~tool_name:name ~start_time
            (Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
        else
          (Log.Mcp.error "tools/call crashed: %s" err_detail;
-          Tool_result.error ~tool_name:name ~start_time
+          (* RFC-0189: catch-all for unexpected exceptions —
+             [Runtime_failure].  Could become more specific via
+             [of_exn] once the exception variants are typed; for
+             now blanket Runtime preserves operator-visible
+             severity (the existing log line stays ERROR). *)
+          Tool_result.error
+            ~failure_class:(Some Tool_result.Runtime_failure)
+            ~tool_name:name ~start_time
             (Printf.sprintf "Internal error: %s" err_detail))
     in
     let result =


### PR DESCRIPTION
## Summary

Continues the explicit failure_class micro-tagging series (#18813 / #18817 / #18820 / #18824 / #18831 / #18835) for the MCP `tools/call` entry point. The three error sites carry distinct semantics:

| Site | Class | Why |
|---|---|---|
| `"Tool timed out after %.0fs"` | `Transient_error` | Caller can retry with longer `timeout_sec` or wait for slow upstream |
| `"MASC not initialized"` exception caught | `Runtime_failure` | Server bootstrap incomplete — operator must run init |
| `"Internal error: %s"` catch-all | `Runtime_failure` | Unexpected exception from dispatch path; preserves operator-visible severity (ERROR log line stays) |

Pattern mirrors iteration-24 `server_bootstrap_loops` split (#18835): selective tagging that preserves original semantics.

## Why this PR shape

- Pure `?failure_class` addition. `Tool_result.error` signature preserved.
- **Zero supersession risk** vs the parallel RFC-0189 stream.
- **Second PR in series to introduce `Transient_error`** (after #18813 broadcast rate-limit).

## Verification

- `dune build --root . --cache=disabled lib/` exit 0

## Test plan

- [x] lib build
- [ ] CI green (Draft)

Refs RFC-0189. Stack with #18813 / #18817 / #18820 / #18824 / #18831 / #18835.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
