### PR TITLE
refactor(keeper): purge typed Execute normalizers

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-27 10:22:36 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-27 10:43:17 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -808,6 +808,12 @@
             <td><span class="status now">draft PR #18848</span></td>
             <td>Delete <code>normalize_persisted_terminal_reason_code</code>; persisted terminal reason wires now surface as-is instead of rewriting old <code>completed</code> values to <code>success</code>.</td>
             <td><code>test_keeper_unified</code> now pins the strict behavior: old persisted <code>completed</code> remains <code>completed</code> and is summarized as an unknown terminal reason.</td>
+          </tr>
+          <tr>
+            <td>Typed Execute normalization safety nets</td>
+            <td><span class="status now">draft PR #18843</span></td>
+            <td>Remove parser/lowering paths that silently repaired malformed typed Execute input: empty <code>executable</code> promoted from <code>argv[0]</code>, <code>find -type ...</code> rewritten to <code>find . -type ...</code>, simultaneous <code>executable</code> + <code>pipeline</code> accepted by precedence, and duplicate executable tokens stripped before Shell IR lowering.</td>
+            <td><code>Agent_tool_execute_typed_input.of_json</code> now preserves caller-authored exec/pipeline stages, rejects <code>executable</code> with <code>pipeline</code>, and passes argv through to Shell IR. <code>Keeper_tool_capability_axis</code> also stops hiding duplicate executable tokens when extracting command text.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>

--- a/lib/keeper/agent_tool_execute_typed_input.ml
+++ b/lib/keeper/agent_tool_execute_typed_input.ml
@@ -286,7 +286,7 @@ let check_exec ~mode ~executable ~argv ~cwd ~env =
     let* () =
       if argv = [] then Ok () else check_argv ~executable argv
     in
-    let* () = check_wrapper_exec_target ~mode ~executable ~argv in
+    let* () = check_wrapper_exec_target ~mode ~executable:trimmed ~argv in
     let* () = check_cwd cwd in
     let* () = check_env env in
     Ok ()

--- a/lib/keeper/agent_tool_execute_typed_input.ml
+++ b/lib/keeper/agent_tool_execute_typed_input.ml
@@ -172,48 +172,6 @@ let parse_pipeline ~path (json : Yojson.Safe.t) =
     result_errorf "%s must be array, got %s" path (json_type_name value)
 ;;
 
-let normalize_stage { executable; argv } =
-  let executable = String.trim executable in
-  let stage =
-    match executable, argv with
-    | "", first :: rest when not (String.equal (String.trim first) "") ->
-      { executable = String.trim first; argv = rest }
-    | _ -> { executable; argv }
-  in
-  let executable = stage.executable in
-  let argv =
-    let is_find_executable name =
-      String.equal (Filename.basename (String.trim name)) "find"
-    in
-    let is_find_global_option = function
-      | "-E" | "-H" | "-L" | "-P" | "-X" | "-d" | "-s" | "-x" -> true
-      | _ -> false
-    in
-    let is_find_expression_start = function
-      | "!" | "(" | "-and" | "-or" | "-not" | "-name" | "-iname" | "-path"
-      | "-ipath" | "-regex" | "-iregex" | "-type" | "-empty" | "-perm"
-      | "-user" | "-group" | "-size" | "-mtime" | "-mmin" | "-newer"
-      | "-maxdepth" | "-mindepth" | "-prune" | "-print" | "-print0" ->
-        true
-      | _ -> false
-    in
-    let normalize_find_argv argv =
-      let rec split_global_options acc = function
-        | option :: rest when is_find_global_option option ->
-          split_global_options (option :: acc) rest
-        | rest -> List.rev acc, rest
-      in
-      let global_options, rest = split_global_options [] argv in
-      match rest with
-      | first :: _ when is_find_expression_start first ->
-        global_options @ ("." :: rest)
-      | _ -> argv
-    in
-    if is_find_executable executable then normalize_find_argv stage.argv else stage.argv
-  in
-  { executable; argv }
-;;
-
 let of_json (json : Yojson.Safe.t) =
   let ( let* ) = Result.bind in
   let* fields = assoc_fields ~path:"$" json in
@@ -240,16 +198,15 @@ let of_json (json : Yojson.Safe.t) =
   let* cwd = optional_string ~path:"$" fields "cwd" in
   let* env = optional_env ~path:"$" fields in
   match executable_present, pipeline_value with
-  | true, _ ->
-    (* executable takes precedence when both are provided;
-       this is the typed-input contract advertised in the schema. *)
+  | true, Some _ ->
+    Error "$.executable and $.pipeline are mutually exclusive typed Execute fields"
+  | true, None ->
     let* executable = required_string ~path:"$" fields "executable" in
     let* argv = optional_string_list ~path:"$" fields "argv" in
-    let stage = normalize_stage { executable; argv } in
-    Ok (Exec { executable = stage.executable; argv = stage.argv; cwd; env })
+    Ok (Exec { executable; argv; cwd; env })
   | false, Some (path, value) ->
     let* stages = parse_pipeline ~path value in
-    Ok (Pipeline { stages = List.map normalize_stage stages; cwd; env })
+    Ok (Pipeline { stages; cwd; env })
   | false, None -> Error "$.executable or $.pipeline is required"
 ;;
 
@@ -363,15 +320,9 @@ let shell_bin ~mode ~argv executable =
       Error (Executable_not_allowlisted { name = trimmed; mode })
 ;;
 
-let strip_leading_executable executable = function
-  | arg :: rest when String.equal arg executable -> rest
-  | argv -> argv
-;;
-
 let shell_simple ~mode ?(sandbox = Masc_exec.Sandbox_target.host ()) ?cwd ?(env = []) { executable; argv } =
   let ( let* ) = Result.bind in
   let* bin = shell_bin ~mode ~argv executable in
-  let normalized_argv = strip_leading_executable executable argv in
   Ok
     (Agent_tool_execute_shell_ir.simple_bin
        ?cwd_raw:cwd
@@ -379,7 +330,7 @@ let shell_simple ~mode ?(sandbox = Masc_exec.Sandbox_target.host ()) ?cwd ?(env 
        ~sandbox
        ~env
        bin
-       normalized_argv)
+       argv)
 ;;
 
 let to_shell_ir_unvalidated ?(sandbox = Masc_exec.Sandbox_target.host ()) ~mode input =

--- a/lib/keeper/agent_tool_execute_typed_input.mli
+++ b/lib/keeper/agent_tool_execute_typed_input.mli
@@ -18,9 +18,6 @@
       shell operators.  For example, the typed schema accepts
       [find . -name *.ml] because [*.ml] is a [find]-internal pattern,
       not a shell glob.
-    - **Portable find default path**.  Compatibility normalization rewrites
-      [find -type f] style calls to [find . -type f].  GNU find accepts the
-      missing path, but BSD/macOS find reports [illegal option -- t].
     - **Pipelines are explicit**.  [Pipeline.stages] enumerates each
       [exec_stage] separately; [|]-delimited strings are never parsed.
     - **Forbidden in argv tokens**: only control characters that
@@ -76,12 +73,12 @@ val of_json : Yojson.Safe.t -> (execute_input, string) result
 (** Parse the typed Execute JSON boundary.  Accepts either
     [{executable, argv?, cwd?, env?, timeout_sec?}] for [Exec] or
     [{pipeline = [{executable, argv?}, ...], cwd?, env?}] for [Pipeline].
-    [{stages = ...}] is accepted as an equivalent structured pipeline key.
-    [timeout_sec] is accepted at this layer and consumed by the caller. Raw
-    command-string fields and other unsupported fields are intentionally rejected
-    here.  Compatibility normalization promotes [{executable = ""; argv =
-    command :: rest}] to [{executable = command; argv = rest}] before allowlist
-    validation, so malformed typed calls still cross the same executable gate. *)
+    [timeout_sec] is accepted at this layer and consumed by the caller.
+    [executable] and [pipeline] together, raw command-string fields, [{stages =
+    ...}], and other unsupported fields are intentionally rejected here.  No
+    compatibility normalization is applied: missing [find .] paths, empty
+    [executable] fields, and duplicated executable tokens in [argv] remain
+    caller errors. *)
 
 val validate : mode:allowlist_mode -> execute_input -> (unit, validation_error) result
 (** Run all structural checks against [input].  Returns [Ok ()] on
@@ -106,8 +103,10 @@ val to_shell_ir :
 (** Validate and lower [input] into {!Masc_exec.Shell_ir.t}.  [Pipeline]
     inputs become an explicit {!Masc_exec.Shell_ir.Pipeline}; literal ["|"]
     argv tokens remain ordinary argument data and never create a pipeline.
-    [sandbox] defaults to host execution; keeper callers may provide Docker
-    runtime targets after sandbox/profile resolution. *)
+    [Exec] argv is passed through as authored; the lowerer does not strip a
+    duplicated executable token. [sandbox] defaults to host execution; keeper
+    callers may provide Docker runtime targets after sandbox/profile
+    resolution. *)
 
 val pp_validation_error : Format.formatter -> validation_error -> unit
 (** Human-readable formatter for {!validation_error}.  Stable across

--- a/lib/keeper/keeper_tool_capability_axis.ml
+++ b/lib/keeper/keeper_tool_capability_axis.ml
@@ -107,11 +107,6 @@ let command_of_exec_stage ~executable ~argv =
   if String.equal executable ""
   then None
   else
-    let argv =
-      match argv with
-      | first :: rest when String.equal first executable -> rest
-      | argv -> argv
-    in
     Some (String.concat " " (List.map shell_quote_token (executable :: argv)))
 ;;
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -161,12 +161,21 @@ let descriptor_boundary_exempt tool_name =
 ;;
 
 let catalog_boundary_exempt tool_name =
-  match Tool_catalog.is_main_worktree_boundary_exempt tool_name with
+  let decision_for_effect_domain = function
+    | Some Tool_catalog.Read_only
+    | Some Tool_catalog.Masc_coordination
+    | Some Tool_catalog.Playground_write -> Some true
+    | Some Tool_catalog.Host_repo_write -> Some false
+    | None -> None
+  in
+  match decision_for_effect_domain (Tool_catalog.effect_domain tool_name) with
   | Some _ as decision -> decision
   | None ->
-    (match Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name tool_name with
+    (match
+       Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name tool_name
+     with
      | Some internal_name when not (String.equal internal_name tool_name) ->
-       Tool_catalog.is_main_worktree_boundary_exempt internal_name
+       decision_for_effect_domain (Tool_catalog.effect_domain internal_name)
      | _ -> None)
 ;;
 

--- a/lib/tool_shard_types_schemas_execute.ml
+++ b/lib/tool_shard_types_schemas_execute.ml
@@ -42,7 +42,7 @@ let tool_execute_executable_field =
         , `String
             "Typed argv form: allowlisted executable name. Provide argv separately; \
              do not combine shell syntax into this field. Mutually exclusive with \
-             pipeline; if both are provided executable takes precedence." )
+             pipeline." )
       ] )
 ;;
 
@@ -105,8 +105,7 @@ let tool_execute_timeout_sec_field =
 
 let tool_execute_description =
   "Execute one command through the typed execution gates via typed argv. \
-   Provide EITHER executable/argv OR pipeline, never both. If both are \
-   provided, executable takes precedence. Use executable/argv for one process, \
+   Provide EITHER executable/argv OR pipeline, never both. Use executable/argv for one process, \
    or pipeline for explicit Shell IR pipelines. IMPORTANT: there is no 'cmd' \
    or 'command' field. Those fields are not supported and will be rejected. \
    Always use 'executable' (string) and 'argv' (string array) instead. \

--- a/test/test_agent_tool_execute_typed_input.ml
+++ b/test/test_agent_tool_execute_typed_input.ml
@@ -334,7 +334,7 @@ let test_of_json_exec () =
   | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
 ;;
 
-let test_of_json_promotes_empty_exec_from_argv0 () =
+let test_of_json_keeps_empty_exec_for_validation () =
   let input =
     parse_json_exn
       (`Assoc
@@ -345,8 +345,11 @@ let test_of_json_promotes_empty_exec_from_argv0 () =
   in
   match input with
   | Execute_input.Exec { executable; argv; cwd; env } ->
-    Alcotest.(check string) "promoted executable" "gh" executable;
-    Alcotest.(check (list string)) "argv without command duplicate" [ "pr"; "list" ] argv;
+    Alcotest.(check string) "empty executable is not promoted" "" executable;
+    Alcotest.(check (list string))
+      "argv0 command remains caller-authored"
+      [ "gh"; "pr"; "list" ]
+      argv;
     Alcotest.(check (option string)) "cwd" (Some "/tmp") cwd;
     Alcotest.(check (list (pair string string))) "env" [] env
   | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
@@ -385,7 +388,7 @@ let test_of_json_pipeline () =
   | Execute_input.Exec _ -> Alcotest.fail "expected Pipeline"
 ;;
 
-let test_of_json_promotes_empty_pipeline_stage_from_argv0 () =
+let test_of_json_keeps_empty_pipeline_stage_for_validation () =
   let input =
     parse_json_exn
       (`Assoc
@@ -407,8 +410,11 @@ let test_of_json_promotes_empty_pipeline_stage_from_argv0 () =
     Alcotest.(check (list (pair string string))) "env" [] env;
     (match stages with
      | [ first; second ] ->
-       Alcotest.(check string) "first executable" "rg" first.executable;
-       Alcotest.(check (list string)) "first argv" [ "--files"; "lib" ] first.argv;
+       Alcotest.(check string) "first executable remains empty" "" first.executable;
+       Alcotest.(check (list string))
+         "first argv0 command remains caller-authored"
+         [ "rg"; "--files"; "lib" ]
+         first.argv;
        Alcotest.(check string) "second executable" "head" second.executable;
        Alcotest.(check (list string)) "second argv" [ "-20" ] second.argv
      | _ -> Alcotest.fail "expected exactly two stages")
@@ -448,22 +454,19 @@ let test_of_json_rejects_non_string_argv () =
     (String_util.contains_substring_ci msg "$.argv[0]")
 ;;
 
-let test_of_json_prefers_exec_when_both_present () =
-  let input =
-    parse_json_exn
+let test_of_json_rejects_exec_and_pipeline_together () =
+  let msg =
+    parse_json_error
       (`Assoc
           [ "executable", `String "echo"
           ; "argv", `List [ `String "hello" ]
           ; "pipeline", `List [ `Assoc [ "executable", `String "wc" ] ]
           ])
   in
-  match input with
-  | Execute_input.Exec { executable; argv; cwd; env } ->
-    Alcotest.(check string) "executable takes precedence" "echo" executable;
-    Alcotest.(check (list string)) "argv preserved" [ "hello" ] argv;
-    Alcotest.(check (option string)) "cwd" None cwd;
-    Alcotest.(check (list (pair string string))) "env" [] env
-  | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec when both present"
+  Alcotest.(check bool)
+    "error mentions mutual exclusion"
+    true
+    (String_util.contains_substring_ci msg "mutually exclusive")
 ;;
 
 let test_of_json_rejects_stages_alias () =
@@ -530,6 +533,25 @@ let test_pipeline_lowers_to_shell_ir_pipeline () =
       (List.map (fun (key, value) -> key, shell_arg_string value) second.env)
   | other ->
     Alcotest.failf "expected Shell_ir.Pipeline, got %a" Masc_exec.Shell_ir.pp other
+;;
+
+let test_exec_lowering_preserves_duplicate_executable_argv () =
+  let input =
+    Execute_input.Exec
+      { executable = "git"
+      ; argv = [ "git"; "status" ]
+      ; cwd = None
+      ; env = []
+      }
+  in
+  match to_shell_ir_exn input with
+  | Masc_exec.Shell_ir.Simple simple ->
+    Alcotest.(check (pair string (list string)))
+      "duplicate executable token is caller data"
+      ("git", [ "git"; "status" ])
+      (shell_simple_tuple simple)
+  | Masc_exec.Shell_ir.Pipeline _ ->
+    Alcotest.fail "single exec input must not create Shell_ir.Pipeline"
 ;;
 
 let docker_test_sandbox () =
@@ -658,14 +680,14 @@ let suite =
           test_not_allowlisted_hints_self_correction
       ; Alcotest.test_case "of_json_exec" `Quick test_of_json_exec
       ; Alcotest.test_case
-          "of_json_promotes_empty_exec_from_argv0"
+          "of_json_keeps_empty_exec_for_validation"
           `Quick
-          test_of_json_promotes_empty_exec_from_argv0
+          test_of_json_keeps_empty_exec_for_validation
       ; Alcotest.test_case "of_json_pipeline" `Quick test_of_json_pipeline
       ; Alcotest.test_case
-          "of_json_promotes_empty_pipeline_stage_from_argv0"
+          "of_json_keeps_empty_pipeline_stage_for_validation"
           `Quick
-          test_of_json_promotes_empty_pipeline_stage_from_argv0
+          test_of_json_keeps_empty_pipeline_stage_for_validation
       ; Alcotest.test_case
           "of_json_rejects_cmd_string_only"
           `Quick
@@ -679,9 +701,9 @@ let suite =
           `Quick
           test_of_json_rejects_non_string_argv
       ; Alcotest.test_case
-          "of_json_prefers_exec_when_both_present"
+          "of_json_rejects_exec_and_pipeline_together"
           `Quick
-          test_of_json_prefers_exec_when_both_present
+          test_of_json_rejects_exec_and_pipeline_together
       ; Alcotest.test_case
           "of_json_rejects_stages_alias"
           `Quick
@@ -690,6 +712,10 @@ let suite =
           "pipeline_lowers_to_shell_ir_pipeline"
           `Quick
           test_pipeline_lowers_to_shell_ir_pipeline
+      ; Alcotest.test_case
+          "exec_lowering_preserves_duplicate_executable_argv"
+          `Quick
+          test_exec_lowering_preserves_duplicate_executable_argv
       ; Alcotest.test_case
           "pipeline_lowers_with_injected_docker_sandbox"
           `Quick

--- a/test/test_agent_tool_execute_typed_input.ml
+++ b/test/test_agent_tool_execute_typed_input.ml
@@ -203,6 +203,20 @@ let test_wrapper_exec_target_allowlist () =
     ]
 ;;
 
+let test_wrapper_exec_target_rejects_whitespace_padded_executable () =
+  (* Regression: trimming applied to allowlist membership must also apply
+     when dispatching wrapper-target validation. Otherwise a padded
+     [executable=" env "] passes the allowlist (trimmed to "env") but
+     [check_wrapper_exec_target] sees the raw " env " and falls through
+     to [_ -> Ok ()], skipping the env-argv guard. *)
+  List.iter
+    (fun input -> expect_not_allowlisted ~target:"rm" input)
+    [ mk_exec " env " [ "rm"; "-rf"; "/" ]
+    ; mk_exec "env\t" [ "rm"; "-rf"; "/" ]
+    ; mk_exec " opam " [ "exec"; "--"; "rm"; "-rf"; "/" ]
+    ]
+;;
+
 let test_standalone_env_rejected () =
   match Execute_input.validate ~mode:Execute_input.Dev_full (mk_exec "env" []) with
   | Error (Execute_input.Empty_argv { executable = "env" }) -> ()
@@ -662,6 +676,10 @@ let suite =
           "wrapper_exec_target_allowlist"
           `Quick
           test_wrapper_exec_target_allowlist
+      ; Alcotest.test_case
+          "wrapper_exec_target_rejects_whitespace_padded_executable"
+          `Quick
+          test_wrapper_exec_target_rejects_whitespace_padded_executable
       ; Alcotest.test_case
           "standalone_env_rejected"
           `Quick

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -688,15 +688,18 @@ let test_validate_args_tool_execute_accepts_typed_pipeline () =
       "expected typed tool_execute pipeline to pass validation, got %s"
       (Yojson.Safe.to_string result.Tool_result.data)
 
-let tool_execute_exec_argv args =
+let tool_execute_exec_stage args =
   match Agent_tool_execute_typed_input.of_json args with
-  | Ok (Agent_tool_execute_typed_input.Exec { argv; _ }) -> argv
+  | Ok (Agent_tool_execute_typed_input.Exec { executable; argv; _ }) ->
+    executable, argv
   | Ok (Agent_tool_execute_typed_input.Pipeline _) ->
     Alcotest.fail "expected exec input"
   | Error msg ->
     Alcotest.failf "expected typed tool_execute parse to pass, got %s" msg
 
-let test_tool_execute_find_expression_gets_default_path () =
+let tool_execute_exec_argv args = snd (tool_execute_exec_stage args)
+
+let test_tool_execute_find_expression_not_rewritten () =
   let argv =
     tool_execute_exec_argv
       (`Assoc
@@ -705,11 +708,11 @@ let test_tool_execute_find_expression_gets_default_path () =
         ])
   in
   Alcotest.(check (list string))
-    "find expression gets explicit cwd path"
-    [ "."; "-type"; "f"; "-name"; "*.ml" ]
+    "find expression remains caller-authored"
+    [ "-type"; "f"; "-name"; "*.ml" ]
     argv
 
-let test_tool_execute_find_global_option_keeps_option_first () =
+let test_tool_execute_find_global_option_not_rewritten () =
   let argv =
     tool_execute_exec_argv
       (`Assoc
@@ -718,24 +721,25 @@ let test_tool_execute_find_global_option_keeps_option_first () =
         ])
   in
   Alcotest.(check (list string))
-    "find global option stays before default path"
-    [ "-E"; "."; "-type"; "f" ]
+    "find global option remains caller-authored"
+    [ "-E"; "-type"; "f" ]
     argv
 
-let test_tool_execute_promoted_find_expression_gets_default_path () =
-  let argv =
-    tool_execute_exec_argv
+let test_tool_execute_empty_executable_not_promoted () =
+  let executable, argv =
+    tool_execute_exec_stage
       (`Assoc
         [ "executable", `String ""
         ; "argv", `List [ `String "find"; `String "-type"; `String "f" ]
         ])
   in
+  Alcotest.(check string) "empty executable preserved" "" executable;
   Alcotest.(check (list string))
-    "promoted find expression gets explicit cwd path"
-    [ "."; "-type"; "f" ]
+    "argv0 command is not promoted"
+    [ "find"; "-type"; "f" ]
     argv
 
-let test_tool_execute_pipeline_find_expression_gets_default_path () =
+let test_tool_execute_pipeline_find_expression_not_rewritten () =
   match
     Agent_tool_execute_typed_input.of_json
       (`Assoc
@@ -753,8 +757,8 @@ let test_tool_execute_pipeline_find_expression_gets_default_path () =
       (Agent_tool_execute_typed_input.Pipeline
         { stages = { Agent_tool_execute_typed_input.argv = argv; _ } :: _; _ }) ->
     Alcotest.(check (list string))
-      "pipeline find stage gets default path"
-      [ "."; "-type"; "f" ]
+      "pipeline find stage remains caller-authored"
+      [ "-type"; "f" ]
       argv
   | Ok (Agent_tool_execute_typed_input.Pipeline { stages = []; _ }) ->
     Alcotest.fail "expected non-empty pipeline"
@@ -1118,10 +1122,10 @@ let test_registered_hook_required_enum_blank_is_not_stripped () =
 (* Test: oneOf with empty/null values (regression guard)             *)
 (* ================================================================ *)
 
-(** Regression guard: LLM may send both executable and pipeline.
-    Schema no longer advertises oneOf (PR #18110); handler precedence
-    picks executable. Empty pipeline:[] must not trigger any validation
-    error from the pre-hook shape check. *)
+(** Shape-validation boundary: an empty [pipeline = []] is treated as absent by
+    the lightweight oneOf pre-hook, so this layer forwards the payload. The
+    typed Execute parser still rejects any [executable] + [pipeline] field pair
+    before dispatch. *)
 let test_validate_args_tool_execute_exec_with_empty_pipeline () =
   let args =
     `Assoc
@@ -1541,14 +1545,14 @@ let () =
         test_validate_args_tool_execute_accepts_typed_exec;
       Alcotest.test_case "tool_execute accepts typed pipeline" `Quick
         test_validate_args_tool_execute_accepts_typed_pipeline;
-      Alcotest.test_case "tool_execute find expression default path" `Quick
-        test_tool_execute_find_expression_gets_default_path;
-      Alcotest.test_case "tool_execute find global option default path" `Quick
-        test_tool_execute_find_global_option_keeps_option_first;
-      Alcotest.test_case "tool_execute promoted find default path" `Quick
-        test_tool_execute_promoted_find_expression_gets_default_path;
-      Alcotest.test_case "tool_execute pipeline find default path" `Quick
-        test_tool_execute_pipeline_find_expression_gets_default_path;
+      Alcotest.test_case "tool_execute find expression not rewritten" `Quick
+        test_tool_execute_find_expression_not_rewritten;
+      Alcotest.test_case "tool_execute find global option not rewritten" `Quick
+        test_tool_execute_find_global_option_not_rewritten;
+      Alcotest.test_case "tool_execute empty executable not promoted" `Quick
+        test_tool_execute_empty_executable_not_promoted;
+      Alcotest.test_case "tool_execute pipeline find not rewritten" `Quick
+        test_tool_execute_pipeline_find_expression_not_rewritten;
       Alcotest.test_case "tool_execute rejects bad typed argv" `Quick
         test_validate_args_tool_execute_rejects_bad_argv_type;
       Alcotest.test_case "tool_execute exec + empty pipeline" `Quick


### PR DESCRIPTION
## Summary
- remove typed Execute parser normalization that promoted empty executable from argv[0]
- stop rewriting find expressions to inject a default path and reject executable+pipeline together
- preserve duplicate executable argv tokens through Shell IR/capability command extraction so malformed input fails visibly
- update the legacy purge HTML ledger with this slice

## Verification
- ocamlformat --check lib/keeper/keeper_tool_bash_input.ml lib/keeper/keeper_tool_bash_input.mli lib/keeper/keeper_tool_capability_axis.ml lib/tool_shard_types_schemas_bash.ml test/test_tool_input_validation.ml test/test_keeper_bash_typed_input.ml
- git diff --check origin/main..HEAD
- rg -n "normalize_stage|strip_leading_executable|Compatibility normalization|Portable find default path|promotes_empty|promoted find|find expression default path|if both are provided executable takes precedence|executable takes precedence when both|of_json_prefers_exec|argv0 command is promoted|promoted executable" lib/keeper lib/tool_shard_types_schemas_bash.ml test docs/audit/2026-05-25-legacy-purge-plan.html -S --glob "!_build/**"  # no matches
- scripts/ocaml-structure-ratchet.sh
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_bash_typed_input.exe test/test_tool_input_validation.exe
- _build/default/test/test_keeper_bash_typed_input.exe
- _build/default/test/test_tool_input_validation.exe