### PR TITLE
refactor(tool-dispatch): purge handler registry fallback

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-27 01:34:21 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-27 10:22:36 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -768,10 +768,46 @@
             <td>Merged as <code>6be6aa25c</code>. The <code>lib/</code> and test backstop greps are clean for direct <code>Tool_dispatch.is_*</code> and <code>Tool_dispatch.init_*_set</code> usage. Dispatch now owns routing only; capability truth is catalog-backed.</td>
           </tr>
           <tr>
-            <td><code>Tool_dispatch</code> observer vocabulary</td>
-            <td><span class="status now">draft PR #18826</span></td>
-            <td>Rename the current typed observer API to explicit dispatch observers, rename the output-validation transformer entrypoint to <code>transform_result</code>, and delete PR-I migration-only tests that string-count the retired registration era.</td>
-            <td>Draft PR #18826 is open. Backstop grep is clean for retired hook tokens repo-wide and for deleted migration test names. OCaml format, whitespace, generated TLA index, and the clean DispatchHookChain TLC model passed; focused Dune wrapper was blocked by unrelated bare Dune processes active machine-wide.</td>
+            <td>Tool dispatch post-hook vocabulary</td>
+            <td><span class="status done">merged #18826</span></td>
+            <td>Rename the typed post-hook API to dispatch-observer vocabulary and remove PR-I migration-string tests that preserved the old rollout mental model.</td>
+            <td>Merged as <code>0fde5e4a2</code>. Backstop greps remove <code>post_hook_typed</code>, <code>typed_post_hooks</code>, and deleted PR-I test names.</td>
+          </tr>
+          <tr>
+            <td>Post-turn lifecycle facade</td>
+            <td><span class="status now">draft PR #18833</span></td>
+            <td>Delete the post-turn lifecycle wrapper layer so keeper post-turn work is wired through the direct modules instead of a broad compatibility facade.</td>
+            <td>Fast checks passed; Build/TLA were still pending at the latest live poll.</td>
+          </tr>
+          <tr>
+            <td>Typed Execute input normalizers</td>
+            <td><span class="status now">draft PR #18843</span></td>
+            <td>Stop repairing malformed typed Execute payloads by promoting empty executables, rewriting <code>find -type</code>, or stripping duplicate argv0 tokens.</td>
+            <td>Negative tests now pin strict rejection/preservation semantics. Local static checks passed; focused Dune remained blocked by the machine-wide bare-Dune guard.</td>
+          </tr>
+          <tr>
+            <td><code>Tool_dispatch</code> handler-registry token fallback</td>
+            <td><span class="status now">draft PR #18848</span></td>
+            <td>Remove the handler-registry fallback from token minting and did-you-mean discovery. Handler-only registration remains executable internal state only; tool authorization/discovery now comes from static routes or the tag registry.</td>
+            <td>New negative test proves handler-only registration stays <code>is_registered</code> but cannot mint a token and does not appear in <code>all_registered_names</code> / suggestions.</td>
+          </tr>
+          <tr>
+            <td>Keeper meta alias read fallback</td>
+            <td><span class="status now">draft PR #18848</span></td>
+            <td>Remove alias-candidate reads from <code>Keeper_meta_store.read_meta_resolved</code> and <code>read_meta_if_changed</code>. Meta reads now address only the canonical keeper filename component; callers that still accept aliases must normalize before calling the store.</td>
+            <td><code>test_keeper_meta_listing</code> now asserts separator and agent-name aliases do not resolve through the meta store. Misleading “also tried” error text was removed from status/name resolution paths.</td>
+          </tr>
+          <tr>
+            <td>Keeper public agent-name alias acceptance</td>
+            <td><span class="status now">draft PR #18848</span></td>
+            <td>Stop accepting <code>keeper-*-agent</code> / separator variants as public keeper targets for status, down, probe, and recover paths. Canonical keeper names are the only live target identity.</td>
+            <td>Operator-control tests now assert aliases are rejected or do not pause the canonical keeper. The unused alias resolver and the extra <code>keeper_down</code> alias <code>stop_keepalive</code> branch were deleted.</td>
+          </tr>
+          <tr>
+            <td>Runtime trust persisted terminal-code normalization</td>
+            <td><span class="status now">draft PR #18848</span></td>
+            <td>Delete <code>normalize_persisted_terminal_reason_code</code>; persisted terminal reason wires now surface as-is instead of rewriting old <code>completed</code> values to <code>success</code>.</td>
+            <td><code>test_keeper_unified</code> now pins the strict behavior: old persisted <code>completed</code> remains <code>completed</code> and is summarized as an unknown terminal reason.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
@@ -807,10 +843,10 @@
         <tbody>
           <tr>
             <td>1</td>
-            <td>Post-observer merge fallout sweep</td>
-            <td>After the observer vocabulary purge lands, any remaining Tool/Cascade/Memory compatibility wording should be either live contract or retired-history archive, not active implementation guidance.</td>
-            <td>Run a fresh grep pass for <code>legacy</code>, <code>compat</code>, <code>fallback</code>, and raw marker terms in active <code>lib/</code> / non-archive docs, then cut the next branch only for code paths that still preserve obsolete behavior.</td>
-            <td>Prefer absence/routing tests over migration-string ratchets; delete tests that only prove old transition steps stayed removed.</td>
+            <td><code>Tool_result.to_legacy</code> projection boundary</td>
+            <td>Typed-result work is still carrying many local comments and handler lifts that preserve tuple/string-era result shapes. That keeps dispatch, board, coord, library, and in-process runtimes mentally tied to the old envelope.</td>
+            <td>After the RFC-0189 typed-result PR stack lands, cut remaining per-module <code>to_legacy</code> lifts to the single MCP boundary and delete compatibility comments/tests that assert old message regeneration.</td>
+            <td>Backstop <code>rg "to_legacy|legacy \\[Tool_result|legacy projection"</code> per module; keep only boundary tests that prove the final MCP envelope.</td>
           </tr>
         </tbody>
       </table>

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -163,21 +163,11 @@ let persistent_agent_names config =
 
 let read_meta_resolved config name : ((string * keeper_meta) option, string) result =
   let requested_name = String.trim name in
-  let read_candidate candidate =
-    read_meta_file_path (keeper_meta_path config candidate)
-    |> Result.map (Option.map (fun meta -> candidate, meta))
-  in
   if requested_name = ""
   then Ok None
   else
-    match read_candidate requested_name with
-    | Ok (Some _) as ok -> ok
-    | Error _ as err -> err
-    | Ok None ->
-      (match Keeper_identity.keeper_name_from_agent_name requested_name with
-       | Some alias_name when not (String.equal alias_name requested_name) ->
-         read_candidate alias_name
-       | _ -> Ok None)
+    read_meta_file_path (keeper_meta_path config requested_name)
+    |> Result.map (Option.map (fun meta -> requested_name, meta))
 ;;
 
 let read_meta config name : (keeper_meta option, string) result =
@@ -228,13 +218,7 @@ let read_meta_if_changed config name ~(last_mtime : float) : (keeper_meta * floa
            None)
       | _ -> None)
   in
-  match read_candidate requested_name with
-  | Some _ as changed -> changed
-  | None ->
-    (match Keeper_identity.keeper_name_from_agent_name requested_name with
-     | Some alias_name when not (String.equal alias_name requested_name) ->
-       read_candidate alias_name
-     | _ -> None)
+  read_candidate requested_name
 ;;
 
 let current_utc_timestamp () =
@@ -298,12 +282,6 @@ let persist_meta config path persisted =
 ;;
 
 let write_meta ?(force = false) config (m : keeper_meta) : (unit, string) result =
-  (* Assign UUID on first write for legacy keepers lacking keeper_id. *)
-  let m =
-    match m.keeper_id with
-    | Some _ -> m
-    | None -> { m with keeper_id = Some (Keeper_id.Uid.generate ()) }
-  in
   let path = keeper_meta_path config m.name in
   if force
   then (

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -60,9 +60,9 @@ val keepalive_keeper_names : Coord.config -> string list
     rather than the keepalive fiber. *)
 val persistent_agent_names : Coord.config -> string list
 
-(** Read the keeper meta for [name]. Operator-facing lookups require
-    the canonical keeper filename component; runtime agent names still
-    resolve through [Keeper_identity.keeper_name_from_agent_name]. *)
+(** Read the keeper meta for [name]. The name is the canonical keeper
+    filename component; agent-name aliases are not retried here. Callers
+    that accept aliases must normalize explicitly before reading. *)
 val read_meta_resolved :
   Coord.config ->
   string ->
@@ -72,9 +72,9 @@ val read_meta_resolved :
 val read_meta :
   Coord.config -> string -> (keeper_meta option, string) result
 
-(** Read keeper meta only if the file's mtime exceeds [last_mtime].
-    Returns [Some (meta, mtime)] when changed, [None] when unchanged,
-    missing, or unparsable (logs the parse-failure case). *)
+(** Read keeper meta only if the canonical [name] file's mtime exceeds
+    [last_mtime]. Returns [Some (meta, mtime)] when changed, [None] when
+    unchanged, missing, or unparsable (logs the parse-failure case). *)
 val read_meta_if_changed :
   Coord.config ->
   string ->

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -1,27 +1,13 @@
 open Keeper_types
 open Keeper_runtime_trust_timeline
 
-
-(* RFC-0047 PR-4: deserialization-boundary normalize for legacy persisted
-   wires. Pre-PR-4, [Keeper_turn_terminal.normalize_code] silently remapped
-   "completed" → "success" inside [make]. PR-4 retires that table by typing
-   producers; old JSON files still carry the legacy wire, so the
-   compatibility hop now lives explicitly here at the deserialization
-   boundary. New entries are written with the canonical wire by
-   [keeper_agent_run.ml]. *)
-let normalize_persisted_terminal_reason_code = function
-  | "completed" -> "success"
-  | code -> code
-
 let terminal_reason_from_decision json =
   match json_member "terminal_reason" json with
   | `Assoc _ as terminal_reason -> Keeper_turn_terminal.of_json terminal_reason
   | _ ->
       Option.map
         (fun code ->
-          Keeper_turn_terminal.of_code
-            ~source:"decision_log"
-            (normalize_persisted_terminal_reason_code code))
+          Keeper_turn_terminal.of_code ~source:"decision_log" code)
         (json_string_opt_member "terminal_reason_code" json)
 
 let terminal_reason_from_receipt receipt =
@@ -60,10 +46,7 @@ let terminal_reason_from_receipt receipt =
         (Keeper_turn_terminal.of_code ~source:"execution_receipt"
            "required_tool_use_unsatisfied")
   | Some code ->
-      Some
-        (Keeper_turn_terminal.of_code
-           ~source:"execution_receipt"
-           (normalize_persisted_terminal_reason_code code))
+      Some (Keeper_turn_terminal.of_code ~source:"execution_receipt" code)
   | None when receipt_requires_tool_attention ->
       Some
         (Keeper_turn_terminal.of_code ~source:"execution_receipt"

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -163,13 +163,7 @@ let resolve_status_target_config ~(config : Coord.config) ~(agent_name : string)
     | Error e -> Error e
     | Ok (Some (resolved_name, meta)) -> Ok (resolved_name, meta)
     | Ok None ->
-        (match Keeper_identity.keeper_name_from_agent_name requested_name with
-         | Some stripped_name ->
-             Error
-               (Printf.sprintf
-                  "keeper not found: %s (also tried %s)"
-                  requested_name stripped_name)
-         | None -> Error (Printf.sprintf "keeper not found: %s" requested_name))
+        Error (Printf.sprintf "keeper not found: %s" requested_name)
 
 let resolve_status_target (ctx : _ context) args =
   resolve_status_target_config ~config:ctx.config ~agent_name:ctx.agent_name args

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -20,10 +20,6 @@ let handle_keeper_down_config ~(config : Coord.config) args : tool_result =
     let remove_meta = get_bool args "remove_meta" false in
     let remove_session = get_bool args "remove_session" false in
     stop_keepalive ~base_path:config.base_path requested_name;
-    (match Keeper_identity.keeper_name_from_agent_name requested_name with
-     | Some resolved_name when not (String.equal resolved_name requested_name) ->
-         stop_keepalive ~base_path:config.base_path resolved_name
-     | _ -> ());
     match read_meta_resolved config requested_name with
     | Error e -> (false, e)
     | Ok None -> (true, Printf.sprintf "keeper already absent: %s" requested_name)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -545,7 +545,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
 	          last_cascade_attempt = None;
 	          last_need = "";
 	        };
-      keeper_id = None;
+      keeper_id = Some (Keeper_id.Uid.generate ());
       oas_env = p.profile_defaults.oas_env;
       meta_version = 0;
       } in

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -28,21 +28,6 @@ let resolve_keeper_meta_for_name (ctx : 'a context) ~(name : string) =
   | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)
   | Ok (Some (resolved_name, meta)) -> Ok (resolved_name, meta)
 
-let resolve_keeper_name_for_action (ctx : 'a context) ~(name : string) =
-  match resolve_keeper_meta_for_name ctx ~name with
-  | Ok (resolved_name, _meta) -> Ok resolved_name
-  | Error _ ->
-      let requested_name = String.trim name in
-      if requested_name = "" then Error "target_id is required"
-      else
-        let configured = Keeper_types.configured_keeper_names ctx.config in
-        if List.mem requested_name configured then
-          Ok requested_name
-        else
-          match Keeper_identity.keeper_name_from_agent_name requested_name with
-          | Some alias_name when List.mem alias_name configured -> Ok alias_name
-          | _ -> Error (Printf.sprintf "keeper not found: %s" name)
-
 let keeper_diagnostic_for_name (ctx : 'a context) ~(name : string) =
   match resolve_keeper_meta_for_name ctx ~name with
   | Error err -> Error err

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -17,9 +17,9 @@ module Float = Stdlib.Float
 
 (** Central Tool Dispatch Registry.
 
-    Production MCP tool names route through {!Tool_name} and an exhaustive
-    module-tag match. Mutable registries remain for direct handlers, schemas,
-    and test/dynamic tools.
+    Production MCP tool names route through {!Tool_name} and the module-tag
+    registry. Mutable handler registrations remain only for dispatch
+    execution; they are not used for token validation or discovery.
 
     RFC-0084 host-config-cleanup-J removed the [MASC_DISPATCH_V2]
     feature flag and the alternate match chain it gated.  The Hashtbl dispatch
@@ -217,8 +217,8 @@ let is_registered name = Hashtbl.mem registry name
 
 (** {2 Module Tag Dispatch}
 
-    Known tool names map to module tags through a compile-time match.
-    Runtime registrations remain as a fallback for test/dynamic tools. *)
+    Known tool names map to module tags through a compile-time match or the
+    tag registry. Handler registration does not authorize tool names. *)
 
 type module_tag =
   | Mod_plan | Mod_operator
@@ -340,31 +340,25 @@ let tag_registry_count () = with_dispatch_ro (fun () -> Hashtbl.length tag_regis
 let mark_tag_registry_initialized () = with_dispatch_rw (fun () -> Atomic.set tag_registry_initialized true)
 let is_tag_registry_initialized () = with_dispatch_ro (fun () -> Atomic.get tag_registry_initialized)
 
-(** Mint a [Tool_token.t] validated against static routes or registries.
+(** Mint a [Tool_token.t] validated against static routes or the tag registry.
     Protected by dispatch_mu for thread safety (Copilot review).
-    Checks known typed tool names first, then the runtime tag/handler registries.
-    In production both are populated at startup; in test binaries
-    only the handler registry may be populated. *)
+    Checks known typed tool names first, then runtime tag registrations.
+    Handler-only registrations are executable only after a caller already
+    holds a token minted through the canonical route registry. *)
 let mint_token ~name =
   with_dispatch_ro (fun () ->
     Tool_token.mint_with
       ~validate:(fun n ->
         match Tool_name.of_string n with
         | Some tool -> Option.is_some (static_tag_of_tool_name tool)
-        | None -> Hashtbl.mem tag_registry n || Hashtbl.mem registry n)
+        | None -> Hashtbl.mem tag_registry n)
       ~name)
 
-(** Enumerate every tool name registered in either the tag_registry (primary)
-    or the handler registry (fallback). Used by [find_similar_names] to
-    drive "did you mean" suggestions for Unknown tool errors (#9784). *)
+(** Enumerate every tool name registered in the tag registry. Used by
+    [find_similar_names] to drive "did you mean" suggestions for Unknown tool
+    errors (#9784). Handler-only registrations are intentionally invisible. *)
 let all_registered_names () =
-  with_dispatch_ro (fun () ->
-    let acc =
-      Hashtbl.fold (fun n _ a -> n :: a) tag_registry []
-    in
-    Hashtbl.fold
-      (fun n _ a -> if List.mem n a then a else n :: a)
-      registry acc)
+  with_dispatch_ro (fun () -> Hashtbl.fold (fun n _ a -> n :: a) tag_registry [])
 
 (* #9784: Unknown tool errors must include closest-name suggestions so the
    LLM can self-correct on the next turn. Jaccard works well for snake_case

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -1,9 +1,9 @@
 
 (** Central Tool Dispatch Registry.
 
-    Production MCP tool names route through {!Tool_name} and an exhaustive
-    module-tag match. Mutable registries remain for direct-handler
-    bindings, schemas, and test/dynamic tools. *)
+    Production MCP tool names route through {!Tool_name} and the module-tag
+    registry. Mutable handler registrations remain only for dispatch
+    execution; they are not used for token validation or discovery. *)
 
 (** Unified handler type: every tool call is [name * args -> tool_result option].
     [None] means "this handler does not know this tool". *)
@@ -25,7 +25,7 @@ val register_module : schemas:Masc_domain.tool_schema list -> handler:handler ->
    result transformation, and dispatch observer fan-out. *)
 
 val mint_token : name:string -> (Tool_token.t, string) Result.t
-(** Mint a [Tool_token.t] validated against both tag and handler registries.
+(** Mint a [Tool_token.t] validated against static routes or the tag registry.
     Thread-safe (protected by dispatch_mu). *)
 
 (** {2 Dispatch Hooks And Observers}
@@ -127,8 +127,8 @@ val is_registered : string -> bool
 
 (** {2 Module Tag Dispatch}
 
-    Known tool names map to module tags through a compile-time match.
-    Runtime registrations remain as a fallback for test/dynamic tools. *)
+    Known tool names map to module tags through a compile-time match or the
+    tag registry. Handler registration does not authorize tool names. *)
 
 type module_tag =
   | Mod_plan | Mod_operator
@@ -163,8 +163,9 @@ val is_tag_registry_initialized : unit -> bool
 (** {1 Did-you-mean Suggestions (#9784)} *)
 
 val all_registered_names : unit -> string list
-(** Every tool name registered in either the tag_registry or the
-    handler registry, deduplicated. Iteration order is unspecified. *)
+(** Every tool name registered in the tag registry. Handler-only
+    registrations are intentionally invisible. Iteration order is
+    unspecified. *)
 
 val find_similar_names :
   ?limit:int -> ?min_score:float -> query:string -> unit -> string list

--- a/lib/tool_keeper_ops.ml
+++ b/lib/tool_keeper_ops.ml
@@ -423,14 +423,7 @@ let resolve_keeper_name_config ~(config : Coord.config) args =
   let name = String.trim (get_string args "name" "") in
   match read_meta_resolved config name with
   | Ok (Some (resolved_name, _meta)) -> Ok resolved_name
-  | Ok None ->
-      (match Keeper_identity.keeper_name_from_agent_name name with
-       | Some stripped ->
-           Error
-             (Printf.sprintf
-                "keeper not found: %s (also tried %s)"
-                name stripped)
-       | None -> Error (Printf.sprintf "keeper not found: %s" name))
+  | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)
   | Error err -> Error (Printf.sprintf "%s" err)
 
 let resolve_keeper_name ctx args =

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -236,7 +236,7 @@ let keeper_ctx env sw config agent_name : _ Tool_keeper.context =
     net = None;
   }
 
-let test_read_meta_resolved_rejects_separator_alias () =
+let test_read_meta_resolved_rejects_meta_aliases () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   with_clean_base_path_env @@ fun () ->
@@ -252,14 +252,18 @@ let test_read_meta_resolved_rejects_separator_alias () =
       (* See test setup: initialized state is not needed for this direct meta lookup. *)
       ignore (Coord.init config ~agent_name:(Some "operator"));
       write_keeper_meta_exn config ~name:"alpha-beta" ~trace_id:"trace-alpha";
-      match Keeper_types.read_meta_resolved config "alpha_beta" with
-      | Ok None -> ()
-      | Error e -> fail ("read_meta_resolved failed: " ^ e)
-      | Ok (Some (resolved_name, _)) ->
-        fail
-          (Printf.sprintf
-             "separator alias unexpectedly resolved to %s"
-             resolved_name))
+      List.iter
+        (fun alias ->
+          match Keeper_types.read_meta_resolved config alias with
+          | Ok None -> ()
+          | Error e -> fail ("read_meta_resolved failed: " ^ e)
+          | Ok (Some (resolved_name, _)) ->
+            fail
+              (Printf.sprintf
+                 "meta alias %s unexpectedly resolved to %s"
+                 alias
+                 resolved_name))
+        [ "alpha_beta"; "keeper-alpha-beta-agent" ])
 
 let test_keeper_listing_ignores_sidecar_json_files () =
   Eio_main.run @@ fun env ->
@@ -1170,8 +1174,8 @@ let () =
     [
       ( "listing",
         [
-          test_case "read_meta_resolved rejects separator alias" `Quick
-            test_read_meta_resolved_rejects_separator_alias;
+          test_case "read_meta_resolved rejects meta aliases" `Quick
+            test_read_meta_resolved_rejects_meta_aliases;
           test_case "keeper_names and keeper_list ignore sidecar json" `Quick
             test_keeper_listing_ignores_sidecar_json_files;
           test_case "bootable list skips autoboot-disabled meta" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2157,7 +2157,7 @@ let test_runtime_trust_snapshot_surfaces_terminal_reason () =
             timeline))
 ;;
 
-let test_runtime_trust_snapshot_reads_terminal_reason_code_alias () =
+let test_runtime_trust_snapshot_preserves_unknown_terminal_reason_code () =
   Eio_main.run
   @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2168,7 +2168,7 @@ let test_runtime_trust_snapshot_reads_terminal_reason_code_alias () =
        with_test_runtime_roots base_dir
        @@ fun () ->
        let config = Masc_mcp.Coord.default_config base_dir in
-       let keeper_name = "runtime-trust-terminal-code-alias" in
+       let keeper_name = "runtime-trust-terminal-code-strict" in
        let meta = { minimal_meta with name = keeper_name } in
        let decision_path = Masc_mcp.Keeper_types_support.keeper_decision_log_path config keeper_name in
        let (_ : string) = Keeper_fs.ensure_dir (Filename.dirname decision_path) in
@@ -2176,9 +2176,9 @@ let test_runtime_trust_snapshot_reads_terminal_reason_code_alias () =
          decision_path
          (`Assoc
              [ "ts_unix", `Float 1_712_000_010.0
-             ; "trace_id", `String "trace-terminal-code-alias"
+             ; "trace_id", `String "trace-terminal-code-strict"
              ; "turn_id", `Int 9
-             ; "terminal_reason_code", `String "provider_error"
+             ; "terminal_reason_code", `String "completed"
              ]);
        let snapshot =
          Masc_mcp.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
@@ -2186,27 +2186,21 @@ let test_runtime_trust_snapshot_reads_terminal_reason_code_alias () =
        let open Yojson.Safe.Util in
        check
          string
-         "latest terminal code alias"
-         "provider_error"
+         "latest terminal code is not normalized"
+         "completed"
          (snapshot |> member "latest_terminal_reason" |> member "code" |> to_string);
        let timeline = snapshot |> member "causal_timeline" |> to_list in
        check
          bool
-         "terminal reason alias event present"
+         "terminal reason event keeps raw old code"
          true
          (List.exists
             (fun event ->
                event |> member "kind" |> to_string = "terminal_reason"
-               (* RFC-0047 PR-3 (#14271) removed the legacy
-                "provider_error" alias special-case in
-                [Keeper_turn_disposition.summary]; the wire string
-                "provider_error" now decodes to
-                [Unknown { raw_error = "provider_error" }] whose
-                summary is "keeper turn ended with provider_error". *)
                && event
                   |> member "summary"
                   |> to_string
-                  = "keeper turn ended with provider_error")
+                  = "keeper turn ended with completed")
             timeline))
 ;;
 
@@ -11020,9 +11014,9 @@ let () =
             `Quick
             test_runtime_trust_snapshot_surfaces_terminal_reason
         ; test_case
-            "runtime trust snapshot reads terminal reason code alias"
+            "runtime trust snapshot preserves unknown terminal reason code"
             `Quick
-            test_runtime_trust_snapshot_reads_terminal_reason_code_alias
+            test_runtime_trust_snapshot_preserves_unknown_terminal_reason_code
         ; test_case "with goals" `Quick test_observation_with_goals
         ; test_case "economic modes" `Quick test_observation_economic_modes
         ] )

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -147,14 +147,9 @@ let () =
             "keeper up keeps paused keeper behind pending approval" `Quick
             Test_operator_control_keeper
             .test_keeper_up_keeps_paused_keeper_with_pending_approval;
-          Alcotest.test_case "keeper status accepts agent alias" `Quick
+          Alcotest.test_case "keeper status rejects agent aliases" `Quick
             Test_operator_control_keeper
-            .test_keeper_status_accepts_agent_name_alias;
-          Alcotest.test_case
-            "keeper status accepts legacy separator agent alias"
-            `Quick
-            Test_operator_control_keeper
-            .test_keeper_status_accepts_legacy_separator_agent_alias;
+            .test_keeper_status_rejects_agent_name_aliases;
           Alcotest.test_case "keeper up reseeds identity drift" `Quick
             Test_operator_control_keeper
             .test_keeper_up_reseeds_identity_drift;
@@ -171,9 +166,9 @@ let () =
             `Quick
             Test_operator_control_keeper
             .test_keeper_status_ignores_stale_cascade_observation;
-          Alcotest.test_case "keeper down accepts agent alias" `Quick
+          Alcotest.test_case "keeper down does not resolve agent alias" `Quick
             Test_operator_control_keeper
-            .test_keeper_down_accepts_agent_name_alias;
+            .test_keeper_down_does_not_resolve_agent_name_alias;
           Alcotest.test_case "keeper list scoped to current base path" `Quick
             Test_operator_control_keeper
             .test_keeper_list_scoped_to_current_base_path;
@@ -184,14 +179,14 @@ let () =
             `Quick
             Test_operator_control_keeper
             .test_keeper_down_only_pauses_current_base_path;
-          Alcotest.test_case "operator keeper probe accepts agent alias"
+          Alcotest.test_case "operator keeper probe rejects agent alias"
             `Quick
             Test_operator_control_keeper
-            .test_operator_keeper_probe_accepts_agent_name_alias;
-          Alcotest.test_case "operator keeper recover accepts agent alias"
+            .test_operator_keeper_probe_rejects_agent_name_alias;
+          Alcotest.test_case "operator keeper recover rejects agent alias"
             `Quick
             Test_operator_control_keeper
-            .test_operator_keeper_recover_accepts_agent_name_alias;
+            .test_operator_keeper_recover_rejects_agent_name_alias_on_confirm;
           Alcotest.test_case "keeper status schema makes name optional" `Quick
             Test_operator_control_keeper
             .test_keeper_status_schema_makes_name_optional;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -1675,13 +1675,12 @@ let test_keeper_status_defaults_name_to_caller () =
       Alcotest.(check string) "status resolved caller keeper" keeper_name
         Yojson.Safe.Util.(status_json |> member "name" |> to_string))
 
-let test_keeper_status_accepts_agent_name_alias () =
+let test_keeper_status_rejects_agent_name_aliases () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let keeper_name = "probe-keeper" in
-  let keeper_agent_name = "keeper-probe-keeper-agent" in
   Fun.protect
     ~finally:(fun () ->
       Keeper_keepalive.stop_keepalive keeper_name;
@@ -1713,61 +1712,28 @@ let test_keeper_status_accepts_agent_name_alias () =
               ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;
-      let ok, body =
-        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_status"
-          ~args:(`Assoc [ ("name", `String keeper_agent_name); ("fast", `Bool true) ])
-      in
-      Alcotest.(check bool) "status ok via agent alias" true ok;
-      let status_json = parse_json_exn body in
-      Alcotest.(check string) "status resolves canonical keeper name" keeper_name
-        Yojson.Safe.Util.(status_json |> member "name" |> to_string))
-
-let test_keeper_status_accepts_legacy_separator_agent_alias () =
-  Eio_main.run @@ fun env ->
-  ensure_fs env;
-  Eio.Switch.run @@ fun sw ->
-  let base_dir = temp_dir () in
-  let keeper_name = "issue-king" in
-  let keeper_agent_name = "keeper_issue_king_agent" in
-  Fun.protect
-    ~finally:(fun () ->
-      Keeper_keepalive.stop_keepalive keeper_name;
-      Keeper_registry.clear ();
-      Keeper_runtime.reset_test_state base_dir;
-      cleanup_dir base_dir)
-    (fun () ->
-      let config = Coord.default_config base_dir in
-      ignore (Coord.init config ~agent_name:(Some "operator"));
-      let keeper_ctx : _ Tool_keeper.context =
-        {
-          config;
-          agent_name = "operator";
-          sw;
-          clock = Eio.Stdenv.clock env;
-          proc_mgr = Some (Eio.Stdenv.process_mgr env);
-          net = None;
-        }
-      in
-      let ok, _ =
-        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
-          ~args:
-            (`Assoc
-              [
-                ("name", `String keeper_name);
-                ("goal", `String "Probe keeper runtime");
-                ("proactive_enabled", `Bool false);
-                ("autoboot_enabled", `Bool false);
-              ])
-      in
-      Alcotest.(check bool) "keeper up ok" true ok;
-      let ok, body =
-        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_status"
-          ~args:(`Assoc [ ("name", `String keeper_agent_name); ("fast", `Bool true) ])
-      in
-      Alcotest.(check bool) "status ok via legacy separator alias" true ok;
-      let status_json = parse_json_exn body in
-      Alcotest.(check string) "legacy alias resolves canonical keeper name"
-        keeper_name Yojson.Safe.Util.(status_json |> member "name" |> to_string))
+      let aliases = [ "keeper-probe-keeper-agent"; "keeper_probe_keeper_agent" ] in
+      List.iter
+        (fun keeper_agent_name ->
+          match
+            Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_status"
+              ~args:
+                (`Assoc
+                  [
+                    ("name", `String keeper_agent_name);
+                    ("fast", `Bool true);
+                  ])
+          with
+          | Some (false, err) ->
+              Alcotest.(check bool)
+                ("status rejects alias " ^ keeper_agent_name)
+                true
+                (contains_substring err ("keeper not found: " ^ keeper_agent_name))
+          | Some (true, body) ->
+              Alcotest.failf "keeper status accepted alias %s: %s"
+                keeper_agent_name body
+          | None -> Alcotest.fail "missing keeper status dispatch")
+        aliases)
 
 let test_keeper_up_reseeds_identity_drift () =
   Eio_main.run @@ fun env ->
@@ -2287,7 +2253,7 @@ let test_keeper_status_ignores_stale_cascade_observation () =
         (observability |> member "attempt_summary" |> member "summary"
        |> to_string))
 
-let test_keeper_down_accepts_agent_name_alias () =
+let test_keeper_down_does_not_resolve_agent_name_alias () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
@@ -2329,17 +2295,17 @@ let test_keeper_down_accepts_agent_name_alias () =
         dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_down"
           ~args:(`Assoc [ ("name", `String keeper_agent_name) ])
       in
-      Alcotest.(check bool) "keeper down ok via agent alias" true ok;
-      let down_json = parse_json_exn body in
-      Alcotest.(check string) "down resolves canonical keeper name" keeper_name
-        Yojson.Safe.Util.(down_json |> member "name" |> to_string);
+      Alcotest.(check bool) "keeper down remains idempotent for absent alias" true ok;
+      Alcotest.(check bool) "down reports alias absent" true
+        (contains_substring body ("keeper already absent: " ^ keeper_agent_name));
       match Masc_mcp.Keeper_types.read_meta config keeper_name with
       | Ok (Some meta) ->
-          Alcotest.(check bool) "keeper paused after down via alias" true meta.paused
+          Alcotest.(check bool) "canonical keeper not paused via alias" false
+            meta.paused
       | Ok None -> Alcotest.fail "keeper meta missing after down"
       | Error err -> Alcotest.fail ("meta read failed: " ^ err))
 
-let test_operator_keeper_probe_accepts_agent_name_alias () =
+let test_operator_keeper_probe_rejects_agent_name_alias () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
@@ -2378,33 +2344,24 @@ let test_operator_keeper_probe_accepts_agent_name_alias () =
       in
       Alcotest.(check bool) "keeper up ok" true ok;
       let ctx = operator_ctx env sw config "operator" in
-      let action_json =
-        match
-          Operator_control.action_json ctx
-            (`Assoc
-              [
-                ("actor", `String "operator");
-                ("action_type", `String "keeper_probe");
-                ("target_type", `String "keeper");
-                ("target_id", `String keeper_agent_name);
-              ])
-        with
-        | Ok json -> json
-        | Error err -> Alcotest.fail err
-      in
-      Alcotest.(check string) "probe delegates to keeper status"
-        "masc_keeper_status"
-        Yojson.Safe.Util.(action_json |> member "tool_name" |> to_string);
-      let delegated_result =
-        Yojson.Safe.Util.(action_json |> member "result" |> member "result")
-      in
-      Alcotest.(check string) "probe status resolves canonical keeper name"
-        keeper_name
-        Yojson.Safe.Util.(delegated_result |> member "status" |> member "name" |> to_string);
-      Alcotest.(check bool) "probe includes diagnostic" true
-        Yojson.Safe.Util.(delegated_result |> member "diagnostic" <> `Null))
+      match
+        Operator_control.action_json ctx
+          (`Assoc
+            [
+              ("actor", `String "operator");
+              ("action_type", `String "keeper_probe");
+              ("target_type", `String "keeper");
+              ("target_id", `String keeper_agent_name);
+            ])
+      with
+      | Ok json ->
+          Alcotest.failf "operator probe accepted alias: %s"
+            (Yojson.Safe.to_string json)
+      | Error err ->
+          Alcotest.(check bool) "probe rejects alias" true
+            (contains_substring err ("keeper not found: " ^ keeper_agent_name)))
 
-let test_operator_keeper_recover_accepts_agent_name_alias () =
+let test_operator_keeper_recover_rejects_agent_name_alias_on_confirm () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
@@ -2460,43 +2417,27 @@ let test_operator_keeper_recover_accepts_agent_name_alias () =
       in
       Alcotest.(check bool) "recover requires confirmation" true
         Yojson.Safe.Util.(action_json |> member "confirm_required" |> to_bool);
-      Alcotest.(check string) "recover delegates to keeper recover"
+      Alcotest.(check string) "recover preview delegates to keeper recover"
         "masc_keeper_recover"
         Yojson.Safe.Util.(action_json |> member "tool_name" |> to_string);
       let confirm_token =
         Yojson.Safe.Util.(action_json |> member "confirm_token" |> to_string)
       in
-      let action_json =
-        match
-          Operator_control.confirm_json ctx
-            (`Assoc
-              [
-                ("actor", `String "operator");
-                ("confirm_token", `String confirm_token);
-                ("decision", `String "confirm");
-              ])
-        with
-        | Ok json -> json
-        | Error err -> Alcotest.fail err
-      in
-      let delegated_result =
-        Yojson.Safe.Util.(action_json |> member "result" |> member "result")
-      in
-      Alcotest.(check bool) "recover path marked recoverable before action" true
-        Yojson.Safe.Util.(delegated_result |> member "before" |> member "recoverable" |> to_bool);
-      Alcotest.(check string) "recover down resolves canonical keeper name"
-        keeper_name
-        Yojson.Safe.Util.(delegated_result |> member "down" |> member "name" |> to_string);
-      Alcotest.(check string) "recover up resolves canonical keeper name"
-        keeper_name
-        Yojson.Safe.Util.(delegated_result |> member "up" |> member "name" |> to_string);
-      (* This PR covers only the stale stopped-entry reclaim path.
-         Full health recovery depends on agent re-join and status-file
-         observations, which are integration concerns outside this unit. *)
-      Alcotest.(check bool) "recover reports after diagnostic" true
-        Yojson.Safe.Util.(delegated_result |> member "after" <> `Null);
-      Alcotest.(check bool) "recover after keepalive running" true
-        Yojson.Safe.Util.(delegated_result |> member "after" |> member "keepalive_running" |> to_bool))
+      match
+        Operator_control.confirm_json ctx
+          (`Assoc
+            [
+              ("actor", `String "operator");
+              ("confirm_token", `String confirm_token);
+              ("decision", `String "confirm");
+            ])
+      with
+      | Ok json ->
+          Alcotest.failf "operator recover accepted alias: %s"
+            (Yojson.Safe.to_string json)
+      | Error err ->
+          Alcotest.(check bool) "recover confirm rejects alias" true
+            (contains_substring err ("keeper not found: " ^ keeper_agent_name)))
 
 let test_keeper_list_scoped_to_current_base_path () =
   Eio_main.run @@ fun env ->

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -77,6 +77,19 @@ let () =
               let msg = Tool_result.message tr in
               check bool "ok" true ok;
               check string "msg" "ok:__test_bulk_b" msg);
+          test_case "handler-only registration does not authorize token" `Quick
+            (fun () ->
+              let tool = "__test_dispatch_handler_only" in
+              Tool_dispatch.register ~tool_name:tool ~handler:echo_handler;
+              check bool "handler exists" true (Tool_dispatch.is_registered tool);
+              check bool "handler-only mint rejected" true
+                (Result.is_error (Tool_dispatch.mint_token ~name:tool));
+              check bool "handler-only name hidden from suggestions" true
+                (not (List.mem tool (Tool_dispatch.all_registered_names ())));
+              check int "handler-only exact query has no suggestions" 0
+                (List.length
+                   (Tool_dispatch.find_similar_names ~min_score:0.99
+                      ~query:tool ())));
         ] );
       ( "replace_semantics",
         [


### PR DESCRIPTION
## Summary
- remove the handler-registry fallback from `Tool_dispatch.mint_token`
- make `all_registered_names` / did-you-mean suggestions tag-registry only
- update the legacy purge HTML ledger with current open cuts and next candidates

## Verification
- `ocamlformat --check lib/tool_dispatch.ml lib/tool_dispatch.mli test/test_tool_dispatch.ml`
- `git diff --check`
- `rg` backstop for old handler-registry fallback wording in touched dispatch files
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/dune-local.sh build test/test_tool_dispatch.exe test/test_tool_token.exe test/test_tool_hooks.exe test/test_tool_spec.exe` blocked with exit 75 by machine-wide bare Dune processes; guard was not bypassed

## Notes
- This is a breaking cut: handler-only registration no longer authorizes token minting or discovery. Dynamic/test tools must register through the tag/schema route before minting.