### PR TITLE
fix(log): propagate agent_name through log_task_transition_failed — close keeper_name observability gap

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -230,7 +230,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   | None ->
   match client_side_transition_gate_error ~task_opt ~action ~action_s with
   | Some err ->
-    log_task_transition_failed (Masc_domain.Task err);
+    log_task_transition_failed ~agent_name:ctx.agent_name (Masc_domain.Task err);
     result_to_response ~tool_name ~start_time (Error (Masc_domain.Task err))
   | None ->
   match handoff_context with
@@ -258,7 +258,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   in
   match completion_state_error with
   | Some err ->
-    log_task_transition_failed err;
+    log_task_transition_failed ~agent_name:ctx.agent_name err;
     result_to_response ~tool_name ~start_time (Error err)
   | None ->
   let completion_owned_by_caller =
@@ -604,7 +604,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
                  ~task_id ())
         | Masc_domain.Claim | Masc_domain.Start | Masc_domain.Done_action | Masc_domain.Cancel | Masc_domain.Release -> ())
    | Error err ->
-       log_task_transition_failed err);
+       log_task_transition_failed ~agent_name:ctx.agent_name err);
   (* Record metrics *)
   (match result, action with
    | Ok _, Masc_domain.Done_action ->

--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -46,12 +46,12 @@ let result_to_response ~tool_name ~start_time = function
         ~tool_name ~start_time
         (Masc_domain.masc_error_to_string e)
 
-let log_task_transition_failed err =
+let log_task_transition_failed ~agent_name err =
   let message = Masc_domain.masc_error_to_string err in
   match err with
   | Masc_domain.Task (Masc_domain.Task_error.InvalidState _) ->
-      Log.Task.warn "task transition failed: %s" message
-  | _ -> Log.Task.error "task transition failed: %s" message
+      Log.Task.warn ~keeper_name:agent_name "task transition failed: %s" message
+  | _ -> Log.Task.error ~keeper_name:agent_name "task transition failed: %s" message
 
 (** Client-side FSM gate: reject impossible transitions before server dispatch.
     Uses [Coord_task_classify.valid_next_actions_for_status] as SSOT. *)


### PR DESCRIPTION
## Summary

Surgical 6-insert / 6-delete fix. \`Log.Task.warn\`/\`error\` accept \`?keeper_name\` but \`log_task_transition_failed\` was calling them without binding it. Every \`task transition failed: ...\` WARN/ERROR in the JSONL log lost its caller identity.

## Observability gap evidence

Local \`~/me/.masc/logs/system_log_2026-05-{24,25,26}.jsonl\` grep for the audit memo target message (\"submit_for_verification requires verification evidence\"):

| Date | events | keeper_name distribution |
|--|--:|--|
| 2026-05-24 | 3 | 3 × \`null\` |
| 2026-05-25 | 69 | 69 × \`null\` |
| 2026-05-26 | 43 | 43 × \`"system"\` |

5/26 jump from \`null\` to literal \`"system"\` is an unrelated change that hard-coded a fallback string — still not the real caller, just a different flavour of unknown. Cross-reference: \`memory/project_masc_system_log_24h_audit_2026_05_27.md\` records \`keeper_name: null 94%\` for the broader transition-fail cluster.

## Root cause

\`lib/tool_task_handlers.ml:38-43\` (before):
\`\`\`ocaml
let log_task_transition_failed err =
  let message = Masc_domain.masc_error_to_string err in
  match err with
  | Masc_domain.Task (Masc_domain.Task_error.InvalidState _) ->
      Log.Task.warn "task transition failed: %s" message
  | _ -> Log.Task.error "task transition failed: %s" message
\`\`\`

Three call sites in \`lib/tool_task.ml:233/261/607\` all have \`ctx.agent_name\` in scope. The helper just doesn't forward it.

## Fix

Add \`~agent_name\` parameter; thread to \`~keeper_name\` on the underlying log calls. All 3 callers updated to pass \`ctx.agent_name\`.

## Why standalone (not bundled with #18822)

Per CLAUDE.md "Surgical Changes". #18822 already retires the substring gate that *raises* the InvalidState here; this PR fixes *attribution* of the WARN/ERROR log lines so future audits can identify which keeper hit the gate. Different concerns, different review surfaces.

## Post-merge expected

\`keeper_name\` field reflects the actual agent (sangsu, albini, keeper-analyst-agent, etc.) instead of \`null\` or \`"system"\`. 24h audit dashboards regain per-keeper attribution for stuck-turn events.

## Test plan

- [ ] Build green
- [ ] After merge, tail \`~/.masc/logs/system_log_*.jsonl\` after triggering a transition failure (e.g. unauthenticated claim attempt) and confirm \`keeper_name\` is non-null/non-\`"system"\`

Related: #18810 (root-cause double-gate), #18822 (Phase E closeout), #18840 (Cdal_evidence_gate internal anti-patterns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)