### PR TITLE
feat(mcp_server_eio_execute): tag explicit failure_class on internal keeper meta lookup error (RFC-0189 small-step)

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -639,7 +639,17 @@ let execute_tool_eio
               | Some blocked, _ -> Some blocked
               | None, coerced_args ->
                 (match internal_keeper_meta_of_agent () with
-                 | Error msg -> Some (Tool_result.error ~tool_name:name ~start_time msg)
+                 | Error msg ->
+                   (* RFC-0189: agent_name has no matching registered
+                      keeper (or base_path mismatch).  Caller can
+                      address by registering the keeper / fixing the
+                      agent invocation context.  Same semantic family
+                      as tool_task_handlers' "Agent '%s' is not a
+                      member of this room" — [Workflow_rejection]. *)
+                   Some
+                     (Tool_result.error
+                        ~failure_class:(Some Tool_result.Workflow_rejection)
+                        ~tool_name:name ~start_time msg)
                  | Ok meta ->
                    let ctx_work =
                      Keeper_exec_context.create


### PR DESCRIPTION
## Summary

Single-site micro-tag: `internal_keeper_meta_of_agent ()` returns `Error msg` when the dispatched `agent_name` has no matching registered keeper, or when the registered keeper's `base_path` differs from the current `config.base_path`.

Both error cases are caller-actionable: the operator can re-register the keeper, fix the agent invocation context, or realign the base_path. Same semantic family as `tool_task_handlers` `"Agent '%s' is not a member of this room"` (tagged `Workflow_rejection` in #18820). **→ `Workflow_rejection`**.

## Out of scope (selective tagging, mirrors #18831 / #18835)

The other 4 `Tool_result.error` sites in this file (lines 508 / 557 / 565 / 694) all wrap `Tool_local_runtime` coprocess success/error tuples and carry **mixed semantics** (the message content varies by the upstream command's stderr, with no typed source variant to discriminate). Leaving those untouched in auto-classify mode preserves the original semantics rather than blanket Workflow_rejection.

## Why this PR shape

- Pure `?failure_class` addition. `Tool_result.error` signature preserved.
- **Zero supersession risk** — single-site change, no caller boundary, no helper introduced.

## Verification

- `dune build --root . --cache=disabled lib/` exit 0

## Test plan

- [x] lib build
- [ ] CI green (Draft)

Refs RFC-0189. Stack with #18813 / #18817 / #18820 / #18824 / #18831 / #18835 / #18841.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
