### PR TITLE
feat(typed_tool_masc): source-typed failure_class mapping from Agent_sdk.tool_error (RFC-0189 small-step)

### DIFF
--- a/lib/typed_tool_masc.ml
+++ b/lib/typed_tool_masc.ml
@@ -30,7 +30,39 @@ let make_dispatch_handler (tool : (_, _) t) : Tool_dispatch.handler =
     let start_time = Time_compat.now () in
     match Agent_sdk.Typed_tool.execute tool.oas_tool args with
     | Ok { content } -> Some (Tool_result.ok ~tool_name:name ~start_time content)
-    | Error { message; _ } -> Some (Tool_result.error ~tool_name:name ~start_time message)
+    | Error { message; recoverable; error_class } ->
+      (* RFC-0189: source-typed mapping from [Agent_sdk.tool_error]
+         to [Tool_result.tool_failure_class].  The SDK's typed
+         error already carries the signal — previously discarded
+         in favour of the auto-classify path's [Runtime_failure]
+         default.
+
+         Mapping (matches the SDK's own [recoverable] /
+         [error_class] semantics — see
+         [agent_sdk/llm_provider/types.mli]):
+         - [recoverable=true] or [error_class=Some Transient]
+           -> [Transient_error] (caller retry is safe).
+         - [error_class=Some Deterministic] (and not recoverable)
+           -> [Workflow_rejection] (caller input rejected;
+              retry without changes won't help).
+         - Otherwise ([Unknown] / [None] / non-recoverable)
+           -> [Runtime_failure] (preserve original auto-classify
+              default; surface as severity-elevated upstream). *)
+      let failure_class : Tool_result.tool_failure_class =
+        if recoverable then Tool_result.Transient_error
+        else
+          match error_class with
+          | Some Agent_sdk.Types.Transient ->
+            Tool_result.Transient_error
+          | Some Agent_sdk.Types.Deterministic ->
+            Tool_result.Workflow_rejection
+          | Some Agent_sdk.Types.Unknown | None ->
+            Tool_result.Runtime_failure
+      in
+      Some
+        (Tool_result.error
+           ~failure_class:(Some failure_class)
+           ~tool_name:name ~start_time message)
 
 let to_spec tool =
   let schema = Agent_sdk.Typed_tool.schema tool.oas_tool in


### PR DESCRIPTION
## Summary

`Agent_sdk.Typed_tool.execute` already returns a typed `tool_error` record with `recoverable : bool` and `error_class : tool_error_class option` (variants: `Transient | Deterministic | Unknown`). The previous code destructured only `message` and **discarded the typed classification signal**, forcing `Tool_result.error`'s auto-classify path to default to `Runtime_failure` for every SDK tool failure.

## Source-typed mapping (no substring classifier)

```ocaml
if recoverable then Tool_result.Transient_error
else
  match error_class with
  | Some Agent_sdk.Types.Transient     -> Tool_result.Transient_error
  | Some Agent_sdk.Types.Deterministic -> Tool_result.Workflow_rejection
  | Some Agent_sdk.Types.Unknown | None -> Tool_result.Runtime_failure
```

| Input | Output | Why |
|---|---|---|
| `recoverable=true` | `Transient_error` | SDK signals retry-safe |
| `recoverable=false + Transient` | `Transient_error` | Same |
| `recoverable=false + Deterministic` | `Workflow_rejection` | Deterministic-deny, caller must fix input |
| `recoverable=false + Unknown/None` | `Runtime_failure` | Preserve auto-classify default |

Aligns with the SDK's own retry policy semantics (`agent_sdk/tool_retry_policy.mli`).

## Why this PR shape

- Single match arm extended. `Tool_result.error` signature preserved.
- **Source-typed mapping** — explicitly avoids the CLAUDE.md Workaround Signature Bar §2 anti-pattern (substring classifier). The SDK's variant is the source of truth.
- **Zero supersession risk** vs parallel RFC-0189 stream.

## End of pattern

This brings the no-handler-signature-change micro-step pattern near completion. Remaining sites:
- 4 `Tool_local_runtime` coprocess wraps in `mcp_server_eio_execute.ml`
- 1 `tool_coord` heartbeat warning-prefix sentinel
— all carry mixed semantics with no typed upstream. Explicit tagging would require source helpers to grow typed errors first.

## Verification

- `dune build --root . --cache=disabled lib/` exit 0

## Test plan

- [x] lib build
- [ ] CI green (Draft)

Refs RFC-0189. Stack with #18813 / #18817 / #18820 / #18824 / #18831 / #18835 / #18841 / #18858.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
