### PR TITLE
test(coord): delete 3 obsolete substring-gate lock-in tests (Phase E Cluster A.1)

### DIFF
--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1665,71 +1665,17 @@ let () = test "transition_claim_blocks_required_tools_even_with_force" (fun () -
   assert (Planning_eio.get_current_task ctx.config = None)
 )
 
-let () = test "transition_submit_for_verification_requires_evidence_ref" (fun () ->
-  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
-    let ctx = make_test_ctx () in
-    let add_result =
-      Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
-        (`Assoc [ ("title", `String "Needs real verification evidence") ])
-    in
-    if not add_result.Tool_result.success then failwith add_result.Tool_result.message;
-    let claim_result =
-      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
-        (`Assoc [ ("task_id", `String "task-001"); ("action", `String "claim") ])
-    in
-    if not claim_result.Tool_result.success then failwith claim_result.Tool_result.message;
-    let submit_result =
-      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
-        (`Assoc
-          [
-            ("task_id", `String "task-001");
-            ("action", `String "submit_for_verification");
-            ("notes", `String "Implementation complete.");
-          ])
-    in
-    assert (not submit_result.Tool_result.success);
-    assert
-      (Tool_result.failure_class submit_result = Some Tool_result.Workflow_rejection);
-    assert
-      (str_contains submit_result.Tool_result.message
-         "requires verification evidence");
-    assert_task_claimed_by ctx ctx.agent_name)
-  )
-
-let () = test "transition_submit_for_verification_rejects_placeholder_evidence_ref" (fun () ->
-  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
-    let ctx = make_test_ctx () in
-    let add_result =
-      Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
-        (`Assoc [ ("title", `String "Reject placeholder evidence") ])
-    in
-    if not add_result.Tool_result.success then failwith add_result.Tool_result.message;
-    let claim_result =
-      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
-        (`Assoc [ ("task_id", `String "task-001"); ("action", `String "claim") ])
-    in
-    if not claim_result.Tool_result.success then failwith claim_result.Tool_result.message;
-    let submit_result =
-      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
-        (`Assoc
-          [
-            ("task_id", `String "task-001");
-            ("action", `String "submit_for_verification");
-            ("notes", `String "Implementation complete.");
-            ( "handoff_context",
-              `Assoc
-                [
-                  ("summary", `String "Implementation complete.");
-                  ("evidence_refs", `List [ `String "none" ]);
-                ] );
-          ])
-    in
-    assert (not submit_result.Tool_result.success);
-    assert
-      (str_contains submit_result.Tool_result.message
-         "requires verification evidence");
-    assert_task_claimed_by ctx ctx.agent_name)
-  )
+(* RFC-0109 Phase E (#18822, 2026-05-27) retired the transition-layer
+   substring evidence gate. The two tests that previously locked in
+   the substring-reject behaviour
+   ([transition_submit_for_verification_requires_evidence_ref] and
+   [transition_submit_for_verification_rejects_placeholder_evidence_ref])
+   have been removed: their intent was the exact behaviour Phase E
+   removes.  Phase E semantics is now pinned by
+   [test/test_coord_task_verification_phase_e.ml] (5 cases) and by
+   the typed CDAL verdict consultation in
+   [test/test_cdal_evidence_gate.ml] (10 cases).  See issue #18830
+   Cluster A.1 for the triage record. *)
 
 let () = test "transition_submit_for_verification_aliases_todo_pr_evidence" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
@@ -1758,27 +1704,14 @@ let () = test "transition_submit_for_verification_aliases_todo_pr_evidence" (fun
     | None -> failwith "expected handoff_context to receive pr_url evidence")
 )
 
-let () = test "transition_submit_for_verification_todo_still_requires_evidence" (fun () ->
-  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
-    let ctx = make_test_ctx_with_agent "agent_code-mcp-client" in
-    add_task_requiring_tools ctx ~title:"Codex CLI approval follow-up" [ "tool_execute" ];
-    let result =
-      Tool_task.handle_transition
-        ~agent_tool_names:[ "masc_status"; "masc_transition" ]
-        ~tool_name:"test_tool" ~start_time:0.0
-        ctx
-        (`Assoc
-          [
-            ("task_id", `String "task-001");
-            ("action", `String "submit_for_verification");
-            ("notes", `String "Implementation is complete.");
-          ])
-    in
-    assert (not result.Tool_result.success);
-    assert (Tool_result.failure_class result = Some Tool_result.Workflow_rejection);
-    assert (str_contains result.Tool_result.message "requires verification evidence");
-    assert_task_todo ctx)
-)
+(* RFC-0109 Phase E (#18822): the transition-layer substring gate that
+   produced the "requires verification evidence" message no longer
+   exists; this test's [str_contains "requires verification evidence"]
+   assertion was the third lock-in of the retired behaviour and has
+   been removed.  The remaining intent — contracted-task submit
+   rejection when no CDAL verdict and no substantive evidence — is
+   covered by [test/test_cdal_evidence_gate.ml]'s missing-verdict
+   arm. See issue #18830 Cluster A.1. *)
 
 (* Regression: the transport-level [pr_url] alias must be hoisted onto
    the typed [handoff_context.evidence_refs] domain, not concatenated


### PR DESCRIPTION
## Summary

Surgical follow-up to merged PR #18822 (RFC-0109 Phase E closeout). Deletes 3 tests in \`test/test_tool_task_coverage.ml\` that asserted the transition-layer substring evidence gate raises \`InvalidState\` — the exact behaviour Phase E removed.

## Tests deleted

| Test | Was line | Lock-in intent |
|--|--:|--|
| \`transition_submit_for_verification_requires_evidence_ref\` | 1668 | substring reject on plain notes |
| \`transition_submit_for_verification_rejects_placeholder_evidence_ref\` | 1699 | substring reject on placeholder evidence_refs |
| \`transition_submit_for_verification_todo_still_requires_evidence\` | 1761 | substring reject on todo-state submit |

All three assert \`str_contains result.message "requires verification evidence"\` against a transition that, post Phase E, no longer raises that message.

## Replacement coverage already in place

- \`test/test_coord_task_verification_phase_e.ml\` (5 cases) pins the new typed-concat semantics (introduced by #18822)
- \`test/test_cdal_evidence_gate.ml\` (10 cases) pins the typed CDAL verdict consultation including the missing-verdict reject arm (Phase D/E-1)

No coverage loss.

## Test 55 retained

\`transition_submit_for_verification_aliases_todo_pr_evidence\` (currently line 1734) is between the deletions and is kept — it exercises the \`submit_pr_evidence\` alias path which is independent of Phase E. It's in Cluster A.2 (#18830) and bundled with the #17843 client-side-gate follow-up.

## Local verification

| | Tests | Fails |
|---|--:|--:|
| Baseline (\`main\` HEAD \`7b6552370\`) | 98 | 22 |
| This PR | 95 | 19 |
| Delta | −3 | −3 (all 3 are the deletions) |

Zero new regressions, three deletions, no other test affected.

## Scope discipline

Per CLAUDE.md "Surgical Changes": this PR touches only \`test/test_tool_task_coverage.ml\`. The remaining Cluster A sub-clusters from #18830:

- **A.2** (1 test): bundled with #17843 client-side-gate follow-up
- **A.3** (3 tests): fixture update for Phase E-1 fallback threshold — needs separate PR with careful contract / required_evidence wiring

## Test plan

- [ ] CI \`test_tool_task_coverage\` passes (or baseline 22→19 reduction confirmed)
- [ ] No new test added; deletion-only PR — review focus is "are the 3 tests genuinely obsolete vs Phase E's actual behaviour"

Related: #18810 (root cause, closed), #18822 (Phase E closeout, merged), #18830 (full triage), #18851 (observability fix, in-flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)