### PR TITLE
refactor(keeper): hide read-only lookup table

### DIFF
--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -115,14 +115,14 @@ let keeper_read_only_tools =
   |> List.sort_uniq String.compare
 ;;
 
-let keeper_read_only_set : (string, unit) Hashtbl.t =
+let keeper_read_only_lookup : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create (List.length keeper_read_only_tools) in
   List.iter (fun name -> Hashtbl.replace tbl name ()) keeper_read_only_tools;
   tbl
 ;;
 
 let is_keeper_read_only_tool (name : string) : bool =
-  Hashtbl.mem keeper_read_only_set name
+  Hashtbl.mem keeper_read_only_lookup name
 ;;
 
 let is_effectively_read_only_tool (name : string) : bool =

--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -41,11 +41,9 @@ val descriptor_read_only_tools : string list
     projections, sorted/deduped. *)
 val keeper_read_only_tools : string list
 
-val keeper_read_only_set : (string, unit) Hashtbl.t
-
 val is_keeper_read_only_tool : string -> bool
 
-(** Combined read-only check: keeper-local set + Tool_dispatch
+(** Combined read-only check: keeper-local lookup + catalog-backed
     read-only/idempotent classification. *)
 val is_effectively_read_only_tool : string -> bool
 

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -498,6 +498,8 @@ let test_keeper_semantic_capabilities_use_capability_axis () =
   let contract_classifier = "lib/keeper/keeper_contract_classifier.ml" in
   let pr_metrics = "lib/keeper/keeper_hooks_oas_pr_metrics.ml" in
   let output_json = "lib/keeper/keeper_hooks_oas_output_json.ml" in
+  let registry = "lib/keeper/keeper_tool_registry.ml" in
+  let registry_mli = "lib/keeper/keeper_tool_registry.mli" in
   assert_contains "lib/dune" "keeper_tool_capability_axis";
   assert_contains axis "Keeper_tool_alias.canonical_resolution";
   assert_not_contains axis "Keeper_tool_alias.route";
@@ -515,6 +517,8 @@ let test_keeper_semantic_capabilities_use_capability_axis () =
   assert_contains output_json
     "Keeper_tool_capability_axis.shell_command_input_candidates";
   assert_contains axis "shell_command_input_candidates";
+  assert_not_contains registry ("keeper_" ^ "read_" ^ "only_" ^ "set");
+  assert_not_contains registry_mli ("keeper_" ^ "read_" ^ "only_" ^ "set");
   assert_not_contains output_json "\"tool_execute\" ->";
   assert_not_contains output_json "\"tool_execute\" ->"
 

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -76,15 +76,18 @@ let test_public_alias_guidance_ignores_public_execute () =
        "Execute")
 ;;
 
-let test_public_alias_guidance_prefers_visible_write_alias () =
+let test_public_alias_guidance_prefers_visible_edit_alias () =
+  let expected =
+    Some
+      "tool_edit_file is an internal keeper implementation tool name, not a \
+       model-facing tool. Use EditFile instead."
+  in
   check
     (option string)
-    "visible write alias"
-    (Some
-       "tool_edit_file is an internal keeper implementation tool name, not a \
-        model-facing tool. Use WriteFile instead.")
+    "visible edit alias"
+    expected
     (Resolution.public_alias_guidance_for_internal_call
-       ~visible_tool_names:[ "WriteFile" ]
+       ~visible_tool_names:[ "EditFile" ]
        "tool_edit_file")
 ;;
 
@@ -152,7 +155,7 @@ let test_has_valid_tool_call_false_when_empty () =
 
 (* Use real canonical tool names. Passive_status tools must have
    Tool_catalog.effect_domain = Some Read_only so classify_tool_progress
-   classifies them correctly without dispatch-owned capability sets. *)
+   classifies them through catalog-backed capabilities. *)
 
 let passive_tool = "keeper_tasks_list"
 let passive_tool_alt = "keeper_context_status"
@@ -262,9 +265,9 @@ let () =
             `Quick
             test_public_alias_guidance_ignores_public_execute
         ; test_case
-            "internal edit prefers visible WriteFile alias"
+            "internal edit prefers visible EditFile alias"
             `Quick
-            test_public_alias_guidance_prefers_visible_write_alias
+            test_public_alias_guidance_prefers_visible_edit_alias
         ; test_case
             "internal alias reports when public alias is not visible"
             `Quick


### PR DESCRIPTION
## Summary
- remove the public Keeper_tool_registry.keeper_read_only_set table export
- keep read-only membership behind is_keeper_read_only_tool using an internal lookup
- add boundary coverage so the public read-only set surface does not return
- refresh the touched alias baseline to the current EditFile public alias

## Verification
- ocamlformat --check lib/keeper/keeper_tool_registry.ml lib/keeper/keeper_tool_registry.mli test/test_keeper_sandbox_boundary_policy.ml test/test_keeper_tool_surface_guard.ml
- rg backstop for retired dispatch capability vocabulary in lib/test/scripts
- git diff --check HEAD~1..HEAD
- MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_sandbox_boundary_policy.exe test/test_keeper_tool_surface_guard.exe
- ./_build/default/test/test_keeper_sandbox_boundary_policy.exe
- ./_build/default/test/test_keeper_tool_surface_guard.exe