### PR TITLE
fix(http-eio): downgrade recognised late-response race to debug

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -139,7 +139,16 @@ let safe_respond_with_string reqd response body =
   | exn -> (
       match Late_response.classify_write_failure exn with
       | Some msg ->
-          Log.Http.warn
+          (* Recognised late-response race (httpun "invalid state" / closed
+             writer).  Aligned with [Server_ws_standalone] heartbeat /
+             send_pong / handler sites which already log this at debug —
+             closes the #13082 review N-of-M leftover: the SSOT classifier
+             was unified but this site kept emitting WARN, drowning the
+             [None] branch's genuinely-unexpected signal in routine
+             disconnect noise.  Comment above ("Genuinely unexpected
+             exceptions still log at WARN") only holds once this branch
+             stops warning too. *)
+          Log.Http.debug
             "[http-eio] respond_with_string skipped (reqd already in \
              error-handling state; classifier match — \
              2026-05-05 OAS cancellation race): %s" msg


### PR DESCRIPTION
## Summary

Downgrade the `Some msg` (recognised late-response race) branch in
`Http_server_eio.safe_respond_with_string` from `Log.Http.warn` to
`Log.Http.debug`.  The `None` (genuinely unexpected exception) branch
keeps `warn` as the comment above the helper already states it should
("Genuinely unexpected exceptions still log at WARN").

## Why this is a real fix, not a workaround

This is the N-of-M leftover from the #13082 review fix.  The
`Late_response.classify_write_failure` SSOT was unified across this
file and `Server_ws_standalone`, but only ws-standalone migrated the
*log level* asymmetry afterwards:

| Site | `Some _` branch | `None` branch |
|---|---|---|
| `server_ws_standalone.ml:268` heartbeat | `Log.Server.debug` | `Log.Server.warn` |
| `server_ws_standalone.ml:323` send_pong | `Log.Server.debug` | `Log.Server.warn` |
| `server_ws_standalone.ml:417` handler   | `Log.Server.debug` | `Log.Server.warn` |
| `http_server_eio.ml:135` respond (this PR) | `Log.Http.warn` → **debug** | `Log.Http.warn` |

The asymmetry mattered: with both branches at `warn`, an operator
watching `Log.Http.warn` cannot distinguish the routine 2026-05-05 OAS
cancellation race (which the SSOT classifier explicitly recognises and
the code intentionally swallows) from a genuinely unexpected exception
that should trigger investigation.  The recognised race fires on every
client disconnect mid-response, so the `None` signal was buried.

Comment line 314-319 in `server_ws_standalone.ml` even claims the
unification "closes the warn-noise gap reported in #13082 review" — but
only for that file.  This PR finishes the job at the original
`safe_respond_with_string`.

## Workaround-signature self-check

1. **Counter-as-Fix** — N/A.  No counter added.  The fix is a level
   correction so the existing log surface stops conflating two
   categories.
2. **String/substring classifier** — `Late_response.classify_write_failure`
   uses `String.starts_with`/`String.equal` on httpun error messages,
   and the existing in-file comment (lines 92-104) justifies this as
   an external-library boundary where the string IS the public API
   surface.  Not changed.
3. **N-of-M completion** — Yes, this PR closes the leftover from
   #13082 review.  Per CLAUDE.md the `_complete the migration_`
   signature is rejection-worthy when a PR *creates* an N-of-M;
   here the PR *closes* one (4/4 sites uniformly aligned after merge).

## Test plan

- [x] `dune build @check --root . --cache=disabled` clean.
- [x] `_build/default/test/test_reqd_invalid_state_swallow.exe` — OK
       (single targeted test, exercises classifier match path).
- [x] `_build/default/test/test_http_server_eio_coverage.exe` — 1
       pre-existing failure (`default_config / max_connections`)
       reproduces on `origin/main` without this change; unrelated
       (config default test, not classifier path).
- [x] `ocamlformat --check lib/http_server_eio.ml` — pass.

## Out of scope

- The substring classifier itself.  Justified by in-file comment as
  external lib boundary.
- Prometheus counter for classifier match rate / unknown-exn rate.
  The level split already restores the WARN signal; if a counter is
  added later it should be in a separate PR with its own observability
  RFC, not bundled here (per §1 Counter-as-Fix avoidance).