### PR TITLE
refactor(keeper): route capability checks through descriptors

### DIFF
--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -48,8 +48,8 @@ val keeper_read_only_tools : string list
 val is_keeper_read_only_tool : string -> bool
 
 (** [true] when [name] is read-only or idempotent (safe to retry).
-    Keeper-local fast-path (no mutex), then catalog-backed
-    {!Tool_capability.has}. Prefer {!has_mutating_side_effect}
+    Keeper-local fast-path (no mutex), then descriptor-aware capability
+    projection. Prefer {!has_mutating_side_effect}
     at call sites for positive-sense readability. *)
 val is_effectively_read_only_tool : string -> bool
 

--- a/lib/keeper/keeper_guards.mli
+++ b/lib/keeper/keeper_guards.mli
@@ -183,8 +183,8 @@ val cost_guard :
   max_cost_usd:float option ->
   Agent_sdk.Hooks.hooks
 
-(** Destructive-pattern detection for tools flagged by
-    {!Tool_capability.has}; runs only when [enabled]. *)
+(** Destructive-pattern detection for tools flagged by descriptor-aware
+    capability projection; runs only when [enabled]. *)
 val destructive_guard :
   meta_ref:Keeper_types.keeper_meta ref ->
   on_gate_decision:(gate_decision_event -> unit) ->

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -177,8 +177,11 @@ let is_keeper_safe_inline_tool name =
   List.mem name keeper_safe_inline_tools
 
 let is_keeper_mcp_context_required name =
-  not (is_keeper_safe_inline_tool name)
-  && Tool_capability.has Tool_capability.Mcp_context_required name
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
+  not (is_keeper_safe_inline_tool stripped)
+  && Agent_tool_descriptor_resolution.capability_has
+       Tool_capability.Mcp_context_required
+       name
 
 let keeper_supported_keeper_masc_tools =
   [ "masc_keeper_list"

--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -137,7 +137,9 @@ let tool_name_can_satisfy_required_contract name =
         ( Tool_catalog.Masc_coordination
         | Tool_catalog.Playground_write
         | Tool_catalog.Host_repo_write ) -> true
-    | None -> not (Tool_capability.has Tool_capability.Read_only name))
+    | None ->
+      not
+        (Agent_tool_descriptor_resolution.capability_has Tool_capability.Read_only name))
 ;;
 
 let required_tool_satisfaction ?(satisfying_tools : string list = [])

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -127,10 +127,10 @@ let is_keeper_read_only_tool (name : string) : bool =
 
 let is_effectively_read_only_tool (name : string) : bool =
   (* Keeper-local check first (bare Hashtbl, no mutex) before
-     catalog-backed capability lookup. *)
+     descriptor-aware capability lookup. *)
   is_keeper_read_only_tool name
-  || Tool_capability.has Tool_capability.Read_only name
-  || Tool_capability.has Tool_capability.Idempotent name
+  || Agent_tool_descriptor_resolution.capability_has Tool_capability.Read_only name
+  || Agent_tool_descriptor_resolution.capability_has Tool_capability.Idempotent name
 ;;
 
 let has_mutating_side_effect (name : string) : bool =

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -20,6 +20,7 @@
 open Alcotest
 module Descriptor = Masc_mcp.Agent_tool_descriptor
 module Exec = Masc_mcp.Keeper_exec_tools
+module Policy = Masc_mcp.Keeper_tool_policy
 module Registry = Masc_mcp.Keeper_tool_registry
 module Resolution = Masc_mcp.Agent_tool_descriptor_resolution
 module Tool_board_registry = Masc_mcp.Tool_board_registry
@@ -221,6 +222,25 @@ let test_readonly_policy_projects_to_input_aware_registry () =
        ~tool_name:"tool_write_file"
        ~input:(`Assoc [ "path", `String "x"; "content", `String "y" ]))
 
+let test_mcp_context_policy_uses_descriptor_resolution () =
+  Alcotest.(check bool)
+    "approval_pending does not require MCP session"
+    false
+    (Policy.is_keeper_mcp_context_required "masc_approval_pending");
+  Alcotest.(check bool)
+    "mcp-prefixed approval_pending keeps inline exemption"
+    false
+    (Policy.is_keeper_mcp_context_required "mcp__masc__masc_approval_pending");
+  Alcotest.(check bool)
+    "approval_get still requires MCP session"
+    true
+    (Policy.is_keeper_mcp_context_required "masc_approval_get");
+  Alcotest.(check bool)
+    "mcp-prefixed approval_get still requires MCP session"
+    true
+    (Policy.is_keeper_mcp_context_required "mcp__masc__masc_approval_get")
+;;
+
 let test_mutation_boundary_delegates_to_descriptor_policy () =
   let search_input = `Assoc [ "pattern", `String "Agent_tool_descriptor" ] in
   Alcotest.(check bool)
@@ -341,6 +361,10 @@ let () =
             "descriptor read-only policy projects to input-aware registry"
             `Quick
             test_readonly_policy_projects_to_input_aware_registry
+        ; test_case
+            "MCP context policy uses descriptor resolution"
+            `Quick
+            test_mcp_context_policy_uses_descriptor_resolution
         ; test_case
             "mutation boundary delegates to descriptor policy"
             `Quick

--- a/test/test_keeper_unified_required_tools.ml
+++ b/test/test_keeper_unified_required_tools.ml
@@ -45,10 +45,16 @@ let test_required_tool_satisfaction_rejects_passive_tools () =
     (satisfies_required_tool "ReadFile" (`Assoc []));
   check bool "SearchFiles alias cannot satisfy required-action contract" false
     (satisfies_required_tool "SearchFiles" (`Assoc []));
+  check bool "mcp-prefixed SearchFiles remains passive" false
+    (satisfies_required_tool "mcp__masc__SearchFiles" (`Assoc []));
+  check bool "SearchWeb alias cannot satisfy required-action contract" false
+    (satisfies_required_tool "SearchWeb" (`Assoc []));
   check bool "ReadFile alias remains passive progress" true
     (KTP.is_passive_status_tool_name "ReadFile");
   check bool "SearchFiles alias remains passive progress" true
-    (KTP.is_passive_status_tool_name "SearchFiles")
+    (KTP.is_passive_status_tool_name "SearchFiles");
+  check bool "SearchWeb alias remains passive progress" true
+    (KTP.is_passive_status_tool_name "SearchWeb")
 ;;
 
 let test_required_tool_satisfaction_accepts_mutating_tools () =

--- a/test/test_mcp_server_eio_tool_profile_capability.ml
+++ b/test/test_mcp_server_eio_tool_profile_capability.ml
@@ -157,6 +157,11 @@ let test_descriptor_resolution_capabilities_for_public_aliases () =
     (capability_has Masc_mcp.Tool_capability.Read_only "SearchFiles");
   check
     bool
+    "mcp-prefixed SearchFiles read-only via descriptor resolution"
+    true
+    (capability_has Masc_mcp.Tool_capability.Read_only "mcp__masc__SearchFiles");
+  check
+    bool
     "WriteFile destructive via descriptor resolution"
     true
     (capability_has Masc_mcp.Tool_capability.Destructive "WriteFile");


### PR DESCRIPTION
Summary: route keeper policy/progress/registry capability checks through Agent_tool_descriptor_resolution, keep MCP-prefixed approval_pending inline exemption, and add descriptor projection tests for public/MCP-prefixed aliases. Tests: ocamlformat --check touched OCaml files; env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_keeper_unified_required_tools.exe ./test/test_mcp_server_eio_tool_profile_capability.exe ./test/test_agent_tool_descriptor_registry_integrity.exe; ran all three built test binaries.