### PR TITLE
fix(cascade): replace runpod_mtp placeholder endpoint with actual pod URL

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -70,7 +70,7 @@ key = "ZAI_API_KEY"
 [providers.runpod_mtp]
 display-name = "RunPod Qwen"
 protocol = "provider_d-http"
-endpoint = "https://example.runpod.net/v1"
+endpoint = "https://ma8xbr1kgbclkl-19123.proxy.runpod.net/v1"
 
 [providers.runpod_mtp.credentials]
 type = "env"
@@ -83,7 +83,7 @@ supports-runtime-mcp-http-headers = true
 
 [providers.runpod_mtp.healthcheck]
 enabled = true
-endpoint = "https://example.runpod.net/v1/models"
+endpoint = "https://ma8xbr1kgbclkl-19123.proxy.runpod.net/v1/models"
 method = "GET"
 timeout_seconds = 10
 probe_interval_seconds = 60


### PR DESCRIPTION
## Summary

`cascade.toml` 의 `runpod_mtp` provider 가 placeholder endpoint `https://example.runpod.net/v1` 를 사용 중. 이 hostname 은 DNS 에서 resolve 되지 않아 모든 cascade attempt 마다 fail → tier-group.primary failover 가 매번 first DNS round-trip 을 낭비. Issue [#18524](https://github.com/yousleepwhen/masc-mcp/issues/18524).

## Changes

`config/cascade.toml` 2 lines:
- L73: `[providers.runpod_mtp].endpoint` 를 실제 pod endpoint `https://ma8xbr1kgbclkl-19123.proxy.runpod.net/v1` 로 정정
- L86: `[providers.runpod_mtp.healthcheck].endpoint` 를 같은 base + `/models` 로 정정

Endpoint reference: `memory/reference_runpod_masc_llamacpp_a40_pod.md` (A40 48GB pod `ma8xbr1kgbclkl`, port quirk: llama-server bind 19123 forced).

## Verification

- `curl https://ma8xbr1kgbclkl-19123.proxy.runpod.net/v1/models` → HTTP 200 (2026-05-27 측정)
- test fixture (`test/test_cascade_phonebook_resolve.ml:20,145`) 는 inline TOML 로 별개 — 영향 없음

## Cluster context (P1#4 cascade)

본 PR 은 [#18845 amplifier cluster](https://github.com/yousleepwhen/masc-mcp/issues/18845#issuecomment-4550479090) 의 **trigger A (config-level) priority 1순위 fix**. trigger A 제거 시 amplifier 효과 약 -20% (5 providers 중 1 trigger 제거). Amplifier 자체 (#18845 per-attempt 30s timeout) 는 RFC 영역으로 별도 다룸. trigger B/C (#18473, #18475) 는 RFC 영역 잔존.

## Dual-SSOT note

repo `config/cascade.toml` 은 first-run seed/reference. 런타임 `~/me/.masc/config/cascade.toml` 은 별도 — 본 PR 머지 후 운영자가 별도 동기화 필요할 수 있음 ([5/26 dual-SSOT 발견](https://github.com/jeong-sik/masc-mcp/pull/18695) 참고).

Closes #18524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
