### PR TITLE
feat(dashboard/keeper-ops): inline lifecycle actions + SSOT cleanup

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -536,7 +536,7 @@ describe('AgentRoster live-only cards', () => {
     expect(container.querySelector('aside h3')?.textContent).toContain('alpha-agent')
 
     await act(async () => {
-      ;(rows[1] as HTMLButtonElement).click()
+      ;(rows[1] as HTMLElement).click()
     })
 
     expect(container.querySelector('aside h3')?.textContent).toContain('beta-agent')
@@ -564,8 +564,11 @@ describe('AgentRoster live-only cards', () => {
 
     const text = container.textContent ?? ''
     expect(text).toContain('운영판정')
-    expect(text).toContain('현재 단계')
-    expect(text).toContain('차단 근거')
+    // 2026-05-27: "현재 단계" 컬럼이 "차단 · 단계" 통합 컬럼으로 합쳐졌고, 종전
+    // "차단 근거" 라벨도 같은 컬럼명으로 변경됨. 통합 라벨 한 곳만 확인하고,
+    // 추가로 액션 컬럼 헤더가 노출되는지 검증한다.
+    expect(text).toContain('차단 · 단계')
+    expect(text).toContain('액션')
     expect(text).toContain('현재 차단: Fiber 미해결')
     expect(text).toContain('Keeper fiber가 종료 상태를 확정하지 못해 supervisor 확인이 필요합니다.')
   })

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -42,6 +42,7 @@ import {
   type RuntimeBand,
 } from '../lib/monitoring-runtime'
 import { KeeperPhaseBadge } from './keeper-phase-indicator'
+import { KeeperActionButtons } from './keeper-action-panel'
 import {
   resolveRuntimeCounts,
   runtimeCountSourceLabel,
@@ -942,33 +943,64 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
       <div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
         <section class="monitor-surface-card monitor-surface-card-medium overflow-hidden" aria-label="Keeper operations list">
-          <div class="grid grid-cols-[minmax(180px,1.35fr)_minmax(90px,0.55fr)_minmax(150px,1fr)_minmax(150px,1fr)_minmax(120px,0.7fr)] gap-3 border-b border-[var(--color-border-divider)] px-4 py-2.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)] max-lg:hidden">
+          <!--
+            2026-05-27 KEEPER OPERATIONS row redesign:
+            - 현재 단계 column was almost always "-" for stuck keepers (the
+              dominant case the surface exists for) and duplicated the
+              SELECTED RUNTIME phase badge. Removed; the blocker/stage cell
+              now switches: blocker text when blocked, stage/phase label
+              when running.
+            - Row is now div role=button so inline action buttons
+              (재개 / 일시정지 / 깨우기 / 기동 / 종료) can be nested without
+              violating no-button-in-button HTML. Enter/Space keep
+              keyboard selection working.
+            - 차단 근거 셀이 truncate(1줄) 였던 것을 line-clamp-2 로 풀어 잘림을 완화.
+          -->
+          <div class="grid grid-cols-[minmax(180px,1.35fr)_minmax(80px,0.5fr)_minmax(170px,1.1fr)_minmax(110px,0.65fr)_minmax(160px,0.9fr)] gap-3 border-b border-[var(--color-border-divider)] px-4 py-2.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)] max-lg:hidden">
             <span>Keeper</span>
             <span>운영판정</span>
-            <span>현재 단계</span>
-            <span>차단 근거</span>
+            <span>차단 · 단계</span>
             <span>최근 도구</span>
+            <span>액션</span>
           </div>
 
           <div class="divide-y divide-[var(--color-border-divider)]">
             ${rosterRows.map(row => {
               const selected = selectedRow?.key === row.key
               const blockerDisplay = rosterBlockerDisplay(row.stateNote, row.keeperRuntime)
-              const nowLabel =
+              const stageLabel =
                 row.fsmStageText
                 ?? row.monitoringEvidence?.phase?.label
-                ?? (row.monitoringEvidence?.stage?.label ?? '-')
+                ?? row.monitoringEvidence?.stage?.label
+                ?? null
+              // 차단이 있으면 차단 근거가 더 의미 있고, 차단이 없으면 현재 단계 라벨로 fallback.
+              // 둘 다 없으면 '-'.
+              const blockerOrStage = row.stateNote
+                ? blockerDisplay.cell
+                : (stageLabel ?? '-')
+              const blockerOrStageTitle = row.stateNote
+                ? blockerDisplay.title
+                : (stageLabel ?? '')
               const latestTool = row.recentTools[0] ?? (row.toolCallCount != null && row.toolCallCount > 0 ? `${row.toolCallCount} calls` : '-')
 
+              const handleRowKey = (e: KeyboardEvent) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  setSelectedKey(row.key)
+                }
+              }
+
               return html`
-                <button
-                  type="button"
+                <div
+                  role="button"
+                  tabIndex=${0}
                   key=${row.key}
                   data-testid="keeper-operations-row"
                   aria-label=${`${row.displayName} 선택`}
                   aria-pressed=${selected}
                   onClick=${() => setSelectedKey(row.key)}
-                  class="grid w-full grid-cols-1 gap-2 px-4 py-3 text-left transition-colors hover:bg-[var(--color-bg-hover)] lg:grid-cols-[minmax(180px,1.35fr)_minmax(90px,0.55fr)_minmax(150px,1fr)_minmax(150px,1fr)_minmax(120px,0.7fr)] lg:items-center lg:gap-3 ${selected ? 'bg-[var(--color-bg-surface)]' : 'bg-transparent'}"
+                  onKeyDown=${handleRowKey}
+                  class="grid w-full cursor-pointer grid-cols-1 gap-2 px-4 py-3 text-left transition-colors hover:bg-[var(--color-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-fg)] lg:grid-cols-[minmax(180px,1.35fr)_minmax(80px,0.5fr)_minmax(170px,1.1fr)_minmax(110px,0.65fr)_minmax(160px,0.9fr)] lg:items-center lg:gap-3 ${selected ? 'bg-[var(--color-bg-surface)]' : 'bg-transparent'}"
                 >
                   <span class="flex min-w-0 items-center gap-3">
                     <span class="shrink-0">
@@ -995,20 +1027,27 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   </span>
 
                   <span class="min-w-0 text-xs leading-snug text-[var(--color-fg-primary)]">
-                    <span class="block truncate lg:hidden text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">현재 단계</span>
-                    <span class="block truncate">${nowLabel}</span>
-                  </span>
-
-                  <span class="min-w-0 text-xs leading-snug text-[var(--color-fg-primary)]">
-                    <span class="block truncate lg:hidden text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">차단 근거</span>
-                    <span class="block truncate" title=${blockerDisplay.title}>${blockerDisplay.cell}</span>
+                    <span class="block truncate lg:hidden text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">차단 · 단계</span>
+                    <span class="line-clamp-2 break-words" title=${blockerOrStageTitle}>${blockerOrStage}</span>
                   </span>
 
                   <span class="min-w-0 text-xs leading-snug text-[var(--color-fg-primary)]">
                     <span class="block truncate lg:hidden text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">최근 도구</span>
-                    <span class="block truncate">${latestTool}</span>
+                    <span class="block truncate" title=${latestTool}>${latestTool}</span>
                   </span>
-                </button>
+
+                  <span class="min-w-0">
+                    <span class="block lg:hidden text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">액션</span>
+                    ${row.keeperRuntime
+                      ? html`<${KeeperActionButtons}
+                          keeper=${row.keeperRuntime}
+                          size="sm"
+                          compact
+                          stopPropagation
+                        />`
+                      : html`<span class="text-3xs text-[var(--color-fg-muted)]">—</span>`}
+                  </span>
+                </div>
               `
             })}
 

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -62,10 +62,10 @@ function afterAction(): void {
   })
 }
 
-type KeeperActionKey = 'pause' | 'resume' | 'wakeup' | 'boot' | 'shutdown'
+export type KeeperActionKey = 'pause' | 'resume' | 'wakeup' | 'boot' | 'shutdown'
 
 /** Execute a lifecycle action for a single keeper with toast feedback. */
-async function runKeeperAction(
+export async function runKeeperAction(
   name: string,
   action: KeeperActionKey,
 ): Promise<void> {
@@ -107,14 +107,36 @@ async function runKeeperAction(
   }
 }
 
-// ── Per-keeper row ────────────────────────────────────────────────────────
+// ── Shared button group ───────────────────────────────────────────────────
 
-function KeeperActionRow({ keeper }: { keeper: Keeper }) {
+/**
+ * KeeperActionButtons — reusable lifecycle button group for a single keeper.
+ *
+ * Used by both the fleet-level KeeperActionPanel row and by inline action
+ * cells inside the KEEPER OPERATIONS table (`agent-roster.ts`). When mounted
+ * inside another clickable parent (a row that handles selection), pass
+ * `stopPropagation` so button clicks don't bubble to row selection.
+ *
+ * Visible verbs match phase semantics (canBoot/canPause/canResume/canWake/
+ * canShutdown) and shutdown is gated by a confirm dialog.
+ */
+export function KeeperActionButtons({
+  keeper,
+  size = 'sm',
+  stopPropagation = false,
+  compact = false,
+}: {
+  keeper: Keeper
+  size?: 'sm' | 'md'
+  stopPropagation?: boolean
+  /** Single-glyph labels (재개/멈춤/깨움/기동/종료) instead of "재개하기" etc. */
+  compact?: boolean
+}) {
   const busy = useSignal(false)
   const vis = keeperActionVisibility(keeper)
-  const pauseDisplay = keeperPauseDisplay(keeper)
 
-  async function handle(action: KeeperActionKey) {
+  async function handle(e: Event, action: KeeperActionKey) {
+    if (stopPropagation) e.stopPropagation()
     if (busy.value) return
     if (action === 'shutdown') {
       const confirmed = await requestConfirm({
@@ -131,6 +153,70 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
       busy.value = false
     }
   }
+
+  // Verb labels match keeperPauseDisplay verb conventions. Compact mode
+  // drops the "하기" suffix so the buttons fit inside a narrow row cell.
+  const label = (full: string, short: string): string => (compact ? short : full)
+
+  return html`
+    <div
+      class="flex items-center gap-1 shrink-0"
+      data-testid="keeper-action-buttons"
+      onClick=${stopPropagation ? (e: Event) => e.stopPropagation() : undefined}
+    >
+      ${vis.canBoot
+        ? html`<${ActionButton}
+            variant="ok"
+            size=${size}
+            disabled=${busy.value}
+            onClick=${(e: Event) => handle(e, 'boot')}
+            title="기동: offline keeper 를 다시 시작합니다 (offline → running)"
+          >${label('기동하기', '기동')}<//>`
+        : null}
+      ${vis.canPause
+        ? html`<${ActionButton}
+            variant="ghost"
+            size=${size}
+            disabled=${busy.value}
+            onClick=${(e: Event) => handle(e, 'pause')}
+            title="일시정지: 실행 중인 keeper 를 일시 멈춥니다 (running → paused, 현재 turn 은 정상 종료)"
+          >${label('일시정지하기', '멈춤')}<//>`
+        : null}
+      ${vis.canResume
+        ? html`<${ActionButton}
+            variant="ok"
+            size=${size}
+            disabled=${busy.value}
+            onClick=${(e: Event) => handle(e, 'resume')}
+            title="재개: 일시정지된 keeper 를 다시 실행합니다 (paused → running)"
+          >${label('재개하기', '재개')}<//>`
+        : null}
+      ${vis.canWake && !vis.canBoot
+        ? html`<${ActionButton}
+            variant="warn"
+            size=${size}
+            disabled=${busy.value}
+            onClick=${(e: Event) => handle(e, 'wakeup')}
+            title="깨우기: idle 또는 stuck 상태에서 다음 turn 을 즉시 시도합니다. 실행 중이어도 노출되는 이유는 cascade/oas/turn timeout 같은 stuck signal 이 backend 보다 먼저 frontend 에 보이는 케이스를 다루기 위함입니다."
+          >${label('깨우기', '깨움')}<//>`
+        : null}
+      ${vis.canShutdown
+        ? html`<${ActionButton}
+            variant="danger"
+            size=${size}
+            disabled=${busy.value}
+            onClick=${(e: Event) => handle(e, 'shutdown')}
+            title="종료: keeper 를 완전 종료합니다 (running/paused → offline, fiber + 리소스 정리)"
+          >${label('종료하기', '종료')}<//>`
+        : null}
+    </div>
+  `
+}
+
+// ── Per-keeper row ────────────────────────────────────────────────────────
+
+function KeeperActionRow({ keeper }: { keeper: Keeper }) {
+  const pauseDisplay = keeperPauseDisplay(keeper)
 
   return html`
     <article
@@ -164,53 +250,7 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
           `
           : null}
       </div>
-      <div class="flex items-center gap-1 shrink-0">
-        ${vis.canBoot
-          ? html`<${ActionButton}
-              variant="ok"
-              size="sm"
-              disabled=${busy.value}
-              onClick=${() => handle('boot')}
-              title="기동: offline keeper 를 다시 시작합니다 (offline → running)"
-            >기동하기<//>`
-          : null}
-        ${vis.canPause
-          ? html`<${ActionButton}
-              variant="ghost"
-              size="sm"
-              disabled=${busy.value}
-              onClick=${() => handle('pause')}
-              title="일시정지: 실행 중인 keeper 를 일시 멈춥니다 (running → paused, 현재 turn 은 정상 종료)"
-            >일시정지하기<//>`
-          : null}
-        ${vis.canResume
-          ? html`<${ActionButton}
-              variant="ok"
-              size="sm"
-              disabled=${busy.value}
-              onClick=${() => handle('resume')}
-              title="재개: 일시정지된 keeper 를 다시 실행합니다 (paused → running)"
-            >재개하기<//>`
-          : null}
-        ${vis.canWake && !vis.canBoot
-          ? html`<${ActionButton}
-              variant="warn"
-              size="sm"
-              disabled=${busy.value}
-              onClick=${() => handle('wakeup')}
-              title="깨우기: idle 또는 stuck 상태에서 다음 turn 을 즉시 시도합니다. 실행 중이어도 노출되는 이유는 cascade/oas/turn timeout 같은 stuck signal 이 backend 보다 먼저 frontend 에 보이는 케이스를 다루기 위함입니다."
-            >깨우기<//>`
-          : null}
-        ${vis.canShutdown
-          ? html`<${ActionButton}
-              variant="danger"
-              size="sm"
-              disabled=${busy.value}
-              onClick=${() => handle('shutdown')}
-              title="종료: keeper 를 완전 종료합니다 (running/paused → offline, fiber + 리소스 정리)"
-            >종료하기<//>`
-          : null}
-      </div>
+      <${KeeperActionButtons} keeper=${keeper} size="sm" />
     </article>
   `
 }


### PR DESCRIPTION
## 요약

KEEPER OPERATIONS 테이블에서 COMMAND 탭으로 이동하지 않고 행에서 바로 키퍼를 재개/일시정지/깨우기/기동/종료할 수 있게 인라인 액션 버튼을 추가했습니다. 그 과정에서 행과 우측 `SELECTED RUNTIME` 패널 사이 중복 정보를 정리했습니다.

## 동기

- COMMAND 탭이나 별도 `KEEPER ACTIONS` 카드로 이동해야만 액션을 보낼 수 있었습니다.
- "현재 단계" 컬럼이 stuck keeper(이 surface 가 존재하는 주된 사례)에서 거의 항상 `-` 였고, 우측 `SELECTED RUNTIME` phase badge 와 중복됐습니다.
- "차단 근거" 셀이 `truncate`(1줄) 라 hover 하지 않으면 풀텍스트를 못 봤습니다.
- 행 wrapper 가 `<button>` 이라 nested `<button>` 액션을 넣을 수 없었습니다 (no-button-in-button HTML).

## 변경

- `dashboard/src/components/keeper-action-panel.ts`
  - `KeeperActionButtons` 를 export. `compact` 모드(`재개/멈춤/깨움/기동/종료` 짧은 라벨) + `stopPropagation` (부모 행 click 전파 차단) prop 추가.
  - 기존 `KeeperActionPanel` row 는 분리한 `KeeperActionButtons` 를 재사용 — 두 surface 가 같은 visibility/optimistic 로직을 공유합니다.
- `dashboard/src/components/agent-roster.ts`
  - 행 wrapper 를 `<button>` → `<div role="button" tabIndex={0}>` + `onKeyDown`(Enter/Space) 으로 변환. `aria-pressed`/`onClick` 동작과 testid 셀렉터는 그대로 유지.
  - 그리드 컬럼 재배치: `Keeper / 운영판정 / 차단 · 단계 / 최근 도구 / 액션`.
    - "현재 단계" 컬럼 제거. "차단·단계" 통합 컬럼은 `stateNote` 가 있으면 차단 근거, 없으면 phase/stage 라벨을 보여줍니다.
    - 셀 `truncate` → `line-clamp-2` 로 잘림 완화.
  - keeperRuntime 있는 행은 `<KeeperActionButtons compact stopPropagation />`, 아닌 행은 dim `—` placeholder.
- `dashboard/src/components/agent-roster.test.ts`: 행 cast `HTMLButtonElement` → `HTMLElement`, 헤더 라벨 검증을 `현재 단계`/`차단 근거` → `차단 · 단계`/`액션` 로 정정.

## 시각 검증

로컬 `pnpm dev` + Chrome:
- active/paused/offline/derived keeper 각각 `keeperActionVisibility` 정책대로 버튼 set 노출 (예: paused → `재개·종료`, offline → `기동·멈춤·종료`, derived → `기동`).
- 우측 `SELECTED RUNTIME` 에서 운영판정/차단/최근도구 라벨이 빠져 행과 정보가 겹치지 않음.
- `차단 · 단계` 컬럼이 stuck keeper 는 `현재 차단: …`, paused 는 `일시정지 원인: …` 으로 한 컬럼 안에서 의미가 항상 유지됨.

## 테스트

- `pnpm typecheck` PASS
- `pnpm exec vitest run src/components/agent-roster.test.ts` → 23/23
- `pnpm exec vitest run src/components/keeper-action-panel.test.ts` → 10/10
- `pnpm exec eslint` (변경 파일) → 0 errors

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] paused keeper 한 명에게 `재개` 직접 클릭 → 행이 active 로 전환되고 우측 패널 라벨이 따라옴
- [ ] active keeper 행의 `멈춤` 클릭 시 부모 행 selection 이 바뀌지 않는지 (stopPropagation)
- [ ] 키보드: 행 포커스 + Enter/Space 로 선택이 그대로 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)
