### PR TITLE
refactor(keeper): project public tool names through descriptors

### DIFF
--- a/lib/keeper/agent_tool_descriptor_resolution.ml
+++ b/lib/keeper/agent_tool_descriptor_resolution.ml
@@ -22,6 +22,28 @@ let canonical_internal_name_for_tool_name tool_name =
   | None -> Keeper_tool_alias.canonical_internal_name tool_name
 ;;
 
+let public_names_for_internal internal_name =
+  Agent_tool_descriptor.public_descriptors_for_internal internal_name
+  |> List.map (fun descriptor -> descriptor.Agent_tool_descriptor.public_name)
+  |> Keeper_types.dedupe_keep_order
+;;
+
+let public_name_for_internal internal_name =
+  match public_names_for_internal internal_name with
+  | first :: _ -> Some first
+  | [] -> None
+;;
+
+let public_names_for_allowed_internal_names internal_names =
+  let allowed = Hashtbl.create (List.length internal_names) in
+  List.iter (fun internal_name -> Hashtbl.replace allowed internal_name ()) internal_names;
+  Agent_tool_descriptor.public_descriptors
+  |> List.filter (fun (descriptor : Agent_tool_descriptor.t) ->
+    Hashtbl.mem allowed descriptor.internal_name)
+  |> List.map (fun descriptor -> descriptor.Agent_tool_descriptor.public_name)
+  |> Keeper_types.dedupe_keep_order
+;;
+
 let effect_domain_for_tool_name tool_name =
   match descriptor_for_tool_name tool_name with
   | Some descriptor -> descriptor.Agent_tool_descriptor.policy.effect_domain

--- a/lib/keeper/agent_tool_descriptor_resolution.mli
+++ b/lib/keeper/agent_tool_descriptor_resolution.mli
@@ -9,6 +9,12 @@ val descriptor_for_tool_name : string -> Agent_tool_descriptor.t option
 
 val canonical_internal_name_for_tool_name : string -> string option
 
+val public_names_for_internal : string -> string list
+
+val public_name_for_internal : string -> string option
+
+val public_names_for_allowed_internal_names : string list -> string list
+
 val effect_domain_for_tool_name : string -> Tool_catalog.effect_domain option
 
 val capability_has : Tool_capability.kind -> string -> bool

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -661,8 +661,9 @@ let keeper_selection_bm25_prefilter_n = 30
    second alias/group table.
 
    Entries stay keyed by canonical handler names. LLM-visible public aliases
-   such as Execute/SearchFiles project through Keeper_tool_alias below, so retrieval
-   shares one public-alias axis instead of carrying duplicate Execute/SearchFiles rows. *)
+   such as Execute/SearchFiles project through Agent_tool_descriptor_resolution
+   below, so retrieval shares one public-alias axis instead of carrying duplicate
+   Execute/SearchFiles rows. *)
 let tool_search_alias_entries =
   [ "keeper_board_post", "게시판 글 작성 올리기 포스트"
   ; "keeper_board_get", "게시판 글 읽기 조회 확인"
@@ -725,14 +726,21 @@ let tool_search_alias_entries =
   ]
 
 let tool_search_aliases name =
+  let aliases_for_descriptor descriptor =
+    Agent_tool_descriptor.internal_names descriptor
+    |> List.find_map (fun internal_name -> List.assoc_opt internal_name tool_search_alias_entries)
+  in
   let aliases =
     match List.assoc_opt name tool_search_alias_entries with
     | Some _ as found -> found
     | None ->
-        (match Keeper_tool_alias.canonical_internal_name name with
-         | Some canonical when not (String.equal canonical name) ->
-             List.assoc_opt canonical tool_search_alias_entries
-         | _ -> None)
+      (match Agent_tool_descriptor_resolution.descriptor_for_tool_name name with
+       | Some descriptor -> aliases_for_descriptor descriptor
+       | None ->
+         (match Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name name with
+          | Some canonical when not (String.equal canonical name) ->
+            List.assoc_opt canonical tool_search_alias_entries
+          | _ -> None))
   in
   match aliases with
   | Some aliases ->

--- a/lib/keeper/keeper_run_tools_search.ml
+++ b/lib/keeper/keeper_run_tools_search.ml
@@ -11,17 +11,8 @@ let partition_tool_search_hits ~core ~core_always ~allowed ~retrieved ~max_resul
      unconditionally let [keeper_tool_search] return aliases even when
      their backing tool was not permitted for the turn, which would invite
      the model to attempt unregistered tool calls. *)
-  let allowed_internal_set =
-    let tbl = Hashtbl.create (List.length allowed) in
-    List.iter (fun n -> Hashtbl.replace tbl n ()) allowed;
-    tbl
-  in
   let aliases_with_allowed_route =
-    Keeper_tool_alias.public_names ()
-    |> List.filter (fun pub ->
-      match Keeper_tool_alias.route pub with
-      | Some r -> Hashtbl.mem allowed_internal_set r.internal_name
-      | None -> false)
+    Agent_tool_descriptor_resolution.public_names_for_allowed_internal_names allowed
   in
   let allowed = allowed @ aliases_with_allowed_route in
   let allowed_set =

--- a/lib/keeper/keeper_tool_name_projection.ml
+++ b/lib/keeper/keeper_tool_name_projection.ml
@@ -30,20 +30,11 @@ let visible_set visible_tool_names =
 ;;
 
 let public_aliases_for_internal_name internal_name =
-  Keeper_tool_alias.public_names ()
-  |> List.filter (fun public_name ->
-    match Keeper_tool_alias.route public_name with
-    | Some route ->
-      List.exists
-        (String.equal internal_name)
-        (Agent_tool_descriptor.internal_names route.descriptor)
-    | None -> false)
+  Agent_tool_descriptor_resolution.public_names_for_internal internal_name
 ;;
 
 let public_alias_for_internal internal_name =
-  match public_aliases_for_internal_name internal_name with
-  | [] -> None
-  | first :: _ -> Some first
+  Agent_tool_descriptor_resolution.public_name_for_internal internal_name
 ;;
 
 let resolve_model_name ~(visible_tool_names : string list) (name : string) =

--- a/lib/keeper/keeper_tool_selection.ml
+++ b/lib/keeper/keeper_tool_selection.ml
@@ -1,8 +1,47 @@
 (** Keeper_tool_selection - deterministic keeper tool-surface selection. *)
 
 let allow_deterministic_tool ~(query_text : string) (name : string) : bool =
-  let _ = query_text in
-  match name with
+  let query = String.lowercase_ascii query_text in
+  let contains needle =
+    let needle = String.lowercase_ascii needle in
+    let needle_len = String.length needle in
+    let query_len = String.length query in
+    let rec loop i =
+      if i + needle_len > query_len
+      then false
+      else if String.sub query i needle_len = needle
+      then true
+      else loop (i + 1)
+    in
+    needle_len = 0 || loop 0
+  in
+  let source_path_hint =
+    (contains "/" || contains "\\") && (contains ".ml" || contains ".mli" || contains ".")
+  in
+  let source_subject =
+    contains "source"
+    || contains "code"
+    || contains "repo"
+    || contains "repository"
+    || contains "function"
+    || contains "symbol"
+    || contains "class"
+    || source_path_hint
+  in
+  let source_read_intent = (contains "read" || contains "open") && source_subject in
+  let source_navigation_intent =
+    source_subject
+    && (contains "search"
+        || contains "find"
+        || contains "show"
+        || contains "list"
+        || contains "grep"
+        || contains "symbol"
+        || contains "function")
+  in
+  match Keeper_tool_resolution.canonical_tool_name name with
+  | "tool_read_file" -> source_read_intent
+  | "tool_workspace_inspect" | "tool_search_files" -> source_navigation_intent
   | _ -> true
 ;;
 
@@ -15,15 +54,33 @@ let deterministic_prefilter_names
   =
   if selection_limit <= 0
   then []
-  else
-    Agent_sdk.Tool_index.retrieve search_index query_text
-    |> List.filter_map (fun (name, _) ->
+  else (
+    let tool_available name =
+      Agent_sdk.Tool_index.retrieve search_index name
+      |> List.exists (fun (found, _) -> String.equal found name)
+    in
+    let preferred_source_tools =
+      [ (allow_deterministic_tool ~query_text "tool_read_file", [ "tool_read_file"; "ReadFile" ])
+      ; ( allow_deterministic_tool ~query_text "tool_workspace_inspect"
+        , [ "tool_workspace_inspect"; "tool_search_files"; "SearchFiles" ] )
+      ]
+      |> List.concat_map (fun (enabled, names) ->
+        if enabled
+        then List.filter (fun name -> (not (List.mem name core)) && tool_available name) names
+        else [])
+    in
+    let retrieved =
+      Agent_sdk.Tool_index.retrieve search_index query_text
+      |> List.filter_map (fun (name, _) ->
       if List.mem name core
       then None
       else if not (allow_deterministic_tool ~query_text name)
       then None
       else Some name)
+    in
+    Keeper_types.dedupe_keep_order (preferred_source_tools @ retrieved)
     |> List.filteri (fun i _ -> i < selection_limit)
+  )
 ;;
 
 let merge_tool_selection_boundary

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -241,6 +241,26 @@ let test_mcp_context_policy_uses_descriptor_resolution () =
     (Policy.is_keeper_mcp_context_required "mcp__masc__masc_approval_get")
 ;;
 
+let test_public_name_projection_uses_descriptor_resolution () =
+  Alcotest.(check (list string))
+    "tool_execute public projection"
+    [ "Execute" ]
+    (Resolution.public_names_for_internal "tool_execute");
+  Alcotest.(check (list string))
+    "tool_workspace_inspect public projection includes legacy internal"
+    [ "SearchFiles" ]
+    (Resolution.public_names_for_internal "tool_workspace_inspect");
+  Alcotest.(check (option string))
+    "tool_write_file preferred public projection"
+    (Some "WriteFile")
+    (Resolution.public_name_for_internal "tool_write_file");
+  Alcotest.(check (list string))
+    "allowed internal routes project to public names"
+    [ "Execute"; "SearchFiles" ]
+    (Resolution.public_names_for_allowed_internal_names
+       [ "tool_execute"; "tool_search_files" ])
+;;
+
 let test_mutation_boundary_delegates_to_descriptor_policy () =
   let search_input = `Assoc [ "pattern", `String "Agent_tool_descriptor" ] in
   Alcotest.(check bool)
@@ -365,6 +385,10 @@ let () =
             "MCP context policy uses descriptor resolution"
             `Quick
             test_mcp_context_policy_uses_descriptor_resolution
+        ; test_case
+            "public names project through descriptor resolution"
+            `Quick
+            test_public_name_projection_uses_descriptor_resolution
         ; test_case
             "mutation boundary delegates to descriptor policy"
             `Quick

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -498,6 +498,21 @@ let test_tool_search_partition_returns_allowed_core_hits () =
     [] (List.map fst partition.discoverable_hits);
   Alcotest.(check int) "no policy filtering" 0 partition.filtered_by_policy
 
+let test_tool_search_partition_projects_allowed_internal_to_public_alias () =
+  let partition =
+    Keeper_run_tools.partition_tool_search_hits
+      ~core:[ "Execute"; "SearchFiles" ]
+      ~core_always:[]
+      ~allowed:[ "tool_execute"; "tool_search_files" ]
+      ~retrieved:[ "Execute", 1.0; "SearchFiles", 0.9; "ReadFile", 0.8 ]
+      ~max_results:10
+  in
+  Alcotest.(check (list string))
+    "descriptor public aliases are visible when backing internals are allowed"
+    [ "Execute"; "SearchFiles" ]
+    (List.map fst partition.visible_core_hits);
+  Alcotest.(check int) "unbacked public hit is filtered" 1 partition.filtered_by_policy
+
 let test_tool_search_partition_filters_policy_denied_core_hits () =
   let partition =
     Keeper_run_tools.partition_tool_search_hits
@@ -601,6 +616,8 @@ let () =
         test_deterministic_prefilter_surfaces_bash_for_draft_pr_request;
       Alcotest.test_case "tool_search returns allowed core hits" `Quick
         test_tool_search_partition_returns_allowed_core_hits;
+      Alcotest.test_case "tool_search projects allowed internals to public aliases" `Quick
+        test_tool_search_partition_projects_allowed_internal_to_public_alias;
       Alcotest.test_case "tool_search filters denied core hits" `Quick
         test_tool_search_partition_filters_policy_denied_core_hits;
       Alcotest.test_case "tool surface truncation dedupes essential tools" `Quick


### PR DESCRIPTION
Summary: Move public-name projection helpers into Agent_tool_descriptor_resolution, route model-facing name projection/tool-search alias expansion through descriptor resolution, and restore source-tool deterministic prefilter gating so passive source tools are surfaced only for source intent. Tests: ocamlformat --check on touched OCaml files; focused dune build for descriptor registry, tool-name projection, and topk LLM tests; test_agent_tool_descriptor_registry_integrity; test_keeper_tool_name_projection; test_keeper_topk_llm; git diff --check; residue scans for direct Keeper_tool_alias public-name route calls in the migrated modules.