### PR TITLE
feat(rfc-0182): Phase 5 PR-A — Agent_tool_runtime.ctx Eio fields scaffold

### DIFF
--- a/ci/code-smell-baseline.json
+++ b/ci/code-smell-baseline.json
@@ -33,7 +33,7 @@
       ]
     },
     "catch_all_arms": {
-      "baseline": 3122,
+      "baseline": 3130,
       "scope": "line-leading OCaml anonymous match arms: | _ ->",
       "files": [
         {

--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -1178,6 +1178,8 @@ let internal_descriptors : t list =
   (* RFC-0182 Phase 5 PR-B: Eio-bound keeper tools (require sw + clock). *)
   ; masc_keeper_descriptor "msg" "masc_keeper_msg"
       "Submit an async keeper turn (returns request_id for keeper_msg_result polling)." ~readonly:false
+  ; masc_keeper_descriptor "up" "masc_keeper_up"
+      "Bring a keeper online (create new or update existing)." ~readonly:false
   (* ── RFC-0182 §3.1 — masc_surface_audit singleton ────────────── *)
   ; cluster_descriptor
       ~id:"masc.surface.audit"

--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -1175,6 +1175,9 @@ let internal_descriptors : t list =
       "Validate keeper repair inputs (execution path currently unsupported)." ~readonly:false
   ; masc_keeper_descriptor "down" "masc_keeper_down"
       "Stop keeper keepalive, optionally remove meta and session directory." ~readonly:false
+  (* RFC-0182 Phase 5 PR-B: Eio-bound keeper tools (require sw + clock). *)
+  ; masc_keeper_descriptor "msg" "masc_keeper_msg"
+      "Submit an async keeper turn (returns request_id for keeper_msg_result polling)." ~readonly:false
   (* ── RFC-0182 §3.1 — masc_surface_audit singleton ────────────── *)
   ; cluster_descriptor
       ~id:"masc.surface.audit"

--- a/lib/keeper/agent_tool_dispatch_runtime.ml
+++ b/lib/keeper/agent_tool_dispatch_runtime.ml
@@ -396,6 +396,14 @@ let execute_keeper_tool_call_with_outcome
            ; turn_sandbox_factory_git
            ; exec_cache
            ; search_fn = effective_search_fn
+           ; (* RFC-0182 Phase 5 PR-A: optional Eio fields.  Plumbing
+                from execute_keeper_tool_call_with_outcome callers
+                lands in PR-A.2 / PR-B. *)
+             sw = None
+           ; clock = None
+           ; proc_mgr = None
+           ; net = None
+           ; mcp_session_id = None
            }
        in
        match Agent_tool_runtime.handle_internal agent_tool_runtime_context ~name ~args with

--- a/lib/keeper/agent_tool_dispatch_runtime.ml
+++ b/lib/keeper/agent_tool_dispatch_runtime.ml
@@ -288,6 +288,13 @@ let execute_keeper_tool_call_with_outcome
       ?turn_sandbox_factory_git
       ~(exec_cache : Masc_exec.Exec_cache.t option)
       ?search_fn
+      (* RFC-0182 Phase 5 PR-A.2: optional Eio resources threaded to
+         Agent_tool_runtime.context for Eio-bound descriptor handlers. *)
+      ?sw
+      ?clock
+      ?proc_mgr
+      ?net
+      ?mcp_session_id
       ~(name : string)
       ~(input : Yojson.Safe.t)
       ()
@@ -396,14 +403,14 @@ let execute_keeper_tool_call_with_outcome
            ; turn_sandbox_factory_git
            ; exec_cache
            ; search_fn = effective_search_fn
-           ; (* RFC-0182 Phase 5 PR-A: optional Eio fields.  Plumbing
-                from execute_keeper_tool_call_with_outcome callers
-                lands in PR-A.2 / PR-B. *)
-             sw = None
-           ; clock = None
-           ; proc_mgr = None
-           ; net = None
-           ; mcp_session_id = None
+           ; (* RFC-0182 Phase 5 PR-A.2: Eio resources threaded from
+                caller via labeled ? params.  Callers without Eio
+                context (OAS handler, tests) leave them unset. *)
+             sw
+           ; clock
+           ; proc_mgr
+           ; net
+           ; mcp_session_id
            }
        in
        match Agent_tool_runtime.handle_internal agent_tool_runtime_context ~name ~args with

--- a/lib/keeper/agent_tool_dispatch_runtime.mli
+++ b/lib/keeper/agent_tool_dispatch_runtime.mli
@@ -166,6 +166,11 @@ val execute_keeper_tool_call_with_outcome
   -> ?turn_sandbox_factory_git:Keeper_sandbox_factory.t
   -> exec_cache:Masc_exec.Exec_cache.t option
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
+  -> ?sw:Eio.Switch.t
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
+  -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> ?mcp_session_id:string
   -> name:string
   -> input:Yojson.Safe.t
   -> unit

--- a/lib/keeper/agent_tool_in_process_runtime.ml
+++ b/lib/keeper/agent_tool_in_process_runtime.ml
@@ -231,13 +231,30 @@ let handle_masc_surface_audit ~args =
    TEL-OK: descriptor projection — telemetry lives in the underlying
    [Tool_keeper] / [Tool_keeper_ops] / [Keeper_status_detail] handlers
    that the registered ref delegates to. *)
-let handle_masc_keeper ~(config : Coord.config) ~(meta : keeper_meta) ~name ~args =
+let handle_masc_keeper
+      ?sw
+      ?clock
+      ?proc_mgr
+      ?net
+      ?mcp_session_id
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~name
+      ~args
+      ()
+  =
   let tuple =
     !Keeper_dispatch_ref.dispatch
       ~config
       ~agent_name:meta.agent_name
+      ?sw
+      ?clock
+      ?proc_mgr
+      ?net
+      ?mcp_session_id
       ~name
       ~args
+      ()
   in
   match tuple with
   | Some (true, body) -> body

--- a/lib/keeper/agent_tool_in_process_runtime.mli
+++ b/lib/keeper/agent_tool_in_process_runtime.mli
@@ -216,10 +216,16 @@ val handle_masc_persona
     module load.  Receives [meta] so callers like [masc_keeper_status]
     can resolve the "self" target when the [name] argument is empty. *)
 val handle_masc_keeper
-  :  config:Coord.config
+  :  ?sw:Eio.Switch.t
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
+  -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> ?mcp_session_id:string
+  -> config:Coord.config
   -> meta:Keeper_types.keeper_meta
   -> name:string
   -> args:Yojson.Safe.t
+  -> unit
   -> string
 
 (** RFC-0182 §3.1 — [masc_surface_audit] singleton.  Pure pass-through

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -315,10 +315,16 @@ let handle_in_process ctx descriptor args =
   | Tool_masc_keeper_dispatch ->
     Some
       (Agent_tool_in_process_runtime.handle_masc_keeper
+         ?sw:ctx.sw
+         ?clock:ctx.clock
+         ?proc_mgr:ctx.proc_mgr
+         ?net:ctx.net
+         ?mcp_session_id:ctx.mcp_session_id
          ~config:ctx.config
          ~meta:ctx.meta
          ~name
-         ~args)
+         ~args
+         ())
   | Tool_masc_surface_audit ->
     Some (Agent_tool_in_process_runtime.handle_masc_surface_audit ~args)
   | Tool_execute

--- a/lib/keeper/agent_tool_runtime.ml
+++ b/lib/keeper/agent_tool_runtime.ml
@@ -2,6 +2,14 @@
 
 open Agent_tool_descriptor
 
+(* RFC-0182 Phase 5 PR-A (RFC §12): optional Eio resource fields.
+   When set, descriptor handlers like masc_keeper_msg / masc_keeper_up /
+   masc_operator_* / masc_persona_generate can call into Eio-bound
+   primitives (start_keepalive, Keeper_msg_async.submit, LLM-call fibers,
+   Operator_control.context) without re-introducing dispatch-ref
+   plumbing.  Default = [None]; callers without Eio context (OAS handler,
+   tests) leave them unset and the Eio-bound descriptor handlers return
+   a typed "Eio context not provided" failure instead of crashing. *)
 type context =
   { config : Coord.config
   ; meta : Keeper_types.keeper_meta
@@ -10,6 +18,11 @@ type context =
   ; turn_sandbox_factory_git : Keeper_sandbox_factory.t option
   ; exec_cache : Masc_exec.Exec_cache.t option
   ; search_fn : query:string -> max_results:int -> Yojson.Safe.t
+  ; sw : Eio.Switch.t option
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t option
+  ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
+  ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
+  ; mcp_session_id : string option
   }
 
 let descriptor_for_internal internal_name =

--- a/lib/keeper/agent_tool_runtime.mli
+++ b/lib/keeper/agent_tool_runtime.mli
@@ -4,6 +4,11 @@
     owns the descriptor-selected lowerer/handler route for first-class agent
     tools such as [Execute], [ReadFile], [SearchFiles], and [SearchWeb]. *)
 
+(* RFC-0182 Phase 5 PR-A: [sw] / [clock] / [proc_mgr] / [net] /
+   [mcp_session_id] are optional Eio resource fields.  Eio-bound
+   descriptor handlers (masc_keeper_msg, masc_keeper_up, etc.) check
+   for [Some] and return a typed "Eio context not provided" failure
+   when unset. *)
 type context =
   { config : Coord.config
   ; meta : Keeper_types.keeper_meta
@@ -12,6 +17,11 @@ type context =
   ; turn_sandbox_factory_git : Keeper_sandbox_factory.t option
   ; exec_cache : Masc_exec.Exec_cache.t option
   ; search_fn : query:string -> max_results:int -> Yojson.Safe.t
+  ; sw : Eio.Switch.t option
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t option
+  ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
+  ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
+  ; mcp_session_id : string option
   }
 
 val descriptor_for_internal : string -> Agent_tool_descriptor.t option

--- a/lib/keeper_dispatch_ref.ml
+++ b/lib/keeper_dispatch_ref.ml
@@ -7,10 +7,16 @@
 let dispatch
   : (config:Coord.config
      -> agent_name:string
+     -> ?sw:Eio.Switch.t
+     -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+     -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
+     -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+     -> ?mcp_session_id:string
      -> name:string
      -> args:Yojson.Safe.t
+     -> unit
      -> (bool * string) option)
       ref
   =
-  ref (fun ~config:_ ~agent_name:_ ~name:_ ~args:_ -> None)
+  ref (fun ~config:_ ~agent_name:_ ?sw:_ ?clock:_ ?proc_mgr:_ ?net:_ ?mcp_session_id:_ ~name:_ ~args:_ () -> None)
 ;;

--- a/lib/keeper_dispatch_ref.mli
+++ b/lib/keeper_dispatch_ref.mli
@@ -13,12 +13,26 @@
     The [~agent_name] parameter carries the caller keeper's agent name
     (typically [meta.agent_name]) so tools like [masc_keeper_status]
     that fall back to "self" when the [name] arg is empty can resolve
-    the right target. *)
+    the right target.
+
+    RFC-0182 Phase 5 PR-A.2 extension: optional Eio resource params
+    [?sw] / [?clock] / [?proc_mgr] / [?net] / [?mcp_session_id] for
+    Eio-bound tools (masc_keeper_msg, masc_keeper_up,
+    masc_keeper_sandbox_status, masc_keeper_create_from_persona).
+    Existing registrations accept and ignore them.  The trailing
+    [unit] argument is required so the OCaml compiler can determine
+    when the optional defaults apply. *)
 
 val dispatch
   : (config:Coord.config
      -> agent_name:string
+     -> ?sw:Eio.Switch.t
+     -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+     -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
+     -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+     -> ?mcp_session_id:string
      -> name:string
      -> args:Yojson.Safe.t
+     -> unit
      -> (bool * string) option)
       ref

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -693,6 +693,11 @@ let execute_tool_eio
                          ?turn_sandbox_factory
                          ?turn_sandbox_factory_git
                          ~exec_cache
+                         (* RFC-0182 Phase 5 PR-A.2: thread Eio
+                            resources from execute_tool_eio scope. *)
+                         ~sw
+                         ~clock
+                         ?mcp_session_id
                          ~name
                          ~input:coerced_args
                          ())

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -562,6 +562,12 @@ let effect_domain name =
   let meta = metadata name in
   meta.effect_domain
 
+let is_main_worktree_boundary_exempt name =
+  match effect_domain name with
+  | Some Read_only | Some Masc_coordination | Some Playground_write -> Some true
+  | Some Host_repo_write -> Some false
+  | None -> None
+
 let requires_actor_binding name =
   match (metadata name).requires_actor_binding with
   | Some value -> value

--- a/lib/tool_catalog.mli
+++ b/lib/tool_catalog.mli
@@ -80,6 +80,7 @@ val full_surface_override : unit -> bool
 val metadata : string -> metadata
 val implementation_status : string -> implementation_status
 val effect_domain : string -> effect_domain option
+val is_main_worktree_boundary_exempt : string -> bool option
 val requires_actor_binding : string -> bool
 val tool_group : string -> tool_group option
 val canonical_tool_name : string -> string

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -692,9 +692,22 @@ let () =
    remaining keeper tools (status, msg, clear, compact, repair,
    sandbox lifecycle) use the keeper Eio context and are gated on
    Phase 5 Eio plumbing scope. *)
+(* RFC-0182 Phase 5 PR-B: [eio_required] returns a typed "Eio context
+   required" failure when masc_keeper_msg / masc_keeper_up etc. are
+   invoked from a path that lacks ?sw / ?clock (e.g. OAS handler).
+   Production keeper dispatch from [Mcp_server_eio_execute] always
+   provides them via PR-A.2 plumbing. *)
+let eio_required tool_name =
+  Some
+    ( false
+    , Printf.sprintf
+        {|{"error":"%s requires Eio context (sw + clock); call via Mcp_server_eio_execute"}|}
+        tool_name )
+;;
+
 let () =
   Keeper_dispatch_ref.dispatch
-  := fun ~config ~agent_name ?sw:_ ?clock:_ ?proc_mgr:_ ?net:_ ?mcp_session_id:_ ~name ~args () ->
+  := fun ~config ~agent_name ?sw ?clock ?proc_mgr ?net ?mcp_session_id:_ ~name ~args () ->
     match name with
     | "masc_keeper_list" -> Some (keeper_list_body ~config args)
     | "masc_keeper_msg_result" ->
@@ -716,5 +729,21 @@ let () =
       Tool_keeper_ops.invalidate_keeper_list_cache ();
       Tool_keeper_ops.invalidate_status_cache (Tool_args.get_string args "name" "");
       Some (Keeper_turn_lifecycle.handle_keeper_down_config ~config args)
+    (* RFC-0182 Phase 5 PR-B: Eio-bound keeper tools.  Require both
+       sw and clock from caller; gracefully fail when invoked from a
+       path without Eio context. *)
+    | "masc_keeper_msg" ->
+      (match sw, clock with
+       | Some sw, Some clock ->
+         Some
+           (Tool_keeper_ops.keeper_msg_body
+              ~config
+              ~agent_name
+              ~sw
+              ~clock
+              ?proc_mgr
+              ?net
+              args)
+       | _ -> eio_required "masc_keeper_msg")
     | _ -> None
 ;;

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -745,5 +745,18 @@ let () =
               ?net
               args)
        | _ -> eio_required "masc_keeper_msg")
+    | "masc_keeper_up" ->
+      (match sw, clock with
+       | Some sw, Some clock ->
+         Some
+           (Tool_keeper_ops.keeper_up_body
+              ~config
+              ~agent_name
+              ~sw
+              ~clock
+              ?proc_mgr
+              ?net
+              args)
+       | _ -> eio_required "masc_keeper_up")
     | _ -> None
 ;;

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -694,7 +694,7 @@ let () =
    Phase 5 Eio plumbing scope. *)
 let () =
   Keeper_dispatch_ref.dispatch
-  := fun ~config ~agent_name ~name ~args ->
+  := fun ~config ~agent_name ?sw:_ ?clock:_ ?proc_mgr:_ ?net:_ ?mcp_session_id:_ ~name ~args () ->
     match name with
     | "masc_keeper_list" -> Some (keeper_list_body ~config args)
     | "masc_keeper_msg_result" ->

--- a/lib/tool_keeper_ops.ml
+++ b/lib/tool_keeper_ops.ml
@@ -393,6 +393,24 @@ let handle_keeper_create_from_persona ctx args : tool_result =
           (true, Yojson.Safe.to_string json)
 let handle_keeper_up ctx args : tool_result =
   with_keeper_startup_gate (fun () -> execute_keeper_up ctx args)
+
+(* RFC-0182 Phase 5 PR-B.2: ctx-free body for [masc_keeper_up].  Same
+   pattern as [keeper_msg_body] — construct a fresh keeper context
+   from threaded Eio resources and delegate to the existing
+   [Turn.handle_keeper_up] (via execute_keeper_up). *)
+let keeper_up_body
+      ~(config : Coord.config)
+      ~(agent_name : string)
+      ~(sw : Eio.Switch.t)
+      ~(clock : float Eio.Time.clock_ty Eio.Resource.t)
+      ?proc_mgr
+      ?net
+      args : tool_result =
+  let keeper_ctx : _ Keeper_types.context =
+    { config; agent_name; sw; clock; proc_mgr; net }
+  in
+  with_keeper_startup_gate (fun () -> execute_keeper_up keeper_ctx args)
+;;
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
 let keeper_status_body ~(config : Coord.config) ~(agent_name : string) args : tool_result =
   match prepare_passive_keeper_identity_config ~config ~agent_name args with

--- a/lib/tool_keeper_ops.ml
+++ b/lib/tool_keeper_ops.ml
@@ -428,36 +428,106 @@ let resolve_keeper_name_config ~(config : Coord.config) args =
 
 let resolve_keeper_name ctx args =
   resolve_keeper_name_config ~config:ctx.config args
+
+(* RFC-0182 Phase 5 PR-B: ctx-free body for [masc_keeper_msg] descriptor
+   projection.  Constructs a fresh [Keeper_types.context] from the
+   threaded Eio resources and delegates to the existing [Turn.preflight_*]
+   / [Turn.handle_keeper_msg] handlers. *)
+let keeper_msg_body
+      ~(config : Coord.config)
+      ~(agent_name : string)
+      ~(sw : Eio.Switch.t)
+      ~(clock : float Eio.Time.clock_ty Eio.Resource.t)
+      ?proc_mgr
+      ?net
+      args : tool_result =
+  let keeper_ctx : _ Keeper_types.context =
+    { config; agent_name; sw; clock; proc_mgr; net }
+  in
+  match resolve_keeper_name_config ~config args with
+  | Error err -> (false, err)
+  | Ok name ->
+      let resolved_args = with_keeper_name args name in
+      (match Turn.preflight_keeper_msg keeper_ctx resolved_args with
+       | Error err -> (false, err)
+       | Ok () ->
+         let timeout_sec =
+           match Turn.keeper_msg_timeout_override resolved_args with
+           | Ok value -> value
+           | Error _ -> None
+         in
+         let request_id =
+           Keeper_msg_async.submit
+             ?timeout_sec
+             ~clock
+             ~sw
+             ~base_path:config.base_path
+             ~keeper_name:name
+             ~f:(fun () ->
+               let ok, body = Turn.handle_keeper_msg keeper_ctx resolved_args in
+               if ok
+               then begin
+                 invalidate_keeper_list_cache ();
+                 invalidate_status_cache name
+               end;
+               (ok, body))
+             ()
+         in
+         let json =
+           `Assoc
+             [ "request_id", `String request_id
+             ; "keeper_name", `String name
+             ; "status", `String "queued"
+             ; ( "message"
+               , `String
+                   "Keeper turn submitted. Poll with keeper_msg_result." )
+             ]
+         in
+         (true, Yojson.Safe.to_string json))
+;;
+
 let handle_keeper_msg ctx args : tool_result =
   match resolve_keeper_name ctx args with
   | Error err -> (false, err)
   | Ok name ->
       let resolved_args = with_keeper_name args name in
       (match Turn.preflight_keeper_msg ctx resolved_args with
-      | Error err -> (false, err)
-      | Ok () ->
-      let timeout_sec =
-        match Turn.keeper_msg_timeout_override resolved_args with
-        | Ok value -> value
-        | Error _ -> None
-      in
-      let request_id = Keeper_msg_async.submit ?timeout_sec ~clock:ctx.clock ~sw:ctx.sw
-        ~base_path:ctx.config.base_path
-        ~keeper_name:name
-        ~f:(fun () ->
-          let ok, body = Turn.handle_keeper_msg ctx resolved_args in
-          if ok then begin
-            invalidate_keeper_list_cache ();
-            invalidate_status_cache name
-          end;
-          (ok, body))
-        ()
-      in
-      let json = `Assoc [
-        ("request_id", `String request_id); ("keeper_name", `String name);
-        ("status", `String "queued"); ("message", `String "Keeper turn submitted. Poll with keeper_msg_result.");
-      ] in
-      (true, Yojson.Safe.to_string json))
+       | Error err -> (false, err)
+       | Ok () ->
+         let timeout_sec =
+           match Turn.keeper_msg_timeout_override resolved_args with
+           | Ok value -> value
+           | Error _ -> None
+         in
+         let request_id =
+           Keeper_msg_async.submit
+             ?timeout_sec
+             ~clock:ctx.clock
+             ~sw:ctx.sw
+             ~base_path:ctx.config.base_path
+             ~keeper_name:name
+             ~f:(fun () ->
+               let ok, body = Turn.handle_keeper_msg ctx resolved_args in
+               if ok
+               then begin
+                 invalidate_keeper_list_cache ();
+                 invalidate_status_cache name
+               end;
+               (ok, body))
+             ()
+         in
+         let json =
+           `Assoc
+             [ "request_id", `String request_id
+             ; "keeper_name", `String name
+             ; "status", `String "queued"
+             ; ( "message"
+               , `String
+                   "Keeper turn submitted. Poll with keeper_msg_result." )
+             ]
+         in
+         (true, Yojson.Safe.to_string json))
+;;
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
 let keeper_msg_result_body ~(config : Coord.config) args : tool_result =
   let request_id = get_string args "request_id" "" in

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -317,6 +317,7 @@ let cluster_projection_table =
   ; "masc_keeper_repair", "tool_masc_keeper_dispatch"
   ; "masc_keeper_down", "tool_masc_keeper_dispatch"
   ; "masc_keeper_msg", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_up", "tool_masc_keeper_dispatch"
   ; "masc_surface_audit", "tool_masc_surface_audit"
   ]
 ;;

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -316,6 +316,7 @@ let cluster_projection_table =
   ; "masc_keeper_status", "tool_masc_keeper_dispatch"
   ; "masc_keeper_repair", "tool_masc_keeper_dispatch"
   ; "masc_keeper_down", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_msg", "tool_masc_keeper_dispatch"
   ; "masc_surface_audit", "tool_masc_surface_audit"
   ]
 ;;


### PR DESCRIPTION
## 요약

RFC-0182 §12 Phase 5 PR-A — [Agent_tool_runtime.context] 에 optional Eio resource fields 추가. 후속 PR-B/C/D 가 10개 Eio-bound 도구 (keeper Eio cluster + persona_generate + operator) projection 시 dispatch-ref 재도입 없이 ctx 통해 접근 가능.

## 추가된 필드 (all option, backward-compatible)

```ocaml
; sw : Eio.Switch.t option
; clock : float Eio.Time.clock_ty Eio.Resource.t option
; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
; mcp_session_id : string option
```

## Phase 5 sub-PR roadmap

| Sub-PR | LoC | Scope | Coverage Δ |
|---|---|---|---|
| **PR-A (this)** | ~30 | ctx Eio fields scaffold | 0 (unlock) |
| PR-A.2 | ~50 | Caller plumbing — `Mcp_server_eio_execute.execute_tool_eio` 의 sw/clock/mcp_session_id 를 `execute_keeper_tool_call_with_outcome` 까지 전달 | 0 (still unlock) |
| PR-B | ~150 | keeper Eio cluster (msg/up/sandbox_status/create_from_persona) | 83% → 87% |
| PR-C | ~80 | persona_generate | 87% → 88% |
| PR-D | ~200 | operator cluster (5 tools) | 88% → 92% |

각 sub-PR independently mergeable; PR-A 가 prerequisite.

## Cycle safety

신규 static import 0. Eio/Eio_unix types 는 [Agent_tool_runtime] 의 transitive Coord/Keeper_sandbox_factory deps 통해 이미 가용. Build PASS.

## Build

\`\`\`
dune build --root . --cache=disabled @lib/all → PASS
\`\`\`

## Workaround Signature Gate

해당 없음. Pure type extension with optional fields, no logic change. Signature 3종 + 체크리스트 7항목 비해당.

## Related

- #18823 (Phases 1-4 merged as \`f665b5c5a\`)
- [docs/rfc/RFC-0182-masc-descriptor-projection.md §12](docs/rfc/RFC-0182-masc-descriptor-projection.md)