### PR TITLE
fix(tools): expose notes + pr_url on keeper_task_done schema

### DIFF
--- a/lib/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_shard_types_schemas_taskboard.ml
@@ -149,12 +149,14 @@ let taskboard_tools : Masc_domain.tool_schema list =
     }
   ; { name = "keeper_task_done"
     ; description =
-        "Mark your claimed task as complete with a result summary. The task must be \
-         claimed by you. If the task was previously submitted for verification \
-         (keeper_task_submit_for_verification), the result MUST include a pr_url \
-         field linking to the PR or evidence artifact — the call will be rejected \
-         otherwise. For tasks still in progress, use keeper_task_submit_for_verification \
-         first."
+        "Mark your claimed task as complete with a result summary. The task must \
+         be claimed by you. For tasks with a verification contract the call is \
+         routed through Submit_for_verification and the Cdal evidence gate; \
+         supply either (a) pr_url with the draft/open PR URL, or (b) notes \
+         that mention every contract.required_evidence entry verbatim and at \
+         least one concrete artefact reference (file path, PR number, commit \
+         hash, trace id). Pure-placeholder notes ('done', 'ok', etc.) keep \
+         the gate closed. Tasks without a contract bypass the gate."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -173,6 +175,28 @@ let taskboard_tools : Masc_domain.tool_schema list =
                         , `String
                             "What was done: files changed, tests run, outcome observed" )
                       ; "minLength", `Int 1
+                      ] )
+                ; ( "notes"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Verification handoff notes (>= 20 chars). For \
+                             contracted tasks: summarise what changed AND \
+                             mention each contract.required_evidence entry \
+                             verbatim. Ignored when the task has no contract."
+                        )
+                      ] )
+                ; ( "pr_url"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Draft or open PR URL. Hoisted into \
+                             handoff_context.evidence_refs by the transport \
+                             layer; satisfies the Cdal evidence gate for \
+                             contracted tasks."
+                        )
                       ] )
                 ] )
           ; "required", `List [ `String "task_id"; `String "result" ]


### PR DESCRIPTION
## 목표

`keeper_task_done` 스키마-게이트 불일치 해소. 2026-05-26 24h 동안 43건 발생한 "requires verification evidence" reject (8명 keeper 영향) 의 진짜 root.

## 증상

```
[2026-05-27 00:47:42 KST] [Keeper] keeper:sangsu tool_call tool=keeper_task_done params=[task_id,result]
[2026-05-27 00:47:42 KST] [ERROR] tool_error: keeper_task_done — Invalid task state: 
  submit_for_verification requires verification evidence: include pr_url for the draft PR, 
  a PR # reference, or an explicit artifact/file/path/commit/branch reference in notes.
```

LLM keeper의 호출 = `params=[task_id, result]` 만. *현재 schema 가 노출하는 정확히 두 필드*. evidence를 전달할 수단이 없음에도 gate는 거부.

## 진짜 Root

| Layer | 상태 |
|---|---|
| `keeper_task_done` schema (advertised) | `task_id` + `result` 만 |
| description 안내 | "result MUST include a pr_url field" — **거짓** (schema에 pr_url 없음) |
| `handle_done` server code | `notes` 이미 파싱 (tool_task.ml:10) |
| `handle_transition` server code | `pr_url` → `handoff_context.evidence_refs` 자동 hoist (tool_task.ml:85-119) |
| `Cdal_evidence_gate.decide` | `notes` + `handoff_context` 검사, 둘 다 빈 상태 → Reject |

서버는 evidence 필드를 *이미 처리*하지만 schema가 keeper에게 *존재 자체*를 안 알려줌. LLM은 schema에 없는 필드 추가 안 함 → 영구 reject loop.

PR #18822 (RFC-0109 Phase E)는 transition layer의 redundant substring gate를 sunset했지만 이 schema 불일치는 별개 차원. Phase E 이후에도 동일 root로 회귀.

## 변경

`lib/tool_shard_types_schemas_taskboard.ml` 단일 파일, +30/-6 LoC:

1. `keeper_task_done` schema에 optional `notes` + `pr_url` 필드 추가
2. description을 typed Cdal evidence gate 의미와 정합하게 재작성 (2 recovery paths, placeholder rejection)
3. `required` 는 `[task_id, result]` 유지 — non-contracted task backward-compatible

## 검증

| Test suite | Baseline (origin/main) | This PR | Delta |
|---|---|---|---|
| `test_cdal_evidence_gate` | PASS (12/12) | PASS (12/12) | 0 |
| `test_keeper_tool_exposure` | 6 fails (pre-existing, keeper_voice_speak unrelated) | 6 fails | 0 |
| `test_keeper_task_dispatch` | 15 fails (pre-existing) | 15 fails | 0 |
| `test_tool_task_coverage` | 18 fails (pre-existing, Issue #18830 영역) | 18 fails | 0 |

**0 회귀**. dune build PASS.

baseline diff 확인 명령 ([[feedback-test-failure-count-requires-baseline-diff]] 회피):
```bash
git stash -u && dune exec --root . test/<name>.exe 2>&1 | grep failures
git stash pop && dune exec --root . test/<name>.exe 2>&1 | grep failures
```

## 미검증

- 실 fleet 효과 (24h post-merge 빈도 측정 필요). 5/26 baseline = 43건/day, 8명 keeper. 0건 가까이 떨어지면 fix complete; 잔여 있으면 LLM이 schema에도 불구하고 evidence 안 채우는 별개 root (prompt 영역).
- prompt registry에 동일 안내가 있는지 (`base.toml`, `verification.anti_rationalization.md` 등) 미점검. schema-prompt 이중 정합성은 후속.

## 워크어라운드 거부 기준 self-check (CLAUDE.md)

- [x] §1 telemetry-as-fix: counter 추가 0, real schema fix
- [x] §2 substring/prefix 분류기: string match 추가/강화 0
- [x] §3 N-of-M: schema는 SSOT, 단일 사이트
- [x] catch-all `_` 추가 0
- [x] cap/cooldown/dedup/repair 0
- [x] test backdoor 0

## RFC 발견

`docs/rfc/RFC-0109-cdal-goal-integration-contract.md` 영역과 정합. 이 변경은 credential/identity/sandbox subsystem이 아니므로 RFC waiver 불필요. Phase E direction과 일관.

## 후속

머지 + server 재시작 후 24h fleet 측정:
```bash
rg "requires verification evidence" .masc/logs/system_log_$(date +%Y-%m-%d).jsonl | wc -l
```
0건 또는 명확한 감소 = fix 성공. 잔여 시 schema-prompt 불일치 후속 Issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
