### PR TITLE
refactor(tool_result): remove quick constructors

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-27 11:11:22 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-27 11:25:39 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -828,6 +828,12 @@
             <td>Targeted tuple backstop is clean for <code>lib/tool_local_runtime*</code>, <code>keeper_tag_dispatch</code>, and <code>agent_tool_in_process_runtime</code>. Focused Dune remains blocked by the machine-wide bare-Dune guard.</td>
           </tr>
           <tr>
+            <td><code>Tool_result.quick_ok</code> / <code>quick_error</code> compatibility constructors</td>
+            <td><span class="status now">draft PR #18911</span></td>
+            <td>Delete the zero-duration convenience constructors so tests and one-line handlers must choose typed payloads and failure classes explicitly.</td>
+            <td><code>quick_ok</code> / <code>quick_error</code> were removed from the public interface and implementation. Active <code>lib/</code> and <code>test/</code> call sites now use <code>make_ok</code> / <code>make_err</code> or boundary-aware <code>ok</code> / <code>error</code>.</td>
+          </tr>
+          <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
             <td><span class="status done">merged #18369</span></td>
             <td>Remove <code>ckpt-*.json</code> recovery, checkpoint writer/reader public APIs, state-snapshot sidecar hydration, migration wording, and obsolete fallback tests.</td>
@@ -861,10 +867,10 @@
         <tbody>
           <tr>
             <td>1</td>
-            <td><code>Tool_result.quick_ok</code> / <code>quick_error</code> compatibility constructors</td>
-            <td>The quick constructors keep new tests and one-line handlers mentally anchored to message-string construction instead of explicit <code>make_ok</code> / <code>make_err</code> payloads and classes.</td>
-            <td>Replace quick helpers with explicit constructors in tests and tiny handlers; keep only domain helpers that commit the failure class at the call site.</td>
-            <td>Backstop <code>rg "Tool_result\\.quick_(ok|error)" lib test</code>; require new one-line test handlers to name tool and failure class explicitly.</td>
+            <td><code>Keeper_types_profile.tool_result = bool * string</code> and <code>Tool_keeper.typed_result_of_tuple</code></td>
+            <td>The keeper profile axis still preserves the old tuple alias and a central tuple-to-typed adapter, so new keeper handlers can keep emitting unclassified string failures.</td>
+            <td>Move the remaining keeper profile handlers to <code>Tool_result.result</code> and delete the tuple alias / adapter instead of projecting at <code>Tool_keeper.dispatch</code>.</td>
+            <td>Backstop <code>rg "type tool_result = bool \\* string|typed_result_of_tuple|bool \\* string" lib/keeper lib/tool_keeper*</code>; keep unrelated protocol tuples out of the match set.</td>
           </tr>
         </tbody>
       </table>

--- a/docs/rfc/RFC-0189-typed-tool-result-variant.md
+++ b/docs/rfc/RFC-0189-typed-tool-result-variant.md
@@ -179,8 +179,9 @@ server edge last (highest blast radius).
 
 ### 3.3 What's *not* changing in PR-1a
 
-- The legacy record `t` and all its constructors (`ok`, `error`, `of_exn`,
-  `quick_ok`, `quick_error`) remain. Behaviour unchanged.
+- At PR-1a time, the legacy record `t` and all its constructors (`ok`,
+  `error`, `of_exn`, `quick_ok`, `quick_error`) were intentionally left in
+  place. The later PR-2/cleanup path removes that compatibility surface.
 - `classify_from_structured_failure_message` is annotated as "scheduled
   for removal in PR-2" but kept live so the legacy `error` constructor
   observes its current behaviour.

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -118,6 +118,14 @@ let execute_tool_eio
       |> List.map (fun key -> `String key)
     | _ -> []
   in
+  let runtime_error_result ?(tool_name = name) msg =
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Runtime_failure
+      ~start_time:(Time_compat.now ())
+      ~data:(`String msg)
+      msg
+  in
   let with_system_internal_audit ~agent_name (result : Tool_result.result) =
     if is_system_internal_tool
     then (
@@ -145,7 +153,7 @@ let execute_tool_eio
     result
   in
   match mode_gate_error with
-  | Some msg -> with_system_internal_audit ~agent_name (Tool_result.quick_error msg)
+  | Some msg -> with_system_internal_audit ~agent_name (runtime_error_result msg)
   | None ->
     (* Enforce tool authorization when enabled *)
     let auth_enabled = Auth.is_auth_enabled config.base_path in
@@ -163,7 +171,7 @@ let execute_tool_eio
      | Error err ->
        with_system_internal_audit
          ~agent_name
-         (Tool_result.quick_error (Masc_domain.masc_error_to_string err))
+         (runtime_error_result (Masc_domain.masc_error_to_string err))
      | Ok () ->
        let dedupe_string_list values =
          values
@@ -253,13 +261,13 @@ let execute_tool_eio
          else None
        in
        (match init_error with
-        | Some msg -> with_system_internal_audit ~agent_name (Tool_result.quick_error msg)
-          | None ->
-            let is_read_only =
-              Agent_tool_descriptor_resolution.capability_has
-                Tool_capability.Read_only
-                name
-            in
+        | Some msg -> with_system_internal_audit ~agent_name (runtime_error_result msg)
+        | None ->
+          let is_read_only =
+            Agent_tool_descriptor_resolution.capability_has
+              Tool_capability.Read_only
+              name
+          in
           let can_auto_join =
             if (not join_required) || agent_name = "unknown"
             then false
@@ -430,7 +438,7 @@ let execute_tool_eio
               ();
             with_system_internal_audit
               ~agent_name
-              (Tool_result.quick_error
+              (runtime_error_result
                  (Printf.sprintf
                     "MASC room not initialized.\n\n\
                      Fastest: masc_start(path=\"<project>\") — one-step init+join, then \
@@ -451,7 +459,7 @@ let execute_tool_eio
               ();
             with_system_internal_audit
               ~agent_name
-              (Tool_result.quick_error
+              (runtime_error_result
                  (Printf.sprintf
                     "Join required before using %s.\n\n\
                      Fastest: masc_start(path=\"<project>\") — one-step join with room \
@@ -741,7 +749,7 @@ let execute_tool_eio
                | Error reason ->
                  with_system_internal_audit
                    ~agent_name
-                   (Tool_result.quick_error
+                   (runtime_error_result
                       ~tool_name:name
                       (format_unknown_tool_error ~reason))
                | Ok _token ->
@@ -777,7 +785,7 @@ let execute_tool_eio
                     Log.Mcp.warn "registry inconsistency: %s minted but no tag" name;
                     with_system_internal_audit
                       ~agent_name
-                      (Tool_result.quick_error
+                      (runtime_error_result
                          ~tool_name:name
                          (Printf.sprintf "Unknown tool: %s (registry inconsistency)" name)))))))
 ;;

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -135,8 +135,8 @@ let handle_get_metrics ?(tool_name = "masc_get_metrics") ?(start_time = 0.0) ctx
   : Tool_result.result
   =
   (* Original used [let*! target = get_string_required] which
-     wrapped "agent_name is required" via legacy
-     [Tool_result.quick_error] — raw message, no envelope.  Existing
+     wrapped "agent_name is required" as a raw message with no envelope.
+     Existing
      test [test_get_metrics_missing_agent_name] parses
      [result.message] as JSON expecting [status = "error"], i.e.
      it was already broken on the raw-message path.  Promote here

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -270,6 +270,9 @@ let to_oas_typed_result (tr : Tool_result.result) : Agent_sdk.Types.tool_result 
     in
     let recoverable, error_class =
       match Tool_result.failure_class tr with
+      | Some Tool_result.Runtime_failure
+        when json_recoverable || Option.is_some json_error_class ->
+        json_recoverable, json_error_class
       | Some cls ->
         (Tool_result.is_retryable cls, oas_error_class_of_tool_failure_class cls)
       | None -> json_recoverable, json_error_class

--- a/lib/tool_types/tool_args.ml
+++ b/lib/tool_types/tool_args.ml
@@ -144,35 +144,23 @@ let ok_response fields =
 
 (** [Tool_result.result] error from a plain message string. *)
 let error_result ?tool_name ?start_time msg =
-  match (tool_name, start_time) with
-  | Some name, Some t ->
-    Tool_result.error ~tool_name:name ~start_time:t msg
-  | Some name, None ->
-    Tool_result.quick_error ~tool_name:name msg
-  | None, _ ->
-    Tool_result.quick_error msg
+  let tool_name = Option.value ~default:"" tool_name in
+  let start_time = Option.value ~default:(Time_compat.now ()) start_time in
+  Tool_result.error ~tool_name ~start_time msg
 
 (** [Tool_result.result] error with machine-readable error code. *)
 let error_result_typed ?tool_name ?start_time ~code msg =
   let msg_with_code = error_response_typed ~code msg in
-  match (tool_name, start_time) with
-  | Some name, Some t ->
-    Tool_result.error ~tool_name:name ~start_time:t msg_with_code
-  | Some name, None ->
-    Tool_result.quick_error ~tool_name:name msg_with_code
-  | None, _ ->
-    Tool_result.quick_error msg_with_code
+  let tool_name = Option.value ~default:"" tool_name in
+  let start_time = Option.value ~default:(Time_compat.now ()) start_time in
+  Tool_result.error ~tool_name ~start_time msg_with_code
 
 (** [Tool_result.result] success with additional JSON fields. *)
 let ok_result ?tool_name ?start_time fields =
   let msg = ok_response fields in
-  match (tool_name, start_time) with
-  | Some name, Some t ->
-    Tool_result.ok ~tool_name:name ~start_time:t msg
-  | Some name, None ->
-    Tool_result.quick_ok ~tool_name:name msg
-  | None, _ ->
-    Tool_result.quick_ok msg
+  let tool_name = Option.value ~default:"" tool_name in
+  let start_time = Option.value ~default:(Time_compat.now ()) start_time in
+  Tool_result.ok ~tool_name ~start_time msg
 
 (** {1 Parse, Don't Validate — Required Field Extractors}
 
@@ -197,7 +185,10 @@ let get_int_required args key =
 
 (** Monadic bind for [('a, string) Result.t] → [Tool_result.result].
     Chains required field extractions with early error return. *)
-let ( let*! ) r f = match r with Ok v -> f v | Error e -> Tool_result.quick_error e
+let ( let*! ) r f =
+  match r with
+  | Ok v -> f v
+  | Error e -> Tool_result.error ~tool_name:"" ~start_time:(Time_compat.now ()) e
 
 (** {1 Structured Field Validation}
 
@@ -264,13 +255,9 @@ let validation_error_response (errors : field_error list) : string =
 (** Convenience: [Tool_result.result] validation error. *)
 let validation_error_result ?tool_name ?start_time errors =
   let msg = validation_error_response errors in
-  match (tool_name, start_time) with
-  | Some name, Some t ->
-    Tool_result.error ~tool_name:name ~start_time:t msg
-  | Some name, None ->
-    Tool_result.quick_error ~tool_name:name msg
-  | None, _ ->
-    Tool_result.quick_error msg
+  let tool_name = Option.value ~default:"" tool_name in
+  let start_time = Option.value ~default:(Time_compat.now ()) start_time in
+  Tool_result.error ~tool_name ~start_time msg
 
 (** {2 Field Validators}
 

--- a/lib/tool_types/tool_args.mli
+++ b/lib/tool_types/tool_args.mli
@@ -103,8 +103,8 @@ val ok_assoc : (string * Yojson.Safe.t) list -> Yojson.Safe.t
     These return structured {!Tool_result.result} directly, eliminating the
     need for [wrap_result] at the dispatch boundary.  Optional
     [~tool_name] and [~start_time] are forwarded to [Tool_result]
-    constructors; when absent, [quick_ok]/[quick_error] variants are
-    used. *)
+    constructors; absent metadata defaults to an empty tool name and the
+    current timestamp. *)
 
 val error_result : ?tool_name:string -> ?start_time:float -> string -> Tool_result.result
 

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -195,9 +195,9 @@ let is_success : result -> bool = function
 
 (** {1 Constructors}
 
-    Bodies return [result] directly.  Signatures kept identical to the
-    pre-PR-2 [Tool_result.result] versions so existing call sites compile
-    untouched — only the return type widened from record to variant. *)
+    Bodies return [result] directly.  Callers must provide execution
+    metadata at the boundary instead of falling back to zero-duration
+    compatibility constructors. *)
 
 let ok ~tool_name ~start_time message_str : result =
   let end_time = Time_compat.now () in
@@ -244,20 +244,6 @@ let of_exn ?failure_class ~tool_name ~start_time exn : result =
       (Stdlib.Printexc.to_string exn)
   in
   Error { class_; message; data = `String message; tool_name; duration_ms }
-;;
-
-let quick_ok ?(tool_name = "") message_str : result =
-  Ok { data = `String message_str; tool_name; duration_ms = 0.0 }
-;;
-
-let quick_error ?(tool_name = "") message_str : result =
-  Error
-    { class_ = Runtime_failure
-    ; message = message_str
-    ; data = `String message_str
-    ; tool_name
-    ; duration_ms = 0.0
-    }
 ;;
 
 (** {1 Typed constructors (RFC-0189)}

--- a/lib/tool_types/tool_result.mli
+++ b/lib/tool_types/tool_result.mli
@@ -87,11 +87,9 @@ val is_success : result -> bool
 
 (** {1 Handler constructors}
 
-    Direct constructors for [Tool_*.dispatch] functions.  RFC-0189 PR-2
-    kept the signatures of [ok]/[error]/[of_exn]/[quick_ok]/[quick_error]
-    identical to the pre-PR-2 versions so the 285 call sites compile
-    untouched — only the return type widened from the legacy record to
-    the [result] variant. *)
+    Direct constructors for [Tool_*.dispatch] functions.  Callers provide
+    execution metadata at the boundary; zero-duration compatibility
+    constructors have been removed. *)
 
 (** Successful result.  [data] is parsed from the message when it
     contains structured JSON, otherwise [`String message]. *)
@@ -116,16 +114,6 @@ val of_exn
   -> start_time:float
   -> exn
   -> result
-
-(** {1 Test helpers}
-
-    Quick constructors for tests and one-liner handlers.  [duration_ms]
-    is set to [0.0] and [tool_name] defaults to [""].
-
-    @since 2.260.0 *)
-
-val quick_ok : ?tool_name:string -> string -> result
-val quick_error : ?tool_name:string -> string -> result
 
 (** {1 Typed constructors (RFC-0189)}
 

--- a/test/test_agent_tool_dispatch_runtime.ml
+++ b/test/test_agent_tool_dispatch_runtime.ml
@@ -4,6 +4,10 @@ module KET = Masc_mcp.Agent_tool_dispatch_runtime
 module KES = Masc_mcp.Agent_tool_shared_runtime
 module Coord = Masc_mcp.Coord
 
+let tool_ok ?(tool_name = "") message =
+  Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
+;;
+
 let temp_dir prefix =
   let dir = Filename.temp_file prefix "" in
   Unix.unlink dir;
@@ -455,7 +459,7 @@ let register_registered_dispatch_probe () =
     ~tool_name:registered_dispatch_probe_tool
     ~handler:(fun ~name ~args:_ ->
       Some
-        (Tool_result.quick_ok ~tool_name:name
+        (tool_ok ~tool_name:name
            (Yojson.Safe.to_string
               (`Assoc
                 [ ("ok", `Bool true)

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -17,6 +17,10 @@ let goal_transition_drop_input = `Assoc [("action", `String "drop")]
 let goal_transition_operator_block_input = `Assoc [("action", `String "operator_block")]
 let no_args = `Null
 
+let tool_ok ?(tool_name = "") message =
+  Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
+;;
+
 (* ── Helpers ────────────────────────────────────────────────── *)
 
 let make_tmpdir () =
@@ -642,7 +646,7 @@ let test_hook_development_allows () =
   setup ();
   Tool_dispatch.register
     ~tool_name:"__gov_test_delete"
-    ~handler:(fun ~name:_ ~args:_ -> Some (Tool_result.quick_ok "ok"));
+    ~handler:(fun ~name:_ ~args:_ -> Some (tool_ok "ok"));
   let tmpdir = make_tmpdir () in
   let config = Coord.default_config tmpdir in
   let hook = Gp.make_pre_hook ~config ~governance_level:"development" in
@@ -658,7 +662,7 @@ let test_hook_production_blocks_critical () =
   setup ();
   Tool_dispatch.register
     ~tool_name:"__gov_test_delete2"
-    ~handler:(fun ~name:_ ~args:_ -> Some (Tool_result.quick_ok "should not reach"));
+    ~handler:(fun ~name:_ ~args:_ -> Some (tool_ok "should not reach"));
   let tmpdir = make_tmpdir () in
   let config = Coord.default_config tmpdir in
   let hook = Gp.make_pre_hook ~config ~governance_level:"production" in

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -5,6 +5,10 @@ open Agent_sdk
 open Alcotest
 open Masc_mcp
 
+let tool_ok ?(tool_name = "") message =
+  Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
+;;
+
 let ensure_wildcard_repo_mapping config keeper_name =
   let masc_root = Common.masc_dir_from_base_path ~base_path:config.Coord.base_path in
   let config_dir = Filename.concat masc_root "config" in
@@ -502,7 +506,7 @@ let test_oas_tool_callbacks_respect_resource_gate () =
                  (fun () ->
                     Eio.Promise.resolve unblock_blocker ();
                     Eio.Promise.await release_blocker;
-                    Tool_result.quick_ok ~tool_name:"tool_execute" "done")
+                    tool_ok ~tool_name:"tool_execute" "done")
              in
              check bool "blocking shell gate call completed" true (Tool_result.is_success result)
            in

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -14,6 +14,19 @@
 module B = Masc_mcp.Tool_bridge
 module O = Tool_output
 
+let tool_ok ?(tool_name = "") message =
+  Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
+;;
+
+let tool_error ?(tool_name = "") message =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Runtime_failure
+    ~start_time:0.0
+    ~data:(`String message)
+    message
+;;
+
 let with_temp_base_path f =
   let dir = Filename.temp_file "masc_bridge_test" "" in
   Sys.remove dir;
@@ -91,7 +104,7 @@ let test_threshold_env_override () =
 let test_to_oas_typed_small_inlined () =
   Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
   let small = "small ok" in
-  match B.to_oas_typed_result (Tool_result.quick_ok ~tool_name:"test" small) with
+  match B.to_oas_typed_result (tool_ok ~tool_name:"test" small) with
   | Ok { content } ->
       Alcotest.(check string) "inlined verbatim" small content;
       Alcotest.(check bool) "no sentinel" false (O.is_sentinel content)
@@ -99,7 +112,7 @@ let test_to_oas_typed_small_inlined () =
 
 let test_to_oas_typed_error_inlined () =
   Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
-  match B.to_oas_typed_result (Tool_result.quick_error ~tool_name:"test" "fail") with
+  match B.to_oas_typed_result (tool_error ~tool_name:"test" "fail") with
   | Ok _ -> Alcotest.fail "expected Error"
   | Error { message; recoverable; _ } ->
       Alcotest.(check string) "message" "fail" message;
@@ -168,7 +181,7 @@ let test_to_oas_typed_result_preserves_transient_failure_class () =
 let test_round_trip_through_oas () =
   Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
   let payload = String.make 5000 'p' in
-  match B.to_oas_typed_result (Tool_result.quick_ok ~tool_name:"test" payload) with
+  match B.to_oas_typed_result (tool_ok ~tool_name:"test" payload) with
   | Ok { content } ->
       let decoded = O.decode_from_oas content in
       (match decoded with

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -4,6 +4,19 @@ module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Tool_result = Tool_result
 module Types = Masc_domain
 
+let tool_ok ?(tool_name = "") message =
+  Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
+;;
+
+let tool_error ?(tool_name = "") message =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Runtime_failure
+    ~start_time:0.0
+    ~data:(`String message)
+    message
+;;
+
 (** Helper: create a minimal tool_schema for registration. *)
 let make_schema ?(props = []) name =
   let prop_entries =
@@ -16,10 +29,10 @@ let make_schema ?(props = []) name =
       `Assoc [ "type", `String "object"; "properties", `Assoc prop_entries ] }
 
 (** Helper: a handler that returns a successful result with "ok:<name>". *)
-let echo_handler ~name ~args:_ = Some (Tool_result.quick_ok ~tool_name:name ("ok:" ^ name))
+let echo_handler ~name ~args:_ = Some (tool_ok ~tool_name:name ("ok:" ^ name))
 
 (** Helper: a handler that returns (false, "fail"). *)
-let fail_handler ~name:_ ~args:_ = Some (Tool_result.quick_error "fail")
+let fail_handler ~name:_ ~args:_ = Some (tool_error "fail")
 
 (** Helper: register a tool in handler, tag, and schema registries.
     The validation pre-hook is fail-closed for schema-less tools. *)
@@ -157,7 +170,7 @@ let () =
               let received_args = ref `Null in
               let capture_handler ~name:_ ~args =
                 received_args := args;
-                Some (Tool_result.quick_ok "captured")
+                Some (tool_ok "captured")
               in
               register_full
                 ~tool_name:tool

--- a/test/test_tool_hooks.ml
+++ b/test/test_tool_hooks.ml
@@ -10,6 +10,10 @@ let call_log : string list ref = ref []
 let log_call s = call_log := !call_log @ [s]
 let reset_log () = call_log := []
 
+let tool_ok ?(tool_name = "") message =
+  Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
+;;
+
 let setup () =
   reset_log ();
   Tool_dispatch.clear_hooks ()
@@ -22,7 +26,7 @@ let test_pre_hook_observes () =
     ~tool_name:"__hook_test"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (Tool_result.quick_ok "ok"));
+      Some (tool_ok "ok"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_test" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
@@ -40,7 +44,7 @@ let test_pre_hook_short_circuits () =
     ~tool_name:"__hook_blocked"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (Tool_result.quick_ok "should not reach"));
+      Some (tool_ok "should not reach"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_blocked" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name ~args:_ ->
     log_call "pre_block";
@@ -69,7 +73,7 @@ let test_multiple_pre_hooks_first_wins () =
     ~tool_name:"__hook_multi"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (Tool_result.quick_ok "ok"));
+      Some (tool_ok "ok"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_multi" ~tag:Mod_misc;
   (* First hook: observe only *)
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
@@ -104,7 +108,7 @@ let test_dispatch_observer_observes () =
     ~tool_name:"__hook_observer"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (Tool_result.quick_ok "original"));
+      Some (tool_ok "original"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_observer" ~tag:Mod_misc;
   Tool_dispatch.register_dispatch_observer (fun outcome result ->
     match outcome, result with
@@ -123,7 +127,7 @@ let test_result_transformer_transforms () =
   Tool_dispatch.register
     ~tool_name:"__hook_transform"
     ~handler:(fun ~name:_ ~args:_ ->
-      Some (Tool_result.quick_ok "original"));
+      Some (tool_ok "original"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_transform" ~tag:Mod_misc;
   Tool_dispatch.set_result_transformer (fun r ->
     match r with
@@ -142,7 +146,7 @@ let test_dispatch_observers_chain () =
   Tool_dispatch.register
     ~tool_name:"__hook_chain"
     ~handler:(fun ~name:_ ~args:_ ->
-      Some (Tool_result.quick_ok "0"));
+      Some (tool_ok "0"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_chain" ~tag:Mod_misc;
   Tool_dispatch.register_dispatch_observer (fun outcome result ->
     match outcome, result with
@@ -166,7 +170,7 @@ let test_result_transformer_chain_replaces_previous () =
   Tool_dispatch.register
     ~tool_name:"__hook_transform_replace"
     ~handler:(fun ~name:_ ~args:_ ->
-      Some (Tool_result.quick_ok "0"));
+      Some (tool_ok "0"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_transform_replace" ~tag:Mod_misc;
   let with_data (s : string) (r : Tool_result.result) : Tool_result.result =
     match r with
@@ -196,7 +200,7 @@ let test_full_lifecycle () =
     ~tool_name:"__hook_full"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (Tool_result.quick_ok "data"));
+      Some (tool_ok "data"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_full" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
@@ -216,7 +220,7 @@ let test_no_hooks_default () =
   Tool_dispatch.register
     ~tool_name:"__hook_none"
     ~handler:(fun ~name ~args:_ ->
-      Some (Tool_result.quick_ok ~tool_name:name "plain"));
+      Some (tool_ok ~tool_name:name "plain"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_none" ~tag:Mod_misc;
   let token = match Tool_dispatch.mint_token ~name:"__hook_none" with Ok t -> t | Error e -> Alcotest.fail e in
   match Tool_dispatch.guarded_dispatch ~token ~args:`Null () with

--- a/test/test_tool_resource_gate.ml
+++ b/test/test_tool_resource_gate.ml
@@ -2,6 +2,10 @@ open Alcotest
 
 module Gate = Masc_mcp.Tool_resource_gate
 
+let tool_ok ?(tool_name = "") message =
+  Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
+;;
+
 let cls name =
   Gate.For_testing.resource_class_to_string name
 ;;
@@ -137,7 +141,7 @@ let test_gate_rejects_when_lane_is_saturated () =
                (fun () ->
                   Eio.Promise.resolve unblock_blocker ();
                   Eio.Promise.await release_blocker;
-                  Tool_result.quick_ok ~tool_name:"tool_execute" "done")
+                  tool_ok ~tool_name:"tool_execute" "done")
            in
            check bool "blocker succeeded" true (Tool_result.is_success result))
         (fun () ->
@@ -149,7 +153,7 @@ let test_gate_rejects_when_lane_is_saturated () =
                ~arguments:(`Assoc [ "cmd", `String "echo queued" ])
                ~is_read_only:false
                ~start_time:(Eio.Time.now clock)
-               (fun () -> Tool_result.quick_ok ~tool_name:"tool_execute" "ran")
+               (fun () -> tool_ok ~tool_name:"tool_execute" "ran")
            in
            Eio.Promise.resolve resolve_release ();
            check bool "second call rejected while saturated" false (Tool_result.is_success result);
@@ -225,7 +229,7 @@ let test_24_tool_search_files_burst_stays_bounded () =
                         atomic_max max_inflight now;
                         Eio.Time.sleep clock 0.02;
                         ignore (atomic_dec inflight : int);
-                        Tool_result.quick_ok ~tool_name:"tool_execute" "done")
+                        tool_ok ~tool_name:"tool_execute" "done")
                  in
                  if (Tool_result.is_success result) then ignore (atomic_inc successes : int))
              done);
@@ -314,7 +318,7 @@ let test_mixed_24_keeper_burst_stays_bounded () =
                            atomic_max tracker.max_inflight now;
                            Eio.Time.sleep clock 0.02;
                            ignore (atomic_dec tracker.inflight : int);
-                           Tool_result.quick_ok ~tool_name "done")
+                           tool_ok ~tool_name "done")
                     in
                     if (Tool_result.is_success result) then ignore (atomic_inc successes : int)))
                cases);

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -4,6 +4,10 @@ module Tool_result = Tool_result
 module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Time_compat = Time_compat
 
+let tool_ok ?(tool_name = "") message =
+  Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
+;;
+
 let test_ok_json_response () =
   let start = 1000.0 in
   let r =
@@ -184,7 +188,7 @@ let test_message_json_roundtrip () =
 let test_dispatch_structured () =
   (* Register a test handler *)
   Tool_dispatch.register ~tool_name:"__test_tool" ~handler:(fun ~name ~args:_ ->
-    Some (Tool_result.quick_ok ~tool_name:name {|{"result":"ok"}|}));
+    Some (tool_ok ~tool_name:name {|{"result":"ok"}|}));
   Tool_dispatch.register_name_tag ~tool_name:"__test_tool" ~tag:Mod_misc;
   let token =
     match Tool_dispatch.mint_token ~name:"__test_tool" with

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -10,6 +10,10 @@ module Tool_capability = Masc_mcp.Tool_capability
 (** Helper: minimal input_schema for test tools. *)
 let empty_schema = `Assoc [ ("type", `String "object") ]
 
+let tool_ok ?(tool_name = "") message =
+  Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
+;;
+
 let () =
   let open Alcotest in
   run "Tool_spec"
@@ -322,7 +326,7 @@ let () =
                 ~description:"direct handler test"
                 ~module_tag:Tool_dispatch.Mod_misc
                 ~input_schema:empty_schema
-                ~handler_binding:(Direct (fun ~name:_ ~args:_ -> Some (Tool_result.quick_ok "ok")))
+                ~handler_binding:(Direct (fun ~name:_ ~args:_ -> Some (tool_ok "ok")))
                 ()
             in
             Tool_spec.register spec;

--- a/test/test_tool_token.ml
+++ b/test/test_tool_token.ml
@@ -15,6 +15,10 @@ let make_tbl entries =
 let empty_tbl = make_tbl []
 let full_tbl = make_tbl [ "masc_status"; "masc_heartbeat"; "masc_tasks" ]
 
+let tool_ok ?(tool_name = "") message =
+  Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
+;;
+
 (* ================================================================ *)
 (* mint — table variant                                              *)
 (* ================================================================ *)
@@ -81,7 +85,7 @@ let test_token_name_readable () =
 let test_mint_token_registered () =
   let tool = "__test_token_registered" in
   Tool_dispatch.register ~tool_name:tool
-    ~handler:(fun ~name:_ ~args:_ -> Some (Tool_result.quick_ok "ok"));
+    ~handler:(fun ~name:_ ~args:_ -> Some (tool_ok "ok"));
   Tool_dispatch.register_name_tag ~tool_name:tool ~tag:Mod_misc;
   match Tool_dispatch.mint_token ~name:tool with
   | Ok token -> check string "name" tool token.name
@@ -95,7 +99,7 @@ let test_mint_token_unregistered () =
 let test_dispatch_with_token () =
   let tool = "__test_token_dispatch" in
   Tool_dispatch.register ~tool_name:tool
-    ~handler:(fun ~name ~args:_ -> Some (Tool_result.quick_ok ~tool_name:name ("dispatched:" ^ name)));
+    ~handler:(fun ~name ~args:_ -> Some (tool_ok ~tool_name:name ("dispatched:" ^ name)));
   Tool_dispatch.register_name_tag ~tool_name:tool ~tag:Mod_misc;
   match Tool_dispatch.mint_token ~name:tool with
   | Error e -> fail e

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -4,6 +4,10 @@
 open Agent_sdk
 open Masc_mcp
 
+let tool_ok ?(tool_name = "") message =
+  Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
+;;
+
 (* Helper: find tool by name from tool list *)
 let find_tool name tools =
   List.find (fun (t : Tool.t) -> t.schema.name = name) tools
@@ -651,7 +655,7 @@ let test_shell_exec_respects_resource_gate () =
                   (fun () ->
                      Eio.Promise.resolve unblock_blocker ();
                      Eio.Promise.await release_blocker;
-                     Tool_result.quick_ok ~tool_name:"tool_execute" "released")
+                     tool_ok ~tool_name:"tool_execute" "released")
               in
               Alcotest.(check bool) "blocker acquired shell lane" true (Tool_result.is_success result))
            (fun () ->


### PR DESCRIPTION
Summary
- Remove Tool_result.quick_ok / quick_error from the public interface and implementation.
- Replace active lib/test call sites with Tool_result.make_ok / make_err or boundary-aware ok/error helpers.
- Update the legacy purge HTML ledger and move the remaining queue to keeper tuple cleanup.

Validation
- rg "Tool_result\\.quick_(ok|error)|quick_(ok|error)|val quick_(ok|error)|let quick_(ok|error)" lib test -g "!_build/**" (no matches)
- ocamlformat --check touched .ml/.mli files
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- scripts/dune-local.sh build lib/masc_mcp.cma (blocked: machine-wide bare-Dune guard exit 75; not bypassed)

Stack
- Base: #18909 purge/tool-local-runtime-tuples-20260527
- Plan: docs/audit/2026-05-25-legacy-purge-plan.html