### PR TITLE
refactor(dashboard/cost): rename cost-domain formatTokens to formatCostTokens (SSOT)

### DIFF
--- a/dashboard/src/components/cost-dashboard.test.ts
+++ b/dashboard/src/components/cost-dashboard.test.ts
@@ -5,7 +5,7 @@ import {
   auditEntryMatchesLogId,
   auditLogRouteParams,
   auditRouteParams,
-  formatTokens,
+  formatCostTokens,
   isAuditFocus,
   isCostFocus,
   isCostView,
@@ -64,7 +64,7 @@ describe("viewModeForCostFocus", () => {
   })
 })
 
-describe("formatTokens", () => {
+describe("formatCostTokens", () => {
   it.each([
     [0, "0"],
     [999, "999"],
@@ -75,7 +75,7 @@ describe("formatTokens", () => {
     [1_500_000, "1.50M"],
     [2_340_000, "2.34M"],
   ])("formats %d as %s", (n, expected) => {
-    expect(formatTokens(n)).toBe(expected)
+    expect(formatCostTokens(n)).toBe(expected)
   })
 })
 

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -64,7 +64,7 @@ import {
   keeperDecisionsState,
   windowMinutes,
 } from './cost/cost-store'
-import { formatTokens, severityClass } from './cost/cost-formatters'
+import { formatCostTokens, severityClass } from './cost/cost-formatters'
 import {
   severityBuckets,
   auditEntryMatchesLogId,
@@ -85,7 +85,7 @@ export {
   isAuditFocus,
   auditRouteParams,
   auditLogRouteParams,
-  formatTokens,
+  formatCostTokens,
   auditEntryMatchesLogId,
   prioritizeAuditEntriesByLogId,
   summarizeAuditActors,
@@ -359,8 +359,8 @@ function ModelRow({
       <th scope="row" class="px-2 py-1.5 text-left font-mono text-xs text-[var(--color-accent-fg)]">
         ${model.model_id}
       </th>
-      <td class="px-2 py-1.5 text-right font-mono text-xs">${formatTokens(inTok)}</td>
-      <td class="px-2 py-1.5 text-right font-mono text-xs">${formatTokens(outTok)}</td>
+      <td class="px-2 py-1.5 text-right font-mono text-xs">${formatCostTokens(inTok)}</td>
+      <td class="px-2 py-1.5 text-right font-mono text-xs">${formatCostTokens(outTok)}</td>
       <td class="px-2 py-1.5 text-right font-mono text-xs text-[var(--color-accent-fg)]">
         ${formatCost(cost)}
       </td>
@@ -409,8 +409,8 @@ function KeeperRow({
       <th scope="row" class="px-2 py-1.5 text-left font-mono text-xs text-[var(--color-accent-fg)]">
         ${keeper.keeper_name}
       </th>
-      <td class="px-2 py-1.5 text-right font-mono text-xs">${formatTokens(inTok)}</td>
-      <td class="px-2 py-1.5 text-right font-mono text-xs">${formatTokens(outTok)}</td>
+      <td class="px-2 py-1.5 text-right font-mono text-xs">${formatCostTokens(inTok)}</td>
+      <td class="px-2 py-1.5 text-right font-mono text-xs">${formatCostTokens(outTok)}</td>
       <td class="px-2 py-1.5 text-right font-mono text-xs text-[var(--color-accent-fg)]">
         ${formatCost(cost)}
       </td>
@@ -1231,7 +1231,7 @@ function CostDashboardContent({ view }: { view: CostView }) {
             />
             <${StatTile}
               label="Tokens In / Out"
-              value=${`${formatTokens(t.totalIn)} / ${formatTokens(t.totalOut)}`}
+              value=${`${formatCostTokens(t.totalIn)} / ${formatCostTokens(t.totalOut)}`}
               delta=${{ direction: 'flat', text: 'aggregated window' }}
             />
             <${StatTile}

--- a/dashboard/src/components/cost/cost-formatters.ts
+++ b/dashboard/src/components/cost/cost-formatters.ts
@@ -1,7 +1,19 @@
 // RFC-0050 PR-1 — extracted from cost-dashboard.ts.
 // Pure formatting helpers. No render dependencies.
 
-export function formatTokens(n: number): string {
+/**
+ * Cost-domain token count formatter. Distinct from `formatTokens` in
+ * `lib/format-number.ts`:
+ *   - 2-decimal M precision (cost dashboards want finer M-scale resolution)
+ *   - lowercase `k` suffix (matches cost-dashboard column convention)
+ *   - assumes caller passes a finite number (cost rows never feed null)
+ *
+ * Do NOT alias this to `formatTokens` — the two formatters intentionally
+ * diverge. Same name with different output was the SSOT violation that
+ * the 2026-05-27 dashboard SSOT audit closed by renaming this cost-domain
+ * variant.
+ */
+export function formatCostTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
   return `${n}`


### PR DESCRIPTION
## 요약

`formatTokens` 라는 동일 함수명이 두 파일에 서로 다른 동작으로 정의되어 있어, 같은 토큰 값이 surface 별로 다르게 표시되고 있었습니다. cost 도메인 변형만 이름을 `formatCostTokens` 로 분리해 "같은 이름 = 같은 동작" SSOT 룰을 회복합니다.

## 기존 drift 사례

| 입력 | `src/lib/format-number.ts:formatTokens` | `src/components/cost/cost-formatters.ts:formatTokens` |
|---|---|---|
| `null` / `NaN` | `'-'` | 런타임 오류 (시그니처에 null 미포함) |
| `1_234_567` | `'1.2M'` (1 decimal) | `'1.23M'` (2 decimal) |
| `1500` | `'1.5K'` (uppercase) | `'1.5k'` (lowercase) |

같은 데이터(예: 1.2M tokens)가 keeper-detail / agent-roster / cost-dashboard 등 surface 별로 다른 표기로 노출되었고, 호출처 9 + 1 파일 중 어느 것이 어느 구현을 쓰는지 grep 없이는 판단 불가했습니다.

## 변경

- `src/components/cost/cost-formatters.ts`: `formatTokens` → `formatCostTokens` rename + JSDoc 으로 의도적 분기(2-decimal M, lowercase k)와 *왜 별도인지* 명시. `Do NOT alias` 명시해 향후 재중복 차단.
- `src/components/cost-dashboard.ts`: import / re-export / 인라인 호출 5곳 → `formatCostTokens`.
- `src/components/cost-dashboard.test.ts`: import + describe 라벨 + 호출 6 위치 → `formatCostTokens`. 기댓값(`'1.0k'`/`'1.00M'`/`'2.34M'`)은 의미상 동일하므로 그대로 유지.

다른 9개 컴포넌트(`keeper-detail-debug/charts/telemetry/ctx-composition/kpi`, `keeper-config-panel`, `agent-profile`, `agent-roster`, `format-number.test`)는 `lib/format-number.ts:formatTokens` 정상 사용 → 영향 없음.

## 왜 통합이 아니라 rename인가

두 구현을 한쪽으로 통합하면:
- `lib` 으로 통일 → cost-dashboard 가 1자리 소수 M / 대문자 K 로 변경되어 column 가독성 회귀.
- cost 쪽 동작으로 통일 → 9개 컴포넌트가 2자리 소수 / 소문자 k 로 강제 변경 + null 안 들어오면 런타임 위험.

도메인이 의도적으로 다르므로 (precision/casing 선호 차이), **함수명에 도메인을 박는 게 진짜 SSOT 보호**: 같은 이름 → 같은 동작 룰은 살아남고, cost 도메인 표기는 보존됩니다.

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run src/components/cost-dashboard.test.ts`: 37/37
- `pnpm exec eslint src/components/cost/ src/components/cost-dashboard.ts`: 0 errors

Refs: `.tmp/dashboard-ssot-inventory.md` Tier 1 C (`formatTokens` 2 파일 중복).

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] cost-dashboard surface 에서 token 셀 표기가 기존과 동일한지(`1.5k`, `1.23M` 형식 유지) UI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
