### PR TITLE
refactor(dashboard/feature-health): rename statusLabel to featureStatusLabel (SSOT)

### DIFF
--- a/dashboard/src/components/feature-health.test.ts
+++ b/dashboard/src/components/feature-health.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
-import { statusLabel } from './feature-health'
+import { featureStatusLabel } from './feature-health'
 
-describe('statusLabel', () => {
+describe('featureStatusLabel', () => {
   it.each([
     ['healthy', '정상'],
     ['warning', '실험적'],
     ['inactive', '비활성'],
     ['deprecated', '폐기 예정'],
-  ] as const)('statusLabel(%s) → %s', (status, expected) => {
-    expect(statusLabel(status)).toBe(expected)
+  ] as const)('featureStatusLabel(%s) → %s', (status, expected) => {
+    expect(featureStatusLabel(status)).toBe(expected)
   })
 })
 

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -106,7 +106,20 @@ export async function refreshFeatureHealth(): Promise<void> {
   await loadFeatureHealth()
 }
 
-export function statusLabel(status: FeatureStatus): string {
+/**
+ * Feature-health-domain status → 한국어 라벨.
+ *
+ * Distinct from `statusLabel` in `lib/status-label.ts` (which handles every
+ * runtime/agent status enum). FeatureStatus is a closed 4-enum
+ * (`'healthy' | 'warning' | 'inactive' | 'deprecated'`) with feature-flag
+ * semantics — 'warning' here means "실험적 (experimental)", not "경고"
+ * which is what lib/status-label maps it to.
+ *
+ * Renamed from `statusLabel` to `featureStatusLabel` on 2026-05-27 to close
+ * the SSOT collision: same function name with incompatible semantics across
+ * two modules was an operator-confusion source.
+ */
+export function featureStatusLabel(status: FeatureStatus): string {
   switch (status) {
     case 'healthy':
       return '정상'
@@ -138,7 +151,7 @@ function statusChipTone(status: FeatureStatus): FeatureHealthTone {
 
 function StatusPill({ status }: { status: FeatureStatus }) {
   return html`
-    <${StatusChip} tone=${statusChipTone(status)}>${statusLabel(status)}<//>
+    <${StatusChip} tone=${statusChipTone(status)}>${featureStatusLabel(status)}<//>
   `
 }
 


### PR DESCRIPTION
## 요약

같은 함수명 `statusLabel` 이 두 모듈에 서로 다른 시그니처/도메인으로 정의되어 있어 "같은 이름 = 같은 의미" SSOT 명명 규칙을 위반하고 있었습니다. feature-health 도메인 변형을 `featureStatusLabel` 로 rename 하여 collision 을 닫습니다 (iter#3 `formatCostTokens` 패턴 재적용).

## 기존 충돌

| 모듈 | 시그니처 | 도메인 | `'warning'` 매핑 |
|---|---|---|---|
| `src/lib/status-label.ts:statusLabel` | `(value?: string \| null) => string` | 모든 runtime/agent status enum (광역 SSOT) | `"경고"` |
| `src/components/feature-health.ts:statusLabel` | `(status: FeatureStatus) => string` | feature-flag 4-enum 전용 | `"실험적"` |

같은 키 `'warning'` 가 모듈에 따라 완전히 다른 한국어 라벨로 매핑됨. import 사이트에서 어느 도메인인지 grep 없이는 판단 불가. lib SSOT 의 주석은 "Consolidates statusLabel ... from mission-utils, agents, agent-roster, status-badge, helpers, ops/helpers" 라며 단일 진실의 출처임을 명시하고 있었으나, feature-health 의 `statusLabel` 은 그 명명 약속에 편승하지 못한 채 별개 의미로 존재.

## 변경

- `src/components/feature-health.ts`
  - `statusLabel` → `featureStatusLabel` rename
  - JSDoc 으로 lib/status-label 과의 의도적 분리 + `'warning'` → `'실험적'` 시멘틱 근거 명시
  - "Renamed from `statusLabel` to `featureStatusLabel` on 2026-05-27 to close the SSOT collision" 한 줄 박아 재중복 차단
- `src/components/feature-health.test.ts`: import + describe 라벨 + 호출 4 위치 갱신

## 영향 범위

- `statusLabel` 외부 import scope: 정의 모듈의 테스트 1 파일뿐
- 다른 컴포넌트는 `refreshFeatureHealth` / `FeatureHealth` 만 사용 → 영향 없음

## 왜 통합이 아니라 rename 인가

- lib SSOT 로 통합 → `'warning'` 이 `"경고"` 가 되어 feature-flag UI 가 회귀 (`'실험적'` 시멘틱 손실)
- feature-health 쪽으로 통합 → 모든 runtime status enum 이 4-enum 으로 제약되어 광역 SSOT 무너짐

두 함수가 도메인이 진짜 다르므로 *이름 분리* 가 진짜 SSOT 보호. iter#3 의 `formatCostTokens` 패턴과 정확히 동일.

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run src/components/feature-health.test.ts`: 4/4
- `pnpm exec eslint`: 0 errors

라벨 문자열 자체는 동일 — 표면 회귀 없음.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#5 신규 발굴)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] FeatureHealth 패널 4 상태 칩 (`정상`/`실험적`/`비활성`/`폐기 예정`) 표기 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
