### PR TITLE
refactor(dashboard/api): dedupe fetchDashboardNamespaceTruth (SSOT)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -11,7 +11,7 @@ import {
 } from './board'
 import { normalizePendingConfirmation } from '../pending-confirm'
 import { normalizeKeeperTrustTerminalReason } from '../keeper-store-normalize'
-import { currentDashboardActor, get, post, withRetries, NAMESPACE_TRUTH_GET_TIMEOUT_MS } from './core'
+import { currentDashboardActor, get, post, withRetries } from './core'
 import { DEFAULT_WINDOW_MINUTES_24H } from '../config/constants'
 import {
   parseAgentRelationsResponse,
@@ -65,7 +65,6 @@ import type {
   GoalVerificationRequest,
   GoalVerificationSummary,
   GoalVerificationVote,
-  DashboardNamespaceTruthResponse,
   BoardSortMode,
   GovernanceCaseBundle,
   GovernanceDecisionItem,
@@ -249,12 +248,14 @@ export function parseContextThresholds(
   }
 }
 
-export function fetchDashboardNamespaceTruth(opts?: AbortableRequestOptions): Promise<DashboardNamespaceTruthResponse> {
-  return get('/api/v1/dashboard/project-snapshot', {
-    timeoutMs: NAMESPACE_TRUTH_GET_TIMEOUT_MS,
-    signal: opts?.signal,
-  })
-}
+// Re-export from the hot-path API barrel where the SSOT definition lives
+// alongside `fetchDashboardShell` / `fetchDashboardBootstrap` (all three
+// share the same hot/bootstrap consumer profile). Until 2026-05-27 the
+// implementation was duplicated here verbatim, with `namespace-truth-actions`
+// importing the hot variant and `telemetry-unified` / `fleet-telemetry-panel`
+// the dashboard.ts variant — same endpoint, same timeout, two definitions
+// that could drift independently. SSOT now lives in `./dashboard-hot`.
+export { fetchDashboardNamespaceTruth } from './dashboard-hot'
 
 export function fetchDashboardExecution(opts?: AbortableRequestOptions): Promise<DashboardExecutionResponse> {
   return get('/api/v1/dashboard/execution', { signal: opts?.signal })


### PR DESCRIPTION
## 요약

`fetchDashboardNamespaceTruth` 가 `api/dashboard.ts` 와 `api/dashboard-hot.ts` 두 모듈에 **완전 동일** 한 구현으로 정의되어 있고, 호출처가 갈라져서 import 되고 있었습니다. dashboard-hot 를 SSOT 자리로 두고 `dashboard.ts` 는 re-export 로 변경 — 호출처 0 영향.

## 기존 SSOT 위반

```ts
// src/api/dashboard.ts (정의 1)
export function fetchDashboardNamespaceTruth(opts?: AbortableRequestOptions) {
  return get('/api/v1/dashboard/project-snapshot', {
    timeoutMs: NAMESPACE_TRUTH_GET_TIMEOUT_MS,
    signal: opts?.signal,
  })
}

// src/api/dashboard-hot.ts (정의 2 — byte-for-byte 동일)
export function fetchDashboardNamespaceTruth(opts?: AbortableRequestOptions) {
  return get('/api/v1/dashboard/project-snapshot', {
    timeoutMs: NAMESPACE_TRUTH_GET_TIMEOUT_MS,
    signal: opts?.signal,
  })
}
```

호출처 갈라짐:
| 모듈 | import 경로 |
|---|---|
| `namespace-truth-actions.ts` | `from './api/dashboard-hot'` |
| `telemetry-unified.ts` | `from '../api/dashboard'` |
| `fleet-telemetry-panel.ts` | `from '../api/dashboard'` |

같은 endpoint 를 호출하는데 import path 가 분기되어 있어, 한쪽 정의에만 timeout / retry policy 변경이 들어가면 silent drift. grep 없이 1 정의로 보임.

## 왜 dashboard-hot 가 SSOT 인가

`dashboard-hot.ts` 의 다른 두 export 도 같은 패턴:

```text
fetchDashboardShell       → dashboard-hot 에만 정의, store.ts 가 import
fetchDashboardBootstrap   → dashboard-hot 에만 정의, store.ts 가 import
fetchDashboardNamespaceTruth → 두 모듈에 정의 (위반)
```

`fetchDashboardNamespaceTruth` 도 hot/bootstrap consumer profile (project snapshot, NAMESPACE_TRUTH_GET_TIMEOUT_MS timeout). 이미 다른 hot API 와 같은 모듈에 있는 게 자연.

## 변경

- `dashboard.ts:fetchDashboardNamespaceTruth` 함수 본체 삭제 → `export { fetchDashboardNamespaceTruth } from './dashboard-hot'` 로 re-export.
- Unused 가 된 `NAMESPACE_TRUTH_GET_TIMEOUT_MS` import 와 `DashboardNamespaceTruthResponse` type import 정리.
- Re-export 라인 위에 SSOT 위치 변경 이력 + dashboard-hot 가 자리인 이유 주석 박음 (향후 재중복 차단).

호출처 0 영향: `from '../api/dashboard'` import 는 re-export 로 그대로 작동.

## 검증

- `pnpm typecheck` PASS (이전엔 unused import 로 `TS6133`/`TS6196` 두 건 → 정리 후 통과)
- `pnpm exec vitest`: 53/53 (namespace-truth-store + fleet-telemetry-panel + telemetry-unified 3 파일 모두)
- `pnpm exec eslint`: 0 errors

표면 동작 회귀 없음 — 동일 endpoint, timeout, 옵션.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#6 항목, 12 export collision 후보 중 하나)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] telemetry-unified / fleet-telemetry-panel surface 에서 namespace truth fetch 동작 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
