### PR TITLE
refactor(dashboard/transport-health): rename formatLatency to formatLatencyFromSeconds (SSOT)

### DIFF
--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -7,7 +7,7 @@ import {
   formatHitRate,
   formatAvgBufferedBytes,
   shouldRefreshFromEvent,
-  formatLatency,
+  formatLatencyFromSeconds,
   formatFloat,
   formatIdle,
   compactId,
@@ -540,7 +540,7 @@ describe('shouldRefreshFromEvent', () => {
   })
 })
 
-describe('formatLatency', () => {
+describe('formatLatencyFromSeconds', () => {
   it.each([
     [0, '-'],
     [0.0000005, '1us'],
@@ -548,8 +548,8 @@ describe('formatLatency', () => {
     [0.5, '500.0ms'],
     [1.234, '1.23s'],
     [60, '60.00s'],
-  ] as const)('formatLatency(%s) → %s', (input, expected) => {
-    expect(formatLatency(input)).toBe(expected)
+  ] as const)('formatLatencyFromSeconds(%s) → %s', (input, expected) => {
+    expect(formatLatencyFromSeconds(input)).toBe(expected)
   })
 })
 

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -143,7 +143,20 @@ export function shouldRefreshFromEvent(event: SSEEvent): boolean {
   return type.startsWith('client_input_')
 }
 
-export function formatLatency(seconds: number): string {
+/**
+ * Transport-domain latency formatter. Takes **seconds** (raw SSE/gRPC
+ * average values from the dashboard transport metrics).
+ *
+ * Distinct from `formatLatency(ms)` in `fleet-telemetry-utils.ts`, which
+ * takes **milliseconds**. Renamed from `formatLatency` to
+ * `formatLatencyFromSeconds` on 2026-05-27: same function name across the
+ * two modules with *different input units* was a 1000x silent-conversion
+ * trap (calling fleet's variant with a seconds value would format "1.5"
+ * as "1ms" instead of "1.5s"). Variable names like `broadcast_avg_seconds`
+ * carry the unit at the call site; this rename carries it at the function
+ * signature too.
+ */
+export function formatLatencyFromSeconds(seconds: number): string {
   if (seconds === 0) return '-'
   if (seconds < 0.001) return `${(seconds * 1_000_000).toFixed(0)}us`
   if (seconds < 1) return `${(seconds * 1000).toFixed(1)}ms`
@@ -470,7 +483,7 @@ export function TransportHealthPanel() {
                 <${MetricRow} label="릴레이 큐" value=${data.sse.relay_queue_depth} />
                 <${MetricRow} label="릴레이 재시도" value=${data.sse.relay_retry_total} sub=${`append ${data.sse.relay_retry_append} · broadcast ${data.sse.relay_retry_broadcast}`} />
                 <${MetricRow} label="릴레이 드롭" value=${data.sse.relay_drop_total} sub=${`queue ${data.sse.relay_drop_queue} · append ${data.sse.relay_drop_append} · broadcast ${data.sse.relay_drop_broadcast}`} />
-                <${MetricRow} label="브로드캐스트 평균" value=${formatLatency(data.sse.broadcast_avg_seconds)} sub=${`${data.sse.broadcast_count}개 이벤트`} />
+                <${MetricRow} label="브로드캐스트 평균" value=${formatLatencyFromSeconds(data.sse.broadcast_avg_seconds)} sub=${`${data.sse.broadcast_count}개 이벤트`} />
               </div>
             <//>
 
@@ -479,7 +492,7 @@ export function TransportHealthPanel() {
                 <${MetricRow} label="리스너" value=${data.grpc.listening ? '활성' : '중단'} />
                 <${MetricRow} label="구독자" value=${data.grpc.subscribers} />
                 <${MetricRow} label="활성 스트림" value=${data.grpc.active_streams} />
-                <${MetricRow} label="하트비트 평균" value=${formatLatency(data.grpc.heartbeat_avg_seconds)} />
+                <${MetricRow} label="하트비트 평균" value=${formatLatencyFromSeconds(data.grpc.heartbeat_avg_seconds)} />
                 <${MetricRow} label="전달된 이벤트" value=${data.grpc.events_delivered} />
                 <${MetricRow}
                   label="드롭된 이벤트"


### PR DESCRIPTION
## 요약

같은 함수명 `formatLatency` 가 두 모듈에 **서로 다른 입력 단위** 로 정의되어 있어 1000x silent conversion 회귀 가능성이 잠재했습니다. transport-health 변형 (seconds 입력) 을 `formatLatencyFromSeconds` 로 rename 하여 단위를 함수 시그니처에 박습니다. (iter#3 `formatCostTokens` / iter#5 `featureStatusLabel` 패턴 재적용.)

## 기존 SSOT 위반

| 모듈 | 시그니처 | `formatLatency(1.5)` |
|---|---|---|
| `transport-health.ts:146` | `(seconds: number) => string` | `'1.50s'` |
| `fleet-telemetry-utils.ts:539` | `(ms: number) => string` | `'1ms'` (1.5 ms 절삭) |

같은 `formatLatency(1.5)` 호출이 변형에 따라 1000x 다른 값으로 포매팅. 호출 사이트 변수명(`broadcast_avg_seconds` vs `last_latency_ms`)이 단위를 표시하지만 함수 이름 자체엔 단위가 없어 import 사이트 교차 사용 시 silent 회귀 위험.

## 변경

- `transport-health.ts:formatLatency` → `formatLatencyFromSeconds` rename + JSDoc 으로 입력 단위 명시 + fleet 변형과의 의도적 분리 근거 박음.
- 같은 파일 내 2 호출처 (SSE 브로드캐스트 평균 `MetricRow` / gRPC 하트비트 평균 `MetricRow`) 갱신.
- `transport-health.test.ts`: import + describe + 호출 4 위치 갱신.

`fleet-telemetry-utils.ts:formatLatency(ms)` 는 ms 입력의 정상 SSOT 로 그대로 유지 — `fleet-telemetry-panel.ts` (1 호출) + 자체 test (4 호출) 무영향.

## 왜 transport 쪽만 rename 인가

| 모듈 | 변경 사이트 |
|---|---|
| transport-health (seconds) | 정의 1 + 호출 2 + test 4 = 7 — **단일 파일 + 테스트** |
| fleet-telemetry-utils (ms) | 정의 + 호출 (다른 파일) + test = 6+ + import 분기 |

scope 비교 후 transport 쪽 rename 이 최소 침습. fleet 쪽은 ms 가 일반적인 latency 단위 (HTTP/DB) 라 default 유지가 자연.

## 검증

- `pnpm typecheck` PASS — 이전엔 `transport-health.test.ts:10` 의 import 에서 `TS2305: Module has no exported member 'formatLatency'` 로 잡혔고, test 쪽도 함께 갱신 후 통과 (noUnusedLocals + import resolution 둘 다 활용)
- `pnpm exec vitest run transport-health.test + fleet-telemetry-utils.test`: 199/199 (양쪽 도메인 모두)
- `pnpm exec eslint`: 0 errors

라벨/표기 변동 없음 — 표면 회귀 0.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#7 항목)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] transport-health 패널 SSE 브로드캐스트/gRPC 하트비트 평균 latency 표기 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
