### PR TITLE
refactor(dashboard/tools): dedupe filterTools to single SSOT in tool-metrics

### DIFF
--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -37,10 +37,22 @@ export function toolMatchesCategory(
   return toolCategory(item.name).label === category
 }
 
-export function filterTools<T extends Pick<ToolMetricsTopEntry, 'name'>>(
+/**
+ * SSOT for tool list filtering across the dashboard.
+ *
+ * Until 2026-05-27 `tool-quality-panel.ts` defined its own 2-arg variant
+ * (`filterTools(tools, query)`) — a strict subset of this 3-arg variant
+ * with `category` always implicitly `'all'`. Two definitions of the same
+ * operation could drift independently. The category parameter now defaults
+ * to `'all'` so the 2-arg call site keeps working through a re-export from
+ * `tool-quality-panel`, and the generic constraint is loosened to any
+ * `{ name: string }` so both `ToolMetricsTopEntry` and `ToolStat` callers
+ * type-check without coupling to a specific tool schema.
+ */
+export function filterTools<T extends { name: string }>(
   items: T[],
   query: string,
-  category: string,
+  category: string = 'all',
 ): T[] {
   const q = query.trim().toLowerCase()
   if (q === '' && category === 'all') return items

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -114,14 +114,14 @@ const successColor = computed(() => {
 // tool table later moves out of this panel.
 const toolSearchQuery = signal('')
 
-// Re-export from SSOT — identical logic in tool-metrics.ts
-export { toolMatchesSearch } from './tool-metrics'
-
-export function filterTools<T extends Pick<ToolStat, 'name'>>(tools: T[], query: string): T[] {
-  const q = query.trim().toLowerCase()
-  if (q === '') return tools
-  return tools.filter(t => t.name.toLowerCase().includes(q))
-}
+// Re-export from SSOT — identical logic in tool-metrics.ts. As of 2026-05-27,
+// `filterTools` is also re-exported (was previously a duplicate 2-arg
+// implementation here). The SSOT 3-arg variant defaults `category` to
+// `'all'`, so existing 2-arg callers (`filterTools(tools, query)`) keep
+// working through this re-export and the test in `tool-quality-panel.test.ts`
+// imports the same symbol path it always did.
+import { filterTools, toolMatchesSearch } from './tool-metrics'
+export { filterTools, toolMatchesSearch }
 
 function RateGauge({ rate, label }: { rate: number; label: string }) {
   const fillClass = rate >= 95 ? 'bg-[var(--ok-10)]' : rate >= 90 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'


### PR DESCRIPTION
## 요약

`filterTools` 가 `tool-metrics.ts` 와 `tool-quality-panel.ts` 두 모듈에 시그니처가 다른 별도 구현으로 정의되어 있었습니다. tool-quality-panel 의 2-arg variant 는 tool-metrics 의 3-arg variant 에 `category='all'` 을 넣은 동작과 동일했고, 같은 파일에 이미 `toolMatchesSearch` 는 SSOT 재-export 되어 있었으나 `filterTools` 만 빠져 있는 partial dedup 이었습니다.

## 기존 SSOT 위반

```ts
// tool-metrics.ts:40 (SSOT 후보)
export function filterTools<T extends Pick<ToolMetricsTopEntry, 'name'>>(
  items: T[], query: string, category: string,
): T[]

// tool-quality-panel.ts:120 (중복 정의)
export function filterTools<T extends Pick<ToolStat, 'name'>>(
  tools: T[], query: string,
): T[]
```

같은 파일(`tool-quality-panel.ts`) 에 `// Re-export from SSOT — identical logic in tool-metrics.ts` 주석 + `toolMatchesSearch` 재-export 가 이미 있는 상태에서 `filterTools` 만 dedup 누락. 작성자가 SSOT 를 인지하고도 partial 로 끝났던 사례.

## 변경

- `tool-metrics.ts:filterTools`
  - `category` 파라미터 default `'all'` → 2-arg 호출도 가능
  - Generic constraint `T extends Pick<ToolMetricsTopEntry, 'name'>` → `T extends { name: string }` 로 일반화. `ToolStat` 같은 다른 tool 스키마도 같은 SSOT 부담 없이 사용 가능 (어차피 본체는 `name` 만 필요)
  - JSDoc 으로 dedup 경위 + generic loosening 근거 박음 → 향후 재중복 차단
- `tool-quality-panel.ts`
  - 중복 `filterTools` 정의 삭제
  - `import { filterTools, toolMatchesSearch } from './tool-metrics'` + `export { filterTools, toolMatchesSearch }` 로 *파일 내 사용 + 외부 재공급* 둘 다 가능하게 함

## 검증

- `pnpm typecheck` PASS — 1차 시도에서 `TS2304: Cannot find name 'filterTools'` 발생 (file-scope binding 누락). 단순 `export ... from` 은 binding 안 잡힌다는 걸 컴파일러가 즉시 알려줘 `import` + 별도 `export` 분리로 해소
- `pnpm exec vitest run tool-quality-panel.test.ts + tool-metrics.test.ts`: 60/60
- `pnpm exec eslint`: 0 errors

호출 사이트 영향:
- `tool-metrics.ts:190`: 그대로 (`filterTools(data.top_20, query, category)`)
- `tool-quality-panel.ts:156`: 그대로 (`filterTools(tools, query)` → category default 'all' 적용)
- `tool-quality-panel.test.ts`: 무변경 (import path/심볼 그대로, 시그니처 호환)

표면 동작 회귀 없음.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#8 항목)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Tool metrics + Tool quality panel surface 의 필터 동작 회귀 없음 (query/category 두 케이스)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
