### PR TITLE
refactor(dashboard/live-store): rename eventKindLabel to journalEventKindLabel (SSOT)

### DIFF
--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -6,7 +6,7 @@ import {
   liveFilters,
   toggleLiveFilter,
   eventKindColor,
-  eventKindLabel,
+  journalEventKindLabel,
   eventKindTone,
   type LiveFilterKind,
 } from '../../live-store'
@@ -66,7 +66,7 @@ export function ActivityStream() {
               class="activity-item rounded-[var(--r-1)] border border-[var(--color-border-divider)] border-l-2 bg-[var(--color-bg-surface)] px-3.5 py-3 ${eventKindColor(entry)} ${i === 0 ? 'activity-item-new' : ''}"
             >
               <div class="activity-item-head flex items-center gap-2">
-                <${StatusChip} tone=${eventKindTone(entry)}>${eventKindLabel(entry)}<//>
+                <${StatusChip} tone=${eventKindTone(entry)}>${journalEventKindLabel(entry)}<//>
                 <span class="text-xs text-[var(--color-fg-primary)] font-medium">${entry.agent}</span>
                 <span class="text-2xs text-[var(--color-fg-muted)] ml-auto">${formatTimeAgo(entry.timestamp)}</span>
               </div>

--- a/dashboard/src/live-store.test.ts
+++ b/dashboard/src/live-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { eventKindColor, eventKindLabel, eventKindTone } from './live-store'
+import { eventKindColor, journalEventKindLabel, eventKindTone } from './live-store'
 import type { JournalEntry } from './types'
 
 function makeEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {
@@ -72,76 +72,76 @@ describe('eventKindTone', () => {
 })
 
 // ================================================================
-// eventKindLabel
+// journalEventKindLabel
 // ================================================================
 
-describe('eventKindLabel', () => {
+describe('journalEventKindLabel', () => {
   it('returns "broadcast" for broadcast eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'broadcast' }))).toBe('broadcast')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'broadcast' }))).toBe('broadcast')
   })
 
   it('returns "joined" for agent_joined eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'agent_joined' }))).toBe('joined')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'agent_joined' }))).toBe('joined')
   })
 
   it('returns "left" for agent_left eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'agent_left' }))).toBe('left')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'agent_left' }))).toBe('left')
   })
 
   it('returns "task" for task_update eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'task_update' }))).toBe('task')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'task_update' }))).toBe('task')
   })
 
   it('returns "post" for board_post eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'board_post' }))).toBe('post')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'board_post' }))).toBe('post')
   })
 
   it('returns "comment" for board_comment eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'board_comment' }))).toBe('comment')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'board_comment' }))).toBe('comment')
   })
 
   it('returns "deleted" for board_delete eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'board_delete' }))).toBe('deleted')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'board_delete' }))).toBe('deleted')
   })
 
   it('returns "heartbeat" for keeper_heartbeat eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'keeper_heartbeat' }))).toBe('heartbeat')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'keeper_heartbeat' }))).toBe('heartbeat')
   })
 
   it('returns "handoff" for keeper_handoff eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'keeper_handoff' }))).toBe('handoff')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'keeper_handoff' }))).toBe('handoff')
   })
 
   it('returns "compact" for keeper_compaction eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'keeper_compaction' }))).toBe('compact')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'keeper_compaction' }))).toBe('compact')
   })
 
   it('returns "guardrail" for keeper_guardrail eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'keeper_guardrail' }))).toBe('guardrail')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'keeper_guardrail' }))).toBe('guardrail')
   })
 
   it('returns "phase" for keeper_phase_changed eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'keeper_phase_changed' }))).toBe('phase')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'keeper_phase_changed' }))).toBe('phase')
   })
 
   it('falls back to kind-based label for unrecognized eventType', () => {
     // board_vote has no explicit case, falls through to kind-based
-    expect(eventKindLabel(makeEntry({ eventType: 'board_vote', kind: 'board' }))).toBe('board')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'board_vote', kind: 'board' }))).toBe('board')
   })
 
   it('falls back to "task" for tasks kind without matching eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'oas_task', kind: 'tasks' }))).toBe('task')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'oas_task', kind: 'tasks' }))).toBe('task')
   })
 
   it('falls back to "keeper" for keepers kind without matching eventType', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'oas_keeper_snapshot', kind: 'keepers' }))).toBe('keeper')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'oas_keeper_snapshot', kind: 'keepers' }))).toBe('keeper')
   })
 
   it('returns "system" as final fallback', () => {
-    expect(eventKindLabel(makeEntry({ eventType: 'oas_tool' }))).toBe('system')
+    expect(journalEventKindLabel(makeEntry({ eventType: 'oas_tool' }))).toBe('system')
   })
 
   it('returns "system" when both kind and eventType are undefined', () => {
-    expect(eventKindLabel(makeEntry({}))).toBe('system')
+    expect(journalEventKindLabel(makeEntry({}))).toBe('system')
   })
 })

--- a/dashboard/src/live-store.ts
+++ b/dashboard/src/live-store.ts
@@ -217,7 +217,18 @@ export function eventKindTone(entry: JournalEntry): LiveEventKindTone {
   return 'neutral'
 }
 
-export function eventKindLabel(entry: JournalEntry): string {
+/**
+ * Live-journal event kind 짧은 라벨. JournalEntry 의 eventType + kind
+ * 조합을 보고 단일 식별자로 압축한다 (예: `'keeper_heartbeat'` → `'heartbeat'`).
+ *
+ * Distinct from `eventKindLabel(kind: string)` in `activity-graph-groups.ts`,
+ * which is a *generic string → label* mapper for the activity graph. Same
+ * function name but different input shape (JournalEntry object vs raw
+ * string) was an import-site collision hazard. Renamed from `eventKindLabel`
+ * to `journalEventKindLabel` on 2026-05-27 so the live-journal variant
+ * carries its domain at the call site.
+ */
+export function journalEventKindLabel(entry: JournalEntry): string {
   const type = entry.eventType
   if (type === 'broadcast') return 'broadcast'
   if (type === 'agent_joined') return 'joined'


### PR DESCRIPTION
## 요약

같은 함수명 `eventKindLabel` 이 두 모듈에 서로 다른 입력 도메인으로 정의되어 있어 SSOT "같은 이름 = 같은 의미" 룰을 위반. live-journal 변형을 `journalEventKindLabel` 로 rename. (iter#3 `formatCostTokens` / iter#5 `featureStatusLabel` / iter#7 `formatLatencyFromSeconds` / iter#8 `filterTools` 패턴 재적용.)

## 기존 충돌

| 모듈 | 시그니처 | 도메인 |
|---|---|---|
| `live-store.ts:220` | `(entry: JournalEntry) => string` | JournalEntry 객체 → 16 case 매핑 (`'keeper_heartbeat'` → `'heartbeat'` 등) |
| `activity-graph-groups.ts:62` | `(kind: string) => string` | 생 string kind 입력 → generic mapper |

입력 타입(`JournalEntry` 객체 vs `string`)이 달라 import 사이트에서 교차 사용해도 typecheck 가 직접 못 잡는 collision hazard. 함수명 자체엔 도메인 정보가 없어 새 사이트가 잘못된 변형을 부르기 쉬움.

## 변경

- `live-store.ts:eventKindLabel` → `journalEventKindLabel` rename
- JSDoc 으로 activity-graph-groups 변형과의 의도적 분리 + Journal 도메인 특수성 명시
- `live-store.test.ts`: import + describe + 호출 13 위치 갱신
- `components/live/activity-stream.ts`: import + 호출 1 위치 갱신

`activity-graph-groups.ts:eventKindLabel(kind: string)` 는 generic 변형으로 그대로 유지 — 자체 파일 3 호출 + test 무영향.

## 검증 학습 포인트

1차 typecheck 가 `src/components/live/activity-stream.ts:9` 의 multi-line import block 의 두 번째 사이트를 `TS2305: has no exported member 'eventKindLabel'` 로 즉시 노출. 사전 grep 이 multi-line import 를 놓친 케이스를 컴파일러가 자동으로 잡았음 — iter#7 의 `transport-health.test.ts` 사이트 누락 패턴과 동일한 보호 작동.

- `pnpm typecheck` PASS (2차 시도, multi-line import 사이트 보강 후)
- `pnpm exec vitest run live-store.test.ts`: 28/28
- `pnpm exec eslint`: 0 errors

라벨 문자열 그대로 — 표면 회귀 없음.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#9 항목)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Activity Stream surface 의 event kind chip 라벨 회귀 없음 (`broadcast`/`heartbeat`/`compact` 등 16 case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
