### PR TITLE
refactor(dashboard/governance): rename kindLabel to governanceKindLabel (SSOT)

### DIFF
--- a/dashboard/src/components/governance-utils.test.ts
+++ b/dashboard/src/components/governance-utils.test.ts
@@ -3,7 +3,7 @@ import {
   itemKey,
   getSelectedDecision,
   filteredItemsByFilter,
-  kindLabel,
+  governanceKindLabel,
   formatAgeSummary,
 } from './governance-utils'
 import type { GovernanceDecisionItem } from '../types'
@@ -117,17 +117,17 @@ describe('filteredItemsByFilter', () => {
 // serializePreview
 // ================================================================
 
-describe('kindLabel', () => {
+describe('governanceKindLabel', () => {
   it('returns "Case" for case', () => {
-    expect(kindLabel('case')).toBe('Case')
+    expect(governanceKindLabel('case')).toBe('Case')
   })
 
   it('returns "Petition" for petition', () => {
-    expect(kindLabel('petition')).toBe('Petition')
+    expect(governanceKindLabel('petition')).toBe('Petition')
   })
 
   it('returns raw value for unknown', () => {
-    expect(kindLabel('custom')).toBe('custom')
+    expect(governanceKindLabel('custom')).toBe('custom')
   })
 })
 

--- a/dashboard/src/components/governance-utils.ts
+++ b/dashboard/src/components/governance-utils.ts
@@ -36,7 +36,20 @@ export function filteredItemsByFilter(filter: GovernanceFilter, items: Governanc
   }
 }
 
-export function kindLabel(value: string): string {
+/**
+ * Governance-domain kind → 표시용 라벨.
+ *
+ * Distinct from `kindLabel(kind: string)` in `board/board-state.ts`:
+ *   - Governance enum: `'case' | 'petition'` → 영어 capitalize (`'Case'`/`'Petition'`)
+ *   - Board enum: `'direct' | 'automation' | 'system'` → 한국어 (`'직접'` 등)
+ *
+ * 같은 함수명에 *완전히 다른 enum + 다른 출력 언어* 가 매핑되어 있어
+ * import 사이트에서 잘못된 변형을 부르면 governance UI 가 한국어 board
+ * 라벨로 회귀 (또는 그 반대). Renamed from `kindLabel` to
+ * `governanceKindLabel` on 2026-05-27 — 이름에 도메인을 박아 SSOT
+ * collision 폐쇄.
+ */
+export function governanceKindLabel(value: string): string {
   switch (value) {
     case 'case':
       return 'Case'


### PR DESCRIPTION
## 요약

같은 함수명 `kindLabel` 이 두 모듈에 서로 다른 enum + 다른 출력 언어 로 정의되어 SSOT collision. governance 변형을 도메인 명시 이름으로 rename. (iter#3 `formatCostTokens` / iter#5 `featureStatusLabel` / iter#7 `formatLatencyFromSeconds` / iter#8 `filterTools` / iter#9 `journalEventKindLabel` 패턴 재적용.)

## 기존 충돌

| 모듈 | 시그니처 | enum | 출력 언어 |
|---|---|---|---|
| `board/board-state.ts:317` | `(kind: string) => string` | `'direct' \| 'automation' \| 'system'` | 한국어 (`'직접'`/`'자동화'`/`'시스템'`) |
| `governance-utils.ts:39` | `(value: string) => string` | `'case' \| 'petition'` | 영어 capitalize (`'Case'`/`'Petition'`) |

두 함수 모두 `(string): string` 시그니처라 타입 시스템이 collision 을 못 잡음. import 사이트에서 잘못된 변형을 부르면 governance UI 가 한국어 board 라벨로 회귀 (또는 그 반대) 하는 silent fail 가능.

## 변경

- `governance-utils.ts:kindLabel` → `governanceKindLabel` rename + JSDoc 으로 board 변형과의 의도적 분리 명시
- `governance-utils.test.ts`: import + describe + 호출 5 위치 갱신

`board/board-state.ts:kindLabel` 는 board 도메인 SSOT 로 유지 — board-surface / post-detail / board-state.test 외부 사용처 다수, 영향 없음.

## Scope

`governance-utils.kindLabel` 외부 import: `governance-utils.test` 단 1 파일. `governance.ts` / `governance-signals.ts` / `governance-actions.ts` 모두 *다른* 함수만 import 하므로 매우 좁은 변경 → typecheck 가 그 fact 를 컴파일러 차원에서 확인.

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run governance-utils.test.ts + board-state.test.ts`: 52/52 (양쪽 도메인 모두)
- `pnpm exec eslint`: 0 errors

라벨 문자열 그대로 — 표면 회귀 없음.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#10 항목)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Governance surface 의 case/petition chip 라벨 (`Case`/`Petition`) 그대로 노출
- [ ] Board surface 의 direct/automation/system chip 라벨 (`직접`/`자동화`/`시스템`) 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
