### PR TITLE
refactor(keeper): project run tools through descriptors

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -413,8 +413,8 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
   in
   let exact_tool_choice_if_public = function
     | [ name ] ->
-      (match Keeper_tool_alias.route name with
-       | Some _ -> Some (Agent_sdk.Types.Tool name)
+      (match Agent_tool_descriptor.find_public name with
+       | Some _descriptor -> Some (Agent_sdk.Types.Tool name)
        | None -> None)
     | [] | _ :: _ :: _ -> None
   in

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -347,66 +347,52 @@ let prepare_agent_setup
   in
   let universe_set = Keeper_tool_policy.tool_name_set all_tool_names in
   let allowed_exec_names = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
-  (* RFC-0064 Phase 2: Remove aliased internal names from the LLM-visible
-     policy surface. Public aliases are the LLM-visible names; internal
+  (* Descriptor-backed public names are the LLM-visible names; internal
      counterparts are implementation details.
 
-     Order matters: compute [aliased_public_names] against the UNFILTERED
+     Order matters: compute [descriptor_public_names] against the UNFILTERED
      internal allowlist, because tool_policy.toml / presets still express
      allowlists in descriptor/internal names (tool_execute, tool_read_file, ...).
-     Stripping internals before the alias-expansion check would leave
-     [aliased_public_names] empty and drop "Execute"/"ReadFile"/... from the
+     Stripping internals before the descriptor expansion check would leave
+     [descriptor_public_names] empty and drop "Execute"/"ReadFile"/... from the
      visible surface. See PR #14596 review. *)
-  let aliased_internal_names =
-    List.filter_map
-      (fun public ->
-         match Keeper_tool_alias.route public with
-         | Some r -> Some r.internal_name
-         | None -> None)
-      (Keeper_tool_alias.public_names ())
+  let descriptor_internal_names =
+    Agent_tool_descriptor.public_descriptors
+    |> List.concat_map Agent_tool_descriptor.internal_names
+    |> Keeper_types.dedupe_keep_order
   in
-  (* Only include a public alias name when its routed internal target is
+  (* Only include a public name when its descriptor internal target is
      itself in [allowed_exec_names]. Otherwise the public name (e.g. "Execute")
      could let the LLM invoke a tool whose internal handler the current
-     keeper/preset has explicitly excluded — the alias would dispatch to
+     keeper/preset has explicitly excluded — the descriptor would dispatch to
      a registered-but-disallowed tool. See PR #14574 review. *)
-  let allowed_set_for_alias_filter =
-    Keeper_tool_policy.tool_name_set allowed_exec_names
-  in
-  let aliased_public_names =
-    List.filter
-      (fun public ->
-         match Keeper_tool_alias.route public with
-         | Some r ->
-           Keeper_tool_policy.StringSet.mem r.internal_name allowed_set_for_alias_filter
-         | None -> false)
-      (Keeper_tool_alias.public_names ())
-  in
-  (* Now strip the aliased internal names from the LLM-visible surface,
-     after [aliased_public_names] has been computed. *)
-  let allowed_exec_names =
-    List.filter
-      (fun name -> not (List.mem name aliased_internal_names))
+  let descriptor_public_names =
+    Agent_tool_descriptor_resolution.public_names_for_allowed_internal_names
       allowed_exec_names
   in
-  let allowed_exec_names_with_aliases = allowed_exec_names @ aliased_public_names in
+  (* Now strip the descriptor internal names from the LLM-visible surface,
+     after [descriptor_public_names] has been computed. *)
+  let allowed_exec_names =
+    List.filter
+      (fun name -> not (List.mem name descriptor_internal_names))
+      allowed_exec_names
+  in
+  let allowed_exec_names_with_public_descriptors =
+    allowed_exec_names @ descriptor_public_names
+  in
   let allowed_exec_set =
-    let base = Keeper_tool_policy.tool_name_set allowed_exec_names_with_aliases in
+    let base =
+      Keeper_tool_policy.tool_name_set allowed_exec_names_with_public_descriptors
+    in
     Keeper_tool_policy.StringSet.union
       base
       (Keeper_tool_policy.tool_name_set Keeper_tool_registry.core_always_tools)
   in
-  let allowed_public_alias_for_internal internal_name =
-    List.find_map
-      (fun public_name ->
-         match Keeper_tool_alias.route public_name with
-         | Some route
-           when String.equal route.internal_name internal_name
-                && Keeper_tool_policy.StringSet.mem public_name universe_set
-                && Keeper_tool_policy.StringSet.mem public_name allowed_exec_set ->
-           Some public_name
-         | _ -> None)
-      (Keeper_tool_alias.public_names ())
+  let allowed_public_name_for_internal internal_name =
+    Agent_tool_descriptor_resolution.public_names_for_internal internal_name
+    |> List.find_opt (fun public_name ->
+      Keeper_tool_policy.StringSet.mem public_name universe_set
+      && Keeper_tool_policy.StringSet.mem public_name allowed_exec_set)
   in
   let max_tools_per_turn =
     if is_retry
@@ -491,7 +477,7 @@ let prepare_agent_setup
     if Keeper_tool_policy.StringSet.mem name universe_set
        && Keeper_tool_policy.StringSet.mem name allowed_exec_set
     then Some name
-    else allowed_public_alias_for_internal name
+    else allowed_public_name_for_internal name
   in
   let filter_visible_policy_surface names =
     names
@@ -508,7 +494,7 @@ let prepare_agent_setup
              && Keeper_tool_policy.StringSet.mem n allowed_exec_set
            then n :: validated, dropped_names
            else
-             match allowed_public_alias_for_internal n with
+             match allowed_public_name_for_internal n with
              | Some public_name -> public_name :: validated, dropped_names
              | None -> validated, n :: dropped_names)
         raw
@@ -797,20 +783,15 @@ let prepare_agent_setup
       else all_allowed, false
     in
     let last_turn_safe = Keeper_tool_policy.last_turn_safe_tool_names () in
-    (* Mirror allowed_exec_names_with_aliases: only include a public alias
+    (* Mirror allowed_exec_names_with_public_descriptors: only include a public name
        in the last-turn-safe set when its routed internal handler is also
        last-turn-safe. Otherwise the public name could re-introduce a tool
        the policy explicitly excluded from the final turn. PR #14574. *)
-    let safe_set = Keeper_tool_policy.tool_name_set last_turn_safe in
-    let aliased_safe_public =
-      List.filter
-        (fun public ->
-           match Keeper_tool_alias.route public with
-           | Some r -> Keeper_tool_policy.StringSet.mem r.internal_name safe_set
-           | None -> false)
-        (Keeper_tool_alias.public_names ())
+    let descriptor_safe_public_names =
+      Agent_tool_descriptor_resolution.public_names_for_allowed_internal_names
+        last_turn_safe
     in
-    let safe_last_turn_tools = last_turn_safe @ aliased_safe_public in
+    let safe_last_turn_tools = last_turn_safe @ descriptor_safe_public_names in
     let all_allowed =
       if is_last_turn && required_tool_names = []
       then

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -641,6 +641,7 @@ let test_public_alias_projection_uses_core_axis () =
   let core_axis = "lib/core/tool_name_alias_axis.ml" in
   let coord_classify = "lib/coord/coord_task_classify.ml" in
   let keeper_alias = "lib/keeper/keeper_tool_alias.ml" in
+  let run_tools_setup = "lib/keeper/keeper_run_tools_setup.ml" in
   let oas_bundle = "lib/keeper/keeper_tools_oas_bundle.ml" in
   assert_contains "lib/core/dune" "tool_name_alias_axis";
   assert_contains core_axis "public_name = \"Execute\"; internal_name = \"tool_execute\"";
@@ -655,6 +656,12 @@ let test_public_alias_projection_uses_core_axis () =
   assert_not_contains keeper_alias
     ("\"Grep\", { internal_name = \"tool_" ^ "workspace_inspect\"");
   assert_not_contains keeper_alias "\"Grep\", { internal_name = \"tool_search_files\"";
+  assert_contains run_tools_setup "Agent_tool_descriptor.public_descriptors";
+  assert_contains
+    run_tools_setup
+    "Agent_tool_descriptor_resolution.public_names_for_allowed_internal_names";
+  assert_not_contains run_tools_setup "Keeper_tool_alias.public_names";
+  assert_not_contains run_tools_setup "Keeper_tool_alias.route";
   assert_contains oas_bundle "Agent_tool_descriptor.public_descriptors";
   assert_not_contains oas_bundle "Keeper_tool_alias.public_names";
   assert_not_contains oas_bundle "Keeper_tool_alias.route"

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -639,6 +639,7 @@ let test_keeper_semantic_capabilities_use_capability_axis () =
 
 let test_public_alias_projection_uses_core_axis () =
   let core_axis = "lib/core/tool_name_alias_axis.ml" in
+  let agent_surface = "lib/keeper/keeper_agent_tool_surface.ml" in
   let coord_classify = "lib/coord/coord_task_classify.ml" in
   let keeper_alias = "lib/keeper/keeper_tool_alias.ml" in
   let run_tools_setup = "lib/keeper/keeper_run_tools_setup.ml" in
@@ -662,6 +663,8 @@ let test_public_alias_projection_uses_core_axis () =
     "Agent_tool_descriptor_resolution.public_names_for_allowed_internal_names";
   assert_not_contains run_tools_setup "Keeper_tool_alias.public_names";
   assert_not_contains run_tools_setup "Keeper_tool_alias.route";
+  assert_contains agent_surface "Agent_tool_descriptor.find_public";
+  assert_not_contains agent_surface "Keeper_tool_alias.route";
   assert_contains oas_bundle "Agent_tool_descriptor.public_descriptors";
   assert_not_contains oas_bundle "Keeper_tool_alias.public_names";
   assert_not_contains oas_bundle "Keeper_tool_alias.route"


### PR DESCRIPTION
## Summary
- replace `keeper_run_tools_setup` direct `Keeper_tool_alias.public_names` / `Keeper_tool_alias.route` scans with descriptor projection APIs
- keep LLM-visible public-name filtering behavior while making `Agent_tool_descriptor` the owner of public/internal projection
- extend the boundary policy test so run-tools setup cannot reintroduce direct alias-table routing

## Stacking
- Stacked on #18916 (`refactor/purge-legacy-terminal-source-20260527`) because current `origin/main` still has the checkpoint-helper build break that #18916 fixes.
- After #18916 merges, retarget/rebase this PR onto `main`; the intended diff is only `keeper_run_tools_setup.ml` plus the boundary-policy ratchet.

## Validation
- `ocamlformat --check lib/keeper/keeper_run_tools_setup.ml test/test_keeper_sandbox_boundary_policy.ml`
- `git diff --check origin/refactor/purge-legacy-terminal-source-20260527...HEAD`
- `rg -n "Keeper_tool_alias\\.public_names|Keeper_tool_alias\\.route" lib/keeper/keeper_run_tools_setup.ml` (no matches)
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh clean`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_keeper_sandbox_boundary_policy.exe ./test/test_agent_tool_descriptor_registry_integrity.exe`
- `./_build/default/test/test_keeper_sandbox_boundary_policy.exe`
- `./_build/default/test/test_agent_tool_descriptor_registry_integrity.exe`
- `scripts/ci/check-determinism-contract.sh`
- `scripts/code-smell/measure.sh`