### PR TITLE
refactor(dashboard/activity-graph): rename categoryLabel to activityCategoryLabel (SSOT)

### DIFF
--- a/dashboard/src/components/activity-graph-groups.ts
+++ b/dashboard/src/components/activity-graph-groups.ts
@@ -47,7 +47,20 @@ export function categoryForActivityKind(kind: string): ActivityCategory {
   return 'other'
 }
 
-export function categoryLabel(category: ActivityCategory): string {
+/**
+ * Activity-timeline-domain category → 한국어 라벨.
+ *
+ * Distinct from `categoryLabel(cat: ContentCategory)` in `board/board-state.ts`:
+ *   - Activity enum: `'task' | 'session' | 'message' | 'board' | 'governance' | 'lifecycle' | 'other'`
+ *   - Board ContentCategory: `'article' | 'review' | 'notice' | 'system'`
+ *
+ * 두 enum 이 다르므로 타입 시스템이 cross-domain mis-use 는 잡아 주지만,
+ * *이름* 충돌이라 import 사이트 자동완성에서 헷갈리고 새 timeline 카테고리
+ * 도입 시 board 쪽 함수를 잘못 부를 위험. Renamed from `categoryLabel` to
+ * `activityCategoryLabel` on 2026-05-27 — 이름에 도메인을 박아 SSOT
+ * collision 폐쇄.
+ */
+export function activityCategoryLabel(category: ActivityCategory): string {
   switch (category) {
     case 'task': return '태스크'
     case 'session': return '세션'

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -19,7 +19,7 @@ import {
   buildActionTimelineGroups,
   buildCategoryCounts,
   buildRawCategoryCounts,
-  categoryLabel,
+  activityCategoryLabel,
   eventDetail,
   eventKindLabel as activityEventKindLabel,
   type ActionTimelineFilter,
@@ -217,7 +217,7 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
                   <div class="min-w-0 flex-1">
                     <div class="flex flex-wrap items-center gap-2">
                       <span class="inline-flex items-center rounded-[var(--r-0)] border px-2 py-0.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)] ${actionCategoryClass(group)}">
-                        ${categoryLabel(group.category)}
+                        ${activityCategoryLabel(group.category)}
                       </span>
                       ${group.actor ? html`<span class="text-2xs font-medium text-[var(--color-fg-primary)]">${group.actor}</span>` : null}
                       ${group.subjectId ? html`<span class="text-2xs text-[var(--color-fg-muted)] font-mono">${group.subjectId}</span>` : null}


### PR DESCRIPTION
## 요약

같은 함수명 `categoryLabel` 이 activity-graph-groups 와 board/board-state 두 모듈에 정의되어 있어 이름 충돌. 두 enum 이 달라 타입 시스템이 cross-domain mis-use 는 잡지만, 이름 자체가 자동완성/리뷰 가독성을 떨어뜨리고 새 activity timeline 카테고리 도입 시 board 함수를 잘못 부를 위험. activity-timeline 변형을 도메인 명시 이름으로 rename. (iter#3 / 5 / 7 / 8 / 9 / 10 패턴 재적용.)

## 기존 충돌

| 모듈 | 시그니처 | enum |
|---|---|---|
| `activity-graph-groups.ts:50` | `(category: ActivityCategory) => string` | `'task' \| 'session' \| 'message' \| 'board' \| 'governance' \| 'lifecycle' \| 'other'` |
| `board/board-state.ts:222` | `(cat: ContentCategory) => string` | `'article' \| 'review' \| 'notice' \| 'system'` |

## 변경

- `activity-graph-groups.ts:categoryLabel` → `activityCategoryLabel` rename + JSDoc 으로 board 변형과의 의도적 분리 + cross-domain mis-use 방지 근거 명시
- `activity-graph.ts`: import + 호출 1 위치 갱신

`board/board-state.ts:categoryLabel` 는 board 도메인 SSOT 로 유지 — board-surface(2 호출) / board-state.test 외부 사용처 다수, 영향 없음.

## Scope

activity-graph-groups.categoryLabel 외부 import: `activity-graph.ts` 1 곳. activity-graph-groups.test.ts 는 categoryLabel 미사용. 매우 좁은 변경.

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run activity-graph-groups.test.ts + board-state.test.ts`: 40/40 (양쪽 도메인)
- `pnpm exec eslint`: 0 errors

라벨 문자열 그대로 — 표면 회귀 없음.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#11 항목)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Activity graph surface 의 category 라벨 (`태스크`/`세션`/`메시지`/`보드`/`거버넌스`/`라이프사이클`/`기타`) 회귀 없음
- [ ] Board surface 의 카테고리 라벨 (`알림/상태`/`시스템` 등) 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
