### PR TITLE
refactor(keeper): project agent surface exact choice through descriptors

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -413,8 +413,8 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
   in
   let exact_tool_choice_if_public = function
     | [ name ] ->
-      (match Keeper_tool_alias.route name with
-       | Some _ -> Some (Agent_sdk.Types.Tool name)
+      (match Agent_tool_descriptor.find_public name with
+       | Some _descriptor -> Some (Agent_sdk.Types.Tool name)
        | None -> None)
     | [] | _ :: _ :: _ -> None
   in

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -639,6 +639,7 @@ let test_keeper_semantic_capabilities_use_capability_axis () =
 
 let test_public_alias_projection_uses_core_axis () =
   let core_axis = "lib/core/tool_name_alias_axis.ml" in
+  let agent_surface = "lib/keeper/keeper_agent_tool_surface.ml" in
   let coord_classify = "lib/coord/coord_task_classify.ml" in
   let keeper_alias = "lib/keeper/keeper_tool_alias.ml" in
   let run_tools_setup = "lib/keeper/keeper_run_tools_setup.ml" in
@@ -662,6 +663,8 @@ let test_public_alias_projection_uses_core_axis () =
     "Agent_tool_descriptor_resolution.public_names_for_allowed_internal_names";
   assert_not_contains run_tools_setup "Keeper_tool_alias.public_names";
   assert_not_contains run_tools_setup "Keeper_tool_alias.route";
+  assert_contains agent_surface "Agent_tool_descriptor.find_public";
+  assert_not_contains agent_surface "Keeper_tool_alias.route";
   assert_contains oas_bundle "Agent_tool_descriptor.public_descriptors";
   assert_not_contains oas_bundle "Keeper_tool_alias.public_names";
   assert_not_contains oas_bundle "Keeper_tool_alias.route"


### PR DESCRIPTION
## Summary
- replace `keeper_agent_tool_surface` exact-tool public-name check from `Keeper_tool_alias.route` to `Agent_tool_descriptor.find_public`
- keep exact tool forcing limited to descriptor-backed public names
- extend the public alias projection boundary test so this surface cannot reintroduce direct alias route checks

## Stacking
- Stacked on #18924 (`refactor/run-tools-descriptor-projection-20260527`), which is stacked on #18916.
- After #18916 and #18924 merge, retarget/rebase this PR onto `main`; intended diff is only `keeper_agent_tool_surface.ml` plus the boundary-policy ratchet.

## Validation
- `ocamlformat --check lib/keeper/keeper_agent_tool_surface.ml test/test_keeper_sandbox_boundary_policy.ml`
- `git diff --check origin/refactor/run-tools-descriptor-projection-20260527...HEAD`
- `rg -n "Keeper_tool_alias\\.route|Keeper_tool_alias\\.public_names" lib/keeper/keeper_agent_tool_surface.ml` (no matches)
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_keeper_sandbox_boundary_policy.exe`
- `./_build/default/test/test_keeper_sandbox_boundary_policy.exe`