### PR TITLE
refactor(dashboard/activity-graph): rename eventKindLabel to activityEventKindLabel (SSOT symmetry)

### DIFF
--- a/dashboard/src/components/activity-graph-groups.ts
+++ b/dashboard/src/components/activity-graph-groups.ts
@@ -59,7 +59,18 @@ export function categoryLabel(category: ActivityCategory): string {
   }
 }
 
-export function eventKindLabel(kind: string): string {
+/**
+ * Activity-timeline-domain event kind (`'agent.joined'` / `'task.done'` 등
+ * dot-namespaced raw kind string) → 한국어 라벨.
+ *
+ * Distinct from `journalEventKindLabel(entry: JournalEntry)` in
+ * `live-store.ts` (iter#9 rename). 입력 타입과 입력 공간이 완전히 다르고
+ * 매핑하는 enum 도 다르다. 두 변형이 같은 이름 `eventKindLabel` 일 때 import
+ * 사이트가 별칭 (`eventKindLabel as activityEventKindLabel`) 으로 회피하던
+ * 패턴 자체가 SSOT 위반 시그널이었음 — 정의에 도메인을 박아 별칭을 제거.
+ * Renamed from `eventKindLabel` to `activityEventKindLabel` on 2026-05-27.
+ */
+export function activityEventKindLabel(kind: string): string {
   switch (kind) {
     case 'agent.joined': return '입장'
     case 'agent.left': return '퇴장'
@@ -208,7 +219,7 @@ function canMergeGroup(group: MutableGroup, event: ActivityGraphTimelineEvent): 
 function sequenceSummary(events: ActivityGraphTimelineEvent[]): string {
   const labels: string[] = []
   for (const event of events) {
-    const label = eventKindLabel(event.kind)
+    const label = activityEventKindLabel(event.kind)
     if (labels[labels.length - 1] !== label) labels.push(label)
   }
   return labels.join(' -> ')
@@ -247,9 +258,9 @@ function groupTitle(category: ActivityCategory, events: ActivityGraphTimelineEve
     case 'governance':
       return subjectId || '거버넌스 활동'
     case 'lifecycle':
-      return actor || eventKindLabel(latest.kind)
+      return actor || activityEventKindLabel(latest.kind)
     default:
-      return subjectId || eventKindLabel(latest.kind)
+      return subjectId || activityEventKindLabel(latest.kind)
   }
 }
 

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -21,7 +21,7 @@ import {
   buildRawCategoryCounts,
   categoryLabel,
   eventDetail,
-  eventKindLabel as activityEventKindLabel,
+  activityEventKindLabel,
   type ActionTimelineFilter,
 } from './activity-graph-groups'
 import { registerActivityRefresh } from '../sse-store'


### PR DESCRIPTION
## 요약

iter#9 (PR #18921) 의 대칭 작업. `live-store.ts:eventKindLabel` 을 `journalEventKindLabel` 로 닫은 직후부터 `activity-graph-groups.ts` 쪽 변형은 그대로 남아 있었고, 호출처 (`activity-graph.ts`) 가 `eventKindLabel as activityEventKindLabel` *별칭 회피* 로 collision 을 우회하고 있었습니다. 별칭 회피 패턴 자체가 "정의에 도메인이 빠져 있다" 는 SSOT 위반 시그널 — 정의에 도메인을 박아 별칭을 제거합니다.

## 기존 상태 (post-iter#9)

| 모듈 | 시그니처 | 도메인 |
|---|---|---|
| `live-store.ts:journalEventKindLabel` | `(entry: JournalEntry) => string` | iter#9 에서 rename 완료 |
| `activity-graph-groups.ts:eventKindLabel` | `(kind: string) => string` | 정의 그대로, 외부에서 `as activityEventKindLabel` 별칭으로만 호출 |

```ts
// activity-graph.ts (호출 사이트가 collision 회피를 별칭으로 처리하고 있었음)
import {
  ...
  eventKindLabel as activityEventKindLabel,
  ...
} from './activity-graph-groups'
```

## 변경

- `activity-graph-groups.ts:eventKindLabel` → `activityEventKindLabel` rename + JSDoc 으로 journalEventKindLabel 과의 의도적 분리 + 별칭 회피 패턴 제거 이유 명시
- 같은 파일 내 호출 3 곳 (`buildActionTimelineGroups` L211, label fallback L250/L252) 갱신
- `activity-graph.ts`: `eventKindLabel as activityEventKindLabel` import alias → `activityEventKindLabel` 직접 import. 별칭 회피 제거 후 import block 더 cleaner

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run activity-graph-groups.test.ts + live-store.test.ts`: 37/37 (양쪽 도메인)
- `pnpm exec eslint`: 0 errors

라벨 문자열 그대로 — 표면 회귀 없음.

Refs:
- `.tmp/dashboard-ssot-inventory.md` (iter#12)
- iter#9 PR #18921 (대칭 작업)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Activity graph timeline event 라벨 (`입장`/`퇴장`/`스폰`/`핸드오프`/`브로드캐스트`/`멘션`/`생성`/`완료` 등) 회귀 없음
- [ ] Live activity stream 의 journal event 라벨 (`heartbeat`/`compact`/`handoff` 등) 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
