### PR TITLE
refactor(dashboard/keeper-detail): drop trustDispositionLabel alias by fixing local-var shadow

### DIFF
--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -12,7 +12,7 @@ import { formatDuration } from './mission-utils'
 import type { Keeper } from '../types'
 import { StrongSecondary, RuntimeBadge } from './keeper-detail-primitives'
 import {
-  trustDispositionLabel as resolveTrustDispositionLabel,
+  trustDispositionLabel,
   computeKeeperVerdict,
   isTurnTerminalFailureCode,
   type KeeperVerdict,
@@ -480,7 +480,9 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
           : 'bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)]'
   // Inline 4-entry copy moved to `./fsm-hub-types` so the same map
   // doesn't drift between this surface and `goals/goal-tree.ts:194`.
-  const trustDispositionLabel = resolveTrustDispositionLabel(trustDisposition)
+  // Local result var keeps a different name from the imported function so
+  // there's no need for an `as resolveTrustDispositionLabel` alias.
+  const trustDispositionDisplay = trustDispositionLabel(trustDisposition)
 
   return html`
     <div class="px-6 pt-4">
@@ -590,7 +592,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         ${trustDisposition
           ? html`
               <span class="inline-flex items-center rounded-[var(--r-0)] px-2 py-0.5 text-2xs font-semibold ${trustToneClass}">
-                검증 ${trustDispositionLabel}
+                검증 ${trustDispositionDisplay}
               </span>
             `
           : null}


### PR DESCRIPTION
## 요약

`keeper-detail-alert-strip.ts` 가 `trustDispositionLabel as resolveTrustDispositionLabel` 별칭 import 로 SSOT 함수를 받고 있었습니다. iter#12 인사이트 ("import X as Y 별칭 회피 패턴 자체가 SSOT 위반 광고판") 적용 — 별칭의 *진짜 원인* 을 찾아 닫습니다.

## 원인 진단

iter#9 (`journalEventKindLabel`) / iter#12 (`activityEventKindLabel`) 의 진짜 *도메인 collision* 과 패턴이 다릅니다. 정의 쪽 collision 이 아니라 **호출 사이트 local variable shadowing**:

```ts
// keeper-detail-alert-strip.ts 기존
import { trustDispositionLabel as resolveTrustDispositionLabel, ... } from './fsm-hub-types'
// ...
const trustDispositionLabel = resolveTrustDispositionLabel(trustDisposition)  // L483: 로컬 변수와 import 함수 이름 충돌
// ...
${trustDispositionLabel}  // L593
```

정의 (`fsm-hub-types.ts:trustDispositionLabel`) 는 적절한 도메인 이름. alias 가 *함수에 도메인을 더하기 위해* 가 아니라 *로컬 변수 충돌 피하기 위해* 존재.

## 변경

- L15: alias 제거. `trustDispositionLabel` 직접 import.
- L485: 로컬 변수명 `trustDispositionLabel` → `trustDispositionDisplay` (함수 호출 결과를 표시용 변수에 담는 의도가 더 명확). 주석으로 "alias 가 왜 더 이상 필요 없는지" 명시해 향후 재중복 차단.
- L595: render 사이트 참조 갱신.

단일 파일 변경. 외부 사용처 영향 0.

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run keeper-detail-alert-strip.test.ts`: 17/17
- `pnpm exec eslint`: 0 errors

표면 동작 회귀 없음 — `trustDispositionLabel(trustDisposition)` 출력 동일.

## 관련 인사이트

iter#13 sweep 에서 발견된 별칭 회피 묶음 4 중 1 처리. 나머지 3 (`goals/goal-tree.ts:12-14` 의 `goalTreeData/Error/Loading as treeData/treeError/treeLoading`, `api/dashboard.ts:1929` 의 `ServerBuildIdentity as DashboardBuildIdentity`) 는 *호출 편의* 차원의 의도된 alias 로 판정 (정의/호출 양쪽 모두 명확) → pass.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#13 sweep, 별칭 회피 패턴 1순위 카테고리)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Keeper detail alert strip 의 trust disposition chip (`검증 Pass`/`Pause`/`Blocked` 등) 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
