### PR TITLE
refactor(keeper): project tool resolution through descriptors

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -413,8 +413,8 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
   in
   let exact_tool_choice_if_public = function
     | [ name ] ->
-      (match Keeper_tool_alias.route name with
-       | Some _ -> Some (Agent_sdk.Types.Tool name)
+      (match Agent_tool_descriptor.find_public name with
+       | Some _descriptor -> Some (Agent_sdk.Types.Tool name)
        | None -> None)
     | [] | _ :: _ :: _ -> None
   in

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -347,66 +347,52 @@ let prepare_agent_setup
   in
   let universe_set = Keeper_tool_policy.tool_name_set all_tool_names in
   let allowed_exec_names = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
-  (* RFC-0064 Phase 2: Remove aliased internal names from the LLM-visible
-     policy surface. Public aliases are the LLM-visible names; internal
+  (* Descriptor-backed public names are the LLM-visible names; internal
      counterparts are implementation details.
 
-     Order matters: compute [aliased_public_names] against the UNFILTERED
+     Order matters: compute [descriptor_public_names] against the UNFILTERED
      internal allowlist, because tool_policy.toml / presets still express
      allowlists in descriptor/internal names (tool_execute, tool_read_file, ...).
-     Stripping internals before the alias-expansion check would leave
-     [aliased_public_names] empty and drop "Execute"/"ReadFile"/... from the
+     Stripping internals before the descriptor expansion check would leave
+     [descriptor_public_names] empty and drop "Execute"/"ReadFile"/... from the
      visible surface. See PR #14596 review. *)
-  let aliased_internal_names =
-    List.filter_map
-      (fun public ->
-         match Keeper_tool_alias.route public with
-         | Some r -> Some r.internal_name
-         | None -> None)
-      (Keeper_tool_alias.public_names ())
+  let descriptor_internal_names =
+    Agent_tool_descriptor.public_descriptors
+    |> List.concat_map Agent_tool_descriptor.internal_names
+    |> Keeper_types.dedupe_keep_order
   in
-  (* Only include a public alias name when its routed internal target is
+  (* Only include a public name when its descriptor internal target is
      itself in [allowed_exec_names]. Otherwise the public name (e.g. "Execute")
      could let the LLM invoke a tool whose internal handler the current
-     keeper/preset has explicitly excluded — the alias would dispatch to
+     keeper/preset has explicitly excluded — the descriptor would dispatch to
      a registered-but-disallowed tool. See PR #14574 review. *)
-  let allowed_set_for_alias_filter =
-    Keeper_tool_policy.tool_name_set allowed_exec_names
-  in
-  let aliased_public_names =
-    List.filter
-      (fun public ->
-         match Keeper_tool_alias.route public with
-         | Some r ->
-           Keeper_tool_policy.StringSet.mem r.internal_name allowed_set_for_alias_filter
-         | None -> false)
-      (Keeper_tool_alias.public_names ())
-  in
-  (* Now strip the aliased internal names from the LLM-visible surface,
-     after [aliased_public_names] has been computed. *)
-  let allowed_exec_names =
-    List.filter
-      (fun name -> not (List.mem name aliased_internal_names))
+  let descriptor_public_names =
+    Agent_tool_descriptor_resolution.public_names_for_allowed_internal_names
       allowed_exec_names
   in
-  let allowed_exec_names_with_aliases = allowed_exec_names @ aliased_public_names in
+  (* Now strip the descriptor internal names from the LLM-visible surface,
+     after [descriptor_public_names] has been computed. *)
+  let allowed_exec_names =
+    List.filter
+      (fun name -> not (List.mem name descriptor_internal_names))
+      allowed_exec_names
+  in
+  let allowed_exec_names_with_public_descriptors =
+    allowed_exec_names @ descriptor_public_names
+  in
   let allowed_exec_set =
-    let base = Keeper_tool_policy.tool_name_set allowed_exec_names_with_aliases in
+    let base =
+      Keeper_tool_policy.tool_name_set allowed_exec_names_with_public_descriptors
+    in
     Keeper_tool_policy.StringSet.union
       base
       (Keeper_tool_policy.tool_name_set Keeper_tool_registry.core_always_tools)
   in
-  let allowed_public_alias_for_internal internal_name =
-    List.find_map
-      (fun public_name ->
-         match Keeper_tool_alias.route public_name with
-         | Some route
-           when String.equal route.internal_name internal_name
-                && Keeper_tool_policy.StringSet.mem public_name universe_set
-                && Keeper_tool_policy.StringSet.mem public_name allowed_exec_set ->
-           Some public_name
-         | _ -> None)
-      (Keeper_tool_alias.public_names ())
+  let allowed_public_name_for_internal internal_name =
+    Agent_tool_descriptor_resolution.public_names_for_internal internal_name
+    |> List.find_opt (fun public_name ->
+      Keeper_tool_policy.StringSet.mem public_name universe_set
+      && Keeper_tool_policy.StringSet.mem public_name allowed_exec_set)
   in
   let max_tools_per_turn =
     if is_retry
@@ -491,7 +477,7 @@ let prepare_agent_setup
     if Keeper_tool_policy.StringSet.mem name universe_set
        && Keeper_tool_policy.StringSet.mem name allowed_exec_set
     then Some name
-    else allowed_public_alias_for_internal name
+    else allowed_public_name_for_internal name
   in
   let filter_visible_policy_surface names =
     names
@@ -508,7 +494,7 @@ let prepare_agent_setup
              && Keeper_tool_policy.StringSet.mem n allowed_exec_set
            then n :: validated, dropped_names
            else
-             match allowed_public_alias_for_internal n with
+             match allowed_public_name_for_internal n with
              | Some public_name -> public_name :: validated, dropped_names
              | None -> validated, n :: dropped_names)
         raw
@@ -797,20 +783,15 @@ let prepare_agent_setup
       else all_allowed, false
     in
     let last_turn_safe = Keeper_tool_policy.last_turn_safe_tool_names () in
-    (* Mirror allowed_exec_names_with_aliases: only include a public alias
+    (* Mirror allowed_exec_names_with_public_descriptors: only include a public name
        in the last-turn-safe set when its routed internal handler is also
        last-turn-safe. Otherwise the public name could re-introduce a tool
        the policy explicitly excluded from the final turn. PR #14574. *)
-    let safe_set = Keeper_tool_policy.tool_name_set last_turn_safe in
-    let aliased_safe_public =
-      List.filter
-        (fun public ->
-           match Keeper_tool_alias.route public with
-           | Some r -> Keeper_tool_policy.StringSet.mem r.internal_name safe_set
-           | None -> false)
-        (Keeper_tool_alias.public_names ())
+    let descriptor_safe_public_names =
+      Agent_tool_descriptor_resolution.public_names_for_allowed_internal_names
+        last_turn_safe
     in
-    let safe_last_turn_tools = last_turn_safe @ aliased_safe_public in
+    let safe_last_turn_tools = last_turn_safe @ descriptor_safe_public_names in
     let all_allowed =
       if is_last_turn && required_tool_names = []
       then

--- a/lib/keeper/keeper_tool_capability_axis.ml
+++ b/lib/keeper/keeper_tool_capability_axis.ml
@@ -2,7 +2,7 @@
 
     Callers may pass public aliases ([Execute], [WriteFile], ...), public MCP
     names, prefixed MCP names, or internal handler names. This module
-    normalizes names through the alias SSOT before answering capability
+    normalizes names through descriptor resolution before answering capability
     predicates. *)
 
 type t =
@@ -27,11 +27,9 @@ let masc_keeper_name (tool : Tool_name.Masc_keeper.t) =
 
 let canonical_tool_name name =
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
-  match Keeper_tool_alias.canonical_resolution name with
-  | Keeper_tool_alias.Public_mcp { internal; _ }
-  | Keeper_tool_alias.Public_alias { internal } -> internal
-  | Keeper_tool_alias.Internal { canonical } -> canonical
-  | Keeper_tool_alias.Unknown -> stripped
+  match Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name name with
+  | Some internal -> internal
+  | None -> stripped
 ;;
 
 let candidate_names name =

--- a/lib/keeper/keeper_tool_name_projection.ml
+++ b/lib/keeper/keeper_tool_name_projection.ml
@@ -41,7 +41,7 @@ let resolve_model_name ~(visible_tool_names : string list) (name : string) =
   let visible = visible_set visible_tool_names in
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
   let internal_name =
-    match Keeper_tool_alias.canonical_internal_name stripped with
+    match Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name stripped with
     | Some internal_name -> internal_name
     | None -> stripped
   in

--- a/lib/keeper/keeper_tool_name_projection.mli
+++ b/lib/keeper/keeper_tool_name_projection.mli
@@ -40,18 +40,16 @@ val visible_set : string list -> (string, unit) Hashtbl.t
 val public_aliases_for_internal_name : string -> string list
 
 val public_alias_for_internal : string -> string option
-(** First public alias for an internal name, or [None]. Semantically
-    equivalent to [Keeper_tool_alias.public_name_for_internal] but
-    routes through this module as the SSOT. *)
+(** First descriptor-backed public alias for an internal name, or [None]. *)
 
 val resolve_model_name :
   visible_tool_names:string list ->
   string ->
   model_resolution
 (** Resolve a tool name against the visible-schema set. Strips the
-    [mcp_masc__] prefix when present, canonicalizes through
-    [Keeper_tool_alias], then prefers a visible public alias over a
-    visible internal name. *)
+    [mcp_masc__] prefix when present, canonicalizes through descriptor
+    resolution, then prefers a visible public alias over a visible internal
+    name. *)
 
 val model_name :
   visible_tool_names:string list ->

--- a/lib/keeper/keeper_tool_resolution.ml
+++ b/lib/keeper/keeper_tool_resolution.ml
@@ -15,7 +15,7 @@
 type tried_source =
   | Dispatch_table              (** S1: Tool_dispatch.is_registered *)
   | Tool_name_variant           (** S2: Tool_name.of_string *)
-  | Alias_route                 (** S3: Keeper_tool_alias.route *)
+  | Public_descriptor           (** S3: Agent_tool_descriptor.find_public *)
   | Alias_internal              (** S4: Keeper_tool_alias.is_known_internal *)
   | Alias_masc_to_internal      (** S5: Keeper_tool_alias.public_masc_to_internal *)
   | Registry_internal_candidate (** S6: Keeper_tool_registry.keeper_internal_candidate_tool_names *)
@@ -37,7 +37,7 @@ let tool_schema_names schemas =
 let string_of_tried_source = function
   | Dispatch_table -> "dispatch_table"
   | Tool_name_variant -> "tool_name_variant"
-  | Alias_route -> "alias_route"
+  | Public_descriptor -> "public_descriptor"
   | Alias_internal -> "alias_internal"
   | Alias_masc_to_internal -> "alias_masc_to_internal"
   | Registry_internal_candidate -> "registry_internal_candidate"
@@ -57,62 +57,82 @@ let resolve name =
     Resolved { canonical = normalized; via = Dispatch_table; surface = None }
   else if Option.is_some (Tool_name.of_string normalized) then
     Resolved { canonical = normalized; via = Tool_name_variant; surface = None }
-  else if Option.is_some (Keeper_tool_alias.route normalized) then
-    Alias_to { from_ = normalized; canonical = normalized; via = Alias_route }
-  else if Keeper_tool_alias.is_known_internal normalized then
-    Resolved { canonical = normalized; via = Alias_internal; surface = None }
-  else begin
-    match Keeper_tool_alias.public_masc_to_internal normalized with
-    | Some internal ->
-        Alias_to { from_ = normalized; canonical = internal; via = Alias_masc_to_internal }
+  else
+    match Agent_tool_descriptor.find_public normalized with
+    | Some descriptor ->
+        Alias_to
+          { from_ = normalized
+          ; canonical = descriptor.Agent_tool_descriptor.internal_name
+          ; via = Public_descriptor
+          }
     | None ->
-      if List.mem normalized (Keeper_tool_registry.keeper_internal_candidate_tool_names) then
-        Resolved { canonical = normalized; via = Registry_internal_candidate; surface = None }
-      else if List.mem normalized (Keeper_tool_registry.effective_core_tools ()) then
-        Resolved { canonical = normalized; via = Registry_core_tools; surface = None }
-      else if List.mem normalized (tool_schema_names Tool_shard.all_keeper_tool_schemas) then
-        Resolved { canonical = normalized; via = Shard_schema; surface = None }
-      else begin
-        (* RFC-0084 §1.3 + §6 D2 — surface coverage gate.
-           [Tool_catalog_surfaces.surface] has 8 variants. 7 are
-           admit-checked here; [Keeper_denied] is excluded (must-deny
-           semantics — checked separately in PR-7 capability gate, not
-           an admission source). *)
-        let surfaces_to_check =
-          [ Tool_catalog_surfaces.Public_mcp
-          ; Tool_catalog_surfaces.Spawned_agent
-          ; Tool_catalog_surfaces.Local_worker
-          ; Tool_catalog_surfaces.Session_min
-          ; Tool_catalog_surfaces.Admin
-          ; Tool_catalog_surfaces.Keeper_internal
-          ; Tool_catalog_surfaces.System_internal
-          ]
-        in
-        let _excluded_must_deny : Tool_catalog_surfaces.surface list =
-          (* PR-7 will route [Keeper_denied] through the capability gate
-             before admission; do not list it as an admit surface here. *)
-          [ Tool_catalog_surfaces.Keeper_denied ]
-        in
-        let rec check_surfaces = function
-          | [] ->
-              let tried =
-                [ Dispatch_table; Tool_name_variant; Alias_route
-                ; Alias_internal; Alias_masc_to_internal
-                ; Registry_internal_candidate; Registry_core_tools
-                ; Shard_schema
-                ]
-                @ List.map (fun s -> Surface s) surfaces_to_check
-              in
-              Unknown { name; tried }
-          | surface :: rest ->
-              if Tool_catalog_surfaces.is_on_surface surface normalized then
-                Resolved { canonical = normalized; via = Surface surface; surface = Some surface }
-              else
-                check_surfaces rest
-        in
-        check_surfaces surfaces_to_check
-      end
-  end
+        if Keeper_tool_alias.is_known_internal normalized then
+          Resolved { canonical = normalized; via = Alias_internal; surface = None }
+        else begin
+          match Keeper_tool_alias.public_masc_to_internal normalized with
+          | Some internal ->
+              Alias_to
+                { from_ = normalized; canonical = internal; via = Alias_masc_to_internal }
+          | None ->
+              if List.mem normalized Keeper_tool_registry.keeper_internal_candidate_tool_names
+              then
+                Resolved
+                  { canonical = normalized; via = Registry_internal_candidate; surface = None }
+              else if List.mem normalized (Keeper_tool_registry.effective_core_tools ())
+              then
+                Resolved
+                  { canonical = normalized; via = Registry_core_tools; surface = None }
+              else if
+                List.mem normalized (tool_schema_names Tool_shard.all_keeper_tool_schemas)
+              then Resolved { canonical = normalized; via = Shard_schema; surface = None }
+              else begin
+                (* RFC-0084 §1.3 + §6 D2 — surface coverage gate.
+                   [Tool_catalog_surfaces.surface] has 8 variants. 7 are
+                   admit-checked here; [Keeper_denied] is excluded (must-deny
+                   semantics — checked separately in PR-7 capability gate, not
+                   an admission source). *)
+                let surfaces_to_check =
+                  [ Tool_catalog_surfaces.Public_mcp
+                  ; Tool_catalog_surfaces.Spawned_agent
+                  ; Tool_catalog_surfaces.Local_worker
+                  ; Tool_catalog_surfaces.Session_min
+                  ; Tool_catalog_surfaces.Admin
+                  ; Tool_catalog_surfaces.Keeper_internal
+                  ; Tool_catalog_surfaces.System_internal
+                  ]
+                in
+                let _excluded_must_deny : Tool_catalog_surfaces.surface list =
+                  (* PR-7 will route [Keeper_denied] through the capability gate
+                     before admission; do not list it as an admit surface here. *)
+                  [ Tool_catalog_surfaces.Keeper_denied ]
+                in
+                let rec check_surfaces = function
+                  | [] ->
+                      let tried =
+                        [ Dispatch_table
+                        ; Tool_name_variant
+                        ; Public_descriptor
+                        ; Alias_internal
+                        ; Alias_masc_to_internal
+                        ; Registry_internal_candidate
+                        ; Registry_core_tools
+                        ; Shard_schema
+                        ]
+                        @ List.map (fun s -> Surface s) surfaces_to_check
+                      in
+                      Unknown { name; tried }
+                  | surface :: rest ->
+                      if Tool_catalog_surfaces.is_on_surface surface normalized then
+                        Resolved
+                          { canonical = normalized
+                          ; via = Surface surface
+                          ; surface = Some surface
+                          }
+                      else check_surfaces rest
+                in
+                check_surfaces surfaces_to_check
+              end
+        end
 
 (* ── Phase 5: full-probe (no short-circuit) ────────────────────────── *)
 
@@ -126,8 +146,8 @@ let all_admitting_sources name =
     sources := Dispatch_table :: !sources;
   if Option.is_some (Tool_name.of_string normalized) then
     sources := Tool_name_variant :: !sources;
-  if Option.is_some (Keeper_tool_alias.route normalized) then
-    sources := Alias_route :: !sources;
+  if Option.is_some (Agent_tool_descriptor.find_public normalized) then
+    sources := Public_descriptor :: !sources;
   if Keeper_tool_alias.is_known_internal normalized then
     sources := Alias_internal :: !sources;
   (match Keeper_tool_alias.public_masc_to_internal normalized with
@@ -210,11 +230,7 @@ let canonical_tool_name_observed name =
 ;;
 
 let public_aliases_for_internal_name internal_name =
-  Keeper_tool_alias.public_names ()
-  |> List.filter (fun public ->
-    match Keeper_tool_alias.route public with
-    | Some route -> String.equal route.internal_name internal_name
-    | None -> false)
+  Agent_tool_descriptor_resolution.public_names_for_internal internal_name
 ;;
 
 let public_alias_guidance_for_internal_call
@@ -223,7 +239,7 @@ let public_alias_guidance_for_internal_call
   : string option
   =
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
-  match Keeper_tool_alias.route stripped with
+  match Agent_tool_descriptor.find_public stripped with
   | Some _ -> None
   | None ->
     let canonical = canonical_tool_name stripped in

--- a/lib/keeper/keeper_tool_resolution.mli
+++ b/lib/keeper/keeper_tool_resolution.mli
@@ -9,7 +9,7 @@
 type tried_source =
   | Dispatch_table              (** Tool_dispatch.is_registered *)
   | Tool_name_variant           (** Tool_name.of_string *)
-  | Alias_route                 (** Keeper_tool_alias.route *)
+  | Public_descriptor           (** Agent_tool_descriptor.find_public *)
   | Alias_internal              (** Keeper_tool_alias.is_known_internal *)
   | Alias_masc_to_internal      (** Keeper_tool_alias.public_masc_to_internal *)
   | Registry_internal_candidate (** keeper_internal_candidate_tool_names *)

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -50,7 +50,7 @@ let resolved_tool_lane_label ~effective_tools ~runtime_mcp_policy =
   | false, false, None -> "none"
 
 let canonical_tool_name_for_lane_check name =
-  match Keeper_tool_alias.canonical_internal_name name with
+  match Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name name with
   | Some internal -> internal
   | None -> name
 

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -641,6 +641,7 @@ let test_public_alias_projection_uses_core_axis () =
   let core_axis = "lib/core/tool_name_alias_axis.ml" in
   let coord_classify = "lib/coord/coord_task_classify.ml" in
   let keeper_alias = "lib/keeper/keeper_tool_alias.ml" in
+  let run_tools_setup = "lib/keeper/keeper_run_tools_setup.ml" in
   let oas_bundle = "lib/keeper/keeper_tools_oas_bundle.ml" in
   assert_contains "lib/core/dune" "tool_name_alias_axis";
   assert_contains core_axis "public_name = \"Execute\"; internal_name = \"tool_execute\"";
@@ -655,6 +656,12 @@ let test_public_alias_projection_uses_core_axis () =
   assert_not_contains keeper_alias
     ("\"Grep\", { internal_name = \"tool_" ^ "workspace_inspect\"");
   assert_not_contains keeper_alias "\"Grep\", { internal_name = \"tool_search_files\"";
+  assert_contains run_tools_setup "Agent_tool_descriptor.public_descriptors";
+  assert_contains
+    run_tools_setup
+    "Agent_tool_descriptor_resolution.public_names_for_allowed_internal_names";
+  assert_not_contains run_tools_setup "Keeper_tool_alias.public_names";
+  assert_not_contains run_tools_setup "Keeper_tool_alias.route";
   assert_contains oas_bundle "Agent_tool_descriptor.public_descriptors";
   assert_not_contains oas_bundle "Keeper_tool_alias.public_names";
   assert_not_contains oas_bundle "Keeper_tool_alias.route"

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -639,6 +639,7 @@ let test_keeper_semantic_capabilities_use_capability_axis () =
 
 let test_public_alias_projection_uses_core_axis () =
   let core_axis = "lib/core/tool_name_alias_axis.ml" in
+  let agent_surface = "lib/keeper/keeper_agent_tool_surface.ml" in
   let coord_classify = "lib/coord/coord_task_classify.ml" in
   let keeper_alias = "lib/keeper/keeper_tool_alias.ml" in
   let run_tools_setup = "lib/keeper/keeper_run_tools_setup.ml" in
@@ -662,6 +663,8 @@ let test_public_alias_projection_uses_core_axis () =
     "Agent_tool_descriptor_resolution.public_names_for_allowed_internal_names";
   assert_not_contains run_tools_setup "Keeper_tool_alias.public_names";
   assert_not_contains run_tools_setup "Keeper_tool_alias.route";
+  assert_contains agent_surface "Agent_tool_descriptor.find_public";
+  assert_not_contains agent_surface "Keeper_tool_alias.route";
   assert_contains oas_bundle "Agent_tool_descriptor.public_descriptors";
   assert_not_contains oas_bundle "Keeper_tool_alias.public_names";
   assert_not_contains oas_bundle "Keeper_tool_alias.route"

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -616,7 +616,10 @@ let test_keeper_semantic_capabilities_use_capability_axis () =
   let registry = "lib/keeper/keeper_tool_registry.ml" in
   let registry_mli = "lib/keeper/keeper_tool_registry.mli" in
   assert_contains "lib/dune" "keeper_tool_capability_axis";
-  assert_contains axis "Keeper_tool_alias.canonical_resolution";
+  assert_contains
+    axis
+    "Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name";
+  assert_not_contains axis "Keeper_tool_alias.canonical_resolution";
   assert_not_contains axis "Keeper_tool_alias.route";
   assert_not_contains axis "Keeper_tool_alias.public_masc_to_internal";
   assert_contains contract_classifier "Keeper_tool_capability_axis.supports_any";

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -645,6 +645,8 @@ let test_public_alias_projection_uses_core_axis () =
   let run_tools_setup = "lib/keeper/keeper_run_tools_setup.ml" in
   let tool_resolution = "lib/keeper/keeper_tool_resolution.ml" in
   let tool_resolution_mli = "lib/keeper/keeper_tool_resolution.mli" in
+  let tool_name_projection = "lib/keeper/keeper_tool_name_projection.ml" in
+  let turn_driver_helpers = "lib/keeper/keeper_turn_driver_helpers.ml" in
   let oas_bundle = "lib/keeper/keeper_tools_oas_bundle.ml" in
   assert_contains "lib/core/dune" "tool_name_alias_axis";
   assert_contains core_axis "public_name = \"Execute\"; internal_name = \"tool_execute\"";
@@ -675,6 +677,14 @@ let test_public_alias_projection_uses_core_axis () =
   assert_not_contains tool_resolution "Keeper_tool_alias.route";
   assert_contains tool_resolution_mli "Agent_tool_descriptor.find_public";
   assert_not_contains tool_resolution_mli "Keeper_tool_alias.route";
+  assert_contains
+    tool_name_projection
+    "Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name";
+  assert_not_contains tool_name_projection "Keeper_tool_alias.canonical_internal_name";
+  assert_contains
+    turn_driver_helpers
+    "Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name";
+  assert_not_contains turn_driver_helpers "Keeper_tool_alias.canonical_internal_name";
   assert_contains oas_bundle "Agent_tool_descriptor.public_descriptors";
   assert_not_contains oas_bundle "Keeper_tool_alias.public_names";
   assert_not_contains oas_bundle "Keeper_tool_alias.route"

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -643,6 +643,8 @@ let test_public_alias_projection_uses_core_axis () =
   let coord_classify = "lib/coord/coord_task_classify.ml" in
   let keeper_alias = "lib/keeper/keeper_tool_alias.ml" in
   let run_tools_setup = "lib/keeper/keeper_run_tools_setup.ml" in
+  let tool_resolution = "lib/keeper/keeper_tool_resolution.ml" in
+  let tool_resolution_mli = "lib/keeper/keeper_tool_resolution.mli" in
   let oas_bundle = "lib/keeper/keeper_tools_oas_bundle.ml" in
   assert_contains "lib/core/dune" "tool_name_alias_axis";
   assert_contains core_axis "public_name = \"Execute\"; internal_name = \"tool_execute\"";
@@ -665,6 +667,14 @@ let test_public_alias_projection_uses_core_axis () =
   assert_not_contains run_tools_setup "Keeper_tool_alias.route";
   assert_contains agent_surface "Agent_tool_descriptor.find_public";
   assert_not_contains agent_surface "Keeper_tool_alias.route";
+  assert_contains tool_resolution "Agent_tool_descriptor.find_public";
+  assert_contains
+    tool_resolution
+    "Agent_tool_descriptor_resolution.public_names_for_internal";
+  assert_not_contains tool_resolution "Keeper_tool_alias.public_names";
+  assert_not_contains tool_resolution "Keeper_tool_alias.route";
+  assert_contains tool_resolution_mli "Agent_tool_descriptor.find_public";
+  assert_not_contains tool_resolution_mli "Keeper_tool_alias.route";
   assert_contains oas_bundle "Agent_tool_descriptor.public_descriptors";
   assert_not_contains oas_bundle "Keeper_tool_alias.public_names";
   assert_not_contains oas_bundle "Keeper_tool_alias.route"

--- a/test/test_keeper_tool_name_projection.ml
+++ b/test/test_keeper_tool_name_projection.ml
@@ -24,6 +24,11 @@ let test_visible_public_alias_wins () =
     "tool_execute projects to visible Execute"
     (Some "Execute")
     (Projection.model_name ~visible_tool_names:[ "Execute" ] "tool_execute");
+  check
+    (option string)
+    "mcp-prefixed public Execute remains visible"
+    (Some "Execute")
+    (Projection.model_name ~visible_tool_names:[ "Execute" ] "mcp__masc__Execute");
   match
     Projection.resolve_model_name ~visible_tool_names:[ "tool_execute"; "Execute" ]
       "tool_execute"

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -4,12 +4,12 @@ module TR = Masc_mcp.Keeper_tool_resolution
 
 (* ── resolve returns correct tried_source for each admission path ── *)
 
-let test_alias_route_admits_execute () =
+let test_public_descriptor_admits_execute () =
   match TR.resolve "Execute" with
-  | TR.Alias_to { canonical; via = TR.Alias_route } ->
-      check string "canonical is Execute" "Execute" canonical
+  | TR.Alias_to { canonical; via = TR.Public_descriptor } ->
+      check string "canonical is tool_execute" "tool_execute" canonical
   | other ->
-      fail (Printf.sprintf "expected Alias_to via Alias_route, got: %s"
+      fail (Printf.sprintf "expected Alias_to via Public_descriptor, got: %s"
               (match other with
                | TR.Resolved { via; _ } -> "Resolved via " ^ TR.string_of_tried_source via
                | TR.Alias_to { via; _ } -> "Alias_to via " ^ TR.string_of_tried_source via
@@ -269,7 +269,7 @@ let test_full_probe_overlap () =
 let () =
   Alcotest.run "test_tool_resolution"
     [ "resolve", [
-        test_case "Execute resolves via Alias_route" `Quick test_alias_route_admits_execute;
+        test_case "Execute resolves via public descriptor" `Quick test_public_descriptor_admits_execute;
         test_case "keeper_board_post resolves via Tool_name_variant" `Quick test_tool_name_variant_admits_keeper_board_post;
         test_case "mcp prefix stripped and resolved" `Quick test_mcp_prefix_stripped;
         test_case "unknown returns tried list" `Quick test_unknown_returns_tried_list;


### PR DESCRIPTION
## Summary
- replace keeper tool resolution public-alias admission with Agent_tool_descriptor.find_public
- project public aliases for internal guidance through Agent_tool_descriptor_resolution
- extend boundary ratchets so keeper_tool_resolution no longer calls Keeper_tool_alias.route/public_names directly

## Verification
- ocamlformat --check lib/keeper/keeper_tool_resolution.ml lib/keeper/keeper_tool_resolution.mli test/test_keeper_tool_resolution.ml test/test_keeper_sandbox_boundary_policy.ml
- rg -n "Keeper_tool_alias\.route|Keeper_tool_alias\.public_names" lib/keeper/keeper_tool_resolution.ml lib/keeper/keeper_tool_resolution.mli
- git diff --check origin/refactor/agent-surface-descriptor-projection-20260527...HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_keeper_tool_resolution.exe ./test/test_keeper_sandbox_boundary_policy.exe
- ./_build/default/test/test_keeper_tool_resolution.exe
- ./_build/default/test/test_keeper_sandbox_boundary_policy.exe
- scripts/ci/check-determinism-contract.sh

Stacked on #18927.