### PR TITLE
refactor(keeper): route tool name projection through descriptors

### DIFF
--- a/lib/keeper/keeper_tool_name_projection.ml
+++ b/lib/keeper/keeper_tool_name_projection.ml
@@ -41,7 +41,7 @@ let resolve_model_name ~(visible_tool_names : string list) (name : string) =
   let visible = visible_set visible_tool_names in
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
   let internal_name =
-    match Keeper_tool_alias.canonical_internal_name stripped with
+    match Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name stripped with
     | Some internal_name -> internal_name
     | None -> stripped
   in

--- a/lib/keeper/keeper_tool_name_projection.mli
+++ b/lib/keeper/keeper_tool_name_projection.mli
@@ -40,18 +40,16 @@ val visible_set : string list -> (string, unit) Hashtbl.t
 val public_aliases_for_internal_name : string -> string list
 
 val public_alias_for_internal : string -> string option
-(** First public alias for an internal name, or [None]. Semantically
-    equivalent to [Keeper_tool_alias.public_name_for_internal] but
-    routes through this module as the SSOT. *)
+(** First descriptor-backed public alias for an internal name, or [None]. *)
 
 val resolve_model_name :
   visible_tool_names:string list ->
   string ->
   model_resolution
 (** Resolve a tool name against the visible-schema set. Strips the
-    [mcp_masc__] prefix when present, canonicalizes through
-    [Keeper_tool_alias], then prefers a visible public alias over a
-    visible internal name. *)
+    [mcp_masc__] prefix when present, canonicalizes through descriptor
+    resolution, then prefers a visible public alias over a visible internal
+    name. *)
 
 val model_name :
   visible_tool_names:string list ->

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -50,7 +50,7 @@ let resolved_tool_lane_label ~effective_tools ~runtime_mcp_policy =
   | false, false, None -> "none"
 
 let canonical_tool_name_for_lane_check name =
-  match Keeper_tool_alias.canonical_internal_name name with
+  match Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name name with
   | Some internal -> internal
   | None -> name
 

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -645,6 +645,8 @@ let test_public_alias_projection_uses_core_axis () =
   let run_tools_setup = "lib/keeper/keeper_run_tools_setup.ml" in
   let tool_resolution = "lib/keeper/keeper_tool_resolution.ml" in
   let tool_resolution_mli = "lib/keeper/keeper_tool_resolution.mli" in
+  let tool_name_projection = "lib/keeper/keeper_tool_name_projection.ml" in
+  let turn_driver_helpers = "lib/keeper/keeper_turn_driver_helpers.ml" in
   let oas_bundle = "lib/keeper/keeper_tools_oas_bundle.ml" in
   assert_contains "lib/core/dune" "tool_name_alias_axis";
   assert_contains core_axis "public_name = \"Execute\"; internal_name = \"tool_execute\"";
@@ -675,6 +677,14 @@ let test_public_alias_projection_uses_core_axis () =
   assert_not_contains tool_resolution "Keeper_tool_alias.route";
   assert_contains tool_resolution_mli "Agent_tool_descriptor.find_public";
   assert_not_contains tool_resolution_mli "Keeper_tool_alias.route";
+  assert_contains
+    tool_name_projection
+    "Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name";
+  assert_not_contains tool_name_projection "Keeper_tool_alias.canonical_internal_name";
+  assert_contains
+    turn_driver_helpers
+    "Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name";
+  assert_not_contains turn_driver_helpers "Keeper_tool_alias.canonical_internal_name";
   assert_contains oas_bundle "Agent_tool_descriptor.public_descriptors";
   assert_not_contains oas_bundle "Keeper_tool_alias.public_names";
   assert_not_contains oas_bundle "Keeper_tool_alias.route"

--- a/test/test_keeper_tool_name_projection.ml
+++ b/test/test_keeper_tool_name_projection.ml
@@ -24,6 +24,11 @@ let test_visible_public_alias_wins () =
     "tool_execute projects to visible Execute"
     (Some "Execute")
     (Projection.model_name ~visible_tool_names:[ "Execute" ] "tool_execute");
+  check
+    (option string)
+    "mcp-prefixed public Execute remains visible"
+    (Some "Execute")
+    (Projection.model_name ~visible_tool_names:[ "Execute" ] "mcp__masc__Execute");
   match
     Projection.resolve_model_name ~visible_tool_names:[ "tool_execute"; "Execute" ]
       "tool_execute"


### PR DESCRIPTION
## Summary
- canonicalize model-facing tool-name projection through Agent_tool_descriptor_resolution
- canonicalize lane required/materialized tool checks through descriptor resolution
- extend boundary ratchets against direct Keeper_tool_alias.canonical_internal_name in those projection paths

## Verification
- ocamlformat --check lib/keeper/keeper_tool_name_projection.ml lib/keeper/keeper_tool_name_projection.mli lib/keeper/keeper_turn_driver_helpers.ml test/test_keeper_tool_name_projection.ml test/test_keeper_sandbox_boundary_policy.ml
- rg -n "Keeper_tool_alias\.canonical_internal_name|Keeper_tool_alias\.public_name_for_internal" lib/keeper/keeper_tool_name_projection.ml lib/keeper/keeper_tool_name_projection.mli lib/keeper/keeper_turn_driver_helpers.ml
- git diff --check origin/refactor/tool-resolution-descriptor-projection-20260527...HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_keeper_tool_name_projection.exe ./test/test_keeper_runtime_manifest.exe ./test/test_keeper_sandbox_boundary_policy.exe
- ./_build/default/test/test_keeper_tool_name_projection.exe
- ./_build/default/test/test_keeper_runtime_manifest.exe test "^wiring$" 2
- ./_build/default/test/test_keeper_sandbox_boundary_policy.exe
- scripts/ci/check-determinism-contract.sh

Note: full ./_build/default/test/test_keeper_runtime_manifest.exe currently fails unrelated fixture paths with Cascade_name.of_string_exn invalid prefix: "default"; the lane-check case touched by this change passes when run directly.

Stacked on #18934.