### PR TITLE
refactor(dashboard/lib): consolidate cleanErrorMessage + compactWhitespace SSOT

### DIFF
--- a/dashboard/src/components/auth-status.test.ts
+++ b/dashboard/src/components/auth-status.test.ts
@@ -26,6 +26,9 @@ vi.mock('../api/core', () => ({
 vi.mock('../api/mcp', () => ({ resetMcpClientState: vi.fn() }))
 vi.mock('../lib/dashboard-auth-access', () => ({
   dashboardAuthAccess: vi.fn().mockReturnValue({ allowed: true, reason: null }),
+  cleanErrorMessage: (value: string | null | undefined): string | null =>
+    value ? value.replace(/^[^\w가-힣@]+/u, '').trim() || null : null,
+  compactWhitespace: (value: string): string => value.replace(/\s+/g, ' ').trim(),
 }))
 vi.mock('../lib/dashboard-actor', () => ({
   hasDashboardActorQueryParam: vi.fn().mockReturnValue(false),

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -10,7 +10,7 @@ import {
   setStoredToken,
 } from '../api/core'
 import { resetMcpClientState } from '../api/mcp'
-import { dashboardAuthAccess } from '../lib/dashboard-auth-access'
+import { dashboardAuthAccess, cleanErrorMessage } from '../lib/dashboard-auth-access'
 import {
   hasDashboardActorQueryParam,
   readStoredDashboardActorName,
@@ -35,11 +35,6 @@ export function __resetForTests(): void {
   tokenInput.value = ''
   actorInput.value = ''
   bannerDismissed.value = false
-}
-
-function cleanErrorMessage(value: string | null | undefined): string | null {
-  if (!value) return null
-  return value.replace(/^[^\w가-힣@]+/u, '').trim() || null
 }
 
 function mutationStatusLabel(allowed: boolean): string {

--- a/dashboard/src/lib/dashboard-auth-access.ts
+++ b/dashboard/src/lib/dashboard-auth-access.ts
@@ -15,11 +15,22 @@ const ROLE_ORDER: Record<DashboardAuthRole, number> = {
   admin: 2,
 }
 
-function compactWhitespace(value: string): string {
+/**
+ * SSOT for auth-text normalization helpers.
+ *
+ * Both `compactWhitespace` and `cleanErrorMessage` were defined byte-for-byte
+ * identically in three places (`lib/dashboard-auth-access.ts`,
+ * `lib/keeper-chat-access.ts`, `components/auth-status.ts`) until
+ * 2026-05-27. Consolidated here because (a) `dashboard-auth-access` is the
+ * base auth module both other consumers already depend on, and (b) the
+ * regex `/^[^\w가-힣@]+/u` is a closed contract for trimming auth error
+ * preambles — drift would change error message visibility per surface.
+ */
+export function compactWhitespace(value: string): string {
   return value.replace(/\s+/g, ' ').trim()
 }
 
-function cleanErrorMessage(value: string | null | undefined): string | null {
+export function cleanErrorMessage(value: string | null | undefined): string | null {
   if (!value) return null
   return value.replace(/^[^\w가-힣@]+/u, '').trim() || null
 }

--- a/dashboard/src/lib/keeper-chat-access.ts
+++ b/dashboard/src/lib/keeper-chat-access.ts
@@ -1,18 +1,13 @@
 import type { DashboardShellAuthSummary } from '../types'
-import { dashboardAuthAccess } from './dashboard-auth-access'
+import {
+  dashboardAuthAccess,
+  cleanErrorMessage,
+  compactWhitespace,
+} from './dashboard-auth-access'
 
 interface KeeperDirectChatAccess {
   blocked: boolean
   message: string | null
-}
-
-function compactWhitespace(value: string): string {
-  return value.replace(/\s+/g, ' ').trim()
-}
-
-function cleanErrorMessage(value: string | null | undefined): string | null {
-  if (!value) return null
-  return value.replace(/^[^\w가-힣@]+/u, '').trim() || null
 }
 
 export function keeperDirectChatAccess(


### PR DESCRIPTION
## 요약

`cleanErrorMessage` 와 `compactWhitespace` 가 3개 파일에 **byte-for-byte 동일** 한 internal helper 로 분산 정의되어 있었습니다. 같은 regex `/^[^\w가-힣@]+/u` (한국어/ASCII boundary trim) 가 세 곳에 복붙되어 한쪽만 정책이 바뀌면 surface 별 다른 에러 메시지 가시성 회귀 가능. iter#14 의 lib-shadowing 본격 처리 첫 PR.

## 기존 위반

| 파일 | 정의 |
|---|---|
| `src/lib/dashboard-auth-access.ts:18,22` | `compactWhitespace`, `cleanErrorMessage` internal |
| `src/lib/keeper-chat-access.ts:9,13` | 동일 본체 internal. 이미 `dashboardAuthAccess` import 중 (base 의존 확립) |
| `src/components/auth-status.ts:40` | `cleanErrorMessage` internal + 5 사이트 호출 |

3 internal helper × byte-for-byte 동일. iter#6 (`fetchDashboardNamespaceTruth`, 2 API 정의 동일) 과 같은 위험 — silent drift.

## 변경

- `lib/dashboard-auth-access.ts`: 두 helper `function` → `export function` 승격. SSOT 위치로 적합한 이유(base 모듈, 둘 다 의존 중) JSDoc 명시
- `lib/keeper-chat-access.ts`: internal 정의 2개 삭제, `dashboard-auth-access` 에서 import 추가
- `components/auth-status.ts`: internal 정의 1개 삭제, 같은 곳에서 import 추가
- `components/auth-status.test.ts`: mock 보강. `vi.mock('../lib/dashboard-auth-access')` 가 기존 `dashboardAuthAccess` 만 stub 했는데, 이제 SSOT 가 더 많은 export 를 갖기 때문에 mock 도 `cleanErrorMessage`/`compactWhitespace` 를 함께 제공해야 한다.

## 학습 포인트: 모듈 전체 mock 의 export 추가 함정

iter#14 의 새 함정: `vi.mock` 은 module export 전체를 mock 객체로 대체. 새 SSOT export 추가 시 *기존 test 의 mock 도 함께 갱신* 필요. typecheck 는 통과해도 (mock object 가 module 타입 아니므로 호환), 런타임에 `is not a function` 으로 잡힘. vitest 의 *partial mock* 지원이 default 가 아니라는 점 명시.

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run dashboard-auth-access.test + keeper-chat-access.test + auth-status.test`: 14/14 (mock 추가 후)
- `pnpm exec eslint`: 0 errors

표면 동작 회귀 없음 — regex/함수 동작 동일.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#14, lib-shadowing 첫 처리)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Auth surface 의 error 메시지 trim 동작 회귀 없음 (한국어/특수문자 prefix 제거 여전히 정확)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
