### PR TITLE
fix(tool-catalog): restore worktree-boundary helper after PR #18915 regression

### DIFF
--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -55,6 +55,12 @@ val has_mutating_side_effect : string -> bool
 val is_read_only_with_input :
   tool_name:string -> input:Yojson.Safe.t -> bool
 
+(** Input-aware main-worktree boundary check: returns [true] when the tool
+    should NOT open the per-turn checkpoint boundary (read-only, MASC
+    coordination, or playground-sandboxed mutations). *)
+val is_main_worktree_boundary_exempt_with_input :
+  tool_name:string -> input:Yojson.Safe.t -> bool
+
 (** Tools whose mutations are safe to leave un-reconciled after
     a transient failure (board posts, broadcasts, task_done). *)
 val reconcile_safe_tools : string list

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -562,6 +562,12 @@ let effect_domain name =
   let meta = metadata name in
   meta.effect_domain
 
+let is_main_worktree_boundary_exempt name =
+  match effect_domain name with
+  | Some Read_only | Some Masc_coordination | Some Playground_write -> Some true
+  | Some Host_repo_write -> Some false
+  | None -> None
+
 let requires_actor_binding name =
   match (metadata name).requires_actor_binding with
   | Some value -> value

--- a/lib/tool_catalog.mli
+++ b/lib/tool_catalog.mli
@@ -80,6 +80,7 @@ val full_surface_override : unit -> bool
 val metadata : string -> metadata
 val implementation_status : string -> implementation_status
 val effect_domain : string -> effect_domain option
+val is_main_worktree_boundary_exempt : string -> bool option
 val requires_actor_binding : string -> bool
 val tool_group : string -> tool_group option
 val canonical_tool_name : string -> string


### PR DESCRIPTION
## Summary
- `dune build .` 가 main HEAD에서 두 개의 Unbound value 로 실패하는 merge regression 복구.
- `Tool_catalog.is_main_worktree_boundary_exempt` 와 `Keeper_tool_registry.is_main_worktree_boundary_exempt_with_input` 두 심볼을 caller code 가 이미 가정하는 형태로 그대로 복원만 한다. 새 로직/표면 확장 없음.

## Why this regression happened
- `ca004ad72` ("refactor(tools): drop legacy worktree boundary helper") 가 main 에서 helper + caller 한 쌍을 정합하게 드롭.
- PR #18915 의 sub-commit `a3a58bfef` 가 그 드롭 이전에 분기된 상태에서 caller 만 다시 가져옴 → fast-forward merge 시점에 main 의 catalog 쪽엔 helper 가 이미 없어서 빌드가 깨짐.
- 평행 RFC-0182 브랜치 `feat/rfc-0182-phase5-pr-a-ctx-eio-extend` 의 `5e5d0684d` 가 이미 동일 fix 를 가지고 있으나 main 에 도달 못 함.

## Changes
- `lib/tool_catalog.ml` (+6): `is_main_worktree_boundary_exempt` 정의 — `effect_domain` 위에 얹는 derived classification.
- `lib/tool_catalog.mli` (+1): val 노출.
- `lib/keeper/keeper_tool_registry.mli` (+6): 이미 `lib/keeper/keeper_tool_registry.ml:185` 에 정의돼 있는 `is_main_worktree_boundary_exempt_with_input` 을 test 와 외부 호출자에게 노출.

## Workaround Bar self-check
- 텔레메트리-as-fix ❌  · substring 분류기 ❌  · N-of-M ❌  · catch-all 추가 ❌  · cap/cooldown/dedup/repair ❌  · test backdoor ❌  · 동일 typo 다중 사이트 ❌
- 본질적으로 caller-already-assumed missing-val 복구 (deletion 의 짝맞춤 누락 보정).

## Test plan
- [x] `dune build . --root .` (worktree, origin/main 베이스) → EXIT=0
- [ ] CI: build + test_agent_tool_descriptor_registry_integrity (WriteFile / Execute playground exempt 2 assertions)
