### PR TITLE
fix(tool-catalog): restore worktree boundary helper

### DIFF
--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -55,6 +55,12 @@ val has_mutating_side_effect : string -> bool
 val is_read_only_with_input :
   tool_name:string -> input:Yojson.Safe.t -> bool
 
+(** Input-aware mutation-boundary exemption. Read-only calls and tools whose
+    descriptor/catalog effect domain is coordination or playground-scoped do not
+    open the main-worktree checkpoint boundary. *)
+val is_main_worktree_boundary_exempt_with_input :
+  tool_name:string -> input:Yojson.Safe.t -> bool
+
 (** Tools whose mutations are safe to leave un-reconciled after
     a transient failure (board posts, broadcasts, task_done). *)
 val reconcile_safe_tools : string list


### PR DESCRIPTION
## Summary

- restore `val is_main_worktree_boundary_exempt_with_input` in `lib/keeper/keeper_tool_registry.mli` (6 lines, signature-only)

Cherry-pick of `f436dc0f0` (already authored 2026-05-27, currently bundled in 3 in-flight PRs #18916/#18924/#18934, none merged due to upstream conflicts / stacking). Unblocks main's `Build and Test` which fails with `Error: Unbound value Registry.is_main_worktree_boundary_exempt_with_input` from `test/test_agent_tool_descriptor_registry_integrity.ml`.

`lib/tool_catalog.ml` + `lib/tool_catalog.mli` portions of the original commit are already on main; only the `keeper_tool_registry.mli` `val` was missing.

## Verification

- `dune build --root . test/test_agent_tool_descriptor_registry_integrity.exe` — PASS
- `_build/default/test/test_agent_tool_descriptor_registry_integrity.exe` — PASS
- `ocamlformat --check lib/keeper/keeper_tool_registry.mli` — PASS
- `git diff --check origin/main..HEAD` — PASS
- `bash ~/me/scripts/pr-rfc-check.sh --pr-body /tmp/pr_body_boundary.md` — PASS

## Related

- Unblocks #18843 (refactor: purge typed Execute normalizers) and other in-flight PRs sharing the same main breakage
- Original commit by @jeong-sik bundled into #18916 (CONFLICTING base #18834), #18924 (stacked on #18916), #18934 (stacked on #18929)
