### PR TITLE
refactor(keeper): project capability axis through descriptors

### DIFF
--- a/lib/keeper/keeper_tool_capability_axis.ml
+++ b/lib/keeper/keeper_tool_capability_axis.ml
@@ -2,7 +2,7 @@
 
     Callers may pass public aliases ([Execute], [WriteFile], ...), public MCP
     names, prefixed MCP names, or internal handler names. This module
-    normalizes names through the alias SSOT before answering capability
+    normalizes names through descriptor resolution before answering capability
     predicates. *)
 
 type t =
@@ -27,11 +27,9 @@ let masc_keeper_name (tool : Tool_name.Masc_keeper.t) =
 
 let canonical_tool_name name =
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
-  match Keeper_tool_alias.canonical_resolution name with
-  | Keeper_tool_alias.Public_mcp { internal; _ }
-  | Keeper_tool_alias.Public_alias { internal } -> internal
-  | Keeper_tool_alias.Internal { canonical } -> canonical
-  | Keeper_tool_alias.Unknown -> stripped
+  match Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name name with
+  | Some internal -> internal
+  | None -> stripped
 ;;
 
 let candidate_names name =

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -616,7 +616,10 @@ let test_keeper_semantic_capabilities_use_capability_axis () =
   let registry = "lib/keeper/keeper_tool_registry.ml" in
   let registry_mli = "lib/keeper/keeper_tool_registry.mli" in
   assert_contains "lib/dune" "keeper_tool_capability_axis";
-  assert_contains axis "Keeper_tool_alias.canonical_resolution";
+  assert_contains
+    axis
+    "Agent_tool_descriptor_resolution.canonical_internal_name_for_tool_name";
+  assert_not_contains axis "Keeper_tool_alias.canonical_resolution";
   assert_not_contains axis "Keeper_tool_alias.route";
   assert_not_contains axis "Keeper_tool_alias.public_masc_to_internal";
   assert_contains contract_classifier "Keeper_tool_capability_axis.supports_any";


### PR DESCRIPTION
## Summary
- normalize keeper semantic capability tool names through Agent_tool_descriptor_resolution
- remove direct Keeper_tool_alias.canonical_resolution from keeper_tool_capability_axis
- extend boundary ratchet for the descriptor-backed capability path

## Verification
- ocamlformat --check lib/keeper/keeper_tool_capability_axis.ml test/test_keeper_sandbox_boundary_policy.ml
- rg -n "Keeper_tool_alias\.canonical_resolution|Keeper_tool_alias\.route|Keeper_tool_alias\.public_masc_to_internal" lib/keeper/keeper_tool_capability_axis.ml
- git diff --check origin/refactor/tool-resolution-descriptor-projection-20260527...HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build ./test/test_keeper_sandbox_boundary_policy.exe
- ./_build/default/test/test_keeper_sandbox_boundary_policy.exe
- scripts/ci/check-determinism-contract.sh

Stacked on #18934 after #18937 was merged into its base.