### PR TITLE
refactor(dashboard/lib): consolidate record-based hasNonEmptyString SSOT

### DIFF
--- a/dashboard/src/components/common/normalize.ts
+++ b/dashboard/src/components/common/normalize.ts
@@ -1,9 +1,9 @@
 // Shared type-safe normalization utilities for unknown API/SSE payloads.
 // Single source of truth — all dashboard modules import from here.
 
-import { isRecord } from '../../lib/type-guards'
+import { isRecord, hasNonEmptyStringField } from '../../lib/type-guards'
 import { unixSecondsToDate } from '../../lib/format-time'
-export { isRecord }
+export { isRecord, hasNonEmptyStringField }
 
 export function asString(value: unknown): string | undefined
 export function asString(value: unknown, fallback: string): string

--- a/dashboard/src/components/ide/keeper-presence-store.ts
+++ b/dashboard/src/components/ide/keeper-presence-store.ts
@@ -1,5 +1,5 @@
 import { signal } from '@preact/signals'
-import { isRecord } from '../common/normalize'
+import { hasNonEmptyStringField, isRecord } from '../common/normalize'
 
 export type KeeperPresenceStatus = 'active' | 'idle' | 'blocked'
 
@@ -119,8 +119,6 @@ export function createKeeperPresenceStore(
   }
 }
 
-type UnknownRecord = Record<string, unknown>
-
 function isPresenceSnapshot(value: unknown): value is KeeperPresenceSnapshot {
   if (!isRecord(value)) return false
   const k = value['kind']
@@ -135,7 +133,7 @@ function withSortedEntries(snap: KeeperPresenceSnapshot): KeeperPresenceSnapshot
 
 function normalizeSnapshot(value: unknown): KeeperPresenceSnapshot | null {
   if (!isRecord(value)) return null
-  if (!hasNonEmptyString(value, 'runtime_id')) return null
+  if (!hasNonEmptyStringField(value, 'runtime_id')) return null
   if (!Array.isArray(value.entries)) return null
 
   const entries = value.entries
@@ -143,8 +141,8 @@ function normalizeSnapshot(value: unknown): KeeperPresenceSnapshot | null {
     .filter((entry): entry is KeeperPresenceEntry => entry !== null)
     .sort(compareEntries)
 
-  const branch = hasNonEmptyString(value, 'branch') ? (value['branch'] as string) : undefined
-  const supervisor = hasNonEmptyString(value, 'supervisor') ? (value['supervisor'] as string) : undefined
+  const branch = hasNonEmptyStringField(value, 'branch') ? (value['branch'] as string) : undefined
+  const supervisor = hasNonEmptyStringField(value, 'supervisor') ? (value['supervisor'] as string) : undefined
 
   const live: KeeperPresenceSnapshot = {
     kind: 'live',
@@ -158,9 +156,9 @@ function normalizeSnapshot(value: unknown): KeeperPresenceSnapshot | null {
 
 function normalizeEntry(value: unknown): KeeperPresenceEntry | null {
   if (!isRecord(value)) return null
-  if (!hasNonEmptyString(value, 'keeper_id')) return null
-  if (!hasNonEmptyString(value, 'workspace_label')) return null
-  if (!hasNonEmptyString(value, 'role')) return null
+  if (!hasNonEmptyStringField(value, 'keeper_id')) return null
+  if (!hasNonEmptyStringField(value, 'workspace_label')) return null
+  if (!hasNonEmptyStringField(value, 'role')) return null
   if (!isKeeperPresenceStatus(value['status'])) return null
   if (!Number.isFinite(value['last_seen_ms'])) return null
 
@@ -178,11 +176,6 @@ function compareEntries(a: KeeperPresenceEntry, b: KeeperPresenceEntry): number 
   if (statusDelta !== 0) return statusDelta
   if (a.last_seen_ms !== b.last_seen_ms) return b.last_seen_ms - a.last_seen_ms
   return a.keeper_id.localeCompare(b.keeper_id)
-}
-
-function hasNonEmptyString(record: UnknownRecord, key: string): boolean {
-  const value = record[key]
-  return typeof value === 'string' && value.trim() !== ''
 }
 
 function isKeeperPresenceStatus(value: unknown): value is KeeperPresenceStatus {

--- a/dashboard/src/components/ide/run-activity-store.ts
+++ b/dashboard/src/components/ide/run-activity-store.ts
@@ -7,7 +7,7 @@
  */
 
 import { signal } from '@preact/signals'
-import { isRecord } from '../common/normalize'
+import { hasNonEmptyStringField, isRecord } from '../common/normalize'
 
 const DEFAULT_MAX_EVENTS = 200
 const RUN_ACTIVITY_VERBS = [
@@ -129,8 +129,6 @@ export function createRunActivityStore(
   }
 }
 
-type UnknownRecord = Record<string, unknown>
-
 function normalizeMaxEvents(value: number | undefined): number {
   if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return value
   return DEFAULT_MAX_EVENTS
@@ -139,20 +137,15 @@ function normalizeMaxEvents(value: number | undefined): number {
 function validEventForRun(event: unknown, runId: string): event is RunActivityEvent {
   if (!isRecord(event)) return false
   if (event.run_id !== runId) return false
-  if (!hasNonEmptyString(event, 'id')) return false
-  if (!hasNonEmptyString(event, 'keeper_id')) return false
-  if (!hasNonEmptyString(event, 'target')) return false
+  if (!hasNonEmptyStringField(event, 'id')) return false
+  if (!hasNonEmptyStringField(event, 'keeper_id')) return false
+  if (!hasNonEmptyStringField(event, 'target')) return false
   if (!isRunActivityVerb(event.verb)) return false
   if (event.detail !== undefined && typeof event.detail !== 'string') return false
   if (event.kind !== undefined && typeof event.kind !== 'string') return false
   if (event.tags !== undefined && !isStringArray(event.tags)) return false
   if (event.context !== undefined && !isRunActivityContext(event.context)) return false
   return Number.isFinite(event.timestamp_ms)
-}
-
-function hasNonEmptyString(record: UnknownRecord, key: string): boolean {
-  const value = record[key]
-  return typeof value === 'string' && value.trim() !== ''
 }
 
 function isStringArray(value: unknown): value is ReadonlyArray<string> {

--- a/dashboard/src/lib/type-guards.ts
+++ b/dashboard/src/lib/type-guards.ts
@@ -4,3 +4,17 @@
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
+
+/**
+ * Check that a record field exists, is a string, and contains non-whitespace content.
+ *
+ * Distinguished from `common/*` value-based `hasNonEmptyString(value)` by signature
+ * (record + key vs value-only) — keep names different so callers can't mix them up.
+ */
+export function hasNonEmptyStringField(
+  record: Record<string, unknown>,
+  key: string,
+): boolean {
+  const value = record[key]
+  return typeof value === 'string' && value.trim() !== ''
+}


### PR DESCRIPTION
## 요약

`hasNonEmptyString` record-룩업 변형이 `ide/run-activity-store.ts` 와 `ide/keeper-presence-store.ts` 에 **byte-for-byte 동일** 정의로 분산. 동반 type alias `UnknownRecord` 도 양쪽 동일. lib-shadowing 2 일차. iter#14 의 lib-shadowing 흐름 연속.

## 기존 위반

| 파일 | 정의 |
|---|---|
| `src/components/ide/run-activity-store.ts:132,153` | `type UnknownRecord = Record<string, unknown>` + `hasNonEmptyString(record, key)` internal |
| `src/components/ide/keeper-presence-store.ts:122,183` | 동일 본체 internal |

본체 `typeof value === 'string' && value.trim() !== ''` (record 기반 string field non-empty 체크) — 양쪽 동일. `UnknownRecord` 도 양쪽 동일.

## 동음이의어 회피: 새 이름 `hasNonEmptyStringField`

같은 코드베이스에 *시그니처 다른* `hasNonEmptyString(value: string | undefined)` 가 `common/button`/`common/checkbox`/`common/card` 3 곳에 존재 (값 기반 체크). 둘을 같은 이름으로 SSOT 추출하면 자동완성 collision + 호출 사이트 가독성 손실. iter#9~12 학습 — **별칭 회피보다 정의 이름에 도메인을 박는다**. record 기반 변형을 `hasNonEmptyStringField` 로 분리해 두 그룹 모두 명확하게.

## 변경

- `lib/type-guards.ts`: `hasNonEmptyStringField(record, key)` 추가. 기존 `isRecord` 와 같은 record 가드 layer 의 SSOT 위치.
- `components/common/normalize.ts`: `hasNonEmptyStringField` re-export 추가 (기존 `isRecord` 와 동일 패턴 — ide 두 store 가 이미 `common/normalize` 경유 import 중이라 자연스러운 path).
- `components/ide/run-activity-store.ts`: 로컬 `UnknownRecord` type alias 삭제, 로컬 `hasNonEmptyString` 정의 삭제, import 갱신, 3 호출 사이트 → `hasNonEmptyStringField`.
- `components/ide/keeper-presence-store.ts`: 동일 처리, 6 호출 사이트 변경.

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run src/components/ide/run-activity-store src/components/ide/keeper-presence-store src/lib/`: 665/665 (41 test files)
- `pnpm exec eslint`: 0 errors

표면 동작 회귀 없음 — 함수 본체 동일.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#15, lib-shadowing 2 일차)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] IDE run-activity / keeper-presence 표면이 normalize 단계에서 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
