### PR TITLE
refactor(keeper): type alert send results

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -113,7 +113,7 @@
 <body>
   <header>
     <h1>MASC Legacy Purge Plan</h1>
-    <div class="meta">Snapshot: 2026-05-27 13:20:47 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
+    <div class="meta">Snapshot: 2026-05-27 13:30:53 KST. Scope: Keeper, Cascade, Tools, Memory surfaces in masc-mcp.</div>
   </header>
   <main>
     <section class="grid" aria-label="summary">
@@ -841,15 +841,21 @@
           </tr>
           <tr>
             <td><code>Tool_bridge.of_oas_tool_result</code> reverse tuple projection</td>
-            <td><span class="status now">draft PR #18936</span></td>
+            <td><span class="status done">merged #18936</span></td>
             <td>Remove the unused OAS-to-<code>bool * string</code> helper so the bridge only converts typed MASC results into typed OAS results, not back into legacy tuple shape.</td>
             <td>There are no active callers. Backstop <code>rg "of_oas_tool_result|Agent_sdk.Types.tool_result -&gt; bool \\* string" lib test</code> is clean after deleting the implementation and interface entry.</td>
           </tr>
           <tr>
             <td>Unused session/progress/subscription tuple tool handlers</td>
-            <td><span class="status now">draft PR #18939</span></td>
+            <td><span class="status done">merged #18939</span></td>
             <td>Delete the unused public helpers that returned <code>bool * string</code> instead of migrating them into another compatibility shape. The live inline tool path already has typed dispatch.</td>
             <td>Remove <code>handle_mcp_session_tool</code>, <code>handle_progress_tool</code>, and <code>handle_subscription_tool</code> plus tests that existed only to preserve those helper contracts. Progress validation tests now call validation functions directly.</td>
+          </tr>
+          <tr>
+            <td>Keeper alerting channel send result tuples</td>
+            <td><span class="status now">draft PR #18944</span></td>
+            <td>Replace <code>bool * string option</code> alert send returns with <code>Alert_sent</code> / <code>Alert_failed</code>, keeping the existing channel result record as the fanout summary.</td>
+            <td>Backstop <code>rg "bool \\* string option|send_once : unit -&gt; bool" lib/keeper/keeper_alerting*</code> is clean after the change.</td>
           </tr>
           <tr>
             <td>Legacy checkpoint / sidecar recovery</td>
@@ -884,11 +890,7 @@
         </thead>
         <tbody>
           <tr>
-            <td>1</td>
-            <td>Keeper alerting channel status tuples</td>
-            <td><code>Keeper_alerting</code> uses <code>bool * string option</code> status returns, which is not the tool-result contract but still makes success/error semantics easy to flatten.</td>
-            <td>Replace with a small local variant such as <code>Sent | Skipped of string | Failed of string</code> if the channel call sites benefit from stricter states.</td>
-            <td>Backstop <code>rg "bool \\* string option" lib/keeper/keeper_alerting*</code>; skip if the variant adds more ceremony than clarity.</td>
+            <td colspan="5">No queued tuple-result candidate remains in this narrow Tool/Keeper result purge queue. Next broad scan should switch to Cascade fallback naming or Memory compatibility surfaces.</td>
           </tr>
         </tbody>
       </table>

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -48,11 +48,22 @@ let alert_retry_delay_seconds (attempt : int) : float =
   let factor = pow2 (max 0 (attempt - 1)) 1 in
   float_of_int (base_ms * factor) /. 1000.0
 
+type alert_send_result =
+  | Alert_sent of string option
+  | Alert_failed of string option
+
+let alert_send_success = function
+  | Alert_sent _ -> true
+  | Alert_failed _ -> false
+
+let alert_send_detail = function
+  | Alert_sent detail | Alert_failed detail -> detail
+
 let run_alert_channel_with_retry
     (ctx : _ context)
     ~(channel : string)
     ~(enabled : bool)
-    ~(send_once : unit -> bool * string option) : alert_channel_result =
+    ~(send_once : unit -> alert_send_result) : alert_channel_result =
   if not enabled then
     {
       channel;
@@ -64,7 +75,9 @@ let run_alert_channel_with_retry
   else
     let max_attempts = 1 + max 0 Env_config.KeeperAlert.max_retries in
     let rec loop attempt last_error =
-      let (ok, detail_opt) = send_once () in
+      let send_result = send_once () in
+      let ok = alert_send_success send_result in
+      let detail_opt = alert_send_detail send_result in
       let detail =
         match detail_opt with
         | Some s when String.trim s <> "" -> Some (short_preview ~max_len:Keeper_config.alert_error_detail_max_chars s)
@@ -269,7 +282,7 @@ let keeper_alert_text
     message_preview reply_preview
 
 let post_keeper_alert_board
-    ~(alert_text : string) : bool * string option =
+    ~(alert_text : string) : alert_send_result =
   let author = let v = String.trim Env_config.KeeperAlert.board_author in
     if v = "" then "keeper-alert-bot" else v in
   let hearth_opt = let v = String.trim Env_config.KeeperAlert.board_hearth in
@@ -287,14 +300,14 @@ let post_keeper_alert_board
       ~post_kind:Board.System_post ?meta_json
       ~visibility ~ttl_hours:24 ?hearth:hearth_opt ()
   with
-  | Ok _ -> (true, Some "board_posted")
-  | Error e -> (false, Some (Board.show_board_error e))
+  | Ok _ -> Alert_sent (Some "board_posted")
+  | Error e -> Alert_failed (Some (Board.show_board_error e))
 
 let post_keeper_alert_slack
-    ~(alert_text : string) : bool * string option =
+    ~(alert_text : string) : alert_send_result =
   let webhook = String.trim Env_config.KeeperAlert.slack_webhook_url in
   if webhook = "" then
-    (false, Some "missing_webhook")
+    Alert_failed (Some "missing_webhook")
   else
     let payload = `Assoc [ ("text", `String alert_text) ] |> Yojson.Safe.to_string in
     let argv = [
@@ -317,13 +330,13 @@ let post_keeper_alert_slack
         argv
     in
     match status with
-    | Unix.WEXITED 0 -> (true, Some "slack_posted")
+    | Unix.WEXITED 0 -> Alert_sent (Some "slack_posted")
     | Unix.WEXITED n ->
-        (false, Some (Printf.sprintf "curl_exit_%d: %s" n (short_preview ~max_len:200 out)))
+        Alert_failed (Some (Printf.sprintf "curl_exit_%d: %s" n (short_preview ~max_len:200 out)))
     | Unix.WSIGNALED n ->
-        (false, Some (Printf.sprintf "curl_signaled_%d" n))
+        Alert_failed (Some (Printf.sprintf "curl_signaled_%d" n))
     | Unix.WSTOPPED n ->
-        (false, Some (Printf.sprintf "curl_stopped_%d" n))
+        Alert_failed (Some (Printf.sprintf "curl_stopped_%d" n))
 
 let slack_alert_token () : string option =
   let pick name =
@@ -392,20 +405,20 @@ let slack_ok_or_error (json : Yojson.Safe.t) : (unit, string) result =
 
 let post_keeper_alert_slack_dm
     ~(alert_text : string)
-    ~(user_id : string) : bool * string option =
+    ~(user_id : string) : alert_send_result =
   let target = String.trim user_id in
   if target = "" then
-    (false, Some "missing_dm_user_id")
+    Alert_failed (Some "missing_dm_user_id")
   else
     match slack_alert_token () with
-    | None -> (false, Some "missing_slack_token")
+    | None -> Alert_failed (Some "missing_slack_token")
     | Some token ->
         let open_payload = `Assoc [ ("users", `String target) ] in
         match slack_api_post_json ~token ~endpoint:"conversations.open" ~payload:open_payload with
-        | Error e -> (false, Some ("dm_open_failed: " ^ e))
+        | Error e -> Alert_failed (Some ("dm_open_failed: " ^ e))
         | Ok open_json ->
             (match slack_ok_or_error open_json with
-             | Error e -> (false, Some ("dm_open_failed: " ^ e))
+             | Error e -> Alert_failed (Some ("dm_open_failed: " ^ e))
              | Ok () ->
                  let channel_id =
                    let open Yojson.Safe.Util in
@@ -414,18 +427,18 @@ let post_keeper_alert_slack_dm
                    | _ -> None
                  in
                  (match channel_id with
-                  | None -> (false, Some "dm_open_failed: missing_channel_id")
+                  | None -> Alert_failed (Some "dm_open_failed: missing_channel_id")
                   | Some cid ->
                       let post_payload = `Assoc [
                         ("channel", `String cid);
                         ("text", `String alert_text);
                       ] in
                       (match slack_api_post_json ~token ~endpoint:"chat.postMessage" ~payload:post_payload with
-                       | Error e -> (false, Some ("dm_post_failed: " ^ e))
+                       | Error e -> Alert_failed (Some ("dm_post_failed: " ^ e))
                        | Ok post_json ->
                            (match slack_ok_or_error post_json with
-                            | Ok () -> (true, Some ("dm_sent:" ^ cid))
-                            | Error e -> (false, Some ("dm_post_failed: " ^ e))))))
+                            | Ok () -> Alert_sent (Some ("dm_sent:" ^ cid))
+                            | Error e -> Alert_failed (Some ("dm_post_failed: " ^ e))))))
 
 let split_csv_nonempty (raw : string) : string list =
   raw
@@ -435,10 +448,10 @@ let split_csv_nonempty (raw : string) : string list =
 
 let post_keeper_alert_github
     ~(title : string)
-    ~(body : string) : bool * string option =
+    ~(body : string) : alert_send_result =
   let repo = String.trim Env_config.KeeperAlert.github_repo in
   if repo = "" then
-    (false, Some "missing_repo")
+    Alert_failed (Some "missing_repo")
   else
     let labels = split_csv_nonempty Env_config.KeeperAlert.github_label in
     let args = [
@@ -458,13 +471,13 @@ let post_keeper_alert_github
         args
     in
     match status with
-    | Unix.WEXITED 0 -> (true, Some (short_preview ~max_len:200 out))
+    | Unix.WEXITED 0 -> Alert_sent (Some (short_preview ~max_len:200 out))
     | Unix.WEXITED n ->
-        (false, Some (Printf.sprintf "gh_exit_%d: %s" n (short_preview ~max_len:200 out)))
+        Alert_failed (Some (Printf.sprintf "gh_exit_%d: %s" n (short_preview ~max_len:200 out)))
     | Unix.WSIGNALED n ->
-        (false, Some (Printf.sprintf "gh_signaled_%d" n))
+        Alert_failed (Some (Printf.sprintf "gh_signaled_%d" n))
     | Unix.WSTOPPED n ->
-        (false, Some (Printf.sprintf "gh_stopped_%d" n))
+        Alert_failed (Some (Printf.sprintf "gh_stopped_%d" n))
 
 let maybe_emit_interesting_alert
     (ctx : _ context)

--- a/lib/keeper/keeper_alerting.mli
+++ b/lib/keeper/keeper_alerting.mli
@@ -40,12 +40,16 @@ val alert_retryable_error : string -> bool
 (** Compute retry delay in seconds with exponential backoff. *)
 val alert_retry_delay_seconds : int -> float
 
+type alert_send_result =
+  | Alert_sent of string option
+  | Alert_failed of string option
+
 (** Run a single alert channel with retry logic. *)
 val run_alert_channel_with_retry :
   _ context ->
   channel:string ->
   enabled:bool ->
-  send_once:(unit -> bool * string option) ->
+  send_once:(unit -> alert_send_result) ->
   alert_channel_result
 
 (** {1 Alert Deduplication} *)
@@ -102,16 +106,16 @@ val keeper_alert_text :
 (** {1 Alert Channel Posting} *)
 
 val post_keeper_alert_board :
-  alert_text:string -> bool * string option
+  alert_text:string -> alert_send_result
 
 val post_keeper_alert_slack :
-  alert_text:string -> bool * string option
+  alert_text:string -> alert_send_result
 
 val post_keeper_alert_slack_dm :
-  alert_text:string -> user_id:string -> bool * string option
+  alert_text:string -> user_id:string -> alert_send_result
 
 val post_keeper_alert_github :
-  title:string -> body:string -> bool * string option
+  title:string -> body:string -> alert_send_result
 
 (** {1 Alert Orchestration} *)
 


### PR DESCRIPTION
## Summary

- replace `bool * string option` alert send returns with `Alert_sent` / `Alert_failed`
- update alert retry fanout to consume the typed send result
- mark merged tuple-handler slices in the purge-plan HTML and clear the narrow tuple-result queue

## Verification

- `ocamlformat --check lib/keeper/keeper_alerting.ml lib/keeper/keeper_alerting.mli`
- `rg -n "bool \\* string option|send_once : unit -> bool|send_once:\\(unit -> bool|alert_text:string -> bool|title:string -> body:string -> bool|\\(true, Some|\\(false, Some" lib/keeper/keeper_alerting.ml lib/keeper/keeper_alerting.mli` returns no matches
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`

Focused Dune was attempted with `scripts/dune-local.sh build lib/masc_mcp.cma`, but the machine-wide bare-Dune guard refused to start another local build because other bare Dune processes are already running. I did not bypass it.
