### PR TITLE
refactor(dashboard/lib): consolidate firstNonEmptyString SSOT in format-string

### DIFF
--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -4,6 +4,7 @@ import { telemetrySourceLabel } from '../config/telemetry-sources'
 import type { Keeper, StopCause } from '../types'
 import { formatElapsedCompact } from '../lib/format-time'
 import { formatMsCompact } from '../lib/format-number'
+import { firstNonEmptyString } from '../lib/format-string'
 import { normalizeStopCause } from '../lib/stop-cause'
 import {
   keeperActivityDisplay,
@@ -128,13 +129,7 @@ export function normalizeModelText(value: string | null | undefined): string | n
   return text == null || isPlaceholderModel(text) ? null : text
 }
 
-export function firstNonEmptyString(...values: Array<string | null | undefined>): string | null {
-  for (const value of values) {
-    const normalized = normalizeText(value)
-    if (normalized) return normalized
-  }
-  return null
-}
+export { firstNonEmptyString }
 
 export function uniqueStrings(values: Array<string | null | undefined>): string[] {
   const seen = new Set<string>()

--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import type { Goal, Keeper, Task } from '../../types'
 import { goals, keepers, tasks } from '../../store'
+import { firstNonEmptyString } from '../../lib/format-string'
 import { KeeperBadge } from '../keeper-badge'
 import {
   formatProgressPct,
@@ -287,18 +288,18 @@ function taskExecutionRouteContext(task: Task): {
   readonly telemetryQuery: string | null
   readonly hasTelemetry: boolean
 } {
-  const sessionId = firstNonEmpty(
+  const sessionId = firstNonEmptyString(
     task.execution_links?.session_id,
     task.contract?.links?.session_id,
   )
-  const operationId = firstNonEmpty(
+  const operationId = firstNonEmptyString(
     task.execution_links?.operation_id,
     task.contract?.links?.operation_id,
   )
   return {
     sessionId,
     operationId,
-    telemetryQuery: firstNonEmpty(operationId, sessionId),
+    telemetryQuery: firstNonEmptyString(operationId, sessionId),
     hasTelemetry: Boolean(sessionId || operationId),
   }
 }
@@ -334,7 +335,7 @@ export function keeperWorkSummary(
 ): KeeperWorkSummary {
   const displayName = normalizedKeeperName(keeperName)
   const keeper = findKeeper(displayName, keeperList)
-  const explicitCurrentTaskId = firstNonEmpty(keeper?.agent?.current_task)
+  const explicitCurrentTaskId = firstNonEmptyString(keeper?.agent?.current_task)
   const assigneeTasks = taskList
     .filter(task => taskMatchesKeeper(task, displayName, keeper))
     .filter(task => task.status !== 'done' && task.status !== 'cancelled')
@@ -342,14 +343,14 @@ export function keeperWorkSummary(
     ? taskList.find(task => task.id === explicitCurrentTaskId) ?? null
     : null
   const activeTasks = uniqTasks(currentTaskById ? [currentTaskById, ...assigneeTasks] : assigneeTasks)
-  const currentTaskId = firstNonEmpty(
+  const currentTaskId = firstNonEmptyString(
     explicitCurrentTaskId,
     activeTasks[0]?.id,
   )
   const currentTask = currentTaskId
     ? activeTasks.find(task => task.id === currentTaskId) ?? null
     : activeTasks[0] ?? null
-  const currentGoalId = firstNonEmpty(
+  const currentGoalId = firstNonEmptyString(
     currentTask?.goal_id,
     activeTasks.find(task => task.goal_id)?.goal_id,
   )
@@ -363,22 +364,22 @@ export function keeperWorkSummary(
     currentTask,
     activeTasks,
     activeTaskCount: currentTaskId && activeTasks.length === 0 ? 1 : activeTasks.length,
-    terminalCode: firstNonEmpty(latestTerminal?.code, keeper?.runtime_blocker_class),
-    terminalSummary: firstNonEmpty(
+    terminalCode: firstNonEmptyString(latestTerminal?.code, keeper?.runtime_blocker_class),
+    terminalSummary: firstNonEmptyString(
       latestTerminal?.summary,
       keeper?.runtime_blocker_summary,
       trust?.attention_reason,
       keeper?.attention_reason,
     ),
-    nextAction: firstNonEmpty(
+    nextAction: firstNonEmptyString(
       latestTerminal?.next_action,
       trust?.latest_next_action,
       trust?.next_human_action,
       keeper?.next_human_action,
     ),
-    recentOutput: firstNonEmpty(keeper?.recent_output_preview, keeper?.recent_input_preview),
+    recentOutput: firstNonEmptyString(keeper?.recent_output_preview, keeper?.recent_input_preview),
     recentTools: keeper?.recent_tool_names ?? keeper?.latest_tool_names ?? EMPTY_TOOLS,
-    runtimeBlocker: firstNonEmpty(keeper?.runtime_blocker_summary, keeper?.last_blocker),
+    runtimeBlocker: firstNonEmptyString(keeper?.runtime_blocker_summary, keeper?.last_blocker),
   }
 }
 
@@ -432,14 +433,6 @@ function queuedActiveTasks(
 
 function normalizedKeeperName(value: string): string {
   return canonicalKeeperName(value) ?? value.trim()
-}
-
-function firstNonEmpty(...values: ReadonlyArray<string | null | undefined>): string | null {
-  for (const value of values) {
-    const trimmed = value?.trim()
-    if (trimmed) return trimmed
-  }
-  return null
 }
 
 function resolveKeeperCursor(

--- a/dashboard/src/lib/format-string.ts
+++ b/dashboard/src/lib/format-string.ts
@@ -5,3 +5,20 @@ export function capitalize(text: string): string {
   if (!text) return text
   return text.charAt(0).toUpperCase() + text.slice(1)
 }
+
+/**
+ * Return the first value that, after trimming, has non-whitespace content.
+ *
+ * Treats `null`, `undefined`, empty strings, and whitespace-only strings as
+ * absent. Returns the trimmed form (not the original) so callers don't have
+ * to re-trim. Returns `null` when every input is absent.
+ */
+export function firstNonEmptyString(
+  ...values: ReadonlyArray<string | null | undefined>
+): string | null {
+  for (const value of values) {
+    const trimmed = value?.trim()
+    if (trimmed) return trimmed
+  }
+  return null
+}

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -1,5 +1,6 @@
 import type { Keeper, KeeperRuntimeBlockerClass } from '../types'
 import { relativeTime } from './format-time'
+import { firstNonEmptyString } from './format-string'
 import { isKeeperPaused } from './keeper-predicates'
 
 /** Max seconds since last heartbeat to consider the keeper process alive. */
@@ -143,14 +144,6 @@ export function keeperDisplayStatus(keeper: Keeper | null | undefined, fallbackS
   return status && status.trim() !== '' ? status : 'unknown'
 }
 
-function firstNonEmpty(...values: Array<string | null | undefined>): string | null {
-  for (const value of values) {
-    const text = trimmed(value)
-    if (text) return text
-  }
-  return null
-}
-
 function codeLabel(value: string | null | undefined): string | null {
   const text = trimmed(value)
   return text ? text.replace(/_/g, ' ') : null
@@ -177,14 +170,14 @@ export function keeperPauseDisplay(keeper: Keeper): KeeperPauseDisplay | null {
     blockerLabel
     ?? attentionReasonForPause(keeper.attention_reason)
     ?? attentionReasonForPause(trust?.attention_reason)
-    ?? firstNonEmpty(
+    ?? firstNonEmptyString(
       keeper.runtime_blocker_summary,
       trust?.latest_terminal_reason?.summary,
       keeper.diagnostic?.continuity_summary,
       keeper.diagnostic?.summary,
     )
     ?? '운영자 일시정지'
-  const nextAction = firstNonEmpty(
+  const nextAction = firstNonEmptyString(
     codeLabel(keeper.next_human_action),
     codeLabel(trust?.next_human_action),
     codeLabel(trust?.latest_next_action),


### PR DESCRIPTION
## 요약

`firstNonEmpty` 가 *시멘틱 동일* 한 두 정의로 분산 + 이미 `firstNonEmptyString` 라는 명시적 이름의 SSOT-shaped 형제가 `fleet-telemetry-utils` 안에 components 디렉토리 깊숙이 묻혀있음. iter#15 의 lib-shadowing 흐름 연속. *시그니처가 다른* `cascade-config-panel.firstNonEmpty` (array+string 리턴) 는 동음이의어 — iter#16 scope 밖.

## 기존 위반

| 파일 | 정의 |
|---|---|
| `src/components/ide/ide-keeper-work-panel.ts:437` | `firstNonEmpty(...values: ReadonlyArray<string \| null \| undefined>): string \| null` — rest, trim 후 truthy 반환 |
| `src/lib/keeper-runtime-display.ts:146` | `firstNonEmpty(...values: Array<string \| null \| undefined>): string \| null` — 외부 `trimmed()` helper 의존, 동일 시멘틱 |
| `src/components/fleet-telemetry-utils.ts:131` | `firstNonEmptyString(...values: Array<string \| null \| undefined>): string \| null` — **이미 export**, `normalizeText()` 의존 |

본체 표현은 셋이 다르지만 시멘틱은 동일 — null/undefined/empty/whitespace-only 를 absent 로 취급, 첫 non-empty 의 trimmed 형태 반환, 모두 absent 시 null. 호출 사이트는 ide-keeper-work-panel 12 + keeper-runtime-display 2 = 14.

## SSOT 위치

`src/lib/format-string.ts` (기존 unified string formatting SSOT — `capitalize` 보유). `firstNonEmptyString` 을 **self-contained** (인라인 `value?.trim()` 사용, 외부 helper 의존 없음) 으로 정의. components/* 의 fleet-telemetry-utils 가 횡적으로 의존되는 *역방향 의존* 회피.

## 변경

- `lib/format-string.ts`: `firstNonEmptyString` self-contained 정의 추가 (rest, trim, null 리턴).
- `components/fleet-telemetry-utils.ts`: 자체 정의 삭제 + `lib/format-string` import + `export { firstNonEmptyString }` re-export 유지 → test 무영향.
- `components/ide/ide-keeper-work-panel.ts`: 자체 `firstNonEmpty` 정의 삭제 + import + 12 호출 사이트 `firstNonEmpty(...)` → `firstNonEmptyString(...)`.
- `lib/keeper-runtime-display.ts`: 자체 `firstNonEmpty` 정의 삭제 + import + 2 호출 사이트 rename. 외부 `trimmed()` helper 의존도 같이 제거됨 (인라인 trim 으로 대체).

## 시멘틱 동등성 검증

| 입력 | 기존 ide/keeper-runtime | 기존 fleet (normalizeText) | 새 SSOT (인라인 trim) |
|---|---|---|---|
| `null` | skip (`?.trim()` → undefined falsy) | skip (normalizeText → null) | skip |
| `undefined` | skip | skip | skip |
| `''` | skip (`''.trim()` → '' falsy) | skip (normalizeText → null) | skip |
| `'  '` | skip (whitespace.trim() → '' falsy) | skip | skip |
| `'  hi  '` | return `'hi'` | return `'hi'` | return `'hi'` |

→ 셋 다 동등. 표면 동작 회귀 없음.

## 동음이의어 — scope 밖

`cascade-config-panel.firstNonEmpty(values: readonly string[]): string` 은:
- 시그니처: array 인자 (rest 아님), `string` 리턴 (null 아님)
- 시멘틱: 첫 non-whitespace 의 **원본** (trim 안 함) 반환, 못 찾으면 `''`

→ 도메인/시그니처/시멘틱 모두 다른 동음이의어. 같은 이름 collision 은 inventory 후속 entry 로 둠.

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run src/lib/format-string src/components/fleet-telemetry-utils src/components/ide/ide-keeper-work-panel src/lib/keeper-runtime-display`: 124/124 (3 test files)
- `pnpm exec eslint`: 0 errors (lib/* warning 2 = pre-existing config 미설정, 본 PR 무관)

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#16, lib-shadowing 3 일차)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] IDE keeper work panel + keeper runtime display 표면 회귀 없음 (Activity / Continuity 필드 우선순위 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
