### PR TITLE
refactor(dashboard/cascade-config): rename firstNonEmpty to firstNonBlankOrEmpty

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -1123,7 +1123,12 @@ function SourceAssistInput({
   `
 }
 
-function firstNonEmpty(values: readonly string[]): string {
+// Find the first entry whose trimmed form is non-empty; return the original
+// (untrimmed) value, or '' when none qualifies. Distinct from
+// `lib/format-string.firstNonEmptyString` — that one returns the *trimmed* form
+// and `string | null`, this one preserves the raw value for `useSignal` seeding
+// and returns `string` so the signal has a guaranteed initial value.
+function firstNonBlankOrEmpty(values: readonly string[]): string {
   return values.find(value => value.trim() !== '') ?? ''
 }
 
@@ -1133,7 +1138,7 @@ function selectedBindingLabel(
   assist: CascadeRawConfigAssist,
 ): string {
   if (provider.trim() !== '' && model.trim() !== '') return `${provider.trim()}.${model.trim()}`
-  return firstNonEmpty(assist.bindings)
+  return firstNonBlankOrEmpty(assist.bindings)
 }
 
 function CascadeSourceAssist({
@@ -1277,9 +1282,9 @@ function CascadeRawConfigEditor({
   const editorDirty = useSignal(false)
   const saving = useSignal(false)
   const saveMessage = useSignal<string | null>(null)
-  const assistProvider = useSignal(firstNonEmpty(raw?.assist?.providers ?? []))
-  const assistModel = useSignal(firstNonEmpty(raw?.assist?.models ?? []))
-  const assistTier = useSignal(firstNonEmpty(raw?.assist?.tiers ?? []) || 'primary')
+  const assistProvider = useSignal(firstNonBlankOrEmpty(raw?.assist?.providers ?? []))
+  const assistModel = useSignal(firstNonBlankOrEmpty(raw?.assist?.models ?? []))
+  const assistTier = useSignal(firstNonBlankOrEmpty(raw?.assist?.tiers ?? []) || 'primary')
   const maxConcurrent = useSignal('2')
   const thinkingBudget = useSignal('8192')
   const mode = rawConfigModeSummary(raw)
@@ -1294,13 +1299,13 @@ function CascadeRawConfigEditor({
     const assist = raw?.assist
     if (!assist) return
     if (!assist.providers.includes(assistProvider.value)) {
-      assistProvider.value = firstNonEmpty(assist.providers)
+      assistProvider.value = firstNonBlankOrEmpty(assist.providers)
     }
     if (!assist.models.includes(assistModel.value)) {
-      assistModel.value = firstNonEmpty(assist.models)
+      assistModel.value = firstNonBlankOrEmpty(assist.models)
     }
     if (!assist.tiers.includes(assistTier.value)) {
-      assistTier.value = firstNonEmpty(assist.tiers) || 'primary'
+      assistTier.value = firstNonBlankOrEmpty(assist.tiers) || 'primary'
     }
   }, [raw?.updated_at, raw?.source_path])
 


### PR DESCRIPTION
## 요약

iter#16 PR #18945 (firstNonEmptyString SSOT, MERGED) 의 후속. 동음이의어 잔존 처리.

`cascade-config-panel.firstNonEmpty(values: readonly string[]): string` 는 iter#16 의 *시멘틱 동일 통합 그룹* 에 포함되지 않았던 **별개 동음이의어**. 같은 이름이지만 시그니처/시멘틱/리턴 정책 모두 다름.

| 항목 | iter#16 SSOT `firstNonEmptyString` | 이 파일의 `firstNonEmpty` |
|---|---|---|
| 시그니처 | `(...rest: string \| null \| undefined): string \| null` | `(values: readonly string[]): string` |
| 리턴 형태 | trimmed form | 원본 (untrimmed) |
| 모두 absent 시 | `null` | `''` (signal seeding 보장) |
| 사용 컨텍스트 | 다중 필드 fallback chain | `useSignal` 초기값 |

→ SSOT 통합 불가능. iter#9~12 패턴 적용 — **별칭 회피보다 정의 이름에 시멘틱 박기**.

## 변경

`cascade-config-panel.ts` 단일 파일:
- `firstNonEmpty` → `firstNonBlankOrEmpty` rename (1 정의 + 7 호출 사이트)
- 정의에 JSDoc 추가 — iter#16 SSOT 와 차이점 명시 (raw value preserve + `''` fallback for signal seeding)

새 이름이 시그니처/리턴 정책을 명시: *blank (whitespace-only 포함 trim 후 빈) 이 아닌 첫 값* + *없으면 `''`*.

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run src/components/cascade-config-panel`: 3/3
- `pnpm exec eslint`: 0 errors

표면 동작 회귀 없음 — 함수 본체 무변경, 이름만 변경.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#17, 동음이의어 후속 처리)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Cascade config panel 의 assist 필드 (provider/model/tier) 초기값 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
