### PR TITLE
refactor(dashboard/lib): split hasNonEmptyString into isNonEmptyString + isNonBlankString

### DIFF
--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -11,6 +11,7 @@
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
+import { isNonEmptyString } from '../../lib/format-string'
 import { ringFocusClasses } from './ring'
 
 export type ButtonVariant = 'primary' | 'ghost' | 'danger' | 'subtle' | 'ok' | 'warn'
@@ -118,10 +119,6 @@ export interface ActionButtonProps {
   children: ComponentChildren
 }
 
-function hasNonEmptyString(value: string | undefined): boolean {
-  return value !== undefined && value !== ''
-}
-
 function pressedState(pressed: boolean | undefined): ButtonPressedState {
   if (pressed === true) return 'true'
   if (pressed === false) return 'false'
@@ -152,15 +149,15 @@ export function summarizeActionButton({
     disabled: disabled === true,
     busy: ariaBusy === true,
     pressedState: pressedState(pressed),
-    hasCustomClass: hasNonEmptyString(cx),
+    hasCustomClass: isNonEmptyString(cx),
     classNameLength: cx?.length ?? 0,
-    hasId: hasNonEmptyString(id),
+    hasId: isNonEmptyString(id),
     idLength: id?.length ?? 0,
-    hasAriaLabel: hasNonEmptyString(ariaLabel),
+    hasAriaLabel: isNonEmptyString(ariaLabel),
     ariaLabelLength: ariaLabel?.length ?? 0,
-    hasTitle: hasNonEmptyString(title),
+    hasTitle: isNonEmptyString(title),
     titleLength: title?.length ?? 0,
-    hasTestId: hasNonEmptyString(testId),
+    hasTestId: isNonEmptyString(testId),
     testIdLength: testId?.length ?? 0,
     hasOnClick: typeof onClick === 'function',
     hasChildren: children !== undefined && children !== null,

--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -3,6 +3,7 @@
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
+import { isNonBlankString } from '../../lib/format-string'
 import { SectionHead } from '../section-head'
 import { statusBadgeTone, statusDotColor } from './status-badge'
 
@@ -63,10 +64,6 @@ const VARIANT_CLASSES: Record<CardVariant, string> = {
   standard: CARD_STANDARD,
   light: CARD_LIGHT,
   compact: CARD_COMPACT,
-}
-
-function hasNonEmptyString(value: string | undefined): boolean {
-  return value !== undefined && value.trim() !== ''
 }
 
 function trimmedTextLength(value: string | undefined): number {
@@ -143,14 +140,14 @@ export function summarizeSurfaceCard({
   return {
     variant,
     tone: tone ?? '',
-    toneSource: hasNonEmptyString(tone) ? 'tone-class' : 'none',
-    hasTone: hasNonEmptyString(tone),
+    toneSource: isNonBlankString(tone) ? 'tone-class' : 'none',
+    hasTone: isNonBlankString(tone),
     toneLength: trimmedTextLength(tone),
-    hasCustomClass: hasNonEmptyString(cx),
+    hasCustomClass: isNonBlankString(cx),
     classNameLength: trimmedTextLength(cx),
-    hasStyle: hasNonEmptyString(style),
+    hasStyle: isNonBlankString(style),
     styleLength: trimmedTextLength(style),
-    hasTestId: hasNonEmptyString(testId),
+    hasTestId: isNonBlankString(testId),
     testIdLength: trimmedTextLength(testId),
     contentState: contentState(children),
   }
@@ -257,11 +254,11 @@ export function summarizeSectionCard({
     eyebrowState: contentState(eyebrow),
     eyebrowTextLength: textLength(eyebrow),
     hasRightSlot: right != null,
-    hasTone: hasNonEmptyString(tone),
+    hasTone: isNonBlankString(tone),
     toneLength: trimmedTextLength(tone),
-    hasCustomClass: hasNonEmptyString(cx),
+    hasCustomClass: isNonBlankString(cx),
     classNameLength: trimmedTextLength(cx),
-    hasTestId: hasNonEmptyString(effectiveTestId),
+    hasTestId: isNonBlankString(effectiveTestId),
     testIdLength: trimmedTextLength(effectiveTestId),
     contentState: contentState(children),
   }

--- a/dashboard/src/components/common/checkbox.ts
+++ b/dashboard/src/components/common/checkbox.ts
@@ -11,6 +11,7 @@
 // ended up shipping orphan labels.
 
 import { html } from 'htm/preact'
+import { isNonEmptyString } from '../../lib/format-string'
 import { ringFocusClasses } from './ring'
 
 const CHECKBOX_BASE = `w-4 h-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] cursor-pointer transition-colors hover:bg-[var(--color-bg-hover)] hover:border-[var(--color-border-strong)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })} accent-[var(--color-accent-fg)]`
@@ -71,10 +72,6 @@ export interface CheckboxProps {
   onClick?: (e: Event) => void
 }
 
-function hasNonEmptyString(value: string | undefined): boolean {
-  return value !== undefined && value !== ''
-}
-
 function checkedState(checked: boolean | undefined): CheckboxCheckedState {
   if (checked === undefined) return 'unset'
   return checked ? 'true' : 'false'
@@ -89,9 +86,9 @@ function a11yHook({
   ariaLabel?: string
   ariaLabelledby?: string
 }): CheckboxA11yHook {
-  if (hasNonEmptyString(ariaLabelledby)) return 'aria-labelledby'
-  if (hasNonEmptyString(ariaLabel)) return 'aria-label'
-  if (hasNonEmptyString(id)) return 'id'
+  if (isNonEmptyString(ariaLabelledby)) return 'aria-labelledby'
+  if (isNonEmptyString(ariaLabel)) return 'aria-label'
+  if (isNonEmptyString(id)) return 'id'
   return 'none'
 }
 
@@ -112,20 +109,20 @@ export function summarizeCheckbox({
     checkedState: checkedState(checked),
     checked: checked === true,
     disabled: disabled === true,
-    hasCustomClass: hasNonEmptyString(cx),
+    hasCustomClass: isNonEmptyString(cx),
     classNameLength: cx?.length ?? 0,
-    hasId: hasNonEmptyString(id),
+    hasId: isNonEmptyString(id),
     idLength: id?.length ?? 0,
-    hasName: hasNonEmptyString(name),
+    hasName: isNonEmptyString(name),
     nameLength: name?.length ?? 0,
     a11yHook: a11yHook({ id, ariaLabel, ariaLabelledby }),
-    hasAriaLabel: hasNonEmptyString(ariaLabel),
+    hasAriaLabel: isNonEmptyString(ariaLabel),
     ariaLabelLength: ariaLabel?.length ?? 0,
-    hasAriaLabelledby: hasNonEmptyString(ariaLabelledby),
+    hasAriaLabelledby: isNonEmptyString(ariaLabelledby),
     ariaLabelledbyLength: ariaLabelledby?.length ?? 0,
-    hasValue: hasNonEmptyString(value),
+    hasValue: isNonEmptyString(value),
     valueLength: value?.length ?? 0,
-    hasTestId: hasNonEmptyString(testId),
+    hasTestId: isNonEmptyString(testId),
     testIdLength: testId?.length ?? 0,
     hasOnChange: onChange !== undefined,
     hasOnClick: onClick !== undefined,

--- a/dashboard/src/lib/format-string.ts
+++ b/dashboard/src/lib/format-string.ts
@@ -7,6 +7,28 @@ export function capitalize(text: string): string {
 }
 
 /**
+ * String presence check without trimming. Treats `''` as absent but keeps
+ * whitespace-only strings (`'   '`) as present.
+ *
+ * Use for attribute presence gates (id/aria-label/title/testId) where raw
+ * empty-string is the only absent state and whitespace is technically valid.
+ */
+export function isNonEmptyString(value: string | undefined): boolean {
+  return value !== undefined && value !== ''
+}
+
+/**
+ * String content check with trimming. Treats `''` and whitespace-only
+ * strings (`'   '`) both as absent.
+ *
+ * Use for content-presence gates (visible label/copy/text) where
+ * whitespace-only is functionally equivalent to empty.
+ */
+export function isNonBlankString(value: string | undefined): boolean {
+  return value !== undefined && value.trim() !== ''
+}
+
+/**
  * Return the first value that, after trimming, has non-whitespace content.
  *
  * Treats `null`, `undefined`, empty strings, and whitespace-only strings as


### PR DESCRIPTION
## 요약

`hasNonEmptyString` common 그룹 처리 — iter#15 분석에서 식별된 *시멘틱 분기를 가진 동음이의어*. iter#15 (`hasNonEmptyStringField` record 변형) 의 후속.

| 파일 | 본체 | 시멘틱 |
|---|---|---|
| `common/button.ts:121` | `value !== undefined && value !== ''` | no trim — `' '` (whitespace-only) 도 present |
| `common/checkbox.ts:74` | 동일 | 동일 (byte-for-byte) |
| `common/card.ts:68` | `value !== undefined && value.trim() !== ''` | with trim — `' '` 도 absent |

같은 이름 + 다른 시멘틱이 *같은 디렉토리 (common/)* 안에서 충돌. 호출 사이트의 *행동* 이 ad-hoc trim 정책에 따라 silent 분기.

## 변경

`lib/format-string.ts` 에 **두 시멘틱 모두** 명시적 이름으로 export — 행동 변경 없음:

```ts
// no-trim: presence (raw '' 만 absent)
export function isNonEmptyString(value: string | undefined): boolean {
  return value !== undefined && value !== ''
}

// with-trim: content (whitespace-only 도 absent)
export function isNonBlankString(value: string | undefined): boolean {
  return value !== undefined && value.trim() !== ''
}
```

- `common/button.ts`: 자체 정의 삭제 + import + 5 호출 → `isNonEmptyString`
- `common/checkbox.ts`: 자체 정의 삭제 + import + 10 호출 → `isNonEmptyString`
- `common/card.ts`: 자체 정의 삭제 + import + 8 호출 → `isNonBlankString`

## 왜 *시멘틱 통일* 하지 않고 *둘 다 보존* 했는가

button/checkbox 와 card 의 trim 분기는 *우연한 ad-hoc* 일 가능성이 크지만 (작성자별 의도 차이), 호출 사이트가 *attribute 게이트* (aria/id/title/testId) 라 `' '` 입력이 의도적으로 들어올 경우 (예: spacer label) 행동 변경이 silent 회귀를 만들 수 있음. 한 PR 에서 *SSOT 추출* + *시멘틱 통일* 둘 다 시도하면 reviewer 가 한 결정만 검토할 수 없음. **iter#18 은 SSOT 추출 + 시멘틱 보존만 한다** — 시멘틱 통일 (옳다면) 은 후속 PR.

대신 함수 이름이 시멘틱 분기를 *드러내서* — `isNonEmptyString` 호출자가 `' '` 정책에 대해 *명시적 선택* 을 내리도록 강제. 미래에 trim 정책으로 바꾸려면 import 만 `isNonBlankString` 로 교체.

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run src/components/common/button src/components/common/checkbox src/components/common/card src/lib/format-string`: 77/77 (6 test files)
- `pnpm exec eslint`: 0 errors

표면 동작 회귀 없음 — 함수 본체 무변경, 시멘틱 두 종 모두 보존.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#18, common-group lib-shadowing)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Button/Checkbox/Card 의 telemetry boolean prop (`hasCustomClass`/`hasAriaLabel`/...) 회귀 없음
- [ ] Card 의 content-presence 게이트 (`hasTone`/`hasStyle`) trim 시멘틱 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
