### PR TITLE
refactor(dashboard): rename errorMessage 4-way homonym to encode policy in name

### DIFF
--- a/dashboard/src/board-metrics.ts
+++ b/dashboard/src/board-metrics.ts
@@ -50,7 +50,12 @@ export function boardMetricNow(): number {
   return typeof now === 'number' && Number.isFinite(now) ? now : Date.now()
 }
 
-function errorMessage(error: unknown): string | null {
+// Pass-through nullable error formatter: returns null when no error is
+// provided (the metric field stays null), uses message||name for Error,
+// keeps raw strings, falls through to String() for anything else. The
+// nullable return is the distinguishing trait vs the string-only
+// errorToString / errorMessageOr variants in other modules.
+function errorMessageOrNull(error: unknown): string | null {
   if (error instanceof Error) return error.message || error.name
   if (typeof error === 'string') return error
   return error == null ? null : String(error)
@@ -71,7 +76,7 @@ export function recordBoardLatency(
       last_ok: ok,
       sample_count: current.sample_count + 1,
       failure_count: current.failure_count + (ok ? 0 : 1),
-      last_error: ok ? null : errorMessage(error),
+      last_error: ok ? null : errorMessageOrNull(error),
     },
   }
 }

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -421,7 +421,7 @@ function ProfileCard({
       await onAssignKeeper(selectedKeeper.value, profile.name)
       assignmentMessage.value = `${selectedKeeper.value} → ${profile.name}`
     } catch (error) {
-      assignmentMessage.value = `Failed to assign: ${errorMessage(error)}`
+      assignmentMessage.value = `Failed to assign: ${errorToString(error)}`
     } finally {
       assigning.value = false
     }
@@ -1090,7 +1090,11 @@ function ClientCapacityTable({ capacity }: { capacity: CascadeClientCapacityResp
   `
 }
 
-function errorMessage(error: unknown): string {
+// Generic Error -> message conversion with String() fallback (no special
+// 'unknown error' literal, no nullable return, no fallback param).
+// Distinct from errorMessageOrNull / errorMessageOrUnknown / errorMessageOr
+// in other modules.
+function errorToString(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
@@ -1349,10 +1353,10 @@ function CascadeRawConfigEditor({
         await onRefresh()
         saveMessage.value = '저장 완료.'
       } catch (error) {
-        saveMessage.value = `저장됨, 새로고침 실패: ${errorMessage(error)}`
+        saveMessage.value = `저장됨, 새로고침 실패: ${errorToString(error)}`
       }
     } catch (error) {
-      saveMessage.value = `Failed to save: ${errorMessage(error)}`
+      saveMessage.value = `Failed to save: ${errorToString(error)}`
     } finally {
       saving.value = false
     }

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -37,7 +37,7 @@ import {
   buildRuntimeWarnings,
   buildTelemetryWarnings,
   emptyState,
-  errorMessage,
+  errorMessageOrUnknown,
   fleetBand,
   formatActivitySignal,
   formatLatency,
@@ -676,7 +676,7 @@ export function FleetTelemetryPanel() {
           ? normalizeKeepers(executionResult.value.keepers)
           : []
       if (executionResult.status === 'rejected' && !isAbortError(executionResult.reason)) {
-        warnings.push(`실행 스냅샷 사용 불가: ${errorMessage(executionResult.reason)}`)
+        warnings.push(`실행 스냅샷 사용 불가: ${errorMessageOrUnknown(executionResult.reason)}`)
       }
 
       const executionTrust =
@@ -684,7 +684,7 @@ export function FleetTelemetryPanel() {
           ? executionTrustResult.value
           : null
       if (executionTrustResult.status === 'rejected' && !isAbortError(executionTrustResult.reason)) {
-        warnings.push(`Execution trust 사용 불가: ${errorMessage(executionTrustResult.reason)}`)
+        warnings.push(`Execution trust 사용 불가: ${errorMessageOrUnknown(executionTrustResult.reason)}`)
       }
 
       const toolQuality =
@@ -692,7 +692,7 @@ export function FleetTelemetryPanel() {
           ? toolQualityResult.value
           : EMPTY_TOOL_QUALITY
       if (toolQualityResult.status === 'rejected' && !isAbortError(toolQualityResult.reason)) {
-        warnings.push(`도구 품질 데이터 사용 불가: ${errorMessage(toolQualityResult.reason)}`)
+        warnings.push(`도구 품질 데이터 사용 불가: ${errorMessageOrUnknown(toolQualityResult.reason)}`)
       }
 
       const telemetrySummary =
@@ -700,7 +700,7 @@ export function FleetTelemetryPanel() {
           ? telemetrySummaryResult.value
           : { generated_at: '', sources: [], total_entries: 0 }
       if (telemetrySummaryResult.status === 'rejected' && !isAbortError(telemetrySummaryResult.reason)) {
-        warnings.push(`텔레메트리 저장소 요약 사용 불가: ${errorMessage(telemetrySummaryResult.reason)}`)
+        warnings.push(`텔레메트리 저장소 요약 사용 불가: ${errorMessageOrUnknown(telemetrySummaryResult.reason)}`)
       }
       warnings.push(...buildTelemetryWarnings(telemetrySummary.sources))
 
@@ -709,7 +709,7 @@ export function FleetTelemetryPanel() {
           ? normalizeNamespaceTruth(namespaceTruthResult.value)
           : null
       if (namespaceTruthResult.status === 'rejected' && !isAbortError(namespaceTruthResult.reason)) {
-        warnings.push(`Control room 사용 불가: ${errorMessage(namespaceTruthResult.reason)}`)
+        warnings.push(`Control room 사용 불가: ${errorMessageOrUnknown(namespaceTruthResult.reason)}`)
       }
 
       const rows = buildFleetRows(keepers, toolQuality)

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -108,7 +108,11 @@ export function emptyState(): FleetTelemetryState {
 // Delegated to config/telemetry-sources (SSOT)
 export const sourceLabel = telemetrySourceLabel
 
-export function errorMessage(reason: unknown): string {
+// Error -> message conversion with a literal 'unknown error' fallback for
+// non-Error inputs. Distinct from errorToString (cascade-config) which uses
+// String(reason) instead, and from errorMessageOr (keeper-detail-hooks)
+// which takes a caller-supplied fallback.
+export function errorMessageOrUnknown(reason: unknown): string {
   return reason instanceof Error ? reason.message : 'unknown error'
 }
 

--- a/dashboard/src/components/keeper-detail-hooks.ts
+++ b/dashboard/src/components/keeper-detail-hooks.ts
@@ -22,7 +22,10 @@ const RUNTIME_TRACE_REFRESH_MS = 30_000
  */
 export type KeeperDetailEvidenceState<T> = EvidenceState<T>
 
-function errorMessage(err: unknown, fallback: string): string {
+// Error -> message conversion with caller-supplied fallback (distinct from
+// errorMessageOrUnknown which hard-codes 'unknown error', and from
+// errorToString / errorMessageOrNull in other modules).
+function errorMessageOr(err: unknown, fallback: string): string {
   return err instanceof Error ? err.message : fallback
 }
 
@@ -50,7 +53,7 @@ export function useKeeperCompositeEvidence(keeperName: string): KeeperDetailEvid
         }
       } catch (err) {
         if (!cancelled && !controller.signal.aborted) {
-          const message = errorMessage(err, 'composite fetch failed')
+          const message = errorMessageOr(err, 'composite fetch failed')
           setEvidence((current) => applyFetchFailed(current, message, Date.now()))
         }
       }
@@ -87,7 +90,7 @@ export function useKeeperRuntimeTraceEvidence(keeperName: string): KeeperDetailE
         }
       } catch (err) {
         if (!cancelled && !controller.signal.aborted) {
-          const message = errorMessage(err, 'runtime trace fetch failed')
+          const message = errorMessageOr(err, 'runtime trace fetch failed')
           setEvidence((current) => applyFetchFailed(current, message, Date.now()))
         }
       }


### PR DESCRIPTION
## 요약

`errorMessage` 4 정의가 *각자 다른 정책* 으로 정의된 4-way 동음이의어. 통합 불가 — 정책이 모두 다름. iter#9~12 패턴 = *이름에 정책 박기* (rename sweep). iter#17 의 `firstNonBlankOrEmpty` 와 같은 패턴.

| 파일 | 시그니처 | 정책 | rename |
|---|---|---|---|
| `board-metrics.ts:53` | `(unknown): string \| null` | Error→msg\|\|name / string→as-is / null→null / else→String | **`errorMessageOrNull`** |
| `cascade-config-panel.ts:1093` | `(unknown): string` | Error→msg / else→String() | **`errorToString`** |
| `fleet-telemetry-utils.ts:111` (export) | `(unknown): string` | Error→msg / else→`'unknown error'` 고정 | **`errorMessageOrUnknown`** |
| `keeper-detail-hooks.ts:25` | `(unknown, fallback: string): string` | Error→msg / else→fallback param | **`errorMessageOr`** |

같은 이름 + 다른 정책 = 자동완성 collision + 호출 사이트가 *어떤 정책 채택* 됐는지 즉시 판단 불가능. 정책 4종이 *디렉토리 한 trip* 거리에 흩어져 있어 silent ad-hoc 분기.

## 왜 SSOT 통합 안 했는가

| 통합 시도 | 문제 |
|---|---|
| `errorToString` 으로 통일 | board-metrics 의 null pass-through 소실 (metric field 가 빈 문자열 들어감) + fleet-telemetry 의 'unknown error' literal 사라짐 (UI warning 메시지 변화) |
| 두 정책으로 단순화 (null vs string) | fleet-telemetry 의 'unknown error' 와 keeper-detail-hooks 의 fallback 차이가 묻힘 |
| 모든 호출처를 generic + wrapper | 호출자 변환 4 도메인, 5+ 파일, silent 행동 변경 위험 |

→ **rename sweep 이 가장 보수적**. 행동 변경 0, 이름이 정책을 *호출 사이트에서 보이게* 만듦.

## 변경

- `board-metrics.ts`: `errorMessage` → `errorMessageOrNull` (1 정의 + 1 호출)
- `components/cascade-config-panel.ts`: `errorMessage` → `errorToString` (1 정의 + 3 호출)
- `components/fleet-telemetry-utils.ts`: `errorMessage` → `errorMessageOrUnknown` (1 정의, export)
- `components/fleet-telemetry-panel.ts`: import + 5 호출 갱신
- `components/keeper-detail-hooks.ts`: `errorMessage` → `errorMessageOr` (1 정의 + 2 호출)

각 정의에 JSDoc 추가 — 다른 3 변형과 차이점 명시. 미래 reviewer 가 *통합 시도* 할 때 의도가 즉시 보임 (iter#17 의 cascade-config-panel JSDoc 와 같은 패턴).

## 영향 없음 검증

- `errorMessage` *property* (keeper-detail-runtime.ts, grpc-pb.ts) → 함수와 무관, 변경 없음
- `errorMessage` *local var* (keeper-actions.ts:264) → local scope, 변경 없음
- `fleet-telemetry-utils.errorMessage` 외부 호출처 = fleet-telemetry-panel 뿐 (test 파일 없음, 다른 모듈 import 없음)

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run src/board-metrics src/components/cascade-config-panel src/components/fleet-telemetry-utils src/components/fleet-telemetry-panel src/components/keeper-detail-hooks`: 106/106 (5 test files)
- `pnpm exec eslint`: 0 errors

표면 동작 회귀 없음 — 함수 본체 무변경.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#19, 동음이의어 4-way rename sweep)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Board metric `last_error` 가 OK 일 때 null 유지
- [ ] Cascade config 의 toast 메시지 형식 유지
- [ ] Fleet telemetry warning 메시지 `'unknown error'` literal 유지
- [ ] Keeper detail 의 fallback 메시지 (`'composite fetch failed'` / `'runtime trace fetch failed'`) 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
