### PR TITLE
docs(rfc): RFC-0190 descriptor visibility SSOT + RFC-0191 descriptor policy SSOT

### DIFF
--- a/docs/rfc/RFC-0190-descriptor-visibility-ssot.md
+++ b/docs/rfc/RFC-0190-descriptor-visibility-ssot.md
@@ -1,0 +1,145 @@
+---
+title: Descriptor as Visibility/Metadata SSOT — Surface Projection from descriptor.policy.visibility
+rfc: "0190"
+status: Draft
+created: 2026-05-27
+updated: 2026-05-27
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0064", "0179", "0182"]
+implementation_prs: []
+---
+
+# RFC-0190 — Descriptor as Visibility/Metadata SSOT
+
+Status: Draft · Architectural framing, no code yet
+Related: RFC-0064 (two-surface tool model), RFC-0179 (`keeper_*` descriptor coverage), RFC-0182 (`masc_*` descriptor projection)
+
+## 0. Problem framing
+
+A 2026-05-27 surface↔descriptor audit (worktree `refactor-mcp-surface-projection-20260527`, `bin/audit_descriptor_surface.exe`) measured the set-difference between `Tool_catalog_surfaces.public_mcp_surface_tools` (operator-facing MCP surface, 57 entries) and `Agent_tool_descriptor.{public,internal}_descriptors` (keeper-facing typed dispatch fact set, 7 + 128 entries).
+
+Result:
+
+| Direction | Count | Examples |
+|---|---|---|
+| surface ∖ descriptor | **9** | `masc_start`, `masc_join`, `masc_leave`, `masc_broadcast`, `masc_messages`, `masc_who`, `masc_keeper_sandbox_status`, `masc_persona_generate`, `masc_keeper_create_from_persona` |
+| descriptor ∖ surface | 82 | `keeper_board_*` (managed-keeper twins), `masc_board_delete`, `masc_config`, `masc_get_metrics`, … (intentionally not operator-visible) |
+| intersect | 46 | already descriptor-backed surface entries |
+
+Two SSOTs that should be one. RFC-0179 + RFC-0182 brought descriptors to *most* of the `masc_*` operator surface, but **9 lifecycle/authoring tools never entered the descriptor system at all** because their handlers live in `lib/tool_inline_dispatch.ml` (MCP server-level inline path), not in `Tool_coord.dispatch` or the cluster `*_dispatch_ref` references the descriptor `runtime_handler` enum routes to.
+
+The descriptor enum (`In_process | Filesystem | Shell_ir | Remote_mcp`) is closed and assumes the descriptor *owns* execution. Tools handled by inline dispatch have no slot.
+
+## 1. Hypothesis the audit invalidated
+
+RFC-0179 framed coverage as "every tool the LLM can call needs a descriptor." That framing assumes a single dispatch axis. The audit shows two distinct axes:
+
+- **Visibility axis** (`policy.visibility`): who can see/call this tool — `Public_mcp | Keeper_internal | Spawned_agent | Local_worker | Admin | Keeper_denied | …`.
+- **Execution axis** (`executor`): how the call is dispatched — `In_process | Filesystem | Shell_ir | Remote_mcp`.
+
+Today `Agent_tool_descriptor.t` collapses both axes into one record, but coverage is asymmetric — the execution axis demands the descriptor own dispatch, which the inline-path tools cannot satisfy without being moved.
+
+## 2. Goal
+
+Make `Agent_tool_descriptor.t` the single source of truth for *visibility and metadata*, with execution-axis ownership being optional. After this RFC:
+
+- `Tool_catalog_surfaces.public_mcp_surface_tools` is computed as
+  `filter (fun d -> d.policy.visibility = Public_mcp) all_descriptors`.
+- Every entry on every surface (`public_mcp_surface_tools`, `spawned_agent_surface_tools`, `local_worker_surface_tools`, `session_min_surface_tools`, `admin_surface_tools`) has a descriptor.
+- Dispatch routing remains opt-in: descriptors whose execution lives in `Tool_inline_dispatch` declare `executor = External_inline` and `runtime_handler = Tool_external_inline`, and the descriptor dispatcher returns `None` for them, leaving the inline path unchanged.
+- The surface↔descriptor diff becomes a compile-/test-time invariant (Phase 4).
+
+## 3. Non-goals
+
+- Move inline-path handlers into the descriptor in-process runtime. The inline path predates descriptors and crosses module boundaries (`Mcp_server_eio_execute`); migrating it is RFC-scope of its own.
+- Change visibility semantics. The `Tool_catalog.visibility` enum stays as-is.
+- Touch `Tool_catalog_surfaces.keeper_internal_tools` or any other hand-managed list beyond `public_mcp_surface_tools` in this RFC. Other surfaces are Phase 5+ follow-ups.
+
+## 4. Model change
+
+```ocaml
+type executor =
+  | Shell_ir
+  | Filesystem
+  | Remote_mcp
+  | In_process
+  | External_inline  (* NEW: descriptor is metadata-only;
+                        execution owned by tool_inline_dispatch *)
+
+type runtime_handler =
+  | ... (* existing variants *)
+  | Tool_external_inline  (* NEW: paired with [External_inline] *)
+```
+
+`Agent_tool_runtime.handle` gains:
+
+```ocaml
+let handle ctx ~descriptor ~args =
+  match descriptor.executor with
+  | Filesystem      -> handle_filesystem ctx descriptor args
+  | Shell_ir        -> handle_shell_ir   ctx descriptor args
+  | Remote_mcp      -> handle_remote_mcp ctx descriptor args
+  | In_process      -> handle_in_process ctx descriptor args
+  | External_inline -> None  (* fall through to inline_dispatch *)
+```
+
+`handle_internal` already returns `string option`; existing callers treat `None` as "descriptor system declines, let the next path handle." The inline path is *that* next path for MCP-server entry points; for keeper-facing entry it is unknown-tool (correct — these tools were never keeper-callable).
+
+## 5. Descriptor entries to add
+
+9 new internal descriptors, all with `visibility = Public_mcp`, `executor = External_inline`, `runtime_handler = Tool_external_inline`.
+
+| name | cluster id | input_schema source |
+|---|---|---|
+| `masc_start` | `masc.coord.start` | `Tool_schemas_coord.schemas` |
+| `masc_join` | `masc.coord.join` | `Tool_schemas_coord.schemas` |
+| `masc_leave` | `masc.coord.leave` | `Tool_schemas_coord.schemas` |
+| `masc_broadcast` | `masc.comm.broadcast` | `Tool_schemas_comm.schemas` |
+| `masc_messages` | `masc.comm.messages` | `Tool_schemas_comm.schemas` |
+| `masc_who` | `masc.comm.who` | `Tool_schemas_comm.schemas` |
+| `masc_keeper_sandbox_status` | `masc.keeper.sandbox_status` | existing keeper schema |
+| `masc_persona_generate` | `masc.persona.generate` | persona authoring schema |
+| `masc_keeper_create_from_persona` | `masc.persona.create_from` | persona authoring schema |
+
+Each entry pulls `description` and `input_schema` from the inline dispatch's existing schema registration; **no duplication is introduced** — descriptors reference the same `Masc_domain.tool_schema` records the inline path already publishes.
+
+## 6. Implementation phases
+
+| Phase | PR scope | Verifiable end-state |
+|---|---|---|
+| **P1** | `External_inline` + `Tool_external_inline` enum extension. `handle` returns `None` for `External_inline`. Zero descriptor entries added yet. | Build green. `internal_descriptors` count unchanged. Test: a synthetic `External_inline` descriptor routes through `handle` → `None`. |
+| **P2** | Add 3 coord lifecycle descriptors (`masc_start/join/leave`). | `audit_descriptor_surface` shows 6 missing, not 9. `masc_start` etc. carry `Public_mcp` visibility. |
+| **P3** | Add 3 comm descriptors (`masc_broadcast/messages/who`). | 3 missing. Inline path untouched. |
+| **P4** | Add 3 remaining (`masc_keeper_sandbox_status`, 2 persona). | 0 missing. **Visibility projection** introduced: `public_mcp_surface_tools = filter (visibility = Public_mcp) all_descriptors |> sort_uniq`. Existing hand list deleted. Compile-time test fails if any surface drift. |
+| **P5** (follow-up) | Audit other surfaces (`spawned_agent_surface_tools` etc.) → separate RFC. | Out of scope for 0190. |
+
+P1–P4 each merges independently. P1 has the only schema change; P2–P4 are pure data additions. No phase requires an inline-path code change.
+
+## 7. Workaround-bar check
+
+This RFC does *not* trigger workaround signatures:
+
+- §1 telemetry-as-fix: no. Fixes structural surface↔descriptor drift, not visibility.
+- §2 string/substring classifier: no. Eliminates string list `public_mcp_surface_tools` in favor of typed `visibility` enum filter.
+- §3 N-of-M: no — the phasing rule is *each phase strictly reduces missing-count*; P4 is forced by an invariant test, not "we'll get to the rest later."
+
+## 8. Open questions
+
+1. Should `External_inline` permit a non-empty `runtime_handler` other than `Tool_external_inline` for future inline-cluster splits? Pinning to one variant is the conservative choice; reconsider only if a real second consumer appears.
+2. `masc_persona_generate` and `masc_keeper_create_from_persona` may have stricter `approval` semantics than current handler defaults — confirm against `tool_inline_dispatch` `inline_tool_requires_*` lists in P4.
+3. RFC-0064 hard-cut public set (7 LLM-native names) is unchanged; the visibility projection covers MCP surface only.
+
+## 9. Rejected alternatives
+
+- **(A-pragmatic)** Add 9 descriptors with `In_process` executor + dispatch arms in `handle_masc_coord` / `handle_masc_persona` / `handle_masc_keeper` that call back into `Tool_inline_dispatch`. Rejected: introduces dual handlers for the same tool name (descriptor cluster *and* inline path), guaranteed drift under future changes.
+- **(B-only)** Keep the hand list, add a test that asserts every surface entry exists in *some* known set (descriptor or allowlist). Rejected as the *final* state — drift cannot be eliminated, only reported. Acceptable as an *interim* gate (see RFC-0190 implementation companion: invariant test PR can land before P1 to ratchet the count down).
+
+## 10. Acceptance criteria
+
+- RFC merged.
+- P1–P4 PRs all merged.
+- `Tool_catalog_surfaces.public_mcp_surface_tools` is a function over `all_descriptors`, not a literal list.
+- `audit_descriptor_surface` reports 0 missing for `Public_mcp` surface.
+- `External_inline` is the *only* executor whose `handle` returns `None`.

--- a/docs/rfc/RFC-0191-descriptor-policy-ssot.md
+++ b/docs/rfc/RFC-0191-descriptor-policy-ssot.md
@@ -1,0 +1,153 @@
+---
+title: Descriptor as Policy SSOT — Consolidate keeper_tool_policy axes onto descriptor.policy
+rfc: "0191"
+status: Draft
+created: 2026-05-27
+updated: 2026-05-27
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0064", "0179", "0182", "0190"]
+implementation_prs: []
+---
+
+# RFC-0191 — Descriptor as Policy SSOT
+
+Status: Draft · Architectural framing, no code yet
+Related: RFC-0179 (`keeper_*` descriptor coverage), RFC-0182 (`masc_*` descriptor projection), RFC-0190 (visibility SSOT)
+
+## 0. Problem framing
+
+`Agent_tool_descriptor.t` already carries a `policy` record:
+
+```ocaml
+type policy =
+  { visibility           : Tool_catalog.visibility
+  ; readonly_of_input    : readonly_of_input
+  ; readonly_hint        : bool option
+  ; effect_domain        : Tool_catalog.effect_domain option
+  ; approval             : approval
+  ; retryable            : bool
+  ; cwd_scope            : string option
+  ; credential_profile   : string option
+  }
+```
+
+Yet `lib/keeper/keeper_tool_policy.ml` is **670 LoC, 63 definitions**, and the only point of contact with the descriptor system is one line (`Agent_tool_descriptor_resolution.capability_has` at line 181). The module independently owns:
+
+| Sub-axis | Hand-managed in `keeper_tool_policy.ml` | Equivalent descriptor field |
+|---|---|---|
+| Writable path prefix list | `keeper_writable_prefixes` (3 entries, hardcoded) | none — should be derived per descriptor (`cwd_scope` + tool-specific) |
+| Path normalization | `normalize_path`, `is_masc_write_allowed` | none |
+| Denied-set | `keeper_denied_set` Hashtbl | `visibility = Keeper_denied` |
+| Tool preset enum | `Minimal/Social/Messaging/Dispatch/Research/Delivery/Full` (7) + `preset_allows_privileged_operations`, `allows_workflow_for_preset`, `allows_shell_write_for_preset` | none — preset is an agent attribute, but the *per-tool* preset gate is missing as a descriptor field |
+| Per-tool inline safety | `keeper_safe_inline_tools` list (handmade) | descriptor `executor = In_process` already captures it |
+| Maintenance gates | `keeper_maintenance_only_tools` list | none — should be `approval = Human_required` + new `audience` field |
+| Last-turn safety | `last_turn_safe_tool_names` list | none — should be a derived property (`readonly_hint = Some true` + `effect_domain = None`) |
+| Allowlist by preset | `preset_allowlist` | should be a descriptor-driven projection |
+| Universe filter | `tool_access_lookup_of_meta`, `filter_by_universe`, `filter_by_access` | should be a descriptor capability check |
+
+Net result: two SSOTs, the smaller (`policy` record) defines structure, the larger (`keeper_tool_policy.ml`) defines truth. Any preset change requires editing the larger one, and the descriptor never gets consulted.
+
+## 1. Why this is dangerous
+
+This is the workaround bar's §2 (string/substring classifier) and §3 (N-of-M) double-trigger:
+
+- §2: `keeper_safe_inline_tools`, `keeper_maintenance_only_tools`, `last_turn_safe_tool_names`, `keeper_denied_set` are all string lists/sets growing per migration. New tools must be added to N lists separately or be silently mis-policied.
+- §3: every time a new tool category surfaces (board sub-boards, persona authoring, sandbox lifecycle), at least one of these lists is patched in isolation. There is no compile-time guarantee that a descriptor's `policy.visibility = Keeper_denied` and the `keeper_denied_set` agree.
+
+CLAUDE.md "워크어라운드 거부 §2/§3" mandates RFC-level resolution.
+
+## 2. Goal
+
+`Agent_tool_descriptor.policy` becomes the authoritative per-tool policy declaration. `keeper_tool_policy.ml` is reduced to:
+
+1. Agent-level state (the *agent's* preset, allowlist resolution at runtime).
+2. Boundary helpers that cannot live on the descriptor (path normalization, preset enum semantics).
+
+Every per-tool policy decision (`is_keeper_denied`, `is_keeper_safe_inline_tool`, `is_keeper_maintenance_only_tool`, `last_turn_safe_tool_names`) is computed from `descriptor.policy`.
+
+## 3. Non-goals
+
+- Move agent-preset semantics into the descriptor. Preset is an agent attribute, not a tool attribute.
+- Eliminate `Keeper_tool_policy_config` (`config/tool_policy.toml`). The TOML is the *operator-tunable* layer; the descriptor is the *source-of-truth* layer. They compose.
+- Touch path-normalization helpers. They predate the descriptor system and have no equivalent.
+
+## 4. Model change
+
+```ocaml
+type policy =
+  { visibility           : Tool_catalog.visibility
+  ; readonly_of_input    : readonly_of_input
+  ; readonly_hint        : bool option
+  ; effect_domain        : Tool_catalog.effect_domain option
+  ; approval             : approval
+  ; retryable            : bool
+  ; cwd_scope            : string option
+  ; credential_profile   : string option
+  ; (* NEW *)
+    audience             : audience_class
+    (* Minimum agent preset required to be granted this tool. *)
+  ; minimum_preset       : tool_preset
+    (* Whether this tool may execute on the final turn before turn cap.
+       Currently a hand-curated list; will be derived from
+       (readonly_hint = Some true && effect_domain = None). *)
+  ; last_turn_safe       : bool
+    (* Whether the tool is permitted on the inline-dispatch fast path
+       (no Eio plumbing). Currently a hand list. *)
+  ; inline_safe          : bool
+  ; (* Maintenance-only tools require an explicit operator gate. *)
+    maintenance_only     : bool
+  }
+
+and audience_class =
+  | Audience_keeper_facing
+  | Audience_operator_facing
+  | Audience_both
+  | Audience_admin_only
+```
+
+`audience_class` and `minimum_preset` are *new* descriptor fields, not derived. The other three (`last_turn_safe`, `inline_safe`, `maintenance_only`) are bridges: introduced as explicit fields in P1, then narrowed in P3 to be *derived* from other fields where possible.
+
+## 5. Implementation phases
+
+| Phase | PR scope | Verifiable end-state |
+|---|---|---|
+| **P1** | Extend `policy` record with 4 new fields. Every existing descriptor literal gets explicit values matching current `keeper_tool_policy.ml` decisions. No callers migrate yet. | Build green. `Agent_tool_descriptor.all_descriptors ()` answers every per-tool policy question. Cross-check test: for each descriptor, assert agreement with `keeper_tool_policy.<predicate>`. Cross-check pass is the migration safety gate. |
+| **P2** | Migrate `is_keeper_denied`, `is_keeper_safe_inline_tool`, `is_keeper_maintenance_only_tool` to descriptor-driven projections. Drop the corresponding string lists/Hashtbls. | `keeper_tool_policy.ml` LoC down by ~60. Test from P1 still passes (no semantic change). |
+| **P3** | Migrate `last_turn_safe_tool_names` to a derivation rule (`readonly_hint = Some true && effect_domain = None`). Drop the hand list. Audit any descriptor whose old-vs-new disagrees — the disagreement *is* the latent bug, fix by descriptor edit. | Last hand list of per-tool policy classification removed. |
+| **P4** | Migrate `preset_allowlist` to read `descriptor.policy.minimum_preset`. Drop preset-keyed string list construction. | `tool_access_lookup_of_meta` becomes a descriptor filter. |
+| **P5** | Drop everything in `keeper_tool_policy.ml` that has no agent-level role. Target: < 250 LoC, only `tool_preset` enum + agent-side state + path normalization + descriptor projections. | LoC reduction ~420. |
+| **P6** (follow-up RFC) | Re-evaluate whether `Keeper_tool_policy_config` (TOML loader) can be regenerated from descriptors instead of edited by operators. Likely no — operators tune presets, not per-tool policy. | Out of scope. |
+
+P1's cross-check test is the central safety device. The test compares every descriptor's projected predicate against the existing `keeper_tool_policy` answer; **the migration is only permitted to advance if all descriptors agree**. Disagreements found in P1 are P1's job to resolve (by descriptor edit, never by changing the predicate to be more permissive).
+
+## 6. Workaround-bar check
+
+This RFC does *not* trigger workaround signatures:
+
+- §1 telemetry-as-fix: no.
+- §2 string/substring classifier: no — this RFC *removes* 4+ string classifiers in favor of a typed record.
+- §3 N-of-M: each phase strictly removes one source-of-truth axis. P5 is the only phase that *deletes* code in bulk, and only after P1–P4's cross-check passes prove equivalence. The "delete 420 LoC" PR in P5 has zero behavior change by construction.
+
+## 7. Open questions
+
+1. **`audience_class` enum granularity.** Today the de facto audience is binary (operator-facing on `public_mcp_surface_tools` vs. keeper-facing on `keeper_internal_tools`), but `Tool_catalog_surfaces.keeper_internal_replacement` already encodes a 1:1 mapping for tools with both surfaces. Audience may want a fifth variant `Audience_both_with_distinct_handler` — open for discussion in P1.
+2. **Maintenance gate consolidation.** `maintenance_only` overlaps `approval = Human_required`. The distinction today: maintenance can be operator-bypassed for a single tool call, approval is a per-call queue event. Keep both fields in P1; reconsider in P5.
+3. **Preset bypass for `tool_preset = Full`.** `Full` preset agents currently skip all preset checks. Keep this behavior — encode as `minimum_preset` defaulting to `Minimal` and a single bypass at the preset evaluator, not as descriptor-level fields.
+4. **`Keeper_tool_policy_config` TOML.** Operators edit it. If a descriptor's static `minimum_preset = Dispatch` is overridden by TOML to `Research`, the TOML wins (operator > source). Document precedence in P4.
+
+## 8. Rejected alternatives
+
+- **Single-PR rewrite of `keeper_tool_policy.ml`.** Rejected: workaround §3 (N-of-M dressed as completeness). The 4 sub-axes are independently risky; bundling them defeats the cross-check test's purpose of catching per-axis semantic drift.
+- **Keep both SSOTs, add a sync test.** Rejected: drift-by-default; sync test only detects, doesn't prevent. Same critique as RFC-0190 (B-only).
+- **Move policy onto `Tool_catalog.metadata`.** Rejected: `Tool_catalog` is the operator-tunable layer (TOML + schema registry); descriptor is the typed-runtime layer. Putting policy on the operator-tunable layer reintroduces the original split that this RFC closes.
+
+## 9. Acceptance criteria
+
+- RFC merged.
+- P1's cross-check test exists and passes on every descriptor for every migrated predicate.
+- P2–P5 PRs all merged.
+- `keeper_tool_policy.ml` is < 250 LoC.
+- `is_keeper_denied`, `is_keeper_safe_inline_tool`, `is_keeper_maintenance_only_tool`, `last_turn_safe_tool_names`, `preset_allowlist` all read from `Agent_tool_descriptor.{public,internal}_descriptors`.
+- No string list of tool names remains in `keeper_tool_policy.ml` outside of preset enum semantics.


### PR DESCRIPTION
## Summary

Two coordinated RFCs that frame the last descriptor-spine debts after RFC-0179 (`keeper_*` coverage) and RFC-0182 (`masc_*` projection).

### RFC-0190 — Descriptor as Visibility/Metadata SSOT

A surface↔descriptor audit (2026-05-27) showed `public_mcp_surface_tools` (57) and `internal_descriptors` (128) are two *different axes*, not strict subsets:

- surface ∖ descriptor: 9 entries (coord lifecycle, comm, persona authoring, sandbox status) whose execution lives in `Tool_inline_dispatch`, never in the `runtime_handler` enum.
- descriptor ∖ surface: 82 entries (managed-keeper twins, admin-only tools) intentionally not operator-visible.

RFC introduces `executor = External_inline` + `runtime_handler = Tool_external_inline` so the 9 inline-path tools enter the descriptor system as metadata + visibility carriers without owning dispatch. Surface becomes `filter (visibility = Public_mcp) all_descriptors` at P4. Phases P1–P4 each strictly reduce the missing-count; no §3 N-of-M signature.

### RFC-0191 — Descriptor as Policy SSOT

`keeper_tool_policy.ml` (670 LoC, 63 definitions) independently owns per-tool decisions that should live on `descriptor.policy`: `keeper_denied_set`, `keeper_safe_inline_tools`, `keeper_maintenance_only_tools`, `last_turn_safe_tool_names`, `preset_allowlist`. Four string lists/sets that grow per migration — the exact §2 (substring classifier) + §3 (N-of-M) pattern CLAUDE.md prohibits.

RFC extends `descriptor.policy` with `audience_class`, `minimum_preset`, `last_turn_safe`, `inline_safe`, `maintenance_only`. P1's cross-check test compares descriptor projection vs. current `keeper_tool_policy` answers per tool — migration only advances if every descriptor agrees. End state: `keeper_tool_policy.ml < 250 LoC`.

## Why two RFCs in one PR

Same axis, same root cause (descriptor model under-specified), different sub-axes (visibility vs. policy). Bundling lets the architectural framing stay consistent — Phase-numbering, workaround-bar checks, and acceptance criteria use the same vocabulary.

## Workaround-bar self-check

- §1 telemetry-as-fix: neither RFC.
- §2 substring classifier: both RFCs *remove* classifiers.
- §3 N-of-M: each phase strictly reduces one source-of-truth axis; phase progression is gated by cross-check tests, not "we'll get to the rest later."

## Test plan

- [x] RFC frontmatter matches existing format (`docs/rfc/RFC-0182-*.md` template).
- [ ] Review for technical accuracy (especially Open Questions §8 in 0190 and §7 in 0191).
- [ ] Approval before any P1 implementation PR opens.

Related: PR #18951 (RFC-0190 invariant test), PR #18952 (RFC-0182 Phase 5 follow-up for task/approval clusters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
