### PR TITLE
refactor(dashboard/common): share CAPTION_CLASS between section-cap and eyebrow

### DIFF
--- a/dashboard/src/components/common/eyebrow.ts
+++ b/dashboard/src/components/common/eyebrow.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
+import { CAPTION_CLASS } from './section-cap'
 
 export type EyebrowTone = 'muted' | 'disabled'
 
@@ -9,15 +10,13 @@ export interface EyebrowSummary {
   readonly classNameLength: number
 }
 
-const BASE = 'text-3xs uppercase tracking-wider'
-
 const TONE_CLASSES: Record<EyebrowTone, string> = {
   muted: 'text-[var(--color-fg-muted)]',
   disabled: 'text-[var(--color-fg-disabled)]',
 }
 
 export function eyebrowClasses(tone: EyebrowTone = 'muted', extra?: string): string {
-  return [BASE, TONE_CLASSES[tone], extra].filter(Boolean).join(' ')
+  return [CAPTION_CLASS, TONE_CLASSES[tone], extra].filter(Boolean).join(' ')
 }
 
 export function summarizeEyebrow({

--- a/dashboard/src/components/common/section-cap.ts
+++ b/dashboard/src/components/common/section-cap.ts
@@ -39,7 +39,15 @@ import type { ComponentChildren } from 'preact'
 type SectionCapTone = 'muted' | 'dim'
 type SectionCapWeight = 'normal' | 'semibold'
 
-const BASE = 'text-3xs uppercase tracking-wider'
+/**
+ * Shared tiny-caps heading className. SectionCap is the primitive owner;
+ * Eyebrow imports from here so a `text-3xs` -> `text-2xs` (or tracking
+ * adjustment) on the design-system side touches one site, not two.
+ *
+ * Keys at a glance: `tiny`(`text-3xs`) + `uppercase` + `wider`
+ * (Tailwind's standard 0.05em tracking).
+ */
+export const CAPTION_CLASS = 'text-3xs uppercase tracking-wider'
 
 const TONE: Record<SectionCapTone, string> = {
   muted: 'text-text-muted',
@@ -60,7 +68,7 @@ export function sectionCapClasses(
   weight: SectionCapWeight = 'normal',
   extra?: string,
 ): string {
-  const parts = [BASE, TONE[tone]]
+  const parts = [CAPTION_CLASS, TONE[tone]]
   const w = WEIGHT[weight]
   if (w !== '') parts.push(w)
   if (extra !== undefined && extra !== '') parts.push(extra)


### PR DESCRIPTION
## 요약

`eyebrow.ts:12` 와 `section-cap.ts:42` 가 *byte-for-byte 동일* base Tailwind 문자열 `'text-3xs uppercase tracking-wider'` 을 각자 내부 const 로 보유. 새 sweep — `BASE` const x8 분석에서 발굴.

특히 흥미: **`section-cap.ts` 의 헤더 코멘트가 정확히 이 drift 문제를 인지**

> "Inline Tailwind strings scattered across ~20 files always drift within weeks (tracking-1 vs tracking-4 vs tracking-[var(--track-label)] — pixel-noise differences that break the grid silently)."

→ section-cap *자체가* drift 방어용으로 만들어졌지만, eyebrow 는 별도 컴포넌트로 *같은 base 를 또 hardcode*. 본인이 만들어진 이유와 같은 패턴이 *형제 컴포넌트* 에서 재발.

## 변경

SSOT 위치 = `section-cap.ts` (이미 *typography primitive owner* 로 헤더 코멘트가 명시):

- `section-cap.ts`: `const BASE = '...'` → `export const CAPTION_CLASS = '...'` + JSDoc 추가 (eyebrow 의존성 + 시멘틱 박음). 1 호출 사이트 (`sectionCapClasses` 안) 도 `BASE` → `CAPTION_CLASS`.
- `eyebrow.ts`: 자체 `BASE` 정의 삭제 + `import { CAPTION_CLASS } from './section-cap'` 추가. 1 호출 사이트 (`eyebrowClasses` 안) 도 rename.

이름 `CAPTION_CLASS` 채택 이유: Material/Apple HIG 의 *caption* typographic term = "small uppercase label". 두 컴포넌트 의도와 일치 + cross-domain 자동완성 collision 없음.

## 영향

- 다른 8 개의 `BASE` const (button/badge/inline-spinner/status-dot/kbd/id-pill 등) 는 *각자 다른 className* — 도메인 specific, SSOT 위반 아님. 이번 PR scope 밖.
- *형제 컴포넌트 의존* 우려 — 그러나 section-cap 헤더 코멘트가 *typography primitive owner intent* 를 명시하고 있어 자연. 미래에 `common/typography.ts` 모듈로 promote 가능 (현재는 over-engineering, 1 상수만 있음).

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run src/components/common/eyebrow src/components/common/section-cap`: 23/23 (4 test files)
- `pnpm exec eslint`: 0 errors

표면 동작 회귀 없음 — 두 컴포넌트가 동일 className 그대로 생성.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#20, Tailwind base 분산)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Eyebrow + SectionCap 의 시각적 출력 동일 (text-3xs / uppercase / tracking-wider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
