### PR TITLE
fix(cascade): complete RFC-0189 PR-1c — qualify Tool_result constructors + drop tuple shapes

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -157,7 +157,7 @@ let make_pre_hook ~config ~governance_level =
        which boundary observes it. *)
     Tool_dispatch.Reject
       (Error
-         { Tool_result.class_ = Workflow_rejection
+         { Tool_result.class_ = Tool_result.Workflow_rejection
          ; message = Yojson.Safe.to_string response
          ; data = response
          ; tool_name = name
@@ -186,7 +186,7 @@ let make_pre_hook ~config ~governance_level =
        from runtime/transient errors. *)
     Tool_dispatch.Reject
       (Error
-         { Tool_result.class_ = Policy_rejection
+         { Tool_result.class_ = Tool_result.Policy_rejection
          ; message = Yojson.Safe.to_string response
          ; data = response
          ; tool_name = name

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -559,10 +559,6 @@ let execute_tool_eio
                      (make_keeper_tool_ctx ())
                      ~name
                      ~args:coerced_args
-                   |> Option.map (fun (ok, msg) ->
-                     if ok
-                     then Tool_result.ok ~tool_name:name ~start_time msg
-                     else Tool_result.error ~tool_name:name ~start_time msg)
                  (* Removed tool families are intentionally not dispatchable. *)
                  | Mod_shard ->
                    let ok, json = Tool_shard.execute name coerced_args in

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -418,19 +418,19 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
                    }
                  in
                  (match Keeper_turn_up_args.parse keeper_ctx args_with_name with
-                 | Error (_ok, msg) ->
+                 | Error result ->
                      Http.Response.json ~status:`Bad_request
                        (Printf.sprintf {|{"error":"%s"}|}
-                          (String.escaped msg))
+                          (String.escaped (Keeper_types.tool_result_body result)))
                        reqd
                  | Ok parsed ->
-                     let ok, msg =
+                     let result =
                        Keeper_turn_up_update.update_keeper keeper_ctx parsed meta0
                      in
-                     if not ok then
+                     if not (Keeper_types.tool_result_success result) then
                        Http.Response.json ~status:`Bad_request
                          (Printf.sprintf {|{"error":"%s"}|}
-                            (String.escaped msg))
+                            (String.escaped (Keeper_types.tool_result_body result)))
                          reqd
                      else
                        let (_st, json) =
@@ -739,4 +739,3 @@ let handle_keeper_bulk_directive_post state _agent_name req reqd body_str =
         reqd
 
 (** Keeper GET sub-routes handler: /config, /chat/history, /trajectory. *)
-

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -293,7 +293,7 @@ let reject_validation ~name ~reason ~message =
   Log.info "tool_input_validation rejected %s: %s" name message;
   Tool_dispatch.Reject
     (Error
-       { Tool_result.class_ = Policy_rejection
+       { Tool_result.class_ = Tool_result.Policy_rejection
        ; message
        ; data =
            `Assoc
@@ -318,7 +318,7 @@ let validation_exception_action ~name exn : Tool_dispatch.pre_hook_action =
   Log.error "%s" message;
   Tool_dispatch.Reject
     (Error
-       { Tool_result.class_ = Runtime_failure
+       { Tool_result.class_ = Tool_result.Runtime_failure
        ; message
        ; data =
            `Assoc
@@ -425,7 +425,7 @@ let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
          actual category instead of bucketing as "unclassified". *)
       Tool_dispatch.Reject
         (Error
-           { Tool_result.class_ = Policy_rejection
+           { Tool_result.class_ = Tool_result.Policy_rejection
            ; message
            ; data =
                `Assoc

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -220,7 +220,7 @@ let restore ~base_path : int =
                }
            else
              Error
-               { Tool_result.class_ = Runtime_failure
+               { Tool_result.class_ = Tool_result.Runtime_failure
                ; message = ""
                ; data = `Null
                ; tool_name = r.tool_name


### PR DESCRIPTION
## Summary

`#18905` (RFC-0189 PR-1c) merged the typed `Tool_result.result` ABI into `main` with `NOT YET BUILDING. Pending cascade fixes (~26 sites)` and listed the call-sites that still consumed the legacy tuple shape. This PR clears the 5 sites that codex P1 review on `#18930` re-surfaced.

## Changes

- `lib/governance_pipeline.ml` (2 sites), `lib/tool_input_validation.ml` (3 sites), `lib/tool_metrics_persist.ml` (1 site): qualify `Tool_result` failure-class constructors so the record literals read `{ Tool_result.class_ = Tool_result.Workflow_rejection; ... }` — same convention already used at `tool_board_*`, `tool_agent`, etc. with the `~class_:Tool_result.<Variant>` form. Removes reliance on OCaml type-directed disambiguation.
- `lib/mcp_server_eio_execute.ml` (`Mod_keeper` arm): drop the `|> Option.map (fun (ok, msg) -> if ok then Tool_result.ok ... else Tool_result.error ...)` block. `Keeper_tool_boundary.dispatch` now returns `Tool_result.result option` directly.
- `lib/server/server_dashboard_http_keeper_api_post.ml` (`handle_keeper_config_post`): switch `Error (_ok, msg)` and `let ok, msg = update_keeper ...` to typed result, with `Keeper_types.tool_result_body` and `tool_result_success` accessors. Matches the typed signatures of `Keeper_turn_up_args.parse` and `Keeper_turn_up_update.update_keeper`.

Net: +11 / -16 across 5 lib files.

## Verification

- `ocamlformat --check` (PASS) on all 5 files.
- `bash ~/me/scripts/pr-rfc-check.sh` (PASS).
- Build still blocked locally by `_build/.lock` contention (concurrent agent build on adjacent worktree); the targeted lib build relies on the cascade landing.

## Codex P1 review (PR #18930) status

| Codex finding | Site | Status |
|---|---|---|
| P1#1 Qualify failure-class constructors | governance_pipeline / tool_input_validation / tool_metrics_persist | Addressed (this PR) |
| P1#2 Update local-runtime tuple callers | `Tool_local_runtime.dispatch` callers | Already typed via `#18906`; no surviving tuple site found |
| P1#3 Update keeper tuple callers | `mcp_server_eio_execute.ml` (`Mod_keeper`) | Addressed (this PR) |
| P2 Preserve success messages | `tool_result.ml:148` accessor | Out of scope — separate follow-up |

## Related

- `#18905` — typed ABI merge with explicit pending-fix list
- `#18930` — keeper tool result tuple alias removal (merged into `#18905`'s base)
- `#18906` — keeper dispatch-ref bridges (typed)