### PR TITLE
refactor(dashboard/lib): extract sparkline dimensions to lib/sparkline-config

### DIFF
--- a/dashboard/src/components/keeper-detail-charts.ts
+++ b/dashboard/src/components/keeper-detail-charts.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { formatTokens } from '../lib/format-number'
+import { SPARKLINE_W, SPARKLINE_H, SPARKLINE_PAD } from '../lib/sparkline-config'
 import { ProgressBar } from './common/progress-bar'
 import { Eyebrow } from './common/eyebrow'
 import { StatusChip } from './common/status-chip'
@@ -11,10 +12,6 @@ import {
   CTX_COLOR_WARN,
 } from './keeper-detail-ctx-utils'
 import { MutedSpan, DetailCard, DetailRow } from './keeper-detail-kpi'
-
-const SPARKLINE_W = 200
-const SPARKLINE_H = 40
-const SPARKLINE_PAD = 2
 
 // ── Context Chart ────────────────────────────────────────
 

--- a/dashboard/src/components/keeper-detail-ctx-composition.ts
+++ b/dashboard/src/components/keeper-detail-ctx-composition.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { formatTokens } from '../lib/format-number'
+import { SPARKLINE_W, SPARKLINE_PAD } from '../lib/sparkline-config'
 import { TextInput } from './common/input'
 import { Eyebrow } from './common/eyebrow'
 import type { Keeper, KeeperMetricPoint } from '../types'
@@ -10,9 +11,6 @@ import {
   filterCtxCompositionEntries,
 } from './keeper-detail-ctx-utils'
 import { MutedSpan, DetailRow, DetailCard } from './keeper-detail-kpi'
-
-const SPARKLINE_W = 200
-const SPARKLINE_PAD = 2
 
 export const ctxCompositionSearch = signal('')
 

--- a/dashboard/src/components/keeper-detail-telemetry.ts
+++ b/dashboard/src/components/keeper-detail-telemetry.ts
@@ -1,13 +1,10 @@
 import { html } from 'htm/preact'
 import { formatTokens } from '../lib/format-number'
+import { SPARKLINE_W, SPARKLINE_H, SPARKLINE_PAD } from '../lib/sparkline-config'
 import { CopyIdButton } from './common/copy-id-button'
 import { Eyebrow } from './common/eyebrow'
 import type { Keeper, KeeperMetricPoint } from '../types'
 import { MutedSpan, DetailRow, DetailCard } from './keeper-detail-kpi'
-
-const SPARKLINE_W = 200
-const SPARKLINE_H = 40
-const SPARKLINE_PAD = 2
 
 function isFiniteMetricValue(value: number | null | undefined): value is number {
   return typeof value === 'number' && Number.isFinite(value)

--- a/dashboard/src/lib/sparkline-config.ts
+++ b/dashboard/src/lib/sparkline-config.ts
@@ -1,0 +1,16 @@
+// Shared sparkline SVG dimensions for the keeper-detail surface.
+//
+// keeper-detail-charts, keeper-detail-telemetry, and
+// keeper-detail-ctx-composition each render small inline charts using
+// the same viewBox so they stack visually in the right-rail. Keep these
+// in one place so a width/height/padding adjustment lands everywhere
+// at once instead of drifting between components.
+
+/** Viewbox width in SVG units. */
+export const SPARKLINE_W = 200
+
+/** Viewbox height in SVG units. */
+export const SPARKLINE_H = 40
+
+/** Inner padding (top/bottom and left/right) in SVG units. */
+export const SPARKLINE_PAD = 2


### PR DESCRIPTION
## 요약

`SPARKLINE_W` / `SPARKLINE_H` / `SPARKLINE_PAD` 가 3 컴포넌트에 *byte-for-byte 동일* 한 dimension 으로 분산 정의. `const` 분포 sweep 에서 발굴.

| 파일 | W | H | PAD |
|---|---|---|---|
| `keeper-detail-charts.ts:15-17` | `200` | `40` | `2` |
| `keeper-detail-telemetry.ts:8-10` | `200` | `40` | `2` |
| `keeper-detail-ctx-composition.ts:14-15` | `200` | — | `2` |

세 컴포넌트 모두 keeper-detail surface 의 *우측 패널* 에서 inline SVG sparkline 을 같은 viewBox 로 stack rendering. 같은 dimension 통일은 *시각적 그리드 정렬* 의도 — drift 가 발생하면 chart 간 height/width 불일치로 패널 정렬 깨짐.

## 변경

- **신설** `src/lib/sparkline-config.ts`: 3 dimension 상수 export + JSDoc (viewBox 의미 + 분산 위험 설명)
- `keeper-detail-charts.ts`: 자체 const 3 정의 삭제 + import 추가
- `keeper-detail-telemetry.ts`: 자체 const 3 정의 삭제 + import 추가
- `keeper-detail-ctx-composition.ts`: 자체 const 2 정의 삭제 + import 추가 (H 미사용)

호출 사이트 (각 컴포넌트의 `SPARKLINE_W` / `SPARKLINE_H` / `SPARKLINE_PAD` 사용처) 무변경 — *이름 그대로* 라 import 로만 해결.

## SSOT 위치 결정

`lib/sparkline-config.ts` 신설 — *공유 dimension* 이라 utility 영역이 자연. components/ 안 *형제 의존* 회피 (어떤 컴포넌트가 owner 인지 모호). 향후 sparkline 관련 helper (rendering, scaling) 추가 위치도 미리 마련.

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run src/components/keeper-detail-charts src/components/keeper-detail-telemetry src/components/keeper-detail-ctx-composition src/lib/sparkline-config`: 2/2 (1 test file — sparkline 자체 test 없음, 컴포넌트 test 도 sparkline dim 미검증)
- `pnpm exec eslint`: 0 errors

표면 동작 회귀 없음 — dimension 값 동일, import 만 추가.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#21, 차트 dimension SSOT 추출)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Keeper detail 의 3 sparkline (context chart / telemetry / ctx-composition) 시각적 정렬 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
