### PR TITLE
fix(cascade): continue RFC-0189 PR-1c cascade in test callers

### DIFF
--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -705,7 +705,7 @@ let test_refresh_once_skips_fresh_cached_result () =
         ~masc_tools:[]
         ~dispatch:(fun ~name ~args:_ ->
           Error
-            { Tool_result.class_ = Runtime_failure
+            { Tool_result.class_ = Tool_result.Runtime_failure
             ; message = "unused"
             ; data = `String "unused"
             ; tool_name = name
@@ -748,7 +748,7 @@ let test_refresh_once_skips_timeout_backoff () =
         ~masc_tools:[]
         ~dispatch:(fun ~name ~args:_ ->
           Error
-            { Tool_result.class_ = Runtime_failure
+            { Tool_result.class_ = Tool_result.Runtime_failure
             ; message = "unused"
             ; data = `String "unused"
             ; tool_name = name

--- a/test/test_mcp_server_eio_tool_dispatch.ml
+++ b/test/test_mcp_server_eio_tool_dispatch.ml
@@ -85,7 +85,7 @@ let test_execute_tool_tag_dispatch_respects_pre_hooks () =
           if String.equal name "masc_tool_help" then
             Tool_dispatch.Reject
               (Error
-                 { Tool_result.class_ = Runtime_failure
+                 { Tool_result.class_ = Tool_result.Runtime_failure
                  ; message = "blocked-by-pre-hook"
                  ; data = `String "blocked-by-pre-hook"
                  ; tool_name = name

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -2771,11 +2771,15 @@ proactive_enabled = true
               ])
         with
         | Ok parsed -> parsed
-        | Error (_ok, msg) -> Alcotest.fail ("active_goal_ids parse failed: " ^ msg)
+        | Error err ->
+            Alcotest.fail
+              ("active_goal_ids parse failed: " ^ Keeper_types.tool_result_body err)
       in
-      let ok, msg =
+      let result =
         Keeper_turn_up_update.update_keeper keeper_ctx parsed_goal_update meta
       in
+      let ok = Keeper_types.tool_result_success result in
+      let msg = Keeper_types.tool_result_body result in
       Alcotest.(check bool) ("active_goal_ids update ok: " ^ msg) true ok;
       let meta = read_keeper_meta_exn config keeper_name in
       let parsed_bad_goal_update =
@@ -2788,11 +2792,15 @@ proactive_enabled = true
               ])
         with
         | Ok parsed -> parsed
-        | Error (_ok, msg) -> Alcotest.fail ("bad active_goal_ids parse failed: " ^ msg)
+        | Error err ->
+            Alcotest.fail
+              ("bad active_goal_ids parse failed: " ^ Keeper_types.tool_result_body err)
       in
-      let ok, msg =
+      let result =
         Keeper_turn_up_update.update_keeper keeper_ctx parsed_bad_goal_update meta
       in
+      let ok = Keeper_types.tool_result_success result in
+      let msg = Keeper_types.tool_result_body result in
       Alcotest.(check bool) "unknown active goal rejected" false ok;
       Alcotest.(check bool) "unknown active goal names surfaced" true
         (contains_substring msg "goal-missing");

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -125,7 +125,7 @@ let test_to_oas_typed_error_uses_json_recoverable_flag () =
   in
   let tr : Tool_result.result =
     Error
-      { Tool_result.class_ = Runtime_failure
+      { Tool_result.class_ = Tool_result.Runtime_failure
       ; message = msg
       ; data = Yojson.Safe.from_string msg
       ; tool_name = "test"

--- a/test/test_tool_hooks.ml
+++ b/test/test_tool_hooks.ml
@@ -50,7 +50,7 @@ let test_pre_hook_short_circuits () =
     log_call "pre_block";
     Tool_dispatch.Reject
       (Error
-         { Tool_result.class_ = Runtime_failure
+         { Tool_result.class_ = Tool_result.Runtime_failure
          ; message = "blocked"
          ; data = `String "blocked"
          ; tool_name = name
@@ -84,7 +84,7 @@ let test_multiple_pre_hooks_first_wins () =
     log_call "pre2_block";
     Tool_dispatch.Reject
       (Error
-         { Tool_result.class_ = Runtime_failure
+         { Tool_result.class_ = Tool_result.Runtime_failure
          ; message = "denied"
          ; data = `String "denied"
          ; tool_name = name

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -43,7 +43,7 @@ let validate_via_oas ~tool_name ~(schema : Yojson.Safe.t) ~(args : Yojson.Safe.t
       in
       Reject
         (Error
-           { Tool_result.class_ = Runtime_failure
+           { Tool_result.class_ = Tool_result.Runtime_failure
            ; message = msg
            ; data = `Assoc [("error", `String msg)]
            ; tool_name


### PR DESCRIPTION
## Summary

Follow-up to `#18956`. `#18905`'s `NOT YET BUILDING. Pending cascade fixes (~26 sites)` commit message named the test files; `#18956` covered the lib sites, this PR covers the surviving **11 test sites** in 6 files that still consume the legacy `Tool_result` shapes.

## Changes (+19/-11)

| File | Type | Sites |
|---|---|---|
| `test/test_tool_input_validation.ml` | record qualify | 1 |
| `test/test_tool_hooks.ml` | record qualify | 2 |
| `test/test_tool_bridge_externalize.ml` | record qualify | 1 |
| `test/test_dashboard_governance.ml` | record qualify | 2 |
| `test/test_mcp_server_eio_tool_dispatch.ml` | record qualify | 1 |
| `test/test_operator_control_keeper.ml` | tuple → typed accessor | 4 |

- **Record qualify (7 sites)**: `{ Tool_result.class_ = Runtime_failure; ... }` → `{ Tool_result.class_ = Tool_result.Runtime_failure; ... }`, matching the lib-side convention from `#18956`.
- **Tuple → typed accessor (4 sites)** in `test_operator_control_keeper` `active_goal_ids` flow (lines 2774, 2776-2778, 2791, 2793-2795):
  - `| Error (_ok, msg) -> Alcotest.fail ("... " ^ msg)` → `| Error err -> Alcotest.fail ("... " ^ Keeper_types.tool_result_body err)` (`Keeper_turn_up_args.parse` returns `(_, tool_result) result`).
  - `let ok, msg = Keeper_turn_up_update.update_keeper ...` → `let result = ... in let ok = Keeper_types.tool_result_success result in let msg = Keeper_types.tool_result_body result in ...` (`update_keeper` returns `tool_result`).

## Verification

- `ocamlformat --check` on all 6 files (PASS).
- `bash ~/me/scripts/pr-rfc-check.sh` (PASS).
- `rg "Tool_result\\.class_ = (Workflow_rejection|Policy_rejection|Runtime_failure|Transient_error)\\b" test/` returns empty after fix.
- `rg "Error \\(_ok, msg\\)|let ok, msg = " test/test_operator_control_keeper.ml` returns empty after fix.

## Cascade closeout status

After this PR, the lib + test surface should be free of the `Tool_result.t` record / `(bool * string)` tuple shapes:

- Lib: cleared by `#18956`.
- Test: cleared by this PR (the named-in-#18905 plus 3 additional sites discovered: `test_tool_bridge_externalize`, `test_dashboard_governance` ×2, `test_operator_control_keeper`).

Some `#18905`-listed test files (`test_rfc_0085_pr5_dispatch_emit`, `test_pr_i_2d_output_validation_transformer`, `test_tool_token`, `test_keeper_exec_tools`, `test_governance_pipeline`, `test_tool_dispatch`, `test_tool_result`, `test_tool_spec`) showed no surviving legacy pattern at this point — likely already cleaned up in interim PRs.

## Related

- `#18905` — typed ABI merge with pending cascade list
- `#18956` — Phase 2 lib cascade fix (5 sites)
- This PR — Phase 3 test cascade fix (11 sites)