### PR TITLE
refactor(dashboard/lib): extract DEFAULT_PANEL_REFRESH_MS to auto-refresh module

### DIFF
--- a/dashboard/src/components/ide/ide-persistence-panel.ts
+++ b/dashboard/src/components/ide/ide-persistence-panel.ts
@@ -19,8 +19,7 @@ import {
   type IdeContextRouteLink,
 } from './ide-context-lens'
 import { useSignalValue } from './use-signal-value'
-
-const REFRESH_MS = 30_000
+import { DEFAULT_PANEL_REFRESH_MS } from '../../lib/auto-refresh'
 
 type LifecycleState = 'created' | 'active' | 'idle' | 'terminated'
 
@@ -238,7 +237,7 @@ function LifecycleMini({ state, phase }: { state: LifecycleState; phase: string 
 
 export function IdePersistencePanel({
   keeperName: explicitKeeperName,
-  pollMs = REFRESH_MS,
+  pollMs = DEFAULT_PANEL_REFRESH_MS,
 }: IdePersistencePanelProps) {
   const activeName = useSignalValue(activeKeeperName)
   const keeperRows = useSignalValue(keepers)

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -15,10 +15,8 @@ import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import { StatusChip, type StatusChipTone } from './common/status-chip'
 import { buildCompactionSpec } from './keeper-fsm-specs'
-import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
+import { DEFAULT_PANEL_REFRESH_MS, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { toKeeperPhase } from '../keeper-store-normalize'
-
-const REFRESH_MS = 30_000
 
 interface KeeperMemoryTierPanelProps {
   keeperName: string
@@ -137,7 +135,7 @@ export function KeeperMemoryTierPanel({
     }
 
     refresh()
-    const cleanup = setupVisibleAutoRefresh(() => refresh(), REFRESH_MS)
+    const cleanup = setupVisibleAutoRefresh(() => refresh(), DEFAULT_PANEL_REFRESH_MS)
 
     return () => {
       controller.abort()

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -16,11 +16,9 @@ import {
 } from '../api/dashboard'
 import { formatTimeAgo } from '../lib/format-time'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
-import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
+import { DEFAULT_PANEL_REFRESH_MS, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { openAgentDetail } from './agent-detail-state'
 import { ringFocusClasses, ringSelectClasses } from './common/ring'
-
-const REFRESH_MS = 30_000
 
 type MemorySubsystemsFocus = 'entries' | 'episodes'
 
@@ -648,7 +646,7 @@ export function MemorySubsystems({ focus }: MemorySubsystemsProps = {}) {
       )
     }
     run()
-    const cleanup = setupVisibleAutoRefresh(run, REFRESH_MS)
+    const cleanup = setupVisibleAutoRefresh(run, DEFAULT_PANEL_REFRESH_MS)
     return () => {
       resource.cancel()
       cleanup()
@@ -972,7 +970,7 @@ export function KeeperMemoryPanel({ keeperName }: { readonly keeperName: string 
       )
     }
     run()
-    const cleanup = setupVisibleAutoRefresh(run, REFRESH_MS)
+    const cleanup = setupVisibleAutoRefresh(run, DEFAULT_PANEL_REFRESH_MS)
     return () => {
       resource.cancel()
       cleanup()

--- a/dashboard/src/lib/auto-refresh.ts
+++ b/dashboard/src/lib/auto-refresh.ts
@@ -1,5 +1,16 @@
 const AUTO_REFRESH_EVENT_DEDUPE_MS = 500
 
+/**
+ * Default polling interval for panel-level auto-refresh.
+ *
+ * Three sibling panels (ide-persistence, keeper-memory-tier,
+ * memory-subsystems) all picked 30s independently. Lifting it here
+ * makes the shared cadence visible — and if a panel needs a different
+ * interval it can pass its own value to `setupVisibleAutoRefresh`
+ * instead of overriding a const by accident.
+ */
+export const DEFAULT_PANEL_REFRESH_MS = 30_000
+
 export function formatAutoRefreshLabel(intervalMs: number): string {
   const seconds = Math.max(1, Math.round(intervalMs / 1000))
   if (seconds % 60 === 0) {


### PR DESCRIPTION
## 요약

3 컴포넌트가 `const REFRESH_MS = 30_000` byte-for-byte 동일하게 분산 정의 — 모두 `setupVisibleAutoRefresh()` 의 polling interval. `const` 분포 sweep 에서 발굴.

| 파일 | 정의 | 사용처 |
|---|---|---|
| `ide-persistence-panel.ts:23` | `30_000` | `setupVisibleAutoRefresh` pollMs default |
| `keeper-memory-tier-panel.ts:21` | `30_000` | `setupVisibleAutoRefresh(refresh, REFRESH_MS)` |
| `memory-subsystems.ts:23` | `30_000` | `setupVisibleAutoRefresh(run, REFRESH_MS)` × 2 |

3 컴포넌트 모두 `lib/auto-refresh.setupVisibleAutoRefresh` 의 호출자. 같은 polling cadence 가 *우연한* 동일이 아니라 *공통 panel refresh 정책* 으로 보임.

## 변경

SSOT 위치 = `lib/auto-refresh.ts` (이미 `setupVisibleAutoRefresh` owner — 자연 위치):

- `lib/auto-refresh.ts`: `export const DEFAULT_PANEL_REFRESH_MS = 30_000` 추가 + JSDoc (override 가능성 명시: "다른 interval 필요 시 setupVisibleAutoRefresh 에 직접 값 전달")
- `ide-persistence-panel.ts`: 자체 const 삭제 + import + 1 호출 사이트 rename
- `keeper-memory-tier-panel.ts`: 자체 const 삭제 + import + 1 호출 사이트 rename
- `memory-subsystems.ts`: 자체 const 삭제 + import + 2 호출 사이트 rename

이름 `DEFAULT_PANEL_REFRESH_MS` 채택 — *default* 어휘가 *override 가능* 의미 박음. 향후 *특정 패널만 60s* 으로 바꾸려면 그 패널이 `setupVisibleAutoRefresh(refresh, 60_000)` 직접 전달.

## 검증

- `pnpm typecheck` PASS
- `pnpm exec vitest run src/lib/auto-refresh src/components/ide/ide-persistence-panel src/components/keeper-memory-tier-panel src/components/memory-subsystems`: 43/43 (6 test files)
- `pnpm exec eslint`: 0 errors (lib warning = 기존 pre-existing config 미설정)

표면 동작 회귀 없음 — 값 동일, polling cadence 변화 없음.

## 학습 포인트: replace_all 의 self-overlap 함정

`replace_all('REFRESH_MS', 'DEFAULT_PANEL_REFRESH_MS')` 가 이미 추가된 import 라인 안의 `DEFAULT_PANEL_REFRESH_MS` 도 다시 매칭해 `DEFAULT_PANEL_DEFAULT_PANEL_REFRESH_MS` 로 깨뜨림 (string substring overlap). typecheck (TS2305 + TS2304 + TS6133) 가 즉시 catch — 컴파일러가 *replace_all 안전망* 역할.

**교훈**: `replace_all` 의 new 가 old 의 superstring 이면 import 라인을 *나중에* 추가하거나 *별도 Edit* 으로 처리. iter#19 의 sed `\b` 한계 학습 누적.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#22, panel refresh cadence SSOT)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] 3 패널 (persistence / memory-tier / memory-subsystems) auto-refresh 30s 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
