### PR TITLE
fix(test): migrate keeper_msg_async submit ~f to typed Tool_result (RFC-0189 PR-1c closeout)

### DIFF
--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -1,6 +1,8 @@
 open Alcotest
 open Masc_mcp
 
+let tr_ok body = Tool_result.ok ~tool_name:"keeper-test" ~start_time:0.0 body
+
 let wait_for_done request_id =
   let rec loop remaining =
     match Keeper_msg_async.poll request_id with
@@ -113,7 +115,7 @@ let test_keeper_msg_async_roundtrip () =
       ~keeper_name:"alpha"
       ~f:(fun () ->
         Eio.Fiber.yield ();
-        true, Yojson.Safe.to_string (`Assoc [ "kind", `String "done" ]))
+        tr_ok (Yojson.Safe.to_string (`Assoc [ "kind", `String "done" ])))
       ()
   in
   let entry = wait_for_done request_id in
@@ -142,7 +144,7 @@ let test_keeper_msg_async_recovers_done_from_disk () =
       ~keeper_name:"beta"
       ~f:(fun () ->
         Eio.Fiber.yield ();
-        true, Yojson.Safe.to_string (`Assoc [ "kind", `String "done" ]))
+        tr_ok (Yojson.Safe.to_string (`Assoc [ "kind", `String "done" ])))
       ()
   in
   let entry = wait_for_done request_id in
@@ -177,7 +179,7 @@ let test_keeper_msg_async_marks_recovered_inflight_lost () =
       ~keeper_name:"gamma"
       ~f:(fun () ->
         Eio.Promise.await promise;
-        true, "{}")
+        tr_ok "{}")
       ()
   in
   ignore (wait_for_running request_id : Keeper_msg_async.entry);
@@ -214,7 +216,7 @@ let test_keeper_msg_async_marks_cancelled_worker_lost () =
         ~keeper_name:"cancelled"
         ~f:(fun () ->
           Eio.Promise.await never;
-          true, "{}")
+          tr_ok "{}")
         ()
     in
     ignore (wait_for_running request_id : Keeper_msg_async.entry);
@@ -249,7 +251,7 @@ let test_keeper_msg_async_timeout_is_terminal_error () =
       ~keeper_name:"timeout"
       ~f:(fun () ->
         Eio.Promise.await release_late;
-        true, Yojson.Safe.to_string (`Assoc [ "kind", `String "late" ]))
+        tr_ok (Yojson.Safe.to_string (`Assoc [ "kind", `String "late" ])))
       ()
   in
   let entry = wait_for_done_with_clock clock request_id in
@@ -304,7 +306,7 @@ let test_keeper_msg_async_gc_removes_stale_terminal_disk_record () =
       ~keeper_name:"delta"
       ~f:(fun () ->
         Eio.Fiber.yield ();
-        true, "{}")
+        tr_ok "{}")
       ()
   in
   let entry = wait_for_done request_id in


### PR DESCRIPTION
## Summary

`#18905` (RFC-0189 PR-1c) merged the typed `Tool_result.result` ABI into `main` with `NOT YET BUILDING. Pending cascade fixes (~26 sites)`. Cascade closeout PRs `#18956` (5 lib sites) and `#18958` (2 test files) covered most of that list. `test/test_keeper_mutex_coverage.ml` was missed — local `dune build .` after pulling reproduces:

```
File "test/test_keeper_mutex_coverage.ml", line 116, characters 8-71:
Error: This expression has type 'a * 'b
       but an expression was expected of type
         Keeper_types.tool_result =
           (Tool_result.success_payload, Tool_result.failure_payload) result
```

`Keeper_msg_async.submit` now takes `~f:(unit -> Keeper_types.tool_result)`. All 6 call sites in this test file still returned the legacy `(bool * string)` tuple.

## Changes

- One-line helper at the top of the file (`tr_ok body = Tool_result.ok ~tool_name:"keeper-test" ~start_time:0.0 body`) so the 6 call sites stay shaped like the original tuples.
- 6 call sites: `true, <body_expr>` → `tr_ok <body_expr>` (alpha/beta/gamma/cancelled/timeout/delta).

Net: `+8 / -6`, one file.

## Verification

- `dune build --root .` PASS.
- `dune exec --root . test/test_keeper_mutex_coverage.exe` PASS — all 10 tests (7 `keeper_msg_async` + 2 `eio_guard` + 1 `voice_bridge`).
- The body invariant the tests check (`Done { ok = true; body }` with `String.length body > 0`) is preserved: `Tool_result.message` of an `Ok` payload stringifies `.data`, which is non-empty for both `"{}"` and the structured `Assoc [...]` payloads.

## Related

- `#18905` — typed `Tool_result.result` ABI merge with the pending-fix list
- `#18956` — codex P1 review closeout (5 lib sites)
- `#18958` — test migration justifications (2 other test files)

## Workaround Signature Gate

Not a workaround — direct N-of-M closeout for one of the 26 sites enumerated by PR #18905's own body. No new substring matchers, no telemetry-as-fix, no catch-all expansion. Matches the typed migration shape `#18956` used in `mcp_server_eio_execute.ml`.

WORKAROUND-WAIVED: gate STRING_CLASSIFIER trigger is a false positive — the body discusses the anti-pattern in the negative ("no new substring matchers"); no classifier code is added.