### PR TITLE
refactor(dashboard/components): consolidate keeper-detail polling consts into DEFAULT_PANEL_REFRESH_MS

### DIFF
--- a/dashboard/src/components/keeper-detail-hooks.ts
+++ b/dashboard/src/components/keeper-detail-hooks.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'preact/hooks'
 import { fetchKeeperComposite, fetchKeeperRuntimeTrace } from '../api/keeper'
 import type { KeeperCompositeSnapshot, KeeperRuntimeTraceResponse } from '../api/keeper'
-import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
+import { DEFAULT_PANEL_REFRESH_MS, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import {
   applyFetchFailed,
   applyFetchSucceeded,
@@ -9,9 +9,6 @@ import {
   loadingEvidence,
   type EvidenceState,
 } from './keeper-detail-evidence-state'
-
-const COMPOSITE_REFRESH_MS = 30_000
-const RUNTIME_TRACE_REFRESH_MS = 30_000
 
 /**
  * Typed evidence state shared by the keeper detail surface. The union
@@ -59,7 +56,7 @@ export function useKeeperCompositeEvidence(keeperName: string): KeeperDetailEvid
       }
     }
     void refresh()
-    const cleanup = setupVisibleAutoRefresh(refresh, COMPOSITE_REFRESH_MS)
+    const cleanup = setupVisibleAutoRefresh(refresh, DEFAULT_PANEL_REFRESH_MS)
     return () => {
       cancelled = true
       controller.abort()
@@ -96,7 +93,7 @@ export function useKeeperRuntimeTraceEvidence(keeperName: string): KeeperDetailE
       }
     }
     void refresh()
-    const cleanup = setupVisibleAutoRefresh(refresh, RUNTIME_TRACE_REFRESH_MS)
+    const cleanup = setupVisibleAutoRefresh(refresh, DEFAULT_PANEL_REFRESH_MS)
     return () => {
       cancelled = true
       controller.abort()


### PR DESCRIPTION
## 요약

iter#22 follow-up. `dashboard/src/components/keeper-detail-hooks.ts` 의 두 file-local const 가 byte-for-byte `30_000` 으로 분산:

| 위치 | 정의 | 사용처 |
|---|---|---|
| `keeper-detail-hooks.ts:13` | `COMPOSITE_REFRESH_MS = 30_000` | `setupVisibleAutoRefresh(refresh, ...)` — composite snapshot |
| `keeper-detail-hooks.ts:14` | `RUNTIME_TRACE_REFRESH_MS = 30_000` | `setupVisibleAutoRefresh(refresh, ...)` — runtime trace |

iter#22 (PR #18960) 가 `lib/auto-refresh.ts` 에 도입한 `DEFAULT_PANEL_REFRESH_MS` 와 *완전히* 같은 정책 (panel-level visible auto-refresh 30s). 두 const 가 동일 cadence 인 것이 *공통 정책* 인지 *우연한 동일* 인지 검토 — 둘 다 `useKeeper*Evidence` hook 의 polling, `setupVisibleAutoRefresh` 호출, default panel refresh policy 와 의미적으로 같음.

## 변경

- `keeper-detail-hooks.ts`: 두 const 삭제 + `lib/auto-refresh` import 에 `DEFAULT_PANEL_REFRESH_MS` 추가 + 2 호출 사이트 rename

향후 keeper-detail 의 cadence 만 다르게 가져가야 한다면 `setupVisibleAutoRefresh(refresh, customMs)` 직접 전달 — *override-by-default* 패턴 유지.

## 검증

- `pnpm typecheck` PASS (silent)
- `pnpm exec vitest run`: 528/529 file PASS (auth-status.a11y 1 fail = **pre-existing**, baseline 측정값 = main 도 동일 1 fail)
- `pnpm exec eslint src/components/keeper-detail-hooks.ts`: 0 errors

표면 동작 회귀 없음 — 값 동일, polling cadence 변화 없음.

## SSOT 확장 적용 범위 한정

* **이 PR**: keeper-detail-hooks (2 사이트) 만 통합. iter#22 의 직접 follow-up.
* **별도 iter 보류**: `TELEMETRY_AUTO_REFRESH_MS` (config/constants.ts:55, 30_000, 5 사이트). UI 라벨 노출 (`formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)`) 패턴이 *telemetry-class* 의 다른 semantics 가능성 — sweep 전 검토 필요.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#23, keeper-detail-hooks refresh cadence SSOT)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] keeper-detail surface (composite + runtime trace) auto-refresh 30s 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
