### PR TITLE
refactor(dashboard/ide): extract IDE_CONTEXT_BADGE_STYLE SSOT for 17px context badges

### DIFF
--- a/dashboard/src/components/ide/context-badge-style.ts
+++ b/dashboard/src/components/ide/context-badge-style.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared inline style for compact IDE context badges (route hop labels,
+ * lane chips, persistence layer markers).
+ *
+ * Three sibling components — execute-output-drawer, ide-persistence-panel,
+ * ide-branch-context-panel — defined this byte-for-byte. Lifting it here
+ * makes the shared visual contract explicit, so a fourth panel needing
+ * a context badge inherits the look instead of copy-pasting (and quietly
+ * drifting on a token rename).
+ *
+ * If a panel needs a different look (e.g. overlay-keeper-trace ships its
+ * own with `minWidth` + `lineHeight` for stacked layout), declare it
+ * inline rather than mutating this constant.
+ */
+export const IDE_CONTEXT_BADGE_STYLE = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  height: '17px',
+  padding: '0 5px',
+  border: '1px solid var(--color-border-muted)',
+  borderRadius: 'var(--r-1)',
+  background: 'var(--color-bg-subtle)',
+  color: 'var(--color-fg-muted)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 'var(--fs-9)',
+  whiteSpace: 'nowrap',
+} as const

--- a/dashboard/src/components/ide/execute-output-drawer.ts
+++ b/dashboard/src/components/ide/execute-output-drawer.ts
@@ -14,6 +14,7 @@ import {
   type IdeContextRouteLink,
 } from './ide-context-lens'
 import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
+import { IDE_CONTEXT_BADGE_STYLE } from './context-badge-style'
 
 const MAX_TERMINAL_LINES = 5000
 
@@ -176,7 +177,7 @@ function ExecuteOutputContextLinks({
         data-context-route-count=${links.length}
         title=${`Linked context: ${routeLabels}`}
         aria-label=${`Execute output has ${links.length} linked context routes: ${routeLabels}`}
-        style=${EXECUTE_OUTPUT_CONTEXT_BADGE_STYLE}
+        style=${IDE_CONTEXT_BADGE_STYLE}
       >
         CTX ${links.length}
       </span>
@@ -192,20 +193,6 @@ function ExecuteOutputContextLinks({
     </div>
   `
 }
-
-const EXECUTE_OUTPUT_CONTEXT_BADGE_STYLE = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  height: '17px',
-  padding: '0 5px',
-  border: '1px solid var(--color-border-muted)',
-  borderRadius: 'var(--r-1)',
-  background: 'var(--color-bg-subtle)',
-  color: 'var(--color-fg-muted)',
-  fontFamily: 'var(--font-mono)',
-  fontSize: 'var(--fs-9)',
-  whiteSpace: 'nowrap',
-} as const
 
 function routeLinkLabels(links: ReadonlyArray<IdeContextRouteLink>): string {
   return links.map(link => link.label).join(', ')

--- a/dashboard/src/components/ide/ide-branch-context-panel.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.ts
@@ -13,6 +13,7 @@ import {
   routeLinksForContext,
   type IdeContextRouteLink,
 } from './ide-context-lens'
+import { IDE_CONTEXT_BADGE_STYLE } from './context-badge-style'
 
 type BranchTone = 'current' | 'dirty' | 'conflict' | 'stale'
 
@@ -381,20 +382,6 @@ const LANE_STATUS_DOT: Record<KeeperPresenceStatus, { color: string; label: stri
   idle: { color: 'var(--color-fg-muted)', label: 'IDLE' },
 }
 
-const LANE_CONTEXT_BADGE_STYLE = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  height: '17px',
-  padding: '0 5px',
-  border: '1px solid var(--color-border-muted)',
-  borderRadius: 'var(--r-1)',
-  background: 'var(--color-bg-subtle)',
-  color: 'var(--color-fg-muted)',
-  fontFamily: 'var(--font-mono)',
-  fontSize: 'var(--fs-9)',
-  whiteSpace: 'nowrap',
-} as const
-
 function LaneRow(
   lane: IdeWorktreeLane,
   presence: KeeperPresenceSnapshot | null,
@@ -450,7 +437,7 @@ function LaneRow(
             data-context-route-count=${routeLinks.length}
             title=${`Linked context: ${routeLabels}`}
             aria-label=${`${lane.label} lane has ${routeLinks.length} linked context routes: ${routeLabels}`}
-            style=${LANE_CONTEXT_BADGE_STYLE}
+            style=${IDE_CONTEXT_BADGE_STYLE}
           >
             CTX ${routeLinks.length}
           </span>

--- a/dashboard/src/components/ide/ide-persistence-panel.ts
+++ b/dashboard/src/components/ide/ide-persistence-panel.ts
@@ -20,6 +20,7 @@ import {
 } from './ide-context-lens'
 import { useSignalValue } from './use-signal-value'
 import { DEFAULT_PANEL_REFRESH_MS } from '../../lib/auto-refresh'
+import { IDE_CONTEXT_BADGE_STYLE } from './context-badge-style'
 
 type LifecycleState = 'created' | 'active' | 'idle' | 'terminated'
 
@@ -471,20 +472,6 @@ function persistenceRouteLinks(
   })
 }
 
-const PERSISTENCE_CONTEXT_BADGE_STYLE = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  height: '17px',
-  padding: '0 5px',
-  border: '1px solid var(--color-border-muted)',
-  borderRadius: 'var(--r-1)',
-  background: 'var(--color-bg-subtle)',
-  color: 'var(--color-fg-muted)',
-  fontFamily: 'var(--font-mono)',
-  fontSize: 'var(--fs-9)',
-  whiteSpace: 'nowrap',
-} as const
-
 function PersistenceRouteLinks({
   links,
 }: {
@@ -499,7 +486,7 @@ function PersistenceRouteLinks({
         data-context-route-count=${links.length}
         title=${`Linked context: ${routeLabels}`}
         aria-label=${`Persistence map has ${links.length} linked context routes: ${routeLabels}`}
-        style=${PERSISTENCE_CONTEXT_BADGE_STYLE}
+        style=${IDE_CONTEXT_BADGE_STYLE}
       >
         CTX ${links.length}
       </span>


### PR DESCRIPTION
## 요약

3 ide 컴포넌트 (`execute-output-drawer`, `ide-persistence-panel`, `ide-branch-context-panel`) 가 **byte-for-byte 동일한 12-property inline style** 을 각자 *다른 prefix* 로 file-local 정의:

| 파일 | 정의 이름 | property 수 |
|---|---|---|
| `execute-output-drawer.ts:196` | `EXECUTE_OUTPUT_CONTEXT_BADGE_STYLE` | 12 |
| `ide-persistence-panel.ts:474` | `PERSISTENCE_CONTEXT_BADGE_STYLE` | 12 |
| `ide-branch-context-panel.ts:384` | `LANE_CONTEXT_BADGE_STYLE` | 12 |

세 정의는 *완전히 같은 17px-high mono-font context badge* — `display:inline-flex / alignItems:center / height:17px / padding:0 5px / border:1px solid var(--color-border-muted) / borderRadius:var(--r-1) / background:var(--color-bg-subtle) / color:var(--color-fg-muted) / fontFamily:var(--font-mono) / fontSize:var(--fs-9) / whiteSpace:nowrap`.

각자 prefix (`EXECUTE_OUTPUT_`, `PERSISTENCE_`, `LANE_`) 가 *내부 const* 의 느낌만 만들 뿐 실제로는 같은 시각 contract. 디자인 토큰 1개 (예: `--color-border-muted`) rename 시 3 파일 silent drift 위험.

## 변경

- **신설** `dashboard/src/components/ide/context-badge-style.ts`: `IDE_CONTEXT_BADGE_STYLE as const` export + JSDoc (overlay-keeper-trace 의 다른 variant 가 *왜* scope 밖인지 명시: minWidth/lineHeight 추가 + display/alignItems 제외 = 시각적으로 다른 style).
- **3 파일**: file-local const 삭제 + `./context-badge-style` import + 호출 사이트 1 rename per file (each: 1 정의 + 1 use).
- **3 ide 외 사이트**: `overlay-keeper-trace.CONTEXT_BADGE_STYLE` (minWidth+lineHeight extension) 와 `ide-presence-strip` / `ide-conversation-rail` (`r-0` + `border-default` 다른 base 토큰) — *시각적으로 다른* style 이라 scope 밖.

호출 사이트 직접 변경 없음 (style object 가 reference 로 그대로 사용됨).

## 검증

- `pnpm typecheck` PASS (silent)
- `pnpm exec vitest run src/components/ide/{execute-output-drawer,ide-persistence-panel,ide-branch-context-panel,context-badge-style}`: 25/25 (5 test files)
- `pnpm exec eslint src/components/ide/{context-badge-style,execute-output-drawer,ide-persistence-panel,ide-branch-context-panel}.ts`: 0 errors

표면 동작 회귀 없음 — 12 properties 동일, reference로 그대로 적용.

## SSOT scope 결정 배경

작업 중 `_CONTEXT_BADGE_STYLE` 6 사이트 분포 확인:
- 그룹 A (`r-0` + border-default, no height): `ide-presence-strip` (bg-elevated) + `ide-conversation-rail` (bg-surface) — *background 다름*, 약한 위반, scope 밖
- 그룹 B (`r-1` + border-muted, height 17px): execute-output-drawer + ide-persistence-panel + ide-branch-context-panel — **byte-for-byte 100% 동일, scope IN**
- 그룹 C (minWidth + lineHeight): overlay-keeper-trace — base + extension 후보지만 *display/alignItems 다름* → 별도 결정 보류

오직 그룹 B 만 SSOT 통합. 향후 디자인이 *4번째 동일 badge* 가 필요하면 `IDE_CONTEXT_BADGE_STYLE` 재사용, *다른 variant* 면 인라인 선언 (JSDoc 의 안내 패턴).

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#24, ide context badge style SSOT)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] 3 panel (execute-output / persistence / branch-context) context badge 시각적 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)
