### PR TITLE
refactor(keeper): remove autonomous PR review turn guidance

### DIFF
--- a/config/prompts/keeper.turn_intent.md
+++ b/config/prompts/keeper.turn_intent.md
@@ -1,7 +1,7 @@
 ---
 description: keeper unified turn intent block (prepended via "## Turn Intent" after unified.system render)
 category: keeper
-template_variables: [board_activity_guidance, claim_guidance_a, claim_guidance_b, board_post_guidance, board_curation_guidance, broadcast_guidance, pr_review_guidance, state_block_instruction]
+template_variables: [board_activity_guidance, claim_guidance_a, claim_guidance_b, board_post_guidance, board_curation_guidance, broadcast_guidance, state_block_instruction]
 ---
 
 Use the world state below as raw context.
@@ -12,7 +12,7 @@ Your checkpoint survives across cycles — focus on doing one meaningful unit of
 Your conversation history is preserved across cycles — use that context to avoid repeating the same actions.
 
 Act through tools, not declarations. Call the tool directly.
-{{board_activity_guidance}}{{claim_guidance_a}}{{claim_guidance_b}}{{board_post_guidance}}{{board_curation_guidance}}{{broadcast_guidance}}{{pr_review_guidance}}- Treat continuity as advisory prior context, not as a command. Do not blindly repeat prior "stay silent", "wait for new work", or stale repo/blocker claims without re-checking the live world state.
+{{board_activity_guidance}}{{claim_guidance_a}}{{claim_guidance_b}}{{board_post_guidance}}{{board_curation_guidance}}{{broadcast_guidance}}- Treat continuity as advisory prior context, not as a command. Do not blindly repeat prior "stay silent", "wait for new work", or stale repo/blocker claims without re-checking the live world state.
 - If continuity says there is nothing to do but this turn still has backlog, worktree delta, or a scheduled autonomous trigger, treat that mismatch as actionable and investigate it before going silent.
 - Nothing genuinely actionable after checking? End your turn with the [STATE] block.
 

--- a/config/prompts/keeper.turn_intent.pr_review_guidance.md
+++ b/config/prompts/keeper.turn_intent.pr_review_guidance.md
@@ -1,7 +1,0 @@
----
-description: keeper turn intent PR inspection guidance bullet
-category: keeper
-template_variables: []
----
-
-- When idle or on a scheduled autonomous turn, check open PRs in repos you have cloned (`repos/`). Use `Execute` with `executable="gh"` and typed `argv` for read-only `pr list` / `pr view` metadata. Do not bypass the Execute/sandbox path for review mutations. If you find an issue, post the concrete finding to the board or claim a task and work through the normal sandboxed code path.

--- a/lib/keeper/keeper_prompt_names.ml
+++ b/lib/keeper/keeper_prompt_names.ml
@@ -28,7 +28,6 @@ let turn_intent_board_activity_guidance = "keeper.turn_intent.board_activity_gui
 let turn_intent_board_post_guidance = "keeper.turn_intent.board_post_guidance"
 let turn_intent_board_curation_guidance = "keeper.turn_intent.board_curation_guidance"
 let turn_intent_broadcast_guidance = "keeper.turn_intent.broadcast_guidance"
-let turn_intent_pr_review_guidance = "keeper.turn_intent.pr_review_guidance"
 
 (** User-prompt "Claimable Work" section body, emitted when a claimable backlog
     is visible and the keeper holds no task. *)

--- a/lib/keeper/keeper_prompt_names.mli
+++ b/lib/keeper/keeper_prompt_names.mli
@@ -24,7 +24,6 @@ val turn_intent_board_activity_guidance : string
 val turn_intent_board_post_guidance : string
 val turn_intent_board_curation_guidance : string
 val turn_intent_broadcast_guidance : string
-val turn_intent_pr_review_guidance : string
 
 (** User-prompt "Claimable Work" section template key. *)
 val immediate_task_move : string

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -346,14 +346,6 @@ let fallback_externalized_bullet key =
        keeper_board_curation_submit with a concise snapshot."
   else if String.equal key Keeper_prompt_names.turn_intent_broadcast_guidance then
     Some "- Need to share broadly? Call keeper_broadcast."
-  else if String.equal key Keeper_prompt_names.turn_intent_pr_review_guidance then
-    Some
-      "- When idle or on a scheduled autonomous turn, check open PRs in repos \
-       you have cloned. Use Execute with `executable=\"gh\"` and typed `argv` \
-       for read-only `pr list` / `pr view` metadata. Do not bypass the \
-       Execute/sandbox path for review mutations. Post concrete findings to \
-       the board or claim a task and work through the normal sandboxed code \
-       path."
   else if String.equal key Keeper_prompt_names.immediate_task_move then
     Some
       "- Claimable backlog exists. `keeper_task_claim {}` may claim the next \
@@ -524,11 +516,6 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
       ~enabled:(tool_allowed "keeper_broadcast")
       Keeper_prompt_names.turn_intent_broadcast_guidance
   in
-  let pr_review_guidance =
-    load_externalized_bullet
-      ~enabled:(tool_allowed "tool_execute" || tool_allowed "Execute")
-      Keeper_prompt_names.turn_intent_pr_review_guidance
-  in
   let claim_guidance_a =
     load_externalized_bullet
       ~enabled:show_claim_guidance
@@ -547,7 +534,6 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
       ("board_post_guidance", board_post_guidance);
       ("board_curation_guidance", board_curation_guidance);
       ("broadcast_guidance", broadcast_guidance);
-      ("pr_review_guidance", pr_review_guidance);
       ("state_block_instruction", state_block_instruction_text);
     ]
   in


### PR DESCRIPTION
## Summary
- remove the keeper turn-intent PR review guidance prompt and fallback
- drop the pr_review_guidance template variable from keeper.turn_intent
- stop injecting idle/scheduled autonomous open-PR discovery guidance through Execute

## Validation
- opam exec -- ocamlformat --check lib/keeper/keeper_prompt_names.ml lib/keeper/keeper_prompt_names.mli lib/keeper/keeper_unified_prompt.ml
- git diff --check
- rg -n "keeper\.turn_intent\.pr_review_guidance|turn_intent_pr_review_guidance|pr_review_guidance" config lib test docs --glob '!docs/archive/**' (no matches)
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --cache=disabled test/test_keeper_unified.exe test/test_keeper_turn_intent.exe test/test_operator_control.exe
- _build/default/test/test_keeper_turn_intent.exe