### PR TITLE
refactor(dashboard/ide): extract IDE_INLINE_BADGE_BASE for inline context chips

### DIFF
--- a/dashboard/src/components/ide/context-badge-style.ts
+++ b/dashboard/src/components/ide/context-badge-style.ts
@@ -25,3 +25,24 @@ export const IDE_CONTEXT_BADGE_STYLE = {
   fontSize: 'var(--fs-9)',
   whiteSpace: 'nowrap',
 } as const
+
+/**
+ * Base style for *inline* IDE context badges that sit inside flowing text
+ * (the presence strip's per-keeper chip, the conversation rail's context
+ * label). Same mono-font visual treatment as the blocky badge above, but
+ * without explicit display/alignItems/height — these chips render at the
+ * surrounding line height.
+ *
+ * Callers spread this base and supply their own `background` token because
+ * the two known sites pick different surfaces (`bg-elevated` for toolbars,
+ * `bg-surface` for the rail). All other 6 properties stay locked here so
+ * a token rename (e.g. `--color-border-default`) updates both sites.
+ */
+export const IDE_INLINE_BADGE_BASE = {
+  fontSize: 'var(--fs-9)',
+  padding: '0 3px',
+  border: '1px solid var(--color-border-default)',
+  borderRadius: 'var(--r-0)',
+  color: 'var(--color-fg-muted)',
+  fontFamily: 'var(--font-mono)',
+} as const

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -37,6 +37,7 @@ import {
   routeRefsFromText,
   type IdeContextRouteLink,
 } from './ide-context-lens'
+import { IDE_INLINE_BADGE_BASE } from './context-badge-style'
 
 function postAuthorId(post: BoardPost): string {
   return post.author_identity?.id ?? post.author ?? '(unknown author)'
@@ -58,13 +59,8 @@ const KIND_TOKEN: Record<ThreadKind, string> = {
   suggest: 'var(--color-status-warn)',
 }
 const CONVERSATION_CONTEXT_BADGE_STYLE = {
-  fontSize: 'var(--fs-9)',
-  padding: '0 3px',
-  border: '1px solid var(--color-border-default)',
-  borderRadius: 'var(--r-0)',
-  color: 'var(--color-fg-muted)',
+  ...IDE_INLINE_BADGE_BASE,
   background: 'var(--color-bg-surface)',
-  fontFamily: 'var(--font-mono)',
 }
 
 const EMPTY_POSTS: ReadonlyArray<BoardPost> = []

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -13,6 +13,7 @@ import {
 } from './keeper-presence-store'
 import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
 import { focusIdeContextAnchor, type IdeContextFocus } from './ide-state'
+import { IDE_INLINE_BADGE_BASE } from './context-badge-style'
 import { routeLinksForContext } from './ide-context-lens'
 import { parseAgentStatus } from '../../lib/agent-status'
 
@@ -47,13 +48,8 @@ interface PresenceContextSummary {
 }
 
 const CONTEXT_BADGE_STYLE = {
-  fontSize: 'var(--fs-9)',
-  padding: '0 3px',
-  border: '1px solid var(--color-border-default)',
-  borderRadius: 'var(--r-0)',
-  color: 'var(--color-fg-muted)',
+  ...IDE_INLINE_BADGE_BASE,
   background: 'var(--color-bg-elevated)',
-  fontFamily: 'var(--font-mono)',
 }
 
 function mapAgentStatus(status: string): KeeperPresenceEntry['status'] {


### PR DESCRIPTION
## 요약

iter#24 (PR #18964) follow-up. iter#24 의 그룹 A 처리 — `_CONTEXT_BADGE_STYLE` 6 사이트 sweep 에서 *그룹 B 와 다른* visual variant 발견했던 2 사이트:

| 파일 | 정의 이름 | properties | 차이 |
|---|---|---|---|
| `ide-presence-strip.ts:49` | `CONTEXT_BADGE_STYLE` | 7 | `background: var(--color-bg-elevated)` |
| `ide-conversation-rail.ts:60` | `CONVERSATION_CONTEXT_BADGE_STYLE` | 7 | `background: var(--color-bg-surface)` |

**6/7 properties byte-for-byte 동일** (`fontSize / padding / border / borderRadius / color / fontFamily`), 1 만 다름 (`background`).

iter#24 의 그룹 B (`IDE_CONTEXT_BADGE_STYLE`, 12 properties, 17px 높이 blocky badge) 와는 *시각적으로 다른* style — *inline* 텍스트 chip (no display/alignItems/height, 더 작은 padding `0 3px`, `--r-0`, `--color-border-default`).

## 변경

- **추가** `dashboard/src/components/ide/context-badge-style.ts`: `IDE_INLINE_BADGE_BASE as const` — 6 공통 properties + JSDoc (왜 background 만 callsite 가 supply 하는지 + 그룹 B 와 어떻게 다른지 설명)
- **2 파일**: file-local 정의를 `{ ...IDE_INLINE_BADGE_BASE, background: <token> }` spread 패턴으로 교체 (호출 사이트 무변경, 객체 reference 그대로)

iter#24 의 *grouped sweep* 패턴 — 같은 prefix 의 6 사이트 분포를 *시각 시그니처* 로 3 그룹화한 결과의 그룹 A 처리. 그룹 C (overlay-keeper-trace base+extension) 는 별도 iter.

## 검증

- `pnpm typecheck` PASS (silent)
- `pnpm exec vitest run src/components/ide/{context-badge-style,ide-presence-strip,ide-conversation-rail}`: 31/31 (3 test files)
- `pnpm exec eslint src/components/ide/{context-badge-style,ide-presence-strip,ide-conversation-rail}.ts`: 0 errors

표면 동작 회귀 없음 — 두 객체 모두 7 properties 동일 (background 는 각자 그대로, 나머지 6 은 base 에서 동일하게 전개).

## SSOT 선택 배경

3 후보:
1. **별도 rename** (iter#18 R 처럼 정책-encode 이름 2개) — 6 properties 가 *byte-for-byte 동일* 이라 *불필요한 verbose*
2. **base + spread** (이 PR) — base 가 6 properties lock, callsite 가 1 properties 결정
3. **factory function** (`makeInlineBadgeStyle(background)`) — type system 측면 spread 가 더 inferrable

base + spread 채택. callsite 가 *background 가 variant 임* 을 명시적으로 보이며, type checker 가 추가 property 도 자유롭게 받음.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#25, ide inline badge base SSOT)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] presence-strip + conversation-rail context chip 시각적 동일 (background 만 그대로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
