### PR TITLE
fix(tool-task): remove is_agent_joined hard gate from masc_claim/masc_claim_next (#18965)

### DIFF
--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -371,9 +371,13 @@ let handle_batch_add_tasks ~tool_name ~start_time ctx args =
       ~created_by:ctx.agent_name ctx.config tasks)
 
 let handle_claim ?agent_tool_names ~tool_name ~start_time ctx args =
-  if not (try Coord.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Stdlib.Not_found -> false) then
-    result_to_response ~tool_name ~start_time (Error (Masc_domain.Agent (Masc_domain.Agent_error.NotJoined ctx.agent_name)))
-  else if not ((=) (args |> member "agent_role") `Null) then
+  (* #18965 — removed [is_agent_joined] hard gate.  Keeper-internal tag
+     dispatch path bypasses MCP entry auto-join, so this gate produced
+     false-negative rejects for every keeper turn (fleet evidence:
+     ~/.masc/agents/ empty while keepers run normally; only
+     masc_claim/masc_claim_next failed).  Coord.claim_task_r works on
+     agent_name alone; gate added no real authorization. *)
+  if not ((=) (args |> member "agent_role") `Null) then
     Tool_result.error
       ~failure_class:(Some Tool_result.Workflow_rejection)
       ~tool_name ~start_time
@@ -465,12 +469,10 @@ let format_no_eligible
         diagnostics
 
 let handle_claim_next ?agent_tool_names ~tool_name ~start_time ctx _args =
-  if not (try Coord.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Stdlib.Not_found -> false) then
-    Tool_result.error
-      ~failure_class:(Some Tool_result.Workflow_rejection)
-      ~tool_name ~start_time
-      (Printf.sprintf "Agent '%s' is not a member of this room" ctx.agent_name)
-  else
+  (* #18965 — removed [is_agent_joined] hard gate (same rationale as
+     [handle_claim] above).  Coord.claim_next_r operates on
+     [~agent_name] alone; backlog read does not require an entry under
+     agents_dir. *)
   let agent_tool_names =
     match agent_tool_names with
     | Some _ -> agent_tool_names


### PR DESCRIPTION
## 요약

`Closes #18965`.

`tool_task_handlers.ml` 의 `handle_claim` / `handle_claim_next` 가 매번 `Coord.is_agent_joined` 를 hard gate 로 사용. Keeper-internal tag dispatch path 가 MCP entry auto-join 을 우회하므로, *fleet 운영 상태* 에서 `~/.masc/agents/` 가 비어있는 경우 `masc_claim` / `masc_claim_next` 만 영구 fail 했다.

### Fleet evidence

- `~/.masc/agents/` 는 5/26 02:33 디렉토리 생성 후 **0 파일**
- 동일 1분 23초 window 에서 `keeper_board_post` (sangsu) / `Execute` (executor) 정상 동작, `masc_claim_next` (analyst, albini) 만 `Agent 'X' is not a member of this room` 실패
- `Coord.claim_next_r` / `Coord.claim_task_r` 는 `~agent_name` 만 받아 backlog 파일을 읽음 — `agents/<name>.json` 미참조

### 변경 내용

`lib/tool_task_handlers.ml`:

- `handle_claim:373-376` — `is_agent_joined` reject 분기 제거
- `handle_claim_next:471-476` — 동일 reject 분기 제거
- 두 위치에 issue 번호 + rationale 주석 추가

총 11 insert / 9 delete (주석 포함). 함수 시그니처 변경 0.

### Caller audit

`Coord.is_agent_joined` 14 callsite 분류 (제거 후):

- Hard gate: **0** (본 PR 로 제거)
- MCP entry auto-join (`mcp_server_eio_execute.ml:300-340`): 유지 — 외부 client 의 `agents/<name>.json` 자동 생성 path
- Soft default (`tool_coord.ml:329, 646`): 유지 — log warn + false 기본값
- Identity / board classification: 유지 — non-reject

### Test impact

- `rg -n 'is not a member of this room' test/` → 0 hit
- `rg -n 'NotJoined' test/` → 1 hit (`test_masc_error_is_retryable.ml:43`) — error type retryability 검사만, gate 동작과 무관

### Workaround Signature Gate

본 PR 은 RFC-0088 §1 시그니처 3종 + 체크리스트 7항목 비해당:

- ❌ Counter-as-Fix — 카운터/텔레메트리 추가 없음 (삭제만)
- ❌ String/Substring 분류기 — 추가 없음 (삭제만)
- ❌ N-of-M 패치 — 본 PR 이 *2 callsite 모두* 동시 처리
- ❌ Repair/Sanitize — symptom 억제 아닌 root removal

### Build

`dune build --root .` PASS (worktree local).

### Related

- Issue #18965 — root analysis with fleet evidence
- Iter 32 live conversation log 진단 (14:48~15:11 KST window)
- 사용자 의견 (live): "room member 라는개념은 지워져야하" — 본 evidence 가 직접 지지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
