### PR TITLE
fix(execute-schema): enforce executable XOR pipeline via JSON Schema not-constraint + self-correcting error message (#18472)

### DIFF
--- a/lib/keeper/agent_tool_execute_typed_input.ml
+++ b/lib/keeper/agent_tool_execute_typed_input.ml
@@ -199,7 +199,12 @@ let of_json (json : Yojson.Safe.t) =
   let* env = optional_env ~path:"$" fields in
   match executable_present, pipeline_value with
   | true, Some _ ->
-    Error "$.executable and $.pipeline are mutually exclusive typed Execute fields"
+    Error
+      "$.executable and $.pipeline are mutually exclusive typed Execute \
+       fields. Pick exactly one form and drop the other: either {executable, \
+       argv} for a single process OR {pipeline} for a multi-stage Shell IR \
+       pipeline. To pipe through a process, put it in pipeline; do not \
+       combine."
   | true, None ->
     let* executable = required_string ~path:"$" fields "executable" in
     let* argv = optional_string_list ~path:"$" fields "argv" in

--- a/lib/tool_shard_types_schemas_execute.ml
+++ b/lib/tool_shard_types_schemas_execute.ml
@@ -151,17 +151,24 @@ let tool_execute_schema : Masc_domain.tool_schema =
           , `List
               [ `Assoc
                   [ "required", `List [ `String "executable" ]
+                  ; ( "not"
+                    , `Assoc [ "required", `List [ `String "pipeline" ] ] )
                   ; ( "description"
                     , `String
-                        "Single-process form: provide executable (and optional \
-                         argv). Must not include pipeline." )
+                        "Single-process form: include 'executable' (and \
+                         optional 'argv').  DO NOT also include 'pipeline' \
+                         in the same call." )
                   ]
               ; `Assoc
                   [ "required", `List [ `String "pipeline" ]
+                  ; ( "not"
+                    , `Assoc
+                        [ "required", `List [ `String "executable" ] ] )
                   ; ( "description"
                     , `String
-                        "Pipeline form: provide pipeline array of exec stages. \
-                         Must not include executable." )
+                        "Pipeline form: include 'pipeline' array of exec \
+                         stages.  DO NOT also include 'executable' in the \
+                         same call." )
                   ]
               ] )
         ]


### PR DESCRIPTION
## 요약

`tool_execute` schema 가 `executable XOR pipeline` sum type 임에도 LLM 이 *둘 다 채워* `$.executable and $.pipeline are mutually exclusive` 로 reject 되는 fleet 패턴.

`#18472` (correction_pipeline) live evidence:
- 14:48:26 `executor` `Execute`: correction_pipeline fixed 4 fields → 같은 turn mutually-exclusive reject
- 14:48:28 `albini` `masc_goal_upsert`: priority=0 fix → range reject (별개 root)
- board task-550 `garnet`/`sangsu` 대화 — `Execute` schema bug 가 keeper 자기진단을 마비시키는 *meta-blocker*

## Root analysis

Schema 가 이미 `oneOf` 보유 (`lib/tool_shard_types_schemas_execute.ml:150-166`):

```json
"oneOf": [
  {"required": ["executable"], "description": "...Must not include pipeline."},
  {"required": ["pipeline"],   "description": "...Must not include executable."}
]
```

그러나 각 clause 가 *required* 만 명시, `not` constraint 부재. LLM 이 JSON Schema `oneOf` 의 *exclusivity semantics* 를 학습 못 함 → schema 가 *product 외양* 으로 보임. Description text 만으로 negation 신호 부족.

## Changes

### 1. `lib/tool_shard_types_schemas_execute.ml` — `not` constraint 추가 (+ 명확한 description)

```ocaml
{ "required": [ "executable" ]
; "not":      { "required": [ "pipeline" ] }
; "description": "...DO NOT also include 'pipeline' in the same call."
}
```

JSON Schema spec 상 `not + required` 가 *해당 필드가 있으면 fail* 을 강제. LLM 이 oneOf 만 학습한 경우보다 *명시적 negation* 으로 회피 학습 강화.

### 2. `lib/keeper/agent_tool_execute_typed_input.ml:200-208` — error message self-correcting hint

기존: `"$.executable and $.pipeline are mutually exclusive typed Execute fields"` (one-liner, no fix path)

새: error 가 *어떻게 고치는지* 직접 안내:

```
Pick exactly one form and drop the other: either {executable, argv} for a
single process OR {pipeline} for a multi-stage Shell IR pipeline. To pipe
through a process, put it in pipeline; do not combine.
```

→ LLM 다음 turn 에 *어떤 형태로 재시도* 해야 하는지 명시. Trial-and-error 회피.

## Workaround Signature Gate

본 PR 은 시그니처 3종 + 체크리스트 7항목 모두 비해당:

- ❌ Counter-as-Fix — 카운터 추가 없음
- ❌ String/substring 분류기 — schema constraint *typed* 추가 (substring match 아님)
- ❌ N-of-M 패치 — 단일 사이트 (schema 1 곳 + validator 1 곳, 1 PR 동시 처리)
- ❌ Repair/Sanitize — symptom 억제 아님, root 변경 (sum type negation 명시)

## Test impact

기존 test `test/test_agent_tool_execute_typed_input.ml:483` 가 `contains_substring_ci msg "mutually exclusive"` 로 검사 — 새 error message 에도 "mutually exclusive" 포함 → PASS 유지.

## Background — task-550 meta-blocker

board `task-550` 에서 garnet/sangsu 가 *distributed lock acquisition* + *Eio timeout* 진단 중이었으나:

> sangsu: "내가 쓰는 도구 자체가 락 비슷한 병목에 걸려 있다... distributed lock 문제를 디버그해야 하는데, 내가 쓰는 도구가..."

`Execute` schema bug 가 keeper 의 *코드 읽기 도구* 를 마비. 본 PR 이 *meta-blocker 해소* — 다른 P0/P1 진단의 *bottleneck multiplier* 역할.

## Related

- Issue #18472 — correction_pipeline limits (P1#5)
- Iter 31 fresh evidence comment ([#18472 issuecomment-4551778994](https://github.com/jeong-sik/masc-mcp/issues/18472#issuecomment-4551778994))
- Board task-550 — distributed lock + Eio timeout (별도 RFC 후보)
- 사용자 직접 지시 (live, iter 34): "근본 수정으로 구현 + 버그 수정"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
