### PR TITLE
refactor(dashboard/lib): extract theme storage SSOT to lib/theme.ts

### DIFF
--- a/dashboard/src/components/theme-switch.ts
+++ b/dashboard/src/components/theme-switch.ts
@@ -13,10 +13,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { ringFocusClasses } from './common/ring'
-
-type ThemeId = 'paper' | null
-const THEME_SEARCH_PARAM = 'theme'
-const THEME_STORAGE_KEYS = ['dashboardTheme', 'masc-theme-v2'] as const
+import { THEME_STORAGE_KEYS, THEME_SEARCH_PARAM, type ThemeId } from '../lib/theme'
 
 function readDomTheme(): ThemeId {
   const attr = document.documentElement.dataset.theme

--- a/dashboard/src/lib/theme.ts
+++ b/dashboard/src/lib/theme.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared theme constants used by both the bootstrap entry (main.ts) and
+ * the runtime toggle (components/theme-switch.ts).
+ *
+ * Two storage keys are written/read in tandem so the same persisted
+ * choice survives across the `dashboardTheme` → `masc-theme-v2` rename
+ * (#8177). Drift between writer and reader sites used to mean a user's
+ * paper theme silently disappeared after a refresh — both sites must
+ * read from this single source.
+ *
+ * `applyTheme` / `normalizeTheme` stay file-local on each side because
+ * their signatures diverge: main.ts only persists, theme-switch.ts also
+ * mirrors a signal and the URL query string.
+ */
+export const THEME_STORAGE_KEYS = ['dashboardTheme', 'masc-theme-v2'] as const
+
+export const THEME_SEARCH_PARAM = 'theme'
+
+export type ThemeId = 'paper' | null

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -42,11 +42,7 @@ import { App } from './app'
 import { performanceMonitor } from './lib/performance-monitor'
 import { startWebVitalsCapture } from './utils/performance-metrics'
 import { startNavTelemetry } from './lib/nav-telemetry'
-
-const THEME_STORAGE_KEYS = ['dashboardTheme', 'masc-theme-v2'] as const
-const THEME_SEARCH_PARAM = 'theme'
-
-type ThemeId = 'paper' | null
+import { THEME_STORAGE_KEYS, THEME_SEARCH_PARAM, type ThemeId } from './lib/theme'
 
 function normalizeTheme(raw: string | null): ThemeId {
   if (raw === 'paper' || raw === 'light') {


### PR DESCRIPTION
## 요약

`THEME_STORAGE_KEYS`, `THEME_SEARCH_PARAM`, `type ThemeId` 3 항목이 *cross-file byte-for-byte 동일* 하게 두 사이트에 분산 정의:

| 파일 | 정의 |
|---|---|
| `dashboard/src/main.ts:46-49` | `THEME_STORAGE_KEYS = ['dashboardTheme', 'masc-theme-v2']` + `THEME_SEARCH_PARAM = 'theme'` + `type ThemeId = 'paper' \| null` |
| `dashboard/src/components/theme-switch.ts:17-19` | 동일 3 항목 (정의 순서만 다름) |

**사용자 가시성 있는 SSOT 위반**: 한 사이트가 storage key 를 *새 값* 으로 변경하면 다른 사이트가 *옛 key* 로 읽어 사용자의 paper 테마 선택이 새로고침 후 silent 손실. iter#22-25 의 polling cadence / inline style SSOT 보다 *직접적인 사용자 영향* 위반.

## 변경

- **신설** `dashboard/src/lib/theme.ts`: `THEME_STORAGE_KEYS`, `THEME_SEARCH_PARAM`, `type ThemeId` export + JSDoc (왜 함수는 file-local 유지하는지 명시)
- **2 파일** (main.ts + components/theme-switch.ts): 자체 정의 삭제 + `lib/theme` import 추가

## SSOT 위치 선택: `lib/theme.ts`

| 옵션 | 채택 여부 | 이유 |
|---|---|---|
| `lib/theme.ts` | ✅ | iter#21/22 `lib/sparkline-config.ts`, `lib/auto-refresh.ts` 패턴 — framework-agnostic constants. main → components → lib 의 *하위* 위치 → layering 위반 없이 양쪽 import 가능 |
| `components/theme-switch.ts` owner | ❌ | main.ts 가 components 를 import 하면 *entry → app → components* layering 위반 |
| `theme.ts` (top-level) | ❌ | lib/ 의 다른 framework-agnostic 상수와 패턴 일관성 |

## 함수 통합은 scope 밖

`applyTheme`, `normalizeTheme` 도 양쪽에 있지만 *시그니처/기능 분기*:
- `main.ts.applyTheme`: dataset.theme + persist (entry-time bootstrap, no signal)
- `theme-switch.ts.applyTheme`: dataset.theme + persist + URL searchParam sync + signal.value 업데이트 (runtime toggle)

iter#19 의 `errorMessage` 4-way 동음이의어 패턴 — 시멘틱 다른 함수 강제 통합 시 silent 회귀. *데이터 (storage keys)* 만 SSOT, *행동 (apply 로직)* 은 file-local 유지.

## 검증

- `pnpm typecheck` PASS (silent)
- `pnpm exec vitest run src/main src/components/theme-switch`: 5/5 (1 test file)
- `pnpm exec eslint src/lib/theme.ts src/main.ts src/components/theme-switch.ts`: 0 errors (2 warnings = pre-existing config noise on lib/main paths)

표면 동작 회귀 없음 — 같은 key 배열 reference, 같은 string literal, 같은 type alias.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#26, theme storage SSOT — 사용자 가시성 위반 첫 사례)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Paper 테마 선택 후 새로고침 → 유지 확인 (main.ts 의 bootstrap 이 components/theme-switch.ts 와 같은 key 로 읽음)
- [ ] `?theme=paper` URL 쿼리 → bootstrap 이 인식 + theme-switch UI 가 paper 상태 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)
