### PR TITLE
refactor(dashboard/ide): extract DEFAULT_LANGUAGE_ID SSOT to ide-language.ts

### DIFF
--- a/dashboard/src/components/ide/ide-data-coordinator.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.ts
@@ -19,8 +19,7 @@ import {
   createCodeDocumentStore,
   type CodeDocumentStore,
 } from './code-document-store'
-
-const DEFAULT_LANGUAGE_ID = 'text' as const
+import { DEFAULT_LANGUAGE_ID } from './ide-language'
 import {
   createKeeperLineOwnershipStore,
   type KeeperLineOwnershipStore,

--- a/dashboard/src/components/ide/ide-language.ts
+++ b/dashboard/src/components/ide/ide-language.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared LSP/IDE language constants.
+ *
+ * `DEFAULT_LANGUAGE_ID` was duplicated byte-for-byte in
+ * ide-lsp-client.ts (textDocument/didOpen fallback when path-based
+ * detection misses) and ide-data-coordinator.ts (initial value for
+ * the code document store + workspace-file response fallback).
+ * Both branches use the LSP "plain text" identifier `'text'`; a drift
+ * here would silently change the fallback language between the
+ * coordinator's optimistic open and the client's actual didOpen.
+ *
+ * Keep this module dependency-free so it can grow into the natural
+ * owner for LSP-related constants (file-extension → language id maps,
+ * encoding defaults) without forming cycles with the LSP client.
+ */
+export const DEFAULT_LANGUAGE_ID = 'text' as const

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -17,8 +17,7 @@ import { StateField, StateEffect, RangeSetBuilder, type Extension } from '@codem
 import { signal } from '@preact/signals'
 import { normalizeIdeContextFilePath } from './ide-state'
 import { DEFAULT_MASC_ORIGIN } from '../../config/constants'
-
-const DEFAULT_LANGUAGE_ID = 'text' as const
+import { DEFAULT_LANGUAGE_ID } from './ide-language'
 
 // ── Types ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## 요약

`DEFAULT_LANGUAGE_ID = 'text' as const` 가 두 IDE 모듈에 byte-for-byte 동일하게 분산 정의:

| 파일 | 사용 |
|---|---|
| `dashboard/src/components/ide/ide-lsp-client.ts:21` | LSP `textDocument/didOpen` fallback (path-based detection 실패 시) |
| `dashboard/src/components/ide/ide-data-coordinator.ts:23` | code document store 초기값 + workspace-file response fallback (3 호출 사이트) |

두 사이트 모두 LSP "plain text" 의미의 `'text'`. drift 시 *coordinator 의 optimistic open* 과 *LSP client 의 실제 didOpen* 이 *다른 fallback language id* 사용 — language detection miss path 에서 silent 분기 위험.

## 변경

- **신설** `dashboard/src/components/ide/ide-language.ts`: `DEFAULT_LANGUAGE_ID` export + JSDoc (양쪽 분기 의미 명시 + future LSP-related 상수 owner 의도 명시)
- **2 파일**: file-local 정의 삭제 + `./ide-language` import (호출 사이트 무변경, 동일 reference)

## SSOT 위치 선택

| 옵션 | 채택 |
|---|---|
| `ide-language.ts` 신설 | ✅ iter#21 `lib/sparkline-config.ts`, iter#26 `lib/theme.ts` 와 같은 *small focused constants module* 패턴. dependency-free 라 future LSP-related (file-extension → language id maps 등) 자연 확장 |
| `ide-lsp-client.ts` owner + data-coordinator 의존 추가 | ❌ data-coordinator → lsp-client 새 의존성 (논리적으론 OK 지만 module graph 추가 비용) |
| `ide-state.ts` 에 export 추가 | ❌ state 모듈에 *constants* 추가 = responsibility mismatch |

## 다른 cross-file duplicate const 의 scope 밖 결정

같은 sweep 에서 발견:
- `MENTION_LISTBOX_ID` x2 — *byte-diff* (`'composer-v2-mention-listbox'` vs `'quick-intervene-mention-listbox'`, DOM id 충돌 회피 의도). 분리 유지가 맞음
- `INPUT_BASE` x2 — *디자인 토큰 drift* (`--color-bg-elevated` vs `--input-bg`). byte-diff, *디자인 시스템 토큰 컨벤션 정리* RFC 영역, SSOT 통합으로 풀 수 없음
- `POLL_INTERVAL_MS` x3 — 3s/5s/10s *다른 정책*, 도메인별 결정

## 검증

- `pnpm typecheck` PASS (silent)
- `pnpm exec vitest run src/components/ide/{ide-lsp-client,ide-data-coordinator,ide-language}`: 10/10 (2 test files)
- `pnpm exec eslint src/components/ide/{ide-language,ide-lsp-client,ide-data-coordinator}.ts`: 0 errors

표면 동작 회귀 없음 — 같은 `'text' as const` reference, 4 호출 사이트 (LSP 1 + data-coordinator 3) 모두 import.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#27, ide language fallback SSOT)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] IDE 에서 *알 수 없는 확장자* 파일 열기 → LSP didOpen fallback 이 `'text'` 로 진행 (coordinator + LSP client 동기 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
