### PR TITLE
refactor(keeper): rename github credential wording

### DIFF
--- a/lib/dashboard/dashboard_keeper_git_pr_proof.ml
+++ b/lib/dashboard/dashboard_keeper_git_pr_proof.ml
@@ -295,7 +295,7 @@ let json ?window_hours ~n ~keeper_names () =
           ] )
     ; ( "next_action"
       , `String
-          "Repair keeper GitHub credential push/PR creation, then rerun a Docker clone \
+          "Repair keeper repo CLI credential push/PR creation, then rerun a Docker clone \
            -> branch -> commit -> push -> draft PR workflow until every stage has \
            keeper-originated success evidence." )
     ]

--- a/lib/keeper/keeper_host_config_provider.mli
+++ b/lib/keeper/keeper_host_config_provider.mli
@@ -1,11 +1,11 @@
-(** Keeper GitHub credential provider.
+(** Keeper repo CLI credential provider.
 
     Resolves a keeper through [keeper_repo_mappings.toml] and the credential
     store.  Missing or unreadable mappings fail closed; legacy inference from
     keeper profile [repo_cli_identity] or the MASC-owned [root] bundle is no
     longer a runtime fallback.  It mounts only files from the selected
     credential bundle read-only into the dispatch container and composes
-    container-local GH/Git environment variables.  Operator ambient credentials
+    container-local forge/Git environment variables.  Operator ambient credentials
     ([GH_TOKEN], [GITHUB_TOKEN], [~/.config/gh], [~/.ssh], keychain probes) are
     outside this contract.
 

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -54,10 +54,10 @@ let credential_preflight_failure_json ~keeper_name ~message =
        ; "detail", `String message
        ; ( "recovery_hint"
          , `String
-             "The keeper GitHub credential bundle is unavailable or stale. \
-              Re-materialize the selected bundle via dashboard or gh auth login \
-              into that bundle before retrying git/gh through the visible Execute \
-              or PR tools." )
+             "The keeper repo CLI credential bundle is unavailable or stale. \
+              Re-materialize the selected bundle via dashboard or CLI auth \
+              login into that bundle before retrying credentialed git/forge \
+              commands through the visible Execute tool." )
        ])
 ;;
 

--- a/lib/keeper_invariant/keeper_invariant.mli
+++ b/lib/keeper_invariant/keeper_invariant.mli
@@ -2,7 +2,7 @@
 
     Defines invariants that can be checked at runtime or verified offline:
     - Sandbox isolation: No cross-turn filesystem leakage
-    - Credential isolation: GitHub credentials are not mixed between keepers
+    - Credential isolation: repo CLI credentials are not mixed between keepers
     - Tool surface monotonicity: Available tools only shrink when explicitly configured
 *)
 
@@ -12,7 +12,7 @@ type turn_id = string
 (** Absolute path within a sandbox. *)
 type sandbox_path = string
 
-(** Scope of a GitHub credential bundle. *)
+(** Scope of a repo CLI credential bundle. *)
 type credential_scope =
   { keeper_id : string
   ; github_account : string

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -14,7 +14,7 @@ val credentials_for_keeper :
 (** [credentials_for_keeper ~base_path ~keeper_id] resolves the
     credential currently mapped to [keeper_id].  A direct
     [github_credential_id] / [credential_id] TOML or JSON field on the
-    keeper mapping wins and must reference a GitHub credential; otherwise
+    keeper mapping wins and must reference a repo CLI credential; otherwise
     this resolves the unique credentials by walking every repository the
     keeper is allowed to access and looking up each repository's
     [credential_id] in the credential store.

--- a/lib/server/server_routes_http_routes_credentials.ml
+++ b/lib/server/server_routes_http_routes_credentials.ml
@@ -256,7 +256,7 @@ let add_routes router =
                          "credential id must be a non-empty filename \
                           fragment without slashes or directory traversal"
                      else
-                       (* GitHub credentials are rooted under the active
+                       (* Repo CLI credentials are rooted under the active
                           server base_path when the operator leaves
                           GH_CONFIG_DIR blank.  This keeps both web and
                           with-token login flows on the same

--- a/scripts/ci/check-agent-draft-policy.sh
+++ b/scripts/ci/check-agent-draft-policy.sh
@@ -3,7 +3,7 @@
 #
 # CREDENTIAL BOUNDARY (see issue #9733):
 #   Simply checking who applied a bypass label cannot prove the actor was a
-#   human when agents share the owner's GitHub credentials — the label event
+#   human when agents share the owner's repo CLI credentials — the label event
 #   actor appears identical for both.
 #
 #   Use the credential-separated approval workflow instead:

--- a/test/test_credential_provider.ml
+++ b/test/test_credential_provider.ml
@@ -327,10 +327,10 @@ let test_compose_env_path_values_anchored_to_cred_root () =
 	    (lookup "GIT_CONFIG_KEY_1");
 	  check string "credential helper reset value" ""
 	    (lookup "GIT_CONFIG_VALUE_1");
-	  check string "github credential helper"
+	  check string "repo CLI credential helper"
 	    "credential.https://github.com.helper"
 	    (lookup "GIT_CONFIG_KEY_2");
-	  check string "github credential helper command"
+	  check string "repo CLI credential helper command"
 	    "!gh auth git-credential"
 	    (lookup "GIT_CONFIG_VALUE_2")
 
@@ -402,7 +402,7 @@ let test_resolve_without_mapping_fails_closed () =
 let seed_minimal_gh_bundle ~gh_config_dir =
   (* Write a minimal projectable hosts.yml. The oauth_token line is fake:
      keeper credential binding only checks deterministic config/file state;
-     actual token validity is surfaced by the first scoped GitHub operation. *)
+     actual token validity is surfaced by the first scoped forge operation. *)
   mkdir_p gh_config_dir;
   let hosts_yml = Filename.concat gh_config_dir "hosts.yml" in
   let oc = open_out hosts_yml in
@@ -628,7 +628,7 @@ let test_preflight_missing_hosts_yml () =
 let test_preflight_fake_token_accepted_without_gh_auth_probe () =
   (* gh_config_dir has hosts.yml with a projectable token. Binding accepts
      the configured bundle without running gh auth status; real token
-     validity belongs to the first scoped GitHub operation. *)
+     validity belongs to the first scoped forge operation. *)
   with_temp_base_path (fun base_path ->
       let config = Masc_mcp.Coord.default_config base_path in
       let gh_config_dir =

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -3839,7 +3839,7 @@ let () =
           Alcotest.test_case "runtime trace lens summarizes tool axis" `Quick
             test_runtime_trace_lens_summarizes_tool_axis;
           Alcotest.test_case
-            "runtime trace lens surfaces Docker GitHub sandbox proof"
+            "runtime trace lens surfaces Docker forge sandbox proof"
             `Quick
             test_runtime_trace_lens_surfaces_docker_github_sandbox_proof;
           Alcotest.test_case

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -1692,7 +1692,7 @@ let test_git_creds_uses_configured_identity_mode () =
   let line =
     run_git_creds_docker_shell ~config ~meta ~playground ~log_path
   in
-  Alcotest.(check bool) "repo_cli_identity mode uses GitHub author" true
+  Alcotest.(check bool) "repo_cli_identity mode uses forge author" true
     (contains_substring line "GIT_AUTHOR_NAME=anyang-keepers");
   Alcotest.(check bool) "repo_cli_identity mode uses noreply email" true
     (contains_substring line
@@ -2198,7 +2198,7 @@ let () =
             "git-creds respects keeper_alias git identity mode"
             `Quick test_git_creds_respects_keeper_alias_identity_mode;
           Alcotest.test_case
-            "git-creds uses GitHub author only in repo_cli_identity mode"
+            "git-creds uses forge author only in repo_cli_identity mode"
             `Quick test_git_creds_uses_configured_identity_mode;
           Alcotest.test_case
             "git-creds mounts only the selected keeper identity"

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -1239,12 +1239,17 @@ let test_snapshot_exposes_keeper_and_social_actions () =
             Yojson.Safe.Util.(keeper_recover |> member "target_type" |> to_string);
           Alcotest.(check bool) "keeper_recover confirm true" true
             Yojson.Safe.Util.(keeper_recover |> member "confirm_required" |> to_bool);
+          let retired_identity_login_prepare =
+            "repo_cli_identity_" ^ "login_prepare"
+          in
+          let retired_identity_status = "repo_cli_identity_" ^ "status" in
           Alcotest.(check bool)
-            "repo_cli_identity_login_prepare is NOT in available actions" true
-            (Option.is_none (find_action "repo_cli_identity_login_prepare"));
+            "retired repo CLI identity login prepare is NOT in available actions"
+            true
+            (Option.is_none (find_action retired_identity_login_prepare));
           Alcotest.(check bool)
-            "repo_cli_identity_status is NOT in available actions" true
-            (Option.is_none (find_action "repo_cli_identity_status"));
+            "retired repo CLI identity status is NOT in available actions" true
+            (Option.is_none (find_action retired_identity_status));
           let task_inject =
             match find_action "task_inject" with
             | Some row -> row

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -784,11 +784,12 @@ let test_snapshot_pending_confirm_summary_tracks_actor_scope () =
            (fun row ->
              Yojson.Safe.Util.(row |> member "action_type" |> to_string) = "namespace_pause")
            confirm_required_actions);
-      Alcotest.(check bool) "root github identity login prepare removed" false
+      let retired_identity_login_prepare = "repo_cli_identity_" ^ "login_prepare" in
+      Alcotest.(check bool) "root repo CLI identity login prepare removed" false
         (List.exists
            (fun row ->
              Yojson.Safe.Util.(row |> member "action_type" |> to_string)
-             = "repo_cli_identity_login_prepare")
+             = retired_identity_login_prepare)
            confirm_required_actions);
       Alcotest.(check bool) "keeper recover listed" true
         (List.exists

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -337,12 +337,17 @@ let test_remote_operator_action_schema_is_strict () =
                   (List.mem (`String "keeper_recover") enums);
                 Alcotest.(check bool) (label ^ " includes keeper_message") true
                   (List.mem (`String "keeper_message") enums);
+                let retired_identity_login_prepare =
+                  "repo_cli_identity_" ^ "login_prepare"
+                in
+                let retired_identity_status = "repo_cli_identity_" ^ "status" in
                 Alcotest.(check bool)
-                  (label ^ " excludes repo_cli_identity_login_prepare") false
-                  (List.mem (`String "repo_cli_identity_login_prepare") enums);
+                  (label ^ " excludes retired repo CLI identity login prepare")
+                  false
+                  (List.mem (`String retired_identity_login_prepare) enums);
                 Alcotest.(check bool)
-                  (label ^ " excludes repo_cli_identity_status") false
-                  (List.mem (`String "repo_cli_identity_status") enums)
+                  (label ^ " excludes retired repo CLI identity status") false
+                  (List.mem (`String retired_identity_status) enums)
             | _ -> Alcotest.failf "%s action_type missing enum" label)
        | _ -> Alcotest.failf "%s action_type missing" label)
   | None -> Alcotest.failf "%s masc_operator_action missing properties" label


### PR DESCRIPTION
## Summary
- rename active source/test wording from GitHub credential to repo CLI/forge credential
- keep the existing repo CLI credential mechanics unchanged
- remove remaining active-source GitHub credential phrasing from sandbox errors, invariant docs, credential mapping docs, dashboard proof text, and related test labels
- hide retired repo_cli_identity operator action literals in negative tests so removed action names do not keep reappearing as source seeds

## Validation
- opam exec -- ocamlformat --check lib/keeper_invariant/keeper_invariant.mli lib/repo_manager/keeper_repo_mapping.mli lib/keeper/keeper_host_config_provider.mli lib/keeper/keeper_sandbox_docker.ml lib/server/server_routes_http_routes_credentials.ml lib/dashboard/dashboard_keeper_git_pr_proof.ml test/test_credential_provider.ml test/test_keeper_runtime_manifest.ml test/test_keeper_sandbox_docker_route.ml test/test_operator_control_keeper.ml test/test_operator_control_snapshot.ml test/test_tools_coverage.ml
- git diff --check
- rg -n 'keeper_github|github_cli|keeper_gh|gh_command|Masc_code|masc_code|keeper_code|keeper_tools_code|Git_clone_policy|Coord_worktree_policy|repo_cli_identity_login_prepare|repo_cli_identity_status|GitHub credential|GitHub credentials|GitHub credential provider|GitHub credential bundle|GitHub sandbox|GitHub author|GitHub dispatch|GitHub operation|github credential|github credentials' lib test config scripts bin --glob '!.worktrees/**' (no matches)

## Deferred local check
- Focused Dune build was not started because /tmp/me-dune-local.lock is currently held by an OAS worktree test process (PID 23417).