### PR TITLE
refactor(dashboard/goals): extract DECK UI vocabulary SSOT to deck-classes.ts

### DIFF
--- a/dashboard/src/components/goals/deck-classes.ts
+++ b/dashboard/src/components/goals/deck-classes.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared Tailwind class strings for the goals/deck UI vocabulary.
+ *
+ * `kanban-components.ts`, `planning.ts`, and `goal-tree.ts` each defined
+ * the same DECK_* primitives byte-for-byte. The vocabulary names a
+ * common visual contract (deck container, body chip, section label,
+ * meta text) so a token rename like `--color-border-strong` updates
+ * every deck-shaped panel instead of silently drifting between sites.
+ *
+ * Scope:
+ * - DECK_PANEL — outer container (overflow-hidden bordered surface)
+ * - DECK_LABEL — section/group label (uppercase mono caps)
+ * - DECK_META  — meta text (mono dim)
+ * - DECK_CHIP  — inline body chip (mono mini-pill)
+ *
+ * `DECK_HEAD` stays file-local because the two definitions visibly
+ * diverge: kanban uses a minimal border-b header while planning adds
+ * flex/justify/gap and an inset shadow stripe. Locking that under one
+ * SSOT would require deciding which header style is canonical — a
+ * design call, not a refactor.
+ */
+export const DECK_PANEL =
+  'overflow-hidden rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)]'
+
+export const DECK_LABEL =
+  'font-mono text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]'
+
+export const DECK_META = 'font-mono text-3xs text-[var(--color-fg-disabled)]'
+
+export const DECK_CHIP =
+  'rounded-[var(--r-0)] border border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 font-mono text-3xs'

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -64,14 +64,12 @@ import {
   goalCompletionSummaryForNode,
   goalCompletionTone,
 } from './goal-completion-summary'
+import { DECK_CHIP, DECK_LABEL, DECK_META } from './deck-classes'
 
 type GoalDetailTab = 'summary' | 'tasks' | 'evidence'
 type GoalTransitionAction = 'request_complete' | 'approve_completion' | 'reject_completion'
 
 const CARD_BOX = 'rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3'
-const DECK_LABEL = 'font-mono text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]'
-const DECK_META = 'font-mono text-3xs text-[var(--color-fg-disabled)]'
-const DECK_CHIP = 'rounded-[var(--r-0)] border border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 font-mono text-3xs'
 const GOAL_PANEL = 'rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-5'
 const TREE_NODE_CARD_BASE = 'group flex items-start gap-3 rounded-[var(--r-1)] border p-3 transition-colors w-full text-left'
 const TREE_NODE_CARD_ACTIVE = `${TREE_NODE_CARD_BASE} border-[var(--color-state-active-border)] bg-[var(--color-state-active-bg)] shadow-[0_0_0_1px_var(--color-brass-border)]`

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -27,15 +27,14 @@ import {
   filterTasksByQuery,
 } from './goal-helpers'
 import { openTaskDetail } from './task-detail-state'
+import { DECK_CHIP, DECK_PANEL } from './deck-classes'
 
 const deletingTaskId = signal<string | null>(null)
 const doneVisibleCount = signal(20)
 const searchDoneVisibleCount = signal(20)
 const DONE_PAGE_SIZE = 20
 const REPO_ISSUES_BASE = 'https://github.com/jeong-sik/masc-mcp/issues'
-const DECK_PANEL = 'overflow-hidden rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)]'
 const DECK_HEAD = 'border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2'
-const DECK_CHIP = 'rounded-[var(--r-0)] border border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 font-mono text-3xs'
 const META_CHIP = 'rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 font-mono text-3xs'
 const BACKLOG_PRESSURE_PRIORITIES = [1, 2, 3, 4] as const
 const BACKLOG_STALE_THRESHOLD_HOURS: Record<number, number | undefined> = {

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -27,14 +27,11 @@ import { TaskBacklog } from './kanban-components'
 import { TaskStaleAlert } from './task-stale-alert'
 import { TaskWall } from './task-wall'
 import { TaskCreateForm } from '../task-manage/task-create-form'
+import { DECK_CHIP, DECK_LABEL, DECK_META, DECK_PANEL } from './deck-classes'
 
 const QUICK_START_DOC_URL = 'https://github.com/jeong-sik/masc-mcp/blob/main/docs/QUICK-START.md'
-const DECK_PANEL = 'overflow-hidden rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)]'
 const DECK_HEAD = 'flex flex-wrap items-start justify-between gap-3 border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2.5 shadow-[inset_0_2px_0_var(--color-accent-fg)]'
 const DECK_CARD = 'rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3'
-const DECK_LABEL = 'font-mono text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]'
-const DECK_META = 'font-mono text-3xs text-[var(--color-fg-disabled)]'
-const DECK_CHIP = 'rounded-[var(--r-0)] border border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 font-mono text-3xs'
 const BRASS_CHIP = 'rounded-[var(--r-0)] border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] px-1.5 py-0.5 font-mono text-3xs text-[var(--color-accent-fg)]'
 
 function PlanningStat({


### PR DESCRIPTION
## 요약

`components/goals/` 의 3 컴포넌트 (`kanban-components.ts`, `planning.ts`, `goal-tree.ts`) 가 *DECK UI vocabulary* 4 종을 byte-for-byte 동일하게 분산 정의:

| const | 분포 | 동일성 |
|---|---|---|
| `DECK_PANEL` | kanban + planning | byte-for-byte 동일 |
| `DECK_LABEL` | planning + goal-tree | byte-for-byte 동일 |
| `DECK_META` | planning + goal-tree | byte-for-byte 동일 |
| `DECK_CHIP` | kanban + planning + goal-tree | byte-for-byte 동일 (3 사이트) |

총 9 정의 → 4 SSOT. 같은 `DECK_*` *공유 vocabulary* (kanban deck 의 UI primitive 세트: panel/label/meta/chip).

토큰 rename (예: `--color-border-strong`, `--track-caps`) 시 9 사이트 silent drift 위험. iter#27 sweep 에서 발견된 *동일 도메인 + 동일 정책* 패턴.

## 변경

- **신설** `dashboard/src/components/goals/deck-classes.ts`: `DECK_PANEL`, `DECK_LABEL`, `DECK_META`, `DECK_CHIP` export + JSDoc (DECK_HEAD 가 *왜 scope 밖* 인지 명시)
- **3 파일**: file-local 정의 삭제 + `./deck-classes` import. 호출 사이트 무변경 (string reference 동일)

## DECK_HEAD scope 밖 결정

| 사이트 | 정의 |
|---|---|
| `kanban-components.ts:37` | `border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2` |
| `planning.ts:33` | `flex flex-wrap items-start justify-between gap-3 border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2.5 shadow-[inset_0_2px_0_var(--color-accent-fg)]` |

planning 이 flex layout + inset shadow + padding 변형. iter#24 그룹 C overlay-keeper-trace 패턴 — *base + extension* 가능성 있지만 *추가가 시각적으로 큼*. SSOT 통합 시 *어느 쪽이 canonical 인지 디자인 결정 필요* → scope 밖, file-local 유지.

## 검증

- `pnpm typecheck` PASS (silent)
- `pnpm exec vitest run src/components/goals/{kanban-components,planning,goal-tree,deck-classes}`: 7/7 (2 test files)
- `pnpm exec eslint src/components/goals/{deck-classes,kanban-components,planning,goal-tree}.ts`: 0 errors

표면 동작 회귀 없음 — string reference 동일, 호출 사이트 변경 없음.

## SSOT 위치: `components/goals/deck-classes.ts`

iter#21 `lib/sparkline-config.ts`, iter#24 `components/ide/context-badge-style.ts`, iter#27 `components/ide/ide-language.ts` 와 같은 *small focused vocabulary module* 패턴. 5번째 zero-import constants file — dashboard 의 *common SSOT 위치 컨벤션* 으로 굳어짐.

`components/goals/` 디렉토리 내부 위치 — 3 사이트 모두 `goals/` 안이라 *layering 위반 없음* + future goal/deck primitives 자연 확장.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#28, DECK UI vocabulary SSOT)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] kanban / planning / goal-tree 의 DECK 시각적 동일 (panel border + label caps + meta dim + chip mini-pill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
