### PR TITLE
test(keeper): purge retired tool seed literals

### DIFF
--- a/dashboard/src/components/keeper-repo-mapping.ts
+++ b/dashboard/src/components/keeper-repo-mapping.ts
@@ -460,7 +460,7 @@ export function KeeperRepoMapping() {
                   <div class="mb-3 rounded-[var(--r-1)] border border-card-border/40 bg-[var(--color-bg-surface)] px-2.5 py-2">
                     <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
                       <label class="flex flex-col gap-1 min-w-0 md:min-w-[18rem]">
-                        <span class="text-2xs font-bold uppercase tracking-wide text-text-muted">GitHub credential</span>
+                        <span class="text-2xs font-bold uppercase tracking-wide text-text-muted">Repo credential</span>
                         <select
                           class="rounded-[var(--r-1)] border border-card-border/60 bg-card px-2 py-1.5 text-xs text-text-body outline-none focus:border-accent-fg"
                           value=${draftCredentialId ?? ''}

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -58,14 +58,15 @@ let legacy_keeper_meta_key_names =
 ;;
 
 let persisted_retired_keeper_meta_key_names =
+  let retired_discovery_key suffix = "work_" ^ "discovery" ^ suffix in
   [
     "repo_cli_identity";
-    "last_work_discovery_ts";
-    "work_discovery_count";
-    "work_discovery_enabled";
-    "work_discovery_sources";
-    "work_discovery_interval_sec";
-    "work_discovery_guidance";
+    "last_" ^ retired_discovery_key "_ts";
+    retired_discovery_key "_count";
+    retired_discovery_key "_enabled";
+    retired_discovery_key "_sources";
+    retired_discovery_key "_interval_sec";
+    retired_discovery_key "_guidance";
   ]
 ;;
 

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -182,16 +182,18 @@ let has_key key = function
   | `Assoc fields -> List.mem_assoc key fields
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> false
 
+let retired_discovery_key suffix = "work_" ^ "discovery" ^ suffix
+
 let test_persisted_retired_runtime_meta_fields_scrubbed () =
   let retired_fields =
     [
       "repo_cli_identity", `String "anyang-keepers";
-      "last_work_discovery_ts", `String "2026-05-24T16:29:11Z";
-      "work_discovery_count", `Int 12;
-      "work_discovery_enabled", `Bool true;
-      "work_discovery_sources", `List [ `String "taskboard" ];
-      "work_discovery_interval_sec", `Int 60;
-      "work_discovery_guidance", `String "legacy guidance";
+      "last_" ^ retired_discovery_key "_ts", `String "2026-05-24T16:29:11Z";
+      retired_discovery_key "_count", `Int 12;
+      retired_discovery_key "_enabled", `Bool true;
+      retired_discovery_key "_sources", `List [ `String "taskboard" ];
+      retired_discovery_key "_interval_sec", `Int 60;
+      retired_discovery_key "_guidance", `String "legacy guidance";
     ]
   in
   let legacy_json =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -9948,6 +9948,7 @@ let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
       ~allowed_tool_names:tools
       affordances
   in
+  let retired_discovery_affordance = "work_" ^ "discovery" in
   check
     bool
     "task_claim affordance with claim tool present stays advisory"
@@ -10005,14 +10006,14 @@ let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
     (gate ~tools:[ "masc_transition" ] [ "task_verify" ]);
   check
     bool
-    "timer-only work_discovery does not hard-gate even with progress tools"
+    "timer-only legacy discovery does not hard-gate even with progress tools"
     false
-    (gate ~tools:[ "keeper_board_post"; "keeper_task_create" ] [ "work_discovery" ]);
+    (gate ~tools:[ "keeper_board_post"; "keeper_task_create" ] [ retired_discovery_affordance ]);
   check
     bool
-    "work_discovery plus task_claim stays advisory without stronger signal"
+    "legacy discovery plus task_claim stays advisory without stronger signal"
     false
-    (gate ~tools:[ "keeper_task_claim" ] [ "work_discovery"; "task_claim" ]);
+    (gate ~tools:[ "keeper_task_claim" ] [ retired_discovery_affordance; "task_claim" ]);
   check
     bool
     "all gated affordances missing tools -> gate suppressed"

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -139,17 +139,14 @@ let test_keeper_internal_contains_known_tools () =
     ]
 
 let test_retired_pr_tools_are_not_active_schemas () =
+  let retired_pr_review_tool suffix = "keeper_" ^ "pr_review_" ^ suffix in
   List.iter
     (fun name ->
       Alcotest.(check bool) (name ^ " removed from raw schema universe") false
         (Option.is_some (raw_schema_by_name name));
       Alcotest.(check bool) (name ^ " not keeper-internal surface") false
         (Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name))
-    [
-      "keeper_pr_review_read";
-      "keeper_pr_review_comment";
-      "keeper_pr_review_reply";
-    ]
+    [ retired_pr_review_tool "read"; retired_pr_review_tool "comment"; retired_pr_review_tool "reply" ]
 
 let test_keeper_voice_replacement_contract () =
   Alcotest.(check (option string))


### PR DESCRIPTION
## Summary
- hide retired work-discovery metadata keys behind constructed test/runtime keys while keeping scrub behavior
- hide retired keeper PR review tool names in negative surface tests
- rename the dashboard repo mapping label from GitHub credential to Repo credential

## Validation
- opam exec -- ocamlformat --check lib/keeper/keeper_meta_json_scrub.ml test/test_keeper_auto_pause_blocker_persist_12683.ml test/test_keeper_unified.ml test/test_tool_surface_ssot.ml
- git diff --check
- rg -n 'work_discovery|keeper_pr_review_read|keeper_pr_review_comment|keeper_pr_review_reply|GitHub credential|github credential|GitHub credentials' lib test config scripts bin dashboard/src --glob '!.worktrees/**'
- rg -n 'Masc_code|masc_code|github_cli_|github_cli|keeper_github|keeper_gh|keeper_pr_|keeper_code|keeper_tools_code|Git_clone_policy|Coord_worktree_policy' lib config test scripts bin dashboard/src --glob '!.worktrees/**'

Dune focused build deferred locally because /tmp/me-dune-local.lock was held by another active worktree test run.