### PR TITLE
fix(tool-task): preserve message via make_ok ~data in masc_claim_next no-eligible (#18954)

### DIFF
--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -522,11 +522,19 @@ let handle_claim_next ?agent_tool_names ~tool_name ~start_time ctx _args =
         ~receipt_required_tool_blocked
         ~agent_tool_names_known
     in
-    let payload =
+    (* #18954: build the structured payload directly via [make_ok ~data]
+       so the message and diagnostics live in the JSON [data] field.
+       The previous form [Tool_result.ok (message ^ "\n" ^ payload)]
+       routed through [structured_payload_of_message], which parsed the
+       trailing JSON object out and discarded the prefix line — leaving
+       [Tool_result.message] able to round-trip only the JSON, not the
+       human-readable lead.  LLM/JSON consumers still see the message
+       inside the JSON [.message] field; we keep the same Assoc shape
+       that callers already inspect. *)
+    let data =
       `Assoc [ "message", `String message; "diagnostics", diagnostics ]
-      |> Yojson.Safe.to_string
     in
-    Tool_result.ok ~tool_name ~start_time (message ^ "\n" ^ payload)
+    Tool_result.make_ok ~tool_name ~start_time ~data ()
   | Coord.Claim_next_error e ->
     (* RFC-0189: Claim_next_error wraps coord-side reasons like
        "no claimable task", "agent not allowed", "permission denied"


### PR DESCRIPTION
## 요약

`Closes #18954`.

`lib/tool_task_handlers.ml:529` 의 `masc_claim_next` no-eligible 응답이 `Tool_result.ok (message ^ "\n" ^ payload)` 형태로 prefix 문자열을 JSON 앞에 붙여 호출. `Tool_result.ok` 생성자가 `structured_payload_of_message` 로 *trailing JSON 을 자동 파싱* 해 `data` 필드로 보관 → `Tool_result.message` 가 Ok arm 에서 `data` 를 재직렬화 → **prefix 문자열 round-trip 손실**.

→ iter 31 caller audit ([#18954 comment](https://github.com/jeong-sik/masc-mcp/issues/18954#issuecomment-4551778862)) 결과 Option 4 (`make_ok ~data`) surgical 안전 확인. 카테고리 A (LLM/JSON-aware) 가 1차 consumer 이고 plain-text prefix 의존 0건.

## 변경 — Option 4 (surgical equivalent)

```ocaml
(* Before — string concat + auto-parse round trip *)
let payload =
  `Assoc [ "message", `String message; "diagnostics", diagnostics ]
  |> Yojson.Safe.to_string
in
Tool_result.ok ~tool_name ~start_time (message ^ "\n" ^ payload)

(* After — explicit structured data *)
let data =
  `Assoc [ "message", `String message; "diagnostics", diagnostics ]
in
Tool_result.make_ok ~tool_name ~start_time ~data ()
```

### 효과

- `Tool_result.message` Ok arm: `Yojson.Safe.to_string data` = compact JSON 형태 반환. `"message"` 필드가 JSON 내부에 그대로 보존됨.
- `Tool_result.to_json`: data 가 `Assoc` 이므로 wire 형식 동일 (escape 차이 없음).
- LLM consumer: JSON 파싱으로 `.message` 추출 — 기능 동등.
- HTTP/operator plain-text consumer (카테고리 B): JSON 으로 표시되어 prefix line 누락. UX 손실 작음 (raw `Tool_result.message` 노출 site 거의 없음).

## Caller audit (iter 31 결과 요약)

`Tool_result.message` ~20 callsite:

- **A (JSON-aware)**: `tool_bridge.ml:261, 263`, `mcp_server_eio_call_tool.ml:666` — LLM/MCP 응답. plain-text prefix 의존 0건.
- **B (plain-text 표시)**: HTTP/operator routes (~10) — JSON 도 표시 가능, prefix UX 약간 손실.
- **C (substring scan)**: `extract_board_post_id` — `'{' 위치` 찾기로 *Option 4 적용 후에도 작동* (`'{' = 0` 시 전체 JSON 파싱).
- **D (log preview only)**: `mcp_server_eio_execute.ml:133` — 영향 없음.

`masc_claim_next` 1차 consumer = LLM = 카테고리 A.

## Test impact

`test/test_tool_task_coverage.ml:1540`:

```ocaml
assert (str_contains (Tool_result.message result) "No eligible tasks available");
```

새 `data = `Assoc [...]` 형식: `Yojson.Safe.to_string` 결과 `{"message":"No eligible tasks available...",...}` 가 `"No eligible tasks available"` substring 포함 → test PASS.

`grep "No eligible tasks available" test/` 다른 의존 사이트 0.

## Workaround Signature Gate

본 PR 은 시그니처 3종 + 체크리스트 7항목 모두 비해당:

- ❌ Counter-as-Fix — telemetry 추가 없음
- ❌ String/substring 분류기 — JSON `data` 가 typed `Yojson.Safe.t`, 무관
- ❌ N-of-M 패치 — blast radius scan (iter 30) 결과 *1 callsite only*, 본 PR 이 전부 cover
- ❌ Repair/Sanitize — symptom 억제 아닌 *explicit constructor 사용*

## Background

본 issue 는 PR #18930 (typed Tool_result spine refactor) 의 Codex inline review §"Tool_result.message accessor loses prefix text on Ok path" 에서 발견. 사용자가 *focused PR + caller audit* 권장. 본 PR 이 그 권장 직접 수행.

iter 30 blast radius scan + iter 31 caller audit + iter 36 fix.

## Related

- Issue #18954 (P2 follow-up from #18930)
- PR #18930 (typed Tool_result spine refactor, source of the regression)
- Iter 30 blast radius scan ([#18954 issuecomment-4551722086](https://github.com/jeong-sik/masc-mcp/issues/18954#issuecomment-4551722086))
- Iter 31 caller audit ([#18954 issuecomment-4551778862](https://github.com/jeong-sik/masc-mcp/issues/18954#issuecomment-4551778862))

🤖 Generated with [Claude Code](https://claude.com/claude-code)
