### PR TITLE
refactor(dashboard/api): consolidate AbortableRequestOptions into api/core.ts

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -500,6 +500,18 @@ export function defaultBoardVoter(): string {
 
 // --- Generic fetcher ---
 
+/**
+ * Minimal request contract: the caller may pass an AbortSignal to cancel
+ * the underlying fetch. Several api/* modules (dashboard, dashboard-hot,
+ * transport-health) had defined this byte-for-byte locally; lifting it
+ * here makes the abort contract single-sourced and lets callers compose
+ * extensions like `AbortableRequestOptions & { light?: boolean }` against
+ * a stable base.
+ */
+export type AbortableRequestOptions = {
+  signal?: AbortSignal
+}
+
 export type GetOptions = {
   timeoutMs?: number
   includeActorHeader?: boolean

--- a/dashboard/src/api/dashboard-hot.ts
+++ b/dashboard/src/api/dashboard-hot.ts
@@ -1,13 +1,9 @@
-import { get, NAMESPACE_TRUTH_GET_TIMEOUT_MS } from './core'
+import { get, NAMESPACE_TRUTH_GET_TIMEOUT_MS, type AbortableRequestOptions } from './core'
 import type {
   DashboardBootstrapResponse,
   DashboardNamespaceTruthResponse,
   DashboardShellResponse,
 } from '../types'
-
-type AbortableRequestOptions = {
-  signal?: AbortSignal
-}
 
 type DashboardShellRequestOptions = AbortableRequestOptions & {
   light?: boolean

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -11,7 +11,7 @@ import {
 } from './board'
 import { normalizePendingConfirmation } from '../pending-confirm'
 import { normalizeKeeperTrustTerminalReason } from '../keeper-store-normalize'
-import { currentDashboardActor, get, post, withRetries } from './core'
+import { currentDashboardActor, get, post, withRetries, type AbortableRequestOptions } from './core'
 import { DEFAULT_WINDOW_MINUTES_24H } from '../config/constants'
 import {
   parseAgentRelationsResponse,
@@ -126,10 +126,6 @@ export { reportToolHostFailure } from './tool-host-failure'
 export { fetchDashboardBootstrap, fetchDashboardShell } from './dashboard-hot'
 
 // --- Dashboard projections ---
-
-type AbortableRequestOptions = {
-  signal?: AbortSignal
-}
 
 export type DashboardFeedRetention = Record<string, unknown> & {
   scope?: string

--- a/dashboard/src/api/transport-health.ts
+++ b/dashboard/src/api/transport-health.ts
@@ -1,4 +1,4 @@
-import { get } from './core'
+import { get, type AbortableRequestOptions } from './core'
 import {
   parseTransportHealthData,
   type HotSession,
@@ -7,10 +7,6 @@ import {
 
 export type { HotSession, TransportHealthData }
 export { TransportHealthSchemaDriftError } from './schemas/transport-health'
-
-type AbortableRequestOptions = {
-  signal?: AbortSignal
-}
 
 // Thin null-returning wrapper preserving the pre-migration contract —
 // `src/api/transport-health.test.ts` has many assertions on


### PR DESCRIPTION
## 요약

`type AbortableRequestOptions = { signal?: AbortSignal }` 가 `dashboard/src/api/` 3 파일에 byte-for-byte 동일하게 분산 정의:

| 파일 | 라인 |
|---|---|
| `dashboard/src/api/transport-health.ts:11` | file-local type |
| `dashboard/src/api/dashboard-hot.ts:8` | file-local type (+ `DashboardShellRequestOptions = AbortableRequestOptions & { light? }` extension) |
| `dashboard/src/api/dashboard.ts:130` | file-local type (15+ 호출 사이트) |

3 정의 모두 *abort 가능 fetch 의 minimal contract* — 같은 시그니처, 같은 의미. 토큰 drift 위험은 작지만 *cross-file type sprawl* — 같은 abstract contract 가 *3 사본* 유지되는 게 SSOT 위반.

## 변경

- **`dashboard/src/api/core.ts`**: `AbortableRequestOptions` export 추가 (이미 `GetOptions` 가 같은 `signal?: AbortSignal` 패턴 보유, *minimal abort-only base* 으로 분리) + JSDoc (caller 가 `& { ... }` extension 으로 composable 함을 명시)
- **3 파일** (`transport-health.ts`, `dashboard-hot.ts`, `dashboard.ts`): file-local type 삭제 + `./core` 의 *기존* import 라인에 `type AbortableRequestOptions` 추가
- 호출 사이트 무변경 — type 이름 동일, 사용 패턴 동일

dashboard-hot 의 `DashboardShellRequestOptions = AbortableRequestOptions & { light?: boolean }` extension 패턴은 그대로 보존 — *intersection 기반 extensibility* 디자인 의도 유지.

## SSOT 위치: `api/core.ts`

| 옵션 | 채택 | 이유 |
|---|---|---|
| `api/core.ts` (이 PR) | ✅ | 이미 *HTTP infrastructure base*, 모든 `api/*` 가 의존 (3 사이트 모두 *기존* `from './core'` import 보유). `GetOptions` 같은 fetcher-side type 의 자연 owner |
| 새 파일 `api/request-options.ts` | ❌ | core.ts 가 이미 generic fetcher types 의 owner, 새 파일 cost 가 가치 대비 큼 |
| `api/dashboard.ts` owner | ❌ | dashboard 가 *consumer* 라 transport-health 같은 다른 API 모듈이 의존 시 도메인 역전 |

## scope 분리 — GetOptions refactor 보류

`GetOptions = { timeoutMs?; includeActorHeader?; signal? }` 가 *`AbortableRequestOptions & { timeoutMs?; includeActorHeader? }` extension* 으로 refactor 가능 (iter#25 base+spread 패턴, iter#28 DECK_PANEL 패턴). **별도 iter** — 이번 PR scope = `AbortableRequestOptions` 통합 only. core.ts 의 `GetOptions` 재구성은 *signal 필드 중복 정리* 라는 *내부 cleanup* 으로 추후 진행.

## 검증

- `pnpm typecheck` PASS (silent)
- `pnpm exec vitest run src/api/{core,dashboard,dashboard-hot,transport-health}`: 96/96 (4 test files)
- `pnpm exec eslint src/api/{core,dashboard,dashboard-hot,transport-health}.ts`: 0 errors (2 warnings = pre-existing config noise)

표면 동작 회귀 없음 — type 이름/시그니처 동일, 모든 호출 사이트 변경 없음.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#29, AbortableRequestOptions API contract SSOT)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Abort 가능 fetch 호출 (transport-health / dashboard-hot fetchDashboardShell / dashboard.fetchDashboardExecution 등) 시 AbortSignal 전달 → 정상 cancel 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)
