### PR TITLE
refactor(ensure_dir): typed Unix_error EEXIST replaces substring classifier in 2 mkdir race paths (RFC-0088)

### DIFF
--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -280,11 +280,15 @@ let buffer_cap = 64
 
 let ensure_dir path =
   let dir = Filename.dirname path in
+  (* See heuristic_metrics.ensure_dir — same RFC-0088 "String 분류기"
+     removal: typed [Unix.Unix_error EEXIST] instead of substring match
+     on the libc error message. *)
   if not (Sys.file_exists dir) then
-    try Sys.mkdir dir 0o755 with
-    | Sys_error msg when String_util.contains_substring msg "exists" -> ()
-    | Sys_error msg ->
-      Log.warn ~ctx:"agent_stress" "cannot mkdir %s: %s" dir msg
+    try Unix.mkdir dir 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+    | Unix.Unix_error (err, _, _) ->
+      Log.warn ~ctx:"agent_stress" "cannot mkdir %s: %s" dir
+        (Unix.error_message err)
 
 let do_flush () =
   match !store_path_ref with

--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -202,11 +202,21 @@ let reset_for_test () =
 
 let ensure_dir path =
   let dir = Filename.dirname path in
+  (* TOCTOU between [Sys.file_exists] and [mkdir] is benign — another
+     fiber may have created the directory in between.  Catch the typed
+     [EEXIST] errno rather than substring-matching [Sys_error msg], so a
+     translation of the libc message can never silently disable this
+     classifier (RFC-0088 "String/Substring 분류기" anti-pattern). *)
   if not (Sys.file_exists dir)
   then (
-    try Sys.mkdir dir 0o755 with
-    | Sys_error msg when String_util.contains_substring msg "exists" -> ()
-    | Sys_error msg -> Log.warn ~ctx:"heuristic_metrics" "cannot mkdir %s: %s" dir msg)
+    try Unix.mkdir dir 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+    | Unix.Unix_error (err, _, _) ->
+      Log.warn
+        ~ctx:"heuristic_metrics"
+        "cannot mkdir %s: %s"
+        dir
+        (Unix.error_message err))
 ;;
 
 let do_flush () =


### PR DESCRIPTION
## 요약

`heuristic_metrics.ml:208` 와 `agent_stress.ml:285` 둘 다 동일 패턴:

```ocaml
try Sys.mkdir dir 0o755 with
| Sys_error msg when String_util.contains_substring msg "exists" -> ()
| Sys_error msg -> Log.warn ...
```

`Sys.file_exists dir` 확인 후 `Sys.mkdir` 호출 사이의 TOCTOU race 를 *normal 으로 흡수* 하려는 의도인데, 분류 키로 `Sys_error msg` 의 libc 문자열 "exists" substring 사용. RFC-0088 §"String/Substring 분류기" 안티패턴:

- libc 메시지가 locale-translated 되면 "exists" 매치 실패 → race 가 *uncategorized warn* 로 변경
- 다른 `Sys_error` 가 같은 substring 가지면 false positive
- Compiler 가 변경을 감지 못 함

## 변경

`Sys.mkdir` → `Unix.mkdir`, 그리고 typed `Unix.Unix_error (Unix.EEXIST, _, _)` 매치로 정확한 errno classification:

```ocaml
try Unix.mkdir dir 0o755 with
| Unix.Unix_error (Unix.EEXIST, _, _) -> ()
| Unix.Unix_error (err, _, _) ->
  Log.warn ~ctx:"..." "cannot mkdir %s: %s" dir
    (Unix.error_message err)
```

- 두 파일 동시 처리 — N-of-M 패치 회피 (CLAUDE.md "1번째 fix → 근본 수정" 원칙)
- Behavior 동등: `Unix.mkdir` 와 `Sys.mkdir` 가 같은 syscall, EEXIST 가 정확히 "directory already exists" 한 케이스
- Log 출력 형식 동일 (`Unix.error_message err` 가 libc 메시지)

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 String/Substring 분류기 패턴을 *제거* 함 (typed errno 도입). pr-rfc-check 가 anti-pattern 언급을 시그니처 매치로 감지하나, 실제 코드 변경은 anti-pattern *deletion* (substring 사이트 2개를 typed `Unix_error EEXIST` 로 교체).

본 PR 은 시그니처 3종 + 체크리스트 7항목 모두 비해당:

- ❌ Counter-as-Fix — telemetry 추가 없음
- ✅ **String/substring 분류기 제거** — 2 사이트 동시
- ❌ N-of-M 패치 — 2 사이트 *모두* 동시 처리, mkdir+exists 패턴 전수 grep 결과 0건 추가
- ❌ Repair/Sanitize — symptom 억제 아닌 *typed error 정확화*

## Test impact

`rg "ensure_dir" test/` 결과 0 hit. ensure_dir 가 internal helper, 직접 테스트 없음. EEXIST race 자체는 *flaky test* 로만 표출 가능 (file system race), CI 환경에서 재현 어려움.

## Background

PR #18977 (`System_error.LockContention` typed variant) 가 RFC-0088 §"String 분류기" 1 사이트 제거 한 직후 audit. `rg 'contains_substring.*"' lib/` 결과 mkdir EEXIST 패턴 2 사이트가 같은 안티패턴.

다음 추가 분류기 안티패턴 후보 (별도 PR):
- `server_dashboard_http_runtime_info.ml:596-629` — "Received SIGTERM/SIGINT", "invalid/repaired agent JSON" classifier
- `server_dashboard_http_core.ml:596-600` — "bearer token belongs to", "token required" auth error classifier

이들은 더 복잡 — log message parsing path, typed exception 도입 비용 큼.

## Related

- PR #18977 (lock contention typed) — 직전 RFC-0088 §"String 분류기" 제거 사례
- RFC-0088 §"String/Substring 분류기" anti-pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
