### PR TITLE
refactor(repo): drop github credential mapping field

### DIFF
--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -13,7 +13,7 @@ let mapping_of_toml toml keeper_id =
   let* repository_ids =
     Otoml.Helpers.find_strings_result toml (path "repositories")
   in
-  let* github_credential_id =
+  let* credential_id =
     match Otoml.find_result toml Fun.id (path "credential_id") with
     | Error _ -> Ok None
     | Ok (Otoml.TomlString id) ->
@@ -27,7 +27,7 @@ let mapping_of_toml toml keeper_id =
           (Printf.sprintf
              "mapping.%s.credential_id must be a string when present" keeper_id)
   in
-  Ok { keeper_id; repository_ids; github_credential_id }
+  Ok { keeper_id; repository_ids; credential_id }
 
 let credential_type_label = function
   | Github -> "GitHub"
@@ -43,7 +43,7 @@ let toml_of_mapping mapping =
     ]
   in
   let fields =
-    match mapping.github_credential_id with
+    match mapping.credential_id with
     | Some id ->
         let id = String.trim id in
         if id = "" then fields
@@ -166,14 +166,14 @@ let credentials_for_keeper ~base_path ~keeper_id =
                   in credential store: %s"
                  id keeper_id msg)
       in
-      (match mapping.github_credential_id with
+      (match mapping.credential_id with
       | Some id when String.trim id <> "" ->
           let id = String.trim id in
           let* credential = resolve_credential id in
           if credential.cred_type <> Github then
             Error
               (Printf.sprintf
-                 "credential %s referenced by github_credential_id for keeper %s \
+                 "credential %s referenced by credential_id for keeper %s \
                   must be of type GitHub, got %s"
                  id keeper_id (credential_type_label credential.cred_type))
           else

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -12,11 +12,10 @@ val allowed_repositories :
 val credentials_for_keeper :
   base_path:string -> keeper_id:string -> (credential list, string) result
 (** [credentials_for_keeper ~base_path ~keeper_id] resolves the
-    credential currently mapped to [keeper_id].  A direct
-    [github_credential_id] / [credential_id] TOML or JSON field on the
-    keeper mapping wins and must reference a repo CLI credential; otherwise
-    this resolves the unique credentials by walking every repository the
-    keeper is allowed to access and looking up each repository's
+    credential currently mapped to [keeper_id].  A direct [credential_id]
+    TOML or JSON field on the keeper mapping wins and must reference a repo
+    CLI credential; otherwise this resolves the unique credentials by
+    walking every repository the keeper is allowed to access and looking up each repository's
     [credential_id] in the credential store.
 
     Returns [Ok []] when the keeper has no mapping, preserving a distinct

--- a/lib/repo_manager/repo_manager_types.ml
+++ b/lib/repo_manager/repo_manager_types.ml
@@ -71,7 +71,7 @@ type credential = {
 type keeper_repo_mapping = {
   keeper_id : string;
   repository_ids : string list;
-  github_credential_id : string option [@default None];
+  credential_id : string option [@default None];
 }
 [@@deriving yojson, show, eq]
 

--- a/lib/repo_manager/repo_manager_types.mli
+++ b/lib/repo_manager/repo_manager_types.mli
@@ -52,7 +52,7 @@ type credential = {
 type keeper_repo_mapping = {
   keeper_id : string;
   repository_ids : string list;
-  github_credential_id : string option [@default None];
+  credential_id : string option [@default None];
 }
 [@@deriving yojson, show, eq]
 

--- a/lib/server/server_routes_http_routes_keeper_repos.ml
+++ b/lib/server/server_routes_http_routes_keeper_repos.ml
@@ -30,7 +30,7 @@ let mapping_json (m : Repo_manager_types.keeper_repo_mapping) : Yojson.Safe.t =
       ("allowed_repos", `List (List.map (fun s -> `String s) m.repository_ids));
       ("allow_all", `Bool allow_all);
       ( "credential_id",
-        match m.github_credential_id with
+        match m.credential_id with
         | Some id ->
             let trimmed = String.trim id in
             if trimmed <> "" then `String trimmed else `Null
@@ -72,7 +72,7 @@ let mapping_of_json keeper_id (json : Yojson.Safe.t) :
             {
               Repo_manager_types.keeper_id;
               repository_ids;
-              github_credential_id = credential_id;
+              credential_id;
             }
       | Error msg, _ | _, Error msg -> Error msg)
   | _ -> Error "expected JSON object body"
@@ -134,7 +134,7 @@ let credential_type_label = function
 
 let validate_mapping_credential ~base_path
     (mapping : Repo_manager_types.keeper_repo_mapping) =
-  match mapping.github_credential_id with
+  match mapping.credential_id with
   | None -> Ok ()
   | Some credential_id -> (
       match Credential_store.find ~base_path credential_id with

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -108,7 +108,7 @@ let seed_single_playground_repo ~config ~(meta : Keeper_types.keeper_meta) playg
   let mapping : Repo_manager_types.keeper_repo_mapping =
     { keeper_id = meta.name
     ; repository_ids = [ "masc-mcp" ]
-    ; github_credential_id = None
+    ; credential_id = None
     }
   in
   (match Keeper_repo_mapping.save_mapping ~base_path:config.Coord.base_path mapping with

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -722,7 +722,7 @@ let test_save_mapping_creates_config_dir () =
         {
           keeper_id = "keeper-new";
           repository_ids = [ "repo-a"; "repo-b" ];
-          github_credential_id = None;
+          credential_id = None;
         }
       in
       match Keeper_repo_mapping.save_mapping ~base_path mapping with
@@ -740,7 +740,7 @@ let test_save_mapping_preserves_credential_id () =
         {
           keeper_id = "keeper-new";
           repository_ids = ["*"];
-          github_credential_id = Some "cred-selected";
+          credential_id = Some "cred-selected";
         }
       in
       match Keeper_repo_mapping.save_mapping ~base_path mapping with
@@ -752,7 +752,7 @@ let test_save_mapping_preserves_credential_id () =
               Alcotest.(check (option string))
                 "credential id"
                 (Some "cred-selected")
-                loaded.github_credential_id
+                loaded.credential_id
           | Ok rows ->
               Alcotest.failf "expected one mapping, got %d" (List.length rows)))
 
@@ -765,7 +765,7 @@ let test_load_all_trims_credential_id () =
           Alcotest.(check (option string))
             "trimmed credential id"
             (Some "cred-selected")
-            loaded.github_credential_id
+            loaded.credential_id
       | Ok rows -> Alcotest.failf "expected one mapping, got %d" (List.length rows))
 
 let test_load_all_rejects_non_string_credential_id () =

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -365,7 +365,7 @@ let seed_repo_cli_credential_mapping
     {
       keeper_id = keeper_name;
       repository_ids;
-      github_credential_id = Some credential_id;
+      credential_id = Some credential_id;
     }
   in
   match

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -126,7 +126,7 @@ let with_registered_repo_fixture f =
          match
            Keeper_repo_mapping.save_mapping
              ~base_path
-             { keeper_id; repository_ids; github_credential_id = None }
+             { keeper_id; repository_ids; credential_id = None }
          with
          | Ok () -> ()
          | Error msg -> Alcotest.fail ("mapping setup failed: " ^ msg)


### PR DESCRIPTION
## Summary
- rename keeper repo mapping's internal record field from github_credential_id to credential_id
- keep the existing TOML/HTTP wire name as credential_id
- update repo mapping, server route, sandbox, fs edit, and worker tests to the neutral field name

## Validation
- rg -n 'github_credential_id' lib test config scripts bin dashboard/src --glob '!.worktrees/**' (no matches)
- opam exec -- ocamlformat --check lib/repo_manager/repo_manager_types.ml lib/repo_manager/repo_manager_types.mli lib/repo_manager/keeper_repo_mapping.ml lib/repo_manager/keeper_repo_mapping.mli lib/server/server_routes_http_routes_keeper_repos.ml test/test_keeper_repo_mapping.ml test/test_keeper_fs_edit_patch.ml test/test_worker_dev_tools.ml test/test_keeper_sandbox_docker_route.ml
- git diff --check origin/main...HEAD

Focused Dune build deferred locally because /tmp/me-dune-local.lock is held by another active worktree build.