### PR TITLE
refactor(dashboard/api): re-express GetOptions as AbortableRequestOptions extension

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -512,10 +512,9 @@ export type AbortableRequestOptions = {
   signal?: AbortSignal
 }
 
-export type GetOptions = {
+export type GetOptions = AbortableRequestOptions & {
   timeoutMs?: number
   includeActorHeader?: boolean
-  signal?: AbortSignal
 }
 
 export async function get<T>(path: string, opts: GetOptions = {}): Promise<T> {


### PR DESCRIPTION
## 요약

iter#29 (PR #18981) follow-up. `GetOptions` 가 `signal?: AbortSignal` 을 *file-internal duplicate* 로 유지 — iter#29 에서 lift 한 `AbortableRequestOptions` 와 같은 필드. intersection 기반 extension 으로 재구성.

```ts
// Before
export type GetOptions = {
  timeoutMs?: number
  includeActorHeader?: boolean
  signal?: AbortSignal
}

// After
export type GetOptions = AbortableRequestOptions & {
  timeoutMs?: number
  includeActorHeader?: boolean
}
```

## 변경

- **`dashboard/src/api/core.ts`** 1 파일 1 type 정의 변경 (4 lines):
  - `signal?: AbortSignal` 필드 삭제
  - `AbortableRequestOptions` intersection 으로 base 명시

호출 사이트 무변경 — TypeScript 구조적 typing 에서 `opts.signal` 접근은 intersection 으로도 그대로 동작.

## 왜 이 작업 (drift 위험 0 으로 박기)

`AbortableRequestOptions.signal` 과 `GetOptions.signal` 이 *별개 정의 같은 type* 인 상태에서, 한 곳에서 *작은 type 변화* (예: `signal: AbortSignal | null`, `signal: AbortSignal | undefined`) 발생 시 silent 분기 위험. intersection 으로 묶으면 *컴파일러가 same source 강제*.

iter#25 (`IDE_INLINE_BADGE_BASE` base+spread), iter#28 (`DECK_PANEL` SSOT) 와 같은 *base + extension* 디자인 패턴의 *type 영역* 적용.

## 검증

- `pnpm typecheck` PASS (silent) — structural typing 정상 작동
- `pnpm exec vitest run`: 528/529 file PASS (1 fail = `auth-status.a11y` popover axe, **pre-existing baseline** — iter#23/27 측정값 동일, GetOptions 와 무관)
- `pnpm exec eslint src/api/core.ts`: 0 errors

표면 동작 회귀 없음 — `GetOptions` 의 shape (4 fields 모두 optional, 동일 type) 변경 없음.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#30, GetOptions intersection refactor — iter#29 follow-up)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] `get(path, opts)` 의 모든 호출 사이트 (`get(path, {signal})`, `get(path, {timeoutMs, signal})` 등) intersection 으로도 정상 type-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
