### PR TITLE
refactor(dashboard/components): consolidate Cytoscape lazy-loader SSOT

### DIFF
--- a/dashboard/src/components/common/cytoscape-fsm.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.ts
@@ -5,6 +5,7 @@ import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import type cytoscape from 'cytoscape'
 import { InlineSpinner } from './inline-spinner'
+import { getCytoscape, type CyCore } from './cytoscape-loader'
 
 // Types for graph spec (consumed by all 3 FSM builders)
 export interface FsmNode {
@@ -103,18 +104,6 @@ interface CytoscapeFsmProps {
   spec: FsmGraphSpec
   height?: string
   class?: string
-}
-
-// Lazy-load Cytoscape for graph-heavy panels.
-type CyCore = cytoscape.Core
-
-let cyPromise: Promise<typeof cytoscape> | null = null
-
-function getCytoscape(): Promise<typeof cytoscape> {
-  if (!cyPromise) {
-    cyPromise = import('cytoscape').then(m => m.default ?? m)
-  }
-  return cyPromise
 }
 
 function buildElements(spec: FsmGraphSpec) {

--- a/dashboard/src/components/common/cytoscape-loader.ts
+++ b/dashboard/src/components/common/cytoscape-loader.ts
@@ -1,0 +1,28 @@
+import type cytoscape from 'cytoscape'
+
+/**
+ * Cytoscape singleton lazy-loader.
+ *
+ * `git-graph-view.ts` and `common/cytoscape-fsm.ts` both shipped the
+ * same three-part pattern locally: a `CyCore` type alias, a
+ * module-scoped `Promise | null` cache, and a `getCytoscape()` function
+ * that dynamic-imports cytoscape once. The two cached promises lived
+ * side by side, so when both panels mounted at the same time they each
+ * triggered their own `import('cytoscape')` call — Vite's module
+ * cache deduplicates the *module* but not the *promise object*.
+ *
+ * Lifting both the type alias and the loader here gives a single
+ * promise shared across every cytoscape-using panel, so the dynamic
+ * import resolves once and a token rename on the dynamic-import shape
+ * (e.g. `m.default ?? m`) only has one site to update.
+ */
+export type CyCore = cytoscape.Core
+
+let cytoscapeModulePromise: Promise<typeof cytoscape> | null = null
+
+export function getCytoscape(): Promise<typeof cytoscape> {
+  if (!cytoscapeModulePromise) {
+    cytoscapeModulePromise = import('cytoscape').then(m => m.default ?? m)
+  }
+  return cytoscapeModulePromise
+}

--- a/dashboard/src/components/git-graph-view.ts
+++ b/dashboard/src/components/git-graph-view.ts
@@ -3,17 +3,7 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 import type cytoscape from 'cytoscape'
 import type { GitGraphResponse, GitGraphNode } from '../api/git-graph'
 import { InlineSpinner } from './common/inline-spinner'
-
-type CyCore = cytoscape.Core
-
-let cytoscapePromise: Promise<typeof cytoscape> | null = null
-
-function getCytoscape(): Promise<typeof cytoscape> {
-  if (!cytoscapePromise) {
-    cytoscapePromise = import('cytoscape').then(m => m.default ?? m)
-  }
-  return cytoscapePromise
-}
+import { getCytoscape, type CyCore } from './common/cytoscape-loader'
 
 // Cytoscape does not resolve CSS variables. Resolve once against :root
 // with fallback to literal hex values.


### PR DESCRIPTION
## 요약

`components/git-graph-view.ts` 와 `components/common/cytoscape-fsm.ts` 가 cytoscape 동적 import 패턴을 *3중 복붙*:

| 요소 | git-graph-view | cytoscape-fsm |
|---|---|---|
| `type CyCore = cytoscape.Core` | line 7 | line 109 (byte-for-byte 동일) |
| `let promise: Promise<...> | null = null` | `cytoscapePromise` | `cyPromise` (변수명 only 다름) |
| `function getCytoscape()` | line 11-16 | line 113-118 (본문 byte-for-byte 동일) |

**부가 이슈** — *별개 promise 객체*: 두 panel 동시 mount 시 *각자 `import('cytoscape')` 호출 trigger*. Vite 가 *모듈 캐시* 는 잡지만 *promise 객체* 는 2개 분리, *useless 2번 await*.

## 변경

- **신설** `dashboard/src/components/common/cytoscape-loader.ts`: `export type CyCore` + `export function getCytoscape()` + module-scoped singleton promise. JSDoc 으로 *공유 promise* 이점 명시
- **`components/git-graph-view.ts`**: file-local `CyCore`/`cytoscapePromise`/`getCytoscape` 삭제 + import. `import type cytoscape from 'cytoscape'` 는 *유지* (cytoscape.ElementDefinition / StylesheetJsonBlock / LayoutOptions / EventObject 등 4 cytoscape namespace type 사용)
- **`components/common/cytoscape-fsm.ts`**: 동일 패턴 — file-local 정의 삭제 + import. `import type cytoscape` 유지 (StylesheetJsonBlock / LayoutOptions / EventObject 사용)

호출 사이트 무변경: `getCytoscape()` 호출, `CyCore | null` 타입 사용 모두 동일 시그니처.

## SSOT 위치: `components/common/cytoscape-loader.ts`

| 옵션 | 채택 | 이유 |
|---|---|---|
| `cytoscape-loader.ts` 신설 (이 PR) | ✅ | iter#21/24/26/27/28 *small focused module* 패턴 (6번째 zero-import-heavy constants/helper file). 의존성 minimal — 단 cytoscape 자체만 import |
| `cytoscape-fsm.ts` owner + git-graph-view 의존 추가 | ❌ | cytoscape-fsm 가 *FSM 그래프 그리기 전체 (370+ lines)* 보유 → git-graph-view 가 *불필요 dep* 끌고 옴 |

## 검증

- `pnpm typecheck` PASS (silent)
- `pnpm exec vitest run src/components/{git-graph-view,common/cytoscape-fsm,common/cytoscape-loader}`: 42/42 (3 test files)
- `pnpm exec eslint src/components/common/cytoscape-loader.ts src/components/git-graph-view.ts src/components/common/cytoscape-fsm.ts`: 0 errors

표면 동작 회귀 없음 — 함수/type 시그니처 동일, lazy-import 동작 동일 (오히려 *1 promise 공유* 로 효율 개선).

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#31, cytoscape lazy-loader SSOT — type + 함수 + 변수 3중 dedup)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] Git graph view (repository panel) 열기 → cytoscape 정상 로드
- [ ] FSM 그래프 (keeper detail surface) 열기 → cytoscape 정상 로드
- [ ] 두 panel 동시 mount → 1 dynamic import 만 발생 (개선)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
