### PR TITLE
refactor(dashboard/keeper-spawn): remove dead MCP shutdownKeeper helper

### DIFF
--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
@@ -320,16 +320,3 @@ export async function savePersonaDraft(opts?: { overwrite?: boolean; dryRun?: bo
   }
 }
 
-export async function shutdownKeeper(keeperName: string): Promise<void> {
-  const access = dashboardAuthAccess(shellAuthSummary.value, 'worker')
-  if (!access.allowed) {
-    showToast(access.reason ?? '키퍼 종료 권한이 없습니다.', 'error', 6000)
-    return
-  }
-  try {
-    await callMcpTool('masc_keeper_down', { name: keeperName })
-    showToast(`${keeperName} 키퍼 종료 완료`, 'success')
-  } catch (err) {
-    showToast(`키퍼 종료 실패: ${err instanceof Error ? err.message : String(err)}`, 'error')
-  }
-}


### PR DESCRIPTION
## 요약

`export function` cross-file duplicate sweep 에서 발견된 *동음이의어 + dead code 동시 케이스*:

| 사이트 | 구현 | 호출 사이트 |
|---|---|---|
| `api/keeper.ts:367` | REST endpoint (`/api/v1/keepers/.../shutdown`) | `keeper-action-panel.ts`, `keeper-detail-lifecycle.ts` (+ tests) — **활성** |
| `keeper-spawn/keeper-spawn-state.ts:323` | MCP tool (`masc_keeper_down`) + auth check + toast | **0건** (전체 dashboard/src 에서 import 0, test 0) — **dead code** |

같은 이름 `shutdownKeeper` 가 *완전히 다른 메커니즘* (REST vs MCP) + *다른 시그니처* (`Promise<KeeperLifecycleResponse>` vs `Promise<void>`) + *다른 부가 동작* (raw response vs auth+toast) 를 가진 *진짜 동음이의어*. iter#9-12 rename 패턴 대신 *dead 쪽 삭제* 로 자동 해소.

## 변경

- **`dashboard/src/components/keeper-spawn/keeper-spawn-state.ts`** line 323-335 (13 lines, MCP-path `shutdownKeeper` 함수) 삭제

의존 imports (`callMcpTool` / `dashboardAuthAccess` / `shellAuthSummary` / `showToast`) 는 *다른 함수들 (spawnKeeperFromPersona, masc_persona_*, masc_keeper_create_from_persona 등)* 이 모두 사용 → 그대로 유지.

## 배경 — 왜 dead 가 되었나

함수 추가 commit `63f33f904 fix(mcp): align persona generation timeout (#9956)` — persona generation timeout fix PR 에서 추가. *Persona spawn 화면에서 "spawn 한 keeper 종료" 버튼* 이 예정이었지만 후속 UI 미구현. 현재 `keeper-action-panel` + `keeper-detail-lifecycle` 가 *REST 경로 (api/keeper.shutdownKeeper)* 로 처리 → MCP path 는 *대체됨*.

향후 *MCP 경로가 필요한 시점* (다른 권한 흐름, 추가 정보 등) 에 *재구현* 가능. 지금 dead 상태로 두면 다음 작업자가 *어느 path 가 canonical 인지* 모호 — 삭제가 *coding hygiene*.

## 검증

- `pnpm typecheck` PASS (silent)
- `pnpm exec vitest run src/components/keeper-spawn`: 26/26 (3 test files)
- `pnpm exec eslint src/components/keeper-spawn/keeper-spawn-state.ts`: 0 errors

표면 동작 회귀 없음 — 호출 사이트 0 이라 *removal 자체가 회귀 0*. REST 경로 `api/keeper.shutdownKeeper` 의 기존 동작 (keeper-action-panel + keeper-detail-lifecycle) 무변경.

## SSOT 보존의 *근본 형태*

코드 자체가 없으면 drift 도 없음. iter#9-12 rename (동음이의어 → 정책-encode 이름) 보다 더 깔끔 — *dead 쪽 제거* 로 *이름 collision 자동 해소*. 다음 sweep 에서 *cross-file duplicate + 한쪽 호출 0* 패턴은 즉시 dead 후보 마킹.

Refs: `.tmp/dashboard-ssot-inventory.md` (iter#32, shutdownKeeper dead code removal)

## Test plan

- [ ] CI: dashboard typecheck / lint / vitest green
- [ ] keeper-action-panel 에서 keeper shutdown 버튼 클릭 → REST 경로 정상 동작
- [ ] keeper-detail-lifecycle 에서 shutdown → REST 경로 정상 동작
- [ ] persona-browser 등 keeper-spawn UI 정상 (dead function 외 의존성 없음 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
