### PR TITLE
fix(repo): avoid credential id record label collision

### DIFF
--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -27,7 +27,7 @@ let mapping_of_toml toml keeper_id =
           (Printf.sprintf
              "mapping.%s.credential_id must be a string when present" keeper_id)
   in
-  Ok { keeper_id; repository_ids; credential_id }
+  Ok { keeper_id; repository_ids; mapped_credential_id = credential_id }
 
 let credential_type_label = function
   | Github -> "GitHub"
@@ -43,7 +43,7 @@ let toml_of_mapping mapping =
     ]
   in
   let fields =
-    match mapping.credential_id with
+    match mapping.mapped_credential_id with
     | Some id ->
         let id = String.trim id in
         if id = "" then fields
@@ -166,7 +166,7 @@ let credentials_for_keeper ~base_path ~keeper_id =
                   in credential store: %s"
                  id keeper_id msg)
       in
-      (match mapping.credential_id with
+      (match mapping.mapped_credential_id with
       | Some id when String.trim id <> "" ->
           let id = String.trim id in
           let* credential = resolve_credential id in

--- a/lib/repo_manager/repo_manager_types.ml
+++ b/lib/repo_manager/repo_manager_types.ml
@@ -71,7 +71,7 @@ type credential = {
 type keeper_repo_mapping = {
   keeper_id : string;
   repository_ids : string list;
-  credential_id : string option [@default None];
+  mapped_credential_id : string option [@default None];
 }
 [@@deriving yojson, show, eq]
 

--- a/lib/repo_manager/repo_manager_types.mli
+++ b/lib/repo_manager/repo_manager_types.mli
@@ -52,7 +52,7 @@ type credential = {
 type keeper_repo_mapping = {
   keeper_id : string;
   repository_ids : string list;
-  credential_id : string option [@default None];
+  mapped_credential_id : string option [@default None];
 }
 [@@deriving yojson, show, eq]
 

--- a/lib/server/server_routes_http_routes_keeper_repos.ml
+++ b/lib/server/server_routes_http_routes_keeper_repos.ml
@@ -30,7 +30,7 @@ let mapping_json (m : Repo_manager_types.keeper_repo_mapping) : Yojson.Safe.t =
       ("allowed_repos", `List (List.map (fun s -> `String s) m.repository_ids));
       ("allow_all", `Bool allow_all);
       ( "credential_id",
-        match m.credential_id with
+        match m.mapped_credential_id with
         | Some id ->
             let trimmed = String.trim id in
             if trimmed <> "" then `String trimmed else `Null
@@ -72,7 +72,7 @@ let mapping_of_json keeper_id (json : Yojson.Safe.t) :
             {
               Repo_manager_types.keeper_id;
               repository_ids;
-              credential_id;
+              mapped_credential_id = credential_id;
             }
       | Error msg, _ | _, Error msg -> Error msg)
   | _ -> Error "expected JSON object body"
@@ -134,7 +134,7 @@ let credential_type_label = function
 
 let validate_mapping_credential ~base_path
     (mapping : Repo_manager_types.keeper_repo_mapping) =
-  match mapping.credential_id with
+  match mapping.mapped_credential_id with
   | None -> Ok ()
   | Some credential_id -> (
       match Credential_store.find ~base_path credential_id with

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -108,7 +108,7 @@ let seed_single_playground_repo ~config ~(meta : Keeper_types.keeper_meta) playg
   let mapping : Repo_manager_types.keeper_repo_mapping =
     { keeper_id = meta.name
     ; repository_ids = [ "masc-mcp" ]
-    ; credential_id = None
+    ; mapped_credential_id = None
     }
   in
   (match Keeper_repo_mapping.save_mapping ~base_path:config.Coord.base_path mapping with

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -722,7 +722,7 @@ let test_save_mapping_creates_config_dir () =
         {
           keeper_id = "keeper-new";
           repository_ids = [ "repo-a"; "repo-b" ];
-          credential_id = None;
+          mapped_credential_id = None;
         }
       in
       match Keeper_repo_mapping.save_mapping ~base_path mapping with
@@ -740,7 +740,7 @@ let test_save_mapping_preserves_credential_id () =
         {
           keeper_id = "keeper-new";
           repository_ids = ["*"];
-          credential_id = Some "cred-selected";
+          mapped_credential_id = Some "cred-selected";
         }
       in
       match Keeper_repo_mapping.save_mapping ~base_path mapping with
@@ -752,7 +752,7 @@ let test_save_mapping_preserves_credential_id () =
               Alcotest.(check (option string))
                 "credential id"
                 (Some "cred-selected")
-                loaded.credential_id
+                loaded.mapped_credential_id
           | Ok rows ->
               Alcotest.failf "expected one mapping, got %d" (List.length rows)))
 
@@ -765,7 +765,7 @@ let test_load_all_trims_credential_id () =
           Alcotest.(check (option string))
             "trimmed credential id"
             (Some "cred-selected")
-            loaded.credential_id
+            loaded.mapped_credential_id
       | Ok rows -> Alcotest.failf "expected one mapping, got %d" (List.length rows))
 
 let test_load_all_rejects_non_string_credential_id () =

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -365,7 +365,7 @@ let seed_repo_cli_credential_mapping
     {
       keeper_id = keeper_name;
       repository_ids;
-      credential_id = Some credential_id;
+      mapped_credential_id = Some credential_id;
     }
   in
   match

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -126,7 +126,7 @@ let with_registered_repo_fixture f =
          match
            Keeper_repo_mapping.save_mapping
              ~base_path
-             { keeper_id; repository_ids; credential_id = None }
+             { keeper_id; repository_ids; mapped_credential_id = None }
          with
          | Ok () -> ()
          | Error msg -> Alcotest.fail ("mapping setup failed: " ^ msg)


### PR DESCRIPTION
## Summary
- rename keeper repo mapping's internal optional credential field to mapped_credential_id
- keep TOML and HTTP wire shape as credential_id
- avoid OCaml record-label ambiguity with repository.credential_id, which broke repo_sync compilation

## Validation
- opam exec -- ocamlformat --check lib/repo_manager/repo_manager_types.ml lib/repo_manager/repo_manager_types.mli lib/repo_manager/keeper_repo_mapping.ml lib/server/server_routes_http_routes_keeper_repos.ml test/test_keeper_repo_mapping.ml test/test_keeper_fs_edit_patch.ml test/test_worker_dev_tools.ml test/test_keeper_sandbox_docker_route.ml
- git diff --check origin/main...HEAD
- rg -n 'type keeper_repo_mapping|mapped_credential_id|github_credential_id' lib/repo_manager lib/server/server_routes_http_routes_keeper_repos.ml test/test_keeper_repo_mapping.ml test/test_keeper_fs_edit_patch.ml test/test_worker_dev_tools.ml test/test_keeper_sandbox_docker_route.ml
- opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-mapping-credential-label-collision-20260527 --cache=disabled test/test_repo_sync.exe test/test_keeper_repo_mapping.exe test/test_keeper_sandbox_docker_route.exe test/test_worker_dev_tools.exe test/test_keeper_fs_edit_patch.exe