### PR TITLE
fix(keeper): enrich tool-call failure logs

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -81,6 +81,32 @@ let idle_decision_to_label = function
   | Agent_sdk.Hooks.AdjustParams _ -> "adjust_params"
   | Agent_sdk.Hooks.ElicitInput _ -> "elicit_input"
 
+let json_value_shape_for_log = function
+  | `Assoc fields -> Printf.sprintf "object:%d" (List.length fields)
+  | `List values -> Printf.sprintf "array:%d" (List.length values)
+  | `String "" -> "string:empty"
+  | `String value -> Printf.sprintf "string:%d" (String.length value)
+  | `Bool _ -> "bool"
+  | `Int _ | `Intlit _ -> "int"
+  | `Float _ -> "number"
+  | `Null -> "null"
+
+let tool_input_shape_for_log = function
+  | `Assoc fields ->
+    fields
+    |> List.sort (fun (left, _) (right, _) -> String.compare left right)
+    |> List.map (fun (key, value) -> key ^ "=" ^ json_value_shape_for_log value)
+    |> String.concat ","
+  | other -> json_value_shape_for_log other
+
+let one_line_preview_for_log text =
+  text
+  |> String.map (function
+    | '\n' | '\r' | '\t' -> ' '
+    | c -> c)
+  |> String_util.utf8_safe ~max_bytes:240 ~suffix:"..."
+  |> String_util.to_string
+
 let failure_class_of_tool_error_json json =
   let direct = Safe_ops.json_string_opt "failure_class" json in
   let nested =
@@ -490,8 +516,18 @@ let make_hooks
           | Ok { Agent_sdk.Types.content; _ } -> "ok", String.length content
           | Error { Agent_sdk.Types.message; _ } -> "error", String.length message
         in
-        Log.Keeper.info "keeper:%s tool_call tool=%s params=[%s] outcome=%s out_len=%d"
-          (!meta_ref).name tool_name input_keys outcome out_len;
+        let input_shape = tool_input_shape_for_log input in
+        let error_preview =
+          match output with
+          | Ok _ -> "-"
+          | Error _ ->
+            output_text
+            |> Observability_redact.redact_preview ~max_len:240
+            |> one_line_preview_for_log
+        in
+        Log.Keeper.info
+          "keeper:%s tool_call tool=%s params=[%s] input_shape=[%s] outcome=%s out_len=%d error_preview=%s"
+          (!meta_ref).name tool_name input_keys input_shape outcome out_len error_preview;
         (* Persistent tool call I/O log for dashboard inspector.
            tool_start_time is keeper-local (one ref per make_hooks call).
            Tool calls within Agent.run are sequential, so no race. *)


### PR DESCRIPTION
## Summary
- Add structured input-shape logging for keeper tool calls so malformed typed-tool payloads show field shapes, not just key names.
- Add a redacted one-line error preview for failed tool calls to make Execute/schema failures diagnosable from keeper logs.

## Context
- Root OAS fix landed in jeong-sik/oas#1789 and was released as `v0.200.2`.
- Downstream MASC pin bump to `agent_sdk 0.200.2` is already on `origin/main` via #18988.
- Separate OAS main CI regressions found during this work are tracked in jeong-sik/oas#1791.

## Verification
- `ocamlformat --check lib/keeper/keeper_hooks_oas.ml`
- `git diff --check`
- `bash scripts/check-oas-pin.sh --local-only`
- `bash scripts/check-oas-pin.sh`
- `scripts/opam-pin-external-deps.sh --install` installed `agent_sdk 0.200.2` locally

## Not run
- `scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe` was attempted but blocked by unrelated live bare Dune processes outside `scripts/dune-local.sh` on the host.