### PR TITLE
perf(dashboard): cache + Domain_pool offload for board/rooms/doctor

### DIFF
--- a/lib/dashboard/dashboard_rooms.ml
+++ b/lib/dashboard/dashboard_rooms.ml
@@ -223,7 +223,7 @@ let room_json ~config messages =
     ]
 ;;
 
-let json ~config ?me ~limit () =
+let compute_json ~config ?me ~limit () =
   let limit = clamp_limit limit in
   let recent_desc =
     Coord.get_messages_raw config ~since_seq:0 ~limit:(fetch_limit limit)
@@ -246,4 +246,24 @@ let json ~config ?me ~limit () =
     ; "messages", `List messages_json
     ; "mentions_inbox", `List mentions_inbox
     ]
+;;
+
+(* /api/v1/dashboard/rooms was measured at 8-9s under live load.
+   [Coord.get_messages_raw] is a synchronous scan over the message
+   store and was being executed on the Eio main domain, so other
+   HTTP fibers sharing the domain stalled for the duration.  Cache
+   the response with stale-while-revalidate and run the underlying
+   compute on a worker domain via Domain_pool. *)
+let cache_ttl_sec = 5.0
+
+let json ~config ?me ~limit () =
+  let key =
+    Printf.sprintf
+      "dashboard.rooms:%s;%s;%d"
+      config.Coord.base_path
+      (Option.value ~default:"-" me)
+      limit
+  in
+  Dashboard_cache.get_or_compute key ~ttl:cache_ttl_sec (fun () ->
+    Domain_pool_ref.submit_io_or_inline (fun () -> compute_json ~config ?me ~limit ()))
 ;;

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -56,63 +56,72 @@ let dashboard_board_json
       blind_votes
   in
   Dashboard_cache.get_or_compute cache_key ~ttl:10.0 (fun () ->
-    let base_fetch =
-      board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset
-    in
-    (* Fetch one extra beyond the requested page so we can answer has_more
-       without a second query. total is only emitted when the result fits
-       entirely inside the fetched window — otherwise null (unknown). *)
-    let probe_fetch = base_fetch + 1 in
-    let posts =
-      Board_dispatch.list_posts
-        ?hearth
-        ~sort_by
-        ~exclude_system
-        ~exclude_automation
-        ?author_filter
-        ~limit:probe_fetch
-        ()
-    in
-    let karma_map = Board_dispatch.get_all_karma () in
-    let get_karma author = Option.value ~default:0 (List.assoc_opt author karma_map) in
-    let fetched_len = List.length posts in
-    let window_end = offset + limit in
-    let has_more = fetched_len > window_end in
-    let total_json : Yojson.Safe.t = if has_more then `Null else `Int fetched_len in
-    let paged = posts |> drop offset |> take limit in
-    let contributor_quality_for = board_contributor_quality_lookup ?config () in
-    let posts_json =
-      List.map
-        (fun (post : Board.post) ->
-           let author = Board.Agent_id.to_string post.author in
-           let post_id = Board.Post_id.to_string post.id in
-           let current_vote = board_current_vote_for_post ~voter ~post_id in
-           let contributor_quality = contributor_quality_for author in
-           board_post_dashboard_json
-             ~blind_votes
-             ?current_vote
-             ?contributor_quality
-             ~author_karma:(get_karma author)
-             post)
-        paged
-    in
-    `Assoc
-      [ "generated_at", `String (Masc_domain.now_iso ())
-      ; ( "summary"
-        , `Assoc
-            [ "visible_posts", `Int (List.length posts_json)
-            ; "sort_by", `String (board_sort_label sort_by)
-            ; "exclude_system", `Bool exclude_system
-            ; "exclude_automation", `Bool exclude_automation
-            ] )
-      ; "posts", `List posts_json
-      ; "count", `Int (List.length posts_json)
-      ; "limit", `Int limit
-      ; "offset", `Int offset
-      ; "has_more", `Bool has_more
-      ; "total", total_json
-      ; "sort_by", `String (board_sort_label sort_by)
-      ])
+    (* /api/v1/dashboard/board was measured at 30-44s on hot keeper
+       fleets.  The compute below scans the post store, fetches the
+       karma map, and per-post enriches with vote + contributor
+       quality.  Running this on the Eio main domain blocked every
+       other HTTP fiber for the duration.  Domain_pool_ref offloads
+       to a worker domain; the [Dashboard_cache] above keeps user
+       requests on the cache fast-path so they never wait for this
+       refresh. *)
+    Domain_pool_ref.submit_io_or_inline (fun () ->
+      let base_fetch =
+        board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset
+      in
+      (* Fetch one extra beyond the requested page so we can answer has_more
+         without a second query. total is only emitted when the result fits
+         entirely inside the fetched window — otherwise null (unknown). *)
+      let probe_fetch = base_fetch + 1 in
+      let posts =
+        Board_dispatch.list_posts
+          ?hearth
+          ~sort_by
+          ~exclude_system
+          ~exclude_automation
+          ?author_filter
+          ~limit:probe_fetch
+          ()
+      in
+      let karma_map = Board_dispatch.get_all_karma () in
+      let get_karma author = Option.value ~default:0 (List.assoc_opt author karma_map) in
+      let fetched_len = List.length posts in
+      let window_end = offset + limit in
+      let has_more = fetched_len > window_end in
+      let total_json : Yojson.Safe.t = if has_more then `Null else `Int fetched_len in
+      let paged = posts |> drop offset |> take limit in
+      let contributor_quality_for = board_contributor_quality_lookup ?config () in
+      let posts_json =
+        List.map
+          (fun (post : Board.post) ->
+             let author = Board.Agent_id.to_string post.author in
+             let post_id = Board.Post_id.to_string post.id in
+             let current_vote = board_current_vote_for_post ~voter ~post_id in
+             let contributor_quality = contributor_quality_for author in
+             board_post_dashboard_json
+               ~blind_votes
+               ?current_vote
+               ?contributor_quality
+               ~author_karma:(get_karma author)
+               post)
+          paged
+      in
+      `Assoc
+        [ "generated_at", `String (Masc_domain.now_iso ())
+        ; ( "summary"
+          , `Assoc
+              [ "visible_posts", `Int (List.length posts_json)
+              ; "sort_by", `String (board_sort_label sort_by)
+              ; "exclude_system", `Bool exclude_system
+              ; "exclude_automation", `Bool exclude_automation
+              ] )
+        ; "posts", `List posts_json
+        ; "count", `Int (List.length posts_json)
+        ; "limit", `Int limit
+        ; "offset", `Int offset
+        ; "has_more", `Bool has_more
+        ; "total", total_json
+        ; "sort_by", `String (board_sort_label sort_by)
+        ]))
 ;;
 
 let dashboard_memory_http_json ?config request : Yojson.Safe.t =

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -360,23 +360,42 @@ let rec add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/doctor" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let self_bin = dashboard_doctor_self_bin () in
-         try
-           let buf, _status =
-             With_process.with_process_args_in
-               self_bin
-               [| self_bin; "doctor"; "all"; "--json" |]
-               (With_process.drain_to_buffer ~chunk:4096)
-           in
-           Http.Response.json
-             ~compress:true
-             ~request:req
-             (Buffer.contents buf)
-             reqd
-         with
-         | Eio.Cancel.Cancelled _ as exn -> raise exn
-         | exn ->
-           let degraded = dashboard_doctor_degraded_json ~self_bin ~exn in
-           Http.Response.json ~compress:true ~request:req degraded reqd
+         (* /api/v1/dashboard/doctor previously fork-exec'd the server
+            binary on every request and drained its JSON stdout
+            synchronously on the Eio main domain.  Both costs (process
+            spawn and the doctor scan itself) blocked every other HTTP
+            fiber sharing the domain.  Cache the response per self_bin
+            with stale-while-revalidate, and run the spawn on a worker
+            domain via [Domain_pool_ref]. *)
+         let cache_key = "dashboard.doctor:" ^ self_bin in
+         let payload =
+           Dashboard_cache.get_or_compute cache_key ~ttl:30.0 (fun () ->
+             Domain_pool_ref.submit_io_or_inline (fun () ->
+               try
+                 let buf, _status =
+                   With_process.with_process_args_in
+                     self_bin
+                     [| self_bin; "doctor"; "all"; "--json" |]
+                     (With_process.drain_to_buffer ~chunk:4096)
+                 in
+                 (* Parse so the cache stores a structured value rather than
+                    a raw string; serialised back below. *)
+                 try Yojson.Safe.from_string (Buffer.contents buf) with
+                 | Yojson.Json_error _ ->
+                   Yojson.Safe.from_string
+                     (dashboard_doctor_degraded_json ~self_bin
+                        ~exn:(Failure "doctor returned invalid JSON"))
+               with
+               | Eio.Cancel.Cancelled _ as exn -> raise exn
+               | exn ->
+                 Yojson.Safe.from_string
+                   (dashboard_doctor_degraded_json ~self_bin ~exn)))
+         in
+         Http.Response.json
+           ~compress:true
+           ~request:req
+           (Yojson.Safe.to_string payload)
+           reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/governance" (fun request reqd ->
        with_public_read (fun state req reqd ->


### PR DESCRIPTION
## 요약

세 개의 무거운 대시보드 endpoint(`/api/v1/dashboard/board`, `/api/v1/dashboard/rooms`, `/api/v1/dashboard/doctor`)가 Eio 메인 도메인을 sync compute로 묶어 다른 모든 HTTP 요청을 stall 시키던 문제를 잡습니다. #18991(branches)에서 확립한 동일 패턴(`Dashboard_cache.get_or_compute` + `Domain_pool_ref.submit_io_or_inline`)을 일관 적용.

## 측정 (cold, single request)

| endpoint | 변경 전 | 변경 후 |
|---|---|---|
| `/api/v1/dashboard/board` | **44.4s** | main 회복 후 측정 첨부 (cache hit < 5ms 예상) |
| `/api/v1/dashboard/rooms` | **8.98s** | 동일 |
| `/api/v1/dashboard/doctor` | self-fork-exec 매 요청 | 30s TTL 캐시 |

Eio 공식 문서:
> "When a fiber executes CPU-bound or blocking I/O work without yielding control, it blocks all other fibers in that domain."

## Root cause

### board (44s)
이미 `Dashboard_cache.get_or_compute` 사용 중이었으나, **compute closure가 메인 도메인에서 sync 실행**. `Board_dispatch.list_posts` 스캔 + `get_all_karma` + per-post `board_post_dashboard_json` enrichment가 통째로 메인 도메인을 묶었음. `submit_io_or_inline` 누락.

### rooms (9s)
**캐시 자체가 없음**. 매 요청마다 `Coord.get_messages_raw config ~since_seq:0 ~limit:fetched` 가 메시지 스토어를 sync 스캔. 같은 도메인의 다른 fiber 정지.

### doctor (self-fork-exec)
매 요청마다 `With_process.with_process_args_in self_bin [|self_bin; "doctor"; "all"; "--json"|]` 로 **server 자신을 fork-exec**. spawn 비용 + doctor scan 비용이 메인 도메인에 누적. 캐시 없음.

## 변경 (3 파일, +123 / -75)

### `lib/dashboard/dashboard_rooms.ml`
- `json`을 `compute_json`로 rename하고 새 `json`을 `Dashboard_cache.get_or_compute ~ttl:5.0` + `Domain_pool_ref.submit_io_or_inline` 래퍼로 교체. key는 `base_path/me/limit` 조합.

### `lib/server/server_dashboard_http.ml`
- `dashboard_board_json` 내부의 `Dashboard_cache.get_or_compute` compute closure를 `Domain_pool_ref.submit_io_or_inline`로 감쌈. 다른 변경 없음 — 캐시 키, TTL, 응답 스키마 동일.

### `lib/server/server_routes_http_routes_dashboard.ml`
- `/api/v1/dashboard/doctor` 핸들러를 `Dashboard_cache.get_or_compute ~ttl:30.0` + `Domain_pool_ref.submit_io_or_inline` 래퍼로 교체. degraded JSON path는 `Yojson.Safe.from_string`로 parse back하여 cache value type에 맞춤.

## 검증

- 3 모듈 모두 bytecode 빌드 통과 (`dune build _build/default/lib/.masc_mcp.objs/byte/masc_mcp__{Dashboard_rooms,Server_dashboard_http,Server_routes_http_routes_dashboard}.cmo`).
- 응답 JSON 스키마 변경 0 — 캐시/오프로드만 추가, compute 로직 무변경.
- ⚠️ Main 자체가 `Agent_sdk.Error.AgentExecutionTimeout` variant 분파일 patch 누락으로 broken — 풀 빌드 및 curl 측정은 main 회복 후 별도 commit/comment로 첨부.

## Workaround Signature Gate

CLAUDE.md §워크어라운드 거부 기준 7항목 모두 비해당:
1. telemetry-as-fix ❌ (실제 fix — cache + offload)
2. string/substring/prefix 분류기 추가 ❌
3. N-of-M 패치 ❌ (3 endpoint 묶음 PR이지만 surgical, 같은 패턴 일괄 적용)
4. catch-all `_ ->` 추가 ❌
5. cap/cooldown/dedup/repair ❌
6. test backdoor ❌
7. typo 반복 fix ❌

## 후속 PR 후보

- `/health` probe (cold 4-8s): `compute_full_health_snapshot`을 Domain_pool offload + `keeper_fleet_safety_health_json` single-pass scan 재사용
- `Auth.load_auth_config` mtime+sha 캐시
- `/api/v1/dashboard/keeper-feature-proof` (3.3s) — 같은 패턴 검토 필요

## Related

- #18991 (branches): 같은 패턴(cache + Domain_pool)을 첫 적용 (53s → ms)
