### PR TITLE
perf(health): offload full health snapshot refresh to a worker domain

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -799,7 +799,19 @@ let start_full_health_snapshot_refresh_loop ~sw ~clock =
         warm_delay_s = 0.5;
         warn_first_failure = false;
       }
-    ~compute:(fun () -> compute_full_health_snapshot_for_refresh request)
+    (* /health probe (5KB probe payload) was measured at 4-8s cold.
+       Even though [Proactive_refresh] runs [compute] on its own
+       fiber, that fiber lives on the Eio main domain — so the 6-10s
+       fleet meta scan inside [compute_full_health_snapshot_for_refresh]
+       blocked every other HTTP fiber for the duration (Eio cooperative
+       scheduling: no yield points inside the synchronous compute).
+
+       Offload to a worker domain via [Domain_pool_ref].  The probe
+       payload is served from the cached snapshot; refresh runs off
+       the main domain so concurrent HTTP requests are not stalled. *)
+    ~compute:(fun () ->
+      Domain_pool_ref.submit_io_or_inline (fun () ->
+        compute_full_health_snapshot_for_refresh request))
     ~on_result:store_full_health_snapshot
 
 module For_testing = struct


### PR DESCRIPTION
## 요약

`/health` probe(5KB payload)가 cold 시점에 4-8초 걸리던 문제. `Proactive_refresh.start`가 별도 fiber로 백그라운드 refresh를 돌렸지만, 그 fiber가 **Eio 메인 도메인**에 있어 6-10s 동안 도메인을 묶었습니다. 같은 도메인의 다른 HTTP fiber가 모두 멈춤. `~compute` 콜백을 `Domain_pool_ref.submit_io_or_inline`로 감싸 worker 도메인에 분리.

## 측정

| 시점 | latency |
|---|---|
| 변경 전 `/health` probe cold | **4.44s** (5KB) |
| 변경 전 `/health?full=1` build duration_ms | **10281ms** internal |
| 변경 전 5 concurrent `/health` TTL 만료 직후 | 2개=4.23s, 3개=6.5s — 정확히 2× single-domain stall 시그니처 |
| 변경 전 `section_timings` | `keeper_fleet_safety` 6711ms, `paused_keepers` 1627ms |
| 변경 후 probe | main 회복 후 별도 commit/comment로 첨부 (목표: cache hit 캐시 응답 < 5ms, refresh는 main domain 미점유) |

Eio 공식 문서:
> "When a fiber executes CPU-bound or blocking I/O work without yielding control, it blocks all other fibers in that domain."

## Root cause

`start_full_health_snapshot_refresh_loop`이 `Proactive_refresh.start ~compute:(fun () -> compute_full_health_snapshot_for_refresh request)` 로 설정. `Proactive_refresh`는 자체 fiber로 돌지만 그 fiber도 **메인 도메인**. 내부 compute가 cooperative yield 없이 6-10s — `paused_keepers_health_json` + `keeper_fleet_safety_health_json` (3중복 keeper meta scan) + `cdal_health_json` 누적.

이 시간 동안 같은 도메인의 다른 모든 HTTP fiber 정지. 동시 5 probe → 2/3 그룹 분할이 그 시그니처(`reference_masc_mcp_*` 메모에 정확히 일치).

`Eio.Domain_manager` 또는 `Eio.Executor_pool`은 masc-mcp 코드베이스에 이미 `lib/core/domain_pool.mli` (RFC-0059 PR-6)로 래핑되어 있는데, health refresh hot path에서는 0번 사용 중.

## 변경 (1 파일, +13 / -1)

`lib/server/server_routes_http_runtime.ml:786-803` `start_full_health_snapshot_refresh_loop`:

```ocaml
  ~compute:(fun () ->
    Domain_pool_ref.submit_io_or_inline (fun () ->
      compute_full_health_snapshot_for_refresh request))
```

- Refresh는 worker 도메인에서 실행
- 사용자 요청 path는 캐시된 snapshot에서 즉시 응답 (이미 구현돼 있던 `make_cached_full_health_json`)
- `Domain_pool` 미초기화 환경(tests 등)에서는 `submit_io_or_inline`이 inline fallback이라 동작 호환

## 검증

- `dune build _build/default/lib/.masc_mcp.objs/byte/masc_mcp__Server_routes_http_runtime.cmo` 성공.
- `Domain_pool_ref` 이미 server bootstrap에서 초기화 (`server_runtime_bootstrap.ml:657 Domain_pool.create`).
- `Proactive_refresh`의 timeout/error path 동일하게 유지 (`~timeout_s`, `on_error`).
- ⚠️ Main 자체가 `Agent_sdk.Error.AgentExecutionTimeout` variant 분파일 patch 누락으로 broken — 풀 빌드 / curl 측정은 main 회복 후 별도 commit으로 첨부.

## Workaround Signature Gate

CLAUDE.md §워크어라운드 거부 기준 7항목 비해당:
1. telemetry-as-fix ❌ (실제 fix)
2. string/substring/prefix 분류기 추가 ❌
3. N-of-M 패치 ❌
4. catch-all `_ ->` 추가 ❌
5. cap/cooldown/dedup/repair ❌
6. test backdoor ❌
7. typo 반복 fix ❌

## 후속 PR 후보

- `keeper_fleet_safety_health_json` single-pass scan 재사용 (이미 `keeper_fleet_meta_scan` 함수 있음. 3중복 read → 1 pass, 6.7s+1.6s → ~1-2s)
- `Auth.load_auth_config` mtime+sha 캐시
- `tcp_port_reachable` `Unix.connect` 제거 (in-memory metric만 신뢰)

## Related

- #18991 (branches: 53s → ms, 같은 cache + Domain_pool 패턴)
- #18993 (board/rooms/doctor: cache + Domain_pool 일괄)
