### PR TITLE
refactor(dashboard/components): consolidate filled-button base class string

### DIFF
--- a/dashboard/src/components/common/button-filled-base.ts
+++ b/dashboard/src/components/common/button-filled-base.ts
@@ -1,0 +1,27 @@
+/**
+ * Filled-button base class string.
+ *
+ * Three component files (`credential-settings.ts`, `keeper-repo-mapping.ts`,
+ * `keeper-config-panel.ts`) each shipped a byte-identical local
+ * `const btnBase = 'py-1.5 px-4 rounded-[var(--r-1)] text-xs font-semibold cursor-pointer border-none'`
+ * and used it as the prefix for `${btnBase} bg-X text-Y` filled buttons.
+ *
+ * Note on `ActionButton` (../common/button.ts): that component is the
+ * canonical SSOT for buttons but its variants resolve through the
+ * component-level token layer (`--button-ok-bg`, `--button-primary-bg`,
+ * etc.), whereas the call sites here paint with raw role tokens
+ * (`--color-status-ok`, `--color-bg-hover`, `--purple`). Migrating each
+ * call site onto `ActionButton` requires deciding how the raw-token
+ * palette maps onto component-level tokens — a design call that lives
+ * outside an SSOT-extraction sweep. Until then, this constant captures
+ * the shared shape (padding, radius, text size/weight, cursor, no border)
+ * so the three files stop drifting.
+ *
+ * A fourth file (`components/keeper-shared.ts`) ships a separate
+ * `const btnBase = '… text-xs font-medium cursor-pointer transition-colors border'`
+ * — visually a different design intent (outlined / transitioned) and
+ * deliberately left unchanged here. The shared name there is a homonym,
+ * not a missed SSOT.
+ */
+export const BTN_FILLED_BASE =
+  'py-1.5 px-4 rounded-[var(--r-1)] text-xs font-semibold cursor-pointer border-none'

--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -21,6 +21,7 @@ const DEFAULT_OAUTH_METHOD: CredentialOauthMethod = 'web'
 import { createAsyncResource } from '../lib/async-state'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
+import { BTN_FILLED_BASE } from './common/button-filled-base'
 
 export {
   coerceCredentialType,
@@ -236,8 +237,7 @@ export function CredentialSettings() {
     }
   }
 
-  const btnBase = 'py-1.5 px-4 rounded-[var(--r-1)] text-xs font-semibold cursor-pointer border-none'
-  const fieldStyle = 'w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded-[var(--r-1)] py-2 px-3 font-sans focus:outline-none focus:border-accent-fg/50 focus:ring-1 focus:ring-accent-fg/50 transition-[border-color,box-shadow] duration-[var(--t-med)] shadow-inset'
+  const fieldStyle ='w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded-[var(--r-1)] py-2 px-3 font-sans focus:outline-none focus:border-accent-fg/50 focus:ring-1 focus:ring-accent-fg/50 transition-[border-color,box-shadow] duration-[var(--t-med)] shadow-inset'
   const helperStyle = 'mt-1 text-3xs leading-relaxed text-text-dim'
 
   return html`
@@ -246,7 +246,7 @@ export function CredentialSettings() {
         <h2 class="text-sm font-bold text-text-strong">크리덴셜 관리</h2>
         <button
           type="button"
-          class="${btnBase} bg-[var(--purple)] text-[var(--color-bg-0)]"
+          class="${BTN_FILLED_BASE} bg-[var(--purple)] text-[var(--color-bg-0)]"
           onClick=${() => {
             showAddForm.value = !isAdding
             if (!isAdding) resetAddDraft()
@@ -386,7 +386,7 @@ export function CredentialSettings() {
             <div class="flex gap-2 mt-1">
               <button
                 type="button"
-                class="${btnBase} bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)]"
+                class="${BTN_FILLED_BASE} bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)]"
                 onClick=${handleSave}
                 disabled=${isSaving}
               >
@@ -394,7 +394,7 @@ export function CredentialSettings() {
               </button>
               <button
                 type="button"
-                class="${btnBase} bg-[var(--color-bg-hover)] text-text-body"
+                class="${BTN_FILLED_BASE} bg-[var(--color-bg-hover)] text-text-body"
                 onClick=${() => { showAddForm.value = false; resetAddDraft() }}
               >
                 취소

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -19,6 +19,7 @@ import { formatTokens, formatPct, formatCost } from '../lib/format-number'
 import { isVerifierRoleKeeper } from '../lib/keeper-utils'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
+import { BTN_FILLED_BASE } from './common/button-filled-base'
 import { KeeperToolAccessSummary } from './keeper-tool-access'
 import { createAsyncResource, loaded } from '../lib/async-state'
 import { SetupGuideCard } from './setup-guide-card'
@@ -705,25 +706,23 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     }
   }
 
-  const btnBase = 'py-1.5 px-4 rounded-[var(--r-1)] text-xs font-semibold cursor-pointer border-none'
-
   // --- Toolbar ---
   const toolbar = html`
     <div class="flex gap-2 items-center mb-3">
       ${isEditing ? html`
         <button type="button"
-          class="${btnBase} bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)]"
+          class="${BTN_FILLED_BASE} bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)]"
           onClick=${saveConfig}
           disabled=${isSaving}
         >${isSaving ? '저장 중...' : '저장'}</button>
         <button type="button"
-          class="${btnBase} bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)]"
+          class="${BTN_FILLED_BASE} bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)]"
           onClick=${cancelEdit}
           disabled=${isSaving}
         >취소</button>
       ` : html`
         <button type="button"
-          class="${btnBase} bg-[var(--purple)] text-[var(--color-bg-0)]"
+          class="${BTN_FILLED_BASE} bg-[var(--purple)] text-[var(--color-bg-0)]"
           title="편집: 프롬프트 편집 모드로 진입합니다"
           onClick=${enterEditMode}
         >편집하기</button>
@@ -1100,12 +1099,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ${runtimeHasChanges ? html`
         <div class="flex gap-2 items-center mt-4 mb-2 p-3 rounded-[var(--r-1)] border border-[var(--accent-30)] bg-[var(--accent-5)]">
           <button type="button"
-            class="${btnBase} bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)]"
+            class="${BTN_FILLED_BASE} bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)]"
             onClick=${saveRuntimeConfig}
             disabled=${runtimeSaving.value}
           >${runtimeSaving.value ? '저장 중...' : '런타임 설정 저장'}</button>
           <button type="button"
-            class="${btnBase} bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)]"
+            class="${BTN_FILLED_BASE} bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)]"
             title="초기화: 변경한 런타임 설정 draft 를 서버 값으로 되돌립니다"
             onClick=${resetRuntimeDraft}
           >초기화하기</button>

--- a/dashboard/src/components/keeper-repo-mapping.ts
+++ b/dashboard/src/components/keeper-repo-mapping.ts
@@ -14,6 +14,7 @@ import { fetchRepositoriesList } from '../api/repositories'
 import { createAsyncResource } from '../lib/async-state'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
+import { BTN_FILLED_BASE } from './common/button-filled-base'
 import {
   credentialStateBadgeClass,
   credentialStateLabel,
@@ -320,8 +321,6 @@ export function KeeperRepoMapping() {
   const mappings = mState.status === 'loaded' ? mState.data : []
   const mappingByKeeper = new Map(mappings.map(m => [m.keeper_id, m]))
 
-  const btnBase = 'py-1.5 px-4 rounded-[var(--r-1)] text-xs font-semibold cursor-pointer border-none'
-
   async function handleSave(keeperId: string) {
     const draft = draftMappings.value.get(keeperId)
     if (draft === undefined) return
@@ -376,7 +375,7 @@ export function KeeperRepoMapping() {
         <h2 class="text-sm font-bold text-text-strong">키퍼 저장소 매핑</h2>
         <button
           type="button"
-          class="${btnBase} bg-[var(--color-bg-hover)] text-text-body"
+          class="${BTN_FILLED_BASE} bg-[var(--color-bg-hover)] text-text-body"
           onClick=${() => loadKeeperRepoMappings({ force: true })}
         >
           새로고침
@@ -447,7 +446,7 @@ export function KeeperRepoMapping() {
                     ` : null}
                     <button
                       type="button"
-                      class="${btnBase} bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)] py-1 px-3 text-2xs"
+                      class="${BTN_FILLED_BASE} bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)] py-1 px-3 text-2xs"
                       onClick=${() => handleSave(keeperId)}
                       disabled=${isSaving || !changed}
                     >


### PR DESCRIPTION
## 요약
`btnBase` 4 사이트 중 3 byte-identical 정의를 `BTN_FILLED_BASE` SSOT 로 통합했습니다. `keeper-shared.ts` 의 4번째 정의는 *다른 design intent* (outlined / transition) 라 의도적으로 동음이의어로 유지합니다.

## 배경
`rg "const btnBase = "` 결과 4 파일에서 발견:

| 파일 | 정의 | 사용 패턴 |
|---|---|---|
| `credential-settings.ts:239` | `'py-1.5 px-4 rounded-[var(--r-1)] text-xs font-semibold cursor-pointer border-none'` | `${btnBase} bg-X text-Y` × 3 |
| `keeper-repo-mapping.ts:323` | (byte-identical) | `${btnBase} bg-X text-Y` × 2 |
| `keeper-config-panel.ts:708` | (byte-identical) | `${btnBase} bg-X text-Y` × 6 |
| `keeper-shared.ts:415` | `'… text-xs font-medium cursor-pointer transition-colors border'` | outlined/ghost variants |

3 동일 사이트 모두 *filled button* (배경색 직접 지정, 윤곽 없음) 의도. `keeper-shared.ts` 는 *outlined button* (border + transition + medium weight) 의도. 시각적/의도적으로 다른 design vocabulary.

## ActionButton 우회 메타 발견
`components/common/button.ts` 의 `ActionButton` 이 *공식 SSOT*. 4 사이트가 *이미 존재하는 컴포넌트를 우회* 하고 inline class string 사용 중입니다. ActionButton variants 는 component-level token (`--button-ok-bg`, `--button-primary-bg` 등) 사용하는 반면, callsite 는 raw role token (`--color-status-ok`, `--color-bg-hover`, `--purple`) 직접 사용 — 디자인 토큰 매핑 결정이 필요해서 callsite migration 은 별도 PR scope 입니다. 본 PR 은 그때까지 3 사이트의 drift 만 방지합니다.

## 변경
- `dashboard/src/components/common/button-filled-base.ts` 신설 — `BTN_FILLED_BASE` export + JSDoc (homonym 의도 + ActionButton migration deferred 이유 명시)
- 3 사이트: local `const btnBase` 삭제, `BTN_FILLED_BASE` import, `${btnBase}` → `${BTN_FILLED_BASE}` rename
- `keeper-shared.ts` 의 다른 `btnBase` (outlined) 는 그대로 (동음이의어 의도)

## 검증
- typecheck PASS
- lint 0 errors
- vitest 528 passed | 1 failed (auth-status.a11y popover axe = pre-existing baseline, iter#23/27 측정값과 동일, 본 PR 변경과 무관)
- 시각적 변경 0 (byte-identical class string, 단순 reference 교체)

## /loop iter#33
SSOT 위반 dashboard 축출 loop 의 iter#33. cumulative 33 PR (21 머지 + 1 OPEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

RFC-WAIVED: pure className SSOT refactor (credential/auth/repo 도메인 로직 변경 0건). 변경된 4 파일 모두 `const btnBase` local 정의 삭제 + `BTN_FILLED_BASE` import + reference rename. byte-identical class string 으로 시각적 변경 없음.
