### PR TITLE
fix(telemetry): supervisor child context, board load timing (v0.19.32)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 (using menhir 3.0)
 
 (name masc_mcp)
-(version 0.19.31)
+(version 0.19.32)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)

--- a/lib/board_votes_json.ml
+++ b/lib/board_votes_json.ml
@@ -170,6 +170,7 @@ let load_persisted_posts store =
   then Ok 0
   else
     try
+      let t0 = Time_compat.now () in
       let now = Time_compat.now () in
       let loaded = ref 0 in
       let lines = Fs_compat.load_jsonl path in
@@ -184,9 +185,10 @@ let load_persisted_posts store =
            | _ -> ())
         lines;
       store.post_count := Hashtbl.length store.posts;
+      let elapsed = Time_compat.now () -. t0 in
       if !loaded > 0
-      then Log.BoardLog.info "loaded %d posts from %s" !loaded path
-      else Log.BoardLog.debug "loaded 0 posts from %s" path;
+      then Log.BoardLog.info "loaded %d posts from %s in %.3fs" !loaded path elapsed
+      else Log.BoardLog.debug "loaded 0 posts from %s in %.3fs" path elapsed;
       Ok !loaded
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
@@ -199,6 +201,7 @@ let load_persisted_comments store =
   then Ok 0
   else
     try
+      let t0 = Time_compat.now () in
       let now = Time_compat.now () in
       let loaded = ref 0 in
       let lines = Fs_compat.load_jsonl path in
@@ -222,9 +225,10 @@ let load_persisted_comments store =
              incr loaded
            | _ -> ())
         lines;
+      let elapsed = Time_compat.now () -. t0 in
       if !loaded > 0
-      then Log.BoardLog.info "loaded %d comments from %s" !loaded path
-      else Log.BoardLog.debug "loaded 0 comments from %s" path;
+      then Log.BoardLog.info "loaded %d comments from %s in %.3fs" !loaded path elapsed
+      else Log.BoardLog.debug "loaded 0 comments from %s in %.3fs" path elapsed;
       Ok !loaded
     with
     | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/supervisor.ml
+++ b/lib/supervisor.ml
@@ -67,7 +67,7 @@ let restart_limit_exceeded cs =
     On failure, logs and applies restart policy. *)
 let rec start_child ~sw ~clock cs =
   if cs.disabled then begin
-    Log.Server.info "[Supervisor] skipping disabled child: %s" cs.spec.name
+    Log.Server.info ~ctx:cs.spec.name "[Supervisor] skipping disabled child: %s" cs.spec.name
   end else begin
     cs.running <- true;
     Eio.Fiber.fork ~sw (fun () ->
@@ -75,21 +75,21 @@ let rec start_child ~sw ~clock cs =
       try
         cs.spec.start ();
         cs.running <- false;
-        Log.Server.info "[Supervisor] child %s exited normally" name
+        Log.Server.info ~ctx:name "[Supervisor] child %s exited normally" name
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         cs.running <- false;
         let msg = Printexc.to_string exn in
-        Log.Server.warn "[Supervisor] child %s crashed: %s" name msg;
+        Log.Server.warn ~ctx:name "[Supervisor] child %s crashed: %s" name msg;
 
         match cs.spec.strategy with
         | Temporary ->
-            Log.Server.info "[Supervisor] child %s is temporary, not restarting" name
+            Log.Server.info ~ctx:name "[Supervisor] child %s is temporary, not restarting" name
         | Transient when exn = Exit ->
-            Log.Server.info "[Supervisor] child %s transient normal exit" name
+            Log.Server.info ~ctx:name "[Supervisor] child %s transient normal exit" name
         | Permanent | Transient ->
             if restart_limit_exceeded cs then begin
               cs.disabled <- true;
-              Log.Server.error "[Supervisor] child %s DISABLED: %d restarts in %.0fs"
+              Log.Server.error ~ctx:name "[Supervisor] child %s DISABLED: %d restarts in %.0fs"
                 name cs.spec.max_restarts cs.spec.restart_window_s
             end else begin
               cs.restart_count <- cs.restart_count + 1;


### PR DESCRIPTION
## Summary
- **P1**: `supervisor.ml` — all 6 per-child `Log.Server` calls now pass `~ctx:name` so child identity appears as structured context (was `null`)
- **P2**: `board_votes_json.ml` — `load_persisted_posts` and `load_persisted_comments` now log elapsed time, enabling slow-disk detection
- Version bump to 0.19.32

## Test plan
- [ ] Verify supervisor log lines show `ctx=<child_name>` instead of `ctx=null`
- [ ] Verify board load logs include `in X.XXXs` timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)