### PR TITLE
fix(tool-input): honor oneOf forbidden field presence

### DIFF
--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -144,6 +144,7 @@ let typed_shell_unsupported_field_hint schema names =
 type one_of_branch = {
   required : string list;
   consts : (string * Yojson.Safe.t) list;
+  forbidden_required : string list;
 }
 
 let one_of_branch_constraints schema =
@@ -170,7 +171,12 @@ let one_of_branch_constraints schema =
                    props
                | _ -> []
              in
-             Some { required; consts })
+             let forbidden_required =
+               match Yojson.Safe.Util.member "not" branch with
+               | `Assoc _ as not_schema -> required_names not_schema
+               | _ -> []
+             in
+             Some { required; consts; forbidden_required })
         branches
     in
     if List.length constraints = List.length branches then constraints else []
@@ -203,6 +209,7 @@ let one_of_required_shape_error schema = function
         | Some (`List []) -> false
         | Some _ -> true
       in
+      let key_is_present name = Option.is_some (List.assoc_opt name fields) in
       let const_field_matches name expected =
         match List.assoc_opt name fields with
         | Some actual -> Yojson.Safe.equal actual expected
@@ -210,6 +217,7 @@ let one_of_required_shape_error schema = function
       in
       let branch_matches branch =
         List.for_all has_present branch.required
+        && not (List.exists key_is_present branch.forbidden_required)
         && List.for_all
              (fun (name, expected) -> const_field_matches name expected)
              branch.consts

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1122,10 +1122,10 @@ let test_registered_hook_required_enum_blank_is_not_stripped () =
 (* Test: oneOf with empty/null values (regression guard)             *)
 (* ================================================================ *)
 
-(** Shape-validation boundary: an empty [pipeline = []] is treated as absent by
-    the lightweight oneOf pre-hook, so this layer forwards the payload. The
-    typed Execute parser still rejects any [executable] + [pipeline] field pair
-    before dispatch. *)
+(** Shape-validation boundary: [not: {required: ["pipeline"]}] must treat the
+    [pipeline] key as present even when its value is an empty array. Otherwise
+    validation forwards a payload that the typed Execute parser rejects as an
+    [executable] + [pipeline] mutually-exclusive pair. *)
 let test_validate_args_tool_execute_exec_with_empty_pipeline () =
   let args =
     `Assoc
@@ -1140,13 +1140,14 @@ let test_validate_args_tool_execute_exec_with_empty_pipeline () =
       ~args
       ()
   with
-  | Ok forwarded ->
-    Alcotest.(check string) "executable preserved" "pwd"
-      (assoc_string "executable" forwarded)
   | Error result ->
+    let msg = Yojson.Safe.to_string (Tool_result.data result) in
+    Alcotest.(check bool) "mentions exact-one-of" true
+      (string_contains msg "exactly one of")
+  | Ok forwarded ->
     Alcotest.failf
-      "expected tool_execute with executable + empty pipeline to pass, got %s"
-      (Yojson.Safe.to_string (Tool_result.data result))
+      "expected tool_execute with executable + empty pipeline to fail, got %s"
+      (Yojson.Safe.to_string forwarded)
 
 (** stages is not a tool_execute input field. Sending stages in args triggers
     additionalProperties rejection since the schema declares
@@ -1186,13 +1187,14 @@ let test_validate_args_tool_execute_pipeline_rejects_null_exec () =
       ~args
       ()
   with
-  | Ok forwarded ->
-    Alcotest.(check bool) "executable not in forwarded" true
-      (Yojson.Safe.Util.member "executable" forwarded = `Null)
   | Error result ->
+    let msg = Yojson.Safe.to_string (Tool_result.data result) in
+    Alcotest.(check bool) "mentions exact-one-of" true
+      (string_contains msg "exactly one of")
+  | Ok forwarded ->
     Alcotest.failf
-      "expected tool_execute pipeline with null exec to pass shape validation, got %s"
-      (Yojson.Safe.to_string (Tool_result.data result))
+      "expected tool_execute pipeline with null exec to fail, got %s"
+      (Yojson.Safe.to_string forwarded)
 
 (* ================================================================ *)
 (* Test: oneOf with const discriminator                              *)


### PR DESCRIPTION
## Summary
- Make tool input oneOf shape validation honor not.required branch constraints
- Treat forbidden keys as present even when their value is null or an empty array, matching typed Execute parser semantics
- Flip tool_execute regressions so executable+empty pipeline and pipeline+null executable fail before handler dispatch

## Validation
- ocamlformat --check lib/tool_input_validation.ml test/test_tool_input_validation.ml
- git diff --check
- blocked: scripts/dune-local.sh build ./test/test_tool_input_validation.exe refused because existing bare dune processes are running outside scripts/dune-local.sh