### PR TITLE
fix(agent-sdk): handle AgentExecutionTimeout in 6 missed sites (#18988 closeout)

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -159,6 +159,7 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
   (* Other Agent error variants are structural (budget, idle, exit, retries,
      guardrails, tripwires) and would recur on any model — not cascadeable. *)
   | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
+  | Agent_sdk.Error.Agent (AgentExecutionTimeout _)
   | Agent_sdk.Error.Agent (TokenBudgetExceeded _)
   | Agent_sdk.Error.Agent (CostBudgetExceeded _)
   | Agent_sdk.Error.Agent (CostBudgetUnenforceable _)

--- a/lib/cascade/cascade_event_bridge_error_json.ml
+++ b/lib/cascade/cascade_event_bridge_error_json.ml
@@ -172,6 +172,14 @@ let sdk_agent_error_fields = function
     ; "participant_name", (match participant_name with Some n -> `String n | None -> `Null)
     ; "question", `String question
     ]
+  | Agent_sdk.Error.AgentExecutionTimeout
+      { elapsed_sec; timeout_sec; turn_count; max_turns } ->
+    [ "variant", `String "agent_execution_timeout"
+    ; "elapsed_sec", `Float elapsed_sec
+    ; "timeout_sec", `Float timeout_sec
+    ; "turn_count", `Int turn_count
+    ; "max_turns", `Int max_turns
+    ]
 ;;
 
 let sdk_mcp_error_fields = function

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -79,6 +79,10 @@ let sdk_termination_semantics = function
     Provider_wall_clock_timeout
   | Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _) ->
     Oas_turn_budget_exhausted
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionTimeout _) ->
+    (* agent_sdk 0.200.2 (#18988): wall-clock deadline analog of
+       MaxTurnsExceeded — both represent runtime budget exhaustion. *)
+    Oas_turn_budget_exhausted
   | Agent_sdk.Error.Agent (Agent_sdk.Error.IdleDetected _) ->
     Oas_idle_budget_exhausted
   | Agent_sdk.Error.Agent (Agent_sdk.Error.ExitConditionMet _) ->
@@ -241,6 +245,11 @@ let agent_error_terminal_reason_code = function
     Printf.sprintf "agent_error_tripwire_violation:tripwire=%s" tripwire
   | Agent_sdk.Error.InputRequired { request_id; question = _; _ } ->
     Printf.sprintf "agent_error_input_required:request_id=%s" request_id
+  | Agent_sdk.Error.AgentExecutionTimeout
+      { elapsed_sec; timeout_sec; turn_count; max_turns } ->
+    Printf.sprintf
+      "agent_error_execution_timeout:elapsed_sec=%.3f,timeout_sec=%.3f,turn_count=%d,max_turns=%d"
+      elapsed_sec timeout_sec turn_count max_turns
 ;;
 
 let network_error_kind_to_wire = function

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -157,6 +157,7 @@ let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool
       contract = Agent_sdk.Completion_contract_id.Require_tool_use
   (* Other agent-level errors are not require-tool-use contract violations. *)
   | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
+  | Agent_sdk.Error.Agent (AgentExecutionTimeout _)
   | Agent_sdk.Error.Agent (TokenBudgetExceeded _)
   | Agent_sdk.Error.Agent (CostBudgetExceeded _)
   | Agent_sdk.Error.Agent (CostBudgetUnenforceable _)
@@ -790,6 +791,7 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Provider _ -> false
   (* Other agent error variants. *)
   | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
+  | Agent_sdk.Error.Agent (AgentExecutionTimeout _)
   | Agent_sdk.Error.Agent (CostBudgetExceeded _)
   | Agent_sdk.Error.Agent (CostBudgetUnenforceable _)
   | Agent_sdk.Error.Agent (UnrecognizedStopReason _)
@@ -815,6 +817,7 @@ let is_input_required_error (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
   | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired _) -> true
   | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
+  | Agent_sdk.Error.Agent (AgentExecutionTimeout _)
   | Agent_sdk.Error.Agent (CostBudgetExceeded _)
   | Agent_sdk.Error.Agent (CostBudgetUnenforceable _)
   | Agent_sdk.Error.Agent (TokenBudgetExceeded _)

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -57,6 +57,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
      | Agent_sdk.Error.Agent (TripwireViolation _) -> Some Sdk_tripwire_violation
      | Agent_sdk.Error.Agent (ExitConditionMet _) -> Some Sdk_exit_condition_met
      | Agent_sdk.Error.Agent (InputRequired _) -> Some Sdk_input_required
+     | Agent_sdk.Error.Agent (AgentExecutionTimeout _) -> Some Sdk_max_turns_exceeded
      (* Provider-level [Api] errors are surfaced via OAS retry / cascade
          layers and do not map to a typed blocker_class by themselves. *)
      | Agent_sdk.Error.Api _

--- a/lib/server/openai_compat_error_map.ml
+++ b/lib/server/openai_compat_error_map.ml
@@ -239,6 +239,13 @@ let of_agent_error (e : Agent_sdk.Error.agent_error) : t =
     ; openai_kind = kind_server
     ; openai_code = Some "exit_condition_met"
     ; message }
+  | AgentExecutionTimeout _ ->
+    (* agent_sdk 0.200.2 (#18988) introduced this variant; surface as 504
+       so callers can distinguish deadline expiry from generic 500s. *)
+    { http_status = `Gateway_timeout
+    ; openai_kind = kind_server
+    ; openai_code = Some "agent_execution_timeout"
+    ; message }
 
 let of_mcp_error (e : Agent_sdk.Error.mcp_error) : t =
   let message = Agent_sdk.Error.to_string (Agent_sdk.Error.Mcp e) in


### PR DESCRIPTION
## Summary

`agent_sdk 0.200.2` (#18988) introduced `Agent_sdk.Error.AgentExecutionTimeout
{ elapsed_sec; timeout_sec; turn_count; max_turns }` as a new agent_error
variant. The version bump merged without updating downstream callers, leaving
`main` build-broken on warning 8 (non-exhaustive pattern-match) across 6 files
/ 9 match arms.

This PR closes the missed N-of-M migration.

## Changes

| File | Match arms | Mapping |
|------|------------|---------|
| `lib/server/openai_compat_error_map.ml` | 1 | `504 Gateway Timeout` with `openai_code = "agent_execution_timeout"` |
| `lib/keeper/keeper_status_bridge_blocker.ml` | 1 | `Sdk_max_turns_exceeded` blocker class |
| `lib/keeper/keeper_agent_error.ml` | 2 | `Oas_turn_budget_exhausted` termination semantics + explicit `error_kind` string |
| `lib/keeper/keeper_error_classify.ml` | 3 | `false` for `is_required_tool_contract_violation` / `is_context_overflow` / `is_input_required_error` |
| `lib/cascade/cascade_attempt_fsm.ml` | 1 | grouped with other "structural, not cascadeable" agent errors |
| `lib/cascade/cascade_event_bridge_error_json.ml` | 1 | explicit JSON emission with all 4 SDK fields |

Net: **+29 / -0** across 6 files.

## Semantic

`AgentExecutionTimeout` is the wall-clock analog of `MaxTurnsExceeded` — both
represent runtime budget exhaustion (turn-count vs. seconds). Routed through
the same handlers throughout.

## Verification

- `dune build --root . lib/` → PASS (exit 0). Was previously broken on every
  `Agent_sdk.Error.Agent ...` match block.
- `bash ~/me/scripts/pr-rfc-check.sh` → PASS (no RFC area touched).

## Unblocks

- RFC-0192 PR-1 (#TBD — `Cascade_deadline` type module) — test exe was
  unbuildable due to this break.
- Any other in-flight work touching `lib/` since the agent_sdk 0.200.2 bump.

## Workaround-bar self-check

- §1 counter-as-fix: N/A — typed handler completion.
- §2 string classifier: N/A — adds typed match arm.
- §3 N-of-M: this PR **completes** the missed N-of-M from #18988 (does not
  introduce one).
- §5 cap/cooldown: N/A.