### PR TITLE
feat(cascade): RFC-0192 PR-1 Cascade_deadline type + math helpers

### DIFF
--- a/lib/cascade/cascade_deadline.ml
+++ b/lib/cascade/cascade_deadline.ml
@@ -1,0 +1,22 @@
+type t = { expires_at_s : float }
+
+let create ~expires_at_s = { expires_at_s }
+
+let of_seconds_from_now ~clock secs =
+  { expires_at_s = Eio.Time.now clock +. secs }
+
+let expires_at d = d.expires_at_s
+
+let remaining_at ~now_s d = Float.max 0.0 (d.expires_at_s -. now_s)
+
+let composed_attempt_budget_at ~now_s ~deadline ~amplifier =
+  Float.min amplifier (remaining_at ~now_s deadline)
+
+let is_expired_at ~now_s d = remaining_at ~now_s d = 0.0
+
+let remaining_seconds ~clock d = remaining_at ~now_s:(Eio.Time.now clock) d
+
+let composed_attempt_budget ~clock ~deadline ~amplifier =
+  composed_attempt_budget_at ~now_s:(Eio.Time.now clock) ~deadline ~amplifier
+
+let is_expired ~clock d = is_expired_at ~now_s:(Eio.Time.now clock) d

--- a/lib/cascade/cascade_deadline.mli
+++ b/lib/cascade/cascade_deadline.mli
@@ -1,0 +1,67 @@
+(** Cascade per-attempt deadline value carrying a wall-clock time horizon.
+
+    RFC-0192 § 2 invariant carrier:
+    [effective_attempt_budget(i) = min(default_amplifier, deadline - now())]
+
+    PR-1 establishes the type and math helpers; PR-2 wires it into
+    [Cascade_tier_wait_scheduler.try_admission_or_wait]; PR-3 has
+    [Keeper_agent_run] compute it from [admission_wait_timeout_sec] and
+    thread through the keeper turn driver chain.
+
+    The pure {!remaining_at} / {!composed_attempt_budget_at} variants take
+    an explicit [now_s] so the math is unit-testable without an Eio runtime.
+    The clock-bearing wrappers ({!of_seconds_from_now} etc.) call
+    {!Eio.Time.now} under the hood and are tested via integration. *)
+
+type t
+
+(** {1 Construction} *)
+
+(** [create ~expires_at_s] is the wall-clock absolute time when this
+    deadline elapses. Exposed primarily for tests. *)
+val create : expires_at_s:float -> t
+
+(** [of_seconds_from_now ~clock secs] is a deadline [secs] in the future
+    relative to [clock]. Use this in production code. *)
+val of_seconds_from_now :
+  clock:float Eio.Time.clock_ty Eio.Resource.t -> float -> t
+
+(** [expires_at d] is the underlying wall-clock seconds since Unix epoch.
+    Exposed for telemetry and logging; do not use for arithmetic — prefer
+    {!remaining_seconds} / {!composed_attempt_budget} to keep callers
+    independent of the time source. *)
+val expires_at : t -> float
+
+(** {1 Pure math (unit-testable, no Eio runtime needed)} *)
+
+(** [remaining_at ~now_s d] is [max 0.0 (expires_at d -. now_s)]. Never
+    negative; an expired deadline returns [0.0]. *)
+val remaining_at : now_s:float -> t -> float
+
+(** [composed_attempt_budget_at ~now_s ~deadline ~amplifier] is the
+    RFC-0192 § 2 invariant:
+    [min amplifier (remaining_at ~now_s deadline)].
+
+    [amplifier] is the per-attempt default (existing
+    [Env_config_keeper.CascadeTierWait.timeout_s ()]) and acts as the
+    upper bound. [deadline] acts as the lower bound. The result is
+    never negative. *)
+val composed_attempt_budget_at :
+  now_s:float -> deadline:t -> amplifier:float -> float
+
+(** [is_expired_at ~now_s d] is [remaining_at ~now_s d = 0.0]. *)
+val is_expired_at : now_s:float -> t -> bool
+
+(** {1 Clock-bearing convenience wrappers (for production callers)} *)
+
+val remaining_seconds :
+  clock:float Eio.Time.clock_ty Eio.Resource.t -> t -> float
+
+val composed_attempt_budget :
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  deadline:t ->
+  amplifier:float ->
+  float
+
+val is_expired :
+  clock:float Eio.Time.clock_ty Eio.Resource.t -> t -> bool

--- a/test/dune
+++ b/test/dune
@@ -101,6 +101,7 @@
   test_post_verifier
   test_reward_advice_artifact
   test_cascade_capability_profile
+  test_cascade_deadline
   test_cascade_secondary_expand
   test_keeper_hooks_oas_telemetry
   test_masc_oas_bridge_timeout_guard
@@ -428,6 +429,7 @@
   test_post_verifier
   test_reward_advice_artifact
   test_cascade_capability_profile
+  test_cascade_deadline
   test_cascade_secondary_expand
   test_keeper_hooks_oas_telemetry
   test_masc_oas_bridge_timeout_guard

--- a/test/test_cascade_deadline.ml
+++ b/test/test_cascade_deadline.ml
@@ -1,0 +1,80 @@
+(** Unit tests for [Cascade_deadline] (RFC-0192 PR-1).
+
+    Pure math tests use the [_at] variants with explicit [now_s] so no
+    Eio runtime is required. The clock-bearing wrappers are exercised by
+    integration tests in PR-2 once the scheduler consumes them. *)
+
+open Alcotest
+
+module D = Masc_mcp.Cascade_deadline
+
+let test_remaining_at_future () =
+  let d = D.create ~expires_at_s:100.0 in
+  check (float 1e-9) "10s remaining" 10.0 (D.remaining_at ~now_s:90.0 d)
+
+let test_remaining_at_now () =
+  let d = D.create ~expires_at_s:100.0 in
+  check (float 1e-9) "0s remaining at expiry" 0.0 (D.remaining_at ~now_s:100.0 d)
+
+let test_remaining_at_past_clamped_to_zero () =
+  let d = D.create ~expires_at_s:100.0 in
+  check (float 1e-9) "expired deadline clamps to 0"
+    0.0 (D.remaining_at ~now_s:150.0 d)
+
+let test_composed_picks_amplifier_when_deadline_far () =
+  (* deadline gives 30s remaining, amplifier 10s → amplifier wins *)
+  let d = D.create ~expires_at_s:130.0 in
+  check (float 1e-9) "amplifier is lower bound"
+    10.0 (D.composed_attempt_budget_at ~now_s:100.0 ~deadline:d ~amplifier:10.0)
+
+let test_composed_picks_deadline_when_amplifier_large () =
+  (* deadline gives 5s remaining, amplifier 30s → deadline wins *)
+  let d = D.create ~expires_at_s:105.0 in
+  check (float 1e-9) "deadline is lower bound"
+    5.0 (D.composed_attempt_budget_at ~now_s:100.0 ~deadline:d ~amplifier:30.0)
+
+let test_composed_zero_when_deadline_expired () =
+  (* expired deadline → 0 regardless of amplifier *)
+  let d = D.create ~expires_at_s:100.0 in
+  check (float 1e-9) "expired deadline zeroes budget"
+    0.0 (D.composed_attempt_budget_at ~now_s:150.0 ~deadline:d ~amplifier:30.0)
+
+let test_composed_equal_when_both_at_boundary () =
+  (* deadline = amplifier = 15 → both 15 *)
+  let d = D.create ~expires_at_s:115.0 in
+  check (float 1e-9) "equal at boundary"
+    15.0 (D.composed_attempt_budget_at ~now_s:100.0 ~deadline:d ~amplifier:15.0)
+
+let test_is_expired_at_matches_remaining_zero () =
+  let d = D.create ~expires_at_s:100.0 in
+  check bool "not expired before" false (D.is_expired_at ~now_s:50.0 d);
+  check bool "expired at exact" true (D.is_expired_at ~now_s:100.0 d);
+  check bool "expired after" true (D.is_expired_at ~now_s:150.0 d)
+
+let test_expires_at_roundtrips () =
+  let d = D.create ~expires_at_s:1779864000.5 in
+  check (float 1e-9) "expires_at preserved" 1779864000.5 (D.expires_at d)
+
+let () =
+  run "cascade_deadline"
+    [
+      ( "pure math (RFC-0192 § 2 invariant)",
+        [
+          test_case "remaining_at: future" `Quick test_remaining_at_future;
+          test_case "remaining_at: at expiry" `Quick test_remaining_at_now;
+          test_case "remaining_at: past clamped to 0" `Quick
+            test_remaining_at_past_clamped_to_zero;
+          test_case "composed_attempt_budget: amplifier upper bound" `Quick
+            test_composed_picks_amplifier_when_deadline_far;
+          test_case "composed_attempt_budget: deadline lower bound" `Quick
+            test_composed_picks_deadline_when_amplifier_large;
+          test_case "composed_attempt_budget: expired deadline = 0" `Quick
+            test_composed_zero_when_deadline_expired;
+          test_case "composed_attempt_budget: equal at boundary" `Quick
+            test_composed_equal_when_both_at_boundary;
+          test_case "is_expired_at: matches remaining = 0" `Quick
+            test_is_expired_at_matches_remaining_zero;
+          test_case "expires_at: roundtrips construction" `Quick
+            test_expires_at_roundtrips;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

RFC-0192 PR-1 (stack 1/4). Establishes the `Cascade_deadline` type and
math helpers carrying the RFC-0192 § 2 invariant
`effective_attempt_budget = min(default_amplifier, deadline - now())`.

This PR is **no-op in production**:

- New module `Cascade_deadline` (`lib/cascade/cascade_deadline.{ml,mli}`,
  67 + 22 lines).
- New unit tests (`test/test_cascade_deadline.ml`, 9 Alcotest cases) covering
  the pure math via `_at` variants with explicit `now_s` — no Eio runtime
  required.
- No existing callers updated. No function signature changes. No behavior
  change anywhere.

PR-2 will wire `Cascade_deadline` into
`Cascade_tier_wait_scheduler.try_admission_or_wait`.

## Design notes

- Pure math (`remaining_at`, `composed_attempt_budget_at`, `is_expired_at`)
  uses an explicit `now_s` so unit tests don't need `Eio_main.run` / mock
  clocks. The clock-bearing wrappers (`of_seconds_from_now`,
  `remaining_seconds`, `composed_attempt_budget`, `is_expired`) call
  `Eio.Time.now` and are tested via integration in PR-2.
- `composed_attempt_budget` is `min` of `amplifier` (upper bound — the
  legacy `Env_config_keeper.CascadeTierWait.timeout_s ()`) and `deadline -
  now` (lower bound). Never negative.
- `is_expired ↔ remaining = 0.0` is the bridge to RFC-0192 PR-4's
  `min_required_sec` removal (math invariant replaces the cliff cutoff).

## Anti-goal compliance (RFC-0192 § 3)

This PR adds:
- ✓ A type-level invariant carrier.
- ✓ Math composition (`min` / `max 0.0`).

This PR does **not** add:
- ✗ Threshold guards / cliff cutoffs.
- ✗ Cap / cooldown / dedup / repair shims.
- ✗ Watchdog timers.
- ✗ `min_required_sec`-style floors.

## Verification

- `dune build --root . lib/cascade/cascade_deadline.{ml,mli}` → PASS
  (isolated module compiles clean).
- `dune build --root . test/test_cascade_deadline.exe` is **blocked by an
  unrelated pre-existing main break**: `agent_sdk 0.200.2` upgrade (#18988)
  introduced `Agent_sdk.Error.AgentExecutionTimeout` without updating 6
  downstream callers. The N-of-M closeout lives in sibling PR **#18999** —
  once that merges, this PR's test exe will build and the 9 cases will run.
- `bash ~/me/scripts/pr-rfc-check.sh` → PASS.

## Stack

| Stage | PR | Status |
|-------|----|--------|
| RFC doc | #18985 | MERGED |
| PR-1 ctx wiring (no-op) | **this** | Draft |
| PR-2 scheduler deadline | TBD | not yet |
| PR-3 caller migration | TBD | not yet |
| PR-4 hard-gate cleanup | TBD | gated on PR-3 + 7d fleet |

## Related

- Closes #18845 (at PR-4 merge)
- Depends on #18999 (sibling, unblocks lib build for test verification)