### PR TITLE
refactor(fs_compat): typed rename_if_exists replaces "No such file" substring guard at 2 keeper rotation sites

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -303,6 +303,32 @@ let rename (src : string) (dst : string) : unit =
     (fun fs -> Eio.Path.rename Eio.Path.(fs / src) Eio.Path.(fs / dst))
 ;;
 
+(* Both runtime paths catch the missing-source case explicitly rather
+   than substring-matching on the libc error text. Stdlib's [Sys.rename]
+   raises [Sys_error] with a libc-translated, locale-sensitive message;
+   matching "No such file" against it skips the Eio path where
+   [Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _))] is propagated instead (the
+   [with_io] normalizer wraps it into a [Sys_error] whose body does not
+   necessarily contain "No such file"). The result was a silent
+   path-dependent classifier failure: callers using the substring guard
+   only recognized the missing-source case under the Stdlib fallback. *)
+let rename_if_exists ~src ~dst =
+  with_fs_or_fallback
+    ~path:src
+    ~fallback:(fun () ->
+      try
+        Stdlib.Sys.rename src dst;
+        true
+      with
+      | Sys_error _ when not (Stdlib.Sys.file_exists src) -> false)
+    (fun fs ->
+      try
+        Eio.Path.rename Eio.Path.(fs / src) Eio.Path.(fs / dst);
+        true
+      with
+      | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) -> false)
+;;
+
 let rmdir (path : string) : unit =
   with_fs_or_fallback
     ~path

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -75,6 +75,14 @@ val file_mtime : string -> float option
 (** Rename file. *)
 val rename : string -> string -> unit
 
+(** [rename_if_exists ~src ~dst] renames [src] to [dst], returning [true]
+    on success and [false] if [src] did not exist. Other I/O errors
+    propagate as [Sys_error] (Eio.Io is normalized internally, matching
+    {!rename}). Both runtime paths recognize the missing-source case
+    via typed catches ([Eio.Fs.Not_found] / verified [Sys.file_exists])
+    rather than substring matching on the libc message. *)
+val rename_if_exists : src:string -> dst:string -> bool
+
 (** Remove directory. *)
 val rmdir : string -> unit
 

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -144,14 +144,12 @@ let maybe_rotate_file path =
           for i = max_rotated downto 2 do
             let src = Printf.sprintf "%s.%d" path (i - 1) in
             let dst = Printf.sprintf "%s.%d" path i in
-            try Fs_compat.rename src dst with
-            | Sys_error msg when String_util.contains_substring msg "No such file" -> ()
+            try ignore (Fs_compat.rename_if_exists ~src ~dst : bool) with
             | Sys_error msg ->
               Log.Misc.warn "rotate: cannot rename %s -> %s: %s" src dst msg
           done;
           let rotated = Printf.sprintf "%s.1" path in
-          try Fs_compat.rename path rotated with
-          | Sys_error msg when String_util.contains_substring msg "No such file" -> ()
+          try ignore (Fs_compat.rename_if_exists ~src:path ~dst:rotated : bool) with
           | Sys_error msg ->
             Log.Misc.warn "rotate: cannot rename %s -> %s: %s" path rotated msg
         end


### PR DESCRIPTION
## 요약

PR #18977 (`LockContention` typed) → PR #18982 (`Unix.EEXIST` typed) 이후 RFC-0088 §"String/Substring 분류기" audit 3번째 surgical PR. `lib/keeper/keeper_types_support.ml:148, 154` 의 *log rotation* 사이트가 `Sys_error msg "No such file"` substring 가드 사용.

### Latent path-dependent silent bug

`Fs_compat.rename` 은 *dual-path wrapper*:

```ocaml
let rename (src : string) (dst : string) : unit =
  with_fs_or_fallback
    ~path:src
    ~fallback:(fun () -> Stdlib.Sys.rename src dst)       (* Stdlib fallback *)
    (fun fs -> Eio.Path.rename Eio.Path.(fs / src) Eio.Path.(fs / dst))  (* Eio path *)
```

- **Stdlib fallback**: `Sys_error` with libc message containing "No such file" — substring 매치 OK
- **Eio path**: `Eio.Io (Fs.E (Eio.Fs.Not_found _))` propagation. `with_io` normalizer wraps it as `Sys_error` (line 38-42), but the resulting string body does **not** necessarily contain "No such file":

```ocaml
let with_io ~path f =
  try f () with
  | Eio.Io _ as e ->
    raise (Sys_error (Printf.sprintf "%s: %s" path (Printexc.to_string e)))
```

`Printexc.to_string` 의 `Eio.Io (Fs.E (Not_found inner))` 출력 형식은 inner exception 의 메시지에 의존 — locale/runtime configuration 에 따라 "No such file" substring 가 *있을 수도, 없을 수도* 있음.

결과: Eio runtime active 인 production 환경에서 missing-source 가 *조용히 normal-path 로 처리되지 않고* `Log.Misc.warn "rotate: cannot rename..."` 로 fire. 로그 노이즈 + classifier 안티패턴 + path-dependent silent bug 3 종.

## 변경

### `Fs_compat.rename_if_exists ~src ~dst : bool` 추가

```ocaml
let rename_if_exists ~src ~dst =
  with_fs_or_fallback
    ~path:src
    ~fallback:(fun () ->
      try
        Stdlib.Sys.rename src dst;
        true
      with
      | Sys_error _ when not (Stdlib.Sys.file_exists src) -> false)
    (fun fs ->
      try
        Eio.Path.rename Eio.Path.(fs / src) Eio.Path.(fs / dst);
        true
      with
      | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) -> false)
```

- **Eio path**: typed `Eio.Fs.Not_found` 매치 — runtime-independent
- **Stdlib path**: `Sys_error` 캐치 후 `Sys.file_exists` 로 verify — substring 매치 제거
- 반환 `bool` — 호출자는 missing-source 와 success 를 명시적으로 알 수 있음

### Consumer 마이그레이션 (`keeper_types_support.ml:147-156`)

before:
```ocaml
try Fs_compat.rename src dst with
| Sys_error msg when String_util.contains_substring msg "No such file" -> ()
| Sys_error msg ->
  Log.Misc.warn "rotate: cannot rename %s -> %s: %s" src dst msg
```

after:
```ocaml
try ignore (Fs_compat.rename_if_exists ~src ~dst : bool) with
| Sys_error msg ->
  Log.Misc.warn "rotate: cannot rename %s -> %s: %s" src dst msg
```

2 사이트 동시 fix (rotation loop + final rename).

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 String/Substring 분류기 패턴을 *제거* 함 (typed `Eio.Fs.Not_found` + `Sys.file_exists` verify 도입). pr-rfc-check 가 anti-pattern 언급을 시그니처 매치로 감지하나, 실제 코드 변경은 anti-pattern *deletion* (2 사이트 → 0). 동반 효과로 path-dependent silent bug 도 제거.

본 PR 은 시그니처 3종 + 체크리스트 7항목 모두 비해당:

- ❌ Counter-as-Fix — telemetry 추가 없음
- ✅ **String/substring 분류기 제거** — 2 사이트 동시
- ❌ N-of-M 패치 — 2 사이트 *모두* 동시 처리 (rotation loop + final)
- ❌ Repair/Sanitize — symptom 억제 아닌 *typed error 정확화 + 부수 silent bug fix*

## Test impact

- `Fs_compat.rename` 시그니처/동작 *무변경*. 기존 사용처 영향 0.
- `rename_if_exists` 는 새 API. consumer 1곳 (`keeper_types_support.ml`) 만 사용. 직접 test 없음 (log rotation 통합 동작은 `keeper_log_rotation_test` 등에서 covered).
- Full `dune build --root .` PASS (rebase against `991db5dd7`).

## Background — iter 38 saturation 정정

iter 38 가 *consumer-side surgical* 후보 saturation 선언 — 본 PR 은 *narrower grep* (`when.*contains_substring` 가드 패턴) 으로 새 사이트 발견. iter 38 의 total-count grep 으로는 *legitimate* 사이트와 *anti-pattern* 사이트 구분 안 되어 false-positive 카운트로 saturation 오판. *Grep pattern 자체가 audit 의 truth-value 를 결정* 하는 사례.

Total `contains_substring` calls in `lib/`: 306 → 304 (2 사이트 제거).
RFC-0088 §"String 분류기" 안티패턴 사이트 (when-guard form): 9 → 7.

## Related

- PR #18977 (lock contention typed)
- PR #18982 (mkdir EEXIST typed) — 직접 선례
- Issue #18986 (RFC scope candidates: Auth Unauthorized + SIGTERM log)
- RFC-0088 §"String/Substring 분류기" anti-pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
