### PR TITLE
feat(cascade): RFC-0192 PR-2 wire deadline into try_admission_or_wait

### DIFF
--- a/lib/cascade/cascade_tier_wait_scheduler.ml
+++ b/lib/cascade/cascade_tier_wait_scheduler.ml
@@ -189,8 +189,20 @@ let backoff_sleep t ~sw delay_s waiter_promise =
 (* ── Main API: try_admission_or_wait ────────────────────────────── *)
 
 let try_admission_or_wait t ~tier_id ?(wait_config = t.default_wait_config)
-    ~sw f =
+    ?deadline:cascade_deadline ~sw f =
   let start_time = Unix.gettimeofday () in
+  (* RFC-0192 § 2: effective per-call timeout =
+       min(wait_config.timeout_s, deadline - now()).
+     Backward-compat: cascade_deadline=None or clock=None → legacy
+     [wait_config.timeout_s] amplifier behaviour. *)
+  let effective_timeout_s =
+    match cascade_deadline, t.clock with
+    | None, _ -> wait_config.timeout_s
+    | Some _, None -> wait_config.timeout_s
+    | Some d, Some clk ->
+      Cascade_deadline.composed_attempt_budget
+        ~clock:clk ~deadline:d ~amplifier:wait_config.timeout_s
+  in
 
   (* Attempt 1: immediate try_acquire *)
   match Cascade_tier_admission.try_acquire t.admission ~tier_id with
@@ -210,12 +222,12 @@ let try_admission_or_wait t ~tier_id ?(wait_config = t.default_wait_config)
   | Cascade_tier_admission.Capacity_full _ ->
       (* Slow path — create tier state lazily, enter wait loop *)
       let ts = get_or_create_tier t tier_id in
-      let deadline = start_time +. wait_config.timeout_s in
+      let wait_deadline_s = start_time +. effective_timeout_s in
       let max_retries = wait_config.max_retries in
       let rec loop attempt total_waited =
         (* Check deadline *)
         let now = Unix.gettimeofday () in
-        if now >= deadline then begin
+        if now >= wait_deadline_s then begin
           Eio.Mutex.use_rw ts.mu ~protect:false (fun () ->
               ts.total_timeouts <- ts.total_timeouts + 1;
               ts.total_rejected <- ts.total_rejected + 1;
@@ -286,7 +298,7 @@ let try_admission_or_wait t ~tier_id ?(wait_config = t.default_wait_config)
               | Cascade_tier_admission.Capacity_full _ ->
                   (* Not admitted yet — check deadline and loop *)
                   let now2 = Unix.gettimeofday () in
-                  if now2 >= deadline then begin
+                  if now2 >= wait_deadline_s then begin
                     Eio.Mutex.use_rw ts.mu ~protect:false (fun () ->
                         ts.total_timeouts <- ts.total_timeouts + 1;
                         ts.total_rejected <- ts.total_rejected + 1;

--- a/lib/cascade/cascade_tier_wait_scheduler.mli
+++ b/lib/cascade/cascade_tier_wait_scheduler.mli
@@ -84,19 +84,31 @@ val try_admission_or_wait :
   t ->
   tier_id:string ->
   ?wait_config:wait_config ->
+  ?deadline:Cascade_deadline.t ->
   sw:Eio.Switch.t ->
   (unit -> 'a) ->
   ('a, rejection_detail) result
-(** [try_admission_or_wait t ~tier_id ?wait_config ~sw f] attempts
+(** [try_admission_or_wait t ~tier_id ?wait_config ?deadline ~sw f] attempts
     admission on the underlying tier.
 
     If capacity is available, [f ()] runs immediately (zero wait).
     If full, the calling fiber enters a bounded wait loop with backoff
     until either:
     - Admission becomes available → [Ok (f ())], or
-    - [timeout_s] elapses → [Error (Timeout_expired _)], or
+    - the effective timeout elapses → [Error (Timeout_expired _)], or
     - [max_retries] exceeded → [Error (Max_retries_exceeded _)], or
     - [sw] is cancelled → [Error (Cancelled _)].
+
+    The effective timeout is computed via the RFC-0192 § 2 invariant:
+    {[
+      effective_timeout_s = match deadline with
+        | None   -> wait_config.timeout_s
+        | Some d -> Cascade_deadline.composed_attempt_budget
+                      ~clock ~deadline:d ~amplifier:wait_config.timeout_s
+    ]}
+    i.e. [min wait_config.timeout_s (deadline - now)]. When [deadline]
+    is omitted (or the scheduler has no clock), behaviour is identical
+    to before this RFC — pure backward compatibility.
 
     On admission, release happens automatically when [f] returns
     (whether normally or by exception) via the underlying

--- a/test/test_cascade_tier_wait_scheduler.ml
+++ b/test/test_cascade_tier_wait_scheduler.ml
@@ -255,6 +255,116 @@ let test_manual_release_wake () =
   | A.Capacity_full _ ->
       fail "should have granted on fresh admission")
 
+(* {1 Deadline propagation (RFC-0192 PR-2)} *)
+
+module D = Masc_mcp.Cascade_deadline
+
+let test_deadline_shorter_than_amplifier_drives_timeout () =
+  (* RFC-0192 § 2 invariant: when [deadline - now < wait_config.timeout_s],
+     the effective per-call budget is the deadline, not the amplifier.
+     A 5s amplifier with a 0.1s deadline must time out near 0.1s. *)
+  Eio_main.run (fun _env ->
+  let admission = A.create ~default_max_inflight:1 () in
+  let scheduler = W.create ~clock:(Eio.Stdenv.clock _env) admission in
+  Eio.Switch.run @@ fun sw ->
+  let blocker_started, blocker_started_r = Eio.Promise.create () in
+  let blocker_never_release_p, _ = Eio.Promise.create () in
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+      ignore (W.try_admission_or_wait scheduler ~tier_id:"deadline" ~sw
+                (fun () ->
+                   Eio.Promise.resolve blocker_started_r ();
+                   Eio.Promise.await blocker_never_release_p;
+                   "never"));
+      `Stop_daemon);
+  Eio.Promise.await blocker_started;
+  let long_amplifier = {
+    W.backoff = W.Constant 0.005;
+    timeout_s = 5.0;  (* would normally wait 5s *)
+    max_retries = None;
+  } in
+  let deadline = D.of_seconds_from_now ~clock:(Eio.Stdenv.clock _env) 0.1 in
+  let start = Unix.gettimeofday () in
+  match W.try_admission_or_wait scheduler ~tier_id:"deadline"
+          ~wait_config:long_amplifier ~deadline ~sw
+          (fun () -> "should_not_run") with
+  | Error (W.Timeout_expired _) ->
+      let elapsed = Unix.gettimeofday () -. start in
+      (* Deadline-driven timeout must be far under amplifier's 5s.
+         Allow generous tolerance for scheduler backoff overhead. *)
+      check bool "elapsed << amplifier (deadline wins)" true (elapsed < 1.0)
+  | Error other ->
+      fail ("wrong rejection type: " ^ Format.asprintf "%a" W.pp_rejection_detail other)
+  | Ok _ ->
+      fail "should have timed out")
+
+let test_no_deadline_falls_back_to_amplifier () =
+  (* Backward compatibility: omitting [deadline] keeps the legacy
+     wait_config.timeout_s amplifier behaviour. *)
+  Eio_main.run (fun _env ->
+  let admission = A.create ~default_max_inflight:1 () in
+  let scheduler = W.create ~clock:(Eio.Stdenv.clock _env) admission in
+  Eio.Switch.run @@ fun sw ->
+  let blocker_started, blocker_started_r = Eio.Promise.create () in
+  let blocker_never_release_p, _ = Eio.Promise.create () in
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+      ignore (W.try_admission_or_wait scheduler ~tier_id:"no_dl" ~sw
+                (fun () ->
+                   Eio.Promise.resolve blocker_started_r ();
+                   Eio.Promise.await blocker_never_release_p;
+                   "never"));
+      `Stop_daemon);
+  Eio.Promise.await blocker_started;
+  let short_amplifier = {
+    W.backoff = W.Constant 0.005;
+    timeout_s = 0.05;
+    max_retries = None;
+  } in
+  (* No ~deadline argument: must time out at amplifier ≈ 0.05s. *)
+  match W.try_admission_or_wait scheduler ~tier_id:"no_dl"
+          ~wait_config:short_amplifier ~sw
+          (fun () -> "should_not_run") with
+  | Error (W.Timeout_expired { tier_id; _ }) ->
+      check string "tier_id matches" "no_dl" tier_id
+  | Error other ->
+      fail ("wrong rejection: " ^ Format.asprintf "%a" W.pp_rejection_detail other)
+  | Ok _ -> fail "should have timed out")
+
+let test_expired_deadline_immediate_timeout () =
+  (* [composed_attempt_budget = 0] when deadline already in the past →
+     first try_acquire still runs (fast path), but the slow path's
+     wait loop sees wait_deadline_s = start_time + 0 → immediate
+     Timeout_expired without waiting. *)
+  Eio_main.run (fun _env ->
+  let admission = A.create ~default_max_inflight:1 () in
+  let scheduler = W.create ~clock:(Eio.Stdenv.clock _env) admission in
+  Eio.Switch.run @@ fun sw ->
+  let blocker_started, blocker_started_r = Eio.Promise.create () in
+  let blocker_never_release_p, _ = Eio.Promise.create () in
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+      ignore (W.try_admission_or_wait scheduler ~tier_id:"expired" ~sw
+                (fun () ->
+                   Eio.Promise.resolve blocker_started_r ();
+                   Eio.Promise.await blocker_never_release_p;
+                   "never"));
+      `Stop_daemon);
+  Eio.Promise.await blocker_started;
+  let deadline = D.create ~expires_at_s:0.0 in  (* far past *)
+  let long_amplifier = {
+    W.backoff = W.Constant 0.001;
+    timeout_s = 5.0;
+    max_retries = None;
+  } in
+  let start = Unix.gettimeofday () in
+  match W.try_admission_or_wait scheduler ~tier_id:"expired"
+          ~wait_config:long_amplifier ~deadline ~sw
+          (fun () -> "should_not_run") with
+  | Error (W.Timeout_expired _) ->
+      let elapsed = Unix.gettimeofday () -. start in
+      check bool "expired deadline aborts within tolerance" true (elapsed < 0.5)
+  | Error other ->
+      fail ("wrong rejection: " ^ Format.asprintf "%a" W.pp_rejection_detail other)
+  | Ok _ -> fail "should have timed out")
+
 (* {1 Test suite} *)
 
 let () =
@@ -286,5 +396,13 @@ let () =
     "external", [
       test_case "manual release wake" `Quick
         test_manual_release_wake;
+    ];
+    "deadline (RFC-0192 PR-2)", [
+      test_case "deadline shorter than amplifier drives timeout" `Quick
+        test_deadline_shorter_than_amplifier_drives_timeout;
+      test_case "no deadline → amplifier fallback (backward-compat)" `Quick
+        test_no_deadline_falls_back_to_amplifier;
+      test_case "expired deadline → immediate timeout" `Quick
+        test_expired_deadline_immediate_timeout;
     ];
   ]


### PR DESCRIPTION
## Summary

RFC-0192 PR-2 (stack 2/4). Wires `Cascade_deadline` (from PR-1 #19001) into
`Cascade_tier_wait_scheduler.try_admission_or_wait` via an optional
`?deadline` parameter, implementing the RFC-0192 § 2 invariant:

```
effective_timeout_s = min(wait_config.timeout_s, deadline - now())
```

## Changes

- `lib/cascade/cascade_tier_wait_scheduler.{ml,mli}`:
  - Added `?deadline:Cascade_deadline.t` to `try_admission_or_wait`.
  - Internal: pre-compute `effective_timeout_s` via
    `Cascade_deadline.composed_attempt_budget` when deadline + clock
    are both present; otherwise fall back to legacy
    `wait_config.timeout_s`.
  - Renamed internal local `deadline : float` → `wait_deadline_s : float`
    for clarity (now it's a wall-clock absolute, parallel to the new
    `Cascade_deadline.t` parameter).
- `test/test_cascade_tier_wait_scheduler.ml`: 3 new test cases in
  the `deadline (RFC-0192 PR-2)` group.

Net: **+148 / -6** across 3 files (lib mli, lib ml, test).

## Backward compatibility

✓ **Fully backward compatible.**

- Existing callers passing no `?deadline` get identical behaviour.
- Existing `wait_config.timeout_s` remains the amplifier (upper bound).
- The `?deadline` parameter is optional; default = `None`.
- No type changes to `wait_config`, `rejection_detail`, or `t`.

`test_no_deadline_falls_back_to_amplifier` explicitly pins this.

## Tests

| Case | Verifies |
|------|----------|
| `deadline shorter than amplifier drives timeout` | RFC-0192 § 2 invariant — when deadline < amplifier, deadline wins |
| `no deadline → amplifier fallback (backward-compat)` | omitting `?deadline` preserves legacy behaviour |
| `expired deadline → immediate timeout` | past-deadline produces `effective_timeout_s = 0` and aborts immediately |

## Anti-goal compliance (RFC-0192 § 3)

This PR adds:
- ✓ A `min` math composition (`amplifier`, `deadline - now`).
- ✓ A typed optional parameter.

This PR does **not** add:
- ✗ Threshold guards / cliff cutoffs.
- ✗ Cap / cooldown / dedup / repair shims.
- ✗ Watchdog timers.
- ✗ `min_required_sec`-style floors.

## Stack

| Stage | PR | Status |
|-------|----|--------|
| RFC doc | #18985 | MERGED |
| PR-1 ctx wiring (Cascade_deadline type) | #19001 | Draft |
| PR-2 scheduler deadline (this) | **this** | Draft |
| PR-3 caller migration in keeper_agent_run | TBD | not yet |
| PR-4 hard-gate cleanup | TBD | gated on PR-3 + 7d fleet |

Branched from PR-1 (`feat/rfc-0192-pr1-ctx-deadline-wiring`). After PR-1 merges,
rebase this onto main.

## Verification

- `dune build --root . lib/cascade/cascade_tier_wait_scheduler.{ml,mli} test/test_cascade_tier_wait_scheduler.ml` → PASS.
- Full lib build + test exe link blocked by **unrelated #18988 missed migration**
  (`Agent_sdk.Error.AgentExecutionTimeout`). Closeout in sibling PR **#18999**.
  Once both #19001 and #18999 merge, this PR's tests will run end-to-end.
- `bash ~/me/scripts/pr-rfc-check.sh` → PASS.

## Related

- Closes #18845 (at PR-4 merge)
- Depends on #19001 (PR-1, Cascade_deadline type)
- Depends on #18999 (sibling AgentExecutionTimeout fix, for lib build)