### PR TITLE
refactor(dashboard/components): consolidate form-field base class string

### DIFF
--- a/dashboard/src/components/common/field-style-base.ts
+++ b/dashboard/src/components/common/field-style-base.ts
@@ -1,0 +1,25 @@
+/**
+ * Form-field base class string.
+ *
+ * Two component files (`credential-settings.ts`, `keeper-config-panel.ts`)
+ * each shipped a byte-identical
+ * `const fieldStyle = 'w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded-[var(--r-1)] py-2 px-3 font-sans focus:outline-none focus:border-accent-fg/50 focus:ring-1 focus:ring-accent-fg/50 transition-[border-color,box-shadow] duration-[var(--t-med)] shadow-inset'`
+ * and used it for `<input>` / `<select>` / `<textarea>` elements with
+ * `class="${fieldStyle}"` (and a couple of `${fieldStyle} resize-y …`
+ * extensions for textarea variants).
+ *
+ * Note on `TextInput` / `TextArea` (../common/input.ts): those primitives
+ * are the canonical SSOT for form inputs but their `INPUT_BASE` resolves
+ * through the component-level input token family
+ * (`--input-bg`, `--input-border`, `--input-fg`), whereas the two call
+ * sites here paint with raw `bg-card/60`, `border-card-border`,
+ * `text-text-strong`, plus a `backdrop-blur-sm` + `shadow-inset` finish
+ * that the component-level slots do not currently carry. Migrating each
+ * call site onto `TextInput` / `TextArea` requires deciding how the
+ * raw-token palette plus the inset/blur affordance maps onto the
+ * component-level tokens — a design call that lives outside an
+ * SSOT-extraction sweep. Until then, this constant captures the shared
+ * shape so the two files stop drifting.
+ */
+export const FIELD_STYLE_BASE =
+  'w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded-[var(--r-1)] py-2 px-3 font-sans focus:outline-none focus:border-accent-fg/50 focus:ring-1 focus:ring-accent-fg/50 transition-[border-color,box-shadow] duration-[var(--t-med)] shadow-inset'

--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -22,6 +22,7 @@ import { createAsyncResource } from '../lib/async-state'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { BTN_FILLED_BASE } from './common/button-filled-base'
+import { FIELD_STYLE_BASE } from './common/field-style-base'
 
 export {
   coerceCredentialType,
@@ -237,7 +238,6 @@ export function CredentialSettings() {
     }
   }
 
-  const fieldStyle ='w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded-[var(--r-1)] py-2 px-3 font-sans focus:outline-none focus:border-accent-fg/50 focus:ring-1 focus:ring-accent-fg/50 transition-[border-color,box-shadow] duration-[var(--t-med)] shadow-inset'
   const helperStyle = 'mt-1 text-3xs leading-relaxed text-text-dim'
 
   return html`
@@ -264,7 +264,7 @@ export function CredentialSettings() {
               <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">ID</label>
               <input
                 type="text"
-                class="${fieldStyle}"
+                class="${FIELD_STYLE_BASE}"
                 placeholder="my-credential"
                 value=${draft.id}
                 onInput=${(e: Event) => { addDraft.value = { ...draft, id: (e.target as HTMLInputElement).value } }}
@@ -274,7 +274,7 @@ export function CredentialSettings() {
               <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">이름</label>
               <input
                 type="text"
-                class="${fieldStyle}"
+                class="${FIELD_STYLE_BASE}"
                 placeholder="선택 사항"
                 value=${draft.name}
                 onInput=${(e: Event) => { addDraft.value = { ...draft, name: (e.target as HTMLInputElement).value } }}
@@ -284,7 +284,7 @@ export function CredentialSettings() {
               <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">사용자명</label>
               <input
                 type="text"
-                class="${fieldStyle}"
+                class="${FIELD_STYLE_BASE}"
                 placeholder="github-user"
                 value=${draft.username}
                 onInput=${(e: Event) => { addDraft.value = { ...draft, username: (e.target as HTMLInputElement).value } }}
@@ -293,7 +293,7 @@ export function CredentialSettings() {
             <div>
               <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">타입</label>
               <select
-                class="${fieldStyle}"
+                class="${FIELD_STYLE_BASE}"
                 value=${draft.type}
                 onChange=${(e: Event) => {
                   const nextType = coerceCredentialType((e.target as HTMLSelectElement).value)
@@ -314,7 +314,7 @@ export function CredentialSettings() {
               <div>
                 <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">gh login</label>
                 <select
-                  class="${fieldStyle}"
+                  class="${FIELD_STYLE_BASE}"
                   value=${draft.oauth_method ?? DEFAULT_OAUTH_METHOD}
                   onChange=${(e: Event) => {
                     addDraft.value = {
@@ -331,7 +331,7 @@ export function CredentialSettings() {
                 <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">GH_CONFIG_DIR</label>
                 <input
                   type="text"
-                  class="${fieldStyle}"
+                  class="${FIELD_STYLE_BASE}"
                   placeholder="base_path/.masc/github-identities/<credential-id>/gh"
                   value=${draft.gh_config_dir ?? ''}
                   onInput=${(e: Event) => { addDraft.value = { ...draft, gh_config_dir: (e.target as HTMLInputElement).value } }}
@@ -342,7 +342,7 @@ export function CredentialSettings() {
                 <div>
                   <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">Token</label>
                   <textarea
-                    class="${fieldStyle} min-h-20 resize-y"
+                    class="${FIELD_STYLE_BASE} min-h-20 resize-y"
                     placeholder="gh auth login --with-token 입력값"
                     value=${draft.token ?? ''}
                     onInput=${(e: Event) => { addDraft.value = { ...draft, token: (e.target as HTMLTextAreaElement).value } }}
@@ -355,7 +355,7 @@ export function CredentialSettings() {
                 <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">SSH key path</label>
                 <input
                   type="text"
-                  class="${fieldStyle}"
+                  class="${FIELD_STYLE_BASE}"
                   placeholder="base_path/.masc/github-identities/<credential-id>/ssh/id_ed25519"
                   value=${draft.ssh_key_path ?? ''}
                   onInput=${(e: Event) => { addDraft.value = { ...draft, ssh_key_path: (e.target as HTMLInputElement).value } }}
@@ -366,7 +366,7 @@ export function CredentialSettings() {
               <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">GPG key id</label>
               <input
                 type="text"
-                class="${fieldStyle}"
+                class="${FIELD_STYLE_BASE}"
                 placeholder="선택 사항"
                 value=${draft.gpg_key_id ?? ''}
                 onInput=${(e: Event) => { addDraft.value = { ...draft, gpg_key_id: (e.target as HTMLInputElement).value } }}
@@ -376,7 +376,7 @@ export function CredentialSettings() {
               <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">설명</label>
               <input
                 type="text"
-                class="${fieldStyle}"
+                class="${FIELD_STYLE_BASE}"
                 placeholder="선택 사항"
                 value=${draft.description ?? ''}
                 onInput=${(e: Event) => { addDraft.value = { ...draft, description: (e.target as HTMLInputElement).value } }}

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -20,6 +20,7 @@ import { isVerifierRoleKeeper } from '../lib/keeper-utils'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { BTN_FILLED_BASE } from './common/button-filled-base'
+import { FIELD_STYLE_BASE } from './common/field-style-base'
 import { KeeperToolAccessSummary } from './keeper-tool-access'
 import { createAsyncResource, loaded } from '../lib/async-state'
 import { SetupGuideCard } from './setup-guide-card'
@@ -452,8 +453,6 @@ function PromptBlock({
   `
 }
 
-const fieldStyle = 'w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded-[var(--r-1)] py-2 px-3 font-sans focus:outline-none focus:border-accent-fg/50 focus:ring-1 focus:ring-accent-fg/50 transition-[border-color,box-shadow] duration-[var(--t-med)] shadow-inset'
-
 // ── Inline editing components for runtime config ────────
 
 function InlineToggleRow({ label, value, onChange }: { label: string; value: boolean; onChange: (v: boolean) => void }) {
@@ -541,7 +540,7 @@ function EditTextarea({ field, label, rows = 3 }: { field: keyof EditDraft; labe
       <div class="text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">${label}</div>
       <textarea
         aria-label=${label}
-        class="${fieldStyle} resize-y custom-scrollbar"
+        class="${FIELD_STYLE_BASE} resize-y custom-scrollbar"
         rows=${rows}
         value=${val}
         onInput=${(e: Event) => updateDraft(field, (e.target as HTMLTextAreaElement).value)}


### PR DESCRIPTION
## 요약
`fieldStyle` 2 사이트 byte-identical 정의를 `FIELD_STYLE_BASE` SSOT 로 통합했습니다.

## 배경
`rg "const fieldStyle ?=" components/` 결과 2 파일에서 발견:

| 파일 | 위치 | 사용 |
|---|---|---|
| `credential-settings.ts:240` | function-scoped | `class="${fieldStyle}"` × 10 (input/select/textarea) |
| `keeper-config-panel.ts:455` | module-level | `class="${fieldStyle} resize-y custom-scrollbar"` × 1 |

두 정의 모두 *form-field surface* — `w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded-[var(--r-1)] py-2 px-3 font-sans focus:outline-none focus:border-accent-fg/50 focus:ring-1 focus:ring-accent-fg/50 transition-[border-color,box-shadow] duration-[var(--t-med)] shadow-inset` (총 11 callsite).

## TextInput / TextArea 우회 메타 발견
`components/common/input.ts` 의 `TextInput` / `TextArea` 가 *공식 SSOT*. 2 사이트가 *이미 존재하는 컴포넌트를 우회* 하고 inline class string 사용 중. 이유:

- input.ts `INPUT_BASE` = component-level input token (`--input-bg`, `--input-border`, `--input-fg`)
- fieldStyle = raw role token (`bg-card/60`, `border-card-border`, `text-text-strong`) + `backdrop-blur-sm` + `shadow-inset` affordance (component-level slot 에 없음)

migration 은 raw-token → component-level token 매핑 + inset/blur affordance 디자인 결정 필요 — 별도 PR scope. 본 PR 은 그때까지 2 사이트의 drift 만 방지합니다.

## 변경
- `dashboard/src/components/common/field-style-base.ts` 신설 — `FIELD_STYLE_BASE` export + JSDoc (TextInput/TextArea migration deferred 이유 명시)
- 2 사이트: local `const fieldStyle` 삭제, `FIELD_STYLE_BASE` import, `${fieldStyle}` → `${FIELD_STYLE_BASE}` rename

## 검증
- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline, iter#23/27/33 과 동일 측정값, 본 PR 변경과 무관)
- 검증 중 일시적 git-graph-panel.test.ts 한 번 fail 관찰 → origin/main baseline + 격리 단독 실행 + 전체 재실행 3 단계로 **flaky timing race** 확정. baseline 1 fail 유지.
- 시각적 변경 0 (byte-identical class string)

## iter#33 부작용 정정
iter#33 (PR #18996) 에서 `const btnBase` 삭제 시 다음 줄과 결합되어 `const fieldStyle ='...'` 처럼 space 1 byte 가 사라진 부작용 발생. 본 PR 의 정의 삭제로 동시 해소.

## /loop iter#34
SSOT 위반 dashboard 축출 loop 의 iter#34. cumulative 34 PR (22 머지 + 1 OPEN).

RFC-WAIVED: pure className SSOT refactor (credential/auth/repo 도메인 로직 변경 0건). 변경된 3 파일 모두 `const fieldStyle` local 정의 삭제 + `FIELD_STYLE_BASE` import + reference rename. byte-identical class string 으로 시각적 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
