### PR TITLE
fix(logs): preserve correction pipeline detail

### DIFF
--- a/lib/agent_sdk_log_bridge.ml
+++ b/lib/agent_sdk_log_bridge.ml
@@ -102,6 +102,13 @@ let interpolate_printf_message message details =
     List.fold_left replace_first_placeholder message replacements
 
 let render_agent_tools_message ~message ~details =
+  let detail_segments keys =
+    keys
+    |> List.filter_map (fun key ->
+         match first_detail_label details [ key ] with
+         | Some value -> Some (Printf.sprintf "%s=%s" key value)
+         | None -> None)
+  in
   match
     first_detail_label details [ "tool_name"; "tool" ],
     first_detail_label details [ "fixes"; "count" ]
@@ -110,9 +117,21 @@ let render_agent_tools_message ~message ~details =
     when String.equal message "correction_pipeline fixed tool input fields"
          || String.equal message
               "tool %s: correction_pipeline fixed %d field(s)" ->
+      let detail =
+        detail_segments
+          [ "fields"
+          ; "stages"
+          ; "input_keys"
+          ; "corrected_keys"
+          ; "added_fields"
+          ; "changed_fields"
+          ]
+      in
       Some
-        (Printf.sprintf "tool %s: correction_pipeline fixed %s field(s)"
-           tool_name fixes)
+        (String.concat " "
+           (Printf.sprintf "tool %s: correction_pipeline fixed %s field(s)"
+              tool_name fixes
+            :: detail))
   | _ -> None
 
 let render_record_message (record : Agent_sdk.Log.record) : string =

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -255,6 +255,20 @@ let test_oas_mainline_warns_are_promoted_in_bridge () =
     (file_contains_pattern "lib/agent_sdk_log_bridge.ml"
        {|Warn, "agent_tools", "ApprovalRequired but no approval callback — executing"|})
 
+let test_correction_pipeline_log_preserves_detail_fields () =
+  List.iter
+    (fun (key, pattern) ->
+      check bool ("bridge renders correction detail " ^ key) true
+        (file_contains_pattern "lib/agent_sdk_log_bridge.ml"
+           pattern))
+    [ "fields", {|[ "fields"|}
+    ; "stages", {|; "stages"|}
+    ; "input_keys", {|; "input_keys"|}
+    ; "corrected_keys", {|; "corrected_keys"|}
+    ; "added_fields", {|; "added_fields"|}
+    ; "changed_fields", {|; "changed_fields"|}
+    ]
+
 let tool_policy_unloaded_metric accessor =
   Prometheus.metric_value_or_zero Prometheus.metric_tool_policy_unloaded_query
     ~labels:[("accessor", accessor)]
@@ -326,6 +340,8 @@ let () =
             test_keeper_mainline_failures_log_at_error;
           test_case "oas mainline warns are promoted in bridge" `Quick
             test_oas_mainline_warns_are_promoted_in_bridge;
+          test_case "correction pipeline log preserves detail fields" `Quick
+            test_correction_pipeline_log_preserves_detail_fields;
           test_case "tool policy pre-init accessors emit metric" `Quick
             test_tool_policy_unloaded_accessors_emit_metric;
           test_case "tool policy init failure emits metric" `Quick


### PR DESCRIPTION
## Summary
- Preserve OAS correction_pipeline detail fields in the MASC one-line log bridge output
- Include fields, stages, input_keys, corrected_keys, added_fields, and changed_fields instead of only 'fixed N field(s)'
- Add a regression guard so these detail keys stay rendered

## Verification
- ocamlformat --check lib/agent_sdk_log_bridge.ml test/test_warn_root_causes.ml
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build ./test/test_warn_root_causes.exe (blocked: existing bare Dune processes outside scripts/dune-local.sh caused wrapper exit 75)