### PR TITLE
perf(operator-trust): drop meta.updated_at from runtime-trust cache key (root pollution)

### DIFF
--- a/lib/operator/operator_control_snapshot_trust.ml
+++ b/lib/operator/operator_control_snapshot_trust.ml
@@ -10,15 +10,39 @@ let string_option_to_json = Json_util.string_opt_to_json
 
 let compact_runtime_trust_cache_ttl_sec = 1.0
 
+(* Cache key for the per-keeper runtime-trust projection.
+
+   The previous key embedded [meta.updated_at] (an ISO timestamp that
+   ticks on every meta refresh).  On a live fleet that produced an
+   unbounded set of unique keys for the same logical record: a
+   snapshot of /api/v1/dashboard/cache-stats showed 41/64 entries
+   (65%) occupied by this single key prefix, evicting genuinely hot
+   keys (dashboard.branches, dashboard.rooms, board:memory) from the
+   shared LRU.
+
+   The timestamp was acting as an invalidation signal, but the other
+   fields already cover the meaningful invariants:
+
+   - [meta.runtime.generation]: bumped on every supervisor-driven
+     restart / takeover — the load-bearing identity bit.
+   - [meta.runtime.usage.total_turns]: monotonic per-turn counter,
+     so any new turn lands on a fresh key.
+   - [meta.paused]: paused/unpaused toggles invalidate.
+
+   And [compact_runtime_trust_cache_ttl_sec = 1.0] is the final
+   safety net: stale data is held for at most one second before the
+   cache forces a refresh.  Dropping [meta.updated_at] gives each
+   keeper exactly one cache slot instead of one per meta refresh
+   tick — pollution disappears, hit_ratio recovers, and stale risk
+   stays bounded by the existing 1s TTL. *)
 let compact_runtime_trust_cache_key
       ~(config : Coord.config)
       ~(meta : Keeper_types.keeper_meta)
   =
   Printf.sprintf
-    "operator:keeper-runtime-trust:compact:v1:%s:%s:%s:%d:%d:%b"
+    "operator:keeper-runtime-trust:compact:v1:%s:%s:%d:%d:%b"
     config.base_path
     meta.name
-    meta.updated_at
     meta.runtime.generation
     meta.runtime.usage.total_turns
     meta.paused


### PR DESCRIPTION
## 요약

`compact_runtime_trust_cache_key`에서 `meta.updated_at` (ISO timestamp) 제거. 이 timestamp가 cache pollution의 진짜 root였습니다. 라이브 서버 `/api/v1/dashboard/cache-stats`에서 64/64 entries 중 41개(65%)가 한 prefix가 차지 — `operator:keeper-runtime-trust:compact:v1:.../2026-05-27T06:48:29Z/...` 같이 timestamp 변형. 한 logical row가 매 meta refresh tick마다 새 slot 차지.

## 변경 (1 파일, +26 / -2)

`lib/operator/operator_control_snapshot_trust.ml:13-25`:

```ocaml
(* before *)
"operator:keeper-runtime-trust:compact:v1:%s:%s:%s:%d:%d:%b"
  config.base_path
  meta.name
  meta.updated_at           ← 제거
  meta.runtime.generation
  meta.runtime.usage.total_turns
  meta.paused

(* after *)
"operator:keeper-runtime-trust:compact:v1:%s:%s:%d:%d:%b"
  config.base_path
  meta.name
  meta.runtime.generation
  meta.runtime.usage.total_turns
  meta.paused
```

## 왜 안전한가

timestamp는 invalidation 신호로 의도된 것 같지만, 다른 필드가 이미 의미 있는 변화를 다 커버:

| 변화 | 신호 |
|---|---|
| supervisor restart / takeover | `meta.runtime.generation` 증가 |
| 새 turn 시작 | `meta.runtime.usage.total_turns` 증가 |
| paused/unpaused 토글 | `meta.paused` 변화 |

그리고 `compact_runtime_trust_cache_ttl_sec = 1.0` (기존 코드) — **TTL 1초가 final safety net**. 다른 종류의 meta 변화가 있어도 1초 안에 cache miss → 재계산. stale data 최대 1초.

## 효과 예상

| | 변경 전 | 변경 후 |
|---|---|---|
| keeper당 cache slot | meta refresh당 1개 (unbounded) | **정확히 1개** |
| 한 prefix가 차지하는 비율 | 65% (41/64) | ~16/256 (N keeper / 256 budget) |
| 사용자 hot key eviction | 빈번 | 거의 없음 |

이번 fix가 #19000 (max_entries 64→256)과 짝을 이룹니다:
- #19000은 budget 늘림
- 이 PR은 worst offender의 unbounded 증가를 멈춤

둘 다 머지되면 cache hit_ratio가 ~31% → 70-90% 예상.

## 검증

- `dune build _build/default/lib/.masc_mcp.objs/byte/masc_mcp__Operator_control_snapshot_trust.cmo` 성공.
- 함수 시그니처 동일 (`~config ~meta`), caller 영향 0.
- 응답 JSON 스키마 변경 0.

## Workaround Signature Gate

CLAUDE.md §워크어라운드 거부 기준 7항목 비해당:
1. telemetry-as-fix ❌
2. string/substring 분류기 ❌
3. N-of-M ❌
4. catch-all ❌
5. cap/cooldown/dedup/repair ❌ (단순 키 단순화, symptom 억제 아님)
6. test backdoor ❌
7. typo 반복 ❌

## Related

- #18991 / #18993 / #18994 / #19007 (cache + Domain_pool offload 시리즈)
- #19000 (cache size 64→256)

## RFC Discovery

`pr-rfc-check.sh`가 operator/ 영역 변경으로 RFC-0008/0009/0019/0038/0068/0074/0141을 매칭. 이번 PR은 **cache key 문자열의 한 segment만 제거**하는 변경으로, credential / identity / trust / cascade / typed disposition 의 본질 동작은 무변경:

- 캐시 hit/miss 의미만 바뀜 (TTL 1s 안에 작동, stale 위험 없음)
- `Keeper_runtime_trust_snapshot.summary_json` 결과값 무변경
- API 응답 스키마 무변경
- 인증/인가/자격 증명 path 무영향

RFC-WAIVED: cache key 문자열 단순화 only; credential/identity/auth/trust 본질 동작 무변경 (위 표 참조).
