### PR TITLE
feat(keeper): task state in descriptor + tool call history in continuity

### DIFF
--- a/lib/keeper/agent_tool_memory_runtime.ml
+++ b/lib/keeper/agent_tool_memory_runtime.ml
@@ -543,6 +543,12 @@ let keeper_context_status_json
                | Some snapshot ->
                  Keeper_memory_policy.keeper_state_snapshot_to_json snapshot )
            ; "continuity_summary", `String continuity_summary
+           ; ( "recent_tool_calls"
+             , `List
+                 (List.map
+                    (fun (s : tool_call_summary) ->
+                       `Assoc [ ("tool", `String s.tool_name); ("outcome", `String s.outcome) ])
+                    meta.runtime.last_turn_tool_calls) )
            ; "recovery_source", `String recovery_source
            ; "memory_tier_summary", `Assoc memory_tier_summary
            ; ( "memory_tier_error_class"

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -438,6 +438,11 @@ type usage_metrics =
   ; last_latency_ms : int
   }
 
+type tool_call_summary =
+  { tool_name : string
+  ; outcome : string
+  }
+
 type agent_runtime_state =
   { usage : usage_metrics
   ; compaction_rt : compaction_runtime
@@ -462,6 +467,7 @@ type agent_runtime_state =
   ; last_blocker : blocker_info option
   ; last_cascade_attempt : cascade_attempt_record option
   ; last_need : string
+  ; last_turn_tool_calls : tool_call_summary list
   }
 
 type keeper_meta =

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -259,6 +259,13 @@ val cascade_attempt_record_to_json :
 val cascade_attempt_record_of_json :
   Yojson.Safe.t -> cascade_attempt_record option
 
+(** {1 Tool call summary for continuity} *)
+
+type tool_call_summary = {
+  tool_name : string;
+  outcome : string;  (** "ok" | "error: <short_msg>" *)
+}
+
 (** {1 Agent runtime state record} *)
 
 type agent_runtime_state = {
@@ -285,6 +292,7 @@ type agent_runtime_state = {
   last_blocker : blocker_info option;
   last_cascade_attempt : cascade_attempt_record option;
   last_need : string;
+  last_turn_tool_calls : tool_call_summary list;
 }
 
 (** {1 Keeper meta record} *)

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -75,6 +75,12 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
         | Some record -> cascade_attempt_record_to_json record
         | None -> `Null )
     ; "last_need", `String rt.last_need
+    ; ( "last_turn_tool_calls"
+      , `List
+          (List.map
+             (fun (s : Keeper_meta_contract.tool_call_summary) ->
+                `Assoc [ ("tool_name", `String s.tool_name); ("outcome", `String s.outcome) ])
+             rt.last_turn_tool_calls) )
     ; "paused", `Bool m.paused
     ; "auto_resume_after_sec", Json_util.float_opt_to_json m.auto_resume_after_sec
     ; ( "current_task_id"
@@ -146,6 +152,7 @@ let fallback_canonical_keeper_meta_key_names =
   ; "last_blocker"
   ; "last_cascade_attempt"
   ; "last_need"
+  ; "last_turn_tool_calls"
   ; "paused"
   ; "auto_resume_after_sec"
   ; "current_task_id"

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -472,6 +472,20 @@ let parse_keeper_state
     | _ -> None
 	  in
 	  let last_need = cap_loaded (Safe_ops.json_string ~default:"" "last_need" json) in
+	  let last_turn_tool_calls =
+	    match json with
+	    | `Assoc fields ->
+	      (match List.assoc_opt "last_turn_tool_calls" fields with
+	       | Some (`List items) ->
+	         List.filter_map
+	           (function
+	            | `Assoc [ ("tool_name", `String n); ("outcome", `String o) ] ->
+	              Some { Keeper_meta_contract.tool_name = n; outcome = o }
+	            | _ -> None)
+	           items
+	       | _ -> [])
+	    | _ -> []
+	  in
 	  let last_cascade_attempt =
 	    match json with
 	    | `Assoc fields ->
@@ -525,6 +539,7 @@ let parse_keeper_state
 	      ; last_blocker
 	      ; last_cascade_attempt
 	      ; last_need
+	      ; last_turn_tool_calls
 	      }
   }
 ;;

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -9,6 +9,22 @@
 
 open Keeper_tools_oas
 
+let task_state_hint ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) : string =
+  match meta.current_task_id with
+  | None -> "No task currently assigned. Use masc_claim_next or masc_tasks to find one."
+  | Some tid ->
+    let task_id = Keeper_id.Task_id.to_string tid in
+    (match Coord_backlog.read_backlog_r config with
+     | Error _ -> Printf.sprintf "Current task: %s (status unavailable)" task_id
+     | Ok backlog ->
+       (match List.find_opt (fun (t : Masc_domain.task) -> t.id = task_id) backlog.tasks with
+        | None -> Printf.sprintf "Current task: %s (not found in backlog)" task_id
+        | Some task ->
+          let status = Masc_domain.task_status_to_string task.task_status in
+          let hint = Coord_task_classify.next_actions_hint task.task_status in
+          Printf.sprintf "Current task: %s, status=%s%s" task_id status hint))
+;;
+
 let make_tool_bundle
       ~(config : Coord.config)
       ~(meta : Keeper_types.keeper_meta)
@@ -118,10 +134,15 @@ let make_tool_bundle
                ~failure_counts
                ()
            in
+           let description =
+             if String.equal td.name "masc_transition"
+             then td.description ^ "\n\n" ^ task_state_hint ~config ~meta
+             else td.description
+           in
            Some
              (Tool_bridge.oas_tool_of_masc
                 ~name:td.name
-                ~description:td.description
+                ~description
                 ~input_schema:td.input_schema
                 (fun input -> h input)))
          else None)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -545,6 +545,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
 	          last_blocker = None;
 	          last_cascade_attempt = None;
 	          last_need = "";
+	          last_turn_tool_calls = [];
 	        };
       keeper_id = Some (Keeper_id.Uid.generate ());
       oas_env = p.profile_defaults.oas_env;

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -227,6 +227,11 @@ val cascade_attempt_record_to_json :
 val cascade_attempt_record_of_json :
   Yojson.Safe.t -> cascade_attempt_record option
 
+type tool_call_summary = {
+  tool_name : string;
+  outcome : string;
+}
+
 type agent_runtime_state = {
   usage: usage_metrics;
   compaction_rt: compaction_runtime;
@@ -251,6 +256,7 @@ type agent_runtime_state = {
   last_blocker: blocker_info option;
   last_cascade_attempt: cascade_attempt_record option;
   last_need: string;
+  last_turn_tool_calls: tool_call_summary list;
 }
 
 (** {1 Keeper meta} *)

--- a/lib/keeper/keeper_unified_metrics_failure.ml
+++ b/lib/keeper/keeper_unified_metrics_failure.ml
@@ -220,5 +220,6 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
          | Some (state : Social.social_state) ->
              Option.value ~default:"" state.need
          | None -> meta.runtime.last_need);
+      last_turn_tool_calls = [];
     };
   }

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -225,6 +225,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
          tracks whether the keeper can make progress. *)
       last_blocker = None;
       last_need = Option.value ~default:"" social_state.need;
+      last_turn_tool_calls = [];
     };
   } in
   record_keeper_total_cost_usd

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -568,6 +568,21 @@ let handle
     ~turn_mode_label
     ~lifecycle;
   let updated_meta = persist_success_meta ~config ~original_meta:meta ~updated_meta in
+  let tool_call_summaries =
+    let max_tool_calls = 10 in
+    result.Keeper_agent_run.tool_calls
+    |> List.map (fun (d : Keeper_agent_run.tool_call_detail) ->
+       ( { tool_name = d.tool_name; outcome = d.outcome }
+         : Keeper_types.tool_call_summary ))
+    |> fun l ->
+    let rec take n = function [] -> [] | h :: t -> if n <= 0 then [] else h :: take (n - 1) t in
+    take max_tool_calls l
+  in
+  let updated_meta =
+    { updated_meta with
+      runtime = { updated_meta.runtime with last_turn_tool_calls = tool_call_summaries }
+    }
+  in
   Keeper_turn_fsm.emit_transition
     ~keeper_name:meta.Keeper_types.name
     ~turn_id:keeper_turn_id


### PR DESCRIPTION
## Summary

- **(A) Dynamic task state in `masc_transition` descriptor**: At tool assembly time, the descriptor reads current task status from backlog and appends valid next actions. This prevents LLM (particularly qwen) from repeatedly calling `masc_transition(start)` on an already `in_progress` task.
- **(B) Tool call history in continuity summary**: `agent_runtime_state` gains `last_turn_tool_calls` (tool_name + outcome). Persisted in JSON, included in continuity summary after compaction/handoff.

## Changes

| File | Change |
|------|--------|
| `keeper_tools_oas_bundle.ml` | Task A: `task_state_hint` enriches `masc_transition` description |
| `keeper_meta_contract.ml/mli` | Task B: `tool_call_summary` type + `last_turn_tool_calls` field |
| `keeper_types.mli` | Task B: facade re-declaration |
| `keeper_unified_turn_success.ml` | Task B: success-path tool call capture (max 10) |
| `keeper_unified_metrics_result.ml` | Task B: runtime state update default |
| `keeper_unified_metrics_failure.ml` | Task B: failure-path runtime update |
| `keeper_turn_up_create.ml` | Task B: initial construction |
| `keeper_meta_json.ml` | Task B: JSON serialization |
| `keeper_meta_json_parse.ml` | Task B: JSON deserialization with fallback |
| `agent_tool_memory_runtime.ml` | Task B: continuity summary includes `recent_tool_calls` |

## Test plan

- [x] `dune build` passes (11 files, +88/-1)
- [ ] Runtime: `masc_transition` descriptor shows task state
- [ ] Runtime: JSON `last_turn_tool_calls` field present after turn
- [ ] Runtime: continuity summary includes `recent_tool_calls` after compaction
- [ ] qwen: reduced repeated `masc_transition(start)` attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)