### PR TITLE
perf(auth): mtime-keyed cache for Auth.load_auth_config

### DIFF
--- a/lib/auth_credential_base.ml
+++ b/lib/auth_credential_base.ml
@@ -135,22 +135,72 @@ let persist_auth_config config (auth_cfg : auth_config) =
   save_private_text_file file (Yojson.Safe.pretty_to_string json)
 ;;
 
+(* mtime-keyed cache for [load_auth_config].
+
+   Every authenticated HTTP request and every WS/MCP transport
+   credential check funnels through [Auth.load_auth_config], which
+   did a [file_exists] + [read_text_file] + [Yojson.Safe.from_string]
+   on every call.  Under live dashboard load that meant hundreds of
+   identical disk reads per second of the same JSON file, with the
+   parse showing up on Eio main-domain profiles.
+
+   Cache policy: keep the most recently observed
+   [{ file; mtime; parsed }] in an [Atomic.t].  If the next call's
+   [(file, mtime)] pair matches, return the cached value.  Different
+   file path, newer mtime, or missing file all fall through to a
+   fresh read.
+
+   Why mtime alone (no content hash): the auth config is mutated in
+   this process only by [persist_auth_config], which writes via
+   [save_private_text_file] (atomic rename).  Any external editor
+   bumps mtime.  Hashing would catch the case where a tool restores
+   an identical-content file with an older mtime, but the worst
+   outcome there is one extra reload — still cheaper than reloading
+   on every request.
+
+   Why a single-slot cache instead of a per-base-path map: the server
+   runs against one [base_path] for the lifetime of the process.
+   Tests that swap configs pay the miss-rebuild cost on the first
+   call after each swap.
+
+   Multi-domain safety: [Atomic.set] publishes the new immutable
+   record atomically; readers see either the previous record or the
+   new one, never a torn entry. *)
+type auth_config_cache_entry = {
+  file : string;
+  mtime : float;
+  parsed : auth_config;
+}
+
+let auth_config_cache : auth_config_cache_entry option Atomic.t =
+  Atomic.make None
+
 (** Load auth config *)
 let load_auth_config config : auth_config =
   let file = auth_config_file config in
-  if file_exists file
-  then (
-    try
-      let content = read_text_file file in
-      let json = Yojson.Safe.from_string content in
-      match auth_config_of_yojson json with
-      | Ok cfg -> cfg
-      | Error msg ->
-        Log.Auth.warn "[load_auth_config] parse error for %s: %s" file msg;
-        default_auth_config
-    with
-    | Sys_error _ | Yojson.Json_error _ -> default_auth_config)
-  else default_auth_config
+  match (try Some (Unix.stat file).Unix.st_mtime with _ -> None) with
+  | None ->
+    (* File missing or unreadable — same fallback as the historical
+       [file_exists] branch.  Do not poison the cache. *)
+    default_auth_config
+  | Some mtime ->
+    (match Atomic.get auth_config_cache with
+     | Some entry
+       when String.equal entry.file file && Float.equal entry.mtime mtime ->
+       entry.parsed
+     | _ ->
+       (try
+          let content = read_text_file file in
+          let json = Yojson.Safe.from_string content in
+          match auth_config_of_yojson json with
+          | Ok parsed ->
+            Atomic.set auth_config_cache (Some { file; mtime; parsed });
+            parsed
+          | Error msg ->
+            Log.Auth.warn "[load_auth_config] parse error for %s: %s" file msg;
+            default_auth_config
+        with
+        | Sys_error _ | Yojson.Json_error _ -> default_auth_config))
 ;;
 
 (** Save auth config *)


### PR DESCRIPTION
## 요약

`Auth.load_auth_config`이 매 인증 요청마다 `file_exists` + `read_text_file` + `Yojson.Safe.from_string`를 했습니다. 라이브 대시보드 load에서 같은 JSON 파일을 초당 수백 번 동일하게 읽고 parse. `Atomic.t` 기반 mtime 캐시로 wrap.

## 영향 범위 (caller 10+곳)

```
lib/auth_doctor.ml:200
lib/mcp_server_eio_execute.ml:286
lib/tool_misc_admin.ml:124, 250, 281
lib/auth_login.ml:65
lib/local/worker_container_types.ml:611
lib/tool_coord.ml:118
lib/server/server_mcp_transport_ws.ml:312
lib/auth_credential_base.ml:139  ← 이 PR이 캐시 wrap
```

모두 시그니처 동일 — `Auth.load_auth_config config : auth_config`. 사이트 변경 0.

## 변경 (1 파일, +56 / -12)

`lib/auth_credential_base.ml:139`:

```ocaml
type auth_config_cache_entry = {
  file : string;
  mtime : float;
  parsed : auth_config;
}

let auth_config_cache : auth_config_cache_entry option Atomic.t =
  Atomic.make None

let load_auth_config config : auth_config =
  let file = auth_config_file config in
  match (try Some (Unix.stat file).Unix.st_mtime with _ -> None) with
  | None -> default_auth_config
  | Some mtime ->
    (match Atomic.get auth_config_cache with
     | Some entry
       when String.equal entry.file file && Float.equal entry.mtime mtime ->
       entry.parsed
     | _ -> (* fresh read + parse + Atomic.set *) ...)
```

## 디자인 결정

**Why mtime only (no content hash)**: `persist_auth_config`이 `save_private_text_file` (atomic rename)으로 쓰므로 어떤 mutation도 mtime을 bump. 외부 editor가 동일 내용을 older mtime으로 restore하는 false-positive 케이스만 있고, worst outcome = 한 번 더 reload — 여전히 매 요청마다 reload보다 저렴.

**Why 단일 slot (per-base-path map 아님)**: 서버는 process lifetime 동안 단일 base_path. 테스트가 config swap하면 첫 호출에서 miss → rebuild. 1회 비용.

**Multi-domain safety**: `Atomic.set`이 immutable record를 atomic publish. reader는 이전 record 또는 새 record 둘 중 하나만 봄, torn entry 불가. mutex 불필요.

## 검증

- `dune build _build/default/lib/.masc_mcp.objs/byte/masc_mcp__Auth_credential_base.cmo` 성공.
- 함수 시그니처 동일. 응답 동작 동일 (missing file / parse error → `default_auth_config`).
- 모든 caller 영향 0.

## Workaround Signature Gate

CLAUDE.md §워크어라운드 거부 기준 7항목 비해당:
1. telemetry-as-fix ❌
2. string/substring 분류기 ❌
3. N-of-M ❌
4. catch-all ❌
5. cap/cooldown/dedup/repair ❌ (mtime keyed cache는 표준 memoization)
6. test backdoor ❌
7. typo 반복 ❌

## RFC Discovery

이 변경은 auth credential subsystem touch — RFC-WAIVED 명시:

RFC-WAIVED: load_auth_config의 결과는 호출 사이트와 동작이 동일. mtime 기반 atomic cache는 표준 memoization 패턴이며, credential / identity / sandbox / repo manager 등 RFC 영역의 본질 동작은 무변경. 캐시 누락(stale)이 자동 자기 치유 (다음 mtime tick에서 invalidate).

## Related

- #18991 / #18993 / #18994 / #19007 (cache + Domain_pool offload)
- #19000 (cache size 64→256)
- #19010 (timestamp key pollution root)
