### PR TITLE
refactor(dashboard): rename CrashCategory homonyms to encode RFC-0174 source vs UI variant

### DIFF
--- a/dashboard/src/components/keeper-supervisor-diagnostics.ts
+++ b/dashboard/src/components/keeper-supervisor-diagnostics.ts
@@ -14,7 +14,7 @@ import {
   groupCrashCohorts,
   filterCrashLog,
   CRASH_CATEGORY_KEYS,
-  type CrashCategory,
+  type SupervisorCrashCategory,
 } from './keeper-supervisor-helpers'
 import type { Keeper, KeeperSupervisorCrashLogEntry } from '../types'
 
@@ -22,7 +22,7 @@ function MutedLabel({ children }: { children: unknown }) {
   return html`<span class="text-xs text-[var(--color-fg-muted)]">${children}</span>`
 }
 
-type CrashFilterKey = 'all' | CrashCategory
+type CrashFilterKey = 'all' | SupervisorCrashCategory
 
 // Module-level signals (per-keeper instance ok — panel only renders for active keeper).
 const crashCategoryFilter = signal<CrashFilterKey>('all')
@@ -43,7 +43,7 @@ function registryStateBadge(state: string | null) {
   return html`<span class="inline-flex items-center py-0.5 px-2 rounded-[var(--r-1)] text-3xs font-semibold ${c.bg} ${c.text}">${state}</span>`
 }
 
-const COHORT_COLORS: Record<CrashCategory, string> = {
+const COHORT_COLORS: Record<SupervisorCrashCategory, string> = {
   heartbeat: 'var(--amber-bright)',
   turn: 'var(--color-status-err)',
   fiber: 'var(--stalled-fg)',

--- a/dashboard/src/components/keeper-supervisor-helpers.ts
+++ b/dashboard/src/components/keeper-supervisor-helpers.ts
@@ -1,11 +1,20 @@
 // Pure helpers for keeper-supervisor-diagnostics.
 // Kept separate so they are unit-testable without preact rendering.
+//
+// `SupervisorCrashCategory` is the production UI variant of crash-reason
+// classification. A separate RFC-0174 source (`LibCrashCategory` /
+// `classifyCrashReasonLib`) lives in `lib/keeper-classifiers.ts` and
+// diverges on the unmatched fallback (`'unknown'` there vs `'other'`
+// here). The two are intentional homonyms — the RFC-0174 source has no
+// production callsite today, so this variant is the de-facto production
+// SSOT, with `'other'` chosen as a UI-friendly bucket label. See the
+// lib file for the migration trade-off.
 
 import type { KeeperSupervisorCrashLogEntry } from '../types'
 
-export type CrashCategory = 'heartbeat' | 'turn' | 'fiber' | 'exception' | 'other'
+export type SupervisorCrashCategory = 'heartbeat' | 'turn' | 'fiber' | 'exception' | 'other'
 
-export const CRASH_CATEGORY_KEYS: readonly CrashCategory[] = [
+export const CRASH_CATEGORY_KEYS: readonly SupervisorCrashCategory[] = [
   'heartbeat',
   'turn',
   'fiber',
@@ -18,21 +27,21 @@ export const CRASH_CATEGORY_KEYS: readonly CrashCategory[] = [
 // "turn_execution_failed", "fiber_crash", "Exception: …" — the prefix
 // determines the cohort. Kept as an explicit prefix→category map so new
 // prefixes require an entry here rather than falling through silently.
-const CRASH_PREFIX_MAP: ReadonlyArray<{ readonly prefix: string; readonly category: CrashCategory }> = [
+const CRASH_PREFIX_MAP: ReadonlyArray<{ readonly prefix: string; readonly category: SupervisorCrashCategory }> = [
   { prefix: 'heartbeat', category: 'heartbeat' },
   { prefix: 'turn', category: 'turn' },
   { prefix: 'fiber', category: 'fiber' },
   { prefix: 'exception', category: 'exception' },
 ]
 
-export function categorizeCrashReason(reason: string | null | undefined): CrashCategory {
+export function categorizeCrashReason(reason: string | null | undefined): SupervisorCrashCategory {
   if (!reason) return 'other'
   const lower = reason.toLowerCase()
   // Defensive exact-match: if backend emits the category name directly
   // (e.g. "heartbeat" instead of "heartbeat_timeout"), prefer that
   // over prefix heuristic so "heartbeat" does not collide with an
   // unrelated longer prefix.
-  if (CRASH_CATEGORY_KEYS.includes(lower as CrashCategory)) return lower as CrashCategory
+  if (CRASH_CATEGORY_KEYS.includes(lower as SupervisorCrashCategory)) return lower as SupervisorCrashCategory
   for (const { prefix, category } of CRASH_PREFIX_MAP) {
     if (lower.startsWith(prefix)) return category
   }
@@ -44,8 +53,8 @@ export function categorizeCrashReason(reason: string | null | undefined): CrashC
  */
 export function groupCrashCohorts(
   crash_log: readonly KeeperSupervisorCrashLogEntry[],
-): Partial<Record<CrashCategory, number>> {
-  const cohorts: Partial<Record<CrashCategory, number>> = {}
+): Partial<Record<SupervisorCrashCategory, number>> {
+  const cohorts: Partial<Record<SupervisorCrashCategory, number>> = {}
   for (const e of crash_log) {
     const key = categorizeCrashReason(e.reason)
     cohorts[key] = (cohorts[key] ?? 0) + 1
@@ -59,7 +68,7 @@ export function groupCrashCohorts(
  */
 export function filterCrashLog(
   crash_log: readonly KeeperSupervisorCrashLogEntry[],
-  category: 'all' | CrashCategory,
+  category: 'all' | SupervisorCrashCategory,
 ): KeeperSupervisorCrashLogEntry[] {
   if (category === 'all') return crash_log.slice()
   return crash_log.filter((e) => categorizeCrashReason(e.reason) === category)

--- a/dashboard/src/lib/keeper-classifiers.test.ts
+++ b/dashboard/src/lib/keeper-classifiers.test.ts
@@ -3,13 +3,13 @@ import {
   keeperPriority,
   isOfflineStatus,
   isAttentionCodeSatisfied,
-  classifyCrashReason,
+  classifyCrashReasonLib,
   isApproveVerdict,
   verdictWithoutRejectPrefix,
   verdictToneClass,
   railStatusMessage,
 } from './keeper-classifiers'
-import type { KeeperPriority, CrashCategory } from './keeper-classifiers'
+import type { KeeperPriority, LibCrashCategory } from './keeper-classifiers'
 
 describe('keeperPriority', () => {
   it.each(['active', 'running', 'thinking', 'tool_use', 'claimed', 'in_progress'] as const)
@@ -56,7 +56,7 @@ describe('isAttentionCodeSatisfied', () => {
   })
 })
 
-describe('classifyCrashReason', () => {
+describe('classifyCrashReasonLib', () => {
   it.each([
     ['heartbeat', 'heartbeat'],
     ['heartbeat_timeout', 'heartbeat'],
@@ -69,12 +69,12 @@ describe('classifyCrashReason', () => {
     ['exception_io', 'exception'],
   ] as const)
   ('classifies "%s" as %s', (input, expected) => {
-    expect(classifyCrashReason(input)).toBe<CrashCategory>(expected)
+    expect(classifyCrashReasonLib(input)).toBe<LibCrashCategory>(expected)
   })
 
   it('returns unknown for unrecognized reason', () => {
-    expect(classifyCrashReason('random_error')).toBe<CrashCategory>('unknown')
-    expect(classifyCrashReason('')).toBe<CrashCategory>('unknown')
+    expect(classifyCrashReasonLib('random_error')).toBe<LibCrashCategory>('unknown')
+    expect(classifyCrashReasonLib('')).toBe<LibCrashCategory>('unknown')
   })
 })
 

--- a/dashboard/src/lib/keeper-classifiers.ts
+++ b/dashboard/src/lib/keeper-classifiers.ts
@@ -50,15 +50,31 @@ export function isAttentionCodeSatisfied(code: string): boolean {
   return code.startsWith('satisfied')
 }
 
-// ── Crash reason classification ──────────────────────────
+// ── Crash reason classification (RFC-0174 SSOT source) ───
+//
+// `LibCrashCategory` and `classifyCrashReasonLib` are the RFC-0174
+// source for crash-reason classification. A separate production-side
+// variant lives at `components/keeper-supervisor-helpers.ts`
+// (`SupervisorCrashCategory` / `categorizeCrashReason`) and diverges on
+// the unmatched fallback — this file returns `'unknown'`, the
+// supervisor variant returns `'other'`. The two are intentional
+// homonyms today (no production callsite of `classifyCrashReasonLib`
+// exists, so the supervisor variant is the de-facto production SSOT),
+// not a missed unification.
+//
+// Migrating the supervisor variant onto this RFC-0174 source — which
+// would consolidate the diverging fallback literal and the
+// `COHORT_COLORS` Record key — is a design call (`'unknown'` is more
+// semantically truthful for *classification failure*, `'other'` is more
+// UI-friendly as a *displayed bucket label*) and is tracked separately.
 
-export type CrashCategory = 'heartbeat' | 'turn' | 'fiber' | 'exception' | 'unknown'
+export type LibCrashCategory = 'heartbeat' | 'turn' | 'fiber' | 'exception' | 'unknown'
 
-const CRASH_EXACT: ReadonlySet<CrashCategory> = new Set<CrashCategory>([
+const CRASH_EXACT: ReadonlySet<LibCrashCategory> = new Set<LibCrashCategory>([
   'heartbeat', 'turn', 'fiber', 'exception',
 ])
 
-const CRASH_PREFIX_MAP: readonly { prefix: string; category: CrashCategory }[] = [
+const CRASH_PREFIX_MAP: readonly { prefix: string; category: LibCrashCategory }[] = [
   { prefix: 'heartbeat', category: 'heartbeat' },
   { prefix: 'turn', category: 'turn' },
   { prefix: 'fiber', category: 'fiber' },
@@ -66,10 +82,12 @@ const CRASH_PREFIX_MAP: readonly { prefix: string; category: CrashCategory }[] =
 ]
 
 /** Classify a raw crash reason string into a typed category.
- *  Exact match preferred over prefix heuristic to avoid ambiguity. */
-export function classifyCrashReason(raw: string): CrashCategory {
+ *  Exact match preferred over prefix heuristic to avoid ambiguity.
+ *  RFC-0174 SSOT source — see file-level note for divergence from the
+ *  production `categorizeCrashReason` UI helper. */
+export function classifyCrashReasonLib(raw: string): LibCrashCategory {
   const lower = raw.toLowerCase()
-  if (CRASH_EXACT.has(lower as CrashCategory)) return lower as CrashCategory
+  if (CRASH_EXACT.has(lower as LibCrashCategory)) return lower as LibCrashCategory
   for (const { prefix, category } of CRASH_PREFIX_MAP) {
     if (lower.startsWith(prefix)) return category
   }


### PR DESCRIPTION
## 요약
같은 이름 + 다른 union literal 인 `CrashCategory` 동음이의어 2 정의를 정책 인코딩 이름 (`LibCrashCategory` / `SupervisorCrashCategory`) 으로 rename 합니다. iter#19 의 `errorMessage` 4-way rename sweep 패턴을 *RFC source vs production UI* 2-way 케이스에 적용.

## 배경

`rg "^export type \w+ = " --no-filename -o -r '$1' | sort | uniq -d` 결과 `CrashCategory` 2 사이트 발견:

| 파일 | 정의 | 사용 |
|---|---|---|
| `lib/keeper-classifiers.ts:55` | `'heartbeat' \| 'turn' \| 'fiber' \| 'exception' \| 'unknown'` | RFC-0174 SSOT source; `classifyCrashReason` 가 unmatched → `'unknown'`; **production callsite 0** (test-only) |
| `components/keeper-supervisor-helpers.ts:6` | `'heartbeat' \| 'turn' \| 'fiber' \| 'exception' \| 'other'` | de-facto production SSOT; `categorizeCrashReason` 가 unmatched → `'other'`; `keeper-supervisor-diagnostics.ts` 의 `COHORT_COLORS: Record<CrashCategory, string>` 가 consume |

두 정의는 **서로 import 안 함** → 컴파일러가 cross-reference 못 잡음 → silent drift. 새 prefix 추가 시 한 쪽만 갱신될 위험. 정책 차이 (`'unknown'` = semantically truthful for *classification failure*, `'other'` = UI-friendly *displayed bucket label*) 가 *의도된 분리* 이지만 *이름이 같아서 통합 안전한 것처럼 보이는* 함정.

## 변경

- `lib/keeper-classifiers.ts`: `CrashCategory` → `LibCrashCategory`, `classifyCrashReason` → `classifyCrashReasonLib`. 파일 헤더에 *RFC-0174 source* + supervisor 변형과의 차이 명시.
- `components/keeper-supervisor-helpers.ts`: `CrashCategory` → `SupervisorCrashCategory`. 파일 헤더에 *production UI variant* + lib 변형과의 차이 명시.
- `components/keeper-supervisor-diagnostics.ts`: import 갱신 (1 type alias + `CrashFilterKey` + `COHORT_COLORS` 매핑).
- `lib/keeper-classifiers.test.ts`: import + assertion type annotation 갱신.

`CRASH_PREFIX_MAP` 두 정의는 그대로 (file-local private const, 이름 collision 없음).

## RFC-0174 production migration 별도 결정

본 PR scope 밖. 향후 디자인 결정:
1. supervisor 변형을 RFC-0174 source 로 흡수 — `'unknown'` adopt, `COHORT_COLORS` Record key 갱신, UI 라벨도 `'unknown'` (의미 명확)
2. RFC-0174 의 dead `classifyCrashReasonLib` 삭제 — RFC-0174 intent 포기
3. 둘 다 유지 (현 상태) — 본 PR 의 rename 으로 silent drift 만 방지

옵션 1 이 가장 정직하지만 UI 라벨 변경 + screenshot 영향. 옵션 2 는 RFC waiver. 옵션 3 (현 상태) 이 surgical.

## 검증

- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline, iter#23/27/33/34 과 동일)
- 첫 run 시 `git-graph-panel.test.ts` + `use-focus-scope.test.ts` 추가 fail 관찰 → 격리 단독 = PASS (15/15, 7/7), 재실행 = baseline 1 fail. **flaky test pair**, 본 PR 변경 무관. iter#34 와 동일한 vitest worker scheduling 비결정성 양상.
- 런타임 동작 변경 0 (pure rename)

## /loop iter#35

SSOT 위반 dashboard 축출 loop 의 iter#35. cumulative 35 PR (23 머지 + 1 OPEN).

RFC-WAIVED: pure type/function rename refactor — runtime behavior 변경 0건. RFC-0174 source 와 supervisor variant 둘 다 *정책이 다른 동음이의어* 임을 이름에 박아 silent drift 만 방지. credential/auth 도메인 로직 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
