### PR TITLE
perf(transport): drop blocking Unix.connect from tcp_port_reachable

### DIFF
--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -108,26 +108,42 @@ let maybe_configured_fields ~include_configured enabled =
   if include_configured then [ "configured", `Bool enabled ] else []
 ;;
 
-let tcp_port_reachable port =
-  try
-    let sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-    Eio_guard.protect
-      ~finally:(fun () ->
-        try Unix.close sock with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn ->
-          Printf.eprintf
-            "[transport_read_model] tcp_port_reachable close failed: %s\n%!"
-            (Printexc.to_string exn))
-      (fun () ->
-         Unix.connect
-           sock
-           (Unix.ADDR_INET
-              (Unix.inet_addr_of_string Masc_network_defaults.masc_http_default_host, port));
-         true)
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> false
+(* [tcp_port_reachable] used to open a stdlib [Unix.socket], call
+   [Unix.connect] against the configured loopback host, and close the
+   socket — all synchronously on the calling fiber's Eio domain.
+
+   That implementation is incompatible with Eio's cooperative
+   scheduling: from the official docs,
+
+     "When a fiber executes CPU-bound or blocking I/O work without
+      yielding control, it blocks all other fibers in that domain."
+
+   The probe was wired into every /health response builder
+   ([websocket_discovery_json], [transport_status_json]) where it
+   short-circuits behind [Transport_metrics.{ws,grpc}_listening].
+   Under normal operation the listening flag is [true] and the
+   stdlib call never runs.  But during startup / warm-up the
+   listening flag is [false] and every concurrent /health probe
+   queued waiting for a blocking [Unix.connect], stalling every
+   other fiber on the main Eio HTTP domain for the duration of the
+   connect.  Concurrent dashboard requests saw this as multi-second
+   latency cliffs at startup.
+
+   Fix: drop the blocking probe entirely.  Callers already OR with
+   the in-memory listening flag, so:
+
+   - listening = true  → reachable = true   (unchanged)
+   - listening = false → reachable = false  (warming up, accurate)
+
+   The latter is the truthful state during warm-up — a listener that
+   has not bound the socket yet is not reachable.  The previous
+   implementation could only have flipped this to [true] by racing
+   against another listener binding the same port, which is not a
+   useful signal.
+
+   Argument kept for API stability; callers still pass [port] from
+   the relevant configured-port lookup but the value is unused. *)
+let tcp_port_reachable (_port : int) : bool = false
 ;;
 
 let websocket_discovery_json (ctx : http_context) =


### PR DESCRIPTION
## 요약

`tcp_port_reachable` (lib/transport_read_model.ml:111)이 매 `/health` 응답 빌드마다 stdlib `Unix.socket` + `Unix.connect` + `Unix.close`를 sync로 실행하던 문제. listening metric이 false인 워밍업 시점에 fallback으로 발동 → blocking syscall이 Eio 메인 도메인 전체 stall. 함수 본문을 `false` return stub으로 교체.

## Eio 공식 문서 인용

> "When a fiber executes CPU-bound or blocking I/O work without yielding control, it blocks all other fibers in that domain."

## 영향 경로

`tcp_port_reachable`는 두 곳에서 호출:

```ocaml
(* lib/transport_read_model.ml:136 *)
let reachable = Transport_metrics.ws_listening () || tcp_port_reachable port in

(* lib/transport_read_model.ml:175 *)
let grpc_reachable = Transport_metrics.grpc_listening () || tcp_port_reachable grpc_port
```

- 정상 동작: `*_listening = true` → short-circuit, stdlib call 안 일어남
- **워밍업 시점**: `*_listening = false` → blocking `Unix.connect` 실행 → 도메인 stall

## 변경 (1 파일, +36 / -20)

```ocaml
let tcp_port_reachable (_port : int) : bool = false
```

함수 시그니처 동일 (`int -> bool`). caller 두 곳 시그니처 무영향.

| 시나리오 | 변경 전 | 변경 후 |
|---|---|---|
| `*_listening = true` | reachable = true | reachable = true (동일) |
| `*_listening = false` (warming up) | blocking connect → stall + 결과 | reachable = false (정확) |

워밍업 중 listener가 socket 안 bind한 상태 = 진짜로 not-yet-reachable. 이전 구현은 다른 listener와 port race로만 true 반환할 수 있었고 그건 유용한 신호가 아닙니다.

## 검증

- `dune build _build/default/lib/.masc_mcp.objs/byte/masc_mcp__Transport_read_model.cmo` 성공.
- 함수 시그니처 동일, caller 영향 0.
- 응답 JSON 스키마 무변경 (`reachable` boolean 그대로).

## Workaround Signature Gate

CLAUDE.md §워크어라운드 거부 기준 7항목 비해당:
1. telemetry-as-fix ❌
2. string/substring 분류기 ❌
3. N-of-M ❌
4. catch-all ❌
5. cap/cooldown/dedup/repair ❌ (blocking syscall 제거는 root fix)
6. test backdoor ❌
7. typo 반복 ❌

## Related

- #18994 (`/health` refresh worker-domain offload) — companion fix.
  - #18994는 refresh 시점의 메인 도메인 stall 제거
  - 이 PR은 probe 호출 자체의 메인 도메인 stall 제거
