### PR TITLE
perf(verification): single-scan helper for /dashboard/proof (load_requests 2x → 1x)

### DIFF
--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -209,9 +209,10 @@ let take n lst =
 let now_iso () = Masc_domain.now_iso ()
 let fd_pressure_fields () = Keeper_fd_pressure.projection_fields ()
 
-let requests_json ?base_path ?task_id ?limit () : Yojson.Safe.t =
-  let limit = clamp_limit limit in
-  let all = load_requests ?base_path () in
+(* Compute the request-listing projection from an already-loaded list.
+   Factored out so [proof_compose] can share the disk scan between
+   summary and request listing. *)
+let requests_json_of_requests ?task_id ~limit all : Yojson.Safe.t =
   let filtered = filter_by_task_id all task_id in
   let sorted = sort_desc filtered in
   let trimmed = take limit sorted in
@@ -221,6 +222,11 @@ let requests_json ?base_path ?task_id ?limit () : Yojson.Safe.t =
      ; ("requests", `List (List.map request_to_json trimmed))
      ]
      @ fd_pressure_fields ())
+
+let requests_json ?base_path ?task_id ?limit () : Yojson.Safe.t =
+  let limit = clamp_limit limit in
+  let all = load_requests ?base_path () in
+  requests_json_of_requests ?task_id ~limit all
 
 (* ── Summary projection ─────────────────────────────── *)
 
@@ -261,9 +267,11 @@ let is_rejected (req : V.verification_request) : bool =
 let bucket_of_status (req : V.verification_request) : string =
   req |> status_bucket_of_request |> status_bucket_to_string
 
-let summary_json ?base_path ?recent () : Yojson.Safe.t =
-  let recent = clamp_recent recent in
-  let all = load_requests ?base_path () in
+(* Compute the summary projection from an already-loaded request list.
+   Factored out so [proof_compose] can share the disk scan between
+   summary and request listing. *)
+let summary_json_of_requests ~recent all : Yojson.Safe.t =
+  let recent = clamp_recent (Some recent) in
   let total = List.length all in
   let pending = ref 0 in
   let approved = ref 0 in
@@ -295,3 +303,23 @@ let summary_json ?base_path ?recent () : Yojson.Safe.t =
      ; ("recent_rejections", `List recent_rejections)
      ]
      @ fd_pressure_fields ())
+
+let summary_json ?base_path ?recent () : Yojson.Safe.t =
+  let recent = Option.value recent ~default:default_recent in
+  let all = load_requests ?base_path () in
+  summary_json_of_requests ~recent all
+
+(* Single-load companion for handlers that emit both projections
+   side-by-side ([/api/v1/dashboard/proof] is the live caller).
+
+   [summary_json] and [requests_json] each call [load_requests], so
+   the historic proof handler scanned the verification store twice
+   per refresh.  This helper performs one scan and folds the two
+   projections from the shared list. *)
+let proof_compose ?base_path ?recent ?limit () : Yojson.Safe.t * Yojson.Safe.t =
+  let recent = Option.value recent ~default:default_recent in
+  let limit = clamp_limit limit in
+  let all = load_requests ?base_path () in
+  let summary = summary_json_of_requests ~recent all in
+  let requests = requests_json_of_requests ~limit all in
+  summary, requests

--- a/lib/dashboard/dashboard_verification.mli
+++ b/lib/dashboard/dashboard_verification.mli
@@ -90,3 +90,21 @@ val requests_json :
       }
     ]} *)
 val summary_json : ?base_path:string -> ?recent:int -> unit -> Yojson.Safe.t
+
+(** Single-load companion to {!summary_json} + {!requests_json}.
+
+    Handlers that emit both projections side-by-side
+    ([/api/v1/dashboard/proof] is the live caller) previously called
+    {!summary_json} and {!requests_json} back-to-back, each
+    performing its own [Verification.list_requests] disk scan.
+    [proof_compose] performs one scan and folds both projections
+    from the shared list, halving the on-disk read cost per refresh.
+
+    The two returned values use the same shapes documented on
+    {!summary_json} and {!requests_json}. *)
+val proof_compose :
+  ?base_path:string ->
+  ?recent:int ->
+  ?limit:int ->
+  unit ->
+  Yojson.Safe.t * Yojson.Safe.t

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -187,11 +187,11 @@ let dashboard_governance_tool_events_http_json request : Yojson.Safe.t =
    so the main domain keeps serving requests during refresh. *)
 let dashboard_proof_compute ~config ~limit ~recent () : Yojson.Safe.t =
   let base_path = config.Coord.base_path in
-  let verification_summary =
-    Dashboard_verification.summary_json ~base_path ~recent ()
-  in
-  let verification_requests =
-    Dashboard_verification.requests_json ~base_path ~limit ()
+  (* Single disk scan via [proof_compose]; the historical
+     [summary_json] + [requests_json] sequence walked the verification
+     store twice per refresh. *)
+  let verification_summary, verification_requests =
+    Dashboard_verification.proof_compose ~base_path ~recent ~limit ()
   in
   let proof_source ~id ~label ~route =
     `Assoc [ "id", `String id; "label", `String label; "route", `String route ]


### PR DESCRIPTION
## 요약

`dashboard_proof_compute` (/api/v1/dashboard/proof 본문)이 `Dashboard_verification.summary_json` + `requests_json`을 back-to-back 호출 → 각자 내부에서 `load_requests` 호출 → **같은 disk scan 2회**. 새 helper `Dashboard_verification.proof_compose`가 한 번 scan하고 둘 다 반환.

## 변경 (3 파일, +57 / -11)

### `lib/dashboard/dashboard_verification.ml`

- `summary_json_of_requests` / `requests_json_of_requests` 추출 (pure projection, list 받음).
- 기존 `summary_json` / `requests_json`은 동일 시그니처 + 내부에서 `load_requests` + projection helper 호출 (외부 동작 변경 0).
- **새**: `proof_compose ?base_path ?recent ?limit () : Yojson.Safe.t * Yojson.Safe.t` — `load_requests` 1회 + 두 projection.

### `lib/dashboard/dashboard_verification.mli`

- `proof_compose` 노출.

### `lib/server/server_dashboard_http.ml`

- `dashboard_proof_compute`에서:
```ocaml
(* before *)
let verification_summary = Dashboard_verification.summary_json ~base_path ~recent () in
let verification_requests = Dashboard_verification.requests_json ~base_path ~limit () in

(* after *)
let verification_summary, verification_requests =
  Dashboard_verification.proof_compose ~base_path ~recent ~limit ()
in
```

## 영향 검증

| caller | 동작 | 변경 |
|---|---|---|
| `server_dashboard_http.ml:dashboard_proof_compute` | proof_compose 사용 | 1× scan |
| 기타 `summary_json` / `requests_json` caller | 기존 그대로 | 영향 0 (cold path, 영향 미미) |

## 검증

- `dune build` 두 모듈 (Dashboard_verification, Server_dashboard_http) bytecode 성공.
- 응답 JSON 스키마 동일 — `summary_json_of_requests` / `requests_json_of_requests`가 기존 본문 그대로.
- `?recent` / `?limit` 기본값 동일.

## Workaround Signature Gate

CLAUDE.md §워크어라운드 거부 기준 7항목 비해당.

## Related

- #19007 (proof handler cache + Domain_pool offload) — 같은 endpoint를 다른 layer에서 보완
- #19000 (cache size 64→256) + #19010 (timestamp key) — cache hit ratio 회복
