### PR TITLE
refactor(coord): typed Coord.Not_initialized exception replaces 4 substring-on-Invalid_argument catch sites

### DIFF
--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -111,9 +111,27 @@ let validate_file_path_r path : (string, masc_error) result =
 (* Ensure initialized                           *)
 (* ============================================ *)
 
+(* Typed sentinel for the not-initialized case.
+
+   Before: [ensure_initialized] raised [Invalid_argument "MASC not
+   initialized. Use masc_init first."], and four downstream catch
+   sites recovered the case via [Printexc.to_string +
+   contains_casefold ... "masc not initialized"]. That was the
+   RFC-0088 §"String/Substring 분류기" anti-pattern in cross-module
+   form — a prose string round-tripped through the exception slot
+   to carry semantic information.
+
+   Registering a printer keeps existing telemetry/log paths that
+   format the exception via [Printexc.to_string] unchanged. *)
+exception Not_initialized
+
+let () =
+  Printexc.register_printer (function
+    | Not_initialized -> Some "MASC not initialized. Use masc_init first."
+    | _ -> None)
+
 let ensure_initialized config =
-  if not (is_initialized config) then
-    invalid_arg "MASC not initialized. Use masc_init first."
+  if not (is_initialized config) then raise Not_initialized
 
 let ensure_initialized_r config : (unit, masc_error) result =
   if is_initialized config then Ok ()

--- a/lib/coord/coord_utils_ops.mli
+++ b/lib/coord/coord_utils_ops.mli
@@ -31,6 +31,14 @@ val validate_file_path_r : string -> (string, masc_error) result
 
 (** {1 Initialization gates} *)
 
+(** Raised by [ensure_initialized] when the config is not initialized.
+    Replaces the previous [Invalid_argument "MASC not initialized..."]
+    that downstream sites recovered via [Printexc.to_string +
+    substring match] (RFC-0088 §"String/Substring 분류기" cross-module
+    form). The [Printexc] printer is registered so existing log paths
+    that format the exception keep the same human-readable message. *)
+exception Not_initialized
+
 val ensure_initialized : config -> unit
 val ensure_initialized_r : config -> (unit, masc_error) result
 

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -615,21 +615,22 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
                  ~tool_name:name ~start_time
                  (Printf.sprintf "Tool timed out after %.0fs: %s%s"
                     timeout_sec name source))
-     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | Coord.Not_initialized ->
+       (* RFC-0189: server bootstrap incomplete — Masc_domain
+          System NotInitialized.  [Runtime_failure] (caller
+          cannot fix; the operator must initialise MASC). *)
+       Tool_result.error
+         ~failure_class:(Some Tool_result.Runtime_failure)
+         ~tool_name:name ~start_time
+         (Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
+     | exn ->
        (* Never let a tool exception crash the MCP server. *)
        let err = Printexc.to_string exn in
        let trace = Printexc.get_backtrace () in
        let err_detail = if String.length trace > 0 then err ^ "\n" ^ trace else err in
-       if contains_casefold err "Invalid_argument(\"MASC not initialized" then
-         (* RFC-0189: server bootstrap incomplete — Masc_domain
-            System NotInitialized.  [Runtime_failure] (caller
-            cannot fix; the operator must initialise MASC). *)
-         Tool_result.error
-           ~failure_class:(Some Tool_result.Runtime_failure)
-           ~tool_name:name ~start_time
-           (Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
-       else
-         (Log.Mcp.error "tools/call crashed: %s" err_detail;
+       (Log.Mcp.error "tools/call crashed: %s" err_detail;
           (* RFC-0189: catch-all for unexpected exceptions —
              [Runtime_failure].  Could become more specific via
              [of_exn] once the exception variants are typed; for

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -765,7 +765,7 @@ let handle_request
                 |> Option.value ~default:`Null
               | method_ -> make_error_typed ~id Mcp_error_code.Method_not_found ("Method not found: " ^ method_)
             with
-            | Invalid_argument msg when contains_casefold msg "masc not initialized" ->
+            | Coord.Not_initialized ->
               make_error_typed
                 ~id
                 Mcp_error_code.Internal_error

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -20,16 +20,6 @@ let keeper_chat_stream_error_json message =
         `Assoc [ ("message", `String message) ] );
     ]
 
-(* Empty needle preserves the legacy "matches all" semantic; non-empty
-   matching delegates to the SSOT helper, which scans byte-wise with
-   inline [Char.lowercase_ascii] and avoids the two
-   [String.lowercase_ascii] allocations plus the per-position
-   [String.sub] of the old form. *)
-let contains_casefold haystack needle =
-  String.length needle = 0
-  || String_util.contains_substring_ci haystack needle
-
-
 (* No external timeout for keeper_msg. Keeper has its own internal limits
    (max_turns, max_cost_usd, max_tokens) that control call duration.
    A fixed external timeout conflicts with multi-turn tool-use loops and
@@ -54,13 +44,12 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
       | None -> (false, "masc_keeper_msg dispatch unavailable")
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Coord.Not_initialized ->
+        (false, Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
     | exn ->
         let err = Printexc.to_string exn in
-        if contains_casefold err "Invalid_argument(\"MASC not initialized" then
-          (false, Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
-        else (
-          Log.Mcp.error "tools/call crashed: %s" err;
-          (false, Printf.sprintf "Internal error: %s" err))
+        Log.Mcp.error "tools/call crashed: %s" err;
+        (false, Printf.sprintf "Internal error: %s" err)
   in
   let end_time = Eio.Time.now clock in
   let duration_ms = Keeper_timing.elapsed_duration_ms ~start_time ~end_time in
@@ -282,13 +271,12 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ state
       | None -> (false, "masc_keeper_msg stream dispatch unavailable")
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Coord.Not_initialized ->
+        (false, Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
     | exn ->
         let err = Printexc.to_string exn in
-        if contains_casefold err "Invalid_argument(\"MASC not initialized" then
-          (false, Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
-        else (
-          Log.Mcp.error "tools/call crashed (stream): %s" err;
-          (false, Printf.sprintf "Internal error: %s" err))
+        Log.Mcp.error "tools/call crashed (stream): %s" err;
+        (false, Printf.sprintf "Internal error: %s" err)
   in
   let end_time = Eio.Time.now clock in
   let duration_ms = Keeper_timing.elapsed_duration_ms ~start_time ~end_time in


### PR DESCRIPTION
## 요약

RFC-0088 §"String/Substring 분류기" anti-pattern 의 *cross-module* 형태 제거. PR #18977 (`LockContention` typed) / #18982 (`Unix.EEXIST` typed) / #19002 (`Eio.Fs.Not_found` typed) 시리즈의 4번째 — exception 타입이 *prose string 의 운반 슬롯* 으로 사용되던 패턴을 typed sentinel exception 으로 대체.

### Root pattern

`lib/coord/coord_utils_ops.ml:114-116`:

```ocaml
let ensure_initialized config =
  if not (is_initialized config) then
    invalid_arg "MASC not initialized. Use masc_init first."
```

`Invalid_argument` 가 *prose* 를 운반 → 4 consumer 가 `Printexc.to_string + contains_casefold` 로 재분류:

| 사이트 | 분류 키 |
|---|---|
| `lib/mcp_server_eio_protocol.ml:768` | `Invalid_argument msg when contains_casefold msg "masc not initialized"` |
| `lib/mcp_server_eio_call_tool.ml:623` | `contains_casefold err "Invalid_argument(\"MASC not initialized"` |
| `lib/server/server_routes_http_keeper_stream.ml:59` | (동일) |
| `lib/server/server_routes_http_keeper_stream.ml:287` | (동일) |

문제:
- exception 메시지 → string → substring match 라는 *우회 채널* 로 semantic information 전달
- libc/Printexc.to_string 형식이 변경되면 4 사이트 동시 silent fail
- compiler 가 새 producer 추가 시 consumer 누락을 감지 못 함

## 변경

### `Coord.Not_initialized` typed sentinel

```ocaml
(* lib/coord/coord_utils_ops.ml *)
exception Not_initialized

let () =
  Printexc.register_printer (function
    | Not_initialized -> Some "MASC not initialized. Use masc_init first."
    | _ -> None)

let ensure_initialized config =
  if not (is_initialized config) then raise Not_initialized
```

`Printexc.register_printer` 가 기존 telemetry/log 출력의 휴먼 메시지를 *완전 동등* 하게 유지 (`Printexc.to_string` 호출 경로는 무변경).

### Consumer 4 사이트 → typed match

before:
```ocaml
| Invalid_argument msg when contains_casefold msg "masc not initialized" ->
  ...handle as NotInitialized...
```

after:
```ocaml
| Coord.Not_initialized ->
  ...handle as NotInitialized...
```

`server_routes_http_keeper_stream.ml` 의 local `contains_casefold` helper 가 dead 가 되어 삭제 (8 LOC).

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 String/Substring 분류기 패턴을 *제거* 함 (typed sentinel exception 도입). pr-rfc-check 가 anti-pattern 언급을 시그니처 매치로 감지하나, 실제 코드 변경은 anti-pattern *deletion*:

- ❌ Counter-as-Fix — telemetry 추가 없음
- ✅ **String/substring 분류기 제거** — 4 사이트 동시
- ❌ N-of-M 패치 — 4 사이트 *모두* 동시 처리, 이외 substring 매치 0 추가
- ❌ Repair/Sanitize — symptom 억제 아닌 *typed exception 도입*

## Test impact

- `ensure_initialized` 의 23 caller 는 *호출자* (catch 안 함) → 영향 0
- 4 consumer 의 typed match 는 *동등한 분류* (Printexc.to_string 의 substring 매치 → constructor 매치)
- Telemetry log 출력 형식 *완전 동등* — `Printexc.register_printer` 가 동일 message 반환
- Full `dune build --root .` PASS (rebased onto `47becc144`, post-#19009 supervisor fix)

## Background — narrower grep audit

iter 39 PR #19002 이후 `when.*contains_substring|when.*contains_casefold` 가드 grep 으로 *cross-module Invalid_argument 분류 패턴* 4 사이트 발견. *Single ensure_initialized emit + 4 consumer* 의 명확한 N-of-M 안티패턴.

Total RFC-0088 §"String 분류기" 안티패턴 사이트 (consumer side, when-guard form):
- iter 35 ~ iter 39: 9 → 7 (2 사이트 제거)
- iter 40 (본 PR): 7 → 3 (4 사이트 제거)

남은 사이트 3은 *legitimate* (TLA+ output parse / docker stderr / trust snapshot heuristic).

## Related

- PR #18977 (lock contention typed)
- PR #18982 (mkdir EEXIST typed)
- PR #19002 (rename_if_exists typed)
- Issue #18986 (RFC scope candidates: Auth Unauthorized + SIGTERM log)
- RFC-0088 §"String/Substring 분류기" anti-pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
