### PR TITLE
fix(telemetry): add ~keeper_name to 19 Log.Task calls

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 (using menhir 3.0)
 
 (name masc_mcp)
-(version 0.19.32)
+(version 0.19.33)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)

--- a/lib/cdal_verdict_gate.ml
+++ b/lib/cdal_verdict_gate.ml
@@ -125,6 +125,7 @@ let lookup_latest_verdict ?base_dir
       if warn_on_missing
       then
         Log.Task.info
+          ~keeper_name:task_id
           "[cdal-gate] task_id=%s: starting window saturated (%d entries) \
            without match; widening to %d and re-scanning"
           task_id limit widened;
@@ -146,6 +147,7 @@ let lookup_latest_verdict ?base_dir
     | Some _, _ -> ()
     | None, [] ->
        Log.Task.warn
+         ~keeper_name:task_id
          "[cdal-gate] task_id=%s: cdal_verdicts ledger is EMPTY at %s. \
           Writer pipeline likely dormant — check that OAS Agent.run \
           emits result.proof and Cdal_eval_v1.persist is reached. (#10115)"
@@ -154,6 +156,7 @@ let lookup_latest_verdict ?base_dir
       if not (Hashtbl.mem saturation_warn_emitted task_id) then begin
         Hashtbl.add saturation_warn_emitted task_id ();
         Log.Task.warn
+          ~keeper_name:task_id
           "[cdal-gate] task_id=%s: scanned newest %d entries (auto-widened \
            %dx from MASC_CDAL_VERDICT_LOOKUP_LIMIT=%d) without match \
            (task_scoped=%d unscoped=%d). Older verdicts beyond this ceiling \
@@ -163,6 +166,7 @@ let lookup_latest_verdict ?base_dir
       end
     | None, _ ->
       Log.Task.warn
+        ~keeper_name:task_id
         "[cdal-gate] task_id=%s: no task-scoped verdict in current ledger \
          window (%d entries scanned, task_scoped=%d, unscoped=%d, below \
          limit=%d). CDAL writer is active; this task either has never \

--- a/lib/tool_task_contract_gate.ml
+++ b/lib/tool_task_contract_gate.ml
@@ -70,7 +70,8 @@ let persisted_contract_rejection ~(agent_name : string)
   | None -> None
   | Some task ->
     if not (Env_config_runtime.Cdal.gate_enabled ()) then begin
-      Log.Task.info "[cdal-gate] disabled, skipping for task=%s agent=%s"
+      Log.Task.info ~keeper_name:task.id
+        "[cdal-gate] disabled, skipping for task=%s agent=%s"
         task.id agent_name;
       None
     end else
@@ -90,6 +91,7 @@ let persisted_contract_rejection ~(agent_name : string)
           else Cdal_verdict_gate.advisory_gate_label
         in
         Log.Task.info
+          ~keeper_name:task.id
           "[cdal-gate] checking verdict for task=%s agent=%s strict=%b gate=%s"
           task.id agent_name contract.strict gate_label;
         let rejection =
@@ -104,6 +106,7 @@ let persisted_contract_rejection ~(agent_name : string)
           (match rejection with
            | Some msg ->
              Log.Task.info
+               ~keeper_name:task.id
                "[cdal-gate] advisory (strict=false) for task=%s: %s"
                task.id msg
            | None -> ());

--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -151,7 +151,8 @@ let sync_planning_current_task_with_owned_task (ctx : context) =
         (match Planning_eio.set_current_task ctx.config ~task_id with
          | Ok () -> ()
          | Error msg ->
-             Log.Task.warn "failed to sync planning current_task to %s: %s"
+             Log.Task.warn ~keeper_name:task_id
+               "failed to sync planning current_task to %s: %s"
                task_id msg)
     | None -> Planning_eio.clear_current_task ctx.config
 
@@ -406,7 +407,7 @@ let handle_claim ?agent_tool_names ~tool_name ~start_time ctx args =
          ("agent_name", `String ctx.agent_name);
          ("timestamp", `Float (Time_compat.now ()));
        ])
-   | Error e -> Log.Task.warn "task claim failed for %s: %s" task_id (Masc_domain.masc_error_to_string e));
+   | Error e -> Log.Task.warn ~keeper_name:task_id "task claim failed for %s: %s" task_id (Masc_domain.masc_error_to_string e));
   result_to_response ~tool_name ~start_time result
 
 (* Look up the current Goal_store phase for each goal id in the agent's

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -134,6 +134,7 @@ let warn_contract_gap (task : Masc_domain.task) =
   (match task.contract with
    | None ->
      Log.Task.warn
+       ~keeper_name:task.id
        "[verification-submit] task=%s has no contract — completion_contract \
         and evidence will be empty in the verification record"
        task.id
@@ -142,6 +143,7 @@ let warn_contract_gap (task : Masc_domain.task) =
           && c.required_evidence = []
           && c.verify_gate_evidence = [] ->
      Log.Task.warn
+       ~keeper_name:task.id
        "[verification-submit] task=%s has a contract but both \
        completion_contract and verification evidence are empty"
        task.id
@@ -159,6 +161,7 @@ let create_submit_request ~(config : Coord.config)
   | Ok _ -> Ok ()
   | Error e ->
     Log.Task.error
+      ~keeper_name:task.id
       "verification create_request failed (task=%s vrf=%s): %s"
       task.id verification_id e;
     Error e
@@ -198,6 +201,7 @@ let notify_submit_for_verification ~(config : Coord.config)
     | Ok _ -> ()
     | Error e ->
       Log.Task.error
+        ~keeper_name:task.id
         "board post failed (task=%s vrf=%s): %s"
         task.id verification_id (Board_types.show_board_error e)
   in
@@ -241,6 +245,7 @@ let record_approve_verification ~(config : Coord.config)
       Ok ()
     | Error e ->
       Log.Task.error
+        ~keeper_name:task_id
         "verification submit_verdict failed (task=%s vrf=%s verifier=%s): %s"
         task_id verification_id verifier e;
       Error e
@@ -267,6 +272,7 @@ let notify_approve_verification ~task_id ~verifier ~verification_id ~notes =
     | Ok _ -> ()
     | Error e ->
       Log.Task.error
+        ~keeper_name:task_id
         "board post failed (task=%s vrf=%s): %s"
         task_id verification_id (Board_types.show_board_error e)
   in
@@ -311,6 +317,7 @@ let record_reject_verification ~(config : Coord.config)
       Ok ()
     | Error e ->
       Log.Task.error
+        ~keeper_name:task_id
         "verification submit_verdict failed (task=%s vrf=%s verifier=%s): %s"
         task_id verification_id verifier e;
       Error e
@@ -336,6 +343,7 @@ let notify_reject_verification ~task_id ~verifier ~verification_id ~reason =
     | Ok _ -> ()
     | Error e ->
       Log.Task.error
+        ~keeper_name:task_id
         "board post failed (task=%s vrf=%s): %s"
         task_id verification_id (Board_types.show_board_error e)
   in
@@ -421,6 +429,7 @@ let check_timeouts ~(config : Coord.config) =
                | Ok _ -> ()
                | Error e ->
                  Log.Task.error
+                   ~keeper_name:task.id
                    "board post failed (task=%s vrf=%s): %s"
                    task.id verification_id (Board_types.show_board_error e)
              in
@@ -453,6 +462,7 @@ let check_timeouts ~(config : Coord.config) =
               | Ok _ -> ()
               | Error e ->
                 Log.Task.error
+                  ~keeper_name:task.id
                   "verification timeout transition failed (task=%s vrf=%s): %s"
                   task.id verification_id
                   (Masc_domain.show_masc_error e))


### PR DESCRIPTION
## Summary
- Add `~keeper_name` structured context to 19 `Log.Task.*` calls across 4 files where task_id was in scope but not propagated to the ring buffer
- `cdal_verdict_gate.ml`: 4 calls (verdict lookup + warn_on_missing branches)
- `tool_task_contract_gate.ml`: 3 calls (gate disabled/checked/advisory)
- `verification_protocol.ml`: 10 calls (submit/approve/reject/timeout error + warn paths)
- `tool_task_handlers.ml`: 2 calls (planning sync + task claim failure)

## Why
`Log.Task` ring buffer entries emitted by these paths had `keeper_name=null` in the JSON output, making it impossible to correlate log entries with specific tasks during debugging.

## Test plan
- [x] `dune build` passes (masc-mcp full build, rebased on latest main)
- [ ] Fleet log inspection: `keeper_name` field populated for cdal-gate / verification entries

## Excluded
- `anti_rationalization.ml` (16 calls): no task_id in module scope
- `log_ledger_health_warn_if_stale` (2 calls): boot-time health check, no task context
- `tool_task_handlers.ml` resolve_agent_name (2 calls): agent-level, not task-level

🤖 Generated with [Claude Code](https://claude.com/claude-code)