### PR TITLE
refactor(dashboard/mission-utils): remove dead relativeTime wrapper

### DIFF
--- a/dashboard/src/components/mission-utils.ts
+++ b/dashboard/src/components/mission-utils.ts
@@ -1,10 +1,6 @@
-import { relativeTime as relativeTimeBase, formatDuration } from '../lib/format-time'
+import { formatDuration } from '../lib/format-time'
 import { trimText } from '../lib/truncate'
 import { toneClass } from '../lib/tone'
 import { statusLabel } from '../lib/status-label'
 
 export { formatDuration, trimText, toneClass, statusLabel }
-
-export function relativeTime(iso?: string | null): string {
-  return relativeTimeBase(iso, '방금')
-}


### PR DESCRIPTION
## 요약
`components/mission-utils.ts` 의 dead `relativeTime` wrapper 5 lines 삭제. 동시에 `relativeTime` 동음이의어 (lib 와 components 양쪽 export) 자연 해소.

## 배경
`rg "^export function relativeTime" -l` 결과 2 사이트 발견:

| 파일 | 정의 | callers |
|---|---|---|
| `lib/format-time.ts:31` | `relativeTime(iso, fallback = '정보 없음')` (canonical SSOT) | `lib/keeper-runtime-display`, `components/verification-requests-panel`, `components/keeper-shared`, `components/mission-utils` (alias) — 4 callers |
| `components/mission-utils.ts:8` | `relativeTime(iso)` → `relativeTimeBase(iso, '방금')` (thin wrapper, 다른 fallback) | **0 callers** |

mission-utils consumer 5 곳 (`keeper-detail-alert-strip`, `keeper-cognition-inspector`, `agent-profile`, `agent-monitor/runtime-strip`, `agent-roster`) 모두 `formatDuration` / `trimText` 만 import. wrapper 는 *placeholder + dead*. test 사용도 0.

## 변경
- `components/mission-utils.ts`: `relativeTime` wrapper 함수 + 본문 + 사용 안 하게 된 `relativeTime as relativeTimeBase` alias import 삭제.

기존 re-export 4종 (`formatDuration`, `trimText`, `toneClass`, `statusLabel`) 그대로 유지.

## iter#32 dead code 패턴 + iter#9 동음이의어 자연 해소
`shutdownKeeper` (iter#32, REST + dead MCP) 패턴과 동일 — *동음이의어 + 한쪽 dead* 케이스. dead 삭제 = rename 보다 깔끔. lib 의 `relativeTime` 이 *유일한 export* 가 되어 호출자 헷갈림 자동 해소.

`'방금'` fallback 이 future 에 필요하면 callsite 에서 `relativeTime(iso, '방금')` 직접 전달 — iter#19 R 패턴 (policy 를 hidden wrapper 에 묻는 것보다 callsite 에 명시).

## 검증
- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline, iter#23/27/33/34/35 와 동일 측정값)

## /loop iter#36
SSOT 위반 dashboard 축출 loop 의 iter#36. cumulative 36 PR (24 머지 + 1 OPEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
