### PR TITLE
refactor(dashboard/transport-health): rename toneClass to toneTextClass to break inverse homonym

### DIFF
--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -12,7 +12,7 @@ import {
   formatIdle,
   compactId,
   statusDot,
-  toneClass,
+  toneTextClass,
   queuePressureTone,
   sseTone,
   transportTone,
@@ -601,13 +601,13 @@ describe('statusDot', () => {
   })
 })
 
-describe('toneClass', () => {
+describe('toneTextClass', () => {
   it.each([
     ['ok', 'text-[var(--color-status-ok)]'],
     ['warn', 'text-[var(--color-status-warn)]'],
     ['bad', 'text-[var(--color-status-err)]'],
-  ] as const)('toneClass(%s) → %s', (input, expected) => {
-    expect(toneClass(input as StatusTone)).toBe(expected)
+  ] as const)('toneTextClass(%s) → %s', (input, expected) => {
+    expect(toneTextClass(input as StatusTone)).toBe(expected)
   })
 })
 

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -207,7 +207,15 @@ export function statusDot(status: StatusTone): string {
   return 'bg-[var(--color-status-err)]'
 }
 
-export function toneClass(status: StatusTone): string {
+// Renamed from `toneClass` to encode the direction of the conversion.
+// `lib/tone.ts` ships a separate `toneClass(string): 'ok' | 'warn' | 'bad'`
+// — a classifier going from free-form status strings to a closed tone
+// label — which is the *inverse* direction of this function (closed
+// `StatusTone` enum to a text-color Tailwind class). The two used to
+// share a name and could be confused on import; the new name pairs
+// nominally with the sibling `statusDot(StatusTone): bg-class` helper
+// just above.
+export function toneTextClass(status: StatusTone): string {
   if (status === 'ok') return 'text-[var(--color-status-ok)]'
   if (status === 'warn') return 'text-[var(--color-status-warn)]'
   return 'text-[var(--color-status-err)]'
@@ -421,7 +429,7 @@ export function TransportHealthPanel() {
           </div>
           <div class="mt-1 text-sm text-text-body">
             primary path: <span class="font-mono text-text-strong">${data.summary.primary_path}</span>
-            <span class=${`ml-2 text-2xs uppercase tracking-wider ${toneClass(sseStatus)}`}>${data.summary.queue_pressure}</span>
+            <span class=${`ml-2 text-2xs uppercase tracking-wider ${toneTextClass(sseStatus)}`}>${data.summary.queue_pressure}</span>
           </div>
           ${truthLine
             ? html`<div class="mt-1 text-2xs text-text-muted">${truthLine}</div>`


### PR DESCRIPTION
## 요약
`components/transport-health.ts` 의 `toneClass` → `toneTextClass` rename. lib 의 같은 이름 함수와 **반대 방향 변환** (classifier vs renderer) 인 inverse homonym 해소.

## 배경
`rg "^export function toneClass" -A 0` 결과 2 정의 발견:

| 파일 | 시그니처 | 의미 |
|---|---|---|
| `lib/tone.ts:2` | `toneClass(tone?: string \| null): string` 반환 `'ok' \| 'warn' \| 'bad'` | **classifier** — open string ('error'/'offline'/'pending' 등) → closed tone label |
| `components/transport-health.ts:210` | `toneClass(status: StatusTone): string` 반환 `text-[var(--color-status-ok)]` 등 | **renderer** — closed `StatusTone` enum → Tailwind text-color class |

두 함수는 *개념적 inverse map* — 입력/출력이 정확히 반대. 이름이 같아서 future caller 가 잘못 import 할 위험. TypeScript 추론이 lib classifier 반환을 transport-health renderer 에 자연스럽게 plumb 하므로 컴파일러가 mismatch 못 catch.

importer 분석:
- `lib/tone.ts:toneClass` → `mission-utils.ts` (re-export), `lib/tone.test.ts`
- `components/transport-health.ts:toneClass` → **외부 importer 0**, file-internal callsite 1 + test 3 references

## 변경
- `components/transport-health.ts`: `toneClass` → `toneTextClass` (출력 종류를 이름에 인코딩). 같은 파일의 sibling `statusDot(StatusTone): bg-class` 와 nominal symmetry (`statusDot` = bg, `toneTextClass` = text). 함수에 JSDoc 으로 lib 의 inverse classifier 와의 분리 이유 명시.
- `transport-health.ts:432` file-internal callsite + test 3 references 갱신.

`lib/tone.ts:toneClass` 는 그대로 — 동음이의어 해소 후 *유일한 toneClass export*.

## scope 밖 동음이의어 (file-internal, collision 없음)
- `components/tools/tool-state.ts:73` — `const toneClass = ...` (local var, 함수 아님)
- `components/tools/config-resolution-panel.ts:75` — `function toneClass(status: string)` (file-internal, not exported)

둘 다 lib export 와 collision 없음 (file scope). iter#33 의 `keeper-shared.btnBase` 동음이의어 케이스 패턴 — 의도된 file-internal.

## 검증
- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline, iter#23/27/33/34/35/36 과 동일)
- 런타임 동작 변경 0 (pure local rename)

## /loop iter#37
SSOT 위반 dashboard 축출 loop 의 iter#37. cumulative 37 PR (25 머지 + 1 OPEN).

iter#19 R 패턴 (errorMessage 4-way diverging policy rename) 의 2-way inverse-homonym 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
