### PR TITLE
refactor(keeper): purge legacy playground prefix rewrite

### DIFF
--- a/lib/keeper/agent_tool_shared_runtime.ml
+++ b/lib/keeper/agent_tool_shared_runtime.ml
@@ -232,39 +232,6 @@ let is_playground_lane_relative_path (raw : string) =
     [ "mind"; "repos" ]
 ;;
 
-let strip_keeper_playground_prefix ~(meta : keeper_meta) (raw : string) =
-  let try_strip ~prefix text =
-    if
-      Filename.is_relative text
-      && String.length text >= String.length prefix
-      && String.starts_with ~prefix text
-    then (
-      let rest =
-        String.sub text (String.length prefix) (String.length text - String.length prefix)
-      in
-      Some (if rest = "" then "." else rest))
-    else None
-  in
-  let sandbox_root = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
-  let legacy_bundle_root = Playground_paths.bundle_root meta.name in
-  let short_root =
-    let rel = Keeper_alerting_path.strip_trailing_slashes sandbox_root in
-    if String.starts_with ~prefix:(Common.masc_dirname ^ "/") rel
-    then String.sub rel 6 (String.length rel - 6)
-    else rel
-  in
-  let prefixes =
-    [ sandbox_root
-    ; Keeper_alerting_path.strip_trailing_slashes sandbox_root
-    ; legacy_bundle_root
-    ; Keeper_alerting_path.strip_trailing_slashes legacy_bundle_root
-    ; short_root ^ "/"
-    ; short_root
-    ]
-  in
-  List.find_map (fun prefix -> try_strip ~prefix raw) prefixes
-;;
-
 let repo_relative_path_candidate ~(meta : keeper_meta) (raw : string) =
   let first_segment =
     match String.split_on_char '/' raw with
@@ -361,14 +328,7 @@ let project_relative_host_path ~(config : Coord.config) (path : string) =
 
 (* Bare filenames and canonical sandbox lanes default to the keeper sandbox,
    but rooted-looking relative paths (for example
-   "workspace/..." or "lib/...") keep project-root/boundary semantics.
-
-   Additionally, strip the keeper's legacy playground prefix when the path
-   already includes it.  Keeper LLMs sometimes construct paths like
-   ".masc/playground/<name>/repos" (relative) or
-   "<base>/.masc/playground/<name>/.masc/playground/<name>/repos" (absolute,
-   doubled).  Stripping early
-   prevents the downstream resolver from doubling the prefix again. *)
+   "workspace/..." or "lib/...") keep project-root/boundary semantics. *)
 let playground_relative_unless_allowed_root
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -389,46 +349,6 @@ let playground_relative_unless_allowed_root
   let trimmed =
     if mapped_from_container
     then Option.value ~default:trimmed (project_relative_host_path ~config trimmed)
-    else trimmed
-  in
-  let trimmed =
-    match strip_keeper_playground_prefix ~meta trimmed with
-    | Some stripped ->
-      Log.Keeper.debug "playground_relative: stripped prefix %S → %S" trimmed stripped;
-      stripped
-    | None -> trimmed
-  in
-  (* 2. Fix doubled playground prefix in absolute paths.
-     E.g. "/base/.masc/playground/X/.masc/playground/X/repos" →
-          "/base/.masc/playground/X/repos" *)
-  let trimmed =
-    if not (Filename.is_relative trimmed)
-    then (
-      let pg_root =
-        keeper_playground_root ~config ~meta
-        |> Keeper_alerting_path.strip_trailing_slashes
-      in
-      let pg_bundle = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
-      let doubled_prefix = pg_root ^ "/" ^ pg_bundle in
-      if String.starts_with ~prefix:doubled_prefix trimmed
-      then (
-        let rest =
-          String.sub
-            trimmed
-            (String.length doubled_prefix)
-            (String.length trimmed - String.length doubled_prefix)
-        in
-        let fixed = Filename.concat pg_root rest in
-        Log.Keeper.debug "playground_relative: fixed doubled abs %S → %S" trimmed fixed;
-        (match project_relative_host_path ~config fixed with
-         | Some rel -> rel
-         | None ->
-           (* NDT-OK: [fixed] is produced by deterministic prefix removal from an
-              absolute keeper playground path. If it is not under the project root,
-              keep the absolute value so the downstream resolver enforces the
-              containment boundary. *)
-           fixed))
-      else trimmed)
     else trimmed
   in
   match rewrite_single_repo_relative_path ~config ~meta trimmed with

--- a/lib/keeper/agent_tool_shared_runtime.mli
+++ b/lib/keeper/agent_tool_shared_runtime.mli
@@ -95,14 +95,6 @@ val relative_path_targets_allowed_root : meta:Keeper_types.keeper_meta -> string
     sandbox lanes for keeper-relative paths). *)
 val is_playground_lane_relative_path : string -> bool
 
-(** Strip the keeper's legacy / sandbox playground prefix from
-    [raw] when present, returning the rest (or ["."] for an empty
-    rest). [None] otherwise. *)
-val strip_keeper_playground_prefix
-  :  meta:Keeper_types.keeper_meta
-  -> string
-  -> string option
-
 (** [true] iff [raw] is a relative path whose first segment looks
     like a repo name (not a sandbox lane / project root marker). *)
 val repo_relative_path_candidate : meta:Keeper_types.keeper_meta -> string -> bool
@@ -118,8 +110,7 @@ val rewrite_single_repo_relative_path
 
 (** Default-route a relative path under the keeper's playground
     unless it already targets an explicit allowed_paths root.
-    Strips legacy/doubled playground prefixes, applies single-repo
-    rewrite, then resolves. *)
+    Applies single-repo rewrite, then resolves. *)
 val playground_relative_unless_allowed_root
   :  config:Coord.config
   -> meta:Keeper_types.keeper_meta

--- a/test/test_agent_tool_execute_safety.ml
+++ b/test/test_agent_tool_execute_safety.ml
@@ -686,7 +686,7 @@ let test_tool_search_files_find_accepts_name_alias () =
   Alcotest.(check string) "alias populates name field" "*.ml"
     (json |> Json.member "name" |> Json.to_string)
 
-let test_tool_search_files_ls_recovers_doubled_playground_prefix () =
+let test_tool_search_files_ls_rejects_doubled_playground_prefix () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
@@ -711,10 +711,15 @@ let test_tool_search_files_ls_recovers_doubled_playground_prefix () =
       ])
   in
   let json = Yojson.Safe.from_string raw in
-  Alcotest.(check bool) "ls succeeds" true
+  Alcotest.(check bool) "ls rejects doubled playground prefix" false
     (json |> Json.member "ok" |> Json.to_bool);
-  Alcotest.(check string) "path normalized to repos root" repos
-    (json |> Json.member "path" |> Json.to_string)
+  (match json |> Json.member "error" |> Json.to_string_option with
+   | Some err ->
+     Alcotest.(check bool)
+       "error rejects absolute doubled path"
+       true
+       (String_util.contains_substring err "absolute paths are not allowed")
+   | None -> Alcotest.fail ("expected path rejection, got: " ^ raw))
 
 let test_tool_search_files_retired_command_op_is_unsupported () =
   with_eio_fs @@ fun () ->
@@ -1129,9 +1134,9 @@ let () =
             `Quick
             test_tool_search_files_find_accepts_name_alias
         ; Alcotest.test_case
-            "doubled playground prefix auto-recovers"
+            "doubled playground prefix rejected"
             `Quick
-            test_tool_search_files_ls_recovers_doubled_playground_prefix
+            test_tool_search_files_ls_rejects_doubled_playground_prefix
         ; Alcotest.test_case
             "retired command op is unsupported"
             `Quick


### PR DESCRIPTION
## Summary
- Remove the shared runtime helper that silently stripped keeper playground prefixes from relative paths.
- Stop auto-repairing doubled absolute playground paths before sandbox path resolution.
- Flip the SearchFiles regression so doubled playground paths now fail closed instead of normalizing to the repos root.

## Verification
- `ocamlformat --check lib/keeper/agent_tool_shared_runtime.ml lib/keeper/agent_tool_shared_runtime.mli test/test_agent_tool_execute_safety.ml`
- `git diff --check origin/main...HEAD`
- `rg -n "strip_keeper_playground_prefix|legacy_bundle_root|legacy playground prefix|doubled playground prefix auto-recovers|recovers_doubled_playground|fixed doubled abs|stripped prefix" lib test docs config scripts` returned no matches
- `scripts/dune-local.sh build ./test/test_agent_tool_execute_safety.exe` blocked: machine-wide bare Dune processes are running outside `scripts/dune-local.sh`, so the wrapper refused to start another build