### PR TITLE
refactor(cascade-config): typed parse_error variant replaces "unavailable" substring filter

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -51,6 +51,13 @@ let parse_weighted_entry_diag = Cascade_config_parser.parse_weighted_entry_diag
 let parse_weighted_entry_with_drop_metric =
   Cascade_config_parser.parse_weighted_entry_with_drop_metric
 let parse_weighted_entries = Cascade_config_parser.parse_weighted_entries
+type parse_error = Cascade_config_parser.parse_error =
+  | Invalid_spec of string
+  | Unknown_provider of { provider : string; spec : string }
+  | Provider_unavailable of { provider : string; env_var : string }
+  | Custom_empty_model of { spec : string }
+
+let parse_error_to_string = Cascade_config_parser.parse_error_to_string
 let parse_model_string_result = Cascade_config_parser.parse_model_string_result
 let expand_auto_models = Cascade_config_parser.expand_auto_models
 let expand_weighted_auto_entries =

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -159,17 +159,26 @@ val order_weighted_entries :
     round-robined independently before the usual weight/health ordering is
     applied. *)
 
-(** Like {!parse_model_string} but returns a [Result] with a diagnostic
-    error message explaining why parsing failed (unknown provider, missing
+(** Like {!parse_model_string} but returns a [Result] with a typed
+    failure mode explaining why parsing failed (unknown provider, missing
     API key, bad format).  Intended for MCP tool boundaries where callers
-    need to report the reason back to the user.
+    need to report the reason back to the user — call
+    {!parse_error_to_string} to render the human-facing message.
 
     @since 0.81.0 *)
+type parse_error = Cascade_config_parser.parse_error =
+  | Invalid_spec of string
+  | Unknown_provider of { provider : string; spec : string }
+  | Provider_unavailable of { provider : string; env_var : string }
+  | Custom_empty_model of { spec : string }
+
+val parse_error_to_string : parse_error -> string
+
 val parse_model_string_result :
   ?temperature:float ->
   ?max_tokens:int ->
   ?system_prompt:string ->
-  string -> (Llm_provider.Provider_config.t, string) result
+  string -> (Llm_provider.Provider_config.t, parse_error) result
 
 (** Expand provider:auto specs that map to multiple models.
     Direct API providers project their candidate list from OAS runtime

--- a/lib/cascade/cascade_config_parser.ml
+++ b/lib/cascade/cascade_config_parser.ml
@@ -438,26 +438,44 @@ let parse_weighted_entries
        label (List.length entries));
   List.rev parsed
 
+(* Typed failure mode for [parse_model_string_result].  See .mli for
+   the rationale (RFC-0088 §"String/Substring 분류기" anti-pattern
+   removal: a downstream caller had been scanning the error string for
+   "unavailable" to filter out the [Provider_unavailable] case). *)
+type parse_error =
+  | Invalid_spec of string
+  | Unknown_provider of { provider : string; spec : string }
+  | Provider_unavailable of { provider : string; env_var : string }
+  | Custom_empty_model of { spec : string }
+
+let parse_error_to_string = function
+  | Invalid_spec s ->
+    Printf.sprintf "invalid model spec %S: expected \"provider:model_id\"" s
+  | Unknown_provider { provider; spec } ->
+    Printf.sprintf "unknown provider %S in model spec %S" provider spec
+  | Provider_unavailable { provider; env_var } ->
+    Printf.sprintf "provider %S unavailable (missing env var %S)" provider env_var
+  | Custom_empty_model { spec } ->
+    Printf.sprintf "invalid custom model spec %S: empty model after @" spec
+
 let parse_model_string_result
     ?(temperature = Llm_provider.Constants.Inference.default_temperature)
     ?(max_tokens = Llm_provider.Constants.Inference.default_max_tokens)
-    ?system_prompt (s : string) : (Llm_provider.Provider_config.t, string) result =
+    ?system_prompt (s : string) : (Llm_provider.Provider_config.t, parse_error) result =
   let s = String.trim s in
   match split_provider_model s with
-  | None ->
-    Error (Printf.sprintf "invalid model spec %S: expected \"provider:model_id\"" s)
+  | None -> Error (Invalid_spec s)
   | Some ("custom", model_id) ->
     (match make_custom_config ~temperature ~max_tokens ?system_prompt model_id with
      | Some cfg -> Ok cfg
-     | None ->
-       Error (Printf.sprintf "invalid custom model spec %S: empty model after @" s))
+     | None -> Error (Custom_empty_model { spec = s }))
   | Some (provider_name, model_id) ->
     match Llm_provider.Provider_registry.find default_registry provider_name with
     | None ->
-      Error (Printf.sprintf "unknown provider %S in model spec %S" provider_name s)
+      Error (Unknown_provider { provider = provider_name; spec = s })
     | Some entry when not (entry.is_available ()) ->
-      Error (Printf.sprintf "provider %S unavailable (missing env var %S)"
-               provider_name entry.defaults.api_key_env)
+      Error (Provider_unavailable
+               { provider = provider_name; env_var = entry.defaults.api_key_env })
     | Some entry ->
       Ok (make_registry_config ~temperature ~max_tokens ?system_prompt
             ~provider_name ~model_id entry)

--- a/lib/cascade/cascade_config_parser.mli
+++ b/lib/cascade/cascade_config_parser.mli
@@ -103,8 +103,32 @@ val parse_weighted_entries :
   Cascade_config_loader.weighted_entry list ->
   Llm_provider.Provider_config.t list
 
+(** Typed failure modes from {!parse_model_string_result}.
+
+    Replaces the previous [string] error payload so downstream callers
+    (notably {!Cascade_catalog_validator}) can match the
+    [Provider_unavailable] case structurally rather than via a
+    "unavailable" substring scan on the error message — the RFC-0088
+    §"String/Substring 분류기" anti-pattern that was the original reason
+    for {!Cascade_catalog_validator.is_provider_unavailable_error}.
+
+    Use {!parse_error_to_string} when a human-facing message is needed
+    (e.g. surfacing through an MCP tool boundary). *)
+type parse_error =
+  | Invalid_spec of string
+      (** Free-form input that did not split into [provider:model_id]. *)
+  | Unknown_provider of { provider : string; spec : string }
+      (** Provider name resolved to no registry entry. *)
+  | Provider_unavailable of { provider : string; env_var : string }
+      (** Provider entry resolved but [is_available ()] returned false
+          because the [api_key_env] is unset. *)
+  | Custom_empty_model of { spec : string }
+      (** [custom:@…] spec with empty model id after the [@]. *)
+
+val parse_error_to_string : parse_error -> string
+
 val parse_model_string_result :
   ?temperature:float ->
   ?max_tokens:int ->
   ?system_prompt:string ->
-  string -> (Llm_provider.Provider_config.t, string) result
+  string -> (Llm_provider.Provider_config.t, parse_error) result

--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -17,9 +17,6 @@ let has_suffix ~suffix s =
      guard preserves the prior validator contract. *)
   String.length s > String.length suffix && String.ends_with ~suffix s
 
-let is_provider_unavailable_error msg =
-  String_util.contains_substring msg "unavailable"
-
 let split_provider_model (s : string) : (string * string) option =
   match String.index_opt s ':' with
   | None -> None
@@ -480,14 +477,14 @@ let diagnose_profile ~materialized_json ~declarative_snapshot ~emit_telemetry
     |> List.filter_map (fun spec ->
            match Cascade_config.parse_model_string_result spec with
            | Ok _ -> None
-           | Error msg when is_provider_unavailable_error msg -> None
+           | Error (Cascade_config.Provider_unavailable _) -> None
            (* Declarative provider bindings can materialize to runtime-only
               provider keys that are already represented by validated
               provider_cfg candidates. Do not reclassify those as invalid. *)
            | Error _
              when List.exists (String.equal spec) candidate_model_strings ->
                None
-           | Error msg -> Some (spec, msg))
+           | Error err -> Some (spec, Cascade_config.parse_error_to_string err))
   in
   let invalid_model_issue =
     if invalid_specs = [] then


### PR DESCRIPTION
## 요약

RFC-0088 §"String/Substring 분류기" anti-pattern 5번째 surgical PR (#18977 → #18982 → #19002 → #19016 → 본 PR). `Cascade_config.parse_model_string_result` 의 single-flat `string` error → typed `parse_error` variant.

### Root pattern

`lib/cascade/cascade_config_parser.ml:444` 의 producer 가 4 종 실패를 모두 `Error string` 으로 flatten:

```ocaml
let parse_model_string_result ... : (_, string) result =
  match ... with
  | None -> Error (Printf.sprintf "invalid model spec %S: ..." s)
  | Some ("custom", model_id) -> ... | None -> Error (... "empty model after @")
  | Some (provider_name, _) ->
    match Provider_registry.find ... with
    | None -> Error (Printf.sprintf "unknown provider %S in model spec %S" ...)
    | Some entry when not (entry.is_available ()) ->
      Error (Printf.sprintf "provider %S unavailable (missing env var %S)" ...)
    | Some entry -> Ok ...
```

`lib/cascade_catalog_validator.ml` 의 consumer 가 *substring scan* 으로 한 arm 만 골라내야 했음:

```ocaml
let is_provider_unavailable_error msg =
  String_util.contains_substring msg "unavailable"
...
| Error msg when is_provider_unavailable_error msg -> None    (* provider unavailable: skip *)
| Error msg -> Some (spec, msg)                                (* other: invalid *)
```

문제:
- `"unavailable"` 가 다른 메시지 텍스트에 등장하면 false positive
- producer prose 변경 시 silent fail
- 4-arm 분류를 1-arm substring 으로 *flatten + 부분 recover*

## 변경

### Typed `parse_error` variant

```ocaml
type parse_error =
  | Invalid_spec of string
  | Unknown_provider of { provider : string; spec : string }
  | Provider_unavailable of { provider : string; env_var : string }
  | Custom_empty_model of { spec : string }

val parse_error_to_string : parse_error -> string
```

`parse_error_to_string` 가 *기존 prose 메시지를 동등하게 재현* — MCP tool boundary 등 사용자 surface 의 텍스트 *완전 보존*.

### Consumer 마이그레이션

before:
```ocaml
| Error msg when is_provider_unavailable_error msg -> None
| Error msg -> Some (spec, msg)
```

after:
```ocaml
| Error (Cascade_config.Provider_unavailable _) -> None
| Error err -> Some (spec, Cascade_config.parse_error_to_string err)
```

Exhaustive structural match. Compiler 가 새 variant 추가 시 consumer 누락 감지. `is_provider_unavailable_error` 헬퍼 삭제 (dead).

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 String/Substring 분류기 패턴을 *제거* 함 (typed sum 도입). pr-rfc-check 가 anti-pattern 언급을 시그니처 매치로 감지하나, 실제 코드 변경은 anti-pattern *deletion*.

- ❌ Counter-as-Fix
- ✅ **String/substring 분류기 제거** — 1 사이트 + 1 helper 삭제
- ❌ N-of-M 패치 — `parse_model_string_result` 의 모든 caller (2) 일괄 마이그레이션
- ❌ Repair/Sanitize — symptom 억제 아닌 *typed exhaustive match 도입*

## Test impact

- `parse_model_string_result` test caller 0 (rg -ln 결과). 변경 영향 없음.
- 사용자 surface (MCP tool error message) 는 `parse_error_to_string` 가 *동등 prose 보존* → 0 변경.
- Full `dune build --root .` PASS (rebased onto `3bac236bb`).

## Background — narrower grep audit

iter 40 PR #19016 이후 `contains_casefold err|contains_casefold msg|contains_substring err|contains_substring msg` grep 으로 추가 surgical 후보 6 사이트 발견. 분류:

- **2-tier intentional** (RFC-0154 system_error_class style): `keeper_failure_circuit_breaker_types.ml`, `keeper_error_classify_post_commit.ml` — 안티패턴 아님 (typed-first + fallback)
- **API boundary** (stdlib Sys_error는 이게 정상): `keeper_tools_oas_handler_exec.ml` (EDEADLK)
- **Single arm filter** (본 PR 대상): `cascade_catalog_validator.ml:480` ← *fix here*
- **TLA+/diff parse**: `autonomy_diff_guard.ml` (legitimate)
- **Dashboard severity classifier**: `keeper_runtime_trust_timeline.ml` (RFC scope)
- **Server log re-parse**: Issue #18986 영역 2 (RFC scope)

Total RFC-0088 §"String 분류기" 안티패턴 사이트 (when-guard form + filter form): 9 → 8 (1 site removed in this PR).

## Related

- PR #18977 (lock contention typed)
- PR #18982 (mkdir EEXIST typed)
- PR #19002 (rename_if_exists typed)
- PR #19016 (Coord.Not_initialized typed)
- Issue #18986 (RFC scope candidates)
- RFC-0088 §"String/Substring 분류기" anti-pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
