### PR TITLE
refactor(keeper): type path rejection classification

### DIFF
--- a/docs/design/keeper-autonomy-proof-harness.md
+++ b/docs/design/keeper-autonomy-proof-harness.md
@@ -60,7 +60,7 @@ Step 2 — join against turn boundary to recover `turn_id`.
 
 Step 3 — map raw error message to typed outcome using:
 - new `Keeper_path_check_error.parse_prefix` (PR #15684) for path-error class
-- `Keeper_failure_circuit_breaker.classify_error` for policy / approval / shell-exit class (substring grep — separate cleanup once that module's TLA+ mirror is updated)
+- `Keeper_failure_circuit_breaker.classify_error` for path rejection / policy / approval / shell-exit class (typed path-prefix parser for path rejection; remaining shell-exit fallback is string-based)
 - explicit `[approval-required]` / `[policy-denied]` log markers for #13567 class
 
 Step 4 — emit `proof_receipt` JSON to `<base-path>/.masc/proof/<date>.jsonl`. Append-only, never edited.

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -14,9 +14,7 @@ type keeper_path_rejection =
   | Not_found_relative of { raw : string }
   | Ambiguous_relative_read_path of { raw : string; candidate_count : int }
 
-(** LLM-facing opaque message.  Preserves legacy string prefixes so
-    downstream string classifiers ([Keeper_failure_circuit_breaker.
-    classify_error]) keep recognising the error class. *)
+(** LLM-facing opaque message. *)
 let rejection_to_user_message = function
   | Path_required -> "path_required"
   | Absolute_path_rejected { raw } ->
@@ -44,6 +42,39 @@ let rejection_to_user_message = function
        relative segment)"
       raw
       candidate_count
+;;
+
+let rejection_message_prefix = function
+  | Path_required -> "path_required"
+  | Absolute_path_rejected _ -> "path_outside_project_root:"
+  | Outside_project_root _ -> "path_outside_project_root:"
+  | Allowed_paths_normalized_empty _ -> "allowed_paths_normalized_empty:"
+  | Outside_sandbox _ -> "path_outside_sandbox:"
+  | Not_found_relative _ -> "path_not_found_under_allowed_roots:"
+  | Ambiguous_relative_read_path _ -> "ambiguous_relative_read_path:"
+;;
+
+let starts_with_ci ~prefix s =
+  let pl = String.length prefix in
+  String.length s >= pl
+  && String.lowercase_ascii (String.sub s 0 pl) = prefix
+;;
+
+let parse_rejection_prefix msg =
+  let trimmed = String.trim msg in
+  if String.lowercase_ascii trimmed = "path_required"
+  then Some Path_required
+  else if starts_with_ci ~prefix:"path_outside_project_root:" trimmed
+  then Some (Outside_project_root { raw = "" })
+  else if starts_with_ci ~prefix:"allowed_paths_normalized_empty:" trimmed
+  then Some (Allowed_paths_normalized_empty { count = 0 })
+  else if starts_with_ci ~prefix:"path_outside_sandbox:" trimmed
+  then Some (Outside_sandbox { raw = "" })
+  else if starts_with_ci ~prefix:"path_not_found_under_allowed_roots:" trimmed
+  then Some (Not_found_relative { raw = "" })
+  else if starts_with_ci ~prefix:"ambiguous_relative_read_path:" trimmed
+  then Some (Ambiguous_relative_read_path { raw = ""; candidate_count = 0 })
+  else None
 ;;
 
 (** Operator-facing telemetry — single call site for all path-rejection

--- a/lib/keeper/keeper_alerting_path.mli
+++ b/lib/keeper/keeper_alerting_path.mli
@@ -12,9 +12,16 @@ type keeper_path_rejection =
   | Not_found_relative of { raw : string }
   | Ambiguous_relative_read_path of { raw : string; candidate_count : int }
 
-(** LLM-facing opaque message derived from the rejection variant.
-    Preserves legacy string prefixes for downstream classifiers. *)
+(** LLM-facing opaque message derived from the rejection variant. *)
 val rejection_to_user_message : keeper_path_rejection -> string
+
+(** Stable lowercase prefix token for [rejection_to_user_message]. *)
+val rejection_message_prefix : keeper_path_rejection -> string
+
+(** Parse only the typed rejection tag from a user-facing rejection
+    message. Payload fields are intentionally left empty / zero because
+    the parser is for classification, not message reconstruction. *)
+val parse_rejection_prefix : string -> keeper_path_rejection option
 
 (** Operator-facing telemetry — increments the path-rejection counter
     with a [kind] label derived from the constructor. *)

--- a/lib/keeper/keeper_failure_circuit_breaker.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker.ml
@@ -9,8 +9,8 @@
     tool calls close it immediately and observers auto-close it after
     [cooling_reset_sec].
 
-    Error classes are coarse categories (path_not_found, cwd_not_directory,
-    path_not_in_allowed_paths/path_outside_sandbox) — not exact error strings. This prevents
+    Error classes are coarse categories (path-not-found, cwd-not-directory,
+    typed path rejection, shell exit, other) — not exact error strings. This prevents
     near-miss variants from resetting the counter.
 
     Spec navigation (OCaml -> TLA+) — plan §19 anchor pattern applied

--- a/lib/keeper/keeper_failure_circuit_breaker_types.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker_types.ml
@@ -11,6 +11,7 @@ type error_class =
   | Other
 
 module Path_check_error = Keeper_path_check_error
+module Path_rejection = Keeper_alerting_path
 
 let classify_path_check_prefix (error_msg : string) : error_class option =
   match Path_check_error.parse_prefix error_msg with
@@ -19,19 +20,75 @@ let classify_path_check_prefix (error_msg : string) : error_class option =
   | None -> None
 ;;
 
+let classify_path_rejection_prefix (error_msg : string) : error_class option =
+  match Path_rejection.parse_rejection_prefix error_msg with
+  | Some (Path_rejection.Not_found_relative _) -> Some Path_not_found
+  | Some
+      (Path_rejection.Absolute_path_rejected _
+      | Path_rejection.Outside_project_root _
+      | Path_rejection.Outside_sandbox _) -> Some Path_not_allowed
+  | Some
+      (Path_rejection.Path_required
+      | Path_rejection.Allowed_paths_normalized_empty _
+      | Path_rejection.Ambiguous_relative_read_path _) -> Some Other
+  | None -> None
+;;
+
+let structured_error_text (error_msg : string) : string option =
+  let json_text =
+    let trimmed = String.trim error_msg in
+    let strip_prefix prefix =
+      let plen = String.length prefix in
+      if String.length trimmed >= plen && String.sub trimmed 0 plen = prefix
+      then Some (String.trim (String.sub trimmed plen (String.length trimmed - plen)))
+      else None
+    in
+    match strip_prefix "error:" with
+    | Some json -> json
+    | None ->
+      (match strip_prefix "tool_error:" with
+       | Some json -> json
+       | None -> trimmed)
+  in
+  match
+    try Some (Yojson.Safe.from_string json_text) with
+    | Yojson.Json_error _ -> None
+  with
+  | Some (`Assoc fields) ->
+    (match List.assoc_opt "error" fields with
+     | Some (`String error) -> Some error
+     | _ ->
+       (match List.assoc_opt "message" fields with
+        | Some (`String message) -> Some message
+        | _ -> None))
+  | _ -> None
+;;
+
+let classify_path_error_text error_msg =
+  match classify_path_check_prefix error_msg with
+  | Some cls -> Some cls
+  | None -> classify_path_rejection_prefix error_msg
+;;
+
 let classify_error (error_msg : string) : error_class =
   if String.length error_msg = 0 then Other
   else
-    match classify_path_check_prefix error_msg with
+    match classify_path_error_text error_msg with
     | Some cls -> cls
     | None ->
-      let contains sub = String_util.contains_substring error_msg sub in
-      if contains "path_not_found" then Path_not_found
-      else if contains "path_not_in_allowed" || contains "path_outside_sandbox" then Path_not_allowed
-      else if contains "cwd_not_directory" then Cwd_not_directory
-      else if contains "No such file or directory" then Path_not_found
-      else if contains "exit" && contains "code" then Shell_exit_nonzero
-      else Other
+      (match structured_error_text error_msg with
+       | Some error ->
+         (match classify_path_error_text error with
+          | Some cls -> cls
+          | None ->
+            if String_util.contains_substring error "No such file or directory"
+            then Path_not_found
+            else Other)
+       | None ->
+         let contains sub = String_util.contains_substring error_msg sub in
+         if contains "No such file or directory" then Path_not_found
+         else if contains "exit" && contains "code" then Shell_exit_nonzero
+         else Other)
 
 let error_class_to_string = function
   | Path_not_found -> "path_not_found"
@@ -69,4 +126,3 @@ type breaker_state = {
      Retained across trips so "cooling" inspection still has context. *)
   mutable recent_failures : failure_signature list;
 }
-

--- a/lib/keeper/keeper_failure_circuit_breaker_types.mli
+++ b/lib/keeper/keeper_failure_circuit_breaker_types.mli
@@ -10,6 +10,7 @@ type error_class =
 module Path_check_error = Keeper_path_check_error
 
 val classify_path_check_prefix : string -> error_class option
+val classify_path_rejection_prefix : string -> error_class option
 val classify_error : string -> error_class
 val error_class_to_string : error_class -> string
 

--- a/lib/keeper/keeper_path_check_error.mli
+++ b/lib/keeper/keeper_path_check_error.mli
@@ -15,9 +15,8 @@
       the prior raw-string prefixes so downstream observers
       (dashboard tool-quality, log aggregators) keep working without
       a behaviour change in this PR.
-    - [parse_prefix] is a typed lookup, not substring grep; a future
-      PR can migrate [keeper_failure_circuit_breaker.classify_error]
-      onto it without rewriting the spec mirror. *)
+    - [parse_prefix] is a typed lookup, not substring grep; circuit
+      breaker classification consumes it directly. *)
 
 type t =
   | Path_outside_whitelist of
@@ -49,4 +48,3 @@ val parse_prefix : string -> t option
 (** Inverse of [to_message] for the variant tag only — payload fields
     are left empty / [None] since the typed module is intended for
     classification, not full message reconstruction. *)
-

--- a/test/test_circuit_breaker.ml
+++ b/test/test_circuit_breaker.ml
@@ -1,7 +1,18 @@
 open Alcotest
 
 module CB = Masc_mcp.Keeper_failure_circuit_breaker
+module KAP = Masc_mcp.Keeper_alerting_path
 module PCE = Masc_mcp.Keeper_path_check_error
+
+let path_not_found_msg raw =
+  KAP.rejection_to_user_message (KAP.Not_found_relative { raw })
+;;
+
+let path_not_allowed_msg raw =
+  KAP.rejection_to_user_message (KAP.Outside_sandbox { raw })
+;;
+
+let json_error error = Yojson.Safe.to_string (`Assoc [ "ok", `Bool false; "error", `String error ])
 
 let contains haystack needle =
   let nl = String.length needle and hl = String.length haystack in
@@ -15,13 +26,23 @@ let contains haystack needle =
 
 let test_classify_path_not_found () =
   check bool "path_not_found from prefix" true
-    (CB.classify_error "path_not_found_under_allowed_roots: /foo" = CB.Path_not_found);
+    (CB.classify_error (path_not_found_msg "/foo") = CB.Path_not_found);
+  check bool "path_not_found from JSON error field" true
+    (CB.classify_error (json_error (path_not_found_msg "/foo")) = CB.Path_not_found);
   check bool "path_not_found from NSFD" true
     (CB.classify_error "No such file or directory" = CB.Path_not_found)
 
 let test_classify_path_not_allowed () =
-  check bool "path_not_allowed" true
-    (CB.classify_error "path_not_in_allowed_paths: /x" = CB.Path_not_allowed)
+  check bool "path_not_allowed from typed rejection" true
+    (CB.classify_error (path_not_allowed_msg "/x") = CB.Path_not_allowed);
+  check bool "path_not_allowed from JSON error field" true
+    (CB.classify_error (json_error (path_not_allowed_msg "/x")) = CB.Path_not_allowed);
+  check bool "outside project root is path_not_allowed" true
+    (CB.classify_error
+       (KAP.rejection_to_user_message (KAP.Outside_project_root { raw = "../x" }))
+     = CB.Path_not_allowed);
+  check bool "legacy path_not_in_allowed no longer drives KCB" true
+    (CB.classify_error "path_not_in_allowed_paths: /x" = CB.Other)
 
 let test_classify_typed_path_check_prefixes () =
   let cwd_msg =
@@ -43,16 +64,16 @@ let test_classify_other () =
 
 let test_no_hint_under_threshold () =
   CB.record_success ~keeper_name:"t1";
-  let r1 = CB.maybe_enrich_error ~keeper_name:"t1" ~error_msg:"path_not_found: /a" in
+  let r1 = CB.maybe_enrich_error ~keeper_name:"t1" ~error_msg:(path_not_found_msg "/a") in
   check bool "1st: no hint" true (not (contains r1 "CIRCUIT BREAKER"));
-  let r2 = CB.maybe_enrich_error ~keeper_name:"t1" ~error_msg:"path_not_found: /b" in
+  let r2 = CB.maybe_enrich_error ~keeper_name:"t1" ~error_msg:(path_not_found_msg "/b") in
   check bool "2nd: no hint" true (not (contains r2 "CIRCUIT BREAKER"))
 
 let test_hint_at_threshold () =
   CB.record_success ~keeper_name:"t2";
-  ignore (CB.maybe_enrich_error ~keeper_name:"t2" ~error_msg:"path_not_found: /a");
-  ignore (CB.maybe_enrich_error ~keeper_name:"t2" ~error_msg:"path_not_found: /b");
-  let r3 = CB.maybe_enrich_error ~keeper_name:"t2" ~error_msg:"path_not_found: /c" in
+  ignore (CB.maybe_enrich_error ~keeper_name:"t2" ~error_msg:(path_not_found_msg "/a"));
+  ignore (CB.maybe_enrich_error ~keeper_name:"t2" ~error_msg:(path_not_found_msg "/b"));
+  let r3 = CB.maybe_enrich_error ~keeper_name:"t2" ~error_msg:(path_not_found_msg "/c") in
   check bool "3rd: HAS hint" true (contains r3 "CIRCUIT BREAKER");
   check bool "mentions playground" true (contains r3 "playground");
   check bool "mentions typed public Execute ls" true
@@ -60,21 +81,21 @@ let test_hint_at_threshold () =
 
 let test_reset_on_success () =
   CB.record_success ~keeper_name:"t3";
-  ignore (CB.maybe_enrich_error ~keeper_name:"t3" ~error_msg:"path_not_found: /a");
-  ignore (CB.maybe_enrich_error ~keeper_name:"t3" ~error_msg:"path_not_found: /b");
+  ignore (CB.maybe_enrich_error ~keeper_name:"t3" ~error_msg:(path_not_found_msg "/a"));
+  ignore (CB.maybe_enrich_error ~keeper_name:"t3" ~error_msg:(path_not_found_msg "/b"));
   CB.record_success ~keeper_name:"t3";
-  let r = CB.maybe_enrich_error ~keeper_name:"t3" ~error_msg:"path_not_found: /c" in
+  let r = CB.maybe_enrich_error ~keeper_name:"t3" ~error_msg:(path_not_found_msg "/c") in
   check bool "after reset: no hint" true (not (contains r "CIRCUIT BREAKER"))
 
 let test_class_change_resets () =
-  ignore (CB.maybe_enrich_error ~keeper_name:"t4" ~error_msg:"path_not_found: /a");
-  ignore (CB.maybe_enrich_error ~keeper_name:"t4" ~error_msg:"path_not_found: /b");
-  ignore (CB.maybe_enrich_error ~keeper_name:"t4" ~error_msg:"path_not_in_allowed_paths: /x");
-  let r = CB.maybe_enrich_error ~keeper_name:"t4" ~error_msg:"path_not_in_allowed_paths: /y" in
+  ignore (CB.maybe_enrich_error ~keeper_name:"t4" ~error_msg:(path_not_found_msg "/a"));
+  ignore (CB.maybe_enrich_error ~keeper_name:"t4" ~error_msg:(path_not_found_msg "/b"));
+  ignore (CB.maybe_enrich_error ~keeper_name:"t4" ~error_msg:(path_not_allowed_msg "/x"));
+  let r = CB.maybe_enrich_error ~keeper_name:"t4" ~error_msg:(path_not_allowed_msg "/y") in
   check bool "class switch: no hint at 2nd" true (not (contains r "CIRCUIT BREAKER"))
 
 let test_snapshot () =
-  ignore (CB.maybe_enrich_error ~keeper_name:"t5" ~error_msg:"path_not_found: /a");
+  ignore (CB.maybe_enrich_error ~keeper_name:"t5" ~error_msg:(path_not_found_msg "/a"));
   match CB.snapshot_json () with
   | `List entries -> check bool "has entries" true (List.length entries > 0)
   | _ -> Alcotest.fail "expected list"
@@ -169,7 +190,7 @@ let test_classify_snapshot_round_trip () =
   (* Force a keeper with count>0 into the real state, snapshot, classify. *)
   CB.record_success ~keeper_name:"rt1";
   ignore (CB.maybe_enrich_error
-            ~keeper_name:"rt1" ~error_msg:"path_not_found: /x");
+            ~keeper_name:"rt1" ~error_msg:(path_not_found_msg "/x"));
   let json = CB.snapshot_json () in
   match CB.classify_snapshot_json json with
   | Error msg -> Alcotest.fail ("round-trip failed: " ^ msg)
@@ -192,7 +213,7 @@ let test_display_state_of_matches_snapshot () =
   let name = "p2-alpha" in
   CB.record_success ~keeper_name:name;
   ignore (CB.maybe_enrich_error
-            ~keeper_name:name ~error_msg:"path_not_found: /a");
+            ~keeper_name:name ~error_msg:(path_not_found_msg "/a"));
   let direct = CB.display_state_of ~keeper_name:name in
   check string "direct lookup = warning" "warning" (display_state_str direct);
   let json = CB.snapshot_json () in
@@ -206,19 +227,16 @@ let test_display_state_of_clears_after_success () =
   let name = "p2-beta" in
   CB.record_success ~keeper_name:name;
   ignore (CB.maybe_enrich_error
-            ~keeper_name:name ~error_msg:"path_not_found: /a");
+            ~keeper_name:name ~error_msg:(path_not_found_msg "/a"));
   CB.record_success ~keeper_name:name;
   let s = CB.display_state_of ~keeper_name:name in
   check string "after success, back to clean" "clean" (display_state_str s)
 
 let trip_keeper name =
   CB.record_success ~keeper_name:name;
-  ignore (CB.maybe_enrich_error
-            ~keeper_name:name ~error_msg:"path_not_found: /a");
-  ignore (CB.maybe_enrich_error
-            ~keeper_name:name ~error_msg:"path_not_found: /b");
-  ignore (CB.maybe_enrich_error
-            ~keeper_name:name ~error_msg:"path_not_found: /c")
+  ignore (CB.maybe_enrich_error ~keeper_name:name ~error_msg:(path_not_found_msg "/a"));
+  ignore (CB.maybe_enrich_error ~keeper_name:name ~error_msg:(path_not_found_msg "/b"));
+  ignore (CB.maybe_enrich_error ~keeper_name:name ~error_msg:(path_not_found_msg "/c"))
 
 let test_display_state_of_success_closes_trip () =
   let name = "p2-trip-success-closes" in


### PR DESCRIPTION
## Summary
- add a typed parser for Keeper_alerting_path rejection messages
- route KCB path classification through typed path-check/path-rejection parsers and JSON error-field extraction
- stop treating legacy path_not_in_allowed_paths substrings as KCB path classes

## Verification
- ocamlformat --check lib/keeper/keeper_alerting_path.ml lib/keeper/keeper_alerting_path.mli lib/keeper/keeper_path_check_error.mli lib/keeper/keeper_failure_circuit_breaker_types.ml lib/keeper/keeper_failure_circuit_breaker_types.mli lib/keeper/keeper_failure_circuit_breaker.ml test/test_circuit_breaker.ml
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_circuit_breaker.exe (blocked: wrapper detected bare dune build --root . PID 96632 outside scripts/dune-local.sh and exited 75)