### PR TITLE
refactor(mcp-resource): typed Mcp_error_code.Invalid_params replaces -32602 literal at 3 resource handler sites

### DIFF
--- a/lib/mcp_server_eio_resource.ml
+++ b/lib/mcp_server_eio_resource.ml
@@ -7,16 +7,25 @@
 let make_response = Mcp_transport_protocol.make_response
 let make_error = Mcp_transport_protocol.make_error
 
+(* Typed wrapper.  The bare [-32602] literal at three call sites was a
+   "Magic Number repetition" anti-pattern (sw-dev §"Magic Number 금지")
+   that bypassed the existing [Mcp_error_code.t] typed sum.  Mirrors
+   the [make_error_typed] helper already used in
+   [mcp_server_eio_protocol.ml]; routes the typed variant through
+   [to_wire_code] so the JSON-RPC envelope stays unchanged. *)
+let make_error_typed ?data ~id (code : Mcp_error_code.t) message =
+  make_error ?data ~id (Mcp_error_code.to_wire_code code) message
+
 let public_tool_help_schemas () =
   Config.visible_tool_schemas ()
 
 let handle_read_resource_eio state id params =
   match params with
-  | None -> make_error ~id (-32602) "Missing params"
+  | None -> make_error_typed ~id Mcp_error_code.Invalid_params "Missing params"
   | Some (`Assoc _ as p) ->
       let uri_str = Safe_ops.json_string "uri" p in
       if uri_str = "" then
-        make_error ~id (-32602) "Missing uri"
+        make_error_typed ~id Mcp_error_code.Invalid_params "Missing uri"
       else begin
         let resource_id, uri = Mcp_server.parse_masc_resource_uri uri_str in
         let config = state.Mcp_server.room_config in
@@ -356,4 +365,4 @@ let handle_read_resource_eio state id params =
             make_response ~id (`Assoc [("contents", contents)])
       end
   | Some _ ->
-      make_error ~id (-32602) "Invalid params"
+      make_error_typed ~id Mcp_error_code.Invalid_params "Invalid params"


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" 안티패턴 제거. `lib/mcp_server_eio_resource.ml` 의 *3 사이트* 가 `Mcp_error_code.Invalid_params` typed sum 우회하고 `-32602` 리터럴 직접 사용.

### Pattern

`Mcp_error_code.t` typed sum + `to_wire_code` 매핑 + `to_http_status` 매핑 SSOT가 *이미 존재* (`lib/server/mcp_error_code.ml`). `mcp_server_eio_protocol.ml:18` 은 `make_error_typed` 헬퍼 통해 *10+ 사이트* 가 typed 경로 사용. `mcp_server_eio_resource.ml` 만 *legacy literal* — pattern 적용 누락.

before (`mcp_server_eio_resource.ml`):
```ocaml
let make_error = Mcp_transport_protocol.make_error

let handle_read_resource_eio state id params =
  match params with
  | None -> make_error ~id (-32602) "Missing params"
  | Some (`Assoc _ as p) ->
      ...
      if uri_str = "" then
        make_error ~id (-32602) "Missing uri"
      ...
  | Some _ ->
      make_error ~id (-32602) "Invalid params"
```

after:
```ocaml
let make_error_typed ?data ~id (code : Mcp_error_code.t) message =
  make_error ?data ~id (Mcp_error_code.to_wire_code code) message

let handle_read_resource_eio state id params =
  match params with
  | None -> make_error_typed ~id Mcp_error_code.Invalid_params "Missing params"
  ...
  | Some _ -> make_error_typed ~id Mcp_error_code.Invalid_params "Invalid params"
```

## 변경

- `mcp_server_eio_resource.ml`: 1 file, +12/-3
  - `make_error_typed` 로컬 헬퍼 추가 (`mcp_server_eio_protocol.ml:18` 패턴 미러)
  - 3 사이트의 `-32602` 리터럴 → `Mcp_error_code.Invalid_params` typed dispatch
- JSON-RPC envelope *byte-for-byte 동등* (to_wire_code 통해 동일 wire code, 동일 message)

## Magic-number lint impact

`bash scripts/lint-magic-number.sh --explain 32602` 결과:
- Before: 6 hits (3 literal call sites + 3 SSOT mapping definitions)
- After: 3 hits (definitions only — `transport.ml:71` constant, `mcp_error_code.ml:19, 33` typed↔wire mapping)

The 3 remaining hits are the *typed sum definition itself* (the SSOT). Anti-pattern *consumer-side* 완전 제거.

## Out-of-scope finding

Same file line 347:
```ocaml
make_error ~id ~data:... (-32002) "Resource not found"
```

`-32002` 가 `Mcp_error_code.t` typed sum 에서 `Not_ready -> "Server is starting up, not ready yet"` 로 매핑 — **literal wire code 와 typed-message 의미 불일치**. MCP spec 의 일부 구현 에서 `-32002` 는 "Resource not found" 로 정의되어 있어, masc-mcp 의 typed sum 자체가 *spec 비호환*.

본 PR 범위 외. 별도 issue 등록 후보 — `Mcp_error_code.t` 에 `Resource_not_found` variant 추가 또는 `Not_ready` 매핑 재고.

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거* 함 (typed sum 사용). 시그니처 3종 + 체크리스트 7항목 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기 (Magic Number 카테고리)
- ❌ N-of-M 패치 — 3 사이트 *모두* 동시 처리
- ❌ Repair/Sanitize

## Test impact

- 사용자 surface (JSON-RPC error envelope) *완전 동등*
- lib/ build PASS (test/ 는 unrelated build cache linker error — main HEAD `a219bd9ef` 자체 영향)

## Related

- PR #18977 / #18982 / #19002 / #19016 / #19026 — RFC-0088 §"String 분류기" series
- 본 PR — 별도 anti-pattern (Magic Number) 같은 *typed sum 우회* 카테고리
- sw-dev §"Magic Number 금지"
- `lib/server/mcp_error_code.ml` — typed sum SSOT

🤖 Generated with [Claude Code](https://claude.com/claude-code)
