### PR TITLE
fix(governance): risk_overrides for 3 substring-classifier false-positives

### DIFF
--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -93,6 +93,11 @@ let risk_overrides : (string * risk_level) list =
     ("masc_claim_next", Medium);
     ("keeper_task_create", Medium); (* routine keeper backlog expansion; force/delete stays gated *)
     ("masc_keeper_reset", Medium); (* usage counter zeroing only; keeper_clear stays Critical *)
+    (* WORKAROUND: substring classifier false-positives (lib/governance_pipeline_risk.ml:101 high_patterns).
+       Removal target: RFC-0193 typed capability table (Issue #19032). Evidence: 11 approval_required/8.4h on 2026-05-27. *)
+    ("masc_plan_set_task", Low); (* "set" substring → High; payload is self-owned task plan metadata *)
+    ("keeper_memory_write", Low); (* "write" substring → High; scoped to own keeper memory *)
+    ("masc_worktree_create", Medium); (* "create" substring → High; meta tooling, no code mutation *)
   ]
 
 let critical_patterns =


### PR DESCRIPTION
## 요약

`lib/governance_pipeline_risk.ml:101 high_patterns` substring 분류기가 3개 self-owned tool을 High risk로 오분류 → `governance_approval` gate 무의미하게 trip. 기존 `risk_overrides` 표(line 87, 이미 5 entry 운영 중)에 3 entry 추가로 차단 해소.

## Evidence (2026-05-27, 8.4h fleet)

11 `governance_approval` decision, **100% false positive**:

| Tool | 차단 횟수 | substring trigger | 실제 위험도 | 새 분류 |
|---|---|---|---|---|
| `masc_plan_set_task` | 5 | `"set"` → High | Low (자기 task plan metadata) | Low |
| `keeper_memory_write` | 5 | `"write"` → High | Low (own keeper memory scope) | Low |
| `masc_worktree_create` | 1 | `"create"` → High | Medium (meta tooling, code 무관) | Medium |

24h 추정 ~31건 자율 차단. PID 3725 server etime 15분 시점의 신선 로그 기준.

## Why `risk_overrides` extension (workaround mechanism alignment)

`risk_overrides` table (line 87-96) 의 *목적 자체*가 substring matcher false-positive 보정 — 기존 5 entry 중 하나의 코멘트 (line 89):

```ocaml
("masc_a2a_query_skill", Low); (* "skill" contains "kill" substring *)
```

분류기 자신이 line 113 `contains_pattern` 의 confusion 을 자인하고 보정 메커니즘을 두고 있음. 본 PR은 그 메커니즘을 의도된 대로 사용 (`tool_edit_file`/`tool_write_file` 같은 실제 source-mutating tool 은 변경 없이 High 유지).

## WORKAROUND

substring 분류기 자체는 RFC-0088 §"String/Substring 분류기" 안티패턴. **현재 PR은 분류기 *영향면적 축소* 이며 분류기 *제거*는 별도 RFC**.

- WORKAROUND: substring classifier false-positives (high_patterns line 101)
- RFC-0193 (substring classifier sunset → typed capability table SSOT)
- removal target: Issue #19032 merge 시 3 entry 동시 삭제

## RFC-WAIVED 근거

scope-narrowing of existing gate, not a new hard gate. 메모 `[[feedback-cascade-budget-no-hard-gates]]` 정신과 일치 — 새 gate 만들지 않음. 기존 `risk_overrides` 보정 패턴의 6-8th entry.

## Test plan

- [x] @check 통과 (typecheck)
- [ ] CI lint/test green
- [ ] 머지 후 fleet 24h 관찰: `governance_approval` decision 로그에서 3 tool 0건 trip
- [ ] 30일 관찰: 다른 false-positive 발견 시 *새 entry 추가 대신* RFC-0193 #19032 진행

## Cross-link

- Issue: #19032 (RFC-0193 sunset)
- Anti-pattern: CLAUDE.md §워크어라운드 거부 기준 §2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
