### PR TITLE
fix(dashboard): clarify runtime count roles

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -44,7 +44,12 @@ import {
 import { KeeperPhaseBadge } from './keeper-phase-indicator'
 import { KeeperActionButtons } from './keeper-action-panel'
 import {
+  expectedKeeperDetailRows,
+  expectedRuntimeDetailRows,
+  formatKeeperCountBreakdown,
+  formatRuntimeRosterCount,
   resolveRuntimeCounts,
+  runtimeDetailRows,
   runtimeCountSourceLabel,
   shouldShowExecutionFallbackState,
 } from '../runtime-counts'
@@ -336,20 +341,19 @@ function expectedCountForKeeperFilter(
   keeperFilter: KeeperFilterMode,
   counts: ReturnType<typeof resolveRuntimeCounts>,
 ): number {
-  // Live counts are authoritative when execution has anything; fall back to the
-  // configured baseline so "expected N runtimes" hints survive a cold-start
-  // before the execution stream hydrates. `configured` has no agent dimension —
-  // agent counts always come from the live view.
-  const useLive = counts.live.totalRuntimes > 0
-  if (keeperFilter === 'keeper-only') return useLive ? counts.live.keepers : counts.configured.keepers
+  // Roster fallback messages compare against detail rows, not active runtime
+  // fibers. A paused keeper is not live capacity, but it is still a row the
+  // operator expects to see in the directory.
+  const useDetailRows = runtimeDetailRows(counts) > 0
+  if (keeperFilter === 'keeper-only') return useDetailRows ? expectedKeeperDetailRows(counts) : counts.configured.keepers
   if (keeperFilter === 'agent-only') return counts.live.agents
-  return useLive ? counts.live.totalRuntimes : counts.configured.totalRuntimes
+  return useDetailRows ? expectedRuntimeDetailRows(counts) : counts.configured.totalRuntimes
 }
 
 const FILTER_META: Record<StatusFilter, { label: string; description: string }> = {
   all: {
-    label: '전체 보기',
-    description: '등록된 런타임 전체를 보여줍니다.',
+    label: '전체 상세',
+    description: 'execution 상세 행 전체를 보여줍니다. 활성 runtime 총계와는 별도 기준입니다.',
   },
   active: { label: runtimeBandMeta('active').label, description: runtimeBandMeta('active').description },
   attention: { label: runtimeBandMeta('attention').label, description: runtimeBandMeta('attention').description },
@@ -732,13 +736,13 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     expectedScopedCount > scopedAgents.length
       ? (
           filtered.length === scopedAgents.length
-            ? `${filtered.length}개 로드됨 · 예상 ${expectedScopedCount}개`
-            : `${filtered.length} / ${scopedAgents.length}개 표시 · 예상 ${expectedScopedCount}개`
+            ? `상세 행 ${filtered.length}개 로드됨 · 예상 ${expectedScopedCount}개`
+            : `상세 행 ${filtered.length} / ${scopedAgents.length}개 표시 · 예상 ${expectedScopedCount}개`
         )
       : (
           filtered.length === scopedAgents.length
-            ? `${filtered.length}개 표시 중`
-            : `${filtered.length} / ${scopedAgents.length}개 표시 중`
+            ? `상세 행 ${filtered.length}개 표시 중`
+            : `상세 행 ${filtered.length} / ${scopedAgents.length}개 표시 중`
         )
   const statusChips = (['all', 'attention', 'active', 'paused', 'offline'] as StatusFilter[]).map(key => ({
     key,
@@ -751,10 +755,14 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const configuredKeepers = runtimeCounts.configured.keepers
   const configuredKeeperDelta = Math.max(0, configuredKeepers - liveKeepers - livePausedKeepers)
   const scopeLabel = keeperFilter === 'keeper-only'
-    ? `키퍼 활성 ${liveKeepers}개${livePausedKeepers > 0 ? ` / 일시정지 ${livePausedKeepers}개` : ''} / 설정 ${configuredKeepers}개`
+    ? formatKeeperCountBreakdown({
+        liveKeepers,
+        pausedKeepers: livePausedKeepers,
+        configuredKeepers,
+      })
     : keeperFilter === 'agent-only'
-      ? `일반 에이전트 ${runtimeCounts.live.agents}개`
-      : `에이전트/키퍼 활성 ${runtimeCounts.live.totalRuntimes}개 / 설정 ${runtimeCounts.configured.totalRuntimes}개`
+      ? `일반 에이전트 활성 ${runtimeCounts.live.agents}`
+      : formatRuntimeRosterCount(runtimeCounts)
   const configuredIdleHint =
     keeperFilter === 'agent-only' || configuredKeeperDelta === 0
       ? null
@@ -767,10 +775,10 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         : '상세 상태 동기화 중'
   const fallbackStateMessage =
     executionError.value
-      ? `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있지만 상세 상태 정보를 아직 가져오지 못했습니다.`
+      ? `${countSourceLabel} 기준 ${scopeLabel}입니다. 상세 상태 정보를 아직 가져오지 못했습니다.`
       : executionLoaded.value
-        ? `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있고 일부만 상세 목록에 반영됐습니다.${configuredIdleHint ? ` ${configuredIdleHint}.` : ''}`
-        : `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있습니다.${configuredIdleHint ? ` ${configuredIdleHint}.` : ''} 상세 상태 정보가 올라오면 상태별 분류와 카드가 채워집니다.`
+        ? `${countSourceLabel} 기준 ${scopeLabel}입니다. 일부만 상세 목록에 반영됐습니다.${configuredIdleHint ? ` ${configuredIdleHint}.` : ''}`
+        : `${countSourceLabel} 기준 ${scopeLabel}입니다.${configuredIdleHint ? ` ${configuredIdleHint}.` : ''} 상세 상태 정보가 올라오면 상태별 분류와 카드가 채워집니다.`
 
   const rosterRows = filtered.map((agent: Agent) => {
     const keeperRuntime =
@@ -910,7 +918,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           <div class="monitor-muted-panel p-3.5 md:p-4">
             <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <div class="text-2xs font-semibold tracking-[var(--track-caps)] text-[var(--color-fg-secondary)] uppercase">운영 상태</div>
+              <div class="text-2xs font-semibold tracking-[var(--track-caps)] text-[var(--color-fg-secondary)] uppercase">상세 상태</div>
               <${FilterChips}
                 chips=${statusChips}
                 value=${filter}

--- a/dashboard/src/components/agents-unified.test.ts
+++ b/dashboard/src/components/agents-unified.test.ts
@@ -10,6 +10,7 @@ const mockRoute = await vi.hoisted(async () => {
 })
 
 type FilterChip = { key: string; label: ComponentChildren }
+type FilterChipWithCount = FilterChip & { count?: ComponentChildren }
 
 vi.mock('./keeper-detail', () => ({
   KeeperDetailPage: () => h('div', { 'data-testid': 'keeper-detail-page' }, 'KeeperDetailPage'),
@@ -40,17 +41,20 @@ vi.mock('./composite-fsm-flowchart', () => ({
 }))
 vi.mock('./common/filter-chips', () => ({
   FilterChips: ({ chips, value, onChange }: {
-    chips: FilterChip[]
+    chips: FilterChipWithCount[]
     value: string
     onChange: (key: string) => void
   }) =>
     h('div', { 'data-testid': 'filter-chips', 'data-value': value },
-      chips.map((chip) => h('button', { key: chip.key, onClick: () => onChange(chip.key) }, chip.label))
+      chips.map((chip) => h('button', { key: chip.key, onClick: () => onChange(chip.key) }, [
+        chip.label,
+        chip.count != null ? h('span', { 'data-testid': `chip-count-${chip.key}` }, chip.count) : null,
+      ]))
     ),
 }))
 vi.mock('./agent-roster', () => ({
   AgentRoster: ({ keeperFilter }: { keeperFilter: string }) => h('div', { 'data-testid': 'agent-roster', 'data-filter': keeperFilter }, 'AgentRoster'),
-  countRuntimeKinds: vi.fn(() => ({ agents: 0, keepers: 0 })),
+  countRuntimeKinds: vi.fn(() => ({ agents: 0, keepers: 0, pausedKeepers: 0, totalRuntimes: 0 })),
 }))
 
 vi.mock('../router', () => ({
@@ -69,10 +73,12 @@ vi.mock('../namespace-truth-store', () => ({
   namespaceTruth: { value: null },
 }))
 vi.mock('../runtime-counts', () => ({
+  formatKeeperRosterCount: vi.fn(() => '상세 16 / 활성 4 / 일시정지 12 / 설정 16'),
+  formatRuntimeRosterCount: vi.fn(() => '상세 20 / 활성 8 / 키퍼 설정 16'),
   resolveRuntimeCounts: vi.fn(() => ({
-    live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
-    configured: { keepers: 0, totalRuntimes: 0, source: 'none' },
-    source: 'unknown',
+    live: { agents: 4, keepers: 4, pausedKeepers: 12, tasks: 0, totalRuntimes: 8, available: true },
+    configured: { keepers: 16, totalRuntimes: 8, source: 'namespace-truth' },
+    source: 'execution',
   })),
 }))
 
@@ -114,6 +120,10 @@ describe('AgentsUnified', () => {
     expect(roster).not.toBeNull()
     expect(roster!.getAttribute('data-filter')).toBe('all')
     expect(container.querySelector('[data-testid="keeper-spawn-panel"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="chip-count-all"]')?.textContent)
+      .toBe('상세 20 / 활성 8 / 키퍼 설정 16')
+    expect(container.querySelector('[data-testid="chip-count-keepers"]')?.textContent)
+      .toBe('상세 16 / 활성 4 / 일시정지 12 / 설정 16')
   })
 
   it('switches to agents view via filter chips', async () => {

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -12,7 +12,11 @@ import { AgentRoster, countRuntimeKinds } from './agent-roster'
 import { AgentProfile } from './agent-profile'
 import { KeeperDetailPage } from './keeper-detail'
 import { namespaceTruth } from '../namespace-truth-store'
-import { resolveRuntimeCounts } from '../runtime-counts'
+import {
+  formatKeeperRosterCount,
+  formatRuntimeRosterCount,
+  resolveRuntimeCounts,
+} from '../runtime-counts'
 import { KeeperSpawnPanel } from './keeper-spawn/keeper-spawn-panel'
 import { KeeperTokenStats } from './keeper-token-stats'
 import { KeeperMultiSelect } from './keeper-multi-select'
@@ -62,11 +66,10 @@ export function AgentsUnified() {
     namespaceTruthCounts: namespaceTruth.value?.root.counts,
     namespaceTruthConfiguredKeepers: namespaceTruth.value?.root.configured_keepers,
   })
-  const liveKeepers = runtimeCounts.live.keepers
-  function chipCount(id: AgentsView): number | null {
-    if (id === 'all') return runtimeCounts.live.totalRuntimes
-    if (id === 'agents') return runtimeCounts.live.agents
-    if (id === 'keepers') return liveKeepers
+  function chipCount(id: AgentsView): number | string | null {
+    if (id === 'all') return formatRuntimeRosterCount(runtimeCounts)
+    if (id === 'agents') return `활성 ${runtimeCounts.live.agents}`
+    if (id === 'keepers') return formatKeeperRosterCount(runtimeCounts)
     return null
   }
   const viewChips = CHIPS.map(chip => ({

--- a/dashboard/src/components/common/command-palette.test.ts
+++ b/dashboard/src/components/common/command-palette.test.ts
@@ -149,4 +149,36 @@ describe('CommandPalette', () => {
       expect(palette?.data?.some((item) => item.id === 'nav-session-sess-1')).toBe(true)
     })
   })
+
+  it('labels mission entities as command targets, not live runtime counts', async () => {
+    missionAgentBriefs.value = [
+      { agent_name: 'worker-a', display_name: 'Worker A', status: 'active' },
+    ]
+    missionKeeperBriefs.value = [
+      { name: 'keeper-a', status: 'paused' },
+      { name: 'keeper-b', status: 'busy' },
+    ]
+    missionSnapshot.value = {
+      sessions: [
+        { session_id: 'sess-1', goal: 'review', status: 'running' },
+      ],
+    }
+
+    const { CommandPalette } = await loadPalette()
+    render(html`<${CommandPalette} />`, container)
+
+    await waitFor(() => {
+      const palette = container.querySelector('ninja-keys') as (HTMLElement & {
+        data?: Array<{ id: string; section?: string; keywords?: string }>
+      }) | null
+      expect(palette?.data?.find((item) => item.id === 'nav-agent-worker-a')?.section)
+        .toBe('Agent targets (1)')
+      expect(palette?.data?.find((item) => item.id === 'nav-keeper-keeper-a')?.section)
+        .toBe('Keeper targets (2)')
+      expect(palette?.data?.find((item) => item.id === 'nav-session-sess-1')?.section)
+        .toBe('Session targets (1)')
+      expect(palette?.data?.find((item) => item.id === 'nav-keeper-keeper-a')?.keywords)
+        .toContain('명령 대상 에이전트 1 / 키퍼 2 / 세션 1')
+    })
+  })
 })

--- a/dashboard/src/components/common/command-palette.ts
+++ b/dashboard/src/components/common/command-palette.ts
@@ -4,6 +4,7 @@ import { navigate, route } from '../../router'
 import { requestConfirm } from './confirm-dialog'
 import { runGarbageCollection, cleanupZombies } from '../flow-control/flow-control-state'
 import { missionSnapshot, missionAgentBriefs, missionKeeperBriefs } from '../../mission-signals'
+import { formatCommandTargetSection, formatCommandTargetSummary } from '../../runtime-counts'
 
 interface CommandPaletteAction {
   id: string
@@ -143,31 +144,36 @@ export function CommandPalette() {
 
     // Add Agents dynamically
     const agents = missionAgentBriefs.value || []
+    const keepers = missionKeeperBriefs.value || []
+    const sessions = missionSnapshot.value?.sessions ?? []
+    const commandTargetSummary = formatCommandTargetSummary({
+      agents: agents.length,
+      keepers: keepers.length,
+      sessions: sessions.length,
+    })
     const agentActions: CommandPaletteAction[] = agents.map(agent => ({
       id: `nav-agent-${agent.agent_name}`,
       title: `에이전트 상세: ${agent.display_name || agent.agent_name}`,
-      section: 'Agents',
-      keywords: `worker detail status ${agent.status || ''}`,
+      section: formatCommandTargetSection('agent', agents.length),
+      keywords: `worker detail status command target mission ${commandTargetSummary} ${agent.status || ''}`,
       handler: () => navigate('overview', { section: 'worker', operation_id: agent.agent_name })
     }))
 
     // Add Keepers dynamically
-    const keepers = missionKeeperBriefs.value || []
     const keeperActions: CommandPaletteAction[] = keepers.map(keeper => ({
       id: `nav-keeper-${keeper.name}`,
       title: `키퍼 상세: ${keeper.name}`,
-      section: 'Keepers',
-      keywords: `bot detail status ${keeper.status || ''}`,
+      section: formatCommandTargetSection('keeper', keepers.length),
+      keywords: `bot detail status command target mission ${commandTargetSummary} ${keeper.status || ''}`,
       handler: () => navigate('overview', { section: 'keeper', operation_id: keeper.name })
     }))
 
     // Add Sessions dynamically
-    const sessions = missionSnapshot.value?.sessions ?? []
     const sessionActions: CommandPaletteAction[] = sessions.map(s => ({
       id: `nav-session-${s.session_id}`,
       title: `세션 확인: ${s.goal || s.session_id}`,
-      section: 'Sessions',
-      keywords: `task run ${s.status || ''}`,
+      section: formatCommandTargetSection('session', sessions.length),
+      keywords: `task run command target mission ${commandTargetSummary} ${s.status || ''}`,
       handler: () => navigate('workspace', { section: 'session', session_id: s.session_id })
     }))
 
@@ -180,7 +186,7 @@ export function CommandPalette() {
   return html`
     <ninja-keys
       ref=${ref}
-      placeholder="명령어 또는 에이전트/세션 검색... (⌘/Ctrl+K)"
+      placeholder="명령어 또는 command target 검색... (⌘/Ctrl+K)"
       hideBreadcrumbs
       style="
         --ninja-modal-background: var(--color-bg-surface);

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -68,9 +68,12 @@ describe('dashboardHealthChips', () => {
 
     expect(chips.map(chip => chip.key)).toEqual([
       'source-mismatch',
+      'keeper-count-basis',
       'paused-keepers',
       'execution-error',
     ])
+    expect(chips.find(chip => chip.key === 'keeper-count-basis')?.label)
+      .toBe('키퍼 활성 1 / 일시정지 1 / 설정 2')
   })
 
   it('returns a healthy chip when no runtime risk is visible', () => {

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -12,6 +12,7 @@ import { isKeeperPaused } from '../lib/keeper-predicates'
 import { dashboardLoading, executionError, keepers, serverStatus, shellCounts, shellRuntimeResolution } from '../store'
 import { missionSnapshot, missionLoading } from '../mission-signals'
 import { namespaceTruthInitializing } from '../namespace-truth-store'
+import { formatKeeperCountBreakdown } from '../runtime-counts'
 import { ErrorBoundary } from './common/error-boundary'
 import { TimeAgo } from './common/time-ago'
 import { LoadingState } from './common/feedback-state'
@@ -397,6 +398,8 @@ function chipRouteFor(key: string): DashboardHealthChipRoute | undefined {
     case 'fleet-liveness-risk':
     case 'no-keeper-rows':
       return { tab: 'monitoring', params: { section: 'fleet-health' } }
+    case 'keeper-count-basis':
+      return { tab: 'monitoring', params: { section: 'agents', view: 'keepers' } }
     default:
       return undefined
   }
@@ -431,6 +434,21 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
   }
 
   const pausedKeepers = input.keepers.filter(isKeeperPaused).length
+  const configured = input.counts?.configured_keepers ?? 0
+  const liveKeepers = input.counts?.keepers ?? input.keepers.length
+  if (configured > 0 && (configured !== liveKeepers || pausedKeepers > 0)) {
+    chips.push({
+      key: 'keeper-count-basis',
+      label: formatKeeperCountBreakdown({
+        liveKeepers,
+        pausedKeepers,
+        configuredKeepers: configured,
+      }),
+      detail: 'counts.keepers=활성 keeper runtime, paused=상세 행 lifecycle, configured_keepers=keeper inventory.',
+      tone: 'muted',
+    })
+  }
+
   if (pausedKeepers > 0) {
     chips.push({
       key: 'paused-keepers',
@@ -455,8 +473,6 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
     chips.push(cdalChip)
   }
 
-  const configured = input.counts?.configured_keepers ?? 0
-  const liveKeepers = input.counts?.keepers ?? input.keepers.length
   if (configured > 0 && liveKeepers === 0) {
     chips.push({
       key: 'no-keeper-rows',

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -2,7 +2,16 @@ import { describe, expect, it } from 'vitest'
 import {
   configuredCountSourceLabel,
   formatActiveOverConfigured,
+  formatCommandTargetSection,
+  formatCommandTargetSummary,
+  expectedKeeperDetailRows,
+  expectedRuntimeDetailRows,
+  formatKeeperCountBreakdown,
+  formatKeeperRosterCount,
+  formatRuntimeRosterCount,
+  keeperDetailRows,
   resolveRuntimeCounts,
+  runtimeDetailRows,
   runtimeCountSourceLabel,
   shouldShowExecutionFallbackState,
 } from './runtime-counts'
@@ -216,6 +225,46 @@ describe('formatActiveOverConfigured', () => {
       configured: { keepers: 0, totalRuntimes: 0, source: 'none' as const },
     }
     expect(formatActiveOverConfigured(counts)).toBe('활성 0 / 설정 0')
+  })
+})
+
+describe('runtime count role helpers', () => {
+  const counts = {
+    live: { agents: 4, keepers: 4, pausedKeepers: 12, tasks: 0, totalRuntimes: 8, available: true },
+    configured: { keepers: 16, totalRuntimes: 8, source: 'namespace-truth' as const },
+  }
+
+  it('keeps detail rows distinct from active runtime totals', () => {
+    expect(keeperDetailRows(counts)).toBe(16)
+    expect(runtimeDetailRows(counts)).toBe(20)
+  })
+
+  it('keeps configured keeper inventory as the expected detail-row floor', () => {
+    const partialCounts = {
+      live: { agents: 4, keepers: 4, pausedKeepers: 0, tasks: 0, totalRuntimes: 8, available: true },
+      configured: { keepers: 16, totalRuntimes: 8, source: 'namespace-truth' as const },
+    }
+    expect(expectedKeeperDetailRows(partialCounts)).toBe(16)
+    expect(expectedRuntimeDetailRows(partialCounts)).toBe(20)
+  })
+
+  it('formats the keeper count roles without losing paused inventory', () => {
+    expect(formatKeeperCountBreakdown({
+      liveKeepers: 4,
+      pausedKeepers: 12,
+      configuredKeepers: 16,
+    })).toBe('키퍼 활성 4 / 일시정지 12 / 설정 16')
+  })
+
+  it('formats roster chips with detail rows, active runtimes, and configured inventory', () => {
+    expect(formatKeeperRosterCount(counts)).toBe('상세 16 / 활성 4 / 일시정지 12 / 설정 16')
+    expect(formatRuntimeRosterCount(counts)).toBe('상세 20 / 활성 8 / 키퍼 설정 16')
+  })
+
+  it('formats command target sections as mission targets, not live runtime counts', () => {
+    expect(formatCommandTargetSection('keeper', 16)).toBe('Keeper targets (16)')
+    expect(formatCommandTargetSummary({ agents: 4, keepers: 16, sessions: 0 }))
+      .toBe('명령 대상 에이전트 4 / 키퍼 16 / 세션 0')
   })
 })
 

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -30,6 +30,14 @@ export interface RuntimeCounts {
   source: RuntimeCountSource
 }
 
+export interface KeeperCountBreakdownInput {
+  liveKeepers: number
+  pausedKeepers?: number
+  configuredKeepers: number
+}
+
+export type CommandTargetKind = 'agent' | 'keeper' | 'session'
+
 interface ResolveRuntimeCountsOptions {
   executionLoaded: boolean
   agentsCount: number
@@ -204,6 +212,81 @@ export function formatActiveOverConfigured(
     return parts.join(' / ')
   }
   return `활성 ${counts.live.totalRuntimes} / 설정 ${counts.configured.totalRuntimes}`
+}
+
+export function keeperDetailRows(counts: Pick<RuntimeCounts, 'live'>): number {
+  return counts.live.keepers + counts.live.pausedKeepers
+}
+
+export function runtimeDetailRows(counts: Pick<RuntimeCounts, 'live'>): number {
+  return counts.live.agents + keeperDetailRows(counts)
+}
+
+export function expectedKeeperDetailRows(counts: Pick<RuntimeCounts, 'live' | 'configured'>): number {
+  return Math.max(keeperDetailRows(counts), counts.configured.keepers)
+}
+
+export function expectedRuntimeDetailRows(counts: Pick<RuntimeCounts, 'live' | 'configured'>): number {
+  return counts.live.agents + expectedKeeperDetailRows(counts)
+}
+
+export function formatKeeperCountBreakdown({
+  liveKeepers,
+  pausedKeepers = 0,
+  configuredKeepers,
+}: KeeperCountBreakdownInput): string {
+  const parts = [`키퍼 활성 ${normalizeCount(liveKeepers)}`]
+  const paused = normalizeCount(pausedKeepers)
+  if (paused > 0) parts.push(`일시정지 ${paused}`)
+  parts.push(`설정 ${normalizeCount(configuredKeepers)}`)
+  return parts.join(' / ')
+}
+
+export function formatKeeperRosterCount(counts: Pick<RuntimeCounts, 'live' | 'configured'>): string {
+  return [
+    `상세 ${keeperDetailRows(counts)}`,
+    formatKeeperCountBreakdown({
+      liveKeepers: counts.live.keepers,
+      pausedKeepers: counts.live.pausedKeepers,
+      configuredKeepers: counts.configured.keepers,
+    }).replace(/^키퍼 /, ''),
+  ].join(' / ')
+}
+
+export function formatRuntimeRosterCount(counts: Pick<RuntimeCounts, 'live' | 'configured'>): string {
+  return [
+    `상세 ${runtimeDetailRows(counts)}`,
+    `활성 ${counts.live.totalRuntimes}`,
+    `키퍼 설정 ${counts.configured.keepers}`,
+  ].join(' / ')
+}
+
+export function formatCommandTargetSection(kind: CommandTargetKind, count: number): string {
+  const normalized = normalizeCount(count)
+  switch (kind) {
+    case 'agent':
+      return `Agent targets (${normalized})`
+    case 'keeper':
+      return `Keeper targets (${normalized})`
+    case 'session':
+      return `Session targets (${normalized})`
+  }
+}
+
+export function formatCommandTargetSummary({
+  agents,
+  keepers,
+  sessions,
+}: {
+  agents: number
+  keepers: number
+  sessions: number
+}): string {
+  return [
+    `명령 대상 에이전트 ${normalizeCount(agents)}`,
+    `키퍼 ${normalizeCount(keepers)}`,
+    `세션 ${normalizeCount(sessions)}`,
+  ].join(' / ')
 }
 
 interface ExecutionFallbackStateOptions {


### PR DESCRIPTION
Summary:
- centralize runtime count role formatting in dashboard runtime-counts SSOT
- label Keeper Ops counts as detail rows vs active runtimes vs configured keeper inventory
- mark command palette entity groups as mission command targets, not live runtime counts

Verification:
- pnpm vitest run --config vitest.config.ts src/runtime-counts.test.ts src/components/agents-unified.test.ts src/components/common/command-palette.test.ts src/components/dashboard-shell.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm eslint src/runtime-counts.ts src/components/agents-unified.ts src/components/agent-roster.ts src/components/dashboard-shell.ts src/components/common/command-palette.ts src/runtime-counts.test.ts src/components/agents-unified.test.ts src/components/dashboard-shell.test.ts src/components/common/command-palette.test.ts (0 errors; 2 existing config ignore warnings for test files)
- git diff --check