### PR TITLE
refactor(keeper-config): named two_days_seconds_int replaces 172800 literal at 7 max_v sites

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -3,6 +3,12 @@
 open Tool_args
 include Keeper_config_rp_helpers
 
+(** Upper bound for keeper time configs expressed in seconds.  Repeated
+    seven times as the bare literal [172800] across this file before
+    the extraction; [Masc_time_constants.day_int * 2] makes the "2 days"
+    intent explicit and satisfies sw-dev §"Magic Number 금지". *)
+let two_days_seconds_int = Masc_time_constants.day_int * 2
+
 (** Default cascade name for keeper turns. Resolved through the live
     [Cascade_catalog_runtime] snapshot so the answer reflects the
     currently-installed catalog rather than module-init state. Falls
@@ -140,8 +146,8 @@ let keeper_compact_max_tokens () : int =
 let keeper_continuity_compaction_cooldown_sec_rp =
   _rp_int ~key:"keeper.compaction.cooldown_sec"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_CONTINUITY_COMPACTION_COOLDOWN_SEC"
-                          ~default:15 ~min_v:0 ~max_v:172800)
-    ~min_v:0 ~max_v:172800
+                          ~default:15 ~min_v:0 ~max_v:two_days_seconds_int)
+    ~min_v:0 ~max_v:two_days_seconds_int
     ~description:"Compaction cooldown (seconds)" ()
 let keeper_continuity_compaction_cooldown_sec () : int =
   Runtime_params.get keeper_continuity_compaction_cooldown_sec_rp
@@ -149,8 +155,8 @@ let keeper_continuity_compaction_cooldown_sec () : int =
 let keeper_bootstrap_proactive_warmup_sec_rp =
   _rp_int ~key:"keeper.proactive.warmup_sec"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOOTSTRAP_PROACTIVE_WARMUP_SEC"
-                          ~default:60 ~min_v:0 ~max_v:172800)
-    ~min_v:0 ~max_v:172800
+                          ~default:60 ~min_v:0 ~max_v:two_days_seconds_int)
+    ~min_v:0 ~max_v:two_days_seconds_int
     ~description:"Bootstrap proactive warmup delay (seconds)" ()
 let keeper_bootstrap_proactive_warmup_sec () : int =
   Runtime_params.get keeper_bootstrap_proactive_warmup_sec_rp
@@ -235,7 +241,7 @@ let normalize_compaction_token_gate (v : int) : int =
   clamp_int v ~min_v:0 ~max_v:5000000
 
 let normalize_continuity_compaction_cooldown_sec (v : int) : int =
-  clamp_int v ~min_v:0 ~max_v:172800
+  clamp_int v ~min_v:0 ~max_v:two_days_seconds_int
 
 (** Default number of recent tool results to keep verbatim during
     OAS context compaction (consumed by
@@ -415,10 +421,10 @@ let resolve_compaction_policy
   (base_profile, ratio, message_gate, token_gate)
 
 let normalize_proactive_idle_sec (v : int) : int =
-  clamp_int v ~min_v:0 ~max_v:172800
+  clamp_int v ~min_v:0 ~max_v:two_days_seconds_int
 
 let normalize_proactive_cooldown_sec (v : int) : int =
-  clamp_int v ~min_v:0 ~max_v:172800
+  clamp_int v ~min_v:0 ~max_v:two_days_seconds_int
 
 
 let keeper_batch_limit_rp =


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" 안티패턴 제거 — PR #19034 (`-32602` literal) 후속, *time literal* 카테고리. `lib/keeper/keeper_config.ml` 가 `172800` (= 2 days in seconds) 을 **7 사이트** 에 repeat — 의미 (2일) 가 *call site 에서 즉시 드러나지 않음*.

### Pattern

`Masc_time_constants` (lib/config/) 는 *time durations 의 SSOT*. 이미 `day_int = 86400` 정의 + `keeper_tool_affinity.ml` 등에서 사용 중. `keeper_config.ml` 만 *legacy literal* — pattern 적용 누락.

before:
```ocaml
let keeper_continuity_compaction_cooldown_sec_rp =
  _rp_int ~key:"keeper.compaction.cooldown_sec"
    ~default:(fun () -> int_of_env_default "MASC_KEEPER_CONTINUITY_COMPACTION_COOLDOWN_SEC"
                          ~default:15 ~min_v:0 ~max_v:172800)
    ~min_v:0 ~max_v:172800
    ~description:"Compaction cooldown (seconds)" ()
```

after:
```ocaml
let two_days_seconds_int = Masc_time_constants.day_int * 2

(* ... *)

let keeper_continuity_compaction_cooldown_sec_rp =
  _rp_int ~key:"keeper.compaction.cooldown_sec"
    ~default:(fun () -> int_of_env_default "MASC_KEEPER_CONTINUITY_COMPACTION_COOLDOWN_SEC"
                          ~default:15 ~min_v:0 ~max_v:two_days_seconds_int)
    ~min_v:0 ~max_v:two_days_seconds_int
    ~description:"Compaction cooldown (seconds)" ()
```

7 사이트 전수 변경:
- Line 143 — `keeper.compaction.cooldown_sec` env default
- Line 144 — `keeper.compaction.cooldown_sec` rp clamp
- Line 152 — `keeper.proactive.warmup_sec` env default
- Line 153 — `keeper.proactive.warmup_sec` rp clamp
- Line 238 — clamp_int call
- Line 418 — clamp_int call
- Line 421 — clamp_int call

## 변경

- `lib/keeper/keeper_config.ml`: 1 file, +13/-7
  - `two_days_seconds_int = Masc_time_constants.day_int * 2` 상수 추가 (top of file)
  - 7 사이트의 `172800` 리터럴 → `two_days_seconds_int`
- 동작 무변경 (수치 동등, 12 곱셈은 module-init 시점 1회 계산)

## Magic-number lint impact

`bash scripts/lint-magic-number.sh --explain 172800` 결과:
- Before: 7 hits (모두 `keeper_config.ml`)
- After: 0 hits (literal 사용처 0; 본 PR 의 *주석* 에만 등장하므로 lint 대상 외)

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거* 함 (named constant + SSOT 참조). 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 7 사이트 *모두* 동시 처리

## Test impact

- 동작 무변경 (수치 동등)
- env knob `MASC_KEEPER_CONTINUITY_COMPACTION_COOLDOWN_SEC` 등 *사용자 surface 0 변경* (max_v 동일)
- `dune build lib/` PASS

## Related

- PR #19034 — `-32602` literal 같은 Magic Number 카테고리
- `lib/config/masc_time_constants.ml` — time SSOT (이미 존재)
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
