### PR TITLE
perf(dashboard): cache+offload bulk wrap (shell + 7 endpoints)

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -740,8 +740,22 @@ let dashboard_shell_http_json
   let cache_key = dashboard_shell_cache_key ~light config in
   let compute () =
     (* Shell endpoint is read-only; use config directly without isolation
-       since state is not available in this context. *)
-    dashboard_shell_payload_json ?timing ~light config
+       since state is not available in this context.
+
+       The payload compute runs status / agents / tasks / keepers /
+       meta_cognition projections (the latter scans board_posts.jsonl and
+       evaluates belief/tension/desire rules — frequently 8s+ on a hot
+       room).  Under cache miss this used to run inline on the calling
+       fiber's Eio main domain, blocking every other HTTP fiber for the
+       duration — the same Eio cooperative scheduling violation that
+       PRs #18991 / #18993 / #18994 / #19007 / #19015 / #19023 / #19024 /
+       #19025 / #19031 fixed for the other dashboard projections.
+
+       [Domain_pool_ref.submit_io_or_inline] runs the compute on a
+       worker domain when the pool is wired, so the main HTTP domain
+       keeps serving requests during the cold-shell refresh. *)
+    Domain_pool_ref.submit_io_or_inline (fun () ->
+      dashboard_shell_payload_json ?timing ~light config)
   in
   let clock_opt =
     match clock with

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -66,9 +66,15 @@ let rec add_routes ~sw ~clock router =
            Server_utils.int_query_param req "limit" ~default:50
            |> Server_utils.clamp ~min_v:1 ~max_v:200
          in
+         let cache_key =
+           Printf.sprintf "nudges:%s:%d"
+             state.Mcp_server.room_config.base_path limit
+         in
          let json =
-           Dashboard_operator_nudges.json
-             ~config:state.Mcp_server.room_config ~limit ()
+           Dashboard_cache.get_or_compute cache_key ~ttl:2.0 (fun () ->
+             Domain_pool_ref.submit_io_or_inline (fun () ->
+               Dashboard_operator_nudges.json
+                 ~config:state.Mcp_server.room_config ~limit ()))
          in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
@@ -469,7 +475,15 @@ let rec add_routes ~sw ~clock router =
      before SSE attaches + explicit tab-refresh). *)
   |> Http.Router.get "/api/v1/operator" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let json = operator_snapshot_http_json ~state ~sw ~clock req in
+         let cache_key =
+           Printf.sprintf "operator_snapshot:%s"
+             state.Mcp_server.room_config.base_path
+         in
+         let json =
+           Dashboard_cache.get_or_compute cache_key ~ttl:2.0 (fun () ->
+             Domain_pool_ref.submit_io_or_inline (fun () ->
+               operator_snapshot_http_json ~state ~sw ~clock req))
+         in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
@@ -520,7 +534,15 @@ let rec add_routes ~sw ~clock router =
 
   |> Http.Router.get "/api/v1/dashboard/planning" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let json = dashboard_planning_http_json ~config:state.Mcp_server.room_config in
+         let cache_key =
+           Printf.sprintf "planning:%s"
+             state.Mcp_server.room_config.base_path
+         in
+         let json =
+           Dashboard_cache.get_or_compute cache_key ~ttl:5.0 (fun () ->
+             Domain_pool_ref.submit_io_or_inline (fun () ->
+               dashboard_planning_http_json ~config:state.Mcp_server.room_config))
+         in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/bootstrap" (fun request reqd ->
@@ -537,7 +559,15 @@ let rec add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/goals" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let json = dashboard_goals_tree_http_json ~config:state.Mcp_server.room_config in
+         let cache_key =
+           Printf.sprintf "goals_tree:%s"
+             state.Mcp_server.room_config.base_path
+         in
+         let json =
+           Dashboard_cache.get_or_compute cache_key ~ttl:5.0 (fun () ->
+             Domain_pool_ref.submit_io_or_inline (fun () ->
+               dashboard_goals_tree_http_json ~config:state.Mcp_server.room_config))
+         in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/goals/detail" (fun request reqd ->
@@ -551,9 +581,15 @@ let rec add_routes ~sw ~clock router =
            respond_json_with_cors ~status:`Bad_request req reqd
              {|{"ok":false,"error":"goal_id query param is required"}|}
          else
+           let cache_key =
+             Printf.sprintf "goal_detail:%s:%s"
+               state.Mcp_server.room_config.base_path goal_id
+           in
            let json =
-             dashboard_goal_detail_http_json
-               ~config:state.Mcp_server.room_config ~goal_id
+             Dashboard_cache.get_or_compute cache_key ~ttl:5.0 (fun () ->
+               Domain_pool_ref.submit_io_or_inline (fun () ->
+                 dashboard_goal_detail_http_json
+                   ~config:state.Mcp_server.room_config ~goal_id))
            in
            Http.Response.json ~compress:true ~request:req
              (Yojson.Safe.to_string json) reqd
@@ -564,12 +600,26 @@ let rec add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/mission" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let json = dashboard_mission_http_json ~state ~sw ~clock req in
+         let cache_key =
+           Printf.sprintf "mission:%s" state.Mcp_server.room_config.base_path
+         in
+         let json =
+           Dashboard_cache.get_or_compute cache_key ~ttl:3.0 (fun () ->
+             Domain_pool_ref.submit_io_or_inline (fun () ->
+               dashboard_mission_http_json ~state ~sw ~clock req))
+         in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/session" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let json = dashboard_session_http_json ~state ~sw ~clock req in
+         let cache_key =
+           Printf.sprintf "session:%s" state.Mcp_server.room_config.base_path
+         in
+         let json =
+           Dashboard_cache.get_or_compute cache_key ~ttl:3.0 (fun () ->
+             Domain_pool_ref.submit_io_or_inline (fun () ->
+               dashboard_session_http_json ~state ~sw ~clock req))
+         in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/tools" (fun request reqd ->


### PR DESCRIPTION
## Summary

Bulk cache+offload wrap covering the most-hit remaining dashboard endpoints, matching the pattern from #18991 / #18993 / #18994 / #19007 / #19015 / #19023 / #19024 / #19025 / #19031.

## Core change — shell payload compute offload

`Server_dashboard_http_core.dashboard_shell_http_json` wraps the `compute` closure in `Domain_pool_ref.submit_io_or_inline`. The compute walks status / agents / tasks / keepers / meta_cognition projections — the latter scans `board_posts.jsonl` and evaluates belief/tension/desire rules (8s+ on hot rooms per existing comment in the file).

Without the offload, every cache miss ran inline on the Eio main domain, blocking every other HTTP fiber until the shell projection finished. **This is the most impactful fix in the batch** — `/shell?light=true` measured at 30s under live load.

## Router-side wraps

| Endpoint | TTL | Note |
|---|---|---|
| `/api/v1/dashboard/nudges` | 2s | top panel, hot |
| `/api/v1/dashboard/mission` | 3s | |
| `/api/v1/dashboard/session` | 3s | |
| `/api/v1/operator` | 2s | operator surface |
| `/api/v1/dashboard/planning` | 5s | |
| `/api/v1/dashboard/goals` | 5s | |
| `/api/v1/dashboard/goals/detail` | 5s | keyed by goal_id |

Cache keys include `base_path` (+ goal_id for /goals/detail). Multi-tenant safe.

## Remaining endpoints (separate PR)

memory-subsystems, tasks/history, mission/briefing, surface-readiness, tool-quality, keeper-feature-proof, transport-health, harness-health, feature-health, eval-feed, telemetry/*, operator/digest — wrap pattern mechanical but per-endpoint cache-key selection benefits from review.

## Test plan

- [x] `dune build` PASS
- [ ] curl `/api/v1/dashboard/shell?light=true` 5× concurrent → first hit takes compute time, rest cache.
- [ ] `cache_stats` shows new `mission:*`, `nudges:*`, `operator_snapshot:*`, etc. prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)