### PR TITLE
refactor(dashboard): extract NO_TIME_INFO const to break cross-file sentinel literal copy

### DIFF
--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -3,7 +3,7 @@ import { AgentFailure, failureTypeFromDiagnostic } from './common/agent-failure'
 import { Markdown } from "./common/markdown"
 import { useState } from 'preact/hooks'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
-import { relativeTime } from '../lib/format-time'
+import { relativeTime, NO_TIME_INFO } from '../lib/format-time'
 import type { Keeper, KeeperDiagnostic } from '../types'
 import {
   abortKeeperThreadMessage,
@@ -143,7 +143,7 @@ function continuityStateLabel(state?: KeeperDiagnostic['continuity_state']): str
 function formatTime(timestamp?: string | null): string | null {
   if (!timestamp) return null
   const result = relativeTime(timestamp)
-  return result === '정보 없음' ? null : result
+  return result === NO_TIME_INFO ? null : result
 }
 
 function formatEligible(seconds?: number | null): string | null {

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -27,17 +27,29 @@ export function formatRelativeAgeMs(ageMs: number): string {
   return formatRelativeSec(Math.max(0, Math.round(ageMs / 1000)))
 }
 
+/**
+ * Sentinel string returned when a time-related helper has no input to format.
+ *
+ * Exposed so call sites that compare against it (e.g. unwrapping the
+ * fallback back to `null` in keeper-shared.formatTime) don't have to
+ * duplicate the literal — changing the displayed sentinel here updates
+ * every comparison automatically. Tests in `format-time.test.ts`
+ * deliberately keep the literal so the assertion documents the
+ * user-visible string.
+ */
+export const NO_TIME_INFO = '정보 없음'
+
 /** Relative time from ISO string — "3분 전", "2시간 전" etc. Uses Intl.RelativeTimeFormat. */
-export function relativeTime(iso?: string | null, fallback = '정보 없음'): string {
+export function relativeTime(iso?: string | null, fallback: string = NO_TIME_INFO): string {
   if (!iso) return fallback
   const ts = Date.parse(iso)
   if (Number.isNaN(ts)) return iso
   return formatRelativeAgeMs(Date.now() - ts)
 }
 
-/** Format elapsed seconds — "3초", "5분", "2시간". Returns '정보 없음' for invalid. */
+/** Format elapsed seconds — "3초", "5분", "2시간". Returns NO_TIME_INFO for invalid. */
 export function formatElapsed(value?: number | null): string {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return '정보 없음'
+  if (typeof value !== 'number' || !Number.isFinite(value)) return NO_TIME_INFO
   if (value < SECONDS_PER_MINUTE) return `${Math.round(value)}초`
   if (value < SECONDS_PER_HOUR) return `${Math.round(value / SECONDS_PER_MINUTE)}분`
   return `${Math.round(value / SECONDS_PER_HOUR)}시간`


### PR DESCRIPTION
## 요약
`'정보 없음'` sentinel literal 의 cross-file copy 를 `NO_TIME_INFO` const 로 통합.

## 배경
`rg "'정보 없음'" -n` 결과 4 production callsite 발견:

| 파일 | 위치 | 역할 |
|---|---|---|
| `lib/format-time.ts:31` | `relativeTime(iso, fallback = '정보 없음')` | default fallback param |
| `lib/format-time.ts:40` | `formatElapsed` return | invalid 입력 시 사용자 노출 문자열 |
| `components/keeper-shared.ts:146` | `result === '정보 없음' ? null : result` | lib fallback 역변환 (string → null) |
| `lib/format-time.test.ts` (3 사이트) | `.toBe('정보 없음')` | spec assertion |

**문제**: `keeper-shared.ts:146` 가 lib 의 *fallback string 을 sentinel 로 비교*. lib 의 fallback 표현이 변경되면 (예: `'정보 없음'` → `'시간 정보 없음'`) keeper-shared 의 *sentinel-to-null 매핑이 silent 하게 안 발화* → invalid timestamp 가 `'시간 정보 없음'` literal 그대로 UI 에 노출. 컴파일러 미감지 silent break.

## 변경

### `lib/format-time.ts`
- `export const NO_TIME_INFO = '정보 없음'` 추가 (JSDoc 으로 sentinel 비교 callsite + test 의 literal 유지 design 결정 명시)
- `relativeTime` default fallback → `NO_TIME_INFO`
- `formatElapsed` invalid return → `NO_TIME_INFO`

### `components/keeper-shared.ts`
- import 갱신: `{ relativeTime, NO_TIME_INFO }`
- comparison: `result === '정보 없음'` → `result === NO_TIME_INFO`

## test 는 literal 유지 (iter#19 R 패턴 확장)
`lib/format-time.test.ts` 의 3 callsite 는 `.toBe('정보 없음')` literal 그대로 유지:

- test = *user-visible string contract spec doc*
- const 화 시 spec 가시성 ↓ (`.toBe(NO_TIME_INFO)` 가 *어떤 string 인지* 직접 읽을 수 없음)
- sentinel 변경 시 test 가 *명시적으로 fail* 해야 user-visible change 의 explicit trigger

## 검증
- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)
- 첫 run 시 3 fail 관찰 → baseline 측정 + 재실행 = 1 fail. iter#34/35/38 와 동일 vitest worker race flaky pair 패턴. baseline-diff SOP 로 false-positive 회피.

## /loop iter#40
SSOT 위반 dashboard 축출 loop 의 iter#40. cumulative 40 PR (27 머지 + 2 OPEN — #19033 + #19?_).

iter#33/34 의 className SSOT, iter#35/37 의 type homonym, iter#36/38/39 의 dead hub/forwarder 패턴 다음으로 **sentinel literal cross-file coupling** 안티패턴 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
