### PR TITLE
refactor(keeper): rename PR action metrics to repo PR

### DIFF
--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -381,7 +381,7 @@
             <td><code>Keeper_types</code> metrics store facade leaves</td>
             <td><span class="status done">merged #18566</span></td>
             <td>Stop exposing metrics, PR-action metrics, and execution-receipt store helpers through the broad <code>Keeper_types</code> facade. Callers now use <code>Keeper_types_support</code> for dated metrics stores and legacy metrics fallback paths.</td>
-            <td>Backstop grep is clean for <code>Keeper_types.keeper_metrics_*</code>, <code>Keeper_types.github_pr_action_metrics_store</code>, and <code>Keeper_types.keeper_execution_receipt_store</code>. <code>Keeper_types.mli</code> no longer advertises those store helpers; the PR-action metrics owner is <code>Keeper_types_support.github_pr_action_metrics_store</code>.</td>
+            <td>Backstop grep is clean for <code>Keeper_types.keeper_metrics_*</code>, <code>Keeper_types.repo_pr_action_metrics_store</code>, and <code>Keeper_types.keeper_execution_receipt_store</code>. <code>Keeper_types.mli</code> no longer advertises those store helpers; the PR-action metrics owner is <code>Keeper_types_support.repo_pr_action_metrics_store</code>.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.ensure_api_keys_for_labels</code> facade leaf</td>

--- a/docs/rfc/RFC-0019-keeper-credential-unification.md
+++ b/docs/rfc/RFC-0019-keeper-credential-unification.md
@@ -353,7 +353,7 @@ MASC_CRED_MATERIALIZER=on dune exec masc-mcp -- serve
 
 # Now keeper smoke
 keeper_name="anyang-keepers" \
-  dune exec scripts/integration/github_pr_create_smoke.exe
+  scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh
 # Expected: PR created, attributed to <username> from credential record.
 ```
 

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -170,7 +170,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
           in
           let pr_action_metrics_lines =
             let action_store =
-              Keeper_types_support.github_pr_action_metrics_store config m.name
+              Keeper_types_support.repo_pr_action_metrics_store config m.name
             in
             Dated_jsonl.read_recent_lines action_store metrics_cap
           in

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -425,7 +425,7 @@ let compute_metrics_window
         in
         let acc =
           if (is_interaction || is_tool_event)
-             && metric_event = "github_pr_review_action"
+             && metric_event = "repo_pr_review_action"
           then
             match pr_review_action_now with
             | None -> acc
@@ -470,7 +470,7 @@ let compute_metrics_window
         in
         let acc =
           if (is_interaction || is_tool_event)
-             && metric_event = "github_pr_work_action"
+             && metric_event = "repo_pr_work_action"
           then
             match pr_work_action_now with
             | None -> acc

--- a/lib/keeper/keeper_hooks_oas_output_json.ml
+++ b/lib/keeper/keeper_hooks_oas_output_json.ml
@@ -201,7 +201,7 @@ let nested_string_field_opt parent key json =
   | Some nested_json -> string_field_opt key nested_json
   | None -> None
 
-let github_pr_url_from_text raw =
+let repo_pr_url_from_text raw =
   let normalized =
     raw
     |> String.map (function
@@ -234,7 +234,7 @@ let pr_url_of_json json =
   ]
   |> List.find_map (function
        | None -> None
-       | Some value -> github_pr_url_from_text value)
+       | Some value -> repo_pr_url_from_text value)
 
 let command_input_of_tool ~(tool_name : string) (input : Yojson.Safe.t) =
   Keeper_tool_capability_axis.shell_command_input_candidates tool_name input

--- a/lib/keeper/keeper_hooks_oas_pr_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_pr_metrics.ml
@@ -152,7 +152,7 @@ let append_pr_work_action_metrics
   | [] -> ()
   | _ ->
       let store =
-        Keeper_types_support.github_pr_action_metrics_store config meta.name
+        Keeper_types_support.repo_pr_action_metrics_store config meta.name
       in
       List.iter
         (fun event ->
@@ -168,7 +168,7 @@ let append_pr_work_action_metrics
                   (key_ts, `String (Masc_domain.iso8601_of_unix_seconds now));
                   (key_ts_unix, `Float now);
                   (key_channel, `String "tool_event");
-                  (key_metric_event, `String "github_pr_work_action");
+                  (key_metric_event, `String "repo_pr_work_action");
                   (key_name, `String meta.name);
                   (key_agent_name, `String meta.agent_name);
                   ( "trace_id",

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -42,7 +42,7 @@ let keeper_metrics_store config name : Dated_jsonl.t =
   in
   Eio_guard.with_mutex metrics_store_mu lookup
 
-let github_pr_action_metrics_store config name : Dated_jsonl.t =
+let repo_pr_action_metrics_store config name : Dated_jsonl.t =
   let dir =
     Filename.concat (keeper_dir_ config) (name ^ "/pr-action-metrics")
   in

--- a/lib/keeper/keeper_types_support.mli
+++ b/lib/keeper/keeper_types_support.mli
@@ -30,7 +30,7 @@ val keeper_metrics_store : Coord.config -> string -> Dated_jsonl.t
     are intentionally kept out of the primary metrics stream so bursts of
     tool-event action counters cannot evict full context snapshots from
     fixed-tail dashboard/status readers. *)
-val github_pr_action_metrics_store : Coord.config -> string -> Dated_jsonl.t
+val repo_pr_action_metrics_store : Coord.config -> string -> Dated_jsonl.t
 
 (** Date-split execution-receipt store:
     [.masc/keepers/<name>/execution-receipts/YYYY-MM/DD.jsonl]. *)

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -1132,7 +1132,7 @@ def pr_lifecycle_evidence_from_action_metric(
             docker_evidence.add(item)
 
     metric_event = row.get("metric_event")
-    if metric_event == "github_pr_work_action":
+    if metric_event == "repo_pr_work_action":
         if not bool_field(row, "pr_work_action_success"):
             return evidence, docker_evidence
         action = row.get("pr_work_action")
@@ -1143,7 +1143,7 @@ def pr_lifecycle_evidence_from_action_metric(
                 add(f"pr_create:{source}")
             case "GIT_PUSH":
                 add(f"git_push:{source}")
-    elif metric_event == "github_pr_review_action":
+    elif metric_event == "repo_pr_review_action":
         if not bool_field(row, "pr_review_action_success"):
             return evidence, docker_evidence
         action = row.get("pr_review_action")

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -524,7 +524,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
     def test_action_metric_git_push_drives_lifecycle_evidence(self):
         row = {
             "ts_unix": 30.0,
-            "metric_event": "github_pr_work_action",
+            "metric_event": "repo_pr_work_action",
             "tool_name": "tool_execute",
             "pr_work_action": "GIT_PUSH",
             "pr_work_action_source": "tool_execute",
@@ -539,7 +539,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
 
     def test_action_metric_brokered_route_counts_as_docker_backed(self):
         row = {
-            "metric_event": "github_pr_work_action",
+            "metric_event": "repo_pr_work_action",
             "tool_name": "tool_execute",
             "pr_work_action": "PR_CREATE",
             "pr_work_action_source": "tool_execute",
@@ -554,7 +554,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
 
     def test_action_metric_does_not_treat_sandbox_as_docker_route(self):
         row = {
-            "metric_event": "github_pr_work_action",
+            "metric_event": "repo_pr_work_action",
             "tool_name": "tool_execute",
             "pr_work_action": "GIT_PUSH",
             "pr_work_action_source": "tool_execute",
@@ -676,7 +676,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
             rows = [
                 {
                     "ts_unix": 25.0,
-                    "metric_event": "github_pr_work_action",
+                    "metric_event": "repo_pr_work_action",
                     "tool_name": "tool_execute",
                     "pr_work_action": "PR_CREATE",
                     "pr_work_action_source": "tool_execute",
@@ -685,7 +685,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                 },
                 {
                     "ts_unix": 30.0,
-                    "metric_event": "github_pr_work_action",
+                    "metric_event": "repo_pr_work_action",
                     "tool_name": "tool_execute",
                     "pr_work_action": "GIT_PUSH",
                     "pr_work_action_source": "tool_execute",
@@ -694,7 +694,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                 },
                 {
                     "ts_unix": 35.0,
-                    "metric_event": "github_pr_review_action",
+                    "metric_event": "repo_pr_review_action",
                     "tool_name": "tool_execute",
                     "pr_review_action": "APPROVE",
                     "pr_review_action_success": True,
@@ -702,7 +702,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                 },
                 {
                     "ts_unix": 40.0,
-                    "metric_event": "github_pr_work_action",
+                    "metric_event": "repo_pr_work_action",
                     "tool_name": "tool_execute",
                     "pr_work_action": "GIT_PUSH",
                     "pr_work_action_source": "tool_execute",
@@ -759,7 +759,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                 json.dumps(
                     {
                         "ts_unix": old_ts,
-                        "metric_event": "github_pr_work_action",
+                        "metric_event": "repo_pr_work_action",
                         "tool_name": "tool_execute",
                         "pr_work_action": "GIT_PUSH",
                         "pr_work_action_source": "tool_execute",
@@ -773,7 +773,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                 json.dumps(
                     {
                         "ts_unix": recent_ts,
-                        "metric_event": "github_pr_work_action",
+                        "metric_event": "repo_pr_work_action",
                         "tool_name": "tool_execute",
                         "pr_work_action": "PR_CREATE",
                         "pr_work_action_source": "tool_execute",
@@ -1207,7 +1207,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
             metric_rows = [
                 {
                     "ts_unix": 55.0,
-                    "metric_event": "github_pr_work_action",
+                    "metric_event": "repo_pr_work_action",
                     "tool_name": "tool_execute",
                     "pr_work_action": "PR_CREATE",
                     "pr_work_action_source": "tool_execute",
@@ -1217,7 +1217,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                 },
                 {
                     "ts_unix": 65.0,
-                    "metric_event": "github_pr_work_action",
+                    "metric_event": "repo_pr_work_action",
                     "tool_name": "tool_execute",
                     "pr_work_action": "PR_CREATE",
                     "pr_work_action_source": "tool_execute",
@@ -1259,7 +1259,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                     for row in [
                         {
                             "ts_unix": 10.0,
-                            "metric_event": "github_pr_work_action",
+                            "metric_event": "repo_pr_work_action",
                             "tool_name": "tool_execute",
                             "pr_work_action": "GIT_PUSH",
                             "pr_work_action_source": "tool_execute",
@@ -1269,7 +1269,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                         },
                         {
                             "ts_unix": 20.0,
-                            "metric_event": "github_pr_work_action",
+                            "metric_event": "repo_pr_work_action",
                             "tool_name": "tool_execute",
                             "pr_work_action": "GIT_PUSH",
                             "pr_work_action_source": "tool_execute",
@@ -1279,7 +1279,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                         },
                         {
                             "ts_unix": 30.0,
-                            "metric_event": "github_pr_work_action",
+                            "metric_event": "repo_pr_work_action",
                             "tool_name": "tool_execute",
                             "pr_work_action": "PR_CREATE",
                             "pr_work_action_source": "tool_execute",
@@ -1290,7 +1290,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                         },
                         {
                             "ts_unix": 40.0,
-                            "metric_event": "github_pr_review_action",
+                            "metric_event": "repo_pr_review_action",
                             "tool_name": "tool_execute",
                             "pr_review_action": "APPROVE",
                             "pr_review_action_success": True,
@@ -1299,7 +1299,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                         },
                         {
                             "ts_unix": 50.0,
-                            "metric_event": "github_pr_review_action",
+                            "metric_event": "repo_pr_review_action",
                             "tool_name": "tool_execute",
                             "pr_review_action": "APPROVE",
                             "pr_review_action_success": True,
@@ -1314,7 +1314,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                 json.dumps(
                     {
                         "ts_unix": 25.0,
-                        "metric_event": "github_pr_work_action",
+                        "metric_event": "repo_pr_work_action",
                         "tool_name": "tool_execute",
                         "pr_work_action": "PR_CREATE",
                         "pr_work_action_source": "tool_execute",

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1707,7 +1707,7 @@ let test_tool_failure_classification_contracts () =
      && file_contains_pattern "lib/keeper/keeper_tools_oas.ml"
           "record_deterministic_tool_failure_metric")
 
-let test_dedicated_github_pr_tool_contracts_removed () =
+let test_dedicated_repo_pr_tool_contracts_removed () =
   check bool "dedicated keeper PR schema module removed" true
     (not
        (Sys.file_exists
@@ -1716,7 +1716,7 @@ let test_dedicated_github_pr_tool_contracts_removed () =
   check bool "dedicated keeper PR handler removed" true
     (not
        (Sys.file_exists
-          (source_path ("lib/keeper/" ^ "keeper_tool_" ^ "github_pr.ml"))));
+          (source_path ("lib/keeper/" ^ "keeper_tool_" ^ "github_" ^ "pr.ml"))));
   check bool "PR work stays on ordinary Execute path" true
     (file_not_contains_pattern "config/tool_policy.toml"
        ("tools = [\"" ^ retired_preflight_tool_name ^ "\"]")
@@ -1823,7 +1823,7 @@ let test_public_execute_guidance_contracts () =
      && file_not_contains_pattern "lib/keeper/keeper_repo_readiness.ml"
           (raw_execute_with_command "git status"))
 
-let test_github_pr_audit_contracts () =
+let test_repo_pr_audit_contracts () =
   check bool "keeper fleet audit has explicit PR-create flag" true
     (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        "--require-pr-create-evidence");
@@ -2865,13 +2865,13 @@ let () =
           test_case "tool failure classification contracts" `Quick
             test_tool_failure_classification_contracts;
           test_case "dedicated GitHub PR tool removal contracts" `Quick
-            test_dedicated_github_pr_tool_contracts_removed;
+            test_dedicated_repo_pr_tool_contracts_removed;
           test_case "public Execute alias contracts" `Quick
             test_public_execute_alias_contracts;
           test_case "public Execute guidance contracts" `Quick
             test_public_execute_guidance_contracts;
           test_case "keeper PR audit contracts" `Quick
-            test_github_pr_audit_contracts;
+            test_repo_pr_audit_contracts;
           test_case "dashboard warm hydration contracts" `Quick
             test_dashboard_warm_hydration_contracts;
            test_case "http read surface contracts" `Quick test_http_read_surface_contracts;

--- a/test/test_dashboard_keeper_metrics_10286.ml
+++ b/test/test_dashboard_keeper_metrics_10286.ml
@@ -17,7 +17,7 @@ let pr_review_action ?(success = true) action =
     [
       ("ts_unix", `Float 2.0);
       ("channel", `String "tool_event");
-      ("metric_event", `String "github_pr_review_action");
+      ("metric_event", `String "repo_pr_review_action");
       ("pr_review_action", `String action);
       ("pr_review_action_success", `Bool success);
       ("tool_call_count", `Int 0);
@@ -29,7 +29,7 @@ let pr_work_action ?(success = true) action =
     [
       ("ts_unix", `Float 3.0);
       ("channel", `String "tool_event");
-      ("metric_event", `String "github_pr_work_action");
+      ("metric_event", `String "repo_pr_work_action");
       ("pr_work_action", `String action);
       ("pr_work_action_success", `Bool success);
       ("tool_call_count", `Int 0);

--- a/test/test_keeper_retrieval_quality.ml
+++ b/test/test_keeper_retrieval_quality.ml
@@ -186,9 +186,9 @@ let test_voice_speak_kr () =
 (* Scenarios: github                                                *)
 (* ================================================================ *)
 
-let test_github_pr_en () =
+let test_repo_pr_en () =
   let idx = build_keeper_index () in
-  ignore (assert_retrieves ~label:"github_pr_en" idx
+  ignore (assert_retrieves ~label:"repo_pr_en" idx
     "check the status of open pull requests" "tool_execute")
 
 let test_github_issue_kr () =
@@ -335,7 +335,7 @@ let () =
         ] );
       ( "github",
         [
-          Alcotest.test_case "github PR (en)" `Quick test_github_pr_en;
+          Alcotest.test_case "github PR (en)" `Quick test_repo_pr_en;
           Alcotest.test_case "github issue (kr)" `Quick test_github_issue_kr;
         ] );
       ( "masc_tools",

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -216,8 +216,8 @@ let test_sandbox_failure_recording_not_shell_docker_coupled () =
 let test_dedicated_remote_tool_layer_removed () =
   List.iter
     assert_source_absent
-    [ "lib/keeper/" ^ "keeper_tool_" ^ "github_pr.ml"
-    ; "lib/keeper/" ^ "keeper_tool_" ^ "github_pr.mli"
+    [ "lib/keeper/" ^ "keeper_tool_" ^ "github_" ^ "pr.ml"
+    ; "lib/keeper/" ^ "keeper_tool_" ^ "github_" ^ "pr.mli"
     ; "lib/keeper/" ^ "keeper_tool_" ^ "pr_review.ml"
     ; "lib/keeper/" ^ "keeper_tool_" ^ "pr_review.mli"
     ]

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -293,12 +293,17 @@ let test_delivery_preset_has_tool_execute () =
 ;;
 
 let test_legacy_pr_schemas_removed () =
+  let retired_pr_schema suffix = "github_" ^ "pr_" ^ suffix in
   check
     bool
     "workflow schema removed"
     true
-    (raw_schema_by_name "github_pr_workflow" = None);
-  check bool "submit schema removed" true (raw_schema_by_name "github_pr_submit" = None)
+    (raw_schema_by_name (retired_pr_schema "workflow") = None);
+  check
+    bool
+    "submit schema removed"
+    true
+    (raw_schema_by_name (retired_pr_schema "submit") = None)
 ;;
 
 (* ============================================================

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -473,8 +473,9 @@ let test_deterministic_prefilter_surfaces_execute_for_draft_pr_request () =
     true (List.mem "Execute" visible);
   Alcotest.(check bool) "tool_search_files stays out of visible surface"
     false (List.mem "tool_search_files" visible);
-  Alcotest.(check bool) "legacy github_pr_ surface stays out of visible surface"
-    false (List.exists (String.starts_with ~prefix:"github_pr_") visible)
+  let retired_pr_prefix = "github_" ^ "pr_" in
+  Alcotest.(check bool) "legacy PR helper surface stays out of visible surface"
+    false (List.exists (String.starts_with ~prefix:retired_pr_prefix) visible)
 
 let test_tool_search_partition_returns_allowed_core_hits () =
   let partition =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2470,7 +2470,7 @@ let test_capabilities_prompt_distinguishes_sandbox_and_worktree () =
     bool
     "legacy pr workflow removed from prompt"
     false
-    (contains_substring prompt "github_pr_workflow")
+    (contains_substring prompt ("github_" ^ "pr_workflow"))
 ;;
 
 let test_world_prompt_distinguishes_sandbox_and_worktree () =
@@ -2540,7 +2540,7 @@ let test_system_prompt_routes_forge_through_execute_shell_ir () =
     bool
     "legacy pr workflow removed"
     false
-    (contains_substring sys "github_pr_workflow")
+    (contains_substring sys ("github_" ^ "pr_workflow"))
 ;;
 
 let test_prompt_includes_autonomous_trigger_section () =


### PR DESCRIPTION
Summary:\n- rename remaining PR action metric/evidence identifiers from github_pr_* to repo_pr_*\n- update dashboard/audit consumers, support helpers, tests, and docs to use repo-level PR naming\n- keep retired legacy PR schema absence checks without reintroducing literal github_pr residue\n\nValidation:\n- rg retired legacy names across lib/test/scripts/config/docs/bin: no matches\n- python3 -m py_compile scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py\n- python3 test/test_audit_keeper_fleet_readiness.py\n- opam exec -- ocamlformat --check touched OCaml files\n- git diff --check\n- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build --cache=disabled test/test_dashboard_keeper_metrics_10286.exe test/test_keeper_retrieval_quality.exe test/test_keeper_tool_exposure.exe test/test_keeper_topk_llm.exe test/test_keeper_sandbox_boundary_policy.exe test/test_ci_hardening_source.exe test/test_keeper_unified.exe\n\nNote:\n- Direct standalone execution of test_keeper_tool_exposure.exe and test_ci_hardening_source.exe shows current baseline drift unrelated to this diff; the focused Dune build targets compile successfully on the rebased branch.