### PR TITLE
refactor(keeper-config): named one_day_seconds_int replaces 86400 literal at 2 max_v sites

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -9,6 +9,12 @@ include Keeper_config_rp_helpers
     intent explicit and satisfies sw-dev §"Magic Number 금지". *)
 let two_days_seconds_int = Masc_time_constants.day_int * 2
 
+(** One-day upper bound expressed in seconds.  Same anti-pattern as
+    [two_days_seconds_int]: the bare literal [86400] appeared twice as
+    a [~max_v] bound for [keeper.proactive.min_interval_sec] without
+    naming the "1 day" intent at the call site. *)
+let one_day_seconds_int = Masc_time_constants.day_int
+
 (** Default cascade name for keeper turns. Resolved through the live
     [Cascade_catalog_runtime] snapshot so the answer reflects the
     currently-installed catalog rather than module-init state. Falls
@@ -200,8 +206,8 @@ let keeper_proactive_min_cooldown_sec () : int =
 let keeper_proactive_min_interval_sec_rp =
   _rp_int ~key:"keeper.proactive.min_interval_sec"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC"
-                          ~default:900 ~min_v:60 ~max_v:86400)
-    ~min_v:60 ~max_v:86400
+                          ~default:900 ~min_v:60 ~max_v:one_day_seconds_int)
+    ~min_v:60 ~max_v:one_day_seconds_int
     ~description:"Minimum proactive turn interval (seconds). Keeper fires a \
                   housekeeping turn at least this often, even with no observable \
                   work signals." ()


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" 안티패턴 *추가* 제거 — PR #19037 (`two_days_seconds_int`, 7 사이트) 의 follow-up. **같은 파일** (`keeper_config.ml`) 안에 남아 있던 `86400` (= 1 day in seconds) **2 사이트** 를 동일 패턴으로 명명.

### Pattern

`Masc_time_constants.day_int = 86400` 이 *이미* SSOT. iter 43 PR 이 `two_days_seconds_int = Masc_time_constants.day_int * 2` thin local binding 도입. 본 PR 은 그 *바로 아래에* `one_day_seconds_int = Masc_time_constants.day_int` 추가 — 두 clamp ceiling 이 call site 에서 대칭으로 읽힘.

before:
```ocaml
let keeper_proactive_min_interval_sec_rp =
  _rp_int ~key:"keeper.proactive.min_interval_sec"
    ~default:(fun () -> int_of_env_default "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC"
                          ~default:900 ~min_v:60 ~max_v:86400)
    ~min_v:60 ~max_v:86400
    ~description:"Minimum proactive turn interval (seconds). ..." ()
```

after:
```ocaml
let one_day_seconds_int = Masc_time_constants.day_int

(* ... *)

let keeper_proactive_min_interval_sec_rp =
  _rp_int ~key:"keeper.proactive.min_interval_sec"
    ~default:(fun () -> int_of_env_default "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC"
                          ~default:900 ~min_v:60 ~max_v:one_day_seconds_int)
    ~min_v:60 ~max_v:one_day_seconds_int
    ~description:"Minimum proactive turn interval (seconds). ..." ()
```

2 사이트:
- Line 203 — `keeper.proactive.min_interval_sec` env default ceiling
- Line 204 — `keeper.proactive.min_interval_sec` rp clamp

## 변경

- `lib/keeper/keeper_config.ml`: 1 file, +8/-2
  - `one_day_seconds_int = Masc_time_constants.day_int` 상수 추가 (iter 43 의 `two_days_seconds_int` 바로 아래)
  - 2 사이트의 `86400` 리터럴 → `one_day_seconds_int`
- 동작 무변경 (수치 동등)

## Magic-number lint impact

`keeper_config.ml` 안 `86400` 리터럴: 2 → 0 (literal 사용처 0; 본 PR 의 *주석* 에만 등장).

파일 전체 매직 넘버 hotspot 잔재 (별도 PR 후보):
- `Default: 86400 (24 hours).` (docstring, lint-clean)
- `86400` literal — keeper_config.ml 안에서는 0 (본 PR 로 완전 제거)

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거* (named constant + SSOT 참조). 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 2 사이트 *모두* 동시 처리

## Test impact

- 동작 무변경 (수치 동등)
- env knob `MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC` *사용자 surface 0 변경* (max_v 동일)
- `dune build lib/` PASS

## Related

- PR #19037 — `two_days_seconds_int` (172800, 7 사이트) — 본 PR 의 직접 선행
- PR #19034 — `Mcp_error_code.Invalid_params` (-32602) — 같은 Magic Number 카테고리, 다른 영역
- `lib/config/masc_time_constants.ml` — time SSOT
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
