### PR TITLE
refactor(keeper-accountability): Masc_time_constants.hour/day replaces 3600.0/86400.0 literals at 4 sites

### DIFF
--- a/lib/keeper/keeper_accountability_types_codec.ml
+++ b/lib/keeper/keeper_accountability_types_codec.ml
@@ -51,9 +51,9 @@ type claim_snapshot =
 let store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
 let store_cache_mu = Eio.Mutex.create ()
 let window_read_count_for_testing_ref : int option ref = ref None
-let task_commitment_expiry_sec = 72.0 *. 3600.0
-let completion_claim_expiry_sec = 24.0 *. 3600.0
-let dedupe_window_sec = 3600.0
+let task_commitment_expiry_sec = 72.0 *. Masc_time_constants.hour
+let completion_claim_expiry_sec = 24.0 *. Masc_time_constants.hour
+let dedupe_window_sec = Masc_time_constants.hour
 let summary_window_days = 14
 
 let claim_kind_to_string = Keeper_accountability_claim_types.claim_kind_to_string
@@ -306,7 +306,7 @@ let read_window_entries (config : Coord_query.config) =
    | Some count -> window_read_count_for_testing_ref := Some (count + 1)
    | None -> ());
   let now = Time_compat.now () in
-  let since = event_date_string (now -. (float_of_int summary_window_days *. 86400.0)) in
+  let since = event_date_string (now -. (float_of_int summary_window_days *. Masc_time_constants.day)) in
   let until = event_date_string now in
   Dated_jsonl.read_range (get_store config) ~since ~until
 ;;


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" 안티패턴 *추가* 제거 — PR #19037 + #19042 (keeper_config 시리즈) 의 *다른 파일* 후속. `lib/keeper/keeper_accountability_types_codec.ml` 의 **4 사이트** (3 hour + 1 day) 가 bare `3600.0` / `86400.0` 리터럴로 시간 단위를 표현.

### Pattern

`Masc_time_constants` (lib/config/) 는 *time durations 의 SSOT* — `hour = 3600.0`, `day = 86400.0`. `keeper_accountability_types_codec.ml` 만 *legacy literal* — pattern 적용 누락.

named constants 의 multiplier 가 *의미를 이미 인코딩* (e.g. `task_commitment_expiry_sec = 72.0 *. 3600.0` = "72 hours"). 그러나 `3600.0` 리터럴 자체는 *unit 가 숨겨짐* — 단위 환산 정합을 require 하는 코드에서 typo (`*. 360.0`) 같은 silent miss 위험.

before:
```ocaml
let task_commitment_expiry_sec = 72.0 *. 3600.0
let completion_claim_expiry_sec = 24.0 *. 3600.0
let dedupe_window_sec = 3600.0
(* ... *)
let since = event_date_string (now -. (float_of_int summary_window_days *. 86400.0)) in
```

after:
```ocaml
let task_commitment_expiry_sec = 72.0 *. Masc_time_constants.hour
let completion_claim_expiry_sec = 24.0 *. Masc_time_constants.hour
let dedupe_window_sec = Masc_time_constants.hour
(* ... *)
let since = event_date_string (now -. (float_of_int summary_window_days *. Masc_time_constants.day)) in
```

4 사이트:
- Line 54 — `task_commitment_expiry_sec` (72h)
- Line 55 — `completion_claim_expiry_sec` (24h)
- Line 56 — `dedupe_window_sec` (1h)
- Line 309 — `event_date_string` since-window (days→seconds)

## 변경

- `lib/keeper/keeper_accountability_types_codec.ml`: 1 file, +4/-4
  - 3 사이트 `3600.0` → `Masc_time_constants.hour`
  - 1 사이트 `86400.0` → `Masc_time_constants.day`
- 동작 무변경 (`Masc_time_constants.hour = 3600.0`, `Masc_time_constants.day = 86400.0` — 값 동등)

## Magic-number lint impact

`keeper_accountability_types_codec.ml` 안 hotspots:
- Before: `3600` 3 hits + `86400` 1 hit = 4
- After: 0

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거* (SSOT 참조). 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 4 사이트 *모두* 동시 처리

## Test impact

- 동작 무변경 (수치 동등)
- 외부 surface (`task_commitment_expiry_sec` 등 named constants) 의 *값* 동일
- `dune build lib/` PASS

## Related

- PR #19037 — `two_days_seconds_int` (172800, 7 사이트) — int 변종
- PR #19042 — `one_day_seconds_int` (86400, 2 사이트) — int 변종
- PR #19034 — `Mcp_error_code.Invalid_params` (-32602) — 다른 영역 같은 카테고리
- PR #19039 — `NO_TIME_INFO` sentinel const (다른 actor, 같은 anti-pattern category)
- `lib/config/masc_time_constants.ml` — time SSOT
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
