### PR TITLE
fix(dashboard): purge legacy command routes

### DIFF
--- a/dashboard/src/components/common/command-palette.test.ts
+++ b/dashboard/src/components/common/command-palette.test.ts
@@ -167,10 +167,9 @@ describe('CommandPalette', () => {
     const { CommandPalette } = await loadPalette()
     render(html`<${CommandPalette} />`, container)
 
+    type PaletteItem = { id: string; section?: string; keywords?: string; handler: () => void }
     await waitFor(() => {
-      const palette = container.querySelector('ninja-keys') as (HTMLElement & {
-        data?: Array<{ id: string; section?: string; keywords?: string }>
-      }) | null
+      const palette = container.querySelector('ninja-keys') as (HTMLElement & { data?: PaletteItem[] }) | null
       expect(palette?.data?.find((item) => item.id === 'nav-agent-worker-a')?.section)
         .toBe('Agent targets (1)')
       expect(palette?.data?.find((item) => item.id === 'nav-keeper-keeper-a')?.section)
@@ -179,6 +178,21 @@ describe('CommandPalette', () => {
         .toBe('Session targets (1)')
       expect(palette?.data?.find((item) => item.id === 'nav-keeper-keeper-a')?.keywords)
         .toContain('명령 대상 에이전트 1 / 키퍼 2 / 세션 1')
+    })
+
+    const palette = container.querySelector('ninja-keys') as (HTMLElement & { data?: PaletteItem[] }) | null
+
+    palette?.data?.find((item) => item.id === 'nav-agent-worker-a')?.handler()
+    expect(navigate).toHaveBeenCalledWith('monitoring', { section: 'agents', agent: 'worker-a' })
+
+    palette?.data?.find((item) => item.id === 'nav-keeper-keeper-a')?.handler()
+    expect(navigate).toHaveBeenCalledWith('monitoring', { section: 'agents', keeper: 'keeper-a' })
+
+    palette?.data?.find((item) => item.id === 'nav-session-sess-1')?.handler()
+    expect(navigate).toHaveBeenCalledWith('monitoring', {
+      section: 'fleet-health',
+      view: 'event-log',
+      session_id: 'sess-1',
     })
   })
 })

--- a/dashboard/src/components/common/command-palette.ts
+++ b/dashboard/src/components/common/command-palette.ts
@@ -156,7 +156,7 @@ export function CommandPalette() {
       title: `에이전트 상세: ${agent.display_name || agent.agent_name}`,
       section: formatCommandTargetSection('agent', agents.length),
       keywords: `worker detail status command target mission ${commandTargetSummary} ${agent.status || ''}`,
-      handler: () => navigate('overview', { section: 'worker', operation_id: agent.agent_name })
+      handler: () => navigate('monitoring', { section: 'agents', agent: agent.agent_name })
     }))
 
     // Add Keepers dynamically
@@ -165,7 +165,7 @@ export function CommandPalette() {
       title: `키퍼 상세: ${keeper.name}`,
       section: formatCommandTargetSection('keeper', keepers.length),
       keywords: `bot detail status command target mission ${commandTargetSummary} ${keeper.status || ''}`,
-      handler: () => navigate('overview', { section: 'keeper', operation_id: keeper.name })
+      handler: () => navigate('monitoring', { section: 'agents', keeper: keeper.name })
     }))
 
     // Add Sessions dynamically
@@ -174,7 +174,7 @@ export function CommandPalette() {
       title: `세션 확인: ${s.goal || s.session_id}`,
       section: formatCommandTargetSection('session', sessions.length),
       keywords: `task run command target mission ${commandTargetSummary} ${s.status || ''}`,
-      handler: () => navigate('workspace', { section: 'session', session_id: s.session_id })
+      handler: () => navigate('monitoring', { section: 'fleet-health', view: 'event-log', session_id: s.session_id })
     }))
 
     ref.current.data = [...baseActions, ...agentActions, ...keeperActions, ...sessionActions]

--- a/dashboard/src/components/control.test.ts
+++ b/dashboard/src/components/control.test.ts
@@ -73,10 +73,10 @@ describe('Operations control surface', () => {
   })
 
   // Phase 7: Connectors was promoted to its own top-level surface so the
-  // Operations panel no longer routes `view=connectors`. Legacy URLs are
-  // handled by a redirect in operations-panel.ts (covered separately by
-  // operations-panel.test.ts). The chip-under-operations rendering test
-  // was removed here because it pinned dead behavior.
+  // Operations panel no longer routes `view=connectors`. Legacy
+  // `command:connectors` URLs are handled by the router, not by mounting a
+  // null OperationsPanel hop. The chip-under-operations rendering test was
+  // removed here because it pinned dead behavior.
 
   it('renders LabInspector when view is inspector (Phase 6)', async () => {
     route.value.params = { section: 'operations', view: 'inspector' }

--- a/dashboard/src/components/operations-panel.ts
+++ b/dashboard/src/components/operations-panel.ts
@@ -1,9 +1,9 @@
 // MASC Dashboard — Operations Panel (Phase 5+6+7)
 // FilterChips toggle for ops/governance/safety/inspector sub-views.
-// Phase 7: connectors split out as a top-level surface (#command?view=connectors → #connectors).
+// Phase 7: connectors split out as a top-level surface. Legacy
+// command:connectors links are routed before this panel mounts.
 
 import { html } from 'htm/preact'
-import { useEffect } from 'preact/hooks'
 import { FilterChips } from './common/filter-chips'
 import { Ops } from './ops'
 import { Governance } from './governance'
@@ -38,22 +38,7 @@ function updateViewParam(next: OpsView): void {
   )
 }
 
-// Legacy URL migration (Phase 7):
-// #command?section=operations&view=connectors → #connectors?section=connector-status
-function redirectLegacyConnectorsView(): void {
-  replaceRoute('connectors', { section: 'connector-status' })
-}
-
 export function OperationsPanel() {
-  const rawView = route.value.params.view
-  const isLegacyConnectors = rawView === 'connectors'
-
-  useEffect(() => {
-    if (isLegacyConnectors) redirectLegacyConnectorsView()
-  }, [isLegacyConnectors])
-
-  if (isLegacyConnectors) return null
-
   const view = currentView()
 
   return html`

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -442,10 +442,10 @@ describe('consolidation redirects (Phase 1)', () => {
     expect(result.section).toBe('planning')
   })
 
-  it('command:connectors → operations?view=connectors (Phase 6)', () => {
+  it('does not keep command:connectors as an in-surface redirect', () => {
     const result = normalizeRouteParams('command', { section: 'connectors' })
     expect(result.section).toBe('operations')
-    expect(result.view).toBe('connectors')
+    expect(result.view).toBeUndefined()
   })
 
   it('command:inspector → operations?view=inspector (Phase 6)', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -388,7 +388,6 @@ export const SECTION_REDIRECTS: Record<TabSectionKey, SectionRedirect> = {
   // Dashboard consolidation Phase 1+6: command surface
   'command:intervene':    { section: 'operations' },
   'command:governance':   { section: 'operations' },
-  'command:connectors':   { section: 'operations', view: 'connectors' },
   'command:inspector':    { section: 'operations', view: 'inspector' },
 
   // Dashboard consolidation Phase 1: workspace surface
@@ -456,7 +455,6 @@ export function normalizeRouteParams(tabId: TabId, params: Record<string, string
   // `CROSS_SURFACE_SECTION_REDIRECTS` (router.ts) and `SECTION_REDIRECTS`
   // (this file, line 332+) that carry `view` as part of the canonical destination
   // (e.g. `monitoring:git-graph → workspace:repositories?view=graph`,
-  // `command:connectors → command:operations?view=connectors`,
   // cockpit IDE `?mode=Split → code:ide-shell?view=split-diff`).
   // `planning` does not gain `view` via redirect (`workspace:goals → planning`
   // drops view); instead, direct `replaceRoute` callers pass `view: 'default'`

--- a/dashboard/src/router.test.ts
+++ b/dashboard/src/router.test.ts
@@ -70,6 +70,20 @@ describe('navigate', () => {
     expect(route.value.params.goal).toBe('goal-1')
   })
 
+  it('redirects retired command connectors links directly to the connectors surface', () => {
+    navigate('command', { section: 'connectors' })
+    expect(route.value.tab).toBe('connectors')
+    expect(route.value.params.section).toBe('connector-status')
+  })
+
+  it('redirects retired command connectors path links without an operations null hop', () => {
+    window.location.hash = '#command/connectors'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+
+    expect(route.value.tab).toBe('connectors')
+    expect(route.value.params.section).toBe('connector-status')
+  })
+
   it('maps cockpit Cognition design deep links into the production keeper surface', () => {
     window.location.hash = '#repo=viewer&branch=wt%2Fsangsu-smoke&mode=Cognition'
     window.dispatchEvent(new HashChangeEvent('hashchange'))

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -24,6 +24,10 @@ type TabSectionKey = `${TabId}:${string}`
 // Exported for RFC-0048 PR-A redirect-ledger contract test. Pure data —
 // not part of the runtime API.
 export const CROSS_SURFACE_SECTION_REDIRECTS: Record<TabSectionKey, CrossSurfaceRedirect> = {
+  'command:connectors': {
+    tab: 'connectors',
+    section: 'connector-status',
+  },
   'monitoring:git-graph': {
     tab: 'workspace',
     section: 'repositories',
@@ -136,7 +140,9 @@ function parseSegments(
   if (segments[0] === 'command' && segments[1]) {
     const nextParams = { ...params }
     const second = decodeSafe(segments[1])
-    if (!VALID_COMMAND_SECTIONS.has(second)) {
+    if (`command:${second}` in CROSS_SURFACE_SECTION_REDIRECTS) {
+      nextParams.section = second
+    } else if (!VALID_COMMAND_SECTIONS.has(second)) {
       console.warn('[router] unknown command section, falling back to operations', second)
       nextParams.section = 'operations'
     } else {

--- a/docs/CONNECTOR-UI-DESIGN.md
+++ b/docs/CONNECTOR-UI-DESIGN.md
@@ -77,8 +77,8 @@ flickers without conveying anything.
 > operator already knows.
 
 - Phase 7 IA promotion: connectors moved out of `operations`, but the
-  legacy `?section=operations&view=connectors` URL still resolves
-  via a redirect in `operations-panel.ts`.
+  legacy `command:connectors` URL still resolves through the router to
+  `connectors:connector-status`.
 - Overview strip rendered *above* the existing stacked detail panels,
   not *replacing* them.
 - Rail sits *above* the existing toggle buttons (📋 Logs / ⚙ Config /

--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -61,8 +61,8 @@ code_refs:
   - `#monitoring?section=cognition` (hidden deep link; keeper detail cognition path)
 - `command`
   - `#command?section=operations`
-  - sub-view는 `view=ops|governance|safety|inspector|connectors` 로 분기한다.
-  - `view=connectors` 는 `#connectors?section=connector-status` 로 canonical redirect 된다.
+  - sub-view는 `view=ops|governance|surfaces|inspector` 로 분기한다.
+  - legacy `#command?section=connectors` / `#command/connectors` 는 `#connectors?section=connector-status` 로 canonical redirect 된다.
 - `connectors`
   - `#connectors?section=connector-status`
 - `workspace`
@@ -93,10 +93,9 @@ code_refs:
 - `monitoring:cascade-inspector -> monitoring:runtime&view=inspector`
 - `monitoring:cost -> monitoring:runtime&view=cost`
 - `monitoring:git-graph -> workspace:repositories&view=graph`
-- `monitoring:safe-autonomy -> command:operations&view=safety`
 - `command:intervene -> command:operations`
 - `command:governance -> command:operations`
-- `command:connectors -> command:operations&view=connectors`
+- `command:connectors -> connectors:connector-status`
 - `command:inspector -> command:operations&view=inspector`
 - `connectors:connector-discord -> connectors:connector-status&connector=discord`
 - `connectors:connector-imessage -> connectors:connector-status&connector=imessage`
@@ -138,8 +137,6 @@ code_refs:
   - cognition memory sub-view read model
 - `GET /api/v1/attribution/summary`
   - fleet-health attribution view
-- `GET /api/v1/dashboard/safe-autonomy`
-  - operations safety view
 - `GET /api/v1/dashboard/transport-health`
   - runtime transport health + connection freshness view
 - `GET /api/v1/dashboard/keeper-feature-proof`

--- a/docs/spec/10-dashboard.md
+++ b/docs/spec/10-dashboard.md
@@ -515,12 +515,11 @@ const DEFAULT_ROUTE: RouteState = { tab: 'overview', params: {}, postId: null }
    - `activity|live -> observatory` (+ `view=live` when applicable)
    - `telemetry|fleet|tool-quality|governance|attribution -> fleet-health` (+ `view`)
    - `cascade-inspector|cost -> runtime` (+ `view`)
-   - `safe-autonomy -> command.operations&view=safety`
    - `git-graph -> workspace.repositories&view=graph`
    - `intervene|governance|inspector -> operations`
    - `workspace.goals -> workspace.planning`
    - `connectors.connector-* -> connectors.connector-status?connector=*`
-7. `command?section=operations&view=connectors` 는 top-level `connectors` surface로 canonical redirect 된다
+7. `command:connectors` 는 top-level `connectors:connector-status` surface로 canonical redirect 된다
 
 ### 4.4. SSE Integration
 


### PR DESCRIPTION
## Summary
- Route Command Palette agent/keeper/session targets to real dashboard consumers instead of dead overview/workspace sections.
- Move legacy command:connectors handling to the router cross-surface redirect and remove the OperationsPanel null redirect hop.
- Update dashboard IA docs to match the current route contract and remove stale safe-autonomy/connectors claims.

## Verification
- pnpm vitest run --config vitest.config.ts src/components/common/command-palette.test.ts src/router.test.ts src/config/navigation.test.ts src/components/operations-panel.test.ts src/components/control.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm eslint src/components/common/command-palette.ts src/components/common/command-palette.test.ts src/router.ts src/router.test.ts src/config/navigation.ts src/config/navigation.test.ts src/components/operations-panel.ts src/components/operations-panel.test.ts src/components/control.test.ts
- git diff --check