### PR TITLE
refactor(dashboard/cytoscape): align stale --color-status-err fallback with tokens.generated.ts source

### DIFF
--- a/dashboard/src/components/common/cytoscape-fsm.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.ts
@@ -34,7 +34,10 @@ export interface FsmGraphSpec {
 // strings are rejected. Resolve once per render against `:root` and
 // pass literal hex/rgb values into the stylesheet.
 // Fallback values mirror the Cockpit Design System defaults from
-// tokens.generated.css so SSR / missing-CSS degrades gracefully.
+// `styles/tokens.generated.ts` so SSR / missing-CSS degrades gracefully.
+// A parallel `TOKEN_FALLBACKS` table lives in `components/git-graph-view.ts`
+// for the git-graph cytoscape view; keep entries that appear in both
+// tables in sync with the design-system source.
 const TOKEN_FALLBACKS: Record<string, string> = {
   '--color-bg-0': '#0c0b08',
   '--color-bg-1': '#141210',

--- a/dashboard/src/components/git-graph-view.test.ts
+++ b/dashboard/src/components/git-graph-view.test.ts
@@ -16,7 +16,7 @@ function styleBlock(blocks: ReturnType<typeof stylesheet>, selector: string): St
 
 describe("borderForStatus", () => {
   it.each([
-    ["conflict", "#ef4444"],
+    ["conflict", "#c46a5a"],
     ["dirty", "#f59e0b"],
     ["current", "#22c55e"],
     ["unknown", "#3a332c"],

--- a/dashboard/src/components/git-graph-view.ts
+++ b/dashboard/src/components/git-graph-view.ts
@@ -7,6 +7,16 @@ import { getCytoscape, type CyCore } from './common/cytoscape-loader'
 
 // Cytoscape does not resolve CSS variables. Resolve once against :root
 // with fallback to literal hex values.
+//
+// These hex values must track the design-system source in
+// `styles/tokens.generated.ts` (raw tier) — that file is the
+// generated SSOT for hex values and `styles/variables.css` aliases
+// role tokens (`--color-status-err: var(--err)` etc.) on top. Picking
+// values from the role tier here means the dashboard color and the
+// cytoscape fallback drift the moment the role mapping or the raw hex
+// changes. A parallel `TOKEN_FALLBACKS` table lives in
+// `components/common/cytoscape-fsm.ts` for the FSM cytoscape view;
+// keep entries that appear in both tables in sync.
 const TOKEN_FALLBACKS: Record<string, string> = {
   '--color-brass-1': '#d4a14a',
   '--color-bg-3': '#211e1a',
@@ -17,7 +27,7 @@ const TOKEN_FALLBACKS: Record<string, string> = {
   '--color-fg-4': '#4a453e',
   '--color-frost-100': '#e2e8f0',
   '--color-white-pure': '#ffffff',
-  '--color-status-err': '#ef4444',
+  '--color-status-err': '#c46a5a',
   '--color-amber-bright': '#f59e0b',
   '--color-emerald': '#22c55e',
   '--color-cyan': '#22d3ee',


### PR DESCRIPTION
## 요약
`git-graph-view.ts` 의 stale `--color-status-err` fallback (`'#ef4444'` Tailwind red-500) 을 design-system canonical (`'#c46a5a'`, `styles/tokens.generated.ts`) 로 동기화. 두 cytoscape view 의 TOKEN_FALLBACKS 가 서로 + design-system source 와 sync 유지하도록 cross-link 헤더 note 추가.

## 배경

`rg "'#[0-9a-fA-F]{6}'"` sweep + Record dict 분석 결과 동일 design token (`--color-status-err`) 에 *다른 hex* 두 곳에 등장:

| 파일 | hex | 출처 |
|---|---|---|
| `components/git-graph-view.ts:20` | `'#ef4444'` | Tailwind red-500 (stale, 옛 palette) |
| `components/common/cytoscape-fsm.ts` | `'#c46a5a'` | tokens.generated.ts `err` raw token (canonical) |
| `styles/tokens.generated.ts:21` | `'#c46a5a'` | **generated SSOT** — design-system source of truth |
| `styles/variables.css` | — | `--color-status-err: var(--err)` (role-tier alias) |

`#ef4444` 는 ~20° hue 차이 (Tailwind red vs design-system terracotta-red) — *CSS variable 가 resolve 되는 정상 동작* 에서는 안 보이지만, *SSR / cytoscape style parser* (CSS var resolve 안 함) 에서 *git-graph 만 다른 색*. silent drift.

cytoscape style parser 가 `var(--x)` 를 거부하기 때문에 두 cytoscape view (git-graph, FSM) 가 각자 `TOKEN_FALLBACKS` dict 로 hex 직접 plumb. 두 dict 가 *file-specific palette* (graph color vs FSM state color) 가지면서 *공통 role-tier token* 도 가짐 — 공통 entry 가 design-system source 와 sync 되어야.

## 변경

### `components/git-graph-view.ts`
- `--color-status-err`: `'#ef4444'` → `'#c46a5a'` (design-system canonical)
- 헤더 코멘트 보강: tokens.generated.ts source + cytoscape-fsm.ts parallel dict 명시, future entry 갱신 시 *sync 유지* 가이드

### `components/git-graph-view.test.ts`
- `borderForStatus(conflict) → #ef4444` test 갱신 → `#c46a5a` (canonical 따라가도록)

### `components/common/cytoscape-fsm.ts`
- 헤더 코멘트 보강: parallel git-graph-view TOKEN_FALLBACKS 명시, sync 가이드 추가
- hex 값 변경 없음 (이미 canonical)

## 검증

- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)
- 첫 run 시 `borderForStatus(conflict) → #ef4444` test fail 즉시 검출 → test 도 canonical 따라가도록 갱신 → 통과. **silent drift 가 production 변경 시 test 가 explicit fail 로 가이드** — iter#40 의 *test = spec doc* 패턴의 *user-visible color contract* 변형.

## iter chain
- iter#33/34: className SSOT (lib 직접 token 와 raw token mapping)
- iter#40: string sentinel cross-file copy → `NO_TIME_INFO`
- iter#41: hex sentinel cross-file drift → design-system canonical 동기화

같은 *cross-file coupling protocol* class, 다른 도메인 (CSS class / string / hex color).

## /loop iter#41
SSOT 위반 dashboard 축출 loop 의 iter#41. cumulative 41 PR (27 머지 + 2 OPEN — #19039 + #19?_).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
