### PR TITLE
fix(supervisor): use keeper_name in server logs

### DIFF
--- a/lib/supervisor.ml
+++ b/lib/supervisor.ml
@@ -116,10 +116,10 @@ let rec start_child ~sw ~clock cs =
 (** Start all children. Call within an Eio.Switch context. *)
 let start ~sw ~clock t =
   if t.started then
-    Log.Server.warn ~ctx:"supervisor" "[Supervisor] already started"
+    Log.Server.warn ~keeper_name:"supervisor" "[Supervisor] already started"
   else begin
     t.started <- true;
-    Log.Server.info ~ctx:"supervisor" "[Supervisor] starting %d children" (List.length t.children);
+    Log.Server.info ~keeper_name:"supervisor" "[Supervisor] starting %d children" (List.length t.children);
     List.iter (fun cs -> start_child ~sw ~clock cs) t.children
   end
 
@@ -166,7 +166,7 @@ let reenable ~sw ~clock t name =
       cs.disabled <- false;
       cs.restart_count <- 0;
       cs.restart_times <- [];
-      Log.Server.info ~ctx:name "[Supervisor] re-enabling child %s" name;
+      Log.Server.info ~keeper_name:name "[Supervisor] re-enabling child %s" name;
       start_child ~sw ~clock cs;
       true
   | _ -> false


### PR DESCRIPTION
## Summary
- Replace the remaining `Log.Server.* ~ctx` calls in `lib/supervisor.ml` with `~keeper_name`.
- Fix the current OCaml build error at `lib/supervisor.ml:119` after the Log.Server context API change.

## Verification
- `scripts/dune-local.sh build lib/masc_mcp.cma` reproduced the `~ctx` type error before this patch.
- Local rebuild was still running/contending with another active Dune build after patch; CI should provide the clean full signal.