### PR TITLE
refactor(dashboard): drop dead HEATMAP_COLORS export, document file-internal SSOT

### DIFF
--- a/dashboard/src/components/activity-heatmap-draw.ts
+++ b/dashboard/src/components/activity-heatmap-draw.ts
@@ -10,6 +10,13 @@ export const LEFT_MARGIN = 28
 export const TOP_PAD = 20
 export const LEGEND_HEIGHT = 32
 
+// Heatmap intensity scale — 5 buckets [empty, 1-25%, 26-50%, 51-75%, 76-100%].
+// File-internal SSOT: a parallel `HEATMAP_COLORS` export used to live in
+// `config/constants.ts` but had zero importers and drifted on the empty
+// bucket (`--color-bg-3` there vs `--color-bg-panel-alt` here). Removed
+// in the same change that added this note. The colocated test
+// (`activity-heatmap.test.ts`) inlines the same five strings as a
+// user-visible spec assertion; keep these two in sync.
 const COLORS: readonly [string, string, string, string, string] = [
   'var(--color-bg-panel-alt)',
   '#0e4a5c',

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -83,15 +83,6 @@ export const OAS_TELEMETRY_REPLAY_LIMIT = envInt('VITE_OAS_TELEMETRY_REPLAY_LIMI
 export const TRIM_TEXT_DEFAULT = 120
 export const TRUNCATE_DEFAULT = 260
 
-// --- Heatmap color scale (5-level: empty → max intensity) ---
-export const HEATMAP_COLORS = [
-  'var(--color-bg-3)', // 0 events
-  '#0e4a5c', // 1-25%
-  '#0e6e7e', // 26-50%
-  '#14919b', // 51-75%
-  'var(--color-cyan)', // 76-100%
-] as const
-
 // --- TLA+ verification panel poll interval ---
 export const TLA_POLL_INTERVAL_MS = 60_000
 


### PR DESCRIPTION
## 요약
`config/constants.ts` 의 dead `HEATMAP_COLORS` export (0 importer) 삭제 + `activity-heatmap-draw.ts` 의 de-facto SSOT 인 file-internal `COLORS` 에 spec 가이드 JSDoc 추가.

## 배경

`rg "'#14919b'" -n` sweep 결과 production 2 사이트 발견:

| 파일 | const | importer | 비고 |
|---|---|---|---|
| `config/constants.ts:87` | `export const HEATMAP_COLORS` | **0** | 의도된 public SSOT, production migration 안 됨 |
| `components/activity-heatmap-draw.ts:13` | `const COLORS` (file-internal) | `intensityColor`, legend draw, colocated test | de-facto production SSOT |

두 dict 가 *5-entry heatmap intensity scale* 로 같은 의도, 그러나 **empty bucket 색 drift**:

| | `HEATMAP_COLORS` (dead) | `COLORS` (de-facto) | test spec |
|---|---|---|---|
| 0 events | `'var(--color-bg-3)'` | `'var(--color-bg-panel-alt)'` | `'var(--color-bg-panel-alt)'` |

`styles/variables.css` 에서 `--color-bg-panel-alt: var(--bg-2)` 와 `--color-bg-3 = var(--bg-3)` 는 *다른 elevation tier* (alias 아님). production 동작 + test spec 가 *bg-panel-alt* 라서 그게 canonical, constants.ts 의 `bg-3` 가 stale.

iter#35 의 `LibCrashCategory` 패턴 재현 — *의도된 SSOT 가 production migration 안 됨* + *별도 file-internal 이 de-facto SSOT* + *두 정의 사이 silent drift*.

## 변경

### `config/constants.ts`
- `HEATMAP_COLORS` export + 헤더 코멘트 9 lines 삭제 (0 importer)

### `components/activity-heatmap-draw.ts`
- file-internal `COLORS` const 위에 JSDoc 추가:
  - de-facto SSOT 명시
  - `HEATMAP_COLORS` deleted 이력 + drift 사유 (empty bucket color) 명시
  - colocated test 가 user-visible spec 임을 명시 (sync 가이드)

## 검증

- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)
- 첫 run 시 `harness-health.test.ts` 추가 fail 관찰 → 격리 단독 = 4/4 PASS → 재실행 = baseline 1 fail. **flaky pair 패밀리 5회 등장** (iter#34/35/38/40/42), vitest worker scheduling 비결정성 패턴. baseline-diff SOP 로 false-positive 회피.

## /loop iter#42
SSOT 위반 dashboard 축출 loop 의 iter#42. cumulative 42 PR (28 머지 + 2 OPEN — #19049 + #19?_).

iter#32/36/38/39 dead-code 패턴 + iter#35 LibCrashCategory homonym 패턴 + iter#41 hex drift 패턴 의 *교집합* — *intended SSOT vs de-facto SSOT drift* 의 hex 변형.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
