### PR TITLE
fix(keeper): register Anthropic SDK tool aliases (Read/Write/Edit) — RFC-0194 §3

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -517,6 +517,83 @@ let public_descriptors =
       ~sandbox:No_sandbox
       ~runtime_handler:Tool_remote_mcp
       ~translate:translate_identity
+  (* RFC-0194 §3 — Claude API native aliases for the file-system trio.
+     Anthropic-trained LLMs (Sonnet 4.x family with Claude Code tool
+     knowledge) emit [Read] / [Write] / [Edit] tool_use blocks directly,
+     not the MASC-internal public names [ReadFile] / [WriteFile] /
+     [EditFile].  Without these aliases, [Agent_tools.find_and_execute_tool]
+     returns "Tool not found", as observed on keeper:sangsu
+     (on_error: Tool not found: Read, agent_tools.find_and_execute_tool).
+
+     Each alias shares the underlying [internal_name] / [translate] /
+     [input_schema] / [runtime_handler] with its [*File] counterpart —
+     same Filesystem executor, same Sandbox_process backend, same
+     readonly/effect_domain policy — so the runtime dispatch path is
+     identical.  Only the [public_name] (LLM-facing surface) and [id]
+     differ.
+
+     This is RFC-0194 §3 ("Dispatch layer is explicit, not inferred")
+     concrete instantiation: registering [Claude_api_native] tool names
+     as first-class public surface rather than relying on LLM to
+     paraphrase them into MASC-internal aliases.  RFC-0194 §1 (typed
+     SSOT over substring) is satisfied because matching happens against
+     the closed [public_descriptors] list — no substring fallback.
+
+     Not invoked: §2 (alternatives in descriptor), §4 (counter-as-fix /
+     substring boost / N-of-M patch) — none apply, this is an
+     additive extension of a typed registry. *)
+  ; descriptor
+      ~id:"agent.read_file.alias_claude"
+      ~public_name:"Read"
+      ~internal_name:"tool_read_file"
+      ~description:"Read one file from the keeper sandbox or an allowed path."
+      ~input_schema:read_file_schema
+      ~policy:
+        (policy
+           ~readonly:true
+           ~effect_domain:Tool_catalog.Read_only
+           ~cwd_scope:"keeper_sandbox_or_allowed_path"
+           ~retryable:true
+           ())
+      ~executor:Filesystem
+      ~backend:Sandbox_process
+      ~sandbox:Backend_selected
+      ~runtime_handler:Tool_read_file
+      ~translate:translate_read_file
+  ; descriptor
+      ~id:"agent.edit_file.alias_claude"
+      ~public_name:"Edit"
+      ~internal_name:"tool_edit_file"
+      ~description:"Patch an existing file by replacing an exact string."
+      ~input_schema:edit_file_schema
+      ~policy:
+        (policy
+           ~readonly:false
+           ~effect_domain:Tool_catalog.Playground_write
+           ~cwd_scope:"keeper_sandbox_or_allowed_path"
+           ())
+      ~executor:Filesystem
+      ~backend:Sandbox_process
+      ~sandbox:Backend_selected
+      ~runtime_handler:Tool_edit_file
+      ~translate:translate_edit_file
+  ; descriptor
+      ~id:"agent.write_file.alias_claude"
+      ~public_name:"Write"
+      ~internal_name:"tool_write_file"
+      ~description:"Write full file content into the keeper sandbox or an allowed path."
+      ~input_schema:write_file_schema
+      ~policy:
+        (policy
+           ~readonly:false
+           ~effect_domain:Tool_catalog.Playground_write
+           ~cwd_scope:"keeper_sandbox_or_allowed_path"
+           ())
+      ~executor:Filesystem
+      ~backend:Sandbox_process
+      ~sandbox:Backend_selected
+      ~runtime_handler:Tool_write_file
+      ~translate:translate_write_file
   ]
 ;;
 


### PR DESCRIPTION
## Summary

Anthropic-trained LLMs (Sonnet 4.x family with Claude Code tool knowledge) emit `Read` / `Write` / `Edit` `tool_use` blocks directly, not the MASC public names `ReadFile` / `WriteFile` / `EditFile`. Without these aliases, `Agent_sdk.Agent_tools.find_and_execute_tool` returns `"Tool not found"`, as observed on keeper:sangsu:

```
keeper:sangsu on_error: Tool not found: Read
(context: agent_tools.find_and_execute_tool)
```

## Why this is RFC-0194 §3

[RFC-0194 §3 (Dispatch layer is explicit, not inferred)](https://github.com/jeong-sik/masc-mcp/blob/main/docs/rfc/RFC-0194-tool-surface-semantic-ssot.md) names this exact failure mode — *"12 confusion (8 Read-via-Execute, 2 keeper_tasks_list-via-Execute)"* — and prescribes typed registration of `Claude_api_native` tool names as first-class public surface.

This PR is the first concrete instantiation of RFC-0194 §3.

## Implementation

Three additive descriptor entries appended to `public_descriptors`:

| public_name | internal_name | translate |
|---|---|---|
| `Read` | `tool_read_file` | `translate_read_file` (file_path→path, limit→max_bytes) |
| `Edit` | `tool_edit_file` | `translate_edit_file` (mode patch) |
| `Write` | `tool_write_file` | `translate_write_file` (overwrite mode) |

Each alias shares **everything** with its `*File` counterpart — same `Filesystem` executor, same `Sandbox_process` backend, same readonly/effect_domain policy, same input_schema, same runtime_handler. Only `public_name` and `id` differ. The `translate_*` functions already accept Anthropic SDK field names; the schema layer was already Anthropic-compatible, only the surface name was missing.

## Coverage scope

- **Included**: Read, Write, Edit (file-system trio).
- **Deferred**: `Bash` alias for `Execute` — Anthropic Bash uses a single `command` string, MASC Execute requires typed `executable`/`argv`/`pipeline`; translate semantics need separate design.
- **Not aliases**: `Glob`/`Grep` — not direct aliases of `SearchFiles` (Glob = name pattern, Grep = content search; SearchFiles bundles ripgrep + reads + listings + git views). Follow-up PRs once translate semantics are decided.

## RFC-0194 principle invocation

| Principle | Status |
|---|---|
| §1 typed SSOT over substring | **satisfied** — matching against closed `public_descriptors` list, no substring fallback |
| §3 dispatch layer explicit | **direct instantiation** |
| §2 alternatives via descriptor | not invoked (no alternative emission added) |
| §4 anti-pattern negation | not triggered (additive typed extension, not symptom suppression) |
| §5 exhaustive coverage | satisfied (list machinery already typed) |

## Test plan

- [x] `dune build` PASS on Agent_tool_descriptor module
- [ ] After server restart, keeper:sangsu's `Read` tool_use → resolves to `tool_read_file` handler, no more "Tool not found"
- [ ] Existing `ReadFile`/`WriteFile`/`EditFile` callers unchanged (same descriptors retained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)