### PR TITLE
refactor(cascade): Masc_time_constants.hour replaces 3600.0 literal at 4 cascade sites

### DIFF
--- a/lib/cascade/cascade_health_tracker_config.ml
+++ b/lib/cascade/cascade_health_tracker_config.ml
@@ -112,7 +112,7 @@ let cooldown_config_for ~provider_key =
 let hard_quota_cooldown_sec =
   read_float_setting
     ~primary:"MASC_CASCADE_HARD_QUOTA_COOLDOWN_SEC"
-    ~default:3600.0
+    ~default:Masc_time_constants.hour
     ()
 
 (** Cooldown duration for provider calls classified as terminal structural
@@ -121,7 +121,7 @@ let hard_quota_cooldown_sec =
 let terminal_failure_cooldown_sec =
   read_float_setting
     ~primary:"MASC_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC"
-    ~default:3600.0
+    ~default:Masc_time_constants.hour
     ()
 
 (** Default cooldown applied immediately on a transient HTTP 429. *)

--- a/lib/cascade/cascade_oas_runner.ml
+++ b/lib/cascade/cascade_oas_runner.ml
@@ -175,7 +175,7 @@ let filter_rejection_reason_label = function
 
 let codex_keeper_bound_skip_seen : (string, float) Hashtbl.t = Hashtbl.create 16
 let codex_keeper_bound_skip_seen_mutex = Mutex.create ()
-let codex_keeper_bound_skip_restate_sec = 3600.0
+let codex_keeper_bound_skip_restate_sec = Masc_time_constants.hour
 
 let codex_keeper_bound_skip_should_emit ~label ~provider_label ~keeper_name ~reason_label =
   let key = Printf.sprintf "%s|%s|%s|%s" label provider_label keeper_name reason_label in
@@ -305,7 +305,7 @@ let classify_filter_rejection
    cache. *)
 let cascade_empty_warn_seen : (string, float) Hashtbl.t = Hashtbl.create 16
 let cascade_empty_warn_seen_mutex = Mutex.create ()
-let cascade_empty_warn_restate_sec = 3600.0
+let cascade_empty_warn_restate_sec = Masc_time_constants.hour
 
 let signature_of_rejected_providers rejected =
   rejected


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" 안티패턴 *추가* 제거 — Magic Number Time-literal 시리즈 (#19037 / #19042 / #19046) 의 *cascade 모듈* 후속. `lib/cascade/` 의 **4 사이트** (2 파일) 가 bare `3600.0` 리터럴.

### Pattern

`Masc_time_constants.hour = 3600.0` 가 *이미* SSOT. cascade 모듈만 *legacy literal* — pattern 적용 누락.

before (`cascade_health_tracker_config.ml`):
```ocaml
let hard_quota_cooldown_sec =
  read_float_setting
    ~primary:"MASC_CASCADE_HARD_QUOTA_COOLDOWN_SEC"
    ~default:3600.0
    ()

let terminal_failure_cooldown_sec =
  read_float_setting
    ~primary:"MASC_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC"
    ~default:3600.0
    ()
```

before (`cascade_oas_runner.ml`):
```ocaml
let codex_keeper_bound_skip_restate_sec = 3600.0
(* ... *)
let cascade_empty_warn_restate_sec = 3600.0
```

after (양쪽 모두):
```ocaml
~default:Masc_time_constants.hour
(* and *)
let codex_keeper_bound_skip_restate_sec = Masc_time_constants.hour
let cascade_empty_warn_restate_sec = Masc_time_constants.hour
```

4 사이트:
- `cascade_health_tracker_config.ml:115` — `hard_quota_cooldown_sec` env default
- `cascade_health_tracker_config.ml:124` — `terminal_failure_cooldown_sec` env default
- `cascade_oas_runner.ml:178` — `codex_keeper_bound_skip_restate_sec` named const
- `cascade_oas_runner.ml:308` — `cascade_empty_warn_restate_sec` named const

## 변경

- `lib/cascade/cascade_health_tracker_config.ml`: 1 file, +2/-2
- `lib/cascade/cascade_oas_runner.ml`: 1 file, +2/-2
- 동작 무변경 (`Masc_time_constants.hour = 3600.0`)

## Magic-number lint impact

`lib/cascade/` 안 `3600.0` 리터럴 hotspots:
- Before: 4 hits
- After: 0

## Out-of-scope finding

`lib/core/safe_ops.ml:67` 도 `utf8_repair_log_idle_eviction_sec = 3600.0` 으로 같은 안티패턴. 그러나 `masc_core` 라이브러리는 `masc_config` 에 의존하지 *않음* (`lib/core/dune`: libraries 목록에 masc_config 없음) → `Masc_time_constants` accessible 안 됨.

해결 옵션 (별도 결정):
- A) `masc_time_constants.ml` 을 `lib/core/` 로 이전 (가장 정확 — 시간 상수는 core domain)
- B) `masc_core` 에 `masc_config` 의존 추가 (cycle 위험: 다른 모듈이 반대 방향일 가능성)
- C) `safe_ops.ml` 안에 local `let hour = 3600.0` 추가 (workaround, SSOT 분기)

본 PR 범위 외. **Library boundary 가 SSOT 확산 길을 막는 사례** — separate decision 필요.

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거* (SSOT 참조). 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — cascade 사이트 *모두* 동시 처리 (safe_ops.ml 1 사이트는 *library boundary* 때문에 별도 결정 필요, N-of-M 자임 아님)

## Test impact

- 동작 무변경 (수치 동등)
- env knob (`MASC_CASCADE_HARD_QUOTA_COOLDOWN_SEC`, `MASC_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC`) *사용자 surface 0 변경*
- `dune build lib/cascade lib/keeper lib/coord` PASS
- `lib/supervisor.ml` main HEAD 의 pre-existing build error (다른 actor 작업) 는 본 PR 무관

## Related

- PR #19037 — `two_days_seconds_int` (172800 int, 7 사이트)
- PR #19042 — `one_day_seconds_int` (86400 int, 2 사이트)
- PR #19046 — `Masc_time_constants.hour/day` (3600.0/86400.0 float, 4 keeper-accountability 사이트)
- PR #19039 — `NO_TIME_INFO` sentinel const (다른 actor, 같은 anti-pattern category)
- `lib/config/masc_time_constants.ml` — time SSOT
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
