### PR TITLE
perf(dashboard/tasks/history): cache+offload (last deferred endpoint)

### DIFF
--- a/lib/server/server_routes_http_dashboard_handlers.ml
+++ b/lib/server/server_routes_http_dashboard_handlers.ml
@@ -75,8 +75,15 @@ let handle_dashboard_task_history state req reqd =
       Server_utils.int_query_param req "limit" ~default:50
       |> Server_utils.clamp ~min_v:1 ~max_v:200
     in
+    let cache_key =
+      Printf.sprintf "task_history:%s:%s:%d"
+        state.Mcp_server.room_config.base_path task_id limit
+    in
     let json =
-      Tool_task.task_history_events_json state.Mcp_server.room_config ~task_id ~limit
+      Dashboard_cache.get_or_compute cache_key ~ttl:5.0 (fun () ->
+        Domain_pool_ref.submit_io_or_inline (fun () ->
+          Tool_task.task_history_events_json state.Mcp_server.room_config
+            ~task_id ~limit))
     in
     Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
 


### PR DESCRIPTION
## Summary

Closes the last deferred item from the dashboard bulk wrap series (#19038 / #19043 / #19045). `handle_dashboard_task_history` lives in the helpers module (`server_routes_http_dashboard_handlers.ml`), not the router, so the wrap belongs at the helper site.

## Implementation

```ocaml
let cache_key =
  Printf.sprintf "task_history:%s:%s:%d"
    state.Mcp_server.room_config.base_path task_id limit
in
Dashboard_cache.get_or_compute cache_key ~ttl:5.0 (fun () ->
  Domain_pool_ref.submit_io_or_inline (fun () ->
    Tool_task.task_history_events_json state.Mcp_server.room_config
      ~task_id ~limit))
```

`Tool_task.task_history_events_json` scans the per-task event store; under cache miss this ran inline on the Eio main domain, blocking concurrent dashboard fibers. Cache key includes `task_id` and `limit` so concurrent variants do not collide.

## Test plan

- [x] `dune build` PASS
- [ ] After server restart, `cache_stats` shows `task_history:*` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)