### PR TITLE
refactor(tool-board-format): Masc_time_constants.hour completes partial migration at 4 sites

### DIFF
--- a/lib/tool_board_format.ml
+++ b/lib/tool_board_format.ml
@@ -56,10 +56,10 @@ let format_timestamp_relative ts =
   let diff = now -. ts in
   if Stdlib.Float.compare diff 60.0 < 0
   then "just now"
-  else if Stdlib.Float.compare diff 3600.0 < 0
+  else if Stdlib.Float.compare diff Masc_time_constants.hour < 0
   then Printf.sprintf "%dm ago" (Stdlib.Int.of_float (diff /. 60.0))
   else if Stdlib.Float.compare diff Masc_time_constants.day < 0
-  then Printf.sprintf "%dh ago" (Stdlib.Int.of_float (diff /. 3600.0))
+  then Printf.sprintf "%dh ago" (Stdlib.Int.of_float (diff /. Masc_time_constants.hour))
   else Printf.sprintf "%dd ago" (Stdlib.Int.of_float (diff /. Masc_time_constants.day))
 ;;
 
@@ -71,10 +71,10 @@ let format_ttl_remaining expires_at =
     let remaining = expires_at -. now in
     if Stdlib.Float.compare remaining 0.0 <= 0
     then "expired"
-    else if Stdlib.Float.compare remaining 3600.0 < 0
+    else if Stdlib.Float.compare remaining Masc_time_constants.hour < 0
     then Printf.sprintf "%dm left" (Stdlib.Int.of_float (remaining /. 60.0))
     else if Stdlib.Float.compare remaining Masc_time_constants.day < 0
-    then Printf.sprintf "%dh left" (Stdlib.Int.of_float (remaining /. 3600.0))
+    then Printf.sprintf "%dh left" (Stdlib.Int.of_float (remaining /. Masc_time_constants.hour))
     else
       Printf.sprintf
         "%dd left"


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" + RFC-0088 §"N-of-M 패치" *제거 측면* — `lib/tool_board_format.ml` 가 **half-migrated** 상태. `Masc_time_constants.day` 4 사이트 이미 사용 중, 인접 `3600.0` (hour) 4 사이트 가 *bare literal 로 남아 있음*. 같은 if/else 사다리 안에서 SSOT 두 스타일 혼재.

### Anti-pattern asymmetry

RFC-0088 §"N-of-M 패치" 시그니처 는 *N-of-M 자임* 후 incremental site fix 가 들어올 때 reject. 본 PR 은 *역방향* — *finishing* a partial migration (4 sites that *should* have been migrated when day was migrated, but weren't). Result: pattern *완전 통일*.

before:
```ocaml
let format_timestamp_relative ts =
  let now = Time_compat.now () in
  let diff = now -. ts in
  if Stdlib.Float.compare diff 60.0 < 0
  then "just now"
  else if Stdlib.Float.compare diff 3600.0 < 0          (* ← raw literal *)
  then Printf.sprintf "%dm ago" (Stdlib.Int.of_float (diff /. 60.0))
  else if Stdlib.Float.compare diff Masc_time_constants.day < 0  (* ← SSOT *)
  then Printf.sprintf "%dh ago" (Stdlib.Int.of_float (diff /. 3600.0))  (* ← raw literal *)
  else Printf.sprintf "%dd ago" (Stdlib.Int.of_float (diff /. Masc_time_constants.day))  (* ← SSOT *)
;;
```

after:
```ocaml
let format_timestamp_relative ts =
  let now = Time_compat.now () in
  let diff = now -. ts in
  if Stdlib.Float.compare diff 60.0 < 0
  then "just now"
  else if Stdlib.Float.compare diff Masc_time_constants.hour < 0
  then Printf.sprintf "%dm ago" (Stdlib.Int.of_float (diff /. 60.0))
  else if Stdlib.Float.compare diff Masc_time_constants.day < 0
  then Printf.sprintf "%dh ago" (Stdlib.Int.of_float (diff /. Masc_time_constants.hour))
  else Printf.sprintf "%dd ago" (Stdlib.Int.of_float (diff /. Masc_time_constants.day))
;;
```

같은 패턴이 `format_ttl_remaining` 에도 적용 — 두 함수 모두 60 / hour / day 사다리가 *uniform SSOT* 로 통일.

4 사이트:
- Line 59 — `format_timestamp_relative`: `compare diff 3600.0 < 0`
- Line 62 — `format_timestamp_relative`: `diff /. 3600.0`
- Line 74 — `format_ttl_remaining`: `compare remaining 3600.0 < 0`
- Line 77 — `format_ttl_remaining`: `remaining /. 3600.0`

## 변경

- `lib/tool_board_format.ml`: 1 file, +4/-4
- 동작 무변경 (`Masc_time_constants.hour = 3600.0`)

## Magic-number lint impact

`lib/tool_board_format.ml` 안 `3600.0` 리터럴: 4 → 0.

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 N-of-M 안티패턴 *제거* (partial migration finishing). 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 자임 — *기존* half-migration 의 *남은 절반* 을 마무리. 새 PR 이 추가 사이트 패치를 deferred 하지 않음. 4 사이트 *모두* 동시 처리

## Test impact

- 동작 무변경 (수치 동등)
- 사용자 surface (relative time formatting `"%dm ago"` / `"%dh ago"` / `"%dd ago"`) *완전 동등*
- `dune build lib/` PASS

## Related

- PR #19037 — `two_days_seconds_int` (172800 int, 7 사이트)
- PR #19042 — `one_day_seconds_int` (86400 int, 2 사이트)
- PR #19046 — `Masc_time_constants.hour/day` (3600.0/86400.0 float, 4 keeper-accountability)
- PR #19058 — `Masc_time_constants.hour` (3600.0 float, 4 cascade)
- `lib/config/masc_time_constants.ml` — time SSOT
- sw-dev §"Magic Number 금지", RFC-0088 §"N-of-M 패치" (removal direction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
