### PR TITLE
refactor(cascade/board/timeline): Masc_time_constants.hour replaces 3600.0 literal at 4 sites across 3 files

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -321,8 +321,8 @@ let sort_posts_in_memory ~sort_by (posts : Board.post list) =
   | Trending ->
       let now = Time_compat.now () in
       List.sort (fun (a : Board.post) (b : Board.post) ->
-        let age_a = Stdlib.Float.max 1.0 ((now -. a.created_at) /. 3600.0) in
-        let age_b = Stdlib.Float.max 1.0 ((now -. b.created_at) /. 3600.0) in
+        let age_a = Stdlib.Float.max 1.0 ((now -. a.created_at) /. Masc_time_constants.hour) in
+        let age_b = Stdlib.Float.max 1.0 ((now -. b.created_at) /. Masc_time_constants.hour) in
         let score_a =
           Stdlib.Float.of_int (a.votes_up - a.votes_down + (a.reply_count * 2))
           /. (Stdlib.( **) age_a 0.5)

--- a/lib/cascade/cascade_attempt_liveness_config.ml
+++ b/lib/cascade/cascade_attempt_liveness_config.ml
@@ -200,7 +200,7 @@ let budget_of_samples samples =
     let observed_wall =
       tuned_seconds
         ~floor:180.0
-        ~ceiling:3600.0
+        ~ceiling:Masc_time_constants.hour
         ~multiplier:1.4
         ~add:30.0
         (seconds_of_ms wall_ms)

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -439,7 +439,7 @@ let turn_completed_events (config : Coord.config) ~agent_name ~limit :
 let build_timeline (config : Coord.config) ~agent_name ~since_hours ~limit
     ~include_tasks ~include_board:_ ~include_tool_calls =
   let now = Time_compat.now () in
-  let cutoff = now -. (since_hours *. 3600.0) in
+  let cutoff = now -. (since_hours *. Masc_time_constants.hour) in
   (* Collect events from the default namespace. *)
   let all_events =
     let agent_evts = agent_events config ~agent_name in


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" 안티패턴 *추가* 제거 — Magic Number Time-literal 시리즈 (#19037 / #19042 / #19046 / #19058 / #19061) 의 *3 파일 cluster* 후속. **4 사이트** (1+2+1) 가 bare `3600.0` 리터럴로 1-hour 시간 단위 표현.

### Pattern

`Masc_time_constants.hour = 3600.0` 가 *이미* SSOT. 세 파일 모두 `masc_mcp` root library 아래라 `masc_mcp.config` 의존 통해 accessible (이미 검증된 경로).

before:
```ocaml
(* cascade_attempt_liveness_config.ml:203 *)
let observed_wall =
  tuned_seconds
    ~floor:180.0
    ~ceiling:3600.0
    ~multiplier:1.4
    ~add:30.0
    (seconds_of_ms wall_ms)

(* board_dispatch.ml:324-325 *)
let age_a = Stdlib.Float.max 1.0 ((now -. a.created_at) /. 3600.0) in
let age_b = Stdlib.Float.max 1.0 ((now -. b.created_at) /. 3600.0) in

(* tool_agent_timeline.ml:442 *)
let cutoff = now -. (since_hours *. 3600.0) in
```

after (모두 `Masc_time_constants.hour` 로):
```ocaml
~ceiling:Masc_time_constants.hour
let age_a = Stdlib.Float.max 1.0 ((now -. a.created_at) /. Masc_time_constants.hour) in
let age_b = Stdlib.Float.max 1.0 ((now -. b.created_at) /. Masc_time_constants.hour) in
let cutoff = now -. (since_hours *. Masc_time_constants.hour) in
```

4 사이트:
- `lib/cascade/cascade_attempt_liveness_config.ml:203` — `observed_wall` ceiling
- `lib/board_dispatch.ml:324` — trending-sort `age_a` 분모
- `lib/board_dispatch.ml:325` — trending-sort `age_b` 분모
- `lib/tool_agent_timeline.ml:442` — event-window `cutoff` 계산

## 변경

- `lib/cascade/cascade_attempt_liveness_config.ml`: 1 file, +1/-1
- `lib/board_dispatch.ml`: 1 file, +2/-2
- `lib/tool_agent_timeline.ml`: 1 file, +1/-1
- 총 +4/-4, 동작 무변경

## Magic-number lint impact

3 파일 안 `3600.0` 리터럴 hotspots:
- Before: 4 hits
- After: 0

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거* (SSOT 참조). 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 3 파일 4 사이트 *모두* 동시 처리

## Test impact

- 동작 무변경 (수치 동등)
- 사용자 surface (trending-sort 결과 순서, attempt liveness ceiling, timeline cutoff) *완전 동등*
- `dune build lib/` PASS

## Related

- PR #19037 — `two_days_seconds_int` (172800 int, 7 사이트)
- PR #19042 — `one_day_seconds_int` (86400 int, 2 사이트)
- PR #19046 — `Masc_time_constants.hour/day` (3600.0/86400.0, 4 keeper-accountability)
- PR #19058 — `Masc_time_constants.hour` (3600.0, 4 cascade)
- PR #19061 — half-migration finishing in `tool_board_format.ml` (4 sites)
- `lib/config/masc_time_constants.ml` — time SSOT
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
