### PR TITLE
fix(dashboard): use summary trust for compact keeper rows

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -49,7 +49,7 @@ let compact_keeper_trust_json ~(config : Coord.config) ~(meta : Keeper_types.kee
   let runtime_trust =
     if Keeper_fd_pressure.active ()
     then Keeper_fd_pressure.degraded_trust_json ()
-    else Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
+    else Keeper_runtime_trust_snapshot.summary_json ~config ~meta
   in
   let member key = Yojson.Safe.Util.member key runtime_trust in
   `Assoc

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -565,8 +565,9 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                   ]
               in
               let runtime_trust =
-                Keeper_runtime_trust_snapshot.snapshot_json
-                  ~config ~meta:m
+                if compact
+                then Keeper_runtime_trust_snapshot.summary_json ~config ~meta:m
+                else Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta:m
               in
               let attention_fields =
                 attention_fields_with_runtime_trust attention_fields runtime_trust

--- a/lib/dashboard/dashboard_http_keeper_trust.ml
+++ b/lib/dashboard/dashboard_http_keeper_trust.ml
@@ -3,7 +3,11 @@ open Dashboard_http_keeper_types
 let keeper_trust_json ?(include_receipt = false)
     (config : Coord.config) (meta : Keeper_types.keeper_meta) =
   let latest_receipt = Keeper_execution_receipt.latest_json config meta.name in
-  let runtime_trust = Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta in
+  let runtime_trust =
+    if include_receipt
+    then Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
+    else Keeper_runtime_trust_snapshot.summary_json ~config ~meta
+  in
   let sandbox_json =
     match latest_receipt with
     | Some receipt -> Yojson.Safe.Util.member "sandbox" receipt

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -671,6 +671,10 @@ let summary_json ~(config : Coord.config) ~(meta : keeper_meta) =
   let execution_summary =
     execution_summary_json ~meta ~latest_receipt
   in
+  let approval_state =
+    approval_state_json ~pending_approval_count ~pending_approvals:`Null
+      ~latest_tool_call ~latest_approval_audit ~latest_receipt
+  in
   let latest_causal_event =
     latest_causal_event_summary ~meta ~latest_decision ~latest_receipt
       ~latest_tool_call ~latest_approval_audit
@@ -685,6 +689,7 @@ let summary_json ~(config : Coord.config) ~(meta : keeper_meta) =
       ("needs_attention", `Bool needs_attention);
       ("attention_reason", Json_util.string_opt_to_json attention_reason);
       ("next_human_action", Json_util.string_opt_to_json next_human_action);
+      ("approval", approval_state);
       ("execution", execution_summary);
       ("latest_terminal_reason", latest_terminal_reason_json);
       ("latest_next_action", Json_util.string_opt_to_json latest_next_action);

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -2314,6 +2314,41 @@ let test_http_cancel_response_contracts () =
          ; {|Some trust -> trust|}
          ]
        ~max_lines:50);
+  check bool "dashboard compact keeper rows use summary runtime trust" true
+    (file_contains_nearby_line_with_patterns
+       "lib/dashboard/dashboard_http_keeper.ml"
+       ~anchor:{|let runtime_trust =|}
+       ~patterns:
+         [ {|if compact|}
+         ; {|Keeper_runtime_trust_snapshot.summary_json ~config ~meta:m|}
+         ; {|else Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta:m|}
+         ]
+       ~max_lines:8);
+  check bool "dashboard compact trust panel uses summary runtime trust" true
+    (file_contains_nearby_line_with_patterns
+       "lib/dashboard/dashboard_http_keeper_trust.ml"
+       ~anchor:{|let runtime_trust =|}
+       ~patterns:
+         [ {|if include_receipt|}
+         ; {|then Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta|}
+         ; {|else Keeper_runtime_trust_snapshot.summary_json ~config ~meta|}
+         ]
+       ~max_lines:8);
+  check bool "dashboard execution compact trust uses summary runtime trust" true
+    (file_contains_nearby_line_with_patterns
+       "lib/dashboard/dashboard_execution.ml"
+       ~anchor:{|let runtime_trust =|}
+       ~patterns:[ {|Keeper_runtime_trust_snapshot.summary_json ~config ~meta|} ]
+       ~max_lines:8);
+  check bool "runtime trust summary preserves approval field" true
+    (file_contains_nearby_line_with_patterns
+       "lib/keeper/keeper_runtime_trust_snapshot.ml"
+       ~anchor:{|let approval_state =|}
+       ~patterns:
+         [ {|approval_state_json ~pending_approval_count ~pending_approvals:`Null|}
+         ; {|("approval", approval_state)|}
+         ]
+       ~max_lines:30);
   check bool "main_eio suppresses stale httpun response writes" true
     (file_contains_pattern "bin/main_eio.ml" {|let safe_reqd_respond|}
     && file_contains_pattern "bin/main_eio.ml"


### PR DESCRIPTION
Summary
- Use Keeper_runtime_trust_snapshot.summary_json for compact dashboard keeper rows and compact execution trust projections.
- Keep full snapshot_json for non-compact/detail rows that need the expensive timeline surface.
- Preserve approval state on summary_json and add source contracts against regressing compact rows back to full snapshot_json.

Validation
- ocamlformat --check lib/keeper/keeper_runtime_trust_snapshot.ml lib/dashboard/dashboard_http_keeper_trust.ml lib/dashboard/dashboard_execution.ml lib/dashboard/dashboard_http_keeper.ml test/test_ci_hardening_source.ml
- git diff --check
- scripts/dune-local.sh build test/test_ci_hardening_source.exe was attempted after rebase but stopped locally behind the shared Dune/opam lock queue; CI is the active build verification.