### PR TITLE
fix(keeper): wake paused keeper on board mention

### DIFF
--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -258,14 +258,65 @@ let board_signal_stimulus ~(reason : string) (signal : Board_dispatch.keeper_boa
   }
 ;;
 
+let board_signal_entry_is_wakeup_candidate (entry : Keeper_registry.registry_entry) =
+  match entry.phase with
+  | Keeper_state_machine.Running | Keeper_state_machine.Paused -> true
+  | _ -> false
+;;
+
+let board_signal_wake_paused_keeper
+      ~(config : Coord.config)
+      ~(stimulus : Keeper_event_queue.stimulus)
+      (meta : keeper_meta)
+  =
+  let resumed_meta = { meta with paused = false; updated_at = now_iso () } in
+  match
+    write_meta_with_merge
+      ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+      config
+      resumed_meta
+  with
+  | Ok () ->
+    Keeper_registry.update_meta ~base_path:config.base_path meta.name resumed_meta;
+    Keeper_registry.dispatch_event_unit
+      ~base_path:config.base_path
+      resumed_meta.name
+      Keeper_state_machine.Operator_resume;
+    Keeper_registry_event_queue.enqueue
+      ~base_path:config.base_path
+      resumed_meta.name
+      stimulus;
+    Keeper_registry.wakeup ~base_path:config.base_path resumed_meta.name;
+    Ok ()
+  | Error err ->
+    Prometheus.inc_counter
+      Keeper_metrics.(to_string WriteMetaFailures)
+      ~labels:[ ("keeper", meta.name); ("phase", "board_signal_resume_sync") ]
+      ();
+    Error (Printf.sprintf "failed to write resumed meta: %s" err)
+;;
+
+let board_signal_wake_keeper
+      ~(config : Coord.config)
+      ~(reason : string)
+      ~(signal : Board_dispatch.keeper_board_signal)
+      (meta : keeper_meta)
+  =
+  let stimulus = board_signal_stimulus ~reason signal in
+  if meta.paused
+  then board_signal_wake_paused_keeper ~config ~stimulus meta
+  else (
+    wakeup_keeper ~base_path:config.base_path ~stimulus meta.name;
+    Ok ())
+;;
+
 let wakeup_relevant_keeper_for_board_signal
       ~(config : Coord.config)
       (signal : Board_dispatch.keeper_board_signal)
   =
-  let running_names =
+  let registry_entries =
     Keeper_registry.all ~base_path:config.base_path ()
-    |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
-      if e.phase = Keeper_state_machine.Running then Some e.name else None)
+    |> List.filter board_signal_entry_is_wakeup_candidate
   in
   let signal_kind_label =
     match signal.kind with
@@ -276,10 +327,10 @@ let wakeup_relevant_keeper_for_board_signal
      when many keepers share a domain.  Yield every ~1000 iterations. *)
   let board_ym = Eio_guard.create_yield_meter () in
   let candidates =
-    running_names
-    |> List.filter_map (fun name ->
+    registry_entries
+    |> List.filter_map (fun (entry : Keeper_registry.registry_entry) ->
       let result =
-        match read_meta config name with
+        match read_meta config entry.name with
         | Ok (Some meta) ->
           let wake_reason =
             Keeper_world_observation.board_signal_wake_reason
@@ -295,8 +346,8 @@ let wakeup_relevant_keeper_for_board_signal
              had no addressee and one that was silently dropped by a
              keeper whose [room_signal_prompt_enabled] / mention_targets
              configuration is too narrow. *)
-          (match wake_reason with
-           | None ->
+          (match wake_reason, entry.phase with
+           | None, Keeper_state_machine.Running ->
              Prometheus.inc_counter
                Keeper_metrics.(to_string BoardSignalNoWakeTotal)
                ~labels:[
@@ -304,8 +355,13 @@ let wakeup_relevant_keeper_for_board_signal
                  ("kind", signal_kind_label);
                ]
                ()
-           | Some _ -> ());
-          Some (meta, wake_reason)
+           | None, _ | Some _, _ -> ());
+          (match entry.phase, wake_reason with
+           | Keeper_state_machine.Paused, Some "explicit_mention" ->
+             Some (meta, wake_reason)
+           | Keeper_state_machine.Paused, _ -> None
+           | Keeper_state_machine.Running, _ -> Some (meta, wake_reason)
+           | _ -> None)
         | _ -> None
       in
       Eio_guard.yield_step board_ym;
@@ -318,15 +374,21 @@ let wakeup_relevant_keeper_for_board_signal
         ~keeper_name:meta.name
         ~post_id:signal.post_id
     then (
-      wakeup_keeper
-        ~base_path:config.base_path
-        ~stimulus:(board_signal_stimulus ~reason signal)
-        meta.name;
-      Log.Keeper.info
-        "board signal wakeup: keeper=%s reason=%s post=%s"
-        meta.name
-        reason
-        signal.post_id)
+      match board_signal_wake_keeper ~config ~reason ~signal meta with
+      | Ok () ->
+        Log.Keeper.info
+          "board signal wakeup: keeper=%s reason=%s post=%s paused_auto_resume=%b"
+          meta.name
+          reason
+          signal.post_id
+          meta.paused
+      | Error err ->
+        Log.Keeper.warn
+          "board signal wakeup failed: keeper=%s reason=%s post=%s error=%s"
+          meta.name
+          reason
+          signal.post_id
+          err)
   in
   let selected, dropped = select_board_wakeup_candidates candidates in
   let yield_meter = Eio_guard.create_yield_meter ~interval:1 () in

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1892,6 +1892,62 @@ let test_board_signal_wakeup_only_wakes_opted_in_scope_keeper () =
           (Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:base_dir "defaulted"
            |> Keeper_event_queue.length)))
 
+let test_board_signal_explicit_mention_resumes_paused_keeper () =
+  R.clear ();
+  let base_dir = temp_base_path "board-wakeup-paused-explicit" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Board.reset_global_for_test ();
+      Masc_mcp.Board_dispatch.reset_for_test ();
+      rm_rf base_dir)
+    (fun () ->
+      with_env "MASC_BASE_PATH" base_dir (fun () ->
+        Masc_mcp.Board.reset_global_for_test ();
+        Masc_mcp.Board_dispatch.reset_for_test ();
+        Masc_mcp.Board_dispatch.init_jsonl ();
+        let config = make_test_config base_dir in
+        let paused = { (make_meta "sleepy") with paused = true } in
+        (match Keeper_types.write_meta ~force:true config paused with
+         | Ok () -> ()
+         | Error err -> fail ("write_meta failed: " ^ err));
+        let entry = R.register ~base_path:base_dir "sleepy" paused in
+        ignore (R.dispatch_event ~base_path:base_dir "sleepy" KSM.Operator_pause);
+        let post =
+          match
+            Masc_mcp.Board_dispatch.create_post ~author:"alice"
+              ~title:"Owner call"
+              ~content:"Can @sleepy take this P1?"
+              ~post_kind:Masc_mcp.Board.Human_post ()
+          with
+          | Ok post -> post
+          | Error err -> fail (Masc_mcp.Board.show_board_error err)
+        in
+        let signal : Masc_mcp.Board_dispatch.keeper_board_signal =
+          {
+            kind = Masc_mcp.Board_dispatch.Board_post_created;
+            post_id = Masc_mcp.Board.Post_id.to_string post.id;
+            author = "alice";
+            title = post.title;
+            content = post.content;
+            hearth = post.hearth;
+            updated_at = Some post.updated_at;
+          }
+        in
+        KK.wakeup_relevant_keeper_for_board_signal ~config signal;
+        check bool "paused keeper woken" true (Atomic.get entry.fiber_wakeup);
+        check int "paused keeper queued board stimulus" 1
+          (Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:base_dir "sleepy"
+           |> Keeper_event_queue.length);
+        (match Keeper_types.read_meta config "sleepy" with
+         | Ok (Some persisted) ->
+           check bool "paused meta resumed" false persisted.paused
+         | Ok None -> fail "expected persisted meta"
+         | Error err -> fail ("read_meta failed: " ^ err));
+        (match R.get ~base_path:base_dir "sleepy" with
+         | Some resumed ->
+           check bool "registry meta resumed" false resumed.meta.paused
+         | None -> fail "expected registry entry")))
+
 let test_board_signal_wakeup_keeps_thread_reply_after_self_comment () =
   R.clear ();
   let base_dir = temp_base_path "board-wakeup-followup" in
@@ -2565,6 +2621,8 @@ let () =
             test_board_signal_wakeup_ignores_unmatched_posts_without_opt_in;
           eio_test "board wakeup only wakes opted-in scope keeper"
             test_board_signal_wakeup_only_wakes_opted_in_scope_keeper;
+          eio_test "board explicit mention resumes paused keeper"
+            test_board_signal_explicit_mention_resumes_paused_keeper;
           eio_test "board wakeup keeps thread reply after self comment"
             test_board_signal_wakeup_keeps_thread_reply_after_self_comment;
           eio_test "effective keepalive meta prefers registry when disk unchanged"


### PR DESCRIPTION
Summary
- Treat paused keeper registry entries as board wake candidates only for explicit @mentions.
- Persist paused=false with heartbeat-field merge, dispatch Operator_resume, enqueue the board stimulus, and wake the keeper.
- Add registry coverage proving explicit mention resumes a paused keeper and queues the board signal.

Validation
- ocamlformat --check lib/keeper/keeper_keepalive_signal.ml test/test_keeper_registry.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_registry.exe was attempted after rebase but stopped locally to avoid holding the shared Dune lock while another long-running build held the opam switch lock.