### PR TITLE
refactor(dashboard): tighten KeeperDirectChatAccess into a discriminated union, drop dead fallback literal copy

### DIFF
--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -257,7 +257,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
           onDraftChange=${(value: string) => { chatInput.value = value }}
           onSend=${() => {
             if (chatAccess.blocked) {
-              showToast(chatAccess.message ?? '직접 통신 권한이 없습니다.', 'error')
+              showToast(chatAccess.message, 'error')
               return
             }
             void sendChat(name)

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -299,7 +299,7 @@ export function KeeperConversationPanel({
   const submit = async () => {
     const prompt = draft.trim()
     if (chatAccess.blocked) {
-      showToast(chatAccess.message ?? '직접 통신 권한이 없습니다.', 'error')
+      showToast(chatAccess.message, 'error')
       return
     }
     if (!keeperName || !prompt) return

--- a/dashboard/src/lib/keeper-chat-access.ts
+++ b/dashboard/src/lib/keeper-chat-access.ts
@@ -5,10 +5,20 @@ import {
   compactWhitespace,
 } from './dashboard-auth-access'
 
-interface KeeperDirectChatAccess {
-  blocked: boolean
-  message: string | null
-}
+/**
+ * Discriminated union — the `blocked: true` branch carries the
+ * user-visible reason as a non-null `message`, so call sites that
+ * already gate behavior on `blocked` (keeper-chat-panel.ts and
+ * keeper-shared.ts) can hand `chatAccess.message` straight to
+ * `showToast` without a `?? '직접 통신 권한이 없습니다.'` literal
+ * copy on each call site. The `blocked: false` branch still ships
+ * `message: null` because both call sites render
+ * `${chatAccess.message ? html\`<warn>${...}</warn>\` : ''}` inline
+ * and need the field to be present on either side of the union.
+ */
+export type KeeperDirectChatAccess =
+  | { blocked: false; message: null }
+  | { blocked: true; message: string }
 
 export function keeperDirectChatAccess(
   summary: DashboardShellAuthSummary | null | undefined,


### PR DESCRIPTION
## 요약
`KeeperDirectChatAccess` interface 를 discriminated union 으로 tighten + 2 callsite 의 dead fallback literal copy (`?? '직접 통신 권한이 없습니다.'`) 제거. iter#40 sentinel-as-const 패턴의 *type-level 응용*.

## 배경

`rg "\?\? '[^']{2,30}'"` sweep 결과 `?? '직접 통신 권한이 없습니다.'` 2 callsite 발견:

| 파일 | line | context |
|---|---|---|
| `components/keeper-chat-panel.ts:260` | inside `if (chatAccess.blocked) { showToast(chatAccess.message ?? '...', 'error') }` | onSend handler |
| `components/keeper-shared.ts:302` | inside `if (chatAccess.blocked) { showToast(chatAccess.message ?? '...', 'error') }` | submit handler |

`lib/keeper-chat-access.ts` 의 `keeperDirectChatAccess` 함수가:
- `blocked: false` 시 → `{ blocked: false, message: null }` (line 17)
- `blocked: true` 시 → `{ blocked: true, message: 'compactWhitespace(`직접 통신 비활성화: ${reason}...`)' }` (line 34-38)

**즉 `{ blocked: true, message: null }` 조합은 절대 생성 안 됨** — `blocked: true` 일 때 `message` 는 항상 non-null. 그러나 type `interface { blocked: boolean; message: string | null }` 가 그 조합을 *type-level 로 허용* → callsite 가 *defensive fallback* 필요 → cross-file literal copy.

## 변경

### `lib/keeper-chat-access.ts`
- interface → discriminated union type alias:
  ```ts
  type KeeperDirectChatAccess =
    | { blocked: false; message: null }
    | { blocked: true; message: string }
  ```
- JSDoc 으로 *왜 이 union 모양* 인지 명시: blocked: true branch 의 non-null message + blocked: false branch 의 explicit null 이 callsite 의 truthy check render 패턴 (`${chatAccess.message ? html`...` : ''}`) 도 자연 narrow 시킴

### Call sites
- `keeper-chat-panel.ts:260`: `chatAccess.message ?? '...'` → `chatAccess.message` (TS 가 `if (chatAccess.blocked)` 안에서 `message: string` narrow)
- `keeper-shared.ts:302`: 동일 변경

`chatAccess.message` 의 truthy render 패턴 (`if (chatAccess.message) { html`<warn>${...}</warn>` }` 형태 line 234/355) 는 그대로 — union 양쪽 모두 message 필드 존재.

## 검증
- typecheck PASS (TS 가 `if (chatAccess.blocked) { ... chatAccess.message }` narrow 자동 처리, fallback 제거 후 type error 없음)
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)

## iter chain

- iter#19: errorMessage 4-way rename (정책 분기 동음이의어)
- iter#40: NO_TIME_INFO sentinel const (lib + caller 의 string literal copy SSOT 화)
- iter#43: **type-level tightening** — type 자체가 guarantee 를 carry → defensive copy 자연 dead

같은 SSOT 위반 class (cross-file string literal copy) 의 *해소 차원 상승* — const SSOT → discriminated union.

## /loop iter#43
SSOT 위반 dashboard 축출 loop 의 iter#43. cumulative 43 PR (28 머지 + 2 OPEN — #19055 + #19?_).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
