### PR TITLE
fix(dashboard): align runtime count authority labels

### DIFF
--- a/dashboard/src/components/common/command-palette.test.ts
+++ b/dashboard/src/components/common/command-palette.test.ts
@@ -171,11 +171,11 @@ describe('CommandPalette', () => {
     await waitFor(() => {
       const palette = container.querySelector('ninja-keys') as (HTMLElement & { data?: PaletteItem[] }) | null
       expect(palette?.data?.find((item) => item.id === 'nav-agent-worker-a')?.section)
-        .toBe('Agent targets (1)')
+        .toBe('Mission agent targets (1)')
       expect(palette?.data?.find((item) => item.id === 'nav-keeper-keeper-a')?.section)
-        .toBe('Keeper targets (2)')
+        .toBe('Mission keeper targets (2)')
       expect(palette?.data?.find((item) => item.id === 'nav-session-sess-1')?.section)
-        .toBe('Session targets (1)')
+        .toBe('Mission session targets (1)')
       expect(palette?.data?.find((item) => item.id === 'nav-keeper-keeper-a')?.keywords)
         .toContain('명령 대상 에이전트 1 / 키퍼 2 / 세션 1')
     })

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -74,6 +74,26 @@ describe('dashboardHealthChips', () => {
     ])
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.label)
       .toBe('키퍼 활성 1 / 일시정지 1 / 설정 2')
+    expect(chips.find(chip => chip.key === 'keeper-count-basis')?.detail)
+      .toBe('활성=shell runtime, paused=상세 행 lifecycle, 설정=shell keeper inventory.')
+  })
+
+  it('uses namespace truth as the configured keeper count authority in health chips', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { agents: 0, keepers: 2, configured_keepers: 2 },
+      namespaceTruthCounts: { agents: 0, keepers: 16, tasks: 0, total_runtimes: 16 },
+      namespaceTruthConfiguredKeepers: 16,
+      keepers: [],
+      runtimeResolution: null,
+      executionError: null,
+      loading: false,
+    })
+
+    expect(chips.find(chip => chip.key === 'keeper-count-basis')?.label)
+      .toBe('키퍼 활성 2 / 설정 16')
+    expect(chips.find(chip => chip.key === 'keeper-count-basis')?.detail)
+      .toBe('활성=shell runtime, paused=상세 행 lifecycle, 설정=project snapshot keeper inventory.')
   })
 
   it('returns a healthy chip when no runtime risk is visible', () => {

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -11,8 +11,13 @@ import { dashboardWsConnected, dashboardWsSseFallbackActive } from '../dashboard
 import { isKeeperPaused } from '../lib/keeper-predicates'
 import { dashboardLoading, executionError, keepers, serverStatus, shellCounts, shellRuntimeResolution } from '../store'
 import { missionSnapshot, missionLoading } from '../mission-signals'
-import { namespaceTruthInitializing } from '../namespace-truth-store'
-import { formatKeeperCountBreakdown } from '../runtime-counts'
+import { namespaceTruth, namespaceTruthInitializing } from '../namespace-truth-store'
+import {
+  configuredCountSourceLabel,
+  formatKeeperCountBreakdown,
+  resolveRuntimeCounts,
+  runtimeCountSourceLabel,
+} from '../runtime-counts'
 import { ErrorBoundary } from './common/error-boundary'
 import { TimeAgo } from './common/time-ago'
 import { LoadingState } from './common/feedback-state'
@@ -169,9 +174,19 @@ interface DashboardHealthChip {
 interface DashboardHealthInput {
   connected: boolean
   counts: {
+    agents?: number
+    tasks?: number
     keepers: number
+    total_runtimes?: number
     configured_keepers: number
   } | null
+  namespaceTruthCounts?: {
+    agents?: number
+    tasks?: number
+    keepers?: number
+    total_runtimes?: number
+  }
+  namespaceTruthConfiguredKeepers?: number
   keepers: Keeper[]
   runtimeResolution: DashboardRuntimeResolution | null
   executionError: string | null
@@ -434,8 +449,24 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
   }
 
   const pausedKeepers = input.keepers.filter(isKeeperPaused).length
-  const configured = input.counts?.configured_keepers ?? 0
-  const liveKeepers = input.counts?.keepers ?? input.keepers.length
+  const fallbackRunningKeepers = Math.max(0, input.keepers.length - pausedKeepers)
+  const runtimeCounts = resolveRuntimeCounts({
+    executionLoaded: input.counts !== null || input.keepers.length > 0,
+    agentsCount: input.counts?.agents ?? 0,
+    keepersCount: input.counts?.keepers ?? fallbackRunningKeepers,
+    pausedKeepersCount: pausedKeepers,
+    namespaceTruthCounts: input.namespaceTruthCounts,
+    namespaceTruthConfiguredKeepers: input.namespaceTruthConfiguredKeepers,
+    shellCounts: input.counts,
+    shellConfiguredKeepers: input.counts?.configured_keepers,
+  })
+  const configured = runtimeCounts.configured.keepers
+  const liveKeepers = runtimeCounts.live.keepers
+  const activeCountSource = input.counts !== null
+    ? 'shell'
+    : input.keepers.length > 0
+      ? '상세 행'
+      : runtimeCountSourceLabel(runtimeCounts.source)
   if (configured > 0 && (configured !== liveKeepers || pausedKeepers > 0)) {
     chips.push({
       key: 'keeper-count-basis',
@@ -444,7 +475,7 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
         pausedKeepers,
         configuredKeepers: configured,
       }),
-      detail: 'counts.keepers=활성 keeper runtime, paused=상세 행 lifecycle, configured_keepers=keeper inventory.',
+      detail: `활성=${activeCountSource} runtime, paused=상세 행 lifecycle, 설정=${configuredCountSourceLabel(runtimeCounts.configured.source)} keeper inventory.`,
       tone: 'muted',
     })
   }
@@ -528,6 +559,8 @@ export function DashboardHealthStrip() {
   const chips = dashboardHealthChips({
     connected: live,
     counts: shellCounts.value,
+    namespaceTruthCounts: namespaceTruth.value?.root.counts,
+    namespaceTruthConfiguredKeepers: namespaceTruth.value?.root.configured_keepers,
     keepers: keepers.value,
     runtimeResolution: shellRuntimeResolution.value,
     executionError: executionError.value,

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -262,7 +262,7 @@ describe('runtime count role helpers', () => {
   })
 
   it('formats command target sections as mission targets, not live runtime counts', () => {
-    expect(formatCommandTargetSection('keeper', 16)).toBe('Keeper targets (16)')
+    expect(formatCommandTargetSection('keeper', 16)).toBe('Mission keeper targets (16)')
     expect(formatCommandTargetSummary({ agents: 4, keepers: 16, sessions: 0 }))
       .toBe('명령 대상 에이전트 4 / 키퍼 16 / 세션 0')
   })

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -265,11 +265,11 @@ export function formatCommandTargetSection(kind: CommandTargetKind, count: numbe
   const normalized = normalizeCount(count)
   switch (kind) {
     case 'agent':
-      return `Agent targets (${normalized})`
+      return `Mission agent targets (${normalized})`
     case 'keeper':
-      return `Keeper targets (${normalized})`
+      return `Mission keeper targets (${normalized})`
     case 'session':
-      return `Session targets (${normalized})`
+      return `Mission session targets (${normalized})`
   }
 }
 


### PR DESCRIPTION
## Summary
- Route dashboard health strip keeper configured counts through the shared runtime-counts resolver so namespace truth is the authority when present.
- Make the health chip detail name active, paused, and configured count sources explicitly.
- Rename command palette count sections to Mission agent/keeper/session targets so they are not confused with live runtime totals.

## Verification
- pnpm vitest run --config vitest.config.ts src/runtime-counts.test.ts src/components/dashboard-shell.test.ts src/components/common/command-palette.test.ts src/components/agents-unified.test.ts src/components/agent-roster.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm eslint src/components/dashboard-shell.ts src/components/dashboard-shell.test.ts src/runtime-counts.ts src/runtime-counts.test.ts src/components/common/command-palette.test.ts
- git diff --check origin/main