### PR TITLE
refactor(dashboard/schemas): export formatIssues from drift-error and stop inlining the same .map block in 7 schemas

### DIFF
--- a/dashboard/src/api/schemas/agent-relations.ts
+++ b/dashboard/src/api/schemas/agent-relations.ts
@@ -19,6 +19,7 @@ import {
   type BaseIssue,
   type InferOutput,
 } from 'valibot'
+import { formatIssues } from './drift-error'
 
 const AgentCollaboratorSchema = object({
   name: string(),
@@ -60,13 +61,7 @@ export type AgentRelationsResponse = InferOutput<typeof AgentRelationsResponseSc
 export class AgentRelationsSchemaDriftError extends Error {
   readonly issues: readonly BaseIssue<unknown>[]
   constructor(issues: readonly BaseIssue<unknown>[]) {
-    const summary = issues
-      .map(issue => {
-        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
-        return `${path}: ${issue.message}`
-      })
-      .join('; ')
-    super(`agent-relations schema drift: ${summary}`)
+    super(`agent-relations schema drift: ${formatIssues(issues)}`)
     this.name = AgentRelationsSchemaDriftError.name
     this.issues = issues
   }

--- a/dashboard/src/api/schemas/agent-timeline.ts
+++ b/dashboard/src/api/schemas/agent-timeline.ts
@@ -19,6 +19,7 @@ import {
   type BaseIssue,
   type InferOutput,
 } from 'valibot'
+import { formatIssues } from './drift-error'
 
 const AgentTimelineEventSchema = object({
   ts: string(),
@@ -59,13 +60,7 @@ export type AgentTimelineResponse = InferOutput<typeof AgentTimelineResponseSche
 export class AgentTimelineSchemaDriftError extends Error {
   readonly issues: readonly BaseIssue<unknown>[]
   constructor(issues: readonly BaseIssue<unknown>[]) {
-    const summary = issues
-      .map(issue => {
-        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
-        return `${path}: ${issue.message}`
-      })
-      .join('; ')
-    super(`agent-timeline schema drift: ${summary}`)
+    super(`agent-timeline schema drift: ${formatIssues(issues)}`)
     this.name = AgentTimelineSchemaDriftError.name
     this.issues = issues
   }

--- a/dashboard/src/api/schemas/drift-error.ts
+++ b/dashboard/src/api/schemas/drift-error.ts
@@ -18,7 +18,15 @@ import {
   type InferOutput,
 } from 'valibot'
 
-function formatIssues(issues: readonly BaseIssue<unknown>[]): string {
+/**
+ * Format a valibot issue list as a `; `-joined string of
+ * `<dotted.path>: <message>` segments, using `<root>` for issues
+ * whose `path` resolves to an empty array. Exposed so per-domain
+ * `SchemaDriftError` subclasses that build their own summary in a
+ * `super(...)` call don't have to inline the same `.map(...).join(';')`
+ * block — keeps the `<root>` sentinel and the segment shape in one place.
+ */
+export function formatIssues(issues: readonly BaseIssue<unknown>[]): string {
   return issues
     .map(issue => {
       const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'

--- a/dashboard/src/api/schemas/gate-status.ts
+++ b/dashboard/src/api/schemas/gate-status.ts
@@ -21,6 +21,7 @@ import {
   type BaseIssue,
   type InferOutput,
 } from 'valibot'
+import { formatIssues } from './drift-error'
 
 const ChannelInfoRawSchema = object({
   channel: string(),
@@ -116,13 +117,7 @@ export interface GateStatusData {
 export class GateStatusSchemaDriftError extends Error {
   readonly issues: readonly BaseIssue<unknown>[]
   constructor(issues: readonly BaseIssue<unknown>[]) {
-    const summary = issues
-      .map(issue => {
-        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
-        return `${path}: ${issue.message}`
-      })
-      .join('; ')
-    super(`gate-status schema drift: ${summary}`)
+    super(`gate-status schema drift: ${formatIssues(issues)}`)
     this.name = GateStatusSchemaDriftError.name
     this.issues = issues
   }

--- a/dashboard/src/api/schemas/git-graph.ts
+++ b/dashboard/src/api/schemas/git-graph.ts
@@ -11,6 +11,7 @@ import {
   type BaseIssue,
   type InferOutput,
 } from 'valibot'
+import { formatIssues } from './drift-error'
 
 const RepoInfoSchema = object({
   id: string(),
@@ -85,13 +86,7 @@ export class GitGraphSchemaDriftError extends Error {
   readonly issues: readonly BaseIssue<unknown>[]
 
   constructor(issues: readonly BaseIssue<unknown>[]) {
-    const summary = issues
-      .map(issue => {
-        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
-        return `${path}: ${issue.message}`
-      })
-      .join('; ')
-    super(`git-graph schema drift: ${summary}`)
+    super(`git-graph schema drift: ${formatIssues(issues)}`)
     this.name = GitGraphSchemaDriftError.name
     this.issues = issues
   }

--- a/dashboard/src/api/schemas/keeper-transitions.ts
+++ b/dashboard/src/api/schemas/keeper-transitions.ts
@@ -18,6 +18,7 @@ import {
   type BaseIssue,
   type InferOutput,
 } from 'valibot'
+import { formatIssues } from './drift-error'
 
 const KeeperTransitionOperatorSignalSchema = object({
   class: string(),
@@ -53,13 +54,7 @@ export type KeeperTransitionsResponse = InferOutput<typeof KeeperTransitionsResp
 export class KeeperTransitionsSchemaDriftError extends Error {
   readonly issues: readonly BaseIssue<unknown>[]
   constructor(issues: readonly BaseIssue<unknown>[]) {
-    const summary = issues
-      .map(issue => {
-        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
-        return `${path}: ${issue.message}`
-      })
-      .join('; ')
-    super(`keeper transitions schema drift: ${summary}`)
+    super(`keeper transitions schema drift: ${formatIssues(issues)}`)
     this.name = KeeperTransitionsSchemaDriftError.name
     this.issues = issues
   }

--- a/dashboard/src/api/schemas/logs.ts
+++ b/dashboard/src/api/schemas/logs.ts
@@ -26,6 +26,7 @@ import {
   type BaseIssue,
   type InferOutput,
 } from 'valibot'
+import { formatIssues } from './drift-error'
 
 const LogEntrySchema = object({
   seq: number(),
@@ -92,13 +93,7 @@ export interface LogsResponse {
 export class LogsSchemaDriftError extends Error {
   readonly issues: readonly BaseIssue<unknown>[]
   constructor(issues: readonly BaseIssue<unknown>[]) {
-    const summary = issues
-      .map(issue => {
-        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
-        return `${path}: ${issue.message}`
-      })
-      .join('; ')
-    super(`logs schema drift: ${summary}`)
+    super(`logs schema drift: ${formatIssues(issues)}`)
     this.name = LogsSchemaDriftError.name
     this.issues = issues
   }

--- a/dashboard/src/api/schemas/provider-logs.ts
+++ b/dashboard/src/api/schemas/provider-logs.ts
@@ -18,6 +18,7 @@ import {
   type BaseIssue,
   type InferOutput,
 } from 'valibot'
+import { formatIssues } from './drift-error'
 
 const ProviderLogCatalogEntrySchema = object({
   id: string(),
@@ -72,13 +73,7 @@ export type ProviderLogTailResponse = InferOutput<typeof ProviderLogTailResponse
 export class ProviderLogsSchemaDriftError extends Error {
   readonly issues: readonly BaseIssue<unknown>[]
   constructor(issues: readonly BaseIssue<unknown>[]) {
-    const summary = issues
-      .map(issue => {
-        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
-        return `${path}: ${issue.message}`
-      })
-      .join('; ')
-    super(`provider logs schema drift: ${summary}`)
+    super(`provider logs schema drift: ${formatIssues(issues)}`)
     this.name = ProviderLogsSchemaDriftError.name
     this.issues = issues
   }


### PR DESCRIPTION
## 요약
`api/schemas/drift-error.ts` 의 file-internal `formatIssues` helper 를 named export 로 promote + 7 schema 의 inline 5-line block 을 1 line `formatIssues(issues)` 호출로 dedup. iter#33/34 ActionButton/TextInput SSOT 우회 패턴의 schema 도메인 변형.

## 배경

`rg "\?\? '<root>'" -n api/schemas/` sweep 결과 9 callsite 발견. drift-error.ts 분석:

```ts
// api/schemas/drift-error.ts (header excerpt)
// Shared base for schema-at-boundary parse errors.
// Subclasses are kept thin (2-line) so callers can keep writing
// `instanceof CompositeSchemaDriftError`...

function formatIssues(issues: readonly BaseIssue<unknown>[]): string {
  return issues.map(issue => {
    const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
    return `${path}: ${issue.message}`
  }).join('; ')
}

export abstract class SchemaDriftError extends Error { ... }
export function parseOrThrow<...>(...) { ... }
```

**상황**: `formatIssues` + `SchemaDriftError` + `parseOrThrow` = 공식 SSOT, 그러나 **0 subclass / 0 callsite** (production migration 미시작). 9 schema 가 *자체 inline 으로 동일 5-line block 복사*. iter#33/34 ActionButton/TextInput SSOT 우회 패턴과 동일.

7 schema 가 *byte-identical*. 1 schema (`actions-activity.ts`) 는 `.slice(0, 3)` prefix 가짐 (memory bound 의도). drift-error.ts 자체 1 callsite = canonical source.

## 변경

### `api/schemas/drift-error.ts`
- `formatIssues` → `export function formatIssues` (named export)
- JSDoc 추가: `<root>` sentinel + segment shape 가 한 곳에 박혀 있다고 명시 (subclass 의 super(...) 호출에서 redundant copy 방지 의도)

### 7 schema migration
| 파일 | inline → call |
|---|---|
| `gate-status.ts` | 5-line block → `formatIssues(issues)` |
| `agent-relations.ts` | 동일 |
| `keeper-transitions.ts` | 동일 |
| `provider-logs.ts` | 동일 |
| `logs.ts` | 동일 |
| `agent-timeline.ts` | 동일 |
| `git-graph.ts` | 동일 |

각 schema 에 `import { formatIssues } from './drift-error'` 추가.

### Scope 밖 (별도 follow-up)
- `actions-activity.ts:229` — `.slice(0, 3)` truncation prefix 가짐. `formatIssues` 가 `maxIssues?` 옵션 받도록 확장 후 migration. 본 PR 에서 inline `if (truncate)` flag 추가하면 helper 가 dirty 해짐.
- `SchemaDriftError` abstract base + `parseOrThrow` migration. 7 schema 가 thin subclass 로 마이그레이션 시 `instanceof <name>SchemaDriftError` integration test 영향 (`components/fsm-hub.integration.test.ts`). 디자인 결정 필요.

## 검증
- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)
- 8 files +23/-50 (27 lines 순 감소)

## iter chain

- iter#33/34: ActionButton/TextInput 공식 SSOT 우회 (디자인 토큰 매핑 결정 필요로 callsite migration 분리)
- iter#44: formatIssues 공식 SSOT 우회 (단순 5-line block, *직접 migration 가능*)

같은 SSOT 우회 안티패턴이 *함수 시그니처가 호환 되는 경우* 직접 migration. iter#33/34 의 *토큰 layer mismatch 차단* 보다 깔끔.

## /loop iter#44
SSOT 위반 dashboard 축출 loop 의 iter#44. cumulative 44 PR (28 머지 + 2 OPEN — #19065 + #19?_).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
