### PR TITLE
refactor(relative-time-format): Masc_time_constants.hour replaces 3600.0 literal at 6 sites across 3 dashboard/tempo files

### DIFF
--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -372,8 +372,8 @@ let format_elapsed_float now ts =
   let elapsed = now -. ts in
   if Stdlib.Float.compare elapsed 0.0 < 0 then "0s"
   else if Stdlib.Float.compare elapsed 60.0 < 0 then Printf.sprintf "%.0fs" elapsed
-  else if Stdlib.Float.compare elapsed 3600.0 < 0 then Printf.sprintf "%.0fm" (elapsed /. 60.0)
-  else Printf.sprintf "%.1fh" (elapsed /. 3600.0)
+  else if Stdlib.Float.compare elapsed Masc_time_constants.hour < 0 then Printf.sprintf "%.0fm" (elapsed /. 60.0)
+  else Printf.sprintf "%.1fh" (elapsed /. Masc_time_constants.hour)
 
 (** Keepers section: real-time FSM phase from Keeper_registry.
     Reads registry snapshot each render — no dashboard-side cache. *)

--- a/lib/dashboard/dashboard_labels.ml
+++ b/lib/dashboard/dashboard_labels.ml
@@ -147,8 +147,8 @@ let format_elapsed now timestamp fallback =
   | Some ts ->
       let elapsed = now -. ts in
       if elapsed < 60.0 then Printf.sprintf "%.0fs ago" elapsed
-      else if elapsed < 3600.0 then Printf.sprintf "%.0fm ago" (elapsed /. 60.0)
-      else Printf.sprintf "%.1fh ago" (elapsed /. 3600.0)
+      else if elapsed < Masc_time_constants.hour then Printf.sprintf "%.0fm ago" (elapsed /. 60.0)
+      else Printf.sprintf "%.1fh ago" (elapsed /. Masc_time_constants.hour)
   | None -> fallback
 
 (* ===== Agent Status Translation ===== *)

--- a/lib/tempo.ml
+++ b/lib/tempo.ml
@@ -138,8 +138,8 @@ let format_state (state : tempo_state) : string =
   let age =
     let elapsed = Time_compat.now () -. state.last_adjusted in
     if elapsed < 60.0 then "just now"
-    else if elapsed < 3600.0 then Printf.sprintf "%.0fm ago" (elapsed /. 60.0)
-    else Printf.sprintf "%.1fh ago" (elapsed /. 3600.0)
+    else if elapsed < Masc_time_constants.hour then Printf.sprintf "%.0fm ago" (elapsed /. 60.0)
+    else Printf.sprintf "%.1fh ago" (elapsed /. Masc_time_constants.hour)
   in
   Printf.sprintf "⏱️ Tempo: %s (%s, adjusted %s)" interval_str state.reason age
 


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" — Magic Number Time-literal 시리즈 (#19037 / #19042 / #19046 / #19058 / #19061 / #19062) 의 **identical-pattern 3 파일 cluster** 후속. `elapsed < 3600.0 ? "%.0fm ago" : "%.1fh ago"` 패턴 *세 파일에서 정확히 같은 ladder* 로 등장.

### Pattern

`Masc_time_constants.hour = 3600.0` SSOT 가 *이미* 존재. 세 파일 모두 root `masc_mcp` library 라 transitive access OK.

세 파일 모두 같은 ladder (60s / hour / 더 큰 단위 fallback):

```ocaml
(* dashboard.ml:375-376 *)
else if Stdlib.Float.compare elapsed 3600.0 < 0 then Printf.sprintf "%.0fm" (elapsed /. 60.0)
else Printf.sprintf "%.1fh" (elapsed /. 3600.0)

(* dashboard_labels.ml:150-151 *)
else if elapsed < 3600.0 then Printf.sprintf "%.0fm ago" (elapsed /. 60.0)
else Printf.sprintf "%.1fh ago" (elapsed /. 3600.0)

(* tempo.ml:141-142 *)
else if elapsed < 3600.0 then Printf.sprintf "%.0fm ago" (elapsed /. 60.0)
else Printf.sprintf "%.1fh ago" (elapsed /. 3600.0)
```

after (모두 `Masc_time_constants.hour`):
```ocaml
else if Stdlib.Float.compare elapsed Masc_time_constants.hour < 0 then ...
else ... (elapsed /. Masc_time_constants.hour)
```

6 사이트:
- `dashboard.ml:375` — threshold compare
- `dashboard.ml:376` — divisor for "h" formatting
- `dashboard/dashboard_labels.ml:150` — threshold compare
- `dashboard/dashboard_labels.ml:151` — divisor
- `tempo.ml:141` — threshold compare
- `tempo.ml:142` — divisor

## 변경

- 3 files, +6/-6 (각 파일 +2/-2)
- 동작 무변경 (`Masc_time_constants.hour = 3600.0`)

## Magic-number lint impact

`3600.0` 리터럴 hotspots:
- Before: 6 hits
- After: 0

## Out-of-scope

`lib/dashboard/dashboard_labels.ml:48,57` 의 `h * 3600 + m * 60` 는 *unit conversion factor* — sw-dev §"Magic Number 금지" 의 명시적 예외 (`"단위 변환 계수(1000)뿐이다"`). 본 PR 미터치.

## ⚠️ Upstream main HEAD regression (not introduced by this PR)

`lib/dashboard/dashboard_http_keeper_detail.ml:121` 에 PR #19066 (`refactor(keeper): remove PR action metrics`) 이 남긴 *unused `is_tool_event` 바인딩* 이 dashboard 서브라이브러리 빌드를 `warning 26 [unused-var]` 으로 차단. 본 PR 범위 외이며 별도 unblock PR 로 처리 예정.

- 본 PR 의 *root-level* 파일 (`dashboard.ml`, `tempo.ml`) 은 individual byte build PASS 확인
- `dashboard_labels.ml` 변경은 *순수 SSOT substitution* — upstream regression 해소 시 정상 빌드 보장

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 3 파일 6 사이트 *모두* 동시 처리

## Related

- PR #19037 — `two_days_seconds_int` (172800 int, 7 사이트)
- PR #19042 — `one_day_seconds_int` (86400 int, 2 사이트)
- PR #19046 — `Masc_time_constants.hour/day` (3600.0/86400.0, 4 keeper-accountability)
- PR #19058 — `Masc_time_constants.hour` (3600.0, 4 cascade)
- PR #19061 — half-migration finishing `tool_board_format.ml` (4 sites)
- PR #19062 — `Masc_time_constants.hour` (3600.0, 4 sites cascade/board/timeline)
- `lib/config/masc_time_constants.ml` — time SSOT
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
