### PR TITLE
fix(dashboard): drop dead is_tool_event binding from keeper detail builder

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -118,7 +118,6 @@ let compute_metrics_window
         let channel = Safe_ops.json_string ~default:"turn" "channel" j in
         let is_turn = channel = "turn" in
         let is_heartbeat = channel = "heartbeat" in
-        let is_tool_event = channel = "tool_event" in
         let is_scheduled_autonomous = channel = "scheduled_autonomous" || channel = "proactive" in
         let is_interaction = is_turn || is_scheduled_autonomous in
         let compacted = Safe_ops.json_bool ~default:false "compacted" j in


### PR DESCRIPTION
## 요약

PR #19066 (`refactor(keeper): remove PR action metrics`, merged main HEAD `ceb6a5c9f`) 가 `lib/dashboard/dashboard_http_keeper_detail.ml:121` 에 *unused* `let is_tool_event = channel = "tool_event"` 바인딩을 남김. `lib/dashboard/dune` 가 `warning 26 [unused-var]` 을 에러로 취급해 **dashboard 서브라이브러리 빌드가 main 에서 깨진 상태**.

### Asymmetry

같은 `let X = channel = "..."` 시리즈 중 *오직 `is_tool_event` 만* dead:

```ocaml
let is_turn = channel = "turn" in                          (* used → is_interaction:123 *)
let is_heartbeat = channel = "heartbeat" in                (* used → line 386 ma_heartbeat_points *)
let is_tool_event = channel = "tool_event" in              (* ← 미사용 *)
let is_scheduled_autonomous = channel = "scheduled_autonomous" || channel = "proactive" in  (* used → is_interaction *)
let is_interaction = is_turn || is_scheduled_autonomous in
```

`is_heartbeat` 가 line 386 의 `ma_heartbeat_points` accumulator 에서 *읽힘* 확인 (rg). `is_tool_event` 만 reader 없음.

## 변경

- `lib/dashboard/dashboard_http_keeper_detail.ml`: 1 file, +0/-1
  - Line 121 의 `let is_tool_event = channel = "tool_event" in` 삭제

## Build impact

Before: `dune build lib/` → `Error (warning 26 [unused-var]): unused variable is_tool_event` (dashboard 서브라이브러리 차단)
After: `dune build lib/` PASS

## Root fix vs Workaround

Root fix (dead-code 삭제). 워크어라운드 아님:
- `is_tool_event` 가 *어디서도 읽히지 않음* → semantic 0 변경
- `let _is_tool_event = ...` prefix workaround 가 아닌 *완전 제거*

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 dead-code *삭제* (root fix). 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기 (`channel = "tool_event"` 본 PR 로 *제거*)
- ❌ N-of-M 패치 — single-site 완전 삭제

## Test impact

- 동작 무변경 (binding 자체가 *읽히지 않았으므로*)
- `dune build lib/` PASS
- CI 차단 해소 — 본 PR merge 후 다른 PR (예: #19072 magic number 시리즈) 빌드 가능

## Related

- PR #19066 — `refactor(keeper): remove PR action metrics` (regression 도입처)
- PR #19072 — magic-number 시리즈 (본 PR merge 대기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
