### PR TITLE
refactor(dashboard): rename keeper operations lane

### DIFF
--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -1,4 +1,4 @@
-// MASC Dashboard — Keeper Operations
+// MASC Dashboard — Keeper Fleet
 // Absorbs: agent-roster + execution + keeper-roster + FSM hub into one
 // operator-first board. Cognition stays available through keeper detail links.
 

--- a/dashboard/src/components/cognition-plane.test.ts
+++ b/dashboard/src/components/cognition-plane.test.ts
@@ -69,7 +69,7 @@ describe('CognitionPlane', () => {
     await flushUi()
 
     expect(container.textContent).toContain('Keeper')
-    expect(container.textContent).toContain('Keeper Operations')
+    expect(container.textContent).toContain('Keeper Fleet')
     expect(container.querySelector('[data-testid="agents-unified"]')).toBeNull()
     expect(container.querySelector('[data-testid="keeper-token-stats"]')).toBeNull()
     expect(container.querySelector('[data-section="agents"]')).not.toBeNull()

--- a/dashboard/src/components/cognition-plane.ts
+++ b/dashboard/src/components/cognition-plane.ts
@@ -103,8 +103,8 @@ function CognitionOverview() {
         params=${{ section: 'agents' }}
         class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] p-3 transition-colors hover:border-[var(--color-border-strong)] hover:bg-[var(--color-bg-elevated)] md:col-span-2"
       >
-        <div class="text-sm font-semibold text-text-strong">Keeper Operations</div>
-        <div class="mt-1 text-xs text-text-muted">Roster, keepers, cognition entry points, and FSM views live in one operations surface.</div>
+        <div class="text-sm font-semibold text-text-strong">Keeper Fleet</div>
+        <div class="mt-1 text-xs text-text-muted">Roster, keepers, cognition entry points, and FSM views live in one fleet surface.</div>
       <//>
     </section>
   `

--- a/dashboard/src/components/status.test.ts
+++ b/dashboard/src/components/status.test.ts
@@ -9,7 +9,7 @@ describe("sectionLabel", () => {
     ["runtime", "Cascade & Runtime"],
     ["fleet-health", "Tool Monitor"],
     ["cognition", "Keeper Cognition"],
-    ["agents", "Keeper Operations"],
+    ["agents", "Keeper Fleet"],
   ] as [StatusSection, string][])("maps %s to %s", (section, expected) => {
     expect(sectionLabel(section)).toBe(expected)
   })

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -89,7 +89,7 @@ export function sectionLabel(section: StatusSection): string {
     case 'cognition':
       return 'Keeper Cognition'
     case 'agents':
-      return 'Keeper Operations'
+      return 'Keeper Fleet'
   }
 }
 

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -97,11 +97,11 @@ describe('connectors navigation (Phase 7, post-2026-04-30 merge)', () => {
 })
 
 describe('monitoring navigation labels', () => {
-  it('uses keeper-operations first Monitor IA labels', () => {
+  it('uses keeper-fleet first Monitor IA labels', () => {
     const sections = visibleSectionItemsForTab('monitoring')
     const labelFor = (id: string) => sections.find(item => item.id === id)?.label
 
-    expect(labelFor('agents')).toBe('Keeper Operations')
+    expect(labelFor('agents')).toBe('Keeper Fleet')
     expect(labelFor('fleet-health')).toBe('Tool Monitor')
     expect(labelFor('runtime')).toBe('Cascade & Runtime')
     expect(labelFor('observatory')).toBe('Evidence Timeline')
@@ -116,7 +116,7 @@ describe('monitoring navigation labels', () => {
     const descriptions = Object.fromEntries(sections.map(item => [item.id, item.description]))
 
     expect(descriptions).toMatchObject({
-      agents: 'Attention-first keeper operations.',
+      agents: 'Live and configured keeper roster.',
       'fleet-health': 'Tool quality and governance signals.',
       runtime: 'Cascade and provider health.',
       observatory: 'Activity and runtime evidence.',
@@ -176,7 +176,7 @@ describe('monitoring navigation labels', () => {
     expect(ids).not.toContain('governance')
   })
 
-  it('puts keeper operations first before tool, runtime, and evidence lanes', () => {
+  it('puts keeper fleet first before tool, runtime, and evidence lanes', () => {
     const sections = visibleSectionItemsForTab('monitoring')
     expect(sections.map(section => section.id)).toEqual([
       'agents',

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -173,8 +173,8 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
   monitoring: [
     {
       id: 'agents',
-      label: 'Keeper Operations',
-      description: 'Attention-first keeper operations.',
+      label: 'Keeper Fleet',
+      description: 'Live and configured keeper roster.',
       params: { section: 'agents' },
     },
     {


### PR DESCRIPTION
## Summary
- Rename the Monitor agents section from Keeper Operations to Keeper Fleet.
- Keep Command Operations reserved for intervention/governance actions.
- Update the cognition deep link card and section-label tests to match the split.

## Verification
- pnpm vitest run --config vitest.config.ts src/config/navigation.test.ts src/components/status.test.ts src/components/cognition-plane.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm eslint src/config/navigation.ts src/config/navigation.test.ts src/components/status.ts src/components/status.test.ts src/components/cognition-plane.ts src/components/cognition-plane.test.ts src/components/agents-unified.ts
- git diff --check origin/main