### PR TITLE
refactor(dashboard): extract MISSING_DATA_DASH const to break repeated '--' fallback literal copy

### DIFF
--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -8,6 +8,7 @@ import { useEffect } from 'preact/hooks'
 import { replaceRoute, route } from '../router'
 import type { ToolQualityResponse } from '../api/dashboard'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
+import { MISSING_DATA_DASH } from '../lib/format-string'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { formatMsCompact, formatNumber } from '../lib/format-number'
 import { refreshShell, shellRuntimeResolution } from '../store'
@@ -456,7 +457,7 @@ function RuntimeBlockerBoard() {
         />
         <${StatTile}
           label="CDAL writer"
-          value=${cdal?.writer_status ?? '--'}
+          value=${cdal?.writer_status ?? MISSING_DATA_DASH}
           status=${cdalTone(cdal)}
           delta=${{ direction: cdal?.operator_action_required ? 'down' : 'flat', text: cdal?.proof_store?.status ?? 'proof unknown' }}
         />

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -17,6 +17,7 @@ import type { GoalTreeNode, KeeperConfig, KeeperHookSlot } from '../types'
 import type { KeeperConfigLoadStatus } from './keeper-detail-source'
 import { formatTokens, formatPct, formatCost } from '../lib/format-number'
 import { isVerifierRoleKeeper } from '../lib/keeper-utils'
+import { MISSING_DATA_DASH } from '../lib/format-string'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { BTN_FILLED_BASE } from './common/button-filled-base'
@@ -550,8 +551,8 @@ function EditTextarea({ field, label, rows = 3 }: { field: keyof EditDraft; labe
 }
 
 function sandboxAnchorText(c: KeeperConfig): string {
-  const basePath = c.sandbox_environment?.base_path ?? '--'
-  const projectRoot = c.sandbox_environment?.project_root ?? '--'
+  const basePath = c.sandbox_environment?.base_path ?? MISSING_DATA_DASH
+  const projectRoot = c.sandbox_environment?.project_root ?? MISSING_DATA_DASH
   return `상대 allowed_paths는 project root ${projectRoot} 기준으로 해석됩니다. config base path는 ${basePath} 입니다.`
 }
 
@@ -981,7 +982,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${ConfigRow} label="container_playground_root" value=${c.sandbox_environment.container_playground_root || '--'} />
         <${ConfigRow} label="sandbox_docker_image" value=${c.sandbox_environment.docker_image || '--'} />
         <${ConfigRow} label="sandbox_memory" value=${c.sandbox_environment.memory || '--'} />
-        <${ConfigRow} label="sandbox_pids_limit" value=${String(c.sandbox_environment.pids_limit ?? '--')} />
+        <${ConfigRow} label="sandbox_pids_limit" value=${String(c.sandbox_environment.pids_limit ?? MISSING_DATA_DASH)} />
         <${ConfigRow} label="sandbox_tmpfs_size" value=${c.sandbox_environment.tmpfs_size || '--'} />
         <${ConfigRow} label="sandbox_seccomp_profile" value=${c.sandbox_environment.seccomp_profile || '--'} />
         <${BoolRow} label="require_rootless" value=${c.sandbox_environment.require_rootless} />

--- a/dashboard/src/components/keeper-supervisor-diagnostics.ts
+++ b/dashboard/src/components/keeper-supervisor-diagnostics.ts
@@ -6,6 +6,7 @@ import { html } from 'htm/preact'
 import { formatPct, formatPct1 } from '../lib/format-number'
 import { signal } from '@preact/signals'
 import { formatTimeAgo, SECONDS_PER_MINUTE, SECONDS_PER_HOUR } from '../lib/format-time'
+import { MISSING_DATA_DASH } from '../lib/format-string'
 import { FilterChips } from './common/filter-chips'
 import { PanelCard } from './common/panel-card'
 import { ProgressBar } from './common/progress-bar'
@@ -97,7 +98,7 @@ function SpEventsPanel({ sp_events }: { sp_events?: unknown[] }) {
         ${entries.map((e) => html`
           <div class="flex items-center justify-between py-1 px-2 rounded-[var(--r-1)] text-2xs bg-[var(--purple-12)]">
             <span class="font-mono text-[var(--color-fg-muted)]">${formatTimeAgo(e.ts ?? 0)}</span>
-            <span class="text-[var(--stalled-fg)]">${e.suppressed_count ?? 0}/${e.total ?? 0} 억제 (${e.dominant_cohort ?? '--'})</span>
+            <span class="text-[var(--stalled-fg)]">${e.suppressed_count ?? 0}/${e.total ?? 0} 억제 (${e.dominant_cohort ?? MISSING_DATA_DASH})</span>
           </div>
         `)}
       </div>

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -11,6 +11,7 @@ import type {
   KeeperRuntimeField,
 } from '../../api/dashboard'
 import { fetchDashboardRuntimeProbe } from '../../api/dashboard'
+import { MISSING_DATA_DASH } from '../../lib/format-string'
 import { Btn } from '../btn'
 import { Card } from '../common/card'
 import { StatusChip } from '../common/status-chip'
@@ -402,7 +403,7 @@ function RuntimeTruthPanel({ runtimeResolution }: { runtimeResolution: Dashboard
   const fd = runtimeResolution.fd_accountant
   const fleet = runtimeResolution.fleet_safety
   const fdValue = fd
-    ? `${fd.fd_open ?? '--'} / ${fd.fd_limit ?? '--'}`
+    ? `${fd.fd_open ?? MISSING_DATA_DASH} / ${fd.fd_limit ?? MISSING_DATA_DASH}`
     : '--'
   const fdTone = fd?.pressure_active ? 'bad' : 'neutral'
 
@@ -414,11 +415,11 @@ function RuntimeTruthPanel({ runtimeResolution }: { runtimeResolution: Dashboard
         <${StatusChip} tone=${fdTone} uppercase=${false}>fd ${fdValue}<//>
       </div>
       <div class="grid gap-3 md:grid-cols-2">
-        <${RuntimeMetaRow} label="effective base" value=${runtimeResolution.resolved_base_path.path ?? '--'} />
-        <${RuntimeMetaRow} label="effective .masc" value=${runtimeResolution.data_root.path ?? '--'} />
-        <${RuntimeMetaRow} label="server repo" value=${runtimeResolution.server_repo_path?.path ?? '--'} />
-        <${RuntimeMetaRow} label="executable commit" value=${runtimeResolution.build.commit ?? '--'} />
-        <${RuntimeMetaRow} label="keeper fibers" value=${String(fleet?.keeper_fibers ?? '--')} />
+        <${RuntimeMetaRow} label="effective base" value=${runtimeResolution.resolved_base_path.path ?? MISSING_DATA_DASH} />
+        <${RuntimeMetaRow} label="effective .masc" value=${runtimeResolution.data_root.path ?? MISSING_DATA_DASH} />
+        <${RuntimeMetaRow} label="server repo" value=${runtimeResolution.server_repo_path?.path ?? MISSING_DATA_DASH} />
+        <${RuntimeMetaRow} label="executable commit" value=${runtimeResolution.build.commit ?? MISSING_DATA_DASH} />
+        <${RuntimeMetaRow} label="keeper fibers" value=${String(fleet?.keeper_fibers ?? MISSING_DATA_DASH)} />
         <${RuntimeMetaRow} label="fd pressure" value=${fd?.pressure_active == null ? '--' : fd.pressure_active ? 'active' : 'clear'} />
       </div>
     <//>
@@ -497,8 +498,8 @@ function RuntimeProbePanel() {
       ${probe
         ? html`
             <div class="grid gap-3 md:grid-cols-2">
-              <${RuntimeMetaRow} label="effective model" value=${probe.effective_model ?? '--'} />
-              <${RuntimeMetaRow} label="server" value=${probe.server_url ?? '--'} />
+              <${RuntimeMetaRow} label="effective model" value=${probe.effective_model ?? MISSING_DATA_DASH} />
+              <${RuntimeMetaRow} label="server" value=${probe.server_url ?? MISSING_DATA_DASH} />
               <${RuntimeMetaRow} label="loaded before/after" value=${`${fmtBoolean(probe.model_loaded_before_probe)} / ${fmtBoolean(probe.model_loaded_after_probe)}`} />
               <${RuntimeMetaRow}
                 label="first run load"
@@ -677,9 +678,9 @@ export function ConfigResolutionPanel({
               </div>
 
               <div class="mt-4 grid gap-3 md:grid-cols-2">
-                <${RuntimeMetaRow} label="server repo head" value=${runtimeResolution.server_repo_git_commit ?? '--'} />
-                <${RuntimeMetaRow} label="workspace head" value=${runtimeResolution.workspace_git_commit ?? '--'} />
-                <${RuntimeMetaRow} label="resolved base head" value=${runtimeResolution.resolved_base_git_commit ?? '--'} />
+                <${RuntimeMetaRow} label="server repo head" value=${runtimeResolution.server_repo_git_commit ?? MISSING_DATA_DASH} />
+                <${RuntimeMetaRow} label="workspace head" value=${runtimeResolution.workspace_git_commit ?? MISSING_DATA_DASH} />
+                <${RuntimeMetaRow} label="resolved base head" value=${runtimeResolution.resolved_base_git_commit ?? MISSING_DATA_DASH} />
                 <${RuntimeMetaRow} label="runtime build" value=${runtimeResolution.build.commit ?? runtimeResolution.build.release_version} />
                 <${RuntimeMetaRow} label="started at" value=${runtimeResolution.build.started_at} />
               </div>

--- a/dashboard/src/lib/format-string.ts
+++ b/dashboard/src/lib/format-string.ts
@@ -1,5 +1,18 @@
 // Unified string formatting utilities.
 
+/**
+ * User-visible sentinel string for missing scalar data in panel rows.
+ *
+ * `'--'` is the dashboard's convention for "value not present" in metadata
+ * tables (RuntimeMetaRow, ConfigRow, supervisor cohort summary, fleet
+ * counts, etc.). Captured here so that a future glyph change — e.g.
+ * an em-dash `'—'` for typography polish or a longer label for
+ * accessibility — propagates without sweeping every `?? '--'` callsite
+ * again. Keep this in sync with any user-visible documentation that
+ * shows the literal.
+ */
+export const MISSING_DATA_DASH = '--'
+
 /** Capitalize first character. Returns empty string unchanged. */
 export function capitalize(text: string): string {
   if (!text) return text


### PR DESCRIPTION
## 요약
17 callsite 의 `?? '--'` UI dashboard sentinel literal copy 를 `lib/format-string.ts` 의 `MISSING_DATA_DASH` const SSOT 화. iter#40 (`NO_TIME_INFO`) 패턴의 UI dash 변형.

## 배경

`rg "\?\? '--'" -n` sweep 결과 17 callsite (4 파일) 에서 같은 literal `'--'` 을 *missing scalar data* fallback 으로 사용:

| 파일 | 사용처 |
|---|---|
| `components/fleet-health-panel.ts` | suppressed counter, cohort label |
| `components/tools/config-resolution-panel.ts` | 9 callsite — RuntimeMetaRow values (effective_model, server_url, repo paths, git commits 등) |
| `components/keeper-supervisor-diagnostics.ts` | writer_status |
| `components/keeper-config-panel.ts` | sandbox base_path, project_root, file descriptor counters, pids_limit 등 |

모두 *user-visible dashboard panel row 의 missing value display 규약*. 17 callsite 가 *literal copy* 로 silent coupling — 미래 glyph 변경 (예: em-dash `'—'` 으로 typography polish 또는 더 긴 label 로 accessibility 개선) 시 17 곳 모두 수동 sweep 필요.

## 변경

### `lib/format-string.ts`
- `export const MISSING_DATA_DASH = '--'` 추가
- JSDoc 으로 *dashboard 의 missing-value display 규약* + 4 consumer panel + 미래 glyph 변경 propagation 명시

### 4 consumer 파일
- 각자 `import { MISSING_DATA_DASH } from '../lib/format-string'` 추가
- 17 callsite 의 `?? '--'` → `?? MISSING_DATA_DASH` (sed bulk swap)

## 검증
- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)
- 시각적 변경 0 (`'--'` 그대로 표시)

## iter chain — cross-file string-literal coupling 안티패턴
- iter#19: errorMessage 4-way diverging policy rename (정책 분기 homonym)
- iter#40: `NO_TIME_INFO` sentinel const (lib + comparison callsite)
- iter#41: hex sentinel drift fix (cytoscape TOKEN_FALLBACKS)
- iter#43: discriminated union (type-level invariant 으로 dead fallback 자연 해소)
- iter#45: **`MISSING_DATA_DASH` UI display sentinel** (17 callsite 의 generic missing-value 규약)

같은 안티패턴 class — *cross-file string literal copy* — 의 *user-visible display sentinel* 변형.

## /loop iter#45
SSOT 위반 dashboard 축출 loop 의 iter#45. cumulative 45 PR (29 머지 + 2 OPEN — #19069 + #19?_).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
