### PR TITLE
fix(dashboard): remove unused tool event flag

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -118,7 +118,6 @@ let compute_metrics_window
         let channel = Safe_ops.json_string ~default:"turn" "channel" j in
         let is_turn = channel = "turn" in
         let is_heartbeat = channel = "heartbeat" in
-        let is_tool_event = channel = "tool_event" in
         let is_scheduled_autonomous = channel = "scheduled_autonomous" || channel = "proactive" in
         let is_interaction = is_turn || is_scheduled_autonomous in
         let compacted = Safe_ops.json_bool ~default:false "compacted" j in


### PR DESCRIPTION
## Summary
- remove the stale local is_tool_event binding from dashboard keeper detail metrics
- preserve existing sparse tool_event filtering through metrics_row_has_context_snapshot

## Validation
- ocamlformat --check lib/dashboard/dashboard_http_keeper_detail.ml
- git diff --check
- scripts/dune-local.sh build lib/masc_mcp.cma test/test_dashboard_keeper_metrics_10286.exe
- ./_build/default/test/test_dashboard_keeper_metrics_10286.exe