### PR TITLE
refactor(dashboard): derive status sections from navigation

### DIFF
--- a/dashboard/src/components/status.test.ts
+++ b/dashboard/src/components/status.test.ts
@@ -22,6 +22,12 @@ describe("monitor lane visibility", () => {
 })
 
 describe("normalizeStatusSection", () => {
+  it("accepts every monitoring navigation section", () => {
+    for (const item of sectionItemsForTab("monitoring")) {
+      expect(normalizeStatusSection(item.params.section)).toBe(item.params.section)
+    }
+  })
+
   it("falls back to the monitoring default section", () => {
     expect(normalizeStatusSection("memory-subsystems")).toBe("agents")
     expect(normalizeStatusSection("unknown")).toBe("agents")

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -14,8 +14,13 @@ export type StatusSection =
   | 'feature-health'
   | 'cognition'
 
-function monitorSectionItem(section: StatusSection) {
+function monitorSectionItem(section: string | undefined) {
+  if (!section) return undefined
   return sectionItemsForTab('monitoring').find(item => item.params.section === section)
+}
+
+function isStatusSection(section: string | undefined): section is StatusSection {
+  return monitorSectionItem(section) !== undefined
 }
 
 export function isMonitorLane(section: StatusSection): boolean {
@@ -92,18 +97,7 @@ function renderSection(section: StatusSection) {
 }
 
 export function normalizeStatusSection(section: string | undefined): StatusSection {
-  if (
-    section === 'observatory'
-    || section === 'journey'
-    || section === 'runtime'
-    || section === 'cascade-config'
-    || section === 'fleet-health'
-    || section === 'doctor'
-    || section === 'transport-health'
-    || section === 'feature-health'
-    || section === 'cognition'
-    || section === 'agents'
-  ) return section
+  if (isStatusSection(section)) return section
   return 'agents'
 }
 


### PR DESCRIPTION
## Summary
- Remove the duplicated Status section allowlist from status.ts.
- Validate Status sections against monitoring entries in DASHBOARD_SECTION_ITEMS.
- Extend status tests to assert every monitoring navigation section is accepted.

## Verification
- pnpm vitest run --config vitest.config.ts src/components/status.test.ts src/config/navigation.test.ts src/components/dashboard-shell.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm eslint src/components/status.ts src/components/status.test.ts src/config/navigation.ts src/config/navigation.test.ts src/components/dashboard-shell.test.ts
- git diff --check origin/main