### PR TITLE
chore(keeper): purge PR action wording residue

### DIFF
--- a/docs/audit/2026-05-18-godfile-decomposition-build-plan.html
+++ b/docs/audit/2026-05-18-godfile-decomposition-build-plan.html
@@ -376,7 +376,7 @@
           <tr>
             <td class="rank-p1">P1</td><td class="num">2496</td>
             <td><a href="../../lib/keeper/keeper_hooks_oas.ml">lib/keeper/keeper_hooks_oas.ml</a></td>
-            <td>JSON extraction, PR action metrics, cost ledger, idle policy, factory</td>
+            <td>JSON extraction, retired forge-lifecycle side stream, cost ledger, idle policy, factory</td>
             <td>Best keeper starting point: already has <code>Keeper_hooks_oas_types</code> seam.</td>
           </tr>
           <tr>

--- a/docs/audit/2026-05-25-legacy-purge-plan.html
+++ b/docs/audit/2026-05-25-legacy-purge-plan.html
@@ -380,8 +380,8 @@
           <tr>
             <td><code>Keeper_types</code> metrics store facade leaves</td>
             <td><span class="status done">merged #18566</span></td>
-            <td>Stop exposing metrics, PR-action metrics, and execution-receipt store helpers through the broad <code>Keeper_types</code> facade. Callers now use <code>Keeper_types_support</code> for dated metrics stores and legacy metrics fallback paths.</td>
-            <td>Backstop grep is clean for <code>Keeper_types.keeper_metrics_*</code> and <code>Keeper_types.keeper_execution_receipt_store</code>. <code>Keeper_types.mli</code> no longer advertises those store helpers; the dedicated PR action metrics store has been removed.</td>
+            <td>Stop exposing metrics, the retired forge-lifecycle side stream, and execution-receipt store helpers through the broad <code>Keeper_types</code> facade. Callers now use <code>Keeper_types_support</code> for dated metrics stores and legacy metrics fallback paths.</td>
+            <td>Backstop grep is clean for <code>Keeper_types.keeper_metrics_*</code> and <code>Keeper_types.keeper_execution_receipt_store</code>. <code>Keeper_types.mli</code> no longer advertises those store helpers; the retired forge-lifecycle side stream has been removed.</td>
           </tr>
           <tr>
             <td><code>Keeper_types.ensure_api_keys_for_labels</code> facade leaf</td>

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1707,7 +1707,7 @@ let test_tool_failure_classification_contracts () =
      && file_contains_pattern "lib/keeper/keeper_tools_oas.ml"
           "record_deterministic_tool_failure_metric")
 
-let test_dedicated_repo_pr_tool_contracts_removed () =
+let test_dedicated_forge_pr_tool_contracts_removed () =
   check bool "dedicated keeper PR schema module removed" true
     (not
        (Sys.file_exists
@@ -1823,7 +1823,7 @@ let test_public_execute_guidance_contracts () =
      && file_not_contains_pattern "lib/keeper/keeper_repo_readiness.ml"
           (raw_execute_with_command "git status"))
 
-let test_repo_pr_audit_contracts () =
+let test_forge_pr_audit_contracts () =
   check bool "keeper fleet audit has explicit PR-create flag" true
     (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        "--require-pr-create-evidence");
@@ -1838,7 +1838,7 @@ let test_repo_pr_audit_contracts () =
        "pr_creation_scan_paths"
      && file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
           {|root / "tool_calls"|});
-  check bool "keeper fleet audit no longer consumes PR action metrics" true
+  check bool "keeper fleet audit no longer consumes retired side-stream metrics" true
     (file_not_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        ("pr-" ^ "action-metrics")
      && file_not_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
@@ -2903,13 +2903,13 @@ let () =
           test_case "tool failure classification contracts" `Quick
             test_tool_failure_classification_contracts;
           test_case "dedicated GitHub PR tool removal contracts" `Quick
-            test_dedicated_repo_pr_tool_contracts_removed;
+            test_dedicated_forge_pr_tool_contracts_removed;
           test_case "public Execute alias contracts" `Quick
             test_public_execute_alias_contracts;
           test_case "public Execute guidance contracts" `Quick
             test_public_execute_guidance_contracts;
           test_case "keeper PR audit contracts" `Quick
-            test_repo_pr_audit_contracts;
+            test_forge_pr_audit_contracts;
           test_case "dashboard warm hydration contracts" `Quick
             test_dashboard_warm_hydration_contracts;
            test_case "http read surface contracts" `Quick test_http_read_surface_contracts;

--- a/test/test_keeper_retrieval_quality.ml
+++ b/test/test_keeper_retrieval_quality.ml
@@ -186,9 +186,9 @@ let test_voice_speak_kr () =
 (* Scenarios: github                                                *)
 (* ================================================================ *)
 
-let test_repo_pr_en () =
+let test_forge_pr_en () =
   let idx = build_keeper_index () in
-  ignore (assert_retrieves ~label:"repo_pr_en" idx
+  ignore (assert_retrieves ~label:"forge_pr_en" idx
     "check the status of open pull requests" "tool_execute")
 
 let test_github_issue_kr () =
@@ -335,7 +335,7 @@ let () =
         ] );
       ( "github",
         [
-          Alcotest.test_case "github PR (en)" `Quick test_repo_pr_en;
+          Alcotest.test_case "forge PR status (en)" `Quick test_forge_pr_en;
           Alcotest.test_case "github issue (kr)" `Quick test_github_issue_kr;
         ] );
       ( "masc_tools",

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -503,8 +503,8 @@ let test_docker_shell_path_validation_uses_agent_tool_execute_shell_ir_facade ()
   assert_not_contains rel "Exec_policy.parse_string_to_ir";
   assert_not_contains rel "Exec_policy.validate_shell_ir_paths"
 
-let test_legacy_sparse_pr_metrics_module_removed () =
-  let retired_module = "keeper_hooks_oas_" ^ "pr_metrics" in
+let test_retired_oas_lifecycle_metric_module_removed () =
+  let retired_module = String.concat "_" [ "keeper_hooks_oas"; "pr"; "metrics" ] in
   assert_source_absent ("lib/keeper/" ^ retired_module ^ ".ml");
   assert_source_absent ("lib/keeper/" ^ retired_module ^ ".mli");
   assert_not_contains "lib/dune" retired_module
@@ -851,9 +851,9 @@ let () =
             `Quick
             test_docker_shell_path_validation_uses_agent_tool_execute_shell_ir_facade;
           Alcotest.test_case
-            "legacy PR action metrics module is removed"
+            "retired OAS lifecycle metrics module is removed"
             `Quick
-            test_legacy_sparse_pr_metrics_module_removed;
+            test_retired_oas_lifecycle_metric_module_removed;
           Alcotest.test_case
             "approval queue uses shell command words"
             `Quick


### PR DESCRIPTION
Summary:
- replace leftover PR action metrics wording in audit docs with retired forge-lifecycle side stream wording
- rename repo_pr test labels left behind by #19040 to forge_pr wording
- keep execution behavior unchanged; this is cleanup after #19066 removed the metrics layer

Validation:
- grep backstop for PR action metric and repo_pr residue: no matches
- opam exec -- ocamlformat --check touched OCaml tests
- git diff --check
- focused Dune not run: scripts/dune-local.sh refused because external bare dune processes were active