### PR TITLE
refactor(coord/keeper): Masc_time_constants.hour/day replaces 3600.0/86400.0 literal at 5 sites across 4 files

### DIFF
--- a/lib/coord/coord_task_cache_invariant.ml
+++ b/lib/coord/coord_task_cache_invariant.ml
@@ -18,7 +18,7 @@ type cache_signal_check =
   | Terminal_tasks of stale_terminal_task list
 
 let task_ref_re = lazy (Re.Pcre.re "\\btask-[0-9]+\\b" |> Re.compile)
-let invalidation_memory_ttl_s = 3600.0
+let invalidation_memory_ttl_s = Masc_time_constants.hour
 let invalidation_memory : (string, float) Hashtbl.t = Hashtbl.create 64
 let invalidation_memory_lock = Mutex.create ()
 

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -75,7 +75,7 @@ let tail_decision_log_lines_or_empty path ~max_bytes ~max_lines =
 ;;
 
 let recent_decision_timestamps config ~keeper_name ~now =
-  let cutoff = now -. (float_of_int summary_window_days *. 86400.0) in
+  let cutoff = now -. (float_of_int summary_window_days *. Masc_time_constants.day) in
   candidate_decision_keeper_names keeper_name
   |> List.concat_map (fun candidate ->
     let path = keeper_decision_log_path config candidate in
@@ -518,7 +518,7 @@ let risk_band_of_metrics
   else "high"
 ;;
 
-let summary_cutoff now = now -. (float_of_int summary_window_days *. 86400.0)
+let summary_cutoff now = now -. (float_of_int summary_window_days *. Masc_time_constants.day)
 
 let summary_json_of_snapshots ~keeper_name ~agent_name ~now snapshots =
   let supported_claims = ref 0 in

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -31,7 +31,7 @@ type entry =
 let mu = Eio.Mutex.create ()
 let pending : (string, entry) Hashtbl.t = Hashtbl.create 16
 let counter = Atomic.make 0
-let max_age_sec = 3600.0
+let max_age_sec = Masc_time_constants.hour
 
 let request_dir ~base_path =
   Filename.concat (Common.masc_dir_from_base_path ~base_path) "keeper_msg_requests"

--- a/lib/keeper/keeper_turn_slot_acquire.ml
+++ b/lib/keeper/keeper_turn_slot_acquire.ml
@@ -155,7 +155,7 @@ let holder_table_atomic : float Holder_map.t Atomic.t =
 let force_released_holders : (holder_key, float) Hashtbl.t = Hashtbl.create 32
 let next_holder_acquisition_id = ref 0
 let holder_mutex = Eio.Mutex.create ()
-let force_release_marker_ttl_sec = 3600.0
+let force_release_marker_ttl_sec = Masc_time_constants.hour
 let with_holder_lock f = Eio.Mutex.use_rw ~protect:true holder_mutex f
 let purge_expired_force_released_holders_locked ~now =
   Hashtbl.filter_map_inplace


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" — Magic Number Time-literal 시리즈 (#19037 / #19042 / #19046 / #19058 / #19061 / #19062 / #19072) 후속. **4 파일 / 5 사이트** — `*_sec = 3600.0` named-const 3 + `*. 86400.0` 2.

### Pattern

`Masc_time_constants.hour = 3600.0` + `.day = 86400.0` SSOT 가 *이미* 존재. 본 PR 의 4 파일 모두 root `masc_mcp` library 라 transitive access OK.

before:
```ocaml
(* coord_task_cache_invariant.ml:21 *)
let invalidation_memory_ttl_s = 3600.0

(* keeper_msg_async.ml:34 *)
let max_age_sec = 3600.0

(* keeper_turn_slot_acquire.ml:158 *)
let force_release_marker_ttl_sec = 3600.0

(* keeper_accountability.ml:78, 521 *)
let cutoff = now -. (float_of_int summary_window_days *. 86400.0) in
let summary_cutoff now = now -. (float_of_int summary_window_days *. 86400.0)
```

after:
```ocaml
let invalidation_memory_ttl_s = Masc_time_constants.hour
let max_age_sec = Masc_time_constants.hour
let force_release_marker_ttl_sec = Masc_time_constants.hour

let cutoff = now -. (float_of_int summary_window_days *. Masc_time_constants.day) in
let summary_cutoff now = now -. (float_of_int summary_window_days *. Masc_time_constants.day)
```

5 사이트:
- `lib/coord/coord_task_cache_invariant.ml:21` — invalidation memory TTL (1h)
- `lib/keeper/keeper_msg_async.ml:34` — async msg max age (1h)
- `lib/keeper/keeper_turn_slot_acquire.ml:158` — force-release marker TTL (1h)
- `lib/keeper/keeper_accountability.ml:78` — `recent_decision_timestamps` window
- `lib/keeper/keeper_accountability.ml:521` — `summary_cutoff` function

## 변경

- 4 files, +5/-5
- 동작 무변경

## Magic-number lint impact

- Before: 3 hits `3600.0` + 2 hits `86400.0` = 5
- After: 0

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 5 사이트 *모두* 동시 처리

## Test impact

- 동작 무변경 (`Masc_time_constants.hour = 3600.0`, `.day = 86400.0`)
- `dune build lib/` PASS

## Related

- PR #19037 — `two_days_seconds_int` (172800 int)
- PR #19042 — `one_day_seconds_int` (86400 int)
- PR #19046 — keeper-accountability hour/day (3600.0/86400.0)
- PR #19058 — cascade hour (3600.0)
- PR #19061 — tool_board_format half-migration finishing
- PR #19062 — cascade/board/timeline hour (3600.0)
- PR #19072 — relative-time-format dashboard/tempo hour (3600.0)
- PR #19075 — dashboard dead-code unblock
- `lib/config/masc_time_constants.ml` — time SSOT
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
