### PR TITLE
refactor(dashboard/schemas): extend formatIssues with maxIssues option and migrate actions-activity

### DIFF
--- a/dashboard/src/api/schemas/actions-activity.ts
+++ b/dashboard/src/api/schemas/actions-activity.ts
@@ -31,6 +31,7 @@ import {
   type BaseIssue,
   type InferOutput,
 } from 'valibot'
+import { formatIssues } from './drift-error'
 
 // Node / edge `kind` and `status` stay open `string()`. They're
 // backend-evolved enumerations (new agent kinds, new lifecycle states)
@@ -223,14 +224,7 @@ export class ActionsActivitySchemaDriftError extends Error {
   readonly issues: readonly BaseIssue<unknown>[]
   readonly endpoint: 'graph' | 'swimlane'
   constructor(endpoint: 'graph' | 'swimlane', issues: readonly BaseIssue<unknown>[]) {
-    const summary = issues
-      .slice(0, 3)
-      .map(issue => {
-        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
-        return `${path}: ${issue.message}`
-      })
-      .join('; ')
-    super(`activity ${endpoint} schema drift: ${summary}`)
+    super(`activity ${endpoint} schema drift: ${formatIssues(issues, { maxIssues: 3 })}`)
     this.name = ActionsActivitySchemaDriftError.name
     this.endpoint = endpoint
     this.issues = issues

--- a/dashboard/src/api/schemas/drift-error.ts
+++ b/dashboard/src/api/schemas/drift-error.ts
@@ -18,6 +18,16 @@ import {
   type InferOutput,
 } from 'valibot'
 
+export interface FormatIssuesOptions {
+  /**
+   * Truncate to the first N issues before formatting. Used by noisy
+   * endpoints (e.g. activity graph/swimlane) that should not surface
+   * the full issue list in an Error message — three is enough to spot
+   * the first failure cluster while keeping the log line bounded.
+   */
+  readonly maxIssues?: number
+}
+
 /**
  * Format a valibot issue list as a `; `-joined string of
  * `<dotted.path>: <message>` segments, using `<root>` for issues
@@ -25,9 +35,18 @@ import {
  * `SchemaDriftError` subclasses that build their own summary in a
  * `super(...)` call don't have to inline the same `.map(...).join(';')`
  * block — keeps the `<root>` sentinel and the segment shape in one place.
+ *
+ * `maxIssues` truncates the input before mapping; without it the
+ * whole list is formatted (existing default).
  */
-export function formatIssues(issues: readonly BaseIssue<unknown>[]): string {
-  return issues
+export function formatIssues(
+  issues: readonly BaseIssue<unknown>[],
+  options?: FormatIssuesOptions,
+): string {
+  const limited = options?.maxIssues !== undefined
+    ? issues.slice(0, options.maxIssues)
+    : issues
+  return limited
     .map(issue => {
       const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
       return `${path}: ${issue.message}`


### PR DESCRIPTION
## 요약
`formatIssues` (iter#44 PR #19069 에서 promote) 에 `maxIssues?` 옵션 추가 + `actions-activity.ts` 의 inline truncate variant migration. iter#44 의 *bulk-migrate-then-extend* 패턴 완성.

## 배경

iter#44 (PR #19069 머지) 가 `formatIssues` 를 `drift-error.ts` 에서 named export 로 promote, 7 sibling schema 의 byte-identical inline block 을 migration. 그러나 `actions-activity.ts` 는 *변형* 가졌음:

```ts
const summary = issues
  .slice(0, 3)              // ← memory bound for noisy endpoint
  .map(issue => {
    const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
    return `${path}: ${issue.message}`
  })
  .join('; ')
super(`activity ${endpoint} schema drift: ${summary}`)
```

`.slice(0, 3)` 가 *activity graph/swimlane endpoint 의 noisy 한 issue 리스트 메모리 제한* 의도. iter#44 PR body 에서 *helper option 확장 후 migration* 별도 PR 명시.

## 변경

### `drift-error.ts`
- `export interface FormatIssuesOptions { readonly maxIssues?: number }` 추가
- `formatIssues(issues, options?)` signature — 옵션 없을 때 전체 list 포맷팅 (backward-compatible, iter#44 의 7 callsite 무영향)
- JSDoc 보강: `maxIssues` 가 *noisy endpoint 의 issue cluster bound* 의도 명시 (3 issues 면 first failure cluster 추적 충분 + log line bounded)

### `actions-activity.ts`
- inline 5-line block + `summary` 변수 → `formatIssues(issues, { maxIssues: 3 })` 1-line call
- `import { formatIssues } from './drift-error'` 추가

## iter chain — *bulk-migrate-then-extend*
- iter#44 (PR #19069): formatIssues 9 callsite 중 7 byte-identical migration, 1 variant (actions-activity) 의도적 분리
- iter#46 (본 PR): helper signature 확장 + variant 흡수

같은 패턴이 future iter 에서 재사용 — *처음 migration 시 variant 분리 보존, 후속 PR 에서 helper 확장 + 흡수*. design 점진 진화 SOP.

## 검증

- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)
- 첫 run 2 fail 관찰 → 재실행 1 fail. **6 번째 flaky pair 등장** (iter#34/35/38/40/42/46), vitest worker scheduling 비결정성 패턴. baseline-diff SOP 로 회피.

## /loop iter#46
SSOT 위반 dashboard 축출 loop 의 iter#46. cumulative 46 PR (30 머지 + 1 OPEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
