### PR TITLE
refactor(dashboard): remove status chip label prop

### DIFF
--- a/dashboard/src/components/common/status-chip.a11y.test.ts
+++ b/dashboard/src/components/common/status-chip.a11y.test.ts
@@ -1,10 +1,9 @@
 // @vitest-environment happy-dom
 //
 // jest-axe coverage for StatusChip — pill renders status verdicts
-// across the dashboard. Two API surfaces (legacy `label` prop + modern
-// `children`) plus tone palette + uppercase toggle. Tests guard that
-// every combination remains axe-clean (no aria-prohibited-attr from
-// span chips and no contrast issues at the chip level).
+// across the dashboard. Children content, tone palette, and uppercase
+// toggle stay axe-clean (no aria-prohibited-attr from span chips and no
+// contrast issues at the chip level).
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
@@ -22,11 +21,6 @@ describe('StatusChip a11y', () => {
     document.body.removeChild(container)
   })
 
-  it('legacy label prop passes axe', async () => {
-    render(html`<${StatusChip} label="OK" />`, container)
-    expect(await axe(container)).toHaveNoViolations()
-  })
-
   it('children API passes axe', async () => {
     render(html`<${StatusChip}>Active<//>`, container)
     expect(await axe(container)).toHaveNoViolations()
@@ -35,10 +29,10 @@ describe('StatusChip a11y', () => {
   it('tone variants (semantic enum + raw Tailwind) pass axe', async () => {
     render(
       html`<div>
-        <${StatusChip} label="OK" tone="ok" />
-        <${StatusChip} label="WARN" tone="warn" />
-        <${StatusChip} label="ERR" tone="err" />
-        <${StatusChip} label="custom" tone="bg-[var(--accent-12)] text-white" />
+        <${StatusChip} tone="ok">OK<//>
+        <${StatusChip} tone="warn">WARN<//>
+        <${StatusChip} tone="err">ERR<//>
+        <${StatusChip} tone="bg-[var(--accent-12)] text-white">custom<//>
       </div>`,
       container,
     )

--- a/dashboard/src/components/common/status-chip.test.ts
+++ b/dashboard/src/components/common/status-chip.test.ts
@@ -155,22 +155,6 @@ describe('StatusChip component', () => {
     expect(el.getAttribute('data-status-chip-is-semantic-tone')).toBe('true')
   })
 
-  it('label prop renders when children absent (legacy API)', () => {
-    render(html`<${StatusChip} label="present" />`, container)
-    const el = container.querySelector('[data-status-chip]')!
-    expect(el.textContent).toBe('present')
-    expect(el.getAttribute('data-status-chip-content-source')).toBe('label')
-    expect(el.getAttribute('data-status-chip-label-length')).toBe('7')
-  })
-
-  it('children win over label when both are set', () => {
-    render(html`<${StatusChip} label="legacy">actual<//>`, container)
-    const el = container.querySelector('[data-status-chip]')!
-    expect(el.textContent).toBe('actual')
-    expect(el.getAttribute('data-status-chip-content-source')).toBe('children')
-    expect(el.getAttribute('data-status-chip-label-length')).toBe('6')
-  })
-
   it('data-status-chip-tone reflects tone prop', () => {
     render(html`<${StatusChip} tone="warn">heads up<//>`, container)
     expect(container.querySelector('[data-status-chip]')!.getAttribute('data-status-chip-tone')).toBe('warn')
@@ -211,15 +195,14 @@ describe('StatusChip component', () => {
       uppercase: true,
       hasCustomClass: false,
       hasTestId: false,
-      labelLength: 0,
       classNameLength: 0,
       testIdLength: 0,
     })
   })
 
-  it('summarizes raw-tone label status chip state', () => {
+  it('summarizes raw-tone children status chip state', () => {
     expect(summarizeStatusChip({
-      label: 'custom',
+      children: 'custom',
       tone: 'bg-[var(--accent-12)]',
       className: 'ml-2',
       uppercase: false,
@@ -227,20 +210,12 @@ describe('StatusChip component', () => {
     })).toEqual({
       tone: 'bg-[var(--accent-12)]',
       isSemanticTone: false,
-      contentSource: 'label',
+      contentSource: 'children',
       uppercase: false,
       hasCustomClass: true,
       hasTestId: true,
-      labelLength: 6,
       classNameLength: 4,
       testIdLength: 11,
     })
-  })
-
-  it('summarizes children content as taking precedence over label', () => {
-    expect(summarizeStatusChip({
-      label: 'legacy',
-      children: 'actual',
-    }).contentSource).toBe('children')
   })
 })

--- a/dashboard/src/components/common/status-chip.ts
+++ b/dashboard/src/components/common/status-chip.ts
@@ -49,7 +49,7 @@ export type StatusChipTone =
   | 'select'
   | ''
 
-export type StatusChipContentSource = 'children' | 'label' | 'empty'
+export type StatusChipContentSource = 'children' | 'empty'
 
 export interface StatusChipSummary {
   readonly tone: string
@@ -58,7 +58,6 @@ export interface StatusChipSummary {
   readonly uppercase: boolean
   readonly hasCustomClass: boolean
   readonly hasTestId: boolean
-  readonly labelLength: number
   readonly classNameLength: number
   readonly testIdLength: number
 }
@@ -170,25 +169,19 @@ function hasChildrenContent(children: ComponentChildren | undefined): boolean {
 }
 
 export function summarizeStatusChip({
-  label,
   tone = '',
   className,
   uppercase = true,
   children,
   testId,
 }: {
-  label?: string
   tone?: string
   className?: string
   uppercase?: boolean
   children?: ComponentChildren
   testId?: string
 }): StatusChipSummary {
-  const contentSource = hasChildrenContent(children)
-    ? 'children'
-    : label !== undefined
-      ? 'label'
-      : 'empty'
+  const contentSource = hasChildrenContent(children) ? 'children' : 'empty'
 
   return {
     tone,
@@ -197,16 +190,12 @@ export function summarizeStatusChip({
     uppercase,
     hasCustomClass: className !== undefined && className !== '',
     hasTestId: testId !== undefined && testId !== '',
-    labelLength: label?.length ?? 0,
     classNameLength: className?.length ?? 0,
     testIdLength: testId?.length ?? 0,
   }
 }
 
 export interface StatusChipProps {
-  /** Legacy API — plain text label. Prefer `children` for new
-      call sites. When both are set, `children` wins. */
-  label?: string
   /** One of the semantic enum members, OR a raw Tailwind class
       string (e.g. the output of `verdictTone()`). Both are valid. */
   tone?: string
@@ -222,7 +211,6 @@ export interface StatusChipProps {
 }
 
 export function StatusChip({
-  label,
   tone = '',
   class: cx,
   uppercase = true,
@@ -230,7 +218,6 @@ export function StatusChip({
   testId,
 }: StatusChipProps) {
   const summary = summarizeStatusChip({
-    label,
     tone,
     className: cx,
     uppercase,
@@ -238,7 +225,7 @@ export function StatusChip({
     testId,
   })
   const cls = statusChipClasses(tone, cx, uppercase)
-  const content = summary.contentSource === 'children' ? children : label ?? ''
+  const content = summary.contentSource === 'children' ? children : ''
   return html`<span
     class=${cls}
     data-status-chip
@@ -248,7 +235,6 @@ export function StatusChip({
     data-status-chip-uppercase=${summary.uppercase ? 'true' : 'false'}
     data-status-chip-has-custom-class=${summary.hasCustomClass}
     data-status-chip-has-test-id=${summary.hasTestId}
-    data-status-chip-label-length=${summary.labelLength}
     data-status-chip-class-length=${summary.classNameLength}
     data-status-chip-test-id-length=${summary.testIdLength}
     data-testid=${testId}

--- a/dashboard/src/components/tlc-results-panel.test.ts
+++ b/dashboard/src/components/tlc-results-panel.test.ts
@@ -54,8 +54,8 @@ vi.mock('./common/feedback-state', () => ({
 }))
 
 vi.mock('./common/status-chip', () => ({
-  StatusChip: ({ tone, label, children }: any) => html`
-    <span data-testid="status-chip" data-tone=${tone}>${children ?? label}</span>
+  StatusChip: ({ tone, children }: any) => html`
+    <span data-testid="status-chip" data-tone=${tone}>${children}</span>
   `,
 }))
 

--- a/dashboard/src/components/tlc-results-panel.ts
+++ b/dashboard/src/components/tlc-results-panel.ts
@@ -183,10 +183,10 @@ function ResultsTable({ entries }: { entries: TlcResultEntry[] }) {
               <td class="py-1 pr-4 font-medium text-[var(--color-fg-primary)]">${entry.spec_name}</td>
               <td class="py-1 pr-4 font-mono text-[var(--color-fg-muted)]">${entry.cfg_name}</td>
               <td class="py-1 pr-4">
-                <${StatusChip} tone=${categoryTone(entry.category)} label=${categoryLabel(entry.category)} />
+                <${StatusChip} tone=${categoryTone(entry.category)}>${categoryLabel(entry.category)}<//>
               </td>
               <td class="py-1 pr-4">
-                <${StatusChip} tone=${tlcStatusTone(entry.status)} label=${tlcStatusLabel(entry.status)} />
+                <${StatusChip} tone=${tlcStatusTone(entry.status)}>${tlcStatusLabel(entry.status)}<//>
               </td>
               <td class="py-1 pr-4 text-right text-[var(--color-fg-secondary)]">${formatTlcMetric(entry.states_explored)}</td>
               <td class="py-1 pr-4 text-right text-[var(--color-fg-secondary)]">${formatTlcMetric(entry.distinct_states)}</td>

--- a/dashboard/src/components/verification-specs-panel.ts
+++ b/dashboard/src/components/verification-specs-panel.ts
@@ -96,10 +96,10 @@ function SpecsTable({ entries }: { entries: TlaSpecEntry[] }) {
               <tr class="border-t border-[var(--color-border-default)]">
                 <td class="py-1 pr-4 font-medium text-[var(--color-fg-primary)]">${entry.name}</td>
                 <td class="py-1 pr-4">
-                  <${StatusChip} tone=${categoryTone(entry.category)} label=${categoryLabel(entry.category)} />
+                  <${StatusChip} tone=${categoryTone(entry.category)}>${categoryLabel(entry.category)}<//>
                 </td>
                 <td class="py-1 pr-4">
-                  <${StatusChip} tone=${cov.tone} label=${cov.label} />
+                  <${StatusChip} tone=${cov.tone}>${cov.label}<//>
                 </td>
                 <td class="py-1 pr-4 font-mono text-[var(--color-fg-muted)]">${entry.path}</td>
                 <td class="py-1 text-[var(--color-fg-muted)]">${shortMtime(entry.mtime_iso)}</td>


### PR DESCRIPTION
## Summary
- Remove the legacy StatusChip label prop and label-specific metadata.
- Migrate remaining StatusChip call sites to children content.
- Drop legacy label API component and a11y tests.

## Verification
- pnpm vitest run --config vitest.config.ts src/components/common/status-chip.test.ts src/components/common/status-chip.a11y.test.ts src/components/tlc-results-panel.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm eslint src/components/common/status-chip.ts src/components/common/status-chip.test.ts src/components/common/status-chip.a11y.test.ts src/components/verification-specs-panel.ts src/components/tlc-results-panel.ts src/components/tlc-results-panel.test.ts
- git diff --check origin/main