### PR TITLE
perf(dashboard/cascade): cache 4 hot endpoints (21s→cached, 4s→cached)

### DIFF
--- a/lib/dashboard_cascade_capacity.ml
+++ b/lib/dashboard_cascade_capacity.ml
@@ -30,7 +30,7 @@ let client_capacity_entry_to_json ((url, info) : string * Cascade_throttle.capac
     ]
 ;;
 
-let client_capacity_json () =
+let client_capacity_json_compute () =
   let entries = Cascade_client_capacity.snapshot () in
   (* Stable ordering by (kind, key) so the dashboard table doesn't
      reshuffle on every poll.  Hashtbl iteration is unordered, so we
@@ -56,9 +56,17 @@ let client_capacity_json () =
           ~scope:"cascade_client_capacity"
           ~producer:"Cascade_client_capacity.register"
           ~store_kind:"process_registry"
-          ~cache_policy:"uncached; reads the live process-local registry" () )
+          ~cache_policy:"2s ttl + stale-while-revalidate via Dashboard_cache" () )
     ; "entries", `List (List.map client_capacity_entry_to_json sorted)
     ]
+;;
+
+(* Snapshot of a live process-local registry; measured 4s/call against a
+   populated registry. Short TTL keeps dashboard reads near-live while
+   absorbing burst polls. *)
+let client_capacity_json () =
+  Dashboard_cache.get_or_compute "cascade:client_capacity" ~ttl:2.0
+    client_capacity_json_compute
 ;;
 
 (* ── Client capacity history projection ─────────────────── *)

--- a/lib/dashboard_cascade_config.ml
+++ b/lib/dashboard_cascade_config.ml
@@ -421,7 +421,9 @@ let save_config_file path content =
    sibling -- there isn't one -- and [raw_json_editable] is gone from the
    schema along with the JSON-native authoring mode it described.
    [raw_json] is rendered in memory from the TOML SSOT on each request. *)
-let raw_config_json () =
+let raw_config_cache_key = "cascade:config:raw"
+
+let raw_config_json_compute () =
   Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
   let source : Cascade_toml_materializer.source_info = source_info () in
   let source_read_error = ref None in
@@ -470,6 +472,14 @@ let raw_config_json () =
     ]
 ;;
 
+(* Wrap [raw_config_json_compute] with [Dashboard_cache]: TOML→JSON render
+   measured at 21s/call on a populated cascade. Long TTL is safe because
+   writes go through [save_raw_config_json] which invalidates the entry. *)
+let raw_config_json () =
+  Dashboard_cache.get_or_compute raw_config_cache_key ~ttl:60.0
+    raw_config_json_compute
+;;
+
 (* RFC-0058 §9 Phase 9.3: dashboard save accepts only TOML payloads now;
    the JSON-native save branch is gone. The save persists the TOML file
    and invalidates the cascade loader's cache. Subsequent reads re-render
@@ -488,6 +498,7 @@ let save_raw_config_json raw_json =
             [Cascade_catalog_runtime] both key their caches on
             [source.source_path] (the TOML path). *)
          invalidate_cascade_config source.source_path;
+         Dashboard_cache.invalidate raw_config_cache_key;
          Ok (config_json ())
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/dashboard_cascade_health_json.ml
+++ b/lib/dashboard_cascade_health_json.ml
@@ -71,7 +71,7 @@ let declared_provider_schemes_of_config ?config_path () : string list =
     Errors from the aggregator (corrupt jsonl, missing directory) are
     caught and the perf fields fall back to [null]; a broken log must
     not take down the dashboard. *)
-let health_json ?(window_minutes = 30) ?(base_path : string option) () =
+let health_json_compute ?(window_minutes = 30) ?(base_path : string option) () =
   let config_path = Cascade_runtime.cascade_config_path () in
   let declared = declared_provider_schemes_set ?config_path () in
   let tracked = Health.all_providers Health.global in
@@ -151,4 +151,17 @@ let health_json ?(window_minutes = 30) ?(base_path : string option) () =
       ( "recommendations"
       , `List (List.map recommendation_to_json (low_trust_recommendations tracked)) )
     ]
+;;
+
+(* Recompute is dominated by [Model_inference_metrics.compute] which scans
+   the full inference log over [window_minutes]; measured 1s/call on a
+   busy cluster. TTL keyed on (window_minutes, base_path) so different
+   dashboards see independent caches. *)
+let health_json ?(window_minutes = 30) ?(base_path : string option) () =
+  let key =
+    Printf.sprintf "cascade:health:%d:%s" window_minutes
+      (Option.value ~default:"" base_path)
+  in
+  Dashboard_cache.get_or_compute key ~ttl:10.0 (fun () ->
+    health_json_compute ~window_minutes ?base_path ())
 ;;

--- a/lib/dashboard_cascade_slo.ml
+++ b/lib/dashboard_cascade_slo.ml
@@ -22,7 +22,7 @@ let compute_slo_counts (events : Cascade_strategy_trace.event list) =
     events
 ;;
 
-let slo_json () =
+let slo_json_compute () =
   let events = Cascade_strategy_trace.snapshot ~limit:slo_sample_limit () in
   let total, ordered, exhausted = compute_slo_counts events in
   let ordered_ratio =
@@ -66,4 +66,11 @@ let slo_json () =
     ; "status", `String status
     ; "violations", `List violations
     ]
+;;
+
+(* Strategy trace events folded over [slo_sample_limit]; measured 3s/call
+   against a busy trace ring. Short TTL because SLO status is polled by
+   the dashboard top bar at a high cadence. *)
+let slo_json () =
+  Dashboard_cache.get_or_compute "cascade:slo" ~ttl:5.0 slo_json_compute
 ;;


### PR DESCRIPTION
## Summary

dashboard cascade subsystem 의 4 hot endpoint 가 cache 없이 호출되어 *user-visible* 페인 (21s/4s/3s/1s). 본 PR 은 `Dashboard_cache` 로 wrap, write-rate 에 맞춘 TTL 차등 + explicit invalidate.

## Fleet Measurement (2026-05-27 18:50, server PID 76042)

직접 curl 측정:

| Endpoint | Latency | TTL |
|---|---|---|
| `/api/v1/cascade/config/raw` | **21.64s** | 60s + explicit invalidate |
| `/api/v1/cascade/client_capacity` | **4.02s** | 2s |
| `/api/v1/cascade/slo` | **3.09s** | 5s |
| `/api/v1/cascade/health` | **1.01s** | 10s |

각 compute path:
- `raw_config_json`: TOML → JSON materialize on **every request** (주석에 "rendered in memory ... on each request" 의도 명시)
- `client_capacity_json`: `Cascade_client_capacity.snapshot ()` + sort
- `slo_json`: `Cascade_strategy_trace.snapshot ~limit` + fold
- `health_json`: 30-min `Model_inference_metrics.compute` aggregate

## Design

**Function-level cache** (self-contained, route handler 무수정):
- `raw_config_json` ← wraps `raw_config_json_compute`. 별도 export `raw_config_cache_key` 로 `save_raw_config_json` 가 explicit invalidate.
- `client_capacity_json` ← wraps `client_capacity_json_compute`. key `"cascade:client_capacity"`.
- `slo_json` ← wraps `slo_json_compute`. key `"cascade:slo"`.
- `health_json` ← wraps `health_json_compute`. key `"cascade:health:%d:%s"` (window_minutes + base_path).

**TTL 선정 근거** (write-rate 기반):
- `raw_config`: TOML 파일 저장 시에만 변경 → long TTL + explicit invalidate
- `client_capacity`: process-local registry 가 fiber acquire/release 마다 변경 → near-live 필요, 2s
- `slo`: top-bar 지표라 dashboard 가 aggressive poll, 5s
- `health`: provider inference metrics 가 minute-scale, 10s

**Stale-while-revalidate** (Dashboard_cache 기본 동작): expired 후 `ttl * 3` 동안 stale 값 반환 + background recompute. user-visible latency 0 (cache hit).

## Workaround Signature Gate

- ❌ counter-as-fix: cache 는 *latency reduction*, counter 추가 아님
- ❌ substring/dispatch 분류기: typed key string literal, classifier 추가 아님
- ❌ N-of-M patch: ✅ same pattern as #19023..#19060 (dashboard perf wraps) — cascade 는 **마지막 cache 미적용 hot read-path** subsystem. 이전 PR 들과 *별개 subsystem* (cascade module = TOML config + provider health + SLO + capacity).
- ❌ cap/cooldown/dedup/repair symptom 억제: cache 는 dedup 의 한 형태지만 ttl-based perf optimization 으로 RFC scope 아님 (이전 wrap PR 들 머지 선례).

## Build

```
$ dune build --root . @check; echo "EXIT=$?"
EXIT=0
```

## Test plan

- [ ] CI build PASS
- [ ] 서버 재시작 후 `time curl http://localhost:8937/api/v1/cascade/config/raw` < 1s (cache hit)
- [ ] `save_raw_config_json` 호출 후 다음 `raw_config_json` read 가 새 값 (invalidate 검증)
- [ ] `cascade/client_capacity` 가 2s 안에 응답
- [ ] dashboard 의 Network 탭에서 위 4 endpoint pending → 즉시 응답

## Related

- PR #19023 dashboard/perf cache
- PR #19024 governance cache
- PR #19025 goal_loop status cache
- PR #19027 verification list_requests cache (mtime-keyed)
- PR #19029 operator snapshot cache (key fix)
- PR #19031 namespace_truth fallback cache
- PR #19060 task history cache
- 본 PR — cascade subsystem (config/raw/health/capacity/slo)
