### PR TITLE
refactor(governance/dashboard/server): Masc_time_constants.hour/day replaces 3600.0/86400.0 literal at 6 sites across 3 files

### DIFF
--- a/lib/dashboard/dashboard_keeper_decision_log_proof.ml
+++ b/lib/dashboard/dashboard_keeper_decision_log_proof.ml
@@ -11,7 +11,7 @@ type turn_span_stat = {
   latest_ts : float option;
 }
 
-let seconds_per_hour = 3600.0
+let seconds_per_hour = Masc_time_constants.hour
 let persistent_turn_window_hours = 24.0
 let recent_turn_max_age_hours = 24.0
 let decision_tail_max_bytes = 512 * 1024

--- a/lib/governance_anomaly.ml
+++ b/lib/governance_anomaly.ml
@@ -80,7 +80,7 @@ let batch_span_hours entries =
             (min min_t t, max max_t t))
           (first_t, first_t) rest
       in
-      let span_h = (max_t -. min_t) /. 3600.0 in
+      let span_h = (max_t -. min_t) /. Masc_time_constants.hour in
       max span_h 0.0167
 
 let activity_volume_of_batch entries =
@@ -136,7 +136,7 @@ let batch_entries ~batch_hours entries =
     let sorted =
       List.sort (fun a b -> Float.compare a.Audit_log.timestamp b.Audit_log.timestamp) entries
     in
-    let span_sec = float_of_int batch_hours *. 3600.0 in
+    let span_sec = float_of_int batch_hours *. Masc_time_constants.hour in
     let rec split batch_start batch_acc acc = function
       | [] ->
           let final = List.rev batch_acc in
@@ -161,7 +161,7 @@ let build_profile ~config ~agent_id ~window_days =
   in
   if List.length entries < 3 then None
   else
-    let cutoff = Unix.gettimeofday () -. (float_of_int window_days *. 86400.0) in
+    let cutoff = Unix.gettimeofday () -. (float_of_int window_days *. Masc_time_constants.day) in
     let recent = List.filter (fun e -> e.Audit_log.timestamp >= cutoff) entries in
     if List.length recent < 3 then None
     else
@@ -410,7 +410,7 @@ let check_agent ~config ~agent_id ~window_days ~threshold =
     | None -> None
     | Some profile ->
         save_profile ~base_path:config.Coord.base_path profile;
-        let cutoff = Unix.gettimeofday () -. 3600.0 in
+        let cutoff = Unix.gettimeofday () -. Masc_time_constants.hour in
         let recent = List.filter (fun e -> e.Audit_log.timestamp >= cutoff) entries in
         let deviations = detect_deviations ~profile ~entries:recent ~threshold in
         let overall_risk = List.fold_left (fun acc d -> max_risk acc d.severity) Low deviations in

--- a/lib/server/server_dashboard_http_link_preview.ml
+++ b/lib/server/server_dashboard_http_link_preview.ml
@@ -14,7 +14,7 @@ type cache_payload = {
   expires_at : float;
 }
 
-let cache_ttl_sec = 3600.0
+let cache_ttl_sec = Masc_time_constants.hour
 let error_ttl_sec = 300.0
 let max_preview_urls = 8
 let preview_timeout_sec = 5.0


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" — Magic Number Time-literal 시리즈 **10번째 PR**. **3 파일 / 6 사이트** — governance_anomaly (4 sites, single file) + 2 named-const single-site files.

### 변경 카테고리

**1. governance_anomaly.ml (4 sites)** — 다양한 시간 변환 (hour/day):
```ocaml
(* L83 *) let span_h = (max_t -. min_t) /. 3600.0 in
(* L139 *) let span_sec = float_of_int batch_hours *. 3600.0 in
(* L164 *) let cutoff = Unix.gettimeofday () -. (float_of_int window_days *. 86400.0) in
(* L413 *) let cutoff = Unix.gettimeofday () -. 3600.0 in
```
→ 모두 `Masc_time_constants.hour` / `.day`

**2. dashboard_keeper_decision_log_proof.ml:14** — local-named alias:
```ocaml
let seconds_per_hour = 3600.0
```
→ `let seconds_per_hour = Masc_time_constants.hour`

local 이름 (`seconds_per_hour`) 은 *in-file readability* 위해 유지. SSOT 가 값을 제공.

**3. server_dashboard_http_link_preview.ml:17** — TTL named-const:
```ocaml
let cache_ttl_sec = 3600.0
```
→ `let cache_ttl_sec = Masc_time_constants.hour`

## 변경

- 3 files, +6/-6
- 5 hour-substitutions + 1 day-substitution
- 동작 무변경

## Magic-number lint impact

- Before: 5 `3600.0` + 1 `86400.0` = 6
- After: 0

## Out-of-scope

`lib/governance_anomaly.ml:84` 의 `0.0167` (= 1/60h = 1분) 은 *기본 fallback 값 (정밀도용)* — single-use, 의미가 *명백한 수치* 라 sw-dev §"Magic Number 금지" exception 적용. 본 PR 미터치.

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 6 사이트 *모두* 동시 처리

## Test impact

- 동작 무변경
- `dune build lib/` PASS

## Related

- PR #19037 / #19042 / #19046 / #19058 / #19061 / #19062 / #19072 / #19084 / #19086 — Magic Number Time-literal 시리즈 누적 1–9
- `lib/config/masc_time_constants.ml` — time SSOT
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
