### PR TITLE
refactor(keeper): remove repo probe fallback surface

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -636,9 +636,6 @@ let fallback_floor_tool_names =
       Keeper Board_get;
     ]
 
-let fallback_repo_probe_tool_names =
-  tool_names Tool_name.[ Keeper Fs_read; Keeper Search_files; Keeper Execute ]
-
 let is_claim_tool_name name =
   Keeper_tool_progress.is_claim_tool_name name
 

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -293,8 +293,6 @@ val tool_names : Tool_name.t list -> string list
 
 val fallback_floor_tool_names : string list
 
-val fallback_repo_probe_tool_names : string list
-
 (** Re-export of [Keeper_tool_progress.is_claim_tool_name]. *)
 val is_claim_tool_name : string -> bool
 

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -520,14 +520,7 @@ let prepare_agent_setup
     validated
   in
   let fallback_tool_surface ~turn =
-    let repo_probe =
-      fallback_repo_probe_tool_names
-      |> List.find_opt (fun name ->
-        Keeper_tool_policy.StringSet.mem name universe_set
-        && Keeper_tool_policy.StringSet.mem name allowed_exec_set)
-      |> Option.to_list
-    in
-    validate_allow_list ~turn (fallback_floor_tool_names @ repo_probe)
+    validate_allow_list ~turn fallback_floor_tool_names
   in
   let tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn ~allowed_tool_names =
     let caller_requires_tools =

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -391,6 +391,13 @@ let test_last_turn_safe_keeps_discovery_and_web_search () =
   check bool "last turn allows SearchWeb alias" true (has_tool "SearchWeb" alias_expanded)
 ;;
 
+let test_fallback_floor_has_no_implicit_repo_tools () =
+  let floor = Keeper_agent_tool_surface.fallback_floor_tool_names in
+  check bool "fallback floor omits Execute" false (List.mem "tool_execute" floor);
+  check bool "fallback floor omits SearchFiles" false (List.mem "tool_search_files" floor);
+  check bool "fallback floor omits ReadFile" false (List.mem "tool_read_file" floor)
+;;
+
 let test_core_coordination_presets_have_task_lifecycle_tools () =
   [ "social", Keeper_types.Social; "messaging", Keeper_types.Messaging ]
   |> List.iter (fun (label, preset) ->
@@ -1304,6 +1311,10 @@ let () =
             "last turn keeps discovery and web search"
             `Quick
             test_last_turn_safe_keeps_discovery_and_web_search
+        ; test_case
+            "fallback floor has no implicit repo tools"
+            `Quick
+            test_fallback_floor_has_no_implicit_repo_tools
         ; test_case
             "core coordination presets have task lifecycle tools"
             `Quick


### PR DESCRIPTION
Summary:
- remove the fallback repo-probe tool list that injected Read/Search/Execute when the computed tool surface was empty
- keep the fallback floor limited to control-plane/context tools
- add a tool exposure test locking Execute/SearchFiles/ReadFile out of fallback floor

Validation:
- rg fallback_repo_probe/repo_probe residue: no matches
- opam exec -- ocamlformat --check touched OCaml files
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_keeper_tool_exposure.exe --cache=disabled (blocked: wrapper refused because external bare dune processes were active)