### PR TITLE
refactor(dashboard/server/voice): Masc_time_constants.hour/day replaces 3600.0/86400.0 literal at 12 sites across 10 files

### DIFF
--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -267,7 +267,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
              Printf.sprintf "자율 턴 없음 (턴 %d회 수행)" turn_count)
           else if effective_activity_age_s >= keeper_action_stale_sec then
             (Exec_warning, Tone_warn,
-             Printf.sprintf "마지막 활동 %.0f시간 전" (effective_activity_age_s /. 3600.0))
+             Printf.sprintf "마지막 활동 %.0f시간 전" (effective_activity_age_s /. Masc_time_constants.hour))
           else
             (Exec_healthy, Tone_ok, "정상 동작 중")
   in

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -83,7 +83,7 @@ let max_runtime_events = 12
 let max_recent_verdicts = 8
 let max_signal_scan = 500
 let runtime_stale_after_s = 30. *. 60.
-let evaluator_stale_after_s = 12. *. 3600.
+let evaluator_stale_after_s = 12. *. Masc_time_constants.hour
 
 (** Runtime health warning thresholds. Distinct from compaction thresholds.
     Values sourced from [Env_config_keeper.DashboardHealth]. *)

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -682,7 +682,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                   (Keeper_status_runtime.keeper_surface_status ~agent_status:agent
                      ~diagnostic) );
               ("keeper_age_s", `Float keeper_age_s);
-              ("uptime_hours", `Float (keeper_age_s /. 3600.0));
+              ("uptime_hours", `Float (keeper_age_s /. Masc_time_constants.hour));
               ("last_turn_ago_s", `Float last_turn_ago_s);
               ("last_handoff_ago_s", `Float last_handoff_ago_s);
               ("last_compaction_ago_s", `Float last_compaction_ago_s);

--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -236,7 +236,7 @@ let metrics_row_has_context_snapshot (j : Yojson.Safe.t) : bool =
 let keeper_metrics_24h_json
     ~(metrics_lines : string list)
     ~(now_ts : float) : Yojson.Safe.t * Yojson.Safe.t =
-  let window_sec = 24.0 *. 3600.0 in
+  let window_sec = Masc_time_constants.day in
   let start_ts = now_ts -. window_sec in
   let lines = metrics_lines in
   let buckets : (int, keeper_24h_bucket_stats) Hashtbl.t = Hashtbl.create 64 in
@@ -253,7 +253,7 @@ let keeper_metrics_24h_json
         then begin
           incr sample_points;
           let bucket_ts =
-            int_of_float (floor (ts_unix /. 3600.0) *. 3600.0)
+            int_of_float (floor (ts_unix /. Masc_time_constants.hour) *. Masc_time_constants.hour)
           in
           let b =
             match Hashtbl.find_opt buckets bucket_ts with

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -13,7 +13,7 @@ open Dashboard_http_helpers
 let tool_call_health_json ?(now_ts = Unix.gettimeofday ()) (config : Coord.config)
     : Yojson.Safe.t =
   let window_hours = 1.0 in
-  let since = now_ts -. (window_hours *. 3600.0) in
+  let since = now_ts -. (window_hours *. Masc_time_constants.hour) in
   let entries =
     try Audit_log.read_entries ~n:50_000 config
     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
@@ -118,7 +118,7 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
     let new_posts_24h =
       List.fold_left
         (fun acc (p : Board.post) ->
-          if p.created_at >= (now_ts -. (24.0 *. 3600.0)) then acc + 1 else acc)
+          if p.created_at >= (now_ts -. Masc_time_constants.day) then acc + 1 else acc)
         0 posts
     in
     let unanswered_posts =

--- a/lib/dashboard/dashboard_keeper_feature_proof.ml
+++ b/lib/dashboard/dashboard_keeper_feature_proof.ml
@@ -332,7 +332,7 @@ let timestamp_within_window ?window_hours ~now ts =
        top-level [json] helper clamps callers' inputs to a sane domain;
        this keeps internal logic robust if a caller bypasses the boundary. *)
     true
-  | Some hours -> now -. ts <= hours *. 3600.0
+  | Some hours -> now -. ts <= hours *. Masc_time_constants.hour
 
 let scheduled_proactive_feature ~config ?window_hours ~now snapshots =
   let decision_stats =

--- a/lib/server/host_fd_pressure_poller.ml
+++ b/lib/server/host_fd_pressure_poller.ml
@@ -148,7 +148,7 @@ let last_warn_log_at = Atomic.make 0.0
 let log_throttled_warn (mk_msg : unit -> string) =
   let now = Time_compat.now () in
   let last = Atomic.get last_warn_log_at in
-  if now -. last >= 3600.0 && Atomic.compare_and_set last_warn_log_at last now
+  if now -. last >= Masc_time_constants.hour && Atomic.compare_and_set last_warn_log_at last now
   then Log.Server.warn "%s" (mk_msg ())
 ;;
 

--- a/lib/server/server_dashboard_http_agent_api.ml
+++ b/lib/server/server_dashboard_http_agent_api.ml
@@ -18,7 +18,7 @@ let add_agent_api_routes router =
            | Some h -> Option.value ~default:24.0 (float_of_string_opt h)
            | None -> 24.0
          in
-         let since = Time_compat.now () -. (hours *. 3600.0) in
+         let since = Time_compat.now () -. (hours *. Masc_time_constants.hour) in
          let activities =
            Telemetry_eio.summarize_agent_activity state.Mcp_server.room_config ~since
          in

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -115,7 +115,7 @@ let handle_keeper_get_subroutes state req request reqd =
           ~default:24
         |> max 1 |> min 168  (* 1h .. 7d *)
       in
-      let since = Time_compat.now () -. (float_of_int window_hours *. 3600.0) in
+      let since = Time_compat.now () -. (float_of_int window_hours *. Masc_time_constants.hour) in
       let read_result =
         Trajectory.read_entries_since_result ~masc_root ~keeper_name:name ~since
       in

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -159,7 +159,7 @@ let cleanup_old_audio_files () =
   if Sys.file_exists dir && Sys.is_directory dir
   then (
     let now = Time_compat.now () in
-    let cutoff = now -. 3600.0 in
+    let cutoff = now -. Masc_time_constants.hour in
     let entries = Sys.readdir dir in
     let removed = ref 0 in
     Array.iter


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" — Magic Number Time-literal 시리즈 **11번째 PR**. **10 파일 / 12 사이트** — dashboard + server + voice 모듈에 흩어진 마지막 큰 cluster.

### 패턴

10 hour-substitutions + 2 day-substitutions. `24.0 *. 3600.0` 표현 2건이 *바로* `Masc_time_constants.day` 로 collapse — 단일 SSOT 호출로 더 명료.

before (대표):
```ocaml
(* dashboard_http_monitoring.ml:16 *)    let since = now_ts -. (window_hours *. 3600.0) in
(* dashboard_http_monitoring.ml:121 *)   if p.created_at >= (now_ts -. (24.0 *. 3600.0)) then ...
(* dashboard_http_keeper_metrics.ml:239 *)  let window_sec = 24.0 *. 3600.0 in
(* dashboard_http_keeper_metrics.ml:256 *)  int_of_float (floor (ts_unix /. 3600.0) *. 3600.0)
(* dashboard_harness_health.ml:86 *)     let evaluator_stale_after_s = 12. *. 3600.
(* host_fd_pressure_poller.ml:151 *)     if now -. last >= 3600.0 && ...
(* voice_bridge.ml:162 *)                let cutoff = now -. 3600.0 in
```

after (SSOT 호출):
```ocaml
*. Masc_time_constants.hour
-. Masc_time_constants.day
= Masc_time_constants.day
floor (... /. Masc_time_constants.hour) *. Masc_time_constants.hour
12. *. Masc_time_constants.hour
>= Masc_time_constants.hour
-. Masc_time_constants.hour
```

12 사이트 (3600.0 × 10 + 86400.0 × 2):
- `dashboard/dashboard_http_monitoring.ml:16, 121` (hour + day)
- `dashboard/dashboard_http_keeper.ml:685` (hour, uptime_hours JSON)
- `dashboard/dashboard_http_keeper_metrics.ml:239, 256` (day + hour-boundary 2개)
- `dashboard/dashboard_keeper_feature_proof.ml:335` (hour, threshold)
- `dashboard/dashboard_execution_builders.ml:270` (hour, Korean UI)
- `dashboard/dashboard_harness_health.ml:86` (`12. *. 3600.` named const)
- `server/server_dashboard_http_agent_api.ml:21` (hour)
- `server/server_dashboard_http_keeper_api.ml:118` (hour)
- `server/host_fd_pressure_poller.ml:151` (hour, throttle)
- `voice/voice_bridge.ml:162` (hour, cutoff)

## 변경

- 10 files, +12/-12
- 10 hour-substitutions + 2 day-substitutions
- 동작 무변경 (`Masc_time_constants.hour = 3600.0`, `.day = 86400.0`)

## Magic-number lint impact

- Before: 10 `3600.0` + 2 `86400.0` = 12
- After: 0

## Out-of-scope

`lib/dashboard/dashboard_keeper_feature_proof.ml:323` 의 `<= hours *. 3600.0` 는 *docstring comment* (recency check 예시 설명). 본 PR 미터치.

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 12 사이트 *모두* 동시 처리

## Test impact

- 동작 무변경
- `dune build lib/` PASS

## Related

- PR #19037 ~ #19089 — Magic Number Time-literal 시리즈 누적 10
- `lib/config/masc_time_constants.ml` — time SSOT
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
