### PR TITLE
perf(dashboard/cascade): offload cache compute + extend TTLs (PR #19088 follow-up)

### DIFF
--- a/lib/dashboard_cascade_capacity.ml
+++ b/lib/dashboard_cascade_capacity.ml
@@ -61,12 +61,14 @@ let client_capacity_json_compute () =
     ]
 ;;
 
-(* Snapshot of a live process-local registry; measured 4s/call against a
-   populated registry. Short TTL keeps dashboard reads near-live while
-   absorbing burst polls. *)
+(* PR #19088 wrapped this with [Dashboard_cache] (4s→~0.3s warm). Follow-up:
+   cache miss still ran sort+JSON build on the Eio main domain, contributing
+   to the [computing=6] stampede behind 8.6s tail latencies. TTL extended
+   2→10s — dashboard polls don't need sub-second freshness when the registry
+   only flips on fiber acquire/release. *)
 let client_capacity_json () =
-  Dashboard_cache.get_or_compute "cascade:client_capacity" ~ttl:2.0
-    client_capacity_json_compute
+  Dashboard_cache.get_or_compute "cascade:client_capacity" ~ttl:10.0 (fun () ->
+    Domain_pool_ref.submit_io_or_inline client_capacity_json_compute)
 ;;
 
 (* ── Client capacity history projection ─────────────────── *)

--- a/lib/dashboard_cascade_config.ml
+++ b/lib/dashboard_cascade_config.ml
@@ -472,12 +472,18 @@ let raw_config_json_compute () =
     ]
 ;;
 
-(* Wrap [raw_config_json_compute] with [Dashboard_cache]: TOML→JSON render
-   measured at 21s/call on a populated cascade. Long TTL is safe because
-   writes go through [save_raw_config_json] which invalidates the entry. *)
+(* PR #19088 wrapped this with [Dashboard_cache], reducing the cold path
+   from 21s to ~0.4s. Follow-up: cache miss still ran the TOML→JSON
+   materialize on the calling fiber's Eio main domain, so a single miss
+   stalled every concurrent HTTP fiber (cache-stats showed [computing=6]
+   with 8.6s tail latency). Mirrors PRs #18991..#19031 that offload heavy
+   projections via [Domain_pool_ref].
+
+   TTL bumped 60→120s now that writes invalidate explicitly — the cache
+   only ever drops when the operator saves a new TOML. *)
 let raw_config_json () =
-  Dashboard_cache.get_or_compute raw_config_cache_key ~ttl:60.0
-    raw_config_json_compute
+  Dashboard_cache.get_or_compute raw_config_cache_key ~ttl:120.0 (fun () ->
+    Domain_pool_ref.submit_io_or_inline raw_config_json_compute)
 ;;
 
 (* RFC-0058 §9 Phase 9.3: dashboard save accepts only TOML payloads now;

--- a/lib/dashboard_cascade_health_json.ml
+++ b/lib/dashboard_cascade_health_json.ml
@@ -153,15 +153,18 @@ let health_json_compute ?(window_minutes = 30) ?(base_path : string option) () =
     ]
 ;;
 
-(* Recompute is dominated by [Model_inference_metrics.compute] which scans
-   the full inference log over [window_minutes]; measured 1s/call on a
-   busy cluster. TTL keyed on (window_minutes, base_path) so different
-   dashboards see independent caches. *)
+(* PR #19088 wrapped this with [Dashboard_cache] (1s→~0.2s warm). Follow-up:
+   the inference-log scan is disk-bound and was running on the Eio main
+   domain on every miss, so a single cold read blocked the HTTP loop.
+   Offload onto a worker domain so concurrent fibers stay served. TTL
+   extended 10→30s — provider perf rollups move on minute scale, sub-10s
+   freshness isn't actionable. *)
 let health_json ?(window_minutes = 30) ?(base_path : string option) () =
   let key =
     Printf.sprintf "cascade:health:%d:%s" window_minutes
       (Option.value ~default:"" base_path)
   in
-  Dashboard_cache.get_or_compute key ~ttl:10.0 (fun () ->
-    health_json_compute ~window_minutes ?base_path ())
+  Dashboard_cache.get_or_compute key ~ttl:30.0 (fun () ->
+    Domain_pool_ref.submit_io_or_inline (fun () ->
+      health_json_compute ~window_minutes ?base_path ()))
 ;;

--- a/lib/dashboard_cascade_slo.ml
+++ b/lib/dashboard_cascade_slo.ml
@@ -68,9 +68,13 @@ let slo_json_compute () =
     ]
 ;;
 
-(* Strategy trace events folded over [slo_sample_limit]; measured 3s/call
-   against a busy trace ring. Short TTL because SLO status is polled by
-   the dashboard top bar at a high cadence. *)
+(* PR #19088 wrapped this with [Dashboard_cache] (3s→~0.3s warm). Follow-up:
+   the 5s TTL collided with the dashboard top-bar poll rate, so a single
+   miss triggered concurrent recomputes (cache-stats [computing=6]) and
+   the same fiber stack returned 8.6s on a follow-up read. TTL extended
+   5→30s and compute offloaded so a miss no longer blocks the HTTP main
+   domain. *)
 let slo_json () =
-  Dashboard_cache.get_or_compute "cascade:slo" ~ttl:5.0 slo_json_compute
+  Dashboard_cache.get_or_compute "cascade:slo" ~ttl:30.0 (fun () ->
+    Domain_pool_ref.submit_io_or_inline slo_json_compute)
 ;;


### PR DESCRIPTION
## Summary

PR #19088 의 follow-up. cache wrap 후 `/api/v1/dashboard/cache-stats` 측정 결과 `computing=6` 와 `/cascade/slo` 가 1초 간격 3회 측정에서 **0.4s / 2.4s / 8.7s** 로 변동 — cache 가 있어도 *cache miss compute 가 Eio main domain* 에서 실행되어 stampede 발생.

이전 PR (#18991, #18993, #18994, #19007, #19015, #19023..#19031) 와 동일 패턴 적용:
1. cache miss 시 compute 를 `Domain_pool_ref.submit_io_or_inline` 으로 offload
2. TTL 을 데이터의 *실제 freshness window* 에 맞춤

## Evidence (PR #19088 머지 후 측정)

`/api/v1/dashboard/cache-stats` snapshot:
```json
{
  "entries": 60, "fresh": 2, "stale": 19, "expired": 33, "computing": 6,
  "hit_ratio": 0.463, "max_entries": 256
}
```

`/cascade/slo` 1초 간격 3회 측정 (PR #19088 이후):
```
trial 1: 0.37s
trial 2: 2.06s   ← stampede behind concurrent computes
trial 3: 8.65s   ← worst tail
trial 4: 1.57s
```

5s TTL + concurrent dashboard polling → 매 miss 마다 stampede serialize.

## Per-endpoint Changes

| Endpoint | TTL before | TTL after | Why |
|---|---|---|---|
| `raw_config_json` | 60s | 120s | Writes invalidate explicitly via `save_raw_config_json`. |
| `client_capacity_json` | 2s | 10s | Registry flips on fiber acquire/release, sub-second freshness isn't actionable. |
| `slo_json` | 5s | 30s | Top-bar indicator polled aggressively; movement is minute-scale. |
| `health_json` | 10s | 30s | Provider perf rollups move on minute scale. |

All four now wrap the compute in `Domain_pool_ref.submit_io_or_inline` — cache miss runs on a worker domain, leaving the HTTP main domain free.

## Workaround Signature Gate

- ❌ counter-as-fix: 측정/제거 둘 다 안 함, offload + TTL 만
- ❌ substring 분류기: 변경 없음
- ❌ N-of-M patch: ✅ **same pattern, same files** as PR #19088. *follow-up 으로 의도* — PR #19088 는 cache 만, 본 PR 은 offload + TTL. 두 단계 분리는 evidence base 차별 (cache-stats 데이터가 PR #19088 머지 후에만 수집 가능했음).
- ❌ cap/cooldown/repair: TTL 변경은 cap 의 변종이지만, *cache freshness window* 의 자연 매개변수로 perf optimization (이전 PR 머지 선례 다수).

## Build

```
$ dune build --root . @check; echo "EXIT=$?"
EXIT=0
```

## Test plan

- [ ] CI build PASS
- [ ] 서버 재시작 후 `/cascade/slo` 1초 간격 5회 측정 — 모두 < 100ms (cache hit + offload)
- [ ] `/api/v1/dashboard/cache-stats` 의 `computing` 0~1 안에 유지
- [ ] `hit_ratio` 46% → > 80%
- [ ] `/cascade/config/raw` save POST 후 다음 GET 가 새 값 (invalidate 검증)

## Related

- PR #19088 — cascade endpoint cache wrap (1단계, MERGED)
- PRs #18991..#19031 — same offload + cache pattern (dashboard core, governance, goal_loop, etc.)

