### PR TITLE
Remove dashboard card legacy wrapper

### DIFF
--- a/dashboard/src/components/activity-graph-panels.test.ts
+++ b/dashboard/src/components/activity-graph-panels.test.ts
@@ -31,8 +31,8 @@ async function loadPanels(options: {
     timeRangeLabel: Vitest.vi.fn((value: string) => value),
   }))
   Vitest.vi.doMock('./common/card', () => ({
-    Card: ({ children, testId, title }: { children?: unknown; testId?: string; title?: string }) =>
-      html`<section data-testid=${testId ?? undefined}><h2>${title ?? ''}</h2>${children}</section>`,
+    SectionCard: ({ children, testId, label }: { children?: unknown; testId?: string; label?: string }) =>
+      html`<section data-testid=${testId ?? undefined}><h2>${label ?? ''}</h2>${children}</section>`,
   }))
   Vitest.vi.doMock('./common/feedback-state', () => ({
     EmptyState: ({ children, message }: { children?: unknown; message?: string }) =>

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -4,7 +4,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { lazy, Suspense } from 'preact/compat'
 import { useEffect } from 'preact/hooks'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { EmptyState, LoadingState } from './common/feedback-state'
 import { ActionButton } from './common/button'
 import { FilterChips } from './common/filter-chips'
@@ -328,7 +328,7 @@ function NodeLeaderboard({ nodes }: { nodes: ActivityGraphNode[] }) {
 function EmptyActivityGraph() {
   return html`
     <div class="flex flex-col gap-5">
-      <${Card} title="활동 분석" class="section mb-4" testId="activity_graph.graph">
+      <${SectionCard} label="활동 분석" class="section mb-4" testId="activity_graph.graph">
         <div class="mb-4">
           <h2 class="monitor-headline">활동 분석 데이터가 비어 있습니다</h2>
           <p class="monitor-subheadline">이 뷰는 런타임 실행 이벤트를 읽어 타임라인과 파생 분석을 그립니다. 지금은 기록된 이벤트가 없어 화면이 비어 있습니다.</p>
@@ -342,7 +342,7 @@ function EmptyActivityGraph() {
 function WarmingUpActivityGraph() {
   return html`
     <div class="flex flex-col gap-5">
-      <${Card} title="활동 분석" class="section mb-4" testId="activity_graph.warming">
+      <${SectionCard} label="활동 분석" class="section mb-4" testId="activity_graph.warming">
         <div class="mb-4">
           <h2 class="monitor-headline">활동 분석 초기화 중</h2>
           <p class="monitor-subheadline">서버가 activity feed를 아직 준비 중입니다. 초기화가 끝나면 그래프와 타임라인이 자동으로 갱신됩니다.</p>
@@ -369,7 +369,7 @@ function useActivityGraphState(since: TimeRangePreset) {
 
 function ActivityTimelinePanel({ data }: { data: ActivityGraphResponse }) {
   return html`
-    <${Card} title="액션 타임라인" class="section" testId="activity_graph.timeline">
+    <${SectionCard} label="액션 타임라인" class="section" testId="activity_graph.timeline">
       <div class="max-h-90 overflow-y-auto">
         <${ActionTimeline} data=${data} />
       </div>
@@ -380,7 +380,7 @@ function ActivityTimelinePanel({ data }: { data: ActivityGraphResponse }) {
 function DerivedActivityPanels({ data }: { data: ActivityGraphResponse }) {
   return html`
     <div class="flex flex-col gap-5">
-      <${Card} title="실행 이벤트 관계 그래프" class="section mb-4" testId="activity_graph.graph">
+      <${SectionCard} label="실행 이벤트 관계 그래프" class="section mb-4" testId="activity_graph.graph">
         <div class="mb-4">
           <p class="monitor-subheadline">에이전트, 작업, 결정, 운영 이벤트 간의 연결을 시각화합니다. 관찰소의 시간 범위를 따라 파생 분석을 갱신합니다.</p>
         </div>
@@ -398,7 +398,7 @@ function DerivedActivityPanels({ data }: { data: ActivityGraphResponse }) {
         </div>
       <//>
 
-      <${Card} title="활동 주체 순위" class="section" testId="activity_graph.leaderboard">
+      <${SectionCard} label="활동 주체 순위" class="section" testId="activity_graph.leaderboard">
         <div class="mb-3">
           <p class="monitor-subheadline">의미적 중요도 기준. 작업 완료, 의사결정, 핸드오프가 단순 입퇴장보다 높게 평가됩니다.</p>
         </div>
@@ -424,7 +424,7 @@ export function ObservatoryActivityPanels() {
         ? html`<${LoadingState}>활동 분석 패널 불러오는 중...<//>`
         : state.error && !data
           ? html`
-              <${Card} title="활동 분석" class="section" testId="activity_graph.error">
+              <${SectionCard} label="활동 분석" class="section" testId="activity_graph.error">
                 <${EmptyState} message=${'활동 그래프를 불러올 수 없습니다: ' + state.error} compact />
                 <${ActionButton} variant="ghost" onClick=${() => { void loadGraph() }}>다시 시도<//>
               <//>

--- a/dashboard/src/components/activity-heatmap.ts
+++ b/dashboard/src/components/activity-heatmap.ts
@@ -6,7 +6,7 @@
 
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { EmptyState } from './common/feedback-state'
 import type { ActivityGraphResponse } from '../types'
 import {
@@ -142,14 +142,14 @@ export function ActivityHeatmap({ data }: HeatmapProps) {
 
   if (total === 0) {
     return html`
-      <${Card} title="활동 히트맵" testId="activity_heatmap">
+      <${SectionCard} label="활동 히트맵" testId="activity_heatmap">
         <${EmptyState}>히트맵을 표시할 이벤트가 없습니다.<//>
       <//>
     `
   }
 
   return html`
-    <${Card} title="활동 히트맵" testId="activity_heatmap">
+    <${SectionCard} label="활동 히트맵" testId="activity_heatmap">
       <div ref=${containerRef} class="relative overflow-x-auto bg-[var(--color-bg-surface)] rounded-[var(--r-1)] p-3 contain-content">
         <canvas ref=${canvasRef} class="block" role="img" aria-label="요일별 시간대별 활동 밀도 히트맵" />
         ${tooltip

--- a/dashboard/src/components/activity-swimlane-fetch.test.ts
+++ b/dashboard/src/components/activity-swimlane-fetch.test.ts
@@ -36,8 +36,8 @@ async function loadSwimlane(options: {
     }),
   }))
   vi.doMock('./common/card', () => ({
-    Card: ({ children, testId, title }: { children?: unknown; testId?: string; title?: string }) =>
-      html`<section data-testid=${testId ?? undefined}><h2>${title ?? ''}</h2>${children}</section>`,
+    SectionCard: ({ children, testId, label }: { children?: unknown; testId?: string; label?: string }) =>
+      html`<section data-testid=${testId ?? undefined}><h2>${label ?? ''}</h2>${children}</section>`,
   }))
   vi.doMock('./common/feedback-state', () => ({
     EmptyState: ({ children }: { children?: unknown }) => html`<div>${children}</div>`,

--- a/dashboard/src/components/activity-swimlane.ts
+++ b/dashboard/src/components/activity-swimlane.ts
@@ -5,7 +5,7 @@ import { html } from 'htm/preact'
 import { useEffect, useRef } from 'preact/hooks'
 import { DataSet } from 'vis-data'
 import { Timeline, TimelineOptions } from 'vis-timeline'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { EmptyState, LoadingState } from './common/feedback-state'
 import { fetchSwimlane } from '../api'
 import { registerActivityRefresh } from '../sse-store'
@@ -205,7 +205,7 @@ export function ActivitySwimlane({ since }: { since?: string }) {
 
   if (s.loading && !data) {
     return html`
-      <${Card} title="활동 타임라인" testId="activity_swimlane">
+      <${SectionCard} label="활동 타임라인" testId="activity_swimlane">
         <${LoadingState}>타임라인 불러오는 중...<//>
       <//>
     `
@@ -213,7 +213,7 @@ export function ActivitySwimlane({ since }: { since?: string }) {
 
   if (s.error && !data) {
     return html`
-      <${Card} title="활동 타임라인" testId="activity_swimlane">
+      <${SectionCard} label="활동 타임라인" testId="activity_swimlane">
         <${EmptyState}>타임라인을 불러올 수 없습니다: ${s.error}<//>
       <//>
     `
@@ -221,7 +221,7 @@ export function ActivitySwimlane({ since }: { since?: string }) {
 
   if (!data) {
     return html`
-      <${Card} title="활동 타임라인" testId="activity_swimlane">
+      <${SectionCard} label="활동 타임라인" testId="activity_swimlane">
         <${LoadingState}>activity feed 워밍업 중...<//>
       <//>
     `
@@ -229,14 +229,14 @@ export function ActivitySwimlane({ since }: { since?: string }) {
 
   if (data.agents.length === 0) {
     return html`
-      <${Card} title="활동 타임라인" testId="activity_swimlane">
+      <${SectionCard} label="활동 타임라인" testId="activity_swimlane">
         <${EmptyState}>표시할 에이전트 활동 타임라인이 없습니다.<//>
       <//>
     `
   }
 
   return html`
-    <${Card} title="활동 타임라인" testId="activity_swimlane">
+    <${SectionCard} label="활동 타임라인" testId="activity_swimlane">
       <div class="mb-2">
         <p class="text-sm text-[var(--color-fg-muted)]">에이전트별 활동 구간을 시간축으로 보여줍니다. 마우스 휠로 줌인/아웃, 드래그로 이동이 가능합니다.</p>
       </div>

--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -3,7 +3,7 @@
 
 import { html } from 'htm/preact'
 import { useState } from 'preact/hooks'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { Markdown } from './common/markdown'
 import { TextInput } from './common/input'
@@ -256,7 +256,7 @@ export function AgentSessionReport({ agentName }: { agentName: string }) {
   const hasQuery = query.trim() !== ''
 
   return html`
-    <${Card} title="세션 활동 리포트" class="mb-5">
+    <${SectionCard} label="세션 활동 리포트" class="mb-5">
       <${SessionMeta} agentName=${agentName} />
 
       ${summary ? html`

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -5,7 +5,7 @@ import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
 import { formatPct } from '../lib/format-number'
 import { useMemo, useRef } from 'preact/hooks'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { EmptyState, ErrorState } from './common/feedback-state'
 import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
@@ -357,11 +357,11 @@ export function AgentDetailOverlay() {
         </div>
 
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <${Card} title="할당된 작업">
+          <${SectionCard} label="할당된 작업">
             ${renderOwnedTasks(ownedTasks, visibleOwnedTasks, isFilteringTasks)}
           <//>
 
-          <${Card} title="최근 활동">
+          <${SectionCard} label="최근 활동">
             ${lines.length === 0
               ? html`<div class="h-full min-h-30"><${EmptyState} message="최근 활동 메시지가 없습니다" compact /></div>`
               : html`<div role="log" aria-label="최근 활동 로그" class="max-h-60 overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-card-border bg-card/40 px-3 py-2.5 font-mono text-xs text-text-body leading-relaxed rounded-[var(--r-1)] shadow-[var(--shadow-1)] hover:bg-card/60 transition-colors">${line}</div>`)}</div>`}
@@ -395,7 +395,7 @@ export function AgentDetailOverlay() {
             ${renderTaskHistories(historyRows, visibleHistories, isFilteringTasks)}
           <//>
 
-          <${Card} title="직접 멘션">
+          <${SectionCard} label="직접 멘션">
             <div class="grid grid-cols-[1fr_auto] gap-3">
               <${TextInput}
                 class="px-4 py-2.5 rounded-[var(--r-1)] bg-card/60 text-text-strong text-sm placeholder:text-text-dim shadow-inset"

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -5,7 +5,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { createAsyncResource } from '../lib/async-state'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
 import { showToast } from './common/toast'
@@ -366,7 +366,7 @@ export function AgentProfile({ name }: { name: string }) {
 
       <div class="grid grid-cols-2 gap-4 mb-4">
         ${!isKeeper ? html`
-        <${Card} title="태스크 (${owned.length})" class="ff-card rounded-[var(--r-1)]">
+        <${SectionCard} label="태스크 (${owned.length})" class="ff-card rounded-[var(--r-1)]">
           ${owned.length === 0
             ? html`<${EmptyState} message="할당된 태스크 없음" compact />`
             : html`<div class="flex flex-col gap-2">${owned.map(t => html`
@@ -386,7 +386,7 @@ export function AgentProfile({ name }: { name: string }) {
           const interests = rel.interests ?? []
           const hasData = collabs.length > 0 || interests.length > 0
           return html`
-            <${Card} title="관계 (${collabs.length})" class="ff-card rounded-[var(--r-1)]">
+            <${SectionCard} label="관계 (${collabs.length})" class="ff-card rounded-[var(--r-1)]">
               <${DashboardFeedSourceStrip} meta=${rel} className="mb-2" />
               ${!hasData ? html`<${EmptyState} message="관계 데이터 없음" compact />` : null}
               ${collabs.length > 0 ? html`
@@ -420,7 +420,7 @@ export function AgentProfile({ name }: { name: string }) {
           `
         })()}
 
-        <${Card} title="타임라인" class="ff-card rounded-[var(--r-1)]">
+        <${SectionCard} label="타임라인" class="ff-card rounded-[var(--r-1)]">
           <${DashboardFeedSourceStrip} meta=${timeline} className="mb-2" />
           ${!timeline || (timeline.events ?? []).length === 0
             ? html`<${EmptyState} message="이벤트 없음" compact />`
@@ -437,11 +437,11 @@ export function AgentProfile({ name }: { name: string }) {
               })}</div>`}
         <//>
 
-        <${Card} title="실시간" class="ff-card rounded-[var(--r-1)]">
+        <${SectionCard} label="실시간" class="ff-card rounded-[var(--r-1)]">
           <${AgentLiveTimeline} name=${name} />
         <//>
 
-        <${Card} title="프로젝트 활동" class="ff-card rounded-[var(--r-1)]">
+        <${SectionCard} label="프로젝트 활동" class="ff-card rounded-[var(--r-1)]">
           ${lines.length === 0
             ? html`<${EmptyState} message="관련 활동 없음" compact />`
             : (() => {
@@ -467,7 +467,7 @@ export function AgentProfile({ name }: { name: string }) {
         <//>
 
         ${(profileData?.taskHistories ?? []).length > 0 ? html`
-          <${Card} title="태스크 이력" class="ff-card rounded-[var(--r-1)] col-span-full">
+          <${SectionCard} label="태스크 이력" class="ff-card rounded-[var(--r-1)] col-span-full">
             <div class="agent-history-list">${(profileData?.taskHistories ?? []).map((row: TaskHistoryRow) => html`
               <div class="border border-[var(--color-border-default)] rounded-[var(--radius-lg)] bg-[var(--color-bg-surface)] p-2.5" key=${row.taskId}>
                 <div class="mb-2"><span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--color-accent-fg)] whitespace-nowrap rounded-[var(--r-0)]">${row.taskId}</span></div>

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect, useRef, useCallback, useMemo, useState } from 'preact/hooks'
 import { RefreshCw, Sparkles, Trophy } from 'lucide-preact'
 import { ActionButton } from '../common/button'
-import { Card } from '../common/card'
+import { SectionCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
 import { showToast } from '../common/toast'
 import { requestConfirm } from '../common/confirm-dialog'
@@ -210,7 +210,7 @@ function renderCategorySection(
   }
 
   return html`
-    <${Card} title=${`${label} (${total})`} class="mb-4">
+    <${SectionCard} label=${`${label} (${total})`} class="mb-4">
       <div class="flex flex-col gap-2">
         ${posts.slice(0, limit).map(post => html`<${PostCard} key=${post.id} post=${post} />`)}
       </div>

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -22,7 +22,8 @@ vi.mock('../../keeper-message', () => ({
 }))
 
 vi.mock('../common/card', () => ({
-  Card: ({ children }: { children?: any }) => h('div', {}, children),
+  SectionCard: ({ children }: { children?: any }) => h('div', {}, children),
+  SurfaceCard: ({ children }: { children?: any }) => h('div', {}, children),
 }))
 
 vi.mock('../common/time-ago', () => ({

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { ActionButton } from '../common/button'
-import { Card } from '../common/card'
+import { SectionCard, SurfaceCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
 import { showToast } from '../common/toast'
 import { EmptyState } from '../common/feedback-state'
@@ -560,7 +560,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
         onClick=${() => navigate('workspace', { section: 'board' })}
       >← 게시판으로 돌아가기<//>
 
-      <${Card}>
+      <${SurfaceCard}>
         <div class="flex flex-col gap-4">
           <div>
             <h1 class="m-0 text-2xl font-semibold leading-tight text-[var(--color-fg-secondary)]">${post.title}</h1>
@@ -656,7 +656,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
       <//>
 
       <div class="mt-4">
-        <${Card} title="댓글">
+        <${SectionCard} label="댓글">
           ${focusedCommentId ? html`
             <${CommentRouteFocusPanel} commentId=${focusedCommentId} comments=${detailComments.value} postId=${post.id} />
           ` : null}

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -44,7 +44,7 @@ import {
   type CascadeValidationStatus,
 } from '../api/dashboard'
 import { Btn } from './btn'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { EmptyState } from './common/feedback-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { TextInput } from './common/input'
@@ -1363,7 +1363,7 @@ function CascadeRawConfigEditor({
   }
 
   return html`
-    <${Card} title=${mode.title}>
+    <${SectionCard} label=${mode.title}>
       <div class="flex flex-col gap-3 p-4">
         <p class="text-sm text-[var(--color-fg-muted)]">${mode.primary}</p>
         <p class="text-xs text-[var(--color-fg-muted)]">
@@ -1492,7 +1492,7 @@ export function CascadeConfigPanel() {
         ? html`<${LoadingState}>cascade snapshot 불러오는 중...<//>`
         : null}
 
-      <${Card} title="캐스케이드 라우팅">
+      <${SectionCard} label="캐스케이드 라우팅">
         ${config
           ? (() => {
               const keeperGroups = groupKeepersByCanonicalCascade(config.keeper_profiles)
@@ -1552,7 +1552,7 @@ export function CascadeConfigPanel() {
         onRefresh=${() => loadCascadeData(resource)}
       />
 
-      <${Card} title="헬스 트래커">
+      <${SectionCard} label="헬스 트래커">
         ${health
           ? html`
             <div class="grid grid-cols-1 gap-3 md:grid-cols-2 mb-3">
@@ -1577,25 +1577,25 @@ export function CascadeConfigPanel() {
           : null}
       <//>
 
-      <${Card} title="클라이언트 용량">
+      <${SectionCard} label="클라이언트 용량">
         ${capacity
           ? html`<${ClientCapacityTable} capacity=${capacity} />`
           : null}
       <//>
 
-      <${Card} title="클라이언트 용량 · 최근 이벤트">
+      <${SectionCard} label="클라이언트 용량 · 최근 이벤트">
         ${history
           ? html`<${ClientCapacityHistoryTable} history=${history} />`
           : null}
       <//>
 
-      <${Card} title="SLO 상태">
+      <${SectionCard} label="SLO 상태">
         ${slo
           ? html`<${SloCard} slo=${slo} />`
           : html`<${EmptyState}>SLO 데이터를 불러오는 중입니다.<//>`}
       <//>
 
-      <${Card} title="전략 결정 · 사이클 추적">
+      <${SectionCard} label="전략 결정 · 사이클 추적">
         ${trace
           ? html`
             <div class="flex items-center gap-3 mb-3">

--- a/dashboard/src/components/common/card.a11y.test.ts
+++ b/dashboard/src/components/common/card.a11y.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 //
-// jest-axe coverage for SurfaceCard / SectionCard / Card. Pure
+// jest-axe coverage for SurfaceCard / SectionCard. Pure
 // container atoms — axe primarily guards landmark-vs-non-landmark
 // usage and that the title-bearing variants surface a real heading
 // rather than a styled <span>.
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { axe } from 'jest-axe'
-import { SurfaceCard, SectionCard, Card } from './card'
+import { SurfaceCard, SectionCard } from './card'
 
 describe('SurfaceCard a11y', () => {
   let container: HTMLElement
@@ -48,28 +48,11 @@ describe('SectionCard a11y', () => {
     document.body.removeChild(container)
   })
 
-  it('with title renders accessibly', async () => {
+  it('with label renders accessibly', async () => {
     render(
-      html`<${SectionCard} title="Recent activity"><p>...</p><//>`,
+      html`<${SectionCard} label="Recent activity"><p>...</p><//>`,
       container,
     )
-    expect(await axe(container)).toHaveNoViolations()
-  })
-})
-
-describe('Card a11y', () => {
-  let container: HTMLElement
-  beforeEach(() => {
-    container = document.createElement('div')
-    document.body.appendChild(container)
-  })
-  afterEach(() => {
-    render(null, container)
-    document.body.removeChild(container)
-  })
-
-  it('with title renders accessibly', async () => {
-    render(html`<${Card} title="Header"><p>body</p><//>`, container)
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/dashboard/src/components/common/card.test.ts
+++ b/dashboard/src/components/common/card.test.ts
@@ -5,7 +5,6 @@ import { render } from 'preact'
 import {
   SurfaceCard,
   SectionCard,
-  Card,
   summarizeSurfaceCard,
   summarizeSectionCard,
   sectionCardStatusDotTone,
@@ -56,7 +55,7 @@ describe('summarizeSurfaceCard', () => {
 describe('summarizeSectionCard', () => {
   it('summarizes status-eyebrow section state', () => {
     expect(summarizeSectionCard({
-      title: 'Transport',
+      label: 'Transport',
       status: 'Watch',
       eyebrow: 'observing',
       tone: 'warn',
@@ -67,7 +66,7 @@ describe('summarizeSectionCard', () => {
     })).toEqual({
       variant: 'compact',
       bodyPadding: 'p-3.5',
-      labelSource: 'title',
+      labelSource: 'label',
       labelState: 'text',
       labelTextLength: 9,
       tailSource: 'status-eyebrow',
@@ -114,7 +113,7 @@ describe('summarizeSectionCard', () => {
     })
 
     expect(summarizeSectionCard({
-      title: 'Queue',
+      label: 'Queue',
       status: '  ',
       tone: ' ',
       testId: ' ',
@@ -131,7 +130,7 @@ describe('summarizeSectionCard', () => {
 
   it('keeps status length aligned to normalized status metadata', () => {
     expect(summarizeSectionCard({
-      title: 'Queue',
+      label: 'Queue',
       status: ' Watch ',
       children: 'Body',
     })).toMatchObject({
@@ -240,19 +239,19 @@ describe('SectionCard', () => {
     expect(container.querySelector('[data-section-card]')?.getAttribute('data-section-card-body-padding')).toBe('p-3.5')
   })
 
-  it('accepts legacy title, right slot, and test id props', () => {
+  it('accepts right slot and test id props', () => {
     const container = document.createElement('div')
     render(
       h(
         SectionCard,
-        { title: 'Section B', right: h('span', null, 'Tail'), testId: 'section-b' },
+        { label: 'Section B', right: h('span', null, 'Tail'), testId: 'section-b' },
         h('p', null, 'Body'),
       ),
       container,
     )
     const el = container.querySelector('[data-testid="section-b"]')
     expect(el).not.toBeNull()
-    expect(el?.getAttribute('data-section-card-label-source')).toBe('title')
+    expect(el?.getAttribute('data-section-card-label-source')).toBe('label')
     expect(el?.getAttribute('data-section-card-tail-source')).toBe('right')
     expect(el?.getAttribute('data-section-card-has-right-slot')).toBe('true')
     expect(el?.getAttribute('data-section-card-has-test-id')).toBe('true')
@@ -267,7 +266,7 @@ describe('SectionCard', () => {
     render(
       h(
         SectionCard,
-        { title: 'Transport', status: 'warn', eyebrow: 'degraded' },
+        { label: 'Transport', status: 'warn', eyebrow: 'degraded' },
         h('p', null, 'Body'),
       ),
       container,
@@ -289,7 +288,7 @@ describe('SectionCard', () => {
     render(
       h(
         SectionCard,
-        { title: 'Transport', status: ' Watch ', eyebrow: 'observing' },
+        { label: 'Transport', status: ' Watch ', eyebrow: 'observing' },
         h('p', null, 'Body'),
       ),
       container,
@@ -305,26 +304,11 @@ describe('SectionCard', () => {
     render(
       h(
         SectionCard,
-        { title: 'Transport', status: 'offline', eyebrow: 'not connected' },
+        { label: 'Transport', status: 'offline', eyebrow: 'not connected' },
         h('p', null, 'Body'),
       ),
       container,
     )
     expect(container.innerHTML).toContain('bg-[var(--color-status-idle)]')
-  })
-})
-
-describe('Card', () => {
-  it('renders as SurfaceCard without title', () => {
-    const container = document.createElement('div')
-    render(h(Card, null, 'Content'), container)
-    expect(container.textContent).toContain('Content')
-  })
-
-  it('renders as SectionCard with title', () => {
-    const container = document.createElement('div')
-    render(h(Card, { title: 'Header' }, 'Body'), container)
-    expect(container.textContent).toContain('Header')
-    expect(container.textContent).toContain('Body')
   })
 })

--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -16,7 +16,7 @@ const CARD_COMPACT = `${CARD_BASE} !p-3.5 !shadow-[var(--shadow-1)]`
 export type CardVariant = 'standard' | 'light' | 'compact'
 export type CardToneSource = 'none' | 'tone-class'
 export type CardContentState = 'empty' | 'text' | 'node'
-export type SectionCardLabelSource = 'label' | 'title' | 'empty'
+export type SectionCardLabelSource = 'label' | 'empty'
 export type SectionCardTailSource = 'right' | 'status-eyebrow' | 'none'
 export type CardStatusDotTone = 'ok' | 'warn' | 'bad' | 'info' | 'neutral'
 
@@ -195,7 +195,6 @@ export function SurfaceCard({
 // ── Section card with label header ──
 export interface SectionCardProps {
   label?: ComponentChildren
-  title?: ComponentChildren
   right?: ComponentChildren
   eyebrow?: ComponentChildren
   status?: string
@@ -214,7 +213,6 @@ function statusDotClass(status?: string): string {
 
 export function summarizeSectionCard({
   label,
-  title,
   right,
   eyebrow,
   status,
@@ -225,13 +223,10 @@ export function summarizeSectionCard({
   'data-testid': dataTestId,
   children,
 }: SectionCardProps): SectionCardSummary {
-  const sectionLabel = label ?? title
+  const sectionLabel = label
   const normalizedStatus = normalizeStatus(status)
   const hasStatus = normalizedStatus !== ''
-  const labelSource =
-    label != null ? 'label' :
-      title != null ? 'title' :
-        'empty'
+  const labelSource = label != null ? 'label' : 'empty'
   const tailSource =
     right != null ? 'right' :
       eyebrow != null || hasStatus ? 'status-eyebrow' :
@@ -266,7 +261,6 @@ export function summarizeSectionCard({
 
 export function SectionCard({
   label,
-  title,
   right,
   eyebrow,
   status,
@@ -289,7 +283,6 @@ export function SectionCard({
   // path; the new wrapper uses p-3.5 to preserve that visual.
   const summary = summarizeSectionCard({
     label,
-    title,
     right,
     eyebrow,
     status,
@@ -301,7 +294,7 @@ export function SectionCard({
     children,
   })
   const bodyPadding = summary.bodyPadding
-  const sectionLabel = label ?? title ?? ''
+  const sectionLabel = label ?? ''
   const tail = right ?? (
     eyebrow != null || summary.hasStatus
       ? html`
@@ -361,25 +354,4 @@ export function SectionCard({
       <div class="${bodyPadding} flex flex-col gap-4">${children}</div>
     </div>
   `
-}
-
-
-// ── Legacy Card (backward compat — accepts title prop) ──
-export interface CardProps {
-  title?: ComponentChildren
-  class?: string
-  variant?: CardVariant
-  testId?: string
-  children: ComponentChildren
-}
-
-export function Card({ title, class: cx, variant = 'standard', testId, children }: CardProps) {
-  if (title) {
-    return html`
-      <${SectionCard} label=${title} class=${cx ?? ''} variant=${variant}>
-        ${children}
-      <//>
-    `
-  }
-  return html`<${SurfaceCard} variant=${variant} class=${cx} testId=${testId}>${children}<//>`
 }

--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -12,7 +12,7 @@ import { useEffect } from 'preact/hooks'
 import { get } from '../api/core'
 import { createAsyncResource, type AsyncResource } from '../lib/async-state'
 import { AsyncContainer } from './common/async-container'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { SectionCap } from './common/section-cap'
 import { Chip } from './chip'
 import { Pill, type PillKind } from './pill'
@@ -330,7 +330,7 @@ export function DoctorPanel() {
 
   return html`
     <div class="space-y-4">
-      <${Card} title="진단" class="section">
+      <${SectionCard} label="진단" class="section">
         <${AsyncContainer}
           state=${doctorEnvelope.state}
           loadingMessage="진단 데이터를 불러오는 중..."

--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { LoadingState } from './common/feedback-state'
 import { fetchExcusePatterns, updateExcusePatterns } from '../api/dashboard'
 import type { ExcusePattern } from '../api/dashboard'
@@ -52,17 +52,17 @@ export function ExcusePatterns() {
 
   if (s.status === 'loading') {
     return html`
-      <${Card} title="Anti-Rationalization 핑계 패턴">
+      <${SectionCard} label="Anti-Rationalization 핑계 패턴">
         <${LoadingState}>핑계 패턴 불러오는 중...<//>
-      </Card>
+      <//>
     `
   }
 
   if (s.status === 'error') {
     return html`
-      <${Card} title="Anti-Rationalization 핑계 패턴">
+      <${SectionCard} label="Anti-Rationalization 핑계 패턴">
         <div class="p-4 text-[var(--color-status-err)]" role="alert">패턴 로드 실패: ${s.message}</div>
-      </Card>
+      <//>
     `
   }
 
@@ -70,7 +70,7 @@ export function ExcusePatterns() {
   const jsonStr = data ? JSON.stringify(data, null, 2) : '[]'
 
   return html`
-    <${Card} title="Anti-Rationalization 핑계 패턴">
+    <${SectionCard} label="Anti-Rationalization 핑계 패턴">
       <div class="p-4">
         <p class="text-sm text-[var(--color-fg-muted)] mb-4">
           이 패턴들은 에이전트 completion note 와 매칭됩니다. 매칭되면 해당 task 는 거부됩니다.
@@ -101,6 +101,6 @@ export function ExcusePatterns() {
           </div>
         </form>
       </div>
-    </Card>
+    <//>
   `
 }

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -8,7 +8,7 @@ import { get } from '../api/core'
 import { createAsyncResource, type AsyncResource } from '../lib/async-state'
 import { formatTimeAgo } from '../lib/format-time'
 import { AsyncContainer } from './common/async-container'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import { SectionCap } from './common/section-cap'
@@ -207,7 +207,7 @@ export function FeatureHealth() {
 
   return html`
     <div class="space-y-4">
-      <${Card} title="기능 상태" class="section">
+      <${SectionCard} label="기능 상태" class="section">
         <${AsyncContainer}
           state=${featureHealth.state}
           loadingMessage="기능 상태 데이터를 불러오는 중..."

--- a/dashboard/src/components/goal-loop-panel.ts
+++ b/dashboard/src/components/goal-loop-panel.ts
@@ -221,13 +221,13 @@ function NextActionBlock({ status }: { status: GoalLoopStatusResponse }) {
   const action = status.nextAction
   if (!action) {
     return html`
-      <${SectionCard} title="Next Action" data-testid="goal-loop-next-action">
+      <${SectionCard} label="Next Action" data-testid="goal-loop-next-action">
         <div class="text-xs text-[var(--color-fg-muted)]">n/a</div>
       <//>
     `
   }
   return html`
-    <${SectionCard} title="Next Action" data-testid="goal-loop-next-action">
+    <${SectionCard} label="Next Action" data-testid="goal-loop-next-action">
       <div class="grid grid-cols-[minmax(0,8rem)_minmax(0,1fr)] gap-x-4 gap-y-2 text-xs max-[760px]:grid-cols-1">
         <div class="font-mono text-[var(--color-fg-muted)]">decision</div>
         <div class="min-w-0 truncate font-mono text-[var(--color-fg-secondary)]">${displayValue(action.decision_id)}</div>
@@ -330,7 +330,7 @@ function GoalCreateBlock({ onCreated }: { onCreated: () => void }) {
   }, [horizon, onCreated, priority, title])
 
   return html`
-    <${SectionCard} title="Create Goal" data-testid="goal-loop-create-goal">
+    <${SectionCard} label="Create Goal" data-testid="goal-loop-create-goal">
       <form class="grid gap-3 md:grid-cols-[minmax(0,1fr)_8rem_6rem_auto]" onSubmit=${submit}>
         <label class="flex min-w-0 flex-col gap-1 text-2xs font-medium text-[var(--color-fg-muted)]">
           Title
@@ -566,7 +566,7 @@ export function GoalLoopPanel({ initialStatus }: GoalLoopPanelProps) {
 
   if (status === null) {
     return html`
-      <${SectionCard} title="GOAL LOOP" data-testid="goal-loop-panel">
+      <${SectionCard} label="GOAL LOOP" data-testid="goal-loop-panel">
         <div class="text-xs text-[var(--color-status-err)]">${error ?? 'status unavailable'}</div>
       <//>
     `

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -7,7 +7,7 @@ import type { ComponentChildren } from 'preact'
 import autoAnimate from '@formkit/auto-animate'
 import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
-import { Card } from '../common/card'
+import { SectionCard } from '../common/card'
 import { TextInput } from '../common/input'
 import { TimeAgo } from '../common/time-ago'
 import { RichContent } from '../common/rich-content'
@@ -395,12 +395,12 @@ export function TaskBacklog() {
   const hasData = executionLoaded.value
 
   if (isLoading) {
-    return html`<${Card} title="태스크 백로그" class="section" variant="compact"><${LoadingState}>백로그 불러오는 중...<//><//>`
+    return html`<${SectionCard} label="태스크 백로그" class="section" variant="compact"><${LoadingState}>백로그 불러오는 중...<//><//>`
   }
 
   if (hasError && !hasData) {
     return html`
-      <${Card} title="태스크 백로그" class="section" variant="compact">
+      <${SectionCard} label="태스크 백로그" class="section" variant="compact">
         <div class="flex flex-col items-center gap-3 py-6">
           <${ErrorState} message="데이터를 불러오지 못했습니다." />
           <${ActionButton} variant="ghost" size="sm" onClick=${() => refreshExecution({ force: true })}>재시도<//>
@@ -410,11 +410,11 @@ export function TaskBacklog() {
   }
 
   if (hasData && totalTasks === 0) {
-    return html`<${Card} title="태스크 백로그" class="section" variant="compact"><${EmptyState} message="등록된 태스크가 없습니다" /><//>`
+    return html`<${SectionCard} label="태스크 백로그" class="section" variant="compact"><${EmptyState} message="등록된 태스크가 없습니다" /><//>`
   }
 
   return html`
-    <${Card} title="태스크 백로그" class="section" variant="compact">
+    <${SectionCard} label="태스크 백로그" class="section" variant="compact">
       ${hasError && hasData ? html`
         <div class="mb-2 rounded-[var(--r-0)] border border-warn/25 bg-warn/10 px-2.5 py-1.5 text-2xs text-warn">마지막 갱신에 실패했습니다. 표시된 데이터가 오래되었을 수 있습니다.</div>
       ` : null}

--- a/dashboard/src/components/governance-monitor.ts
+++ b/dashboard/src/components/governance-monitor.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect, useMemo } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { ActionButton } from './common/button'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { EmptyState } from './common/feedback-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { Select } from './common/select'
@@ -160,7 +160,7 @@ export function GovernanceMonitor() {
         ? html`<${LoadingState}>governance metrics 불러오는 중...<//>`
         : null}
 
-      <${Card} title="승인 대기열">
+      <${SectionCard} label="승인 대기열">
         ${data ? html`
           <div class="grid grid-cols-4 gap-3">
             <${StatTile}
@@ -195,7 +195,7 @@ export function GovernanceMonitor() {
         ` : null}
       <//>
 
-      <${Card} title="도구 거부 (${data?.window_minutes ?? windowMinutes.value}m)">
+      <${SectionCard} label="도구 거부 (${data?.window_minutes ?? windowMinutes.value}m)">
         <div class="flex flex-col gap-2">
           <${TextInput}
             type="search"

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -6,7 +6,7 @@ import type { GovernanceJudgeSummary, KeeperApprovalQueueItem, KeeperApprovalRul
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { SECONDS_PER_DAY } from '../lib/format-time'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import type { KpiCellKind } from './kpi-shared'
 import { KpiStripIsland, type KpiStripIslandData } from './kpi-strip-island'
 import { EmptyState } from './common/feedback-state'
@@ -242,7 +242,7 @@ function JudgmentsSection() {
       : 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-text-muted'
     return html`
       <div data-testid="live-judge-empty">
-        <${Card} title=${title} class="section mb-5" variant="compact">
+        <${SectionCard} label=${title} class="section mb-5" variant="compact">
           <${EmptyState} message=${message} compact />
           ${lastSeen || meta ? html`
             <div class="mt-1 flex flex-wrap items-center justify-center gap-2 text-2xs ${tone === 'warn' ? 'text-warn' : 'text-text-dim'}">
@@ -258,7 +258,7 @@ function JudgmentsSection() {
   }
 
   return html`
-    <${Card} title=${title} class="section mb-5" variant="compact">
+    <${SectionCard} label=${title} class="section mb-5" variant="compact">
       <div class="flex flex-col gap-2.5">
         ${judgments.map(j => html`
           <div class="rounded-[var(--r-1)] border border-card-border bg-card/34 p-3.5 text-sm" data-testid="judgment-item">
@@ -503,7 +503,7 @@ function KeeperApprovalQueueSection() {
     : 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-text-muted text-2xs px-2 py-0.5 font-bold'
   return html`
     <div id="keeper-hitl-approval" data-testid="keeper-hitl-approval">
-    <${Card} title="Keeper HITL Approval Queue" class="section mb-5" variant="compact">
+    <${SectionCard} label="Keeper HITL Approval Queue" class="section mb-5" variant="compact">
       <div class="mb-3 flex items-center justify-between gap-3">
         <div class="text-xs text-text-muted">
           Keeper tool calls above the risk threshold wait here.
@@ -615,7 +615,7 @@ function ApprovalRulesSection() {
   const rules = governanceData.value?.approval_rules ?? []
   const actingId = governanceApprovalActing.value
   return html`
-    <${Card} title="Always Rules" class="section mb-5" variant="compact">
+    <${SectionCard} label="Always Rules" class="section mb-5" variant="compact">
       <div class="mb-3 text-xs text-text-muted">
         Auto-approval rules derived from approved requests. Critical, destructive shell/git, and manual-decision states are never auto-approved even when a rule exists.
       </div>

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -4,7 +4,7 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { formatPct1 } from '../lib/format-number'
 import { assertExhaustive } from '../lib/exhaustive'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { SectionCap } from './common/section-cap'
 import { MermaidGraph } from './common/mermaid-graph'
 import { KpiStripIsland, type KpiStripIslandData } from './kpi-strip-island'
@@ -323,11 +323,11 @@ export function HarnessHealth() {
 
   return html`
     <div class="space-y-4">
-      <${Card} title="안전 감시" class="section">
+      <${SectionCard} label="안전 감시" class="section">
         ${overviewContent}
       <//>
 
-      <${Card} title="감시 흐름도" class="section">
+      <${SectionCard} label="감시 흐름도" class="section">
         ${!data || !flowSource ? html`
           <${EmptySignal} text="감시 흐름 데이터가 없습니다." />
         ` : html`
@@ -335,7 +335,7 @@ export function HarnessHealth() {
         `}
       <//>
 
-      <${Card} title="평가 모델 건강도" class="section">
+      <${SectionCard} label="평가 모델 건강도" class="section">
         ${!data || !cal ? html`
           <${EmptySignal} text="평가 모델 데이터가 없습니다." />
         ` : html`
@@ -400,7 +400,7 @@ export function HarnessHealth() {
         `}
       <//>
 
-      <${Card} title="압축 전 상태" class="section">
+      <${SectionCard} label="압축 전 상태" class="section">
         ${!data ? html`
           <${EmptySignal} text="압축 전 상태 데이터가 없습니다." />
         ` : html`
@@ -440,7 +440,7 @@ export function HarnessHealth() {
         `}
       <//>
 
-      <${Card} title="세대 교체 기록" class="section">
+      <${SectionCard} label="세대 교체 기록" class="section">
         ${!data ? html`
           <${EmptySignal} text="세대 교체 데이터가 없습니다." />
         ` : html`

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -16,7 +16,7 @@ import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { keepers } from '../store'
 import type { Keeper } from '../types'
 import { ActionButton } from './common/button'
-import { Card } from './common/card'
+import { SurfaceCard } from './common/card'
 import { EmptyState, ErrorState, LoadingState } from './common/feedback-state'
 import { Select } from './common/select'
 import { StatusChip, keeperStateTone } from './common/status-chip'
@@ -477,7 +477,7 @@ export function JourneyPanel() {
 
   return html`
     <div class="flex flex-col gap-4">
-      <${Card} class="flex flex-col gap-4">
+      <${SurfaceCard} class="flex flex-col gap-4">
         <div class="flex flex-wrap items-start justify-between gap-4">
           <div class="min-w-0">
             <div class="flex flex-wrap items-center gap-2">

--- a/dashboard/src/components/keeper-decisions-stream.ts
+++ b/dashboard/src/components/keeper-decisions-stream.ts
@@ -4,7 +4,7 @@ import { createAsyncResource, type AsyncResource } from '../lib/async-state'
 import { fetchKeeperDecisions, type KeeperDecision, type KeeperDecisionsResponse } from '../api/dashboard'
 import { formatTimeHms } from '../lib/format-time'
 import { AsyncContainer } from './common/async-container'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { EmptyState } from './common/feedback-state'
 import { KeeperBadge } from './keeper-badge'
 
@@ -136,7 +136,7 @@ export function KeeperDecisionsStream({ limit = 200 }: { limit?: number }) {
   }, [limit])
 
   return html`
-    <${Card} title="Keeper Decisions" class="section">
+    <${SectionCard} label="Keeper Decisions" class="section">
       <div class="mb-3 flex justify-end">
         <button
           type="button"

--- a/dashboard/src/components/lab-inspector.ts
+++ b/dashboard/src/components/lab-inspector.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { DoctorPanel } from './doctor-panel'
 import { FeatureHealth } from './feature-health'
 import { ServerConfig } from './server-config'
@@ -80,7 +80,7 @@ function InspectorTabButton({
 function InspectorOverview() {
   return html`
     <div class="grid gap-4">
-      <${Card} title="대시보드 포커스" class="section">
+      <${SectionCard} label="대시보드 포커스" class="section">
         <div class="grid gap-3">
           <div class="rounded-[var(--r-1)] border border-card-border/35 bg-[var(--color-bg-elevated)]/10 px-4 py-3 text-sm leading-airy text-[var(--color-fg-primary)]">
             이제 대시보드는 <strong class="text-[var(--color-fg-secondary)]">핵심 운영 화면</strong>에 더 집중합니다.
@@ -112,7 +112,7 @@ export function LabInspector() {
 
   return html`
     <div class="flex flex-col gap-4">
-      <${Card} title="운영 인스펙터" class="section">
+      <${SectionCard} label="운영 인스펙터" class="section">
         <div class="flex flex-col gap-3">
           <div class="flex flex-wrap gap-2">
             <${InspectorTabButton} id="overview" label="개요" />

--- a/dashboard/src/components/oas-health-chip.ts
+++ b/dashboard/src/components/oas-health-chip.ts
@@ -4,7 +4,7 @@
 import { html } from 'htm/preact'
 import { useComputed } from '@preact/signals'
 import { oasHealthSummary, oasAgentEvents, oasKeeperSnapshots } from '../store'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { StatTile } from './common/stat-tile'
 import { EmptyState } from './common/feedback-state'
 import { formatRelativeAgeMs } from '../lib/format-time'
@@ -115,7 +115,7 @@ export function OasHealthChip() {
 
   if (summary.value.totalEvents === 0) {
     return html`
-      <${Card} title="OAS 런타임">
+      <${SectionCard} label="OAS 런타임">
         <${EmptyState} message="아직 OAS 이벤트가 수신되지 않았습니다." />
       <//>
     `
@@ -136,7 +136,7 @@ export function OasHealthChip() {
       : describeEvidenceDetail(summary.value)
 
   return html`
-    <${Card} title="OAS 런타임">
+    <${SectionCard} label="OAS 런타임">
       <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2">
         <${StatTile}
           label="총 이벤트"

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -402,7 +402,7 @@ function FunnelCard({ counts }: { counts: FunnelCounts }) {
   const total = counts.created + counts.inProgress + counts.awaiting + counts.completed
   const segPct = (n: number) => total > 0 ? (n / total) * 100 : 0
   return html`
-    <${SectionCard} title="Today" right=${html`<span class="text-2xs text-[var(--color-fg-muted)]">task basis</span>`} data-testid="overview-funnel">
+    <${SectionCard} label="Today" right=${html`<span class="text-2xs text-[var(--color-fg-muted)]">task basis</span>`} data-testid="overview-funnel">
       <${KpiStripIsland}
         ariaLabel="Today funnel"
         cols=${5}
@@ -439,7 +439,7 @@ export function progressPct(session: DashboardMissionSessionCard | null): number
 function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | null }) {
   if (!active) {
     return html`
-      <${SectionCard} title="Active mission" data-testid="overview-party-empty">
+      <${SectionCard} label="Active mission" data-testid="overview-party-empty">
         <p class="text-2xs text-[var(--color-fg-muted)] italic">No active mission</p>
       <//>
     `
@@ -450,7 +450,7 @@ function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | nu
   const members = active.member_names
 
   return html`
-    <${SectionCard} title="Active Mission" data-testid="overview-party">
+    <${SectionCard} label="Active Mission" data-testid="overview-party">
       <div class="space-y-4">
         <div class="flex items-center justify-between">
            <p class="text-xs font-semibold text-[var(--color-fg-default)] truncate flex-1 mr-4">
@@ -534,14 +534,14 @@ function KeeperStrip({ keeperList }: { keeperList: readonly Keeper[] }) {
 
   if (activeKeepers.length === 0) {
     return html`
-      <${SectionCard} title="Active Keepers" data-testid="overview-keepers-empty">
+      <${SectionCard} label="Active Keepers" data-testid="overview-keepers-empty">
         <p class="text-2xs text-[var(--color-fg-muted)] italic">No active keepers</p>
       <//>
     `
   }
 
   return html`
-    <${SectionCard} title="Fleet Lifeline" data-testid="overview-keepers">
+    <${SectionCard} label="Fleet Lifeline" data-testid="overview-keepers">
       <div class="space-y-4">
         ${activeKeepers.slice(0, 1).map(
           k => html`

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -4,7 +4,7 @@
 import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
-import { Card } from './common/card'
+import { SurfaceCard } from './common/card'
 import { EmptyState } from './common/feedback-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { TextInput } from './common/input'
@@ -345,7 +345,7 @@ export function PrometheusMetrics() {
         )
 
         return html`
-          <${Card}>
+          <${SurfaceCard}>
             <button
               class="flex w-full items-center justify-between text-left"
               aria-expanded=${expanded ? 'true' : 'false'}

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -10,7 +10,7 @@ import {
   type DashboardRuntimeProvidersResponse,
 } from '../api/dashboard'
 import { ActionButton } from './common/button'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { EmptyState } from './common/feedback-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { Select } from './common/select'
@@ -400,7 +400,7 @@ export function RuntimeMonitor() {
         ? html`<${LoadingState}>runtime snapshot 불러오는 중...<//>`
         : null}
 
-      <${Card} title="런타임 상태">
+      <${SectionCard} label="런타임 상태">
         <div class="grid grid-cols-2 gap-3 mb-4">
           <${StatTile}
             label="런타임"
@@ -444,7 +444,7 @@ export function RuntimeMonitor() {
         </div>
       <//>
 
-      <${Card} title="런타임 메트릭">
+      <${SectionCard} label="런타임 메트릭">
         <div class="grid grid-cols-3 gap-3 mb-4">
           <${StatTile}
             label="텔레메트리 윈도우"

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { TextInput } from './common/input'
 import { TransportHealthPanel } from './transport-health'
 import { ConfigResolutionPanel } from './tools/config-resolution-panel'
@@ -169,7 +169,7 @@ export function ServerConfig() {
   }
 
   return html`
-    <${Card} title="서버 설정" class="section">
+    <${SectionCard} label="서버 설정" class="section">
       <div class="mb-3 flex items-center gap-2">
         <${TextInput}
           class="flex-1"

--- a/dashboard/src/components/surf.ts
+++ b/dashboard/src/components/surf.ts
@@ -71,7 +71,7 @@ export interface SurfProps {
    *  inline strip (auth banner) or a roomier card body (chat error). */
   padding?: SurfPadding
   /** Drop the rounded-[var(--r-1)] corner — used when Surf sits inside a parent
-   *  that already provides the radius (e.g. inside a Card). */
+   *  that already provides the radius (e.g. inside a card surface). */
   flat?: boolean
   /** Forwarded to data-testid. */
   testId?: string

--- a/dashboard/src/components/surface-readiness-panel.ts
+++ b/dashboard/src/components/surface-readiness-panel.ts
@@ -5,7 +5,7 @@ import { get } from '../api/core'
 import { createAsyncResource, type AsyncResource } from '../lib/async-state'
 import { formatTimeAgoEn } from '../lib/format-time'
 import { AsyncContainer } from './common/async-container'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { FilterChips } from './common/filter-chips'
 import { EmptyState } from './common/feedback-state'
 import { StatusChip, type StatusChipTone } from './common/status-chip'
@@ -259,7 +259,7 @@ export function SurfaceReadinessPanel() {
   }, [])
 
   return html`
-    <${Card} title="Surface Readiness" class="section">
+    <${SectionCard} label="Surface Readiness" class="section">
       <${AsyncContainer}
         state=${surfaceReadiness.state}
         loadingMessage="Loading surface readiness..."

--- a/dashboard/src/components/tlc-results-panel.test.ts
+++ b/dashboard/src/components/tlc-results-panel.test.ts
@@ -36,8 +36,8 @@ vi.mock('./btn', () => ({
 }))
 
 vi.mock('./common/card', () => ({
-  Card: ({ title, children }: any) => html`
-    <section data-testid="card"><h3>${title}</h3>${children}</section>
+  SectionCard: ({ label, children }: any) => html`
+    <section data-testid="card"><h3>${label}</h3>${children}</section>
   `,
 }))
 

--- a/dashboard/src/components/tlc-results-panel.ts
+++ b/dashboard/src/components/tlc-results-panel.ts
@@ -18,7 +18,7 @@ import {
   type TlcResultStatus,
 } from '../api/dashboard'
 import { Btn } from './btn'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { EmptyState } from './common/feedback-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { FilterChips } from './common/filter-chips'
@@ -224,7 +224,7 @@ export function TlcResultsPanel() {
   }
 
   return html`
-    <${Card} title="TLC 결과">
+    <${SectionCard} label="TLC 결과">
       <div class="flex flex-col gap-3">
         <div class="flex items-center gap-3 flex-wrap">
           <${Btn} onClick=${() => void loadTlcResults(resource)}>

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -13,7 +13,7 @@ import type {
 import { fetchDashboardRuntimeProbe } from '../../api/dashboard'
 import { MISSING_DATA_DASH } from '../../lib/format-string'
 import { Btn } from '../btn'
-import { Card } from '../common/card'
+import { SectionCard } from '../common/card'
 import { StatusChip } from '../common/status-chip'
 import { CopyIdButton } from '../common/copy-id-button'
 import { TextInput } from '../common/input'
@@ -583,7 +583,7 @@ export function ConfigResolutionPanel({
   const rootSource = resolution?.config_root.source ?? ''
 
   return html`
-    <${Card} title="설정 경로" class="section mb-4">
+    <${SectionCard} label="설정 경로" class="section mb-4">
       ${resolution
         ? html`
             <div class="mb-6">

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -9,7 +9,7 @@ import {
   type DashboardPromptItem,
   type PromptSource,
 } from '../../api'
-import { Card } from '../common/card'
+import { SectionCard } from '../common/card'
 import { ErrorState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { TextArea, TextInput } from '../common/input'
@@ -165,7 +165,7 @@ export function PromptRegistryPanel() {
   }
 
   return html`
-    <${Card} title="프롬프트 레지스트리" class="section mb-4">
+    <${SectionCard} label="프롬프트 레지스트리" class="section mb-4">
       <div class="mb-4 text-xs text-[var(--color-fg-muted)] leading-relaxed">
         <div>기준 원문은 resolved config root의 <code>prompts/*.md</code>입니다. 경로는 설정 경로 상세 패널에서 확인할 수 있습니다.</div>
         <div>이 화면에서는 현재 effective 값 확인과 runtime override 적용/해제만 합니다.</div>

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -17,9 +17,9 @@ vi.mock('./tool-state', () => ({
 }))
 
 vi.mock('../common/card', () => ({
-  Card: ({ title, children }: { title: string; children: unknown }) => html`
-    <section data-card-title=${title}>
-      <h2>${title}</h2>
+  SectionCard: ({ label, children }: { label: string; children: unknown }) => html`
+    <section data-card-title=${label}>
+      <h2>${label}</h2>
       ${children}
     </section>
   `,

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -3,7 +3,7 @@
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { signal } from '@preact/signals'
-import { Card } from '../common/card'
+import { SectionCard } from '../common/card'
 import { ToolMetrics } from '../tool-metrics'
 import {
   toolsData,
@@ -57,7 +57,7 @@ export function Tools() {
         runtimeResolution=${data?.runtime_resolution}
       />
 
-      <${Card} title="시스템 도구 목록" class="section mb-4">
+      <${SectionCard} label="시스템 도구 목록" class="section mb-4">
         <${FullInventoryView}
           inventory=${inventory}
           loading=${loading}
@@ -65,7 +65,7 @@ export function Tools() {
         />
       <//>
 
-      <${Card} title="도구 사용 현황" class="section mb-4">
+      <${SectionCard} label="도구 사용 현황" class="section mb-4">
         ${usage
           ? html`
               <div class="text-xs text-[var(--color-fg-muted)] mb-2">

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -481,7 +481,7 @@ export function TransportHealthPanel() {
         </summary>
         <div class="p-4">
           <div class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3">
-            <${SectionCard} title="SSE" status=${sseStatus} eyebrow=${`${data.sse.sessions_total} 활성`}>
+            <${SectionCard} label="SSE" status=${sseStatus} eyebrow=${`${data.sse.sessions_total} 활성`}>
               <div class="divide-y divide-card-border/50">
                 <${MetricRow} label="옵저버" value=${data.sse.sessions_observer} />
                 <${MetricRow} label="코디네이터" value=${data.sse.sessions_coordinator} />
@@ -495,7 +495,7 @@ export function TransportHealthPanel() {
               </div>
             <//>
 
-            <${SectionCard} title="gRPC" status=${grpcStatus} eyebrow=${transportEyebrow(data.grpc.configured, data.grpc.listening, data.grpc.port)}>
+            <${SectionCard} label="gRPC" status=${grpcStatus} eyebrow=${transportEyebrow(data.grpc.configured, data.grpc.listening, data.grpc.port)}>
               <div class="divide-y divide-card-border/50">
                 <${MetricRow} label="리스너" value=${data.grpc.listening ? '활성' : '중단'} />
                 <${MetricRow} label="구독자" value=${data.grpc.subscribers} />
@@ -510,7 +510,7 @@ export function TransportHealthPanel() {
               </div>
             <//>
 
-            <${SectionCard} title="WebSocket" status=${wsStatus} eyebrow=${transportEyebrow(data.websocket.configured, data.websocket.listening, data.websocket.port)}>
+            <${SectionCard} label="WebSocket" status=${wsStatus} eyebrow=${transportEyebrow(data.websocket.configured, data.websocket.listening, data.websocket.port)}>
               <div class="divide-y divide-card-border/50">
                 <${MetricRow} label="리스너" value=${data.websocket.listening ? 'live' : 'down'} />
                 <${MetricRow} label="세션" value=${data.websocket.sessions} />
@@ -539,7 +539,7 @@ export function TransportHealthPanel() {
               </div>
             <//>
 
-            <${SectionCard} title="WebRTC" status=${webrtcStatus} eyebrow=${webrtcEyebrow(data)}>
+            <${SectionCard} label="WebRTC" status=${webrtcStatus} eyebrow=${webrtcEyebrow(data)}>
               <div class="divide-y divide-card-border/50">
                 <${MetricRow} label="시그널링" value=${data.webrtc.signaling_available ? 'ready' : 'down'} sub=${data.webrtc.signaling_mode} />
                 <${MetricRow} label="연결된 채널" value=${data.webrtc.connected_channels} />
@@ -549,7 +549,7 @@ export function TransportHealthPanel() {
               </div>
             <//>
 
-            <${SectionCard} title="HTTP" status=${h2Status} eyebrow=${data.http2.listener_mode}>
+            <${SectionCard} label="HTTP" status=${h2Status} eyebrow=${data.http2.listener_mode}>
               <div class="divide-y divide-card-border/50">
                 <${MetricRow} label="POST" value=${data.streamable_http.endpoint} />
                 <${MetricRow} label="옵저버 스트림" value=${data.streamable_http.observer_stream} />
@@ -558,7 +558,7 @@ export function TransportHealthPanel() {
               </div>
             <//>
 
-            <${SectionCard} title="에이전트 풀" status=${clusterStatus} eyebrow=${clusterEyebrow}>
+            <${SectionCard} label="에이전트 풀" status=${clusterStatus} eyebrow=${clusterEyebrow}>
               <div class="divide-y divide-card-border/50">
                 <div class="text-3xs text-text-muted mb-2">클러스터 내 관리 유닛 풀. 부실(stale) = 하트비트가 끊긴 에이전트.</div>
                 <${MetricRow} label="관리 유닛" value=${formatMetricValue(data.cluster.managed_units)} sub=${managedUnitsSub} />

--- a/dashboard/src/components/verification-requests-panel.test.ts
+++ b/dashboard/src/components/verification-requests-panel.test.ts
@@ -33,8 +33,8 @@ vi.mock('../api/dashboard', () => ({
 // ── Mock UI primitives (real Preact components) ───────
 
 vi.mock('./common/card', () => ({
-  Card: ({ title, children }: any) => html`
-    <div data-testid="card"><h3>${title}</h3>${children}</div>
+  SectionCard: ({ label, children }: any) => html`
+    <div data-testid="card"><h3>${label}</h3>${children}</div>
   `,
 }))
 
@@ -278,4 +278,3 @@ describe('VerificationRequestsPanel', () => {
 })
 
 // ── filterVerificationRequests pure helper ─────────────
-

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -23,7 +23,7 @@ import {
   type VerificationRequestsResponse,
 } from '../api/dashboard'
 import { Btn } from './btn'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { EmptyState } from './common/feedback-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { StatusChip } from './common/status-chip'
@@ -611,7 +611,7 @@ export function VerificationRequestsPanel() {
           `
         : null}
 
-      <${Card} title="검증 요청">
+      <${SectionCard} label="검증 요청">
         ${data
           ? html`<${RequestsTable}
               requests=${filtered}

--- a/dashboard/src/components/verification-specs-panel.ts
+++ b/dashboard/src/components/verification-specs-panel.ts
@@ -19,7 +19,7 @@ import {
   type TlaSpecsResponse,
 } from '../api/dashboard'
 import { Btn } from './btn'
-import { Card } from './common/card'
+import { SectionCard } from './common/card'
 import { EmptyState } from './common/feedback-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { StatusChip } from './common/status-chip'
@@ -187,7 +187,7 @@ export function VerificationSpecsPanel() {
         ? html`<${LoadingState}>TLA+ 스펙 목록 불러오는 중...<//>`
         : null}
 
-      <${Card} title="형식 명세">
+      <${SectionCard} label="형식 명세">
         <div class="mb-2 text-xs text-[var(--color-fg-muted)]">
           <span class="font-mono">${dirLabel}</span>
         </div>


### PR DESCRIPTION
Summary:
- Remove the legacy Card wrapper and route callers to SectionCard label or SurfaceCard.
- Remove SectionCard title alias so label is the sole header prop.
- Update dashboard tests/mocks for the explicit card primitives.

Verification:
- pnpm vitest run --config vitest.config.ts src/components/common/card.test.ts src/components/common/card.a11y.test.ts src/components/verification-requests-panel.test.ts src/components/tools/tools-main.test.ts src/components/tlc-results-panel.test.ts src/components/activity-graph-panels.test.ts src/components/activity-swimlane-fetch.test.ts src/components/board/post-detail.test.ts --no-file-parallelism --maxWorkers=1 (8 files, 75 tests)
- pnpm typecheck
- pnpm eslint <changed dashboard files> (0 errors; 4 ignored-test-file warnings)
- git diff --check origin/main