### PR TITLE
refactor(auth/cdal/coord/drift/dated_jsonl): Masc_time_constants.hour/day replaces 3600.0/86400.0 literal at 10 sites across 8 files

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -107,7 +107,7 @@ let prune_archive ~base_path ~retention_days ~min_keep : int * int =
   then 0, 0
   else (
     let now = Unix.gettimeofday () in
-    let cutoff = now -. (float_of_int retention_days *. 86400.0) in
+    let cutoff = now -. (float_of_int retention_days *. Masc_time_constants.day) in
     let entries =
       try Sys.readdir archive_dir |> Array.to_list with
       | Sys_error _ -> []

--- a/lib/auth_credential_token.ml
+++ b/lib/auth_credential_token.ml
@@ -56,7 +56,8 @@ let expires_at_for_auth_config auth_cfg =
   if auth_cfg.token_expiry_hours > 0
   then (
     let expiry =
-      Time_compat.now () +. (float_of_int auth_cfg.token_expiry_hours *. 3600.0)
+      Time_compat.now ()
+      +. (float_of_int auth_cfg.token_expiry_hours *. Masc_time_constants.hour)
     in
     let tm = Unix.gmtime expiry in
     Some

--- a/lib/cdal_verdict_gate.ml
+++ b/lib/cdal_verdict_gate.ml
@@ -240,7 +240,7 @@ let ledger_health_report ?base_dir () : ledger_health =
 (* Threshold for boot-time staleness WARN.  7 days picks up the
    12-day production dormancy from #10115 with margin while not
    firing on transient quiet periods. *)
-let stale_age_seconds_default = 7. *. 86400.
+let stale_age_seconds_default = 7. *. Masc_time_constants.day
 
 let log_ledger_health_warn_if_stale ?base_dir
     ?(stale_age_seconds = stale_age_seconds_default) () : ledger_health =
@@ -253,14 +253,14 @@ let log_ledger_health_warn_if_stale ?base_dir
         Cdal_eval_v1.persist. (#10115)"
        report.base_dir
    | Some _, Some age when age > stale_age_seconds ->
-     let days = age /. 86400. in
+     let days = age /. Masc_time_constants.day in
      Log.Task.warn
        "[cdal-gate] ledger health: latest verdict file is %.1f \
         days old (threshold %.1f days; %d files scanned in %s).  \
         Writer pipeline likely dormant — strict-contract tasks \
         will fail until restored. (#10115)"
        days
-       (stale_age_seconds /. 86400.)
+       (stale_age_seconds /. Masc_time_constants.day)
        report.total_files
        report.base_dir
    | Some _, _ -> ());

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -360,7 +360,7 @@ let claim_next_r
         let effective_priority (task : Masc_domain.task) =
           let age_hours =
             match parse_time task.created_at with
-            | Some created -> (now -. created) /. 3600.0
+            | Some created -> (now -. created) /. Masc_time_constants.hour
             | None -> 0.0
           in
           let boost = Float.to_int (Float.round (age_hours /. 24.0)) in

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -231,7 +231,7 @@ let prune_unlocked t ~days =
   if days <= 0 then 0
   else begin
     let now = Unix.gettimeofday () in
-    let cutoff = now -. (float_of_int days *. 86400.0) in
+    let cutoff = now -. (float_of_int days *. Masc_time_constants.day) in
     let cutoff_tm = Unix.gmtime cutoff in
     let cutoff_month =
       Printf.sprintf "%04d-%02d"

--- a/lib/drift_guard.ml
+++ b/lib/drift_guard.ml
@@ -276,7 +276,7 @@ let get_drift_stats config ~days =
   if not (Sys.file_exists path) then (0, 0, 0.0)
   else
     let cutoff =
-      Time_compat.now () -. (float_of_int (max 0 days) *. 24.0 *. 3600.0)
+      Time_compat.now () -. (float_of_int (max 0 days) *. Masc_time_constants.day)
     in
     (* Streaming aggregation — total / drift_count / similarity_sum
        fold over the JSONL without materialising the row list. The

--- a/lib/level2_config.ml
+++ b/lib/level2_config.ml
@@ -43,7 +43,9 @@ module Hebbian = struct
      1h / 14d ratio satisfies this: ~336 consolidation passes before a
      single synapse's decay window closes. *)
   let consolidation_interval_s () =
-    Env_config_core.get_float ~default:3600.0 "MASC_HEBBIAN_CONSOLIDATION_INTERVAL_S"
+    Env_config_core.get_float
+      ~default:Masc_time_constants.hour
+      "MASC_HEBBIAN_CONSOLIDATION_INTERVAL_S"
   let decay_after_days () =
     Env_config_core.get_float ~default:14.0 "MASC_HEBBIAN_DECAY_AFTER_DAYS"
 end

--- a/lib/reputation_ledger_v2.ml
+++ b/lib/reputation_ledger_v2.ml
@@ -215,7 +215,9 @@ let read_events_for_agent (config : Coord.config) ~agent_id ~window_days
   if String.trim agent_id = "" then []
   else begin
     let now = Time_compat.now () in
-    let since = event_date_string (now -. (float_of_int window_days *. 86400.0)) in
+    let since =
+      event_date_string (now -. (float_of_int window_days *. Masc_time_constants.day))
+    in
     let until = event_date_string now in
     let store = get_store config in
     Dated_jsonl.read_range store ~since ~until


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" — Magic Number Time-literal 시리즈 **12번째 PR**. **8 파일 / 10 사이트** — auth + cdal + coord + drift + dated_jsonl + reputation + level2 small/scattered cluster.

### 패턴

3 hour-substitutions + 7 day-substitutions. `24.0 *. 3600.0` 표현 1건 (drift_guard) 이 `Masc_time_constants.day` 로 collapse.

before:
```ocaml
(* level2_config.ml:46 *)              ~default:3600.0
(* auth_credential_token.ml:59 *)      ... *. 3600.0
(* coord_task_schedule.ml:363 *)       ... /. 3600.0
(* dated_jsonl.ml:234 *)               days *. 86400.0
(* reputation_ledger_v2.ml:218 *)      window_days *. 86400.0
(* drift_guard.ml:279 *)               days *. 24.0 *. 3600.0
(* cdal_verdict_gate.ml:243 *)         7. *. 86400.
(* cdal_verdict_gate.ml:256 *)         age /. 86400.
(* cdal_verdict_gate.ml:263 *)         stale_age_seconds /. 86400.
(* auth.ml:110 *)                      retention_days *. 86400.0
```

after:
```ocaml
~default:Masc_time_constants.hour
*. Masc_time_constants.hour
/. Masc_time_constants.hour
*. Masc_time_constants.day
*. Masc_time_constants.day    (* 24.0 *. 3600.0 collapses *)
7. *. Masc_time_constants.day
/. Masc_time_constants.day
```

10 사이트 (3600.0 × 3 + 86400.0 × 7):
- `lib/level2_config.ml:46` (Hebbian consolidation 1h default)
- `lib/auth_credential_token.ml:59` (token expiry hours)
- `lib/coord/coord_task_schedule.ml:363` (age_hours divisor)
- `lib/dated_jsonl/dated_jsonl.ml:234` (retention window)
- `lib/reputation_ledger_v2.ml:218` (window_days)
- `lib/drift_guard.ml:279` (`24.0 *. 3600.0` → day collapse)
- `lib/cdal_verdict_gate.ml:243` (7-day stale threshold)
- `lib/cdal_verdict_gate.ml:256` (age → days)
- `lib/cdal_verdict_gate.ml:263` (threshold → days)
- `lib/auth.ml:110` (auth archive retention)

## 변경

- 8 files, +15/-10
- 3 hour-substitutions + 7 day-substitutions
- 동작 무변경 (`Masc_time_constants.hour = 3600.0`, `.day = 86400.0`)

## Magic-number lint impact

- Before: 3 `3600.0` + 7 `86400.0` = 10
- After: 0

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 10 사이트 *모두* 동시 처리

## Test impact

- 동작 무변경
- `dune build lib/` PASS

## Related

- PR #19037 ~ #19096 — Magic Number Time-literal 시리즈 누적 11
- `lib/config/masc_time_constants.ml` — time SSOT
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
