### PR TITLE
perf(dashboard/keeper-api): cache + offload tool-stats (5-trial 0.16s..1.92s)

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -115,86 +115,104 @@ let handle_keeper_get_subroutes state req request reqd =
           ~default:24
         |> max 1 |> min 168  (* 1h .. 7d *)
       in
-      let since = Time_compat.now () -. (float_of_int window_hours *. Masc_time_constants.hour) in
-      let read_result =
-        Trajectory.read_entries_since_result ~masc_root ~keeper_name:name ~since
+      (* Trajectory scan + tool-stat aggregation + hourly timeline +
+         coverage-gap lookup all hit disk under [masc_root]. 5-trial
+         latency variance 0.16s..1.92s (mean ~1.0s) on PR #19097 HEAD
+         because each miss ran on the calling fiber's Eio main domain.
+         Mirrors PRs #19088 / #19097 — cache + offload, key includes the
+         inputs that change the result. *)
+      let cache_key =
+        Printf.sprintf "keeper:tool-stats:%s:%s:%d" masc_root name window_hours
       in
-      let entries = read_result.Trajectory.entries in
-      let tools = Trajectory.aggregate_tool_stats entries in
-      let timeline = Trajectory.hourly_timeline entries in
-      let latest_ts =
-        List.fold_left
-          (fun acc (entry : Trajectory.tool_call_entry) ->
-            match acc with
-            | Some ts when ts >= entry.ts -> acc
-            | _ -> Some entry.ts)
-          None entries
+      let json =
+        Dashboard_cache.get_or_compute cache_key ~ttl:5.0 (fun () ->
+          Domain_pool_ref.submit_io_or_inline (fun () ->
+            let since =
+              Time_compat.now ()
+              -. (float_of_int window_hours *. Masc_time_constants.hour)
+            in
+            let read_result =
+              Trajectory.read_entries_since_result ~masc_root ~keeper_name:name ~since
+            in
+            let entries = read_result.Trajectory.entries in
+            let tools = Trajectory.aggregate_tool_stats entries in
+            let timeline = Trajectory.hourly_timeline entries in
+            let latest_ts =
+              List.fold_left
+                (fun acc (entry : Trajectory.tool_call_entry) ->
+                  match acc with
+                  | Some ts when ts >= entry.ts -> acc
+                  | _ -> Some entry.ts)
+                None entries
+            in
+            let latest_age_s =
+              match latest_ts with
+              | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
+              | None -> None
+            in
+            let freshness_slo_s = 300.0 in
+            let dashboard_surface = "/api/v1/keepers/:name/tool-stats" in
+            let coverage_gaps =
+              Telemetry_coverage_gap.read_recent ~masc_root ~n:32
+              |> List.filter (fun gap ->
+                   String.equal
+                     (Safe_ops.json_string ~default:"" "dashboard_surface" gap)
+                     dashboard_surface
+                   &&
+                   match Safe_ops.json_string_opt "keeper_name" gap with
+                   | Some keeper_name -> String.equal keeper_name name
+                   | None -> true)
+            in
+            let latest_gap =
+              List.rev coverage_gaps |> List.find_opt (fun _ -> true)
+            in
+            let health, stale_reason =
+              match latest_gap with
+              | Some gap ->
+                  ( "coverage_gap",
+                    Safe_ops.json_string ~default:"coverage_gap" "stale_reason" gap )
+              | None -> (
+                  match latest_age_s with
+                  | None -> ("empty", "no_entries")
+                  | Some age when age > freshness_slo_s ->
+                      ("stale", "freshness_slo_exceeded")
+                  | Some _ -> ("ok", ""))
+            in
+            `Assoc [
+              ("keeper", `String name);
+              ("window_hours", `Int window_hours);
+              ("total_entries", `Int (List.length entries));
+              ("source", `String "trajectory_tool_call");
+              ( "producer",
+                `String
+                  "keeper_hooks_oas.post_tool_use|mcp_server_eio_call_tool.runtime_mcp" );
+              ("durable_store", `String (Trajectory.trajectories_dir masc_root name));
+              ("dashboard_surface", `String dashboard_surface);
+              ("freshness_slo_s", `Float freshness_slo_s);
+              ( "latest_ts_unix",
+                match latest_ts with Some ts -> `Float ts | None -> `Null );
+              ( "latest_ts_iso",
+                match latest_ts with
+                | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
+                | None -> `Null );
+              ( "latest_age_s",
+                match latest_age_s with Some age -> `Float age | None -> `Null );
+              ("health", `String health);
+              ( "stale_reason",
+                if stale_reason = "" then `Null else `String stale_reason );
+              ( "gate_decode",
+                `Assoc
+                  [
+                    ( "parsed_gate_count",
+                      `Int read_result.Trajectory.gate_decode.parsed_gate_count );
+                    ( "legacy_default_count",
+                      `Int read_result.Trajectory.gate_decode.legacy_default_count );
+                  ] );
+              ("coverage_gaps", `List coverage_gaps);
+              ("tools", `List (List.map Trajectory.tool_stat_to_json tools));
+              ("timeline", `List (List.map Trajectory.hourly_bucket_to_json timeline));
+            ]))
       in
-      let latest_age_s =
-        match latest_ts with
-        | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
-        | None -> None
-      in
-      let freshness_slo_s = 300.0 in
-      let dashboard_surface = "/api/v1/keepers/:name/tool-stats" in
-      let coverage_gaps =
-        Telemetry_coverage_gap.read_recent ~masc_root ~n:32
-        |> List.filter (fun gap ->
-             String.equal
-               (Safe_ops.json_string ~default:"" "dashboard_surface" gap)
-               dashboard_surface
-             &&
-             match Safe_ops.json_string_opt "keeper_name" gap with
-             | Some keeper_name -> String.equal keeper_name name
-             | None -> true)
-      in
-      let latest_gap = List.rev coverage_gaps |> List.find_opt (fun _ -> true) in
-      let health, stale_reason =
-        match latest_gap with
-        | Some gap ->
-            ( "coverage_gap",
-              Safe_ops.json_string ~default:"coverage_gap" "stale_reason" gap )
-        | None -> (
-            match latest_age_s with
-            | None -> ("empty", "no_entries")
-            | Some age when age > freshness_slo_s ->
-                ("stale", "freshness_slo_exceeded")
-            | Some _ -> ("ok", ""))
-      in
-      let json = `Assoc [
-        ("keeper", `String name);
-        ("window_hours", `Int window_hours);
-        ("total_entries", `Int (List.length entries));
-        ("source", `String "trajectory_tool_call");
-        ( "producer",
-          `String
-            "keeper_hooks_oas.post_tool_use|mcp_server_eio_call_tool.runtime_mcp" );
-        ("durable_store", `String (Trajectory.trajectories_dir masc_root name));
-        ("dashboard_surface", `String dashboard_surface);
-        ("freshness_slo_s", `Float freshness_slo_s);
-        ( "latest_ts_unix",
-          match latest_ts with Some ts -> `Float ts | None -> `Null );
-        ( "latest_ts_iso",
-          match latest_ts with
-          | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
-          | None -> `Null );
-        ( "latest_age_s",
-          match latest_age_s with Some age -> `Float age | None -> `Null );
-        ("health", `String health);
-        ( "stale_reason",
-          if stale_reason = "" then `Null else `String stale_reason );
-        ( "gate_decode",
-          `Assoc
-            [
-              ( "parsed_gate_count",
-                `Int read_result.Trajectory.gate_decode.parsed_gate_count );
-              ( "legacy_default_count",
-                `Int read_result.Trajectory.gate_decode.legacy_default_count );
-            ] );
-        ("coverage_gaps", `List coverage_gaps);
-        ("tools", `List (List.map Trajectory.tool_stat_to_json tools));
-        ("timeline", `List (List.map Trajectory.hourly_bucket_to_json timeline));
-      ] in
       Http.Response.json ~compress:true ~request:req
         (Yojson.Safe.to_string json) reqd
   else if ends_with "/tool-calls" then


### PR DESCRIPTION
## Summary

`/api/v1/keepers/:name/tool-stats` 가 cache 없이 매 호출마다 disk scan + aggregation. 5-trial 측정에서 **0.16s ~ 1.92s** variance (mean ~1.0s). PR #19088 / #19097 와 동일 패턴 적용 (cache + offload).

## Evidence (PR #19097 HEAD, 5-trial)

```
trial 1: 0.56s
trial 2: 1.92s   ← worst case
trial 3: 1.37s
trial 4: 0.16s
trial 5: 1.12s
```

dashboard 가 keeper 별로 polling 하면 N keeper 마다 같은 패턴 — single-domain Eio loop 에서 직렬 stall.

## Why slow

매 호출:
1. `Trajectory.read_entries_since_result ~masc_root ~keeper_name ~since` — disk scan over window_hours (default 24h)
2. `Trajectory.aggregate_tool_stats entries` — tool 별 통계
3. `Trajectory.hourly_timeline entries` — 시간 buckets
4. `Telemetry_coverage_gap.read_recent ~masc_root ~n:32` + filter — 추가 disk read

전부 매 호출 단조반복 + Eio main domain.

## Fix

```ocaml
let cache_key =
  Printf.sprintf "keeper:tool-stats:%s:%s:%d" masc_root name window_hours
in
let json =
  Dashboard_cache.get_or_compute cache_key ~ttl:5.0 (fun () ->
    Domain_pool_ref.submit_io_or_inline (fun () ->
      (* ... existing compute, unchanged ... *)
      `Assoc [...]))
in
Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
```

- Cache key: `masc_root + name + window_hours` — 인자가 같은 호출만 dedup
- TTL 5s: dashboard ~2s polling cadence 에 맞게, 한 window 안 두 번째 호출은 cache hit
- offload: cache miss compute 가 worker domain 으로 → HTTP main domain unblock

Compute body 무수정 — closure capture only.

## Workaround Signature Gate

- counter-as-fix? NO
- substring 분류기? NO
- N-of-M patch? **PR #19088 / #19097 / #19023..#19060 와 같은 패턴**. 단 *다른 subsystem* (`keeper API` vs `cascade`). 본 PR 은 cache+offload 가 *없던* 새 endpoint. evidence-based (5-trial variance).
- cap/cooldown: TTL 은 cache freshness window 매개변수. perf optimization 으로 이전 PR 머지 선례 다수.

## Build

```
$ dune build --root . @check; echo "EXIT=$?"
EXIT=0
```

## Test plan

- [ ] CI build PASS
- [ ] 서버 재시작 후 `/keepers/sangsu/tool-stats` 5회 측정 — 모두 < 100ms (cache hit)
- [ ] keeper N=10 동시 호출 시 main domain stall 없음
- [ ] `cache-stats` 에서 `keeper:tool-stats:*` entry 정상 등록

## Related

- PR #19088 — cascade endpoint cache (1단계)
- PR #19097 — cascade offload + TTL tuning (2단계)
- PR #19060 — task history cache (다른 endpoint, 같은 패턴)
- 본 PR — keeper tool-stats (P0 from cache-stats post-#19097 audit)

## Next candidates (별도 PR)

- `/api/v1/keepers/:name/tool-calls` — 같은 module, 비슷한 compute
- `/api/v1/cascade/client_capacity/history?limit=100` 1.07s — query params (limit/kind/since_ts) cache key 신중
