### PR TITLE
refactor(dashboard/test): centralise happy-dom Document cast types into a single helper file

### DIFF
--- a/dashboard/src/components/common/copy-id-button.test.ts
+++ b/dashboard/src/components/common/copy-id-button.test.ts
@@ -8,12 +8,11 @@ import {
   summarizeCopyIdButton,
 } from './copy-id-button'
 import { _testGetToasts, _testResetToasts } from './toast'
+import type { ExecCommandFn, HappyDomDocument } from './happy-dom-helpers'
 
 // happy-dom does not expose `document.execCommand` by default. Assign/delete
 // directly rather than spying on an undefined property.
 
-type ExecCommandFn = (cmd: string) => boolean
-type HappyDomDocument = { execCommand?: ExecCommandFn }
 const doc = document as unknown as HappyDomDocument
 const flushUi = async () => {
   for (let i = 0; i < 5; i++) await Promise.resolve()

--- a/dashboard/src/components/common/copyable-code.test.ts
+++ b/dashboard/src/components/common/copyable-code.test.ts
@@ -8,13 +8,12 @@ import {
   summarizeCopyableCode,
 } from './copyable-code'
 import { _testResetToasts } from './toast'
+import type { ExecCommandFn, HappyDomDocument } from './happy-dom-helpers'
 
 const flushUi = async () => {
   for (let i = 0; i < 5; i++) await Promise.resolve()
 }
 
-type ExecCommandFn = (cmd: string) => boolean
-type HappyDomDocument = { execCommand?: ExecCommandFn }
 const doc = document as unknown as HappyDomDocument
 
 describe('CopyableCode', () => {

--- a/dashboard/src/components/common/happy-dom-helpers.ts
+++ b/dashboard/src/components/common/happy-dom-helpers.ts
@@ -1,0 +1,16 @@
+// Test-only type fixtures for happy-dom-backed unit tests.
+//
+// `vitest` runs this dashboard's tests against happy-dom rather than a
+// real browser. happy-dom implements `document.execCommand` as an
+// optional method, but neither the real DOM `Document` type nor
+// happy-dom's exported type spell that out cleanly — copy-button tests
+// have to cast through `unknown` to stub it. Two test files (`copyable-code`,
+// `copy-id-button`) shipped the exact same three-line fixture; centralise
+// the cast types here so a future API tweak (e.g. happy-dom typing
+// `execCommand` natively) only updates one place.
+//
+// `export type` only — keeps this module type-only at the import boundary
+// so production bundlers tree-shake the file out cleanly.
+
+export type ExecCommandFn = (cmd: string) => boolean
+export type HappyDomDocument = { execCommand?: ExecCommandFn }


### PR DESCRIPTION
## 요약
2 test 파일 (`copyable-code.test.ts`, `copy-id-button.test.ts`) 의 byte-identical 3-line happy-dom Document cast type fixture 를 `components/common/happy-dom-helpers.ts` 신설 + type-only export 로 SSOT 화.

## 배경
`rg "as unknown as HappyDomDocument"` sweep 결과 2 test 파일에 동일 fixture 발견:

```ts
type ExecCommandFn = (cmd: string) => boolean
type HappyDomDocument = { execCommand?: ExecCommandFn }
const doc = document as unknown as HappyDomDocument
```

happy-dom (vitest 의 DOM 환경) 이 `document.execCommand` 를 *optional method* 로 expose 하지만 standard `Document` type 이 cleanly 표현 못 함. copy-button test 들이 `unknown` cast 필요. 미래 happy-dom 의 typing 변경 (e.g. `execCommand` native typing) 시 2 곳 모두 갱신 필요.

## 변경

### `components/common/happy-dom-helpers.ts` (신설)
- `export type ExecCommandFn = (cmd: string) => boolean`
- `export type HappyDomDocument = { execCommand?: ExecCommandFn }`
- JSDoc 으로 *happy-dom 의 `execCommand` optional typing 한계* + *type-only export 가 production bundle 에서 tree-shake* 명시

### 2 test 파일 migration
- `copyable-code.test.ts` + `copy-id-button.test.ts`: inline `type` 정의 2 줄 삭제 + `import type { ExecCommandFn, HappyDomDocument } from './happy-dom-helpers'` 추가
- `const doc = document as unknown as HappyDomDocument` cast 는 *각 describe block 의 local mock teardown* 위해 file scope 유지

## 검증
- typecheck PASS
- lint 0 errors
- targeted tests (copyable-code + copy-id-button) 25/25 PASS
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)
- 첫 2 run 모두 추가 fail (`harness-health`, `board-surface`) 관찰 → 재실행 1 fail = baseline 만. **8 번째 flaky pair 등장** (iter#34/35/38/40/42/46/47/48). baseline-diff SOP 로 false-positive 회피.

## iter#19 R 패턴 응용
test = spec doc 패턴이 *infrastructure type fixture* 영역에 적용. assertion 의 *literal 명세* 는 inline 유지하되, *cross-test infrastructure type* 만 SSOT 화. 두 갈래 (spec doc 유지 vs infrastructure SSOT) 가 *test 영역에서도 같이 적용 가능* 임을 보여줌.

## /loop iter#48
SSOT 위반 dashboard 축출 loop 의 iter#48. cumulative 48 PR (31 머지 + 1 OPEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
