### PR TITLE
Remove StatTile legacy variants

### DIFF
--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -308,17 +308,17 @@ function CharacterPlate({ name }: { name: string }) {
       <div class="w-full mt-2">
         ${isKeeper ? html`
           <${StatGrid} cols=${4} items=${[
-            { label: 'CTX', value: ctxPct != null ? `${ctxPct}%` : 'N/A', hint: keeper.context_tokens != null && keeper.context_max != null ? `${formatTokens(keeper.context_tokens)} / ${formatTokens(keeper.context_max)}` : undefined, variant: 'gold' },
-            { label: '세대', value: generation ?? 0, variant: 'gold' },
-            { label: '턴', value: keeper.turn_count ?? 0, variant: 'gold' },
-            { label: '자율 턴', value: keeper.autonomous_turn_count ?? 0, hint: autonomyHint(keeper.autonomous_turn_count, keeper.proactive_enabled), variant: 'gold' },
+            { label: 'CTX', value: ctxPct != null ? `${ctxPct}%` : 'N/A', delta: keeper.context_tokens != null && keeper.context_max != null ? { direction: 'flat' as const, text: `${formatTokens(keeper.context_tokens)} / ${formatTokens(keeper.context_max)}` } : undefined },
+            { label: '세대', value: generation ?? 0 },
+            { label: '턴', value: keeper.turn_count ?? 0 },
+            { label: '자율 턴', value: keeper.autonomous_turn_count ?? 0, delta: autonomyHint(keeper.autonomous_turn_count, keeper.proactive_enabled) ? { direction: 'flat' as const, text: autonomyHint(keeper.autonomous_turn_count, keeper.proactive_enabled) } : undefined },
           ]} />
         ` : html`
           <${StatGrid} cols=${4} items=${[
-            { label: '완료', value: summary ? summary.tasks_completed : 'N/A', variant: 'gold' },
-            { label: '수임', value: summary ? summary.tasks_claimed : 'N/A', variant: 'gold' },
-            { label: '메시지', value: summary ? summary.messages_sent : 'N/A', variant: 'gold' },
-            { label: '활동', value: summary && summary.active_duration_minutes > 0 ? `${Math.round(summary.active_duration_minutes)}m` : summary ? '0m' : 'N/A', variant: 'gold' },
+            { label: '완료', value: summary ? summary.tasks_completed : 'N/A' },
+            { label: '수임', value: summary ? summary.tasks_claimed : 'N/A' },
+            { label: '메시지', value: summary ? summary.messages_sent : 'N/A' },
+            { label: '활동', value: summary && summary.active_duration_minutes > 0 ? `${Math.round(summary.active_duration_minutes)}m` : summary ? '0m' : 'N/A' },
           ]} />
         `}
       </div>

--- a/dashboard/src/components/common/stat-tile.a11y.test.ts
+++ b/dashboard/src/components/common/stat-tile.a11y.test.ts
@@ -1,8 +1,7 @@
 // @vitest-environment happy-dom
 //
 // jest-axe coverage for StatGrid (StatTile is internal — exposed via the
-// grid). Tests pin all 4 variants (default/gold/accent/warn) + grid
-// columns config + tiles with optional hint.
+// grid). Tests pin KPI status classes, grid columns config, and delta text.
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
@@ -20,7 +19,7 @@ describe('StatGrid a11y', () => {
     document.body.removeChild(container)
   })
 
-  it('default variant grid passes axe', async () => {
+  it('default status grid passes axe', async () => {
     render(
       html`<${StatGrid}
         items=${[
@@ -34,14 +33,14 @@ describe('StatGrid a11y', () => {
     expect(await axe(container)).toHaveNoViolations()
   })
 
-  it('all 4 variants in one grid pass axe', async () => {
+  it('all 4 statuses in one grid pass axe', async () => {
     render(
       html`<${StatGrid}
         items=${[
-          { label: 'Default', value: 10 },
-          { label: 'Gold', value: 20, variant: 'gold' },
-          { label: 'Accent', value: 30, variant: 'accent' },
-          { label: 'Warn', value: 5, variant: 'warn' },
+          { label: 'Critical', value: 1, status: 'crit' },
+          { label: 'Warn', value: 2, status: 'warn' },
+          { label: 'Ok', value: 3, status: 'ok' },
+          { label: 'Neutral', value: 4, status: 'brass' },
         ]}
         cols=${4}
       />`,
@@ -50,12 +49,12 @@ describe('StatGrid a11y', () => {
     expect(await axe(container)).toHaveNoViolations()
   })
 
-  it('tiles with hint passes axe', async () => {
+  it('tiles with delta text pass axe', async () => {
     render(
       html`<${StatGrid}
         items=${[
-          { label: 'Throughput', value: '1.2k', hint: 'last 5m' },
-          { label: 'Errors', value: 0, hint: 'all clear', variant: 'gold' },
+          { label: 'Throughput', value: '1.2k', delta: { direction: 'flat', text: 'last 5m' } },
+          { label: 'Errors', value: 0, status: 'ok', delta: { direction: 'flat', text: 'all clear' } },
         ]}
       />`,
       container,

--- a/dashboard/src/components/common/stat-tile.test.ts
+++ b/dashboard/src/components/common/stat-tile.test.ts
@@ -11,38 +11,12 @@ describe('StatTile', () => {
     expect(container.textContent).toContain('99.9%')
   })
 
-  it('renders hint when provided', () => {
-    const container = document.createElement('div')
-    render(h(StatTile, { label: 'A', value: '1', hint: 'last hour' }), container)
-    expect(container.textContent).toContain('last hour')
-  })
-
-  it('applies default variant styles', () => {
+  it('uses brass KPI status by default', () => {
     const container = document.createElement('div')
     render(h(StatTile, { label: 'A', value: '1' }), container)
     const el = container.querySelector('div')
-    expect(el?.classList.contains('bg-[var(--color-bg-elevated)]')).toBe(true)
-  })
-
-  it('applies gold variant styles', () => {
-    const container = document.createElement('div')
-    render(h(StatTile, { label: 'A', value: '1', variant: 'gold' }), container)
-    const el = container.querySelector('div')
-    expect(el?.classList.contains('bg-[var(--color-brass-soft)]')).toBe(true)
-  })
-
-  it('applies accent variant styles', () => {
-    const container = document.createElement('div')
-    render(h(StatTile, { label: 'A', value: '1', variant: 'accent' }), container)
-    const el = container.querySelector('div')
-    expect(el?.classList.contains('bg-[var(--color-state-active-bg)]')).toBe(true)
-  })
-
-  it('applies warn variant styles', () => {
-    const container = document.createElement('div')
-    render(h(StatTile, { label: 'A', value: '1', variant: 'warn' }), container)
-    const el = container.querySelector('div')
-    expect(el?.classList.contains('text-[var(--color-warn-fg)]')).toBe(true)
+    expect(el?.classList.contains('kpi-cell')).toBe(true)
+    expect(el?.classList.contains('is-brass')).toBe(true)
   })
 
   it('applies kpi-cell status class when status is provided', () => {
@@ -81,13 +55,12 @@ describe('StatTile', () => {
     expect(val?.textContent).toBe('999')
   })
 
-  it('status overrides variant styling', () => {
+  it('applies explicit ok status class', () => {
     const container = document.createElement('div')
-    render(h(StatTile, { label: 'A', value: '1', variant: 'gold', status: 'ok' }), container)
+    render(h(StatTile, { label: 'A', value: '1', status: 'ok' }), container)
     const el = container.querySelector('div')
     expect(el?.classList.contains('kpi-cell')).toBe(true)
     expect(el?.classList.contains('is-ok')).toBe(true)
-    expect(el?.classList.contains('bg-[var(--color-brass-soft)]')).toBe(false)
   })
 })
 

--- a/dashboard/src/components/common/stat-tile.ts
+++ b/dashboard/src/components/common/stat-tile.ts
@@ -1,20 +1,17 @@
 // StatTile — reusable KPI/stat display tile.
-// Layer 1: inline variant (backward compat, label/value/hint).
-// Layer 2: kpi.css status semantics (inset accent bar, gradient bg, delta, spark).
+// Uses kpi.css status semantics (inset accent bar, gradient bg, delta, spark).
 
 import { html } from 'htm/preact'
 import { Sparkline } from './sparkline'
 
 type DeltaDirection = 'up' | 'down' | 'flat'
+type StatTileStatus = 'crit' | 'warn' | 'ok' | 'brass'
 
 interface StatTileProps {
   label: string
   value: string | number
-  hint?: string
-  variant?: 'default' | 'gold' | 'accent' | 'warn'
-  /** Semantic status — applies kpi.css inset accent bar + gradient bg.
-   *  Overrides `variant` for background/value-color when provided. */
-  status?: 'crit' | 'warn' | 'ok' | 'brass'
+  /** Semantic status — applies kpi.css inset accent bar + gradient bg. */
+  status?: StatTileStatus
   /** Trend indicator next to value. */
   delta?: { direction: DeltaDirection; text?: string }
   /** Pulse animation on value — signals live-updating data. */
@@ -23,21 +20,7 @@ interface StatTileProps {
   sparkValues?: number[]
 }
 
-const VARIANT_STYLES = {
-  default: 'bg-[var(--color-bg-elevated)] border-[var(--color-border-default)] text-[var(--color-fg-secondary)]',
-  gold: 'bg-[var(--color-brass-soft)] border-[var(--color-brass-border)] text-[var(--color-fg-secondary)]',
-  accent: 'bg-[var(--color-state-active-bg)] border-[var(--color-state-active-border)] text-[var(--color-fg-secondary)]',
-  warn: 'bg-[var(--color-warn-soft)] border-[var(--color-warn-border)] text-[var(--color-warn-fg)]',
-} as const
-
-const LABEL_STYLES = {
-  default: 'text-[var(--color-fg-muted)]',
-  gold: 'text-[var(--color-brass-fg)]',
-  accent: 'text-[var(--color-state-active-fg)]',
-  warn: 'text-[var(--color-warn-fg)]',
-} as const
-
-const STATUS_CLASS = {
+const STATUS_CLASS: Record<StatTileStatus, string> = {
   crit: 'is-crit',
   warn: 'is-warn',
   ok: 'is-ok',
@@ -50,33 +33,14 @@ const DELTA_ARROW: Record<DeltaDirection, string> = {
   flat: '→',
 }
 
-export function StatTile({ label, value, hint, variant = 'default', status, delta, live, sparkValues }: StatTileProps) {
-  const useStatus = status != null
-  const cellClass = useStatus
-    ? `kpi-cell ${STATUS_CLASS[status]}${live ? ' is-live' : ''}`
-    : `flex flex-col items-center gap-0.5 rounded-[var(--r-1)] border px-4 py-3 ${VARIANT_STYLES[variant]}`
-
-  const valueClass = useStatus
-    ? 'kpi-value'
-    : 'text-base font-bold tabular-nums leading-tight'
-
-  const labelClass = useStatus
-    ? 'kpi-label'
-    : `text-[length:var(--fs-2xs)] tracking-wider uppercase ${LABEL_STYLES[variant]}`
-
+export function StatTile({ label, value, status = 'brass', delta, live, sparkValues }: StatTileProps) {
   return html`
-    <div class="${cellClass}">
-      ${useStatus ? html`
-        <span class="${labelClass}">${label}</span>
-        <div class="kpi-row">
-          <span class="${valueClass}">${value}</span>
-          ${delta ? html`<span class="kpi-delta ${delta.direction}">${delta.text ?? DELTA_ARROW[delta.direction]}</span>` : null}
-        </div>
-      ` : html`
-        <span class="${valueClass}">${value}</span>
-        <span class="${labelClass}">${label}</span>
-        ${hint ? html`<span class="text-[length:var(--fs-2xs)] text-[var(--color-fg-disabled)] mt-0.5">${hint}</span>` : null}
-      `}
+    <div class="kpi-cell ${STATUS_CLASS[status]}${live ? ' is-live' : ''}">
+      <span class="kpi-label">${label}</span>
+      <div class="kpi-row">
+        <span class="kpi-value">${value}</span>
+        ${delta ? html`<span class="kpi-delta ${delta.direction}">${delta.text ?? DELTA_ARROW[delta.direction]}</span>` : null}
+      </div>
       ${sparkValues && sparkValues.length >= 2 ? html`
         <${Sparkline}
           values=${sparkValues}


### PR DESCRIPTION
Summary:
- Remove the StatTile legacy variant/hint rendering path.
- Render StatTile through KPI status semantics only, with brass as the neutral default.
- Move agent profile StatGrid hint metadata to delta text and remove variant item fields.

Verification:
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/common/stat-tile.test.ts src/components/common/stat-tile.a11y.test.ts --no-file-parallelism --maxWorkers=1 (2 files, 14 tests)
- pnpm eslint src/components/common/stat-tile.ts src/components/common/stat-tile.test.ts src/components/common/stat-tile.a11y.test.ts src/components/agent-profile.ts
- git diff --check origin/main