### PR TITLE
fix(log): replace Printf.eprintf/Eio.traceln with structured Log

### DIFF
--- a/lib/cdal_runtime/contract_runner.ml
+++ b/lib/cdal_runtime/contract_runner.ml
@@ -1,5 +1,7 @@
 module Retry = Llm_provider.Retry
 
+let _log = Log.create ~module_name:"contract_runner" ()
+
 type run_result =
   { response : (Types.api_response, Error.sdk_error) result
   ; proof : Cdal_proof.t
@@ -52,10 +54,18 @@ let finalize_during_exception finalized capture_state ~result_status =
   match finalize_once finalized capture_state ~result_status with
   | _ -> ()
   | exception exn ->
-    Printf.eprintf
-      "cdal contract runner: proof finalize failed during %s exception path: %s\n%!"
-      (Cdal_proof.result_status_to_string result_status)
-      (Printexc.to_string exn)
+    let result_status = Cdal_proof.result_status_to_string result_status in
+    let error = Printexc.to_string exn in
+    let message =
+      Printf.sprintf
+        "proof finalize failed during exception path: result_status=%s error=%s"
+        result_status
+        error
+    in
+    let before = Log.dropped_without_sink_count () in
+    Log.error _log message [ Log.S ("result_status", result_status); Log.S ("error", error) ];
+    if Log.dropped_without_sink_count () > before
+    then Printf.eprintf "contract_runner: %s\n%!" message
 ;;
 
 let run

--- a/lib/cdal_runtime/proof_store.ml
+++ b/lib/cdal_runtime/proof_store.ml
@@ -1,3 +1,5 @@
+let _log = Log.create ~module_name:"proof_store" ()
+
 type config = { root : string }
 
 type resolved_ref =
@@ -53,7 +55,17 @@ let run_status_path config ~run_id =
 
 let log_error context = function
   | Ok () -> ()
-  | Error err -> Printf.eprintf "[proof_store] %s: %s\n%!" context (Error.to_string err)
+  | Error err ->
+    let error = Error.to_string err in
+    let before = Log.dropped_without_sink_count () in
+    Log.error _log "proof store error"
+      [ Log.S ("context", context); Log.S ("error", error) ];
+    if Log.dropped_without_sink_count () > before
+    then
+      Printf.eprintf
+        "proof_store: proof store error context=%s error=%s\n%!"
+        context
+        error
 ;;
 
 let write_json context path json =

--- a/lib/opentelemetry_client_cohttp_eio.ml
+++ b/lib/opentelemetry_client_cohttp_eio.ml
@@ -67,7 +67,7 @@ let n_errors = Atomic.make 0
 let n_dropped = Atomic.make 0
 
 let report_err_ = function
-  | `Sysbreak -> Printf.eprintf "opentelemetry: ctrl-c captured, stopping\n%!"
+  | `Sysbreak -> Log.warn "opentelemetry: ctrl-c captured, stopping"
   | `Failure msg -> Format.eprintf "@[<2>opentelemetry: export failed: %s@]@." msg
   | `Status (code, { Opentelemetry.Proto.Status.code = scode; message; details }) ->
     let pp_details out l =
@@ -225,7 +225,7 @@ let mk_emitter ~stop ~clock ~net (config : Config.t) : (module EMITTER) =
       match r with
       | Ok () -> ()
       | Error `Sysbreak ->
-        Printf.eprintf "ctrl-c captured, stopping\n%!";
+        Log.warn "opentelemetry: ctrl-c captured, stopping";
         Atomic.set stop true
       | Error err ->
         Atomic.incr n_errors;
@@ -261,8 +261,8 @@ let mk_emitter ~stop ~clock ~net (config : Config.t) : (module EMITTER) =
       try f () with
       | e ->
         let bt = Printexc.get_backtrace () in
-        Printf.eprintf
-          "opentelemetry-eio: uncaught exception in %s: %s\n%s\n%!"
+        Log.warn
+          "opentelemetry-eio: uncaught exception in %s: %s\n%s"
           where
           (Printexc.to_string e)
           bt
@@ -326,14 +326,14 @@ let mk_emitter ~stop ~clock ~net (config : Config.t) : (module EMITTER) =
 
     let tick () =
       if Config.Env.get_debug ()
-      then Printf.eprintf "tick (from domain %d)\n%!" (Domain.self () :> int);
+      then Log.debug "opentelemetry: tick (from domain %d)" (Domain.self () :> int);
       run_tick_callbacks ();
       sample_gc_metrics_if_needed ();
       emit_all ~force:false
     ;;
 
     let cleanup ~on_done () =
-      if Config.Env.get_debug () then Printf.eprintf "opentelemetry: exiting...\n%!";
+      if Config.Env.get_debug () then Log.debug "opentelemetry: exiting...";
       Atomic.set stop true;
       run_tick_callbacks ();
       sample_gc_metrics_if_needed ();
@@ -370,7 +370,7 @@ module Backend (Emitter : EMITTER) : Opentelemetry.Collector.BACKEND = struct
 
   let signal_emit_gc_metrics () =
     if Config.Env.get_debug ()
-    then Printf.eprintf "opentelemetry: emit GC metrics requested\n%!";
+    then Log.debug "opentelemetry: emit GC metrics requested";
     Atomic.set needs_gc_metrics true
   ;;
 

--- a/lib/process/exec_tap.ml
+++ b/lib/process/exec_tap.ml
@@ -11,8 +11,6 @@
     - Writer exceptions are swallowed, except Eio.Cancel.Cancelled which
       must always propagate.  Tap must not break production. *)
 
-let _log = Log.create ~module_name:"exec_tap" ()
-
 type call_kind =
   | Exec_gate_decision
   | Process_eio_run_argv
@@ -148,7 +146,7 @@ let write_line ~kind ~argv ?env ?cwd (extras : extra_field list) =
       (try writer line with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->
-           Log.warn _log "writer failed" [ Log.S ("error", Printexc.to_string exn) ])
+           Log.error "exec_tap writer failed: %s" (Printexc.to_string exn))
 
 let record ~kind ~argv ?env ?cwd () =
   write_line ~kind ~argv ?env ?cwd []
@@ -209,7 +207,7 @@ let install_from_env () =
                   write_all fd line 0 len)
            in
            enable ~writer;
-           Log.info _log "enabled" [ Log.S ("path", out_path) ]
+           Log.info "exec_tap enabled: %s" out_path
        | Error msg ->
-           Log.warn _log "disabled: cannot open" [ Log.S ("path", out_path); Log.S ("error", msg) ])
+           Log.warn "exec_tap disabled: cannot open %s: %s" out_path msg)
   | None | Some _ -> ()

--- a/lib/process/exec_tap.ml
+++ b/lib/process/exec_tap.ml
@@ -11,6 +11,8 @@
     - Writer exceptions are swallowed, except Eio.Cancel.Cancelled which
       must always propagate.  Tap must not break production. *)
 
+let _log = Log.create ~module_name:"exec_tap" ()
+
 type call_kind =
   | Exec_gate_decision
   | Process_eio_run_argv
@@ -146,8 +148,7 @@ let write_line ~kind ~argv ?env ?cwd (extras : extra_field list) =
       (try writer line with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->
-           Printf.eprintf "[exec_tap] writer failed: %s\n%!"
-             (Printexc.to_string exn))
+           Log.warn _log "writer failed" [ Log.S ("error", Printexc.to_string exn) ])
 
 let record ~kind ~argv ?env ?cwd () =
   write_line ~kind ~argv ?env ?cwd []
@@ -208,8 +209,7 @@ let install_from_env () =
                   write_all fd line 0 len)
            in
            enable ~writer;
-           Printf.eprintf "[exec_tap] enabled \xe2\x86\x92 %s\n%!" out_path
+           Log.info _log "enabled" [ Log.S ("path", out_path) ]
        | Error msg ->
-           Printf.eprintf "[exec_tap] disabled: cannot open %s \xe2\x80\x94 %s\n%!"
-             out_path msg)
+           Log.warn _log "disabled: cannot open" [ Log.S ("path", out_path); Log.S ("error", msg) ])
   | None | Some _ -> ()

--- a/lib/prometheus_process.ml
+++ b/lib/prometheus_process.ml
@@ -24,10 +24,8 @@ let update_fd_gauges ~set_gauge ~metric_open_fds =
   if count >= fd_warn_threshold && not (Atomic.get fd_warned_once)
   then (
     Atomic.set fd_warned_once true;
-    Printf.eprintf
-      "[WARN] [Server] process open fd count %d has reached warn threshold %d — likely \
-       socket/file leak, investigate before accept() starts failing with EMFILE.\n\
-       %!"
+    Log.warn
+      "process open fd count %d reached warn threshold %d — likely socket/file leak"
       count
       fd_warn_threshold)
   else if count < fd_warn_threshold / 2

--- a/lib/prometheus_store.ml
+++ b/lib/prometheus_store.ml
@@ -34,7 +34,7 @@ let with_lock f =
      let trace = Printexc.raw_backtrace_to_string bt0 in
      let dump = Printf.sprintf "Prometheus.with_lock: %s\nCaller stack:\n%s" msg trace in
      Atomic.set last_deadlock_backtrace (Some dump);
-     Printf.eprintf "[ERROR] [Prometheus] %s\n%!" dump;
+     Log.error "Prometheus mutex deadlock: %s" dump;
      raise exn);
   Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock metrics_mutex) f
 ;;


### PR DESCRIPTION
## Summary
- Replace Printf.eprintf/Eio.traceln with structured Log across 10 files
- Library boundary respected: cdal_runtime uses OAS Log (structured fields), masc-mcp lib uses format-string Log
- exec_tap.ml: 3 Printf.eprintf → Log (writer failed, enabled, disabled)
- cascade_config_loader.ml: 2 Eio.traceln → Log.info ~ctx
- keeper_memory_bank.ml: 1 Eio.traceln → Log.Keeper.warn
- supervisor.ml: fix Log.Server ~ctx → ~keeper_name (API mismatch)
- cdal_runtime: 2 Printf.eprintf → OAS structured Log (proof_store, contract_runner)
- prometheus_store/process/transport_read_model: 3 Printf.eprintf → format-string Log
- opentelemetry_client_cohttp_eio.ml: 6 Printf.eprintf → Log (ctrl-c, debug, uncaught exn)

## Not converted (library boundary)
- fs_compat/*.ml, masc_http_client/pool.ml: no Log dependency, Printf.eprintf kept
- hooks.ml (OAS): agent_sdk_base cannot use Log (circular dep), Eio.traceln kept
- masc_log/log.ml: is the Log module itself, Printf.eprintf kept

## Test plan
- [x] `dune build lib/masc_mcp.cma` passes
- [ ] CI full build + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)