### PR TITLE
refactor(dashboard/ide): absorb 6 variant Number.isSafeInteger guards into isPositiveSafeInteger

### DIFF
--- a/dashboard/src/components/ide/anchored-thread-trace-bridge.ts
+++ b/dashboard/src/components/ide/anchored-thread-trace-bridge.ts
@@ -1,4 +1,5 @@
 import { pushTrace } from './keeper-trace-store'
+import { isPositiveSafeInteger } from '../common/normalize'
 
 /**
  * RFC-0028 PR-δ producer: anchored-thread → keeper-trace bridge.
@@ -70,7 +71,5 @@ export function bridgePostsToTrace(
 }
 
 function lineFromPost(post: AnchoredThreadProducerInput): number | null {
-  return typeof post.line === 'number' && Number.isSafeInteger(post.line) && post.line >= 1
-    ? post.line
-    : null
+  return isPositiveSafeInteger(post.line) ? post.line : null
 }

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -295,7 +295,7 @@ function mergeTagContext(next: MutableRunActivityContext, rawTag: string): void 
   }
   if (key === 'line') {
     const line = Number.parseInt(value, 10)
-    if (Number.isSafeInteger(line) && line >= 1) next.line = line
+    if (isPositiveSafeInteger(line)) next.line = line
     return
   }
   if (key === 'goal') next.goal_id = value

--- a/dashboard/src/components/ide/ide-editor-extensions.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.ts
@@ -10,6 +10,7 @@ import {
 import type { LineOwnership } from './keeper-line-ownership-store'
 import type { KeeperTraceContextFields, KeeperTraceEvent, KeeperTraceSource } from './keeper-trace-store'
 import { kSigil } from '../keeper-badge'
+import { isPositiveSafeInteger } from '../common/normalize'
 
 // ── Read-only lock ────────────────────────────────────────────────
 // Prevents all user input. CM6 6.x uses EditorState.changeFilter.
@@ -517,9 +518,7 @@ function selectTraceLineFromGutterClick(
   const stack = target.closest('.cm-trace-stack')
   if (!(stack instanceof HTMLElement) || stack.getAttribute('aria-hidden') === 'true') return false
   const lineFromMarker = Number(stack.dataset.line)
-  const line = Number.isSafeInteger(lineFromMarker) && lineFromMarker >= 1
-    ? lineFromMarker
-    : blockLine
+  const line = isPositiveSafeInteger(lineFromMarker) ? lineFromMarker : blockLine
   const traceLine = getTraceLines().find(candidate => candidate.line === line)
   const topEvent = traceLine?.events[0]
   if (!topEvent) return false
@@ -656,14 +655,10 @@ function traceEventFilePath(event: KeeperTraceEvent): string | null {
 
 function traceEventLine(event: KeeperTraceEvent): number | null {
   if (event.source === 'anchored-thread') {
-    return event.line !== null && Number.isSafeInteger(event.line) && event.line >= 1
-      ? event.line
-      : null
+    return isPositiveSafeInteger(event.line) ? event.line : null
   }
   if (event.source === 'activity-event') {
-    return Number.isSafeInteger(event.line) && event.line >= 1
-      ? event.line
-      : null
+    return isPositiveSafeInteger(event.line) ? event.line : null
   }
   if (
     event.source === 'cascade-hop'
@@ -671,7 +666,7 @@ function traceEventLine(event: KeeperTraceEvent): number | null {
     || event.source === 'decision-log'
   ) {
     const line = event.line
-    return line !== undefined && Number.isSafeInteger(line) && line >= 1
+    return isPositiveSafeInteger(line)
       ? line
       : null
   }


### PR DESCRIPTION
## 요약
iter#47 (PR #19095) 의 `isPositiveSafeInteger` type predicate 활용 — 변형 6 callsite (typeof guard 없는 / null-check 있는 / undefined-check 있는) 흡수. iter#44/#46/#47 의 *bulk-migrate-then-extend* SOP 세 번째 적용.

## 배경

iter#47 가 *byte-identical 3-clause* (`typeof === 'number' && Number.isSafeInteger && >= 1`) 7 callsite migration. 다음 sweep 결과 *variant 6 callsite* 발견 — *positive-safe-integer 같은 rule* 이지만 *value 가 이미 narrowed 되어 typeof guard 생략* 또는 *null/undefined check 가 추가됨*:

| 파일 | callsite | inline pattern |
|---|---|---|
| `anchored-thread-trace-bridge.ts:73` | `typeof post.line === 'number' && Number.isSafeInteger(post.line) && post.line >= 1` (실제로 byte-identical, iter#47 누락) |
| `ide-editor-extensions.ts:520` | `Number.isSafeInteger(lineFromMarker) && lineFromMarker >= 1` (number 추론) |
| `ide-editor-extensions.ts:659` | `event.line !== null && Number.isSafeInteger(event.line) && event.line >= 1` |
| `ide-editor-extensions.ts:664` | `Number.isSafeInteger(event.line) && event.line >= 1` |
| `ide-editor-extensions.ts:674` | `line !== undefined && Number.isSafeInteger(line) && line >= 1` |
| `ide-activity-panel.ts:298` | `Number.isSafeInteger(line) && line >= 1` (Number.parseInt 결과) |

`isPositiveSafeInteger(value: unknown): value is number` 가:
- non-number → false
- null / undefined → false (typeof !== 'number')
- NaN → false (Number.isSafeInteger 가 NaN false)

각 callsite 의 leading null/undefined/redundant typeof check 는 **자동 처리** — predicate 가 unknown 받아 모두 false 발화.

## 변경

### 6 callsite migration
- `anchored-thread-trace-bridge.ts:73` — `isPositiveSafeInteger(post.line) ? post.line : null`
- `ide-editor-extensions.ts:520` — `isPositiveSafeInteger(lineFromMarker) ? lineFromMarker : blockLine`
- `ide-editor-extensions.ts:659` — `isPositiveSafeInteger(event.line) ? event.line : null`
- `ide-editor-extensions.ts:664` — `isPositiveSafeInteger(event.line) ? event.line : null`
- `ide-editor-extensions.ts:674` — `isPositiveSafeInteger(line) ? line : null`
- `ide-activity-panel.ts:298` — `if (isPositiveSafeInteger(line)) next.line = line`

### Import 추가
- `anchored-thread-trace-bridge.ts` + `ide-editor-extensions.ts` 신규 import (각각 sibling component path)
- `ide-activity-panel.ts` 는 iter#47 PR #19095 에서 이미 import 됨, 추가 변경 없음

## 검증

- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)

## iter chain — *bulk-migrate-then-extend* 세 번째 적용

- iter#44 (PR #19069): `formatIssues` 7 byte-identical migration + actions-activity variant 분리 보존
- iter#46 (PR #19085): `formatIssues` 에 `maxIssues` 옵션 추가 + actions-activity variant 흡수
- iter#47 (PR #19095): `isPositiveSafeInteger` 7 byte-identical migration + 6 variant 분리 보존
- iter#49 (본 PR): 6 variant 흡수 — predicate 의 unknown 입력 처리로 자동 흡수 (helper 시그니처 확장 불필요)

iter#46 vs iter#49 차이: iter#46 는 *helper 시그니처 확장 필요* (maxIssues 옵션), iter#49 는 *predicate 의 unknown 입력 처리만으로 흡수 가능*. **bulk-migrate-then-extend 의 두 sub-variant** — *시그니처 확장* vs *기존 시그니처 충분*.

## /loop iter#49
SSOT 위반 dashboard 축출 loop 의 iter#49. cumulative 49 PR (31 머지 + 2 OPEN — #19101 + #19?_).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
