### PR TITLE
fix(keeper): hydrate personality fields from profile_defaults in prompt path

### DIFF
--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -143,10 +143,11 @@ let prepare_run_context
       ~short_goal:meta.short_goal
       ~mid_goal:meta.mid_goal
       ~long_goal:meta.long_goal
-      ~will:meta.will
-      ~needs:meta.needs
-      ~desires:meta.desires
-      ~instructions:meta.instructions
+      ~will:(Option.value profile_defaults.will ~default:meta.will)
+      ~needs:(Option.value profile_defaults.needs ~default:meta.needs)
+      ~desires:(Option.value profile_defaults.desires ~default:meta.desires)
+      ~instructions:
+        (Option.value profile_defaults.instructions ~default:meta.instructions)
       ~persona_extended
       ~keeper_name:meta.name
       ~active_goals

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -436,22 +436,29 @@ let autonomous_trigger_lines
   | _ -> []
 
 let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
+    ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
     ~(observation : Keeper_world_observation.world_observation)
     () : string * string
     =
   ignore base_path;
+  let will = Option.value profile_defaults.will ~default:meta.will in
+  let needs = Option.value profile_defaults.needs ~default:meta.needs in
+  let desires = Option.value profile_defaults.desires ~default:meta.desires in
+  let instructions =
+    Option.value profile_defaults.instructions ~default:meta.instructions
+  in
   let trait_lines =
     String.concat ""
       [
 
-        line_block "Will" meta.will;
-        line_block "Needs" meta.needs;
-        line_block "Desires" meta.desires;
+        line_block "Will" will;
+        line_block "Needs" needs;
+        line_block "Desires" desires;
       ]
   in
   let instructions_block =
-    if meta.instructions = "" then ""
-    else Printf.sprintf "\nInstructions:\n%s\n" meta.instructions
+    if instructions = "" then ""
+    else Printf.sprintf "\nInstructions:\n%s\n" instructions
   in
   let goal_lines =
     String.concat ""

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -22,6 +22,7 @@ val state_block_instruction_text : string
 val build_prompt :
   meta:Keeper_types.keeper_meta ->
   base_path:string ->
+  profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
   observation:Keeper_world_observation.world_observation ->
   unit ->
   string * string

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -263,6 +263,7 @@ let run_keeper_cycle
                  Keeper_unified_prompt.build_prompt
                    ~meta
                    ~base_path:config.base_path
+                   ~profile_defaults
                    ~observation
                    ()
                in


### PR DESCRIPTION
## Summary

`build_keeper_system_prompt: personality fields empty: [will, needs, desires]` WARN + prompt 안 config-drift marker 가 매 turn 마다 emit 되던 문제 fix.

- **Root**: PR #18963 (`refactor(keeper): TOML=config SSOT, JSON=runtime-only`) 가 `will/needs/desires` 를 config 로 분류 → runtime JSON 에서 scrub. 그러나 두 prompt-build path (`keeper_run_context.ml`, `keeper_unified_prompt.ml`) 는 raw `meta.{will,needs,desires}` 사용 → empty default 로 떨어짐 → WARN.
- **Fix**: `keeper_runtime.ml:249-251` 의 reconcile path 가 이미 사용 중인 `apply_default profile_defaults.* meta.*` 패턴을 prompt-build path 에도 적용 (여기선 `Option.value ... ~default:meta.*`). `profile_defaults` 는 두 caller 모두 *이미* 손에 들고 있어서 추가 디스크 read 0.
- **Disk state 검증**: 19/19 persona profile 모두 nested `keeper.{will,needs,desires}` 정상값 (21~150 bytes). `load_keeper_profile_defaults_from_persona:198-200` 가 nested 잘 읽음 → `profile_defaults.*` 가 `Some "<value>"` 로 채워짐.

### 변경 파일

| 파일 | 라인 | 변경 |
|---|---|---|
| `lib/keeper/keeper_run_context.ml` | 146-149 | `~will:meta.will` → `~will:(Option.value profile_defaults.will ~default:meta.will)` (4 fields) |
| `lib/keeper/keeper_unified_prompt.ml` | 438-450 | `build_prompt` 시그니처에 `~profile_defaults` 추가 + 내부 `Option.value` fallback |
| `lib/keeper/keeper_unified_prompt.mli` | 22-27 | 시그니처 동기화 |
| `lib/keeper/keeper_unified_turn.ml` | 263-268 | caller wire (`profile_defaults` 이미 line 166-167 에서 로드됨) |

총 4 file, +19/-9.

## Workaround Signature Gate

비해당. 본 PR 은 *anti-pattern 해소* 이지 추가 아님:
- ❌ Counter-as-Fix: WARN 자체를 끄지 않음. 데이터가 정상 흐름으로 들어가서 WARN emit 조건이 자연스럽게 사라짐.
- ❌ String/Substring 분류기: typed Option 패턴 (`Option.value`) — 컴파일러가 nullability 검증.
- ❌ N-of-M: 두 사이트 모두 한 PR 에서 처리. caller 가 같은 `profile_defaults` 를 들고 있는 자연스러운 단위.
- ❌ cap/cooldown/dedup/repair: 데이터 정합성 wiring 만.

## Test plan

- [ ] Local build PASS (`dune build lib`)
- [ ] 머지 후 keeper 서버 재기동
- [ ] fleet 로그에서 `personality fields empty` WARN 0건 확인 (이전: ~134/24h aggregated, ~50 in-prompt marker/cycle)
- [ ] LLM 이 받는 system_prompt 에서 "Personality config drift" marker 사라짐 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
