### PR TITLE
refactor(governance/dashboard): add Masc_time_constants.hour_int + 10 int sites + HOTFIX dated_jsonl/dune (main broken)

### DIFF
--- a/lib/config/masc_time_constants.ml
+++ b/lib/config/masc_time_constants.ml
@@ -15,6 +15,9 @@ let hour = 3600.0
 (** Seconds in one day (24 h). *)
 let day = 86400.0
 
+(** Integer seconds in one hour. *)
+let hour_int = 3600
+
 (** Integer seconds in one day. *)
 let day_int = 86400
 

--- a/lib/config/masc_time_constants.mli
+++ b/lib/config/masc_time_constants.mli
@@ -15,6 +15,9 @@ val hour : float
 val day : float
 (** Seconds in one day (24 h). *)
 
+val hour_int : int
+(** Integer seconds in one hour. *)
+
 val day_int : int
 (** Integer seconds in one day. *)
 

--- a/lib/dashboard/dashboard_goals_types_accessor.ml
+++ b/lib/dashboard/dashboard_goals_types_accessor.ml
@@ -209,11 +209,13 @@ let latest_iso ?fallback values =
       Some (List.fold_left iso_max first rest)
 
 let stagnation_threshold_seconds = function
-  | Goal_store.Short -> 6 * 3600
-  | Goal_store.Mid -> 24 * 3600
-  | Goal_store.Long -> 72 * 3600
+  | Goal_store.Short -> 6 * Masc_time_constants.hour_int
+  | Goal_store.Mid -> Masc_time_constants.day_int
+  | Goal_store.Long -> 3 * Masc_time_constants.day_int
 
 let human_duration seconds =
-  if seconds < 3600 then Printf.sprintf "%dm" (seconds / 60)
-  else if seconds < 86400 then Printf.sprintf "%dh" (seconds / 3600)
-  else Printf.sprintf "%dd" (seconds / 86400)
+  if seconds < Masc_time_constants.hour_int
+  then Printf.sprintf "%dm" (seconds / 60)
+  else if seconds < Masc_time_constants.day_int
+  then Printf.sprintf "%dh" (seconds / Masc_time_constants.hour_int)
+  else Printf.sprintf "%dd" (seconds / Masc_time_constants.day_int)

--- a/lib/dated_jsonl/dune
+++ b/lib/dated_jsonl/dune
@@ -7,4 +7,4 @@
  ; live in the single (flags ...) stanza so the effective warning mask is
  ; not split across (flags)/(ocamlc_flags)/(ocamlopt_flags).
  (flags (:standard -w -32 -w +4))
- (libraries fs_compat jsonl_writer eio unix yojson))
+ (libraries fs_compat jsonl_writer masc_mcp.config eio unix yojson))

--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -327,10 +327,11 @@ let keeper_handoff_cooldown_sec =
   register_int
     ~key:"keeper.handoff_cooldown_sec"
     ~default:(fun () -> 300)
-    ~min:30 ~max:3600
+    ~min:30 ~max:Masc_time_constants.hour_int
     ~meta:{ description = "Handoff 쿨다운(초)";
             value_type = "int";
-            min_value = Some (`Int 30); max_value = Some (`Int 3600) }
+            min_value = Some (`Int 30);
+            max_value = Some (`Int Masc_time_constants.hour_int) }
     ()
 
 (** Context ratio above which handoff pressure alert fires. *)
@@ -388,10 +389,11 @@ let keeper_snapshot_sec =
   register_int
     ~key:"keeper.snapshot_sec"
     ~default:(fun () -> Env_config_keeper.KeeperRuntime.snapshot_sec)
-    ~min:15 ~max:3600
+    ~min:15 ~max:Masc_time_constants.hour_int
     ~meta:{ description = "Snapshot 캡처 주기(초)";
             value_type = "int";
-            min_value = Some (`Int 15); max_value = Some (`Int 3600) }
+            min_value = Some (`Int 15);
+            max_value = Some (`Int Masc_time_constants.hour_int) }
     ()
 
 let keeper_work_as_hb_enabled =


### PR DESCRIPTION
## ⚠️ HOTFIX 포함 — main 이 현재 broken

PR #19099 (머지됨) 가 `lib/dated_jsonl/dated_jsonl.ml:234` 에 `Masc_time_constants.day` 호출을 추가했지만 `lib/dated_jsonl/dune` 의 `(libraries ...)` 에 `masc_mcp.config` 의존성을 추가하지 않아서 origin/main `736ef11e7` 시점부터 **build 실패** 상태입니다:

```
File "lib/dated_jsonl/dated_jsonl.ml", line 234, characters 46-65:
234 |     let cutoff = now -. (float_of_int days *. Masc_time_constants.day) in
Error: Unbound module Masc_time_constants
```

본 PR 은 1줄 dune fix 로 main green 복구.

## 요약

sw-dev §"Magic Number 금지" — Magic Number Time-literal 시리즈 **13번째 PR**. 3개 묶음:

### 1. SSOT 확장 — `Masc_time_constants.hour_int = 3600`

기존 `day_int : int` 와 대칭. 이전엔 int 사이트 (validation range max, integer unit conversion) 에서 SSOT 호출 불가 → magic number 잔류.

```ocaml
(* lib/config/masc_time_constants.ml *)
let hour_int = 3600
let day_int = 86400
```

### 2. 10 int site 교체 (3600 × 8 + 86400 × 2)

**governance_registry (4 sites — bound semantics)**:
```ocaml
(* before *)                              (* after *)
~min:30 ~max:3600                         ~min:30 ~max:Masc_time_constants.hour_int
max_value = Some (`Int 3600)              max_value = Some (`Int Masc_time_constants.hour_int)
~min:15 ~max:3600                         ~min:15 ~max:Masc_time_constants.hour_int
max_value = Some (`Int 3600)              max_value = Some (`Int Masc_time_constants.hour_int)
```

두 surface 의 max 가 "최대 1시간" 임을 코드 자체에 노출.

**dashboard_goals_types_accessor (6 sites — unit conversion)**:
```ocaml
(* before *)
| Goal_store.Short -> 6 * 3600
| Goal_store.Mid -> 24 * 3600
| Goal_store.Long -> 72 * 3600
if seconds < 3600 then ... (seconds / 60)
else if seconds < 86400 then "%dh" (seconds / 3600)
else "%dd" (seconds / 86400)

(* after *)
| Goal_store.Short -> 6 * Masc_time_constants.hour_int
| Goal_store.Mid -> Masc_time_constants.day_int               (* 24 * 3600 collapses *)
| Goal_store.Long -> 3 * Masc_time_constants.day_int          (* 72 * 3600 = 3 days *)
if seconds < Masc_time_constants.hour_int ...
else if seconds < Masc_time_constants.day_int
then "%dh" (seconds / Masc_time_constants.hour_int)
else "%dd" (seconds / Masc_time_constants.day_int)
```

Mid/Long 의 `24 * 3600` / `72 * 3600` 표현은 *3-단계 계산 (24 × 3600 = 86400; 86400 × N = days)* 을 강요. SSOT 호출은 한 단계로 의미 노출.

### 3. HOTFIX — `lib/dated_jsonl/dune`

```ocaml
(* before *)  (libraries fs_compat jsonl_writer eio unix yojson))
(* after  *)  (libraries fs_compat jsonl_writer masc_mcp.config eio unix yojson))
```

`(wrapped false)` 인 `masc_mcp.config` 가 `Masc_time_constants` 를 unwrapped 로 노출 — 다른 sub-library 가 의존하는 방식과 동일 (lib/cdal/dune, lib/backend/dune 등).

## Out-of-scope

`dashboard_goals_types_accessor.ml:217` 의 `seconds / 60` (minute conversion) — `Masc_time_constants` 에 `minute : float` 는 있지만 `minute_int` 없음. 본 PR 범위 밖. 후속 candidate.

## 변경

- 5 files, +21/-11
- 1 SSOT entry 추가 (ml + mli)
- 10 magic-number int 사이트 → 0
- 1 dune dep 추가 (hotfix)

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거* + main breakage *fix*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 10 사이트 *모두* + SSOT 부재 *모두* 동시 처리

## Test impact

- 동작 무변경 (`hour_int = 3600`, `day_int = 86400` 모두 기존 literal 과 동일)
- `dune build lib/` PASS (worktree)
- main 의 dated_jsonl build 실패 → 본 PR 머지 후 PASS

## Related

- PR #19099 — broke main (introduced `Masc_time_constants.day` call without dune dep)
- PR #19037 ~ #19099 — Magic Number Time-literal 시리즈 누적 12
- `lib/config/masc_time_constants.ml` — time SSOT
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
