### PR TITLE
Remove dashboard InfoCard wrapper

### DIFF
--- a/dashboard/src/components/common/info-card.ts
+++ b/dashboard/src/components/common/info-card.ts
@@ -1,5 +1,0 @@
-import { html } from 'htm/preact'
-
-export function InfoCard({ children }: { children: unknown }) {
-  return html`<div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-3">${children}</div>`
-}

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -8,11 +8,10 @@ import { get } from '../api/core'
 import { createAsyncResource, type AsyncResource } from '../lib/async-state'
 import { formatTimeAgo } from '../lib/format-time'
 import { AsyncContainer } from './common/async-container'
-import { SectionCard } from './common/card'
+import { SectionCard, SurfaceCard } from './common/card'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import { SectionCap } from './common/section-cap'
-import { InfoCard } from './common/info-card'
 import { StatusChip, type StatusChipTone } from './common/status-chip'
 import { KpiStripIsland, type KpiStripIslandData } from './kpi-strip-island'
 
@@ -157,7 +156,7 @@ function StatusPill({ status }: { status: FeatureStatus }) {
 
 function FeatureItem({ item }: { item: FeatureHealthItem }) {
   return html`
-    <${InfoCard}>
+    <${SurfaceCard} variant="compact">
       <div class="flex items-start justify-between gap-3">
         <div class="flex-1">
           <div class="flex items-center gap-2">

--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -11,7 +11,6 @@ import { TextInput } from './common/input'
 import { SectionCap } from './common/section-cap'
 import { StatusChip } from './common/status-chip'
 import { StatusDot } from './common/status-dot'
-import { InfoCard } from './common/info-card'
 import type {
   RailStatus,
   GateDistribution,
@@ -383,7 +382,7 @@ export function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
       ${isFiltering && visibleItems.length === 0
         ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${items.length} items)</div>`
         : visibleItems.map(item => html`
-          <${InfoCard}>
+          <${SurfaceCard} variant="compact">
             <div class="flex items-start justify-between gap-3">
               <div>
                 <${ItemTitle}>${item.task_title || item.task_id}</${ItemTitle}>
@@ -430,7 +429,7 @@ export function PreCompactList({ section }: { section: HarnessSignalSection<PreC
       ${isFiltering && visibleItems.length === 0
         ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${section.recent_events.length} items)</div>`
         : visibleItems.map(item => html`
-          <${InfoCard}>
+          <${SurfaceCard} variant="compact">
             <div class="flex items-start justify-between gap-3">
               <${ItemTitle}>${item.keeper_name}</${ItemTitle}>
               <div class="text-xs text-[var(--color-fg-muted)]">${formatTimestamp(item.timestamp)}</div>
@@ -482,7 +481,7 @@ export function HandoffList({ section }: { section: HarnessSignalSection<Handoff
       ${isFiltering && visibleItems.length === 0
         ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${section.recent_events.length} items)</div>`
         : visibleItems.map(item => html`
-          <${InfoCard}>
+          <${SurfaceCard} variant="compact">
             <div class="flex items-start justify-between gap-3">
               <${ItemTitle}>${item.keeper_name}</${ItemTitle}>
               <div class="text-xs text-[var(--color-fg-muted)]">${formatTimestamp(item.timestamp)}</div>


### PR DESCRIPTION
Summary:
- Delete the no-op InfoCard wrapper component.
- Replace remaining InfoCard call sites with SurfaceCard variant="compact".
- Keep harness/feature health card surfaces on the shared card primitive.

Verification:
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/harness-health-sections.test.ts src/components/feature-health.test.ts --no-file-parallelism --maxWorkers=1 (2 files, 90 tests)
- pnpm eslint src/components/feature-health.ts src/components/harness-health-sections.ts
- git diff --check origin/main
- rg InfoCard/info-card dashboard/src/components (no matches)