### PR TITLE
feat(rfc-0195): typed alternatives field on workflow_rejection (P0 minimal slice)

### DIFF
--- a/lib/keeper/agent_tool_task_runtime.ml
+++ b/lib/keeper/agent_tool_task_runtime.ml
@@ -20,10 +20,20 @@ let keeper_task_result_json ?(typed_outcome = (None : Keeper_tool_outcome.t opti
       (`Assoc ([ "ok", `Bool false; "error", `String (Masc_domain.masc_error_to_string e) ] @ typed_fields))
 ;;
 
-let workflow_rejection_error_json ?(rule_id = "keeper_task_argument_rejected") message =
+let workflow_rejection_error_json
+      ?(rule_id = "keeper_task_argument_rejected")
+      ?(alternatives = [])
+      message
+  =
+  (* RFC-0195 P0: [alternatives] is a typed list of tool names the
+     LLM can call instead.  Empty list omits the field; non-empty
+     surfaces it directly in the JSON payload so the LLM does not
+     have to parse prose [hint] strings to discover next-tool
+     candidates. *)
   Tool_task_payloads.workflow_rejection_payload_json
     ~rule_id
     ~scope_policy:"block_scope"
+    ~alternatives
     message
 ;;
 
@@ -763,6 +773,7 @@ let handle_keeper_task_tool
     if task_id = ""
     then
       workflow_rejection_error_json
+        ~alternatives:[ "keeper_task_claim"; "keeper_tasks_list" ]
         "task_id is required. Use the task_id you got from keeper_task_claim."
     else if result_text = ""
     then
@@ -777,6 +788,7 @@ let handle_keeper_task_tool
          keeper-vocabulary error). Enforce the schema here so the
          error names the field the keeper actually sent. *)
       workflow_rejection_error_json
+        ~alternatives:[ "keeper_task_done"; "keeper_task_submit_for_verification" ]
         "result is required. Audit trail: describe what you completed. \
          Example: result='Refactored module X, all tests green, no flake'."
     else (
@@ -820,18 +832,23 @@ let handle_keeper_task_tool
     if task_id = ""
     then
       workflow_rejection_error_json
+        ~alternatives:[ "keeper_task_claim"; "keeper_tasks_list" ]
         "task_id is required. Use the task_id you got from keeper_task_claim."
     else if notes = ""
     then
       workflow_rejection_error_json
+        ~alternatives:[ "keeper_task_submit_for_verification" ]
         "notes is required. Include verification evidence and test summary."
     else if pr_url = ""
     then
       workflow_rejection_error_json
+        ~alternatives:
+          [ "keeper_task_submit_for_verification"; "keeper_task_done" ]
         "pr_url is required. Include the PR opened for this task."
     else if not (Tool_task_completion_review.pr_url_has_pull_ref pr_url)
     then
       workflow_rejection_error_json
+        ~alternatives:[ "keeper_task_submit_for_verification" ]
         "pr_url must be a GitHub pull request URL or PR # reference. \
          Do not submit placeholders like 'draft', 'none', or 'pending'."
     else (

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -189,6 +189,7 @@ let workflow_rejection_payload_json
       ?tool_suggestion
       ?hint
       ?scope_policy
+      ?(alternatives = [])
       ?(extra_fields = [])
       ~error_class
       ~recoverability
@@ -203,6 +204,14 @@ let workflow_rejection_payload_json
       [ "scope_policy", `String (workflow_rejection_scope_policy_to_string scope_policy) ]
     | None -> []
   in
+  let alternatives_field =
+    if alternatives = []
+    then []
+    else
+      [ ( "alternatives"
+        , `List (List.map (fun name -> `String name) alternatives) )
+      ]
+  in
   let fields =
     [ "ok", `Bool false
     ; "error", `String message
@@ -211,6 +220,7 @@ let workflow_rejection_payload_json
     ; "recoverable", `Bool (workflow_rejection_recoverability_to_bool recoverability)
     ]
     @ optional_string_field "hint" hint
+    @ alternatives_field
     @ (if diagnosis = [] then [] else [ "diagnosis", `Assoc diagnosis ])
     @ extra_fields
   in

--- a/lib/keeper/keeper_tools_oas_workflow.mli
+++ b/lib/keeper/keeper_tools_oas_workflow.mli
@@ -73,11 +73,18 @@ val workflow_rejection_payload_json
   -> ?tool_suggestion:string
   -> ?hint:string
   -> ?scope_policy:workflow_rejection_scope_policy
+  -> ?alternatives:string list
   -> ?extra_fields:(string * Yojson.Safe.t) list
   -> error_class:workflow_rejection_error_class
   -> recoverability:workflow_rejection_recoverability
   -> string
   -> string
+(** [alternatives] is the typed list of tool names the caller can use
+    instead.  RFC-0195 P0: surface a typed [alternatives] field on
+    every workflow_rejection emit so the LLM receives concrete next-
+    tool candidates rather than parsing prose hints.  Empty list (default)
+    omits the field entirely; existing callers that omit this argument
+    are unaffected. *)
 
 (** Extract [workflow_rejection_info] from a raw JSON string. *)
 val workflow_rejection_info_of_raw : string -> workflow_rejection_info option

--- a/lib/tool_task_payloads.ml
+++ b/lib/tool_task_payloads.ml
@@ -41,6 +41,7 @@ let workflow_rejection_payload_json
       ?tool_suggestion
       ?hint
       ?scope_policy
+      ?(alternatives = [])
       ?extra_fields
       message
   =
@@ -54,6 +55,7 @@ let workflow_rejection_payload_json
     ?tool_suggestion
     ?hint
     ?scope_policy
+    ~alternatives
     ?extra_fields
     ~error_class:Keeper_tools_oas_workflow.Workflow_error_deterministic
     ~recoverability:Keeper_tools_oas_workflow.Workflow_unrecoverable

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1277,6 +1277,48 @@ let test_tool_result_error_json_preserves_structured_workflow_rejection () =
     (json_string "scope_policy" diagnosis)
 ;;
 
+(* RFC-0195 P0: workflow_rejection_payload_json must surface a typed
+   [alternatives] field when callers provide one, and must omit the
+   field when the list is empty (the default). *)
+let test_workflow_rejection_alternatives_field_emitted () =
+  let message =
+    Tool_task_payloads.workflow_rejection_payload_json
+      ~rule_id:"task_done_result_missing"
+      ~alternatives:[ "keeper_task_done"; "keeper_task_submit_for_verification" ]
+      "result is required"
+  in
+  let json = parse message in
+  let alternatives_field = Yojson.Safe.Util.member "alternatives" json in
+  match alternatives_field with
+  | `List items ->
+    check
+      (list string)
+      "alternatives surfaces both typed tool names"
+      [ "keeper_task_done"; "keeper_task_submit_for_verification" ]
+      (List.map
+         (function
+           | `String name -> name
+           | _ -> Alcotest.fail "alternatives entries must be strings")
+         items)
+  | _ ->
+    Alcotest.fail "alternatives field missing or wrong shape"
+;;
+
+let test_workflow_rejection_alternatives_field_omitted_when_empty () =
+  let message =
+    Tool_task_payloads.workflow_rejection_payload_json
+      ~rule_id:"some_rule"
+      "some error"
+  in
+  let json = parse message in
+  let alternatives_field = Yojson.Safe.Util.member "alternatives" json in
+  check
+    bool
+    "empty alternatives must not emit the field"
+    true
+    (alternatives_field = `Null)
+;;
+
 let test_failure_boundary_ignores_error_text_without_failure_class () =
   let decision =
     Keeper_tools_oas_failure_boundary.classify_raw_failure


### PR DESCRIPTION
## Summary

RFC-0195 P0 minimal slice — surface a typed `alternatives` field on every `workflow_rejection` JSON payload so LLMs receive concrete next-tool candidates as a structured list instead of having to parse prose `hint` strings. Closes the 6 dead-end emit sites in `agent_tool_task_runtime.ml` (Task_done + Task_submit_for_verification).

This PR is the *minimum surface* for RFC-0195 P0:
- workflow_rejection emit path (lib/keeper/keeper_tools_oas_workflow.ml + tool_task_payloads.ml proxy + agent_tool_task_runtime.ml caller)
- 6 callsite update inside Task_done / Task_submit_for_verification handlers
- 2 new tests covering emit + omission

Per-tool descriptor enrichment (when_to_use / examples / alternatives field on the catalog descriptor) is deliberately a *different surface* and ships separately. RFC-0198 already supplies the Execute descriptor's Phase A→B alternative pointer.

Refs: RFC-0194 §2 (every LLM-blocking gate names an alternative), RFC-0195 P0 (descriptor enrichment + minimal alternatives)

## What changed

`lib/keeper/keeper_tools_oas_workflow.ml` + `.mli`:
- New `?alternatives:string list` optional parameter on `workflow_rejection_payload_json` (default `[]`)
- When non-empty, emits a JSON `alternatives` field at the payload top level; empty list omits the field entirely (zero overhead)
- Existing `?rule_id`, `?tool_suggestion`, `?hint` parameters unchanged for backward-compat

`lib/tool_task_payloads.ml`:
- Proxy `workflow_rejection_payload_json` threads `~alternatives` through to the workflow module

`lib/keeper/agent_tool_task_runtime.ml`:
- `workflow_rejection_error_json` gains `?alternatives` and forwards it
- 6 callsites updated with typed `~alternatives`:
  - Task_done task_id-missing  → `[keeper_task_claim; keeper_tasks_list]`
  - Task_done result-missing   → `[keeper_task_done; keeper_task_submit_for_verification]`
  - Task_submit_for_verification task_id-missing  → `[keeper_task_claim; keeper_tasks_list]`
  - Task_submit_for_verification notes-missing    → `[keeper_task_submit_for_verification]` (re-call)
  - Task_submit_for_verification pr_url-missing   → `[keeper_task_submit_for_verification; keeper_task_done]`
  - Task_submit_for_verification pr_url-invalid   → `[keeper_task_submit_for_verification]` (re-call with valid url)

`test/test_keeper_tools_oas.ml`:
- `workflow_rejection_alternatives_field_emitted` — typed list of tool names surfaces in JSON output
- `workflow_rejection_alternatives_field_omitted_when_empty` — empty default keeps wire shape unchanged

## Backward compatibility

- All new parameters are optional with `[]` default → existing callers compile and behave identically
- JSON payload gains an optional `alternatives` field only when non-empty → consumers that don't read it see no change
- `workflow_rejection_recovery_fields` parsing path (which reads `tool_suggestion` / `hint`) untouched in this PR; it can be migrated to consume `alternatives` in a follow-up once fleet evidence confirms LLM adoption

## Why this is not a workaround (RFC-0194 §4 negation)

- **Not §1 Counter-as-fix**: this *closes* the dead-end (workflow_rejection that gives the LLM no next-tool signal); it does not merely observe the failure.
- **Not §2 String/Substring 분류기 보강**: `alternatives` is a typed `string list` (concrete Tool_name values, validated at the descriptor catalog surface); no substring matching.
- **Not §3 N-of-M**: this PR touches the 6 callsites that share *one* emit function. The other 6 tools that RFC-0195 ultimately enriches with `when_to_use` / `examples` / `alternatives` belong to a separate descriptor surface (different file, different reviewer concerns) and ship in a follow-up.

## Stack

Independent of RFC-0198 Phase A/B; based directly on main.

## Test plan

- [x] `dune build lib/keeper/` — PASS
- [ ] `dune test test/test_keeper_tools_oas.exe` — 2 new cases + existing regression
- [ ] 7-day fleet observation: `workflow_rejection` events containing typed `alternatives` array (target: 100% of the 6 emit sites)
- [ ] Follow-up: workflow_rejection_recovery parsing reads `alternatives` (separate PR after fleet adoption)

WORKAROUND-WAIVED: gate matched "substring" inside §4 negation; this PR introduces a typed string list, not a substring matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
