### PR TITLE
refactor(misc): Masc_time_constants.hour/days_to_seconds replaces 3600.0/604800.0 at 5 sites + dated_jsonl/dune defense

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -723,7 +723,7 @@ let () =
 (* Board artifact cleanup — wraps Board_dispatch for GC *)
 let () =
   Atomic.set Coord_hooks.cleanup_board_artifacts_fn (fun () ->
-    let stale_system_daily_sec = 12.0 *. 3600.0 in
+    let stale_system_daily_sec = 12.0 *. Masc_time_constants.hour in
     let board_artifact_title title =
       let title = String.lowercase_ascii (String.trim title) in
       String.starts_with ~prefix:"[keeper daily]" title

--- a/lib/dated_jsonl/dune
+++ b/lib/dated_jsonl/dune
@@ -7,4 +7,4 @@
  ; live in the single (flags ...) stanza so the effective warning mask is
  ; not split across (flags)/(ocamlc_flags)/(ocamlopt_flags).
  (flags (:standard -w -32 -w +4))
- (libraries fs_compat jsonl_writer eio unix yojson))
+ (libraries fs_compat jsonl_writer masc_mcp.config eio unix yojson))

--- a/lib/keeper_fd_pressure.ml
+++ b/lib/keeper_fd_pressure.ml
@@ -233,7 +233,7 @@ let external_cooldown_sec_of level =
   in
   Env_config_core.get_float ~default:default_sec env_var
   |> Float.max 5.0
-  |> Float.min 3600.0
+  |> Float.min Masc_time_constants.hour
 ;;
 
 let engage_external ~reason ~level ~ts () =

--- a/lib/telemetry_unified_source_meta.ml
+++ b/lib/telemetry_unified_source_meta.ml
@@ -54,8 +54,8 @@ let source_freshness_slo_s = function
   | Agent_event -> 900.0
   (* Tool_usage covers Tool_catalog_surfaces.System_internal admin-only
      tools — sparse by design. Match the SSOT in tool_usage_log.ml. *)
-  | Tool_usage -> 3600.0
-  | Goal_event -> 604800.0
+  | Tool_usage -> Masc_time_constants.hour
+  | Goal_event -> Masc_time_constants.days_to_seconds 7
   | Tool_metric -> 900.0
 
 let source_producer = function

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -50,7 +50,7 @@ let dashboard_surface = "/api/v1/dashboard/tools"
    "stale" alerts on healthy fleets. 3600 s matches the operational rhythm
    without masking a true write-pipeline failure — Dated_jsonl append errors
    already record a coverage_gap that bypasses this SLO. *)
-let freshness_slo_s = 3600.0
+let freshness_slo_s = Masc_time_constants.hour
 
 let store_dir masc_root = Filename.concat masc_root "tool_usage"
 


### PR DESCRIPTION
## ⚠️ main 이 여전히 broken — defense-in-depth dune fix 포함

PR #19109 (Draft, OPEN) 가 origin/main 의 `lib/dated_jsonl/dune` masc_mcp.config dep 누락을 1줄 fix 로 hotfix 중입니다. 본 PR 의 base 도 origin/main 이라 같은 fail 발생 → 본 PR 도 동일한 1줄 dune fix 포함. PR #19109 가 먼저 머지되면 본 PR 의 dune 라인이 trivial conflict (이미 같은 변경이라 무동작) — `git pull --rebase origin main` 으로 자동 해결.

## 요약

sw-dev §"Magic Number 금지" — Magic Number Time-literal 시리즈 **14번째 PR**. lib-root 흩어진 float 5 사이트.

### 패턴

4 hour-substitutions + 1 week-substitution. `604800.0` 가 `days_to_seconds 7` 로 collapse — 의미가 "epoch 형 raw seconds" 에서 "7-day window" 로 노출.

before:
```ocaml
(* tool_usage_log.ml:53 *)               let freshness_slo_s = 3600.0
(* keeper_fd_pressure.ml:236 *)          |> Float.min 3600.0
(* telemetry_unified_source_meta.ml:57 *)  | Tool_usage -> 3600.0
(* telemetry_unified_source_meta.ml:58 *)  | Goal_event -> 604800.0
(* coord.ml:726 *)                       let stale_system_daily_sec = 12.0 *. 3600.0
```

after:
```ocaml
let freshness_slo_s = Masc_time_constants.hour
|> Float.min Masc_time_constants.hour
| Tool_usage -> Masc_time_constants.hour
| Goal_event -> Masc_time_constants.days_to_seconds 7
let stale_system_daily_sec = 12.0 *. Masc_time_constants.hour
```

`telemetry_unified_source_meta.ml:57` 의 주석은 "Match the SSOT in `tool_usage_log.ml`" — 본 PR 이 그 SSOT 자체를 한 단계 더 끌어올린다 (literal SSOT → typed SSOT).

5 사이트 (3600.0 × 4 + 604800.0 × 1):
- `lib/tool_usage_log.ml:53` (Tool_usage freshness SLO, 1h)
- `lib/keeper_fd_pressure.ml:236` (cooldown ceiling, 1h)
- `lib/telemetry_unified_source_meta.ml:57` (Tool_usage source SLO, 1h)
- `lib/telemetry_unified_source_meta.ml:58` (Goal_event SLO, 7d)
- `lib/coord.ml:726` (daily-board cleanup, 12h)

## 변경

- 4 ml files + 1 dune file
- 4 hour-substitutions + 1 week-substitution
- 동작 무변경 (`Masc_time_constants.hour = 3600.0`, `days_to_seconds 7 = 604800.0`)

## Magic-number lint impact

- Before: 4 `3600.0` + 1 `604800.0` = 5
- After: 0

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거* + main fail defense. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 5 사이트 *모두* 동시 처리

## Test impact

- 동작 무변경
- `dune build lib/` PASS

## Related

- PR #19109 — main hotfix (lib/dated_jsonl/dune masc_mcp.config dep)
- PR #19037 ~ #19109 — Magic Number Time-literal 시리즈 누적 13
- `lib/config/masc_time_constants.ml` — time SSOT (`hour`, `days_to_seconds`)
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
