### PR TITLE
refactor(dashboard): extract parsePositiveLineString to close inline regex+parseInt drift between positiveLine and routeFocusLine

### DIFF
--- a/dashboard/src/components/common/normalize.ts
+++ b/dashboard/src/components/common/normalize.ts
@@ -102,11 +102,30 @@ export function idString(value: unknown): string | undefined {
   return isPositiveSafeInteger(value) ? String(value) : undefined
 }
 
+/**
+ * Parse a `^[1-9]\d*$` string into a positive safe-integer `number`,
+ * returning `undefined` on any non-matching input (empty, sign,
+ * leading zero, decimal, non-digit) and on regex-passes-but-not-safe
+ * inputs like `'9999999999999999999'` (digit string too long to fit
+ * a safe JS integer).
+ *
+ * Two call sites previously inlined the regex test + parseInt only:
+ * `positiveLine` here (string branch) and `ide-shell.routeFocusLine`.
+ * The latter additionally guarded the parsed value with
+ * `isPositiveSafeInteger`; the former did not, so the unsafe-integer
+ * edge case silently returned a non-safe number through `positiveLine`.
+ * Centralising the parser closes that gap.
+ */
+export function parsePositiveLineString(raw: string): number | undefined {
+  if (!/^[1-9]\d*$/.test(raw)) return undefined
+  const value = Number.parseInt(raw, 10)
+  return isPositiveSafeInteger(value) ? value : undefined
+}
+
 export function positiveLine(value: unknown): number | undefined {
   if (isPositiveSafeInteger(value)) return value
   if (typeof value !== 'string') return undefined
-  const trimmed = value.trim()
-  return /^[1-9]\d*$/.test(trimmed) ? Number.parseInt(trimmed, 10) : undefined
+  return parsePositiveLineString(value.trim())
 }
 
 export interface CodeLocation {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -8,7 +8,7 @@ import {
   type IdeContextFocusRouteLink,
 } from './ide-state'
 import { createIdeDataCoordinator } from './ide-data-coordinator'
-import { isPositiveSafeInteger } from '../common/normalize'
+import { parsePositiveLineString } from '../common/normalize'
 import { IdeExplorer } from './ide-explorer'
 import { IdeEditor, type IdeEditorView } from './ide-editor'
 import { IdeConversationRail } from './ide-conversation-rail'
@@ -137,9 +137,7 @@ function routeFocusFile(params: Record<string, string>): string | undefined {
 function routeFocusLine(params: Record<string, string>): number | undefined {
   const raw = params.line?.trim() || params.lineno?.trim()
   if (!raw) return undefined
-  if (!/^[1-9]\d*$/.test(raw)) return undefined
-  const value = Number.parseInt(raw, 10)
-  return isPositiveSafeInteger(value) ? value : undefined
+  return parsePositiveLineString(raw)
 }
 
 function routeFocusLabel(params: Record<string, string>, filePath: string): string {


### PR DESCRIPTION
## 요약
`positiveLine` 과 `routeFocusLine` 의 inline `^[1-9]\d*$` regex + parseInt chain dedup + 잠재 silent bug fix. `parsePositiveLineString(raw: string): number | undefined` helper export.

## 배경

`rg "/\^\[1-9\]\\\d\*\\\$/"` sweep 결과 2 callsite 발견:

| 파일 | callsite | chain |
|---|---|---|
| `components/common/normalize.ts:109` | `positiveLine` (string branch) | regex test → parseInt — **isPositiveSafeInteger guard 누락** |
| `components/ide/ide-shell.ts:140-142` | `routeFocusLine` | regex test → parseInt → **isPositiveSafeInteger guard 있음** |

**잠재 silent bug** — `positiveLine` 가 `'9999999999999999999'` 같은 *regex 통과하지만 SafeInteger 범위 초과* 입력에 silent 한 non-safe number 반환. `routeFocusLine` 는 같은 입력 reject. `positiveLine` 는 `extractCodeLocation` 통해 *backend record 의 line field* 처리에 사용 — 외부 데이터의 *unbounded length* 위험.

iter#41 hex sentinel drift 와 같은 *canonical 정렬* 패턴 — 두 sibling 중 하나가 *drift*, SSOT 화 시 자동 correction.

## 변경

### `components/common/normalize.ts`
- `parsePositiveLineString(raw: string): number | undefined` 새 helper export
- JSDoc 으로 *regex 통과 + non-safe int* edge case 명시 + 두 callsite 의 *drift 위치* + canonical 정렬 의도 명시
- `positiveLine` 의 string branch 가 helper 호출 (자동 isPositiveSafeInteger guard 적용)

### `components/ide/ide-shell.ts`
- import `isPositiveSafeInteger` → `parsePositiveLineString` (helper 호출이 guard 내장)
- `routeFocusLine` 의 3-line regex+parseInt+guard chain → 1-line `parsePositiveLineString(raw)`

## 검증

- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)

## iter chain

iter#41 (`--color-status-err` hex drift fix): canonical SSOT source 가 *두 sibling 중 어느 쪽이 drift 인지* 확정 → drift 사이트 정렬. 본 PR 도 같은 구조 — `routeFocusLine` 가 *isPositiveSafeInteger guard 포함* canonical, `positiveLine` 가 *guard 누락* drift. SSOT 화 자동 correction.

## /loop iter#50
SSOT 위반 dashboard 축출 loop 의 iter#50 milestone. cumulative 50 PR (33 머지 + 1 OPEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
