### PR TITLE
docs: add Keeper tool substrate HTML report

### DIFF
--- a/docs/design/tool-execution-substrate-plan.html
+++ b/docs/design/tool-execution-substrate-plan.html
@@ -1,0 +1,907 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Keeper Tool Execution Substrate Plan</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f4f6f8;
+      --ink: #17202a;
+      --muted: #617083;
+      --panel: #ffffff;
+      --line: #d7dee8;
+      --soft: #eef2f6;
+      --navy: #0e2a47;
+      --teal: #0f766e;
+      --blue: #1d4ed8;
+      --green: #15803d;
+      --amber: #a16207;
+      --red: #b91c1c;
+      --violet: #6d28d9;
+      --slate: #344054;
+      --shadow: 0 10px 32px rgba(15, 23, 42, 0.08);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family:
+        Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+        "Segoe UI", sans-serif;
+      color: var(--ink);
+      background:
+        linear-gradient(180deg, #e9eef4 0, var(--bg) 240px),
+        var(--bg);
+      line-height: 1.55;
+    }
+
+    a { color: var(--blue); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    header {
+      background: var(--navy);
+      color: #ffffff;
+      padding: 34px 34px 30px;
+      border-bottom: 6px solid #14b8a6;
+    }
+
+    header .eyebrow {
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #a7f3d0;
+      font-weight: 700;
+    }
+
+    h1, h2, h3, h4 { margin: 0; line-height: 1.18; }
+    h1 {
+      margin-top: 8px;
+      max-width: 980px;
+      font-size: 34px;
+      font-weight: 800;
+    }
+    header p {
+      max-width: 1060px;
+      color: #dbe7f3;
+      margin: 12px 0 0;
+      font-size: 16px;
+    }
+
+    main {
+      width: min(1280px, calc(100% - 34px));
+      margin: 24px auto 60px;
+    }
+
+    section {
+      margin-top: 22px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+      padding: 22px;
+    }
+
+    section.flat {
+      box-shadow: none;
+      background: transparent;
+      border: 0;
+      padding: 0;
+    }
+
+    h2 {
+      font-size: 22px;
+      color: #132337;
+      margin-bottom: 12px;
+    }
+
+    h3 {
+      font-size: 17px;
+      margin-top: 18px;
+      color: #213044;
+    }
+
+    h4 {
+      font-size: 14px;
+      margin-top: 12px;
+      color: #2f3f53;
+    }
+
+    p { margin: 8px 0 0; }
+    ul, ol { margin: 8px 0 0 20px; padding: 0; }
+    li { margin: 4px 0; }
+
+    code, pre {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 13px;
+    }
+
+    code {
+      background: #eef2f7;
+      border: 1px solid #dbe3ed;
+      border-radius: 4px;
+      padding: 1px 5px;
+    }
+
+    pre {
+      background: #0f172a;
+      color: #e2e8f0;
+      border-radius: 8px;
+      overflow-x: auto;
+      padding: 14px;
+      margin: 10px 0 0;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      border: 1px solid var(--line);
+      margin-top: 12px;
+      background: #ffffff;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    th, td {
+      text-align: left;
+      vertical-align: top;
+      border-bottom: 1px solid var(--line);
+      padding: 10px 12px;
+      font-size: 14px;
+    }
+
+    th {
+      background: #edf2f7;
+      color: #233044;
+      font-weight: 800;
+    }
+
+    tr:last-child td { border-bottom: 0; }
+
+    .kicker {
+      color: var(--muted);
+      font-size: 14px;
+      margin-top: 4px;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .grid.four { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+      box-shadow: var(--shadow);
+    }
+
+    .card h3 { margin-top: 0; }
+
+    .metric {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      min-height: 120px;
+    }
+
+    .metric .value {
+      font-size: 28px;
+      font-weight: 800;
+      color: var(--teal);
+    }
+
+    .metric .label {
+      font-weight: 800;
+      color: #263548;
+    }
+
+    .metric .note {
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .status {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 2px 8px;
+      font-size: 12px;
+      font-weight: 800;
+      white-space: nowrap;
+    }
+
+    .status.goal { color: #075985; background: #e0f2fe; }
+    .status.done { color: var(--green); background: #dcfce7; }
+    .status.next { color: var(--amber); background: #fef3c7; }
+    .status.risk { color: var(--red); background: #fee2e2; }
+    .status.rule { color: var(--violet); background: #ede9fe; }
+
+    .callout {
+      border-left: 5px solid var(--teal);
+      background: #ecfeff;
+      padding: 14px 16px;
+      margin-top: 14px;
+      border-radius: 6px;
+    }
+
+    .warning {
+      border-left-color: var(--amber);
+      background: #fffbeb;
+    }
+
+    .danger {
+      border-left-color: var(--red);
+      background: #fef2f2;
+    }
+
+    .diagram {
+      display: grid;
+      grid-template-columns: repeat(7, minmax(110px, 1fr));
+      gap: 8px;
+      align-items: stretch;
+      margin-top: 14px;
+    }
+
+    .node {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #ffffff;
+      min-height: 92px;
+      padding: 11px;
+      position: relative;
+    }
+
+    .node::after {
+      content: "";
+      position: absolute;
+      right: -8px;
+      top: 50%;
+      width: 8px;
+      height: 2px;
+      background: #9aa8b8;
+    }
+
+    .node:last-child::after { display: none; }
+    .node strong { display: block; font-size: 14px; }
+    .node span { display: block; margin-top: 6px; color: var(--muted); font-size: 12px; }
+
+    .node.public { border-top: 4px solid var(--blue); }
+    .node.substrate { border-top: 4px solid var(--teal); }
+    .node.policy { border-top: 4px solid var(--amber); }
+    .node.runtime { border-top: 4px solid var(--violet); }
+    .node.evidence { border-top: 4px solid var(--green); }
+
+    .timeline {
+      display: grid;
+      grid-template-columns: 180px 1fr;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+      margin-top: 12px;
+    }
+
+    .time-row { display: contents; }
+    .time-label, .time-body {
+      border-bottom: 1px solid var(--line);
+      padding: 12px;
+      background: #ffffff;
+    }
+    .time-row:last-child .time-label,
+    .time-row:last-child .time-body { border-bottom: 0; }
+    .time-label {
+      background: #f0f4f8;
+      font-weight: 800;
+      color: #334155;
+    }
+
+    .mini-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 10px;
+    }
+
+    .pill {
+      display: inline-flex;
+      border: 1px solid var(--line);
+      background: #ffffff;
+      border-radius: 999px;
+      padding: 5px 10px;
+      font-size: 13px;
+      font-weight: 700;
+      color: #334155;
+    }
+
+    footer {
+      width: min(1280px, calc(100% - 34px));
+      margin: 0 auto 44px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    @media (max-width: 1040px) {
+      .grid, .grid.two, .grid.four { grid-template-columns: 1fr; }
+      .diagram { grid-template-columns: 1fr; }
+      .node::after { display: none; }
+      .timeline { grid-template-columns: 1fr; }
+      .time-label { border-bottom: 0; }
+      header { padding: 28px 20px; }
+      h1 { font-size: 28px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="eyebrow">MASC Keeper Tools Program</div>
+    <h1>Tool Execution Substrate: Primitive Typed Tools, Shell IR Core, and Keeper Tools Success</h1>
+    <p>
+      A design report and implementation plan for keeping the Keeper tool surface small,
+      typed, evidence-rich, and reliable under live autonomous operation.
+    </p>
+  </header>
+
+  <main>
+    <section class="flat">
+      <div class="grid four">
+        <div class="card metric">
+          <div class="value">7</div>
+          <div class="label">Public primitive tools</div>
+          <div class="note"><code>Execute</code>, file/search, and web evidence tools.</div>
+        </div>
+        <div class="card metric">
+          <div class="value">4</div>
+          <div class="label">Executor classes</div>
+          <div class="note"><code>Shell_ir</code>, <code>Filesystem</code>, <code>Remote_mcp</code>, <code>In_process</code>.</div>
+        </div>
+        <div class="card metric">
+          <div class="value">0</div>
+          <div class="label">GitHub micro-tools</div>
+          <div class="note"><code>gh</code> and <code>git</code> stay inside typed <code>Execute</code>.</div>
+        </div>
+        <div class="card metric">
+          <div class="value">1</div>
+          <div class="label">Keeper Tools goal</div>
+          <div class="note">Reliable tool calls with clear routing, policy, and recovery evidence.</div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Program Goal</h2>
+      <p>
+        The program goal is <strong>Keeper Tools Success</strong>: keepers should choose,
+        execute, recover from, and explain tool calls without falling into legacy names,
+        over-specific GitHub tools, raw shell ambiguity, or unobservable policy failures.
+      </p>
+
+      <div class="callout">
+        <strong>Goal ID proposal:</strong>
+        <code>goal-keeper-tool-execution-substrate-success-20260527</code>
+        <p>
+          This goal is complete only when active keeper tools succeed through the typed
+          substrate in realistic work loops, not merely when a descriptor enum compiles.
+        </p>
+      </div>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Objective</th>
+            <th>Success metric</th>
+            <th>Target</th>
+            <th>Primary proof</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Tool naming success</td>
+            <td>Legacy or hallucinated public tool calls such as <code>Read</code>, <code>Bash</code>, <code>pr_comment</code>, and <code>gh_pr</code>.</td>
+            <td><span class="status goal">0 active-surface hits</span></td>
+            <td>Descriptor projection tests plus active prompt/config/source ratchets.</td>
+          </tr>
+          <tr>
+            <td>Execute substrate success</td>
+            <td>Command workflows represented as typed <code>executable</code> plus <code>argv</code>, then lowered to decided Shell IR.</td>
+            <td><span class="status goal">100% for git/gh/dune test scenarios</span></td>
+            <td>Keeper tool harness scenarios and Shell IR audit.</td>
+          </tr>
+          <tr>
+            <td>Recovery success</td>
+            <td>Deterministic rejection returns the correct next tool or argument shape.</td>
+            <td><span class="status goal">No repeated same-args retries</span></td>
+            <td>Workflow rejection tests and live log sampling.</td>
+          </tr>
+          <tr>
+            <td>Evidence success</td>
+            <td>Every call records route, policy decision, decision reason, sandbox/backend, and Shell IR risk when applicable.</td>
+            <td><span class="status goal">Per-call JSONL is authoritative</span></td>
+            <td>Receipt tests and dashboard projection checks.</td>
+          </tr>
+          <tr>
+            <td>Operator success</td>
+            <td>A failed tool call can be diagnosed from one receipt row without reading three subsystems.</td>
+            <td><span class="status goal">Single-row diagnosis</span></td>
+            <td>Tool call evidence and keeper detail dashboard.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Core Thesis</h2>
+      <p>
+        A tool should be a stable semantic capability, not a wrapper around a common
+        command. GitHub comments, PR reviews, PR closes, and commits are command
+        workflows. They belong inside <code>Execute</code> as typed <code>gh</code> or
+        <code>git</code> argv. MASC-owned state transitions such as tasks, goals,
+        board posts, approvals, memory, and keeper lifecycle remain structured tools.
+      </p>
+
+      <div class="callout warning">
+        <strong>Rejected failure mode:</strong>
+        <code>pr_comment</code>, <code>pr_review</code>, <code>pr_close</code>,
+        <code>gh_pr</code>, and <code>gh_commit</code> increased schema, policy, docs,
+        prompt, receipt, and test coupling while adding no stronger safety boundary
+        than typed <code>Execute</code> can provide.
+      </div>
+
+      <div class="mini-list" aria-label="accepted public tools">
+        <span class="pill">Execute</span>
+        <span class="pill">SearchFiles</span>
+        <span class="pill">ReadFile</span>
+        <span class="pill">EditFile</span>
+        <span class="pill">WriteFile</span>
+        <span class="pill">SearchWeb</span>
+        <span class="pill">FetchWeb</span>
+      </div>
+    </section>
+
+    <section>
+      <h2>Architecture</h2>
+      <p>
+        The descriptor is the contract. The executor is a primitive route. The sandbox
+        is containment. Hooks observe. Receipts prove the decision.
+      </p>
+
+      <div class="diagram" aria-label="tool execution architecture diagram">
+        <div class="node public">
+          <strong>Public Tool</strong>
+          <span>Model-facing name such as <code>Execute</code> or <code>ReadFile</code>.</span>
+        </div>
+        <div class="node public">
+          <strong>Descriptor</strong>
+          <span>Schema, public name, internal name, policy, executor, backend, sandbox.</span>
+        </div>
+        <div class="node substrate">
+          <strong>Typed Input</strong>
+          <span>Strict JSON. No raw shell strings for <code>Execute</code>.</span>
+        </div>
+        <div class="node substrate">
+          <strong>Shell IR</strong>
+          <span>Typed command representation with decided risk envelope.</span>
+        </div>
+        <div class="node policy">
+          <strong>Gate</strong>
+          <span>Risk, write access, allowlist, path scope, approval.</span>
+        </div>
+        <div class="node runtime">
+          <strong>Runtime</strong>
+          <span>Sandbox or host process dispatch through selected backend.</span>
+        </div>
+        <div class="node evidence">
+          <strong>Receipt</strong>
+          <span>Route, policy decision, reason, risk, output, retry class.</span>
+        </div>
+      </div>
+
+      <h3>Execute Path</h3>
+      <pre><code>Execute JSON
+  -> Agent_tool_execute_typed_input
+  -> Shell_ir.t
+  -> Shell_ir_risk.decided envelope
+  -> Shell_command_gate.gate_typed
+  -> validate_shell_ir_paths
+  -> sandbox target selection
+  -> Exec_dispatch.dispatch_decided
+  -> per-call evidence JSONL + turn receipt summary</code></pre>
+
+      <h3>Descriptor Executor Contract</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Executor</th>
+            <th>Purpose</th>
+            <th>Examples</th>
+            <th>Not allowed to become</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>Shell_ir</code></td>
+            <td>Typed command execution and structured search-file command adapters.</td>
+            <td><code>Execute</code>, <code>SearchFiles</code></td>
+            <td><code>Gh_cli</code>, <code>Git_cli</code>, raw <code>Bash</code>.</td>
+          </tr>
+          <tr>
+            <td><code>Filesystem</code></td>
+            <td>Semantic file reads and writes with reviewable path/content shape.</td>
+            <td><code>ReadFile</code>, <code>EditFile</code>, <code>WriteFile</code></td>
+            <td>Ad hoc shell redirection or command-generated file mutation.</td>
+          </tr>
+          <tr>
+            <td><code>Remote_mcp</code></td>
+            <td>Remote evidence or MCP capability boundary.</td>
+            <td><code>SearchWeb</code>, <code>FetchWeb</code></td>
+            <td>Mirroring every remote operation as a first-class tool.</td>
+          </tr>
+          <tr>
+            <td><code>In_process</code></td>
+            <td>MASC-owned state and lifecycle transitions.</td>
+            <td>Tasks, board, goals, approvals, memory, keeper status.</td>
+            <td>CLI wrappers or vendor-specific transport shortcuts.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Comparative Research</h2>
+      <p>
+        The external systems are useful as contrast, not as templates. MASC should
+        borrow their safety lessons while rejecting tool-surface sprawl.
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>System</th>
+            <th>Observed tool model</th>
+            <th>Strength to borrow</th>
+            <th>Risk to reject</th>
+            <th>MASC stance</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>OpenClaw</td>
+            <td>Small built-in tool set, optional skills/MCP, high-risk shell command tool disabled by default.</td>
+            <td>Privilege shell execution and make built-ins understandable.</td>
+            <td>Raw shell command as the normal execution language.</td>
+            <td>Typed <code>Execute</code> only; raw shell does not become the model contract.</td>
+          </tr>
+          <tr>
+            <td>Hermes Agents</td>
+            <td>Broad tools and toolsets, terminal backends, file/browser/memory/delegation tools, dynamic MCP tools.</td>
+            <td>Toolsets and backend selection are useful for exposure control.</td>
+            <td>Tool count becoming a second product API.</td>
+            <td>Keep toolsets for capability grouping, but preserve primitive executor classes.</td>
+          </tr>
+          <tr>
+            <td>Claude Code local tree</td>
+            <td>Many concrete tools plus central permission decisions and Bash guidance to prefer dedicated file/search tools.</td>
+            <td>Structured file/search tools improve review, permissions, summaries, and diffs.</td>
+            <td>Prompt guidance alone cannot hold a boundary under autonomous loops.</td>
+            <td>Enforce boundaries in descriptors, tests, ratchets, and receipts.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p class="kicker">
+        Sources verified 2026-05-27:
+        <a href="https://openclawdoc.com/docs/agents/overview/">OpenClaw agents docs</a>,
+        <a href="https://openclawdoc.com/docs/agents/shell-commands">OpenClaw shell command docs</a>,
+        <a href="https://github.com/openclaw/openclaw">OpenClaw source</a>,
+        <a href="https://hermes-agent.nousresearch.com/docs/reference/tools-reference/">Hermes tools reference</a>,
+        <a href="https://github.com/NousResearch/hermes-agent">Hermes source</a>.
+      </p>
+    </section>
+
+    <section>
+      <h2>Implementation Plan</h2>
+      <p>
+        This is a staged PR campaign. Each stage has a narrow diff, a local proof,
+        and a regression guard. The sequence intentionally starts with documentation
+        and ratchets before changing runtime behavior.
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Phase</th>
+            <th>Goal</th>
+            <th>Deliverables</th>
+            <th>Validation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><span class="status done">PR-A</span> Decision report</td>
+            <td>Make the target architecture explicit.</td>
+            <td>Markdown plan plus this HTML implementation report.</td>
+            <td><code>git diff --check</code></td>
+          </tr>
+          <tr>
+            <td><span class="status next">PR-B</span> Executor ratchets</td>
+            <td>Prevent reintroduction of <code>Gh_cli</code>, <code>Git_cli</code>, <code>Oas_bridge</code>.</td>
+            <td>Descriptor enum/source tests and active-surface micro-tool ratchets.</td>
+            <td><code>scripts/dune-local.sh build test/test_agent_tool_descriptor_registry_integrity.exe test/test_keeper_tool_alias.exe</code></td>
+          </tr>
+          <tr>
+            <td><span class="status next">PR-C</span> Prompt alignment</td>
+            <td>Stop keeper prompts from suggesting stale names.</td>
+            <td>Normalize keeper prompts to <code>SearchWeb</code>, <code>FetchWeb</code>, <code>SearchFiles</code>, <code>ReadFile</code>, <code>EditFile</code>, <code>WriteFile</code>, <code>Execute</code>.</td>
+            <td><code>scripts/dune-local.sh build test/test_keeper_tool_alias.exe test/test_keeper_tool_matrix.exe</code></td>
+          </tr>
+          <tr>
+            <td><span class="status next">PR-D</span> Decision evidence</td>
+            <td>Make each tool call diagnosable from one receipt row.</td>
+            <td><code>policy_decision</code>, <code>decision_source</code>, <code>decision_reason</code>, and Shell IR risk class in per-call evidence.</td>
+            <td>Receipt tests plus dashboard projection tests.</td>
+          </tr>
+          <tr>
+            <td><span class="status risk">PR-E</span> Shell IR audit maintenance</td>
+            <td>Resolve the live <code>G3</code> metric mismatch.</td>
+            <td>Either restore meaningful direct coverage or replace the old grep heuristic with facade-aware coverage.</td>
+            <td><code>scripts/audit-shell-ir-consumption.sh --json</code> and focused Shell IR tests.</td>
+          </tr>
+          <tr>
+            <td><span class="status next">PR-F</span> GitHub workflow cleanup</td>
+            <td>Remove any guidance implying dedicated GitHub micro-tools.</td>
+            <td>Docs/prompts/hints rewritten to typed <code>Execute</code> <code>gh</code>/<code>git</code> workflows.</td>
+            <td>Active-surface <code>rg</code> ratchet.</td>
+          </tr>
+          <tr>
+            <td><span class="status next">PR-G</span> Keeper success harness</td>
+            <td>Prove keepers can use the tool set to finish realistic work.</td>
+            <td>Scenario harness for code edit/test, GitHub PR comment, web evidence, legacy-name recovery, and deterministic rejection.</td>
+            <td>Harness summary JSON with pass/fail counts and tool-decision evidence.</td>
+          </tr>
+          <tr>
+            <td><span class="status next">PR-H</span> Dashboard success view</td>
+            <td>Expose tool health to operators.</td>
+            <td>Keeper detail panel showing descriptor route, policy decision, error class, recovery hint, and repeated-failure count.</td>
+            <td>Dashboard component tests and fixture-backed screenshots if UI changes are material.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Keeper Tools Success Harness</h2>
+      <p>
+        The harness should exercise the actual behavior that matters in production:
+        tool selection, deterministic failure, recovery, and evidence quality.
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Scenario</th>
+            <th>Expected tool path</th>
+            <th>Success condition</th>
+            <th>Failure that must be caught</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Read current source</td>
+            <td><code>SearchFiles</code> then <code>ReadFile</code></td>
+            <td>No legacy <code>Read</code> call; file evidence has descriptor route.</td>
+            <td><code>Tool not found: Read</code> loops.</td>
+          </tr>
+          <tr>
+            <td>Edit and test</td>
+            <td><code>EditFile</code> or <code>WriteFile</code>, then <code>Execute</code> typed <code>dune</code>/<code>scripts/dune-local.sh</code></td>
+            <td>Write gate decision is explicit; command runs through Shell IR.</td>
+            <td>Raw shell string, glob, redirect, or chained command accepted silently.</td>
+          </tr>
+          <tr>
+            <td>GitHub PR comment</td>
+            <td><code>Execute</code> with <code>executable = "gh"</code> and typed argv.</td>
+            <td>No <code>pr_comment</code> or <code>gh_pr</code> tool exists or is suggested.</td>
+            <td>New GitHub micro-tool added for convenience.</td>
+          </tr>
+          <tr>
+            <td>Web evidence</td>
+            <td><code>SearchWeb</code> then <code>FetchWeb</code></td>
+            <td>Keeper prompt and descriptor surface agree on names.</td>
+            <td>Prompt tells keeper to call <code>masc_web_search</code> when only alias is exposed.</td>
+          </tr>
+          <tr>
+            <td>Rejected mutation in read-only preset</td>
+            <td><code>Execute</code> typed argv rejected by Shell IR risk/write gate.</td>
+            <td>Single deterministic rejection with alternative and no same-args retry.</td>
+            <td>Retry storm or unclassified workflow rejection.</td>
+          </tr>
+          <tr>
+            <td>Sandbox path mismatch</td>
+            <td>Descriptor-selected sandbox target plus path validator.</td>
+            <td>Receipt shows selected sandbox, rejected path, and correction hint.</td>
+            <td>Opaque Eio timeout or generic process error without route evidence.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Admission Bar</h2>
+      <p>
+        New tools must pass this review before implementation. A "no" here should
+        redirect the work to a skill, runbook, prompt, or typed <code>Execute</code>
+        example.
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Question</th>
+            <th>Reject if yes</th>
+            <th>Admit if true</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Can this be done by <code>Execute</code> with typed argv?</td>
+            <td><span class="status rule">Do not add tool</span></td>
+            <td>Only admit if the CLI shape cannot carry required review semantics.</td>
+          </tr>
+          <tr>
+            <td>Can this be done by file/search tools?</td>
+            <td><span class="status rule">Do not add tool</span></td>
+            <td>Only admit if state is not file-system state.</td>
+          </tr>
+          <tr>
+            <td>Is this MASC-owned state?</td>
+            <td>No, if it is vendor CLI state.</td>
+            <td>Yes for tasks, goals, board, approvals, memory, keeper lifecycle.</td>
+          </tr>
+          <tr>
+            <td>Does it add a stable semantic contract?</td>
+            <td>No, if it just wraps a vendor command.</td>
+            <td>Yes, if it provides transactionality, typed receipts, or review UX.</td>
+          </tr>
+          <tr>
+            <td>Can receipt evidence explain the decision?</td>
+            <td>No, if the decision hides in hooks or logs only.</td>
+            <td>Yes, if per-call JSONL records decision source and reason.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Risk Register</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Risk</th>
+            <th>Impact</th>
+            <th>Mitigation</th>
+            <th>Owner surface</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Convenience pressure reintroduces GitHub micro-tools.</td>
+            <td>Tool sprawl, prompt drift, test bloat, vendor coupling.</td>
+            <td>Active-surface ratchet and admission checklist.</td>
+            <td>Descriptor + prompts + tests.</td>
+          </tr>
+          <tr>
+            <td>Shell IR audit metric drift hides real coverage loss.</td>
+            <td>False confidence in gate/path validation.</td>
+            <td>Facade-aware G3 metric and scenario tests.</td>
+            <td>Shell IR audit + runtime tests.</td>
+          </tr>
+          <tr>
+            <td>Static descriptor evidence lacks actual policy decision.</td>
+            <td>Operators cannot diagnose why a call failed.</td>
+            <td>Add per-call <code>policy_decision</code>, source, reason, risk class.</td>
+            <td>Receipt and dashboard.</td>
+          </tr>
+          <tr>
+            <td>Prompt names diverge from active schema names.</td>
+            <td>Keepers call missing tools and waste turns.</td>
+            <td>Prompt/matrix alignment tests and hard-cut surface checks.</td>
+            <td>Prompt registry and tool alias tests.</td>
+          </tr>
+          <tr>
+            <td>Hooks become hidden policy owners.</td>
+            <td>Policy behavior becomes hard to reason about and hard to test.</td>
+            <td>Hooks observe only; policy stays in descriptors/gates.</td>
+            <td>Hook observation boundary tests.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Research-Style Evaluation Plan</h2>
+      <p>
+        Treat the tool substrate as a small empirical system. Each experiment should
+        produce durable JSON evidence, not a free-text success claim.
+      </p>
+
+      <div class="timeline">
+        <div class="time-row">
+          <div class="time-label">Hypothesis H1</div>
+          <div class="time-body">
+            A seven-tool public surface plus MASC-owned in-process domain tools reduces
+            tool-name errors compared with legacy aliases and micro-tools.
+            <br><strong>Measure:</strong> unknown tool calls, legacy-name calls, and
+            correction-loop count per 100 keeper turns.
+          </div>
+        </div>
+        <div class="time-row">
+          <div class="time-label">Hypothesis H2</div>
+          <div class="time-body">
+            Typed <code>Execute</code> through Shell IR is safer than raw shell strings for
+            git/gh/dune workflows without needing GitHub-specific tools.
+            <br><strong>Measure:</strong> deterministic reject quality, same-args retries,
+            successful gh/git scenarios, and Shell IR risk coverage.
+          </div>
+        </div>
+        <div class="time-row">
+          <div class="time-label">Hypothesis H3</div>
+          <div class="time-body">
+            Per-call decision evidence reduces operator diagnosis time for tool failures.
+            <br><strong>Measure:</strong> number of files/log streams required to explain a
+            failure before and after receipt enrichment.
+          </div>
+        </div>
+        <div class="time-row">
+          <div class="time-label">Hypothesis H4</div>
+          <div class="time-body">
+            Prompt/schema alignment prevents <code>Tool not found: Read</code> and similar
+            wake-loop failures.
+            <br><strong>Measure:</strong> stale prompt name scan and live failed-tool logs.
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Appendix: Current Evidence</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Evidence</th>
+            <th>2026-05-27 observation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Descriptor executor enum</td>
+            <td><code>Shell_ir</code>, <code>Filesystem</code>, <code>Remote_mcp</code>, <code>In_process</code>.</td>
+          </tr>
+          <tr>
+            <td>Shell IR audit</td>
+            <td><code>G1=3</code>, <code>G2 string=0/IR=2</code>, <code>G3=2</code>, <code>G4 phantom=18</code>, <code>G5=4</code>, <code>G6=1</code>, <code>G7=0</code>.</td>
+          </tr>
+          <tr>
+            <td>Active micro-tool scan</td>
+            <td>No active-surface hits for <code>pr_comment</code>, <code>pr_review</code>, <code>pr_close</code>, <code>gh_pr</code>, <code>gh_commit</code>, or <code>github_comment</code> in descriptor/prompt/policy/matrix surfaces.</td>
+          </tr>
+          <tr>
+            <td>Known caveat</td>
+            <td>Broader source scans include <code>pr_review_*</code> dashboard/reporting metrics and tests; classify those separately from active tool names.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+
+  <footer>
+    Generated as part of PR #19105. This report complements
+    <code>docs/design/tool-execution-substrate-plan.md</code>.
+  </footer>
+</body>
+</html>

--- a/docs/design/tool-execution-substrate-plan.md
+++ b/docs/design/tool-execution-substrate-plan.md
@@ -3,6 +3,7 @@
 Status: decision plan
 Created: 2026-05-27
 Scope: keeper agent tool surface, descriptor spine, Shell IR, and tool admission rules
+HTML companion: `docs/design/tool-execution-substrate-plan.html`
 
 ## Decision
 


### PR DESCRIPTION
## Summary
- Adds a detailed HTML design report for the Keeper tool execution substrate plan.
- Defines the explicit Keeper Tools Success goal and measurable success criteria.
- Expands the implementation plan with architecture diagrams, comparative research, WBS phases, success harness scenarios, admission rules, risks, and research-style evaluation hypotheses.

## Validation
- git diff --check
- python3 HTML sanity check for doctype/html/section structure
- ASCII scan over updated design files