### PR TITLE
refactor(dashboard/server): Masc_time_constants.hour_int replaces 3600 int literal at 6 sites across 3 files

### DIFF
--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -109,7 +109,7 @@ let tool_call_health_json ?(now_ts = Unix.gettimeofday ()) (config : Coord.confi
   ]
 
 let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
-  let warn_age_s = 3600 in
+  let warn_age_s = Masc_time_constants.hour_int in
   let bad_age_s = 21600 in
   let slo_target_age_s = 900 in
   try

--- a/lib/server/server_routes_http_runtime_health_helpers.ml
+++ b/lib/server/server_routes_http_runtime_health_helpers.ml
@@ -49,9 +49,13 @@ let health_uptime_secs () =
 
 let health_uptime_string uptime_secs =
   if uptime_secs < 60 then Printf.sprintf "%ds" uptime_secs
-  else if uptime_secs < 3600 then
+  else if uptime_secs < Masc_time_constants.hour_int then
     Printf.sprintf "%dm %ds" (uptime_secs / 60) (uptime_secs mod 60)
-  else Printf.sprintf "%dh %dm" (uptime_secs / 3600) ((uptime_secs mod 3600) / 60)
+  else
+    Printf.sprintf
+      "%dh %dm"
+      (uptime_secs / Masc_time_constants.hour_int)
+      ((uptime_secs mod Masc_time_constants.hour_int) / 60)
 
 let protocol_json ~listener =
   `Assoc

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -556,8 +556,9 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       let stale_threshold_hours = 12 in
       let build = Build_identity.current () in
       (match build.binary_commit, build.binary_commit_age_seconds with
-       | Some binary_commit, Some age when age > stale_threshold_hours * 3600 ->
-         let hours = age / 3600 in
+       | Some binary_commit, Some age
+         when age > stale_threshold_hours * Masc_time_constants.hour_int ->
+         let hours = age / Masc_time_constants.hour_int in
          Log.Server.warn
            "Server binary commit %s is %d hours old (>%dh threshold). \
             Rebuild + restart recommended to pick up newer fixes; see \


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" — Magic Number Time-literal 시리즈 **15번째 PR**. PR #19109 (MERGED) 가 추가한 `Masc_time_constants.hour_int` SSOT 활용. **3 파일 / 6 사이트** — dashboard + server health endpoints.

### 패턴

6 hour-substitutions (int). `mod 3600 / 60` 표현 (`server_routes_http_runtime_health_helpers.ml:54`) 도 `mod hour_int / 60` 으로 — magic 3600 만 제거, magic 60 (minute) 은 남김.

before:
```ocaml
(* dashboard_http_monitoring.ml:112 *)         let warn_age_s = 3600 in
(* server_runtime_bootstrap.ml:559-560 *)
                | Some binary_commit, Some age
                  when age > stale_threshold_hours * 3600 ->
                  let hours = age / 3600 in
(* server_routes_http_runtime_health_helpers.ml:52-54 *)
                else if uptime_secs < 3600 then ...
                else Printf.sprintf "%dh %dm"
                  (uptime_secs / 3600)
                  ((uptime_secs mod 3600) / 60)
```

after:
```ocaml
let warn_age_s = Masc_time_constants.hour_int in
| Some binary_commit, Some age
  when age > stale_threshold_hours * Masc_time_constants.hour_int ->
  let hours = age / Masc_time_constants.hour_int in
else if uptime_secs < Masc_time_constants.hour_int then ...
else Printf.sprintf "%dh %dm"
  (uptime_secs / Masc_time_constants.hour_int)
  ((uptime_secs mod Masc_time_constants.hour_int) / 60)
```

6 사이트 (3600 int × 6):
- `dashboard/dashboard_http_monitoring.ml:112` (board freshness WARN)
- `server/server_runtime_bootstrap.ml:559-560` (binary-age threshold + hours conversion, 2 sites)
- `server/server_routes_http_runtime_health_helpers.ml:52, 54, 54` (< 1h branch + hours conversion + mod-residual, 3 sites)

## Out-of-scope

`uptime_secs / 60` + `uptime_secs mod 60` — `minute_int` SSOT 미존재 (현 `Masc_time_constants` 는 `minute : float` 만). 본 PR 은 hour_int 활용에 집중. minute_int 추가는 별도 RFC 또는 사용자 결정 필요.

## 변경

- 3 files, +10/-5
- 6 hour-substitutions (int)
- 동작 무변경 (`hour_int = 3600`)

## Magic-number lint impact

- Before: 6 `3600` (int)
- After: 0

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 6 사이트 *모두* 동시 처리

## Test impact

- 동작 무변경
- `dune build lib/` PASS (base `acfd106a4`, post-#19109 main)

## Related

- PR #19109 (MERGED `c84967c26`) — `Masc_time_constants.hour_int` SSOT 추가
- PR #19037 ~ #19113 — Magic Number Time-literal 시리즈 누적 14
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
