### PR TITLE
Remove dashboard className summary aliases

### DIFF
--- a/dashboard/src/components/common/badge.test.ts
+++ b/dashboard/src/components/common/badge.test.ts
@@ -43,10 +43,6 @@ describe('summarizeCountBadge (pure)', () => {
     })
   })
 
-  it('keeps className as a fallback alias but lets class win', () => {
-    expect(summarizeCountBadge({ className: 'ml-2' }).customClassLength).toBe(4)
-    expect(summarizeCountBadge({ class: 'ring-1', className: 'ml-2' }).customClassLength).toBe(6)
-  })
 })
 
 describe('CountBadge', () => {

--- a/dashboard/src/components/common/badge.ts
+++ b/dashboard/src/components/common/badge.ts
@@ -18,11 +18,6 @@ export interface CountBadgeProps {
   children?: ComponentChildren
 }
 
-type CountBadgeSummaryInput = Pick<CountBadgeProps, 'tone' | 'class'> & {
-  /** Back-compat alias for older pure callers. `class` wins when both exist. */
-  className?: string
-}
-
 const TONE_CLASSES: Record<BadgeTone, string> = {
   default: 'bg-[var(--color-bg-hover)] text-[var(--color-fg-muted)]',
   warn: 'bg-[var(--warn-12)] text-[var(--color-status-warn)]',
@@ -40,13 +35,11 @@ export function countBadgeClasses(tone: BadgeTone = 'default', extra?: string): 
 export function summarizeCountBadge({
   tone = 'default',
   class: classProp,
-  className,
-}: CountBadgeSummaryInput): CountBadgeSummary {
-  const customClass = classProp ?? className
+}: Pick<CountBadgeProps, 'tone' | 'class'>): CountBadgeSummary {
   return {
     tone,
-    hasCustomClass: customClass !== undefined && customClass !== '',
-    customClassLength: customClass?.length ?? 0,
+    hasCustomClass: classProp !== undefined && classProp !== '',
+    customClassLength: classProp?.length ?? 0,
   }
 }
 

--- a/dashboard/src/components/common/kbd.test.ts
+++ b/dashboard/src/components/common/kbd.test.ts
@@ -83,10 +83,6 @@ describe('summarizeKbd (pure)', () => {
     })
   })
 
-  it('keeps className as a fallback alias but lets class win', () => {
-    expect(summarizeKbd({ className: 'ml-1' }).classNameLength).toBe(4)
-    expect(summarizeKbd({ class: 'mr-22', className: 'ml-1' }).classNameLength).toBe(5)
-  })
 })
 
 describe('Kbd component', () => {

--- a/dashboard/src/components/common/kbd.ts
+++ b/dashboard/src/components/common/kbd.ts
@@ -52,11 +52,6 @@ export interface KbdProps {
   testId?: string
 }
 
-type KbdSummaryInput = Pick<KbdProps, 'size' | 'class' | 'title'> & {
-  /** Back-compat alias for older pure callers. `class` wins when both exist. */
-  className?: string
-}
-
 const BASE =
   'inline-flex items-center justify-center rounded-xs border border-b-2 font-mono text-center text-3xs ' +
   'border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)]'
@@ -77,16 +72,14 @@ export function kbdClasses(size: KbdSize = 'md', extra?: string): string {
 export function summarizeKbd({
   size = 'md',
   class: classProp,
-  className,
   title,
-}: KbdSummaryInput): KbdSummary {
-  const customClass = classProp ?? className
+}: Pick<KbdProps, 'size' | 'class' | 'title'>): KbdSummary {
   return {
     size,
     hasTitle: title !== undefined && title !== '',
-    hasCustomClass: customClass !== undefined && customClass !== '',
+    hasCustomClass: classProp !== undefined && classProp !== '',
     titleLength: title?.length ?? 0,
-    classNameLength: customClass?.length ?? 0,
+    classNameLength: classProp?.length ?? 0,
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove pure-summary-only className aliases from CountBadge and Kbd helpers.
- Delete alias compatibility tests so class remains the single prop surface.

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/common/badge.test.ts src/components/common/badge.a11y.test.ts src/components/common/kbd.test.ts src/components/common/kbd.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/common/badge.ts src/components/common/badge.test.ts src/components/common/badge.a11y.test.ts src/components/common/kbd.ts src/components/common/kbd.test.ts src/components/common/kbd.a11y.test.ts
- git diff --check origin/main