### PR TITLE
refactor(server/dashboard): Masc_time_constants.hour_int/day_int at 4 sites (ms-converter + tz-offset parser)

### DIFF
--- a/lib/dashboard/dashboard_labels.ml
+++ b/lib/dashboard/dashboard_labels.ml
@@ -45,7 +45,8 @@ let parse_iso_timestamp (s : string) : float option =
             let mm = String.sub raw 4 2 in
             if all_digits hh && all_digits mm then
               match int_of_string_opt hh, int_of_string_opt mm with
-              | Some h, Some m -> Some (sign * ((h * 3600) + (m * 60)))
+              | Some h, Some m ->
+                Some (sign * ((h * Masc_time_constants.hour_int) + (m * 60)))
               | _ -> None
             else
               None
@@ -54,7 +55,8 @@ let parse_iso_timestamp (s : string) : float option =
             let mm = String.sub raw 3 2 in
             if all_digits hh && all_digits mm then
               match int_of_string_opt hh, int_of_string_opt mm with
-              | Some h, Some m -> Some (sign * ((h * 3600) + (m * 60)))
+              | Some h, Some m ->
+                Some (sign * ((h * Masc_time_constants.hour_int) + (m * 60)))
               | _ -> None
             else
               None

--- a/lib/server/server_activity_http.ml
+++ b/lib/server/server_activity_http.ml
@@ -61,8 +61,8 @@ let parse_since_ms (raw : string) : int option =
   let num_str = String.sub raw 0 (len - 1) in
   match (int_of_string_opt num_str, suffix) with
     | Some n, 'm' -> Some (n * 60 * 1000)
-    | Some n, 'h' -> Some (n * 3600 * 1000)
-    | Some n, 'd' -> Some (n * 24 * 3600 * 1000)
+    | Some n, 'h' -> Some (n * Masc_time_constants.hour_int * 1000)
+    | Some n, 'd' -> Some (n * Masc_time_constants.day_int * 1000)
     | _ -> None
 
 let graph_http_json ~deps ~state request =


### PR DESCRIPTION
## 요약

sw-dev §"Magic Number 금지" — Magic Number Time-literal 시리즈 **16번째 PR**. PR #19109 (MERGED) 가 추가한 `hour_int`/`day_int` SSOT 활용. **2 파일 / 4 사이트** — ms-converter + tz-offset parser.

### 패턴

3 hour-substitutions + 1 day-substitution (int). `24 * 3600` 가 `day_int` 로 collapse — 단일 참조로 의미 노출 강화.

before:
```ocaml
(* server_activity_http.ml:64-65 *)
| Some n, 'h' -> Some (n * 3600 * 1000)
| Some n, 'd' -> Some (n * 24 * 3600 * 1000)

(* dashboard_labels.ml:48 (6-char +HH:MM) *)
| Some h, Some m -> Some (sign * ((h * 3600) + (m * 60)))
(* dashboard_labels.ml:57 (5-char +HHMM)  *)
| Some h, Some m -> Some (sign * ((h * 3600) + (m * 60)))
```

after:
```ocaml
| Some n, 'h' -> Some (n * Masc_time_constants.hour_int * 1000)
| Some n, 'd' -> Some (n * Masc_time_constants.day_int * 1000)
| Some h, Some m ->
  Some (sign * ((h * Masc_time_constants.hour_int) + (m * 60)))
```

4 사이트 (3600 int × 3 + `24 * 3600` × 1):
- `lib/server/server_activity_http.ml:64` (`'h' suffix`, hour)
- `lib/server/server_activity_http.ml:65` (`'d' suffix`, day — `24 * 3600` collapses)
- `lib/dashboard/dashboard_labels.ml:48` (tz-offset `+HH:MM`)
- `lib/dashboard/dashboard_labels.ml:57` (tz-offset `+HHMM`)

### Partial SSOT 적용

`dashboard_labels.ml` 의 `(h * 3600) + (m * 60)` 는 **부분 SSOT 화**:
- `h * 3600` → `h * Masc_time_constants.hour_int` ✓
- `m * 60` (minutes-to-seconds) — 그대로

이유: `Masc_time_constants` 에 `minute : float` 만 있고 `minute_int` 없음. 시리즈 일관성 정책 (sw-dev §"단위 변환 계수" 예외 적용 후보). minute_int 신규 추가는 후속 RFC.

### `* 1000` 보존

`server_activity_http.ml` 의 `* 1000` (seconds-to-ms factor) — canonical ms-converter idiom. `ms_per_sec` 상수 추가는 *의미 노출* 효과보다 *추가 indirection* 비용이 큼. 보존.

## 변경

- 2 files, +6/-4
- 3 hour-substitutions + 1 day-substitution
- 동작 무변경

## Magic-number lint impact

- Before: 4 `3600` (int)
- After: 0

## Workaround Signature Gate

WORKAROUND-WAIVED: 본 PR 은 Magic Number 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 4 사이트 *모두* 동시 처리

## Test impact

- 동작 무변경
- `dune build lib/` PASS (base `acfd106a4`)

## Related

- PR #19109 (MERGED) — `hour_int`/`day_int` SSOT
- PR #19116 (OPEN Draft) — hour_int 첫 활용 사례
- PR #19037 ~ #19116 — Magic Number Time-literal 시리즈 누적 15
- sw-dev §"Magic Number 금지"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
