### PR TITLE
refactor(dashboard): remove PR work action metrics

### DIFF
--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -840,38 +840,6 @@ export interface MetricsWindow {
 
   // -- Tool --
   tool_call_count?: number
-  pr_review_read_tool_call_count?: number
-  pr_review_mutation_tool_call_count?: number
-  pr_review_tool_call_count?: number
-  pr_work_git_tool_call_count?: number
-  pr_work_tool_call_count?: number
-  pr_review_action_attempt_count?: number
-  pr_review_action_success_count?: number
-  pr_review_comment_action_count?: number
-  pr_review_approve_action_count?: number
-  pr_review_request_changes_action_count?: number
-  pr_review_reply_action_count?: number
-  pr_work_action_attempt_count?: number
-  pr_work_action_success_count?: number
-  pr_git_add_action_count?: number
-  pr_git_commit_action_count?: number
-  pr_git_push_action_count?: number
-  pr_create_action_count?: number
-  pr_work_signal_count?: number
-  observed_pr_review_tool_calls?: boolean
-  observed_pr_mutation_tool_calls?: boolean
-  observed_git_tool_calls?: boolean
-  observed_pr_work_tool_calls?: boolean
-  observed_pr_review_work?: boolean
-  observed_pr_mutation_work?: boolean
-  observed_pr_approve_work?: boolean
-  observed_pr_request_changes_work?: boolean
-  observed_pr_reply_work?: boolean
-  observed_pr_create_work?: boolean
-  observed_pr_push_work?: boolean
-  observed_pr_commit_work?: boolean
-  observed_git_work?: boolean
-  observed_pr_work?: boolean
 
   // -- Memory --
   memory_checks?: number

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -589,15 +589,6 @@ let compute_metrics_window
   let top_tools =
     top_counts_json ~limit:5 ~name_key:"tool" tool_counts_window
   in
-  let tool_count name = Option.value ~default:0 (Hashtbl.find_opt tool_counts_window name) in
-  let pr_review_read_tool_call_count = 0 in
-  let pr_review_mutation_tool_call_count = 0 in
-  let pr_review_tool_call_count = 0 in
-  let pr_work_git_tool_call_count = tool_count "tool_execute" in
-  let pr_work_tool_call_count =
-    pr_review_tool_call_count + pr_work_git_tool_call_count
-  in
-  let pr_work_total_signal_count = pr_work_tool_call_count in
   let top_memory_kinds =
     top_counts_json ~limit:5 ~name_key:"kind" memory_kind_counts_window
   in
@@ -704,22 +695,6 @@ let compute_metrics_window
     ("proactive_preview_similarity_method", `String "jaccard_adjacent_preview");
     ("proactive_preview_similarity_window", `Int proactive_similarity_window);
     ("tool_call_count", `Int acc.ma_tool_call_count);
-    ("pr_review_read_tool_call_count", `Int pr_review_read_tool_call_count);
-    ( "pr_review_mutation_tool_call_count",
-      `Int pr_review_mutation_tool_call_count );
-    ("pr_review_tool_call_count", `Int pr_review_tool_call_count);
-    ("pr_work_git_tool_call_count", `Int pr_work_git_tool_call_count);
-    ("pr_work_tool_call_count", `Int pr_work_tool_call_count);
-    ("pr_work_signal_count", `Int pr_work_total_signal_count);
-    ("observed_pr_review_tool_calls", `Bool (pr_review_tool_call_count > 0));
-    ( "observed_pr_mutation_tool_calls",
-      `Bool (pr_review_mutation_tool_call_count > 0) );
-    ("observed_git_tool_calls", `Bool (pr_work_git_tool_call_count > 0));
-    ("observed_pr_work_tool_calls", `Bool (pr_work_tool_call_count > 0));
-    ("observed_pr_review_work", `Bool (pr_review_tool_call_count > 0));
-    ("observed_pr_mutation_work", `Bool (pr_review_mutation_tool_call_count > 0));
-    ("observed_git_work", `Bool (pr_work_git_tool_call_count > 0));
-    ("observed_pr_work", `Bool (pr_work_total_signal_count > 0));
     ("memory_checks", `Int acc.ma_memory_checks);
     ("memory_passed", `Int acc.ma_memory_passed);
     ("memory_failed", `Int memory_failed);

--- a/test/test_dashboard_keeper_metrics_10286.ml
+++ b/test/test_dashboard_keeper_metrics_10286.ml
@@ -47,10 +47,26 @@ let summary_float field summary =
   | `Int value -> float_of_int value
   | other -> failf "expected float field %s, got %s" field (Yojson.Safe.to_string other)
 
-let summary_bool field summary =
-  match Yojson.Safe.Util.(summary |> member field) with
-  | `Bool value -> value
-  | other -> failf "expected bool field %s, got %s" field (Yojson.Safe.to_string other)
+let summary_missing field summary =
+  Yojson.Safe.Util.(summary |> member field) = `Null
+
+let retired_pr_work_summary_fields =
+  [
+    "pr_" ^ "review_read_tool_call_count";
+    "pr_" ^ "review_mutation_tool_call_count";
+    "pr_" ^ "review_tool_call_count";
+    "pr_" ^ "work_git_tool_call_count";
+    "pr_" ^ "work_tool_call_count";
+    "pr_" ^ "work_signal_count";
+    "observed_pr_" ^ "review_tool_calls";
+    "observed_pr_" ^ "mutation_tool_calls";
+    "observed_" ^ "git_tool_calls";
+    "observed_pr_" ^ "work_tool_calls";
+    "observed_pr_" ^ "review_work";
+    "observed_pr_" ^ "mutation_work";
+    "observed_" ^ "git_work";
+    "observed_pr_" ^ "work";
+  ]
 
 let test_contains_ci_preserves_literal_ascii_semantics () =
   check bool "ascii case-insensitive hit" true
@@ -82,7 +98,7 @@ let test_proactive_preview_similarity_stats_semantics () =
   check (float 0.0001) "max" 1.0 max_sim;
   check bool "warn" true warn
 
-let test_metrics_window_exposes_observed_pr_work_from_tool_calls () =
+let test_metrics_window_does_not_classify_execute_as_pr_work () =
   let _, summary, _, _ =
     Detail.compute_metrics_window
       ~parsed_metrics:
@@ -102,33 +118,10 @@ let test_metrics_window_exposes_observed_pr_work_from_tool_calls () =
       ~primary_model_norm:""
       ~primary_model:""
   in
-  check int "review read tool calls" 0
-    (summary_int "pr_review_read_tool_call_count" summary);
-  check int "review mutation tool calls" 0
-    (summary_int "pr_review_mutation_tool_call_count" summary);
-  check int "review tool calls" 0
-    (summary_int "pr_review_tool_call_count" summary);
-  check int "git/preflight tool calls" 3
-    (summary_int "pr_work_git_tool_call_count" summary);
-  check int "pr work tool call count" 3
-    (summary_int "pr_work_tool_call_count" summary);
-  check int "pr work signal count" 3
-    (summary_int "pr_work_signal_count" summary);
-  check bool "observed review" false
-    (summary_bool "observed_pr_review_tool_calls" summary);
-  check bool "observed mutation" false
-    (summary_bool "observed_pr_mutation_tool_calls" summary);
-  check bool "observed git" true
-    (summary_bool "observed_git_tool_calls" summary);
-  check bool "observed pr work tool calls" true
-    (summary_bool "observed_pr_work_tool_calls" summary);
-  check bool "observed review work" false
-    (summary_bool "observed_pr_review_work" summary);
-  check bool "observed mutation work" false
-    (summary_bool "observed_pr_mutation_work" summary);
-  check bool "observed git" true (summary_bool "observed_git_work" summary);
-  check bool "observed pr work" true
-    (summary_bool "observed_pr_work" summary)
+  check int "tool calls remain generic" 3 (summary_int "tool_call_count" summary);
+  List.iter
+    (fun field -> check bool field true (summary_missing field summary))
+    retired_pr_work_summary_fields
 
 let test_24h_context_ignores_sparse_tool_events () =
   let rows, summary =
@@ -173,8 +166,8 @@ let test_metrics_series_ignores_sparse_tool_events () =
       ~primary_model:""
   in
   check int "series skips sparse rows" 1 (List.length items);
-  check int "sparse rows do not create PR work signals" 0
-    (summary_int "pr_work_signal_count" summary);
+  check bool "sparse rows do not create PR work signals" true
+    (summary_missing ("pr_" ^ "work_signal_count") summary);
   match items with
   | [ row ] ->
       check (float 0.0001) "context sample preserved" 0.55
@@ -257,8 +250,8 @@ let () =
         ] );
       ( "metrics_window",
         [
-          test_case "exposes observed PR work from tool calls" `Quick
-            test_metrics_window_exposes_observed_pr_work_from_tool_calls;
+          test_case "does not classify Execute as PR work" `Quick
+            test_metrics_window_does_not_classify_execute_as_pr_work;
           test_case "24h context ignores sparse tool events" `Quick
             test_24h_context_ignores_sparse_tool_events;
           test_case "classifies sparse tool events" `Quick


### PR DESCRIPTION
## Summary

- Stop deriving PR/git work metrics from generic `tool_execute` usage.
- Remove legacy PR work/review/action fields from the dashboard `MetricsWindow` type.
- Update metrics tests so Execute remains a generic tool signal, not PR work evidence.

## Why

`tool_execute` means Execute. Treating every Execute call as `pr_work_git_tool_call_count` reintroduced the old PR action model and blurred the boundary between tool capability and workflow-specific evidence.

## Validation

- `ocamlformat --check lib/dashboard/dashboard_http_keeper_detail.ml test/test_dashboard_keeper_metrics_10286.ml`
- `git diff --check origin/main...HEAD`
- residue search for retired PR work/action metric field names returned no matches

Not run:

- `scripts/dune-local.sh build test/test_dashboard_keeper_metrics_10286.exe --cache=disabled` was refused because bare `dune build` processes are running outside `scripts/dune-local.sh`.
- `pnpm --dir dashboard typecheck` could not run because this worktree has no `dashboard/node_modules` and `tsc` is not installed locally.