### PR TITLE
fix(keeper): make build_prompt ~profile_defaults optional (follow-up #19108)

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -436,16 +436,19 @@ let autonomous_trigger_lines
   | _ -> []
 
 let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
-    ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
+    ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
     ~(observation : Keeper_world_observation.world_observation)
     () : string * string
     =
   ignore base_path;
-  let will = Option.value profile_defaults.will ~default:meta.will in
-  let needs = Option.value profile_defaults.needs ~default:meta.needs in
-  let desires = Option.value profile_defaults.desires ~default:meta.desires in
-  let instructions =
-    Option.value profile_defaults.instructions ~default:meta.instructions
+  let will, needs, desires, instructions =
+    match profile_defaults with
+    | Some d ->
+        ( Option.value d.will ~default:meta.will
+        , Option.value d.needs ~default:meta.needs
+        , Option.value d.desires ~default:meta.desires
+        , Option.value d.instructions ~default:meta.instructions )
+    | None -> (meta.will, meta.needs, meta.desires, meta.instructions)
   in
   let trait_lines =
     String.concat ""

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -22,7 +22,10 @@ val state_block_instruction_text : string
 val build_prompt :
   meta:Keeper_types.keeper_meta ->
   base_path:string ->
-  profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
+  ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
   observation:Keeper_world_observation.world_observation ->
   unit ->
   string * string
+(** When [?profile_defaults] is omitted, personality fields fall back to
+    [meta.{will,needs,desires,instructions}] directly (legacy behavior).
+    Production hot path supplies it; tests can keep the bare call. *)


### PR DESCRIPTION
## Summary

Follow-up to merged PR #19108. CodexBot review ([discussion_r3310346294](https://github.com/jeong-sik/masc-mcp/pull/19108#discussion_r3310346294)) flagged that `~profile_defaults` as a *required* labeled arg breaks 35 call sites in `test/test_keeper_unified.ml` (e.g. line 2209) that omit it — `Keeper_unified_prompt` is exposed through the mli so those tests no longer type-check.

## Change

Switch `~profile_defaults` → `?profile_defaults` (optional). When omitted, personality fields fall back to raw `meta.{will,needs,desires,instructions}` (legacy behavior).

- **Production hot path** (`keeper_unified_turn.ml:263`) continues to supply it → config-drift fix from #19108 remains effective.
- **Test path** keeps the bare calls → 35 callers compile unchanged (zero test churn).
- **Default behavior preservation**: `None` branch returns the exact same tuple shape as pre-#19108 — no semantic change for callers that don't opt in.

| 파일 | 변경 |
|---|---|
| `lib/keeper/keeper_unified_prompt.mli` | `profile_defaults:...` → `?profile_defaults:...` + docstring |
| `lib/keeper/keeper_unified_prompt.ml` | `match profile_defaults with Some d -> ... | None -> raw meta tuple` |

Diff: 2 file, +13/-7.

## Verification

- `dune build lib test` PASS (exit 0)
- 머지 후 별도 동작 변화 없음 — caller 가 `~profile_defaults` 안 넘기면 #19108 이전과 동일하게 raw `meta.*` 사용

## Workaround Signature Gate

비해당. Optional argument 도입은 typed escape hatch (`Option`). String 분류기/Counter/N-of-M/repair 모두 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
