### PR TITLE
Align StatusDot summary class input

### DIFF
--- a/dashboard/src/components/common/status-dot.test.ts
+++ b/dashboard/src/components/common/status-dot.test.ts
@@ -72,7 +72,7 @@ describe('summarizeStatusDot (pure)', () => {
 
   it('summarizes semantic dots with tone metadata', () => {
     const tone = 'bg-[var(--ok-10)] ring-1'
-    expect(summarizeStatusDot({ size: 'md', className: tone, ariaLabel: 'healthy' })).toEqual({
+    expect(summarizeStatusDot({ size: 'md', class: tone, ariaLabel: 'healthy' })).toEqual({
       size: 'md',
       mode: 'semantic',
       hasCustomClass: true,

--- a/dashboard/src/components/common/status-dot.ts
+++ b/dashboard/src/components/common/status-dot.ts
@@ -66,20 +66,20 @@ export function normalizeStatusDotAriaLabel(ariaLabel?: string): string | undefi
 
 export function summarizeStatusDot({
   size = 'sm',
-  className,
+  class: classProp,
   ariaLabel,
 }: {
   size?: StatusDotSize
-  className?: string
+  class?: string
   ariaLabel?: string
 }): StatusDotSummary {
   const hasAriaLabel = normalizeStatusDotAriaLabel(ariaLabel) !== undefined
   return {
     size,
     mode: hasAriaLabel ? 'semantic' : 'decorative',
-    hasCustomClass: className !== undefined && className !== '',
+    hasCustomClass: classProp !== undefined && classProp !== '',
     hasAriaLabel,
-    classNameLength: className?.length ?? 0,
+    classNameLength: classProp?.length ?? 0,
   }
 }
 
@@ -103,7 +103,7 @@ export function StatusDot({
   ariaLabel,
   testId,
 }: StatusDotProps) {
-  const summary = summarizeStatusDot({ size, className: cx, ariaLabel })
+  const summary = summarizeStatusDot({ size, class: cx, ariaLabel })
   const cls = statusDotClasses(size, cx)
   const normalizedAriaLabel = normalizeStatusDotAriaLabel(ariaLabel)
   const semantic = summary.mode === 'semantic'


### PR DESCRIPTION
## Summary
- Change summarizeStatusDot input from className to class so the pure helper matches the actual StatusDot prop surface.
- Keep existing summary output/data attributes unchanged.

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/common/status-dot.test.ts src/components/common/status-dot.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/common/status-dot.ts src/components/common/status-dot.test.ts src/components/common/status-dot.a11y.test.ts
- git diff --check origin/main