### PR TITLE
refactor(dashboard/board): extract SYSTEM_MESSAGE_FROM const to dedupe 3 'system' fallback literals

### DIFF
--- a/dashboard/src/components/board/mention-inbox.ts
+++ b/dashboard/src/components/board/mention-inbox.ts
@@ -6,6 +6,7 @@ import { EmptyState } from '../common/feedback-state'
 import { RichContent } from '../common/rich-content'
 import { TimeAgo } from '../common/time-ago'
 import { stripStateBlocks } from '../../keeper-message'
+import { SYSTEM_MESSAGE_FROM } from '../../lib/board-utils'
 import { currentDashboardActorName } from '../../lib/dashboard-session-actor'
 import { navigate } from '../../router'
 import { messages, shellAuthSummary } from '../../store'
@@ -134,7 +135,7 @@ function MessageRow({ row }: { row: MentionInboxRow }) {
   return html`
     <article class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3.5 py-3">
       <div class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-        <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">${row.message.from ?? 'system'}</span>
+        <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">${row.message.from ?? SYSTEM_MESSAGE_FROM}</span>
         ${row.message.timestamp
           ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${row.message.timestamp} /></span>`
           : null}

--- a/dashboard/src/components/board/message-room-timeline.ts
+++ b/dashboard/src/components/board/message-room-timeline.ts
@@ -6,6 +6,7 @@ import { EmptyState } from '../common/feedback-state'
 import { RichContent } from '../common/rich-content'
 import { TimeAgo } from '../common/time-ago'
 import { stripStateBlocks } from '../../keeper-message'
+import { SYSTEM_MESSAGE_FROM } from '../../lib/board-utils'
 import { navigate } from '../../router'
 import { messages } from '../../store'
 import type { Message } from '../../types'
@@ -109,7 +110,7 @@ function TimelineMessage({ row }: { row: TimelineRow }) {
       </div>
       <div class="min-w-0">
         <div class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-          <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">${row.message.from ?? 'system'}</span>
+          <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">${row.message.from ?? SYSTEM_MESSAGE_FROM}</span>
           ${row.message.timestamp
             ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${row.message.timestamp} /></span>`
             : null}

--- a/dashboard/src/components/board/state-block-messages.ts
+++ b/dashboard/src/components/board/state-block-messages.ts
@@ -6,6 +6,7 @@ import { EmptyState } from '../common/feedback-state'
 import { RichContent } from '../common/rich-content'
 import { TimeAgo } from '../common/time-ago'
 import { stripStateBlocks } from '../../keeper-message'
+import { SYSTEM_MESSAGE_FROM } from '../../lib/board-utils'
 import { navigate } from '../../router'
 import { messages } from '../../store'
 import type { Message } from '../../types'
@@ -97,7 +98,7 @@ function StateRow({ row }: { row: StateBlockRow }) {
         ${row.message.seq !== undefined
           ? html`<span class="text-3xs font-semibold tabular-nums uppercase tracking-[var(--track-caps)] text-[var(--warn-bright)]">#${row.message.seq}</span>`
           : null}
-        <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">${row.message.from ?? 'system'}</span>
+        <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">${row.message.from ?? SYSTEM_MESSAGE_FROM}</span>
         ${row.message.timestamp
           ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${row.message.timestamp} /></span>`
           : null}
@@ -137,7 +138,7 @@ function StateRow({ row }: { row: StateBlockRow }) {
 
 export function StateBlockMessages() {
   const rows = useMemo(() => buildStateBlockRows(messages.value), [messages.value])
-  const sourceCount = new Set(rows.map(row => row.message.from ?? 'system')).size
+  const sourceCount = new Set(rows.map(row => row.message.from ?? SYSTEM_MESSAGE_FROM)).size
 
   return html`
     <section class="grid gap-4" aria-labelledby="state-block-messages-heading">

--- a/dashboard/src/lib/board-utils.ts
+++ b/dashboard/src/lib/board-utils.ts
@@ -1,5 +1,15 @@
 // Board display utilities — shared between memory.ts and memory-post-detail.ts
 
+/**
+ * User-visible fallback shown when a board message arrives without a
+ * `from` field — three board panels (state-block-messages,
+ * mention-inbox, message-room-timeline) used to inline the literal
+ * `'system'` in `row.message.from ?? 'system'`. Captured here so a
+ * future relabel (e.g. localising to `'시스템'` or distinguishing
+ * automation from system) updates every panel in one place.
+ */
+export const SYSTEM_MESSAGE_FROM = 'system'
+
 import { navigate } from '../router'
 import { findKeeper } from './keeper-utils'
 import { openKeeperDetail } from '../components/keeper-detail'


### PR DESCRIPTION
## 요약
3 board 패널의 `'system'` fallback literal 을 `lib/board-utils.ts` 의 `SYSTEM_MESSAGE_FROM` const 로 SSOT 화. iter#40/45 user-visible sentinel 패턴의 board domain 응용.

## 배경

`rg "\?\? 'system'" -n` sweep 결과 6 callsite 중 **board-domain 3 callsite** 동일 의미:

| 파일 | callsite | 의미 |
|---|---|---|
| `components/board/state-block-messages.ts:100` | `row.message.from ?? 'system'` | sender label render |
| `components/board/state-block-messages.ts:140` | `row.message.from ?? 'system'` | distinct sender count (Set) |
| `components/board/mention-inbox.ts:137` | `row.message.from ?? 'system'` | sender label render |
| `components/board/message-room-timeline.ts:112` | `row.message.from ?? 'system'` | sender label render |

나머지 3 callsite (ide-activity-panel actor, status-tray entry kind 등) 는 *다른 도메인 의미* — file-internal scope 유지.

## 변경

### `lib/board-utils.ts`
- `export const SYSTEM_MESSAGE_FROM = 'system'` 추가
- JSDoc 으로 3 consumer 파일 + 미래 relabel 시나리오 (locale 변경, automation vs system 구분) 명시

### 3 board 파일
- 각자 `import { SYSTEM_MESSAGE_FROM } from '../../lib/board-utils'` 추가
- `?? 'system'` → `?? SYSTEM_MESSAGE_FROM` (sed bulk swap)

## 검증
- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)
- 시각적 변경 0

## iter chain — user-visible sentinel SSOT
- iter#40: `NO_TIME_INFO` (lib 의 fallback + comparison sentinel)
- iter#45: `MISSING_DATA_DASH` (UI dash 17 callsite)
- iter#51: `SYSTEM_MESSAGE_FROM` (board sender fallback 3 callsite)

같은 *cross-file user-visible string literal coupling* 안티패턴의 board domain 응용. user-visible label 변경 시 1 곳만 갱신.

## /loop iter#51
SSOT 위반 dashboard 축출 loop 의 iter#51. cumulative 51 PR (33 머지 + 2 OPEN — #19114 + #19?_).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
