### PR TITLE
[codex] Guard Execute against stale sandbox repos

### DIFF
--- a/lib/exec_policy.mli
+++ b/lib/exec_policy.mli
@@ -64,6 +64,8 @@ val validate_command_tool_execute :
 
 val simple_literal_args : Masc_exec.Shell_ir.simple -> string list option
 
+val path_argument_values : string -> string list -> string list
+
 val existing_dir_path_values_of_shell_ir : Masc_exec.Shell_ir.t -> string list
 
 val validate_shell_ir_paths :

--- a/lib/keeper/agent_tool_execute_path.ml
+++ b/lib/keeper/agent_tool_execute_path.ml
@@ -27,7 +27,7 @@ let normalize_repo_cwd_path path =
   Keeper_alerting_path.normalize_path_for_check path
   |> Keeper_alerting_path.strip_trailing_slashes
 
-let repo_root_of_cwd ~(config : Coord.config) ~(meta : keeper_meta) cwd =
+let repo_path_context ~(config : Coord.config) ~(meta : keeper_meta) cwd =
   let playground =
     keeper_playground_root ~config ~meta
     |> normalize_repo_cwd_path
@@ -50,10 +50,10 @@ let repo_root_of_cwd ~(config : Coord.config) ~(meta : keeper_meta) cwd =
         let worktree_root =
           Filename.concat (Filename.concat repo_root ".worktrees") task_name
         in
-        Some (repo_name, repo_root, [ repo_root; worktree_root ])
+        Some (repo_name, repo_root, worktree_root, [ worktree_root ])
       | repo_name :: _ when Keeper_repo_readiness.safe_repo_component repo_name ->
         let repo_root = Filename.concat repos_root repo_name in
-        Some (repo_name, repo_root, [ repo_root ])
+        Some (repo_name, repo_root, repo_root, [ repo_root ])
       | _ -> None
 
 let repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel =
@@ -69,12 +69,16 @@ let repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel =
     repo_name
     repo_name
 
-let validate_repo_cwd_ready ~(config : Coord.config) ~(meta : keeper_meta) cwd =
-  match repo_root_of_cwd ~config ~meta cwd with
+let validate_repo_path_ready
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~(probe_path : string)
+      cwd
+  =
+  match repo_path_context ~config ~meta cwd with
   | None -> Ok ()
-  | Some (repo_name, repo_root, accepted_toplevels) ->
-    let probe_path = cwd in
-    if not (safe_is_dir repo_root) then
+  | Some (repo_name, repo_root, _path_root, accepted_toplevels) ->
+    if not (safe_is_dir probe_path) then
       Error
         (repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel:None)
     else
@@ -99,71 +103,72 @@ let validate_repo_cwd_ready ~(config : Coord.config) ~(meta : keeper_meta) cwd =
         Error
           (repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel:top_opt)
 
+let validate_repo_cwd_ready ~(config : Coord.config) ~(meta : keeper_meta) cwd =
+  validate_repo_path_ready ~config ~meta ~probe_path:cwd cwd
+
 let validate_repo_path_args_ready
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(cwd : string)
       (ir : Masc_exec.Shell_ir.t)
   =
-  let literal_args_of_simple simple =
-    let rec collect acc = function
-      | [] -> Some (List.rev acc)
-      | Masc_exec.Shell_ir.Lit (arg, _) :: rest -> collect (arg :: acc) rest
-      | Masc_exec.Shell_ir.Concat _ :: _ | Masc_exec.Shell_ir.Var _ :: _ -> None
+  let path_args_of_simple simple =
+    let command_name =
+      Masc_exec.Exec_program.to_string simple.Masc_exec.Shell_ir.bin
+      |> Filename.basename
     in
-    collect [] simple.Masc_exec.Shell_ir.args
+    match Exec_policy.simple_literal_args simple with
+    | None -> []
+    | Some args -> Exec_policy.path_argument_values command_name args
   in
-  let rec literal_path_args = function
+  let rec path_args = function
     | Masc_exec.Shell_ir.Simple simple ->
-      Option.value ~default:[] (literal_args_of_simple simple)
+      path_args_of_simple simple
     | Masc_exec.Shell_ir.Pipeline stages ->
-      List.concat_map literal_path_args stages
+      List.concat_map path_args stages
   in
-  let validate_seen seen raw =
+  let validate_target seen raw =
     let trimmed = String.trim raw in
-    if trimmed = "" || String.starts_with ~prefix:"-" trimmed then Ok seen
+    if trimmed = "" then Ok seen
     else
       let target =
         if Filename.is_relative trimmed then Filename.concat cwd trimmed else trimmed
       in
-      match repo_root_of_cwd ~config ~meta target with
+      match repo_path_context ~config ~meta target with
       | None -> Ok seen
-      | Some (repo_name, repo_root, accepted_toplevels) ->
-        let key = normalize_repo_cwd_path repo_root in
+      | Some (_repo_name, repo_root, path_root, _accepted_toplevels) ->
+        let key = normalize_repo_cwd_path path_root in
         if List.mem key seen then Ok seen
-        else if not (safe_is_dir repo_root) then
-          Error
-            (repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel:None)
-        else
-          let top =
-            Keeper_repo_readiness.run_git
-              ~timeout_sec:Keeper_repo_readiness.read_only_probe_timeout_sec
-              ~clone_path:repo_root
-              [ "rev-parse"; "--show-toplevel" ]
-          in
-          let top_opt = if top.ok then Some top.output else None in
-          let top_matches =
-            top.ok
-            && List.exists
-                 (fun expected ->
-                    String.equal
-                      (normalize_repo_cwd_path top.output)
-                      (normalize_repo_cwd_path expected))
-                 accepted_toplevels
-          in
-          if top_matches then Ok (key :: seen)
-          else
-            Error
-              (repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel:top_opt)
+        else (
+          match
+            validate_repo_path_ready
+              ~config
+              ~meta
+              ~probe_path:path_root
+              target
+          with
+          | Ok () -> Ok (key :: seen)
+          | Error _ as err -> err)
   in
-  literal_path_args ir
+  let validate_seen (expect_separated_path, seen) raw =
+    let trimmed = String.trim raw in
+    if expect_separated_path
+    then Result.map (fun seen -> false, seen) (validate_target seen trimmed)
+    else (
+      match Exec_policy_path_arg_descriptor.path_value_of_flagged_token trimmed with
+      | Some path -> Result.map (fun seen -> false, seen) (validate_target seen path)
+      | None when Exec_policy_path_arg_descriptor.is_path_flag trimmed ->
+        Ok (true, seen)
+      | None -> Result.map (fun seen -> false, seen) (validate_target seen trimmed))
+  in
+  path_args ir
   |> List.fold_left
        (fun acc raw ->
           match acc with
           | Error _ as err -> err
           | Ok seen -> validate_seen seen raw)
-       (Ok [])
-  |> Result.map ignore
+       (Ok (false, []))
+  |> Result.map (fun _ -> ())
 
 let resolve_tool_write_cwd
       ~(config : Coord.config)

--- a/lib/keeper/agent_tool_execute_path.ml
+++ b/lib/keeper/agent_tool_execute_path.ml
@@ -23,6 +23,148 @@ let resolve_tool_read_cwd
     in
     Error (Printf.sprintf "cwd_not_directory: %s (%s)" cwd detail)
 
+let normalize_repo_cwd_path path =
+  Keeper_alerting_path.normalize_path_for_check path
+  |> Keeper_alerting_path.strip_trailing_slashes
+
+let repo_root_of_cwd ~(config : Coord.config) ~(meta : keeper_meta) cwd =
+  let playground =
+    keeper_playground_root ~config ~meta
+    |> normalize_repo_cwd_path
+  in
+  let repos_root = Filename.concat playground "repos" |> normalize_repo_cwd_path in
+  let cwd = normalize_repo_cwd_path cwd in
+  if String.equal cwd repos_root then None
+  else
+    let prefix = repos_root ^ "/" in
+    if not (String.starts_with ~prefix cwd) then None
+    else
+      let suffix =
+        String.sub cwd (String.length prefix) (String.length cwd - String.length prefix)
+      in
+      match String.split_on_char '/' suffix with
+      | repo_name :: ".worktrees" :: task_name :: _
+        when Keeper_repo_readiness.safe_repo_component repo_name
+             && Keeper_repo_readiness.safe_repo_component task_name ->
+        let repo_root = Filename.concat repos_root repo_name in
+        let worktree_root =
+          Filename.concat (Filename.concat repo_root ".worktrees") task_name
+        in
+        Some (repo_name, repo_root, [ repo_root; worktree_root ])
+      | repo_name :: _ when Keeper_repo_readiness.safe_repo_component repo_name ->
+        let repo_root = Filename.concat repos_root repo_name in
+        Some (repo_name, repo_root, [ repo_root ])
+      | _ -> None
+
+let repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel =
+  Printf.sprintf
+    "sandbox_repo_not_ready: sandbox path is under repos/%s, but %s is not an \
+     independent git checkout (git_toplevel=%s). Repair or reclone the sandbox \
+     repo under repos/%s, then retry with cwd=\"repos/%s\" or \
+     cwd=\"repos/%s/.worktrees/<task>\"."
+    repo_name
+    repo_root
+    (Option.value ~default:"<none>" git_toplevel)
+    repo_name
+    repo_name
+    repo_name
+
+let validate_repo_cwd_ready ~(config : Coord.config) ~(meta : keeper_meta) cwd =
+  match repo_root_of_cwd ~config ~meta cwd with
+  | None -> Ok ()
+  | Some (repo_name, repo_root, accepted_toplevels) ->
+    let probe_path = cwd in
+    if not (safe_is_dir repo_root) then
+      Error
+        (repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel:None)
+    else
+      let top =
+        Keeper_repo_readiness.run_git
+          ~timeout_sec:Keeper_repo_readiness.read_only_probe_timeout_sec
+          ~clone_path:probe_path
+          [ "rev-parse"; "--show-toplevel" ]
+      in
+      let top_opt = if top.ok then Some top.output else None in
+      let top_matches =
+        top.ok
+        && List.exists
+             (fun expected ->
+                String.equal
+                  (normalize_repo_cwd_path top.output)
+                  (normalize_repo_cwd_path expected))
+             accepted_toplevels
+      in
+      if top_matches then Ok ()
+      else
+        Error
+          (repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel:top_opt)
+
+let validate_repo_path_args_ready
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~(cwd : string)
+      (ir : Masc_exec.Shell_ir.t)
+  =
+  let literal_args_of_simple simple =
+    let rec collect acc = function
+      | [] -> Some (List.rev acc)
+      | Masc_exec.Shell_ir.Lit (arg, _) :: rest -> collect (arg :: acc) rest
+      | Masc_exec.Shell_ir.Concat _ :: _ | Masc_exec.Shell_ir.Var _ :: _ -> None
+    in
+    collect [] simple.Masc_exec.Shell_ir.args
+  in
+  let rec literal_path_args = function
+    | Masc_exec.Shell_ir.Simple simple ->
+      Option.value ~default:[] (literal_args_of_simple simple)
+    | Masc_exec.Shell_ir.Pipeline stages ->
+      List.concat_map literal_path_args stages
+  in
+  let validate_seen seen raw =
+    let trimmed = String.trim raw in
+    if trimmed = "" || String.starts_with ~prefix:"-" trimmed then Ok seen
+    else
+      let target =
+        if Filename.is_relative trimmed then Filename.concat cwd trimmed else trimmed
+      in
+      match repo_root_of_cwd ~config ~meta target with
+      | None -> Ok seen
+      | Some (repo_name, repo_root, accepted_toplevels) ->
+        let key = normalize_repo_cwd_path repo_root in
+        if List.mem key seen then Ok seen
+        else if not (safe_is_dir repo_root) then
+          Error
+            (repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel:None)
+        else
+          let top =
+            Keeper_repo_readiness.run_git
+              ~timeout_sec:Keeper_repo_readiness.read_only_probe_timeout_sec
+              ~clone_path:repo_root
+              [ "rev-parse"; "--show-toplevel" ]
+          in
+          let top_opt = if top.ok then Some top.output else None in
+          let top_matches =
+            top.ok
+            && List.exists
+                 (fun expected ->
+                    String.equal
+                      (normalize_repo_cwd_path top.output)
+                      (normalize_repo_cwd_path expected))
+                 accepted_toplevels
+          in
+          if top_matches then Ok (key :: seen)
+          else
+            Error
+              (repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel:top_opt)
+  in
+  literal_path_args ir
+  |> List.fold_left
+       (fun acc raw ->
+          match acc with
+          | Error _ as err -> err
+          | Ok seen -> validate_seen seen raw)
+       (Ok [])
+  |> Result.map ignore
+
 let resolve_tool_write_cwd
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -36,7 +178,10 @@ let resolve_tool_write_cwd
   in
   match resolved with
   | Error _ as err -> err
-  | Ok cwd when Fs_compat.file_exists cwd && Sys.is_directory cwd -> Ok cwd
+  | Ok cwd when Fs_compat.file_exists cwd && Sys.is_directory cwd ->
+    (match validate_repo_cwd_ready ~config ~meta cwd with
+     | Ok () -> Ok cwd
+     | Error _ as err -> err)
   | Ok cwd -> Error (Printf.sprintf "cwd_not_directory: %s" cwd)
 
 (* Docker playground path mapping: host → container.

--- a/lib/keeper/agent_tool_execute_path.mli
+++ b/lib/keeper/agent_tool_execute_path.mli
@@ -12,6 +12,17 @@ val resolve_tool_write_cwd :
   args:Yojson.Safe.t ->
   (string, string) result
 
+val validate_repo_path_args_ready :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  Masc_exec.Shell_ir.t ->
+  (unit, string) result
+(** Reject typed Execute path arguments that point into a sandbox [repos/<repo>]
+    directory unless that repo is an independent git checkout. This catches
+    commands run from the playground root with arguments like
+    [./repos/masc-mcp/lib/foo.ml]. *)
+
 val auto_correct_path :
   meta:Keeper_types.keeper_meta -> string -> string option
 (** Auto-correct common LLM-hallucinated path prefixes

--- a/lib/keeper/agent_tool_execute_runtime.ml
+++ b/lib/keeper/agent_tool_execute_runtime.ml
@@ -213,7 +213,11 @@ let handle_tool_execute_typed
           let dispatch_result =
             Agent_tool_execute_shell_ir.dispatch_classified
               ~before_path_validation:(fun ir ->
-                Ok ())
+                Agent_tool_execute_path.validate_repo_path_args_ready
+                  ~config
+                  ~meta
+                  ~cwd
+                  ir)
               ~allowed_commands
               ~keeper_id:meta.name
               ~base_path:root

--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -33,6 +33,12 @@ let safe_is_dir path =
   try Sys.file_exists path && Sys.is_directory path with
   | Sys_error _ -> false
 
+let normalize_path path =
+  Keeper_alerting_path.normalize_path_for_check path
+  |> Keeper_alerting_path.strip_trailing_slashes
+
+let same_path a b = String.equal (normalize_path a) (normalize_path b)
+
 let safe_repo_component s =
   s <> "" && s <> "." && s <> ".."
   && not (String.contains s '/')
@@ -143,7 +149,14 @@ let inspect
     let inside =
       run_git ~timeout_sec:read_only_probe_timeout_sec ~clone_path [ "rev-parse"; "--is-inside-work-tree" ]
     in
-    if not inside.ok then
+    let top =
+      if inside.ok then
+        run_git ~timeout_sec:read_only_probe_timeout_sec ~clone_path
+          [ "rev-parse"; "--show-toplevel" ]
+      else { inside with ok = false; output = "" }
+    in
+    if (not inside.ok) || (not top.ok) || not (same_path clone_path top.output)
+    then
       common_fields "not_git_repo" false
         "This sandbox repo directory is not a git clone; reclone it under repos/."
         [
@@ -151,6 +164,7 @@ let inspect
           "is_git_repo", `Bool false;
           "has_origin", `Bool false;
           "git_error", `String inside.output;
+          "git_toplevel", (if top.ok then `String top.output else `Null);
         ]
     else
       let status =

--- a/test/test_agent_tool_execute_safety.ml
+++ b/test/test_agent_tool_execute_safety.ml
@@ -419,6 +419,107 @@ let test_tool_execute_rejects_parent_git_repo_path_arg () =
       (String_util.contains_substring err "No such file or directory")
   | None -> Alcotest.fail ("expected error json, got: " ^ raw)
 
+let test_tool_execute_rg_pattern_under_repos_is_not_repo_path () =
+  with_eio_fs @@ fun () ->
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  let config = Coord.default_config base in
+  let meta = make_local_meta "sangsu" in
+  let playground = Filename.concat base (playground_path_of meta.name) in
+  let repo_dir = Filename.concat playground "repos/masc-mcp" in
+  ensure_dir repo_dir;
+  ignore
+    (Fs_compat.save_file_atomic
+       (Filename.concat playground "note.txt")
+       "literal repos/masc-mcp mention\n");
+  let raw =
+    Agent_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "rg"
+           ; "argv", `List [ `String "repos/masc-mcp"; `String "." ]
+           ; "cwd", `String playground
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "rg pattern succeeds" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check bool) "pattern was not treated as stale repo path" false
+    (raw |> String_util.contains_substring "sandbox_repo_not_ready")
+
+let test_tool_execute_rejects_inline_git_work_tree_path_arg () =
+  with_eio_fs @@ fun () ->
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  run_process_ok ~cwd:base "git" [ "init"; "-q"; "--initial-branch=main" ];
+  let config = Coord.default_config base in
+  let meta = make_local_meta "sangsu" in
+  let playground = Filename.concat base (playground_path_of meta.name) in
+  ensure_dir (Filename.concat playground "repos/masc-mcp");
+  let raw =
+    Agent_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "git"
+           ; "argv", `List [ `String "--work-tree=./repos/masc-mcp"; `String "status" ]
+           ; "cwd", `String playground
+           ])
+      ()
+  in
+  match parse_error_field raw with
+  | Some err ->
+    Alcotest.(check bool) "sandbox_repo_not_ready"
+      true
+      (String_util.contains_substring err "sandbox_repo_not_ready")
+  | None -> Alcotest.fail ("expected error json, got: " ^ raw)
+
+let test_tool_execute_rejects_stale_worktree_path_arg () =
+  with_eio_fs @@ fun () ->
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  let config = Coord.default_config base in
+  let meta = make_local_meta "sangsu" in
+  let playground = Filename.concat base (playground_path_of meta.name) in
+  let repo_dir = Filename.concat playground "repos/masc-mcp" in
+  ensure_dir repo_dir;
+  run_process_ok ~cwd:repo_dir "git" [ "init"; "-q"; "--initial-branch=main" ];
+  ensure_dir (Filename.concat repo_dir ".worktrees/task");
+  let raw =
+    Agent_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "cat"
+           ; "argv", `List [ `String "./repos/masc-mcp/.worktrees/task/.missing.ml" ]
+           ; "cwd", `String playground
+           ])
+      ()
+  in
+  match parse_error_field raw with
+  | Some err ->
+    Alcotest.(check bool) "sandbox_repo_not_ready"
+      true
+      (String_util.contains_substring err "sandbox_repo_not_ready");
+    Alcotest.(check bool) "stale worktree root is surfaced"
+      true
+      (String_util.contains_substring err ".worktrees/task")
+  | None -> Alcotest.fail ("expected error json, got: " ^ raw)
+
 let test_tool_execute_elapsed_duration_preserves_positive_sub_ms () =
   let elapsed = Agent_tool_command_runtime.For_testing.elapsed_duration_ms in
   Alcotest.(check int) "sub-ms positive duration rounds up to 1" 1
@@ -1203,6 +1304,18 @@ let () =
             "repo path arg rejects parent git checkout"
             `Quick
             test_tool_execute_rejects_parent_git_repo_path_arg
+        ; Alcotest.test_case
+            "rg pattern under repos is not a repo path"
+            `Quick
+            test_tool_execute_rg_pattern_under_repos_is_not_repo_path
+        ; Alcotest.test_case
+            "inline git work-tree path rejects parent git checkout"
+            `Quick
+            test_tool_execute_rejects_inline_git_work_tree_path_arg
+        ; Alcotest.test_case
+            "stale worktree path arg rejects parent clone"
+            `Quick
+            test_tool_execute_rejects_stale_worktree_path_arg
         ] )
     ; ( "edge"
       , [ Alcotest.test_case

--- a/test/test_agent_tool_execute_safety.ml
+++ b/test/test_agent_tool_execute_safety.ml
@@ -293,15 +293,131 @@ let make_docker_meta name =
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_docker_meta failed: " ^ err)
 
+let make_local_meta name =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String ("agent-" ^ name));
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "sandbox test");
+        ("sandbox_profile", `String "local");
+        ("network_mode", `String "inherit");
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("make_local_meta failed: " ^ err)
+
 let with_eio_fs f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   f ()
 
+let read_file path =
+  In_channel.with_open_bin path In_channel.input_all
+
+let run_process ~cwd prog argv =
+  let out = Filename.temp_file "tool-execute-safety-out" ".txt" in
+  let err = Filename.temp_file "tool-execute-safety-err" ".txt" in
+  let out_fd = Unix.openfile out [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600 in
+  let err_fd = Unix.openfile err [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600 in
+  let original_cwd = Sys.getcwd () in
+  let pid =
+    Fun.protect
+      ~finally:(fun () ->
+        Sys.chdir original_cwd;
+        Unix.close out_fd;
+        Unix.close err_fd)
+      (fun () ->
+        Sys.chdir cwd;
+        Unix.create_process prog (Array.of_list (prog :: argv)) Unix.stdin out_fd
+          err_fd)
+  in
+  let _, status = Unix.waitpid [] pid in
+  let stdout = read_file out in
+  let stderr = read_file err in
+  Sys.remove out;
+  Sys.remove err;
+  (status, stdout, stderr)
+
+let run_process_ok ~cwd prog argv =
+  match run_process ~cwd prog argv with
+  | Unix.WEXITED 0, _, _ -> ()
+  | status, stdout, stderr ->
+    Alcotest.failf "command failed: %s status=%s stdout=%s stderr=%s" prog
+      (Masc_mcp.Keeper_sandbox_exec_failure.status_label status)
+      stdout stderr
+
 let parse_error_field raw =
   Yojson.Safe.from_string raw
   |> Json.member "error"
   |> Json.to_string_option
+
+let test_tool_execute_rejects_parent_git_repo_cwd () =
+  with_eio_fs @@ fun () ->
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  run_process_ok ~cwd:base "git" [ "init"; "-q"; "--initial-branch=main" ];
+  let config = Coord.default_config base in
+  let meta = make_local_meta "sangsu" in
+  let repo_dir =
+    Filename.concat base ".masc/playground/sangsu/repos/masc-mcp"
+  in
+  ensure_dir repo_dir;
+  let args =
+    `Assoc
+      [ "cwd", `String "repos/masc-mcp"
+      ; "executable", `String "cat"
+      ; "argv", `List [ `String "lib/foo.ml" ]
+      ]
+  in
+  match
+    Masc_mcp.Agent_tool_execute_path.resolve_tool_write_cwd ~config ~meta ~args
+  with
+  | Ok cwd -> Alcotest.failf "expected repo cwd rejection, got %s" cwd
+  | Error err ->
+    Alcotest.(check bool) "sandbox_repo_not_ready"
+      true
+      (String_util.contains_substring err "sandbox_repo_not_ready");
+    Alcotest.(check bool) "parent git top-level is surfaced"
+      true
+      (String_util.contains_substring err base)
+
+let test_tool_execute_rejects_parent_git_repo_path_arg () =
+  with_eio_fs @@ fun () ->
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  run_process_ok ~cwd:base "git" [ "init"; "-q"; "--initial-branch=main" ];
+  let config = Coord.default_config base in
+  let meta = make_local_meta "sangsu" in
+  let playground = Filename.concat base (playground_path_of meta.name) in
+  let repo_dir = Filename.concat playground "repos/masc-mcp" in
+  ensure_dir repo_dir;
+  let raw =
+    Agent_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "cat"
+           ; "argv", `List [ `String "./repos/masc-mcp/.missing.ml" ]
+           ; "cwd", `String playground
+           ])
+      ()
+  in
+  match parse_error_field raw with
+  | Some err ->
+    Alcotest.(check bool) "sandbox_repo_not_ready"
+      true
+      (String_util.contains_substring err "sandbox_repo_not_ready");
+    Alcotest.(check bool) "cat did not reach runtime missing-file error"
+      false
+      (String_util.contains_substring err "No such file or directory")
+  | None -> Alcotest.fail ("expected error json, got: " ^ raw)
 
 let test_tool_execute_elapsed_duration_preserves_positive_sub_ms () =
   let elapsed = Agent_tool_command_runtime.For_testing.elapsed_duration_ms in
@@ -1079,6 +1195,14 @@ let () =
             "path traversal blocked after canonicalization"
             `Quick
             test_playground_guard_traversal
+        ; Alcotest.test_case
+            "repo cwd rejects parent git checkout"
+            `Quick
+            test_tool_execute_rejects_parent_git_repo_cwd
+        ; Alcotest.test_case
+            "repo path arg rejects parent git checkout"
+            `Quick
+            test_tool_execute_rejects_parent_git_repo_path_arg
         ] )
     ; ( "edge"
       , [ Alcotest.test_case

--- a/test/test_keeper_repo_readiness.ml
+++ b/test/test_keeper_repo_readiness.ml
@@ -49,6 +49,10 @@ let json_bool key json =
 let json_string key json =
   Yojson.Safe.Util.(json |> member key |> to_string)
 
+let normalize_path path =
+  Masc_mcp.Keeper_alerting_path.normalize_path_for_check path
+  |> Masc_mcp.Keeper_alerting_path.strip_trailing_slashes
+
 let test_missing_clone () =
   let base_path = temp_dir "masc-repo-readiness" in
   let config = Masc_mcp.Coord.default_config base_path in
@@ -131,6 +135,27 @@ let run_process_ok ~cwd prog argv =
 
 let git_ok ~cwd args =
   run_process_ok ~cwd "git" (Array.of_list ("git" :: args))
+
+let test_parent_git_checkout_does_not_count_as_clone () =
+  let base_path = temp_dir "masc-repo-readiness" in
+  git_ok ~cwd:base_path [ "init"; "-q"; "--initial-branch=main" ];
+  let config = Masc_mcp.Coord.default_config base_path in
+  let meta = make_meta "keeper-one" in
+  let clone_path =
+    Masc_mcp.Keeper_repo_readiness.clone_path ~config
+      ~meta ~repo_name:"masc-mcp"
+  in
+  mkdir_p clone_path;
+  let json =
+    Masc_mcp.Keeper_repo_readiness.inspect ~config
+      ~meta ~repo:"jeong-sik/masc-mcp" ()
+  in
+  check bool "not ok" false (json_bool "ok" json);
+  check string "state" "not_git_repo" (json_string "state" json);
+  check bool "exists" true (json_bool "exists" json);
+  check bool "is_git_repo" false (json_bool "is_git_repo" json);
+  check string "parent top-level surfaced" (normalize_path base_path)
+    Yojson.Safe.Util.(json |> member "git_toplevel" |> to_string |> normalize_path)
 
 let create_file_storm ~base_path ~count =
   for i = 0 to count - 1 do
@@ -323,6 +348,8 @@ let () =
       [
         test_case "missing clone" `Quick test_missing_clone;
         test_case "non-git clone" `Quick test_non_git_clone;
+        test_case "parent git checkout is not clone" `Quick
+          test_parent_git_checkout_does_not_count_as_clone;
         test_case "invalid repo_name" `Quick test_invalid_repo_name;
         test_case "missing clone skips workspace discovery" `Quick
           test_missing_clone_skips_workspace_discovery;


### PR DESCRIPTION
## Summary

- Tighten keeper repo readiness so a sandbox `repos/<repo>` directory only counts as ready when `git rev-parse --show-toplevel` resolves to that repo root.
- Add Execute preflight checks for both `cwd="repos/<repo>"` and path arguments like `./repos/masc-mcp/...` before Shell IR dispatch reaches `cat`, `rg`, or `git` at runtime.
- Add regression coverage for parent-repo walk-up false positives and the sampled Execute path-argument failure mode.

## Root Cause

Some live playground paths such as `.masc/playground/<keeper>/repos/masc-mcp` can exist as stale directories without being independent Git checkouts. The previous readiness check accepted them because `git rev-parse --is-inside-work-tree` walked upward into the parent `/Users/dancer/me` checkout. Execute then treated the sandbox repo lane as usable and only failed later with runtime errors like `cat: ./repos/masc-mcp/...: No such file or directory`.

## Impact

This changes the failure mode from ambiguous runtime `cat`/`rg`/`git` errors to deterministic `sandbox_repo_not_ready` guidance. It does not mutate or reclone active live playground directories; it prevents MASC from misclassifying corrupted repo lanes and gives the operator/model a direct repair signal.

## Validation

- `git diff --check`
- `ocamlformat --check lib/keeper/agent_tool_execute_path.ml lib/keeper/agent_tool_execute_path.mli lib/keeper/agent_tool_execute_runtime.ml lib/keeper/keeper_repo_readiness.ml test/test_agent_tool_execute_safety.ml test/test_keeper_repo_readiness.ml`
- `scripts/dune-local.sh build test/test_keeper_repo_readiness.exe` built once before the final test expectation tweak; direct binary run exposed a macOS `/var` vs `/private/var` expectation issue, then the test was updated to normalize both sides.

Blocked follow-up validation:

- `scripts/dune-local.sh build test/test_keeper_repo_readiness.exe`
- `scripts/dune-local.sh build test/test_agent_tool_execute_safety.exe`

Both were retried, but the repo wrapper refused to start while another session had a bare `dune build --root . @check` running outside `scripts/dune-local.sh`.