### PR TITLE
Hide StatusDot internal helpers

### DIFF
--- a/dashboard/src/components/common/status-dot.test.ts
+++ b/dashboard/src/components/common/status-dot.test.ts
@@ -2,96 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
-import {
-  StatusDot,
-  normalizeStatusDotAriaLabel,
-  summarizeStatusDot,
-  statusDotClasses,
-  statusDotSizeClass,
-} from './status-dot'
-
-describe('statusDotSizeClass (pure)', () => {
-  it('default size is sm (8px — baseline row marker)', () => {
-    expect(statusDotSizeClass()).toBe('w-2 h-2')
-  })
-
-  it('produces the expected Tailwind pair for each named variant', () => {
-    expect(statusDotSizeClass('xs')).toBe('w-1.5 h-1.5')
-    expect(statusDotSizeClass('sm')).toBe('w-2 h-2')
-    expect(statusDotSizeClass('md')).toBe('w-2.5 h-2.5')
-    expect(statusDotSizeClass('lg')).toBe('w-3 h-3')
-  })
-})
-
-describe('statusDotClasses (pure)', () => {
-  it('always includes the invariant base (rounded-full + shrink-0 + inline-block)', () => {
-    const cls = statusDotClasses()
-    expect(cls).toContain('rounded-full')
-    expect(cls).toContain('shrink-0')
-    expect(cls).toContain('inline-block')
-  })
-
-  it('tone class is appended after size (caller controls color)', () => {
-    const cls = statusDotClasses('sm', 'bg-[var(--ok-10)]')
-    expect(cls).toContain('w-2 h-2')
-    expect(cls).toContain('bg-[var(--ok-10)]')
-  })
-
-  it('empty / undefined tone does not leave trailing whitespace', () => {
-    expect(statusDotClasses('sm', '')).not.toMatch(/\s$/)
-    expect(statusDotClasses('sm', undefined)).not.toMatch(/\s$/)
-  })
-
-  it('extra class appended after tone (margin, ring, etc.)', () => {
-    const cls = statusDotClasses('sm', 'bg-[var(--bad-10)]', 'ml-1')
-    expect(cls).toContain('bg-[var(--bad-10)]')
-    expect(cls).toContain('ml-1')
-    expect(cls.indexOf('bg-[var(--bad-10)]')).toBeLessThan(cls.indexOf('ml-1'))
-  })
-})
-
-describe('normalizeStatusDotAriaLabel (pure)', () => {
-  it('trims usable labels and drops empty labels', () => {
-    expect(normalizeStatusDotAriaLabel(' running ')).toBe('running')
-    expect(normalizeStatusDotAriaLabel('')).toBeUndefined()
-    expect(normalizeStatusDotAriaLabel('   ')).toBeUndefined()
-    expect(normalizeStatusDotAriaLabel()).toBeUndefined()
-  })
-})
-
-describe('summarizeStatusDot (pure)', () => {
-  it('summarizes the decorative default without reading the DOM', () => {
-    expect(summarizeStatusDot({})).toEqual({
-      size: 'sm',
-      mode: 'decorative',
-      hasCustomClass: false,
-      hasAriaLabel: false,
-      classNameLength: 0,
-    })
-  })
-
-  it('summarizes semantic dots with tone metadata', () => {
-    const tone = 'bg-[var(--ok-10)] ring-1'
-    expect(summarizeStatusDot({ size: 'md', class: tone, ariaLabel: 'healthy' })).toEqual({
-      size: 'md',
-      mode: 'semantic',
-      hasCustomClass: true,
-      hasAriaLabel: true,
-      classNameLength: tone.length,
-    })
-  })
-
-  it('keeps empty aria labels decorative to avoid nameless role=img dots', () => {
-    expect(summarizeStatusDot({ ariaLabel: '' })).toMatchObject({
-      mode: 'decorative',
-      hasAriaLabel: false,
-    })
-    expect(summarizeStatusDot({ ariaLabel: '   ' })).toMatchObject({
-      mode: 'decorative',
-      hasAriaLabel: false,
-    })
-  })
-})
+import { StatusDot } from './status-dot'
 
 describe('StatusDot component', () => {
   let container: HTMLElement
@@ -108,6 +19,10 @@ describe('StatusDot component', () => {
     render(html`<${StatusDot} />`, container)
     const el = container.querySelector('[data-status-dot]') as HTMLElement
     expect(el.tagName).toBe('SPAN')
+    expect(el.className).toContain('inline-block')
+    expect(el.className).toContain('rounded-full')
+    expect(el.className).toContain('shrink-0')
+    expect(el.className).toContain('w-2 h-2')
     expect(el.getAttribute('data-status-dot-size')).toBe('sm')
     expect(el.getAttribute('data-status-dot-mode')).toBe('decorative')
     expect(el.getAttribute('data-status-dot-has-custom-class')).toBe('false')
@@ -116,7 +31,7 @@ describe('StatusDot component', () => {
   })
 
   it('tone class (passed via `class`) ends up on the span', () => {
-    const tone = 'bg-[var(--ok-10)]'
+    const tone = 'bg-[var(--ok-10)] ml-1'
     render(html`<${StatusDot} class=${tone} />`, container)
     const el = container.querySelector('[data-status-dot]')!
     expect(el.className).toContain(tone)
@@ -136,7 +51,7 @@ describe('StatusDot component', () => {
 
   it('ariaLabel promotes to semantic mode: role=img, no aria-hidden', () => {
     render(
-      html`<${StatusDot} ariaLabel="running" class="bg-[var(--ok-10)]" />`,
+      html`<${StatusDot} ariaLabel=" running " class="bg-[var(--ok-10)]" />`,
       container,
     )
     const el = container.querySelector('[data-status-dot]')!
@@ -158,10 +73,17 @@ describe('StatusDot component', () => {
   })
 
   it('each size variant renders distinct Tailwind tokens', () => {
-    for (const size of ['xs', 'sm', 'md', 'lg'] as const) {
+    const sizeClasses = {
+      xs: 'w-1.5 h-1.5',
+      sm: 'w-2 h-2',
+      md: 'w-2.5 h-2.5',
+      lg: 'w-3 h-3',
+    } as const
+    for (const [size, cls] of Object.entries(sizeClasses)) {
       render(html`<${StatusDot} size=${size} />`, container)
       const el = container.querySelector('[data-status-dot]') as HTMLElement
       expect(el.getAttribute('data-status-dot-size')).toBe(size)
+      expect(el.className).toContain(cls)
       render(null, container)
     }
   })

--- a/dashboard/src/components/common/status-dot.ts
+++ b/dashboard/src/components/common/status-dot.ts
@@ -22,9 +22,9 @@
 import { html } from 'htm/preact'
 
 export type StatusDotSize = 'xs' | 'sm' | 'md' | 'lg'
-export type StatusDotMode = 'decorative' | 'semantic'
+type StatusDotMode = 'decorative' | 'semantic'
 
-export interface StatusDotSummary {
+interface StatusDotSummary {
   readonly size: StatusDotSize
   readonly mode: StatusDotMode
   readonly hasCustomClass: boolean
@@ -32,10 +32,7 @@ export interface StatusDotSummary {
   readonly classNameLength: number
 }
 
-/** Pure: Tailwind size tokens for each named variant. Exposed so
-    a caller that wraps its own <span> (legacy code in a hot render
-    path avoiding an extra component) stays pixel-identical. */
-export function statusDotSizeClass(size: StatusDotSize = 'sm'): string {
+function statusDotSizeClass(size: StatusDotSize = 'sm'): string {
   switch (size) {
     case 'xs': return 'w-1.5 h-1.5'  // 6px — inline legend dots
     case 'sm': return 'w-2 h-2'      // 8px — default row marker
@@ -46,9 +43,7 @@ export function statusDotSizeClass(size: StatusDotSize = 'sm'): string {
 
 const BASE = 'inline-block rounded-full shrink-0'
 
-/** Pure: full class string for a dot. Exposed so callers can pre-build
-    the string in a loop without mounting N components. */
-export function statusDotClasses(
+function statusDotClasses(
   size: StatusDotSize = 'sm',
   toneClass?: string,
   extra?: string,
@@ -59,12 +54,12 @@ export function statusDotClasses(
   return parts.join(' ')
 }
 
-export function normalizeStatusDotAriaLabel(ariaLabel?: string): string | undefined {
+function normalizeStatusDotAriaLabel(ariaLabel?: string): string | undefined {
   const normalized = ariaLabel?.trim()
   return normalized === '' ? undefined : normalized
 }
 
-export function summarizeStatusDot({
+function summarizeStatusDot({
   size = 'sm',
   class: classProp,
   ariaLabel,


### PR DESCRIPTION
## Summary
- Remove StatusDot helper exports that had no external callers.
- Delete the stale legacy-hot-render-path exposure comment.
- Keep component behavior covered through DOM assertions instead of helper imports.

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/common/status-dot.test.ts src/components/common/status-dot.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/common/status-dot.ts src/components/common/status-dot.test.ts src/components/common/status-dot.a11y.test.ts
- git diff --check origin/main