### PR TITLE
Remove legacy focus ring mode

### DIFF
--- a/dashboard/src/components/common/ring.test.ts
+++ b/dashboard/src/components/common/ring.test.ts
@@ -115,12 +115,6 @@ describe('ringFocusClasses (pure)', () => {
     expect(cls).toContain('focus-visible:ring-offset-bg-1')
   })
 
-  it('visible=false uses bare focus: prefix (legacy mouse+keyboard)', () => {
-    const cls = ringFocusClasses({ visible: false })
-    expect(cls).toBe('focus:outline-none focus:ring-1 focus:ring-accent-fg')
-    expect(cls).not.toContain('focus-visible:')
-  })
-
   it('inset=true emits ring-inset and suppresses offset', () => {
     const cls = ringFocusClasses({ width: 2, tone: 'accent-fg', inset: true })
     expect(cls).toContain('focus-visible:ring-inset')

--- a/dashboard/src/components/common/ring.ts
+++ b/dashboard/src/components/common/ring.ts
@@ -111,10 +111,6 @@ export interface RingFocusOpts {
    *  whenever `offset > 0`, otherwise the offset would render as the
    *  wrong color. Default `page`. */
   offsetSurface?: RingOffsetSurface
-  /** Focus ring uses the `focus-visible:` Tailwind variant by default
-   *  (keyboard-only). Set `false` to use bare `focus:` (mouse + keyboard
-   *  — rare, but matches a few legacy callsites). */
-  visible?: boolean
   /** Render the ring inside the element instead of outside (`ring-inset`).
    *  Used when the element has no padding/margin headroom for an external
    *  ring (e.g. swimlane segments in fsm-hub-timeline-panels). Mutually
@@ -137,8 +133,7 @@ export function ringFocusClasses(opts: RingFocusOpts = {}): string {
   const tone = opts.tone ?? 'accent'
   const width = opts.width ?? 1
   const offset = opts.offset ?? 0
-  const visible = opts.visible !== false
-  const prefix = visible ? 'focus-visible:' : 'focus:'
+  const prefix = 'focus-visible:'
 
   const parts: string[] = [
     `${prefix}outline-none`,

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -33,7 +33,6 @@ export function normalizeMemorySubsystemsFocus(focus?: string): MemorySubsystems
 
 function memoryFocusTargetClasses(focused: boolean): string {
   const base = ringFocusClasses({
-    visible: false,
     tone: 'accent-medium',
     width: 2,
     offset: 2,


### PR DESCRIPTION
## Summary
- Remove ringFocusClasses visible=false support so focus rings consistently use focus-visible.
- Move the memory subsystem focus target to the default focus-visible path.
- Delete the legacy bare-focus test case.

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/common/ring.test.ts src/components/memory-subsystems.test.ts --no-file-parallelism --maxWorkers=1
- pnpm vitest run --config vitest.config.ts src/components/memory-subsystems.focus.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/common/ring.ts src/components/common/ring.test.ts src/components/memory-subsystems.ts
- git diff --check origin/main