### PR TITLE
refactor(keeper-memory): typed match replaces 3 Option.get sites + dead None-guard

### DIFF
--- a/lib/keeper/agent_tool_memory_runtime.ml
+++ b/lib/keeper/agent_tool_memory_runtime.ml
@@ -127,32 +127,32 @@ let search_memory_bank
                ~detail:
                  "memory bank row is missing required kind, text, source, or trace_id";
              None)
-           else if expected_horizon = None || horizon = None
-           then (
-             report_memory_bank_read_drop
-               ~path
-               ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
-               ~detail:"memory bank row has unknown kind or missing horizon";
-             None)
-           else if not (String.equal (Option.get expected_horizon) (Option.get horizon))
-           then (
-             report_memory_bank_read_drop
-               ~path
-               ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
-               ~detail:"memory bank row kind/horizon mismatch";
-             None)
-           else
-             Some
-               { kind
-               ; horizon = Option.get horizon
-               ; source = Some source
-               ; text
-               ; priority
-               ; generation
-               ; turn
-               ; ts
-               ; score = ts_unix
-               }
+           else (
+             match expected_horizon, horizon with
+             | None, _ | _, None ->
+               report_memory_bank_read_drop
+                 ~path
+                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                 ~detail:"memory bank row has unknown kind or missing horizon";
+               None
+             | Some eh, Some h when not (String.equal eh h) ->
+               report_memory_bank_read_drop
+                 ~path
+                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                 ~detail:"memory bank row kind/horizon mismatch";
+               None
+             | Some _, Some h ->
+               Some
+                 { kind
+                 ; horizon = h
+                 ; source = Some source
+                 ; text
+                 ; priority
+                 ; generation
+                 ; turn
+                 ; ts
+                 ; score = ts_unix
+                 })
          with
          | Yojson.Safe.Util.Type_error (detail, _) ->
            report_memory_bank_read_drop


### PR DESCRIPTION
## 요약

Partial function 안티패턴 (`Option.get`) 제거 — `lib/keeper/agent_tool_memory_runtime.ml` 의 memory bank row parser 4-step `if/else if` ladder 를 단일 `match (expected_horizon, horizon)` 로 lift.

### 문제

```ocaml
(* before — 4-step ladder *)
if schema_version <> ... then None
else if kind = "" || text = "" || ... then None
else if expected_horizon = None || horizon = None
then (
  report_memory_bank_read_drop ~detail:"... missing horizon";
  None)
else if not (String.equal (Option.get expected_horizon) (Option.get horizon))
then (
  report_memory_bank_read_drop ~detail:"... kind/horizon mismatch";
  None)
else
  Some { kind; horizon = Option.get horizon; ... }
```

`else if expected_horizon = None || horizon = None` 가드가 *후속* `Option.get expected_horizon` / `Option.get horizon` (137) + `Option.get horizon` (147) 의 `Some` invariant 를 *암묵 보장*. 컴파일러가 invariant 강제 못 함 → 가드 분기와 `Option.get` 사이트가 *독립적으로* drift 위험.

### 해결

```ocaml
(* after — typed match *)
else (
  match expected_horizon, horizon with
  | None, _ | _, None ->
    report_memory_bank_read_drop ~detail:"... missing horizon";
    None
  | Some eh, Some h when not (String.equal eh h) ->
    report_memory_bank_read_drop ~detail:"... kind/horizon mismatch";
    None
  | Some _, Some h ->
    Some { kind; horizon = h; ... })
```

- 3 `Option.get` 사이트 제거 (130, 137, 147)
- `else if None || None` guard 가 `| None, _ | _, None` 패턴에 흡수
- `Some eh, Some h when ...` 가 동등성 가드를 *typed* 로 표현
- exhaustive `match` — 컴파일러가 모든 branch 강제

### 동작 변경 없음

4 가지 case 모두 같은 site 의 같은 reason/detail 로 `report_memory_bank_read_drop` 호출 후 `None` 반환. success branch 의 record 도 동일.

## 변경

- 1 file (`lib/keeper/agent_tool_memory_runtime.ml`), +26/-26
- 3 `Option.get` 사이트 → 0
- `dune build lib/` PASS

## Workaround Signature Gate

WORKAROUND-WAIVED: Partial function 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 한 함수 안 3 사이트 *모두* 동시 처리

## Related

- 남은 `Option.get` 사이트: `lib/server/server_ide_lsp_proxy.ml:596` — `route_admission` typed variant 확장 필요 (별도 PR, 더 큰 scope)
- sw-dev: "Parse, don't validate" — partial function 회피
- CLAUDE.md `사고는 명시적` — `Some` invariant 를 type 으로 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)
