### PR TITLE
refactor(dashboard/tool-executor): route copy buttons through copyToClipboard helper instead of raw navigator.clipboard

### DIFF
--- a/dashboard/src/components/tool-executor/tool-result-display.ts
+++ b/dashboard/src/components/tool-executor/tool-result-display.ts
@@ -3,6 +3,7 @@ import { useSignal } from '@preact/signals'
 import { formatTimeAgo } from '../../lib/format-time'
 import { CountBadge } from '../common/badge'
 import { ActionButton } from '../common/button'
+import { copyToClipboard } from '../common/copyable-code'
 import { JsonViewer } from '../common/json-viewer'
 import { parseToolBlobMarker, type ToolBlobMarker } from '../../lib/tool-blob-marker'
 import { fetchToolBlob } from '../../api/tool-blob'
@@ -80,7 +81,7 @@ function StoredBlobView({
               접기 (${marker.bytes.toLocaleString()}B)
             <//>
             <${ActionButton} variant="subtle" size="sm"
-              onClick=${() => void navigator.clipboard.writeText(fullText.value ?? '')}>복사<//>
+              onClick=${() => void copyToClipboard(fullText.value ?? '')}>복사<//>
           </div>
           <div class="px-3 py-2 overflow-x-auto max-h-100 overflow-y-auto">
             ${(() => {
@@ -158,7 +159,7 @@ export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolRe
             onClick=${() => { expanded.value = !expanded.value }}>
             ${expanded.value ? '접기' : '펼치기'} (${lines}줄)
           <//>
-          <${ActionButton} variant="subtle" size="sm" onClick=${() => void navigator.clipboard.writeText(text)}>복사<//>
+          <${ActionButton} variant="subtle" size="sm" onClick=${() => void copyToClipboard(text)}>복사<//>
         </div>
         ${expanded.value ? html`
           <div class="px-3 py-2 overflow-x-auto max-h-100 overflow-y-auto">


### PR DESCRIPTION
## 요약
`tool-result-display.ts` 의 2 copy button 이 raw `navigator.clipboard.writeText` 직접 호출 → 공식 `copyToClipboard` helper migration. *공식 SSOT 우회* 패턴 + *silent copy-failure bug* 동시 fix.

## 배경

`components/common/copyable-code.ts:64-87` 가 *공식 clipboard helper*:

```ts
export async function copyToClipboard(text: string): Promise<boolean> {
  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
    try {
      await navigator.clipboard.writeText(text)
      return true
    } catch {
      // fall through to execCommand fallback
    }
  }
  if (typeof document === 'undefined') return false
  const ta = document.createElement('textarea')
  // ... hidden textarea + document.execCommand('copy') fallback
}
```

3 layer 처리:
1. **`navigator.clipboard.writeText`** — modern API
2. **`document.execCommand('copy')` fallback** — HTTP+non-localhost, cross-origin iframe, non-secure context
3. **SSR safe** (`typeof document === 'undefined'` check)

그러나 `components/tool-executor/tool-result-display.ts:84/162` 2 copy button 이 *raw `navigator.clipboard.writeText` 직접 호출* → fallback 무시 → **Clipboard API gated 환경에서 silent copy 실패**.

iter#33/34 (ActionButton/TextInput) 우회 패턴과 동일 shape. 본 케이스는 *시그니처 호환* — `copyToClipboard(text)` 가 `navigator.clipboard.writeText(text)` 와 동일 signature + fallback 추가. **직접 migration 가능** (iter#44 formatIssues 패턴).

## 변경

### `tool-result-display.ts`
- `import { copyToClipboard } from '../common/copyable-code'` 추가
- 2 callsite:
  - `void navigator.clipboard.writeText(fullText.value ?? '')` → `void copyToClipboard(fullText.value ?? '')`
  - `void navigator.clipboard.writeText(text)` → `void copyToClipboard(text)`

`void` discard semantics 그대로 (`Promise<boolean>` 반환 무시) — 기존 동작과 호환.

## 검증
- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)

## iter chain — SSOT 우회 + silent bug fix
- iter#33/34: ActionButton/TextInput SSOT 우회 — token mismatch design call 로 callsite migration 분리
- iter#41: hex sentinel drift — canonical 정렬로 silent visual mismatch fix
- iter#44: formatIssues SSOT 우회 — 시그니처 호환 직접 migration
- iter#50: parsePositiveLineString — sibling 사이 silent boundary check drift fix
- iter#52: **copyToClipboard SSOT 우회 — fallback path 자동 적용으로 silent copy-failure bug fix**

같은 *공식 SSOT 우회* 안티패턴이 *함수 시그니처 호환* 시 *user-facing silent bug fix* 와 동시 SSOT 화 자연.

## /loop iter#52
SSOT 위반 dashboard 축출 loop 의 iter#52. cumulative 52 PR (34 머지 + 2 OPEN — #19122 + #19?_).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
