### PR TITLE
refactor(keeper-invariant): typed match replaces List.tl + 'when acc <> []' guard

### DIFF
--- a/lib/keeper_invariant/keeper_invariant.ml
+++ b/lib/keeper_invariant/keeper_invariant.ml
@@ -13,7 +13,13 @@ type tool_name = string
 let normalize_path path =
   let rec collapse acc = function
     | [] -> List.rev acc
-    | ".." :: rest when acc <> [] -> collapse (List.tl acc) rest
+    | ".." :: rest ->
+      (* Preserve fall-through behaviour: when acc is empty (we are at
+         the path root), [".."] is treated as a literal segment and
+         pushed onto acc.  When acc has at least one element, pop it. *)
+      (match acc with
+       | [] -> collapse (".." :: acc) rest
+       | _ :: tl -> collapse tl rest)
     | "." :: rest -> collapse acc rest
     | "" :: rest -> collapse acc rest
     | segment :: rest -> collapse (segment :: acc) rest


### PR DESCRIPTION
## 요약

Partial function 안티패턴 — `List.tl` + `when acc <> []` guard 의 typed lift. `lib/keeper_invariant/keeper_invariant.ml` `normalize_path` 의 path-collapse 루프.

### 문제

```ocaml
(* before *)
let rec collapse acc = function
  | [] -> List.rev acc
  | ".." :: rest when acc <> [] -> collapse (List.tl acc) rest
  | "." :: rest -> collapse acc rest
  | "" :: rest -> collapse acc rest
  | segment :: rest -> collapse (segment :: acc) rest
```

`when acc <> []` 가드와 `List.tl acc` partial function 이 *별도* 표현 — 컴파일러가 두 표현의 invariant 일치 강제 못 함. `acc = []` 케이스는 fall-through → 마지막 `segment :: rest` 매치 → `".."` 가 segment 로 push (root-relative `..` 보존).

### 해결

```ocaml
(* after *)
let rec collapse acc = function
  | [] -> List.rev acc
  | ".." :: rest ->
    (* Preserve fall-through behaviour: when acc is empty (we are at
       the path root), [".."] is treated as a literal segment and
       pushed onto acc.  When acc has at least one element, pop it. *)
    (match acc with
     | [] -> collapse (".." :: acc) rest
     | _ :: tl -> collapse tl rest)
  | "." :: rest -> collapse acc rest
  | "" :: rest -> collapse acc rest
  | segment :: rest -> collapse (segment :: acc) rest
```

- `List.tl acc` 제거 — `_ :: tl` 패턴이 `tl` 을 바인딩
- `when acc <> []` 가드 제거 — 패턴이 직접 분기
- `acc = []` 케이스를 **명시적으로 표현** — root-relative `..` 가 segment push 되는 동작이 `collapse (".." :: acc) rest` 로 코드에 드러남 (이전엔 fall-through 라 *읽지 않으면 안 보임*)

### 동작 무변경

`test_keeper_invariant.exe` 16/16 tests PASS — `path_traversal_rejected` (root-relative `..` 경로 검증) 포함.

## 변경

- 1 file (`lib/keeper_invariant/keeper_invariant.ml`), +7/-1
- 1 `List.tl` 사이트 제거
- `dune build lib/` PASS
- 16/16 tests PASS

## Out-of-scope

남은 `List.hd` / `List.tl` 사이트 4개 — 각각 invariant 분석이 다르므로 별도 PR 후보:

- `board_comment_rate_limit.ml:33` (`List.length >= limit` 가드 + `List.sort`)
- `cascade_declarative_parser.ml:319` (`Error errs` non-empty 암묵 invariant)
- `cdal_runtime/autonomy_exec.ml:236` (호출자 non-empty 보장)
- `keeper/keeper_status_bridge.ml:232` (`Option.value ~default:(List.hd lines)`)

## Workaround Signature Gate

WORKAROUND-WAIVED: Partial function 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 단일 site 정리 (다른 4 사이트 별도 분석/PR 명시)

## Related

- PR #19127 — `Option.get` 안티패턴 sweep (3 sites typed match)
- sw-dev: "Parse, don't validate" — partial function 회피
- CLAUDE.md `사고는 명시적` — invariant 를 type 으로 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)
