### PR TITLE
Remove unused status label aliases

### DIFF
--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -1,7 +1,6 @@
 // Ops helpers — shared view helpers built on top of the canonical ops state.
 
 import { showToast } from '../common/toast'
-import { prettyJson, displayStatus } from '../../lib/status-label'
 import type { OperatorKeeperSnapshot } from '../../types'
 import { dispatchOperatorAction } from '../../operator-store'
 import { workflowActionLabel, type DashboardWorkflowContext } from '../../workflow-context'
@@ -30,8 +29,6 @@ export {
   hydratedWorkflowId,
   persistActorName,
 }
-
-export { prettyJson, displayStatus }
 
 function canonicalizeActionType(value?: string | null): string | null {
   if (!value) return null

--- a/dashboard/src/lib/status-label.test.ts
+++ b/dashboard/src/lib/status-label.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { statusLabel, displayStatus, prettyJson } from './status-label'
+import { statusLabel } from './status-label'
 
 describe('statusLabel', () => {
   it('maps ok variants', () => {
@@ -44,31 +44,6 @@ describe('statusLabel', () => {
   it('trims whitespace', () => { expect(statusLabel('  ok  ')).toBe('안정') })
 })
 
-describe('displayStatus', () => {
-  // displayStatus now delegates to statusLabel — same key, same label.
-  // The prior `failed → '문제'` divergence is intentionally removed; both
-  // call sites get `'오류'` so operators see one consistent surface.
-  it('maps core statuses (delegates to statusLabel)', () => {
-    expect(displayStatus('active')).toBe('진행 중')
-    expect(displayStatus('paused')).toBe('일시정지')
-    expect(displayStatus('done')).toBe('완료')
-    expect(displayStatus('failed')).toBe('오류') // was '문제' — unified
-    expect(displayStatus('stopped')).toBe('중단됨')
-    expect(displayStatus('offline')).toBe('오프라인')
-    expect(displayStatus('idle')).toBe('대기')
-  })
-  it('maps unbooted', () => { expect(displayStatus('unbooted')).toBe('미기동') })
-  it('returns 확인 필요 for empty/null', () => {
-    expect(displayStatus('')).toBe('확인 필요')
-    expect(displayStatus(null)).toBe('확인 필요')
-  })
-  it('passes through unrecognized', () => { expect(displayStatus('deploying')).toBe('deploying') })
-  it('is case-insensitive', () => {
-    expect(displayStatus('ACTIVE')).toBe('진행 중')
-    expect(displayStatus('Paused')).toBe('일시정지')
-  })
-})
-
 describe('statusLabel collision fixes (Iter#36)', () => {
   // Before this PR three pairs of distinct English keys collapsed onto the
   // same Korean label, making the dashboard label ambiguous.
@@ -84,19 +59,4 @@ describe('statusLabel collision fixes (Iter#36)', () => {
   it('in_progress aliases active/running', () => {
     expect(statusLabel('in_progress')).toBe('진행 중')
   })
-})
-
-describe('prettyJson', () => {
-  it('returns empty for null/undefined', () => {
-    expect(prettyJson(null)).toBe('')
-    expect(prettyJson(undefined)).toBe('')
-  })
-  it('passes through strings', () => { expect(prettyJson('hello')).toBe('hello') })
-  it('formats objects', () => {
-    const r = prettyJson({ a: 1 })
-    expect(r).toContain('"a"')
-    expect(r).toContain('1')
-  })
-  it('formats arrays', () => { expect(prettyJson([1, 2])).toBe('[\n  1,\n  2\n]') })
-  it('formats numbers', () => { expect(prettyJson(42)).toBe('42') })
 })

--- a/dashboard/src/lib/status-label.ts
+++ b/dashboard/src/lib/status-label.ts
@@ -1,5 +1,5 @@
 // Unified status display utilities.
-// Consolidates statusLabel, displayStatus, prettyJson from
+// Consolidates statusLabel from
 // mission-utils, agents, agent-roster, status-badge, helpers, ops/helpers.
 //
 // SSOT principle: one English-key → one Korean label. Sister keys that share
@@ -103,27 +103,5 @@ export function statusLabel(value?: string | null): string {
       return '확인 필요'
     default:
       return value?.trim() || '확인 필요'
-  }
-}
-
-/**
- * Short display status — thin alias for {@link statusLabel} kept for
- * backwards-compat with existing call sites. Previously this duplicated the
- * dispatch table with `error → '문제'` while statusLabel returned `'오류'`,
- * a silent divergence operators could only spot by reading both code paths.
- * Delegating removes that divergence: same key, same label, everywhere.
- */
-export function displayStatus(status?: string | null): string {
-  return statusLabel(status)
-}
-
-/** Format unknown values as pretty JSON or pass-through strings. */
-export function prettyJson(value: unknown): string {
-  if (value === null || value === undefined) return ''
-  if (typeof value === 'string') return value
-  try {
-    return JSON.stringify(value, null, 2)
-  } catch {
-    return String(value)
   }
 }


### PR DESCRIPTION
## Summary
- Remove unused displayStatus and prettyJson exports from the status-label module.
- Remove the ops/helpers re-export shim for those unused utilities.
- Keep statusLabel as the single status-label SSOT.

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/lib/status-label.test.ts src/components/ops/helpers.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/lib/status-label.ts src/lib/status-label.test.ts src/components/ops/helpers.ts src/components/ops/helpers.test.ts (src/lib files are ignored by current eslint config; ops helper files passed)
- git diff --check origin/main