### PR TITLE
refactor(board-rate-limit): typed match replaces List.hd in check, exhaustive guard for non-empty invariant

### DIFF
--- a/lib/board_comment_rate_limit.ml
+++ b/lib/board_comment_rate_limit.ml
@@ -29,10 +29,16 @@ let check ~author ~now =
       let recent = List.filter (fun t -> now -. t < window) !ts_ref in
       ts_ref := recent;
       if List.length recent >= limit
-      then
-        let oldest = List.hd (List.sort Stdlib.compare recent) in
-        let retry_after = window -. (now -. oldest) +. 1.0 in
-        Some retry_after
+      then (
+        (* [limit > 0] (line 23) plus [List.length recent >= limit]
+           guarantee the sorted list is non-empty; the [[]] branch is
+           unreachable but typed exhaustively so the compiler enforces
+           the invariant. *)
+        match List.sort Stdlib.compare recent with
+        | [] -> None
+        | oldest :: _ ->
+          let retry_after = window -. (now -. oldest) +. 1.0 in
+          Some retry_after)
       else None
 ;;
 


### PR DESCRIPTION
## 요약

Partial function 안티패턴 — `List.hd` + runtime guard typed lift. `lib/board_comment_rate_limit.ml` `check`.

### 문제

```ocaml
(* before *)
if List.length recent >= limit
then
  let oldest = List.hd (List.sort Stdlib.compare recent) in
  let retry_after = window -. (now -. oldest) +. 1.0 in
  Some retry_after
else None
```

`List.length recent >= limit` 가드 + 위 `if limit <= 0 then None` early-return 가 *암묵 invariant* 로 `recent` non-empty 보장. 그러나 `List.hd` partial call 이 *그 invariant 를 type 으로 노출 안 함* — 컴파일러 강제 X. 가드 분기와 `List.hd` 사이트가 *별도 표현* 이라 drift 위험.

### 해결

```ocaml
(* after *)
if List.length recent >= limit
then (
  (* [limit > 0] (line 23) plus [List.length recent >= limit]
     guarantee the sorted list is non-empty; the [[]] branch is
     unreachable but typed exhaustively so the compiler enforces
     the invariant. *)
  match List.sort Stdlib.compare recent with
  | [] -> None
  | oldest :: _ ->
    let retry_after = window -. (now -. oldest) +. 1.0 in
    Some retry_after)
else None
```

- `List.hd` 제거 — `oldest :: _` 패턴이 head 직접 바인딩
- `[]` branch 가 *exhaustive match 강제* — compiler enforced
- 인라인 주석이 invariant 출처 (line 23 + line 31 가드) 명시 → reader 가 line 23 까지 거슬러 올라가지 않아도 됨

### 동작 무변경

- `List.sort` 결과 비어있을 수 없음 (`recent` 가 비어있지 않으므로) — `oldest :: _` 가 항상 매치
- `[]` branch 의 `None` 은 unreachable 이지만 compiler 강제 위해 명시

## 변경

- 1 file, +9/-3
- 1 `List.hd` 사이트 제거
- `dune build lib/` PASS
- No test caller (`board_comment_rate_limit` 가 `test/` 에 안 잡힘) — type-check 가 검증 surface

## Out-of-scope

남은 `List.hd` / `List.tl` 사이트:

- `cascade_declarative_parser.ml:319` (`Error errs` non-empty 암묵 invariant — Error 컨트랙트 변경 필요)
- `cdal_runtime/autonomy_exec.ml:236` (호출자 non-empty 보장, 함수 시작점)
- `keeper/keeper_status_bridge.ml:232` (`if lines = []` guard 가 *큰 else block* 감싸 — lift refactor 가 더 크게 변경)

각각 별도 PR. keeper_status_bridge 는 `if lines = []` 자체를 `match lines with | [] -> None | first :: _ -> ...` 로 lift 하면 외부 scope 의 `first` 가 line 232 의 `List.hd lines` 를 교체 — diff 가 큰 refactor.

## Workaround Signature Gate

WORKAROUND-WAIVED: Partial function 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 단일 site (3 사이트 별도 분석 명시)

## Related

- PR #19127 (MERGED) — `Option.get` 안티패턴 sweep
- PR #19130 (MERGED) — `List.tl` + `when` guard 안티패턴
- sw-dev: "Parse, don't validate"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
