### PR TITLE
refactor(dashboard): centralise escapeRegExp helper, drop two byte-identical file-internal copies

### DIFF
--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -12,6 +12,7 @@ import {
 } from './keeper-line-ownership-store'
 import type { UnifiedDiffRow } from '../../api/workspace'
 import type { IdeAnnotation } from '../../api/schemas/ide-annotations'
+import { escapeRegExp } from '../../lib/format-string'
 import {
   readOnlyExt,
   themeExt,
@@ -810,9 +811,6 @@ export function currentFileFindMatches(
   return matches
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
 
 // ── CM6 read-only editor ──────────────────────────────────────────
 // Preact ref-based mount — no vDOM conflict with CM6's DOM management.

--- a/dashboard/src/lib/format-string.ts
+++ b/dashboard/src/lib/format-string.ts
@@ -57,3 +57,20 @@ export function firstNonEmptyString(
   }
   return null
 }
+
+/**
+ * Escape a string for safe interpolation into a `new RegExp(...)` source.
+ *
+ * Replaces the standard ECMAScript regex meta-characters with their
+ * backslash-escaped form so the input is matched literally. Use whenever
+ * a user-supplied or interpolated string ends up inside a `RegExp` —
+ * e.g. building a needle pattern, asserting a CSS token literal in a
+ * test, etc.
+ *
+ * Two file-internal copies (`components/ide/ide-editor.ts` needle
+ * highlighting, `styles/cockpit-token-cascade.test.ts` CSS literal
+ * assertions) shipped this exact body before centralising here.
+ */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/dashboard/src/styles/cockpit-token-cascade.test.ts
+++ b/dashboard/src/styles/cockpit-token-cascade.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { escapeRegExp } from '../lib/format-string'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const generatedCss = readFileSync(join(here, 'tokens.generated.css'), 'utf8')
@@ -21,10 +22,6 @@ function expectDeclarationExists(css: string, name: string) {
 
 function expectNoDeclaration(css: string, name: string, value: string) {
   expect(css).not.toMatch(new RegExp(`${name}:\\s*${escapeRegExp(value)}\\s*;`))
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 describe('Cockpit token cascade', () => {


### PR DESCRIPTION
## 요약
`escapeRegExp` 함수의 byte-identical file-internal 정의 2 copies 를 `lib/format-string.ts` SSOT export 로 통합.

## 배경
`rg "^function escapeRegExp" -A 3` sweep 결과 2 file 에 *byte-identical* 정의 발견:

| 파일 | line | scope |
|---|---|---|
| `components/ide/ide-editor.ts:813` | needle-highlight regex builder | file-internal |
| `styles/cockpit-token-cascade.test.ts:26` | CSS literal-assertion helper | file-internal |

```ts
function escapeRegExp(value: string): string {
  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
}
```

iter#19 R 패턴의 *file-scope 동음이의어* 가 아닌 *진짜 SSOT 위반* — 같은 이름 + 같은 시그니처 + 같은 본문 + 같은 의도. saturation 50+ iter 진입 후에도 surgical 후보 발견.

## 변경

### `lib/format-string.ts`
- `export function escapeRegExp(value: string): string` 추가
- JSDoc 으로 ECMAScript regex meta-character 집합 + 2 consumer 명시

### 2 callsite migration
- `components/ide/ide-editor.ts`: file-internal 함수 제거 + `import { escapeRegExp } from '../../lib/format-string'`
- `styles/cockpit-token-cascade.test.ts`: file-internal 함수 제거 + `import { escapeRegExp } from '../lib/format-string'`

기존 callsite 사용 그대로 — 런타임 동작 변경 0.

## 검증
- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)

## /loop iter#53
SSOT 위반 dashboard 축출 loop 의 iter#53. cumulative 53 PR (35 머지 + 1 OPEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
