### PR TITLE
Remove fsm hub compatibility reexports

### DIFF
--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -27,11 +27,13 @@ import {
 import type { GateKeepersData } from '../api/gate'
 import { normalizeKeepers } from '../keeper-store-normalize'
 import {
-  deriveStateEntries,
-  deriveSwimlaneSegments,
   isCompositeFetchNotFound,
   shouldUseGateKeeperFallback,
 } from './fsm-hub'
+import {
+  deriveStateEntries,
+  deriveSwimlaneSegments,
+} from './fsm-hub-derivations'
 import type { CompositeObservation } from './fsm-hub-types'
 
 /** Server-shaped keeper composite snapshot matching the projected

--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -4,23 +4,24 @@ import { describe, expect, it } from 'vitest'
 import {
   appendCompositeObservation,
   deriveLaneDwellHistograms,
-  deriveObservedLaneSummaries,
-  deriveOperationalInsight,
   derivePhaseLog,
   deriveStateEntries,
   deriveSwimlaneSegments,
   deriveTimeAxisTicks,
   deriveTopTransitions,
   deriveTransitionHistory,
-  filterKeeperNames,
-  flagTooltip,
   inferTransitionReason,
-  invariantDescription,
-  isTransitionInSegment,
   laneTransitionCount,
+} from './fsm-hub-derivations'
+import {
   type CompositeObservation,
   type HoveredSegment,
-} from './fsm-hub'
+} from './fsm-hub-types'
+import { deriveObservedLaneSummaries } from './fsm-hub-lane-analysis'
+import { deriveOperationalInsight } from './fsm-hub-invariant-analysis'
+import { flagTooltip, invariantDescription } from './fsm-hub-health-panels'
+import { isTransitionInSegment } from './fsm-hub-timeline-panels'
+import { filterKeeperNames } from './fsm-hub'
 
 function observation(
   overrides: Partial<CompositeObservation> = {},

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -42,55 +42,11 @@ import { MeasurementCard, InvariantsPanel } from './fsm-hub-health-panels'
 import { ringFocusClasses } from './common/ring'
 import { formatIndependentCounters, formatRatioPair } from './counter-format'
 
-// ── Backward-compatible re-exports ─────────────────────
-// External consumers (agents-unified.ts, fsm-hub.test.ts)
-// import from './fsm-hub' — these re-exports keep that working.
-
-export type {
-  CompositeObservation,
-  DwellEntry,
-  HoveredSegment,
-  LaneDwell,
-  OperationalInsight,
-  ObservedLaneSummary,
-  StateEntries,
-  TimeAxisTick,
-  SwimlaneSegment,
-  TopTransition,
-} from './fsm-hub-types'
-
-export { displayState } from './fsm-hub-types'
-
 import {
   toolRequirementLabel,
   toolSurfaceClassLabel,
   turnLaneLabel,
 } from './fsm-hub-types'
-
-export {
-  appendCompositeObservation,
-  deriveLaneDwellHistograms,
-  deriveTransitionHistory,
-  deriveTopTransitions,
-  derivePhaseLog,
-  deriveStateEntries,
-  deriveTimeAxisTicks,
-  deriveSwimlaneSegments,
-  laneTransitionCount,
-  inferTransitionReason,
-} from './fsm-hub-derivations'
-
-export { deriveOperationalInsight } from './fsm-hub-invariant-analysis'
-export { deriveObservedLaneSummaries } from './fsm-hub-lane-analysis'
-
-export {
-  flagTooltip,
-  invariantDescription,
-} from './fsm-hub-health-panels'
-
-export {
-  isTransitionInSegment,
-} from './fsm-hub-timeline-panels'
 
 export function shouldUseGateKeeperFallback(
   executionLoadedValue: boolean,


### PR DESCRIPTION
## Summary
- Remove the fsm-hub compatibility re-export block.
- Update fsm-hub tests to import helpers from their owning modules.
- Keep fsm-hub exporting only the component and local helpers it owns.

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/fsm-hub.test.ts src/components/fsm-hub.integration.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/fsm-hub.ts src/components/fsm-hub.test.ts src/components/fsm-hub.integration.test.ts (test files are ignored by current eslint config; fsm-hub.ts passed)
- git diff --check origin/main