### PR TITLE
refactor(cdal-runtime/autonomy_exec): typed match replaces List.hd in spawn_child, fall-through guarded by Result error

### DIFF
--- a/lib/cdal_runtime/autonomy_exec.ml
+++ b/lib/cdal_runtime/autonomy_exec.ml
@@ -233,22 +233,34 @@ let spawn_child ~sw config effective =
     Unix.set_nonblock stdout_r;
     Unix.set_nonblock stderr_r;
     let env = build_env ~config in
-    let exec = List.hd effective in
-    let pid =
-      Unix.create_process_env
-        exec
-        (Array.of_list effective)
-        env
-        stdin_fd
-        stdout_w
-        stderr_w
-    in
-    close_registered stdin_fd_ref;
-    close_registered stdout_w_ref;
-    close_registered stderr_w_ref;
-    stdout_r_ref := None;
-    stderr_r_ref := None;
-    Ok (pid, stdout_r, stderr_r)
+    (* [effective] non-empty is guaranteed by [validate_config] (line 82:
+       empty argv is rejected with [invalid_config "argv" ...]).  The
+       [[]] branch is typed for compiler exhaustiveness so future
+       refactors that bypass [effective_argv] are caught at type-check
+       time instead of crashing in [Unix.create_process_env]. *)
+    match effective with
+    | [] ->
+      cleanup_setup_fds ();
+      Error
+        (invalid_config
+           "effective"
+           "spawn_child reached with empty argv (validate_config bypass)")
+    | exec :: _ ->
+      let pid =
+        Unix.create_process_env
+          exec
+          (Array.of_list effective)
+          env
+          stdin_fd
+          stdout_w
+          stderr_w
+      in
+      close_registered stdin_fd_ref;
+      close_registered stdout_w_ref;
+      close_registered stderr_w_ref;
+      stdout_r_ref := None;
+      stderr_r_ref := None;
+      Ok (pid, stdout_r, stderr_r)
   with
   | Unix.Unix_error (err, fn, arg) ->
     cleanup_setup_fds ();


### PR DESCRIPTION
## 요약

Partial function 안티패턴 — `List.hd effective` typed lift + 호출자 invariant 명시. `lib/cdal_runtime/autonomy_exec.ml` `spawn_child`.

### 문제

```ocaml
(* before *)
let env = build_env ~config in
let exec = List.hd effective in
let pid =
  Unix.create_process_env
    exec
    (Array.of_list effective)
    env ...
in
...
Ok (pid, stdout_r, stderr_r)
```

`effective : string list` 가 *호출자 invariant* 로 non-empty 보장 — `validate_config` (line 82) 가 `argv = []` 를 reject:

```ocaml
| [] -> Error (invalid_config "argv" "command argv must not be empty")
```

그러나 컴파일러는 그 invariant 강제 못 함. `List.hd` partial call 이 *호출자 contract* 와 *spawn_child 시그니처* 사이에 drift 시 crash (`Sys_error`).

### 해결

```ocaml
(* after *)
match effective with
| [] ->
  cleanup_setup_fds ();
  Error
    (invalid_config
       "effective"
       "spawn_child reached with empty argv (validate_config bypass)")
| exec :: _ ->
  let pid =
    Unix.create_process_env
      exec
      (Array.of_list effective)
      env ...
  in
  ...
  Ok (pid, stdout_r, stderr_r)
```

- `List.hd` 제거 — `exec :: _` 가 head 직접 바인딩
- `[]` branch 가 *exhaustive match* + `cleanup_setup_fds()` + `Error` 반환 — typed safety net. 현 caller graph 에서 unreachable 이지만 *향후 refactor 가 `effective_argv` 우회* 시 clean Result error 로 surfaces (crash 대신).
- 인라인 주석이 invariant 출처 (line 82 `validate_config`) 명시.

### 동작 무변경

- `effective_argv` 가 `spawn_child` 의 유일한 caller path. 그 함수의 `Ok (prefix @ cwd_wrapper @ argv)` 가 `argv` 의 non-empty invariant 보존.
- 따라서 현재 `[]` branch 는 unreachable. typed safety net 만 추가.

## 변경

- 1 file, +28/-16
- 1 `List.hd` 사이트 제거
- `dune build lib/` PASS

## Out-of-scope

남은 `List.hd` 사이트 2개:

- `cascade_declarative_parser.ml:319` (`Error errs` non-empty 암묵 invariant — parse_credential 컨트랙트)
- `keeper/keeper_status_bridge.ml:232` (외부 `if lines = []` guard 큰 else block 통째 lift refactor)

각각 별도 PR.

## Workaround Signature Gate

WORKAROUND-WAIVED: Partial function 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 단일 site 처리 (남은 2 사이트 별도 분석)

## Related

- PR #19127 (MERGED) — Option.get 3 sites typed match
- PR #19130 (MERGED) — List.tl + `when` guard typed match
- PR #19133 (OPEN Draft) — board_comment_rate_limit List.hd
- sw-dev: "Parse, don't validate"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
