### PR TITLE
Remove fleet tool coverage alias

### DIFF
--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -571,7 +571,6 @@ describe('summaryCounts', () => {
     const counts = summaryCounts(rows)
     expect(counts.live).toBe(2)
     expect(counts.hot).toBe(1)
-    expect(counts.toolCovered).toBe(1)
     expect(counts.toolTelemetryCovered).toBe(1)
     expect(counts.toolActive).toBe(1)
     expect(counts.toolQuiet).toBe(0)
@@ -584,7 +583,6 @@ describe('summaryCounts', () => {
       makeRow({ name: 'unknown', tool_calls: 0, recent_tools: [], tool_activity_known: false }),
     ])
 
-    expect(counts.toolCovered).toBe(1)
     expect(counts.toolTelemetryCovered).toBe(1)
     expect(counts.toolActive).toBe(0)
     expect(counts.toolQuiet).toBe(1)
@@ -599,15 +597,6 @@ describe('summaryCounts', () => {
     ])
 
     expect(toolTelemetryCoverageDetail(counts, 3)).toBe('도구 telemetry 확인 2/3 · 활동 1 · 기록 없음 1 · 미확인 1')
-  })
-
-  it('counts explicit zero-tool telemetry as covered', () => {
-    const counts = summaryCounts([
-      makeRow({ recent_tools: [], tool_calls: 0, tool_activity_known: true }),
-      makeRow({ recent_tools: [], tool_calls: 0, tool_activity_known: false }),
-    ])
-
-    expect(counts.toolCovered).toBe(1)
   })
 })
 

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -704,7 +704,6 @@ export function toolSummary(row: FleetRow): { label: string; title: string } {
 
 export interface FleetSummaryCounts {
   live: number
-  toolCovered: number
   toolTelemetryCovered: number
   toolActive: number
   toolQuiet: number
@@ -751,8 +750,6 @@ export function summaryCounts(rows: FleetRow[]): FleetSummaryCounts {
   ).length
   return {
     live,
-    // Back-compat alias: coverage means "tool telemetry is known", not active usage.
-    toolCovered: toolTelemetryCovered,
     toolTelemetryCovered,
     toolActive,
     toolQuiet,


### PR DESCRIPTION
## Summary
- Remove FleetSummaryCounts.toolCovered back-compat alias.
- Keep toolTelemetryCovered as the single summary field for known tool telemetry.
- Drop tests that only exercised the alias.

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/fleet-telemetry-utils.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/fleet-telemetry-utils.ts src/components/fleet-telemetry-utils.test.ts (test file is ignored by current eslint config; utils file passed)
- git diff --check origin/main