### PR TITLE
refactor(cascade-decl): typed match replaces List.hd in parse_credential error reporter

### DIFF
--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -313,11 +313,17 @@ let parse_provider (id : string) (tbl : Otoml.t)
         (match parse_credential cred_tbl (path ^ ".credentials") with
          | Ok c -> Some c
          | Error errs ->
-           Logs.warn (fun m ->
-             m
-               "cascade_declarative_parser: %s"
-               (let e = List.hd errs in
-                Printf.sprintf "%s: %s" e.path e.message));
+           (* [parse_credential] always wraps its single failure through
+              the [error] helper (line 18) which builds a 1-element
+              list, so the [[]] branch is unreachable.  Typed for
+              exhaustiveness so a future change to the error-shape
+              contract does not silently lose the diagnostic. *)
+           let detail =
+             match errs with
+             | [] -> "<empty error list>"
+             | e :: _ -> Printf.sprintf "%s: %s" e.path e.message
+           in
+           Logs.warn (fun m -> m "cascade_declarative_parser: %s" detail);
            None)
       | None -> None
     in


### PR DESCRIPTION
## 요약

Partial function 안티패턴 — `List.hd errs` 의 typed lift + `[error]` helper invariant 코드 노출. `lib/cascade_decl/cascade_declarative_parser.ml` `parse_credential` error 보고.

### 문제

```ocaml
(* before *)
| Error errs ->
  Logs.warn (fun m ->
    m
      "cascade_declarative_parser: %s"
      (let e = List.hd errs in
       Printf.sprintf "%s: %s" e.path e.message));
  None)
```

`parse_credential` 의 모든 Error branch (4 곳) 가 helper 함수 통해 errs 생성:

```ocaml
let error path message = [ { path; message } ]      (* line 18 *)
```

→ `errs` 항상 *1-element list*. 그러나 컴파일러는 이 invariant 강제 못 함 — 타입이 `parse_error list`. `List.hd` partial call 이 helper contract 와 *별도 표현* 이라 drift 시 crash.

### 해결

```ocaml
(* after *)
| Error errs ->
  (* [parse_credential] always wraps its single failure through
     the [error] helper (line 18) which builds a 1-element
     list, so the [[]] branch is unreachable.  Typed for
     exhaustiveness so a future change to the error-shape
     contract does not silently lose the diagnostic. *)
  let detail =
    match errs with
    | [] -> "<empty error list>"
    | e :: _ -> Printf.sprintf "%s: %s" e.path e.message
  in
  Logs.warn (fun m -> m "cascade_declarative_parser: %s" detail);
  None)
```

- `List.hd` 제거 — `e :: _` 패턴이 head 직접 바인딩
- `[]` branch 가 *exhaustive match* + `<empty error list>` 센티넬 — unreachable but compiler-enforced
- 인라인 주석이 invariant 출처 (`error` helper line 18) 명시
- `let detail = ...` 추출 — `Logs.warn` lambda 가 format 계산 인라인 안 함, 가독성 향상

### 동작 무변경

- `parse_credential` 의 4 Error arm 모두 `error path message` 호출 → `errs` 항상 1 element
- 따라서 `[]` branch unreachable. `e :: _` branch 가 항상 매치, 기존 `Printf.sprintf` 와 동일 출력

## 변경

- 1 file, +12/-4 (approx)
- 1 `List.hd` 사이트 제거
- `dune build lib/` PASS

## Out-of-scope

남은 `List.hd` 사이트 1개:

- `keeper/keeper_status_bridge.ml:232` (외부 `if lines = []` guard 가 *큰 else block* 감싸 — lift refactor 가 더 크게 변경. 별도 PR.)

## Workaround Signature Gate

WORKAROUND-WAIVED: Partial function 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 단일 site 처리 (마지막 1 사이트 별도 분석)

## Related

- PR #19127 (MERGED) — Option.get 3 sites typed match
- PR #19130 (MERGED) — List.tl + `when` guard typed match
- PR #19133 (MERGED) — board_comment_rate_limit List.hd
- PR #19137 (MERGED) — autonomy_exec List.hd typed safety net
- sw-dev: "Parse, don't validate"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
