### PR TITLE
refactor(dashboard): centralise unixishToMs helper across 3 IDE trace bridges

### DIFF
--- a/dashboard/src/components/ide/cascade-hop-trace-bridge.ts
+++ b/dashboard/src/components/ide/cascade-hop-trace-bridge.ts
@@ -1,4 +1,5 @@
 import { pushTrace } from './keeper-trace-store'
+import { unixishToMs } from '../../lib/format-time'
 import {
   normalizeTraceProducerContext,
   type KeeperTraceProducerContextInput,
@@ -57,11 +58,6 @@ export interface CascadeHopProducerInput {
   readonly strategy: string
   readonly cycle: number
   readonly context?: KeeperTraceProducerContextInput | null
-}
-
-function unixishToMs(ts: number): number {
-  if (!Number.isFinite(ts)) return Number.NaN
-  return ts > 1_000_000_000_000 ? ts : ts * 1000
 }
 
 function dedupKey(event: CascadeHopProducerInput): string {

--- a/dashboard/src/components/ide/decision-log-trace-bridge.ts
+++ b/dashboard/src/components/ide/decision-log-trace-bridge.ts
@@ -1,4 +1,5 @@
 import { pushTrace } from './keeper-trace-store'
+import { unixishToMs } from '../../lib/format-time'
 import {
   normalizeTraceProducerContext,
   type KeeperTraceProducerContextInput,
@@ -64,11 +65,6 @@ export interface DecisionLogProducerInput {
   readonly choice?: string | null
   readonly reason?: string | null
   readonly context?: KeeperTraceProducerContextInput | null
-}
-
-function unixishToMs(ts: number | null): number {
-  if (ts === null || !Number.isFinite(ts)) return Number.NaN
-  return ts > 1_000_000_000_000 ? ts : ts * 1000
 }
 
 function dedupKey(decision: DecisionLogProducerInput): string {

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { fetchBoard } from '../../api/board'
 import type { BoardPost } from '../../types/core'
 import { bridgePostsToTrace } from './anchored-thread-trace-bridge'
+import { unixishToMs } from '../../lib/format-time'
 import { bridgeCascadeEventsToTrace } from './cascade-hop-trace-bridge'
 import { bridgeDecisionsToTrace } from './decision-log-trace-bridge'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
@@ -104,11 +105,6 @@ async function fetchCascadeReplayEvents(): Promise<ReadonlyArray<CascadeStrategy
 
 function parseIsoToMs(iso: string): number {
   return new Date(iso).getTime()
-}
-
-function unixishToMs(ts: number | null): number {
-  if (ts === null || !Number.isFinite(ts)) return Number.NaN
-  return ts > 1_000_000_000_000 ? ts : ts * 1000
 }
 
 function boardKindFromPost(post: BoardPost): ThreadKind {

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -198,3 +198,22 @@ export function formatDelta(delta: number, decimals = 4): string {
   const sign = delta >= 0 ? '+' : ''
   return `${sign}${delta.toFixed(decimals)}`
 }
+
+/**
+ * Coerce a Unix timestamp into milliseconds, accepting either seconds or
+ * milliseconds depending on magnitude.
+ *
+ * Backend producers emit timestamps in both units — anchored threads and
+ * activity events use milliseconds, cascade hops and decision logs use
+ * seconds. Any value larger than `1e12` is treated as already-millis;
+ * anything smaller is multiplied by 1000. `null` / `NaN` / non-finite
+ * inputs return `NaN` so callers can branch on `Number.isFinite` once.
+ *
+ * Three IDE trace bridges (`decision-log-trace-bridge`,
+ * `cascade-hop-trace-bridge`, `ide-conversation-rail`) shipped this
+ * exact body file-internal before centralising here.
+ */
+export function unixishToMs(ts: number | null | undefined): number {
+  if (ts === null || ts === undefined || !Number.isFinite(ts)) return Number.NaN
+  return ts > 1_000_000_000_000 ? ts : ts * 1000
+}


### PR DESCRIPTION
## 요약
3 IDE trace bridge 의 file-internal `unixishToMs` 함수 (시그니처 미세 차이 + 본문 동일) 를 `lib/format-time.ts` SSOT export 로 통합.

## 배경

`rg "^function unixishToMs\(" -A 4` sweep 결과 3 file 에 동일 의도 helper 발견:

| 파일 | line | 시그니처 | callsite count |
|---|---|---|---|
| `components/ide/decision-log-trace-bridge.ts:69` | `(ts: number \| null)` | 1 |
| `components/ide/cascade-hop-trace-bridge.ts:62` | `(ts: number)` | 1 |
| `components/ide/ide-conversation-rail.ts:109` | `(ts: number \| null)` | 2 |

본문 동일:
```ts
if (... !Number.isFinite(ts)) return Number.NaN
return ts > 1_000_000_000_000 ? ts : ts * 1000
```

backend timestamp 가 *seconds (cascade hops, decision logs)* + *milliseconds (anchored threads, activity events)* 둘 다 emit. 1e12 boundary 가 magnitude 로 자동 disambiguate. 같은 변환을 3 file 이 file-internal 복사.

## 변경

### `lib/format-time.ts`
- `export function unixishToMs(ts: number | null | undefined): number` 추가 (가장 wide signature, 3 callsite 모두 호환)
- JSDoc: backend dual-emit + boundary 의도 + 3 consumer cross-reference
- NaN 반환 — caller `Number.isFinite` 한 번 사용

### 3 trace bridge migration
- file-internal `function unixishToMs` 삭제
- `import { unixishToMs } from '../../lib/format-time'` 추가

기존 callsite 그대로 — 런타임 동작 변경 0.

## 검증

- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)
- 첫 run 2 fail 관찰 → 재실행 1 fail. **9 번째 flaky pair 등장** (iter#34/35/38/40/42/46/47/48/54 — `use-focus-scope` 재등장). baseline-diff SOP 로 false-positive 회피.

## iter chain — file-internal helper duplicate sweep
- iter#53: `escapeRegExp` (2 copies, byte-identical)
- iter#54: **`unixishToMs` (3 copies, 시그니처 미세 차이 + 본문 동일)**

saturation 후에도 helper duplicate 잔여 — *function name + body pattern* 검색이 새 angle.

## /loop iter#54
SSOT 위반 dashboard 축출 loop 의 iter#54. cumulative 54 PR (35 머지 + 2 OPEN — #19135 + #19?_).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
