### PR TITLE
refactor(keeper-status-bridge): typed match replaces last List.hd, completes List.hd/List.tl sweep

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -226,10 +226,21 @@ let runtime_blocker_surface_of_progress_snapshot
                    ; "실제 막힘"
                    ]
             then
+              (* The outer [if lines = [] then None] guard (line 168)
+                 already returns early on an empty narrative; the
+                 [[]] arm below is unreachable here but typed for
+                 exhaustiveness so a future refactor that drops the
+                 outer guard does not silently fall through to a
+                 Sys_error from [List.hd]. *)
+              let first_line =
+                match lines with
+                | [] -> ""
+                | h :: _ -> h
+              in
               surface
                 "synthetic_stall"
                 (line_with [ Keeper_synthetic_marker.marker_prefix ]
-                 |> Option.value ~default:(List.hd lines))
+                 |> Option.value ~default:first_line)
             else (
               match
                 line_with


### PR DESCRIPTION
## 요약

Partial function 안티패턴 — `List.hd lines` 의 typed lift. `lib/keeper/keeper_status_bridge.ml` synthetic_stall fallback. **List.hd / List.tl 전체 sweep 마지막 사이트**.

### 문제

```ocaml
(* before, line 232 *)
surface
  "synthetic_stall"
  (line_with [ Keeper_synthetic_marker.marker_prefix ]
   |> Option.value ~default:(List.hd lines))
```

외부 line 168 의 `if lines = [] then None else (...)` 가드 가 *암묵 invariant* 로 `lines` non-empty 보장. 그러나 `List.hd` partial call 이 *그 invariant 를 type 으로 노출 안 함* — 외부 if-guard drop 시 crash.

### 해결

```ocaml
(* after *)
(* The outer [if lines = [] then None] guard (line 168)
   already returns early on an empty narrative; the
   [[]] arm below is unreachable here but typed for
   exhaustiveness so a future refactor that drops the
   outer guard does not silently fall through to a
   Sys_error from [List.hd]. *)
let first_line =
  match lines with
  | [] -> ""
  | h :: _ -> h
in
surface
  "synthetic_stall"
  (line_with [ Keeper_synthetic_marker.marker_prefix ]
   |> Option.value ~default:first_line)
```

- `List.hd` 제거 — `h :: _` 패턴이 head 직접 바인딩
- `[]` branch 가 *exhaustive match* + `""` 센티넬 — unreachable but compiler-enforced
- 인라인 주석이 invariant 출처 (line 168 outer guard) 명시
- 미래에 outer guard 가 drop 되면 *crash 대신 benign empty fallback* — silent safety net

### Local helper 만 변경한 이유

진짜 typed lift 는 line 168 `if lines = [] then None` 자체를 `match lines with | [] -> None | first :: _ -> (...)` 로 변환해서 *외부 scope 의 `first`* 가 line 232 fallback 으로 직접 가용. 그러나 else block 이 ~100 lines 라 *전체 indentation churn* 발생 → 별도 큰 PR.

본 PR 은 *minimal surgical* — line 232 사이트만 typed lift. 후속 refactor 가 가능하면 외부 guard 도 lift.

## 변경

- 1 file, +12/-3
- 1 `List.hd` 사이트 제거
- `dune build lib/` PASS

## List.hd / List.tl sweep 완료

본 PR 로 *전 lib/ 의 `List.hd` / `List.tl` 안티패턴* 5 사이트 sweep 완료:

| PR | 사이트 | 패턴 |
|----|--------|------|
| #19130 (MERGED) | `keeper_invariant.ml:16` (List.tl) | `when` guard → `match` |
| #19133 (MERGED) | `board_comment_rate_limit.ml:33` | `length >= limit` guard → `match` |
| #19137 (MERGED) | `autonomy_exec.ml:236` | caller invariant → Result Error |
| #19140 (OPEN) | `cascade_declarative_parser.ml:319` | helper `[error ...]` invariant → exhaustive |
| 본 PR | `keeper_status_bridge.ml:232` | outer if-guard → unreachable sentinel |

## Workaround Signature Gate

WORKAROUND-WAIVED: Partial function 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — sweep 마지막 site (5 사이트 모두 분리 PR 로 완결)

## Related

- PR #19127 (MERGED) — Option.get 3 sites typed match
- PR #19130, #19133, #19137 (MERGED), #19140 (OPEN) — List.hd / List.tl sweep
- sw-dev: "Parse, don't validate" — partial function 회피

🤖 Generated with [Claude Code](https://claude.com/claude-code)
