### PR TITLE
Remove operations connector legacy residue

### DIFF
--- a/dashboard/src/components/operations-panel.test.ts
+++ b/dashboard/src/components/operations-panel.test.ts
@@ -20,9 +20,6 @@ async function loadPanel() {
   vi.doMock('./governance', () => ({
     Governance: () => html`<div data-testid="governance">Governance</div>`,
   }))
-  vi.doMock('./connector-status', () => ({
-    ConnectorStatusPanel: () => html`<div data-testid="connectors">Connectors</div>`,
-  }))
   vi.doMock('./lab-inspector', () => ({
     LabInspector: () => html`<div data-testid="inspector">Inspector</div>`,
   }))
@@ -50,7 +47,6 @@ describe('OperationsPanel', () => {
     vi.doUnmock('../router')
     vi.doUnmock('./ops')
     vi.doUnmock('./governance')
-    vi.doUnmock('./connector-status')
     vi.doUnmock('./lab-inspector')
     vi.doUnmock('./surface-readiness-panel')
   })
@@ -98,7 +94,7 @@ describe('OperationsPanel', () => {
     expect(container.querySelector('[data-testid="surfaces"]')).not.toBeNull()
   })
 
-  it('renders FilterChips options without legacy connectors view', async () => {
+  it('renders FilterChips options for the current operations views', async () => {
     const { OperationsPanel } = await loadPanel()
     render(html`<${OperationsPanel} />`, container)
     await flushUi()
@@ -112,8 +108,6 @@ describe('OperationsPanel', () => {
     expect(labels).toContain('Governance')
     expect(labels).toContain('Surfaces')
     expect(labels).toContain('Inspector')
-    expect(labels).not.toContain('Connectors')
-    expect(labels).not.toContain('Safety')
   })
 
   it('falls back to default for unknown view param', async () => {

--- a/dashboard/src/components/operations-panel.ts
+++ b/dashboard/src/components/operations-panel.ts
@@ -1,7 +1,5 @@
 // MASC Dashboard — Operations Panel (Phase 5+6+7)
-// FilterChips toggle for ops/governance/safety/inspector sub-views.
-// Phase 7: connectors split out as a top-level surface. Legacy
-// command:connectors links are routed before this panel mounts.
+// FilterChips toggle for ops/governance/surfaces/inspector sub-views.
 
 import { html } from 'htm/preact'
 import { FilterChips } from './common/filter-chips'


### PR DESCRIPTION
## Summary
- Remove stale operations-panel comments about the legacy connector route.
- Drop unused connector-status mocks from operations-panel tests.
- Rename the chip-list test to assert the current operations views instead of legacy absence.

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/operations-panel.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/operations-panel.ts src/components/operations-panel.test.ts (test file is ignored by current eslint config; component file passed)
- git diff --check origin/main