### PR TITLE
test: ratchet Keeper tool execution substrate

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -110,6 +110,16 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/no-legacy-tool-surface-name.sh --fail
 
+  no-tool-substrate-adapter-surface:
+    name: Tool substrate adapter surface ratchet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
+      - name: Run lint
+        run: bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail
+
   no-tool-result-error-printexc:
     name: RFC-0148 backsliding guard (no Tool_result.error + Printexc.to_string)
     runs-on: ubuntu-latest

--- a/docs/design/tool-execution-substrate-plan.html
+++ b/docs/design/tool-execution-substrate-plan.html
@@ -629,10 +629,10 @@
             <td><code>git diff --check</code></td>
           </tr>
           <tr>
-            <td><span class="status next">PR-B</span> Executor ratchets</td>
+            <td><span class="status done">PR-B</span> Executor ratchets</td>
             <td>Prevent reintroduction of <code>Gh_cli</code>, <code>Git_cli</code>, <code>Oas_bridge</code>.</td>
-            <td>Descriptor enum/source tests and active-surface micro-tool ratchets.</td>
-            <td><code>scripts/dune-local.sh build test/test_agent_tool_descriptor_registry_integrity.exe test/test_keeper_tool_alias.exe</code></td>
+            <td><code>scripts/lint/no-tool-substrate-adapter-surface.sh</code>, CI wiring, and source-contract tests.</td>
+            <td><code>bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail</code>, focused source-test build, and targeted case <code>test source_guard 28</code>.</td>
           </tr>
           <tr>
             <td><span class="status next">PR-C</span> Prompt alignment</td>
@@ -888,7 +888,7 @@
           </tr>
           <tr>
             <td>Active micro-tool scan</td>
-            <td>No active-surface hits for <code>pr_comment</code>, <code>pr_review</code>, <code>pr_close</code>, <code>gh_pr</code>, <code>gh_commit</code>, or <code>github_comment</code> in descriptor/prompt/policy/matrix surfaces.</td>
+            <td>Enforced by <code>scripts/lint/no-tool-substrate-adapter-surface.sh</code> and source-guard case 28: no active-surface hits for <code>pr_comment</code>, <code>pr_review</code>, <code>pr_close</code>, <code>gh_pr</code>, <code>gh_commit</code>, <code>github_comment</code>, or PR wrapper prefixes in descriptor/prompt/policy/matrix surfaces.</td>
           </tr>
           <tr>
             <td>Known caveat</td>

--- a/docs/design/tool-execution-substrate-plan.md
+++ b/docs/design/tool-execution-substrate-plan.md
@@ -238,6 +238,9 @@ git diff --check
 
 ### PR-B: Descriptor Executor Ratchet
 
+Status: implemented in this PR as a narrow active-surface lint plus CI/source
+guard wiring.
+
 Add tests that fail if descriptor executor variants reintroduce:
 
 - `Gh_cli`
@@ -257,7 +260,9 @@ tool hint surfaces:
 Validation:
 
 ```bash
-scripts/dune-local.sh build test/test_agent_tool_descriptor_registry_integrity.exe test/test_keeper_tool_alias.exe
+bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail
+scripts/dune-local.sh build test/test_ci_hardening_source.exe
+./_build/default/test/test_ci_hardening_source.exe test source_guard 28
 ```
 
 ### PR-C: Prompt and Matrix Alignment

--- a/scripts/lint/no-tool-substrate-adapter-surface.allowlist
+++ b/scripts/lint/no-tool-substrate-adapter-surface.allowlist
@@ -1,0 +1,5 @@
+# no-tool-substrate-adapter-surface allowlist
+#
+# Format: `path:line:class:literal` keys. Empty file = baseline 0 occurrences.
+# Add only when the tool execution substrate genuinely needs a temporary
+# compatibility mention. Each entry should cite the PR that introduced it.

--- a/scripts/lint/no-tool-substrate-adapter-surface.sh
+++ b/scripts/lint/no-tool-substrate-adapter-surface.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Guard the Keeper tool execution substrate against two regressions:
+#
+#   1. Descriptor executor variants that turn gh/git/OAS bridge adapters into
+#      first-class tool concepts. Those belong behind Shell_ir or runtime
+#      plumbing, not in the descriptor executor enum.
+#   2. GitHub/PR micro-tool names returning to active descriptor, prompt,
+#      policy, or capability-matrix surfaces.
+#
+# The scan is intentionally narrow. It does not scan timeout/runtime plumbing
+# such as Timeout_policy.Layer.Oas_bridge, and it does not scan dashboard
+# reporting metrics that use PR review as a work category.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ALLOWLIST="${ROOT}/scripts/lint/no-tool-substrate-adapter-surface.allowlist"
+
+MODE="--fail"
+case "${1:---fail}" in
+  --fail|"") MODE="--fail" ;;
+  --print) MODE="--print" ;;
+  -h|--help)
+    sed -n '2,24p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *)
+    echo "Usage: $0 [--fail|--print]" >&2
+    exit 2
+    ;;
+esac
+
+for tool in rg sed sort mktemp comm wc find; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "[no-tool-substrate-adapter-surface] required tool missing: $tool" >&2
+    exit 2
+  }
+done
+
+cd "$ROOT"
+
+EXECUTOR_SCAN_FILES=(
+  "lib/keeper/agent_tool_descriptor.ml"
+  "lib/keeper/agent_tool_descriptor.mli"
+)
+
+SURFACE_SCAN_FILES=(
+  "lib/keeper/agent_tool_descriptor.ml"
+  "lib/keeper/agent_tool_descriptor.mli"
+  "lib/keeper/keeper_tool_alias.ml"
+  "lib/keeper/keeper_tool_alias.mli"
+  "lib/tool_catalog.ml"
+  "lib/tool_catalog.mli"
+  "lib/tool_catalog_surfaces.ml"
+  "lib/tool_catalog_surfaces.mli"
+  "config/tool_policy.toml"
+  "docs/KEEPER-CAPABILITY-MATRIX.md"
+  "docs/KEEPER-FILE-MODEL.md"
+  "docs/KEEPER-USER-MANUAL.md"
+)
+
+while IFS= read -r prompt_file; do
+  SURFACE_SCAN_FILES+=("$prompt_file")
+done < <(find config/prompts -type f | sort)
+
+EXECUTOR_PATTERN='\b(Gh_cli|Git_cli|Oas_bridge)\b'
+MICRO_TOOL_PATTERN='\b(pr_comment|pr_review|pr_close|gh_pr|gh_commit|github_comment|github_pr|keeper_pr_[A-Za-z0-9_]*|github_pr_[A-Za-z0-9_]*)\b'
+
+current_tmp="$(mktemp -t tool-substrate-adapter-surface.current.XXXXXX)"
+allow_tmp="$(mktemp -t tool-substrate-adapter-surface.allow.XXXXXX)"
+new_tmp="$(mktemp -t tool-substrate-adapter-surface.new.XXXXXX)"
+stale_tmp="$(mktemp -t tool-substrate-adapter-surface.stale.XXXXXX)"
+trap 'rm -f "$current_tmp" "$allow_tmp" "$new_tmp" "$stale_tmp"' EXIT
+
+scan_pattern() {
+  local class="$1"
+  local pattern="$2"
+  shift 2
+
+  for file in "$@"; do
+    [[ -f "$file" ]] || continue
+    while IFS=: read -r path line content; do
+      [[ -n "${path:-}" && -n "${line:-}" ]] || continue
+      while IFS= read -r literal; do
+        [[ -n "$literal" ]] || continue
+        printf '%s:%s:%s:%s\n' "$path" "$line" "$class" "$literal"
+      done < <(printf '%s\n' "$content" | rg -o "$pattern" || true)
+    done < <(rg --with-filename --no-heading --line-number --color=never "$pattern" "$file" || true)
+  done
+}
+
+{
+  scan_pattern "executor_adapter" "$EXECUTOR_PATTERN" "${EXECUTOR_SCAN_FILES[@]}"
+  scan_pattern "micro_tool" "$MICRO_TOOL_PATTERN" "${SURFACE_SCAN_FILES[@]}"
+} | sort -u >"$current_tmp"
+
+if [[ -f "$ALLOWLIST" ]]; then
+  sed -E 's/#.*//; s/[[:space:]]//g; /^$/d' "$ALLOWLIST" | sort -u >"$allow_tmp"
+else
+  : >"$allow_tmp"
+fi
+
+comm -13 "$allow_tmp" "$current_tmp" >"$new_tmp"
+comm -23 "$allow_tmp" "$current_tmp" >"$stale_tmp"
+
+current_count="$(wc -l <"$current_tmp" | tr -d ' ')"
+allow_count="$(wc -l <"$allow_tmp" | tr -d ' ')"
+new_count="$(wc -l <"$new_tmp" | tr -d ' ')"
+stale_count="$(wc -l <"$stale_tmp" | tr -d ' ')"
+
+printf "%-44s %8s\n" "metric" "count"
+echo "----------------------------------------------------"
+printf "%-44s %8s\n" "tool_substrate_forbidden_current" "$current_count"
+printf "%-44s %8s\n" "tool_substrate_allowlist_entries" "$allow_count"
+printf "%-44s %8s\n" "tool_substrate_new_hits" "$new_count"
+printf "%-44s %8s\n" "tool_substrate_stale_allowlist" "$stale_count"
+
+if [[ "$MODE" = "--print" ]]; then
+  echo
+  echo "[no-tool-substrate-adapter-surface] current keys:"
+  sed 's/^/  - /' "$current_tmp"
+  exit 0
+fi
+
+fail=0
+
+if [[ -s "$new_tmp" ]]; then
+  echo
+  echo "[no-tool-substrate-adapter-surface] DRIFT UP: forbidden adapter or micro-tool surface reappeared" >&2
+  sed 's/^/  - /' "$new_tmp" >&2
+  echo "  Keep gh/git work behind Execute/Shell_ir, and model PR work as ordinary CLI/worktree operations." >&2
+  echo "  Do not add dedicated PR/GitHub micro-tools to active descriptor, prompt, policy, or capability surfaces." >&2
+  fail=1
+fi
+
+if [[ -s "$stale_tmp" ]]; then
+  echo
+  echo "[no-tool-substrate-adapter-surface] STALE ALLOWLIST: entries no longer match source" >&2
+  sed 's/^/  - /' "$stale_tmp" >&2
+  echo "  Remove these from $ALLOWLIST in the same PR." >&2
+  fail=1
+fi
+
+exit $fail

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1691,6 +1691,31 @@ let test_public_execute_alias_contracts () =
      && file_not_contains_pattern "lib/keeper/keeper_run_tools.ml"
           "register_structured_routes")
 
+let test_tool_execution_substrate_ratchet_contracts () =
+  check bool "tool substrate ratchet script exists" true
+    (Sys.file_exists
+       (source_path "scripts/lint/no-tool-substrate-adapter-surface.sh"));
+  check bool "tool substrate ratchet is wired to fundamental check" true
+    (file_contains_pattern ".github/workflows/fundamental-check.yml"
+       "scripts/lint/no-tool-substrate-adapter-surface.sh --fail");
+  check bool "descriptor executor keeps adapters out of first-class enum" true
+    (file_not_contains_pattern "lib/keeper/agent_tool_descriptor.ml" "Gh_cli"
+     && file_not_contains_pattern "lib/keeper/agent_tool_descriptor.ml" "Git_cli"
+     && file_not_contains_pattern "lib/keeper/agent_tool_descriptor.ml" "Oas_bridge"
+     && file_not_contains_pattern "lib/keeper/agent_tool_descriptor.mli" "Gh_cli"
+     && file_not_contains_pattern "lib/keeper/agent_tool_descriptor.mli" "Git_cli"
+     && file_not_contains_pattern "lib/keeper/agent_tool_descriptor.mli" "Oas_bridge");
+  check bool "active prompt and policy surfaces avoid GitHub micro-tool ids" true
+    (file_not_contains_pattern "config/tool_policy.toml" "pr_comment"
+     && file_not_contains_pattern "config/tool_policy.toml" "pr_review"
+     && file_not_contains_pattern "config/tool_policy.toml" "gh_commit"
+     && file_not_contains_pattern "config/prompts/keeper.tool_hints.toml" "pr_comment"
+     && file_not_contains_pattern "config/prompts/keeper.tool_hints.toml" "pr_review"
+     && file_not_contains_pattern "config/prompts/keeper.tool_hints.toml" "gh_commit"
+     && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "pr_comment"
+     && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "pr_review"
+     && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "gh_commit")
+
 let test_public_execute_guidance_contracts () =
   let raw_command prefix = "command='" ^ prefix in
   let raw_execute_with_command prefix = "Execute with " ^ raw_command prefix in
@@ -2797,6 +2822,8 @@ let () =
             test_tool_failure_classification_contracts;
           test_case "dedicated GitHub PR tool removal contracts" `Quick
             test_dedicated_forge_pr_tool_contracts_removed;
+          test_case "tool execution substrate ratchet contracts" `Quick
+            test_tool_execution_substrate_ratchet_contracts;
           test_case "public Execute alias contracts" `Quick
             test_public_execute_alias_contracts;
           test_case "public Execute guidance contracts" `Quick


### PR DESCRIPTION
## Summary
- add a narrow lint guard for descriptor executor adapter names and GitHub/PR micro-tool names on active tool surfaces
- wire the guard into Fundamental Check
- add a source-contract test and update the tool execution substrate HTML/Markdown plan to mark PR-B implemented

## Validation
- bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail
- bash scripts/lint/no-legacy-tool-surface-name.sh --fail
- bash -n scripts/lint/no-tool-substrate-adapter-surface.sh
- git diff --check origin/main..HEAD
- python3 HTML parser sanity check for docs/design/tool-execution-substrate-plan.html
- ASCII scan for the new lint/report files
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_ci_hardening_source.exe
- ./_build/default/test/test_ci_hardening_source.exe test source_guard 28

## Notes
- Full test_ci_hardening_source.exe was not used as the acceptance signal because existing unrelated source-guard cases are red in this runtime; the new case 28 passes when targeted.