### PR TITLE
feat(cascade): RFC-0197 Phase B-1 — per-candidate watchdog wrap

### DIFF
--- a/lib/keeper/keeper_turn_driver_try_cascade.ml
+++ b/lib/keeper/keeper_turn_driver_try_cascade.ml
@@ -566,13 +566,87 @@ let rec run
                      "provider attempt scope released before completion; parent \
                       cancellation or outer timeout interrupted the attempt")
                 attempt_latency_ms));
-        match
+        (* RFC-0197 Phase B-1 — per-candidate watchdog wrap.
+
+           Wrap each [try_provider] call in [Eio.Time.with_timeout_exn]
+           when both a clock and a positive per-provider timeout are
+           available, so a single hung provider can no longer hold the
+           whole cascade hostage. On timeout we synthesize the same
+           [Error (Api Timeout)] result tuple that the inner
+           [Cascade_attempt_liveness_config.outer_wall_for_attempt]
+           layer would return when active — the cascade run loop then
+           moves on to the next candidate (RFC-0197 §"Layer 2" describes
+           why the inner layer is None in Enforce mode and why fallback
+           was unreachable).
+
+           Deadline math composition (RFC-0192 §2 invariant —
+           [min(amplifier, deadline - now)]) is deliberately left to a
+           follow-up PR: [try_cascade_ctx] currently carries only
+           [wait_timeout_sec] which is the admission-wait budget, not a
+           turn-level deadline. Threading a real [Cascade_deadline.t]
+           into this ctx is its own surgical change. *)
+        let attempt_call () =
           try_provider ctx
             ?resume_checkpoint
             ?per_provider_timeout_s:pp_timeout
             candidate
-        with
-        | result, checkpoint_after, liveness_success_sample ->
+        in
+        let clock_opt = Eio_context.get_clock_opt () in
+        let synthesize_per_candidate_timeout ~elapsed_s t =
+          Log.Misc.info
+            "[cascade-fallback] cascade %s: per-candidate watchdog \
+             timeout after %.1fs, falling back"
+            ctx.cascade_name
+            t;
+          let result =
+            Error
+              (Agent_sdk.Error.Api
+                 (Agent_sdk.Error.Timeout
+                    { message =
+                        Printf.sprintf
+                          "Per-candidate watchdog timeout after %.1fs"
+                          t
+                    }))
+          in
+          let attempt_latency_ms = elapsed_s *. 1_000.0 in
+          emit_provider_attempt_finished_once
+            ~status:"timeout"
+            ~checkpoint_after_present:false
+            ~response_model:`Null
+            ~error:
+              (`String
+                (Printf.sprintf
+                   "per-candidate watchdog timeout after %.1fs" t))
+            ~exception_kind:"timeout"
+            attempt_latency_ms;
+          record_attempt_terminal
+            ~error:
+              (Some
+                 (Printf.sprintf
+                    "per-candidate watchdog timeout after %.1fs" t))
+            attempt_latency_ms;
+          (result, None, None, attempt_latency_ms)
+        in
+        let invoke_attempt () =
+          match clock_opt, pp_timeout with
+          | Some clock, Some t when t > 0.0 ->
+            (try
+               `Result (Eio.Time.with_timeout_exn clock t attempt_call)
+             with
+             | Eio.Time.Timeout ->
+               let elapsed_s =
+                 Int64.to_float
+                   (Mtime.Span.to_uint64_ns
+                      (Mtime.span attempt_started_at (Mtime_clock.now ())))
+                 /. 1_000_000_000.0
+               in
+               `Per_candidate_timeout (elapsed_s, t))
+          | _, _ -> `Result (attempt_call ())
+        in
+        match invoke_attempt () with
+        | `Per_candidate_timeout (elapsed_s, t) ->
+          synthesize_per_candidate_timeout ~elapsed_s t
+        | `Result (result, checkpoint_after, liveness_success_sample) ->
           let attempt_latency_ms =
             (Int64.to_float (Mtime.Span.to_uint64_ns (Mtime.span attempt_started_at (Mtime_clock.now ()))) /. 1_000_000.)
           in


### PR DESCRIPTION
## Summary

RFC-0197 **Phase B-1** — per-candidate watchdog wrap. Adds `Eio.Time.with_timeout_exn` around the per-candidate `try_provider` call in `lib/keeper/keeper_turn_driver_try_cascade.ml`, so a single hung provider can no longer hold the whole cascade hostage. On timeout the wrap synthesizes the same `(Error (Api Timeout), None, None)` tuple shape that the inner `Cascade_attempt_liveness_config.outer_wall_for_attempt` layer returns when active — the cascade run loop then proceeds to the next candidate, restoring the failover behaviour RFC-0197 §Layer 2 documented as unreachable in Enforce mode.

Closes the *4 tier failover chain unreachable* root cause documented in RFC-0197 §Impact. The pre-merge fleet baseline (analyst keeper, `tier-group.glm-coding-with-spark`) is ~100% `attempt=1` terminal; the RFC target is ≤50% (i.e. ≥50% of failures reach attempt≥2 via fallback).

## Why "B-1" and not the single "Phase B" the RFC describes

The RFC says Phase B is a single PR covering *both* the per-candidate wrap *and* shared deadline composition (`min(per_provider_effective_timeout, remaining_turn_deadline)`). Implementing it as one PR turned out to be unsafe:

- RFC-0197 §Implementation outline §B.2 says "[ctx already has `deadline` from RFC-0192 PR-1]".
- The actual `try_cascade_ctx` in `lib/keeper/keeper_turn_driver_try_cascade.ml` carries only `wait_timeout_sec : float option`, which is the *admission-wait* budget, not a turn-level deadline (see `Keeper_runtime_resolved.admission_wait_timeout_sec`).
- Threading a real `Cascade_deadline.t` through this ctx is its own surgical change touching `keeper_agent_run.ml` and the surrounding wiring.

Splitting the work into B-1 (this PR — per-candidate wrap) and B-2 (follow-up — shared deadline) preserves the RFC §"Anti-pattern check" guarantees and ships the *immediate failover-restoration value* without the deadline-wiring blast radius.

## What changed

`lib/keeper/keeper_turn_driver_try_cascade.ml`:
- Around the existing `match try_provider ctx ?resume_checkpoint ?per_provider_timeout_s:pp_timeout candidate with …`, wrap in `Eio.Time.with_timeout_exn` when both:
  - a clock is available via `Eio_context.get_clock_opt ()`
  - `pp_timeout` is `Some t` with `t > 0.0`
- On `Eio.Time.Timeout`, synthesize:
  - `result = Error (Agent_sdk.Error.Api (Timeout {message=…}))`
  - `checkpoint_after = None`, `liveness_success_sample = None`
  - emit the same `provider_attempt_finished` manifest (status=`timeout`)
  - emit a `[cascade-fallback] cascade %s: per-candidate watchdog timeout after %.1fs, falling back` info log (mirrors the existing `outer_wall_for_provider` log)
  - call `record_attempt_terminal` with the timeout error
- The cascade run loop's normal `Error` handling then transitions to the next candidate.

Inner `Cascade_attempt_liveness_config.outer_wall_for_attempt` (the Layer-2 wrap that returns `None` in Enforce mode) is **not** changed — RFC-0197 §Compatibility explicitly preserves it.

## Why this is not a workaround (RFC-0194 §4 negation)

- **Not §1 Counter-as-fix**: this introduces a *behavioural change* (timeout now bounds the per-candidate attempt). The `[cascade-fallback]` log line is reused from the existing per-provider path; no new metric or counter is added.
- **Not §2 String/Substring classifier**: the timeout is caught as the typed `Eio.Time.Timeout` exception. (The word "substring" appears only in this negation paragraph.)
- **Not §3 N-of-M**: a single wrap location is added. The Layer-2 inner wrap is intentionally left untouched per RFC §Compatibility.
- **No new hard gate**: the per-provider timeout `pp_timeout` is the same value the cascade config already carries; we are not introducing a new ceiling, only enforcing the existing one at the cascade level.

## Reachable surface

`try_provider` lives behind `try_cascade_ctx.try_provider_ctx`, and the call we are wrapping is the only invocation of it in the cascade run loop. No other callers of `try_provider` exist outside `try_cascade.ml`, so the wrap location is the single bottleneck for failover behaviour — there is no per-callsite migration to do later.

## Stack

Independent of RFC-0195 / RFC-0198; based directly on main.

## Test plan

- [x] `dune build --root . @check` — clean
- [x] `dune exec --root . test/test_cascade_attempt_liveness.exe` — 21/21 PASS
- [x] `dune exec --root . test/test_cascade_attempt_liveness_config.exe` — 13/13 PASS
- [ ] Fleet observation (RFC-0197 §Phase D, 7-day window):
  - `[cascade-fallback] cascade %s: per-candidate watchdog timeout` log line appears for hung-provider cases
  - analyst keeper `attempt=1` terminal rate drops from ~100% baseline toward ≤50%
- [ ] Follow-up: **Phase B-2** — thread a `Cascade_deadline.t` through `try_cascade_ctx` and replace the wrap budget `t` with `Cascade_deadline.composed_attempt_budget ~clock ~deadline ~amplifier:t`, restoring the RFC-0192 §2 invariant inside this layer.

WORKAROUND-WAIVED: gate matched the literal word "substring" inside the §4 negation paragraph above; this PR introduces a typed `Eio.Time.Timeout` exception path, not a substring matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
