### PR TITLE
fix(keeper): cache docker preflight result to avoid boot 12s timeout

### DIFF
--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -828,6 +828,29 @@ let docker_preflight ~timeout_sec () =
       })
 ;;
 
+(* Preflight result cache. POST /api/v1/keepers/<name>/boot was hitting
+   the 12s HTTP timeout because every boot re-ran [ensure_keeper_sandbox_runtime]
+   plus [ensure_keeper_sandbox_image_present] inline — docker daemon ping
+   + image presence probe. Docker daemon state and the resolved image
+   presence change on minute scale, so caching the Ok result for 10s
+   collapses bursts (cluster start, dashboard "boot" button retries) into
+   one probe.
+
+   Errors are NOT cached: surface immediately and re-probe on the next
+   call so an operator fixing docker between boot attempts sees the new
+   state without waiting for cache expiry. *)
+let preflight_cache_ttl = 10.0
+
+let preflight_cache_result : (float * (unit, string) result) Atomic.t =
+  Atomic.make (0.0, Ok ())
+
+let preflight_cache_lookup ~now =
+  let ts, result = Atomic.get preflight_cache_result in
+  if ts > 0.0 && now -. ts < preflight_cache_ttl
+  then Some result
+  else None
+;;
+
 let ensure_keeper_startup_preflight ~timeout_sec ~sandbox_profile =
   match sandbox_profile with
   | Keeper_types.Local -> Ok ()
@@ -835,20 +858,30 @@ let ensure_keeper_startup_preflight ~timeout_sec ~sandbox_profile =
     if not (Env_config_sandbox.Preflight.enabled ())
     then Ok ()
     else (
-      let timeout_sec = docker_preflight_timeout ~timeout_sec in
-      let image = Env_config_sandbox.Runtime.docker_image () in
-      match ensure_keeper_sandbox_runtime ~timeout_sec with
-      | Error message ->
-        Error
-          (Printf.sprintf "Docker sandbox startup preflight failed: %s" message)
-      | Ok _ ->
-        (match ensure_keeper_sandbox_image_present ~image ~timeout_sec with
-         | Ok () -> Ok ()
-         | Error message ->
-           Error
-             (Printf.sprintf
-                "Docker sandbox startup preflight failed: %s"
-                message)))
+      let now = Unix.gettimeofday () in
+      match preflight_cache_lookup ~now with
+      | Some cached -> cached
+      | None ->
+        let timeout_sec = docker_preflight_timeout ~timeout_sec in
+        let image = Env_config_sandbox.Runtime.docker_image () in
+        let result =
+          match ensure_keeper_sandbox_runtime ~timeout_sec with
+          | Error message ->
+            Error
+              (Printf.sprintf "Docker sandbox startup preflight failed: %s" message)
+          | Ok _ ->
+            (match ensure_keeper_sandbox_image_present ~image ~timeout_sec with
+             | Ok () -> Ok ()
+             | Error message ->
+               Error
+                 (Printf.sprintf
+                    "Docker sandbox startup preflight failed: %s"
+                    message))
+        in
+        (match result with
+         | Ok () -> Atomic.set preflight_cache_result (now, result)
+         | Error _ -> ());
+        result)
 ;;
 
 module For_testing = struct


### PR DESCRIPTION
## Summary

POST `/api/v1/keepers/<name>/boot` 가 12s HTTP timeout 으로 fail. trace 결과 root 는 `Keeper_sandbox_runtime.ensure_keeper_startup_preflight` — 매 boot 마다 docker daemon ping + image presence probe 를 *blocking sync* 로 실행. 본 PR 은 preflight 의 Ok 결과를 10s 동안 in-memory cache 하여 burst 시 dedup.

## Evidence

사용자 보고: `POST /api/v1/keepers/masc-improver/boot: timeout after 12000ms`

Code path trace:
1. `POST /api/v1/keepers/<name>/boot`
2. → `handle_keeper_lifecycle_post action="boot"` (lifecycle_post.ml)
3. → `Tool_keeper.dispatch "masc_keeper_up"` (line 619 of tool_keeper.ml)
4. → `execute_keeper_up` → `Turn.handle_keeper_up`
5. → `Keeper_turn_up_update.update_keeper` (line 19 of keeper_turn_up.ml)
6. → **`Keeper_sandbox_runtime.ensure_keeper_startup_preflight`** (line 391 of keeper_turn_up_update.ml, line 831 of keeper_sandbox_runtime.ml)
7. → `ensure_keeper_sandbox_runtime` (docker daemon ping) + `ensure_keeper_sandbox_image_present` (image pull check)

각 boot 마다 매번 docker probe. docker daemon 응답 느릴 때 12s+ 발생.

## Fix

`ensure_keeper_startup_preflight` 안에 self-contained Atomic.t cache:

```ocaml
let preflight_cache_ttl = 10.0
let preflight_cache_result : (float * (unit, string) result) Atomic.t =
  Atomic.make (0.0, Ok ())

let ensure_keeper_startup_preflight ~timeout_sec ~sandbox_profile =
  match sandbox_profile with
  | Local -> Ok ()
  | Docker ->
    if not (Preflight.enabled ()) then Ok ()
    else (
      let now = Unix.gettimeofday () in
      match preflight_cache_lookup ~now with
      | Some cached -> cached
      | None ->
        let result = (* original probe *) in
        (match result with
         | Ok () -> Atomic.set preflight_cache_result (now, result)
         | Error _ -> ());  (* errors NOT cached *)
        result)
```

**Design 결정**:
- Atomic.t (lock-free): preflight probe 자체가 일부 동시성 허용 (worst case 일시 multiple probes, 마지막 result 가 cache)
- TTL 10s: docker daemon state 짧은 시간 변경 안 됨, dashboard burst 흡수에 충분
- **Errors NOT cached**: operator 가 docker daemon fix 시 즉시 다음 boot 에 반영 (cache 만료 대기 X)
- Local profile / Preflight disabled: cache path 진입 안 함 (기존 동작 유지)

## Workaround Signature Gate

- counter-as-fix? NO — cache 는 latency reduction
- substring 분류기? NO
- N-of-M patch? 새 영역 (이전 PR #19088/#19097/#19100 은 dashboard cache, 본 PR 은 boot path)
- cap/cooldown/dedup? cache 는 dedup 의 한 형태이지만 ttl-based perf optimization 으로 보편 패턴

## Build

```
$ dune build lib/keeper
EXIT=0
```

(전체 build 는 worktree 다른 axis 에 영향 없음 — `lib/keeper` 단독 type-check 통과 + commit 작은 self-contained scope.)

## Test plan

- [ ] CI build PASS
- [ ] 서버 재시작 후 POST `/keepers/<name>/boot` 1차 호출: cold (몇 초 소요)
- [ ] 2차 호출 (10s 안에): cache hit, <100ms
- [ ] docker daemon 일시 stop 후 호출: error 반환 + cache NOT updated
- [ ] docker daemon 재시작 후 호출: 다음 호출이 fresh probe (cached error 없음)

## Limitations

- **Cache 가 진짜 root 인지 측정 안 됨**: trace 는 강하지만 *실제 timing breakdown* (preflight 가 12s 의 어느 정도 차지) 측정 안 됨. preflight 가 root 가 아니면 본 PR 효과 부분적. follow-up: log instrumentation PR 또는 fleet evidence 수집.
- **error 시 stampede**: error path 가 cache 안 되어 여러 fiber 가 동시에 N 번 probe. error 가 일시적이면 burst 발생 가능. acceptable trade-off (visibility 우선).

## Related
- PR #19088 / #19097 / #19100 — dashboard cache+offload (다른 영역)
- 본 PR — boot path 의 preflight cache
