### PR TITLE
Remove fleet telemetry utility reexport aliases

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -17,6 +17,7 @@ import {
 } from '../api/dashboard'
 import { resetKeeper } from '../api/keeper'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
+import { telemetrySourceLabel } from '../config/telemetry-sources'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { useSavedSignal } from '../lib/saved-signal'
 import { normalizeKeepers } from '../keeper-store-normalize'
@@ -45,7 +46,6 @@ import {
   pressureClass,
   sourceCountClass,
   sourceDetail,
-  sourceLabel,
   statusClass,
   successClass,
   summaryCounts,
@@ -552,7 +552,7 @@ function TelemetrySourcesPanel({ sources }: { sources: TelemetrySourceSummary[] 
       ${sorted.map(source => html`
         <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
           <div class="flex items-center justify-between gap-3">
-            <div class="text-2xs font-medium text-[var(--text)]">${sourceLabel(source.source)}</div>
+            <div class="text-2xs font-medium text-[var(--text)]">${telemetrySourceLabel(source.source)}</div>
             <div class="font-mono text-2xs ${sourceCountClass(source)}">
               ${source.entry_count.toLocaleString()}
             </div>

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -7,7 +7,6 @@ import {
   normalizeText,
   isPlaceholderModel,
   normalizeModelText,
-  firstNonEmptyString,
   uniqueStrings,
   successClass,
   fleetBand,
@@ -250,16 +249,6 @@ describe('buildFleetRows runtime labels', () => {
       source: 'runtime_blocker_class',
       summary: 'no provider can satisfy required tools',
     })
-  })
-})
-
-describe('firstNonEmptyString', () => {
-  it('returns first non-null trimmed string', () => {
-    expect(firstNonEmptyString(null, '  ', 'hello', 'world')).toBe('hello')
-  })
-
-  it('returns null when all are empty', () => {
-    expect(firstNonEmptyString(null, undefined, '  ')).toBeNull()
   })
 })
 

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -1,6 +1,5 @@
 import type { DashboardExecutionTrustResponse, TelemetrySourceSummary, ToolQualityResponse } from '../api/dashboard'
 import type { DashboardNamespaceTruthResponse } from '../types'
-import { telemetrySourceLabel } from '../config/telemetry-sources'
 import type { Keeper, StopCause } from '../types'
 import { formatElapsedCompact } from '../lib/format-time'
 import { formatMsCompact } from '../lib/format-number'
@@ -105,9 +104,6 @@ export function emptyState(): FleetTelemetryState {
   }
 }
 
-// Delegated to config/telemetry-sources (SSOT)
-export const sourceLabel = telemetrySourceLabel
-
 // Error -> message conversion with a literal 'unknown error' fallback for
 // non-Error inputs. Distinct from errorToString (cascade-config) which uses
 // String(reason) instead, and from errorMessageOr (keeper-detail-hooks)
@@ -132,8 +128,6 @@ export function normalizeModelText(value: string | null | undefined): string | n
   const text = normalizeText(value)
   return text == null || isPlaceholderModel(text) ? null : text
 }
-
-export { firstNonEmptyString }
 
 export function uniqueStrings(values: Array<string | null | undefined>): string[] {
   const seen = new Set<string>()

--- a/dashboard/src/lib/format-string.test.ts
+++ b/dashboard/src/lib/format-string.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { firstNonEmptyString } from './format-string'
+
+describe('firstNonEmptyString', () => {
+  it('returns the first trimmed non-empty string', () => {
+    expect(firstNonEmptyString(null, '  ', ' hello ', 'world')).toBe('hello')
+  })
+
+  it('returns null when all values are empty', () => {
+    expect(firstNonEmptyString(null, undefined, '  ')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Remove sourceLabel alias export from fleet-telemetry-utils and import telemetrySourceLabel from its config SSOT at the panel callsite.
- Remove firstNonEmptyString re-export from fleet-telemetry-utils.
- Move firstNonEmptyString coverage to lib/format-string.test.ts.

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/fleet-telemetry-utils.test.ts src/components/fleet-telemetry-panel.test.ts src/lib/format-string.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/fleet-telemetry-utils.ts src/components/fleet-telemetry-utils.test.ts src/components/fleet-telemetry-panel.ts src/components/fleet-telemetry-panel.test.ts src/lib/format-string.ts src/lib/format-string.test.ts (test/lib files ignored by current eslint config; component files passed)
- git diff --check origin/main