### PR TITLE
refactor(keeper-error-classify/unified-turn-execution): typed extract_input_required replaces if + match + assert false

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -809,6 +809,18 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.A2a _
   | Agent_sdk.Error.Internal _ -> false
 
+(** Extract the [InputRequired] payload from an [sdk_error], if any.
+    Typed companion to {!is_input_required_error}; callers that need
+    the [input_required] record use this option-returning function so
+    a [match ... | _ -> assert false] tail is no longer required. *)
+let extract_input_required (err : Agent_sdk.Error.sdk_error)
+  : Agent_sdk.Error.input_required option
+  =
+  match err with
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired ir) -> Some ir
+  | _ -> None
+;;
+
 (** [true] when the error is an OAS [InputRequired] — the agent paused
     to request human input.  Not a failure; a special stop condition. *)
 let is_input_required_error (err : Agent_sdk.Error.sdk_error) : bool =

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -55,6 +55,15 @@ val is_context_overflow : Agent_sdk.Error.sdk_error -> bool
     to request human input.  Not a failure; a special stop condition. *)
 val is_input_required_error : Agent_sdk.Error.sdk_error -> bool
 
+(** Extract the [InputRequired] payload from an [sdk_error], if any.
+    Typed companion to {!is_input_required_error} — callers that need
+    the [input_required] record (request_id, question, …) avoid a
+    separate pattern match plus [assert false] when the predicate
+    has already filtered for the constructor. *)
+val extract_input_required
+  :  Agent_sdk.Error.sdk_error
+  -> Agent_sdk.Error.input_required option
+
 (** [true] when an error represents terminal cascade exhaustion or a
     final accept-rejected result from the MASC OAS boundary. *)
 val is_cascade_exhausted_error : Agent_sdk.Error.sdk_error -> bool

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -229,12 +229,8 @@ let run (ctx : ctx)
       Cascade_name.to_string execution.cascade_name
     in
     let mark_terminal_error err =
-      if EC.is_input_required_error err then begin
-        let ir =
-          match err with
-          | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired ir) -> ir
-          | _ -> assert false
-        in
+      match EC.extract_input_required err with
+      | Some ir ->
         Keeper_registry.mark_turn_cascade_done
           ~base_path:config.base_path
           meta.name;
@@ -253,7 +249,7 @@ let run (ctx : ctx)
           ~prev:Keeper_turn_fsm.Streaming
           (Keeper_turn_fsm.Cancelled
              Keeper_turn_fsm.Cancelled_input_required)
-      end else
+      | None ->
         Keeper_unified_turn_terminal_error.handle
           ~config
           ~keeper_name:meta.name


### PR DESCRIPTION
## 요약

Partial function 안티패턴 — `if EC.is_input_required_error err then begin let ir = match ... | _ -> assert false in ...` 의 typed lift. 새 typed companion `extract_input_required` 추가 후 callsite 정리.

### 문제

`lib/keeper/keeper_unified_turn_execution.ml:231-237`:

```ocaml
let mark_terminal_error err =
  if EC.is_input_required_error err then begin
    let ir =
      match err with
      | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired ir) -> ir
      | _ -> assert false
    in
    ...
```

`is_input_required_error : sdk_error -> bool` 가 *constructor 검사 후 bool 반환*. 다음 `match err with InputRequired ir -> ir | _ -> assert false` 가 *같은 constructor* 를 다시 검사 + 페이로드 추출. 컴파일러는 두 검사의 일치 강제 못 함 → `assert false` partial.

### 해결

`Keeper_error_classify` 에 typed companion 추가:

```ocaml
(* keeper_error_classify.mli *)
val extract_input_required
  :  Agent_sdk.Error.sdk_error
  -> Agent_sdk.Error.input_required option

(* keeper_error_classify.ml *)
let extract_input_required (err : Agent_sdk.Error.sdk_error)
  : Agent_sdk.Error.input_required option
  =
  match err with
  | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired ir) -> Some ir
  | _ -> None
;;
```

Callsite typed match:

```ocaml
let mark_terminal_error err =
  match EC.extract_input_required err with
  | Some ir ->
    Keeper_registry.mark_turn_cascade_done ~base_path:config.base_path meta.name;
    Log.Keeper.info ... ir.Agent_sdk.Error.request_id ...
    Keeper_turn_fsm.emit_transition ...
  | None ->
    Keeper_unified_turn_terminal_error.handle ~config ... err
```

- `assert false` 제거 — 컴파일러가 모든 branch 강제
- 단일 `match` 가 *predicate + projection* 결합 — type-level invariant
- `is_input_required_error` 보존 (다른 callsite `keeper_unified_turn.ml:597` 의 `Error err when EC.is_input_required_error err` when-guard 가 사용)

### 동작 무변경

- `extract_input_required` 가 `is_input_required_error` 와 *같은 constructor* 검사
- `None` arm 이 *원래 if-else else-arm* (`Keeper_unified_turn_terminal_error.handle`) 와 동일

## 변경

- 3 files (`keeper_error_classify.mli` + `keeper_error_classify.ml` + `keeper_unified_turn_execution.ml`)
- 1 `assert false` 사이트 제거
- 새 typed helper 1 (`extract_input_required`)
- `dune build lib/` PASS

## Out-of-scope

`keeper_unified_turn.ml:597` 의 `| Error err when EC.is_input_required_error err -> ...` — match-when guard 형식이라 *typed extract* 변환 시 `match ... with | Some ir -> ... | None -> ...` 으로 큰 refactor. 별도 PR.

다른 `assert false` 사이트는 *주석 안* 또는 *test*. 본 PR 외 새 surgical 없음.

## Workaround Signature Gate

WORKAROUND-WAIVED: Partial function 안티패턴 *제거* + typed companion 신설. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — typed companion 신설로 future callsite 도 활용 가능

## Related

- PR #19127 (MERGED) — Option.get typed match
- PR #19130, #19133, #19137, #19140, #19142 (MERGED) — List.hd/List.tl sweep 완결
- sw-dev: "Parse, don't validate" — predicate + projection 결합

🤖 Generated with [Claude Code](https://claude.com/claude-code)
