### PR TITLE
perf(dashboard/activity): cache+offload 3 activity endpoints

### DIFF
--- a/lib/server/server_activity_http.ml
+++ b/lib/server/server_activity_http.ml
@@ -40,6 +40,13 @@ let last_event_id request =
       | None -> 0)
   | None -> 0
 
+(* Dashboard panel polls /api/v1/activity/events ~every refresh tick with the
+   same default query (no [after_seq] cursor — see dashboard ide-activity-panel).
+   [Activity_graph.json_response] hits JSONL on disk ([activity-events/YYYY-MM/DD.jsonl]).
+   Wrap with [Dashboard_cache] (2s TTL — short enough for near-live feel,
+   long enough to collapse concurrent panel reloads) and offload compute via
+   [Domain_pool_ref.submit_io_or_inline] so the HTTP main domain keeps serving
+   while disk read + JSON build runs on a worker. *)
 let events_http_json ~deps ~state request =
 
   let kinds = kind_filters deps request in
@@ -50,8 +57,14 @@ let events_http_json ~deps ~state request =
     deps.int_query_param request "limit" ~default:200
     |> clamp ~min_v:1 ~max_v:1000
   in
-  Activity_graph.json_response state.Mcp_server.room_config ~kinds
-    ~after_seq ~limit ()
+  let cache_key =
+    Printf.sprintf "activity:events:%s:%d:%d"
+      (String.concat "," kinds) after_seq limit
+  in
+  Dashboard_cache.get_or_compute cache_key ~ttl:2.0 (fun () ->
+    Domain_pool_ref.submit_io_or_inline (fun () ->
+      Activity_graph.json_response state.Mcp_server.room_config ~kinds
+        ~after_seq ~limit ()))
 
 let parse_since_ms (raw : string) : int option =
   let len = String.length raw in
@@ -76,18 +89,27 @@ let graph_http_json ~deps ~state request =
     deps.int_query_param request "timeline_limit" ~default:80
     |> clamp ~min_v:10 ~max_v:200
   in
-  let since_ms =
-    match deps.query_param request "since" with
-    | Some raw ->
-        (match parse_since_ms raw with
-         | Some delta_ms ->
-             let now_ms = int_of_float (Time_compat.now () *. 1000.0) in
-             Some (now_ms - delta_ms)
-         | None -> None)
-    | None -> None
+  let since_raw =
+    deps.query_param request "since" |> Option.value ~default:""
   in
-  Activity_graph.graph_json state.Mcp_server.room_config ~kinds ~limit
-    ~timeline_limit ?since_ms ()
+  (* Cache key uses [since_raw] (request param) not [since_ms] (now-derived) so
+     two requests within the TTL window with the same "5m" window hit the same
+     entry. Concrete [since_ms] is computed inside the compute closure on miss. *)
+  let cache_key =
+    Printf.sprintf "activity:graph:%s:%d:%d:%s"
+      (String.concat "," kinds) limit timeline_limit since_raw
+  in
+  Dashboard_cache.get_or_compute cache_key ~ttl:2.0 (fun () ->
+    Domain_pool_ref.submit_io_or_inline (fun () ->
+      let since_ms =
+        match parse_since_ms since_raw with
+        | Some delta_ms ->
+            let now_ms = int_of_float (Time_compat.now () *. 1000.0) in
+            Some (now_ms - delta_ms)
+        | None -> None
+      in
+      Activity_graph.graph_json state.Mcp_server.room_config ~kinds ~limit
+        ~timeline_limit ?since_ms ()))
 
 let swimlane_http_json ~deps ~state request =
 
@@ -95,18 +117,23 @@ let swimlane_http_json ~deps ~state request =
     deps.int_query_param request "limit" ~default:500
     |> clamp ~min_v:1 ~max_v:2000
   in
-  let since_ms =
-    match deps.query_param request "since" with
-    | Some raw ->
-        (match parse_since_ms raw with
-         | Some delta_ms ->
-             let now_ms = int_of_float (Time_compat.now () *. 1000.0) in
-             Some (now_ms - delta_ms)
-         | None -> None)
-    | None -> None
+  let since_raw =
+    deps.query_param request "since" |> Option.value ~default:""
   in
-  Activity_graph.agent_spans_json state.Mcp_server.room_config ~limit
-    ?since_ms ()
+  let cache_key =
+    Printf.sprintf "activity:swimlane:%d:%s" limit since_raw
+  in
+  Dashboard_cache.get_or_compute cache_key ~ttl:2.0 (fun () ->
+    Domain_pool_ref.submit_io_or_inline (fun () ->
+      let since_ms =
+        match parse_since_ms since_raw with
+        | Some delta_ms ->
+            let now_ms = int_of_float (Time_compat.now () *. 1000.0) in
+            Some (now_ms - delta_ms)
+        | None -> None
+      in
+      Activity_graph.agent_spans_json state.Mcp_server.room_config ~limit
+        ?since_ms ()))
 
 let stream_headers ~deps origin =
   Httpun.Headers.of_list


### PR DESCRIPTION
## Summary

Dashboard 의 가장 느린 GET (`/api/v1/activity/events` 4.9s) + 같은 파일의 2 sibling endpoint (`/activity/graph` 1.41s, `/activity/swimlane`) 에 `Dashboard_cache` + `Domain_pool_ref.submit_io_or_inline` 패턴 적용. PR #19088/#19097/#19100 와 같은 cache+offload 패턴.

## Evidence

Dashboard page→API mapping 측정 결과:

| Endpoint | Baseline |
|---|---|
| `/api/v1/activity/events` | **4.9s** (P0 #1) |
| `/api/v1/activity/graph` | 1.41s (P0 #4) |
| `/api/v1/activity/swimlane` | (사용 site 적지만 동일 pattern) |

Dashboard `ide-activity-panel.ts:200` 가 `?limit=50` 만 사용 (no `after_seq` cursor) — 매 panel refresh 가 같은 query. cache hit rate 높을 것.

Code path: `events_http_json` → `Activity_graph.json_response` → `list_events_with_meta` (JSONL disk read, `activity-events/YYYY-MM/DD.jsonl` 패턴). source meta 가 직접 `"cache_policy": "uncached"` 명시.

## Fix

3 endpoints 모두 같은 패턴:

```ocaml
let cache_key = Printf.sprintf "activity:events:%s:%d:%d" 
  (String.concat "," kinds) after_seq limit in
Dashboard_cache.get_or_compute cache_key ~ttl:2.0 (fun () ->
  Domain_pool_ref.submit_io_or_inline (fun () ->
    Activity_graph.json_response state.Mcp_server.room_config ~kinds 
      ~after_seq ~limit ()))
```

**Design 결정**:
- **TTL=2.0s**: dashboard panel polling cadence + real-time staleness 최소. cascade endpoint 의 30s 보다 짧음 — activity events 는 "live feel" 이 중요.
- **Cache key uses `since_raw` (request param) not `since_ms`**: now-derived `since_ms` 가 cache key 에 들어가면 매 fetch 마다 different key → cache miss. `since_raw` ("5m", "1h") 는 stable.
- **`since_ms` computed inside closure**: cache miss 시 실제 disk query 의 since 는 fresh now 기준. 같은 raw param 이라도 다른 시간에 cache 만료되면 새 since_ms 계산.

## Workaround Signature Gate

- counter-as-fix? NO — cache 는 latency reduction
- substring 분류기? NO
- N-of-M patch? 같은 영역 (dashboard cache) 의 *새 파일* — PR #19097/#19100 이 다른 endpoint 영역, 본 PR 은 activity 영역의 첫 wrap
- cap/cooldown/dedup? cache 는 dedup 의 한 형태이지만 ttl-based perf optimization 으로 보편 패턴

## Build

```
$ dune build lib/server
EXIT=0
```

## Test plan

- [ ] CI build PASS
- [ ] 서버 재시작 후 `/activity/events?limit=50` 첫 호출: cold (~4.9s 가까운 latency)
- [ ] 2 호출 (2s 안에): cache hit, <100ms
- [ ] concurrent 5 fetch (multi-fiber burst): single compute (stampede protection)
- [ ] kinds 다르면 different cache key: independent miss/compute

## Related

- PR #19088 — cascade GET cache (4 endpoints)
- PR #19097 — cascade offload + TTL tune (PR #19088 follow-up)
- PR #19100 — keeper tool-stats cache+offload
- **본 PR** — activity 3 endpoints cache+offload
- Follow-up: governance/tool-events 1.45s, feature-health 1.34s, heuristics/coverage 1.31s, sidecar/schema 1.23s, execution 1.19s, board 1.12s 가 같은 dashboard P0 cluster
