### PR TITLE
refactor(env-config-keeper/auth-credential-base): narrow try-with-wildcard to typed exceptions (RFC-0145)

### DIFF
--- a/lib/auth_credential_base.ml
+++ b/lib/auth_credential_base.ml
@@ -178,7 +178,14 @@ let auth_config_cache : auth_config_cache_entry option Atomic.t =
 (** Load auth config *)
 let load_auth_config config : auth_config =
   let file = auth_config_file config in
-  match (try Some (Unix.stat file).Unix.st_mtime with _ -> None) with
+  (* RFC-0145 — narrow from a wildcard catch-all to the only exception
+     [Unix.stat] raises on a missing or unreadable file.  Other runtime
+     exceptions are intentionally not caught here so we do not silently
+     poison the auth config cache on novel filesystem failure modes. *)
+  match
+    try Some (Unix.stat file).Unix.st_mtime with
+    | Unix.Unix_error _ -> None
+  with
   | None ->
     (* File missing or unreadable — same fallback as the historical
        [file_exists] branch.  Do not poison the cache. *)

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -766,7 +766,12 @@ module CascadeTierWait = struct
     let v = get_string ~default:"" "MASC_CASCADE_TIER_WAIT_MAX_RETRIES" in
     match v with
     | "" | "none" | "unlimited" -> None
-    | s -> (try Some (int_of_string s) with _ -> None)
+    | s ->
+      (* RFC-0145 — narrow from a wildcard catch-all to the only
+         exception [int_of_string] raises on malformed numeric input.
+         Other runtime exceptions (e.g. [Out_of_memory]) propagate. *)
+      (try Some (int_of_string s) with
+       | Failure _ -> None)
 end
 
 (** {1 Cascade Runtime Overrides}


### PR DESCRIPTION
## 요약

RFC-0145 — Wildcard catch-all → typed exception narrowing. 2 사이트.

### 문제

```ocaml
(* lib/config/env_config_keeper.ml:769 *)
| s -> (try Some (int_of_string s) with _ -> None)

(* lib/auth_credential_base.ml:181 *)
match (try Some (Unix.stat file).Unix.st_mtime with _ -> None) with
```

`with _ ->` 가 *모든 예외 삼킴* — `Out_of_memory`, `Stack_overflow`, async cancellation 까지. *Silent Failure* 안티패턴.

### 해결

```ocaml
(* env_config_keeper.ml *)
| s ->
  (* RFC-0145 — narrow from a wildcard catch-all to the only
     exception [int_of_string] raises on malformed numeric input.
     Other runtime exceptions (e.g. [Out_of_memory]) propagate. *)
  (try Some (int_of_string s) with
   | Failure _ -> None)

(* auth_credential_base.ml *)
(* RFC-0145 — narrow from a wildcard catch-all to the only exception
   [Unix.stat] raises on a missing or unreadable file.  Other runtime
   exceptions are intentionally not caught here so we do not silently
   poison the auth config cache on novel filesystem failure modes. *)
match
  try Some (Unix.stat file).Unix.st_mtime with
  | Unix.Unix_error _ -> None
with
```

각 사이트 narrowing 근거 (어떤 exception 이 *유일하게* raise 되는지) 를 인라인 주석으로 명시.

### 동작 무변경

- `int_of_string` 의 `Failure` 와 `Unix.stat` 의 `Unix_error` 는 *기존에도 catch* 했음
- *기타 예외* (Out_of_memory, async cancel) 는 *기존엔 silent swallowed* 이고 이제 *propagate*
- production 에서 기타 예외 발생 시 *crash 가 아니라 caller scope 에서 처리* — *진짜 위험* (예: OOM) 이 발견 가능

## 변경

- 2 files (`env_config_keeper.ml`, `auth_credential_base.ml`)
- +14/-2
- 2 wildcard catches narrow 됨
- `dune build lib/` PASS

## Out-of-scope

- `lib/cascade/cascade_tier_admission.ml:102` — `release ... with _ -> ()` (cleanup silent ignore). `release` 내부 raise 가능 예외 audit 필요. 별도 PR.

## Workaround Signature Gate

WORKAROUND-WAIVED: Silent Failure 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 2 사이트 *모두* 동시 처리 + 명확한 typed boundary

## Related

- RFC-0145 — exception narrowing 패턴 (lib/server/host_fd_pressure_poller.ml 등 사례)
- CLAUDE.md `Silent Failure 를 사전에 방지`
- PR #19149 (OPEN) — Partial function 시리즈 6번째

🤖 Generated with [Claude Code](https://claude.com/claude-code)
