### PR TITLE
refactor(dashboard/board): centralise boardMessageRowKey, drop 2 byte-identical rowKey copies

### DIFF
--- a/dashboard/src/components/board/mention-inbox.ts
+++ b/dashboard/src/components/board/mention-inbox.ts
@@ -6,7 +6,7 @@ import { EmptyState } from '../common/feedback-state'
 import { RichContent } from '../common/rich-content'
 import { TimeAgo } from '../common/time-ago'
 import { stripStateBlocks } from '../../keeper-message'
-import { SYSTEM_MESSAGE_FROM } from '../../lib/board-utils'
+import { SYSTEM_MESSAGE_FROM, boardMessageRowKey } from '../../lib/board-utils'
 import { currentDashboardActorName } from '../../lib/dashboard-session-actor'
 import { navigate } from '../../router'
 import { messages, shellAuthSummary } from '../../store'
@@ -125,10 +125,6 @@ function previewContent(message: Message): string {
   return stripStateBlocks(message.content).trim() || message.content.trim() || '(empty)'
 }
 
-function rowKey(row: MentionInboxRow): string {
-  return row.message.id ?? `${row.message.seq ?? 'message'}-${row.index}`
-}
-
 function MessageRow({ row }: { row: MentionInboxRow }) {
   const preview = previewContent(row.message)
   const hasState = row.message.content.includes('[STATE]')
@@ -182,7 +178,7 @@ function MentionLane({
       </div>
       ${rows.length === 0
         ? html`<${EmptyState} message=${emptyMessage} compact />`
-        : html`<div class="grid gap-2.5">${rows.map(row => html`<${MessageRow} key=${rowKey(row)} row=${row} />`)}</div>`}
+        : html`<div class="grid gap-2.5">${rows.map(row => html`<${MessageRow} key=${boardMessageRowKey(row.message, row.index)} row=${row} />`)}</div>`}
     </section>
   `
 }

--- a/dashboard/src/components/board/message-room-timeline.ts
+++ b/dashboard/src/components/board/message-room-timeline.ts
@@ -6,7 +6,7 @@ import { EmptyState } from '../common/feedback-state'
 import { RichContent } from '../common/rich-content'
 import { TimeAgo } from '../common/time-ago'
 import { stripStateBlocks } from '../../keeper-message'
-import { SYSTEM_MESSAGE_FROM } from '../../lib/board-utils'
+import { SYSTEM_MESSAGE_FROM, boardMessageRowKey } from '../../lib/board-utils'
 import { navigate } from '../../router'
 import { messages } from '../../store'
 import type { Message } from '../../types'
@@ -95,10 +95,6 @@ export function buildMessageRoomModel(messageList: readonly Message[]): MessageR
 
 function previewContent(message: Message): string {
   return stripStateBlocks(message.content).trim() || message.content.trim() || '(empty)'
-}
-
-function rowKey(row: TimelineRow): string {
-  return row.message.id ?? `${row.message.seq ?? 'message'}-${row.index}`
 }
 
 function TimelineMessage({ row }: { row: TimelineRow }) {
@@ -215,7 +211,7 @@ export function MessageRoomTimeline() {
             </div>
             <${ComposerV2} roomId=${composerRoom} />
             <section role="tabpanel" aria-label=${active ? `#${active.room} timeline` : 'Message timeline'} class="grid gap-2.5">
-              ${active?.rows.map(row => html`<${TimelineMessage} key=${rowKey(row)} row=${row} />`)}
+              ${active?.rows.map(row => html`<${TimelineMessage} key=${boardMessageRowKey(row.message, row.index)} row=${row} />`)}
             </section>
           `}
     </section>

--- a/dashboard/src/lib/board-utils.ts
+++ b/dashboard/src/lib/board-utils.ts
@@ -10,7 +10,26 @@
  */
 export const SYSTEM_MESSAGE_FROM = 'system'
 
+/**
+ * Stable list-item key for a board `Message` row at position `index`.
+ *
+ * Prefers the message's own id (set by the backend on durable posts).
+ * Falls back to `<seq>-<index>` for unposted/draft rows where `id`
+ * hasn't been assigned yet, with `'message'` as the seq placeholder.
+ *
+ * Two board panels (`mention-inbox`, `message-room-timeline`) shipped
+ * this exact body file-internal as `rowKey`. A third (`state-block-messages`)
+ * uses a different base (`id ?? seq ?? index` single chain) plus a
+ * `state-block.slice(0, 24)` suffix and is left on its own helper —
+ * a future change to its base policy can adopt this helper once the
+ * suffix is parameterised.
+ */
+export function boardMessageRowKey(message: Message, index: number): string {
+  return message.id ?? `${message.seq ?? 'message'}-${index}`
+}
+
 import { navigate } from '../router'
+import type { Message } from '../types'
 import { findKeeper } from './keeper-utils'
 import { openKeeperDetail } from '../components/keeper-detail'
 import type { BoardActorIdentity, BoardContributorQuality } from '../types'


### PR DESCRIPTION
## 요약
2 board 패널의 `rowKey` byte-identical 함수를 `lib/board-utils.ts` 의 `boardMessageRowKey` SSOT export 로 통합. iter#54/55 function-body duplicate sweep 5번째 적용.

## 배경

`rg "^function rowKey\(" -A 3` sweep 결과 3 board 패널에 *유사 정의* 발견:

| 파일 | 본문 |
|---|---|
| `mention-inbox.ts:128` | `row.message.id ?? \`${row.message.seq ?? 'message'}-${row.index}\`` |
| `message-room-timeline.ts:100` | (동일) |
| `state-block-messages.ts` | `\`${row.message.id ?? row.message.seq ?? row.index}-${row.stateBlock.slice(0, 24)}\`` (variant) |

2 byte-identical (mention-inbox + message-room-timeline) — 통합 후보. 1 variant (state-block-messages) — base policy + suffix shape 다름, 분리 보존.

## 변경

### `lib/board-utils.ts`
- `export function boardMessageRowKey(message: Message, index: number): string` 추가
- iter#51 `SYSTEM_MESSAGE_FROM` 와 같은 *board domain utility* 위치
- `import type { Message } from '../types'` 추가
- JSDoc: fallback chain (id → seq+index) + variant 분리 사유 명시

### 2 callsite migration
- `mention-inbox.ts`, `message-room-timeline.ts`: file-internal `function rowKey` 삭제 + import 확장 + `rowKey(row)` → `boardMessageRowKey(row.message, row.index)`

### Variant 분리 (별도 PR scope)
- `state-block-messages.ts` — base policy + suffix shape 다름. iter#46 bulk-migrate-then-extend 패턴: 후속 PR 에서 *helper 파라미터 확장* 후 흡수 가능 (`boardMessageRowKey(message, index, { suffix })` 같은 형태).

## 검증
- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)

## iter chain — file-internal helper sweep 5번째

- iter#48: happy-dom-helpers (test cast types, 2 file)
- iter#53: escapeRegExp (prod + test 동일 helper, 2 file)
- iter#54: unixishToMs (3 IDE trace bridge)
- iter#55: routeHashParams (3 IDE test 파일)
- iter#56: **boardMessageRowKey (2 board 패널 + 1 variant 분리)**

saturation 후 *function-body duplicate sweep* 패턴 정착 — 5 회 누적.

## /loop iter#56
SSOT 위반 dashboard 축출 loop 의 iter#56. cumulative 56 PR (36 머지 + 2 OPEN — #19147 + #19?_).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
