### PR TITLE
Remove tool quality filter reexports

### DIFF
--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -40,14 +40,10 @@ export function toolMatchesCategory(
 /**
  * SSOT for tool list filtering across the dashboard.
  *
- * Until 2026-05-27 `tool-quality-panel.ts` defined its own 2-arg variant
- * (`filterTools(tools, query)`) — a strict subset of this 3-arg variant
- * with `category` always implicitly `'all'`. Two definitions of the same
- * operation could drift independently. The category parameter now defaults
- * to `'all'` so the 2-arg call site keeps working through a re-export from
- * `tool-quality-panel`, and the generic constraint is loosened to any
- * `{ name: string }` so both `ToolMetricsTopEntry` and `ToolStat` callers
- * type-check without coupling to a specific tool schema.
+ * Until 2026-05-27 `tool-quality-panel.ts` exposed its own compatible import
+ * path for this operation. Callers now import the filter from this owning
+ * module, while the category parameter still defaults to `'all'` for the
+ * two-argument `filterTools(tools, query)` panel use case.
  */
 export function filterTools<T extends { name: string }>(
   items: T[],

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -4,10 +4,8 @@ import { act } from 'preact/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ToolQualityResponse } from '../api/dashboard'
 import {
-  filterTools,
   pickAxisLabelIndices,
   rateColorVar,
-  toolMatchesSearch,
 } from './tool-quality-panel'
 import { classifyCoverageError, errorHintFromClass, errorHintFromGap } from './common/coverage-gap-block'
 import type { CoverageGapDisplay } from './common/source-health'
@@ -418,40 +416,6 @@ describe('ToolQualityPanel', () => {
   })
 })
 
-describe('toolMatchesSearch', () => {
-  const tool = { name: 'keeper_task_claim' }
-
-  it('returns true for empty query (no filter)', () => {
-    expect(toolMatchesSearch(tool, '')).toBe(true)
-    expect(toolMatchesSearch(tool, '   ')).toBe(true)
-  })
-
-  it('matches substring in the middle of the name', () => {
-    expect(toolMatchesSearch(tool, 'task')).toBe(true)
-    expect(toolMatchesSearch(tool, 'r_t')).toBe(true)
-  })
-
-  it('matches prefix and suffix', () => {
-    expect(toolMatchesSearch(tool, 'keeper')).toBe(true)
-    expect(toolMatchesSearch(tool, 'claim')).toBe(true)
-  })
-
-  it('is case-insensitive', () => {
-    expect(toolMatchesSearch(tool, 'TASK')).toBe(true)
-    expect(toolMatchesSearch(tool, 'Keeper')).toBe(true)
-    expect(toolMatchesSearch({ name: 'MASC_ToolName' }, 'toolname')).toBe(true)
-  })
-
-  it('ignores surrounding whitespace in the query', () => {
-    expect(toolMatchesSearch(tool, '  task  ')).toBe(true)
-  })
-
-  it('returns false for non-matching substring', () => {
-    expect(toolMatchesSearch(tool, 'xyz')).toBe(false)
-    expect(toolMatchesSearch(tool, 'cascade')).toBe(false)
-  })
-})
-
 describe('classifyCoverageError', () => {
   it('returns null for empty / missing input', () => {
     expect(classifyCoverageError(null)).toBeNull()
@@ -608,53 +572,5 @@ describe('pickAxisLabelIndices', () => {
       expect(indices[0]).toBe(0)
       expect(indices[indices.length - 1]).toBe(n - 1)
     }
-  })
-})
-
-describe('filterTools', () => {
-  const tools = [
-    { name: 'keeper_task_claim' },
-    { name: 'keeper_task_done' },
-    { name: 'masc_broadcast' },
-    { name: 'cascade_route' },
-    { name: 'read_file' },
-  ]
-
-  it('returns the input reference when query is empty', () => {
-    expect(filterTools(tools, '')).toBe(tools)
-    expect(filterTools(tools, '   ')).toBe(tools)
-  })
-
-  it('returns only tools whose name contains the query', () => {
-    const result = filterTools(tools, 'task')
-    expect(result.map(t => t.name)).toEqual([
-      'keeper_task_claim',
-      'keeper_task_done',
-    ])
-  })
-
-  it('is case-insensitive', () => {
-    const result = filterTools(tools, 'KEEPER')
-    expect(result).toHaveLength(2)
-    expect(result.every(t => t.name.includes('keeper'))).toBe(true)
-  })
-
-  it('returns an empty array when nothing matches', () => {
-    expect(filterTools(tools, 'zzz')).toEqual([])
-  })
-
-  it('does not mutate the source array', () => {
-    const snapshot = tools.map(t => t.name)
-    filterTools(tools, 'task')
-    expect(tools.map(t => t.name)).toEqual(snapshot)
-  })
-
-  it('preserves extra fields on the input objects', () => {
-    const rich = [
-      { name: 'alpha', calls: 10 },
-      { name: 'beta', calls: 20 },
-    ]
-    const result = filterTools(rich, 'alpha')
-    expect(result).toEqual([{ name: 'alpha', calls: 10 }])
   })
 })

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -22,6 +22,7 @@ import {
   coverageGapDisplay,
 } from './common/source-health'
 import { CoverageGapBlock } from './common/coverage-gap-block'
+import { filterTools } from './tool-metrics'
 
 const TOOL_QUALITY_WINDOW_HOURS = 24
 
@@ -109,19 +110,7 @@ const successColor = computed(() => {
   return 'text-[var(--bad-light)]'
 })
 
-// Per-tool search (case-insensitive substring on raw tool name).
-// Kept as a pure function so it can be tested in isolation and re-used if the
-// tool table later moves out of this panel.
 const toolSearchQuery = signal('')
-
-// Re-export from SSOT — identical logic in tool-metrics.ts. As of 2026-05-27,
-// `filterTools` is also re-exported (was previously a duplicate 2-arg
-// implementation here). The SSOT 3-arg variant defaults `category` to
-// `'all'`, so existing 2-arg callers (`filterTools(tools, query)`) keep
-// working through this re-export and the test in `tool-quality-panel.test.ts`
-// imports the same symbol path it always did.
-import { filterTools, toolMatchesSearch } from './tool-metrics'
-export { filterTools, toolMatchesSearch }
 
 function RateGauge({ rate, label }: { rate: number; label: string }) {
   const fillClass = rate >= 95 ? 'bg-[var(--ok-10)]' : rate >= 90 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'


### PR DESCRIPTION
Summary
- remove the tool-quality-panel re-export path for filterTools/toolMatchesSearch
- keep ToolQualityPanel consuming filterTools from the owning tool-metrics module
- drop duplicate panel tests now covered by tool-metrics.test.ts

Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/tool-quality-panel.test.ts src/components/tool-metrics.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/tool-quality-panel.ts src/components/tool-quality-panel.test.ts src/components/tool-metrics.ts src/components/tool-metrics.test.ts (test files ignored by current eslint config; no errors)
- git diff --check origin/main