### PR TITLE
fix(log): replace remaining Format/Printf.eprintf with Log calls (7 sites)

### DIFF
--- a/lib/cdal_runtime/mode_enforcer.ml
+++ b/lib/cdal_runtime/mode_enforcer.ml
@@ -1,3 +1,5 @@
+let _log = Log.create ~module_name:"mode_enforcer" ()
+
 type tool_effect_class =
   | Read_only
   | Local_mutation
@@ -542,11 +544,11 @@ let hooks st =
            | PreToolUse { tool_use_id; tool_name; input; turn; _ } ->
              (match check_violation st ~tool_use_id ~tool_name ~input ~turn with
               | Some v ->
-                Format.eprintf
-                  "[mode_enforcer] SKIP tool=%s kind=%s mode=%s@."
-                  tool_name
-                  (violation_kind_to_string v.violation_kind)
-                  (Execution_mode.to_string v.effective_mode);
+                Log.debug _log "mode enforcement skip"
+                  [ Log.S ("tool", tool_name)
+                  ; Log.S ("kind", violation_kind_to_string v.violation_kind)
+                  ; Log.S ("mode", Execution_mode.to_string v.effective_mode)
+                  ];
                 Skip
               | None -> Continue)
            | _ -> Continue)

--- a/lib/opentelemetry_client_cohttp_eio.ml
+++ b/lib/opentelemetry_client_cohttp_eio.ml
@@ -68,19 +68,19 @@ let n_dropped = Atomic.make 0
 
 let report_err_ = function
   | `Sysbreak -> Log.warn "opentelemetry: ctrl-c captured, stopping"
-  | `Failure msg -> Format.eprintf "@[<2>opentelemetry: export failed: %s@]@." msg
+  | `Failure msg -> Log.warn "opentelemetry: export failed: %s" msg
   | `Status (code, { Opentelemetry.Proto.Status.code = scode; message; details }) ->
-    let pp_details out l =
-      List.iter (fun s -> Format.fprintf out "%S;@ " (Bytes.unsafe_to_string s)) l
+    let details_str =
+      List.map (fun s -> Bytes.unsafe_to_string s) details
+      |> String.concat "; "
     in
-    Format.eprintf
-      "@[<2>opentelemetry: export failed with@ http code=%d@ status {@[code=%ld;@ \
-       message=%S;@ details=[@[%a@]]@]}@]@."
+    Log.warn
+      "opentelemetry: export failed with http code=%d status={code=%ld; message=%S; \
+       details=[%s]}"
       code
       scode
       (Bytes.unsafe_to_string message)
-      pp_details
-      details
+      details_str
 ;;
 
 module Httpc : sig
@@ -314,7 +314,7 @@ let mk_emitter ~stop ~clock ~net (config : Config.t) : (module EMITTER) =
       List.iter
         (fun f ->
            try f () with
-           | e -> Printf.eprintf "on tick callback raised: %s\n" (Printexc.to_string e))
+           | e -> Log.warn "opentelemetry: on tick callback raised: %s" (Printexc.to_string e))
         (AList.get @@ Atomic.get on_tick_cbs_)
     ;;
   end in
@@ -356,10 +356,9 @@ module Backend (Emitter : EMITTER) : Opentelemetry.Collector.BACKEND = struct
           (if Config.Env.get_debug ()
            then
              let@ () = Lock.with_lock in
-             Format.eprintf
-               "send spans %a@."
-               (Format.pp_print_list Trace.pp_resource_spans)
-               l);
+             Log.debug "opentelemetry: send spans %s"
+               (Format.asprintf "%a"
+                  (Format.pp_print_list Trace.pp_resource_spans) l));
           push_trace l;
           ret ())
     }
@@ -413,10 +412,9 @@ module Backend (Emitter : EMITTER) : Opentelemetry.Collector.BACKEND = struct
           (if Config.Env.get_debug ()
            then
              let@ () = Lock.with_lock in
-             Format.eprintf
-               "send metrics %a@."
-               (Format.pp_print_list Metrics.pp_resource_metrics)
-               m);
+             Log.debug "opentelemetry: send metrics %s"
+               (Format.asprintf "%a"
+                  (Format.pp_print_list Metrics.pp_resource_metrics) m));
           let m = List.rev_append (additional_metrics ()) m in
           push_metrics m;
           ret ())
@@ -429,10 +427,9 @@ module Backend (Emitter : EMITTER) : Opentelemetry.Collector.BACKEND = struct
           (if Config.Env.get_debug ()
            then
              let@ () = Lock.with_lock in
-             Format.eprintf
-               "send logs %a@."
-               (Format.pp_print_list Logs.pp_resource_logs)
-               m);
+             Log.debug "opentelemetry: send logs %s"
+               (Format.asprintf "%a"
+                  (Format.pp_print_list Logs.pp_resource_logs) m));
           push_logs m;
           ret ())
     }


### PR DESCRIPTION
## Summary
- Replace 7 remaining `Format.eprintf`/`Printf.eprintf` sites with proper structured `Log` calls
- `opentelemetry_client_cohttp_eio.ml`: 6 sites (report_err_ Failure/Status, run_tick_callbacks, debug send_{spans,metrics,logs})
- `cdal_runtime/mode_enforcer.ml`: 1 site (enforcement skip notification using OAS structured Log)

## Conversion technique
- `Format.eprintf "%a@." pp x` → `Log.debug "msg %s" (Format.asprintf "%a" pp x)` (%a pretty-printer serialization)
- `Printf.eprintf "msg %s\n%!" arg` → `Log.warn "msg %s" arg` (direct format-string Log)
- OAS structured Log: `Log.debug _log "msg" [Log.S("key","val"); ...]` (mode_enforcer only)

## Intentionally unconverted sites
| File | Reason |
|------|--------|
| `masc_log/log.ml` (10 sites) | Is the Log module itself |
| `fs_compat/fs_compat.ml` (3 sites) | No Log dependency |
| `fs_compat/atomic_write.ml` (1 site) | No Log dependency |
| `masc_http_client/pool.ml` (1 site) | No Log dependency |
| `cdal_runtime/proof_store.ml` (1 site) | Fallback stderr when Log has no sink |
| `cdal_runtime/contract_runner.ml` (1 site) | Fallback stderr when Log has no sink |

## Test plan
- [x] `dune build @check` passes (full type-check)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>