### PR TITLE
Remove tool call duration formatter alias

### DIFF
--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -11,7 +11,8 @@ import { TextInput } from './common/input'
 import { DashboardFeedSourceStrip } from './common/dashboard-feed-source-strip'
 import { agentTimeline } from './agent-detail-state'
 import { trimText } from '../lib/truncate'
-import { toolCategory, durationColor, formatDuration, formatArgs } from './tool-call-shared'
+import { formatMsCompact } from '../lib/format-number'
+import { toolCategory, durationColor, formatArgs } from './tool-call-shared'
 import type { AgentTimelineEvent } from '../api'
 
 function timelineEventIcon(type: string): string {
@@ -111,7 +112,7 @@ function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }
         <span class="text-xs font-mono font-medium ${cat.color} truncate max-w-50" title=${toolName}>${toolName}</span>
         <span class="text-3xs px-1 py-0.5 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-disabled)]">${cat.label}</span>
         ${durationMs != null
-          ? html`<span class="text-2xs font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span>`
+          ? html`<span class="text-2xs font-mono ${durationColor(durationMs)}">${formatMsCompact(durationMs)}</span>`
           : null}
         ${success
           ? html`<span class="text-3xs px-1 py-0.5 rounded-[var(--r-1)] bg-[var(--ok-soft)] text-[var(--color-status-ok)]">ok</span>`

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -11,7 +11,7 @@ import {
   fetchKeeperRuntimeTrace,
   type KeeperRuntimeTraceResponse,
 } from '../api/keeper'
-import { formatCost } from '../lib/format-number'
+import { formatCost, formatMsCompact } from '../lib/format-number'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { keepers } from '../store'
 import type { Keeper } from '../types'
@@ -33,7 +33,6 @@ import {
 import {
   durationColor,
   formatArgs,
-  formatDuration,
   normalizeToolName,
   toolCategory,
 } from './tool-call-shared'
@@ -128,7 +127,7 @@ function formatTimestamp(ms: number | null): string {
 
 function formatMaybeDuration(ms: number | null): string {
   return typeof ms === 'number' && Number.isFinite(ms) && ms > 0
-    ? formatDuration(ms)
+    ? formatMsCompact(ms)
     : 'not recorded'
 }
 

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -7,10 +7,11 @@ import { useSignal } from '@preact/signals'
 import { fetchKeeperToolCalls } from '../api/dashboard'
 import type { ToolCallEntry, ToolCallsResponse, TelemetryFreshnessMetadata } from '../api/dashboard'
 import { formatTimeHms } from '../lib/format-time'
+import { formatMsCompact } from '../lib/format-number'
 import { LoadingState } from './common/feedback-state'
 import { asRecord, mergeRouteRecord, hasRouteContext, type MutableRouteContext } from './common/normalize'
 import { SectionCap } from './common/section-cap'
-import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
+import { toolCategory, durationColor } from './tool-call-shared'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { parseToolBlobMarker } from '../lib/tool-blob-marker'
 import { CopyIdButton } from './common/copy-id-button'
@@ -188,7 +189,7 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
         <span class="font-mono text-[var(--color-fg-secondary)] flex-shrink-0 w-16">${formatTimestamp(entry.ts)}</span>
         <span class="font-mono font-medium text-[var(--color-fg-secondary)] truncate flex-1" title=${entry.tool}>${entry.tool}</span>
         <span class=${`font-mono flex-shrink-0 w-16 text-right ${durationColor(entry.duration_ms)}`}>
-          ${formatDuration(entry.duration_ms)}
+          ${formatMsCompact(entry.duration_ms)}
         </span>
         <span class=${`flex-shrink-0 w-5 text-center ${entry.success ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-err)]'}`}>
           ${entry.success ? 'O' : 'X'}

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -6,8 +6,8 @@ import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import { fetchKeeperToolStats } from '../api/dashboard'
 import type { ToolStat, HourlyBucket, ToolStatsResponse, TelemetryFreshnessMetadata } from '../api/dashboard'
-import { toolCategory, formatDuration, durationColor, normalizeToolName } from './tool-call-shared'
-import { formatCost } from '../lib/format-number'
+import { toolCategory, durationColor, normalizeToolName } from './tool-call-shared'
+import { formatCost, formatMsCompact } from '../lib/format-number'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { TextInput } from './common/input'
 import { SectionCap } from './common/section-cap'
@@ -301,7 +301,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
               </div>
               <span class="w-8 text-right text-2xs font-mono text-[var(--color-fg-muted)]">${stat.call_count}</span>
               <span class="w-14 text-right text-3xs font-mono ${durationColor(stat.avg_duration_ms)}">
-                ${formatDuration(stat.avg_duration_ms)}
+                ${formatMsCompact(stat.avg_duration_ms)}
               </span>
             </div>
           `
@@ -332,8 +332,8 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
             <div class="flex items-center justify-between py-1 px-2 rounded-[var(--r-1)] bg-[var(--color-bg-surface)]">
               <span class="text-2xs font-mono text-[var(--color-fg-muted)]">${normalizeToolName(stat.name)}</span>
               <div class="flex items-center gap-3">
-                <span class="text-3xs text-[var(--color-fg-disabled)]">avg ${formatDuration(stat.avg_duration_ms)}</span>
-                <span class="text-2xs font-mono font-medium ${durationColor(stat.p95_duration_ms)}">p95 ${formatDuration(stat.p95_duration_ms)}</span>
+                <span class="text-3xs text-[var(--color-fg-disabled)]">avg ${formatMsCompact(stat.avg_duration_ms)}</span>
+                <span class="text-2xs font-mono font-medium ${durationColor(stat.p95_duration_ms)}">p95 ${formatMsCompact(stat.p95_duration_ms)}</span>
               </div>
             </div>
           `)}

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -9,8 +9,8 @@ import { Markdown } from '../common/markdown'
 import { ProgressBar } from '../common/progress-bar'
 import { truncate } from '../../lib/truncate'
 import { asNullableString, asRecord, extractCodeLocation, type CodeLocation } from '../common/normalize'
-import { formatCost } from '../../lib/format-number'
-import { toolCategory, durationColor, formatDuration, formatArgs as sharedFormatArgs } from '../tool-call-shared'
+import { formatCost, formatMsCompact } from '../../lib/format-number'
+import { toolCategory, durationColor, formatArgs as sharedFormatArgs } from '../tool-call-shared'
 import { SectionHeader } from '../common/section-header'
 import {
   openIdeContextRouteLink,
@@ -532,7 +532,7 @@ function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
       ${event.cost_usd != null && event.cost_usd > 0 ? html`
         <div class="flex gap-3 text-3xs text-[var(--color-fg-disabled)]">
           <span>비용: <span class="font-mono text-[var(--color-accent-fg)]">${formatCost(event.cost_usd)}</span></span>
-          ${event.duration_ms != null ? html`<span>소요: <span class="font-mono ${durationColor(event.duration_ms)}">${formatDuration(event.duration_ms)}</span></span>` : null}
+          ${event.duration_ms != null ? html`<span>소요: <span class="font-mono ${durationColor(event.duration_ms)}">${formatMsCompact(event.duration_ms)}</span></span>` : null}
         </div>
       ` : null}
     </div>
@@ -680,7 +680,7 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
         <div class="flex items-center gap-3 text-xs flex-wrap">
           <span><span class="text-[var(--color-fg-disabled)]">출력:</span> <span class="font-mono">${outputTokens.toLocaleString()}tok</span></span>
           <span><span class="text-[var(--color-fg-disabled)]">종료:</span> <span class="font-mono ${stopColor}">${stopReason}</span></span>
-          ${durationMs != null ? html`<span><span class="text-[var(--color-fg-disabled)]">소요:</span> <span class="font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span></span>` : null}
+          ${durationMs != null ? html`<span><span class="text-[var(--color-fg-disabled)]">소요:</span> <span class="font-mono ${durationColor(durationMs)}">${formatMsCompact(durationMs)}</span></span>` : null}
           ${turn != null ? html`<span><span class="text-[var(--color-fg-disabled)]">턴:</span> <span class="font-mono">${String(turn)}</span></span>` : null}
         </div>
         ${responseText ? html`
@@ -800,7 +800,7 @@ export function SessionTraceEntry({ event, searchQuery }: { event: UnifiedTraceE
       ${'' /* Right side: duration + time */}
       <div class="flex-shrink-0 flex flex-col items-end gap-0.5">
         ${event.duration_ms != null ? html`
-          <span class="text-2xs font-mono ${durationColor(event.duration_ms)}">${formatDuration(event.duration_ms)}</span>
+          <span class="text-2xs font-mono ${durationColor(event.duration_ms)}">${formatMsCompact(event.duration_ms)}</span>
         ` : null}
         <${TimeAgo} timestamp=${event.ts_iso} class="text-3xs text-[var(--color-fg-disabled)]" />
       </div>

--- a/dashboard/src/components/tool-call-shared.test.ts
+++ b/dashboard/src/components/tool-call-shared.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
   toolCategory,
-  formatDuration,
   summarizeEntries,
   durationColor,
   formatArgs,
@@ -69,40 +68,6 @@ describe('toolCategory', () => {
   it('matches memory category', () => {
     const result = toolCategory('memory_recall')
     expect(result.label).toBe('memory')
-  })
-})
-
-// ================================================================
-// formatDuration (tool-call-shared version, milliseconds)
-// ================================================================
-
-describe('formatDuration', () => {
-  it('formats milliseconds', () => {
-    expect(formatDuration(500)).toBe('500ms')
-  })
-
-  it('formats seconds', () => {
-    expect(formatDuration(1500)).toBe('1.5s')
-  })
-
-  it('formats minutes', () => {
-    expect(formatDuration(90000)).toBe('1.5m')
-  })
-
-  it('rounds milliseconds', () => {
-    expect(formatDuration(499)).toBe('499ms')
-  })
-
-  it('formats 0 as 0ms', () => {
-    expect(formatDuration(0)).toBe('0ms')
-  })
-
-  it('formats exactly 1 second', () => {
-    expect(formatDuration(1000)).toBe('1.0s')
-  })
-
-  it('formats exactly 1 minute', () => {
-    expect(formatDuration(60000)).toBe('1.0m')
   })
 })
 

--- a/dashboard/src/components/tool-call-shared.ts
+++ b/dashboard/src/components/tool-call-shared.ts
@@ -2,7 +2,6 @@
 // and tool-call-timeline components.
 
 import { truncate } from '../lib/truncate'
-import { formatMsCompact } from '../lib/format-number'
 
 // ── Constants ────────────────────────────────────────────
 
@@ -82,9 +81,6 @@ export function toolCategory(name: string): ToolCategoryResult {
   const found = TOOL_CATEGORIES.find(c => c.match(name))
   return found ?? DEFAULT_TOOL_STYLE
 }
-
-/** Format duration as human-readable string with unit. */
-export const formatDuration = formatMsCompact
 
 /** Summarize a list of trajectory entries: total duration, success count, error count. */
 export function summarizeEntries(entries: Array<{ duration_ms?: number; error?: string | null }>): {

--- a/dashboard/src/lib/format-number.test.ts
+++ b/dashboard/src/lib/format-number.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { describe, expect, it } from 'vitest'
-import { formatPct, formatPct1, formatTokens, formatNumber, formatCost } from './format-number'
+import { formatPct, formatPct1, formatTokens, formatNumber, formatCost, formatMsCompact } from './format-number'
 
 describe('formatPct', () => {
   it('formats 0 as 0%', () => {
@@ -171,5 +171,32 @@ describe('formatCost', () => {
 
   it('uses custom fallback', () => {
     expect(formatCost(null, 'N/A')).toBe('N/A')
+  })
+})
+
+describe('formatMsCompact', () => {
+  it('formats milliseconds', () => {
+    expect(formatMsCompact(500)).toBe('500ms')
+  })
+
+  it('formats seconds', () => {
+    expect(formatMsCompact(1500)).toBe('1.5s')
+  })
+
+  it('formats minutes', () => {
+    expect(formatMsCompact(90000)).toBe('1.5m')
+  })
+
+  it('rounds milliseconds', () => {
+    expect(formatMsCompact(499)).toBe('499ms')
+  })
+
+  it('formats 0 as 0ms', () => {
+    expect(formatMsCompact(0)).toBe('0ms')
+  })
+
+  it('formats exact unit boundaries', () => {
+    expect(formatMsCompact(1000)).toBe('1.0s')
+    expect(formatMsCompact(60000)).toBe('1.0m')
   })
 })


### PR DESCRIPTION
Summary
- remove the tool-call-shared formatDuration alias over formatMsCompact
- update tool-call UI call sites to import formatMsCompact from the owning format-number module
- move millisecond formatter coverage from tool-call-shared.test.ts to format-number.test.ts

Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/tool-call-shared.test.ts src/lib/format-number.test.ts --no-file-parallelism --maxWorkers=1
- pnpm vitest run --config vitest.config.ts src/components/keeper-tool-call-inspector-render.test.ts src/components/keeper-tool-call-inspector.test.ts src/components/keeper-tool-telemetry.test.ts src/components/agent-detail-timeline.test.ts src/components/journey-panel.test.ts src/components/session-trace/session-trace-entry.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/tool-call-shared.ts src/components/tool-call-shared.test.ts src/lib/format-number.test.ts src/components/keeper-tool-telemetry.ts src/components/keeper-tool-call-inspector.ts src/components/journey-panel.ts src/components/agent-detail-timeline.ts src/components/session-trace/session-trace-entry.ts (test files ignored by current eslint config; no errors)
- git diff --check origin/main