### PR TITLE
perf(dashboard/fleet): extend tool-quality 5s→30s, feature-health 10s→60s

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -718,8 +718,13 @@ let rec add_routes ~sw ~clock router =
               | Some w -> Printf.sprintf "%.2f" w
               | None -> "-")
          in
+         (* TTL extended 5s→30s — [aggregate ~n:5000] over a 24h window was
+            measured at 30s cache miss (curl --max-time 30 timeout in the
+            page→endpoint profile). The window itself is hours-scale so
+            6× longer TTL still serves near-live data; under 30s window the
+            poll just hit the previous compute and never wait 30s again. *)
          let json =
-           Dashboard_cache.get_or_compute cache_key ~ttl:5.0 (fun () ->
+           Dashboard_cache.get_or_compute cache_key ~ttl:30.0 (fun () ->
              Domain_pool_ref.submit_io_or_inline (fun () ->
                Dashboard_http_tool_quality.aggregate ~n ?window_hours ()))
          in
@@ -810,8 +815,12 @@ let rec add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/feature-health" (fun _request reqd ->
        with_public_read (fun _state req reqd ->
          let cache_key = "feature_health" in
+         (* TTL extended 10s→60s — feature flags + provider rollups move on
+            minute scale, but the compute was measured at 3.5s (page→endpoint
+            profile, cold or near-expiry). 10s TTL means every 11th poll
+            eats 3.5s; 60s collapses to 1/60 polls. *)
          let json =
-           Dashboard_cache.get_or_compute cache_key ~ttl:10.0 (fun () ->
+           Dashboard_cache.get_or_compute cache_key ~ttl:60.0 (fun () ->
              Domain_pool_ref.submit_io_or_inline (fun () ->
                Dashboard_feature_health.json ()))
          in


### PR DESCRIPTION
## Summary

Dashboard 의 *cache-already-applied* 두 endpoint 의 TTL 을 측정 기반으로 연장. Cache miss latency 가 무거운 endpoint 의 reuse window 6배 확장 → cold-miss 빈도 ~6배 감소.

| Endpoint | TTL (전) | TTL (후) | Cache miss 측정 |
|---|---|---|---|
| `/api/v1/dashboard/tool-quality` | 5s | **30s** | 30s timeout (n=5000, windowHours=24) |
| `/api/v1/dashboard/feature-health` | 10s | **60s** | 3.5s (feature flag + provider rollup) |

## Evidence

Live 서버에서 sequential measurement (curl single-thread):

```
shell:           0.18s  ← snapshot wait-free
namespace-truth: 0.06s  ← snapshot wait-free
cache-stats:     1.20s  ← warm second call
feature-health:  3.50s  ← cache miss (10s TTL 너무 짧음)
tool-quality:    30s timeout  ← cache miss (5s TTL 매우 짧음, n=5000 fold 무거움)
```

`/api/v1/dashboard/cache-stats` overall:
- entries: 62 / max 256
- **hit_ratio: 0.504 (50.4%)** — 절반이 miss
- fresh: 2, stale: 24, expired: 36 — 진짜 fresh 거의 없음

→ TTL 이 endpoint 의 polling cadence 보다 짧아서 *매번 cache 만료* 후 fetch.

## Fix

tool-quality TTL 5s → 30s, feature-health 10s → 60s. 두 endpoint 모두 *cache+offload 이미 적용*된 상태. compute 자체는 안 바꿈, TTL constant 만 변경.

### Why TTL extend 이 정당한가

**tool-quality** (n=5000, 24h window):
- `windowHours=24` 이라는 query param 자체가 *24시간* window 의 data — 분-단위 movement
- 5s TTL은 *micro-second polling* 도 못 막을 정도로 짧음
- 30s 도 window 의 1/2880 — staleness 무의미

**feature-health** (provider rollups + feature flags):
- 측정 기반: `Dashboard_feature_health.json ()` 3.5s
- 10s TTL 이면 fetch every 11s = 매 fetch 마다 cold miss
- feature flag 변경 빈도 = 분-단위, 60s 도 충분 fresh

## Workaround Signature Gate

- counter-as-fix? NO — latency reduction
- substring 분류기? NO
- N-of-M patch? NO — TTL constant 만 변경 (1-line each)
- cap/cooldown/dedup? cache TTL 은 dedup 의 한 형태이지만, 측정 evidence 기반 *tuning* — 같은 pattern 의 PR #19097 (cascade TTL 2/5/10s → 10/30s) 가 이미 precedent

## Build

```
$ dune build lib/server
EXIT=0
```

## Test plan

- [ ] CI build PASS
- [ ] 서버 재시작 후 `/tool-quality?n=5000&windowHours=24` 첫 호출: cold (~30s)
- [ ] 2 호출 (30s 안에): cache hit, <100ms
- [ ] Fleet panel 5-fetch concurrent 시 wall time 감소 측정
- [ ] `/feature-health` 동일 패턴 (~3.5s → cached)

## Limitations

- **TTL extend ≠ snapshot warm-up**: 첫 cold miss latency 는 그대로. 사용자에게 *cold start* 시점에 30s wait 가능성 유지. 진짜 fix 는 RFC-0138 패턴 (background refresh fiber + atomic read) — 75-120 LoC, 별도 PR.
- **24h window 의 underlying data 변경 빈도**: TTL 30s 가 stale 가능. 단 dashboard 가 24h window 를 *통계* 로 보기 때문에 1분 staleness 도 무영향.

## Related

- PR #19088 — cascade GET cache (4 endpoints)
- PR #19097 — cascade offload + TTL tune (PR #19088 follow-up, precedent)
- PR #19100, #19146, #19150 — 같은 시리즈
- batch2 (in-flight) — governance/tool-events + heuristics/coverage cache+offload
- **본 PR** — Fleet 5-fetch panel 의 cache-miss latency 측정 기반 TTL 연장
