### PR TITLE
refactor(server-routes/dashboard-setup): narrow executable_file_exists wildcard catch (RFC-0145)

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard_setup.ml
+++ b/lib/server/server_routes_http_routes_dashboard_setup.ml
@@ -69,13 +69,19 @@ let dashboard_dev_token_path = Server_routes_http_dashboard_dev_token.dashboard_
 let ensure_dashboard_dev_token = Server_routes_http_dashboard_dev_token.ensure_dashboard_dev_token
 
 let executable_file_exists path =
+  (* RFC-0145 — narrow from a wildcard catch-all to the only exceptions
+     [Sys.is_directory] and [Unix.access] raise when the path is
+     missing, not a directory, or not executable.  Other runtime
+     exceptions propagate so we do not silently report a healthy
+     filesystem as non-executable. *)
   try
     Sys.file_exists path
     && not (Sys.is_directory path)
     &&
     (Unix.access path [ Unix.X_OK ];
      true)
-  with _ -> false
+  with
+  | Sys_error _ | Unix.Unix_error _ -> false
 
 let append_unique candidate acc =
   match candidate with


### PR DESCRIPTION
## 요약

RFC-0145 — Wildcard catch-all → typed exception narrowing. `lib/server/server_routes_http_routes_dashboard_setup.ml:71-78` `executable_file_exists`. 시리즈 누적 3 사이트.

### 문제

```ocaml
(* before *)
let executable_file_exists path =
  try
    Sys.file_exists path
    && not (Sys.is_directory path)
    &&
    (Unix.access path [ Unix.X_OK ];
     true)
  with _ -> false
```

`with _ ->` 가 *모든 예외 삼킴*. 의도: missing/non-executable file 검출. 실제: `Out_of_memory`, `Stack_overflow`, async cancellation 까지 *false 로 silent*.

### 해결

```ocaml
(* after *)
let executable_file_exists path =
  (* RFC-0145 — narrow from a wildcard catch-all to the only exceptions
     [Sys.is_directory] and [Unix.access] raise when the path is
     missing, not a directory, or not executable.  Other runtime
     exceptions propagate so we do not silently report a healthy
     filesystem as non-executable. *)
  try
    Sys.file_exists path
    && not (Sys.is_directory path)
    &&
    (Unix.access path [ Unix.X_OK ];
     true)
  with
  | Sys_error _ | Unix.Unix_error _ -> false
```

3 검사 함수의 raise surface:
- `Sys.file_exists` — raise 안 함 (per docs)
- `Sys.is_directory` — `Sys_error` (path 없음/permission)
- `Unix.access` — `Unix.Unix_error` (file 미존재 / not executable)

narrow → `Sys_error _ | Unix.Unix_error _`.

### 동작 무변경

- 의도된 case (missing / non-executable file) 는 *Sys_error/Unix_error* → `false` (기존과 동일)
- 비의도 case (OOM, stack overflow, async cancel) 는 *propagate* (기존엔 false 로 silent)

## 변경

- 1 file, +7/-1
- 1 wildcard catch narrow
- `dune build lib/` PASS for affected file

## ⚠️ Upstream breakage 주의

main HEAD `c8d3778e4` 의 `lib/keeper/keeper_turn_driver_try_cascade.ml:604` 가 `Agent_sdk.Error.Timeout` 사용하지만 그 constructor 는 `Agent_sdk.Error` 모듈에 직접 export 안 됨 (실제 위치: `Retry.api_error` variant). PR #19145 (RFC-0197 watchdog) 영향. 본 PR 의 변경과 *완전 무관* — keeper 영역 안 건드림. 단 full-tree `dune build` 는 그 upstream 에러 surface 가능 — keeper 영역 hotfix 가 lands 되면 본 PR CI 도 정상.

## Out-of-scope

- `cascade_tier_admission.ml:102` (`release_quietly`) — finally clause, 의도된 catch-all (manifest §"finally 예외 내부 처리"). RFC-0145 narrow 부적절.
- `cascade_tier_wait_scheduler.ml:222, 298` — 같은 finally 정당화.

## Workaround Signature Gate

WORKAROUND-WAIVED: Silent Failure 안티패턴 *제거*. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 1 site 정리 + 정당화된 사이트 skip 명시

## Related

- PR #19151 (OPEN) — 같은 RFC-0145 narrow series (int_of_string + Unix.stat)
- RFC-0145 — exception narrowing 패턴

🤖 Generated with [Claude Code](https://claude.com/claude-code)
