### PR TITLE
hotfix(keeper-turn-driver): drop incorrect Agent_sdk.Error prefix on Timeout — main HEAD broken since #19145

### DIFF
--- a/lib/keeper/keeper_turn_driver_try_cascade.ml
+++ b/lib/keeper/keeper_turn_driver_try_cascade.ml
@@ -599,9 +599,15 @@ let rec run
             ctx.cascade_name
             t;
           let result =
+            (* The [Timeout] constructor lives on [Retry.api_error]
+               (aliased as [Agent_sdk.Error.api_error]); it is not a
+               direct member of [Agent_sdk.Error] itself.  The
+               surrounding [Api] constructor's payload type pins the
+               namespace, so [Timeout] resolves without an outer
+               module prefix. *)
             Error
               (Agent_sdk.Error.Api
-                 (Agent_sdk.Error.Timeout
+                 (Timeout
                     { message =
                         Printf.sprintf
                           "Per-candidate watchdog timeout after %.1fs"


### PR DESCRIPTION
## ⚠️ HOTFIX — main HEAD broken since PR #19145

origin/main `b67f6d82a` 의 `lib/keeper/keeper_turn_driver_try_cascade.ml:604` 가 `dune build lib/` fail:

```
File "lib/keeper/keeper_turn_driver_try_cascade.ml", line 604, characters 18-41:
604 |                  (Agent_sdk.Error.Timeout
                        ^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound constructor Agent_sdk.Error.Timeout
```

PR #19145 (RFC-0197 per-candidate watchdog) 머지 후 *9 PR 동안 silent*:
- #19146, #19147, #19148, #19149, #19150, #19151, #19152, #19153, #19155, #19156, #19158, #19159 — keeper 영역 안 건드림 → CI `Build and Test` SKIPPED gate 통과.
- 본인 PR #19151 (RFC-0145 narrow) 머지 시점부터 새 PR base 가 broken main → `dune build lib/` 검증 시도하면 surface.

본 PR 의 patch 는 1 줄 (line 604):

```diff
- (Agent_sdk.Error.Api
-    (Agent_sdk.Error.Timeout
+ (Agent_sdk.Error.Api
+    (Timeout
        { message = ... }))
```

## 왜 prefix 변경?

`Timeout` 는 `Retry.api_error` variant (위치: `/Users/dancer/.opam/.../agent_sdk/llm_provider/retry.mli:43`).  `Agent_sdk.Error` 모듈에는 `type api_error = Retry.api_error` type alias 만 존재 — constructor 직접 export 안 됨.

OCaml constructor resolution: outer constructor `Agent_sdk.Error.Api : api_error -> sdk_error` 의 *payload type* (`api_error`) 가 inner constructor 의 namespace 를 *pin*. 따라서 `Timeout {...}` 만으로 컴파일러가 `Retry.api_error.Timeout` 로 resolve.

인라인 주석에 이 reasoning 명시 — 향후 reader 가 prefix 변경 시 같은 함정 회피.

## 영향

- `dune build lib/` PASS (main broken 해소)
- 동작 무변경 — constructor lookup 만 type-correct 화

## ⚠️ Silent breakage 시간선 분석 (docs/audit retrospective §2.5 패턴)

같은 패턴 두 번째 — PR #19099 (Magic Number 시리즈) 의 `dated_jsonl/dune` dep 누락 → 7 시간 silent + PR #19109 hotfix. 이번엔 **PR #19145 → main HEAD 동안 ~10 PR 머지** silent. CI gate `Detect Changed Surfaces` 의 *blind spot* 이 반복 surface 됨.

회고 문서 §4 체크리스트 보강 candidate:
- [ ] PR push 전 *full `dune build lib/`* 검증 (sub-library 만 검증 부족)
- [ ] CI `Build and Test` SKIPPED 상태 의심 — keeper/server/cdal core 영역 변경 시 manual `dune build` 필수

## Workaround Signature Gate

WORKAROUND-WAIVED: Production-blocking main breakage hotfix. 시그니처 3종 비해당:

- ❌ Counter-as-Fix
- ❌ String/substring 분류기
- ❌ N-of-M 패치 — 단일 surgical 1 line

## Related

- PR #19145 — RFC-0197 per-candidate watchdog (breakage 도입)
- PR #19099 / #19109 — 동일한 silent main breakage 패턴 (Magic Number 시리즈)
- docs/audit/2026-05-27-magic-number-time-literal-series-retrospective.md §2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
