### PR TITLE
Remove harness health timestamp alias

### DIFF
--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -154,8 +154,6 @@ export function statusCardClass(status: RailStatus): string {
   }
 }
 
-export const formatTimestamp = formatTimestampKo
-
 export function freshnessLabel(ts: number | null | undefined, fallback = '기록 없음'): string {
   if (ts == null) return fallback
   return formatTimeAgo(ts)
@@ -387,7 +385,7 @@ export function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
               <div>
                 <${ItemTitle}>${item.task_title || item.task_id}</${ItemTitle}>
                 <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
-                  ${item.agent_name || '(unknown agent)'} · ${item.gate || '(unknown gate)'} · ${item.evaluator_cascade || '(unknown cascade)'} · ${formatTimestamp(item.timestamp)}
+                  ${item.agent_name || '(unknown agent)'} · ${item.gate || '(unknown gate)'} · ${item.evaluator_cascade || '(unknown cascade)'} · ${formatTimestampKo(item.timestamp)}
                 </div>
               </div>
               <${StatusDot} size="md" class=${verdictTone(item.verdict)} />
@@ -432,7 +430,7 @@ export function PreCompactList({ section }: { section: HarnessSignalSection<PreC
           <${SurfaceCard} variant="compact">
             <div class="flex items-start justify-between gap-3">
               <${ItemTitle}>${item.keeper_name}</${ItemTitle}>
-              <div class="text-xs text-[var(--color-fg-muted)]">${formatTimestamp(item.timestamp)}</div>
+              <div class="text-xs text-[var(--color-fg-muted)]">${formatTimestampKo(item.timestamp)}</div>
             </div>
             <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--color-fg-primary)]">
               <span>컨텍스트 ${Math.round(item.context_ratio * 100)}%</span>
@@ -484,7 +482,7 @@ export function HandoffList({ section }: { section: HarnessSignalSection<Handoff
           <${SurfaceCard} variant="compact">
             <div class="flex items-start justify-between gap-3">
               <${ItemTitle}>${item.keeper_name}</${ItemTitle}>
-              <div class="text-xs text-[var(--color-fg-muted)]">${formatTimestamp(item.timestamp)}</div>
+              <div class="text-xs text-[var(--color-fg-muted)]">${formatTimestampKo(item.timestamp)}</div>
             </div>
             <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--color-fg-primary)]">
               <span>${item.generation}세대</span>

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -3,6 +3,7 @@
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { formatPct1 } from '../lib/format-number'
+import { formatTimestampKo } from '../lib/format-time'
 import { assertExhaustive } from '../lib/exhaustive'
 import { SectionCard } from './common/card'
 import { SectionCap } from './common/section-cap'
@@ -23,7 +24,6 @@ import type {
 import {
   railStatusLabel,
   freshnessLabel,
-  formatTimestamp,
   heroTitle,
   heroBody,
   railDetail,
@@ -308,7 +308,7 @@ export function HarnessHealth() {
           </div>
 
           <div class="mt-4 text-xs text-[var(--color-fg-disabled)]">
-            generated ${formatTimestamp(data.generated_at)} · 마지막 안전 신호 ${freshnessLabel(data.overview.last_signal_at)}
+            generated ${formatTimestampKo(data.generated_at)} · 마지막 안전 신호 ${freshnessLabel(data.overview.last_signal_at)}
           </div>
         </div>
 


### PR DESCRIPTION
Summary
- remove the harness-health-sections formatTimestamp alias over formatTimestampKo
- update harness health call sites to use the owning format-time formatter directly

Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/harness-health-sections.test.ts src/components/harness-health.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/harness-health.ts src/components/harness-health-sections.ts src/components/harness-health-sections.test.ts src/components/harness-health.test.ts (test files ignored by current eslint config; no errors)
- git diff --check origin/main