### PR TITLE
fix(keeper): align verifier tool policy surface

### DIFF
--- a/config/personas/verifier/profile.json
+++ b/config/personas/verifier/profile.json
@@ -21,8 +21,7 @@
       "masc_add_task",
       "masc_batch_add_tasks",
       "masc_claim_next",
-      "masc_deliver",
-      "masc_transition"
+      "masc_deliver"
     ],
     "mention_targets": [
       "verifier",

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -450,32 +450,6 @@ let failing_minimum_tool_names () : string list =
   shard_floor @ essential_masc_minimum_names
   |> List.sort_uniq String.compare
 
-let is_verifier_identity raw =
-  let normalized = String.trim raw |> String.lowercase_ascii in
-  String.equal normalized "verifier"
-  || String.equal normalized "keeper-verifier-agent"
-
-let is_verifier_meta (meta : keeper_meta) =
-  is_verifier_identity meta.name || is_verifier_identity meta.agent_name
-
-let verifier_disallowed_task_mutation_tools =
-  [ "keeper_task_claim"
-  ; "masc_claim_next"
-  ; "masc_transition"
-  ; "keeper_task_done"
-  ; "keeper_task_submit_for_verification"
-  ; "keeper_task_force_release"
-  ; "keeper_task_force_done"
-  ]
-
-let filter_verifier_tool_surface (meta : keeper_meta) names =
-  if not (is_verifier_meta meta)
-  then names
-  else
-    List.filter
-      (fun name -> not (List.mem name verifier_disallowed_task_mutation_tools))
-      names
-
 let keeper_allowed_tool_names ?(write_done = false)
     ?(phase = Keeper_state_machine.Running) (meta : keeper_meta) :
     string list =
@@ -489,7 +463,6 @@ let keeper_allowed_tool_names ?(write_done = false)
     let lookup = tool_access_lookup_of_meta meta in
     lookup.candidate_names
     |> List.filter (fun name -> filter_by_access ~lookup name)
-    |> filter_verifier_tool_surface meta
     |> dedupe_tool_names
 
 (** Universe tool names: candidates minus denied, no policy filter.

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -220,10 +220,13 @@ let test_verifier_config_hides_worker_lifecycle_tools () =
         | Error e -> fail (Printf.sprintf "verifier meta fixture: %s" e)
       in
       let lookup = KPolicy.tool_access_lookup_of_meta meta in
+      let visible_tools = KPolicy.keeper_allowed_tool_names meta in
       List.iter
         (fun tool_name ->
           check bool ("verifier keeps " ^ tool_name) true
-            (KPolicy.can_execute ~lookup tool_name))
+            (KPolicy.can_execute ~lookup tool_name);
+          check bool ("verifier exposes " ^ tool_name) true
+            (List.mem tool_name visible_tools))
         [
           "keeper_tasks_list";
           "masc_tasks";
@@ -233,7 +236,9 @@ let test_verifier_config_hides_worker_lifecycle_tools () =
       List.iter
         (fun tool_name ->
           check bool ("verifier hides " ^ tool_name) false
-            (KPolicy.can_execute ~lookup tool_name))
+            (KPolicy.can_execute ~lookup tool_name);
+          check bool ("verifier does not expose " ^ tool_name) false
+            (List.mem tool_name visible_tools))
         [
           "keeper_task_claim";
           "keeper_task_create";


### PR DESCRIPTION
## Summary
- remove the verifier-specific hardcoded tool surface filter from keeper tool policy
- keep verifier worker-flow blocks declarative via tool_denylist, while leaving masc_transition visible for approve/reject
- update verifier persona denylist and TOML validation coverage so visible surface and can_execute agree

## Verification
- PASS: jq empty config/personas/verifier/profile.json
- PASS: git diff --check
- ATTEMPTED: scripts/dune-local.sh build test/test_keeper_toml_config_validation.exe test/test_tool_task_coverage.exe
  - blocked by existing local compile error outside this diff: lib/keeper/keeper_turn_driver_try_cascade.ml:604 Unbound constructor Agent_sdk.Error.Timeout
