### PR TITLE
refactor(dashboard/board): centralise previewBoardMessage, drop 2 byte-identical previewContent copies

### DIFF
--- a/dashboard/src/components/board/mention-inbox.ts
+++ b/dashboard/src/components/board/mention-inbox.ts
@@ -5,8 +5,7 @@ import { ActionButton } from '../common/button'
 import { EmptyState } from '../common/feedback-state'
 import { RichContent } from '../common/rich-content'
 import { TimeAgo } from '../common/time-ago'
-import { stripStateBlocks } from '../../keeper-message'
-import { SYSTEM_MESSAGE_FROM, boardMessageRowKey } from '../../lib/board-utils'
+import { SYSTEM_MESSAGE_FROM, boardMessageRowKey, previewBoardMessage } from '../../lib/board-utils'
 import { currentDashboardActorName } from '../../lib/dashboard-session-actor'
 import { navigate } from '../../router'
 import { messages, shellAuthSummary } from '../../store'
@@ -121,12 +120,8 @@ export function buildMentionInboxModel(
   }
 }
 
-function previewContent(message: Message): string {
-  return stripStateBlocks(message.content).trim() || message.content.trim() || '(empty)'
-}
-
 function MessageRow({ row }: { row: MentionInboxRow }) {
-  const preview = previewContent(row.message)
+  const preview = previewBoardMessage(row.message)
   const hasState = row.message.content.includes('[STATE]')
   return html`
     <article class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3.5 py-3">

--- a/dashboard/src/components/board/message-room-timeline.ts
+++ b/dashboard/src/components/board/message-room-timeline.ts
@@ -5,8 +5,7 @@ import { ActionButton } from '../common/button'
 import { EmptyState } from '../common/feedback-state'
 import { RichContent } from '../common/rich-content'
 import { TimeAgo } from '../common/time-ago'
-import { stripStateBlocks } from '../../keeper-message'
-import { SYSTEM_MESSAGE_FROM, boardMessageRowKey } from '../../lib/board-utils'
+import { SYSTEM_MESSAGE_FROM, boardMessageRowKey, previewBoardMessage } from '../../lib/board-utils'
 import { navigate } from '../../router'
 import { messages } from '../../store'
 import type { Message } from '../../types'
@@ -93,12 +92,8 @@ export function buildMessageRoomModel(messageList: readonly Message[]): MessageR
   }
 }
 
-function previewContent(message: Message): string {
-  return stripStateBlocks(message.content).trim() || message.content.trim() || '(empty)'
-}
-
 function TimelineMessage({ row }: { row: TimelineRow }) {
-  const preview = previewContent(row.message)
+  const preview = previewBoardMessage(row.message)
   return html`
     <article class="grid grid-cols-[3rem_minmax(0,1fr)] gap-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3.5 py-3">
       <div class="pt-0.5 text-right text-3xs font-semibold tabular-nums uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">

--- a/dashboard/src/lib/board-utils.ts
+++ b/dashboard/src/lib/board-utils.ts
@@ -28,10 +28,31 @@ export function boardMessageRowKey(message: Message, index: number): string {
   return message.id ?? `${message.seq ?? 'message'}-${index}`
 }
 
+/**
+ * One-line preview text for a board `Message`.
+ *
+ * Prefers the state-stripped content (so a message that's *only* a
+ * state block falls through to either raw content or `'(empty)'`).
+ * The state-only case is what differentiates this fallback chain from
+ * the `state-block-messages` panel's variant, which intentionally
+ * surfaces `'(state-only message)'` instead because that view is
+ * specifically for state-block traffic.
+ *
+ * Two board panels (`mention-inbox`, `message-room-timeline`) shipped
+ * this exact body file-internal as `previewContent`. The third panel
+ * (`state-block-messages`) stays on its own variant — its empty branch
+ * is `'(state-only message)'` rather than `'(empty)'`, and the fallback
+ * chain skips the raw content step.
+ */
+export function previewBoardMessage(message: Message): string {
+  return stripStateBlocks(message.content).trim() || message.content.trim() || '(empty)'
+}
+
 import { navigate } from '../router'
 import type { Message } from '../types'
 import { findKeeper } from './keeper-utils'
 import { openKeeperDetail } from '../components/keeper-detail'
+import { stripStateBlocks } from '../keeper-message'
 import type { BoardActorIdentity, BoardContributorQuality } from '../types'
 
 /** Strip inline markdown formatting from title text (bold, italic, code). */


### PR DESCRIPTION
## 요약
2 board 패널의 `previewContent` byte-identical helper 를 `lib/board-utils.ts` 의 `previewBoardMessage` SSOT export 로 통합. iter#56 (`boardMessageRowKey`) follow-up — 같은 board panel trio, 같은 패턴.

## 배경

`rg "^function previewContent\(" -A 2` sweep 결과 3 board 패널에 *유사 정의* 발견:

| 파일 | 본문 |
|---|---|
| `mention-inbox.ts:124` | `stripStateBlocks(message.content).trim() \|\| message.content.trim() \|\| '(empty)'` |
| `message-room-timeline.ts:96` | (byte-identical) |
| `state-block-messages.ts` | `stripStateBlocks(message.content).trim() \|\| '(state-only message)'` (variant) |

2 byte-identical (mention-inbox + message-room-timeline) — 통합. 1 variant (state-block-messages) — *state-only view 의 의도된 다른 empty 메시지* + *raw content fallback skip*, 분리 보존.

## 변경

### `lib/board-utils.ts`
- `export function previewBoardMessage(message: Message): string` 추가
- `import { stripStateBlocks } from '../keeper-message'` 추가
- iter#56 `boardMessageRowKey` 와 같은 board domain helper 위치
- JSDoc: fallback chain (stripped → raw → '(empty)') + variant 분리 사유 (state-only view 의 다른 empty label) 명시

### 2 callsite migration
- `mention-inbox.ts` + `message-room-timeline.ts`: file-internal `function previewContent` 삭제
- `previewContent(row.message)` → `previewBoardMessage(row.message)`
- `import { stripStateBlocks }` 도 unused — 함께 제거 (helper 안으로 이동)
- `import { ..., previewBoardMessage }` 확장

## 검증
- typecheck PASS
- lint 0 errors (unused stripStateBlocks import 제거로 깔끔)
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)

## iter chain — board panel trio dedup

- iter#51: `SYSTEM_MESSAGE_FROM` (3 board panel 의 `'system'` literal)
- iter#56: `boardMessageRowKey` (2 byte-identical + 1 variant rowKey)
- iter#58: **`previewBoardMessage` (2 byte-identical + 1 variant previewContent)**

같은 board panel trio (mention-inbox, message-room-timeline, state-block-messages) 의 *3 helper* 가 single SSOT 통합 (2개) + variant 보존 (1개) 패턴. iter#46/#56 bulk-migrate-then-extend 일관 적용.

## /loop iter#58
SSOT 위반 dashboard 축출 loop 의 iter#58. cumulative 58 PR (37 머지 + 2 OPEN — #19161 + #19?_).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
