### PR TITLE
Remove dashboard API dead reexports

### DIFF
--- a/dashboard/src/api/credentials.ts
+++ b/dashboard/src/api/credentials.ts
@@ -44,7 +44,6 @@ export function coerceCredentialType(raw: unknown): CredentialType {
 
 import { get, post, del } from './core'
 import { isRecord } from '../lib/type-guards'
-export { isRecord }
 
 export function parseCredentialState(raw: unknown): CredentialState | null {
   if (!isRecord(raw)) return null

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -27,8 +27,6 @@ let mcpSessionId: string | null = null
 let initPromise: Promise<void> | null = null
 let initCooldownTimer: ReturnType<typeof setTimeout> | null = null
 
-export { ensureDevToken }
-
 async function bestEffortReportToolHostFailure(payload: {
   toolName: string
   message: string

--- a/dashboard/src/components/credential-settings.test.ts
+++ b/dashboard/src/components/credential-settings.test.ts
@@ -11,10 +11,10 @@ import {
   credentialStateLabel,
   credentialTypeBadgeClass,
   credentialTypeLabel,
-  isRecord,
   normalizeCredentialsResponse,
   parseCredentialState,
 } from "./credential-settings"
+import { isRecord } from "../lib/type-guards"
 
 describe("coerceCredentialType", () => {
   it("returns github for unknown", () => {

--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -26,7 +26,6 @@ import { FIELD_STYLE_BASE } from './common/field-style-base'
 
 export {
   coerceCredentialType,
-  isRecord,
   normalizeCredentialsResponse,
   parseCredentialState,
 } from '../api/credentials'


### PR DESCRIPTION
Summary
- remove the unused api/credentials isRecord re-export
- remove the unused api/mcp ensureDevToken re-export
- update credential settings tests to import isRecord from the owning type-guards module

Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/api/mcp.test.ts src/components/credential-settings.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/api/credentials.ts src/api/mcp.ts src/components/credential-settings.ts src/components/credential-settings.test.ts (ignored warnings for current eslint config; no errors)
- git diff --check origin/main