### PR TITLE
refactor(dashboard): drop formatDuration alias shadowing public formatDurationCompound

### DIFF
--- a/dashboard/src/components/keeper-detail-ctx-utils.test.ts
+++ b/dashboard/src/components/keeper-detail-ctx-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatDurationCompound as formatDuration } from '../lib/format-time'
+import { formatDurationCompound } from '../lib/format-time'
 import { autonomyHint } from './keeper-detail-ctx-utils'
 
 describe('autonomyHint', () => {
@@ -25,22 +25,22 @@ describe('autonomyHint', () => {
   })
 })
 
-describe('formatDuration', () => {
+describe('formatDurationCompound', () => {
   it('formats seconds under 60', () => {
-    expect(formatDuration(0)).toBe('0초')
-    expect(formatDuration(30)).toBe('30초')
-    expect(formatDuration(59)).toBe('59초')
+    expect(formatDurationCompound(0)).toBe('0초')
+    expect(formatDurationCompound(30)).toBe('30초')
+    expect(formatDurationCompound(59)).toBe('59초')
   })
 
   it('formats minutes under 3600', () => {
-    expect(formatDuration(60)).toBe('1분')
-    expect(formatDuration(120)).toBe('2분')
-    expect(formatDuration(3599)).toBe('59분')
+    expect(formatDurationCompound(60)).toBe('1분')
+    expect(formatDurationCompound(120)).toBe('2분')
+    expect(formatDurationCompound(3599)).toBe('59분')
   })
 
   it('formats hours with remaining minutes', () => {
-    expect(formatDuration(3600)).toBe('1시간 0분')
-    expect(formatDuration(3660)).toBe('1시간 1분')
-    expect(formatDuration(7384)).toBe('2시간 3분')
+    expect(formatDurationCompound(3600)).toBe('1시간 0분')
+    expect(formatDurationCompound(3660)).toBe('1시간 1분')
+    expect(formatDurationCompound(7384)).toBe('2시간 3분')
   })
 })

--- a/dashboard/src/components/keeper-detail-kpi.ts
+++ b/dashboard/src/components/keeper-detail-kpi.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { formatPct1, formatTokens } from '../lib/format-number'
-import { formatDurationCompound as formatDuration } from '../lib/format-time'
+import { formatDurationCompound } from '../lib/format-time'
 import { Eyebrow } from './common/eyebrow'
 import { StatTile } from './common/stat-tile'
 import type { Keeper, KeeperMetricPoint } from '../types'
@@ -100,7 +100,7 @@ export function OperationalHealth({ keeper }: { keeper: Keeper }) {
         ${lastCompAgo != null ? html`
           <div class="p-2 rounded-[var(--r-1)] border ${KPI_TONE['default']} flex flex-col gap-0.5">
             <${Eyebrow}>마지막 압축</${Eyebrow}>
-            <span class="text-xs font-mono text-[var(--color-fg-secondary)]">${formatDuration(lastCompAgo)} 전</span>
+            <span class="text-xs font-mono text-[var(--color-fg-secondary)]">${formatDurationCompound(lastCompAgo)} 전</span>
           </div>
         ` : null}
       </div>


### PR DESCRIPTION
## 요약
2 file 의 `formatDurationCompound as formatDuration` alias 제거 — 공식 SSOT export 와 cross-file homonym 충돌. test name 도 *실제 검증 함수* 따라 갱신.

## 배경

`rg "import \{ \w+ as \w+ \} from"` sweep 결과 *같은 path, 같은 alias* 2 callsite 발견:

| 파일 | import | 의미 |
|---|---|---|
| `components/keeper-detail-kpi.ts:3` | `formatDurationCompound as formatDuration` | production callsite |
| `components/keeper-detail-ctx-utils.test.ts:2` | (동일) | test for that callsite |

`lib/format-time.ts` 가 **둘 다 공식 export**:
- `formatDuration(seconds)` — *single unit* ('1시간', '30분')
- `formatDurationCompound(seconds)` — *compound* ('1시간 30분')

다른 함수. alias 가 file-locally 둘을 *같은 이름* 으로 만들어 *공식 export 와 silent homonym*.

## 잠재 bug — test name 오해

`describe('formatDuration', () => { ... expect(formatDuration(3660)).toBe('1시간 1분') })` — test name 이 *formatDuration* 인데 expectation 은 *compound rendering* (1시간 1분). **test name 이 실제 검증 대상과 불일치**. iter#19 R 패턴의 *test = spec doc* 위반.

## 변경

- `keeper-detail-kpi.ts`: alias 제거 + 1 production callsite `formatDuration(...)` → `formatDurationCompound(...)`
- `keeper-detail-ctx-utils.test.ts`: alias 제거 + `describe('formatDuration', ...)` → `describe('formatDurationCompound', ...)` + 모든 `expect(formatDuration(...))` → `expect(formatDurationCompound(...))`

## 검증

- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = `auth-status.a11y` popover axe pre-existing baseline)

## iter chain — iter#19 R 패턴의 cross-file alias 변형

- iter#19: errorMessage 4-way diverging policy rename (file-scope homonym)
- iter#53: escapeRegExp byte-identical 2 copy (file-internal duplicate)
- iter#59: **formatDuration alias 2-file cross-file homonym** — *cross-file consistent alias* 가 *공식 SSOT export 와 의미 충돌*

같은 SSOT 위반 class 의 *alias 변형* — 명시적 helper export 와의 silent conflict.

## /loop iter#59
SSOT 위반 dashboard 축출 loop 의 iter#59. cumulative 59 PR (37 머지 + 2 OPEN + 1 추가 OPEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
