### PR TITLE
Remove dashboard WS parser reexport

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -13,9 +13,9 @@ import {
   dashboardSlicesForRoute,
   disconnectDashboardWS,
   flushPendingInbound,
-  parseWebSocketSseFrames,
   subscribeDashboardRoute,
 } from './dashboard-ws'
+import { parseWebSocketSseFrames } from './dashboard-ws-parse'
 import { clearStoredToken, setStoredToken } from './api/core'
 import {
   DASHBOARD_WS_HEARTBEAT_INTERVAL_MS,

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -3,7 +3,7 @@ import { parseSSEMessage } from './schemas/sse'
 import { hydrateDashboardSlice, routeServerPushEvent } from './sse-store'
 import { batch } from '@preact/signals'
 import { dashboardBearerToken } from './api/core'
-import { parseWebSocketSseFrames as parseWebSocketSseFramesImpl } from './dashboard-ws-parse'
+import { parseWebSocketSseFrames } from './dashboard-ws-parse'
 import {
   GLOBAL_DASHBOARD_PUSH_SLICES,
   type DashboardPushSlice,
@@ -14,9 +14,6 @@ import {
   RECONNECT_JITTER_MS,
   RECONNECT_MAX_MS,
 } from './config/constants'
-
-// Re-export for test consumers that assert on frame parsing.
-export const parseWebSocketSseFrames = parseWebSocketSseFramesImpl
 import {
   dashboardWsConnected,
   dashboardWsLastError,
@@ -549,7 +546,7 @@ function processInboundMessage(data: string): void {
     try {
       raw = JSON.parse(data)
     } catch {
-      for (const payload of parseWebSocketSseFramesImpl(data)) {
+      for (const payload of parseWebSocketSseFrames(data)) {
         handleRawPush(payload)
       }
       return


### PR DESCRIPTION
Summary
- Remove the dashboard-ws.ts parser re-export that existed only for test consumers.
- Keep production code importing parseWebSocketSseFrames directly from dashboard-ws-parse.ts.
- Update dashboard-ws.test.ts to import the parser from its owning module.

Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/dashboard-ws.test.ts src/dashboard-ws-parse.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/dashboard-ws.ts src/dashboard-ws.test.ts src/dashboard-ws-parse.test.ts (0 errors; parse test ignored warning only)
- git diff --check origin/main