### PR TITLE
Remove agent detail keeper alias

### DIFF
--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -12,8 +12,8 @@ import {
   agentTimeline,
   missionAgentBrief,
   continuityBriefForAgent,
-  keeperForAgent,
 } from './agent-detail-state'
+import { findKeeper } from '../lib/keeper-utils'
 import type { AgentTimelineEvent } from '../api'
 
 // ── Helpers (exported for testing) ───────────────
@@ -129,7 +129,7 @@ function taskEventColor(type: string): string {
 function SessionMeta({ agentName }: { agentName: string }) {
   const brief = missionAgentBrief(agentName)
   const continuity = continuityBriefForAgent(agentName)
-  const keeper = keeperForAgent(agentName)
+  const keeper = findKeeper(agentName)
   const timeline = agentTimeline.value
 
   const meta: { label: string; value: string }[] = []

--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -62,8 +62,6 @@ export function assignedTasks(agentName: string | null): Task[] {
   return tasks.value.filter(t => t.assignee === agentName)
 }
 
-export const keeperForAgent = findKeeper
-
 export function missionAgentBrief(agentName: string | null): DashboardMissionAgentBrief | null {
   if (!agentName) return null
   const mission = missionSnapshot.value
@@ -85,7 +83,7 @@ export function workerBriefForAgent(agentName: string | null) {
 
 /** Collect lowercase name variants for an agent (including keeper aliases). */
 function agentMatchNames(agentName: string): string[] {
-  const keeper = keeperForAgent(agentName)
+  const keeper = findKeeper(agentName)
   return [agentName, keeper?.name, keeper?.agent_name]
     .filter((n): n is string => n != null && n !== '')
     .map(n => n.toLowerCase())
@@ -117,7 +115,7 @@ export function setKeeperRedirect(fn: (agentName: string) => boolean): void {
 
 export function openAgentDetail(agentName: string): void {
   if (_keeperRedirect && _keeperRedirect(agentName)) return
-  const keeper = keeperForAgent(agentName)
+  const keeper = findKeeper(agentName)
   if (keeper) {
     void import('./keeper-detail')
       .then(({ openKeeperDetail }) => {

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -11,6 +11,7 @@ import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
 import { resolveUnifiedStatus } from '../lib/unified-status'
 import { keeperDisplayStatus } from '../lib/keeper-runtime-display'
+import { findKeeper } from '../lib/keeper-utils'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
 import { keeperIdentityHint } from './common/keeper-identity'
@@ -32,7 +33,6 @@ import {
   sendingMention,
   selectedAgent,
   assignedTasks,
-  keeperForAgent,
   missionAgentBrief,
   continuityBriefForAgent,
   closeAgentDetail,
@@ -58,7 +58,7 @@ export { selectedAgentName, openAgentDetail, closeAgentDetail } from './agent-de
 
 // Wire keeper redirect: keeper-linked agents open the keeper detail overlay
 setKeeperRedirect((agentName: string) => {
-  const keeper = keeperForAgent(agentName)
+  const keeper = findKeeper(agentName)
   if (keeper) {
     openKeeperDetail(keeper)
     return true
@@ -174,7 +174,7 @@ export function AgentDetailOverlay() {
   const closeButtonRef = useRef<HTMLButtonElement>(null)
 
   const agent = selectedAgent()
-  const keeper = keeperForAgent(agentName)
+  const keeper = findKeeper(agentName)
   const continuityBrief = continuityBriefForAgent(agentName)
   const missionBrief = missionAgentBrief(agentName)
   const ownedTasks = assignedTasks(agentName)


### PR DESCRIPTION
Summary
- Remove the agent-detail-state keeperForAgent alias.
- Use the canonical findKeeper helper directly inside agent detail state.
- Update agent detail consumers to import findKeeper from lib/keeper-utils, keeping keeper lookup SSOT in one module.

Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/agent-detail-state.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/agent-detail-state.ts src/components/agent-detail.ts src/components/agent-detail-session-report.ts src/components/agent-detail-state.test.ts (0 errors; test file ignored warning only)
- git diff --check origin/main