### PR TITLE
refactor(dashboard/ide): absorb 3 more inline positive-safe-integer guards into isPositiveSafeInteger

### DIFF
--- a/dashboard/src/components/ide/code-document-store.ts
+++ b/dashboard/src/components/ide/code-document-store.ts
@@ -1,6 +1,6 @@
 import { signal } from '@preact/signals'
 import { fetchIdeRegions, type IdeCodeRegion } from '../../api/ide'
-import { isRecord, asNullableString } from '../common/normalize'
+import { isRecord, asNullableString, isPositiveSafeInteger } from '../common/normalize'
 
 export interface CodeDocumentSource {
   readonly file_path: string | null
@@ -132,7 +132,7 @@ function parseLines(content: string, maxLines: number): ReadonlyArray<CodeDocume
 }
 
 function normalizeMaxLines(value: number | undefined): number {
-  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return value
+  if (isPositiveSafeInteger(value)) return value
   return 5_000
 }
 

--- a/dashboard/src/components/ide/ide-state.ts
+++ b/dashboard/src/components/ide/ide-state.ts
@@ -12,6 +12,7 @@
 
 import { signal } from '@preact/signals'
 import type { TabId } from '../../types'
+import { isPositiveSafeInteger } from '../common/normalize'
 
 export const activeIdeFile = signal<string | null>(null)
 
@@ -52,9 +53,7 @@ export function focusIdeContextAnchor(
 }
 
 export function normalizeIdeContextLine(value: number | undefined): number | undefined {
-  return Number.isSafeInteger(value) && value !== undefined && value >= 1
-    ? value
-    : undefined
+  return isPositiveSafeInteger(value) ? value : undefined
 }
 
 export function normalizeIdeContextFilePath(value: string): string | null {

--- a/dashboard/src/components/ide/run-activity-store.ts
+++ b/dashboard/src/components/ide/run-activity-store.ts
@@ -130,7 +130,7 @@ export function createRunActivityStore(
 }
 
 function normalizeMaxEvents(value: number | undefined): number {
-  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return value
+  if (isPositiveSafeInteger(value)) return value
   return DEFAULT_MAX_EVENTS
 }
 


### PR DESCRIPTION
## 요약
3 변형 `Number.isSafeInteger(value) && value > 0` / `>= 1` callsite 를 `isPositiveSafeInteger` 로 추가 흡수. iter#47/49 bulk-migrate-then-extend SOP 3 번째 적용.

## 배경

`rg "Number\.isSafeInteger\(" -n` sweep 결과 6 잔여 callsite 중 *predicate 호환 3 callsite* 발견:

| 파일 | 시그니처 | 의미 |
|---|---|---|
| `ide-state.ts:55` | `normalizeIdeContextLine` — `Number.isSafeInteger(value) && value !== undefined && value >= 1` | `value !== undefined` redundant (isSafeInteger 가 undefined → false) |
| `code-document-store.ts:135` | `normalizeMaxLines` — `typeof value === 'number' && Number.isSafeInteger(value) && value > 0` | `> 0` 형태 |
| `run-activity-store.ts:133` | `normalizeMaxEvents` — (동일 `> 0` 형태) |

`> 0` 와 `>= 1` 는 `Number.isSafeInteger` 하에서 *integer 강제* → 동일 의미. 같은 *positive safe integer* rule.

### Scope 밖 (다른 rule)
- `keeper-cursor-overlay.ts:57` — `>= 0` (non-negative), iter#47/49 와 다른 rule
- `ide-conversation-rail.ts:342` — `Math.max(0, value)` (clamp shape), 다른 의도

## 변경

3 callsite migration:
- `ide-state.ts:55`: 신규 import + `isPositiveSafeInteger(value) ? value : undefined`
- `code-document-store.ts:135`: 기존 import 확장 + `isPositiveSafeInteger(value)`
- `run-activity-store.ts:133`: iter#47 import 활용 + `isPositiveSafeInteger(value)`

## 검증

- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = baseline)

## iter chain — bulk-migrate-then-extend SOP 3 번째

- iter#47: 7 byte-identical migration
- iter#49: 6 variant 흡수 (predicate unknown 입력 자동 처리)
- iter#60: 3 추가 variant 흡수 (`>= 1` vs `> 0` integer 동등)

iter#50 milestone 이후 *predicate-based duplicate sweep* 도 3 회 누적. 추가 variant 잔여 = 2 callsite (다른 rule).

## /loop iter#60 milestone
SSOT 위반 dashboard 축출 loop 의 iter#60 milestone. cumulative 60 PR (37 머지 + 4 OPEN — #19161 + #19167 + #19171 + #19?_).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
