### PR TITLE
Remove KPI mono stack reexport

### DIFF
--- a/dashboard/src/components/kpi-cell.solid.tsx
+++ b/dashboard/src/components/kpi-cell.solid.tsx
@@ -10,12 +10,12 @@
 
 import { Show, type JSX } from 'solid-js'
 import { Bar, type BarKind } from './bar.solid'
+import { MONO_STACK } from './common/font-stacks'
 import { useKpiStripContext } from './kpi-strip.solid'
 import {
   kpiCellAriaLabel,
   VALUE_COLOR_BY_KIND,
   DELTA_COLOR_BY_DIRECTION,
-  MONO_STACK,
   type KpiCellProps,
   type KpiCellVariant,
 } from './kpi-shared'

--- a/dashboard/src/components/kpi-cell.ts
+++ b/dashboard/src/components/kpi-cell.ts
@@ -17,12 +17,12 @@ import { html } from 'htm/preact'
 import type { VNode } from 'preact'
 import { Bar } from './bar'
 import { type BarKind } from './bar-shared'
+import { MONO_STACK } from './common/font-stacks'
 import {
   DEFAULT_KPI_CELL_VARIANT,
   kpiCellAriaLabel,
   VALUE_COLOR_BY_KIND,
   DELTA_COLOR_BY_DIRECTION,
-  MONO_STACK,
   type KpiCellProps,
 } from './kpi-shared'
 

--- a/dashboard/src/components/kpi-shared.ts
+++ b/dashboard/src/components/kpi-shared.ts
@@ -118,5 +118,3 @@ export const DELTA_COLOR_BY_DIRECTION: Record<'pos' | 'neg', string> = {
   pos: 'var(--color-status-ok)',
   neg: 'var(--color-status-err)',
 }
-
-export { MONO_STACK } from './common/font-stacks'


### PR DESCRIPTION
Summary
- Remove the MONO_STACK re-export from kpi-shared.ts.
- Import MONO_STACK directly from common/font-stacks.ts in both Preact and Solid KPI cells.
- Keep kpi-shared focused on KPI-specific types, constants, and pure helpers.

Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/kpi-cell.test.ts src/components/kpi-strip.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/kpi-cell.ts src/components/kpi-cell.solid.tsx src/components/kpi-shared.ts src/components/kpi-cell.test.ts src/components/kpi-strip.test.ts (0 errors; config ignored warnings only)
- git diff --check origin/main

Note
- Attempted Solid-specific vitest: pnpm vitest run --config vitest.solid.config.ts src/components/kpi-cell.solid.test.tsx src/components/kpi-strip.solid.test.tsx --no-file-parallelism --maxWorkers=1. It failed before loading tests with existing Vite module resolution error for /@fs/.../@testing-library/jest-dom/dist/vitest.mjs.