### PR TITLE
Remove time ago formatter reexport

### DIFF
--- a/dashboard/src/components/common/time-ago.ts
+++ b/dashboard/src/components/common/time-ago.ts
@@ -83,5 +83,3 @@ export function TimeAgo({ timestamp, mode = 'relative', class: cx }: TimeAgoProp
   const cls = cx ? `time-ago ${cx}` : 'time-ago'
   return html`<time class=${cls} datetime=${iso} title=${tooltip} aria-label=${label}>${text}</time>`
 }
-
-export { formatTimeAgo }

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -14,7 +14,7 @@ import { connected, totalEvents } from '../../sse'
 import { ActionButton } from '../common/button'
 import { EmptyState, ErrorState } from '../common/feedback-state'
 import { StatusChip } from '../common/status-chip'
-import { formatTimeAgo } from '../common/time-ago'
+import { formatTimeAgo } from '../../lib/format-time'
 
 const FILTER_OPTIONS: { kind: LiveFilterKind; label: string }[] = [
   { kind: 'broadcast', label: '브로드캐스트' },


### PR DESCRIPTION
Summary
- Remove the formatTimeAgo re-export from components/common/time-ago.ts.
- Keep TimeAgo as the component module surface.
- Update live/activity-stream.ts to import formatTimeAgo directly from lib/format-time.ts, the formatter SSOT.

Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/common/time-ago.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/common/time-ago.ts src/components/live/activity-stream.ts src/components/common/time-ago.test.ts
- git diff --check origin/main