### PR TITLE
refactor(dashboard): centralise isStringArray in lib/type-guards, drop 2 file-internal copies

### DIFF
--- a/dashboard/src/components/ide/run-activity-store.ts
+++ b/dashboard/src/components/ide/run-activity-store.ts
@@ -8,6 +8,7 @@
 
 import { signal } from '@preact/signals'
 import { hasNonEmptyStringField, isPositiveSafeInteger, isRecord } from '../common/normalize'
+import { isStringArray } from '../../lib/type-guards'
 
 const DEFAULT_MAX_EVENTS = 200
 const RUN_ACTIVITY_VERBS = [
@@ -148,9 +149,6 @@ function validEventForRun(event: unknown, runId: string): event is RunActivityEv
   return Number.isFinite(event.timestamp_ms)
 }
 
-function isStringArray(value: unknown): value is ReadonlyArray<string> {
-  return Array.isArray(value) && value.every(item => typeof item === 'string')
-}
 
 function isRunActivityContext(value: unknown): value is RunActivityContext {
   if (!isRecord(value)) return false

--- a/dashboard/src/components/keeper-detail-history.ts
+++ b/dashboard/src/components/keeper-detail-history.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import { formatPct1 } from '../lib/format-number'
 import { unixSecondsToDate } from '../lib/format-time'
+import { isStringArray } from '../lib/type-guards'
 import { ActionButton } from './common/button'
 import { requestConfirm } from './common/confirm-dialog'
 import {
@@ -339,9 +340,6 @@ interface LineageVerdictMeta {
   detail: string
 }
 
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every(item => typeof item === 'string')
-}
 
 function isLineageJudgment(value: unknown): value is LineageJudgment {
   if (!isRecord(value)) return false

--- a/dashboard/src/lib/type-guards.ts
+++ b/dashboard/src/lib/type-guards.ts
@@ -18,3 +18,19 @@ export function hasNonEmptyStringField(
   const value = record[key]
   return typeof value === 'string' && value.trim() !== ''
 }
+
+/**
+ * Narrow an `unknown` to `ReadonlyArray<string>` — an array whose every
+ * element is a string. Used wherever a JSON-decoded field is expected to
+ * be a string list but the wire format is `unknown`.
+ *
+ * `keeper-detail-history.ts` and `ide/run-activity-store.ts` shipped this
+ * exact body file-internal (the first as `value is string[]`, the
+ * second as `value is ReadonlyArray<string>`). The wider readonly form
+ * accommodates both call sites — TypeScript's array variance treats
+ * `string[]` as assignable to `ReadonlyArray<string>` in the asserted
+ * branch.
+ */
+export function isStringArray(value: unknown): value is ReadonlyArray<string> {
+  return Array.isArray(value) && value.every(item => typeof item === 'string')
+}


### PR DESCRIPTION
## 요약
`isStringArray` 2 file file-internal copy 를 `lib/type-guards.ts` SSOT export 로 통합. iter#48-58 file-internal helper sweep 7 번째 적용.

## 배경

`rg "^function (is\w+)\(" non-exported duplicate sweep` 결과 2 file 발견:

| 파일 | 시그니처 |
|---|---|
| `components/keeper-detail-history.ts:342` | `value is string[]` |
| `components/ide/run-activity-store.ts:151` | `value is ReadonlyArray<string>` |

같은 본문 (`Array.isArray(value) && value.every(item => typeof item === 'string')`), 다른 asserted return type.

`lib/type-guards.ts` 가 *공식 type guard hub* (`isRecord`, `hasNonEmptyStringField` 등) — `isStringArray` 자연 위치.

## 변경

### `lib/type-guards.ts`
- `export function isStringArray(value: unknown): value is ReadonlyArray<string>` 추가
- **Wider readonly variant 채택**: TypeScript 의 array variance 가 `string[]` → `ReadonlyArray<string>` 호환 → keeper-detail-history caller cast 불필요
- JSDoc: 2 consumer + variance 처리 명시

### 2 callsite migration
- 각 file file-internal `function isStringArray` 삭제
- `import { isStringArray } from '../lib/type-guards'` (또는 `'../../lib/type-guards'`) 추가

## 검증
- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = baseline)

## iter chain — file-internal helper sweep 7 번째

iter#48 (happy-dom-helpers) → iter#53 (escapeRegExp) → iter#54 (unixishToMs) → iter#55 (routeHashParams) → iter#56 (boardMessageRowKey) → iter#57 (routeLinkLabels) → iter#58 (previewBoardMessage) → iter#61 (**isStringArray**)

같은 SOP 7 회 누적 — `^function (\w+)\(` cross-file duplicate 검색 + 통합 위치 결정 + variant 흡수.

## /loop iter#61
SSOT 위반 dashboard 축출 loop 의 iter#61. cumulative 61 PR (37 머지 + 5 OPEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
