### PR TITLE
Remove keeper phase refresh alias

### DIFF
--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -45,7 +45,7 @@ export function eventLabel(event: unknown): string {
   return '?'
 }
 
-async function loadAll() {
+export async function refreshKeeperPhaseTimeline() {
   const names = keepers.value.map(k => k.name)
   if (names.length === 0) return
   loading.value = true
@@ -136,7 +136,7 @@ function KeeperStrip({ name, data }: { name: string; data: KeeperTransitionsResp
 }
 
 export function KeeperPhaseTimeline() {
-  useEffect(() => { void loadAll() }, [])
+  useEffect(() => { void refreshKeeperPhaseTimeline() }, [])
 
   const data = transitionData.value
   const isLoading = loading.value
@@ -157,7 +157,7 @@ export function KeeperPhaseTimeline() {
         <button
           type="button"
           class="text-2xs text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)] transition-colors"
-          onClick=${() => { void loadAll() }}
+          onClick=${() => { void refreshKeeperPhaseTimeline() }}
         >새로고침</button>
       </div>
       ${keeperList.map(k => {
@@ -174,5 +174,3 @@ export function KeeperPhaseTimeline() {
     </div>
   `
 }
-
-export { loadAll as refreshKeeperPhaseTimeline }


### PR DESCRIPTION
Summary
- Replace the private loadAll function plus alias export with a named refreshKeeperPhaseTimeline export.
- Update KeeperPhaseTimeline internal refresh calls to use the same public refresh name.
- Remove the export { loadAll as refreshKeeperPhaseTimeline } alias surface.

Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/keeper-phase-strip.test.ts src/components/keeper-reactivity-monitor.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/keeper-phase-strip.ts src/components/keeper-phase-strip.test.ts src/components/keeper-reactivity-monitor.test.ts (0 errors; test ignored warnings only)
- git diff --check origin/main