### PR TITLE
Remove keeper lifecycle refresh alias

### DIFF
--- a/dashboard/src/components/keeper-lifecycle-timeline.ts
+++ b/dashboard/src/components/keeper-lifecycle-timeline.ts
@@ -70,7 +70,7 @@ export function lifecycleEventLabel(event: string): string {
 
 // ── Data loading ──────────────────────────────────────────────────────────
 
-async function loadAll() {
+export async function refreshKeeperLifecycleTimeline() {
   const names = keepers.value.map(k => k.name)
   if (names.length === 0) return
   loading.value = true
@@ -165,7 +165,7 @@ function KeeperLifecycleRow({
 // ── Public component ──────────────────────────────────────────────────────
 
 export function KeeperLifecycleTimeline() {
-  useEffect(() => { void loadAll() }, [])
+  useEffect(() => { void refreshKeeperLifecycleTimeline() }, [])
 
   const data = lifecycleData.value
   const isLoading = loading.value
@@ -188,7 +188,7 @@ export function KeeperLifecycleTimeline() {
         <button
           type="button"
           class="text-2xs text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)] transition-colors"
-          onClick=${() => { void loadAll() }}
+          onClick=${() => { void refreshKeeperLifecycleTimeline() }}
         >새로고침</button>
       </div>
       ${keeperList.map(k => {
@@ -208,5 +208,3 @@ export function KeeperLifecycleTimeline() {
     </div>
   `
 }
-
-export { loadAll as refreshKeeperLifecycleTimeline }


### PR DESCRIPTION
Summary
- Replace the private loadAll function plus alias export with a named refreshKeeperLifecycleTimeline export.
- Update KeeperLifecycleTimeline internal refresh calls to use the same public refresh name.
- Remove the export { loadAll as refreshKeeperLifecycleTimeline } alias surface.

Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/keeper-lifecycle-timeline.test.ts src/components/keeper-reactivity-monitor.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/keeper-lifecycle-timeline.ts src/components/keeper-lifecycle-timeline.test.ts src/components/keeper-reactivity-monitor.test.ts (0 errors; test ignored warnings only)
- git diff --check origin/main