### PR TITLE
Remove governance refresh reexport

### DIFF
--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -26,9 +26,6 @@ import {
 } from './governance-store'
 import { formatAgeSummary } from './governance-utils'
 
-// Re-export for consumers that import from './governance'
-export { refreshGovernance } from './governance-store'
-
 function MetaTag({ children, mono = false }: { children: unknown; mono?: boolean }) {
   const cls = `rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-text-muted${mono ? ' font-mono' : ''}`
   return html`<span class=${cls}>${children}</span>`


### PR DESCRIPTION
Summary
- Remove the unused refreshGovernance re-export from components/governance.ts.
- Keep governance.ts focused on the Governance component and local pure helpers.
- Leave refreshGovernance exported from governance-store/governance-actions, where callers should import it directly.

Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/governance.test.ts src/components/governance-risk.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/components/governance.ts src/components/governance.test.ts src/components/governance-risk.test.ts (0 errors; test ignored warnings only)
- git diff --check origin/main