### PR TITLE
refactor(dashboard): centralise isFiniteMetricValue in lib/format-number, drop 2 file-internal copies

### DIFF
--- a/dashboard/src/components/keeper-detail-charts.ts
+++ b/dashboard/src/components/keeper-detail-charts.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { formatTokens } from '../lib/format-number'
+import { formatTokens, isFiniteMetricValue } from '../lib/format-number'
 import { SPARKLINE_W, SPARKLINE_H, SPARKLINE_PAD } from '../lib/sparkline-config'
 import { ProgressBar } from './common/progress-bar'
 import { Eyebrow } from './common/eyebrow'
@@ -141,9 +141,6 @@ export function TokenTrendChart({ keeper }: { keeper: Keeper }) {
 
 // ── Sparkline helpers ────────────────────────────────────
 
-function isFiniteMetricValue(value: number | null | undefined): value is number {
-  return typeof value === 'number' && Number.isFinite(value)
-}
 
 export function miniSparkline(
   data: Array<number | null | undefined>,

--- a/dashboard/src/components/keeper-detail-telemetry.ts
+++ b/dashboard/src/components/keeper-detail-telemetry.ts
@@ -1,14 +1,11 @@
 import { html } from 'htm/preact'
-import { formatTokens } from '../lib/format-number'
+import { formatTokens, isFiniteMetricValue } from '../lib/format-number'
 import { SPARKLINE_W, SPARKLINE_H, SPARKLINE_PAD } from '../lib/sparkline-config'
 import { CopyIdButton } from './common/copy-id-button'
 import { Eyebrow } from './common/eyebrow'
 import type { Keeper, KeeperMetricPoint } from '../types'
 import { MutedSpan, DetailRow, DetailCard } from './keeper-detail-kpi'
 
-function isFiniteMetricValue(value: number | null | undefined): value is number {
-  return typeof value === 'number' && Number.isFinite(value)
-}
 
 function miniSparkline(
   data: Array<number | null | undefined>,

--- a/dashboard/src/lib/format-number.ts
+++ b/dashboard/src/lib/format-number.ts
@@ -44,9 +44,22 @@ export function formatCost(value: number | null | undefined, fallback = '--'): s
 /** Format millisecond duration as compact string: "3ms", "1.5s", "2.3m".
  *  Returns fallback for null/NaN/undefined/negative. */
 export function formatMsCompact(ms: number | null | undefined, fallback = ''): string {
-  if (typeof ms !== 'number' || !Number.isFinite(ms) || ms < 0) return fallback
+  if (!isFiniteMetricValue(ms) || ms < 0) return fallback
   const rounded = Math.round(ms)
   if (rounded < 1000) return `${rounded}ms`
   if (rounded < 60_000) return `${(rounded / 1000).toFixed(1)}s`
   return `${(rounded / 60_000).toFixed(1)}m`
+}
+
+/**
+ * Type predicate for "a finite numeric metric value". Narrows
+ * `number | null | undefined` (the wire shape for nullable metrics)
+ * down to `number` so callers can plot or compare directly.
+ *
+ * `keeper-detail-charts.ts` and `keeper-detail-telemetry.ts` shipped
+ * this body file-internal with the same signature; the inline copies
+ * are deleted in the same change that exports this helper.
+ */
+export function isFiniteMetricValue(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
 }


### PR DESCRIPTION
## 요약
`isFiniteMetricValue` 2 file-internal copy 를 `lib/format-number.ts` SSOT export 로 통합 + `formatMsCompact` 도 새 predicate 활용. iter#48-58/61 file-internal helper sweep 8 번째 적용.

## 배경
`rg "^function isFiniteMetricValue\(" -A 2` sweep 결과 2 callsite *byte-identical*:

| 파일 | 시그니처 |
|---|---|
| `components/keeper-detail-charts.ts:144` | `value is number` |
| `components/keeper-detail-telemetry.ts:9` | (동일) |

본문: `typeof value === 'number' && Number.isFinite(value)`.

`lib/format-number.ts` 내부 `formatMsCompact` 도 *동일 typeof+isFinite chain* 인라인 사용 — 자체 callsite 도 helper 활용 자연.

## 변경

### `lib/format-number.ts`
- `export function isFiniteMetricValue(value: number | null | undefined): value is number` 추가 + JSDoc (2 consumer cross-ref)
- `formatMsCompact` 가 inline guard → `isFiniteMetricValue(ms)` 활용 (helper 내부 자기 사용)

### 2 callsite migration
- 각 file file-internal `function isFiniteMetricValue` 삭제
- `import { formatTokens, isFiniteMetricValue } from '../lib/format-number'` (기존 import 확장)

## 검증
- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = baseline)

## iter chain — file-internal helper sweep 8 번째

iter#48 happy-dom-helpers + iter#53 escapeRegExp + iter#54 unixishToMs + iter#55 routeHashParams + iter#56 boardMessageRowKey + iter#57 routeLinkLabels + iter#58 previewBoardMessage + iter#61 isStringArray + iter#62 **isFiniteMetricValue**

같은 SOP 8 회 누적. `^function (\w+)\(` cross-file 검색 + variance 흡수.

## /loop iter#62
SSOT 위반 dashboard 축출 loop 의 iter#62. cumulative 62 PR (37 머지 + 6 OPEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
