### PR TITLE
refactor(task): unify verification submit action

### DIFF
--- a/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
+++ b/docs/KEEPER-CONTINUITY-PRODUCTION-RUNBOOK.md
@@ -86,7 +86,7 @@ Each release or promotion decision should capture these artifacts:
 - validation harness report from `docs/KEEPER-CONTINUITY-VALIDATION.md`
 - checkpoint diagnosis note or structured inspection artifact proving the OAS load path used for truth
 - example `masc_keeper_status` output showing `trace_id`, `generation`, `trace_history_count`, and `continuity_summary`
-- operator note or PR evidence linking the implemented fix to the diagnosed root cause
+- operator note or evidence ref linking the implemented fix to the diagnosed root cause
 
 Preferred evidence bundle:
 

--- a/docs/design/lsp-symbol-graph-exporter.md
+++ b/docs/design/lsp-symbol-graph-exporter.md
@@ -263,7 +263,7 @@ Done evidence:
 
 - This document exists.
 - The HTML design artifact links the contract.
-- GitHub issue #16083 has a PR evidence comment.
+- GitHub issue #16083 has an evidence-ref comment.
 
 ### Small Goal: `task-387`
 

--- a/docs/rfc/RFC-0109-cdal-goal-integration-contract.md
+++ b/docs/rfc/RFC-0109-cdal-goal-integration-contract.md
@@ -406,7 +406,7 @@ queryable via `Cdal_verdict_gate.lookup_latest_verdict ~task_id`:
 (* lib/tool_task.ml — replace the inline call site *)
 let submit_evidence_error =
   match requested_action with
-  | Submit_for_verification | Submit_pr_evidence
+  | Submit_for_verification
   | Done_action when done_redirects_to_verification ->
     (match Cdal_verdict_gate.lookup_latest_verdict ~task_id with
      | Some { status = Satisfied; _ } -> None

--- a/lib/cdal_evidence_gate.mli
+++ b/lib/cdal_evidence_gate.mli
@@ -1,7 +1,7 @@
 (** Cdal_evidence_gate — RFC-0109 Phase D.
 
     Layered evidence-gate decision for [submit_for_verification] /
-    todo verification bypass / [Done_action when done_redirects_to_verification].
+    [Done_action when done_redirects_to_verification].
 
     Replaces the old substring-classifier-only verification gate with a
     typed CDAL verdict consultation. Contracted tasks now fail closed

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -137,7 +137,6 @@ let task_action_of_transition : Masc_domain.task_action -> Audit_log.action = fu
   | Masc_domain.Cancel -> Audit_log.CancelTask
   | Masc_domain.Release -> Audit_log.ReleaseTask
   | ( Masc_domain.Submit_for_verification
-    | Masc_domain.Submit_pr_evidence
     | Masc_domain.Approve_verification
     | Masc_domain.Reject_verification ) as action ->
     Audit_log.Custom ("task_" ^ Masc_domain.task_action_to_string action)
@@ -248,7 +247,6 @@ let observe_task_transition_event
     | Masc_domain.Done_action
     | Masc_domain.Release
     | Masc_domain.Submit_for_verification
-    | Masc_domain.Submit_pr_evidence
     | Masc_domain.Approve_verification
     | Masc_domain.Reject_verification -> Log.Info
   in
@@ -275,7 +273,6 @@ let observe_task_transition_event
          Telemetry_eio.track_task_completed config ~task_id ~duration_ms ~success:false
        | Masc_domain.Release
        | Masc_domain.Submit_for_verification
-       | Masc_domain.Submit_pr_evidence
        | Masc_domain.Reject_verification -> ())
    with
    | Stdlib.Effect.Unhandled _ as exn ->

--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -54,8 +54,7 @@ let classify_completion_path
   | Masc_domain.Approve_verification -> "via_verification"
   | Masc_domain.Claim | Masc_domain.Start | Masc_domain.Done_action
   | Masc_domain.Cancel | Masc_domain.Release
-  | Masc_domain.Submit_for_verification | Masc_domain.Reject_verification
-  | Masc_domain.Submit_pr_evidence ->
+  | Masc_domain.Submit_for_verification | Masc_domain.Reject_verification ->
     if force then "forced_done"
     else (match drift with
           | Some Coord_task_lifecycle.Claimed_to_done_skip -> "claimed_to_done_skip"
@@ -407,7 +406,7 @@ let valid_next_actions_for_status
   : Masc_domain.task_status -> Masc_domain.task_action list
   = function
   | Masc_domain.Todo ->
-    [ Masc_domain.Claim; Masc_domain.Cancel; Masc_domain.Submit_pr_evidence ]
+    [ Masc_domain.Claim; Masc_domain.Cancel; Masc_domain.Submit_for_verification ]
   | Masc_domain.Claimed _ ->
     [ Masc_domain.Start
     ; Masc_domain.Done_action

--- a/lib/coord/coord_task_lifecycle.ml
+++ b/lib/coord/coord_task_lifecycle.ml
@@ -108,7 +108,17 @@ let decide
     ) -> Error Invalid_transition
   (* ── Submit for verification ──────────────────── *)
   | Masc_domain.Submit_for_verification, Masc_domain.Todo ->
-    if verification_enabled then Error Invalid_transition else Error Verification_disabled
+    if not verification_enabled
+    then Error Verification_disabled
+    else
+      ok
+        (Masc_domain.AwaitingVerification
+           { assignee = agent_name
+           ; submitted_at = now
+           ; verification_id = new_verification_id ()
+           ; deadline =
+               verification_deadline ~now ~timeout_seconds:verification_timeout_seconds
+           })
   | ( Masc_domain.Submit_for_verification
     , (Masc_domain.Claimed { assignee; _ } | Masc_domain.InProgress { assignee; _ }) ) ->
     if not verification_enabled
@@ -128,25 +138,6 @@ let decide
     , (Masc_domain.AwaitingVerification _ | Masc_domain.Done _ | Masc_domain.Cancelled _)
     ) ->
     if verification_enabled then Error Invalid_transition else Error Verification_disabled
-  (* ── Submit verification evidence (Todo bypass) ─────────────────────── *)
-  | Masc_domain.Submit_pr_evidence, Masc_domain.Todo ->
-    if not verification_enabled
-    then Error Verification_disabled
-    else
-      ok
-        (Masc_domain.AwaitingVerification
-           { assignee = agent_name
-           ; submitted_at = now
-           ; verification_id = new_verification_id ()
-           ; deadline =
-               verification_deadline ~now ~timeout_seconds:verification_timeout_seconds
-           })
-  | ( Masc_domain.Submit_pr_evidence
-    , ( Masc_domain.Claimed _
-      | Masc_domain.InProgress _
-      | Masc_domain.AwaitingVerification _
-      | Masc_domain.Done _
-      | Masc_domain.Cancelled _ ) ) -> Error Invalid_transition
   (* ── Approve verification ─────────────────────── *)
   | ( Masc_domain.Approve_verification
     , Masc_domain.AwaitingVerification { assignee; verification_id; _ } ) ->

--- a/lib/coord/coord_task_transition_executor.ml
+++ b/lib/coord/coord_task_transition_executor.ml
@@ -15,8 +15,7 @@ type transition_backlog_update =
 let action_persists_handoff_context = function
   | Masc_domain.Release
   | Masc_domain.Done_action
-  | Masc_domain.Submit_for_verification
-  | Masc_domain.Submit_pr_evidence ->
+  | Masc_domain.Submit_for_verification ->
     true
   | Masc_domain.Claim
   | Masc_domain.Start
@@ -35,7 +34,6 @@ let normalize_task_before_status ~action task =
   | Masc_domain.Done_action
   | Masc_domain.Cancel
   | Masc_domain.Submit_for_verification
-  | Masc_domain.Submit_pr_evidence
   | Masc_domain.Approve_verification
   | Masc_domain.Reject_verification ->
     task
@@ -52,7 +50,6 @@ let release_counters ~action task handoff_context =
   | Masc_domain.Done_action
   | Masc_domain.Cancel
   | Masc_domain.Submit_for_verification
-  | Masc_domain.Submit_pr_evidence
   | Masc_domain.Approve_verification
   | Masc_domain.Reject_verification ->
     task.cycle_count, task.reclaim_policy, task.do_not_reclaim_reason

--- a/lib/coord/coord_task_transitions.ml
+++ b/lib/coord/coord_task_transitions.ml
@@ -69,7 +69,6 @@ let transition_task_r
           | Masc_domain.Release
           | Masc_domain.Start
           | Masc_domain.Submit_for_verification
-          | Masc_domain.Submit_pr_evidence
           | Masc_domain.Approve_verification
           | Masc_domain.Reject_verification
           | Masc_domain.Done_action
@@ -91,8 +90,7 @@ let transition_task_r
           | Masc_domain.Release
           | Masc_domain.Submit_for_verification
           | Masc_domain.Approve_verification
-          | Masc_domain.Reject_verification
-          | Masc_domain.Submit_pr_evidence -> Ok ()
+          | Masc_domain.Reject_verification -> Ok ()
         in
         let* () =
           (match action, task.task_status with
@@ -113,7 +111,6 @@ let transition_task_r
             | Masc_domain.Cancel
             | Masc_domain.Release
             | Masc_domain.Submit_for_verification
-            | Masc_domain.Submit_pr_evidence
             | Masc_domain.Approve_verification
             | Masc_domain.Reject_verification ), _ -> Ok ())
           [@warning "-4"]
@@ -224,7 +221,7 @@ let transition_task_r
 (* WORKAROUND: action (9) × task_status (6) × new_status (6) × option (2) = 648 combos. *)
         let* () =
           (match action, task.task_status, new_status, prepare_verification_request with
-          | ( (Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence)
+          | ( Masc_domain.Submit_for_verification
             , _
             , Masc_domain.AwaitingVerification { assignee; verification_id; _ }
             , prepare_opt ) ->
@@ -252,7 +249,7 @@ let transition_task_r
                              task_id
                              verification_id
                              e)))))
-          | ( (Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence)
+          | ( Masc_domain.Submit_for_verification
             , _
             , _
             , Some _ ) ->
@@ -280,8 +277,7 @@ let transition_task_r
               | Masc_domain.Release
               | Masc_domain.Approve_verification
               | Masc_domain.Reject_verification
-              | Masc_domain.Submit_for_verification
-              | Masc_domain.Submit_pr_evidence )
+              | Masc_domain.Submit_for_verification )
             , _
             , _
             , None ) -> Ok ()) [@warning "-4"]
@@ -347,8 +343,7 @@ let transition_task_r
               | Masc_domain.Done_action
               | Masc_domain.Cancel
               | Masc_domain.Release
-              | Masc_domain.Submit_for_verification
-              | Masc_domain.Submit_pr_evidence )
+              | Masc_domain.Submit_for_verification )
             , _
             , Some _ ) -> Ok ()
           | ( ( Masc_domain.Claim
@@ -357,7 +352,6 @@ let transition_task_r
               | Masc_domain.Cancel
               | Masc_domain.Release
               | Masc_domain.Submit_for_verification
-              | Masc_domain.Submit_pr_evidence
               | Masc_domain.Approve_verification
               | Masc_domain.Reject_verification )
             , _
@@ -399,7 +393,6 @@ let transition_task_r
          | Masc_domain.Done_action, _
          | Masc_domain.Cancel, _
          | Masc_domain.Submit_for_verification, _
-         | Masc_domain.Submit_pr_evidence, _
          | Masc_domain.Approve_verification, _
          | Masc_domain.Reject_verification, _
          | Masc_domain.Release, Masc_domain.Claimed _
@@ -438,7 +431,6 @@ let transition_task_r
          | Masc_domain.Done_action
          | Masc_domain.Cancel
          | Masc_domain.Submit_for_verification
-         | Masc_domain.Submit_pr_evidence
          | Masc_domain.Approve_verification
          | Masc_domain.Reject_verification -> ());
         if new_status = task.task_status && set_current = None
@@ -520,7 +512,7 @@ let transition_task_r
                           , Masc_domain.task_handoff_context_to_yojson handoff_context )
                         ]
                       | None -> []))
-           | Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence ->
+           | Masc_domain.Submit_for_verification ->
              let payload =
                `Assoc
                  ([ "task_id", `String task_id ]
@@ -559,7 +551,6 @@ let transition_task_r
             | Masc_domain.Start
             | Masc_domain.Release
             | Masc_domain.Submit_for_verification
-            | Masc_domain.Submit_pr_evidence
             | Masc_domain.Approve_verification
             | Masc_domain.Reject_verification -> None
           in
@@ -586,7 +577,6 @@ let transition_task_r
            | Masc_domain.Claim
            | Masc_domain.Start
            | Masc_domain.Submit_for_verification
-           | Masc_domain.Submit_pr_evidence
            | Masc_domain.Approve_verification
            | Masc_domain.Reject_verification -> ());
           Ok

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -400,7 +400,6 @@ let record_task_transition
         ~reason
         ~evidence_refs:[ "task:" ^ task_id ]
         ~max_age_sec:task_commitment_expiry_sec
-    | Masc_domain.Submit_pr_evidence
     | Masc_domain.Submit_for_verification
     | Masc_domain.Approve_verification
     | Masc_domain.Reject_verification -> ())

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -425,10 +425,9 @@ let task_fsm_transitions : (string * string list * string * string option) list 
     ("release",                 ["claimed"; "in_progress"],                "todo",                   None);
     (* Action names match [Masc_domain.task_action_to_string] (SSOT):
        Approve_verification -> "approve", Reject_verification -> "reject". *)
-    ("submit_for_verification", ["claimed"; "in_progress"],                "awaiting_verification",  Some "MASC_VERIFICATION_FSM_ENABLED + verifier-FSM only");
+    ("submit_for_verification", ["todo"; "claimed"; "in_progress"],        "awaiting_verification",  Some "MASC_VERIFICATION_FSM_ENABLED + evidence_refs");
     ("approve",                 ["awaiting_verification"],                 "done",                   Some "MASC_VERIFICATION_FSM_ENABLED + verifier != assignee");
     ("reject",                  ["awaiting_verification"],                 "in_progress",            Some "MASC_VERIFICATION_FSM_ENABLED + verifier != assignee");
-    ("submit_pr_evidence",      ["todo"],                                  "awaiting_verification",  Some "MASC_VERIFICATION_FSM_ENABLED + no required-tool gate");
   ]
 
 let task_fsm_transition_to_json (action, froms, to_, gate) =

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -474,8 +474,7 @@ let dashboard_verification_resolve_http_json
      | Masc_domain.Done_action
      | Masc_domain.Cancel
      | Masc_domain.Release
-     | Masc_domain.Submit_for_verification
-     | Masc_domain.Submit_pr_evidence -> ());
+     | Masc_domain.Submit_for_verification -> ());
     Ok
       (`Assoc
           [ "ok", `Bool true

--- a/lib/task_transition_state/task_transition_state.ml
+++ b/lib/task_transition_state/task_transition_state.ml
@@ -27,7 +27,6 @@ type transition_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
-  | Submit_pr_evidence
 
 type family =
   | Invalid_transition of
@@ -73,7 +72,6 @@ let transition_action_to_string = function
   | Submit_for_verification -> "submit_for_verification"
   | Approve_verification -> "approve_verification"
   | Reject_verification -> "reject_verification"
-  | Submit_pr_evidence -> "submit_pr_evidence"
 
 let family_to_string = function
   | Invalid_transition { from_status; action } ->
@@ -111,7 +109,6 @@ let all_transition_actions : transition_action list =
   ; Submit_for_verification
   ; Approve_verification
   ; Reject_verification
-  ; Submit_pr_evidence
   ]
 
 let all_families : family list =
@@ -186,7 +183,6 @@ let parse_transition_action_token (s : string) : transition_action option =
   | "submit_for_verification" -> Some Submit_for_verification
   | "approve_verification" | "approve" -> Some Approve_verification
   | "reject_verification" | "reject" -> Some Reject_verification
-  | "submit_pr_evidence" -> Some Submit_pr_evidence
   | _ -> None
 
 (* Find the substring between [prefix] and the first occurrence of

--- a/lib/task_transition_state/task_transition_state.mli
+++ b/lib/task_transition_state/task_transition_state.mli
@@ -94,7 +94,6 @@ type transition_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
-  | Submit_pr_evidence
 
 (** Closed-enum classification of the [InvalidState] error message.
     Derived from the [Tool_task.validate_transition] surface and the

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -357,8 +357,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   let evidence_decision =
     let needs_gate =
       match requested_action with
-      | Masc_domain.Submit_for_verification
-      | Masc_domain.Submit_pr_evidence -> true
+      | Masc_domain.Submit_for_verification -> true
       | Masc_domain.Done_action when done_redirects_to_verification -> true
       | Masc_domain.Claim
       | Masc_domain.Start
@@ -396,17 +395,6 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
          ~extra_fields
          reason)
   | Cdal_evidence_gate.Pass ->
-  let action =
-    match requested_action, task_opt with
-    | ( Masc_domain.Submit_for_verification
-      , Some ({ task_status = Masc_domain.Todo; _ } : Masc_domain.task) ) ->
-      Log.Task.info
-        "[verification-alias] routing todo submit_for_verification with evidence through verification path task=%s agent=%s"
-        task_id
-        ctx.agent_name;
-      Masc_domain.Submit_pr_evidence
-    | _ -> action
-  in
   let action_s = Masc_domain.task_action_to_string action in
   let default_time = Time_compat.now () -. 60.0 in
   let (started_at_actual, collaborators_from_task) = match task_opt with
@@ -433,7 +421,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   in
   let prepare_verification_request =
     match action with
-    | Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence ->
+    | Masc_domain.Submit_for_verification ->
       Some
         (fun ~task ~assignee ~verification_id ~evidence_refs ->
            Verification_protocol.create_submit_request
@@ -477,8 +465,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
     | Masc_domain.Done_action
     | Masc_domain.Cancel
     | Masc_domain.Release
-    | Masc_domain.Submit_for_verification
-    | Masc_domain.Submit_pr_evidence ->
+    | Masc_domain.Submit_for_verification ->
       None
   in
   let verifier_approve_gate_rejection =
@@ -545,7 +532,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
          ("timestamp", `Float (Time_compat.now ()));
        ]);
        (match action with
-        | Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence ->
+        | Masc_domain.Submit_for_verification ->
           let tasks = Coord.get_tasks_raw ctx.config in
           (match List.find_opt (fun (t : Masc_domain.task) -> String.equal t.id task_id) tasks with
            | Some task ->
@@ -653,7 +640,6 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
          ~verdict:(Post_verifier.Fail "task_cancelled");
        Prometheus.record_task_failed ()
    | Ok _, (Masc_domain.Claim | Masc_domain.Start | Masc_domain.Submit_for_verification
-            | Masc_domain.Submit_pr_evidence
             | Masc_domain.Approve_verification | Masc_domain.Reject_verification | Masc_domain.Release)
    | Error _, _ -> ());
   result_to_response ~tool_name ~start_time result

--- a/lib/tool_task_args.ml
+++ b/lib/tool_task_args.ml
@@ -76,7 +76,7 @@ let synthesize_summary_from_siblings args =
 
    Exit-class actions:
      Done_action / Cancel / Release / Submit_for_verification /
-     Submit_pr_evidence / Approve_verification / Reject_verification
+     Approve_verification / Reject_verification
    Entry-class actions (no summary required):
      Claim / Start
 
@@ -89,7 +89,6 @@ let transition_action_requires_summary : Masc_domain.task_action -> bool =
   | Masc_domain.Cancel
   | Masc_domain.Release
   | Masc_domain.Submit_for_verification
-  | Masc_domain.Submit_pr_evidence
   | Masc_domain.Approve_verification
   | Masc_domain.Reject_verification ->
     true

--- a/lib/tool_task_payloads.ml
+++ b/lib/tool_task_payloads.ml
@@ -22,8 +22,7 @@ let verifier_transition_action_allowed = function
   | Masc_domain.Done_action
   | Masc_domain.Cancel
   | Masc_domain.Release
-  | Masc_domain.Submit_for_verification
-  | Masc_domain.Submit_pr_evidence ->
+  | Masc_domain.Submit_for_verification ->
     false
 
 let verifier_transition_rejection ~agent_name ~action =

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -255,7 +255,6 @@ type task_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
-  | Submit_pr_evidence
 [@@deriving show]
 
 let task_action_of_string s =
@@ -268,7 +267,6 @@ let task_action_of_string s =
   | "submit_for_verification" -> Ok Submit_for_verification
   | "approve" -> Ok Approve_verification
   | "reject" -> Ok Reject_verification
-  | "submit_pr_evidence" -> Ok Submit_pr_evidence
   | other -> Error (Printf.sprintf "Unknown task action: %s" other)
 
 let task_action_to_string = function
@@ -280,13 +278,11 @@ let task_action_to_string = function
   | Submit_for_verification -> "submit_for_verification"
   | Approve_verification -> "approve"
   | Reject_verification -> "reject"
-  | Submit_pr_evidence -> "submit_pr_evidence"
 
 (** All valid task actions, derived from the ADT (single source of truth). *)
 let all_task_actions =
   [ Claim; Start; Done_action; Cancel; Release;
-    Submit_for_verification; Approve_verification; Reject_verification;
-    Submit_pr_evidence ]
+    Submit_for_verification; Approve_verification; Reject_verification ]
 let valid_task_action_strings = List.map task_action_to_string all_task_actions
 
 type task_status =

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -82,7 +82,6 @@ type task_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
-  | Submit_pr_evidence
 [@@deriving show]
 
 val task_action_of_string : string -> (task_action, string) result

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -2,8 +2,8 @@
 """Audit live keeper fleet readiness from on-disk MASC runtime state.
 
 This is intentionally read-only. It separates configuration readiness
-(Docker, repo CLI identity, PR-capable preset) from durable evidence
-(recent turns, board actions, persisted PR references) so operators do not
+(Docker, repo CLI identity, work-capable preset) from durable evidence
+(recent turns, board actions, persistent work references) so operators do not
 mistake a configured capability for proof that every keeper already used it.
 """
 
@@ -25,7 +25,7 @@ from typing import Any
 import tomllib
 
 
-PR_CAPABLE_PRESETS = {"research", "delivery", "full"}
+WORK_CAPABLE_PRESETS = {"research", "delivery", "full"}
 BOARD_TOOLS = {
     "keeper_board_post",
     "keeper_board_comment",
@@ -54,14 +54,6 @@ DESIGN_DOMAIN_MARKERS = {
     "ui",
     "ux",
 }
-PR_URL_RE = re.compile(
-    r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+"
-)
-PR_CREATED_NUMBER_RE = re.compile(
-    r"\b(?:created|opened|published)\s+(?:a\s+)?(?:github\s+)?"
-    r"(?:draft\s+)?PR\s*#([0-9]+)\b",
-    re.IGNORECASE,
-)
 GH_HOSTS_USER_RE = re.compile(r"^\s*user:\s*['\"]?([^'\"\s#]+)")
 ERROR_STATUSES = {"error", "failed", "failure", "timeout", "cancelled", "canceled"}
 
@@ -92,8 +84,6 @@ class KeeperAudit:
     web_search_action: bool
     product_action: bool
     design_action: bool
-    pr_created_evidence: bool
-    pr_url_evidence: bool
     provider_turn_evidence: bool
     checkpoint_evidence: bool
     history_evidence: bool
@@ -103,28 +93,12 @@ class KeeperAudit:
     web_search_evidence: list[str]
     product_evidence: list[str]
     design_evidence: list[str]
-    pr_evidence_refs: list[str]
-    pr_evidence_sources: list[str]
     provider_turn_evidence_refs: list[str]
     checkpoint_evidence_refs: list[str]
     history_evidence_refs: list[str]
     tool_call_log_evidence_refs: list[str]
     failures: list[str]
     warnings: list[str]
-
-
-@dataclass
-class PrCreationEvidence:
-    refs: set[str]
-    sources: set[str]
-
-    @property
-    def created(self) -> bool:
-        return bool(self.refs)
-
-    @property
-    def url_present(self) -> bool:
-        return any(ref.startswith("https://github.com/") for ref in self.refs)
 
 
 @dataclass
@@ -369,87 +343,6 @@ def dict_field(data: dict[str, Any], key: str) -> dict[str, Any] | None:
     return value if isinstance(value, dict) else None
 
 
-def pr_ref_texts_from_structured_output(row: dict[str, Any]) -> list[str]:
-    texts: list[str] = []
-    output = row.get("output")
-    if isinstance(output, str):
-        texts.append(output)
-    elif isinstance(output, dict):
-        for key in ("output", "pr_url", "pull_request_url", "url", "html_url"):
-            texts.append(text_field(output, key))
-        result = output.get("result")
-        if isinstance(result, dict):
-            for key in ("pr_url", "pull_request_url", "url", "html_url"):
-                texts.append(text_field(result, key))
-            for key in ("pr_number", "number"):
-                value = result.get(key)
-                if isinstance(value, int) and value > 0:
-                    texts.append(f"PR#{value}")
-                elif isinstance(value, str) and value.strip().isdigit():
-                    texts.append(f"PR#{value.strip()}")
-        for key in ("pr_number", "number"):
-            value = output.get(key)
-            if isinstance(value, int) and value > 0:
-                texts.append(f"PR#{value}")
-            elif isinstance(value, str) and value.strip().isdigit():
-                texts.append(f"PR#{value.strip()}")
-    for key in ("pr_url", "pull_request_url", "url", "html_url"):
-        texts.append(text_field(row, key))
-    for key in ("pr_number", "number"):
-        value = row.get(key)
-        if isinstance(value, int) and value > 0:
-            texts.append(f"PR#{value}")
-        elif isinstance(value, str) and value.strip().isdigit():
-            texts.append(f"PR#{value.strip()}")
-    route_evidence = dict_field(row, "route_evidence")
-    if route_evidence is not None:
-        for key in ("pr_url", "pull_request_url", "url", "html_url"):
-            texts.append(text_field(route_evidence, key))
-        for key in ("pr_number", "number"):
-            value = route_evidence.get(key)
-            if isinstance(value, int) and value > 0:
-                texts.append(f"PR#{value}")
-            elif isinstance(value, str) and value.strip().isdigit():
-                texts.append(f"PR#{value.strip()}")
-    return [text for text in texts if text]
-
-
-def add_pr_refs_from_structured_output(
-    *,
-    refs: set[str],
-    sources: set[str],
-    source: str,
-    row: dict[str, Any],
-) -> bool:
-    added = False
-    for text in pr_ref_texts_from_structured_output(row):
-        for url in PR_URL_RE.findall(text):
-            refs.add(url)
-            sources.add(source)
-            added = True
-        for match in PR_CREATED_NUMBER_RE.findall(text):
-            refs.add(f"PR#{match}")
-            sources.add(source)
-            added = True
-        if text.startswith("PR#") and text[3:].isdigit():
-            refs.add(text)
-            sources.add(source)
-            added = True
-    return added
-
-
-def pr_evidence_from_row(row: dict[str, Any]) -> tuple[set[str], set[str]]:
-    refs: set[str] = set()
-    sources: set[str] = set()
-    source = text_field(row, "_source_path")
-    if row_succeeded(row):
-        add_pr_refs_from_structured_output(
-            refs=refs, sources=sources, source=source, row=row
-        )
-
-    return refs, sources
-
-
 def output_json(row: dict[str, Any]) -> dict[str, Any]:
     output = row.get("output")
     if isinstance(output, dict):
@@ -617,47 +510,6 @@ def trace_session_ids_from_row(row: dict[str, Any]) -> set[str]:
         add(container.get("trace_id"))
         add(container.get("session_id"))
     return ids
-
-
-def pr_creation_scan_paths(base_path: Path, name: str) -> list[Path]:
-    root = base_path / ".masc"
-    paths: list[Path] = decision_log_paths(base_path, name)
-    history = root / "keepers" / name / ".playground_pr_history.jsonl"
-    if history.exists():
-        paths.append(history)
-    for subdir in ("metrics", "execution-receipts"):
-        base = root / "keepers" / name / subdir
-        if base.is_dir():
-            paths.extend(
-                sorted(path for path in base.rglob("*.jsonl") if path.is_file())
-            )
-    trajectories = root / "trajectories" / name
-    if trajectories.is_dir():
-        paths.extend(
-            sorted(path for path in trajectories.glob("*.jsonl") if path.is_file())
-        )
-    calls_dir = root / "tool_calls"
-    if calls_dir.exists():
-        paths.extend(
-            sorted(path for path in calls_dir.rglob("*.jsonl") if path.is_file())
-        )
-    return paths
-
-
-def scan_pr_creation_evidence(base_path: Path, name: str) -> PrCreationEvidence:
-    refs: set[str] = set()
-    sources: set[str] = set()
-    for path in pr_creation_scan_paths(base_path, name):
-        for row in iter_jsonl(path):
-            row = dict(row)
-            row_keeper = row.get("keeper") or row.get("keeper_name") or row.get("name")
-            if isinstance(row_keeper, str) and row_keeper != name:
-                continue
-            row["_source_path"] = str(path)
-            row_refs, row_sources = pr_evidence_from_row(row)
-            refs.update(row_refs)
-            sources.update(row_sources)
-    return PrCreationEvidence(refs=refs, sources=sources)
 
 
 def board_post_paths(base_path: Path) -> list[Path]:
@@ -1054,8 +906,6 @@ def audit_keeper(
     require_web_search_evidence: bool,
     require_product_evidence: bool,
     require_design_evidence: bool,
-    require_pr_created_evidence: bool,
-    require_pr_url_evidence: bool,
     require_provider_turn_evidence: bool,
     require_checkpoint_evidence: bool,
     require_history_evidence: bool,
@@ -1091,11 +941,14 @@ def audit_keeper(
         failures.append("sandbox_not_docker")
     if network_mode != "inherit":
         failures.append("network_not_inherit")
-    if tool_preset not in PR_CAPABLE_PRESETS:
-        failures.append("preset_not_pr_capable")
+    if tool_preset not in WORK_CAPABLE_PRESETS:
+        failures.append("preset_not_work_capable")
     if not repo_cli_identity:
         failures.append("repo_cli_identity_missing")
-    elif forbidden_repo_cli_identities and repo_cli_identity in forbidden_repo_cli_identities:
+    elif (
+        forbidden_repo_cli_identities
+        and repo_cli_identity in forbidden_repo_cli_identities
+    ):
         failures.append(f"repo_cli_identity_forbidden_{repo_cli_identity}")
     if git_identity_mode != "repo_cli_identity":
         failures.append("git_identity_mode_not_repo_cli_identity")
@@ -1124,7 +977,6 @@ def audit_keeper(
         name,
         max_silence_hours=max_silence_hours,
     )
-    pr_creation_evidence = scan_pr_creation_evidence(base_path, name)
     web_search_ts, web_search_evidence = scan_keeper_web_search_evidence(
         base_path,
         name,
@@ -1172,8 +1024,6 @@ def audit_keeper(
     web_search_action = bool(web_search_evidence)
     product_action = bool(product_evidence)
     design_action = bool(design_evidence)
-    pr_created_evidence = pr_creation_evidence.created
-    pr_url_evidence = pr_creation_evidence.url_present
     provider_turn_evidence = persistent_work_evidence.provider_turn
     checkpoint_evidence = persistent_work_evidence.checkpoint
     history_evidence = persistent_work_evidence.history
@@ -1186,14 +1036,6 @@ def audit_keeper(
         failures.append("product_action_evidence_missing")
     if require_design_evidence and not design_action:
         failures.append("design_action_evidence_missing")
-    if require_pr_created_evidence and not pr_created_evidence:
-        failures.append("pr_created_evidence_missing")
-    elif not pr_created_evidence:
-        warnings.append("pr_created_evidence_missing")
-    if require_pr_url_evidence and not pr_url_evidence:
-        failures.append("pr_url_evidence_missing")
-    elif pr_created_evidence and not pr_url_evidence:
-        warnings.append("pr_url_evidence_missing")
     if require_provider_turn_evidence and not provider_turn_evidence:
         failures.append("provider_turn_evidence_missing")
     if require_checkpoint_evidence and not checkpoint_evidence:
@@ -1222,8 +1064,6 @@ def audit_keeper(
         web_search_action=web_search_action,
         product_action=product_action,
         design_action=design_action,
-        pr_created_evidence=pr_created_evidence,
-        pr_url_evidence=pr_url_evidence,
         provider_turn_evidence=provider_turn_evidence,
         checkpoint_evidence=checkpoint_evidence,
         history_evidence=history_evidence,
@@ -1233,8 +1073,6 @@ def audit_keeper(
         web_search_evidence=sorted(web_search_evidence),
         product_evidence=sorted(product_evidence),
         design_evidence=sorted(design_evidence),
-        pr_evidence_refs=sorted(pr_creation_evidence.refs),
-        pr_evidence_sources=sorted(pr_creation_evidence.sources),
         provider_turn_evidence_refs=sorted(persistent_work_evidence.provider_turn_refs),
         checkpoint_evidence_refs=sorted(persistent_work_evidence.checkpoint_refs),
         history_evidence_refs=sorted(persistent_work_evidence.history_refs),
@@ -1267,8 +1105,6 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
             require_web_search_evidence=args.require_web_search_evidence,
             require_product_evidence=args.require_product_evidence,
             require_design_evidence=args.require_design_evidence,
-            require_pr_created_evidence=args.require_pr_created_evidence,
-            require_pr_url_evidence=args.require_pr_url_evidence,
             require_provider_turn_evidence=(
                 args.require_provider_turn_evidence
                 or args.require_persistent_work_evidence
@@ -1317,8 +1153,6 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
             "require_product_evidence": args.require_product_evidence,
             "require_design_evidence": args.require_design_evidence,
             "forbid_repo_cli_identity": args.forbid_repo_cli_identity or [],
-            "require_pr_created_evidence": args.require_pr_created_evidence,
-            "require_pr_url_evidence": args.require_pr_url_evidence,
             "require_provider_turn_evidence": args.require_provider_turn_evidence,
             "require_checkpoint_evidence": args.require_checkpoint_evidence,
             "require_history_evidence": args.require_history_evidence,
@@ -1356,7 +1190,6 @@ def print_text(report: dict[str, Any]) -> None:
             "web_search={web_search} "
             "gh_account={github_account} "
             "product={product} design={design} "
-            "pr_created={pr_created} pr_url={pr_url} "
             "provider_turn={provider_turn} checkpoint={checkpoint} "
             "history={history} tool_call_log={tool_call_log}".format(
                 name=keeper["name"],
@@ -1372,16 +1205,12 @@ def print_text(report: dict[str, Any]) -> None:
                 web_search=str(keeper["web_search_action"]).lower(),
                 product=str(keeper["product_action"]).lower(),
                 design=str(keeper["design_action"]).lower(),
-                pr_created=str(keeper["pr_created_evidence"]).lower(),
-                pr_url=str(keeper["pr_url_evidence"]).lower(),
                 provider_turn=str(keeper["provider_turn_evidence"]).lower(),
                 checkpoint=str(keeper["checkpoint_evidence"]).lower(),
                 history=str(keeper["history_evidence"]).lower(),
                 tool_call_log=str(keeper["tool_call_log_evidence"]).lower(),
             )
         )
-        for ref in keeper["pr_evidence_refs"][:5]:
-            print(f"    pr_evidence: {ref}")
         for ref in keeper["web_search_evidence"][:5]:
             print(f"    web_search_evidence: {ref}")
         for ref in keeper["provider_turn_evidence_refs"][:3]:
@@ -1451,16 +1280,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "Fail unless each keeper has recent design-domain board evidence "
             "from explicit hearth or metadata markers."
         ),
-    )
-    parser.add_argument(
-        "--require-pr-created-evidence",
-        action="store_true",
-        help="Fail unless each keeper has structured successful PR creation evidence.",
-    )
-    parser.add_argument(
-        "--require-pr-url-evidence",
-        action="store_true",
-        help="Fail unless each keeper has a structured GitHub pull request URL.",
     )
     parser.add_argument(
         "--require-provider-turn-evidence",

--- a/scripts/lint/no-ocaml-comment-terminator-trap.sh
+++ b/scripts/lint/no-ocaml-comment-terminator-trap.sh
@@ -7,10 +7,10 @@
 # source, surfacing as a generic "Syntax error".
 #
 # Why this gate exists:
-#   PR #15836 cleanup added a comment naming pr_url consumers as
+#   PR #15836 cleanup added a comment naming legacy evidence consumers as
 #     (keeper_tool_call_log, keeper_hooks_oas, audit_keeper_*)
 #   The trailing `_*)` closed the surrounding block comment, so the
-#   next line ("already read pr_url as a typed field ...") was
+#   next line ("already read the typed field ...") was
 #   parsed as OCaml source. `dune build` reported:
 #     File "lib/tool_task.ml", line 907, characters 29-31: Syntax error
 #   PR #15846 hotfixed by replacing the glob with `audit_keeper_...`.

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -57,8 +57,6 @@ def audit_args(base_path: Path, expected_keepers: int):
         require_web_search_evidence=False,
         require_product_evidence=False,
         require_design_evidence=False,
-        require_pr_created_evidence=False,
-        require_pr_url_evidence=False,
         require_provider_turn_evidence=False,
         require_checkpoint_evidence=False,
         require_history_evidence=False,
@@ -286,142 +284,6 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
             with self.assertRaises(StopIteration):
                 next(rows)
             self.assertEqual(list(audit.iter_jsonl(root / "missing.jsonl")), [])
-
-    def test_pr_creation_evidence_ignores_free_text_claims(self):
-        refs, sources = audit.pr_evidence_from_row(
-            {
-                "_source_path": "events.jsonl",
-                "message": "created PR #123",
-                "response_preview": "https://github.com/acme/repo/pull/123",
-            }
-        )
-
-        self.assertEqual(refs, set())
-        self.assertEqual(sources, set())
-
-    def test_pr_creation_evidence_counts_successful_tool_execute_output(self):
-        refs, sources = audit.pr_evidence_from_row(
-            {
-                "_source_path": "events.jsonl",
-                "tool": "tool_execute",
-                "ok": True,
-                "output": {
-                    "pr_url": "https://github.com/acme/repo/pull/123",
-                    "number": 123,
-                },
-            }
-        )
-
-        self.assertEqual(
-            refs,
-            {
-                "https://github.com/acme/repo/pull/123",
-                "PR#123",
-            },
-        )
-        self.assertEqual(sources, {"events.jsonl"})
-
-    def test_pr_creation_evidence_rejects_failed_tool_execute_output(self):
-        refs, sources = audit.pr_evidence_from_row(
-            {
-                "_source_path": "events.jsonl",
-                "tool": "tool_execute",
-                "ok": False,
-                "output": {"pr_url": "https://github.com/acme/repo/pull/123"},
-            }
-        )
-
-        self.assertEqual(refs, set())
-        self.assertEqual(sources, set())
-
-    def test_pr_creation_evidence_rejects_generic_tool_execute_success(self):
-        refs, sources = audit.pr_evidence_from_row(
-            {
-                "_source_path": "events.jsonl",
-                "tool": "tool_execute",
-                "ok": True,
-                "output": {"ok": True, "stdout": "hello"},
-            }
-        )
-
-        self.assertEqual(refs, set())
-        self.assertEqual(sources, set())
-
-    def test_pr_creation_evidence_reads_structured_pr_url(self):
-        refs, sources = audit.pr_evidence_from_row(
-            {
-                "_source_path": "events.jsonl",
-                "tool": "tool_execute",
-                "ok": True,
-                "output": {"url": "https://github.com/acme/repo/pull/124"},
-            }
-        )
-
-        self.assertEqual(refs, {"https://github.com/acme/repo/pull/124"})
-        self.assertEqual(sources, {"events.jsonl"})
-
-    def test_pr_creation_evidence_ignores_freeform_pr_url_mentions(self):
-        refs, sources = audit.pr_evidence_from_row(
-            {
-                "_source_path": "events.jsonl",
-                "tool": "tool_execute",
-                "ok": True,
-                "message": "created https://github.com/acme/repo/pull/124",
-            }
-        )
-
-        self.assertEqual(refs, set())
-        self.assertEqual(sources, set())
-
-    def test_scan_pr_creation_evidence_reads_keeper_scoped_paths(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            keepers_dir = root / ".masc" / "keepers"
-            keepers_dir.mkdir(parents=True)
-            (keepers_dir / "alpha.decisions.jsonl").write_text(
-                json.dumps(
-                    {
-                        "tool": "tool_execute",
-                        "ok": True,
-                        "output": {
-                            "pr_url": "https://github.com/acme/repo/pull/125",
-                            "number": 125,
-                        },
-                    }
-                )
-                + "\n",
-                encoding="utf-8",
-            )
-
-            evidence = audit.scan_pr_creation_evidence(root, "alpha")
-
-        self.assertEqual(
-            evidence.refs,
-            {
-                "https://github.com/acme/repo/pull/125",
-                "PR#125",
-            },
-        )
-        self.assertEqual(
-            evidence.sources,
-            {str(keepers_dir / "alpha.decisions.jsonl")},
-        )
-
-    def test_pr_creation_evidence_reads_route_evidence_pr_url(self):
-        row = {
-            "_source_path": "tool_calls.jsonl",
-            "tool": "tool_execute",
-            "success": True,
-            "route_evidence": {
-                "pr_url": "https://github.com/acme/repo/pull/42\n",
-                "via": "docker",
-            },
-        }
-
-        refs, sources = audit.pr_evidence_from_row(row)
-
-        self.assertEqual(refs, {"https://github.com/acme/repo/pull/42"})
-        self.assertEqual(sources, {"tool_calls.jsonl"})
 
     def test_scan_keeper_evidence_reads_rotated_decision_logs(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -776,7 +638,6 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                     "output": json.dumps(
                         {
                             "ok": True,
-                            "pr_url": "https://github.com/acme/repo/pull/2",
                             "via": "docker",
                         }
                     ),

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1468,6 +1468,10 @@ let test_keeper_required_tool_contracts () =
           "pr_url_has_pull_ref");
   check bool "transition runtime no longer hoists pr_url aliases" true
     (file_not_contains_pattern "lib/tool_task.ml" "pr_url");
+  check bool "submit_pr_evidence action stays retired" true
+    (file_not_contains_pattern "lib/types/types_core.ml" "Submit_pr_evidence"
+     && file_not_contains_pattern "lib/tool_task_schemas.ml" "submit_pr_evidence"
+     && file_not_contains_pattern "lib/mcp_server.ml" "submit_pr_evidence");
   check bool "keeper msg schema documents required_tool_names alias" true
     (file_contains_pattern "lib/keeper/keeper_schema.ml"
        "required_tool_names")

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1750,20 +1750,27 @@ let test_public_execute_guidance_contracts () =
      && file_not_contains_pattern "lib/keeper/keeper_repo_readiness.ml"
           (raw_execute_with_command "git status"))
 
-let test_forge_pr_audit_contracts () =
-  check bool "keeper fleet audit has explicit PR-create flag" true
+let test_keeper_readiness_persistent_work_contracts () =
+  check bool "keeper fleet audit no longer exposes PR-create flags" true
+    (file_not_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+       ("--require-" ^ "pr-create-evidence")
+     && file_not_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+          ("--require-" ^ "pr-created-evidence")
+     && file_not_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+          ("--require-" ^ "pr-url-evidence"));
+  check bool "keeper fleet audit has explicit persistent-work flag" true
     (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
-       "--require-pr-create-evidence");
+       "--require-persistent-work-evidence");
   check bool "keeper fleet audit no longer consumes PR tool markers" true
     (file_not_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        ("PR_" ^ "CREATE_TOOLS")
      && file_not_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
           ("has_" ^ "gh_pr_create_marker"));
-  check bool "keeper fleet audit scans filesystem JSONL evidence" true
+  check bool "keeper fleet audit scans persistent filesystem JSONL evidence" true
     (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
-       "pr_creation_scan_paths"
+       "scan_persistent_work_evidence"
      && file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
-          {|root / "tool_calls"|});
+          "tool_call_log_path");
   check bool "keeper fleet audit no longer consumes retired side-stream metrics" true
     (file_not_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        ("pr-" ^ "action-metrics")
@@ -2844,8 +2851,8 @@ let () =
             test_public_execute_alias_contracts;
           test_case "public Execute guidance contracts" `Quick
             test_public_execute_guidance_contracts;
-          test_case "keeper PR audit contracts" `Quick
-            test_forge_pr_audit_contracts;
+          test_case "keeper readiness persistent work contracts" `Quick
+            test_keeper_readiness_persistent_work_contracts;
           test_case "dashboard warm hydration contracts" `Quick
             test_dashboard_warm_hydration_contracts;
            test_case "http read surface contracts" `Quick test_http_read_surface_contracts;

--- a/test/test_coord_task_lifecycle.ml
+++ b/test/test_coord_task_lifecycle.ml
@@ -41,7 +41,6 @@ let action_to_string = function
   | D.Submit_for_verification -> "submit_for_verification"
   | D.Approve_verification -> "approve"
   | D.Reject_verification -> "reject"
-  | D.Submit_pr_evidence -> "submit_pr_evidence"
 ;;
 
 let sort_actions xs =
@@ -108,16 +107,15 @@ let assert_consistent_with_decide
 (* ── Per-status pinning tests (same_agent=true, force=false, verification on) ── *)
 
 let test_todo () =
-  (* Todo: Claim opens the lifecycle. Submit_pr_evidence is the only direct
-     bypass into AwaitingVerification. Release is idempotent. Submit_for_verification
-     emits Verification_disabled when verification_enabled=false, otherwise
-     Invalid_transition — both are [Error]. Cancel from Todo is accepted. *)
+  (* Todo: Claim opens the lifecycle. Submit_for_verification can send
+     verifier-ready evidence directly to AwaitingVerification. Release is
+     idempotent. Cancel from Todo is accepted. *)
   let task_status = D.Todo in
   let actual =
     L.valid_next_actions
       ~verification_enabled:true ~same_agent:true ~force:false ~task_status
   in
-  let expected = [ D.Claim; D.Cancel; D.Release; D.Submit_pr_evidence ] in
+  let expected = [ D.Claim; D.Cancel; D.Release; D.Submit_for_verification ] in
   assert_actions ~ctx:"todo" ~expected ~actual;
   assert_consistent_with_decide
     ~ctx:"todo/consistency" ~verification_enabled:true
@@ -131,7 +129,7 @@ let test_claimed_by_self () =
       ~verification_enabled:true ~same_agent:true ~force:false ~task_status
   in
   (* From Claimed by self: Claim (idempotent), Start, Done, Cancel,
-     Release, Submit_for_verification. Submit_pr_evidence is Todo-only. *)
+     Release, Submit_for_verification. *)
   let expected =
     [ D.Claim
     ; D.Start
@@ -261,8 +259,6 @@ let test_verification_disabled_todo () =
       ~verification_enabled:false ~same_agent:true ~force:false ~task_status
   in
   let expected = [ D.Claim; D.Cancel; D.Release ] in
-  (* Note: Submit_pr_evidence under verification_disabled returns
-     Verification_disabled too — excluded compared to test_todo. *)
   assert_actions ~ctx:"todo-verification-disabled" ~expected ~actual;
   assert_consistent_with_decide
     ~ctx:"todo-verification-disabled/consistency" ~verification_enabled:false

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -95,7 +95,6 @@ let action_to_canonical = function
   | Submit_for_verification -> "submit_for_verification"
   | Approve_verification -> "approve"
   | Reject_verification -> "reject"
-  | Submit_pr_evidence -> "submit_pr_evidence"
 
 let check_action input expected =
   match task_action_of_string input with
@@ -160,7 +159,7 @@ let test_awaiting_verification_in_enum () =
     true (List.mem "awaiting_verification" valid_task_status_strings)
 
 let test_actions_enum_has_verification_actions () =
-  let must = ["submit_for_verification"; "approve"; "reject"; "submit_pr_evidence"] in
+  let must = ["submit_for_verification"; "approve"; "reject"] in
   List.iter (fun s ->
     Alcotest.(check bool) (Printf.sprintf "%s present" s) true
       (List.mem s valid_task_action_strings)


### PR DESCRIPTION
## Summary

- remove the `Submit_pr_evidence` task action variant and `submit_pr_evidence` public transition
- make `submit_for_verification` handle Todo -> AwaitingVerification directly when verification is enabled
- update lifecycle hints, MCP transition docs, task telemetry matches, tests, and source guards to the single submit action
- drop keeper fleet readiness PR-created/PR-URL evidence gates and their audit scans/tests

## Product impact

Verification now has one submit action: `submit_for_verification` with concrete `evidence_refs`. The old PR-specific bypass action and PR-readiness evidence gates are no longer part of the task FSM, schema surface, or keeper fleet readiness audit.

## Evidence

- `ocamlformat --check lib/types/types_core.ml lib/types/types_core.mli lib/coord/coord_task_lifecycle.ml lib/coord/coord_task_classify.ml lib/coord/coord_task_transition_executor.ml lib/coord/coord_task_transitions.ml lib/coord.ml lib/tool_task.ml lib/tool_task_args.ml lib/tool_task_payloads.ml lib/task_transition_state/task_transition_state.ml lib/task_transition_state/task_transition_state.mli lib/cdal_evidence_gate.mli lib/mcp_server.ml lib/keeper/keeper_accountability.ml lib/server/server_dashboard_http.ml test/test_coord_task_lifecycle.ml test/test_types.ml`
- `python3 -m py_compile scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `python3 test/test_audit_keeper_fleet_readiness.py`
- `ruff check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `ruff format --check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `pyright --outputjson scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `bash -n scripts/lint/no-ocaml-comment-terminator-trap.sh`
- `git diff --check`
- residue scan: no `Submit_pr_evidence` / `submit_pr_evidence` outside the new source guard assertion; audit PR evidence fields/flags/functions removed
- `scripts/dune-local.sh build test/test_coord_task_lifecycle.exe test/test_types.exe test/test_tool_task_coverage.exe test/test_keeper_task_dispatch.exe test/test_ci_hardening_source.exe --cache=disabled` blocked with exit 75 because live bare Dune processes were already running outside `scripts/dune-local.sh`

## Direct evidence

schema_version: 1
direct_ratio: 7/8
provenance: mixed

Local static/Python checks passed; focused Dune was blocked by the host-wide bare Dune guard, not by a compiler error from this branch.

## Review evidence

Draft stacked PR on top of #19154 for CI/reviewer pass.

## Linked issue

None.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`refactor/submit-verification-unify-20260527` → `refactor/verification-evidence-refs-20260527` · 3 commit(s) · synced 2026-05-27T14:09:23Z

| sha | subject | date |
|---|---|---|
| `507bb4cf4` | refactor(task): unify verification submit action | 2026-05-27 |
| `757823fb0` | refactor(audit): drop PR evidence readiness gates | 2026-05-27 |
| `c4b7f0196` | test: update readiness audit source guard | 2026-05-27 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->