### PR TITLE
refactor(dashboard/async-state): route 2 inline error ternaries through file-local toErrorMessage helper

### DIFF
--- a/dashboard/src/lib/async-state.ts
+++ b/dashboard/src/lib/async-state.ts
@@ -89,7 +89,7 @@ export function createAsyncResource<T>(): AsyncResource<T> {
         promise = fn()
       } catch (e) {
         if (gen === generation) {
-          state.value = failed(e instanceof Error ? e.message : String(e))
+          state.value = failed(toErrorMessage(e))
         }
         return Promise.resolve()
       }
@@ -99,7 +99,7 @@ export function createAsyncResource<T>(): AsyncResource<T> {
           if (gen === generation) state.value = loaded(data)
         })
         .catch(e => {
-          if (gen === generation) state.value = failed(e instanceof Error ? e.message : String(e))
+          if (gen === generation) state.value = failed(toErrorMessage(e))
         })
         .finally(() => {
           if (gen === generation) inflight = null


### PR DESCRIPTION
## 요약
`lib/async-state.ts` 의 *file-internal SSOT 위반* 정리 — 같은 file 안 `toErrorMessage` helper 가 존재하는데 2 callsite 가 inline 으로 ternary 재작성. helper 경유로 route.

## 배경
`rg "instanceof Error \? \w+\.message : String\(\w+\)" lib/async-state.ts -n` 결과:

```
92:  state.value = failed(e instanceof Error ? e.message : String(e))
102: state.value = failed(e instanceof Error ? e.message : String(e))
120: return error instanceof Error ? error.message : String(error)  // function toErrorMessage
```

`toErrorMessage` 가 file-internal helper (line 119-121) — 그러나 *같은 file 안 line 92/102* 가 *inline ternary* 사용. helper 우회.

**file-internal SSOT 위반** — *file 안* 에서 SSOT 깨짐. helper 정책 변경 (예: `'unknown error'` fallback) 시 *같은 file 안 callsite 가 미적용*. iter#48-58 의 *cross-file file-internal helper sweep* 의 *intra-file 변형*.

## 변경

- `lib/async-state.ts:92` — `e instanceof Error ? e.message : String(e)` → `toErrorMessage(e)`
- `lib/async-state.ts:102` — 동일 migration

기존 `toErrorMessage` helper 본문 그대로 — 런타임 동작 변경 0.

## 검증

- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = baseline)

## scope 작은 이유 = iter#64 학습

iter#64 가 *45 callsite × 27 file* sweep 시도 → 27 file × 매뉴얼 import 부담 + 6 PR backlog 와 충돌 → 전체 revert. 본 iter 는 *1 file × 2 callsite, helper 이미 존재* — *최소 surgical*. iter#64 의 *scope 평가 학습* 적용.

## iter chain

- iter#48-58/61-62: *cross-file* file-internal helper sweep (8 회)
- iter#65: **intra-file** file-internal helper sweep — *같은 file 안* 의 callsite ↔ helper bypass

같은 SSOT class 의 *해소 차원* — *file scope 내부 일관성*.

## /loop iter#65
SSOT 위반 dashboard 축출 loop 의 iter#65. cumulative 63 PR (37 머지 + 6 OPEN + 1 OPEN). iter#64 revert 후 작은 surgical 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
