### PR TITLE
[codex] Optimize HTTP JSON response hot paths

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -9,6 +9,7 @@
  auth_nickname
  plan_action_outcome
  prometheus_text
+ http_response_payload
  error_event_type
  keeper_alert_persist_kind
  keeper_metrics_sse_failure_kind

--- a/lib/http_response_payload.ml
+++ b/lib/http_response_payload.ml
@@ -1,0 +1,69 @@
+(** Shared HTTP response payload handling.
+
+    Keep Accept-Encoding parsing, compression choice, and response headers in
+    one place so H1, H2, and gateway routes do not drift as endpoint count
+    grows. *)
+
+let vary_accept_encoding = ("vary", "Accept-Encoding")
+
+let lower_trim s = String.trim s |> String.lowercase_ascii
+
+let q_value params =
+  let parse_q param =
+    let param = lower_trim param in
+    if String.starts_with ~prefix:"q=" param then
+      match float_of_string_opt (String.sub param 2 (String.length param - 2)) with
+      | Some q -> Some q
+      | None -> Some 0.0
+    else
+      None
+  in
+  Option.value ~default:1.0 (List.find_map parse_q params)
+
+let encoding_matches accepted token =
+  match String.split_on_char ';' accepted with
+  | [] -> false
+  | raw_token :: params ->
+      let raw_token = lower_trim raw_token in
+      (String.equal raw_token token || String.equal raw_token "*") && q_value params > 0.0
+
+let accepts_encoding_header ~token = function
+  | None -> false
+  | Some accept_encoding ->
+      accept_encoding
+      |> String.split_on_char ','
+      |> List.exists (fun accepted -> encoding_matches accepted token)
+
+let accepts_zstd_header header =
+  accepts_encoding_header ~token:"zstd" header
+
+let accepts_zstd_dict_header = function
+  | None -> false
+  | Some accept_encoding ->
+      accept_encoding
+      |> String.split_on_char ','
+      |> List.exists (fun accepted ->
+        match String.split_on_char ';' accepted with
+        | [] -> false
+        | raw_token :: params ->
+            let raw_token = lower_trim raw_token in
+            let params = List.map lower_trim params in
+            q_value params > 0.0
+            && (String.equal raw_token "zstd-dict"
+                || (String.equal raw_token "zstd"
+                    && List.exists (String.equal "dict=masc") params)))
+
+let compress_body ?(level = 3) ?(compress = true) ~accept_encoding body =
+  if not compress then
+    body, []
+  else if not (accepts_zstd_header accept_encoding) then
+    body, [ vary_accept_encoding ]
+  else
+    match Compression_codec.compress ~level body with
+    | Compression_codec.Unchanged payload -> payload, [ vary_accept_encoding ]
+    | Compression_codec.Compressed { payload; encoding } ->
+        ( payload
+        , [
+            ("content-encoding", Compression_codec.content_encoding encoding);
+            vary_accept_encoding;
+          ] )

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -44,25 +44,13 @@ type request_handler =
 module Compression = struct
   (** Check if client accepts zstd encoding *)
   let accepts_zstd (request : Httpun.Request.t) : bool =
-    match Httpun.Headers.get request.headers "accept-encoding" with
-    | Some accept_encoding ->
-        String.lowercase_ascii accept_encoding
-        |> fun s -> String.split_on_char ',' s
-        |> List.exists (fun enc ->
-             String.trim enc |> String.lowercase_ascii |> fun e ->
-             e = "zstd" || String.sub e 0 (min 4 (String.length e)) = "zstd")
-    | None -> false
+    Http_response_payload.accepts_zstd_header
+      (Httpun.Headers.get request.headers "accept-encoding")
 
   (** Check if client accepts dictionary-enhanced zstd *)
   let accepts_zstd_dict (request : Httpun.Request.t) : bool =
-    match Httpun.Headers.get request.headers "accept-encoding" with
-    | Some accept_encoding ->
-        String.lowercase_ascii accept_encoding
-        |> String.split_on_char ','
-        |> List.exists (fun enc ->
-             let e = String.trim enc in
-             e = "zstd-dict" || e = "zstd;dict=masc")
-    | None -> false
+    Http_response_payload.accepts_zstd_dict_header
+      (Httpun.Headers.get request.headers "accept-encoding")
 
   (** Compress with dictionary if beneficial
       @return (compressed_data, encoding_name option) *)
@@ -199,31 +187,27 @@ module Response = struct
       @param compress Enable compression if client accepts (default: true)
       @param request Optional request to check Accept-Encoding header *)
   let json ?(status = `OK) ?(compress = true) ?(extra_headers = []) ?request body reqd =
-    let should_compress =
-      compress &&
+    let request =
       match request with
-      | Some req -> Compression.accepts_zstd req
-      | None -> false
+      | Some req -> req
+      | None -> Httpun.Reqd.request reqd
     in
-    let final_body, encoding =
-      if should_compress then
-        (* Use dictionary-based compression for better small message handling *)
-        Compression.compress body
-      else
-        (body, None)
+    let final_body, compression_headers =
+      Http_response_payload.compress_body
+        ~compress
+        ~accept_encoding:(Httpun.Headers.get request.headers "accept-encoding")
+        body
     in
     let base_headers = [
       ("content-type", "application/json; charset=utf-8");
       ("content-length", string_of_int (String.length final_body));
-      ("vary", "Accept-Encoding");
     ] in
-    let headers = match encoding with
-      | Some enc -> ("content-encoding", enc) :: base_headers
-      | None -> base_headers
-    in
-    let headers = extra_headers @ headers in
+    let headers = extra_headers @ base_headers @ compression_headers in
     let response = Httpun.Response.create ~headers:(Httpun.Headers.of_list headers) status in
     safe_respond_with_string reqd response final_body
+
+  let json_value ?status ?compress ?extra_headers ?request value reqd =
+    json ?status ?compress ?extra_headers ?request (Yojson.Safe.to_string value) reqd
 
   (** Sunset headers for deprecated endpoints per RFC 8594.
       [date] must be an HTTP-date (RFC 7231 S7.1.1.1), e.g. ["Sat, 01 Jun 2026 00:00:00 GMT"].
@@ -265,24 +249,18 @@ module Response = struct
         safe_respond_with_string reqd response ""
     | _ ->
         (* Serve full response, with compression if possible *)
-        let accepts_zstd = Compression.accepts_zstd request in
-        let final_body, encoding =
-          if accepts_zstd then
-            let (compressed, did_compress) = Compression.compress_zstd ~level:3 body in
-            if did_compress then (compressed, Some "zstd") else (body, None)
-          else (body, None)
+        let final_body, compression_headers =
+          Http_response_payload.compress_body
+            ~accept_encoding:(Httpun.Headers.get request.Httpun.Request.headers "accept-encoding")
+            body
         in
         let base_headers = [
           ("content-type", "text/html; charset=utf-8");
           ("content-length", string_of_int (String.length final_body));
           ("etag", etag_value);
           ("cache-control", html_cache_control);
-          ("vary", "Accept-Encoding");
         ] in
-        let headers = match encoding with
-          | Some enc -> ("content-encoding", enc) :: base_headers
-          | None -> base_headers
-        in
+        let headers = base_headers @ compression_headers in
         let response = Httpun.Response.create ~headers:(Httpun.Headers.of_list headers) status in
         safe_respond_with_string reqd response final_body
 

--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -108,7 +108,8 @@ module Response : sig
 
   (** JSON response with optional zstd compression.  Default
       status [`OK].  When [compress = true] (default) AND
-      [?request] supplies a [Compression.accepts_zstd] match,
+      [?request] or the request attached to [reqd] supplies an
+      [Accept-Encoding: zstd] match,
       uses dictionary-based compression for small messages
       (~70% reduction vs ~6% with standard zstd). *)
   val json
@@ -117,6 +118,15 @@ module Response : sig
     -> ?extra_headers:(string * string) list
     -> ?request:Httpun.Request.t
     -> string
+    -> Httpun.Reqd.t
+    -> unit
+
+  val json_value
+    :  ?status:Httpun.Status.t
+    -> ?compress:bool
+    -> ?extra_headers:(string * string) list
+    -> ?request:Httpun.Request.t
+    -> Yojson.Safe.t
     -> Httpun.Reqd.t
     -> unit
 

--- a/lib/http_server_h2.ml
+++ b/lib/http_server_h2.ml
@@ -40,6 +40,13 @@ let request_of_reqd reqd =
 
 (** Simple response helpers - H2 streaming API *)
 module Response = struct
+  let maybe_compress ?(compress = true) reqd body =
+    let request = H2.Reqd.request reqd in
+    Http_response_payload.compress_body
+      ~compress
+      ~accept_encoding:(H2.Headers.get request.headers "accept-encoding")
+      body
+
   (** Send a complete response body *)
   let send_body reqd response body =
     (* H2 API: respond_with_streaming returns Body.Writer.t directly
@@ -48,32 +55,37 @@ module Response = struct
     H2.Body.Writer.write_string writer body;
     H2.Body.Writer.close writer
 
-  let text ?(status = `OK) body reqd =
-    let headers = H2.Headers.of_list ([
-      ("content-type", "text/plain; charset=utf-8");
-      ("content-length", string_of_int (String.length body));
-    ]) in
+  let send_typed_body
+      ?(status = `OK)
+      ?(headers = [])
+      ?(compress = true)
+      ~content_type
+      body
+      reqd =
+    let final_body, compression_headers = maybe_compress ~compress reqd body in
+    let headers =
+      H2.Headers.of_list
+        ([
+           ("content-type", content_type);
+           ("content-length", string_of_int (String.length final_body));
+         ]
+        @ compression_headers
+        @ headers)
+    in
     let response = H2.Response.create ~headers status in
-    send_body reqd response body
+    send_body reqd response final_body
+
+  let text ?(status = `OK) body reqd =
+    send_typed_body ~status ~content_type:"text/plain; charset=utf-8" body reqd
 
   let html ?(status = `OK) ?(headers = []) body reqd =
-    let base_headers = [
-      ("content-type", "text/html; charset=utf-8");
-      ("content-length", string_of_int (String.length body));
-    ] in
-    let response = H2.Response.create
-      ~headers:(H2.Headers.of_list (base_headers @ headers))
-      status
-    in
-    send_body reqd response body
+    send_typed_body ~status ~headers ~content_type:"text/html; charset=utf-8" body reqd
 
   let json ?(status = `OK) body reqd =
-    let headers = H2.Headers.of_list ([
-      ("content-type", "application/json; charset=utf-8");
-      ("content-length", string_of_int (String.length body));
-    ]) in
-    let response = H2.Response.create ~headers status in
-    send_body reqd response body
+    send_typed_body ~status ~content_type:"application/json; charset=utf-8" body reqd
+
+  let json_value ?status value reqd =
+    json ?status (Yojson.Safe.to_string value) reqd
 
   let not_found reqd =
     text ~status:`Not_found "404 Not Found" reqd
@@ -97,15 +109,7 @@ module Response = struct
     H2.Reqd.respond_with_streaming ~flush_headers_immediately:true reqd response
 
   let bytes ?(status = `OK) ?(headers = []) ~content_type body reqd =
-    let base_headers = [
-      ("content-type", content_type);
-      ("content-length", string_of_int (String.length body));
-    ] in
-    let response = H2.Response.create
-      ~headers:(H2.Headers.of_list (base_headers @ headers))
-      status
-    in
-    send_body reqd response body
+    send_typed_body ~status ~headers ~compress:false ~content_type body reqd
 
   let internal_error msg reqd =
     text ~status:`Internal_server_error ("500 Internal Server Error: " ^ msg) reqd

--- a/lib/http_server_h2.mli
+++ b/lib/http_server_h2.mli
@@ -85,7 +85,12 @@ module Response : sig
     ?status:H2.Status.t -> string -> H2.Reqd.t -> unit
   (** JSON response.  Default status [`OK].  Sets
       [content-type: application/json; charset=utf-8] and
-      [content-length]. *)
+      [content-length].  Compresses with zstd when the H2 request
+      advertises [Accept-Encoding: zstd]. *)
+
+  val json_value :
+    ?status:H2.Status.t -> Yojson.Safe.t -> H2.Reqd.t -> unit
+  (** JSON response from a structured Yojson value. *)
 
   val not_found : H2.Reqd.t -> unit
   (** Pinned ["404 Not Found"] body, status [`Not_found]. *)

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -582,7 +582,13 @@ let cors_headers origin =
 
 let respond_json_with_cors ?(status = `OK) request reqd body =
   let origin = get_origin request in
-  Http_server_eio.Response.json ~status ~extra_headers:(cors_headers origin) body reqd
+  Http_server_eio.Response.json ~status ~request
+    ~extra_headers:(cors_headers origin) body reqd
+
+let respond_json_value_with_cors ?(status = `OK) request reqd value =
+  let origin = get_origin request in
+  Http_server_eio.Response.json_value ~status ~request
+    ~extra_headers:(cors_headers origin) value reqd
 
 let public_read_cors_headers request =
   match public_read_cors_origin_opt request with
@@ -591,7 +597,11 @@ let public_read_cors_headers request =
 
 let respond_public_read_json ?(status = `OK) request reqd body =
   Http_server_eio.Response.json ~status
-    ~extra_headers:(public_read_cors_headers request) body reqd
+    ~request ~extra_headers:(public_read_cors_headers request) body reqd
+
+let respond_public_read_json_value ?(status = `OK) request reqd value =
+  Http_server_eio.Response.json_value ~status
+    ~request ~extra_headers:(public_read_cors_headers request) value reqd
 
 let auth_error_json err =
   Yojson.Safe.to_string

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -220,6 +220,11 @@ val respond_json_with_cors :
   Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
 (** Send a JSON body with CORS headers attached. *)
 
+val respond_json_value_with_cors :
+  ?status:Httpun.Status.t ->
+  Httpun.Request.t -> Httpun.Reqd.t -> Yojson.Safe.t -> unit
+(** Send a structured JSON body with CORS headers attached. *)
+
 val public_read_cors_headers :
   Httpun.Request.t -> (string * Httpun.Headers.value) list
 (** Header set for public-read responses (looser than the protected
@@ -229,6 +234,11 @@ val respond_public_read_json :
   ?status:Httpun.Status.t ->
   Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
 (** Public-read JSON responder. *)
+
+val respond_public_read_json_value :
+  ?status:Httpun.Status.t ->
+  Httpun.Request.t -> Httpun.Reqd.t -> Yojson.Safe.t -> unit
+(** Structured public-read JSON responder. *)
 
 val auth_error_json : Masc_domain.masc_error -> string
 (** Render an auth error as the standard JSON envelope. *)

--- a/lib/server/server_dashboard_http_agent_api.ml
+++ b/lib/server/server_dashboard_http_agent_api.ml
@@ -34,14 +34,14 @@ let add_agent_api_routes router =
                ("last_seen", `Float a.last_seen);
              ]) activities));
          ] in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
 
   (* Tool metrics -- unified registry stats for dashboard *)
   |> Http.Router.get "/api/v1/tool-metrics" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = Tool_unified.summary_report () in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
 
   (* Agent timeline -- per-agent activity timeline for Observatory detail *)
@@ -55,8 +55,13 @@ let add_agent_api_routes router =
            | None -> ""
          in
          if agent_name = "" then
-           Http.Response.json ~status:`Bad_request
-             {|{"error":"agent_name query parameter is required"}|} reqd
+           Http.Response.json_value ~status:`Bad_request
+             (`Assoc
+                [
+                  ( "error",
+                    `String "agent_name query parameter is required" );
+                ])
+             reqd
          else
            let since_hours =
              match Server_utils.query_param req "since_hours" with
@@ -75,8 +80,7 @@ let add_agent_api_routes router =
                ~include_tasks:true ~include_board:false
                ~include_tool_calls:true
            in
-           Http.Response.json ~compress:true ~request:req
-             (Yojson.Safe.to_string json) reqd
+          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
 
   (* Agent relations -- collaboration network + trust edges *)
@@ -90,10 +94,14 @@ let add_agent_api_routes router =
            | None -> ""
          in
          if agent_name = "" then
-           Http.Response.json ~status:`Bad_request
-             {|{"error":"agent_name query parameter is required"}|} reqd
+           Http.Response.json_value ~status:`Bad_request
+             (`Assoc
+                [
+                  ( "error",
+                    `String "agent_name query parameter is required" );
+                ])
+             reqd
          else
            let json = Dashboard_agent_relations.json ~agent_name () in
-           Http.Response.json ~compress:true ~request:req
-             (Yojson.Safe.to_string json) reqd
+          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -33,6 +33,20 @@ type keeper_purge_cleanup_result =
   ; agent_cleanup_results : agent_purge_cleanup_result list
   }
 
+let invalid_request field =
+  Printf.sprintf "invalid request: requires {\"%s\":\"...\"}" field
+;;
+
+let respond_ok ~request reqd =
+  Http.Response.json_value ~compress:true ~request (`Assoc [ ("ok", `Bool true) ]) reqd
+;;
+
+let respond_error ?(status = `Bad_request) ~request reqd message =
+  Http.Response.json_value ~status ~request
+    (`Assoc [ ("ok", `Bool false); ("error", `String message) ])
+    reqd
+;;
+
 let rec rm_rf path =
   if Fs_compat.file_exists path
   then if Sys.is_directory path
@@ -301,21 +315,15 @@ let add_delete_action_routes router =
              let json = Yojson.Safe.from_string body_str in
              match Safe_ops.json_string_opt "post_id" json with
              | None ->
-                 Http.Response.json ~status:`Bad_request ~request:req
-                   {|{"ok":false,"error":"invalid request: requires {\"post_id\":\"...\"}"}|} reqd
+                 respond_error ~request:req reqd (invalid_request "post_id")
              | Some post_id ->
              match Board_dispatch.delete_post ~post_id with
-             | Ok () ->
-                 Http.Response.json ~compress:true ~request:req
-                   {|{"ok":true}|} reqd
+             | Ok () -> respond_ok ~request:req reqd
              | Error err ->
-                 Http.Response.json ~status:`Not_found ~request:req
-                   (Printf.sprintf {|{"ok":false,"error":"%s"}|}
-                      (String.escaped (Board_types.show_board_error err)))
-                   reqd
+                 respond_error ~status:`Not_found ~request:req reqd
+                   (Board_types.show_board_error err)
            with Yojson.Json_error _ ->
-             Http.Response.json ~status:`Bad_request ~request:req
-               {|{"ok":false,"error":"invalid request: requires {\"post_id\":\"...\"}"}|} reqd
+             respond_error ~request:req reqd (invalid_request "post_id")
          )
        ) request reqd)
 
@@ -327,22 +335,17 @@ let add_delete_action_routes router =
              let json = Yojson.Safe.from_string body_str in
              match Safe_ops.json_string_opt "task_id" json with
              | None ->
-                 Http.Response.json ~status:`Bad_request ~request:req
-                   {|{"ok":false,"error":"invalid request: requires {\"task_id\":\"...\"}"}|} reqd
+                 respond_error ~request:req reqd (invalid_request "task_id")
              | Some task_id ->
              let config = state.Mcp_server.room_config in
              match Task_dispatch.delete_task config ~task_id with
-             | Ok () ->
-                 Http.Response.json ~compress:true ~request:req
-                   {|{"ok":true}|} reqd
+             | Ok () -> respond_ok ~request:req reqd
              | Error err ->
-                 Http.Response.json ~status:`Not_found ~request:req
-                   (Printf.sprintf {|{"ok":false,"error":"task delete failed: %s"}|}
-                      (String.escaped (Masc_domain.masc_error_to_string err)))
-                   reqd
+                 respond_error ~status:`Not_found ~request:req reqd
+                   (Printf.sprintf "task delete failed: %s"
+                      (Masc_domain.masc_error_to_string err))
            with Yojson.Json_error _ ->
-             Http.Response.json ~status:`Bad_request ~request:req
-               {|{"ok":false,"error":"invalid request: requires {\"task_id\":\"...\"}"}|} reqd
+             respond_error ~request:req reqd (invalid_request "task_id")
          )
        ) request reqd)
 
@@ -354,21 +357,15 @@ let add_delete_action_routes router =
              let json = Yojson.Safe.from_string body_str in
              match Safe_ops.json_string_opt "goal_id" json with
              | None ->
-                 Http.Response.json ~status:`Bad_request ~request:req
-                   {|{"ok":false,"error":"invalid request: requires {\"goal_id\":\"...\"}"}|} reqd
+                 respond_error ~request:req reqd (invalid_request "goal_id")
              | Some goal_id ->
              let config = state.Mcp_server.room_config in
              match Goal_store.delete_goal config ~goal_id with
-             | Ok () ->
-                 Http.Response.json ~compress:true ~request:req
-                   {|{"ok":true}|} reqd
+             | Ok () -> respond_ok ~request:req reqd
              | Error msg ->
-                 Http.Response.json ~status:`Not_found ~request:req
-                   (Printf.sprintf {|{"ok":false,"error":"%s"}|} (String.escaped msg))
-                   reqd
+                 respond_error ~status:`Not_found ~request:req reqd msg
            with Yojson.Json_error _ ->
-             Http.Response.json ~status:`Bad_request ~request:req
-               {|{"ok":false,"error":"invalid request: requires {\"goal_id\":\"...\"}"}|} reqd
+             respond_error ~request:req reqd (invalid_request "goal_id")
          )
        ) request reqd)
 
@@ -380,9 +377,7 @@ let add_delete_action_routes router =
              let json = Yojson.Safe.from_string body_str in
              match Safe_ops.json_string_opt "agent_name" json with
              | None ->
-               Http.Response.json ~status:`Bad_request ~request:req
-                 {|{"ok":false,"error":"invalid request: requires {\"agent_name\":\"...\"}"}|}
-                 reqd
+               respond_error ~request:req reqd (invalid_request "agent_name")
              | Some requested_name ->
                let config = state.Mcp_server.room_config in
                (match resolve_keeper_purge_target config requested_name with
@@ -391,23 +386,21 @@ let add_delete_action_routes router =
                   let purge_result =
                     purge_keeper_artifacts config requested_name keeper_target
                   in
-                  Http.Response.json ~compress:true ~request:req
-                    (Yojson.Safe.to_string
-                       (`Assoc
-                          [
-                            ("ok", `Bool true);
-                            ("target_kind", `String "keeper");
-                            ("agent_name", `String keeper_target.agent_name);
-                            ("keeper_name", `String keeper_target.keeper_name);
-                            ("removed_keeper_toml", `Bool toml_deleted);
-                            ( "keeper_pending_confirms_removed",
-                              `Int purge_result.keeper_pending_confirms_removed
-                            );
-                            ( "cleanup_results",
-                              `List
-                                (List.map agent_purge_cleanup_result_to_json
-                                   purge_result.agent_cleanup_results) );
-                          ]))
+                  Http.Response.json_value ~compress:true ~request:req
+                    (`Assoc
+                       [
+                         ("ok", `Bool true);
+                         ("target_kind", `String "keeper");
+                         ("agent_name", `String keeper_target.agent_name);
+                         ("keeper_name", `String keeper_target.keeper_name);
+                         ("removed_keeper_toml", `Bool toml_deleted);
+                         ( "keeper_pending_confirms_removed",
+                           `Int purge_result.keeper_pending_confirms_removed );
+                         ( "cleanup_results",
+                           `List
+                             (List.map agent_purge_cleanup_result_to_json
+                                purge_result.agent_cleanup_results) );
+                       ])
                     reqd
                 | None -> (
                   match resolve_plain_agent_target config requested_name with
@@ -416,27 +409,23 @@ let add_delete_action_routes router =
                       purge_agent_filesystem_artifacts config
                         [ requested_name; agent_name ]
                     in
-                    Http.Response.json ~compress:true ~request:req
-                      (Yojson.Safe.to_string
-                         (`Assoc
-                            [
-                              ("ok", `Bool true);
-                              ("target_kind", `String "agent");
-                              ("agent_name", `String agent_name);
-                              ( "cleanup_results",
-                                `List
-                                  (List.map agent_purge_cleanup_result_to_json
-                                     cleanup_results) );
-                            ]))
+                    Http.Response.json_value ~compress:true ~request:req
+                      (`Assoc
+                         [
+                           ("ok", `Bool true);
+                           ("target_kind", `String "agent");
+                           ("agent_name", `String agent_name);
+                           ( "cleanup_results",
+                             `List
+                               (List.map agent_purge_cleanup_result_to_json
+                                  cleanup_results) );
+                         ])
                       reqd
                   | None ->
-                    Http.Response.json ~status:`Not_found ~request:req
-                      {|{"ok":false,"error":"agent or keeper not found"}|}
-                      reqd))
+                    respond_error ~status:`Not_found ~request:req reqd
+                      "agent or keeper not found"))
            with Yojson.Json_error _ ->
-             Http.Response.json ~status:`Bad_request ~request:req
-               {|{"ok":false,"error":"invalid request: requires {\"agent_name\":\"...\"}"}|}
-               reqd
+             respond_error ~request:req reqd (invalid_request "agent_name")
          )
        ) request reqd)
 
@@ -446,10 +435,12 @@ let add_delete_action_routes router =
          let config = state.Mcp_server.room_config in
          let sweep_config = Goal_janitor.runtime_config () in
          let result = Goal_janitor.run ~config:sweep_config config in
-         Http.Response.json ~compress:true ~request
-           (Yojson.Safe.to_string
-              (`Assoc [("ok", `Bool true);
-                       ("result", Goal_janitor.sweep_result_to_yojson result)]))
+         Http.Response.json_value ~compress:true ~request
+           (`Assoc
+              [
+                ("ok", `Bool true);
+                ("result", Goal_janitor.sweep_result_to_yojson result);
+              ])
            reqd
        ) request reqd)
 
@@ -477,30 +468,29 @@ let add_delete_action_routes router =
                Board_moderation.flag_reason_of_string reason_str
                |> Option.value ~default:Board_moderation.Spam
              in
-             (match Safe_ops.json_string_opt "target_id" json with
-              | None ->
-                  Http.Response.json ~status:`Bad_request ~request:req
-                    {|{"ok":false,"error":"invalid request: requires {\"target_id\":\"...\"}"}|} reqd
-              | Some target_id ->
+            (match Safe_ops.json_string_opt "target_id" json with
+             | None ->
+                  respond_error ~request:req reqd (invalid_request "target_id")
+             | Some target_id ->
                   let reporter =
                     Safe_ops.json_string_opt "reporter" json
                     |> Option.value ~default:"operator"
                   in
-                  (match Board_moderation.flag ~target_kind ~target_id ~reporter ~reason with
-                   | Error msg ->
-                       Http.Response.json ~status:`Conflict ~request:req
-                         (Yojson.Safe.to_string
-                            (`Assoc [("ok", `Bool false); ("error", `String msg)]))
+                   (match Board_moderation.flag ~target_kind ~target_id ~reporter ~reason with
+                    | Error msg ->
+                       Http.Response.json_value ~status:`Conflict ~request:req
+                         (`Assoc [("ok", `Bool false); ("error", `String msg)])
                          reqd
-                   | Ok entry ->
-                       Http.Response.json ~compress:true ~request:req
-                         (Yojson.Safe.to_string
-                            (`Assoc [("ok", `Bool true);
-                                     ("entry", Board_moderation.queue_entry_to_json entry)]))
+                    | Ok entry ->
+                       Http.Response.json_value ~compress:true ~request:req
+                         (`Assoc
+                            [
+                              ("ok", `Bool true);
+                              ("entry", Board_moderation.queue_entry_to_json entry);
+                            ])
                          reqd))
            with Yojson.Json_error _ ->
-             Http.Response.json ~status:`Bad_request ~request:req
-               {|{"ok":false,"error":"invalid JSON body"}|} reqd
+             respond_error ~request:req reqd "invalid JSON body"
          )
        ) request reqd)
 
@@ -519,8 +509,7 @@ let add_delete_action_routes router =
            ("entries", `List (List.map Board_moderation.queue_entry_to_json entries));
            ("count",   `Int (List.length entries));
          ] in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
 
   |> Http.Router.post "/api/v1/dashboard/board/moderation/action" (fun request reqd ->
@@ -541,20 +530,22 @@ let add_delete_action_routes router =
                Safe_ops.json_string_opt "action" json
                |> Option.value ~default:""
              in
-             (match Board_moderation.action_kind_of_string action_str with
-              | None ->
-                  Http.Response.json ~status:`Bad_request ~request:req
-                    (Yojson.Safe.to_string
-                       (`Assoc [("ok", `Bool false);
-                                ("error",
-                                 `String ("unknown action: " ^ action_str ^
-                                          "; valid: approve, remove, hide, warn"))]))
+               (match Board_moderation.action_kind_of_string action_str with
+                | None ->
+                  Http.Response.json_value ~status:`Bad_request ~request:req
+                    (`Assoc
+                       [
+                         ("ok", `Bool false);
+                         ( "error",
+                           `String
+                             ("unknown action: " ^ action_str
+                            ^ "; valid: approve, remove, hide, warn") );
+                       ])
                     reqd
               | Some action ->
                   (match Safe_ops.json_string_opt "target_id" json with
                    | None ->
-                       Http.Response.json ~status:`Bad_request ~request:req
-                         {|{"ok":false,"error":"invalid request: requires {\"target_id\":\"...\"}"}|} reqd
+                       respond_error ~request:req reqd (invalid_request "target_id")
                    | Some target_id ->
                        let reason =
                          Option.bind
@@ -570,9 +561,10 @@ let add_delete_action_routes router =
                        (match Board_moderation.record_action ~target_kind ~target_id
                                 ~actor ~action ?reason ?note () with
                         | Error msg ->
-                            Http.Response.json ~status:`Internal_server_error ~request:req
-                              (Yojson.Safe.to_string
-                                 (`Assoc [("ok", `Bool false); ("error", `String msg)]))
+                            Http.Response.json_value
+                              ~status:`Internal_server_error ~request:req
+                              (`Assoc
+                                 [("ok", `Bool false); ("error", `String msg)])
                               reqd
                         | Ok entry ->
                             (* If the action is Remove, also delete from board *)
@@ -595,14 +587,16 @@ let add_delete_action_routes router =
                               | None      -> []
                               | Some warn -> [("delete_warning", `String warn)]
                             in
-                            Http.Response.json ~compress:true ~request:req
-                              (Yojson.Safe.to_string
-                                 (`Assoc ([("ok",    `Bool true);
-                                           ("entry", Board_moderation.audit_entry_to_json entry)]
-                                          @ extra)))
+                            Http.Response.json_value ~compress:true ~request:req
+                              (`Assoc
+                                 ([ ("ok", `Bool true);
+                                    ( "entry",
+                                      Board_moderation.audit_entry_to_json entry
+                                    );
+                                  ]
+                                  @ extra))
                               reqd)))
            with Yojson.Json_error _ ->
-             Http.Response.json ~status:`Bad_request ~request:req
-               {|{"ok":false,"error":"invalid JSON body"}|} reqd
+             respond_error ~request:req reqd "invalid JSON body"
          )
        ) request reqd)

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -22,32 +22,29 @@ let handle_keeper_get_subroutes state req request reqd =
   if ends_with "/chat/history" then
     let name = extract_name "/chat/history" in
     if name = "" then
-      Server_auth.respond_json_with_cors ~status:`Bad_request request reqd
-        {|{"error":"missing keeper name"}|}
+      Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
+        (error_json "missing keeper name")
     else
       let base_dir = state.Mcp_server.room_config.base_path in
       let messages =
         Keeper_chat_store.load ~base_dir ~keeper_name:name
       in
-      Server_auth.respond_json_with_cors ~status:`OK request reqd
-        (Yojson.Safe.to_string (Keeper_chat_store.to_json_array messages))
+      Server_auth.respond_json_value_with_cors ~status:`OK request reqd
+        (Keeper_chat_store.to_json_array messages)
   else if ends_with keeper_suffix_checkpoints then
     let name = extract_name keeper_suffix_checkpoints in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request
-        {|{"error":"keeper name is required"}|} reqd
+      respond_error reqd "keeper name is required"
     else
       let (st, json) = keeper_checkpoint_inventory_json state.Mcp_server.room_config name in
       let status : Httpun.Status.t =
         match st with `OK -> `OK | `Not_found -> `Not_found
       in
-      Http.Response.json ~status ~compress:true ~request:req
-        (Yojson.Safe.to_string json) reqd
+      Http.Response.json_value ~status ~compress:true ~request:req json reqd
   else if ends_with keeper_suffix_runtime_trace then
     let name = extract_name keeper_suffix_runtime_trace in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request
-        {|{"error":"keeper name is required"}|} reqd
+      respond_error reqd "keeper name is required"
     else
       let trace_id = Server_utils.query_param req "trace_id" in
       let turn_id =
@@ -66,13 +63,11 @@ let handle_keeper_get_subroutes state req request reqd =
       let status : Httpun.Status.t =
         match st with `OK -> `OK | `Not_found -> `Not_found
       in
-      Http.Response.json ~status ~compress:true ~request:req
-        (Yojson.Safe.to_string json) reqd
+      Http.Response.json_value ~status ~compress:true ~request:req json reqd
   else if ends_with "/config" then
     let name = extract_name "/config" in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request
-        {|{"error":"keeper name is required"}|} reqd
+      respond_error reqd "keeper name is required"
     else
       let config = state.Mcp_server.room_config in
       let (st, json) =
@@ -81,13 +76,11 @@ let handle_keeper_get_subroutes state req request reqd =
       let status : Httpun.Status.t =
         match st with `OK -> `OK | `Not_found -> `Not_found
       in
-      Http.Response.json ~status ~compress:true ~request:req
-        (Yojson.Safe.to_string json) reqd
+      Http.Response.json_value ~status ~compress:true ~request:req json reqd
   else if ends_with keeper_suffix_bdi_snapshot then
     let name = extract_name keeper_suffix_bdi_snapshot in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request
-        {|{"error":"keeper name is required"}|} reqd
+      respond_error reqd "keeper name is required"
     else
       let config = state.Mcp_server.room_config in
       let (st, json) =
@@ -96,17 +89,16 @@ let handle_keeper_get_subroutes state req request reqd =
       let status : Httpun.Status.t =
         match st with `OK -> `OK | `Not_found -> `Not_found
       in
-      Http.Response.json ~status ~compress:true ~request:req
-        (Yojson.Safe.to_string json) reqd
+      Http.Response.json_value ~status ~compress:true ~request:req json reqd
   else if ends_with "/tool-stats" then
     let name = extract_name "/tool-stats" in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request
-        {|{"error":"keeper name is required"}|} reqd
+      respond_error reqd "keeper name is required"
     else if not (Keeper_config.validate_name name) then
-      Http.Response.json ~status:`Bad_request
-        (Yojson.Safe.to_string
-           (`Assoc [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])) reqd
+      Http.Response.json_value ~status:`Bad_request
+        (`Assoc
+           [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])
+        reqd
     else
       let config = state.Mcp_server.room_config in
       let masc_root = Coord.masc_root_dir config in
@@ -213,17 +205,16 @@ let handle_keeper_get_subroutes state req request reqd =
               ("timeline", `List (List.map Trajectory.hourly_bucket_to_json timeline));
             ]))
       in
-      Http.Response.json ~compress:true ~request:req
-        (Yojson.Safe.to_string json) reqd
+      Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/tool-calls" then
     let name = extract_name "/tool-calls" in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request
-        {|{"error":"keeper name is required"}|} reqd
+      respond_error reqd "keeper name is required"
     else if not (Keeper_config.validate_name name) then
-      Http.Response.json ~status:`Bad_request
-        (Yojson.Safe.to_string
-           (`Assoc [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])) reqd
+      Http.Response.json_value ~status:`Bad_request
+        (`Assoc
+           [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])
+        reqd
     else
       let limit =
         Server_utils.int_query_param req "limit" ~default:50
@@ -299,26 +290,23 @@ let handle_keeper_get_subroutes state req request reqd =
         ("coverage_gaps", `List coverage_gaps);
         ("entries", `List entries);
       ] in
-      Http.Response.json ~compress:true ~request:req
-        (Yojson.Safe.to_string json) reqd
+      Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/trajectory" then
     let name = extract_name "/trajectory" in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request
-        {|{"error":"keeper name is required"}|} reqd
+      respond_error reqd "keeper name is required"
     else if not (Keeper_config.validate_name name) then
-      Http.Response.json ~status:`Bad_request
-        (Yojson.Safe.to_string
-           (`Assoc [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])) reqd
+      Http.Response.json_value ~status:`Bad_request
+        (`Assoc
+           [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])
+        reqd
     else
       let config = state.Mcp_server.room_config in
       (match Keeper_types.read_meta config name with
        | Error e ->
-         Http.Response.json ~status:`Internal_server_error
-           (Printf.sprintf {|{"error":"%s"}|} (String.escaped e)) reqd
+         respond_error ~status:`Internal_server_error reqd e
        | Ok None ->
-         Http.Response.json ~status:`Not_found
-           (Printf.sprintf {|{"error":"keeper %S not found"}|} name) reqd
+         respond_error ~status:`Not_found reqd (Printf.sprintf "keeper %S not found" name)
        | Ok (Some m) ->
          let trajectory_default_limit = 50 in
          let trajectory_max_limit = 500 in
@@ -382,13 +370,11 @@ let handle_keeper_get_subroutes state req request reqd =
            ("entries", `List (List.map
              (Trajectory.trajectory_line_to_json ~result_max_len ~content_max_len) recent));
          ] in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd)
+         Http.Response.json_value ~compress:true ~request:req json reqd)
   else if ends_with "/transitions" then
     let name = extract_name "/transitions" in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request
-        {|{"error":"keeper name is required"}|} reqd
+      respond_error reqd "keeper name is required"
     else
       let limit =
         Server_utils.int_query_param req "limit" ~default:20
@@ -410,14 +396,12 @@ let handle_keeper_get_subroutes state req request reqd =
         "count", `Int (json_list_length transitions);
         "transitions", transitions;
       ] in
-      Http.Response.json ~compress:true ~request:req
-        (Yojson.Safe.to_string json) reqd
+      Http.Response.json_value ~compress:true ~request:req json reqd
   (* #12798 Dashboard Gaps: lifecycle event timeline per keeper. *)
   else if ends_with "/lifecycle" then
     let name = extract_name "/lifecycle" in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request
-        {|{"error":"keeper name is required"}|} reqd
+      respond_error reqd "keeper name is required"
     else
       let limit =
         Server_utils.int_query_param req "limit" ~default:50
@@ -431,13 +415,11 @@ let handle_keeper_get_subroutes state req request reqd =
         "count", `Int (json_list_length events);
         "events", events;
       ] in
-      Http.Response.json ~compress:true ~request:req
-        (Yojson.Safe.to_string json) reqd
+      Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/eval" then
     let name = extract_name "/eval" in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request
-        {|{"error":"keeper name is required"}|} reqd
+      respond_error reqd "keeper name is required"
     else
       let base_path = state.Mcp_server.room_config.base_path in
       let limit =
@@ -480,13 +462,11 @@ let handle_keeper_get_subroutes state req request reqd =
         ("snapshots",
           `List (List.map Dashboard_eval_feed.snapshot_to_json snapshots));
       ] in
-      Http.Response.json ~compress:true ~request:req
-        (Yojson.Safe.to_string json) reqd
+      Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/state-diagram" then
     let name = extract_name "/state-diagram" in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request
-        {|{"error":"keeper name is required"}|} reqd
+      respond_error reqd "keeper name is required"
     else
       let base_path = state.Mcp_server.room_config.base_path in
       let phase = Keeper_registry.get_phase ~base_path name in
@@ -631,8 +611,7 @@ let handle_keeper_get_subroutes state req request reqd =
         "memory_kind_usage", memory_kind_usage;
         "memory_kind_usage_error_class", memory_kind_usage_error_class_json;
       ] in
-      Http.Response.json ~compress:true ~request:req
-        (Yojson.Safe.to_string json) reqd
+      Http.Response.json_value ~compress:true ~request:req json reqd
   else if req_path = prefix ^ "composite" then
     (* LT-16a: fleet-wide composite snapshot. Enumerates every
        registered keeper via [Keeper_registry.all] and projects each
@@ -650,29 +629,26 @@ let handle_keeper_get_subroutes state req request reqd =
       Server_dashboard_http.dashboard_fleet_composite_json
         ~config:state.Mcp_server.room_config ()
     in
-    Http.Response.json ~compress:true ~request:req
-      (Yojson.Safe.to_string json) reqd
+    Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/composite" then
     (* RFC-0003 §7: composite lifecycle snapshot derived from the
        registry entry via the [Keeper_composite_observer] pure
        projection. No mutation, no I/O, no provider/token access. *)
     let name = extract_name "/composite" in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request
-        {|{"error":"keeper name is required"}|} reqd
+      respond_error reqd "keeper name is required"
     else
       let base_path = state.Mcp_server.room_config.base_path in
       (match Keeper_registry.get ~base_path name with
        | None ->
-         Http.Response.json ~status:`Not_found
-           (Printf.sprintf {|{"error":"keeper %S not registered"}|} name) reqd
+         respond_error ~status:`Not_found reqd
+           (Printf.sprintf "keeper %S not registered" name)
        | Some entry ->
          let json =
            Server_dashboard_http.dashboard_keeper_composite_json
              ~config:state.Mcp_server.room_config entry
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd)
+         Http.Response.json_value ~compress:true ~request:req json reqd)
   else if req_path = prefix ^ "regime" then
     (* 7th FSM axis MVP: fleet-wide behavioral-regime snapshot. Same
        purity contract as the composite route above, uses the
@@ -692,20 +668,18 @@ let handle_keeper_get_subroutes state req request reqd =
                snapshots);
       ]
     in
-    Http.Response.json ~compress:true ~request:req
-      (Yojson.Safe.to_string json) reqd
+    Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/regime" then
     (* Per-keeper behavioral-regime snapshot. *)
     let name = extract_name "/regime" in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request
-        {|{"error":"keeper name is required"}|} reqd
+      respond_error reqd "keeper name is required"
     else
       let base_path = state.Mcp_server.room_config.base_path in
       (match Keeper_registry.get ~base_path name with
        | None ->
-         Http.Response.json ~status:`Not_found
-           (Printf.sprintf {|{"error":"keeper %S not registered"}|} name) reqd
+         respond_error ~status:`Not_found reqd
+           (Printf.sprintf "keeper %S not registered" name)
        | Some entry ->
          let snapshot =
            Keeper_behavioral_regime_observer.observe entry
@@ -713,8 +687,6 @@ let handle_keeper_get_subroutes state req request reqd =
          let json =
            Keeper_behavioral_regime_observer.snapshot_to_json snapshot
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd)
+         Http.Response.json_value ~compress:true ~request:req json reqd)
   else
-    Http.Response.json ~status:`Not_found
-      {|{"error":"not found"}|} reqd
+    respond_error ~status:`Not_found reqd "not found"

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -5,6 +5,22 @@ open Server_dashboard_http_keeper_api_types
 
 module Http = Http_server_eio
 
+let error_json ?ok message =
+  let fields = [ ("error", `String message) ] in
+  let fields =
+    match ok with
+    | None -> fields
+    | Some value -> ("ok", `Bool value) :: fields
+  in
+  `Assoc fields
+
+let respond_error ?(status = `Bad_request) ?request ?ok reqd message =
+  Http.Response.json_value ?request ~status (error_json ?ok message) reqd
+
+let tool_detail_json body =
+  try Yojson.Safe.from_string body with
+  | Yojson.Json_error _ -> `String body
+
 let refresh_keeper_execution_surfaces ~config ~name event =
   Operator_control_snapshot.invalidate_snapshot_cache ();
   Dashboard_projection_cache.invalidate_snapshot_json ~config;
@@ -36,13 +52,11 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
   in
   match suffix_result with
   | Error msg ->
-      Http.Response.json ~status:`Bad_request
-        (Printf.sprintf {|{"error":"%s"}|} (String.escaped msg)) reqd
+      respond_error reqd msg
   | Ok suffix ->
   let name = extract_keeper_name_for_post req_path suffix in
   if String.length name = 0 then
-    Http.Response.json ~status:`Bad_request
-      {|{"error":"keeper name is required"}|} reqd
+    respond_error reqd "keeper name is required"
   else
     let config = state.Mcp_server.room_config in
     let resolve_keeper_agent_name () =
@@ -174,9 +188,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
     in
     match args_result with
     | Error msg ->
-        Http.Response.json ~status:`Bad_request
-          (Printf.sprintf {|{"ok":false,"error":"%s"}|} (String.escaped msg))
-          reqd
+        respond_error ~ok:false reqd msg
     | Ok args ->
         let started_at = Eio.Time.now clock in
         let duration_ms () =
@@ -219,12 +231,15 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
              | None -> Keeper_types.meta_to_json entry.meta
            in
            log_lifecycle_result "already_live";
-           Http.Response.json ~compress:true ~request:req
-             (Printf.sprintf
-                {|{"ok":true,"action":"%s","name":"%s","already_live":true,"detail":%s}|}
-                (String.escaped action)
-                (String.escaped name)
-                (Yojson.Safe.to_string detail))
+           Http.Response.json_value ~compress:true ~request:req
+             (`Assoc
+                [
+                  ("ok", `Bool true);
+                  ("action", `String action);
+                  ("name", `String name);
+                  ("already_live", `Bool true);
+                  ("detail", detail);
+                ])
              reqd
          | None ->
            (match Tool_keeper.dispatch keeper_ctx ~name:tool_name ~args with
@@ -242,12 +257,14 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
                  | Some _ | None -> ());
                 invalidate_keeper_execution_surfaces ~config ());
               log_lifecycle_result "ok";
-              Http.Response.json ~compress:true ~request:req
-                (Printf.sprintf
-                   {|{"ok":true,"action":"%s","name":"%s","detail":%s}|}
-                   (String.escaped action)
-                   (String.escaped name)
-                   body)
+              Http.Response.json_value ~compress:true ~request:req
+                (`Assoc
+                   [
+                     ("ok", `Bool true);
+                     ("action", `String action);
+                     ("name", `String name);
+                     ("detail", tool_detail_json body);
+                   ])
                 reqd
             | Some result when Tool_result.is_success result ->
               (match action with
@@ -256,23 +273,24 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
                  refresh_keeper_execution_surfaces ~config ~name "stopped"
                | _ -> invalidate_keeper_execution_surfaces ~config ());
               log_lifecycle_result "ok";
-              Http.Response.json ~compress:true ~request:req
-                (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s"}|}
-                   (String.escaped action)
-                   (String.escaped name))
+              Http.Response.json_value ~compress:true ~request:req
+                (`Assoc
+                   [
+                     ("ok", `Bool true);
+                     ("action", `String action);
+                     ("name", `String name);
+                   ])
                 reqd
             | Some result ->
               let body = Tool_result.message result in
               log_lifecycle_result "rejected";
-              Http.Response.json ~status:`Bad_request ~request:req
-                (Yojson.Safe.to_string
-                   (`Assoc [("ok", `Bool false); ("error", `String body)]))
+              Http.Response.json_value ~status:`Bad_request ~request:req
+                (`Assoc [("ok", `Bool false); ("error", `String body)])
                 reqd
             | None ->
               log_lifecycle_result "dispatch_none";
-              Http.Response.json ~status:`Internal_server_error ~request:req
-                {|{"ok":false,"error":"dispatch returned None"}|}
-                reqd))
+              respond_error ~status:`Internal_server_error ~request:req ~ok:false
+                reqd "dispatch returned None"))
 
 (** POST /api/v1/keepers/:name/directive — pause / resume / wakeup.
 

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -34,6 +34,18 @@ let keeper_tools_response_json (meta : Keeper_types.keeper_meta) =
       ("total_active", `Int (List.length allowed));
     ]
 
+let error_json ?ok message =
+  let fields = [ ("error", `String message) ] in
+  let fields =
+    match ok with
+    | None -> fields
+    | Some value -> ("ok", `Bool value) :: fields
+  in
+  `Assoc fields
+
+let respond_error ?(status = `Bad_request) ?request ?ok reqd message =
+  Http.Response.json_value ?request ~status (error_json ?ok message) reqd
+
 (** Handle POST /api/v1/keepers/:name/tools.
     Extracted so it can be called from any prefix_post handler that
     catches POST /api/v1/keepers/* requests. *)
@@ -47,16 +59,12 @@ let handle_keeper_tools_post state req reqd =
     let tlen = String.length req_path in
     let name = String.trim (String.sub req_path plen (tlen - plen - slen)) in
     if String.length name = 0 then
-      Http.Response.json ~status:`Bad_request {|{"error":"keeper name required"}|} reqd
+      respond_error reqd "keeper name required"
     else
       let config = state.Mcp_server.room_config in
       match Keeper_types.read_meta config name with
-      | Error msg ->
-          Http.Response.json ~status:`Not_found
-            (Printf.sprintf {|{"error":"%s"}|} (String.escaped msg)) reqd
-      | Ok None ->
-          Http.Response.json ~status:`Not_found
-            (Printf.sprintf {|{"error":"keeper %S not found"}|} name) reqd
+      | Error msg -> respond_error ~status:`Not_found reqd msg
+      | Ok None -> respond_error ~status:`Not_found reqd (Printf.sprintf "keeper %S not found" name)
       | Ok (Some meta) ->
           (try
              let args = Yojson.Safe.from_string body_str in
@@ -89,22 +97,20 @@ let handle_keeper_tools_post state req reqd =
              in
              (match updated_meta with
              | Error msg ->
-                 Http.Response.json ~status:`Bad_request
-                   (Printf.sprintf {|{"error":"%s"}|} (String.escaped msg)) reqd
+                 respond_error reqd msg
              | Ok meta' ->
                  (* force: user-initiated tool config is authoritative.
                     Skips version CAS since user intent overrides
                     concurrent keeper turn updates. *)
                  (match Keeper_types.write_meta ~force:true config meta' with
                   | Ok () ->
-                      Http.Response.json ~compress:true ~request:req
-                        (Yojson.Safe.to_string (keeper_tools_response_json meta')) reqd
+                      Http.Response.json_value ~compress:true ~request:req
+                        (keeper_tools_response_json meta') reqd
                   | Error e ->
-                      Http.Response.json ~status:`Internal_server_error
-                        (Printf.sprintf {|{"error":"write failed: %s"}|} (String.escaped e)) reqd))
+                      respond_error ~status:`Internal_server_error reqd
+                        (Printf.sprintf "write failed: %s" e)))
            with Yojson.Json_error e ->
-             Http.Response.json ~status:`Bad_request
-               (Printf.sprintf {|{"error":"invalid json: %s"}|} (String.escaped e)) reqd))
+             respond_error reqd (Printf.sprintf "invalid json: %s" e)))
 
 (* Trajectory preview helpers moved to Server_dashboard_http_keeper_api_types. *)
 
@@ -284,8 +290,7 @@ let handle_keeper_checkpoints_post state req reqd body_str =
   let req_path = Http.Request.path req in
   let name = extract_keeper_name_for_suffix req_path keeper_suffix_checkpoints in
   if String.length name = 0 then
-    Http.Response.json ~status:`Bad_request
-      {|{"ok":false,"error":"keeper name is required"}|} reqd
+    respond_error ~ok:false reqd "keeper name is required"
   else
     let config = state.Mcp_server.room_config in
     try
@@ -300,8 +305,7 @@ let handle_keeper_checkpoints_post state req reqd body_str =
             |> Json_util.dedupe_keep_order
           in
           if snapshot_ids = [] then
-            Http.Response.json ~status:`Bad_request
-              {|{"ok":false,"error":"snapshot_ids is required"}|} reqd
+            respond_error ~ok:false reqd "snapshot_ids is required"
           else
             let trace_id_result =
               match Keeper_types.read_meta_resolved config name with
@@ -313,10 +317,7 @@ let handle_keeper_checkpoints_post state req reqd body_str =
             in
             (match trace_id_result with
              | Error msg ->
-                 Http.Response.json ~status:`Not_found
-                   (Printf.sprintf {|{"ok":false,"error":"%s"}|}
-                      (String.escaped msg))
-                   reqd
+                 respond_error ~status:`Not_found ~ok:false reqd msg
              | Ok trace_id ->
                  let session_dir = Keeper_types_support.keeper_session_dir config trace_id in
                  let (deleted, missing) =
@@ -326,32 +327,24 @@ let handle_keeper_checkpoints_post state req reqd body_str =
                  let (_status, inventory) =
                    keeper_checkpoint_inventory_json config name
                  in
-                 Http.Response.json ~compress:true ~request:req
-                   (Yojson.Safe.to_string
-                      (`Assoc
-                         [
-                           ("ok", `Bool true);
-                           ("action", `String "delete_history");
-                           ("keeper", `String name);
-                           ("deleted_snapshot_ids", `List (List.map (fun id -> `String id) deleted));
-                           ("missing_snapshot_ids", `List (List.map (fun id -> `String id) missing));
-                           ("inventory", inventory);
-                         ]))
+                 Http.Response.json_value ~compress:true ~request:req
+                   (`Assoc
+                      [
+                        ("ok", `Bool true);
+                        ("action", `String "delete_history");
+                        ("keeper", `String name);
+                        ("deleted_snapshot_ids", `List (List.map (fun id -> `String id) deleted));
+                        ("missing_snapshot_ids", `List (List.map (fun id -> `String id) missing));
+                        ("inventory", inventory);
+                   ])
                    reqd)
       | "" ->
-          Http.Response.json ~status:`Bad_request
-            {|{"ok":false,"error":"action is required"}|} reqd
+          respond_error ~ok:false reqd "action is required"
       | other ->
-          Http.Response.json ~status:`Bad_request
-            (Printf.sprintf {|{"ok":false,"error":"unknown action: %s"}|}
-               (String.escaped other))
-            reqd
+          respond_error ~ok:false reqd (Printf.sprintf "unknown action: %s" other)
     with
     | Yojson.Json_error e ->
-        Http.Response.json ~status:`Bad_request
-          (Printf.sprintf {|{"ok":false,"error":"invalid json: %s"}|}
-             (String.escaped e))
-          reqd
+        respond_error ~ok:false reqd (Printf.sprintf "invalid json: %s" e)
 
 let refresh_keeper_execution_surfaces =
   Server_dashboard_http_keeper_api_lifecycle_post.refresh_keeper_execution_surfaces
@@ -362,20 +355,13 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
   let req_path = Http.Request.path req in
   let name = extract_keeper_name_for_post req_path keeper_suffix_config in
   if String.length name = 0 then
-    Http.Response.json ~status:`Bad_request
-      {|{"error":"keeper name is required"}|} reqd
+    respond_error reqd "keeper name is required"
   else
     let config = state.Mcp_server.room_config in
     match Keeper_types.read_meta config name with
-    | Error msg ->
-        Http.Response.json ~status:`Not_found
-          (Printf.sprintf {|{"error":"%s"}|}
-             (String.escaped msg))
-          reqd
+    | Error msg -> respond_error ~status:`Not_found reqd msg
     | Ok None ->
-        Http.Response.json ~status:`Not_found
-          (Printf.sprintf {|{"error":"keeper %S not found"}|} name)
-          reqd
+        respond_error ~status:`Not_found reqd (Printf.sprintf "keeper %S not found" name)
     | Ok (Some meta0) ->
         (try
            let args = Yojson.Safe.from_string body_str in
@@ -398,11 +384,9 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
                if Option.is_some body_name
                   && body_name <> Some name
                then
-                 Http.Response.json ~status:`Bad_request
-                   (Printf.sprintf
-                      {|{"error":"keeper name mismatch: route=%S body=%S"}|}
-                      name (Option.value ~default:"" body_name))
-                   reqd
+                 respond_error reqd
+                   (Printf.sprintf "keeper name mismatch: route=%S body=%S" name
+                      (Option.value ~default:"" body_name))
                else
                  let args_with_name =
                    `Assoc (("name", `String name) :: List.remove_assoc "name" fields)
@@ -419,34 +403,22 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
                  in
                  (match Keeper_turn_up_args.parse keeper_ctx args_with_name with
                  | Error result ->
-                     Http.Response.json ~status:`Bad_request
-                       (Printf.sprintf {|{"error":"%s"}|}
-                          (String.escaped (Keeper_types.tool_result_body result)))
-                       reqd
+                     respond_error reqd (Keeper_types.tool_result_body result)
                  | Ok parsed ->
                      let result =
                        Keeper_turn_up_update.update_keeper keeper_ctx parsed meta0
                      in
                      if not (Keeper_types.tool_result_success result) then
-                       Http.Response.json ~status:`Bad_request
-                         (Printf.sprintf {|{"error":"%s"}|}
-                            (String.escaped (Keeper_types.tool_result_body result)))
-                         reqd
+                       respond_error reqd (Keeper_types.tool_result_body result)
                      else
                        let (_st, json) =
                          Dashboard_http_keeper.keeper_config_json config name
                        in
-                       Http.Response.json ~compress:true ~request:req
-                         (Yojson.Safe.to_string json) reqd)
+                       Http.Response.json_value ~compress:true ~request:req json reqd)
            | None ->
-               Http.Response.json ~status:`Bad_request
-                 {|{"error":"request body must be a JSON object"}|}
-                 reqd
+               respond_error reqd "request body must be a JSON object"
          with Yojson.Json_error e ->
-           Http.Response.json ~status:`Bad_request
-             (Printf.sprintf {|{"error":"invalid json: %s"}|}
-                (String.escaped e))
-             reqd)
+           respond_error reqd (Printf.sprintf "invalid json: %s" e))
 
 let handle_keeper_lifecycle_post =
   Server_dashboard_http_keeper_api_lifecycle_post.handle_keeper_lifecycle_post
@@ -454,8 +426,7 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
   let req_path = Http.Request.path req in
   let name = extract_keeper_name_for_post req_path keeper_suffix_directive in
   if String.length name = 0 then
-    Http.Response.json ~status:`Bad_request
-      {|{"error":"keeper name is required"}|} reqd
+    respond_error reqd "keeper name is required"
   else
     let action =
       try
@@ -470,14 +441,11 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
                  "invalid action %S: expected pause, resume, or wakeup" a)
         | None -> Error "missing \"action\" field"
       with Yojson.Json_error e ->
-        Error (Printf.sprintf "invalid json: %s" (String.escaped e))
+        Error (Printf.sprintf "invalid json: %s" e)
     in
-    match action with
-    | Error msg ->
-        Http.Response.json ~status:`Bad_request
-          (Printf.sprintf {|{"ok":false,"error":%s}|}
-             (Yojson.Safe.to_string (`String msg)))
-          reqd
+  match action with
+  | Error msg ->
+      respond_error ~ok:false reqd msg
     | Ok directive ->
         let config = state.Mcp_server.room_config in
         let action_str =
@@ -539,9 +507,13 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
            | `Pause -> refresh_keeper_execution_surfaces ~config ~name "paused"
            | `Resume -> refresh_keeper_execution_surfaces ~config ~name "resumed"
            | `Wakeup -> invalidate_keeper_execution_surfaces ~config ());
-          Http.Response.json ~compress:true ~request:req
-            (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s"}|}
-               (String.escaped action_str) (String.escaped name))
+          Http.Response.json_value ~compress:true ~request:req
+            (`Assoc
+               [
+                 ("ok", `Bool true);
+                 ("action", `String action_str);
+                 ("name", `String name);
+               ])
             reqd
         in
         let needs_meta_for_state_transition =
@@ -561,12 +533,14 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
                ~labels:[("phase", Keeper_paused_state_persist_phase.(to_label Directive));
                         ("reason", "read_meta_error")]
                ();
-             Http.Response.json ~status:`Internal_server_error ~request:req
-               (Printf.sprintf
-                  {|{"ok":false,"action":"%s","name":"%s","error":"read_meta failed: %s"}|}
-                  (String.escaped action_str)
-                  (String.escaped name)
-                  (String.escaped err))
+             Http.Response.json_value ~status:`Internal_server_error ~request:req
+               (`Assoc
+                  [
+                    ("ok", `Bool false);
+                    ("action", `String action_str);
+                    ("name", `String name);
+                    ("error", `String (Printf.sprintf "read_meta failed: %s" err));
+                  ])
                reqd
          | Ok None, true ->
              Log.Keeper.warn
@@ -578,11 +552,14 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
                ~labels:[("phase", Keeper_paused_state_persist_phase.(to_label Directive));
                         ("reason", "meta_missing")]
                ();
-             Http.Response.json ~status:`Not_found ~request:req
-               (Printf.sprintf
-                  {|{"ok":false,"action":"%s","name":"%s","error":"keeper meta not found"}|}
-                  (String.escaped action_str)
-                  (String.escaped name))
+             Http.Response.json_value ~status:`Not_found ~request:req
+               (`Assoc
+                  [
+                    ("ok", `Bool false);
+                    ("action", `String action_str);
+                    ("name", `String name);
+                    ("error", `String "keeper meta not found");
+                  ])
                reqd
          | Error err, false ->
              (* Wakeup does not require meta; log but proceed. *)
@@ -639,9 +616,8 @@ let handle_keeper_bulk_directive_post state _agent_name req reqd body_str =
   in
   match parsed with
   | Error msg ->
-      Http.Response.json ~status:`Bad_request
-        (Printf.sprintf {|{"ok":false,"error":%s}|}
-           (Yojson.Safe.to_string (`String msg)))
+      Http.Response.json_value ~status:`Bad_request
+        (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
         reqd
   | Ok (names, directive) ->
       let config = state.Mcp_server.room_config in
@@ -726,16 +702,15 @@ let handle_keeper_bulk_directive_post state _agent_name req reqd body_str =
             | _ -> acc)
           0 results
       in
-      Http.Response.json ~compress:true ~request:req
-        (Yojson.Safe.to_string
-           (`Assoc
-             [
-               ("ok", `Bool true);
-               ("action", `String action_str);
-               ("requested", `Int (List.length names));
-               ("succeeded", `Int ok_count);
-               ("results", `List results);
-             ]))
+      Http.Response.json_value ~compress:true ~request:req
+        (`Assoc
+           [
+             ("ok", `Bool true);
+             ("action", `String action_str);
+             ("requested", `Int (List.length names));
+             ("succeeded", `Int ok_count);
+             ("results", `List results);
+           ])
         reqd
 
 (** Keeper GET sub-routes handler: /config, /chat/history, /trajectory. *)

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -174,60 +174,55 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
          Health & Metrics
          ───────────────────────────────────────────────────────────────────── *)
       | `GET, "/health" ->
-          let body =
+          let json =
             Server_routes_http_runtime.make_health_response_json ~listener:"h2" httpun_request
-            |> Yojson.Safe.to_string
           in
-          h2_respond_json h2_reqd body ~extra_headers:cors
+          h2_respond_json_value h2_reqd json ~extra_headers:cors
 
       | `GET, p when String.equal p Server_health_paths.liveness ->
-          let body =
-            Yojson.Safe.to_string
-              (`Assoc [
-                 ("live", `Bool true);
-                 ("startup", Server_startup_state.to_yojson ());
-               ])
+          let json =
+            `Assoc [
+              ("live", `Bool true);
+              ("startup", Server_startup_state.to_yojson ());
+            ]
           in
-          h2_respond_json h2_reqd body ~extra_headers:cors
+          h2_respond_json_value h2_reqd json ~extra_headers:cors
 
       | `GET, p when String.equal p Server_health_paths.readiness ->
           let current = Server_startup_state.(!state) in
-          let body, status =
+          let json, status =
             if current.state_ready then
-              (Yojson.Safe.to_string
-                 (`Assoc [
-                    ("ready", `Bool true);
-                    ("phase", `String (Server_startup_state.phase_to_string current.phase));
-                    ("backend_mode", `String current.backend_mode);
-                  ]),
+              (`Assoc [
+                 ("ready", `Bool true);
+                 ("phase", `String (Server_startup_state.phase_to_string current.phase));
+                 ("backend_mode", `String current.backend_mode);
+               ],
                `OK)
             else
-              (Yojson.Safe.to_string
-                 (`Assoc [
-                    ("ready", `Bool false);
-                    ("phase", `String (Server_startup_state.phase_to_string current.phase));
-                    ("elapsed_sec", `Float (Server_startup_state.elapsed_since_start ()));
-                  ]),
+              (`Assoc [
+                 ("ready", `Bool false);
+                 ("phase", `String (Server_startup_state.phase_to_string current.phase));
+                 ("elapsed_sec", `Float (Server_startup_state.elapsed_since_start ()));
+               ],
                `Service_unavailable)
           in
-          h2_respond_json ~status h2_reqd body ~extra_headers:cors
+          h2_respond_json_value ~status h2_reqd json ~extra_headers:cors
 
       | `GET, ("/.well-known/agent.json" | "/.well-known/agent-card.json") ->
-          h2_respond_json h2_reqd
-            (Server_routes_http_runtime.agent_card_json httpun_request
-             |> Yojson.Safe.to_string)
+          h2_respond_json_value h2_reqd
+            (Server_routes_http_runtime.agent_card_json httpun_request)
             ~extra_headers:cors
 
       | `GET, "/ws" ->
-          let body =
+          let json =
             Server_routes_http_runtime.websocket_discovery_json httpun_request
-            |> Yojson.Safe.to_string
           in
-          h2_respond_json h2_reqd body ~extra_headers:cors
+          h2_respond_json_value h2_reqd json ~extra_headers:cors
 
       | `POST, "/webrtc/offer" ->
           if not (Server_webrtc_transport.is_enabled ()) then
-            h2_respond_json h2_reqd {|{"error":"webrtc transport disabled"}|}
+            h2_respond_json_value h2_reqd
+              (`Assoc [ ("error", `String "webrtc transport disabled") ])
               ~status:`Not_found ~extra_headers:cors
           else
             with_server_state h2_reqd (fun state ->
@@ -250,13 +245,14 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                     | Ok body ->
                         h2_respond_json h2_reqd body ~extra_headers:cors
                     | Error msg ->
-                        h2_respond_json h2_reqd
-                          (Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ]))
+                        h2_respond_json_value h2_reqd
+                          (`Assoc [ ("error", `String msg) ])
                           ~status:`Bad_request ~extra_headers:cors))
 
       | `POST, "/webrtc/answer" ->
           if not (Server_webrtc_transport.is_enabled ()) then
-            h2_respond_json h2_reqd {|{"error":"webrtc transport disabled"}|}
+            h2_respond_json_value h2_reqd
+              (`Assoc [ ("error", `String "webrtc transport disabled") ])
               ~status:`Not_found ~extra_headers:cors
           else
             with_server_state h2_reqd (fun state ->
@@ -279,20 +275,17 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                     | Ok body ->
                         h2_respond_json h2_reqd body ~extra_headers:cors
                     | Error msg ->
-                        h2_respond_json h2_reqd
-                          (Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ]))
+                        h2_respond_json_value h2_reqd
+                          (`Assoc [ ("error", `String msg) ])
                           ~status:`Bad_request ~extra_headers:cors))
 
       | `GET, "/metrics" ->
           let body = Prometheus.to_prometheus_text () in
-          let headers = H2.Headers.of_list ([
-            ("content-type", "text/plain; version=0.0.4; charset=utf-8");
-            ("content-length", string_of_int (String.length body));
-          ] @ cors) in
-          let response = H2.Response.create ~headers `OK in
-          let writer = H2.Reqd.respond_with_streaming ~flush_headers_immediately:true h2_reqd response in
-          H2.Body.Writer.write_string writer body;
-          H2.Body.Writer.close writer
+          h2_respond_body
+            ~content_type:"text/plain; version=0.0.4; charset=utf-8"
+            h2_reqd
+            body
+            ~extra_headers:cors
 
       | `GET, "/" ->
           h2_respond_text h2_reqd "MASC MCP Server (HTTP/2)" ~extra_headers:cors
@@ -442,12 +435,10 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                        h2_respond_empty h2_reqd ~status:`Accepted
                                          ~extra_headers:mcp_hdrs
                                    | json when is_http_error_response json ->
-                                       let body = Yojson.Safe.to_string json in
-                                       h2_respond_json h2_reqd body ~status:`Bad_request
+                                       h2_respond_json_value h2_reqd json ~status:`Bad_request
                                          ~extra_headers:mcp_hdrs
                                    | json ->
-                                       let body = Yojson.Safe.to_string json in
-                                       h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs)))))
+                                       h2_respond_json_value h2_reqd json ~extra_headers:mcp_hdrs)))))
 
       | `DELETE, "/mcp/operator" ->
           h2_respond_removed_surface h2_reqd ~surface:"operator_remote" ~extra_headers:cors
@@ -555,7 +546,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                   ("message", `String "Use /api/v1/dashboard/shell and surface-specific projection endpoints.");
                 ]
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+            h2_respond_json_value h2_reqd json
               ~status:`Gone ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/shell" ->
@@ -568,14 +559,14 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                 ~request:httpun_request ~light
                 state.Mcp_server.room_config
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/branches" ->
           with_server_state h2_reqd (fun state ->
             let json =
               Dashboard_branches.json ~config:state.Mcp_server.room_config
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/nudges" ->
           with_server_state h2_reqd (fun state ->
@@ -587,7 +578,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               Dashboard_operator_nudges.json
                 ~config:state.Mcp_server.room_config ~limit ()
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+            h2_respond_json_value h2_reqd json
               ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/rooms"
@@ -606,7 +597,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               Dashboard_rooms.json ~config:state.Mcp_server.room_config ?me
                 ~limit ()
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+            h2_respond_json_value h2_reqd json
               ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/heuristics"
@@ -615,7 +606,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             Server_routes_http_routes_provider_runs.dashboard_heuristics_json
               httpun_request
           in
-          h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+          h2_respond_json_value h2_reqd json
             ~extra_headers:cors
 
       | `GET, "/api/v1/dashboard/heuristics/coverage"
@@ -624,7 +615,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             Server_routes_http_routes_provider_runs.dashboard_heuristics_coverage_json
               httpun_request
           in
-          h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+          h2_respond_json_value h2_reqd json
             ~extra_headers:cors
 
       | `GET, "/api/v1/dashboard/stress"
@@ -634,20 +625,20 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               Server_routes_http_routes_provider_runs.dashboard_stress_json
                 ~config:state.Mcp_server.room_config httpun_request
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+            h2_respond_json_value h2_reqd json
               ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/config" ->
           with_h2_public_read h2_reqd (fun _state ->
             let json = Env_config_introspect.to_json () in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/config/excuse-patterns" ->
           with_h2_public_read h2_reqd (fun _state ->
             let patterns = Anti_rationalization.load_excuse_patterns () in
             let json_items = List.map (fun (pat, reason) -> `List [`String pat; `String reason]) patterns in
             let json = `List json_items in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `POST, "/api/v1/dashboard/config/excuse-patterns" ->
           with_h2_token_permission_auth h2_reqd ~permission:Masc_domain.CanAdmin
@@ -657,37 +648,34 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                   let json = Yojson.Safe.from_string body_str in
                   match Anti_rationalization.parse_excuse_patterns_json json with
                   | Error msg ->
-                      let err_json =
-                        Yojson.Safe.to_string
-                          (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
-                      in
-                      h2_respond_json
+                      h2_respond_json_value
                         h2_reqd
-                        err_json
+                        (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
                         ~status:`Bad_request
                         ~extra_headers:cors
                   | Ok patterns ->
                       (match Anti_rationalization.save_excuse_patterns patterns with
                        | Ok () ->
-                           h2_respond_json h2_reqd {|{"ok":true}|}
+                           h2_respond_json_value h2_reqd
+                             (`Assoc [ ("ok", `Bool true) ])
                              ~extra_headers:cors
                        | Error msg ->
-                           let err_json =
-                             Yojson.Safe.to_string
-                               (`Assoc
-                                  [ ("ok", `Bool false); ("error", `String msg) ])
-                           in
-                           h2_respond_json
+                           h2_respond_json_value
                              h2_reqd
-                             err_json
+                             (`Assoc
+                                [ ("ok", `Bool false); ("error", `String msg) ])
                              ~status:`Internal_server_error
                              ~extra_headers:cors)
                 with
                 | Eio.Cancel.Cancelled _ as exn -> raise exn
                 | _exn ->
-                    h2_respond_json
+                    h2_respond_json_value
                       h2_reqd
-                      {|{"ok":false,"error":"Invalid JSON body"}|}
+                      (`Assoc
+                         [
+                           ("ok", `Bool false);
+                           ("error", `String "Invalid JSON body");
+                         ])
                       ~status:`Bad_request
                       ~extra_headers:cors))
 
@@ -703,12 +691,12 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               Server_dashboard_snapshot_select.select_project_snapshot_json
                 ~state ~sw ~clock httpun_request
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/execution" ->
           with_h2_public_read h2_reqd (fun state ->
             let json = dashboard_execution_http_json ~state ~sw ~clock httpun_request in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/execution-trust" ->
           with_h2_public_read h2_reqd (fun state ->
@@ -716,12 +704,12 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               dashboard_execution_trust_http_json ~state ~sw ~clock
                 httpun_request
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/board" ->
           with_h2_public_read h2_reqd (fun _state ->
             let json = dashboard_memory_http_json httpun_request in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/governance" ->
           with_h2_public_read h2_reqd (fun state ->
@@ -729,7 +717,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               dashboard_governance_http_json httpun_request
                 ~base_path:state.Mcp_server.room_config.base_path
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/proof" ->
           with_h2_public_read h2_reqd (fun state ->
@@ -737,7 +725,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               dashboard_proof_http_json
                 ~config:state.Mcp_server.room_config httpun_request
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/planning" ->
           with_h2_public_read h2_reqd (fun state ->
@@ -745,7 +733,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               dashboard_planning_http_json
                 ~config:state.Mcp_server.room_config
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/bootstrap" ->
           (* Same SSOT as the HTTP/1.1 router so the HTTP/2 client sees
@@ -755,7 +743,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             let json =
               dashboard_bootstrap_http_json ~state ~sw ~clock httpun_request
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/goals" ->
           with_h2_public_read h2_reqd (fun state ->
@@ -763,7 +751,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               dashboard_goals_tree_http_json
                 ~config:state.Mcp_server.room_config
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/goals/detail" ->
           with_h2_public_read h2_reqd (fun state ->
@@ -773,15 +761,19 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               | None -> ""
             in
             if goal_id = "" then
-              h2_respond_json h2_reqd
-                {|{"ok":false,"error":"goal_id query param is required"}|}
+              h2_respond_json_value h2_reqd
+                (`Assoc
+                   [
+                     ("ok", `Bool false);
+                     ("error", `String "goal_id query param is required");
+                   ])
                 ~status:`Bad_request ~extra_headers:cors
             else
               let json =
                 dashboard_goal_detail_http_json
                   ~config:state.Mcp_server.room_config ~goal_id
               in
-              h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+              h2_respond_json_value h2_reqd json
                 ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/tasks/history" ->
@@ -792,7 +784,8 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               | None -> ""
             in
             if task_id = "" then
-              h2_respond_json h2_reqd {|{"error":"task_id is required"}|}
+              h2_respond_json_value h2_reqd
+                (`Assoc [ ("error", `String "task_id is required") ])
                 ~status:`Bad_request ~extra_headers:cors
             else
               let limit =
@@ -803,18 +796,18 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                 Tool_task.task_history_events_json state.Mcp_server.room_config
                   ~task_id ~limit
               in
-              h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+              h2_respond_json_value h2_reqd json
                 ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/mission" ->
           with_h2_public_read h2_reqd (fun state ->
             let json = dashboard_mission_http_json ~state ~sw ~clock httpun_request in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/session" ->
           with_h2_public_read h2_reqd (fun state ->
             let json = dashboard_session_http_json ~state ~sw ~clock httpun_request in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/mission/briefing" ->
           with_h2_public_read h2_reqd (fun state ->
@@ -822,24 +815,24 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               dashboard_mission_briefing_http_json ~state ~sw ~clock
                 httpun_request
             in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/transport-health" ->
           with_h2_public_read h2_reqd (fun state ->
             let json = dashboard_transport_health_http_json ~state in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/perf" ->
           with_h2_public_read h2_reqd (fun state ->
             let json = dashboard_perf_http_json state.Mcp_server.room_config in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/oas/telemetry/recent" ->
           with_h2_public_read h2_reqd (fun _state ->
             let provider = oas_telemetry_provider_param httpun_request in
             let limit = oas_telemetry_limit_param httpun_request in
             let json = Dashboard_oas_bridge.recent_json ?provider ~limit () in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+            h2_respond_json_value h2_reqd json
               ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/oas/telemetry/summary" ->
@@ -847,7 +840,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             let provider = oas_telemetry_provider_param httpun_request in
             let limit = oas_telemetry_limit_param httpun_request in
             let json = Dashboard_oas_bridge.summary_json ?provider ~limit () in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+            h2_respond_json_value h2_reqd json
               ~extra_headers:cors)
 
       | `GET, p when String.starts_with ~prefix:"/api/v1/command-plane" p ->
@@ -864,7 +857,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               ("tempo_interval_s", `Float tempo.current_interval_s);
               ("paused", `Bool room_state.paused);
             ] in
-            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/openapi.json" ->
           let host_header = get_header_any_case httpun_request.headers "host" in
@@ -876,9 +869,8 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           let json =
             Transport.Rest.generate_openapi_document
               ~host:resolved_host ~port:resolved_port ()
-            |> Yojson.Safe.to_string
           in
-          h2_respond_json h2_reqd json ~extra_headers:cors
+          h2_respond_json_value h2_reqd json ~extra_headers:cors
 
       | `GET, "/api/v1/namespace/current"
       | `GET, "/api/v1/room/current"

--- a/lib/server/server_h2_gateway_helpers.ml
+++ b/lib/server/server_h2_gateway_helpers.ml
@@ -1,48 +1,69 @@
+let maybe_compress ?(compress = true) h2_reqd body =
+  let req = H2.Reqd.request h2_reqd in
+  Http_response_payload.compress_body
+    ~compress
+    ~accept_encoding:(H2.Headers.get req.headers "accept-encoding")
+    body
 
-let h2_respond_json ?(status = `OK) ?(extra_headers = []) h2_reqd body =
+let h2_respond_body
+    ?(status = `OK)
+    ?(extra_headers = [])
+    ?(compress = true)
+    ~content_type
+    h2_reqd
+    body =
+  let final_body, compression_headers = maybe_compress ~compress h2_reqd body in
   let headers = H2.Headers.of_list ([
-    ("content-type", "application/json; charset=utf-8");
-    ("content-length", string_of_int (String.length body));
-  ] @ extra_headers) in
+    ("content-type", content_type);
+    ("content-length", string_of_int (String.length final_body));
+  ] @ compression_headers @ extra_headers) in
   let response = H2.Response.create ~headers status in
   let writer = H2.Reqd.respond_with_streaming ~flush_headers_immediately:true h2_reqd response in
-  H2.Body.Writer.write_string writer body;
+  H2.Body.Writer.write_string writer final_body;
   H2.Body.Writer.close writer
+
+let h2_respond_json_string ?status ?extra_headers h2_reqd body =
+  h2_respond_body
+    ?status
+    ?extra_headers
+    ~compress:true
+    ~content_type:"application/json; charset=utf-8"
+    h2_reqd
+    body
+
+let h2_respond_json ?status ?extra_headers h2_reqd body =
+  h2_respond_json_string ?status ?extra_headers h2_reqd body
+
+let h2_respond_json_value ?status ?extra_headers h2_reqd json =
+  h2_respond_json_string ?status ?extra_headers h2_reqd
+    (Yojson.Safe.to_string json)
 
 let h2_respond_text ?(status = `OK) ?(extra_headers = []) h2_reqd body =
-  let headers = H2.Headers.of_list ([
-    ("content-type", "text/plain; charset=utf-8");
-    ("content-length", string_of_int (String.length body));
-  ] @ extra_headers) in
-  let response = H2.Response.create ~headers status in
-  let writer = H2.Reqd.respond_with_streaming ~flush_headers_immediately:true h2_reqd response in
-  H2.Body.Writer.write_string writer body;
-  H2.Body.Writer.close writer
+  h2_respond_body
+    ~status
+    ~extra_headers
+    ~compress:true
+    ~content_type:"text/plain; charset=utf-8"
+    h2_reqd
+    body
 
 let h2_respond_html ?(status = `OK) ?(extra_headers = []) h2_reqd body =
-  let headers = H2.Headers.of_list ([
-    ("content-type", "text/html; charset=utf-8");
-    ("content-length", string_of_int (String.length body));
-  ] @ extra_headers) in
-  let response = H2.Response.create ~headers status in
-  let writer = H2.Reqd.respond_with_streaming ~flush_headers_immediately:true h2_reqd response in
-  H2.Body.Writer.write_string writer body;
-  H2.Body.Writer.close writer
+  h2_respond_body
+    ~status
+    ~extra_headers
+    ~compress:true
+    ~content_type:"text/html; charset=utf-8"
+    h2_reqd
+    body
 
 let h2_respond_bytes
     ?(status = `OK)
     ?(extra_headers = [])
+    ?(compress = false)
     ~content_type
     h2_reqd
     body =
-  let headers = H2.Headers.of_list ([
-    ("content-type", content_type);
-    ("content-length", string_of_int (String.length body));
-  ] @ extra_headers) in
-  let response = H2.Response.create ~headers status in
-  let writer = H2.Reqd.respond_with_streaming ~flush_headers_immediately:true h2_reqd response in
-  H2.Body.Writer.write_string writer body;
-  H2.Body.Writer.close writer
+  h2_respond_body ~status ~extra_headers ~compress ~content_type h2_reqd body
 
 let h2_respond_empty ?(status = `No_content) ?(extra_headers = []) h2_reqd =
   let headers = H2.Headers.of_list (("content-length", "0") :: extra_headers) in
@@ -51,19 +72,19 @@ let h2_respond_empty ?(status = `No_content) ?(extra_headers = []) h2_reqd =
   H2.Body.Writer.close writer
 
 let h2_respond_removed_surface h2_reqd ~surface ~extra_headers =
-  let body =
-    Yojson.Safe.to_string
-      (`Assoc
-         [
-           ("error", `String "removed_surface");
-           ("surface", `String surface);
-           ( "message",
-             `String
-               "This compatibility surface was removed. Keepers and local clients should use the OAS-backed repo coordination front door."
-           );
-         ])
-  in
-  h2_respond_json ~status:`Gone h2_reqd body ~extra_headers
+  h2_respond_json_value
+    ~status:`Gone
+    h2_reqd
+    (`Assoc
+       [
+         ("error", `String "removed_surface");
+         ("surface", `String surface);
+         ( "message",
+           `String
+             "This compatibility surface was removed. Keepers and local clients should use the OAS-backed repo coordination front door."
+         );
+       ])
+    ~extra_headers
 
 let h2_read_body h2_reqd callback =
   let body = H2.Reqd.request_body h2_reqd in

--- a/lib/server/server_h2_gateway_helpers.mli
+++ b/lib/server/server_h2_gateway_helpers.mli
@@ -1,9 +1,21 @@
 (** H2 gateway response helpers. *)
 
+val h2_respond_body :
+  ?status:H2.Status.t ->
+  ?extra_headers:(string * string) list ->
+  ?compress:bool ->
+  content_type:string ->
+  H2.Reqd.t -> string -> unit
+
 val h2_respond_json :
   ?status:H2.Status.t ->
   ?extra_headers:(string * string) list ->
   H2.Reqd.t -> string -> unit
+
+val h2_respond_json_value :
+  ?status:H2.Status.t ->
+  ?extra_headers:(string * string) list ->
+  H2.Reqd.t -> Yojson.Safe.t -> unit
 
 val h2_respond_text :
   ?status:H2.Status.t ->
@@ -18,6 +30,7 @@ val h2_respond_html :
 val h2_respond_bytes :
   ?status:H2.Status.t ->
   ?extra_headers:(string * string) list ->
+  ?compress:bool ->
   content_type:string ->
   H2.Reqd.t -> string -> unit
 

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -15,8 +15,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
       let status =
         match status with `OK -> `OK | `Error -> `Internal_server_error
       in
-      h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~status
-        ~extra_headers:cors;
+      h2_respond_json_value h2_reqd json ~status ~extra_headers:cors;
       true
 
   | `GET, "/api/v1/board" ->
@@ -73,7 +72,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
         ("offset", `Int offset);
         ("sort_by", `String (board_sort_label sort_by));
       ] in
-      h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors;
+      h2_respond_json_value h2_reqd json ~extra_headers:cors;
       true
 
   | `GET, "/api/v1/board/curation" ->
@@ -83,7 +82,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
         | Some snap ->
             `Assoc [("snapshot", Board_curation.snapshot_to_yojson snap)]
       in
-      h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors;
+      h2_respond_json_value h2_reqd json ~extra_headers:cors;
       true
 
   | `GET, "/api/v1/board/hearths" ->
@@ -93,13 +92,13 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
           `Assoc [("name", `String name); ("count", `Int count)]
         ) hearths));
       ] in
-      h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors;
+      h2_respond_json_value h2_reqd json ~extra_headers:cors;
       true
 
   | `GET, "/api/v1/board/flairs" ->
       let flairs = List.map Board.flair_to_yojson Board.available_flairs in
       let json = `Assoc [("flairs", `List flairs)] in
-      h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors;
+      h2_respond_json_value h2_reqd json ~extra_headers:cors;
       true
 
   | `GET, "/api/v1/board/sub-boards" ->
@@ -111,7 +110,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
               `List (List.map Board.sub_board_to_yojson sub_boards) );
           ]
       in
-      h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors;
+      h2_respond_json_value h2_reqd json ~extra_headers:cors;
       true
 
   | `GET, "/api/v1/board/karma/ledger" ->
@@ -144,7 +143,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
                    totals) );
           ]
       in
-      h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors;
+      h2_respond_json_value h2_reqd json ~extra_headers:cors;
       true
 
   | `GET, p
@@ -172,7 +171,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
           `Assoc [("agent", `String agent); ("karma", `Int k)]
         ) sorted));
       ] in
-      h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors;
+      h2_respond_json_value h2_reqd json ~extra_headers:cors;
       true
 
   | `GET, "/static/css/middleware.css" ->
@@ -221,20 +220,14 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
                || Filename.check_suffix filename ".css"
                || Filename.check_suffix filename ".svg"
              in
-             let accepts_zstd =
-               Http_server_eio.Compression.accepts_zstd httpun_request
-             in
              let final_body, encoding_headers =
-               if is_compressible && accepts_zstd then
-                 let (compressed, did_compress) =
-                   Http_server_eio.Compression.compress_zstd ~level:3 body
-                 in
-                 if did_compress then
-                   (compressed, [("content-encoding", "zstd"); ("vary", "Accept-Encoding")])
-                 else
-                   (body, [])
-               else
-                 (body, [])
+               Http_response_payload.compress_body
+                 ~compress:is_compressible
+                 ~accept_encoding:
+                   (Httpun.Headers.get
+                      httpun_request.Httpun.Request.headers
+                      "accept-encoding")
+                 body
              in
              let base_headers = [
                ("content-type", ct);

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -170,10 +170,10 @@ let add_routes router =
          let json =
            `List (List.map Ide_annotation_types.annotation_to_json annotations)
          in
-         Http.Response.json
+         Http.Response.json_value
            ~compress:true
            ~request
-           (Yojson.Safe.to_string (json_ok json))
+           (json_ok json)
            reqd)
       request
       reqd)
@@ -260,23 +260,22 @@ let add_routes router =
                   ()
               with
               | Ok annotation ->
-                Http.Response.json
+                Http.Response.json_value
                   ~status:`Created
                   ~request
-                  (Yojson.Safe.to_string
-                     (json_ok (Ide_annotation_types.annotation_to_json annotation)))
+                  (json_ok (Ide_annotation_types.annotation_to_json annotation))
                   reqd
               | Error msg ->
-                Http.Response.json
+                Http.Response.json_value
                   ~status:`Bad_request
                   ~request
-                  (Yojson.Safe.to_string (json_error msg))
+                  (json_error msg)
                   reqd)
            | _ ->
-             Http.Response.json
+             Http.Response.json_value
                ~status:`Bad_request
                ~request
-               (Yojson.Safe.to_string (json_error "Missing required fields"))
+               (json_error "Missing required fields")
                reqd))
       request
       reqd)
@@ -308,20 +307,20 @@ let add_routes router =
          in
          if id = "" || keeper_id = ""
          then
-           Http.Response.json
+           Http.Response.json_value
              ~status:`Bad_request
              ~request
-             (Yojson.Safe.to_string (json_error "Missing id or keeper_id"))
+             (json_error "Missing id or keeper_id")
              reqd
          else (
            let partition = resolve_partition_for_query ~state ~uri in
            match Ide_annotations.delete ~base_dir:base ~partition ~id ~keeper_id () with
            | Ok () -> Http.Response.json ~status:`No_content ~request "{}" reqd
            | Error msg ->
-             Http.Response.json
+             Http.Response.json_value
                ~status:`Forbidden
                ~request
-               (Yojson.Safe.to_string (json_error msg))
+               (json_error msg)
                reqd))
       request
       reqd)
@@ -351,10 +350,10 @@ let add_routes router =
              ()
          in
          let json = `List (List.map Ide_annotation_types.region_to_json regions) in
-         Http.Response.json
+         Http.Response.json_value
            ~compress:true
            ~request
-           (Yojson.Safe.to_string (json_ok json))
+           (json_ok json)
            reqd)
       request
       reqd)
@@ -364,10 +363,10 @@ let add_routes router =
     with_public_read
       (fun state _req reqd ->
          let snapshot = build_presence_snapshot state in
-         Http.Response.json
+         Http.Response.json_value
            ~compress:true
            ~request
-           (Yojson.Safe.to_string (json_ok snapshot))
+           (json_ok snapshot)
            reqd)
       request
       reqd)

--- a/lib/server/server_routes_http_dashboard_handlers.ml
+++ b/lib/server/server_routes_http_dashboard_handlers.ml
@@ -21,7 +21,7 @@ let handle_broadcast state agent_name reqd body_str =
       | Some msg -> fields @ [ ("error", `String msg) ]
       | None -> fields
     in
-    Http.Response.json (Yojson.Safe.to_string (`Assoc fields)) reqd
+    Http.Response.json_value (`Assoc fields) reqd
   in
   try
     let json = Yojson.Safe.from_string body_str in
@@ -39,13 +39,12 @@ let handle_broadcast state agent_name reqd body_str =
 
 let handle_dashboard_link_previews state req reqd body_str =
   let respond_error message =
-    Http.Response.json ~status:`Bad_request ~request:req
-      (Yojson.Safe.to_string
-         (`Assoc
-           [
-             ("ok", `Bool false);
-             ("error", `String message);
-           ]))
+    Http.Response.json_value ~status:`Bad_request ~request:req
+      (`Assoc
+         [
+           ("ok", `Bool false);
+           ("error", `String message);
+         ])
       reqd
   in
   try
@@ -55,8 +54,7 @@ let handle_dashboard_link_previews state req reqd body_str =
         ~state ~args
     with
     | Ok json ->
-        Http.Response.json ~compress:true ~request:req
-          (Yojson.Safe.to_string json) reqd
+        Http.Response.json_value ~compress:true ~request:req json reqd
     | Error message -> respond_error message
   with Yojson.Json_error message ->
     respond_error ("invalid json: " ^ message)
@@ -68,8 +66,9 @@ let handle_dashboard_task_history state req reqd =
     | None -> ""
   in
   if task_id = "" then
-    Http.Response.json ~status:`Bad_request ~request:req
-      {|{"error":"task_id is required"}|} reqd
+    Http.Response.json_value ~status:`Bad_request ~request:req
+      (`Assoc [ ("error", `String "task_id is required") ])
+      reqd
   else
     let limit =
       Server_utils.int_query_param req "limit" ~default:50
@@ -85,7 +84,7 @@ let handle_dashboard_task_history state req reqd =
           Tool_task.task_history_events_json state.Mcp_server.room_config
             ~task_id ~limit))
     in
-    Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+    Http.Response.json_value ~compress:true ~request:req json reqd
 
 let handle_dashboard_rooms state req reqd =
   let limit =
@@ -98,5 +97,4 @@ let handle_dashboard_rooms state req reqd =
     | None -> trimmed_query_param req "agent"
   in
   let json = Dashboard_rooms.json ~config:state.Mcp_server.room_config ?me ~limit () in
-  Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
-
+  Http.Response.json_value ~compress:true ~request:req json reqd

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -268,14 +268,10 @@ let serve_dashboard_static name request reqd =
           "public, max-age=31536000, immutable"
       in
       let final_body, encoding_headers =
-        if is_compressible_asset name && Http.Compression.accepts_zstd request then
-          let (compressed, did_compress) = Http.Compression.compress_zstd ~level:3 body in
-          if did_compress then
-            (compressed, [("content-encoding", "zstd"); ("vary", "Accept-Encoding")])
-          else
-            (body, [])
-        else
-          (body, [])
+        Http_response_payload.compress_body
+          ~compress:(is_compressible_asset name)
+          ~accept_encoding:(Httpun.Headers.get request.Httpun.Request.headers "accept-encoding")
+          body
       in
       let headers = ("cache-control", cache_control) :: encoding_headers in
       Http.Response.bytes ~headers ~content_type final_body reqd
@@ -449,21 +445,17 @@ let keepers_summary_from_registry ~base_path
 let bonsai_api_keepers_summary request reqd =
   match !server_state with
   | None ->
-      respond_public_read_json
+      respond_public_read_json_value
         ~status:`Internal_server_error
         request
         reqd
-        (Yojson.Safe.to_string
-           (`Assoc [ ("error", `String "server state not initialized") ]))
+        (`Assoc [ ("error", `String "server state not initialized") ])
   | Some state ->
       let resp =
         keepers_summary_from_registry ~base_path:state.room_config.base_path
       in
-      let body =
-        Yojson.Safe.to_string
-          (Masc_dashboard_api_types.Keepers.response_to_yojson resp)
-      in
-      respond_public_read_json request reqd body
+      respond_public_read_json_value request reqd
+        (Masc_dashboard_api_types.Keepers.response_to_yojson resp)
 
 let serve_bonsai_static name request reqd =
   let path = Filename.concat (bonsai_asset_root ()) name in
@@ -477,14 +469,10 @@ let serve_bonsai_static name request reqd =
           "public, max-age=31536000, immutable"
       in
       let final_body, encoding_headers =
-        if is_compressible_asset name && Http.Compression.accepts_zstd request then
-          let (compressed, did_compress) = Http.Compression.compress_zstd ~level:3 body in
-          if did_compress then
-            (compressed, [("content-encoding", "zstd"); ("vary", "Accept-Encoding")])
-          else
-            (body, [])
-        else
-          (body, [])
+        Http_response_payload.compress_body
+          ~compress:(is_compressible_asset name)
+          ~accept_encoding:(Httpun.Headers.get request.Httpun.Request.headers "accept-encoding")
+          body
       in
       let headers = ("cache-control", cache_control) :: encoding_headers in
       Http.Response.bytes ~headers ~content_type final_body reqd

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -99,17 +99,16 @@ let governance_param_risk param_key =
   |> Option.map (fun (surface : Governance_registry.surface) -> surface.risk)
 
 let respond_high_risk_param_blocked request reqd ~param_key ~risk =
-  respond_json_with_cors ~status:`Forbidden request reqd
-    (Yojson.Safe.to_string
-       (`Assoc
-          [
-            ("ok", `Bool false);
-            ( "error",
-              `String
-                (Printf.sprintf
-                   "runtime param %s is %s risk and no longer supports direct dashboard mutation"
-                   param_key risk) );
-          ]))
+  respond_json_value_with_cors ~status:`Forbidden request reqd
+    (`Assoc
+       [
+         ("ok", `Bool false);
+         ( "error",
+           `String
+             (Printf.sprintf
+                "runtime param %s is %s risk and no longer supports direct dashboard mutation"
+                param_key risk) );
+       ])
 
 let board_curation_json () =
   match Board_dispatch.latest_curation_snapshot () with
@@ -146,19 +145,19 @@ let board_karma_ledger_json req =
     ]
 
 let respond_board_json reqd json =
-  Http.Response.json (Yojson.Safe.to_string json) reqd
+  Http.Response.json_value json reqd
 
 let add_routes ~sw ~clock router =
   router
   |> Http.Router.get "/api/v1/activity/events" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = activity_events_http_json ~sw ~clock ~state req in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/activity/graph" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = activity_graph_http_json ~sw ~clock ~state req in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/activity/swimlane" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -166,7 +165,7 @@ let add_routes ~sw ~clock router =
            Server_activity_http.swimlane_http_json
              ~deps:(activity_http_deps ~sw ~clock) ~state req
          in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/governance/params" (fun request reqd ->
        with_public_read (fun _state _req reqd ->
@@ -202,7 +201,7 @@ let add_routes ~sw ~clock router =
                ("surfaces", surfaces);
              ]
          in
-         Http.Response.json (Yojson.Safe.pretty_to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)
 
   |> Http.Router.get "/api/v1/governance/params/audit" (fun request reqd ->
@@ -214,7 +213,7 @@ let add_routes ~sw ~clock router =
            ("entries", `List entries);
            ("count", `Int (List.length entries));
          ] in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)
 
   |> Http.Router.get "/api/v1/audit" (fun request reqd ->
@@ -242,8 +241,8 @@ let add_routes ~sw ~clock router =
              ?kind:kind_filter ?severity:severity_filter ?since:since_filter
              ?until:until_filter ~limit all_entries
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req
+           json reqd
        ) request reqd)
 
   |> Http.Router.get "/api/v1/board" (fun request reqd ->
@@ -314,7 +313,7 @@ let add_routes ~sw ~clock router =
            ("offset", `Int offset);
            ("sort_by", `String (board_sort_label sort_by));
          ] in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)
 
   |> Http.Router.get "/api/v1/board/hearths" (fun request reqd ->
@@ -325,7 +324,7 @@ let add_routes ~sw ~clock router =
              `Assoc [("name", `String name); ("count", `Int count)]
            ) hearths));
          ] in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)
 
   |> Http.Router.get "/api/v1/board/curation" (fun request reqd ->
@@ -336,7 +335,7 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/board/flairs" (fun _request reqd ->
        let flairs = List.map Board.flair_to_yojson Board.available_flairs in
        let json = `Assoc [("flairs", `List flairs)] in
-       Http.Response.json (Yojson.Safe.to_string json) reqd)
+       Http.Response.json_value json reqd)
 
   |> Http.Router.get "/api/v1/board/sub-boards" (fun _request reqd ->
        respond_board_json reqd (board_sub_boards_json ()))
@@ -372,17 +371,14 @@ let add_routes ~sw ~clock router =
              (match Board_dispatch.create_sub_board ~slug ~name ~description
                       ~owner:agent_name ~members ?access () with
               | Ok sb ->
-                  Http.Response.json
-                    (Yojson.Safe.to_string (Board.sub_board_to_yojson sb)) reqd
+                  Http.Response.json_value (Board.sub_board_to_yojson sb) reqd
               | Error e ->
-                  Http.Response.json ~status:`Bad_request
-                    (Yojson.Safe.to_string
-                       (`Assoc [("error", `String (Tool_board.board_error_to_string e))]))
+                  Http.Response.json_value ~status:`Bad_request
+                    (`Assoc [("error", `String (Tool_board.board_error_to_string e))])
                     reqd)
            with Yojson.Json_error msg ->
-             Http.Response.json ~status:`Bad_request
-               (Yojson.Safe.to_string
-                  (`Assoc [("error", `String ("invalid JSON: " ^ msg))]))
+             Http.Response.json_value ~status:`Bad_request
+               (`Assoc [("error", `String ("invalid JSON: " ^ msg))])
                reqd))
          request reqd)
 
@@ -390,19 +386,16 @@ let add_routes ~sw ~clock router =
        let path = Http.Request.path request in
        (match extract_path_param ~prefix:"/api/v1/board/sub-boards/" path with
         | None ->
-            Http.Response.json ~status:`Bad_request
-              (Yojson.Safe.to_string
-                 (`Assoc [("error", `String "sub_board_id is required")]))
+            Http.Response.json_value ~status:`Bad_request
+              (`Assoc [("error", `String "sub_board_id is required")])
               reqd
         | Some sub_board_id ->
             (match Board_dispatch.get_sub_board ~sub_board_id with
              | Ok sb ->
-                 Http.Response.json
-                   (Yojson.Safe.to_string (Board.sub_board_to_yojson sb)) reqd
+                 Http.Response.json_value (Board.sub_board_to_yojson sb) reqd
              | Error e ->
-                 Http.Response.json ~status:`Not_found
-                   (Yojson.Safe.to_string
-                      (`Assoc [("error", `String (Tool_board.board_error_to_string e))]))
+                 Http.Response.json_value ~status:`Not_found
+                   (`Assoc [("error", `String (Tool_board.board_error_to_string e))])
                    reqd)))
 
   |> Http.Router.prefix_delete "/api/v1/board/sub-boards/" (fun request reqd ->
@@ -411,19 +404,16 @@ let add_routes ~sw ~clock router =
          let path = Http.Request.path request in
          (match extract_path_param ~prefix:"/api/v1/board/sub-boards/" path with
           | None ->
-              Http.Response.json ~status:`Bad_request
-                (Yojson.Safe.to_string
-                   (`Assoc [("error", `String "sub_board_id is required")]))
+              Http.Response.json_value ~status:`Bad_request
+                (`Assoc [("error", `String "sub_board_id is required")])
                 reqd
           | Some sub_board_id ->
               (match Board_dispatch.delete_sub_board ~sub_board_id with
                | Ok () ->
-                   Http.Response.json
-                     (Yojson.Safe.to_string (`Assoc [("deleted", `Bool true)])) reqd
+                   Http.Response.json_value (`Assoc [("deleted", `Bool true)]) reqd
                | Error e ->
-                   Http.Response.json ~status:`Not_found
-                     (Yojson.Safe.to_string
-                        (`Assoc [("error", `String (Tool_board.board_error_to_string e))]))
+                   Http.Response.json_value ~status:`Not_found
+                     (`Assoc [("error", `String (Tool_board.board_error_to_string e))])
                      reqd)))
          request reqd)
 
@@ -445,24 +435,20 @@ let add_routes ~sw ~clock router =
              let path = Http.Request.path request in
              (match extract_path_param ~prefix:"/api/v1/board/sub-boards/" path with
               | None ->
-                  Http.Response.json ~status:`Bad_request
-                    (Yojson.Safe.to_string
-                       (`Assoc [("error", `String "sub_board_id is required")]))
+                  Http.Response.json_value ~status:`Bad_request
+                    (`Assoc [("error", `String "sub_board_id is required")])
                     reqd
               | Some sub_board_id ->
                   (match Board_dispatch.update_sub_board ~sub_board_id ?name ?description ?members:members_arg ?access () with
                    | Ok sb ->
-                       Http.Response.json
-                         (Yojson.Safe.to_string (Board.sub_board_to_yojson sb)) reqd
+                       Http.Response.json_value (Board.sub_board_to_yojson sb) reqd
                    | Error e ->
-                       Http.Response.json ~status:`Bad_request
-                         (Yojson.Safe.to_string
-                            (`Assoc [("error", `String (Tool_board.board_error_to_string e))]))
+                       Http.Response.json_value ~status:`Bad_request
+                         (`Assoc [("error", `String (Tool_board.board_error_to_string e))])
                          reqd))
            with Yojson.Json_error msg ->
-             Http.Response.json ~status:`Bad_request
-               (Yojson.Safe.to_string
-                  (`Assoc [("error", `String ("invalid JSON: " ^ msg))]))
+             Http.Response.json_value ~status:`Bad_request
+               (`Assoc [("error", `String ("invalid JSON: " ^ msg))])
                reqd))
          request reqd)
 
@@ -471,8 +457,8 @@ let add_routes ~sw ~clock router =
          let path = Http.Request.path request in
          (match extract_path_param ~prefix:"/api/v1/board/" path with
           | None ->
-              Http.Response.json
-                (Yojson.Safe.to_string (`Assoc [("error", `String "post_id is required")]))
+              Http.Response.json_value
+                (`Assoc [("error", `String "post_id is required")])
                 ~status:`Bad_request reqd
           | Some "curation" ->
               respond_board_json reqd (board_curation_json ())
@@ -514,11 +500,9 @@ let add_routes ~sw ~clock router =
                match r with
                | Ok v -> f v
                | Error msg ->
-                   respond_json_with_cors ~status:`Bad_request request reqd
-                     (Yojson.Safe.to_string (`Assoc [
-                       ("ok", `Bool false);
-                       ("message", `String msg)
-                     ]))
+                   respond_json_value_with_cors ~status:`Bad_request request reqd
+                     (`Assoc
+                        [ ("ok", `Bool false); ("message", `String msg) ])
              in
              let* args =
                try Ok (Yojson.Safe.from_string body_str)
@@ -530,16 +514,15 @@ let add_routes ~sw ~clock router =
              let ok = Tool_result.is_success result in
              let msg = Tool_result.message result in
              let status = if ok then `OK else `Bad_request in
-             respond_json_with_cors ~status request reqd
-               (Yojson.Safe.to_string (`Assoc [
-                 ("ok", `Bool ok); ("message", `String msg)
-               ]))
+             respond_json_value_with_cors ~status request reqd
+               (`Assoc [ ("ok", `Bool ok); ("message", `String msg) ])
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-             respond_json_with_cors ~status:`Bad_request request reqd
-               (Yojson.Safe.to_string (`Assoc [
-                 ("ok", `Bool false);
-                 ("message", `String (Printexc.to_string exn))
-               ]))
+             respond_json_value_with_cors ~status:`Bad_request request reqd
+               (`Assoc
+                  [
+                    ("ok", `Bool false);
+                    ("message", `String (Printexc.to_string exn));
+                  ])
          )
        ) request reqd)
 
@@ -553,11 +536,9 @@ let add_routes ~sw ~clock router =
                match r with
                | Ok v -> f v
                | Error msg ->
-                   respond_json_with_cors ~status:`Bad_request request reqd
-                     (Yojson.Safe.to_string (`Assoc [
-                       ("ok", `Bool false);
-                       ("message", `String msg)
-                     ]))
+                   respond_json_value_with_cors ~status:`Bad_request request reqd
+                     (`Assoc
+                        [ ("ok", `Bool false); ("message", `String msg) ])
              in
              let* args =
                try Ok (Yojson.Safe.from_string body_str)
@@ -574,16 +555,15 @@ let add_routes ~sw ~clock router =
              let ok = Tool_result.is_success result in
              let msg = Tool_result.message result in
              let status = if ok then `Created else `Bad_request in
-             respond_json_with_cors ~status request reqd
-               (Yojson.Safe.to_string (`Assoc [
-                 ("ok", `Bool ok); ("message", `String msg)
-               ]))
+             respond_json_value_with_cors ~status request reqd
+               (`Assoc [ ("ok", `Bool ok); ("message", `String msg) ])
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-             respond_json_with_cors ~status:`Bad_request request reqd
-               (Yojson.Safe.to_string (`Assoc [
-                 ("ok", `Bool false);
-                 ("message", `String (Printexc.to_string exn))
-               ]))
+             respond_json_value_with_cors ~status:`Bad_request request reqd
+               (`Assoc
+                  [
+                    ("ok", `Bool false);
+                    ("message", `String (Printexc.to_string exn));
+                  ])
          )
        ) request reqd)
 
@@ -597,11 +577,9 @@ let add_routes ~sw ~clock router =
                match r with
                | Ok v -> f v
                | Error msg ->
-                   respond_json_with_cors ~status:`Bad_request request reqd
-                     (Yojson.Safe.to_string (`Assoc [
-                       ("ok", `Bool false);
-                       ("message", `String msg)
-                     ]))
+                   respond_json_value_with_cors ~status:`Bad_request request reqd
+                     (`Assoc
+                        [ ("ok", `Bool false); ("message", `String msg) ])
              in
              let* args =
                try Ok (Yojson.Safe.from_string body_str)
@@ -613,16 +591,15 @@ let add_routes ~sw ~clock router =
              let ok = Tool_result.is_success result in
              let msg = Tool_result.message result in
              let status = if ok then `Created else `Bad_request in
-             respond_json_with_cors ~status request reqd
-               (Yojson.Safe.to_string (`Assoc [
-                 ("ok", `Bool ok); ("message", `String msg)
-               ]))
+             respond_json_value_with_cors ~status request reqd
+               (`Assoc [ ("ok", `Bool ok); ("message", `String msg) ])
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-             respond_json_with_cors ~status:`Bad_request request reqd
-               (Yojson.Safe.to_string (`Assoc [
-                 ("ok", `Bool false);
-                 ("message", `String (Printexc.to_string exn))
-               ]))
+             respond_json_value_with_cors ~status:`Bad_request request reqd
+               (`Assoc
+                  [
+                    ("ok", `Bool false);
+                    ("message", `String (Printexc.to_string exn));
+                  ])
          )
        ) request reqd)
   |> Http.Router.get "/api/v1/karma" (fun request reqd ->
@@ -634,7 +611,7 @@ let add_routes ~sw ~clock router =
              `Assoc [("agent", `String agent); ("karma", `Int k)]
            ) sorted));
          ] in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)
 
   |> Http.Router.get "/api/v1/board/karma/ledger" (fun request reqd ->
@@ -648,8 +625,8 @@ let add_routes ~sw ~clock router =
          let path = Http.Request.path request in
          (match extract_path_param ~prefix:"/api/v1/mentions/" path with
           | None ->
-              Http.Response.json
-                (Yojson.Safe.to_string (`Assoc [("error", `String "agent_name is required")]))
+              Http.Response.json_value
+                (`Assoc [("error", `String "agent_name is required")])
                 ~status:`Bad_request reqd
           | Some agent_name ->
               let limit = standard_limit request in
@@ -666,7 +643,7 @@ let add_routes ~sw ~clock router =
                 ("unread_count", `Int unread);
                 ("mentions", `List (List.map Mention_inbox.mention_record_to_json mentions));
               ] in
-              Http.Response.json (Yojson.Safe.to_string json) reqd)
+              Http.Response.json_value json reqd)
        ) request reqd)
 
   (* Agent Reputation API *)
@@ -675,17 +652,16 @@ let add_routes ~sw ~clock router =
          let path = Http.Request.path request in
          (match extract_path_param ~prefix:"/api/v1/reputation/" path with
           | None ->
-              Http.Response.json
-                (Yojson.Safe.to_string (`Assoc [("error", `String "agent_name is required")]))
+              Http.Response.json_value
+                (`Assoc [("error", `String "agent_name is required")])
                 ~status:`Bad_request reqd
           | Some agent_name ->
               let rep =
                 Agent_reputation.compute_reputation
                   state.Mcp_server.room_config ~agent_name
               in
-              Http.Response.json
-                (Yojson.Safe.to_string (Agent_reputation.reputation_to_json rep))
-                reqd)
+              Http.Response.json_value
+                (Agent_reputation.reputation_to_json rep) reqd)
        ) request reqd)
 
   (* Activity Feed API *)
@@ -701,14 +677,14 @@ let add_routes ~sw ~clock router =
            ("items", `List (List.map Activity_feed.activity_item_to_json items));
            ("count", `Int (List.length items));
          ] in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)
 
   (* Prompt Registry API *)
   |> Http.Router.get "/api/v1/prompts" (fun request reqd ->
        with_public_read (fun _state _req reqd ->
          let json = Prompt_registry.prompts_json () in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)
 
   |> Http.Router.post "/api/v1/prompts" (fun request reqd ->
@@ -722,10 +698,9 @@ let add_routes ~sw ~clock router =
              let action = Yojson.Safe.Util.(member "action" args |> to_string_option)
                |> Option.value ~default:"set" in
              if key = "" then
-               respond_json_with_cors ~status:`Bad_request request reqd
-                 (Yojson.Safe.to_string (`Assoc [
-                   ("ok", `Bool false); ("error", `String "key is required")
-                 ]))
+               respond_json_value_with_cors ~status:`Bad_request request reqd
+                 (`Assoc
+                    [ ("ok", `Bool false); ("error", `String "key is required") ])
              else begin
                let result = match action with
                  | "clear" ->
@@ -751,26 +726,26 @@ let add_routes ~sw ~clock router =
                in
                match result with
                | Ok msg ->
-                 respond_json_with_cors request reqd
-                   (Yojson.Safe.to_string (`Assoc [
-                     ("ok", `Bool true);
-                     ("message", `String msg);
-                     ("key", `String key);
-                     ("source", `String (Prompt_registry.prompt_source key));
-                     ("effective", `String (Prompt_registry.get_prompt key));
-                   ]))
+                 respond_json_value_with_cors request reqd
+                   (`Assoc
+                      [
+                        ("ok", `Bool true);
+                        ("message", `String msg);
+                        ("key", `String key);
+                        ("source", `String (Prompt_registry.prompt_source key));
+                        ("effective", `String (Prompt_registry.get_prompt key));
+                      ])
                | Error msg ->
-                 respond_json_with_cors ~status:`Bad_request request reqd
-                   (Yojson.Safe.to_string (`Assoc [
-                     ("ok", `Bool false); ("error", `String msg)
-                   ]))
+                 respond_json_value_with_cors ~status:`Bad_request request reqd
+                   (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
              end
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-             respond_json_with_cors ~status:`Bad_request request reqd
-               (Yojson.Safe.to_string (`Assoc [
-                 ("ok", `Bool false);
-                 ("error", `String (Printexc.to_string exn))
-               ]))
+             respond_json_value_with_cors ~status:`Bad_request request reqd
+               (`Assoc
+                  [
+                    ("ok", `Bool false);
+                    ("error", `String (Printexc.to_string exn));
+                  ])
          )
        ) request reqd)
 
@@ -790,17 +765,15 @@ let add_routes ~sw ~clock router =
                |> to_string_option) |> Option.value ~default:"" |> String.trim in
              let value_json = match Yojson.Safe.Util.member "value" args with
                | `Null -> None | v -> Some v in
-             if param_key = "" then
-               respond_json_with_cors ~status:`Bad_request request reqd
-                 (Yojson.Safe.to_string (`Assoc [
-                   ("ok", `Bool false); ("error", `String "param_key is required")
-                 ]))
+            if param_key = "" then
+               respond_json_value_with_cors ~status:`Bad_request request reqd
+                 (`Assoc
+                    [ ("ok", `Bool false); ("error", `String "param_key is required") ])
              else match value_json with
              | None ->
-               respond_json_with_cors ~status:`Bad_request request reqd
-                 (Yojson.Safe.to_string (`Assoc [
-                   ("ok", `Bool false); ("error", `String "value is required")
-                 ]))
+               respond_json_value_with_cors ~status:`Bad_request request reqd
+                 (`Assoc
+                    [ ("ok", `Bool false); ("error", `String "value is required") ])
              | Some value ->
                (match governance_param_risk param_key with
                 | Some "high" ->
@@ -815,13 +788,12 @@ let add_routes ~sw ~clock router =
                     in
                     (match Runtime_params.set_by_key param_key value with
                      | Error msg ->
-                         respond_json_with_cors ~status:`Bad_request request reqd
-                           (Yojson.Safe.to_string
-                              (`Assoc
-                                 [
-                                   ("ok", `Bool false);
-                                   ("error", `String msg);
-                                 ]))
+                         respond_json_value_with_cors ~status:`Bad_request request reqd
+                           (`Assoc
+                              [
+                                ("ok", `Bool false);
+                                ("error", `String msg);
+                              ])
                      | Ok () ->
                          Runtime_params.persist ~base_path;
                          Runtime_params.record_audit ~base_path
@@ -835,22 +807,22 @@ let add_routes ~sw ~clock router =
                                 ("new_value", value);
                                 ("actor", `String actor);
                               ]);
-                         respond_json_with_cors request reqd
-                           (Yojson.Safe.to_string
-                              (`Assoc
-                                 [
-                                   ("ok", `Bool true);
-                                   ( "message",
-                                     `String
-                                       (Printf.sprintf "Set %s = %s" param_key
-                                          (Yojson.Safe.to_string value)) );
-                                 ]))))
+                         respond_json_value_with_cors request reqd
+                           (`Assoc
+                              [
+                                ("ok", `Bool true);
+                                ( "message",
+                                  `String
+                                    (Printf.sprintf "Set %s = %s" param_key
+                                       (Yojson.Safe.to_string value)) );
+                              ])))
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-             respond_json_with_cors ~status:`Bad_request request reqd
-               (Yojson.Safe.to_string (`Assoc [
-                 ("ok", `Bool false);
-                 ("error", `String (Printexc.to_string exn))
-               ]))
+             respond_json_value_with_cors ~status:`Bad_request request reqd
+               (`Assoc
+                  [
+                    ("ok", `Bool false);
+                    ("error", `String (Printexc.to_string exn));
+                  ])
          )
        ) request reqd)
 
@@ -867,11 +839,10 @@ let add_routes ~sw ~clock router =
                sanitized_dashboard_actor_for_request ~base_path request
                |> Option.value ~default:"dashboard"
              in
-             if param_key = "" then
-               respond_json_with_cors ~status:`Bad_request request reqd
-                 (Yojson.Safe.to_string (`Assoc [
-                   ("ok", `Bool false); ("error", `String "param_key is required")
-                 ]))
+            if param_key = "" then
+               respond_json_value_with_cors ~status:`Bad_request request reqd
+                 (`Assoc
+                    [ ("ok", `Bool false); ("error", `String "param_key is required") ])
              else begin
                match governance_param_risk param_key with
                | Some "high" ->
@@ -886,13 +857,12 @@ let add_routes ~sw ~clock router =
                    in
                    match Runtime_params.clear_by_key param_key with
                    | Error msg ->
-                       respond_json_with_cors ~status:`Bad_request request reqd
-                         (Yojson.Safe.to_string
-                            (`Assoc
-                               [
-                                 ("ok", `Bool false);
-                                 ("error", `String msg);
-                               ]))
+                       respond_json_value_with_cors ~status:`Bad_request request reqd
+                         (`Assoc
+                            [
+                              ("ok", `Bool false);
+                              ("error", `String msg);
+                            ])
                    | Ok () ->
                        let new_value =
                          match Runtime_params.registry ()
@@ -912,21 +882,21 @@ let add_routes ~sw ~clock router =
                               ("new_value", new_value);
                               ("actor", `String actor);
                             ]);
-                       respond_json_with_cors request reqd
-                         (Yojson.Safe.to_string
-                            (`Assoc
-                               [
-                                 ("ok", `Bool true);
-                                 ( "message",
-                                   `String
-                                     (Printf.sprintf "Cleared %s to default" param_key) );
-                               ]))
+                       respond_json_value_with_cors request reqd
+                         (`Assoc
+                            [
+                              ("ok", `Bool true);
+                              ( "message",
+                                `String
+                                  (Printf.sprintf "Cleared %s to default" param_key) );
+                            ])
              end
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-             respond_json_with_cors ~status:`Bad_request request reqd
-               (Yojson.Safe.to_string (`Assoc [
-                 ("ok", `Bool false);
-                 ("error", `String (Printexc.to_string exn))
-               ]))
+             respond_json_value_with_cors ~status:`Bad_request request reqd
+               (`Assoc
+                  [
+                    ("ok", `Bool false);
+                    ("error", `String (Printexc.to_string exn));
+                  ])
          )
        ) request reqd)

--- a/lib/server/server_routes_http_routes_artifacts.ml
+++ b/lib/server/server_routes_http_routes_artifacts.ml
@@ -67,20 +67,16 @@ let add_routes router =
            let path = Http.Request.path request in
            match extract_path_param ~prefix:"/api/v1/artifacts/" path with
            | None ->
-               respond_public_read_json ~status:`Bad_request request reqd
-                 (Yojson.Safe.to_string
-                    (`Assoc [ ("error", `String "sha256 path parameter required") ]))
+               respond_public_read_json_value ~status:`Bad_request request reqd
+                 (`Assoc [ ("error", `String "sha256 path parameter required") ])
            | Some raw when not (is_valid_sha256 raw) ->
-               respond_public_read_json ~status:`Bad_request request reqd
-                 (Yojson.Safe.to_string
-                    (`Assoc
-                      [
-                        ("error", `String "invalid sha256");
-                        ( "reason",
-                          `String "expected 64-char lowercase hex" );
-                      ]))
+               respond_public_read_json_value ~status:`Bad_request request reqd
+                 (`Assoc
+                    [
+                      ("error", `String "invalid sha256");
+                      ("reason", `String "expected 64-char lowercase hex");
+                    ])
            | Some sha256 ->
                let json, status = blob_response ~sha256 in
-               respond_public_read_json ~status request reqd
-                 (Yojson.Safe.to_string json))
+               respond_public_read_json_value ~status request reqd json)
          request reqd)

--- a/lib/server/server_routes_http_routes_attribution.ml
+++ b/lib/server/server_routes_http_routes_attribution.ml
@@ -59,12 +59,10 @@ let add_routes router =
            | None -> None
          in
          let json = recent_json ?gate ?limit () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/attribution/summary" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = summary_json () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)

--- a/lib/server/server_routes_http_routes_autonomous.ml
+++ b/lib/server/server_routes_http_routes_autonomous.ml
@@ -33,14 +33,12 @@ let add_routes router =
          with_public_read
            (fun _state _req reqd ->
              let json = phases_response () in
-             respond_public_read_json ~status:`OK request reqd
-               (Yojson.Safe.to_string json))
+             respond_public_read_json_value ~status:`OK request reqd json)
            request reqd)
   |> Http.Router.prefix_get "/api/v1/autonomous/transitions"
        (fun request reqd ->
          with_public_read
            (fun _state _req reqd ->
              let json = transitions_response () in
-             respond_public_read_json ~status:`OK request reqd
-               (Yojson.Safe.to_string json))
+             respond_public_read_json_value ~status:`OK request reqd json)
            request reqd)

--- a/lib/server/server_routes_http_routes_cascade.ml
+++ b/lib/server/server_routes_http_routes_cascade.ml
@@ -41,23 +41,20 @@ let add_routes router =
        with_public_read (fun state req reqd ->
          let base_path = state.Mcp_server.room_config.base_path in
          let json = Dashboard_cascade.config_json ~base_path () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/cascade/config/raw" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = Dashboard_cascade.raw_config_json () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/cascade/config/raw" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
          (fun _state _agent_name req reqd ->
            Http.Request.read_body_async reqd (fun body_str ->
              let response status message =
-               Http.Response.json ~status ~request:req
-                 (Yojson.Safe.to_string
-                    (`Assoc [ ("ok", `Bool false); ("error", `String message) ]))
+               Http.Response.json_value ~status ~request:req
+                 (`Assoc [ ("ok", `Bool false); ("error", `String message) ])
                  reqd
              in
              match config_source_text_of_body body_str with
@@ -68,8 +65,7 @@ let add_routes router =
              | Ok raw_json -> (
                  match Dashboard_cascade.save_raw_config_json raw_json with
                  | Ok json ->
-                     Http.Response.json ~request:req
-                       (Yojson.Safe.to_string json) reqd
+                     Http.Response.json_value ~request:req json reqd
                  | Error msg ->
                      response `Bad_request msg))
          ) request reqd)
@@ -79,14 +75,12 @@ let add_routes router =
          let json =
            Dashboard_cascade.health_json ~base_path ()
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/cascade/client_capacity" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = Dashboard_cascade.client_capacity_json () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/cascade/client_capacity/history"
        (fun request reqd ->
@@ -100,8 +94,7 @@ let add_routes router =
              Dashboard_cascade.client_capacity_history_json
                ~limit ?kind ?since_ts ()
            in
-           Http.Response.json ~compress:true ~request:req
-             (Yojson.Safe.to_string json) reqd
+           Http.Response.json_value ~compress:true ~request:req json reqd
          ) request reqd)
   |> Http.Router.get "/api/v1/cascade/strategy_trace" (fun request reqd ->
        with_public_read (fun _state req reqd ->
@@ -112,8 +105,7 @@ let add_routes router =
          let json =
            Dashboard_cascade.strategy_trace_json ~limit ?cascade ()
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/cascade/audit_runs" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -125,8 +117,7 @@ let add_routes router =
          let json =
            Dashboard_cascade.audit_runs_json ~base_path ~limit ?cascade ()
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/cascade/inspector" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -139,12 +130,10 @@ let add_routes router =
            Dashboard_cascade.audit_runs_json
              ~dashboard_surface:"/api/v1/cascade/inspector" ~base_path ~limit ?cascade ()
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/cascade/slo" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = Dashboard_cascade.slo_json () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -153,12 +153,12 @@ let handle_gate_message ~sw ~clock state request reqd =
     in
     match result with
     | Ok out ->
-        respond_json_with_cors ~status:`OK request reqd
-          (Yojson.Safe.to_string (Channel_gate.outbound_to_json out))
+        respond_json_value_with_cors ~status:`OK request reqd
+          (Channel_gate.outbound_to_json out)
     | Error (gate_err, client_msg) ->
         let status = http_status_of_gate_error gate_err in
-        respond_json_with_cors ~status request reqd
-          (Yojson.Safe.to_string (Channel_gate.error_json client_msg))
+        respond_json_value_with_cors ~status request reqd
+          (Channel_gate.error_json client_msg)
   )
 
 (** GET /api/v1/gate/events?channel=<channel>&keeper=<keeper>&room_id=<room>&limit=<n>
@@ -183,15 +183,14 @@ let handle_gate_events _state request reqd =
       ?room_id:(trim_filter "room_id")
       ~limit ()
   in
-  respond_public_read_json ~status:`OK request reqd
-    (Yojson.Safe.to_string json)
+  respond_public_read_json_value ~status:`OK request reqd json
 
 (** GET /api/v1/gate/health
 
     Simple health check for the gate layer. *)
 let handle_gate_health _state request reqd =
-  respond_public_read_json ~status:`OK request reqd
-    {|{"ok":true,"service":"channel_gate"}|}
+  respond_public_read_json_value ~status:`OK request reqd
+    (`Assoc [ ("ok", `Bool true); ("service", `String "channel_gate") ])
 
 (** GET /api/v1/gate/status
 
@@ -199,8 +198,7 @@ let handle_gate_health _state request reqd =
     average latency, error counts.  Public read. *)
 let handle_gate_status _state request reqd =
   let json = Channel_gate_metrics.snapshot_json () in
-  respond_public_read_json ~status:`OK request reqd
-    (Yojson.Safe.to_string json)
+  respond_public_read_json_value ~status:`OK request reqd json
 
 (** GET /api/v1/gate/connectors
 
@@ -218,8 +216,7 @@ let handle_gate_connectors _state request reqd =
     Channel_gate_connector.connectors_json ~gate_status_json:gate_status
       ~audit_limit ()
   in
-  respond_public_read_json ~status:`OK request reqd
-    (Yojson.Safe.to_string json)
+  respond_public_read_json_value ~status:`OK request reqd json
 
 (** GET /api/v1/gate/connector/status?name=<connector>&audit_limit=<n>
 
@@ -243,22 +240,20 @@ let handle_gate_connector_status _state request reqd =
   in
   match connector_name with
   | None | Some "" ->
-      respond_public_read_json ~status:`Bad_request request reqd
-        (Yojson.Safe.to_string
-           (Channel_gate.error_json "name or channel is required"))
+      respond_public_read_json_value ~status:`Bad_request request reqd
+        (Channel_gate.error_json "name or channel is required")
   | Some name -> (
       match Channel_gate_connector.find name with
       | None ->
-          respond_public_read_json ~status:`Not_found request reqd
-            (Yojson.Safe.to_string
-               (Channel_gate.error_json ("unknown connector: " ^ name)))
+          respond_public_read_json_value ~status:`Not_found request reqd
+            (Channel_gate.error_json ("unknown connector: " ^ name))
       | Some (module C) ->
           let audit_limit =
             int_query_param request "audit_limit" ~default:10
             |> fun value -> max 1 (min 50 value)
           in
-          respond_public_read_json ~status:`OK request reqd
-            (Yojson.Safe.to_string (C.status_json ~audit_limit ())))
+          respond_public_read_json_value ~status:`OK request reqd
+            (C.status_json ~audit_limit ()))
 
 let gate_keeper_ctx ~sw ~clock state =
   {
@@ -298,9 +293,8 @@ let respond_keeper_tool_json ~sw ~clock state request reqd ~tool_name ~args =
       | Yojson.Json_error err ->
           Log.Misc.error "channel_gate %s returned invalid json: %s"
             tool_name err;
-          respond_json_with_cors ~status:`Internal_server_error request reqd
-            (Yojson.Safe.to_string
-               (Channel_gate.error_json "internal error")) )
+          respond_json_value_with_cors ~status:`Internal_server_error request reqd
+            (Channel_gate.error_json "internal error") )
   | Some result ->
       let err = Tool_result.message result in
       let lower = String.lowercase_ascii err in
@@ -308,12 +302,11 @@ let respond_keeper_tool_json ~sw ~clock state request reqd ~tool_name ~args =
         if String_util.contains_substring lower "keeper not found" then `Not_found
         else `Bad_gateway
       in
-      respond_json_with_cors ~status request reqd
-        (Yojson.Safe.to_string (Channel_gate.error_json err))
+      respond_json_value_with_cors ~status request reqd
+        (Channel_gate.error_json err)
   | None ->
-      respond_json_with_cors ~status:`Service_unavailable request reqd
-        (Yojson.Safe.to_string
-           (Channel_gate.error_json "keeper dispatch unavailable"))
+      respond_json_value_with_cors ~status:`Service_unavailable request reqd
+        (Channel_gate.error_json "keeper dispatch unavailable")
 
 (** GET /api/v1/gate/keepers?limit=100&detailed=true
 
@@ -338,17 +331,15 @@ let handle_gate_keeper_status ~sw ~clock state request reqd =
   | Some raw_name ->
       let name = String.trim raw_name in
       if name = "" then
-        respond_json_with_cors ~status:`Bad_request request reqd
-          (Yojson.Safe.to_string
-             (Channel_gate.error_json "name is required"))
+        respond_json_value_with_cors ~status:`Bad_request request reqd
+          (Channel_gate.error_json "name is required")
       else
         let args = `Assoc [ ("name", `String name) ] in
         respond_keeper_tool_json ~sw ~clock state request reqd
           ~tool_name:"masc_keeper_status" ~args
   | None ->
-      respond_json_with_cors ~status:`Bad_request request reqd
-        (Yojson.Safe.to_string
-           (Channel_gate.error_json "name is required"))
+      respond_json_value_with_cors ~status:`Bad_request request reqd
+        (Channel_gate.error_json "name is required")
 
 (** Shared bind handler: parse body, validate keeper, dispatch to connector. *)
 let handle_bind_for_connector ~sw ~clock state request reqd
@@ -373,22 +364,19 @@ let handle_bind_for_connector ~sw ~clock state request reqd
         |> String.trim
       in
       if channel_id = "" then
-        respond_json_with_cors ~status:`Bad_request request reqd
-          (Yojson.Safe.to_string
-             (Channel_gate.error_json "channel_id is required"))
+        respond_json_value_with_cors ~status:`Bad_request request reqd
+          (Channel_gate.error_json "channel_id is required")
       else if keeper_name = "" then
-        respond_json_with_cors ~status:`Bad_request request reqd
-          (Yojson.Safe.to_string
-             (Channel_gate.error_json "keeper_name is required"))
+        respond_json_value_with_cors ~status:`Bad_request request reqd
+          (Channel_gate.error_json "keeper_name is required")
       else
         match keeper_exists ~sw ~clock state keeper_name with
         | Error err ->
-            respond_json_with_cors ~status:`Service_unavailable request reqd
-              (Yojson.Safe.to_string (Channel_gate.error_json err))
+            respond_json_value_with_cors ~status:`Service_unavailable request reqd
+              (Channel_gate.error_json err)
         | Ok false ->
-            respond_json_with_cors ~status:`Not_found request reqd
-              (Yojson.Safe.to_string
-                 (Channel_gate.error_json ("unknown keeper: " ^ keeper_name)))
+            respond_json_value_with_cors ~status:`Not_found request reqd
+              (Channel_gate.error_json ("unknown keeper: " ^ keeper_name))
         | Ok true -> (
             let actor_name =
               sanitized_dashboard_actor_for_request
@@ -398,15 +386,13 @@ let handle_bind_for_connector ~sw ~clock state request reqd
             in
             match bind_fn ~channel_id ~keeper_name ~actor_name with
             | Ok payload ->
-                respond_json_with_cors ~status:`OK request reqd
-                  (Yojson.Safe.to_string payload)
+                respond_json_value_with_cors ~status:`OK request reqd payload
             | Error err ->
-                respond_json_with_cors ~status:`Internal_server_error request
-                  reqd
-                  (Yojson.Safe.to_string (Channel_gate.error_json err)))
+                respond_json_value_with_cors ~status:`Internal_server_error
+                  request reqd (Channel_gate.error_json err))
     with Yojson.Json_error _ ->
-      respond_json_with_cors ~status:`Bad_request request reqd
-        (Yojson.Safe.to_string (Channel_gate.error_json "invalid json")))
+      respond_json_value_with_cors ~status:`Bad_request request reqd
+        (Channel_gate.error_json "invalid json"))
 
 (** Shared unbind handler: parse body, dispatch to connector. *)
 let handle_unbind_for_connector state request reqd
@@ -424,9 +410,8 @@ let handle_unbind_for_connector state request reqd
         |> String.trim
       in
       if channel_id = "" then
-        respond_json_with_cors ~status:`Bad_request request reqd
-          (Yojson.Safe.to_string
-             (Channel_gate.error_json "channel_id is required"))
+        respond_json_value_with_cors ~status:`Bad_request request reqd
+          (Channel_gate.error_json "channel_id is required")
       else
         let actor_name =
           sanitized_dashboard_actor_for_request
@@ -436,18 +421,16 @@ let handle_unbind_for_connector state request reqd
         in
         match unbind_fn ~channel_id ~actor_name with
         | Ok payload ->
-            respond_json_with_cors ~status:`OK request reqd
-              (Yojson.Safe.to_string payload)
+            respond_json_value_with_cors ~status:`OK request reqd payload
         | Error "binding not found" ->
-            respond_json_with_cors ~status:`Not_found request reqd
-              (Yojson.Safe.to_string
-                 (Channel_gate.error_json "binding not found"))
+            respond_json_value_with_cors ~status:`Not_found request reqd
+              (Channel_gate.error_json "binding not found")
         | Error err ->
-            respond_json_with_cors ~status:`Internal_server_error request reqd
-              (Yojson.Safe.to_string (Channel_gate.error_json err))
+            respond_json_value_with_cors ~status:`Internal_server_error request reqd
+              (Channel_gate.error_json err)
     with Yojson.Json_error _ ->
-      respond_json_with_cors ~status:`Bad_request request reqd
-        (Yojson.Safe.to_string (Channel_gate.error_json "invalid json")))
+      respond_json_value_with_cors ~status:`Bad_request request reqd
+        (Channel_gate.error_json "invalid json"))
 
 (** POST /api/v1/gate/connector/bind?name=<connector>
 
@@ -460,15 +443,13 @@ let handle_gate_connector_bind ~sw ~clock state request reqd =
     |> Option.value ~default:""
   in
   if connector_name = "" then
-    respond_json_with_cors ~status:`Bad_request request reqd
-      (Yojson.Safe.to_string (Channel_gate.error_json "name is required"))
+    respond_json_value_with_cors ~status:`Bad_request request reqd
+      (Channel_gate.error_json "name is required")
   else
     match Channel_gate_connector.find connector_name with
     | None ->
-        respond_json_with_cors ~status:`Not_found request reqd
-          (Yojson.Safe.to_string
-             (Channel_gate.error_json
-                ("unknown connector: " ^ connector_name)))
+        respond_json_value_with_cors ~status:`Not_found request reqd
+          (Channel_gate.error_json ("unknown connector: " ^ connector_name))
     | Some (module C) ->
         handle_bind_for_connector ~sw ~clock state request reqd
           ~bind_fn:C.bind
@@ -483,15 +464,13 @@ let handle_gate_connector_unbind _state request reqd =
     |> Option.value ~default:""
   in
   if connector_name = "" then
-    respond_json_with_cors ~status:`Bad_request request reqd
-      (Yojson.Safe.to_string (Channel_gate.error_json "name is required"))
+    respond_json_value_with_cors ~status:`Bad_request request reqd
+      (Channel_gate.error_json "name is required")
   else
     match Channel_gate_connector.find connector_name with
     | None ->
-        respond_json_with_cors ~status:`Not_found request reqd
-          (Yojson.Safe.to_string
-             (Channel_gate.error_json
-                ("unknown connector: " ^ connector_name)))
+        respond_json_value_with_cors ~status:`Not_found request reqd
+          (Channel_gate.error_json ("unknown connector: " ^ connector_name))
     | Some (module C) ->
         handle_unbind_for_connector _state request reqd
           ~unbind_fn:C.unbind

--- a/lib/server/server_routes_http_routes_credentials.ml
+++ b/lib/server/server_routes_http_routes_credentials.ml
@@ -153,9 +153,9 @@ let add_routes router =
          let base_path = state.Mcp_server.room_config.base_path in
          match Credential_store.load_all ~base_path with
          | Error msg ->
-             Http.Response.json ~status:`Internal_server_error ~request:req
-               (Yojson.Safe.to_string
-                  (`Assoc [ ("ok", `Bool false); ("error", `String msg) ]))
+             Http.Response.json_value ~status:`Internal_server_error
+               ~request:req
+               (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
                reqd
          | Ok credentials ->
              let credentials =
@@ -173,9 +173,7 @@ let add_routes router =
                    ("total", `Int (List.length credentials));
                  ]
              in
-             Http.Response.json ~compress:true ~request:req
-               (Yojson.Safe.to_string json)
-               reqd
+             Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.prefix_get "/api/v1/credentials/" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -183,31 +181,27 @@ let add_routes router =
          let path = Http.Request.path request in
          match extract_path_param ~prefix:"/api/v1/credentials/" path with
          | None | Some "" ->
-             Http.Response.json ~status:`Bad_request ~request:req
-               (Yojson.Safe.to_string
-                  (`Assoc
-                    [ ("ok", `Bool false); ("error", `String "missing credential id") ]))
+             Http.Response.json_value ~status:`Bad_request ~request:req
+               (`Assoc
+                  [ ("ok", `Bool false); ("error", `String "missing credential id") ])
                reqd
          | Some id -> (
              match Credential_store.find ~base_path id with
              | Error msg ->
-                 Http.Response.json ~status:`Not_found ~request:req
-                   (Yojson.Safe.to_string
-                      (`Assoc [ ("ok", `Bool false); ("error", `String msg) ]))
+                 Http.Response.json_value ~status:`Not_found ~request:req
+                   (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
                    reqd
              | Ok credential ->
-                 Http.Response.json ~request:req
-                   (Yojson.Safe.to_string (credential_json credential))
-                   reqd)
+                 Http.Response.json_value ~request:req
+                   (credential_json credential) reqd)
        ) request reqd)
   |> Http.Router.post "/api/v1/credentials" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
          (fun state _agent_name req reqd ->
            Http.Request.read_body_async reqd (fun body_str ->
              let response status message =
-               Http.Response.json ~status ~request:req
-                 (Yojson.Safe.to_string
-                    (`Assoc [ ("ok", `Bool false); ("error", `String message) ]))
+               Http.Response.json_value ~status ~request:req
+                 (`Assoc [ ("ok", `Bool false); ("error", `String message) ])
                  reqd
              in
              match Yojson.Safe.from_string body_str with
@@ -281,10 +275,8 @@ let add_routes router =
                                 with
                                 | Error msg -> response `Bad_request msg
                                 | Ok cred ->
-                                    Http.Response.json ~request:req
-                                      (Yojson.Safe.to_string
-                                         (credential_json cred))
-                                      reqd)
+                                    Http.Response.json_value ~request:req
+                                      (credential_json cred) reqd)
                             | "with_token" -> (
                                 match token_opt with
                                 | None ->
@@ -355,11 +347,9 @@ let add_routes router =
                                             | Error msg ->
                                                 response `Bad_request msg
                                             | Ok cred ->
-                                                Http.Response.json
+                                                Http.Response.json_value
                                                   ~request:req
-                                                  (Yojson.Safe.to_string
-                                                     (credential_json
-                                                        cred))
+                                                  (credential_json cred)
                                                   reqd))))
                             | other ->
                                 response `Bad_request
@@ -377,20 +367,21 @@ let add_routes router =
              let path = Http.Request.path request in
              match extract_path_param ~prefix:"/api/v1/credentials/" path with
              | None | Some "" ->
-                 Http.Response.json ~status:`Bad_request ~request:req
-                   (Yojson.Safe.to_string
-                      (`Assoc
-                        [ ("ok", `Bool false); ("error", `String "missing credential id") ]))
+                 Http.Response.json_value ~status:`Bad_request ~request:req
+                   (`Assoc
+                      [
+                        ("ok", `Bool false);
+                        ("error", `String "missing credential id");
+                      ])
                    reqd
              | Some id -> (
                  match Credential_store.remove ~base_path id with
                  | Error msg ->
-                     Http.Response.json ~status:`Bad_request ~request:req
-                       (Yojson.Safe.to_string
-                          (`Assoc [ ("ok", `Bool false); ("error", `String msg) ]))
+                     Http.Response.json_value ~status:`Bad_request ~request:req
+                       (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
                        reqd
                  | Ok () ->
-                     Http.Response.json ~request:req
-                       (Yojson.Safe.to_string (`Assoc [ ("ok", `Bool true) ]))
+                     Http.Response.json_value ~request:req
+                       (`Assoc [ ("ok", `Bool true) ])
                        reqd)
            ) request reqd)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -11,6 +11,25 @@ open Server_routes_http_keeper_stream
 
 include Server_routes_http_routes_dashboard_setup
 
+let dashboard_error_json ?ok message =
+  let fields = [ ("error", `String message) ] in
+  let fields =
+    match ok with
+    | None -> fields
+    | Some value -> ("ok", `Bool value) :: fields
+  in
+  `Assoc fields
+
+let respond_dashboard_error ?(status = `Bad_request) ?request ?ok reqd message =
+  Http.Response.json_value ?request ~status
+    (dashboard_error_json ?ok message)
+    reqd
+
+let respond_dashboard_ok ?request reqd =
+  Http.Response.json_value ?request ~compress:true
+    (`Assoc [ ("ok", `Bool true) ])
+    reqd
+
 let rec add_routes ~sw ~clock router =
   router
   |> Http.Router.post "/api/v1/broadcast" (fun request reqd ->
@@ -40,8 +59,7 @@ let rec add_routes ~sw ~clock router =
                ("message", `String "Use /api/v1/dashboard/shell and surface-specific projection endpoints.");
              ]
          in
-         Http.Response.json ~status:`Gone ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~status:`Gone ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/shell" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -56,9 +74,7 @@ let rec add_routes ~sw ~clock router =
              ?clock:state.Mcp_server.clock ~request:req
              ~timing ~light state.Mcp_server.room_config
          in
-         Http.Response.json ~compress:true ~request:req
-           ~extra_headers:(Server_timing.extra_header timing)
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req ~extra_headers:(Server_timing.extra_header timing) json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/nudges" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -76,8 +92,7 @@ let rec add_routes ~sw ~clock router =
                Dashboard_operator_nudges.json
                  ~config:state.Mcp_server.room_config ~limit ()))
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/goal-loop/status" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -85,12 +100,12 @@ let rec add_routes ~sw ~clock router =
            Dashboard_goal_loop.status_json
              ~base_path:state.Mcp_server.room_config.base_path ()
          in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/branches" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = Dashboard_branches.json ~config:state.Mcp_server.room_config in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/rooms" (fun request reqd ->
        with_public_read handle_dashboard_rooms request reqd)
@@ -104,9 +119,8 @@ let rec add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/dev-token" (fun request reqd ->
        if (not (http_auth_bind_is_loopback ()))
           || http_auth_strict_enabled () then
-         Http.Response.json ~status:`Not_found ~request:request
-           {|{"error":"dev-token endpoint disabled (non-loopback bind or strict auth)"}|}
-           reqd
+         respond_dashboard_error ~status:`Not_found ~request reqd
+           "dev-token endpoint disabled (non-loopback bind or strict auth)"
        else
          with_public_read (fun state req reqd ->
            let base_path = state.Mcp_server.room_config.base_path in
@@ -114,23 +128,17 @@ let rec add_routes ~sw ~clock router =
            begin
              match raw_result with
              | Ok raw ->
-               let body =
-                 Yojson.Safe.to_string (`Assoc [ ("token", `String raw) ])
-               in
-               Http.Response.json ~request:req body reqd
+               Http.Response.json_value ~request:req
+                 (`Assoc [ ("token", `String raw) ]) reqd
              | Error msg ->
-               let body =
-                 Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
-               in
-               Http.Response.json ~status:`Internal_server_error
-                 ~request:req body reqd
+               Http.Response.json_value ~status:`Internal_server_error
+                 ~request:req (`Assoc [ ("error", `String msg) ]) reqd
            end) request reqd)
   |> Http.Router.get "/api/v1/dashboard/runtime-probe" (fun request reqd ->
        let force = Server_utils.bool_query_param request "force" ~default:false in
        let handle _state req reqd =
          let json = dashboard_runtime_probe_http_json ~force () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        in
        with_tool_auth ~tool_name:"masc_runtime_ollama_probe" handle request reqd)
   (* Phase 1 Action 2 — live Dashboard_cache state surface.  Renders
@@ -141,8 +149,7 @@ let rec add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/cache-stats" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = Dashboard_cache.stats () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/logs" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -164,8 +171,7 @@ let rec add_routes ~sw ~clock router =
                ; "level", `String level_filter
                ]
            in
-           Http.Response.json ~status:`Bad_request ~compress:true ~request:req
-             (Yojson.Safe.to_string json) reqd
+           Http.Response.json_value ~status:`Bad_request ~compress:true ~request:req json reqd
          | Some applied_level ->
            let min_level = Log.level_to_int applied_level in
            let since_seq =
@@ -186,8 +192,7 @@ let rec add_routes ~sw ~clock router =
              dashboard_logs_json ~config:state.Mcp_server.room_config ~limit
                ~level_filter ~applied_level ~min_level ~module_filter ~since_seq entries
            in
-           Http.Response.json ~compress:true ~request:req
-             (Yojson.Safe.to_string json) reqd
+           Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/provider-logs" (fun request reqd ->
        with_public_read (fun _state req reqd ->
@@ -197,14 +202,12 @@ let rec add_routes ~sw ~clock router =
              Domain_pool_ref.submit_io_or_inline (fun () ->
                Provider_logs.dashboard_provider_logs_json ()))
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/provider-logs/tail" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
+         with_public_read (fun _state req reqd ->
          let status, json = Provider_logs.dashboard_provider_log_tail_json req in
-         Http.Response.json ~status ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~status ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/logs/tool-host-failures" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_broadcast" (fun state req reqd ->
@@ -225,12 +228,10 @@ let rec add_routes ~sw ~clock router =
                Dashboard_tool_host_events.record ?fs:state.Mcp_server.fs
                  state.Mcp_server.room_config
                  report;
-               Http.Response.json ~compress:true ~request:req {|{"ok":true}|}
-                 reqd
+               respond_dashboard_ok ~request:req reqd
            | Error message ->
-               Http.Response.json ~status:`Bad_request ~request:req
-                 (Yojson.Safe.to_string
-                    (`Assoc [ ("ok", `Bool false); ("error", `String message) ]))
+               Http.Response.json_value ~status:`Bad_request ~request:req
+                 (`Assoc [ ("ok", `Bool false); ("error", `String message) ])
                  reqd)
        ) request reqd)
   (* RFC-0049 — surface/section open counters. Aggregate Prometheus
@@ -248,12 +249,10 @@ let rec add_routes ~sw ~clock router =
            match result with
            | Ok event ->
                Dashboard_nav_event.record event;
-               Http.Response.json ~request:req {|{"ok":true}|} reqd
+               respond_dashboard_ok ~request:req reqd
            | Error message ->
-               Http.Response.json ~status:`Bad_request ~request:req
-                 (Yojson.Safe.to_string
-                    (`Assoc
-                      [ ("ok", `Bool false); ("error", `String message) ]))
+               Http.Response.json_value ~status:`Bad_request ~request:req
+                 (`Assoc [ ("ok", `Bool false); ("error", `String message) ])
                  reqd)
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/config" (fun request reqd ->
@@ -264,7 +263,7 @@ let rec add_routes ~sw ~clock router =
              Domain_pool_ref.submit_io_or_inline (fun () ->
                Env_config_introspect.to_json ()))
          in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/config/excuse-patterns" (fun request reqd ->
        with_public_read (fun _state req reqd ->
@@ -280,7 +279,7 @@ let rec add_routes ~sw ~clock router =
                in
                `List json_items))
          in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/config/excuse-patterns" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
@@ -290,20 +289,20 @@ let rec add_routes ~sw ~clock router =
                let json = Yojson.Safe.from_string body_str in
                match Anti_rationalization.parse_excuse_patterns_json json with
                | Error msg ->
-                 Http.Response.json ~status:`Bad_request ~request:req
-                   (Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String msg)])) reqd
+                 Http.Response.json_value ~status:`Bad_request ~request:req
+                   (`Assoc [("ok", `Bool false); ("error", `String msg)]) reqd
                | Ok patterns ->
                  (match Anti_rationalization.save_excuse_patterns patterns with
                  | Ok () ->
-                     Http.Response.json ~request:req {|{"ok":true}|} reqd
+                     respond_dashboard_ok ~request:req reqd
                  | Error msg ->
-                     Http.Response.json ~status:`Internal_server_error ~request:req
-                       (Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String msg)])) reqd)
+                     Http.Response.json_value ~status:`Internal_server_error ~request:req
+                       (`Assoc [("ok", `Bool false); ("error", `String msg)]) reqd)
              with
              | Eio.Cancel.Cancelled _ as exn -> raise exn
              | _exn ->
-               Http.Response.json ~status:`Bad_request ~request:req
-                 (Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String "Invalid JSON body")])) reqd
+               Http.Response.json_value ~status:`Bad_request ~request:req
+                 (`Assoc [("ok", `Bool false); ("error", `String "Invalid JSON body")]) reqd
            )
          ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/project-snapshot" (fun request reqd ->
@@ -318,9 +317,7 @@ let rec add_routes ~sw ~clock router =
            Server_dashboard_snapshot_select.select_project_snapshot_json
              ~state ~sw ~clock ~timing req
          in
-         Http.Response.json ~compress:true ~request:req
-           ~extra_headers:(Server_timing.extra_header timing)
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req ~extra_headers:(Server_timing.extra_header timing) json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/namespace-truth" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -334,29 +331,26 @@ let rec add_routes ~sw ~clock router =
            Server_dashboard_snapshot_select.select_project_snapshot_json
              ~state ~sw ~clock ~timing req
          in
-         Http.Response.json ~compress:true ~request:req
-           ~extra_headers:(Server_timing.extra_header timing)
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req ~extra_headers:(Server_timing.extra_header timing) json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/execution" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_execution_http_json ~state ~sw ~clock request in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/execution-trust" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json =
            dashboard_execution_trust_http_json ~state ~sw ~clock request
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/board" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json =
            dashboard_memory_http_json ~config:state.Mcp_server.room_config req
          in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/link-previews" (fun request reqd ->
        with_permission_auth ~permission:Masc_domain.CanReadState
@@ -380,8 +374,7 @@ let rec add_routes ~sw ~clock router =
                dashboard_memory_subsystems_http_json ~config
                  ~include_memory_entries req))
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        in
        if include_memory_entries then
          with_token_permission_auth ~permission:Masc_domain.CanReadState
@@ -422,31 +415,29 @@ let rec add_routes ~sw ~clock router =
                  Yojson.Safe.from_string
                    (dashboard_doctor_degraded_json ~self_bin ~exn)))
          in
-         Http.Response.json
+         Http.Response.json_value
            ~compress:true
            ~request:req
-           (Yojson.Safe.to_string payload)
+           payload
            reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/governance" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let base_path = state.Mcp_server.room_config.base_path in
          let json = dashboard_governance_http_json req ~base_path in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/governance/tool-events" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = dashboard_governance_tool_events_http_json req in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/proof" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json =
            dashboard_proof_http_json ~config:state.Mcp_server.room_config req
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/governance/approvals/resolve" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_operator_confirm" (fun state _req reqd ->
@@ -456,19 +447,13 @@ let rec add_routes ~sw ~clock router =
              let base_path = state.Mcp_server.room_config.base_path in
              match dashboard_governance_approval_resolve_http_json ~base_path ~args with
              | Ok json ->
-                 respond_json_with_cors request reqd (Yojson.Safe.to_string json)
+                 respond_json_value_with_cors request reqd json
              | Error (Gone _ as err) ->
-                 respond_json_with_cors ~status:`Not_found request reqd
-                   (Yojson.Safe.to_string
-                      (operator_error_json (approval_resolve_http_error_to_string err)))
+                 respond_json_value_with_cors ~status:`Not_found request reqd (operator_error_json (approval_resolve_http_error_to_string err))
              | Error (Bad_request _ as err) ->
-                 respond_json_with_cors ~status:`Bad_request request reqd
-                   (Yojson.Safe.to_string
-                      (operator_error_json (approval_resolve_http_error_to_string err)))
+                 respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json (approval_resolve_http_error_to_string err))
            with Yojson.Json_error msg ->
-             respond_json_with_cors ~status:`Bad_request request reqd
-               (Yojson.Safe.to_string
-                  (operator_error_json (Printf.sprintf "invalid json: %s" msg)))
+             respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json (Printf.sprintf "invalid json: %s" msg))
          )
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/governance/approvals/rules/delete" (fun request reqd ->
@@ -481,15 +466,11 @@ let rec add_routes ~sw ~clock router =
                dashboard_governance_approval_rule_delete_http_json ~base_path ~args
              with
              | Ok json ->
-                 respond_json_with_cors request reqd (Yojson.Safe.to_string json)
+                 respond_json_value_with_cors request reqd json
              | Error message ->
-                 respond_json_with_cors ~status:`Bad_request request reqd
-                   (Yojson.Safe.to_string
-                      (operator_error_json message))
+                 respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json message)
            with Yojson.Json_error msg ->
-             respond_json_with_cors ~status:`Bad_request request reqd
-               (Yojson.Safe.to_string
-                  (operator_error_json (Printf.sprintf "invalid json: %s" msg)))
+             respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json (Printf.sprintf "invalid json: %s" msg))
          )
        ) request reqd)
 
@@ -509,18 +490,15 @@ let rec add_routes ~sw ~clock router =
              Domain_pool_ref.submit_io_or_inline (fun () ->
                operator_snapshot_http_json ~state ~sw ~clock req))
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/operator/digest" (fun request reqd ->
        with_public_read (fun state req reqd ->
          match operator_digest_http_json ~state ~sw ~clock req with
          | Ok json ->
-             Http.Response.json ~compress:true ~request:req
-               (Yojson.Safe.to_string json) reqd
+             Http.Response.json_value ~compress:true ~request:req json reqd
          | Error message ->
-             respond_json_with_cors ~status:`Bad_request request reqd
-               (Yojson.Safe.to_string (operator_error_json message))
+             respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json message)
        ) request reqd)
   |> Http.Router.post "/api/v1/operator/action" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_operator_action" (fun state req reqd ->
@@ -529,14 +507,11 @@ let rec add_routes ~sw ~clock router =
              let args = Yojson.Safe.from_string body_str in
              match operator_action_http_json ~state ~sw ~clock req ~args with
              | Ok json ->
-                 respond_json_with_cors request reqd (Yojson.Safe.to_string json)
+                 respond_json_value_with_cors request reqd json
              | Error message ->
-                 respond_json_with_cors ~status:`Bad_request request reqd
-                   (Yojson.Safe.to_string (operator_error_json message))
+                 respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json message)
            with Yojson.Json_error msg ->
-             respond_json_with_cors ~status:`Bad_request request reqd
-               (Yojson.Safe.to_string
-                  (operator_error_json (Printf.sprintf "invalid json: %s" msg)))
+             respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json (Printf.sprintf "invalid json: %s" msg))
          )
        ) request reqd)
   |> Http.Router.post "/api/v1/operator/confirm" (fun request reqd ->
@@ -546,14 +521,11 @@ let rec add_routes ~sw ~clock router =
              let args = Yojson.Safe.from_string body_str in
              match operator_confirm_http_json ~state ~sw ~clock req ~args with
              | Ok json ->
-                 respond_json_with_cors request reqd (Yojson.Safe.to_string json)
+                 respond_json_value_with_cors request reqd json
              | Error message ->
-                 respond_json_with_cors ~status:`Bad_request request reqd
-                   (Yojson.Safe.to_string (operator_error_json message))
+                 respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json message)
            with Yojson.Json_error msg ->
-             respond_json_with_cors ~status:`Bad_request request reqd
-               (Yojson.Safe.to_string
-                  (operator_error_json (Printf.sprintf "invalid json: %s" msg)))
+             respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json (Printf.sprintf "invalid json: %s" msg))
          )
        ) request reqd)
 
@@ -568,7 +540,7 @@ let rec add_routes ~sw ~clock router =
              Domain_pool_ref.submit_io_or_inline (fun () ->
                dashboard_planning_http_json ~config:state.Mcp_server.room_config))
          in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/bootstrap" (fun request reqd ->
        (* Cold-start bootstrap: routes to the shared SSOT
@@ -579,8 +551,7 @@ let rec add_routes ~sw ~clock router =
           just the auth + transport wrapper. *)
        with_public_read (fun state req reqd ->
          let json = dashboard_bootstrap_http_json ~state ~sw ~clock req in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/goals" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -593,7 +564,7 @@ let rec add_routes ~sw ~clock router =
              Domain_pool_ref.submit_io_or_inline (fun () ->
                dashboard_goals_tree_http_json ~config:state.Mcp_server.room_config))
          in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/goals/detail" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -603,8 +574,8 @@ let rec add_routes ~sw ~clock router =
            |> Option.value ~default:""
          in
          if goal_id = "" then
-           respond_json_with_cors ~status:`Bad_request req reqd
-             {|{"ok":false,"error":"goal_id query param is required"}|}
+           respond_public_read_json_value ~status:`Bad_request req reqd
+             (dashboard_error_json ~ok:false "goal_id query param is required")
          else
            let cache_key =
              Printf.sprintf "goal_detail:%s:%s"
@@ -616,8 +587,7 @@ let rec add_routes ~sw ~clock router =
                  dashboard_goal_detail_http_json
                    ~config:state.Mcp_server.room_config ~goal_id))
            in
-           Http.Response.json ~compress:true ~request:req
-             (Yojson.Safe.to_string json) reqd
+           Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/tasks/history" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -633,7 +603,7 @@ let rec add_routes ~sw ~clock router =
              Domain_pool_ref.submit_io_or_inline (fun () ->
                dashboard_mission_http_json ~state ~sw ~clock req))
          in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/session" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -645,7 +615,7 @@ let rec add_routes ~sw ~clock router =
              Domain_pool_ref.submit_io_or_inline (fun () ->
                dashboard_session_http_json ~state ~sw ~clock req))
          in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/tools" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -663,9 +633,7 @@ let rec add_routes ~sw ~clock router =
                     ~base_path:state.Mcp_server.room_config.base_path request)
                state.Mcp_server.room_config
            in
-         Http.Response.json ~compress:true ~request:req
-           ~extra_headers:(Server_timing.extra_header timing)
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req ~extra_headers:(Server_timing.extra_header timing) json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/mission/briefing" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -678,7 +646,7 @@ let rec add_routes ~sw ~clock router =
              Domain_pool_ref.submit_io_or_inline (fun () ->
                dashboard_mission_briefing_http_json ~state ~sw ~clock req))
          in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/surface-readiness" (fun request reqd ->
        with_public_read (fun _state req reqd ->
@@ -692,8 +660,7 @@ let rec add_routes ~sw ~clock router =
              Domain_pool_ref.submit_io_or_inline (fun () ->
                Dashboard_surface_readiness.json ?surface_id ()))
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/tool-quality" (fun request reqd ->
        with_public_read (fun _state req reqd ->
@@ -728,8 +695,7 @@ let rec add_routes ~sw ~clock router =
              Domain_pool_ref.submit_io_or_inline (fun () ->
                Dashboard_http_tool_quality.aggregate ~n ?window_hours ()))
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/keeper-feature-proof" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -775,8 +741,7 @@ let rec add_routes ~sw ~clock router =
                Dashboard_keeper_feature_proof.json
                  ~config ~n ?window_hours ?success_threshold_pct ()))
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/transport-health" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -786,12 +751,12 @@ let rec add_routes ~sw ~clock router =
              Domain_pool_ref.submit_io_or_inline (fun () ->
                dashboard_transport_health_http_json ~state))
          in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/perf" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_perf_http_json state.Mcp_server.room_config in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/harness-health" (fun _request reqd ->
        with_public_read (fun state req reqd ->
@@ -809,8 +774,7 @@ let rec add_routes ~sw ~clock router =
                Dashboard_harness_health.json ~config:state.Mcp_server.room_config
                  ?since ?until ()))
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) _request reqd)
   |> Http.Router.get "/api/v1/dashboard/feature-health" (fun _request reqd ->
        with_public_read (fun _state req reqd ->
@@ -824,8 +788,7 @@ let rec add_routes ~sw ~clock router =
              Domain_pool_ref.submit_io_or_inline (fun () ->
                Dashboard_feature_health.json ()))
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) _request reqd)
   (* ── Eval feed (RFC-MASC-005 Phase 2) ── *)
   |> Http.Router.get "/api/v1/dashboard/eval-feed" (fun request reqd ->
@@ -882,8 +845,7 @@ let rec add_routes ~sw ~clock router =
                  ("agents", `List per_agent);
                ]))
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
 
   (* ── Telemetry unified view ── *)
@@ -900,25 +862,21 @@ let rec add_routes ~sw ~clock router =
            Server_dashboard_snapshot_select.select_telemetry_summary_json
              ~timing state.Mcp_server.room_config
          in
-         Http.Response.json ~compress:true ~request:req
-           ~extra_headers:(Server_timing.extra_header timing)
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req ~extra_headers:(Server_timing.extra_header timing) json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/oas/telemetry/recent" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let provider = oas_telemetry_provider_param req in
          let limit = oas_telemetry_limit_param req in
          let json = Dashboard_oas_bridge.recent_json ?provider ~limit () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/oas/telemetry/summary" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let provider = oas_telemetry_provider_param req in
          let limit = oas_telemetry_limit_param req in
          let json = Dashboard_oas_bridge.summary_json ?provider ~limit () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
 
   (* ── Dashboard delete actions (extracted) ── *)
@@ -943,8 +901,8 @@ let rec add_routes ~sw ~clock router =
            | Ok payload ->
                handle_keeper_chat_stream ~sw ~clock state request reqd payload
            | Error message ->
-               respond_json_with_cors ~status:`Bad_request request reqd
-                 (Yojson.Safe.to_string (keeper_chat_stream_error_json message))
+               respond_json_value_with_cors ~status:`Bad_request request reqd
+                 (keeper_chat_stream_error_json message)
          )
        ) request reqd)
 
@@ -1020,8 +978,7 @@ let rec add_routes ~sw ~clock router =
                )
              ) request reqd
        | Keeper_api.Keeper_post_unknown ->
-           Http.Response.json ~status:`Not_found
-             {|{"error":"not found"}|} reqd)
+           respond_dashboard_error ~status:`Not_found reqd "not found")
 
   (* ── Agent API routes (extracted) ── *)
   |> Server_dashboard_http_agent_api.add_agent_api_routes
@@ -1032,10 +989,10 @@ and add_keeper_cascade_routes router =
   (* ── Keeper cascade config API ──────────────────────────────── *)
 
   |> Http.Router.get "/api/v1/keeper/cascades" (fun request reqd ->
-       with_public_read (fun _state _req reqd ->
+         with_public_read (fun _state _req reqd ->
          let gate = cascade_profile_gate () in
-         Http.Response.json ~request:request
-           (Yojson.Safe.to_string (`Assoc [
+         Http.Response.json_value ~request:request
+           (`Assoc [
              ("profiles", `List (List.map (fun s -> `String s) gate.valid_profiles));
              ( "invalid_profiles",
                `List
@@ -1047,7 +1004,7 @@ and add_keeper_cascade_routes router =
                           ("errors", `List (List.map (fun err -> `String err) errors));
                         ])
                     gate.invalid_profiles) );
-           ])) reqd
+           ]) reqd
        ) request reqd)
 
   |> Http.Router.post "/api/v1/keeper/cascade" (fun request reqd ->
@@ -1057,72 +1014,59 @@ and add_keeper_cascade_routes router =
          Http.Request.read_body_async reqd (fun body_str ->
            match Yojson.Safe.from_string body_str with
            | exception Yojson.Json_error _ ->
-             Http.Response.json ~status:`Bad_request ~request:req
-               {|{"ok":false,"error":"invalid JSON body"}|} reqd
+             respond_dashboard_error ~request:req ~ok:false reqd "invalid JSON body"
            | json ->
              let keeper_name = Safe_ops.json_string_opt "keeper" json in
              let cascade_name = Safe_ops.json_string_opt "cascade_name" json in
              match keeper_name, cascade_name with
              | None, _ | _, None ->
-               Http.Response.json ~status:`Bad_request ~request:req
-                 {|{"ok":false,"error":"requires {\"keeper\":\"...\",\"cascade_name\":\"...\"}"}|}
-                 reqd
+               respond_dashboard_error ~request:req ~ok:false reqd
+                 "requires {\"keeper\":\"...\",\"cascade_name\":\"...\"}"
              | Some name, Some cascade ->
                let known = available_cascade_profiles () in
                let invalid = invalid_cascade_assignment_profiles () in
                (match List.assoc_opt cascade invalid with
                 | Some reasons ->
-                  Http.Response.json ~status:`Conflict ~request:req
+                  respond_dashboard_error ~status:`Conflict ~request:req
+                    ~ok:false reqd
                     (Printf.sprintf
-                       {|{"ok":false,"error":"cascade %s is invalid in active cascade.toml: %s"}|}
-                       (String.escaped cascade)
-                       (String.escaped (String.concat " | " reasons)))
-                    reqd
+                       "cascade %s is invalid in active cascade.toml: %s"
+                       cascade
+                       (String.concat " | " reasons))
                 | None ->
                if not (List.mem cascade known) then
-                 Http.Response.json ~status:`Bad_request ~request:req
-                   (Printf.sprintf
-                     {|{"ok":false,"error":"unknown cascade %s. Available: %s"}|}
-                     (String.escaped cascade)
-                     (String.concat ", " known))
-                   reqd
+                 respond_dashboard_error ~request:req ~ok:false reqd
+                   (Printf.sprintf "unknown cascade %s. Available: %s"
+                      cascade (String.concat ", " known))
                else
                match Config_dir_resolver.keeper_toml_path_opt name with
                | None ->
-                 Http.Response.json ~status:`Not_found ~request:req
-                   (Printf.sprintf
-                     {|{"ok":false,"error":"no TOML config for keeper %s"}|}
-                     (String.escaped name))
-                   reqd
+                 respond_dashboard_error ~status:`Not_found ~request:req
+                   ~ok:false reqd
+                   (Printf.sprintf "no TOML config for keeper %s" name)
                | Some toml_path ->
                  match Keeper_toml_loader.update_keeper_toml_field
                          ~path:toml_path ~key:"cascade_name" ~value:cascade with
                  | Error e ->
-                   Http.Response.json ~status:`Internal_server_error ~request:req
-                     (Printf.sprintf {|{"ok":false,"error":"%s"}|}
-                       (String.escaped e))
-                     reqd
+                   respond_dashboard_error ~status:`Internal_server_error
+                     ~request:req ~ok:false reqd e
                  | Ok () ->
                    let config = state.Mcp_server.room_config in
-                   (match sync_keeper_cascade_meta ~config ~name
+                    (match sync_keeper_cascade_meta ~config ~name
                             ~cascade_name:cascade with
                     | Error e ->
-                      Http.Response.json ~status:`Internal_server_error ~request:req
-                        (Printf.sprintf
-                           {|{"ok":false,"error":"%s"}|}
-                           (String.escaped e))
-                        reqd
+                      respond_dashboard_error ~status:`Internal_server_error
+                        ~request:req ~ok:false reqd e
                     | Ok live_meta_synced ->
-                      Http.Response.json ~request:req
-                        (Yojson.Safe.to_string
-                           (`Assoc
-                              [
-                                ("ok", `Bool true);
-                                ("keeper", `String name);
-                                ("cascade_name", `String cascade);
-                                ("source", `String "toml");
-                                ("live_meta_synced", `Bool live_meta_synced);
-                              ]))
+                      Http.Response.json_value ~request:req
+                        (`Assoc
+                           [
+                             ("ok", `Bool true);
+                             ("keeper", `String name);
+                             ("cascade_name", `String cascade);
+                             ("source", `String "toml");
+                             ("live_meta_synced", `Bool live_meta_synced);
+                           ])
                         reqd))
          )
        ) request reqd)

--- a/lib/server/server_routes_http_routes_dashboard_setup.ml
+++ b/lib/server/server_routes_http_routes_dashboard_setup.ml
@@ -292,7 +292,6 @@ let handle_telemetry request reqd =
         Dashboard_cache.get_or_compute cache_key
           ~ttl:dashboard_telemetry_cache_ttl_sec compute)
     in
-    Http.Response.json ~compress:true ~request:req
-      ~extra_headers:(Server_timing.extra_header timing)
-      (Yojson.Safe.to_string json) reqd
+    Http.Response.json_value ~compress:true ~request:req
+      ~extra_headers:(Server_timing.extra_header timing) json reqd
   ) request reqd

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -55,17 +55,14 @@ let redirect_to_dashboard reqd =
   respond_redirect ~location:"/dashboard" reqd
 
 let websocket_discovery_handler request reqd =
-  let body =
-    websocket_discovery_json request |> Yojson.Safe.to_string
-  in
-  Http.Response.json body reqd
+  Http.Response.json_value (websocket_discovery_json request) reqd
 
 let webrtc_signaling_handler signaling_fn request reqd =
   with_permission_auth ~permission:Masc_domain.CanBroadcast
     (fun _state _req reqd ->
       if not (Server_webrtc_transport.is_enabled ()) then
-        Http.Response.json ~status:`Not_found
-          {|{"error":"webrtc transport disabled"}|}
+        Http.Response.json_value ~status:`Not_found
+          (`Assoc [ ("error", `String "webrtc transport disabled") ])
           reqd
       else
         Http.Request.read_body_async reqd (fun body_str ->
@@ -73,9 +70,8 @@ let webrtc_signaling_handler signaling_fn request reqd =
           | Ok body ->
               Http.Response.json body reqd
           | Error msg ->
-              Http.Response.json ~status:`Bad_request
-                (Yojson.Safe.to_string
-                   (`Assoc [ ("error", `String msg) ]))
+              Http.Response.json_value ~status:`Bad_request
+                (`Assoc [ ("error", `String msg) ])
                 reqd))
     request reqd
 
@@ -85,16 +81,12 @@ let add_routes ~port ~host router =
   |> Http.Router.get Server_health_paths.liveness liveness_handler
   |> Http.Router.get Server_health_paths.readiness readiness_handler
   |> Http.Router.get "/.well-known/agent.json" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
-         Http.Response.json
-           (Yojson.Safe.to_string (Runtime.agent_card_json req))
-           reqd)
+         with_public_read (fun _state req reqd ->
+         Http.Response.json_value (Runtime.agent_card_json req) reqd)
          request reqd)
   |> Http.Router.get "/.well-known/agent-card.json" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
-         Http.Response.json
-           (Yojson.Safe.to_string (Runtime.agent_card_json req))
-           reqd)
+         with_public_read (fun _state req reqd ->
+         Http.Response.json_value (Runtime.agent_card_json req) reqd)
          request reqd)
   |> Http.Router.get "/ws" websocket_discovery_handler
   |> Http.Router.get "/metrics" (fun request reqd ->
@@ -200,9 +192,8 @@ let add_routes ~port ~host router =
          let json =
            Transport.Rest.generate_openapi_document
              ~host:resolved_host ~port:resolved_port ()
-           |> Yojson.Safe.to_string
          in
-         Http.Response.json json reqd
+         Http.Response.json_value json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/voice/config" (fun request reqd ->
        with_public_read (fun _state _req reqd ->
@@ -210,7 +201,7 @@ let add_routes ~port ~host router =
          let status =
            match status with `OK -> `OK | `Error -> `Internal_server_error
          in
-         Http.Response.json ~status (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~status json reqd
        ) request reqd)
   |> Http.Router.get "/" (fun request reqd ->
        match canonical_root_dashboard_location ~default_port:port request with

--- a/lib/server/server_routes_http_routes_keeper_repos.ml
+++ b/lib/server/server_routes_http_routes_keeper_repos.ml
@@ -81,27 +81,24 @@ let handle_list_mappings state req reqd =
   let base_path = state.Mcp_server.room_config.base_path in
   match Keeper_repo_mapping.load_all ~base_path with
   | Error msg ->
-      Http.Response.json ~status:`Internal_server_error ~request:req
-        (Yojson.Safe.to_string
-           (`Assoc [("ok", `Bool false); ("error", `String msg)]))
+      Http.Response.json_value ~status:`Internal_server_error ~request:req
+        (`Assoc [("ok", `Bool false); ("error", `String msg)])
         reqd
   | Ok mappings ->
-      Http.Response.json ~compress:true ~request:req
-        (Yojson.Safe.to_string
-           (`Assoc
-             [
-               ("mappings", `List (List.map mapping_json mappings));
-               ("total", `Int (List.length mappings));
-             ]))
+      Http.Response.json_value ~compress:true ~request:req
+        (`Assoc
+           [
+             ("mappings", `List (List.map mapping_json mappings));
+             ("total", `Int (List.length mappings));
+           ])
         reqd
 
 let handle_get_mapping state keeper_id req reqd =
   let base_path = state.Mcp_server.room_config.base_path in
   match Keeper_repo_mapping.load_all ~base_path with
   | Error msg ->
-      Http.Response.json ~status:`Internal_server_error ~request:req
-        (Yojson.Safe.to_string
-           (`Assoc [("ok", `Bool false); ("error", `String msg)]))
+      Http.Response.json_value ~status:`Internal_server_error ~request:req
+        (`Assoc [("ok", `Bool false); ("error", `String msg)])
         reqd
   | Ok mappings -> (
       match
@@ -111,20 +108,18 @@ let handle_get_mapping state keeper_id req reqd =
           mappings
       with
       | Some mapping ->
-          Http.Response.json ~compress:true ~request:req
-            (Yojson.Safe.to_string (mapping_json mapping))
-            reqd
+          Http.Response.json_value ~compress:true ~request:req
+            (mapping_json mapping) reqd
       | None ->
-          Http.Response.json ~status:`Not_found ~request:req
-            (Yojson.Safe.to_string
-               (`Assoc
-                 [
-                   ("ok", `Bool false);
-                   ( "error",
-                     `String
-                       (Printf.sprintf "No mapping found for keeper: %s"
-                          keeper_id) );
-                 ]))
+          Http.Response.json_value ~status:`Not_found ~request:req
+            (`Assoc
+               [
+                 ("ok", `Bool false);
+                 ( "error",
+                   `String
+                     (Printf.sprintf "No mapping found for keeper: %s" keeper_id)
+                 );
+               ])
             reqd)
 
 let credential_type_label = function
@@ -154,9 +149,8 @@ let handle_save_mapping state keeper_id req reqd =
   let base_path = state.Mcp_server.room_config.base_path in
   Http.Request.read_body_async reqd (fun body_str ->
       let response status message =
-        Http.Response.json ~status ~request:req
-          (Yojson.Safe.to_string
-             (`Assoc [("ok", `Bool false); ("error", `String message)]))
+        Http.Response.json_value ~status ~request:req
+          (`Assoc [("ok", `Bool false); ("error", `String message)])
           reqd
       in
       match Yojson.Safe.from_string body_str with
@@ -171,9 +165,8 @@ let handle_save_mapping state keeper_id req reqd =
                   match Keeper_repo_mapping.save_mapping ~base_path mapping with
                   | Error msg -> response `Bad_request msg
                   | Ok () ->
-                      Http.Response.json ~request:req
-                        (Yojson.Safe.to_string (mapping_json mapping))
-                        reqd))))
+                      Http.Response.json_value ~request:req
+                        (mapping_json mapping) reqd))))
 
 let add_routes router =
   router
@@ -184,9 +177,8 @@ let add_routes router =
          (fun state req reqd ->
            match extract_keeper_id (Http.Request.path req) with
            | Error msg ->
-               Http.Response.json ~status:`Bad_request ~request:req
-                 (Yojson.Safe.to_string
-                    (`Assoc [("ok", `Bool false); ("error", `String msg)]))
+               Http.Response.json_value ~status:`Bad_request ~request:req
+                 (`Assoc [("ok", `Bool false); ("error", `String msg)])
                  reqd
            | Ok keeper_id -> handle_get_mapping state keeper_id req reqd)
          request reqd)
@@ -195,9 +187,8 @@ let add_routes router =
          (fun state _agent_name req reqd ->
            match extract_keeper_id (Http.Request.path req) with
            | Error msg ->
-               Http.Response.json ~status:`Bad_request ~request:req
-                 (Yojson.Safe.to_string
-                    (`Assoc [("ok", `Bool false); ("error", `String msg)]))
+               Http.Response.json_value ~status:`Bad_request ~request:req
+                 (`Assoc [("ok", `Bool false); ("error", `String msg)])
                  reqd
            | Ok keeper_id -> handle_save_mapping state keeper_id req reqd)
          request reqd)

--- a/lib/server/server_routes_http_routes_multimodal.ml
+++ b/lib/server/server_routes_http_routes_multimodal.ml
@@ -171,8 +171,7 @@ let add_routes router =
              let json =
                list_response ?kind_filter ?created_by_filter ?query ()
              in
-             respond_public_read_json ~status:`OK request reqd
-               (Yojson.Safe.to_string json))
+             respond_public_read_json_value ~status:`OK request reqd json)
            request reqd)
   |> Http.Router.prefix_get "/api/v1/multimodal/get/"
        (fun request reqd ->
@@ -184,19 +183,13 @@ let add_routes router =
                  ~prefix:"/api/v1/multimodal/get/" path
              with
              | None ->
-                 respond_public_read_json ~status:`Bad_request
-                   request reqd
-                   (Yojson.Safe.to_string
-                      (`Assoc
-                        [
-                          ("error", `String "id required");
-                        ]))
+                 respond_public_read_json_value ~status:`Bad_request request
+                   reqd (`Assoc [ ("error", `String "id required") ])
              | Some id_str ->
                  let json, status =
                    artifact_response ~id_str
                  in
-                 respond_public_read_json ~status request reqd
-                   (Yojson.Safe.to_string json))
+                 respond_public_read_json_value ~status request reqd json)
            request reqd)
   |> Http.Router.prefix_get "/api/v1/multimodal/provenance/"
        (fun request reqd ->
@@ -208,17 +201,11 @@ let add_routes router =
                  ~prefix:"/api/v1/multimodal/provenance/" path
              with
              | None ->
-                 respond_public_read_json ~status:`Bad_request
-                   request reqd
-                   (Yojson.Safe.to_string
-                      (`Assoc
-                        [
-                          ("error", `String "id required");
-                        ]))
+                 respond_public_read_json_value ~status:`Bad_request request
+                   reqd (`Assoc [ ("error", `String "id required") ])
              | Some id_str ->
                  let json, status =
                    provenance_response ~id_str
                  in
-                 respond_public_read_json ~status request reqd
-                   (Yojson.Safe.to_string json))
+                 respond_public_read_json_value ~status request reqd json)
            request reqd)

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -175,23 +175,20 @@ let dashboard_stress_json ~config req =
 let respond_dashboard_heuristics request reqd =
   with_public_read (fun _state req reqd ->
     let json = dashboard_heuristics_json req in
-    Http.Response.json ~compress:true ~request:req
-      (Yojson.Safe.to_string json) reqd
+    Http.Response.json_value ~compress:true ~request:req json reqd
   ) request reqd
 
 let respond_dashboard_heuristics_coverage request reqd =
   with_public_read (fun _state req reqd ->
     let json = dashboard_heuristics_coverage_json req in
-    Http.Response.json ~compress:true ~request:req
-      (Yojson.Safe.to_string json) reqd
+    Http.Response.json_value ~compress:true ~request:req json reqd
   ) request reqd
 
 let respond_dashboard_stress request reqd =
   with_public_read (fun state req reqd ->
     let config = state.Mcp_server.room_config in
     let json = dashboard_stress_json ~config req in
-    Http.Response.json ~compress:true ~request:req
-      (Yojson.Safe.to_string json) reqd
+    Http.Response.json_value ~compress:true ~request:req json reqd
   ) request reqd
 
 let add_routes ~sw router =
@@ -199,8 +196,7 @@ let add_routes ~sw router =
   |> Http.Router.get "/api/v1/providers" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = Dashboard_provider_runs.provider_inventory_json () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/models/metrics" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -225,8 +221,7 @@ let add_routes ~sw router =
                in
                Model_inference_metrics.to_json agg)
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/agent-runs" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
@@ -244,47 +239,40 @@ let add_routes ~sw router =
                    ~prompt
                with
                | Ok payload ->
-                   respond_json_with_cors ~status:`Created request reqd
-                     (Yojson.Safe.to_string payload)
+                   respond_json_value_with_cors ~status:`Created request reqd payload
                | Error message ->
-                   respond_json_with_cors ~status:`Bad_request request reqd
-                     (Yojson.Safe.to_string
-                        (`Assoc [ ("error", `String message) ]))
+                   respond_json_value_with_cors ~status:`Bad_request request reqd
+                     (`Assoc [ ("error", `String message) ])
              with
              | Yojson.Json_error error ->
-                 respond_json_with_cors ~status:`Bad_request request reqd
-                   (Yojson.Safe.to_string
-                      (`Assoc
-                        [
-                          ( "error",
-                            `String ("invalid json: " ^ error) );
-                        ]))
+                 respond_json_value_with_cors ~status:`Bad_request request reqd
+                   (`Assoc
+                      [
+                        ( "error",
+                          `String ("invalid json: " ^ error) );
+                      ])
              | Yojson.Safe.Util.Type_error (error, _) ->
-                 respond_json_with_cors ~status:`Bad_request request reqd
-                   (Yojson.Safe.to_string
-                      (`Assoc
-                        [
-                          ( "error",
-                            `String ("invalid request shape: " ^ error) );
-                        ])))
+                 respond_json_value_with_cors ~status:`Bad_request request reqd
+                   (`Assoc
+                      [
+                        ( "error",
+                          `String ("invalid request shape: " ^ error) );
+                      ]))
        ) request reqd)
   |> Http.Router.prefix_get "/api/v1/agent-runs/" (fun request reqd ->
        with_read_auth (fun _state req reqd ->
          let req_path = Http.Request.path req in
          match extract_path_param ~prefix:"/api/v1/agent-runs/" req_path with
          | None ->
-             respond_json_with_cors ~status:`Bad_request request reqd
-               (Yojson.Safe.to_string
-                  (`Assoc [ ("error", `String "run_id is required") ]))
+             respond_json_value_with_cors ~status:`Bad_request request reqd
+               (`Assoc [ ("error", `String "run_id is required") ])
          | Some run_id ->
              (match Dashboard_provider_runs.run_status_json run_id with
              | Ok payload ->
-                 respond_json_with_cors request reqd
-                   (Yojson.Safe.to_string payload)
+                 respond_json_value_with_cors request reqd payload
              | Error message ->
-                 respond_json_with_cors ~status:`Not_found request reqd
-                   (Yojson.Safe.to_string
-                      (`Assoc [ ("error", `String message) ])))
+                 respond_json_value_with_cors ~status:`Not_found request reqd
+                   (`Assoc [ ("error", `String message) ]))
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/keeper-costs" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -302,8 +290,7 @@ let add_routes ~sw router =
            Dashboard_http_keeper.keeper_cost_aggregates_json
              ~config ~keepers ~window_minutes:window
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/cost-latency" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -317,8 +304,7 @@ let add_routes ~sw router =
                Model_inference_metrics.compute_cost_latency_json
                  ~base_path ~window_minutes:window)
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/keeper-decisions" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -336,8 +322,7 @@ let add_routes ~sw router =
            Dashboard_http_keeper.keeper_decisions_json
              ~config ~keepers ~limit ()
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/keeper-decisions-log" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -355,8 +340,7 @@ let add_routes ~sw router =
            Dashboard_http_keeper.keeper_decisions_log_json
              ~config ~keepers ~limit ()
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/keeper-memory-log" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -374,8 +358,7 @@ let add_routes ~sw router =
            Dashboard_http_keeper.keeper_memory_log_json
              ~config ~keepers ~limit ()
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/heuristics" respond_dashboard_heuristics
   |> Http.Router.get "/api/v1/heuristics" respond_dashboard_heuristics

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -9,8 +9,7 @@ let json_error message =
   `Assoc [("ok", `Bool false); ("error", `String message)]
 
 let json_response ~status req reqd json =
-  Http.Response.json ~status ~request:req
-    (Yojson.Safe.to_string json) reqd
+  Http.Response.json_value ~status ~request:req json reqd
 
 let repositories_prefix = "/api/v1/repositories/"
 let sync_suffix = "/sync"
@@ -223,16 +222,14 @@ let handle_list_repositories state req reqd =
             ("total", `Int (List.length repos));
           ]
       in
-      Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd
+      Http.Response.json_value ~request:req json reqd
 
 let handle_get_repository state id req reqd =
   let base_path = base_path_of_state state in
   match Repo_store.find ~base_path id with
   | Error msg -> json_response ~status:`Not_found req reqd (json_error msg)
   | Ok repo ->
-      Http.Response.json ~request:req
-        (Yojson.Safe.to_string (repository_json repo))
-        reqd
+      Http.Response.json_value ~request:req (repository_json repo) reqd
 
 let handle_list_branches state id req reqd =
   let base_path = base_path_of_state state in
@@ -253,7 +250,7 @@ let handle_list_branches state id req reqd =
                        branches) );
               ]
           in
-          Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd)
+          Http.Response.json_value ~request:req json reqd)
 
 let handle_get_repository_path state req reqd =
   match extract_repo_id (Http.Request.path req) with
@@ -280,7 +277,7 @@ let handle_add_repository state _agent_name req reqd =
               json_response ~status:`Bad_request req reqd (json_error msg)
           | Ok added_repo ->
               let json = repository_json added_repo in
-              Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd))
+              Http.Response.json_value ~request:req json reqd))
 
 let handle_remove_repository state _agent_name req reqd =
   let base_path = base_path_of_state state in
@@ -297,7 +294,7 @@ let handle_remove_repository state _agent_name req reqd =
           json_response ~status:`Not_found req reqd (json_error msg)
       | Ok () ->
           let json = `Assoc [("id", `String id); ("removed", `Bool true)] in
-          Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd)
+          Http.Response.json_value ~request:req json reqd)
       | _ ->
           json_response ~status:`Bad_request req reqd
             (json_error "DELETE expects /api/v1/repositories/:id"))
@@ -329,9 +326,8 @@ let handle_update_repository state _agent_name req reqd =
                           json_response ~status:`Internal_server_error req reqd
                             (json_error msg)
                       | Ok persisted ->
-                          Http.Response.json ~request:req
-                            (Yojson.Safe.to_string (repository_json persisted))
-                            reqd))))
+                          Http.Response.json_value ~request:req
+                            (repository_json persisted) reqd))))
       | _ ->
           json_response ~status:`Not_found req reqd
             (json_error "unknown repository endpoint"))
@@ -375,8 +371,7 @@ let handle_sync_repository state _agent_name req reqd =
                         ("branches", branches);
                       ]
                   in
-                  Http.Response.json ~request:req (Yojson.Safe.to_string json)
-                    reqd)))
+                  Http.Response.json_value ~request:req json reqd)))
 
 let handle_discover_repositories state _agent_name req reqd =
   let base_path = base_path_of_state state in
@@ -393,7 +388,7 @@ let handle_discover_repositories state _agent_name req reqd =
             ("registered", `Bool true);
           ]
       in
-      Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd
+      Http.Response.json_value ~request:req json reqd
 
 let add_routes router =
   router

--- a/lib/server/server_routes_http_routes_resilience.ml
+++ b/lib/server/server_routes_http_routes_resilience.ml
@@ -77,14 +77,12 @@ let add_routes router =
          with_public_read
            (fun _state _req reqd ->
              let json = levels_response () in
-             respond_public_read_json ~status:`OK request reqd
-               (Yojson.Safe.to_string json))
+             respond_public_read_json_value ~status:`OK request reqd json)
            request reqd)
   |> Http.Router.prefix_get "/api/v1/resilience/strategies"
        (fun request reqd ->
          with_public_read
            (fun _state _req reqd ->
              let json = strategies_response () in
-             respond_public_read_json ~status:`OK request reqd
-               (Yojson.Safe.to_string json))
+             respond_public_read_json_value ~status:`OK request reqd json)
            request reqd)

--- a/lib/server/server_routes_http_routes_room.ml
+++ b/lib/server/server_routes_http_routes_room.ml
@@ -23,7 +23,7 @@ module Keeper_stream = Server_routes_http_keeper_stream
            ("tempo_interval_s", `Float status.tempo_interval_s);
            ("paused", `Bool status.paused);
          ] in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/tasks" (fun request reqd ->
        with_read_auth (fun state req reqd ->
@@ -69,7 +69,7 @@ module Keeper_stream = Server_routes_http_keeper_stream
            ("offset", `Int offset);
            ("total", `Int total);
          ] in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/agents" (fun request reqd ->
        with_read_auth (fun state req reqd ->
@@ -104,7 +104,7 @@ module Keeper_stream = Server_routes_http_keeper_stream
            ("offset", `Int offset);
            ("total", `Int total);
          ] in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/messages" (fun request reqd ->
        with_read_auth (fun state req reqd ->
@@ -136,5 +136,5 @@ module Keeper_stream = Server_routes_http_keeper_stream
            ("since_seq", `Int since_seq);
            ("total", `Int total);
          ] in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value json reqd
        ) request reqd)

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -500,7 +500,7 @@ let clamp_lines = function
 ;;
 
 let respond_json request reqd ~status body =
-  respond_json_with_cors ~status request reqd (Yojson.Safe.to_string body)
+  respond_json_value_with_cors ~status request reqd body
 ;;
 
 let bad_request request reqd msg =

--- a/lib/server/server_routes_http_routes_verification.ml
+++ b/lib/server/server_routes_http_routes_verification.ml
@@ -56,8 +56,7 @@ let add_routes router =
          let json =
            Dashboard_verification.requests_json ~base_path ?task_id ?limit ()
          in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/verification/summary" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -68,20 +67,17 @@ let add_routes router =
          in
          let base_path = state.Mcp_server.room_config.base_path in
          let json = Dashboard_verification.summary_json ~base_path ?recent () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/verification/specs" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = Dashboard_tla_specs.specs_json () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/verification/tlc-results" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = Dashboard_tla_specs.tlc_results_json () in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
+         Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/verification/resolve" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_operator_confirm"
@@ -96,17 +92,14 @@ let add_routes router =
                    ~config ~verifier ~args
                with
                | Ok json ->
-                   respond_json_with_cors request reqd
-                     (Yojson.Safe.to_string json)
+                   respond_json_value_with_cors request reqd json
                | Error message ->
-                   respond_json_with_cors
+                   respond_json_value_with_cors
                      ~status:`Bad_request request reqd
-                     (Yojson.Safe.to_string (verification_error_json message))
+                     (verification_error_json message)
              with Yojson.Json_error msg ->
-               respond_json_with_cors
+               respond_json_value_with_cors
                  ~status:`Bad_request request reqd
-                 (Yojson.Safe.to_string
-                    (verification_error_json
-                       (Printf.sprintf "invalid json: %s" msg)))
+                 (verification_error_json (Printf.sprintf "invalid json: %s" msg))
            )
          ) request reqd)

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -122,8 +122,7 @@ let json_error message =
   `Assoc [("ok", `Bool false); ("error", `String message)]
 
 let json_response ~status req reqd json =
-  Http.Response.json ~status ~request:req
-    (Yojson.Safe.to_string json) reqd
+  Http.Response.json_value ~status ~request:req json reqd
 
 (* Strip CR/LF and other control characters from a value before placing
    it into an HTTP response header. RFC 7230 §3.2.4 prohibits CR/LF in
@@ -150,8 +149,8 @@ let source_header source =
   [("X-Workspace-Source", v)]
 
 let json_response_with_source ~status ~source req reqd json =
-  Http.Response.json ~status ~extra_headers:(source_header source)
-    ~request:req (Yojson.Safe.to_string json) reqd
+  Http.Response.json_value ~status ~extra_headers:(source_header source)
+    ~request:req json reqd
 
 (* --- Safe path --- *)
 

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -843,47 +843,41 @@ let make_health_response_json ?(listener = "http/1.1") request =
 
 (** Health check handler *)
 let health_handler request reqd =
-  Http.Response.json
-    (Yojson.Safe.to_string (make_health_response_json request))
-    reqd
+  Http.Response.json_value (make_health_response_json request) reqd
 
 (** Liveness probe: responds 200 as soon as the HTTP accept loop is running.
     Does not depend on server_state initialization.
     Kubernetes/Railway liveness probe target. *)
 let liveness_handler _request reqd =
   let startup = Server_startup_state.to_yojson () in
-  let body =
-    Yojson.Safe.to_string
-      (`Assoc
-         [
-           ("live", `Bool true);
-           ("startup", startup);
-         ])
-  in
-  Http.Response.json body reqd
+  Http.Response.json_value
+    (`Assoc
+       [
+         ("live", `Bool true);
+         ("startup", startup);
+       ])
+    reqd
 
 (** Readiness probe: responds 200 only when server_state is initialized. *)
 let readiness_handler _request reqd =
   let current = Server_startup_state.(!state) in
   if current.state_ready then
-    Http.Response.json
-      (Yojson.Safe.to_string
-         (`Assoc
-            [
-              ("ready", `Bool true);
-              ("phase", `String (Server_startup_state.phase_to_string current.phase));
-              ("backend_mode", `String current.backend_mode);
-            ]))
+    Http.Response.json_value
+      (`Assoc
+         [
+           ("ready", `Bool true);
+           ("phase", `String (Server_startup_state.phase_to_string current.phase));
+           ("backend_mode", `String current.backend_mode);
+         ])
       reqd
   else
-    Http.Response.json ~status:`Service_unavailable
-      (Yojson.Safe.to_string
-         (`Assoc
-            [
-              ("ready", `Bool false);
-              ("phase", `String (Server_startup_state.phase_to_string current.phase));
-              ("elapsed_sec", `Float (Server_startup_state.elapsed_since_start ()));
-            ]))
+    Http.Response.json_value ~status:`Service_unavailable
+      (`Assoc
+         [
+           ("ready", `Bool false);
+           ("phase", `String (Server_startup_state.phase_to_string current.phase));
+           ("elapsed_sec", `Float (Server_startup_state.elapsed_since_start ()));
+         ])
       reqd
 
 let board_post_detail_json ~include_moderation ~blind_votes ~config ~voter


### PR DESCRIPTION
## Summary
- Add a shared HTTP response payload module for Accept-Encoding parsing, zstd compression, and response compression headers.
- Route H1/H2/gateway JSON responses through structured `json_value` helpers instead of route-local `Yojson.Safe.to_string` or handcrafted JSON strings.
- Preserve raw string passthrough only where the body is already produced by WebRTC, GraphQL, MCP JSON-RPC, or other upstream handlers.
- Fold the latest main-side SDK timeout constructor fix into the rebased branch by keeping the `Timeout` API-error constructor form.

## Validation
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build bin/main_eio.exe`
- `git diff --check origin/main..HEAD`
- `rg -nUP "Http\\.Response\\.json[\\s\\S]{0,500}Yojson\\.Safe\\.to_string" lib/server lib/http_server_eio.ml lib/http_server_h2.ml`
- `rg -nUP "respond_(?:json_with_cors|public_read_json)[\\s\\S]{0,500}Yojson\\.Safe\\.to_string" lib/server`
- changed-file risk scan for `Stdlib.Lazy`, `Fun.protect`, `failwith`, `assert false`, and `Sys.readdir`