### PR TITLE
Remove harness health refresh reexport

### DIFF
--- a/dashboard/src/components/harness-health.test.ts
+++ b/dashboard/src/components/harness-health.test.ts
@@ -143,7 +143,8 @@ async function loadComponentWithApi(api: {
     `,
   }))
   const module = await import('./harness-health')
-  module.resetHarnessHealthState()
+  const { resetHarnessHealthState } = await import('./harness-health-state')
+  resetHarnessHealthState()
   return module
 }
 
@@ -160,7 +161,7 @@ describe('HarnessHealth', () => {
   })
 
   afterEach(async () => {
-    const { resetHarnessHealthState } = await import('./harness-health')
+    const { resetHarnessHealthState } = await import('./harness-health-state')
     resetHarnessHealthState()
     render(null, container)
     container.remove()

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -14,8 +14,6 @@ import {
   loadHarnessHealth,
   clearHarnessReloadTimer,
   handleHarnessSSE,
-  resetHarnessHealthState,
-  refreshHarnessSurface,
 } from './harness-health-state'
 import type {
   RailStatus,
@@ -37,8 +35,6 @@ import {
   PreCompactList,
   HandoffList,
 } from './harness-health-sections'
-
-export { resetHarnessHealthState, refreshHarnessSurface }
 
 // ── Mermaid flow helpers (live state graph) ──
 // Mermaid classDef requires literal hex values — CSS vars are not resolved.

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -20,7 +20,7 @@ async function refreshObservatoryPanel(): Promise<void> {
 }
 
 async function refreshHarnessLabSurface(): Promise<void> {
-  const { refreshHarnessSurface } = await import('./components/harness-health')
+  const { refreshHarnessSurface } = await import('./components/harness-health-state')
   await refreshHarnessSurface()
 }
 


### PR DESCRIPTION
## Summary
- remove the harness-health component re-export for harness refresh/reset helpers
- point tab refresh and harness tests at the owning harness-health-state module directly

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/harness-health.test.ts src/components/harness-health-state.test.ts src/tab-refresh.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/harness-health.ts src/components/harness-health.test.ts src/components/harness-health-state.ts src/components/harness-health-state.test.ts src/tab-refresh.ts src/tab-refresh.test.ts
- git diff --check origin/main

## Notes
- The same vitest bundle first hit the default 5000ms timeout on the initial harness render test while 43/44 tests passed; rerunning the exact focused bundle with --testTimeout=15000 passed 44/44.