### PR TITLE
feat(dashboard): export errorToString helper from lib/format-string for upcoming callsite migration

### DIFF
--- a/dashboard/src/lib/format-string.ts
+++ b/dashboard/src/lib/format-string.ts
@@ -74,3 +74,39 @@ export function firstNonEmptyString(
 export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
+
+/**
+ * Coerce an `unknown` caught error (try/catch, Promise reject) to a
+ * display-ready string. Returns `err.message` when `err` is an `Error`
+ * instance, otherwise routes through `String(err)` — which preserves
+ * `'null'` / `'undefined'` distinctions and stringifies primitives.
+ *
+ * Differs from `fleet-telemetry-utils.errorMessageOrUnknown`, which
+ * collapses every non-Error to the literal `'unknown error'`. Keep
+ * both — `errorToString` surfaces the raw form (right for toast
+ * messages and console logs), while the other is appropriate when a
+ * stable display label is needed.
+ *
+ * ~45 call sites currently inline this exact ternary across
+ * `dashboard-ws`, `lib/async-state` (file-internal helper),
+ * `api/mcp`, `components/cascade-config-panel`,
+ * `components/cascade-inspector`, `components/cascade-waterfall`,
+ * `components/excuse-patterns`, `components/git-graph-view`,
+ * `components/goal-loop-panel`, `components/goals/goal-tree`,
+ * `components/handoff-timeline`, `components/ide/execute-output-drawer`,
+ * `components/ide/ide-branch-context-panel`,
+ * `components/ide/interject-store`, `components/journey-panel`,
+ * `components/keeper-chat-panel`, `components/keeper-reactivity-monitor`,
+ * `components/keeper-spawn/keeper-spawn-state`,
+ * `components/prometheus-metrics`, `components/task-manage/task-manage-state`,
+ * `components/telemetry-unified`,
+ * `components/tool-executor/tool-executor-state`,
+ * `components/tool-executor/tool-result-display`,
+ * `components/tools/config-resolution-panel`,
+ * `components/tools/prompt-registry-panel`,
+ * `components/verification-requests-panel`, etc. Callsite migration is
+ * staged separately (see follow-up PR).
+ */
+export function errorToString(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}


### PR DESCRIPTION
## 요약
`errorToString(err: unknown): string` helper 를 `lib/format-string.ts` 에 export. **helper-only PR** — ~45 callsite migration 은 follow-up PR (iter#64 large sweep revert 후 split).

## 배경

`rg "instanceof Error \? \w+\.message : String\(\w+\)" -n` sweep 결과 *~45 callsite* 가 정규 패턴 inline:

```ts
err instanceof Error ? err.message : String(err)
```

3 variant: 34 × `err` + 7 × `e` + 4 × `error`. 27 file 분포.

`fleet-telemetry-utils.errorMessageOrUnknown` 가 sibling helper 지만 *다른 정책* (non-Error → `'unknown error'` literal). toast message / 원시 form log 용도에는 `errorToString` (String(err) routing) 가 적합.

## 변경

### `lib/format-string.ts`
- `export function errorToString(err: unknown): string` 추가
- JSDoc: 정책 명시 + sibling 헬퍼 (errorMessageOrUnknown) 차이 + 27 file 의 callsite 분포 cross-reference

### Callsite migration 분리

iter#64 에서 *45 callsite × 27 file × 매뉴얼 import* large sweep 시도 → heredoc auto-insert silent fail + 6 PR backlog 와 충돌 → 전체 revert. 본 PR 는 **helper-only**, callsite migration 은 별도 follow-up (iter#46/49/60 bulk-migrate-then-extend SOP).

## 검증

- typecheck PASS
- lint 0 errors
- vitest 528/529 (1 fail = baseline)
- 1 파일 +36/-0 (helper export + JSDoc)

## iter chain — helper-only split

- iter#64 (REVERTED): 45 callsite + helper single PR — scope 너무 큼
- iter#66 (본 PR): helper-only export
- iter#67+ (follow-up): 27 file callsite migration (각 path level 별로 batch 가능)

## /loop iter#66
SSOT 위반 dashboard 축출 loop 의 iter#66. cumulative 64 PR (43 머지 + 1 OPEN — #19189 + 본 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
