### PR TITLE
Remove activity graph refresh alias

### DIFF
--- a/dashboard/src/components/activity-graph-store.ts
+++ b/dashboard/src/components/activity-graph-store.ts
@@ -19,8 +19,6 @@ export function loadGraphForRange(since: TimeRangePreset) {
   })
 }
 
-export function loadGraph() {
+export function refreshActivityGraph() {
   return loadGraphForRange(activityRange())
 }
-
-export { loadGraph as refreshActivityGraph }

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -33,7 +33,7 @@ import {
 import {
   activityRange,
   graphResource,
-  loadGraph,
+  refreshActivityGraph,
   loadGraphForRange,
 } from './activity-graph-store'
 import type { ActivityGraphResponse, ActivityGraphNode, ActionTimelineGroup } from '../types'
@@ -426,7 +426,7 @@ export function ObservatoryActivityPanels() {
           ? html`
               <${SectionCard} label="활동 분석" class="section" testId="activity_graph.error">
                 <${EmptyState} message=${'활동 그래프를 불러올 수 없습니다: ' + state.error} compact />
-                <${ActionButton} variant="ghost" onClick=${() => { void loadGraph() }}>다시 시도<//>
+                <${ActionButton} variant="ghost" onClick=${() => { void refreshActivityGraph() }}>다시 시도<//>
               <//>
             `
           : !data


### PR DESCRIPTION
## Summary
- replace the activity graph store's loadGraph alias export with an owning refreshActivityGraph function
- update the activity graph retry button to use the same refresh entrypoint as tab refresh

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/activity-graph-store.test.ts src/components/activity-graph-panels.test.ts src/tab-refresh.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/activity-graph.ts src/components/activity-graph-store.ts src/components/activity-graph-store.test.ts src/components/activity-graph-panels.test.ts src/tab-refresh.ts src/tab-refresh.test.ts
- git diff --check origin/main

## Notes
- Vitest emitted ECONNREFUSED logs for localhost:3000 in this bundle, but the run exited 0 with 3 files / 23 tests passed.