### PR TITLE
feat(log): add ~keeper_name to 26 Log.Task calls

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -22,6 +22,7 @@ type review_request =
   ; task_description : string
   ; completion_notes : string
   ; agent_name : string
+  ; task_id : string
   }
 
 type verdict =
@@ -581,6 +582,7 @@ let review
         ~labels:[ "pattern", pattern; "decision", "terminal_reject" ]
         ();
       Log.Task.info
+        ~keeper_name:req.task_id
         "[anti-rationalization] agent=%s task=%s excuse_pattern=%s \
          gate2_fail_closed=true → terminal reject"
         req.agent_name
@@ -609,6 +611,7 @@ let review
             ~labels:[ "pattern", pattern; "decision", "advisory_to_llm" ]
             ();
           Log.Task.info
+        ~keeper_name:req.task_id
             "[anti-rationalization] agent=%s task=%s excuse_pattern=%s (advisory; \
              deferring to LLM evaluator with context)"
             req.agent_name
@@ -632,6 +635,7 @@ let review
             then None
             else (
               Log.Task.info
+        ~keeper_name:req.task_id
                 "[anti-rationalization] contract unmet (legacy): agent=%s task=%s \
                  unmet=[%s]"
                 req.agent_name
@@ -657,6 +661,7 @@ let review
          (match generator_cascade with
           | Some gc when gc = evaluator_cascade ->
             Log.Task.warn
+        ~keeper_name:req.task_id
               "[anti-rationalization] same cascade for generator (%s) and evaluator (%s) \
                — cross-model separation not active"
               gc
@@ -676,6 +681,7 @@ let review
                 | Reject r -> "Rejected: " ^ r)
            | Error msg ->
              Log.Task.warn
+        ~keeper_name:req.task_id
                "[anti-rationalization] structured verdict parse failed: %s"
                msg;
              Tool_result.error
@@ -703,12 +709,12 @@ let review
             let v, gate, fallback_reason =
               match !verdict_ref with
               | Some v ->
-                Log.Task.info "[anti-rationalization] verdict via structured tool call";
+                Log.Task.info ~keeper_name:req.task_id "[anti-rationalization] verdict via structured tool call";
                 v, Structured_tool, None
               | None ->
                 (* LLM responded with text — lenient fallback *)
                 let text = Agent_sdk_response.text_of_response result.response in
-                Log.Task.info "[anti-rationalization] verdict via text fallback";
+                Log.Task.info ~keeper_name:req.task_id "[anti-rationalization] verdict via text fallback";
                 (match parse_verdict text with
                  | Ok v -> v, Llm_text_fallback, None
                  | Error "empty review output" ->
@@ -720,6 +726,7 @@ let review
                  completing keeper for an evaluator-side gap. Observed
                  35 rejects in 2 days (#8688, <base-path>/.masc/tool_calls). *)
                    Log.Task.warn
+        ~keeper_name:req.task_id
                      "[anti-rationalization] evaluator returned empty text (approving by \
                       liveness)";
                    Approve, Fallback, Some "evaluator returned empty response"
@@ -727,6 +734,7 @@ let review
                    (* ADR D3: parse failure is NOT silently approved.
                  Use Reject instead of Approve for unknown format. *)
                    Log.Task.warn
+        ~keeper_name:req.task_id
                      "[anti-rationalization] verdict parse failed: %s (rejecting)"
                      parse_err;
                    ( Reject (sprintf "review format unrecognized: %s" parse_err)
@@ -736,6 +744,7 @@ let review
             (match v with
              | Reject reason ->
                Log.Task.info
+        ~keeper_name:req.task_id
                  "[anti-rationalization] LLM rejected: agent=%s task=%s cascade=%s \
                   reason=%s"
                  req.agent_name
@@ -744,6 +753,7 @@ let review
                  reason
              | Approve ->
                Log.Task.info
+        ~keeper_name:req.task_id
                  "[anti-rationalization] LLM approved: agent=%s task=%s cascade=%s"
                  req.agent_name
                  req.task_title
@@ -830,6 +840,7 @@ let review
                     ]
                   ();
                 Log.Task.error
+        ~keeper_name:req.task_id
                   "[anti-rationalization] cascade %s permanently dead AND gate-2 \
                    advisory pattern=%s active: rejecting (safety net) rather than \
                    laundering excuse phrase through liveness.  OPERATOR ACTION \
@@ -859,6 +870,7 @@ let review
                   }
               | None ->
                 Log.Task.error
+        ~keeper_name:req.task_id
                   "[anti-rationalization] cascade %s has zero callable providers — \
                    ALL keepers using this evaluator are blocked from task \
                    completion.  Approving by liveness; OPERATOR ACTION REQUIRED: \
@@ -895,6 +907,7 @@ let review
                   ~labels:[ "pattern", pattern; "decision", "advisory_safety_net_reject" ]
                   ();
                 Log.Task.warn
+        ~keeper_name:req.task_id
                   "[anti-rationalization] LLM unavailable + gate-2 advisory pattern=%s \
                    active: rejecting (safety net) (cascade=%s err=%s)"
                   pattern
@@ -916,6 +929,7 @@ let review
                   }
               | None, Env_config.AntiRationalization.Open ->
                 Log.Task.warn
+        ~keeper_name:req.task_id
                   "[anti-rationalization] LLM unavailable: %s (approving by default; \
                    mode=open MASC_ANTI_RATIONALIZATION_FAIL_MODE=open)"
                   msg;
@@ -928,6 +942,7 @@ let review
                   }
               | None, Env_config.AntiRationalization.Closed ->
                 Log.Task.warn
+        ~keeper_name:req.task_id
                   "[anti-rationalization] LLM unavailable: %s (rejecting by default; \
                    mode=closed MASC_ANTI_RATIONALIZATION_FAIL_MODE=closed)"
                   msg;

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -21,6 +21,7 @@ type review_request = {
   task_description : string;
   completion_notes : string;
   agent_name : string;
+  task_id : string;
 }
 
 (** Gate verdict. *)

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -52,7 +52,7 @@ and handle_cancel_task ~tool_name ~start_time ctx args =
          handoff_to = None;
        } in
        (try let _ = Metrics_store_eio.record ctx.config metric in ()
-        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error "Metrics_store_eio.record(cancel) failed: %s" (Stdlib.Printexc.to_string exn));
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error ~keeper_name:task_id "Metrics_store_eio.record(cancel) failed: %s" (Stdlib.Printexc.to_string exn));
        (* Feed failure into Thompson Sampling quality signal *)
        Thompson_sampling.record_vote ~agent_name:ctx.agent_name ~direction:`Down;
        Thompson_sampling.record_quality_signal
@@ -69,7 +69,7 @@ and handle_cancel_task ~tool_name ~start_time ctx args =
          ("timestamp", `Float (Time_compat.now ()));
        ])
    | Error err ->
-       Log.Task.error "metrics record failed: %s" (Masc_domain.masc_error_to_string err));
+       Log.Task.error ~keeper_name:task_id "metrics record failed: %s" (Masc_domain.masc_error_to_string err));
   result_to_response ~tool_name ~start_time result
 
 and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
@@ -203,7 +203,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
       match Auth.read_initial_admin ctx.config.base_path with
       | Some admin when String.equal ctx.agent_name admin -> true
       | _ ->
-        Log.Task.warn "[anti-rationalization] force=true rejected: agent=%s lacks admin privilege"
+        Log.Task.warn ~keeper_name:task_id "[anti-rationalization] force=true rejected: agent=%s lacks admin privilege"
           ctx.agent_name;
         false
     else false
@@ -336,6 +336,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
         (match task.contract with
          | Some contract when contract_requires_verification contract ->
            Log.Task.info
+             ~keeper_name:task_id
              "[verifier-gate] redirecting Done→Submit_for_verification task=%s agent=%s contract_items=%d"
              task_id ctx.agent_name
              (List.length contract.completion_contract
@@ -396,6 +397,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
     | ( Masc_domain.Submit_for_verification
       , Some ({ task_status = Masc_domain.Todo; _ } : Masc_domain.task) ) ->
       Log.Task.info
+        ~keeper_name:task_id
         "[verification-alias] treating todo submit_for_verification with evidence as submit_pr_evidence task=%s agent=%s"
         task_id
         ctx.agent_name;
@@ -505,7 +507,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
                 ?handoff_context ?agent_tool_names ?prepare_verification_request
                 ?prepare_verification_verdict () in
       if is_version_mismatch r && attempt < max_cas_retries then begin
-        Log.Task.info "CAS version mismatch on %s (attempt %d/%d), retrying in %.0fms"
+        Log.Task.info ~keeper_name:task_id "CAS version mismatch on %s (attempt %d/%d), retrying in %.0fms"
           task_id (attempt + 1) max_cas_retries (cas_retry_delay_s *. 1000.0);
         Time_compat.sleep cas_retry_delay_s;
         try_transition (attempt + 1)
@@ -564,6 +566,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
           (match verification_id_before with
            | None ->
              Log.Task.warn
+               ~keeper_name:task_id
                "approve_verification action for task %s without verification_id_before (skipping notify)"
                task_id
            | Some verification_id ->
@@ -591,6 +594,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
           (match verification_id_before with
            | None ->
              Log.Task.warn
+               ~keeper_name:task_id
                "reject_verification action for task %s without verification_id_before (skipping notify)"
                task_id
            | Some verification_id ->
@@ -621,7 +625,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
          handoff_to = None;
        } in
        (try let _ = Metrics_store_eio.record ctx.config metric in ()
-        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error "Metrics_store_eio.record(transition-done) failed: %s" (Stdlib.Printexc.to_string exn));
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error ~keeper_name:task_id "Metrics_store_eio.record(transition-done) failed: %s" (Stdlib.Printexc.to_string exn));
        Thompson_sampling.record_vote ~agent_name:ctx.agent_name ~direction:`Up;
        Thompson_sampling.record_quality_signal
          ~agent_name:ctx.agent_name
@@ -641,7 +645,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
          handoff_to = None;
        } in
        (try let _ = Metrics_store_eio.record ctx.config metric in ()
-        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error "Metrics_store_eio.record(transition-cancel) failed: %s" (Stdlib.Printexc.to_string exn));
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error ~keeper_name:task_id "Metrics_store_eio.record(transition-cancel) failed: %s" (Stdlib.Printexc.to_string exn));
        Thompson_sampling.record_vote ~agent_name:ctx.agent_name ~direction:`Down;
        Thompson_sampling.record_quality_signal
          ~agent_name:ctx.agent_name

--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -193,6 +193,7 @@ let review_completion_notes
         task_description = task.description;
         completion_notes = notes;
         agent_name = ctx.agent_name;
+        task_id = task.id;
       } in
       let on_verdict result =
         Eval_calibration.record_verdict

--- a/test/test_anti_rationalization_coverage.ml
+++ b/test/test_anti_rationalization_coverage.ml
@@ -53,6 +53,7 @@ let make_request ?(title="Fix login bug") ?(desc="Users cannot login") ?(agent="
     task_description = desc;
     completion_notes = notes;
     agent_name = agent;
+    task_id = "test-task-ar";
   }
 
 (* ================================================================ *)

--- a/test/test_anti_rationalization_gate2_advisory_10113.ml
+++ b/test/test_anti_rationalization_gate2_advisory_10113.ml
@@ -53,6 +53,7 @@ let make_request ~notes : AR.review_request =
     task_title = "test task";
     task_description = "test description";
     completion_notes = notes;
+    task_id = "test-task-10113";
   }
 
 (* The advisory text must contain the flagged phrase verbatim and

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -109,6 +109,7 @@ let make_req ?(title = "Task") ?(notes = "Detailed completion notes") () :
     task_description = "desc";
     completion_notes = notes;
     agent_name = "agent_code";
+    task_id = "test-task-dash";
   }
 
 let make_result ?(verdict = AR.Approve) ?(gate = AR.Structured_tool)

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -34,7 +34,7 @@ let make_req ?(title = "Fix auth bug") ?(desc = "Fix the login issue")
     ?(notes = "Implemented JWT refresh token rotation") ?(agent = "dreamer") ()
   : AR.review_request =
   { task_title = title; task_description = desc;
-    completion_notes = notes; agent_name = agent }
+    completion_notes = notes; agent_name = agent; task_id = "test-task-eval" }
 
 let make_result ?(verdict = AR.Approve) ?(cascade = "verifier")
     ?gen_cascade ?(gate = AR.Structured_tool) ?fallback_reason () : AR.review_result =

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -2240,7 +2240,8 @@ let make_review_request () : Anti_rationalization.review_request =
   { task_title = "Fix login bug";
     task_description = "desc";
     completion_notes = "notes";
-    agent_name = "dreamer" }
+    agent_name = "dreamer";
+    task_id = "test-task-1" }
 
 let make_review_result
     ?(verdict = Anti_rationalization.Approve)


### PR DESCRIPTION
## Summary

- Add `~keeper_name:task_id` to 10 `Log.Task` calls in `tool_task.ml` where `task_id` was already in scope (cancel metrics, transition metrics, CAS retry, verification redirect, approval/rejection missing verification_id, force rejection)
- Add `task_id` field to `Anti_rationalization.review_request` type and thread `~keeper_name:req.task_id` to 16 `Log.Task` calls in `anti_rationalization.ml`
- Update construction site in `tool_task_handlers.ml` and 4 test files

## Context

Follow-up to PR #19155 (eprintf→Log conversion). After converting all structurally convertible `Printf.eprintf` sites, this PR adds `~keeper_name` context to `Log.Task` calls that had `task_id` available but weren't passing it through. This improves fleet observability by ensuring task-scoped logs carry the keeper identity for dashboard filtering.

## Structural unconvertibles (not touched)

- `task_dispatch.ml`: 4 initialization calls — no task context
- `tool_task_handlers.ml:125,168`: resolve_agent_name — only agent_name, no task_id
- `cdal_verdict_gate.ml:250,257`: ledger health — no task context
- `verification_protocol.ml:476`: function-level exception handler — no task in scope
- `dashboard_verification.ml:181`: list_requests failure — no task context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>