### PR TITLE
Remove bar shared reexports

### DIFF
--- a/dashboard/src/components/bar.solid.tsx
+++ b/dashboard/src/components/bar.solid.tsx
@@ -13,8 +13,6 @@
 import type { JSX } from 'solid-js'
 import { barPercent, FILL_COLOR, type BarProps, type BarKind } from './bar-shared'
 
-export { barPercent, type BarProps, type BarKind } from './bar-shared'
-
 export function Bar(props: BarProps): JSX.Element {
   const kind = (): BarKind => props.kind ?? 'default'
   const pct = (): number => barPercent(props.value)

--- a/dashboard/src/components/bar.ts
+++ b/dashboard/src/components/bar.ts
@@ -31,8 +31,6 @@ import { html } from 'htm/preact'
 import type { VNode } from 'preact'
 import { barPercent, FILL_COLOR, type BarProps } from './bar-shared'
 
-export { barPercent, type BarProps, type BarKind } from './bar-shared'
-
 export function Bar(props: BarProps): VNode {
   const kind = props.kind ?? 'default'
   const pct = barPercent(props.value)

--- a/dashboard/src/components/kpi-cell.solid.tsx
+++ b/dashboard/src/components/kpi-cell.solid.tsx
@@ -9,7 +9,8 @@
 // optional Bar progress row, caption + delta in standard/stacked variants.
 
 import { Show, type JSX } from 'solid-js'
-import { Bar, type BarKind } from './bar.solid'
+import { Bar } from './bar.solid'
+import { type BarKind } from './bar-shared'
 import { MONO_STACK } from './common/font-stacks'
 import { useKpiStripContext } from './kpi-strip.solid'
 import {


### PR DESCRIPTION
## Summary
- remove bar-shared helper/type re-exports from the Preact and Solid Bar component modules
- update the Solid KPI cell to import BarKind from the owning bar-shared module directly

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/bar.test.ts src/components/bar.solid.test.tsx src/components/kpi-cell.solid.test.tsx --no-file-parallelism --maxWorkers=1 --testTimeout=15000 (default config runs the Preact bar test: 1 file / 21 tests passed; Solid tests are excluded by that config)
- pnpm eslint src/components/bar.ts src/components/bar.solid.tsx src/components/kpi-cell.solid.tsx src/components/bar.test.ts src/components/bar.solid.test.tsx src/components/kpi-cell.solid.test.tsx
- git diff --check origin/main

## Known local verification gap
- pnpm vitest run --config vitest.solid.config.ts src/components/bar.solid.test.tsx src/components/kpi-cell.solid.test.tsx --no-file-parallelism --maxWorkers=1 --testTimeout=15000 failed before importing tests: Cannot find module '/@fs/Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/.pnpm/@testing-library+jest-dom@6.9.1/node_modules/@testing-library/jest-dom/dist/vitest.mjs'. This is the existing local Solid config/module resolution issue, not an assertion failure from this change.