### PR TITLE
refactor(cascade-phonebook): typed of_string + Failure-catch removal

### DIFF
--- a/lib/cascade/cascade_phonebook_parser.ml
+++ b/lib/cascade/cascade_phonebook_parser.ml
@@ -82,12 +82,13 @@ let parse_provider (id : string) (tbl : Otoml.t)
   in
   let auth_env = Otoml.find_opt tbl Otoml.get_string [ "auth_env" ] in
   let note = Otoml.find_opt tbl Otoml.get_string [ "note" ] in
-  (try
-     let protocol = protocol_of_string protocol_str in
-     let flavor = flavor_of_string flavor_str in
-     Ok { id; endpoint; protocol; flavor; auth_env; note }
-   with Failure msg ->
-     Error (error path msg))
+  match protocol_of_string protocol_str, flavor_of_string flavor_str with
+  | None, _ ->
+    Error (error path (Printf.sprintf "Unknown protocol: %s" protocol_str))
+  | _, None ->
+    Error (error path (Printf.sprintf "Unknown server flavor: %s" flavor_str))
+  | Some protocol, Some flavor ->
+    Ok { id; endpoint; protocol; flavor; auth_env; note }
 
 (* ── Model Capabilities ──────────────────────────────────────── *)
 

--- a/lib/cascade/cascade_phonebook_types.ml
+++ b/lib/cascade/cascade_phonebook_types.ml
@@ -25,14 +25,19 @@ type cascade_server_flavor =
 [@@deriving show, eq]
 
 let flavor_of_string = function
-  | "llama-cpp" -> Llama_cpp
-  | "ollama" -> Ollama
-  | "vllm" -> Vllm
-  | "provider_d" -> Provider_d_wire
-  | "provider_g" -> Provider_g_wire
-  | "zai-provider_k" -> Provider_k_zai
-  | "provider_h" -> Provider_h_wire
-  | s -> failwith (Printf.sprintf "Unknown server flavor: %s" s)
+  | "llama-cpp" -> Some Llama_cpp
+  | "ollama" -> Some Ollama
+  | "vllm" -> Some Vllm
+  | "provider_d" -> Some Provider_d_wire
+  | "provider_g" -> Some Provider_g_wire
+  | "zai-provider_k" -> Some Provider_k_zai
+  | "provider_h" -> Some Provider_h_wire
+  | _ -> None
+
+let flavor_of_string_exn s =
+  match flavor_of_string s with
+  | Some f -> f
+  | None -> failwith (Printf.sprintf "Unknown server flavor: %s" s)
 
 let flavor_to_string = function
   | Llama_cpp -> "llama-cpp"
@@ -53,11 +58,16 @@ type cascade_protocol =
 [@@deriving show, eq]
 
 let protocol_of_string = function
-  | "provider_d-http" -> Openai_http
-  | "ollama-http" -> Ollama_http
-  | "provider_a-http" -> Provider_a_http
-  | "provider_d-cli" -> Openai_cli
-  | s -> failwith (Printf.sprintf "Unknown protocol: %s" s)
+  | "provider_d-http" -> Some Openai_http
+  | "ollama-http" -> Some Ollama_http
+  | "provider_a-http" -> Some Provider_a_http
+  | "provider_d-cli" -> Some Openai_cli
+  | _ -> None
+
+let protocol_of_string_exn s =
+  match protocol_of_string s with
+  | Some p -> p
+  | None -> failwith (Printf.sprintf "Unknown protocol: %s" s)
 
 let protocol_to_string = function
   | Openai_http -> "provider_d-http"

--- a/lib/cascade/cascade_phonebook_types.mli
+++ b/lib/cascade/cascade_phonebook_types.mli
@@ -4,14 +4,30 @@ type cascade_server_flavor =
   | Llama_cpp | Ollama | Vllm | Provider_d_wire | Provider_g_wire | Provider_k_zai | Provider_h_wire
 [@@deriving show, eq]
 
-val flavor_of_string : string -> cascade_server_flavor
+val flavor_of_string : string -> cascade_server_flavor option
+(** Parse a flavor string.  Returns [None] for unknown values.
+
+    Prefer this over {!flavor_of_string_exn}.  The exn variant exists
+    only for backward-compat callers that already wrap their use site
+    in a top-level [Failure] handler. *)
+
+val flavor_of_string_exn : string -> cascade_server_flavor
+(** Partial — raises [Failure] on unknown values. *)
+
 val flavor_to_string : cascade_server_flavor -> string
 
 type cascade_protocol =
   | Openai_http | Ollama_http | Provider_a_http | Openai_cli
 [@@deriving show, eq]
 
-val protocol_of_string : string -> cascade_protocol
+val protocol_of_string : string -> cascade_protocol option
+(** Parse a protocol string.  Returns [None] for unknown values.
+
+    Prefer this over {!protocol_of_string_exn}. *)
+
+val protocol_of_string_exn : string -> cascade_protocol
+(** Partial — raises [Failure] on unknown values. *)
+
 val protocol_to_string : cascade_protocol -> string
 
 type cascade_phonebook_provider = {


### PR DESCRIPTION
## 요약

`Cascade_phonebook_types.{flavor,protocol}_of_string` 가 unknown 입력 시 `failwith` raise. Caller `cascade_phonebook_parser.ml:85-90` 는 `try ... with Failure msg ->` 로 catch + typed Result 변환.

→ **2개 안티패턴 동시 출현**:
- 파일: lib/cascade/cascade_phonebook_types.ml:35, 60 — partial function (`failwith` raise without typed alternative)
- 파일: lib/cascade/cascade_phonebook_parser.ml:85-90 — `with Failure msg ->` wildcard catch (RFC-0145 narrow target)

## 변경

**Parse, don't validate** 원칙 적용 — typed companion 패턴:

```ocaml
(* Before *)
val flavor_of_string : string -> cascade_server_flavor
(* raises Failure on unknown *)

(* After *)
val flavor_of_string     : string -> cascade_server_flavor option
val flavor_of_string_exn : string -> cascade_server_flavor
```

Same for `protocol_of_string`. `_exn` variant 은 `cascade_name.ml` convention 과 동일 (legacy/exn callers 용 backward-compat).

**Caller migration** (`cascade_phonebook_parser.ml:85-91`):

```ocaml
(* Before *)
(try
   let protocol = protocol_of_string protocol_str in
   let flavor = flavor_of_string flavor_str in
   Ok { id; endpoint; protocol; flavor; auth_env; note }
 with Failure msg ->
   Error (error path msg))

(* After *)
match protocol_of_string protocol_str, flavor_of_string flavor_str with
| None, _    -> Error (error path (Printf.sprintf "Unknown protocol: %s" protocol_str))
| _, None    -> Error (error path (Printf.sprintf "Unknown server flavor: %s" flavor_str))
| Some protocol, Some flavor ->
  Ok { id; endpoint; protocol; flavor; auth_env; note }
```

- 동작 동일 (unknown 입력 → error path 동일 message)
- `with Failure _ ->` wildcard 제거 (다른 `failwith` 가 우연히 잡히던 위험 차단)
- Caller graph: 1 caller 만 영향 (`cascade_phonebook_parser.ml`); `_exn` variant 콜러 0건

## 검증

- `dune build lib/ --root .` exit 0 — full library tree green
- Caller scan: `rg '(flavor|protocol)_of_string' lib/ test/ | grep -v transport` → 1 caller only

## Anti-pattern removal

CLAUDE.md sw-dev `"Parse, don't validate"` (Alexis King) + partial-function retrospective (PR #19188) §2.4 (typed companion) + §2.5 (RFC-0145 narrow).

## Workaround Signature Gate

WORKAROUND-WAIVED: anti-pattern *removal* PR. 시그니처 3종 비해당:

- ❌ Counter-as-Fix (텔레메트리 추가 없음)
- ❌ String/substring 분류기 (오히려 typed sum 강화 — string match 1단계가 `_` 으로 *총망라*)
- ❌ N-of-M 패치 (1 caller 전부 migration)

## Related

- `docs/audit/2026-05-27-partial-function-sweep-retrospective.md` (#19188) §2.4 typed companion 패턴
- `lib/cascade_name/cascade_name.ml` — 같은 `_exn` convention 사용 선례
- PR #19149 — `extract_input_required` typed companion 선례

🤖 Generated with [Claude Code](https://claude.com/claude-code)
