### PR TITLE
fix(keeper): ratchet transition action policy

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -100,6 +100,16 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/no-provider-name-hardcoding.sh --fail
 
+  no-keeper-behavior-hardcoding:
+    name: Keeper behavior hardcoding ratchet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
+      - name: Run lint
+        run: bash scripts/lint/no-keeper-behavior-hardcoding.sh
+
   no-legacy-tool-surface-name:
     name: Legacy tool surface name ratchet (RFC-0064)
     runs-on: ubuntu-latest

--- a/config/keepers/verifier.toml
+++ b/config/keepers/verifier.toml
@@ -17,6 +17,13 @@ tool_denylist = [
   "masc_batch_add_tasks",
   "masc_claim_next",
   "masc_deliver",
+  "masc_transition:claim",
+  "masc_transition:start",
+  "masc_transition:done",
+  "masc_transition:cancel",
+  "masc_transition:release",
+  "masc_transition:submit_for_verification",
+  "masc_transition:submit_pr_evidence",
 ]
 repo_cli_identity = "reviewer-keepers-nonoperator-0506b"
 git_identity_mode = "repo_cli_identity"

--- a/config/personas/verifier/profile.json
+++ b/config/personas/verifier/profile.json
@@ -21,7 +21,14 @@
       "masc_add_task",
       "masc_batch_add_tasks",
       "masc_claim_next",
-      "masc_deliver"
+      "masc_deliver",
+      "masc_transition:claim",
+      "masc_transition:start",
+      "masc_transition:done",
+      "masc_transition:cancel",
+      "masc_transition:release",
+      "masc_transition:submit_for_verification",
+      "masc_transition:submit_pr_evidence"
     ],
     "mention_targets": [
       "verifier",

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -175,14 +175,22 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   | Ok action ->
   let requested_action = action in
   let action_s = Masc_domain.task_action_to_string action in
-  if is_verifier_agent_name ctx.agent_name
-     && not (verifier_transition_action_allowed action)
+  let transition_action_denylist = keeper_transition_action_denylist ctx in
+  if
+    transition_action_denied_by_denylist
+      ~tool_denylist:transition_action_denylist
+      ~action:action_s
   then
     Tool_result.error
       ~failure_class:(Some Tool_result.Workflow_rejection)
       ~tool_name
       ~start_time
-      (verifier_transition_rejection ~agent_name:ctx.agent_name ~action:action_s)
+      (transition_action_policy_rejection
+         ~agent_name:ctx.agent_name
+         ~action:action_s
+         ~allowed_actions:
+           (transition_action_allowed_actions
+              ~tool_denylist:transition_action_denylist))
   else
   let notes = get_string args "notes" "" in
   let reason = get_string args "reason" "" in
@@ -210,14 +218,14 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   in
   let tasks = Coord.get_tasks_raw ctx.config in
   let task_opt = List.find_opt (fun (t : Masc_domain.task) -> String.equal t.id task_id) tasks in
-  let verifier_terminal_verdict_noop =
-    if is_verifier_agent_name ctx.agent_name
-       && verifier_transition_action_allowed action
+  let terminal_verdict_noop =
+    if transition_action_policy_applies transition_action_denylist
+       && is_verdict_transition_action action
     then
       match task_opt with
       | Some task when Masc_domain.task_status_is_terminal task.task_status ->
         Some
-          (verifier_terminal_verdict_noop_message
+          (terminal_verdict_noop_message
              ~task_id
              ~action:action_s
              ~status:(Masc_domain.task_status_to_string task.task_status))
@@ -225,7 +233,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
     else
       None
   in
-  match verifier_terminal_verdict_noop with
+  match terminal_verdict_noop with
   | Some message -> Tool_result.ok ~tool_name ~start_time message
   | None ->
   match client_side_transition_gate_error ~task_opt ~action ~action_s with

--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -178,6 +178,32 @@ let keeper_agent_tool_names (ctx : context) =
        | Some entry -> Some (Keeper_tool_policy.keeper_allowed_tool_names entry.meta)
        | None -> None)
 
+let keeper_meta_for_agent (ctx : context) =
+  let resolved =
+    try Coord.resolve_agent_name ctx.config ctx.agent_name with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        Log.Task.warn "resolve_agent_name failed for keeper policy %s: %s"
+          ctx.agent_name
+          (Stdlib.Printexc.to_string exn);
+        ctx.agent_name
+  in
+  [ ctx.agent_name; resolved ]
+  |> List.filter_map Keeper_identity.canonical_keeper_name
+  |> Json_util.dedupe_keep_order
+  |> List.find_map (fun keeper_name ->
+       match Keeper_registry.get ~base_path:ctx.config.base_path keeper_name with
+       | Some entry -> Some entry.meta
+       | None ->
+           match Keeper_types.read_meta ctx.config keeper_name with
+           | Ok (Some meta) -> Some meta
+           | Ok None | Error _ -> None)
+
+let keeper_transition_action_denylist (ctx : context) =
+  match keeper_meta_for_agent ctx with
+  | Some meta -> meta.tool_denylist
+  | None -> []
+
 let review_completion_notes
     ~(completion_contract : string list option)
     ~(evaluator_cascade : string option)
@@ -595,4 +621,3 @@ let transition_known_args =
     "evaluator_cascade";
     "handoff_context";
   ]
-

--- a/lib/tool_task_payloads.ml
+++ b/lib/tool_task_payloads.ml
@@ -1,5 +1,5 @@
-(** Tool_task_payloads — pure JSON payload builders and verifier-name
-    guards for task tools.
+(** Tool_task_payloads — pure JSON payload builders and task-policy
+    helpers for task tools.
 
     No [context], no IO, no broadcast. Extracted from {!Tool_task} so
     the payload contracts (field names, nullability, cross-model
@@ -8,12 +8,35 @@
 
     @since God file decomposition — extracted from tool_task.ml *)
 
-let is_verifier_agent_name agent_name =
-  let normalized = String.lowercase_ascii (String.trim agent_name) in
-  String.equal normalized "verifier"
-  || String.equal normalized "keeper-verifier-agent"
+let transition_action_denylist_prefix = "masc_transition:"
 
-let verifier_transition_action_allowed = function
+let normalize_transition_action raw =
+  String.trim raw |> String.lowercase_ascii
+
+let transition_action_denylist_entry action =
+  transition_action_denylist_prefix ^ normalize_transition_action action
+
+let is_transition_action_denylist_entry raw =
+  let normalized = normalize_transition_action raw in
+  String.length normalized > String.length transition_action_denylist_prefix
+  && String.sub normalized 0 (String.length transition_action_denylist_prefix)
+     = transition_action_denylist_prefix
+
+let transition_action_denied_by_denylist ~tool_denylist ~action =
+  let expected = transition_action_denylist_entry action in
+  List.exists
+    (fun entry -> String.equal (normalize_transition_action entry) expected)
+    tool_denylist
+
+let transition_action_policy_applies tool_denylist =
+  List.exists is_transition_action_denylist_entry tool_denylist
+
+let transition_action_allowed_actions ~tool_denylist =
+  Masc_domain.valid_task_action_strings
+  |> List.filter (fun action ->
+    not (transition_action_denied_by_denylist ~tool_denylist ~action))
+
+let is_verdict_transition_action = function
   | Masc_domain.Approve_verification
   | Masc_domain.Reject_verification ->
     true
@@ -26,14 +49,19 @@ let verifier_transition_action_allowed = function
   | Masc_domain.Submit_pr_evidence ->
     false
 
-let verifier_transition_rejection ~agent_name ~action =
+let transition_action_policy_rejection ~agent_name ~action ~allowed_actions =
+  let allowed =
+    match allowed_actions with
+    | [] -> "(none)"
+    | xs -> String.concat "|" xs
+  in
   Printf.sprintf
-    "Verifier action guard: agent '%s' may only call masc_transition(action=approve|reject). Got action=%s. Inspect task history/status for completed tasks, and reject insufficient or analysis-only evidence instead of claiming, starting, releasing, submitting, cancelling, or marking tasks done."
-    agent_name action
+    "Transition action policy guard: agent '%s' may only call masc_transition(action=%s). Got action=%s. Inspect task history/status before claiming, starting, releasing, submitting, cancelling, marking tasks done, or making a verification verdict."
+    agent_name allowed action
 
-let verifier_terminal_verdict_noop_message ~task_id ~action ~status =
+let terminal_verdict_noop_message ~task_id ~action ~status =
   Printf.sprintf
-    "Verifier stale verdict ignored: task %s is already %s, so masc_transition(action=%s) was treated as a no-op. Do not retry this verdict; inspect task history or list awaiting_verification tasks instead."
+    "Stale verification verdict ignored: task %s is already %s, so masc_transition(action=%s) was treated as a no-op. Do not retry this verdict; inspect task history or list awaiting_verification tasks instead."
     task_id status action
 
 let workflow_rejection_payload_json

--- a/scripts/lint/no-keeper-behavior-hardcoding.sh
+++ b/scripts/lint/no-keeper-behavior-hardcoding.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "[no-keeper-behavior-hardcoding] required tool missing: rg" >&2
+  exit 1
+fi
+
+targets=(
+  "lib/keeper"
+  "lib/coord"
+  "lib/tool_task.ml"
+  "lib/tool_task_payloads.ml"
+  "lib/tool_task_handlers.ml"
+)
+
+patterns=(
+  'is_verifier_agent_name'
+  'keeper-verifier-agent'
+  'String[.]equal[^\n]*"verifier"'
+  '"verifier"[^\n]*String[.]equal'
+)
+
+tmp="$(mktemp -t keeper-behavior-hardcoding.XXXXXX)"
+trap 'rm -f "$tmp"' EXIT
+
+for pattern in "${patterns[@]}"; do
+  (cd "$ROOT" && rg -n --glob '*.ml' --glob '*.mli' "$pattern" "${targets[@]}") \
+    >>"$tmp" || true
+done
+
+if [[ -s "$tmp" ]]; then
+  echo "[no-keeper-behavior-hardcoding] hardcoded keeper identity behavior found" >&2
+  cat "$tmp" >&2
+  echo "[no-keeper-behavior-hardcoding] encode keeper-specific behavior in config/meta policy instead" >&2
+  exit 1
+fi
+
+echo "[no-keeper-behavior-hardcoding] OK"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1716,6 +1716,19 @@ let test_tool_execution_substrate_ratchet_contracts () =
      && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "pr_review"
      && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "gh_commit")
 
+let test_keeper_behavior_hardcoding_ratchet_contracts () =
+  check bool "keeper behavior hardcoding ratchet script exists" true
+    (Sys.file_exists
+       (source_path "scripts/lint/no-keeper-behavior-hardcoding.sh"));
+  check bool "keeper behavior hardcoding ratchet is wired to fundamental check" true
+    (file_contains_pattern ".github/workflows/fundamental-check.yml"
+       "scripts/lint/no-keeper-behavior-hardcoding.sh");
+  check bool "task transition behavior avoids verifier identity hardcoding" true
+    (file_not_contains_pattern "lib/tool_task_payloads.ml" "is_verifier_agent_name"
+     && file_not_contains_pattern "lib/tool_task_payloads.ml"
+          "keeper-verifier-agent"
+     && file_not_contains_pattern "lib/tool_task.ml" "is_verifier_agent_name")
+
 let test_public_execute_guidance_contracts () =
   let raw_command prefix = "command='" ^ prefix in
   let raw_execute_with_command prefix = "Execute with " ^ raw_command prefix in
@@ -2824,6 +2837,8 @@ let () =
             test_dedicated_forge_pr_tool_contracts_removed;
           test_case "tool execution substrate ratchet contracts" `Quick
             test_tool_execution_substrate_ratchet_contracts;
+          test_case "keeper behavior hardcoding ratchet contracts" `Quick
+            test_keeper_behavior_hardcoding_ratchet_contracts;
           test_case "public Execute alias contracts" `Quick
             test_public_execute_alias_contracts;
           test_case "public Execute guidance contracts" `Quick

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -3,6 +3,7 @@ open Alcotest
 module KTP = Masc_mcp.Keeper_types_profile
 module KT = Masc_mcp.Keeper_types
 module KPolicy = Masc_mcp.Keeper_tool_policy
+module TaskPayloads = Masc_mcp.Tool_task_payloads
 
 (** Validate that every .toml file in config/keepers/ parses successfully
     with the OCaml TOML parser.  This catches syntax that is valid standard
@@ -250,7 +251,29 @@ let test_verifier_config_hides_worker_lifecycle_tools () =
           "masc_batch_add_tasks";
           "masc_claim_next";
           "masc_deliver";
-        ]
+        ];
+      List.iter
+        (fun action ->
+          check bool ("verifier blocks transition action " ^ action) true
+            (TaskPayloads.transition_action_denied_by_denylist
+               ~tool_denylist:denylist
+               ~action))
+        [
+          "claim";
+          "start";
+          "done";
+          "cancel";
+          "release";
+          "submit_for_verification";
+          "submit_pr_evidence";
+        ];
+      List.iter
+        (fun action ->
+          check bool ("verifier allows transition action " ^ action) false
+            (TaskPayloads.transition_action_denied_by_denylist
+               ~tool_denylist:denylist
+               ~action))
+        [ "approve"; "reject" ]
 
 (** Write a temporary TOML file, run load_keeper_toml, clean up. *)
 let with_temp_toml content f =

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -89,7 +89,20 @@ let add_task_requiring_tools ctx ~title tools =
   in
   if not (Tool_result.is_success result) then failwith (Tool_result.message result)
 
-let register_test_keeper ctx ~keeper_name ~agent_name =
+let verifier_transition_action_denylist =
+  List.map
+    (fun action -> "masc_transition:" ^ action)
+    [
+      "claim";
+      "start";
+      "done";
+      "cancel";
+      "release";
+      "submit_for_verification";
+      "submit_pr_evidence";
+    ]
+
+let register_test_keeper ?(tool_denylist = []) ctx ~keeper_name ~agent_name =
   match
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
@@ -97,6 +110,8 @@ let register_test_keeper ctx ~keeper_name ~agent_name =
           ("name", `String keeper_name);
           ("agent_name", `String agent_name);
           ("trace_id", `String ("test-trace-" ^ keeper_name));
+          ( "tool_denylist",
+            `List (List.map (fun tool -> `String tool) tool_denylist) );
         ])
   with
   | Ok meta ->
@@ -1020,6 +1035,8 @@ let () = test "handle_transition_done_on_awaiting_verification_is_explicit" (fun
 
 let () = test "handle_transition_verifier_blocks_non_verdict_actions" (fun () ->
   let ctx = make_test_ctx_with_agent "verifier" in
+  register_test_keeper ctx ~keeper_name:"verifier" ~agent_name:"verifier"
+    ~tool_denylist:verifier_transition_action_denylist;
   let _ =
     Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [ ("title", `String "Verifier must not claim") ])
@@ -1038,7 +1055,7 @@ let () = test "handle_transition_verifier_blocks_non_verdict_actions" (fun () ->
       assert (not (Tool_result.is_success result));
       assert
         ((Tool_result.failure_class result) = Some Tool_result.Workflow_rejection);
-      assert (str_contains (Tool_result.message result) "Verifier action guard");
+      assert (str_contains (Tool_result.message result) "Transition action policy guard");
       assert (str_contains (Tool_result.message result) "approve|reject"))
     [ "claim"; "done"; "submit_for_verification" ];
   assert_task_todo ctx;
@@ -1046,6 +1063,8 @@ let () = test "handle_transition_verifier_blocks_non_verdict_actions" (fun () ->
 
 let () = test "handle_transition_verifier_noops_terminal_verdicts" (fun () ->
   let ctx = make_test_ctx_with_agent "worker" in
+  register_test_keeper ctx ~keeper_name:"verifier" ~agent_name:"verifier"
+    ~tool_denylist:verifier_transition_action_denylist;
   let verifier_ctx = { ctx with Tool_task.agent_name = "verifier" } in
   let _ = Coord.add_task ctx.config ~title:"Already done" ~priority:1 ~description:"" in
   let _ = Coord.claim_task ctx.config ~agent_name:"worker" ~task_id:"task-001" in


### PR DESCRIPTION
## Summary
- Move verifier transition behavior from name-based hardcoding to keeper meta policy using `masc_transition:<action>` denylist entries.
- Configure verifier to deny non-verdict transition actions while keeping `approve` / `reject` available.
- Add a keeper behavior hardcoding ratchet script and wire it into `fundamental-check` plus source-level coverage.

## Validation
- `bash scripts/lint/no-keeper-behavior-hardcoding.sh`
- `jq empty config/personas/verifier/profile.json`
- `bash -n scripts/lint/no-keeper-behavior-hardcoding.sh`
- `ocamlformat --check lib/tool_task_payloads.ml lib/tool_task_handlers.ml lib/tool_task.ml test/test_tool_task_coverage.ml test/test_keeper_toml_config_validation.ml test/test_ci_hardening_source.ml`
- `git diff --cached --check`

Focused Dune build was attempted locally. One attempt reached the existing `Agent_sdk.Error.Timeout` constructor mismatch in `lib/keeper/keeper_turn_driver_try_cascade.ml`; the final branch attempt was queued behind an unrelated `dune-local` lock and stopped to avoid adding host contention.