### PR TITLE
Remove agent detail selection reexports

### DIFF
--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -27,7 +27,6 @@ export type TaskHistoryRow = {
   taskId: string
   text: string
 }
-export { selectedAgentName } from './agent-detail-selection'
 
 // --- Signals ---
 

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -23,8 +23,8 @@ import { AgentWorkerBrief } from './agent-detail-worker'
 import { AgentDetailMemory } from './agent-detail-memory'
 import { CollapsibleSection } from './common/collapsible'
 import { SessionTraceView } from './session-trace/session-trace-view'
+import { selectedAgentName } from './agent-detail-selection'
 import {
-  selectedAgentName,
   loading,
   detailError,
   namespaceActivity,
@@ -52,9 +52,6 @@ import { showToast } from './common/toast'
 import { invalidateDashboardCache, refreshDashboard } from '../store'
 import { purgeAgent } from '../api/actions'
 import { ringFocusClasses } from './common/ring'
-
-// Re-export public API for external consumers
-export { selectedAgentName, openAgentDetail, closeAgentDetail } from './agent-detail-state'
 
 // Wire keeper redirect: keeper-linked agents open the keeper detail overlay
 setKeeperRedirect((agentName: string) => {

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -2,7 +2,8 @@
 
 import { html } from 'htm/preact'
 import { focusAgents } from '../../live-store'
-import { openAgentDetail, selectedAgentName } from '../agent-detail-state'
+import { selectedAgentName } from '../agent-detail-selection'
+import { openAgentDetail } from '../agent-detail-state'
 import { TimeAgo } from '../common/time-ago'
 import { ringFocusClasses } from '../common/ring'
 

--- a/dashboard/src/components/live/pulse-strip.ts
+++ b/dashboard/src/components/live/pulse-strip.ts
@@ -2,7 +2,8 @@
 
 import { html } from 'htm/preact'
 import { agentPulses, type PulseState } from '../../live-store'
-import { openAgentDetail, selectedAgentName } from '../agent-detail-state'
+import { selectedAgentName } from '../agent-detail-selection'
+import { openAgentDetail } from '../agent-detail-state'
 
 function pulseStateClass(state: PulseState): string {
   switch (state) {


### PR DESCRIPTION
## Summary
- remove selectedAgentName re-export from agent-detail-state
- remove the unused agent-detail component API re-export
- import selectedAgentName from the owning agent-detail-selection module in live agent views

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/agent-detail-state.test.ts src/components/live/pulse-strip.a11y.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/agent-detail-state.ts src/components/agent-detail.ts src/components/live/focus-sidebar.ts src/components/live/pulse-strip.ts src/components/agent-detail-state.test.ts src/components/live/pulse-strip.a11y.test.ts
- git diff --check origin/main