### PR TITLE
refactor(dashboard/format-number): route 5 inline finite-check ternaries through file-local isFiniteMetricValue helper

### DIFF
--- a/dashboard/src/lib/format-number.ts
+++ b/dashboard/src/lib/format-number.ts
@@ -2,20 +2,20 @@
 
 /** Format a 0–1 ratio as percentage string. Returns fallback for null/NaN. */
 export function formatPct(value: number | null | undefined, fallback = '-'): string {
-  if (value == null || !Number.isFinite(value)) return fallback
+  if (!isFiniteMetricValue(value)) return fallback
   return `${Math.round(value * 100)}%`
 }
 
 /** Format a 0–1 ratio as percentage with 1 decimal. Returns fallback for null/NaN. */
 export function formatPct1(value: number | null | undefined, fallback = '-'): string {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  if (!isFiniteMetricValue(value)) return fallback
   return `${(value * 100).toFixed(1)}%`
 }
 
 /** Abbreviate large token counts: 1234567 → "1.2M", 4500 → "4.5K".
  *  Distinguishes 0 (valid data) from undefined (no data). */
 export function formatTokens(n: number | null | undefined): string {
-  if (n == null || !Number.isFinite(n)) return '-'
+  if (!isFiniteMetricValue(n)) return '-'
   if (n === 0) return '0'
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
@@ -25,7 +25,7 @@ export function formatTokens(n: number | null | undefined): string {
 /** Format a number with locale-aware grouping and configurable decimals.
  *  Returns fallback for null/NaN/undefined. */
 export function formatNumber(value: number | null | undefined, digits = 0, fallback = '--'): string {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  if (!isFiniteMetricValue(value)) return fallback
   return value.toLocaleString('ko-KR', {
     minimumFractionDigits: digits,
     maximumFractionDigits: digits,
@@ -35,7 +35,7 @@ export function formatNumber(value: number | null | undefined, digits = 0, fallb
 /** Format a USD cost value. Sub-cent values get 4 decimals; otherwise 2.
  *  Returns fallback for null/NaN/undefined. */
 export function formatCost(value: number | null | undefined, fallback = '--'): string {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  if (!isFiniteMetricValue(value)) return fallback
   if (value === 0) return '$0'
   if (value < 0.01) return `$${value.toFixed(4)}`
   return `$${value.toFixed(2)}`


### PR DESCRIPTION
## 변경 내용

`dashboard/src/lib/format-number.ts` 한 파일 안에서 `isFiniteMetricValue` helper 가 export 되어 있는데, **6 개 formatter 중 5 개가 inline 으로 같은 finite-check 를 다시 작성**하고 있었습니다. 이 PR 은 5 callsite 를 helper 로 라우팅합니다.

| Formatter | 기존 inline check | 변경 후 |
|-----------|-------------------|---------|
| `formatPct` | `value == null \|\| !Number.isFinite(value)` | `!isFiniteMetricValue(value)` |
| `formatPct1` | `typeof value !== 'number' \|\| !Number.isFinite(value)` | `!isFiniteMetricValue(value)` |
| `formatTokens` | `n == null \|\| !Number.isFinite(n)` | `!isFiniteMetricValue(n)` |
| `formatNumber` | `typeof value !== 'number' \|\| !Number.isFinite(value)` | `!isFiniteMetricValue(value)` |
| `formatCost` | `typeof value !== 'number' \|\| !Number.isFinite(value)` | `!isFiniteMetricValue(value)` |
| `formatMsCompact` | (이미 helper 사용 — 변경 없음) | — |

## 등가성 (behaviour preserved)

세 가지 inline variant 모두 `!isFiniteMetricValue(value)` 와 *runtime + 타입* 양쪽으로 등가입니다.

- `Number.isFinite(null)` → `false` (coerce 안 함)
- `Number.isFinite(undefined)` → `false`
- `Number.isFinite(NaN)` → `false`
- `Number.isFinite(<number>)` → 값에 따라

따라서 inline 의 선행 `value == null` 또는 `typeof value !== 'number'` 는 *runtime 동작*에 영향 없는 redundant guard 였습니다. helper 의 `value is number` predicate 가 TypeScript narrowing 도 동일하게 제공합니다.

## SSOT 의의

PR #19189 (`lib/async-state` 의 `toErrorMessage` file-local helper 우회) 와 *같은 SSOT class*: **intra-file helper bypass**. helper 가 같은 파일에 export 되어 있어도, callsite 가 inline 으로 같은 식을 다시 쓰면 helper 정책 변경 시 (예: `NaN` strict 처리, `BigInt` 지원) 자동 전파되지 않습니다. 6 곳 중 1 곳만 갱신되고 나머지 5 곳 stale.

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run src/lib/format-number.test.ts` — 45/45 pass
- `pnpm vitest run` — 528/529 (1 baseline flaky: `auth-status.a11y.test.ts` Preact happy-dom timing race; main 동일)
- 1 file +5/-5

## Out of scope

이 PR 은 `format-number.ts` *file-internal* SSOT 위반만 처리합니다. 다른 파일에서 `Number.isFinite(...)` inline 사용은 cross-file scope 라 별도 PR.

