### PR TITLE
refactor(dashboard): drop PR create runtime proof field

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -239,8 +239,7 @@ describe('keeper runtime trace', () => {
             network_modes: ['inherit'],
             docker_visible: true,
             git_credentials_enabled: true,
-            github_identity_materialized: true,
-            pr_create_observed: true,
+            repo_cli_identity_materialized: true,
             latest_at: '2026-05-13T00:00:01Z',
           },
         },
@@ -328,7 +327,7 @@ describe('keeper runtime trace', () => {
     expect(result.runtime_lens.axes.provider_attempt.terminal_status).toBe('timeout')
     expect(result.runtime_lens.axes.runtime_proof.status).toBe('pass')
     expect(result.runtime_lens.axes.runtime_proof.docker_visible).toBe(true)
-    expect(result.runtime_lens.axes.runtime_proof.github_identity_materialized).toBe(true)
+    expect(result.runtime_lens.axes.runtime_proof.repo_cli_identity_materialized).toBe(true)
     expect(result.runtime_lens.axes.runtime_proof.tools).toEqual(['Execute', 'SearchFiles'])
     expect(result.runtime_lens.swimlanes.provider.terminal_status).toBe('timeout')
     expect(result.runtime_lens.swimlanes.memory_context.terminal_status).toBe('unknown')

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -848,8 +848,7 @@ export interface KeeperRuntimeLensRuntimeProofAxis {
   network_modes: string[]
   docker_visible: boolean
   git_credentials_enabled: boolean
-  github_identity_materialized: boolean
-  pr_create_observed: boolean
+  repo_cli_identity_materialized: boolean
   latest_at: string | null
 }
 
@@ -1317,8 +1316,7 @@ function parseRuntimeLensRuntimeProofAxis(raw: unknown): KeeperRuntimeLensRuntim
     network_modes: stringListField(obj, 'network_modes'),
     docker_visible: obj.docker_visible === true,
     git_credentials_enabled: obj.git_credentials_enabled === true,
-    github_identity_materialized: obj.github_identity_materialized === true,
-    pr_create_observed: obj.pr_create_observed === true,
+    repo_cli_identity_materialized: obj.repo_cli_identity_materialized === true,
     latest_at: nullableStringField(obj, 'latest_at'),
   }
 }

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -543,8 +543,7 @@ describe('RuntimeLensSection', () => {
             network_modes: ['inherit'],
             docker_visible: true,
             git_credentials_enabled: true,
-            github_identity_materialized: true,
-            pr_create_observed: true,
+            repo_cli_identity_materialized: true,
             latest_at: '2026-05-13T00:00:01Z',
           },
           context: {
@@ -779,7 +778,7 @@ describe('RuntimeLensSection', () => {
     expect(screen.getByText('pass / 2 calls')).toBeInTheDocument()
     expect(screen.getByText('sandbox proof')).toBeInTheDocument()
     expect(screen.getByText('docker')).toBeInTheDocument()
-    expect(screen.getByText('GitHub proof')).toBeInTheDocument()
+    expect(screen.getByText('repo CLI proof')).toBeInTheDocument()
     expect(screen.getByText('git creds / identity materialized')).toBeInTheDocument()
     expect(screen.getByText('proof tools')).toBeInTheDocument()
     expect(screen.getByText('Execute, SearchFiles')).toBeInTheDocument()

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -1081,8 +1081,8 @@ export function RuntimeLensSection({
         <${SignalRow} label="runtime proof" value=${`${proof.status} / ${proof.matched_tool_call_count} calls`} />
         <${SignalRow} label="sandbox proof" value=${proof.docker_visible ? formatLensList(proof.sandbox_profiles, 'docker') : 'not observed'} />
         <${SignalRow}
-          label="GitHub proof"
-          value=${`${proof.git_credentials_enabled ? 'git creds' : 'no git creds'} / ${proof.github_identity_materialized ? 'identity materialized' : 'identity missing'}`}
+          label="repo CLI proof"
+          value=${`${proof.git_credentials_enabled ? 'git creds' : 'no git creds'} / ${proof.repo_cli_identity_materialized ? 'identity materialized' : 'identity missing'}`}
         />
         <${SignalRow} label="proof tools" value=${formatLensList(proof.tools)} />
         <${SignalRow} label="network proof" value=${formatLensList(proof.network_modes)} />


### PR DESCRIPTION
## Summary

- remove `pr_create_observed` from the dashboard runtime proof client model
- switch the dashboard parser/component/tests to the server-emitted `repo_cli_identity_materialized` field
- relabel the detail row from GitHub proof to repo CLI proof

## Product impact

The dashboard no longer carries a PR-create proof axis in the keeper runtime lens. The UI now reflects the generic repo CLI identity materialization proof emitted by the server.

## Evidence

- `pnpm typecheck`
- `pnpm vitest run --config vitest.config.ts src/api/keeper.test.ts src/components/keeper-detail-runtime.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm eslint src/api/keeper.ts src/api/keeper.test.ts src/components/keeper-detail-runtime.ts src/components/keeper-detail-runtime.test.ts` returned 0 errors and 3 existing config warnings: touched files ignored because no matching ESLint config was supplied
- `git diff --check`
- residue scan: no `github_identity_materialized` / `pr_create_observed` under `dashboard/src`, `lib`, or `test`

## Direct evidence

schema_version: 1
direct_ratio: 5/5
provenance: direct

## Review evidence

Draft PR for CI/reviewer pass.

## Linked issue

None.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`purge/dashboard-runtime-pr-create-proof-20260527` → `main` · 1 commit(s) · synced 2026-05-27T14:22:56Z

| sha | subject | date |
|---|---|---|
| `0a2aefd35` | refactor(dashboard): drop PR create runtime proof field | 2026-05-27 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->