### PR TITLE
Remove task detail selection reexport

### DIFF
--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -12,8 +12,8 @@ import { RichContent } from '../common/rich-content'
 import { TextInput } from '../common/input'
 import { TimeAgo } from '../common/time-ago'
 import { findKeeper } from '../../lib/keeper-utils'
+import { selectedTask } from './task-detail-selection'
 import {
-  selectedTask,
   closeTaskDetail,
   taskEvents,
   taskEventsLoading,

--- a/dashboard/src/components/goals/task-detail-state.ts
+++ b/dashboard/src/components/goals/task-detail-state.ts
@@ -9,7 +9,6 @@ import { buildTraceEvents, type UnifiedTraceEvent } from '../session-trace/sessi
 import { findKeeper } from '../../lib/keeper-utils'
 import { goalById } from './goal-helpers'
 import type { Goal, Task } from '../../types'
-export { selectedTask } from './task-detail-selection'
 
 // -- Activity filter (owned here, consumed by task-activity-list) ---
 


### PR DESCRIPTION
## Summary
- remove selectedTask re-export from task-detail-state
- import selectedTask from the owning task-detail-selection module in the overlay

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/goals/task-detail-state.test.ts src/components/goals/task-activity-list.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/goals/task-detail-overlay.ts src/components/goals/task-detail-state.ts src/components/goals/task-detail-state.test.ts src/components/goals/task-activity-list.test.ts
- git diff --check origin/main