### PR TITLE
Export governance resource directly

### DIFF
--- a/dashboard/src/components/governance-signals.ts
+++ b/dashboard/src/components/governance-signals.ts
@@ -7,8 +7,7 @@ import type { GovernanceFilter } from './governance-utils'
 import { createAsyncResource, getData } from '../lib/async-state'
 
 // ── Main governance resource ──
-const governanceResource = createAsyncResource<DashboardGovernanceResponse>()
-export { governanceResource }
+export const governanceResource = createAsyncResource<DashboardGovernanceResponse>()
 
 export const governanceLoading = computed(() => governanceResource.state.value.status === 'loading')
 export const governanceError = signal('')


### PR DESCRIPTION
## Summary
- replace the separate governanceResource export statement with a direct exported const
- keep governanceResource ownership in governance-signals without the extra alias line

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/governance.test.ts src/components/governance-risk.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/governance-signals.ts src/components/governance.test.ts src/components/governance-risk.test.ts
- git diff --check origin/main