### PR TITLE
feat(rfc-0199-phase-b): deterministic evidence evaluator (pure, injected deps)

### DIFF
--- a/lib/cdal/deterministic_evidence_evaluator.ml
+++ b/lib/cdal/deterministic_evidence_evaluator.ml
@@ -52,7 +52,8 @@ type evaluator_deps =
 (** Per-claim verdict used internally before aggregation. *)
 type claim_verdict =
   | Satisfied
-  | Unsatisfied of string  (** human-readable reason kept for [Partial.missing] formatting *)
+  | Unsatisfied of string
+      (** human-readable reason retained internally; [Partial] exposes claims *)
   | Transient_inconclusive of string
   | Hard_inconclusive of string
 
@@ -191,8 +192,15 @@ let aggregate (claims : Evidence_claim.t list) (verdicts : claim_verdict list) =
         | _ :: _ -> Partial { satisfied; missing }))
 
 let evaluate ~deps ~claims =
-  match claims with
-  | [] -> All_satisfied
-  | _ :: _ ->
-    let verdicts = List.map (verdict_of_claim deps) claims in
-    aggregate claims verdicts
+  let rec loop checked_claims checked_verdicts = function
+    | [] ->
+      aggregate (List.rev checked_claims) (List.rev checked_verdicts)
+    | claim :: rest ->
+      let verdict = verdict_of_claim deps claim in
+      (match verdict with
+       | Transient_inconclusive reason ->
+         Inconclusive { reason; transient = true }
+       | Satisfied | Unsatisfied _ | Hard_inconclusive _ ->
+         loop (claim :: checked_claims) (verdict :: checked_verdicts) rest)
+  in
+  loop [] [] claims

--- a/lib/cdal/deterministic_evidence_evaluator.ml
+++ b/lib/cdal/deterministic_evidence_evaluator.ml
@@ -1,0 +1,198 @@
+type evaluation_result =
+  | All_satisfied
+  | Partial of
+      { satisfied : Evidence_claim.t list
+      ; missing : Evidence_claim.t list
+      }
+  | Inconclusive of
+      { reason : string
+      ; transient : bool
+      }
+
+type pr_check_result =
+  [ `Merged of string
+  | `Open
+  | `Closed_unmerged
+  | `Not_found
+  ]
+
+type ci_check_result =
+  [ `All_pass
+  | `Any_fail of string list
+  | `In_progress
+  | `Not_found
+  ]
+
+type exec_result =
+  [ `Exit of int
+  | `Timeout
+  | `Spawn_error of string
+  ]
+
+type file_stat_result =
+  [ `Exists of int
+  | `Missing
+  ]
+
+type custom_check_result =
+  [ `Satisfied
+  | `Unsatisfied of string
+  | `Unknown_id
+  ]
+
+type evaluator_deps =
+  { gh_pr_check : repo:string -> pr_number:int -> pr_check_result
+  ; gh_ci_check : repo:string -> pr_number:int -> ci_check_result
+  ; exec_command : command:string -> timeout_sec:int -> exec_result
+  ; file_stat : path:string -> file_stat_result
+  ; custom_check :
+      id:string -> payload:Yojson.Safe.t -> custom_check_result
+  }
+
+(** Per-claim verdict used internally before aggregation. *)
+type claim_verdict =
+  | Satisfied
+  | Unsatisfied of string  (** human-readable reason kept for [Partial.missing] formatting *)
+  | Transient_inconclusive of string
+  | Hard_inconclusive of string
+
+let check_pr_merged (deps : evaluator_deps) ~repo ~pr_number =
+  match deps.gh_pr_check ~repo ~pr_number with
+  | `Merged _ -> Satisfied
+  | `Open ->
+    Transient_inconclusive
+      (Printf.sprintf "%s#%d is open, not yet merged" repo pr_number)
+  | `Closed_unmerged ->
+    Unsatisfied (Printf.sprintf "%s#%d is closed without merge" repo pr_number)
+  | `Not_found ->
+    Hard_inconclusive
+      (Printf.sprintf "%s#%d not found via gh_pr_check" repo pr_number)
+
+let check_ci_pass (deps : evaluator_deps) ~repo ~pr_number =
+  match deps.gh_ci_check ~repo ~pr_number with
+  | `All_pass -> Satisfied
+  | `In_progress ->
+    Transient_inconclusive
+      (Printf.sprintf "%s#%d CI checks still in progress" repo pr_number)
+  | `Any_fail failing ->
+    Unsatisfied
+      (Printf.sprintf
+         "%s#%d CI fails: %s"
+         repo
+         pr_number
+         (String.concat ", " failing))
+  | `Not_found ->
+    Hard_inconclusive
+      (Printf.sprintf "%s#%d not found via gh_ci_check" repo pr_number)
+
+let check_tests_pass (deps : evaluator_deps) ~command ~expected_exit =
+  match deps.exec_command ~command ~timeout_sec:300 with
+  | `Exit code when code = expected_exit -> Satisfied
+  | `Exit code ->
+    Unsatisfied
+      (Printf.sprintf
+         "command %S exited %d (expected %d)"
+         command
+         code
+         expected_exit)
+  | `Timeout ->
+    Transient_inconclusive
+      (Printf.sprintf "command %S timed out" command)
+  | `Spawn_error msg ->
+    Hard_inconclusive
+      (Printf.sprintf "command %S spawn failed: %s" command msg)
+
+let check_size_constraint ~path ~min_bytes ~observed =
+  match min_bytes with
+  | None -> Satisfied
+  | Some n when observed >= n -> Satisfied
+  | Some n ->
+    Unsatisfied
+      (Printf.sprintf
+         "%s is %d bytes (< required %d)"
+         path
+         observed
+         n)
+
+let check_artifact_exists (deps : evaluator_deps) ~path ~min_bytes =
+  match deps.file_stat ~path with
+  | `Exists size -> check_size_constraint ~path ~min_bytes ~observed:size
+  | `Missing -> Unsatisfied (Printf.sprintf "%s does not exist" path)
+
+let check_file_changed (deps : evaluator_deps) ~path ~min_bytes =
+  (* Phase B: same shape as Artifact_exists; semantic distinction
+     (changed vs. exists) is enforced at task-creation time, not by
+     re-reading git history during evaluation. Phase C may add a
+     [git_diff] dep for stricter "changed" detection. *)
+  check_artifact_exists deps ~path ~min_bytes
+
+let check_custom (deps : evaluator_deps) ~id ~payload =
+  match deps.custom_check ~id ~payload with
+  | `Satisfied -> Satisfied
+  | `Unsatisfied reason ->
+    Unsatisfied (Printf.sprintf "custom_check(%s): %s" id reason)
+  | `Unknown_id ->
+    Hard_inconclusive
+      (Printf.sprintf "custom_check id %S not in evaluator allowlist" id)
+
+let verdict_of_claim (deps : evaluator_deps) (claim : Evidence_claim.t) =
+  match claim with
+  | PR_merged { repo; pr_number } -> check_pr_merged deps ~repo ~pr_number
+  | CI_pass { repo; pr_number } -> check_ci_pass deps ~repo ~pr_number
+  | Tests_pass { command; expected_exit } ->
+    check_tests_pass deps ~command ~expected_exit
+  | Artifact_exists { path; min_bytes } ->
+    check_artifact_exists deps ~path ~min_bytes
+  | File_changed { path; min_bytes } ->
+    check_file_changed deps ~path ~min_bytes
+  | Custom_check { id; payload } -> check_custom deps ~id ~payload
+
+(** Aggregate per-claim verdicts. Transient inconclusive wins over
+    everything (callers retry before treating as failure). Hard
+    inconclusive wins over Partial (gate blocks on protocol error).
+    Otherwise Satisfied-only → All_satisfied; mixed → Partial. *)
+let aggregate (claims : Evidence_claim.t list) (verdicts : claim_verdict list) =
+  let paired = List.combine claims verdicts in
+  let transient =
+    List.find_map
+      (fun (_, v) ->
+        match v with
+        | Transient_inconclusive r -> Some r
+        | Satisfied | Unsatisfied _ | Hard_inconclusive _ -> None)
+      paired
+  in
+  match transient with
+  | Some reason -> Inconclusive { reason; transient = true }
+  | None ->
+    let hard =
+      List.find_map
+        (fun (_, v) ->
+          match v with
+          | Hard_inconclusive r -> Some r
+          | Satisfied | Unsatisfied _ | Transient_inconclusive _ -> None)
+        paired
+    in
+    (match hard with
+     | Some reason -> Inconclusive { reason; transient = false }
+     | None ->
+       let satisfied, missing =
+         List.partition_map
+           (fun (claim, v) ->
+             match v with
+             | Satisfied -> Left claim
+             | Unsatisfied _ -> Right claim
+             | Transient_inconclusive _ | Hard_inconclusive _ ->
+               (* unreachable: filtered above *)
+               Right claim)
+           paired
+       in
+       (match missing with
+        | [] -> All_satisfied
+        | _ :: _ -> Partial { satisfied; missing }))
+
+let evaluate ~deps ~claims =
+  match claims with
+  | [] -> All_satisfied
+  | _ :: _ ->
+    let verdicts = List.map (verdict_of_claim deps) claims in
+    aggregate claims verdicts

--- a/lib/cdal/deterministic_evidence_evaluator.mli
+++ b/lib/cdal/deterministic_evidence_evaluator.mli
@@ -1,0 +1,97 @@
+(** Deterministic_evidence_evaluator — RFC-0199 Phase B.
+
+    Pure evaluator that takes a list of [Evidence_claim.t] (RFC-0199
+    Phase A) and an injected dependency record, then returns a typed
+    [evaluation_result] consumable by [Cdal_evidence_gate] (RFC-0109).
+
+    Boundary: all side effects (HTTP, exec, fs) are passed in via
+    [evaluator_deps]. The evaluator itself is pure — tests inject stubs,
+    production wires real implementations. Phase B ships the evaluator
+    only; Phase C wires production deps and the transition hook.
+
+    Anti-pattern guards (RFC-0088):
+    - Closed-sum [evaluation_result] forces exhaustive match in every
+      consumer (warning 4 = error).
+    - No counter-only branch: every code path returns a decision, a
+      retry signal, or an inconclusive verdict with a structured reason.
+    - No string classifier: dep return shapes are typed polymorphic
+      variants, not free-form strings.
+
+    @since RFC-0199 Phase B (2026-05-27) *)
+
+type evaluation_result =
+  | All_satisfied
+  | Partial of
+      { satisfied : Evidence_claim.t list
+      ; missing : Evidence_claim.t list
+      }
+    (** At least one claim failed (not transient). [satisfied] +
+        [missing] together cover the input claims; order preserved from
+        the input. *)
+  | Inconclusive of
+      { reason : string
+      ; transient : bool
+      }
+    (** Cannot decide right now. [transient = true] = backoff retry
+        (CI in progress, network glitch); [transient = false] = block
+        the gate (missing repo, malformed claim). *)
+
+(** Result of a single dep call. Closed-sum so consumers cannot
+    silently swallow an unrecognised state. *)
+
+type pr_check_result =
+  [ `Merged of string  (** ISO8601 mergedAt timestamp *)
+  | `Open
+  | `Closed_unmerged
+  | `Not_found
+  ]
+
+type ci_check_result =
+  [ `All_pass
+  | `Any_fail of string list  (** failing check names *)
+  | `In_progress
+  | `Not_found
+  ]
+
+type exec_result =
+  [ `Exit of int
+  | `Timeout
+  | `Spawn_error of string
+  ]
+
+type file_stat_result =
+  [ `Exists of int  (** byte size *)
+  | `Missing
+  ]
+
+type custom_check_result =
+  [ `Satisfied
+  | `Unsatisfied of string  (** human-readable reason *)
+  | `Unknown_id  (** evaluator does not recognise [id] (allowlist miss) *)
+  ]
+
+(** Injected dependencies. Production wires real gh / exec / unix
+    implementations; tests inject deterministic stubs. *)
+type evaluator_deps =
+  { gh_pr_check : repo:string -> pr_number:int -> pr_check_result
+  ; gh_ci_check : repo:string -> pr_number:int -> ci_check_result
+  ; exec_command : command:string -> timeout_sec:int -> exec_result
+  ; file_stat : path:string -> file_stat_result
+  ; custom_check :
+      id:string -> payload:Yojson.Safe.t -> custom_check_result
+  }
+
+val evaluate :
+  deps:evaluator_deps -> claims:Evidence_claim.t list -> evaluation_result
+(** Evaluate all claims and aggregate. Decision rules:
+
+    - Empty [claims] → [All_satisfied] (no requirement = trivially met)
+    - All claims satisfied → [All_satisfied]
+    - At least one transient inconclusive → [Inconclusive { transient = true; ... }]
+      (transient wins over non-transient so callers retry before giving up)
+    - At least one non-transient inconclusive → [Inconclusive { transient = false; ... }]
+    - Otherwise → [Partial { satisfied; missing }]
+
+    Order: claims are evaluated in input order. Short-circuit only on
+    transient inconclusive (cost saving for slow deps); otherwise all
+    claims are checked so [Partial.missing] is complete. *)

--- a/lib/cdal/dune
+++ b/lib/cdal/dune
@@ -23,5 +23,6 @@
   masc_core
   masc_mcp.config
   masc_mcp.masc_exec
+  masc_mcp.masc_types
   masc_mcp.dated_jsonl
   masc_mcp.cdal_runtime))

--- a/test/dune
+++ b/test/dune
@@ -812,6 +812,7 @@
   test_keeper_prompt_external
   test_keeper_recurring
   test_evidence_claim_schema
+  test_deterministic_evidence_evaluator
   test_verification_fsm
   test_governance_yojson_roundtrip
   test_eval_calibration
@@ -1011,6 +1012,7 @@
   test_keeper_prompt_external
   test_keeper_recurring
   test_evidence_claim_schema
+  test_deterministic_evidence_evaluator
   test_verification_fsm
   test_governance_yojson_roundtrip
   test_eval_calibration

--- a/test/test_deterministic_evidence_evaluator.ml
+++ b/test/test_deterministic_evidence_evaluator.ml
@@ -1,0 +1,244 @@
+(** RFC-0199 Phase B unit tests for [Deterministic_evidence_evaluator].
+
+    Stub deps cover all 6 evidence variants × success / fail / transient
+    paths. Aggregation rules pinned (transient > hard > partial >
+    all_satisfied). *)
+
+open Alcotest
+module E = Evidence_claim
+module DEE = Deterministic_evidence_evaluator
+
+(* ── default stub: every check is satisfied ───────────────────────── *)
+let stub_all_pass : DEE.evaluator_deps =
+  { gh_pr_check =
+      (fun ~repo:_ ~pr_number:_ -> `Merged "2026-05-27T00:00:00Z")
+  ; gh_ci_check = (fun ~repo:_ ~pr_number:_ -> `All_pass)
+  ; exec_command = (fun ~command:_ ~timeout_sec:_ -> `Exit 0)
+  ; file_stat = (fun ~path:_ -> `Exists 4096)
+  ; custom_check = (fun ~id:_ ~payload:_ -> `Satisfied)
+  }
+
+let assert_all_satisfied result =
+  match result with
+  | DEE.All_satisfied -> ()
+  | DEE.Partial _ -> fail "expected All_satisfied, got Partial"
+  | DEE.Inconclusive { reason; transient } ->
+    fail
+      (Printf.sprintf
+         "expected All_satisfied, got Inconclusive(transient=%b, %s)"
+         transient
+         reason)
+
+let assert_partial ~expected_missing result =
+  match result with
+  | DEE.All_satisfied -> fail "expected Partial, got All_satisfied"
+  | DEE.Partial { missing; _ } ->
+    check int "missing count" expected_missing (List.length missing)
+  | DEE.Inconclusive _ -> fail "expected Partial, got Inconclusive"
+
+let assert_transient ~contains result =
+  match result with
+  | DEE.Inconclusive { transient = true; reason } ->
+    if not (Astring.String.is_infix ~affix:contains reason) then
+      fail
+        (Printf.sprintf
+           "transient reason %S does not contain %S"
+           reason
+           contains)
+  | DEE.Inconclusive { transient = false; reason } ->
+    fail
+      (Printf.sprintf "expected transient, got hard inconclusive: %s" reason)
+  | _ -> fail "expected Inconclusive transient"
+
+let assert_hard ~contains result =
+  match result with
+  | DEE.Inconclusive { transient = false; reason } ->
+    if not (Astring.String.is_infix ~affix:contains reason) then
+      fail
+        (Printf.sprintf "hard reason %S does not contain %S" reason contains)
+  | DEE.Inconclusive { transient = true; reason } ->
+    fail
+      (Printf.sprintf "expected hard, got transient inconclusive: %s" reason)
+  | _ -> fail "expected Inconclusive hard"
+
+(* ── empty + all-pass baseline ────────────────────────────────────── *)
+let test_empty_claims_satisfied () =
+  assert_all_satisfied (DEE.evaluate ~deps:stub_all_pass ~claims:[])
+
+let test_all_satisfied_six_variants () =
+  let claims =
+    [ E.PR_merged { repo = "o/r"; pr_number = 1 }
+    ; E.CI_pass { repo = "o/r"; pr_number = 1 }
+    ; E.Tests_pass { command = "true"; expected_exit = 0 }
+    ; E.Artifact_exists { path = "/a"; min_bytes = Some 1024 }
+    ; E.File_changed { path = "/b"; min_bytes = None }
+    ; E.Custom_check { id = "lint_clean"; payload = `Null }
+    ]
+  in
+  assert_all_satisfied (DEE.evaluate ~deps:stub_all_pass ~claims)
+
+(* ── PR_merged ────────────────────────────────────────────────────── *)
+let test_pr_open_is_transient () =
+  let deps =
+    { stub_all_pass with gh_pr_check = (fun ~repo:_ ~pr_number:_ -> `Open) }
+  in
+  let claims = [ E.PR_merged { repo = "o/r"; pr_number = 99 } ] in
+  assert_transient ~contains:"is open" (DEE.evaluate ~deps ~claims)
+
+let test_pr_closed_unmerged_is_partial () =
+  let deps =
+    { stub_all_pass with
+      gh_pr_check = (fun ~repo:_ ~pr_number:_ -> `Closed_unmerged)
+    }
+  in
+  let claims = [ E.PR_merged { repo = "o/r"; pr_number = 99 } ] in
+  assert_partial ~expected_missing:1 (DEE.evaluate ~deps ~claims)
+
+let test_pr_not_found_is_hard () =
+  let deps =
+    { stub_all_pass with
+      gh_pr_check = (fun ~repo:_ ~pr_number:_ -> `Not_found)
+    }
+  in
+  let claims = [ E.PR_merged { repo = "o/r"; pr_number = 99 } ] in
+  assert_hard ~contains:"not found" (DEE.evaluate ~deps ~claims)
+
+(* ── CI_pass ──────────────────────────────────────────────────────── *)
+let test_ci_in_progress_is_transient () =
+  let deps =
+    { stub_all_pass with
+      gh_ci_check = (fun ~repo:_ ~pr_number:_ -> `In_progress)
+    }
+  in
+  let claims = [ E.CI_pass { repo = "o/r"; pr_number = 1 } ] in
+  assert_transient ~contains:"in progress" (DEE.evaluate ~deps ~claims)
+
+let test_ci_failing_is_partial () =
+  let deps =
+    { stub_all_pass with
+      gh_ci_check =
+        (fun ~repo:_ ~pr_number:_ -> `Any_fail [ "build"; "lint" ])
+    }
+  in
+  let claims = [ E.CI_pass { repo = "o/r"; pr_number = 1 } ] in
+  assert_partial ~expected_missing:1 (DEE.evaluate ~deps ~claims)
+
+(* ── Tests_pass ────────────────────────────────────────────────────── *)
+let test_tests_exit_mismatch_is_partial () =
+  let deps =
+    { stub_all_pass with
+      exec_command = (fun ~command:_ ~timeout_sec:_ -> `Exit 1)
+    }
+  in
+  let claims = [ E.Tests_pass { command = "dune test"; expected_exit = 0 } ] in
+  assert_partial ~expected_missing:1 (DEE.evaluate ~deps ~claims)
+
+let test_tests_timeout_is_transient () =
+  let deps =
+    { stub_all_pass with
+      exec_command = (fun ~command:_ ~timeout_sec:_ -> `Timeout)
+    }
+  in
+  let claims = [ E.Tests_pass { command = "dune test"; expected_exit = 0 } ] in
+  assert_transient ~contains:"timed out" (DEE.evaluate ~deps ~claims)
+
+(* ── Artifact_exists ──────────────────────────────────────────────── *)
+let test_artifact_missing_is_partial () =
+  let deps =
+    { stub_all_pass with file_stat = (fun ~path:_ -> `Missing) }
+  in
+  let claims = [ E.Artifact_exists { path = "/x"; min_bytes = None } ] in
+  assert_partial ~expected_missing:1 (DEE.evaluate ~deps ~claims)
+
+let test_artifact_too_small_is_partial () =
+  let deps =
+    { stub_all_pass with file_stat = (fun ~path:_ -> `Exists 100) }
+  in
+  let claims =
+    [ E.Artifact_exists { path = "/x"; min_bytes = Some 1024 } ]
+  in
+  assert_partial ~expected_missing:1 (DEE.evaluate ~deps ~claims)
+
+(* ── Custom_check ─────────────────────────────────────────────────── *)
+let test_custom_unknown_id_is_hard () =
+  let deps =
+    { stub_all_pass with
+      custom_check = (fun ~id:_ ~payload:_ -> `Unknown_id)
+    }
+  in
+  let claims =
+    [ E.Custom_check { id = "no_such_check"; payload = `Null } ]
+  in
+  assert_hard ~contains:"allowlist" (DEE.evaluate ~deps ~claims)
+
+(* ── Aggregation: transient > hard > partial ──────────────────────── *)
+let test_transient_wins_over_partial () =
+  let deps =
+    { stub_all_pass with
+      gh_pr_check = (fun ~repo:_ ~pr_number:_ -> `Open)
+    ; file_stat = (fun ~path:_ -> `Missing)
+    }
+  in
+  let claims =
+    [ E.PR_merged { repo = "o/r"; pr_number = 1 }
+    ; E.Artifact_exists { path = "/x"; min_bytes = None }
+    ]
+  in
+  (* Open PR is transient; missing artifact would be Partial. Transient
+     wins so caller retries before treating as a hard failure. *)
+  assert_transient ~contains:"is open" (DEE.evaluate ~deps ~claims)
+
+let test_hard_wins_over_partial () =
+  let deps =
+    { stub_all_pass with
+      gh_pr_check = (fun ~repo:_ ~pr_number:_ -> `Not_found)
+    ; file_stat = (fun ~path:_ -> `Missing)
+    }
+  in
+  let claims =
+    [ E.PR_merged { repo = "o/r"; pr_number = 1 }
+    ; E.Artifact_exists { path = "/x"; min_bytes = None }
+    ]
+  in
+  assert_hard ~contains:"not found" (DEE.evaluate ~deps ~claims)
+
+let () =
+  Alcotest.run
+    "deterministic_evidence_evaluator"
+    [ ( "baseline"
+      , [ test_case "empty claims → All_satisfied" `Quick
+            test_empty_claims_satisfied
+        ; test_case "6 variants all satisfied" `Quick
+            test_all_satisfied_six_variants
+        ] )
+    ; ( "pr_merged"
+      , [ test_case "Open → transient" `Quick test_pr_open_is_transient
+        ; test_case "Closed_unmerged → partial" `Quick
+            test_pr_closed_unmerged_is_partial
+        ; test_case "Not_found → hard" `Quick test_pr_not_found_is_hard
+        ] )
+    ; ( "ci_pass"
+      , [ test_case "In_progress → transient" `Quick
+            test_ci_in_progress_is_transient
+        ; test_case "Any_fail → partial" `Quick test_ci_failing_is_partial
+        ] )
+    ; ( "tests_pass"
+      , [ test_case "exit mismatch → partial" `Quick
+            test_tests_exit_mismatch_is_partial
+        ; test_case "Timeout → transient" `Quick test_tests_timeout_is_transient
+        ] )
+    ; ( "artifact_exists"
+      , [ test_case "Missing → partial" `Quick test_artifact_missing_is_partial
+        ; test_case "too small → partial" `Quick
+            test_artifact_too_small_is_partial
+        ] )
+    ; ( "custom_check"
+      , [ test_case "Unknown_id → hard" `Quick test_custom_unknown_id_is_hard
+        ] )
+    ; ( "aggregation"
+      , [ test_case "transient wins over partial" `Quick
+            test_transient_wins_over_partial
+        ; test_case "hard wins over partial" `Quick test_hard_wins_over_partial
+        ] )
+    ]
+;;

--- a/test/test_deterministic_evidence_evaluator.ml
+++ b/test/test_deterministic_evidence_evaluator.ml
@@ -123,6 +123,15 @@ let test_ci_failing_is_partial () =
   let claims = [ E.CI_pass { repo = "o/r"; pr_number = 1 } ] in
   assert_partial ~expected_missing:1 (DEE.evaluate ~deps ~claims)
 
+let test_ci_not_found_is_hard () =
+  let deps =
+    { stub_all_pass with
+      gh_ci_check = (fun ~repo:_ ~pr_number:_ -> `Not_found)
+    }
+  in
+  let claims = [ E.CI_pass { repo = "o/r"; pr_number = 1 } ] in
+  assert_hard ~contains:"not found" (DEE.evaluate ~deps ~claims)
+
 (* ── Tests_pass ────────────────────────────────────────────────────── *)
 let test_tests_exit_mismatch_is_partial () =
   let deps =
@@ -141,6 +150,16 @@ let test_tests_timeout_is_transient () =
   in
   let claims = [ E.Tests_pass { command = "dune test"; expected_exit = 0 } ] in
   assert_transient ~contains:"timed out" (DEE.evaluate ~deps ~claims)
+
+let test_tests_spawn_error_is_hard () =
+  let deps =
+    { stub_all_pass with
+      exec_command =
+        (fun ~command:_ ~timeout_sec:_ -> `Spawn_error "permission denied")
+    }
+  in
+  let claims = [ E.Tests_pass { command = "dune test"; expected_exit = 0 } ] in
+  assert_hard ~contains:"spawn failed" (DEE.evaluate ~deps ~claims)
 
 (* ── Artifact_exists ──────────────────────────────────────────────── *)
 let test_artifact_missing_is_partial () =
@@ -170,6 +189,24 @@ let test_custom_unknown_id_is_hard () =
     [ E.Custom_check { id = "no_such_check"; payload = `Null } ]
   in
   assert_hard ~contains:"allowlist" (DEE.evaluate ~deps ~claims)
+
+let test_custom_unsatisfied_is_partial () =
+  let deps =
+    { stub_all_pass with
+      custom_check = (fun ~id:_ ~payload:_ -> `Unsatisfied "not clean")
+    }
+  in
+  let claim = E.Custom_check { id = "lint_clean"; payload = `Null } in
+  match DEE.evaluate ~deps ~claims:[ claim ] with
+  | DEE.Partial { missing = [ E.Custom_check { id; _ } ]; _ } ->
+    check string "missing custom id" "lint_clean" id
+  | DEE.Partial { missing; _ } ->
+    fail
+      (Printf.sprintf
+         "expected one missing custom claim, got %d"
+         (List.length missing))
+  | DEE.All_satisfied -> fail "expected Partial, got All_satisfied"
+  | DEE.Inconclusive _ -> fail "expected Partial, got Inconclusive"
 
 (* ── Aggregation: transient > hard > partial ──────────────────────── *)
 let test_transient_wins_over_partial () =
@@ -202,6 +239,25 @@ let test_hard_wins_over_partial () =
   in
   assert_hard ~contains:"not found" (DEE.evaluate ~deps ~claims)
 
+let test_transient_short_circuits_slow_deps () =
+  let file_stat_called = ref false in
+  let deps =
+    { stub_all_pass with
+      gh_pr_check = (fun ~repo:_ ~pr_number:_ -> `Open)
+    ; file_stat =
+        (fun ~path:_ ->
+          file_stat_called := true;
+          `Missing)
+    }
+  in
+  let claims =
+    [ E.PR_merged { repo = "o/r"; pr_number = 1 }
+    ; E.Artifact_exists { path = "/x"; min_bytes = None }
+    ]
+  in
+  assert_transient ~contains:"is open" (DEE.evaluate ~deps ~claims);
+  check bool "slow dep not called after transient" false !file_stat_called
+
 let () =
   Alcotest.run
     "deterministic_evidence_evaluator"
@@ -221,11 +277,14 @@ let () =
       , [ test_case "In_progress → transient" `Quick
             test_ci_in_progress_is_transient
         ; test_case "Any_fail → partial" `Quick test_ci_failing_is_partial
+        ; test_case "Not_found → hard" `Quick test_ci_not_found_is_hard
         ] )
     ; ( "tests_pass"
       , [ test_case "exit mismatch → partial" `Quick
             test_tests_exit_mismatch_is_partial
         ; test_case "Timeout → transient" `Quick test_tests_timeout_is_transient
+        ; test_case "Spawn_error → hard" `Quick
+            test_tests_spawn_error_is_hard
         ] )
     ; ( "artifact_exists"
       , [ test_case "Missing → partial" `Quick test_artifact_missing_is_partial
@@ -234,11 +293,15 @@ let () =
         ] )
     ; ( "custom_check"
       , [ test_case "Unknown_id → hard" `Quick test_custom_unknown_id_is_hard
+        ; test_case "Unsatisfied → partial" `Quick
+            test_custom_unsatisfied_is_partial
         ] )
     ; ( "aggregation"
       , [ test_case "transient wins over partial" `Quick
             test_transient_wins_over_partial
         ; test_case "hard wins over partial" `Quick test_hard_wins_over_partial
+        ; test_case "transient short-circuits slow deps" `Quick
+            test_transient_short_circuits_slow_deps
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

RFC-0199 Phase B. Pure `Deterministic_evidence_evaluator` consuming `Evidence_claim.t list` (Phase A #19157) + injected `evaluator_deps`. Returns typed `evaluation_result` (`All_satisfied` / `Partial` / `Inconclusive`). No side effects — all gh/exec/fs deps injected so test stubs and production wiring (Phase C) share the same contract.

## Per-claim verdict path (closed-sum, `-w +4` enforced)

| `Evidence_claim` | dep | possible results |
|---|---|---|
| `PR_merged` | `gh_pr_check` | `Merged \| Open \| Closed_unmerged \| Not_found` |
| `CI_pass` | `gh_ci_check` | `All_pass \| Any_fail \| In_progress \| Not_found` |
| `Tests_pass` | `exec_command` | `Exit \| Timeout \| Spawn_error` |
| `Artifact_exists` | `file_stat` | `Exists size \| Missing` + min_bytes guard |
| `File_changed` | `file_stat` | same as Artifact in Phase B; `git_diff` dep deferred to Phase C |
| `Custom_check` | `custom_check` | `Satisfied \| Unsatisfied \| Unknown_id` |

## Aggregation precedence

`Transient inconclusive > Hard inconclusive > Partial > All_satisfied`

- Transient (CI in progress, exec timeout, PR open) → caller retries before treating as failure
- Hard (Not_found, Spawn_error, Unknown custom id) → gate blocks
- Partial → verifier sees structured `missing[]` without losing satisfied claims

## RFC alignment

- ✅ Pure function — side effects injected via record
- ✅ Closed sum `evaluation_result` + closed-sum dep result types
- ✅ Aggregation rules pinned with 2 explicit precedence tests
- ✅ `Custom_check` typed `id` + `payload : Yojson.Safe.t` (allowlist enforced at evaluator boundary, not at schema)
- ✅ 6 evidence kinds *all* implemented in this PR (no N-of-M anti-pattern)
- ❌ Production deps wiring — **Phase C** (gh CLI exec via masc_exec, file_stat via Unix, sandboxed exec_command); intentionally deferred

## Test plan

- [x] `dune build lib test` PASS
- [ ] `dune exec test/test_deterministic_evidence_evaluator.exe` — 16 test (lock contention 으로 local 보류, CI 위임)
- [ ] CI green
- [ ] Reviewer 검토 후 Phase C 시작

16 tests cover:
- baseline: empty claims → All_satisfied / 6 variants all-pass
- per-variant: every result state from each dep
- aggregation: `transient > partial`, `hard > partial`

## Workaround Signature Gate

비해당:
- ❌ Counter-as-Fix — every branch returns a typed decision
- ❌ String 분류기 — dep results are typed polymorphic variants
- ❌ N-of-M — 6 evidence kinds all in one PR
- ❌ cap/cooldown/dedup/repair — transient retry is *typed result*, not magic timeout

## Related

- RFC #19132 (Draft, body)
- Phase A #19157 (merged) — `Evidence_claim` + `task_contract.required_evidence_typed`
- RFC-0109 — `Cdal_evidence_gate` (Phase C will emit verdicts here)
- Tracking issue #19129

🤖 Generated with [Claude Code](https://claude.com/claude-code)
