### PR TITLE
docs: align keeper web tool prompts

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -86,7 +86,7 @@ Decide what to do based on the current world state below.
 ### Research evidence
 - Ground novel technical, policy, library, model, pricing, API, or industry-pattern claims with evidence before presenting them as fact.
 - Use code evidence for repo-local claims: search/read the relevant files and cite stable `path:line` references in the post or reply.
-- Use web evidence for external or current claims: call `masc_web_search` to find sources, then call `masc_web_fetch` to read the selected source before citing it.
+- Use web evidence for external or current claims: call `SearchWeb` to find sources, then call `FetchWeb` to read the selected source before citing it.
 - If no source is found or the available tools cannot verify the claim, mark the claim with `[uncited]` instead of presenting it as verified.
 - When posting research-backed findings to the board, include a `sources` array on `keeper_board_post`/`masc_board_post` with `{url, quote}` entries. The board will persist those sources in metadata and append a Sources footer.
 
@@ -104,7 +104,7 @@ Use extend_turns only when a single coherent action genuinely requires more step
 - Respond to board activity (`keeper_board_comment`, if available)
 - Search knowledge library (`keeper_library_search` / `keeper_library_read`, if available)
 - Run shell commands to investigate (`Execute { executable: "git", argv: ["log", "--oneline", "-10"], cwd: "repos/REPO" }`, if available)
-- Search the web (`masc_web_search`) for tech context or documentation, then fetch (`masc_web_fetch`) selected pages before citing
+- Search the web (`SearchWeb`) for tech context or documentation, then fetch (`FetchWeb`) selected pages before citing
 - Recall past context (`keeper_memory_search`, if available) before repeating past work
 - Search code patterns (`SearchFiles { pattern: "regex", path: "lib", type: "ml" }`, if available)
 - Audit failed tasks (`keeper_tasks_audit`, if available) before deciding there is nothing to do

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -86,7 +86,7 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | Workflow | Primary tools |
 |----------|---------------|
 | 의견 내기 / 토론 참여 | `keeper_board_post`, `keeper_board_comment` |
-| 최신 정보 / 외부 자료 확인 | `masc_web_search` (also exposed to model clients as `SearchWeb`) |
+| 최신 정보 / 외부 자료 확인 | `SearchWeb` -> `FetchWeb` |
 | 찬성 / 반대 신호 | `keeper_board_vote` |
 | 거버넌스 의견 제출 | retired as keeper tools; use board discussion/vote paths and governance dashboard read models |
 | 목표 / 계획 lifecycle | `masc_goal_list`, `masc_goal_upsert`, `masc_goal_transition`, `masc_goal_verify` |

--- a/docs/design/tool-execution-substrate-plan.html
+++ b/docs/design/tool-execution-substrate-plan.html
@@ -635,10 +635,10 @@
             <td><code>bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail</code>, focused source-test build, and targeted case <code>test source_guard 28</code>.</td>
           </tr>
           <tr>
-            <td><span class="status next">PR-C</span> Prompt alignment</td>
+            <td><span class="status done">PR-C</span> Prompt alignment</td>
             <td>Stop keeper prompts from suggesting stale names.</td>
-            <td>Normalize keeper prompts to <code>SearchWeb</code>, <code>FetchWeb</code>, <code>SearchFiles</code>, <code>ReadFile</code>, <code>EditFile</code>, <code>WriteFile</code>, <code>Execute</code>.</td>
-            <td><code>scripts/dune-local.sh build test/test_keeper_tool_alias.exe test/test_keeper_tool_matrix.exe</code></td>
+            <td>Normalize keeper prompts to <code>SearchWeb</code>, <code>FetchWeb</code>, <code>SearchFiles</code>, <code>ReadFile</code>, <code>EditFile</code>, <code>WriteFile</code>, <code>Execute</code>, with an active-surface guard against keeper-facing <code>masc_web_*</code> names.</td>
+            <td><code>bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail</code>, focused source-test build, targeted case <code>test source_guard 28</code>, and focused alias/matrix build.</td>
           </tr>
           <tr>
             <td><span class="status done">PR-C.1</span> Claim lock contention</td>

--- a/docs/design/tool-execution-substrate-plan.md
+++ b/docs/design/tool-execution-substrate-plan.md
@@ -266,6 +266,9 @@ scripts/dune-local.sh build test/test_ci_hardening_source.exe
 
 ### PR-C: Prompt and Matrix Alignment
 
+Status: implemented in this PR for keeper-facing web aliases and protected by
+the active-surface lint/source guard.
+
 Normalize keeper-facing prompts to the active public names:
 
 - `SearchWeb`
@@ -284,6 +287,9 @@ should not ask keepers to call `masc_web_search` when the active public alias is
 Validation:
 
 ```bash
+bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail
+scripts/dune-local.sh build test/test_ci_hardening_source.exe
+./_build/default/test/test_ci_hardening_source.exe test source_guard 28
 scripts/dune-local.sh build test/test_keeper_tool_alias.exe test/test_keeper_tool_matrix.exe
 ```
 

--- a/scripts/lint/no-tool-substrate-adapter-surface.sh
+++ b/scripts/lint/no-tool-substrate-adapter-surface.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# Guard the Keeper tool execution substrate against two regressions:
+# Guard the Keeper tool execution substrate against three regressions:
 #
 #   1. Descriptor executor variants that turn gh/git/OAS bridge adapters into
 #      first-class tool concepts. Those belong behind Shell_ir or runtime
 #      plumbing, not in the descriptor executor enum.
 #   2. GitHub/PR micro-tool names returning to active descriptor, prompt,
 #      policy, or capability-matrix surfaces.
+#   3. Internal web MCP names appearing in keeper-facing prompts or workflow
+#      guidance where the model-facing aliases are SearchWeb / FetchWeb.
 #
 # The scan is intentionally narrow. It does not scan timeout/runtime plumbing
 # such as Timeout_policy.Layer.Oas_bridge, and it does not scan dashboard
@@ -59,12 +61,18 @@ SURFACE_SCAN_FILES=(
   "docs/KEEPER-USER-MANUAL.md"
 )
 
+KEEPER_PROMPT_SCAN_FILES=(
+  "docs/KEEPER-CAPABILITY-MATRIX.md"
+)
+
 while IFS= read -r prompt_file; do
   SURFACE_SCAN_FILES+=("$prompt_file")
+  KEEPER_PROMPT_SCAN_FILES+=("$prompt_file")
 done < <(find config/prompts -type f | sort)
 
 EXECUTOR_PATTERN='\b(Gh_cli|Git_cli|Oas_bridge)\b'
 MICRO_TOOL_PATTERN='\b(pr_comment|pr_review|pr_close|gh_pr|gh_commit|github_comment|github_pr|keeper_pr_[A-Za-z0-9_]*|github_pr_[A-Za-z0-9_]*)\b'
+INTERNAL_WEB_TOOL_PATTERN='\b(masc_web_search|masc_web_fetch)\b'
 
 current_tmp="$(mktemp -t tool-substrate-adapter-surface.current.XXXXXX)"
 allow_tmp="$(mktemp -t tool-substrate-adapter-surface.allow.XXXXXX)"
@@ -92,6 +100,7 @@ scan_pattern() {
 {
   scan_pattern "executor_adapter" "$EXECUTOR_PATTERN" "${EXECUTOR_SCAN_FILES[@]}"
   scan_pattern "micro_tool" "$MICRO_TOOL_PATTERN" "${SURFACE_SCAN_FILES[@]}"
+  scan_pattern "internal_web_tool" "$INTERNAL_WEB_TOOL_PATTERN" "${KEEPER_PROMPT_SCAN_FILES[@]}"
 } | sort -u >"$current_tmp"
 
 if [[ -f "$ALLOWLIST" ]]; then
@@ -130,6 +139,7 @@ if [[ -s "$new_tmp" ]]; then
   sed 's/^/  - /' "$new_tmp" >&2
   echo "  Keep gh/git work behind Execute/Shell_ir, and model PR work as ordinary CLI/worktree operations." >&2
   echo "  Do not add dedicated PR/GitHub micro-tools to active descriptor, prompt, policy, or capability surfaces." >&2
+  echo "  Use SearchWeb / FetchWeb in keeper-facing prompts; keep masc_web_* names in MCP compatibility docs only." >&2
   fail=1
 fi
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1714,7 +1714,24 @@ let test_tool_execution_substrate_ratchet_contracts () =
      && file_not_contains_pattern "config/prompts/keeper.tool_hints.toml" "gh_commit"
      && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "pr_comment"
      && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "pr_review"
-     && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "gh_commit")
+     && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "gh_commit");
+  check bool "keeper-facing prompts use web aliases, not internal MCP web names" true
+    (file_not_contains_pattern "config/prompts/keeper.unified.system.md"
+       "masc_web_search"
+     && file_not_contains_pattern "config/prompts/keeper.unified.system.md"
+          "masc_web_fetch"
+     && file_not_contains_pattern "config/prompts/keeper.tool_hints.toml"
+          "masc_web_search"
+     && file_not_contains_pattern "config/prompts/keeper.tool_hints.toml"
+          "masc_web_fetch"
+     && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md"
+          "masc_web_search"
+     && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md"
+          "masc_web_fetch"
+     && file_contains_pattern "config/prompts/keeper.unified.system.md" "SearchWeb"
+     && file_contains_pattern "config/prompts/keeper.unified.system.md" "FetchWeb"
+     && file_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "SearchWeb"
+     && file_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "FetchWeb")
 
 let test_public_execute_guidance_contracts () =
   let raw_command prefix = "command='" ^ prefix in


### PR DESCRIPTION
## Summary

Implements PR-C from the Tool Execution Substrate plan on top of the current
stack: keeper-facing web guidance now uses `SearchWeb` / `FetchWeb` instead of
internal `masc_web_search` / `masc_web_fetch` names.

This PR is stacked on #19197. The older draft #19162 covers the same logical
slice from an earlier base and can be treated as superseded by this stack PR.

## Product impact

Keepers should stop being taught to call internal MCP web tool names when the
active model-facing aliases are `SearchWeb` and `FetchWeb`.

## Guardrails

- Extends `scripts/lint/no-tool-substrate-adapter-surface.sh` to reject
  keeper-facing `masc_web_*` names in prompts and the capability matrix.
- Adds a source-guard assertion that prompts/matrix contain `SearchWeb` and
  `FetchWeb` while avoiding the internal web MCP names.
- Updates the HTML/MD implementation report so PR-C is marked complete.

## Evidence

- `rg -n "masc_web_search|masc_web_fetch" config/prompts docs/KEEPER-CAPABILITY-MATRIX.md`
  returned no matches.
- `bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_ci_hardening_source.exe test/test_keeper_tool_alias.exe test/test_keeper_tool_matrix.exe`
- `./_build/default/test/test_ci_hardening_source.exe test source_guard 28`
- `./_build/default/test/test_keeper_tool_alias.exe`
- `opam exec -- ocamlformat --check test/test_ci_hardening_source.ml`
- `bash -n scripts/lint/no-tool-substrate-adapter-surface.sh`
- `python3 -m html.parser docs/design/tool-execution-substrate-plan.html`
- `git diff --check`

## Direct evidence

schema_version: 1
direct_ratio: 9/9
provenance: direct

## Review evidence

The source guard now checks both sides of the web alias contract: internal
`masc_web_search` / `masc_web_fetch` names are absent from keeper-facing
prompts and the capability matrix, while `SearchWeb` and `FetchWeb` remain
present in those surfaces.

## Linked issue

n/a

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`prompt-matrix-alignment-stack-20260527` → `dashboard-tool-success-view-20260527` · 1 commit(s) · synced 2026-05-27T14:32:28Z

| sha | subject | date |
|---|---|---|
| `c0834be48` | docs: align keeper web tool prompts | 2026-05-27 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->