### PR TITLE
refactor(status): drop playground PR history surface

### DIFF
--- a/dashboard/src/components/keeper-detail-comms.ts
+++ b/dashboard/src/components/keeper-detail-comms.ts
@@ -53,21 +53,6 @@ function isPlaygroundRepo(r: unknown): r is PlaygroundRepo {
     && typeof r.last_action === 'string'
 }
 
-interface PlaygroundPR {
-  pr_url: string
-  branch: string
-  title: string
-  draft: boolean
-}
-
-function isPlaygroundPR(r: unknown): r is PlaygroundPR {
-  if (!isRecord(r)) return false
-  return typeof r.pr_url === 'string'
-    && typeof r.branch === 'string'
-    && typeof r.title === 'string'
-    && typeof r.draft === 'boolean'
-}
-
 interface PlaygroundWorktree {
   name: string
   path: string
@@ -87,10 +72,9 @@ export function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
   if (!isRecord(execCtx)) return null
 
   const repos = (Array.isArray(execCtx.playground_repos) ? execCtx.playground_repos : []).filter(isPlaygroundRepo)
-  const prs = (Array.isArray(execCtx.pr_history) ? execCtx.pr_history : []).filter(isPlaygroundPR)
   const worktrees = (Array.isArray(execCtx.active_worktrees) ? execCtx.active_worktrees : []).filter(isPlaygroundWorktree)
 
-  if (repos.length === 0 && prs.length === 0 && worktrees.length === 0) return null
+  if (repos.length === 0 && worktrees.length === 0) return null
 
   return html`
     <${PanelCard} title="플레이그라운드">
@@ -110,22 +94,6 @@ export function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
                     <div class="text-3xs text-[var(--color-fg-muted)] font-mono mt-0.5 truncate">${r.latest_commit}</div>
                   </div>
                   <span class="text-3xs text-[var(--color-fg-disabled)] flex-shrink-0">${r.last_action}</span>
-                </div>
-              `)}
-            </div>
-          </div>
-        ` : null}
-
-        ${prs.length > 0 ? html`
-          <div>
-            <${SectionHeader} size="xs" class="mb-1.5">PRs (${prs.length})</${SectionHeader}>
-            <div class="flex flex-col gap-1.5">
-              ${prs.map(pr => html`
-                <div class="flex items-center gap-2 px-3 py-1.5 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
-                  <span class="text-xs text-[var(--color-fg-secondary)] truncate flex-1">${pr.title}</span>
-                  <${MonoBadge}>${pr.branch}</${MonoBadge}>
-                  ${pr.draft ? html`<span class="text-3xs px-1 py-0.5 rounded-[var(--r-1)] bg-[var(--warn-10)] text-[var(--color-status-warn)] border border-[var(--warn-20)]">draft</span>` : null}
-                  <a href=${pr.pr_url} target="_blank" rel="noopener" class="text-3xs text-[var(--color-accent-fg)] hover:underline flex-shrink-0">PR</a>
                 </div>
               `)}
             </div>

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -59,7 +59,7 @@ Typical contents:
 
 - cloned repos for keeper-driven edits
 - scratch files and temporary notes
-- keeper-local state such as repo caches or PR history
+- keeper-local state such as repo caches
 
 ### Handoff
 

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -950,7 +950,6 @@ let handle_keeper_status_config ~(config : Coord.config) ~(agent_name : string) 
                    (Coord_utils.safe_filename (Keeper_id.Trace_id.to_string m.runtime.trace_id)))));
            ]);
            (let sandbox = Keeper_sandbox.of_meta ~config:config ~meta:m in
-           let playground_abs = sandbox.host_root_abs in
            (* #10650 + B1 follow-up: keeper-LLM-facing execution_context must
               not surface host paths.  For Docker keepers the host abs path
               does not exist inside the container, so the LLM previously
@@ -958,9 +957,7 @@ let handle_keeper_status_config ~(config : Coord.config) ~(agent_name : string) 
               directory] errors.  default_cwd / private_workspace_root use
               [keeper_visible_root_abs] (container path for Docker, host
               path for Local).  Host-only fields (sandbox_host_root,
-              playground_path) are intentionally omitted — server-side
-              file reads below still use [playground_abs] but never expose
-              it through the JSON response. *)
+              playground_path) are intentionally omitted. *)
            let keeper_visible_abs = Keeper_sandbox.keeper_visible_root_abs sandbox in
            "execution_context", `Assoc [
              ("sandbox_id", `String sandbox.sandbox_id);
@@ -984,14 +981,6 @@ let handle_keeper_status_config ~(config : Coord.config) ~(agent_name : string) 
              ("playground_repos",
                Keeper_sandbox_control.playground_repos_json
                  ~config:config ~meta:m);
-             ("pr_history",
-               let pr_path = Filename.concat playground_abs
-                 ".playground_pr_history.jsonl" in
-               try
-                 let entries = Fs_compat.load_jsonl pr_path in
-                 (* Last 10 PRs, most recent first *)
-                 `List (List.take 10 (List.rev entries))
-               with Sys_error _ -> `List []);
              ("active_worktrees",
                let worktrees_dir = Filename.concat config.base_path ".worktrees" in
                try


### PR DESCRIPTION
## Summary

- remove `execution_context.pr_history` from keeper status detail responses
- remove the dashboard playground PR-history card and parser/guard
- scrub the glossary reference to keeper-local PR history

## Product impact

Keeper status no longer publishes a side-channel PR history file. The playground panel now shows only concrete repo/worktree state; PR evidence belongs in task evidence refs and receipts, not keeper status.

## Evidence

- `ocamlformat --check lib/keeper/keeper_status_detail.ml`
- `pnpm typecheck`
- `pnpm eslint src/components/keeper-detail-comms.ts`
- `git diff --check`
- residue scan: no `pr_history`, `.playground_pr_history`, or `PR history` in the touched status/dashboard/glossary files
- broader residue scan still finds `.playground_pr_history.jsonl` in `scripts/audit-keeper-fleet-readiness.py`; that deletion is covered by pending PR #19186
- `scripts/dune-local.sh build lib/keeper/keeper_status_detail.ml --cache=disabled` blocked with exit 75 because live bare Dune processes were already running outside `scripts/dune-local.sh`

## Direct evidence

schema_version: 1
direct_ratio: 5/6
provenance: mixed

Local static checks passed; focused Dune was blocked by the host-wide bare Dune guard, not by a compiler error from this branch.

## Review evidence

Draft PR for CI/reviewer pass.

## Linked issue

None.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`purge/status-pr-history-20260527` → `main` · 1 commit(s) · synced 2026-05-27T14:33:47Z

| sha | subject | date |
|---|---|---|
| `fe3e52eca` | refactor(status): drop playground PR history surface | 2026-05-27 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->