### PR TITLE
refactor(dashboard): migrate 4 errorToString callsites in dashboard-ws + api/mcp (batch 1/N)

### DIFF
--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -17,6 +17,7 @@ import {
 } from '../config/constants'
 import { reportToolHostFailure } from './tool-host-failure'
 import { showActionToast } from '../components/common/toast'
+import { errorToString } from '../lib/format-string'
 
 // --- MCP Session Management ---
 
@@ -267,7 +268,7 @@ async function callMcpToolInternal(
     const parsed = parseMcpHttpResponse(text)
     return extractMcpText(parsed)
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = errorToString(err)
     if (shouldReportToolHostFailure(message)) {
       await bestEffortReportToolHostFailure({
         toolName,

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -23,6 +23,7 @@ import {
   noteDashboardWsPing,
   noteDashboardWsPong,
 } from './dashboard-ws-state'
+import { errorToString } from './lib/format-string'
 
 type JsonObject = Record<string, unknown>
 type PendingRpc = {
@@ -588,7 +589,7 @@ function reconnectAfterCurrentSocketFailure(ws: WebSocket, err: unknown): void {
   batch(() => {
     dashboardWsConnected.value = false
     dashboardWsReady.value = false
-    dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+    dashboardWsLastError.value = errorToString(err)
   })
   if (!wasReady) clearCachedWsUrl()
   lastSubscribeKey = ''
@@ -632,7 +633,7 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
   } catch (err) {
     if (generation === connectGeneration && shouldReconnect) {
       batch(() => {
-        dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+        dashboardWsLastError.value = errorToString(err)
       })
       scheduleReconnect()
     }
@@ -663,7 +664,7 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     // a stale entry from an earlier session does not survive.
     clearCachedWsUrl()
     batch(() => {
-      dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+      dashboardWsLastError.value = errorToString(err)
     })
     scheduleReconnect()
     return


### PR DESCRIPTION
## 변경 내용

PR #19193 이 머지되어 `errorToString(err: unknown): string` 이 `lib/format-string.ts` 에서 export 가능합니다. 본 PR 은 **callsite migration 의 첫 batch — 2 파일 4 callsite** 만 처리합니다. blast radius 를 작게 유지해 multi-batch sweep SOP 를 검증합니다.

## Migrated callsites

| File | Line | Context |
|------|------|---------|
| `src/dashboard-ws.ts` | 592 | `reconnectAfterCurrentSocketFailure` socket failure |
| `src/dashboard-ws.ts` | 636 | `connectDashboardWS` discovery failure |
| `src/dashboard-ws.ts` | 667 | `connectDashboardWS` WebSocket ctor failure |
| `src/api/mcp.ts` | 271 | MCP tool call host-failure reporting |

각 사이트는 byte-for-byte 동일한 inline ternary:
```ts
err instanceof Error ? err.message : String(err)
```
→
```ts
errorToString(err)
```

## 등가성

`errorToString` 의 body 는 PR #19193 에서 정확히 같은 표현식입니다:
```ts
export function errorToString(err: unknown): string {
  return err instanceof Error ? err.message : String(err)
}
```
runtime 동작은 동일, type 추론도 동일 (둘 다 `string` 반환).

## Out of scope

남은 23 파일 (~41 callsite) 은 follow-up batch PR — `lib/format-string.ts` 의 `errorToString` JSDoc 에 분포 roadmap.

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run src/dashboard-ws*.test.ts src/api/mcp.test.ts` — 65/65 pass
- `pnpm vitest run` — 528/529 (1 baseline flaky `auth-status.a11y.test.ts`; main 동일)
- 2 file +6/-4

