### PR TITLE
fix(keeper): enforce task_state_file_probe_blocked at Execute gate

### DIFF
--- a/lib/keeper/agent_tool_execute_typed_input.ml
+++ b/lib/keeper/agent_tool_execute_typed_input.ml
@@ -28,6 +28,23 @@ type allowlist_mode =
   | Dev_full
   | Readonly
 
+(** Closed sum of task-state file paths that keepers must read through
+    [keeper_tasks_list] / [masc_status] rather than via shell probes.
+    The prompt (config/prompts/keeper.world.md and keeper.unified.system.md)
+    already names these paths as forbidden and promises a runtime
+    [task_state_file_probe_blocked] enforcement; this type makes the
+    promise true at the Execute gate. New patterns must be added here
+    as variants, not as substring rules (RFC-0088 §"String 분류기"). *)
+type task_state_path =
+  | Backlog_json  (** [.masc/backlog.json] *)
+  | State_backlog_json  (** [.masc/state/backlog.json] *)
+  | Goal_loop_status_json  (** [.masc/goal-loop/status.json] *)
+  | Repo_local_backlog_json
+      (** [repos/<repo>/.masc/backlog.json] or [repos/<repo>/.masc/state/backlog.json] *)
+  | Repo_worktree_task_json
+      (** [repos/<repo>/.worktrees/<task>/.task.json] *)
+  | Top_level_task_json  (** [.task.json] / [task.json] at any depth *)
+
 type validation_error =
   | Executable_not_allowlisted of {
       name : string;
@@ -44,6 +61,12 @@ type validation_error =
       executable : string;
       index : int;
       token : string;
+    }
+  | Argv_probes_task_state_file of {
+      executable : string;
+      index : int;
+      token : string;
+      matched : task_state_path;
     }
   | Redirect_path_not_absolute of {
       fd : int;
@@ -345,14 +368,91 @@ let looks_like_shell_redirection token =
       else false
 ;;
 
+(** Normalise a path-like token for blocklist matching: strip a single
+    leading [./] (the prompt mentions both [.masc/backlog.json] and
+    bare-prefixed forms in the wild) and an optional trailing [/]. Does
+    not resolve [..] or normalize multiple slashes; the blocklist
+    targets canonical literal forms emitted by typical shell muscle
+    memory ([cat .masc/backlog.json], [ls .masc/state/]), not arbitrary
+    filesystem traversal — that's the sandbox's job. *)
+let normalize_probe_token token =
+  let t =
+    if String.length token >= 2 && String.sub token 0 2 = "./"
+    then String.sub token 2 (String.length token - 2)
+    else token
+  in
+  if String.length t > 0 && t.[String.length t - 1] = '/'
+  then String.sub t 0 (String.length t - 1)
+  else t
+;;
+
+(** Closed pattern matcher. Mirrors the prompt's forbidden-path list
+    one-to-one (config/prompts/keeper.world.md). Adding a new blocked
+    path means: (a) update the prompt, (b) add a [task_state_path]
+    variant, (c) extend this matcher. The exhaustive match on the
+    return value forces every consumer to handle every new variant. *)
+let looks_like_task_state_probe token : task_state_path option =
+  let t = normalize_probe_token token in
+  let starts_with prefix s =
+    let pl = String.length prefix
+    and sl = String.length s in
+    sl >= pl && String.sub s 0 pl = prefix
+  in
+  let ends_with suffix s =
+    let sl = String.length suffix
+    and tl = String.length s in
+    tl >= sl && String.sub s (tl - sl) sl = suffix
+  in
+  let contains needle s =
+    let nl = String.length needle
+    and sl = String.length s in
+    if nl = 0 || nl > sl
+    then false
+    else
+      let rec loop i =
+        if i + nl > sl
+        then false
+        else if String.sub s i nl = needle
+        then true
+        else loop (i + 1)
+      in
+      loop 0
+  in
+  if t = ".masc/backlog.json" then Some Backlog_json
+  else if t = ".masc/state/backlog.json" then Some State_backlog_json
+  else if t = ".masc/goal-loop/status.json" then Some Goal_loop_status_json
+  else if
+    starts_with "repos/" t
+    && (ends_with "/.masc/backlog.json" t
+        || ends_with "/.masc/state/backlog.json" t)
+  then Some Repo_local_backlog_json
+  else if
+    starts_with "repos/" t
+    && contains "/.worktrees/" t
+    && ends_with "/.task.json" t
+  then Some Repo_worktree_task_json
+  else if t = ".task.json" || t = "task.json" then Some Top_level_task_json
+  else None
+;;
+
 let check_argv ~executable argv =
   let rec loop i = function
     | [] -> Ok ()
-    | token :: _ when shell_metachar_in_token token ->
-      Error (Argv_contains_shell_metachar { executable; index = i; token })
-    | token :: _ when looks_like_shell_redirection token ->
-      Error (Argv_contains_shell_redirection { executable; index = i; token })
-    | _ :: rest -> loop (i + 1) rest
+    | token :: rest ->
+      if shell_metachar_in_token token
+      then
+        Error (Argv_contains_shell_metachar { executable; index = i; token })
+      else if looks_like_shell_redirection token
+      then
+        Error
+          (Argv_contains_shell_redirection { executable; index = i; token })
+      else (
+        match looks_like_task_state_probe token with
+        | Some matched ->
+          Error
+            (Argv_probes_task_state_file
+               { executable; index = i; token; matched })
+        | None -> loop (i + 1) rest)
   in
   loop 0 argv
 ;;
@@ -616,6 +716,27 @@ let pp_validation_error ppf = function
       executable
       index
       token
+  | Argv_probes_task_state_file { executable; index; token; matched } ->
+    let path_name =
+      match matched with
+      | Backlog_json -> ".masc/backlog.json"
+      | State_backlog_json -> ".masc/state/backlog.json"
+      | Goal_loop_status_json -> ".masc/goal-loop/status.json"
+      | Repo_local_backlog_json -> "repos/<repo>/.masc/[state/]backlog.json"
+      | Repo_worktree_task_json -> "repos/<repo>/.worktrees/<task>/.task.json"
+      | Top_level_task_json -> ".task.json"
+    in
+    Format.fprintf
+      ppf
+      "task_state_file_probe_blocked: executable %S argv[%d]=%S targets \
+       task-state file (%s) which is intentionally not mounted in the \
+       keeper sandbox. Use keeper_tasks_list / masc_status to read task \
+       state — those tools return the same data through the typed \
+       interface that the runtime actually trusts."
+      executable
+      index
+      token
+      path_name
   | Redirect_path_not_absolute { fd; path } ->
     let label =
       match fd with

--- a/lib/keeper/agent_tool_execute_typed_input.mli
+++ b/lib/keeper/agent_tool_execute_typed_input.mli
@@ -75,6 +75,21 @@ type allowlist_mode =
   | Dev_full
   | Readonly
 
+(** Closed sum of task-state file paths that keepers must read through
+    [keeper_tasks_list] / [masc_status] rather than via shell probes.
+    The prompt (config/prompts/keeper.world.md and
+    keeper.unified.system.md) names these paths as forbidden and
+    promises a runtime [task_state_file_probe_blocked] enforcement; this
+    type lets the Execute gate actually enforce that promise. New
+    blocked paths must be added here, not as substring rules. *)
+type task_state_path =
+  | Backlog_json
+  | State_backlog_json
+  | Goal_loop_status_json
+  | Repo_local_backlog_json
+  | Repo_worktree_task_json
+  | Top_level_task_json
+
 type validation_error =
   | Executable_not_allowlisted of {
       name : string;
@@ -100,6 +115,18 @@ type validation_error =
           {!RFC-0198 Phase B} typed redirect fields or {!Pipeline} mode,
           instead of the runtime [find]/[grep] "unknown primary" failure
           that previously surfaced via [exec exit 1]. *)
+  | Argv_probes_task_state_file of {
+      executable : string;
+      index : int;
+      token : string;
+      matched : task_state_path;
+    }
+      (** Issue #18892. Token matches one of the
+          {!task_state_path} forms. Reading task state from the
+          filesystem is forbidden by the prompt and intentionally not
+          mounted in the keeper sandbox; the typed rejection points the
+          caller at [keeper_tasks_list] / [masc_status] instead of the
+          generic ENOENT that the runtime previously surfaced. *)
   | Redirect_path_not_absolute of {
       fd : int;
       path : string;

--- a/test/test_agent_tool_execute_typed_input.ml
+++ b/test/test_agent_tool_execute_typed_input.ml
@@ -980,6 +980,97 @@ let test_of_json_rejects_redirect_with_both_discard_and_file () =
   | Error _ -> ()
 ;;
 
+(* Issue #18892: Task-state file probe rejection.
+
+   The prompt forbids reading task-state JSON files via shell (see
+   config/prompts/keeper.world.md). Before this fix the runtime did not
+   enforce the promise — keepers ran [cat .masc/backlog.json] and saw
+   only a generic ENOENT. These tests pin the typed rejection so the
+   contract is observable from outside the gate. *)
+
+let expect_task_state_probe ~token ~variant input =
+  match Execute_input.validate ~mode:Execute_input.Dev_full input with
+  | Error
+      (Execute_input.Argv_probes_task_state_file
+        { token = t; matched; _ }) ->
+    Alcotest.(check string) "rejected token text" token t;
+    Alcotest.(check bool)
+      (Printf.sprintf "matched %s variant" token)
+      true
+      (matched = variant)
+  | Error other ->
+    Alcotest.failf
+      "expected Argv_probes_task_state_file for %S, got %a"
+      token
+      Execute_input.pp_validation_error
+      other
+  | Ok () -> Alcotest.failf "expected %S to be rejected" token
+;;
+
+let test_task_state_probe_paths_rejected () =
+  let cases =
+    [ ".masc/backlog.json", Execute_input.Backlog_json
+    ; ".masc/state/backlog.json", Execute_input.State_backlog_json
+    ; ".masc/goal-loop/status.json", Execute_input.Goal_loop_status_json
+    ; ( "repos/masc-mcp/.masc/backlog.json"
+      , Execute_input.Repo_local_backlog_json )
+    ; ( "repos/masc-mcp/.masc/state/backlog.json"
+      , Execute_input.Repo_local_backlog_json )
+    ; ( "repos/oas/.worktrees/feature-x/.task.json"
+      , Execute_input.Repo_worktree_task_json )
+    ; ".task.json", Execute_input.Top_level_task_json
+    ; "task.json", Execute_input.Top_level_task_json
+    ; "./.masc/backlog.json", Execute_input.Backlog_json
+    ]
+  in
+  List.iter
+    (fun (token, variant) ->
+      let input = mk_exec "cat" [ token ] in
+      expect_task_state_probe ~token ~variant input)
+    cases
+;;
+
+let test_task_state_probe_rejection_redirects_to_keeper_tasks_list () =
+  let input = mk_exec "cat" [ ".masc/backlog.json" ] in
+  match Execute_input.validate ~mode:Execute_input.Dev_full input with
+  | Error (Execute_input.Argv_probes_task_state_file _ as err) ->
+    let msg = Format.asprintf "%a" Execute_input.pp_validation_error err in
+    Alcotest.(check bool)
+      "error mentions keeper_tasks_list redirect"
+      true
+      (contains_substring msg "keeper_tasks_list");
+    Alcotest.(check bool)
+      "error mentions task_state_file_probe_blocked rule_id"
+      true
+      (contains_substring msg "task_state_file_probe_blocked")
+  | _ -> Alcotest.fail "expected Argv_probes_task_state_file"
+;;
+
+let test_task_state_probe_does_not_match_random_json () =
+  (* Tokens that contain "backlog" or "json" elsewhere must NOT trigger
+     the gate — false positives would block legitimate work. *)
+  let benign =
+    [ "config/backlog.example.json"
+    ; "build/output.json"
+    ; "lib/keeper/keeper_task_state.ml"
+    ; ".masc/personas/verifier/profile.json"
+    ; "repos/masc-mcp/lib/dune"
+    ]
+  in
+  List.iter
+    (fun token ->
+      let input = mk_exec "cat" [ token ] in
+      match Execute_input.validate ~mode:Execute_input.Dev_full input with
+      | Ok () -> ()
+      | Error other ->
+        Alcotest.failf
+          "benign token %S unexpectedly rejected: %a"
+          token
+          Execute_input.pp_validation_error
+          other)
+    benign
+;;
+
 let suite =
   ("typed tool_execute argv schema",
     List.map
@@ -1094,6 +1185,18 @@ let suite =
           "rfc_0198_phaseb_file_relative_path_rejected"
           `Quick
           test_redirect_file_relative_path_rejected
+      ; Alcotest.test_case
+          "issue_18892_task_state_probe_paths_rejected"
+          `Quick
+          test_task_state_probe_paths_rejected
+      ; Alcotest.test_case
+          "issue_18892_task_state_probe_redirects_to_keeper_tasks_list"
+          `Quick
+          test_task_state_probe_rejection_redirects_to_keeper_tasks_list
+      ; Alcotest.test_case
+          "issue_18892_task_state_probe_no_false_positives"
+          `Quick
+          test_task_state_probe_does_not_match_random_json
       ; Alcotest.test_case
           "rfc_0198_phaseb_stderr_discard_equivalent_to_dev_null"
           `Quick


### PR DESCRIPTION
## Summary

Closes #18892. Runtime enforcement of `task_state_file_probe_blocked` — the prompt's `keeper.world.md` + `keeper.unified.system.md` + `keeper.immediate_task_move.md` have been *promising* this enforcement since RFC-0?? but the Execute gate never actually checked. LLM 의 학습된 행동 (cat .masc/backlog.json, ls .masc/state/) 가 ENOENT 로 surface 됐고, 동일 패턴 fleet 에서 ramarama × 10 + albini × 5 + executor (live 23:22 KST) × N / day 반복.

## Change

`lib/keeper/agent_tool_execute_typed_input.ml` (+ mli):

1. **신설 closed sum** `task_state_path`:
   ```
   | Backlog_json              (* .masc/backlog.json *)
   | State_backlog_json        (* .masc/state/backlog.json *)
   | Goal_loop_status_json     (* .masc/goal-loop/status.json *)
   | Repo_local_backlog_json   (* repos/<repo>/.masc/[state/]backlog.json *)
   | Repo_worktree_task_json   (* repos/<repo>/.worktrees/<task>/.task.json *)
   | Top_level_task_json       (* .task.json | task.json *)
   ```
   *Prompt 의 forbidden list 와 1:1 일대일*. 새 forbidden path 추가는 (a) prompt 업데이트, (b) variant 추가, (c) matcher 확장 — 컴파일러가 누락 잡음 (exhaustive match).

2. **신설 variant** `Argv_probes_task_state_file { executable; index; token; matched }` in `validation_error`.

3. **신설 matcher** `looks_like_task_state_probe : string -> task_state_path option`. Substring 무한 확장이 아니라 *정확한 literal form* (LLM muscle memory). `normalize_probe_token` 로 leading `./` 만 strip — `..` resolution 안 함 (sandbox 책임).

4. **`check_argv` hook**: shell_redirection 다음 case, `Argv_probes_task_state_file` 반환.

5. **`pp_validation_error` 새 case**: typed redirect message —
   ```
   task_state_file_probe_blocked: ... targets task-state file (...) which is intentionally
   not mounted in the keeper sandbox. Use keeper_tasks_list / masc_status to read task
   state — those tools return the same data through the typed interface that the runtime
   actually trusts.
   ```
   LLM 이 보면 즉시 redirect 가능. *프롬프트 문구와 일치* (`task_state_file_probe_blocked` rule_id 그대로).

## Test plan

`test/test_agent_tool_execute_typed_input.ml` 3 신규 test:

- **9 path × 6 variant** `test_task_state_probe_paths_rejected` — 모든 forbidden form 매치
- **error message contract** `test_task_state_probe_rejection_redirects_to_keeper_tasks_list` — `keeper_tasks_list` + `task_state_file_probe_blocked` 두 키워드 포함
- **false positive guard** `test_task_state_probe_does_not_match_random_json` — `config/backlog.example.json`, `build/output.json`, `lib/keeper/keeper_task_state.ml`, `.masc/personas/verifier/profile.json` 등 *benign* path 통과 (over-block 방지)

## Why this is root fix, not workaround

CLAUDE.md §Workaround Bar 시그니처 *전부 비해당*:
- ❌ Counter-as-Fix — typed reject 가 *fix*, counter 만 늘리지 않음
- ❌ String 분류기 — closed sum (6 variant), substring 무한 추가 path 없음
- ❌ N-of-M — 6 forbidden path 한 PR 에 *전부*
- ❌ cap/cooldown/dedup/repair — symptom 억제 아니라 *promise 를 실현*

가장 큰 의미: **prompt 가 거짓말을 멈춤**. "runtime blocks" 라는 문구가 진짜 enforce. LLM trust 회복.

## Boundary

- **Gate 위치**: Execute typed schema 의 `check_argv` — 즉 *Execute tool 의 argv* 만 체크. Pipeline stage 도 동일 path 통과 (각 stage 의 argv check_argv 통과 필요).
- **Sandbox 책임**: filesystem traversal (`..`, symlink, etc) 은 sandbox 영역. Gate 는 *literal token shape* 만 봄.
- **Prompt-runtime contract**: 새 forbidden path 추가 시 prompt + type + matcher 3 곳 동시 update. Compiler 가 강제 (exhaustive).

## Related

- Issue #18892 (root)
- 2026-05-27 fleet evidence: ramarama × 10 (.masc/backlog.json) + albini × 5 (.masc/goal-loop/status.json) + executor 23:22 KST (repos/masc-mcp/.masc/state/backlog.json)
- config/prompts/keeper.world.md (forbidden list source-of-truth)
- config/prompts/keeper.unified.system.md (rule_id source)
- config/prompts/keeper.immediate_task_move.md (referenced enforcement promise)
- RFC-0088 §"Counter-as-Fix" — 본 PR 이 그 anti-pattern 의 반대 사례 (counter 0, fix-as-decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
