### PR TITLE
Remove board action reexports

### DIFF
--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -19,8 +19,6 @@ import {
   loadMoreBoardPosts,
 } from '../../store'
 import {
-  votePost,
-  voteComment,
   fetchBoardHearths,
   fetchBoardFlairs,
   fetchSubBoards,
@@ -51,9 +49,6 @@ export {
   refreshBoard,
   loadMoreBoardPosts,
 }
-export { votePost }
-export { voteComment }
-export { deleteBoardPost }
 export type { BoardComment, BoardPost, BoardSortMode }
 
 // ── Sort modes ─────────────────────────────────────────────────────

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -16,6 +16,8 @@ import { RichContent } from '../common/rich-content'
 import { CursorPagination } from '../common/pagination'
 import { stripStateBlocks } from '../../keeper-message'
 import { navigate, navigateToPost, route } from '../../router'
+import { votePost } from '../../api/board'
+import { deleteBoardPost } from '../../api/actions'
 import { registerBoardHearthsRefresh } from '../../sse-store'
 import { boardLatencyMetrics, type BoardLatencyMetric } from '../../board-metrics'
 import { MessageRoomTimeline } from './message-room-timeline'
@@ -94,8 +96,6 @@ import {
   visibilityBadgeColor,
   postVisibilityAuditLabel,
   postVisibilityAuditDetails,
-  votePost,
-  deleteBoardPost,
   refreshBoardHearths,
   refreshBoardFlairs,
   loadSubBoardOptionsForPost,

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -44,6 +44,8 @@ vi.mock('../common/feedback-state', () => ({
 
 vi.mock('../../api/board', () => ({
   fetchBoardReactions: vi.fn().mockResolvedValue([]),
+  votePost: vi.fn().mockResolvedValue(undefined),
+  voteComment: vi.fn().mockResolvedValue(undefined),
   toggleReaction: vi.fn().mockResolvedValue({
     target_type: 'comment',
     target_id: 'c1',
@@ -86,8 +88,6 @@ vi.mock('./board-state', () => ({
     return `표시 중 · ${visibility} · 댓글 ${post.comment_count ?? 0}개 · ${score} · ${updated}`
   },
   boardPostKind: () => 'direct',
-  votePost: vi.fn(),
-  voteComment: vi.fn().mockResolvedValue(undefined),
   refreshBoard: vi.fn(),
 }))
 
@@ -98,8 +98,8 @@ import {
   countCommentDescendants,
   filterCommentTree,
 } from './post-detail'
-import { detailComments, voteComment, votePost } from './board-state'
-import { toggleReaction } from '../../api/board'
+import { detailComments } from './board-state'
+import { toggleReaction, voteComment, votePost } from '../../api/board'
 import type { BoardComment } from '../../types/core'
 
 afterEach(() => {

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -12,6 +12,7 @@ import { RichContent } from '../common/rich-content'
 import { TextInput } from '../common/input'
 import { stripStateBlocks } from '../../keeper-message'
 import { navigate, replaceRoute, route } from '../../router'
+import { votePost, voteComment } from '../../api/board'
 import { ModerationBadge } from './moderation-badge'
 import { ReactionBar } from './reaction-bar'
 import {
@@ -39,8 +40,6 @@ import {
   visibilityBadgeColor,
   postVisibilityAuditLabel,
   boardPostKind,
-  votePost,
-  voteComment,
   refreshBoard,
 } from './board-state'
 import type { BoardComment, BoardPost } from './board-state'


### PR DESCRIPTION
## Summary
- remove vote/delete action re-exports from board-state
- import post/comment vote actions from the board API owner in board UI files
- keep deleteBoardPost owned by api/actions while board-state still uses it internally for bulk delete

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/board/board-state.test.ts src/components/board/board-surface.test.ts src/components/board/post-detail.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/board/board-state.ts src/components/board/board-surface.ts src/components/board/post-detail.ts src/components/board/post-detail.test.ts src/components/board/board-state.test.ts src/components/board/board-surface.test.ts
- git diff --check origin/main