### PR TITLE
perf(activity): RFC-0201 Step 1 — wait-free snapshot for events_http_json

### DIFF
--- a/lib/dashboard/dashboard_snapshot.ml
+++ b/lib/dashboard/dashboard_snapshot.ml
@@ -13,6 +13,8 @@ type t = {
   tools : Yojson.Safe.t;
   namespace_truth : Yojson.Safe.t;
   telemetry_summary : Yojson.Safe.t;
+  activity_events_default : Yojson.Safe.t;
+  (* RFC-0201 Step 1 — see [.mli] for contract. *)
 }
 
 (* Lock-free publish slot.  Holds [None] before the first publish so
@@ -69,6 +71,11 @@ let bootstrap ~(config : Coord.config) : t =
      [Server_dashboard_http_namespace_truth.namespace_truth_snapshot_from_caches]
      on its first interval (~2s after server start). *)
   let namespace_truth = `Null in
+  (* RFC-0201: leave [activity_events_default] [`Null] in bootstrap.
+     [Activity_graph.json_response] reads disk JSONL; we keep the
+     bootstrap path light and let the refresh fiber populate on its
+     first interval (~2s after start), same as [namespace_truth]. *)
+  let activity_events_default = `Null in
   let t =
     {
       generated_at = Unix.gettimeofday ();
@@ -77,6 +84,7 @@ let bootstrap ~(config : Coord.config) : t =
       tools;
       namespace_truth;
       telemetry_summary;
+      activity_events_default;
     }
   in
   (* Publish only if the slot is still empty — never overwrite a
@@ -141,6 +149,16 @@ let refresh_loop
           | Some json -> json
           | None -> `Null)
     in
+    let activity_events_default =
+      (* RFC-0201 Step 1.  Snapshot the dashboard panel's default
+         query at the API max [limit=1000]; handlers slice this list
+         down to their requested limit per call.  The cost is paid
+         once per [interval_sec] in this background fiber, not on the
+         request path. *)
+      safe "activity_events_default" (fun () ->
+        Activity_graph.json_response config ~kinds:[] ~after_seq:0
+          ~limit:1000 ())
+    in
     {
       generated_at = Unix.gettimeofday ();
       generation = next_generation ();
@@ -148,6 +166,7 @@ let refresh_loop
       tools;
       namespace_truth;
       telemetry_summary;
+      activity_events_default;
     }
   in
   let rec loop () =
@@ -170,7 +189,8 @@ let refresh_loop
 
 let publish_for_test t = Atomic.set slot (Some t)
 
-let make_for_test ~shell ~tools ~namespace_truth ~telemetry_summary =
+let make_for_test ~shell ~tools ~namespace_truth ~telemetry_summary
+      ?(activity_events_default = `Null) () =
   {
     generated_at = Unix.gettimeofday ();
     generation = next_generation ();
@@ -178,6 +198,7 @@ let make_for_test ~shell ~tools ~namespace_truth ~telemetry_summary =
     tools;
     namespace_truth;
     telemetry_summary;
+    activity_events_default;
   }
 ;;
 

--- a/lib/dashboard/dashboard_snapshot.mli
+++ b/lib/dashboard/dashboard_snapshot.mli
@@ -27,6 +27,14 @@ type t = private {
   tools : Yojson.Safe.t;
   namespace_truth : Yojson.Safe.t;
   telemetry_summary : Yojson.Safe.t;
+  activity_events_default : Yojson.Safe.t;
+  (** RFC-0201 Step 1.  [Activity_graph.json_response] computed against
+      the default-shaped query ([kinds=[]], [after_seq=0],
+      [limit=1000]).  Handlers slice this to the request's [limit] for
+      default-shaped queries; non-default queries (cursor, kinds
+      filter, since) fall through to the synchronous compute path.
+      [`Null] until the refresh fiber's first publish (bootstrap stays
+      [`Null] like [namespace_truth]). *)
 }
 
 val current : unit -> t option
@@ -70,6 +78,8 @@ val make_for_test :
   tools:Yojson.Safe.t ->
   namespace_truth:Yojson.Safe.t ->
   telemetry_summary:Yojson.Safe.t ->
+  ?activity_events_default:Yojson.Safe.t ->
+  unit ->
   t
 (** Test-only constructor.  Outside tests, snapshots are produced only
     by the refresh fiber. *)

--- a/lib/server/server_activity_http.ml
+++ b/lib/server/server_activity_http.ml
@@ -40,13 +40,53 @@ let last_event_id request =
       | None -> 0)
   | None -> 0
 
-(* Dashboard panel polls /api/v1/activity/events ~every refresh tick with the
-   same default query (no [after_seq] cursor — see dashboard ide-activity-panel).
-   [Activity_graph.json_response] hits JSONL on disk ([activity-events/YYYY-MM/DD.jsonl]).
-   Wrap with [Dashboard_cache] (2s TTL — short enough for near-live feel,
-   long enough to collapse concurrent panel reloads) and offload compute via
-   [Domain_pool_ref.submit_io_or_inline] so the HTTP main domain keeps serving
-   while disk read + JSON build runs on a worker. *)
+(* RFC-0201 Step 1.  Default-shaped queries (kinds=[], after_seq=0)
+   read from [Dashboard_snapshot.current ()].activity_events_default —
+   the snapshot is refreshed every interval_sec by the background
+   refresh fiber, so the HTTP path is a wait-free atomic read plus a
+   list slice down to the request's [limit].  Non-default queries
+   (cursor, kinds filter) fall through to the cache+offload path
+   from PR #19150. *)
+let slice_default_events_to_limit json ~limit =
+  match json with
+  | `Assoc fields ->
+    let events_list =
+      match List.assoc_opt "events" fields with
+      | Some (`List xs) -> xs
+      | _ -> []
+    in
+    let len = List.length events_list in
+    let sliced =
+      if len <= limit then events_list
+      else
+        (* Drop the oldest entries; snapshot is sorted seq-ascending so
+           the most recent [limit] events live at the tail.  Matches
+           [Activity_graph.json_response]'s own tail-slice semantics for
+           [after_seq=0]. *)
+        let drop_count = len - limit in
+        List.filteri (fun i _ -> i >= drop_count) events_list
+    in
+    let next_after_seq =
+      match List.rev sliced with
+      | (`Assoc last_fields) :: _ ->
+        (match List.assoc_opt "seq" last_fields with
+         | Some (`Int n) -> `Int n
+         | _ -> List.assoc_opt "next_after_seq" fields |> Option.value ~default:(`Int 0))
+      | _ ->
+        List.assoc_opt "after_seq" fields |> Option.value ~default:(`Int 0)
+    in
+    let replaced =
+      List.map (fun (k, v) ->
+        match k with
+        | "events" -> (k, `List sliced)
+        | "count" -> (k, `Int (List.length sliced))
+        | "limit" -> (k, `Int limit)
+        | "next_after_seq" -> (k, next_after_seq)
+        | _ -> (k, v)) fields
+    in
+    `Assoc replaced
+  | other -> other
+
 let events_http_json ~deps ~state request =
 
   let kinds = kind_filters deps request in
@@ -57,14 +97,29 @@ let events_http_json ~deps ~state request =
     deps.int_query_param request "limit" ~default:200
     |> clamp ~min_v:1 ~max_v:1000
   in
-  let cache_key =
-    Printf.sprintf "activity:events:%s:%d:%d"
-      (String.concat "," kinds) after_seq limit
+  let is_default_query = kinds = [] && after_seq = 0 in
+  let snapshot_hit =
+    if is_default_query then
+      match Dashboard_snapshot.current () with
+      | Some snap when snap.activity_events_default <> `Null ->
+        Some (slice_default_events_to_limit snap.activity_events_default ~limit)
+      | _ -> None
+    else None
   in
-  Dashboard_cache.get_or_compute cache_key ~ttl:2.0 (fun () ->
-    Domain_pool_ref.submit_io_or_inline (fun () ->
-      Activity_graph.json_response state.Mcp_server.room_config ~kinds
-        ~after_seq ~limit ()))
+  match snapshot_hit with
+  | Some json -> json
+  | None ->
+    (* Fall through: non-default query OR snapshot not yet published.
+       Keep the PR #19150 cache+offload wrap so cold-start callers do
+       not stall the HTTP main domain. *)
+    let cache_key =
+      Printf.sprintf "activity:events:%s:%d:%d"
+        (String.concat "," kinds) after_seq limit
+    in
+    Dashboard_cache.get_or_compute cache_key ~ttl:2.0 (fun () ->
+      Domain_pool_ref.submit_io_or_inline (fun () ->
+        Activity_graph.json_response state.Mcp_server.room_config ~kinds
+          ~after_seq ~limit ()))
 
 let parse_since_ms (raw : string) : int option =
   let len = String.length raw in

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -725,7 +725,7 @@ let test_dashboard_shell_snapshot_selector_injects_auth () =
                 ])
            ~tools:`Null
            ~namespace_truth:`Null
-           ~telemetry_summary:`Null
+           ~telemetry_summary:`Null ()
        in
        Lib.Dashboard_snapshot.publish_for_test snapshot;
        let json =
@@ -825,7 +825,7 @@ let test_shell_snapshot_wire_returns_snapshot_when_published () =
   Lib.Dashboard_snapshot.publish_for_test
     (Lib.Dashboard_snapshot.make_for_test
        ~shell:sentinel ~tools:`Null
-       ~namespace_truth:`Null ~telemetry_summary:`Null);
+       ~namespace_truth:`Null ~telemetry_summary:`Null ());
   let timing = Lib.Server_timing.create () in
   let json =
     Lib.Server_dashboard_snapshot_select.select_shell_json
@@ -871,7 +871,7 @@ let test_shell_snapshot_wire_light_variant_bypasses_snapshot () =
   Lib.Dashboard_snapshot.publish_for_test
     (Lib.Dashboard_snapshot.make_for_test
        ~shell:sentinel ~tools:`Null
-       ~namespace_truth:`Null ~telemetry_summary:`Null);
+       ~namespace_truth:`Null ~telemetry_summary:`Null ());
   let timing = Lib.Server_timing.create () in
   let json =
     Lib.Server_dashboard_snapshot_select.select_shell_json
@@ -959,7 +959,7 @@ let test_tools_snapshot_wire_returns_snapshot_when_actor_omitted () =
   Lib.Dashboard_snapshot.publish_for_test
     (Lib.Dashboard_snapshot.make_for_test
        ~shell:`Null ~tools:sentinel
-       ~namespace_truth:`Null ~telemetry_summary:`Null);
+       ~namespace_truth:`Null ~telemetry_summary:`Null ());
   let timing = Lib.Server_timing.create () in
   let json =
     Lib.Server_dashboard_snapshot_select.select_tools_json
@@ -995,7 +995,7 @@ let test_telemetry_summary_snapshot_wire_returns_snapshot () =
   Lib.Dashboard_snapshot.publish_for_test
     (Lib.Dashboard_snapshot.make_for_test
        ~shell:`Null ~tools:`Null
-       ~namespace_truth:`Null ~telemetry_summary:sentinel);
+       ~namespace_truth:`Null ~telemetry_summary:sentinel ());
   let timing = Lib.Server_timing.create () in
   let json =
     Lib.Server_dashboard_snapshot_select.select_telemetry_summary_json
@@ -1038,7 +1038,7 @@ let test_project_snapshot_wire_returns_snapshot_when_populated () =
   Lib.Dashboard_snapshot.publish_for_test
     (Lib.Dashboard_snapshot.make_for_test
        ~shell:`Null ~tools:`Null
-       ~namespace_truth:sentinel ~telemetry_summary:`Null);
+       ~namespace_truth:sentinel ~telemetry_summary:`Null ());
   let clock = Eio.Stdenv.clock env in
   let state = Lib.Mcp_server.create_state ~base_path:"/tmp/rfc-0138-step3" in
   let req = request "/api/v1/dashboard/project-snapshot" in

--- a/test/test_dashboard_snapshot.ml
+++ b/test/test_dashboard_snapshot.ml
@@ -24,6 +24,7 @@ let test_publish_then_current () =
       ~tools:(`String "tools-value")
       ~namespace_truth:(`String "nt-value")
       ~telemetry_summary:(`String "ts-value")
+      ()
   in
   Dashboard_snapshot.publish_for_test snap;
   match Dashboard_snapshot.current () with
@@ -43,7 +44,7 @@ let test_reset_clears_slot () =
   let snap =
     Dashboard_snapshot.make_for_test
       ~shell:`Null ~tools:`Null
-      ~namespace_truth:`Null ~telemetry_summary:`Null
+      ~namespace_truth:`Null ~telemetry_summary:`Null ()
   in
   Dashboard_snapshot.publish_for_test snap;
   Alcotest.(check bool) "populated before reset"
@@ -57,15 +58,15 @@ let test_generation_monotonic () =
   Dashboard_snapshot.reset_for_test ();
   let s1 =
     Dashboard_snapshot.make_for_test ~shell:`Null ~tools:`Null
-      ~namespace_truth:`Null ~telemetry_summary:`Null
+      ~namespace_truth:`Null ~telemetry_summary:`Null ()
   in
   let s2 =
     Dashboard_snapshot.make_for_test ~shell:`Null ~tools:`Null
-      ~namespace_truth:`Null ~telemetry_summary:`Null
+      ~namespace_truth:`Null ~telemetry_summary:`Null ()
   in
   let s3 =
     Dashboard_snapshot.make_for_test ~shell:`Null ~tools:`Null
-      ~namespace_truth:`Null ~telemetry_summary:`Null
+      ~namespace_truth:`Null ~telemetry_summary:`Null ()
   in
   Alcotest.(check bool) "s2.generation > s1.generation"
     true (s2.generation > s1.generation);
@@ -77,7 +78,7 @@ let test_generated_at_recent () =
   let before = Unix.gettimeofday () in
   let s =
     Dashboard_snapshot.make_for_test ~shell:`Null ~tools:`Null
-      ~namespace_truth:`Null ~telemetry_summary:`Null
+      ~namespace_truth:`Null ~telemetry_summary:`Null ()
   in
   let after = Unix.gettimeofday () in
   Alcotest.(check bool) "generated_at >= before"


### PR DESCRIPTION
## Summary

RFC-0201 Step 1 — `/api/v1/activity/events` 의 default-shaped query 를 `Dashboard_snapshot` wait-free read 로 전환. Non-default query (cursor / kinds filter) 는 PR #19150 의 cache+offload path 유지.

## Changes

### 1. `Dashboard_snapshot.t` 에 새 필드 추가
```ocaml
type t = private {
  ...existing fields...
  activity_events_default : Yojson.Safe.t;  (* NEW *)
}
```

- `bootstrap` 에서 `\`Null` (cold start 회피 — `namespace_truth` 패턴과 동일)
- `refresh_loop` 에서 매 `interval_sec` (현재 2s) compute:
  `Activity_graph.json_response config ~kinds:[] ~after_seq:0 ~limit:1000 ()`
- `make_for_test` 시그니처: `?activity_events_default:Yojson.Safe.t -> unit -> t`

### 2. `events_http_json` 분기 로직
- `kinds = [] && after_seq = 0` (dashboard panel 의 actual query) → snapshot atomic read → list slice down to request's `limit`
- non-default query → 기존 cache+offload (#19150) path

### 3. `slice_default_events_to_limit json ~limit`
- snapshot 의 1000-event payload 를 request limit 으로 truncate
- `events` / `count` / `limit` / `next_after_seq` 필드 갱신
- snapshot 의 seq-ascending sort 가정 (Activity_graph.json_response 동일 semantics)

## Why this is the right shape

RFC-0138 이 5 endpoint (shell / tools / namespace-truth / telemetry-summary / room-truth) 에서 이미 사용한 패턴:
- HTTP path = `Atomic.get` + JSON slice → wait-free, sub-millisecond
- Compute = background fiber, every `interval_sec` (one cost per interval, not per HTTP request)
- File-base storage 유지 (JSONL append-only)

PR #19150 의 cache wrap (TTL 2s) 은 underlying compute (7-8s) 보다 TTL 이 짧아 매 poll 마다 cold miss. Snapshot 패턴은 compute 비용을 background fiber 로 분리하여 HTTP 가 cache TTL 와 무관하게 항상 sub-ms.

## Measurement (예상)

| Query type | Before (PR #19150) | After (Step 1) |
|---|---|---|
| Default `?limit=50` (dashboard panel) | 7.88s cold / 8.52s warm | < 100 ms (snapshot slice) |
| Cursor `?after_seq=N` (rare, IDE replay) | unchanged | unchanged |
| Kinds filter `?kinds=task,coord` | unchanged | unchanged |

## File-base 제약 (RFC §3)

이 PR 은 **하지 않음**:
- ❌ In-memory event store 로 JSONL 대체
- ❌ DB 도입
- ❌ Schema 변경

**유지**: JSONL append-only, per-day file, operator-tail-able. Snapshot 의 *source* 는 여전히 disk JSONL — *compute owner* 만 background fiber 로 이동.

## Workaround Signature Gate

WORKAROUND-WAIVED: RFC-0201 의 첫 step implementation. PR #19150 의 cache wrap 은 fallback path 로 유지 (cold start / non-default query). Counter-as-fix / substring / N-of-M / catch-all / cap-cooldown / test-backdoor 비위반.

## Build

```
$ dune build lib/ EXIT=0  (lib first pass)
$ dune build @check        (lib + test)
```

## Test plan

- [ ] CI build PASS
- [ ] 서버 재시작 후 `/activity/events?limit=50` 측정: < 100 ms
- [ ] `/activity/events?limit=50` 다른 limit (10, 200) 도 < 100 ms
- [ ] `/activity/events?after_seq=N` 은 cache+offload path (PR #19150 동일 성능)
- [ ] `/api/v1/dashboard/cache-stats` 에 `activity:events:::*` 키 빈도 감소

## Open follow-ups (별도 PR)

- Step 2: `graph_http_json` snapshot wire
- Step 3: `swimlane_http_json` snapshot wire
- Step 4: `read_all_events` past-day cache (refresh fiber cost 자체 감소)
- Step 5: PR #19150 cache wrap retire (cleanup)

## Related

- RFC-0201 (docs/rfc/RFC-0201-activity-events-wait-free-snapshot.md, PR #19205 MERGED)
- RFC-0138 — pattern source (Dashboard Snapshot lock-free, 5 endpoints applied)
- PR #19150 — cache+offload wrap (fallback path 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
