### PR TITLE
refactor(sandbox): rename docker git dispatch proof label

### DIFF
--- a/docs/CONFIG-DOCTOR.md
+++ b/docs/CONFIG-DOCTOR.md
@@ -91,8 +91,8 @@ Core fields:
 - `sandbox_preflight`: Docker keeper sandbox readiness (`docker` daemon,
   local image presence, required commands, hardening checks). The JSON also
   exposes `hard_mode`, `credential_fallbacks_disabled`, and `git_egress` so
-  operators can confirm whether git/gh traffic is legacy Docker dispatch or
-  hard-mode brokered structured tools.
+  operators can confirm whether repo CLI traffic uses identity dispatch or the
+  container network policy.
 
 Important interpretation:
 

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -422,7 +422,7 @@ let keeper_config_json (config : Coord.config) (name : string)
           ("git_egress",
             `String
               (if Env_config_sandbox.Runtime.git_dispatch () then
-                 "docker_git_dispatch"
+                 "repo_cli_identity_dispatch"
                else
                  "container_network_policy"));
           ("credential_fallbacks_disabled", `Bool false);

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -812,7 +812,7 @@ let docker_preflight ~timeout_sec () =
       ; credential_fallbacks_disabled = false
       ; git_egress =
           (if Env_config_sandbox.Runtime.git_dispatch ()
-           then "docker_git_dispatch"
+           then "repo_cli_identity_dispatch"
            else "container_network_policy")
       ; image
       ; docker_runtime_ok


### PR DESCRIPTION
## Summary

- rename the sandbox preflight `git_egress` proof value from `docker_git_dispatch` to `repo_cli_identity_dispatch`
- update the dashboard snapshot projection to emit the same repo CLI identity label
- remove the CONFIG-DOCTOR wording that described repo traffic as legacy Docker dispatch

## Product impact

- User-visible change: dashboard/config-doctor proof output no longer presents repo CLI egress as Docker-owned git dispatch.

## Evidence

- `ocamlformat --check lib/keeper/keeper_sandbox_runtime.ml lib/dashboard/dashboard_http_keeper_snapshot.ml`
- `git diff --check`
- `rg -n "docker_git_dispatch|legacy Docker dispatch|git/gh traffic" lib test docs dashboard scripts` produced no matches
- `scripts/dune-local.sh build lib/keeper/keeper_sandbox_runtime.ml lib/dashboard/dashboard_http_keeper_snapshot.ml --cache=disabled` blocked with exit 75 because live bare Dune processes are bypassing the repo wrapper; I did not override with `MASC_DUNE_ALLOW_BARE_DUNE=1`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 3/4
provenance: mixed
stages:
  - name: ocamlformat
    command: ocamlformat --check lib/keeper/keeper_sandbox_runtime.ml lib/dashboard/dashboard_http_keeper_snapshot.ml
    result: pass
  - name: diff-check
    command: git diff --check
    result: pass
  - name: legacy-residue-scan
    command: rg -n "docker_git_dispatch|legacy Docker dispatch|git/gh traffic" lib test docs dashboard scripts
    result: pass
  - name: focused-dune
    command: scripts/dune-local.sh build lib/keeper/keeper_sandbox_runtime.ml lib/dashboard/dashboard_http_keeper_snapshot.ml --cache=disabled
    result: blocked_exit_75_live_bare_dune
```

## GOAL LOOP ACT checklist

- [x] Observe — legacy `docker_git_dispatch` proof value still leaked through sandbox/dashboard config output
- [x] Orient — this contradicts the tool/sandbox split: Docker is containment, Execute/repo CLI identity is the execution proof
- [x] Decide — bounded rename of the proof value and docs wording keeps the change small
- [x] Act — changed only the two producers and config-doctor documentation
- [x] Verify — formatting, diff hygiene, and legacy residue scan passed; focused Dune was blocked by machine-wide bare Dune processes
- [x] Loop — remaining broader legacy purge continues in stacked PRs

## Review evidence

- Not requested for this narrow purge slice.

## Linked issue

- Relates #19040

## Variant addition checklist

- [x] **OCaml** — no variant added or removed; string proof value only
- [x] **TypeScript** — no union type changed
- [x] **TLA+ spec** — not applicable
- [x] **Event / JSON schema** — no schema enum changed
- [ ] **`make check-variants` passes** — not run; no variant/domain literal changed

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`purge/docker-git-dispatch-label-20260527` → `main` · 1 commit(s) · synced 2026-05-27T14:43:15Z

| sha | subject | date |
|---|---|---|
| `e7b71385d` | refactor(sandbox): rename docker git dispatch proof label | 2026-05-27 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->