### PR TITLE
refactor(dashboard): migrate 7 errorToString callsites + delete 1 file-internal duplicate (batch 2/N)

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -53,6 +53,7 @@ import { StatusChip } from './common/status-chip'
 import type { ManagedAsyncResource } from '../lib/async-state'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { formatPct1 } from '../lib/format-number'
+import { errorToString } from '../lib/format-string'
 
 interface CascadeData {
   config: CascadeConfigResponse | null
@@ -1090,13 +1091,6 @@ function ClientCapacityTable({ capacity }: { capacity: CascadeClientCapacityResp
   `
 }
 
-// Generic Error -> message conversion with String() fallback (no special
-// 'unknown error' literal, no nullable return, no fallback param).
-// Distinct from errorMessageOrNull / errorMessageOrUnknown / errorMessageOr
-// in other modules.
-function errorToString(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
-}
 
 function SourceAssistInput({
   id,

--- a/dashboard/src/components/cascade-waterfall.ts
+++ b/dashboard/src/components/cascade-waterfall.ts
@@ -20,6 +20,7 @@ import {
 import { LoadingState, ErrorState } from './common/feedback-state'
 import { TimeAgo } from './common/time-ago'
 import { formatMsCompact } from '../lib/format-number'
+import { errorToString } from '../lib/format-string'
 
 // ── Module-level signals ──────────────────────────────────────────────────
 
@@ -106,7 +107,7 @@ async function refreshWaterfall() {
     waterfallEvents.value = res.events
     waterfallUpdatedAt.value = res.updated_at
   } catch (err) {
-    waterfallError.value = err instanceof Error ? err.message : String(err)
+    waterfallError.value = errorToString(err)
   } finally {
     waterfallLoading.value = false
   }

--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -5,6 +5,7 @@ import { LoadingState } from './common/feedback-state'
 import { fetchExcusePatterns, updateExcusePatterns } from '../api/dashboard'
 import type { ExcusePattern } from '../api/dashboard'
 import { createAsyncResource } from '../lib/async-state'
+import { errorToString } from '../lib/format-string'
 
 const patternsResource = createAsyncResource<ExcusePattern[]>()
 const saving = signal(false)
@@ -38,7 +39,7 @@ function handleSave(event: Event) {
       saving.value = false
     })
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = errorToString(err)
     saveMessage.value = `잘못된 형식: ${msg}`
   }
 }

--- a/dashboard/src/components/git-graph-view.ts
+++ b/dashboard/src/components/git-graph-view.ts
@@ -4,6 +4,7 @@ import type cytoscape from 'cytoscape'
 import type { GitGraphResponse, GitGraphNode } from '../api/git-graph'
 import { InlineSpinner } from './common/inline-spinner'
 import { getCytoscape, type CyCore } from './common/cytoscape-loader'
+import { errorToString } from '../lib/format-string'
 
 // Cytoscape does not resolve CSS variables. Resolve once against :root
 // with fallback to literal hex values.
@@ -275,7 +276,7 @@ export function GitGraphView({ graph, focusRef = null }: GitGraphViewProps) {
         setLoading(false)
       } catch (err) {
         if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err))
+          setError(errorToString(err))
           setLoading(false)
         }
       }

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -12,6 +12,7 @@ import {
   type KeeperRuntimeTraceResponse,
 } from '../api/keeper'
 import { formatCost, formatMsCompact } from '../lib/format-number'
+import { errorToString } from '../lib/format-string'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { keepers } from '../store'
 import type { Keeper } from '../types'
@@ -57,7 +58,7 @@ async function settleSource<T>(
     return {
       ok: false,
       label,
-      error: err instanceof Error ? err.message : String(err),
+      error: errorToString(err),
     }
   }
 }


### PR DESCRIPTION
## 변경 내용

PR #19209 (batch 1, dashboard-ws + api/mcp) 의 후속. **depth-2 components/ 5 파일** 처리:
- 4 file × 1 callsite inline ternary 치환
- 1 file (cascade-config-panel) 는 *file-internal duplicate helper* 제거 + 3 callsite 가 lib import 로 자동 라우팅

## Migrated callsites

| File | Line | Context |
|------|------|---------|
| `cascade-waterfall.ts` | 109 | `waterfallError.value` on fetch fail |
| `excuse-patterns.ts` | 41 | `saveMessage` on update fail |
| `git-graph-view.ts` | 278 | `setError` on fetch fail |
| `journey-panel.ts` | 60 | trace error capture |
| `cascade-config-panel.ts` | 425, 1357, 1360 | assignmentMessage + 2× saveMessage (이제 lib helper 호출) |

## File-internal duplicate 제거 (cascade-config-panel.ts)

작업 중 typecheck 가 *intra-file duplicate* 를 자동 감지:
```
error TS2440: Import declaration conflicts with local declaration of 'errorToString'.
```

`cascade-config-panel.ts` 에 같은 이름 + 같은 body 의 helper 가 file-internal 로 있었습니다 (line 1098-1100):
```ts
function errorToString(error: unknown): string {
  return error instanceof Error ? error.message : String(error)
}
```

PR #19189 (`lib/async-state` toErrorMessage), PR #19201 (`lib/format-number` self-bypass), PR #19193 (`lib/format-string` errorToString export) 와 같은 SSOT class — **canonical helper 한 곳, shadow copy 0**. components/ 안에서 가장 큰 file-internal duplicate 였습니다.

## 등가성

`errorToString` body 는 모든 곳에서 동일:
```ts
err instanceof Error ? err.message : String(err)
```
runtime 동작 + type 추론 동일.

## SOP 확립 — typecheck 가 silent failure catch

iter#64 의 27 file × heredoc import insert 시도가 silent 실패한 사례와 달리, **file 당 명시적 import edit** 은 typecheck 가 missing-import + duplicate declaration 을 즉시 감지합니다. 본 batch 에서 cascade-config-panel duplicate 가 정확히 그 방식으로 발견되었습니다.

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (5 관련 test file) — 62/62 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 5 file +9/-11

## Out of scope

남은 18 파일 (~33 callsite) follow-up batch PR.

