### PR TITLE
perf(activity): RFC-0201 Step 4 — past-day file (path, mtime) cache

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -200,16 +200,72 @@ let repair_event_file_utf8_once config path =
             repair.text
           end)
 
+let parse_events_from_file config path =
+  let content = repair_event_file_utf8_once config path in
+  let lines = String.split_on_char '\n' content in
+  List.filter_map
+    (fun line ->
+      if String.trim line = "" then None else parse_event_line line)
+    lines
+
+(* RFC-0201 Step 4 — past-day file cache.
+
+   [read_all_events] historically full-scans every activity-events
+   JSONL file on every call.  With 15+ MB of historic data that
+   compute dominated the background refresh fiber and undermined
+   the Step 1 wait-free read (snapshot only refreshes after the
+   fiber finishes one full scan).
+
+   Past-day files are immutable: once the calendar day rolls over,
+   no process appends to that JSONL again.  Cache the parsed event
+   list per (path, mtime).  On re-read, if mtime matches the cached
+   entry, reuse the parsed list and skip [Fs_compat.load_file] +
+   line split + parse.  Only the current-day file (whose mtime
+   changes on append) is reparsed each refresh. *)
+module Past_day_path_map = Stdlib.Map.Make (String)
+
+(* [Atomic.t] holding an immutable persistent map keeps reads
+   wait-free across HTTP fibers and the refresh fiber.  CAS update
+   loses only the *parse result* on contention; the underlying
+   file remains the SSOT, so a lost insert just causes a re-parse
+   on the next call. *)
+let past_day_cache : (float * event list) Past_day_path_map.t Atomic.t =
+  Atomic.make Past_day_path_map.empty
+
+let past_day_cache_lookup path mtime =
+  match Past_day_path_map.find_opt path (Atomic.get past_day_cache) with
+  | Some (cached_mtime, parsed) when Float.equal cached_mtime mtime ->
+    Some parsed
+  | _ -> None
+
+let rec past_day_cache_insert path mtime parsed =
+  let prev = Atomic.get past_day_cache in
+  let next = Past_day_path_map.add path (mtime, parsed) prev in
+  if not (Atomic.compare_and_set past_day_cache prev next) then
+    past_day_cache_insert path mtime parsed
+
+let file_mtime path =
+  try Some (Unix.stat path).Unix.st_mtime with _ -> None
+
 let read_all_events config =
+  let current_day = day_path config in
   collect_event_files config
   |> List.fold_left
        (fun acc path ->
-         let content = repair_event_file_utf8_once config path in
-         let lines = String.split_on_char '\n' content in
          let rows =
-           List.filter_map (fun line ->
-             if String.trim line = "" then None
-             else parse_event_line line) lines
+           if String.equal path current_day then
+             (* Current-day file mtime changes on every append. *)
+             parse_events_from_file config path
+           else
+             match file_mtime path with
+             | None -> parse_events_from_file config path
+             | Some mtime ->
+               (match past_day_cache_lookup path mtime with
+                | Some cached -> cached
+                | None ->
+                  let parsed = parse_events_from_file config path in
+                  past_day_cache_insert path mtime parsed;
+                  parsed)
          in
          List.rev_append rows acc)
        []


### PR DESCRIPTION
## Summary

RFC-0201 Step 4 — `Activity_graph.read_all_events` 의 past-day JSONL 에 `(path, mtime)` cache 추가. Refresh fiber 의 single-cycle compute 시간을 ~7s → ~ms 로 감소.

## Why

Step 1 (PR #19212) 가 *HTTP read* 를 wait-free 로 바꿨음. 그러나 *refresh fiber* 자체는 매 cycle `read_all_events` 전체 full-scan (Fs_compat.load_file + line split + parse over ~15 MB). 결과:

- Refresh fiber single cycle: **~7s**
- `interval_sec=2s` 인데 compute 자체가 7s → snapshot freshness 가 *cycle 시간만큼 stale*
- Step 1 wait-free read 의 *publishing rate* 가 한 cycle 당 1 회 = 매 7-9 초

## Solution

Past-day JSONL = **immutable**. 캘린더 day 가 roll over 되면 그 파일에 더 이상 append 안 됨.

```ocaml
module Past_day_path_map = Stdlib.Map.Make(String)

let past_day_cache : (float * event list) Past_day_path_map.t Atomic.t =
  Atomic.make Past_day_path_map.empty

let read_all_events config =
  let current_day = day_path config in
  collect_event_files config
  |> List.fold_left (fun acc path ->
       let rows =
         if String.equal path current_day then
           parse_events_from_file config path  (* re-parse on every append *)
         else
           match file_mtime path with
           | None -> parse_events_from_file config path
           | Some mtime ->
             (match past_day_cache_lookup path mtime with
              | Some cached -> cached
              | None ->
                let parsed = parse_events_from_file config path in
                past_day_cache_insert path mtime parsed;
                parsed)
       in
       List.rev_append rows acc) []
  |> List.sort ...
```

## Design 결정

### Atomic.t + persistent Stdlib.Map (Hashtbl 대신)

`Activity_graph.json_response` 가 *worker domain* 에서 호출 가능 (`Domain_pool_ref.submit_io_or_inline` — PR #19150 의 fallback path). Stdlib Hashtbl 은 *not safe across domains*. Immutable persistent map + atomic ref:

- **Wait-free read** (readers 무관 contention)
- **CAS update**: lost insert 시 *file 다시 parse* — 파일이 SSOT 라 correctness loss 없음
- Lock-free, no `Mutex`, no `Eio.Mutex`

### (path, mtime) cache key

- past-day file 의 `mtime` 은 안 바뀜 → permanent cache hit
- current-day file 은 `mtime` 변경 = append → cache 진입 안 함 (re-parse)
- mtime 자체가 *file modification* 의 ground truth

### File-base 유지 (RFC §3 제약)

- ❌ In-memory event store 로 JSONL 대체 안 함
- ❌ DB / index file 추가 안 함  
- ✅ Cache 는 *parse result 만* 보관 — file 자체가 SSOT, mtime 변경 시 cache invalidate

## Expected impact

| Operation | Before | After |
|---|---|---|
| Refresh fiber single cycle (15 MB historic) | ~7 s | **~ms** (current-day only) |
| Snapshot freshness | ~7-9 s stale | ≤ `interval_sec` (2s) |
| `/activity/events` default | 0.06 s (Step 1) | 0.06 s (unchanged) |
| `/activity/events` cursor (fallback) | ~7 s | **~ms** (same path benefits) |
| `/activity/graph` / `/swimlane` (uncached fallback) | ~7-8 s | **~ms** |

## Why this fix is the right shape

- 알고리즘 root: past-day full-scan 이 *불필요*. file immutability 가 cache 정당성 제공.
- Memory: ~365 entries (year of past-day files), each parsed list. 큰 데이터지만 *persistent map shares structure* — 효율적.
- Robustness: file disappear / mtime stat fail → cache miss + 일반 parse path. No exception escape.

## Workaround Signature Gate

WORKAROUND-WAIVED: RFC-0201 Step 4 implementation. File immutability invariant 기반 cache — counter / substring / N-of-M / catch-all / cap-cooldown / test-backdoor 비위반. RFC §7 self-check 전부 PASS.

## Build

```
$ dune build lib/  EXIT=0
```

## Test plan

- [ ] CI build PASS
- [ ] 서버 재시작 후 `/api/v1/dashboard/cache-stats` 에서 `generation` 갱신 cadence 확인 (~ 2s 마다 increment)
- [ ] `/activity/events` warm < 100 ms (Step 1 + Step 4 결합)
- [ ] `/activity/graph` / `/swimlane` (cache+offload fallback) cold-miss latency 감소 확인
- [ ] 자정 자정 cross 시 어제 파일이 자동 cache 진입 (mtime stable)

## Related

- RFC-0201 (docs/rfc/RFC-0201-activity-events-wait-free-snapshot.md)
- PR #19205 — RFC-0201 spec (MERGED)
- PR #19212 — Step 1 events_http_json snapshot wire (MERGED)
- **본 PR** — Step 4 past-day file cache
- Step 2/3 (graph/swimlane snapshot wire) — 별도 PR 예정
- Step 5 (PR #19150 cache wrap retire) — 마지막 cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
