### PR TITLE
refactor(tools): remove gh failure bucket framing

### DIFF
--- a/scripts/analyze-keeper-execute-failures.sh
+++ b/scripts/analyze-keeper-execute-failures.sh
@@ -4,7 +4,8 @@
 # Reproducible census for the keeper Execute quality loop. Reads
 # <base-path>/.masc/tool_calls and buckets Execute failures by the same leak
 # classes used in the 240h runtime triage. It also prints a compact summary
-# for the adjacent shell/code surfaces that share the same failure budget.
+# for the adjacent descriptor-backed file/edit surfaces that share the same
+# failure budget.
 #
 # Usage:
 #   scripts/analyze-keeper-execute-failures.sh [base_path] [window_hours]
@@ -77,7 +78,7 @@ def output_text:
 def combined: output_text + " " + (.action_radius.error // "") + " " + cmd;
 def failed: (.success == false or .semantic_success == false);
 def inferred_shape:
-  if (cmd | test("gh pr checks"; "i")) then "gh_pr_checks"
+  if (cmd | test("gh pr checks"; "i")) then "repo_cli_pr_checks"
   elif (cmd | test("&&|\\|\\||;|\\n|\\r"; "i")) then "chaining"
   elif (cmd | test("2>/dev/null|2> /dev/null|2>>/dev/null|2>&1|\\| head|\\| grep|\\| sed|\\| python|>|<"; "i")) then "pipe_or_redirect"
   else "unknown" end;
@@ -89,11 +90,11 @@ def category:
   elif (combined | test("old_string not found"; "i")) then "edit_old_string_not_found"
   elif (combined | test("old_string found [0-9]+ times|Use replace_all=true"; "i")) then "edit_ambiguous_match"
   elif (combined | test("path_outside_sandbox|Write restricted to allowed sandboxes|Cross-agent playground"; "i")) then "path_outside_sandbox"
-  elif (combined | test("is a MASC tool, not a shell command|tool_invoked_as_shell_command|`?gh`? is NOT available in the keeper sandbox"; "i")) then "wrong_tool_channel"
+  elif (combined | test("is a MASC tool, not a shell command|tool_invoked_as_shell_command|repo CLI is NOT available in the keeper sandbox"; "i")) then "wrong_tool_channel"
   elif (combined | test("command.*not.*allowed|not allowlisted|not in allowlist|not permitted by.*allowlist"; "i")) then "command_not_allowed"
   elif (combined | test("pipe_or_redirect|Execute accepts one direct command|tool_execute accepts one direct command|tool_execute_command_shape_blocked|2>/dev/null|2> /dev/null|2>>/dev/null|2>&1|\\| head|\\| grep|\\| sed|\\| python|&&|\\|\\|"; "i")) then "shape_block:pipe_or_redirect"
   elif (combined | test("tool_approval_required|destructive|blocked for all presets|operator_required|risk threshold"; "i")) then "approval_or_destructive_block"
-  elif (combined | test("sandbox root cannot run git/gh|multiple sandbox repos|Set cwd explicitly"; "i")) then "cwd_required_multi_repo"
+  elif (combined | test("sandbox root cannot run repo CLI|multiple sandbox repos|Set cwd explicitly"; "i")) then "cwd_required_multi_repo"
   elif (combined | test("No such file or directory|cannot access|cannot change to|cwd_not_directory|not a git repository|outside allowed directories|Path blocked"; "i")) then "missing_path_or_wrong_cwd"
   elif (combined | test("image_not_found|Unable to find image.*masc-keeper-sandbox|pull access denied for masc-keeper-sandbox"; "i")) then "docker_image_not_found"
   elif (combined | test("timeout|timed out"; "i")) then "timeout"
@@ -117,7 +118,7 @@ def output_text:
 def combined: output_text + " " + (.action_radius.error // "") + " " + cmd;
 def failed: (.success == false or .semantic_success == false);
 def inferred_shape:
-  if (cmd | test("gh pr checks"; "i")) then "gh_pr_checks"
+  if (cmd | test("gh pr checks"; "i")) then "repo_cli_pr_checks"
   elif (cmd | test("&&|\\|\\||;|\\n|\\r"; "i")) then "chaining"
   elif (cmd | test("2>/dev/null|2> /dev/null|2>>/dev/null|2>&1|\\| head|\\| grep|\\| sed|\\| python|>|<"; "i")) then "pipe_or_redirect"
   else "unknown" end;
@@ -129,11 +130,11 @@ def category:
   elif (combined | test("old_string not found"; "i")) then "edit_old_string_not_found"
   elif (combined | test("old_string found [0-9]+ times|Use replace_all=true"; "i")) then "edit_ambiguous_match"
   elif (combined | test("path_outside_sandbox|Write restricted to allowed sandboxes|Cross-agent playground"; "i")) then "path_outside_sandbox"
-  elif (combined | test("is a MASC tool, not a shell command|tool_invoked_as_shell_command|`?gh`? is NOT available in the keeper sandbox"; "i")) then "wrong_tool_channel"
+  elif (combined | test("is a MASC tool, not a shell command|tool_invoked_as_shell_command|repo CLI is NOT available in the keeper sandbox"; "i")) then "wrong_tool_channel"
   elif (combined | test("command.*not.*allowed|not allowlisted|not in allowlist|not permitted by.*allowlist"; "i")) then "command_not_allowed"
   elif (combined | test("pipe_or_redirect|Execute accepts one direct command|tool_execute accepts one direct command|tool_execute_command_shape_blocked|2>/dev/null|2> /dev/null|2>>/dev/null|2>&1|\\| head|\\| grep|\\| sed|\\| python|&&|\\|\\|"; "i")) then "shape_block:pipe_or_redirect"
   elif (combined | test("tool_approval_required|destructive|blocked for all presets|operator_required|risk threshold"; "i")) then "approval_or_destructive_block"
-  elif (combined | test("sandbox root cannot run git/gh|multiple sandbox repos|Set cwd explicitly"; "i")) then "cwd_required_multi_repo"
+  elif (combined | test("sandbox root cannot run repo CLI|multiple sandbox repos|Set cwd explicitly"; "i")) then "cwd_required_multi_repo"
   elif (combined | test("No such file or directory|cannot access|cannot change to|cwd_not_directory|not a git repository|outside allowed directories|Path blocked"; "i")) then "missing_path_or_wrong_cwd"
   elif (combined | test("image_not_found|Unable to find image.*masc-keeper-sandbox|pull access denied for masc-keeper-sandbox"; "i")) then "docker_image_not_found"
   elif (combined | test("timeout|timed out"; "i")) then "timeout"


### PR DESCRIPTION
## Summary

- rename the Execute failure analyzer bucket from `gh_pr_checks` to `repo_cli_pr_checks`
- replace the analyzer's shell/code framing with descriptor-backed file/edit surface wording
- remove legacy `git/gh` and raw `gh unavailable` error text matchers from the analyzer categories

## Product impact

- User-visible change: Execute quality reports no longer expose GitHub/gh as a top-level failure bucket or describe adjacent tools as code/shell surfaces.

## Evidence

- `bash -n scripts/analyze-keeper-execute-failures.sh`
- `git diff --check`
- `rg -n 'gh_pr_checks|shell/code surfaces|git/gh|GitHub CLI|github_cli_|keeper_gh_|keeper_pr_' scripts/analyze-keeper-execute-failures.sh` produced no matches

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 3/3
provenance: direct
stages:
  - name: shell-syntax
    command: bash -n scripts/analyze-keeper-execute-failures.sh
    result: pass
  - name: diff-check
    command: git diff --check
    result: pass
  - name: legacy-residue-scan
    command: rg -n 'gh_pr_checks|shell/code surfaces|git/gh|GitHub CLI|github_cli_|keeper_gh_|keeper_pr_' scripts/analyze-keeper-execute-failures.sh
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — analyzer still emitted `gh_pr_checks` and described adjacent surfaces as shell/code
- [x] Orient — this conflicts with the descriptor-backed Execute/file/edit tool model
- [x] Decide — scope is limited to analyzer labels and category matchers
- [x] Act — updated one script, no runtime schema or OCaml API changed
- [x] Verify — shell syntax, diff hygiene, and legacy residue scan passed
- [x] Loop — broader legacy purge remains in stacked PRs

## Review evidence

- Not requested for this narrow script label cleanup.

## Linked issue

- Relates #19040

## Variant addition checklist

- [x] **OCaml** — not applicable
- [x] **TypeScript** — not applicable
- [x] **TLA+ spec** — not applicable
- [x] **Event / JSON schema** — no schema enum changed
- [ ] **`make check-variants` passes** — not run; no variant/domain literal changed

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`purge/execute-analyzer-gh-framing-20260527` → `main` · 1 commit(s) · synced 2026-05-27T14:54:03Z

| sha | subject | date |
|---|---|---|
| `0ae332cbe` | refactor(tools): remove gh failure bucket framing | 2026-05-27 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->