### PR TITLE
Remove kpi strip shared reexports

### DIFF
--- a/dashboard/src/components/kpi-strip.solid.tsx
+++ b/dashboard/src/components/kpi-strip.solid.tsx
@@ -10,13 +10,9 @@
 // KpiStrip provides KpiStripContext; KpiCell.solid reads it and
 // defaults `bare` to true when the cell is inside a strip. Caller
 // can still set `bare={false}` to opt out (test parity below).
-//
-// `resolveStripCols` is exported for direct testing (pure helper).
 
 import { createContext, useContext, type JSX } from 'solid-js'
 import { resolveStripCols, type KpiStripVariant } from './kpi-shared'
-
-export { resolveStripCols, type KpiStripVariant } from './kpi-shared'
 
 export interface KpiStripProps {
   variant?: KpiStripVariant

--- a/dashboard/src/components/kpi-strip.ts
+++ b/dashboard/src/components/kpi-strip.ts
@@ -33,8 +33,6 @@ import { html } from 'htm/preact'
 import { cloneElement, toChildArray, type VNode, type ComponentChildren } from 'preact'
 import { resolveStripCols, type KpiStripVariant } from './kpi-shared'
 
-export { resolveStripCols, type KpiStripVariant } from './kpi-shared'
-
 export interface KpiStripProps {
   /** Strip layout variant. Drives the column count + density. */
   variant?: KpiStripVariant


### PR DESCRIPTION
## Summary
- remove resolveStripCols/KpiStripVariant re-exports from Preact and Solid KpiStrip components
- keep helper/type ownership in kpi-shared, where tests already import them directly
- remove the stale Solid comment claiming the helper is re-exported for tests

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/kpi-strip.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/kpi-strip.ts src/components/kpi-strip.solid.tsx src/components/kpi-strip.test.ts src/components/kpi-strip.solid.test.tsx
- git diff --check origin/main

## Known local verification gap
- pnpm vitest run --config vitest.solid.config.ts src/components/kpi-strip.solid.test.tsx --no-file-parallelism --maxWorkers=1 --testTimeout=15000 failed before importing tests: Cannot find module '/@fs/Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/.pnpm/@testing-library+jest-dom@6.9.1/node_modules/@testing-library/jest-dom/dist/vitest.mjs'. This matches the existing local Solid config/module resolution issue seen in adjacent cleanup slices.