### PR TITLE
refactor(dashboard): migrate 7 errorToString callsites across 5 depth-2 components (batch 3/N)

### DIFF
--- a/dashboard/src/components/cascade-inspector.ts
+++ b/dashboard/src/components/cascade-inspector.ts
@@ -15,6 +15,7 @@ import { LoadingState, ErrorState, EmptyState } from './common/feedback-state'
 import { FilterChips } from './common/filter-chips'
 import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
+import { errorToString } from '../lib/format-string'
 
 export type CascadeInspectorFocus = 'deep-dive' | 'compare'
 type CascadeInspectorChip = 'trace' | CascadeInspectorFocus
@@ -91,7 +92,7 @@ async function refreshTrace() {
     traceEvents.value = res.events
     traceUpdatedAt.value = res.updated_at
   } catch (err) {
-    traceError.value = err instanceof Error ? err.message : String(err)
+    traceError.value = errorToString(err)
   } finally {
     traceLoading.value = false
   }
@@ -104,7 +105,7 @@ async function refreshHealth() {
     const res = await fetchCascadeHealth()
     healthProviders.value = res.providers
   } catch (err) {
-    healthError.value = err instanceof Error ? err.message : String(err)
+    healthError.value = errorToString(err)
   } finally {
     healthLoading.value = false
   }

--- a/dashboard/src/components/goal-loop-panel.ts
+++ b/dashboard/src/components/goal-loop-panel.ts
@@ -14,6 +14,7 @@ import { fetchDashboardGoalsTree } from '../api/dashboard'
 import { callMcpTool } from '../api/mcp'
 import { asString, isRecord } from './common/normalize'
 import { formatMsCompact } from '../lib/format-number'
+import { errorToString } from '../lib/format-string'
 import { hydrateGoalTreeSnapshot } from '../goal-tree-state'
 import { navigate } from '../router'
 import {
@@ -324,7 +325,7 @@ function GoalCreateBlock({ onCreated }: { onCreated: () => void }) {
           .catch(() => undefined)
       })
       .catch((err) => {
-        setError(err instanceof Error ? err.message : String(err))
+        setError(errorToString(err))
       })
       .finally(() => setSubmitting(false))
   }, [horizon, onCreated, priority, title])
@@ -550,7 +551,7 @@ export function GoalLoopPanel({ initialStatus }: GoalLoopPanelProps) {
     void fetchGoalLoopStatus()
       .then(setStatus)
       .catch((err) => {
-        setError(err instanceof Error ? err.message : String(err))
+        setError(errorToString(err))
       })
       .finally(() => setLoading(false))
   }, [])

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -17,6 +17,7 @@ import { Surf } from './surf'
 import type { KeeperConversationEntry } from '../types'
 import { shellAuthSummary } from '../store'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
+import { errorToString } from '../lib/format-string'
 
 export interface ChatMessage {
   role: 'user' | 'assistant'
@@ -171,7 +172,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
         // Surface via chatError so the operator distinguishes "no
         // history yet" from "load failed" in the UI.
         if (stale) return
-        const msg = err instanceof Error ? err.message : String(err)
+        const msg = errorToString(err)
         chatError.value = `이전 대화 불러오기 실패: ${msg}`
       })
     return () => { stale = true }

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -26,6 +26,7 @@ import { TELEMETRY_SOURCE_META, telemetrySourceMeta } from '../config/telemetry-
 import { formatElapsedCompact, unixSecondsToDate } from '../lib/format-time'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { isAbortError } from '../lib/async-state'
+import { errorToString } from '../lib/format-string'
 import { Btn } from './btn'
 import { OasHealthChip } from './oas-health-chip'
 import { CopyIdButton } from './common/copy-id-button'
@@ -1199,7 +1200,7 @@ export function TelemetryUnified() {
           if (isAbortError(error)) throw error
           return {
             cacheStats: null,
-            cacheStatsError: error instanceof Error ? error.message : String(error),
+            cacheStatsError: errorToString(error),
           }
         })
       const [telemetry, , store, cacheStatsResult] = await Promise.all([

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -28,6 +28,7 @@ import { EmptyState } from './common/feedback-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { StatusChip } from './common/status-chip'
 import { relativeTime } from '../lib/format-time'
+import { errorToString } from '../lib/format-string'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import type { ManagedAsyncResource } from '../lib/async-state'
@@ -197,7 +198,7 @@ async function submitResolve(
     setRowAction(row.request_id, { kind: 'idle' })
     refresh()
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = errorToString(err)
     setRowAction(row.request_id, { kind: 'error', message })
   }
 }


### PR DESCRIPTION
## 변경 내용

PR #19209 (batch 1) + PR #19214 (batch 2) 의 후속. **depth-2 components/ 의 마지막 5 file** 7 callsite 처리.

batch 1 (2 file) + batch 2 (5 file) + batch 3 (5 file) = depth-2 errorToString migration 누적 12 file 18 callsite. 남은 작업은 depth-3 (ide/, goals/, tools/, tool-executor/, keeper-spawn/, task-manage/, flow-control/) 으로 별도 batch.

## Migrated callsites

| File | Line | Context |
|------|------|---------|
| `cascade-inspector.ts` | 94 | `traceError.value` on fetch fail |
| `cascade-inspector.ts` | 107 | `healthError.value` on fetch fail |
| `goal-loop-panel.ts` | 327 | `setError` on fetch fail |
| `goal-loop-panel.ts` | 553 | `setError` on fetch fail |
| `keeper-chat-panel.ts` | 174 | `msg` on sendMessage fail |
| `telemetry-unified.ts` | 1202 | `cacheStatsError` on fetch fail |
| `verification-requests-panel.ts` | 200 | `message` on mutate fail |

각 사이트 byte-for-byte 동일 inline ternary → `errorToString(err)`.

## 등가성

`errorToString` body (PR #19193 의 export):
```ts
err instanceof Error ? err.message : String(err)
```
runtime + type 추론 동일.

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (5 관련 test file) — 77/77 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 5 file +12/-7

## Out of scope

남은 ~13 file (depth-3, multi-callsite) follow-up batch.

