### PR TITLE
fix(test): unstale 2 tests broken by RFC-0199 Phase A typed evidence_claim

### DIFF
--- a/test/test_evidence_claim_schema.ml
+++ b/test/test_evidence_claim_schema.ml
@@ -6,7 +6,7 @@
     stay diff-friendly. *)
 
 open Alcotest
-module EC = Masc_mcp.Evidence_claim
+module EC = Evidence_claim
 
 let check_claim = check (testable EC.pp EC.equal)
 

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -141,6 +141,7 @@ let strict_contract ?(verify_gate_evidence = []) () : Masc_domain.task_contract 
   ; completion_contract = [ "tests pass" ]
   ; required_tools = []
   ; required_evidence = []
+  ; required_evidence_typed = []
   ; inspect_gate_evidence = []
   ; verify_gate_evidence
   ; links = { operation_id = None; session_id = None }


### PR DESCRIPTION
## Summary

`dune build .` (전체 tree) 두 test 가 fail — PR #19157 (`feat(rfc-0199-phase-a)` MERGED, commit `3eea18e38`) 후 stale.

```
test/test_evidence_claim_schema.ml:9
  Unbound module Masc_mcp.Evidence_claim

test/test_keeper_task_dispatch.ml:140-147
  Some record fields are undefined: required_evidence_typed
```

CI 통과 이유: 두 test 가 `(tests ...)` stanza 에 포함 안 되어 CI build target 의 일부 아님. `dune build .` 만 fail.

## Root cause

PR #19157 변경:
1. `Evidence_claim` module 을 `masc_types` 별도 sublibrary 로 추출 (`lib/types/dune`, `wrapped false`). `Masc_mcp.Evidence_claim` 경로 더 이상 존재 안 함.
2. `task_contract` record 에 `required_evidence_typed : Evidence_claim.t list` 필드 추가 (`lib/types/types_core.ml:497`). `[@default []]` annotation 은 `ppx_deriving_yojson` 용 — record literal 에는 모든 필드 명시 필수.

두 test 가 *test stanza 에 포함 안 됨* 으로 stale 검출 안 됨.

## Fix

```ocaml
(* test_evidence_claim_schema.ml:9 *)
- module EC = Masc_mcp.Evidence_claim
+ module EC = Evidence_claim
(* masc_types 는 wrapped=false 라 flat namespace.
   masc_test_deps:112 가 (re_export masc_types) 보유. *)
```

```ocaml
(* test_keeper_task_dispatch.ml:140-147 record literal *)
  { strict = true
  ; completion_contract = [ "tests pass" ]
  ; required_tools = []
  ; required_evidence = []
+ ; required_evidence_typed = []
  ; inspect_gate_evidence = []
  ; verify_gate_evidence
  ; links = { operation_id = None; session_id = None }
  }
```

## Why this is the right shape

- *내용* 변경 0 (test logic 그대로)
- 새 field default value `[]` 는 RFC-0199 의 `[@default []]` annotation 과 일치
- Path 정정은 lib refactor 결과 *반영*

## Workaround Signature Gate

WORKAROUND-WAIVED: stale test catch-up — counter / substring / N-of-M / catch-all / cap-cooldown / test-backdoor 비위반.

## Follow-up (separate RFC scope)

PR #19157 가 broken test 머지된 *root* 는 CI 의 build coverage gap. `dune build .` 또는 `dune build @check` 를 CI gate 로 promote 하면 이 class 의 stale-test drift 가 submit time 에 검출됨. 별도 RFC 권고.

## Build

```
$ dune build --root . .  EXIT=0
```

## Test plan

- [ ] CI build PASS (기존 CI target)
- [ ] Local `dune build .` PASS (새로 회복)

## Related

- PR #19157 — `feat(rfc-0199-phase-a)` (broken test 의 culprit)
- 관련 future RFC: CI build coverage gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
