### PR TITLE
refactor(dashboard): migrate 5 errorToString callsites across 5 depth-3 components (batch 4/N)

### DIFF
--- a/dashboard/src/components/ide/execute-output-drawer.ts
+++ b/dashboard/src/components/ide/execute-output-drawer.ts
@@ -16,6 +16,7 @@ import {
 import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
 import { IDE_CONTEXT_BADGE_STYLE } from './context-badge-style'
 import { routeLinkLabels } from './ide-context-route-helpers'
+import { errorToString } from '../../lib/format-string'
 
 const MAX_TERMINAL_LINES = 5000
 
@@ -268,7 +269,7 @@ export function ExecuteOutputDrawer({ keeperName }: ExecuteOutputDrawerProps) {
     }).catch(err => {
       if (controller.signal.aborted) return
       setStatus('error')
-      const message = err instanceof Error ? err.message : String(err)
+      const message = errorToString(err)
       setLines(current =>
         appendLines(current, [{ text: message, stream: 'stderr' }]),
       )

--- a/dashboard/src/components/ide/ide-branch-context-panel.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.ts
@@ -15,6 +15,7 @@ import {
 } from './ide-context-lens'
 import { IDE_CONTEXT_BADGE_STYLE } from './context-badge-style'
 import { routeLinkLabels } from './ide-context-route-helpers'
+import { errorToString } from '../../lib/format-string'
 
 type BranchTone = 'current' | 'dirty' | 'conflict' | 'stale'
 
@@ -255,7 +256,7 @@ export function IdeBranchContextPanel({
         })
         .catch(err => {
           if (cancelled || controller.signal.aborted) return
-          setError(err instanceof Error ? err.message : String(err))
+          setError(errorToString(err))
           setState('error')
         })
     }

--- a/dashboard/src/components/ide/interject-store.ts
+++ b/dashboard/src/components/ide/interject-store.ts
@@ -1,4 +1,5 @@
 import { signal } from '@preact/signals'
+import { errorToString } from '../../lib/format-string'
 
 export type InterjectActionKind = 'send' | 'approve' | 'pause' | 'drain'
 
@@ -154,7 +155,7 @@ export function createInterjectStore({
       setSnapshot({
         ...after,
         busy_action: null,
-        error: err instanceof Error ? err.message : String(err),
+        error: errorToString(err),
       })
       return false
     }

--- a/dashboard/src/components/task-manage/task-manage-state.ts
+++ b/dashboard/src/components/task-manage/task-manage-state.ts
@@ -2,6 +2,7 @@ import { signal } from '@preact/signals'
 import { callMcpTool } from '../../api/mcp'
 import { showToast } from '../common/toast'
 import { refreshExecution, refreshGoals } from '../../store'
+import { errorToString } from '../../lib/format-string'
 
 export const showTaskCreate = signal(false)
 export const taskCreating = signal(false)
@@ -29,7 +30,7 @@ export async function createTask(input: TaskCreateInput): Promise<boolean> {
     ])
     return true
   } catch (err) {
-    showToast(`태스크 생성 실패: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    showToast(`태스크 생성 실패: ${errorToString(err)}`, 'error')
     return false
   } finally {
     taskCreating.value = false

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -18,6 +18,7 @@ import { StatusChip } from '../common/status-chip'
 import { CopyIdButton } from '../common/copy-id-button'
 import { TextInput } from '../common/input'
 import { formatNumber } from '../../lib/format-number'
+import { errorToString } from '../../lib/format-string'
 
 function ConfigCard({
   class: cx,
@@ -446,7 +447,7 @@ function RuntimeProbePanel() {
       state.value = {
         ...state.value,
         loading: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: errorToString(error),
       }
     }
   }


### PR DESCRIPTION
## 변경 내용

PR #19209 (batch 1) / PR #19214 (batch 2, MERGED) / PR #19220 (batch 3) 의 후속. depth-2 sweep 종료 후 **첫 depth-3 batch — 5 single-callsite file**.

import path 만 `'../lib/format-string'` (depth-2) → `'../../lib/format-string'` (depth-3) 으로 바뀐 것 외에 batch 2/3 과 동일 패턴.

## Migrated callsites

| File | Line | Context |
|------|------|---------|
| `ide/execute-output-drawer.ts` | 271 | `message` on stream fail |
| `ide/ide-branch-context-panel.ts` | 258 | `setError` on fetch fail |
| `ide/interject-store.ts` | 157 | dispatch result `error` field |
| `tools/config-resolution-panel.ts` | 449 | lookup `error` field |
| `task-manage/task-manage-state.ts` | 32 | toast on task-create fail |

각 사이트 byte-for-byte 동일 inline ternary → `errorToString(err)`.

## file-internal duplicate 점검

5 file 모두 file-internal `errorToString` helper 0 — typecheck 통과로 자동 확인 (iter#69 cascade-config-panel duplicate 가 정확히 그렇게 발견된 것과 동일 SOP).

## 등가성

`errorToString` body (PR #19193 export):
```ts
err instanceof Error ? err.message : String(err)
```

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (6 관련 test file) — 52/52 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 5 file +10/-5

## Out of scope

남은 depth-3 ~5 file (multi-callsite: flow-control-state 4, goal-tree 3, keeper-spawn-state 3, prompt-registry-panel 3, tool-executor-state 2). follow-up batch.

