### PR TITLE
refactor(dashboard): migrate 15 errorToString callsites across 5 multi-callsite depth-3 components (batch 5/N)

### DIFF
--- a/dashboard/src/components/flow-control/flow-control-state.ts
+++ b/dashboard/src/components/flow-control/flow-control-state.ts
@@ -4,6 +4,7 @@ import { namespaceTruth, namespaceTruthInitializing } from '../../namespace-trut
 import { serverStatus, shellAuthSummary } from '../../store'
 import { showToast } from '../common/toast'
 import { dashboardAuthAccess } from '../../lib/dashboard-auth-access'
+import { errorToString } from '../../lib/format-string'
 
 type FlowState = 'unknown' | 'initializing' | 'running' | 'paused'
 export const flowState = signal<FlowState>('unknown')
@@ -69,7 +70,7 @@ export async function pauseRoom(): Promise<void> {
   }
   flowLoading.value = true
   try { await callMcpTool('masc_pause', {}); flowState.value = 'paused'; showToast('Namespace paused.', 'success') }
-  catch (err) { showToast(`Pause failed: ${err instanceof Error ? err.message : String(err)}`, 'error') }
+  catch (err) { showToast(`Pause failed: ${errorToString(err)}`, 'error') }
   finally { flowLoading.value = false }
 }
 
@@ -81,7 +82,7 @@ export async function resumeRoom(): Promise<void> {
   }
   flowLoading.value = true
   try { await callMcpTool('masc_resume', {}); flowState.value = 'running'; showToast('Namespace resumed.', 'success') }
-  catch (err) { showToast(`Resume failed: ${err instanceof Error ? err.message : String(err)}`, 'error') }
+  catch (err) { showToast(`Resume failed: ${errorToString(err)}`, 'error') }
   finally { flowLoading.value = false }
 }
 
@@ -99,7 +100,7 @@ export async function runGarbageCollection(): Promise<void> {
     maintenanceResult.value = raw
     showToast('GC complete.', 'success')
   } catch (err) {
-    showToast(`GC failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    showToast(`GC failed: ${errorToString(err)}`, 'error')
   } finally { maintenanceLoading.value = false }
 }
 
@@ -115,6 +116,6 @@ export async function cleanupZombies(): Promise<void> {
     maintenanceResult.value = raw
     showToast('Zombie cleanup complete.', 'success')
   } catch (err) {
-    showToast(`Zombie cleanup failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    showToast(`Zombie cleanup failed: ${errorToString(err)}`, 'error')
   } finally { maintenanceLoading.value = false }
 }

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -65,6 +65,7 @@ import {
   goalCompletionTone,
 } from './goal-completion-summary'
 import { DECK_CHIP, DECK_LABEL, DECK_META } from './deck-classes'
+import { errorToString } from '../../lib/format-string'
 
 type GoalDetailTab = 'summary' | 'tasks' | 'evidence'
 type GoalTransitionAction = 'request_complete' | 'approve_completion' | 'reject_completion'
@@ -530,7 +531,7 @@ async function refreshTree() {
   try {
     hydrateGoalTreeSnapshot(await fetchDashboardGoalsTree())
   } catch (err) {
-    treeError.value = err instanceof Error ? err.message : String(err)
+    treeError.value = errorToString(err)
   } finally {
     treeLoading.value = false
   }
@@ -549,7 +550,7 @@ async function refreshGoalDetail(goalId: string) {
     detailData.value = next
   } catch (err) {
     if (detailRequestSeq !== reqId) return
-    detailError.value = err instanceof Error ? err.message : String(err)
+    detailError.value = errorToString(err)
   } finally {
     if (detailRequestSeq === reqId) detailLoading.value = false
   }
@@ -891,7 +892,7 @@ function GoalLifecycleActionPanel({ node }: { node: GoalTreeNode }) {
           refreshGoalDetail(node.id),
         ])
       } catch (err) {
-        setError(err instanceof Error ? err.message : String(err))
+        setError(errorToString(err))
       } finally {
         setPendingAction(null)
       }

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
@@ -5,6 +5,7 @@ import { showToast } from '../common/toast'
 import { createAsyncResource, getData } from '../../lib/async-state'
 import { refreshExecution, shellAuthSummary } from '../../store'
 import { dashboardAuthAccess } from '../../lib/dashboard-auth-access'
+import { errorToString } from '../../lib/format-string'
 
 export interface PersonaSummary {
   name: string
@@ -222,7 +223,7 @@ export async function spawnKeeperFromPersona(personaName: string, opts?: { dryRu
       void refreshExecution({ force: true })
     }
   } catch (err) {
-    const message = formatKeeperSpawnError(err instanceof Error ? err.message : String(err))
+    const message = formatKeeperSpawnError(errorToString(err))
     spawnResult.value = { success: false, message }
     showToast(`키퍼 생성 실패: ${message}`, 'error')
   } finally {
@@ -270,7 +271,7 @@ export async function generatePersonaDraft(input: GeneratePersonaDraftInput): Pr
     personaAuthoringResult.value = { success: true, message: result }
     showToast(`${draft.handle} 페르소나 초안 생성`, 'success')
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = errorToString(err)
     personaAuthoringResult.value = { success: false, message }
     showToast(`페르소나 생성 실패: ${message}`, 'error')
   } finally {
@@ -312,7 +313,7 @@ export async function savePersonaDraft(opts?: { overwrite?: boolean; dryRun?: bo
       showToast(`${draft.handle} 페르소나 저장 dry-run 완료`, 'success')
     }
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = errorToString(err)
     personaAuthoringResult.value = { success: false, message }
     showToast(`페르소나 저장 실패: ${message}`, 'error')
   } finally {

--- a/dashboard/src/components/tool-executor/tool-executor-state.ts
+++ b/dashboard/src/components/tool-executor/tool-executor-state.ts
@@ -5,6 +5,7 @@ import { showToast } from '../common/toast'
 import { buildDefaults, stripEmptyOptionals, validateRequired } from './schema-form'
 import { shellAuthSummary } from '../../store'
 import { dashboardAuthAccess, type DashboardAuthRole } from '../../lib/dashboard-auth-access'
+import { errorToString } from '../../lib/format-string'
 
 const allToolSchemas = signal<McpToolSchema[]>([])
 export const schemasLoading = signal(false)
@@ -59,7 +60,7 @@ export async function loadToolSchemas(force = false): Promise<void> {
     })) as McpToolSchema[]
     schemasLoadedAt.value = Date.now()
   } catch (err) {
-    schemasError.value = err instanceof Error ? err.message : String(err)
+    schemasError.value = errorToString(err)
     showToast('도구 스키마 로드 실패', 'error')
   } finally {
     schemasLoading.value = false
@@ -111,7 +112,7 @@ export async function executeTool(): Promise<void> {
     lastResult.value = { success: true, text, toolName: tool.name, timestamp: Date.now() }
     showToast(`${tool.name} 실행 완료`, 'success')
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const message = errorToString(err)
     lastResult.value = { success: false, text: message, toolName: tool.name, timestamp: Date.now() }
     showToast(`${tool.name} 실행 실패`, 'error')
   } finally {

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -15,6 +15,7 @@ import { ActionButton } from '../common/button'
 import { TextArea, TextInput } from '../common/input'
 import { FilterChips } from '../common/filter-chips'
 import { StatusChip } from '../common/status-chip'
+import { errorToString } from '../../lib/format-string'
 
 type PromptSourceFilter = 'all' | PromptSource
 
@@ -111,7 +112,7 @@ export function PromptRegistryPanel() {
       const nextPrompt = nextPrompts.find(prompt => prompt.key === nextSelectedKey) ?? nextPrompts[0] ?? null
       setDraft(normalizeDraft(nextPrompt))
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(errorToString(err))
     } finally {
       setLoading(false)
     }
@@ -139,7 +140,7 @@ export function PromptRegistryPanel() {
       setStatus(response.message ?? 'override 설정됨')
       await loadPrompts(selectedPrompt.key)
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(errorToString(err))
     } finally {
       setSaving(false)
     }
@@ -158,7 +159,7 @@ export function PromptRegistryPanel() {
       setStatus(response.message ?? 'override cleared')
       await loadPrompts(selectedPrompt.key)
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setError(errorToString(err))
     } finally {
       setSaving(false)
     }


### PR DESCRIPTION
## 변경 내용

PR #19193 (helper export) + PR #19214 (batch 2) + PR #19225 (batch 4) 머지 완료. errorToString consolidation 의 **마지막 depth-3 batch — 5 multi-callsite file, 15 callsite**.

본 PR 이 머지되면 남은 inline `err instanceof Error ? err.message : String(err)` 사이트는 PR #19209 (batch 1, dashboard-ws + api/mcp) 4 callsite 뿐. PR #19209 가 머지되면 dashboard 전체 errorToString SSOT consolidation 완료.

## Migrated callsites

| File | Lines | Count | Context |
|------|-------|-------|---------|
| `flow-control/flow-control-state.ts` | 72, 84, 102, 118 | 4 | showToast on pause/resume/GC/zombie-cleanup fail |
| `goals/goal-tree.ts` | 533, 552, 894 | 3 | tree/detail/setError on fetch fail |
| `keeper-spawn/keeper-spawn-state.ts` | 225, 273, 315 | 3 | spawn error / message (1× wrapped by `formatKeeperSpawnError`) |
| `tools/prompt-registry-panel.ts` | 114, 142, 161 | 3 | setError on fetch/save/refresh fail |
| `tool-executor/tool-executor-state.ts` | 62, 114 | 2 | schemasError / message on tool list fail |

모든 15 callsite byte-for-byte 동일 inline ternary → `errorToString(err)`.

## 등가성

`errorToString` body (PR #19193 export, `lib/format-string`):
```ts
err instanceof Error ? err.message : String(err)
```
runtime 동작 + type 추론 동일.

**참고 — keeper-spawn-state:225**: `formatKeeperSpawnError(err instanceof Error ? err.message : String(err))` → `formatKeeperSpawnError(errorToString(err))`. wrapper 가 그대로 유지되므로 동작 동일.

## file-internal duplicate 점검

5 file 모두 file-internal `errorToString` helper 0 — typecheck 통과로 자동 확인.

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (8 관련 test file) — 60/60 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 5 file +20/-15

## 누적 (consolidation 진행 상황)

- depth-2: 12 file 18 callsite — batch 1/2/3 (#19209 still open, #19214/#19220 merged)
- depth-3 single-callsite: 5 file 5 callsite — batch 4 (#19225 merged)
- depth-3 multi-callsite: 5 file 15 callsite — batch 5 (this PR)
- helper-only export: PR #19193 (merged)

**총 22 file 38 callsite + 1 file-internal duplicate 제거** 가 단일 SSOT (`lib/format-string.ts` errorToString) 로 수렴.

