### PR TITLE
refactor(dashboard): export ownership effect directly

### DIFF
--- a/dashboard/src/components/ide/ide-editor-extensions.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.ts
@@ -272,7 +272,7 @@ class BlameMarker extends GutterMarker {
 
 const BLAME_EMPTY = new BlameMarker(null)
 
-const setOwnership = StateEffect.define<ReadonlyMap<number, LineOwnership>>()
+export const setOwnership = StateEffect.define<ReadonlyMap<number, LineOwnership>>()
 
 const blameMarkerField = StateField.define<BlameMarker[]>({
   create() {
@@ -1427,5 +1427,3 @@ export function lineNumberExt(): Extension {
 export function blameExtensions(): Extension[] {
   return [blameGutterExt()]
 }
-
-export { setOwnership }


### PR DESCRIPTION
## Summary
- export the CodeMirror ownership StateEffect at its definition site
- remove the trailing setOwnership re-export from ide-editor-extensions

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/ide/ide-editor-extensions.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/ide/ide-editor-extensions.ts src/components/ide/ide-editor-extensions.test.ts
- git diff --check origin/main