### PR TITLE
refactor(dashboard): remove fleet transition fields reexport

### DIFF
--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -35,7 +35,6 @@ import {
   displayState,
   extractLaneValue,
   INVARIANT_LABELS,
-  TRANSITION_FIELDS,
   type LaneKey,
 } from './fsm-hub-types'
 
@@ -1304,8 +1303,3 @@ export function inferKeeperNameFrom(snap: KeeperCompositeSnapshot): string {
   const m = /^keeper:([^:]+):/.exec(snap.correlation_id)
   return m?.[1] ?? snap.correlation_id
 }
-
-// Re-exported helpers let tests target the pure slices without spinning
-// up the component. TRANSITION_FIELDS is re-exported for completeness
-// so a caller doesn't need to reach into fsm-hub-types for AXES parity.
-export { TRANSITION_FIELDS }


### PR DESCRIPTION
## Summary
- remove the unused TRANSITION_FIELDS re-export from fleet-fsm-matrix
- drop the import that only existed to support that re-export
- remove the stale re-export comment

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/fleet-fsm-matrix.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/fleet-fsm-matrix.ts src/components/fleet-fsm-matrix.test.ts
- git diff --check origin/main