### PR TITLE
refactor(dashboard): import keeper detail page directly

### DIFF
--- a/dashboard/src/components/agents-unified.test.ts
+++ b/dashboard/src/components/agents-unified.test.ts
@@ -12,7 +12,7 @@ const mockRoute = await vi.hoisted(async () => {
 type FilterChip = { key: string; label: ComponentChildren }
 type FilterChipWithCount = FilterChip & { count?: ComponentChildren }
 
-vi.mock('./keeper-detail', () => ({
+vi.mock('./keeper-detail-page', () => ({
   KeeperDetailPage: () => h('div', { 'data-testid': 'keeper-detail-page' }, 'KeeperDetailPage'),
 }))
 vi.mock('./agent-profile', () => ({

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -10,7 +10,7 @@ import { navigate, route } from '../router'
 import { agents, keepers, executionLoaded } from '../store'
 import { AgentRoster, countRuntimeKinds } from './agent-roster'
 import { AgentProfile } from './agent-profile'
-import { KeeperDetailPage } from './keeper-detail'
+import { KeeperDetailPage } from './keeper-detail-page'
 import { namespaceTruth } from '../namespace-truth-store'
 import {
   formatKeeperRosterCount,

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -136,8 +136,8 @@ vi.mock('../router', () => ({
   route: mocks.route,
 }))
 
+import { KeeperDetailPage } from './keeper-detail-page'
 import {
-  KeeperDetailPage,
   clearKeeperDetailSelection,
   closeKeeperDetail,
   filterCheckpointHistory,

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -1,6 +1,5 @@
-// Keeper detail grouped exports from decomposed keeper-detail-*.ts modules.
+// Keeper detail state/history facade from decomposed keeper-detail-*.ts modules.
 
-export { KeeperDetailPage } from './keeper-detail-page'
 export {
   selectedKeeper,
   openKeeperDetail,


### PR DESCRIPTION
## Summary
- remove KeeperDetailPage from the keeper-detail facade
- import the page component from keeper-detail-page at actual page consumers
- keep keeper-detail as the state/history helper facade

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/keeper-detail.test.ts src/components/agents-unified.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/keeper-detail.ts src/components/keeper-detail-page.ts src/components/agents-unified.ts src/components/agents-unified.test.ts src/components/keeper-detail.test.ts
- git diff --check origin/main

## Notes
- eslint reports agents-unified.test.ts and keeper-detail.test.ts are ignored by the current config; command exits successfully.