### PR TITLE
refactor(dashboard): centralise [0,100] percentage clamp in lib/format-number.clampPct

### DIFF
--- a/dashboard/src/components/common/progress-bar.ts
+++ b/dashboard/src/components/common/progress-bar.ts
@@ -13,6 +13,7 @@
 // mounting a component per row.
 
 import { html } from 'htm/preact'
+import { clampPct } from '../../lib/format-number'
 
 export type ProgressBarSize = 'xs' | 'sm' | 'md'
 export type ProgressBarTone =
@@ -40,16 +41,12 @@ export interface ProgressBarSummary {
   readonly testIdLength: number
 }
 
-function clampProgressPct(pct: number): number {
-  return Math.max(0, Math.min(100, pct))
-}
-
 /** Pure: clamp a percentage into [0, 100] and produce the inline width
     style string. Exposed so callers that need to render the bar inline
     (inside a flex row with other progress bars) can use the same
     semantics without mounting the component. */
 export function progressBarWidthStyle(pct: number): string {
-  const clamped = clampProgressPct(pct)
+  const clamped = clampPct(pct)
   return `width: ${clamped.toFixed(2)}%`
 }
 
@@ -130,7 +127,7 @@ export function summarizeProgressBar({
   ariaLabel,
   testId,
 }: ProgressBarProps): ProgressBarSummary {
-  const clampedPct = clampProgressPct(pct)
+  const clampedPct = clampPct(pct)
   const fillSource = cx !== undefined && cx !== '' ? 'custom-class' : 'tone'
 
   return {

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -4,6 +4,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
 import { SECONDS_PER_HOUR } from '../../lib/format-time'
+import { clampPct } from '../../lib/format-number'
 import { fetchDashboardGoalDetail, fetchDashboardGoalsTree } from '../../api/dashboard'
 import { currentDashboardActor } from '../../api/core'
 import { callMcpTool } from '../../api/mcp'
@@ -556,7 +557,7 @@ async function refreshGoalDetail(goalId: string) {
 }
 
 function ConvergenceBar({ pct, size = 'md' }: { pct: number; size?: 'sm' | 'md' }) {
-  const clamped = Math.max(0, Math.min(100, pct))
+  const clamped = clampPct(pct)
   const barColor =
     clamped >= 80 ? 'var(--color-status-ok)'
     : clamped >= 50 ? 'var(--color-amber-bright)'

--- a/dashboard/src/lib/board-utils.ts
+++ b/dashboard/src/lib/board-utils.ts
@@ -53,6 +53,7 @@ import type { Message } from '../types'
 import { findKeeper } from './keeper-utils'
 import { openKeeperDetail } from '../components/keeper-detail'
 import { stripStateBlocks } from '../keeper-message'
+import { clampPct } from './format-number'
 import type { BoardActorIdentity, BoardContributorQuality } from '../types'
 
 /** Strip inline markdown formatting from title text (bold, italic, code). */
@@ -102,7 +103,7 @@ export function boardActorTitle(
 
 export function contributorQualityPercent(quality?: BoardContributorQuality | null): number | null {
   if (!quality || !Number.isFinite(quality.score)) return null
-  return Math.max(0, Math.min(100, Math.round(quality.score * 100)))
+  return clampPct(Math.round(quality.score * 100))
 }
 
 export function contributorQualityBandLabel(quality?: BoardContributorQuality | null): string {

--- a/dashboard/src/lib/format-number.ts
+++ b/dashboard/src/lib/format-number.ts
@@ -63,3 +63,17 @@ export function formatMsCompact(ms: number | null | undefined, fallback = ''): s
 export function isFiniteMetricValue(value: number | null | undefined): value is number {
   return typeof value === 'number' && Number.isFinite(value)
 }
+
+/**
+ * Clamp a percentage value into the `[0, 100]` range. Width-style
+ * renderers, badge colour thresholds, and quality-score normalisers
+ * all need this exact body — three callsites previously inlined
+ * `Math.max(0, Math.min(100, ...))` (plus `progress-bar.ts` shipped
+ * a file-internal `clampProgressPct` helper with this body).
+ *
+ * Does not handle `NaN`: a `NaN` input returns `NaN`. Pair with
+ * `isFiniteMetricValue` if the input could be invalid.
+ */
+export function clampPct(value: number): number {
+  return Math.max(0, Math.min(100, value))
+}


### PR DESCRIPTION
## 변경 내용

`lib/format-number.ts` 에 `clampPct(value: number): number` 추가, **3 file 4 callsite** 의 `Math.max(0, Math.min(100, ...))` 패턴 통합.

errorToString consolidation (PR #19193 + #19209/#19214/#19220/#19225/#19229) 이후의 후속 SSOT extraction — *같은 class 의 다른 axis*. 1 file-internal helper (progress-bar.ts `clampProgressPct`) 제거 + 2 inline → lib helper 라우팅.

## 변경 사이트

| File | Line | 이전 | 이후 |
|------|------|------|------|
| `lib/format-number.ts` | + | (없음) | `export function clampPct(value: number): number` |
| `components/common/progress-bar.ts` | 43 | `function clampProgressPct(pct)` (file-internal) | (삭제) |
| `components/common/progress-bar.ts` | 52 | `clampProgressPct(pct)` | `clampPct(pct)` |
| `components/common/progress-bar.ts` | 133 | `clampProgressPct(pct)` | `clampPct(pct)` |
| `lib/board-utils.ts` | 105 | `Math.max(0, Math.min(100, Math.round(quality.score * 100)))` | `clampPct(Math.round(quality.score * 100))` |
| `components/goals/goal-tree.ts` | 559 | `Math.max(0, Math.min(100, pct))` | `clampPct(pct)` |

## SSOT 의미

PR #19193 (errorToString) / PR #19201 (isFiniteMetricValue self-bypass) / PR #19214 (file-internal duplicate 제거) 와 *같은 class* — **canonical helper 한 곳, shadow copy 0**.

미래 정책 변경 시:
- `[0, 100]` 범위가 아닌 `[0, 100)` 으로 바꾸려면? → `clampPct` 한 곳만 수정
- 음수 입력에 `NaN` 반환하도록 strict화? → 한 곳만 수정
- 현재 4 callsite 가 자동 전파 (이전엔 3 곳 stale)

## NaN 처리 의도적 부재

`clampPct` 는 `NaN` 입력 시 `NaN` 반환. JSDoc 에 명시: callers 가 invalid input 가능성이 있으면 같은 모듈의 `isFiniteMetricValue` 와 pair 사용. 이는 기존 callsite 의 명시적 동작과 일치 (board-utils 는 `isFinite` 가드 후 clamp, 다른 두 곳은 input 이 항상 number 임을 가정).

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (5 관련 test file) — 81/81 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 4 file +21/-8

