### PR TITLE
[codex] Index HTTP router dispatch table

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -222,7 +222,7 @@ let try_mcp_validation_block ~is_mcp_like ~request ~protocol_version ~origin req
 (** Method/path dispatcher for MCP-validated requests. Caller is
     responsible for rate limiting and origin/protocol-version checks
     before invoking this function. *)
-let dispatch_route ~routes ~request ~path reqd =
+let dispatch_route ~router ~request ~path reqd =
   match request.Httpun.Request.meth, path with
   | `OPTIONS, _ -> options_handler request reqd
   | `GET, "/ws" ->
@@ -433,7 +433,7 @@ let dispatch_route ~routes ~request ~path reqd =
           ~config ~voter ~response_format:format ~post_id
       in
       Http.Response.json ~status body reqd
-  | _ -> Http.Router.dispatch routes request reqd
+  | _ -> Http.Router.dispatch router request reqd
 
 let log_late_response_failure ~context msg =
   Log.Http.warn "%s: response already unwritable; skipped late response (%s)"
@@ -468,7 +468,7 @@ let make_extended_handler routes =
       in
       let origin = get_origin request in
       if try_mcp_validation_block ~is_mcp_like ~request ~protocol_version ~origin reqd then ()
-      else dispatch_route ~routes ~request ~path reqd
+      else dispatch_route ~router:routes ~request ~path reqd
     with
     (* Re-raise cancellation so Eio structured concurrency propagates cleanly.
        Previously the catch-all swallowed Cancelled and tried to write a 500

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -406,9 +406,9 @@ module Request = struct
 
   (** Get path from request target *)
   let path (request : Httpun.Request.t) =
-    match String.split_on_char '?' request.target with
-    | p :: _ -> p
-    | [] -> request.target (* split always returns non-empty, but type-safe *)
+    match String.index_opt request.target '?' with
+    | Some idx -> String.sub request.target 0 idx
+    | None -> request.target
 
   (** Get HTTP method *)
   let method_ (request : Httpun.Request.t) =
@@ -421,7 +421,10 @@ end
 
 (** Router for simple path-based routing *)
 module Router = struct
+  type route_kind = Exact | Prefix
+
   type route = {
+    kind: route_kind;
     path: string;
     methods: Httpun.Method.t list;
     handler: request_handler;
@@ -432,12 +435,51 @@ module Router = struct
     | `Method_not_allowed
     | `Not_found ]
 
-  type t = route list
+  type t = {
+    exact_by_path: (string, route list) Hashtbl.t;
+    mutable prefix_routes: route list;
+    mutable route_count: int;
+  }
 
-  let empty : t = []
+  let create () =
+    { exact_by_path = Hashtbl.create 128; prefix_routes = []; route_count = 0 }
 
-  let add ~path ~methods ~handler routes =
-    { path; methods; handler } :: routes
+  let route_count router = router.route_count
+
+  let routes router =
+    let exact =
+      router.exact_by_path |> Hashtbl.to_seq_values |> List.of_seq |> List.concat
+    in
+    exact @ router.prefix_routes
+
+  let insert_prefix_route route routes =
+    let route_len = String.length route.path in
+    let rec loop acc = function
+      | [] -> List.rev (route :: acc)
+      | candidate :: rest
+        when route_len >= String.length candidate.path ->
+          List.rev_append acc (route :: candidate :: rest)
+      | candidate :: rest -> loop (candidate :: acc) rest
+    in
+    loop [] routes
+
+  let add_kind kind ~path ~methods ~handler router =
+    let route = { kind; path; methods; handler } in
+    (match kind with
+     | Exact ->
+         let existing =
+           match Hashtbl.find_opt router.exact_by_path path with
+           | Some routes -> routes
+           | None -> []
+         in
+         Hashtbl.replace router.exact_by_path path (route :: existing)
+     | Prefix ->
+         router.prefix_routes <- insert_prefix_route route router.prefix_routes);
+    router.route_count <- router.route_count + 1;
+    router
+
+  let add ~path ~methods ~handler router =
+    add_kind Exact ~path ~methods ~handler router
 
   let get path handler routes =
     add ~path ~methods:[`GET] ~handler routes
@@ -451,59 +493,42 @@ module Router = struct
   (** Match by prefix: path field is treated as a prefix, not exact match.
       The suffix (path after the prefix) is available via [Request.path]. *)
   let prefix_get prefix handler routes =
-    add ~path:("PREFIX:" ^ prefix) ~methods:[`GET] ~handler routes
+    add_kind Prefix ~path:prefix ~methods:[`GET] ~handler routes
 
   let prefix_post prefix handler routes =
-    add ~path:("PREFIX:" ^ prefix) ~methods:[`POST] ~handler routes
+    add_kind Prefix ~path:prefix ~methods:[`POST] ~handler routes
 
   let prefix_delete prefix handler routes =
-    add ~path:("PREFIX:" ^ prefix) ~methods:[`DELETE] ~handler routes
+    add_kind Prefix ~path:prefix ~methods:[`DELETE] ~handler routes
 
   let prefix_put prefix handler routes =
-    add ~path:("PREFIX:" ^ prefix) ~methods:[`PUT] ~handler routes
+    add_kind Prefix ~path:prefix ~methods:[`PUT] ~handler routes
 
-  let resolve routes request =
+  let resolve router request =
     let req_path = Request.path request in
     let req_method = Request.method_ request in
-    (* Try exact matches first *)
-    let path_matches =
-      List.filter (fun route ->
-        (not (String.length route.path > 7
-              && String.sub route.path 0 7 = "PREFIX:"))
-        && String.equal route.path req_path
-      ) routes
-    in
-    match List.find_opt (fun route -> List.mem req_method route.methods) path_matches with
+    let exact_path_matches = Hashtbl.find_opt router.exact_by_path req_path in
+    match
+      Option.bind exact_path_matches (fun routes ->
+        List.find_opt (fun route -> List.mem req_method route.methods) routes)
+    with
     | Some route -> `Matched route
     | None ->
-        (* Try prefix matches *)
-        let prefix_matches =
-          List.filter (fun route ->
-            String.length route.path > 7
-            && String.sub route.path 0 7 = "PREFIX:"
-            && let prefix = String.sub route.path 7 (String.length route.path - 7) in
-               String.starts_with req_path ~prefix
-            && List.mem req_method route.methods
-          ) routes
-        in
-        let prefix_matches =
-          List.sort
-            (fun a b ->
-              let a_len = String.length a.path - 7 in
-              let b_len = String.length b.path - 7 in
-              compare b_len a_len)
-            prefix_matches
-        in
-        (match prefix_matches with
-         | route :: _ -> `Matched route
-         | [] ->
-             if path_matches = [] then
-               `Not_found
-             else
-               `Method_not_allowed)
+        (match
+           List.find_opt
+             (fun route ->
+                String.starts_with req_path ~prefix:route.path
+                && List.mem req_method route.methods)
+             router.prefix_routes
+         with
+         | Some route -> `Matched route
+         | None ->
+             (match exact_path_matches with
+              | Some _ -> `Method_not_allowed
+              | None -> `Not_found))
 
-  let dispatch routes request reqd =
-    match resolve routes request with
+  let dispatch router request reqd =
+    match resolve router request with
     | `Matched route -> route.handler request reqd
     | `Not_found -> Response.not_found reqd
     | `Method_not_allowed -> Response.method_not_allowed reqd

--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -10,7 +10,7 @@
     \[Shutdown] (graceful-shutdown signaling), the 5 built-in
     handlers ([health_handler], [ready_handler],
     [metrics_handler], [mcp_post_handler], [mcp_get_handler]),
-    \[default_routes] (the route list assembled from those
+    \[default_routes] (the route table assembled from those
     handlers), \[with_streamable_mcp_request_handler],
     \[make_request_handler] (router → request_handler
     converter), \[error_handler] (httpun connection error
@@ -245,12 +245,11 @@ end
     matches take precedence over prefix matches (longest prefix
     wins among prefix matches). *)
 module Router : sig
-  (** [path] uses the [PREFIX:] sentinel internally for
-      prefix-match routes; callers should use {!prefix_get} /
-      {!prefix_post} instead of crafting the sentinel
-      manually. *)
+  type route_kind = Exact | Prefix
+
   type route =
-    { path : string
+    { kind : route_kind
+    ; path : string
     ; methods : Httpun.Method.t list
     ; handler : request_handler
     }
@@ -261,9 +260,14 @@ module Router : sig
     | `Not_found
     ]
 
-  type t = route list
+  (** Indexed dispatch table.  Route registration updates exact path buckets
+      and a longest-prefix ordered prefix table at build time, so request
+      dispatch does not scan/sort the full endpoint list. *)
+  type t
 
-  val empty : t
+  val create : unit -> t
+  val route_count : t -> int
+  val routes : t -> route list
 
   (** Generic add; prefer the typed wrappers below. *)
   val add

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -16,7 +16,7 @@ let make_routes ~port ~host ~sw ~clock =
      the callback. *)
   Server_routes_http_routes_multimodal.bind_workspace_getter
     Multimodal.Workspace_holder.get;
-  Http.Router.empty
+  Http.Router.create ()
   |> Server_routes_http_routes_frontend.add_routes ~port ~host
   |> Server_routes_http_routes_room.add_routes
   |> Server_routes_http_routes_dashboard.add_routes ~sw ~clock

--- a/lib/server/server_routes_http_routes_channel_gate.mli
+++ b/lib/server/server_routes_http_routes_channel_gate.mli
@@ -8,8 +8,8 @@
 val add_routes :
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
-  Http_server_eio.Router.route list ->
-  Http_server_eio.Router.route list
+  Http_server_eio.Router.t ->
+  Http_server_eio.Router.t
 
 val record_validation_error_metric :
   duration_ms:int -> string -> string -> unit

--- a/lib/server/server_routes_http_routes_credentials.ml
+++ b/lib/server/server_routes_http_routes_credentials.ml
@@ -358,9 +358,7 @@ let add_routes router =
                                       \"web\" or \"with_token\""
                                      other))))))
          request reqd)
-  |> Http.Router.add ~path:("PREFIX:/api/v1/credentials/")
-       ~methods:[`DELETE]
-       ~handler:(fun request reqd ->
+  |> Http.Router.prefix_delete "/api/v1/credentials/" (fun request reqd ->
          with_token_permission_auth ~permission:Masc_domain.CanAdmin
            (fun state _agent_name req reqd ->
              let base_path = state.Mcp_server.room_config.base_path in

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -402,14 +402,10 @@ let add_routes router =
   |> Http.Router.post "/api/v1/repositories/discover" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
          handle_discover_repositories request reqd)
-  |> Http.Router.add ~path:("PREFIX:" ^ repositories_prefix)
-       ~methods:[`DELETE]
-       ~handler:(fun request reqd ->
+  |> Http.Router.prefix_delete repositories_prefix (fun request reqd ->
          with_token_permission_auth ~permission:Masc_domain.CanAdmin
            handle_remove_repository request reqd)
-  |> Http.Router.add ~path:("PREFIX:" ^ repositories_prefix)
-       ~methods:[`PUT]
-       ~handler:(fun request reqd ->
+  |> Http.Router.prefix_put repositories_prefix (fun request reqd ->
          with_token_permission_auth ~permission:Masc_domain.CanAdmin
            handle_update_repository request reqd)
   |> Http.Router.prefix_post repositories_prefix (fun request reqd ->

--- a/lib/server/server_routes_http_routes_sidecar.mli
+++ b/lib/server/server_routes_http_routes_sidecar.mli
@@ -336,6 +336,6 @@ val handle_start :
   Httpun.Request.t -> Httpun.Reqd.t -> unit
 
 val add_routes :
-  sw:'a -> clock:'b -> Http.Router.route list -> Http.Router.route list
+  sw:'a -> clock:'b -> Http.Router.t -> Http.Router.t
 (** Compose every sidecar route on top of [routes].  Called from the
     HTTP routing assembly. *)

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -8,38 +8,38 @@ open Masc_mcp.Http_server_eio
 (* ===== Unit Tests for Router ===== *)
 
 let test_router_empty () =
-  let routes = Router.empty in
-  Alcotest.(check int) "empty router" 0 (List.length routes)
+  let routes = Router.create () in
+  Alcotest.(check int) "empty router" 0 (Router.route_count routes)
 ;;
 
 let test_router_add_get () =
   let handler _req _reqd = () in
-  let routes = Router.empty |> Router.get "/test" handler in
-  Alcotest.(check int) "one route" 1 (List.length routes)
+  let routes = Router.create () |> Router.get "/test" handler in
+  Alcotest.(check int) "one route" 1 (Router.route_count routes)
 ;;
 
 let test_router_add_post () =
   let handler _req _reqd = () in
-  let routes = Router.empty |> Router.post "/api" handler in
-  Alcotest.(check int) "one route" 1 (List.length routes)
+  let routes = Router.create () |> Router.post "/api" handler in
+  Alcotest.(check int) "one route" 1 (Router.route_count routes)
 ;;
 
 let test_router_add_multiple () =
   let handler _req _reqd = () in
   let routes =
-    Router.empty
+    Router.create ()
     |> Router.get "/health" handler
     |> Router.post "/api/call" handler
     |> Router.any "/any" handler
   in
-  Alcotest.(check int) "three routes" 3 (List.length routes)
+  Alcotest.(check int) "three routes" 3 (Router.route_count routes)
 ;;
 
 let test_router_prefix_specificity () =
   let generic_handler _req _reqd = () in
   let asset_handler _req _reqd = () in
   let routes =
-    Router.empty
+    Router.create ()
     |> Router.prefix_get "/dashboard/assets/" asset_handler
     |> Router.prefix_get "/dashboard/" generic_handler
   in
@@ -48,11 +48,31 @@ let test_router_prefix_specificity () =
   | `Matched route ->
     Alcotest.(check string)
       "longest prefix route should win"
-      "PREFIX:/dashboard/assets/"
+      "/dashboard/assets/"
       route.path
   | `Method_not_allowed ->
     Alcotest.fail "expected a matched prefix route, got method_not_allowed"
   | `Not_found -> Alcotest.fail "expected a matched prefix route, got not_found"
+;;
+
+let test_router_indexed_prefix_fallback_after_exact_method_miss () =
+  let exact_handler _req _reqd = () in
+  let prefix_handler _req _reqd = () in
+  let routes =
+    Router.create ()
+    |> Router.get "/api/v1/items/42" exact_handler
+    |> Router.prefix_post "/api/v1/items/" prefix_handler
+  in
+  let request = Httpun.Request.create `POST "/api/v1/items/42" in
+  match Router.resolve routes request with
+  | `Matched route ->
+    Alcotest.(check string)
+      "indexed router preserves prefix fallback"
+      "/api/v1/items/"
+      route.path
+  | `Method_not_allowed ->
+    Alcotest.fail "expected prefix fallback, got method_not_allowed"
+  | `Not_found -> Alcotest.fail "expected prefix fallback, got not_found"
 ;;
 
 let test_frontend_transport_routes_present () =
@@ -60,13 +80,13 @@ let test_frontend_transport_routes_present () =
     Masc_mcp.Server_routes_http_routes_frontend.add_routes
       ~port:8935
       ~host:"127.0.0.1"
-      Router.empty
+      (Router.create ())
   in
   let has_route meth path =
     List.exists
       (fun (route : Router.route) ->
          String.equal route.path path && List.mem meth route.methods)
-      routes
+      (Router.routes routes)
   in
   Alcotest.(check bool) "GET /ws route" true (has_route `GET "/ws");
   Alcotest.(check bool)
@@ -167,7 +187,7 @@ let test_parse_host_port_rejects_userinfo_in_host_header () =
 let test_default_config () =
   Alcotest.(check int) "default port" 8935 default_config.port;
   Alcotest.(check string) "default host" "127.0.0.1" default_config.host;
-  Alcotest.(check int) "default max_connections" 128 default_config.max_connections
+  Alcotest.(check int) "default max_connections" 512 default_config.max_connections
 ;;
 
 let test_custom_config () =
@@ -282,6 +302,9 @@ let router_tests =
   ; "add POST route", `Quick, test_router_add_post
   ; "add multiple routes", `Quick, test_router_add_multiple
   ; "prefix specificity", `Quick, test_router_prefix_specificity
+  ; ( "indexed prefix fallback after exact method miss"
+    , `Quick
+    , test_router_indexed_prefix_fallback_after_exact_method_miss )
   ; "frontend transport routes present", `Quick, test_frontend_transport_routes_present
   ; ( "frontend canonical localhost redirect"
     , `Quick


### PR DESCRIPTION
## Summary
- Replace the HTTP/1 router's route-list dispatch with an indexed route table built during route registration.
- Store exact routes in path buckets and keep prefix routes ordered by longest prefix, removing the `PREFIX:` sentinel path convention from callers.
- Reduce request-path parsing allocation by switching from `String.split_on_char` to `String.index_opt`.
- Update affected route modules/tests, including stale `default_config.max_connections` test expectation to match the documented/default value of 512.

## Validation
- `git diff --check origin/main..HEAD`
- `ocamlformat --check bin/main_eio.ml lib/http_server_eio.ml lib/http_server_eio.mli lib/server/server_routes_http.ml lib/server/server_routes_http_routes_channel_gate.mli lib/server/server_routes_http_routes_credentials.ml lib/server/server_routes_http_routes_repositories.ml lib/server/server_routes_http_routes_sidecar.mli test/test_http_server_eio.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_http_server_eio.exe`
- `./_build/default/test/test_http_server_eio.exe`