### PR TITLE
refactor(dashboard): remove ide shell active file reexport

### DIFF
--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -37,10 +37,6 @@ import {
   serializeActive,
 } from '../../../design-system/headless-core/layered-overlay'
 
-// Re-export to preserve the public path used by existing callers. The
-// canonical source now lives in `./ide-state` to avoid circular imports.
-export { activeIdeFile }
-
 type ViewTab = IdeEditorView
 type IdeFocus = 'review'
 type IdeStatusbarChipTone = 'brass' | 'ghost' | 'info' | 'ok'


### PR DESCRIPTION
## Summary
- remove the legacy activeIdeFile re-export from ide-shell
- keep activeIdeFile sourced only from ide-state, which all current callers already use

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/ide/ide-shell.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/ide/ide-shell.ts src/components/ide/ide-shell.test.ts src/components/ide/ide-state.ts
- git diff --check origin/main