### PR TITLE
refactor(dashboard): centralise [0,1] unit-interval clamp in lib/format-number.clampUnitInterval

### DIFF
--- a/dashboard/src/components/board/board-curation-panel.ts
+++ b/dashboard/src/components/board/board-curation-panel.ts
@@ -9,10 +9,11 @@ import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { SurfaceCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
 import { MISSING_DATA_DASH } from '../../lib/format-string'
+import { clampUnitInterval } from '../../lib/format-number'
 
 function percent(value: number | null | undefined): string {
   if (typeof value !== 'number' || !Number.isFinite(value)) return MISSING_DATA_DASH
-  return `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`
+  return `${Math.round(clampUnitInterval(value) * 100)}%`
 }
 
 function postIdList(ids: readonly string[]) {

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -6,6 +6,7 @@ import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import { MermaidGraph } from './common/mermaid-graph'
 import { Select } from './common/select'
+import { clampUnitInterval } from '../lib/format-number'
 import {
   fetchMemorySubsystems,
   type MemorySubsystemsResponse,
@@ -160,7 +161,7 @@ const weightBarClass = (w: number) => weightTier(w).tw
 // Floor 0.25 keeps low-weight cells distinguishable from empty (undefined)
 // cells drawn at var(--color-bg-panel-alt). Floor and range are arbitrary — picked by eye,
 // not derived from a perceptual model. Tune if empty/low contrast is wrong.
-const weightOpacity = (w: number) => 0.25 + 0.75 * Math.sqrt(Math.max(0, Math.min(1, w)))
+const weightOpacity = (w: number) => 0.25 + 0.75 * Math.sqrt(clampUnitInterval(w))
 
 /**
  * Pure filter for the Hebbian synapses table rows.
@@ -344,7 +345,7 @@ function WeightSparkline({ history }: { history?: Array<[number, number]> }) {
   const points = chronological
     .map(([, weight], i) => {
       const x = (i / (n - 1)) * (sw - 2) + 1
-      const y = sh - 1 - Math.max(0, Math.min(1, weight)) * (sh - 2)
+      const y = sh - 1 - clampUnitInterval(weight) * (sh - 2)
       return `${x.toFixed(1)},${y.toFixed(1)}`
     })
     .join(' ')

--- a/dashboard/src/components/observatory/cursor-store.ts
+++ b/dashboard/src/components/observatory/cursor-store.ts
@@ -3,6 +3,7 @@
 // cursorPosition. Tracks render vertical line + tooltip at cursor's time.
 
 import { signal, type Signal } from '@preact/signals'
+import { clampUnitInterval } from '../../lib/format-number'
 
 interface CursorPosition {
   /** Cursor's time in ms since epoch. */
@@ -21,7 +22,7 @@ export function setCursorFromEvent(
 ): void {
   const rect = trackEl.getBoundingClientRect()
   const x = event.clientX - rect.left
-  const pct = Math.max(0, Math.min(1, x / rect.width))
+  const pct = clampUnitInterval(x / rect.width)
   const ts = windowStart + (windowEnd - windowStart) * pct
   cursorPosition.value = { ts, pct }
 }

--- a/dashboard/src/lib/format-number.ts
+++ b/dashboard/src/lib/format-number.ts
@@ -77,3 +77,20 @@ export function isFiniteMetricValue(value: number | null | undefined): value is 
 export function clampPct(value: number): number {
   return Math.max(0, Math.min(100, value))
 }
+
+/**
+ * Clamp a value into the unit interval `[0, 1]`. Used for ratios,
+ * probabilities, and normalised cursor positions before they get
+ * multiplied into a wider range (× 100 for a percentage, × pixel
+ * width for a coordinate, etc.).
+ *
+ * Four callsites previously inlined `Math.max(0, Math.min(1, ...))`
+ * (`board-curation-panel.ts` quality display, `observatory/cursor-store.ts`
+ * pointer position, `memory-subsystems.ts` weight opacity + chart Y).
+ *
+ * Does not handle `NaN`: a `NaN` input returns `NaN`. Pair with
+ * `isFiniteMetricValue` when the source might be invalid.
+ */
+export function clampUnitInterval(value: number): number {
+  return Math.max(0, Math.min(1, value))
+}


### PR DESCRIPTION
## 변경 내용

PR #19234 (`clampPct` for `[0, 100]`) 의 sibling. `[0, 1]` 단위 구간 (ratio / probability / normalised cursor position) 의 4 callsite 가 inline `Math.max(0, Math.min(1, ...))` 사용 — `lib/format-number.ts` 에 `clampUnitInterval(value: number): number` 추가하여 통합.

## 변경 사이트

| File | Line | 이전 | 이후 |
|------|------|------|------|
| `lib/format-number.ts` | + | (없음) | `export function clampUnitInterval(value: number): number` |
| `components/board/board-curation-panel.ts` | 14 | `Math.max(0, Math.min(1, value))` | `clampUnitInterval(value)` (contributor quality 표시) |
| `components/observatory/cursor-store.ts` | 24 | `Math.max(0, Math.min(1, x / rect.width))` | `clampUnitInterval(x / rect.width)` (정규화 cursor) |
| `components/memory-subsystems.ts` | 163 | `Math.sqrt(Math.max(0, Math.min(1, w)))` | `Math.sqrt(clampUnitInterval(w))` (weight opacity √ 변환) |
| `components/memory-subsystems.ts` | 347 | `Math.max(0, Math.min(1, weight))` | `clampUnitInterval(weight)` (Hebbian Y 좌표) |

## SSOT 의미 — PR #19234 와 같은 axis, 다른 범위

errorToString consolidation (PR #19193/#19209/#19214/#19220/#19225/#19229) 이후 새 발견된 clamp-helper SSOT family:

- `[0, 100]` 퍼센트 clamp: `clampPct` (PR #19234, 4 callsite)
- `[0, 1]` 단위 구간 clamp: `clampUnitInterval` (본 PR, 4 callsite)

두 helper 같은 모듈 (lib/format-number.ts), 같은 NaN 처리 정책 (untouched, `isFiniteMetricValue` 와 pair), 같은 자리수 (`Math.max + Math.min`).

미래 정책 변경 시 (예: `NaN` strict 처리, 음수 입력 throw) 한 곳만 수정으로 4 callsite 자동 전파 (이전엔 4 곳 stale).

## NaN 처리

JSDoc 에 명시: `NaN → NaN` 반환. invalid input 가능 시 같은 모듈 `isFiniteMetricValue` 와 pair. 기존 callsite 의 명시적 동작과 일치 (board-curation-panel 은 `isFinite` guard 후 clamp, 다른 세 곳은 number 가정).

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (5 관련 test file: format-number / board-curation-panel / memory-subsystems / memory-subsystems.focus / observatory) — 68/68 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 4 file +24/-4

