### PR TITLE
[codex] Fix Execute argv JSON frontdoor

### DIFF
--- a/lib/keeper/agent_tool_execute_typed_input.ml
+++ b/lib/keeper/agent_tool_execute_typed_input.ml
@@ -200,6 +200,12 @@ let optional_redirect_target ~path fields key =
       (json_type_name value)
 ;;
 
+let normalize_argv_for_executable ~executable argv =
+  match argv with
+  | first :: rest when String.equal (String.trim first) (String.trim executable) -> rest
+  | _ -> argv
+;;
+
 let parse_stage ~path_prefix ~index (value : Yojson.Safe.t) =
   let ( let* ) = Result.bind in
   let path = Printf.sprintf "%s[%d]" path_prefix index in
@@ -207,6 +213,7 @@ let parse_stage ~path_prefix ~index (value : Yojson.Safe.t) =
   let* () = reject_unknown_fields ~path ~allowed:[ "executable"; "argv" ] fields in
   let* executable = required_string ~path fields "executable" in
   let* argv = optional_string_list ~path fields "argv" in
+  let argv = normalize_argv_for_executable ~executable argv in
   Ok { executable; argv }
 ;;
 
@@ -255,6 +262,12 @@ let of_json (json : Yojson.Safe.t) =
   let executable_present = Option.is_some (member fields "executable") in
   let pipeline_value =
     match member fields "pipeline" with
+    | Some (`List []) when executable_present ->
+      (* Some providers/middleware include an empty pipeline array while using
+         the single-process form. Treat only the empty value as absent; a
+         populated pipeline is still mutually exclusive with executable. *)
+      None
+    | Some `Null when executable_present -> None
     | Some value -> Some ("$.pipeline", value)
     | None -> None
   in
@@ -271,6 +284,7 @@ let of_json (json : Yojson.Safe.t) =
   | true, None ->
     let* executable = required_string ~path:"$" fields "executable" in
     let* argv = optional_string_list ~path:"$" fields "argv" in
+    let argv = normalize_argv_for_executable ~executable argv in
     let* stdin = optional_redirect_target ~path:"$" fields "stdin" in
     let* stdout = optional_redirect_target ~path:"$" fields "stdout" in
     let* stderr = optional_redirect_target ~path:"$" fields "stderr" in
@@ -278,7 +292,16 @@ let of_json (json : Yojson.Safe.t) =
   | false, Some (path, value) ->
     let* stages = parse_pipeline ~path value in
     Ok (Pipeline { stages; cwd; env })
-  | false, None -> Error "$.executable or $.pipeline is required"
+  | false, None -> (
+    let* argv = optional_string_list ~path:"$" fields "argv" in
+    match argv with
+    | executable :: argv ->
+      let argv = normalize_argv_for_executable ~executable argv in
+      let* stdin = optional_redirect_target ~path:"$" fields "stdin" in
+      let* stdout = optional_redirect_target ~path:"$" fields "stdout" in
+      let* stderr = optional_redirect_target ~path:"$" fields "stderr" in
+      Ok (Exec { executable; argv; cwd; env; stdin; stdout; stderr })
+    | [] -> Error "$.executable or $.pipeline is required")
 ;;
 
 (* Execve-style: argv tokens pass verbatim to the child process, so

--- a/test/test_agent_tool_execute_typed_input.ml
+++ b/test/test_agent_tool_execute_typed_input.ml
@@ -356,6 +356,65 @@ let test_of_json_exec () =
   | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
 ;;
 
+let test_of_json_promotes_argv0_when_executable_missing () =
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ "argv", `List [ `String "git"; `String "status"; `String "--short" ]
+          ; "cwd", `String "/tmp"
+          ; "env", `Assoc [ "LC_ALL", `String "C" ]
+          ])
+  in
+  match input with
+  | Execute_input.Exec { executable; argv; cwd; env; _ } ->
+    Alcotest.(check string) "argv0 promoted to executable" "git" executable;
+    Alcotest.(check (list string)) "remaining argv" [ "status"; "--short" ] argv;
+    Alcotest.(check (option string)) "cwd" (Some "/tmp") cwd;
+    Alcotest.(check (list (pair string string))) "env" [ "LC_ALL", "C" ] env
+  | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
+;;
+
+let test_of_json_drops_duplicate_executable_argv0 () =
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ "executable", `String "cat"
+          ; "argv", `List [ `String "cat"; `String "repos/masc-mcp/README.md" ]
+          ])
+  in
+  match input with
+  | Execute_input.Exec { executable; argv; _ } ->
+    Alcotest.(check string) "executable" "cat" executable;
+    Alcotest.(check (list string)) "argv" [ "repos/masc-mcp/README.md" ] argv
+  | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
+;;
+
+let test_of_json_rejects_empty_argv_without_executable () =
+  let msg =
+    parse_json_error (`Assoc [ "argv", `List [] ])
+  in
+  Alcotest.(check bool)
+    "error still requires a command form"
+    true
+    (String_util.contains_substring_ci msg "$.executable or $.pipeline is required")
+;;
+
+let test_of_json_ignores_empty_pipeline_with_executable () =
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ "executable", `String "echo"
+          ; "argv", `List [ `String "hello" ]
+          ; "pipeline", `List []
+          ])
+  in
+  match input with
+  | Execute_input.Exec { executable; argv; _ } ->
+    Alcotest.(check string) "executable" "echo" executable;
+    Alcotest.(check (list string)) "argv" [ "hello" ] argv
+  | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
+;;
+
 let test_of_json_keeps_empty_exec_for_validation () =
   let input =
     parse_json_exn
@@ -405,6 +464,33 @@ let test_of_json_pipeline () =
        Alcotest.(check string) "first executable" "printf" first.executable;
        Alcotest.(check (list string)) "first argv" [ "hello" ] first.argv;
        Alcotest.(check string) "second executable" "wc" second.executable;
+       Alcotest.(check (list string)) "second argv" [ "-c" ] second.argv
+     | _ -> Alcotest.fail "expected exactly two stages")
+  | Execute_input.Exec _ -> Alcotest.fail "expected Pipeline"
+;;
+
+let test_of_json_pipeline_drops_duplicate_stage_argv0 () =
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ ( "pipeline"
+            , `List
+                [ `Assoc
+                    [ "executable", `String "printf"
+                    ; "argv", `List [ `String "printf"; `String "hello" ]
+                    ]
+                ; `Assoc
+                    [ "executable", `String "wc"
+                    ; "argv", `List [ `String "wc"; `String "-c" ]
+                    ]
+                ] )
+          ])
+  in
+  match input with
+  | Execute_input.Pipeline { stages; _ } ->
+    (match stages with
+     | [ first; second ] ->
+       Alcotest.(check (list string)) "first argv" [ "hello" ] first.argv;
        Alcotest.(check (list string)) "second argv" [ "-c" ] second.argv
      | _ -> Alcotest.fail "expected exactly two stages")
   | Execute_input.Exec _ -> Alcotest.fail "expected Pipeline"
@@ -1020,6 +1106,22 @@ let suite =
           test_not_allowlisted_hints_self_correction
       ; Alcotest.test_case "of_json_exec" `Quick test_of_json_exec
       ; Alcotest.test_case
+          "of_json_promotes_argv0_when_executable_missing"
+          `Quick
+          test_of_json_promotes_argv0_when_executable_missing
+      ; Alcotest.test_case
+          "of_json_drops_duplicate_executable_argv0"
+          `Quick
+          test_of_json_drops_duplicate_executable_argv0
+      ; Alcotest.test_case
+          "of_json_rejects_empty_argv_without_executable"
+          `Quick
+          test_of_json_rejects_empty_argv_without_executable
+      ; Alcotest.test_case
+          "of_json_ignores_empty_pipeline_with_executable"
+          `Quick
+          test_of_json_ignores_empty_pipeline_with_executable
+      ; Alcotest.test_case
           "of_json_keeps_empty_exec_for_validation"
           `Quick
           test_of_json_keeps_empty_exec_for_validation
@@ -1028,6 +1130,10 @@ let suite =
           "of_json_keeps_empty_pipeline_stage_for_validation"
           `Quick
           test_of_json_keeps_empty_pipeline_stage_for_validation
+      ; Alcotest.test_case
+          "of_json_pipeline_drops_duplicate_stage_argv0"
+          `Quick
+          test_of_json_pipeline_drops_duplicate_stage_argv0
       ; Alcotest.test_case
           "of_json_rejects_cmd_string_only"
           `Quick


### PR DESCRIPTION
## Summary

- Tolerate typed Execute JSON where `argv[0]` contains the command name but `executable` is omitted.
- Drop duplicated `argv[0]` when it matches `executable` for single-process and pipeline-stage inputs.
- Treat empty/null `pipeline` as absent when a single-process `executable` form is present.

## Why

Recent keeper logs showed repeated false-negative Execute failures such as `executable="cat"` with `argv=["cat", path]`, which executes as `cat cat path`, plus schema-adjacent inputs where providers supplied only argv or an empty pipeline alongside executable.

## Validation

- `git diff --check`
- `ocamlformat --check lib/keeper/agent_tool_execute_typed_input.ml test/test_agent_tool_execute_typed_input.ml`
- `scripts/dune-local.sh build test/test_agent_tool_execute_typed_input.exe`
- `_build/default/test/test_agent_tool_execute_typed_input.exe` (48 tests)

## Operational Notes

This PR only normalizes at the JSON boundary. Direct internal `Exec` construction/lowering still preserves duplicate argv, so existing low-level execve semantics remain unchanged.