### PR TITLE
refactor(dashboard): route 5 inline AbortError name checks through lib/async-state isAbortError

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -8,6 +8,7 @@ import type {
   OperatorSnapshot,
 } from '../types'
 import { sanitizeDashboardActorName } from '../lib/dashboard-actor'
+import { isAbortError } from '../lib/async-state'
 import {
   currentDashboardActorName,
   setCanonicalDashboardActor,
@@ -255,7 +256,7 @@ export async function fetchWithTimeout(path: string, init: RequestInit, timeoutM
       signal: controller.signal,
     })
   } catch (err) {
-    if (err instanceof Error && err.name === 'AbortError') {
+    if (isAbortError(err)) {
       if (upstreamSignal?.aborted) {
         throw err
       }

--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -21,6 +21,7 @@ import { EmptyState } from './common/feedback-state'
 import { TextInput } from './common/input'
 import { highlightMatch } from '../lib/highlight-match'
 import { unixSecondsToDate } from '../lib/format-time'
+import { isAbortError } from '../lib/async-state'
 
 const POLL_INTERVAL_MS = 5_000
 const RECENT_LIMIT = 50
@@ -253,7 +254,7 @@ export function AttributionPanel() {
         recent.value = r.events
         error.value = null
       } catch (e) {
-        if (cancelled || (e as Error).name === 'AbortError') return
+        if (cancelled || isAbortError(e)) return
         error.value = (e as Error).message || 'attribution fetch failed'
       } finally {
         if (!cancelled) loading.value = false

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -29,6 +29,7 @@ import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { fetchTelemetry, type TelemetryEntry } from '../api/dashboard'
 import { useSavedSignal } from '../lib/saved-signal'
+import { isAbortError } from '../lib/async-state'
 import { ringFocusClasses } from './common/ring'
 
 type A2aEventKind = 'lifecycle' | 'failure' | 'tool' | 'handoff' | 'context' | 'unknown'
@@ -265,7 +266,7 @@ export function HandoffTimeline({
         setError(null)
       } catch (e) {
         if (cancelled) return
-        if ((e as Error).name === 'AbortError') return
+        if (isAbortError(e)) return
         setError(e instanceof Error ? e.message : String(e))
       }
     }

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -4,6 +4,7 @@ import { Markdown } from "./common/markdown"
 import { useState } from 'preact/hooks'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
 import { relativeTime, NO_TIME_INFO } from '../lib/format-time'
+import { isAbortError } from '../lib/async-state'
 import type { Keeper, KeeperDiagnostic } from '../types'
 import {
   abortKeeperThreadMessage,
@@ -307,7 +308,7 @@ export function KeeperConversationPanel({
     try {
       await sendKeeperThreadMessage(keeperName, prompt)
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') return
+      if (isAbortError(err)) return
       const message = err instanceof Error ? err.message : `${keeperName} 메시지 전송 실패`
       showToast(message, 'error')
     }

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -5,6 +5,7 @@ import {
   streamKeeperMessage,
 } from './api/keeper'
 import { invalidateDashboardCache, refreshDashboard } from './store'
+import { isAbortError } from './lib/async-state'
 import type {
   KeeperConversationDelivery,
   KeeperDiagnostic,
@@ -225,9 +226,7 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
       error: null,
     })
   } catch (err) {
-    const isAbort =
-      err instanceof Error && err.name === 'AbortError'
-    if (isAbort) {
+    if (isAbortError(err)) {
       finalizeAssistantEntry(keeperName, assistantId, {
         delivery: 'timeout',
         streamState: null,


### PR DESCRIPTION
## 변경 내용

`lib/async-state.ts:124` 에 이미 `isAbortError(error: unknown): boolean` 이 export 되어 있는데 **5 callsite 가 inline 으로** 같은 패턴을 다시 작성하고 있었습니다. 본 PR 은 5 callsite 를 helper 로 라우팅합니다.

`isAbortError` body:
```ts
export function isAbortError(error: unknown): boolean {
  return error instanceof Error && error.name === 'AbortError'
}
```

## 변경 사이트

### 직접 등가 migration (3 site — byte-for-byte 동일 body)

| File | Line | 이전 | 이후 |
|------|------|------|------|
| `keeper-actions.ts` | 229 | `err instanceof Error && err.name === 'AbortError'` | `isAbortError(err)` |
| `api/core.ts` | 258 | `err instanceof Error && err.name === 'AbortError'` | `isAbortError(err)` |
| `components/keeper-shared.ts` | 310 | `err instanceof Error && err.name === 'AbortError'` | `isAbortError(err)` |

### Type-assertion fallthrough migration (2 site — `instanceof Error` 가드 추가)

| File | Line | 이전 | 이후 |
|------|------|------|------|
| `components/handoff-timeline.ts` | 268 | `(e as Error).name === 'AbortError'` | `isAbortError(e)` |
| `components/attribution-panel.ts` | 256 | `(e as Error).name === 'AbortError'` | `isAbortError(e)` |

**Behaviour change (안전 방향)**: 이 두 사이트는 `(e as Error).name` 으로 runtime check 없이 field 접근 — 만약 non-Error throw (예: 일반 object) 가 발생하면 crash 또는 silent abort-match. `isAbortError(e)` 라우팅은 `instanceof Error` 가드를 추가하여 non-Error 입력이 false 반환 → catch block 이 정상 error path 로 falls through. Error / DOMException (browsers 에서 Error 의 subclass) 입력은 동작 동일.

## Out of scope

`components/keeper-chat-panel.ts:137` 는 `err instanceof DOMException && err.name === 'AbortError'` — DOMException 전용 check (Error 보다 strict). 다른 semantic 이라 그대로 유지.

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (5 관련 test file: api/core / handoff-timeline / keeper-shared / attribution-panel / lib/async-state) — 97/97 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 5 file +10/-7

## SSOT 의미

PR #19193 (errorToString), PR #19214 (cascade-config-panel duplicate 제거), PR #19234 (clampPct), PR #19237 (clampUnitInterval) 와 *같은 class* — canonical helper 가 이미 존재, inline copy 가 helper 로 수렴.

