### PR TITLE
refactor(dashboard): remove session trace live-store reexport

### DIFF
--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, beforeEach } from 'vitest'
 import {
-  appendLiveToolCall,
   closeSessionTrace,
   getTraceEvents,
   getFilteredEvents,
@@ -18,6 +17,7 @@ import {
   _liveTraceFeeds as liveTraceFeeds,
   _traceSlots as traceSlots,
 } from './session-trace-state'
+import { appendLiveToolCall } from './session-trace-live-store'
 
 // Reset trace slots before each test
 beforeEach(() => {

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -817,8 +817,6 @@ export async function loadSessionTrace(agentName: string, isKeeper: boolean): Pr
   }
 }
 
-export { appendLiveOasEvent, appendLiveToolCall } from './session-trace-live-store'
-
 export function closeSessionTrace(agentName: string): void {
   const next = { ...traceSlots.value }
   delete next[agentName]


### PR DESCRIPTION
## Summary
- remove appendLiveOasEvent/appendLiveToolCall re-export from session-trace-state
- import appendLiveToolCall directly from session-trace-live-store in the state test
- keep production live trace callers on the live-store SSOT path

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/session-trace/session-trace-state.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/session-trace/session-trace-state.ts src/components/session-trace/session-trace-state.test.ts src/components/session-trace/session-trace-live-store.ts
- git diff --check origin/main