### PR TITLE
refactor(dashboard): remove inspector keeper pin projection

### DIFF
--- a/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
@@ -4,7 +4,6 @@ import { html } from 'htm/preact'
 import { activeKeeperName } from '../../keeper-state'
 import {
   InspectorKeeperBDI,
-  inspectorKeeperPin,
   normalizeKeeperBdiSnapshot,
   pinInspectorKeeper,
 } from './inspector-keeper-bdi'
@@ -67,7 +66,6 @@ afterEach(() => {
   activeIdeFile.value = 'package.json'
   ideContextFocus.value = null
   window.location.hash = ''
-  void inspectorKeeperPin.value
 })
 
 function setCursorFor(keeperId: string, cursor: Partial<KeeperCursor> & { file_path: string; line: number }): void {
@@ -373,4 +371,3 @@ describe('InspectorKeeperBDI', () => {
     render(null, container)
   })
 })
-

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -1,4 +1,3 @@
-import { computed } from '@preact/signals'
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { activeKeeperName } from '../../keeper-state'
@@ -59,16 +58,10 @@ interface InspectorKeeperPin {
   readonly line: number | null
 }
 
-/**
- * RFC-0027 PR-α backward-compat: legacy single-pin signal is now a derived
- * projection over the head of `pinnedKeepers` (max-4 LRU store). Reads stay
- * identical; mutators move to `pinKeeper` / `clearPins` from
- * `multi-keeper-pin-store.ts`.
- */
-export const inspectorKeeperPin = computed<InspectorKeeperPin | null>(() => {
+function inspectorPinFromHead(): InspectorKeeperPin | null {
   const head = headPinnedKeeper.value
   return head ? { keeperName: head.keeperName, line: head.line } : null
-})
+}
 
 export function pinInspectorKeeper(keeperName: string, line: number | null): void {
   const trimmed = keeperName.trim()
@@ -138,8 +131,8 @@ async function fetchKeeperBdiSnapshot(keeperName: string, signal: AbortSignal): 
 }
 
 function useInspectorKeeperPin(): InspectorKeeperPin | null {
-  const [pin, setPin] = useState(inspectorKeeperPin.value)
-  useEffect(() => inspectorKeeperPin.subscribe(value => setPin(value)), [])
+  const [pin, setPin] = useState<InspectorKeeperPin | null>(inspectorPinFromHead())
+  useEffect(() => headPinnedKeeper.subscribe(() => setPin(inspectorPinFromHead())), [])
   return pin
 }
 

--- a/dashboard/src/components/ide/multi-keeper-pin-store.ts
+++ b/dashboard/src/components/ide/multi-keeper-pin-store.ts
@@ -3,19 +3,14 @@ import { computed, signal } from '@preact/signals'
 /**
  * RFC-0027 PR-α: multi-keeper pin store.
  *
- * Replaces the single `inspectorKeeperPin` signal in `inspector-keeper-bdi.ts`
- * with a bounded LRU collection (max 4) while preserving the legacy single-pin
- * API for callers that have not yet migrated. Layout decisions about how many
- * pins to render concurrently belong to the consumer (`InspectorMultiKeeperBDI`),
+ * Replaces the old single-pin inspector state with a bounded LRU collection
+ * (max 4). Layout decisions about how many pins to render concurrently
+ * belong to the consumer (`InspectorMultiKeeperBDI`),
  * not the store.
  *
  * Backward-compat (RFC-0027 §10):
  *   - `pinInspectorKeeper(name, line)` re-exported from `inspector-keeper-bdi.ts`
  *     forwards into `pinKeeper(name, line)`. Callers see no shape change.
- *   - `inspectorKeeperPin` re-exported from `inspector-keeper-bdi.ts` is a
- *     `computed` projection of the head entry (`entries[0]`). Read-only access
- *     remains identical; tests that previously did
- *     `inspectorKeeperPin.value = null` must move to `clearPins()`.
  *
  * Cap = 4 ties to RFC-0027 §11 #1 (320px inspector rail + compact-fold). The
  * cap is a constant in the store rather than a runtime parameter so test
@@ -74,10 +69,7 @@ export function unpinKeeper(keeperName: string): void {
   pinnedKeepers.value = { ...prev, entries: next }
 }
 
-/**
- * Drop every pin. Used by tests that previously set
- * `inspectorKeeperPin.value = null`.
- */
+/** Drop every pin. */
 export function clearPins(): void {
   if (pinnedKeepers.value.entries.length === 0) return
   pinnedKeepers.value = { ...pinnedKeepers.value, entries: [] }


### PR DESCRIPTION
## Summary
- remove the legacy inspectorKeeperPin computed projection
- subscribe InspectorKeeperBDI directly to headPinnedKeeper from the multi-pin store
- remove stale single-pin compatibility comments and test reset reads

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/multi-keeper-pin-store.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/ide/inspector-keeper-bdi.ts src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/multi-keeper-pin-store.ts src/components/ide/multi-keeper-pin-store.test.ts
- git diff --check origin/main