### PR TITLE
[codex] Optimize HTTP dispatch and encoding hot paths

### DIFF
--- a/lib/http_response_payload.ml
+++ b/lib/http_response_payload.ml
@@ -6,33 +6,142 @@
 
 let vary_accept_encoding = ("vary", "Accept-Encoding")
 
-let lower_trim s = String.trim s |> String.lowercase_ascii
+let is_ascii_space = function
+  | ' ' | '\t' | '\n' | '\r' | '\012' -> true
+  | _ -> false
 
-let q_value params =
-  let parse_q param =
-    let param = lower_trim param in
-    if String.starts_with ~prefix:"q=" param then
-      match float_of_string_opt (String.sub param 2 (String.length param - 2)) with
-      | Some q -> Some q
-      | None -> Some 0.0
+let trim_span value start stop =
+  let rec trim_left i =
+    if i < stop && is_ascii_space value.[i] then
+      trim_left (i + 1)
     else
-      None
+      i
   in
-  Option.value ~default:1.0 (List.find_map parse_q params)
+  let start = trim_left start in
+  let rec trim_right i =
+    if i > start && is_ascii_space value.[i - 1] then
+      trim_right (i - 1)
+    else
+      i
+  in
+  start, trim_right stop
 
-let encoding_matches accepted token =
-  match String.split_on_char ';' accepted with
-  | [] -> false
-  | raw_token :: params ->
-      let raw_token = lower_trim raw_token in
-      (String.equal raw_token token || String.equal raw_token "*") && q_value params > 0.0
+let index_char value ch start stop =
+  let rec loop i =
+    if i >= stop then
+      None
+    else if Char.equal value.[i] ch then
+      Some i
+    else
+      loop (i + 1)
+  in
+  loop start
+
+let ascii_lower_char = function
+  | 'A' .. 'Z' as ch -> Char.chr (Char.code ch + 32)
+  | ch -> ch
+
+let equal_ascii_ci_span value start stop token =
+  let len = stop - start in
+  len = String.length token
+  &&
+  let rec loop i =
+    if i = len then
+      true
+    else
+      Char.equal
+        (ascii_lower_char value.[start + i])
+        (ascii_lower_char token.[i])
+      && loop (i + 1)
+  in
+  loop 0
+
+let starts_with_ascii_ci_span value start stop prefix =
+  let len = stop - start in
+  let prefix_len = String.length prefix in
+  len >= prefix_len
+  &&
+  let rec loop i =
+    if i = prefix_len then
+      true
+    else
+      Char.equal
+        (ascii_lower_char value.[start + i])
+        (ascii_lower_char prefix.[i])
+      && loop (i + 1)
+  in
+  loop 0
+
+let q_param_value value start stop =
+  let start, stop = trim_span value start stop in
+  if starts_with_ascii_ci_span value start stop "q=" then
+    let value_start = start + 2 in
+    match float_of_string_opt (String.sub value value_start (stop - value_start)) with
+    | Some q -> Some q
+    | None -> Some 0.0
+  else
+    None
+
+let q_value_in_params value start stop =
+  let rec loop start =
+    if start >= stop then
+      None
+    else
+      let next =
+        match index_char value ';' start stop with
+        | Some idx -> idx
+        | None -> stop
+      in
+      match q_param_value value start next with
+      | Some q -> Some q
+      | None -> if next >= stop then None else loop (next + 1)
+  in
+  Option.value ~default:1.0 (loop start)
+
+let param_exists value start stop target =
+  let rec loop start =
+    if start >= stop then
+      false
+    else
+      let next =
+        match index_char value ';' start stop with
+        | Some idx -> idx
+        | None -> stop
+      in
+      let param_start, param_stop = trim_span value start next in
+      equal_ascii_ci_span value param_start param_stop target
+      || (next < stop && loop (next + 1))
+  in
+  loop start
+
+let encoding_matches_span value start stop token =
+  let token_stop, params_start =
+    match index_char value ';' start stop with
+    | Some idx -> idx, idx + 1
+    | None -> stop, stop
+  in
+  let token_start, token_stop = trim_span value start token_stop in
+  (equal_ascii_ci_span value token_start token_stop token
+   || equal_ascii_ci_span value token_start token_stop "*")
+  && q_value_in_params value params_start stop > 0.0
 
 let accepts_encoding_header ~token = function
   | None -> false
   | Some accept_encoding ->
-      accept_encoding
-      |> String.split_on_char ','
-      |> List.exists (fun accepted -> encoding_matches accepted token)
+      let stop = String.length accept_encoding in
+      let rec loop start =
+        if start >= stop then
+          false
+        else
+          let next =
+            match index_char accept_encoding ',' start stop with
+            | Some idx -> idx
+            | None -> stop
+          in
+          encoding_matches_span accept_encoding start next token
+          || (next < stop && loop (next + 1))
+      in
+      loop 0
 
 let accepts_zstd_header header =
   accepts_encoding_header ~token:"zstd" header
@@ -40,18 +149,31 @@ let accepts_zstd_header header =
 let accepts_zstd_dict_header = function
   | None -> false
   | Some accept_encoding ->
-      accept_encoding
-      |> String.split_on_char ','
-      |> List.exists (fun accepted ->
-        match String.split_on_char ';' accepted with
-        | [] -> false
-        | raw_token :: params ->
-            let raw_token = lower_trim raw_token in
-            let params = List.map lower_trim params in
-            q_value params > 0.0
-            && (String.equal raw_token "zstd-dict"
-                || (String.equal raw_token "zstd"
-                    && List.exists (String.equal "dict=masc") params)))
+      let stop = String.length accept_encoding in
+      let segment_matches start stop =
+        let token_stop, params_start =
+          match index_char accept_encoding ';' start stop with
+          | Some idx -> idx, idx + 1
+          | None -> stop, stop
+        in
+        let token_start, token_stop = trim_span accept_encoding start token_stop in
+        q_value_in_params accept_encoding params_start stop > 0.0
+        && (equal_ascii_ci_span accept_encoding token_start token_stop "zstd-dict"
+            || (equal_ascii_ci_span accept_encoding token_start token_stop "zstd"
+                && param_exists accept_encoding params_start stop "dict=masc"))
+      in
+      let rec loop start =
+        if start >= stop then
+          false
+        else
+          let next =
+            match index_char accept_encoding ',' start stop with
+            | Some idx -> idx
+            | None -> stop
+          in
+          segment_matches start next || (next < stop && loop (next + 1))
+      in
+      loop 0
 
 let compress_body ?(level = 3) ?(compress = true) ~accept_encoding body =
   if not compress then

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -435,22 +435,40 @@ module Router = struct
     | `Method_not_allowed
     | `Not_found ]
 
-  type t = {
-    exact_by_path: (string, route list) Hashtbl.t;
+  type method_routes = {
+    exact_by_path: (string, route) Hashtbl.t;
     mutable prefix_routes: route list;
+  }
+
+  type t = {
+    get: method_routes;
+    post: method_routes;
+    put: method_routes;
+    delete: method_routes;
+    options: method_routes;
+    exact_paths: (string, unit) Hashtbl.t;
+    mutable routes: route list;
     mutable route_count: int;
   }
 
+  let create_method_routes () =
+    { exact_by_path = Hashtbl.create 128; prefix_routes = [] }
+
   let create () =
-    { exact_by_path = Hashtbl.create 128; prefix_routes = []; route_count = 0 }
+    {
+      get = create_method_routes ();
+      post = create_method_routes ();
+      put = create_method_routes ();
+      delete = create_method_routes ();
+      options = create_method_routes ();
+      exact_paths = Hashtbl.create 128;
+      routes = [];
+      route_count = 0;
+    }
 
   let route_count router = router.route_count
 
-  let routes router =
-    let exact =
-      router.exact_by_path |> Hashtbl.to_seq_values |> List.of_seq |> List.concat
-    in
-    exact @ router.prefix_routes
+  let routes router = List.rev router.routes
 
   let insert_prefix_route route routes =
     let route_len = String.length route.path in
@@ -463,18 +481,40 @@ module Router = struct
     in
     loop [] routes
 
+  let method_routes router = function
+    | `GET -> Some router.get
+    | `POST -> Some router.post
+    | `PUT -> Some router.put
+    | `DELETE -> Some router.delete
+    | `OPTIONS -> Some router.options
+    | _ -> None
+
+  let add_to_method_routes kind route method_routes =
+    match kind with
+    | Exact -> Hashtbl.replace method_routes.exact_by_path route.path route
+    | Prefix ->
+        method_routes.prefix_routes <-
+          insert_prefix_route route method_routes.prefix_routes
+
   let add_kind kind ~path ~methods ~handler router =
     let route = { kind; path; methods; handler } in
     (match kind with
      | Exact ->
-         let existing =
-           match Hashtbl.find_opt router.exact_by_path path with
-           | Some routes -> routes
-           | None -> []
-         in
-         Hashtbl.replace router.exact_by_path path (route :: existing)
+         Hashtbl.replace router.exact_paths path ();
+         List.iter
+           (fun method_ ->
+              match method_routes router method_ with
+              | Some routes -> add_to_method_routes Exact route routes
+              | None -> ())
+           methods
      | Prefix ->
-         router.prefix_routes <- insert_prefix_route route router.prefix_routes);
+         List.iter
+           (fun method_ ->
+              match method_routes router method_ with
+              | Some routes -> add_to_method_routes Prefix route routes
+              | None -> ())
+           methods);
+    router.routes <- route :: router.routes;
     router.route_count <- router.route_count + 1;
     router
 
@@ -504,28 +544,31 @@ module Router = struct
   let prefix_put prefix handler routes =
     add_kind Prefix ~path:prefix ~methods:[`PUT] ~handler routes
 
+  let resolve_prefix routes req_path =
+    List.find_opt
+      (fun route -> String.starts_with req_path ~prefix:route.path)
+      routes.prefix_routes
+
   let resolve router request =
     let req_path = Request.path request in
     let req_method = Request.method_ request in
-    let exact_path_matches = Hashtbl.find_opt router.exact_by_path req_path in
-    match
-      Option.bind exact_path_matches (fun routes ->
-        List.find_opt (fun route -> List.mem req_method route.methods) routes)
-    with
-    | Some route -> `Matched route
+    match method_routes router req_method with
+    | Some routes -> (
+        match Hashtbl.find_opt routes.exact_by_path req_path with
+        | Some route -> `Matched route
+        | None -> (
+            match resolve_prefix routes req_path with
+            | Some route -> `Matched route
+            | None ->
+                if Hashtbl.mem router.exact_paths req_path then
+                  `Method_not_allowed
+                else
+                  `Not_found))
     | None ->
-        (match
-           List.find_opt
-             (fun route ->
-                String.starts_with req_path ~prefix:route.path
-                && List.mem req_method route.methods)
-             router.prefix_routes
-         with
-         | Some route -> `Matched route
-         | None ->
-             (match exact_path_matches with
-              | Some _ -> `Method_not_allowed
-              | None -> `Not_found))
+        if Hashtbl.mem router.exact_paths req_path then
+          `Method_not_allowed
+        else
+          `Not_found
 
   let dispatch router request reqd =
     match resolve router request with

--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -260,9 +260,10 @@ module Router : sig
     | `Not_found
     ]
 
-  (** Indexed dispatch table.  Route registration updates exact path buckets
-      and a longest-prefix ordered prefix table at build time, so request
-      dispatch does not scan/sort the full endpoint list. *)
+  (** Indexed dispatch table.  Route registration updates method-specific
+      exact path tables and longest-prefix ordered prefix tables at build time,
+      so request dispatch does not scan/sort the full endpoint list or perform
+      per-candidate method-list membership checks. *)
   type t
 
   val create : unit -> t
@@ -299,10 +300,11 @@ module Router : sig
   val prefix_put : string -> request_handler -> t -> t
 
   (** [resolve routes request] returns [`Matched route] when
-      either an exact path+method match exists OR (no exact
-      match) the longest prefix match exists.  Returns
-      [`Method_not_allowed] when path matches but method does
-      not, [`Not_found] otherwise. *)
+      either an exact path+method match exists OR the
+      longest prefix match for that method exists.  Returns
+      [`Method_not_allowed] when an exact path exists but no
+      route for the request method exists, [`Not_found]
+      otherwise. *)
   val resolve : t -> Httpun.Request.t -> resolution
 
   (** [dispatch routes request reqd] wires {!resolve} to the

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -75,6 +75,17 @@ let test_router_indexed_prefix_fallback_after_exact_method_miss () =
   | `Not_found -> Alcotest.fail "expected prefix fallback, got not_found"
 ;;
 
+let test_router_method_index_preserves_exact_405 () =
+  let handler _req _reqd = () in
+  let routes = Router.create () |> Router.get "/api/v1/exact-only" handler in
+  let request = Httpun.Request.create `POST "/api/v1/exact-only" in
+  match Router.resolve routes request with
+  | `Method_not_allowed -> ()
+  | `Matched route ->
+    Alcotest.failf "expected method_not_allowed, got matched route %s" route.path
+  | `Not_found -> Alcotest.fail "expected method_not_allowed, got not_found"
+;;
+
 let test_frontend_transport_routes_present () =
   let routes =
     Masc_mcp.Server_routes_http_routes_frontend.add_routes
@@ -278,6 +289,36 @@ let test_accepts_zstd_negative () =
   Alcotest.(check bool) "no zstd" false (Compression.accepts_zstd request)
 ;;
 
+let test_accepts_zstd_rejects_q_zero () =
+  let headers =
+    Httpun.Headers.of_list [ "accept-encoding", "gzip, zstd;q=0, br" ]
+  in
+  let request = Httpun.Request.create ~headers `GET "/" in
+  Alcotest.(check bool) "zstd q=0 rejected" false (Compression.accepts_zstd request)
+;;
+
+let test_accepts_zstd_dict_positive () =
+  let headers =
+    Httpun.Headers.of_list [ "accept-encoding", "gzip, zstd; dict=masc" ]
+  in
+  let request = Httpun.Request.create ~headers `GET "/" in
+  Alcotest.(check bool)
+    "zstd dictionary accepted"
+    true
+    (Compression.accepts_zstd_dict request)
+;;
+
+let test_accepts_zstd_dict_rejects_q_zero () =
+  let headers =
+    Httpun.Headers.of_list [ "accept-encoding", "zstd; dict=masc; q=0" ]
+  in
+  let request = Httpun.Request.create ~headers `GET "/" in
+  Alcotest.(check bool)
+    "zstd dictionary q=0 rejected"
+    false
+    (Compression.accepts_zstd_dict request)
+;;
+
 let test_accepts_zstd_no_header () =
   let request = Httpun.Request.create `GET "/" in
   Alcotest.(check bool) "no header" false (Compression.accepts_zstd request)
@@ -292,6 +333,9 @@ let compression_tests =
   ; "accepts zstd (positive)", `Quick, test_accepts_zstd_positive
   ; "accepts zstd (only)", `Quick, test_accepts_zstd_only_zstd
   ; "accepts zstd (negative)", `Quick, test_accepts_zstd_negative
+  ; "accepts zstd rejects q=0", `Quick, test_accepts_zstd_rejects_q_zero
+  ; "accepts zstd-dict positive", `Quick, test_accepts_zstd_dict_positive
+  ; "accepts zstd-dict rejects q=0", `Quick, test_accepts_zstd_dict_rejects_q_zero
   ; "accepts zstd (no header)", `Quick, test_accepts_zstd_no_header
   ]
 ;;
@@ -305,6 +349,9 @@ let router_tests =
   ; ( "indexed prefix fallback after exact method miss"
     , `Quick
     , test_router_indexed_prefix_fallback_after_exact_method_miss )
+  ; ( "method index preserves exact 405"
+    , `Quick
+    , test_router_method_index_preserves_exact_405 )
   ; "frontend transport routes present", `Quick, test_frontend_transport_routes_present
   ; ( "frontend canonical localhost redirect"
     , `Quick


### PR DESCRIPTION
## Summary
- Split the HTTP/1 router dispatch table by method so exact-route resolution is a single method-specific path lookup and prefix scans only inspect routes for the request method.
- Preserve exact-path 405 behavior and prefix fallback after exact method misses while removing per-candidate method-list membership checks from dispatch.
- Replace allocation-heavy `Accept-Encoding` parsing (`split_on_char` + trim/lowercase/list scans) with span-based ASCII parsing shared by H1/H2 response payload handling.
- Add regression coverage for method-indexed 405 behavior and `q=0` / dictionary zstd negotiation.

## Validation
- `git diff --check origin/main..HEAD`
- `ocamlformat --check lib/http_response_payload.ml lib/http_server_eio.ml lib/http_server_eio.mli test/test_http_server_eio.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build bin/main_eio.exe test/test_http_server_eio.exe`
- `./_build/default/test/test_http_server_eio.exe` (34 tests)