### PR TITLE
refactor(dashboard): route 4 inline isRecord bodies through lib/type-guards isRecord

### DIFF
--- a/dashboard/src/api/schemas/gate-connectors.ts
+++ b/dashboard/src/api/schemas/gate-connectors.ts
@@ -39,6 +39,7 @@ import {
 
 import { SchemaDriftError, parseOrThrow } from './drift-error'
 import { safeParseChannelInfo, type ChannelInfo } from './gate-status'
+import { isRecord } from '../../lib/type-guards'
 
 // --- Nested schemas ---
 
@@ -295,8 +296,8 @@ function parseBindingSummary(raw: unknown, configuredBindingsCount: number): Con
   }
   // Cross-field default preserved: if the backend omitted
   // configured_bindings_count, fall back to the decoded array length.
-  const hasField = raw !== null && typeof raw === 'object' && !Array.isArray(raw)
-    && typeof (raw as Record<string, unknown>).configured_bindings_count === 'number'
+  const hasField = isRecord(raw)
+    && typeof raw.configured_bindings_count === 'number'
   return {
     ...parsed.output,
     configured_bindings_count: hasField

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -40,6 +40,7 @@ import {
   type RunActivityVerb,
 } from './run-activity-store'
 import { bridgeRunActivityEventsToTrace } from './run-activity-trace-bridge'
+import { isRecord } from '../../lib/type-guards'
 
 const FALLBACK_VERB_MAP: Readonly<Record<string, RunActivityVerb>> = {
   approved: 'approved',
@@ -169,9 +170,8 @@ function targetFromSubject(subject: ApiActivityEvent['subject'], kind: string): 
 }
 
 function detailFromPayload(payload: unknown, kind: string): string | undefined {
-  if (typeof payload === 'object' && payload !== null && !Array.isArray(payload)) {
-    const record = payload as Record<string, unknown>
-    const summary = record['summary'] ?? record['title'] ?? record['body'] ?? record['reason']
+  if (isRecord(payload)) {
+    const summary = payload['summary'] ?? payload['title'] ?? payload['body'] ?? payload['reason']
     if (typeof summary === 'string' && summary.trim() !== '') {
       const truncated = summary.length > 120 ? summary.slice(0, 117) + '...' : summary
       return truncated

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -51,6 +51,7 @@ import { mergeServerStatus } from './store-normalizers'
 import { normalizeOperatorSnapshot, normalizeOperatorDigest } from './operator-normalizers'
 import { operatorSnapshot, operatorRoomDigest } from './operator-signals'
 import { compositeTick, hydrateFleetCompositeSnapshot } from './composite-signals'
+import { isRecord } from './lib/type-guards'
 import { hydrateGoalTreeSnapshot } from './goal-tree-state'
 import { showToast } from './components/common/toast'
 import type { ErrorCode } from './types/error'
@@ -541,9 +542,7 @@ export function hydrateServerPushEvent(event: SSEEvent): boolean {
 }
 
 function eventPayloadRecord(payload: unknown): Record<string, unknown> {
-  return payload && typeof payload === 'object' && !Array.isArray(payload)
-    ? payload as Record<string, unknown>
-    : { payload }
+  return isRecord(payload) ? payload : { payload }
 }
 
 export function hydrateDashboardSlice(slice: string, payload: unknown, eventType?: string): void {

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -5,6 +5,7 @@ import { signal, type ReadonlySignal } from '@preact/signals'
 import type { JournalEntry, JournalEventType, SSEEvent } from './types'
 import { SYSTEM_ACTOR_NAME } from './types/core'
 import { formatCost } from './lib/format-number'
+import { isRecord } from './lib/type-guards'
 import {
   removeBoardPost,
 } from './store'
@@ -50,8 +51,8 @@ function traceValueString(value: unknown): string | null {
 
 function traceToolArgs(value: unknown): string | Record<string, unknown> | null {
   if (typeof value === 'string') return value
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
-    return value as Record<string, unknown>
+  if (isRecord(value)) {
+    return value
   }
   return traceValueString(value)
 }


### PR DESCRIPTION
## 변경 내용

`lib/type-guards.ts:4` 에 이미 `isRecord(value: unknown): value is Record<string, unknown>` 이 export 되어 있는데 **4 callsite 가 inline body 를 반복 작성** 하고 있었습니다.

게다가 inline 패턴은 type narrowing 을 잃어버려 *세 곳이 manual `as Record<string, unknown>` cast 작성* — `isRecord` 의 predicate 가 narrowing 을 해줘서 cast 가 불필요해집니다.

## 변경 사이트

### Exact null-check variant (1 site)

| File | Before | After |
|------|--------|-------|
| `components/ide/ide-activity-panel.ts:172` | `typeof payload === 'object' && payload !== null && !Array.isArray(payload)` + `const record = payload as Record<string, unknown>` | `isRecord(payload)` + use `payload` directly |

### Same-order, separate AND-chain (1 site)

| File | Before | After |
|------|--------|-------|
| `api/schemas/gate-connectors.ts:298` | `raw !== null && typeof raw === 'object' && !Array.isArray(raw) && typeof (raw as Record<string, unknown>).configured_bindings_count === 'number'` | `isRecord(raw) && typeof raw.configured_bindings_count === 'number'` |

### Truthy-AND variant (2 site)

| File | Before | After |
|------|--------|-------|
| `sse.ts:53` | `value && typeof value === 'object' && !Array.isArray(value)` + `return value as Record<string, unknown>` | `isRecord(value)` + `return value` |
| `sse-store.ts:544` | `payload && typeof payload === 'object' && !Array.isArray(payload) ? payload as Record<string, unknown> : ...` | `isRecord(payload) ? payload : ...` |

## 등가성

`isRecord` body:
```ts
return typeof value === 'object' && value !== null && !Array.isArray(value)
```

truthy-AND variant 과 null-check variant 는 `unknown` 입력에 대해 *동일한 boolean* 을 반환합니다:
- `typeof null === 'object'` 이지만 `null !== null` 은 false, `null && ...` 도 false → 둘 다 false
- `typeof '' === 'string'`, `typeof 0 === 'number'`, `typeof false === 'boolean'` 등 falsy primitive 는 `typeof === 'object'` 에서 일찍 fail → variant 무관 같은 동작
- `{}, []` 등 object → 둘 다 typeof 통과, `!== null` / truthy 양쪽 통과, `Array.isArray` 가 분기

JSON-derived `unknown` 값에서 정확히 동일.

## 부수 효과 — manual cast 제거 3 곳

`isRecord` 의 `value is Record<string, unknown>` predicate 가 narrowing 을 제공하므로 세 callsite 가 자체적으로 작성하던 `as Record<string, unknown>` cast 를 자동 제거 — TypeScript 가 narrowed type 으로 추론.

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (5 관련 test file: sse / sse-store / gate-connectors / ide-activity-panel x 2) — 61/61 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`; 첫 run 2 transient → 두 번째 1 baseline)
- 4 file +11/-10

## SSOT 의미

PR #19193 (errorToString), PR #19234 (clampPct), PR #19237 (clampUnitInterval), PR #19240 (isAbortError) 와 *같은 SSOT class* — canonical helper 가 이미 존재, inline copy 가 helper 로 수렴.

