### PR TITLE
refactor(dashboard): remove session trace trigger aliases

### DIFF
--- a/dashboard/src/components/session-trace/session-trace-filter.ts
+++ b/dashboard/src/components/session-trace/session-trace-filter.ts
@@ -8,7 +8,7 @@ import {
   getKindCounts, getTraceFilter, setTraceFilter,
   getStatusCounts, getTraceStatusFilter, setTraceStatusFilter,
   getTraceSearchQuery, setTraceSearchQuery,
-  _traceSlots,
+  traceSlots,
 } from './session-trace-state'
 import type { TraceEventKind, TraceStatus } from './session-trace-state'
 
@@ -36,8 +36,8 @@ const STATUS_CHIPS: Array<{ key: StatusKey; label: string }> = [
 ]
 
 export function SessionTraceFilter({ agentName }: { agentName: string }) {
-  // Read _traceSlots.value to subscribe to slot changes
-  void _traceSlots.value
+  // Read traceSlots.value to subscribe to slot changes.
+  void traceSlots.value
 
   const counts = getKindCounts(agentName)
   const currentFilter = getTraceFilter(agentName)

--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -14,10 +14,9 @@ import {
   getTraceLoading,
   getTraceError,
   buildTraceEvents,
-  _liveTraceFeeds as liveTraceFeeds,
-  _traceSlots as traceSlots,
+  traceSlots,
 } from './session-trace-state'
-import { appendLiveToolCall } from './session-trace-live-store'
+import { appendLiveToolCall, liveTraceFeeds } from './session-trace-live-store'
 
 // Reset trace slots before each test
 beforeEach(() => {

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -103,7 +103,7 @@ interface TraceSlot {
 
 // ── Per-agent state map ────────────────────────────────
 
-const traceSlots = signal<Record<string, TraceSlot>>({})
+export const traceSlots = signal<Record<string, TraceSlot>>({})
 
 const EMPTY_SLOT: TraceSlot = { events: [], loading: false, error: null, filter: 'all', statusFilter: 'all', searchQuery: '', fetchToken: 0 }
 
@@ -314,8 +314,6 @@ export function getKindCounts(agent: string): Record<TraceEventKind | 'all', num
 // ── Trigger signal ─────────────────────────────────────
 // Components subscribe to this to know when traceSlots changed.
 // Reading traceSlots.value inside a component body tracks reactivity.
-export { traceSlots as _traceSlots }
-export { liveTraceFeeds as _liveTraceFeeds }
 
 // ── Filter action ──────────────────────────────────────
 

--- a/dashboard/src/components/session-trace/session-trace-view.ts
+++ b/dashboard/src/components/session-trace/session-trace-view.ts
@@ -16,7 +16,7 @@ import {
   getTraceSearchQuery,
   loadSessionTrace,
   closeSessionTrace,
-  _traceSlots,
+  traceSlots,
 } from './session-trace-state'
 import type { TraceSummary } from './session-trace-state'
 import { isOfflineStatus } from '../../lib/keeper-classifiers'
@@ -107,8 +107,8 @@ export function SessionTraceView({ agentName, isKeeper, keeperStatus, keeperGene
     }
   }, [agentName, isKeeper])
 
-  // Subscribe to traceSlots changes for reactivity
-  void _traceSlots.value
+  // Subscribe to traceSlots changes for reactivity.
+  void traceSlots.value
 
   const loading = getTraceLoading(agentName)
   const error = getTraceError(agentName)


### PR DESCRIPTION
## Summary
- export traceSlots directly from session-trace-state
- remove _traceSlots and _liveTraceFeeds alias exports
- import liveTraceFeeds directly from session-trace-live-store in tests

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/session-trace/session-trace-state.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/session-trace/session-trace-state.ts src/components/session-trace/session-trace-state.test.ts src/components/session-trace/session-trace-filter.ts src/components/session-trace/session-trace-view.ts src/components/session-trace/session-trace-live-store.ts
- git diff --check origin/main