### PR TITLE
refactor(dashboard/input): drop file-internal hasNonEmptyValue duplicate, route 9 sites through lib isNonEmptyString

### DIFF
--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -10,6 +10,7 @@
 
 import { html } from 'htm/preact'
 import { ringFocusClasses } from './ring'
+import { isNonEmptyString } from '../../lib/format-string'
 
 export type InputControlKind = 'text-input' | 'textarea'
 export type InputAriaExpandedState = 'unset' | 'true' | 'false' | 'other'
@@ -50,10 +51,6 @@ function nonEmptyLength(value: string | undefined): number {
   return value?.length ?? 0
 }
 
-function hasNonEmptyValue(value: string | undefined): boolean {
-  return value !== undefined && value !== ''
-}
-
 function ariaExpandedState(value: boolean | string | undefined): InputAriaExpandedState {
   if (value === undefined) return 'unset'
   if (value === true || value === 'true') return 'true'
@@ -73,15 +70,15 @@ function textAreaAutocompleteState({
   ariaActiveDescendant?: string
 }): TextAreaAutocompleteState {
   const hasAutocompleteShape =
-    hasNonEmptyValue(role) ||
-    hasNonEmptyValue(ariaAutocomplete) ||
-    hasNonEmptyValue(ariaControls) ||
-    hasNonEmptyValue(ariaActiveDescendant)
+    isNonEmptyString(role) ||
+    isNonEmptyString(ariaAutocomplete) ||
+    isNonEmptyString(ariaControls) ||
+    isNonEmptyString(ariaActiveDescendant)
   if (!hasAutocompleteShape) return 'none'
   if (
     role === 'combobox' &&
-    hasNonEmptyValue(ariaAutocomplete) &&
-    hasNonEmptyValue(ariaControls)
+    isNonEmptyString(ariaAutocomplete) &&
+    isNonEmptyString(ariaControls)
   ) return 'complete'
   return 'partial'
 }
@@ -132,19 +129,19 @@ function summarizeInputControl({
     type: type ?? '',
     rows: rows ?? 0,
     hasRows: rows !== undefined,
-    hasValue: hasNonEmptyValue(value),
+    hasValue: isNonEmptyString(value),
     valueLength: nonEmptyLength(value),
-    hasPlaceholder: hasNonEmptyValue(placeholder),
+    hasPlaceholder: isNonEmptyString(placeholder),
     placeholderLength: nonEmptyLength(placeholder),
     disabled: disabled === true,
     required: required === true,
-    hasCustomClass: hasNonEmptyValue(className),
+    hasCustomClass: isNonEmptyString(className),
     classNameLength: nonEmptyLength(className),
-    hasId: hasNonEmptyValue(id),
-    hasName: hasNonEmptyValue(name),
-    hasAriaLabel: hasNonEmptyValue(ariaLabel),
-    hasAutoComplete: hasNonEmptyValue(autoComplete),
-    hasTestId: hasNonEmptyValue(testId),
+    hasId: isNonEmptyString(id),
+    hasName: isNonEmptyString(name),
+    hasAriaLabel: isNonEmptyString(ariaLabel),
+    hasAutoComplete: isNonEmptyString(autoComplete),
+    hasTestId: isNonEmptyString(testId),
     autoFocus: autoFocus === true,
     ariaExpandedState: ariaExpandedState(ariaExpanded),
     autocompleteState: textAreaAutocompleteState({


### PR DESCRIPTION
## 변경 내용

`components/common/input.ts:53-55` 가 자체 helper 보유:

```ts
function hasNonEmptyValue(value: string | undefined): boolean {
  return value !== undefined && value !== ''
}
```

이건 **byte-for-byte 동일한 함수 `isNonEmptyString` 이 이미 `lib/format-string.ts:29` 에서 export 중**입니다 (PR #19193 helper-only 와 같은 모듈). 같은 file 안 9 callsite 가 helper 우회.

## 변경

1. file-internal `hasNonEmptyValue` 삭제 (3 lines)
2. `import { isNonEmptyString } from '../../lib/format-string'` 추가
3. 9 callsite 자동 routing:
   - aria signal aggregation (5 calls): `role`, `ariaAutocomplete`, `ariaControls`, `ariaActiveDescendant`, + combined check
   - `InputControlSummary` builder (4 calls): `hasValue`, `hasPlaceholder`, `hasCustomClass`, `hasTestId`

## 등가성

`isNonEmptyString` (`lib/format-string.ts:29`):
```ts
export function isNonEmptyString(value: string | undefined): boolean {
  return value !== undefined && value !== ''
}
```

같은 signature, 같은 body. runtime + type 추론 동일.

## SSOT 의미

PR #19214 (cascade-config-panel 의 file-internal `errorToString` duplicate 제거) 와 *같은 class*. canonical helper 가 이미 lib/ 에 살아있는데 component 안에 shadow copy 존재 — 정책 변경 시 (예: `'\t\n'` 같은 whitespace-only 입력 처리 변경) 한 곳만 갱신되고 다른 곳 stale.

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (3 관련 test file: input / input.a11y / format-string) — 33/33 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 1 file +15/-18

