### PR TITLE
refactor(dashboard): remove inspector pin wrapper

### DIFF
--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -18,7 +18,8 @@ import { IdeInterject } from './ide-interject'
 import { ExecuteOutputDrawer } from './execute-output-drawer'
 import { IdePresenceStrip } from './ide-presence-strip'
 import { IDE_LAYERS, IdeToolbar } from './ide-toolbar'
-import { InspectorKeeperBDI, pinInspectorKeeper } from './inspector-keeper-bdi'
+import { InspectorKeeperBDI } from './inspector-keeper-bdi'
+import { pinKeeper } from './multi-keeper-pin-store'
 import { OverlayKeeperTrace } from './overlay-keeper-trace'
 import { IdePersistencePanel } from './ide-persistence-panel'
 import { IdeBranchContextPanel } from './ide-branch-context-panel'
@@ -677,7 +678,7 @@ export function IdeShell() {
             findOpen=${findOpen}
             onFindOpen=${handleFindOpen}
             onFindClose=${handleFindClose}
-            onKeeperLineSelect=${pinInspectorKeeper}
+            onKeeperLineSelect=${pinKeeper}
             annotations=${annotations}
           />
           <${OverlayKeeperTrace} active=${activeLayers.has('keeper-trace')} />

--- a/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
@@ -5,10 +5,9 @@ import { activeKeeperName } from '../../keeper-state'
 import {
   InspectorKeeperBDI,
   normalizeKeeperBdiSnapshot,
-  pinInspectorKeeper,
 } from './inspector-keeper-bdi'
 import { routeHashParams } from './ide-test-helpers'
-import { clearPins } from './multi-keeper-pin-store'
+import { clearPins, pinKeeper } from './multi-keeper-pin-store'
 import { clearTraces, pushTrace } from './keeper-trace-store'
 import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
 import { activeIdeFile, ideContextFocus } from './ide-state'
@@ -108,7 +107,7 @@ describe('InspectorKeeperBDI', () => {
   it('pins selected keeper/line and renders the BDI snapshot', async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify(snapshot)))
     vi.stubGlobal('fetch', fetchMock)
-    pinInspectorKeeper('scholar', 42)
+    pinKeeper('scholar', 42)
 
     const container = createContainer()
     render(html`<${InspectorKeeperBDI} pollMs=${60_000} />`, container)
@@ -161,7 +160,7 @@ describe('InspectorKeeperBDI', () => {
 
     const fetchMock = vi.fn(async () => new Response(JSON.stringify(snapshot)))
     vi.stubGlobal('fetch', fetchMock)
-    pinInspectorKeeper('scholar', 42)
+    pinKeeper('scholar', 42)
 
     const container = createContainer()
     render(html`<${InspectorKeeperBDI} pollMs=${60_000} traceActive=${true} />`, container)
@@ -192,7 +191,7 @@ describe('InspectorKeeperBDI', () => {
 
     const fetchMock = vi.fn(async () => new Response(JSON.stringify(snapshot)))
     vi.stubGlobal('fetch', fetchMock)
-    pinInspectorKeeper('scholar', 42)
+    pinKeeper('scholar', 42)
 
     const container = createContainer()
     render(html`<${InspectorKeeperBDI} pollMs=${60_000} />`, container)

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -4,7 +4,7 @@ import { activeKeeperName } from '../../keeper-state'
 import { get } from '../../api/core'
 import { bridgeBdiSnapshotsToTrace } from './bdi-snapshot-trace-bridge'
 import { asBoolean, asNumber, asString, isRecord, toIsoTimestamp } from '../common/normalize'
-import { clearPins, headPinnedKeeper, pinKeeper } from './multi-keeper-pin-store'
+import { headPinnedKeeper } from './multi-keeper-pin-store'
 import { globalPresenceSnapshot, PRESENCE_DOT, presenceEntries, type KeeperPresenceEntry } from './keeper-presence-store'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
 // Imported from `./ide-state` rather than `./ide-shell` to avoid the
@@ -61,15 +61,6 @@ interface InspectorKeeperPin {
 function inspectorPinFromHead(): InspectorKeeperPin | null {
   const head = headPinnedKeeper.value
   return head ? { keeperName: head.keeperName, line: head.line } : null
-}
-
-export function pinInspectorKeeper(keeperName: string, line: number | null): void {
-  const trimmed = keeperName.trim()
-  if (trimmed) {
-    pinKeeper(trimmed, line)
-  } else {
-    clearPins()
-  }
 }
 
 function normalizeTokenSpend(raw: unknown): KeeperBdiTokenSpend | null {

--- a/dashboard/src/components/ide/multi-keeper-pin-store.ts
+++ b/dashboard/src/components/ide/multi-keeper-pin-store.ts
@@ -8,10 +8,6 @@ import { computed, signal } from '@preact/signals'
  * belong to the consumer (`InspectorMultiKeeperBDI`),
  * not the store.
  *
- * Backward-compat (RFC-0027 §10):
- *   - `pinInspectorKeeper(name, line)` re-exported from `inspector-keeper-bdi.ts`
- *     forwards into `pinKeeper(name, line)`. Callers see no shape change.
- *
  * Cap = 4 ties to RFC-0027 §11 #1 (320px inspector rail + compact-fold). The
  * cap is a constant in the store rather than a runtime parameter so test
  * surface is small.
@@ -103,10 +99,7 @@ export function reorderPins(fromName: string, toIdx: number): void {
   pinnedKeepers.value = { ...prev, entries: next }
 }
 
-/**
- * Head entry projection for legacy single-pin callers. Returns `null` when no
- * keeper is pinned.
- */
+/** Head entry projection for consumers that render one active inspector. */
 export const headPinnedKeeper = computed<PinnedKeeperEntry | null>(
   () => pinnedKeepers.value.entries[0] ?? null,
 )


### PR DESCRIPTION
## Summary
- remove the pinInspectorKeeper compatibility wrapper
- wire IDE line selection directly to multi-keeper pin store pinKeeper
- update BDI tests and stale compatibility comments to use the multi-pin SSOT

## Verification
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/ide-shell.test.ts src/components/ide/multi-keeper-pin-store.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=15000
- pnpm eslint src/components/ide/inspector-keeper-bdi.ts src/components/ide/inspector-keeper-bdi.test.ts src/components/ide/ide-shell.ts src/components/ide/ide-shell.test.ts src/components/ide/multi-keeper-pin-store.ts src/components/ide/multi-keeper-pin-store.test.ts
- git diff --check origin/main