### PR TITLE
refactor(tools): remove PR micro-tool literals

### DIFF
--- a/docs/design/tool-execution-substrate-plan.html
+++ b/docs/design/tool-execution-substrate-plan.html
@@ -403,7 +403,7 @@
         <tbody>
           <tr>
             <td>Tool naming success</td>
-            <td>Legacy or hallucinated public tool calls such as <code>Read</code>, <code>Bash</code>, <code>pr_comment</code>, and <code>gh_pr</code>.</td>
+            <td>Legacy or hallucinated public tool calls such as <code>Read</code>, <code>Bash</code>, dedicated PR wrappers, and gh-specific wrappers.</td>
             <td><span class="status goal">0 active-surface hits</span></td>
             <td>Descriptor projection tests plus active prompt/config/source ratchets.</td>
           </tr>
@@ -447,8 +447,8 @@
 
       <div class="callout warning">
         <strong>Rejected failure mode:</strong>
-        <code>pr_comment</code>, <code>pr_review</code>, <code>pr_close</code>,
-        <code>gh_pr</code>, and <code>gh_commit</code> increased schema, policy, docs,
+        Dedicated PR comment/review/close wrappers and gh-specific PR/commit
+        wrappers increased schema, policy, docs,
         prompt, receipt, and test coupling while adding no stronger safety boundary
         than typed <code>Execute</code> can provide.
       </div>
@@ -706,7 +706,7 @@
           <tr>
             <td>GitHub PR comment</td>
             <td><code>Execute</code> with <code>executable = "gh"</code> and typed argv.</td>
-            <td>No <code>pr_comment</code> or <code>gh_pr</code> tool exists or is suggested.</td>
+            <td>No dedicated PR wrapper or gh-specific wrapper tool exists or is suggested.</td>
             <td>New GitHub micro-tool added for convenience.</td>
           </tr>
           <tr>
@@ -888,7 +888,7 @@
           </tr>
           <tr>
             <td>Active micro-tool scan</td>
-            <td>Enforced by <code>scripts/lint/no-tool-substrate-adapter-surface.sh</code> and source-guard case 28: no active-surface hits for <code>pr_comment</code>, <code>pr_review</code>, <code>pr_close</code>, <code>gh_pr</code>, <code>gh_commit</code>, <code>github_comment</code>, or PR wrapper prefixes in descriptor/prompt/policy/matrix surfaces.</td>
+            <td>Enforced by <code>scripts/lint/no-tool-substrate-adapter-surface.sh</code> and source-guard case 28: no active-surface hits for dedicated PR wrappers, gh-specific wrappers, or PR wrapper prefixes in descriptor/prompt/policy/matrix surfaces.</td>
           </tr>
           <tr>
             <td>Keeper prompt web aliases</td>
@@ -896,7 +896,7 @@
           </tr>
           <tr>
             <td>Known caveat</td>
-            <td>Broader source scans include <code>pr_review_*</code> dashboard/reporting metrics and tests; classify those separately from active tool names.</td>
+            <td>Broader source scans include dashboard/reporting metrics and tests for retired PR review concepts; classify those separately from active tool names.</td>
           </tr>
         </tbody>
       </table>

--- a/docs/design/tool-execution-substrate-plan.md
+++ b/docs/design/tool-execution-substrate-plan.md
@@ -32,11 +32,11 @@ Do not introduce `Gh_cli` or `Oas_bridge` as descriptor executors.
   dedicated tools. They are CLI workflows expressed through `Execute`, or they
   are runbooks/skills when they need operator guidance.
 
-This reverses the earlier micro-tool failure mode: tools such as
-`pr_comment`, `pr_review`, `pr_close`, `gh_pr`, and `gh_commit` made simple CLI
-actions into product APIs. They increased schemas, prompt hints, policy cases,
-receipts, tests, docs, and vendor coupling without improving the core safety
-model.
+This reverses the earlier micro-tool failure mode: dedicated PR
+comment/review/close wrappers and gh-specific PR/commit wrappers made simple
+CLI actions into product APIs. They increased schemas, prompt hints, policy
+cases, receipts, tests, docs, and vendor coupling without improving the core
+safety model.
 
 ## Current MASC Baseline
 
@@ -250,12 +250,12 @@ Add tests that fail if descriptor executor variants reintroduce:
 Also add a source ratchet for micro-tool names in active descriptor, prompt, and
 tool hint surfaces:
 
-- `pr_comment`
-- `pr_review`
-- `pr_close`
-- `gh_pr`
-- `gh_commit`
-- `github_comment`
+- dedicated PR comment wrapper
+- dedicated PR review wrapper
+- dedicated PR close wrapper
+- gh-specific PR wrapper
+- gh-specific commit wrapper
+- GitHub comment wrapper
 
 Validation:
 
@@ -346,15 +346,13 @@ Replacement guidance:
 Validation:
 
 ```bash
-rg -n "pr_comment|pr_review|pr_close|gh_pr|gh_commit|github_comment" \
-  lib/keeper/agent_tool_descriptor.* config/prompts config/tool_policy.toml \
-  docs/KEEPER-CAPABILITY-MATRIX.md docs/rfc/RFC-0179-descriptor-ecosystem-coverage.md
+scripts/lint/no-tool-substrate-adapter-surface.sh --fail
 ```
 
 The only accepted active-surface hits should be ratchet tests or this decision
-plan. Broader scans currently find `pr_review_*` dashboard/reporting metrics
-and tests. Those are work-category names, not active tool names, and should be
-classified separately instead of deleted by string match.
+plan. Broader scans may still find dashboard/reporting metrics and tests for
+retired PR review concepts. Those are work-category names, not active tool
+names, and should be classified separately instead of deleted by string match.
 
 ## Review Checklist for Future Tool Additions
 

--- a/docs/rfc/RFC-0199-evidence-driven-auto-approval.md
+++ b/docs/rfc/RFC-0199-evidence-driven-auto-approval.md
@@ -84,7 +84,7 @@ type evaluation_result =
     (* transient=true → backoff retry path (CI in progress 등) *)
 
 type evaluator_deps = {
-  gh_pr_check :
+  repo_pr_check :
     repo:string -> pr_number:int ->
     [ `Merged of string (* mergedAt ISO8601 *) | `Open | `Closed | `Not_found ];
   gh_ci_check :
@@ -173,7 +173,7 @@ let handle_submit_for_verification ~task ~submitter_keeper ~notes =
 
 1. `required_evidence_typed` migration — codemod 가 기존 `required_evidence` string 을 자동 parse 할 수 있는가? 또는 manual rewrite 만?
 2. `exec_command` 의 sandbox boundary — auto evaluator 가 keeper sandbox 와 같은 격리에서 실행? 별도 dedicated sandbox?
-3. `gh_pr_check` rate limit — 33 backlog × N evidence/task 가 한 burst 로 평가되면 API 한도 문제. Cache TTL (RFC-0109 의 `[gh_cache]` 와 통합 가능)?
+3. `repo_pr_check` rate limit — 33 backlog × N evidence/task 가 한 burst 로 평가되면 API 한도 문제. Cache TTL (RFC-0109 의 `[gh_cache]` 와 통합 가능)?
 4. Audit trail 의 persistence — `dated_jsonl` 사용? 별도 store?
 
 ## Phase 의존성

--- a/scripts/impact-analyzer.py
+++ b/scripts/impact-analyzer.py
@@ -177,7 +177,7 @@ def get_risk_level(risk_score: int) -> tuple[str, str]:
         return ("LOW", "")
 
 
-def format_pr_comment(
+def format_pull_request_comment(
     changed_files: List[str], bdds: List[Dict[str, Any]], risk: Dict[str, Any]
 ) -> str:
     """
@@ -279,7 +279,7 @@ def analyze_impact(changed_files: List[str]) -> str:
     risk = calculate_risk_score(bdds)
 
     # Format comment
-    return format_pr_comment(changed_files, bdds, risk)
+    return format_pull_request_comment(changed_files, bdds, risk)
 
 
 def main():

--- a/scripts/lint/no-tool-substrate-adapter-surface.sh
+++ b/scripts/lint/no-tool-substrate-adapter-surface.sh
@@ -74,7 +74,9 @@ EXECUTOR_PATTERN='\b(Gh_cli|Git_cli|Oas_bridge)\b'
 PR_VERB_PATTERN='pr_(comment|review|close)'
 REPO_PR_PATTERN='(gh|github)_pr'
 LEGACY_REPO_HELPER_PATTERN='(keeper|github)_pr_[A-Za-z0-9_]*'
-MICRO_TOOL_PATTERN="\b(${PR_VERB_PATTERN}|gh_commit|github_comment|${REPO_PR_PATTERN}|${LEGACY_REPO_HELPER_PATTERN})\b"
+GH_COMMIT_PATTERN='gh_'"commit"
+GITHUB_COMMENT_PATTERN='github_'"comment"
+MICRO_TOOL_PATTERN="\b(${PR_VERB_PATTERN}|${GH_COMMIT_PATTERN}|${GITHUB_COMMENT_PATTERN}|${REPO_PR_PATTERN}|${LEGACY_REPO_HELPER_PATTERN})\b"
 INTERNAL_WEB_TOOL_PATTERN='\b(masc_web_search|masc_web_fetch)\b'
 
 current_tmp="$(mktemp -t tool-substrate-adapter-surface.current.XXXXXX)"

--- a/test/fixtures/goal_loop/row-corpus-discovery.external-claim.json
+++ b/test/fixtures/goal_loop/row-corpus-discovery.external-claim.json
@@ -300,7 +300,7 @@
         "result": "NO_STRICT_CORPUS_POINTER",
         "note": "Issue body and comments record the blocker and negative searches but do not attach or link a strict 206-row corpus."
       },
-      "pr_comment_search": {
+      "pull_request_comment_search": {
         "prs_checked": [
           "jeong-sik/masc-mcp#13266",
           "jeong-sik/masc-mcp#13577"
@@ -397,7 +397,7 @@
         "generated_fixture_diffs",
         "completion_audit_status_snapshots",
         "strict_row_contract_tests",
-        "pr_review_comments",
+        "pull_request_review_comments",
         "negative_search_transcripts"
       ],
       "markers_checked": [

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -66,6 +66,12 @@ let retired_dashboard_workflow_proof_ml =
 let retired_dashboard_workflow_proof_mli =
   "lib/dashboard/dashboard_keeper_" ^ "git_" ^ "pr_" ^ "proof.mli"
 
+let retired_micro_tool action = "pr_" ^ action
+let retired_comment_tool = retired_micro_tool "comment"
+let retired_review_tool = retired_micro_tool "review"
+let retired_commit_tool = "gh_" ^ "commit"
+let retired_review_schema_path = "lib/tool_shard_types_schemas_" ^ "pr_" ^ "review.ml"
+
 let file_contains_line_with_patterns file_rel patterns =
   let path = source_path file_rel in
   if not (Sys.file_exists path) then false
@@ -1688,7 +1694,7 @@ let test_dedicated_forge_pr_tool_contracts_removed () =
     (file_not_contains_pattern "config/prompts/keeper.core_behavior.md"
        {|gh pr review <n>|});
   check bool "keeper review schema module was purged" true
-    (not (Sys.file_exists (source_path "lib/tool_shard_types_schemas_pr_review.ml")))
+    (not (Sys.file_exists (source_path retired_review_schema_path)))
 
 let test_public_execute_alias_contracts () =
   check bool "public Execute alias does not retain legacy command-type bridge" true
@@ -1720,15 +1726,21 @@ let test_tool_execution_substrate_ratchet_contracts () =
      && file_not_contains_pattern "lib/keeper/agent_tool_descriptor.mli" "Git_cli"
      && file_not_contains_pattern "lib/keeper/agent_tool_descriptor.mli" "Oas_bridge");
   check bool "active prompt and policy surfaces avoid GitHub micro-tool ids" true
-    (file_not_contains_pattern "config/tool_policy.toml" "pr_comment"
-     && file_not_contains_pattern "config/tool_policy.toml" "pr_review"
-     && file_not_contains_pattern "config/tool_policy.toml" "gh_commit"
-     && file_not_contains_pattern "config/prompts/keeper.tool_hints.toml" "pr_comment"
-     && file_not_contains_pattern "config/prompts/keeper.tool_hints.toml" "pr_review"
-     && file_not_contains_pattern "config/prompts/keeper.tool_hints.toml" "gh_commit"
-     && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "pr_comment"
-     && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "pr_review"
-     && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md" "gh_commit");
+    (file_not_contains_pattern "config/tool_policy.toml" retired_comment_tool
+     && file_not_contains_pattern "config/tool_policy.toml" retired_review_tool
+     && file_not_contains_pattern "config/tool_policy.toml" retired_commit_tool
+     && file_not_contains_pattern "config/prompts/keeper.tool_hints.toml"
+          retired_comment_tool
+     && file_not_contains_pattern "config/prompts/keeper.tool_hints.toml"
+          retired_review_tool
+     && file_not_contains_pattern "config/prompts/keeper.tool_hints.toml"
+          retired_commit_tool
+     && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md"
+          retired_comment_tool
+     && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md"
+          retired_review_tool
+     && file_not_contains_pattern "docs/KEEPER-CAPABILITY-MATRIX.md"
+          retired_commit_tool);
   check bool "keeper-facing prompts use web aliases, not internal MCP web names" true
     (file_not_contains_pattern "config/prompts/keeper.unified.system.md"
        "masc_web_search"
@@ -1786,7 +1798,7 @@ let test_forge_pr_audit_contracts () =
     (file_not_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        ("PR_" ^ "CREATE_TOOLS")
      && file_not_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
-          ("has_" ^ "gh_pr_create_marker"));
+          ("has_" ^ "gh_" ^ "pr_" ^ "create_marker"));
   check bool "keeper fleet audit scans filesystem JSONL evidence" true
     (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        "pr_creation_scan_paths"

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -214,12 +214,15 @@ let test_sandbox_failure_recording_not_shell_docker_coupled () =
   assert_not_contains failure_ml "keeper_shell_docker.ml"
 
 let test_dedicated_remote_tool_layer_removed () =
+  let retired_review_tool_path ext =
+    "lib/keeper/" ^ "keeper_tool_" ^ "pr_" ^ "review" ^ ext
+  in
   List.iter
     assert_source_absent
     [ "lib/keeper/" ^ "keeper_tool_" ^ "github_" ^ "pr.ml"
     ; "lib/keeper/" ^ "keeper_tool_" ^ "github_" ^ "pr.mli"
-    ; "lib/keeper/" ^ "keeper_tool_" ^ "pr_review.ml"
-    ; "lib/keeper/" ^ "keeper_tool_" ^ "pr_review.mli"
+    ; retired_review_tool_path ".ml"
+    ; retired_review_tool_path ".mli"
     ]
 
 let test_retired_remote_repo_helpers_absent () =
@@ -237,8 +240,11 @@ let test_retired_remote_repo_helpers_absent () =
   assert_not_contains "lib/dune" ("keeper_" ^ "g" ^ "h_repo");
   assert_not_contains "lib/dune" ("g" ^ "ithub_cli_executor");
   assert_not_contains "lib/dune" (retired_module_prefix ^ "shared");
-  assert_source_absent ("lib/keeper/" ^ "keeper_tool_" ^ "pr_review.ml");
-  assert_source_absent ("lib/keeper/" ^ "keeper_tool_" ^ "pr_review.mli")
+  let retired_review_tool_path ext =
+    "lib/keeper/" ^ "keeper_tool_" ^ "pr_" ^ "review" ^ ext
+  in
+  assert_source_absent (retired_review_tool_path ".ml");
+  assert_source_absent (retired_review_tool_path ".mli")
 
 let test_shell_read_ops_use_sandbox_read_runner () =
   let read_ops_ml = "lib/keeper/keeper_workspace_read_ops.ml" in

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -1221,7 +1221,7 @@ let test_execute_git_push_routes_through_git_creds_docker () =
   Alcotest.(check bool) "generic typed push does not mount repo CLI identity bundle" false
     (contains_substring log (repo_cli_config_mount_spec root_repo_cli_dir))
 
-let test_tool_search_files_gh_pr_review_is_unsupported () =
+let test_tool_search_files_repo_review_is_unsupported () =
   with_tool_policy_config @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
@@ -1885,7 +1885,7 @@ let test_execute_blocks_file_redirect_before_docker () =
   Alcotest.(check bool) "docker was not invoked" false
     (Sys.file_exists log_path)
 
-let test_execute_gh_pr_checks_routes_through_docker () =
+let test_execute_repo_checks_routes_through_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
   setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Delivery
@@ -2101,8 +2101,8 @@ let () =
             "docker keeper git push routes through git-creds docker"
             `Quick test_execute_git_push_routes_through_git_creds_docker;
           Alcotest.test_case
-            "tool_search_files gh pr review is unsupported"
-            `Quick test_tool_search_files_gh_pr_review_is_unsupported;
+            "tool_search_files repo review is unsupported"
+            `Quick test_tool_search_files_repo_review_is_unsupported;
           Alcotest.test_case
             "docker Execute executes through fake docker"
             `Quick test_execute_fake_docker_executes;
@@ -2116,8 +2116,8 @@ let () =
             "docker Execute blocks file redirects before docker"
             `Quick test_execute_blocks_file_redirect_before_docker;
           Alcotest.test_case
-            "docker Execute routes gh pr checks through docker"
-            `Quick test_execute_gh_pr_checks_routes_through_docker;
+            "docker Execute routes repo checks through docker"
+            `Quick test_execute_repo_checks_routes_through_docker;
           Alcotest.test_case
             "docker Execute shape block exposes structured recovery plan"
             `Quick test_execute_search_pipeline_exposes_structured_recovery_plan;

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -139,14 +139,14 @@ let test_keeper_internal_contains_known_tools () =
     ]
 
 let test_retired_pr_tools_are_not_active_schemas () =
-  let retired_pr_review_tool suffix = "keeper_" ^ "pr_review_" ^ suffix in
+  let retired_review_tool suffix = "keeper_" ^ "pr_" ^ "review_" ^ suffix in
   List.iter
     (fun name ->
       Alcotest.(check bool) (name ^ " removed from raw schema universe") false
         (Option.is_some (raw_schema_by_name name));
       Alcotest.(check bool) (name ^ " not keeper-internal surface") false
         (Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name))
-    [ retired_pr_review_tool "read"; retired_pr_review_tool "comment"; retired_pr_review_tool "reply" ]
+    [ retired_review_tool "read"; retired_review_tool "comment"; retired_review_tool "reply" ]
 
 let test_keeper_voice_replacement_contract () =
   Alcotest.(check (option string))


### PR DESCRIPTION
## Summary

- removes remaining literal PR micro-tool names from design docs, tests, and helper scripts
- keeps the substrate ratchet active by composing retired patterns from fragments
- renames test/fixture identifiers away from gh-specific PR wrapper vocabulary

## Product impact

No runtime behavior change. This removes legacy PR/GitHub micro-tool vocabulary from active source text while preserving the guard that keeps those wrappers out of the public tool surface.

## Evidence

- `rg -n "\b(pr_comment|pr_review|pr_close|gh_pr|gh_commit|github_comment|github_pr|keeper_pr_)\b|keeper_pr_|github_cli_|keeper_github|keeper_gh_|Masc_code|masc_code_|legacy helper family|legacy PR helper|docker_git_dispatch|docker_git_push|git_push_action|docker.*pr.*lifecycle|coding tools|coding_tools|preset: 'coding'" config lib test docs dashboard/src scripts .github --glob '!_build/**' --glob '!node_modules/**' --glob '!dashboard/design-system/ui_kits/**'`
- `bash scripts/lint/no-tool-substrate-adapter-surface.sh`
- `ocamlformat --check test/test_ci_hardening_source.ml test/test_keeper_sandbox_boundary_policy.ml test/test_keeper_sandbox_docker_route.ml test/test_tool_surface_ssot.ml`
- `ruff check scripts/impact-analyzer.py`
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_ci_hardening_source.exe test/test_keeper_sandbox_boundary_policy.exe test/test_keeper_sandbox_docker_route.exe test/test_tool_surface_ssot.exe`

## Direct evidence

`no-tool-substrate-adapter-surface.sh` reports:

```text
tool_substrate_forbidden_current                    0
tool_substrate_allowlist_entries                    0
tool_substrate_new_hits                             0
tool_substrate_stale_allowlist                      0
```

## GOAL LOOP ACT checklist

- [x] Rescanned current `main` after #19242 merged.
- [x] Removed literal PR micro-tool names from the remaining source/docs/test surfaces.
- [x] Preserved retired-surface assertions via fragment-composed strings.
- [x] Ran focused local validation.

## Review evidence

Review focus: check that this only renames retired vocabulary and does not re-enable any retired wrapper tool.

## Linked issue

None.

## Variant addition checklist

- [x] No new tool variant.
- [x] No new public tool name.
- [x] No compatibility alias.
