### PR TITLE
refactor(dashboard): route 8 missing-data dash sites through lib/format-string MISSING_DATA_DASH (batch 1/N)

### DIFF
--- a/dashboard/src/components/board/board-curation-panel.ts
+++ b/dashboard/src/components/board/board-curation-panel.ts
@@ -8,9 +8,10 @@ import { ActionButton } from '../common/button'
 import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { SurfaceCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
+import { MISSING_DATA_DASH } from '../../lib/format-string'
 
 function percent(value: number | null | undefined): string {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return '--'
+  if (typeof value !== 'number' || !Number.isFinite(value)) return MISSING_DATA_DASH
   return `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`
 }
 

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -205,7 +205,7 @@ function ToolAttentionTable({ rows }: { rows: ToolAttentionRow[] }) {
               </div>
               <div>
                 <div class="uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Latency</div>
-                <div class="font-mono text-[var(--color-fg-secondary)]">${formatMsCompact(row.avg_ms, '--')}</div>
+                <div class="font-mono text-[var(--color-fg-secondary)]">${formatMsCompact(row.avg_ms, MISSING_DATA_DASH)}</div>
               </div>
               <div>
                 <div class="uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Output</div>
@@ -249,7 +249,7 @@ function ToolAttentionTable({ rows }: { rows: ToolAttentionRow[] }) {
                 </td>
                 <td class="px-3 py-2 text-right font-mono text-[var(--color-fg-secondary)]">${formatNumber(row.calls)}</td>
                 <td class="px-3 py-2 text-right font-mono ${successTone}">${row.success_pct.toFixed(1)}%</td>
-                <td class="px-3 py-2 text-right font-mono text-[var(--color-fg-muted)]">${formatMsCompact(row.avg_ms, '--')}</td>
+                <td class="px-3 py-2 text-right font-mono text-[var(--color-fg-muted)]">${formatMsCompact(row.avg_ms, MISSING_DATA_DASH)}</td>
                 <td class="px-3 py-2 text-right font-mono ${row.output_truncated_count ? 'text-[var(--color-status-warn)]' : 'text-[var(--color-fg-muted)]'}">
                   ${row.output_truncated_count
                     ? `${formatNumber(row.output_truncated_count)} clipped`
@@ -282,18 +282,18 @@ function FailureCategoryList({ quality }: { quality: ToolQualityResponse | null 
 }
 
 function countText(value: number | null | undefined): string {
-  return typeof value === 'number' && Number.isFinite(value) ? formatNumber(value) : '--'
+  return typeof value === 'number' && Number.isFinite(value) ? formatNumber(value) : MISSING_DATA_DASH
 }
 
 function secondsText(value: number | null | undefined): string {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return '--'
+  if (typeof value !== 'number' || !Number.isFinite(value)) return MISSING_DATA_DASH
   if (value < 60) return `${Math.max(0, Math.round(value))}s`
   if (value < 3600) return `${Math.round(value / 60)}m`
   return `${Math.round(value / 3600)}h`
 }
 
 function compactList(values: string[], limit = 3): string {
-  if (values.length === 0) return '--'
+  if (values.length === 0) return MISSING_DATA_DASH
   const shown = values.slice(0, limit).join(', ')
   return values.length > limit ? `${shown} +${values.length - limit}` : shown
 }

--- a/dashboard/src/components/governance-monitor.ts
+++ b/dashboard/src/components/governance-monitor.ts
@@ -13,6 +13,7 @@ import { StatusChip } from './common/status-chip'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { useSavedSignal } from '../lib/saved-signal'
+import { MISSING_DATA_DASH } from '../lib/format-string'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { get, type GetOptions } from '../api/core'
 
@@ -91,7 +92,7 @@ async function fetchGovernanceToolEvents(
 }
 
 function fmtSec(value: number | null): string {
-  if (value == null || Number.isNaN(value)) return '--'
+  if (value == null || Number.isNaN(value)) return MISSING_DATA_DASH
   if (value < 60) return `${value.toFixed(1)}s`
   return `${(value / 60).toFixed(1)}m`
 }

--- a/dashboard/src/components/repo-detail-panel.ts
+++ b/dashboard/src/components/repo-detail-panel.ts
@@ -10,6 +10,7 @@ import { selectedRepoId, syncRepository, deleteRepository, normalizeRepoStatus, 
 import { requestConfirm } from './common/confirm-dialog'
 import { StatusBadge as CommonStatusBadge } from './common/status-badge'
 import { formatDateTimeKo as formatDate } from '../lib/format-time'
+import { MISSING_DATA_DASH } from '../lib/format-string'
 import { Trash2, GitBranch, Clock, Calendar, Folder, Link, Shield, RefreshCw } from 'lucide-preact'
 
 // ── Branch type ──────────────────────────────────────────
@@ -117,7 +118,7 @@ function InfoRow({
 }) {
   const displayValue =
     value === null || value === undefined || value === ''
-      ? '--'
+      ? MISSING_DATA_DASH
       : typeof value === 'boolean'
         ? (value ? 'ON' : 'OFF')
         : String(value)


### PR DESCRIPTION
## 변경 내용

`lib/format-string.ts:14` 이 `MISSING_DATA_DASH = '--'` 을 export 하며 JSDoc 에 마이그레이션 의도 명시:

> Captured here so that a future glyph change — e.g. an em-dash `'—'` for typography polish or a longer label for accessibility — propagates without sweeping every `?? '--'` callsite again.

대시보드에 inline `'--'` literal 이 약 50 곳 남아있는 상태에서 본 PR 은 **batch 1: 4 file × 8 callsite** 처리.

특히 `fleet-health-panel.ts` 는 이미 `MISSING_DATA_DASH` 를 import 중 (line 460 cdal writer_status 사용) — *partial migration* 상태였음. 본 PR 이 이 file 의 5 잔존 callsite 를 완료.

## 변경 사이트

| File | Line | Context |
|------|------|---------|
| `fleet-health-panel.ts` | 208, 252 | `formatMsCompact(row.avg_ms, '--')` fallback param × 2 |
| `fleet-health-panel.ts` | 285 | `countText` non-finite return |
| `fleet-health-panel.ts` | 289 | `secondsText` non-finite return |
| `fleet-health-panel.ts` | 296 | `compactList` empty return |
| `board-curation-panel.ts` | 13 | `percent()` non-finite guard |
| `governance-monitor.ts` | 94 | `fmtSec()` null/NaN guard |
| `repo-detail-panel.ts` | 120 | `ConfigRow` display fallback (null/undefined/empty) |

각 사이트 `'--'` literal → `MISSING_DATA_DASH` import.

## 등가성

`MISSING_DATA_DASH` 의 *값* 이 `'--'`. 이름 변경만 — runtime 동작 100% 동일.

미래 정책 변경 시:
- em-dash `'—'` 으로 typography polish
- longer label for accessibility
- 영어 vs 한국어 sentinel 분기

→ `lib/format-string.ts` 한 곳만 갱신, 8 callsite 자동 전파.

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (4 관련 test file) — 54/54 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 4 file +11/-8

## Out of scope

남은 ~40+ inline `'--'` 사이트 (`keeper-config-panel.ts` 18+, `runtime-monitor.ts` 6+, `tools/config-resolution-panel.ts` 5+, `lib/format-time.ts:121`, `lib/format-number.ts:27/37` default params 등) — follow-up batch.

