### PR TITLE
refactor: remove docker spawn effective concurrency alias

### DIFF
--- a/lib/docker_spawn_throttle.ml
+++ b/lib/docker_spawn_throttle.ml
@@ -9,8 +9,5 @@
 
 let with_slot f = Fd_accountant.with_slot ~kind:Docker_spawn f
 
-let effective_concurrency () =
-  Fd_accountant.effective_concurrency ~kind:Docker_spawn
-
 let configured_max () =
   Fd_accountant.configured_concurrency ~kind:Docker_spawn

--- a/lib/docker_spawn_throttle.mli
+++ b/lib/docker_spawn_throttle.mli
@@ -29,10 +29,6 @@ val configured_max : unit -> int
 (** Return the configured concurrency cap (env or default) for the current process.
     Used by tests to assert the invariant that the throttle never exceeds its ceiling. *)
 
-val effective_concurrency : unit -> int
-(** Return the effective concurrency cap, same as {!configured_max}.
-    Alias for backward compatibility with test fixtures. *)
-
 val with_slot : (unit -> 'a) -> 'a
 (** [with_slot f] acquires a docker-spawn slot, runs [f ()], releases
     the slot, and returns [f]'s result. If [Keeper_fd_pressure.active ()]
@@ -40,4 +36,3 @@ val with_slot : (unit -> 'a) -> 'a
     in-flight callers.
 
     Exceptions from [f] propagate; the slot is always released. *)
-

--- a/test/test_docker_spawn_throttle.ml
+++ b/test/test_docker_spawn_throttle.ml
@@ -5,6 +5,7 @@
     - Layer B: fd_pressure trip degrades effective concurrency to 1 *)
 
 module DST = Masc_mcp.Docker_spawn_throttle
+module FA = Masc_mcp.Fd_accountant
 module FD = Masc_mcp.Keeper_fd_pressure
 
 let with_eio f =
@@ -47,17 +48,17 @@ let test_concurrency_capped_under_fanin () =
     (observed <= max_cap)
 
 let test_degraded_mode_serializes () =
-  (* Trip fd_pressure; effective_concurrency must report 1. *)
+  (* Trip fd_pressure; Docker_spawn effective concurrency must report 1. *)
   FD.reset_for_tests ();
   FD.note ~site:"unit-test" ~detail:"too many open files in system" ();
   Alcotest.(check bool) "FD.active is true after note" true (FD.active ());
   Alcotest.(check int) "effective_concurrency = 1 while degraded" 1
-    (DST.effective_concurrency ());
+    (FA.effective_concurrency ~kind:FA.Docker_spawn);
   FD.reset_for_tests ();
   Alcotest.(check int)
     "effective_concurrency restored after reset"
     (DST.configured_max ())
-    (DST.effective_concurrency ())
+    (FA.effective_concurrency ~kind:FA.Docker_spawn)
 
 let test_exception_releases_slot () =
   (* If f raises, the slot must still be released — verify by running


### PR DESCRIPTION
## Summary
- remove the Docker_spawn_throttle.effective_concurrency compatibility alias
- update docker spawn throttle tests to assert the Docker_spawn cap through Fd_accountant directly

## Verification
- rg "Docker_spawn_throttle\.effective_concurrency|effective_concurrency \(\)" lib bin test -n
- git diff --check origin/main
- scripts/dune-local.sh build test/test_docker_spawn_throttle.exe
- scripts/dune-local.sh exec test/test_docker_spawn_throttle.exe
- _build/default/test/test_docker_spawn_throttle.exe