### PR TITLE
[codex] Fix rg context flag path extraction

### DIFF
--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -515,6 +515,12 @@ let command_pattern_arg_flags cmd =
     ; "--regexp", true
     ; "-f", true
     ; "--file", true
+    ; "-A", false
+    ; "--after-context", false
+    ; "-B", false
+    ; "--before-context", false
+    ; "-C", false
+    ; "--context", false
     ; "-g", false
     ; "--glob", false
     ; "--iglob", false
@@ -528,6 +534,12 @@ let command_pattern_arg_flags cmd =
     ; "--regexp", true
     ; "-f", true
     ; "--file", true
+    ; "-A", false
+    ; "--after-context", false
+    ; "-B", false
+    ; "--before-context", false
+    ; "-C", false
+    ; "--context", false
     ; "--include", false
     ; "--exclude", false
     ; "--exclude-dir", false

--- a/test/test_exec_policy_path_arg_descriptor.ml
+++ b/test/test_exec_policy_path_arg_descriptor.ml
@@ -103,6 +103,28 @@ let test_corpus_and_predicate_are_in_sync () =
   Alcotest.(check bool) "a non-corpus name returns false" false
     (D.command_materializes_path_arg "made-up-command-12345")
 
+let test_rg_context_flags_are_not_path_args () =
+  let values =
+    Exec_policy.path_argument_values "rg"
+      [ "capacity"; "repos/masc-mcp"; "-n"; "-C"; "3" ]
+  in
+  Alcotest.(check bool) "search path remains" true
+    (List.mem "repos/masc-mcp" values);
+  Alcotest.(check bool) "context flag skipped" false (List.mem "-C" values);
+  Alcotest.(check bool) "context count skipped" false (List.mem "3" values)
+
+let test_grep_context_flags_are_not_path_args () =
+  let values =
+    Exec_policy.path_argument_values "grep"
+      [ "-R"; "-C"; "3"; "capacity"; "repos/masc-mcp" ]
+  in
+  Alcotest.(check bool) "grep search path remains" true
+    (List.mem "repos/masc-mcp" values);
+  Alcotest.(check bool) "grep context flag skipped" false
+    (List.mem "-C" values);
+  Alcotest.(check bool) "grep context count skipped" false
+    (List.mem "3" values)
+
 let () =
   Alcotest.run "exec_policy_path_arg_descriptor"
     [ ( "separated flag form"
@@ -123,5 +145,11 @@ let () =
             test_command_materializes_path_arg_exclusions
         ; Alcotest.test_case "corpus ⇔ predicate in sync" `Quick
             test_corpus_and_predicate_are_in_sync
+        ] )
+    ; ( "path arg extraction"
+      , [ Alcotest.test_case "rg context flags are not paths" `Quick
+            test_rg_context_flags_are_not_path_args
+        ; Alcotest.test_case "grep context flags are not paths" `Quick
+            test_grep_context_flags_are_not_path_args
         ] )
     ]


### PR DESCRIPTION
## Summary
- Treat `rg`/`grep` context-count options (`-A/-B/-C`, long forms) as non-path option values during Execute path extraction.
- Prevent `rg ... -C 3` from leaking `3` into existing-directory validation as if it were `git -C 3`.
- Add regression coverage for the recent runtime log shape: `rg capacity repos/masc-mcp -n -C 3`.

## Runtime Evidence
Recent `~/me/.masc/logs/system_log_2026-05-27.jsonl` entries showed `tool_execute` failing with:

`cwd_not_directory: 3 (directory does not exist under cwd; create or repair the sandbox repo/worktree first)`

The blocked command was `rg capacity repos/masc-mcp -n -C 3`, where `-C 3` is ripgrep context count, not cwd.

## Validation
- `git diff --check`
- `ocamlformat --check lib/exec_policy.ml test/test_exec_policy_path_arg_descriptor.ml`
- `scripts/dune-local.sh build test/test_exec_policy_path_arg_descriptor.exe`
- `_build/default/test/test_exec_policy_path_arg_descriptor.exe` (9 tests)
