### PR TITLE
chore: remove code smell ratchet wrapper

### DIFF
--- a/scripts/code-smell-ratchet.sh
+++ b/scripts/code-smell-ratchet.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-# Backward-compatible entrypoint for the RFC-0151 code-smell ratchet.
-
-set -euo pipefail
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "${SCRIPT_DIR}/code-smell/measure.sh" "$@"


### PR DESCRIPTION
## Summary
- remove the unused backward-compatible scripts/code-smell-ratchet.sh entrypoint
- keep the code smell ratchet SSOT at scripts/code-smell/measure.sh, which CI already invokes directly

## Verification
- rg "scripts/code-smell-ratchet\.sh|code-smell-ratchet\.sh" -n --glob '!_build/**' --glob '!node_modules/**'
- rg "scripts/code-smell/measure\.sh|code-smell/measure\.sh" .github scripts docs -n
- git diff --check origin/main
- bash scripts/code-smell/measure.sh --print