### PR TITLE
refactor(dashboard): finish MISSING_DATA_DASH migration in runtime-monitor + tools/config-resolution-panel (batch 3/N, 12 sites)

### DIFF
--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -21,6 +21,7 @@ import { Table, type TableColumn } from './common/table'
 import type { ManagedAsyncResource } from '../lib/async-state'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { formatCost, formatNumber, formatPct1 } from '../lib/format-number'
+import { MISSING_DATA_DASH } from '../lib/format-string'
 import { formatTimeHms } from '../lib/format-time'
 
 /**
@@ -161,7 +162,7 @@ function fmtSuccessRate(metric: DashboardRuntimeModelMetric): string {
   const success = metric.success_count ?? metric.entry_count ?? 0
   const errors = metric.error_count ?? 0
   const total = success + errors
-  if (total === 0) return '--'
+  if (total === 0) return MISSING_DATA_DASH
   const pct = (success / total) * 100
   return `${pct.toFixed(1)}%`
 }
@@ -226,7 +227,7 @@ function metricMissingLabel(metric: DashboardRuntimeModelMetric): string {
   if (metric.primary_coverage_reason === 'text_only_unmetered') return 'n/a'
   if (metric.coverage_status === 'none') return 'missing'
   if (metric.coverage_status === 'partial') return 'partial'
-  return '--'
+  return MISSING_DATA_DASH
 }
 
 function fmtCoverageAwareNumber(
@@ -235,12 +236,12 @@ function fmtCoverageAwareNumber(
   digits = 0,
 ): string {
   const formatted = formatNumber(value, digits)
-  return formatted !== '--' ? formatted : metricMissingLabel(metric)
+  return formatted !== MISSING_DATA_DASH ? formatted : metricMissingLabel(metric)
 }
 
 function fmtCoverageAwareCost(metric: DashboardRuntimeModelMetric, value?: number | null): string {
   const formatted = formatCost(value)
-  return formatted !== '--' ? formatted : metricMissingLabel(metric)
+  return formatted !== MISSING_DATA_DASH ? formatted : metricMissingLabel(metric)
 }
 
 function recentEntryMissingLabel(
@@ -269,7 +270,7 @@ function fmtRecentEntryNumber(
   digits = 0,
 ): string {
   const formatted = formatNumber(value, digits)
-  return formatted !== '--' ? formatted : recentEntryMissingLabel(entry)
+  return formatted !== MISSING_DATA_DASH ? formatted : recentEntryMissingLabel(entry)
 }
 
 function fmtRecentEntryCost(
@@ -277,7 +278,7 @@ function fmtRecentEntryCost(
   value?: number | null,
 ): string {
   const formatted = formatCost(value)
-  return formatted !== '--' ? formatted : recentEntryMissingLabel(entry)
+  return formatted !== MISSING_DATA_DASH ? formatted : recentEntryMissingLabel(entry)
 }
 
 function recentEntryDetail(
@@ -309,7 +310,7 @@ const recentEntryColumns: TableColumn<RecentEntry>[] = [
       const detail = recentEntryDetail(re)
       return html`
         <div>
-          <div>${re.ts_unix > 0 ? formatTimeHms(re.ts_unix) : '--'}</div>
+          <div>${re.ts_unix > 0 ? formatTimeHms(re.ts_unix) : MISSING_DATA_DASH}</div>
           ${detail ? html`<div class="text-3xs text-[var(--color-fg-muted)] mt-0.5">${detail}</div>` : null}
         </div>
       `

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -11,14 +11,13 @@ import type {
   KeeperRuntimeField,
 } from '../../api/dashboard'
 import { fetchDashboardRuntimeProbe } from '../../api/dashboard'
-import { MISSING_DATA_DASH } from '../../lib/format-string'
+import { MISSING_DATA_DASH, errorToString } from '../../lib/format-string'
 import { Btn } from '../btn'
 import { SectionCard } from '../common/card'
 import { StatusChip } from '../common/status-chip'
 import { CopyIdButton } from '../common/copy-id-button'
 import { TextInput } from '../common/input'
 import { formatNumber } from '../../lib/format-number'
-import { errorToString } from '../../lib/format-string'
 
 function ConfigCard({
   class: cx,
@@ -295,7 +294,7 @@ function DiagnosticRow({ item }: { item: DashboardRuntimeDiagnostic }) {
 function fmtBoolean(value: boolean | null | undefined): string {
   if (value === true) return 'yes'
   if (value === false) return 'no'
-  return '--'
+  return MISSING_DATA_DASH
 }
 
 function probeTone(signal: string | null | undefined, probeOk: boolean | null | undefined): string {
@@ -354,7 +353,7 @@ function sourceTone(source: string): string {
 }
 
 function fmtKeeperValue(value: number | null, fmt: 'int' | 'float' | 'duration'): string {
-  if (value === null || value === undefined) return '--'
+  if (value === null || value === undefined) return MISSING_DATA_DASH
   switch (fmt) {
     case 'int': return String(Math.round(value))
     case 'float': return value.toFixed(1)
@@ -405,7 +404,7 @@ function RuntimeTruthPanel({ runtimeResolution }: { runtimeResolution: Dashboard
   const fleet = runtimeResolution.fleet_safety
   const fdValue = fd
     ? `${fd.fd_open ?? MISSING_DATA_DASH} / ${fd.fd_limit ?? MISSING_DATA_DASH}`
-    : '--'
+    : MISSING_DATA_DASH
   const fdTone = fd?.pressure_active ? 'bad' : 'neutral'
 
   return html`
@@ -421,7 +420,7 @@ function RuntimeTruthPanel({ runtimeResolution }: { runtimeResolution: Dashboard
         <${RuntimeMetaRow} label="server repo" value=${runtimeResolution.server_repo_path?.path ?? MISSING_DATA_DASH} />
         <${RuntimeMetaRow} label="executable commit" value=${runtimeResolution.build.commit ?? MISSING_DATA_DASH} />
         <${RuntimeMetaRow} label="keeper fibers" value=${String(fleet?.keeper_fibers ?? MISSING_DATA_DASH)} />
-        <${RuntimeMetaRow} label="fd pressure" value=${fd?.pressure_active == null ? '--' : fd.pressure_active ? 'active' : 'clear'} />
+        <${RuntimeMetaRow} label="fd pressure" value=${fd?.pressure_active == null ? MISSING_DATA_DASH : fd.pressure_active ? 'active' : 'clear'} />
       </div>
     <//>
   `
@@ -518,7 +517,7 @@ function RuntimeProbePanel() {
                 label="prompt eval delta"
                 value=${assessment?.prompt_eval_duration_reduction_ratio != null
                   ? `${formatNumber(assessment.prompt_eval_duration_reduction_ratio * 100, 1)}%`
-                  : '--'}
+                  : MISSING_DATA_DASH}
               />
               <${RuntimeMetaRow}
                 label="loaded models"


### PR DESCRIPTION
## 변경 내용

PR #19250 (batch 1, 4 file 8 site) + PR #19255 (batch 2, keeper-config-panel 21 site) 의 후속. **2 file 12 site** 처리.

## 변경 사이트

### `runtime-monitor.ts` (7 site — 신규 import + 7 inline)

| Line | Pattern | 의미 |
|------|---------|------|
| 164 | `if (total === 0) return '--'` | sentinel return |
| 229 | `return '--'` (coverageStateLabel default) | sentinel return |
| 238 | `formatted !== '--' ? formatted : metricMissingLabel(...)` | formatter 출력 comparison |
| 243 | 동일 패턴 (formatCost) | formatter 출력 comparison |
| 272 | 동일 패턴 (fmtRecentEntryNumber) | formatter 출력 comparison |
| 280 | 동일 패턴 (fmtRecentEntryCost) | formatter 출력 comparison |
| 312 | `formatTimeHms(re.ts_unix) : '--'` | sentinel ternary |

**중요**: 4 line (238/243/272/280) 은 `formatted !== '--'` 로 *formatter 출력값과의 직접 비교*. 이 site 들은 `'--'` literal 을 inline 으로 유지하면 미래 MISSING_DATA_DASH 글리프 변경 시 *조용히 망가짐* (formatter 는 em-dash 반환, 비교는 hyphen-hyphen 와 안 맞음 → missing branch 가 영원히 false). `MISSING_DATA_DASH` 라우팅으로 *coupling 회복*.

### `tools/config-resolution-panel.ts` (5 site + 중복 import 통합)

| Line | Pattern |
|------|---------|
| 298 | `fmtBoolean` default return |
| 357 | `fmtKeeperValue` null guard |
| 408 | RuntimeMetaRow fd row fallback |
| 424 | RuntimeMetaRow fd pressure null branch |
| 521 | prompt_eval ratio ternary fallback |

**Import 정리**: line 14 `import { MISSING_DATA_DASH } from '../../lib/format-string'` + line 21 `import { errorToString } from '../../lib/format-string'` — 같은 module 에서 2 개 import 문. 하나로 통합.

## 등가성

`MISSING_DATA_DASH` 값이 `'--'`. rename only. 단, runtime-monitor 의 4 comparison site 는 *latent coupling bug fix*: lib glyph 변경 시 자동 전파 (이전엔 stale literal).

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (2 관련 test file) — 18/18 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 2 file +14/-14

## 누적 진행 (MDD migration)

- batch 1 (#19250): 4 file 8 site
- batch 2 (#19255): 1 file 21 site
- batch 3 (본 PR): 2 file 12 site

누적 **7 file 41 site**. 남은 ~10 site (lib/format-time:121, lib/format-number:27/37 default params, etc.) — final batch.

