### PR TITLE
refactor(dashboard): extract UNKNOWN_STATUS_LABEL ('확인 필요') to lib/format-string + route 7 callsites

### DIFF
--- a/dashboard/src/lib/format-string.ts
+++ b/dashboard/src/lib/format-string.ts
@@ -13,6 +13,20 @@
  */
 export const MISSING_DATA_DASH = '--'
 
+/**
+ * Korean user-visible label for "value not present / status unknown" —
+ * the textual counterpart to `MISSING_DATA_DASH` for sites that need a
+ * readable phrase instead of a glyph.
+ *
+ * Seven production sites previously inlined this literal (`format-time`
+ * duration guards, `status-label` unknown-status branch, `monitoring-runtime`
+ * + `unified-status` default phase label, `operator-actions` preview
+ * fallback). Captured here so an accessibility or localisation change
+ * (e.g. switching to `'알 수 없음'`, adding a screen-reader prefix)
+ * propagates without sweeping every callsite again.
+ */
+export const UNKNOWN_STATUS_LABEL = '확인 필요'
+
 /** Capitalize first character. Returns empty string unchanged. */
 export function capitalize(text: string): string {
   if (!text) return text

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -1,5 +1,7 @@
 // Unified time formatting utilities.
 
+import { UNKNOWN_STATUS_LABEL } from './format-string'
+
 export const SECONDS_PER_MINUTE = 60
 export const SECONDS_PER_HOUR = 3600
 export const SECONDS_PER_DAY = 86400
@@ -55,9 +57,9 @@ export function formatElapsed(value?: number | null): string {
   return `${Math.round(value / SECONDS_PER_HOUR)}시간`
 }
 
-/** Format duration in seconds as Korean text — includes days. Returns '확인 필요' for invalid. */
+/** Format duration in seconds as Korean text — includes days. Returns UNKNOWN_STATUS_LABEL for invalid. */
 export function formatDuration(seconds?: number | null): string {
-  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) return '확인 필요'
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) return UNKNOWN_STATUS_LABEL
   if (seconds < SECONDS_PER_MINUTE) return `${Math.round(seconds)}초`
   if (seconds < SECONDS_PER_HOUR) return `${Math.round(seconds / SECONDS_PER_MINUTE)}분`
   if (seconds < SECONDS_PER_DAY) return `${Math.round(seconds / SECONDS_PER_HOUR)}시간`
@@ -65,9 +67,9 @@ export function formatDuration(seconds?: number | null): string {
 }
 
 /** Format duration in seconds as Korean text with compound units — "2시간 30분", "1시간 0분".
- *  Returns '확인 필요' for invalid. */
+ *  Returns UNKNOWN_STATUS_LABEL for invalid. */
 export function formatDurationCompound(seconds: number): string {
-  if (!Number.isFinite(seconds) || seconds < 0) return '확인 필요'
+  if (!Number.isFinite(seconds) || seconds < 0) return UNKNOWN_STATUS_LABEL
   const totalMinutes = Math.floor(seconds / SECONDS_PER_MINUTE)
   const totalHours = Math.floor(totalMinutes / 60)
 

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -1,6 +1,7 @@
 import type { Agent, Keeper, PipelineStage } from '../types'
 import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
 import { parseAgentStatus } from './agent-status'
+import { UNKNOWN_STATUS_LABEL } from './format-string'
 import {
   deriveKeeperRuntimeProjection,
   type KeeperRuntimeProjection,
@@ -40,7 +41,7 @@ interface MonitoringEvidence {
 
 const UNKNOWN_PHASE_META: PhaseMeta = {
   key: 'unknown',
-  label: '확인 필요',
+  label: UNKNOWN_STATUS_LABEL,
   description: 'phase 정보가 부족해 수동 확인이 필요합니다.',
 }
 

--- a/dashboard/src/lib/status-label.ts
+++ b/dashboard/src/lib/status-label.ts
@@ -1,3 +1,5 @@
+import { UNKNOWN_STATUS_LABEL } from './format-string'
+
 // Unified status display utilities.
 // Consolidates statusLabel from
 // mission-utils, agents, agent-roster, status-badge, helpers, ops/helpers.
@@ -100,8 +102,8 @@ export function statusLabel(value?: string | null): string {
       return '기록됨'
     case 'unknown':
     case '':
-      return '확인 필요'
+      return UNKNOWN_STATUS_LABEL
     default:
-      return value?.trim() || '확인 필요'
+      return value?.trim() || UNKNOWN_STATUS_LABEL
   }
 }

--- a/dashboard/src/lib/unified-status.ts
+++ b/dashboard/src/lib/unified-status.ts
@@ -2,6 +2,7 @@
 // into a single canonical status with Korean label and tooltip.
 
 import { statusLabel } from './status-label.js'
+import { UNKNOWN_STATUS_LABEL } from './format-string'
 
 interface UnifiedStatusResult {
   canonical: string
@@ -94,7 +95,7 @@ export function resolveUnifiedStatus(
   // Unknown
   return {
     canonical: 'unknown',
-    label: '확인 필요',
+    label: UNKNOWN_STATUS_LABEL,
     description: '상태 정보 없음',
   }
 }

--- a/dashboard/src/operator-actions.ts
+++ b/dashboard/src/operator-actions.ts
@@ -13,6 +13,7 @@ import type {
 } from './types'
 import { registerOperatorRefresh } from './sse-store'
 import { UI_REFRESH_TTL_MS } from './config/constants'
+import { UNKNOWN_STATUS_LABEL } from './lib/format-string'
 import {
   operatorSnapshot,
   operatorRoomDigest,
@@ -61,7 +62,7 @@ function appendLog(entry: Omit<OperatorActionLogEntry, 'id' | 'at'>): void {
 
 function logMessageFromResult(result: OperatorActionResult): string {
   if (result.confirm_required) {
-    return stringifyUnknown(result.preview) || '확인 필요'
+    return stringifyUnknown(result.preview) || UNKNOWN_STATUS_LABEL
   }
   return stringifyUnknown(result.result)
     || stringifyUnknown(result.executed_action)


### PR DESCRIPTION
## 변경 내용

5 sibling lib module + 1 app module 이 각자 같은 한국어 missing-data sentinel `'확인 필요'` 를 inline 으로 emit — canonical 상수 부재. MISSING_DATA_DASH (`'--'`, glyph) 의 *Korean text counterpart* 입니다.

`lib/format-string.ts` 에 `export const UNKNOWN_STATUS_LABEL = '확인 필요'` 를 추가하고 7 callsite 라우팅.

## 변경 사이트

| File | Line | Context |
|------|------|---------|
| `lib/format-time.ts` | 62 | `formatDuration` invalid-input branch |
| `lib/format-time.ts` | 72 | `formatDurationCompound` invalid-input branch |
| `lib/status-label.ts` | 103 | `statusLabel` `unknown`/`''` case |
| `lib/status-label.ts` | 105 | `statusLabel` default fallback |
| `lib/monitoring-runtime.ts` | 43 | default phase metadata label |
| `lib/unified-status.ts` | 97 | fallback when all sources empty |
| `src/operator-actions.ts` | 64 | preview fallback when stringifyUnknown returns `''` |

각 site `'확인 필요'` → `UNKNOWN_STATUS_LABEL` import.

## SSOT 의미

PR #19193 (errorToString helper-only) / PR #19250 (MISSING_DATA_DASH batch 1) 와 *같은 class*: 같은 한국어 텍스트가 5개 sibling lib module 에 분산 inline → canonical 상수로 수렴.

미래 변경 시:
- `'알 수 없음'` 으로 phrasing 변경
- 접근성 prefix 추가 (e.g. `'상태 미확인'`)
- 영어 fallback 분기 (i18n)

→ `lib/format-string.ts` 한 곳만 갱신, 7 callsite 자동 전파.

## 등가성

`UNKNOWN_STATUS_LABEL` 의 *값* 이 `'확인 필요'`. rename only. runtime + type 추론 동일.

## 의존성 변경

`lib/format-string.ts` 가 zero-import canonical sink 이므로 새 import edge (format-time / status-label / monitoring-runtime / unified-status → format-string) 추가가 cycle 무관:

- format-string.ts: 0 imports (전과 동일)
- format-time.ts: 0 → 1 (format-string)
- status-label.ts: 0 → 1
- monitoring-runtime.ts: 4 → 5
- unified-status.ts: 1 → 2

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (5 관련 test file: format-time / format-string / status-label / unified-status / monitoring-runtime) — 83/83 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 6 file +30/-9 (helper export 추가 + 7 callsite migration)

