### PR TITLE
[codex] Optimize HTTP prefix route lookup

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -454,9 +454,15 @@ module Router = struct
     | `Method_not_allowed
     | `Not_found ]
 
+  type prefix_node = {
+    children: (char, prefix_node) Hashtbl.t;
+    mutable routes: route list;
+  }
+
   type method_routes = {
     exact_by_path: (string, route) Hashtbl.t;
     mutable prefix_routes: route list;
+    prefix_root: prefix_node;
   }
 
   type t = {
@@ -470,8 +476,15 @@ module Router = struct
     mutable route_count: int;
   }
 
+  let create_prefix_node () =
+    { children = Hashtbl.create 4; routes = [] }
+
   let create_method_routes () =
-    { exact_by_path = Hashtbl.create 128; prefix_routes = [] }
+    {
+      exact_by_path = Hashtbl.create 128;
+      prefix_routes = [];
+      prefix_root = create_prefix_node ();
+    }
 
   let create () =
     {
@@ -500,6 +513,26 @@ module Router = struct
     in
     loop [] routes
 
+  let insert_prefix_trie (route : route) (root : prefix_node) =
+    let path = route.path in
+    let path_len = String.length path in
+    let rec loop (node : prefix_node) idx =
+      if idx = path_len then
+        node.routes <- insert_prefix_route route node.routes
+      else
+        let ch = path.[idx] in
+        let child =
+          match Hashtbl.find_opt node.children ch with
+          | Some child -> child
+          | None ->
+              let child = create_prefix_node () in
+              Hashtbl.add node.children ch child;
+              child
+        in
+        loop child (idx + 1)
+    in
+    loop root 0
+
   let method_routes router = function
     | `GET -> Some router.get
     | `POST -> Some router.post
@@ -513,7 +546,8 @@ module Router = struct
     | Exact -> Hashtbl.replace method_routes.exact_by_path route.path route
     | Prefix ->
         method_routes.prefix_routes <-
-          insert_prefix_route route method_routes.prefix_routes
+          insert_prefix_route route method_routes.prefix_routes;
+        insert_prefix_trie route method_routes.prefix_root
 
   let add_kind kind ~path ~methods ~handler router =
     let route = { kind; path; methods; handler } in
@@ -564,9 +598,21 @@ module Router = struct
     add_kind Prefix ~path:prefix ~methods:[`PUT] ~handler routes
 
   let resolve_prefix routes req_path =
-    List.find_opt
-      (fun route -> String.starts_with req_path ~prefix:route.path)
-      routes.prefix_routes
+    let path_len = String.length req_path in
+    let rec loop (node : prefix_node) idx best =
+      let best =
+        match node.routes with
+        | route :: _ -> Some route
+        | [] -> best
+      in
+      if idx = path_len then
+        best
+      else
+        match Hashtbl.find_opt node.children req_path.[idx] with
+        | Some child -> loop child (idx + 1) best
+        | None -> best
+    in
+    loop routes.prefix_root 0 None
 
   let resolve router request =
     let req_path = Request.path request in

--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -261,9 +261,9 @@ module Router : sig
     ]
 
   (** Indexed dispatch table.  Route registration updates method-specific
-      exact path tables and longest-prefix ordered prefix tables at build time,
-      so request dispatch does not scan/sort the full endpoint list or perform
-      per-candidate method-list membership checks. *)
+      exact path tables and prefix tries at build time, so request dispatch
+      does not scan/sort the full endpoint list or perform per-candidate
+      method-list membership checks. *)
   type t
 
   val create : unit -> t

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -55,6 +55,45 @@ let test_router_prefix_specificity () =
   | `Not_found -> Alcotest.fail "expected a matched prefix route, got not_found"
 ;;
 
+let test_router_prefix_trie_preserves_specificity () =
+  let dashboard_handler _req _reqd = () in
+  let board_handler _req _reqd = () in
+  let sub_board_handler _req _reqd = () in
+  let routes =
+    Router.create ()
+    |> Router.prefix_get "/dashboard/" dashboard_handler
+    |> Router.prefix_get "/api/v1/board/" board_handler
+    |> Router.prefix_get "/api/v1/board/sub-boards/" sub_board_handler
+  in
+  let request = Httpun.Request.create `GET "/api/v1/board/sub-boards/main" in
+  match Router.resolve routes request with
+  | `Matched route ->
+    Alcotest.(check string)
+      "longest prefix on the trie path should win"
+      "/api/v1/board/sub-boards/"
+      route.path
+  | `Method_not_allowed ->
+    Alcotest.fail "expected trie prefix match, got method_not_allowed"
+  | `Not_found -> Alcotest.fail "expected trie prefix match, got not_found"
+;;
+
+let test_router_prefix_trie_preserves_root_prefix () =
+  let root_handler _req _reqd = () in
+  let api_handler _req _reqd = () in
+  let routes =
+    Router.create ()
+    |> Router.prefix_get "/" root_handler
+    |> Router.prefix_get "/api/v1/" api_handler
+  in
+  let request = Httpun.Request.create `GET "/unknown/path" in
+  match Router.resolve routes request with
+  | `Matched route ->
+    Alcotest.(check string) "root prefix remains a fallback" "/" route.path
+  | `Method_not_allowed ->
+    Alcotest.fail "expected root prefix fallback, got method_not_allowed"
+  | `Not_found -> Alcotest.fail "expected root prefix fallback, got not_found"
+;;
+
 let test_router_indexed_prefix_fallback_after_exact_method_miss () =
   let exact_handler _req _reqd = () in
   let prefix_handler _req _reqd = () in
@@ -346,6 +385,12 @@ let router_tests =
   ; "add POST route", `Quick, test_router_add_post
   ; "add multiple routes", `Quick, test_router_add_multiple
   ; "prefix specificity", `Quick, test_router_prefix_specificity
+  ; ( "prefix trie preserves specificity"
+    , `Quick
+    , test_router_prefix_trie_preserves_specificity )
+  ; ( "prefix trie preserves root prefix"
+    , `Quick
+    , test_router_prefix_trie_preserves_root_prefix )
   ; ( "indexed prefix fallback after exact method miss"
     , `Quick
     , test_router_indexed_prefix_fallback_after_exact_method_miss )


### PR DESCRIPTION
Summary:
- Replace method-specific prefix route list scans with a prefix trie built at route registration time.
- Preserve longest-prefix behavior while avoiding full prefix-list scans on exact misses.
- Add router tests for trie specificity and root-prefix fallback.

Validation:
- git diff --check
- ocamlformat --check lib/http_server_eio.ml lib/http_server_eio.mli test/test_http_server_eio.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build bin/main_eio.exe test/test_http_server_eio.exe
- ./_build/default/test/test_http_server_eio.exe (36 tests)