### PR TITLE
perf(activity): RFC-0201 Step 5 — retire PR #19150 cache wrap

### DIFF
--- a/lib/server/server_activity_http.ml
+++ b/lib/server/server_activity_http.ml
@@ -109,17 +109,14 @@ let events_http_json ~deps ~state request =
   match snapshot_hit with
   | Some json -> json
   | None ->
-    (* Fall through: non-default query OR snapshot not yet published.
-       Keep the PR #19150 cache+offload wrap so cold-start callers do
-       not stall the HTTP main domain. *)
-    let cache_key =
-      Printf.sprintf "activity:events:%s:%d:%d"
-        (String.concat "," kinds) after_seq limit
-    in
-    Dashboard_cache.get_or_compute cache_key ~ttl:2.0 (fun () ->
-      Domain_pool_ref.submit_io_or_inline (fun () ->
-        Activity_graph.json_response state.Mcp_server.room_config ~kinds
-          ~after_seq ~limit ()))
+    (* RFC-0201 Step 5.  Cache wrap retired — non-default queries
+       (cursor / kinds filter) are operator-driven and rare, so a
+       per-key Dashboard_cache entry has marginal hit-rate value.
+       Offload via Domain_pool_ref still protects the HTTP main
+       domain from JSONL-scan stall. *)
+    Domain_pool_ref.submit_io_or_inline (fun () ->
+      Activity_graph.json_response state.Mcp_server.room_config ~kinds
+        ~after_seq ~limit ())
 
 let parse_since_ms (raw : string) : int option =
   let len = String.length raw in
@@ -168,21 +165,17 @@ let graph_http_json ~deps ~state request =
   match snapshot_hit with
   | Some json -> json
   | None ->
-    let cache_key =
-      Printf.sprintf "activity:graph:%s:%d:%d:%s"
-        (String.concat "," kinds) limit timeline_limit since_raw
-    in
-    Dashboard_cache.get_or_compute cache_key ~ttl:2.0 (fun () ->
-      Domain_pool_ref.submit_io_or_inline (fun () ->
-        let since_ms =
-          match parse_since_ms since_raw with
-          | Some delta_ms ->
-              let now_ms = int_of_float (Time_compat.now () *. 1000.0) in
-              Some (now_ms - delta_ms)
-          | None -> None
-        in
-        Activity_graph.graph_json state.Mcp_server.room_config ~kinds ~limit
-          ~timeline_limit ?since_ms ()))
+    (* RFC-0201 Step 5 — cache wrap retired (see events_http_json). *)
+    Domain_pool_ref.submit_io_or_inline (fun () ->
+      let since_ms =
+        match parse_since_ms since_raw with
+        | Some delta_ms ->
+            let now_ms = int_of_float (Time_compat.now () *. 1000.0) in
+            Some (now_ms - delta_ms)
+        | None -> None
+      in
+      Activity_graph.graph_json state.Mcp_server.room_config ~kinds ~limit
+        ~timeline_limit ?since_ms ())
 
 let swimlane_http_json ~deps ~state request =
 
@@ -207,20 +200,17 @@ let swimlane_http_json ~deps ~state request =
   match snapshot_hit with
   | Some json -> json
   | None ->
-    let cache_key =
-      Printf.sprintf "activity:swimlane:%d:%s" limit since_raw
-    in
-    Dashboard_cache.get_or_compute cache_key ~ttl:2.0 (fun () ->
-      Domain_pool_ref.submit_io_or_inline (fun () ->
-        let since_ms =
-          match parse_since_ms since_raw with
-          | Some delta_ms ->
-              let now_ms = int_of_float (Time_compat.now () *. 1000.0) in
-              Some (now_ms - delta_ms)
-          | None -> None
-        in
-        Activity_graph.agent_spans_json state.Mcp_server.room_config ~limit
-          ?since_ms ()))
+    (* RFC-0201 Step 5 — cache wrap retired (see events_http_json). *)
+    Domain_pool_ref.submit_io_or_inline (fun () ->
+      let since_ms =
+        match parse_since_ms since_raw with
+        | Some delta_ms ->
+            let now_ms = int_of_float (Time_compat.now () *. 1000.0) in
+            Some (now_ms - delta_ms)
+        | None -> None
+      in
+      Activity_graph.agent_spans_json state.Mcp_server.room_config ~limit
+        ?since_ms ())
 
 let stream_headers ~deps origin =
   Httpun.Headers.of_list


### PR DESCRIPTION
## Summary

RFC-0201 Step 5 (마지막) — PR #19150 의 `Dashboard_cache.get_or_compute` wrap 을 3 endpoint fallback path 에서 제거. `Domain_pool_ref.submit_io_or_inline` 만 유지.

## Why retire

Steps 1-4 (#19212/#19215/#19257) 후 *default-shape query* 는 모두 `Dashboard_snapshot` wait-free read 가 intercept. PR #19150 의 cache wrap 가 *fallback* path 에만 잔존:

| Endpoint | Fallback trigger |
|---|---|
| `events_http_json` | `kinds ≠ []` OR `after_seq > 0` |
| `graph_http_json` | `kinds ≠ []` OR `limit ≠ 500` OR `timeline_limit ≠ 80` OR `since_raw ≠ ""` |
| `swimlane_http_json` | `limit ≠ 500` OR `since_raw ≠ ""` |

이 fallback 들은 *operator-driven* (cursor replay, IDE debug, time-range query) — rare. Cache key 가 *query parameterized* 라 두 호출이 TTL window 안 같은 key 공유 가능성 적음. **Marginal hit-rate 가치**.

## Change

3 endpoint fallback 단순화:

```ocaml
(* Before: cache + offload *)
let cache_key = Printf.sprintf "activity:events:%s:%d:%d" ... in
Dashboard_cache.get_or_compute cache_key ~ttl:2.0 (fun () ->
  Domain_pool_ref.submit_io_or_inline (fun () ->
    Activity_graph.json_response ...))

(* After: offload only *)
Domain_pool_ref.submit_io_or_inline (fun () ->
  Activity_graph.json_response ...)
```

- `Dashboard_cache.get_or_compute` 제거
- `cache_key` 변수 제거
- `Domain_pool_ref.submit_io_or_inline` 유지 (HTTP main domain stall 방지)

## RFC §9 Acceptance criterion 충족

> `cache-stats` 에 zero `activity:events:*` / `activity:graph:*` / `activity:swimlane:*` entries

이 PR 머지 후 — *모든* path 에서 `activity:*` cache entry 생성 안 됨 (default = snapshot, fallback = inline offload).

## Impact

| Query type | Before | After |
|---|---|---|
| Default (panel poll) | `Atomic.get` snapshot (sub-ms) | unchanged |
| Non-default (operator) | Cache wrap (TTL 2s) → fallback to compute | Direct offload compute |
| `cache-stats` activity:* entries | 변동 (TTL-based) | **항상 0** |

Non-default query latency: cache hit (rare) 가 ~0.1s → miss compute (~7s × past-day cache 효과). 즉 *cache hit 손실*. 단:
- Non-default 빈도 *낮음* (operator/IDE only)
- Step 4 의 past-day cache 가 compute 자체를 *< 500 ms* 로 만듦
- 운영자가 *반복적* 으로 같은 cursor 누르지 않음

## Workaround Signature Gate

WORKAROUND-WAIVED: cache wrap *retire* (removing, not adding). Counter-as-fix / substring / N-of-M / catch-all / cap-cooldown / test-backdoor 비위반. PR #19150 의 *원래 패턴* 이 RFC-0201 시점에 *replaced by wait-free snapshot*.

## Build

```
$ dune build --root . .  EXIT=0
```

## Test plan

- [ ] CI build PASS
- [ ] 서버 재시작 후 `cache-stats` 응답에서 `activity:*` 키 0 개 확인
- [ ] Default `/activity/events?limit=50` < 100 ms (snapshot — Step 1 unchanged)
- [ ] Default `/activity/graph` < 100 ms (Step 2)
- [ ] Default `/activity/swimlane` < 100 ms (Step 3)
- [ ] Operator query `/activity/events?after_seq=N` → fallback path, < 500 ms (Step 4 cache 효과)

## RFC-0201 종결

본 PR 머지 시 RFC-0201 의 모든 step 완료:

- ✅ Step 1 (#19212) — events_http_json snapshot wire
- ✅ Step 4 (#19215) — past-day file cache
- ✅ Steps 2+3 (#19257) — graph + swimlane snapshot wire
- ✅ Step 5 (본 PR) — PR #19150 cache wrap retire

RFC-0201 §9 acceptance criteria 모두 충족 (`cache-stats` zero entries 포함).

## Related

- RFC-0201 spec (#19205 MERGED)
- PR #19150 — original cache wrap (this PR retires)
- PRs #19212 / #19215 / #19257 — Steps 1 / 4 / 2+3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
