### PR TITLE
refactor(dashboard): remove agent identity tuple wrapper

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -533,7 +533,7 @@ let task_json (task : Masc_domain.task) =
 ;;
 
 let agent_json ~(model_map : (string, string) Hashtbl.t) (agent : Masc_domain.agent) =
-  let emoji, korean_name = get_agent_identity agent.name in
+  let profile = get_agent_profile agent.name in
   let model_value =
     match Hashtbl.find_opt model_map agent.name with
     | Some m when m <> "" -> `String m
@@ -550,8 +550,8 @@ let agent_json ~(model_map : (string, string) Hashtbl.t) (agent : Masc_domain.ag
     ; "joined_at", `String agent.joined_at
     ; "last_seen", `String agent.last_seen
     ; "capabilities", `List (List.map (fun value -> `String value) agent.capabilities)
-    ; "emoji", `String emoji
-    ; "koreanName", `String korean_name
+    ; "emoji", `String profile.emoji
+    ; "koreanName", `String profile.korean_name
     ; "model", model_value
     ]
 ;;

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -158,7 +158,7 @@ let worker_state_of_agent
         else
           Option.value ~default:"Idle / waiting for assignment" recent_output_preview
   in
-  let (emoji, korean_name) = get_agent_identity agent.name in
+  let profile = get_agent_profile agent.name in
   {
     tone_rank = Dashboard_utils.tone_rank tone;
     last_signal_ts;
@@ -188,8 +188,8 @@ let worker_state_of_agent
           ("active_task_count", `Int active_task_count);
           ("related_session_id", json_string_option related_session_id);
           ("related_operation_id", json_string_option related_operation_id);
-          ("emoji", `String emoji);
-          ("korean_name", `String korean_name);
+          ("emoji", `String profile.emoji);
+          ("korean_name", `String profile.korean_name);
           ("model", `Null);
           ("recent_output_preview", json_string_option recent_output_preview);
           ("recent_event", json_string_option recent_output_preview);
@@ -309,7 +309,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
     |> option_or_else (fun () -> audit.latest_action_source)
   in
   let skill_route_summary = skill_route_summary_of_keeper keeper in
-  let (emoji, korean_name) = get_agent_identity name in
+  let profile = get_agent_profile name in
   {
     tone_rank = Dashboard_utils.tone_rank tone;
     last_signal_ts;
@@ -373,8 +373,8 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
               match String_util.trim_to_option (string_field "active_model" keeper) with
               | Some value -> `String value
               | None -> `Null );
-            ("emoji", `String emoji);
-            ("korean_name", `String korean_name);
+            ("emoji", `String profile.emoji);
+            ("korean_name", `String profile.korean_name);
             ("skill_reason", json_string_option (String_util.trim_to_option (string_field "goal" keeper)));
           ]);
   }

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -411,11 +411,6 @@ let get_agent_profile (name : string) : agent_profile =
         primary_value = None;
       }
 
-(** Backward-compatible wrapper: returns (emoji, korean_name) tuple *)
-let get_agent_identity (name : string) =
-  let profile = get_agent_profile name in
-  (profile.emoji, profile.korean_name)
-
 let handoff_json ~surface ?command_surface ?operation_id ~label ~target_type ~target_id
     ~focus_kind () =
   `Assoc

--- a/lib/dashboard/dashboard_execution_helpers.mli
+++ b/lib/dashboard/dashboard_execution_helpers.mli
@@ -9,10 +9,8 @@
     {!Dashboard_execution}) do
     [include Dashboard_execution_helpers] in their .ml +
     .mli, so this boundary's surface flows through to
-    every dashboard execution consumer.  Plus 2 dotted
-    callers ({!get_agent_identity} from
-    [dashboard_http_keeper_metrics],
-    {!get_agent_profile} from
+    every dashboard execution consumer.  Plus dotted
+    callers ({!get_agent_profile} from
     [server_dashboard_http_core] +
     [server_routes_http_routes_room]).
 
@@ -137,10 +135,6 @@ type agent_profile = {
 val get_agent_profile : string -> agent_profile
 (** Resolves the agent's profile through the persona
     file → Neo4j cache → fallback chain. *)
-
-val get_agent_identity : string -> string * string
-(** [(emoji, korean_name)] tuple for [name] — pinned for
-    [dashboard_http_keeper_metrics]. *)
 
 (** {1 JSON envelope helpers} *)
 

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -578,6 +578,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                   ("trust_observatory", trust_observatory);
                 ]
               in
+              let profile = Dashboard_execution_helpers.get_agent_profile m.name in
 	            `Assoc ([
               ("name", `String m.name);
               ("pipeline_stage", `String
@@ -600,8 +601,8 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                 | Some keeper_id ->
                     `String (Keeper_id.Uid.to_string keeper_id)
                 | None -> `Null );
-              ("emoji", `String (let (e, _) = get_agent_identity m.name in e));
-              ("koreanName", `String (let (_, k) = get_agent_identity m.name in k));
+              ("emoji", `String profile.emoji);
+              ("koreanName", `String profile.korean_name);
               ("trace_id", `String (Keeper_id.Trace_id.to_string m.runtime.trace_id));
               ("generation", `Int m.runtime.generation);
               ( "current_task_id",

--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -460,6 +460,3 @@ let top_count_name_and_count
   |> function
   | (k, v) :: _ -> Some (k, v)
   | [] -> None
-
-let get_agent_identity (name : string) =
-  Dashboard_execution_helpers.get_agent_identity name

--- a/lib/dashboard/dashboard_http_keeper_metrics.mli
+++ b/lib/dashboard/dashboard_http_keeper_metrics.mli
@@ -14,7 +14,7 @@
     [jaccard_similarity_text], [take_last]),
     [type keeper_24h_bucket_stats] + builder, the 24h JSON
     helpers ([keeper_metrics_24h_json],
-    [keeper_history_summary_json]), and [get_agent_identity]. *)
+    [keeper_history_summary_json]). *)
 
 (** {1 Model name normalization (cascade-visible)} *)
 
@@ -129,15 +129,6 @@ val keeper_history_summary_json :
        compaction_count, handoff_count)].  The 6-tuple shape is
     operator-visible in the dashboard and pinned at the contract
     seam. *)
-
-val get_agent_identity : string -> string * string
-(** [get_agent_identity name] is a thin re-export of
-    {!Dashboard_execution_helpers.get_agent_identity}.  Returns
-    [(emoji, label)] for the named agent — used by the
-    keeper-detail builder to attach an emoji + display label to
-    each row.  Kept here so the cascade consumer can call it
-    bare via include without opening
-    [Dashboard_execution_helpers] separately. *)
 
 (** {1 Test-visible helpers}
     Pinned for behaviour-tests under {!test/test_dashboard_keeper_metrics_10286}. *)


### PR DESCRIPTION
## Summary
- remove Dashboard_execution_helpers.get_agent_identity tuple wrapper
- remove Dashboard_http_keeper_metrics.get_agent_identity re-export
- update dashboard call sites to read emoji and korean_name from get_agent_profile directly

## Verification
- rg "get_agent_identity" lib/dashboard -n
- git diff --check origin/main
- ocamlformat --check lib/dashboard/dashboard_execution.ml lib/dashboard/dashboard_execution_builders.ml lib/dashboard/dashboard_execution_helpers.ml lib/dashboard/dashboard_execution_helpers.mli lib/dashboard/dashboard_http_keeper.ml lib/dashboard/dashboard_http_keeper_metrics.ml lib/dashboard/dashboard_http_keeper_metrics.mli
- scripts/dune-local.sh build test/test_dashboard_execution.exe test/test_dashboard_namespace_truth.exe test/test_dashboard_keeper_metrics_10286.exe (passed before rebase)
- _build/default/test/test_dashboard_namespace_truth.exe (13 tests passed)
- _build/default/test/test_dashboard_keeper_metrics_10286.exe (8 tests passed)

## Known Baseline
- _build/default/test/test_dashboard_execution.exe currently fails on origin/main and this branch at read_model.011 with approval_state=null after approval resolution. The failure was reproduced from the clean main checkout at f600bffb2, so it is not introduced by this wrapper removal.
- Re-running scripts/dune-local.sh build after the final rebase was blocked by an external bare dune build that bypassed the machine-wide dune-local lock.