### PR TITLE
refactor(tools): remove PR tool family wording

### DIFF
--- a/docs/audit/2026-05-20-keeper-tool-surface-live-evidence-record.md
+++ b/docs/audit/2026-05-20-keeper-tool-surface-live-evidence-record.md
@@ -27,7 +27,7 @@ Live findings:
 
 - 1차: Live logs and Bash census were queried from `/Users/dancer/me/.masc` for the current six-hour window.
 - 2차: GitHub open PRs were queried on `jeong-sik/masc-mcp`; OAS downstream pin was checked with `scripts/check-oas-pin.sh`.
-- 3차: Prompt/code guidance was changed so model-facing hints render public aliases (`Execute`, `ReadFile`, `SearchFiles`, `EditFile`, `WriteFile`) and native PR tools instead of internal `tool_execute` call recipes.
+- 3차: Prompt/code guidance was changed so model-facing hints render public aliases (`Execute`, `ReadFile`, `SearchFiles`, `EditFile`, `WriteFile`) and typed repository workflows instead of internal `tool_execute` call recipes.
 - 재현 결과: prompt/tool-surface grep for private keeper tool names, legacy raw-command Bash examples, and stale `cmd` examples returned no matches after the change. `ocamlformat --check lib/keeper/keeper_tool_guidance.ml lib/keeper/keeper_unified_prompt.ml test/test_keeper_unified.ml`, `git diff --check`, and this evidence-record validator passed. Focused Dune validation command was `scripts/dune-local.sh build ./test/test_keeper_unified.exe`, but it was not completed because `/tmp/me-dune-local.lock` was held by PID 5198 running `test/test_keeper_fd_pressure_fleet.exe` for another worktree; the waiting command was cancelled to avoid adding more queue pressure.
 
 ## 불확실성
@@ -38,6 +38,6 @@ Live findings:
 
 ## 적용범위
 
-- 영향 받는 영역: Keeper prompt generation, dynamic preferred-tool hints, GitHub workflow guidance, unified prompt fallback strings, and focused prompt regression tests.
+- 영향 받는 영역: Keeper prompt generation, dynamic preferred-tool hints, repository workflow guidance, unified prompt fallback strings, and focused prompt regression tests.
 - 제약/배제: Does not change Bash parser/safety gates, GitHub credential bundles, cascade capacity, OAS provider behavior, or OAS pin state.
 - 롤백 조건: Roll back if focused prompt tests fail, public alias routing is not active in the deployed OAS tool schema, or runtime policy intentionally exposes internal `tool_execute` as the only callable schema name.

--- a/docs/design/tool-execution-substrate-plan.html
+++ b/docs/design/tool-execution-substrate-plan.html
@@ -403,7 +403,7 @@
         <tbody>
           <tr>
             <td>Tool naming success</td>
-            <td>Legacy or hallucinated public tool calls such as <code>Read</code>, <code>Bash</code>, dedicated PR wrappers, and gh-specific wrappers.</td>
+            <td>Legacy or hallucinated public tool calls such as <code>Read</code>, <code>Bash</code>, dedicated repository mutation wrappers, and gh-specific wrappers.</td>
             <td><span class="status goal">0 active-surface hits</span></td>
             <td>Descriptor projection tests plus active prompt/config/source ratchets.</td>
           </tr>
@@ -706,7 +706,7 @@
           <tr>
             <td>GitHub PR comment</td>
             <td><code>Execute</code> with <code>executable = "gh"</code> and typed argv.</td>
-            <td>No dedicated PR wrapper or gh-specific wrapper tool exists or is suggested.</td>
+            <td>No dedicated repository mutation wrapper or gh-specific wrapper tool exists or is suggested.</td>
             <td>New GitHub micro-tool added for convenience.</td>
           </tr>
           <tr>
@@ -888,7 +888,7 @@
           </tr>
           <tr>
             <td>Active micro-tool scan</td>
-            <td>Enforced by <code>scripts/lint/no-tool-substrate-adapter-surface.sh</code> and source-guard case 28: no active-surface hits for dedicated PR wrappers, gh-specific wrappers, or PR wrapper prefixes in descriptor/prompt/policy/matrix surfaces.</td>
+            <td>Enforced by <code>scripts/lint/no-tool-substrate-adapter-surface.sh</code> and source-guard case 28: no active-surface hits for dedicated repository mutation wrappers, gh-specific wrappers, or retired repository wrapper prefixes in descriptor/prompt/policy/matrix surfaces.</td>
           </tr>
           <tr>
             <td>Keeper prompt web aliases</td>

--- a/docs/design/tool-execution-substrate-plan.md
+++ b/docs/design/tool-execution-substrate-plan.md
@@ -253,7 +253,7 @@ tool hint surfaces:
 - dedicated PR comment wrapper
 - dedicated PR review wrapper
 - dedicated PR close wrapper
-- gh-specific PR wrapper
+- gh-specific repository mutation wrapper
 - gh-specific commit wrapper
 - GitHub comment wrapper
 

--- a/docs/rfc/RFC-0180-runtime-error-sweep-roadmap.md
+++ b/docs/rfc/RFC-0180-runtime-error-sweep-roadmap.md
@@ -44,7 +44,7 @@ ERROR 571 의 8 패턴 (θ = 본 cycle fix, 7 잔존):
 ### Group 1: LLM-facing prompt 강화 (β, ζ, γ partial, ε partial) — config + 1 lib commit
 
 - **β**: PR #18686 머지 — `tool_execute_description` 끝 COMMON REJECTIONS 절 추가
-- **ζ/γ/ε partial**: `<base-path>/.masc/config/keepers/*.toml` (15 keeper) 의 instructions 끝에 *운영 hot-path 공통 규칙* footer — typed PR helper 우선 사용, `executable=""` 금지, playground cleanup 감지, PR closed graceful skip
+- **ζ/γ/ε partial**: `<base-path>/.masc/config/keepers/*.toml` (15 keeper) 의 instructions 끝에 *운영 hot-path 공통 규칙* footer — typed `Execute` repository workflow 우선 사용, `executable=""` 금지, playground cleanup 감지, closed review graceful skip
 - Workaround Sig: #5 positive (typed boundary 강화)
 
 ### Group 2: Sandbox typed boundary (α) — RFC 후속 PR-1

--- a/docs/tla-audit/kwp-r13-work-pipeline-banner-staleness-refresh-2026-05-12.md
+++ b/docs/tla-audit/kwp-r13-work-pipeline-banner-staleness-refresh-2026-05-12.md
@@ -16,7 +16,7 @@ The iter-81 / iter-85 wrap-ups + iter 86 (KeeperTurnSlot) + iter 87 (OperatorPau
 | `find lib -name "*github*"` returns 0 hits in lib/keeper/ | **Retired as a probe** — PR-wrapper files were removed later, and generic GitHub filenames are too broad for the modeled work-pipeline surface | replace the probe: the durable signal is `rg 'force_push_attempted\|workspace_init' lib/keeper/` → 0 |
 | The primitives (`force_push_attempted`, `workspace_init`, `workspace_cleaned`, `commit_identity`, `submit_count`) have 0 hits in lib/keeper/ | **Still true** — `rg 'force_push_attempted\|workspace_init\|workspace_cleaned\|commit_identity\|submit_count' lib/keeper/` → 0 | keep — this is the right probe |
 | "This spec is NOT in scripts/tla-check.sh (TLC does not run it)" | **Decayed / misleading** — `scripts/tla-check.sh` exists; the spec is referenced in `specs/Makefile` and `scripts/ci/check-tla-harness-coverage.sh`; `specs/bug-models/KeeperWorkPipelineBug.tla` exists. The reason it isn't *checked* is that it's in `specs/Makefile`'s `KNOWN_FAILURES` (`KeeperWorkPipeline: clean spec violates invariant (exit 13) — model needs fix, not path issue`), so `make -C specs check-clean` skips it | rewrite: it's in the corpus but in `KNOWN_FAILURES` due to a *model* bug (an invariant the clean spec violates) — separate from the runtime-not-wired situation |
-| Actual keeper tool runtime surface: descriptor-routed `agent_tool_*_runtime` modules | Still accurate; PR wrappers are no longer part of the active surface | keep |
+| Actual keeper tool runtime surface: descriptor-routed `agent_tool_*_runtime` modules | Still accurate; dedicated repository mutation wrappers are no longer part of the active surface | keep |
 
 ## The substantive finding (beyond the stale banner)
 

--- a/lib/keeper/keeper_sandbox_exec_failure.ml
+++ b/lib/keeper/keeper_sandbox_exec_failure.ml
@@ -1,7 +1,7 @@
 (** Sandbox backend exec failure formatting + recording.
 
     Owns backend failure messages and keeper-registry recording. The
-    command surface (Execute, structured search, PR tools, etc.) is
+    command surface (Execute, structured search, repository workflows, etc.) is
     intentionally not part of this module name because the same sandbox
     backend failure can be reached through multiple tools.
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -57,7 +57,7 @@ let core_always_tools =
       keeper_tasks_audit (admin).
     - keeper_tools_list moved from core_always to discoverable.
     - Execute stays visible because it is the write-side git path after
-      removing legacy PR wrappers.
+      removing retired repository mutation wrappers.
     - 26 → 20 tools.  9B tool selection accuracy improves with fewer
       choices (vLLM Semantic Router research: k=3-5 optimal for 7-9B).
 

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -185,7 +185,8 @@ let all_read_only_keeper_tools () : string list =
 
    Built from [all_shards] plus unsharded default tools that must remain
    available without creating another capability-family shard. Retired GitHub
-   PR helper schemas are intentionally excluded from this keeper-facing registry.
+   Dedicated repository mutation schemas are intentionally excluded from this
+   keeper-facing registry.
 
    Callers must still run [Config.dedupe_schemas] because a
    single tool can appear under multiple shards and the schema list may

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -2,7 +2,7 @@
 """Audit live keeper fleet readiness from on-disk MASC runtime state.
 
 This is intentionally read-only. It separates configuration readiness
-(Docker, repo CLI identity, PR-capable preset) from durable evidence
+(Docker, repo CLI identity, repo-mutation-capable preset) from durable evidence
 (recent turns, board actions, persisted PR references) so operators do not
 mistake a configured capability for proof that every keeper already used it.
 """

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1641,20 +1641,20 @@ let test_dedicated_forge_pr_tool_contracts_removed () =
     (file_not_contains_pattern "lib/operator/operator_control.ml" "root_fallback");
   check bool "keeper manual does not gate readiness on gh auth status" true
     (file_not_contains_pattern "docs/KEEPER-USER-MANUAL.md" "gh auth status");
-  check bool "retired PR wrapper names absent from active policy" true
+  check bool "retired repository wrapper names absent from active policy" true
     (file_not_contains_pattern "config/tool_policy.toml"
        ("keeper_" ^ "pr_")
      && file_not_contains_pattern "config/tool_policy.toml"
           ("github_" ^ "pr_"));
-  check bool "stale PR helper wording absent from active docs" true
+  check bool "stale repository helper wording absent from active docs" true
     (file_not_contains_pattern "config/prompts/keeper.capabilities.md"
-       ("dedicated " ^ "PR tool")
+       ("dedicated " ^ "repository tool")
      && file_not_contains_pattern "docs/KEEPER-USER-MANUAL.md"
-          ("dedicated " ^ "PR tool")
+          ("dedicated " ^ "repository tool")
      && file_not_contains_pattern "docs/KEEPER-USER-MANUAL.md"
           ("native " ^ "PR/GitHub tools")
      && file_not_contains_pattern "docs/KEEPER-FILE-MODEL.md"
-          ("dedicated " ^ "PR tool")
+          ("dedicated " ^ "repository tool")
      && not
           (Sys.file_exists
              (source_path "docs/design/keeper-tool-runtime-boundary-plan.md"))
@@ -1794,7 +1794,7 @@ let test_forge_pr_audit_contracts () =
   check bool "keeper fleet audit has explicit PR-create flag" true
     (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        "--require-pr-create-evidence");
-  check bool "keeper fleet audit no longer consumes PR tool markers" true
+  check bool "keeper fleet audit no longer consumes repository tool markers" true
     (file_not_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        ("PR_" ^ "CREATE_TOOLS")
      && file_not_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
@@ -2876,7 +2876,7 @@ let () =
              test_docker_config_storage_contracts;
           test_case "tool failure classification contracts" `Quick
             test_tool_failure_classification_contracts;
-          test_case "dedicated GitHub PR tool removal contracts" `Quick
+          test_case "dedicated repository tool removal contracts" `Quick
             test_dedicated_forge_pr_tool_contracts_removed;
           test_case "tool execution substrate ratchet contracts" `Quick
             test_tool_execution_substrate_ratchet_contracts;


### PR DESCRIPTION
## Summary

- removes remaining "PR helper/tool/wrapper" family wording from active source, tests, and design docs
- keeps the actual repository workflow semantics expressed as typed `Execute` / repository mutation workflows
- updates the source guard labels so PR does not read as a first-class tool family

## Product impact

No runtime behavior change. This is vocabulary cleanup for the tool architecture: pull-request work remains a repository workflow, not a standalone keeper tool family.

## Evidence

- `rg -n "PR-capable|PR helper|PR helpers|PR wrapper|PR wrappers|PR tool|PR tools|GitHub workflow guidance|native PR tools|dedicated GitHub PR tool|PR tool markers|typed PR helper" config lib test docs scripts dashboard/src --glob '!_build/**' --glob '!node_modules/**' --glob '!dashboard/design-system/ui_kits/**'`
- `ocamlformat --check lib/tool_shard.ml lib/keeper/keeper_sandbox_exec_failure.ml lib/keeper/keeper_tool_registry.ml test/test_ci_hardening_source.ml`
- `ruff check scripts/audit-keeper-fleet-readiness.py`
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build lib/tool_shard.ml lib/keeper/keeper_sandbox_exec_failure.ml lib/keeper/keeper_tool_registry.ml test/test_ci_hardening_source.exe` passed before the final rebase; after final rebase, rerun was blocked by unrelated bare `dune build --root . @check` / `dune build --root . lib/masc_mcp.cma` processes and the wrapper correctly refused to bypass them.

## Direct evidence

The targeted PR helper/tool/wrapper wording scan returns no matches.

## GOAL LOOP ACT checklist

- [x] Rescanned latest `main` for PR-as-tool-family wording.
- [x] Removed the remaining active-source matches.
- [x] Preserved repository workflow semantics.
- [x] Ran focused local validation where the host allowed it.

## Review evidence

Review focus: wording only. This should not affect tool dispatch, policy, schemas, or sandbox routing.

## Linked issue

None.

## Variant addition checklist

- [x] No new tool variant.
- [x] No new public tool name.
- [x] No compatibility alias.
