### PR TITLE
refactor(dashboard): extract errorMessageOr to lib/format-string + route 6 callsites (file-internal + 4 inline)

### DIFF
--- a/dashboard/src/components/keeper-detail-hooks.ts
+++ b/dashboard/src/components/keeper-detail-hooks.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'preact/hooks'
 import { fetchKeeperComposite, fetchKeeperRuntimeTrace } from '../api/keeper'
 import type { KeeperCompositeSnapshot, KeeperRuntimeTraceResponse } from '../api/keeper'
 import { DEFAULT_PANEL_REFRESH_MS, setupVisibleAutoRefresh } from '../lib/auto-refresh'
+import { errorMessageOr } from '../lib/format-string'
 import {
   applyFetchFailed,
   applyFetchSucceeded,
@@ -18,13 +19,6 @@ import {
  * [keeper-detail-evidence-state.ts] for the rationale.
  */
 export type KeeperDetailEvidenceState<T> = EvidenceState<T>
-
-// Error -> message conversion with caller-supplied fallback (distinct from
-// errorMessageOrUnknown which hard-codes 'unknown error', and from
-// errorToString / errorMessageOrNull in other modules).
-function errorMessageOr(err: unknown, fallback: string): string {
-  return err instanceof Error ? err.message : fallback
-}
 
 /**
  * RFC-0046 §7 follow-up #1: single composite snapshot fetch shared

--- a/dashboard/src/lib/format-string.ts
+++ b/dashboard/src/lib/format-string.ts
@@ -124,3 +124,24 @@ export function escapeRegExp(value: string): string {
 export function errorToString(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
+
+/**
+ * Variant of `errorToString` that lets the caller supply the fallback
+ * string for non-Error values, instead of routing through `String(err)`.
+ *
+ * Right when a stable, caller-controlled label is needed in place of
+ * the raw form — typically when the error originates from an async
+ * operation whose failure mode is opaque ("Failed to load mission
+ * snapshot", "composite fetch failed") and the underlying value would
+ * be unhelpful to surface.
+ *
+ * Distinct from siblings:
+ * - `errorToString(err)` falls back to `String(err)` (raw)
+ * - `fleet-telemetry-utils.errorMessageOrUnknown(err)` hard-codes
+ *   `'unknown error'`
+ * - `board-metrics.errorMessageOrNull(err)` returns `null` for
+ *   nullish input (different signature)
+ */
+export function errorMessageOr(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback
+}

--- a/dashboard/src/mission-actions.ts
+++ b/dashboard/src/mission-actions.ts
@@ -1,4 +1,5 @@
 import { isAbortError } from './lib/async-state'
+import { errorMessageOr } from './lib/format-string'
 import {
   missionSnapshot,
   missionLoading,
@@ -60,7 +61,7 @@ export async function refreshMissionSnapshot(
       missionSnapshot.value = normalized
       lastMissionSnapshotRefreshAt = Date.now()
     } catch (err) {
-      missionError.value = err instanceof Error ? err.message : 'Failed to load mission snapshot'
+      missionError.value = errorMessageOr(err, 'Failed to load mission snapshot')
     } finally {
       missionLoading.value = false
       inflightMissionSnapshotRefresh = null
@@ -88,7 +89,7 @@ export async function refreshMissionSessionDetail(
     missionSessionDetail.value = normalizeMissionSessionDetail(raw)
   } catch (err) {
     if (isAbortError(err)) return
-    missionSessionDetailError.value = err instanceof Error ? err.message : 'Failed to load session detail'
+    missionSessionDetailError.value = errorMessageOr(err, 'Failed to load session detail')
   } finally {
     if (!opts?.signal?.aborted) {
       missionSessionDetailLoading.value = false
@@ -115,7 +116,7 @@ export async function refreshMissionBriefing(
     }
   } catch (err) {
     if (isAbortError(err)) return
-    missionBriefingError.value = err instanceof Error ? err.message : 'Failed to load mission briefing'
+    missionBriefingError.value = errorMessageOr(err, 'Failed to load mission briefing')
     clearMissionBriefingPoll()
   } finally {
     if (!opts?.signal?.aborted) {

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -33,6 +33,7 @@ import type {
 import { fetchDashboardBootstrap, fetchDashboardShell } from './api/dashboard-hot'
 import { journal } from './sse'
 import { showToast } from './components/common/toast'
+import { errorMessageOr } from './lib/format-string'
 import {
   keeperFreshnessTs,
   normalizeKeepers,
@@ -926,7 +927,7 @@ async function doFetchExecution(): Promise<void> {
     hydrateExecutionSnapshot(data)
   } catch (err) {
     console.warn('[Dashboard] execution fetch error:', err)
-    executionError.value = err instanceof Error ? err.message : 'Execution projection load failed'
+    executionError.value = errorMessageOr(err, 'Execution projection load failed')
     showToast('실행 데이터 로드 실패', 'error', 5000)
   } finally {
     executionLoading.value = false


### PR DESCRIPTION
## 변경 내용

`errorToString` (PR #19193) 의 **companion helper**. 같은 body 이지만 non-Error branch 가 caller-supplied fallback. raw error 값 surface 가 부적절하고 stable label 이 선호되는 경우 (async fetch failure UI message).

`lib/format-string.ts` 에 `errorMessageOr(err: unknown, fallback: string): string` 추가, file-internal duplicate + inline callsite 6 곳 통합.

## 변경 사이트

### file-internal duplicate (1 — 2 usage site)

| File | Line | Action |
|------|------|--------|
| `components/keeper-detail-hooks.ts` | 25–27 | 삭제 (body 동일) |
| (위 file) | 53, 90 | 이미 `errorMessageOr` 호출 — 새 import 로 자동 라우팅 |

### inline custom-fallback (4)

| File | Line | Fallback string |
|------|------|----------------|
| `mission-actions.ts` | 63 | `'Failed to load mission snapshot'` |
| `mission-actions.ts` | 91 | `'Failed to load session detail'` |
| `mission-actions.ts` | 118 | `'Failed to load mission briefing'` |
| `store.ts` | 929 | `'Execution projection load failed'` |

각 `err instanceof Error ? err.message : '<string>'` → `errorMessageOr(err, '<string>')`.

## sibling helper 구분 (JSDoc 에 명시)

| Helper | Non-Error branch |
|--------|------------------|
| `errorToString(err)` (lib/format-string) | `String(err)` — raw form |
| `errorMessageOr(err, fallback)` ← 본 PR | `fallback` — caller-supplied label |
| `fleet-telemetry-utils.errorMessageOrUnknown(err)` | `'unknown error'` literal |
| `board-metrics.errorMessageOrNull(err)` | `null` (다른 return type) |

## 등가성

`errorMessageOr(err, x)` body = `err instanceof Error ? err.message : x` — runtime/type 100% 동일.

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (3 관련 test: format-string / mission-actions / store) — 15/15 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 4 file +28/-11

## SSOT 의미

PR #19193 (errorToString helper-only) → PR #19209 (callsite migration batch) chain 의 *variant 1: custom fallback*. lib/format-string 의 error-handling helper surface 가 errorToString + errorMessageOr 두 axis 로 확장 — *raw* vs *labelled* 의 캐노니컬 분기.

