### PR TITLE
test(harness): remove transport base url alias

### DIFF
--- a/scripts/harness/transport/common.sh
+++ b/scripts/harness/transport/common.sh
@@ -12,14 +12,10 @@ MASC_HTTP_PORT="${MASC_HTTP_PORT:-$(harness_pick_free_port)}"
 MASC_GRPC_PORT="${MASC_GRPC_PORT:-$(harness_pick_free_port)}"
 MASC_WS_PORT="${MASC_WS_PORT:-$(harness_pick_free_port)}"
 # Issue #8423: `MASC_HTTP_BASE_URL` is the documented name the OCaml
-# server reads (server_bootstrap_http.ml, env_config_core.ml). The
-# harness historically only exported `MASC_BASE_URL`, so an operator
-# setting `MASC_HTTP_BASE_URL` saw the real service while `verify_*.sh`
-# kept probing the free-port default. Honour the documented name first,
-# keep `MASC_BASE_URL` as a legacy alias so the 7 in-tree `verify_*.sh`
-# callers keep working until a follow-up PR migrates them.
+# server reads (server_bootstrap_http.ml, env_config_core.ml). Transport
+# harness scripts use that same name directly so the probed endpoint matches
+# the configured server endpoint.
 MASC_HTTP_BASE_URL="${MASC_HTTP_BASE_URL:-http://127.0.0.1:${MASC_HTTP_PORT}}"
-MASC_BASE_URL="${MASC_HTTP_BASE_URL}"
 MASC_GRPC_ADDR="127.0.0.1:${MASC_GRPC_PORT}"
 MASC_WS_URL="ws://127.0.0.1:${MASC_WS_PORT}"
 
@@ -28,7 +24,6 @@ export MASC_HTTP_PORT
 export MASC_GRPC_PORT
 export MASC_WS_PORT
 export MASC_HTTP_BASE_URL
-export MASC_BASE_URL
 export MASC_GRPC_ADDR
 export MASC_WS_URL
 
@@ -79,11 +74,11 @@ cleanup_transport_server() {
 }
 
 ensure_server() {
-  if curl -fsS --max-time 2 "${MASC_BASE_URL}/health" >/dev/null 2>&1; then
+  if curl -fsS --max-time 2 "${MASC_HTTP_BASE_URL}/health" >/dev/null 2>&1; then
     return 0
   fi
   if [[ "${MASC_TRANSPORT_AUTOSTART:-1}" != "1" ]]; then
-    echo "ERROR: MASC server not running on ${MASC_BASE_URL}" >&2
+    echo "ERROR: MASC server not running on ${MASC_HTTP_BASE_URL}" >&2
     echo "Set MASC_TRANSPORT_AUTOSTART=1 or start a server manually." >&2
     exit 2
   fi
@@ -113,7 +108,7 @@ ensure_server() {
   trap cleanup_transport_server EXIT
 
   if ! harness_wait_for_health "$MASC_HTTP_PORT" 25; then
-    echo "ERROR: transport harness server failed to become healthy on ${MASC_BASE_URL}" >&2
+    echo "ERROR: transport harness server failed to become healthy on ${MASC_HTTP_BASE_URL}" >&2
     harness_print_log_tail "$TRANSPORT_SERVER_LOG_FILE"
     exit 1
   fi
@@ -138,7 +133,7 @@ mcp_initialize_session() {
   headers="$(harness_mktemp_file "masc-transport-init-header")"
   body="$(harness_mktemp_file "masc-transport-init-body")"
   payload='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"transport-harness","version":"1.0"}}}'
-  if ! curl -fsS -D "$headers" -o "$body" -X POST "${MASC_BASE_URL}/mcp" \
+  if ! curl -fsS -D "$headers" -o "$body" -X POST "${MASC_HTTP_BASE_URL}/mcp" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -d "$payload" >/dev/null; then
@@ -167,7 +162,7 @@ mcp_call_tool() {
   local payload
   payload="$(printf '{"jsonrpc":"2.0","id":%s,"method":"tools/call","params":{"name":"%s","arguments":%s}}' \
     "$request_id" "$tool_name" "$arguments_json")"
-  curl -fsS -X POST "${MASC_BASE_URL}/mcp" \
+  curl -fsS -X POST "${MASC_HTTP_BASE_URL}/mcp" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -H "Mcp-Session-Id: ${session_id}" \

--- a/scripts/harness/transport/verify_grpc_subscribe.sh
+++ b/scripts/harness/transport/verify_grpc_subscribe.sh
@@ -109,7 +109,7 @@ else
 fi
 rm -f "${subscribe_output}"
 
-if curl -fsS "${MASC_BASE_URL}/health" >/dev/null 2>&1; then
+if curl -fsS "${MASC_HTTP_BASE_URL}/health" >/dev/null 2>&1; then
   pass "server healthy after subscriber disconnect"
 else
   fail "server health after disconnect" "health check failed"

--- a/scripts/harness/transport/verify_h2c_autodetect.sh
+++ b/scripts/harness/transport/verify_h2c_autodetect.sh
@@ -21,7 +21,7 @@ require_server
 echo "--- h2c Auto-detect E2E ---"
 
 # Test 1: HTTP/1.1 always works
-if curl -sf --http1.1 "${MASC_BASE_URL}/health" >/dev/null 2>&1; then
+if curl -sf --http1.1 "${MASC_HTTP_BASE_URL}/health" >/dev/null 2>&1; then
   pass "HTTP/1.1 health check"
 else
   fail "HTTP/1.1 health check" "failed"
@@ -30,7 +30,7 @@ fi
 # Test 2: h2c prior-knowledge (direct HTTP/2 without upgrade)
 # This is the reliable way to test h2c — --http2 uses Upgrade header
 # which serve_auto may not support (MSG_PEEK detects connection preface).
-h2pk_proto=$(curl -sf -o /dev/null -w '%{http_version}' --http2-prior-knowledge "${MASC_BASE_URL}/health" 2>&1 || echo "fail")
+h2pk_proto=$(curl -sf -o /dev/null -w '%{http_version}' --http2-prior-knowledge "${MASC_HTTP_BASE_URL}/health" 2>&1 || echo "fail")
 if [ "$h2pk_proto" = "2" ] || [ "$h2pk_proto" = "2.0" ]; then
   pass "h2c prior-knowledge health check (proto: ${h2pk_proto})"
 else
@@ -38,7 +38,7 @@ else
 fi
 
 # Test 3: MCP POST over h2c (the actual production path)
-h2_mcp_code=$(curl -sf --max-time 5 --http2-prior-knowledge -X POST "${MASC_BASE_URL}/mcp" \
+h2_mcp_code=$(curl -sf --max-time 5 --http2-prior-knowledge -X POST "${MASC_HTTP_BASE_URL}/mcp" \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"h2c-harness","version":"1.0"}},"id":1}' \
@@ -50,7 +50,7 @@ else
 fi
 
 # Test 4: HTTP/1.1 SSE endpoint (most critical path)
-sse_headers=$(curl -sf -I -m 3 --http1.1 "${MASC_BASE_URL}/sse" 2>&1 || true)
+sse_headers=$(curl -sf -I -m 3 --http1.1 "${MASC_HTTP_BASE_URL}/sse" 2>&1 || true)
 if echo "$sse_headers" | grep -qi "200\|text/event-stream"; then
   pass "HTTP/1.1 SSE endpoint accessible"
 else
@@ -61,7 +61,7 @@ fi
 pids=()
 success=0
 for _ in 1 2 3 4; do
-  curl -sf --http1.1 "${MASC_BASE_URL}/health" >/dev/null 2>&1 &
+  curl -sf --http1.1 "${MASC_HTTP_BASE_URL}/health" >/dev/null 2>&1 &
   pids+=($!)
 done
 for pid in "${pids[@]}"; do

--- a/scripts/harness/transport/verify_sse.sh
+++ b/scripts/harness/transport/verify_sse.sh
@@ -17,14 +17,14 @@ require_server
 
 # Test 1: Health check
 echo "--- SSE Transport E2E ---"
-if curl -sf "${MASC_BASE_URL}/health" >/dev/null 2>&1; then
+if curl -sf "${MASC_HTTP_BASE_URL}/health" >/dev/null 2>&1; then
   pass "health endpoint responds"
 else
   fail "health endpoint" "no response"
 fi
 
 # Test 2: SSE endpoint sends correct headers
-headers=$(curl -sf -I -m 3 "${MASC_BASE_URL}/sse" 2>&1 || true)
+headers=$(curl -sf -I -m 3 "${MASC_HTTP_BASE_URL}/sse" 2>&1 || true)
 if echo "$headers" | grep -qi "text/event-stream"; then
   pass "SSE content-type: text/event-stream"
 else
@@ -39,7 +39,7 @@ init_req='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersi
 init_deadline=$(( $(date +%s) + 15 ))
 init_resp=""
 while [[ "$(date +%s)" -lt "$init_deadline" ]]; do
-  init_resp=$(curl -sf -X POST "${MASC_BASE_URL}/mcp" \
+  init_resp=$(curl -sf -X POST "${MASC_HTTP_BASE_URL}/mcp" \
     -H "Content-Type: application/json" \
     -H "${MCP_ACCEPT}" \
     -d "$init_req" 2>&1 || true)
@@ -62,7 +62,7 @@ session_deadline=$(( $(date +%s) + 15 ))
 SESSION_ID=""
 while [[ "$(date +%s)" -lt "$session_deadline" ]]; do
   SESSION_ID="$(
-    curl -sf -i -X POST "${MASC_BASE_URL}/mcp" \
+    curl -sf -i -X POST "${MASC_HTTP_BASE_URL}/mcp" \
       -H "Content-Type: application/json" \
       -H "${MCP_ACCEPT}" \
       -d "$init_req" 2>&1 \
@@ -74,7 +74,7 @@ while [[ "$(date +%s)" -lt "$session_deadline" ]]; do
   sleep 1
 done
 tools_req='{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
-tools_resp=$(curl -sf -X POST "${MASC_BASE_URL}/mcp" \
+tools_resp=$(curl -sf -X POST "${MASC_HTTP_BASE_URL}/mcp" \
   -H "Content-Type: application/json" \
   -H "${MCP_ACCEPT}" \
   -H "Mcp-Session-Id: ${SESSION_ID}" \

--- a/scripts/harness/transport/verify_truth.sh
+++ b/scripts/harness/transport/verify_truth.sh
@@ -33,7 +33,7 @@ fetch_transport_health_json() {
   local body=""
   for _ in {1..25}; do
     if body="$(curl -fsS --max-time 5 \
-      "${MASC_BASE_URL}/api/v1/dashboard/transport-health" 2>/dev/null)" &&
+      "${MASC_HTTP_BASE_URL}/api/v1/dashboard/transport-health" 2>/dev/null)" &&
       jq -e '.streamable_http and .grpc and .websocket and .http2' \
         <<<"$body" >/dev/null 2>&1; then
       printf '%s\n' "$body"
@@ -177,7 +177,7 @@ probe_sse() {
   status="$(curl -sS -N --max-time 2 -D "$headers" -o /dev/null \
     -w '%{http_code}' \
     -H "Accept: application/json, text/event-stream" \
-    "${MASC_BASE_URL}/mcp?sse_kind=observer&session_id=transport-truth-$$" \
+    "${MASC_HTTP_BASE_URL}/mcp?sse_kind=observer&session_id=transport-truth-$$" \
     2>/dev/null || printf '000')"
   if grep -qi "content-type:.*text/event-stream" "$headers"; then
     rm -f "$headers"
@@ -197,13 +197,13 @@ probe_h2c() {
   local mcp_probe health_probe status version
   mcp_probe="$(curl --http2-prior-knowledge -sS --max-time 3 -o /dev/null \
     -w '%{http_code} %{http_version}' -X POST \
-    "${MASC_BASE_URL}/mcp" \
+    "${MASC_HTTP_BASE_URL}/mcp" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"transport-truth-h2","version":"1.0"}}}' \
     2>/dev/null || true)"
   health_probe="$(curl --http2-prior-knowledge -sS --max-time 3 -o /dev/null \
-    -w '%{http_code} %{http_version}' "${MASC_BASE_URL}/health" \
+    -w '%{http_code} %{http_version}' "${MASC_HTTP_BASE_URL}/health" \
     2>/dev/null || true)"
   status="$(awk '{print $1}' <<<"$mcp_probe")"
   version="$(awk '{print $2}' <<<"$health_probe")"
@@ -226,7 +226,7 @@ probe_h2c() {
 probe_mcp_post() {
   local status
   status="$(curl -sS --max-time 3 -o /dev/null -w '%{http_code}' -X POST \
-    "${MASC_BASE_URL}/mcp" \
+    "${MASC_HTTP_BASE_URL}/mcp" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"transport-truth-http","version":"1.0"}}}' \
@@ -267,7 +267,7 @@ compare_truth() {
   fi
 }
 
-health_json="$(curl -fsS --max-time 5 "${MASC_BASE_URL}/health")"
+health_json="$(curl -fsS --max-time 5 "${MASC_HTTP_BASE_URL}/health")"
 if jq -e '.version and .paths and .startup' <<<"$health_json" >/dev/null; then
   pass "/health returns structured server health"
 else
@@ -338,7 +338,7 @@ tool_grpc="$(json_bool "$transport_status_json" '.grpc as $grpc | if ($grpc | ha
 compare_truth "grpc" "$dashboard_grpc" "$tool_grpc" "$actual_grpc" \
   "tcp=127.0.0.1:${grpc_port}"
 
-ws_discovery="$(curl -fsS --max-time 5 "${MASC_BASE_URL}/ws" 2>/dev/null || printf '{}')"
+ws_discovery="$(curl -fsS --max-time 5 "${MASC_HTTP_BASE_URL}/ws" 2>/dev/null || printf '{}')"
 ws_port="$(jq -r '.ws_port // empty' <<<"$ws_discovery" 2>/dev/null || true)"
 if [[ "$ws_port" =~ ^[0-9]+$ ]] && probe_ws_handshake "127.0.0.1" "$ws_port"; then
   actual_ws="true"

--- a/scripts/harness/transport/verify_webrtc_live_env.sh
+++ b/scripts/harness/transport/verify_webrtc_live_env.sh
@@ -51,7 +51,7 @@ require_server
 
 echo "--- WebRTC Live Env Interop ---"
 
-health_json="$(curl -fsS "${MASC_BASE_URL}/health")"
+health_json="$(curl -fsS "${MASC_HTTP_BASE_URL}/health")"
 health_check="$(
   HEALTH_JSON="$health_json" EXPECTED_URLS="$MASC_WEBRTC_ICE_URLS" python3 - <<'PY'
 import json, os, sys
@@ -168,7 +168,7 @@ print(json.dumps({
 }))
 PY
 
-offer_resp="$(curl -fsS -X POST "${MASC_BASE_URL}/webrtc/offer" -H "Content-Type: application/json" --data @"$offer_payload")"
+offer_resp="$(curl -fsS -X POST "${MASC_HTTP_BASE_URL}/webrtc/offer" -H "Content-Type: application/json" --data @"$offer_payload")"
 offer_id="$(
   OFFER_JSON="$offer_resp" python3 - <<'PY'
 import json, os
@@ -183,7 +183,7 @@ else
   exit 1
 fi
 
-answer_resp="$(curl -fsS -X POST "${MASC_BASE_URL}/webrtc/answer" \
+answer_resp="$(curl -fsS -X POST "${MASC_HTTP_BASE_URL}/webrtc/answer" \
   -H "Content-Type: application/json" \
   -d "{\"offer_id\":\"${offer_id}\",\"agent_name\":\"webrtc-live-server\"}")"
 answer_check="$(

--- a/scripts/harness/transport/verify_webrtc_signaling.sh
+++ b/scripts/harness/transport/verify_webrtc_signaling.sh
@@ -16,7 +16,7 @@ require_server
 
 echo "--- WebRTC Signaling E2E ---"
 
-health_resp="$(curl -fsS "${MASC_BASE_URL}/health")"
+health_resp="$(curl -fsS "${MASC_HTTP_BASE_URL}/health")"
 webrtc_enabled="$(
   HEALTH_JSON="$health_resp" python3 - <<'PY'
 import json, os
@@ -32,7 +32,7 @@ else
 fi
 
 offer_resp="$(
-  curl -fsS -X POST "${MASC_BASE_URL}/webrtc/offer" \
+  curl -fsS -X POST "${MASC_HTTP_BASE_URL}/webrtc/offer" \
     -H "Content-Type: application/json" \
     -d '{"agent_name":"e2e-tester","ice_candidates":["candidate:842163049 1 udp 1677729535 127.0.0.1 50000 typ srflx raddr 0.0.0.0 rport 9"],"dtls_fingerprint":"sha256:abc"}'
 )"
@@ -51,7 +51,7 @@ else
 fi
 
 answer_resp="$(
-  curl -fsS -X POST "${MASC_BASE_URL}/webrtc/answer" \
+  curl -fsS -X POST "${MASC_HTTP_BASE_URL}/webrtc/answer" \
     -H "Content-Type: application/json" \
     -d "{\"offer_id\":\"${offer_id}\",\"agent_name\":\"e2e-answerer\",\"ice_candidates\":[\"candidate:1 1 udp 2130706431 127.0.0.1 50001 typ host\"]}"
 )"
@@ -70,7 +70,7 @@ else
 fi
 
 dup_resp="$(
-  curl -fsS -X POST "${MASC_BASE_URL}/webrtc/answer" \
+  curl -fsS -X POST "${MASC_HTTP_BASE_URL}/webrtc/answer" \
     -H "Content-Type: application/json" \
     -d "{\"offer_id\":\"${offer_id}\",\"agent_name\":\"e2e-dup\"}" 2>&1 || true
 )"
@@ -81,7 +81,7 @@ else
 fi
 
 invalid_resp="$(
-  curl -fsS -X POST "${MASC_BASE_URL}/webrtc/answer" \
+  curl -fsS -X POST "${MASC_HTTP_BASE_URL}/webrtc/answer" \
     -H "Content-Type: application/json" \
     -d '{"offer_id":"nonexistent-id","agent_name":"e2e-invalid"}' 2>&1 || true
 )"

--- a/scripts/harness/transport/verify_ws.sh
+++ b/scripts/harness/transport/verify_ws.sh
@@ -15,7 +15,7 @@ require_server
 
 echo "--- WebSocket Transport E2E ---"
 
-ws_discovery="$(curl -fsS "${MASC_BASE_URL}/ws" 2>&1 || true)"
+ws_discovery="$(curl -fsS "${MASC_HTTP_BASE_URL}/ws" 2>&1 || true)"
 read -r ws_enabled ws_port ws_url <<EOF
 $(WS_DISCOVERY="$ws_discovery" python3 - <<'PY'
 import json, os
@@ -34,7 +34,7 @@ else
 fi
 
 read_sse_external_subscriber_count() {
-  curl -fsS "${MASC_BASE_URL}/metrics" 2>/dev/null \
+  curl -fsS "${MASC_HTTP_BASE_URL}/metrics" 2>/dev/null \
     | awk '$1=="masc_sse_external_subscribers_total" { print int($2); found=1; exit } END { if (!found) print -1 }' \
     2>/dev/null || echo "-1"
 }
@@ -196,7 +196,7 @@ else
 fi
 rm -f "$ws_output" "$ws_handshake"
 
-if curl -fsS "${MASC_BASE_URL}/health" >/dev/null 2>&1; then
+if curl -fsS "${MASC_HTTP_BASE_URL}/health" >/dev/null 2>&1; then
   pass "server healthy after WebSocket test"
 else
   fail "server health" "health check failed after WebSocket test"


### PR DESCRIPTION
## Summary
- remove the transport harness MASC_BASE_URL legacy alias
- migrate in-tree transport verify scripts to MASC_HTTP_BASE_URL directly
- keep unrelated user-facing MASC_BASE_URL scripts outside scripts/harness/transport untouched

## Verification
- rg "MASC_BASE_URL" scripts/harness/transport -n
- bash -n scripts/harness/transport/common.sh scripts/harness/transport/verify_grpc_subscribe.sh scripts/harness/transport/verify_h2c_autodetect.sh scripts/harness/transport/verify_sse.sh scripts/harness/transport/verify_truth.sh scripts/harness/transport/verify_webrtc_live_env.sh scripts/harness/transport/verify_webrtc_signaling.sh scripts/harness/transport/verify_ws.sh
- git diff --check origin/main