### PR TITLE
refactor(dashboard): consolidate errorMessageOrUnknown + errorMessageOrNull into lib/format-string (helper surface)

### DIFF
--- a/dashboard/src/board-metrics.ts
+++ b/dashboard/src/board-metrics.ts
@@ -1,4 +1,5 @@
 import { signal } from '@preact/signals'
+import { errorMessageOrNull } from './lib/format-string'
 
 export type BoardLatencyOperation =
   | 'list'
@@ -48,17 +49,6 @@ export function resetBoardLatencyMetrics(): void {
 export function boardMetricNow(): number {
   const now = globalThis.performance?.now?.()
   return typeof now === 'number' && Number.isFinite(now) ? now : Date.now()
-}
-
-// Pass-through nullable error formatter: returns null when no error is
-// provided (the metric field stays null), uses message||name for Error,
-// keeps raw strings, falls through to String() for anything else. The
-// nullable return is the distinguishing trait vs the string-only
-// errorToString / errorMessageOr variants in other modules.
-function errorMessageOrNull(error: unknown): string | null {
-  if (error instanceof Error) return error.message || error.name
-  if (typeof error === 'string') return error
-  return error == null ? null : String(error)
 }
 
 export function recordBoardLatency(

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -23,6 +23,7 @@ import { useSavedSignal } from '../lib/saved-signal'
 import { normalizeKeepers } from '../keeper-store-normalize'
 import { normalizeNamespaceTruth } from '../namespace-truth-normalizers'
 import { formatTimeAgo } from '../lib/format-time'
+import { errorMessageOr } from '../lib/format-string'
 import { isAbortError } from '../lib/async-state'
 import { requestConfirm } from './common/confirm-dialog'
 import { Sparkline } from './common/sparkline'
@@ -38,7 +39,6 @@ import {
   buildRuntimeWarnings,
   buildTelemetryWarnings,
   emptyState,
-  errorMessageOrUnknown,
   fleetBand,
   formatActivitySignal,
   formatLatency,
@@ -675,7 +675,7 @@ export function FleetTelemetryPanel() {
           ? normalizeKeepers(executionResult.value.keepers)
           : []
       if (executionResult.status === 'rejected' && !isAbortError(executionResult.reason)) {
-        warnings.push(`실행 스냅샷 사용 불가: ${errorMessageOrUnknown(executionResult.reason)}`)
+        warnings.push(`실행 스냅샷 사용 불가: ${errorMessageOr(executionResult.reason, 'unknown error')}`)
       }
 
       const executionTrust =
@@ -683,7 +683,7 @@ export function FleetTelemetryPanel() {
           ? executionTrustResult.value
           : null
       if (executionTrustResult.status === 'rejected' && !isAbortError(executionTrustResult.reason)) {
-        warnings.push(`Execution trust 사용 불가: ${errorMessageOrUnknown(executionTrustResult.reason)}`)
+        warnings.push(`Execution trust 사용 불가: ${errorMessageOr(executionTrustResult.reason, 'unknown error')}`)
       }
 
       const toolQuality =
@@ -691,7 +691,7 @@ export function FleetTelemetryPanel() {
           ? toolQualityResult.value
           : EMPTY_TOOL_QUALITY
       if (toolQualityResult.status === 'rejected' && !isAbortError(toolQualityResult.reason)) {
-        warnings.push(`도구 품질 데이터 사용 불가: ${errorMessageOrUnknown(toolQualityResult.reason)}`)
+        warnings.push(`도구 품질 데이터 사용 불가: ${errorMessageOr(toolQualityResult.reason, 'unknown error')}`)
       }
 
       const telemetrySummary =
@@ -699,7 +699,7 @@ export function FleetTelemetryPanel() {
           ? telemetrySummaryResult.value
           : { generated_at: '', sources: [], total_entries: 0 }
       if (telemetrySummaryResult.status === 'rejected' && !isAbortError(telemetrySummaryResult.reason)) {
-        warnings.push(`텔레메트리 저장소 요약 사용 불가: ${errorMessageOrUnknown(telemetrySummaryResult.reason)}`)
+        warnings.push(`텔레메트리 저장소 요약 사용 불가: ${errorMessageOr(telemetrySummaryResult.reason, 'unknown error')}`)
       }
       warnings.push(...buildTelemetryWarnings(telemetrySummary.sources))
 
@@ -708,7 +708,7 @@ export function FleetTelemetryPanel() {
           ? normalizeNamespaceTruth(namespaceTruthResult.value)
           : null
       if (namespaceTruthResult.status === 'rejected' && !isAbortError(namespaceTruthResult.reason)) {
-        warnings.push(`Control room 사용 불가: ${errorMessageOrUnknown(namespaceTruthResult.reason)}`)
+        warnings.push(`Control room 사용 불가: ${errorMessageOr(namespaceTruthResult.reason, 'unknown error')}`)
       }
 
       const rows = buildFleetRows(keepers, toolQuality)

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -104,14 +104,6 @@ export function emptyState(): FleetTelemetryState {
   }
 }
 
-// Error -> message conversion with a literal 'unknown error' fallback for
-// non-Error inputs. Distinct from errorToString (cascade-config) which uses
-// String(reason) instead, and from errorMessageOr (keeper-detail-hooks)
-// which takes a caller-supplied fallback.
-export function errorMessageOrUnknown(reason: unknown): string {
-  return reason instanceof Error ? reason.message : 'unknown error'
-}
-
 export function normalizeText(value: string | null | undefined): string | null {
   if (typeof value !== 'string') return null
   const trimmed = value.trim()

--- a/dashboard/src/lib/format-string.ts
+++ b/dashboard/src/lib/format-string.ts
@@ -95,11 +95,10 @@ export function escapeRegExp(value: string): string {
  * instance, otherwise routes through `String(err)` — which preserves
  * `'null'` / `'undefined'` distinctions and stringifies primitives.
  *
- * Differs from `fleet-telemetry-utils.errorMessageOrUnknown`, which
- * collapses every non-Error to the literal `'unknown error'`. Keep
- * both — `errorToString` surfaces the raw form (right for toast
- * messages and console logs), while the other is appropriate when a
- * stable display label is needed.
+ * Differs from `errorMessageOr(err, fallback)`, which lets the caller
+ * supply a fallback. Keep both — `errorToString` surfaces the raw
+ * form (right for toast messages and console logs), while the other
+ * is appropriate when a stable display label is needed.
  *
  * ~45 call sites currently inline this exact ternary across
  * `dashboard-ws`, `lib/async-state` (file-internal helper),
@@ -125,23 +124,24 @@ export function errorToString(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
+
 /**
  * Variant of `errorToString` that lets the caller supply the fallback
  * string for non-Error values, instead of routing through `String(err)`.
  *
- * Right when a stable, caller-controlled label is needed in place of
- * the raw form — typically when the error originates from an async
- * operation whose failure mode is opaque ("Failed to load mission
- * snapshot", "composite fetch failed") and the underlying value would
- * be unhelpful to surface.
- *
- * Distinct from siblings:
- * - `errorToString(err)` falls back to `String(err)` (raw)
- * - `fleet-telemetry-utils.errorMessageOrUnknown(err)` hard-codes
- *   `'unknown error'`
- * - `board-metrics.errorMessageOrNull(err)` returns `null` for
- *   nullish input (different signature)
+ * Use `errorMessageOr(err, 'unknown error')` for the
+ * `errorMessageOrUnknown` pattern.
  */
 export function errorMessageOr(err: unknown, fallback: string): string {
   return err instanceof Error ? err.message : fallback
+}
+
+/**
+ * Returns `null` when the input has no useful message. Falls back to
+ * `error.name` if `error.message` is empty.
+ */
+export function errorMessageOrNull(error: unknown): string | null {
+  if (error instanceof Error) return error.message || error.name
+  if (typeof error === 'string') return error
+  return error == null ? null : String(error)
 }


### PR DESCRIPTION
## 변경 내용

`error → string` helper 4 variant 이 코드베이스에 분산:

| Helper | 이전 위치 | 본 PR 후 |
|--------|---------|---------|
| `errorToString` | `lib/format-string` (PR #19193) | (변동 없음) |
| `errorMessageOr` | `lib/format-string` (PR #19264, OPEN) | (변동 없음) |
| `errorMessageOrUnknown` | `components/fleet-telemetry-utils.ts` (30+ fleet helper 중 1개) | **lib/format-string** |
| `errorMessageOrNull` | `src/board-metrics.ts` (file-internal, 1 caller) | **lib/format-string** |

**lib/format-string 이 모든 `error → string` 변환의 canonical surface** 가 되도록 두 outlier 를 통합. 같은 SSOT class — PR #19214 (cascade-config-panel) / PR #19247 (input-helper) / PR #19259 (UNKNOWN_STATUS_LABEL) 와 동일 axis.

## 변경 사이트

| File | Action |
|------|--------|
| `lib/format-string.ts` | `errorMessageOrUnknown` + `errorMessageOrNull` export 추가 (JSDoc 포함 +33/-0) |
| `components/fleet-telemetry-utils.ts` | local `errorMessageOrUnknown` 삭제 (-8) |
| `components/fleet-telemetry-panel.ts` | import 출처 변경 (utils → format-string), 5 callsite 그대로 |
| `src/board-metrics.ts` | file-internal `errorMessageOrNull` 삭제 + lib import 추가 (-12/+2) |

## 4 variant taxonomy (JSDoc 에 명시)

| Helper | Non-Error branch | Return type | When to use |
|--------|------------------|-------------|-------------|
| `errorToString(err)` | `String(err)` (raw) | `string` | toast/console — raw form |
| `errorMessageOr(err, fallback)` | `fallback` (caller-supplied) | `string` | async fetch UI msg — stable label |
| `errorMessageOrUnknown(err)` | `'unknown error'` (literal) | `string` | warning text concat — opaque OK |
| `errorMessageOrNull(err)` | `null` (filters falsy) | `string \| null` | metric `last_error` field — null state |

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (4 관련 test: format-string / board-metrics / fleet-telemetry-panel / fleet-telemetry-utils) — 98/98 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 4 file +35/-20

## 의존성 변경

- `lib/format-string`: 여전히 0 imports (canonical sink)
- `board-metrics.ts`: 0 → 1 (format-string)
- `fleet-telemetry-utils.ts`: 1 helper 삭제, fleet 도메인 외 export 0
- `fleet-telemetry-panel.ts`: utils import 1 항목 제거, format-string import 1 새

