### PR TITLE
[codex] Optimize HTTP body chunk accumulation

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -9,6 +9,7 @@
  auth_nickname
  plan_action_outcome
  prometheus_text
+ http_body_buffer
  http_response_payload
  error_event_type
  keeper_alert_persist_kind

--- a/lib/http_body_buffer.ml
+++ b/lib/http_body_buffer.ml
@@ -1,0 +1,47 @@
+(** Growable request-body accumulator for httpun/h2 bigstring chunks.
+
+    [Bigstringaf.substring] allocates one string per body chunk before callers
+    copy that string into a [Buffer].  This helper keeps the same final
+    string API while copying chunks directly into a growable bytes buffer. *)
+
+type t = {
+  mutable bytes: Bytes.t;
+  mutable length: int;
+}
+
+let create initial_capacity =
+  { bytes = Bytes.create (max 0 initial_capacity); length = 0 }
+
+let length t = t.length
+
+let next_capacity current needed =
+  let rec loop capacity =
+    if capacity >= needed then
+      capacity
+    else if capacity > max_int / 2 then
+      needed
+    else
+      loop (capacity * 2)
+  in
+  loop (max 1 current)
+
+let ensure_capacity t needed =
+  let current = Bytes.length t.bytes in
+  if needed > current then begin
+    let bytes = Bytes.create (next_capacity current needed) in
+    Bytes.blit t.bytes 0 bytes 0 t.length;
+    t.bytes <- bytes
+  end
+
+let add_bigstring t bigstring ~off ~len =
+  if len < 0 then
+    invalid_arg "Http_body_buffer.add_bigstring: negative length";
+  let needed = t.length + len in
+  if needed < t.length then
+    invalid_arg "Http_body_buffer.add_bigstring: length overflow";
+  ensure_capacity t needed;
+  Bigstringaf.blit_to_bytes bigstring ~src_off:off t.bytes ~dst_off:t.length ~len;
+  t.length <- needed
+
+let contents t =
+  Bytes.sub_string t.bytes 0 t.length

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -365,12 +365,11 @@ module Request = struct
            | Some len when len > 0 && len < max_body_bytes -> len
            | _ -> 1024
          in
-         let buf = Buffer.create initial_capacity in
-         let seen_bytes = ref 0 in
+         let buf = Http_body_buffer.create initial_capacity in
          let rec read_loop () =
            Httpun.Body.Reader.schedule_read body
              ~on_eof:(fun () ->
-               let body_str = Buffer.contents buf in
+               let body_str = Http_body_buffer.contents buf in
                try on_body body_str with
                  | Eio.Cancel.Cancelled _ as e -> raise e
                  | exn ->
@@ -378,14 +377,12 @@ module Request = struct
              ~on_read:(fun buffer ~off ~len ->
                if !stopped then ()
                else
-                 let next_bytes = !seen_bytes + len in
+                 let next_bytes = Http_body_buffer.length buf + len in
                  if next_bytes > max_body_bytes then begin
                    stop ();
                    on_error (`Too_large max_body_bytes)
                  end else begin
-                   seen_bytes := next_bytes;
-                   let chunk = Bigstringaf.substring buffer ~off ~len in
-                   Buffer.add_string buf chunk;
+                   Http_body_buffer.add_bigstring buf buffer ~off ~len;
                    read_loop ()
                  end)
          in

--- a/lib/http_server_h2.ml
+++ b/lib/http_server_h2.ml
@@ -176,15 +176,14 @@ end
 (** Read request body - H2 uses async body reading with callback *)
 let read_body_async reqd callback =
   let body = H2.Reqd.request_body reqd in
-  let buf = Buffer.create 4096 in
+  let buf = Http_body_buffer.create 4096 in
   let rec read_loop () =
     H2.Body.Reader.schedule_read body
       ~on_eof:(fun () ->
-        let body_str = Buffer.contents buf in
+        let body_str = Http_body_buffer.contents buf in
         callback body_str)
       ~on_read:(fun bigstring ~off ~len ->
-        let bytes = Bigstringaf.substring bigstring ~off ~len in
-        Buffer.add_string buf bytes;
+        Http_body_buffer.add_bigstring buf bigstring ~off ~len;
         read_loop ())
   in
   read_loop ()

--- a/lib/server/server_h2_gateway_helpers.ml
+++ b/lib/server/server_h2_gateway_helpers.ml
@@ -88,13 +88,12 @@ let h2_respond_removed_surface h2_reqd ~surface ~extra_headers =
 
 let h2_read_body h2_reqd callback =
   let body = H2.Reqd.request_body h2_reqd in
-  let buf = Buffer.create 4096 in
+  let buf = Http_body_buffer.create 4096 in
   let rec read_loop () =
     H2.Body.Reader.schedule_read body
-      ~on_eof:(fun () -> callback (Buffer.contents buf))
+      ~on_eof:(fun () -> callback (Http_body_buffer.contents buf))
       ~on_read:(fun bigstring ~off ~len ->
-        let chunk = Bigstringaf.substring bigstring ~off ~len in
-        Buffer.add_string buf chunk;
+        Http_body_buffer.add_bigstring buf bigstring ~off ~len;
         read_loop ())
   in
   read_loop ()


### PR DESCRIPTION
Summary:
- Add Http_body_buffer, a private growable bytes accumulator for request-body bigstring chunks.
- Replace per-chunk Bigstringaf.substring + Buffer.add_string in H1, H2, and H2 gateway body readers with direct Bigstringaf.blit_to_bytes accumulation.
- Preserve final callback API as string while removing one temporary string allocation per body chunk.

Validation:
- git diff --check origin/main..HEAD
- ocamlformat --check lib/http_body_buffer.ml lib/http_server_eio.ml lib/http_server_h2.ml lib/server/server_h2_gateway_helpers.ml
- env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build bin/main_eio.exe test/test_http_server_eio.exe
- ./_build/default/test/test_http_server_eio.exe (36 tests)

Note:
- Local wrapper build used MASC_SKIP_PIN_CHECK=1 because the shared opam switch has agent_sdk floor 0.200.5 while current masc-mcp main still declares 0.200.2; downgrade was correctly refused by scripts/opam-pin-external-deps.sh.