### PR TITLE
refactor(dashboard): route 7 inline Math.round(X*100)+'%' patterns through lib/format-number.formatPct

### DIFF
--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -2,7 +2,7 @@
 
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
-import { formatPct1 } from '../lib/format-number'
+import { formatPct, formatPct1 } from '../lib/format-number'
 import { formatTimestampKo } from '../lib/format-time'
 import { assertExhaustive } from '../lib/exhaustive'
 import { SectionCard } from './common/card'
@@ -414,9 +414,7 @@ export function HarnessHealth() {
                 {
                   variant: 'stacked',
                   label: '최근 컨텍스트 사용률',
-                  value: data.overview.latest_pre_compact_ratio != null
-                    ? `${Math.round(data.overview.latest_pre_compact_ratio * 100)}%`
-                    : '-',
+                  value: formatPct(data.overview.latest_pre_compact_ratio),
                   caption: `최근 ${data.pre_compact.total_recent}건`,
                 },
                 {

--- a/dashboard/src/lib/keeper-runtime-projection.ts
+++ b/dashboard/src/lib/keeper-runtime-projection.ts
@@ -8,6 +8,7 @@ import {
   type KeeperOperationalState,
 } from './keeper-operational-state'
 import { formatDuration } from './format-time'
+import { formatPct } from './format-number'
 
 export type KeeperLinkedRuntimeState = 'offline' | 'online' | 'unlinked'
 export type KeeperRuntimeProjectionTone = 'ok' | 'warn' | 'bad' | 'info' | 'neutral'
@@ -427,8 +428,8 @@ function buildProjectionSignals({
   const blockerAttention = opState.kind === 'stuck' || opState.attention !== 'clean'
   const ksmAttention = fsmLanes.some(lane => lane.axis === 'KSM' && lane.contributesToAttention)
   const heartbeatAge = heartbeat.ageMs === null ? 'age unknown' : `${Math.round(heartbeat.ageMs / 1000)}s old`
-  const contextValue = context.ratio === null ? 'unknown' : `${Math.round(context.ratio * 100)}%`
-  const contextThreshold = `${Math.round(context.threshold * 100)}%`
+  const contextValue = formatPct(context.ratio, 'unknown')
+  const contextThreshold = formatPct(context.threshold)
   const socialValue =
     socialModel.recognized === false
       ? 'unrecognized'

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -4,7 +4,7 @@
 import { signal, type ReadonlySignal } from '@preact/signals'
 import type { JournalEntry, JournalEventType, SSEEvent } from './types'
 import { SYSTEM_ACTOR_NAME } from './types/core'
-import { formatCost } from './lib/format-number'
+import { formatCost, formatPct } from './lib/format-number'
 import { isRecord } from './lib/type-guards'
 import {
   removeBoardPost,
@@ -503,7 +503,7 @@ function handleEvent(event: SSEEvent): void {
     case 'keeper_heartbeat':
       addTypedJournalEntry(
         event.name ?? agent,
-        `Heartbeat gen=${event.generation ?? '?'} ctx=${event.context_ratio != null ? Math.round(event.context_ratio * 100) + '%' : '?'}`,
+        `Heartbeat gen=${event.generation ?? '?'} ctx=${formatPct(event.context_ratio, '?')}`,
         'keepers',
         'keeper_heartbeat',
         {
@@ -511,7 +511,7 @@ function handleEvent(event: SSEEvent): void {
           source: event.source,
           narrativeText:
             `${actorLabel(event.name ?? agent)}가 하트비트를 보냈습니다`
-            + ` (gen ${event.generation ?? '?'}, ctx ${event.context_ratio != null ? Math.round(event.context_ratio * 100) + '%' : '?'})`,
+            + ` (gen ${event.generation ?? '?'}, ctx ${formatPct(event.context_ratio, '?')})`,
         },
       )
       break
@@ -649,7 +649,7 @@ function handleEvent(event: SSEEvent): void {
       }
       addTypedJournalEntry(
         snap.keeper_name,
-        `Keeper snapshot gen=${snap.generation} ctx=${Math.round(snap.context_ratio * 100)}%`,
+        `Keeper snapshot gen=${snap.generation} ctx=${formatPct(snap.context_ratio)}`,
         'oas',
         'oas_keeper_snapshot',
         {
@@ -657,7 +657,7 @@ function handleEvent(event: SSEEvent): void {
           source: event.source,
           narrativeText:
             `${actorLabel(snap.keeper_name)}의 keeper snapshot이 갱신되었습니다`
-            + ` (gen ${snap.generation}, ctx ${Math.round(snap.context_ratio * 100)}%)`,
+            + ` (gen ${snap.generation}, ctx ${formatPct(snap.context_ratio)})`,
           ...envelopeFromEvent(event),
         },
       )


### PR DESCRIPTION
## 변경 내용

`lib/format-number.ts` 의 `formatPct(value, fallback)` 이 이미 `ratio → ${Math.round(value * 100)}%` conversion 을 제공하며 null/NaN fallback 도 지원. **3 file 7 callsite 가 같은 body 를 inline 으로** 반복.

세 file 모두 이미 `lib/format-number` 에서 다른 helper (`formatCost`, `formatPct1`, `formatDuration` 등) import 중이라 추가 import 비용 0.

## 변경 사이트

### Ternary-collapse migration (3 site)

| File | Before | After |
|------|--------|-------|
| `sse.ts:506` | `event.context_ratio != null ? Math.round(event.context_ratio * 100) + '%' : '?'` | `formatPct(event.context_ratio, '?')` |
| `sse.ts:514` | (same) | (same) |
| `harness-health.ts:417-419` | `data.overview.latest_pre_compact_ratio != null ? \`${Math.round(...)}%\` : '-'` | `formatPct(data.overview.latest_pre_compact_ratio)` (default '-') |
| `keeper-runtime-projection.ts:431` | `context.ratio === null ? 'unknown' : \`${Math.round(...)}%\`` | `formatPct(context.ratio, 'unknown')` |

### Direct-body migration (input guaranteed non-null) (4 site)

| File | Before | After |
|------|--------|-------|
| `sse.ts:652` | `${Math.round(snap.context_ratio * 100)}%` | `${formatPct(snap.context_ratio)}` |
| `sse.ts:660` | (same) | (same) |
| `keeper-runtime-projection.ts:432` | `${Math.round(context.threshold * 100)}%` | `formatPct(context.threshold)` |

## 등가성

`formatPct(value, fallback)` body:
```ts
if (!isFiniteMetricValue(value)) return fallback
return `${Math.round(value * 100)}%`
```

inline `Math.round(X * 100) + '%'` 와 valid input 시 동일. invalid input 시 `isFiniteMetricValue` guard 가 fallback 반환 — 직접 ternary 보다 *robust* (NaN/Infinity 도 fallback).

## SSOT 의미

PR #19193 (errorToString) / PR #19234 (clampPct) / PR #19245 (isRecord) / PR #19264 (errorMessageOr) 와 *같은 class*. inline ternary-collapse 부수효과 — *3 branch* (null check / format / fallback) 가 *1 call* 로 응집. mis-edit 한쪽 branch 만 잡는 위험 제거.

## 검증

- `pnpm typecheck` — 0 error
- `pnpm lint` — 0 error
- `pnpm vitest run` (4 관련 test: sse / harness-health / keeper-runtime-projection / format-number) — 59/59 pass
- `pnpm vitest run` (full) — 528/529 (1 baseline flaky `auth-status.a11y`)
- 3 file +10/-11

