### PR TITLE
refactor(tools): remove retired worktree tool name

### DIFF
--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -928,7 +928,7 @@ describe('approval_state.pending_first — worktree approval blocker surfacing',
             pending_count: 1,
             pending_first: {
               id: 'appr_2cae9bec14f6',
-              tool_name: 'masc_worktree_create',
+              tool_name: 'Execute',
               task_id: 'task-187',
               blocker_class: 'blocked_before_worktree',
             },
@@ -938,7 +938,7 @@ describe('approval_state.pending_first — worktree approval blocker surfacing',
     ])
     expect(keeper?.trust?.approval_state?.pending_first).toEqual({
       id: 'appr_2cae9bec14f6',
-      tool_name: 'masc_worktree_create',
+      tool_name: 'Execute',
       task_id: 'task-187',
       blocker_class: 'blocked_before_worktree',
     })

--- a/docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md
+++ b/docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md
@@ -78,7 +78,7 @@ Source-level boundary tests prevent regressions in layer ownership:
 The boundary test intentionally fails if:
 
 - tool code reintroduces Docker path literals or profile detection;
-- coord worktree helpers reintroduce Docker container-root construction
+- coord repo-path helpers reintroduce Docker container-root construction
   or sandbox-profile parsing;
 - Docker shell code re-exports generic command classification or parses
   raw shell commands directly;

--- a/docs/MASC-V2-DESIGN.md
+++ b/docs/MASC-V2-DESIGN.md
@@ -264,8 +264,8 @@ git worktree prune
 {"seq":2,"type":"agent_leave","agent":"agent-llm-a","reason":"session_end","ts":"..."}
 
 // Worktree lifecycle
-{"seq":3,"type":"worktree_create","agent":"agent-llm-a","branch":"agent-llm-a/PK-123","ts":"..."}
-{"seq":4,"type":"worktree_remove","agent":"agent-llm-a","branch":"agent-llm-a/PK-123","ts":"..."}
+{"seq":3,"type":"worktree_prepared","agent":"agent-llm-a","branch":"agent-llm-a/PK-123","ts":"..."}
+{"seq":4,"type":"worktree_cleaned","agent":"agent-llm-a","branch":"agent-llm-a/PK-123","ts":"..."}
 
 // Task lifecycle
 {"seq":5,"type":"task_claim","agent":"agent-llm-a","task":"PK-123","ts":"..."}

--- a/docs/spec/02-types-and-invariants.md
+++ b/docs/spec/02-types-and-invariants.md
@@ -531,7 +531,6 @@ type permission =
   | CanReadState | CanAddTask | CanClaimTask | CanCompleteTask
   | CanBroadcast
   | CanOpenPortal | CanSendPortal
-  | CanCreateWorktree | CanRemoveWorktree
   | CanVote | CanInterrupt | CanApprove
   | CanAdmin
 ```
@@ -540,7 +539,7 @@ type permission =
 
 | Role | Permissions |
 |------|------------|
-| Worker | `CanReadState`, `CanJoin`, `CanLeave`, `CanAddTask`, `CanClaimTask`, `CanCompleteTask`, `CanBroadcast`, `CanOpenPortal`, `CanSendPortal`, `CanCreateWorktree`, `CanRemoveWorktree`, `CanVote` |
+| Worker | `CanReadState`, `CanJoin`, `CanLeave`, `CanAddTask`, `CanClaimTask`, `CanCompleteTask`, `CanBroadcast`, `CanOpenPortal`, `CanSendPortal`, `CanVote` |
 | Admin | Worker + `CanInit`, `CanReset`, `CanInterrupt`, `CanApprove`, `CanAdmin` (전체) |
 
 ### 9.3 Agent Credential

--- a/docs/spec/03-room-coordination.md
+++ b/docs/spec/03-room-coordination.md
@@ -440,30 +440,27 @@ type mode =
 
 ---
 
-## 9. Git Operations (`coord_git`)
+## 9. Repo Worktree Workflow
 
 에이전트별 git worktree 격리.
 
-### 9.1 Worktree Create
+### 9.1 Worktree Preparation
 
-```
-Coord_git.create ~agent_name ~task_id ~base_branch
-```
+Worktree preparation is an ordinary repository workflow. Agents use typed
+`Execute` with explicit `git` argv from a scoped repository cwd; coordination
+state may record the resulting path, but there is no standalone coordination tool
+for this workflow.
 
 1. git 저장소 검증 (`.git` 존재 확인)
 2. worktree 경로 생성: `.worktrees/{agent_name}-{task_id}`
 3. branch 이름: `{agent_name}/{task_id}`
-4. `git fetch origin` -> `git worktree add` (base branch에서 분기)
+4. typed `Execute` runs `git fetch origin` -> `git worktree add` (base branch에서 분기)
 5. 에이전트 `current_task` 갱신
 6. 태스크 backlog에 `worktree_info` 연결 (`link_task` 옵션)
 
-### 9.2 Worktree Remove
+### 9.2 Worktree Cleanup
 
-```
-Coord_git.remove ~agent_name ~task_id
-```
-
-- `git worktree remove --force`
+- typed `Execute` may run `git worktree remove --force`
 - 로컬 브랜치 삭제
 
 ### 9.3 Task Worktree Metadata

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -297,7 +297,7 @@ type tier = Essential | Standard | Full
 
 | Tier | 도구 수 | 용도 |
 |------|---------|------|
-| Essential | ~21 | 핵심 워크플로우 (`join`, `add_task`, `broadcast`, `heartbeat`, `worktree_create` 등) |
+| Essential | ~21 | 핵심 워크플로우 (`join`, `add_task`, `broadcast`, `heartbeat`, repo worktree workflow 등) |
 | Standard | ~50 | Essential + Board, Governance V2, Handover, Spawn |
 | Full | 전체 | 모든 등록 도구 |
 

--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -97,7 +97,6 @@ let risk_overrides : (string * risk_level) list =
        Removal target: RFC-0193 typed capability table (Issue #19032). Evidence: 11 approval_required/8.4h on 2026-05-27. *)
     ("masc_plan_set_task", Low); (* "set" substring → High; payload is self-owned task plan metadata *)
     ("keeper_memory_write", Low); (* "write" substring → High; scoped to own keeper memory *)
-    ("masc_worktree_create", Medium); (* "create" substring → High; meta tooling, no code mutation *)
   ]
 
 let critical_patterns =

--- a/lib/tool_help_registry.ml
+++ b/lib/tool_help_registry.ml
@@ -182,7 +182,7 @@ let manual_help_entry name =
             "Returns the canonical short description, visibility metadata, and detailed help for a specific tool.";
           doc_refs = [ "docs/COMMAND-PLANE-RUNBOOK.md" ];
           prompt_hints = [ "Pair with prompt 'tool_help' when you want a ready-to-use explanation." ];
-          examples = [ "name='keeper_task_done'"; "name='masc_worktree_create'" ];
+          examples = [ "name='keeper_task_done'"; "name='masc_plan_set_task'" ];
           alternatives = [];
         }
   | "masc_tool_admin_snapshot" ->
@@ -332,28 +332,6 @@ let manual_help_entry name =
               "task_id='task-123'";
             ];
           alternatives = [];
-        }
-  | "masc_worktree_create" ->
-      Some
-        {
-          name;
-          short_description = "Create a git worktree linked to a MASC task.";
-          when_to_use =
-            "Use at the start of a task that needs an isolated working tree (3+ file modifications, multi-agent coordination, branch-based PR workflow).";
-          key_constraints =
-            [
-              "Branch name must follow the repo convention (feature/PK-… or fix/…).";
-              "Worktree path is repo-local under .worktrees/ — never absolute or outside the repo root.";
-            ];
-          details_markdown =
-            "Backed by git worktree add; the resulting path is recorded against the task so coordination tools can surface it.";
-          doc_refs = [ "instructions/workflow-git.md" ];
-          prompt_hints = [];
-          examples =
-            [
-              "branch='feat/rfc-0195-descriptor-enrichment' base='origin/main'";
-            ];
-          alternatives = [ "masc_worktree_remove" ];
         }
   | "masc_plan_set_task" ->
       Some

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1146,7 +1146,7 @@ let test_sandbox_worktree_write_rule_rejects_unclaimed_or_root_checkout () =
        ~input:root_checkout_input
        ~risk_level:AQ.High)
 
-let test_callback_production_worktree_create_auto_approved () =
+let test_callback_production_worktree_prepare_auto_approved () =
   with_test_config @@ fun config ->
   let pending_before = AQ.pending_count () in
   let cb =
@@ -1164,7 +1164,7 @@ let test_callback_production_worktree_create_auto_approved () =
       Alcotest.(check int) "no pending approval"
         pending_before (AQ.pending_count ())
   | Agent_sdk.Hooks.Reject r ->
-      Alcotest.fail ("expected Approve for worktree create, got Reject: " ^ r)
+      Alcotest.fail ("expected Approve for worktree preparation, got Reject: " ^ r)
   | _ -> Alcotest.fail "unexpected decision"
 
 let test_callback_paranoid_medium_risk_uses_remembered_policy () =
@@ -1474,8 +1474,8 @@ let () =
         "sandbox worktree write routine rejects unclaimed/root checkout"
         `Quick
         test_sandbox_worktree_write_rule_rejects_unclaimed_or_root_checkout;
-      Alcotest.test_case "production worktree create auto-approved" `Quick
-        test_callback_production_worktree_create_auto_approved;
+      Alcotest.test_case "production worktree preparation auto-approved" `Quick
+        test_callback_production_worktree_prepare_auto_approved;
       Alcotest.test_case "paranoid medium risk uses remembered policy" `Quick
         test_callback_paranoid_medium_risk_uses_remembered_policy;
       Alcotest.test_case "always_approve bypasses threshold" `Quick

--- a/test/test_tool_help_metadata_rfc_0195.ml
+++ b/test/test_tool_help_metadata_rfc_0195.ml
@@ -49,10 +49,9 @@ let lookup name =
    - Four are registered in Config.raw_all_tool_schemas and
      therefore round-trip through find_entry. Those are the
      ones this test pins.
-   - Two (masc_worktree_create, masc_plan_set_task) are
-     coordination-side tools whose schemas live on a different
-     surface that this PR does not modify. Their manual_help
-     entries are written here as future-proofing — they take
+   - One (masc_plan_set_task) is a coordination-side tool whose schema lives on
+     a different surface that this PR does not modify. Its manual_help
+     entry is written here as future-proofing — it takes
      effect the moment those schemas join the keeper-side
      registry. See PR body §"Reachable surface" for the split. *)
 let curated_with_examples =

--- a/test/test_tool_prefilter.ml
+++ b/test/test_tool_prefilter.ml
@@ -154,10 +154,10 @@ let test_synonym_code_read () =
   check bool "synonym: tool_read_file via 'read source'" true
     (has_tool "tool_read_file" result)
 
-let test_synonym_worktree_create () =
+let test_synonym_worktree_prepare () =
   let result = Tool_prefilter.filter
     ~tools:extended_tools ~query:"create a new worktree" ~k:3 in
-  check bool "synonym: tool_execute via 'create worktree'" true
+  check bool "synonym: tool_execute via worktree preparation request" true
     (has_tool "tool_execute" result)
 
 let test_synonym_web_search () =
@@ -260,7 +260,7 @@ let () =
           test_case "claim_next via synonym" `Quick test_synonym_claim_next;
           test_case "code_search via synonym" `Quick test_synonym_code_search;
           test_case "code_read via synonym" `Quick test_synonym_code_read;
-          test_case "worktree_create via synonym" `Quick test_synonym_worktree_create;
+          test_case "worktree preparation via synonym" `Quick test_synonym_worktree_prepare;
           test_case "web_search via synonym" `Quick test_synonym_web_search;
         ] );
       ( "zero_result",


### PR DESCRIPTION
## Summary

- removes the stale `masc_worktree_create` / `masc_worktree_remove` tool-name surface from help, risk overrides, docs, and tests
- rewrites worktree preparation as a typed `Execute` repository workflow instead of a standalone coordination tool
- removes stale worktree create/remove permission and event names from legacy spec docs

## Product impact

No runtime dispatch change. This is a surface cleanup: worktree preparation remains a repo-local workflow via typed `Execute` and explicit git argv.

## Evidence

- `rg -n "masc_worktree_create|masc_worktree_remove|worktree_create|worktree_remove|CanCreateWorktree|CanRemoveWorktree|Coord_git\\.create|Coord_git\\.remove|worktree tool|worktree helper|worktree wrapper" dashboard/src lib test config docs scripts --glob '!_build/**' --glob '!node_modules/**' --glob '!dashboard/design-system/ui_kits/**'`
- `ocamlformat --check lib/governance_pipeline_risk.ml lib/tool_help_registry.ml test/test_hitl_approval.ml test/test_tool_help_metadata_rfc_0195.ml test/test_tool_prefilter.ml`
- `git diff --check origin/main...HEAD`
- `pnpm exec vitest run --config vitest.config.ts src/keeper-store-normalize.test.ts --no-file-parallelism --maxWorkers=1` did not run because this worktree has no dashboard JS dependencies installed (`vitest` not found).
- `scripts/dune-local.sh build lib/governance_pipeline_risk.ml lib/tool_help_registry.ml test/test_hitl_approval.exe test/test_tool_help_metadata_rfc_0195.exe test/test_tool_prefilter.exe` did not run because the shared opam switch is pinned to agent_sdk `b70bfc56...`, while this branch expects `61ad57f...`; the suggested pin repair refused to downgrade below the shared floor.

## Direct evidence

The targeted retired worktree-tool-name scan returns no matches.

## GOAL LOOP ACT checklist

- [x] Removed stale worktree tool names from active help/risk/test/docs surfaces.
- [x] Preserved the repo worktree workflow as typed `Execute`.
- [x] Ran targeted grep, OCaml format, and diff checks.
- [x] Recorded unavailable test gates accurately.

## Review evidence

Review focus: wording/surface cleanup only. The branch should not alter actual worktree execution behavior.

## Linked issue

None.

## Variant addition checklist

- [x] No new tool variant.
- [x] No new public tool name.
- [x] No compatibility alias.
