### PR TITLE
feat: wire workflow rejection scope blocking to task claim (F4)

### DIFF
--- a/lib/keeper/keeper_task_owner_backend.ml
+++ b/lib/keeper/keeper_task_owner_backend.ml
@@ -117,5 +117,6 @@ let install_hooks () =
           (fun config ~agent_name -> transition_action_denylist_fn config ~agent_name)
       ; active_goal_phases_for_agent =
           (fun config ~agent_name -> active_goal_phases_for_agent_fn config ~agent_name)
+      ; workflow_scope_block_ttl_seconds = Keeper_tools_oas.workflow_block_ttl_seconds
       }
 ;;

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -147,7 +147,7 @@ let failure_count_jump_to counts key ~target =
    After this many seconds, a scope block expires and the agent may
    retry the same (tool, task, action) scope — e.g. after creating a PR
    externally and re-submitting for verification. *)
-let workflow_block_ttl_seconds = 1800.
+let workflow_block_ttl_seconds = Keeper_tools_oas_workflow.workflow_block_ttl_seconds
 
 let workflow_rejection_count_record counts key =
   Mutex.protect counts.mutex (fun () ->

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -49,6 +49,8 @@ type failure_counts
 
 val create_failure_counts : unit -> failure_counts
 
+val workflow_block_ttl_seconds : float
+
 val failure_count_get : failure_counts -> string -> int
 
 val failure_count_record_failure : failure_counts -> string -> int

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -82,11 +82,11 @@ let execute_with_observers
                      failure_counts
                      scope_key
                      info);
-                (* F4: also register the task ID in the global blocked-task
-                   registry so [claim_next_r] can exclude it. *)
+                (* F4: also register the task ID in the workspace-scoped
+                   blocked-task registry so [claim_next_r] can exclude it. *)
                 (match info.task_id with
                  | Some tid ->
-                   Tool_task_handlers.register_scope_blocked_task_id tid
+                   Tool_task.register_scope_blocked_task_id config tid
                  | None -> ())
               | None -> ());
             workflow_rejection_recovery_fields ~tool_name:name ~count raw_result

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -81,7 +81,13 @@ let execute_with_observers
                   (workflow_rejection_scope_block_record
                      failure_counts
                      scope_key
-                     info)
+                     info);
+                (* F4: also register the task ID in the global blocked-task
+                   registry so [claim_next_r] can exclude it. *)
+                (match info.task_id with
+                 | Some tid ->
+                   Tool_task_handlers.register_scope_blocked_task_id tid
+                 | None -> ())
               | None -> ());
             workflow_rejection_recovery_fields ~tool_name:name ~count raw_result
           | None -> [])

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -84,7 +84,7 @@ let execute_with_observers
                      info);
                 (* F4: also register the task ID in the workspace-scoped
                    blocked-task registry so [claim_next_r] can exclude it. *)
-                (match info.task_id with
+                (match workflow_task_id_of_input_or_info ~input info with
                  | Some tid ->
                    Tool_task.register_scope_blocked_task_id config tid
                  | None -> ())

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -86,7 +86,7 @@ let execute_with_observers
                    blocked-task registry so [claim_next_r] can exclude it. *)
                 (match workflow_task_id_of_input_or_info ~input info with
                  | Some tid ->
-                   Tool_task.register_scope_blocked_task_id config tid
+                   Tool_task.register_scope_blocked_task_id config ~task_id:tid
                  | None -> ())
               | None -> ());
             workflow_rejection_recovery_fields ~tool_name:name ~count raw_result

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -37,6 +37,11 @@ type workflow_rejection_block =
   ; blocked_at : float
   }
 
+(* TTL for workflow rejection scope blocks (#18500).
+   Shared with the task-claim exclusion registry so both loop breakers expire
+   together. *)
+let workflow_block_ttl_seconds = 1800.
+
 let json_assoc_field_opt = Json_util.assoc_member_opt
 let json_assoc_string_opt = Json_util.assoc_string_opt
 let detail_json_opt = Keeper_tools_oas_json.detail_json_opt
@@ -50,6 +55,12 @@ let json_nonempty_string_opt key json =
     let value = String.trim value in
     if String.equal value "" then None else Some value
   | _ -> None
+;;
+
+let workflow_task_id_of_input_or_info ~input (info : workflow_rejection_info) =
+  match json_nonempty_string_opt "task_id" input with
+  | Some _ as task_id -> task_id
+  | None -> info.task_id
 ;;
 
 let workflow_rejection_info_of_json json =

--- a/lib/keeper/keeper_tools_oas_workflow.mli
+++ b/lib/keeper/keeper_tools_oas_workflow.mli
@@ -115,6 +115,11 @@ val workflow_rejection_recovery_fields
 (** Extract a non-empty string value from JSON. *)
 val json_nonempty_string_opt : string -> Yojson.Safe.t -> string option
 
+val workflow_task_id_of_input_or_info
+  :  input:Yojson.Safe.t
+  -> workflow_rejection_info
+  -> string option
+
 (** Check if handoff_context has non-empty evidence_refs. *)
 val json_has_nonempty_evidence_refs : Yojson.Safe.t -> bool
 
@@ -136,6 +141,8 @@ type workflow_rejection_block =
   ; hint : string option
   ; blocked_at : float
   }
+
+val workflow_block_ttl_seconds : float
 
 (** Build structured recovery fields from a workflow rejection block. *)
 val workflow_rejection_scope_block_fields

--- a/lib/tool_task.mli
+++ b/lib/tool_task.mli
@@ -74,7 +74,7 @@ val build_verdict_sse_payload :
 
 (** F4: Register a task ID as scope-blocked by a workflow rejection.
     [handle_claim_next] excludes these IDs from the next claim cycle.
-    Entries expire after 1800s to match [Keeper_tools_oas.workflow_block_ttl_seconds]. *)
+    Entries expire with the shared workflow scope-block TTL. *)
 val register_scope_blocked_task_id : ?now:float -> Workspace.config -> string -> unit
 
 (** F4: Return currently scope-blocked task IDs (non-expired). *)

--- a/lib/tool_task.mli
+++ b/lib/tool_task.mli
@@ -75,7 +75,7 @@ val build_verdict_sse_payload :
 (** F4: Register a task ID as scope-blocked by a workflow rejection.
     [handle_claim_next] excludes these IDs from the next claim cycle.
     Entries expire after 1800s to match [Keeper_tools_oas.workflow_block_ttl_seconds]. *)
-val register_scope_blocked_task_id : string -> unit
+val register_scope_blocked_task_id : ?now:float -> Workspace.config -> string -> unit
 
 (** F4: Return currently scope-blocked task IDs (non-expired). *)
-val scope_blocked_task_ids : unit -> string list
+val scope_blocked_task_ids : Workspace.config -> string list

--- a/lib/tool_task.mli
+++ b/lib/tool_task.mli
@@ -71,3 +71,11 @@ val build_verdict_sse_payload :
   req:Anti_rationalization.review_request ->
   result:Anti_rationalization.review_result ->
   Yojson.Safe.t
+
+(** F4: Register a task ID as scope-blocked by a workflow rejection.
+    [handle_claim_next] excludes these IDs from the next claim cycle.
+    Entries expire after 1800s to match [Keeper_tools_oas.workflow_block_ttl_seconds]. *)
+val register_scope_blocked_task_id : string -> unit
+
+(** F4: Return currently scope-blocked task IDs (non-expired). *)
+val scope_blocked_task_ids : unit -> string list

--- a/lib/tool_task.mli
+++ b/lib/tool_task.mli
@@ -75,7 +75,8 @@ val build_verdict_sse_payload :
 (** F4: Register a task ID as scope-blocked by a workflow rejection.
     [handle_claim_next] excludes these IDs from the next claim cycle.
     Entries expire with the shared workflow scope-block TTL. *)
-val register_scope_blocked_task_id : ?now:float -> Workspace.config -> string -> unit
+val register_scope_blocked_task_id :
+  ?now:float -> Workspace.config -> task_id:string -> unit
 
 (** F4: Return currently scope-blocked task IDs (non-expired). *)
 val scope_blocked_task_ids : Workspace.config -> string list

--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -64,7 +64,11 @@ let blocked_task_ids_mutex = Mutex.create ()
 let blocked_task_key (config : Workspace.config) task_id = config.base_path, task_id
 
 let register_scope_blocked_task_id ?now config task_id =
-  let now = Option.value now ~default:(Time_compat.now ()) in
+  let now =
+    match now with
+    | Some now -> now
+    | None -> Time_compat.now ()
+  in
   let key = blocked_task_key config task_id in
   Mutex.protect blocked_task_ids_mutex (fun () ->
     Hashtbl.replace blocked_task_ids_table key now)

--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -35,6 +35,7 @@ type task_owner_hooks =
   ; agent_tool_names : Workspace.config -> agent_name:string -> string list option
   ; transition_action_denylist : Workspace.config -> agent_name:string -> string list
   ; active_goal_phases_for_agent : Workspace.config -> agent_name:string -> string list
+  ; workflow_scope_block_ttl_seconds : float
   }
 
 let default_task_owner_hooks =
@@ -43,6 +44,7 @@ let default_task_owner_hooks =
   ; agent_tool_names = (fun _ ~agent_name:_ -> None)
   ; transition_action_denylist = (fun _ ~agent_name:_ -> [])
   ; active_goal_phases_for_agent = (fun _ ~agent_name:_ -> [])
+  ; workflow_scope_block_ttl_seconds = 1800.
   }
 ;;
 
@@ -55,7 +57,7 @@ let current_task_owner_hooks () = Atomic.get task_owner_hooks
    [handle_claim_next] can exclude it from the next [claim_next_r] call. Entries
    expire with the same TTL as the per-tool workflow scope block. *)
 
-let blocked_task_ttl_seconds = Keeper_tools_oas_workflow.workflow_block_ttl_seconds
+let blocked_task_ttl_seconds () = (current_keeper_hooks ()).workflow_scope_block_ttl_seconds
 
 let blocked_task_ids_table : (string * string, float) Hashtbl.t = Hashtbl.create 16
 let blocked_task_ids_mutex = Mutex.create ()
@@ -79,7 +81,7 @@ let scope_blocked_task_ids config =
     let expired = ref [] in
     Hashtbl.iter
       (fun key blocked_at ->
-        if now -. blocked_at > blocked_task_ttl_seconds then
+        if now -. blocked_at > blocked_task_ttl_seconds () then
           expired := key :: !expired)
       blocked_task_ids_table;
     List.iter (fun k -> Hashtbl.remove blocked_task_ids_table k) !expired;

--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -50,6 +50,33 @@ let task_owner_hooks = Atomic.make default_task_owner_hooks
 let set_task_owner_hooks hooks = Atomic.set task_owner_hooks hooks
 let current_task_owner_hooks () = Atomic.get task_owner_hooks
 
+(* Workflow rejection scope-blocked task registry. When a tool execution yields
+   a [Block_scope] workflow rejection, the task ID is recorded here so that
+   [handle_claim_next] can exclude it from the next [claim_next_r] call. Entries
+   expire after [blocked_task_ttl_seconds] to match the per-keeper
+   [workflow_block_ttl_seconds] in [Keeper_tools_oas]. *)
+
+let blocked_task_ttl_seconds = 1800.
+
+let blocked_task_ids_table : (string, float) Hashtbl.t = Hashtbl.create 16
+let blocked_task_ids_mutex = Mutex.create ()
+
+let register_scope_blocked_task_id task_id =
+  Mutex.protect blocked_task_ids_mutex (fun () ->
+    Hashtbl.replace blocked_task_ids_table task_id (Time_compat.now ()))
+
+let scope_blocked_task_ids () =
+  Mutex.protect blocked_task_ids_mutex (fun () ->
+    let now = Time_compat.now () in
+    let expired = ref [] in
+    Hashtbl.iter
+      (fun task_id blocked_at ->
+        if now -. blocked_at > blocked_task_ttl_seconds then
+          expired := task_id :: !expired)
+      blocked_task_ids_table;
+    List.iter (fun k -> Hashtbl.remove blocked_task_ids_table k) !expired;
+    Hashtbl.fold (fun task_id _ acc -> task_id :: acc) blocked_task_ids_table [])
+
 open Tool_args
 
 (* RFC-0189: [Masc_domain] backend Error variants (Task_error /
@@ -454,7 +481,17 @@ let handle_claim_next ~tool_name ~start_time ctx _args =
      [handle_claim] above).  Workspace.claim_next_r operates on
      [~agent_name] alone; backlog read does not require an entry under
      agents_dir. *)
-  let result = Workspace.claim_next_r ctx.config ~agent_name:ctx.agent_name () in
+  (* F4: exclude tasks that are scope-blocked by prior workflow rejections.
+     The blocked-ID set is populated by [register_scope_blocked_task_id]
+     when a [Block_scope] workflow rejection is recorded. *)
+  let exclude_task_ids = scope_blocked_task_ids () in
+  let result =
+    Workspace.claim_next_r
+      ctx.config
+      ~agent_name:ctx.agent_name
+      ~exclude_task_ids
+      ()
+  in
   match result with
   | Workspace.Claim_next_claimed { message; task_id; _ } ->
     sync_owner_current_task_binding ctx;

--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -53,10 +53,9 @@ let current_task_owner_hooks () = Atomic.get task_owner_hooks
 (* Workflow rejection scope-blocked task registry. When a tool execution yields
    a [Block_scope] workflow rejection, the task ID is recorded here so that
    [handle_claim_next] can exclude it from the next [claim_next_r] call. Entries
-   expire after [blocked_task_ttl_seconds] to match the per-keeper
-   [workflow_block_ttl_seconds] in [Keeper_tools_oas]. *)
+   expire with the same TTL as the per-tool workflow scope block. *)
 
-let blocked_task_ttl_seconds = 1800.
+let blocked_task_ttl_seconds = Keeper_tools_oas_workflow.workflow_block_ttl_seconds
 
 let blocked_task_ids_table : (string * string, float) Hashtbl.t = Hashtbl.create 16
 let blocked_task_ids_mutex = Mutex.create ()

--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -57,7 +57,7 @@ let current_task_owner_hooks () = Atomic.get task_owner_hooks
    [handle_claim_next] can exclude it from the next [claim_next_r] call. Entries
    expire with the same TTL as the per-tool workflow scope block. *)
 
-let blocked_task_ttl_seconds () = (current_keeper_hooks ()).workflow_scope_block_ttl_seconds
+let blocked_task_ttl_seconds () = (current_task_owner_hooks ()).workflow_scope_block_ttl_seconds
 
 let blocked_task_ids_table : (string * string, float) Hashtbl.t = Hashtbl.create 16
 let blocked_task_ids_mutex = Mutex.create ()

--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -58,24 +58,33 @@ let current_task_owner_hooks () = Atomic.get task_owner_hooks
 
 let blocked_task_ttl_seconds = 1800.
 
-let blocked_task_ids_table : (string, float) Hashtbl.t = Hashtbl.create 16
+let blocked_task_ids_table : (string * string, float) Hashtbl.t = Hashtbl.create 16
 let blocked_task_ids_mutex = Mutex.create ()
 
-let register_scope_blocked_task_id task_id =
-  Mutex.protect blocked_task_ids_mutex (fun () ->
-    Hashtbl.replace blocked_task_ids_table task_id (Time_compat.now ()))
+let blocked_task_key (config : Workspace.config) task_id = config.base_path, task_id
 
-let scope_blocked_task_ids () =
+let register_scope_blocked_task_id ?now config task_id =
+  let now = Option.value now ~default:(Time_compat.now ()) in
+  let key = blocked_task_key config task_id in
+  Mutex.protect blocked_task_ids_mutex (fun () ->
+    Hashtbl.replace blocked_task_ids_table key now)
+
+let scope_blocked_task_ids config =
+  let base_path = config.Workspace.base_path in
   Mutex.protect blocked_task_ids_mutex (fun () ->
     let now = Time_compat.now () in
     let expired = ref [] in
     Hashtbl.iter
-      (fun task_id blocked_at ->
+      (fun key blocked_at ->
         if now -. blocked_at > blocked_task_ttl_seconds then
-          expired := task_id :: !expired)
+          expired := key :: !expired)
       blocked_task_ids_table;
     List.iter (fun k -> Hashtbl.remove blocked_task_ids_table k) !expired;
-    Hashtbl.fold (fun task_id _ acc -> task_id :: acc) blocked_task_ids_table [])
+    Hashtbl.fold
+      (fun (entry_base_path, task_id) _ acc ->
+        if String.equal entry_base_path base_path then task_id :: acc else acc)
+      blocked_task_ids_table
+      [])
 
 open Tool_args
 
@@ -484,7 +493,7 @@ let handle_claim_next ~tool_name ~start_time ctx _args =
   (* F4: exclude tasks that are scope-blocked by prior workflow rejections.
      The blocked-ID set is populated by [register_scope_blocked_task_id]
      when a [Block_scope] workflow rejection is recorded. *)
-  let exclude_task_ids = scope_blocked_task_ids () in
+  let exclude_task_ids = scope_blocked_task_ids ctx.config in
   let result =
     Workspace.claim_next_r
       ctx.config

--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -62,7 +62,7 @@ let blocked_task_ids_mutex = Mutex.create ()
 
 let blocked_task_key (config : Workspace.config) task_id = config.base_path, task_id
 
-let register_scope_blocked_task_id ?now config task_id =
+let register_scope_blocked_task_id ?now config ~task_id =
   let now =
     match now with
     | Some now -> now

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1307,6 +1307,38 @@ let test_workflow_rejection_scope_policy_block_scope () =
       (Keeper_tools_oas_workflow.workflow_rejection_should_scope_block info)
 ;;
 
+let test_workflow_rejection_task_id_prefers_input () =
+  let info task_id : Keeper_tools_oas_workflow.workflow_rejection_info =
+    { task_id
+    ; rule_id = Some "submit_verification_missing_evidence"
+    ; tool_suggestion = None
+    ; hint = None
+    ; scope_policy = Keeper_tools_oas_workflow.Block_scope
+    }
+  in
+  check
+    (option string)
+    "input task_id wins"
+    (Some "task-input")
+    (Keeper_tools_oas_workflow.workflow_task_id_of_input_or_info
+       ~input:(`Assoc [ "task_id", `String " task-input " ])
+       (info (Some "task-output")));
+  check
+    (option string)
+    "empty input falls back to rejection info"
+    (Some "task-output")
+    (Keeper_tools_oas_workflow.workflow_task_id_of_input_or_info
+       ~input:(`Assoc [ "task_id", `String " " ])
+       (info (Some "task-output")));
+  check
+    (option string)
+    "missing both stays none"
+    None
+    (Keeper_tools_oas_workflow.workflow_task_id_of_input_or_info
+       ~input:(`Assoc [])
+       (info None))
+;;
+
 let test_workflow_rejection_retry_policy_requires_explicit_markers () =
   let should_skip raw =
     match
@@ -1664,7 +1696,12 @@ let test_workflow_rejection_scope_blocks_transition_variants () =
               bool
               "first rejection asks self correction"
               true
-              (json_bool "self_correction_required" json)
+              (json_bool "self_correction_required" json);
+            check
+              bool
+              "input task_id registered for claim_next exclusion"
+              true
+              (List.mem "task-001" (Tool_task.scope_blocked_task_ids config))
           | Ok _ -> fail "missing verification evidence should reject");
          let variant_args =
            `Assoc
@@ -1992,6 +2029,10 @@ let () =
             "workflow rejection scope policy block_scope"
             `Quick
             test_workflow_rejection_scope_policy_block_scope
+        ; test_case
+            "workflow rejection task_id prefers input"
+            `Quick
+            test_workflow_rejection_task_id_prefers_input
         ; test_case
             "workflow rejection retry policy requires explicit markers"
             `Quick

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1361,7 +1361,7 @@ let () = test "handle_claim_next_excludes_scope_blocked_task" (fun () ->
     Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [ ("title", `String "Next eligible") ])
   in
-  Tool_task.register_scope_blocked_task_id ctx.config "task-001";
+  Tool_task.register_scope_blocked_task_id ctx.config ~task_id:"task-001";
   let result =
     Tool_task.handle_claim_next ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [])
   in
@@ -1376,7 +1376,7 @@ let () = test "scope_blocked_task_ids_expire" (fun () ->
   Tool_task.register_scope_blocked_task_id
     ~now:(Time_compat.now () -. 3600.)
     ctx.config
-    "task-001";
+    ~task_id:"task-001";
   let ids = Tool_task.scope_blocked_task_ids ctx.config in
   if List.mem "task-001" ids
   then failwith "expected expired scope-blocked task id to be pruned"
@@ -1384,7 +1384,9 @@ let () = test "scope_blocked_task_ids_expire" (fun () ->
 
 let () = test "scope_blocked_task_ids_are_workspace_scoped" (fun () ->
   let blocked_ctx = make_test_ctx_with_agent "blocked-agent" in
-  Tool_task.register_scope_blocked_task_id blocked_ctx.config "task-001";
+  Tool_task.register_scope_blocked_task_id
+    blocked_ctx.config
+    ~task_id:"task-001";
   let claim_ctx = make_test_ctx_with_agent "claim-agent" in
   let _ =
     Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 claim_ctx

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1351,6 +1351,58 @@ let () = test "handle_claim_next_returns_claim_observation" (fun () ->
           = ctx.agent_name)
 )
 
+let () = test "handle_claim_next_excludes_scope_blocked_task" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ =
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "Scope blocked") ])
+  in
+  let _ =
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "Next eligible") ])
+  in
+  Tool_task.register_scope_blocked_task_id ctx.config "task-001";
+  let result =
+    Tool_task.handle_claim_next ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [])
+  in
+  let message = Tool_result.message result in
+  assert (Tool_result.is_success result);
+  if not (str_contains message "task-002")
+  then failwith ("expected scope-blocked task-001 to be skipped, got: " ^ message)
+)
+
+let () = test "scope_blocked_task_ids_expire" (fun () ->
+  let ctx = make_test_ctx () in
+  Tool_task.register_scope_blocked_task_id
+    ~now:(Time_compat.now () -. 3600.)
+    ctx.config
+    "task-001";
+  let ids = Tool_task.scope_blocked_task_ids ctx.config in
+  if List.mem "task-001" ids
+  then failwith "expected expired scope-blocked task id to be pruned"
+)
+
+let () = test "scope_blocked_task_ids_are_workspace_scoped" (fun () ->
+  let blocked_ctx = make_test_ctx_with_agent "blocked-agent" in
+  Tool_task.register_scope_blocked_task_id blocked_ctx.config "task-001";
+  let claim_ctx = make_test_ctx_with_agent "claim-agent" in
+  let _ =
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 claim_ctx
+      (`Assoc [ ("title", `String "Same raw id, different workspace") ])
+  in
+  let result =
+    Tool_task.handle_claim_next
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      claim_ctx
+      (`Assoc [])
+  in
+  let message = Tool_result.message result in
+  assert (Tool_result.is_success result);
+  if not (str_contains message "task-001")
+  then failwith ("expected workspace-local task-001 to remain claimable, got: " ^ message)
+)
+
 let () =
   test "handle_claim_next_ignores_required_tools_without_server_surface" (fun () ->
     let ctx = make_test_ctx () in


### PR DESCRIPTION
## Summary

- Wire workflow rejection scope blocking to task claim path (audit finding F4)
- When a tool execution yields a `Block_scope` workflow rejection, the task ID is registered in a process-global blocked-task registry with 1800s TTL
- `handle_claim_next` reads this registry and passes blocked IDs as `~exclude_task_ids` to `claim_next_r`, preventing re-claim of tasks stuck in a workflow rejection loop

## Changes

| File | Change |
|------|--------|
| `lib/tool_task_handlers.ml` | Add `register_scope_blocked_task_id` / `scope_blocked_task_ids` with mutex-protected Hashtbl + TTL expiry. Wire `~exclude_task_ids` in `handle_claim_next` → `claim_next_r` |
| `lib/tool_task.mli` | Expose new F4 functions |
| `lib/keeper/keeper_tools_oas_handler_exec.ml` | Register task ID after `workflow_rejection_scope_block_record` |

## Test plan

- [x] `dune build` passes (0 new compile errors)
- [x] `test_tool_task_coverage` baseline: 19 pre-existing failures, 0 regressions
- [ ] CI full suite green

## Context

Audit report `masc-unresolved-root-cause-source-report-2026-05-19.html` finding F4: `Block_scope` workflow rejection types/logic exist in `keeper_tools_oas_workflow.ml`, state management exists in `keeper_tools_oas.ml` (`workflow_block_table`), but the wiring to task claim was missing. The `claim_next_r` function already accepts `~exclude_task_ids` — this PR connects the two.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>