### PR TITLE
fix(cascade): add fallback tiers to prevent cascade exhaustion

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -765,8 +765,10 @@ strategy = "failover"
 
 [tier.governance]
 # System-only baseline for governance / judge calls.
+# Added codex-spark.for-keeper-turn for provider diversity — GLM rate-limit
+# was a SPOF causing 16x/day OAS bridge timeouts and verification starvation.
 keeper-assignable = false
-members = ["glm-coding.glm-flashx", "openai_compat.deepseek-v4-flash.for-keeper-turn"]
+members = ["glm-coding.glm-flashx", "openai_compat.deepseek-v4-flash.for-keeper-turn", "cli_tool_a.codex-spark.for-keeper-turn"]
 strategy = "failover"
 
 [tier.tier_small]
@@ -794,7 +796,11 @@ strategy = "failover"
 # ── Tier-Groups (fallback chains) ──────────────────────────────
 
 [tier-group.primary]
-tiers = ["primary"]
+# Fallback chain: primary → __safe_lane. When all primary members
+# fail (RunPod unhealthy + GLM rate-limited + local_mtp down),
+# __safe_lane provides codex-spark + deepseek-v4-flash as last resort.
+# Fixes: cascade tier-group.primary exhausted (Issue #18524 cluster).
+tiers = ["primary", "__safe_lane"]
 strategy = "priority_tier"
 fallback = true
 
@@ -823,7 +829,11 @@ keeper-assignable = false
 [tier-group.strict_tool_candidates]
 # Tier-group for routes requiring tool_strict profile capabilities
 # (runtime_mcp_tools, runtime_tool_events, runtime_mcp_http_headers).
-tiers = ["strict_tool_candidates"]
+# Fallback: when RunPod (sole tool_strict provider) is unhealthy,
+# keeper_diverse provides alternative providers. The capability profile
+# filter will reject non-tool_strict providers, but this gives the
+# cascade a degradation path instead of immediate exhaustion.
+tiers = ["strict_tool_candidates", "keeper_diverse"]
 strategy = "priority_tier"
 fallback = true
 required_capability_profile = "tool_strict"


### PR DESCRIPTION
## Summary

- **tier-group.primary**: Added `__safe_lane` fallback tier — cascade now tries primary first, then __safe_lane as last resort
- **tier-group.strict_tool_candidates**: Added `keeper_diverse` fallback tier for tool_strict routes
- **tier.governance**: Added `cli_tool_a.codex-spark.for-keeper-turn` for provider diversity (GLM rate-limit SPOF)

## Root Cause Analysis

### Cluster 1 — Cascade Exhaustion
`tier-group.primary` had only `["primary"]` tier. When all 5 members failed (RunPod unhealthy + GLM rate-limited + local_mtp down), cascade died immediately at cycle 0.

**Fix**: `tiers = ["primary", "__safe_lane"]`. The declarative adapter (`cascade_declarative_adapter.ml:394-396`) auto-sets `max_cycles = max 1 (List.length tier_tiers) = 2`, so cycle 0 tries primary, cycle 1 tries __safe_lane.

### Cluster 2 — OAS/Governance Timeout
`tier.governance` had only GLM + deepseek. GLM rate-limit caused 16x/day OAS bridge timeouts.

**Fix**: Added `cli_tool_a.codex-spark.for-keeper-turn` as third provider.

### Cluster 3 — Verification Starvation
Downstream of Cluster 2 — 21 tasks stuck in `awaiting_verification` because verifiers couldn't get governance judge capacity.

**Fix**: Resolved by Cluster 2 fix (more governance capacity).

## Config-only change

No OCaml code modified. TOML parsed at runtime. Build passes.

RFC-WAIVED: config-only change, no code modification, no credential/identity/auth/sandbox involvement.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>