### PR TITLE
fix(keeper): add approve/reject to routine allowlist for verifier autonomy

### DIFF
--- a/lib/keeper/keeper_routine_allowlist.ml
+++ b/lib/keeper/keeper_routine_allowlist.ml
@@ -61,12 +61,16 @@ type rule = {
 let rules : rule list =
   [
     (* masc_transition: keeper task lifecycle. Only the routine actions
-       are allowlisted. cancel and force_* are intentionally excluded. *)
+       are allowlisted. cancel and force_* are intentionally excluded.
+       "approve" and "reject" are verifier-specific actions — without
+       them the verifier's autonomous verification workflow hits the
+       HITL approval gate and blocks indefinitely. *)
     {
       tool = "masc_transition";
       max_risk = RL.Medium;
       allowed_actions =
-        Some [ "claim"; "start"; "heartbeat"; "done"; "release" ];
+        Some [ "claim"; "start"; "heartbeat"; "done"; "release";
+               "approve"; "reject" ];
       label = "keeper_routine.masc_transition";
     };
 

--- a/test/test_keeper_routine_allowlist.ml
+++ b/test/test_keeper_routine_allowlist.ml
@@ -39,6 +39,18 @@ let test_transition_release_matches () =
     true
     (RA.matches ~tool_name:"masc_transition" ~input ~risk_level:RL.Low)
 
+let test_transition_approve_matches () =
+  let input = transition_input "approve" in
+  Alcotest.(check bool) "approve matches"
+    true
+    (RA.matches ~tool_name:"masc_transition" ~input ~risk_level:RL.Medium)
+
+let test_transition_reject_matches () =
+  let input = transition_input "reject" in
+  Alcotest.(check bool) "reject matches"
+    true
+    (RA.matches ~tool_name:"masc_transition" ~input ~risk_level:RL.Medium)
+
 (* ── matches: NOT allowlisted (still gated) ─────────────────── *)
 
 let test_transition_cancel_not_matched () =
@@ -354,6 +366,10 @@ let () =
             test_transition_done_matches;
           Alcotest.test_case "release auto-approves" `Quick
             test_transition_release_matches;
+          Alcotest.test_case "approve auto-approves" `Quick
+            test_transition_approve_matches;
+          Alcotest.test_case "reject auto-approves" `Quick
+            test_transition_reject_matches;
           Alcotest.test_case "case-insensitive action" `Quick
             test_case_insensitive_action;
         ] );


### PR DESCRIPTION
## Summary

- Verifier keeper's autonomous verification workflow was blocked at the governance pipeline HITL gate
- The `masc_transition` routine allowlist only included lifecycle actions (claim/start/heartbeat/done/release), but the verifier's two allowed actions (`approve`/`reject`) were exactly the ones NOT in the list
- This caused the verifier to block indefinitely on the `Keeper_approval_queue` Promise, making the entire verification flow non-functional

## Root Cause

The governance pipeline (`governance_pipeline.ml:388-401`) checks `Keeper_routine_allowlist.rule_label` first. If it returns `Some`, the call is auto-approved. If `None`, it falls through to HITL approval queue.

The `masc_transition` rule in `keeper_routine_allowlist.ml:68-69` had:
```ocaml
allowed_actions = Some [ "claim"; "start"; "heartbeat"; "done"; "release" ];
```

Missing: `"approve"` and `"reject"` — the verifier's only allowed actions per its `tool_denylist` in `verifier.toml:9-27`.

## Fix

Add `"approve"` and `"reject"` to the `masc_transition` allowed_actions. These are Low/Medium risk verification decisions, not destructive operations.

## Security Analysis

- The verifier's `tool_denylist` already restricts it to approve/reject only (all other lifecycle actions are denied)
- Other keepers don't have approve/reject on their tool surface — adding to the allowlist doesn't widen the attack surface
- `cancel` and `force_*` remain excluded from the allowlist
- Risk level stays at `Medium` — Critical risk would still require operator approval

## Test Plan

- [x] `dune build --root .` succeeds
- [x] `test_keeper_routine_allowlist` — 43/43 tests pass (including 2 new approve/reject tests)
- [ ] CI full test suite
- [ ] Manual verification: verifier keeper can autonomously approve/reject without HITL blocking

## Related

- Board post: p-ed71e577c808624bff2557a00a7ee120 (Verifier Tool Policy Gap — Recurring Blocker)
- Board post: p-650b7e127a3e342c571cd11477beef2b (Verification Bottleneck — Albini Follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)