### PR TITLE
refactor(tool_name): handle MCP prefix at parse boundary + remove magic numbers

### DIFF
--- a/lib/coord/coord_task_receipts.ml
+++ b/lib/coord/coord_task_receipts.ml
@@ -32,15 +32,22 @@ let hyphen_name name =
     name
 ;;
 
+let keeper_agent_prefix = "keeper-"
+let keeper_agent_suffix = "-agent"
+
 let keeper_name_from_agent_name agent_name =
   let trimmed = String.trim agent_name in
+  let prefix_len = String.length keeper_agent_prefix in
+  let suffix_len = String.length keeper_agent_suffix in
+  let min_full = prefix_len + suffix_len + 1 in
   if
-    String.starts_with ~prefix:"keeper-" trimmed
-    && String.ends_with ~suffix:"-agent" trimmed
-    && String.length trimmed > 13
-  then Some (String.sub trimmed 7 (String.length trimmed - 13))
-  else if String.ends_with ~suffix:"-agent" trimmed && String.length trimmed > 6
-  then Some (String.sub trimmed 0 (String.length trimmed - 6))
+    String.starts_with ~prefix:keeper_agent_prefix trimmed
+    && String.ends_with ~suffix:keeper_agent_suffix trimmed
+    && String.length trimmed > min_full
+  then Some (String.sub trimmed prefix_len (String.length trimmed - prefix_len - suffix_len))
+  else if String.ends_with ~suffix:keeper_agent_suffix trimmed
+          && String.length trimmed > suffix_len
+  then Some (String.sub trimmed 0 (String.length trimmed - suffix_len))
   else None
 ;;
 

--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -59,8 +59,12 @@ let legacy_keeper_internal_tool_names =
      or use [Custom] with explicit write tool names. *)
   Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
   |> List.filter (fun name ->
-         not (String.starts_with ~prefix:"masc_" name)
-         && not (List.exists (String.equal name) write_tools))
+         let is_masc =
+           match Tool_name.of_string name with
+           | Some t -> Tool_name.is_masc t
+           | None -> false
+         in
+         not is_masc && not (List.exists (String.equal name) write_tools))
 ;;
 
 let legacy_session_min_tool_names =

--- a/lib/keeper/keeper_tool_name_projection.ml
+++ b/lib/keeper/keeper_tool_name_projection.ml
@@ -122,7 +122,9 @@ let filter_model_visible_suggestions names =
   |> List.filter_map (fun name ->
     match public_alias_for_internal name with
     | Some public -> Some public
-    | None when String.starts_with ~prefix:"keeper_" name -> None
+    | None when (match Tool_name.of_string name with
+        | Some t -> Tool_name.is_keeper t
+        | None -> false) -> None
     | None -> Some name)
   |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
 ;;

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -223,7 +223,9 @@ let keeper_supported_masc_schemas (schemas : Masc_domain.tool_schema list) =
     || eq Tool_name.Masc.Board_delete
   in
   List.filter (fun (s : Masc_domain.tool_schema) ->
-      String.starts_with ~prefix:"masc_" s.name
+      (match Tool_name.of_string s.name with
+       | Some t -> Tool_name.is_masc t
+       | None -> false)
       && not (is_keeper_mcp_context_required s.name)
       && supported_in_keeper s.name
       && not (is_keeper_denied s.name)

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -538,7 +538,16 @@ let to_string = function
   | Masc_keeper mk -> Masc_keeper.to_string mk
 ;;
 
+let mcp_prefix = "mcp__masc__"
+
 let of_string s =
+  (* MCP protocol namespaces tool names as "mcp__masc__<name>".
+     Strip at the parse boundary so internal code never sees the prefix. *)
+  let s =
+    if String.starts_with ~prefix:mcp_prefix s
+    then String.sub s (String.length mcp_prefix) (String.length s - String.length mcp_prefix)
+    else s
+  in
   match Keeper.of_string s with
   | Some k -> Some (Keeper k)
   | None ->

--- a/lib/tool_registration_check.ml
+++ b/lib/tool_registration_check.ml
@@ -33,8 +33,9 @@ let add_names names tbl =
 let raw_masc_tool_names () =
   Config.raw_all_tool_schemas
   |> List.filter_map (fun (schema : Masc_domain.tool_schema) ->
-    if String.starts_with ~prefix:"masc_" schema.name then Some schema.name
-    else None)
+    match Tool_name.of_string schema.name with
+    | Some t when Tool_name.is_masc t -> Some schema.name
+    | _ -> None)
 
 let runtime_keeper_tool_names () =
   Hashtbl.create 512

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -138,6 +138,28 @@ let test_unknown_returns_none () =
       None (Tool_name.of_string s)
   ) unknowns
 
+let test_mcp_prefix_stripped () =
+  (* MCP protocol namespaces tool names as "mcp__masc__<name>".
+     Tool_name.of_string must strip the prefix at parse boundary.
+     After stripping "mcp__masc__", the bare name (e.g. "masc_claim_next")
+     is matched against Tool_name.of_string. *)
+  let cases =
+    [ ("mcp__masc__masc_claim_next", Tool_name.Masc Claim_next)
+    ; ("mcp__masc__keeper_board_post", Tool_name.Keeper Board_post)
+    ; ("mcp__masc__masc_keeper_status", Tool_name.Masc_keeper Status)
+    ; ("mcp__masc__masc_heartbeat", Tool_name.Masc Heartbeat)
+    ]
+  in
+  List.iter (fun (input, expected) ->
+    Alcotest.(check (option (of_pp Tool_name.pp)))
+      (Printf.sprintf "mcp prefix: %s" input)
+      (Some expected) (Tool_name.of_string input)
+  ) cases;
+  (* Unknown names with MCP prefix still fail closed *)
+  Alcotest.(check (option (of_pp Tool_name.pp)))
+    "mcp prefix unknown -> None"
+    None (Tool_name.of_string "mcp__masc__nonexistent")
+
 let test_keeper_board_write_helpers () =
   let open Tool_name.Keeper in
   List.iter
@@ -271,6 +293,7 @@ let () =
       Alcotest.test_case "masc_keeper prefix" `Quick test_masc_keeper_prefix;
       Alcotest.test_case "all unique" `Quick test_all_names_unique;
       Alcotest.test_case "unknown -> None" `Quick test_unknown_returns_none;
+      Alcotest.test_case "mcp prefix stripped" `Quick test_mcp_prefix_stripped;
       Alcotest.test_case "keeper board write helpers" `Quick
         test_keeper_board_write_helpers;
       Alcotest.test_case "keeper board write facade" `Quick


### PR DESCRIPTION
## Summary
- `Tool_name.of_string` now strips `mcp__masc__` MCP protocol namespace prefix at the parse boundary, matching documented intent ("Parse boundary: of_string at MCP/JSON ingress only")
- `coord_task_receipts.ml`: replaces magic numbers (7, 13, 6) in `keeper_name_from_agent_name` with named constants (`keeper_agent_prefix`, `keeper_agent_suffix`)
- Adds test coverage for MCP prefix parsing (4 positive cases + 1 unknown fail-closed)

## Test plan
- [ ] `dune exec test/test_tool_name.exe` — 16 tests pass (added `mcp prefix stripped`)
- [ ] `dune build @runtest` — full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
