### PR TITLE
refactor(keeper): SSOT facade for keeper_turn_slot.mli

### DIFF
--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -1,30 +1,20 @@
-exception Semaphore_wait_timeout of float
+(** Keeper Turn Slot — concurrency control for keeper turn execution.
 
-type slot_pool =
-  | Turn_pool
-  | Autonomous_pool
-  | Reactive_pool
+    Manages semaphores, fairness queuing, and slot diagnostics for
+    keeper turn concurrency.
 
-val slot_pool_to_string : slot_pool -> string
+    All type definitions ([slot_pool], [semaphore_wait_phase],
+    [semaphore_wait_timeout]) and their pure converters live in
+    {!Keeper_turn_slot_types}.  Re-exported here so callers can
+    continue using [Keeper_turn_slot.slot_pool] etc. without reaching
+    into the types submodule. *)
 
-type semaphore_wait_phase =
-  | Autonomous_queue_head
-  | Autonomous_slot
-  | Reactive_slot
-  | Turn_slot
+(** {1 SSOT Types} *)
+include module type of struct
+  include Keeper_turn_slot_types
+end
 
-val semaphore_wait_phase_to_string : semaphore_wait_phase -> string
-
-type semaphore_wait_timeout = {
-  timeout_wait_sec : float;
-  timeout_phase : semaphore_wait_phase;
-  timeout_autonomous_available : int;
-  timeout_reactive_available : int;
-  timeout_turn_available : int;
-  timeout_queue_depth : int;
-  timeout_queue_ahead : int option;
-  timeout_holders : (string * float) list;
-}
+(** {1 Own-module types and vals} *)
 
 (** Global turn slot cap. Safety ceiling for ALL keeper turns. *)
 val keeper_turn_throttle_limit : int


### PR DESCRIPTION
## Summary
- Replace manually redeclared types (`slot_pool`, `Semaphore_wait_timeout` exception, `semaphore_wait_phase`, `semaphore_wait_timeout`) with `include module type of struct include Keeper_turn_slot_types end`
- Types module is now the single source of truth for slot/pool/phase variants and wait-timeout payload
- Also brings in `int_of_env_default` helper previously hidden in the types module

## Changes
- `lib/keeper/keeper_turn_slot.mli`: 271 → 258 lines (−13)
- No changes to `.ml` implementation — interface-only refactor

## SSOT Pattern
Continues the `include module type of` pattern (6th module):
- `keeper_state_machine.mli` → `keeper_state_machine_types` (PR #19291)
- `keeper_execution_receipt.mli` → `keeper_execution_receipt_types` (PR #19292)
- `keeper_failure_circuit_breaker.mli` → `keeper_failure_circuit_breaker_types` (PR #19293)
- `keeper_runtime_manifest.mli` → `keeper_runtime_manifest_types` (PR #19295)
- `keeper_transition_audit.mli` → `keeper_transition_audit_types` (PR #19296)

## Test plan
- `dune build --root .` passes (verified locally)
- No behavioral change — type identity preserved via `include`

🤖 Generated with [Claude Code](https://claude.com/claude-code)