### PR TITLE
refactor(dashboard): consolidate SSOT for keeper phases and pipeline stages

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -76,9 +76,10 @@ type StatusFilter = 'all' | RuntimeBand
 type RosterStateNote = { label: string; text: string; kind?: string }
 type RosterPresenceDisplay = { status: string | null; detail: string | null }
 
+// PipelineStage SSOT: branches aligned to `types/core.ts#PipelineStage`.
+// Legacy `tool_use` / `scheduled_autonomous` / `thinking` removed — the
+// backend never emits them as pipeline_stage.
 function stageBadgeClass(stageKey: string): string {
-  if (stageKey === 'tool_use') return 'border-[var(--info-border)] bg-[var(--accent-12)] text-[var(--color-accent-fg)]'
-  if (stageKey === 'scheduled_autonomous' || stageKey === 'thinking') return 'border-[var(--ok-border)] bg-[var(--ok-soft)] text-[var(--color-status-ok)]'
   if (stageKey === 'handoff' || stageKey === 'compacting') return 'border-[var(--purple-24)] bg-[var(--purple-12)] text-[var(--stalled-fg)]'
   if (stageKey === 'failing' || stageKey === 'crashed') return 'border-[var(--err-border)] bg-[var(--bad-soft)] text-[var(--color-status-err)]'
   if (stageKey === 'paused') return 'border-[var(--purple-24)] bg-[var(--purple-12)] text-[var(--purple)]'

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -43,6 +43,7 @@ import {
   formatActivitySignal,
   formatLatency,
   formatPercent,
+  isOfflineDiagnosticHealthState,
   pressureClass,
   sourceCountClass,
   sourceDetail,
@@ -406,7 +407,7 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                   : null
               )
             const rowHintClass =
-              diagnosticState === 'offline' || diagnosticState === 'dead'
+              isOfflineDiagnosticHealthState(diagnosticState)
                 ? 'text-[var(--bad-light)]'
                 : 'text-[var(--color-status-warn)]'
             return html`

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -293,6 +293,15 @@ export function buildToolQualityMap(toolQuality: ToolQualityResponse): Map<strin
 
 type FleetBand = 'attention' | 'active' | 'paused' | 'offline'
 
+// Fleet offline status tokens — shared by `fleetBand()` and `statusClass()`.
+// Overlaps with `OFFLINE_DISPLAY_STATUSES` in keeper-classifiers.ts but
+// excludes `'inactive'`: fleet treats inactive as an attention signal
+// (line below), not a hard offline. This is an intentional semantic
+// divergence, not drift.
+const FLEET_OFFLINE_STATUSES: ReadonlySet<string> = new Set([
+  'offline', 'unbooted', 'stopped', 'dead', 'crashed',
+])
+
 function normalizedDiagnosticHealthState(row: FleetRow): string | null {
   return normalizeText(row.diagnostic_health_state)?.toLowerCase() ?? null
 }
@@ -311,11 +320,7 @@ export function fleetBand(row: FleetRow): FleetBand {
   if (
     !row.keepalive_running
     || isOfflineDiagnosticHealthState(diagnosticHealthState)
-    || normalizedStatus === 'offline'
-    || normalizedStatus === 'unbooted'
-    || normalizedStatus === 'stopped'
-    || normalizedStatus === 'dead'
-    || normalizedStatus === 'crashed'
+    || FLEET_OFFLINE_STATUSES.has(normalizedStatus)
   ) {
     return 'offline'
   }
@@ -503,11 +508,7 @@ export function statusClass(row: FleetRow): string {
   if (
     !row.keepalive_running
     || isOfflineDiagnosticHealthState(diagnosticHealthState)
-    || normalizedStatus === 'offline'
-    || normalizedStatus === 'stopped'
-    || normalizedStatus === 'unbooted'
-    || normalizedStatus === 'dead'
-    || normalizedStatus === 'crashed'
+    || FLEET_OFFLINE_STATUSES.has(normalizedStatus)
   ) {
     return 'text-[var(--bad-light)]'
   }

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -306,7 +306,7 @@ function normalizedDiagnosticHealthState(row: FleetRow): string | null {
   return normalizeText(row.diagnostic_health_state)?.toLowerCase() ?? null
 }
 
-function isOfflineDiagnosticHealthState(state: string | null): boolean {
+export function isOfflineDiagnosticHealthState(state: string | null): boolean {
   return state === 'offline' || state === 'dead'
 }
 

--- a/dashboard/src/components/keeper-detail-lifecycle.ts
+++ b/dashboard/src/components/keeper-detail-lifecycle.ts
@@ -9,9 +9,14 @@ import type { Keeper } from '../types'
 import { DialogOverlay } from './common/dialog'
 import { TextArea } from './common/input'
 import { Checkbox } from './common/checkbox'
+import { isOfflineStatus } from '../lib/keeper-classifiers'
 
 export function KeeperLifecycleButtons({ keeper, effectiveStatus }: { keeper: Keeper; effectiveStatus: string }) {
-  const isOffline = ['offline', 'inactive', 'dead', 'crashed', 'unbooted', 'stopped'].includes(effectiveStatus)
+  // SSOT: `isOfflineStatus` from keeper-classifiers.ts (includes crashed,
+  // unbooted, stopped). `'working'` is a UI-derived PulseState, not a
+  // backend agent status — kept inline for the running check since no
+  // SSOT predicate covers the full display-status union.
+  const isOffline = isOfflineStatus(effectiveStatus)
   const isRunning = ['active', 'running', 'idle', 'busy', 'listening', 'working'].includes(effectiveStatus)
 
   if (isOffline) return html`

--- a/dashboard/src/components/keeper-fsm-specs.ts
+++ b/dashboard/src/components/keeper-fsm-specs.ts
@@ -2,7 +2,8 @@
 // Each returns an FsmGraphSpec consumed by CytoscapeFsm.
 
 import type { FsmGraphSpec, FsmNode, FsmEdge } from './common/cytoscape-fsm'
-import { compositePhaseTone, toKsmPhase } from '../lib/keeper-operational-state'
+import { compositePhaseTone } from '../lib/keeper-operational-state'
+import { toKeeperPhase } from '../keeper-store-normalize'
 
 
 // ================================================================
@@ -143,7 +144,7 @@ export function buildCompositeFsmSpec(params: CompositeFsmParams): FsmGraphSpec 
   // `fsm-hub-invariant-analysis.ts` (N-of-M anti-pattern). Unknown wire
   // values fall back to 'active' to match the previous fall-through
   // semantics of the inline OR chain.
-  const ksmPhase = toKsmPhase(params.phase)
+  const ksmPhase = toKeeperPhase(params.phase)
   const ksmTone: 'active' | 'warn' | 'err' = ksmPhase === null ? 'active' : compositePhaseTone(ksmPhase)
   const nodes: FsmNode[] = [
     ...clusterNodes('KSM', 'KSM · keeper lifecycle', KSM_STATES, params.phase, ksmTone),

--- a/dashboard/src/components/live/keeper-health-strip.ts
+++ b/dashboard/src/components/live/keeper-health-strip.ts
@@ -25,8 +25,10 @@ function pressureColor(ratio: number): string {
   return 'bg-[var(--color-status-ok)]'
 }
 
-function stageIndicator(stage: string): string {
-  if (stage === 'thinking') return 'border-[var(--color-accent-soft)]'
+// PipelineStage SSOT: `types/core.ts#PipelineStage` does not include
+// `'thinking'` (that's a trajectory content type). The prior check for
+// `stage === 'thinking'` was dead code.
+function stageIndicator(_stage: string): string {
   return 'border-transparent'
 }
 

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -31,6 +31,7 @@ import { openTaskDetail } from '../goals/task-detail-state'
 import { nowSecondsSignal, useNowSecondsTicker } from '../../lib/now-signal'
 import { keeperDisplayStatus } from '../../lib/keeper-runtime-display'
 import { isKeeperPaused } from '../../lib/keeper-predicates'
+import { isAgentOffline } from '../../lib/agent-status'
 
 // ─── Alert Panel ─────────────────────────────────────────────────────────────
 
@@ -53,7 +54,7 @@ export interface TaskAlert {
 /** Derive a list of failing / offline agent alerts from the live agent list. */
 export function deriveAgentAlerts(agentList: readonly Agent[]): AgentAlert[] {
   return agentList
-    .filter(a => a.status === 'offline' || a.status === 'inactive')
+    .filter(a => isAgentOffline(a))
     .map(a => ({
       name: a.name,
       display: a.koreanName && a.koreanName !== '' ? a.koreanName : a.name,

--- a/dashboard/src/lib/keeper-classifiers.test.ts
+++ b/dashboard/src/lib/keeper-classifiers.test.ts
@@ -36,7 +36,7 @@ describe('keeperPriority', () => {
 })
 
 describe('isOfflineStatus', () => {
-  it.each(['offline', 'inactive', 'dead', 'crashed'])
+  it.each(['offline', 'inactive', 'dead', 'crashed', 'unbooted', 'stopped'])
   ('returns true for %s', (status) => {
     expect(isOfflineStatus(status)).toBe(true)
   })

--- a/dashboard/src/lib/keeper-classifiers.test.ts
+++ b/dashboard/src/lib/keeper-classifiers.test.ts
@@ -12,7 +12,7 @@ import {
 import type { KeeperPriority, LibCrashCategory } from './keeper-classifiers'
 
 describe('keeperPriority', () => {
-  it.each(['active', 'running', 'thinking', 'tool_use', 'claimed', 'in_progress'] as const)
+  it.each(['active', 'running', 'busy', 'listening', 'claimed', 'in_progress'] as const)
   ('returns 1 for active status: %s', (status) => {
     expect(keeperPriority(status)).toBe<KeeperPriority>(1)
   })
@@ -28,6 +28,10 @@ describe('keeperPriority', () => {
     expect(keeperPriority('crashed')).toBe<KeeperPriority>(2)
     expect(keeperPriority('')).toBe<KeeperPriority>(2)
     expect(keeperPriority('something_new')).toBe<KeeperPriority>(2)
+    // Trajectory content types are NOT keeper statuses — they map to
+    // intermediate priority (2), not active (1).
+    expect(keeperPriority('thinking')).toBe<KeeperPriority>(2)
+    expect(keeperPriority('tool_use')).toBe<KeeperPriority>(2)
   })
 })
 

--- a/dashboard/src/lib/keeper-classifiers.ts
+++ b/dashboard/src/lib/keeper-classifiers.ts
@@ -13,8 +13,12 @@
 
 export type KeeperPriority = 1 | 2 | 3
 
+// Agent/keeper status SSOT: values from `types/core.ts#AgentStatus` plus
+// backend-emitted defaults (`'offline'`, `'unknown'`). Trajectory content
+// types (`'thinking'`, `'tool_use'`) are NOT keeper statuses — they live
+// in a different axis (trajectory event kind).
 const ACTIVE_STATUSES: ReadonlySet<string> = new Set([
-  'active', 'running', 'thinking', 'tool_use', 'claimed', 'in_progress',
+  'active', 'running', 'busy', 'listening', 'claimed', 'in_progress',
 ])
 
 /** Terminal statuses for waterfall priority — does NOT include 'crashed'

--- a/dashboard/src/lib/keeper-classifiers.ts
+++ b/dashboard/src/lib/keeper-classifiers.ts
@@ -28,9 +28,10 @@ const PRIORITY_TERMINAL_STATUSES: ReadonlySet<string> = new Set([
 ])
 
 /** Offline display statuses — includes 'crashed' (keeper is not running
- *  but was recently active). Used for UI contextual messages, not sorting. */
+ *  but was recently active) and 'unbooted'/'stopped' (lifecycle terminal).
+ *  Used for UI contextual messages, not sorting. */
 const OFFLINE_DISPLAY_STATUSES: ReadonlySet<string> = new Set([
-  'offline', 'inactive', 'dead', 'crashed',
+  'offline', 'inactive', 'dead', 'crashed', 'unbooted', 'stopped',
 ])
 
 /** Classify keeper status into a priority tier for waterfall display ordering.

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -10,10 +10,10 @@ import {
   deriveKeeperDisplayReason,
   deriveKeeperOperationalState,
   deriveKeeperTurnPhase,
-  toKsmPhase,
   type KeeperAttention,
-  type KeeperKsmPhase,
 } from './keeper-operational-state'
+import { toKeeperPhase } from '../keeper-store-normalize'
+import type { KeeperPhase } from '../types/core'
 
 function makeKeeper(overrides: Partial<Keeper> = {}): Keeper {
   return {
@@ -446,37 +446,46 @@ interface DeriveInputsLite {
   composite: KeeperCompositeSnapshot | null
 }
 
-describe('toKsmPhase — RFC-0135 PR-11 wire-boundary narrow', () => {
-  it.each<KeeperKsmPhase>([
-    'offline', 'running', 'failing', 'overflowed', 'compacting',
-    'handing_off', 'draining', 'paused', 'stopped', 'crashed',
-    'restarting', 'dead', 'zombie',
-  ])('accepts canonical KSM phase %s', (phase) => {
-    expect(toKsmPhase(phase)).toBe(phase)
+describe('toKeeperPhase — wire-boundary narrow (lowercase + PascalCase)', () => {
+  it.each<KeeperPhase>([
+    'Offline', 'Running', 'Failing', 'Overflowed', 'Compacting',
+    'HandingOff', 'Draining', 'Paused', 'Stopped', 'Crashed',
+    'Restarting', 'Dead', 'Zombie',
+  ])('accepts PascalCase KeeperPhase %s', (phase) => {
+    expect(toKeeperPhase(phase)).toBe(phase)
+  })
+  it.each([
+    ['offline', 'Offline'],
+    ['running', 'Running'],
+    ['failing', 'Failing'],
+    ['handing_off', 'HandingOff'],
+    ['dead', 'Dead'],
+  ])('accepts lowercase wire format %s → %s', (input, expected) => {
+    expect(toKeeperPhase(input)).toBe(expected)
   })
   it('returns null on unknown string', () => {
-    expect(toKsmPhase('plotting_revenge')).toBeNull()
+    expect(toKeeperPhase('plotting_revenge')).toBeNull()
   })
   it('returns null on null/undefined', () => {
-    expect(toKsmPhase(null)).toBeNull()
-    expect(toKsmPhase(undefined)).toBeNull()
+    expect(toKeeperPhase(null)).toBeNull()
+    expect(toKeeperPhase(undefined)).toBeNull()
   })
   it('returns null on empty string', () => {
-    expect(toKsmPhase('')).toBeNull()
+    expect(toKeeperPhase('')).toBeNull()
   })
 })
 
-describe('compositePhaseTone — RFC-0135 PR-11 exhaustive switch', () => {
-  it.each<KeeperKsmPhase>(['offline', 'running'])('phase %s ⇒ active', (phase) => {
+describe('compositePhaseTone — exhaustive switch over KeeperPhase', () => {
+  it.each<KeeperPhase>(['Offline', 'Running'])('phase %s ⇒ active', (phase) => {
     expect(compositePhaseTone(phase)).toBe('active')
   })
-  it.each<KeeperKsmPhase>([
-    'overflowed', 'compacting', 'handing_off', 'draining', 'paused', 'restarting',
+  it.each<KeeperPhase>([
+    'Overflowed', 'Compacting', 'HandingOff', 'Draining', 'Paused', 'Restarting',
   ])('phase %s ⇒ warn', (phase) => {
     expect(compositePhaseTone(phase)).toBe('warn')
   })
-  it.each<KeeperKsmPhase>([
-    'failing', 'stopped', 'crashed', 'dead', 'zombie',
+  it.each<KeeperPhase>([
+    'Failing', 'Stopped', 'Crashed', 'Dead', 'Zombie',
   ])('phase %s ⇒ err', (phase) => {
     expect(compositePhaseTone(phase)).toBe('err')
   })

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -247,64 +247,32 @@ function computeKeeperAttention(
 // invariant-analysis (N-of-M anti-pattern; software-development.md
 // §AI 코드 생성 안티패턴 #2).
 //
-// `KeeperKsmPhase` is the closed sum of states emitted by the backend
-// KeeperStateMachine TLA spec (KSM_STATES in keeper-fsm-specs.ts).
-// `compositePhaseTone` is total and exhaustive — adding a new variant
-// here requires touching every consumer at compile time.
-
-export type KeeperKsmPhase =
-  | 'offline'
-  | 'running'
-  | 'failing'
-  | 'overflowed'
-  | 'compacting'
-  | 'handing_off'
-  | 'draining'
-  | 'paused'
-  | 'stopped'
-  | 'crashed'
-  | 'restarting'
-  | 'dead'
-  | 'zombie'
-
-const KSM_PHASE_VALUES: ReadonlySet<string> = new Set<KeeperKsmPhase>([
-  'offline', 'running', 'failing', 'overflowed', 'compacting',
-  'handing_off', 'draining', 'paused', 'stopped', 'crashed',
-  'restarting', 'dead', 'zombie',
-])
-
-/** Narrow `string` to `KeeperKsmPhase` if it is a known value, else
- *  return `null`. Use at the schema/wire boundary; downstream code
- *  should consume the typed sum directly. */
-export function toKsmPhase(raw: string | null | undefined): KeeperKsmPhase | null {
-  if (raw == null) return null
-  return KSM_PHASE_VALUES.has(raw) ? (raw as KeeperKsmPhase) : null
-}
-
 /** Three-valued tone classification used by FSM-graph node rendering
  *  and invariant cards: terminal/error phases → 'err', long-running
  *  rare-state phases → 'warn', live forward-progress phases → 'active'.
  *
- *  Exhaustive over `KeeperKsmPhase`. If TypeScript reports a missing
+ *  Exhaustive over `KeeperPhase` (the SSOT PascalCase sum from
+ *  `types/core.ts`). Callers with a lowercase wire-format string should
+ *  narrow via `toKeeperPhase` first. If TypeScript reports a missing
  *  case after adding a new variant, route it to the appropriate tone —
  *  do not add a `default:` (RFC-0135 §9-4 forbids catch-all). */
-export function compositePhaseTone(phase: KeeperKsmPhase): 'active' | 'warn' | 'err' {
+export function compositePhaseTone(phase: KeeperPhase): 'active' | 'warn' | 'err' {
   switch (phase) {
-    case 'offline':
-    case 'running':
+    case 'Offline':
+    case 'Running':
       return 'active'
-    case 'overflowed':
-    case 'compacting':
-    case 'handing_off':
-    case 'draining':
-    case 'paused':
-    case 'restarting':
+    case 'Overflowed':
+    case 'Compacting':
+    case 'HandingOff':
+    case 'Draining':
+    case 'Paused':
+    case 'Restarting':
       return 'warn'
-    case 'failing':
-    case 'stopped':
-    case 'crashed':
-    case 'dead':
-    case 'zombie':
+    case 'Failing':
+    case 'Stopped':
+    case 'Crashed':
+    case 'Dead':
+    case 'Zombie':
       return 'err'
   }
 }

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -204,6 +204,7 @@ const RUNNING_STATUS_TOKENS = new Set<string>([
   'running',
   'idle',
   'busy',
+  'listening',
 ])
 
 const RUNNING_PHASES_EXCLUDING_RESTARTING: ReadonlySet<string> = new Set<string>([

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -105,6 +105,7 @@ const STAGE_PHASE_EQUIVALENTS: Record<string, string> = {
   compacting: 'Compacting',
   handoff: 'HandingOff',
   failing: 'Failing',
+  overflowed: 'Overflowed',
   draining: 'Draining',
   paused: 'Paused',
   crashed: 'Crashed',

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -76,19 +76,23 @@ const PHASE_LABELS: Record<string, PhaseMeta> = {
   unknown: UNKNOWN_PHASE_META,
 }
 
+// PipelineStage SSOT: `types/core.ts#PipelineStage` (10 values from
+// `Keeper_status_runtime.pipeline_stage_of_phase`). Legacy entries
+// `thinking` / `tool_use` / `scheduled_autonomous` removed — the backend
+// never emits them as pipeline_stage (they live in trajectory
+// content_type / turn channel respectively).
 const STAGE_LABELS: Record<string, StageMeta> = {
   idle: { key: 'idle', label: '활동 없음', description: '지금 진행 중인 세부 활동 단계가 없습니다.' },
-  thinking: { key: 'thinking', label: '사고', description: '응답이나 다음 액션을 결정하는 중입니다.' },
-  tool_use: { key: 'tool_use', label: '도구', description: '도구를 호출하거나 결과를 소비하는 중입니다.' },
   compacting: { key: 'compacting', label: '압축', description: '컨텍스트 압축 단계를 수행 중입니다.' },
   handoff: { key: 'handoff', label: '승계', description: '같은 keeper를 새 trace와 새 세대로 이어붙이는 중입니다.' },
-  scheduled_autonomous: { key: 'scheduled_autonomous', label: '자율', description: '예약된 자율 턴을 수행 중입니다.' },
+  offline: { key: 'offline', label: '오프라인', description: '활동 정보를 확인하지 못했습니다.' },
   failing: { key: 'failing', label: '오류', description: '세부 파이프라인 단계에서 오류를 감지했습니다.' },
+  overflowed: { key: 'overflowed', label: '초과', description: '파이프라인이 용량을 초과했습니다.' },
   draining: { key: 'draining', label: '종료', description: '활동 종료를 위해 파이프라인을 비우는 중입니다.' },
   paused: { key: 'paused', label: '일시정지', description: '활동 단계도 함께 정지된 상태입니다.' },
   crashed: { key: 'crashed', label: '중단', description: '파이프라인 실행이 비정상 종료되었습니다.' },
   restarting: { key: 'restarting', label: '재시작', description: '파이프라인을 다시 올리는 중입니다.' },
-  offline: OFFLINE_STAGE_META,
+  unknown: { key: 'unknown', label: '미상', description: '파이프라인 단계 정보가 없습니다.' },
 }
 
 const DEFAULT_PHASE_BY_BAND: Partial<Record<RuntimeBand, string>> = {

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -76,7 +76,7 @@ const PHASE_LABELS: Record<string, PhaseMeta> = {
   unknown: UNKNOWN_PHASE_META,
 }
 
-// PipelineStage SSOT: `types/core.ts#PipelineStage` (10 values from
+// PipelineStage SSOT: `types/core.ts#PipelineStage` (11 values from
 // `Keeper_status_runtime.pipeline_stage_of_phase`). Legacy entries
 // `thinking` / `tool_use` / `scheduled_autonomous` removed — the backend
 // never emits them as pipeline_stage (they live in trajectory

--- a/dashboard/src/lib/unified-status.ts
+++ b/dashboard/src/lib/unified-status.ts
@@ -26,7 +26,8 @@ export function resolveUnifiedStatus(
   const primary = (keeperStatus ?? agentStatus ?? '').toLowerCase()
   const signal = (signalTruth ?? '').toLowerCase()
 
-  // Offline / inactive — process not running
+  // Offline / inactive — process not running.
+  // Matches agent-status.ts SSOT: isAgentOffline checks the same two tokens.
   if (primary === 'offline' || primary === 'inactive') {
     return {
       canonical: 'offline',
@@ -47,7 +48,8 @@ export function resolveUnifiedStatus(
     }
   }
 
-  // Active states
+  // Active states. `'working'` is a UI-derived PulseState, not a backend
+  // agent status — intentionally outside ACTIVE_STATUSES SSOT.
   if (primary === 'active' || primary === 'running' || primary === 'busy' || primary === 'working') {
     const desc = signal === 'stale'
       ? '프로세스 활성 (미션 활동은 오래됨)'

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -1,6 +1,7 @@
 import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
 import { normalizeKeeperTrust } from './keeper-store-normalize'
 import { normalizeStopCause } from './lib/stop-cause'
+import { parseAgentStatus } from './lib/agent-status'
 import type {
   Agent, Task, Message, ServerStatus,
   DashboardExecutionSummary, DashboardExecutionHandoff,
@@ -38,19 +39,11 @@ import type {
 
 export function normalizeAgentStatus(value: unknown): Agent['status'] {
   const raw = typeof value === 'string' ? value.trim().toLowerCase() : ''
-  if (
-    raw === 'active'
-    || raw === 'busy'
-    || raw === 'listening'
-    || raw === 'idle'
-    || raw === 'inactive'
-    || raw === 'offline'
-  ) {
-    return raw
-  }
+  // Backend aliases that normalize to canonical AgentStatus tokens.
   if (raw === 'in_progress' || raw === 'claimed') return 'busy'
   if (raw === 'dead' || raw === 'left') return 'offline'
-  return undefined
+  // Canonical tokens — validated by parseAgentStatus SSOT.
+  return parseAgentStatus(raw) ?? undefined
 }
 
 export function normalizeTaskStatus(value: unknown): Task['status'] {


### PR DESCRIPTION
## Summary

Dashboard 코드에서 keeper phase, pipeline stage, agent status의 SSOT를 정리합니다.

### 변경 1: KeeperKsmPhase 제거
- `keeper-operational-state.ts`: 중복 타입 `KeeperKsmPhase` 제거, `KeeperPhase` (PascalCase, `types/core.ts`) SSOT로 통합
- `keeper-fsm-specs.ts`: `toKsmPhase` → `toKeeperPhase` 마이그레이션
- `keeper-operational-state.test.ts`: 테스트 값 lowercase → PascalCase 변경

### 변경 2: Pipeline Stage 정리
- `monitoring-runtime.ts`: `STAGE_LABELS`에서 백엔드가 절대 emit하지 않는 legacy entries 3개 제거 (`thinking`, `tool_use`, `scheduled_autonomous`), `PipelineStage` 타입에 맞게 11 entries로 정렬
- `agent-roster.ts`: `stageBadgeClass`의 dead branches 3개 제거

### 변경 3: Status Classifier 정리
- `keeper-classifiers.ts`: `ACTIVE_STATUSES`에서 trajectory content types (`'thinking'`, `'tool_use'`) 제거, 유효한 agent statuses (`'busy'`, `'listening'`) 추가
- `keeper-health-strip.ts`: `stageIndicator`의 dead branch 제거 (`'thinking'`은 PipelineStage에 없음)
- `keeper-classifiers.test.ts`: 테스트 업데이트 + trajectory type regression coverage 추가

## Motivation

3개 축의 SSOT가 각각 `types/core.ts`에 정의되어 있지만, Dashboard 여러 파일이 문자열 리터럴이나 중복 타입을 사용:

| 축 | SSOT | 값 | 이전 문제 |
|---|---|---|---|
| KeeperPhase | `types/core.ts` (PascalCase) | 13 values | `KeeperKsmPhase` (lowercase 복사본) 존재 |
| PipelineStage | `types/core.ts` | 11 values | `thinking`/`tool_use`/`scheduled_autonomous` (다른 축의 값) 혼입 |
| AgentStatus | `types/core.ts` | 4+2 values | `ACTIVE_STATUSES`에 trajectory types 혼입 |

## Test plan
- [x] `tsc --noEmit` 통과
- [x] `vitest run` 6655/6656 pass (기존 a11y test failure 1건은 무관)
- [ ] CodeRabbit 리뷰 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)