### PR TITLE
fix(keeper): add Coding to tool_preset ADT

### DIFF
--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -12,6 +12,7 @@ type tool_preset =
   | Messaging
   | Dispatch
   | Research
+  | Coding
   | Delivery
   | Full
 
@@ -73,6 +74,7 @@ let tool_preset_to_string = function
   | Messaging -> "messaging"
   | Dispatch -> "dispatch"
   | Research -> "research"
+  | Coding -> "coding"
   | Delivery -> "delivery"
   | Full -> "full"
 ;;
@@ -85,7 +87,7 @@ let tool_preset_to_string = function
     Adding another constructor will fail compilation in
     [tool_preset_to_string] and in the witness test. *)
 let all_tool_presets =
-  [ Minimal; Social; Messaging; Dispatch; Research; Delivery; Full ]
+  [ Minimal; Social; Messaging; Dispatch; Research; Coding; Delivery; Full ]
 ;;
 
 let valid_tool_preset_strings = List.map tool_preset_to_string all_tool_presets
@@ -97,6 +99,7 @@ let tool_preset_of_string raw =
   | "messaging" -> Some Messaging
   | "dispatch" -> Some Dispatch
   | "research" -> Some Research
+  | "coding" -> Some Coding
   | "delivery" -> Some Delivery
   | "full" -> Some Full
   | _ -> None

--- a/lib/keeper/keeper_meta_tool_access.mli
+++ b/lib/keeper/keeper_meta_tool_access.mli
@@ -9,6 +9,7 @@ type tool_preset =
   | Messaging
   | Dispatch
   | Research
+  | Coding
   | Delivery
   | Full
 

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -9,7 +9,7 @@ module Persona_contract = Keeper_persona_authoring_contract
     -> Keeper_schema), so the test in [test_types.ml :: tool_preset_ssot]
     asserts these two lists stay in sync. *)
 let tool_preset_enum_strings =
-  [ "minimal"; "social"; "messaging"; "dispatch"; "research"; "delivery"; "full" ]
+  [ "minimal"; "social"; "messaging"; "dispatch"; "research"; "coding"; "delivery"; "full" ]
 
 (** Issue #8467: canonical strings for [Keeper_types_profile.sandbox_profile],
     [network_mode], . Same cycle constraint as

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -116,13 +116,14 @@ let preset_name_of_tool_preset = function
   | Messaging -> "messaging"
   | Dispatch -> "dispatch"
   | Research -> "research"
+  | Coding -> "coding"
   | Delivery -> "delivery"
   | Full -> "full"
 
 (* ── Privileged operation gates ------------------------------------ *)
 
 let preset_allows_privileged_operations = function
-  | Delivery | Full -> true
+  | Coding | Delivery | Full -> true
   | Minimal | Social | Messaging | Dispatch | Research -> false
 
 let allows_workflow_for_preset (preset : tool_preset) : bool =

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -92,6 +92,7 @@ type tool_preset =
   | Messaging
   | Dispatch
   | Research
+  | Coding
   | Delivery
   | Full
 

--- a/lib/keeper/keeper_types_profile_toml_normalizers.ml
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.ml
@@ -61,7 +61,7 @@ let lower_string_list_opt = function
   | xs -> Some (List.map String.lowercase_ascii xs)
 
 let valid_tool_preset_raw_strings =
-  [ "minimal"; "social"; "messaging"; "dispatch"; "research"; "delivery"; "full" ]
+  [ "minimal"; "social"; "messaging"; "dispatch"; "research"; "coding"; "delivery"; "full" ]
 
 let normalize_tool_preset_raw raw =
   let normalized = String.trim (String.lowercase_ascii raw) in

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -345,7 +345,7 @@ let () =
         ) ["worker"; "admin"]);
     ];
     "tool_preset_ssot", [
-      (* Issue #8430: witness covers all 7 variants — adding an 8th
+      (* Issue #8430: witness covers all 8 variants — adding a 9th
          constructor will fail to compile here AND in
          tool_preset_to_string. *)
       Alcotest.test_case "witness covers all variants" `Quick (fun () ->
@@ -356,8 +356,8 @@ let () =
             Alcotest.failf "tool_preset_to_string %S not in valid_tool_preset_strings" actual
         in
         witness Minimal; witness Social; witness Messaging; witness Dispatch; witness Research;
-        witness Delivery; witness Full;
-        Alcotest.(check int) "count" 7 (List.length valid_tool_preset_strings));
+        witness Coding; witness Delivery; witness Full;
+        Alcotest.(check int) "count" 8 (List.length valid_tool_preset_strings));
       Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
         (* Keeper_schema.tool_preset_enum_strings is a hand-mirrored copy
            of Keeper_types.valid_tool_preset_strings (cycle-avoidance).


### PR DESCRIPTION
## Summary

- `tool_policy.toml` defines `[presets.coding]` but OCaml `tool_preset` ADT lacked the `Coding` constructor
- Runtime emitted `"invalid keeper tool_access.preset: coding"` 938 times per boot (67 × 14 keepers)
- Add `Coding` to all 5 SSOT surfaces: ADT, parsers, schema mirror, TOML normalizer, privileged gate, witness test

## Root Cause

The `tool_preset` type is a closed sum defined in 3 OCaml locations + 1 schema mirror + 1 TOML normalizer, kept in sync via a compile-time witness test (Issue #8430). When `tool_policy.toml` added `[presets.coding]`, the OCaml ADT was not updated — the TOML normalizer rejected `"coding"` as invalid, and every keeper boot cycle logged 67 WARN events.

## Changes

| File | Change |
|------|--------|
| `keeper_meta_tool_access.ml/.mli` | Add `Coding` constructor to ADT, `to_string`, `of_string`, `all_tool_presets` |
| `keeper_types.mli` | Add `Coding` to re-exported type |
| `keeper_schema.ml` | Add `"coding"` to `tool_preset_enum_strings` mirror |
| `keeper_types_profile_toml_normalizers.ml` | Add `"coding"` to `valid_tool_preset_raw_strings` |
| `keeper_tool_policy.ml` | Handle `Coding` in `preset_name_of_tool_preset` + `preset_allows_privileged_operations` (true — same surface as Delivery) |
| `test/test_types.ml` | Witness count 7→8, add `witness Coding` |

## Test Plan

- [x] `dune build --root .` — clean
- [x] `dune exec test/test_types_coverage.exe` — 185 tests pass
- [ ] CI green
- [ ] Runtime verification: keeper boot with `tool_access.preset = "coding"` no longer emits WARN

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>