### PR TITLE
feat(config): add search_files to minimal and social presets (#19305)

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -150,15 +150,17 @@ email_pattern = "{name}@masc.local"
 
 # ── Presets ─────────────────────────────────────────────────────────
 
+# Minimal: base tools + search_files for read-only git operations
+# (git_status, git_log, git_diff). Gives every keeper basic repo visibility.
 [presets.minimal]
-groups = ["base"]
+groups = ["base", "search_files"]
 masc_groups = ["essential"]
 masc_tools = ["masc_tool_help"]
 
-# Social: persona keepers that live on the board + web search.
-# ~15 tools. Optimal for 9B tool selection accuracy.
+# Social: persona keepers that live on the board + web search + git read.
+# ~16 tools. Optimal for 9B tool selection accuracy.
 [presets.social]
-groups = ["base", "board_core", "coordination_core", "filesystem", "voice"]
+groups = ["base", "board_core", "coordination_core", "filesystem", "search_files", "voice"]
 masc_groups = ["essential", "coordination"]
 
 # Messaging: social + search files and library for broader interaction.


### PR DESCRIPTION
## Summary
- Adds `search_files` tool group to `minimal` and `social` presets in `config/tool_policy.toml`
- Gives all keepers basic git read access (`git_status`, `git_log`, `git_diff`) via `tool_search_files`
- Previously only `messaging`+ presets had this capability; `minimal` and `social` keepers were blind to repo state

## Motivation
Issue #19305 investigation revealed that 4/6 presets exclude `execute` and even read-only git operations. The `search_files` group already provides `git_status`, `git_log`, `git_diff` as `Filesystem_read` effect domain operations (see `lib/tool_resource_axis.ml:118`). Adding it to the two smallest presets gives every keeper basic repo visibility without granting write access.

## Changes
| Preset | Before | After |
|--------|--------|-------|
| `minimal` | `["base"]` | `["base", "search_files"]` |
| `social` | `["base", "board_core", "coordination_core", "filesystem", "voice"]` | same + `"search_files"` |

## Tool count impact
- `minimal`: 6 → 7 tools (+1 `tool_search_files`)
- `social`: ~15 → ~16 tools (+1 `tool_search_files`)

## Safety
- No write operations added — `search_files` is read-only (`Filesystem_read` effect domain)
- No governance or credential implications
- Existing presets (`messaging`, `dispatch`, `research`, `delivery`, `full`) already include `search_files`

## Related
- Issue #19305: 5-layer lock analysis for keeper autonomous Git operations
- Issue #19306: Issue body for this improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
