### PR TITLE
fix(keeper): auto-create missing CWD under sandbox containment

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -145,7 +145,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 799 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
+| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 804 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
 | `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 510 | Stdout-idle timeout for CLI subprocess transports (Provider_c CLI today; Claude Code / Provider_f CLI / Codex CLI nee... |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 163 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 182 | Enable keeper debug logging. Default: false. |

--- a/lib/keeper/agent_tool_execute_path.ml
+++ b/lib/keeper/agent_tool_execute_path.ml
@@ -16,12 +16,15 @@ let resolve_tool_read_cwd
   | Error _ as err -> err
   | Ok cwd when Fs_compat.file_exists cwd && Sys.is_directory cwd -> Ok cwd
   | Ok cwd ->
-    let exists = Fs_compat.file_exists cwd in
-    let detail =
-      if not exists then "path_does_not_exist"
-      else "path_is_file_not_directory"
-    in
-    Error (Printf.sprintf "cwd_not_directory: %s (%s)" cwd detail)
+    if not (Fs_compat.file_exists cwd) then begin
+      (* Auto-create missing CWD under the sandbox.  The path has already
+         passed [resolve_keeper_read_path] sandbox containment, so creating
+         it is safe.  This handles stale worktree references and first-run
+         repo directories that the LLM targets before clone. *)
+      ignore (Keeper_fs.ensure_dir cwd);
+      Ok cwd
+    end else
+      Error (Printf.sprintf "cwd_not_directory: %s (path_is_file_not_directory)" cwd)
 
 let normalize_repo_cwd_path path =
   Keeper_alerting_path.normalize_path_for_check path
@@ -187,7 +190,14 @@ let resolve_tool_write_cwd
     (match validate_repo_cwd_ready ~config ~meta cwd with
      | Ok () -> Ok cwd
      | Error _ as err -> err)
-  | Ok cwd -> Error (Printf.sprintf "cwd_not_directory: %s" cwd)
+  | Ok cwd ->
+    if not (Fs_compat.file_exists cwd) then begin
+      ignore (Keeper_fs.ensure_dir cwd);
+      match validate_repo_cwd_ready ~config ~meta cwd with
+      | Ok () -> Ok cwd
+      | Error _ as err -> err
+    end else
+      Error (Printf.sprintf "cwd_not_directory: %s (path_is_file_not_directory)" cwd)
 
 (* Docker playground path mapping: host → container.
    Host:      <base_path>/.masc/playground/<keeper>/repos/X

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -107,7 +107,11 @@ let write_run config (run : run_record) =
 let read_run config task_id : (run_record, string) result =
   let path = run_json_path config task_id in
   if not (path_exists config path) then
-    Error (Printf.sprintf "Run not found for task %s (expected at %s)" task_id path)
+    Error
+      (Printf.sprintf
+         "Run not found for task %s (expected at %s). \
+          Call masc_run_init with this task_id first to create the run."
+         task_id path)
   else
     match run_record_of_json (read_json config path) with
     | Some r -> Ok r


### PR DESCRIPTION
## Summary
- **P2 (cwd_not_directory, 105/day)**: Auto-create missing CWD directories when path passes sandbox containment validation. Handles stale worktree references and first-run repo directories.
- **P3 (masc_run_get, 24/day)**: Improve error message for missing run to suggest calling `masc_run_init` first.
- **CI fix**: Regenerate `docs/runtime-tunables.md` (env knob catalog drift).

## Changes
- `lib/keeper/agent_tool_execute_path.ml`: In both `resolve_tool_read_cwd` and `resolve_tool_write_cwd`, when a sandbox-validated path doesn't exist, auto-create it via `Keeper_fs.ensure_dir` instead of returning `cwd_not_directory` error.
- `lib/run_eio.ml`: Improve `read_run` error message with actionable hint.
- `docs/runtime-tunables.md`: Regenerated.

## Security
Auto-create only happens **after** sandbox containment validation (`resolve_keeper_read_path` / `resolve_keeper_path`). Paths outside the sandbox are rejected before directory creation is attempted.

## Test plan
- [ ] Verify `test_keeper_path_check_error` passes (6/6)
- [ ] Verify CI Build and Test passes
- [ ] Monitor fleet `cwd_not_directory` error rate post-deploy (target: near zero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>