### PR TITLE
fix(coord): read-only routing, verifier tools, and transition remediation

### DIFF
--- a/ci/code-smell-baseline.json
+++ b/ci/code-smell-baseline.json
@@ -37,7 +37,7 @@
       ]
     },
     "catch_all_arms": {
-      "baseline": 3087,
+      "baseline": 3085,
       "scope": "line-leading OCaml anonymous match arms: | _ ->",
       "files": [
         {
@@ -1502,7 +1502,7 @@
         },
         {
           "file": "lib/keeper/keeper_repo_readiness.ml",
-          "value": 5
+          "value": 3
         },
         {
           "file": "lib/keeper/keeper_routine_allowlist.ml",

--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -290,11 +290,50 @@ let default_completion_contract_text ~title ~description =
       (Printf.sprintf "Task scope satisfied: %s - %s" title description)
 ;;
 
+let write_intent_keywords =
+  [ "write"; "edit"; "create file"; "implement"; "fix"; "refactor"
+  ; "pr "; "pull request"; "commit"; "push"; "merge"
+  ; "modify"; "update"; "add "; "delete"; "remove"
+  ; "test"; "spec"; "lint"; "build"
+  ; "작성"; "수정"; "구현"; "추가"; "삭제"; "변경"
+  ]
+
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  if needle_len = 0 then true
+  else if needle_len > haystack_len then false
+  else
+    let rec loop i =
+      if i + needle_len > haystack_len then false
+      else if String.sub haystack i needle_len = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let text_signals_write_intent ~title ~description =
+  let combined =
+    String.lowercase_ascii (title ^ " " ^ description)
+  in
+  List.exists
+    (fun keyword -> contains_substring ~needle:keyword combined)
+    write_intent_keywords
+
+let infer_required_tools_from_text ~title ~description =
+  if text_signals_write_intent ~title ~description
+  then [ "keeper_fs_edit"; "tool_execute" ]
+  else []
+
 let ensure_task_contract_for_verification ?contract ~title ~description () =
   let base =
     match contract with
     | Some contract -> normalize_task_contract contract
     | None -> empty_task_contract
+  in
+  let required_tools =
+    if base.required_tools <> []
+    then base.required_tools
+    else infer_required_tools_from_text ~title ~description
   in
   let completion_contract =
     if base.completion_contract <> []
@@ -314,7 +353,7 @@ let ensure_task_contract_for_verification ?contract ~title ~description () =
     else default_verification_evidence_refs
   in
   normalize_task_contract
-    { base with completion_contract; required_evidence; verify_gate_evidence }
+    { base with required_tools; completion_contract; required_evidence; verify_gate_evidence }
 ;;
 
 let merge_execution_links

--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -227,8 +227,48 @@ let missing_required_tools ~allowed required =
     required
 ;;
 
+let write_intent_keywords =
+  [ "write"; "edit"; "create"; "implement"; "fix"; "refactor"
+  ; "pr "; "pull request"; "commit"; "push"; "merge"
+  ; "modify"; "update"; "add "; "delete"; "remove"
+  ; "test"; "spec"; "lint"; "build"; "generate"; "migrate"
+  ; "setup"; "configure"; "deploy"; "ship"; "patch"
+  ; "작성"; "수정"; "구현"; "추가"; "삭제"; "변경"; "생성"; "배포"
+  ]
+
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  if needle_len = 0 then true
+  else if needle_len > haystack_len then false
+  else
+    let rec loop i =
+      if i + needle_len > haystack_len then false
+      else if String.sub haystack i needle_len = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let text_signals_write_intent ~title ~description =
+  let combined =
+    String.lowercase_ascii (title ^ " " ^ description)
+  in
+  List.exists
+    (fun keyword -> contains_substring ~needle:keyword combined)
+    write_intent_keywords
+
+let infer_required_tools_from_text ~title ~description =
+  if text_signals_write_intent ~title ~description
+  then [ "tool_edit_file"; "tool_execute" ]
+  else []
+
 let required_tool_claim_guard config ~agent_name ?agent_tool_names task =
   let required_tools = task_required_tools task in
+  let required_tools =
+    if required_tools = []
+    then infer_required_tools_from_text ~title:task.title ~description:task.description
+    else required_tools
+  in
   match required_tools, agent_tool_names with
   | [], _ -> Ok ()
   | _ :: _, None ->
@@ -289,40 +329,6 @@ let default_completion_contract_text ~title ~description =
       ~max_len:220
       (Printf.sprintf "Task scope satisfied: %s - %s" title description)
 ;;
-
-let write_intent_keywords =
-  [ "write"; "edit"; "create file"; "implement"; "fix"; "refactor"
-  ; "pr "; "pull request"; "commit"; "push"; "merge"
-  ; "modify"; "update"; "add "; "delete"; "remove"
-  ; "test"; "spec"; "lint"; "build"
-  ; "작성"; "수정"; "구현"; "추가"; "삭제"; "변경"
-  ]
-
-let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  if needle_len = 0 then true
-  else if needle_len > haystack_len then false
-  else
-    let rec loop i =
-      if i + needle_len > haystack_len then false
-      else if String.sub haystack i needle_len = needle then true
-      else loop (i + 1)
-    in
-    loop 0
-
-let text_signals_write_intent ~title ~description =
-  let combined =
-    String.lowercase_ascii (title ^ " " ^ description)
-  in
-  List.exists
-    (fun keyword -> contains_substring ~needle:keyword combined)
-    write_intent_keywords
-
-let infer_required_tools_from_text ~title ~description =
-  if text_signals_write_intent ~title ~description
-  then [ "tool_edit_file"; "tool_execute" ]
-  else []
 
 let ensure_task_contract_for_verification ?contract ~title ~description () =
   let base =

--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -321,7 +321,7 @@ let text_signals_write_intent ~title ~description =
 
 let infer_required_tools_from_text ~title ~description =
   if text_signals_write_intent ~title ~description
-  then [ "keeper_fs_edit"; "tool_execute" ]
+  then [ "tool_edit_file"; "tool_execute" ]
   else []
 
 let ensure_task_contract_for_verification ?contract ~title ~description () =

--- a/lib/coord/coord_task_classify.mli
+++ b/lib/coord/coord_task_classify.mli
@@ -113,6 +113,7 @@ val normalize_execution_links
 val normalize_task_contract : Masc_domain.task_contract -> Masc_domain.task_contract
 val empty_task_contract : Masc_domain.task_contract
 val task_required_tools : Masc_domain.task -> string list
+val infer_required_tools_from_text : title:string -> description:string -> string list
 val canonical_required_tool_name : string -> string
 val missing_required_tools : allowed:string list -> string list -> string list
 

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -467,7 +467,15 @@ let claim_next_r
           make_required_tools_predicate ?agent_tool_names ()
         in
         let required_tool_claim_allowed (task : Masc_domain.task) =
-          let required_tools = task_required_tools task in
+          let required_tools =
+            match task_required_tools task with
+            | [] ->
+              (* Fallback for tasks created before required_tools inference:
+                 infer from title/description keywords. *)
+              Coord_task_classify.infer_required_tools_from_text
+                ~title:task.title ~description:task.description
+            | tools -> tools
+          in
           required_tools_allowed_for_agent required_tools
           && not (receipt_blocks_task task)
         in

--- a/lib/coord/coord_task_transitions.ml
+++ b/lib/coord/coord_task_transitions.ml
@@ -198,6 +198,9 @@ let transition_task_r
               | Masc_domain.InProgress _, Masc_domain.Claim ->
                 " Remediation: task is already in_progress under someone. Use \
                  masc_claim_next for unclaimed work."
+              | Masc_domain.InProgress _, Masc_domain.Start ->
+                " Remediation: task is already in_progress. Valid actions from \
+                 in_progress: done, submit_for_verification, release, cancel."
               | Masc_domain.Done _, _ ->
                 " Remediation: task is already in a terminal state (done). Use \
                  masc_add_task for new work or masc_tasks to find claimable items."

--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -45,12 +45,22 @@ let normalize_tool_names names =
   |> dedupe_keep_order
 ;;
 
+let write_tools =
+  [ "tool_edit_file"; "tool_write_file"; "tool_execute" ]
+;;
+
 let legacy_keeper_internal_tool_names =
   (* Keep legacy masc coordination defaults explicit in
      [legacy_session_min_tool_names]; new [masc_*] internal tools should not
-     silently expand missing [tool_access] migrations. *)
+     silently expand missing [tool_access] migrations.
+     Write tools are excluded so that keepers without explicit [tool_access]
+     cannot claim write-intent tasks.  Keepers that need write access must
+     set [tool_access] to a preset that includes write tools (e.g. Full)
+     or use [Custom] with explicit write tool names. *)
   Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
-  |> List.filter (fun name -> not (String.starts_with ~prefix:"masc_" name))
+  |> List.filter (fun name ->
+         not (String.starts_with ~prefix:"masc_" name)
+         && not (List.exists (String.equal name) write_tools))
 ;;
 
 let legacy_session_min_tool_names =

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -164,8 +164,9 @@ Example: masc_batch_add_tasks({tasks: [{title: 'Task A', goal_id: 'g-123', prior
   {
     name = "masc_tasks";
     description = "List tasks in backlog with their status and assignee. \
-Defaults to active tasks (todo/claimed/in_progress). \
+Defaults to active tasks (todo/claimed/in_progress/awaiting_verification). \
 Use include_done/include_cancelled or status to filter. \
+awaiting_verification tasks are pending reviewer approval. \
 Output includes task ID, title, priority, assignee, timestamps. \
 Tip: Look for status='todo' tasks to claim.";
     input_schema = `Assoc [
@@ -173,7 +174,7 @@ Tip: Look for status='todo' tasks to claim.";
       ("properties", `Assoc [
         ("status", `Assoc [
           ("type", `String "string");
-          ("description", `String "Optional status filter: todo|claimed|in_progress|done|cancelled");
+          ("description", `String "Optional status filter: todo|claimed|in_progress|awaiting_verification|done|cancelled");
         ]);
         ("include_done", `Assoc [
           ("type", `String "boolean");

--- a/test/test_coord_task_lifecycle.ml
+++ b/test/test_coord_task_lifecycle.ml
@@ -310,6 +310,90 @@ let test_exhaustive_consistency () =
     statuses
 ;;
 
+(* ── required_tools inference from write-intent keywords ──── *)
+
+module Classify = Coord_task_classify
+
+let assert_equal_string_list ~ctx ~expected ~actual =
+  if expected <> actual
+  then (
+    Printf.printf
+      "FAIL [%s]\n  expected: [%s]\n  actual:   [%s]\n%!"
+      ctx
+      (String.concat "; " expected)
+      (String.concat "; " actual);
+    exit 1)
+;;
+
+let test_write_intent_detected () =
+  let contract =
+    Classify.ensure_task_contract_for_verification
+      ~title:"Fix the authentication bug"
+      ~description:"The login flow needs to be updated"
+      ()
+  in
+  assert_equal_string_list
+    ~ctx:"write-intent: fix+update detected"
+    ~expected:[ "keeper_fs_edit"; "tool_execute" ]
+    ~actual:contract.required_tools
+;;
+
+let test_write_intent_korean () =
+  let contract =
+    Classify.ensure_task_contract_for_verification
+      ~title:"로그인 버그 수정"
+      ~description:"인증 흐름을 변경해야 합니다"
+      ()
+  in
+  assert_equal_string_list
+    ~ctx:"write-intent: Korean 수정+변경 detected"
+    ~expected:[ "keeper_fs_edit"; "tool_execute" ]
+    ~actual:contract.required_tools
+;;
+
+let test_write_intent_pr () =
+  let contract =
+    Classify.ensure_task_contract_for_verification
+      ~title:"Create PR for feature X"
+      ~description:"Submit pull request with new dashboard"
+      ()
+  in
+  assert_equal_string_list
+    ~ctx:"write-intent: PR detected"
+    ~expected:[ "keeper_fs_edit"; "tool_execute" ]
+    ~actual:contract.required_tools
+;;
+
+let test_no_write_intent () =
+  let contract =
+    Classify.ensure_task_contract_for_verification
+      ~title:"Analyze system performance"
+      ~description:"Review current metrics and report findings"
+      ()
+  in
+  assert_equal_string_list
+    ~ctx:"no write-intent: analyze+review"
+    ~expected:[]
+    ~actual:contract.required_tools
+;;
+
+let test_explicit_required_tools_preserved () =
+  let explicit_contract =
+    { Classify.empty_task_contract with required_tools = [ "custom_tool"; "another_tool" ] }
+  in
+  let contract =
+    Classify.ensure_task_contract_for_verification
+      ~contract:explicit_contract
+      ~title:"Fix the bug"
+      ~description:"This should not override"
+      ()
+  in
+  assert_equal_string_list
+    ~ctx:"explicit required_tools preserved"
+    ~expected:[ "custom_tool"; "another_tool" ]
+    ~actual:contract.required_tools
+;;
+
 (* ── runner ───────────────────────────────────────────────── *)
 
 let () =
@@ -324,5 +408,10 @@ let () =
   test_cancelled ();
   test_verification_disabled_todo ();
   test_exhaustive_consistency ();
+  test_write_intent_detected ();
+  test_write_intent_korean ();
+  test_write_intent_pr ();
+  test_no_write_intent ();
+  test_explicit_required_tools_preserved ();
   print_endline "test_coord_task_lifecycle: all assertions passed"
 ;;

--- a/test/test_coord_task_lifecycle.ml
+++ b/test/test_coord_task_lifecycle.ml
@@ -334,7 +334,7 @@ let test_write_intent_detected () =
   in
   assert_equal_string_list
     ~ctx:"write-intent: fix+update detected"
-    ~expected:[ "keeper_fs_edit"; "tool_execute" ]
+    ~expected:[ "tool_edit_file"; "tool_execute" ]
     ~actual:contract.required_tools
 ;;
 
@@ -347,7 +347,7 @@ let test_write_intent_korean () =
   in
   assert_equal_string_list
     ~ctx:"write-intent: Korean 수정+변경 detected"
-    ~expected:[ "keeper_fs_edit"; "tool_execute" ]
+    ~expected:[ "tool_edit_file"; "tool_execute" ]
     ~actual:contract.required_tools
 ;;
 
@@ -360,7 +360,7 @@ let test_write_intent_pr () =
   in
   assert_equal_string_list
     ~ctx:"write-intent: PR detected"
-    ~expected:[ "keeper_fs_edit"; "tool_execute" ]
+    ~expected:[ "tool_edit_file"; "tool_execute" ]
     ~actual:contract.required_tools
 ;;
 


### PR DESCRIPTION
## Summary
- Layer 1: `required_tools` keyword inference from task title/description at claim time
- Layer 2: Phantom tool name correction in keyword inference
- Layer 3: Exclude write tools from default `tool_access` (read-only keepers can't claim write-intent tasks)
- Layer 4: Add `awaiting_verification` to `masc_tasks` status filter docs
- Layer 5: Add remediation hint for `InProgress + Start` invalid transition

## Root Cause
Multiple agents (ramarama, executor) hit confusing errors when:
1. Tasks with `required_tools` couldn't be claimed by keepers without matching tool access
2. `InProgress` task getting `Start` action produced empty remediation string (catch-all `_ -> ""`)
3. `masc_tasks` schema didn't document `awaiting_verification` as valid status filter

## Test plan
- [ ] Verify `masc_transition` with `action=start` on `InProgress` task returns clear remediation
- [ ] Verify `masc_tasks` with `status=awaiting_verification` returns matching tasks
- [ ] Verify read-only preset keepers are excluded from claiming write-intent tasks
- [ ] CI passes (pre-existing failures only: Dashboard, Draft Auto-Merge Guard, Lint, Meta Guards, OCaml Structure Ratchet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
