### PR TITLE
fix(auth): dashboard same-origin detection via Referer header

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -407,10 +407,9 @@ let host_port_of_request request =
           host_header (Printexc.to_string exn);
         None)
 
-(* Evaluated at module init time (eager). MASC_ALLOW_ANONYMOUS_MUTATIONS
-   must be set before the module is loaded. This is safe because the
-   server process sets all env vars at startup before any module init. *)
-let allow_anonymous_mutations =
+(* Re-reads the env var on each call so MASC_ALLOW_ANONYMOUS_MUTATIONS
+   can be toggled without restarting the server process. *)
+let allow_anonymous_mutations () =
   match Sys.getenv_opt "MASC_ALLOW_ANONYMOUS_MUTATIONS" with
   | Some ("1" | "true") -> true
   | _ -> false
@@ -441,15 +440,34 @@ let is_allowlisted_loopback_dev_origin origin =
       |> List.exists (fun allowed -> allowed = candidate)
   | _ -> false
 
+(* Browsers omit Origin for same-origin requests per the Fetch spec, but
+   always include Referer.  If the Referer's host:port matches the
+   request's Host header, the request is same-origin and trusted. *)
+let is_same_server_referer referer request =
+  match host_port_scheme_of_origin referer, host_port_of_request request with
+  | Some (ref_host, ref_port, scheme), Some (req_host, req_port)
+    when String.equal
+           (normalize_loopback_host ref_host)
+           (normalize_loopback_host req_host) ->
+    let default = default_port_of_scheme scheme in
+    let norm p = match p with Some _ -> p | None -> default in
+    norm ref_port = norm req_port
+  | _ -> false
+
 let ensure_same_origin_browser_request request :
     (unit, Masc_domain.masc_error) result =
   match Httpun.Headers.get request.Httpun.Request.headers "origin" with
   | None ->
-    if allow_anonymous_mutations then Ok ()
-    else
-      Error (Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized
-        "Authentication required: provide a bearer token or Origin header. \
-         Set MASC_ALLOW_ANONYMOUS_MUTATIONS=true for local development."))
+    (* Same-origin browser requests don't send Origin.  Check Referer
+       as a fallback — browsers always include it even for same-origin. *)
+    (match Httpun.Headers.get request.Httpun.Request.headers "referer" with
+     | Some referer when is_same_server_referer referer request -> Ok ()
+     | _ ->
+       if allow_anonymous_mutations () then Ok ()
+       else
+         Error (Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized
+           "Authentication required: provide a bearer token or Origin header. \
+            Set MASC_ALLOW_ANONYMOUS_MUTATIONS=true for local development.")))
   | Some origin -> (
       match host_port_scheme_of_origin origin, host_port_of_request request with
       | Some (origin_host, origin_port, scheme),

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -155,9 +155,9 @@ val host_port_scheme_of_origin :
 val host_port_of_request : Httpun.Request.t -> (string * int option) option
 (** Host/port from the request's [Host] header. *)
 
-val allow_anonymous_mutations : bool
-(** Compile-time toggle: when [true] non-loopback mutations skip auth
-    (test fixtures only). *)
+val allow_anonymous_mutations : unit -> bool
+(** Re-reads [MASC_ALLOW_ANONYMOUS_MUTATIONS] on each call.
+    When [true] non-loopback mutations skip auth (test fixtures only). *)
 
 val default_loopback_dev_mutation_origins : string list
 (** Built-in allowlist of dev-loopback origins (e.g. Vite). *)


### PR DESCRIPTION
## Summary

- Browsers omit the `Origin` header for same-origin requests per the Fetch spec, causing the dashboard's mutation calls to be rejected as unauthenticated
- When no `Origin` is present, check the `Referer` header — browsers always include it — and treat the request as trusted when Referer's host:port matches the request's Host header
- Change `allow_anonymous_mutations` from an eager `let` binding to a `unit -> bool` function so the env var is re-read on each call, allowing runtime toggling without server restart

## Problem

The MASC server serves the dashboard at `/dashboard/`, making all dashboard API calls same-origin. Per the HTTP Fetch spec, browsers do NOT send `Origin` headers for same-origin requests. This caused `ensure_same_origin_browser_request` to reject every dashboard mutation with:

```
AuthError: Unauthorized: Authentication required: provide a bearer token or Origin header.
```

Additionally, `allow_anonymous_mutations` was a `let` binding evaluated at module init time, so changing `MASC_ALLOW_ANONYMOUS_MUTATIONS` after server start had no effect.

## Solution

1. **Referer-based same-origin detection**: When no `Origin` header is present, check the `Referer` header. If Referer's host:port matches the request's Host header, treat as trusted same-origin.

2. **Dynamic env var evaluation**: Changed `allow_anonymous_mutations` from `let` to `let () ... =` function so it re-reads the env var on each call.

## Test plan

- [x] All 97 auth tests pass (`test_auth_coverage.exe`)
- [x] `dune build @check` passes
- [ ] Verify dashboard mutations work without bearer token when served from same origin
- [ ] Verify cross-origin requests still require proper auth

## Files changed

- `lib/server/server_auth.ml` — Referer-based same-origin detection + dynamic `allow_anonymous_mutations`
- `lib/server/server_auth.mli` — Updated type signature for `allow_anonymous_mutations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)