### PR TITLE
feat(trajectory): batch pending entries with background flush

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -580,4 +580,23 @@ let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =
   Stdlib.Mutex.protect path_mu (fun () ->
     Stdlib.output_string oc line;
     Stdlib.flush oc)
+
+let append_jsonl_batch (path : string) (jsons : Yojson.Safe.t list) : unit =
+  if jsons = [] then ()
+  else begin
+    test_exec_home_guard ~op:"append_jsonl_batch" path;
+    let dir = Stdlib.Filename.dirname path in
+    mkdir_p_memoized dir;
+    let buf = Buffer.create 4096 in
+    List.iter (fun json ->
+      Buffer.add_string buf (Yojson.Safe.to_string json);
+      Buffer.add_char buf '\n'
+    ) jsons;
+    let chunk = Buffer.contents buf in
+    let oc = Fd_cache.get_writer path in
+    let path_mu = get_append_path_mutex path in
+    Stdlib.Mutex.protect path_mu (fun () ->
+      Stdlib.output_string oc chunk;
+      Stdlib.flush oc)
+  end
 ;;

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -155,6 +155,11 @@ val fold_jsonl_lines
     is registered at [at_exit]. *)
 val append_jsonl : string -> Yojson.Safe.t -> unit
 
+(** [append_jsonl_batch path jsons] writes multiple JSON entries to [path]
+    in a single lock+flush cycle. More efficient than calling [append_jsonl]
+    repeatedly when batching pending entries. No-op if [jsons] is empty. *)
+val append_jsonl_batch : string -> Yojson.Safe.t list -> unit
+
 (** Flush and close every cached [out_channel] held by
     [append_jsonl]. Safe to call concurrently with active appends;
     a subsequent [append_jsonl] re-opens fresh. Intended for

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -244,7 +244,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
           ~masc_root
           ~keeper_name:meta.name
           ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-          ~generation:meta.runtime.generation
+          ~generation:meta.runtime.generation ()
       in
       let effective_models =
         if direct_reply then

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -217,7 +217,7 @@ let record_pre_dispatch_terminal_observation
   let started_at = now_iso () in
   let masc_root = Coord.masc_root_dir config in
   let trajectory_acc =
-    Trajectory.create_accumulator ~masc_root ~keeper_name:meta.name ~trace_id ~generation
+    Trajectory.create_accumulator ~masc_root ~keeper_name:meta.name ~trace_id ~generation ()
   in
   finalize_trajectory_acc ~config ~keeper_name:meta.name trajectory_acc trajectory_outcome;
   let ended_at = now_iso () in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -282,7 +282,7 @@ let run_keeper_cycle
                    ~masc_root
                    ~keeper_name:meta.name
                    ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                   ~generation:meta.runtime.generation
+                   ~generation:meta.runtime.generation ()
                in
                let max_cost_usd = Keeper_config.keeper_tool_cost_max_usd () in
                (* 4. Build turn prompt callback: use our unified system prompt *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -354,6 +354,19 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       loop ()
     in
     loop ());
+  (* Background fiber: flush pending trajectory entries every 2 seconds.
+     Batches per-tool-call JSONL writes to reduce disk I/O. *)
+  Eio.Fiber.fork ~sw (fun () ->
+    let rec loop () =
+      Eio.Time.sleep clock 2.0;
+      (try Trajectory.flush_all_pending ()
+       with Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Log.Keeper.warn "trajectory flush_all_pending failed: %s"
+           (Printexc.to_string exn));
+      loop ()
+    in
+    loop ());
   (* 1. HTTP socket first — Railway healthcheck can reach /health immediately *)
   let config = Server_bootstrap_http.make_http_config ~host ~port in
   let routes = make_routes ~port:config.port ~host:config.host ~sw ~clock in

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -316,6 +316,10 @@ let append_summary ~(masc_root : string) ~(keeper_name : string) ~(trace_id : st
 (* Trajectory accumulator (mutable, per-session)                    *)
 (* ================================================================ *)
 
+type pending_entry = {
+  pe_json : Yojson.Safe.t;
+}
+
 type accumulator = {
   mutable entries : tool_call_entry list;
   mutable total_cost : float;
@@ -330,10 +334,28 @@ type accumulator = {
   (** Claimed task ID for cost attribution.
       Starts as None; set via [set_task_id] when keeper claims a task.
       Propagated to trajectory record on [finalize]. *)
+  pending_queue : pending_entry Queue.t;
+  pending_mu : Stdlib.Mutex.t;
+  mutable last_flush : float;
+  mutable on_flush_error : (exn -> unit) option;
 }
 
-let create_accumulator ~masc_root ~keeper_name ~trace_id ~generation : accumulator =
-  { entries = [];
+(* Global registry of active accumulators for batch flush.
+   The background flush fiber iterates this to drain pending queues. *)
+let active_accumulators : (string * string, accumulator) Hashtbl.t = Hashtbl.create 16
+let active_acc_mu = Stdlib.Mutex.create ()
+
+let register_accumulator (acc : accumulator) =
+  Stdlib.Mutex.protect active_acc_mu (fun () ->
+    Hashtbl.replace active_accumulators (acc.keeper_name, acc.trace_id) acc)
+
+let unregister_accumulator (acc : accumulator) =
+  Stdlib.Mutex.protect active_acc_mu (fun () ->
+    Hashtbl.remove active_accumulators (acc.keeper_name, acc.trace_id))
+
+let create_accumulator ?on_flush_error ~masc_root ~keeper_name ~trace_id ~generation () : accumulator =
+  let acc = {
+    entries = [];
     total_cost = 0.0;
     total_calls = 0;
     turn = 0;
@@ -343,7 +365,13 @@ let create_accumulator ~masc_root ~keeper_name ~trace_id ~generation : accumulat
     started_at = Time_compat.now ();
     masc_root;
     task_id = None;
-  }
+    pending_queue = Queue.create ();
+    pending_mu = Stdlib.Mutex.create ();
+    last_flush = 0.0;
+    on_flush_error;
+  } in
+  register_accumulator acc;
+  acc
 
 (** Bind a claimed task to this trajectory for cost attribution. *)
 let set_task_id (acc : accumulator) (id : string) : unit =
@@ -361,16 +389,42 @@ let record_entry ?runtime_contract ?action_radius ?on_persist_error
   acc.entries <- entry :: acc.entries;
   acc.total_cost <- acc.total_cost +. entry.cost_usd;
   acc.total_calls <- acc.total_calls + 1;
-  (* Persist immediately for crash recovery *)
-  (try
-     append_entry ?runtime_contract ?action_radius ~masc_root:acc.masc_root
-       ~keeper_name:acc.keeper_name ~trace_id:acc.trace_id entry
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-       Log.Keeper.error "Failed to persist entry for %s: %s" acc.trace_id
-         (Printexc.to_string exn);
-       (match on_persist_error with
+  (* Store on_persist_error for use during batch flush *)
+  (match on_persist_error, acc.on_flush_error with
+   | Some cb, None -> acc.on_flush_error <- Some cb
+   | _ -> ());
+  (* Enqueue for batched write instead of synchronous disk I/O *)
+  let json = entry_to_json ?runtime_contract ?action_radius entry in
+  Stdlib.Mutex.protect acc.pending_mu (fun () ->
+    Queue.push { pe_json = json } acc.pending_queue)
+
+(** Drain the pending queue and write all entries in a single batch.
+    Acquires the per-accumulator mutex to safely drain the queue. *)
+let flush_pending (acc : accumulator) : unit =
+  let entries_to_flush =
+    Stdlib.Mutex.protect acc.pending_mu (fun () ->
+      if Queue.is_empty acc.pending_queue then []
+      else
+        let items = Queue.fold (fun acc pe -> pe :: acc) [] acc.pending_queue in
+        Queue.clear acc.pending_queue;
+        List.rev items)
+  in
+  match entries_to_flush with
+  | [] -> ()
+  | _ ->
+    let dir = trajectories_dir acc.masc_root acc.keeper_name in
+    Fs_compat.mkdir_p dir;
+    let path = trajectory_path acc.masc_root acc.keeper_name acc.trace_id in
+    let jsons = List.map (fun pe -> pe.pe_json) entries_to_flush in
+    (try
+       Fs_compat.append_jsonl_batch path jsons;
+       acc.last_flush <- Time_compat.now ()
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Log.Keeper.error "Failed to flush trajectory batch for %s: %s"
+         acc.trace_id (Printexc.to_string exn);
+       (match acc.on_flush_error with
         | None -> ()
         | Some report ->
             try report exn
@@ -378,11 +432,21 @@ let record_entry ?runtime_contract ?action_radius ?on_persist_error
             | Eio.Cancel.Cancelled _ as e -> raise e
             | report_exn ->
                 Log.Keeper.warn
-                  "Failed to report trajectory persist gap for %s: %s"
+                  "Failed to report trajectory flush error for %s: %s"
                   acc.trace_id
                   (Printexc.to_string report_exn)))
 
+(** Flush pending entries for all active accumulators.
+    Called by the background flush fiber in server_runtime_bootstrap. *)
+let flush_all_pending () : unit =
+  let accs = Stdlib.Mutex.protect active_acc_mu (fun () ->
+    Hashtbl.fold (fun _ acc accs -> acc :: accs) active_accumulators []) in
+  List.iter flush_pending accs
+
 let finalize (acc : accumulator) (outcome : trajectory_outcome) : trajectory =
+  (* Flush any remaining pending entries before writing summary *)
+  flush_pending acc;
+  unregister_accumulator acc;
   let traj = {
     scenario_id = None;
     keeper_name = acc.keeper_name;

--- a/lib/trajectory/trajectory.mli
+++ b/lib/trajectory/trajectory.mli
@@ -135,6 +135,10 @@ val read_all_lines :
 
     Mutable session-scoped state for tracking tool calls in progress. *)
 
+type pending_entry = {
+  pe_json : Yojson.Safe.t;
+}
+
 type accumulator = {
   mutable entries : tool_call_entry list;
   mutable total_cost : float;
@@ -146,11 +150,16 @@ type accumulator = {
   started_at : float;
   masc_root : string;
   mutable task_id : string option;
+  pending_queue : pending_entry Queue.t;
+  pending_mu : Mutex.t;
+  mutable last_flush : float;
+  mutable on_flush_error : (exn -> unit) option;
 }
 
 val create_accumulator :
+  ?on_flush_error:(exn -> unit) ->
   masc_root:string -> keeper_name:string -> trace_id:string ->
-  generation:int -> accumulator
+  generation:int -> unit -> accumulator
 
 val set_task_id : accumulator -> string -> unit
 val clear_task_id : accumulator -> unit
@@ -163,6 +172,16 @@ val record_entry :
   tool_call_entry ->
   unit
 val finalize : accumulator -> trajectory_outcome -> trajectory
+
+val flush_pending : accumulator -> unit
+(** [flush_pending acc] drains the pending queue and writes all entries
+    to disk in a single batch. Called automatically by [finalize] and
+    by the background flush fiber. *)
+
+val flush_all_pending : unit -> unit
+(** [flush_all_pending ()] flushes pending entries for all active
+    accumulators. Called by the background flush fiber in
+    server_runtime_bootstrap. *)
 
 val detect_entropy :
   ?threshold:int -> ?args_json:string -> accumulator -> string -> (string * int) option

--- a/test/test_eval_gate.ml
+++ b/test/test_eval_gate.ml
@@ -17,7 +17,7 @@ let with_tmpdir f =
 let make_acc dir =
   Trajectory.create_accumulator
     ~masc_root:dir ~keeper_name:"test-keeper"
-    ~trace_id:"gate-test" ~generation:0
+    ~trace_id:"gate-test" ~generation:0 ()
 
 let default_config = Eval_gate.default_config
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5913,7 +5913,7 @@ let test_pre_tool_gate_records_durable_attempt_telemetry () =
            ~masc_root
            ~keeper_name
            ~trace_id
-           ~generation:9
+           ~generation:9 ()
        in
        KTCL.reset_for_testing ();
        KTCL.init ~base_path:base_dir ();

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -54,7 +54,7 @@ let test_create_accumulator () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"test-keeper"
-      ~trace_id:"trace-001" ~generation:0 in
+      ~trace_id:"trace-001" ~generation:0 () in
     Alcotest.(check int) "initial turn" 0 acc.Trajectory.turn;
     Alcotest.(check (float 0.0001)) "initial cost" 0.0 acc.Trajectory.total_cost;
     Alcotest.(check int) "initial entries" 0 (List.length acc.Trajectory.entries))
@@ -67,7 +67,7 @@ let test_record_entry () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"test-keeper"
-      ~trace_id:"trace-002" ~generation:0 in
+      ~trace_id:"trace-002" ~generation:0 () in
     let entry : Trajectory.tool_call_entry = {
       ts = 1000.0;
       ts_iso = "2026-01-01T00:00:00Z";
@@ -93,7 +93,7 @@ let test_entropy_not_triggered () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"test-keeper"
-      ~trace_id:"trace-003" ~generation:0 in
+      ~trace_id:"trace-003" ~generation:0 () in
     (* Add 1 consecutive call — with +1 for upcoming, count=2 < threshold 3 *)
     let mk_entry tool = { Trajectory.
       ts = 1000.0; ts_iso = ""; turn = 1; round = 0;
@@ -110,7 +110,7 @@ let test_entropy_triggered () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"test-keeper"
-      ~trace_id:"trace-004" ~generation:0 in
+      ~trace_id:"trace-004" ~generation:0 () in
     let mk_entry tool = { Trajectory.
       ts = 1000.0; ts_iso = ""; turn = 1; round = 0;
       tool_name = tool; args_json = "{}";
@@ -135,7 +135,7 @@ let test_increment_turn () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"test-keeper"
-      ~trace_id:"trace-005" ~generation:0 in
+      ~trace_id:"trace-005" ~generation:0 () in
     Alcotest.(check int) "turn 0" 0 acc.Trajectory.turn;
     Trajectory.increment_turn acc;
     Alcotest.(check int) "turn 1" 1 acc.Trajectory.turn;
@@ -150,7 +150,7 @@ let test_finalize () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"test-keeper"
-      ~trace_id:"trace-006" ~generation:0 in
+      ~trace_id:"trace-006" ~generation:0 () in
     Trajectory.increment_turn acc;
     let entry : Trajectory.tool_call_entry = {
       ts = 1000.0; ts_iso = "2026-01-01T00:00:00Z";
@@ -189,7 +189,7 @@ let test_calls_in_current_turn () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"test-keeper"
-      ~trace_id:"trace-007" ~generation:0 in
+      ~trace_id:"trace-007" ~generation:0 () in
     Trajectory.increment_turn acc;
     let mk tool = { Trajectory.
       ts = 1000.0; ts_iso = ""; turn = acc.Trajectory.turn; round = 0;
@@ -211,14 +211,14 @@ let test_task_id_default_none () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"test-keeper"
-      ~trace_id:"trace-tid-001" ~generation:0 in
+      ~trace_id:"trace-tid-001" ~generation:0 () in
     Alcotest.(check (option string)) "task_id default" None acc.Trajectory.task_id)
 
 let test_set_task_id () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"test-keeper"
-      ~trace_id:"trace-tid-002" ~generation:0 in
+      ~trace_id:"trace-tid-002" ~generation:0 () in
     Trajectory.set_task_id acc "task-042";
     Alcotest.(check (option string)) "task_id set"
       (Some "task-042") acc.Trajectory.task_id)
@@ -227,7 +227,7 @@ let test_clear_task_id () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"test-keeper"
-      ~trace_id:"trace-tid-003" ~generation:0 in
+      ~trace_id:"trace-tid-003" ~generation:0 () in
     Trajectory.set_task_id acc "task-042";
     Trajectory.clear_task_id acc;
     Alcotest.(check (option string)) "task_id cleared" None acc.Trajectory.task_id)
@@ -236,7 +236,7 @@ let test_finalize_propagates_task_id () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"test-keeper"
-      ~trace_id:"trace-tid-004" ~generation:0 in
+      ~trace_id:"trace-tid-004" ~generation:0 () in
     Trajectory.set_task_id acc "task-099";
     Trajectory.increment_turn acc;
     let traj = Trajectory.finalize acc Trajectory.Completed in
@@ -247,7 +247,7 @@ let test_task_id_in_trajectory_json () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"test-keeper"
-      ~trace_id:"trace-tid-005" ~generation:0 in
+      ~trace_id:"trace-tid-005" ~generation:0 () in
     Trajectory.set_task_id acc "task-json-test";
     let traj = Trajectory.finalize acc Trajectory.Completed in
     let json = Trajectory.trajectory_to_json traj in
@@ -262,7 +262,7 @@ let test_task_id_null_when_none () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"test-keeper"
-      ~trace_id:"trace-tid-006" ~generation:0 in
+      ~trace_id:"trace-tid-006" ~generation:0 () in
     let traj = Trajectory.finalize acc Trajectory.Completed in
     let json = Trajectory.trajectory_to_json traj in
     let open Yojson.Safe.Util in


### PR DESCRIPTION
## Summary

Replace per-tool-call synchronous disk I/O with in-memory queue + periodic background flush for trajectory entries. This eliminates the trajectory JSONL write from the hot path, reducing API latency.

### Changes

- **`lib/fs_compat/fs_compat.ml`**: Add `append_jsonl_batch` for single-lock multi-entry writes
- **`lib/trajectory/trajectory.ml`**: 
  - Extend accumulator with `pending_queue`, `pending_mu`, `last_flush`, `on_flush_error`
  - `record_entry` now enqueues instead of writing immediately
  - Add `flush_pending` to drain queue and batch-write
  - Add global accumulator registry for background flush fiber
- **`lib/trajectory/trajectory.mli`**: Expose new types and functions
- **`lib/server/server_runtime_bootstrap.ml`**: Add background fiber that flushes pending entries every 2 seconds
- **`lib/keeper/keeper_turn.ml`**, **`keeper_turn_helpers.ml`**, **`keeper_unified_turn.ml`**: Update `create_accumulator` callers
- **`test/test_trajectory.ml`**, **`test/test_eval_gate.ml`**, **`test/test_keeper_unified.ml`**: Update test callers

### Performance Impact

Eliminates 1 synchronous disk write per keeper tool call. The background fiber batches multiple entries into a single write operation every 2 seconds.

### Test plan

- [ ] `dune build .` passes
- [ ] `dune runtest` passes (excluding pre-existing failures)
- [ ] Manual test: start server, make MCP tool calls, verify trajectory files are written correctly
- [ ] Check that pending entries are flushed within 2 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)