### PR TITLE
WIP: purge tier/tier-group concept from cascade system

### DIFF
--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -332,24 +332,17 @@ type cascade_scoring_params =
   }
 [@@deriving show, eq]
 
-type cascade_tier =
+type cascade_profile_node =
   { name : string
   ; members : string list
+  ; child_profiles : string list option
   ; strategy : cascade_strategy
   ; max_concurrent : int option
   ; cycle_policy : cascade_cycle_policy option
   ; sticky_ttl_ms : int option
   ; scoring_params : cascade_scoring_params option
   ; keeper_assignable : bool option
-  }
-[@@deriving show, eq]
-
-type cascade_tier_group =
-  { name : string
-  ; tiers : string list
-  ; strategy : cascade_strategy
-  ; fallback : bool
-  ; keeper_assignable : bool option
+  ; fallback : bool option
   ; required_capability_profile : string option
   }
 [@@deriving show, eq]
@@ -372,11 +365,10 @@ type cascade_config =
   ; models : cascade_model_spec list
   ; bindings : cascade_binding list
   ; aliases : cascade_alias list
-  ; tiers : cascade_tier list
-  ; tier_groups : cascade_tier_group list
+  ; profiles : cascade_profile_node list
   ; routes : cascade_route list
   ; system_targets : cascade_route list
-  ; profiles : cascade_profile list
+  ; capability_profiles : cascade_profile list
   }
 [@@deriving show, eq]
 


### PR DESCRIPTION
## Summary

Complete removal of tier/tier-group distinction from masc-mcp cascade system.

## Problem

The \"tier-group.\" and \"tier.\" string prefixes and the artificial tier vs
tier-group distinction are implementation artifacts, not domain concepts.

## Changes (IN PROGRESS)

- [x] `cascade_declarative_types.ml`: `cascade_profile_node` replaces `cascade_tier` + `cascade_tier_group`
- [ ] `cascade_declarative_parser.ml`: parse [tier.X] and [tier-group.Y] into unified profiles
- [ ] `cascade_declarative_validator.ml`: remove tier/tier-group validation split
- [ ] `cascade_config_resolve.ml`: prefix-based lookup → profile_node lookup
- [ ] All keeper/runtime files: `cfg.tiers` / `cfg.tier_groups` → `cfg.profiles`
- [ ] Dashboard tests: remove hardcoded prefix strings
- [ ] Documentation update

## Current State

Type system foundation committed. 50+ files remain to migrate.
Build will fail until all references are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>