### PR TITLE
refactor(cascade): remove tier and tier-group from cascade config

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -728,186 +728,63 @@ temperature = 0.3
 max-output = 8192
 temperature = 0.3
 
-# ── Layer 5: Tiers ─────────────────────────────────────────────
-
-[tier.primary]
-# Canonical keeper/workflow tier. Operator priority:
-# RunPod -> local llama-server :8080 -> GLM Coding -> Codex Spark.
-members = [
-  "runpod_mtp.qwen-runpod.keeper",
-  "local_mtp.qwen-local.keeper",
-  "glm-coding.glm-5-turbo",
-  "glm-coding.glm-flashx",
-  "cli_tool_a.codex-spark.for-keeper-turn",
-]
-strategy = "failover"
-
-[tier.keeper_diverse]
-# Fallback tier for contract violation retry. Different model
-# composition from primary to break correlated failure.
-members = ["cli_tool_b.gemini-flash", "cli_tool_a.codex-spark", "openai_compat.qwen3-5.for-keeper-turn"]
-strategy = "failover"
-
-[tier.strict_tool_candidates]
-# Tool-strict lane for providers that can carry runtime MCP tools and headers.
-keeper-assignable = true
-members = ["runpod_mtp.qwen-runpod.keeper"]
-strategy = "failover"
-
-[tier.scoring]
-# System-only short-output tier for rerank/scoring calls.
-# Members are aliases (Layer 4) with reduced max-output.
-keeper-assignable = false
-members = [
-  "cli_tool_a.codex-spark.for-scoring",
-]
-strategy = "failover"
-
-[tier.governance]
-# System-only baseline for governance / judge calls.
-keeper-assignable = false
-members = ["glm-coding.glm-flashx", "openai_compat.deepseek-v4-flash.for-keeper-turn"]
-strategy = "failover"
-
-[tier.tier_small]
-# Operator opt-in slot for 4B-class local models. Empty by default;
-# routes fall through to tier_medium via tier-group fallback.
-members = []
-strategy = "failover"
-
-[tier.tier_medium]
-# 9B-class cloud-coding models for moderate tasks.
-members = ["glm-coding.glm-flashx", "openai_compat.deepseek-v4-flash.for-keeper-turn"]
-strategy = "failover"
-
-[tier.__safe_lane]
-# System-only baseline tier (RFC-0027 PR-4). Last-resort fallback
-# target that satisfies every capability profile. Not keeper-assignable.
-# Diversity invariant: __safe_lane MUST NOT share both members with tier.primary
-# (D11 fix 2026-05-21). When the dominant provider (GLM) degrades, primary and
-# __safe_lane must not fail in correlation — keep at least one non-GLM provider
-# from a different vendor family (cli_tool_a) to break the correlated failure path.
-keeper-assignable = false
-members = ["cli_tool_a.codex-spark.for-keeper-turn", "openai_compat.deepseek-v4-flash.for-keeper-turn"]
-strategy = "failover"
-
-# ── Tier-Groups (fallback chains) ──────────────────────────────
-
-[tier-group.primary]
-tiers = ["primary"]
-strategy = "priority_tier"
-fallback = true
-
-[tier-group.tier_small]
-tiers = ["tier_small", "tier_medium", "primary"]
-strategy = "priority_tier"
-fallback = true
-
-[tier-group.tier_medium]
-tiers = ["tier_medium", "primary"]
-strategy = "priority_tier"
-fallback = true
-
-[tier-group.scoring]
-tiers = ["scoring", "__safe_lane"]
-strategy = "priority_tier"
-fallback = true
-keeper-assignable = false
-
-[tier-group.governance]
-tiers = ["governance", "__safe_lane"]
-strategy = "priority_tier"
-fallback = true
-keeper-assignable = false
-
-[tier-group.strict_tool_candidates]
-# Tier-group for routes requiring tool_strict profile capabilities
-# (runtime_mcp_tools, runtime_tool_events, runtime_mcp_http_headers).
-tiers = ["strict_tool_candidates"]
-strategy = "priority_tier"
-fallback = true
-required_capability_profile = "tool_strict"
-
-[tier-group.ollama_cloud_stable]
-# Recovery target for cascade_exhausted on local Ollama lanes.
-# Referenced by keeper turn disposition (test_keeper_turn_disposition.ml:280)
-# and by error classifier fallback hints (test_keeper_error_classify_recoverable.ml:187).
-tiers = ["tier_medium", "primary", "__safe_lane"]
-strategy = "priority_tier"
-fallback = true
-keeper-assignable = false
-
-[tier-group.provider_inventory_sweep]
-# Sweep lane for full provider inventory performance measurement
-# (docs/CASCADE-ROUTES.md §sweep). Background only; isolated from
-# production fallback chains to avoid resource contention with live work.
-tiers = ["primary", "keeper_diverse", "__safe_lane"]
-strategy = "priority_tier"
-fallback = true
-keeper-assignable = false
-
-# ── Routes (logical usage → tier-group) ────────────────────────
-#
-# RFC-0058 §4 R6: route targets resolve to tier-groups, tiers,
-# bindings, or aliases (validated by `Cascade_declarative_validator`
-# rule R7). The seed below targets tier-groups exclusively because
-# routing through a tier-group keeps fallback chains explicit and
-# discourages callers from depending on a single tier without a
-# documented degradation path.
+# ── Routes (simplified: direct model reference) ────────────────
+# Tier/tier-group concept removed. All routes reference the global
+# default model directly via provider:model string format.
 
 [routes.keeper_turn]
-target = "tier-group.primary"
+target = "runpod:glm-coding-with-spark"
 
 [routes.phase_recovery]
-target = "tier-group.primary"
+target = "runpod:glm-coding-with-spark"
 
 [routes.phase_buffer]
-target = "tier-group.primary"
+target = "runpod:glm-coding-with-spark"
 
 [routes.tool_required]
-target = "tier-group.primary"
+target = "runpod:glm-coding-with-spark"
 
 [routes.governance_judge]
-target = "tier-group.governance"
+target = "runpod:glm-coding-with-spark"
 
 [routes.operator_judge]
-target = "tier-group.governance"
+target = "runpod:glm-coding-with-spark"
 
 [routes.cross_verifier]
-target = "tier-group.governance"
+target = "runpod:glm-coding-with-spark"
 
 [routes.verifier]
-target = "tier-group.governance"
+target = "runpod:glm-coding-with-spark"
 
 [routes.adversarial_reviewer]
-target = "tier-group.primary"
+target = "runpod:glm-coding-with-spark"
 
 [routes.auto_responder]
-target = "tier-group.primary"
+target = "runpod:glm-coding-with-spark"
 
 [routes.routing]
-target = "tier-group.primary"
+target = "runpod:glm-coding-with-spark"
 
 [routes.openai_compat]
-target = "tier-group.primary"
+target = "runpod:glm-coding-with-spark"
 
 [routes.persona_generation]
-target = "tier-group.primary"
+target = "runpod:glm-coding-with-spark"
 
 [routes.provider_benchmark]
-target = "tier-group.provider_inventory_sweep"
+target = "runpod:glm-coding-with-spark"
 
 [routes.llm_rerank]
-target = "tier-group.primary"
+target = "runpod:glm-coding-with-spark"
 
 [routes.simple_task]
-target = "tier-group.primary"
+target = "runpod:glm-coding-with-spark"
 
 [routes.moderate_task]
-target = "tier-group.primary"
+target = "runpod:glm-coding-with-spark"
 
 [routes.complex_task]
-target = "tier-group.primary"
+target = "runpod:glm-coding-with-spark"
 
 # ── Profiles (capability requirements per route class) ─────────
 

--- a/config/keepers/base.toml
+++ b/config/keepers/base.toml
@@ -9,7 +9,7 @@
 # disabling autoboot for this file. discover_keepers_toml still loads it
 # as a profile-defaults source for downstream keepers.
 autoboot_enabled = false
-cascade_name = "primary"
+model = "runpod:glm-coding-with-spark"
 sandbox_profile = "docker"
 network_mode = "inherit"
 repo_cli_identity = "anyang-keepers"

--- a/lib/cascade/cascade_catalog_runtime_validate.ml
+++ b/lib/cascade/cascade_catalog_runtime_validate.ml
@@ -43,20 +43,8 @@ let deprecated_logical_profile_name_error ~kind name :
   else None
 
 let deprecated_logical_profile_name_errors
-    (cfg : Cascade_declarative_types.cascade_config) =
-  let tier_errors =
-    List.filter_map
-      (fun (tier : Cascade_declarative_types.cascade_tier) ->
-        deprecated_logical_profile_name_error ~kind:"tier" tier.name)
-      cfg.tiers
-  in
-  let tier_group_errors =
-    List.filter_map
-      (fun (group : Cascade_declarative_types.cascade_tier_group) ->
-        deprecated_logical_profile_name_error ~kind:"tier-group" group.name)
-      cfg.tier_groups
-  in
-  tier_errors @ tier_group_errors
+    (_cfg : Cascade_declarative_types.cascade_config) =
+  []
 
 (* RFC-0058 Phase 8.3: operator opt-in flag for cold-boot tolerance of
    partial cascade catalogs. Default is [false], preserving the existing
@@ -183,24 +171,6 @@ let validate_strategy ~config_path ~name =
         match Cascade_strategy.parse_config_kind raw_kind with
         | Error msg ->
             [ Printf.sprintf "unknown strategy %S: %s" raw_kind msg ]
-        | Ok Cascade_strategy.Priority_tier -> (
-            match cfg.tiers with
-            | None ->
-                [
-                  "priority_tier requires a non-empty <name>_tiers \
-                   configuration";
-                ]
-            | Some raw_tiers -> (
-                match
-                  Cascade_config.normalize_priority_tiers ~config_path
-                    ~name raw_tiers
-                with
-                | Ok _ -> []
-                | Error msg ->
-                    [
-                      Printf.sprintf
-                        "priority_tier normalization failed: %s" msg;
-                    ]))
         | Ok _ -> [])
   in
   if strategy_errors <> [] then

--- a/lib/cascade/cascade_config_resolve.ml
+++ b/lib/cascade/cascade_config_resolve.ml
@@ -142,57 +142,15 @@ let weighted_entry_of_materialized_member json member =
       | None -> None)
   | _ -> None
 
-let materialized_tier_members json tier_name =
-  match
-    Option.bind (json_assoc_opt "tier" json) (fun tiers_json ->
-        json_assoc_opt tier_name tiers_json)
-  with
-  | Some tier_json -> json_string_list_member "members" tier_json
-  | None -> []
+(* Tier/tier-group purge: [materialized_tier_members] /
+   [materialized_tier_group_tiers] / [configured_weighted_entries_from_materialized_json]
+   are retired.  Profile resolution now routes through the declarative
+   snapshot or runtime catalog exclusively; there is no JSON-materialized
+   tier-based fallback.  [weighted_entry_of_materialized_member] is kept
+   for the direct-provider:model path in future refactor phases. *)
 
-let materialized_tier_group_tiers json group_name =
-  match
-    Option.bind (json_assoc_opt "tier-group" json) (fun groups_json ->
-        json_assoc_opt group_name groups_json)
-  with
-  | Some group_json -> json_string_list_member "tiers" group_json
-  | None -> []
-
-let configured_weighted_entries_from_materialized_json json ~name =
-  let trimmed = String.trim name in
-  let candidates =
-    if String.starts_with ~prefix:"tier-group." trimmed
-       || String.starts_with ~prefix:"tier." trimmed
-    then [ trimmed ]
-    else [ trimmed; "tier-group." ^ trimmed; "tier." ^ trimmed ]
-  in
-  let resolve_profile profile_name =
-    if String.starts_with ~prefix:"tier-group." profile_name then
-      let group_name =
-        String.sub profile_name 11 (String.length profile_name - 11)
-      in
-      Some
-        (materialized_tier_group_tiers json group_name
-         |> List.concat_map (materialized_tier_members json)
-         |> List.filter_map (weighted_entry_of_materialized_member json))
-    else if String.starts_with ~prefix:"tier." profile_name then
-      let tier_name =
-        String.sub profile_name 5 (String.length profile_name - 5)
-      in
-      Some
-        (materialized_tier_members json tier_name
-         |> List.filter_map (weighted_entry_of_materialized_member json))
-    else None
-  in
-  match
-    candidates
-    |> List.find_map (fun candidate ->
-           match resolve_profile candidate with
-           | Some (_ :: _ as entries) -> Some entries
-           | Some [] | None -> None)
-  with
-  | Some entries -> entries
-  | None -> []
+let configured_weighted_entries_from_materialized_json _json ~name:_ =
+  []
 
 (* ── resolve_model_strings family ────────────────────── *)
 

--- a/lib/cascade/cascade_config_strategy_resolve.ml
+++ b/lib/cascade/cascade_config_strategy_resolve.ml
@@ -18,18 +18,6 @@ let warn_unknown_strategy ~name ~raw ~msg ~fallback_kind =
       name msg (Cascade_strategy.kind_to_string fallback_kind)
   end
 
-let invalid_priority_tier_warned : (string * string, unit) Hashtbl.t =
-  Hashtbl.create 4
-
-let warn_invalid_priority_tier ~name ~msg ~fallback_kind =
-  let key = (name, msg) in
-  if not (Hashtbl.mem invalid_priority_tier_warned key) then begin
-    Hashtbl.add invalid_priority_tier_warned key ();
-    Log.Keeper.warn
-      "cascade %s: %s; falling back to %s"
-      name msg (Cascade_strategy.kind_to_string fallback_kind)
-  end
-
 let default_strategy_kind ?config_path ~name () =
   let (_ : string option) = config_path in
   let (_ : string) = name in
@@ -70,42 +58,6 @@ let model_ids_of_specs (specs : string list) : string list =
          | _ -> None)
   |> List.sort_uniq String.compare
 
-let normalize_priority_tiers ~config_path ~name raw_tiers =
-  (* Probe the active TOML before resolving declarative candidates so an
-     unreadable cascade.toml surfaces as a load-failure error instead of the
-     generic "no configured models" message — the latter mis-leads
-     operators into thinking the profile is empty when the file is broken. *)
-  match Cascade_config_loader.load_catalog_source config_path with
-  | Error msg ->
-      Error
-        (Printf.sprintf
-           "priority_tier validation skipped: cascade config load failed: %s"
-           msg)
-  | Ok json ->
-  let configured_model_ids =
-    Resolve.configured_weighted_entries_from_materialized_json json ~name
-    |> List.map (fun (entry : Cascade_config_loader.weighted_entry) -> entry.model)
-    |> model_ids_of_specs
-  in
-  if configured_model_ids = [] then
-    Error "priority_tier has no configured models to validate against"
-  else
-    let normalized =
-      raw_tiers
-      |> List.filter_map (fun tier ->
-             let tier_model_ids =
-               model_ids_of_specs tier
-               |> List.filter (fun model_id ->
-                      List.mem model_id configured_model_ids)
-             in
-             if tier_model_ids = [] then None else Some tier_model_ids)
-    in
-    if normalized = [] then
-      Error
-        "priority_tier tiers did not match any configured candidate model ids"
-    else
-      Ok normalized
-
 let resolve_strategy ?config_path ~name () =
   match config_path with
   | None -> Cascade_strategy.failover
@@ -117,25 +69,6 @@ let resolve_strategy ?config_path ~name () =
       parse_kind_or_default ~name ~default_kind cfg.kind
     in
     let cycle = cycle_policy_from_loader cfg in
-    let kind, tiers =
-      match parsed_kind with
-      | Cascade_strategy.Priority_tier ->
-          let result =
-            match cfg.tiers with
-            | Some raw_tiers ->
-                normalize_priority_tiers ~config_path:path ~name raw_tiers
-            | None ->
-                Error
-                  "priority_tier requires a non-empty <name>_tiers configuration"
-          in
-          (match result with
-           | Ok tiers -> (parsed_kind, tiers)
-           | Error msg ->
-               warn_invalid_priority_tier
-                 ~name ~msg ~fallback_kind:default_kind;
-               (default_kind, []))
-      | _ -> (parsed_kind, [])
-    in
     ignore cfg.sticky_ttl_ms;
     ignore cfg.latency_baseline_ms;
     ignore cfg.rate_limit_recency_window_s;
@@ -144,7 +77,7 @@ let resolve_strategy ?config_path ~name () =
     ignore cfg.server_error_recency_window_s;
     ignore cfg.server_error_decay_base;
     ignore cfg.server_error_skip_after;
-    { Cascade_strategy.kind; cycle; tiers }
+    { Cascade_strategy.kind = parsed_kind; cycle; tiers = [] }
 
 let resolve_ollama_max_concurrent ?config_path ~name () =
   match config_path with

--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -19,7 +19,6 @@ type adapter_error =
   | Binding_resolution_failed of string
   | Alias_resolution_failed of string
   | Strategy_mismatch of string
-  | Tier_group_empty of string
   | Duplicate_route of string
   | Internal of string
 [@@deriving show]
@@ -365,7 +364,6 @@ let apply_alias_overrides (base : Llm_provider.Provider_config.t)
 let map_strategy_kind (decl : cascade_strategy) : Cascade_strategy.kind =
   match decl with
   | Failover -> Cascade_strategy.Failover
-  | Priority_tier -> Cascade_strategy.Priority_tier
 
 let map_cycle_policy (cp : cascade_cycle_policy) :
     Cascade_strategy.cycle_policy =
@@ -373,34 +371,6 @@ let map_cycle_policy (cp : cascade_cycle_policy) :
     Cascade_strategy.max_cycles = cp.max_cycles;
     backoff_base_ms = cp.backoff_base_ms;
     backoff_cap_ms = cp.backoff_cap_ms;
-  }
-
-let build_strategy (tier : cascade_tier) : Cascade_strategy.t =
-  let kind = map_strategy_kind tier.strategy in
-  let cycle =
-    match tier.cycle_policy with
-    | Some cp -> map_cycle_policy cp
-    | None -> Cascade_strategy.default_cycle_policy
-  in
-  ignore tier.sticky_ttl_ms;
-  ignore tier.scoring_params;
-  { Cascade_strategy.kind; cycle; tiers = [] }
-
-let build_tier_group_strategy (tg : cascade_tier_group)
-    (tier_tiers : string list list) : Cascade_strategy.t =
-  let kind = map_strategy_kind tg.strategy in
-  let cycle =
-    match kind with
-    | Cascade_strategy.Priority_tier ->
-      { Cascade_strategy.default_cycle_policy with
-        max_cycles = max 1 (List.length tier_tiers)
-      }
-    | Cascade_strategy.Failover -> Cascade_strategy.default_cycle_policy
-  in
-  {
-    Cascade_strategy.kind;
-    cycle;
-    tiers = tier_tiers;
   }
 
 (* --- Member resolution --- *)
@@ -442,71 +412,6 @@ let resolve_member (cfg : cascade_config)
          errors := Binding_resolution_failed member :: !errors;
          None)
 
-(* --- Tier → adapted_profile --- *)
-
-let build_profile_from_tier (cfg : cascade_config)
-    (bindings_by_key : (string, cascade_binding) Hashtbl.t)
-    (aliases_by_key : (string, cascade_alias) Hashtbl.t)
-    (resolved_configs : (string, provider_config_with_override) Hashtbl.t)
-    (errors : adapter_error list ref)
-    (tier : cascade_tier) :
-    adapted_profile =
-  let provider_configs =
-    List.filter_map
-      (resolve_member cfg bindings_by_key aliases_by_key
-         resolved_configs errors)
-      tier.members
-  in
-  let strategy = build_strategy tier in
-  {
-    name = Printf.sprintf "tier.%s" tier.name;
-    provider_configs;
-    strategy;
-    ollama_max_concurrent = tier.max_concurrent;
-    cli_max_concurrent = tier.max_concurrent;
-    required_capability_profile = None;
-  }
-
-(* --- Tier-group → adapted_profile --- *)
-
-let build_profile_from_tier_group (cfg : cascade_config)
-    (bindings_by_key : (string, cascade_binding) Hashtbl.t)
-    (aliases_by_key : (string, cascade_alias) Hashtbl.t)
-    (resolved_configs : (string, provider_config_with_override) Hashtbl.t)
-    (tiers_by_name : (string, cascade_tier) Hashtbl.t)
-    (errors : adapter_error list ref)
-    (tg : cascade_tier_group) :
-    adapted_profile =
-  let resolved_tiers =
-    List.filter_map
-      (fun name -> Hashtbl.find_opt tiers_by_name name)
-      tg.tiers
-  in
-  let resolved_configs_by_tier =
-    List.map
-      (fun (tier : cascade_tier) ->
-         List.filter_map
-           (resolve_member cfg bindings_by_key aliases_by_key
-              resolved_configs errors)
-           tier.members)
-      resolved_tiers
-  in
-  let provider_configs = List.concat resolved_configs_by_tier in
-  let tier_member_keys =
-    List.map
-      (List.map (fun (cfg, _) -> provider_health_key_of_config cfg))
-      resolved_configs_by_tier
-  in
-  let strategy = build_tier_group_strategy tg tier_member_keys in
-  {
-    name = Printf.sprintf "tier-group.%s" tg.name;
-    provider_configs;
-    strategy;
-    ollama_max_concurrent = None;
-    cli_max_concurrent = None;
-    required_capability_profile = tg.required_capability_profile;
-  }
-
 (* --- Route target resolution --- *)
 
 let resolve_route_target (target : string)
@@ -526,18 +431,11 @@ let resolve_system_target (target : string)
 
 (* --- Default profile detection --- *)
 
-let find_default_profile (cfg : cascade_config)
-    (profile_names : string list)
-    (bindings_by_key : (string, cascade_binding) Hashtbl.t) :
+let find_default_profile (_cfg : cascade_config)
+    (_profile_names : string list)
+    (_bindings_by_key : (string, cascade_binding) Hashtbl.t) :
     string option =
-  let has_default =
-    List.exists (fun (b : cascade_binding) -> b.is_default) cfg.bindings
-  in
-  if not has_default then None
-  else List.find_opt (fun name ->
-    String.starts_with ~prefix:"tier." name ||
-    String.starts_with ~prefix:"tier-group." name)
-    profile_names
+  None
 
 (* --- Duplicate route detection --- *)
 
@@ -573,11 +471,6 @@ let adapt_config (cfg : cascade_config) : adapted_catalog =
     Hashtbl.replace aliases_by_key key a)
     cfg.aliases;
 
-  let tiers_by_name = Hashtbl.create 8 in
-  List.iter (fun (t : cascade_tier) ->
-    Hashtbl.replace tiers_by_name t.name t)
-    cfg.tiers;
-
   (* Resolved configs cache (member key → provider_config_with_override) *)
   let resolved_configs = Hashtbl.create 32 in
 
@@ -589,61 +482,14 @@ let adapt_config (cfg : cascade_config) : adapted_catalog =
     | None -> ())
     cfg.bindings;
 
-  (* Build profiles from tiers *)
-  let tier_profiles =
-    List.map
-      (build_profile_from_tier cfg bindings_by_key aliases_by_key
-         resolved_configs errors)
-      cfg.tiers
-  in
-
-  (* Build profiles from tier-groups *)
-  let tg_profiles =
-    List.map
-      (build_profile_from_tier_group cfg bindings_by_key aliases_by_key
-         resolved_configs tiers_by_name errors)
-      cfg.tier_groups
-  in
-
-  let all_profiles = tier_profiles @ tg_profiles in
-  let profile_names = List.map (fun p -> p.name) all_profiles in
+  let all_profiles = [] in
+  let profile_names = [] in
 
   (* Resolve routes *)
   let route_errors = check_duplicate_routes cfg.routes in
   let routes =
     List.filter_map (fun (r : cascade_route) ->
-      (* Route target can be: tier-group.X, tier.X, or a binding key *)
-      let target_profile =
-        if String.starts_with ~prefix:"tier-group." r.target then
-          resolve_route_target r.target profile_names
-        else if String.starts_with ~prefix:"tier." r.target then
-          resolve_route_target r.target profile_names
-        else
-          (* Binding or alias key → find the profile that contains it *)
-          let matching_profile =
-            List.find_opt (fun (p : adapted_profile) ->
-              List.exists
-                (fun (pc, _override) ->
-                  let model_string =
-                    Printf.sprintf "%s:%s"
-                      (Llm_provider.Provider_kind.to_string pc.Llm_provider.Provider_config.kind)
-                      pc.Llm_provider.Provider_config.model_id
-                  in
-                  String.starts_with ~prefix:r.target model_string)
-                p.provider_configs)
-            all_profiles
-          in
-          match matching_profile with
-          | Some p -> Some p.name
-          | None -> None
-      in
-      match target_profile with
-      | Some name -> Some (r.name, name)
-      | None ->
-        errors := Internal
-          (Printf.sprintf "route %S target %S unresolved" r.name r.target)
-          :: !errors;
-        None)
+      Some (r.name, r.target))
       cfg.routes
   in
 

--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -495,52 +495,11 @@ let declarative_member_exists (cfg : Cascade_declarative_types.cascade_config) m
             member)
        cfg.bindings
 
-let declarative_tier_members (cfg : Cascade_declarative_types.cascade_config)
-    tier_name =
-  let open Cascade_declarative_types in
-  match
-    cfg.tiers
-    |> List.find_opt (fun (tier : cascade_tier) ->
-         String.equal tier.name tier_name)
-  with
-  | Some tier -> tier.members
-  | None -> []
-
-let declarative_tier_group_members
-    (cfg : Cascade_declarative_types.cascade_config)
-    group_name =
-  let open Cascade_declarative_types in
-  let tiers_by_name = Hashtbl.create (List.length cfg.tiers) in
-  List.iter
-    (fun (tier : cascade_tier) -> Hashtbl.replace tiers_by_name tier.name tier)
-    cfg.tiers;
-  match
-    cfg.tier_groups
-    |> List.find_opt (fun (group : cascade_tier_group) ->
-         String.equal group.name group_name)
-  with
-  | None -> []
-  | Some group ->
-      group.tiers
-      |> List.filter_map (Hashtbl.find_opt tiers_by_name)
-      |> List.concat_map (fun (tier : cascade_tier) -> tier.members)
-
 let declarative_members_for_profile
     (cfg : Cascade_declarative_types.cascade_config)
     profile_name =
-  match strip_prefix ~prefix:"tier." profile_name with
-  | Some tier_name -> declarative_tier_members cfg tier_name
-  | None -> (
-      match strip_prefix ~prefix:"tier-group." profile_name with
-      | Some group_name -> declarative_tier_group_members cfg group_name
-      | None ->
-          let group_members = declarative_tier_group_members cfg profile_name in
-          if group_members <> [] then group_members
-          else
-            let tier_members = declarative_tier_members cfg profile_name in
-            if tier_members <> [] then tier_members
-            else if declarative_member_exists cfg profile_name then [ profile_name ]
-            else [])
+  if declarative_member_exists cfg profile_name then [ profile_name ]
+  else []
 
 let declarative_route_target
     (cfg : Cascade_declarative_types.cascade_config)
@@ -556,12 +515,6 @@ let declarative_route_target
     |> List.find_opt (fun (route : cascade_route) -> String.equal route.name route_key)
     |> Option.map (fun route -> route.target)
 
-let first_nonempty_members cfg candidates =
-  candidates
-  |> List.find_map (fun profile_name ->
-       let members = declarative_members_for_profile cfg profile_name in
-       if members = [] then None else Some members)
-
 let max_output_tokens_ceiling_of_cascade_name cascade_name =
   match cascade_config_path () with
   | None -> None
@@ -570,19 +523,15 @@ let max_output_tokens_ceiling_of_cascade_name cascade_name =
       | Error _ -> None
       | Ok cfg ->
           let raw_name = cascade_name_to_string cascade_name in
-          let resolved_name =
-            match Cascade_catalog_runtime.resolve_declared_name ~raw_name () with
-            | Ok resolved -> Some (Cascade_name.to_string resolved)
-            | Error _ -> None
+          let members =
+            if declarative_member_exists cfg raw_name then [ raw_name ]
+            else []
           in
-          [ resolved_name; declarative_route_target cfg raw_name; Some raw_name ]
-          |> List.filter_map Fun.id
-          |> first_nonempty_members cfg
-          |> Option.map (fun members ->
-               members
-               |> List.map (declarative_member_max_output_tokens cfg)
-               |> min_positive_int_options)
-          |> Option.join)
+          if members = [] then None
+          else
+            members
+            |> List.map (declarative_member_max_output_tokens cfg)
+            |> min_positive_int_options)
 
 let resolve_named_providers_result ?provider_filter
     ?(require_tool_choice_support = false)

--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -100,21 +100,20 @@ let json_string_list_member key = function
       | _ -> [])
   | _ -> []
 
-let profile_names_from_namespace ~prefix = function
-  | Some (`Assoc fields) ->
-    fields
-    |> List.filter_map (fun (name, _value) ->
-           let name = String.trim name in
-           if String.equal name ""
-           then None
-           else Some (Printf.sprintf "%s.%s" prefix name))
-  | _ -> []
-
 let discover_profiles_from_materialized_json json =
-  profile_names_from_namespace ~prefix:"tier" (assoc_opt "tier" json)
-  @ profile_names_from_namespace ~prefix:"tier-group"
-      (assoc_opt "tier-group" json)
-  |> List.sort_uniq String.compare
+  (* Tier/tier-group purge: profiles are route targets (provider:model strings).
+     Discovery reads [routes.*.target] from the materialized JSON. *)
+  match assoc_opt "routes" json with
+  | Some (`Assoc routes) ->
+    routes
+    |> List.filter_map (fun (_name, route_json) ->
+           match assoc_opt "target" route_json with
+           | Some (`String target) ->
+               let trimmed = String.trim target in
+               if String.equal trimmed "" then None else Some trimmed
+           | _ -> None)
+    |> List.sort_uniq String.compare
+  | _ -> []
 
 let discover_profiles_impl ~emit_telemetry ~config_path =
   let load_catalog_source =
@@ -132,39 +131,11 @@ let discover_profiles ~config_path =
 let discover_profiles_for_diagnostics ~config_path =
   discover_profiles_impl ~emit_telemetry:false ~config_path
 
-let materialized_tier_members json tier_name =
-  match
-    Option.bind (assoc_opt "tier" json) (fun tiers_json ->
-        assoc_opt tier_name tiers_json)
-  with
-  | Some tier_json -> json_string_list_member "members" tier_json
-  | None -> []
-
-let materialized_tier_group_tiers json group_name =
-  match
-    Option.bind (assoc_opt "tier-group" json) (fun groups_json ->
-        assoc_opt group_name groups_json)
-  with
-  | Some group_json -> json_string_list_member "tiers" group_json
-  | None -> []
-
-let materialized_model_specs_for_profile json profile =
-  let tier_group_prefix = "tier-group." in
-  let tier_prefix = "tier." in
-  if String.starts_with ~prefix:tier_group_prefix profile then
-    let group_name =
-      String.sub profile (String.length tier_group_prefix)
-        (String.length profile - String.length tier_group_prefix)
-    in
-    materialized_tier_group_tiers json group_name
-    |> List.concat_map (materialized_tier_members json)
-  else if String.starts_with ~prefix:tier_prefix profile then
-    let tier_name =
-      String.sub profile (String.length tier_prefix)
-        (String.length profile - String.length tier_prefix)
-    in
-    materialized_tier_members json tier_name
-  else []
+(* Tier/tier-group purge: [materialized_model_specs_for_profile] and its
+   helpers [materialized_tier_members] / [materialized_tier_group_tiers]
+   are removed.  Profile model specs now come exclusively from the
+   declarative snapshot or runtime profile build; there is no JSON
+   materialized fallback for tier-based resolution. *)
 
 let model_ids_of_specs (specs : string list) : string list =
   specs
@@ -180,57 +151,8 @@ let format_spec_errors specs =
   |> List.map (fun (spec, msg) -> Printf.sprintf "%S (%s)" spec msg)
   |> String.concat ", "
 
-let priority_tier_issue ~profile configured_specs raw_tiers =
-  let configured_model_ids = model_ids_of_specs configured_specs in
-  if configured_model_ids = [] then
-    Some
-      {
-        profile = Some profile;
-        severity = Catalog_error;
-        message =
-          Printf.sprintf
-            "Cascade preset %s uses priority_tier but has no configured \
-             models to validate."
-            profile;
-      }
-  else
-    let normalized =
-      raw_tiers
-      |> List.filter_map (fun tier ->
-             let tier_model_ids =
-               model_ids_of_specs tier
-               |> List.filter (fun model_id ->
-                      List.mem model_id configured_model_ids)
-             in
-             if tier_model_ids = [] then None else Some tier_model_ids)
-    in
-    if normalized = [] then
-      Some
-        {
-          profile = Some profile;
-          severity = Catalog_error;
-          message =
-            Printf.sprintf
-              "Cascade preset %s uses priority_tier, but every tier \
-               collapses after model-id normalization; runtime will fall \
-               back to failover."
-              profile;
-        }
-    else if List.length normalized < List.length raw_tiers then
-      Some
-        {
-          profile = Some profile;
-          severity = Catalog_warn;
-          message =
-            Printf.sprintf
-              "Cascade preset %s uses priority_tier, but %d/%d tier(s) \
-               collapse after model-id normalization."
-              profile
-              (List.length raw_tiers - List.length normalized)
-              (List.length raw_tiers);
-        }
-    else
-      None
+(* Tier/tier-group purge: [priority_tier_issue] removed with the
+   [priority_tier] strategy concept. *)
 
 (* Catalog warn: a cascade carrying [cli_tool_a] with no
    bound-actor-tolerant fallback will reject every keeper-bound
@@ -448,7 +370,7 @@ let diagnose_profile ~materialized_json ~declarative_snapshot ~emit_telemetry
       List.map
         (fun (entry : Cascade_config_loader.weighted_entry) -> entry.model)
         p.weighted_entries
-    | None -> materialized_model_specs_for_profile materialized_json profile
+    | None -> []
   in
   let candidate_model_strings =
     match snapshot_profile with

--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -1,8 +1,8 @@
 (** Declarative cascade TOML parser (RFC-0058 v2).
 
     Parses the 5-layer TOML schema into typed [cascade_config].
-    Reserved top-level namespaces: providers, models, system, tier,
-    tier-group, routes, profiles. Any other top-level table is a
+    Reserved top-level namespaces: providers, models, system, routes,
+    profiles. Any other top-level table is a
     provider alias, with sub-tables as model bindings or aliases. *)
 
 open Cascade_declarative_types
@@ -526,7 +526,7 @@ let parse_models (toml : Otoml.t) : (cascade_model_spec list, parse_error list) 
 (* --- Reserved namespace detection --- *)
 
 let reserved_namespaces =
-  [ "providers"; "models"; "system"; "tier"; "tier-group"; "routes"; "profiles" ]
+  [ "providers"; "models"; "system"; "routes"; "profiles" ]
 ;;
 
 let is_reserved (name : string) : bool = List.mem name reserved_namespaces
@@ -671,11 +671,10 @@ let parse_bindings_and_aliases (toml : Otoml.t)
 let strategy_of_string (s : string) : (cascade_strategy, string) result =
   match s with
   | "failover" -> Ok Failover
-  | "priority_tier" -> Ok Priority_tier
   | _ ->
     Error
       (Printf.sprintf
-         "unsupported strategy %S: expected one of failover, priority_tier"
+         "unsupported strategy %S: expected one of failover"
          s)
 ;;
 
@@ -723,85 +722,6 @@ let keeper_assignable_result path tbl =
           keeper-assignable or keeper_assignable")
   | Some _ as value, None | None, (Some _ as value) -> Ok value
   | None, None -> Ok None
-;;
-
-let parse_tier (name : string) (tbl : Otoml.t) : (cascade_tier, parse_error list) result =
-  let path = Printf.sprintf "tier.%s" name in
-  let members =
-    match Otoml.find_opt tbl (Otoml.get_array Otoml.get_string) [ "members" ] with
-    | Some m -> m
-    | None -> []
-  in
-  let strategy_result =
-    match Otoml.find_opt tbl Otoml.get_string [ "strategy" ] with
-    | Some s -> strategy_of_string s
-    | None -> Ok Failover
-  in
-  match strategy_result, keeper_assignable_result path tbl with
-  | Error e, _ -> Error (error (path ^ ".strategy") e)
-  | _, Error e -> Error e
-  | Ok strategy, Ok keeper_assignable ->
-    let max_concurrent = Otoml.find_opt tbl Otoml.get_integer [ "max-concurrent" ] in
-    let cycle_policy = parse_cycle_policy tbl in
-    let sticky_ttl_ms = Otoml.find_opt tbl Otoml.get_integer [ "sticky-ttl-ms" ] in
-    let scoring_params = parse_scoring_params tbl in
-    Ok
-      { name
-      ; members
-      ; strategy
-      ; max_concurrent
-      ; cycle_policy
-      ; sticky_ttl_ms
-      ; scoring_params
-      ; keeper_assignable
-      }
-;;
-
-let parse_tiers (toml : Otoml.t) : (cascade_tier list, parse_error list) result =
-  match Otoml.find_opt toml Fun.id [ "tier" ] with
-  | None -> Ok []
-  | Some tier_tbl ->
-    let entries = Otoml.get_table tier_tbl in
-    partition_results
-      (List.map (fun (name, tbl) -> parse_tier name tbl) entries)
-;;
-
-(* --- Layer 5b: Tier Groups --- *)
-
-let parse_tier_group (name : string) (tbl : Otoml.t)
-  : (cascade_tier_group, parse_error list) result
-  =
-  let path = Printf.sprintf "tier-group.%s" name in
-  let tiers =
-    match Otoml.find_opt tbl (Otoml.get_array Otoml.get_string) [ "tiers" ] with
-    | Some t -> t
-    | None -> []
-  in
-  let strategy_result =
-    match Otoml.find_opt tbl Otoml.get_string [ "strategy" ] with
-    | Some s -> strategy_of_string s
-    | None -> Ok Failover
-  in
-  match strategy_result, keeper_assignable_result path tbl with
-  | Error e, _ -> Error (error (path ^ ".strategy") e)
-  | _, Error e -> Error e
-  | Ok strategy, Ok keeper_assignable ->
-    let fallback = Otoml.find_or ~default:false tbl Otoml.get_boolean [ "fallback" ] in
-    let required_capability_profile =
-      Otoml.find_opt tbl Otoml.get_string [ "required_capability_profile" ]
-    in
-    Ok { name; tiers; strategy; fallback; keeper_assignable; required_capability_profile }
-;;
-
-let parse_tier_groups (toml : Otoml.t)
-  : (cascade_tier_group list, parse_error list) result
-  =
-  match Otoml.find_opt toml Fun.id [ "tier-group" ] with
-  | None -> Ok []
-  | Some tg_tbl ->
-    let entries = Otoml.get_table tg_tbl in
-    partition_results
-      (List.map (fun (name, tbl) -> parse_tier_group name tbl) entries)
 ;;
 
 (* --- Layer 5c: Routes --- *)
@@ -885,12 +805,9 @@ let extract_after_all_errors_guard ~label = function
 let parse_toml (toml : Otoml.t) : (cascade_config, parse_error list) result =
   let providers_result = parse_providers toml in
   let models_result = parse_models toml in
-  let tiers_result = parse_tiers toml in
-  let tier_groups_result = parse_tier_groups toml in
   let errs = function Ok _ -> [] | Error errs -> errs in
   let all_errors =
     errs providers_result @ errs models_result
-    @ errs tiers_result @ errs tier_groups_result
   in
   let bindings, aliases = parse_bindings_and_aliases toml in
   let routes = parse_routes toml in
@@ -903,12 +820,8 @@ let parse_toml (toml : Otoml.t) : (cascade_config, parse_error list) result =
       extract_after_all_errors_guard ~label:"providers" providers_result
     in
     let models = extract_after_all_errors_guard ~label:"models" models_result in
-    let tiers = extract_after_all_errors_guard ~label:"tiers" tiers_result in
-    let tier_groups =
-      extract_after_all_errors_guard ~label:"tier_groups" tier_groups_result
-    in
     Ok
-      { providers; models; bindings; aliases; tiers; tier_groups; routes; system_targets; profiles })
+      { providers; models; bindings; aliases; routes; system_targets; profiles })
 ;;
 
 let parse_string (content : string) : (cascade_config, parse_error list) result =

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -311,7 +311,6 @@ type cascade_alias =
 
 type cascade_strategy =
   | Failover
-  | Priority_tier
 [@@deriving show, eq]
 
 type cascade_cycle_policy =
@@ -329,28 +328,6 @@ type cascade_scoring_params =
   ; server_error_recency_window_s : float
   ; server_error_decay_base : float
   ; server_error_skip_after : int
-  }
-[@@deriving show, eq]
-
-type cascade_tier =
-  { name : string
-  ; members : string list
-  ; strategy : cascade_strategy
-  ; max_concurrent : int option
-  ; cycle_policy : cascade_cycle_policy option
-  ; sticky_ttl_ms : int option
-  ; scoring_params : cascade_scoring_params option
-  ; keeper_assignable : bool option
-  }
-[@@deriving show, eq]
-
-type cascade_tier_group =
-  { name : string
-  ; tiers : string list
-  ; strategy : cascade_strategy
-  ; fallback : bool
-  ; keeper_assignable : bool option
-  ; required_capability_profile : string option
   }
 [@@deriving show, eq]
 
@@ -372,8 +349,6 @@ type cascade_config =
   ; models : cascade_model_spec list
   ; bindings : cascade_binding list
   ; aliases : cascade_alias list
-  ; tiers : cascade_tier list
-  ; tier_groups : cascade_tier_group list
   ; routes : cascade_route list
   ; system_targets : cascade_route list
   ; profiles : cascade_profile list

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -247,7 +247,6 @@ type cascade_alias =
 
 type cascade_strategy =
   | Failover
-  | Priority_tier
 [@@deriving show, eq]
 
 (** {1 Strategy-specific parameter types} *)
@@ -270,29 +269,7 @@ type cascade_scoring_params =
   }
 [@@deriving show, eq]
 
-(** {1 Layer 5: Tiers, Tier-Groups, Routes} *)
-
-type cascade_tier =
-  { name : string
-  ; members : string list
-  ; strategy : cascade_strategy
-  ; max_concurrent : int option
-  ; cycle_policy : cascade_cycle_policy option
-  ; sticky_ttl_ms : int option
-  ; scoring_params : cascade_scoring_params option
-  ; keeper_assignable : bool option
-  }
-[@@deriving show, eq]
-
-type cascade_tier_group =
-  { name : string
-  ; tiers : string list
-  ; strategy : cascade_strategy
-  ; fallback : bool
-  ; keeper_assignable : bool option
-  ; required_capability_profile : string option
-  }
-[@@deriving show, eq]
+(** {1 Layer 5: Routes} *)
 
 type cascade_route =
   { name : string
@@ -314,8 +291,6 @@ type cascade_config =
   ; models : cascade_model_spec list
   ; bindings : cascade_binding list
   ; aliases : cascade_alias list
-  ; tiers : cascade_tier list
-  ; tier_groups : cascade_tier_group list
   ; routes : cascade_route list
   ; system_targets : cascade_route list
   ; profiles : cascade_profile list

--- a/lib/cascade_decl/cascade_declarative_validator.ml
+++ b/lib/cascade_decl/cascade_declarative_validator.ml
@@ -1,16 +1,15 @@
 (** Declarative cascade config cross-reference validator (RFC-0058 v2).
 
-    Validates 11 load-time invariants on a parsed [cascade_config]:
+    Validates load-time invariants on a parsed [cascade_config].
+    Tier/tier-group purge: R5-R6 removed, R7 simplified.
+
     R1: Every binding references an existing provider
     R2: Every binding references an existing model
     R3: Every alias references an existing binding
     R4: Alias max-input ≤ model max-context
-    R5: Tier members resolve to valid bindings or aliases
-    R6: Tier-group tiers reference existing tiers
-    R7: Route targets reference existing tier-groups, tiers, or bindings
+    R7: Route targets reference existing bindings or aliases
     R8: System targets reference existing bindings or aliases
     R9: At most one is-default=true per provider
-    R10: Strategy-specific fields match the declared strategy
     R11: Binding max-concurrent required and positive (RFC-0058 §3.4)
     R12: Protocol ↔ transport consistency (RFC-0058 §2.1) *)
 
@@ -45,19 +44,8 @@ let alias_keys (cfg : cascade_config) : string list =
     cfg.aliases
 ;;
 
-let tier_names (cfg : cascade_config) : string list =
-  List.map (fun (t : cascade_tier) -> Printf.sprintf "tier.%s" t.name) cfg.tiers
-;;
-
-let tier_names_bare (cfg : cascade_config) : string list =
-  List.map (fun (t : cascade_tier) -> t.name) cfg.tiers
-;;
-
-let tier_group_names (cfg : cascade_config) : string list =
-  List.map
-    (fun (g : cascade_tier_group) -> Printf.sprintf "tier-group.%s" g.name)
-    cfg.tier_groups
-;;
+(* Tier/tier-group purge: tier_names, tier_names_bare, tier_group_names
+   removed.  Route targets resolve directly to bindings/aliases. *)
 
 (* Build a name-keyed Hashtbl once for O(1) membership.  Eight
    validator rules below (R1-R8) used to do [List.mem key list]
@@ -155,58 +143,12 @@ let validate_alias_max_input (cfg : cascade_config) : validation_error list =
     cfg.aliases
 ;;
 
-(* --- R5: Tier members resolve to binding or alias --- *)
-
-let validate_tier_members (cfg : cascade_config) : validation_error list =
-  let all_valid_set = name_set (binding_keys cfg @ alias_keys cfg) in
-  List.concat_map
-    (fun (t : cascade_tier) ->
-       List.filter_map
-         (fun member ->
-            if Hashtbl.mem all_valid_set member
-            then None
-            else
-              Some
-                { rule = "R5"
-                ; path = Printf.sprintf "tier.%s.members" t.name
-                ; message =
-                    Printf.sprintf
-                      "tier member %S does not resolve to any binding or alias"
-                      member
-                })
-         t.members)
-    cfg.tiers
-;;
-
-(* --- R6: Tier-group tiers reference existing tiers --- *)
-
-let validate_tier_group_refs (cfg : cascade_config) : validation_error list =
-  let tnames_set = name_set (tier_names_bare cfg) in
-  List.concat_map
-    (fun (g : cascade_tier_group) ->
-       List.filter_map
-         (fun tier_name ->
-            if Hashtbl.mem tnames_set tier_name
-            then None
-            else
-              Some
-                { rule = "R6"
-                ; path = Printf.sprintf "tier-group.%s.tiers" g.name
-                ; message =
-                    Printf.sprintf "tier-group references unknown tier %S" tier_name
-                })
-         g.tiers)
-    cfg.tier_groups
-;;
-
-(* --- R7: Route targets exist --- *)
+(* --- R7: Route targets exist ---
+   Tier/tier-group purge: route targets resolve directly to bindings
+   or aliases. No tier-group or tier indirection. *)
 
 let validate_route_targets (cfg : cascade_config) : validation_error list =
-  let all_targets_set =
-    name_set
-      (tier_group_names cfg @ tier_names cfg
-      @ binding_keys cfg @ alias_keys cfg)
-  in
+  let all_targets_set = name_set (binding_keys cfg @ alias_keys cfg) in
   List.filter_map
     (fun (r : cascade_route) ->
        if Hashtbl.mem all_targets_set r.target
@@ -217,8 +159,7 @@ let validate_route_targets (cfg : cascade_config) : validation_error list =
            ; path = Printf.sprintf "routes.%s.target" r.name
            ; message =
                Printf.sprintf
-                 "route target %S does not resolve to any tier-group, tier, binding, or \
-                  alias"
+                 "route target %S does not resolve to any binding or alias"
                  r.target
            })
     cfg.routes
@@ -268,41 +209,7 @@ let validate_single_default (cfg : cascade_config) : validation_error list =
     counts
 ;;
 
-(* --- R10: Strategy-specific fields match declared strategy --- *)
-
-let validate_strategy_fields (cfg : cascade_config) : validation_error list =
-  List.concat_map
-    (fun (t : cascade_tier) ->
-       let path = Printf.sprintf "tier.%s" t.name in
-       let retired_field_errors field_name retired_strategy =
-         err
-           "R10"
-           (Printf.sprintf "%s.%s" path field_name)
-           (Printf.sprintf
-              "%s belongs to retired internal strategy %S and is not \
-               supported by cascade.toml strategy %s"
-              field_name
-              retired_strategy
-              (show_cascade_strategy t.strategy))
-       in
-       let cycle_errs =
-         match t.cycle_policy with
-         | None -> []
-         | Some _ -> retired_field_errors "cycle-policy" "circuit_breaker_cycling"
-       in
-       let sticky_errs =
-         match t.sticky_ttl_ms with
-         | None -> []
-         | Some _ -> retired_field_errors "sticky-ttl-ms" "sticky"
-       in
-       let scoring_errs =
-         match t.scoring_params with
-         | None -> []
-         | Some _ -> retired_field_errors "scoring-params" "weighted_random"
-       in
-       cycle_errs @ sticky_errs @ scoring_errs)
-    cfg.tiers
-;;
+(* R10 (strategy fields) removed with tier/tier-group purge. *)
 
 (* --- R11: Binding max-concurrent is required and positive ---
 
@@ -387,12 +294,9 @@ let validate (cfg : cascade_config) : validation_error list =
   @ validate_binding_models cfg
   @ validate_alias_bindings cfg
   @ validate_alias_max_input cfg
-  @ validate_tier_members cfg
-  @ validate_tier_group_refs cfg
   @ validate_route_targets cfg
   @ validate_system_targets cfg
   @ validate_single_default cfg
-  @ validate_strategy_fields cfg
   @ validate_binding_capacity cfg
   @ validate_protocol_transport cfg
 ;;

--- a/lib/cascade_name/cascade_name.ml
+++ b/lib/cascade_name/cascade_name.ml
@@ -1,15 +1,15 @@
-let canonical_prefixes = [ "tier-group."; "tier."; "route." ]
-
-let is_canonical_prefix s =
-  List.exists (fun prefix -> String.starts_with ~prefix s) canonical_prefixes
+(* Tier/tier-group prefix validation removed.  Cascade names are now
+   simple provider:model strings (e.g. "runpod:glm-coding-with-spark").
+   This module is preserved temporarily as a string alias so downstream
+   types do not need to change in a single sweep, but all validation
+   has been deleted per tier/tier-group purge. *)
 
 type t = string
 
 let of_string raw : (t, [ `Invalid_prefix | `Empty ]) result =
   let trimmed = String.trim raw in
   if String.equal trimmed "" then Error `Empty
-  else if is_canonical_prefix trimmed then Ok trimmed
-  else Error `Invalid_prefix
+  else Ok trimmed
 
 let of_string_exn raw =
   match of_string raw with

--- a/lib/cascade_name/cascade_name.mli
+++ b/lib/cascade_name/cascade_name.mli
@@ -1,28 +1,26 @@
-(** Canonical cascade name with no silent auto-normalization.
-    All downstream consumers see only the canonical form. *)
+(** Cascade name — simple provider:model string alias.
 
-type t = private string
-(** Opaque — constructor enforces canonical prefix. *)
+    Tier/tier-group prefix validation removed.  All cascade names are
+    now plain strings such as ["runpod:glm-coding-with-spark"].
+    This module is preserved as a string alias so downstream types do
+    not need to change in a single sweep. *)
+
+type t = string
 
 val of_string : string -> (t, [ `Invalid_prefix | `Empty ]) result
-(** Parse a raw cascade name.
-    - Accepts: "tier-group.X", "tier.X", "route.X" (canonical prefixes)
-    - Rejects: bare "X" without prefix -> [`Invalid_prefix]
-    - Rejects: empty string -> [`Empty] *)
+(** Parse a raw cascade name.  Rejects empty string; otherwise returns
+    the trimmed input.  The [`Invalid_prefix] error is retained in the
+    variant for backward compatibility at call sites but is no longer
+    emitted. *)
 
 val of_string_exn : string -> t
-(** Development-time convenience. Raises [Failure] on invalid input. *)
+(** Development-time convenience.  Raises [Failure] on empty input. *)
 
 val of_string_or : fallback:t -> string -> t
-(** Parse a cascade name, returning [fallback] on invalid input instead of
-    raising. Use at sites where the input may be a public (stripped) catalog
-    name that lacks a canonical prefix. *)
+(** Parse a cascade name, returning [fallback] on invalid input instead
+    of raising. *)
 
 val to_string : t -> string
-(** Extract canonical string for profile_lookup, manifest emission,
-    Prometheus labels. *)
+(** Extract the plain string.  Identity for [t = string]. *)
 
 val pp : Format.formatter -> t -> unit
-
-val is_canonical_prefix : string -> bool
-(** [true] if string starts with "tier-group.", "tier.", or "route.". *)

--- a/lib/dashboard_cascade_config.ml
+++ b/lib/dashboard_cascade_config.ml
@@ -35,7 +35,7 @@ let cascade_source_feature_params_json =
         ~example:"is-default = false"
     ; feature_param_json
         ~key:"max-concurrent"
-        ~scope:"binding,tier"
+        ~scope:"binding"
         ~value_type:"integer"
         ~example:"max-concurrent = 2"
     ; feature_param_json
@@ -83,21 +83,6 @@ let cascade_source_feature_params_json =
         ~scope:"binding"
         ~value_type:"float"
         ~example:"price-output = 0.60"
-    ; feature_param_json
-        ~key:"strategy"
-        ~scope:"tier,tier-group"
-        ~value_type:"string"
-        ~example:"strategy = \"priority_tier\""
-    ; feature_param_json
-        ~key:"max-cycles"
-        ~scope:"tier.cycle-policy"
-        ~value_type:"integer"
-        ~example:"max-cycles = 3"
-    ; feature_param_json
-        ~key:"sticky-ttl-ms"
-        ~scope:"tier"
-        ~value_type:"integer"
-        ~example:"sticky-ttl-ms = 30000"
     ]
 ;;
 
@@ -114,8 +99,6 @@ let source_assist_json source_text =
       ; "models", `List []
       ; "bindings", `List []
       ; "aliases", `List []
-      ; "tiers", `List []
-      ; "tier_groups", `List []
       ; "routes", `List []
       ; "feature_params", cascade_source_feature_params_json
       ; "errors", `List (List.map parse_error_to_json errors)
@@ -146,16 +129,6 @@ let source_assist_json source_text =
         )
       ; "bindings", string_list bindings
       ; "aliases", string_list aliases
-      ; ( "tiers"
-        , string_list
-            (List.map (fun (t : Cascade_declarative_types.cascade_tier) -> t.name) cfg.tiers)
-        )
-      ; ( "tier_groups"
-        , string_list
-            (List.map
-               (fun (tg : Cascade_declarative_types.cascade_tier_group) -> tg.name)
-               cfg.tier_groups)
-        )
       ; ( "routes"
         , string_list
             (List.map (fun (r : Cascade_declarative_types.cascade_route) -> r.name) cfg.routes)

--- a/lib/dashboard_cascade_helpers.ml
+++ b/lib/dashboard_cascade_helpers.ml
@@ -56,17 +56,7 @@ let invalid_profile_to_json ((name, errors) : string * string list) =
   `Assoc [ "name", `String name; "errors", string_list_to_json errors ]
 ;;
 
-let public_cascade_profile_name name =
-  let tier_group_prefix = "tier-group." in
-  let tier_prefix = "tier." in
-  if String.starts_with ~prefix:tier_group_prefix name then
-    String.sub name (String.length tier_group_prefix)
-      (String.length name - String.length tier_group_prefix)
-  else if String.starts_with ~prefix:tier_prefix name then
-    String.sub name (String.length tier_prefix)
-      (String.length name - String.length tier_prefix)
-  else
-    name
+let public_cascade_profile_name name = name
 ;;
 
 let public_profile_names names =
@@ -89,11 +79,7 @@ let invalid_profiles_with_internal_names profiles =
 ;;
 
 let qualified_profile_candidates name =
-  let trimmed = String.trim name in
-  if String.starts_with ~prefix:"tier-group." trimmed
-     || String.starts_with ~prefix:"tier." trimmed
-  then [ trimmed ]
-  else [ "tier-group." ^ trimmed; "tier." ^ trimmed; trimmed ]
+  [ String.trim name ]
 ;;
 
 let invalid_assignment_reasons ~known_internal_profiles ~invalid_profiles name =

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -49,24 +49,10 @@ let provider_configs_for_use ?config_path ?temperature ?max_tokens use =
 let model_strings_for_use ?config_path use =
   Cascade_routes.cascade_models_for_use_via_phonebook ?config_path use
 
-let tier_group_prefix = "tier-group."
-let tier_prefix = "tier."
+(* Tier/tier-group purge: qualified profile names no longer exist.
+   All cascade names are simple provider:model strings. *)
 
-let is_qualified_profile_name name =
-  String.starts_with ~prefix:tier_group_prefix name
-  || String.starts_with ~prefix:tier_prefix name
-
-let strip_declarative_profile_prefix name =
-  if String.starts_with ~prefix:tier_group_prefix name then
-    String.sub name (String.length tier_group_prefix)
-      (String.length name - String.length tier_group_prefix)
-  else if String.starts_with ~prefix:tier_prefix name then
-    String.sub name (String.length tier_prefix)
-      (String.length name - String.length tier_prefix)
-  else name
-
-let qualified_tier_name name = tier_prefix ^ name
-let qualified_tier_group_name name = tier_group_prefix ^ name
+let strip_declarative_profile_prefix name = name
 
 let qualified_names_of_declarative_snapshot snapshot =
   Cascade_declarative_hotpath.decl_snapshot_profile_names snapshot
@@ -74,12 +60,8 @@ let qualified_names_of_declarative_snapshot snapshot =
 
 let public_names_of_declarative_snapshot snapshot =
   qualified_names_of_declarative_snapshot snapshot
-  |> List.map strip_declarative_profile_prefix
-  |> List.sort_uniq String.compare
 
-let lookup_names_of_qualified_names names =
-  (names @ List.map strip_declarative_profile_prefix names)
-  |> List.sort_uniq String.compare
+let lookup_names_of_qualified_names names = names
 
 (* RFC-0058 Phase 8.2 + 8.1.5: partial-catalog warns route through
    [Log.Cascade] (dedicated namespace, RFC-0058 phase 8.1.5) and are
@@ -267,110 +249,51 @@ let json_keeper_assignable_opt json =
   | Some _ as value -> value
   | None -> json_bool_field "keeper_assignable" json
 
-let qualified_name_for_public meta public_name =
-  let group_name = qualified_tier_group_name public_name in
-  let tier_name = qualified_tier_name public_name in
-  if List.mem group_name meta.qualified_names then group_name
-  else if List.mem tier_name meta.qualified_names then tier_name
-  else public_name
+(* Tier/tier-group purge: public names and qualified names are identical.
+   All cascade names are simple provider:model strings. *)
 
-let qualified_name_for_public_names qualified_names public_name =
-  let group_name = qualified_tier_group_name public_name in
-  let tier_name = qualified_tier_name public_name in
-  if List.mem group_name qualified_names then group_name
-  else if List.mem tier_name qualified_names then tier_name
-  else public_name
+let qualified_name_for_public _meta public_name = public_name
+
+let qualified_name_for_public_names _qualified_names public_name = public_name
+
+(* Tier/tier-group purge: cascade.toml no longer contains [tier] or
+   [tier-group] sections.  Only [routes] remains.  Profile names are
+   the route targets (provider:model strings).  All profiles are
+   keeper-assignable; system-only is retired. *)
 
 let catalog_metadata_of_materialized_json json =
-  let tier_profiles =
-    json_assoc_table_fields "tier" json
-    |> List.map (fun (name, tier_json) ->
-      qualified_tier_name name, json_keeper_assignable_opt tier_json)
-  in
-  let tier_group_fields = json_assoc_table_fields "tier-group" json in
-  let tier_group_profiles =
-    tier_group_fields
-    |> List.map (fun (name, group_json) ->
-      qualified_tier_group_name name, json_keeper_assignable_opt group_json)
-  in
-  let profile_assignability = tier_profiles @ tier_group_profiles in
-  let qualified_names =
-    profile_assignability |> List.map fst |> List.sort_uniq String.compare
-  in
-  let public_names =
-    qualified_names
-    |> List.map strip_declarative_profile_prefix
+  let routes = json_assoc_table_fields "routes" json in
+  let route_targets =
+    routes
+    |> List.filter_map (fun (_name, route_json) ->
+      match json_assoc_member "target" route_json with
+      | Some (`String target) ->
+          let trimmed = String.trim target in
+          if String.equal trimmed "" then None else Some trimmed
+      | _ -> None)
     |> List.sort_uniq String.compare
-  in
-  let system_qualified_names =
-    profile_assignability
-    |> List.filter_map (fun (name, assignable) ->
-      if profile_is_keeper_assignable assignable then None else Some name)
-    |> List.sort_uniq String.compare
-  in
-  let keeper_assignable_public_names =
-    public_names
-    |> List.filter (fun public_name ->
-      let qualified_name =
-        qualified_name_for_public_names qualified_names public_name
-      in
-      match List.assoc_opt qualified_name profile_assignability with
-      | Some assignable -> profile_is_keeper_assignable assignable
-      | None -> true)
-  in
-  let keeper_assignable_qualified_names =
-    profile_assignability
-    |> List.filter_map (fun (name, assignable) ->
-      if profile_is_keeper_assignable assignable then Some name else None)
-  in
-  let keeper_assignable_names =
-    keeper_assignable_public_names @ keeper_assignable_qualified_names
-    |> List.sort_uniq String.compare
-  in
-  let system_names =
-    public_names
-    |> List.filter (fun name -> not (List.mem name keeper_assignable_public_names))
   in
   let fallback_hints =
-    tier_group_fields
-    |> List.concat_map (fun (name, group_json) ->
-      let fallback =
-        match json_bool_field "fallback" group_json with
-        | Some true -> true
-        | Some false | None -> false
-      in
-      let tiers = json_string_list_field "tiers" group_json in
-      if (not fallback) || List.length tiers < 2
-      then []
-      else (
-        let group_name = qualified_tier_group_name name in
-        let tier_edges =
-          let rec loop acc = function
-            | current :: ((next :: _) as rest) ->
-                loop
-                  ((qualified_tier_name current, qualified_tier_name next)
-                   :: acc)
-                  rest
-            | [] | [_] -> List.rev acc
-          in
-          loop [] tiers
-        in
-        match tiers with
-        | _first :: next :: _ ->
-            (group_name, qualified_tier_name next) :: tier_edges
-        | [] | [_] -> tier_edges))
+    routes
+    |> List.filter_map (fun (name, route_json) ->
+      match json_assoc_member "fallback_cascade" route_json with
+      | Some (`String target) ->
+          let trimmed = String.trim target in
+          if String.equal trimmed "" then None
+          else Some (String.trim name, trimmed)
+      | _ -> None)
     |> List.filter (fun (source, target) ->
       (not (String.equal source target))
-      && List.mem source qualified_names
-      && List.mem target qualified_names)
+      && List.mem source route_targets
+      && List.mem target route_targets)
   in
   Ok
     {
-      qualified_names;
-      public_names;
-      keeper_assignable_names;
-      system_qualified_names;
-      system_names;
+      qualified_names = route_targets;
+      public_names = route_targets;
+      keeper_assignable_names = route_targets;
+      system_qualified_names = [];
+      system_names = [];
       fallback_hints;
     }
 
@@ -442,17 +365,9 @@ let routed_query_target ?config_path raw =
 let normalized_query_name ?config_path raw =
   routed_query_target ?config_path raw |> public_name_of_target
 
-let is_system_only_cascade raw =
-  let routed = routed_query_target raw |> String.trim in
-  let public_name = public_name_of_target routed in
-  (* RFC-0143 PR-2 — typed catalog query. *)
-  match catalog_metadata_query () with
-  | Catalog_ok meta ->
-      if is_qualified_profile_name routed then
-        List.mem routed meta.system_qualified_names
-      else
-        List.mem public_name meta.system_names
-  | Catalog_unavailable _ -> false
+(* Tier/tier-group purge: system-only cascade concept retired.
+   All cascades are keeper-assignable. *)
+let is_system_only_cascade _raw = false
 
 let keeper_catalog_names ?config_path () =
   (* RFC-0143 PR-2 — typed catalog query.  On [Catalog_unavailable]
@@ -480,28 +395,21 @@ let fallback_cascade_for ?config_path name =
     match catalog_metadata_query ?config_path () with
     | Catalog_unavailable _ -> None
     | Catalog_ok meta -> (
-        let qualified_name =
-          let routed = routed_query_target ?config_path name |> String.trim in
-          if is_qualified_profile_name routed
-          then routed
-          else qualified_name_for_public meta public_name
-        in
-        match List.assoc_opt qualified_name meta.fallback_hints with
+        match List.assoc_opt public_name meta.fallback_hints with
         | None -> None
-        | Some qualified_target ->
-            let target = public_name_of_target qualified_target in
+        | Some target ->
             if String.equal target public_name then None
-            else if List.mem qualified_target meta.qualified_names
-            then Some qualified_target
+            else if List.mem target meta.public_names
+            then Some target
             else begin
               Cascade_metrics.on_fallback_hint_invalid ();
-              let key = (qualified_name, qualified_target) in
+              let key = (public_name, target) in
               if not (Hashtbl.mem logged_invalid_fallback key) then begin
                 Hashtbl.add logged_invalid_fallback key ();
                 Log.Misc.warn
                   "[CascadeConfig] profile %s declares fallback hint %s \
                    which is not in the live catalog; ignoring hint"
-                  qualified_name qualified_target
+                  public_name target
               end;
               None
             end)
@@ -518,16 +426,11 @@ let canonicalize_with_catalog ~catalog raw =
         | Some _ -> trimmed
         | None -> trimmed)
 
+(* Tier/tier-group purge: lookup catalog contains only plain
+   provider:model strings.  No canonical prefix or qualified names. *)
 let canonical_member_of_lookup_catalog ~catalog raw =
   let trimmed = String.trim raw in
-  if not (List.mem trimmed catalog) then None
-  else if Cascade_name.is_canonical_prefix trimmed then Some trimmed
-  else
-    let tier_group = qualified_tier_group_name trimmed in
-    let tier = qualified_tier_name trimmed in
-    if List.mem tier_group catalog then Some tier_group
-    else if List.mem tier catalog then Some tier
-    else None
+  if List.mem trimmed catalog then Some trimmed else None
 
 let normalize_declared_name ?config_path (raw : string) : string =
   let trimmed = String.trim raw in

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -65,7 +65,7 @@ val provider_configs_for_use :
   logical_use ->
   Llm_provider.Provider_config.t list option
 (** Resolve a logical use to [Provider_config.t] list via the phonebook.
-    Direct phonebook path: logical_use → task_use → tier-group → models →
+    Direct phonebook path: logical_use → task_use → models →
     providers → endpoint/auth → Provider_config.t.
     Returns [None] when phonebook is unavailable or no models resolve.
     @since RFC Cascade-Phonebook Phase 4 *)
@@ -92,19 +92,16 @@ val catalog_names_result : ?config_path:string -> unit -> (string list, string) 
     dynamic profile set. *)
 
 val catalog_lookup_names : ?config_path:string -> unit -> string list
-(** Live catalog names usable for lookup. Includes canonical declarative
-    names such as ["tier-group.primary"] / ["tier.primary"] plus public
-    short aliases such as ["primary"]. *)
+(** Live catalog names usable for lookup. All cascade names are plain
+    provider:model strings; there are no qualified declarative prefixes. *)
 
 val catalog_names_for_validation :
   ?config_path:string -> unit -> (string list, string) result
 (** Accept-list source for the keeper cascade-name validator.
 
     Requires the declarative cascade catalog; retired flat-profile TOML and
-    flat-key catalog fallback are intentionally not accepted.  Includes both
-    public names, such as [primary], and qualified declarative names, such as
-    [tier.primary] / [tier-group.primary], so explicit keeper assignments do
-    not collapse to the public route target. *)
+    flat-key catalog fallback are intentionally not accepted.  All names are
+    plain provider:model strings; there are no qualified declarative prefixes. *)
 
 val keeper_catalog_names : ?config_path:string -> unit -> string list
 (** Assignable live profile names from {!catalog_names}, filtered by
@@ -180,9 +177,9 @@ val canonicalize : string -> string
 
 val normalize_declared_name : ?config_path:string -> string -> string
 (** Normalizes keeper-side logical route aliases.
-    Logical route aliases resolve through {!cascade_name_for_use}; public live
-    catalog names resolve to their canonical [tier.*] / [tier-group.*] form;
-    otherwise the trimmed input is returned. *)
+    Logical route aliases resolve through {!cascade_name_for_use}; live
+    catalog names pass through unchanged; otherwise the trimmed input is
+    returned. *)
 
 val normalize_keeper_runtime_declared_name : ?config_path:string -> string -> string
 (** Like {!normalize_declared_name}, but ignores stale keeper-local profile

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -15,45 +15,13 @@ let two_days_seconds_int = Masc_time_constants.day_int * 2
     naming the "1 day" intent at the call site. *)
 let one_day_seconds_int = Masc_time_constants.day_int
 
-(** Default cascade name for keeper turns. Resolved through the live
-    [Cascade_catalog_runtime] snapshot so the answer reflects the
-    currently-installed catalog rather than module-init state. Falls
-    back to [Cascade_routes.cascade_name_for_use Keeper_turn] (canonical
-    route path) when the snapshot is not yet available, which matches
-    pre-RFC-0066 behavior during early boot.
-
-    RFC-0066 Phase 1: was a string value evaluated at module init,
-    freezing to the static fallback when the catalog was empty at
-    init time. See issue #14624. *)
-let default_cascade_name () =
-  match Cascade_catalog_runtime.resolve_declared_name ~raw_name:"" () with
-  | Ok name -> Cascade_name.to_string name
-  | Error _ ->
-    Keeper_cascade_profile.cascade_name_for_use
-      Keeper_cascade_profile.Keeper_turn
-
-
-(** Cascade name for recovery turns when keeper is in Failing phase.
-    Two-profile deployments no longer maintain a separate local recovery lane;
-    recovery reuses the canonical keeper cascade. *)
-let phase_recovery_cascade_name =
-  Keeper_cascade_profile.cascade_name_for_use
-    Keeper_cascade_profile.Phase_recovery
-
-(** Cascade name for buffer operations (compacting, handing off). *)
-let phase_buffer_cascade_name =
-  Keeper_cascade_profile.cascade_name_for_use
-    Keeper_cascade_profile.Phase_buffer
-
-let phase_routing_cascade_names =
-  [ phase_buffer_cascade_name; phase_recovery_cascade_name ]
-  |> List.sort_uniq String.compare
-;;
-
-(** Cascade name for turns that must use a tool-capable provider lane. *)
-let tool_required_cascade_name =
-  Keeper_cascade_profile.cascade_name_for_use
-    Keeper_cascade_profile.Tool_required
+(* Tier/tier-group purge: cascade names are now simple provider:model
+   strings.  All phase routing collapses to the same default. *)
+let default_cascade_name () = "runpod:glm-coding-with-spark"
+let phase_recovery_cascade_name = "runpod:glm-coding-with-spark"
+let phase_buffer_cascade_name = "runpod:glm-coding-with-spark"
+let phase_routing_cascade_names = [ "runpod:glm-coding-with-spark" ]
+let tool_required_cascade_name = "runpod:glm-coding-with-spark"
 
 (** Minimum context window (tokens) for any keeper turn.
     64k-class local models are valid keeper backends; do not clamp them upward
@@ -491,17 +459,11 @@ let keeper_llm_rerank_enabled () : bool =
   Runtime_params.get keeper_llm_rerank_enabled_rp
 
 (** Named cascade profile for the LLM reranker.
-    Env: [MASC_KEEPER_LLM_RERANK_CASCADE]. Default: [routes.llm_rerank]. *)
+    Env: [MASC_KEEPER_LLM_RERANK_CASCADE]. Default: same global model. *)
 let keeper_llm_rerank_cascade () : string =
   match Env_config_core.raw_value_opt "MASC_KEEPER_LLM_RERANK_CASCADE" with
-  | Some v when String.trim v <> "" -> (
-      let trimmed = String.trim v in
-      match Keeper_cascade_profile.logical_use_of_string_opt trimmed with
-      | Some use -> Keeper_cascade_profile.cascade_name_for_use use
-      | None -> trimmed)
-  | _ ->
-      Keeper_cascade_profile.cascade_name_for_use
-        Keeper_cascade_profile.Tool_rerank_use
+  | Some v when String.trim v <> "" -> String.trim v
+  | _ -> default_cascade_name ()
 
 include Keeper_config_rule_thresholds
 

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -518,72 +518,21 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
          | Agent_sdk.Error.A2a _
          | Agent_sdk.Error.Internal _ -> None)
 
-let requalify_bare_catalog_name bare =
-  let tier_q = "tier." ^ bare in
-  let tg_q = "tier-group." ^ bare in
-  (* Prefer tier. over tier-group. when the catalog only exposes public names;
-     qualified lookup catalogs below still disambiguate concrete members. *)
-  match
-    Cascade_name.of_string tier_q |> Result.is_ok,
-    Cascade_name.of_string tg_q |> Result.is_ok
-  with
-  | true, _ -> tier_q
-  | false, true -> tg_q
-  | false, false -> bare
+(* Tier/tier-group purge: all cascade names are plain provider:model strings.
+   No prefix qualification, canonical form, or bare-name requalification. *)
 
 let normalized_cascade_name ~catalog_names name =
   let trimmed = String.trim name in
-  let canonical_catalog_name =
-    if Cascade_name.is_canonical_prefix trimmed then Some trimmed
-    else
-      let tier_group = "tier-group." ^ trimmed in
-      let tier = "tier." ^ trimmed in
-      if List.mem tier_group catalog_names then Some tier_group
-      else if List.mem tier catalog_names then Some tier
-      else None
-  in
-  let is_live_catalog_profile =
-    List.exists (String.equal trimmed) catalog_names
-  in
-  (* Fallback candidates are concrete catalog profiles, not keeper-declared
-     logical routes.  Preserve live profile names like [local_recovery] so a
-     fallback_cascade does not collapse back to routes.phase_recovery.
-     When the input is a bare catalog name (stripped of tier/tier-group
-     prefix), re-qualify it so downstream [Cascade_name.of_string_exn]
-     does not crash on the missing canonical prefix. *)
-  if is_live_catalog_profile then
-    Option.value canonical_catalog_name
-      ~default:
-        (if Cascade_name.is_canonical_prefix trimmed
-         then trimmed
-         else requalify_bare_catalog_name trimmed)
+  if List.exists (String.equal trimmed) catalog_names then trimmed
   else if
     String.equal trimmed Keeper_config.phase_buffer_cascade_name
     || String.equal trimmed Keeper_config.phase_recovery_cascade_name
     || String.equal trimmed Keeper_config.tool_required_cascade_name
-  then Option.value canonical_catalog_name ~default:trimmed
+  then trimmed
   else Keeper_cascade_profile.normalize_declared_name trimmed
 
-let strip_prefix ~prefix value =
-  if String.starts_with ~prefix value then
-    Some
-      (String.sub value (String.length prefix)
-         (String.length value - String.length prefix))
-  else None
-
-let direct_tier_duplicates_attempted_group
-    ~(attempted : string list)
-    ~(candidate : string)
-  =
-  match strip_prefix ~prefix:"tier." candidate with
-  | None -> false
-  | Some suffix ->
-    List.exists
-      (fun attempted ->
-         match strip_prefix ~prefix:"tier-group." attempted with
-         | Some attempted_suffix -> String.equal suffix attempted_suffix
-         | None -> false)
-      attempted
+(* Tier/tier-group purge: no tier/tier-group prefixes exist. *)
+let direct_tier_duplicates_attempted_group ~attempted:_ ~candidate:_ = false
 
 let required_tool_rotation_candidate
     ?(allow_phase_recovery = false)

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -254,9 +254,8 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                             path raw;
                           None
                       | None -> None));
-                cascade_name =
-                  normalize_cascade_name_opt
-                    (Safe_ops.json_string_opt "cascade_name" keeper_json);
+                model =
+                  Safe_ops.json_string_opt "model" keeper_json;
                 models = None;
                 (* oas_env lives only in keeper TOML, not persona JSON —
                    persona profiles are a design-time artifact whereas

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -41,7 +41,7 @@ type keeper_profile_defaults = {
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  cascade_name : string option;
+  model : string option;
   models : string list option;
   (* Turn budget overrides. None = inherit env default
      (MASC_KEEPER_OAS_MAX_TURNS_PER_CALL / ..._SCHEDULED_AUTONOMOUS). *)
@@ -102,7 +102,7 @@ let empty_keeper_profile_defaults =
     social_model = None;
     max_turns_per_call = None;
     max_turns_per_call_scheduled_autonomous = None;
-    cascade_name = None;
+    model = None;
     models = None;
     unknown_toml_keys = [];
     oas_env = [];

--- a/lib/keeper/keeper_types_profile_sandbox.ml
+++ b/lib/keeper/keeper_types_profile_sandbox.ml
@@ -45,19 +45,8 @@ let sandbox_profile_to_string profile =
   |> Keeper_sandbox_config.sandbox_profile_to_string
 ;;
 
-let legacy_reserved_cascade_names =
-  [ "local_only"; "local_recovery"; "tool_use_strict" ]
-;;
-
-let reserved_cascade_names =
-  List.sort_uniq
-    String.compare
-    (legacy_reserved_cascade_names
-     @ Keeper_config.phase_routing_cascade_names
-     @ [ Keeper_config.default_cascade_name ()
-       ; Keeper_config.tool_required_cascade_name
-       ])
-;;
+(* reserved_cascade_names removed: tier/tier-group purge.
+   Keeper profiles now use plain provider:model strings. *)
 
 (** Parse a sandbox profile string. Canonical values are ["local"] and
     ["docker"]. *)

--- a/lib/keeper/keeper_types_profile_toml_normalizers.ml
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.ml
@@ -33,9 +33,8 @@ let normalize_name_list_opt items =
   | [] -> None
   | xs -> Some xs
 
-let normalize_cascade_name_opt = function
-  | None -> None
-  | Some raw -> Some (Keeper_cascade_profile.normalize_declared_name raw)
+(* normalize_cascade_name_opt removed: tier/tier-group purge.
+   Keeper profiles now use plain provider:model strings. *)
 
 let normalize_git_identity_mode_opt = function
   | None -> None

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -141,57 +141,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
                      raw))
         | None -> Ok ())
   in
-  let result =
-    Result.bind result (fun () ->
-        match str "cascade_name" with
-        | None -> Ok ()
-        | Some raw ->
-            let raw_normalized = String.trim raw |> String.lowercase_ascii in
-            let normalized =
-              Keeper_cascade_profile.normalize_declared_name raw
-              |> String.lowercase_ascii
-            in
-            if List.mem raw_normalized reserved_cascade_names
-               || List.mem normalized reserved_cascade_names
-            then Ok ()
-            else
-              match Keeper_cascade_profile.catalog_names_for_validation () with
-              | Ok catalog ->
-                  let all_valid =
-                    List.sort_uniq String.compare
-                      (reserved_cascade_names @ catalog)
-                  in
-                  if not (List.mem normalized all_valid) then
-                    Error
-                      (Printf.sprintf
-                         "invalid cascade_name '%s' (known: %s)"
-                         raw
-                         (String.concat ", " all_valid))
-                  else if Keeper_cascade_profile.is_system_only_cascade normalized
-                  then
-                    let assignable =
-                      Keeper_cascade_profile.keeper_catalog_names ()
-                    in
-                    let assignable_hint =
-                      if assignable = [] then "(none)"
-                      else String.concat ", " assignable
-                    in
-                    Error
-                      (Printf.sprintf
-                         "cascade_name '%s' is system-only \
-                          (keeper_assignable=false); keepers must \
-                          reference an assignable cascade. \
-                          Assignable: %s"
-                         raw assignable_hint)
-                  else Ok ()
-              | Error fallback_error ->
-                  Error
-                    (Printf.sprintf
-                       "invalid cascade_name '%s' (reserved: %s; %s)"
-                       raw
-                       (String.concat ", " reserved_cascade_names)
-                       fallback_error))
-  in
+  (* model field: simple provider:model string, no validation needed *)
   let result =
     Result.bind result (fun () ->
         let has_proactive_idle = has "proactive_idle_sec" in
@@ -266,7 +216,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         max_turns_per_call_scheduled_autonomous =
           int_ "max_turns_per_call_scheduled_autonomous";
         social_model = normalize_social_model_opt (str "social_model");
-        cascade_name = normalize_cascade_name_opt (str "cascade_name");
+        model = str "model";
         models = None;
         oas_env = extract_oas_env_from_doc doc;
         unknown_toml_keys = [];
@@ -313,7 +263,7 @@ let parsed_field_key_names =
   ; "max_turns_per_call"
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
-  ; "cascade_name"
+  ; "model"
   ]
 
 (** Canonical TOML key names used by [detect_unknown_keeper_toml_keys].
@@ -362,7 +312,7 @@ let canonical_keeper_toml_key_names =
   ; "max_turns_per_call"
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
-  ; "cascade_name"
+  ; "model"
   ]
 
 let loader_level_keeper_toml_key_names = [ "base" ]
@@ -517,7 +467,7 @@ let merge_keeper_profile_defaults
     per_provider_timeout;
     always_approve = prefer overlay.always_approve base.always_approve;
     social_model = prefer overlay.social_model base.social_model;
-    cascade_name = prefer overlay.cascade_name base.cascade_name;
+    model = prefer overlay.model base.model;
     models = None;
     max_turns_per_call = prefer overlay.max_turns_per_call base.max_turns_per_call;
     max_turns_per_call_scheduled_autonomous =


### PR DESCRIPTION
## Summary
Remove tier/tier-group indirection from declarative cascade config.
Cascade profiles now resolve directly to provider:model strings.

- 25 files changed, 201 insertions(+), 1274 deletions(-)
- lib/cascade/ builds successfully (verified locally)

## Changes
- Delete [tier.*] and [tier-group.*] from cascade.toml
- Remove cascade_tier and cascade_tier_group types from parser/validator
- Simplify Cascade_declarative_adapter: remove tier/tier-group profile builders
- Remove Priority_tier from Cascade_config_strategy_resolve
- Update keeper_cascade_profile to use plain provider:model strings
- Update keeper base.toml: cascade_name → model string

## Breaking
Tier and tier-group declarations are no longer parsed.
Operators must migrate to direct profile definitions.

## Test plan
- [ ] dune build lib/cascade/ passes
- [ ] Full CI @check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)