### PR TITLE
fix(keeper): log credential resolution errors instead of silent fallback

### DIFF
--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -299,7 +299,11 @@ let start_container (t : t) ~(timeout_sec : float) =
                List.concat_map (fun (k, v) -> [ "-e"; k ^ "=" ^ v ]) binding.env
              in
              mounts, envs
-           | Error _ -> [], []
+           | Error err ->
+             Log.Keeper.warn
+               "%s: credential resolution failed — container will start without git/gh credentials: %s"
+               t.meta.name (Keeper_credential_provider.pp_error err);
+             [], []
          in
          let argv =
            Keeper_sandbox_runtime.docker_command_argv ()


### PR DESCRIPTION
## Summary

- Credential resolution failures in `keeper_turn_sandbox_runtime.start_container` were silently swallowed — `| Error _ -> [], []` returned empty mounts/envs with zero diagnostic output
- Keepers starting without git/gh credentials had no way to know why their sandbox containers couldn't access repositories
- Now logs a `WARN` with the keeper name and structured error before falling back to credential-less operation

## Context

This is part of the 5-layer lock analysis for keeper Git/PR capability (Issues #19318, #19320):

| Layer | Status | Notes |
|-------|--------|-------|
| Lock 1 — No dedicated Git/PR tools | OPEN (#19320) | Structural, RFC needed |
| Lock 2 — Preset exclusion | FIXED (#19308) | search_files preset expansion |
| Lock 3.1 — Git factory wiring | FIXED (#19317) | typed Shell IR git commands |
| Lock 3.2 — Credential config | FIXED | credentials.toml + keeper_repo_mappings.toml |
| Lock 4 — Destructive classification | REVISED | NOT a blocker (keepers default to Execute mode) |
| Lock 5 — Docker Network_none | FIXED | network_mode = "inherit" |

This PR addresses the **silent failure** anti-pattern: when credential resolution fails (missing config, invalid token, materializer error), the keeper starts its container without credentials and has no diagnostic to indicate why git/gh operations fail at runtime.

## Changes

- `lib/keeper/keeper_turn_sandbox_runtime.ml:302`: `| Error _ -> [], []` → `| Error err -> Log.Keeper.warn "..."; [], []`
- Uses existing `Keeper_credential_provider.pp_error` for structured error display
- Uses existing `Log.Keeper.warn` logging facility
- No behavioral change — container still starts without credentials on error (graceful degradation)

## Verification

- `dune build --root . @check` PASS
- `pp_error` exists in `keeper_credential_provider.mli`
- `Log.Keeper.warn` is used elsewhere in the same file

## Next Steps

- Lock 1 (dedicated Git/PR tool surface) requires RFC — Issue #19320
- Per-keeper credential isolation (currently all 6 keepers share `jeong-sik-gh`)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>