### PR TITLE
refactor(core): consolidate option_*_json helpers to Json_util.option_to_yojson

### DIFF
--- a/lib/dashboard_tla_specs.ml
+++ b/lib/dashboard_tla_specs.ml
@@ -303,15 +303,8 @@ let list_tlc_results () =
     cfg_entries_for_spec spec |> List.map (result_for_cfg ~results_dir spec))
 ;;
 
-let option_int_json = function
-  | Some v -> `Int v
-  | None -> `Null
-;;
-
-let option_string_json = function
-  | Some v -> `String v
-  | None -> `Null
-;;
+let option_int_json = Json_util.option_to_yojson (fun v -> `Int v)
+let option_string_json = Json_util.option_to_yojson (fun v -> `String v)
 
 let option_time_json = function
   | Some v -> `String (iso_of_unix_time v)

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -370,15 +370,8 @@ let nested_float_field outer inner json =
   | None -> None
 ;;
 
-let option_string_json = function
-  | Some value -> `String value
-  | None -> `Null
-;;
-
-let option_float_json = function
-  | Some value -> `Float value
-  | None -> `Null
-;;
+let option_string_json = Json_util.option_to_yojson (fun v -> `String v)
+let option_float_json = Json_util.option_to_yojson (fun v -> `Float v)
 
 let summary_schema = "keeper.reaction_ledger.summary.v1"
 let fleet_summary_schema = "keeper.reaction_ledger.fleet_summary.v1"

--- a/lib/keeper_fd_pressure.ml
+++ b/lib/keeper_fd_pressure.ml
@@ -565,10 +565,7 @@ let admitted = function
   | Block _ -> false
 ;;
 
-let option_int_json = function
-  | Some value -> `Int value
-  | None -> `Null
-;;
+let option_int_json = Json_util.option_to_yojson (fun v -> `Int v)
 
 let admission_block_to_json = function
   | Fd_pressure_cooldown remaining_sec ->

--- a/lib/server/server_dashboard_logs_json.ml
+++ b/lib/server/server_dashboard_logs_json.ml
@@ -8,15 +8,8 @@
    Pure JSON builder over [Log.Ring.entry list] - the ring read happens
    in the caller. *)
 
-let option_int_json = function
-  | Some value -> `Int value
-  | None -> `Null
-;;
-
-let option_string_json = function
-  | Some value -> `String value
-  | None -> `Null
-;;
+let option_int_json = Json_util.option_to_yojson (fun v -> `Int v)
+let option_string_json = Json_util.option_to_yojson (fun v -> `String v)
 
 let store_path ~masc_root =
   Filename.concat

--- a/lib/server/server_routes_http_dashboard_provider_logs.ml
+++ b/lib/server/server_routes_http_dashboard_provider_logs.ml
@@ -2,13 +2,8 @@
 
 module Cascade_decl = Cascade_declarative_types
 
-let option_int_json = function
-  | Some value -> `Int value
-  | None -> `Null
-
-let option_string_json = function
-  | Some value -> `String value
-  | None -> `Null
+let option_int_json = Json_util.option_to_yojson (fun v -> `Int v)
+let option_string_json = Json_util.option_to_yojson (fun v -> `String v)
 
 let provider_log_surface = "/api/v1/dashboard/provider-logs"
 let provider_log_tail_surface = "/api/v1/dashboard/provider-logs/tail"

--- a/lib/server/server_routes_http_routes_dashboard_setup.ml
+++ b/lib/server/server_routes_http_routes_dashboard_setup.ml
@@ -25,13 +25,8 @@ let invalid_cascade_profiles = Cascade_profile_gate.invalid_profiles
 let invalid_cascade_assignment_profiles =
   Cascade_profile_gate.invalid_assignment_profiles
 
-let option_int_json = function
-  | Some value -> `Int value
-  | None -> `Null
-
-let option_string_json = function
-  | Some value -> `String value
-  | None -> `Null
+let option_int_json = Json_util.option_to_yojson (fun v -> `Int v)
+let option_string_json = Json_util.option_to_yojson (fun v -> `String v)
 
 (* Dashboard /logs JSON builder extracted to
    [Server_dashboard_logs_json] (godfile decomp). *)


### PR DESCRIPTION
## Summary
- Replace 6 files' local `option_int_json`, `option_string_json`, `option_float_json` helpers with `Json_util.option_to_yojson` from the shared utility module
- Net -34 lines of duplicate helper code removed

## Why
Multiple files defined identical `option_*_json` functions. `Json_util.option_to_yojson` already exists and is used elsewhere. Consolidating eliminates duplication.

## Verification
- Full `dune build --root .` passes
- No functional changes — pure refactor

## Test plan
- [ ] CI `Build and Test` passes
- [ ] CI lint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
RFC-WAIVED: pure refactor, no subsystem boundary changes