### PR TITLE
fix(cascade): repair .mli + test drift left by #19327 tier-group purge

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -128,9 +128,7 @@ let apply_provider_filter = Cascade_config_provider_filter.apply_provider_filter
 let apply_provider_filter_strict =
   Cascade_config_provider_filter.apply_provider_filter_strict
 
-(* Strategy / priority-tier / concurrency resolution (this PR) *)
-let normalize_priority_tiers =
-  Cascade_config_strategy_resolve.normalize_priority_tiers
+(* Strategy / concurrency resolution (priority-tier removed in #19327). *)
 let resolve_strategy = Cascade_config_strategy_resolve.resolve_strategy
 let resolve_ollama_max_concurrent =
   Cascade_config_strategy_resolve.resolve_ollama_max_concurrent

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -517,14 +517,7 @@ val resolve_strategy :
     - [backoff_cap_ms < backoff_base_ms] → clamped up to
       [backoff_base_ms]. *)
 
-val normalize_priority_tiers :
-  config_path:string ->
-  name:string ->
-  string list list ->
-  (string list list, string) result
-(** Validate and normalize a [priority_tier] tier matrix against the
-    configured candidate model ids for [name]. Returns [Error] when all
-    tiers collapse or when the profile has no configured candidates. *)
+(* normalize_priority_tiers removed: tier/tier-group purge in #19327. *)
 
 val resolve_ollama_max_concurrent :
   ?config_path:string ->

--- a/lib/cascade/cascade_config_strategy_resolve.mli
+++ b/lib/cascade/cascade_config_strategy_resolve.mli
@@ -1,21 +1,13 @@
-(** Cascade strategy + priority-tier + concurrency resolution.
+(** Cascade strategy + concurrency resolution.
 
     Pulls {!Cascade_config_loader.strategy_config} fields and turns them
-    into a typed {!Cascade_strategy.t} value. Owns the priority-tier
-    normalization that maps the raw tier matrix against the configured
-    candidate model ids.
+    into a typed {!Cascade_strategy.t} value.
 
     Extracted from [cascade_config.ml]. {!Cascade_config} re-exports
     every public binding here so external callers keep their existing
     API.
 
     @stability Internal *)
-
-val normalize_priority_tiers :
-  config_path:string ->
-  name:string ->
-  string list list ->
-  (string list list, string) result
 
 val resolve_strategy :
   ?config_path:string ->

--- a/lib/dashboard_cascade_config.ml
+++ b/lib/dashboard_cascade_config.ml
@@ -301,7 +301,13 @@ let config_json ?base_path () =
         then None
         else (
           let cascade_name =
-            match doc.Keeper_types_profile.cascade_name with
+            (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model
+               in keeper_profile_defaults but this consumer was missed.
+               Reading [.model] preserves the prior behavior of treating the
+               keeper-declared string as a cascade name. Root: separate review
+               needed — [.model] now stores a direct provider:model string per
+               #19327, which may not round-trip through cascade-name routing. *)
+            match doc.Keeper_types_profile.model with
             | Some c -> c
             | None -> (Keeper_config.default_cascade_name ())
           in

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -137,7 +137,8 @@ let invalid_profile_defaults_error ~keeper_name detail =
 let effective_declarative_cascade_name
     (defaults : Keeper_types_profile.keeper_profile_defaults)
     (meta : keeper_meta) =
-  match defaults.cascade_name, defaults.manifest_path with
+  (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model. *)
+  match defaults.model, defaults.manifest_path with
   | Some cascade_name, _ ->
       Keeper_cascade_profile.normalize_keeper_runtime_declared_name cascade_name
   | None, Some _ -> (Keeper_config.default_cascade_name ())
@@ -215,14 +216,17 @@ let ensure_keeper_meta config name =
         ()
     with
     | Error detail ->
+        (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model.
+           Field-label strings kept for backward-compat in error messages
+           so dashboards / log scrapers do not break on the rename. *)
         let field =
-          match defaults.cascade_name, defaults.manifest_path with
+          match defaults.model, defaults.manifest_path with
           | Some _, _ -> "profile.cascade_name"
           | None, Some _ -> "manifest.default_cascade_name"
           | None, None -> "meta.cascade_name"
         in
         let raw_value =
-          match defaults.cascade_name, defaults.manifest_path with
+          match defaults.model, defaults.manifest_path with
           | Some cascade_name, _ -> cascade_name
           | None, Some _ -> (Keeper_config.default_cascade_name ())
           | None, None -> cascade_name_of_meta meta

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -26,7 +26,10 @@ let effective_declarative_cascade_name
       (defaults : keeper_profile_defaults)
       (meta : keeper_meta)
   =
-  match defaults.cascade_name, defaults.manifest_path with
+  (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model. The
+     value is still routed through normalize_keeper_runtime_declared_name;
+     reviewer should confirm provider:model strings normalize correctly. *)
+  match defaults.model, defaults.manifest_path with
   | Some cascade_name, _ ->
     Keeper_cascade_profile.normalize_keeper_runtime_declared_name cascade_name
   | None, Some _ -> (Keeper_config.default_cascade_name ())

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -54,7 +54,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     | None -> Option.value ~default:[] p.profile_defaults.active_goal_ids
   in
   let selected_cascade_name =
-    match p.cascade_name_opt, p.profile_defaults.cascade_name with
+    (* WORKAROUND (#19327 follow-up): cascade_name→model field rename. *)
+    match p.cascade_name_opt, p.profile_defaults.model with
     | Some name, _ -> name
     | None, Some name -> name
     | None, None -> Keeper_config.default_cascade_name ()

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -275,7 +275,8 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
          present; otherwise preserve the existing keeper's cascade_ref so
          dashboard drift remains visible.  See #6747. *)
       (let group =
-         match p.cascade_name_opt, p.profile_defaults.cascade_name with
+         (* WORKAROUND (#19327 follow-up): cascade_name→model field rename. *)
+         match p.cascade_name_opt, p.profile_defaults.model with
          | Some name, _ -> name
          | None, Some name -> name
          | None, None ->

--- a/lib/keeper/keeper_types_profile.mli
+++ b/lib/keeper/keeper_types_profile.mli
@@ -31,7 +31,6 @@ val ensure_dir : string -> string
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_cascade_name_opt : string option -> string option
 val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -41,7 +41,7 @@ type keeper_profile_defaults = {
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  cascade_name : string option;
+  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;

--- a/lib/keeper/keeper_types_profile_sandbox.mli
+++ b/lib/keeper/keeper_types_profile_sandbox.mli
@@ -15,7 +15,6 @@ type network_mode =
 [@@deriving tla]
 
 val sandbox_profile_to_string : sandbox_profile -> string
-val reserved_cascade_names : string list
 val sandbox_profile_of_string : string -> sandbox_profile option
 val all_sandbox_profiles : sandbox_profile list
 val valid_sandbox_profile_strings : string list

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -137,7 +137,6 @@ val is_terminal : network_mode -> bool
 val is_active : network_mode -> bool
 val is_idle : network_mode -> bool
 val sandbox_profile_to_string : sandbox_profile -> string
-val reserved_cascade_names : string list
 val sandbox_profile_of_string : string -> sandbox_profile option
 val all_sandbox_profiles : sandbox_profile list
 val valid_sandbox_profile_strings : string list
@@ -190,7 +189,7 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  cascade_name : string option;
+  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
@@ -213,7 +212,6 @@ val keeper_oas_context_of_defaults :
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_cascade_name_opt : string option -> string option
 val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -137,7 +137,6 @@ val is_terminal : network_mode -> bool
 val is_active : network_mode -> bool
 val is_idle : network_mode -> bool
 val sandbox_profile_to_string : sandbox_profile -> string
-val reserved_cascade_names : string list
 val sandbox_profile_of_string : string -> sandbox_profile option
 val all_sandbox_profiles : sandbox_profile list
 val valid_sandbox_profile_strings : string list
@@ -190,7 +189,7 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  cascade_name : string option;
+  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
@@ -213,7 +212,6 @@ val keeper_oas_context_of_defaults :
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_cascade_name_opt : string option -> string option
 val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -137,7 +137,6 @@ val is_terminal : network_mode -> bool
 val is_active : network_mode -> bool
 val is_idle : network_mode -> bool
 val sandbox_profile_to_string : sandbox_profile -> string
-val reserved_cascade_names : string list
 val sandbox_profile_of_string : string -> sandbox_profile option
 val all_sandbox_profiles : sandbox_profile list
 val valid_sandbox_profile_strings : string list
@@ -190,7 +189,7 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  cascade_name : string option;
+  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
@@ -213,7 +212,6 @@ val keeper_oas_context_of_defaults :
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_cascade_name_opt : string option -> string option
 val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -137,7 +137,6 @@ val is_terminal : network_mode -> bool
 val is_active : network_mode -> bool
 val is_idle : network_mode -> bool
 val sandbox_profile_to_string : sandbox_profile -> string
-val reserved_cascade_names : string list
 val sandbox_profile_of_string : string -> sandbox_profile option
 val all_sandbox_profiles : sandbox_profile list
 val valid_sandbox_profile_strings : string list
@@ -190,7 +189,7 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  cascade_name : string option;
+  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
@@ -213,7 +212,6 @@ val keeper_oas_context_of_defaults :
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_cascade_name_opt : string option -> string option
 val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list

--- a/test/test_admission_queue_coverage.ml
+++ b/test/test_admission_queue_coverage.ml
@@ -9,11 +9,8 @@ open Alcotest
 
 module AQ = Masc_mcp.Admission_queue
 
-let cascade_name raw =
-  let canonical =
-    if Cascade_name.is_canonical_prefix raw then raw else "route." ^ raw
-  in
-  Cascade_name.of_string_exn canonical
+(* #19327 tier-group purge: Cascade_name is a plain string alias now. *)
+let cascade_name raw = Cascade_name.of_string_exn raw
 
 (* ============================================================
    Passthrough Contract

--- a/test/test_cascade_config_validity.ml
+++ b/test/test_cascade_config_validity.ml
@@ -105,83 +105,15 @@ let test_cascade_json_absent () =
   check bool "config/cascade.json absent" false (Sys.file_exists (config_path "cascade.json"))
 ;;
 
-let find_tier_group cfg name =
-  cfg.Types.tier_groups
-  |> List.find_opt (fun (group : Types.cascade_tier_group) ->
-    String.equal group.name name)
-;;
-
-let find_tier cfg name =
-  cfg.Types.tiers
-  |> List.find_opt (fun (tier : Types.cascade_tier) ->
-    String.equal tier.name name)
-;;
-
-let index_of value values =
-  let rec loop index = function
-    | [] -> None
-    | candidate :: rest ->
-      if String.equal candidate value then Some index else loop (index + 1) rest
-  in
-  loop 0 values
-;;
-
-let test_ollama_cloud_stable_is_system_only () =
-  let cfg = load_checked_in_cascade_toml () in
-  match find_tier_group cfg "ollama_cloud_stable" with
-  | None -> fail "missing tier-group.ollama_cloud_stable"
-  | Some group ->
-    check
-      (option bool)
-      "ollama_cloud_stable keeper-assignable"
-      (Some false)
-      group.keeper_assignable
-;;
-
-let test_strict_tool_group_does_not_bypass_glm_before_ollama_cloud () =
-  let cfg = load_checked_in_cascade_toml () in
-  match find_tier_group cfg "strict_tool_candidates" with
-  | None -> fail "missing tier-group.strict_tool_candidates"
-  | Some group ->
-    (match index_of "ollama_cloud_stable" group.tiers with
-     | None -> ()
-     | Some cloud_index ->
-       (match index_of "provider_k-coding-with-spark" group.tiers with
-        | Some glm_index when glm_index < cloud_index -> ()
-        | Some _ ->
-          fail
-            "strict_tool_candidates must try provider_k-coding-with-spark before \
-             ollama_cloud_stable"
-        | None ->
-          fail
-            "strict_tool_candidates must not include ollama_cloud_stable without \
-             provider_k-coding-with-spark ahead of it"))
-;;
-
-let test_no_deprecated_profile_names () =
-  let cfg = load_checked_in_cascade_toml () in
-  let deprecated_tiers =
-    cfg.Types.tiers
-    |> List.filter_map (fun (tier : Types.cascade_tier) ->
-      if Masc_mcp.Cascade_config_loader.is_deprecated_logical_profile_name tier.name
-      then Some ("tier." ^ tier.name)
-      else None)
-  in
-  let deprecated_groups =
-    cfg.Types.tier_groups
-    |> List.filter_map (fun (group : Types.cascade_tier_group) ->
-      if
-        Masc_mcp.Cascade_config_loader.is_deprecated_logical_profile_name
-          group.name
-      then Some ("tier-group." ^ group.name)
-      else None)
-  in
-  check
-    string
-    "deprecated tier/tier-group names"
-    ""
-    (String.concat ", " (deprecated_tiers @ deprecated_groups))
-;;
+(* #19327 tier-group purge: tier/tier_groups removed from cascade_config.
+   The tier-group-specific helpers (find_tier_group / find_tier / index_of)
+   and the four tests that exercised them
+   (ollama_cloud_stable_is_system_only,
+    strict_tool_group_does_not_bypass_glm_before_ollama_cloud,
+    no_deprecated_profile_names, primary_priority_order)
+   have been removed.  If equivalent invariants are still desired against
+   the new direct-binding cascade.toml schema, a separate test file should
+   cover them. *)
 
 let check_qwen_thinking_control cfg model_id =
   match Types.model_capabilities_for_id cfg model_id with
@@ -203,24 +135,6 @@ let test_qwen_models_use_chat_template_kwargs () =
   check_qwen_thinking_control cfg "qwen3-5"
 ;;
 
-let test_primary_priority_order () =
-  let cfg = load_checked_in_cascade_toml () in
-  match find_tier cfg "primary" with
-  | None -> fail "missing tier.primary"
-  | Some tier ->
-    check
-      (list string)
-      "primary priority"
-      [
-        "runpod_mtp.qwen-runpod.keeper";
-        "local_mtp.qwen-local.keeper";
-        "glm-coding.glm-5-turbo";
-        "glm-coding.glm-flashx";
-        "cli_tool_a.codex-spark.for-keeper-turn";
-      ]
-      tier.members
-;;
-
 let () =
   run
     "cascade config validity"
@@ -232,25 +146,9 @@ let () =
             test_cascade_toml_runtime_validates_without_rejected_profiles
         ; test_case "cascade.json is not a checked-in source" `Quick test_cascade_json_absent
         ; test_case
-            "ollama_cloud_stable is system-only"
-            `Quick
-            test_ollama_cloud_stable_is_system_only
-        ; test_case
-            "strict tool group does not bypass GLM before Ollama Cloud"
-            `Quick
-            test_strict_tool_group_does_not_bypass_glm_before_ollama_cloud
-        ; test_case
-            "cascade.toml has no deprecated profile names"
-            `Quick
-            test_no_deprecated_profile_names
-        ; test_case
             "provider_h models use chat_template_kwargs thinking control"
             `Quick
             test_qwen_models_use_chat_template_kwargs
-        ; test_case
-            "primary tier follows operator priority"
-            `Quick
-            test_primary_priority_order
         ] )
     ]
 ;;

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -658,18 +658,7 @@ let test_alias_parent_missing () =
           ; thinking_budget = None
           }
         ]
-    ; tiers =
-        [ { name = "t"
-          ; members = [ "x.m.a" ]
-          ; strategy = Failover
-          ; max_concurrent = None
-          ; cycle_policy = None
-          ; sticky_ttl_ms = None
-          ; scoring_params = None
-          ; keeper_assignable = None
-          }
-        ]
-    ; tier_groups = []
+    (* #19327: tier/tier_groups fields removed from cascade_config. *)
     ; routes = []
     ; system_targets = []
     ; profiles = []
@@ -855,18 +844,7 @@ let test_duplicate_routes () =
           }
         ]
     ; aliases = []
-    ; tiers =
-        [ { name = "primary"
-          ; members = [ "cli_tool_d.haiku" ]
-          ; strategy = Failover
-          ; max_concurrent = None
-          ; cycle_policy = None
-          ; sticky_ttl_ms = None
-          ; scoring_params = None
-          ; keeper_assignable = None
-          }
-        ]
-    ; tier_groups = []
+    (* #19327: tier/tier_groups fields removed from cascade_config. *)
     ; routes =
         [ { name = "dup"; target = "tier.primary" }
         ; { name = "dup"; target = "tier.primary" }

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -829,8 +829,8 @@ let test_partial_snapshot_errors_disjoint_from_profile_names () =
               | Adapter.Provider_not_found s
               | Adapter.Model_not_found s
               | Adapter.Binding_resolution_failed s
-              | Adapter.Alias_resolution_failed s
-              | Adapter.Tier_group_empty s -> Some s
+              | Adapter.Alias_resolution_failed s -> Some s
+              (* #19327: Tier_group_empty constructor removed. *)
               | Adapter.Strategy_mismatch _
               | Adapter.Duplicate_route _
               | Adapter.Internal _ -> None)

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -146,8 +146,7 @@ let test_minimal_parse () =
   check int "models" 1 (List.length cfg.models);
   check int "bindings" 1 (List.length cfg.bindings);
   check int "aliases" 0 (List.length cfg.aliases);
-  check int "tiers" 0 (List.length cfg.tiers);
-  check int "tier_groups" 0 (List.length cfg.tier_groups);
+  (* #19327: tier/tier_groups fields removed from cascade_config. *)
   check int "routes" 0 (List.length cfg.routes);
   check int "system_targets" 0 (List.length cfg.system_targets)
 ;;
@@ -225,65 +224,9 @@ let test_layer4_aliases () =
   | None -> failwith "missing governance alias"
 ;;
 
-let test_layer5_tiers () =
-  let cfg = ok_config (parse_string full_toml) in
-  check int "tiers" 3 (List.length cfg.tiers);
-  (match List.find_opt (fun (t : cascade_tier) -> t.name = "rerank") cfg.tiers with
-   | Some t ->
-     check
-       (list string)
-       "rerank members"
-       [ "agent_llm_a-code.haiku.for-scoring" ]
-       t.members;
-     check (option bool) "rerank keeper_assignable" (Some false)
-       t.keeper_assignable;
-     check
-       string
-       "rerank strategy"
-       "Cascade_declarative_types.Failover"
-       (show_cascade_strategy t.strategy)
-   | None -> failwith "missing rerank tier");
-  match List.find_opt (fun (t : cascade_tier) -> t.name = "primary") cfg.tiers with
-  | Some t ->
-    check
-      (list string)
-      "primary members"
-      [ "agent_llm_a-code.sonnet"; "agent_llm_a-code.haiku" ]
-      t.members;
-    check opt_int "primary max_concurrent" (Some 5) t.max_concurrent
-  | None -> failwith "missing primary tier"
-;;
-
-let test_layer5_tier_groups () =
-  let cfg = ok_config (parse_string full_toml) in
-  check int "tier_groups" 1 (List.length cfg.tier_groups);
-  match
-    List.find_opt (fun (g : cascade_tier_group) -> g.name = "primary") cfg.tier_groups
-  with
-  | Some g ->
-    check (list string) "tiers" [ "primary"; "local" ] g.tiers;
-    check bool "fallback" true g.fallback;
-    check (option bool) "keeper_assignable" (Some true) g.keeper_assignable;
-    check
-      string
-      "strategy"
-      "Cascade_declarative_types.Priority_tier"
-      (show_cascade_strategy g.strategy)
-  | None -> failwith "missing primary tier group"
-;;
-
-let test_keeper_assignable_duplicate_keys_rejected () =
-  let toml =
-    {|
-[tier.t]
-members = []
-keeper-assignable = true
-keeper_assignable = false
-|}
-  in
-  let errs = is_error (parse_string toml) in
-  has_error_at "tier.t.keeper-assignable" errs
-;;
+(* #19327 tier-group purge: test_layer5_tiers, test_layer5_tier_groups,
+   test_keeper_assignable_duplicate_keys_rejected removed.  All asserted
+   tier/tier-group parsing fields that no longer exist. *)
 
 let test_routes () =
   let cfg = ok_config (parse_string full_toml) in
@@ -516,273 +459,16 @@ let test_api_format_of_protocol () =
   check bool "unknown" true (api_format_of_protocol "unknown" |> Result.is_error)
 ;;
 
-let test_supported_config_strategies_parse () =
-  let strategies =
-    [ "failover", Failover
-    ; "priority_tier", Priority_tier
-    ]
-  in
-  List.iter
-    (fun (name, expected) ->
-       let toml =
-         Printf.sprintf
-           {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
+(* #19327 tier-group purge: test_supported_config_strategies_parse and
+   test_retired_config_strategies_rejected removed.  Both asserted parser
+   behavior on [tier.*] sections; Priority_tier strategy variant and
+   cfg.tiers field no longer exist.  Only [Failover] remains as a
+   cascade_strategy. *)
 
-[models.m]
-max-context = 4096
 
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "%s"
-|}
-           name
-       in
-       let cfg = ok_config (parse_string toml) in
-       match cfg.tiers with
-       | [ t ] ->
-         check
-           string
-           (name ^ " strategy")
-           (show_cascade_strategy expected)
-           (show_cascade_strategy t.strategy)
-       | _ -> failwith "expected exactly one tier")
-    strategies
-;;
-
-let test_retired_config_strategies_rejected () =
-  let retired =
-    [
-      "capacity_aware";
-      "weighted_random";
-      "circuit_breaker_cycling";
-      "sticky";
-      "round_robin";
-    ]
-  in
-  List.iter
-    (fun name ->
-       let toml =
-         Printf.sprintf
-           {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "%s"
-|}
-           name
-       in
-       match parse_string toml with
-       | Ok _ -> failwith ("expected retired strategy rejection: " ^ name)
-       | Error errs -> has_error_at "tier.t.strategy" errs)
-    retired
-;;
-
-(* --- Strategy-specific field tests --- *)
-
-let test_cycle_policy () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-max-cycles = 3
-backoff-base-ms = 500
-backoff-cap-ms = 10000
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] ->
-    (match t.cycle_policy with
-     | Some cp ->
-       check int "max_cycles" 3 cp.max_cycles;
-       check int "backoff_base_ms" 500 cp.backoff_base_ms;
-       check int "backoff_cap_ms" 10000 cp.backoff_cap_ms
-     | None -> failwith "expected cycle_policy")
-  | _ -> failwith "expected exactly one tier"
-;;
-
-let test_cycle_policy_absent () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] -> check bool "no cycle_policy" true (t.cycle_policy = None)
-  | _ -> failwith "expected exactly one tier"
-;;
-
-let test_cycle_policy_partial_ignored () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-max-cycles = 3
-backoff-base-ms = 500
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] -> check bool "partial yields None" true (t.cycle_policy = None)
-  | _ -> failwith "expected exactly one tier"
-;;
-
-let test_sticky_ttl_ms () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-sticky-ttl-ms = 600000
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] -> check opt_int "sticky_ttl_ms" (Some 600000) t.sticky_ttl_ms
-  | _ -> failwith "expected exactly one tier"
-;;
-
-let test_sticky_ttl_ms_absent () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] -> check opt_int "no sticky_ttl_ms" None t.sticky_ttl_ms
-  | _ -> failwith "expected exactly one tier"
-;;
-
-let test_scoring_params () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-latency-baseline-ms = 200.0
-rate-limit-recency-window-s = 60.0
-rate-limit-decay-base = 0.5
-rate-limit-skip-after = 3
-server-error-recency-window-s = 120.0
-server-error-decay-base = 0.3
-server-error-skip-after = 5
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] ->
-    (match t.scoring_params with
-     | Some sp ->
-       check float_testable "latency_baseline" 200.0 sp.latency_baseline_ms;
-       check float_testable "rl_recency" 60.0 sp.rate_limit_recency_window_s;
-       check float_testable "rl_decay" 0.5 sp.rate_limit_decay_base;
-       check int "rl_skip" 3 sp.rate_limit_skip_after;
-       check float_testable "se_recency" 120.0 sp.server_error_recency_window_s;
-       check float_testable "se_decay" 0.3 sp.server_error_decay_base;
-       check int "se_skip" 5 sp.server_error_skip_after
-     | None -> failwith "expected scoring_params")
-  | _ -> failwith "expected exactly one tier"
-;;
-
-let test_scoring_params_partial_ignored () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-latency-baseline-ms = 200.0
-rate-limit-recency-window-s = 60.0
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] -> check bool "partial scoring yields None" true (t.scoring_params = None)
-  | _ -> failwith "expected exactly one tier"
-;;
+(* #19327 tier-group purge: Strategy-specific field tests removed
+   (cycle_policy / sticky_ttl_ms / scoring_params).  All exercised
+   cfg.tiers field that no longer exists. *)
 
 (* --- Capabilities tests (#14608 tool/event fields + RFC-0058 §2.4 Phase 5.1 dispatch fields) --- *)
 
@@ -1563,14 +1249,7 @@ let () =
     ; "layer2_models", [ test_case "model specs" `Quick test_layer2_models ]
     ; "layer3_bindings", [ test_case "bindings" `Quick test_layer3_bindings ]
     ; "layer4_aliases", [ test_case "aliases" `Quick test_layer4_aliases ]
-    ; ( "layer5_tiers"
-      , [ test_case "tiers" `Quick test_layer5_tiers
-        ; test_case "tier groups" `Quick test_layer5_tier_groups
-        ; test_case
-            "duplicate keeper assignability keys rejected"
-            `Quick
-            test_keeper_assignable_duplicate_keys_rejected
-        ] )
+    (* #19327: layer5_tiers test group removed. *)
     ; ( "routes"
       , [ test_case "routes" `Quick test_routes
         ; test_case "system targets" `Quick test_system_targets
@@ -1595,25 +1274,8 @@ let () =
         ; test_case "key formatters" `Quick test_key_formatters
         ; test_case "api_format_of_protocol" `Quick test_api_format_of_protocol
         ] )
-    ; ( "strategies"
-      , [ test_case "supported strategies parse" `Quick
-            test_supported_config_strategies_parse
-        ; test_case "retired strategies rejected" `Quick
-            test_retired_config_strategies_rejected
-        ] )
-    ; ( "cycle_policy"
-      , [ test_case "parses all-or-nothing" `Quick test_cycle_policy
-        ; test_case "absent yields None" `Quick test_cycle_policy_absent
-        ; test_case "partial yields None" `Quick test_cycle_policy_partial_ignored
-        ] )
-    ; ( "sticky_ttl"
-      , [ test_case "parses sticky-ttl-ms" `Quick test_sticky_ttl_ms
-        ; test_case "absent yields None" `Quick test_sticky_ttl_ms_absent
-        ] )
-    ; ( "scoring_params"
-      , [ test_case "parses all 7 fields" `Quick test_scoring_params
-        ; test_case "partial yields None" `Quick test_scoring_params_partial_ignored
-        ] )
+    (* #19327: strategies / cycle_policy / sticky_ttl / scoring_params
+       test groups removed. *)
     ; ( "capabilities"
       , [ test_case "present parses with defaults" `Quick test_capabilities_present
         ; test_case "absent yields None" `Quick test_capabilities_absent

--- a/test/test_cascade_declarative_validator.ml
+++ b/test/test_cascade_declarative_validator.ml
@@ -160,8 +160,7 @@ let test_r3_unknown_binding () =
       thinking_enabled = None;
       thinking_budget = None;
     }];
-    tiers = [];
-    tier_groups = [];
+    (* #19327: tier/tier_groups fields removed from cascade_config. *)
     routes = [];
     system_targets = [];
     profiles = [];

--- a/test/test_cascade_name.ml
+++ b/test/test_cascade_name.ml
@@ -1,42 +1,25 @@
-(** RFC-0163 Phase A: Cascade_name.t unit tests.
+(** Cascade_name.t unit tests.
 
-    Validates the canonical-prefix enforcement that replaces the
-    auto-normalize bypass in [cascade_catalog_runtime_resolve.ml]. *)
+    Post-#19327 (tier/tier-group purge): Cascade_name is a plain string
+    alias.  The prior canonical-prefix enforcement (tier./tier-group./route.)
+    is no longer present, so the cases that previously asserted
+    [Error `Invalid_prefix] now succeed.  [`Invalid_prefix] is retained
+    in the variant for source compatibility but is no longer emitted. *)
 
 open Alcotest
 
 module CN = Cascade_name
 
-(* ── Valid parse tests ─────────────────────────────────────────── *)
-
-let test_tier_group_prefix () =
-  match CN.of_string "tier-group.strict_tool_candidates" with
+let test_round_trip () =
+  match CN.of_string "runpod:glm-coding-with-spark" with
   | Ok t ->
-    check string "round-trip" "tier-group.strict_tool_candidates" (CN.to_string t)
-  | Error _ -> fail "expected Ok for tier-group prefix"
-
-let test_tier_prefix () =
-  match CN.of_string "tier.primary" with
-  | Ok t -> check string "round-trip" "tier.primary" (CN.to_string t)
-  | Error _ -> fail "expected Ok for tier prefix"
-
-let test_route_prefix () =
-  match CN.of_string "route.default" with
-  | Ok t -> check string "round-trip" "route.default" (CN.to_string t)
-  | Error _ -> fail "expected Ok for route prefix"
+    check string "round-trip" "runpod:glm-coding-with-spark" (CN.to_string t)
+  | Error _ -> fail "expected Ok for plain provider:model"
 
 let test_whitespace_trimmed () =
-  match CN.of_string "  tier-group.x  " with
-  | Ok t -> check string "round-trip" "tier-group.x" (CN.to_string t)
+  match CN.of_string "  provider:model  " with
+  | Ok t -> check string "trimmed" "provider:model" (CN.to_string t)
   | Error _ -> fail "expected Ok after trimming"
-
-(* ── Invalid parse tests ───────────────────────────────────────── *)
-
-let test_bare_short_form () =
-  match CN.of_string "strict_tool_candidates" with
-  | Ok _ -> fail "expected Error for bare short form"
-  | Error `Invalid_prefix -> ()
-  | Error `Empty -> fail "expected Invalid_prefix, got Empty"
 
 let test_empty_string () =
   match CN.of_string "" with
@@ -50,40 +33,19 @@ let test_whitespace_only () =
   | Error `Empty -> ()
   | Error `Invalid_prefix -> fail "expected Empty, got Invalid_prefix"
 
-let test_unknown_prefix () =
-  match CN.of_string "group.something" with
-  | Ok _ -> fail "expected Error for unknown prefix"
-  | Error `Invalid_prefix -> ()
-  | Error `Empty -> fail "expected Invalid_prefix, got Empty"
-
-(* ── of_string_exn tests ──────────────────────────────────────── *)
-
 let test_of_string_exn_ok () =
-  check string "exn round-trip" "tier-group.x" (CN.to_string (CN.of_string_exn "tier-group.x"))
-
-let test_is_canonical_prefix () =
-  check bool "tier-group. is canonical" true (CN.is_canonical_prefix "tier-group.x");
-  check bool "tier. is canonical" true (CN.is_canonical_prefix "tier.x");
-  check bool "route. is canonical" true (CN.is_canonical_prefix "route.x");
-  check bool "bare is not canonical" false (CN.is_canonical_prefix "x");
-  check bool "empty is not canonical" false (CN.is_canonical_prefix "")
+  check string "exn round-trip" "x" (CN.to_string (CN.of_string_exn "x"))
 
 let () =
   Alcotest.run "cascade_name"
     [ ( "valid"
-      , [ test_case "tier-group prefix" `Quick test_tier_group_prefix
-        ; test_case "tier prefix" `Quick test_tier_prefix
-        ; test_case "route prefix" `Quick test_route_prefix
+      , [ test_case "round-trip" `Quick test_round_trip
         ; test_case "whitespace trimmed" `Quick test_whitespace_trimmed
         ] )
     ; ( "invalid"
-      , [ test_case "bare short form" `Quick test_bare_short_form
-        ; test_case "empty string" `Quick test_empty_string
+      , [ test_case "empty string" `Quick test_empty_string
         ; test_case "whitespace only" `Quick test_whitespace_only
-        ; test_case "unknown prefix" `Quick test_unknown_prefix
         ] )
-    ; ( "exn_and_helpers"
-      , [ test_case "of_string_exn ok" `Quick test_of_string_exn_ok
-        ; test_case "is_canonical_prefix" `Quick test_is_canonical_prefix
-        ] )
+    ; ( "exn"
+      , [ test_case "of_string_exn ok" `Quick test_of_string_exn_ok ] )
     ]

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -21,14 +21,9 @@ module Owne = Masc_mcp.Keeper_turn_driver
 module KT = Masc_mcp.Keeper_types
 module Retry = Llm_provider.Retry
 
-let cascade_name raw =
-  let trimmed = String.trim raw in
-  let canonical =
-    if Cascade_name.is_canonical_prefix trimmed
-    then trimmed
-    else "tier-group." ^ trimmed
-  in
-  Cascade_name.of_string_exn canonical
+(* #19327 tier-group purge: Cascade_name is a plain string alias now;
+   the prefix canonicalization this helper used to do is no longer needed. *)
+let cascade_name raw = Cascade_name.of_string_exn (String.trim raw)
 ;;
 
 let test_cascade = cascade_name "tier.test_cascade"
@@ -471,15 +466,10 @@ let test_rotation_finds_next_cascade_for_auth_error () =
 
 (* ---- Bare-name requalification tests (cascade-name-prefix-mismatch fix) ---- *)
 
-let test_normalized_cascade_name_requalifies_bare_tier_name () =
-  let catalog_names = [ "strict_tool_candidates"; "primary"; "coding_with_spark" ] in
-  let result =
-    KEC.normalized_cascade_name ~catalog_names "strict_tool_candidates"
-  in
-  check bool "result has canonical prefix" true
-    (Cascade_name.is_canonical_prefix result);
-  check string "result is tier-qualified"
-    "tier.strict_tool_candidates" result
+(* #19327 tier-group purge: test_normalized_cascade_name_requalifies_bare_tier_name
+   removed.  It asserted that bare "strict_tool_candidates" was rewritten to
+   "tier.strict_tool_candidates" using the tier-prefix canonical form; that
+   prefix layer is gone. *)
 
 let test_normalized_cascade_name_passes_through_already_qualified () =
   let catalog_names = [ "strict_tool_candidates"; "primary" ] in
@@ -572,8 +562,7 @@ let () =
         ] );
       ( "normalized_cascade_name_bare_requalify",
         [
-          test_case "bare tier name requalified with prefix" `Quick
-            test_normalized_cascade_name_requalifies_bare_tier_name;
+          (* #19327: "bare tier name requalified with prefix" test removed. *)
           test_case "already-qualified name passes through" `Quick
             test_normalized_cascade_name_passes_through_already_qualified;
           test_case "config special names preserved" `Quick

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -689,8 +689,9 @@ preset = "delivery"
       | Error e -> fail e
       | Ok (name, defaults) ->
           check string "name from filename" "sangsu" name;
+          (* #19327: field renamed cascade_name→model. *)
           check (option string) "base cascade" (Some "route.keeper_turn")
-            defaults.cascade_name;
+            defaults.model;
           check (option string) "base sandbox" (Some "docker")
             (Option.map KTP.sandbox_profile_to_string defaults.sandbox_profile);
           check (option string) "base network" (Some "inherit")

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -28,14 +28,10 @@ module Keeper_fs = Masc_mcp.Keeper_fs
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_types_support = Masc_mcp.Keeper_types_support
 
+(* #19327 tier-group purge: Cascade_name is a plain string alias now. *)
 let oas_error_cascade_name raw =
-  let normalized = Masc_mcp.Keeper_cascade_profile.normalize_declared_name raw in
-  let canonical =
-    if Cascade_name.is_canonical_prefix normalized
-    then normalized
-    else "tier-group." ^ normalized
-  in
-  Cascade_name.of_string_exn canonical
+  Masc_mcp.Keeper_cascade_profile.normalize_declared_name raw
+  |> Cascade_name.of_string_exn
 ;;
 
 let phase_buffer_cascade_name () =


### PR DESCRIPTION
## Summary

Fixes the `dune build .` drift left by [#19327 refactor(cascade): remove tier and tier-group from cascade config](https://github.com/jeong-sik/masc-mcp/pull/19327). Scope-bound to **mechanical** `.mli`/test sync — no architecture changes.

26 files, +92/-624.

## ⚠️ main is currently doubly broken — block this PR until #19340 is resolved

Verified on `origin/main` HEAD `7bd648db0`:

1. **`#19327` drift** (this PR's scope) — `.mli`/test refer to types removed in the `.ml`.
2. **`#19340 refactor(cascade, keeper): purge dead tier/tier-group and phonebook code` drift** (NOT in this PR's scope) — separate `.mli` files reference `Tier_admission_*` / `Tier_admission` / `Tier_admission_exhausted` constructors that `.ml` renamed to `Admission_*`, **plus** a real module-level dependency cycle:

   ```
   Cascade_config → Cascade_config_resolve → Cascade_routes →
   Cascade_catalog_runtime → Cascade_catalog_runtime_resolve →
   Cascade_catalog_runtime_validate → (Cascade_routes / Cascade_declarative_adapter) → Cascade_config
   ```

   `Cascade_routes:218` (`known_profile_names ()`) and `Cascade_catalog_runtime_validate:281,406-420` (`Cascade_routes.configured_route_targets`, `cascade_name_for_use`) form a true bidirectional dep, not just a facade detour. Two facade-bypass tries reduced the cycle by one hop but the structural cycle remains. Fixing it requires either callback injection / dependency inversion or removing one of the two cross-calls — out of this PR's mechanical sync scope.

**Recommendation**: revert `#19340` to unblock main, then rebase this PR and re-evaluate. Alternatively the `#19340` author can publish a follow-up that (a) syncs the 3 stale `.mli` (`cascade_internal_error.mli` / `keeper_health_probe.mli` / `provider_error_class.mli`), (b) syncs `keeper_turn_driver.mli`'s `For_testing` module signatures (`cascade_tier_admission_policy_of_priority` → `cascade_admission_policy_of_priority`, `with_cascade_tier_admission_for_testing` → `with_cascade_admission_for_testing`), (c) renames `tier_id` → `admission_key` in 4 test files (`test_cascade_saturation_signal.ml`, `test_cascade_tier_admission.ml`, `test_cascade_declarative_hotpath.ml`, `test_cascade_tier_wait_scheduler.ml`), (d) deletes 5 dead test files referencing the removed `Cascade_phonebook_types` / `Cascade_routing_policy` modules (`test_cascade_phonebook*.ml`, `test_cascade_routing_policy*.ml`) plus their `test/dune` entries, and (e) breaks the cycle.

This PR's content is correct against the schema `#19327` intended to ship, and the rebase auto-merged cleanly with `#19340`'s incremental changes (one resolved conflict in `cascade_declarative_adapter.mli` — `#19340` removed both `Strategy_mismatch` and `Tier_group_empty` from `adapter_error`, which is strictly more thorough than our `Tier_group_empty`-only removal; accepted `#19340`'s version).

## Root cause — CI Gate Skip recurrence (this is happening repeatedly)

`#19327` was merged with `Build and Test` / `Lint` / `Health` / `CI Gate` / `TLA+ Model Checking` reported as **CANCELLED** behind the `Detect Changed Surfaces` gate. `#19340` was merged the same day under the same pattern. Memory `reference_masc_mcp_ci_build_test_skips.md` records the original 2026-05-12 incident. That is now a **two-strikes-in-24-hours** recurrence and is the structural fix the team should prioritize — broken cascade/keeper refactors are reaching main because the gate's "relevant surface" computation under-estimates blast radius.

## Changes (this PR — #19327 follow-up only)

### `.mli` sync (8 files)
- `keeper_types_profile_defaults.mli`: `cascade_name : string option` → `model : string option`
- `keeper_types_profile_toml.mli` / `_toml_io.mli` / `_toml_parser.mli` (re-exports): same rename
- `keeper_types_profile_sandbox.mli` / `_toml.mli` / `_toml_io.mli` / `_toml_parser.mli`: drop `reserved_cascade_names`
- `keeper_types_profile.mli` / `_toml.mli` / `_toml_normalizers.mli` / `_toml_parser.mli`: drop `normalize_cascade_name_opt`
- `cascade_config.mli` / `cascade_config_strategy_resolve.mli`: drop `normalize_priority_tiers`
- `cascade_declarative_adapter.mli`: drop `Tier_group_empty` (rebase merged with #19340 also dropping `Strategy_mismatch`)

### Consumer `.ml` sites `#19327` missed (6 sites in 5 files)
Each rewritten to read `.model` instead of `.cascade_name`, marked with `WORKAROUND (#19327 follow-up)`:
- `lib/dashboard_cascade_config.ml:304`
- `lib/keeper/keeper_status_bridge.ml:29`
- `lib/keeper/keeper_runtime.ml:140` + `:220`
- `lib/keeper/keeper_turn_up_update.ml:278`
- `lib/keeper/keeper_turn_up_create.ml:57`
- `lib/cascade/cascade_config.ml:131`: drop dead `Cascade_config_strategy_resolve.normalize_priority_tiers` call

**Semantic gap surfaced — needs reviewer judgment**: four of the six sites pipe the new `.model` value into `Keeper_cascade_profile.normalize_keeper_runtime_declared_name`, which is the *cascade-name* normalizer that routes through `cascade_name_for_use`. `#19327` makes `.model` hold direct provider:model strings like `runpod:glm-coding-with-spark`. Whether those round-trip through cascade-name routing without surprise is open — preserved legacy behavior here to keep this PR mechanical.

### Test migration (11 files)
- 4 helpers using `Cascade_name.is_canonical_prefix` simplified (now a plain string alias)
- 3 record literals dropped `tiers = [...]` / `tier_groups = []` (fields removed)
- `test_cascade_declarative_parser.ml`: 8 tier-strategy field tests deleted (`cycle_policy` / `sticky_ttl_ms` / `scoring_params` / `layer5_tiers` / `supported_config_strategies_parse` / ...)
- `test_cascade_declarative_hotpath.ml:833`: drop `Tier_group_empty` match arm
- `test_cascade_config_validity.ml`: delete `find_tier_group` / `find_tier` helpers + 4 tier-group-dependent tests
- `test_keeper_toml.ml:693`: `defaults.cascade_name` → `defaults.model`
- `test_keeper_error_classify_recoverable.ml`: delete `test_normalized_cascade_name_requalifies_bare_tier_name`

## Verification

- `dune build lib/` PASSES against post-#19340 main (the broken-from-#19340 modules `cascade_internal_error.ml`, `provider_error_class.ml`, `keeper_health_probe.ml`, `keeper_turn_driver.ml`, `cascade_routes.ml` ↔ `cascade_catalog_runtime_validate.ml` cycle still fail — not in this PR's scope)
- Pre-rebase the full `dune build .` was GREEN (verified before #19340 landed)
- `pr-rfc-check.sh` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
