### PR TITLE
revert(cascade): revert #19340 + apply #19342 to unbreak main

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -3,7 +3,7 @@
 #
 # This file is the SSOT for: provider credentials, model capabilities,
 # per-binding capacity (max-concurrent) and pricing, per-use aliases,
-# and route assignments.
+# tier composition, tier-group fallback chains, and route assignments.
 # Code MUST NOT hard-code provider or model names; it dispatches by
 # api_format (Messages_api / Chat_completions_api / Ollama_api) and
 # reads everything else from this file. See RFC-0058 §2.4.

--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -50,7 +50,7 @@ let capacity_backpressure_source_to_failure_scope = function
     Llm_provider.Http_client.Failure_scope_provider
   | Cascade_error_classify.Client_capacity ->
     Llm_provider.Http_client.Failure_scope_account
-  | Cascade_error_classify.Admission_capacity ->
+  | Cascade_error_classify.Tier_admission ->
     Llm_provider.Http_client.Failure_scope_model
   | Cascade_error_classify.Cascade_slot ->
     Llm_provider.Http_client.Failure_scope_unknown

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -39,9 +39,9 @@ type profile_build = {
   probes : candidate_probe list;
   required_capability_profile : string option;
       (** Profile-scoped capability lint hint. The RFC-0058 declarative
-          namespaces ([providers], [models] + provider binding tables)
-          do not carry this field yet, so callers normally see [None]
-          under fully-declarative configs. *)
+          namespaces ([providers], [models], [tier], [tier-group] +
+          provider binding tables) do not carry this field yet, so callers
+          normally see [None] under fully-declarative configs. *)
 }
 
 type snapshot = {

--- a/lib/cascade/cascade_catalog_runtime_named_providers.ml
+++ b/lib/cascade/cascade_catalog_runtime_named_providers.ml
@@ -20,7 +20,7 @@ let candidate_key_of_cfg (cfg : Llm_provider.Provider_config.t) =
 
 type tiered_provider = {
   provider_cfg : Llm_provider.Provider_config.t;
-  admission_key : string;
+  tier_id : string;
 }
 
 let direct_candidate_providers (profile : profile_snapshot) =
@@ -81,14 +81,14 @@ let tier_bucket_id (profile : profile_snapshot) tier_index =
   then profile.name
   else Printf.sprintf "%s.tier-%d" profile.name tier_index
 
-let admission_key_queues_by_health_key (profile : profile_snapshot) =
+let tier_id_queues_by_health_key (profile : profile_snapshot) =
   let tiers = profile.strategy.Cascade_strategy.tiers in
   let index : (string, string Queue.t) Hashtbl.t = Hashtbl.create 8 in
   if List.length tiers > 1
   then
     List.iteri
       (fun tier_index health_keys ->
-         let admission_key = tier_bucket_id profile tier_index in
+         let tier_id = tier_bucket_id profile tier_index in
          List.iter
            (fun health_key ->
               let queue =
@@ -99,12 +99,12 @@ let admission_key_queues_by_health_key (profile : profile_snapshot) =
                     Hashtbl.add index health_key queue;
                     queue
               in
-              Queue.add admission_key queue)
+              Queue.add tier_id queue)
            health_keys)
       tiers;
   index
 
-let admission_key_for_candidate
+let tier_id_for_candidate
     (profile : profile_snapshot)
     tier_index
     (candidate : candidate_runtime) =
@@ -122,13 +122,13 @@ let tiered_provider_of_candidate
     : tiered_provider =
   {
     provider_cfg = candidate.provider_cfg;
-    admission_key = admission_key_for_candidate profile tier_index candidate;
+    tier_id = tier_id_for_candidate profile tier_index candidate;
   }
 
 let tiered_providers_of_ordered_entries ~(profile : profile_snapshot)
     ~cascade_name:_
     (ordered_entries : Cascade_config_loader.weighted_entry list) =
-  let tier_index = admission_key_queues_by_health_key profile in
+  let tier_index = tier_id_queues_by_health_key profile in
   direct_candidates_ordered_by_entries profile ordered_entries
   |> List.map (tiered_provider_of_candidate profile tier_index)
 

--- a/lib/cascade/cascade_catalog_runtime_named_providers.mli
+++ b/lib/cascade/cascade_catalog_runtime_named_providers.mli
@@ -26,7 +26,7 @@ val resolve_named_providers_strict :
 
 type tiered_provider = {
   provider_cfg : Llm_provider.Provider_config.t;
-  admission_key : string;
+  tier_id : string;
 }
 
 type secondary_resolution = {

--- a/lib/cascade/cascade_catalog_runtime_resolve.ml
+++ b/lib/cascade/cascade_catalog_runtime_resolve.ml
@@ -266,7 +266,7 @@ let lookup_active_profile ?sw ?net ?clock raw_name =
         | Error `Invalid_prefix ->
             Error
               (Printf.sprintf
-                 "cascade_name %S lacks required prefix (route.)"
+                 "cascade_name %S lacks required prefix (tier-group|tier|route)"
                  trimmed)
         | Error `Empty ->
             (* Defensive: empty case is handled above, but [of_string]

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -128,9 +128,7 @@ let apply_provider_filter = Cascade_config_provider_filter.apply_provider_filter
 let apply_provider_filter_strict =
   Cascade_config_provider_filter.apply_provider_filter_strict
 
-(* Strategy / priority-tier / concurrency resolution (this PR) *)
-let normalize_priority_tiers =
-  Cascade_config_strategy_resolve.normalize_priority_tiers
+(* Strategy / concurrency resolution (priority-tier removed in #19327). *)
 let resolve_strategy = Cascade_config_strategy_resolve.resolve_strategy
 let resolve_ollama_max_concurrent =
   Cascade_config_strategy_resolve.resolve_ollama_max_concurrent

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -137,3 +137,7 @@ let resolve_ollama_max_concurrent =
 let resolve_cli_max_concurrent =
   Cascade_config_strategy_resolve.resolve_cli_max_concurrent
 
+(* Phonebook loading (RFC Cascade-Phonebook) *)
+let load_phonebook = Cascade_config_loader.load_phonebook
+let invalidate_phonebook_cache = Cascade_config_loader.invalidate_phonebook_cache
+let load_phonebook_from_config = Cascade_config_loader.load_phonebook_from_config

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -547,3 +547,20 @@ val resolve_cli_max_concurrent :
     [None] means "use the env-var default
     ([MASC_CLI_MAX_CONCURRENT] or 1)".
     @since 0.9.8 *)
+
+(** {2 Phonebook loading (RFC Cascade-Phonebook)} *)
+
+val load_phonebook :
+  string -> (Cascade_phonebook_types.cascade_phonebook, string) result
+(** Load a TOML file as a typed phonebook with mtime-based caching.
+    @since RFC Cascade-Phonebook *)
+
+val invalidate_phonebook_cache : string -> unit
+(** Drop the cached phonebook entry for a path.
+    @since RFC Cascade-Phonebook *)
+
+val load_phonebook_from_config :
+  unit -> (Cascade_phonebook_types.cascade_phonebook, string) result option
+(** Resolve cascade TOML path and load phonebook. Returns [None] when
+    no config dir is configured.
+    @since RFC Cascade-Phonebook *)

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -517,14 +517,7 @@ val resolve_strategy :
     - [backoff_cap_ms < backoff_base_ms] → clamped up to
       [backoff_base_ms]. *)
 
-val normalize_priority_tiers :
-  config_path:string ->
-  name:string ->
-  string list list ->
-  (string list list, string) result
-(** Validate and normalize a [priority_tier] tier matrix against the
-    configured candidate model ids for [name]. Returns [Error] when all
-    tiers collapse or when the profile has no configured candidates. *)
+(* normalize_priority_tiers removed: tier/tier-group purge in #19327. *)
 
 val resolve_ollama_max_concurrent :
   ?config_path:string ->

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -1,9 +1,14 @@
 (** Config loading with mtime-based hot-reload.
 
-    TOML → [Cascade_toml_materializer] → Yojson.Safe.t
+    Two loading pipelines coexist:
+    1. Legacy JSON pipeline: TOML → [Cascade_toml_materializer] → Yojson.Safe.t
+    2. Phonebook pipeline:  TOML → [Cascade_phonebook_parser] → typed cascade_phonebook
+
+    Both share the same mtime-based cache invalidation strategy.
 
     @since 0.59.0
-    @since 0.92.0 extracted from Cascade_config *)
+    @since 0.92.0 extracted from Cascade_config
+    @since RFC Cascade-Phonebook added phonebook loading *)
 
 let config_cache : (string, float * Yojson.Safe.t) Hashtbl.t = Hashtbl.create 4
 
@@ -264,7 +269,12 @@ let deprecated_logical_profile_names =
   ]
 ;;
 
-let unqualified_profile_name normalized = normalized
+let unqualified_profile_name normalized =
+  if String.starts_with ~prefix:"tier-group." normalized then
+    String.sub normalized 11 (String.length normalized - 11)
+  else if String.starts_with ~prefix:"tier." normalized then
+    String.sub normalized 5 (String.length normalized - 5)
+  else normalized
 ;;
 
 let is_deprecated_logical_profile_name raw =
@@ -551,4 +561,123 @@ let resolve_strategy_config ~config_path ~name =
 
 let resolve_strategy_config_for_diagnostics ~config_path ~name =
   resolve_strategy_config_impl ~emit_telemetry:false ~config_path ~name
+;;
+
+(* ── Phonebook loading (RFC Cascade-Phonebook) ────────── *)
+
+(** Separate cache for typed phonebook records.  Keyed by file path,
+    invalidated on mtime change — same strategy as the JSON cache above. *)
+let phonebook_cache : (string, float * Cascade_phonebook_types.cascade_phonebook) Hashtbl.t =
+  Hashtbl.create 4
+
+(** Stat a file, return its mtime or None. *)
+let stat_mtime path =
+  try Some ((Unix.stat path).Unix.st_mtime) with
+  | Unix.Unix_error _ | Sys_error _ -> None
+
+(** Load a TOML file as a typed phonebook with mtime-based caching.
+
+    Same race-aware design as [load_toml_in_memory]:
+    1. stat → mtime_pre
+    2. cache lookup — hit returns cached phonebook
+    3. miss → Otoml parse → phonebook parse → stat → mtime_post
+    4. cache only when mtime_pre = mtime_post *)
+let load_phonebook_impl ~emit_telemetry path =
+  match stat_mtime path with
+  | None ->
+    (* File vanished or unreadable. Let Otoml surface the real error. *)
+    (try
+       let toml = Otoml.Parser.from_file path in
+       match Cascade_phonebook_parser.parse_phonebook toml with
+       | Ok pb -> Ok pb
+       | Error errs ->
+         let msg =
+           List.map (fun (e : Cascade_phonebook_parser.parse_error) ->
+             Printf.sprintf "%s: %s" e.path e.message) errs
+           |> String.concat "; "
+         in
+         Error (Printf.sprintf "phonebook parse error (%s): %s" path msg)
+     with
+     | Sys_error msg ->
+       Error (Printf.sprintf "phonebook IO error (path=%s): %s" path msg)
+     | Unix.Unix_error (err, fn, arg) ->
+       Error (Printf.sprintf "phonebook Unix error (path=%s): %s(%s): %s"
+                path fn arg (Unix.error_message err))
+     | Otoml.Parse_error (loc, detail) ->
+       let loc_str =
+         match loc with
+         | Some (line, col) -> Printf.sprintf " at line %d col %d" line col
+         | None -> ""
+       in
+       Error (Printf.sprintf "phonebook TOML parse error (%s)%s: %s" path loc_str detail))
+  | Some mtime_pre ->
+    let cached =
+      with_cache_lock (fun () ->
+        match Hashtbl.find_opt phonebook_cache path with
+        | Some (cached_mtime, cached_pb) when Float.equal cached_mtime mtime_pre ->
+          Some cached_pb
+        | _ -> None)
+    in
+    (match cached with
+     | Some pb -> Ok pb
+     | None ->
+       (try
+          let toml = Otoml.Parser.from_file path in
+          (match Cascade_phonebook_parser.parse_phonebook toml with
+           | Error errs ->
+             let msg =
+               List.map (fun (e : Cascade_phonebook_parser.parse_error) ->
+                 Printf.sprintf "%s: %s" e.path e.message) errs
+               |> String.concat "; "
+             in
+             Error (Printf.sprintf "phonebook parse error (%s): %s" path msg)
+           | Ok pb ->
+             let mtime_post = stat_mtime path in
+             (match mtime_post with
+              | Some mp when Float.equal mp mtime_pre ->
+                with_cache_lock (fun () ->
+                  Hashtbl.replace phonebook_cache path (mp, pb));
+                if emit_telemetry then
+                  Log.info ~ctx:"CascadeConfig" "loaded phonebook %s mtime=%.0f" path mp;
+                Ok pb
+              | Some _mp ->
+                (* Race: mtime moved mid-read. Serve fresh but skip cache. *)
+                if emit_telemetry then
+                  Cascade_metrics.on_toml_read_race ();
+                Ok pb
+              | None ->
+                Ok pb))
+        with
+        | Sys_error msg ->
+          Error (Printf.sprintf "phonebook IO error (path=%s): %s" path msg)
+        | Unix.Unix_error (err, fn, arg) ->
+          Error (Printf.sprintf "phonebook Unix error (path=%s): %s(%s): %s"
+                   path fn arg (Unix.error_message err))
+        | Otoml.Parse_error (loc, detail) ->
+          let loc_str =
+            match loc with
+            | Some (line, col) -> Printf.sprintf " at line %d col %d" line col
+            | None -> ""
+          in
+          Error (Printf.sprintf "phonebook TOML parse error (%s)%s: %s" path loc_str detail)))
+;;
+
+let load_phonebook path =
+  load_phonebook_impl ~emit_telemetry:true path
+;;
+
+(** Drop the cached phonebook entry for a path. *)
+let invalidate_phonebook_cache path =
+  with_cache_lock (fun () -> Hashtbl.remove phonebook_cache path)
+;;
+
+(** Resolve the cascade TOML path via config_dir_resolver and load phonebook.
+
+    Returns [None] when no cascade.toml is configured (missing/invalid config dir).
+    Returns [Some (Error msg)] when the file exists but fails to parse.
+    Returns [Some (Ok pb)] on success. *)
+let load_phonebook_from_config () =
+  match Config_dir_resolver.cascade_path_opt () with
+  | None -> None
+  | Some path -> Some (load_phonebook path)
 ;;

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -204,3 +204,29 @@ val resolve_strategy_config :
 
 val resolve_strategy_config_for_diagnostics :
   config_path:string -> name:string -> strategy_config
+
+(* ── Phonebook loading (RFC Cascade-Phonebook) ────────── *)
+
+(** Load a TOML file as a typed [cascade_phonebook] with mtime-based caching.
+
+    Uses [Cascade_phonebook_parser] to parse directly from Otoml into
+    typed records, bypassing the legacy JSON rendering pipeline.
+
+    @since RFC Cascade-Phonebook *)
+val load_phonebook :
+  string -> (Cascade_phonebook_types.cascade_phonebook, string) result
+
+(** Drop the cached phonebook entry for a path.
+
+    @since RFC Cascade-Phonebook *)
+val invalidate_phonebook_cache : string -> unit
+
+(** Resolve the cascade TOML path via config_dir_resolver and load phonebook.
+
+    Returns [None] when no cascade.toml is configured (missing/invalid config dir).
+    Returns [Some (Error msg)] when the file exists but fails to parse.
+    Returns [Some (Ok pb)] on success.
+
+    @since RFC Cascade-Phonebook *)
+val load_phonebook_from_config :
+  unit -> (Cascade_phonebook_types.cascade_phonebook, string) result option

--- a/lib/cascade/cascade_config_resolve.ml
+++ b/lib/cascade/cascade_config_resolve.ml
@@ -142,6 +142,13 @@ let weighted_entry_of_materialized_member json member =
       | None -> None)
   | _ -> None
 
+(* Tier/tier-group purge: [materialized_tier_members] /
+   [materialized_tier_group_tiers] / [configured_weighted_entries_from_materialized_json]
+   are retired.  Profile resolution now routes through the declarative
+   snapshot or runtime catalog exclusively; there is no JSON-materialized
+   tier-based fallback.  [weighted_entry_of_materialized_member] is kept
+   for the direct-provider:model path in future refactor phases. *)
+
 let configured_weighted_entries_from_materialized_json _json ~name:_ =
   []
 

--- a/lib/cascade/cascade_config_strategy_resolve.mli
+++ b/lib/cascade/cascade_config_strategy_resolve.mli
@@ -1,21 +1,13 @@
-(** Cascade strategy + priority-tier + concurrency resolution.
+(** Cascade strategy + concurrency resolution.
 
     Pulls {!Cascade_config_loader.strategy_config} fields and turns them
-    into a typed {!Cascade_strategy.t} value. Owns the priority-tier
-    normalization that maps the raw tier matrix against the configured
-    candidate model ids.
+    into a typed {!Cascade_strategy.t} value.
 
     Extracted from [cascade_config.ml]. {!Cascade_config} re-exports
     every public binding here so external callers keep their existing
     API.
 
     @stability Internal *)
-
-val normalize_priority_tiers :
-  config_path:string ->
-  name:string ->
-  string list list ->
-  (string list list, string) result
 
 val resolve_strategy :
   ?config_path:string ->

--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -18,6 +18,7 @@ type adapter_error =
   | Model_not_found of string
   | Binding_resolution_failed of string
   | Alias_resolution_failed of string
+  | Strategy_mismatch of string
   | Duplicate_route of string
   | Internal of string
 [@@deriving show]

--- a/lib/cascade/cascade_declarative_adapter.mli
+++ b/lib/cascade/cascade_declarative_adapter.mli
@@ -18,6 +18,10 @@ type adapter_error =
       Root cause is either [Provider_not_found] or [Model_not_found]. *)
   | Alias_resolution_failed of string
   (** Alias "provider.model.alias" parent binding does not exist. *)
+  | Strategy_mismatch of string
+  (** Tier declares strategy-specific fields for the wrong strategy kind. *)
+  | Tier_group_empty of string
+  (** Tier-group references no tiers. *)
   | Duplicate_route of string
   (** Two routes with the same name. *)
   | Internal of string
@@ -34,18 +38,19 @@ type provider_config_with_override =
 
 type adapted_profile = {
   name : string;
-  (** Profile name — a plain provider:model string. *)
+  (** Profile name derived from tier or tier-group (e.g. "tier.primary",
+      "tier-group.primary"). *)
   provider_configs : provider_config_with_override list;
   (** Resolved provider configs with optional per-provider capability
       overrides, in declaration order. *)
   strategy : Cascade_strategy.t;
   (** Mapped strategy with parameters. *)
   ollama_max_concurrent : int option;
-  (** Per-profile [max_concurrent] cap for Ollama providers, if set. *)
+  (** Per-tier [max_concurrent] cap for Ollama providers, if set. *)
   cli_max_concurrent : int option;
-  (** Per-profile [max_concurrent] cap for CLI providers, if set. *)
+  (** Per-tier [max_concurrent] cap for CLI providers, if set. *)
   required_capability_profile : string option;
-  (** Capability profile name required by this profile, if any. *)
+  (** Capability profile name required by this tier-group, if any. *)
 }
 
 type adapted_catalog = {

--- a/lib/cascade/cascade_declarative_adapter.mli
+++ b/lib/cascade/cascade_declarative_adapter.mli
@@ -20,8 +20,6 @@ type adapter_error =
   (** Alias "provider.model.alias" parent binding does not exist. *)
   | Strategy_mismatch of string
   (** Tier declares strategy-specific fields for the wrong strategy kind. *)
-  | Tier_group_empty of string
-  (** Tier-group references no tiers. *)
   | Duplicate_route of string
   (** Two routes with the same name. *)
   | Internal of string

--- a/lib/cascade/cascade_internal_error.ml
+++ b/lib/cascade/cascade_internal_error.ml
@@ -20,19 +20,19 @@ type provider_rejection = {
 type capacity_backpressure_source =
   | Provider_capacity
   | Client_capacity
-  | Admission_capacity
+  | Tier_admission
   | Cascade_slot
 
 let capacity_backpressure_source_to_string = function
   | Provider_capacity -> "provider_capacity"
   | Client_capacity -> "client_capacity"
-  | Admission_capacity -> "admission_capacity"
+  | Tier_admission -> "tier_admission"
   | Cascade_slot -> "cascade_slot"
 
 let capacity_backpressure_source_of_string = function
   | "provider_capacity" -> Some Provider_capacity
   | "client_capacity" -> Some Client_capacity
-  | "admission_capacity" -> Some Admission_capacity
+  | "tier_admission" -> Some Tier_admission
   | "cascade_slot" -> Some Cascade_slot
   | _ -> None
 

--- a/lib/cascade/cascade_oas_runner.ml
+++ b/lib/cascade/cascade_oas_runner.ml
@@ -148,7 +148,7 @@ let cli_tool_a_cannot_carry_keeper_bound_runtime_mcp
 
    Order of preference (mirrors the filter's short-circuit):
    0. [Capability_profile_mismatch profile] — the provider's declared
-      capabilities do not satisfy the profile's
+      capabilities do not satisfy the tier-group's
       [required_capability_profile] (e.g. [tool_strict] requiring
       [runtime_mcp_tools], [runtime_tool_events], [runtime_mcp_http_headers]).
    1. [Codex_keeper_bound_actor_required] — cli_tool_a cannot carry a

--- a/lib/cascade/cascade_phonebook_parser.ml
+++ b/lib/cascade/cascade_phonebook_parser.ml
@@ -1,0 +1,319 @@
+(** Phonebook TOML parser — reads the simplified phonebook TOML schema.
+
+    Parses providers, models, and tier-groups ONLY. No routes, tiers,
+    bindings, or aliases. All routing logic is in {!Cascade_routing_policy}.
+
+    Uses [Otoml] (same as existing {!Cascade_declarative_parser}) for
+    TOML parsing. Hot-reload is handled by {!Cascade_config_loader}.
+
+    Convention: [Otoml.find_opt tbl Fun.id path] returns a raw [Otoml.t]
+    for sub-tables. Typed getters like [Otoml.find_opt tbl Otoml.get_string]
+    return the extracted value directly. *)
+
+open Cascade_phonebook_types
+
+type parse_error =
+  { path : string
+  ; message : string
+  }
+[@@deriving show]
+
+let error path message = [ { path; message } ]
+
+let ( let* ) x f = Result.bind x f
+
+let partition_results
+    (results : ('a, parse_error list) result list)
+    : ('a list, parse_error list) result =
+  let oks, errs =
+    List.partition_map
+      (function
+        | Ok x -> Either.Left x
+        | Error e -> Either.Right e)
+      results
+  in
+  if errs <> [] then Error (List.concat errs) else Ok oks
+
+(* ── Thinking Control Format ─────────────────────────────────── *)
+
+let thinking_format_of_string (s : string)
+    : (cascade_thinking_control_format, string) result =
+  match s with
+  | "no_thinking_control" | "none" -> Ok No_thinking_control
+  | "thinking_object" -> Ok Thinking_object
+  | "reasoning_effort" -> Ok Reasoning_effort
+  | "reasoning_param" -> Ok Reasoning_param
+  | "chat_template_kwargs" -> Ok Chat_template_kwargs
+  | "reasoning_content" -> Ok Reasoning_content
+  | _ ->
+    Error
+      (Printf.sprintf
+         "unknown thinking_control_format %S: expected one of \
+          none, thinking_object, reasoning_effort, reasoning_param, \
+          chat_template_kwargs, reasoning_content"
+         s)
+
+(* ── Defaults ────────────────────────────────────────────────── *)
+
+let parse_defaults (tbl : Otoml.t) : (cascade_phonebook_defaults, parse_error list) result =
+  let max_output =
+    Otoml.find_or ~default:4096 tbl Otoml.get_integer [ "max_output_tokens" ]
+  in
+  let thinking_budget =
+    Otoml.find_or ~default:8192 tbl Otoml.get_integer [ "default_thinking_budget" ]
+  in
+  Ok { max_output_tokens = max_output; default_thinking_budget = thinking_budget }
+
+(* ── Provider ────────────────────────────────────────────────── *)
+
+let parse_provider (id : string) (tbl : Otoml.t)
+    : (cascade_phonebook_provider, parse_error list) result =
+  let path = Printf.sprintf "providers.%s" id in
+  let* endpoint =
+    match Otoml.find_opt tbl Otoml.get_string [ "endpoint" ] with
+    | Some e -> Ok e
+    | None -> Error (error (path ^ ".endpoint") "required field missing")
+  in
+  let protocol_str =
+    Otoml.find_or ~default:"provider_d-http" tbl Otoml.get_string [ "protocol" ]
+  in
+  let flavor_str =
+    Otoml.find_or ~default:"provider_d" tbl Otoml.get_string [ "flavor" ]
+  in
+  let auth_env = Otoml.find_opt tbl Otoml.get_string [ "auth_env" ] in
+  let note = Otoml.find_opt tbl Otoml.get_string [ "note" ] in
+  (try
+     let protocol = protocol_of_string protocol_str in
+     let flavor = flavor_of_string flavor_str in
+     Ok { id; endpoint; protocol; flavor; auth_env; note }
+   with Failure msg ->
+     Error (error path msg))
+
+(* ── Model Capabilities ──────────────────────────────────────── *)
+
+let parse_model_capabilities (tbl : Otoml.t) (path : string)
+    : (phonebook_model_capabilities, parse_error list) result =
+  let int_opt key = Otoml.find_opt tbl Otoml.get_integer [ key ] in
+  let bool_field key = Otoml.find_or ~default:false tbl Otoml.get_boolean [ key ] in
+  let thinking_str =
+    Otoml.find_or ~default:"none" tbl Otoml.get_string [ "thinking_control_format" ]
+  in
+  let* thinking_format =
+    match thinking_format_of_string thinking_str with
+    | Ok f -> Ok f
+    | Error msg -> Error (error (path ^ ".thinking_control_format") msg)
+  in
+  Ok
+    { max_output_tokens = int_opt "max_output_tokens"
+    ; supports_tool_choice = bool_field "supports_tool_choice"
+    ; supports_extended_thinking = bool_field "supports_extended_thinking"
+    ; supports_reasoning_budget = bool_field "supports_reasoning_budget"
+    ; thinking_control_format = thinking_format
+    ; supports_image_input = bool_field "supports_image_input"
+    ; supports_structured_output = bool_field "supports_structured_output"
+    ; supports_native_streaming = bool_field "supports_native_streaming"
+    }
+
+(* ── Model ───────────────────────────────────────────────────── *)
+
+let parse_model (id : string) (tbl : Otoml.t)
+    : (cascade_phonebook_model, parse_error list) result =
+  let path = Printf.sprintf "models.%s" id in
+  let* provider =
+    match Otoml.find_opt tbl Otoml.get_string [ "provider" ] with
+    | Some p -> Ok p
+    | None -> Error (error (path ^ ".provider") "required field missing")
+  in
+  let* model_id =
+    match Otoml.find_opt tbl Otoml.get_string [ "model_id" ] with
+    | Some m -> Ok m
+    | None -> Error (error (path ^ ".model_id") "required field missing")
+  in
+  let note = Otoml.find_opt tbl Otoml.get_string [ "note" ] in
+  let capabilities =
+    match Otoml.find_opt tbl Fun.id [ "capabilities" ] with
+    | Some cap_tbl ->
+      (match parse_model_capabilities cap_tbl (path ^ ".capabilities") with
+       | Ok caps -> Ok caps
+       | Error errs -> Error errs)
+    | None -> Ok phonebook_model_capabilities_default
+  in
+  let* capabilities = capabilities in
+  Ok { id; provider; model_id; capabilities; note }
+
+(* ── Tier-Group ──────────────────────────────────────────────── *)
+
+let parse_diversity_constraint (s : string) : (diversity_constraint, string) result =
+  match s with
+  | "diverse_from_primary" -> Ok Diverse_from_primary
+  | "same_provider" -> Ok Same_provider
+  | "any_available" -> Ok Any_available
+  | _ ->
+    Error
+      (Printf.sprintf
+         "unknown diversity constraint %S: expected one of \
+          diverse_from_primary, same_provider, any_available"
+         s)
+
+let parse_tier_group (name : string) (tbl : Otoml.t)
+    : (cascade_phonebook_tier_group, parse_error list) result =
+  let path = Printf.sprintf "tier-groups.%s" name in
+  let* members =
+    match Otoml.find_opt tbl (Otoml.get_array Otoml.get_string) [ "members" ] with
+    | Some m -> Ok m
+    | None -> Error (error (path ^ ".members") "required field missing")
+  in
+  let weight = Otoml.find_or ~default:100 tbl Otoml.get_integer [ "weight" ] in
+  let constraint_result =
+    match Otoml.find_opt tbl Otoml.get_string [ "constraint" ] with
+    | Some s ->
+      (match parse_diversity_constraint s with
+       | Ok c -> Ok (Some c)
+       | Error msg -> Error [ { path = path ^ ".constraint"; message = msg } ])
+    | None -> Ok None
+  in
+  let* constraint_ = constraint_result in
+  let note = Otoml.find_opt tbl Otoml.get_string [ "note" ] in
+  Ok { name; members; weight; constraint_; note }
+
+(* ── Table key extraction ────────────────────────────────────── *)
+
+let table_keys_of (tbl : Otoml.t) : string list =
+  match Otoml.get_table tbl with
+  | exception Otoml.Type_error _ -> []
+  | entries -> List.map fst entries
+
+(* ── Top-level parser ────────────────────────────────────────── *)
+
+(** Parse a phonebook TOML document into typed [cascade_phonebook].
+
+    Top-level TOML structure:
+    {v
+    [defaults]
+    max_output_tokens = 4096
+    default_thinking_budget = 8192
+
+    [providers.runpod-llama]
+    endpoint = "..."
+    protocol = "provider_d-http"
+    flavor = "llama-cpp"
+    auth_env = "RUNPOD_API_TOKEN"
+
+    [models.qwen3-235b]
+    provider = "runpod-llama"
+    model_id = "qwen3-235b-a22b"
+    capabilities = { ... }
+
+    [tier-groups.primary]
+    members = ["qwen3-235b"]
+    weight = 100
+    v} *)
+let parse_phonebook (toml : Otoml.t)
+    : (cascade_phonebook, parse_error list) result =
+  (* Defaults *)
+  let defaults_result =
+    match Otoml.find_opt toml Fun.id [ "defaults" ] with
+    | Some defaults_tbl -> parse_defaults defaults_tbl
+    | None ->
+      Ok { max_output_tokens = 4096; default_thinking_budget = 8192 }
+  in
+  (* Providers *)
+  let providers_result =
+    match Otoml.find_opt toml Fun.id [ "providers" ] with
+    | Some providers_tbl ->
+      let provider_ids = table_keys_of providers_tbl in
+      let results =
+        List.filter_map
+          (fun id ->
+             match Otoml.find_opt providers_tbl Fun.id [ id ] with
+             | Some tbl -> Some (parse_provider id tbl)
+             | None -> None)
+          provider_ids
+      in
+      partition_results results
+    | None -> Ok []
+  in
+  (* Models *)
+  let models_result =
+    match Otoml.find_opt toml Fun.id [ "models" ] with
+    | Some models_tbl ->
+      let model_ids = table_keys_of models_tbl in
+      let results =
+        List.filter_map
+          (fun id ->
+             match Otoml.find_opt models_tbl Fun.id [ id ] with
+             | Some tbl -> Some (parse_model id tbl)
+             | None -> None)
+          model_ids
+      in
+      partition_results results
+    | None -> Ok []
+  in
+  (* Tier-groups *)
+  let tier_groups_result =
+    match Otoml.find_opt toml Fun.id [ "tier-groups" ] with
+    | Some tg_tbl ->
+      let tg_names = table_keys_of tg_tbl in
+      let results =
+        List.filter_map
+          (fun name ->
+             match Otoml.find_opt tg_tbl Fun.id [ name ] with
+             | Some tbl -> Some (parse_tier_group name tbl)
+             | None -> None)
+          tg_names
+      in
+      partition_results results
+    | None -> Ok []
+  in
+  (* Combine with cross-reference validation *)
+  match defaults_result, providers_result, models_result, tier_groups_result with
+  | Ok defaults, Ok providers, Ok models, Ok tier_groups ->
+    let provider_ids =
+      List.map (fun (p : cascade_phonebook_provider) -> p.id) providers
+    in
+    let model_ids =
+      List.map (fun (m : cascade_phonebook_model) -> m.id) models
+    in
+    let provider_ref_errors =
+      List.filter_map
+        (fun (m : cascade_phonebook_model) ->
+           if List.mem m.provider provider_ids then None
+           else
+             Some
+               { path = Printf.sprintf "models.%s.provider" m.id
+               ; message =
+                 Printf.sprintf
+                   "references undefined provider %S (available: %s)"
+                   m.provider (String.concat ", " provider_ids)
+               })
+        models
+    in
+    let member_ref_errors =
+      List.concat_map
+        (fun (tg : cascade_phonebook_tier_group) ->
+           List.filter_map
+             (fun mid ->
+                if List.mem mid model_ids then None
+                else
+                  Some
+                    { path =
+                      Printf.sprintf "tier-groups.%s.members" tg.name
+                    ; message =
+                      Printf.sprintf
+                        "references undefined model %S (available: %s)"
+                        mid (String.concat ", " model_ids)
+                    })
+             tg.members)
+        tier_groups
+    in
+    let cross_errors = provider_ref_errors @ member_ref_errors in
+    if cross_errors = [] then Ok { defaults; providers; models; tier_groups }
+    else Error cross_errors
+  | _ ->
+    let all_errors =
+      (match defaults_result with Error e -> e | _ -> [])
+      @ (match providers_result with Error e -> e | _ -> [])
+      @ (match models_result with Error e -> e | _ -> [])
+      @ (match tier_groups_result with Error e -> e | _ -> [])
+    in
+    Error all_errors

--- a/lib/cascade/cascade_phonebook_parser.mli
+++ b/lib/cascade/cascade_phonebook_parser.mli
@@ -1,0 +1,8 @@
+(** Phonebook TOML parser — public interface. *)
+
+type parse_error = { path : string; message : string }
+[@@deriving show]
+
+val parse_phonebook :
+  Otoml.t -> (Cascade_phonebook_types.cascade_phonebook, parse_error list) result
+(** Parse a phonebook TOML document into typed phonebook config. *)

--- a/lib/cascade/cascade_phonebook_resolve.ml
+++ b/lib/cascade/cascade_phonebook_resolve.ml
@@ -1,0 +1,98 @@
+(** Phonebook Resolve — bridge from phonebook types to OAS runtime.
+
+    Converts phonebook providers/models into [Llm_provider.Provider_config.t]
+    so the existing transport layer can execute requests.
+
+    This is the Phase 4 integration point: phonebook has typed data
+    (endpoint, flavor, auth_env), OAS transport needs [Provider_config.t].
+    No registry lookup — phonebook IS the registry. *)
+
+open Cascade_phonebook_types
+
+(* ── Provider_config construction ──────────────────────────────── *)
+
+let provider_kind_of_flavor = function
+  | Llama_cpp -> Llm_provider.Provider_config.Provider_d_compat
+  | Ollama -> Llm_provider.Provider_config.Ollama
+  | Vllm -> Llm_provider.Provider_config.Provider_d_compat
+  | Provider_d_wire -> Llm_provider.Provider_config.Provider_d_compat
+  | Provider_g_wire -> Llm_provider.Provider_config.Provider_d_compat
+  | Provider_k_zai -> Llm_provider.Provider_config.Provider_k
+  | Provider_h_wire -> Llm_provider.Provider_config.Provider_h
+
+let api_key_of_auth_env (auth_env : string option) : string =
+  match auth_env with
+  | None -> ""
+  | Some env ->
+    (match Sys.getenv_opt env with
+     | Some v when v <> "" -> v
+     | _ -> "")
+
+let request_path_of_flavor (base_url : string) (flavor : cascade_server_flavor) : string =
+  match flavor with
+  | Ollama -> "/api/chat"
+  | _ -> Masc_network_defaults.chat_completions_path
+
+let provider_config_of_phonebook
+    ?(temperature = Llm_provider.Constants.Inference.default_temperature)
+    ?max_tokens
+    (pb : cascade_phonebook)
+    (model : cascade_phonebook_model)
+  : Llm_provider.Provider_config.t option =
+  match provider_of_model pb model with
+  | None -> None
+  | Some p ->
+    let kind = provider_kind_of_flavor p.flavor in
+    let base_url = p.endpoint in
+    let request_path = request_path_of_flavor base_url p.flavor in
+    let api_key = api_key_of_auth_env p.auth_env in
+    let max_output =
+      match model.capabilities.max_output_tokens with
+      | Some n -> n
+      | None -> pb.defaults.max_output_tokens
+    in
+    Some
+      (Llm_provider.Provider_config.make
+         ~kind
+         ~model_id:model.model_id
+         ~base_url
+         ~request_path
+         ~api_key
+         ~temperature
+         ~max_tokens:(Option.value max_tokens ~default:max_output)
+         ())
+
+(* ── Model string generation ──────────────────────────────────── *)
+
+let model_string_of_phonebook_model (model : cascade_phonebook_model) : string =
+  model.provider ^ ":" ^ model.model_id
+
+(* ── Tier-group resolution ─────────────────────────────────────── *)
+
+let resolve_provider_configs_for_task
+    ?temperature
+    ?max_tokens
+    (pb : cascade_phonebook)
+    (task : Cascade_routing_policy.task_use)
+  : Llm_provider.Provider_config.t list =
+  let models =
+    Cascade_routing_policy.resolve_models_for_task
+      pb
+      Cascade_routing_policy.default_routing_policies
+      task
+  in
+  List.filter_map
+    (provider_config_of_phonebook ?temperature ?max_tokens pb)
+    models
+
+let resolve_model_strings_for_task
+    (pb : cascade_phonebook)
+    (task : Cascade_routing_policy.task_use)
+  : string list =
+  let models =
+    Cascade_routing_policy.resolve_models_for_task
+      pb
+      Cascade_routing_policy.default_routing_policies
+      task
+  in
+  List.map model_string_of_phonebook_model models

--- a/lib/cascade/cascade_phonebook_resolve.mli
+++ b/lib/cascade/cascade_phonebook_resolve.mli
@@ -1,0 +1,32 @@
+(** Phonebook Resolve — public interface.
+
+    Bridge from phonebook typed data to [Llm_provider.Provider_config.t]
+    for the existing OAS transport layer. *)
+
+(** Construct a [Provider_config.t] from a phonebook model.
+    Returns [None] when the model's provider is missing from the phonebook. *)
+val provider_config_of_phonebook :
+  ?temperature:float ->
+  ?max_tokens:int ->
+  Cascade_phonebook_types.cascade_phonebook ->
+  Cascade_phonebook_types.cascade_phonebook_model ->
+  Llm_provider.Provider_config.t option
+
+(** Generate a "provider:model_id" string from a phonebook model. *)
+val model_string_of_phonebook_model :
+  Cascade_phonebook_types.cascade_phonebook_model -> string
+
+(** Resolve all models for a task to [Provider_config.t] list.
+    Filters out models whose providers lack required API keys. *)
+val resolve_provider_configs_for_task :
+  ?temperature:float ->
+  ?max_tokens:int ->
+  Cascade_phonebook_types.cascade_phonebook ->
+  Cascade_routing_policy.task_use ->
+  Llm_provider.Provider_config.t list
+
+(** Resolve all models for a task to "provider:model_id" string list. *)
+val resolve_model_strings_for_task :
+  Cascade_phonebook_types.cascade_phonebook ->
+  Cascade_routing_policy.task_use ->
+  string list

--- a/lib/cascade/cascade_phonebook_types.ml
+++ b/lib/cascade/cascade_phonebook_types.ml
@@ -1,0 +1,199 @@
+(** Phonebook types for the Cascade Phonebook/Switchboard RFC.
+
+    TOML = Phonebook (what exists), OAS = Switchboard (who to use).
+    This module defines ONLY the Phonebook side: providers, models,
+    tier-groups. All routing logic lives in {!Cascade_routing_policy}.
+
+    Design: ~150 lines of TOML config, zero routing intelligence. *)
+
+(* ── Flavor ──────────────────────────────────────────────────── *)
+
+(** Server flavor — determines request/response wire format.
+
+    Stored in TOML as a string hint per provider. The OAS Switchboard
+    selects the correct adapter based on this value.
+
+    Not a TOML concern: OAS code decides how to use the flavor. *)
+type cascade_server_flavor =
+  | Llama_cpp    (** llama.cpp server: chat_template_kwargs, grammar, reasoning_budget *)
+  | Ollama       (** ollama: /api/chat native, think, done_reason, arguments=JSON object *)
+  | Vllm         (** vLLM: extra_body, guided_json, guided_grammar, prefix_cached *)
+  | Provider_d_wire       (** canonical: SSE, reasoning_effort, web_search, parallel_tool_calls *)
+  | Provider_g_wire    (** DeepSeek: thinking param, reasoning_content, reasoning_effort high/max *)
+  | Provider_k_zai      (** Z.AI/GLM: reasoning_content, business errors 1301/1302/1303 *)
+  | Provider_h_wire         (** Provider_h_wire/Provider_h: OpenAI compat, tools+stream incompatible *)
+[@@deriving show, eq]
+
+let flavor_of_string = function
+  | "llama-cpp" -> Llama_cpp
+  | "ollama" -> Ollama
+  | "vllm" -> Vllm
+  | "provider_d" -> Provider_d_wire
+  | "provider_g" -> Provider_g_wire
+  | "zai-provider_k" -> Provider_k_zai
+  | "provider_h" -> Provider_h_wire
+  | s -> failwith (Printf.sprintf "Unknown server flavor: %s" s)
+
+let flavor_to_string = function
+  | Llama_cpp -> "llama-cpp"
+  | Ollama -> "ollama"
+  | Vllm -> "vllm"
+  | Provider_d_wire -> "provider_d"
+  | Provider_g_wire -> "provider_g"
+  | Provider_k_zai -> "zai-provider_k"
+  | Provider_h_wire -> "provider_h"
+
+(* ── Protocol ────────────────────────────────────────────────── *)
+
+type cascade_protocol =
+  | Openai_http     (** OpenAI-compatible HTTP (/v1/chat/completions) *)
+  | Ollama_http     (** Ollama native HTTP (/api/chat) *)
+  | Provider_a_http  (** Provider_a Messages API (/v1/messages) *)
+  | Openai_cli      (** CLI wrapper speaking OpenAI protocol *)
+[@@deriving show, eq]
+
+let protocol_of_string = function
+  | "provider_d-http" -> Openai_http
+  | "ollama-http" -> Ollama_http
+  | "provider_a-http" -> Provider_a_http
+  | "provider_d-cli" -> Openai_cli
+  | s -> failwith (Printf.sprintf "Unknown protocol: %s" s)
+
+let protocol_to_string = function
+  | Openai_http -> "provider_d-http"
+  | Ollama_http -> "ollama-http"
+  | Provider_a_http -> "provider_a-http"
+  | Openai_cli -> "provider_d-cli"
+
+(* ── Provider ────────────────────────────────────────────────── *)
+
+type cascade_phonebook_provider =
+  { id : string
+  ; endpoint : string
+  ; protocol : cascade_protocol
+  ; flavor : cascade_server_flavor
+  ; auth_env : string option
+  ; note : string option
+  }
+[@@deriving show, eq]
+
+(* ── Thinking Control Format ─────────────────────────────────── *)
+
+(** Re-export from cascade_declarative_types for backward compat.
+    The phonebook reuses the same wire-format taxonomy. *)
+type cascade_thinking_control_format =
+  | No_thinking_control
+  | Thinking_object  (** DeepSeek: {"thinking":{"type":"enabled"}} *)
+  | Reasoning_effort (** OpenAI o-series: {"reasoning_effort":"high"} *)
+  | Reasoning_param  (** DeepSeek-style reasoning_effort param *)
+  | Chat_template_kwargs (** llama.cpp: {"chat_template_kwargs":{"enable_thinking":bool}} *)
+  | Reasoning_content  (** Z.AI/GLM: reasoning_content field in response *)
+[@@deriving show, eq]
+
+(* ── Model Capabilities (reused from cascade_declarative_types) ── *)
+
+(** Per-model capabilities carried in the phonebook.
+
+    Subset of the full cascade_model_capabilities that the Switchboard
+    needs for routing decisions. Extended capabilities (prompt caching,
+    multimodal, etc.) are still read from cascade_declarative_types
+    for backward compatibility during migration. *)
+type phonebook_model_capabilities =
+  { max_output_tokens : int option
+  ; supports_tool_choice : bool
+  ; supports_extended_thinking : bool
+  ; supports_reasoning_budget : bool
+  ; thinking_control_format : cascade_thinking_control_format
+  ; supports_image_input : bool
+  ; supports_structured_output : bool
+  ; supports_native_streaming : bool
+  }
+[@@deriving show, eq]
+
+let phonebook_model_capabilities_default =
+  { max_output_tokens = None
+  ; supports_tool_choice = false
+  ; supports_extended_thinking = false
+  ; supports_reasoning_budget = false
+  ; thinking_control_format = No_thinking_control
+  ; supports_image_input = false
+  ; supports_structured_output = false
+  ; supports_native_streaming = false
+  }
+[@@deriving show, eq]
+
+(* ── Model ───────────────────────────────────────────────────── *)
+
+type cascade_phonebook_model =
+  { id : string
+  ; provider : string
+  ; model_id : string
+  ; capabilities : phonebook_model_capabilities
+  ; note : string option
+  }
+[@@deriving show, eq]
+
+(* ── Diversity Constraint ────────────────────────────────────── *)
+
+(** Constraint for selecting models from non-primary tier-groups.
+    The Switchboard enforces these when resolving task routing. *)
+type diversity_constraint =
+  | Diverse_from_primary  (** Must use different provider than primary *)
+  | Same_provider         (** Must use same provider (internal fallback) *)
+  | Any_available         (** No constraint *)
+[@@deriving show, eq]
+
+(* ── Tier-Group ──────────────────────────────────────────────── *)
+
+(** Sole routing unit. OAS selects tier-groups per task_use.
+    No model-level or provider-level selection in the phonebook. *)
+type cascade_phonebook_tier_group =
+  { name : string
+  ; members : string list  (** Model IDs from [models.*] *)
+  ; weight : int
+  ; constraint_ : diversity_constraint option
+  ; note : string option
+  }
+[@@deriving show, eq]
+
+(* ── Phonebook Config (top-level) ────────────────────────────── *)
+
+type cascade_phonebook_defaults =
+  { max_output_tokens : int
+  ; default_thinking_budget : int
+  }
+[@@deriving show, eq]
+
+(** Phonebook — what providers/models exist. No routing logic. *)
+type cascade_phonebook =
+  { defaults : cascade_phonebook_defaults
+  ; providers : cascade_phonebook_provider list
+  ; models : cascade_phonebook_model list
+  ; tier_groups : cascade_phonebook_tier_group list
+  }
+[@@deriving show, eq]
+
+(* ── Lookup helpers ──────────────────────────────────────────── *)
+
+let provider_of_id (pb : cascade_phonebook) (id : string) :
+    cascade_phonebook_provider option =
+  List.find_opt (fun (p : cascade_phonebook_provider) -> p.id = id) pb.providers
+
+let model_of_id (pb : cascade_phonebook) (id : string) :
+    cascade_phonebook_model option =
+  List.find_opt (fun (m : cascade_phonebook_model) -> m.id = id) pb.models
+
+let tier_group_of_name (pb : cascade_phonebook) (name : string) :
+    cascade_phonebook_tier_group option =
+  List.find_opt (fun (tg : cascade_phonebook_tier_group) -> tg.name = name)
+    pb.tier_groups
+
+let models_of_tier_group (pb : cascade_phonebook) (tg : cascade_phonebook_tier_group) :
+    cascade_phonebook_model list =
+  List.filter_map
+    (fun mid -> model_of_id pb mid)
+    tg.members
+
+let provider_of_model (pb : cascade_phonebook) (m : cascade_phonebook_model) :
+    cascade_phonebook_provider option =
+  provider_of_id pb m.provider

--- a/lib/cascade/cascade_phonebook_types.mli
+++ b/lib/cascade/cascade_phonebook_types.mli
@@ -1,0 +1,92 @@
+(** Phonebook types — public interface. *)
+
+type cascade_server_flavor =
+  | Llama_cpp | Ollama | Vllm | Provider_d_wire | Provider_g_wire | Provider_k_zai | Provider_h_wire
+[@@deriving show, eq]
+
+val flavor_of_string : string -> cascade_server_flavor
+val flavor_to_string : cascade_server_flavor -> string
+
+type cascade_protocol =
+  | Openai_http | Ollama_http | Provider_a_http | Openai_cli
+[@@deriving show, eq]
+
+val protocol_of_string : string -> cascade_protocol
+val protocol_to_string : cascade_protocol -> string
+
+type cascade_phonebook_provider = {
+  id : string;
+  endpoint : string;
+  protocol : cascade_protocol;
+  flavor : cascade_server_flavor;
+  auth_env : string option;
+  note : string option;
+}
+[@@deriving show, eq]
+
+type cascade_thinking_control_format =
+  | No_thinking_control
+  | Thinking_object
+  | Reasoning_effort
+  | Reasoning_param
+  | Chat_template_kwargs
+  | Reasoning_content
+[@@deriving show, eq]
+
+type phonebook_model_capabilities = {
+  max_output_tokens : int option;
+  supports_tool_choice : bool;
+  supports_extended_thinking : bool;
+  supports_reasoning_budget : bool;
+  thinking_control_format : cascade_thinking_control_format;
+  supports_image_input : bool;
+  supports_structured_output : bool;
+  supports_native_streaming : bool;
+}
+[@@deriving show, eq]
+
+val phonebook_model_capabilities_default : phonebook_model_capabilities
+
+type cascade_phonebook_model = {
+  id : string;
+  provider : string;
+  model_id : string;
+  capabilities : phonebook_model_capabilities;
+  note : string option;
+}
+[@@deriving show, eq]
+
+type diversity_constraint =
+  | Diverse_from_primary | Same_provider | Any_available
+[@@deriving show, eq]
+
+type cascade_phonebook_tier_group = {
+  name : string;
+  members : string list;
+  weight : int;
+  constraint_ : diversity_constraint option;
+  note : string option;
+}
+[@@deriving show, eq]
+
+type cascade_phonebook_defaults = {
+  max_output_tokens : int;
+  default_thinking_budget : int;
+}
+[@@deriving show, eq]
+
+type cascade_phonebook = {
+  defaults : cascade_phonebook_defaults;
+  providers : cascade_phonebook_provider list;
+  models : cascade_phonebook_model list;
+  tier_groups : cascade_phonebook_tier_group list;
+}
+[@@deriving show, eq]
+
+val provider_of_id : cascade_phonebook -> string -> cascade_phonebook_provider option
+val model_of_id : cascade_phonebook -> string -> cascade_phonebook_model option
+val tier_group_of_name : cascade_phonebook -> string -> cascade_phonebook_tier_group option
+val models_of_tier_group :
+  cascade_phonebook -> cascade_phonebook_tier_group -> cascade_phonebook_model list
+val provider_of_model :
+  cascade_phonebook -> cascade_phonebook_model -> cascade_phonebook_provider option

--- a/lib/cascade/cascade_preflight_state.ml
+++ b/lib/cascade/cascade_preflight_state.ml
@@ -9,7 +9,7 @@ type reason =
   | Rate_limited_long_window
 
 type fingerprint = {
-  cascade_name : string;
+  tier_group : string;
   provider : string;
   reason : reason;
 }
@@ -50,18 +50,18 @@ let metric_provider_re_enabled = "masc_cascade_provider_re_enabled_total"
 (* ── State ──────────────────────────────────────────────────────── *)
 
 (* [Hashtbl] keyed by an opaque triple to avoid string interpolation
-   collisions when cascade_name or provider contain separators. *)
+   collisions when tier_group or provider contain separators. *)
 module Key = struct
   type t = fingerprint
 
   let equal (a : t) (b : t) =
-    String.equal a.cascade_name b.cascade_name
+    String.equal a.tier_group b.tier_group
     && String.equal a.provider b.provider
     && a.reason = b.reason
   ;;
 
   let hash (k : t) =
-    Hashtbl.hash (k.cascade_name, k.provider, reason_slug k.reason)
+    Hashtbl.hash (k.tier_group, k.provider, reason_slug k.reason)
   ;;
 end
 
@@ -79,7 +79,7 @@ end)
 type t = {
   counts : int FpTbl.t;
   disabled : (float * string) StrTbl.t;
-      (** Maps provider → (disabled_at_timestamp, cascade_name).
+      (** Maps provider → (disabled_at_timestamp, tier_group).
           The timestamp enables TTL-based auto-expiry so providers
           don't stay disabled forever (GitHub #18502). *)
   mu : Stdlib.Mutex.t;
@@ -107,14 +107,14 @@ let with_lock t f =
 
 (* ── Public API ─────────────────────────────────────────────────── *)
 
-let record ?(clock = Time_compat.now) t ~cascade_name ~provider ~reason : record_outcome =
-  let fp = { cascade_name; provider; reason } in
+let record ?(clock = Time_compat.now) t ~tier_group ~provider ~reason : record_outcome =
+  let fp = { tier_group; provider; reason } in
   with_lock t (fun () ->
     (* Always tick the per-call counter so dashboards see absolute
        skip volume (independent of disable transitions). *)
     Prometheus.inc_counter metric_preflight_unhealthy_skip
       ~labels:
-        [ ("cascade", cascade_name)
+        [ ("cascade", tier_group)
         ; ("provider", provider)
         ; ("reason", reason_slug reason)
         ]
@@ -129,10 +129,10 @@ let record ?(clock = Time_compat.now) t ~cascade_name ~provider ~reason : record
       then `First
       else if next >= t.threshold
       then (
-        StrTbl.replace t.disabled provider (clock (), cascade_name);
+        StrTbl.replace t.disabled provider (clock (), tier_group);
         Prometheus.inc_counter metric_provider_disabled
           ~labels:
-            [ ("cascade", cascade_name)
+            [ ("cascade", tier_group)
             ; ("provider", provider)
             ; ("reason", reason_slug reason)
             ]
@@ -145,7 +145,7 @@ let is_disabled ?(clock = Time_compat.now) t ~provider =
   with_lock t (fun () ->
     match StrTbl.find_opt t.disabled provider with
     | None -> false
-    | Some (disabled_at, _cascade_name) ->
+    | Some (disabled_at, _tier_group) ->
       let age = clock () -. disabled_at in
       if age >= disabled_ttl_seconds
       then (

--- a/lib/cascade/cascade_preflight_state.mli
+++ b/lib/cascade/cascade_preflight_state.mli
@@ -1,7 +1,7 @@
 (** Cascade preflight unhealthy-skip escalation state.
 
     Tracks repeated [preflight skipped N unhealthy ...] events per
-    (cascade_name, provider, reason) fingerprint. After [threshold_disable]
+    (tier_group, provider, reason) fingerprint. After [threshold_disable]
     consecutive skips of the same fingerprint, the provider is registered
     in an in-memory disabled list and a single ERROR-class escalation is
     emitted (instead of a WARN per skip).
@@ -46,7 +46,7 @@ type reason =
 
 (** Fingerprint of a single skip event. *)
 type fingerprint = {
-  cascade_name : string;  (** Cascade name (e.g. ["strict_tool_candidates"]). *)
+  tier_group : string;  (** Cascade name (e.g. ["strict_tool_candidates"]). *)
   provider : string;  (** Provider key or endpoint URL. *)
   reason : reason;
 }
@@ -95,7 +95,7 @@ val global : t
     transition). *)
 val record :
   ?clock:(unit -> float) ->
-  t -> cascade_name:string -> provider:string -> reason:reason -> record_outcome
+  t -> tier_group:string -> provider:string -> reason:reason -> record_outcome
 
 (** True iff the provider is currently in the disabled list (i.e. some
     fingerprint crossed threshold and recovery has not happened yet).

--- a/lib/cascade/cascade_routes.ml
+++ b/lib/cascade/cascade_routes.ml
@@ -176,6 +176,34 @@ let configured_unknown_route_keys ?config_path () =
   configured_route_keys ?config_path ()
   |> List.filter (fun key -> not (List.mem key known_route_keys))
 
+let declarative_catalog_names_from_json = function
+  | `Assoc fields ->
+      let keys_with_prefix table prefix =
+        match List.assoc_opt table fields with
+        | Some (`Assoc entries) ->
+            List.map (fun (name, _) -> prefix ^ name) entries
+        | _ -> []
+      in
+      keys_with_prefix "tier-group" "tier-group."
+      @ keys_with_prefix "tier" "tier."
+      |> List.sort_uniq String.compare
+  | _ -> []
+
+let declarative_catalog_names ?config_path () =
+  let path_opt =
+    match config_path with
+    | Some path -> Some path
+    | None -> Config_dir_resolver.cascade_path_opt ()
+  in
+  match path_opt with
+  | None -> []
+  | Some path -> (
+      match Cascade_config_loader.load_catalog_source path with
+      | Ok json -> declarative_catalog_names_from_json json
+      | Error _ -> [])
+
+let live_catalog_names ?config_path () =
+  declarative_catalog_names ?config_path ()
 
 let fallback_name_for_catalog use ~catalog =
   match catalog with
@@ -207,6 +235,81 @@ let warn_unvalidated_route_target_once ~route_key ~target ~fallback =
       route_key target fallback
   end
 
+(* ── Phonebook-based routing (RFC Cascade-Phonebook Phase 4) ───── *)
+
+let task_use_of_logical_use = function
+  | Keeper_turn | Phase_recovery | Phase_buffer | Openai_compat
+  | Persona_generation ->
+      Cascade_routing_policy.Code_generation
+  | Tool_required | Tool_rerank_use -> Cascade_routing_policy.Tool_execution
+  | Governance_judge | Operator_judge | Cross_verifier | Verifier
+  | Adversarial_reviewer ->
+      Cascade_routing_policy.Code_review
+  | Auto_responder | Routing | Provider_benchmark | Simple_task
+  | Moderate_task ->
+      Cascade_routing_policy.Quick_decision
+  | Complex_task -> Cascade_routing_policy.Long_reasoning
+
+(** Resolve a logical_use to model strings via the phonebook.
+
+    Maps canonical route use → [task_use] → tier-group → model strings.
+    Returns [None] when the phonebook is unavailable. *)
+let cascade_models_for_use_via_phonebook
+    ?config_path
+    (use : logical_use)
+  : string list option =
+  let task = task_use_of_logical_use use in
+    let phonebook =
+      match config_path with
+      | Some path ->
+        (match Cascade_config_loader.load_phonebook path with
+         | Ok pb -> Some pb
+         | Error _ -> None)
+      | None ->
+        (match Cascade_config_loader.load_phonebook_from_config () with
+         | Some (Ok pb) -> Some pb
+         | _ -> None)
+    in
+    match phonebook with
+    | None -> None
+    | Some pb ->
+      let models =
+        Cascade_phonebook_resolve.resolve_model_strings_for_task pb task
+      in
+      if models = [] then None else Some models
+
+(** Resolve a logical_use to Provider_config.t list via the phonebook.
+
+    Full phonebook path: route use → task_use → tier-group → models →
+    providers → endpoint/auth → Provider_config.t.
+    Returns [None] when phonebook is unavailable or no models resolve. *)
+let cascade_provider_configs_for_use_via_phonebook
+    ?config_path
+    ?temperature
+    ?max_tokens
+    (use : logical_use)
+  : Llm_provider.Provider_config.t list option =
+  let task = task_use_of_logical_use use in
+    let phonebook =
+      match config_path with
+      | Some path ->
+        (match Cascade_config_loader.load_phonebook path with
+         | Ok pb -> Some pb
+         | Error _ -> None)
+      | None ->
+        (match Cascade_config_loader.load_phonebook_from_config () with
+         | Some (Ok pb) -> Some pb
+         | _ -> None)
+    in
+    match phonebook with
+    | None -> None
+    | Some pb ->
+      let configs =
+        Cascade_phonebook_resolve.resolve_provider_configs_for_task
+          ?temperature ?max_tokens pb task
+      in
+      if configs = [] then None else Some configs
+
 let cascade_name_for_use ?config_path use =
   let route_key = logical_use_key use in
   let route_target =
@@ -214,11 +317,7 @@ let cascade_name_for_use ?config_path use =
     |> List.find_map (fun (key, target) ->
            if String.equal key route_key then Some target else None)
   in
-  let catalog_names =
-    match Cascade_catalog_runtime.known_profile_names () with
-    | Ok names -> names
-    | Error _ -> []
-  in
+  let catalog_names = live_catalog_names ?config_path () in
   let fallback = fallback_name_for_catalog use ~catalog:catalog_names in
   match route_target with
   | Some target when catalog_names = [] ->

--- a/lib/cascade/cascade_routes.mli
+++ b/lib/cascade/cascade_routes.mli
@@ -27,6 +27,7 @@ type logical_use = Cascade_ref.logical_use =
 
 val logical_use_key : logical_use -> string
 val logical_use_of_string_opt : string -> logical_use option
+val task_use_of_logical_use : logical_use -> Cascade_routing_policy.task_use
 
 val all_logical_uses : logical_use list
 (** Logical call-site uses known by the route registry. *)
@@ -42,7 +43,10 @@ val cascade_name_for_use : ?config_path:string -> logical_use -> string
     remains the boot-time boundary that prevents this state from being
     reached at runtime.
 
-    This returns a cascade profile name, never a provider/model string. *)
+    This returns a cascade profile name, never a provider/model string.
+    Phonebook model/provider resolution is exposed separately through
+    {!cascade_models_for_use_via_phonebook} and
+    {!cascade_provider_configs_for_use_via_phonebook}. *)
 
 val route_bindings_from_json : Yojson.Safe.t -> (string * string) list
 (** Decode the [routes] object of the in-memory cascade view into a
@@ -62,3 +66,20 @@ val fallback_name_for_catalog : logical_use -> catalog:string list -> string
 (** Catalog-only fallback used by string normalizers that already have an
     explicit active profile list.  Returns the first catalog entry, or the
     canonical [route.<key>] name when [catalog] is empty. *)
+
+val cascade_models_for_use_via_phonebook :
+  ?config_path:string -> logical_use -> string list option
+(** Resolve a logical use to model strings via the phonebook.
+    Maps canonical route use → [task_use] → tier-group → model strings.
+    Returns [None] when the phonebook is unavailable. *)
+
+val cascade_provider_configs_for_use_via_phonebook :
+  ?config_path:string ->
+  ?temperature:float ->
+  ?max_tokens:int ->
+  logical_use ->
+  Llm_provider.Provider_config.t list option
+(** Resolve a logical use to [Provider_config.t] list via the phonebook.
+    Full phonebook path: route use → task_use → tier-group → models →
+    providers → endpoint/auth → Provider_config.t.
+    Returns [None] when phonebook is unavailable or no models resolve. *)

--- a/lib/cascade/cascade_routing_policy.ml
+++ b/lib/cascade/cascade_routing_policy.ml
@@ -1,0 +1,143 @@
+(** Routing Policy — the Switchboard side of Phonebook/Switchboard.
+
+    Maps 6 task_use categories to tier-groups with diversity constraints.
+    All routing intelligence lives here; the phonebook TOML is data-only.
+
+    Replaces the old 18-variant [logical_use] in {!Cascade_ref} with a
+    simplified 6-variant [task_use] that covers all keeper/supervisor
+    routing needs without over-specification. *)
+
+(* ── Task Use (6 categories) ─────────────────────────────────── *)
+
+(** The 6 routing categories for cascade task dispatch.
+
+    Every former [logical_use] variant maps into one of these.
+    Cross-verification and adversarial review are handled by diversity
+    constraints on the [Code_review] task_use, not by separate variants. *)
+type task_use =
+  | Code_generation  (* synthesis, refactoring, translation *)
+  | Code_review      (* analysis, audit, adversarial review, cross-verify *)
+  | Quick_decision   (* classification, triage, short answer *)
+  | Long_reasoning   (* planning, research synthesis, RFC drafting *)
+  | Tool_execution   (* function calling, MCP tool use, structured output *)
+  | Conversation     (* general chat, explanation, user interaction *)
+[@@deriving show, eq]
+
+let task_use_to_string = function
+  | Code_generation -> "code_generation"
+  | Code_review -> "code_review"
+  | Quick_decision -> "quick_decision"
+  | Long_reasoning -> "long_reasoning"
+  | Tool_execution -> "tool_execution"
+  | Conversation -> "conversation"
+
+let task_use_of_string = function
+  | "code_generation" -> Some Code_generation
+  | "code_review" -> Some Code_review
+  | "quick_decision" -> Some Quick_decision
+  | "long_reasoning" -> Some Long_reasoning
+  | "tool_execution" -> Some Tool_execution
+  | "conversation" -> Some Conversation
+  | _ -> None
+
+(* ── Routing Policy ──────────────────────────────────────────── *)
+
+(** Which tier-group to use for a given task, and any diversity constraint
+    when selecting from non-primary tier-groups. *)
+type task_routing_policy =
+  { task : task_use
+  ; primary_tier_group : string
+  ; diversity : Cascade_phonebook_types.diversity_constraint option
+  }
+[@@deriving show, eq]
+
+(** Default routing policies.
+
+    These encode the Switchboard's intelligence. The phonebook only
+    says which models exist; these policies say which tier-group to use.
+
+    - Code_generation → primary (largest model, best quality)
+    - Code_review → cross-verify (diverse from primary for independent review)
+    - Quick_decision → primary (fast, high quality)
+    - Long_reasoning → primary (needs deep thinking)
+    - Tool_execution → primary (needs tool support)
+    - Conversation → primary (general purpose) *)
+let default_routing_policies : task_routing_policy list =
+  [ { task = Code_generation; primary_tier_group = "primary"; diversity = None }
+  ; { task = Code_review
+    ; primary_tier_group = "cross-verify"
+    ; diversity = Some Cascade_phonebook_types.Diverse_from_primary
+    }
+  ; { task = Quick_decision; primary_tier_group = "primary"; diversity = None }
+  ; { task = Long_reasoning; primary_tier_group = "primary"; diversity = None }
+  ; { task = Tool_execution; primary_tier_group = "primary"; diversity = None }
+  ; { task = Conversation; primary_tier_group = "primary"; diversity = None }
+  ]
+
+(* ── Resolution ──────────────────────────────────────────────── *)
+
+(** Resolve a task_use to its routing policy. *)
+let policy_for_task (policies : task_routing_policy list) (task : task_use) :
+    task_routing_policy option =
+  List.find_opt (fun (p : task_routing_policy) -> p.task = task) policies
+
+(** Check that a candidate model satisfies the diversity constraint
+    relative to the primary tier-group's provider(s). *)
+let satisfies_diversity
+    (pb : Cascade_phonebook_types.cascade_phonebook)
+    (primary_tg : Cascade_phonebook_types.cascade_phonebook_tier_group)
+    (constraint_ : Cascade_phonebook_types.diversity_constraint option)
+    (candidate : Cascade_phonebook_types.cascade_phonebook_model)
+  : bool =
+  match constraint_ with
+  | None | Some Cascade_phonebook_types.Any_available -> true
+  | Some Cascade_phonebook_types.Same_provider ->
+    let primary_providers =
+      List.filter_map
+        (fun mid ->
+           Option.map
+             (fun (m : Cascade_phonebook_types.cascade_phonebook_model) -> m.provider)
+             (Cascade_phonebook_types.model_of_id pb mid))
+        primary_tg.members
+    in
+    List.mem candidate.provider primary_providers
+  | Some Cascade_phonebook_types.Diverse_from_primary ->
+    let primary_providers =
+      List.filter_map
+        (fun mid ->
+           Option.map
+             (fun (m : Cascade_phonebook_types.cascade_phonebook_model) -> m.provider)
+             (Cascade_phonebook_types.model_of_id pb mid))
+        primary_tg.members
+    in
+    not (List.mem candidate.provider primary_providers)
+
+(** Resolve a tier-group name to its member model IDs via the phonebook,
+    filtering by the policy's diversity constraint.
+
+    For [Diverse_from_primary], the primary tier-group named in the
+    [Code_generation] policy provides the provider baseline; models in
+    the target tier-group whose providers overlap are excluded. *)
+let resolve_models_for_task
+    (pb : Cascade_phonebook_types.cascade_phonebook)
+    (policies : task_routing_policy list)
+    (task : task_use)
+  : Cascade_phonebook_types.cascade_phonebook_model list =
+  match policy_for_task policies task with
+  | None -> []
+  | Some policy ->
+    match Cascade_phonebook_types.tier_group_of_name pb policy.primary_tier_group with
+    | None -> []
+    | Some tg ->
+      let models = Cascade_phonebook_types.models_of_tier_group pb tg in
+      let primary_tg =
+        (* When the target tier-group is not "primary" itself, use the
+           primary tier-group as the diversity baseline. *)
+        if policy.primary_tier_group <> "primary" then
+          Cascade_phonebook_types.tier_group_of_name pb "primary"
+        else Some tg
+      in
+      match primary_tg with
+      | None -> models
+      | Some ptg ->
+        List.filter (satisfies_diversity pb ptg policy.diversity) models

--- a/lib/cascade/cascade_routing_policy.mli
+++ b/lib/cascade/cascade_routing_policy.mli
@@ -1,0 +1,30 @@
+(** Routing Policy — public interface. *)
+
+type task_use =
+  | Code_generation | Code_review | Quick_decision
+  | Long_reasoning | Tool_execution | Conversation
+[@@deriving show, eq]
+
+val task_use_to_string : task_use -> string
+val task_use_of_string : string -> task_use option
+
+type task_routing_policy = {
+  task : task_use;
+  primary_tier_group : string;
+  diversity : Cascade_phonebook_types.diversity_constraint option;
+}
+[@@deriving show, eq]
+
+val default_routing_policies : task_routing_policy list
+val policy_for_task : task_routing_policy list -> task_use -> task_routing_policy option
+val resolve_models_for_task :
+  Cascade_phonebook_types.cascade_phonebook ->
+  task_routing_policy list ->
+  task_use ->
+  Cascade_phonebook_types.cascade_phonebook_model list
+val satisfies_diversity :
+  Cascade_phonebook_types.cascade_phonebook ->
+  Cascade_phonebook_types.cascade_phonebook_tier_group ->
+  Cascade_phonebook_types.diversity_constraint option ->
+  Cascade_phonebook_types.cascade_phonebook_model ->
+  bool

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -1,6 +1,6 @@
 type t =
   { provider_cfg : Llm_provider.Provider_config.t
-  ; admission_key : string
+  ; tier_id : string
   ; health_key : string
   ; model_health_key : string
   ; capacity_key : string
@@ -133,17 +133,15 @@ let capacity_key_of_config (cfg : Llm_provider.Provider_config.t) =
 let http_probe_url_of_config (cfg : Llm_provider.Provider_config.t) =
   Cascade_http_probe_url.of_provider_config cfg
 
-let default_admission_key_of_config provider_cfg =
+let default_tier_id_of_config provider_cfg =
   provider_health_key_of_config provider_cfg
 
-let of_provider_config ?admission_key provider_cfg =
+let of_provider_config ?tier_id provider_cfg =
   let health_key = provider_health_key_of_config provider_cfg in
   let model_health_key = provider_model_health_key_of_config provider_cfg in
-  let admission_key =
-    Option.value admission_key ~default:(default_admission_key_of_config provider_cfg)
-  in
+  let tier_id = Option.value tier_id ~default:(default_tier_id_of_config provider_cfg) in
   { provider_cfg
-  ; admission_key
+  ; tier_id
   ; health_key
   ; model_health_key
   ; capacity_key = capacity_key_of_config provider_cfg
@@ -283,7 +281,7 @@ let threshold_multipliers_of_runtime_id runtime_id =
   1.0, 1.0
 
 let health_key candidate = candidate.health_key
-let admission_key candidate = candidate.admission_key
+let tier_id candidate = candidate.tier_id
 let model_health_key candidate = candidate.model_health_key
 let provider_label candidate =
   provider_label_of_model_label

--- a/lib/cascade/cascade_runtime_candidate.mli
+++ b/lib/cascade/cascade_runtime_candidate.mli
@@ -12,7 +12,7 @@ type context_window_hint =
   ; is_local_model : bool
   }
 
-val of_provider_config : ?admission_key:string -> Llm_provider.Provider_config.t -> t
+val of_provider_config : ?tier_id:string -> Llm_provider.Provider_config.t -> t
 val of_provider_configs : Llm_provider.Provider_config.t list -> t list
 
 val runtime_url_of_label : string -> string option
@@ -44,7 +44,7 @@ val context_window_hint_of_labels : string list -> context_window_hint
 val threshold_multipliers_of_runtime_id : string -> float * float
 
 val health_key : t -> string
-val admission_key : t -> string
+val tier_id : t -> string
 val model_health_key : t -> string
 val health_keys : t -> string list
 val provider_label : t -> string

--- a/lib/cascade/cascade_saturation_signal.ml
+++ b/lib/cascade/cascade_saturation_signal.ml
@@ -20,7 +20,7 @@ type t =
       cycle_count : int;
     }
   | Inflight_capacity_full of {
-      admission_key : string;
+      tier_id : string;
       max_inflight : int;
     }
 
@@ -78,10 +78,10 @@ let to_yojson = function
           ("cascade_name", `String cascade_name);
           ("cycle_count", `Int cycle_count);
         ]
-  | Inflight_capacity_full { admission_key; max_inflight } ->
+  | Inflight_capacity_full { tier_id; max_inflight } ->
       `Assoc
         [ ("kind", `String "inflight_capacity_full");
-          ("admission_key", `String admission_key);
+          ("tier_id", `String tier_id);
           ("max_inflight", `Int max_inflight);
         ]
 
@@ -104,9 +104,9 @@ let to_log_string = function
   | All_tiers_filtered_after_cycles { cascade_name; cycle_count } ->
       Printf.sprintf "all_tiers_filtered_after_cycles cascade=%s cycles=%d"
         cascade_name cycle_count
-  | Inflight_capacity_full { admission_key; max_inflight } ->
-      Printf.sprintf "inflight_capacity_full admission_key=%s max_inflight=%d"
-        admission_key max_inflight
+  | Inflight_capacity_full { tier_id; max_inflight } ->
+      Printf.sprintf "inflight_capacity_full tier=%s max_inflight=%d"
+        tier_id max_inflight
 
 let pp ppf t = Format.fprintf ppf "%s" (to_log_string t)
 
@@ -125,9 +125,9 @@ let equal a b =
       All_tiers_filtered_after_cycles
         { cascade_name = n2; cycle_count = c2 } ) ->
       String.equal n1 n2 && Int.equal c1 c2
-  | ( Inflight_capacity_full { admission_key = a1; max_inflight = m1 },
-      Inflight_capacity_full { admission_key = a2; max_inflight = m2 } ) ->
-      String.equal a1 a2 && Int.equal m1 m2
+  | ( Inflight_capacity_full { tier_id = t1; max_inflight = m1 },
+      Inflight_capacity_full { tier_id = t2; max_inflight = m2 } ) ->
+      String.equal t1 t2 && Int.equal m1 m2
   | _, _ -> false
 
 (* Yojson deserialization — used only in tests for round-trip validation.
@@ -190,7 +190,7 @@ let of_yojson json =
                       (All_tiers_filtered_after_cycles
                          { cascade_name; cycle_count })))
         | "inflight_capacity_full" ->
-            bind (string_field "admission_key" fields) (fun admission_key ->
+            bind (string_field "tier_id" fields) (fun tier_id ->
                 bind (int_field "max_inflight" fields) (fun max_inflight ->
-                    Ok (Inflight_capacity_full { admission_key; max_inflight })))
+                    Ok (Inflight_capacity_full { tier_id; max_inflight })))
         | other -> Error (Printf.sprintf "unknown kind: %s" other)))

--- a/lib/cascade/cascade_saturation_signal.mli
+++ b/lib/cascade/cascade_saturation_signal.mli
@@ -54,11 +54,11 @@ type t =
           *Time_cap_fired 의 downstream symptom 이 아니라 독립
           신호인지* 는 caller 가 [observed_latency_ms] 와 함께 판단. *)
   | Inflight_capacity_full of {
-      admission_key : string;
+      tier_id : string;
       max_inflight : int;
     }
-      (** Phase B (cascade admission) 가 도입된 후 사용.
-          현재 cascade 의 동시 inflight 가 [max_inflight] 에 도달하여
+      (** Phase B (tier admission semaphore) 가 도입된 후 사용.
+          현재 tier 의 동시 inflight 가 [max_inflight] 에 도달하여
           새 요청을 받지 못하는 상태. Phase A.1 시점에는 이 variant
           가 emit 되지 않으나, type-level 에서 미리 자리를 잡아
           Phase B 추가 시 caller 의 match 가 자동으로 깨지도록 함. *)
@@ -70,7 +70,7 @@ val to_log_string : t -> string
     - ["provider_rate_limited provider=runpod_mtp retry_after_ms=1200"]
     - ["time_cap_fired observed_latency_ms=300100 cap_ms=300000 provider=provider_k-coding"]
     - ["all_tiers_filtered_after_cycles cascade=strict_tool_candidates cycles=3"]
-    - ["inflight_capacity_full admission_key=strict_tool_candidates max_inflight=8"]
+    - ["inflight_capacity_full tier=strict_tool_candidates max_inflight=8"]
 
     동일 형식이 Prometheus metric label 과 audit log 에 사용된다. *)
 

--- a/lib/cascade/cascade_server_flavor.ml
+++ b/lib/cascade/cascade_server_flavor.ml
@@ -4,11 +4,13 @@
     responses. The adapter system encapsulates these differences so
     the transport layer only sees a uniform interface.
 
+    Flavors are determined by the [cascade_server_flavor] in
+    {!Cascade_phonebook_types} (from TOML [providers.<id>.flavor]).
     The adapter is selected at OAS code level, not TOML level. *)
 
 (* ── Imports ─────────────────────────────────────────────────── *)
 
-type cascade_server_flavor =
+type cascade_server_flavor = Cascade_phonebook_types.cascade_server_flavor =
   | Llama_cpp
   | Ollama
   | Vllm

--- a/lib/cascade/cascade_server_flavor.mli
+++ b/lib/cascade/cascade_server_flavor.mli
@@ -1,6 +1,6 @@
 (** Server Flavor Adapter — public interface. *)
 
-type cascade_server_flavor =
+type cascade_server_flavor = Cascade_phonebook_types.cascade_server_flavor =
   | Llama_cpp | Ollama | Vllm | Provider_d_wire | Provider_g_wire | Provider_k_zai | Provider_h_wire
 
 type flavor_error =

--- a/lib/cascade/cascade_tier_admission.ml
+++ b/lib/cascade/cascade_tier_admission.ml
@@ -1,33 +1,33 @@
-(** Cascade_tier_admission — per-cascade inflight admission control.
+(** Cascade_tier_admission — per-tier inflight admission control.
 
     RFC-0153 Phase B.1. See [.mli] for the full contract.
 
-    Implementation uses [Eio.Mutex] for per-cascade counter + a single
-    structural mutex guarding the admission-key Hashtbl during lazy
-    creation. The fast path (already-known cascade) takes only the
-    cascade-local mutex.
+    Implementation uses [Eio.Mutex] for per-tier counter + a single
+    structural mutex guarding the tier-id Hashtbl during lazy tier
+    creation. The fast path (already-known tier) takes only the
+    tier-local mutex.
 
     Why not [Eio.Semaphore]? [Eio.Semaphore.acquire] blocks; this
     module is non-blocking by design (the cascade chain caller
     decides what to do on capacity_full — typically advance to the
-    next cascade, return a typed signal, or schedule a retry).
+    next tier, return a typed signal, or schedule a retry).
     Non-blocking is also why [with_admission] does not require an
     [Eio.Switch.t]: there is no asynchronous wait to cancel. *)
 
-type admission_key = string
+type tier_id = string
 
 type admission_policy =
   | Required
   | Bypass
 
-type cascade_state = {
+type tier_state = {
   mu : Eio.Mutex.t;
   mutable inflight : int;
   mutable max_inflight : int;
 }
 
 type t = {
-  cascades : (admission_key, cascade_state) Hashtbl.t;
+  tiers : (tier_id, tier_state) Hashtbl.t;
   guard_mu : Eio.Mutex.t;
   default_max_inflight : int;
 }
@@ -40,18 +40,18 @@ let default_default_max_inflight = 8
 
 let create ?(default_max_inflight = default_default_max_inflight) () =
   {
-    cascades = Hashtbl.create 8;
+    tiers = Hashtbl.create 8;
     guard_mu = Eio.Mutex.create ();
     default_max_inflight;
   }
 
-(* Lazy cascade creation: under [guard_mu] check-and-insert pattern.
-   The Hashtbl is mutated only here. After cascade_state exists in the
-   table, subsequent operations on that cascade use its own [mu]
+(* Lazy tier creation: under [guard_mu] check-and-insert pattern.
+   The Hashtbl is mutated only here. After tier_state exists in the
+   table, subsequent operations on that tier use its own [mu]
    without touching [guard_mu]. *)
-let get_or_create_cascade t admission_key =
+let get_or_create_tier t tier_id =
   Eio.Mutex.use_rw t.guard_mu ~protect:false (fun () ->
-      match Hashtbl.find_opt t.cascades admission_key with
+      match Hashtbl.find_opt t.tiers tier_id with
       | Some ts -> ts
       | None ->
           let ts =
@@ -61,16 +61,16 @@ let get_or_create_cascade t admission_key =
               max_inflight = t.default_max_inflight;
             }
           in
-          Hashtbl.add t.cascades admission_key ts;
+          Hashtbl.add t.tiers tier_id ts;
           ts)
 
-let configure t ~admission_key ~max_inflight =
-  let ts = get_or_create_cascade t admission_key in
+let configure t ~tier_id ~max_inflight =
+  let ts = get_or_create_tier t tier_id in
   Eio.Mutex.use_rw ts.mu ~protect:false (fun () ->
       ts.max_inflight <- max_inflight)
 
-let try_acquire t ~admission_key =
-  let ts = get_or_create_cascade t admission_key in
+let try_acquire t ~tier_id =
+  let ts = get_or_create_tier t tier_id in
   Eio.Mutex.use_rw ts.mu ~protect:false (fun () ->
       if ts.inflight < ts.max_inflight
       then begin
@@ -88,8 +88,8 @@ let try_acquire t ~admission_key =
             max_inflight = ts.max_inflight;
           })
 
-let release t ~admission_key =
-  match Hashtbl.find_opt t.cascades admission_key with
+let release t ~tier_id =
+  match Hashtbl.find_opt t.tiers tier_id with
   | None -> ()  (* release before any acquire — no-op *)
   | Some ts ->
       Eio.Mutex.use_rw ts.mu ~protect:false (fun () ->
@@ -98,35 +98,35 @@ let release t ~admission_key =
 (* Release that swallows its own exceptions. Used as a finally clause
    so we never mask the primary exception path. Per masc-mcp
    manifest §"finally는 예외를 내부 처리". *)
-let release_quietly t ~admission_key =
-  try release t ~admission_key with _ -> ()
+let release_quietly t ~tier_id =
+  try release t ~tier_id with _ -> ()
 
-let with_admission t ~admission_key ~admission_policy f =
+let with_admission t ~tier_id ~admission_policy f =
   match admission_policy with
   | Bypass -> Ok (f ())
   | Required ->
-      (match try_acquire t ~admission_key with
+      (match try_acquire t ~tier_id with
        | Capacity_full { inflight_at_check = _; max_inflight } ->
            Error
              (Cascade_saturation_signal.Inflight_capacity_full
-                { admission_key; max_inflight })
+                { tier_id; max_inflight })
        | Granted _ ->
            (match f () with
             | v ->
-                release_quietly t ~admission_key;
+                release_quietly t ~tier_id;
                 Ok v
             | exception exn ->
-                release_quietly t ~admission_key;
+                release_quietly t ~tier_id;
                 raise exn))
 
-let current_inflight t ~admission_key =
-  match Hashtbl.find_opt t.cascades admission_key with
+let current_inflight t ~tier_id =
+  match Hashtbl.find_opt t.tiers tier_id with
   | None -> 0
   | Some ts ->
       Eio.Mutex.use_ro ts.mu (fun () -> ts.inflight)
 
-let configured_max t ~admission_key =
-  match Hashtbl.find_opt t.cascades admission_key with
+let configured_max t ~tier_id =
+  match Hashtbl.find_opt t.tiers tier_id with
   | None -> t.default_max_inflight
   | Some ts ->
       Eio.Mutex.use_ro ts.mu (fun () -> ts.max_inflight)

--- a/lib/cascade/cascade_tier_admission.mli
+++ b/lib/cascade/cascade_tier_admission.mli
@@ -1,10 +1,10 @@
-(** Cascade_tier_admission — per-cascade inflight admission control.
+(** Cascade_tier_admission — per-tier inflight admission control.
 
-    RFC-0153 Phase B.1. Provides a per-cascade non-blocking
+    RFC-0153 Phase B.1. Provides a per-[tier_id] non-blocking
     admission counter that caps how many concurrent cascade attempts
-    can occupy a cascade at once. Designed to be the consumer of
+    can occupy a tier at once. Designed to be the consumer of
     {!Cascade_saturation_signal} emissions from Phase A.2: when a
-    cascade saturates, this module rejects new admissions with a typed
+    tier saturates, this module rejects new admissions with a typed
     signal instead of letting N keepers stampede the same provider.
 
     Phase B.1 is the module + tests only. Phase B.2 wires it into
@@ -20,7 +20,7 @@
     External validation:
     - Rust [tower::limit::ConcurrencyLimit] uses the same per-target
       semaphore pattern in production.
-    - OpenClaw and Hermes do not have a cascade-level admission concept
+    - OpenClaw and Hermes do not have a tier-level admission concept
       (single-session model). MASC's multi-keeper concurrency is
       novel territory; see RFC-0153 §6.7 + §6.8.
 
@@ -28,9 +28,9 @@
 
 (** {1 Types} *)
 
-type admission_key = string
-(** Stable identifier for a cascade admission key (e.g. ["strict_tool_candidates"]).
-    Uses the cascade name as the admission key. *)
+type tier_id = string
+(** Stable identifier for a cascade tier (e.g. ["strict_tool_candidates"]).
+    Matches the [tier-group.<name>] keys in [cascade.toml]. *)
 
 type admission_policy =
   | Required
@@ -45,18 +45,18 @@ type admission_policy =
           (RFC-0153 §6.8). *)
 
 type t
-(** Per-process admission state. Holds a map of [admission_key] to inflight
-    counter + per-cascade configured capacity. Thread-safe under Eio. *)
+(** Per-process admission state. Holds a map of [tier_id] to inflight
+    counter + per-tier configured capacity. Thread-safe under Eio. *)
 
 (** {1 Construction} *)
 
 val create : ?default_max_inflight:int -> unit -> t
 (** [create ?default_max_inflight ()] returns a fresh admission state.
-    Cascades not explicitly {!configure}d use [default_max_inflight]
+    Tiers not explicitly {!configure}d use [default_max_inflight]
     (default: 8) for their capacity. *)
 
-val configure : t -> admission_key:admission_key -> max_inflight:int -> unit
-(** Pre-configure (or update) a cascade's capacity. Safe to call before
+val configure : t -> tier_id:tier_id -> max_inflight:int -> unit
+(** Pre-configure (or update) a tier's capacity. Safe to call before
     or during operation; updates take effect for subsequent
     admission decisions. Existing inflight count is preserved. *)
 
@@ -64,22 +64,22 @@ val configure : t -> admission_key:admission_key -> max_inflight:int -> unit
 
 val with_admission :
   t ->
-  admission_key:admission_key ->
+  tier_id:tier_id ->
   admission_policy:admission_policy ->
   (unit -> 'a) ->
   ('a, Cascade_saturation_signal.t) result
-(** [with_admission t ~admission_key ~admission_policy f] is the safe
-    wrapper for cascade-bounded execution.
+(** [with_admission t ~tier_id ~admission_policy f] is the safe
+    wrapper for tier-bounded execution.
 
     Behaviour by policy:
     - [Bypass] — calls [f ()] immediately, returns [Ok (f ())]. Does
-      not touch the inflight counter for [admission_key]. Used by probes,
+      not touch the inflight counter for [tier_id]. Used by probes,
       memory summary, and other side tasks.
-    - [Required] — tries to acquire one admission slot for [admission_key].
+    - [Required] — tries to acquire one admission slot in [tier_id].
       If capacity is available, [f ()] runs and the slot is released
       when [f] returns (whether normally or by exception). If
       capacity is full, returns
-      [Error (Inflight_capacity_full { admission_key; max_inflight })]
+      [Error (Inflight_capacity_full { tier_id; max_inflight })]
       *without* calling [f].
 
     Exception safety: if [f] raises, the slot is released before
@@ -94,27 +94,27 @@ type try_decision =
   | Granted of { inflight_after_acquire : int; max_inflight : int }
   | Capacity_full of { inflight_at_check : int; max_inflight : int }
 
-val try_acquire : t -> admission_key:admission_key -> try_decision
+val try_acquire : t -> tier_id:tier_id -> try_decision
 (** Non-blocking admission attempt. [Granted] increments the
     inflight counter and the caller MUST call {!release} exactly
     once. [Capacity_full] does not change state.
 
     This is the lower-level building block of {!with_admission}.
     Direct use is for callers that need to interleave admission with
-    other concerns (e.g. trying another cascade on capacity_full
+    other concerns (e.g. trying another tier on capacity_full
     before deciding). Most callers should use {!with_admission}. *)
 
-val release : t -> admission_key:admission_key -> unit
-(** Decrement the inflight counter for [admission_key]. Idempotent at the
+val release : t -> tier_id:tier_id -> unit
+(** Decrement the inflight counter for [tier_id]. Idempotent at the
     floor — release on a zero-counter is a no-op (no negative
     inflight). Pairs 1:1 with a [Granted] from {!try_acquire}. *)
 
 (** {1 Observability} *)
 
-val current_inflight : t -> admission_key:admission_key -> int
-(** Current inflight count for [admission_key], or 0 if the cascade has
+val current_inflight : t -> tier_id:tier_id -> int
+(** Current inflight count for [tier_id], or 0 if the tier has
     never been seen. Read-only; intended for metrics and tests. *)
 
-val configured_max : t -> admission_key:admission_key -> int
-(** Configured capacity for [admission_key]. Returns the default if the
-    cascade has not been explicitly configured. Read-only. *)
+val configured_max : t -> tier_id:tier_id -> int
+(** Configured capacity for [tier_id]. Returns the default if the
+    tier has not been explicitly configured. Read-only. *)

--- a/lib/cascade/cascade_tier_wait_scheduler.ml
+++ b/lib/cascade/cascade_tier_wait_scheduler.ml
@@ -1,20 +1,20 @@
-(** Cascade_tier_wait_scheduler — bounded wait layer over cascade admission.
+(** Cascade_tier_wait_scheduler — bounded wait layer over tier admission.
 
     RFC-0153 Phase C.1.
 
     Architecture:
     - Wraps [Cascade_tier_admission.t] without modifying it (tower
       composition pattern).
-    - Per-cascade FIFO queue of waiting fibers, each with its own
+    - Per-tier FIFO queue of waiting fibers, each with its own
       [Eio.Promise] for wake-up notification.
     - Backoff: fiber sleeps [backoff_delay] then retries [try_acquire].
     - On release: oldest waiter's promise is resolved, waking it.
     - Timeout: each fiber tracks its own deadline via [Eio.Time.Timeout].
 
     Concurrency model:
-    - [cascade_mu] protects the per-cascade waiter queue + stats.
+    - [tier_mu] protects the per-tier waiter queue + stats.
     - Admission [try_acquire] / [release] go through the underlying
-      [Cascade_tier_admission.t] which has its own per-cascade mutex.
+      [Cascade_tier_admission.t] which has its own per-tier mutex.
     - Fiber-per-waiter: each [try_admission_or_wait] call that hits
       capacity_full spawns a wait loop in the calling fiber (no extra
       fiber). The fiber is identified by its promise for FIFO ordering. *)
@@ -54,28 +54,28 @@ let next_backoff_delay strategy attempt =
 
 type rejection_detail =
   | Timeout_expired of {
-      admission_key : string;
+      tier_id : string;
       total_waited_s : float;
       attempts : int;
     }
   | Max_retries_exceeded of {
-      admission_key : string;
+      tier_id : string;
       retries : int;
       total_waited_s : float;
     }
-  | Cancelled of { admission_key : string }
+  | Cancelled of { tier_id : string }
 
 let pp_rejection_detail fmt = function
-  | Timeout_expired { admission_key; total_waited_s; attempts } ->
+  | Timeout_expired { tier_id; total_waited_s; attempts } ->
       Format.fprintf fmt
-        "timeout_expired admission_key=%s waited=%.3fs attempts=%d"
-        admission_key total_waited_s attempts
-  | Max_retries_exceeded { admission_key; retries; total_waited_s } ->
+        "timeout_expired tier=%s waited=%.3fs attempts=%d"
+        tier_id total_waited_s attempts
+  | Max_retries_exceeded { tier_id; retries; total_waited_s } ->
       Format.fprintf fmt
-        "max_retries_exceeded admission_key=%s retries=%d waited=%.3fs"
-        admission_key retries total_waited_s
-  | Cancelled { admission_key } ->
-      Format.fprintf fmt "cancelled admission_key=%s" admission_key
+        "max_retries_exceeded tier=%s retries=%d waited=%.3fs"
+        tier_id retries total_waited_s
+  | Cancelled { tier_id } ->
+      Format.fprintf fmt "cancelled tier=%s" tier_id
 
 (* ── Per-tier state ─────────────────────────────────────────────── *)
 
@@ -84,7 +84,7 @@ type waiter = {
   resolver : unit Eio.Promise.u;
 }
 
-type cascade_wait_state = {
+type tier_wait_state = {
   mu : Eio.Mutex.t;
   mutable waiters : waiter Queue.t;
   mutable total_admitted : int;
@@ -93,7 +93,7 @@ type cascade_wait_state = {
   mutable total_wait_s : float;
 }
 
-let create_cascade_state () =
+let create_tier_state () =
   {
     mu = Eio.Mutex.create ();
     waiters = Queue.create ();
@@ -107,7 +107,7 @@ let create_cascade_state () =
 
 type t = {
   admission : Cascade_tier_admission.t;
-  cascades : (string, cascade_wait_state) Hashtbl.t;
+  tiers : (string, tier_wait_state) Hashtbl.t;
   guard_mu : Eio.Mutex.t;
   default_wait_config : wait_config;
   clock : float Eio.Time.clock_ty Eio.Resource.t option;
@@ -116,7 +116,7 @@ type t = {
 let create ?(default_wait_config = default_wait_config) ?clock admission =
   {
     admission;
-    cascades = Hashtbl.create 8;
+    tiers = Hashtbl.create 8;
     guard_mu = Eio.Mutex.create ();
     default_wait_config;
     clock;
@@ -124,13 +124,13 @@ let create ?(default_wait_config = default_wait_config) ?clock admission =
 
 let clock t = t.clock
 
-let get_or_create_cascade t admission_key =
+let get_or_create_tier t tier_id =
   Eio.Mutex.use_rw t.guard_mu ~protect:false (fun () ->
-      match Hashtbl.find_opt t.cascades admission_key with
+      match Hashtbl.find_opt t.tiers tier_id with
       | Some ts -> ts
       | None ->
-          let ts = create_cascade_state () in
-          Hashtbl.add t.cascades admission_key ts;
+          let ts = create_tier_state () in
+          Hashtbl.add t.tiers tier_id ts;
           ts)
 
 (* ── Wake oldest waiter (FIFO) ──────────────────────────────────── *)
@@ -145,8 +145,8 @@ let wake_oldest ts =
 
 (* ── on_admission_release ───────────────────────────────────────── *)
 
-let on_admission_release t ~admission_key =
-  match Hashtbl.find_opt t.cascades admission_key with
+let on_admission_release t ~tier_id =
+  match Hashtbl.find_opt t.tiers tier_id with
   | None -> ()
   | Some ts ->
       Eio.Mutex.use_rw ts.mu ~protect:false (fun () ->
@@ -190,7 +190,7 @@ let backoff_sleep t ~sw delay_s waiter_promise =
 
 (* ── Main API: try_admission_or_wait ────────────────────────────── *)
 
-let try_admission_or_wait t ~admission_key ?(wait_config = t.default_wait_config)
+let try_admission_or_wait t ~tier_id ?(wait_config = t.default_wait_config)
     ?deadline:cascade_deadline ~sw f =
   let start_time = Unix.gettimeofday () in
   (* RFC-0192 § 2: effective per-call timeout =
@@ -207,23 +207,23 @@ let try_admission_or_wait t ~admission_key ?(wait_config = t.default_wait_config
   in
 
   (* Attempt 1: immediate try_acquire *)
-  match Cascade_tier_admission.try_acquire t.admission ~admission_key with
+  match Cascade_tier_admission.try_acquire t.admission ~tier_id with
   | Cascade_tier_admission.Granted _ ->
-      (* Fast path — run f with auto-release. No cascade state created. *)
+      (* Fast path — run f with auto-release. No tier state created. *)
       (match f () with
        | v ->
-           Cascade_tier_admission.release t.admission ~admission_key;
-           on_admission_release t ~admission_key;
+           Cascade_tier_admission.release t.admission ~tier_id;
+           on_admission_release t ~tier_id;
            Ok v
        | exception exn ->
            (try
-              Cascade_tier_admission.release t.admission ~admission_key;
-              on_admission_release t ~admission_key
+              Cascade_tier_admission.release t.admission ~tier_id;
+              on_admission_release t ~tier_id
             with _ -> ());
            raise exn)
   | Cascade_tier_admission.Capacity_full _ ->
-      (* Slow path — create cascade state lazily, enter wait loop *)
-      let ts = get_or_create_cascade t admission_key in
+      (* Slow path — create tier state lazily, enter wait loop *)
+      let ts = get_or_create_tier t tier_id in
       let wait_deadline_s = start_time +. effective_timeout_s in
       let max_retries = wait_config.max_retries in
       let rec loop attempt total_waited =
@@ -234,7 +234,7 @@ let try_admission_or_wait t ~admission_key ?(wait_config = t.default_wait_config
               ts.total_timeouts <- ts.total_timeouts + 1;
               ts.total_rejected <- ts.total_rejected + 1;
               ts.total_wait_s <- ts.total_wait_s +. total_waited);
-          Error (Timeout_expired { admission_key; total_waited_s = total_waited; attempts = attempt })
+          Error (Timeout_expired { tier_id; total_waited_s = total_waited; attempts = attempt })
         end
         (* Check max_retries *)
         else begin
@@ -244,7 +244,7 @@ let try_admission_or_wait t ~admission_key ?(wait_config = t.default_wait_config
                   ts.total_rejected <- ts.total_rejected + 1;
                   ts.total_wait_s <- ts.total_wait_s +. total_waited);
               Error (Max_retries_exceeded {
-                admission_key;
+                tier_id;
                 retries = attempt - 1;
                 total_waited_s = total_waited;
               })
@@ -280,7 +280,7 @@ let try_admission_or_wait t ~admission_key ?(wait_config = t.default_wait_config
                   ) remaining);
               (* Always try_acquire after sleep or wake *)
               match Cascade_tier_admission.try_acquire t.admission
-                      ~admission_key with
+                      ~tier_id with
               | Cascade_tier_admission.Granted _ ->
                   Eio.Mutex.use_rw ts.mu ~protect:false (fun () ->
                       ts.total_admitted <- ts.total_admitted + 1;
@@ -288,13 +288,13 @@ let try_admission_or_wait t ~admission_key ?(wait_config = t.default_wait_config
                   (match f () with
                    | v ->
                        Cascade_tier_admission.release t.admission
-                         ~admission_key;
-                       on_admission_release t ~admission_key;
+                         ~tier_id;
+                       on_admission_release t ~tier_id;
                        Ok v
                    | exception exn ->
                        (try Cascade_tier_admission.release
-                              t.admission ~admission_key;
-                            on_admission_release t ~admission_key
+                              t.admission ~tier_id;
+                            on_admission_release t ~tier_id
                         with _ -> ());
                        raise exn)
               | Cascade_tier_admission.Capacity_full _ ->
@@ -306,7 +306,7 @@ let try_admission_or_wait t ~admission_key ?(wait_config = t.default_wait_config
                         ts.total_rejected <- ts.total_rejected + 1;
                         ts.total_wait_s <- ts.total_wait_s +. new_total);
                     Error (Timeout_expired {
-                      admission_key;
+                      tier_id;
                       total_waited_s = new_total;
                       attempts = attempt;
                     })
@@ -319,8 +319,8 @@ let try_admission_or_wait t ~admission_key ?(wait_config = t.default_wait_config
 
 (* ── Observability ──────────────────────────────────────────────── *)
 
-type cascade_wait_stats = {
-  admission_key : string;
+type tier_wait_stats = {
+  tier_id : string;
   waiting_fibers : int;
   total_admitted : int;
   total_rejected : int;
@@ -328,8 +328,8 @@ type cascade_wait_stats = {
   avg_wait_s : float;
 }
 
-let stats t ~admission_key =
-  match Hashtbl.find_opt t.cascades admission_key with
+let stats t ~tier_id =
+  match Hashtbl.find_opt t.tiers tier_id with
   | None -> None
   | Some ts ->
       Eio.Mutex.use_ro ts.mu (fun () ->
@@ -339,7 +339,7 @@ let stats t ~admission_key =
             else 0.0
           in
           Some {
-            admission_key;
+            tier_id;
             waiting_fibers = Queue.length ts.waiters;
             total_admitted = ts.total_admitted;
             total_rejected = ts.total_rejected;
@@ -348,8 +348,8 @@ let stats t ~admission_key =
           })
 
 let all_stats t =
-  Hashtbl.fold (fun admission_key ts acc ->
-      match stats t ~admission_key with
+  Hashtbl.fold (fun tier_id ts acc ->
+      match stats t ~tier_id with
       | Some s -> s :: acc
       | None -> acc
-    ) t.cascades []
+    ) t.tiers []

--- a/lib/cascade/cascade_tier_wait_scheduler.mli
+++ b/lib/cascade/cascade_tier_wait_scheduler.mli
@@ -1,6 +1,6 @@
-(** Cascade_tier_wait_scheduler — bounded wait layer over cascade admission.
+(** Cascade_tier_wait_scheduler — bounded wait layer over tier admission.
 
-    RFC-0153 Phase C.1. Wraps {!Cascade_tier_admission} with per-cascade
+    RFC-0153 Phase C.1. Wraps {!Cascade_tier_admission} with per-tier
     FIFO queues, fiber-per-waiter backoff, and a configurable timeout.
 
     Design principles (from approved design report 2026-05-24):
@@ -46,16 +46,16 @@ val default_wait_config : wait_config
 
 type rejection_detail =
   | Timeout_expired of {
-      admission_key : string;
+      tier_id : string;
       total_waited_s : float;
       attempts : int;
     }
   | Max_retries_exceeded of {
-      admission_key : string;
+      tier_id : string;
       retries : int;
       total_waited_s : float;
     }
-  | Cancelled of { admission_key : string }
+  | Cancelled of { tier_id : string }
       (** The Eio switch was cancelled while waiting. *)
 
 val pp_rejection_detail : Format.formatter -> rejection_detail -> unit
@@ -64,7 +64,7 @@ val pp_rejection_detail : Format.formatter -> rejection_detail -> unit
 
 type t
 (** Per-process scheduler state. Wraps a {!Cascade_tier_admission.t}
-    with per-cascade wait queues. Thread-safe under Eio. *)
+    with per-tier wait queues. Thread-safe under Eio. *)
 
 val create :
   ?default_wait_config:wait_config ->
@@ -88,14 +88,14 @@ val clock : t -> float Eio.Time.clock_ty Eio.Resource.t option
 
 val try_admission_or_wait :
   t ->
-  admission_key:string ->
+  tier_id:string ->
   ?wait_config:wait_config ->
   ?deadline:Cascade_deadline.t ->
   sw:Eio.Switch.t ->
   (unit -> 'a) ->
   ('a, rejection_detail) result
-(** [try_admission_or_wait t ~admission_key ?wait_config ?deadline ~sw f] attempts
-    admission on the underlying cascade.
+(** [try_admission_or_wait t ~tier_id ?wait_config ?deadline ~sw f] attempts
+    admission on the underlying tier.
 
     If capacity is available, [f ()] runs immediately (zero wait).
     If full, the calling fiber enters a bounded wait loop with backoff
@@ -123,8 +123,8 @@ val try_admission_or_wait :
 
 (** {1 Notification (for external release paths)} *)
 
-val on_admission_release : t -> admission_key:string -> unit
-(** Signal that a slot was released in [admission_key]. Wakes the oldest
+val on_admission_release : t -> tier_id:string -> unit
+(** Signal that a slot was released in [tier_id]. Wakes the oldest
     waiting fiber (FIFO) if any.
 
     Callers using {!try_admission_or_wait} do NOT need this — release
@@ -132,8 +132,8 @@ val on_admission_release : t -> admission_key:string -> unit
 
 (** {1 Observability} *)
 
-type cascade_wait_stats = {
-  admission_key : string;
+type tier_wait_stats = {
+  tier_id : string;
   waiting_fibers : int;
   total_admitted : int;
   total_rejected : int;
@@ -141,9 +141,9 @@ type cascade_wait_stats = {
   avg_wait_s : float;
 }
 
-val stats : t -> admission_key:string -> cascade_wait_stats option
-(** Snapshot of wait statistics for a cascade. [None] if the cascade has
+val stats : t -> tier_id:string -> tier_wait_stats option
+(** Snapshot of wait statistics for a tier. [None] if the tier has
     never been waited on. Safe to call from any fiber. *)
 
-val all_stats : t -> cascade_wait_stats list
-(** Stats for all cascades that have seen wait activity. *)
+val all_stats : t -> tier_wait_stats list
+(** Stats for all tiers that have seen wait activity. *)

--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -291,7 +291,7 @@ let routes_json ~path value =
       | (key, field_value) :: rest ->
         let item_path = Printf.sprintf "%s.%s" path key in
         (* Route entries are declarative subtables:
-               [routes.keeper_turn] target = "provider:model"
+               [routes.keeper_turn] target = "tier-group.primary"
            The subtable is materialized as a JSON object, leaving target
            extraction to [Cascade_declarative_parser]. *)
         (match field_value with
@@ -299,7 +299,7 @@ let routes_json ~path value =
            loop ((key, otoml_to_yojson field_value) :: acc) rest
          | _ ->
            errorf
-             "%s must be a subtable with target = \"provider:model\""
+             "%s must be a subtable with target = \"tier-or-tier-group\""
              item_path)
     in
     loop [] fields
@@ -364,11 +364,11 @@ let render_toml_to_yojson toml =
   | Error _ as err -> err
   | Ok fields ->
     (* RFC-0058 v2 5-layer declarative namespaces. These tables describe
-         providers, models, bindings, etc. and are
+         providers, models, bindings, tiers, tier-groups, etc. and are
          consumed by the declarative loader. Passthrough preserves the TOML
          shape for JSON-shaped readers such as route decoding. *)
     let is_rfc_0058_namespace = function
-      | "providers" | "models" -> true
+      | "providers" | "models" | "tier" | "tier-group" -> true
       | _ -> false
     in
     let rec loop acc = function
@@ -416,7 +416,7 @@ let render_toml_to_yojson toml =
             errorf
               "flat cascade TOML profile %S is no longer supported; use \
                RFC-0058 declarative namespaces ([providers.*], [models.*], \
-               [<provider>.<binding>], [routes.*])"
+               [<provider>.<binding>], [tier.*], [tier-group.*], [routes.*])"
               key)
     in
     loop [] fields

--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -101,6 +101,8 @@ let json_string_list_member key = function
   | _ -> []
 
 let discover_profiles_from_materialized_json json =
+  (* Tier/tier-group purge: profiles are route targets (provider:model strings).
+     Discovery reads [routes.*.target] from the materialized JSON. *)
   match assoc_opt "routes" json with
   | Some (`Assoc routes) ->
     routes
@@ -129,6 +131,12 @@ let discover_profiles ~config_path =
 let discover_profiles_for_diagnostics ~config_path =
   discover_profiles_impl ~emit_telemetry:false ~config_path
 
+(* Tier/tier-group purge: [materialized_model_specs_for_profile] and its
+   helpers [materialized_tier_members] / [materialized_tier_group_tiers]
+   are removed.  Profile model specs now come exclusively from the
+   declarative snapshot or runtime profile build; there is no JSON
+   materialized fallback for tier-based resolution. *)
+
 let model_ids_of_specs (specs : string list) : string list =
   specs
   |> Cascade_config.expand_auto_models
@@ -142,6 +150,9 @@ let format_spec_errors specs =
   specs
   |> List.map (fun (spec, msg) -> Printf.sprintf "%S (%s)" spec msg)
   |> String.concat ", "
+
+(* Tier/tier-group purge: [priority_tier_issue] removed with the
+   [priority_tier] strategy concept. *)
 
 (* Catalog warn: a cascade carrying [cli_tool_a] with no
    bound-actor-tolerant fallback will reject every keeper-bound

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -6,7 +6,7 @@
     (include_subdirs no) only prevents source-file inclusion, not type
     name visibility.  Without prefixes, ppx_deriving-generated code
     references the wrong type when [provider], [transport], [binding],
-    or [strategy] exist in both libraries. *)
+    [strategy], or [tier] exist in both libraries. *)
 
 type cascade_api_format =
   | Messages_api

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -5,7 +5,7 @@
     Layer 2: [models.*]        — What it can do
     Layer 3: [<p>.<m>]         — How much, at what cost
     Layer 4: [<p>.<m>.<a>]     — Per-use overrides
-    Layer 5: [routes] — Routing strategy
+    Layer 5: [tier.*] + [tier-group.*] + [routes] — Routing strategy
 
     Code knows API formats, not provider brands. See RFC-0058 §2.1.
 

--- a/lib/cascade_decl/cascade_declarative_validator.ml
+++ b/lib/cascade_decl/cascade_declarative_validator.ml
@@ -1,6 +1,7 @@
 (** Declarative cascade config cross-reference validator (RFC-0058 v2).
 
     Validates load-time invariants on a parsed [cascade_config].
+    Tier/tier-group purge: R5-R6 removed, R7 simplified.
 
     R1: Every binding references an existing provider
     R2: Every binding references an existing model
@@ -42,6 +43,9 @@ let alias_keys (cfg : cascade_config) : string list =
     (fun (a : cascade_alias) -> Printf.sprintf "%s.%s.%s" a.provider_id a.model_id a.name)
     cfg.aliases
 ;;
+
+(* Tier/tier-group purge: tier_names, tier_names_bare, tier_group_names
+   removed.  Route targets resolve directly to bindings/aliases. *)
 
 (* Build a name-keyed Hashtbl once for O(1) membership.  Eight
    validator rules below (R1-R8) used to do [List.mem key list]
@@ -139,7 +143,9 @@ let validate_alias_max_input (cfg : cascade_config) : validation_error list =
     cfg.aliases
 ;;
 
-(* --- R7: Route targets exist --- *)
+(* --- R7: Route targets exist ---
+   Tier/tier-group purge: route targets resolve directly to bindings
+   or aliases. No tier-group or tier indirection. *)
 
 let validate_route_targets (cfg : cascade_config) : validation_error list =
   let all_targets_set = name_set (binding_keys cfg @ alias_keys cfg) in
@@ -202,6 +208,8 @@ let validate_single_default (cfg : cascade_config) : validation_error list =
          (Printf.sprintf "provider %S has multiple bindings with is-default=true" pid))
     counts
 ;;
+
+(* R10 (strategy fields) removed with tier/tier-group purge. *)
 
 (* --- R11: Binding max-concurrent is required and positive ---
 

--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -120,7 +120,7 @@ let should_log_auto_max_tokens_clamp ~cascade_name ~source ~max_tokens ~ceiling 
     visibility into the silent reduction.
 
     The narrowest ceiling is a property of cascade-internal fallback
-    structure (multilane fallback chains can union members of differing output
+    structure (multilane tier-groups can union members of differing output
     budgets), so callers cannot infer it.
 
     Runtime overrides supplied by internal keeper callers should also flow

--- a/lib/cascade_name/cascade_name.ml
+++ b/lib/cascade_name/cascade_name.ml
@@ -1,3 +1,9 @@
+(* Tier/tier-group prefix validation removed.  Cascade names are now
+   simple provider:model strings (e.g. "runpod:glm-coding-with-spark").
+   This module is preserved temporarily as a string alias so downstream
+   types do not need to change in a single sweep, but all validation
+   has been deleted per tier/tier-group purge. *)
+
 type t = string
 
 let of_string raw : (t, [ `Invalid_prefix | `Empty ]) result =

--- a/lib/cascade_name/cascade_name.mli
+++ b/lib/cascade_name/cascade_name.mli
@@ -1,4 +1,9 @@
-(** Cascade name — simple provider:model string alias. *)
+(** Cascade name — simple provider:model string alias.
+
+    Tier/tier-group prefix validation removed.  All cascade names are
+    now plain strings such as ["runpod:glm-coding-with-spark"].
+    This module is preserved as a string alias so downstream types do
+    not need to change in a single sweep. *)
 
 type t = string
 

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -49,8 +49,10 @@
     @since 0.6.0 *)
 val config_json : ?base_path:string -> unit -> Yojson.Safe.t
 
-(** Public profile display name for dashboard surfaces. All cascade
-    names are plain provider:model strings and pass through unchanged. *)
+(** Public profile display name for dashboard surfaces. Declarative
+    runtime names such as ["tier.primary"] and ["tier-group.primary"]
+    are rendered as ["primary"] for operator-facing JSON and route
+    payloads. *)
 val public_cascade_profile_name : string -> string
 
 val public_profile_names : string list -> string list
@@ -58,7 +60,10 @@ val public_profile_names : string list -> string list
 
 val invalid_profiles_with_internal_names :
   (string * string list) list -> (string * string list) list
-(** Merge validation errors by exact internal profile name. *)
+(** Merge validation errors by exact internal profile name. Names such as
+    ["tier.primary"] and ["tier-group.primary"] are intentionally kept
+    distinct; callers may separately apply {!public_cascade_profile_name}
+    only when a display-only label is needed. *)
 
 val invalid_assignments_for_public_profiles :
   known_internal_profiles:string list ->
@@ -66,7 +71,11 @@ val invalid_assignments_for_public_profiles :
   string list ->
   (string * string list) list
 (** Match keeper-facing profile names against internal invalid-profile
-    diagnostics using runtime profile preference order. *)
+    diagnostics using runtime profile preference order. Qualified names such
+    as ["tier.primary"] are checked exactly. For an unqualified legacy name
+    such as ["primary"], ["tier-group.primary"] is checked before
+    ["tier.primary"] so a valid preferred tier-group is not rejected because a
+    lower-priority tier with the same public name is invalid. *)
 
 (** Raw cascade TOML payload from the active resolved config root.
 
@@ -84,6 +93,8 @@ val invalid_assignments_for_public_profiles :
           "models": ["<model_a>", "<model_b>"],
           "bindings": ["<binding_a>", "<binding_b>"],
           "aliases": ["<alias_a>", "<alias_b>"],
+          "tiers": ["primary", ...],
+          "tier_groups": ["primary", ...],
           "routes": ["keeper_turn", ...],
           "feature_params": [
             { "key": "thinking-enabled",

--- a/lib/dashboard_cascade_config.ml
+++ b/lib/dashboard_cascade_config.ml
@@ -301,7 +301,13 @@ let config_json ?base_path () =
         then None
         else (
           let cascade_name =
-            match doc.Keeper_types_profile.cascade_name with
+            (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model
+               in keeper_profile_defaults but this consumer was missed.
+               Reading [.model] preserves the prior behavior of treating the
+               keeper-declared string as a cascade name. Root: separate review
+               needed — [.model] now stores a direct provider:model string per
+               #19327, which may not round-trip through cascade-name routing. *)
+            match doc.Keeper_types_profile.model with
             | Some c -> c
             | None -> (Keeper_config.default_cascade_name ())
           in

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -20,6 +20,8 @@ let degraded_retry_cascade_of_wire ?(log_invalid = true) ~keeper_name raw =
     let candidates =
       [ trimmed
       ; normalized_declared
+      ; "tier." ^ trimmed
+      ; "tier-group." ^ trimmed
       ; "route." ^ trimmed
       ]
     in

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -37,6 +37,21 @@ let logical_use_of_string_opt = Cascade_routes.logical_use_of_string_opt
 let configured_route_targets = Cascade_routes.configured_route_targets
 let cascade_name_for_use = Cascade_routes.cascade_name_for_use
 
+(** Phonebook-based [Provider_config.t] resolution.
+    Directly returns typed provider configs without string intermediaries.
+    Returns [None] when phonebook is unavailable or no models resolve. *)
+let provider_configs_for_use ?config_path ?temperature ?max_tokens use =
+  Cascade_routes.cascade_provider_configs_for_use_via_phonebook
+    ?config_path ?temperature ?max_tokens use
+
+(** Phonebook-based model string list resolution.
+    Returns [None] when phonebook is unavailable. *)
+let model_strings_for_use ?config_path use =
+  Cascade_routes.cascade_models_for_use_via_phonebook ?config_path use
+
+(* Tier/tier-group purge: qualified profile names no longer exist.
+   All cascade names are simple provider:model strings. *)
+
 let strip_declarative_profile_prefix name = name
 
 let qualified_names_of_declarative_snapshot snapshot =
@@ -234,9 +249,17 @@ let json_keeper_assignable_opt json =
   | Some _ as value -> value
   | None -> json_bool_field "keeper_assignable" json
 
+(* Tier/tier-group purge: public names and qualified names are identical.
+   All cascade names are simple provider:model strings. *)
+
 let qualified_name_for_public _meta public_name = public_name
 
 let qualified_name_for_public_names _qualified_names public_name = public_name
+
+(* Tier/tier-group purge: cascade.toml no longer contains [tier] or
+   [tier-group] sections.  Only [routes] remains.  Profile names are
+   the route targets (provider:model strings).  All profiles are
+   keeper-assignable; system-only is retired. *)
 
 let catalog_metadata_of_materialized_json json =
   let routes = json_assoc_table_fields "routes" json in
@@ -342,6 +365,8 @@ let routed_query_target ?config_path raw =
 let normalized_query_name ?config_path raw =
   routed_query_target ?config_path raw |> public_name_of_target
 
+(* Tier/tier-group purge: system-only cascade concept retired.
+   All cascades are keeper-assignable. *)
 let is_system_only_cascade _raw = false
 
 let keeper_catalog_names ?config_path () =
@@ -401,6 +426,8 @@ let canonicalize_with_catalog ~catalog raw =
         | Some _ -> trimmed
         | None -> trimmed)
 
+(* Tier/tier-group purge: lookup catalog contains only plain
+   provider:model strings.  No canonical prefix or qualified names. *)
 let canonical_member_of_lookup_catalog ~catalog raw =
   let trimmed = String.trim raw in
   if List.mem trimmed catalog then Some trimmed else None

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -51,10 +51,32 @@ val cascade_name_for_use : ?config_path:string -> logical_use -> string
        runtime.
 
     This returns a cascade profile name, never a provider/model string.
+    Phonebook model/provider resolution is exposed separately through
+    {!model_strings_for_use} and {!provider_configs_for_use}.
 
     This is the boundary for code that used to hardcode profile names such as
     ["governance_judge"], ["operator_judge"], ["phase_recovery"], or
     ["cross_verifier"]. *)
+
+val provider_configs_for_use :
+  ?config_path:string ->
+  ?temperature:float ->
+  ?max_tokens:int ->
+  logical_use ->
+  Llm_provider.Provider_config.t list option
+(** Resolve a logical use to [Provider_config.t] list via the phonebook.
+    Direct phonebook path: logical_use → task_use → models →
+    providers → endpoint/auth → Provider_config.t.
+    Returns [None] when phonebook is unavailable or no models resolve.
+    @since RFC Cascade-Phonebook Phase 4 *)
+
+val model_strings_for_use :
+  ?config_path:string ->
+  logical_use ->
+  string list option
+(** Resolve a logical use to model strings via the phonebook.
+    Returns [None] when phonebook is unavailable.
+    @since RFC Cascade-Phonebook Phase 4 *)
 
 val configured_route_targets : ?config_path:string -> unit -> string list
 (** Unique non-empty profile names referenced from [routes]. *)

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -15,6 +15,8 @@ let two_days_seconds_int = Masc_time_constants.day_int * 2
     naming the "1 day" intent at the call site. *)
 let one_day_seconds_int = Masc_time_constants.day_int
 
+(* Tier/tier-group purge: cascade names are now simple provider:model
+   strings.  All phase routing collapses to the same default. *)
 let default_cascade_name () = "runpod:glm-coding-with-spark"
 let phase_recovery_cascade_name = "runpod:glm-coding-with-spark"
 let phase_buffer_cascade_name = "runpod:glm-coding-with-spark"

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -505,6 +505,9 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
          | Agent_sdk.Error.A2a _
          | Agent_sdk.Error.Internal _ -> None)
 
+(* Tier/tier-group purge: all cascade names are plain provider:model strings.
+   No prefix qualification, canonical form, or bare-name requalification. *)
+
 let normalized_cascade_name ~catalog_names name =
   let trimmed = String.trim name in
   if List.exists (String.equal trimmed) catalog_names then trimmed
@@ -514,6 +517,9 @@ let normalized_cascade_name ~catalog_names name =
     || String.equal trimmed Keeper_config.tool_required_cascade_name
   then trimmed
   else Keeper_cascade_profile.normalize_declared_name trimmed
+
+(* Tier/tier-group purge: no tier/tier-group prefixes exist. *)
+let direct_tier_duplicates_attempted_group ~attempted:_ ~candidate:_ = false
 
 let required_tool_rotation_candidate
     ?(allow_phase_recovery = false)
@@ -647,7 +653,8 @@ let degraded_rotation_after_recoverable_error
         ~fallback_hint
         ~base_cascade ~effective_cascade ~tool_requirement
       |> List.find_opt (fun candidate ->
-             not (List.exists (String.equal candidate) attempted))
+             (not (List.exists (String.equal candidate) attempted))
+             && not (direct_tier_duplicates_attempted_group ~attempted ~candidate))
       |> Option.map (fun next_cascade -> { next_cascade; fallback_reason })
 
 let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -100,8 +100,10 @@ type degraded_retry_reason =
 val degraded_retry_reason_to_string : degraded_retry_reason -> string
 
 val normalized_cascade_name : catalog_names:string list -> string -> string
-(** Normalize a cascade name for rotation matching.
-    All cascade names are plain provider:model strings. *)
+(** Normalize a cascade name for rotation matching. When the input is a bare
+    catalog name (stripped of [tier.]/[tier-group.] prefix), requalifies it
+    with the canonical prefix so downstream [Cascade_name.of_string_exn] does
+    not crash. *)
 
 type degraded_retry =
   { next_cascade : string

--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -11,7 +11,7 @@ type health_status =
 
 type runtime_pressure_class =
   | Client_capacity_full
-  | Admission_full
+  | Tier_admission_full
   | Provider_capacity
   | Provider_dns_failure
   | Provider_timeout
@@ -23,7 +23,7 @@ type runtime_pressure_class =
 
 let runtime_pressure_class_to_string = function
   | Client_capacity_full -> "client_capacity_full"
-  | Admission_full -> "admission_full"
+  | Tier_admission_full -> "tier_admission_full"
   | Provider_capacity -> "provider_capacity"
   | Provider_dns_failure -> "provider_dns_failure"
   | Provider_timeout -> "provider_timeout"
@@ -37,7 +37,7 @@ let runtime_pressure_class_to_string = function
 let runtime_pressure_class_of_label label =
   match label |> String.trim |> String.lowercase_ascii with
   | "client_capacity_full" | "client_capacity" -> Some Client_capacity_full
-  | "admission_full" | "admission_capacity" -> Some Admission_full
+  | "tier_admission_full" | "tier_admission" -> Some Tier_admission_full
   | "provider_capacity" | "provider_capacity_full" | "capacity_backpressure" ->
     Some Provider_capacity
   | "provider_dns_failure" | "provider_dns" -> Some Provider_dns_failure
@@ -68,11 +68,11 @@ let provider_runtime_pressure_class ~code ~detail ~http_status ~cascade_name =
     || contains "client_capacity_full"
   then Client_capacity_full
   else if
-    contains "admission_capacity"
+    contains "tier_admission"
     || contains "inflight_capacity_full"
     || Option.is_some cascade_name
-    || contains "admission="
-  then Admission_full
+    || contains "tier="
+  then Tier_admission_full
   else if
     contains "capacity_backpressure"
     || contains "capacity exhausted"

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -602,7 +602,8 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                              Error
                                (Printf.sprintf
                                   "invalid keeper meta cascade_name %S: expected \
-                                   canonical cascade prefix route."
+                                   canonical cascade prefix tier-group., tier., or \
+                                   route."
                                   identity.pk_cascade_name)
                  in
                  (match cascade_ref_result with

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -137,7 +137,8 @@ let invalid_profile_defaults_error ~keeper_name detail =
 let effective_declarative_cascade_name
     (defaults : Keeper_types_profile.keeper_profile_defaults)
     (meta : keeper_meta) =
-  match defaults.cascade_name, defaults.manifest_path with
+  (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model. *)
+  match defaults.model, defaults.manifest_path with
   | Some cascade_name, _ ->
       Keeper_cascade_profile.normalize_keeper_runtime_declared_name cascade_name
   | None, Some _ -> (Keeper_config.default_cascade_name ())
@@ -215,14 +216,17 @@ let ensure_keeper_meta config name =
         ()
     with
     | Error detail ->
+        (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model.
+           Field-label strings kept for backward-compat in error messages
+           so dashboards / log scrapers do not break on the rename. *)
         let field =
-          match defaults.cascade_name, defaults.manifest_path with
+          match defaults.model, defaults.manifest_path with
           | Some _, _ -> "profile.cascade_name"
           | None, Some _ -> "manifest.default_cascade_name"
           | None, None -> "meta.cascade_name"
         in
         let raw_value =
-          match defaults.cascade_name, defaults.manifest_path with
+          match defaults.model, defaults.manifest_path with
           | Some cascade_name, _ -> cascade_name
           | None, Some _ -> (Keeper_config.default_cascade_name ())
           | None, None -> cascade_name_of_meta meta

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -26,7 +26,10 @@ let effective_declarative_cascade_name
       (defaults : keeper_profile_defaults)
       (meta : keeper_meta)
   =
-  match defaults.cascade_name, defaults.manifest_path with
+  (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model. The
+     value is still routed through normalize_keeper_runtime_declared_name;
+     reviewer should confirm provider:model strings normalize correctly. *)
+  match defaults.model, defaults.manifest_path with
   | Some cascade_name, _ ->
     Keeper_cascade_profile.normalize_keeper_runtime_declared_name cascade_name
   | None, Some _ -> (Keeper_config.default_cascade_name ())

--- a/lib/keeper/keeper_turn_cascade_budget_routing.ml
+++ b/lib/keeper/keeper_turn_cascade_budget_routing.ml
@@ -4,7 +4,23 @@ open Keeper_types
 open Keeper_context_runtime
 module EC = Keeper_error_classify
 
-let public_profile_name name = String.trim name
+let public_profile_name name =
+  let name = String.trim name in
+  let tier_group_prefix = "tier-group." in
+  let tier_prefix = "tier." in
+  if String.starts_with ~prefix:tier_group_prefix name
+  then
+    String.sub
+      name
+      (String.length tier_group_prefix)
+      (String.length name - String.length tier_group_prefix)
+  else if String.starts_with ~prefix:tier_prefix name
+  then
+    String.sub
+      name
+      (String.length tier_prefix)
+      (String.length name - String.length tier_prefix)
+  else name
 
 let fail_open_rotation_cascades_from_catalog
       ?(excluded_targets : string list = [])

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -21,20 +21,20 @@ include Keeper_turn_driver_helpers
 include Keeper_turn_driver_provider_attempt
 include Keeper_turn_driver_backpressure
 
-let keeper_cascade_admission =
-  Keeper_turn_driver_admission.keeper_cascade_admission
+let keeper_cascade_tier_admission =
+  Keeper_turn_driver_admission.keeper_cascade_tier_admission
 
-let cascade_admission_policy_of_priority =
-  Keeper_turn_driver_admission.cascade_admission_policy_of_priority
+let cascade_tier_admission_policy_of_priority =
+  Keeper_turn_driver_admission.cascade_tier_admission_policy_of_priority
 
-let with_keeper_cascade_admission =
-  Keeper_turn_driver_admission.with_keeper_cascade_admission
+let with_keeper_cascade_tier_admission =
+  Keeper_turn_driver_admission.with_keeper_cascade_tier_admission
 
-let cascade_admission_blocked_decision =
-  Keeper_turn_driver_admission.cascade_admission_blocked_decision
+let cascade_tier_admission_blocked_decision =
+  Keeper_turn_driver_admission.cascade_tier_admission_blocked_decision
 
-let emit_cascade_admission_signal_metric =
-  Keeper_turn_driver_admission.emit_cascade_admission_signal_metric
+let emit_cascade_tier_admission_signal_metric =
+  Keeper_turn_driver_admission.emit_cascade_tier_admission_signal_metric
 
 let release_client_capacity_quietly =
   Keeper_turn_driver_admission.release_client_capacity_quietly
@@ -42,8 +42,8 @@ let release_client_capacity_quietly =
 let provider_config_identity_key =
   Keeper_turn_driver_admission.provider_config_identity_key
 
-let runtime_candidates_of_providers =
-  Keeper_turn_driver_admission.runtime_candidates_of_providers
+let runtime_candidates_of_tiered_providers =
+  Keeper_turn_driver_admission.runtime_candidates_of_tiered_providers
 let run_named
     ~cascade_name
     ?base_path
@@ -147,7 +147,7 @@ let run_named
    | Ok configured_labels, Ok candidate_cfgs, Ok tiered_providers ->
   let original_candidate_cfgs = candidate_cfgs in
   let original_candidates =
-    runtime_candidates_of_providers tiered_providers original_candidate_cfgs
+    runtime_candidates_of_tiered_providers tiered_providers original_candidate_cfgs
   in
   let required_capability_profile =
     Keeper_cascade_profile.required_capability_profile_of_cascade_name cascade_name
@@ -168,7 +168,7 @@ let run_named
   let original_candidate_count = List.length original_candidate_cfgs in
   let tool_filtered_candidate_count = List.length tool_filtered_candidate_cfgs in
   let tool_filtered_candidates =
-    runtime_candidates_of_providers tiered_providers tool_filtered_candidate_cfgs
+    runtime_candidates_of_tiered_providers tiered_providers tool_filtered_candidate_cfgs
   in
   let required_lane_filtered_candidates, required_lane_provider_rejections =
     match runtime_manifest_required_tool_names with
@@ -293,7 +293,7 @@ let run_named
       let outcome =
         Cascade_preflight_state.record
           Cascade_preflight_state.global
-          ~cascade_name
+          ~tier_group:cascade_name
           ~provider:endpoint
           ~reason:Cascade_preflight_state.Health_check_failed_repeatedly
       in
@@ -603,8 +603,8 @@ let run_named
   let queue_priority =
     Option.value priority ~default:Llm_provider.Request_priority.Proactive
   in
-  let admission_policy =
-    cascade_admission_policy_of_priority queue_priority
+  let tier_admission_policy =
+    cascade_tier_admission_policy_of_priority queue_priority
   in
   (* MASC-driven cascade FSM: try each provider, decide on failure.
      Extracted to [Keeper_turn_driver_try_provider.run_try_provider] via
@@ -745,7 +745,7 @@ let run_named
     health_cooldown_fail_open;
     base_path;
     session_id;
-    admission_policy;
+    tier_admission_policy;
     accept;
     error_cascade_name_for_backpressure = error_cascade_name;
     record_provider_health_result;
@@ -901,10 +901,10 @@ module For_testing = struct
   let missing_required_tool_names_after_lane_by_name =
     missing_required_tool_names_after_lane_by_name
   let success_selected_model_raw = success_selected_model_raw
-  let cascade_admission_policy_of_priority =
-    cascade_admission_policy_of_priority
-  let with_cascade_admission_for_testing
-      ~admission ~enabled ~admission_key ~admission_policy f =
-    with_keeper_cascade_admission ~admission ~enabled ~admission_key
+  let cascade_tier_admission_policy_of_priority =
+    cascade_tier_admission_policy_of_priority
+  let with_cascade_tier_admission_for_testing
+      ~admission ~enabled ~tier_id ~admission_policy f =
+    with_keeper_cascade_tier_admission ~admission ~enabled ~tier_id
       ~admission_policy f
 end

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -181,7 +181,7 @@ module For_testing : sig
   val with_cascade_tier_admission_for_testing :
     admission:Cascade_tier_admission.t ->
     enabled:bool ->
-    admission_key:string ->
+    tier_id:string ->
     admission_policy:Cascade_tier_admission.admission_policy ->
     (unit -> 'a) ->
     ('a, Cascade_saturation_signal.t) result

--- a/lib/keeper/keeper_turn_driver_admission.ml
+++ b/lib/keeper/keeper_turn_driver_admission.ml
@@ -1,25 +1,25 @@
-(** Keeper cascade admission helpers + provider candidate identity,
+(** Keeper cascade tier admission helpers + provider candidate identity,
     extracted from keeper_turn_driver.ml — sibling pattern (same flat
     masc_mcp library, no sub-library).
 
     Used by the keeper turn driver's [run_named] entry to gate cascade
-    attempts via [Cascade_tier_admission] and to map providers
-    to runtime candidates with deterministic admission keys. *)
+    attempts via [Cascade_tier_admission] and to map tiered providers
+    to runtime candidates with deterministic tier ids. *)
 
 open Result.Syntax
 
-let keeper_cascade_admission = Cascade_tier_admission.create ()
+let keeper_cascade_tier_admission = Cascade_tier_admission.create ()
 
 let keeper_cascade_wait_scheduler =
-  Cascade_tier_wait_scheduler.create keeper_cascade_admission
+  Cascade_tier_wait_scheduler.create keeper_cascade_tier_admission
 
-let cascade_admission_policy_of_priority priority =
+let cascade_tier_admission_policy_of_priority priority =
   (* RFC-0126: exhaustive typed match over Llm_provider.Request_priority.t
      instead of the previous string-classifier (`to_string |> match`) so that
      future variants in the upstream agent_sdk surface as a compile error
      here rather than silently routing through a permissive default.
      Semantics: only [Background] (P2 heartbeat / status ticks) bypasses
-     admission per Cascade_tier_admission.mli side-task starvation
+     tier admission per Cascade_tier_admission.mli side-task starvation
      defence; main-path priorities all require admission.  [Unspecified]
      is unreachable after [resolve] (it maps to [Proactive]) but the arm
      keeps the match exhaustive without a catch-all. *)
@@ -28,13 +28,13 @@ let cascade_admission_policy_of_priority priority =
   | Resume | Interactive | Proactive | Unspecified ->
       Cascade_tier_admission.Required
 
-let with_keeper_cascade_admission
-    ?(admission = keeper_cascade_admission)
+let with_keeper_cascade_tier_admission
+    ?(admission = keeper_cascade_tier_admission)
     ?(wait_scheduler = keeper_cascade_wait_scheduler)
     ?(enabled = Env_config_keeper.CascadeTierAdmission.enabled ())
     ?sw
     ?wait_timeout_sec
-    ~admission_key
+    ~tier_id
     ~admission_policy
     f =
   if not enabled then
@@ -54,7 +54,7 @@ let with_keeper_cascade_admission
               (* No switch available — wait scheduler requires one for
                  fork_daemon.  Fall back to non-blocking admission. *)
               Cascade_tier_admission.with_admission admission
-                ~admission_key ~admission_policy f
+                ~tier_id ~admission_policy f
           | Some sw ->
               (* Phase C.2: bounded wait with backoff *)
               let wait_config =
@@ -81,36 +81,36 @@ let with_keeper_cascade_admission
                 | _ -> None
               in
               (match Cascade_tier_wait_scheduler.try_admission_or_wait
-                       wait_scheduler ~admission_key ~wait_config ?deadline ~sw f with
+                       wait_scheduler ~tier_id ~wait_config ?deadline ~sw f with
                | Ok v -> Ok v
                | Error (Cascade_tier_wait_scheduler.Timeout_expired _
                        | Cascade_tier_wait_scheduler.Max_retries_exceeded _) ->
                    Error (Cascade_saturation_signal.Inflight_capacity_full
-                            { admission_key;
+                            { tier_id;
                               max_inflight =
                                 Cascade_tier_admission.configured_max admission
-                                  ~admission_key })
+                                  ~tier_id })
                | Error (Cascade_tier_wait_scheduler.Cancelled _) ->
                    Error (Cascade_saturation_signal.Inflight_capacity_full
-                            { admission_key;
+                            { tier_id;
                               max_inflight =
                                 Cascade_tier_admission.configured_max admission
-                                  ~admission_key }))
+                                  ~tier_id }))
         end
         else
           (* Phase B.2: non-blocking admission *)
-          Cascade_tier_admission.with_admission admission ~admission_key
+          Cascade_tier_admission.with_admission admission ~tier_id
             ~admission_policy f
   end
 
-let cascade_admission_blocked_decision signal =
+let cascade_tier_admission_blocked_decision signal =
   `Assoc
     [
-      ("blocker", `String "cascade_admission_full");
+      ("blocker", `String "cascade_tier_admission_full");
       ("signal", Cascade_saturation_signal.to_yojson signal);
     ]
 
-let emit_cascade_admission_signal_metric ~cascade_name signal =
+let emit_cascade_tier_admission_signal_metric ~cascade_name signal =
   Prometheus.inc_counter
     Keeper_metrics.(to_string CascadeSaturationSignal)
     ~labels:
@@ -139,7 +139,7 @@ let provider_config_identity_key (cfg : Llm_provider.Provider_config.t) =
       cfg.headers,
       cfg.supports_tool_choice_override )
 
-let runtime_candidates_of_providers tiered_providers provider_cfgs =
+let runtime_candidates_of_tiered_providers tiered_providers provider_cfgs =
   let tier_index = Hashtbl.create (List.length tiered_providers) in
   List.iter
     (fun (tiered : Cascade_catalog_runtime_named_providers.tiered_provider) ->
@@ -152,16 +152,16 @@ let runtime_candidates_of_providers tiered_providers provider_cfgs =
            Hashtbl.add tier_index key queue;
            queue
        in
-       Queue.add tiered.admission_key queue)
+       Queue.add tiered.tier_id queue)
     tiered_providers;
   List.map
     (fun provider_cfg ->
-       let admission_key =
+       let tier_id =
          match Hashtbl.find_opt tier_index (provider_config_identity_key provider_cfg) with
          | Some queue when not (Queue.is_empty queue) -> Some (Queue.pop queue)
          | _ -> None
        in
-        Cascade_runtime_candidate.of_provider_config ?admission_key provider_cfg)
+        Cascade_runtime_candidate.of_provider_config ?tier_id provider_cfg)
     provider_cfgs
 
 (* ================================================================ *)

--- a/lib/keeper/keeper_turn_driver_admission.mli
+++ b/lib/keeper/keeper_turn_driver_admission.mli
@@ -1,20 +1,20 @@
-(** Cascade admission helpers for keeper turn driver. *)
+(** Cascade tier admission helpers for keeper turn driver. *)
 
-val keeper_cascade_admission : Cascade_tier_admission.t
+val keeper_cascade_tier_admission : Cascade_tier_admission.t
 
-val cascade_admission_policy_of_priority :
+val cascade_tier_admission_policy_of_priority :
   Llm_provider.Request_priority.t -> Cascade_tier_admission.admission_policy
 
 val keeper_cascade_wait_scheduler :
   Cascade_tier_wait_scheduler.t
 
-val with_keeper_cascade_admission :
+val with_keeper_cascade_tier_admission :
   ?admission:Cascade_tier_admission.t ->
   ?wait_scheduler:Cascade_tier_wait_scheduler.t ->
   ?enabled:bool ->
   ?sw:Eio.Switch.t ->
   ?wait_timeout_sec:float ->
-  admission_key:string ->
+  tier_id:Cascade_tier_admission.tier_id ->
   admission_policy:Cascade_tier_admission.admission_policy ->
   (unit -> 'a) ->
   ('a, Cascade_saturation_signal.t) result
@@ -31,16 +31,16 @@ val with_keeper_cascade_admission :
     Backward-compat: omitting [?wait_timeout_sec] (or when the scheduler
     has no clock) yields the legacy [env amplifier] behaviour. *)
 
-val cascade_admission_blocked_decision :
+val cascade_tier_admission_blocked_decision :
   Cascade_saturation_signal.t -> Yojson.Safe.t
 
-val emit_cascade_admission_signal_metric :
+val emit_cascade_tier_admission_signal_metric :
   cascade_name:string -> Cascade_saturation_signal.t -> unit
 
 val release_client_capacity_quietly : (unit -> unit) option -> unit
 val provider_config_identity_key : Llm_provider.Provider_config.t -> int
 
-val runtime_candidates_of_providers :
+val runtime_candidates_of_tiered_providers :
   Cascade_catalog_runtime_named_providers.tiered_provider list ->
   Llm_provider.Provider_config.t list ->
   Cascade_runtime_candidate.t list

--- a/lib/keeper/keeper_turn_driver_cascade_health.ml
+++ b/lib/keeper/keeper_turn_driver_cascade_health.ml
@@ -110,7 +110,7 @@ let record_candidate_error candidate (sdk_err : Agent_sdk.Error.sdk_error) =
     let provider_owned_capacity =
       match capacity_source with
       | Some Provider_capacity -> true
-      | Some (Client_capacity | Admission_capacity | Cascade_slot) -> false
+      | Some (Client_capacity | Tier_admission | Cascade_slot) -> false
       | None -> true
     in
     if not provider_owned_capacity

--- a/lib/keeper/keeper_turn_driver_try_cascade.ml
+++ b/lib/keeper/keeper_turn_driver_try_cascade.ml
@@ -54,7 +54,7 @@ type try_cascade_ctx =
     health_cooldown_fail_open : bool
   ; base_path : string option
   ; session_id : string option
-  ; admission_policy : Cascade_tier_admission.admission_policy
+  ; tier_admission_policy : Cascade_tier_admission.admission_policy
   ; (* Cascade accept predicate *)
     accept : Agent_sdk_response.api_response -> bool
   ; (* Error cascade name for backpressure *)
@@ -138,10 +138,10 @@ let emit_capacity_blocked_manifest ctx ~capacity_key =
     ~decision:(client_capacity_full_decision ~capacity_key)
     Keeper_runtime_manifest.Pre_dispatch_blocked
 
-let emit_admission_blocked_manifest ctx signal =
+let emit_tier_admission_blocked_manifest ctx signal =
   ctx.emit_runtime_manifest
     ~status:"blocked"
-    ~decision:(Keeper_turn_driver_admission.cascade_admission_blocked_decision signal)
+    ~decision:(Keeper_turn_driver_admission.cascade_tier_admission_blocked_decision signal)
     Keeper_runtime_manifest.Pre_dispatch_blocked
 
 let capacity_backpressure_of_http_error ctx ?source last_err =
@@ -382,7 +382,7 @@ let rec run
         ~pre_dispatch_required_tool_rejections_rev
         ?last_capacity_source ?last_capacity_backpressure ctx rest last_err)
     else
-    let admission_key = Cascade_runtime_candidate.admission_key candidate in
+    let tier_admission_id = Cascade_runtime_candidate.tier_id candidate in
     let health_cooldown =
       Cascade_runtime_candidate.first_health_cooldown candidate
     in
@@ -545,9 +545,9 @@ let rec run
         ~model_id:runtime_candidate_label ~latency_ms ~error
     in
     let attempt_with_admission =
-      Keeper_turn_driver_admission.with_keeper_cascade_admission
-        ~admission_key
-        ~admission_policy:ctx.admission_policy
+      Keeper_turn_driver_admission.with_keeper_cascade_tier_admission
+        ~tier_id:tier_admission_id
+        ~admission_policy:ctx.tier_admission_policy
         ?wait_timeout_sec:ctx.wait_timeout_sec
         (fun () ->
            Eio.Switch.run (fun provider_attempt_sw ->
@@ -719,27 +719,27 @@ let rec run
     match attempt_with_admission with
     | Error signal ->
       Keeper_turn_driver_admission.release_client_capacity_quietly capacity_release;
-      emit_admission_blocked_manifest ctx signal;
-      Keeper_turn_driver_admission.emit_cascade_admission_signal_metric
+      emit_tier_admission_blocked_manifest ctx signal;
+      Keeper_turn_driver_admission.emit_cascade_tier_admission_signal_metric
         ~cascade_name:ctx.cascade_name signal;
-      record_cascade_attempt ctx candidate ~outcome:(`Failure "admission_full") ();
+      record_cascade_attempt ctx candidate ~outcome:(`Failure "tier_admission_full") ();
       Cascade_observation.record_fallback_event ctx.capture
         ~from_model:runtime_candidate_label
         ~to_model:runtime_candidate_label
-        ~reason:"admission_full";
+        ~reason:"tier_admission_full";
       Log.Misc.info
-        "[cascade-fallback] cascade %s: %s skipped because admission \
+        "[cascade-fallback] cascade %s: %s skipped because tier admission \
          %s is full, trying next"
         ctx.cascade_name
         runtime_candidate_label
-        admission_key;
+        tier_admission_id;
       let capacity_detail =
-        Printf.sprintf "admission %s is full" admission_key
+        Printf.sprintf "tier admission %s is full" tier_admission_id
       in
       run ~on_success ?resume_checkpoint ?per_provider_timeout_s
         ~pre_dispatch_required_tool_rejections_rev
         ~last_capacity_backpressure:
-          (Admission_capacity, capacity_detail, Some Cascade_health_tracker_config.default_capacity_backpressure_backoff_sec)
+          (Tier_admission, capacity_detail, Some Cascade_health_tracker_config.default_capacity_backpressure_backoff_sec)
         ctx rest last_err
     | Ok (result, checkpoint_after, liveness_success_sample, attempt_latency_ms) ->
     let record_accepted_liveness_sample () =

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -54,7 +54,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     | None -> Option.value ~default:[] p.profile_defaults.active_goal_ids
   in
   let selected_cascade_name =
-    match p.cascade_name_opt, p.profile_defaults.cascade_name with
+    (* WORKAROUND (#19327 follow-up): cascade_name→model field rename. *)
+    match p.cascade_name_opt, p.profile_defaults.model with
     | Some name, _ -> name
     | None, Some name -> name
     | None, None -> Keeper_config.default_cascade_name ()

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -275,7 +275,8 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
          present; otherwise preserve the existing keeper's cascade_ref so
          dashboard drift remains visible.  See #6747. *)
       (let group =
-         match p.cascade_name_opt, p.profile_defaults.cascade_name with
+         (* WORKAROUND (#19327 follow-up): cascade_name→model field rename. *)
+         match p.cascade_name_opt, p.profile_defaults.model with
          | Some name, _ -> name
          | None, Some name -> name
          | None, None ->

--- a/lib/keeper/keeper_types_profile.mli
+++ b/lib/keeper/keeper_types_profile.mli
@@ -31,7 +31,6 @@ val ensure_dir : string -> string
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_cascade_name_opt : string option -> string option
 val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -41,7 +41,7 @@ type keeper_profile_defaults = {
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  cascade_name : string option;
+  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;

--- a/lib/keeper/keeper_types_profile_sandbox.ml
+++ b/lib/keeper/keeper_types_profile_sandbox.ml
@@ -45,6 +45,9 @@ let sandbox_profile_to_string profile =
   |> Keeper_sandbox_config.sandbox_profile_to_string
 ;;
 
+(* reserved_cascade_names removed: tier/tier-group purge.
+   Keeper profiles now use plain provider:model strings. *)
+
 (** Parse a sandbox profile string. Canonical values are ["local"] and
     ["docker"]. *)
 let sandbox_profile_of_string raw =

--- a/lib/keeper/keeper_types_profile_sandbox.mli
+++ b/lib/keeper/keeper_types_profile_sandbox.mli
@@ -15,7 +15,6 @@ type network_mode =
 [@@deriving tla]
 
 val sandbox_profile_to_string : sandbox_profile -> string
-val reserved_cascade_names : string list
 val sandbox_profile_of_string : string -> sandbox_profile option
 val all_sandbox_profiles : sandbox_profile list
 val valid_sandbox_profile_strings : string list

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -137,7 +137,6 @@ val is_terminal : network_mode -> bool
 val is_active : network_mode -> bool
 val is_idle : network_mode -> bool
 val sandbox_profile_to_string : sandbox_profile -> string
-val reserved_cascade_names : string list
 val sandbox_profile_of_string : string -> sandbox_profile option
 val all_sandbox_profiles : sandbox_profile list
 val valid_sandbox_profile_strings : string list
@@ -190,7 +189,7 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  cascade_name : string option;
+  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
@@ -213,7 +212,6 @@ val keeper_oas_context_of_defaults :
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_cascade_name_opt : string option -> string option
 val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -137,7 +137,6 @@ val is_terminal : network_mode -> bool
 val is_active : network_mode -> bool
 val is_idle : network_mode -> bool
 val sandbox_profile_to_string : sandbox_profile -> string
-val reserved_cascade_names : string list
 val sandbox_profile_of_string : string -> sandbox_profile option
 val all_sandbox_profiles : sandbox_profile list
 val valid_sandbox_profile_strings : string list
@@ -190,7 +189,7 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  cascade_name : string option;
+  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
@@ -213,7 +212,6 @@ val keeper_oas_context_of_defaults :
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_cascade_name_opt : string option -> string option
 val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list

--- a/lib/keeper/keeper_types_profile_toml_normalizers.ml
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.ml
@@ -33,6 +33,9 @@ let normalize_name_list_opt items =
   | [] -> None
   | xs -> Some xs
 
+(* normalize_cascade_name_opt removed: tier/tier-group purge.
+   Keeper profiles now use plain provider:model strings. *)
+
 let normalize_git_identity_mode_opt = function
   | None -> None
   | Some raw -> (

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -137,7 +137,6 @@ val is_terminal : network_mode -> bool
 val is_active : network_mode -> bool
 val is_idle : network_mode -> bool
 val sandbox_profile_to_string : sandbox_profile -> string
-val reserved_cascade_names : string list
 val sandbox_profile_of_string : string -> sandbox_profile option
 val all_sandbox_profiles : sandbox_profile list
 val valid_sandbox_profile_strings : string list
@@ -190,7 +189,7 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  cascade_name : string option;
+  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
@@ -213,7 +212,6 @@ val keeper_oas_context_of_defaults :
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_cascade_name_opt : string option -> string option
 val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -137,7 +137,6 @@ val is_terminal : network_mode -> bool
 val is_active : network_mode -> bool
 val is_idle : network_mode -> bool
 val sandbox_profile_to_string : sandbox_profile -> string
-val reserved_cascade_names : string list
 val sandbox_profile_of_string : string -> sandbox_profile option
 val all_sandbox_profiles : sandbox_profile list
 val valid_sandbox_profile_strings : string list
@@ -190,7 +189,7 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  cascade_name : string option;
+  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
@@ -213,7 +212,6 @@ val keeper_oas_context_of_defaults :
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_cascade_name_opt : string option -> string option
 val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list

--- a/lib/keeper/provider_error_class.ml
+++ b/lib/keeper/provider_error_class.ml
@@ -13,7 +13,7 @@ type response_timeout_kind =
 
 type t =
   | Client_capacity_exhausted
-  | Admission_exhausted of { capability_profile : string option }
+  | Tier_admission_exhausted of { capability_profile : string option }
   | Backpressure of
       { http_status : int
       ; retry_after_ms : int option
@@ -56,7 +56,7 @@ let response_timeout_kind_to_string = function
 
 let to_short_tag = function
   | Client_capacity_exhausted -> "client_capacity_exhausted"
-  | Admission_exhausted _ -> "admission_exhausted"
+  | Tier_admission_exhausted _ -> "tier_admission_exhausted"
   | Backpressure _ -> "backpressure"
   | Dns_resolution_failure _ -> "dns_resolution_failure"
   | Response_timeout _ -> "response_timeout"
@@ -66,7 +66,7 @@ let to_short_tag = function
 let raw_payload = function
   | Unspecified { raw_code; raw_detail } -> Some (raw_code, raw_detail)
   | Client_capacity_exhausted
-  | Admission_exhausted _
+  | Tier_admission_exhausted _
   | Backpressure _
   | Dns_resolution_failure _
   | Response_timeout _ -> None

--- a/lib/keeper/provider_error_class.mli
+++ b/lib/keeper/provider_error_class.mli
@@ -45,8 +45,8 @@ type t =
           our side, not the provider.  RFC-0042 / RFC-0058 territory.
           Reactor: pause new admission, drain in-flight. *)
   | Tier_admission_exhausted of { capability_profile : string option }
-      (** Cascade admission denied because every model in the strict
-          capability profile is saturated or unavailable.
+      (** Cascade tier-group admission denied because every model in
+          the strict capability profile is saturated or unavailable.
           [capability_profile] is the canonical profile name (e.g.
           [Some "strict_tool_candidates"]) when the adapter can
           attribute the denial to a specific profile, [None]

--- a/lib/server/server_routes_http_routes_dashboard.mli
+++ b/lib/server/server_routes_http_routes_dashboard.mli
@@ -12,8 +12,9 @@ val add_routes :
   Http_server_eio.Router.t -> Http_server_eio.Router.t
 
 val available_cascade_profiles : unit -> string list
-(** Snapshot of cascade profiles currently considered valid by the
-    runtime gate. Recomputed on each call. *)
+(** Snapshot of qualified cascade profiles currently considered valid by the
+    runtime gate, such as ["tier.primary"] or ["tier-group.primary"].
+    Recomputed on each call. *)
 
 val invalid_cascade_profiles : unit -> (string * string list) list
 (** Snapshot of [(profile_name, violations)] pairs for cascade

--- a/test/test_admission_queue_coverage.ml
+++ b/test/test_admission_queue_coverage.ml
@@ -9,11 +9,8 @@ open Alcotest
 
 module AQ = Masc_mcp.Admission_queue
 
-let cascade_name raw =
-  let canonical =
-    if Cascade_name.is_canonical_prefix raw then raw else "route." ^ raw
-  in
-  Cascade_name.of_string_exn canonical
+(* #19327 tier-group purge: Cascade_name is a plain string alias now. *)
+let cascade_name raw = Cascade_name.of_string_exn raw
 
 (* ============================================================
    Passthrough Contract

--- a/test/test_cascade_config_validity.ml
+++ b/test/test_cascade_config_validity.ml
@@ -105,83 +105,15 @@ let test_cascade_json_absent () =
   check bool "config/cascade.json absent" false (Sys.file_exists (config_path "cascade.json"))
 ;;
 
-let find_tier_group cfg name =
-  cfg.Types.tier_groups
-  |> List.find_opt (fun (group : Types.cascade_tier_group) ->
-    String.equal group.name name)
-;;
-
-let find_tier cfg name =
-  cfg.Types.tiers
-  |> List.find_opt (fun (tier : Types.cascade_tier) ->
-    String.equal tier.name name)
-;;
-
-let index_of value values =
-  let rec loop index = function
-    | [] -> None
-    | candidate :: rest ->
-      if String.equal candidate value then Some index else loop (index + 1) rest
-  in
-  loop 0 values
-;;
-
-let test_ollama_cloud_stable_is_system_only () =
-  let cfg = load_checked_in_cascade_toml () in
-  match find_tier_group cfg "ollama_cloud_stable" with
-  | None -> fail "missing tier-group.ollama_cloud_stable"
-  | Some group ->
-    check
-      (option bool)
-      "ollama_cloud_stable keeper-assignable"
-      (Some false)
-      group.keeper_assignable
-;;
-
-let test_strict_tool_group_does_not_bypass_glm_before_ollama_cloud () =
-  let cfg = load_checked_in_cascade_toml () in
-  match find_tier_group cfg "strict_tool_candidates" with
-  | None -> fail "missing tier-group.strict_tool_candidates"
-  | Some group ->
-    (match index_of "ollama_cloud_stable" group.tiers with
-     | None -> ()
-     | Some cloud_index ->
-       (match index_of "provider_k-coding-with-spark" group.tiers with
-        | Some glm_index when glm_index < cloud_index -> ()
-        | Some _ ->
-          fail
-            "strict_tool_candidates must try provider_k-coding-with-spark before \
-             ollama_cloud_stable"
-        | None ->
-          fail
-            "strict_tool_candidates must not include ollama_cloud_stable without \
-             provider_k-coding-with-spark ahead of it"))
-;;
-
-let test_no_deprecated_profile_names () =
-  let cfg = load_checked_in_cascade_toml () in
-  let deprecated_tiers =
-    cfg.Types.tiers
-    |> List.filter_map (fun (tier : Types.cascade_tier) ->
-      if Masc_mcp.Cascade_config_loader.is_deprecated_logical_profile_name tier.name
-      then Some ("tier." ^ tier.name)
-      else None)
-  in
-  let deprecated_groups =
-    cfg.Types.tier_groups
-    |> List.filter_map (fun (group : Types.cascade_tier_group) ->
-      if
-        Masc_mcp.Cascade_config_loader.is_deprecated_logical_profile_name
-          group.name
-      then Some ("tier-group." ^ group.name)
-      else None)
-  in
-  check
-    string
-    "deprecated tier/tier-group names"
-    ""
-    (String.concat ", " (deprecated_tiers @ deprecated_groups))
-;;
+(* #19327 tier-group purge: tier/tier_groups removed from cascade_config.
+   The tier-group-specific helpers (find_tier_group / find_tier / index_of)
+   and the four tests that exercised them
+   (ollama_cloud_stable_is_system_only,
+    strict_tool_group_does_not_bypass_glm_before_ollama_cloud,
+    no_deprecated_profile_names, primary_priority_order)
+   have been removed.  If equivalent invariants are still desired against
+   the new direct-binding cascade.toml schema, a separate test file should
+   cover them. *)
 
 let check_qwen_thinking_control cfg model_id =
   match Types.model_capabilities_for_id cfg model_id with
@@ -203,24 +135,6 @@ let test_qwen_models_use_chat_template_kwargs () =
   check_qwen_thinking_control cfg "qwen3-5"
 ;;
 
-let test_primary_priority_order () =
-  let cfg = load_checked_in_cascade_toml () in
-  match find_tier cfg "primary" with
-  | None -> fail "missing tier.primary"
-  | Some tier ->
-    check
-      (list string)
-      "primary priority"
-      [
-        "runpod_mtp.qwen-runpod.keeper";
-        "local_mtp.qwen-local.keeper";
-        "glm-coding.glm-5-turbo";
-        "glm-coding.glm-flashx";
-        "cli_tool_a.codex-spark.for-keeper-turn";
-      ]
-      tier.members
-;;
-
 let () =
   run
     "cascade config validity"
@@ -232,25 +146,9 @@ let () =
             test_cascade_toml_runtime_validates_without_rejected_profiles
         ; test_case "cascade.json is not a checked-in source" `Quick test_cascade_json_absent
         ; test_case
-            "ollama_cloud_stable is system-only"
-            `Quick
-            test_ollama_cloud_stable_is_system_only
-        ; test_case
-            "strict tool group does not bypass GLM before Ollama Cloud"
-            `Quick
-            test_strict_tool_group_does_not_bypass_glm_before_ollama_cloud
-        ; test_case
-            "cascade.toml has no deprecated profile names"
-            `Quick
-            test_no_deprecated_profile_names
-        ; test_case
             "provider_h models use chat_template_kwargs thinking control"
             `Quick
             test_qwen_models_use_chat_template_kwargs
-        ; test_case
-            "primary tier follows operator priority"
-            `Quick
-            test_primary_priority_order
         ] )
     ]
 ;;

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -658,18 +658,7 @@ let test_alias_parent_missing () =
           ; thinking_budget = None
           }
         ]
-    ; tiers =
-        [ { name = "t"
-          ; members = [ "x.m.a" ]
-          ; strategy = Failover
-          ; max_concurrent = None
-          ; cycle_policy = None
-          ; sticky_ttl_ms = None
-          ; scoring_params = None
-          ; keeper_assignable = None
-          }
-        ]
-    ; tier_groups = []
+    (* #19327: tier/tier_groups fields removed from cascade_config. *)
     ; routes = []
     ; system_targets = []
     ; profiles = []
@@ -855,18 +844,7 @@ let test_duplicate_routes () =
           }
         ]
     ; aliases = []
-    ; tiers =
-        [ { name = "primary"
-          ; members = [ "cli_tool_d.haiku" ]
-          ; strategy = Failover
-          ; max_concurrent = None
-          ; cycle_policy = None
-          ; sticky_ttl_ms = None
-          ; scoring_params = None
-          ; keeper_assignable = None
-          }
-        ]
-    ; tier_groups = []
+    (* #19327: tier/tier_groups fields removed from cascade_config. *)
     ; routes =
         [ { name = "dup"; target = "tier.primary" }
         ; { name = "dup"; target = "tier.primary" }

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -829,8 +829,8 @@ let test_partial_snapshot_errors_disjoint_from_profile_names () =
               | Adapter.Provider_not_found s
               | Adapter.Model_not_found s
               | Adapter.Binding_resolution_failed s
-              | Adapter.Alias_resolution_failed s
-              | Adapter.Tier_group_empty s -> Some s
+              | Adapter.Alias_resolution_failed s -> Some s
+              (* #19327: Tier_group_empty constructor removed. *)
               | Adapter.Strategy_mismatch _
               | Adapter.Duplicate_route _
               | Adapter.Internal _ -> None)

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -146,8 +146,7 @@ let test_minimal_parse () =
   check int "models" 1 (List.length cfg.models);
   check int "bindings" 1 (List.length cfg.bindings);
   check int "aliases" 0 (List.length cfg.aliases);
-  check int "tiers" 0 (List.length cfg.tiers);
-  check int "tier_groups" 0 (List.length cfg.tier_groups);
+  (* #19327: tier/tier_groups fields removed from cascade_config. *)
   check int "routes" 0 (List.length cfg.routes);
   check int "system_targets" 0 (List.length cfg.system_targets)
 ;;
@@ -225,65 +224,9 @@ let test_layer4_aliases () =
   | None -> failwith "missing governance alias"
 ;;
 
-let test_layer5_tiers () =
-  let cfg = ok_config (parse_string full_toml) in
-  check int "tiers" 3 (List.length cfg.tiers);
-  (match List.find_opt (fun (t : cascade_tier) -> t.name = "rerank") cfg.tiers with
-   | Some t ->
-     check
-       (list string)
-       "rerank members"
-       [ "agent_llm_a-code.haiku.for-scoring" ]
-       t.members;
-     check (option bool) "rerank keeper_assignable" (Some false)
-       t.keeper_assignable;
-     check
-       string
-       "rerank strategy"
-       "Cascade_declarative_types.Failover"
-       (show_cascade_strategy t.strategy)
-   | None -> failwith "missing rerank tier");
-  match List.find_opt (fun (t : cascade_tier) -> t.name = "primary") cfg.tiers with
-  | Some t ->
-    check
-      (list string)
-      "primary members"
-      [ "agent_llm_a-code.sonnet"; "agent_llm_a-code.haiku" ]
-      t.members;
-    check opt_int "primary max_concurrent" (Some 5) t.max_concurrent
-  | None -> failwith "missing primary tier"
-;;
-
-let test_layer5_tier_groups () =
-  let cfg = ok_config (parse_string full_toml) in
-  check int "tier_groups" 1 (List.length cfg.tier_groups);
-  match
-    List.find_opt (fun (g : cascade_tier_group) -> g.name = "primary") cfg.tier_groups
-  with
-  | Some g ->
-    check (list string) "tiers" [ "primary"; "local" ] g.tiers;
-    check bool "fallback" true g.fallback;
-    check (option bool) "keeper_assignable" (Some true) g.keeper_assignable;
-    check
-      string
-      "strategy"
-      "Cascade_declarative_types.Priority_tier"
-      (show_cascade_strategy g.strategy)
-  | None -> failwith "missing primary tier group"
-;;
-
-let test_keeper_assignable_duplicate_keys_rejected () =
-  let toml =
-    {|
-[tier.t]
-members = []
-keeper-assignable = true
-keeper_assignable = false
-|}
-  in
-  let errs = is_error (parse_string toml) in
-  has_error_at "tier.t.keeper-assignable" errs
-;;
+(* #19327 tier-group purge: test_layer5_tiers, test_layer5_tier_groups,
+   test_keeper_assignable_duplicate_keys_rejected removed.  All asserted
+   tier/tier-group parsing fields that no longer exist. *)
 
 let test_routes () =
   let cfg = ok_config (parse_string full_toml) in
@@ -516,273 +459,16 @@ let test_api_format_of_protocol () =
   check bool "unknown" true (api_format_of_protocol "unknown" |> Result.is_error)
 ;;
 
-let test_supported_config_strategies_parse () =
-  let strategies =
-    [ "failover", Failover
-    ; "priority_tier", Priority_tier
-    ]
-  in
-  List.iter
-    (fun (name, expected) ->
-       let toml =
-         Printf.sprintf
-           {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
+(* #19327 tier-group purge: test_supported_config_strategies_parse and
+   test_retired_config_strategies_rejected removed.  Both asserted parser
+   behavior on [tier.*] sections; Priority_tier strategy variant and
+   cfg.tiers field no longer exist.  Only [Failover] remains as a
+   cascade_strategy. *)
 
-[models.m]
-max-context = 4096
 
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "%s"
-|}
-           name
-       in
-       let cfg = ok_config (parse_string toml) in
-       match cfg.tiers with
-       | [ t ] ->
-         check
-           string
-           (name ^ " strategy")
-           (show_cascade_strategy expected)
-           (show_cascade_strategy t.strategy)
-       | _ -> failwith "expected exactly one tier")
-    strategies
-;;
-
-let test_retired_config_strategies_rejected () =
-  let retired =
-    [
-      "capacity_aware";
-      "weighted_random";
-      "circuit_breaker_cycling";
-      "sticky";
-      "round_robin";
-    ]
-  in
-  List.iter
-    (fun name ->
-       let toml =
-         Printf.sprintf
-           {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "%s"
-|}
-           name
-       in
-       match parse_string toml with
-       | Ok _ -> failwith ("expected retired strategy rejection: " ^ name)
-       | Error errs -> has_error_at "tier.t.strategy" errs)
-    retired
-;;
-
-(* --- Strategy-specific field tests --- *)
-
-let test_cycle_policy () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-max-cycles = 3
-backoff-base-ms = 500
-backoff-cap-ms = 10000
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] ->
-    (match t.cycle_policy with
-     | Some cp ->
-       check int "max_cycles" 3 cp.max_cycles;
-       check int "backoff_base_ms" 500 cp.backoff_base_ms;
-       check int "backoff_cap_ms" 10000 cp.backoff_cap_ms
-     | None -> failwith "expected cycle_policy")
-  | _ -> failwith "expected exactly one tier"
-;;
-
-let test_cycle_policy_absent () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] -> check bool "no cycle_policy" true (t.cycle_policy = None)
-  | _ -> failwith "expected exactly one tier"
-;;
-
-let test_cycle_policy_partial_ignored () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-max-cycles = 3
-backoff-base-ms = 500
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] -> check bool "partial yields None" true (t.cycle_policy = None)
-  | _ -> failwith "expected exactly one tier"
-;;
-
-let test_sticky_ttl_ms () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-sticky-ttl-ms = 600000
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] -> check opt_int "sticky_ttl_ms" (Some 600000) t.sticky_ttl_ms
-  | _ -> failwith "expected exactly one tier"
-;;
-
-let test_sticky_ttl_ms_absent () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] -> check opt_int "no sticky_ttl_ms" None t.sticky_ttl_ms
-  | _ -> failwith "expected exactly one tier"
-;;
-
-let test_scoring_params () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-latency-baseline-ms = 200.0
-rate-limit-recency-window-s = 60.0
-rate-limit-decay-base = 0.5
-rate-limit-skip-after = 3
-server-error-recency-window-s = 120.0
-server-error-decay-base = 0.3
-server-error-skip-after = 5
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] ->
-    (match t.scoring_params with
-     | Some sp ->
-       check float_testable "latency_baseline" 200.0 sp.latency_baseline_ms;
-       check float_testable "rl_recency" 60.0 sp.rate_limit_recency_window_s;
-       check float_testable "rl_decay" 0.5 sp.rate_limit_decay_base;
-       check int "rl_skip" 3 sp.rate_limit_skip_after;
-       check float_testable "se_recency" 120.0 sp.server_error_recency_window_s;
-       check float_testable "se_decay" 0.3 sp.server_error_decay_base;
-       check int "se_skip" 5 sp.server_error_skip_after
-     | None -> failwith "expected scoring_params")
-  | _ -> failwith "expected exactly one tier"
-;;
-
-let test_scoring_params_partial_ignored () =
-  let toml =
-    {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-latency-baseline-ms = 200.0
-rate-limit-recency-window-s = 60.0
-|}
-  in
-  let cfg = ok_config (parse_string toml) in
-  match cfg.tiers with
-  | [ t ] -> check bool "partial scoring yields None" true (t.scoring_params = None)
-  | _ -> failwith "expected exactly one tier"
-;;
+(* #19327 tier-group purge: Strategy-specific field tests removed
+   (cycle_policy / sticky_ttl_ms / scoring_params).  All exercised
+   cfg.tiers field that no longer exists. *)
 
 (* --- Capabilities tests (#14608 tool/event fields + RFC-0058 §2.4 Phase 5.1 dispatch fields) --- *)
 
@@ -1563,14 +1249,7 @@ let () =
     ; "layer2_models", [ test_case "model specs" `Quick test_layer2_models ]
     ; "layer3_bindings", [ test_case "bindings" `Quick test_layer3_bindings ]
     ; "layer4_aliases", [ test_case "aliases" `Quick test_layer4_aliases ]
-    ; ( "layer5_tiers"
-      , [ test_case "tiers" `Quick test_layer5_tiers
-        ; test_case "tier groups" `Quick test_layer5_tier_groups
-        ; test_case
-            "duplicate keeper assignability keys rejected"
-            `Quick
-            test_keeper_assignable_duplicate_keys_rejected
-        ] )
+    (* #19327: layer5_tiers test group removed. *)
     ; ( "routes"
       , [ test_case "routes" `Quick test_routes
         ; test_case "system targets" `Quick test_system_targets
@@ -1595,25 +1274,8 @@ let () =
         ; test_case "key formatters" `Quick test_key_formatters
         ; test_case "api_format_of_protocol" `Quick test_api_format_of_protocol
         ] )
-    ; ( "strategies"
-      , [ test_case "supported strategies parse" `Quick
-            test_supported_config_strategies_parse
-        ; test_case "retired strategies rejected" `Quick
-            test_retired_config_strategies_rejected
-        ] )
-    ; ( "cycle_policy"
-      , [ test_case "parses all-or-nothing" `Quick test_cycle_policy
-        ; test_case "absent yields None" `Quick test_cycle_policy_absent
-        ; test_case "partial yields None" `Quick test_cycle_policy_partial_ignored
-        ] )
-    ; ( "sticky_ttl"
-      , [ test_case "parses sticky-ttl-ms" `Quick test_sticky_ttl_ms
-        ; test_case "absent yields None" `Quick test_sticky_ttl_ms_absent
-        ] )
-    ; ( "scoring_params"
-      , [ test_case "parses all 7 fields" `Quick test_scoring_params
-        ; test_case "partial yields None" `Quick test_scoring_params_partial_ignored
-        ] )
+    (* #19327: strategies / cycle_policy / sticky_ttl / scoring_params
+       test groups removed. *)
     ; ( "capabilities"
       , [ test_case "present parses with defaults" `Quick test_capabilities_present
         ; test_case "absent yields None" `Quick test_capabilities_absent

--- a/test/test_cascade_declarative_validator.ml
+++ b/test/test_cascade_declarative_validator.ml
@@ -160,8 +160,7 @@ let test_r3_unknown_binding () =
       thinking_enabled = None;
       thinking_budget = None;
     }];
-    tiers = [];
-    tier_groups = [];
+    (* #19327: tier/tier_groups fields removed from cascade_config. *)
     routes = [];
     system_targets = [];
     profiles = [];

--- a/test/test_cascade_name.ml
+++ b/test/test_cascade_name.ml
@@ -1,42 +1,25 @@
-(** RFC-0163 Phase A: Cascade_name.t unit tests.
+(** Cascade_name.t unit tests.
 
-    Validates the canonical-prefix enforcement that replaces the
-    auto-normalize bypass in [cascade_catalog_runtime_resolve.ml]. *)
+    Post-#19327 (tier/tier-group purge): Cascade_name is a plain string
+    alias.  The prior canonical-prefix enforcement (tier./tier-group./route.)
+    is no longer present, so the cases that previously asserted
+    [Error `Invalid_prefix] now succeed.  [`Invalid_prefix] is retained
+    in the variant for source compatibility but is no longer emitted. *)
 
 open Alcotest
 
 module CN = Cascade_name
 
-(* ── Valid parse tests ─────────────────────────────────────────── *)
-
-let test_tier_group_prefix () =
-  match CN.of_string "tier-group.strict_tool_candidates" with
+let test_round_trip () =
+  match CN.of_string "runpod:glm-coding-with-spark" with
   | Ok t ->
-    check string "round-trip" "tier-group.strict_tool_candidates" (CN.to_string t)
-  | Error _ -> fail "expected Ok for tier-group prefix"
-
-let test_tier_prefix () =
-  match CN.of_string "tier.primary" with
-  | Ok t -> check string "round-trip" "tier.primary" (CN.to_string t)
-  | Error _ -> fail "expected Ok for tier prefix"
-
-let test_route_prefix () =
-  match CN.of_string "route.default" with
-  | Ok t -> check string "round-trip" "route.default" (CN.to_string t)
-  | Error _ -> fail "expected Ok for route prefix"
+    check string "round-trip" "runpod:glm-coding-with-spark" (CN.to_string t)
+  | Error _ -> fail "expected Ok for plain provider:model"
 
 let test_whitespace_trimmed () =
-  match CN.of_string "  tier-group.x  " with
-  | Ok t -> check string "round-trip" "tier-group.x" (CN.to_string t)
+  match CN.of_string "  provider:model  " with
+  | Ok t -> check string "trimmed" "provider:model" (CN.to_string t)
   | Error _ -> fail "expected Ok after trimming"
-
-(* ── Invalid parse tests ───────────────────────────────────────── *)
-
-let test_bare_short_form () =
-  match CN.of_string "strict_tool_candidates" with
-  | Ok _ -> fail "expected Error for bare short form"
-  | Error `Invalid_prefix -> ()
-  | Error `Empty -> fail "expected Invalid_prefix, got Empty"
 
 let test_empty_string () =
   match CN.of_string "" with
@@ -50,40 +33,19 @@ let test_whitespace_only () =
   | Error `Empty -> ()
   | Error `Invalid_prefix -> fail "expected Empty, got Invalid_prefix"
 
-let test_unknown_prefix () =
-  match CN.of_string "group.something" with
-  | Ok _ -> fail "expected Error for unknown prefix"
-  | Error `Invalid_prefix -> ()
-  | Error `Empty -> fail "expected Invalid_prefix, got Empty"
-
-(* ── of_string_exn tests ──────────────────────────────────────── *)
-
 let test_of_string_exn_ok () =
-  check string "exn round-trip" "tier-group.x" (CN.to_string (CN.of_string_exn "tier-group.x"))
-
-let test_is_canonical_prefix () =
-  check bool "tier-group. is canonical" true (CN.is_canonical_prefix "tier-group.x");
-  check bool "tier. is canonical" true (CN.is_canonical_prefix "tier.x");
-  check bool "route. is canonical" true (CN.is_canonical_prefix "route.x");
-  check bool "bare is not canonical" false (CN.is_canonical_prefix "x");
-  check bool "empty is not canonical" false (CN.is_canonical_prefix "")
+  check string "exn round-trip" "x" (CN.to_string (CN.of_string_exn "x"))
 
 let () =
   Alcotest.run "cascade_name"
     [ ( "valid"
-      , [ test_case "tier-group prefix" `Quick test_tier_group_prefix
-        ; test_case "tier prefix" `Quick test_tier_prefix
-        ; test_case "route prefix" `Quick test_route_prefix
+      , [ test_case "round-trip" `Quick test_round_trip
         ; test_case "whitespace trimmed" `Quick test_whitespace_trimmed
         ] )
     ; ( "invalid"
-      , [ test_case "bare short form" `Quick test_bare_short_form
-        ; test_case "empty string" `Quick test_empty_string
+      , [ test_case "empty string" `Quick test_empty_string
         ; test_case "whitespace only" `Quick test_whitespace_only
-        ; test_case "unknown prefix" `Quick test_unknown_prefix
         ] )
-    ; ( "exn_and_helpers"
-      , [ test_case "of_string_exn ok" `Quick test_of_string_exn_ok
-        ; test_case "is_canonical_prefix" `Quick test_is_canonical_prefix
-        ] )
+    ; ( "exn"
+      , [ test_case "of_string_exn ok" `Quick test_of_string_exn_ok ] )
     ]

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -21,14 +21,9 @@ module Owne = Masc_mcp.Keeper_turn_driver
 module KT = Masc_mcp.Keeper_types
 module Retry = Llm_provider.Retry
 
-let cascade_name raw =
-  let trimmed = String.trim raw in
-  let canonical =
-    if Cascade_name.is_canonical_prefix trimmed
-    then trimmed
-    else "tier-group." ^ trimmed
-  in
-  Cascade_name.of_string_exn canonical
+(* #19327 tier-group purge: Cascade_name is a plain string alias now;
+   the prefix canonicalization this helper used to do is no longer needed. *)
+let cascade_name raw = Cascade_name.of_string_exn (String.trim raw)
 ;;
 
 let test_cascade = cascade_name "tier.test_cascade"
@@ -471,15 +466,10 @@ let test_rotation_finds_next_cascade_for_auth_error () =
 
 (* ---- Bare-name requalification tests (cascade-name-prefix-mismatch fix) ---- *)
 
-let test_normalized_cascade_name_requalifies_bare_tier_name () =
-  let catalog_names = [ "strict_tool_candidates"; "primary"; "coding_with_spark" ] in
-  let result =
-    KEC.normalized_cascade_name ~catalog_names "strict_tool_candidates"
-  in
-  check bool "result has canonical prefix" true
-    (Cascade_name.is_canonical_prefix result);
-  check string "result is tier-qualified"
-    "tier.strict_tool_candidates" result
+(* #19327 tier-group purge: test_normalized_cascade_name_requalifies_bare_tier_name
+   removed.  It asserted that bare "strict_tool_candidates" was rewritten to
+   "tier.strict_tool_candidates" using the tier-prefix canonical form; that
+   prefix layer is gone. *)
 
 let test_normalized_cascade_name_passes_through_already_qualified () =
   let catalog_names = [ "strict_tool_candidates"; "primary" ] in
@@ -572,8 +562,7 @@ let () =
         ] );
       ( "normalized_cascade_name_bare_requalify",
         [
-          test_case "bare tier name requalified with prefix" `Quick
-            test_normalized_cascade_name_requalifies_bare_tier_name;
+          (* #19327: "bare tier name requalified with prefix" test removed. *)
           test_case "already-qualified name passes through" `Quick
             test_normalized_cascade_name_passes_through_already_qualified;
           test_case "config special names preserved" `Quick

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -689,8 +689,9 @@ preset = "delivery"
       | Error e -> fail e
       | Ok (name, defaults) ->
           check string "name from filename" "sangsu" name;
+          (* #19327: field renamed cascade_name→model. *)
           check (option string) "base cascade" (Some "route.keeper_turn")
-            defaults.cascade_name;
+            defaults.model;
           check (option string) "base sandbox" (Some "docker")
             (Option.map KTP.sandbox_profile_to_string defaults.sandbox_profile);
           check (option string) "base network" (Some "inherit")

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -28,14 +28,10 @@ module Keeper_fs = Masc_mcp.Keeper_fs
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_types_support = Masc_mcp.Keeper_types_support
 
+(* #19327 tier-group purge: Cascade_name is a plain string alias now. *)
 let oas_error_cascade_name raw =
-  let normalized = Masc_mcp.Keeper_cascade_profile.normalize_declared_name raw in
-  let canonical =
-    if Cascade_name.is_canonical_prefix normalized
-    then normalized
-    else "tier-group." ^ normalized
-  in
-  Cascade_name.of_string_exn canonical
+  Masc_mcp.Keeper_cascade_profile.normalize_declared_name raw
+  |> Cascade_name.of_string_exn
 ;;
 
 let phase_buffer_cascade_name () =


### PR DESCRIPTION
## Summary

**Stacked PR**: reverts [#19340 refactor(cascade, keeper): purge dead tier/tier-group and phonebook code](https://github.com/jeong-sik/masc-mcp/pull/19340) and applies #19342's `.mli`/test sync on top.  Result: `dune build .` PASS against current main.

```
ba13ffd22 fix(cascade): repair .mli + test drift left by #19327 tier-group purge   (= #19342)
1ddf30224 Revert "refactor(cascade, keeper): purge dead tier/tier-group and phonebook code (#19340)"
de58dae2d fix(shell-ir): make all parsers tolerant of unknown flags (#19333)        (main HEAD)
```

## Why revert #19340

`#19340` was merged on 2026-05-28 with `Build and Test` / `Lint` / `Health` / `CI Gate` / `TLA+ Model Checking` reported as **CANCELLED** behind the `Detect Changed Surfaces` gate.  Verified locally on `origin/main` HEAD `de58dae2d` (post-`#19340`):

```
$ dune build .
Error: dependency cycle between modules in _build/default/lib:
   Worker_runtime → Worker_container → Cascade_config → Cascade_config_resolve →
   Cascade_routes → Cascade_catalog_runtime → Cascade_catalog_runtime_named_providers →
   Cascade_catalog_runtime_resolve → Cascade_catalog_runtime_validate → Cascade_routes
```

Plus 5 stale `.mli` / 11 stale tests:

- `lib/cascade/cascade_internal_error.mli` — `Tier_admission` (renamed to `Admission_capacity` in `.ml`)
- `lib/keeper/keeper_health_probe.mli` — `Tier_admission_full` (renamed to `Admission_full`)
- `lib/keeper/provider_error_class.mli` — `Tier_admission_exhausted` (renamed to `Admission_exhausted`)
- `lib/keeper/keeper_turn_driver.mli` — `For_testing.cascade_tier_admission_policy_of_priority` / `with_cascade_tier_admission_for_testing` (renamed without the `tier_` segment)
- `lib/cascade/cascade_declarative_adapter.mli` — still has `Tier_group_empty` constructor that `.ml` removed
- 5 test files reference removed modules `Cascade_phonebook_types` / `Cascade_routing_policy`
- 4 test files use `~tier_id` / `tier_id` field that was renamed to `~admission_key`
- `test_provider_error_class.ml` uses `P.Tier_admission_exhausted`

The dependency cycle (`Cascade_routes:218` ↔ `Cascade_catalog_runtime_validate:281,406-420`) is **structural** — facade bypass cannot remove it.  Resolving it requires dependency injection or moving one of the two cross-calls into a higher layer.  That is an architecture decision the original author of `#19340` should make, not a follow-up PR.

`#19340`'s underlying refactor (purging dead tier/tier-group and phonebook code) is a desirable cleanup; we just need a version that actually builds.  Recommended path:

1. **Merge this PR** to unbreak main.
2. The `#19340` author re-submits the cleanup as a Draft PR, lets `Build and Test` actually run (`Detect Changed Surfaces` gate likely needs to be widened so cascade/keeper refactors are not classified as "no relevant surface change" — this is now the **second** two-strikes-in-24-hours incident; see `memory/reference_masc_mcp_ci_build_test_skips.md`).
3. New PR resolves the cycle, syncs `.mli`, migrates tests, then merges.

## Commits

### 1. `Revert "refactor(cascade, keeper): purge dead tier/tier-group and phonebook code (#19340)"`

`git revert` of squash-merge commit `7bd648db0`.  66 files, +1661/-304 (mirror of #19340).  No manual edits.

### 2. `fix(cascade): repair .mli + test drift left by #19327 tier-group purge`

Identical to PR [#19342](https://github.com/jeong-sik/masc-mcp/pull/19342), cherry-picked onto the revert.  One mechanical fix on top: re-apply the `Tier_group_empty` removal from `cascade_declarative_adapter.mli` (the original PR's rebase had auto-resolved this against #19340's broader removal of both `Strategy_mismatch` and `Tier_group_empty`; without #19340 in the base, only `Tier_group_empty` needs removing here).

See [#19342's body](https://github.com/jeong-sik/masc-mcp/pull/19342) for the full per-file breakdown of the `.mli` sync / consumer rewrite / test migration scope.

## Verification

- `dune build .` PASSES against this branch
- `pr-rfc-check.sh` PASS
- `#19342` should be closed in favor of this PR if this PR is merged

## Process notes

This is the second time in 24 hours that a cascade-area refactor reached main with the CI build gate skipped (#19327 yesterday 17:50 KST, #19340 today ~21:27 KST).  Memory entry `feedback_baseline_paired_update_missed.md` records a related "paired-update missed" pattern.  Recommend (a) widening `Detect Changed Surfaces`'s blast-radius computation for `lib/cascade/` and `lib/keeper/` paths, (b) removing the skip-on-no-changed-surface optimization for `Build and Test` specifically, or (c) requiring an explicit `SKIP-BUILD-GATE:` label in the PR body when the gate skips for cascade-area diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
