### PR TITLE
fix(cascade): reclassify HTTP 524 as transient for cascade failover

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -45,15 +45,12 @@ let is_transient_network_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Api (Overloaded _) -> true
   | Agent_sdk.Error.Api (ServerError { status = 503; _ }) -> true
   (* Cloudflare 52x timeout family — origin server unreachable or
-     slow to respond.
-     522 = Connection timed out (TCP handshake failed).
-     524 = A timeout occurred after the origin accepted the request; keep it
-     out of the same-cascade transient retry path so it can short-circuit into
-     the degraded cascade rotation server_error path instead. *)
+     slow to respond. Both are transient: a different provider may succeed
+     where one origin timed out, so the cascade should advance. *)
   | Agent_sdk.Error.Api (ServerError { status = 522; _ }) -> true
-  | Agent_sdk.Error.Api (ServerError { status = 524; _ }) -> false
+  | Agent_sdk.Error.Api (ServerError { status = 524; _ }) -> true
   | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code = 524; _ }) ->
-      false
+      true
   | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { transient; _ }) ->
       transient
   (* Non-transient API errors. *)

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -156,7 +156,7 @@ module Http_client = struct
         when List.mem code [ 400; 422 ] && is_http_body_parse_error body ->
           Provider_parse_error
       | Llm_provider.Http_client.HttpError { code; _ } ->
-          if List.mem code Llm_provider.Constants.Http.cascadable_codes then
+          if List.mem code Llm_provider.Constants.Http.cascadable_codes || code = 524 then
             Transient_http code
           else
             Terminal_http code

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -359,12 +359,14 @@ let test_server_error_502_is_recoverable () =
   | None ->
     fail "ServerError 502 should be recoverable (trigger cascade rotation)"
 
-let test_server_error_524_is_capacity_backpressure_rotation_not_transient_retry () =
+let test_server_error_524_is_transient_network_error_and_cascade_rotation () =
   let err =
     Agent_sdk.Error.Api
       (Retry.ServerError { status = 524; message = "a timeout occurred" })
   in
-  check bool "524 not same-cascade transient" false (KEC.is_transient_network_error err);
+  (* 524 is transient: a different provider may succeed where one origin
+     timed out, so the cascade should advance. *)
+  check bool "524 is transient network error" true (KEC.is_transient_network_error err);
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
     check string "524 -> capacity_backpressure" "capacity_backpressure"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -11497,12 +11497,12 @@ let () =
                        { status = 522
                        ; message = "Connection timed out"
                        }))))
-        ; test_case "ServerError 524 short-circuits same-cascade transient retry" `Quick
+        ; test_case "ServerError 524 advances cascade to next provider" `Quick
           (fun () ->
             check
               bool
-              "524 cloudflare timeout is not same-cascade transient"
-              false
+              "524 cloudflare timeout is transient — advances cascade"
+              true
               (EC.is_transient_network_error
                  (Agent_sdk.Error.Api
                     (ServerError


### PR DESCRIPTION
## Problem

Cloudflare 524 (origin timeout) was classified as Terminal_http, which stops cascade failover immediately. When a provider returns 524, the keeper gave up instead of trying the next provider.

This means a single slow provider (e.g., RunPod under load) could terminate the entire turn with Cascade_exhausted, even when other providers in the cascade were healthy.

## Changes

- lib/oas_compat/oas_compat.ml: add || code = 524 to cascadable_codes check, reclassifying 524 as Transient_http (enables cascade advance)
- lib/keeper/keeper_error_classify.ml: change 524 from false to true in is_transient_network_error, with updated comment explaining the rationale
- test/test_keeper_error_classify_recoverable.ml: update test name and assertion to match new semantics
- test/test_keeper_unified.ml: update test name and assertion

## Rationale

524 = Cloudflare A timeout occurred — the origin server was reachable but too slow to respond. This is transient infrastructure behavior: a different provider may succeed where one origin timed out. The cascade should advance, not stop.

## Local Build Note

Local dune build @check is blocked by pre-existing build errors from the tier/tier-group removal refactor (#19340), unrelated to this change. The 4 files touched by this PR compile successfully.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>