### PR TITLE
fix(githooks): path-scoped skip for docs/asset-only pre-commit (closes #19345)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,55 @@
 #!/bin/sh
 set -e
 
+# Issue #19345: Path-scoped skip for docs/asset-only commits.
+#
+# `dune build --root .` is the source-of-truth type-check gate, but
+# on a fresh worktree it eats 5-15 min of cold cache before any
+# commit can land — even when the staged set is just `.md` or
+# `docs/`. The skip set below is explicitly enumerated (closed set,
+# default-safe): anything outside the listed extensions/prefixes
+# still triggers the full build, so unknown file types cannot
+# silently bypass type-check.
+#
+# Anti-pattern guardrails (CLAUDE.md §워크어라운드 거부 기준):
+#   §1 telemetry-as-fix: not applicable — actually changes scope.
+#   §2 string classifier: closed extension/prefix allowlist, not a
+#       free-form substring match on commit message or content.
+#   §3 N-of-M: single file change, no caller migration needed.
+
+staged="$(git diff --cached --name-only --diff-filter=ACMR)"
+
+if [ -z "$staged" ]; then
+  exit 0  # nothing staged (e.g. amend with no content changes)
+fi
+
+build_needed=0
+for f in $staged; do
+  case "$f" in
+    # Documentation / prose.
+    *.md|*.markdown|*.txt|*.rst|*.adoc)            ;;
+    # Image / asset binaries.
+    *.png|*.jpg|*.jpeg|*.gif|*.svg|*.ico|*.webp)   ;;
+    # Top-level meta files.
+    LICENSE|LICENSE.*|CHANGELOG|CHANGELOG.*)       ;;
+    NOTICE|NOTICE.*|AUTHORS|AUTHORS.*|CONTRIBUTORS) ;;
+    # Doc / GitHub workflow directories.
+    docs/*|.github/*|.githooks/README*)            ;;
+    # Git metadata that never affects OCaml build.
+    .gitignore|.gitattributes|.gitmessage)         ;;
+    # Anything else: build needed.
+    *)
+      build_needed=1
+      break
+      ;;
+  esac
+done
+
+if [ "$build_needed" = "0" ]; then
+  echo "pre-commit: docs/asset-only staged set, skipping dune build (#19345)"
+  exit 0
+fi
+
 # Type-check all OCaml code without producing binaries.
 # Fails fast on type errors before they reach CI.
 dune build --root .


### PR DESCRIPTION
## Summary

Closes #19345. `.githooks/pre-commit` ran `dune build --root .` on every commit, including docs-only changes — 5-15 min cold-cache gate on fresh worktrees for changes that cannot affect the OCaml build.

Single-file edit (`+49`): enumerate a closed skip set of file extensions and path prefixes that cannot affect the build. Anything outside the set still triggers the full `dune build --root .`.

## Skip set

| Category | Patterns |
|---|---|
| Docs/prose | `.md` `.markdown` `.txt` `.rst` `.adoc` |
| Image/asset | `.png` `.jpg` `.jpeg` `.gif` `.svg` `.ico` `.webp` |
| Top-level meta | `LICENSE` `CHANGELOG` `NOTICE` `AUTHORS` `CONTRIBUTORS` (with `.*` suffix) |
| Doc/workflow dirs | `docs/*` `.github/*` `.githooks/README*` |
| Git metadata | `.gitignore` `.gitattributes` `.gitmessage` |

## Anti-pattern guardrails (CLAUDE.md §워크어라운드 거부 기준)

- **§1 telemetry-as-fix**: avoided. Actually changes scope of the gate.
- **§2 string classifier**: closed extension/prefix allowlist, not a free-form substring match. Issue body explicitly rejects `"docs:"` commit-message prefix — this hook never reads commit messages.
- **§3 N-of-M**: single-file change, no caller migration.

## Default-safe direction

Skip set is an explicit positive list, not "build only when extension is `.ml`/`.mli`". A new file type (e.g. `.proto` added later) without a skip rule will still trigger build — preferable to silently bypassing type-check on unknown shapes.

## Test plan

Manual classifier verification ran 11 staged sets in worktree before commit:

| Staged set | Expected | Actual |
|---|---|---|
| `docs/foo.md` | SKIP | SKIP ✓ |
| `README.md` | SKIP | SKIP ✓ |
| `LICENSE` | SKIP | SKIP ✓ |
| `.gitignore` | SKIP | SKIP ✓ |
| `docs/foo.md docs/bar.png` | SKIP | SKIP ✓ |
| `lib/keeper/foo.ml` | BUILD | BUILD ✓ |
| `docs/foo.md` + `lib/keeper/foo.ml` | BUILD | BUILD ✓ |
| empty | SKIP | SKIP ✓ |
| `.github/workflows/ci.yml` | SKIP | SKIP ✓ |
| `dune-project` | BUILD | BUILD ✓ |
| `test/test_foo.ml` | BUILD | BUILD ✓ |

## CI status

`origin/main` remains broken from #19340 ml/mli drift (provider_error_class `Admission_exhausted` vs `Tier_admission_exhausted`, keeper_types_profile_sandbox `reserved_cascade_names`). This hook change is logic-isolated from that breakage. Committed with `--no-verify` (user-approved) because the pre-commit's own `dune build` cannot pass on broken main — exactly the friction this PR removes for future commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)