### PR TITLE
feat(keeper): Cancelled_by_parent fiber_drop_cause (PR #19346 phase 2)

### DIFF
--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -68,6 +68,7 @@ val stale_kill_class_to_string : stale_kill_class -> string
     missed-resolutions inside the same supervisor crash log. *)
 type fiber_drop_cause =
   | Graceful_shutdown
+  | Cancelled_by_parent
   | Unexpected
 
 type failure_reason =

--- a/lib/keeper/keeper_registry_types_failure.ml
+++ b/lib/keeper/keeper_registry_types_failure.ml
@@ -45,10 +45,19 @@ type fiber_drop_cause =
   (** Supervisor saw shutdown in progress (flag, cancel context, or
             explicit shutdown reason). Emitted at INFO severity, does not
             count toward restart budget or trigger cascade enrichment. *)
+  | Cancelled_by_parent
+  (** Fiber observed [Eio.Cancel.Cancelled] from a parent switch
+            (supervisor restart, sibling failure propagating cancel)
+            while shutdown was not in progress. Operationally a transient
+            cancel that the supervisor itself triggered — restart budget
+            should not count it the same as a genuine missed-resolution
+            bug. Emitted at WARN severity, separate cohort from
+            [Unexpected]. *)
   | Unexpected
   (** Fiber finally ran with [resolved=false] outside any shutdown
-            context. Emitted at ERROR severity. Drives the existing
-            [cohort=fiber_unresolved] supervisor pause path. *)
+            context and without a parent cancellation signal. Genuine
+            missed-resolution bug. Emitted at ERROR severity. Drives the
+            existing [cohort=fiber_unresolved] supervisor pause path. *)
 
 type failure_reason =
   | Heartbeat_consecutive_failures of int
@@ -129,12 +138,15 @@ let failure_reason_to_string = function
       (ambiguous_partial_commit_kind_to_string kind)
       detail
   | Fiber_unresolved Graceful_shutdown -> "fiber_unresolved(graceful_shutdown)"
+  | Fiber_unresolved Cancelled_by_parent -> "fiber_unresolved(cancelled_by_parent)"
   | Fiber_unresolved Unexpected -> "fiber_unresolved"
   (* Backward-compat string form: [Unexpected] preserves the legacy
      "fiber_unresolved" wire value so existing log-line / dashboard
-     greps and persisted crash_log rows continue to match. The graceful
-     variant gets a distinct suffix so 24h fleet audits can split the
-     26:9 noise:signal ratio (Issue #18901 diagnosis). *)
+     greps and persisted crash_log rows continue to match. Graceful
+     and cancelled-by-parent variants get distinct suffixes so 24h
+     fleet audits can split the noise:signal ratio (Issue #18901) and
+     supervisor restart/back-off can treat parent-cancel differently
+     from genuine missed-resolution. *)
   | Exception s -> Printf.sprintf "exception(%s)" s
   | Turn_overflow_pause -> "turn_overflow_pause"
   | Turn_livelock_pause -> "turn_livelock_pause"
@@ -160,13 +172,14 @@ let failure_reason_cohort_key = function
   | Some (Tool_required_unsatisfied _) -> "tool_required_unsatisfied"
   | Some (Ambiguous_partial_commit _) -> "ambiguous_partial_commit"
   | Some (Fiber_unresolved Graceful_shutdown) -> "fiber_unresolved_graceful"
+  | Some (Fiber_unresolved Cancelled_by_parent) -> "fiber_unresolved_cancelled"
   | Some (Fiber_unresolved Unexpected) -> "fiber_unresolved"
-  (* Cohort split: graceful shutdown gets its own cohort so the
-     supervisor self-preservation pause policy
-     [keeper_supervisor_pause_policy.ml] no longer treats SIGTERM
-     races as a fiber-drop epidemic. The legacy "fiber_unresolved"
-     key stays bound to [Unexpected] for dashboard / metrics
-     backward-compat. *)
+  (* Cohort split: graceful shutdown and parent-cancelled each get
+     their own cohort so the supervisor self-preservation pause
+     policy [keeper_supervisor_pause_policy.ml] no longer treats
+     SIGTERM races *or* parent-cancel restarts as a fiber-drop
+     epidemic. The legacy "fiber_unresolved" key stays bound to
+     [Unexpected] for dashboard / metrics backward-compat. *)
   | Some (Exception _) -> "exception"
   | Some Turn_overflow_pause -> "turn_overflow_pause"
   | Some Turn_livelock_pause -> "turn_livelock_pause"

--- a/lib/keeper/keeper_registry_types_failure.mli
+++ b/lib/keeper/keeper_registry_types_failure.mli
@@ -24,6 +24,7 @@ val stale_kill_class_to_string :
     missed-resolution bugs. *)
 type fiber_drop_cause =
   | Graceful_shutdown
+  | Cancelled_by_parent
   | Unexpected
 type failure_reason =
     Heartbeat_consecutive_failures of int

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -105,6 +105,17 @@ let launch_supervised_fiber
     in
     fork_body (fun () ->
       let resolved = ref false in
+      (* Issue #18901 follow-up: distinguish parent-cancellation from
+         genuine missed-resolution in the finally branch. The body's
+         try/with re-raises [Eio.Cancel.Cancelled] (line 281 area)
+         which then propagates to the surrounding switch, leaving the
+         finally to fire with [resolved=false]. Without this flag the
+         finally cannot tell whether the unresolved drop was a parent
+         cancel (supervisor restart, sibling failure) or a real
+         missed-resolution bug — both collapsed into [Unexpected].
+         Setting the flag from the cancel handler keeps the typed
+         [fiber_drop_cause] payload accurate. *)
+      let cancelled_by_parent = ref false in
       let resolve_done value =
         if not !resolved then
           (* Issue #18335: the keepalive layer (keeper_keepalive.ml:760-791)
@@ -278,7 +289,9 @@ let launch_supervised_fiber
                    "normal exit"
                    ())
            with
-           | Eio.Cancel.Cancelled _ as e -> raise e
+           | Eio.Cancel.Cancelled _ as e ->
+             cancelled_by_parent := true;
+             raise e
            | exn ->
              (* RFC-0002: unified crash handler.
                 Keeper_fiber_crash carries no payload — failure_reason is
@@ -385,6 +398,25 @@ let launch_supervised_fiber
                 Keeper_registry.mark_dead ~base_path meta.name ~at:(Time_compat.now ());
                 (* fire-and-forget: resolve_done signals completion *)
                 ignore (resolve_done (`Crashed "shutdown")))
+              else if !cancelled_by_parent
+              then (
+                (* Issue #18901 follow-up: parent-cancel branch. The
+                   body's try/with caught [Eio.Cancel.Cancelled] and set
+                   the flag before re-raising. Shutdown was not in
+                   progress, so this is a *supervisor-driven* cancel
+                   (restart, sibling failure propagating cancel) rather
+                   than a missed-resolution bug. WARN severity, separate
+                   cohort, no record_crash — parent cancels are
+                   expected lifecycle events, not restart-budget signal. *)
+                Log.Keeper.warn
+                  "%s: fiber unresolved after parent cancellation (transient)"
+                  meta.name;
+                Keeper_registry.set_failure_reason
+                  ~base_path
+                  meta.name
+                  (Some (Keeper_registry.Fiber_unresolved Cancelled_by_parent));
+                Keeper_registry.mark_dead ~base_path meta.name ~at:(Time_compat.now ());
+                ignore (resolve_done (`Crashed "cancelled_by_parent")))
               else (
 	                let reason =
 	                  Keeper_registry.failure_reason_to_string

--- a/test/test_phase2_self_preservation.ml
+++ b/test/test_phase2_self_preservation.ml
@@ -99,6 +99,26 @@ let test_failure_reason_fiber () =
   let s = R.failure_reason_to_string (R.Fiber_unresolved R.Unexpected) in
   check string "fiber reason" "fiber_unresolved" s
 
+let test_failure_reason_fiber_graceful () =
+  (* Issue #18901: Graceful_shutdown cause emits a distinct suffix so
+     SIGTERM-race artifacts no longer collapse into the legacy
+     ERROR-level cohort. *)
+  let s =
+    R.failure_reason_to_string (R.Fiber_unresolved R.Graceful_shutdown)
+  in
+  check string "fiber graceful reason"
+    "fiber_unresolved(graceful_shutdown)" s
+
+let test_failure_reason_fiber_cancelled_by_parent () =
+  (* Issue #18901 follow-up: Cancelled_by_parent cause separates
+     supervisor-driven cancels (restart, sibling failure propagating
+     cancel) from genuine missed-resolution bugs. *)
+  let s =
+    R.failure_reason_to_string (R.Fiber_unresolved R.Cancelled_by_parent)
+  in
+  check string "fiber cancelled-by-parent reason"
+    "fiber_unresolved(cancelled_by_parent)" s
+
 let test_failure_reason_exception () =
   let s = R.failure_reason_to_string (R.Exception "Sys_error(disk full)") in
   check string "exception reason" "exception(Sys_error(disk full))" s
@@ -213,13 +233,28 @@ let test_cohort_key_heartbeat () =
 
 let test_cohort_key_fiber () =
   (* Issue #18901: Unexpected cause keeps the legacy
-     "fiber_unresolved" cohort key for backward-compat. The new
-     Graceful_shutdown cause maps to a separate cohort
-     ("fiber_unresolved_graceful") covered elsewhere. *)
+     "fiber_unresolved" cohort key for backward-compat. *)
   let key =
     Sup.cohort_key_of_reason (Some (R.Fiber_unresolved R.Unexpected))
   in
   check string "fiber cohort" "fiber_unresolved" key
+
+let test_cohort_key_fiber_graceful () =
+  let key =
+    Sup.cohort_key_of_reason
+      (Some (R.Fiber_unresolved R.Graceful_shutdown))
+  in
+  check string "fiber graceful cohort" "fiber_unresolved_graceful" key
+
+let test_cohort_key_fiber_cancelled_by_parent () =
+  (* Issue #18901 follow-up: parent cancel cohort separates from
+     [Unexpected] so the supervisor pause policy does not treat
+     restart-driven cancels as a fiber-drop epidemic. *)
+  let key =
+    Sup.cohort_key_of_reason
+      (Some (R.Fiber_unresolved R.Cancelled_by_parent))
+  in
+  check string "fiber cancelled cohort" "fiber_unresolved_cancelled" key
 
 let test_cohort_key_exception () =
   let key = Sup.cohort_key_of_reason
@@ -261,6 +296,10 @@ let () =
     "failure_reason", [
       test_case "heartbeat" `Quick test_failure_reason_heartbeat;
       test_case "fiber_unresolved" `Quick test_failure_reason_fiber;
+      test_case "fiber_unresolved graceful" `Quick
+        test_failure_reason_fiber_graceful;
+      test_case "fiber_unresolved cancelled_by_parent" `Quick
+        test_failure_reason_fiber_cancelled_by_parent;
       test_case "exception" `Quick test_failure_reason_exception;
       test_case "ambiguous partial commit" `Quick
         test_failure_reason_ambiguous_partial_commit;
@@ -284,6 +323,9 @@ let () =
     "cohort_detection", [
       test_case "heartbeat key" `Quick test_cohort_key_heartbeat;
       test_case "fiber key" `Quick test_cohort_key_fiber;
+      test_case "fiber key graceful" `Quick test_cohort_key_fiber_graceful;
+      test_case "fiber key cancelled_by_parent" `Quick
+        test_cohort_key_fiber_cancelled_by_parent;
       test_case "exception key" `Quick test_cohort_key_exception;
       test_case "none key" `Quick test_cohort_key_none;
     ];


### PR DESCRIPTION
## Summary

Phase 2 follow-up of [#19346](https://github.com/jeong-sik/masc-mcp/pull/19346) (typed `fiber_drop_cause` split). Adds a third variant `Cancelled_by_parent` between `Graceful_shutdown` and `Unexpected` to capture supervisor-driven cancels (restart, sibling failure propagating cancel) — currently misclassified as `Unexpected` and inflating the ERROR-level baseline.

5 files, +104/-15.

## Why a third variant

PR #19346 used `Shutdown.is_shutting_down_global()` to decide cause. That covers SIGTERM/SIGINT shutdowns but not the *normal lifecycle* event of a supervisor cancelling a keeper to restart it. Without a separate cause, every supervisor restart fires `Eio.Cancel.Cancelled` → finally with `resolved=false` → `Unexpected` cohort → ERROR-level crash row + restart-budget consumption.

## Detection: body-scope `ref`

```ocaml
let cancelled_by_parent = ref false in
...
try ... with
| Eio.Cancel.Cancelled _ as e ->
    cancelled_by_parent := true;
    raise e
| exn -> ... (* unified crash handler *)
```

The flag is captured by closure, set deterministically when the body's Cancel handler observes the exception, then read in the finally for the 3-way branch:

| Condition | Cause | Severity | Cohort |
|---|---|---|---|
| `Shutdown.is_shutting_down_global()` | `Graceful_shutdown` | INFO | `fiber_unresolved_graceful` |
| else if `!cancelled_by_parent` | `Cancelled_by_parent` | WARN | `fiber_unresolved_cancelled` |
| else | `Unexpected` | ERROR | `fiber_unresolved` |

`Eio.Cancel.check ()` and `is_on` were considered and rejected — `check ()` would re-raise inside the finally and break the branching, while `is_on` lacks a stable accessor across Eio versions.

## Test plan

`test_phase2_self_preservation.ml` adds 4 cases (2 to_string + 2 cohort_key) for the new cause. Existing `Unexpected` and `Graceful_shutdown` tests are unaffected.

## Workaround-signature self-check

- **§1 telemetry-as-fix**: avoided. The flag drives actual branching (severity, cohort, downstream policy), not a counter.
- **§2 substring classifier**: avoided. Variant extension on closed sum, no string parsing.
- **§3 N-of-M**: avoided. Existing consumers used `Fiber_unresolved _` wildcard from PR #19346, so the variant addition flows through without further caller migration.

## Fleet impact prediction

Once supervisor restart fires Cancel.Cancelled on a keeper switch, the next finally tags the drop with `Cancelled_by_parent` instead of `Unexpected`. Expected effect after 24h: a chunk of the previous `Unexpected` baseline relocates to `fiber_unresolved_cancelled`, shrinking the legacy ERROR cohort to genuine missed-resolution only.

## CI status

origin/main remains broken by #19340 ml/mli drift + cascade module cycle. Committed with `--no-verify` (user-approved per CLAUDE.md governance). CI re-runs once main recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)