### PR TITLE
refactor(dashboard): unify keeper info exposure (mention hook, paused predicate, phase normalize)

### DIFF
--- a/dashboard/src/components/board/composer-v2.ts
+++ b/dashboard/src/components/board/composer-v2.ts
@@ -5,7 +5,6 @@ import { currentDashboardActor, sendBroadcast } from '../../api'
 import {
   dispatchOperatorAction,
   operatorActionBusy,
-  operatorSnapshot,
 } from '../../operator-store'
 import { showToast } from '../common/toast'
 import { ActionButton } from '../common/button'
@@ -16,15 +15,11 @@ import {
   stateBlockKeys,
   STATE_BLOCK_TEMPLATE,
 } from '../ops/ops-state'
-import { isKeeperOperatorTargetable } from '../../lib/keeper-predicates'
 import {
   keeperNameFromTarget,
-  mentionQueryFromMessage,
-  trailingMentionNameFromMessage,
-  onlineKeeperNameForMention,
-  mentionCandidates,
   replaceTrailingMentionDraft,
 } from '../../lib/mention-utils'
+import { useOperatorMentionContext } from '../common/use-operator-mention-context'
 
 export type ComposerV2Mode = 'broadcast' | 'dm' | 'state-block'
 
@@ -109,41 +104,36 @@ export function ComposerV2({ roomId }: { roomId?: string | null }) {
   const [keeperTarget, setKeeperTarget] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
-  const [activeMentionIndex, setActiveMentionIndex] = useState(0)
-  const [dismissedMentionQuery, setDismissedMentionQuery] = useState<string | null>(null)
   const room = normalizeRoomId(roomId)
-  const snapshot = operatorSnapshot.value
   const busy = submitting || operatorActionBusy.value
-  // Paused keepers stay targetable so operators can DM/probe/resume them,
-  // even when another lifecycle axis still carries an offline-ish token.
-  const onlineKeepers = (snapshot?.keepers ?? [])
-    .filter(isKeeperOperatorTargetable)
-    .map(keeper => ({ name: keeper.name, status: keeper.status }))
-  const onlineKeeperNames = onlineKeepers.map(keeper => keeper.name).join('\0')
-  const selectedKeeper = keeperNameFromTarget(keeperTarget)
-  const selectedKeeperOnline = !!selectedKeeper && onlineKeepers.some(k => k.name === selectedKeeper)
-  const mentionQuery = mode === 'dm' ? mentionQueryFromMessage(draft) : null
-  const trailingMention = mode === 'dm' ? trailingMentionNameFromMessage(draft) : null
-  const trailingMentionTarget = mode === 'dm' ? onlineKeeperNameForMention(onlineKeepers, trailingMention) : null
-  const unresolvedTrailingMention = mode === 'dm' && !!trailingMention && !trailingMentionTarget
-  const effectiveKeeper = trailingMentionTarget ?? selectedKeeper
-  const effectiveKeeperOnline = !!trailingMentionTarget || selectedKeeperOnline
-  const mentionMatches = mode === 'dm' ? mentionCandidates(onlineKeepers, mentionQuery, effectiveKeeper) : []
-  const mentionListOpen = mentionQuery !== null && dismissedMentionQuery !== mentionQuery
-  const activeMention = mentionListOpen ? mentionMatches[activeMentionIndex] ?? mentionMatches[0] : null
-  const activeMentionOptionId = activeMention
-    ? `${MENTION_LISTBOX_ID}-option-${Math.max(mentionMatches.indexOf(activeMention), 0)}`
-    : undefined
+  const mention = useOperatorMentionContext({
+    message: draft,
+    target: keeperTarget,
+    dmActive: mode === 'dm',
+    listboxId: MENTION_LISTBOX_ID,
+  })
+  const {
+    onlineKeepers,
+    onlineKeeperNames,
+    selectedKeeperOnline,
+    mentionQuery,
+    trailingMentionTarget,
+    unresolvedTrailingMention,
+    effectiveKeeper,
+    effectiveKeeperOnline,
+    mentionMatches,
+    mentionListOpen,
+    activeMentionOptionId,
+    activeMentionIndex,
+    setActiveMentionIndex,
+    dismissedMentionQuery,
+    setDismissedMentionQuery,
+  } = mention
   const stateKeys = mode === 'state-block' ? stateBlockKeys(draft) : []
   const sendDisabled = busy
     || draft.trim() === ''
     || (mode === 'dm' && (!effectiveKeeperOnline || unresolvedTrailingMention))
     || (mode === 'state-block' && stateKeys.length === 0)
-
-  useEffect(() => {
-    setActiveMentionIndex(0)
-    setDismissedMentionQuery(null)
-  }, [mentionQuery, onlineKeeperNames])
 
   useEffect(() => {
     if (mode !== 'dm') return

--- a/dashboard/src/components/common/use-operator-mention-context.test.ts
+++ b/dashboard/src/components/common/use-operator-mention-context.test.ts
@@ -1,0 +1,148 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { useOperatorMentionContext, type OperatorMentionContext } from './use-operator-mention-context'
+import { operatorSnapshot } from '../../operator-store'
+import type { OperatorKeeperSnapshot, OperatorSnapshot } from '../../types'
+
+const LISTBOX_ID = 'test-listbox'
+
+function snapshotWithKeepers(keepers: OperatorKeeperSnapshot[]): OperatorSnapshot {
+  return {
+    root: { paused: false, namespace: 'default' },
+    sessions: [],
+    keepers,
+    recent_messages: [],
+    pending_confirms: [],
+    available_actions: [],
+  } as unknown as OperatorSnapshot
+}
+
+function Probe({
+  message,
+  target,
+  dmActive,
+  onContext,
+}: {
+  message: string
+  target: string
+  dmActive: boolean
+  onContext: (ctx: OperatorMentionContext) => void
+}) {
+  const ctx = useOperatorMentionContext({ message, target, dmActive, listboxId: LISTBOX_ID })
+  // Capture synchronously during render — vitest jsdom does not flush
+  // useEffect within the await-microtask window the test uses.
+  onContext(ctx)
+  return html`<div data-testid="probe-online">${ctx.onlineKeeperNames}</div>`
+}
+
+describe('useOperatorMentionContext', () => {
+  let container: HTMLDivElement
+  let captured: OperatorMentionContext | null
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    captured = null
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    operatorSnapshot.value = null
+  })
+
+  it('filters keepers via isKeeperOperatorTargetable (paused stays, offline drops)', async () => {
+    operatorSnapshot.value = snapshotWithKeepers([
+      { name: 'alpha', status: 'active' } as OperatorKeeperSnapshot,
+      { name: 'beta',  status: 'offline' } as OperatorKeeperSnapshot,
+      { name: 'gamma', status: 'paused', paused: true } as OperatorKeeperSnapshot,
+    ])
+
+    render(
+      html`<${Probe} message="" target="" dmActive=${false} onContext=${(c: OperatorMentionContext) => { captured = c }} />`,
+      container,
+    )
+
+    expect(captured?.onlineKeepers.map(k => k.name).sort()).toEqual(['alpha', 'gamma'])
+    expect(captured?.onlineKeeperNames).toBe('alpha\0gamma')
+  })
+
+  it('skips mention parsing when dmActive is false', async () => {
+    operatorSnapshot.value = snapshotWithKeepers([
+      { name: 'alpha', status: 'active' } as OperatorKeeperSnapshot,
+    ])
+
+    render(
+      html`<${Probe} message="hello @al" target="" dmActive=${false} onContext=${(c: OperatorMentionContext) => { captured = c }} />`,
+      container,
+    )
+
+    expect(captured?.mentionQuery).toBeNull()
+    expect(captured?.mentionMatches).toEqual([])
+    expect(captured?.mentionListOpen).toBe(false)
+  })
+
+  it('parses mention query and resolves trailing @name target when dmActive', async () => {
+    operatorSnapshot.value = snapshotWithKeepers([
+      { name: 'alpha', status: 'active' } as OperatorKeeperSnapshot,
+      { name: 'beta',  status: 'active' } as OperatorKeeperSnapshot,
+    ])
+
+    render(
+      html`<${Probe} message="hi @al" target="" dmActive=${true} onContext=${(c: OperatorMentionContext) => { captured = c }} />`,
+      container,
+    )
+
+    expect(captured?.mentionQuery).toBe('al')
+    expect(captured?.mentionMatches.map(m => m.name)).toContain('alpha')
+    expect(captured?.mentionListOpen).toBe(true)
+  })
+
+  it('routes effective target: trailing mention overrides selected target', async () => {
+    operatorSnapshot.value = snapshotWithKeepers([
+      { name: 'alpha', status: 'active' } as OperatorKeeperSnapshot,
+      { name: 'beta',  status: 'active' } as OperatorKeeperSnapshot,
+    ])
+
+    render(
+      html`<${Probe} message="ping @beta " target="keeper:alpha" dmActive=${true} onContext=${(c: OperatorMentionContext) => { captured = c }} />`,
+      container,
+    )
+
+    expect(captured?.selectedKeeper).toBe('alpha')
+    expect(captured?.trailingMentionTarget).toBe('beta')
+    expect(captured?.effectiveKeeper).toBe('beta')
+    expect(captured?.effectiveKeeperOnline).toBe(true)
+  })
+
+  it('flags unresolvedTrailingMention when @name does not match any online keeper', async () => {
+    operatorSnapshot.value = snapshotWithKeepers([
+      { name: 'alpha', status: 'active' } as OperatorKeeperSnapshot,
+    ])
+
+    render(
+      html`<${Probe} message="@ghost " target="" dmActive=${true} onContext=${(c: OperatorMentionContext) => { captured = c }} />`,
+      container,
+    )
+
+    expect(captured?.trailingMention).toBe('ghost')
+    expect(captured?.trailingMentionTarget).toBeNull()
+    expect(captured?.unresolvedTrailingMention).toBe(true)
+    expect(captured?.effectiveKeeperOnline).toBe(false)
+  })
+
+  it('builds per-option activeMentionOptionId from listboxId', async () => {
+    operatorSnapshot.value = snapshotWithKeepers([
+      { name: 'alpha', status: 'active' } as OperatorKeeperSnapshot,
+    ])
+
+    render(
+      html`<${Probe} message="@a" target="" dmActive=${true} onContext=${(c: OperatorMentionContext) => { captured = c }} />`,
+      container,
+    )
+
+    expect(captured?.activeMentionOptionId).toBe(`${LISTBOX_ID}-option-0`)
+  })
+})

--- a/dashboard/src/components/common/use-operator-mention-context.ts
+++ b/dashboard/src/components/common/use-operator-mention-context.ts
@@ -1,0 +1,119 @@
+// Shared @mention + target-selector computation for operator messaging surfaces.
+//
+// Both ComposerV2 (board) and QuickIntervene (ops) consume operatorSnapshot,
+// filter via isKeeperOperatorTargetable, and derive the same mention state
+// (active candidate, listbox open/dismissed, effective target). The 15-line
+// derived block plus two useState hooks plus the reset effect were duplicated
+// between the two surfaces; this hook collapses them into one SSOT.
+
+import { useEffect, useState, type Dispatch, type StateUpdater } from 'preact/hooks'
+import { operatorSnapshot } from '../../operator-store'
+import { isKeeperOperatorTargetable } from '../../lib/keeper-predicates'
+import {
+  keeperNameFromTarget,
+  mentionCandidates,
+  mentionQueryFromMessage,
+  onlineKeeperNameForMention,
+  trailingMentionNameFromMessage,
+  type MentionCandidate,
+  type OnlineKeeper,
+} from '../../lib/mention-utils'
+
+export interface OperatorMentionContext {
+  onlineKeepers: OnlineKeeper[]
+  /** Stable join used as a useEffect dependency to detect roster diffs. */
+  onlineKeeperNames: string
+  selectedKeeper: string | null
+  selectedKeeperOnline: boolean
+  mentionQuery: string | null
+  trailingMention: string | null
+  trailingMentionTarget: string | null
+  unresolvedTrailingMention: boolean
+  effectiveKeeper: string | null
+  effectiveKeeperOnline: boolean
+  mentionMatches: MentionCandidate[]
+  mentionListOpen: boolean
+  activeMention: MentionCandidate | null
+  activeMentionOptionId: string | undefined
+  activeMentionIndex: number
+  setActiveMentionIndex: Dispatch<StateUpdater<number>>
+  dismissedMentionQuery: string | null
+  setDismissedMentionQuery: Dispatch<StateUpdater<string | null>>
+}
+
+export interface UseOperatorMentionContextOptions {
+  message: string
+  target: string
+  /** True when the composer mode treats `@name` as a mention. */
+  dmActive: boolean
+  /** ARIA listbox id used to build per-option ids. Surfaces use different ids. */
+  listboxId: string
+}
+
+export function useOperatorMentionContext(
+  opts: UseOperatorMentionContextOptions,
+): OperatorMentionContext {
+  const { message, target, dmActive, listboxId } = opts
+
+  const [activeMentionIndex, setActiveMentionIndex] = useState(0)
+  const [dismissedMentionQuery, setDismissedMentionQuery] = useState<string | null>(null)
+
+  const snapshot = operatorSnapshot.value
+  // Paused keepers stay targetable so operators can DM/probe/resume them,
+  // even when another lifecycle axis still carries an offline-ish token.
+  const onlineKeepers: OnlineKeeper[] = (snapshot?.keepers ?? [])
+    .filter(isKeeperOperatorTargetable)
+    .map(keeper => ({ name: keeper.name, status: keeper.status }))
+  const onlineKeeperNames = onlineKeepers.map(keeper => keeper.name).join('\0')
+
+  const selectedKeeper = keeperNameFromTarget(target)
+  const selectedKeeperOnline =
+    !!selectedKeeper && onlineKeepers.some(keeper => keeper.name === selectedKeeper)
+
+  const mentionQuery = dmActive ? mentionQueryFromMessage(message) : null
+  const trailingMention = dmActive ? trailingMentionNameFromMessage(message) : null
+  const trailingMentionTarget = dmActive
+    ? onlineKeeperNameForMention(onlineKeepers, trailingMention)
+    : null
+  const unresolvedTrailingMention = dmActive && !!trailingMention && !trailingMentionTarget
+
+  const effectiveKeeper = trailingMentionTarget ?? selectedKeeper
+  const effectiveKeeperOnline = !!trailingMentionTarget || selectedKeeperOnline
+
+  const mentionMatches = dmActive
+    ? mentionCandidates(onlineKeepers, mentionQuery, effectiveKeeper)
+    : []
+  const mentionListOpen = mentionQuery !== null && dismissedMentionQuery !== mentionQuery
+  const activeMention: MentionCandidate | null = mentionListOpen
+    ? mentionMatches[activeMentionIndex] ?? mentionMatches[0] ?? null
+    : null
+  const activeMentionOptionId = activeMention
+    ? `${listboxId}-option-${Math.max(mentionMatches.indexOf(activeMention), 0)}`
+    : undefined
+
+  useEffect(() => {
+    setActiveMentionIndex(0)
+    setDismissedMentionQuery(null)
+  }, [mentionQuery, onlineKeeperNames])
+
+  return {
+    onlineKeepers,
+    onlineKeeperNames,
+    selectedKeeper,
+    selectedKeeperOnline,
+    mentionQuery,
+    trailingMention,
+    trailingMentionTarget,
+    unresolvedTrailingMention,
+    effectiveKeeper,
+    effectiveKeeperOnline,
+    mentionMatches,
+    mentionListOpen,
+    activeMention,
+    activeMentionOptionId,
+    activeMentionIndex,
+    setActiveMentionIndex,
+    dismissedMentionQuery,
+    setDismissedMentionQuery,
+  }
+}

--- a/dashboard/src/components/keeper-lifecycle-timeline.ts
+++ b/dashboard/src/components/keeper-lifecycle-timeline.ts
@@ -23,7 +23,6 @@ import {
 import { TimeAgo } from './common/time-ago'
 import { LoadingState } from './common/feedback-state'
 import { getPhaseStyle } from './keeper-phase-indicator'
-import { toPascalPhase } from './keeper-phase-strip'
 
 // ── Module-level signals ──────────────────────────────────────────────────
 
@@ -99,7 +98,7 @@ export async function refreshKeeperLifecycleTimeline() {
 function LifecycleEventRow({ ev }: { ev: KeeperLifecycleEvent }) {
   const tone = lifecycleEventTone(ev.event)
   const style = toneStyle(tone)
-  const phaseStyle = ev.phase ? getPhaseStyle(toPascalPhase(ev.phase)) : null
+  const phaseStyle = ev.phase ? getPhaseStyle(ev.phase) : null
 
   return html`
     <div

--- a/dashboard/src/components/keeper-phase-strip.test.ts
+++ b/dashboard/src/components/keeper-phase-strip.test.ts
@@ -1,47 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { toPascalPhase, eventLabel } from './keeper-phase-strip'
+import { eventLabel } from './keeper-phase-strip'
 
-// ================================================================
-// toPascalPhase
-// ================================================================
-
-describe('toPascalPhase', () => {
-  it('converts simple lowercase to PascalCase', () => {
-    expect(toPascalPhase('running')).toBe('Running')
-  })
-
-  it('converts snake_case to PascalCase', () => {
-    expect(toPascalPhase('handing_off')).toBe('HandingOff')
-  })
-
-  it('converts multi-segment snake_case', () => {
-    expect(toPascalPhase('a_b_c')).toBe('ABC')
-  })
-
-  it('handles already PascalCase input', () => {
-    expect(toPascalPhase('Running')).toBe('Running')
-  })
-
-  it('handles empty string', () => {
-    expect(toPascalPhase('')).toBe('')
-  })
-
-  it('handles mixed case', () => {
-    expect(toPascalPhase('HANDING_OFF')).toBe('HandingOff')
-  })
-
-  it('handles single underscore', () => {
-    expect(toPascalPhase('off_line')).toBe('OffLine')
-  })
-
-  it('handles no underscore', () => {
-    expect(toPascalPhase('dead')).toBe('Dead')
-  })
-
-  it('handles overflowing', () => {
-    expect(toPascalPhase('overflowed')).toBe('Overflowed')
-  })
-})
+// `toPascalPhase` was sunset 2026-05-28 — the same lowercase→PascalCase
+// normalization is now handled by `toKeeperPhase` (keeper-store-normalize),
+// which `getPhaseStyle` calls internally. Coverage for that path lives in
+// keeper-store-normalize.test.ts (closed-set parsing with compile-time
+// coverage check). The strip no longer ships a generic regex normalizer.
 
 // ================================================================
 // eventLabel

--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -12,19 +12,12 @@ import { getPhaseStyle } from './keeper-phase-indicator'
 const transitionData = signal<Map<string, KeeperTransitionsResponse>>(new Map())
 const loading = signal(false)
 
-/** Server sends lowercase (e.g. "running", "handing_off"); PHASE_STYLES uses PascalCase. */
-export function toPascalPhase(phase: string): string {
-  return phase.toLowerCase()
-    .replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
-    .replace(/^./, s => s.toUpperCase())
-}
-
 function phaseColor(phase: string): string {
-  return getPhaseStyle(toPascalPhase(phase)).color
+  return getPhaseStyle(phase).color
 }
 
 function phaseInlineStyle(phase: string): string {
-  const style = getPhaseStyle(toPascalPhase(phase))
+  const style = getPhaseStyle(phase)
   return `color: ${style.color}; background: ${style.bg}; border: 1px solid ${style.border};`
 }
 
@@ -108,7 +101,7 @@ function KeeperStrip({ name, data }: { name: string; data: KeeperTransitionsResp
   const transitions = data.transitions
 
   return html`
-    <div class="flex items-center gap-3 py-2 px-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]" role="listitem" aria-label="${name}: ${getPhaseStyle(toPascalPhase(phase)).label}, 전환 ${transitions.length}건">
+    <div class="flex items-center gap-3 py-2 px-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]" role="listitem" aria-label="${name}: ${getPhaseStyle(phase).label}, 전환 ${transitions.length}건">
       <div class="w-24 shrink-0">
         <div class="text-sm font-semibold text-[var(--color-fg-secondary)] truncate">${name}</div>
         <div
@@ -116,7 +109,7 @@ function KeeperStrip({ name, data }: { name: string; data: KeeperTransitionsResp
           style="${phaseInlineStyle(phase)}"
           role="status"
         >
-          ${getPhaseStyle(toPascalPhase(phase)).icon} ${getPhaseStyle(toPascalPhase(phase)).label}
+          ${getPhaseStyle(phase).icon} ${getPhaseStyle(phase).label}
         </div>
       </div>
       <div class="flex-1 flex items-center gap-1.5 overflow-x-auto min-h-6">

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -6,10 +6,7 @@ import { CARD_STANDARD } from '../common/card'
 import { ActionButton } from '../common/button'
 import { TextArea, TextInput } from '../common/input'
 import { Select } from '../common/select'
-import {
-  operatorActionBusy,
-  operatorSnapshot,
-} from '../../operator-store'
+import { operatorActionBusy } from '../../operator-store'
 import { route } from '../../router'
 import {
   actorName,
@@ -24,16 +21,14 @@ import {
   type QuickComposerMode,
 } from './ops-state'
 import { executeAction } from './helpers'
-import { isKeeperOperatorTargetable } from '../../lib/keeper-predicates'
 import {
   type OnlineKeeper,
   keeperNameFromTarget,
-  mentionQueryFromMessage,
-  trailingMentionNameFromMessage,
   onlineKeeperNameForMention,
-  mentionCandidates,
   replaceTrailingMentionDraft,
+  trailingMentionNameFromMessage,
 } from '../../lib/mention-utils'
+import { useOperatorMentionContext } from '../common/use-operator-mention-context'
 
 interface ComposerTarget {
   action_type: 'broadcast' | 'keeper_message'
@@ -110,43 +105,39 @@ async function submitQuickMessage(onlineKeepers: OnlineKeeper[]) {
 
 export function QuickIntervene() {
   const [showAdvanced, setShowAdvanced] = useState(false)
-  const [activeMentionIndex, setActiveMentionIndex] = useState(0)
-  const [dismissedMentionQuery, setDismissedMentionQuery] = useState<string | null>(null)
   const appliedRouteFocus = useRef<string | null>(null)
-  const snapshot = operatorSnapshot.value
-  const keepers = snapshot?.keepers ?? []
   const busy = operatorActionBusy.value
   const currentRoute = route.value
-
-  // Keep paused keepers targetable for operator DMs even if their agent
-  // status is currently offline-ish.
-  const onlineKeepers = keepers.filter(isKeeperOperatorTargetable)
-  const onlineKeeperNames = onlineKeepers.map(keeper => keeper.name).join('\0')
   const mode = quickComposerMode.value
+
+  const mention = useOperatorMentionContext({
+    message: quickMessage.value,
+    target: quickTarget.value,
+    dmActive: mode === 'dm',
+    listboxId: MENTION_LISTBOX_ID,
+  })
+  const {
+    onlineKeepers,
+    onlineKeeperNames,
+    selectedKeeperOnline,
+    mentionQuery,
+    unresolvedTrailingMention,
+    effectiveKeeper,
+    effectiveKeeperOnline,
+    mentionMatches,
+    mentionListOpen,
+    activeMentionOptionId,
+    activeMentionIndex,
+    setActiveMentionIndex,
+    dismissedMentionQuery,
+    setDismissedMentionQuery,
+  } = mention
+
   const stateKeys = mode === 'state' ? stateBlockKeys(quickMessage.value) : []
-  const selectedKeeper = keeperNameFromTarget(quickTarget.value)
-  const selectedKeeperOnline = !!selectedKeeper && onlineKeepers.some(k => k.name === selectedKeeper)
-  const mentionQuery = mode === 'dm' ? mentionQueryFromMessage(quickMessage.value) : null
-  const trailingMention = mode === 'dm' ? trailingMentionNameFromMessage(quickMessage.value) : null
-  const trailingMentionTarget = mode === 'dm' ? onlineKeeperNameForMention(onlineKeepers, trailingMention) : null
-  const unresolvedTrailingMention = mode === 'dm' && !!trailingMention && !trailingMentionTarget
-  const effectiveKeeper = trailingMentionTarget ?? selectedKeeper
-  const effectiveKeeperOnline = !!trailingMentionTarget || selectedKeeperOnline
-  const mentionMatches = mode === 'dm' ? mentionCandidates(onlineKeepers, mentionQuery, effectiveKeeper) : []
-  const mentionListOpen = mentionQuery !== null && dismissedMentionQuery !== mentionQuery
-  const activeMention = mentionListOpen ? mentionMatches[activeMentionIndex] ?? mentionMatches[0] : null
-  const activeMentionOptionId = activeMention
-    ? `${MENTION_LISTBOX_ID}-option-${Math.max(mentionMatches.indexOf(activeMention), 0)}`
-    : undefined
   const sendDisabled = busy
     || quickMessage.value.trim() === ''
     || (mode === 'dm' && (!effectiveKeeperOnline || unresolvedTrailingMention))
     || (mode === 'state' && stateKeys.length === 0)
-
-  useEffect(() => {
-    setActiveMentionIndex(0)
-    setDismissedMentionQuery(null)
-  }, [mentionQuery, onlineKeeperNames])
 
   useEffect(() => {
     const focus = currentRoute.params.focus ?? null

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -423,14 +423,19 @@ export function keeperRecentActionLabel(
 
 export function keeperRuntimeHint(keeper: Keeper | null | undefined): string | null {
   if (!keeper) return null
+  // Use the SSOT predicate so a keeper paused by phase or pipeline_stage —
+  // not just by the `paused` flag — still surfaces the "일시정지" prefix.
+  // The same file already routes the *summary* and *short* axes through
+  // isKeeperPaused (L135, L166); the runtime hint had drifted to raw flag.
+  const paused = isKeeperPaused(keeper)
   const runtimeBlocker = keeperRuntimeBlockerHint(keeper)
-  if (runtimeBlocker) return keeper.paused ? `일시정지 원인 · ${runtimeBlocker}` : runtimeBlocker
+  if (runtimeBlocker) return paused ? `일시정지 원인 · ${runtimeBlocker}` : runtimeBlocker
   const socialFallback = socialModelFallbackHint(keeper)
   if (socialFallback) return socialFallback
   const blocker = keeper.last_blocker?.trim()
-  if (keeper.paused && blocker) return `일시정지 · ${blocker}`
-  if (keeper.paused && keeper.keepalive_running) return '일시정지 · 하트비트만 유지 중'
-  if (keeper.paused) return '일시정지됨'
+  if (paused && blocker) return `일시정지 · ${blocker}`
+  if (paused && keeper.keepalive_running) return '일시정지 · 하트비트만 유지 중'
+  if (paused) return '일시정지됨'
   if (blocker) return `차단 요인 · ${blocker}`
   return null
 }


### PR DESCRIPTION
## Summary

Follow-up to #19347 (Monitor SSOT consolidation). Audited the rest of the dashboard for keeper info exposure inconsistencies on three axes — **데이터 소스 / SSOT predicate / phase 정규화** — and fixed the three actionable findings in one surgical change.

## Findings (audit)

| 축 | 사이트 | 종류 | 처리 |
|---|---|---|---|
| 데이터 소스 | `board/composer-v2.ts` ↔ `ops/quick-intervene.ts` | ~20줄 mention 로직 + 2 useState 중복 (DRY 위반) | **통일** — `useOperatorMentionContext()` hook 추출 |
| Predicate 회피 | `lib/keeper-runtime-display.ts:keeperRuntimeHint` | raw `keeper.paused` 4분기, 같은 파일 다른 함수는 `isKeeperPaused()` 호출 | **교체** — SSOT predicate 호출로 |
| Phase 정규화 | `components/keeper-phase-strip.ts:toPascalPhase` | `getPhaseStyle()` 가 이미 내부에서 `toKeeperPhase()` SSOT 호출 → 이중 변환, 컴포넌트 파일에서 SSOT 흉내 | **숙청** — 함수 + import + test block 제거 |

부수 발견 (별도 도메인, 본 PR scope 밖): `governance.ts` judge status / `activity-graph` node status / `flow-control` namespace pause / `keeper-presence-store` IDE presence — 각자 다른 도메인이라 keeper roster SSOT 와 충돌하지 않음.

## Changes

### #1 — Mention context hook 통일
- **새 파일**: `dashboard/src/components/common/use-operator-mention-context.ts` (96 LOC)
  - `operatorSnapshot.value` 읽기 + `isKeeperOperatorTargetable` 필터 + mention 파싱 + 파생 effective target + `activeMentionIndex` / `dismissedMentionQuery` state 캡슐화
  - hook 안에 reset effect 까지 포함 (`mentionQuery`, `onlineKeeperNames` 변화 시 reset)
  - parameter: `{ message, target, dmActive, listboxId }` — listboxId 는 컴포넌트별 다른 ARIA id 라 외부 주입
- `composer-v2.ts`: 26줄 inline computation → `mention = useOperatorMentionContext({...})` + destructure
- `quick-intervene.ts`: 동일 패턴으로 단순화
- **새 테스트**: `use-operator-mention-context.test.ts` (6 cases — filter / dm gating / parsing / effective target routing / unresolved mention / per-option id)

### #2 — `keeperRuntimeHint` SSOT predicate
- `lib/keeper-runtime-display.ts` 의 raw `keeper.paused` 4분기 (L427/431/432/433) → `const paused = isKeeperPaused(keeper)` 1회 호출 후 재사용. phase==='Paused' 인데 paused===false 인 keeper 도 "일시정지" prefix 받음. 같은 파일 L135/L166 가 이미 동일 SSOT 호출 — 일관성 회복.

### #3 — `toPascalPhase` 숙청
- `keeper-phase-strip.ts`: 함수 정의 + 3 internal caller (L23/L27/L104/L112) 제거
- `keeper-lifecycle-timeline.ts`: import + L102 caller 제거
- `keeper-phase-strip.test.ts`: `toPascalPhase` describe block (9 cases) 제거 + 사유 코멘트 (SSOT 가 `keeper-store-normalize.test.ts` 에서 closed-set 보장)

Net: **+71 / -129 lines** (+ new hook 96 LOC).

## Local Verification

- `tsc --noEmit` → exit 0
- `vitest run src/components/{common,board,ops,keeper-phase-strip,keeper-lifecycle-timeline} src/lib` → **201 files / 2184 tests pass** (incl. 6 new hook tests)
- `eslint` (8 변경 파일) → exit 0

## Skipped / Caveats

- **Pre-commit hook skipped** (`--no-verify`, 사용자 명시 승인, #19347 와 동일 사유). main HEAD 가 `test_cascade_phonebook_*` / `test_keeper_unified` 빌드 깨짐을 유지 — 본 PR 의 dashboard TypeScript 변경과 0 교집합.
- Vite full build 미실행 (CI 가 cover).
- UI 시각 검증 미수행 — composer-v2 와 quick-intervene 의 mention 자동완성·키보드 동선이 변하지 않았는지는 hook 의 동작 동등성 테스트로만 보증 (실제 keyboard interaction 은 컴포넌트 안에 남아 hook 영향 없음).

## RFC

RFC mandatory subsystem 비해당 (`pr-rfc-check.sh` 가 PASS 확인). 단순 dashboard 컴포넌트/유틸 refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
