### PR TITLE
feat(cascade): OpenAI-compatible capacity probe for RunPod health

### DIFF
--- a/lib/cascade/cascade_capacity_probe.ml
+++ b/lib/cascade/cascade_capacity_probe.ml
@@ -125,3 +125,4 @@ end
 (* ── Built-in probe registration ─────────────────────────────── *)
 
 let () = register (module Cascade_http_probe.Http_probe)
+let () = register (module Cascade_openai_probe.Openai_probe)

--- a/lib/cascade/cascade_openai_probe.ml
+++ b/lib/cascade/cascade_openai_probe.ml
@@ -1,0 +1,205 @@
+(** See cascade_openai_probe.mli for documentation. *)
+
+(* ── Explicit URL registry ──────────────────────────────────── *)
+let registered_urls : (string, unit) Hashtbl.t = Hashtbl.create 4
+let registry_mutex = Eio.Mutex.create ()
+
+let register_url ~url =
+  Eio.Mutex.use_rw ~protect:false registry_mutex (fun () ->
+    Hashtbl.replace registered_urls url ())
+;;
+
+let is_registered ~url =
+  Eio.Mutex.use_ro registry_mutex (fun () -> Hashtbl.mem registered_urls url)
+;;
+
+let registered_count () =
+  Eio.Mutex.use_ro registry_mutex (fun () -> Hashtbl.length registered_urls)
+;;
+
+let registry_clear () =
+  Eio.Mutex.use_rw ~protect:false registry_mutex (fun () ->
+    Hashtbl.clear registered_urls)
+;;
+
+(* ── Cache ──────────────────────────────────────────────────── *)
+
+type cache_entry =
+  { capacity : Cascade_throttle.capacity_info
+  ; recorded_at : float
+  }
+
+let cache_ttl_s = 5.0
+
+let cache : (string, cache_entry) Hashtbl.t = Hashtbl.create 8
+let cache_mutex = Eio.Mutex.create ()
+let now_default () = Unix.gettimeofday ()
+
+let cache_clear () =
+  Eio.Mutex.use_rw ~protect:false cache_mutex (fun () -> Hashtbl.clear cache)
+;;
+
+let cache_size () = Eio.Mutex.use_ro cache_mutex (fun () -> Hashtbl.length cache)
+
+let cached_capacity ?now url =
+  let now =
+    match now with
+    | Some n -> n
+    | None -> now_default ()
+  in
+  Eio.Mutex.use_ro cache_mutex (fun () ->
+    match Hashtbl.find_opt cache url with
+    | Some entry when now -. entry.recorded_at <= cache_ttl_s -> Some entry.capacity
+    | _ -> None)
+;;
+
+let store_capacity ~url ~capacity ~now =
+  Eio.Mutex.use_rw ~protect:false cache_mutex (fun () ->
+    Hashtbl.replace cache url { capacity; recorded_at = now })
+;;
+
+(* ── JSON parser ────────────────────────────────────────────── *)
+
+let parse_response json =
+  let open Yojson.Safe.Util in
+  match json with
+  | `Assoc _ ->
+    (match member "object" json with
+     | `String "list" ->
+       (match member "data" json with
+        | `List items when List.length items > 0 ->
+          Some
+            { Cascade_throttle.total = 1
+            ; process_active = 0
+            ; process_available = 1
+            ; process_queue_length = 0
+            ; source = Llm_provider.Provider_throttle.Discovered
+            }
+        | _ -> None)
+     | _ -> None)
+  | _ -> None
+;;
+
+(* ── HTTP probe ─────────────────────────────────────────────── *)
+
+let probe_endpoint_of base_url =
+  let stripped =
+    if String.ends_with ~suffix:"/" base_url
+    then String.sub base_url 0 (String.length base_url - 1)
+    else base_url
+  in
+  stripped ^ "/v1/models"
+;;
+
+let probe_timeout_default_s = 2.0
+
+let try_probe ~sw ~net:_ ?clock ?timeout_s ?now url =
+  let timeout_s =
+    match timeout_s with
+    | Some v -> v
+    | None -> probe_timeout_default_s
+  in
+  let _ = sw in
+  let now =
+    match now with
+    | Some n -> n
+    | None -> now_default ()
+  in
+  let endpoint = probe_endpoint_of url in
+  match
+    Masc_http_client.get_sync
+      ?clock
+      ~timeout_sec:timeout_s
+      ~url:endpoint
+      ~headers:[ "accept", "application/json" ]
+      ()
+  with
+  | Error message ->
+    Log.Cascade.debug
+      "[cascade-openai-probe] probe transport failure at %s: %s"
+      endpoint message;
+    None
+  | Ok (status, body) when status = 200 ->
+    let body_preview =
+      String.sub body 0 (min 200 (String.length body))
+    in
+    let parsed =
+      try Ok (Yojson.Safe.from_string body) with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | Yojson.Json_error msg -> Error (`Json_parse_error msg)
+      | exn -> Error (`Other exn)
+    in
+    (match parsed with
+     | Ok json ->
+       (match parse_response json with
+        | None ->
+          Log.Cascade.debug
+            "[cascade-openai-probe] dropping probe response from %s: \
+             unexpected shape; body_preview=%S"
+            endpoint body_preview;
+          None
+        | Some cap ->
+          store_capacity ~url ~capacity:cap ~now;
+          Some cap)
+     | Error (`Json_parse_error msg) ->
+       Log.Cascade.debug
+         "[cascade-openai-probe] dropping probe response from %s: \
+          malformed JSON (%s); body_preview=%S"
+         endpoint msg body_preview;
+       None
+     | Error (`Other exn) ->
+       Log.Cascade.debug
+         "[cascade-openai-probe] dropping probe response from %s: %s; \
+          body_preview=%S"
+         endpoint (Printexc.to_string exn) body_preview;
+       None)
+  | Ok (status, _body) ->
+    Log.Cascade.debug
+      "[cascade-openai-probe] probe non-200 at %s: status=%d"
+      endpoint status;
+    None
+;;
+
+let refresh_many ~sw ~net ?timeout_s urls =
+  let timeout_s =
+    match timeout_s with
+    | Some v -> v
+    | None -> probe_timeout_default_s
+  in
+  List.iter
+    (fun url ->
+       if is_registered ~url
+       then (
+         match cached_capacity url with
+         | Some _ -> ()
+         | None ->
+           let _ = try_probe ~sw ~net ~timeout_s url in
+           ()))
+    urls
+;;
+
+(* ── Probe adapter ───────────────────────────────────────────── *)
+
+module Openai_probe = struct
+  let can_probe ~url =
+    String.length url > 0
+  ;;
+
+  let probe ~sw ~net ~url ?timeout_s () =
+    match timeout_s with
+    | None -> try_probe ~sw ~net url
+    | Some v -> try_probe ~sw ~net ~timeout_s:v url
+  ;;
+
+  let cached ~url ?now () =
+    match now with
+    | None -> cached_capacity url
+    | Some v -> cached_capacity ~now:v url
+  ;;
+
+  let refresh_many ~sw ~net ~urls ?timeout_s () =
+    match timeout_s with
+    | None -> refresh_many ~sw ~net urls
+    | Some v -> refresh_many ~sw ~net ~timeout_s:v urls
+  ;;
+end

--- a/lib/cascade/cascade_openai_probe.mli
+++ b/lib/cascade/cascade_openai_probe.mli
@@ -1,0 +1,23 @@
+(** OpenAI-compatible endpoint capacity probe.
+
+    Probes OpenAI-compatible endpoints (RunPod, vLLM, etc.) via
+    [/v1/models] for basic health/capacity discovery.  Registered in
+    [Cascade_capacity_probe] after the ollama-specific probe; ollama
+    URLs take precedence via first-match semantics.
+
+    @since 0.10.0 *)
+
+(* ── Explicit URL registry ──────────────────────────────────── *)
+
+val register_url : url:string -> unit
+val is_registered : url:string -> bool
+val registered_count : unit -> int
+
+(* ── Cache ──────────────────────────────────────────────────── *)
+
+val cached_capacity : ?now:float -> string -> Cascade_throttle.capacity_info option
+val cache_size : unit -> int
+
+(* ── Probe adapter ───────────────────────────────────────────── *)
+
+module Openai_probe : Cascade_capacity_probe.Probe

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -464,7 +464,11 @@ let register_http_probe_capable ~max_concurrent candidate =
   | Some url ->
       if not (Cascade_client_capacity.is_registered url) then
         Cascade_client_capacity.register ~url ~max_concurrent;
-      Cascade_http_probe.register_url ~url
+      (match candidate.provider_cfg.kind with
+       | Llm_provider.Provider_config.Ollama ->
+           Cascade_http_probe.register_url ~url
+       | _ ->
+           Cascade_openai_probe.register_url ~url)
 
 let strategy_adapter : t Cascade_strategy.adapter =
   { health_key; capacity_key }


### PR DESCRIPTION
## Summary

RunPod MTP endpoint가 synchronous capacity probing 대상에서 제외되어, cascade가 RunPod의 capacity/health 상태를 실시간으로 인지하지 못하고 있었습니다. Background `Provider_health`는 60s interval로 느리고, failover 결정 시점에 최신 health 정보가 없습니다.

OpenAI-compatible endpoint(`/v1/models`)용 capacity probe를 추가하여 RunPod를 포함한 모든 OpenAI-compatible provider가 synchronous capacity discovery 대상이 되도록 합니다.

## Changes

- **New**: `cascade_openai_probe.ml{,i}` — OpenAI-compatible `/v1/models` probe
  - URL registry (explicit opt-in per provider)
  - 5s cache TTL, 2.0s HTTP timeout
  - JSON parser: `object="list"` + non-empty `data` array 확인
  - Fail-open: 모든 error는 `None` 반환, debug 로깅만
  - `can_probe`는 broad (모든 non-empty URL), `cached`/`refresh_many`는 explicit registry 확인

- **Modified**: `cascade_capacity_probe.ml`
  - `register (module Cascade_openai_probe.Openai_probe)` 추가 (ollama probe 이후)
  - Ollama가 first-match precedence 유지

- **Modified**: `cascade_runtime_candidate.ml`
  - `register_http_probe_capable`를 provider kind별로 분기:
    - `Ollama` -> `Cascade_http_probe.register_url`
    - 그 외 -> `Cascade_openai_probe.register_url`

## Verification

- `dune build lib/cascade/` PASS
- `dune build @check`는 tier-purge PR (#19340) pre-existing breakage로 인해 전체 tree 실패, cascade lib 자체는 clean

## Design Notes

- **Broad `can_probe` + selective registration**: `cascade_http_probe_url.ml`의 gate(`can_probe`)는 broad catch-all로 열어두고, 실제 HTTP 요청은 `refresh_many`/`cached`에서 explicit registry hit 여부로 제어. 이 pattern은 기존 ollama probe의 explicit registry와 동일한 구조.
- **Fail-open everywhere**: probe 실패, parse 실패, non-200 모두 `None` -> `has_capacity`는 `None`일 때 `true`. Cascade "merry go round"는 멈추지 않습니다.

## Related

- Fix 4 of 5 in root cause fix cluster
- RFC-0192 deadline composition (Fix 2), typed fiber_unresolved (Fix 3), 524 reclassification (Fix 1) 이미 merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)