### PR TITLE
feat(cascade): expose capacity probe source to metrics

### DIFF
--- a/lib/cascade/cascade_http_probe.ml
+++ b/lib/cascade/cascade_http_probe.ml
@@ -184,6 +184,12 @@ let try_probe ~sw ~net:_ ?clock ?timeout_s ?now url =
        (match parse_response json with
         | None -> None
         | Some cap ->
+          let source_label =
+            match cap.Cascade_throttle.source with
+            | Llm_provider.Provider_throttle.Discovered -> "discovered"
+            | Llm_provider.Provider_throttle.Fallback -> "fallback"
+          in
+          Cascade_metrics.on_capacity_probe ~url ~source:source_label;
           store_capacity ~url ~capacity:cap ~now;
           Some cap)
      | Error (`Json_parse_error msg) ->

--- a/lib/cascade/cascade_metrics.ml
+++ b/lib/cascade/cascade_metrics.ml
@@ -394,6 +394,13 @@ let on_strategy_starvation_guard ~cascade ~strategy =
     ~labels:[ ("cascade", cascade); ("strategy", strategy) ]
     ()
 
+let metric_capacity_probe = "masc_cascade_capacity_probe_result_total"
+
+let on_capacity_probe ~url ~source =
+  Prometheus.inc_counter metric_capacity_probe
+    ~labels:[ ("url", url); ("source", source) ]
+    ()
+
 (* [Cascade_runtime.default_model_strings] has two arms that fall
    back to the provider-adapter default-local fallback label when the
    normal cascade.toml-derived label resolution can't produce

--- a/lib/cascade/cascade_metrics.mli
+++ b/lib/cascade/cascade_metrics.mli
@@ -130,6 +130,13 @@ val on_strategy_starvation_guard : cascade:string -> strategy:string -> unit
     pre-capacity-filter candidate list because every candidate
     reported capacity=0.  [strategy] must be [priority_tier]. *)
 
+val on_capacity_probe : url:string -> source:string -> unit
+(** Tick the capacity-probe result counter when a probe (ollama or
+    OpenAI-compatible) successfully returns capacity data.
+    [source] must be one of [discovered] or [fallback].  Provides
+    visibility into whether cascade capacity decisions are based on
+    live endpoint data or on static fallback assumptions. *)
+
 val on_default_label_fallback : cascade:string -> reason:string -> unit
 (** Tick the default-label-fallback counter at
     [Cascade_runtime.default_model_strings] when label resolution

--- a/lib/cascade/cascade_metrics_registry.ml
+++ b/lib/cascade/cascade_metrics_registry.ml
@@ -64,6 +64,11 @@ let all_cascade_counters : (string * string) list =
        (duration distribution, this is entry rate by cause)." )
   ; ( "masc_cascade_strategy_starvation_guard_total"
     , "masc_cascade_strategy_starvation_guard_total" )
+  ; ( "masc_cascade_capacity_probe_result_total"
+    , "Total successful capacity probe results by source. Labels: url, \
+       source (discovered | fallback). Provides visibility into whether \
+       cascade capacity decisions are based on live endpoint data or \
+       static fallback assumptions." )
   ; ( "masc_cascade_default_label_fallback_total"
     , "masc_cascade_default_label_fallback_total" )
   ; ( "masc_cascade_max_context_fallback_total"


### PR DESCRIPTION
## Summary

`Cascade_throttle.capacity_info.source` 필드(`Discovered` | `Fallback`)가 Prometheus 메트릭에 전혀 노출되지 않아, 운영자가 capacity=0 신호가 live probe에서 왔는지 static fallback에서 왔는지 구분할 수 없었습니다.

새 counter `[masc_cascade_capacity_probe_result_total]`를 추가하여 이 gap을 메웁니다.

## Changes

- **New metric**: `masc_cascade_capacity_probe_result_total`
  - Labels: `url` (probed endpoint), `source` (`discovered` | `fallback`)
  - Call site: `Cascade_http_probe.try_probe` 성공 시 emit
  - `Cascade_metrics.on_capacity_probe ~url ~source` helper 추가
  - `Cascade_metrics_registry`에 counter 등록

## Observability Impact

- 기존 `masc_cascade_strategy_starvation_guard_total`와 페어링: starvation guard가 터질 때, 같은 URL에 최근 `discovered` entry가 있는지 확인하면 endpoint가 진짜 exhausted인지 probe가 깨진 건지 구분 가능
- `cascade_openai_probe` emission은 #19359 머지 후 follow-up 추가 예정

## Verification

- `dune build lib/cascade/` PASS

## Related

- Fix 5 of 5 in root cause fix cluster
- #19359 (OpenAI-compatible probe — stacked, 머지 후 openai probe 쪽도 동일 metric emit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)