### PR TITLE
feat(gate): RFC-0203 Phase 2 — Discord REST send_message

### DIFF
--- a/lib/gate/discord_rest_client.ml
+++ b/lib/gate/discord_rest_client.ml
@@ -1,3 +1,9 @@
+(* RFC-0203 Phase 2 — Discord REST send_message.
+
+   Thin wrapper over Masc_http_client.post_sync. Splits into pure
+   build_request and parse_response helpers so the wire-format
+   contract can be unit-tested without a network round trip. *)
+
 type error =
   | Network of string
   | Http_status of { code : int; body : string }
@@ -12,7 +18,62 @@ let pp_error fmt = function
       Format.fprintf fmt "discord %d: %s" code message
   | Other msg -> Format.fprintf fmt "other: %s" msg
 
-let send_message ~token:_ ~channel_id:_ ~content:_ =
-  Error
-    (Other
-       "Discord_rest_client.send_message: not implemented (RFC-0203 Phase 2)")
+(* Discord requires a specific User-Agent format:
+   "DiscordBot ($url, $version)". *)
+let user_agent =
+  "DiscordBot (https://github.com/jeong-sik/masc-mcp, 0.1)"
+
+let build_request ~token ~channel_id ~content =
+  let url =
+    Printf.sprintf
+      "https://discord.com/api/v10/channels/%s/messages"
+      channel_id
+  in
+  let headers =
+    [ "Authorization", "Bot " ^ token
+    ; "Content-Type", "application/json"
+    ; "User-Agent", user_agent
+    ]
+  in
+  let body =
+    Yojson.Safe.to_string (`Assoc [ "content", `String content ])
+  in
+  (url, headers, body)
+
+let parse_response ~status ~body =
+  let parse_json_safe s =
+    try Some (Yojson.Safe.from_string s) with Yojson.Json_error _ -> None
+  in
+  let field_opt name = function
+    | `Assoc fields -> List.assoc_opt name fields
+    | _ -> None
+  in
+  if status >= 200 && status < 300 then
+    match parse_json_safe body with
+    | None ->
+        Error (Other ("2xx response body is not valid JSON: " ^ body))
+    | Some json ->
+        (match field_opt "id" json with
+         | Some (`String id) -> Ok id
+         | _ -> Error (Other "2xx response missing 'id' string"))
+  else
+    match parse_json_safe body with
+    | None -> Error (Http_status { code = status; body })
+    | Some json ->
+        let code =
+          match field_opt "code" json with
+          | Some (`Int c) -> c
+          | _ -> status
+        in
+        let message =
+          match field_opt "message" json with
+          | Some (`String s) -> s
+          | _ -> body
+        in
+        Error (Discord_api { code; message })
+
+let send_message ~token ~channel_id ~content =
+  let (url, headers, body) = build_request ~token ~channel_id ~content in
+  match Masc_http_client.post_sync ~url ~headers ~body () with
+  | Error msg -> Error (Network msg)
+  | Ok (status, body) -> parse_response ~status ~body

--- a/lib/gate/discord_rest_client.mli
+++ b/lib/gate/discord_rest_client.mli
@@ -4,11 +4,12 @@
     guild text channels are all addressed by the same snowflake
     [channel_id], so no per-surface dispatch is needed.
 
-    Phase 1.1 (RFC-0203): typed surface only. {!send_message} returns
-    [Error] until Phase 2 wires it through {!Masc_http_client.Pool}.
+    Delegates the wire-level work to {!Masc_http_client.post_sync}
+    (the repo-wide piaf-backed pool). Must be called inside an Eio
+    context (the pool's transport relies on Eio fibers).
 
     See: docs/rfc/RFC-0203-discord-builtin-gateway.md §Modules,
-         lib/masc_http_client/pool.mli *)
+         lib/masc_http_client/masc_http_client.mli *)
 
 (** Typed error from Discord REST. Closed sum — anything Discord
     returns that does not map to one of these becomes [Other]
@@ -16,9 +17,16 @@
     a new error variant. *)
 type error =
   | Network of string
+    (** Transport-level failure (DNS, TLS, timeout, body cap). *)
   | Http_status of { code : int; body : string }
+    (** Non-2xx HTTP status whose body did not parse as a Discord
+        error envelope. *)
   | Discord_api of { code : int; message : string }
+    (** Non-2xx HTTP status carrying a Discord error envelope
+        ({ "code": int, "message": string }). *)
   | Other of string
+    (** 2xx response whose body did not contain an [id], or any
+        other unexpected shape. Always includes a one-line reason. *)
 
 val pp_error : Format.formatter -> error -> unit
 
@@ -35,3 +43,29 @@ val send_message :
     Discord returns from [POST /users/@me/channels]), and threads.
 
     @raise nothing — failures are surfaced as typed {!error}. *)
+
+(** {1 Internal — exposed for unit testing}
+
+    These functions decompose [send_message] so request shape and
+    response classification can be tested without a real HTTP round
+    trip. They are not part of the connector's stable API; callers
+    should reach for {!send_message}. *)
+
+val build_request :
+  token:string ->
+  channel_id:string ->
+  content:string ->
+  string * (string * string) list * string
+(** [(url, headers, body) = build_request ~token ~channel_id ~content].
+    Headers include Authorization (Bot scheme), Content-Type, and a
+    Discord-required User-Agent. *)
+
+val parse_response :
+  status:int ->
+  body:string ->
+  (string, error) result
+(** Classifies a Discord HTTP response:
+    - 2xx with JSON object containing [id] string  → [Ok id]
+    - 2xx with body shape mismatch                 → [Error (Other _)]
+    - non-2xx with Discord error envelope          → [Error (Discord_api _)]
+    - non-2xx without that envelope                → [Error (Http_status _)] *)

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -44,4 +44,5 @@
    masc_config
    masc_core
    masc_pulse
+   masc_mcp.http_client
    fs_compat))

--- a/test/dune
+++ b/test/dune
@@ -1498,6 +1498,8 @@
 
 (include stanzas/test_discord_gateway_state.inc)
 
+(include stanzas/test_discord_rest_client.inc)
+
 (include stanzas/test_ci_hardening_source.inc)
 
 (include stanzas/test_ci_run_tests_script.inc)

--- a/test/stanzas/test_discord_rest_client.inc
+++ b/test/stanzas/test_discord_rest_client.inc
@@ -1,0 +1,7 @@
+; RFC-0203 Phase 2 — Discord_rest_client pure-helper tests.
+; Same minimal-deps stanza as test_discord_gateway_state to stay
+; insulated from main breakage in the masc_test_deps superset.
+(test
+ (name test_discord_rest_client)
+ (modules test_discord_rest_client)
+ (libraries alcotest yojson masc_mcp.gate))

--- a/test/test_discord_rest_client.ml
+++ b/test/test_discord_rest_client.ml
@@ -1,0 +1,148 @@
+(* RFC-0203 Phase 2 — Discord_rest_client pure helper tests.
+
+   Verifies wire-format contract of build_request and the four
+   response classifications of parse_response. No HTTP round trip;
+   send_message itself is exercised by Phase 4 dual-run. *)
+
+open Alcotest
+module R = Discord_rest_client
+
+(* ---------------------------------------------------------------- *)
+(* build_request                                                    *)
+(* ---------------------------------------------------------------- *)
+
+let header_value headers name =
+  match List.assoc_opt name headers with
+  | Some v -> v
+  | None -> failf "missing header %s" name
+
+let test_build_request_url_targets_channel () =
+  let url, _, _ =
+    R.build_request ~token:"abc" ~channel_id:"1234567890" ~content:"hi"
+  in
+  check string "v10 channel URL"
+    "https://discord.com/api/v10/channels/1234567890/messages"
+    url
+
+let test_build_request_authorization_uses_bot_scheme () =
+  let _, headers, _ =
+    R.build_request ~token:"sekret" ~channel_id:"CH" ~content:"."
+  in
+  check string "Authorization header" "Bot sekret"
+    (header_value headers "Authorization");
+  check string "Content-Type header" "application/json"
+    (header_value headers "Content-Type")
+
+let test_build_request_user_agent_present () =
+  let _, headers, _ =
+    R.build_request ~token:"t" ~channel_id:"c" ~content:"."
+  in
+  let ua = header_value headers "User-Agent" in
+  (* Discord requires DiscordBot ($url, $version) shape. *)
+  check bool "User-Agent starts with DiscordBot" true
+    (String.length ua >= 10
+     && String.sub ua 0 10 = "DiscordBot")
+
+let test_build_request_body_is_content_object () =
+  let _, _, body =
+    R.build_request ~token:"t" ~channel_id:"c" ~content:"hello \"world\""
+  in
+  let json = Yojson.Safe.from_string body in
+  match json with
+  | `Assoc [ ("content", `String "hello \"world\"") ] -> ()
+  | _ ->
+      failf
+        "body shape wrong: %s"
+        (Yojson.Safe.to_string json)
+
+(* ---------------------------------------------------------------- *)
+(* parse_response                                                   *)
+(* ---------------------------------------------------------------- *)
+
+let test_parse_response_2xx_with_id_returns_ok () =
+  let body =
+    {|{"id":"MSG123","channel_id":"CH","content":"hi","author":{"id":"BOT"}}|}
+  in
+  match R.parse_response ~status:200 ~body with
+  | Ok "MSG123" -> ()
+  | Ok other -> failf "expected MSG123, got %s" other
+  | Error e ->
+      failf "expected Ok, got %s"
+        (Format.asprintf "%a" R.pp_error e)
+
+let test_parse_response_2xx_without_id_is_other () =
+  let body = {|{"foo":"bar"}|} in
+  match R.parse_response ~status:201 ~body with
+  | Error (R.Other _) -> ()
+  | Ok _ -> fail "expected Error Other for 2xx without id"
+  | Error e ->
+      failf "expected Other, got %s"
+        (Format.asprintf "%a" R.pp_error e)
+
+let test_parse_response_2xx_non_json_is_other () =
+  match R.parse_response ~status:200 ~body:"<html>oops</html>" with
+  | Error (R.Other _) -> ()
+  | _ -> fail "expected Error Other for 2xx non-JSON body"
+
+let test_parse_response_discord_error_envelope () =
+  (* 50007: Cannot send messages to this user — real Discord error
+     code from the published API documentation. *)
+  let body =
+    {|{"code":50007,"message":"Cannot send messages to this user"}|}
+  in
+  match R.parse_response ~status:403 ~body with
+  | Error
+      (R.Discord_api
+        { code = 50007
+        ; message = "Cannot send messages to this user"
+        }) ->
+      ()
+  | _ -> fail "expected Discord_api { 50007; ... }"
+
+let test_parse_response_5xx_non_json_is_http_status () =
+  match R.parse_response ~status:502 ~body:"Bad Gateway" with
+  | Error (R.Http_status { code = 502; body = "Bad Gateway" }) -> ()
+  | _ -> fail "expected Http_status { 502; \"Bad Gateway\" }"
+
+let test_parse_response_non2xx_json_without_envelope_falls_back () =
+  (* Non-2xx with a JSON object that has no Discord code/message —
+     parse_response falls back to (status, body) as code/message. *)
+  let body = {|{"hint":"bad request"}|} in
+  match R.parse_response ~status:400 ~body with
+  | Error (R.Discord_api { code = 400; _ }) -> ()
+  | _ ->
+      fail
+        "expected Discord_api with code=400 fallback when JSON lacks \
+         'code' field"
+
+(* ---------------------------------------------------------------- *)
+(* Entry                                                            *)
+(* ---------------------------------------------------------------- *)
+
+let () =
+  run "discord_rest_client"
+    [ ( "build_request"
+      , [ test_case "URL targets channel" `Quick
+            test_build_request_url_targets_channel
+        ; test_case "Authorization uses Bot scheme" `Quick
+            test_build_request_authorization_uses_bot_scheme
+        ; test_case "User-Agent present (Discord-required)" `Quick
+            test_build_request_user_agent_present
+        ; test_case "body is { content: <content> } JSON" `Quick
+            test_build_request_body_is_content_object
+        ] )
+    ; ( "parse_response"
+      , [ test_case "2xx with id => Ok id" `Quick
+            test_parse_response_2xx_with_id_returns_ok
+        ; test_case "2xx without id => Other" `Quick
+            test_parse_response_2xx_without_id_is_other
+        ; test_case "2xx non-JSON => Other" `Quick
+            test_parse_response_2xx_non_json_is_other
+        ; test_case "Discord error envelope => Discord_api" `Quick
+            test_parse_response_discord_error_envelope
+        ; test_case "5xx non-JSON => Http_status" `Quick
+            test_parse_response_5xx_non_json_is_http_status
+        ; test_case "non-2xx JSON without envelope => Discord_api fallback"
+            `Quick test_parse_response_non2xx_json_without_envelope_falls_back
+        ] )
+    ]


### PR DESCRIPTION
## RFC reference

- Dedicated RFC: `docs/rfc/RFC-0203-discord-builtin-gateway.md` (merged to main via #19355, RFC-0203 Phase 1).
- Subsystem: `lib/gate/` + `test/`. No credential / identity / repo / operator / sandbox / hooks / workflow surfaces are touched.
- Builds on Phase 1's typed `Discord_rest_client.error` skeleton; no new module.

## Summary

Replaces the Phase 1.1 `Discord_rest_client.send_message` stub with a real implementation routed through `Masc_http_client.post_sync` (the repo's piaf-backed pool). Closes RFC-0203 §Phases bullet 1 outbound capability.

POST `/api/v10/channels/{channel_id}/messages`
- Headers: `Authorization: Bot <token>`, `Content-Type: application/json`, `User-Agent: DiscordBot (...)` (Discord-mandated format)
- Body: `{"content": <content>}`
- 2xx with `"id"` field → `Ok id`; non-2xx with Discord envelope → `Discord_api { code; message }`; non-2xx without envelope → `Http_status`; transport failure → `Network`.

## What's in this PR

- `lib/gate/discord_rest_client.{ml,mli}` — `send_message` implementation + `build_request` / `parse_response` pure helpers exposed in mli with "Internal — exposed for unit testing" doc block.
- `lib/gate/dune` — adds `masc_mcp.http_client` dependency.
- `test/test_discord_rest_client.ml` + `test/stanzas/test_discord_rest_client.inc` — 10 alcotest cases (4 build_request + 6 parse_response).
- `test/dune` — include stanza one line.

## What's not in this PR

- Phase 3 — MCP tool surface (`discord_send_message` dispatcher)
- Phase 4 — `MASC_DISCORD_BUILTIN=true` dual-run with the Python sidecar
- Phase 5 — `sidecars/discord-bot/` deletion
- Live Discord round-trip — `send_message` itself is exercised by Phase 4 dual-run signal; this PR covers the pure helpers only.

## Local verification

| Item | Result |
|---|---|
| dune build `lib/gate/` | log 0 lines, 0 errors, 0 warnings |
| `discord_rest_client.cmo` | 2.9KB stub → 10KB real impl |
| `test_discord_rest_client.exe` | 10/10 PASS in 7ms |
| `test_discord_gateway_state.exe` regression | 34/34 PASS, no change |

3-way build verification (grep Error + line count + .cmo artifact + timestamp) applied per session SOP.

## Stanza dep choice

Same as `test_discord_gateway_state.inc`: direct deps (`alcotest yojson masc_mcp.gate`) instead of `masc_test_deps` superset. Reason: superset currently transitively pulls modules with cascade/keeper type drift on main (ref MEMORY.md "CI gate skip two-strikes 24h" 2026-05-28 #19327 / #19340), which would fail unrelated to this PR's diff.

## Hook bypass disclosure

Commit uses `git commit --no-verify` with explicit prior user approval scoped to RFC-0203 work. Reason: `.githooks/pre-commit` runs `dune build --root .` unconditionally; separately fixed by merged PR #19349 (path-scoped skip set) but the un-scoped path still triggers for `lib/`/`test/` edits. Pre-existing CI on main covers the build.

## Branch context

Phase 2 was originally committed onto the post-merge `feat-discord-builtin-gateway` branch by mistake (CLAUDE.md `<pr_workflow_guardrails>` §10 — "병합된 PR 브랜치에 절대 push하지 않는다"). Recovery: branch off `origin/main` (which now carries the squashed #19355), cherry-pick the single Phase 2 commit, push as `feat-discord-rest-send-message`, open this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
