### PR TITLE
fix(cascade): break capacity probe dependency cycle (#19367)

### DIFF
--- a/lib/cascade/cascade_openai_probe.mli
+++ b/lib/cascade/cascade_openai_probe.mli
@@ -20,4 +20,28 @@ val cache_size : unit -> int
 
 (* ── Probe adapter ───────────────────────────────────────────── *)
 
-module Openai_probe : Cascade_capacity_probe.Probe
+(** First-class probe wrapper for registration with
+    {!Cascade_capacity_probe.register}.  Structurally satisfies
+    {!Cascade_capacity_probe.Probe} without an explicit annotation,
+    avoiding a circular dependency between the two compilation units. *)
+module Openai_probe : sig
+  val can_probe : url:string -> bool
+
+  val probe
+    :  sw:Eio.Switch.t
+    -> net:[> [> `Generic ] Eio.Net.ty ] Eio.Resource.t
+    -> url:string
+    -> ?timeout_s:float
+    -> unit
+    -> Cascade_throttle.capacity_info option
+
+  val cached : url:string -> ?now:float -> unit -> Cascade_throttle.capacity_info option
+
+  val refresh_many
+    :  sw:Eio.Switch.t
+    -> net:[> [> `Generic ] Eio.Net.ty ] Eio.Resource.t
+    -> urls:string list
+    -> ?timeout_s:float
+    -> unit
+    -> unit
+end

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -534,9 +534,9 @@ let () =
           test_case "ServerError 502 is recoverable" `Quick
             test_server_error_502_is_recoverable;
           test_case
-            "ServerError 524 is capacity backpressure but not transient retry"
+            "ServerError 524 is transient network error and cascade rotation"
             `Quick
-            test_server_error_524_is_capacity_backpressure_rotation_not_transient_retry;
+            test_server_error_524_is_transient_network_error_and_cascade_rotation;
           test_case "wrapped ServerError 524 is capacity backpressure" `Quick
             test_wrapped_524_is_capacity_backpressure;
           test_case "AuthError is recoverable" `Quick


### PR DESCRIPTION
## Summary

Fixes main breakage from PR #19359 + #19361 interaction (Issue #19367).

Three issues fixed:
1. **Dependency cycle**: `cascade_openai_probe.mli` explicitly referenced `Cascade_capacity_probe.Probe` type, creating circular dependency
2. **Signature mismatch**: `Openai_probe` module signature didn't match
3. **Test reference**: Old test function name referenced at line 539

## Changes

- `cascade_openai_probe.mli`: Removed explicit `Cascade_capacity_probe.Probe` annotation, using structural typing instead (same pattern as `Http_probe`)
- `test_keeper_error_classify_recoverable.ml`: Updated test case reference to match function renamed in PR #19348

## Verification

- `dune build .` PASS
- Closes #19367

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>