### PR TITLE
fix(dashboard): update stale_fleet_batch test to include paused prefix

### DIFF
--- a/dashboard/src/components/mission-agent-cards.test.ts
+++ b/dashboard/src/components/mission-agent-cards.test.ts
@@ -140,7 +140,7 @@ describe('mission keeper runtime helpers', () => {
     } as Keeper
 
     expect(keeperRuntimeHint(keeper)).toBe(
-      '여러 keeper가 같은 watchdog 창에서 stale로 종료되어 supervisor pause/backoff 상태 확인이 필요합니다.',
+      '일시정지 원인 · 여러 keeper가 같은 watchdog 창에서 stale로 종료되어 supervisor pause/backoff 상태 확인이 필요합니다.',
     )
   })
 


### PR DESCRIPTION
## Summary
- `keeperRuntimeHint` prepends "일시정지 원인 · " when `isKeeperPaused(keeper)` is true (PR #19354)
- Test for `stale_fleet_batch` blocker at line 142 was not updated, causing Dashboard CI failure
- This blocks CI Gate for all PRs (Dashboard is a required check)

## Root cause
PR #19354 introduced `isKeeperPaused` predicate that adds "일시정지 원인 · " prefix to runtime blocker hints when the keeper is paused. The `stale_fleet_batch` test case still expected the raw hint without prefix.

## Test plan
- [ ] Dashboard test passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)