### PR TITLE
fix(schemas/execute): widen tool_execute.timeout_sec to accept JSON string (#18472)

### DIFF
--- a/lib/tool_shard_types_schemas_execute.ml
+++ b/lib/tool_shard_types_schemas_execute.ml
@@ -94,12 +94,27 @@ let tool_execute_cwd_field =
 ;;
 
 let tool_execute_timeout_sec_field =
+  (* Issue #18472: the LLM emits the field as a JSON string (["30"])
+     about 60x/day, which the Anthropic SDK schema validator then rejects
+     under a strict ["type": "number"], routing the call through
+     [correction_pipeline] for a silent string-to-number coerce
+     ([oas:agent_tools] events ["fixed 1 field(s) fields=timeout_sec
+     stages=coercion"] on the [Execute] tool, 60/141 = 43% of the
+     5/29 correction load). The downstream handler
+     ([Agent_tool_execute_timeout.clamp_shell_timeout]) reads the field
+     via [Safe_ops.json_float] which already coerces both shapes, so the
+     coercion is a wire-format quirk, not a semantic one. Widening the
+     advertised JSON Schema to accept either shape lets the LLM's typical
+     string representation pass validation directly. *)
   ( "timeout_sec"
   , `Assoc
-      [ "type", `String "number"
+      [ ( "type"
+        , `List [ `String "number"; `String "string" ] )
       ; ( "description"
         , `String
-            "Timeout seconds for foreground typed execution (default: 30, max: 180)." )
+            "Timeout seconds for foreground typed execution (default: 30, max: \
+             180). Numeric strings (e.g. \"30\") are accepted and coerced; \
+             prefer the bare number form." )
       ] )
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -1795,6 +1795,8 @@
 
 (include stanzas/test_claim_outcome_typed.inc)
 
+(include stanzas/test_execute_timeout_schema_widen.inc)
+
 (include stanzas/test_parse_outcome.inc)
 
 (include stanzas/test_pr_open_script.inc)

--- a/test/stanzas/test_execute_timeout_schema_widen.inc
+++ b/test/stanzas/test_execute_timeout_schema_widen.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_execute_timeout_schema_widen)
+ (modules test_execute_timeout_schema_widen)
+ (libraries masc_mcp alcotest yojson))

--- a/test/test_execute_timeout_schema_widen.ml
+++ b/test/test_execute_timeout_schema_widen.ml
@@ -1,0 +1,79 @@
+(* Issue #18472 surgical: pin the widened [type] of [tool_execute]'s
+   [timeout_sec] field. The Anthropic SDK schema validator rejects a
+   strict ["number"] when the LLM emits a JSON string (["30"]), routing
+   the call through [correction_pipeline] for a silent coerce — 60
+   events on 2026-05-29 in [/private/tmp/masc-server.log], 43% of that
+   day's [correction_pipeline] load. Widening the advertised JSON
+   Schema to [["number","string"]] lets the LLM's typical shape pass
+   validation without correction. The downstream handler
+   ([Agent_tool_execute_timeout.clamp_shell_timeout] →
+   [Safe_ops.json_float]) already accepts both shapes, so there is no
+   semantic change — only a wire-format widening. *)
+
+open Alcotest
+module S = Masc_mcp.Tool_shard_types_schemas_execute
+
+(* Pull the JSON associated with the [timeout_sec] field's [type] key. *)
+let type_value () =
+  match S.tool_execute_timeout_sec_field with
+  | _name, `Assoc fields ->
+    (match List.assoc_opt "type" fields with
+     | Some v -> v
+     | None -> Alcotest.fail "timeout_sec field is missing the 'type' key")
+  | _ -> Alcotest.fail "timeout_sec field is not a JSON object"
+
+let type_accepts_number_and_string () =
+  match type_value () with
+  | `List xs ->
+    let strings =
+      List.map
+        (function
+          | `String s -> s
+          | _ -> Alcotest.fail "timeout_sec type list contains a non-string element")
+        xs
+    in
+    check (list string)
+      "timeout_sec type accepts both number and string (in declared order)"
+      [ "number"; "string" ]
+      strings
+  | `String single ->
+    Alcotest.failf
+      "timeout_sec type is still the strict scalar %S; widening regressed"
+      single
+  | other ->
+    Alcotest.failf
+      "timeout_sec type has unexpected JSON shape: %s"
+      (Yojson.Safe.to_string other)
+
+(* The widening must preserve the user-facing description so the LLM
+   keepers' prompt context does not lose the default/max hint. *)
+let description_mentions_default_and_max () =
+  let _name, body = S.tool_execute_timeout_sec_field in
+  let body = match body with `Assoc xs -> xs | _ -> Alcotest.fail "field not an object" in
+  let desc =
+    match List.assoc_opt "description" body with
+    | Some (`String s) -> s
+    | _ -> Alcotest.fail "timeout_sec description missing or not a string"
+  in
+  let contains hay needle =
+    let nh = String.length hay
+    and nn = String.length needle in
+    let rec loop i =
+      if i + nn > nh then false
+      else if String.sub hay i nn = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+  in
+  check bool "description still mentions default 30" true (contains desc "default: 30");
+  check bool "description still mentions max 180" true (contains desc "max: 180")
+
+let () =
+  run "execute_timeout_schema_widen"
+    [ "type widening"
+    , [ test_case "accepts number and string" `Quick type_accepts_number_and_string ]
+    ; "description preserved"
+    , [ test_case "default + max still documented" `Quick
+          description_mentions_default_and_max
+      ]
+    ]


### PR DESCRIPTION
## Root finding

\`Tool_shard_types_schemas_execute.tool_execute_timeout_sec_field\` declares:

\`\`\`ocaml
( \"timeout_sec\"
, \`Assoc
    [ \"type\", \`String \"number\"
    ; \"description\", \`String \"Timeout seconds ... default: 30, max: 180.\" ] )
\`\`\`

The Anthropic SDK schema validator therefore rejects the **JSON string form** (\`\"30\"\`) that keeper LLMs emit, routing the call through \`correction_pipeline\` for a silent string-to-number coerce.

Fleet baseline from \`/private/tmp/masc-server.log\` on 2026-05-29 (stdout sink — the only path that captured \`oas:agent_tools\` events before [PR #19379](https://github.com/jeong-sik/masc-mcp/pull/19379)'s atomic-rotate fix landed):

\`\`\`
correction_pipeline rows (5/29 partial): 141
fields=timeout_sec stages=coercion:      60   ← 43% of the day's load
on tool=Execute:                         60   ← all from typed Execute
\`\`\`

## Why the fix is wire-format-only

The downstream handler does **not** depend on the wire type:

\`\`\`
Agent_tool_execute_runtime.handle_tool_execute_typed
  └─ Agent_tool_execute_timeout.clamp_shell_timeout
       └─ Safe_ops.json_float ~default \"timeout_sec\" args
\`\`\`

\`Safe_ops.json_float\` already coerces both number and numeric-string. The Anthropic SDK rejection is a wire-format quirk, not a semantic one. Widening:

\`\`\`ocaml
\"type\", \`List [ \`String \"number\"; \`String \"string\" ]
\`\`\`

makes the LLM's typical shape pass validation directly, eliminating the \`fixed 1 field(s) fields=timeout_sec stages=coercion\` corrections that previously fired ~60/day.

## Anti-pattern check (RFC-0088 §Workaround Rejection Bar)

| Signature | This PR |
|---|---|
| §1 counter-as-fix | The *fix* is the wire-format widening; the previous \`correction_pipeline\` event was the silent coerce that hid the schema mismatch. We're removing the *need* for that coerce, not annotating it. |
| §2 substring classifier | N/A |
| §3 N-of-M | 1 file touched; downstream parser already handles both shapes — no caller migration |
| §4 cap/cooldown/dedup/repair | N/A |
| §5 exhaustive enforce | Closed multi-type JSON Schema accepts the two valid wire shapes. Anything else still fails validation as before |
| §6 test backdoor | tests use the public \`tool_execute_timeout_sec_field\` binding only |
| §7 codemod miss | N/A |

## Tests

\`test/test_execute_timeout_schema_widen.ml\` — 2 cases, both PASS:

\`\`\`
$ dune exec test/test_execute_timeout_schema_widen.exe
execute_timeout_schema_widen:
  type widening:         accepts number and string    [OK]
  description preserved: default + max still docu...  [OK]
Test Successful in 0.001s. 2 tests run.
\`\`\`

## Out of scope (separate follow-up)

- **Remaining 57% of 5/29 correction_pipeline load**: \`fields=content\` (38, format_normalization, \`keeper_board_post\`) and \`fields=limit\` (18, coercion, \`keeper_board_list\`). Each needs its own analysis of the source-side coerce vs schema fix tradeoff.
- **Advertised-but-unused typed field**: \`Agent_tool_execute_typed_input.execute_input\` does not carry \`timeout_sec\` — silently dropped at typed parse, then re-extracted by caller from raw args. Pre-existing split-brain, out of scope for the wire-format fix.

## RFC-WAIVED

No credential / identity / sandbox / hooks / workflow surface touched.

## Related

- #18472 (the issue this is part of)
- PR #19379 (atomic-rotate + self-heal that restored the fleet log so this baseline could be measured)
- PR #19360 (RFC-0196 P0 typed Tool_name lookup — same RFC-0088 §2 removal pattern at a different layer)
- Memory: \`reference_masc_fleet_log_path_drift_2026_05_29\` (path drift discovery that surfaced the right baseline)

🤖 Generated with Claude Code