### PR TITLE
fix(schemas): widen limit field to accept JSON string at 3 sites (#18472)

### DIFF
--- a/lib/tool_shard_types_schemas_base.ml
+++ b/lib/tool_shard_types_schemas_base.ml
@@ -61,8 +61,20 @@ let base_tools : Masc_domain.tool_schema list =
                       ] )
                 ; ( "limit"
                   , `Assoc
-                      [ "type", `String "integer"
-                      ; "description", `String "max results (1-10, default 5)"
+                      [ (* Issue #18472: LLM keepers emit [limit] as a JSON
+                           string (["5"]); strict ["integer"] routes through
+                           [correction_pipeline] for a silent coerce. The
+                           runtime handler reads via [Safe_ops.json_int] /
+                           [json_float] which accepts both shapes, so this is
+                           wire-format only. Mirrors PR #19383's widening on
+                           [tool_execute.timeout_sec]. *)
+                        ( "type"
+                        , `List [ `String "integer"; `String "string" ] )
+                      ; ( "description"
+                        , `String
+                            "max results (1-10, default 5). Numeric strings \
+                             (e.g. \"5\") are accepted; prefer the bare \
+                             integer form." )
                       ] )
                 ; (* Issue #8484: derive from local mirror that tracks
            [Agent_tool_memory_runtime.valid_memory_search_source_strings]. *)

--- a/lib/tool_shard_types_schemas_board.ml
+++ b/lib/tool_shard_types_schemas_board.ml
@@ -125,9 +125,18 @@ let board_tools : Masc_domain.tool_schema list =
                       ] )
                 ; ( "limit"
                   , `Assoc
-                      [ "type", `String "integer"
+                      [ (* Issue #18472: same wire-format widening as
+                           PR #19383 on [tool_execute.timeout_sec]. The
+                           board_list runtime accepts both shapes; the
+                           strict ["integer"] only fires Anthropic-SDK
+                           [correction_pipeline] coerce. *)
+                        ( "type"
+                        , `List [ `String "integer"; `String "string" ] )
                       ; ( "description"
-                        , `String "Max posts to return (default: 20, max: 50)" )
+                        , `String
+                            "Max posts to return (default: 20, max: 50). \
+                             Numeric strings are accepted; prefer the bare \
+                             integer form." )
                       ] )
                 ; (* Issue #8513: derive from local mirror tracking
            [Board_dispatch.valid_sort_order_strings].  Schema used to
@@ -221,8 +230,17 @@ let board_tools : Masc_domain.tool_schema list =
                       ] )
                 ; ( "limit"
                   , `Assoc
-                      [ "type", `String "integer"
-                      ; "description", `String "Max results (default: 20)"
+                      [ (* Issue #18472: same widening as PR #19383 / sibling
+                           sites above. No fleet evidence yet on this site
+                           (board_search), but bundled here per RFC-0088 §3
+                           N-of-M avoidance — three [limit] sites with the
+                           same defect; fix all at once. *)
+                        ( "type"
+                        , `List [ `String "integer"; `String "string" ] )
+                      ; ( "description"
+                        , `String
+                            "Max results (default: 20). Numeric strings are \
+                             accepted; prefer the bare integer form." )
                       ] )
                 ] )
           ; "required", `List [ `String "query" ]

--- a/test/dune
+++ b/test/dune
@@ -1797,6 +1797,8 @@
 
 (include stanzas/test_execute_timeout_schema_widen.inc)
 
+(include stanzas/test_limit_schema_widen.inc)
+
 (include stanzas/test_parse_outcome.inc)
 
 (include stanzas/test_pr_open_script.inc)

--- a/test/stanzas/test_limit_schema_widen.inc
+++ b/test/stanzas/test_limit_schema_widen.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_limit_schema_widen)
+ (modules test_limit_schema_widen)
+ (libraries masc_mcp masc_types alcotest yojson))

--- a/test/test_limit_schema_widen.ml
+++ b/test/test_limit_schema_widen.ml
@@ -1,0 +1,85 @@
+(* Issue #18472 follow-up to PR #19383: widen [limit] from strict
+   ["integer"] to ["integer", "string"] across the three sites that
+   advertise it — [keeper_memory_search], [keeper_board_list],
+   [keeper_board_search]. Fleet evidence on 2026-05-29 partial:
+
+     fields=limit stages=coercion total:        18
+       ReadFile (Anthropic-native, not ours):  13
+       keeper_board_list:                       4
+       keeper_memory_search:                    1
+       keeper_board_search:                     0  ← no traffic yet but
+                                                     same defect; bundled
+                                                     per RFC-0088 §3 N-of-M.
+
+   Runtime handlers in [Agent_tool_memory_runtime] and the board list /
+   search dispatchers read [limit] via [Safe_ops.json_int] which already
+   accepts both shapes. The Anthropic-SDK schema rejection is purely a
+   wire-format quirk. *)
+
+open Alcotest
+
+module Base = Masc_mcp.Tool_shard_types_schemas_base
+module Board = Masc_mcp.Tool_shard_types_schemas_board
+
+let find_tool_schema schemas name =
+  List.find_opt (fun (s : Masc_domain.tool_schema) -> String.equal s.name name) schemas
+  |> function
+  | Some s -> s
+  | None -> Alcotest.failf "tool schema %S not found" name
+
+let limit_type schema =
+  match schema.Masc_domain.input_schema with
+  | `Assoc fields ->
+    (match List.assoc_opt "properties" fields with
+     | Some (`Assoc props) ->
+       (match List.assoc_opt "limit" props with
+        | Some (`Assoc limit_fields) ->
+          (match List.assoc_opt "type" limit_fields with
+           | Some v -> v
+           | None -> Alcotest.failf "%s: limit field missing 'type'" schema.name)
+        | _ -> Alcotest.failf "%s: limit field missing in properties" schema.name)
+     | _ -> Alcotest.failf "%s: properties not an Assoc" schema.name)
+  | _ -> Alcotest.failf "%s: input_schema not an Assoc" schema.name
+
+let check_widened name type_value =
+  match type_value with
+  | `List xs ->
+    let strings =
+      List.map
+        (function
+          | `String s -> s
+          | _ -> Alcotest.failf "%s: limit type list contains non-string" name)
+        xs
+    in
+    check (list string)
+      (Printf.sprintf "%s: limit type widened to integer + string" name)
+      [ "integer"; "string" ]
+      strings
+  | `String single ->
+    Alcotest.failf
+      "%s: limit type is still scalar %S; widening regressed"
+      name single
+  | other ->
+    Alcotest.failf "%s: limit type has unexpected JSON: %s" name
+      (Yojson.Safe.to_string other)
+
+let memory_search_limit_widened () =
+  let schema = find_tool_schema Base.base_tools "keeper_memory_search" in
+  check_widened "keeper_memory_search" (limit_type schema)
+
+let board_list_limit_widened () =
+  let schema = find_tool_schema Board.board_tools "keeper_board_list" in
+  check_widened "keeper_board_list" (limit_type schema)
+
+let board_search_limit_widened () =
+  let schema = find_tool_schema Board.board_tools "keeper_board_search" in
+  check_widened "keeper_board_search" (limit_type schema)
+
+let () =
+  run "limit_schema_widen"
+    [ "all three limit sites accept integer + string"
+    , [ test_case "keeper_memory_search" `Quick memory_search_limit_widened
+      ; test_case "keeper_board_list" `Quick board_list_limit_widened
+      ; test_case "keeper_board_search" `Quick board_search_limit_widened
+      ]
+    ]


### PR DESCRIPTION
## Root finding

Follow-up to [PR #19383](https://github.com/jeong-sik/masc-mcp/pull/19383) (\`tool_execute.timeout_sec\`). Same Anthropic-SDK schema validation pattern: keeper LLMs emit the field as a numeric JSON string (\`\"5\"\`, \`\"20\"\`) and a strict \`\"type\": \"integer\"\` declaration routes the call through \`correction_pipeline\` for a silent coerce. The runtime handlers already accept both shapes via \`Safe_ops.json_int\` / \`json_float\`, so this is wire-format only.

## Fleet baseline (5/29 partial, /private/tmp/masc-server.log)

\`\`\`
correction_pipeline fields=limit stages=coercion total: 18
  ReadFile (Anthropic, not ours): 13
  keeper_board_list:               4
  keeper_memory_search:            1
  keeper_board_search:             0   ← no traffic yet but same defect
\`\`\`

ReadFile is out of scope (Anthropic SDK). The three \`keeper_*\` sites are all declared \`\"type\": \"integer\"\`; widening all three at once avoids the RFC-0088 §3 N-of-M antipattern (\"PR #N only fixed K of M sites\"). The zero-traffic third site is bundled deliberately.

## Changes

| File | Site | Change |
|---|---|---|
| \`lib/tool_shard_types_schemas_base.ml\` | \`keeper_memory_search.limit\` | \`integer\` → \`[integer, string]\` |
| \`lib/tool_shard_types_schemas_board.ml\` | \`keeper_board_list.limit\` | same |
| \`lib/tool_shard_types_schemas_board.ml\` | \`keeper_board_search.limit\` | same (no fleet traffic yet, bundled per §3) |
| \`test/test_limit_schema_widen.ml\` (new) | — | 3 cases pinning the widened shape at all three schema list entries |

Tests use the existing public \`base_tools\` / \`board_tools\` bindings; no private mli widening.

## Anti-pattern check (RFC-0088)

| Signature | This PR |
|---|---|
| §1 counter-as-fix | Removes the *need* for the coerce; same shape as PR #19383 |
| §2 substring classifier | N/A |
| §3 N-of-M | **Explicit avoidance** — 3 identified sites all fixed in one PR, including the zero-traffic one |
| §4 cap/cooldown/dedup/repair | N/A |
| §5 exhaustive enforce | Closed multi-type schema; anything else still fails validation |
| §6 test backdoor | Public schema bindings only |
| §7 codemod miss | N/A — 3 sites, all explicit |

## Build / test status

- Type-check: test \`.cmo\` builds clean.
- Test exe link: blocked by an **unrelated** \`origin/main\` breakage in the \`Dashboard_utils\` / \`option_*_json\` surface (\`json_string_list_member\`, \`string_field_opt\`, \`json_string_option\`, \`string_list_to_json\` all currently unbound). Same upstream cause is breaking \`pre-commit\`'s full \`dune build --root .\`. The three \`.ml\` files this PR touches build cleanly in isolation. CI green-light depends on upstream clearance.

Filing the upstream breakage as a separate follow-up if not already tracked.

## Out of scope (carried from PR #19383)

- \`ReadFile.limit\` — Anthropic-side schema, not ours.
- Remaining 5/29 \`correction_pipeline\` load: \`fields=content stages=format_normalization\` (38 events on \`keeper_board_post\` / \`keeper_board_comment\`) — \`format_normalization\` is an Anthropic-SDK-internal stage with **zero hits** in our codebase, so the raw input shape is not visible. Audit deferred until we capture the raw input.

## RFC-WAIVED

No credential / identity / sandbox / hooks / workflow surface touched.

## Related

- #18472 (the issue)
- PR #19383 (sister widening — \`tool_execute.timeout_sec\`)
- PR #19379 (atomic rotate + self-heal that restored the fleet log so this baseline could be measured)
- Memory: \`reference_masc_fleet_log_path_drift_2026_05_29\`

🤖 Generated with Claude Code