### PR TITLE
fix(cascade): remove stale tier admission references from docs and comments

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -104,10 +104,6 @@ the categorization roadmap. Newly-added typed getters in
 |---|---|---|---|---|---|
 | `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 226 | Alert dedup window, clamped to >= 5s. Default: 60. |
 | `MASC_CASCADE_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 743 | {1 Cascade Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Cascade_saturation_signal.t] emission from... |
-| `MASC_CASCADE_TIER_ADMISSION_ENABLED` | feature_flag | n/a | n/a | 755 | {1 Cascade Tier Admission (RFC-0153 Phase B.2)} Runtime kill switch for per-tier inflight admission in the main keepe... |
-| `MASC_CASCADE_TIER_WAIT_ENABLED` | feature_flag | n/a | n/a | 760 |  |
-| `MASC_CASCADE_TIER_WAIT_MAX_RETRIES` | typed:string | unclassified | unclassified | 766 |  |
-| `MASC_CASCADE_TIER_WAIT_TIMEOUT_S` | typed:float | unclassified | unclassified | 763 |  |
 | `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 670 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
 | `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 705 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
 | `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 706 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -732,8 +732,8 @@ end
 (** {1 Cascade Saturation Signal (RFC-0153 Phase A.2)}
 
     Feature flag for typed [Cascade_saturation_signal.t] emission from
-    structured cascade/provider errors. The signal is consumed by Phase B
-    (tier admission semaphore) and Phase C (adaptive throttling).
+    structured cascade/provider errors. The signal is consumed by Phase C
+    (adaptive throttling).
 
     Default off. Phase A.2 emit is purely additive — it increments a new
     Prometheus counter ([masc_keeper_cascade_saturation_signal_total])


### PR DESCRIPTION
## Summary

Follow-up to PR #19381. The tier/tier-group admission system was fully deleted in that PR, but stale documentation references and comments remained in two places. This PR cleans them up.

## Changes

### 1. docs/runtime-tunables.md

Removed 4 env knob rows that no longer have any implementation:

| Knob | Status |
|------|--------|
| `MASC_CASCADE_TIER_ADMISSION_ENABLED` | Module deleted in #19381 |
| `MASC_CASCADE_TIER_WAIT_ENABLED` | Module deleted in #19381 |
| `MASC_CASCADE_TIER_WAIT_MAX_RETRIES` | Wait scheduler deleted in #19381 |
| `MASC_CASCADE_TIER_WAIT_TIMEOUT_S` | Wait scheduler deleted in #19381 |

### 2. lib/config/env_config_keeper.ml

Updated the `CascadeSaturationSignal` module header comment to remove the stale reference to "Phase B (tier admission semaphore)" consumption. Phase C (adaptive throttling) remains valid.

## Build verification

```
dune build @check  # passes clean (only pre-existing websocket duplicate warning)
```

## Related

- PR #19381 — complete tier admission system removal

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>