### PR TITLE
perf(dashboard): cache /api/v1/dashboard/branches git subprocess

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -110,7 +110,22 @@ let rec add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/branches" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let json = Dashboard_branches.json ~config:state.Mcp_server.room_config in
+         (* Dashboard_branches.json spawns `git -C <repo> branch` per request
+            via Exec_gate. Without caching, a burst of parallel dashboard
+            requests spawns one subprocess each AND runs it inline on the main
+            HTTP domain, head-of-line-blocking other requests. Wrap in the
+            shared get_or_compute + Executor_pool offload (mirrors /planning,
+            /nudges): parallel bursts collapse to one git spawn per TTL, run on
+            a pool domain. realtime TTL keeps the "live" branch list fresh. *)
+         let cache_key =
+           Printf.sprintf "branches:%s"
+             state.Mcp_server.room_config.base_path
+         in
+         let json =
+           Dashboard_cache.get_or_compute cache_key ~ttl:realtime_cache_ttl_s (fun () ->
+             Domain_pool_ref.submit_io_or_inline (fun () ->
+               Dashboard_branches.json ~config:state.Mcp_server.room_config))
+         in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/rooms" (fun request reqd ->


### PR DESCRIPTION
## 목적

`/api/v1/dashboard/branches`가 **매 요청 git subprocess를 spawn**하던 것을 캐시+offload로 감쌉니다. 전수 엔드포인트 병렬 스윕(2026-05-29)에서 발견한 "느린 이유"의 구체적 첫 수정입니다.

## 진단 (전수 스윕 + 직렬화 프로브)

masc-mcp가 지원하는 **146개 GET 엔드포인트를 병렬 호출**(`~/me/.tmp/masc-perf-2026-05-29/sweep-all.sh`)한 결과:

- 대부분 엔드포인트는 `Dashboard_cache.get_or_compute`로 캐시돼 **ms** (config 0.015s, logs 0.002s).
- `server_routes_http_routes_dashboard.ml`의 48개 대시보드 GET 라우트 중 **20개만 캐시, ~28개 uncached**.
- uncached 중 `/branches`는 `Dashboard_branches.json` → `Exec_gate.run_argv`로 **`git -C <repo> --no-optional-locks branch`를 매 요청 spawn** → 단독 ~1.3s.
- **직렬화 증거**: 캐시된 가벼운 12개를 병렬 호출하니 전부 ~3.4s로 수렴(0.003s짜리 config 포함). 느린 uncached 핸들러가 단일 Eio HTTP 도메인을 점유 → 빠른 요청들이 head-of-line 대기.

## 변경

`/branches` 핸들러를 `/planning`·`/nudges`와 동일한 패턴으로 래핑:
```
Dashboard_cache.get_or_compute "branches:<base_path>" ~ttl:realtime_cache_ttl_s (fun () ->
  Domain_pool_ref.submit_io_or_inline (fun () ->
    Dashboard_branches.json ~config))
```
- **캐시(realtime TTL 15s)**: 병렬 버스트가 TTL당 git spawn 1회로 collapse. "live" 브랜치 데이터의 신선도(15s)는 유지.
- **offload**: git spawn이 Executor_pool 도메인에서 실행 → 메인 HTTP 도메인 블록 방지.

1 파일, 핸들러 1개. 기존 20개 캐시 라우트가 쓰는 공유 패턴 적용 (새 추상화 아님).

## 검증

- 컴파일: pre-commit `dune build --root .` (코드 변경이라 자동 실행) + CI.
- 동작: branches는 15s 내 반복/병렬 요청에서 캐시 히트(git spawn 0회), 15s 후 1회 재spawn. cache_key는 base_path별.
- end-to-end 지연 개선의 라이브 측정은 서버 재빌드/재기동 필요 → deploy 후 `~/me/.tmp/masc-perf-2026-05-29/serial-test.sh`에 `/branches` 포함해 재측정 권장.

## 범위 / 후속 (silent drop 아님)

- 이 PR: `/branches` (uncached subprocess의 명확한 standout).
- 후속: `/dashboard/rooms`(~4.7s), `/status`(~4.0s) 등 나머지 uncached-slow ~28개. rooms는 query param(limit/me) 의존이라 param-aware cache_key 필요, status는 freshness 분석 필요 → 별도 PR.
- 상위 방향: RFC-0204 (dashboard read serving isolation).

RFC-WAIVED: dashboard 캐시 패턴(RFC-0138) 적용일 뿐 credential/operator/keeper-sandbox/hooks 등 gated subsystem 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
