### PR TITLE
fix(cascade): append model_id to HTTP provider capacity keys

### DIFF
--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -124,7 +124,11 @@ let cli_sentinel_of_kind kind =
     None
 
 let capacity_key_of_config (cfg : Llm_provider.Provider_config.t) =
-  if cfg.base_url <> "" then cfg.base_url
+  let base_url = String.trim cfg.base_url in
+  if base_url <> "" then
+    let model_id = String.trim cfg.model_id in
+    if model_id <> "" then Printf.sprintf "%s:%s" base_url model_id
+    else base_url
   else
     match cli_sentinel_of_kind cfg.kind with
     | Some sentinel -> sentinel


### PR DESCRIPTION
## Summary

- `capacity_key_of_config` now returns `"base_url:model_id"` for HTTP providers when `model_id` is non-empty
- Previously returned only `cfg.base_url`, causing all models on the same endpoint to share a single capacity slot (SPOF)
- Matches the pattern already used by `provider_health_key_of_config` (`%s:%s` with model_id)

## Root Cause

`capacity_key_of_config` (line 126 of `cascade_runtime_candidate.ml`) used `cfg.base_url` as the capacity key for HTTP providers. Two models on the same endpoint (e.g., `gpt-4` and `gpt-3.5-turbo` both on `https://api.openai.com/v1`) would share one capacity slot. When one model exhausted the slot, the other was blocked unnecessarily.

## Impact

| Before | After |
|--------|-------|
| `https://api.openai.com/v1` (shared) | `https://api.openai.com/v1:gpt-4` (per-model) |
| All HTTP models share 1 capacity slot | Each model gets independent capacity tracking |

CLI sentinel keys (`cli:cli_tool_a` etc.) are unchanged — they already encode provider kind and don't have model_id ambiguity.

## Self-consistency

The capacity system uses `capacity_key` consistently:
- **Register**: `register_declared_client_capacity` → `Cascade_client_capacity.register ~url:capacity_key`
- **Acquire**: `acquire_client_capacity_slot` → `Cascade_client_capacity.try_acquire capacity_key`
- **Strategy**: `cascade_strategy.ml` → `adapter.capacity_key` → `ctx.capacity key`
- **Dashboard**: `dashboard_cascade_capacity.ml` → displays `key` from registry snapshot

All use the same key from `capacity_key_of_config`, so the change propagates correctly.

## Test plan

- [ ] `dune build --root . lib/cascade/` — compiles clean
- [ ] Existing tests pass (they use synthetic fixtures, not `capacity_key_of_config` directly)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>