### PR TITLE
chore(discord): RFC-0203 docs sweep + self-skip guard in gateway filter

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -354,10 +354,14 @@ Current host note:
 
 Notes:
 
-- Discord connector runtime files are shared between the gate server and the
-  Discord bot. When the bot uses relative paths, resolve them against the same
-  `MASC_BASE_PATH` as the server. Operational setup and verification steps live
-  in `sidecars/discord-bot/README.md`.
+- Discord connector runtime files (`.gate/runtime/discord/status.json`,
+  `bindings.json`, `binding_audit.jsonl`) are now read and written by the
+  in-process gateway (`lib/server/server_discord_in_process_gateway.{ml,mli}`
+  + `lib/gate/channel_gate_discord_state.{ml,mli}`) after RFC-0203 §Phase 3
+  (#19393) deleted the external `sidecars/discord-bot/`. Path resolution is
+  unchanged; the consumer just moved into the same server process. Operator
+  setup: set `DISCORD_BOT_TOKEN` in the server's env and restart. See
+  `docs/CONNECTOR-CONFIG-SCHEMA.md` §Discord.
 - All voice paths resolve relative to `MASC_BASE_PATH/.masc/`.
   `voice_config.json` is discovered at `<runtime_root>/voice_config.json`
   where `<runtime_root>` = `MASC_BASE_PATH/.masc/`.

--- a/docs/CONNECTOR-CONFIG-SCHEMA.md
+++ b/docs/CONNECTOR-CONFIG-SCHEMA.md
@@ -33,24 +33,38 @@ env  >  runtime TOML  >  field defaults
 
 ## Per-sidecar required/unique fields
 
-### Discord (`sidecars/discord-bot/src/config.py`)
+### Discord (in-process gateway — RFC-0203 §Phase 3)
 
-| Field | Env alias | Type | Required | Notes |
-|---|---|---|---|---|
-| `discord_bot_token` | `DISCORD_BOT_TOKEN` | str | **yes** | Developer Portal → Bot → Reset Token. |
-| `discord_keeper_map` | `DISCORD_KEEPER_MAP` | JSON str | no (default `{}`) | `{"<channel_id>": "<keeper_name>"}` — startup-only mapping; runtime edits go through `/api/v1/gate/connector/bind`. |
-| `discord_admin_role_id` | `DISCORD_ADMIN_ROLE_ID` | str | no | role allowed to use admin commands. |
-| `discord_binding_audit_path` | `DISCORD_BINDING_AUDIT_PATH` | path | no | append-only audit log (JSONL). |
-| `discord_names_path` | `DISCORD_NAMES_PATH` | path | no | guild/channel id→name side-map, written every `STATUS_HEARTBEAT_SEC`. |
-| `status_heartbeat_sec` | `STATUS_HEARTBEAT_SEC` | int | no (10) | |
-| `gate_max_retries` | `GATE_MAX_RETRIES` | int | no (2) | Discord-only; others have no retry knob. |
+The Discord connector runs **inside the server process**, not as an
+external sidecar (`sidecars/discord-bot/` was deleted in #19393).
+Module: `lib/server/server_discord_in_process_gateway.{ml,mli}` plus
+the gate-state extension in `lib/gate/channel_gate_discord_state.{ml,mli}`.
+
+| Env var | Required | Notes |
+|---|---|---|
+| `DISCORD_BOT_TOKEN` | **yes** | Developer Portal → Bot → Reset Token. Read at every `send_message` call, so token rotation does not require a server restart. If unset the gateway logs a warning and skips startup; the rest of the server boots normally. |
+| `MASC_DISCORD_TRIGGER_POLICY` | no (default `mention_only`) | One of `mention_only`, `user_only:<discord_user_id>`, `all`. Closed sum; unknown values fall back to `mention_only`. |
+
+Channel→keeper bindings live where they always did:
+`Channel_gate_discord_state.bind` / `unbind` write to
+`.gate/runtime/discord/bindings.json` (overridable via
+`MASC_DISCORD_BINDING_STORE_PATH`). The HTTP routes
+`/api/v1/gate/connector/bind?name=discord` and
+`/api/v1/gate/connector/unbind?name=discord` remain functional and
+are how the dashboard mutates bindings.
+
+The pre-cutover env vars `DISCORD_KEEPER_MAP`, `DISCORD_ADMIN_ROLE_ID`,
+`DISCORD_BINDING_AUDIT_PATH`, `DISCORD_NAMES_PATH`,
+`STATUS_HEARTBEAT_SEC`, `GATE_MAX_RETRIES` were sidecar-only and
+no longer apply.
 
 Discord-specific setup (cannot be driven from dashboard — operator must do):
 
 1. https://discord.com/developers/applications → New Application.
-2. Bot tab → Reset Token → paste into dashboard field.
-3. Bot tab → enable **Message Content Intent**.
+2. Bot tab → Reset Token → paste into shell env as `DISCORD_BOT_TOKEN`.
+3. Bot tab → enable **Message Content Intent** (required for `GUILD_MESSAGES`/`MESSAGE_CONTENT` intents).
 4. OAuth2 URL Generator → `bot` scope, permissions: Send Messages, Embed Links, Read Message History → invite.
+5. Restart the server so the new token is picked up at the next gateway connect.
 
 ### iMessage (`sidecars/imessage-bot/src/config.py`)
 

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -333,17 +333,32 @@ let decode_dispatch ~bot_user_id ~event_name ~payload =
    suppressed (the "quiet, mention-triggered bot" default), per
    RFC-0203 §Shape interpretation. *)
 
-let message_passes_policy policy ~author_id ~mentions_bot =
-  match policy with
-  | All -> true
-  | Mention_only -> mentions_bot
-  | User_only id -> String.equal author_id id
+(* Self-skip guard: an inbound event whose actor is the bot itself
+   is always suppressed, regardless of trigger policy. [Mention_only]
+   is naturally safe — the bot doesn't @itself — but [All] accepts
+   everything and [User_only id] can collide with [bot_user_id] (the
+   operator pastes the wrong snowflake), so the guard is unconditional
+   to make the self-reply-loop class of bug structurally impossible. *)
+let is_self ~bot_user_id actor_id =
+  match bot_user_id with
+  | Some self -> String.equal self actor_id
+  | None -> false
 
-let reaction_passes_policy policy ~user_id =
-  match policy with
-  | All -> true
-  | Mention_only -> false
-  | User_only id -> String.equal user_id id
+let message_passes_policy policy ~bot_user_id ~author_id ~mentions_bot =
+  if is_self ~bot_user_id author_id then false
+  else
+    match policy with
+    | All -> true
+    | Mention_only -> mentions_bot
+    | User_only id -> String.equal author_id id
+
+let reaction_passes_policy policy ~bot_user_id ~user_id =
+  if is_self ~bot_user_id user_id then false
+  else
+    match policy with
+    | All -> true
+    | Mention_only -> false
+    | User_only id -> String.equal user_id id
 
 (* ── Outbound frame builders (internal) ────────────────────────── *)
 
@@ -494,12 +509,15 @@ let handle_dispatch t (frame : frame) =
              ] )
        | Ok (Message_create { author_id; mentions_bot; _ } as ev) ->
            if
-             message_passes_policy t'.config.trigger_policy ~author_id
+             message_passes_policy t'.config.trigger_policy
+               ~bot_user_id:t'.config.bot_user_id ~author_id
                ~mentions_bot
            then (t', [ Emit_event ev ])
            else no_op t'
        | Ok (Reaction_add { user_id; _ } as ev) ->
-           if reaction_passes_policy t'.config.trigger_policy ~user_id
+           if
+             reaction_passes_policy t'.config.trigger_policy
+               ~bot_user_id:t'.config.bot_user_id ~user_id
            then (t', [ Emit_event ev ])
            else no_op t'
        | Ok (Ignored "RESUMED") ->

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -586,6 +586,82 @@ let test_policy_all_emits_messages_and_reactions () =
     (has_emit_event react_effects)
 
 (* ---------------------------------------------------------------- *)
+(* RFC-0203 Phase 3 follow-up — self-skip guard. Bot-authored events *)
+(* are suppressed regardless of trigger policy so a misconfigured   *)
+(* User_only:<bot_id> or All policy can't loop the bot into itself. *)
+(* ---------------------------------------------------------------- *)
+
+let test_self_message_suppressed_under_all_policy () =
+  let m = connected_with_policy ~policy:S.All ~bot_user_id:"BOT" in
+  let payload =
+    message_create_payload
+      ~id:"SELF1" ~channel_id:"C1" ~author_id:"BOT" ~content:"echo"
+      ~mention_ids:[] ()
+  in
+  let _, effects =
+    S.step m ~now_mono:3.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload ~seq:7))
+  in
+  check bool
+    "bot's own message suppressed even under All policy"
+    false (has_emit_event effects)
+
+let test_self_message_suppressed_when_user_only_targets_bot_id () =
+  (* Operator footgun: pasted bot's own id as the user_only target.
+     Without the self-skip guard this would loop. *)
+  let m =
+    connected_with_policy
+      ~policy:(S.User_only "BOT") ~bot_user_id:"BOT"
+  in
+  let payload =
+    message_create_payload
+      ~id:"SELF2" ~channel_id:"C1" ~author_id:"BOT" ~content:"loop?"
+      ~mention_ids:[] ()
+  in
+  let _, effects =
+    S.step m ~now_mono:3.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload ~seq:8))
+  in
+  check bool
+    "self-message suppressed even when User_only id collides with bot_user_id"
+    false (has_emit_event effects)
+
+let test_self_reaction_suppressed_under_all_policy () =
+  let m = connected_with_policy ~policy:S.All ~bot_user_id:"BOT" in
+  let payload =
+    reaction_add_payload
+      ~channel_id:"C1" ~message_id:"SELF1" ~user_id:"BOT" ~emoji_name:"✅"
+      ()
+  in
+  let _, effects =
+    S.step m ~now_mono:3.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_REACTION_ADD" ~payload ~seq:9))
+  in
+  check bool
+    "bot's own reaction suppressed even under All policy"
+    false (has_emit_event effects)
+
+let test_non_self_message_still_emitted_under_all () =
+  (* Regression guard: self-skip must not break the non-self path. *)
+  let m = connected_with_policy ~policy:S.All ~bot_user_id:"BOT" in
+  let payload =
+    message_create_payload
+      ~id:"OTHER1" ~channel_id:"C1" ~author_id:"VINCENT" ~content:"hi"
+      ~mention_ids:[] ()
+  in
+  let _, effects =
+    S.step m ~now_mono:3.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload ~seq:10))
+  in
+  check bool
+    "non-self message still emits under All policy"
+    true (has_emit_event effects)
+
+(* ---------------------------------------------------------------- *)
 (* Phase 1.4 — reconnect / resume arms                              *)
 (* ---------------------------------------------------------------- *)
 
@@ -868,6 +944,17 @@ let () =
             `Quick test_policy_user_only_reaction_matching_reactor_passes
         ; test_case "all + any message + any reaction => both Emit_event"
             `Quick test_policy_all_emits_messages_and_reactions
+        ] )
+    ; ( "self-skip guard"
+      , [ test_case "self message suppressed under All" `Quick
+            test_self_message_suppressed_under_all_policy
+        ; test_case "self message suppressed when User_only id == bot id"
+            `Quick
+            test_self_message_suppressed_when_user_only_targets_bot_id
+        ; test_case "self reaction suppressed under All" `Quick
+            test_self_reaction_suppressed_under_all_policy
+        ; test_case "non-self message still emits under All (regression)"
+            `Quick test_non_self_message_still_emitted_under_all
         ] )
     ; ( "reconnect / resume"
       , [ test_case


### PR DESCRIPTION
## Summary

Two unrelated cleanups stacked on the RFC-0203 Phase 3 cutover (#19393):

1. **Docs sweep** — remove the post-cutover stale prose in `docs/CONNECTOR-CONFIG-SCHEMA.md` §Discord (was still describing the deleted `sidecars/discord-bot/src/config.py` env vars) and `docs/BOOT-ENV-STATE-INVENTORY.md` §Notes (was still pointing operators to the deleted sidecar README).
2. **Self-skip guard** in `Discord_gateway_state.message_passes_policy` / `reaction_passes_policy` — when the inbound event's actor id equals `bot_user_id`, the event is suppressed regardless of trigger policy. Closes the self-reply-loop class of bug structurally so a misconfigured `User_only:<bot_id>` or `All` policy can't loop the bot into itself.

## What's in this PR

### Docs

- **`docs/CONNECTOR-CONFIG-SCHEMA.md`** — §Discord rewritten as "in-process gateway (RFC-0203 §Phase 3)". Env-var table reduced to the two that actually apply (`DISCORD_BOT_TOKEN`, `MASC_DISCORD_TRIGGER_POLICY`). The sidecar-only knobs (`DISCORD_KEEPER_MAP`, `DISCORD_ADMIN_ROLE_ID`, `DISCORD_BINDING_AUDIT_PATH`, `DISCORD_NAMES_PATH`, `STATUS_HEARTBEAT_SEC`, `GATE_MAX_RETRIES`) are listed as no-longer-applicable with a one-line pointer to the bindings HTTP routes. Operator setup steps point to env vars instead of `sidecars/discord-bot/src/config.py`.
- **`docs/BOOT-ENV-STATE-INVENTORY.md`** — §Notes Discord row rewritten: the runtime files now sit at the same paths but are produced by the in-process gateway modules (`Server_discord_in_process_gateway` + `Channel_gate_discord_state`); operator setup is `set DISCORD_BOT_TOKEN + restart`.

Other docs touching `discord-bot` (no remaining ones in the production-doc set after this PR — `dashboard/src/components/connector-status.test.ts` still has discord lifecycle assertions and is out of scope per #19393's PR body).

### Self-skip guard

- **`lib/gate/discord_gateway_state.ml`** — new `is_self ~bot_user_id actor_id` helper. Both `message_passes_policy` and `reaction_passes_policy` apply it before consulting `trigger_policy`. The `bot_user_id` arg is sourced from `t'.config.bot_user_id`, which is populated by the `READY` handler.
- **`test/test_discord_gateway_state.ml`** — 4 new tests in a new `self-skip guard` group:
  - self message under `All` policy → suppressed
  - self message under `User_only "BOT"` where `bot_user_id = "BOT"` (operator footgun) → suppressed
  - self reaction under `All` policy → suppressed
  - non-self message under `All` regression → still emitted

## Workaround Rejection Bar self-check

- **No string classifier.** `is_self` is a typed predicate over `string option` and `string`. No substring matching, no regex, no policy-key heuristic.
- **No catch-all wildcard.** `message_passes_policy` and `reaction_passes_policy` still match every `trigger_policy` constructor exhaustively; the self-skip is a *pre-filter* that doesn't loosen the existing exhaustiveness.
- **No telemetry-as-fix.** This PR fixes behaviour, not measurement. The self-reply-loop is closed at the filter layer, not papered over with a per-emit counter or a dedup pass downstream.
- **No N-of-M.** Self-skip is applied once at the filter, not sprinkled at every caller. Adding a new policy variant or a new gateway-event variant doesn't need to re-implement self-skip.
- **No cap/cooldown/dedup/repair.** No retry on bot-authored events; they're filtered before any side effect.

## Test plan (4 new + 34 regression = 38/38 PASS)

| Group | Cases | Pins |
|---|---|---|
| `self-skip guard` (new) | 4 | All/self → drop, User_only collision → drop, All/self-reaction → drop, All/non-self → still emits |
| `trigger_policy filter` regression | 7 | unchanged |
| Full `test_discord_gateway_state` | 38 | 38/38 PASS in 10ms |

## Local verification

| Item | Result |
|---|---|
| `dune build test/test_discord_gateway_state.exe` | clean |
| `test_discord_gateway_state.exe` | 38/38 PASS in 10ms |

## Out of scope (follow-ups)

- **Dashboard discord lifecycle UI** — `dashboard/src/components/connector-status.ts` and its tests still treat `discord` like an external sidecar (Start/Stop buttons, `cd sidecars/discord-bot && ./run.sh` hint). Needs a dedicated PR; ~200-400 LoC + 30+ test assertion updates.
- **Activity board push** — the `board.posted`/`board.commented` auto-push to Discord channels that the deleted sidecar provided was dropped per user direction; re-add as an in-process subscriber when needed.

## Hook bypass disclosure

Commit will use `git commit --no-verify` with explicit prior user approval scoped to RFC-0203 follow-up work. The `.githooks/pre-commit` runs `dune build --root .` on non-allowlisted paths, which fails on main today due to the ongoing Json_util consolidation drift (independent of this PR — see #19393 PR body for the same disclosure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)