### PR TITLE
refactor(ssot): consolidate remaining inline JSON helpers to Json_util (round 2)

### DIFF
--- a/lib/activity_graph/dune
+++ b/lib/activity_graph/dune
@@ -16,6 +16,7 @@
    masc_core
    masc_types
    masc_log
+   masc_mcp.dashboard_utils
    fs_compat
    time_compat
    yojson

--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -33,12 +33,12 @@ let payload_agent_name payload =
      envelope [agent_name] is Null for 9%+ of daily events, breaking
      per-agent filters over the Dated_jsonl store under [.masc/oas-events/].
      See #7827. *)
-  match payload_string_opt "agent_name" payload with
+  match Json_util.get_string payload "agent_name" with
   | Some _ as value -> value
   | None ->
-    (match payload_string_opt "agent" payload with
+    (match Json_util.get_string payload "agent" with
      | Some _ as value -> value
-     | None -> payload_string_opt "keeper_name" payload)
+     | None -> Json_util.get_string payload "keeper_name")
 ;;
 
 let emit_native_event_log (evt : Agent_sdk.Event_bus.event) (json : Yojson.Safe.t) =

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -295,11 +295,11 @@ let keeper_runtime_trust_json keeper =
 ;;
 
 let lowercase_json_string key json =
-  string_field_opt key json |> Option.map String.lowercase_ascii
+  Json_util.get_string json key |> Option.map String.lowercase_ascii
 ;;
 
 let terminal_reason_json trust = member_assoc "latest_terminal_reason" trust
-let terminal_reason_code trust = terminal_reason_json trust |> string_field_opt "code"
+let terminal_reason_code trust = terminal_reason_json trust |> (fun j -> Json_util.get_string j "code")
 
 let terminal_reason_severity trust =
   terminal_reason_json trust |> lowercase_json_string "severity"
@@ -307,7 +307,7 @@ let terminal_reason_severity trust =
 
 let terminal_reason_disposition trust =
   terminal_reason_json trust
-  |> string_field_opt "disposition"
+  |> (fun j -> Json_util.get_string j "disposition")
   |> Option.map Keeper_turn_disposition.of_wire
 ;;
 

--- a/lib/dashboard/dashboard_http_keeper_feeds.ml
+++ b/lib/dashboard/dashboard_http_keeper_feeds.ml
@@ -400,11 +400,11 @@ let keeper_decisions_log_json
                 in
                 let summary = String.concat " \xc2\xb7 " summary_parts in
                 let evidence_refs =
-                  let refs = json_string_list_member "evidence_refs" json in
+                  let refs = Json_util.get_string_list json "evidence_refs" in
                   let refs =
                     if refs <> []
                     then refs
-                    else json_string_list_member "raw_evidence_refs" json
+                    else Json_util.get_string_list json "raw_evidence_refs"
                   in
                   List.map (fun value -> `String value) refs
                 in

--- a/lib/dashboard/dashboard_http_keeper_trust.ml
+++ b/lib/dashboard/dashboard_http_keeper_trust.ml
@@ -48,26 +48,26 @@ let keeper_trust_json ?(include_receipt = false)
   in
   let requested_tools =
     match latest_receipt with
-    | Some receipt -> json_string_list_member "requested_tools" receipt
+    | Some receipt -> Json_util.get_string_list receipt "requested_tools"
     | None -> []
   in
   let required_tools, required_tool_candidates, missing_required_tools =
     match latest_receipt with
     | Some receipt ->
         let surface = Yojson.Safe.Util.member "tool_surface" receipt in
-        ( json_string_list_member "required_tools" surface,
-          json_string_list_member "required_tool_candidates" surface,
-          json_string_list_member "missing_required_tools" surface )
+        ( Json_util.get_string_list surface "required_tools",
+          Json_util.get_string_list surface "required_tool_candidates",
+          Json_util.get_string_list surface "missing_required_tools" )
     | None -> ([], [], [])
   in
   let tools_used =
     match latest_receipt with
-    | Some receipt -> json_string_list_member "tools_used" receipt
+    | Some receipt -> Json_util.get_string_list receipt "tools_used"
     | None -> []
   in
   let unexpected_tools =
     match latest_receipt with
-    | Some receipt -> json_string_list_member "unexpected_tools" receipt
+    | Some receipt -> Json_util.get_string_list receipt "unexpected_tools"
     | None -> []
   in
   `Assoc

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -157,7 +157,7 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
       ("posts_total", `Int total_posts);
       ("new_posts_24h", `Int new_posts_24h);
       ("unanswered_posts", `Int unanswered_posts);
-      ("last_activity_age_s", json_int_opt last_activity_age_s);
+      ("last_activity_age_s", Json_util.int_opt_to_json last_activity_age_s);
       ("slo_target_age_s", `Int slo_target_age_s);
       ("slo_breached", `Bool slo_breached);
     ], true)

--- a/lib/dashboard/dashboard_mission_agents.ml
+++ b/lib/dashboard/dashboard_mission_agents.ml
@@ -389,7 +389,7 @@ let build_agent_briefs config sessions attention_queue _room_json (keepers : Yoj
                   ("display_name", `String display_name);
                   ("is_live", `Bool (Option.is_some agent));
                   ( "archived_reason",
-                    json_string_option
+                    Json_util.string_opt_to_json
                       (if Option.is_some agent
                        then None
                        else archived_reason_for_session related_session) );

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -223,7 +223,7 @@ let build_keeper_briefs (config : Coord.config) (keepers : Yojson.Safe.t list) =
                       ("context_ratio", Json_util.option_to_yojson (fun value -> `Float value) context_ratio);
                       ("last_turn_ago_s", member_assoc "last_turn_ago_s" keeper);
                       ( "current_work",
-                        json_string_option
+                        Json_util.string_opt_to_json
                           (match String_util.trim_to_option (string_field "short_goal" keeper) with
                            | Some value -> Some value
                            | None -> String_util.trim_to_option (string_field "goal" keeper)) );
@@ -530,7 +530,7 @@ let session_timeline_json session_json =
              ("timestamp", member_assoc "ts_iso" event_json);
              ("event_type", member_assoc "event_type" event_json);
              ( "actor",
-               json_string_option
+               Json_util.string_opt_to_json
                  (match String_util.trim_to_option (string_field "actor" detail) with
                  | Some value -> Some value
                  | None -> String_util.trim_to_option (string_field "agent" detail)) );

--- a/lib/keeper/keeper_persona.ml
+++ b/lib/keeper/keeper_persona.ml
@@ -21,7 +21,7 @@ let persona_list_handler args : tool_result =
     if detailed then
       `List (List.map persona_summary_to_json personas)
     else
-      string_list_to_json (List.map (fun (persona : Keeper_types_profile.persona_summary) -> persona.persona_name) personas)
+      Json_util.json_string_list (List.map (fun (persona : Keeper_types_profile.persona_summary) -> persona.persona_name) personas)
   in
   let json =
     `Assoc
@@ -57,7 +57,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
             [
               ("persona", persona_summary_to_json persona);
               ("ready", `Bool (errors = []));
-              ("errors", string_list_to_json errors);
+              ("errors", Json_util.json_string_list errors);
               ("resolved_args", resolved_args);
             ]
         in
@@ -69,7 +69,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
                [
                  ("persona", persona_summary_to_json persona);
                  ("ready", `Bool false);
-                 ("errors", string_list_to_json errors);
+                 ("errors", Json_util.json_string_list errors);
                  ("resolved_args", resolved_args);
                ]))
       else

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -634,11 +634,11 @@ let docker_preflight_to_yojson (preflight : docker_preflight) =
     ; "git_egress", `String preflight.git_egress
     ; "image", `String preflight.image
     ; "docker_runtime_ok", `Bool preflight.docker_runtime_ok
-    ; option_field "docker_runtime_error" preflight.docker_runtime_error
+    ; Json_util.string_opt_field "docker_runtime_error" preflight.docker_runtime_error
     ; "hardening_ok", `Bool preflight.hardening_ok
-    ; option_field "hardening_error" preflight.hardening_error
+    ; Json_util.string_opt_field "hardening_error" preflight.hardening_error
     ; "image_present", `Bool preflight.image_present
-    ; option_field "image_error" preflight.image_error
+    ; Json_util.string_opt_field "image_error" preflight.image_error
     ; ( "failure_classes"
       , `List
           (List.map

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -43,7 +43,7 @@ let string_array_schema =
 let persona_axis_schema (axis : Persona_contract.archetype_axis) =
   `Assoc
     [ "type", `String "string"
-    ; "enum", Persona_contract.string_list_to_json axis.choices
+    ; "enum", Json_util.json_string_list axis.choices
     ; "description", `String axis.schema_description
     ]
 

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -764,11 +764,11 @@ let handle_keeper_status_config ~(config : Coord.config) ~(agent_name : string) 
            ("sandbox_live", sandbox_live);
            ("effective_sandbox_image",
              Json_util.string_opt_to_json effective_sandbox_image);
-           ("tool_denylist", string_list_to_json m.tool_denylist);
-           ("allowed_tool_names", string_list_to_json allowed_tools);
-           ("allowed_tool_preview", string_list_to_json allowed_tool_preview);
+           ("tool_denylist", Json_util.json_string_list m.tool_denylist);
+           ("allowed_tool_names", Json_util.json_string_list allowed_tools);
+           ("allowed_tool_preview", Json_util.json_string_list allowed_tool_preview);
            ("latest_tool_names",
-             string_list_to_json tool_audit_snapshot.latest_tool_names);
+             Json_util.json_string_list tool_audit_snapshot.latest_tool_names);
            ("latest_tool_call_count",
              Json_util.int_opt_to_json tool_audit_snapshot.latest_tool_call_count);
            ("latest_action_source",
@@ -819,10 +819,10 @@ let handle_keeper_status_config ~(config : Coord.config) ~(agent_name : string) 
                `String (network_mode_to_string m.network_mode));
              ("effective_sandbox_image",
                Json_util.string_opt_to_json effective_sandbox_image);
-             ("allowed_paths", string_list_to_json m.allowed_paths);
-           ("allowed_tools", string_list_to_json allowed_tools);
-            ("available_internal_tools", string_list_to_json all_internal_tools);
-            ("blocked_internal_tools", string_list_to_json blocked_internal_tools);
+             ("allowed_paths", Json_util.json_string_list m.allowed_paths);
+           ("allowed_tools", Json_util.json_string_list allowed_tools);
+            ("available_internal_tools", Json_util.json_string_list all_internal_tools);
+            ("blocked_internal_tools", Json_util.json_string_list blocked_internal_tools);
            ]);
            ("auto_execution_session", auto_execution_session_surface_json ());
            ("auto_execution_session_enabled", `Bool false);
@@ -980,7 +980,7 @@ let handle_keeper_status_config ~(config : Coord.config) ~(agent_name : string) 
              ("sandbox_live", sandbox_live);
              ("effective_sandbox_image",
                Json_util.string_opt_to_json effective_sandbox_image);
-             ("allowed_paths", string_list_to_json m.allowed_paths);
+             ("allowed_paths", Json_util.json_string_list m.allowed_paths);
              ("playground_repos",
                Keeper_sandbox_control.playground_repos_json
                  ~config:config ~meta:m);

--- a/lib/keeper/keeper_tools_oas_deterministic_error.ml
+++ b/lib/keeper/keeper_tools_oas_deterministic_error.ml
@@ -7,7 +7,7 @@
 
 open Keeper_tools_oas_workflow
 
-let json_assoc_field_opt = Keeper_tools_oas_json.json_assoc_field_opt
+let json_assoc_field_opt = Json_util.assoc_member_opt
 let detail_json_opt = Keeper_tools_oas_json.detail_json_opt
 let json_assoc_string_opt = Keeper_tools_oas_json.json_assoc_string_opt
 

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -37,8 +37,8 @@ type workflow_rejection_block =
   ; blocked_at : float
   }
 
-let json_assoc_field_opt = Keeper_tools_oas_json.json_assoc_field_opt
-let json_assoc_string_opt = Keeper_tools_oas_json.json_assoc_string_opt
+let json_assoc_field_opt = Json_util.assoc_member_opt
+let json_assoc_string_opt = Json_util.assoc_string_opt
 let detail_json_opt = Keeper_tools_oas_json.detail_json_opt
 let json_or_detail_string_opt = Keeper_tools_oas_json.json_or_detail_string_opt
 let json_or_detail_bool_opt = Keeper_tools_oas_json.json_or_detail_bool_opt

--- a/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
+++ b/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
@@ -152,14 +152,14 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                   ( "missing_required_tools",
                     Json_util.json_string_list missing_required_tools );
                   ( "turn_lane",
-                    json_string_opt
+                    Json_util.string_opt_to_json
                       (json_string_member_opt "turn_lane" tool_decision) );
                   ( "tool_surface_class",
-                    json_string_opt
+                    Json_util.string_opt_to_json
                       (json_string_member_opt "tool_surface_class"
                          tool_decision) );
                   ( "tool_requirement",
-                    json_string_opt
+                    Json_util.string_opt_to_json
                       (first_string_opt
                          [
                            json_string_member_opt "tool_requirement"
@@ -192,9 +192,9 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
               `Assoc
                 [
                   ("resolved", `Bool has_provider_lane);
-                  ("status", json_string_opt provider_lane_status);
+                  ("status", Json_util.string_opt_to_json provider_lane_status);
                   ( "resolved_lane",
-                    json_string_opt
+                    Json_util.string_opt_to_json
                       (json_string_member_opt "resolved_lane" lane_decision)
                   );
                   ( "effective_tool_count",
@@ -238,7 +238,7 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                   ("started_count", `Int scan.provider_started_count);
                   ("finished_count", `Int scan.provider_finished_count);
                   ( "terminal_status",
-                    json_string_opt
+                    Json_util.string_opt_to_json
                       (Option.map
                          (fun row -> row.Keeper_runtime_manifest.status)
                          scan.provider_terminal_row) );

--- a/lib/server/server_dashboard_http_keeper_api_summary_aggregates.ml
+++ b/lib/server/server_dashboard_http_keeper_api_summary_aggregates.ml
@@ -23,20 +23,20 @@ let provider_attempts_summary_json (scan : runtime_manifest_scan) : Yojson.Safe.
     [ "started_count", `Int scan.provider_started_count
     ; "finished_count", `Int scan.provider_finished_count
     ; ( "terminal_status"
-      , json_string_opt
+      , Json_util.string_opt_to_json
           (Option.map (fun row -> row.Keeper_runtime_manifest.status) terminal) )
-    ; "terminal_model_source", json_string_opt (terminal_decision_string "model_source")
+    ; "terminal_model_source", Json_util.string_opt_to_json (terminal_decision_string "model_source")
     ; ( "terminal_resolved_model_source"
-      , json_string_opt (terminal_decision_string "resolved_model_source") )
+      , Json_util.string_opt_to_json (terminal_decision_string "resolved_model_source") )
     ; ( "terminal_capability_source"
-      , json_string_opt (terminal_decision_string "capability_source") )
+      , Json_util.string_opt_to_json (terminal_decision_string "capability_source") )
     ; ( "terminal_fallback_authority"
-      , json_string_opt (terminal_decision_string "fallback_authority") )
+      , Json_util.string_opt_to_json (terminal_decision_string "fallback_authority") )
     ; ( "terminal_provider_source_cascade"
-      , json_string_opt (terminal_decision_string "provider_source_cascade") )
-    ; "terminal_error", json_string_opt (terminal_decision_string "error")
+      , Json_util.string_opt_to_json (terminal_decision_string "provider_source_cascade") )
+    ; "terminal_error", Json_util.string_opt_to_json (terminal_decision_string "error")
     ; ( "terminal_exception_kind"
-      , json_string_opt (terminal_decision_string "exception_kind") )
+      , Json_util.string_opt_to_json (terminal_decision_string "exception_kind") )
     ; "attempts", `List (List.map provider_attempt_row_json attempt_rows)
     ]
 ;;

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
@@ -34,19 +34,18 @@ let runtime_lens_tool_surface_parts scan =
   let required_tools =
     first_non_empty_string_list
       [
-        json_string_list_member "required_tool_names" lane_decision;
-        json_string_list_member "required_tool_names" tool_decision;
+        Json_util.get_string_list lane_decision "required_tool_names";
+        Json_util.get_string_list tool_decision "required_tool_names";
       ]
   in
   let materialized_tools =
-    json_string_list_member "materialized_tool_names" lane_decision
+    Json_util.get_string_list lane_decision "materialized_tool_names"
   in
   let missing_required_tools =
     first_non_empty_string_list
       [
-        json_string_list_member "missing_required_tool_names_after_lane"
-          lane_decision;
-        json_string_list_member "missing_required_tool_names" tool_decision;
+        Json_util.get_string_list lane_decision "missing_required_tool_names_after_lane";
+        Json_util.get_string_list tool_decision "missing_required_tool_names";
       ]
   in
   ( tool_decision
@@ -83,10 +82,10 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
   in
   let claim_status = json_string_member_opt "status" claim_scope in
   let claim_mode = json_string_member_opt "mode" claim_scope in
-  let claim_excluded_count = json_int_member_opt "excluded_count" claim_scope in
+  let claim_excluded_count = Json_util.get_int claim_scope "excluded_count" in
   let cascade_override =
     Option.value
-      (json_bool_member_opt "cascade_override" config_drift)
+      (Json_util.get_bool config_drift "cascade_override")
       ~default:false
   in
   let pre_dispatch_reason =

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml
@@ -157,7 +157,7 @@ let runtime_lens_accumulate_tool_proof acc json =
   runtime_lens_update_latest_ts acc json;
   let tool = Option.value (json_string_member_opt "tool" json) ~default:"unknown_tool" in
   runtime_lens_set_add acc.tools tool;
-  if json_bool_member_opt "success" json = Some true then (
+  if Json_util.get_bool json "success" = Some true then (
     acc.successful_tool_call_count <- acc.successful_tool_call_count + 1;
     runtime_lens_set_add acc.successful_tools tool)
   else (

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_summaries.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_summaries.ml
@@ -33,34 +33,34 @@ let claim_scope_summary_json ~keeper_name ~trace_id ?turn_id () =
       [ ("present", `Bool true)
       ; ("source", `String "keeper_task_claim_tool_call")
       ; ("status", `String (claim_status_of_output output))
-      ; ("result", json_string_opt (json_string_member_opt "result" output))
-      ; ("mode", json_string_opt (json_string_member_opt "mode" claim_scope))
+      ; ("result", Json_util.string_opt_to_json (json_string_member_opt "result" output))
+      ; ("mode", Json_util.string_opt_to_json (json_string_member_opt "mode" claim_scope))
       ; ( "scoped",
-          match json_bool_member_opt "scoped" claim_scope with
+          match Json_util.get_bool claim_scope "scoped" with
           | Some value -> `Bool value
           | None -> `Null )
       ; ( "active_goal_ids",
-          Json_util.json_string_list (json_string_list_member "active_goal_ids" claim_scope) )
+          Json_util.json_string_list (Json_util.get_string_list claim_scope "active_goal_ids") )
       ; ( "effective_goal_ids",
           Json_util.json_string_list
-            (json_string_list_member "effective_goal_ids" claim_scope) )
+            (Json_util.get_string_list claim_scope "effective_goal_ids") )
       ; ( "fallback_reason",
-          json_string_opt (json_string_member_opt "fallback_reason" claim_scope) )
+          Json_util.string_opt_to_json (json_string_member_opt "fallback_reason" claim_scope) )
       ; ( "matched_goal_id",
-          json_string_opt (json_string_member_opt "matched_goal_id" claim_scope) )
+          Json_util.string_opt_to_json (json_string_member_opt "matched_goal_id" claim_scope) )
       ; ( "excluded_count",
           match json_int_member_opt "excluded_count" claim_scope with
           | Some value -> `Int value
           | None -> `Null )
       ; ( "claimed_task_id",
           match claimed_task with
-          | Some task -> json_string_opt (json_string_member_opt "task_id" task)
+          | Some task -> Json_util.string_opt_to_json (json_string_member_opt "task_id" task)
           | None -> `Null )
       ; ( "claimed_goal_id",
           match claimed_task with
-          | Some task -> json_string_opt (json_string_member_opt "goal_id" task)
+          | Some task -> Json_util.string_opt_to_json (json_string_member_opt "goal_id" task)
           | None -> `Null )
-      ; ("trace_id", json_string_opt (json_string_member_opt "trace_id" call))
+      ; ("trace_id", Json_util.string_opt_to_json (json_string_member_opt "trace_id" call))
       ; ( "keeper_turn_id",
           match json_int_member_opt "keeper_turn_id" call with
           | Some value -> `Int value
@@ -105,7 +105,7 @@ let config_drift_summary_json ~config ~keeper_name =
       ]
   | Ok (Some meta) ->
     let sources = Keeper_status_bridge.source_provenance_json config meta in
-    let override_fields = json_string_list_member "override_fields" sources in
+    let override_fields = Json_util.get_string_list sources "override_fields" in
     let cascade_detail = find_override_field_source "model.cascade_name" sources in
     let default_cascade_name, live_cascade_name =
       match cascade_detail with
@@ -122,17 +122,17 @@ let config_drift_summary_json ~config ~keeper_name =
       ; ( "has_live_override",
           `Bool
             (Option.value
-               (json_bool_member_opt "has_live_override" sources)
+               (Json_util.get_bool sources "has_live_override")
                ~default:false) )
       ; ("cascade_override", `Bool cascade_override)
       ; ("override_fields", Json_util.json_string_list override_fields)
-      ; ("default_cascade_name", json_string_opt default_cascade_name)
-      ; ("live_cascade_name", json_string_opt live_cascade_name)
+      ; ("default_cascade_name", Json_util.string_opt_to_json default_cascade_name)
+      ; ("live_cascade_name", Json_util.string_opt_to_json live_cascade_name)
       ; ( "active_config_root",
-          json_string_opt (json_string_member_opt "active_config_root" sources) )
+          Json_util.string_opt_to_json (json_string_member_opt "active_config_root" sources) )
       ; ( "active_config_root_source",
-          json_string_opt
+          Json_util.string_opt_to_json
             (json_string_member_opt "active_config_root_source" sources) )
       ; ( "default_manifest_path",
-          json_string_opt (json_string_member_opt "default_manifest_path" sources) )
+          Json_util.string_opt_to_json (json_string_member_opt "default_manifest_path" sources) )
       ]

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
@@ -19,7 +19,7 @@ let runtime_lens_gap_json gap =
       ("code", `String gap.code);
       ("severity", `String gap.severity);
       ("lane", `String gap.lane);
-      ("detail", json_string_opt gap.detail);
+      ("detail", Json_util.string_opt_to_json gap.detail);
     ]
 
 let runtime_lens_gap_codes_for_lane gaps lane =

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -857,8 +857,8 @@ let runtime_count_authority_json ~runtime_count ~shell_counts
       ("shell_arbitration_allowed", `Bool false);
       ("live_total_runtimes", `Int runtime_count);
       ("live_keepers", `Int live_keepers);
-      ("configured_keepers", json_int_opt configured_keepers_count);
-      ("configured_minus_live_keepers", json_int_opt configured_minus_live);
+      ("configured_keepers", Json_util.int_opt_to_json configured_keepers_count);
+      ("configured_minus_live_keepers", Json_util.int_opt_to_json configured_minus_live);
       ( "count_roles",
         `Assoc
           [


### PR DESCRIPTION
## Summary

Follow-up to PR #19391 (merged). Replaces remaining non-canonical JSON/string helper usages with their `Json_util` equivalents across 21 files.

### Changes

| Pattern replaced | Canonical form | Files |
|---|---|---|
| `string_list_to_json` | `Json_util.json_string_list` | `keeper_status_detail.ml` (9 sites) |
| `json_string_list_member` | `Json_util.get_string_list` | `dashboard_http_keeper_trust.ml`, `server_dashboard_http_keeper_runtime_lens_summaries.ml` |
| `json_string_opt` (encoder) | `Json_util.string_opt_to_json` | `server_dashboard_http_keeper_runtime_lens_summaries.ml` |
| `json_bool_member_opt` | `Json_util.get_bool` | `server_dashboard_http_keeper_runtime_lens_summaries.ml` |
| `payload_string_opt` | `Json_util.get_string` | `cascade_event_bridge.ml` |
| `string_field_opt` | `Json_util.get_string` | `dashboard_execution.ml` |
| `json_assoc_field_opt` / `json_assoc_string_opt` | `Json_util.assoc_member_opt` / `assoc_string_opt` | server lens modules |

Also adds `dashboard_utils` dependency to `activity_graph/dune` for `first_some` SSOT.

### Why

Multiple modules define local aliases or reimplementations of JSON option encoders/decoders that already exist in `Json_util` (canonical) or `Safe_ops`. This creates:
- Argument order confusion (`key json` vs `json key`)
- Maintenance burden when the canonical API changes
- Inconsistent null-handling semantics

### Test plan

- [ ] `dune build @check` passes
- [ ] CI Build and Test green
- [ ] No behavioral change (pure rename, 80 insertions = 80 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)