### PR TITLE
refactor(keeper): reclassify No_tool_capable_provider into Cascade_exhausted No_tool_capable

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -107,6 +107,11 @@ type cascade_exhaustion_reason =
         and triggering the harsher [Cascade_exhausted { retryable = false }]
         failure policy.  This variant enables the softer
         [Soft_fail_turn + Provider_cooldown] path. *)
+  | No_tool_capable
+    (** Cascade exhausted because no configured provider can satisfy the
+        required tool set.  Previously a standalone [blocker_class] variant;
+        reclassified here because the cascade rotation filtered all candidates
+        before dispatch — a semantic subset of cascade exhaustion. *)
   | Other_detail of string
 
 type blocker_class =
@@ -120,7 +125,6 @@ type blocker_class =
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation
-  | No_tool_capable_provider
   | Stay_silent_loop
   | Fiber_unresolved
     (** 2026-05-05: turn fiber finished without invoking [resolve_done]
@@ -158,6 +162,7 @@ type blocker_class =
   | Sdk_input_required
 
 let blocker_class_to_string = function
+  | Cascade_exhausted No_tool_capable -> "cascade_exhausted_no_tool_capable"
   | Cascade_exhausted _ -> "cascade_exhausted"
   | Capacity_backpressure -> "capacity_backpressure"
   | Ambiguous_post_commit_timeout -> "ambiguous_post_commit_timeout"
@@ -168,7 +173,6 @@ let blocker_class_to_string = function
   | Turn_timeout -> "turn_timeout"
   | Turn_livelock_blocked -> "turn_livelock_blocked"
   | Completion_contract_violation -> "completion_contract_violation"
-  | No_tool_capable_provider -> "no_tool_capable_provider"
   | Stay_silent_loop -> "stay_silent_loop"
   | Fiber_unresolved -> "fiber_unresolved"
   | Stale_turn_timeout -> "stale_turn_timeout"
@@ -187,6 +191,7 @@ let blocker_class_to_string = function
 ;;
 
 let blocker_class_of_serialized_string = function
+  | "cascade_exhausted_no_tool_capable" -> Some (Cascade_exhausted No_tool_capable)
   | "cascade_exhausted" -> Some (Cascade_exhausted (Other_detail "cascade_exhausted"))
   | "capacity_backpressure" -> Some Capacity_backpressure
   | "ambiguous_post_commit_timeout" -> Some Ambiguous_post_commit_timeout
@@ -197,7 +202,6 @@ let blocker_class_of_serialized_string = function
   | "turn_timeout" -> Some Turn_timeout
   | "turn_livelock_blocked" -> Some Turn_livelock_blocked
   | "completion_contract_violation" -> Some Completion_contract_violation
-  | "no_tool_capable_provider" -> Some No_tool_capable_provider
   | "stay_silent_loop" -> Some Stay_silent_loop
   | "fiber_unresolved" -> Some Fiber_unresolved
   | "stale_turn_timeout" -> Some Stale_turn_timeout
@@ -232,6 +236,8 @@ let cascade_exhaustion_summary = function
     "Cascade exhausted after the per-OAS-call ceiling (max_execution_time_s) fired."
   | Capacity_exhausted ->
     "Cascade exhausted; all providers reported capacity backpressure."
+  | No_tool_capable ->
+    "Cascade exhausted; no configured provider can satisfy the required tool set."
   | Other_detail _ ->
     "Cascade exhausted; inspect cascade attempts for the dominant root cause."
 ;;
@@ -247,7 +253,6 @@ let blocker_class_continue_gate = function
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation
-  | No_tool_capable_provider
   | Stay_silent_loop
   | Fiber_unresolved
   | Stale_turn_timeout
@@ -275,6 +280,7 @@ let cascade_exhaustion_reason_to_json = function
   | Structural_attempt_timeout { detail } ->
     `Assoc [ "tag", `String "structural_attempt_timeout"; "detail", `String detail ]
   | Capacity_exhausted -> `String "capacity_exhausted"
+  | No_tool_capable -> `String "no_tool_capable"
   | Other_detail msg -> `Assoc [ "tag", `String "other_detail"; "message", `String msg ]
 ;;
 
@@ -286,6 +292,7 @@ let cascade_exhaustion_reason_of_json = function
   | `String "candidates_filtered_after_cycles" -> Some Candidates_filtered_after_cycles
   | `String "max_turns_exceeded" -> Some Max_turns_exceeded
   | `String "capacity_exhausted" -> Some Capacity_exhausted
+  | `String "no_tool_capable" -> Some No_tool_capable
   | `Assoc fields ->
     (match List.assoc_opt "tag" fields with
      | Some (`String "structural_attempt_timeout") ->

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -79,7 +79,6 @@ let blocker_class_indicates_overflow (klass : blocker_class) : bool =
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation
-  | No_tool_capable_provider
   | Stay_silent_loop
   | Fiber_unresolved
   | Stale_turn_timeout

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -369,7 +369,7 @@ let attention_fields_json (config : Coord_utils.config) (meta : keeper_meta) =
         true, Some "paused", Some "inspect_blocker_before_resume"
       | Some blocker when is_cascade_exhausted_blocker_class blocker.blocker_class ->
         true, Some "cascade_attempts_exhausted", Some "inspect_cascade_attempts"
-      | Some blocker when is_no_tool_capable_provider_blocker_class blocker.blocker_class ->
+      | Some blocker when is_no_tool_capable_blocker_class blocker.blocker_class ->
         true, Some "provider_tool_capability_missing", Some "inspect_provider_tool_lane"
       | Some blocker when is_completion_contract_blocker_class blocker.blocker_class ->
         true, Some "completion_contract_violation", Some "inspect_completion_contract"

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -18,7 +18,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
   | Some (Keeper_turn_driver.Cascade_exhausted { reason; _ }) ->
     Some (Cascade_exhausted reason)
   | Some (Keeper_turn_driver.Resumable_cli_session _) -> None
-  | Some (Keeper_turn_driver.No_tool_capable_provider _) -> Some No_tool_capable_provider
+  | Some (Keeper_turn_driver.No_tool_capable_provider _) -> Some (Cascade_exhausted No_tool_capable)
   | Some (Keeper_turn_driver.Accept_rejected _) -> None
   | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
     Some Admission_queue_wait_timeout
@@ -94,8 +94,8 @@ let is_cascade_exhausted_blocker_class blocker_class =
     (blocker_class_to_string (Cascade_exhausted (Other_detail "")))
 ;;
 
-let is_no_tool_capable_provider_blocker_class blocker_class =
-  String.equal blocker_class (blocker_class_to_string No_tool_capable_provider)
+let is_no_tool_capable_blocker_class blocker_class =
+  String.equal blocker_class "cascade_exhausted_no_tool_capable"
 ;;
 
 let is_completion_contract_blocker_class blocker_class =
@@ -146,10 +146,6 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
       if summary = ""
       then
         "OAS Agent.run or the enclosing cascade-attempt watchdog hit its execution timeout; this is not a provider HTTP timeout."
-      else summary
-    | No_tool_capable_provider ->
-      if summary = ""
-      then "No configured provider can satisfy the required tool set before dispatch."
       else summary
     | Completion_contract_violation ->
       (* TEL-OK: string literal in blocker classification summary, not an action handler *)
@@ -276,7 +272,7 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
            (Printf.sprintf
               "No tool-capable provider available (registry path): %s"
               detail)
-         No_tool_capable_provider)
+         (Cascade_exhausted No_tool_capable))
   | Keeper_registry.Provider_runtime_error { code; detail } ->
     Some
       { blocker_class = "provider_runtime_error"

--- a/test/test_keeper_status_runtime.ml
+++ b/test/test_keeper_status_runtime.ml
@@ -596,7 +596,7 @@ let test_runtime_surface_names_no_tool_provider_details () =
     runtime |> member "runtime_blocker_summary" |> to_string
   in
   check string "runtime blocker class"
-    "no_tool_capable_provider"
+    "cascade_exhausted_no_tool_capable"
     (runtime |> member "runtime_blocker_class" |> to_string);
   check bool "summary names required execution tool" true
     (has_substring surfaced_summary "tool_execute");
@@ -746,13 +746,13 @@ let test_runtime_blocker_summary_is_not_reparsed_from_masc_error_payload () =
       (KT.Cascade_exhausted KT.No_providers_available)
   in
   let no_tool_surface =
-    KSB.runtime_blocker_surface_of_typed_class ~summary KT.No_tool_capable_provider
+    KSB.runtime_blocker_surface_of_typed_class ~summary (KT.Cascade_exhausted KT.No_tool_capable)
   in
   check string "cascade summary stays opaque" summary cascade_surface.summary;
   check string "no-tool summary stays opaque" summary no_tool_surface.summary;
   check string "cascade class stays typed" "cascade_exhausted"
     cascade_surface.blocker_class;
-  check string "no-tool class stays typed" "no_tool_capable_provider"
+  check string "no-tool class stays typed" "cascade_exhausted_no_tool_capable"
     no_tool_surface.blocker_class
 ;;
 


### PR DESCRIPTION
## Summary
- Reclassifies `No_tool_capable_provider` from standalone `blocker_class` variant to `Cascade_exhausted No_tool_capable` within the `cascade_exhaustion_reason` ADT
- Serialized form `"cascade_exhausted_no_tool_capable"` preserves bridge-layer distinction for dashboard attention reasons
- 5 files changed, +19/-17

## Motivation
`No_tool_capable_provider` semantically represents cascade exhaustion — the cascade rotation filtered all candidates before dispatch. Keeping it as a standalone `blocker_class` variant obscured this relationship and violated the principle that `blocker_class` should be a flat error taxonomy, not a nested classification.

## Changes
- **`keeper_meta_contract.ml`**: Add `No_tool_capable` to `cascade_exhaustion_reason`, remove `No_tool_capable_provider` from `blocker_class`, add serialization/deserialization/summary arms
- **`keeper_status_bridge_blocker.ml`**: Map `Keeper_turn_driver.No_tool_capable_provider` to `Cascade_exhausted No_tool_capable`, rename predicate to `is_no_tool_capable_blocker_class`
- **`keeper_status_bridge.ml`**: Update predicate call
- **`keeper_rollover.ml`**: Remove dead `No_tool_capable_provider` arm (now caught by `Cascade_exhausted _`)
- **`test_keeper_status_runtime.ml`**: Update expected serialized strings and typed constructor usage

## Design Decision
The serialized form uses `"cascade_exhausted_no_tool_capable"` (not generic `"cascade_exhausted"`) so that the bridge layer's string-based predicates can still distinguish the specific "provider_tool_capability_missing" attention reason from generic cascade exhaustion. This is a deliberate backward-compatibility choice — the string is a dashboard label, not a classification key.

## Test plan
- [ ] `dune build` passes (pre-existing SSOT refactoring errors on main are unrelated)
- [ ] `test_keeper_status_runtime` tests pass with updated expectations
- [ ] Dashboard attention reason "provider_tool_capability_missing" still surfaces correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>