### PR TITLE
chore(dashboard): RFC-0203 follow-up — gate Discord lifecycle UI for in-process gateway

### DIFF
--- a/dashboard/src/components/connector-onboarding.test.ts
+++ b/dashboard/src/components/connector-onboarding.test.ts
@@ -23,44 +23,48 @@ describe('ConnectorOnboardingGrid', () => {
     resetSetupGuideExpansionState()
   })
 
-  it('renders one card per known sidecar in stable order', () => {
+  it('renders one card per external sidecar in stable order (in-process omitted)', () => {
     render(html`<${ConnectorOnboardingGrid} />`, container)
 
     const text = container.textContent ?? ''
-    expect(text).toContain('Discord')
+    // Discord is in-process (RFC-0203 §Phase 3) — no onboarding card.
+    expect(text).not.toContain('Discord')
     expect(text).toContain('iMessage')
     expect(text).toContain('Slack')
     expect(text).toContain('Telegram')
 
-    // Each card has its own brand-colored container (4 cards).
+    // 3 brand-coloured cards now (discord filtered out).
     const cards = container.querySelectorAll('[style*="linear-gradient"]')
-    expect(cards.length).toBe(4)
+    expect(cards.length).toBe(3)
   })
 
-  it('exposes the start command for each sidecar (run.sh per bridge)', () => {
+  it('exposes the start command for each external sidecar (run.sh per bridge)', () => {
     render(html`<${ConnectorOnboardingGrid} />`, container)
     const text = container.textContent ?? ''
-    expect(text).toContain('cd sidecars/discord-bot && ./run.sh')
+    // Discord card is omitted from onboarding — no run.sh to expose.
+    expect(text).not.toContain('cd sidecars/discord-bot && ./run.sh')
     expect(text).toContain('cd sidecars/imessage-bot && ./run.sh')
     expect(text).toContain('cd sidecars/slack-bot && ./run.sh')
     expect(text).toContain('cd sidecars/telegram-bot && ./run.sh')
   })
 
   // Pin the sidecarCommands() shape so a future refactor can't re-introduce
-  // the per-bridge pkill fork we just deleted.
-  it('uses ./run.sh stop for every bridge (no pkill)', () => {
-    for (const id of ['discord', 'imessage', 'slack', 'telegram']) {
+  // the per-bridge pkill fork we just deleted. Iterate the 3 remaining
+  // external sidecars only — discord no longer has a sidecar (RFC-0203 §Phase 3).
+  it('uses ./run.sh stop for every external bridge (no pkill)', () => {
+    for (const id of ['imessage', 'slack', 'telegram']) {
       const { stop } = sidecarCommands(id)
       expect(stop).toBe(`cd sidecars/${id}-bot && ./run.sh stop`)
       expect(stop).not.toContain('pkill')
     }
   })
 
-  it('embeds a collapsed SetupGuideCard per known connector', () => {
+  it('embeds a collapsed SetupGuideCard per external onboarding card', () => {
     render(html`<${ConnectorOnboardingGrid} />`, container)
-    // 4 setup-guide toggle buttons (one per onboarding card), all collapsed.
+    // 3 setup-guide toggle buttons (one per remaining onboarding card),
+    // all collapsed.
     const toggles = container.querySelectorAll('button[aria-expanded]')
-    expect(toggles.length).toBe(4)
+    expect(toggles.length).toBe(3)
     toggles.forEach(btn => {
       expect(btn.getAttribute('aria-expanded')).toBe('false')
     })
@@ -70,7 +74,10 @@ describe('ConnectorOnboardingGrid', () => {
     render(html`<${ConnectorOnboardingGrid} />`, container)
     const startAll = container.querySelector('[data-testid="bulk-action-start"]') as HTMLButtonElement
     expect(startAll).toBeTruthy()
-    // With zero registered connectors, all 4 count as "down".
+    // ConnectorBulkActions still derives its count from
+    // KNOWN_CONNECTOR_IDS (status-panel side), not the onboarding
+    // grid's filtered list — discord is still a known connector for
+    // the gate, just not externally spawnable.
     expect(startAll.textContent).toContain('(4)')
   })
 
@@ -79,25 +86,28 @@ describe('ConnectorOnboardingGrid', () => {
     expect(container.textContent ?? '').toContain('아직 연결된 사이드카가 없습니다')
   })
 
-  it('renders a per-card Start button with testId matching each connector id', () => {
+  it('renders a per-card Start button with testId for each external sidecar', () => {
     render(html`<${ConnectorOnboardingGrid} />`, container)
     const buttons = container.querySelectorAll('[data-testid^="onboarding-start-"]')
-    expect(buttons.length).toBe(4)
+    expect(buttons.length).toBe(3)
     const ids = Array.from(buttons)
       .map(b => b.getAttribute('data-testid')!.replace('onboarding-start-', ''))
-    expect(ids).toEqual(['discord', 'imessage', 'slack', 'telegram'])
+    // Discord omitted — KNOWN_CONNECTOR_IDS order with in-process filtered out.
+    expect(ids).toEqual(['imessage', 'slack', 'telegram'])
   })
 
   it('per-card Start button starts in the idle "Start" label, not inflight', () => {
     render(html`<${ConnectorOnboardingGrid} />`, container)
-    const discordBtn = container.querySelector('[data-testid="onboarding-start-discord"]') as HTMLButtonElement
-    expect(discordBtn.textContent).toContain('Start')
-    expect(discordBtn.textContent).not.toContain('Starting')
+    // Discord is no longer in the onboarding grid; use slack as the
+    // representative external sidecar.
+    const slackBtn = container.querySelector('[data-testid="onboarding-start-slack"]') as HTMLButtonElement
+    expect(slackBtn.textContent).toContain('Start')
+    expect(slackBtn.textContent).not.toContain('Starting')
     // ActionButton omits aria-busy when ariaBusy=false (ARIA default is
     // already "false" — no need to render it). When the inflight state
     // flips, ariaBusy=true would render aria-busy="true" instead.
-    expect(discordBtn.getAttribute('aria-busy')).toBeNull()
-    expect(discordBtn.disabled).toBe(false)
+    expect(slackBtn.getAttribute('aria-busy')).toBeNull()
+    expect(slackBtn.disabled).toBe(false)
   })
 })
 

--- a/dashboard/src/components/connector-onboarding.ts
+++ b/dashboard/src/components/connector-onboarding.ts
@@ -13,6 +13,7 @@ import {
   connectorAccentStyle,
   sidecarCommands,
   startSidecar,
+  isInProcessConnector,
   CONNECTOR_DISPLAY_NAMES,
   KNOWN_CONNECTOR_IDS,
   type KnownConnectorId,
@@ -86,7 +87,9 @@ export function ConnectorOnboardingGrid() {
       </div>
       <${ConnectorBulkActions} connectors=${[]} />
       <div class="grid grid-cols-2 gap-3 max-[900px]:grid-cols-1">
-        ${KNOWN_CONNECTOR_IDS.map(id => html`<${OnboardingCard} connectorId=${id} />`)}
+        ${KNOWN_CONNECTOR_IDS
+          .filter(id => !isInProcessConnector(id))
+          .map(id => html`<${OnboardingCard} connectorId=${id} />`)}
       </div>
     </div>
   `

--- a/dashboard/src/components/connector-setup-guides.test.ts
+++ b/dashboard/src/components/connector-setup-guides.test.ts
@@ -15,7 +15,7 @@ describe("CONNECTOR_SETUP_GUIDES", () => {
   })
 
   it.each([
-    ["discord", "Discord 봇 등록"],
+    ["discord", "Discord 봇 등록 (서버 내장 게이트웨이)"],
     ["imessage", "iMessage 권한 (macOS only)"],
     ["slack", "Slack App + Socket Mode"],
     ["telegram", "Telegram BotFather"],

--- a/dashboard/src/components/connector-setup-guides.ts
+++ b/dashboard/src/components/connector-setup-guides.ts
@@ -21,21 +21,23 @@ interface ConnectorSetupGuide {
 
 export const CONNECTOR_SETUP_GUIDES: Record<string, ConnectorSetupGuide> = {
   discord: {
-    title: 'Discord 봇 등록',
-    intro: 'Bot Token + Message Content Intent + OAuth bot scope가 필요합니다.',
+    title: 'Discord 봇 등록 (서버 내장 게이트웨이)',
+    intro: 'Bot Token + Message Content Intent + OAuth bot scope가 필요합니다. RFC-0203 §Phase 3 이후 별도 사이드카 프로세스 없이 서버 프로세스 내부에서 Discord Gateway 에 직접 연결합니다.',
     steps: [
       {
         text: 'Discord Developer Portal에서 새 Application 생성.',
         link: { href: 'https://discord.com/developers/applications', label: 'Developer Portal' },
       },
-      { text: 'Bot 탭 → Reset Token → 토큰 복사 (DISCORD_BOT_TOKEN).' },
+      { text: 'Bot 탭 → Reset Token → 토큰 복사.' },
+      { text: '쉘 환경변수 DISCORD_BOT_TOKEN 으로 export (예: ~/.zshenv 에 추가).' },
       { text: 'Bot 탭 → Privileged Gateway Intents → Message Content Intent 활성화.' },
       { text: 'OAuth2 → URL Generator → scope: bot, permissions: Send Messages / Embed Links / Read Message History.' },
       { text: '생성된 URL을 열어 봇을 길드에 초대.' },
+      { text: 'masc-mcp 서버를 재기동 — 부팅 시 자동으로 Discord Gateway 에 연결됩니다.' },
     ],
     references: [
-      { href: 'https://discordpy.readthedocs.io/', label: 'discord.py docs' },
       { href: 'https://discord.com/developers/docs/topics/gateway#gateway-intents', label: 'Gateway Intents' },
+      { href: 'https://discord.com/developers/docs/reference', label: 'Discord API Reference' },
     ],
   },
   imessage: {

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -657,16 +657,26 @@ describe('ConnectorStatusPanel', () => {
   })
 
   it('shows sidecar-off empty state when no bindings and sidecar offline', async () => {
+    // RFC-0203 §Phase 3 — Discord is in-process and does not render
+    // the sidecar-off panel anymore; use Slack as the representative
+    // external sidecar for this assertion. The in-process hint case
+    // (Discord with !available) is covered by the follow-up test
+    // below.
+    const slackConnector = {
+      ...sampleConnectorsResponse().connectors[0],
+      connector_id: 'slack',
+      display_name: 'Slack',
+      channel: 'slack',
+      available: false,
+      connected: false,
+      stale: false,
+      status: 'offline',
+      status_path: '/tmp/slack_status.json',
+      configured_bindings: [],
+    }
     const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
     const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse({
-      connectors: [{
-        ...sampleConnectorsResponse().connectors[0],
-        available: false,
-        connected: false,
-        stale: false,
-        status: 'offline',
-        configured_bindings: [],
-      }],
+      connectors: [slackConnector],
     }))
     const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
 
@@ -682,9 +692,9 @@ describe('ConnectorStatusPanel', () => {
 
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
     expect(text).toContain('사이드카 미시작')
-    expect(text).toContain('cd sidecars/discord-bot && ./run.sh')
+    expect(text).toContain('cd sidecars/slack-bot && ./run.sh')
     expect(text).toContain('사이드카 status 파일이')
-    expect(text).toContain('/tmp/discord_status.json')
+    expect(text).toContain('/tmp/slack_status.json')
     expect(text).toContain('관찰되지 않았습니다')
     expect(text).toContain('Start')
     expect(text).toContain('status')
@@ -710,11 +720,68 @@ describe('ConnectorStatusPanel', () => {
     const copyLabels = Array.from(panel!.querySelectorAll<HTMLButtonElement>('[data-copy-button]'))
       .map(button => button.getAttribute('aria-label'))
     expect(copyLabels).toEqual([
-      'Copy Discord sidecar start command',
-      'Copy Discord sidecar tail logs command',
-      'Copy Discord sidecar status command',
-      'Copy Discord sidecar stop command',
+      'Copy Slack sidecar start command',
+      'Copy Slack sidecar tail logs command',
+      'Copy Slack sidecar status command',
+      'Copy Slack sidecar stop command',
     ])
+  })
+
+  // RFC-0203 §Phase 3 — Discord runs in-process. When the gateway
+  // hasn't connected (e.g. DISCORD_BOT_TOKEN unset), the operator
+  // sees the in-process hint panel instead of the sidecar-off panel,
+  // and there are no Start/Stop buttons or run.sh hints anywhere.
+  it('shows in-process unavailable hint for Discord (no sidecar Start panel, no run.sh)', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse({
+      connectors: [{
+        ...sampleConnectorsResponse().connectors[0],
+        available: false,
+        connected: false,
+        stale: false,
+        status: 'offline',
+        configured_bindings: [],
+      }],
+    }))
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
+    // The new in-process hint replaces the sidecar Start panel.
+    expect(text).toContain('서버 내장 게이트웨이')
+    expect(text).toContain('DISCORD_BOT_TOKEN')
+    expect(text).toContain('재기동')
+    // None of the sidecar-only affordances should appear for discord.
+    expect(text).not.toContain('사이드카 미시작')
+    expect(text).not.toContain('cd sidecars/discord-bot && ./run.sh')
+
+    // The in-process panel uses the same amber tone for visual
+    // consistency with the sidecar-off panel, but it's a different
+    // data attribute so existing sidecar-targeted CSS / hooks don't
+    // accidentally apply.
+    const sidecarPanel = container.querySelector('[data-sidecar-not-started-panel]')
+    expect(sidecarPanel).toBeNull()
+    const inProcessPanel = container.querySelector('[data-in-process-not-running-panel]') as HTMLElement | null
+    expect(inProcessPanel).toBeTruthy()
+    expect(inProcessPanel!.className).toContain('bg-[var(--warn-10)]')
+    expect(inProcessPanel!.className).toContain('border-l-[var(--color-warn)]')
+
+    const chip = inProcessPanel!.querySelector('[data-in-process-status-chip]')
+    expect(chip).toBeTruthy()
+    expect(chip!.textContent).toContain('연결되지 않음')
+
+    // No Start/Stop button, no copyable run.sh command.
+    expect(inProcessPanel!.querySelector('button[aria-label*="start"]')).toBeNull()
+    expect(inProcessPanel!.querySelector('[data-copy-button]')).toBeNull()
   })
 
   it('shows no-keepers empty state when keeper directory is empty', async () => {

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -63,8 +63,12 @@ function activeConnectorFilter(): string | null {
   return KNOWN_CONNECTOR_IDS.includes(connector as KnownConnectorId) ? connector : null
 }
 
-// Per-connector lifecycle hints. All four sidecars now ship a run.sh wrapper
-// (discord/imessage/slack/telegram) — see sidecars/<id>-bot/run.sh.
+// Per-connector lifecycle hints. The three remaining external sidecars
+// (imessage/slack/telegram) ship a run.sh wrapper — see
+// sidecars/<id>-bot/run.sh. Discord runs in-process under
+// Server_discord_in_process_gateway (RFC-0203 §Phase 3, PR #19393);
+// no sidecar process, no lifecycle command panel — see
+// {@link IN_PROCESS_CONNECTOR_IDS}.
 // Source of truth: docs/CONNECTOR-CONFIG-SCHEMA.md.
 interface SidecarCommands {
   start: string
@@ -73,10 +77,35 @@ interface SidecarCommands {
   stop: string
 }
 
-// Known connectors with first-class onboarding/lifecycle support. Source of
-// truth: the four sidecars under /sidecars/ and config/navigation.ts.
+// Known connectors that appear in the dashboard (status panels, accent
+// colours, channel icons). Includes both external sidecars and the
+// in-process Discord gateway — the operator still wants to see Discord's
+// status row even though there's no sidecar process to start.
+//
+// Source of truth: the three remaining sidecars under /sidecars/, the
+// in-process gateway under lib/server/server_discord_in_process_gateway.{ml,mli},
+// and config/navigation.ts.
 export const KNOWN_CONNECTOR_IDS = ['discord', 'imessage', 'slack', 'telegram'] as const
 export type KnownConnectorId = (typeof KNOWN_CONNECTOR_IDS)[number]
+
+// Subset of {@link KNOWN_CONNECTOR_IDS} that run inside the server
+// process. For these, the "사이드카 미시작 / Start / Stop / tail
+// run.sh" lifecycle affordances are suppressed because there is no
+// sidecar process — the operator boots them by setting an env var and
+// restarting the server. RFC-0203 §Phase 3.
+export const IN_PROCESS_CONNECTOR_IDS = ['discord'] as const
+export type InProcessConnectorId = (typeof IN_PROCESS_CONNECTOR_IDS)[number]
+
+export function isInProcessConnector(connectorId: string): boolean {
+  return (IN_PROCESS_CONNECTOR_IDS as readonly string[]).includes(connectorId)
+}
+
+// The env var the operator must set to activate an in-process connector.
+// One per IN_PROCESS_CONNECTOR_IDS entry. Used by the status panel hint
+// shown in place of the "Start sidecar" affordance.
+export const IN_PROCESS_CONNECTOR_ENV: Record<InProcessConnectorId, string> = {
+  discord: 'DISCORD_BOT_TOKEN',
+}
 
 export const CONNECTOR_DISPLAY_NAMES: Record<KnownConnectorId, string> = {
   discord: 'Discord',
@@ -85,8 +114,10 @@ export const CONNECTOR_DISPLAY_NAMES: Record<KnownConnectorId, string> = {
   telegram: 'Telegram',
 }
 
+// Sidecar directories — only for connectors that actually run as
+// external sidecar processes. Discord is intentionally absent
+// (RFC-0203 §Phase 3 deleted sidecars/discord-bot/).
 const SIDECAR_DIRS: Record<string, string> = {
-  discord: 'sidecars/discord-bot',
   imessage: 'sidecars/imessage-bot',
   slack: 'sidecars/slack-bot',
   telegram: 'sidecars/telegram-bot',
@@ -749,8 +780,19 @@ function ConnectorLivePanel({
 
   const showNoKeeperEmpty =
     configuredBindings.length === 0 && !connector?.available && keepers.length === 0 && !keeperDirectoryError
+  // RFC-0203 §Phase 3: in-process connectors (currently just Discord)
+  // have no sidecar process and therefore no "사이드카 미시작" Start
+  // affordance. Render the in-process info hint instead — see
+  // showInProcessUnavailableHint below.
   const showSidecarOffEmpty =
-    !showNoKeeperEmpty && configuredBindings.length === 0 && !connector?.available
+    !showNoKeeperEmpty
+    && configuredBindings.length === 0
+    && !connector?.available
+    && !isInProcessConnector(connectorId)
+  const showInProcessUnavailableHint =
+    !showNoKeeperEmpty
+    && !connector?.available
+    && isInProcessConnector(connectorId)
 
   const headerIcon = channelIcon(connector?.channel ?? connectorId)
 
@@ -775,7 +817,7 @@ function ConnectorLivePanel({
           ? html`<${MutedSpan}><span aria-hidden="true">· </span>self-chat ${truncateMiddle(connector.self_chat_guid, 28)}</${MutedSpan}>`
           : null}
         <span class="ml-auto flex items-center gap-2">
-          ${connector?.available
+          ${connector?.available && !isInProcessConnector(connectorId)
             ? html`
                 <button
                   type="button"
@@ -811,6 +853,12 @@ function ConnectorLivePanel({
           {
             openConfig: () => openConnectorConfig(connectorId),
             toggleProcess: () => {
+              // RFC-0203 §Phase 3: in-process gateways have no
+              // sidecar process to toggle. The readiness rail still
+              // gets a callback to keep the type stable, but it's a
+              // no-op for these connectors — the operator manages
+              // them via env var + server restart.
+              if (isInProcessConnector(connectorId)) return
               const isUp = connector?.available === true
               void withRailInflight(connectorId, 'process', () =>
                 isUp ? stopSidecar(connectorId) : startSidecar(connectorId),
@@ -1015,6 +1063,42 @@ function ConnectorLivePanel({
                       variant="secondary"
                     />
                   </div>
+                </div>
+                <${SetupGuideCard} connectorId=${connectorId} />
+              </${SurfaceCard}>
+            `
+          })()
+        : null}
+
+      ${showInProcessUnavailableHint
+        ? (() => {
+            // RFC-0203 §Phase 3: in-process gateways (Discord) have no
+            // sidecar process to start, so the operator sees this hint
+            // instead of the "Start sidecar" panel. Same amber tone as
+            // the sidecar panel — "needs action, not broken" — but the
+            // remediation is an env var + restart, not a CLI command.
+            const envVar = IN_PROCESS_CONNECTOR_ENV[connectorId as InProcessConnectorId]
+            return html`
+              <${SurfaceCard}
+                class="mt-3 !border-dashed !border-[var(--warn-20)] !border-l-4 !border-l-[var(--color-warn)] !bg-[var(--warn-10)] !px-3 !py-3 text-xs"
+                data-in-process-not-running-panel
+              >
+                <div class="mb-1 flex flex-wrap items-center gap-2">
+                  <span
+                    class="inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--color-status-warn)]"
+                    aria-label=${`${connectorName} in-process gateway 상태: 연결되지 않음`}
+                    data-in-process-status-chip
+                  >
+                    <span aria-hidden="true">⊘</span>
+                    <span>연결되지 않음</span>
+                  </span>
+                  <span class="font-medium text-[var(--color-fg-primary)]">서버 내장 게이트웨이</span>
+                  ${connector?.updated_at
+                    ? html`<span class="text-3xs text-[var(--color-fg-disabled)]">last seen ${timeAgo(connector.updated_at)}</span>`
+                    : null}
+                </div>
+                <div class="text-2xs text-[var(--color-status-warn)]/80">
+                  ${connectorName} 게이트웨이가 서버 프로세스 내부에서 동작합니다. 별도 사이드카 프로세스가 없으므로 Start/Stop 버튼이 없습니다. <${Tk}>${envVar}<//> 환경변수를 설정하고 서버를 재기동하면 자동으로 Discord Gateway 에 연결됩니다.
                 </div>
                 <${SetupGuideCard} connectorId=${connectorId} />
               </${SurfaceCard}>


### PR DESCRIPTION
## Summary

Dashboard cleanup follow-up to RFC-0203 Phase 3 (#19393): mark Discord as an in-process connector and suppress sidecar-only lifecycle affordances (Start/Stop buttons, `cd sidecars/discord-bot && ./run.sh` hints, the onboarding card with its Start button). The status panel, brand colours, channel icon, and connector tile remain — operators still want to see Discord's bindings and connected state at a glance.

This is the "out of scope" follow-up explicitly called out in #19393's PR body.

## What's in this PR

### Typed marker

- **`dashboard/src/components/connector-status.ts`**:
  - New `export const IN_PROCESS_CONNECTOR_IDS = ['discord'] as const` + matching `InProcessConnectorId` type.
  - New `export function isInProcessConnector(connectorId: string): boolean`.
  - New `export const IN_PROCESS_CONNECTOR_ENV: Record<InProcessConnectorId, string>` — maps each in-process connector to the env var an operator must set (`DISCORD_BOT_TOKEN` for discord). Used by the new hint panel.
  - `SIDECAR_DIRS` no longer lists discord (the entry was misleading post-Phase-3 since no `sidecars/discord-bot/` directory exists).

### UI gates

- **`showSidecarOffEmpty`** gates on `!isInProcessConnector(connectorId)` — discord no longer renders the amber "사이드카 미시작 / Start / cd sidecars/.../run.sh" panel.
- **`showInProcessUnavailableHint`** (new) renders for in-process connectors when `!connector?.available` — same amber tone for consistency, different `data-in-process-not-running-panel` attribute, text explains "set DISCORD_BOT_TOKEN + restart". No Start button, no copyable command, no Stop button.
- **Header Stop button** (line ~820) gates on `!isInProcessConnector(connectorId)` — even when discord is available, no Stop button (because there's no process to stop).
- **Readiness rail `toggleProcess`** early-returns for in-process connectors — clicking the rail process pill does nothing for discord rather than firing a useless API call.

### Onboarding grid

- **`dashboard/src/components/connector-onboarding.ts`**:
  - `KNOWN_CONNECTOR_IDS.filter(id => !isInProcessConnector(id))` before mapping to cards.
  - Discord no longer appears in the cold-start onboarding grid; operators bootstrap it via env var + server restart, not via a UI Start button.

### Setup guide

- **`dashboard/src/components/connector-setup-guides.ts`** §discord rewritten:
  - Title: `Discord 봇 등록` → `Discord 봇 등록 (서버 내장 게이트웨이)`.
  - Intro mentions in-process gateway + RFC reference.
  - New step explicitly: "쉘 환경변수 `DISCORD_BOT_TOKEN` 으로 export".
  - New step: "masc-mcp 서버 재기동 — 부팅 시 자동으로 Discord Gateway 에 연결".
  - `discord.py docs` reference removed (Python library no longer used).
  - `Discord API Reference` reference added.

### Tests

- **`connector-onboarding.test.ts`** (5 cases updated):
  - "renders one card per known sidecar" → "renders one card per **external** sidecar (in-process omitted)" with `cards.length: 4 → 3`.
  - "exposes the start command for each sidecar" updated to assert discord run.sh is *not* present + remaining 3 sidecars are.
  - "uses ./run.sh stop for every bridge" loop limited to `['imessage', 'slack', 'telegram']`.
  - "embeds a collapsed SetupGuideCard per known connector": `toggles.length: 4 → 3`.
  - "renders a per-card Start button with testId": `ids: ['discord', ...] → ['imessage', 'slack', 'telegram']`.
  - "Start button starts in the idle Start label": uses `slack` instead of `discord` as the representative external sidecar.
- **`connector-status.test.ts`** (1 case updated, 1 case added):
  - Existing "shows sidecar-off empty state when no bindings and sidecar offline" updated to use `slack` fixture so it still exercises the sidecar-off panel.
  - New "shows in-process unavailable hint for Discord (no sidecar Start panel, no run.sh)" pins: `data-in-process-not-running-panel` exists, `data-sidecar-not-started-panel` is null, contains `서버 내장 게이트웨이` + `DISCORD_BOT_TOKEN` + `재기동`, no `사이드카 미시작` / `cd sidecars/...` strings, no Start button or copyable command inside.
- **`connector-setup-guides.test.ts`** (1 case updated): title literal updated.

## Workaround Rejection Bar self-check

- **No string classifier.** `isInProcessConnector` is a typed membership check against a `readonly string[]` derived from a `const as const` literal. Adding a new in-process connector requires editing the constant + the env-var map — no substring matching.
- **No catch-all wildcard.** The new `showInProcessUnavailableHint` branch is exhaustive over `IN_PROCESS_CONNECTOR_IDS`. The `IN_PROCESS_CONNECTOR_ENV` record is typed `Record<InProcessConnectorId, string>` so adding a variant without a corresponding env entry is a TS error.
- **No telemetry-as-fix.** This PR removes misleading UI affordances and adds a correct hint panel; no counters, no logging.
- **No N-of-M.** The `isInProcessConnector` guard is applied at every relevant render site (4 gates: `showSidecarOffEmpty`, Header Stop button, `toggleProcess`, Onboarding grid filter). No call site copies the discord literal.
- **No cap/cooldown/dedup/repair.** No retry, no rate limit, no fallback masking.

## Test plan (258 PASS across 13 dashboard test files)

| File | Cases | Notes |
|---|---|---|
| `connector-status.test.ts` | 26 | +1 in-process hint case, updated sidecar-off case |
| `connector-onboarding.test.ts` | 10 | 5 cases reshaped to omit discord |
| `connector-setup-guides.test.ts` | 17 | title literal updated |
| `connector-overview-strip.test.ts` | — | regression |
| `connector-quick-bind.test.ts` | — | regression |
| `connector-overview-skeleton.test.ts` | — | regression |
| `sidecar-log-viewer.test.ts` | — | regression |
| `doctor-panel.test.ts` | — | regression |
| `connector-config-form.test.ts` | — | regression |
| `connector-paths-strip.test.ts` | — | regression |
| `setup-guide-card.test.ts` | — | regression |
| `connector-keeper-matrix.test.ts` | — | regression |
| `connector-card-border.test.ts` | — | regression |

- `pnpm typecheck` (tsc --noEmit): clean
- `pnpm lint` (eslint src): clean

## Out of scope

- **HTTP routes** `/api/v1/gate/connector/bind?name=discord` and `/unbind?name=discord` still serve the dashboard's binding UI for discord — no change needed (the in-process gateway uses the same `Channel_gate_discord_state` binding store).
- **Sidecar lifecycle HTTP routes** (`/api/v1/sidecar/discord/...`) — already return 400 after #19393 dropped discord from `Doctor_dispatch.known_sidecars`; the dashboard never calls them for discord now that the buttons are gone.

## Hook bypass disclosure

Commit will use `git commit --no-verify` with explicit prior user approval scoped to RFC-0203 follow-up work. The `.githooks/pre-commit` runs `dune build --root .` on non-allowlisted paths, which still fails on main today due to the ongoing Json_util consolidation drift (independent of this PR — same disclosure as #19393 / #19396).

🤖 Generated with [Claude Code](https://claude.com/claude-code)