### PR TITLE
fix(ssot): complete JSON/string helper purge to Json_util (restore main build, completes #19391)

### DIFF
--- a/lib/activity_graph/activity_graph_types.ml
+++ b/lib/activity_graph/activity_graph_types.ml
@@ -147,7 +147,7 @@ let assoc_replace_int_opt name value fields =
   | Some value when value >= 1 -> assoc_replace name (`Int value) fields
   | _ -> fields
 
-let first_some = Dashboard_utils.first_some
+let first_some a b = match a with Some _ as v -> v | None -> b
 
 let tag_context_pair raw =
   match String.index_opt raw ':' with

--- a/lib/keeper/keeper_tools_oas_deterministic_error.ml
+++ b/lib/keeper/keeper_tools_oas_deterministic_error.ml
@@ -9,7 +9,7 @@ open Keeper_tools_oas_workflow
 
 let json_assoc_field_opt = Json_util.assoc_member_opt
 let detail_json_opt = Keeper_tools_oas_json.detail_json_opt
-let json_assoc_string_opt = Keeper_tools_oas_json.json_assoc_string_opt
+let json_assoc_string_opt = Json_util.assoc_string_opt
 
 let recovery_plan_json_opt json =
   match json_assoc_field_opt "recovery_plan" json with

--- a/lib/tool_library.mli
+++ b/lib/tool_library.mli
@@ -66,8 +66,8 @@ val source_of_string_opt : string -> library_source option
 
 (** {1 String helper} *)
 
-val string_contains : sub:string -> string -> bool
-(** [string_contains ~sub s] is [true] iff [sub] is a contiguous
+val string_contains : needle:string -> string -> bool
+(** [string_contains ~needle s] is [true] iff [needle] is a contiguous
     substring of [s].  Byte-wise — case-sensitive.  Callers
     lowercase both inputs when case-insensitive matching is
     required (see {!handle_read} / {!handle_search}). *)

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1000,7 +1000,7 @@ let test_library_search_returns_results () =
            true
            (let low = String.lowercase_ascii (Tool_result.message search_result) in
             String.length low > 0
-            && not (Tool_library.string_contains ~sub:"no documents" low));
+            && not (Tool_library.string_contains ~needle:"no documents" low));
          (* Read *)
          let read_result =
            Tool_library.handle_read
@@ -1016,7 +1016,7 @@ let test_library_search_returns_results () =
            "read contains MLFQ content"
            true
            (Tool_library.string_contains
-              ~sub:"Multi-Level Feedback Queue"
+              ~needle:"Multi-Level Feedback Queue"
               (Tool_result.message read_result))))
 ;;
 


### PR DESCRIPTION
## 목적

SSOT consolidation 라운드(#19391/#19398/#19406/#19409/#19410)가 이 브랜치의 원래 24파일 중 **20파일을 흡수**했습니다. 현재 main 위로 rebase한 결과, 라운드가 제거한 helper를 아직 참조하는 **잔여 caller 3곳 + 라벨 불일치 1곳**만 남습니다.

## 변경 (4 files, +6/-6)

| 파일 | 수정 | main의 현재 상태 |
|---|---|---|
| `keeper_tools_oas_deterministic_error.ml` | `Keeper_tools_oas_json.json_assoc_string_opt` → `Json_util.assoc_string_opt` | 정의 제거됨 → **Unbound value** |
| `activity_graph_types.ml` | `Dashboard_utils.first_some` → inline | 정의 제거됨 → **Unbound value** (+ cross-lib 의존 제거) |
| `tool_library.mli` | `string_contains ~sub:` → `~needle:` | impl·전 caller는 `~needle:` → **"Labels needle and sub do not match"** |
| `test/test_keeper_tools_oas.ml` | 호출 2곳 `~sub:` → `~needle:` | 위와 동일 |

세 수정 모두 현재 main(`ee730f9c6`)에 **여전히 살아있는 컴파일 에러**를 고칩니다(grep 검증 완료).

## 범위 밖 (중요)

이 PR은 main의 **별개 차원** 깨짐인 Keeper_types facade 제거(#19399/#19400발 `sandbox_profile`/`keeper_meta`/`write_meta_with_merge`/`is_no_tool_capable_blocker_class` unbound)는 **건드리지 않습니다**. 이를 고치는 열린 PR이 없어, main의 `Build and Test`는 그게 랜딩하기 전까지 red 유지됩니다. 이 PR은 **SSOT-helper 차원만** 정리합니다.

RFC-WAIVED: mechanical SSOT helper 마이그레이션, credential/sandbox 로직 무관.
WORKAROUND-WAIVED: 제거된 helper alias(안티패턴)를 *제거*하는 작업으로, shim 추가의 정반대.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
