### PR TITLE
feat(shell-ir): make Shell_ir_risk read the typed GADT (RFC-0160 §S1)

### DIFF
--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -319,20 +319,22 @@ let is_write_operation (words : string list) =
   | [] -> false
 ;;
 
+let is_short_option arg = String.length arg > 1 && arg.[0] = '-' && arg.[1] <> '-'
+let has_short_flag flag arg = is_short_option arg && String.contains arg flag
+
+let is_protected_branch_target arg =
+  let target = String.lowercase_ascii arg in
+  List.mem
+    target
+    [ "main"; "master"; "origin/main"; "origin/master";
+      "refs/heads/main"; "refs/heads/master" ]
+  || List.exists
+       (fun suffix -> String.ends_with ~suffix target)
+       [ ":main"; ":master"; ":origin/main"; ":origin/master";
+         ":refs/heads/main"; ":refs/heads/master" ]
+;;
+
 let is_destructive_bash_operation (words : string list) =
-  let is_short_option arg = String.length arg > 1 && arg.[0] = '-' && arg.[1] <> '-' in
-  let has_short_flag flag arg = is_short_option arg && String.contains arg flag in
-  let is_protected_branch_target arg =
-    let target = String.lowercase_ascii arg in
-    List.mem
-      target
-      [ "main"; "master"; "origin/main"; "origin/master";
-        "refs/heads/main"; "refs/heads/master" ]
-    || List.exists
-         (fun suffix -> String.ends_with ~suffix target)
-         [ ":main"; ":master"; ":origin/main"; ":origin/master";
-           ":refs/heads/main"; ":refs/heads/master" ]
-  in
   match words with
   | "git" :: "push" :: rest ->
     let has_force =
@@ -360,20 +362,216 @@ let is_destructive_bash_operation (words : string list) =
   | _ -> false
 ;;
 
+(* --- Word-list decision (pre-typed-GADT path) -----------------------
+
+   Retained for the [Generic] escape hatch (env/redirect/$VAR/unknown
+   bin), for [Pipeline]s, and as the differential baseline that
+   [risk_of_typed] must never under-classify. *)
+
+let classify_words (words : string list) : risk_class =
+  if is_destructive_bash_operation words then Destructive_protected
+  else if is_write_operation words then
+    (match classify_write_detail words with
+     | Some r -> r
+     | None -> R2_Irreversible)
+  else
+    (match words with
+     | "gh" :: _ -> classify_repo_hosting_cli words
+     | _ -> R0_Read)
+;;
+
+(* --- Typed-GADT decision substrate (RFC-0160 §S1 completion) ----------
+
+   [risk_of_typed] is the risk opinion implied by the typed command
+   shape alone — the first decision path that reads the [Shell_ir_typed]
+   GADT instead of re-flattening to a word list. [classify] combines it
+   with the word-list floor ([classify_words]) by taking the stricter of
+   the two, so the overall decision is monotone-safe by construction.
+
+   The match is exhaustive (no [_ ->] catch-all): adding a constructor
+   to [Shell_ir_typed_types.command] forces a compile error here, so a
+   new typed command cannot reach dispatch without a risk decision.
+   CLAUDE.md §"FSM Sparse Match" — every constructor named, no wildcard.
+
+   Policy (2026-05-29, option B — monotone-safe, escalate dangerous
+   gaps only): the type closes word-list holes it makes visible —
+   [Sudo] (privilege escalation; the word-list head token was "sudo" so
+   its "rm"/"git push" arms never fired -> silent R0), [Su] and [Mkfs]
+   (R0 -> R2). Commands the word-list already classifies keep their risk
+   (curl/sed/git pull stay R0; git push/commit stay R1; rm -rf protected
+   stays Destructive). [Gh] and [Generic] return R0 here because the
+   type cannot see their risk-bearing tokens (gh -X METHOD / graphql
+   body live in [rest]); the word-list floor in [classify] supplies it.
+   Dropping that floor is gated on the typed model subsuming it. *)
+
+let npm_write_subcommands =
+  [ "add"; "install"; "link"; "prune"; "publish"; "remove"; "unlink";
+    "update"; "up" ]
+;;
+
+let risk_of_typed (w : Shell_ir_typed.wrapped) : risk_class =
+  let open Shell_ir_typed in
+  match w with
+  (* --- read / inspection: R0_Read ----------------------------------- *)
+  | W (Ls _) -> R0_Read
+  | W (Cat _) -> R0_Read
+  | W (Rg _) -> R0_Read
+  | W (Find _) -> R0_Read
+  | W (Head _) -> R0_Read
+  | W (Tail _) -> R0_Read
+  | W (Grep _) -> R0_Read
+  | W (Wc _) -> R0_Read
+  | W (Pwd _) -> R0_Read
+  | W (Echo _) -> R0_Read
+  | W (Which _) -> R0_Read
+  | W (Sort _) -> R0_Read
+  | W (Cut _) -> R0_Read
+  | W (Tr _) -> R0_Read
+  | W (Date _) -> R0_Read
+  | W (Env _) -> R0_Read
+  | W (Printenv _) -> R0_Read
+  | W (Uniq _) -> R0_Read
+  | W (Basename _) -> R0_Read
+  | W (Dirname _) -> R0_Read
+  | W (Test _) -> R0_Read
+  | W (Stat _) -> R0_Read
+  | W (Hostname _) -> R0_Read
+  | W (Whoami _) -> R0_Read
+  | W (Du _) -> R0_Read
+  | W (Df _) -> R0_Read
+  | W (File _) -> R0_Read
+  | W (Printf _) -> R0_Read
+  | W (Uname _) -> R0_Read
+  | W (Ps _) -> R0_Read
+  | W (Tty _) -> R0_Read
+  | W (Diff _) -> R0_Read
+  (* git read subcommands: R0 (parity with word-list) *)
+  | W (Git_status _) -> R0_Read
+  | W (Git_diff _) -> R0_Read
+  | W (Git_log _) -> R0_Read
+  (* git pull: word-list does not list "pull" as write -> R0 (kept under
+     option B; escalation deferred to a correctness follow-up) *)
+  | W (Git_pull _) -> R0_Read
+  (* network commands the word-list leaves at R0 (option B: unchanged) *)
+  | W (Curl _) -> R0_Read
+  | W (Wget _) -> R0_Read
+  | W (Ssh _) -> R0_Read
+  | W (Scp _) -> R0_Read
+  | W (Tar _) -> R0_Read
+  | W (Sed _) -> R0_Read
+  | W (Rsync _) -> R0_Read
+  (* interpreters / build tools the word-list leaves at R0 *)
+  | W (Node _) -> R0_Read
+  | W (Python _) -> R0_Read
+  | W (Python3 _) -> R0_Read
+  | W (Pip _) -> R0_Read
+  | W (Patch _) -> R0_Read
+  | W (Cargo _) -> R0_Read
+  | W (Go _) -> R0_Read
+  | W (Opam _) -> R0_Read
+  | W (Npx _) -> R0_Read
+  | W (Uv _) -> R0_Read
+  | W (Glab _) -> R0_Read
+  | W (Pytest _) -> R0_Read
+  | W (Terminal_notifier _) -> R0_Read
+  | W (Ruff _) -> R0_Read
+  | W (Pyright _) -> R0_Read
+  | W (Tsc _) -> R0_Read
+  | W (Ocamlfind _) -> R0_Read
+  | W (Rustc _) -> R0_Read
+  | W (Gofmt _) -> R0_Read
+  | W (Gradle _) -> R0_Read
+  | W (Ninja _) -> R0_Read
+  | W (Java _) -> R0_Read
+  | W (Javac _) -> R0_Read
+  | W (Mvn _) -> R0_Read
+  | W (Cmake _) -> R0_Read
+  | W (Dune_local_sh _) -> R0_Read
+  | W (Osascript _) -> R0_Read
+  | W (Play _) -> R0_Read
+  | W (Rec _) -> R0_Read
+  | W (Ffplay _) -> R0_Read
+  | W (Mpg123 _) -> R0_Read
+  | W (Open _) -> R0_Read
+  (* --- reversible mutation: R1 (parity with word-list write list) --- *)
+  | W (Mkdir _) -> R1_Reversible_mutation
+  | W (Chmod _) -> R1_Reversible_mutation
+  | W (Chown _) -> R1_Reversible_mutation
+  | W (Make _) -> R1_Reversible_mutation
+  | W (Git_clone _) -> R1_Reversible_mutation
+  | W (Git_commit _) -> R1_Reversible_mutation
+  (* node package managers: write subcommands -> R1, else R0 *)
+  | W (Npm { subcommand; _ }) ->
+    if List.mem subcommand npm_write_subcommands then R1_Reversible_mutation
+    else R0_Read
+  | W (Yarn { subcommand; _ }) ->
+    if List.mem subcommand npm_write_subcommands then R1_Reversible_mutation
+    else R0_Read
+  | W (Pnpm { subcommand; _ }) ->
+    if List.mem subcommand npm_write_subcommands then R1_Reversible_mutation
+    else R0_Read
+  (* git push: force / force-with-lease to a protected branch is
+     Destructive_protected (word-list parity via [is_protected_branch_target]
+     on the typed [branch] field); any other push is R1 *)
+  | W (Git_push { force; force_with_lease; branch; _ }) ->
+    let forced = force || force_with_lease in
+    let protected_target =
+      match branch with
+      | Some b -> is_protected_branch_target b
+      | None -> false
+    in
+    if forced && protected_target then Destructive_protected
+    else R1_Reversible_mutation
+  (* --- irreversible: R2 --------------------------------------------- *)
+  (* Su / Dd / Mkfs: word-list head-token match missed Su/Mkfs (-> R0);
+     the type makes them visible. Dd was already R2 in the word-list. *)
+  | W (Su _) -> R2_Irreversible
+  | W (Dd _) -> R2_Irreversible
+  | W (Mkfs _) -> R2_Irreversible
+  (* rm: recursive + force -> Destructive_protected, else R2 (word-list
+     parity with [is_destructive_bash_operation] / [classify_write_detail]) *)
+  | W (Rm { recursive; force; _ }) ->
+    if recursive && force then Destructive_protected else R2_Irreversible
+  (* --- privilege escalation: Destructive_protected ------------------ *)
+  (* sudo wraps an arbitrary argv; the word-list head was "sudo" so its
+     "rm"/"git push" arms never fired (silent R0). Privilege escalation
+     always requires approval. *)
+  | W (Sudo _) -> Destructive_protected
+  (* gh: the typed [Gh] constructor buries the HTTP method (-X DELETE)
+     and graphql body in [rest], so the type alone cannot decide gh
+     risk. [classify]'s word-list floor supplies it; revisit here once
+     the typed model captures the method + graphql body. *)
+  | W (Gh _) -> R0_Read
+  | W (Docker _) -> R0_Read
+  (* escape hatch (env/redirect/$VAR/unknown bin): no typed shape to
+     read; [classify]'s word-list floor classifies it. *)
+  | W (Generic _) -> R0_Read
+;;
+
 (* --- Main classifier ------------------------------------------------ *)
 
+let risk_rank = function
+  | R0_Read -> 0
+  | R1_Reversible_mutation -> 1
+  | R2_Irreversible -> 2
+  | Destructive_protected -> 3
+;;
+
+let max_risk a b = if risk_rank a >= risk_rank b then a else b
+
+(* The decision is the stricter of the typed-shape opinion and the
+   word-list floor, so it is monotone-safe by construction: never lower
+   than the legacy word-list verdict. The typed path contributes
+   escalations the substring path missed (Sudo/Su/Mkfs); the word-list
+   floor covers what the type cannot fully see (gh -X METHOD, Generic,
+   multi-stage pipelines). Removing the floor is gated on the typed
+   model becoming complete enough to subsume it (RFC-0160 follow-up). *)
 let classify (T ir : undecided t) : decided decided_ir =
-  let words = flat_stage_words ir in
-  let risk =
-    if is_destructive_bash_operation words then
-      Destructive_protected
-    else if is_write_operation words then
-      (match classify_write_detail words with
-       | Some r -> r
-       | None -> R2_Irreversible)
-    else
-      (match words with
-       | "gh" :: _ -> classify_repo_hosting_cli words
-       | _ -> R0_Read)
+  let word_risk = classify_words (flat_stage_words ir) in
+  let typed_risk =
+    match ir with
+    | Shell_ir.Simple s -> risk_of_typed (Shell_ir_typed.of_simple s)
+    | Shell_ir.Pipeline _ -> R0_Read
   in
-  { ir; risk }
+  { ir; risk = max_risk typed_risk word_risk }
+;;

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -34,7 +34,25 @@ val classify : undecided t -> decided decided_ir
 (** Run the unified risk classifier over the wrapped IR.
     Uses [Exec_policy_mutation_classifier] for bash operations,
     then repo-hosting CLI subcommand tables for ["gh"] command operations,
-    defaulting to R0. *)
+    defaulting to R0.
+
+    [Simple] commands are lowered to the [Shell_ir_typed] GADT and
+    classified by [risk_of_typed]; [Pipeline]s and the [Generic] escape
+    hatch fall back to the word-list classifier [classify_words]. *)
+
+val risk_of_typed : Shell_ir_typed.wrapped -> risk_class
+(** Risk opinion implied by the typed command shape alone (RFC-0160 §S1)
+    — the first decision path that reads the [Shell_ir_typed] GADT.
+    Exhaustive over [Shell_ir_typed_types.command]: a new constructor
+    forces a compile error here. [classify] combines this with
+    [classify_words] by taking the stricter of the two, so [Gh]/[Generic]
+    may return a lower opinion here than the word-list floor supplies. *)
+
+val classify_words : string list -> risk_class
+(** Word-list risk classifier — the pre-GADT decision path, retained as
+    the safety floor in [classify] for [Generic]/[Pipeline] and for
+    risk-bearing tokens the typed model does not yet capture (gh
+    -X METHOD / graphql body). *)
 
 val is_write_operation : string list -> bool
 (** [true] when the flattened word list indicates a write-level operation:

--- a/lib/exec/test/test_shell_ir_risk.ml
+++ b/lib/exec/test/test_shell_ir_risk.ml
@@ -270,6 +270,80 @@ let test_s7_stamp_invariant () =
          (Risk.string_of_risk_class reclassified_risk))
     stamp_invariant_cases
 
+(* --- typed-GADT escalation: word-list gaps the type closes ---------
+
+   These cases are R0 under the word-list alone (the head token was
+   "sudo"/"su"/"mkfs", so the "rm"/"git push" arms never fired and the
+   command name was not in the write list). The typed GADT path
+   escalates them. Proves [risk_of_typed] adds safety, not just parity. *)
+
+let test_typed_escalation_closes_wordlist_gaps () =
+  (* word-list baseline is R0 for each (gap), so any escalation here is
+     attributable to the typed path. *)
+  let assert_floor_is_r0 words =
+    Alcotest.(check string)
+      (Printf.sprintf "word-list floor R0 for [%s]" (String.concat " " words))
+      "R0"
+      (Risk.string_of_risk_class (Risk.classify_words words))
+  in
+  (* sudo: privilege escalation -> Destructive_protected *)
+  assert_floor_is_r0 [ "sudo"; "rm"; "-rf"; "/" ];
+  let sudo = simple_ir "sudo" [ "rm"; "-rf"; "/" ] in
+  Alcotest.(check bool)
+    "sudo -> Destructive_protected"
+    true
+    (Risk.is_destructive (Risk.classify (Risk.undecided sudo)));
+  (* su: root shell -> R2 *)
+  assert_floor_is_r0 [ "su"; "-"; "root" ];
+  let su = simple_ir "su" [ "-"; "root" ] in
+  Alcotest.(check bool)
+    "su -> R2"
+    true
+    (Risk.is_r2 (Risk.classify (Risk.undecided su)));
+  (* mkfs: filesystem create -> R2 *)
+  assert_floor_is_r0 [ "mkfs"; "/dev/sda1" ];
+  let mkfs = simple_ir "mkfs" [ "/dev/sda1" ] in
+  Alcotest.(check bool)
+    "mkfs -> R2"
+    true
+    (Risk.is_r2 (Risk.classify (Risk.undecided mkfs)))
+
+(* --- monotone-safe invariant: classify >= word-list floor ----------
+
+   Structural guard: [classify] takes the stricter of the typed opinion
+   and the word-list floor, so its verdict is never below the floor.
+   Fails loudly if the floor is ever removed without a type that
+   subsumes it. *)
+
+let test_monotone_floor_invariant () =
+  let rank = function
+    | Masc_exec.Shell_ir_risk.R0_Read -> 0
+    | R1_Reversible_mutation -> 1
+    | R2_Irreversible -> 2
+    | Destructive_protected -> 3
+  in
+  let corpus =
+    [ ("ls", []); ("cat", [ "f" ]); ("git", [ "commit"; "-m"; "x" ]);
+      ("git", [ "push"; "--force"; "origin"; "main" ]); ("rm", [ "-rf"; "d" ]);
+      ("sudo", [ "apt"; "install" ]); ("gh", [ "api"; "-XDELETE"; "/x" ]);
+      ("gh", [ "repo"; "delete"; "o/r" ]); ("curl", [ "https://x" ]);
+      ("mkdir", [ "-p"; "d" ]); ("npm", [ "install" ]); ("npm", [ "test" ]);
+      ("dd", [ "if=/dev/zero"; "of=/dev/sda" ]); ("mkfs", [ "/dev/sda1" ]) ]
+  in
+  List.iter
+    (fun (b, a) ->
+       let ir = simple_ir b a in
+       let full = (Risk.classify (Risk.undecided ir)).Risk.risk in
+       let floor = Risk.classify_words (b :: a) in
+       Alcotest.(check bool)
+         (Printf.sprintf "%s %s: classify=%s >= floor=%s" b
+            (String.concat " " a)
+            (Risk.string_of_risk_class full)
+            (Risk.string_of_risk_class floor))
+         true
+         (rank full >= rank floor))
+    corpus
+
 (* --- test runner --- *)
 
 let () =
@@ -290,4 +364,6 @@ let () =
   test_classify_repo_hosting_cli_read_only_prefixes_equivalence ();
   test_classify_unknown_read ();
   test_s7_stamp_invariant ();
-  print_endline "test_shell_ir_risk: 16/16 passed"
+  test_typed_escalation_closes_wordlist_gaps ();
+  test_monotone_floor_invariant ();
+  print_endline "test_shell_ir_risk: 18/18 passed"


### PR DESCRIPTION
## What

Make `Shell_ir_risk.classify` read the typed `Shell_ir_typed` GADT (RFC-0160 §S1 completion).

## Why

The 93-constructor `Shell_ir_typed` GADT was a **carrier no decision path read**. `classify` re-flattened the IR back to a word list and string-matched (`"git" :: sub :: _`, `"rm" :: rest`, ...). The only GADT consumers were `Capability_check_typed.of_command` (capability-only, and one behind the default-Off `MASC_EXEC_GATE` shadow gate). So the typed shape and the risk decision were two parallel pipelines over the same input — the exact "병렬 typed shape / decision-by-string" drift RFC-0160 §0 set out to close, still present at the risk layer.

## How

- Add `risk_of_typed : Shell_ir_typed.wrapped -> risk_class` — an **exhaustive** match over the GADT. No `_ ->` catch-all, so adding a constructor to `Shell_ir_typed_types.command` forces a compile error here (CLAUDE.md §"FSM Sparse Match" — compiler-enforced consumer).
- `classify` now takes the **stricter of** the typed opinion and the word-list classifier (`max_risk typed word`). The result is **monotone-safe by construction**: never below the legacy word-list verdict.

## Policy (option B — monotone-safe, escalate dangerous gaps only)

The typed path closes word-list holes the substring matcher missed, without changing risk for commands the word-list already handles:

| command | word-list | typed (this PR) | note |
|---|---|---|---|
| `sudo rm -rf /` | R0 (head token "sudo" → rm arm never fired) | **Destructive_protected** | privilege escalation |
| `su - root` | R0 | **R2** | gap closed |
| `mkfs … /dev/..` | R0 | **R2** | gap closed |
| `git push --force origin main` | Destructive_protected | Destructive_protected | unchanged |
| `git commit` / `mkdir` / `npm install` | R1 | R1 | unchanged |
| `curl POST` / `git pull` / `sed -i` | R0 | R0 | unchanged (deferred to correctness follow-up) |

## Why the word-list is retained (not a workaround)

`Gh` and `Generic` return R0 from `risk_of_typed` because the type cannot see their risk-bearing tokens — `gh api -X DELETE` and the graphql body live in the typed `Gh.rest` bucket, and `Generic` is the env/redirect/`$VAR`/unknown-bin escape. The word-list classifier supplies their risk as a safety floor inside `classify`. This is a **typed-model completeness gap, not a fix-by-fallback**: removing the floor is explicitly gated on enriching the typed model (type the `-X METHOD` + graphql body), tracked as an RFC-0160 follow-up. The floor never downgrades; it only backstops what the type cannot yet express.

WORKAROUND-WAIVED: the retained word-list path is an anti-pattern *removal* in progress (the GADT now drives escalation decisions); the floor is a typed-model-completeness backstop with a named removal gate, not a symptom-suppression patch. No new substring classifier is added — `risk_of_typed` replaces string matching with exhaustive typed dispatch.

## Tests

`lib/exec/test/test_shell_ir_risk.ml`: existing 16 cases preserved (read→R0, write→R1, destructive, gh api DELETE/POST/GET/graphql, git reset --hard→R2, pipeline destructive, S7 phantom invariant ×26); +2 added (typed escalation closes word-list gaps; monotone floor invariant over a 14-command corpus) = **18/18**. `dune build lib/exec` clean.

## CI caveat

Based on `origin/main` `8e3e42d7b`. `main`'s `@check` is currently intermittently broken by a fleet of concurrent SSOT-consolidation PRs (dangling helper refs in `lib/keeper`/`lib/tool_library`/`lib/dashboard` — none in `lib/exec`). If the surface gate builds the full tree, CI may be red for reasons unrelated to this change. Draft until main stabilizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
