### PR TITLE
refactor(cascade): remove Priority_tier strategy and tier/tier-group concept

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -76,8 +76,6 @@ type state = Cascade_catalog_runtime_cache.state =
 type secondary_resolution =
   Cascade_catalog_runtime_named_providers.secondary_resolution = {
   providers : Llm_provider.Provider_config.t list;
-  tiered_providers :
-    Cascade_catalog_runtime_named_providers.tiered_provider list;
   secondary_resolver :
     int ->
     Llm_provider.Provider_config.t ->

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -146,15 +146,13 @@ val resolve_named_providers_strict :
 
 type secondary_resolution = {
   providers : Llm_provider.Provider_config.t list;
-  tiered_providers : Cascade_catalog_runtime_named_providers.tiered_provider list;
   secondary_resolver :
     int -> Llm_provider.Provider_config.t ->
     Llm_provider.Provider_config.t option;
 }
-(** Providers resolved from a named cascade plus their admission tier
-    identities and an index-aware secondary lookup derived from the same
-    ordered entries. The resolver is pure over this snapshot and does
-    not re-read or re-rotate catalog state. *)
+(** Providers resolved from a named cascade plus an index-aware secondary
+    lookup derived from the same ordered entries. The resolver is pure
+    over this snapshot and does not re-read or re-rotate catalog state. *)
 
 val resolve_named_providers_strict_with_secondary_resolver :
   ?sw:Eio.Switch.t ->

--- a/lib/cascade/cascade_catalog_runtime_named_providers.ml
+++ b/lib/cascade/cascade_catalog_runtime_named_providers.ml
@@ -18,16 +18,6 @@ let candidate_key_of_cfg (cfg : Llm_provider.Provider_config.t) =
       cfg.headers,
       cfg.supports_tool_choice_override )
 
-type tiered_provider = {
-  provider_cfg : Llm_provider.Provider_config.t;
-  admission_key : string;
-}
-
-let direct_candidate_providers (profile : profile_snapshot) =
-  List.map
-    (fun (candidate : candidate_runtime) -> candidate.provider_cfg)
-    profile.candidates
-
 let direct_candidates_ordered_by_entries
     (profile : profile_snapshot)
     (ordered_entries : Cascade_config_loader.weighted_entry list) =
@@ -74,68 +64,6 @@ let direct_candidate_providers_ordered_by_entries
     (ordered_entries : Cascade_config_loader.weighted_entry list) =
   direct_candidates_ordered_by_entries profile ordered_entries
   |> List.map (fun (candidate : candidate_runtime) -> candidate.provider_cfg)
-
-let tier_bucket_id (profile : profile_snapshot) tier_index =
-  let tiers = profile.strategy.Cascade_strategy.tiers in
-  if List.length tiers <= 1
-  then profile.name
-  else Printf.sprintf "%s.tier-%d" profile.name tier_index
-
-let admission_key_queues_by_health_key (profile : profile_snapshot) =
-  let tiers = profile.strategy.Cascade_strategy.tiers in
-  let index : (string, string Queue.t) Hashtbl.t = Hashtbl.create 8 in
-  if List.length tiers > 1
-  then
-    List.iteri
-      (fun tier_index health_keys ->
-         let admission_key = tier_bucket_id profile tier_index in
-         List.iter
-           (fun health_key ->
-              let queue =
-                match Hashtbl.find_opt index health_key with
-                | Some queue -> queue
-                | None ->
-                    let queue = Queue.create () in
-                    Hashtbl.add index health_key queue;
-                    queue
-              in
-              Queue.add admission_key queue)
-           health_keys)
-      tiers;
-  index
-
-let admission_key_for_candidate
-    (profile : profile_snapshot)
-    tier_index
-    (candidate : candidate_runtime) =
-  let health_key =
-    Cascade_config_provider_binding.provider_health_key_of_config candidate.provider_cfg
-  in
-  match Hashtbl.find_opt tier_index health_key with
-  | Some queue when not (Queue.is_empty queue) -> Queue.pop queue
-  | _ -> profile.name
-
-let tiered_provider_of_candidate
-    profile
-    tier_index
-    (candidate : candidate_runtime)
-    : tiered_provider =
-  {
-    provider_cfg = candidate.provider_cfg;
-    admission_key = admission_key_for_candidate profile tier_index candidate;
-  }
-
-let tiered_providers_of_ordered_entries ~(profile : profile_snapshot)
-    ~cascade_name:_
-    (ordered_entries : Cascade_config_loader.weighted_entry list) =
-  let tier_index = admission_key_queues_by_health_key profile in
-  direct_candidates_ordered_by_entries profile ordered_entries
-  |> List.map (tiered_provider_of_candidate profile tier_index)
-
-let provider_configs_of_ordered_entries ~(profile : profile_snapshot)
-    ~cascade_name:_
-    (ordered_entries : Cascade_config_loader.weighted_entry list) =
-  direct_candidate_providers_ordered_by_entries profile ordered_entries
 
 let candidates_with_overrides_of_ordered_entries ~(profile : profile_snapshot)
     ~cascade_name:_
@@ -280,7 +208,6 @@ let resolve_named_providers_strict ?sw ?net ?clock ?provider_filter
 
 type secondary_resolution = {
   providers : Llm_provider.Provider_config.t list;
-  tiered_providers : tiered_provider list;
   secondary_resolver :
     int ->
     Llm_provider.Provider_config.t ->
@@ -319,18 +246,10 @@ let resolve_named_providers_strict_with_secondary_resolver ?sw ?net ?clock
           ~cascade:normalized profile.weighted_entries
       in
       let parsed_pairs =
-        let direct_pairs =
-          tiered_providers_of_ordered_entries ~profile
-            ~cascade_name:normalized ordered_entries
-          |> List.map (fun tiered -> (tiered, None))
-        in
-        direct_pairs
+        direct_candidate_providers_ordered_by_entries profile ordered_entries
+        |> List.map (fun cfg -> (cfg, None))
       in
-      let primaries =
-        List.map
-          (fun (tiered, _) -> tiered.provider_cfg)
-          parsed_pairs
-      in
+      let primaries = List.map fst parsed_pairs in
       (match
          Cascade_config.apply_provider_filter_strict ~provider_filter
            ~label:normalized primaries
@@ -347,7 +266,7 @@ let resolve_named_providers_strict_with_secondary_resolver ?sw ?net ?clock
          let filtered_pairs =
            parsed_pairs
            |> List.filter (fun (primary, _) ->
-                  provider_filter_allows primary.provider_cfg)
+                  provider_filter_allows primary)
            |> List.map (fun (primary, secondary) ->
                   let secondary =
                     match secondary with
@@ -356,12 +275,7 @@ let resolve_named_providers_strict_with_secondary_resolver ?sw ?net ?clock
                   in
                   (primary, secondary))
          in
-         let tiered_providers = List.map fst filtered_pairs in
-         let providers =
-           List.map
-             (fun tiered -> tiered.provider_cfg)
-             tiered_providers
-         in
+         let providers = List.map fst filtered_pairs in
          if providers = [] then (
            Cascade_metrics.on_resolve_failure ~cascade:normalized
              ~reason:"no_callable_providers";
@@ -378,12 +292,12 @@ let resolve_named_providers_strict_with_secondary_resolver ?sw ?net ?clock
              else
                let indexed_primary, secondary = slots.(provider_index) in
                if
-                 candidate_key_of_cfg indexed_primary.provider_cfg
+                 candidate_key_of_cfg indexed_primary
                  = candidate_key_of_cfg primary
                then secondary
                else None
            in
-           Ok { providers; tiered_providers; secondary_resolver })
+           Ok { providers; secondary_resolver })
 
 (* Deprecated compatibility hook for RFC-0027 PR-9b dual-track resolution.
    Declarative cascade execution now carries typed [Provider_config]

--- a/lib/cascade/cascade_catalog_runtime_named_providers.mli
+++ b/lib/cascade/cascade_catalog_runtime_named_providers.mli
@@ -24,14 +24,8 @@ val resolve_named_providers_strict :
   unit ->
   (Llm_provider.Provider_config.t list, string) result
 
-type tiered_provider = {
-  provider_cfg : Llm_provider.Provider_config.t;
-  admission_key : string;
-}
-
 type secondary_resolution = {
   providers : Llm_provider.Provider_config.t list;
-  tiered_providers : tiered_provider list;
   secondary_resolver :
     int ->
     Llm_provider.Provider_config.t ->

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -444,7 +444,6 @@ type strategy_config =
   ; backoff_cap_ms : int option
   ; ollama_max_concurrent : int option
   ; cli_max_concurrent : int option
-  ; tiers : string list list option
   ; sticky_ttl_ms : int option
   ; (* ── Retired scoring parameter overrides (diagnostics only) ── *)
     latency_baseline_ms : float option
@@ -471,32 +470,6 @@ type strategy_config =
       When [None], falls back to env var, then default 4. *)
   }
 
-(* Read a [string list list] from a JSON [list of list of string].
-   Returns [None] when the key is missing or any element has the
-   wrong shape; tier configuration must be all-or-nothing to avoid
-   silent misroutes. *)
-let read_tiers_field json key =
-  let open Yojson.Safe.Util in
-  match json |> member key with
-  | `Null -> None
-  | `List outer ->
-    let parse_tier = function
-      | `List inner ->
-        let strs =
-          List.filter_map
-            (function
-              | `String s when String.trim s <> "" -> Some (String.trim s)
-              | _ -> None)
-            inner
-        in
-        if List.length strs = List.length inner && strs <> [] then Some strs else None
-      | _ -> None
-    in
-    let tiers = List.filter_map parse_tier outer in
-    if List.length tiers = List.length outer && tiers <> [] then Some tiers else None
-  | _ -> None
-;;
-
 let empty_strategy_config =
   { kind = None
   ; max_cycles = None
@@ -504,7 +477,6 @@ let empty_strategy_config =
   ; backoff_cap_ms = None
   ; ollama_max_concurrent = None
   ; cli_max_concurrent = None
-  ; tiers = None
   ; sticky_ttl_ms = None
   ; latency_baseline_ms = None
   ; rate_limit_recency_window_s = None
@@ -532,7 +504,6 @@ let resolve_strategy_config_impl ~emit_telemetry ~config_path ~name =
     ; backoff_cap_ms = read_int_field json (name ^ "_backoff_cap_ms")
     ; ollama_max_concurrent = read_int_field json (name ^ "_ollama_max_concurrent")
     ; cli_max_concurrent = read_int_field json (name ^ "_cli_max_concurrent")
-    ; tiers = read_tiers_field json (name ^ "_tiers")
     ; sticky_ttl_ms = read_int_field json (name ^ "_sticky_ttl_ms")
     ; latency_baseline_ms = read_float_field json (name ^ "_latency_baseline_ms")
     ; rate_limit_recency_window_s =

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -154,14 +154,6 @@ type strategy_config = {
       limited to one in-flight subprocess.
       @since 0.9.8 *)
 
-  tiers : string list list option;
-  (** ["{name}_tiers"]. Used by the [priority_tier] strategy.  Each
-      inner array is a tier of provider keys (matched against the
-      [model] field in [{name}_models]); outer order is tier order
-      (tier 0 = highest priority).  Example JSON:
-      [\[\["ollama:qwen3-coder:30b"\], \["cli_tool_b:provider_f-3-flash-preview"\]\]].
-      @since 0.9.7 *)
-
   sticky_ttl_ms : int option;
   (** ["{name}_sticky_ttl_ms"]. Retired legacy field.  Parsed only so
       diagnostics can reject stale runtime JSON explicitly. *)

--- a/lib/cascade/cascade_config_strategy_resolve.ml
+++ b/lib/cascade/cascade_config_strategy_resolve.ml
@@ -1,4 +1,4 @@
-(** Cascade strategy + priority-tier + concurrency resolution.
+(** Cascade strategy + concurrency resolution.
 
     Extracted from [cascade_config.ml]. *)
 
@@ -80,7 +80,7 @@ let resolve_strategy ?config_path ~name () =
     ignore cfg.server_error_recency_window_s;
     ignore cfg.server_error_decay_base;
     ignore cfg.server_error_skip_after;
-    { Cascade_strategy.kind = parsed_kind; cycle; tiers = [] }
+    { Cascade_strategy.kind = parsed_kind; cycle }
 
 let resolve_ollama_max_concurrent ?config_path ~name () =
   match config_path with

--- a/lib/cascade/cascade_metrics.ml
+++ b/lib/cascade/cascade_metrics.ml
@@ -376,24 +376,6 @@ let on_provider_cooldown ~provider ~reason =
     ~labels:[ ("provider", provider); ("reason", reason) ]
     ()
 
-(* [Cascade_strategy.Priority_tier] has a "starvation guard"
-   fail-OPEN: when every candidate reports capacity=0 the function
-   falls through with the pre-filter candidate list so at least one
-   call is attempted (and the upstream real error — rate limit,
-   auth — surfaces) instead of silently exhausting the cascade.
-
-   A non-zero rate signals capacity probes have been judging the
-   cascade exhausted; pair with iter-8 probe metrics and iter-20
-   provider_cooldown to attribute the cause.
-
-   Cardinality: cascades (~10) x strategies (1) = ~10 series. *)
-let metric_strategy_starvation_guard = "masc_cascade_strategy_starvation_guard_total"
-
-let on_strategy_starvation_guard ~cascade ~strategy =
-  Prometheus.inc_counter metric_strategy_starvation_guard
-    ~labels:[ ("cascade", cascade); ("strategy", strategy) ]
-    ()
-
 let metric_capacity_probe = "masc_cascade_capacity_probe_result_total"
 
 let on_capacity_probe ~url ~source =

--- a/lib/cascade/cascade_metrics.mli
+++ b/lib/cascade/cascade_metrics.mli
@@ -124,11 +124,6 @@ val on_provider_cooldown : provider:string -> reason:string -> unit
     histogram, which captures duration distribution but not entry
     rate or reason. *)
 
-val on_strategy_starvation_guard : cascade:string -> strategy:string -> unit
-(** Tick the strategy-starvation-guard counter when
-    [Cascade_strategy.order_candidates] falls through with the
-    pre-capacity-filter candidate list because every candidate
-    reported capacity=0.  [strategy] must be [priority_tier]. *)
 
 val on_capacity_probe : url:string -> source:string -> unit
 (** Tick the capacity-probe result counter when a probe (ollama or

--- a/lib/cascade/cascade_metrics_registry.ml
+++ b/lib/cascade/cascade_metrics_registry.ml
@@ -62,8 +62,6 @@ let all_cascade_counters : (string * string) list =
        | hard_quota | terminal_failure). Counter complement to the \
        existing [keeper_provider_block_duration_sec] histogram \
        (duration distribution, this is entry rate by cause)." )
-  ; ( "masc_cascade_strategy_starvation_guard_total"
-    , "masc_cascade_strategy_starvation_guard_total" )
   ; ( "masc_cascade_capacity_probe_result_total"
     , "Total successful capacity probe results by source. Labels: url, \
        source (discovered | fallback). Provides visibility into whether \

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -1,6 +1,5 @@
 type t =
   { provider_cfg : Llm_provider.Provider_config.t
-  ; admission_key : string
   ; health_key : string
   ; model_health_key : string
   ; capacity_key : string
@@ -133,17 +132,10 @@ let capacity_key_of_config (cfg : Llm_provider.Provider_config.t) =
 let http_probe_url_of_config (cfg : Llm_provider.Provider_config.t) =
   Cascade_http_probe_url.of_provider_config cfg
 
-let default_admission_key_of_config provider_cfg =
-  provider_health_key_of_config provider_cfg
-
-let of_provider_config ?admission_key provider_cfg =
+let of_provider_config provider_cfg =
   let health_key = provider_health_key_of_config provider_cfg in
   let model_health_key = provider_model_health_key_of_config provider_cfg in
-  let admission_key =
-    Option.value admission_key ~default:(default_admission_key_of_config provider_cfg)
-  in
   { provider_cfg
-  ; admission_key
   ; health_key
   ; model_health_key
   ; capacity_key = capacity_key_of_config provider_cfg
@@ -283,7 +275,6 @@ let threshold_multipliers_of_runtime_id runtime_id =
   1.0, 1.0
 
 let health_key candidate = candidate.health_key
-let admission_key candidate = candidate.admission_key
 let model_health_key candidate = candidate.model_health_key
 let provider_label candidate =
   provider_label_of_model_label

--- a/lib/cascade/cascade_runtime_candidate.mli
+++ b/lib/cascade/cascade_runtime_candidate.mli
@@ -12,7 +12,7 @@ type context_window_hint =
   ; is_local_model : bool
   }
 
-val of_provider_config : ?admission_key:string -> Llm_provider.Provider_config.t -> t
+val of_provider_config : Llm_provider.Provider_config.t -> t
 val of_provider_configs : Llm_provider.Provider_config.t list -> t list
 
 val runtime_url_of_label : string -> string option
@@ -44,7 +44,6 @@ val context_window_hint_of_labels : string list -> context_window_hint
 val threshold_multipliers_of_runtime_id : string -> float * float
 
 val health_key : t -> string
-val admission_key : t -> string
 val model_health_key : t -> string
 val health_keys : t -> string list
 val provider_label : t -> string

--- a/lib/cascade/cascade_strategy.ml
+++ b/lib/cascade/cascade_strategy.ml
@@ -9,9 +9,6 @@ type signal_ctx = {
   cascade_name : Cascade_name.t;
 }
 
-let signal_cascade_name ctx =
-  Cascade_name.to_string ctx.cascade_name
-
 type cycle_policy = {
   max_cycles : int;
   backoff_base_ms : int;
@@ -37,29 +34,25 @@ let backoff_ms policy ~cycle =
 
 type kind =
   | Failover [@tla.symbol "failover"]
-  | Priority_tier [@tla.symbol "priority_tier"]
 [@@deriving tla]
 
 let kind_to_string = function
   | Failover -> "failover"
-  | Priority_tier -> "priority_tier"
 
-(* Issue #8603: SSOT helpers — replace hard-coded list in [parse_kind]'s
-   Error arm so adding an 8th constructor updates the operator-visible
-   error message automatically. Same Variant SSOT shape as #8486 /
-   #8467 / #8592 / #8601. *)
+(* Issue #8603: SSOT helpers — the [parse_kind] Error arm lists
+   [valid_kind_strings] (derived from [all_kinds]) so adding a second
+   constructor updates the operator-visible error message automatically.
+   Same Variant SSOT shape as #8486 / #8467 / #8592 / #8601. *)
 let all_kinds = [
   Failover;
-  Priority_tier;
 ]
 
 let valid_kind_strings = List.map kind_to_string all_kinds
 
-let config_kind_strings = [ "failover"; "priority_tier" ]
+let config_kind_strings = [ "failover" ]
 
 let parse_kind = function
   | "failover" -> Ok Failover
-  | "priority_tier" -> Ok Priority_tier
   | other ->
     Error (Printf.sprintf
              "unknown cascade strategy %S (expected one of: %s)"
@@ -77,13 +70,11 @@ let parse_config_kind raw =
 type t = {
   kind : kind;
   cycle : cycle_policy;
-  tiers : string list list;
 }
 
 let failover = {
   kind = Failover;
   cycle = default_cycle_policy;
-  tiers = [];
 }
 
 type 'a adapter = {
@@ -92,14 +83,6 @@ type 'a adapter = {
 }
 
 (* ── Filters ────────────────────────────────────────────────────── *)
-
-let has_capacity ctx ~url =
-  match ctx.capacity url with
-  | None -> true                          (* unknown → fail-open *)
-  | Some info -> info.Cascade_throttle.process_available > 0
-
-let filter_capacity adapter ctx cands =
-  List.filter (fun c -> has_capacity ctx ~url:(adapter.capacity_key c)) cands
 
 let key_is_full ctx key =
   match ctx.capacity key with
@@ -126,82 +109,13 @@ let filter_cooldown adapter ctx cands =
               ~provider_key:(adapter.health_key c)))
     cands
 
-(* ── Priority tier ──────────────────────────────────────────────── *)
-
-(* Pick the tier for [cycle], clamped to the last tier when [cycle]
-   exceeds [length tiers - 1].  Returns [[]] when [tiers] is empty
-   (no usable configuration → starvation guard handled at caller). *)
-let tier_for_cycle tiers ~cycle =
-  match tiers with
-  | [] -> []
-  | _ ->
-    let n = List.length tiers in
-    let idx = if cycle >= n then n - 1 else max 0 cycle in
-    match List.nth_opt tiers idx with
-    | Some tier -> tier
-    | None -> []
-
-let priority_tier_order adapter ctx ~tiers ~cycle cands =
-  let allowed = tier_for_cycle tiers ~cycle in
-  match allowed with
-  | [] -> []
-  | _ ->
-    (* Materialise [allowed] as a Hashtbl once so the per-candidate
-       membership check is O(1); prior shape did [List.mem health_key
-       allowed] per candidate, i.e. O(C x A) per ordering call. *)
-    let allowed_set = Hashtbl.create (List.length allowed) in
-    List.iter (fun name -> Hashtbl.replace allowed_set name ()) allowed;
-    let in_tier c = Hashtbl.mem allowed_set (adapter.health_key c) in
-    let tier_cands = List.filter in_tier cands in
-    (* Starvation guard: if every tier candidate reports capacity=0, fall
-       through with the unfiltered tier list so at least one call is
-       attempted and the real upstream error (rate limit, auth) surfaces
-       instead of silently exhausting the cascade. *)
-    let with_capacity = filter_capacity adapter ctx tier_cands in
-    if with_capacity = [] then (
-      Cascade_metrics.on_strategy_starvation_guard
-        ~cascade:(signal_cascade_name ctx)
-        ~strategy:"priority_tier";
-      dedupe_full_capacity_keys adapter ctx tier_cands)
-    else with_capacity
-
 (* ── Public ordering ────────────────────────────────────────────── *)
 
-let order_candidates t ~adapter ~ctx ~cycle cands =
+let order_candidates t ~adapter ~ctx ~cycle:_ cands =
   match t.kind with
   | Failover ->
     filter_cooldown adapter ctx cands
     |> dedupe_full_capacity_keys adapter ctx
-  | Priority_tier ->
-    priority_tier_order adapter ctx ~tiers:t.tiers ~cycle cands
-
-(* p50 latency band thresholds (milliseconds).  Each band maps to a
-   latency_score multiplier: <=instant → 1.0, <=fast → 0.8,
-   <=moderate → 0.6, <=slow → 0.4, <=degraded → 0.2, else → 0.1.
-   Overlaps with p95 bands in {!Cascade_health_tracker} but p50
-   tolerances are tighter (median vs tail). *)
-let p50_latency_instant_ms = 1000.0
-let p50_latency_fast_ms = 3000.0
-let p50_latency_moderate_ms = 5000.0
-let p50_latency_slow_ms = 15000.0
-let p50_latency_degraded_ms = 30000.0
-
-let latency_score_of_p50_ms = function
-  | ms when (not (Float.is_finite ms)) || ms <= 0.0 -> 1.0
-  | ms when ms <= p50_latency_instant_ms -> 1.0
-  | ms when ms <= p50_latency_fast_ms -> 0.8
-  | ms when ms <= p50_latency_moderate_ms -> 0.6
-  | ms when ms <= p50_latency_slow_ms -> 0.4
-  | ms when ms <= p50_latency_degraded_ms -> 0.2
-  | _ -> 0.1
-
-let latency_score_for_provider health ~provider_key =
-  match Cascade_health_tracker.provider_info health ~provider_key with
-  | None -> 1.0
-  | Some info ->
-    (match info.Cascade_health_tracker.p50_latency_ms with
-     | None -> 1.0
-     | Some p50 -> latency_score_of_p50_ms p50)
 
 (* ── Stateful hooks ─────────────────────────────────────────────── *)
 

--- a/lib/cascade/cascade_strategy.mli
+++ b/lib/cascade/cascade_strategy.mli
@@ -8,10 +8,11 @@
     after a backoff sleep); the strategy can return a different ordering
     because health and capacity signals may have changed.
 
-    The shipped runtime supports two operator-visible strategies:
-    [Failover] and [Priority_tier].  Older experimental strategies were
-    retired from the public ADT so they cannot be selected accidentally
-    by config, tests, or internal callers.
+    The shipped runtime supports a single operator-visible strategy:
+    [Failover].  Older experimental strategies (priority-tier and the
+    pre-RFC-0058 tier-group routing) were retired from the public ADT so
+    they cannot be selected accidentally by config, tests, or internal
+    callers.
 
     @since 0.9.6 *)
 
@@ -40,8 +41,9 @@ type signal_ctx = {
       current shipped strategies do not read it. *)
 
   cascade_name : Cascade_name.t;
-  (** Cascade identifier (the [<name>] in [<name>_models]).  Used for
-      priority-tier starvation telemetry. *)
+  (** Cascade identifier (the [<name>] in [<name>_models]).  Kept in the
+      signal context for call-site stability; current shipped strategies
+      do not read it. *)
 }
 
 (** {1 Cycle policy — orthogonal to strategy kind} *)
@@ -74,16 +76,8 @@ val backoff_ms : cycle_policy -> cycle:int -> int
 type kind =
   | Failover
     (** S1 — input order preserved, always-available.  Equivalent to
-        the pre-strategy behaviour (linear failover). *)
-
-  | Priority_tier
-    (** S2 — providers grouped into ordered tiers via [tiers] in {!t}.
-        Cycle [n] only considers tier [n] (clamped to last tier).
-        Within a tier, capacity-aware filtering is applied; the tier
-        is "active" iff at least one of its providers survives the
-        filter, otherwise the cycle yields the empty list and the
-        caller advances to the next cycle (i.e. next tier).
-        @since 0.9.7 *)
+        the pre-strategy behaviour (linear failover).  The sole shipped
+        strategy after priority-tier removal. *)
 [@@deriving tla]
 (** [@@deriving tla] generates [to_tla_symbol] (kind -> string),
     [all_symbols] (string list), and [all_states] (kind list) so
@@ -124,17 +118,10 @@ val parse_config_kind : string -> (kind, string) result
 type t = {
   kind : kind;
   cycle : cycle_policy;
-
-  tiers : string list list;
-  (** Used only by [Priority_tier].  Each inner list is the set of
-      provider keys (matched against [adapter.health_key]) that form
-      one tier; outer order is tier order (tier 0 = highest priority).
-      Empty list when the strategy is not [Priority_tier].
-      @since 0.9.7 *)
 }
 
 val failover : t
-(** [{ kind = Failover; cycle = default_cycle_policy; tiers = [] }].
+(** [{ kind = Failover; cycle = default_cycle_policy }].
     What callers receive when no per-cascade strategy is configured. *)
 
 (** {1 Candidate adapter}
@@ -162,8 +149,7 @@ val order_candidates :
   'a list
 (** [order_candidates t ~adapter ~ctx ~cycle candidates] is the ordered
     subset of [candidates] to attempt in [cycle].  Returns the empty
-    list when no candidate is usable right now (e.g. all capacity domains
-    report [process_available = 0] for S2), in which case the caller
+    list when no candidate is usable right now, in which case the caller
     should either advance to the next cycle with a backoff or report
     [Cascade_exhausted].
 
@@ -172,18 +158,10 @@ val order_candidates :
     concrete capacity-backpressure error while avoiding repeated attempts
     against the same saturated key.
 
-    This function is pure and must not perform IO.  [cycle] is
-    0-indexed (first cycle = 0). *)
-
-val latency_score_for_provider :
-  Cascade_health_tracker.t -> provider_key:string -> float
-(** [latency_score_for_provider health ~provider_key] maps a provider's
-    recent p50 latency hint to a routing score in [0.0, 1.0].
-
-    Unknown providers and providers without latency samples score [1.0],
-    preserving optimistic fail-open behaviour. Slow persisted latency
-    hints score lower so trust snapshots can restore routing penalties
-    after process restart. *)
+    This function is pure and must not perform IO.  [cycle] is accepted
+    for call-site stability but no longer selects a tier (failover is
+    cycle-independent; health and capacity signals are re-read each
+    cycle). *)
 
 (** {1 Completion hook} *)
 

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -123,16 +123,15 @@ let run_named
   in
   (match
      ( named_resolution.configured_labels_result,
-       named_resolution.candidate_cfgs_result,
-       named_resolution.tiered_providers_result )
+       named_resolution.candidate_cfgs_result )
    with
-   | Error detail, _, _ | _, Error detail, _ | _, _, Error detail ->
+   | Error detail, _ | _, Error detail ->
        Log.Misc.error "cascade %s: %s" cascade_name detail;
        Error (cascade_catalog_error_to_sdk_error detail)
-   | Ok configured_labels, Ok candidate_cfgs, Ok tiered_providers ->
+   | Ok configured_labels, Ok candidate_cfgs ->
   let original_candidate_cfgs = candidate_cfgs in
   let original_candidates =
-    runtime_candidates_of_providers tiered_providers original_candidate_cfgs
+    runtime_candidates_of_providers original_candidate_cfgs
   in
   let required_capability_profile =
     Keeper_cascade_profile.required_capability_profile_of_cascade_name cascade_name
@@ -153,7 +152,7 @@ let run_named
   let original_candidate_count = List.length original_candidate_cfgs in
   let tool_filtered_candidate_count = List.length tool_filtered_candidate_cfgs in
   let tool_filtered_candidates =
-    runtime_candidates_of_providers tiered_providers tool_filtered_candidate_cfgs
+    runtime_candidates_of_providers tool_filtered_candidate_cfgs
   in
   let required_lane_filtered_candidates, required_lane_provider_rejections =
     match runtime_manifest_required_tool_names with

--- a/lib/keeper/keeper_turn_driver_admission.ml
+++ b/lib/keeper/keeper_turn_driver_admission.ml
@@ -22,30 +22,8 @@ let provider_config_identity_key (cfg : Llm_provider.Provider_config.t) =
       cfg.headers,
       cfg.supports_tool_choice_override )
 
-let runtime_candidates_of_providers tiered_providers provider_cfgs =
-  let tier_index = Hashtbl.create (List.length tiered_providers) in
-  List.iter
-    (fun (tiered : Cascade_catalog_runtime_named_providers.tiered_provider) ->
-       let key = provider_config_identity_key tiered.provider_cfg in
-       let queue =
-         match Hashtbl.find_opt tier_index key with
-         | Some queue -> queue
-         | None ->
-           let queue = Queue.create () in
-           Hashtbl.add tier_index key queue;
-           queue
-       in
-       Queue.add tiered.admission_key queue)
-    tiered_providers;
-  List.map
-    (fun provider_cfg ->
-       let admission_key =
-         match Hashtbl.find_opt tier_index (provider_config_identity_key provider_cfg) with
-         | Some queue when not (Queue.is_empty queue) -> Some (Queue.pop queue)
-         | _ -> None
-       in
-        Cascade_runtime_candidate.of_provider_config ?admission_key provider_cfg)
-    provider_cfgs
+let runtime_candidates_of_providers provider_cfgs =
+  Cascade_runtime_candidate.of_provider_configs provider_cfgs
 
 (* ================================================================ *)
 (* Facade-only: run_named, run_model_by_label, and MASC tool bridges  *)

--- a/lib/keeper/keeper_turn_driver_admission.mli
+++ b/lib/keeper/keeper_turn_driver_admission.mli
@@ -7,6 +7,5 @@ val release_client_capacity_quietly : (unit -> unit) option -> unit
 val provider_config_identity_key : Llm_provider.Provider_config.t -> int
 
 val runtime_candidates_of_providers :
-  Cascade_catalog_runtime_named_providers.tiered_provider list ->
   Llm_provider.Provider_config.t list ->
   Cascade_runtime_candidate.t list

--- a/lib/keeper/keeper_turn_driver_named_resolution.ml
+++ b/lib/keeper/keeper_turn_driver_named_resolution.ml
@@ -8,8 +8,6 @@ type secondary_resolver =
 type t = {
   configured_labels_result : (string list, string) result;
   candidate_cfgs_result : (Llm_provider.Provider_config.t list, string) result;
-  tiered_providers_result :
-    (Cascade_catalog_runtime_named_providers.tiered_provider list, string) result;
   secondary_resolver : secondary_resolver option;
 }
 
@@ -24,11 +22,6 @@ let resolve ~sw ~net ?provider_filter ~cascade_name ~runtime_cascade_name () =
     | Ok resolution -> Ok resolution.providers
     | Error detail -> Error detail
   in
-  let tiered_providers_result =
-    match named_resolution with
-    | Ok resolution -> Ok resolution.tiered_providers
-    | Error detail -> Error detail
-  in
   let secondary_resolver =
     match named_resolution with
     | Ok resolution -> Some resolution.secondary_resolver
@@ -38,6 +31,5 @@ let resolve ~sw ~net ?provider_filter ~cascade_name ~runtime_cascade_name () =
     configured_labels_result =
       Cascade_runtime.models_of_cascade_name_result runtime_cascade_name;
     candidate_cfgs_result;
-    tiered_providers_result;
     secondary_resolver;
   }

--- a/lib/keeper/keeper_turn_driver_named_resolution.mli
+++ b/lib/keeper/keeper_turn_driver_named_resolution.mli
@@ -8,8 +8,6 @@ type secondary_resolver =
 type t = {
   configured_labels_result : (string list, string) result;
   candidate_cfgs_result : (Llm_provider.Provider_config.t list, string) result;
-  tiered_providers_result :
-    (Cascade_catalog_runtime_named_providers.tiered_provider list, string) result;
   secondary_resolver : secondary_resolver option;
 }
 

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-27T03:36:07Z (HEAD: 6ce961960)
+Generated: 2026-05-29T02:39:31Z (HEAD: 7d5f1574f)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -54,7 +54,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | Cancellation.tla | Cancellation | manual | 2 | 1 | clean={inv:TypeOK, inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} buggy={inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} | bbed415483ac |
 | CascadeKeeperRecovery.tla | CascadeKeeperRecovery | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 370581910533 |
 | CascadeResolver.tla | CascadeResolver | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:NeverRouteToDown} | e0c5a7d1d999 |
-| CascadeStrategy.tla | CascadeStrategy | manual | 2 | 1 | clean={inv:Safety} buggy={inv:BoundedCycle} | 6227c3d02bc3 |
+| CascadeStrategy.tla | CascadeStrategy | manual | 2 | 1 | clean={inv:Safety} buggy={inv:BoundedCycle} | 1c5dfe537049 |
 | KeeperContinueGate.tla | KeeperContinueGate | manual | 2 | 1 | clean={inv:Safety, prop:PendingEventuallyResolves} buggy={inv:ApprovedResolutionClearsFailure} | 7f71fad0d4cb |
 | KeeperContractViolated.tla | KeeperContractViolated | manual | 2 | 1 | clean={inv:Safety} buggy={inv:Safety} | 65324331c483 |
 | KeeperEmptyToolUniverse.tla | KeeperEmptyToolUniverse | manual | 2 | 1 | clean={inv:Safety} buggy={inv:Safety} | 588dbb775130 |

--- a/specs/boundary/CascadeStrategy.tla
+++ b/specs/boundary/CascadeStrategy.tla
@@ -49,7 +49,7 @@ OutcomeSet == {"in_progress", "accepted", "exhausted"}
 \* test. The model below abstracts over candidate ordering, but the
 \* exported strategy kind set still must not drift from
 \* lib/cascade/cascade_strategy.ml.
-StrategyKindSet == {"failover", "priority_tier"}
+StrategyKindSet == {"failover"}
 NoneProvider == "_none_"
 ASSUME NoneProvider \notin Candidates
 

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -106,6 +106,10 @@ let with_temp_cascade_toml body f =
     f
 
 let test_cascade_output_cap_not_context_window () =
+  (* RFC-0058: ceilings resolve a concrete binding/alias key (route/profile
+     ceiling resolution was removed with the tier concept). The narrowest
+     member of the former [tier.primary] is the [remote.long] binding. *)
+  let cascade_name = Cascade_name.of_string_exn "remote.long" in
   with_temp_cascade_toml
     {|
 [providers.remote]
@@ -123,11 +127,11 @@ max-output-tokens = 8192
 [remote.long]
 max-concurrent = 1
 
-[tier.primary]
-members = ["remote.long"]
+[profiles.primary]
+provider_filter = "remote"
 
 [routes.keeper_turn]
-target = "tier.primary"
+target = "remote.long"
 |}
     (fun () ->
       let ceiling = CR.max_output_tokens_ceiling_of_cascade_name cascade_name in
@@ -137,6 +141,9 @@ target = "tier.primary"
       |> check_ok "above output ceiling clamped" 8192)
 
 let test_public_cap_helper_clamps_caller_override_to_cascade_ceiling () =
+  (* RFC-0058: ceiling resolves the concrete [remote.narrow] binding key
+     (former sole member of [tier.primary]). *)
+  let cascade_name = Cascade_name.of_string_exn "remote.narrow" in
   with_temp_cascade_toml
     {|
 [providers.remote]
@@ -154,11 +161,11 @@ max-output-tokens = 8192
 [remote.narrow]
 max-concurrent = 1
 
-[tier.primary]
-members = ["remote.narrow"]
+[profiles.primary]
+provider_filter = "remote"
 
 [routes.keeper_turn]
-target = "tier.primary"
+target = "remote.narrow"
 |}
     (fun () ->
       let ceiling = CR.max_output_tokens_ceiling_of_cascade_name cascade_name in
@@ -175,6 +182,12 @@ target = "tier.primary"
       |> check_ok "capped caller override accepted" 8192)
 
 let test_resolve_max_tokens_caps_automatic_value_to_cascade_ceiling () =
+  (* RFC-0058: ceilings resolve a concrete member key. The narrowest former
+     [tier.strict_tool_candidates] member is the provider_c alias, whose model
+     capability (16384) caps the alias [max-output] (64000). *)
+  let cascade_name =
+    Cascade_name.of_string_exn "cli_tool_c.provider_c-cli-coding.tool_candidate"
+  in
   with_temp_cascade_toml
     {|
 [providers.cli_tool_d]
@@ -217,16 +230,11 @@ temperature = 0.2
 max-output = 64000
 temperature = 0.2
 
-[tier.strict_tool_candidates]
-members = ["cli_tool_d.agent_llm_a-auto.tool_candidate", "cli_tool_c.provider_c-cli-coding.tool_candidate"]
-strategy = "failover"
-
-[tier-group.strict_tool_candidates]
-tiers = ["strict_tool_candidates"]
-strategy = "failover"
+[profiles.strict_tool_candidates]
+provider_filter = "cli_tool_c"
 
 [routes.keeper_turn]
-target = "tier-group.strict_tool_candidates"
+target = "cli_tool_c.provider_c-cli-coding.tool_candidate"
 |}
     (fun () ->
       let ceiling = CR.max_output_tokens_ceiling_of_cascade_name cascade_name in
@@ -282,6 +290,12 @@ let test_auto_max_tokens_clamp_warning_dedupes_by_tuple () =
        ~ceiling:8192)
 
 let test_resolve_provider_derived_max_tokens_matches_failover_ceiling () =
+  (* RFC-0058: ceilings resolve a concrete member key. The narrowest member
+     of the former [tier-group.strict_tool_candidates] (spanning two tiers) is
+     the ollama recovery alias, whose model capability is 8192. *)
+  let cascade_name =
+    Cascade_name.of_string_exn "ollama.local-recovery.recovery"
+  in
   with_temp_cascade_toml
     {|
 [providers.cli_tool_d]
@@ -343,20 +357,14 @@ temperature = 0.2
 max-output = 8192
 temperature = 0.2
 
-[tier.strict_tool_candidates]
-members = ["cli_tool_d.agent_llm_a-auto.tool_candidate", "cli_tool_c.provider_c-cli-coding.tool_candidate"]
-strategy = "failover"
+[profiles.strict_tool_candidates]
+provider_filter = "cli_tool_c"
 
-[tier.recovery]
-members = ["ollama.local-recovery.recovery"]
-strategy = "failover"
-
-[tier-group.strict_tool_candidates]
-tiers = ["strict_tool_candidates", "recovery"]
-strategy = "failover"
+[profiles.recovery]
+provider_filter = "ollama"
 
 [routes.keeper_turn]
-target = "tier-group.strict_tool_candidates"
+target = "ollama.local-recovery.recovery"
 |}
     (fun () ->
       let ceiling = CR.max_output_tokens_ceiling_of_cascade_name cascade_name in
@@ -374,7 +382,7 @@ target = "tier-group.strict_tool_candidates"
 let test_resolve_tier_group_max_tokens_uses_model_capability_ceiling () =
   let cascade_name =
     Cascade_name.of_string_exn
-      "tier-group.strict_tool_candidates"
+      "runpod_mtp.qwen36-mtp.keeper"
   in
   with_temp_cascade_toml
     {|
@@ -417,16 +425,11 @@ is-default = true
 max-output = 16384
 temperature = 0.3
 
-[tier.strict_tool_candidates]
-members = ["runpod_mtp.qwen36-mtp.keeper", "provider_k-coding.provider_k-turbo.keeper"]
-strategy = "failover"
-
-[tier-group.strict_tool_candidates]
-tiers = ["strict_tool_candidates"]
-strategy = "failover"
+[profiles.strict_tool_candidates]
+provider_filter = "runpod_mtp"
 
 [routes.keeper_turn]
-target = "tier-group.strict_tool_candidates"
+target = "runpod_mtp.qwen36-mtp.keeper"
 |}
     (fun () ->
       let ceiling = CR.max_output_tokens_ceiling_of_cascade_name cascade_name in

--- a/test/test_cascade_catalog_runtime_yojson.ml
+++ b/test/test_cascade_catalog_runtime_yojson.ml
@@ -169,16 +169,11 @@ tools-support = true
 [ollama.local-default]
 max-concurrent = 1
 
-[tier.local]
-members = ["ollama.local-default"]
-strategy = "failover"
-
-[tier-group.provider_k-coding-with-spark]
-tiers = ["local"]
-strategy = "failover"
+[profiles.provider_k-coding-with-spark]
+provider_filter = "ollama"
 
 [routes.keeper_turn]
-target = "tier-group.provider_k-coding-with-spark"
+target = "ollama.local-default"
 |}
 
 let test_local_probe_without_eio_is_skipped_not_error () =
@@ -193,7 +188,7 @@ let test_local_probe_without_eio_is_skipped_not_error () =
     let profile =
       List.find
         (fun (profile : C.profile_build) ->
-          String.equal profile.name "tier-group.provider_k-coding-with-spark")
+          String.equal profile.name "provider_k-coding-with-spark")
         snapshot.profiles
     in
     (match profile.probes with

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -48,14 +48,6 @@ let has_binding_failed (key : string) (errs : adapter_error list) =
     errs
 ;;
 
-let has_alias_failed (key : string) (errs : adapter_error list) =
-  has_error
-    (function
-      | Alias_resolution_failed s -> s = key
-      | _ -> false)
-    errs
-;;
-
 let has_duplicate_route (name : string) (errs : adapter_error list) =
   has_error
     (function
@@ -135,24 +127,17 @@ max-input = 4096
 
 [ollama.qwen3]
 
-[tier.rerank]
-members = ["cli_tool_d.haiku.for-scoring"]
-strategy = "failover"
+[profiles.rerank]
+provider_filter = "cli_tool_d"
 
-[tier.primary]
-members = ["cli_tool_d.sonnet", "cli_tool_d.haiku"]
-strategy = "failover"
+[profiles.primary]
+provider_filter = "cli_tool_d"
 
-[tier.local]
-members = ["ollama.qwen3"]
-strategy = "failover"
-
-[tier-group.primary]
-tiers = ["primary", "local"]
-strategy = "priority_tier"
+[profiles.local]
+provider_filter = "ollama"
 
 [routes.keeper_turn]
-target = "tier-group.primary"
+target = "cli_tool_d.haiku"
 
 [system.governance]
 target = "cli_tool_d.haiku.for-scoring"
@@ -171,30 +156,20 @@ let test_valid_catalog_structure () =
 
 let test_valid_tier_profiles () =
   let catalog = adapt_toml valid_toml in
-  let tier_names = List.map (fun (p : adapted_profile) -> p.name) catalog.profiles in
-  check bool "has tier.rerank" true (List.mem "tier.rerank" tier_names);
-  check bool "has tier.primary" true (List.mem "tier.primary" tier_names);
-  check bool "has tier.local" true (List.mem "tier.local" tier_names);
-  check bool "has tier-group.primary" true (List.mem "tier-group.primary" tier_names)
+  let profile_names = List.map (fun (p : adapted_profile) -> p.name) catalog.profiles in
+  check bool "has rerank" true (List.mem "rerank" profile_names);
+  check bool "has primary" true (List.mem "primary" profile_names);
+  check bool "has local" true (List.mem "local" profile_names)
 ;;
 
 let test_valid_tier_members_resolved () =
   let catalog = adapt_toml valid_toml in
   let rerank =
-    List.find (fun (p : adapted_profile) -> p.name = "tier.rerank") catalog.profiles
+    List.find (fun (p : adapted_profile) -> p.name = "rerank") catalog.profiles
   in
-  check int "rerank has 1 provider_config" 1 (List.length rerank.provider_configs)
-;;
-
-let test_valid_tier_group_flattened () =
-  let catalog = adapt_toml valid_toml in
-  let primary =
-    List.find
-      (fun (p : adapted_profile) -> p.name = "tier-group.primary")
-      catalog.profiles
-  in
-  (* primary has 2 members + local has 1 member = 3 provider_configs *)
-  check int "primary has 3 provider_configs" 3 (List.length primary.provider_configs)
+  (* provider_filter = "cli_tool_d" selects all cli_tool_d bindings:
+     cli_tool_d.haiku + cli_tool_d.sonnet = 2 provider_configs. *)
+  check int "rerank has 2 provider_configs" 2 (List.length rerank.provider_configs)
 ;;
 
 let test_valid_routes () =
@@ -202,9 +177,9 @@ let test_valid_routes () =
   let route_targets = List.map snd catalog.routes in
   check
     bool
-    "routes to tier-group.primary"
+    "routes to cli_tool_d.haiku"
     true
-    (List.mem "tier-group.primary" route_targets)
+    (List.mem "cli_tool_d.haiku" route_targets)
 ;;
 
 let test_valid_system_targets () =
@@ -215,11 +190,6 @@ let test_valid_system_targets () =
     "system target is alias key"
     true
     (List.mem "cli_tool_d.haiku.for-scoring" targets)
-;;
-
-let test_valid_default_profile () =
-  let catalog = adapt_toml valid_toml in
-  check bool "has default profile" true (catalog.default_profile <> None)
 ;;
 
 let test_registered_http_provider_uses_toml_endpoint_without_api_key () =
@@ -241,15 +211,14 @@ tools-support = true
 [provider_k-coding.provider_k-5-turbo]
 max-concurrent = 2
 
-[tier.medium]
-members = ["provider_k-coding.provider_k-5-turbo"]
-strategy = "failover"
+[profiles.medium]
+provider_filter = "provider_k-coding"
 |}
   in
   let catalog = adapt_toml toml in
   no_errors catalog.errors;
   let medium =
-    List.find (fun (p : adapted_profile) -> p.name = "tier.medium") catalog.profiles
+    List.find (fun (p : adapted_profile) -> p.name = "medium") catalog.profiles
   in
   match medium.provider_configs with
   | [ (cfg, _) ] ->
@@ -272,7 +241,7 @@ strategy = "failover"
 ;;
 
 let test_registered_http_provider_without_credentials_uses_registry_api_key_env () =
-  with_env "ZAI_API_KEY" "zai-review-test-key" (fun () ->
+  with_env "ZAI_CODING_API_KEY" "zai-review-test-key" (fun () ->
     let toml =
       {|
 [providers.provider_k-coding]
@@ -287,15 +256,14 @@ tools-support = true
 [provider_k-coding.provider_k-5-turbo]
 max-concurrent = 2
 
-[tier.medium]
-members = ["provider_k-coding.provider_k-5-turbo"]
-strategy = "failover"
+[profiles.medium]
+provider_filter = "provider_k-coding"
 |}
     in
     let catalog = adapt_toml toml in
     no_errors catalog.errors;
     let medium =
-      List.find (fun (p : adapted_profile) -> p.name = "tier.medium") catalog.profiles
+      List.find (fun (p : adapted_profile) -> p.name = "medium") catalog.profiles
     in
     match medium.provider_configs with
     | [ (cfg, _) ] ->
@@ -338,16 +306,15 @@ tools-support = true
 [ollama_cloud.provider_k-5-1-cloud]
 max-concurrent = 1
 
-[tier.provider_k-coding-with-spark]
-members = ["ollama_cloud.provider_k-5-1-cloud"]
-strategy = "failover"
+[profiles.provider_k-coding-with-spark]
+provider_filter = "ollama_cloud"
 |}
     in
     let catalog = adapt_toml toml in
     no_errors catalog.errors;
     let coding_tier =
       List.find
-        (fun (p : adapted_profile) -> p.name = "tier.provider_k-coding-with-spark")
+        (fun (p : adapted_profile) -> p.name = "provider_k-coding-with-spark")
         catalog.profiles
     in
     match coding_tier.provider_configs with
@@ -401,16 +368,15 @@ supports-tool-choice = true
 [ollama_cloud.qwen3-5]
 max-concurrent = 1
 
-[tier.ollama_cloud_primary]
-members = ["ollama_cloud.qwen3-5"]
-strategy = "failover"
+[profiles.ollama_cloud_primary]
+provider_filter = "ollama_cloud"
 |}
     in
     let catalog = adapt_toml toml in
     no_errors catalog.errors;
     let primary =
       List.find
-        (fun (p : adapted_profile) -> p.name = "tier.ollama_cloud_primary")
+        (fun (p : adapted_profile) -> p.name = "ollama_cloud_primary")
         catalog.profiles
     in
     match primary.provider_configs with
@@ -453,16 +419,15 @@ supports-tool-choice = true
 [provider_k-coding.provider_k-5-1]
 max-concurrent = 1
 
-[tier.provider_k-coding-primary]
-members = ["provider_k-coding.provider_k-5-1"]
-strategy = "failover"
+[profiles.provider_k-coding-primary]
+provider_filter = "provider_k-coding"
 |}
   in
   let catalog = adapt_toml toml in
   no_errors catalog.errors;
   let tier =
     List.find
-      (fun (p : adapted_profile) -> p.name = "tier.provider_k-coding-primary")
+      (fun (p : adapted_profile) -> p.name = "provider_k-coding-primary")
       catalog.profiles
   in
   match tier.provider_configs with
@@ -502,15 +467,14 @@ tools-support = true
 
 [local-provider_d.remote]
 
-[tier.medium]
-members = ["local-provider_d.remote"]
-strategy = "failover"
+[profiles.medium]
+provider_filter = "local-provider_d"
 |}
   in
   let catalog = adapt_toml toml in
   no_errors catalog.errors;
   let medium =
-    List.find (fun (p : adapted_profile) -> p.name = "tier.medium") catalog.profiles
+    List.find (fun (p : adapted_profile) -> p.name = "medium") catalog.profiles
   in
   match medium.provider_configs with
   | [ (cfg, _) ] ->
@@ -552,15 +516,14 @@ tools-support = true
 [cli_tool_d.haiku]
 max-concurrent = 1
 
-[tier.primary]
-members = ["cli_tool_d.haiku"]
-strategy = "failover"
+[profiles.primary]
+provider_filter = "cli_tool_d"
 |}
   in
   let catalog = adapt_toml toml in
   no_errors catalog.errors;
   let primary =
-    List.find (fun (p : adapted_profile) -> p.name = "tier.primary") catalog.profiles
+    List.find (fun (p : adapted_profile) -> p.name = "primary") catalog.profiles
   in
   match primary.provider_configs with
   | [ (cfg, _) ] ->
@@ -616,57 +579,12 @@ is-default = true
   has_model_not_found "nonexistent-model" catalog.errors
 ;;
 
-(* --- Error: alias resolution fails when parent missing --- *)
-
-let test_alias_parent_missing () =
-  let cfg =
-    { providers =
-        [ { id = "x"
-          ; display_name = "X"
-          ; protocol = "provider_a"
-          ; api_format = Messages_api
-          ; transport = Cli "x"
-          ; is_non_interactive = false
-          ; credentials = None
-          ; capabilities = None
-          ; log = None
-          ; healthcheck = None
-          ; headers = None
-          }
-        ]
-    ; models =
-        [ { id = "m"
-          ; api_name = "test-model"
-          ; max_context = 4096
-          ; tools_support = true
-          ; thinking_support = false
-          ; max_thinking_budget = None
-          ; streaming = true
-          ; capabilities = None
-          ; match_prefixes = []
-          }
-        ]
-    ; bindings = []
-    ; aliases =
-        [ { provider_id = "x"
-          ; model_id = "m"
-          ; name = "a"
-          ; max_input = None
-          ; max_output = None
-          ; temperature = None
-          ; thinking_enabled = None
-          ; thinking_budget = None
-          }
-        ]
-    (* #19327: tier/tier_groups fields removed from cascade_config. *)
-    ; routes = []
-    ; system_targets = []
-    ; profiles = []
-    }
-  in
-  let catalog = adapt_config cfg in
-  has_alias_failed "x.m.a" catalog.errors
-;;
+(* Note: the legacy [Alias_resolution_failed] error path was produced by
+   tier-member resolution ([resolve_member]), which the tier purge removed.
+   Aliases are no longer resolved into profile members, so the
+   "alias parent missing" error case is unreachable and its test was
+   dropped. Alias-parent validation, if reinstated, belongs to a separate
+   declarative-validation concern (tracked via issue). *)
 
 (* --- Strategy mapping --- *)
 
@@ -683,13 +601,11 @@ api-name = "model-a-haiku"
 
 [cli_tool_d.haiku]
 
-[tier.failover-t]
-members = ["cli_tool_d.haiku"]
-strategy = "failover"
+[profiles.failover-t]
+provider_filter = "cli_tool_d"
 
-[tier.priority-t]
-members = ["cli_tool_d.haiku"]
-strategy = "priority_tier"
+[profiles.priority-t]
+provider_filter = "cli_tool_d"
 |}
   in
   let catalog = adapt_toml toml in
@@ -710,70 +626,11 @@ strategy = "priority_tier"
       expected
       profile.strategy.Cascade_strategy.kind
   in
-  check_kind "tier.failover-t" Cascade_strategy.Failover;
-  check_kind "tier.priority-t" Cascade_strategy.Priority_tier
-;;
-
-let test_provider_d_http_tier_group_uses_endpoint_scoped_health_keys () =
-  let toml =
-    {|
-[providers.runpod]
-protocol = "provider_d-http"
-endpoint = "https://runpod.example.test/v1"
-
-[providers.glm]
-protocol = "provider_d-http"
-endpoint = "https://api.z.ai/api/coding/paas/v4"
-
-[models.runpod-qwen]
-max-context = 128000
-api-name = "runpod-qwen"
-tools-support = true
-
-[models.glm-5-turbo]
-max-context = 128000
-api-name = "glm-5-turbo"
-tools-support = true
-
-[runpod.runpod-qwen]
-[glm.glm-5-turbo]
-
-[tier.runpod]
-members = ["runpod.runpod-qwen"]
-strategy = "failover"
-
-[tier.glm]
-members = ["glm.glm-5-turbo"]
-strategy = "failover"
-
-[tier-group.custom-priority]
-tiers = ["runpod", "glm"]
-strategy = "priority_tier"
-|}
-  in
-  let catalog = adapt_toml toml in
-  no_errors catalog.errors;
-  let profile =
-    List.find
-      (fun (p : adapted_profile) -> p.name = "tier-group.custom-priority")
-      catalog.profiles
-  in
-  match profile.strategy.Cascade_strategy.tiers with
-  | [ [ first ]; [ second ] ] ->
-    check bool "tier health keys are endpoint-scoped"
-      true
-      (not (String.equal first second));
-    check bool "runpod tier key includes endpoint"
-      true
-      (String.contains first '@');
-    check bool "glm tier key includes endpoint"
-      true
-      (String.contains second '@')
-  | tiers ->
-    fail
-      (Printf.sprintf
-         "expected two single-entry tiers, got %d tiers"
-         (List.length tiers))
+  check_kind "failover-t" Cascade_strategy.Failover;
+  (* [priority_tier] is retired: declarative profiles no longer carry a
+     per-profile strategy, so every profile resolves to the sole surviving
+     [Failover] strategy. *)
+  check_kind "priority-t" Cascade_strategy.Failover
 ;;
 
 (* --- Multiple errors accumulated --- *)
@@ -857,41 +714,6 @@ let test_duplicate_routes () =
   has_duplicate_route "dup" catalog.errors
 ;;
 
-(* --- Empty tier-group produces empty provider_configs --- *)
-
-let test_empty_tier_group () =
-  let toml =
-    {|
-[providers.cli_tool_d]
-protocol = "provider_a-cli"
-command = "agent_llm_a"
-
-[models.haiku]
-max-context = 200000
-api-name = "model-a-haiku"
-
-[cli_tool_d.haiku]
-
-[tier.real]
-members = ["cli_tool_d.haiku"]
-strategy = "failover"
-
-[tier-group.empty]
-tiers = ["real"]
-strategy = "priority_tier"
-|}
-  in
-  let catalog = adapt_toml toml in
-  (* tier-group.empty has tier "real" with 1 member — not actually empty *)
-  check
-    bool
-    "has tier-group.empty profile"
-    true
-    (List.exists
-       (fun (p : adapted_profile) -> p.name = "tier-group.empty")
-       catalog.profiles)
-;;
-
 (* --- Test suite --- *)
 
 let () =
@@ -901,10 +723,8 @@ let () =
       , [ test_case "structure" `Quick test_valid_catalog_structure
         ; test_case "tier profiles" `Quick test_valid_tier_profiles
         ; test_case "tier members resolved" `Quick test_valid_tier_members_resolved
-        ; test_case "tier-group flattened" `Quick test_valid_tier_group_flattened
         ; test_case "routes" `Quick test_valid_routes
         ; test_case "system targets" `Quick test_valid_system_targets
-        ; test_case "default profile" `Quick test_valid_default_profile
         ; test_case
             "registered HTTP provider uses TOML endpoint"
             `Quick
@@ -937,17 +757,11 @@ let () =
     ; ( "errors"
       , [ test_case "unknown provider" `Quick test_unknown_provider
         ; test_case "unknown model" `Quick test_unknown_model
-        ; test_case "alias parent missing" `Quick test_alias_parent_missing
         ; test_case "multiple errors" `Quick test_multiple_errors
         ; test_case "duplicate routes" `Quick test_duplicate_routes
         ] )
     ; ( "strategy"
       , [ test_case "supported variants" `Quick test_strategy_mapping
-        ; test_case
-            "provider_d-http tier-group keys are endpoint-scoped"
-            `Quick
-            test_provider_d_http_tier_group_uses_endpoint_scoped_health_keys
         ] )
-    ; "edge_cases", [ test_case "empty tier-group" `Quick test_empty_tier_group ]
     ]
 ;;

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -110,28 +110,14 @@ temperature = 0.1
 keep-alive = "5m"
 num-ctx = 32768
 
-[tier.rerank]
-keeper-assignable = false
-members = ["agent_llm_a-code.haiku.for-scoring"]
-strategy = "failover"
+[profiles.primary]
+provider_filter = "agent_llm_a-code"
 
-[tier.primary]
-members = ["agent_llm_a-code.sonnet", "agent_llm_a-code.haiku"]
-strategy = "failover"
-max-concurrent = 5
-
-[tier.local]
-members = ["ollama.qwen3-8b"]
-strategy = "failover"
-
-[tier-group.primary]
-tiers = ["primary", "local"]
-strategy = "priority_tier"
-fallback = true
-keeper-assignable = true
+[profiles.local]
+provider_filter = "ollama"
 
 [routes.keeper_turn]
-target = "tier-group.primary"
+target = "agent_llm_a-code.haiku"
 
 [system.governance]
 target = "agent_llm_a-code.haiku.for-governance"
@@ -234,7 +220,7 @@ let test_routes () =
   match
     List.find_opt (fun (r : cascade_route) -> r.name = "keeper_turn") cfg.routes
   with
-  | Some r -> check string "route target" "tier-group.primary" r.target
+  | Some r -> check string "route target" "agent_llm_a-code.haiku" r.target
   | None -> failwith "missing keeper_turn route"
 ;;
 
@@ -305,18 +291,6 @@ tools-support = true
   in
   let errs = is_error (parse_string toml) in
   has_error_at "models.bad-model.max-context" errs
-;;
-
-let test_unknown_strategy () =
-  let toml =
-    {|
-[tier.bad-strategy]
-members = ["x"]
-strategy = "nonexistent_strategy"
-|}
-  in
-  let errs = is_error (parse_string toml) in
-  has_error_at "tier.bad-strategy.strategy" errs
 ;;
 
 let test_invalid_toml_syntax () =
@@ -1255,7 +1229,6 @@ let () =
         ; test_case "missing transport" `Quick test_missing_transport
         ; test_case "both transports" `Quick test_both_transport
         ; test_case "missing max-context" `Quick test_missing_max_context
-        ; test_case "unknown strategy" `Quick test_unknown_strategy
         ; test_case "invalid TOML syntax" `Quick test_invalid_toml_syntax
         ; test_case "empty TOML" `Quick test_empty_toml
         ; test_case

--- a/test/test_cascade_declarative_validator.ml
+++ b/test/test_cascade_declarative_validator.ml
@@ -26,12 +26,6 @@ let has_rule_at (rule : string) (path : string) (errs : validation_error list) =
 let no_errors (errs : validation_error list) =
   check int "no errors" 0 (List.length errs)
 
-let has_parse_error_at (path : string) (errs : parse_error list) =
-  check bool
-    ("has parse error at " ^ path)
-    true
-    (List.exists (fun (e : parse_error) -> e.path = path) errs)
-
 let validate_toml (toml : string) : validation_error list =
   match parse_string toml with
   | Ok cfg -> validate cfg
@@ -78,24 +72,14 @@ max-input = 4096
 [ollama.qwen3-8b]
 max-concurrent = 1
 
-[tier.rerank]
-members = ["agent_llm_a-code.haiku.for-scoring"]
-strategy = "failover"
+[profiles.primary]
+provider_filter = "agent_llm_a-code"
 
-[tier.primary]
-members = ["agent_llm_a-code.sonnet", "agent_llm_a-code.haiku"]
-strategy = "failover"
-
-[tier.local]
-members = ["ollama.qwen3-8b"]
-strategy = "failover"
-
-[tier-group.primary]
-tiers = ["primary", "local"]
-strategy = "priority_tier"
+[profiles.local]
+provider_filter = "ollama"
 
 [routes.keeper_turn]
-target = "tier-group.primary"
+target = "agent_llm_a-code.haiku"
 
 [system.governance]
 target = "agent_llm_a-code.haiku.for-scoring"
@@ -207,75 +191,6 @@ max-input = 4096
   let errs = validate_toml toml in
   no_errors errs
 
-(* --- R5: Tier member does not resolve --- *)
-
-let test_r5_unknown_tier_member () =
-  let toml = {|
-[providers.agent_llm_a-code]
-protocol = "provider_a-cli"
-command = "agent_llm_a"
-
-[models.haiku]
-max-context = 200000
-
-[agent_llm_a-code.haiku]
-is-default = true
-
-[tier.bad-tier]
-members = ["agent_llm_a-code.haiku", "nonexistent.binding"]
-strategy = "failover"
-|} in
-  let errs = validate_toml toml in
-  has_rule "R5" errs
-
-let test_r5_alias_member_ok () =
-  let toml = {|
-[providers.agent_llm_a-code]
-protocol = "provider_a-cli"
-command = "agent_llm_a"
-
-[models.haiku]
-max-context = 200000
-
-[agent_llm_a-code.haiku]
-is-default = true
-max-concurrent = 1
-
-[agent_llm_a-code.haiku.alias-a]
-max-input = 4096
-
-[tier.t]
-members = ["agent_llm_a-code.haiku.alias-a"]
-strategy = "failover"
-|} in
-  let errs = validate_toml toml in
-  no_errors errs
-
-(* --- R6: Tier-group references unknown tier --- *)
-
-let test_r6_unknown_tier () =
-  let toml = {|
-[providers.agent_llm_a-code]
-protocol = "provider_a-cli"
-command = "agent_llm_a"
-
-[models.haiku]
-max-context = 200000
-
-[agent_llm_a-code.haiku]
-is-default = true
-
-[tier.real]
-members = ["agent_llm_a-code.haiku"]
-strategy = "failover"
-
-[tier-group.broken]
-tiers = ["real", "phantom"]
-strategy = "failover"
-|} in
-  let errs = validate_toml toml in
-  has_rule "R6" errs
-
 (* --- R7: Route target does not resolve --- *)
 
 let test_r7_unknown_route_target () =
@@ -311,29 +226,6 @@ max-concurrent = 1
 
 [routes.direct]
 target = "agent_llm_a-code.haiku"
-|} in
-  let errs = validate_toml toml in
-  no_errors errs
-
-let test_r7_route_to_tier () =
-  let toml = {|
-[providers.agent_llm_a-code]
-protocol = "provider_a-cli"
-command = "agent_llm_a"
-
-[models.haiku]
-max-context = 200000
-
-[agent_llm_a-code.haiku]
-is-default = true
-max-concurrent = 1
-
-[tier.primary]
-members = ["agent_llm_a-code.haiku"]
-strategy = "failover"
-
-[routes.via-tier]
-target = "tier.primary"
 |} in
   let errs = validate_toml toml in
   no_errors errs
@@ -451,191 +343,6 @@ target = "no.such.binding"
   has_rule "R8" errs;
   check bool "multiple errors" true (List.length errs >= 3)
 
-(* --- R10: Strategy-field consistency --- *)
-
-let test_r10_cycle_policy_on_wrong_strategy () =
-  let toml = {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-max-concurrent = 1
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-max-cycles = 3
-backoff-base-ms = 500
-backoff-cap-ms = 10000
-|} in
-  let errs = validate_toml toml in
-  has_rule_at "R10" "tier.t.cycle-policy" errs
-
-let test_retired_cycle_policy_strategy_rejected_by_parser () =
-  let toml = {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-max-concurrent = 1
-
-[tier.t]
-members = ["p.m"]
-strategy = "circuit_breaker_cycling"
-max-cycles = 3
-backoff-base-ms = 500
-backoff-cap-ms = 10000
-|} in
-  match parse_string toml with
-  | Ok _ -> Alcotest.fail "expected retired strategy to be rejected"
-  | Error errs -> has_parse_error_at "tier.t.strategy" errs
-
-let test_r10_sticky_ttl_on_wrong_strategy () =
-  let toml = {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-max-concurrent = 1
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-sticky-ttl-ms = 600000
-|} in
-  let errs = validate_toml toml in
-  has_rule_at "R10" "tier.t.sticky-ttl-ms" errs
-
-let test_retired_sticky_strategy_rejected_by_parser () =
-  let toml = {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-max-concurrent = 1
-
-[tier.t]
-members = ["p.m"]
-strategy = "sticky"
-sticky-ttl-ms = 600000
-|} in
-  match parse_string toml with
-  | Ok _ -> Alcotest.fail "expected retired strategy to be rejected"
-  | Error errs -> has_parse_error_at "tier.t.strategy" errs
-
-let test_r10_scoring_on_wrong_strategy () =
-  let toml = {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-max-concurrent = 1
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-latency-baseline-ms = 200.0
-rate-limit-recency-window-s = 60.0
-rate-limit-decay-base = 0.5
-rate-limit-skip-after = 3
-server-error-recency-window-s = 120.0
-server-error-decay-base = 0.3
-server-error-skip-after = 5
-|} in
-  let errs = validate_toml toml in
-  has_rule_at "R10" "tier.t.scoring-params" errs
-
-let test_retired_scoring_strategy_rejected_by_parser () =
-  let toml = {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-max-concurrent = 1
-
-[tier.t]
-members = ["p.m"]
-strategy = "weighted_random"
-latency-baseline-ms = 200.0
-rate-limit-recency-window-s = 60.0
-rate-limit-decay-base = 0.5
-rate-limit-skip-after = 3
-server-error-recency-window-s = 120.0
-server-error-decay-base = 0.3
-server-error-skip-after = 5
-|} in
-  match parse_string toml with
-  | Ok _ -> Alcotest.fail "expected retired strategy to be rejected"
-  | Error errs -> has_parse_error_at "tier.t.strategy" errs
-
-let test_r10_no_strategy_fields_is_ok () =
-  let toml = {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-max-concurrent = 1
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-|} in
-  let errs = validate_toml toml in
-  no_errors errs
-
-let test_r10_multiple_mismatches () =
-  let toml = {|
-[providers.p]
-protocol = "provider_a-cli"
-command = "c"
-
-[models.m]
-max-context = 4096
-
-[p.m]
-max-concurrent = 1
-
-[tier.t]
-members = ["p.m"]
-strategy = "failover"
-max-cycles = 3
-backoff-base-ms = 500
-backoff-cap-ms = 10000
-sticky-ttl-ms = 600000
-|} in
-  let errs = validate_toml toml in
-  has_rule "R10" errs;
-  check bool "multiple R10 errors" true
-    (List.length (List.filter (fun e -> e.rule = "R10") errs) >= 2)
-
 (* --- Test suite --- *)
 
 (* --- R12: Protocol ↔ transport consistency --- *)
@@ -721,17 +428,9 @@ let () =
         test_case "max-input exceeds max-context" `Quick test_r4_max_input_exceeds;
         test_case "max-input within max-context" `Quick test_r4_max_input_ok;
       ];
-      "R5_tier_members", [
-        test_case "unknown tier member" `Quick test_r5_unknown_tier_member;
-        test_case "alias as tier member" `Quick test_r5_alias_member_ok;
-      ];
-      "R6_tier_group_refs", [
-        test_case "unknown tier in group" `Quick test_r6_unknown_tier;
-      ];
       "R7_route_targets", [
         test_case "unknown route target" `Quick test_r7_unknown_route_target;
         test_case "route to binding" `Quick test_r7_route_to_binding;
-        test_case "route to tier" `Quick test_r7_route_to_tier;
       ];
       "R8_system_targets", [
         test_case "unknown system target" `Quick test_r8_unknown_system_target;
@@ -743,19 +442,6 @@ let () =
       ];
       "multi", [
         test_case "multiple errors at once" `Quick test_multiple_errors;
-      ];
-      "R10_strategy_fields", [
-        test_case "cycle_policy on wrong strategy" `Quick test_r10_cycle_policy_on_wrong_strategy;
-        test_case "retired cycle_policy strategy rejected" `Quick
-          test_retired_cycle_policy_strategy_rejected_by_parser;
-        test_case "sticky_ttl on wrong strategy" `Quick test_r10_sticky_ttl_on_wrong_strategy;
-        test_case "retired sticky strategy rejected" `Quick
-          test_retired_sticky_strategy_rejected_by_parser;
-        test_case "scoring on wrong strategy" `Quick test_r10_scoring_on_wrong_strategy;
-        test_case "retired scoring strategy rejected" `Quick
-          test_retired_scoring_strategy_rejected_by_parser;
-        test_case "no strategy fields is ok" `Quick test_r10_no_strategy_fields_is_ok;
-        test_case "multiple mismatches" `Quick test_r10_multiple_mismatches;
       ];
       "R12_protocol_transport", [
         test_case "cli protocol with cli transport ok" `Quick test_r12_cli_protocol_with_cli_transport;

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -95,11 +95,6 @@ let mk_ctx ?(health = H.create ())
   { health; capacity; now; rand_int = rand;
     keeper_name; cascade_name = Cascade_name.of_string_exn cascade_name }
 
-let mk_t ?(cycle = S.default_cycle_policy)
-         ?(tiers = [])
-         kind : S.t =
-  { kind; cycle; tiers }
-
 (* ── S1 Failover ─────────────────────────────────────────────── *)
 
 let test_failover_preserves_order () =
@@ -185,8 +180,7 @@ let test_parse_kind_known () =
       check string ("parse " ^ s) (S.kind_to_string expected) (S.kind_to_string k)
     | Error msg -> fail (Printf.sprintf "expected Ok, got Error %s" msg)
   in
-  check_ok "failover" S.Failover;
-  check_ok "priority_tier" S.Priority_tier
+  check_ok "failover" S.Failover
 
 let string_contains haystack needle =
   let nlen = String.length needle in
@@ -210,7 +204,7 @@ let test_parse_config_kind_supported () =
   check
     (list string)
     "config kind strings"
-    [ "failover"; "priority_tier" ]
+    [ "failover" ]
     S.config_kind_strings;
   let check_ok s expected =
     match S.parse_config_kind s with
@@ -218,12 +212,12 @@ let test_parse_config_kind_supported () =
       check string ("parse config " ^ s) (S.kind_to_string expected) (S.kind_to_string k)
     | Error msg -> fail (Printf.sprintf "expected Ok, got Error %s" msg)
   in
-  check_ok "failover" S.Failover;
-  check_ok "priority_tier" S.Priority_tier
+  check_ok "failover" S.Failover
 
 let test_parse_config_kind_retired_rejected () =
   let rejected =
-    [ "capacity_aware"
+    [ "priority_tier"  (* retired: tier routing removed *)
+    ; "capacity_aware"
     ; "weighted_random"
     ; "circuit_breaker_cycling"
     ; "sticky"
@@ -245,7 +239,7 @@ let test_parse_config_kind_retired_rejected () =
            bool
            ("config error mentions supported kinds for " ^ raw)
            true
-           (string_contains msg "failover" && string_contains msg "priority_tier"))
+           (string_contains msg "failover"))
     rejected
 
 (* ── Cascade_client_capacity ─────────────────────────────────── *)
@@ -438,75 +432,6 @@ let test_client_capacity_json_exposes_provenance () =
   check string "retention scope" "cascade_client_capacity"
     (json_string "scope" retention);
   check string "store kind" "process_registry" (json_string "store_kind" retention)
-
-(* ── Phase B: Priority_tier (S5) ───────────────────────────── *)
-
-let test_priority_tier_picks_first_tier () =
-  let cands = [mk_cand "a"; mk_cand "b"; mk_cand "c"] in
-  let strat = mk_t S.Priority_tier
-      ~tiers:[["a"]; ["b"; "c"]]
-  in
-  let ctx = mk_ctx () in
-  let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
-  check (list string) "cycle 0 → tier 0 (a only)" ["a"] (names ordered)
-
-let test_priority_tier_advances_with_cycle () =
-  let cands = [mk_cand "a"; mk_cand "b"; mk_cand "c"] in
-  let strat = mk_t S.Priority_tier
-      ~tiers:[["a"]; ["b"; "c"]]
-  in
-  let ctx = mk_ctx () in
-  let cycle1 = S.order_candidates strat ~adapter ~ctx ~cycle:1 cands in
-  check (list string) "cycle 1 → tier 1 (b, c)" ["b"; "c"] (names cycle1)
-
-let test_priority_tier_clamps_overflow () =
-  let cands = [mk_cand "a"; mk_cand "b"] in
-  let strat = mk_t S.Priority_tier ~tiers:[["a"]; ["b"]] in
-  let ctx = mk_ctx () in
-  let cycle99 = S.order_candidates strat ~adapter ~ctx ~cycle:99 cands in
-  check (list string) "cycle ≥ tiers count → last tier" ["b"] (names cycle99)
-
-let test_priority_tier_capacity_filter () =
-  let cands = [mk_cand "a"; mk_cand "b"] in
-  let table = [
-    (List.nth cands 0).url, mk_capacity_info ~total:1 ~active:1;
-  ] in
-  let strat = mk_t S.Priority_tier ~tiers:[["a"; "b"]] in
-  let ctx = mk_ctx ~capacity:(stub_capacity table) () in
-  let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
-  check (list string) "tier 0 with 'a' busy → only 'b'" ["b"] (names ordered)
-
-let test_priority_tier_starvation_guard () =
-  (* All tier candidates report capacity=0.  Without the guard the
-     cascade would exit empty and surface as "all candidates filtered
-     after N cycle(s)"; with it, the tier list itself is returned so
-     at least one real call is attempted. *)
-  let cands = [mk_cand "a"; mk_cand "b"] in
-  let table = [
-    (List.nth cands 0).url, mk_capacity_info ~total:1 ~active:1;
-    (List.nth cands 1).url, mk_capacity_info ~total:1 ~active:1;
-  ] in
-  let strat = mk_t S.Priority_tier ~tiers:[["a"; "b"]] in
-  let ctx = mk_ctx ~capacity:(stub_capacity table) () in
-  let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
-  check (list string) "all-busy tier → fall through with tier list"
-    ["a"; "b"] (names ordered)
-
-let test_priority_tier_starvation_guard_dedupes_full_shared_capacity_key () =
-  let cands =
-    [
-      { name = "a"; url = "https://shared.example/v1" };
-      { name = "b"; url = "https://shared.example/v1" };
-    ]
-  in
-  let table =
-    [ "https://shared.example/v1", mk_capacity_info ~total:1 ~active:1 ]
-  in
-  let strat = mk_t S.Priority_tier ~tiers:[["a"; "b"]] in
-  let ctx = mk_ctx ~capacity:(stub_capacity table) () in
-  let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
-  check (list string) "all-busy shared key → one representative"
-    ["a"] (names ordered)
 
 (* ── Cascade_state auto-rotation primitive ───────────────────── *)
 
@@ -889,7 +814,7 @@ let test_trace_prometheus_counter_increments () =
   ST.record (mk_trace_event ~cascade_name:"tier.primary"
                ~strategy:"failover" ~kind:ST.Ordered ());
   ST.record (mk_trace_event ~cascade_name:"tier.nick0cave"
-               ~strategy:"priority_tier"
+               ~strategy:"failover"
                ~kind:ST.Filtered_empty ~backoff_ms:500 ());
   let text = Masc_mcp.Prometheus.to_prometheus_text () in
   let ordered =
@@ -899,13 +824,13 @@ let test_trace_prometheus_counter_increments () =
   in
   let filtered =
     find_strategy_counter_value text
-      ~cascade:"tier.nick0cave" ~strategy:"priority_tier"
+      ~cascade:"tier.nick0cave" ~strategy:"failover"
       ~kind:"filtered_empty"
     |> Option.value ~default:0.0
   in
   check bool "primary/failover/ordered advanced by >= 2"
     true (ordered >= before +. 2.0);
-  check bool "nick0cave/priority_tier/filtered_empty >= 1"
+  check bool "nick0cave/failover/filtered_empty >= 1"
     true (filtered >= 1.0)
 
 let test_strategy_trace_json_exposes_provenance () =
@@ -1002,20 +927,6 @@ let () =
         test_snapshot_reflects_active_acquires;
       test_case "dashboard JSON exposes provenance" `Quick
         test_client_capacity_json_exposes_provenance;
-    ];
-    "priority_tier", [
-      test_case "cycle 0 picks first tier" `Quick
-        test_priority_tier_picks_first_tier;
-      test_case "cycle advances with tier index" `Quick
-        test_priority_tier_advances_with_cycle;
-      test_case "cycle overflow clamps to last tier" `Quick
-        test_priority_tier_clamps_overflow;
-      test_case "tier respects capacity filter" `Quick
-        test_priority_tier_capacity_filter;
-      test_case "all-busy tier falls through (starvation guard)" `Quick
-        test_priority_tier_starvation_guard;
-      test_case "all-busy shared key falls through once" `Quick
-        test_priority_tier_starvation_guard_dedupes_full_shared_capacity_key;
     ];
     "cascade_state", [
       test_case "round_robin bound<=0 returns 0" `Quick

--- a/test/test_cascade_strategy_labels.ml
+++ b/test/test_cascade_strategy_labels.ml
@@ -51,10 +51,10 @@ let test_cascade_strategy_kind_labels_lowercase () =
         (String.lowercase_ascii s) s)
     Cascade_strategy.all_kinds
 
-let test_cascade_strategy_all_kinds_documented_two () =
+let test_cascade_strategy_all_kinds_documented_one () =
   Alcotest.(check int)
-    "all_kinds covers the shipped strategies (Failover, Priority_tier)"
-    2
+    "all_kinds covers the sole shipped strategy (Failover)"
+    1
     (List.length Cascade_strategy.all_kinds)
 
 (* ── Cascade_strategy_trace.event_kind ───────────────────────── *)
@@ -98,7 +98,7 @@ let () =
           Alcotest.test_case "labels lowercase" `Quick
             test_cascade_strategy_kind_labels_lowercase;
           Alcotest.test_case "all_kinds documents shipped strategies"
-            `Quick test_cascade_strategy_all_kinds_documented_two;
+            `Quick test_cascade_strategy_all_kinds_documented_one;
         ] );
       ( "cascade_strategy_trace.event_kind",
         [

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -531,62 +531,6 @@ let test_cascade_name_accepts_catalog_entry () =
       if catalog = [] then ()
       else fail (Printf.sprintf "%s should be accepted: %s" test_name e)
 
-let test_resolve_model_strings_reads_declarative_profile () =
-  with_temp_config_dir minimal_cascade_profile_metadata_toml
-  @@ fun ~config_root:_ ~cascade_path ->
-  let models =
-    Masc_mcp.Cascade_config.resolve_model_strings
-      ~config_path:cascade_path ~name:"primary" ~defaults:["fallback"] ()
-  in
-  check (list string) "primary group models"
-    ["ollama:qwen3:8b"; "ollama:qwen3:1.7b"]
-    models
-
-let test_resolve_model_strings_uses_provider_protocol_for_custom_id () =
-  let cascade_toml =
-    {|
-[providers.custom]
-protocol = "provider_d-http"
-endpoint = "https://example.invalid/v1"
-
-[models.stable]
-api-name = "gpt-custom"
-max-context = 32768
-tools-support = true
-
-[custom.stable]
-max-concurrent = 1
-
-[tier.primary]
-members = ["custom.stable"]
-strategy = "failover"
-
-[routes.keeper_turn]
-target = "tier.primary"
-|}
-  in
-  with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
-  let models =
-    Masc_mcp.Cascade_config.resolve_model_strings
-      ~config_path:cascade_path ~name:"primary" ~defaults:["fallback"] ()
-  in
-  check (list string) "custom provider resolved from protocol"
-    ["custom:gpt-custom@https://example.invalid/v1"]
-    models
-
-let test_cascade_profile_metadata_from_toml () =
-  with_temp_config_dir minimal_cascade_profile_metadata_toml
-  @@ fun ~config_root:_ ~cascade_path:_ ->
-  check (list string) "keeper assignable catalog"
-    ["backup"; "primary"; "tier-group.primary"; "tier.backup"; "tier.primary"]
-    (Masc_mcp.Keeper_cascade_profile.keeper_catalog_names ());
-  check bool "rerank route is system-only" true
-    (Masc_mcp.Keeper_cascade_profile.is_system_only_cascade "llm_rerank");
-  check bool "scoring catalog entry is system-only" true
-    (Masc_mcp.Keeper_cascade_profile.is_system_only_cascade "scoring");
-  check (option string) "primary fallback hint" (Some "tier.backup")
-    (Masc_mcp.Keeper_cascade_profile.fallback_cascade_for "primary")
-
 let test_cascade_name_accepts_unrouted_assignable_catalog_entry () =
   with_temp_config_dir minimal_cascade_profile_metadata_toml
   @@ fun ~config_root:_ ~cascade_path:_ ->
@@ -602,220 +546,6 @@ let test_cascade_name_accepts_unrouted_assignable_catalog_entry () =
         (Printf.sprintf
            "unrouted keeper-assignable catalog entry should be accepted: %s"
            e)
-
-let test_keeper_assignability_uses_preferred_qualified_profile () =
-  let cascade_toml =
-    {|
-[providers.ollama]
-protocol = "ollama-http"
-endpoint = "http://localhost:11434"
-
-[models.qwen3]
-api-name = "qwen3:8b"
-max-context = 32768
-tools-support = true
-
-[ollama.qwen3]
-max-concurrent = 1
-
-[tier.primary]
-members = ["ollama.qwen3"]
-strategy = "failover"
-
-[tier-group.primary]
-tiers = ["primary"]
-strategy = "priority_tier"
-keeper-assignable = false
-
-[routes.keeper_turn]
-target = "tier-group.primary"
-|}
-  in
-  with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
-  check bool "preferred tier-group controls public assignability" false
-    (List.mem "primary" (Masc_mcp.Keeper_cascade_profile.keeper_catalog_names ()));
-  check bool "preferred tier-group is system-only" true
-    (Masc_mcp.Keeper_cascade_profile.is_system_only_cascade "primary");
-  check bool "qualified tier remains assignable" false
-    (Masc_mcp.Keeper_cascade_profile.is_system_only_cascade "tier.primary");
-  check bool "qualified tier-group remains system-only" true
-    (Masc_mcp.Keeper_cascade_profile.is_system_only_cascade "tier-group.primary");
-  let resolved_string raw =
-    match
-      Masc_mcp.Keeper_cascade_profile.resolve_live_result
-        ~config_path:cascade_path raw
-    with
-    | Ok name -> Cascade_name.to_string name
-    | Error (`Unresolved raw) ->
-        fail
-          (Printf.sprintf
-             "qualified cascade %S did not resolve against test catalog"
-             raw)
-  in
-  check string "qualified tier resolves without fallback" "tier.primary"
-    (resolved_string "tier.primary");
-  check string "qualified tier-group resolves without fallback" "tier-group.primary"
-    (resolved_string "tier-group.primary");
-  (match
-     with_temp_toml
-       "[keeper]\nname = \"testkeeper\"\ncascade_name = \"tier.primary\"\n"
-       KTP.load_keeper_toml
-   with
-   | Ok _ -> ()
-   | Error e ->
-       fail
-         (Printf.sprintf
-            "explicit qualified tier.primary should be accepted: %s"
-            e));
-  let result =
-    with_temp_toml
-      "[keeper]\nname = \"testkeeper\"\ncascade_name = \"primary\"\n"
-      KTP.load_keeper_toml
-  in
-  match result with
-  | Ok _ -> fail "preferred system-only tier-group should reject public primary"
-  | Error e ->
-      check bool "error mentions system-only" true
-        (contains ~needle:"system-only" e)
-
-let test_fallback_cascade_preserves_qualified_source_profile () =
-  let cascade_toml =
-    {|
-[providers.ollama]
-protocol = "ollama-http"
-endpoint = "http://localhost:11434"
-
-[models.qwen3]
-api-name = "qwen3:8b"
-max-context = 32768
-tools-support = true
-
-[ollama.qwen3]
-is-default = true
-max-concurrent = 1
-
-[tier.primary]
-members = ["ollama.qwen3"]
-strategy = "failover"
-
-[tier.mid]
-members = ["ollama.qwen3"]
-strategy = "failover"
-
-[tier.slow]
-members = ["ollama.qwen3"]
-strategy = "failover"
-
-[tier-group.primary]
-tiers = ["mid", "slow"]
-strategy = "priority_tier"
-fallback = true
-
-[tier-group.alt]
-tiers = ["primary", "mid"]
-strategy = "priority_tier"
-fallback = true
-
-[routes.keeper_turn]
-target = "tier-group.primary"
-|}
-  in
-  with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
-  check (option string) "public primary resolves as tier-group.primary"
-    (Some "tier.slow")
-    (Masc_mcp.Keeper_cascade_profile.fallback_cascade_for
-       ~config_path:cascade_path "primary");
-  check (option string) "qualified tier.primary keeps tier edge"
-    (Some "tier.mid")
-    (Masc_mcp.Keeper_cascade_profile.fallback_cascade_for
-       ~config_path:cascade_path "tier.primary")
-
-let test_fallback_cascade_returns_canonical_tier_target () =
-  let cascade_toml =
-    {|
-[providers.ollama]
-protocol = "ollama-http"
-endpoint = "http://localhost:11434"
-
-[models.qwen3]
-api-name = "qwen3:8b"
-max-context = 32768
-tools-support = true
-
-[ollama.qwen3]
-is-default = true
-max-concurrent = 1
-
-[tier.primary]
-members = ["ollama.qwen3"]
-strategy = "failover"
-
-[tier.local_llama]
-members = ["ollama.qwen3"]
-strategy = "failover"
-
-[tier.glm]
-members = ["ollama.qwen3"]
-strategy = "failover"
-
-[tier-group.coding]
-tiers = ["primary", "local_llama", "glm"]
-strategy = "priority_tier"
-fallback = true
-
-[routes.keeper_turn]
-target = "tier-group.coding"
-|}
-  in
-  with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
-  check
-    (option string)
-    "tier-group fallback keeps canonical tier target"
-    (Some "tier.local_llama")
-    (Masc_mcp.Keeper_cascade_profile.fallback_cascade_for
-       ~config_path:cascade_path "tier-group.coding")
-
-let test_normalize_declared_name_canonicalizes_public_catalog_members () =
-  let cascade_toml =
-    {|
-[providers.ollama]
-protocol = "ollama-http"
-endpoint = "http://localhost:11434"
-
-[models.qwen3]
-api-name = "qwen3:8b"
-max-context = 32768
-tools-support = true
-
-[ollama.qwen3]
-is-default = true
-max-concurrent = 1
-
-[tier.strict_tool_candidates]
-members = ["ollama.qwen3"]
-strategy = "failover"
-
-[tier.local_llama]
-members = ["ollama.qwen3"]
-strategy = "failover"
-
-[tier-group.strict_tool_candidates]
-tiers = ["strict_tool_candidates"]
-strategy = "priority_tier"
-
-[routes.keeper_turn]
-target = "tier-group.strict_tool_candidates"
-|}
-  in
-  with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
-  check string "public tier-group alias canonicalizes to tier-group"
-    "tier-group.strict_tool_candidates"
-    (Masc_mcp.Keeper_cascade_profile.normalize_declared_name
-       ~config_path:cascade_path "strict_tool_candidates");
-  check string "public tier alias canonicalizes to tier"
-    "tier.local_llama"
-    (Masc_mcp.Keeper_cascade_profile.normalize_declared_name
-       ~config_path:cascade_path "local_llama")
 
 let test_keeper_runtime_declared_name_ignores_non_keeper_route_target () =
   let cascade_toml =
@@ -859,6 +589,8 @@ target = "tier.ollama_cloud_primary"
        ~config_path:cascade_path "tier.ollama_cloud_primary")
 
 let test_catalog_validator_surfaces_adapter_errors () =
+  (* RFC-0058: a binding whose provider is not declared in [providers.*]
+     yields a [Binding_resolution_failed] adapter error. *)
   let cascade_toml =
     {|
 [providers.ollama]
@@ -870,12 +602,11 @@ api-name = "qwen3:8b"
 max-context = 32768
 tools-support = true
 
-[tier.broken]
-members = ["ollama.qwen3"]
-strategy = "failover"
+[undeclared_provider.qwen3]
+max-concurrent = 1
 
 [routes.keeper_turn]
-target = "tier.broken"
+target = "undeclared_provider.qwen3"
 |}
   in
   with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
@@ -898,26 +629,18 @@ target = "tier.broken"
   check bool "adapter error is surfaced as catalog error" true has_adapter_error
 
 let test_catalog_validator_surfaces_declarative_parse_errors () =
+  (* RFC-0058: an unknown provider protocol is a declarative parse error
+     (strategy validation was retired with the tier concept). *)
   let cascade_toml =
     {|
-[providers.ollama]
-protocol = "ollama-http"
-endpoint = "http://localhost:11434"
+[providers.broken]
+protocol = "not_a_protocol"
+command = "x"
 
 [models.qwen3]
 api-name = "qwen3:8b"
 max-context = 32768
 tools-support = true
-
-[ollama.qwen3]
-max-concurrent = 1
-
-[tier.primary]
-members = ["ollama.qwen3"]
-strategy = "not_a_strategy"
-
-[routes.keeper_turn]
-target = "tier.primary"
 |}
   in
   with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
@@ -934,7 +657,7 @@ target = "tier.primary"
              contains
                ~needle:"Declarative cascade parse error"
                issue.message
-             && contains ~needle:"not_a_strategy" issue.message)
+             && contains ~needle:"providers.broken.protocol" issue.message)
       issues
   in
   check bool "parse error is surfaced as catalog error" true has_parse_error
@@ -948,26 +671,18 @@ let rejection_error_messages rejection =
        | _ -> None)
 
 let test_runtime_validation_rejects_declarative_parse_errors () =
+  (* RFC-0058: an unknown provider protocol is a declarative parse error that
+     runtime validation rejects (strategy validation retired with tiers). *)
   let cascade_toml =
     {|
-[providers.ollama]
-protocol = "ollama-http"
-endpoint = "http://localhost:11434"
+[providers.broken]
+protocol = "not_a_protocol"
+command = "x"
 
 [models.qwen3]
 api-name = "qwen3:8b"
 max-context = 32768
 tools-support = true
-
-[ollama.qwen3]
-max-concurrent = 1
-
-[tier.primary]
-members = ["ollama.qwen3"]
-strategy = "not_a_strategy"
-
-[routes.keeper_turn]
-target = "tier.primary"
 |}
   in
   with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
@@ -984,10 +699,12 @@ target = "tier.primary"
         (List.exists
            (fun message ->
               contains ~needle:"declarative cascade parse error" message
-              && contains ~needle:"not_a_strategy" message)
+              && contains ~needle:"providers.broken.protocol" message)
            errors)
 
 let test_runtime_validation_rejects_declarative_adapter_errors () =
+  (* RFC-0058: a binding referencing an undeclared provider produces a
+     [Binding_resolution_failed] adapter error that runtime validation rejects. *)
   let cascade_toml =
     {|
 [providers.ollama]
@@ -999,12 +716,11 @@ api-name = "qwen3:8b"
 max-context = 32768
 tools-support = true
 
-[tier.broken]
-members = ["ollama.qwen3"]
-strategy = "failover"
+[undeclared_provider.qwen3]
+max-concurrent = 1
 
 [routes.keeper_turn]
-target = "tier.broken"
+target = "undeclared_provider.qwen3"
 |}
   in
   with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
@@ -1023,63 +739,6 @@ target = "tier.broken"
               contains ~needle:"declarative cascade adapter error" message
               && contains ~needle:"Binding_resolution_failed" message)
            errors)
-
-let test_runtime_validation_rejects_deprecated_profile_names () =
-  let cascade_toml =
-    {|
-[providers.ollama]
-protocol = "ollama-http"
-endpoint = "http://localhost:11434"
-
-[models.qwen3]
-api-name = "qwen3:8b"
-max-context = 32768
-tools-support = true
-
-[ollama.qwen3]
-max-concurrent = 1
-
-[tier.local_only]
-members = ["ollama.qwen3"]
-strategy = "failover"
-
-[tier-group.local_only]
-tiers = ["local_only"]
-
-[routes.keeper_turn]
-target = "tier-group.local_only"
-|}
-  in
-  with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
-  match
-    (* #19327/#19340 follow-up: validate_path now takes ~route_data. *)
-    Masc_mcp.Cascade_catalog_runtime.validate_path
-      ~route_data:Masc_mcp.Cascade_catalog_runtime.empty_route_data
-      ~config_path:cascade_path ()
-  with
-  | Ok _ -> fail "runtime validation should reject deprecated cascade profile names"
-  | Error rejection ->
-      let errors = rejection_error_messages rejection in
-      check bool "runtime rejection contains deprecated profile name" true
-        (List.exists
-           (fun message ->
-              contains ~needle:"deprecated cascade profile name" message
-              && contains ~needle:"local_only" message)
-           errors)
-
-let test_cascade_name_rejects_system_only_catalog_entry () =
-  with_temp_config_dir minimal_cascade_profile_metadata_toml
-  @@ fun ~config_root:_ ~cascade_path:_ ->
-  let result =
-    with_temp_toml
-      "[keeper]\nname = \"testkeeper\"\ncascade_name = \"scoring\"\n"
-      KTP.load_keeper_toml
-  in
-  match result with
-  | Ok _ -> fail "system-only cascade_name should be rejected"
-  | Error e ->
-      check bool "error mentions system-only" true
-        (contains ~needle:"system-only" e)
 
 let test_tool_access_accepts_dispatch () =
   let result =
@@ -1208,22 +867,8 @@ let () =
             test_cascade_name_accepts_tool_lane_without_catalog;
           test_case "accepts live catalog entry" `Quick
             test_cascade_name_accepts_catalog_entry;
-          test_case "resolves declarative profile model strings" `Quick
-            test_resolve_model_strings_reads_declarative_profile;
-          test_case "resolves custom provider ids through protocol" `Quick
-            test_resolve_model_strings_uses_provider_protocol_for_custom_id;
-          test_case "derives profile metadata from cascade.toml" `Quick
-            test_cascade_profile_metadata_from_toml;
           test_case "accepts unrouted assignable catalog entry" `Quick
             test_cascade_name_accepts_unrouted_assignable_catalog_entry;
-          test_case "assignability follows preferred qualified profile" `Quick
-            test_keeper_assignability_uses_preferred_qualified_profile;
-          test_case "fallback preserves qualified source profile" `Quick
-            test_fallback_cascade_preserves_qualified_source_profile;
-          test_case "fallback returns canonical tier target" `Quick
-            test_fallback_cascade_returns_canonical_tier_target;
-          test_case "declared public names canonicalize to catalog members" `Quick
-            test_normalize_declared_name_canonicalizes_public_catalog_members;
           test_case "keeper runtime ignores non-keeper route target" `Quick
             test_keeper_runtime_declared_name_ignores_non_keeper_route_target;
           test_case "surfaces declarative adapter errors" `Quick
@@ -1234,10 +879,6 @@ let () =
             test_runtime_validation_rejects_declarative_parse_errors;
           test_case "runtime rejects declarative adapter errors" `Quick
             test_runtime_validation_rejects_declarative_adapter_errors;
-          test_case "runtime rejects deprecated profile names" `Quick
-            test_runtime_validation_rejects_deprecated_profile_names;
-          test_case "rejects system-only catalog entry" `Quick
-            test_cascade_name_rejects_system_only_catalog_entry;
           test_case "accepts dispatch tool_access preset" `Quick
             test_tool_access_accepts_dispatch;
         ] );

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -845,12 +845,12 @@ let () =
           if not (List.mem actual C.valid_kind_strings) then
             Alcotest.failf "kind_to_string %S not in valid_kind_strings" actual)
           C.all_kinds;
-        Alcotest.(check int) "count" 2 (List.length C.all_kinds);
-        Alcotest.(check int) "strings count" 2
+        Alcotest.(check int) "count" 1 (List.length C.all_kinds);
+        Alcotest.(check int) "strings count" 1
           (List.length C.valid_kind_strings));
       Alcotest.test_case "valid_kind_strings pinned to wire format" `Quick (fun () ->
         Alcotest.(check (list string)) "wire-format names"
-          [ "failover"; "priority_tier" ]
+          [ "failover" ]
           Masc_mcp.Cascade_strategy.valid_kind_strings);
       Alcotest.test_case "parse_kind error mentions every valid kind" `Quick (fun () ->
         let module C = Masc_mcp.Cascade_strategy in


### PR DESCRIPTION
## 목적

`tier` / `tier-group` 개념과 그 구현을 cascade 전반에서 제거합니다. Cascade 중심에서 **Runtime 중심**으로 전환하는 작업의 일부이며, 런타임 전략 ADT를 실제로 출하 중인 `Failover` 단일 variant로 수렴시킵니다.

하위호환은 유지하지 않습니다(요청). 레거시 `[tier.X]` / `[tier-group.X]` 테이블은 더 이상 예약 네임스페이스가 아니며, 파싱 시 잘못된 binding으로 거부됩니다.

## 변경 범위

**런타임 코어 (lib/cascade)**
- `cascade_strategy`: `Priority_tier` variant, `tiers` 필드, `tier_for_cycle`, `priority_tier_order`, `signal_cascade_name`, `has_capacity`/`filter_capacity`, starvation-guard 메트릭 제거. `order_candidates`가 단일 `Failover` arm으로 수렴. `all_kinds = [ Failover ]`.
- `cascade_catalog_runtime`(_named_providers): `tiered_provider` / `admission_key` 배관 제거. named provider를 평범한 `(cfg, None)` 쌍으로 해소.
- `cascade_runtime_candidate`: `admission_key` 필드 + 기본 helper 제거.
- `cascade_config_loader` / `cascade_config_strategy_resolve`: `tiers` 필드 + `read_tiers_field` 제거. 전략은 `{ kind; cycle }`만으로 해소.
- `cascade_metrics`(_registry): `strategy_starvation_guard` 카운터 제거.

**Keeper (lib/keeper)**
- `keeper_turn_driver`(_admission/_named_resolution): named resolution과 admission에서 `tiered_providers` 튜플 슬롯 제거.

**명세**
- `CascadeStrategy.tla`: `StrategyKindSet -> {"failover"}`. `specs/INDEX.md` 재생성 (해시/타임스탬프 갱신). OCaml↔TLA parity 테스트 통과.

**테스트**
- declarative fixture를 `[tier.X]` / `[tier-group.X]` → RFC-0058 `[profiles.X]` capability 모델로 현대화(검증 의도가 살아남는 경우).
- 의미 자체가 제거된 tier 개념인 단언은 삭제: `is_system_only` tier-group, tier-group public assignability, fallback canonical tier target, deprecated profile-name 거부 등.

## 검증 상태 (정직 보고)

- ✅ `dune build --root .` **exit 0** (전 파일 컴파일 통과; dune-project의 pre-existing duplicate-dep 경고는 본 변경 무관).
- ✅ 직접 영향 테스트 7/8 green: `test_cascade_strategy`, `test_cascade_strategy_labels`, `test_tla_literal_parity`, `test_cascade_declarative_adapter`, `test_cascade_declarative_parser`, `test_cascade_declarative_validator`, `test_cascade_capability_gate`, `test_cascade_catalog_runtime_yojson`.
- ⚠️ `test_keeper_toml_config_validation`: **3 failures / 20 tests** (검증 미완 — 본 Draft에서 follow-up 예정):
  - case 6 `surfaces declarative adapter errors`, case 9 `runtime rejects declarative adapter errors`: 현대화한 `[undeclared_provider]` fixture가 `Binding_resolution_failed`를 트리거하지 않음. 정정 방향 확인됨 — 선언된 provider에 `protocol="provider_a-http"`(Messages_api) → `provider_kind_for_http_provider`가 None 반환 → `Binding_resolution_failed`.
  - case 0 `rejects unknown cascade_name` (`definitely_missing_profile`): tier 무관으로 추정, 원인 규명 중.

## 범위 외 (별도 부채)

origin/main 베이스에는 tier와 무관한 pre-existing 테스트 실패가 광범위하게 존재합니다(`test_keeper_unified`의 world-observation/sandbox 등 다수). `git stash`로 본 변경이 회귀를 일으키지 않음을 확인했습니다. 본 PR 범위에 포함하지 않으며 별도 이슈로 다룹니다.

## Draft 사유

사용자 요청으로 검증 완료 전 Draft를 먼저 올립니다. File 4의 3건(cases 6/9/0)을 같은 브랜치에 follow-up commit으로 정리한 뒤 Ready 전환을 검토합니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
