### PR TITLE
refactor(dashboard): consolidate JSON helpers to Json_util SSOT

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -25,10 +25,6 @@ let compute_outcomes_rollup = Outcomes.compute_outcomes_rollup
    last_latency_ms_json moved to Dashboard_http_keeper_types
    (intra-library file split, 2026-05-16). *)
 
-(* json_string_list_member + json_string_member_opt +
-   terminal_reason_code_of_decision_json moved to
-   Dashboard_http_keeper_types (intra-library file split, 2026-05-16). *)
-
 let keeper_trust_json = Trust.keeper_trust_json
 
 (* execution_trust_source / _producer / _dashboard_surface / _freshness_slo_s

--- a/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
+++ b/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
@@ -153,19 +153,19 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                     Json_util.json_string_list missing_required_tools );
                   ( "turn_lane",
                     Json_util.string_opt_to_json
-                      (json_string_member_opt "turn_lane" tool_decision) );
+                      (Json_util.get_string tool_decision "turn_lane") );
                   ( "tool_surface_class",
                     Json_util.string_opt_to_json
-                      (json_string_member_opt "tool_surface_class"
-                         tool_decision) );
+                      (Json_util.get_string tool_decision
+                         "tool_surface_class") );
                   ( "tool_requirement",
                     Json_util.string_opt_to_json
                       (first_string_opt
                          [
-                           json_string_member_opt "tool_requirement"
-                             tool_decision;
-                           json_string_member_opt "tool_requirement"
-                             lane_decision;
+                           Json_util.get_string tool_decision
+                             "tool_requirement";
+                           Json_util.get_string lane_decision
+                             "tool_requirement";
                          ]) );
                   ( "visible_tool_count",
                     Json_util.int_opt_to_json
@@ -195,7 +195,7 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                   ("status", Json_util.string_opt_to_json provider_lane_status);
                   ( "resolved_lane",
                     Json_util.string_opt_to_json
-                      (json_string_member_opt "resolved_lane" lane_decision)
+                      (Json_util.get_string lane_decision "resolved_lane")
                   );
                   ( "effective_tool_count",
                     Json_util.int_opt_to_json

--- a/lib/server/server_dashboard_http_keeper_api_scan_summary.ml
+++ b/lib/server/server_dashboard_http_keeper_api_scan_summary.ml
@@ -21,8 +21,8 @@
 open Server_dashboard_http_keeper_api_types
 
 let receipt_row_matches ?turn_id keeper_name trace_id json =
-  let keeper_matches = json_string_member_opt "keeper_name" json = Some keeper_name in
-  let trace_matches = json_string_member_opt "trace_id" json = Some trace_id in
+  let keeper_matches = Json_util.get_string json "keeper_name" = Some keeper_name in
+  let trace_matches = Json_util.get_string json "trace_id" = Some trace_id in
   let turn_matches =
     match turn_id with
     | None -> false

--- a/lib/server/server_dashboard_http_keeper_api_summary_aggregates.ml
+++ b/lib/server/server_dashboard_http_keeper_api_summary_aggregates.ml
@@ -17,7 +17,7 @@ let provider_attempts_summary_json (scan : runtime_manifest_scan) : Yojson.Safe.
   let terminal = scan.provider_terminal_row in
   let terminal_decision_string key =
     Option.bind terminal (fun row ->
-      json_string_member_opt key row.Keeper_runtime_manifest.decision)
+      Json_util.get_string row.Keeper_runtime_manifest.decision key)
   in
   `Assoc
     [ "started_count", `Int scan.provider_started_count

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -125,24 +125,10 @@ let extract_keeper_name_for_post req_path suffix =
   in
   if is_valid_keeper_name raw then raw else ""
 
-let json_string_member_opt = Json_util.get_string
-
-let json_string_list_member name json =
-  Json_util.json_string_list_member name json |> Json_util.dedupe_keep_order
-
 let take_last limit values =
   let len = List.length values in
   if len <= limit then values
   else List.filteri (fun idx _ -> idx >= len - limit) values
-
-let json_assoc_member_opt name json =
-  match Yojson.Safe.Util.member name json with
-  | `Assoc _ as value -> Some value
-  | _ -> None
-
-let json_string_value_opt = function
-  | `String value -> Some value
-  | _ -> None
 
 let manifest_row_matches ?turn_id keeper_name trace_id
     (row : Keeper_runtime_manifest.t) =
@@ -162,7 +148,7 @@ let unique_present_paths paths =
   |> Json_util.dedupe_keep_order
 
 let provider_attempt_row_json (row : Keeper_runtime_manifest.t) =
-  let decision_string key = json_string_member_opt row.decision key in
+  let decision_string key = Json_util.get_string row.decision key in
   `Assoc
     [
       ("ts", `String row.ts);
@@ -220,8 +206,8 @@ let tool_call_output_text_opt json =
   match Yojson.Safe.Util.member "output" json with
   | `String value -> Some value
   | `Assoc _ as output -> (
-    match json_assoc_member_opt "_blob" output with
-    | Some blob -> json_string_member_opt "preview" blob
+    match Json_util.assoc_member_opt "_blob" output with
+    | Some blob -> Json_util.get_string blob "preview"
     | None -> None)
   | _ -> None
 
@@ -234,21 +220,21 @@ let parse_tool_output_json_opt json =
     | Error _ -> None)
 
 let tool_call_runtime_contract json =
-  match json_assoc_member_opt "runtime_contract" json with
+  match Json_util.assoc_member_opt "runtime_contract" json with
   | Some contract -> contract
   | None -> `Assoc []
 
 let tool_call_matches_trace ?turn_id ~keeper_name ~trace_id json =
   let contract = tool_call_runtime_contract json in
   let keeper_matches =
-    match json_string_member_opt "keeper" json with
+    match Json_util.get_string json "keeper" with
     | Some keeper -> String.equal keeper keeper_name
     | None -> true
   in
   let trace_matches =
     match
-      ( json_string_member_opt "trace_id" json,
-        json_string_member_opt "trace_id" contract )
+      ( Json_util.get_string json "trace_id",
+        Json_util.get_string contract "trace_id" )
     with
     | Some value, _ | _, Some value -> String.equal value trace_id
     | None, None -> false
@@ -272,11 +258,11 @@ let string_has_prefix = Server_dashboard_http_json_utils.string_has_prefix
 
 let claim_status_of_output output =
   let result =
-    match json_string_member_opt "result" output with
+    match Json_util.get_string output "result" with
     | Some value -> String.trim value
     | None -> ""
   in
-  match json_assoc_member_opt "claimed_task" output with
+  match Json_util.assoc_member_opt "claimed_task" output with
   | Some _ -> "claimed"
   | None when string_has_prefix ~prefix:"No eligible tasks" result -> "no_eligible"
   | None when string_has_prefix ~prefix:"No unclaimed tasks" result -> "no_unclaimed"

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -76,17 +76,6 @@ val extract_keeper_name_for_post : string -> string -> string
 (** [extract_keeper_name_for_post path suffix]: variant used by the
     POST dispatcher. *)
 
-(** {1 Internal JSON / list helpers}
-
-    Pure Yojson member extractors + a small list utility, used across
-    keeper_dashboard_http_keeper_api.ml's many response-builder helpers.
-    Exposed here so the godfile keeps referencing them through include. *)
-
-val json_string_member_opt : string -> Yojson.Safe.t -> string option
-val json_string_list_member : string -> Yojson.Safe.t -> string list
-val json_assoc_member_opt : string -> Yojson.Safe.t -> Yojson.Safe.t option
-val json_string_value_opt : Yojson.Safe.t -> string option
-
 val manifest_row_matches :
   ?turn_id:int ->
   string ->

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
@@ -12,7 +12,7 @@ let clock_refs decision =
 
 let clock_string row key =
   match clock_refs row.Keeper_runtime_manifest.decision with
-  | Some refs -> json_string_member_opt key refs
+  | Some refs -> Json_util.get_string refs key
   | None -> None
 
 let clock_string_non_empty row key =
@@ -63,12 +63,12 @@ let fallback_checkpoint_id row =
   let decision = row.Keeper_runtime_manifest.decision in
   first_string_opt
     [
-      json_string_member_opt "session_id" decision
+      Json_util.get_string decision "session_id"
       |> Option.map (fun session_id ->
         Printf.sprintf "checkpoint:%s:oas-%s" session_id (oas_turn_label row));
       basename_opt row.Keeper_runtime_manifest.links.checkpoint_path
       |> Option.map (fun base -> "checkpoint:" ^ base);
-      json_string_member_opt "checkpoint_path" decision
+      Json_util.get_string decision "checkpoint_path"
       |> basename_opt
       |> Option.map (fun base -> "checkpoint:" ^ base);
     ]
@@ -191,14 +191,14 @@ let clock_edge_json ~idx ~provider_attempt_index row =
     first_string_opt
       [
         clock_string row "event_bus_correlation_id";
-        json_string_member_opt "correlation_id" decision;
+        Json_util.get_string decision "correlation_id";
       ]
   in
   let event_bus_run_id =
     first_string_opt
       [
         clock_string row "event_bus_run_id";
-        json_string_member_opt "run_id" decision;
+        Json_util.get_string decision "run_id";
       ]
   in
   let event_bus_event_count =
@@ -273,7 +273,7 @@ let clock_edge_json ~idx ~provider_attempt_index row =
       ] );
     ]
 
-let edge_string key edge = json_string_member_opt key edge
+let edge_string key edge = Json_util.get_string edge key
 let edge_int key edge = Json_util.get_int edge key
 let edge_string_list key edge = Json_util.get_string_list edge key
 

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_clock_groups.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_clock_groups.ml
@@ -8,7 +8,7 @@ open Server_dashboard_http_keeper_api_types
 open Server_dashboard_http_keeper_runtime_manifest_scan
 open Server_dashboard_http_keeper_runtime_lens_swimlane
 
-let edge_string key edge = json_string_member_opt key edge
+let edge_string key edge = Json_util.get_string edge key
 let edge_int key edge = Json_util.get_int edge key
 let edge_string_list key edge = Json_util.get_string_list edge key
 
@@ -183,7 +183,7 @@ let clock_group_open_gap ~code ~severity ~lane ~label groups =
   let open_ids =
     groups
     |> List.filter_map (fun group ->
-      match Json_util.get_bool group "closed", json_string_member_opt "group_id" group with
+      match Json_util.get_bool group "closed", Json_util.get_string group "group_id" with
       | Some false, Some group_id when String.trim group_id <> "" -> Some group_id
       | _ -> None)
   in
@@ -204,7 +204,7 @@ let runtime_lens_clock_group_gaps scan =
   let groups = clock_group_jsons scan in
   let groups_of_type group_type =
     List.filter
-      (fun group -> json_string_member_opt "group_type" group = Some group_type)
+      (fun group -> Json_util.get_string group "group_type" = Some group_type)
       groups
   in
   let edge_ids =

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
@@ -80,8 +80,8 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
     || scan.context_compacted_event_count > 0
     || scan.event_bus_count > 0
   in
-  let claim_status = json_string_member_opt "status" claim_scope in
-  let claim_mode = json_string_member_opt "mode" claim_scope in
+  let claim_status = Json_util.get_string claim_scope "status" in
+  let claim_mode = Json_util.get_string claim_scope "mode" in
   let claim_excluded_count = Json_util.get_int claim_scope "excluded_count" in
   let cascade_override =
     Option.value
@@ -92,8 +92,8 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
     match scan.latest_pre_dispatch_blocked_row with
     | Some row ->
       first_string_opt
-        [ json_string_member_opt "reason" row.Keeper_runtime_manifest.decision
-        ; json_string_member_opt "terminal_reason_code" row.Keeper_runtime_manifest.decision
+        [ Json_util.get_string row.Keeper_runtime_manifest.decision "reason"
+        ; Json_util.get_string row.Keeper_runtime_manifest.decision "terminal_reason_code"
         ; Some row.Keeper_runtime_manifest.status
         ]
     | None -> None
@@ -151,10 +151,10 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
                Some
                  (Printf.sprintf "default=%s live=%s"
                     (Option.value
-                       (json_string_member_opt "default_cascade_name" config_drift)
+                       (Json_util.get_string config_drift "default_cascade_name")
                        ~default:"unknown")
                     (Option.value
-                       (json_string_member_opt "live_cascade_name" config_drift)
+                       (Json_util.get_string config_drift "live_cascade_name")
                        ~default:"unknown"))
            }
            gaps
@@ -417,7 +417,7 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
          match scan.provider_terminal_row with
          | Some row ->
            let decision = row.Keeper_runtime_manifest.decision in
-           (match json_string_member_opt "terminal_provider_kind" decision with
+           (match Json_util.get_string decision "terminal_provider_kind" with
             | Some _ -> gaps
             | None ->
               { code = "provider_provenance_missing"
@@ -478,7 +478,7 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
          | Some row ->
            let decision = row.Keeper_runtime_manifest.decision in
            let clock_refs = Yojson.Safe.Util.member "clock_refs" decision in
-           (match json_string_member_opt "compaction_source" clock_refs with
+           (match Json_util.get_string clock_refs "compaction_source" with
             | Some _ -> gaps
             | None ->
               { code = "compaction_source_missing"
@@ -492,7 +492,7 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
          match scan.latest_context_injected_row with
          | Some row ->
            let decision = row.Keeper_runtime_manifest.decision in
-           (match json_string_member_opt "context_digest" decision with
+           (match Json_util.get_string decision "context_digest" with
             | Some _ -> gaps
             | None ->
               { code = "context_digest_missing"
@@ -506,7 +506,7 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
          match scan.latest_memory_injected_row with
          | Some row ->
            let decision = row.Keeper_runtime_manifest.decision in
-           (match json_string_member_opt "payload_digest" decision with
+           (match Json_util.get_string decision "payload_digest" with
             | Some _ -> gaps
             | None ->
               { code = "memory_payload_digest_missing"

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml
@@ -104,8 +104,8 @@ let runtime_lens_text_contains text needle =
   string_contains ~needle text
 
 let runtime_lens_call_has_docker_proof json output_opt text =
-  json_string_member_opt "sandbox_profile" json = Some "docker"
-  || json_string_member_opt "sandbox_profile" (tool_call_runtime_contract json)
+  Json_util.get_string json "sandbox_profile" = Some "docker"
+  || Json_util.get_string (tool_call_runtime_contract json) "sandbox_profile"
      = Some "docker"
   || runtime_lens_text_contains text "\"sandbox_profile\":\"docker\""
   || runtime_lens_text_contains text "\"via\":\"docker\""
@@ -143,7 +143,7 @@ let runtime_lens_call_has_repo_cli_identity output_opt text =
 
 let runtime_lens_collect_profile acc json =
   let add_from table field source =
-    match json_string_member_opt field source with
+    match Json_util.get_string source field with
     | Some value -> runtime_lens_set_add table value
     | None -> ()
   in
@@ -155,7 +155,7 @@ let runtime_lens_collect_profile acc json =
 let runtime_lens_accumulate_tool_proof acc json =
   acc.matched_tool_call_count <- acc.matched_tool_call_count + 1;
   runtime_lens_update_latest_ts acc json;
-  let tool = Option.value (json_string_member_opt "tool" json) ~default:"unknown_tool" in
+  let tool = Option.value (Json_util.get_string json "tool") ~default:"unknown_tool" in
   runtime_lens_set_add acc.tools tool;
   if Json_util.get_bool json "success" = Some true then (
     acc.successful_tool_call_count <- acc.successful_tool_call_count + 1;

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_summaries.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_summaries.ml
@@ -11,7 +11,7 @@ let claim_scope_summary_json ~keeper_name ~trace_id ?turn_id () =
     entries
     |> List.find_opt (fun json ->
       String.equal
-        (Option.value ~default:"" (json_string_member_opt "tool" json))
+        (Option.value ~default:"" (Json_util.get_string json "tool"))
         "keeper_task_claim"
       && tool_call_matches_trace ?turn_id ~keeper_name ~trace_id json)
   in
@@ -24,17 +24,17 @@ let claim_scope_summary_json ~keeper_name ~trace_id ?turn_id () =
       | _ -> `Assoc []
     in
     let claim_scope =
-      match json_assoc_member_opt "claim_scope" output with
+      match Json_util.assoc_member_opt "claim_scope" output with
       | Some scope -> scope
       | None -> `Assoc []
     in
-    let claimed_task = json_assoc_member_opt "claimed_task" output in
+    let claimed_task = Json_util.assoc_member_opt "claimed_task" output in
     `Assoc
       [ ("present", `Bool true)
       ; ("source", `String "keeper_task_claim_tool_call")
       ; ("status", `String (claim_status_of_output output))
-      ; ("result", Json_util.string_opt_to_json (json_string_member_opt "result" output))
-      ; ("mode", Json_util.string_opt_to_json (json_string_member_opt "mode" claim_scope))
+      ; ("result", Json_util.string_opt_to_json (Json_util.get_string output "result"))
+      ; ("mode", Json_util.string_opt_to_json (Json_util.get_string claim_scope "mode"))
       ; ( "scoped",
           match Json_util.get_bool claim_scope "scoped" with
           | Some value -> `Bool value
@@ -45,24 +45,24 @@ let claim_scope_summary_json ~keeper_name ~trace_id ?turn_id () =
           Json_util.json_string_list
             (Json_util.get_string_list claim_scope "effective_goal_ids") )
       ; ( "fallback_reason",
-          Json_util.string_opt_to_json (json_string_member_opt "fallback_reason" claim_scope) )
+          Json_util.string_opt_to_json (Json_util.get_string claim_scope "fallback_reason") )
       ; ( "matched_goal_id",
-          Json_util.string_opt_to_json (json_string_member_opt "matched_goal_id" claim_scope) )
+          Json_util.string_opt_to_json (Json_util.get_string claim_scope "matched_goal_id") )
       ; ( "excluded_count",
-          match json_int_member_opt "excluded_count" claim_scope with
+          match Json_util.get_int claim_scope "excluded_count" with
           | Some value -> `Int value
           | None -> `Null )
       ; ( "claimed_task_id",
           match claimed_task with
-          | Some task -> Json_util.string_opt_to_json (json_string_member_opt "task_id" task)
+          | Some task -> Json_util.string_opt_to_json (Json_util.get_string task "task_id")
           | None -> `Null )
       ; ( "claimed_goal_id",
           match claimed_task with
-          | Some task -> Json_util.string_opt_to_json (json_string_member_opt "goal_id" task)
+          | Some task -> Json_util.string_opt_to_json (Json_util.get_string task "goal_id")
           | None -> `Null )
-      ; ("trace_id", Json_util.string_opt_to_json (json_string_member_opt "trace_id" call))
+      ; ("trace_id", Json_util.string_opt_to_json (Json_util.get_string call "trace_id"))
       ; ( "keeper_turn_id",
-          match json_int_member_opt "keeper_turn_id" call with
+          match Json_util.get_int call "keeper_turn_id" with
           | Some value -> `Int value
           | None -> `Null )
       ]
@@ -71,7 +71,7 @@ let find_override_field_source field sources =
   match Yojson.Safe.Util.member "override_field_sources" sources with
   | `List values ->
     List.find_opt
-      (fun value -> json_string_member_opt "field" value = Some field)
+      (fun value -> Json_util.get_string value "field" = Some field)
       values
   | _ -> None
 
@@ -110,8 +110,8 @@ let config_drift_summary_json ~config ~keeper_name =
     let default_cascade_name, live_cascade_name =
       match cascade_detail with
       | Some detail ->
-        ( Yojson.Safe.Util.member "default_value" detail |> json_string_value_opt,
-          Yojson.Safe.Util.member "live_value" detail |> json_string_value_opt )
+        ( Yojson.Safe.Util.member "default_value" detail |> Yojson.Safe.Util.to_string_option,
+          Yojson.Safe.Util.member "live_value" detail |> Yojson.Safe.Util.to_string_option )
       | None -> (None, None)
     in
     let cascade_override = Option.is_some cascade_detail in
@@ -129,10 +129,10 @@ let config_drift_summary_json ~config ~keeper_name =
       ; ("default_cascade_name", Json_util.string_opt_to_json default_cascade_name)
       ; ("live_cascade_name", Json_util.string_opt_to_json live_cascade_name)
       ; ( "active_config_root",
-          Json_util.string_opt_to_json (json_string_member_opt "active_config_root" sources) )
+          Json_util.string_opt_to_json (Json_util.get_string sources "active_config_root") )
       ; ( "active_config_root_source",
           Json_util.string_opt_to_json
-            (json_string_member_opt "active_config_root_source" sources) )
+            (Json_util.get_string sources "active_config_root_source") )
       ; ( "default_manifest_path",
-          Json_util.string_opt_to_json (json_string_member_opt "default_manifest_path" sources) )
+          Json_util.string_opt_to_json (Json_util.get_string sources "default_manifest_path") )
       ]

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
@@ -124,8 +124,8 @@ let update_runtime_manifest_scan scan row =
      let clock_refs = Yojson.Safe.Util.member "clock_refs" decision in
      match clock_refs with
      | `Assoc _ ->
-       let event_id = json_string_member_opt "event_id" clock_refs in
-       let parent_event_id = json_string_member_opt "parent_event_id" clock_refs in
+       let event_id = Json_util.get_string clock_refs "event_id" in
+       let parent_event_id = Json_util.get_string clock_refs "parent_event_id" in
        (match event_id, parent_event_id with
         | Some eid, Some peid -> Some (peid, eid)
         | _ -> None)
@@ -155,7 +155,7 @@ let update_runtime_manifest_scan scan row =
     in
     match clock_refs with
     | `Assoc _ ->
-      (match json_string_member_opt "source_clock" clock_refs with
+      (match Json_util.get_string clock_refs "source_clock" with
        | Some clock -> (
          match Keeper_runtime_manifest.source_clock_of_string clock with
          | Some valid -> Keeper_runtime_manifest.source_clock_to_string valid
@@ -206,10 +206,10 @@ let update_runtime_manifest_scan scan row =
    | Keeper_runtime_manifest.Event_bus_correlated ->
      let decision = row.Keeper_runtime_manifest.decision in
      scan.event_bus_count <- scan.event_bus_count + 1;
-     (match json_string_member_opt "correlation_id" decision with
+     (match Json_util.get_string decision "correlation_id" with
       | Some value -> scan.event_bus_correlation_ids <- value :: scan.event_bus_correlation_ids
       | None -> ());
-     (match json_string_member_opt "run_id" decision with
+     (match Json_util.get_string decision "run_id" with
       | Some value -> scan.event_bus_run_ids <- value :: scan.event_bus_run_ids
       | None -> ());
      scan.context_compact_started_count <-


### PR DESCRIPTION
## Summary

- **2 unbound `json_int_member_opt` calls** replaced with `Json_util.get_int` (build fix — these were left unbound after RFC-0205 Phase 1 removed the `Keeper_types` include chain)
- **~30 `json_string_member_opt` usages** across 12 dashboard files replaced with `Json_util.get_string` (canonical SSOT, correct `json key` argument order)
- **~5 `json_assoc_member_opt` usages** replaced with `Json_util.assoc_member_opt`
- **Alias definitions removed** from `api_types.ml` + `.mli` — the intermediate layer (`json_string_member_opt`, `json_assoc_member_opt`, `json_string_value_opt`, `json_string_list_member`) is no longer needed
- **Stale comment** removed from `dashboard_http_keeper.ml`

## Files changed (12)

| File | Change |
|------|--------|
| `api_types.ml` | Removed 4 alias definitions + replaced 7 internal usages |
| `api_types.mli` | Removed 4 stale `val` signatures |
| `api_runtime_lens.ml` | 5 usages → `Json_util.get_string`/`get_int` |
| `api_scan_summary.ml` | 2 usages → `Json_util.get_string` |
| `api_summary_aggregates.ml` | 1 usage → `Json_util.get_string` |
| `runtime_lens_clock_edges.ml` | 6 usages → `Json_util.get_string` |
| `runtime_lens_clock_groups.ml` | 3 usages → `Json_util.get_string` |
| `runtime_lens_gaps.ml` | 10 usages → `Json_util.get_string` |
| `runtime_lens_proof.ml` | 4 usages → `Json_util.get_string` |
| `runtime_lens_summaries.ml` | 15 usages → `Json_util.get_string`/`get_int`/`assoc_member_opt` |
| `runtime_manifest_scan.ml` | 5 usages → `Json_util.get_string` |
| `dashboard_http_keeper.ml` | Removed stale comment |

## Why

The `json_string_member_opt` alias had **wrong argument order** (`key json` instead of `json key`), creating a silent bug vector. The `json_int_member_opt` symbol was **completely unbound** — a build error masked by CI behavior. All JSON option accessors should go through `Json_util` as the single source of truth.

## Test plan

- [ ] CI build passes
- [ ] Dashboard runtime-trace endpoint returns correct JSON structure
- [ ] No regressions in keeper dashboard pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>