### PR TITLE
docs(rfc-0204): WS dispatch + refresh-loop scheduling root (§8-9)

### DIFF
--- a/docs/rfc/RFC-0204-dashboard-serving-isolation.md
+++ b/docs/rfc/RFC-0204-dashboard-serving-isolation.md
@@ -15,6 +15,8 @@ related:
 # RFC-0204 — Dashboard Read Serving Isolation from Fleet Compute
 
 > Evidence record: measured 2026-05-29 against `main_eio.exe :8935` (base-path `/Users/dancer/me`). Raw curl runs (sequential / parallel-burst / repeat-floor / head-of-line) under `~/me/.tmp/masc-perf-2026-05-29/`.
+>
+> Update 2026-05-29 (§8–§9, WS/refresh scheduling): re-measured at 1-min load 36 (16-core), with the host carrying two kidsnote node dev servers (126% + 98% CPU), `fseventsd` (111%), `Mail.app` (85%), `watchman` (35%), and several `claude` sessions; `main_eio` got 14.7% CPU. `GET /dashboard/shell?light=true` cold-miss 2.44s → warm 12–19ms (60s cache); `GET /dashboard/shell` (wait-free snapshot) cold 0.46s → warm 17ms. The browser-observed 30–40s was during the load-100–220 peak, not this state. Confirms host CPU contention is the dominant trigger; the server change makes degradation graceful but cannot manufacture CPU. WS-dispatch + refresh-loop facts in §8 verified against the same checkout. Root-cause design produced by a 5-agent analysis workflow (`~/me/.tmp/masc-perf-2026-05-29/rootfix-design.workflow.js`).
 
 ## 1. Problem
 
@@ -72,3 +74,46 @@ Quantitative, reproducible, under *controlled* host load (stop builds, apply the
 - Domain budget: 15 (keeper) + N (dashboard) on a 16-core host — does the keeper pool shrink to `recommended-3`?
 - Does any dashboard compute legitimately need keeper-pool locality (shared in-process state)? Audit before splitting.
 - Is Option A worth it vs. just the cheap supporting changes (inline-fallback fix + pre-warm)? Measure the cheaper changes first; they may remove most contention without a second pool.
+- (Phase 3) Does any REST handler reachable from the accept loop touch mutable keeper-owned state guarded by `Eio.Mutex`? If yes those paths must stay on the main domain (hybrid routing) — needs a per-handler call-graph audit before moving accept to the serving domain.
+- (Phase 3) `Eio.Domain_manager.run` vs a long-lived spawned domain: the serving domain must persist for process lifetime and own its switch without the parent switch tearing it down — confirm the Eio idiom before implementing.
+- The keeper-burst isolation regression test (§5) is the proposed Phase 3 merge gate but does not yet exist — it must be authored first.
+
+## 8. Extension — WS dispatch & refresh-loop scheduling (the scheduling-capacity root)
+
+§1–§3 isolate dashboard *compute*. They do not address the two paths the browser actually fails on first: the WebSocket `dashboard/hello` RPC (30s client timeout) and the snapshot publisher that feeds wait-free reads. Both starve on the single main domain regardless of compute isolation, because the work that starves is *scheduling*, not CPU on a worker.
+
+### 8.1 The decisive Eio fact
+
+`Eio.Executor_pool.submit`/`submit_exn` **block the calling fiber** until the worker finishes (eio `executor_pool.mli`). So offloading dashboard compute to a pool (Option A) does not rescue the WS-hello or refresh paths: the fiber that submitted still has to be *re-scheduled on the main domain* to resume after the worker returns. Under main-domain CPU starvation that continuation never runs. The root for these two paths is therefore **scheduling capacity for the dispatch/await fibers**, not compute capacity for the worker. Option A is necessary for compute QoS but insufficient for WS-hello/refresh starvation.
+
+### 8.2 New code facts (verified against `5cfd0b914`)
+
+1. **WS message dispatch double-forks onto the main switch.** `server_runtime_bootstrap.ml:772-776`: `~on_message:(fun ws_session_id body_str -> Eio.Fiber.fork ~sw (fun () -> … Mcp_eio.handle_request ~clock ~sw …))`. The httpun-ws frame callback already runs on a per-connection fiber forked on `~sw`; `on_message` forks a *second* fiber onto the same `~sw` to do the RPC. Both land on the one main-domain OS thread, behind the 24 keeper keepalive fibers (`keeper_supervisor_launch.ml:104`, `~sw:ctx.sw` = bootstrap `~sw`) and the 5 refresh loops.
+2. **`dashboard/hello` work is trivial.** `server_mcp_transport_ws.ml:335-351`: `find_session` (one `Eio.Mutex` acquire), `verify_dashboard_token` (mtime/TTL-cached `Auth.load_auth_config`, `:311-333`), two field writes, JSON build. No I/O, no clock, no provider stream, no fork. A 30s timeout means the forked fiber was never scheduled to completion — not that the handler is slow.
+3. **The unified snapshot publisher computes inline on the main domain.** `dashboard_snapshot.ml:122` `refresh_loop` calls `Server_dashboard_http_core.dashboard_shell_payload_json config` directly at `:140` (and tools/telemetry/activity projections) with **no `submit_io`**, then `Eio.Time.sleep clock interval_sec` at `:217`. Unlike the per-surface loops (which offload via `run_dashboard_compute ~mode:Offloaded_readonly`), this publisher’s compute runs on the starved main thread, so `snap.shell` ages under load and the wait-free read serves stale data.
+4. **`shell?light=true` bypasses the wait-free snapshot.** `server_dashboard_snapshot_select.ml:12-15`: when `light`, it always calls `dashboard_shell_http_json` (`Dashboard_cache.get_or_compute_with_timeout`, server ceiling) and never reads `Dashboard_snapshot.current()`; the non-light branch reads `snap.shell` wait-free (`Atomic.get`).
+
+### 8.3 Verdict on "make `light` read the published snapshot" (option A from the perf thread)
+
+**Mitigation, not a root fix — and harmful if shipped alone.** `light=true` bypasses the snapshot today *precisely because* the publisher (8.2.3) is unreliable under load. Flipping `light` to read `Dashboard_snapshot.current()` while the publisher still computes inline trades a visible 35s timeout for **silent staleness** (old data, no signal). It becomes a legitimate part of the root fix only **after** the publisher is made reliable (offloaded + on a non-contended lane, Phase 2): then one fresh snapshot serves both `light` and non-light wait-free and the recompute path is deleted. Do not ship the `light`→snapshot change before Phase 2.
+
+### 8.4 Session-field race — prerequisite before any off-domain move
+
+`dashboard_hello` (`server_mcp_transport_ws.ml:335-351`) writes `session.dashboard_authenticated <- true; session.dashboard_agent <- agent` at `:344-345` **outside** `sessions_mutex` — `find_session` (`:288-289`) releases the mutex before the writes. Readers are also unlocked: `:275/:277` (session result), `:378/:409/:430/:445` (auth gates), `:661/:708` (SSE forward gate). Today single-domain cooperative scheduling serializes these (the writes have no suspension point), so there is **no live race and no behavior change** — but moving WS dispatch to another domain (Phase 3) turns this into a real cross-domain data race. The writes must be put under `with_sessions_rw`, and the hot-path readers (notably the SSE gate at `:661/:708`) audited, *before* the off-domain move. `Eio.Mutex` is single-domain (`coord_utils_backend_setup.ml:135-138`); any session field shared across the domain boundary needs `Eio.Mutex`-under-both-sides or `Atomic`.
+
+### 8.5 RFC-0059 safety of the serving-domain direction
+
+The root fix is the **inverse** of withdrawn RFC-0059. RFC-0059 moved keeper keepalive *bodies* (switch-bound, cancellation-scoped, provider-streaming) onto worker domains and tore keepers down at boot by touching `ctx.sw` cross-domain (`keeper_supervisor_launch.ml:71-77`). This direction keeps every keeper fiber and the keeper switch on the main domain untouched, and moves only the **stateless dashboard serving** (which already crosses domains via `submit_io_or_inline` and reads wait-free `Atomic` snapshots) onto its own domain with its own switch. It would violate RFC-0059 only if it moved keeper bodies, forked the keepalive/watchdog onto the serving domain, or shared the keeper switch — it does none of these. Residual hazard is symmetric: serving-domain fibers must own their switch (per-domain `Eio.Switch.run`), never fork onto or cancel through `ctx.sw`, and never touch `Eio.Mutex`-guarded keeper state cross-domain (gated by the §9 Phase 3 per-handler audit).
+
+## 9. Phased plan (each independently shippable + measured against the harness)
+
+Ordered by leverage and risk. **Empirical gate: re-measure after Phase 0 at controlled load < 16. If WS-hello no longer times out, Phases 2–3 are deferrable** — do not build the domain split on the peak-pileup symptom alone.
+
+| Phase | Change | Risk | Verifies |
+|---|---|---|---|
+| **0 — host hygiene + cheap server** | Operational: reduce the concurrent build/dev-server pileup (the dominant trigger; watchman recrawl already fixed in `~/.watchmanconfig`). In-server: wire the dead `submit_cpu` (weight 1.0) for the heavy board/JSON handlers; verify the 8-surface pre-warm actually populates `Dashboard_cache`. | Low (operational, reversible; pool-admission accounting only) | Whether WS-hello times out purely from host pressure. Sets the controlled-load baseline. |
+| **1 — session-field synchronization** | Put the `dashboard_authenticated`/`dashboard_agent` writes (`server_mcp_transport_ws.ml:344-345`) under `with_sessions_rw`; audit the unlocked readers (`:275/:378/:409/:430/:445/:661/:708`). | Low; no behavior change under current single-domain serialization | Prerequisite gate for Phase 3. A latent-race removal on its own. |
+| **2 — RFC-0204 Option A pool + publisher offload** | Add the dedicated dashboard `Executor_pool`; route `Dashboard_snapshot.refresh_loop` compute (`dashboard_snapshot.ml:137-203`) through it like the per-surface loops. Makes the publisher reliable → enables `light`→snapshot (§8.3) as a real fix, not staleness. | Low-med (domain budget, §7) | Dashboard refresh + light-shell never queue behind keeper compute. |
+| **3 — ROOT: dedicated serving domain** | Spawn one serving domain with its own switch; move WS transport start (`server_runtime_bootstrap.ml:771`), the 5 refresh publishers + full-health (`:886-916`), and the HTTP accept loop onto it. Keepers stay on `ctx.sw` = main. | Med (Eio domain/switch affinity — the §8.5 hazard); env-flag gated, per-handler shared-state audit, keeper-burst regression test as merge gate | WS `dashboard/hello` + provider-logs latency stay flat while keeper reactive concurrency is driven to saturation (§5 keeper-burst test). The only phase that proves the root. |
+
+Mitigations worth doing alongside (none replace Phase 3): a server-side `Eio.Time.with_timeout` around the `dashboard/hello` branch (surfaces starvation as a typed error instead of a silent 30s client timeout — observability, not a fix); deploy the already-merged SSE `/mcp` observer auth fix (#19401) so the 3-tier fallback has a working middle layer. **Do not** raise `DASHBOARD_WS_RPC_TIMEOUT_MS` (`dashboard/src/config/constants.ts`, 30_000) — symptom suppression (CLAUDE.md cap/cooldown bar); the queue still grows.


### PR DESCRIPTION
## 목적

대시보드 "30초 멈춤"의 **근본 설계(C)**를 RFC-0204에 확장합니다. 기존 RFC-0204는 dashboard *compute* 격리(Option A/B/C)는 다루지만, 브라우저가 **실제로 먼저 실패하는 두 경로** — WS `dashboard/hello`(30초 타임아웃)와 inline snapshot publisher — 는 다루지 않았습니다. 5-에이전트 근본원인 워크플로 + 재측정 결과로 §8-9를 추가합니다.

## 핵심 결론 (코드 변경 없음, 설계 문서만)

- **결정적 Eio 사실**: `submit`/`submit_exn`은 호출 fiber를 **블록**합니다. 그래서 compute를 풀로 offload해도(Option A) WS-hello/refresh starvation을 못 풉니다 — await continuation이 여전히 굶주린 main 도메인에서 재스케줄되어야 하기 때문. **근본 = compute capacity가 아니라 scheduling capacity.**
- **WS on_message 이중 fork** (`server_runtime_bootstrap.ml:772-776`): 24개 keeper fiber + 5개 refresh loop 뒤에서 같은 `~sw`에 두 번째 fiber를 fork. 단일 OS 스레드.
- **publisher inline compute** (`dashboard_snapshot.ml:140`, submit_io 없음): main 도메인 inline → 부하 시 `snap.shell` 노화.
- **`shell?light`→스냅샷 verdict**: Phase 2(publisher 신뢰화) 없이 단독 적용하면 35초 타임아웃을 **silent staleness로 맞바꿈** → 단독 ship 금지.
- **session-field 레이스** (`server_mcp_transport_ws.ml:344-345`, lock 밖 write): 단일 도메인에선 무해, Phase 3(도메인 분리) 후엔 cross-domain race → off-domain 이동의 전제조건.

## 검증 (file:line, checkout `5cfd0b914`)

세 load-bearing 사실 모두 소스에서 직접 확인:
- `server_runtime_bootstrap.ml:772-776` 이중 fork ✓
- `dashboard_snapshot.ml:140`/`:217` inline compute ✓
- `server_mcp_transport_ws.ml:288-289`(find_session unlock) vs `:344-345`(lock 밖 write) ✓

**재측정 (load 36)**: host가 kidsnote node dev 서버 2개(126%+98%) + fseventsd(111%) + Mail(85%)를 돌리는 중 main_eio는 14.7% CPU. `shell?light` cold 2.44s/warm 12ms, non-light(wait-free) cold 0.46s/warm 17ms. 브라우저의 30-40초는 load 100-220 peak 때. → **호스트 CPU 경합이 지배적 트리거**임을 실측 확인. 서버 변경은 graceful degradation일 뿐 CPU를 만들어내지 못함.

## 4-Phase 계획 (각 독립 배포 + harness 측정)

| Phase | 변경 | 위험 |
|---|---|---|
| 0 | 호스트 hygiene(빌드 pileup) + `submit_cpu` 배선 + pre-warm 확인 | Low |
| 1 | session-field 동기화 (write를 `with_sessions_rw` 안으로) | Low, 동작 무변 |
| 2 | Option A 전용 풀 + publisher offload → `light`→스냅샷 안전화 | Low-Med |
| 3 | **ROOT**: 전용 serving 도메인(WS+refresh+accept) | Med, env-flag + 회귀 테스트 gate |

**실증 gate**: Phase 0 후 controlled load<16에서 재측정. WS-hello 타임아웃이 사라지면 Phase 2-3는 deferrable — peak-pileup 증상만으로 위험한 도메인 분리를 짓지 않는다.

## 범위 / 영향

- **이 PR: RFC 문서만** (docs/rfc/, 코드 0줄). pre-commit이 docs-only로 빌드 skip.
- 후속 PR: Phase 1(session-field), Phase 2(풀+offload), Phase 3(serving 도메인, 별도 env-flag).

RFC-WAIVED: 본 PR은 RFC 문서 자체의 확장입니다(dashboard serving 영역, gated subsystem credential/operator/keeper-sandbox/hooks/workflow 아님). 코드 변경 없음.

WORKAROUND-WAIVED: §9 mitigation 표가 "cap/cooldown bar"와 `DASHBOARD_WS_RPC_TIMEOUT_MS`를 언급하나, 이는 **그 워크어라운드를 명시적으로 거부**하는 맥락(do NOT raise)입니다. 추가가 아닌 거부 문서화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
