### PR TITLE
fix(cascade): apply synthetic retry_after default at capacity_backpressure construction

### DIFF
--- a/lib/keeper/keeper_turn_driver_backpressure.ml
+++ b/lib/keeper/keeper_turn_driver_backpressure.ml
@@ -47,7 +47,10 @@ let capacity_backpressure_of_http_error ?source ~cascade_name last_err =
            source =
              Option.value source ~default:Provider_capacity;
            detail = message;
-           retry_after_sec = retry_after;
+           retry_after_sec =
+             (match retry_after with
+              | Some _ -> retry_after
+              | None -> Some synthetic_retry_after_sec);
          })
   | Some
       (Llm_provider.Http_client.NetworkError
@@ -101,7 +104,10 @@ let capacity_backpressure_of_sdk_error
               cascade_name;
               source = Provider_capacity;
               detail;
-              retry_after_sec = retry_after;
+              retry_after_sec =
+                (match retry_after with
+                 | Some _ -> retry_after
+                 | None -> Some synthetic_retry_after_sec);
             }))
   | Agent_sdk.Error.Internal msg
     when message_looks_like_capacity_backpressure msg ->


### PR DESCRIPTION
## Summary

Two `Capacity_backpressure` construction sites in `keeper_turn_driver_backpressure.ml` passed the provider's `retry_after` directly without applying the synthetic 30s default when the provider omits the `Retry-After` header. This caused `retry_after_sec: null` in telemetry even though the cascade health tracker internally applied the synthetic backoff.

## Problem

The cascade health tracker already handles the `null` case by falling back to `default_capacity_backpressure_backoff_sec` (30s). However, the `Capacity_backpressure` error variant constructed at the caller level carried `retry_after_sec = None`, causing:

1. **Telemetry gap**: `retry_after_sec: null` in board/error posts despite an active 30s backoff
2. **Observability inconsistency**: Internal backoff logic and external telemetry disagree

## Fix

Apply the existing `synthetic_retry_after_sec` constant (already defined at line 14) at the two construction sites where it was missing:

- **HTTP `Capacity_exhausted` path** (line 50): `retry_after` from provider header → fallback to `Some synthetic_retry_after_sec`
- **SDK `CapacityExhausted` path** (line 104): `retry_after` from SDK error → fallback to `Some synthetic_retry_after_sec`

The two other construction sites (Local_resource_exhaustion, Internal msg) already applied the default correctly.

## Files Changed

- `lib/keeper/keeper_turn_driver_backpressure.ml` — 8 insertions, 2 deletions

## Test Plan

- [ ] `dune build @check` passes
- [ ] Existing capacity_backpressure tests continue to pass
- [ ] Verify telemetry shows `retry_after_sec: 30.0` instead of `null` for provider without Retry-After header

## Related

- Board post p-48065c45242e81c655d203bbd7fde6af (retry_after_sec null analysis)
- `cascade_health_tracker_config.ml`: `default_capacity_backpressure_backoff_sec = 30.0`
- `cascade_attempt_fsm_capacity_backpressure.ml`: `Cbr_synthetic_default` ADT

🤖 Generated with [Claude Code](https://claude.ai/code)