### PR TITLE
refactor(ssot): replace raw Yojson.Safe.Util.member with Json_util (round 3)

### DIFF
--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -371,26 +371,24 @@ let strict_assoc_params params =
            (Json_util.kind_name other))
 
 let cursor_param payload =
-  let open Yojson.Safe.Util in
-  match payload |> member "cursor" with
-  | `Null -> Ok None
-  | `String value ->
+  match Json_util.assoc_member_opt "cursor" payload with
+  | None -> Ok None
+  | Some (`String value) ->
       let trimmed = String.trim value in
       if trimmed = "" then
         Error "Invalid params: cursor must not be empty"
       else
         Ok (Some trimmed)
-  | other ->
+  | Some other ->
       Error
         (Printf.sprintf "Invalid params: cursor must be a string (received %s)"
            (Json_util.kind_name other))
 
 let bool_param payload key =
-  let open Yojson.Safe.Util in
-  match payload |> member key with
-  | `Null -> Ok false
-  | `Bool value -> Ok value
-  | other ->
+  match Json_util.assoc_member_opt key payload with
+  | None -> Ok false
+  | Some (`Bool value) -> Ok value
+  | Some other ->
       Error
         (Printf.sprintf "Invalid params: %s must be a boolean (received %s)"
            key (Json_util.kind_name other))
@@ -453,16 +451,15 @@ let cursor_only_params params =
            (Json_util.kind_name other))
 
 let validate_optional_meta payload =
-  match Yojson.Safe.Util.member "_meta" payload with
-  | `Null
-  | `Assoc _ -> Ok ()
-  | other ->
+  match Json_util.assoc_member_opt "_meta" payload with
+  | None
+  | Some (`Assoc _) -> Ok ()
+  | Some other ->
       Error
         (Printf.sprintf "Invalid params: _meta must be an object (received %s)"
            (Json_util.kind_name other))
 
 let requested_tool_list_params params =
-  let open Yojson.Safe.Util in
   let* fields = strict_assoc_params params in
   let allowed =
     [ "_meta"; "names"; "include_hidden"; "include_usage"; "cursor" ]
@@ -480,9 +477,9 @@ let requested_tool_list_params params =
     let payload = `Assoc fields in
     let* () = validate_optional_meta payload in
     let* names =
-      match payload |> member "names" with
-      | `Null -> Ok None
-      | `List items ->
+      match Json_util.assoc_member_opt "names" payload with
+      | None -> Ok None
+      | Some (`List items) ->
           items
           |> List.fold_left
                (fun acc item ->
@@ -497,7 +494,7 @@ let requested_tool_list_params params =
                           (Json_util.kind_name bad)))
                (Ok [])
           |> Result.map (fun names -> Some (List.rev names))
-      | other ->
+      | Some other ->
           Error
             (Printf.sprintf
                "Invalid params: names must be an array of strings (received %s)"
@@ -515,7 +512,6 @@ let requested_tool_list_params params =
       }
 
 let parse_cursor_only_params params =
-  let open Yojson.Safe.Util in
   let* fields = strict_assoc_params params in
   let allowed = [ "_meta"; "cursor" ] in
   let unknown =
@@ -530,10 +526,10 @@ let parse_cursor_only_params params =
   else
     let payload = `Assoc fields in
     let* () = validate_optional_meta payload in
-    match payload |> member "cursor" with
-    | `Null -> Ok { cursor = None }
-    | `String cursor -> Ok { cursor = Some cursor }
-    | other ->
+    match Json_util.assoc_member_opt "cursor" payload with
+    | None -> Ok { cursor = None }
+    | Some (`String cursor) -> Ok { cursor = Some cursor }
+    | Some other ->
         Error
           (Printf.sprintf
              "Invalid params: cursor must be a string (received %s)"

--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -465,7 +465,7 @@ let snapshot_json ?hearth ~limit config =
     Meta_cognition_rules.belief_rules
     |> List.filter_map (fun rule -> belief_json ~limit rule sources)
     |> List.sort (fun a b ->
-           let count_of json key = json |> Yojson.Safe.Util.member key |> Yojson.Safe.Util.to_int in
+           let count_of json key = Option.value ~default:0 (Json_util.get_int json key) in
            compare (count_of b "support_agent_count") (count_of a "support_agent_count"))
   in
   let total_belief_count = List.length all_beliefs in
@@ -473,9 +473,9 @@ let snapshot_json ?hearth ~limit config =
   let all_contested =
     all_beliefs
     |> List.filter (fun json ->
-           (match Yojson.Safe.Util.member "status" json with
-            | `String s -> String.equal s "contested"
-            | _ -> false))
+           (match Json_util.get_string json "status" with
+            | Some s -> String.equal s "contested"
+            | None -> false))
   in
   let total_contested_belief_count = List.length all_contested in
   let contested_beliefs = take limit all_contested in
@@ -483,10 +483,7 @@ let snapshot_json ?hearth ~limit config =
     Meta_cognition_rules.tension_rules
     |> List.filter_map (fun rule -> tension_json ~limit governance_cases rule sources)
     |> List.sort (fun a b ->
-           let count_of json =
-             json |> Yojson.Safe.Util.member "recurrence_count"
-             |> Yojson.Safe.Util.to_int
-           in
+           let count_of json = Option.value ~default:0 (Json_util.get_int json "recurrence_count") in
            compare (count_of b) (count_of a))
     |> take limit
   in
@@ -494,10 +491,7 @@ let snapshot_json ?hearth ~limit config =
     Meta_cognition_rules.desire_rules
     |> List.filter_map (fun rule -> desire_json ~limit rule sources)
     |> List.sort (fun a b ->
-           let count_of json =
-             json |> Yojson.Safe.Util.member "source_agent_count"
-             |> Yojson.Safe.Util.to_int
-           in
+           let count_of json = Option.value ~default:0 (Json_util.get_int json "source_agent_count") in
            compare (count_of b) (count_of a))
     |> take limit
   in
@@ -593,8 +587,8 @@ let assoc_subset_or_null json fields =
   | value -> value
 
 let first_item_or_null json key =
-  match Yojson.Safe.Util.member key json with
-  | `List (item :: _) -> item
+  match Json_util.assoc_member_opt key json with
+  | Some (`List (item :: _)) -> item
   | _ -> `Null
 
 let summary_json ?hearth config =
@@ -602,10 +596,10 @@ let summary_json ?hearth config =
   `Assoc
     [
       ( "stagnation_score",
-        Yojson.Safe.Util.member "stagnation_score" snapshot );
-      ("belief_count", Yojson.Safe.Util.member "total_belief_count" snapshot);
+        Option.value ~default:`Null (Json_util.assoc_member_opt "stagnation_score" snapshot) );
+      ("belief_count", Option.value ~default:`Null (Json_util.assoc_member_opt "total_belief_count" snapshot));
       ("contested_belief_count",
-        Yojson.Safe.Util.member "total_contested_belief_count" snapshot);
+        Option.value ~default:`Null (Json_util.assoc_member_opt "total_contested_belief_count" snapshot));
       ( "dominant_belief",
         assoc_subset_or_null
           (first_item_or_null snapshot "beliefs")

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -122,9 +122,8 @@ let handle_agent_update ?(tool_name = "masc_agent_update") ?(start_time = 0.0) c
   =
   let status = get_string_opt args "status" in
   let capabilities =
-    match Yojson.Safe.Util.member "capabilities" args with
-    | `Null -> None
-    | `List _ -> Some (get_string_list args "capabilities")
+    match Json_util.assoc_member_opt "capabilities" args with
+    | Some (`List _) -> Some (get_string_list args "capabilities")
     | _ -> None
   in
   result_to_response ~tool_name ~start_time


### PR DESCRIPTION
## Summary

- Replace direct `Yojson.Safe.Util.member` + `to_int`/`to_string` usage with `Json_util.assoc_member_opt` / `get_string` / `get_int` in 3 files
- 14 total usages removed (8 + 1 + 5)
- Follows PR #19406 (dashboard round 2) — continues the SSOT consolidation effort

## Changes

| File | Usages removed | Pattern |
|------|---------------|---------|
| `meta_cognition_snapshot.ml` | 8 | `count_of` helpers, status check, summary_json field extraction |
| `tool_agent.ml` | 1 | capabilities presence check |
| `mcp_server_eio_tool_profile.ml` | 5 | cursor_param, bool_param, validate_optional_meta, requested/parse params |

## Scope note

~150 `Yojson.Safe.Util.member` usages remain across 15+ files (see below). This PR targets the isolated, straightforward replacements. Remaining files have more complex `let open Yojson.Safe.Util in` patterns requiring per-file analysis.

**Intentionally excluded**: `lib/ide/` — RFC-0056 leaf-isolation invariant (local `string_opt_to_json` is correct architecture).

## Remaining sites (top 10)

```
meta_cognition_parse.ml:21
dashboard_http_keeper_trust.ml:21
voice_config.ml:19
dashboard_http_keeper.ml:13
server_dashboard_http_namespace_truth_support.ml:10
coord_goals.ml:10
dashboard_execution.ml:9
tool_input_validation.ml:8
dashboard_http_keeper_feeds.ml:7
keeper_status_detail_observability.ml:6
```

## Test plan

- [ ] `dune build .` passes
- [ ] Existing tests pass
- [ ] No behavioral change (pure refactor, `Yojson.Safe.Util.member` returns `Null` for missing keys; `Json_util.assoc_member_opt` returns `None` — mapped correctly in each match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>