### PR TITLE
test(cascade): fix #19405 follow-up — declarative adapter-error cases 6/9

### DIFF
--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -589,24 +589,26 @@ target = "tier.ollama_cloud_primary"
        ~config_path:cascade_path "tier.ollama_cloud_primary")
 
 let test_catalog_validator_surfaces_adapter_errors () =
-  (* RFC-0058: a binding whose provider is not declared in [providers.*]
-     yields a [Binding_resolution_failed] adapter error. *)
+  (* A binding on a Messages_api provider (protocol provider_a-http) cannot be
+     materialized: provider_kind_for_http_provider returns None for Messages_api,
+     so resolve_binding_config emits a [Binding_resolution_failed] adapter error.
+     (This replaced the legacy [tier.X] member-resolution trigger.) *)
   let cascade_toml =
     {|
-[providers.ollama]
-protocol = "ollama-http"
-endpoint = "http://localhost:11434"
+[providers.provider_a]
+protocol = "provider_a-http"
+endpoint = "https://api.provider_a.example"
 
 [models.qwen3]
 api-name = "qwen3:8b"
 max-context = 32768
 tools-support = true
 
-[undeclared_provider.qwen3]
+[provider_a.qwen3]
 max-concurrent = 1
 
 [routes.keeper_turn]
-target = "undeclared_provider.qwen3"
+target = "provider_a.qwen3"
 |}
   in
   with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->
@@ -703,24 +705,25 @@ tools-support = true
            errors)
 
 let test_runtime_validation_rejects_declarative_adapter_errors () =
-  (* RFC-0058: a binding referencing an undeclared provider produces a
-     [Binding_resolution_failed] adapter error that runtime validation rejects. *)
+  (* A binding on a Messages_api provider (protocol provider_a-http) yields a
+     [Binding_resolution_failed] adapter error (provider_kind None) that runtime
+     validation rejects. (Replaced the legacy [tier.X] member-resolution trigger.) *)
   let cascade_toml =
     {|
-[providers.ollama]
-protocol = "ollama-http"
-endpoint = "http://localhost:11434"
+[providers.provider_a]
+protocol = "provider_a-http"
+endpoint = "https://api.provider_a.example"
 
 [models.qwen3]
 api-name = "qwen3:8b"
 max-context = 32768
 tools-support = true
 
-[undeclared_provider.qwen3]
+[provider_a.qwen3]
 max-concurrent = 1
 
 [routes.keeper_turn]
-target = "undeclared_provider.qwen3"
+target = "provider_a.qwen3"
 |}
   in
   with_temp_config_dir cascade_toml @@ fun ~config_root:_ ~cascade_path ->


### PR DESCRIPTION
## 목적

PR #19405(tier/tier-group 제거)의 follow-up. 머지 당시 미완으로 남겨둔 `test_keeper_toml_config_validation`의 declarative adapter-error 검증 2건(case 6 / case 9)을 수정합니다.

#19405는 tier fixture를 현대화하면서 `[undeclared_provider.qwen3]` 형태를 썼는데, 이는 binding으로 인식되지 않아 adapter error를 전혀 발생시키지 않습니다(두 케이스가 의미를 잃고 실패).

## 변경

`test/test_keeper_toml_config_validation.ml` 1파일:

- `test_catalog_validator_surfaces_adapter_errors` (case 6)
- `test_runtime_validation_rejects_declarative_adapter_errors` (case 9)

두 fixture를 **선언된 provider**로 교체합니다 — `protocol = "provider_a-http"`(= `Messages_api`):

```toml
[providers.provider_a]
protocol = "provider_a-http"
endpoint = "https://api.provider_a.example"
[models.qwen3]
api-name = "qwen3:8b"
max-context = 32768
tools-support = true
[provider_a.qwen3]
max-concurrent = 1
[routes.keeper_turn]
target = "provider_a.qwen3"
```

`cascade_declarative_adapter.provider_kind_for_http_provider`는 `Messages_api`에 대해 `None`을 반환하므로, `resolve_binding_config`가 의도된 `Binding_resolution_failed`를 발생시킵니다. 두 케이스가 다시 검증 의미를 회복합니다.

## 검증 상태 (정직 보고)

- ⚠️ **CI는 현재 red입니다.** origin/main(`cde0e296b`)이 컴파일되지 않습니다. tier와 무관한 별도 refactor(아래)가 caller 갱신을 누락해 main이 깨진 상태이며, 이 PR은 그 위에 올라가므로 `Build and Test`가 lib 컴파일 단계에서 실패합니다.
- 이 PR의 변경 자체(test fixture)는 tier 무관이며 #19405 follow-up으로 독립적입니다. main이 green으로 복구되면 본 PR도 자동으로 green이 됩니다.
- 로컬 기준: `dune build --root .`는 broken-main의 4개 클러스터(① keeper_meta/sandbox_profile · ② SSOT JSON helper 잔여 · ③ blocker_class · ④ keeper_rollover 비exhaustive)에서 실패. 이 PR의 fixture 변경은 그 에러 집합과 무관(test 1파일).

## broken-main 의존성

main 컴파일 복구는 별도 PR로 진행 중입니다(여러 SSOT consolidation + RFC-0205 facade 제거가 caller 갱신을 미완으로 남긴 누적 결과). 본 PR은 그 PR이 머지되어 main이 green이 된 뒤 Ready 전환합니다.

## 범위 외

case 0 `rejects unknown cascade_name`은 tier 무관 pre-existing 실패로, base `7d5f1574f`에서도 동일하게 실패합니다(standalone `dune exec` 시, repo config dir 미설정으로 ambient cascade catalog 상태에 의존). 본 PR 범위에 포함하지 않습니다.

## Draft 사유

사용자 요청으로 broken-main 복구 전에 Draft를 먼저 올립니다. main green 복구 후 CI 통과를 확인하고 Ready 전환합니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
