### PR TITLE
refactor(ws): typed Atomic dashboard auth state (RFC-0204 Phase 1)

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -17,13 +17,23 @@
 let sha1 s =
   Digestif.SHA1.(digest_string s |> to_raw_string)
 
+(** Dashboard authentication state for a WebSocket session.  Set once by
+    [dashboard_hello] and then read on the SSE forward hot path and the
+    dashboard RPC auth gates.  Held in an [Atomic.t] on the session
+    ([dashboard_auth]) so the single write and the many reads stay tear-free
+    if dashboard serving moves off the main Eio domain (RFC-0204 §8.4,
+    Phase 1).  [Authenticated] carries the resolved agent name, or [None]
+    when the auth config permits tokenless dashboard reads. *)
+type dashboard_auth_state =
+  | Unauthenticated
+  | Authenticated of { agent : string option }
+
 (** Active WebSocket session state. *)
 type ws_session = {
   id: string;
   wsd: Httpun_ws.Wsd.t;
   mutable closed: bool;
-  mutable dashboard_authenticated: bool;
-  mutable dashboard_agent: string option;
+  dashboard_auth: dashboard_auth_state Atomic.t;
   mutable dashboard_route: string option;
   dashboard_slices: (string, unit) Hashtbl.t;
   mutable dashboard_seq: int;
@@ -40,6 +50,19 @@ type ws_session = {
   mutable dashboard_last_buffered_amount: int;
   mutable inbound_partial_text: Buffer.t option;
 }
+
+(** [true] when the dashboard handshake has completed for this state. *)
+let dashboard_auth_is_authenticated = function
+  | Unauthenticated -> false
+  | Authenticated _ -> true
+
+(** Resolved agent name for an authenticated state, [None] otherwise. *)
+let dashboard_auth_agent = function
+  | Unauthenticated -> None
+  | Authenticated { agent } -> agent
+
+(** Reads a session's current dashboard auth state (wait-free). *)
+let dashboard_auth session = Atomic.get session.dashboard_auth
 
 (** Registry of active WebSocket sessions. *)
 let sessions : (string, ws_session) Hashtbl.t = Hashtbl.create 16
@@ -130,8 +153,7 @@ let new_session ~id ~wsd =
     id;
     wsd;
     closed = false;
-    dashboard_authenticated = false;
-    dashboard_agent = None;
+    dashboard_auth = Atomic.make Unauthenticated;
     dashboard_route = None;
     dashboard_slices = Hashtbl.create 8;
     dashboard_seq = 0;
@@ -268,13 +290,14 @@ let dashboard_session_result session =
       session.dashboard_slices []
     |> List.sort compare
   in
+  let auth = dashboard_auth session in
   `Assoc
     [
       ("protocol", `String "dashboard-ws.v1");
       ("session_id", `String session.id);
-      ("authenticated", `Bool session.dashboard_authenticated);
+      ("authenticated", `Bool (dashboard_auth_is_authenticated auth));
       ( "agent",
-        match session.dashboard_agent with
+        match dashboard_auth_agent auth with
         | Some agent -> `String agent
         | None -> `Null );
       ( "route",
@@ -341,8 +364,10 @@ let dashboard_hello ~base_path ~session_id ?token () =
         match verify_dashboard_token ~base_path token with
         | Error msg -> Error msg
         | Ok agent ->
-            session.dashboard_authenticated <- true;
-            session.dashboard_agent <- agent;
+            (* Single writer per session: dashboard_hello is the only site
+               that sets the auth state, so Atomic.set (not compare_and_set)
+               is sufficient.  Revisit if a second writer is introduced. *)
+            Atomic.set session.dashboard_auth (Authenticated { agent });
             Ok (dashboard_auth_success_payload session))
   in
   Transport_metrics.observe_ws_dashboard_hello_latency
@@ -375,7 +400,7 @@ let dashboard_subscribe ~session_id ?route ~slices () =
   match find_session session_id with
   | None -> Error "WebSocket session not found"
   | Some session ->
-      if not session.dashboard_authenticated then
+      if not (dashboard_auth_is_authenticated (dashboard_auth session)) then
         Error "dashboard/subscribe requires dashboard/hello first"
       else begin
         let invalid =
@@ -406,7 +431,7 @@ let dashboard_unsubscribe ~session_id ?slices () =
   match find_session session_id with
   | None -> Error "WebSocket session not found"
   | Some session ->
-      if not session.dashboard_authenticated then
+      if not (dashboard_auth_is_authenticated (dashboard_auth session)) then
         Error "dashboard/unsubscribe requires dashboard/hello first"
       else begin
         with_sessions_rw (fun () ->
@@ -427,7 +452,7 @@ let dashboard_ping ~session_id () =
   match find_session session_id with
   | None -> Error "WebSocket session not found"
   | Some session ->
-      if not session.dashboard_authenticated then
+      if not (dashboard_auth_is_authenticated (dashboard_auth session)) then
         Error "dashboard/ping requires dashboard/hello first"
       else
         Ok
@@ -442,7 +467,7 @@ let dashboard_ack ~session_id ~seq ?buffered_amount () =
   match find_session session_id with
   | None -> Error "WebSocket session not found"
   | Some session ->
-      if not session.dashboard_authenticated then
+      if not (dashboard_auth_is_authenticated (dashboard_auth session)) then
         Error "dashboard/ack requires dashboard/hello first"
       else begin
         if seq > session.dashboard_last_ack_seq then
@@ -658,7 +683,7 @@ let client_buffer_limit_bytes () =
     authenticated dashboard sessions track bufferedAmount; anonymous
     sessions always pass. *)
 let session_is_backpressured session =
-  if not session.dashboard_authenticated then false
+  if not (dashboard_auth_is_authenticated (dashboard_auth session)) then false
   else
     let limit = client_buffer_limit_bytes () in
     limit > 0 && session.dashboard_last_buffered_amount >= limit
@@ -705,7 +730,7 @@ let send_dashboard_or_raw_sse session sse_event =
     Transport_metrics.inc_ws_throttled_delivery ();
     true
   end
-  else if session.dashboard_authenticated then begin
+  else if dashboard_auth_is_authenticated (dashboard_auth session) then begin
     (* Parse once and reuse for both the delta-build branch and the
        slice-mismatch decision.  parse_sse_dashboard_event hits a
        single-slot Atomic cache after the broadcast's first call, but

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -62,12 +62,19 @@
 
 (** {1 Session record} *)
 
+type dashboard_auth_state =
+  | Unauthenticated
+  | Authenticated of { agent : string option }
+(** Dashboard handshake state for a session.  Set once by [dashboard_hello],
+    read on the SSE forward hot path and the dashboard RPC auth gates.  Held
+    in an [Atomic.t] field so the single write and many reads are tear-free if
+    dashboard serving moves off the main Eio domain (RFC-0204 §8.4, Phase 1). *)
+
 type ws_session = {
   id : string;
   wsd : Httpun_ws.Wsd.t;
   mutable closed : bool;
-  mutable dashboard_authenticated : bool;
-  mutable dashboard_agent : string option;
+  dashboard_auth : dashboard_auth_state Atomic.t;
   mutable dashboard_route : string option;
   dashboard_slices : (string, unit) Hashtbl.t;
   mutable dashboard_seq : int;
@@ -83,6 +90,12 @@ type ws_session = {
     the dashboard handshake / ack state machine; see the
     [#10648] / dashboard-ws.v1 protocol notes in the .ml
     for the field semantics. *)
+
+val dashboard_auth_is_authenticated : dashboard_auth_state -> bool
+(** [true] once [dashboard_hello] has authenticated the session. *)
+
+val dashboard_auth_agent : dashboard_auth_state -> string option
+(** Resolved agent name for an [Authenticated] state, [None] otherwise. *)
 
 (** {1 SSE parse record} *)
 

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -626,6 +626,30 @@ let test_slice_fanout_flag_reads_env () =
         Alcotest.(check bool) "env=false → disabled"
           false (Ws.slice_index_enabled ())))
 
+(* ====== Dashboard auth state (RFC-0204 §8.4, Phase 1) ====== *)
+
+let test_dashboard_auth_unauthenticated () =
+  Alcotest.(check bool) "Unauthenticated is not authenticated"
+    false (Ws.dashboard_auth_is_authenticated Ws.Unauthenticated);
+  Alcotest.(check (option string)) "Unauthenticated carries no agent"
+    None (Ws.dashboard_auth_agent Ws.Unauthenticated)
+
+let test_dashboard_auth_authenticated_with_agent () =
+  let st = Ws.Authenticated { agent = Some "garnet" } in
+  Alcotest.(check bool) "Authenticated counts as authenticated"
+    true (Ws.dashboard_auth_is_authenticated st);
+  Alcotest.(check (option string)) "agent name is carried through"
+    (Some "garnet") (Ws.dashboard_auth_agent st)
+
+let test_dashboard_auth_authenticated_tokenless () =
+  (* An auth config that permits tokenless dashboard reads resolves to an
+     authenticated state with no agent name. *)
+  let st = Ws.Authenticated { agent = None } in
+  Alcotest.(check bool) "tokenless still counts as authenticated"
+    true (Ws.dashboard_auth_is_authenticated st);
+  Alcotest.(check (option string)) "tokenless carries no agent"
+    None (Ws.dashboard_auth_agent st)
+
 let () =
   Alcotest.run "WebSocket Transport" [
     ("session_registry", [
@@ -722,5 +746,13 @@ let () =
         test_slice_fanout_flag_default_is_on;
       Alcotest.test_case "flag reads env var" `Quick
         test_slice_fanout_flag_reads_env;
+    ]);
+    ("dashboard_auth_state", [
+      Alcotest.test_case "Unauthenticated has no auth and no agent" `Quick
+        test_dashboard_auth_unauthenticated;
+      Alcotest.test_case "Authenticated carries the agent name" `Quick
+        test_dashboard_auth_authenticated_with_agent;
+      Alcotest.test_case "tokenless Authenticated has no agent" `Quick
+        test_dashboard_auth_authenticated_tokenless;
     ]);
   ]


### PR DESCRIPTION
## 목적

RFC-0204 **Phase 1** — dashboard WS 세션의 인증 상태(`dashboard_authenticated`/`dashboard_agent`)를 **typed `Atomic.t`** 로 동기화합니다. Phase 3(WS dispatch를 main Eio 도메인 밖으로)의 전제조건입니다.

## 변경

두 개의 비동기화 `mutable` 세션 필드
```
mutable dashboard_authenticated : bool
mutable dashboard_agent : string option
```
를 하나의 closed sum을 담은 `Atomic.t` 한 필드로 교체:
```ocaml
type dashboard_auth_state =
  | Unauthenticated
  | Authenticated of { agent : string option }

dashboard_auth : dashboard_auth_state Atomic.t   (* non-mutable; atomic box이 mutable cell *)
```
헬퍼: `dashboard_auth_is_authenticated`, `dashboard_auth_agent`, `dashboard_auth`(=`Atomic.get`).

## 왜 (트레이드오프)

이 필드들은 `dashboard_hello`에서 **`sessions_mutex` 밖에서** write되고(`find_session`이 write 전에 lock 반납), SSE forward hot-path(`session_is_backpressured`/`send_dashboard_or_raw_sse`)와 dashboard RPC auth gate(subscribe/unsubscribe/ping/ack)에서 lock 없이 read됩니다.

- **오늘(단일 Eio 도메인)**: 협조 스케줄링 + write에 suspension point 없음 → 직렬화됨 → **동작 변화 없음, live race 없음**.
- **Phase 3 이후(도메인 분리)**: 단일 atomic swap은 tear-free. 분리된 두 필드는 torn read(authenticated=true인데 agent 미설정)를 허용하고, broadcast hot-path에 Mutex를 걸면 경합 회귀.
- closed sum은 옛 `bool × option` 공간의 불가능 조합 `(authenticated=false, agent=Some _)`을 제거하고 read site(8개 helper 호출 / 7개 함수)에 컴파일러 exhaustive 검사를 강제. `Authenticated { agent = None }`은 tokenless/auth-disabled read로 유효(Parse-don't-validate).
- 모듈 기존 `Atomic` idiom(`client_buffer_limit_cache`, `slice_index_enabled_cache`)과 일치.

## 검증

- `dune build --root . lib/server` **exit 0** (내 변경 surface).
- `test/test_ws_transport.ml`에 `dashboard_auth_state` 테스트 그룹 추가(3 상태 predicate; 실제 `ws_session`은 `Wsd.t` 필요로 unit test 불가하므로 typed core를 직접 검증).
- 적대적 검증 워크플로(4 렌즈: 동작 보존 / 누락 사이트 sweep / OCaml-5 메모리 모델 / 스코프·테스트) — **verdict: `approve_with_nits`, behavior-preserving = yes, required_fixes = 0건** (confidence 0.95-0.99, 전 repo stale-ref sweep 0건). nit(커밋 메시지 과장 표현, single-writer 주석)은 본 커밋에 반영 완료.

> ⚠️ **CI 주의**: 현재 `origin/main`(`cde0e296b`)이 깨져 있습니다(미완 SSOT helper 마이그레이션 — `cascade_event_bridge.ml:140` 등 ~12파일이 제거된 unqualified helper 참조; `Detect Changed Surfaces` gate-skip으로 broken main 머지). full-lib/test 링크는 **본 변경과 무관하게** 차단됩니다. main 복구 후 rebase → green 예상. **이 PR은 main 복구 전까지 Draft 유지.**

## 범위

- 이 PR: auth pair만(Phase 1 범위). 같은 패턴의 다른 필드(`dashboard_route`/`dashboard_seq`/`dashboard_last_ack_seq`/`dashboard_last_buffered_amount`/`closed`)는 의도적 deferral(Phase 3 전 일괄 감사).
- 후속: Phase 2(Option A 풀+publisher offload), Phase 3(serving 도메인).

RFC-WAIVED: RFC-0204 §8.4가 명시한 Phase 1 구현. credential/operator/keeper-sandbox/hooks/workflow 변경 없음(인증 *저장/검증* 로직 불변 — auth state의 *동기화 표현*만 변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
