### PR TITLE
perf(dashboard): offload snapshot publisher compute to worker domain (RFC-0204 Phase 2)

### DIFF
--- a/lib/dashboard/dashboard_snapshot.ml
+++ b/lib/dashboard/dashboard_snapshot.ml
@@ -204,9 +204,19 @@ let refresh_loop
   in
   let rec loop () =
     (match
-       (* If the whole compute path fails (e.g. exception escapes a
+       (* Offload the snapshot compute to a worker domain (RFC-0204 sections 8-9
+          Phase 2).  The projection build (shell board scan + 3 activity
+          graphs) is CPU-heavy and previously ran inline on the main Eio
+          domain, contending with WS dispatch and keeper fibers under host
+          load.  [submit_cpu_or_inline] reserves a full worker slot
+          (weight 1.0, matching the per-surface refresh loops'
+          [run_dashboard_compute ~mode:Offloaded_readonly]) and falls back to
+          inline before the pool is installed at boot.  Every shared cell
+          [compute] touches is an [Atomic] ([slot], [generation_counter]), so
+          it is cross-domain safe; the publish ([Atomic.set slot]) stays on
+          this fiber.  If the whole compute path fails (an exception escapes a
           [safe] wrapper), keep the previous snapshot live. *)
-       try Some (compute ()) with
+       try Some (Domain_pool_ref.submit_cpu_or_inline compute) with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->
          log_failure "compute" exn;


### PR DESCRIPTION
## 목적

RFC-0204 **Phase 2 (step 1)** — `Dashboard_snapshot.refresh_loop`의 snapshot compute를 **worker 도메인으로 offload**합니다. 이게 `light`→스냅샷 fix("A")를 안전하게 만드는 publisher 신뢰화의 첫 단계입니다.

## 변경 (1줄 로직 + 주석)

`lib/dashboard/dashboard_snapshot.ml` `refresh_loop`:
```
- try Some (compute ()) with
+ try Some (Domain_pool_ref.submit_cpu_or_inline compute) with
```

`compute`는 7개 projection(shell board scan + tools + telemetry + namespace_truth + 3 activity graph)을 빌드합니다. 기존엔 이걸 **main Eio 도메인 inline**으로 실행 → WS dispatch·keeper fiber와 critical path 경합. 이제 worker 도메인에서 실행.

## 왜 (트레이드오프)

- **근본 분석(RFC-0204 §8)**: per-surface refresh loop는 이미 `run_dashboard_compute ~mode:Offloaded_readonly`로 offload하는데, **unified publisher만 inline**이었습니다(`dashboard_snapshot.ml:137-203`, submit 없음). 그래서 부하 시 publisher가 굶어 `snap.shell`이 노화 → wait-free read가 stale 제공.
- **weight 선택**: compute는 CPU-heavy(board 936KB JSON 빌드)라 `submit_cpu_or_inline`(weight 1.0)을 사용 — per-surface loop의 weight-1.0과 일치. RFC-0204 "Supporting changes"가 명시한 **dead `submit_cpu` 배선**(heavy 핸들러는 0.05 IO가 아닌 1.0 CPU)을 활성화(첫 production caller).
- **cross-domain 안전**: `compute`가 건드리는 공유 셀은 전부 Atomic(`slot : t option Atomic.t`, `generation_counter` via `Atomic.fetch_and_add`). projection 함수들은 light-shell 경로(`server_dashboard_http_core.ml:751`)에서 이미 worker로 offload되어 pool-safe 입증됨. publish(`Atomic.set slot`)는 calling fiber에 유지.
- **한계(정직)**: 공유 풀에 submit하므로 keeper 포화 시 `submit_*_or_inline`이 inline-on-main으로 fallback(현 동작과 동일). 완전 격리는 **Option A 전용 dashboard 풀**(후속 PR). 이 PR은 풀 여유 있는 일반 경우를 개선 + publisher 신뢰화의 전제.

## 검증

- `dune build --root . lib/dashboard` **exit 0**, `lib/server` **exit 0** (integration; refresh_loop 시그니처 불변).
- 적대적 검증 워크플로(2 렌즈: worker-domain 안전성 / 동작·cancellation·scope) — **실행 중(`w4tfam2om`); verdict는 완료 시 PR 코멘트로 반영.** lib-build는 이미 통과.
- ⚠️ full-lib/test 런타임 검증은 **본 변경 무관한 pre-existing main breakage**(미완 SSOT 마이그레이션, Issue #19390)로 차단. main green 후 측정.

## 범위 / 후속

- 이 PR: `refresh_loop`만(surgical). `bootstrap()` cold-path는 inline 유지(별도 1회성 warmup).
- 후속: `light`→스냅샤 read(server_dashboard_snapshot_select.ml, 본 PR로 publisher 신뢰화 후 안전), Option A 전용 dashboard 풀, Phase 3 serving 도메인.

RFC-WAIVED: RFC-0204 §8-9가 명시한 Phase 2 step 1. credential/operator/keeper-sandbox/hooks/workflow 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
