### PR TITLE
fix(coord): reject claim when agent tool surface unknown

### DIFF
--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -281,7 +281,13 @@ let required_tool_claim_guard config ~agent_name ?agent_tool_names task =
           ; "required_tools", `List (List.map (fun name -> `String name) required_tools)
           ; "ts", `String (now_iso ())
           ]);
-    Ok ()
+    Error
+      (Masc_domain.Task
+         (Masc_domain.Task_error.InvalidState
+            (Printf.sprintf
+               "Workflow rejected: task %s requires tool(s) but %s has no registered tool surface"
+               task.id
+               agent_name)))
   | _ :: _, Some allowed ->
     let missing = missing_required_tools ~allowed required_tools in
     if missing = []

--- a/test/dune
+++ b/test/dune
@@ -851,6 +851,7 @@
   test_board_karma_ledger
   test_task_dispatch
   test_coord_task_lifecycle
+  test_coord_task_classify_guard
   test_make_required_tools_predicate
   test_coord_task_verification_phase_e
   test_drift_guard_core
@@ -1074,6 +1075,7 @@
   test_board_karma_ledger
   test_task_dispatch
   test_coord_task_lifecycle
+  test_coord_task_classify_guard
   test_make_required_tools_predicate
   test_coord_task_verification_phase_e
   test_drift_guard_core

--- a/test/test_coord_task_classify_guard.ml
+++ b/test/test_coord_task_classify_guard.ml
@@ -1,0 +1,154 @@
+(** Unit tests for [Coord_task_classify.required_tool_claim_guard].
+
+    Validates that the guard correctly rejects claims when the agent's
+    tool surface is unknown ([agent_tool_names = None]) and the task
+    requires specific tools.  This prevents routing loops where agents
+    without the right tools claim tasks they cannot execute. *)
+
+module CTC = Coord_task_classify
+
+(* Minimal config stub — only [base_path] is used by [log_event]. *)
+let test_config : CTC.config =
+  { base_path = "/tmp/test-classify-guard"
+  ; workspace_path = "/tmp/test-classify-guard"
+  ; lock_expiry_minutes = 5
+  ; backend_config = Backend_types.default_config
+  ; backend = CTC.Memory (Backend.Memory.create ())
+  }
+
+let make_task ~id ~title ~description ~required_tools () : Masc_domain.task =
+  { id
+  ; title
+  ; description
+  ; priority = 3
+  ; task_status = Masc_domain.Todo
+  ; files = []
+  ; created_at = "2026-05-29T00:00:00Z"
+  ; created_by = None
+  ; goal_id = None
+  ; stage = None
+  ; contract =
+      (if required_tools = []
+       then None
+       else Some { Masc_domain.strict = false
+                 ; completion_contract = []
+                 ; required_tools
+                 ; required_evidence = []
+                 ; required_evidence_typed = []
+                 ; inspect_gate_evidence = []
+                 ; verify_gate_evidence = []
+                 ; links = { operation_id = None; session_id = None }
+                 })
+  ; handoff_context = None
+  ; cycle_count = 0
+  ; reclaim_policy = None
+  ; do_not_reclaim_reason = None
+  }
+
+(* -- agent_tool_names = None, required_tools non-empty → rejected -------- *)
+
+let test_none_with_required_tools_rejects () =
+  let task =
+    make_task ~id:"t1" ~title:"Run tests"
+      ~description:"Execute the test suite"
+      ~required_tools:[ "Bash"; "Read" ]
+      ()
+  in
+  (* Omit ~agent_tool_names to pass None *)
+  match CTC.required_tool_claim_guard test_config ~agent_name:"codex-mcp-client" task with
+  | Ok () ->
+    Alcotest.fail "expected rejection when agent_tool_names=None and required_tools non-empty"
+  | Error _ -> ()
+
+(* -- agent_tool_names = None, required_tools empty → accepted ----------- *)
+
+let test_none_with_empty_tools_accepts () =
+  let task =
+    make_task ~id:"t2" ~title:"Write docs"
+      ~description:"Update the README"
+      ~required_tools:[]
+      ()
+  in
+  (* Omit ~agent_tool_names to pass None *)
+  match CTC.required_tool_claim_guard test_config ~agent_name:"codex-mcp-client" task with
+  | Ok () -> ()
+  | Error e ->
+    Alcotest.failf "expected acceptance but got error: %s"
+      (Masc_domain.masc_error_to_string e)
+
+(* -- agent_tool_names = Some [...], all tools present → accepted -------- *)
+
+let test_some_with_all_tools_accepts () =
+  let task =
+    make_task ~id:"t3" ~title:"Run tests"
+      ~description:"Execute the test suite"
+      ~required_tools:[ "Bash"; "Read" ]
+      ()
+  in
+  match CTC.required_tool_claim_guard test_config ~agent_name:"keeper-helper"
+          ~agent_tool_names:[ "Bash"; "Read"; "Grep" ] task with
+  | Ok () -> ()
+  | Error e ->
+    Alcotest.failf "expected acceptance but got error: %s"
+      (Masc_domain.masc_error_to_string e)
+
+(* -- agent_tool_names = Some [...], missing tools → rejected ------------ *)
+
+let test_some_with_missing_tools_rejects () =
+  let task =
+    make_task ~id:"t4" ~title:"Run tests"
+      ~description:"Execute the test suite"
+      ~required_tools:[ "Bash"; "Read"; "Grep" ]
+      ()
+  in
+  match CTC.required_tool_claim_guard test_config ~agent_name:"codex-mcp-client"
+          ~agent_tool_names:[ "Read" ] task with
+  | Ok () ->
+    Alcotest.fail "expected rejection when required tools are missing"
+  | Error _ -> ()
+
+(* -- agent_tool_names = Some [] → rejected when tools required ---------- *)
+
+let test_empty_list_with_required_tools_rejects () =
+  let task =
+    make_task ~id:"t5" ~title:"Run tests"
+      ~description:"Execute the test suite"
+      ~required_tools:[ "Bash" ]
+      ()
+  in
+  match CTC.required_tool_claim_guard test_config ~agent_name:"codex-mcp-client"
+          ~agent_tool_names:[] task with
+  | Ok () ->
+    Alcotest.fail "expected rejection when agent has no tools but task requires some"
+  | Error _ -> ()
+
+let () =
+  Alcotest.run "coord_task_classify.required_tool_claim_guard"
+    [
+      ( "unknown surface (None)",
+        [
+          Alcotest.test_case
+            "required tools non-empty → reject"
+            `Quick
+            test_none_with_required_tools_rejects;
+          Alcotest.test_case
+            "required tools empty → accept"
+            `Quick
+            test_none_with_empty_tools_accepts;
+        ] );
+      ( "known surface (Some)",
+        [
+          Alcotest.test_case
+            "all tools present → accept"
+            `Quick
+            test_some_with_all_tools_accepts;
+          Alcotest.test_case
+            "missing tools → reject"
+            `Quick
+            test_some_with_missing_tools_rejects;
+          Alcotest.test_case
+            "empty list with required → reject"
+            `Quick
+            test_empty_list_with_required_tools_rejects;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- Fixes routing loop where agents without registered tool surface (e.g., codex-mcp-client) could claim tasks requiring specific tools
- `required_tool_claim_guard` now returns `Error` when `agent_tool_names=None` and `required_tools` is non-empty
- Previously returned `Ok ()`, allowing claims that would fail at execution time

## Root Cause
When `agent_tool_names` is `None` (unknown tool surface), the guard incorrectly allowed claims regardless of required tools. This created routing loops: agent claims task → discovers it lacks tools → releases → same agent reclaims → infinite cycle.

## Fix
`coord_task_classify.ml:281-290`: Changed from `Ok ()` to `Error (Task (InvalidState ...))` when:
- `agent_tool_names = None` (unknown surface)
- `task.contract.required_tools` is non-empty

## Relationship to PR #19373
PR #19373 (merged) fixed `make_required_tools_predicate` in `coord_task_schedule.ml` — the predicate that filters tasks at schedule time. This PR fixes the complementary guard in `coord_task_classify.ml` — the validation at actual claim time. Both are needed because they cover different code paths:
- **#19373**: predicate-level (task visibility/filtering)
- **#19418**: claim-time guard (last line of defense)

## Test Plan
- [x] 5 Alcotest cases covering all guard paths:
  - None + required tools → reject
  - None + empty tools → accept
  - Some + all tools present → accept
  - Some + missing tools → reject
  - Some [] + required tools → reject

## Related
- Complements PR #19373 (merged) — predicate-level fix
- Closes routing loop observed in fleet logs (codex-mcp-client claiming Bash/Read tasks)
- Board: p-dc65f3b2 (Systemic Blockers), p-b23cb09c (tool_execute missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>