### PR TITLE
perf(dashboard): serve shell?light from published snapshot (RFC-0204 "A")

### DIFF
--- a/lib/dashboard/dashboard_snapshot.ml
+++ b/lib/dashboard/dashboard_snapshot.ml
@@ -10,6 +10,12 @@ type t = {
   generated_at : float;
   generation : int;
   shell : Yojson.Safe.t;
+  shell_light : Yojson.Safe.t;
+  (* RFC-0204 section 8.3 ("A"): the [~light] projection of the shell,
+     published alongside [shell] so a [shell?light=true] read serves it
+     wait-free instead of recomputing.  Light is a DIFFERENT shape from
+     [shell] (skips belief/tension evaluation, uses the light agent-count /
+     runtime projections), so it is stored separately rather than derived. *)
   tools : Yojson.Safe.t;
   namespace_truth : Yojson.Safe.t;
   telemetry_summary : Yojson.Safe.t;
@@ -47,6 +53,14 @@ let bootstrap ~(config : Coord.config) : t =
       Server_dashboard_http_core.dashboard_shell_payload_json config
     with exn ->
       Log.Dashboard.warn "dashboard_snapshot bootstrap shell failed: %s"
+        (Printexc.to_string exn);
+      `Null
+  in
+  let shell_light =
+    try
+      Server_dashboard_http_core.dashboard_shell_payload_json ~light:true config
+    with exn ->
+      Log.Dashboard.warn "dashboard_snapshot bootstrap shell_light failed: %s"
         (Printexc.to_string exn);
       `Null
   in
@@ -91,6 +105,7 @@ let bootstrap ~(config : Coord.config) : t =
       generated_at = Unix.gettimeofday ();
       generation = next_generation ();
       shell;
+      shell_light;
       tools;
       namespace_truth;
       telemetry_summary;
@@ -136,8 +151,21 @@ let refresh_loop
   in
   let compute () =
     let shell =
+      (* [shell] intentionally omits [~light]: the snapshot publishes the FULL
+         shell.  Its non-light path uses Eio.Fiber.all, which is safe on the
+         Executor_pool worker domain this [compute] runs on -- each worker
+         opens its own Switch.run and forks the job as a fiber (eio
+         executor_pool.ml run_worker), so Fiber.all resolves against the
+         worker's context, not the main domain's.  Do not "fix" this to
+         [~light:true]; that would change [shell] to the light shape. *)
       safe "shell" (fun () ->
         Server_dashboard_http_core.dashboard_shell_payload_json config)
+    in
+    let shell_light =
+      (* RFC-0204 section 8.3 ("A"): publish the light projection too so
+         [shell?light=true] reads it wait-free. *)
+      safe "shell_light" (fun () ->
+        Server_dashboard_http_core.dashboard_shell_payload_json ~light:true config)
     in
     let tools =
       safe "tools" (fun () ->
@@ -194,6 +222,7 @@ let refresh_loop
       generated_at = Unix.gettimeofday ();
       generation = next_generation ();
       shell;
+      shell_light;
       tools;
       namespace_truth;
       telemetry_summary;
@@ -232,7 +261,8 @@ let refresh_loop
 
 let publish_for_test t = Atomic.set slot (Some t)
 
-let make_for_test ~shell ~tools ~namespace_truth ~telemetry_summary
+let make_for_test ~shell ?(shell_light = `Null) ~tools ~namespace_truth
+      ~telemetry_summary
       ?(activity_events_default = `Null)
       ?(activity_graph_default = `Null)
       ?(activity_swimlane_default = `Null) () =
@@ -240,6 +270,7 @@ let make_for_test ~shell ~tools ~namespace_truth ~telemetry_summary
     generated_at = Unix.gettimeofday ();
     generation = next_generation ();
     shell;
+    shell_light;
     tools;
     namespace_truth;
     telemetry_summary;

--- a/lib/dashboard/dashboard_snapshot.mli
+++ b/lib/dashboard/dashboard_snapshot.mli
@@ -24,6 +24,12 @@ type t = private {
   generated_at : float;          (** Unix.gettimeofday at publish.  *)
   generation : int;              (** Monotonic publish counter.    *)
   shell : Yojson.Safe.t;
+  shell_light : Yojson.Safe.t;
+  (** RFC-0204 section 8.3 ("A").  The [~light] projection of [shell],
+      published alongside it so [shell?light=true] is served wait-free
+      from the snapshot instead of recomputing.  Different shape from
+      [shell] (light skips belief/tension and uses the light agent-count /
+      runtime projections), hence stored, not derived. *)
   tools : Yojson.Safe.t;
   namespace_truth : Yojson.Safe.t;
   telemetry_summary : Yojson.Safe.t;
@@ -89,6 +95,7 @@ val publish_for_test : t -> unit
 
 val make_for_test :
   shell:Yojson.Safe.t ->
+  ?shell_light:Yojson.Safe.t ->
   tools:Yojson.Safe.t ->
   namespace_truth:Yojson.Safe.t ->
   telemetry_summary:Yojson.Safe.t ->

--- a/lib/server/server_dashboard_snapshot_select.ml
+++ b/lib/server/server_dashboard_snapshot_select.ml
@@ -10,9 +10,27 @@ let select_shell_json
     | None -> Server_timing.create ()
   in
   if light
-  then
-    Server_dashboard_http_core.dashboard_shell_http_json
-      ?clock ?request ~timing:timing_obj ~light config
+  then (
+    (* RFC-0204 section 8.3 ("A"): serve the published light projection
+       wait-free.  Mirrors the non-light branch below but reads
+       [snap.shell_light]; falls back to the (offloaded, timeout-guarded)
+       recompute only before the first snapshot publish. *)
+    match Dashboard_snapshot.current () with
+    | Some snap ->
+      let shell =
+        Server_timing.measure
+          timing_obj
+          (Server_timing.Custom "snapshot_read")
+          (fun () -> snap.shell_light)
+      in
+      (match request with
+       | None -> shell
+       | Some request ->
+         Server_dashboard_http_core.dashboard_shell_with_request_auth_json
+           ~request config shell)
+    | None ->
+      Server_dashboard_http_core.dashboard_shell_http_json
+        ?clock ?request ~timing:timing_obj ~light config)
   else (
     match Dashboard_snapshot.current () with
     | Some snap ->

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -815,8 +815,8 @@ let test_dashboard_message_json_surfaces_temporal_decay_fields () =
 
    1. snapshot published + light=false  -> return [snap.shell]
    2. snapshot empty + light=false      -> fall back to compute path
-   3. snapshot published + light=true   -> ignore snapshot, fall back
-                                           (one-sprint compatibility) *)
+   3. snapshot published + light=true   -> return [snap.shell_light]
+                                           (RFC-0204 section 8.3 "A") *)
 
 let test_shell_snapshot_wire_returns_snapshot_when_published () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
@@ -864,13 +864,17 @@ let test_shell_snapshot_wire_falls_back_when_empty () =
     (paths_of snapshot_json <> `Null
      && paths_of snapshot_json = paths_of direct_json)
 
-let test_shell_snapshot_wire_light_variant_bypasses_snapshot () =
+let test_shell_snapshot_wire_light_reads_shell_light () =
+  (* RFC-0204 section 8.3 ("A"): light=true now serves the published light
+     projection [snap.shell_light], not the full [snap.shell] and not a
+     recompute. *)
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   Lib.Dashboard_snapshot.reset_for_test ();
-  let sentinel = `Assoc [ "wire_sentinel", `String "snapshot-path" ] in
+  let full = `Assoc [ "wire_sentinel", `String "full-shell" ] in
+  let light = `Assoc [ "wire_sentinel", `String "light-shell" ] in
   Lib.Dashboard_snapshot.publish_for_test
     (Lib.Dashboard_snapshot.make_for_test
-       ~shell:sentinel ~tools:`Null
+       ~shell:full ~shell_light:light ~tools:`Null
        ~namespace_truth:`Null ~telemetry_summary:`Null ());
   let timing = Lib.Server_timing.create () in
   let json =
@@ -878,10 +882,15 @@ let test_shell_snapshot_wire_light_variant_bypasses_snapshot () =
       ~timing ~light:true config
   in
   let open Yojson.Safe.Util in
+  Alcotest.(check string)
+    "light=true returns the published shell_light projection"
+    "light-shell"
+    (json |> member "wire_sentinel" |> to_string);
+  let header = Lib.Server_timing.to_header_value timing in
   Alcotest.(check bool)
-    "light=true must NOT return the snapshot sentinel"
+    "Server-Timing records snapshot_read on light hit"
     true
-    (json |> member "wire_sentinel" = `Null);
+    (let re = Re.compile (Re.Perl.re "snapshot_read") in Re.execp re header);
   Lib.Dashboard_snapshot.reset_for_test ()
 
 let test_dashboard_shell_light_includes_runtime_health_ssot () =
@@ -1115,8 +1124,8 @@ let () =
             test_shell_snapshot_wire_returns_snapshot_when_published;
           test_case "RFC-0138 shell wire falls back when snapshot empty" `Quick
             test_shell_snapshot_wire_falls_back_when_empty;
-          test_case "RFC-0138 shell wire light variant bypasses snapshot" `Quick
-            test_shell_snapshot_wire_light_variant_bypasses_snapshot;
+          test_case "RFC-0204 shell wire light reads shell_light" `Quick
+            test_shell_snapshot_wire_light_reads_shell_light;
           test_case "light shell carries runtime health SSOT" `Quick
             test_dashboard_shell_light_includes_runtime_health_ssot;
           test_case "light shell counts agents from summary fields" `Quick


### PR DESCRIPTION
## 목적

RFC-0204 **"A"** — `shell?light=true` 요청을 **발행된 스냅샷에서 wait-free로** 서빙합니다(타임아웃 유발 recompute 대신). Phase 2(#19416)가 publisher를 offload해 스냅샷을 fresh하게 유지하므로 이제 안전합니다.

## 변경

1. `Dashboard_snapshot.t`에 **`shell_light` 필드** 추가 (record + .mli private record + `make_for_test ?shell_light`).
2. **publisher**(bootstrap + refresh `compute`)가 full `shell`과 함께 `shell_light = dashboard_shell_payload_json ~light:true config`도 발행.
3. **`select_shell_json` light 분기**가 `snap.shell_light`를 wait-free로 읽음(non-light 분기 정확히 미러; 첫 publish 전엔 recompute fallback).

## 왜 (트레이드오프)

- light는 full의 부분집합이 아니라 **다른 shape**입니다(belief/tension skip, light agent-count/runtime projection, `"light": true` 태그). 그래서 `snap.shell`(full)을 light에 주면 응답 shape이 바뀝니다 → **별도 필드로 저장**(derive 아님).
- request-auth overlay(`dashboard_shell_with_request_auth_json`)는 `"auth"` 키만 교체하고 나머지는 pass-through → light/full **shape-agnostic**, 안전.
- **순서 의존**: Phase 2(#19416)가 publisher를 offload해 신뢰화한 *후에만* 안전. 그 전엔 "타임아웃 → silent staleness" 맞바꿈이라 단독 금지였음(종합 결과 verdict).
- 효과: shell?light cold-miss recompute(load 36서 2.4s, peak 35s) → wait-free 스냅샷 read(ms).

## 검증

- `dune build --root . lib/dashboard` + `lib/server` **exit 0**. 컴파일러가 record 생성 3곳(bootstrap/refresh/make_for_test) 모두 `shell_light` 포함 강제.
- **테스트 갱신**: 옛 동작("light=true는 snapshot 무시", RFC-0138 wire test)을 검증하던 `test_shell_snapshot_wire_light_variant_bypasses_snapshot`를 **`..._light_reads_shell_light`로 rewrite** — full/light 별도 sentinel 발행 후 light=true가 **light sentinel**을 반환함을 증명 + snapshot_read timing 확인.
- 적대적 검증 워크플로(behavior/shape/auth-overlay) **백그라운드 실행** — verdict는 PR 코멘트로 반영.
- ⚠️ test-exe 런타임은 **본 변경 무관 pre-existing main breakage**(#19390)로 차단. main green 후.

부수: refresh `compute`에 full shell의 non-light `Eio.Fiber.all`이 Executor_pool worker 도메인에서 안전함을 주석으로 명시(eio `executor_pool.ml run_worker`가 job을 자체 `Switch.run` 하 fiber로 fork) — #19416 적대적 리뷰 nit 해소.

## 범위 / 후속

- 이 PR: shell light만. tools/telemetry는 이미 snapshot 서빙(별도).
- 후속: #2 Option A 전용 dashboard 풀, #3 Phase 3 serving 도메인.

RFC-WAIVED: RFC-0204 section 8.3 명시 구현. credential/operator/keeper-sandbox/hooks/workflow 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
