### PR TITLE
fix(dashboard): SSOT Json_util arg-order + assoc_member_opt option unwrap

### DIFF
--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -235,7 +235,7 @@ let parse_optional_policy args field =
   match Json_util.assoc_member_opt field args with
   | None | Some `Null -> Ok None
   | Some json when is_noop_verifier_policy_json json -> Ok None
-  | json ->
+  | Some json ->
     (match Goal_verification.goal_verifier_policy_of_yojson json with
      | Ok policy -> Ok (Some policy)
      | Error msg ->
@@ -254,7 +254,7 @@ let parse_optional_policy args field =
 let parse_optional_principal args field =
   match Json_util.assoc_member_opt field args with
   | None | Some `Null -> Ok None
-  | json ->
+  | Some json ->
     (match Goal_verification.goal_principal_of_yojson json with
      | Ok principal -> Ok (Some principal)
      | Error msg ->
@@ -358,7 +358,7 @@ let validate_goal_completion_ready config ~goal_id ~override_note =
 let parse_optional_string_list args field =
   match Json_util.assoc_member_opt field args with
   | None | Some `Null -> Ok None
-  | `List values ->
+  | Some (`List values) ->
     (try Ok (Some (List.map Yojson.Safe.Util.to_string values)) with
      | Eio.Cancel.Cancelled _ as e -> raise e
      | _ ->

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -206,7 +206,7 @@ let record_render_phase_timings (t : render_phase_timings_ms) =
 ;;
 
 let assoc_member_if_object key json =
-  Json_util.get_object json key
+  Json_util.get_object key json
 ;;
 
 let existing_keeper_trust_json keeper_json =
@@ -292,7 +292,7 @@ let keeper_runtime_trust_json keeper =
 ;;
 
 let lowercase_json_string key json =
-  Json_util.get_string json key |> Option.map String.lowercase_ascii
+  Json_util.get_string key json |> Option.map String.lowercase_ascii
 ;;
 
 let terminal_reason_json trust = member_assoc "latest_terminal_reason" trust

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -14,7 +14,7 @@ include Dashboard_goals_types
 let observe_goal_attainment_metrics (goal : Goal_store.goal) attainment =
   let labels = [ ("goal_id", goal.id) ] in
   let measured, pct =
-    match Json_util.get_int "attainment_pct" attainment with
+    match Json_util.get_int attainment "attainment_pct" with
     | Some pct -> (1.0, float_of_int pct)
     | None -> (0.0, 0.0)
   in
@@ -138,7 +138,7 @@ let build_goal_verification_projection ~(config : Coord.config) goals =
     requests;
   List.iter
     (fun json ->
-      match Json_util.get_string "goal_id" json with
+      match Json_util.get_string json "goal_id" with
       | Some goal_id ->
           let existing =
             Option.value (Hashtbl.find_opt events_table goal_id) ~default:[]

--- a/lib/dashboard/dashboard_goals_types_accessor.ml
+++ b/lib/dashboard/dashboard_goals_types_accessor.ml
@@ -94,73 +94,73 @@ let link_source_of_values values =
   | _ -> "mixed"
 let receipt_error_kind json =
   match Json_util.assoc_member_opt "error" json with
-  | Some (`Assoc _ as error) -> Json_util.get_string "kind" error
+  | Some (`Assoc _ as error) -> Json_util.get_string error "kind"
   | _ -> None
 
 let receipt_error_message json =
   match Json_util.assoc_member_opt "error" json with
-  | Some (`Assoc _ as error) -> Json_util.get_string "message" error
+  | Some (`Assoc _ as error) -> Json_util.get_string error "message"
   | _ -> None
 
 let receipt_sandbox_kind json =
   match Json_util.assoc_member_opt "sandbox" json with
-  | Some sandbox -> Json_util.get_string "kind" sandbox
+  | Some sandbox -> Json_util.get_string sandbox "kind"
   | None -> None
 
 let receipt_approval_profile json =
   match Json_util.assoc_member_opt "approval" json with
-  | Some approval -> Json_util.get_string "profile" approval
+  | Some approval -> Json_util.get_string approval "profile"
   | None -> None
 
 let receipt_cascade_name json =
   match Json_util.assoc_member_opt "cascade" json with
-  | Some cascade -> Json_util.get_string "name" cascade
+  | Some cascade -> Json_util.get_string cascade "name"
   | None -> None
 
 let receipt_cascade_outcome json =
   match Json_util.assoc_member_opt "cascade" json with
-  | Some cascade -> Json_util.get_string "outcome" cascade
+  | Some cascade -> Json_util.get_string cascade "outcome"
   | None -> None
 
 let receipt_cascade_fallback_applied json =
-  match Json_util.assoc_member_opt "cascade" json with
-  | Some cascade -> Json_util.get_bool "fallback_applied" cascade
-  | None -> None
+  (match Json_util.assoc_member_opt "cascade" json with
+  | Some cascade -> Json_util.get_bool cascade "fallback_applied"
+  | None -> None)
   |> Option.value ~default:false
 
 let receipt_outcome json =
-  Json_util.get_string "outcome" json
+  Json_util.get_string json "outcome"
 
 let receipt_started_at json =
-  Json_util.get_string "started_at" json
+  Json_util.get_string json "started_at"
 
 let receipt_ended_at json =
-  Json_util.get_string "ended_at" json
+  Json_util.get_string json "ended_at"
 
 let receipt_turn_count json =
-  Json_util.get_int "turn_count" json
+  Json_util.get_int json "turn_count"
 
 let trust_disposition json =
-  Json_util.get_string "disposition" json
+  Json_util.get_string json "disposition"
 
 let trust_disposition_reason json =
-  Json_util.get_string "disposition_reason" json
+  Json_util.get_string json "disposition_reason"
 
 let trust_attention_reason json =
-  Json_util.get_string "attention_reason" json
+  Json_util.get_string json "attention_reason"
 
 let trust_needs_attention json =
-  Json_util.get_bool "needs_attention" json
+  Json_util.get_bool json "needs_attention"
   |> Option.value ~default:false
 
 let trust_snapshot_unavailable json =
   String.equal
-    (Json_util.get_string "disposition_reason" json
+    (Json_util.get_string json "disposition_reason"
      |> Option.value ~default:"")
     "runtime_trust_snapshot_unavailable"
 
 let trust_turn_id json =
-  Json_util.get_int "turn_id" json
+  Json_util.get_int json "turn_id"
 
 let trust_latest_event json =
   match Json_util.assoc_member_opt "latest_causal_event" json with
@@ -169,21 +169,21 @@ let trust_latest_event json =
 
 let trust_latest_event_ts json =
   Option.bind (trust_latest_event json) (fun event ->
-      Json_util.get_string "ts" event )
+      Json_util.get_string event "ts" )
 
 let trust_latest_event_ts_unix json =
   Option.bind (trust_latest_event json) (fun event ->
-      Json_util.get_float "ts_unix" event )
+      Json_util.get_float event "ts_unix" )
 
 let trust_sandbox_risk json =
   String.equal
-    (Json_util.get_string "disposition_reason" json
+    (Json_util.get_string json "disposition_reason"
      |> Option.value ~default:"")
     "sandbox_violation"
 
 let trust_cascade_risk json =
   String.equal
-    (Json_util.get_string "disposition_reason" json
+    (Json_util.get_string json "disposition_reason"
      |> Option.value ~default:"")
     "cascade_exhausted"
 

--- a/lib/dashboard/dashboard_goals_types_builder.ml
+++ b/lib/dashboard/dashboard_goals_types_builder.ml
@@ -73,8 +73,8 @@ let runtime_blocker_event_from_meta ~config ~(meta : Keeper_meta_contract.keeper
   in
   let assoc_string_opt name =
     match List.assoc_opt name runtime_blocker_fields with
-    | Some json -> to_string_option json
-    | None -> None
+    | Some (`String s) -> Some s
+    | _ -> None
   in
   let blocker_class = assoc_string_opt "runtime_blocker_class" in
   let blocker_summary = assoc_string_opt "runtime_blocker_summary" in
@@ -272,7 +272,7 @@ let rec build_tree context goals goal =
   let approval_activity_values =
     direct_pending_approvals
     |> List.filter_map (fun json ->
-           Json_util.get_string "requested_at_iso" json)
+           Json_util.get_string json "requested_at_iso")
   in
   let receipt_activity_values =
     direct_receipts |> List.filter_map receipt_ended_at

--- a/lib/dashboard/dashboard_goals_types_health.ml
+++ b/lib/dashboard/dashboard_goals_types_health.ml
@@ -88,10 +88,10 @@ let tree_badges ~pending_approvals ~sandbox_risk ~cascade_risk ~fsm_risk ~stalle
   List.rev !badges
 
 let approval_matches_goal goal_id approval_json =
-  let goal_ids = Json_util.get_string_list "goal_ids" approval_json in
+  let goal_ids = Json_util.get_string_list approval_json "goal_ids" in
   List.mem goal_id goal_ids
   ||
-  match Json_util.get_string "goal_id" approval_json with
+  match Json_util.get_string approval_json "goal_id" with
   | Some pending_goal_id -> String.equal pending_goal_id goal_id
   | None -> false
 
@@ -169,11 +169,11 @@ let display_disposition_of_receipt_json receipt =
      regression in alerting), but the reason label now distinguishes
      them so the operator can chase the right producer fix. *)
   let operator_disposition =
-    Json_util.get_string "operator_disposition" receipt
+    Json_util.get_string receipt "operator_disposition"
     |> Option.value ~default:"<missing operator_disposition field>"
   in
   let operator_disposition_reason =
-    Json_util.get_string "operator_disposition_reason" receipt
+    Json_util.get_string receipt "operator_disposition_reason"
     |> Option.value ~default:""
   in
   let reason fallback =

--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -13,6 +13,9 @@
 
 open Dashboard_goals_types_accessor
 
+let to_string_option = function | `String s -> Some s | _ -> None
+let to_int_option = function | `Int n -> Some n | `Intlit s -> (try Some (int_of_string s) with _ -> None) | _ -> None
+
 let goal_status_color = function
   | Goal_store.Active -> "#4ade80"
   | Goal_store.Paused -> "#f59e0b"
@@ -227,12 +230,12 @@ let json_member_or_null field = function
 
 let goal_event_timeline_json event =
   let event_type =
-    Json_util.get_string "event_type" event
+    Json_util.get_string event "event_type"
     |> Option.value ~default:"goal_event"
   in
   let payload = Option.value ~default:`Null (Json_util.assoc_member_opt "payload" event) in
   let payload_field field = json_member_or_null field payload in
-  let ts = Json_util.get_string "ts" event |> Option.value ~default:"" in
+  let ts = Json_util.get_string event "ts" |> Option.value ~default:"" in
   let title, summary, severity =
     match event_type with
     | "goal_phase" ->
@@ -342,15 +345,15 @@ let build_goal_timeline node linked_keepers approvals goal_events =
   let approval_events =
     approvals
     |> List.filter_map (fun approval ->
-           match Json_util.get_string "requested_at_iso" approval with
+           match Json_util.get_string approval "requested_at_iso" with
            | None -> None
            | Some requested_at ->
                let approval_id =
-                 Json_util.get_string "id" approval
+                 Json_util.get_string approval "id"
                  |> Option.value ~default:"approval"
                in
                let tool_name =
-                 Json_util.get_string "tool_name" approval
+                 Json_util.get_string approval "tool_name"
                  |> Option.value ~default:"tool"
                in
                Some
@@ -358,7 +361,7 @@ let build_goal_timeline node linked_keepers approvals goal_events =
                     ~lane:("approval:" ^ approval_id)
                     ~title:(Printf.sprintf "Approval · %s" tool_name)
                     ~summary:
-                      (Json_util.get_string "input_preview" approval
+                      (Json_util.get_string approval "input_preview"
                        |> Option.value ~default:"pending operator decision")
                     ~severity:"warn"))
   in
@@ -368,19 +371,19 @@ let build_goal_timeline node linked_keepers approvals goal_events =
            match trust_latest_event detail.runtime_trust with
            | Some event ->
                let title =
-                 Json_util.get_string "title" event
+                 Json_util.get_string event "title"
                  |> Option.value ~default:(Printf.sprintf "Keeper · %s" detail.meta.name)
                in
                let summary =
-                 Json_util.get_string "summary" event
+                 Json_util.get_string event "summary"
                  |> Option.value ~default:"latest keeper event"
                in
                let severity =
-                 Json_util.get_string "severity" event
+                 Json_util.get_string event "severity"
                  |> Option.value ~default:"warn"
                in
                let ts =
-                 Json_util.get_string "ts" event
+                 Json_util.get_string event "ts"
                  |> Option.value ~default:(Masc_domain.now_iso ())
                in
                Some
@@ -420,6 +423,6 @@ let build_goal_timeline node linked_keepers approvals goal_events =
   let goal_events = List.map goal_event_timeline_json goal_events in
   task_events @ approval_events @ keeper_events @ goal_events
   |> List.sort (fun left right ->
-         let lts = Json_util.get_string "ts" left |> Option.value ~default:"" in
-         let rts = Json_util.get_string "ts" right |> Option.value ~default:"" in
+         let lts = Json_util.get_string left "ts" |> Option.value ~default:"" in
+         let rts = Json_util.get_string right "ts" |> Option.value ~default:"" in
          String.compare rts lts)

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -283,17 +283,17 @@ let get_state base_path =
 let key_of kind id = kind ^ ":" ^ id
 
 let judgment_key json =
-  let kind = Json_util.get_string "target_kind" json |> Option.value ~default:"" in
-  let id = Json_util.get_string "target_id" json |> Option.value ~default:"" in
+  let kind = Json_util.get_string json "target_kind" |> Option.value ~default:"" in
+  let id = Json_util.get_string json "target_id" |> Option.value ~default:"" in
   key_of kind id
 
 let judgment_generated_at json =
-  Json_util.get_string "generated_at" json |> Dashboard_utils.parse_iso_opt
+  Json_util.get_string json "generated_at" |> Dashboard_utils.parse_iso_opt
   |> Option.value ~default:0.0
 
 let normalize_disk_recommended_action judgment =
   match Json_util.assoc_member_opt "recommended_action" judgment with
-  | `Assoc action_fields ->
+  | Some (`Assoc action_fields) ->
       let canonical_tool =
         match List.assoc_opt "resolved_tool" action_fields with
         | Some (`String tool) ->
@@ -328,7 +328,7 @@ let load_judgments_into_table jsons =
   let table = Hashtbl.create 32 in
   List.iter (fun json ->
     try
-      let status = Json_util.get_string "status" json in
+      let status = Json_util.get_string json "status" in
       if status = Some "active" then
         let key = judgment_key json in
         match Hashtbl.find_opt table key with
@@ -385,7 +385,7 @@ let fresh_judgments_json ~base_path ~limit =
   latest_judgments base_path
   |> List.map normalize_disk_recommended_action
   |> List.filter (fun j ->
-    match Json_util.get_string "expires_at" j with
+    match Json_util.get_string j "expires_at" with
     | Some iso ->
       (match Dashboard_utils.parse_iso_opt (Some iso) with
        | Some ts -> ts > now
@@ -482,7 +482,7 @@ let parse_recommended_action json =
   match Json_util.assoc_member_opt "recommended_action" json with
   | Some (`Assoc _ as action_json) ->
       let resolved_tool =
-        Json_util.get_string "resolved_tool" action_json
+        Json_util.get_string action_json "resolved_tool"
         |> Option.map normalize_allowed_tool_name
       in
       let resolved_tool =
@@ -500,7 +500,7 @@ let parse_recommended_action json =
             ( "reason",
               `String
                 (normalize_text
-                   (Json_util.get_string "reason" action_json
+                   (Json_util.get_string action_json "reason"
                   |> Option.value ~default:"")) );
             ("payload_preview", m "payload_preview" action_json);
           ])
@@ -529,7 +529,7 @@ let parse_lenient_governance_json raw_text =
 
 let parse_required_guardrail_state json =
   match Json_util.assoc_member_opt "guardrail_state" json with
-  | `Assoc fields ->
+  | Some (`Assoc fields) ->
       let required_field name =
         match List.assoc_opt name fields with
         | Some value -> Ok value
@@ -555,24 +555,24 @@ let parse_required_guardrail_state json =
            Error
              "invalid guardrail_state: expected requires_human_gate bool, \
               pending_confirm_token string|null, ready_to_execute bool")
-  | `Null -> Error "missing guardrail_state"
+  | None | Some `Null -> Error "missing guardrail_state"
   | _ -> Error "invalid guardrail_state: expected object"
 
 let parse_item_judgment ~generated_at ~expires_at ~model_used:_ json =
   let target_kind =
-    Json_util.get_string "kind" json |> Option.value ~default:""
+    Json_util.get_string json "kind" |> Option.value ~default:""
     |> String.lowercase_ascii
   in
-  let target_id = Json_util.get_string "id" json |> Option.value ~default:"" in
+  let target_id = Json_util.get_string json "id" |> Option.value ~default:"" in
   if target_kind = "" || target_id = "" then Ok None
   else
     let summary =
-      normalize_text (Json_util.get_string "summary" json |> Option.value ~default:"")
+      normalize_text (Json_util.get_string json "summary" |> Option.value ~default:"")
     in
     if summary = "" then Ok None
     else
       let confidence =
-        Json_util.get_float "confidence" json
+        Json_util.get_float json "confidence"
         |> Option.value ~default:0.0
         |> fun v -> max 0.0 (min 1.0 v)
       in
@@ -614,7 +614,7 @@ let parse_governance_response ~raw_text ~generated_at ~expires_at ~model_used =
       match parsed with
       | `Assoc _ -> (
           match Json_util.assoc_member_opt "items" parsed with
-          | `List rows ->
+          | Some (`List rows) ->
               let rec loop acc = function
                 | [] -> Ok (List.rev acc)
                 | row :: rest -> (

--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -210,7 +210,7 @@ let metrics_row_has_context_snapshot (j : Yojson.Safe.t) : bool =
   has_ratio (m "context_ratio")
   && has_int (m "context_tokens")
   && has_int (m "context_max")
-  && has_int (member "message_count" j)
+  && has_int (m "message_count")
 
 let keeper_metrics_24h_json
     ~(metrics_lines : string list)

--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -70,7 +70,7 @@ let terminal_reason_code_of_decision_json json =
   | Some _ as value -> value
   | None ->
     (match Json_util.assoc_member_opt "terminal_reason" json with
-     | `Assoc _ as terminal_reason ->
+     | Some (`Assoc _ as terminal_reason) ->
        Json_util.assoc_string_opt "code" terminal_reason
      | _ -> None)
 

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -126,22 +126,21 @@ let build_recommended_action ~actor ~target_type ~target_id json =
   match json with
   | `Assoc _ ->
       let action_type =
-        Json_util.get_string member_action_type json |> Option.map String.trim
+        Json_util.get_string json member_action_type |> Option.map String.trim
       in
       (match action_type with
       | Some action_type when action_type <> "" && allowed_action_type action_type ->
           let severity =
-            Json_util.get_string member_severity json
+            Json_util.get_string json member_severity
             |> Option.value ~default:severity_warn
           in
           let reason =
             normalize_text
-              (Json_util.get_string member_reason json |> Option.value ~default:"")
+              (Json_util.get_string json member_reason |> Option.value ~default:"")
           in
           let suggested_payload =
             match Json_util.assoc_member_opt member_suggested_payload json with
             | Some (`Assoc _ as value) -> value
-            | `Assoc _ as value -> value
             | _ -> `Assoc []
           in
           let preview =
@@ -184,12 +183,12 @@ let parse_room_judgment ~config ~generated_at ~generated_at_unix ~model_used:_ j
   | `Assoc _ ->
       let summary =
         normalize_text
-          (Json_util.get_string member_summary json |> Option.value ~default:"")
+          (Json_util.get_string json member_summary |> Option.value ~default:"")
       in
       if summary = "" then None
       else
         let confidence =
-          Json_util.get_float member_confidence json
+          Json_util.get_float json member_confidence
           |> Option.value ~default:0.0
         in
         let fresh_until_unix =
@@ -204,7 +203,7 @@ let parse_room_judgment ~config ~generated_at ~generated_at_unix ~model_used:_ j
                   ~target_id:None (Option.value ~default:`Null (Json_util.assoc_member_opt member_recommended_action json)))
              ~evidence_refs:(parse_string_list json "evidence_refs")
              ~disagreement_with_truth:
-               (Json_util.get_bool member_disagreement_with_truth json
+               (Json_util.get_bool json member_disagreement_with_truth
                |> Option.value ~default:false)
              ~generated_at ~generated_at_unix
              ~fresh_until:(Dashboard_utils.iso_of_unix fresh_until_unix)


### PR DESCRIPTION
Dashboard modules missed during SSOT consolidation rounds 1-4. Json_util.get_* arg order reversed (51 callsites), assoc_member_opt returns option needing Some wrapper (6 patterns), local to_string_option/to_int_option helpers, pipe precedence fix, non-exhaustive match wildcard. Reduces main compile errors 22 to 13. All 13 remaining are keeper_meta/sandbox_profile/cascade-to-runtime (separate PRs).