### PR TITLE
fix(keeper,build): complete RFC-0205 facade-removal caller grind — restore main compile

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -18,6 +18,7 @@ module Coord = Masc_mcp.Coord
 module Coord_utils = Coord_utils
 module Tool_keeper = Masc_mcp.Tool_keeper
 module Keeper_types = Masc_mcp.Keeper_types
+module Keeper_meta_store = Masc_mcp.Keeper_meta_store
 module Keeper_memory = Masc_mcp.Keeper_memory
 module Keeper_execution = Masc_mcp.Keeper_execution
 module Keeper_runtime = Masc_mcp.Keeper_runtime
@@ -1068,7 +1069,7 @@ let keeper_doctor_claim_scope_json ~keeper_name =
       ]
 
 let keeper_doctor_config_drift_json ~config ~keeper_name =
-  match Keeper_types.read_meta config keeper_name with
+  match Keeper_meta_store.read_meta config keeper_name with
   | Ok (Some meta) ->
     let sources = Keeper_status_bridge.source_provenance_json config meta in
     let override_fields = keeper_doctor_json_string_list "override_fields" sources in
@@ -1123,7 +1124,7 @@ let keeper_doctor_config_drift_json ~config ~keeper_name =
       ]
 
 let keeper_doctor_current_task_json config meta =
-  match meta.Keeper_types.current_task_id with
+  match meta.Masc_mcp.Keeper_meta_contract.current_task_id with
   | None -> `Assoc [ "present", `Bool false; "task_id", `Null ]
   | Some task_id ->
     let task_id_s = Keeper_id.Task_id.to_string task_id in
@@ -1245,7 +1246,7 @@ let doctor_keeper_report base_path keeper_name =
   in
   let config = Coord.default_config config_report.base_path in
   Keeper_tool_call_log.init ~base_path:config.base_path ();
-  let meta_result = Keeper_types.read_meta config keeper_name in
+  let meta_result = Keeper_meta_store.read_meta config keeper_name in
   let claim_scope = keeper_doctor_claim_scope_json ~keeper_name in
   let config_drift = keeper_doctor_config_drift_json ~config ~keeper_name in
   let async = keeper_doctor_async_json ~keeper_name ~claim_scope in

--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -137,10 +137,10 @@ let wrap_event
     ; "ts_unix", `Float ts
     ; "correlation_id", `String correlation_id
     ; "run_id", `String run_id
-    ; "agent_name", json_string_opt agent_name
-    ; "task_id", json_string_opt task_id
+    ; "agent_name", Json_util.string_opt_to_json agent_name
+    ; "task_id", Json_util.string_opt_to_json task_id
     ; "turn", Option.fold ~none:`Null ~some:(fun value -> `Int value) turn
-    ; "tool_name", json_string_opt tool_name
+    ; "tool_name", Json_util.string_opt_to_json tool_name
     ; "payload", payload
     ]
 ;;
@@ -361,9 +361,9 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
          ~event_type
          ~payload
          ?agent_name:(payload_agent_name payload)
-         ?task_id:(payload_string_opt "task_id" payload)
-         ?turn:(payload_int_opt "turn" payload)
-         ?tool_name:(payload_string_opt "tool_name" payload)
+         ?task_id:(Json_util.assoc_string_opt "task_id" payload)
+         ?turn:(Json_util.assoc_int_opt "turn" payload)
+         ?tool_name:(Json_util.assoc_string_opt "tool_name" payload)
          ())
   | Agent_sdk.Event_bus.InferenceTelemetry
       { provider

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -2,6 +2,12 @@ include Dashboard_execution_helpers
 include Dashboard_execution_fixture
 include Dashboard_execution_builders
 
+(* RFC-0205 #19399 facade cleanup removed the [Keeper_types] open that
+   previously brought [string_field_opt] into scope. Re-point at its real
+   home in [Json_util]; signature ([name -> json -> string option]) is
+   identical. *)
+let string_field_opt = Json_util.assoc_string_opt
+
 let room_status_json (config : Coord.config) : Yojson.Safe.t =
   let room_state_opt =
     if Coord.is_initialized config then Some (Coord.read_state config) else None

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -212,7 +212,7 @@ let record_render_phase_timings (t : render_phase_timings_ms) =
 ;;
 
 let assoc_member_if_object key json =
-  Json_util.get_object key json
+  Json_util.get_object json key
 ;;
 
 let existing_keeper_trust_json keeper_json =
@@ -298,7 +298,7 @@ let keeper_runtime_trust_json keeper =
 ;;
 
 let lowercase_json_string key json =
-  Json_util.get_string key json |> Option.map String.lowercase_ascii
+  Json_util.get_string json key |> Option.map String.lowercase_ascii
 ;;
 
 let terminal_reason_json trust = member_assoc "latest_terminal_reason" trust

--- a/lib/dashboard/dashboard_keeper_feature_proof.ml
+++ b/lib/dashboard/dashboard_keeper_feature_proof.ml
@@ -352,7 +352,7 @@ let scheduled_proactive_feature ~config ?window_hours ~now snapshots =
       | None -> false)
   in
   let total = keeper_count enabled in
-  let has_recent_meta_evidence meta =
+  let has_recent_meta_evidence (meta : Keeper_meta_contract.keeper_meta) =
     meta.runtime.proactive_rt.count_total > 0
     && timestamp_within_window ?window_hours ~now
          meta.runtime.proactive_rt.last_ts

--- a/lib/keeper/agent_tool_task_runtime.ml
+++ b/lib/keeper/agent_tool_task_runtime.ml
@@ -339,7 +339,7 @@ let sync_keeper_meta_current_task
     in
     Keeper_registry.update_meta ~base_path:config.base_path meta.name updated_meta;
     (match
-       write_meta_with_merge ~merge:merge_current_task_id config updated_meta
+       Keeper_meta_store.write_meta_with_merge ~merge:merge_current_task_id config updated_meta
      with
      | Ok () -> ()
      | Error msg ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -97,7 +97,7 @@ let persist_directive_meta_update
          | latest_path :: _ -> latest_path
          | [] -> default_path))
   in
-  match Keeper_fs.save_json_atomic persisted_path (meta_to_json updated_meta) with
+  match Keeper_fs.save_json_atomic persisted_path (Keeper_meta_json.meta_to_json updated_meta) with
   | Ok () ->
     Keeper_registry.update_meta ~base_path:entry.base_path entry.name updated_meta
   | Error msg ->

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -124,6 +124,7 @@ type blocker_class =
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation
+  | No_tool_capable_provider
   | Stay_silent_loop
   | Fiber_unresolved
     (** 2026-05-05: turn fiber finished without invoking [resolve_done]
@@ -172,6 +173,7 @@ let blocker_class_to_string = function
   | Turn_timeout -> "turn_timeout"
   | Turn_livelock_blocked -> "turn_livelock_blocked"
   | Completion_contract_violation -> "completion_contract_violation"
+  | No_tool_capable_provider -> "no_tool_capable_provider"
   | Stay_silent_loop -> "stay_silent_loop"
   | Fiber_unresolved -> "fiber_unresolved"
   | Stale_turn_timeout -> "stale_turn_timeout"
@@ -201,6 +203,7 @@ let blocker_class_of_serialized_string = function
   | "turn_timeout" -> Some Turn_timeout
   | "turn_livelock_blocked" -> Some Turn_livelock_blocked
   | "completion_contract_violation" -> Some Completion_contract_violation
+  | "no_tool_capable_provider" -> Some No_tool_capable_provider
   | "stay_silent_loop" -> Some Stay_silent_loop
   | "fiber_unresolved" -> Some Fiber_unresolved
   | "stale_turn_timeout" -> Some Stale_turn_timeout
@@ -252,6 +255,7 @@ let blocker_class_continue_gate = function
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation
+  | No_tool_capable_provider
   | Stay_silent_loop
   | Fiber_unresolved
   | Stale_turn_timeout
@@ -508,9 +512,9 @@ type keeper_meta =
   ; desires : string
   ; instructions : string
   ; (* -- Policy -- *)
-    sandbox_profile : sandbox_profile
+    sandbox_profile : Keeper_types_profile.sandbox_profile
   ; sandbox_image : string option
-  ; network_mode : network_mode
+  ; network_mode : Keeper_types_profile.network_mode
   ; allowed_paths : string list
   ; tool_access : tool_access
   ; tool_preset_source : string option

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -154,6 +154,11 @@ type cascade_exhaustion_reason =
           Previously [ProviderFailure { kind = Capacity_exhausted _ }] fell
           through to [Other_detail message], losing auto-recovery eligibility
           and triggering the harsher failure policy. *)
+  | No_tool_capable
+      (** Cascade exhausted because no configured provider can satisfy the
+          required tool set.  Previously a standalone [blocker_class] variant;
+          reclassified here because the cascade rotation filtered all candidates
+          before dispatch — a semantic subset of cascade exhaustion. *)
   | Other_detail of string
 
 type blocker_class =

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -155,10 +155,11 @@ type cascade_exhaustion_reason =
           through to [Other_detail message], losing auto-recovery eligibility
           and triggering the harsher failure policy. *)
   | No_tool_capable
-      (** Cascade exhausted because no configured provider can satisfy the
-          required tool set.  Previously a standalone [blocker_class] variant;
-          reclassified here because the cascade rotation filtered all candidates
-          before dispatch — a semantic subset of cascade exhaustion. *)
+      (** Cascade exhausted because the provider rotation filtered out every
+          candidate before dispatch — none advertised the required tool
+          capability for this turn. Distinct from [Capacity_exhausted], which
+          reaches dispatch. Serialized via the [cascade_exhausted_no_tool_capable]
+          code; the related [blocker_class] variant is [No_tool_capable_provider]. *)
   | Other_detail of string
 
 type blocker_class =

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -6,7 +6,7 @@
 
 include Keeper_meta_json_scrub
 
-let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
+let meta_to_json (m : Keeper_meta_contract.keeper_meta) : Yojson.Safe.t =
   let rt = m.runtime in
   (* Config/personality/policy fields are TOML-only; JSON persists
      runtime state exclusively.  See [config_field_names] for the

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -16,7 +16,7 @@ let meta_to_json (m : Keeper_meta_contract.keeper_meta) : Yojson.Safe.t =
     ; "agent_name", `String m.agent_name
     ; "trace_id", `String (Keeper_id.Trace_id.to_string rt.trace_id)
     ; "trace_history", `List (List.map (fun s -> `String s) rt.trace_history)
-    ; "last_seen_seq_by_room", room_seq_map_to_json m.last_seen_seq_by_room
+    ; "last_seen_seq_by_room", Keeper_types_profile.room_seq_map_to_json m.last_seen_seq_by_room
     ; "generation", `Int rt.generation
     ; "last_handoff_ts", `Float rt.last_handoff_ts
     ; "created_at", `String m.created_at
@@ -41,13 +41,13 @@ let meta_to_json (m : Keeper_meta_contract.keeper_meta) : Yojson.Safe.t =
     ; "proactive_visible_count_total", `Int rt.proactive_rt.visible_count_total
     ; "last_visible_proactive_ts", `Float rt.proactive_rt.last_visible_ts
     ; ( "last_proactive_outcome"
-      , `String (proactive_cycle_outcome_to_string rt.proactive_rt.last_outcome) )
+      , `String (Keeper_meta_contract.proactive_cycle_outcome_to_string rt.proactive_rt.last_outcome) )
     ; "last_proactive_reason", `String rt.proactive_rt.last_reason
     ; "last_proactive_preview", `String rt.proactive_rt.last_preview
     ; "consecutive_noop_count", `Int rt.proactive_rt.consecutive_noop_count
     ; "last_compaction_check_ts", `Float rt.compaction_rt.last_check_ts
     ; ( "last_compaction_decision"
-      , `String (compaction_runtime_decision_to_string rt.compaction_rt.last_decision)
+      , `String (Keeper_meta_contract.compaction_runtime_decision_to_string rt.compaction_rt.last_decision)
       )
     ; "last_continuity_update_ts", `Float rt.last_continuity_update_ts
     ; "continuity_summary", `String m.continuity_summary
@@ -66,11 +66,11 @@ let meta_to_json (m : Keeper_meta_contract.keeper_meta) : Yojson.Safe.t =
     ; "last_current_intention", `String rt.last_current_intention
     ; ( "last_blocker"
       , match rt.last_blocker with
-        | Some info -> blocker_info_to_json info
+        | Some info -> Keeper_meta_contract.blocker_info_to_json info
         | None -> `Null )
     ; ( "last_cascade_attempt"
       , match rt.last_cascade_attempt with
-        | Some record -> cascade_attempt_record_to_json record
+        | Some record -> Keeper_meta_contract.cascade_attempt_record_to_json record
         | None -> `Null )
     ; "last_need", `String rt.last_need
     ; ( "last_turn_tool_calls"
@@ -180,7 +180,7 @@ let canonical_keeper_meta_key_names =
   match meta_of_json seed_json with
   | Ok meta ->
     (match meta_to_json meta with
-     | `Assoc fields -> fields |> List.map fst |> dedupe_keep_order
+     | `Assoc fields -> fields |> List.map fst |> Json_util.dedupe_keep_order
      | _ -> fallback_canonical_keeper_meta_key_names)
   | Error msg ->
     Prometheus.inc_counter
@@ -202,7 +202,7 @@ let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
         if List.mem key canonical_keeper_meta_key_names
         then None
         else Some key)
-      |> dedupe_keep_order
+      |> Json_util.dedupe_keep_order
     in
     (match unknown with
      | [] -> ()

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -80,17 +80,17 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
       Safe_ops.json_string_list "trace_history" json |> List.filter Keeper_config.validate_name
     in
     let pk_goal =
-      Safe_ops.json_string ~default:"" "goal" json |> normalize_goal_horizon_text
+      Safe_ops.json_string ~default:"" "goal" json |> Keeper_config_text.normalize_goal_horizon_text
     in
     let pk_short_goal, pk_mid_goal, pk_long_goal =
-      resolve_goal_horizons
+      Keeper_config_text.resolve_goal_horizons
         ~goal:pk_goal
         ~short_goal_opt:
-          (normalize_goal_horizon_opt (Safe_ops.json_string_opt "short_goal" json))
+          (Keeper_config_text.normalize_goal_horizon_opt (Safe_ops.json_string_opt "short_goal" json))
         ~mid_goal_opt:
-          (normalize_goal_horizon_opt (Safe_ops.json_string_opt "mid_goal" json))
+          (Keeper_config_text.normalize_goal_horizon_opt (Safe_ops.json_string_opt "mid_goal" json))
         ~long_goal_opt:
-          (normalize_goal_horizon_opt (Safe_ops.json_string_opt "long_goal" json))
+          (Keeper_config_text.normalize_goal_horizon_opt (Safe_ops.json_string_opt "long_goal" json))
     in
     let pk_social_model =
       Safe_ops.json_string
@@ -193,62 +193,62 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
     let pp_allowed_paths = Safe_ops.json_string_list "allowed_paths" json in
     let pp_tool_denylist = Safe_ops.json_string_list "tool_denylist" json in
     let pp_mention_targets =
-      Safe_ops.json_string_list "mention_targets" json |> dedupe_keep_order
+      Safe_ops.json_string_list "mention_targets" json |> Json_util.dedupe_keep_order
     in
     let pp_room_signal_prompt_enabled =
       Safe_ops.json_bool
-        ~default:default_room_signal_prompt_enabled
+        ~default:Keeper_config_text.default_room_signal_prompt_enabled
         "room_signal_prompt_enabled"
         json
     in
     let pp_joined_room_ids =
       Safe_ops.json_string_list "joined_room_ids" json
-      |> List.filter validate_name
-      |> dedupe_keep_order
+      |> List.filter Keeper_config.validate_name
+      |> Json_util.dedupe_keep_order
     in
     let pp_last_seen_seq_by_room =
-      Yojson.Safe.Util.member "last_seen_seq_by_room" json |> room_seq_map_of_json
+      Yojson.Safe.Util.member "last_seen_seq_by_room" json |> Keeper_types_profile.room_seq_map_of_json
     in
     let proactive_enabled =
-      Safe_ops.json_bool ~default:default_proactive_enabled "proactive_enabled" json
+      Safe_ops.json_bool ~default:Keeper_config_text.default_proactive_enabled "proactive_enabled" json
     in
     let proactive_idle_sec =
-      Safe_ops.json_int ~default:default_proactive_idle_sec "proactive_idle_sec" json
-      |> normalize_proactive_idle_sec
+      Safe_ops.json_int ~default:Keeper_config_text.default_proactive_idle_sec "proactive_idle_sec" json
+      |> Keeper_config.normalize_proactive_idle_sec
     in
     let proactive_cooldown_sec =
       Safe_ops.json_int
-        ~default:default_proactive_cooldown_sec
+        ~default:Keeper_config_text.default_proactive_cooldown_sec
         "proactive_cooldown_sec"
         json
-      |> normalize_proactive_cooldown_sec
+      |> Keeper_config.normalize_proactive_cooldown_sec
     in
     let env_ratio_gate, env_message_gate, env_token_gate =
-      keeper_compaction_policy_from_env ()
+      Keeper_config.keeper_compaction_policy_from_env ()
     in
     let compaction_profile =
-      Safe_ops.json_string ~default:default_compaction_profile "compaction_profile" json
-      |> canonical_compaction_profile
-      |> Option.value ~default:default_compaction_profile
+      Safe_ops.json_string ~default:Keeper_config.default_compaction_profile "compaction_profile" json
+      |> Keeper_config.canonical_compaction_profile
+      |> Option.value ~default:Keeper_config.default_compaction_profile
     in
     let compaction_ratio_gate =
       Safe_ops.json_float ~default:env_ratio_gate "compaction_ratio_gate" json
-      |> normalize_compaction_ratio_gate
+      |> Keeper_config.normalize_compaction_ratio_gate
     in
     let compaction_message_gate =
       Safe_ops.json_int ~default:env_message_gate "compaction_message_gate" json
-      |> normalize_compaction_message_gate
+      |> Keeper_config.normalize_compaction_message_gate
     in
     let compaction_token_gate =
       Safe_ops.json_int ~default:env_token_gate "compaction_token_gate" json
-      |> normalize_compaction_token_gate
+      |> Keeper_config.normalize_compaction_token_gate
     in
     let continuity_compaction_cooldown_sec =
       Safe_ops.json_int
-        ~default:(keeper_continuity_compaction_cooldown_sec ())
+        ~default:(Keeper_config.keeper_continuity_compaction_cooldown_sec ())
         "continuity_compaction_cooldown_sec"
         json
-      |> normalize_continuity_compaction_cooldown_sec
+      |> Keeper_config.normalize_continuity_compaction_cooldown_sec
     in
     let pp_auto_handoff = Safe_ops.json_bool ~default:true "auto_handoff" json in
     let pp_handoff_threshold =
@@ -258,7 +258,7 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
       Safe_ops.json_int ~default:300 "handoff_cooldown_sec" json
     in
     let pp_per_provider_timeout_s =
-      normalize_per_provider_timeout_json_field
+      Keeper_types_profile.normalize_per_provider_timeout_json_field
         ~source:(Printf.sprintf "keeper meta %s" keeper_name)
         ~field:"per_provider_timeout_s"
         json
@@ -580,10 +580,10 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                    ~trace_id:identity.pk_trace_id
                    ~trace_history:identity.pk_trace_history
                in
-               if not (validate_name identity.pk_name)
+               if not (Keeper_config.validate_name identity.pk_name)
                then Error "invalid keeper meta (bad name)"
                else if
-                 not (validate_name (Keeper_id.Trace_id.to_string identity.pk_trace_id))
+                 not (Keeper_config.validate_name (Keeper_id.Trace_id.to_string identity.pk_trace_id))
                then Error "invalid keeper meta (bad trace_id)"
                else
                  let cascade_ref_result =

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -6,6 +6,8 @@
 
 open Keeper_meta_json_scrub
 open Keeper_types_profile_sandbox
+open Keeper_meta_tool_access
+open Keeper_meta_contract
 
 type parsed_keeper_identity =
   { pk_name : string
@@ -75,7 +77,7 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
   | Error e -> Error ("keeper meta parse error: " ^ e)
   | Ok pk_trace_id ->
     let pk_trace_history =
-      Safe_ops.json_string_list "trace_history" json |> List.filter validate_name
+      Safe_ops.json_string_list "trace_history" json |> List.filter Keeper_config.validate_name
     in
     let pk_goal =
       Safe_ops.json_string ~default:"" "goal" json |> normalize_goal_horizon_text

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -4,6 +4,15 @@
     stays in [Keeper_meta_json] so canonical-key derivation can
     use the public facade without creating a cycle. *)
 
+(* RFC-0205 #19399 removed [open Keeper_types_profile] / [open Keeper_meta_contract]
+   from the implementation and replaced them with [open Keeper_types_profile_sandbox],
+   but left this interface without the matching opens, leaving the policy-slice field
+   types unbound. Mirror the implementation's open context so the signature resolves
+   the same names. *)
+open Keeper_meta_json_scrub
+open Keeper_types_profile_sandbox
+open Keeper_meta_tool_access
+open Keeper_meta_contract
 
 (** Parsed identity slice of a persisted keeper meta. *)
 type parsed_keeper_identity =

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -39,7 +39,7 @@ let drop_assoc_keys (keys : string list) (json : Yojson.Safe.t) : Yojson.Safe.t 
 ;;
 
 let reject_removed_keeper_meta_fields (json : Yojson.Safe.t) =
-  let present = present_json_keys removed_keeper_meta_key_names json in
+  let present = Keeper_config_text.present_json_keys Keeper_config_text.removed_keeper_meta_key_names json in
   match present with
   | [] -> Ok ()
   | fields ->
@@ -69,7 +69,7 @@ let persisted_retired_keeper_meta_key_names =
 ;;
 
 let reject_legacy_keeper_meta_fields (json : Yojson.Safe.t) =
-  let present = present_json_keys legacy_keeper_meta_key_names json in
+  let present = Keeper_config_text.present_json_keys legacy_keeper_meta_key_names json in
   match present with
   | [] -> Ok ()
   | fields ->
@@ -83,7 +83,7 @@ let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) : Yojson.Safe.
   match json with
   | `Assoc fields ->
     let scrub_candidate_key_names =
-      removed_keeper_meta_key_names
+      Keeper_config_text.removed_keeper_meta_key_names
       @ persisted_retired_keeper_meta_key_names
       @ config_field_names
     in

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -25,8 +25,8 @@ let read_meta_file_path path : (keeper_meta option, string) result =
     | Error e -> Error e
     | Ok json ->
       let json, _scrubbed = Keeper_meta_json_scrub.scrub_persisted_keeper_meta_json ~path json in
-      warn_unknown_keeper_meta_keys ~path json;
-      (match meta_of_json json with
+      Keeper_meta_json.warn_unknown_keeper_meta_keys ~path json;
+      (match Keeper_meta_json_parse.meta_of_json json with
        | Ok meta -> Ok (Some meta)
        | Error e ->
          Prometheus.inc_counter
@@ -59,7 +59,7 @@ let is_keeper_meta_file f =
 ;;
 
 let persisted_keeper_names config =
-  let dir = keeper_dir config in
+  let dir = Keeper_types_profile.keeper_dir config in
   match Safe_ops.list_dir_safe dir with
   | Error e ->
     Prometheus.inc_counter
@@ -72,7 +72,7 @@ let persisted_keeper_names config =
     files
     |> List.filter is_keeper_meta_file
     |> List.map Filename.remove_extension
-    |> List.filter validate_name
+    |> List.filter Keeper_config.validate_name
     |> List.sort String.compare
 ;;
 
@@ -80,7 +80,7 @@ let configured_keeper_names _config =
   Config_dir_resolver.log_warnings ~context:"KeeperTypes" ();
   Keeper_types_profile.discover_keepers_toml (Config_dir_resolver.keepers_dir ())
   |> List.map fst
-  |> dedupe_keep_order
+  |> Json_util.dedupe_keep_order
 ;;
 
 let keeper_names config =
@@ -93,13 +93,13 @@ let keeper_names config =
 ;;
 
 let declarative_autoboot_enabled_by_default name =
-  match (load_keeper_profile_defaults name).autoboot_enabled with
+  match (Keeper_types_profile.load_keeper_profile_defaults name).autoboot_enabled with
   | Some false -> false
   | Some true | None -> true
 ;;
 
 let effective_autoboot_enabled name meta =
-  match (load_keeper_profile_defaults name).autoboot_enabled with
+  match (Keeper_types_profile.load_keeper_profile_defaults name).autoboot_enabled with
   | Some value -> value
   | None -> meta.autoboot_enabled
 ;;
@@ -107,7 +107,7 @@ let effective_autoboot_enabled name meta =
 let keepalive_keeper_names config =
   configured_keeper_names config
   |> List.filter_map (fun name ->
-    match read_meta_file_path (keeper_meta_path config name) with
+    match read_meta_file_path (Keeper_types_profile.keeper_meta_path config name) with
     | Ok (Some meta)
       when (not meta.paused) && effective_autoboot_enabled name meta ->
         Some meta.name
@@ -140,7 +140,7 @@ let keepalive_keeper_names config =
 let persistent_agent_names config =
   configured_keeper_names config
   |> List.filter_map (fun name ->
-    match read_meta_file_path (keeper_meta_path config name) with
+    match read_meta_file_path (Keeper_types_profile.keeper_meta_path config name) with
     | Ok (Some meta)
       when (not meta.paused) && effective_autoboot_enabled name meta ->
         Some meta.name
@@ -167,14 +167,14 @@ let read_meta_resolved config name : ((string * keeper_meta) option, string) res
   if requested_name = ""
   then Ok None
   else
-    read_meta_file_path (keeper_meta_path config requested_name)
+    read_meta_file_path (Keeper_types_profile.keeper_meta_path config requested_name)
     |> Result.map (Option.map (fun meta -> requested_name, meta))
 ;;
 
 let read_meta config name : (keeper_meta option, string) result =
   let requested_name = String.trim name in
-  let path = keeper_meta_path config requested_name in
-  if keeper_debug
+  let path = Keeper_types_profile.keeper_meta_path config requested_name in
+  if Keeper_types_profile.keeper_debug
   then
     Log.Keeper.debug
       "read_meta name=%s path=%s exists=%b"
@@ -194,7 +194,7 @@ let read_meta config name : (keeper_meta option, string) result =
 let read_meta_if_changed config name ~(last_mtime : float) : (keeper_meta * float) option =
   let requested_name = String.trim name in
   let read_candidate candidate =
-    let path = keeper_meta_path config candidate in
+    let path = Keeper_types_profile.keeper_meta_path config candidate in
     if not (Fs_compat.file_exists path)
     then None
     else (
@@ -273,7 +273,7 @@ let refresh_progress_updated_line config name =
 ;;
 
 let persist_meta config path persisted =
-  let json = meta_to_json persisted in
+  let json = Keeper_meta_json.meta_to_json persisted in
   match Keeper_fs.save_json_atomic path json with
   | Ok () ->
     !runtime_meta_write_sync_hook config persisted;
@@ -283,7 +283,7 @@ let persist_meta config path persisted =
 ;;
 
 let write_meta ?(force = false) config (m : keeper_meta) : (unit, string) result =
-  let path = keeper_meta_path config m.name in
+  let path = Keeper_types_profile.keeper_meta_path config m.name in
   if force
   then (
     let persisted = { m with meta_version = m.meta_version + 1 } in
@@ -330,7 +330,7 @@ let write_meta_with_merge
       (m : keeper_meta)
   : (unit, string) result
   =
-  let path = keeper_meta_path config m.name in
+  let path = Keeper_types_profile.keeper_meta_path config m.name in
   let rec attempt n (caller : keeper_meta) =
     match write_meta config caller with
     | Ok () -> Ok ()

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -4,6 +4,10 @@
     their public API while durable meta storage is separated from the
     compatibility facade. *)
 
+(* Canonical [keeper_meta] type home. The RFC-0205 #19399 facade cleanup
+   removed the open that previously brought these names into scope, leaving
+   the bare references below unbound. *)
+open Keeper_meta_contract
 
 let runtime_meta_write_sync_hook : (Coord.config -> keeper_meta -> unit) ref =
   ref (fun _ _ -> ())
@@ -20,7 +24,7 @@ let read_meta_file_path path : (keeper_meta option, string) result =
     match Safe_ops.read_json_file_safe path with
     | Error e -> Error e
     | Ok json ->
-      let json, _scrubbed = scrub_persisted_keeper_meta_json ~path json in
+      let json, _scrubbed = Keeper_meta_json_scrub.scrub_persisted_keeper_meta_json ~path json in
       warn_unknown_keeper_meta_keys ~path json;
       (match meta_of_json json with
        | Ok meta -> Ok (Some meta)

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -4,6 +4,10 @@
     keep their public API while durable meta storage is separated
     from the compatibility facade. *)
 
+(* Canonical [keeper_meta] type home. The RFC-0205 #19399 facade cleanup
+   removed the open that previously brought these names into scope, leaving
+   the bare references below unbound. *)
+open Keeper_meta_contract
 
 (** Hook invoked after each successful [write_meta] /
     [write_meta_with_merge]. Reset by the runtime to keep

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -889,8 +889,8 @@ let handle_persona_generate ctx args =
                    ~temperature
                    ~max_tokens
                    ~approval:Approval_callbacks.auto_approve
-                   ~sw:ctx.sw
-                   ?net:ctx.net
+                   ~sw:ctx.Keeper_types_profile.sw
+                   ?net:ctx.Keeper_types_profile.net
                    ())
            with
            | Error err ->

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -537,7 +537,8 @@ let tool_usage_of ~base_path name =
   | None -> []
   | Some entry ->
     StringMap.fold (fun n e acc -> (n, e) :: acc) entry.tool_usage []
-    |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count)
+    |> List.sort (fun (_, (a : tool_call_entry)) (_, (b : tool_call_entry)) ->
+         Int.compare b.count a.count)
 ;;
 
 (* Lookup API (find_by_name / find_by_agent_name / find_by_id /

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -81,6 +81,7 @@ let blocker_class_indicates_overflow (klass : blocker_class) : bool =
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation
+  | No_tool_capable_provider
   | Stay_silent_loop
   | Fiber_unresolved
   | Stale_turn_timeout

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -472,7 +472,7 @@ let execution_summary_json ~meta ~latest_receipt =
     | Some receipt ->
         receipt |> json_member "sandbox"
         |> json_string_opt_member "kind"
-    | None -> Some (Keeper_types_profile_sandbox.sandbox_profile_to_string meta.sandbox_profile)
+    | None -> Some (Keeper_types_profile_sandbox.sandbox_profile_to_string meta.Keeper_meta_contract.sandbox_profile)
   in
   let network_mode =
     match latest_receipt with

--- a/lib/keeper/keeper_sandbox_containment.ml
+++ b/lib/keeper/keeper_sandbox_containment.ml
@@ -17,7 +17,7 @@ let is_hardened_profile = function
   | Keeper_types_profile_sandbox.Local -> false
 
 let check_target ~operation ~config ~meta ~target =
-  if not (is_hardened_profile meta.Keeper_types_profile_sandbox.sandbox_profile) then
+  if not (is_hardened_profile meta.Keeper_meta_contract.sandbox_profile) then
     Ok ()
   else
     let playground = playground_root_abs ~config ~meta in

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -206,7 +206,7 @@ let docker_result_pair = function
    [docker exec] against a warm container. *)
 
 let resolve_sandbox_image meta =
-  match meta.sandbox_image with
+  match meta.Keeper_meta_contract.sandbox_image with
   | Some img when String.trim img <> "" -> img
   | _ -> Env_config_sandbox.Runtime.docker_image ()
 ;;

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -371,7 +371,7 @@ let attention_fields_json (config : Coord_utils.config) (meta : keeper_meta) =
         true, Some "paused", Some "inspect_blocker_before_resume"
       | Some blocker when is_cascade_exhausted_blocker_class blocker.blocker_class ->
         true, Some "cascade_attempts_exhausted", Some "inspect_cascade_attempts"
-      | Some blocker when is_no_tool_capable_blocker_class blocker.blocker_class ->
+      | Some blocker when is_no_tool_capable_provider_blocker_class blocker.blocker_class ->
         true, Some "provider_tool_capability_missing", Some "inspect_provider_tool_lane"
       | Some blocker when is_completion_contract_blocker_class blocker.blocker_class ->
         true, Some "completion_contract_violation", Some "inspect_completion_contract"

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -96,7 +96,7 @@ let is_cascade_exhausted_blocker_class blocker_class =
     (blocker_class_to_string (Cascade_exhausted (Other_detail "")))
 ;;
 
-let is_no_tool_capable_blocker_class blocker_class =
+let is_no_tool_capable_provider_blocker_class blocker_class =
   String.equal blocker_class "cascade_exhausted_no_tool_capable"
 ;;
 
@@ -154,6 +154,12 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
       if summary = ""
       then
         "Provider response violated the required completion/tool contract after dispatch."
+      else summary
+    | No_tool_capable_provider ->
+      (* TEL-OK: string literal in blocker classification summary, not an action handler *)
+      if summary = ""
+      then
+        "No provider candidate advertised the required tool capability for this keeper turn."
       else summary
     (* All remaining blocker_class variants carry no class-specific summary
        transformation — fall back to the live summary or the typed name. *)

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -720,7 +720,7 @@ let handle_keeper_status_config ~(config : Coord.config) ~(agent_name : string) 
 
          let json = `Assoc ([
            ("name", `String name);
-           ("meta", meta_to_json m);
+           ("meta", Keeper_meta_json.meta_to_json m);
            ("goal", `String m.goal);
            ("short_goal", `String m.short_goal);
            ("mid_goal", `String m.mid_goal);

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -495,7 +495,7 @@ let sweep_and_recover (ctx : _ context) =
              && (not (paused_meta_requires_reconcile_recovery meta))
              && not (Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta.name)
         ->
-        let path = Keeper_meta_contract.keeper_meta_path ctx.config name in
+        let path = Keeper_types_profile.keeper_meta_path ctx.config name in
         (try
            Sys.remove path;
            publish_lifecycle

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -177,6 +177,7 @@ let cascade_reason_is_structural_attempt_timeout
   | Keeper_meta_contract.Candidates_filtered_after_cycles
   | Keeper_meta_contract.Max_turns_exceeded
   | Keeper_meta_contract.Capacity_exhausted
+  | Keeper_meta_contract.No_tool_capable
   | Keeper_meta_contract.Other_detail _ -> false
 
 let degraded_retry_bypasses_slot_phase_guard

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -414,4 +414,4 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
        | Ok () ->
          stop_keepalive ~base_path:ctx.config.base_path updated.name;
          start_keepalive ctx updated;
-         tool_result_ok (Yojson.Safe.to_string (meta_to_json updated))))
+         tool_result_ok (Yojson.Safe.to_string (Keeper_meta_json.meta_to_json updated))))

--- a/lib/keeper/keeper_unified_turn_stay_silent.ml
+++ b/lib/keeper/keeper_unified_turn_stay_silent.ml
@@ -78,7 +78,8 @@ let mark_loop_detected ~(config : Coord.config) meta ~streak ~threshold =
     meta
 ;;
 
-let clear_if_recovered ~(config : Coord.config) meta ~previous_streak ~was_latched =
+let clear_if_recovered ~(config : Coord.config) (meta : Keeper_meta_contract.keeper_meta)
+    ~previous_streak ~was_latched =
   if was_latched then begin
     match Keeper_registry.get ~base_path:config.base_path meta.name with
     | Some { Keeper_registry.last_failure_reason =

--- a/lib/keeper/keeper_unified_turn_stay_silent.ml
+++ b/lib/keeper/keeper_unified_turn_stay_silent.ml
@@ -34,7 +34,7 @@ let mark_loop_detected ~(config : Coord.config) meta ~streak ~threshold =
   in
   Keeper_registry.set_failure_reason
     ~base_path:config.base_path
-    meta.name
+    meta.Keeper_meta_contract.name
     (Some failure_reason);
   let stimulus =
     recovery_stimulus

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -54,7 +54,7 @@ let apply_lifecycle ~config ~base_dir ~meta ~final_execution ~current_turn_block
   lifecycle
 ;;
 
-let apply_loop_detectors ~config updated_meta result =
+let apply_loop_detectors ~config (updated_meta : Keeper_meta_contract.keeper_meta) result =
   let updated_meta =
     match
       Keeper_stay_silent_loop_detector.record_turn
@@ -111,7 +111,7 @@ let apply_loop_detectors ~config updated_meta result =
 
 let append_metrics_snapshot
       ~config
-      ~meta
+      ~(meta : Keeper_meta_contract.keeper_meta)
       ~updated_meta
       ~observation
       ~result
@@ -183,7 +183,7 @@ let append_metrics_snapshot
 
 let emit_activity_graph
       ~config
-      ~updated_meta
+      ~(updated_meta : Keeper_meta_contract.keeper_meta)
       ~result
       ~latency_ms
       ~turn_cost
@@ -265,7 +265,8 @@ let emit_activity_graph
       (Printexc.to_string exn)
 ;;
 
-let record_accountability ~config ~updated_meta ~social_state ~result claim =
+let record_accountability ~config ~(updated_meta : Keeper_meta_contract.keeper_meta)
+    ~social_state ~result claim =
   let trace_id = Keeper_id.Trace_id.to_string updated_meta.runtime.trace_id in
   let validated_evidence = KUM.visible_run_validation result in
   let strong_evidence =
@@ -293,7 +294,7 @@ let record_accountability ~config ~updated_meta ~social_state ~result claim =
 ;;
 
 let emit_usage_metrics_and_log
-      ~updated_meta
+      ~(updated_meta : Keeper_meta_contract.keeper_meta)
       ~result
       ~latency_ms
       ~usage_trust
@@ -394,7 +395,8 @@ let emit_usage_metrics_and_log
     outcome_str
 ;;
 
-let persist_success_meta ~config ~original_meta ~updated_meta =
+let persist_success_meta ~config ~(original_meta : Keeper_meta_contract.keeper_meta)
+    ~(updated_meta : Keeper_meta_contract.keeper_meta) =
   let updated_meta =
     if updated_meta.auto_resume_after_sec <> None
     then { updated_meta with auto_resume_after_sec = None }
@@ -431,7 +433,8 @@ let persist_success_meta ~config ~original_meta ~updated_meta =
   updated_meta
 ;;
 
-let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
+let reset_turn_failures_for_stop_reason ~config
+    ~(updated_meta : Keeper_meta_contract.keeper_meta) result =
   match result.Keeper_agent_run.stop_reason with
   | Cascade_runner.TurnBudgetExhausted { turns_used; limit } ->
     Log.Keeper.info

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -110,6 +110,7 @@ let cascade_exhaustion_reason_code
   | Keeper_meta_contract.Structural_attempt_timeout _ ->
     "cascade_exhausted_structural_attempt_timeout"
   | Keeper_meta_contract.Capacity_exhausted -> "cascade_exhausted_capacity_exhausted"
+  | Keeper_meta_contract.No_tool_capable -> "cascade_exhausted_no_tool_capable"
   | Keeper_meta_contract.Other_detail detail -> cascade_exhaustion_detail_code detail
 ;;
 

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -106,7 +106,7 @@ let resolve_keeper_purge_target config requested_name =
   let rec loop = function
     | [] -> None
     | candidate :: rest -> (
-      let candidate_meta_path = Keeper_meta_contract.keeper_meta_path config candidate in
+      let candidate_meta_path = Keeper_types_profile.keeper_meta_path config candidate in
       let candidate_toml_path = Config_dir_resolver.keeper_toml_path_opt candidate in
       match Keeper_meta_store.read_meta_resolved config candidate with
       | Ok (Some (resolved_name, meta)) ->
@@ -262,7 +262,7 @@ let purge_agent_filesystem_artifacts config agent_names =
 
 let purge_keeper_artifacts config requested_name
     ({ keeper_name; agent_name; trace_id; toml_path } : keeper_purge_target) =
-  let keeper_dir = Keeper_meta_store.keeper_dir config in
+  let keeper_dir = Keeper_types_profile.keeper_dir config in
   let keeper_runtime_dir = Filename.concat keeper_dir keeper_name in
   let cleanup_names =
     [ requested_name; keeper_name; agent_name ]
@@ -286,7 +286,7 @@ let purge_keeper_artifacts config requested_name
   List.iter
     (remove_path_if_exists ~context:"keeper_purge")
     [
-      Keeper_meta_contract.keeper_meta_path config keeper_name;
+      Keeper_types_profile.keeper_meta_path config keeper_name;
       Keeper_types_support.keeper_metrics_path config keeper_name;
       Keeper_types_support.keeper_memory_bank_path config keeper_name;
       Keeper_types_support.keeper_generation_index_path config keeper_name;

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -27,7 +27,7 @@ let init_keeper_tool_registry () =
 
 (** Test fixture parser for [keeper_meta] JSON.
 
-    The production parser at [Masc_mcp.Keeper_types.meta_of_json] requires
+    The production parser at [Masc_mcp.Keeper_meta_json_parse.meta_of_json] requires
     explicit [sandbox_profile] / [network_mode] fields (see fail-loud change
     in keeper_meta_json_parse.ml). Test fixtures historically built minimal
     [`Assoc] payloads that omitted those fields and depended on the silent
@@ -53,7 +53,7 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
     | `Assoc fields -> `Assoc (augment fields)
     | other -> other
   in
-  Masc_mcp.Keeper_types.meta_of_json json'
+  Masc_mcp.Keeper_meta_json_parse.meta_of_json json'
 
 (** Walk up the directory tree from [Sys.getcwd()] until
     [config/tool_policy.toml] is found, then return that directory.

--- a/test/test_agent_tool_dispatch_runtime.ml
+++ b/test/test_agent_tool_dispatch_runtime.ml
@@ -51,8 +51,8 @@ let make_meta ?(name = "keeper-exec-tools") ?(policy_voice_enabled = false) ?too
     match tool_access with
     | Some value -> value
     | None ->
-        Masc_mcp.Keeper_types.Preset
-          { preset = Masc_mcp.Keeper_types.Full; also_allow = [] }
+        Masc_mcp.Keeper_meta_tool_access.Preset
+          { preset = Masc_mcp.Keeper_meta_tool_access.Full; also_allow = [] }
   in
   match
     Masc_test_deps.meta_of_json_fixture
@@ -64,7 +64,7 @@ let make_meta ?(name = "keeper-exec-tools") ?(policy_voice_enabled = false) ?too
           ("allowed_paths", `List [ `String "*" ]);
           ("policy_voice_enabled", `Bool policy_voice_enabled);
           ( "tool_access",
-            Masc_mcp.Keeper_types.tool_access_to_json tool_access );
+            Masc_mcp.Keeper_meta_tool_access.tool_access_to_json tool_access );
         ])
   with
   | Ok meta -> meta
@@ -164,7 +164,7 @@ let test_malformed_json_like_payload_detected () =
 
 let test_execute_with_outcome_policy_gate_is_failure () =
   with_exec_fixture
-    ~tool_access:(Masc_mcp.Keeper_types.Custom [ "keeper_tools_list" ])
+    ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "keeper_tools_list" ])
     "agent_tool_dispatch_runtime_policy_gate"
     (fun ~config ~meta ~ctx_work ->
       let result =
@@ -196,7 +196,7 @@ let test_tool_not_allowed_increments_counter () =
   let tool = "tool_read_file" in
   let reason = "not_in_allow_set" in
   with_exec_fixture
-    ~tool_access:(Masc_mcp.Keeper_types.Custom [ "keeper_tools_list" ])
+    ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "keeper_tools_list" ])
     "agent_tool_dispatch_runtime_not_allowed_counter"
     (fun ~config ~meta ~ctx_work ->
       let before = counter_for_tool_not_allowed ~keeper ~tool ~reason in
@@ -229,8 +229,8 @@ let test_tool_not_allowed_denied_by_policy_counter () =
           ; ("trace_id", `String "test-not-allowed-b")
           ; ("allowed_paths", `List [ `String "*" ])
           ; ( "tool_access"
-            , Masc_mcp.Keeper_types.tool_access_to_json
-                (Masc_mcp.Keeper_types.Custom [ "keeper_board_post" ]) )
+            , Masc_mcp.Keeper_meta_tool_access.tool_access_to_json
+                (Masc_mcp.Keeper_meta_tool_access.Custom [ "keeper_board_post" ]) )
           ; ( "tool_denylist"
             , `List [ `String "keeper_board_post" ] )
           ])
@@ -269,7 +269,7 @@ let test_tool_not_allowed_reason_label_is_bounded () =
   (* Verify that the reason label written into the JSON payload is one
      of the three bounded vocabulary values, not a free-form string. *)
   with_exec_fixture
-    ~tool_access:(Masc_mcp.Keeper_types.Custom [ "keeper_tools_list" ])
+    ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "keeper_tools_list" ])
     "agent_tool_dispatch_runtime_reason_bounded"
     (fun ~config ~meta ~ctx_work ->
       let result =
@@ -290,7 +290,7 @@ let test_keeper_tools_list_json_uses_typed_groups () =
     make_meta
       ~policy_voice_enabled:true
       ~tool_access:
-        (Masc_mcp.Keeper_types.Custom
+        (Masc_mcp.Keeper_meta_tool_access.Custom
            [ "keeper_board_post";
              "keeper_board_fake";
              "keeper_voice_speak";

--- a/test/test_agent_tool_execute_safety.ml
+++ b/test/test_agent_tool_execute_safety.ml
@@ -742,9 +742,9 @@ let make_write_enabled_meta name =
         ("trace_id", `String ("trace-" ^ name));
         ("goal", `String "write-enabled Execute test");
         ( "tool_access",
-          Keeper_types.tool_access_to_json
-            (Keeper_types.Preset
-               { preset = Keeper_types.Delivery; also_allow = [] }) );
+          Masc_mcp.Keeper_meta_tool_access.tool_access_to_json
+            (Masc_mcp.Keeper_meta_tool_access.Preset
+               { preset = Masc_mcp.Keeper_meta_tool_access.Delivery; also_allow = [] }) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with

--- a/test/test_agent_tool_search_files_containment.ml
+++ b/test/test_agent_tool_search_files_containment.ml
@@ -79,7 +79,7 @@ let make_meta ~name ~sandbox =
         ("goal", `String "search files containment test");
         ("allowed_paths", `List [ `String "*" ]);
         ( "sandbox_profile",
-          `String (Keeper_types.sandbox_profile_to_string sandbox) );
+          `String (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
@@ -202,7 +202,7 @@ let blocked_by_sandbox_boundary raw =
       || starts_with "path_outside_project_root" err
 
 let test_legacy_keeper_unaffected () =
-  setup ~keeper_name:"alice" ~sandbox:Keeper_types.Local
+  setup ~keeper_name:"alice" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "secret.txt" in
   let raw =
@@ -218,7 +218,7 @@ let test_legacy_keeper_unaffected () =
     (blocked_by_symmetric_sandbox raw)
 
 let test_docker_keeper_blocks_ls_outside () =
-  setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
+  setup ~keeper_name:"minjae" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside_dir = Filename.concat base "outside_playground" in
   ensure_dir outside_dir;
@@ -237,7 +237,7 @@ let test_docker_keeper_blocks_ls_outside () =
     (blocked_by_sandbox_boundary raw)
 
 let test_docker_keeper_blocks_cat_outside () =
-  setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
+  setup ~keeper_name:"minjae" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "host_secret.txt" in
   let factory = Keeper_sandbox_factory.create ~config ~meta () in
@@ -254,7 +254,7 @@ let test_docker_keeper_blocks_cat_outside () =
     (blocked_by_sandbox_boundary raw)
 
 let test_docker_keeper_blocks_rg_outside () =
-  setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
+  setup ~keeper_name:"minjae" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside_dir = Filename.concat base "outside_playground" in
   ensure_dir outside_dir;
@@ -282,7 +282,7 @@ let test_docker_keeper_blocks_rg_outside () =
     (blocked_by_sandbox_boundary raw)
 
 let test_docker_keeper_blocks_find_outside () =
-  setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
+  setup ~keeper_name:"minjae" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside_dir = Filename.concat base "outside_playground" in
   ensure_dir outside_dir;
@@ -306,7 +306,7 @@ let test_docker_keeper_blocks_find_outside () =
     (blocked_by_sandbox_boundary raw)
 
 let test_docker_keeper_allows_inside_playground () =
-  setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
+  setup ~keeper_name:"minjae" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~base:_ ~config ~meta ~playground ->
   let demo = Filename.concat playground "demo.txt" in
   ignore (Fs_compat.save_file_atomic demo "hello inside playground");
@@ -321,7 +321,7 @@ let test_docker_keeper_allows_inside_playground () =
     (blocked_by_sandbox_boundary raw)
 
 let test_docker_relative_repos_path_resolves_inside_playground () =
-  setup ~keeper_name:"provider_k-coding" ~sandbox:Keeper_types.Docker
+  setup ~keeper_name:"provider_k-coding" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~base:_ ~config ~meta ~playground ->
   let repos = Filename.concat playground "repos" in
   ensure_dir repos;
@@ -336,7 +336,7 @@ let test_docker_relative_repos_path_resolves_inside_playground () =
     Alcotest.fail ("bare repos should stay inside playground: " ^ e)
 
 let test_docker_relative_repos_cwd_resolves_inside_playground () =
-  setup ~keeper_name:"provider_k-coding" ~sandbox:Keeper_types.Docker
+  setup ~keeper_name:"provider_k-coding" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~base:_ ~config ~meta ~playground ->
   let repo = Filename.concat playground "repos/masc-mcp" in
   ensure_dir repo;
@@ -351,7 +351,7 @@ let test_docker_relative_repos_cwd_resolves_inside_playground () =
     Alcotest.fail ("relative repos cwd should stay inside playground: " ^ e)
 
 let test_docker_container_cwd_maps_to_host_worktree () =
-  setup ~keeper_name:"executor" ~sandbox:Keeper_types.Docker
+  setup ~keeper_name:"executor" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~base:_ ~config ~meta ~playground ->
   let host_worktree =
     Filename.concat playground "repos/masc-mcp/.worktrees/task-186"
@@ -376,7 +376,7 @@ let test_docker_container_cwd_maps_to_host_worktree () =
   | Error e -> Alcotest.fail ("write cwd should map container path: " ^ e)
 
 let test_docker_container_file_path_maps_to_host_worktree () =
-  setup ~keeper_name:"executor" ~sandbox:Keeper_types.Docker
+  setup ~keeper_name:"executor" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~base:_ ~config ~meta ~playground ->
   let host_file =
     Filename.concat playground
@@ -399,7 +399,7 @@ let test_docker_container_file_path_maps_to_host_worktree () =
   | Error e -> Alcotest.fail ("file path should map container path: " ^ e)
 
 let test_docker_other_container_root_stays_blocked () =
-  setup ~keeper_name:"executor" ~sandbox:Keeper_types.Docker
+  setup ~keeper_name:"executor" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~base:_ ~config ~meta ~playground:_ ->
   let other_container_cwd =
     Filename.concat
@@ -414,7 +414,7 @@ let test_docker_other_container_root_stays_blocked () =
       (String_util.contains_substring e "path_outside_project_root")
 
 let test_docker_git_creds_contained () =
-  setup ~keeper_name:"poe" ~sandbox:Keeper_types.Docker
+  setup ~keeper_name:"poe" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "git_secret.txt" in
   let factory = Keeper_sandbox_factory.create ~config ~meta () in

--- a/test/test_cascade_attempt_provenance.ml
+++ b/test/test_cascade_attempt_provenance.ml
@@ -49,10 +49,10 @@ let test_record_cascade_attempt_round_trips_from_meta () =
       let config = Masc_mcp.Coord.default_config base_path in
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "cascade-attempt-test"));
       let keeper_name = "provenance-keeper" in
-      (match KT.write_meta ~force:true config (make_meta keeper_name) with
+      (match Masc_mcp.Keeper_meta_store.write_meta ~force:true config (make_meta keeper_name) with
        | Ok () -> ()
        | Error err -> fail ("initial write_meta failed: " ^ err));
-      let expected : KT.cascade_attempt_record =
+      let expected : Masc_mcp.Keeper_meta_contract.cascade_attempt_record =
         { provider_id = "runpod_mtp"
         ; http_status = Some 502
         ; outcome = `Failure "GGML_ASSERT(logits!=nullptr)"
@@ -63,7 +63,7 @@ let test_record_cascade_attempt_round_trips_from_meta () =
         ~base_path:config.base_path
         ~keeper_name
         expected;
-      match KT.read_meta config keeper_name with
+      match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
       | Error err -> fail ("read_meta failed: " ^ err)
       | Ok None -> fail "keeper meta missing after cascade attempt write"
       | Ok (Some meta) ->

--- a/test/test_cascade_error_classify_decoder.ml
+++ b/test/test_cascade_error_classify_decoder.ml
@@ -51,7 +51,7 @@ let test_roundtrip_other_detail () =
       "tier-group.primary"
       (Classify.cascade_name_to_string cascade_name);
     (match reason with
-     | Keeper_types.Other_detail msg ->
+     | Masc_mcp.Keeper_meta_contract.Other_detail msg ->
        Alcotest.(check string) "Other_detail payload preserved" "all providers tried" msg
      | _ -> Alcotest.fail "expected Other_detail reason")
   | _ -> Alcotest.fail "expected Cascade_exhausted"
@@ -74,7 +74,7 @@ let test_roundtrip_structural_attempt_timeout () =
   match decoded with
   | Some (Classify.Cascade_exhausted { reason; _ }) ->
     (match reason with
-     | Keeper_types.Structural_attempt_timeout { detail } ->
+     | Masc_mcp.Keeper_meta_contract.Structural_attempt_timeout { detail } ->
        Alcotest.(check string)
          "Structural_attempt_timeout detail preserved"
          "max_execution_time_s exceeded"
@@ -102,7 +102,7 @@ let test_roundtrip_bare_string_reason () =
          (fun fmt _ -> Format.fprintf fmt "reason")
          ( = ))
       "bare string reason decoded"
-      Keeper_types.No_providers_available
+      Masc_mcp.Keeper_meta_contract.No_providers_available
       reason
   | _ -> Alcotest.fail "expected Cascade_exhausted"
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1332,9 +1332,9 @@ let test_keeper_zombie_field_contracts () =
           missing_required_tools = [];
           materialized_tools = [];
         };
-      sandbox_kind = Masc_mcp.Keeper_types.Local;
+      sandbox_kind = Masc_mcp.Keeper_types_profile_sandbox.Local;
       sandbox_root = None;
-      network_mode = Masc_mcp.Keeper_types.Network_none;
+      network_mode = Masc_mcp.Keeper_types_profile_sandbox.Network_none;
       approval_profile = None;
       approval_profile_derived = false;
       cascade_name = Cascade_name.of_string_exn "default";

--- a/test/test_config_runtime_split.ml
+++ b/test/test_config_runtime_split.ml
@@ -5,17 +5,17 @@ let () =
   let seed = Yojson.Safe.from_string {|
 {"name": "test-keeper", "agent_name": "test-agent", "trace_id": "trace-001"}
 |} in
-  let result = Keeper_types.meta_of_json seed in
+  let result = Keeper_meta_json_parse.meta_of_json seed in
   match result with
   | Error msg ->
     Printf.printf "FAIL test1: meta_of_json: %s\n" msg; exit 1
   | Ok meta ->
-    let json = Keeper_types.meta_to_json meta in
+    let json = Keeper_meta_json.meta_to_json meta in
     (match json with
      | `Assoc fields ->
        let keys = List.map fst fields in
        Printf.printf "test1: seed round-trip OK (%d keys)\n" (List.length keys);
-       let config_keys = Keeper_types.config_field_names in
+       let config_keys = Keeper_meta_json_scrub.config_field_names in
        let leaked = List.filter (fun k -> List.mem k config_keys) keys in
        if leaked <> [] then begin
          Printf.printf "FAIL test1: config keys leaked: %s\n" (String.concat ", " leaked);
@@ -32,7 +32,7 @@ let () =
  "compaction_profile": "balanced",
  "total_turns": 42, "total_input_tokens": 1000}
 |} in
-  (match Keeper_types.meta_of_json existing with
+  (match Keeper_meta_json_parse.meta_of_json existing with
    | Error msg ->
      Printf.printf "FAIL test2: legacy JSON parse: %s\n" msg; exit 1
    | Ok meta ->
@@ -49,12 +49,12 @@ let () =
  "sandbox_profile": "docker", "network_mode": "inherit",
  "total_turns": 100}
 |} in
-  (match Keeper_types.meta_of_json existing with
+  (match Keeper_meta_json_parse.meta_of_json existing with
    | Ok meta ->
-     (match Keeper_types.meta_to_json meta with
+     (match Keeper_meta_json.meta_to_json meta with
       | `Assoc fields ->
         let keys = List.map fst fields in
-        let config_keys = Keeper_types.config_field_names in
+        let config_keys = Keeper_meta_json_scrub.config_field_names in
         let leaked = List.filter (fun k -> List.mem k config_keys) keys in
         if leaked <> [] then begin
           Printf.printf "FAIL test3: config keys in output: %s\n" (String.concat ", " leaked);

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -181,9 +181,9 @@ let make_test_meta name =
           ("agent_name", `String name);
           ("trace_id", `String ("trace-" ^ name));
           ( "tool_access",
-            Lib.Keeper_types.tool_access_to_json
-              (Lib.Keeper_types.Preset
-                 { preset = Lib.Keeper_types.Minimal; also_allow = [] }) );
+            Lib.Keeper_meta_tool_access.tool_access_to_json
+              (Lib.Keeper_meta_tool_access.Preset
+                 { preset = Lib.Keeper_meta_tool_access.Minimal; also_allow = [] }) );
         ])
   with
   | Ok meta -> meta

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -467,7 +467,7 @@ let append_execution_receipt
     ?(required_tool_candidates = [])
     config ~keeper_name =
   let meta =
-    match Lib.Keeper_types.read_meta config keeper_name with
+    match Lib.Keeper_meta_store.read_meta config keeper_name with
     | Ok (Some meta) -> meta
     | Ok None -> fail ("keeper meta missing for receipt: " ^ keeper_name)
     | Error err -> fail ("read_meta failed for receipt: " ^ err)
@@ -517,7 +517,7 @@ let append_execution_receipt
       approval_profile = Some "trusted_local";
       approval_profile_derived = false;
       cascade_name =
-        Cascade_name.of_string_exn (Lib.Keeper_types.cascade_name_of_meta meta);
+        Cascade_name.of_string_exn (Lib.Keeper_meta_contract.cascade_name_of_meta meta);
       cascade_selected_model = Some "custom:mock";
       cascade_attempt_count = 2;
       cascade_fallback_applied = true;
@@ -569,7 +569,7 @@ let append_execution_receipt
   let day = Printf.sprintf "%02d.jsonl" tm.tm_mday in
   let base_dir =
     Filename.concat
-      (Lib.Keeper_types.keeper_dir config)
+      (Lib.Keeper_types_profile.keeper_dir config)
       (keeper_name ^ "/execution-receipts")
   in
   let month_dir = Filename.concat base_dir month in

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -115,7 +115,7 @@ let append_keeper_receipt
     ?(tool_requirement = Keeper_agent_tool_surface.Required)
     ?(cascade_outcome : Keeper_execution_receipt.cascade_outcome =
       Cascade_completed) (config : Coord.config)
-    (meta : Keeper_types.keeper_meta) =
+    (meta : Keeper_meta_contract.keeper_meta) =
   let started_at = Masc_domain.now_iso () in
   let ended_at = Masc_domain.now_iso () in
   let receipt : Keeper_execution_receipt.t =
@@ -159,7 +159,7 @@ let append_keeper_receipt
       network_mode = meta.network_mode;
       approval_profile = Some "trusted_local";
       approval_profile_derived = false;
-      cascade_name = Cascade_name.of_string_exn (Keeper_types.cascade_name_of_meta meta);
+      cascade_name = Cascade_name.of_string_exn (Keeper_meta_contract.cascade_name_of_meta meta);
       cascade_selected_model = Some "openai:gpt-5.4";
       cascade_attempt_count = 1;
       cascade_fallback_applied = false;
@@ -186,7 +186,7 @@ let append_keeper_receipt
   Keeper_execution_receipt.append config receipt
 
 let append_keeper_decision_with_null_telemetry
-    (config : Coord.config) (meta : Keeper_types.keeper_meta) =
+    (config : Coord.config) (meta : Keeper_meta_contract.keeper_meta) =
   Fs_compat.append_jsonl
     (Keeper_types_support.keeper_decision_log_path config meta.name)
     (`Assoc
@@ -199,7 +199,7 @@ let append_keeper_decision_with_null_telemetry
       ])
 
 let append_keeper_decision_terminal_reason
-    (config : Coord.config) (meta : Keeper_types.keeper_meta) =
+    (config : Coord.config) (meta : Keeper_meta_contract.keeper_meta) =
   Fs_compat.append_jsonl
     (Keeper_types_support.keeper_decision_log_path config meta.name)
     (`Assoc
@@ -824,7 +824,7 @@ let test_goal_fsm_withholds_stalled_when_activity_is_metadata_only () =
   rewrite_goal_updated_at config ~goal_id:goal.id
     ~updated_at:"2026-04-01T00:00:00Z";
   let meta = make_keeper_meta ~name:"metadata-only-keeper" ~goal_id:goal.id in
-  (match Keeper_types.write_meta ~force:true config meta with
+  (match Keeper_meta_store.write_meta ~force:true config meta with
    | Ok () -> ()
    | Error err -> fail ("write_meta failed: " ^ err));
   let node = Dashboard_goals.dashboard_goals_tree_json ~config |> root_node in
@@ -863,7 +863,7 @@ let test_goal_detail_surfaces_keeper_runtime_trust_and_blockers () =
     | Error msg -> fail msg
   in
   let meta = make_keeper_meta ~name:"goal-keeper" ~goal_id:goal.id in
-  (match Keeper_types.write_meta ~force:true config meta with
+  (match Keeper_meta_store.write_meta ~force:true config meta with
    | Ok () -> ()
    | Error err -> fail ("write_meta failed: " ^ err));
   append_keeper_receipt config meta;
@@ -910,7 +910,7 @@ let test_goal_detail_uses_receipt_disposition_for_required_tool_failure () =
     | Error msg -> fail msg
   in
   let meta = make_keeper_meta ~name:"tool-failure-keeper" ~goal_id:goal.id in
-  (match Keeper_types.write_meta ~force:true config meta with
+  (match Keeper_meta_store.write_meta ~force:true config meta with
    | Ok () -> ()
    | Error err -> fail ("write_meta failed: " ^ err));
   append_keeper_receipt ~reported_tools:[] ~observed_tools:[] ~canonical_tools:[]
@@ -944,7 +944,7 @@ let test_goal_tree_tolerates_null_decision_telemetry () =
     | Error msg -> fail msg
   in
   let meta = make_keeper_meta ~name:"null-telemetry-keeper" ~goal_id:goal.id in
-  (match Keeper_types.write_meta ~force:true config meta with
+  (match Keeper_meta_store.write_meta ~force:true config meta with
    | Ok () -> ()
    | Error err -> fail ("write_meta failed: " ^ err));
   append_keeper_decision_with_null_telemetry config meta;
@@ -983,12 +983,12 @@ let test_goal_detail_does_not_promote_synthetic_blocker_over_receipt () =
         {
           base.runtime with
           last_blocker =
-            Some (Keeper_types.blocker_info_of_class
-                    ~detail:"turn timed out" Keeper_types.Turn_timeout);
+            Some (Keeper_meta_contract.blocker_info_of_class
+                    ~detail:"turn timed out" Keeper_meta_contract.Turn_timeout);
         };
     }
   in
-  (match Keeper_types.write_meta ~force:true config meta with
+  (match Keeper_meta_store.write_meta ~force:true config meta with
    | Ok () -> ()
    | Error err -> fail ("write_meta failed: " ^ err));
   append_keeper_receipt config meta;
@@ -1025,7 +1025,7 @@ let test_goal_detail_promotes_newer_runtime_blocker_over_stale_receipt () =
     | Error msg -> fail msg
   in
   let meta = make_keeper_meta ~name:"newer-blocker-keeper" ~goal_id:goal.id in
-  (match Keeper_types.write_meta ~force:true config meta with
+  (match Keeper_meta_store.write_meta ~force:true config meta with
    | Ok () -> ()
    | Error err -> fail ("write_meta failed: " ^ err));
   append_keeper_receipt config meta;
@@ -1042,13 +1042,13 @@ let test_goal_detail_promotes_newer_runtime_blocker_over_stale_receipt () =
               last_turn_ts = Unix.gettimeofday () +. 60.0;
             };
           last_blocker =
-            Some (Keeper_types.blocker_info_of_class
+            Some (Keeper_meta_contract.blocker_info_of_class
                     ~detail:"Internal error: [masc_oas_error] {\"kind\":\"oas_timeout_budget\"}"
-                    Keeper_types.Turn_timeout);
+                    Keeper_meta_contract.Turn_timeout);
         };
     }
   in
-  (match Keeper_types.write_meta ~force:true config blocked_meta with
+  (match Keeper_meta_store.write_meta ~force:true config blocked_meta with
    | Ok () -> ()
    | Error err -> fail ("write_meta failed: " ^ err));
   match Dashboard_goals.goal_detail_json ~config ~goal_id:goal.id with
@@ -1091,7 +1091,7 @@ let test_goal_detail_keeps_decision_terminal_reason_over_newer_blocker () =
   let meta =
     make_keeper_meta ~name:"decision-over-blocker-keeper" ~goal_id:goal.id
   in
-  (match Keeper_types.write_meta ~force:true config meta with
+  (match Keeper_meta_store.write_meta ~force:true config meta with
    | Ok () -> ()
    | Error err -> fail ("write_meta failed: " ^ err));
   append_keeper_receipt config meta;
@@ -1109,13 +1109,13 @@ let test_goal_detail_keeps_decision_terminal_reason_over_newer_blocker () =
               last_turn_ts = Unix.gettimeofday () +. 60.0;
             };
           last_blocker =
-            Some (Keeper_types.blocker_info_of_class
+            Some (Keeper_meta_contract.blocker_info_of_class
                     ~detail:"Internal error: [masc_oas_error] {\"kind\":\"oas_timeout_budget\"}"
-                    Keeper_types.Turn_timeout);
+                    Keeper_meta_contract.Turn_timeout);
         };
     }
   in
-  (match Keeper_types.write_meta ~force:true config blocked_meta with
+  (match Keeper_meta_store.write_meta ~force:true config blocked_meta with
    | Ok () -> ()
    | Error err -> fail ("write_meta failed: " ^ err));
   match Dashboard_goals.goal_detail_json ~config ~goal_id:goal.id with
@@ -1145,7 +1145,7 @@ let test_goal_detail_derives_attention_from_receipt_disposition () =
     | Error msg -> fail msg
   in
   let meta = make_keeper_meta ~name:"receipt-disposition-keeper" ~goal_id:goal.id in
-  (match Keeper_types.write_meta ~force:true config meta with
+  (match Keeper_meta_store.write_meta ~force:true config meta with
    | Ok () -> ()
    | Error err -> fail ("write_meta failed: " ^ err));
   append_keeper_receipt

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -55,7 +55,7 @@ let make_keeper_meta ?(name = "keeper-a") ?(trace_id = "trace-keeper-a") () =
   | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
 
 let write_keeper_meta config meta =
-  match Keeper_types.write_meta config meta with
+  match Masc_mcp.Keeper_meta_store.write_meta config meta with
   | Ok () -> ()
   | Error err -> Alcotest.fail ("write_meta failed: " ^ err)
 

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -45,7 +45,7 @@ let with_store f =
 
 let make_meta ?(name = "alpha") () =
   match
-    KT.meta_of_json
+    Masc_mcp.Keeper_meta_json_parse.meta_of_json
       (`Assoc
         [
           ("name", `String name);
@@ -105,8 +105,8 @@ let persist_keeper_with_proactive
                  | Some outcome -> outcome
                  | None ->
                    if proactive_count_total > 0
-                   then KT.Proactive_tool_use
-                   else KT.Proactive_never_started);
+                   then Masc_mcp.Keeper_meta_contract.Proactive_tool_use
+                   else Masc_mcp.Keeper_meta_contract.Proactive_never_started);
             };
           autonomous_action_count;
           autonomous_turn_count = autonomous_action_count;
@@ -115,7 +115,7 @@ let persist_keeper_with_proactive
         };
     }
   in
-  match KT.write_meta ~force:true config meta with
+  match Masc_mcp.Keeper_meta_store.write_meta ~force:true config meta with
   | Ok () -> meta
   | Error err -> fail ("write_meta failed: " ^ err)
 
@@ -561,7 +561,7 @@ let test_scheduled_proactive_meta_error_does_not_prove_success () =
   ignore
     (persist_keeper_with_proactive
        ~proactive_last_ts:(now -. 60.0)
-       ~proactive_last_outcome:KT.Proactive_error
+       ~proactive_last_outcome:Masc_mcp.Keeper_meta_contract.Proactive_error
        config ~proactive_enabled:true
        ~name:"alpha" ~total_turns:3 ~autonomous_action_count:2
        ~autonomous_tool_turn_count:2 ~board_reactive_turn_count:1

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -638,7 +638,7 @@ let make_keeper_meta_json
            @ opt_bool "proactive_enabled" proactive_enabled
            @ opt_string "current_task_id" current_task_id))
   with
-  | Ok meta -> Masc_mcp.Keeper_types.meta_to_json meta |> Yojson.Safe.pretty_to_string
+  | Ok meta -> Masc_mcp.Keeper_meta_json.meta_to_json meta |> Yojson.Safe.pretty_to_string
   | Error err -> fail ("keeper meta fixture parse failed: " ^ err)
 ;;
 
@@ -650,9 +650,9 @@ let write_and_register_keeper
     ?current_task_id
     ()
   =
-  Fs_compat.mkdir_p (Masc_mcp.Keeper_types.keeper_dir config);
+  Fs_compat.mkdir_p (Masc_mcp.Keeper_types_profile.keeper_dir config);
   write_file
-    (Masc_mcp.Keeper_types.keeper_meta_path config keeper_name)
+    (Masc_mcp.Keeper_types_profile.keeper_meta_path config keeper_name)
     (make_keeper_meta_json
        ~name:keeper_name
        ~paused:false
@@ -660,7 +660,7 @@ let write_and_register_keeper
        ?proactive_enabled
        ?current_task_id
        ());
-  match Masc_mcp.Keeper_types.read_meta config keeper_name with
+  match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
   | Ok (Some meta) ->
     ignore
       (Masc_mcp.Keeper_registry.register_offline
@@ -684,9 +684,9 @@ let write_keeper_toml_fixture ~config_root ~keeper_name =
 let seed_auth_and_keeper ~base_path ~keeper_name =
   let config = Masc_mcp.Coord.default_config base_path in
   ignore (Masc_mcp.Coord.init config ~agent_name:(Some "bootstrap-admin"));
-  Fs_compat.mkdir_p (Masc_mcp.Keeper_types.keeper_dir config);
+  Fs_compat.mkdir_p (Masc_mcp.Keeper_types_profile.keeper_dir config);
   write_file
-    (Masc_mcp.Keeper_types.keeper_meta_path config keeper_name)
+    (Masc_mcp.Keeper_types_profile.keeper_meta_path config keeper_name)
     (make_keeper_meta_json ~name:keeper_name ());
   ignore
     (Masc_mcp.Auth.enable_auth
@@ -742,7 +742,7 @@ let append_execution_receipt
     ?ended_at
     config ~keeper_name =
   let meta =
-    match Masc_mcp.Keeper_types.read_meta config keeper_name with
+    match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
     | Ok (Some meta) -> meta
     | Ok None -> fail ("keeper meta missing for receipt: " ^ keeper_name)
     | Error err -> fail ("read_meta failed for receipt: " ^ err)
@@ -801,7 +801,7 @@ let append_execution_receipt
       approval_profile_derived = false;
       cascade_name =
         Cascade_name.of_string_exn
-          (Masc_mcp.Keeper_types.cascade_name_of_meta meta);
+          (Masc_mcp.Keeper_meta_contract.cascade_name_of_meta meta);
       cascade_selected_model = Some "custom:mock";
       cascade_attempt_count = 2;
       cascade_fallback_applied;
@@ -818,7 +818,7 @@ let append_execution_receipt
              {
                from_cascade =
                  Cascade_name.of_string_exn
-                   (Masc_mcp.Keeper_types.cascade_name_of_meta meta);
+                   (Masc_mcp.Keeper_meta_contract.cascade_name_of_meta meta);
                to_cascade =
                  Cascade_name.of_string_exn
                    retry_cascade;
@@ -857,7 +857,7 @@ let append_execution_receipt
   let day = Printf.sprintf "%02d.jsonl" tm.tm_mday in
   let base_dir =
     Filename.concat
-      (Masc_mcp.Keeper_types.keeper_dir config)
+      (Masc_mcp.Keeper_types_profile.keeper_dir config)
       (keeper_name ^ "/execution-receipts")
   in
   let month_dir = Filename.concat base_dir month in
@@ -1058,7 +1058,7 @@ let test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404 () =
     "boot route reaches lifecycle handler"
     true
     (contains_substr {|"action":"boot"|} boot_result.body);
-  (match Masc_mcp.Keeper_types.read_meta config keeper_name with
+  (match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
    | Ok (Some meta) ->
        check bool "boot resumes paused keeper meta" false meta.paused
    | Ok None -> fail "keeper meta missing after boot route"
@@ -1083,13 +1083,13 @@ let test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404 () =
     "shutdown route reaches lifecycle handler"
     true
     (contains_substr {|"action":"shutdown"|} shutdown_result.body);
-  (match Masc_mcp.Keeper_types.read_meta config keeper_name with
+  (match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
    | Ok (Some meta) ->
        let updated_meta =
          {
            meta with
            continuity_summary = "stale continuity snapshot";
-           updated_at = Masc_mcp.Keeper_types.now_iso ();
+           updated_at = Masc_domain.now_iso ();
            runtime =
              {
                meta.runtime with
@@ -1097,7 +1097,7 @@ let test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404 () =
              };
          }
        in
-       (match Masc_mcp.Keeper_types.write_meta ~force:true config updated_meta with
+       (match Masc_mcp.Keeper_meta_store.write_meta ~force:true config updated_meta with
         | Ok () -> ()
         | Error err -> fail ("failed to seed continuity summary: " ^ err))
    | Ok None -> fail "keeper meta missing before clear route"
@@ -1126,14 +1126,14 @@ let test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404 () =
     "clear route reports continuity cleanup"
     true
     (contains_substr {|"continuity_cleared":true|} clear_result.body);
-  (match Masc_mcp.Keeper_types.read_meta config keeper_name with
+  (match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
    | Ok (Some meta) ->
        check string "clear resets continuity summary" "" meta.continuity_summary;
        check (float 0.0001) "clear resets continuity freshness" 0.0
          meta.runtime.last_continuity_update_ts
    | Ok None -> fail "keeper meta missing after clear route"
    | Error err -> fail ("failed to read keeper meta after clear: " ^ err));
-  match Masc_mcp.Keeper_types.read_meta config keeper_name with
+  match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
   | Ok (Some meta) -> check bool "shutdown persists paused keeper meta" true meta.paused
   | Ok None -> fail "keeper meta missing after shutdown route"
   | Error err -> fail ("failed to read keeper meta after shutdown: " ^ err)
@@ -1165,7 +1165,7 @@ let test_keeper_directive_resume_updates_paused_meta () =
   require_status "execution GET returns 200 after directive" 200 execution_after_resume;
   check bool "execution reflects resumed keeper after directive" false
     (execution_keeper_paused execution_after_resume.body keeper_name);
-  match Masc_mcp.Keeper_types.read_meta config keeper_name with
+  match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
   | Ok (Some meta) ->
       check bool "directive resume clears paused keeper meta" false meta.paused
   | Ok None -> fail "keeper meta missing after directive resume"
@@ -1237,7 +1237,7 @@ let test_agent_purge_route_removes_keeper_artifacts_and_toml () =
     ~env_overrides:[ "MASC_CONFIG_DIR", config_root ]
   @@ fun ~port ~config ~admin_token ~keeper_name ->
   let meta =
-    match Masc_mcp.Keeper_types.read_meta config keeper_name with
+    match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
     | Ok (Some meta) -> meta
     | Ok None -> fail "keeper meta missing before purge"
     | Error err -> fail ("failed to read keeper meta before purge: " ^ err)
@@ -1272,7 +1272,7 @@ let test_agent_purge_route_removes_keeper_artifacts_and_toml () =
     (contains_substr {|"target_kind":"keeper"|} purge_result.body);
   check bool "keeper purge reports toml deletion" true
     (contains_substr {|"removed_keeper_toml":true|} purge_result.body);
-  (match Masc_mcp.Keeper_types.read_meta config keeper_name with
+  (match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
    | Ok None -> ()
    | Ok (Some _) -> fail "keeper meta should be removed after purge"
    | Error err -> fail ("failed to read keeper meta after purge: " ^ err));
@@ -1291,7 +1291,7 @@ let test_agent_purge_route_removes_keeper_artifacts_and_toml () =
     (Sys.file_exists agent_metrics_dir);
   check bool "keeper runtime directory removed" false
     (Sys.file_exists
-       (Filename.concat (Masc_mcp.Keeper_types.keeper_dir config) keeper_name));
+       (Filename.concat (Masc_mcp.Keeper_types_profile.keeper_dir config) keeper_name));
   check bool "keeper session trace removed" false
     (Sys.file_exists
        (Masc_mcp.Keeper_types_support.keeper_session_dir config
@@ -1754,12 +1754,12 @@ let test_composite_runtime_attention_surfaces_fiber_stop () =
       let keeper_name = "stop_requested_demo" in
       let config = Masc_mcp.Coord.default_config base_path in
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "bootstrap-admin"));
-      Fs_compat.mkdir_p (Masc_mcp.Keeper_types.keeper_dir config);
+      Fs_compat.mkdir_p (Masc_mcp.Keeper_types_profile.keeper_dir config);
       write_file
-        (Masc_mcp.Keeper_types.keeper_meta_path config keeper_name)
+        (Masc_mcp.Keeper_types_profile.keeper_meta_path config keeper_name)
         (make_keeper_meta_json ~name:keeper_name ~paused:false ());
       let meta =
-        match Masc_mcp.Keeper_types.read_meta config keeper_name with
+        match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
         | Ok (Some meta) -> meta
         | Ok None -> fail "keeper meta missing for fiber-stop composite test"
         | Error err -> fail ("read_meta failed: " ^ err)
@@ -1809,12 +1809,12 @@ let test_composite_runtime_attention_ignores_previous_receipt_during_live_turn (
       let keeper_name = "live_turn_previous_receipt_demo" in
       let config = Masc_mcp.Coord.default_config base_path in
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "bootstrap-admin"));
-      Fs_compat.mkdir_p (Masc_mcp.Keeper_types.keeper_dir config);
+      Fs_compat.mkdir_p (Masc_mcp.Keeper_types_profile.keeper_dir config);
       write_file
-        (Masc_mcp.Keeper_types.keeper_meta_path config keeper_name)
+        (Masc_mcp.Keeper_types_profile.keeper_meta_path config keeper_name)
         (make_keeper_meta_json ~name:keeper_name ~paused:false ());
       let meta =
-        match Masc_mcp.Keeper_types.read_meta config keeper_name with
+        match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
         | Ok (Some meta) -> meta
         | Ok None -> fail "keeper meta missing for live-turn receipt test"
         | Error err -> fail ("read_meta failed: " ^ err)

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -417,9 +417,9 @@ let test_dashboard_mission_keeper_brief_registry_lookup_scoped_to_base_path () =
             ("agent_name", `String name);
             ("trace_id", `String ("trace-" ^ name));
             ( "tool_access",
-              Lib.Keeper_types.tool_access_to_json
-                (Lib.Keeper_types.Preset
-                   { preset = Lib.Keeper_types.Minimal; also_allow }) );
+              Lib.Keeper_meta_tool_access.tool_access_to_json
+                (Lib.Keeper_meta_tool_access.Preset
+                   { preset = Lib.Keeper_meta_tool_access.Minimal; also_allow }) );
           ])
     with
     | Ok meta -> meta

--- a/test/test_decision_pipeline.ml
+++ b/test/test_decision_pipeline.ml
@@ -242,7 +242,7 @@ let make_obs_meta name =
     ("sandbox_profile", `String "local");
     ("network_mode", `String "inherit");
   ] in
-  match KTypes.meta_of_json json with
+  match Masc_mcp.Keeper_meta_json_parse.meta_of_json json with
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_obs_meta failed: " ^ err)
 

--- a/test/test_decision_pipeline_observer.ml
+++ b/test/test_decision_pipeline_observer.ml
@@ -118,7 +118,7 @@ let make_obs_meta name =
         ("sandbox_profile", `String "local");
       ]
   in
-  match KTypes.meta_of_json json with
+  match Masc_mcp.Keeper_meta_json_parse.meta_of_json json with
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_obs_meta failed: " ^ err)
 

--- a/test/test_docker_client_mock.ml
+++ b/test/test_docker_client_mock.ml
@@ -40,7 +40,7 @@ let sample_session_plan () =
       ~container_root:"/keeper/sess"
       ~base_path:"/srv/masc"
       ~container_kind:"turn"
-      ~network_mode:Keeper_types.Network_none
+      ~network_mode:Keeper_types_profile_sandbox.Network_none
       ~host_root:"/var/masc/sess"
       ~uid:1
       ~gid:1

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -66,7 +66,7 @@ let sample_session_plan () =
       ~container_root:"/keeper/sess"
       ~base_path:"/srv/masc"
       ~container_kind:"turn"
-      ~network_mode:Keeper_types.Network_none
+      ~network_mode:Keeper_types_profile_sandbox.Network_none
       ~host_root:"/var/masc/sess"
       ~uid:4321
       ~gid:8765

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -423,7 +423,7 @@ let test_fresh_presence_preserves_turn_failures () =
       cleanup_dir base_path)
     (fun () ->
       let config = Masc_mcp.Coord.default_config base_path in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "operator";
@@ -480,7 +480,7 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "tester"));
       let meta = make_meta keeper_name in
       Eio.Switch.run @@ fun sw ->
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "tester";

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -24,7 +24,7 @@ let temp_dir () =
   dir
 
 let meta_from_json json =
-  match KT.meta_of_json json with
+  match Masc_mcp.Keeper_meta_json_parse.meta_of_json json with
   | Ok m -> m
   | Error e -> Alcotest.fail ("meta parse failed: " ^ e)
 

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -31,7 +31,7 @@ let iso_of_unix ts =
     tm.Unix.tm_mday tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
 
 let make_test_meta ?(name = "keeper-sangsu") ?(agent_name = "keeper-sangsu-agent") ()
-    : Keeper_types.keeper_meta =
+    : Keeper_meta_contract.keeper_meta =
   match Masc_test_deps.meta_of_json_fixture
           (`Assoc
              [
@@ -39,9 +39,9 @@ let make_test_meta ?(name = "keeper-sangsu") ?(agent_name = "keeper-sangsu-agent
                ("agent_name", `String agent_name);
                ("trace_id", `String "test-trace-accountability");
                ( "tool_access",
-                 Keeper_types.tool_access_to_json
-                   (Keeper_types.Preset
-                      { preset = Keeper_types.Full; also_allow = [] }) );
+                 Keeper_meta_tool_access.tool_access_to_json
+                   (Keeper_meta_tool_access.Preset
+                      { preset = Keeper_meta_tool_access.Full; also_allow = [] }) );
              ])
   with
   | Ok meta -> meta

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -28,7 +28,7 @@ let make_meta
     ?(policy_voice_enabled = false)
     
     ()
-  : Keeper_types.keeper_meta =
+  : Masc_mcp.Keeper_meta_contract.keeper_meta =
   match Masc_test_deps.meta_of_json_fixture
     (`Assoc [
       ("name", `String name);

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -16,7 +16,7 @@ let make_meta ?(allowed_paths = []) ~name () =
         ("allowed_paths", `List (List.map (fun path -> `String path) allowed_paths));
       ]
   in
-  match KT.meta_of_json json with
+  match Masc_mcp.Keeper_meta_json_parse.meta_of_json json with
   | Ok meta -> meta
   | Error err -> fail ("make_meta: " ^ err)
 
@@ -104,8 +104,8 @@ let test_validate_rejects_star_wildcard () =
         ~config
         ~keeper_name:"keeper"
         ~repo_cli_identity:None
-        ~sandbox_profile:KT.Local
-        ~network_mode:KT.Network_inherit
+        ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Local
+        ~network_mode:Masc_mcp.Keeper_types_profile_sandbox.Network_inherit
         ~allowed_paths:["*"]
     with
     | Ok () -> fail "expected wildcard rejection"
@@ -121,8 +121,8 @@ let test_validate_local_rejects_network_none () =
         ~config
         ~keeper_name:"keeper"
         ~repo_cli_identity:None
-        ~sandbox_profile:KT.Local
-        ~network_mode:KT.Network_none
+        ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Local
+        ~network_mode:Masc_mcp.Keeper_types_profile_sandbox.Network_none
         ~allowed_paths:[]
     with
     | Ok () -> fail "expected local network_mode rejection"
@@ -135,7 +135,7 @@ let test_validate_docker_allows_private_root_paths () =
   with_temp_config (fun config ->
     let allowed =
       [
-        Masc_mcp.Keeper_turn_up_args.private_workspace_root_rel ~sandbox_profile:KT.Docker
+        Masc_mcp.Keeper_turn_up_args.private_workspace_root_rel ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Docker
           "keeper";
       ]
     in
@@ -144,8 +144,8 @@ let test_validate_docker_allows_private_root_paths () =
         ~config
         ~keeper_name:"keeper"
         ~repo_cli_identity:None
-        ~sandbox_profile:KT.Docker
-        ~network_mode:KT.Network_none
+        ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Docker
+        ~network_mode:Masc_mcp.Keeper_types_profile_sandbox.Network_none
         ~allowed_paths:allowed
     with
     | Ok () -> ()
@@ -158,8 +158,8 @@ let test_validate_docker_rejects_paths_outside_private_root () =
         ~config
         ~keeper_name:"keeper"
         ~repo_cli_identity:None
-        ~sandbox_profile:KT.Docker
-        ~network_mode:KT.Network_inherit
+        ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Docker
+        ~network_mode:Masc_mcp.Keeper_types_profile_sandbox.Network_inherit
         ~allowed_paths:["workspace/outside"]
     with
     | Ok () -> fail "expected docker path rejection"

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -15,16 +15,16 @@ module KT = Masc_mcp.Keeper_types
 module MC = Masc_mcp.Keeper_meta_contract
 
 let test_turn_timeout_blocker_class_roundtrip () =
-  let cls = KT.Turn_timeout in
-  let label = KT.blocker_class_to_string cls in
+  let cls = Masc_mcp.Keeper_meta_contract.Turn_timeout in
+  let label = Masc_mcp.Keeper_meta_contract.blocker_class_to_string cls in
   check bool "label non-empty" true (String.length label > 0);
   match MC.blocker_class_of_serialized_string label with
   | Some _ -> ()
   | None -> fail "Turn_timeout label did not parse back"
 
 let test_stale_fleet_batch_blocker_class_roundtrip () =
-  let cls = KT.Stale_fleet_batch in
-  let label = KT.blocker_class_to_string cls in
+  let cls = Masc_mcp.Keeper_meta_contract.Stale_fleet_batch in
+  let label = Masc_mcp.Keeper_meta_contract.blocker_class_to_string cls in
   check string "label" "stale_fleet_batch" label;
   match MC.blocker_class_of_serialized_string label with
   | Some MC.Stale_fleet_batch -> ()
@@ -32,8 +32,8 @@ let test_stale_fleet_batch_blocker_class_roundtrip () =
   | None -> fail "Stale_fleet_batch label did not parse back"
 
 let test_capacity_backpressure_blocker_class_roundtrip () =
-  let cls = KT.Capacity_backpressure in
-  let label = KT.blocker_class_to_string cls in
+  let cls = Masc_mcp.Keeper_meta_contract.Capacity_backpressure in
+  let label = Masc_mcp.Keeper_meta_contract.blocker_class_to_string cls in
   check string "label" "capacity_backpressure" label;
   match MC.blocker_class_of_serialized_string label with
   | Some MC.Capacity_backpressure -> ()
@@ -49,7 +49,7 @@ let test_meta_json_roundtrip_with_auto_pause_blocker () =
     ("sandbox_profile", `String "local");
     ("network_mode", `String "inherit");
   ] in
-  let meta = match KT.meta_of_json base_json with
+  let meta = match Masc_mcp.Keeper_meta_json_parse.meta_of_json base_json with
     | Ok m -> m
     | Error err -> fail ("parse base: " ^ err)
   in
@@ -59,12 +59,12 @@ let test_meta_json_roundtrip_with_auto_pause_blocker () =
     auto_resume_after_sec = Some 3600.0;
     runtime = { meta.runtime with
       last_blocker =
-        Some (KT.blocker_info_of_class
-                ~detail:blocker_text KT.Turn_timeout);
+        Some (Masc_mcp.Keeper_meta_contract.blocker_info_of_class
+                ~detail:blocker_text Masc_mcp.Keeper_meta_contract.Turn_timeout);
     };
   } in
-  let json = KT.meta_to_json paused_meta in
-  let reparsed = match KT.meta_of_json json with
+  let json = Masc_mcp.Keeper_meta_json.meta_to_json paused_meta in
+  let reparsed = match Masc_mcp.Keeper_meta_json_parse.meta_of_json json with
     | Ok m -> m
     | Error err -> fail ("roundtrip: " ^ err)
   in
@@ -75,7 +75,7 @@ let test_meta_json_roundtrip_with_auto_pause_blocker () =
    | Some info ->
      check string "last_blocker.detail preserved" blocker_text info.detail;
      (match info.klass with
-      | KT.Turn_timeout -> ()
+      | Masc_mcp.Keeper_meta_contract.Turn_timeout -> ()
       | _ -> fail "legacy timeout-budget blocker did not collapse to Turn_timeout")
    | None -> fail "last_blocker should be Some after roundtrip")
 
@@ -88,22 +88,22 @@ let test_meta_json_roundtrip_with_stale_storm_blocker () =
     ("sandbox_profile", `String "local");
     ("network_mode", `String "inherit");
   ] in
-  let meta = match KT.meta_of_json base_json with
+  let meta = match Masc_mcp.Keeper_meta_json_parse.meta_of_json base_json with
     | Ok m -> m
     | Error err -> fail ("parse base: " ^ err)
   in
-  let blocker_text = KT.blocker_class_to_string KT.Turn_timeout in
+  let blocker_text = Masc_mcp.Keeper_meta_contract.blocker_class_to_string Masc_mcp.Keeper_meta_contract.Turn_timeout in
   let paused_meta = { meta with
     paused = true;
     auto_resume_after_sec = Some 7200.0;
     runtime = { meta.runtime with
       last_blocker =
-        Some (KT.blocker_info_of_class
-                ~detail:blocker_text KT.Turn_timeout);
+        Some (Masc_mcp.Keeper_meta_contract.blocker_info_of_class
+                ~detail:blocker_text Masc_mcp.Keeper_meta_contract.Turn_timeout);
     };
   } in
-  let json = KT.meta_to_json paused_meta in
-  let reparsed = match KT.meta_of_json json with
+  let json = Masc_mcp.Keeper_meta_json.meta_to_json paused_meta in
+  let reparsed = match Masc_mcp.Keeper_meta_json_parse.meta_of_json json with
     | Ok m -> m
     | Error err -> fail ("roundtrip: " ^ err)
   in
@@ -111,7 +111,7 @@ let test_meta_json_roundtrip_with_stale_storm_blocker () =
    | Some info ->
      check string "last_blocker.detail" blocker_text info.detail;
      (match info.klass with
-      | KT.Turn_timeout -> ()
+      | Masc_mcp.Keeper_meta_contract.Turn_timeout -> ()
       | _ -> fail "blocker klass not Turn_timeout after roundtrip")
    | None -> fail "last_blocker should be Some after roundtrip")
 
@@ -138,7 +138,7 @@ let test_legacy_last_blocker_pair_rejected () =
          ])
     | json -> json
   in
-  match KT.meta_of_json legacy_json with
+  match Masc_mcp.Keeper_meta_json_parse.meta_of_json legacy_json with
   | Ok _ -> fail "legacy blocker pair should be rejected"
   | Error msg ->
     check string
@@ -154,7 +154,7 @@ let test_legacy_last_blocker_string_rejected () =
         (fields @ [ "last_blocker", `String "turn wall-clock timeout exceeded" ])
     | json -> json
   in
-  match KT.meta_of_json legacy_json with
+  match Masc_mcp.Keeper_meta_json_parse.meta_of_json legacy_json with
   | Ok _ -> fail "legacy string last_blocker should be rejected"
   | Error msg ->
     check string
@@ -170,7 +170,7 @@ let test_repo_cli_identity_runtime_meta_rejected () =
       `Assoc (fields @ [ "repo_cli_identity", `String "anyang-keepers" ])
     | json -> json
   in
-  match KT.meta_of_json legacy_json with
+  match Masc_mcp.Keeper_meta_json_parse.meta_of_json legacy_json with
   | Ok _ -> fail "runtime meta repo_cli_identity field should be rejected"
   | Error msg ->
     check string
@@ -206,12 +206,12 @@ let test_persisted_retired_runtime_meta_fields_scrubbed () =
     ~finally:(fun () -> try Sys.remove path with _ -> ())
     (fun () ->
        Yojson.Safe.to_file path legacy_json;
-       let scrubbed, changed = KT.scrub_persisted_keeper_meta_json ~path legacy_json in
+       let scrubbed, changed = Masc_mcp.Keeper_meta_json_scrub.scrub_persisted_keeper_meta_json ~path legacy_json in
        check bool "scrubbed" true changed;
        List.iter
          (fun (key, _) -> check bool (key ^ " removed") false (has_key key scrubbed))
          retired_fields;
-       (match KT.meta_of_json scrubbed with
+       (match Masc_mcp.Keeper_meta_json_parse.meta_of_json scrubbed with
         | Ok _ -> ()
         | Error err -> fail ("scrubbed meta should parse: " ^ err));
        let persisted = Yojson.Safe.from_file path in

--- a/test/test_keeper_benchmark_canary.ml
+++ b/test/test_keeper_benchmark_canary.ml
@@ -56,7 +56,7 @@ let make_meta ?(name = "analyst") ?(models = []) () =
         ("models", `List (List.map (fun value -> `String value) models))
         :: base_fields
   in
-  match KT.meta_of_json (`Assoc fields) with
+  match Masc_mcp.Keeper_meta_json_parse.meta_of_json (`Assoc fields) with
   | Ok meta -> meta
   | Error err -> fail ("meta_of_json failed: " ^ err)
 

--- a/test/test_keeper_cascade_auto_pause_task074.ml
+++ b/test/test_keeper_cascade_auto_pause_task074.ml
@@ -38,7 +38,7 @@ let cascade_name raw = Cascade_name.of_string_exn raw
 let mk_cascade_exhausted () =
   Owne.sdk_error_of_masc_internal_error
     (Owne.Cascade_exhausted
-       { cascade_name = cascade_name "test"; reason = KT.All_providers_failed })
+       { cascade_name = cascade_name "test"; reason = Masc_mcp.Keeper_meta_contract.All_providers_failed })
 
 let mk_no_tool_capable () =
   Owne.sdk_error_of_masc_internal_error

--- a/test/test_keeper_cdal_contract.ml
+++ b/test/test_keeper_cdal_contract.ml
@@ -16,7 +16,7 @@ let make_meta ?(name = "cdal-keeper") ?current_task_id () =
     ; "network_mode", `String "none"
     ; "allowed_paths", `List [ `String "/workspace/project" ]
     ; "active_goal_ids", `List [ `String "goal-cdal" ]
-    ; "tool_access", Keeper_types.tool_access_to_json (Keeper_types.Custom [ "tool_execute" ])
+    ; "tool_access", Keeper_meta_tool_access.tool_access_to_json (Keeper_meta_tool_access.Custom [ "tool_execute" ])
     ]
   in
   let fields =

--- a/test/test_keeper_egress_audit.ml
+++ b/test/test_keeper_egress_audit.ml
@@ -23,7 +23,7 @@ let make_meta ?(paused = false) ?(autoboot_enabled = true) ~name ~sandbox () =
         ("trace_id", `String ("trace-" ^ name));
         ("goal", `String "egress audit test");
         ( "sandbox_profile",
-          `String (Keeper_types.sandbox_profile_to_string sandbox) );
+          `String (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
         ("paused", `Bool paused);
         ("autoboot_enabled", `Bool autoboot_enabled);
       ]
@@ -56,7 +56,7 @@ let write_egress_at path =
 
 let test_docker_ok_when_expected_present () =
   let config = make_config () in
-  let meta = make_meta ~name:"sangsu" ~sandbox:Keeper_types.Docker () in
+  let meta = make_meta ~name:"sangsu" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker () in
   let expected = Masc_mcp.Keeper_sandbox_docker.egress_policy_path ~config ~meta in
   write_egress_at expected;
   let r = Keeper_egress_audit.audit_one ~config ~meta in
@@ -66,7 +66,7 @@ let test_docker_ok_when_expected_present () =
 
 let test_docker_stale_orphan_when_only_host_direct_present () =
   let config = make_config () in
-  let meta = make_meta ~name:"executor" ~sandbox:Keeper_types.Docker () in
+  let meta = make_meta ~name:"executor" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker () in
   let host_direct =
     Keeper_egress_audit.host_direct_egress_path ~config ~meta
   in
@@ -89,7 +89,7 @@ let test_docker_stale_orphan_when_only_host_direct_present () =
 
 let test_docker_missing_when_neither_present () =
   let config = make_config () in
-  let meta = make_meta ~name:"verifier" ~sandbox:Keeper_types.Docker () in
+  let meta = make_meta ~name:"verifier" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker () in
   let r = Keeper_egress_audit.audit_one ~config ~meta in
   match r.status with
   | Keeper_egress_audit.Missing_at_expected _ -> ()
@@ -99,7 +99,7 @@ let test_docker_missing_when_neither_present () =
 
 let test_local_ok_when_expected_present () =
   let config = make_config () in
-  let meta = make_meta ~name:"ramarama" ~sandbox:Keeper_types.Local () in
+  let meta = make_meta ~name:"ramarama" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local () in
   let expected = Masc_mcp.Keeper_sandbox_docker.egress_policy_path ~config ~meta in
   write_egress_at expected;
   let r = Keeper_egress_audit.audit_one ~config ~meta in
@@ -113,7 +113,7 @@ let test_local_missing_does_not_check_orphan () =
      [Missing_at_expected]. *)
   let config = make_config () in
   let meta =
-    make_meta ~name:"velvet-hammer" ~sandbox:Keeper_types.Local ()
+    make_meta ~name:"velvet-hammer" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local ()
   in
   let r = Keeper_egress_audit.audit_one ~config ~meta in
   match r.status with
@@ -124,16 +124,16 @@ let test_local_missing_does_not_check_orphan () =
 
 let test_audit_all_partitions_correctly () =
   let config = make_config () in
-  let m_ok = make_meta ~name:"sangsu" ~sandbox:Keeper_types.Docker () in
+  let m_ok = make_meta ~name:"sangsu" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker () in
   write_egress_at
     (Masc_mcp.Keeper_sandbox_docker.egress_policy_path ~config ~meta:m_ok);
   let m_stale =
-    make_meta ~name:"executor" ~sandbox:Keeper_types.Docker ()
+    make_meta ~name:"executor" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ()
   in
   write_egress_at
     (Keeper_egress_audit.host_direct_egress_path ~config ~meta:m_stale);
   let m_missing =
-    make_meta ~name:"verifier" ~sandbox:Keeper_types.Docker ()
+    make_meta ~name:"verifier" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ()
   in
   let results =
     Keeper_egress_audit.audit_all ~config
@@ -162,7 +162,7 @@ let contains_substring haystack needle =
 
 let test_format_log_line_tags () =
   let config = make_config () in
-  let m = make_meta ~name:"sangsu" ~sandbox:Keeper_types.Docker () in
+  let m = make_meta ~name:"sangsu" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker () in
   let r_missing = Keeper_egress_audit.audit_one ~config ~meta:m in
   Alcotest.(check bool)
     "missing line tagged [egress_audit:missing]" true
@@ -179,9 +179,9 @@ let test_format_log_line_tags () =
 let test_missing_summary_line () =
   let config = make_config () in
   let analyst =
-    make_meta ~name:"analyst" ~sandbox:Keeper_types.Docker ()
+    make_meta ~name:"analyst" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ()
   in
-  let base = make_meta ~name:"base" ~sandbox:Keeper_types.Docker () in
+  let base = make_meta ~name:"base" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker () in
   let results =
     [
       Keeper_egress_audit.audit_one ~config ~meta:base;
@@ -212,17 +212,17 @@ let test_inactive_missing_reason () =
   in
   Alcotest.(check string)
     "active keeper has no suppression reason" ""
-    (reason (make_meta ~name:"active" ~sandbox:Keeper_types.Local ()));
+    (reason (make_meta ~name:"active" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local ()));
   Alcotest.(check string)
     "paused suppresses missing egress warning" "paused"
     (reason
-       (make_meta ~paused:true ~name:"paused" ~sandbox:Keeper_types.Local ()));
+       (make_meta ~paused:true ~name:"paused" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local ()));
   Alcotest.(check string)
     "autoboot disabled suppresses missing egress warning"
     "autoboot_disabled"
     (reason
        (make_meta ~autoboot_enabled:false ~name:"disabled"
-          ~sandbox:Keeper_types.Local ()))
+          ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local ()))
 
 let () =
   Alcotest.run "Keeper Egress Audit"

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -59,7 +59,7 @@ let make_accept_rejected () =
        { scope = "test"; model = None; reason = "no body" })
 
 let test_other_detail_generic_recoverable () =
-  let err = make_cascade_exhausted (KT.Other_detail "transport unavailable") in
+  let err = make_cascade_exhausted (Masc_mcp.Keeper_meta_contract.Other_detail "transport unavailable") in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
     check string "Other_detail (non-quota) -> cascade_exhausted"
@@ -71,7 +71,7 @@ let test_other_detail_generic_recoverable () =
 let test_slot_full_other_detail_maps_to_capacity_backpressure () =
   let err =
     make_cascade_exhausted
-      (KT.Other_detail "slot full, cascading to next provider")
+      (Masc_mcp.Keeper_meta_contract.Other_detail "slot full, cascading to next provider")
   in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
@@ -115,7 +115,7 @@ let test_provider_capacity_backpressure_is_capacity_backpressure () =
     fail "Provider CapacityExhausted should be recoverable as capacity"
 
 let test_all_providers_failed_recoverable () =
-  let err = make_cascade_exhausted KT.All_providers_failed in
+  let err = make_cascade_exhausted Masc_mcp.Keeper_meta_contract.All_providers_failed in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
     check string "All_providers_failed -> cascade_exhausted"
@@ -125,7 +125,7 @@ let test_all_providers_failed_recoverable () =
     fail "Cascade_exhausted with All_providers_failed should be recoverable"
 
 let test_no_providers_available_recoverable () =
-  let err = make_cascade_exhausted KT.No_providers_available in
+  let err = make_cascade_exhausted Masc_mcp.Keeper_meta_contract.No_providers_available in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
     check string "No_providers_available -> cascade_exhausted"
@@ -136,7 +136,7 @@ let test_no_providers_available_recoverable () =
 
 let test_candidates_filtered_specific_reason () =
   (* Specific reasons must keep their existing labels. *)
-  let err = make_cascade_exhausted KT.Candidates_filtered_after_cycles in
+  let err = make_cascade_exhausted Masc_mcp.Keeper_meta_contract.Candidates_filtered_after_cycles in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
     check string "Candidates_filtered keeps specific label"
@@ -146,7 +146,7 @@ let test_candidates_filtered_specific_reason () =
     fail "Candidates_filtered should be recoverable"
 
 let test_max_turns_specific_reason () =
-  let err = make_cascade_exhausted KT.Max_turns_exceeded in
+  let err = make_cascade_exhausted Masc_mcp.Keeper_meta_contract.Max_turns_exceeded in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
     check string "Max_turns keeps specific label" "max_turns" (KEC.degraded_retry_reason_to_string reason)
@@ -179,8 +179,8 @@ let test_accept_rejected_non_recoverable () =
    the keeper loops forever without auto-pause. *)
 let test_auto_recoverable_cascade_exhausted_is_still_cascade_exhausted () =
   let cases =
-    [ (KT.Candidates_filtered_after_cycles, "Candidates_filtered_after_cycles")
-    ; (KT.Max_turns_exceeded, "Max_turns_exceeded")
+    [ (Masc_mcp.Keeper_meta_contract.Candidates_filtered_after_cycles, "Candidates_filtered_after_cycles")
+    ; (Masc_mcp.Keeper_meta_contract.Max_turns_exceeded, "Max_turns_exceeded")
     ]
   in
   List.iter (fun (reason, label) ->
@@ -194,7 +194,7 @@ let test_auto_recoverable_cascade_exhausted_is_still_cascade_exhausted () =
     ) cases
 
 let test_catalog_rotation_preserves_order_without_base_injection () =
-  let err = make_cascade_exhausted KT.All_providers_failed in
+  let err = make_cascade_exhausted Masc_mcp.Keeper_meta_contract.All_providers_failed in
   match
     KEC.degraded_rotation_after_recoverable_error
       ~rotation_cascades:[ "catalog_first"; "base_only" ]
@@ -211,7 +211,7 @@ let test_catalog_rotation_preserves_order_without_base_injection () =
   | None -> fail "Expected catalog-ordered degraded retry"
 
 let test_rotation_skips_direct_tier_after_attempted_tier_group () =
-  let err = make_cascade_exhausted KT.Candidates_filtered_after_cycles in
+  let err = make_cascade_exhausted Masc_mcp.Keeper_meta_contract.Candidates_filtered_after_cycles in
   match
     KEC.degraded_rotation_after_recoverable_error
       ~rotation_cascades:
@@ -371,7 +371,7 @@ let test_server_error_524_is_transient_network_error_and_cascade_rotation () =
 let test_wrapped_524_is_capacity_backpressure () =
   let err =
     make_cascade_exhausted
-      (KT.Other_detail
+      (Masc_mcp.Keeper_meta_contract.Other_detail
          "all tiers failed (last runtime=runtime, error=Server error 524: error \
           code: 524)")
   in

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -40,7 +40,7 @@ let rec ensure_dir path =
     if p <> path then ensure_dir p;
     Unix.mkdir path 0o755)
 
-let make_meta ?(sandbox = Keeper_types.Local) name =
+let make_meta ?(sandbox = Masc_mcp.Keeper_types_profile_sandbox.Local) name =
   let json =
     `Assoc
       [
@@ -50,7 +50,7 @@ let make_meta ?(sandbox = Keeper_types.Local) name =
         ("goal", `String "patch test");
         ("allowed_paths", `List [ `String "*" ]);
         ( "sandbox_profile",
-          `String (Keeper_types.sandbox_profile_to_string sandbox) );
+          `String (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
@@ -66,7 +66,7 @@ let with_eio_fs f =
     ~clock:(Eio.Stdenv.clock env);
   f ()
 
-let setup ?(sandbox = Keeper_types.Local) f =
+let setup ?(sandbox = Masc_mcp.Keeper_types_profile_sandbox.Local) f =
   with_eio_fs @@ fun () ->
   let base = temp_dir () in
   ensure_dir (Filename.concat base Common.masc_dirname);
@@ -94,7 +94,7 @@ let parse_error raw =
 let parse_int raw field =
   parse raw |> Json.member field |> Json.to_int_option
 
-let public_fs_edit_call ~public ~config ~(meta : Keeper_types.keeper_meta) args =
+let public_fs_edit_call ~public ~config ~(meta : Masc_mcp.Keeper_meta_contract.keeper_meta) args =
   let args = Keeper_tool_alias.translate_input ~public args in
   Agent_tool_filesystem_runtime.handle_file_write
     ~turn_sandbox_factory:None
@@ -102,7 +102,7 @@ let public_fs_edit_call ~public ~config ~(meta : Keeper_types.keeper_meta) args 
     ~keeper_name:meta.name
     ~args
 
-let seed_single_playground_repo ~config ~(meta : Keeper_types.keeper_meta) playground =
+let seed_single_playground_repo ~config ~(meta : Masc_mcp.Keeper_meta_contract.keeper_meta) playground =
   let repo = Filename.concat playground "repos/masc-mcp" in
   ensure_dir (Filename.concat repo ".git");
   let mapping : Repo_manager_types.keeper_repo_mapping =

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -18,15 +18,15 @@ module P = Masc_mcp.Prometheus
 (* ----------------------------------------------------------------- *)
 
 (** Build a minimal keeper_meta ref for guards that only read [name]. *)
-let make_meta_ref (name : string) : Masc_mcp.Keeper_types.keeper_meta ref =
+let make_meta_ref (name : string) : Masc_mcp.Keeper_meta_contract.keeper_meta ref =
   let json : Yojson.Safe.t = `Assoc [
     ("name", `String name);
     ("agent_name", `String name);
     ("trace_id", `String "keeper-guards-test");
     ("tool_access",
-      Masc_mcp.Keeper_types.tool_access_to_json
-        (Masc_mcp.Keeper_types.Preset
-           { preset = Masc_mcp.Keeper_types.Full; also_allow = [] }));
+      Masc_mcp.Keeper_meta_tool_access.tool_access_to_json
+        (Masc_mcp.Keeper_meta_tool_access.Preset
+           { preset = Masc_mcp.Keeper_meta_tool_access.Full; also_allow = [] }));
   ] in
   match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> ref meta

--- a/test/test_keeper_identity_parse.ml
+++ b/test/test_keeper_identity_parse.ml
@@ -61,7 +61,7 @@ let test_removed_keeper_cascade_alias_rejected () =
   | Ok meta ->
       fail
         ("expected removed alias rejection, got "
-         ^ Keeper_types.cascade_name_of_meta meta)
+         ^ Keeper_meta_contract.cascade_name_of_meta meta)
 
 let test_unknown_bare_cascade_name_rejected () =
   (* Bare cascade names are no longer accepted. Operators must use
@@ -91,7 +91,7 @@ let test_unknown_bare_cascade_name_rejected () =
   | Ok meta ->
       fail
         ("expected bare cascade rejection, got "
-         ^ Keeper_types.cascade_name_of_meta meta)
+         ^ Keeper_meta_contract.cascade_name_of_meta meta)
 
 let test_missing_trace_id () =
   let json =

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -127,7 +127,7 @@ let has_tool_use_id ~tool_use_id msgs =
 let make_keeper_meta ?(name = "keeper-lifecycle-test")
     ?(trace_id = "trace-keeper-lifecycle") () =
   match
-    KT.meta_of_json
+    Masc_mcp.Keeper_meta_json_parse.meta_of_json
       (`Assoc
         [
           ("name", `String name);
@@ -160,7 +160,7 @@ let build_dense_context ~turns ~max_tokens ~state_reply =
   KEC.append ctx (Agent_sdk.Types.assistant_msg state_reply)
   |> KEC.sync_oas_context
 
-let save_checkpoint ~base_dir ~(meta : KT.keeper_meta) ~ctx =
+let save_checkpoint ~base_dir ~(meta : Masc_mcp.Keeper_meta_contract.keeper_meta) ~ctx =
   let session =
     KEC.create_session ~session_id:(Masc_mcp.Keeper_id.Trace_id.to_string meta.runtime.trace_id) ~base_dir
   in
@@ -210,7 +210,7 @@ let test_post_turn_lifecycle_without_checkpoint_records_skip () =
       check string "skip decision" "skipped:no_checkpoint"
         (KEC.compaction_decision_to_string lifecycle.compaction.decision);
       check string "runtime decision persisted" "skipped:no_checkpoint"
-        (KT.compaction_runtime_decision_to_string
+        (Masc_mcp.Keeper_meta_contract.compaction_runtime_decision_to_string
            lifecycle.updated_meta.runtime.compaction_rt.last_decision);
       check bool "last check ts recorded" true
         (lifecycle.updated_meta.runtime.compaction_rt.last_check_ts > 0.0);
@@ -1031,7 +1031,7 @@ let test_post_turn_resilience_runtime_executor_pauses_handoff () =
             };
         }
       in
-      (match KT.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail ("write_meta failed: " ^ err));
       ignore (KR.register ~base_path:config.base_path meta.name meta);

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -53,7 +53,7 @@ let check_persistence_read_drop_delta ~surface ~reason ~before ~delta =
 let make_keeper_meta ?(name = "keeper-lifecycle-test")
     ?(trace_id = "trace-keeper-lifecycle") () =
   match
-    KT.meta_of_json
+    Masc_mcp.Keeper_meta_json_parse.meta_of_json
       (`Assoc
         [
           ("name", `String name);
@@ -68,7 +68,7 @@ let make_keeper_meta ?(name = "keeper-lifecycle-test")
   | Ok meta -> meta
   | Error err -> fail ("meta_of_json failed: " ^ err)
 
-let base_lifecycle ~(meta : KT.keeper_meta) : KEC.post_turn_lifecycle =
+let base_lifecycle ~(meta : Masc_mcp.Keeper_meta_contract.keeper_meta) : KEC.post_turn_lifecycle =
   {
     updated_meta = meta;
     checkpoint = None;
@@ -237,7 +237,7 @@ let test_keepalive_dispatch_event_rejection_increments_metric () =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       KR.clear ();
       let config = Masc_mcp.Coord.default_config base_dir in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "test-operator";
@@ -308,7 +308,7 @@ let test_heartbeat_history_fallback_counts_malformed_rows () =
       let before_invalid =
         persistence_read_drop_total ~surface ~reason:invalid_reason
       in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "test-operator";

--- a/test/test_keeper_llama_only.ml
+++ b/test/test_keeper_llama_only.ml
@@ -60,7 +60,7 @@ let labels_for_turn meta =
 let make_meta ?(last_model_used = "provider_k-5.1") ?(models = []) () =
   let base =
     match
-    KT.meta_of_json
+    Masc_mcp.Keeper_meta_json_parse.meta_of_json
       (`Assoc
         [
           ("name", `String "keeper-llama-only-test");
@@ -111,7 +111,7 @@ let test_legacy_explicit_models_do_not_override_cascade_resolution () =
 
 let test_meta_of_json_rejects_legacy_models () =
   match
-    KT.meta_of_json
+    Masc_mcp.Keeper_meta_json_parse.meta_of_json
       (`Assoc
         [
           ("name", `String "keeper-llama-only-test");

--- a/test/test_keeper_local_profile_docker_playground.ml
+++ b/test/test_keeper_local_profile_docker_playground.ml
@@ -10,8 +10,8 @@ let make_meta ~name ~sandbox_profile ~network_mode =
       ; "agent_name", `String ("agent-" ^ name)
       ; "trace_id", `String ("trace-" ^ name)
       ; "goal", `String "local profile routing regression"
-      ; "sandbox_profile", `String (KT.sandbox_profile_to_string sandbox_profile)
-      ; "network_mode", `String (KT.network_mode_to_string network_mode)
+      ; "sandbox_profile", `String (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile)
+      ; "network_mode", `String (Masc_mcp.Keeper_types_profile_sandbox.network_mode_to_string network_mode)
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
@@ -23,12 +23,12 @@ let check_effective label expected meta =
   let expected_profile, expected_network = expected in
   check string
     (label ^ " profile")
-    (KT.sandbox_profile_to_string expected_profile)
-    (KT.sandbox_profile_to_string profile);
+    (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string expected_profile)
+    (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string profile);
   check string
     (label ^ " network")
-    (KT.network_mode_to_string expected_network)
-    (KT.network_mode_to_string network)
+    (Masc_mcp.Keeper_types_profile_sandbox.network_mode_to_string expected_network)
+    (Masc_mcp.Keeper_types_profile_sandbox.network_mode_to_string network)
 
 let test_local_profile_stays_local_when_docker_playground_enabled () =
   check bool
@@ -38,24 +38,24 @@ let test_local_profile_stays_local_when_docker_playground_enabled () =
   let meta =
     make_meta
       ~name:"local-keeper"
-      ~sandbox_profile:KT.Local
-      ~network_mode:KT.Network_inherit
+      ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Local
+      ~network_mode:Masc_mcp.Keeper_types_profile_sandbox.Network_inherit
   in
   check_effective
     "declared local"
-    (KT.Local, KT.Network_inherit)
+    (Masc_mcp.Keeper_types_profile_sandbox.Local, Masc_mcp.Keeper_types_profile_sandbox.Network_inherit)
     meta
 
 let test_docker_profile_stays_docker () =
   let meta =
     make_meta
       ~name:"docker-keeper"
-      ~sandbox_profile:KT.Docker
-      ~network_mode:KT.Network_none
+      ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Docker
+      ~network_mode:Masc_mcp.Keeper_types_profile_sandbox.Network_none
   in
   check_effective
     "declared docker"
-    (KT.Docker, KT.Network_none)
+    (Masc_mcp.Keeper_types_profile_sandbox.Docker, Masc_mcp.Keeper_types_profile_sandbox.Network_none)
     meta
 
 let () =

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -95,13 +95,13 @@ let read_json_file path = Yojson.Safe.from_file path
 
 
 let make_meta ?(name = "keeper-bridge-test") ?tool_access ?(tool_denylist = [])
-    ?(sandbox_profile = Masc_mcp.Keeper_types.Local) () =
+    ?(sandbox_profile = Masc_mcp.Keeper_types_profile_sandbox.Local) () =
   let tool_access =
     match tool_access with
     | Some access -> access
     | None ->
-        Masc_mcp.Keeper_types.Preset
-          { preset = Masc_mcp.Keeper_types.Full; also_allow = [] }
+        Masc_mcp.Keeper_meta_tool_access.Preset
+          { preset = Masc_mcp.Keeper_meta_tool_access.Full; also_allow = [] }
   in
   match Masc_test_deps.meta_of_json_fixture
     (`Assoc
@@ -111,16 +111,16 @@ let make_meta ?(name = "keeper-bridge-test") ?tool_access ?(tool_denylist = [])
         ("trace_id", `String (name ^ "-trace"));
         ( "sandbox_profile",
           `String
-            (Masc_mcp.Keeper_types.sandbox_profile_to_string sandbox_profile)
+            (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile)
         );
-        ("tool_access", Masc_mcp.Keeper_types.tool_access_to_json tool_access);
+        ("tool_access", Masc_mcp.Keeper_meta_tool_access.tool_access_to_json tool_access);
         ("tool_denylist", `List (List.map (fun s -> `String s) tool_denylist));
       ])
   with
   | Ok meta -> meta
   | Error e -> failwith e
 
-let with_registered_keeper ~config (meta : Masc_mcp.Keeper_types.keeper_meta) f =
+let with_registered_keeper ~config (meta : Masc_mcp.Keeper_meta_contract.keeper_meta) f =
   let base_path = config.Coord.base_path in
   Masc_mcp.Keeper_registry.unregister ~base_path meta.name;
   ignore (Masc_mcp.Keeper_registry.register ~base_path meta.name meta);
@@ -149,7 +149,7 @@ let test_inject_stores_filtered_masc () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_types.Custom
+        (Masc_mcp.Keeper_meta_tool_access.Custom
            [ "masc_status"; "masc_broadcast"; "masc_messages" ])
       ()
   in
@@ -181,8 +181,8 @@ let test_messaging_preset_exposes_board () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_types.Preset
-           { preset = Masc_mcp.Keeper_types.Messaging; also_allow = [] })
+        (Masc_mcp.Keeper_meta_tool_access.Preset
+           { preset = Masc_mcp.Keeper_meta_tool_access.Messaging; also_allow = [] })
       ()
   in
   let names = KET.keeper_allowed_tool_names meta in
@@ -201,7 +201,7 @@ let test_custom_opens_specific_tools_only () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_types.Custom
+        (Masc_mcp.Keeper_meta_tool_access.Custom
            [ "masc_status"; "masc_tasks"; "masc_join" ])
       ()
   in
@@ -221,7 +221,7 @@ let test_deny_overrides_allow () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_types.Custom
+        (Masc_mcp.Keeper_meta_tool_access.Custom
            [ "masc_status"; "masc_tasks"; "masc_join" ])
       ~tool_denylist:[ "masc_tasks" ] ()
   in
@@ -234,7 +234,7 @@ let test_deny_overrides_allow () =
 let test_custom_empty_blocks_all () =
   prime_keeper_bridge ();
   let meta =
-    make_meta ~tool_access:(Masc_mcp.Keeper_types.Custom []) ()
+    make_meta ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom []) ()
   in
   let names = KET.keeper_allowed_tool_names meta in
   Alcotest.(check int) "no tools" 0 (List.length names)
@@ -244,9 +244,9 @@ let test_preset_with_also_allow_opens_extra_tool () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_types.Preset
+        (Masc_mcp.Keeper_meta_tool_access.Preset
            {
-             preset = Masc_mcp.Keeper_types.Minimal;
+             preset = Masc_mcp.Keeper_meta_tool_access.Minimal;
              also_allow = [ "masc_tasks" ];
            })
       ()
@@ -265,7 +265,7 @@ let test_custom_keeps_registered_inline_board_tool () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_types.Custom
+        (Masc_mcp.Keeper_meta_tool_access.Custom
            [ "keeper_board_post"; "masc_who" ])
       ()
   in
@@ -289,7 +289,7 @@ let test_dashboard_tool_count_uses_schema_ssot () =
       let meta =
         make_meta
           ~tool_access:
-            (Masc_mcp.Keeper_types.Custom [ bridge_name ])
+            (Masc_mcp.Keeper_meta_tool_access.Custom [ bridge_name ])
           ()
       in
       let allowed = KET.keeper_allowed_tool_names meta in
@@ -354,7 +354,7 @@ let test_read_meta_file_rejects_legacy_tool_keys () =
             ("tool_also_allow", `List [ `String "masc_governance_status" ]);
             ("allowed_providers", `List [ `String "provider_k" ]);
           ]);
-      match Masc_mcp.Keeper_types.read_meta_file_path path with
+      match Masc_mcp.Keeper_meta_store.read_meta_file_path path with
       | Ok _ -> Alcotest.fail "expected legacy tool policy rejection"
       | Error e ->
           Alcotest.(check string)
@@ -380,7 +380,7 @@ let test_read_meta_file_rejects_legacy_tool_access_kind () =
             ("trace_id", `String "legacy-unrestricted-trace");
             ("tool_access", `Assoc [ ("kind", `String "unrestricted") ]);
           ]);
-      match Masc_mcp.Keeper_types.read_meta_file_path path with
+      match Masc_mcp.Keeper_meta_store.read_meta_file_path path with
       | Ok _ -> Alcotest.fail "expected legacy tool_access kind rejection"
       | Error e ->
           Alcotest.(check string)
@@ -403,7 +403,7 @@ let test_read_meta_file_defaults_missing_tool_access_without_rewrite () =
             ("sandbox_profile", `String "local");
             ("network_mode", `String "inherit");
           ]);
-      match Masc_mcp.Keeper_types.read_meta_file_path path with
+      match Masc_mcp.Keeper_meta_store.read_meta_file_path path with
       | Error e -> Alcotest.fail e
       | Ok None -> Alcotest.fail "expected keeper meta"
       | Ok (Some meta) ->
@@ -451,9 +451,9 @@ let test_tool_access_preset_empty_json_preserved () =
     | Ok meta -> meta
     | Error e -> failwith e
   in
-  match meta.Masc_mcp.Keeper_types.tool_access with
-  | Masc_mcp.Keeper_types.Preset
-      { preset = Masc_mcp.Keeper_types.Delivery; also_allow } ->
+  match meta.Masc_mcp.Keeper_meta_contract.tool_access with
+  | Masc_mcp.Keeper_meta_tool_access.Preset
+      { preset = Masc_mcp.Keeper_meta_tool_access.Delivery; also_allow } ->
       Alcotest.(check int) "preset empty preserved" 0 (List.length also_allow)
   | _ -> Alcotest.fail "expected delivery preset with empty also_allow"
 
@@ -476,8 +476,8 @@ let test_tool_access_custom_empty_json_preserved () =
     | Ok meta -> meta
     | Error e -> failwith e
   in
-  match meta.Masc_mcp.Keeper_types.tool_access with
-  | Masc_mcp.Keeper_types.Custom names ->
+  match meta.Masc_mcp.Keeper_meta_contract.tool_access with
+  | Masc_mcp.Keeper_meta_tool_access.Custom names ->
       Alcotest.(check int) "custom empty preserved" 0 (List.length names)
   | _ -> Alcotest.fail "expected Custom []"
 
@@ -598,7 +598,7 @@ let test_allowlist_gates_shard_tools () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_types.Custom
+        (Masc_mcp.Keeper_meta_tool_access.Custom
            [ "masc_status"; "masc_tasks" ])
       ()
   in
@@ -624,7 +624,7 @@ let test_approval_pending_bridge_uses_keeper_safe_inline_dispatch () =
       let config = Coord.default_config dir in
       let meta =
         make_meta
-          ~tool_access:(Masc_mcp.Keeper_types.Custom [ "masc_approval_pending" ])
+          ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "masc_approval_pending" ])
           ()
       in
       with_registered_keeper ~config meta (fun () ->
@@ -660,8 +660,8 @@ let test_read_only_preflight_accepts_sandbox_relative_repo_path () =
         let meta =
           make_meta
             ~name:"masc-improver"
-            ~sandbox_profile:Masc_mcp.Keeper_types.Docker
-            ~tool_access:(Masc_mcp.Keeper_types.Custom [ "tool_read_file" ])
+            ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Docker
+            ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "tool_read_file" ])
             ()
         in
         with_registered_keeper ~config meta (fun () ->
@@ -719,8 +719,8 @@ let test_write_preflight_accepts_docker_container_repo_path () =
         let meta =
           make_meta
             ~name:"sangsu"
-            ~sandbox_profile:Masc_mcp.Keeper_types.Docker
-            ~tool_access:(Masc_mcp.Keeper_types.Custom [ "tool_edit_file" ])
+            ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Docker
+            ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "tool_edit_file" ])
             ()
         in
         with_registered_keeper ~config meta (fun () ->
@@ -786,8 +786,8 @@ let test_write_preflight_accepts_sandbox_relative_repo_path () =
         let meta =
           make_meta
             ~name:keeper_name
-            ~sandbox_profile:Masc_mcp.Keeper_types.Docker
-            ~tool_access:(Masc_mcp.Keeper_types.Custom [ "tool_edit_file" ])
+            ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Docker
+            ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "tool_edit_file" ])
             ()
         in
         ignore (Masc_mcp.Keeper_registry.register ~base_path:dir keeper_name meta);
@@ -823,7 +823,7 @@ let test_schemas_match_names () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_types.Custom
+        (Masc_mcp.Keeper_meta_tool_access.Custom
            [ "masc_status"; "masc_join"; "masc_tasks" ])
       ()
   in

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -1,6 +1,6 @@
 (** #9764/#9733/#9769: write_meta CAS retry semantics.
 
-    Verifies that [Keeper_types.write_meta_with_merge] with
+    Verifies that [Keeper_meta_store.write_meta_with_merge] with
     [Keeper_meta_merge.caller_wins]:
       - succeeds when no concurrent writer interferes
       - succeeds after N attempts when the disk version has advanced
@@ -59,23 +59,23 @@ let test_no_conflict_writes_first_attempt () =
     let m0 = make_meta ~name:"alpha" in
     (* Initial write — no existing file. *)
     (match
-       Keeper_types.write_meta_with_merge
+       Keeper_meta_store.write_meta_with_merge
          ~merge:Keeper_meta_merge.caller_wins config m0
      with
      | Ok () -> ()
      | Error e -> fail ("first write failed: " ^ e));
     (* Read what landed on disk and bump caller's version to match. *)
-    let disk = match Keeper_types.read_meta config "alpha" with
+    let disk = match Keeper_meta_store.read_meta config "alpha" with
       | Ok (Some m) -> m
       | _ -> fail "disk read failed"
     in
     let m1 = { disk with goal = "updated goal" } in
     match
-      Keeper_types.write_meta_with_merge
+      Keeper_meta_store.write_meta_with_merge
         ~merge:Keeper_meta_merge.caller_wins config m1
     with
     | Ok () ->
-      let after = match Keeper_types.read_meta config "alpha" with
+      let after = match Keeper_meta_store.read_meta config "alpha" with
         | Ok (Some m) -> m
         | _ -> fail "read after write failed"
       in
@@ -91,17 +91,17 @@ let test_retry_succeeds_after_concurrent_bump () =
     let config = Coord.default_config base_dir in
     ignore (Coord.init config ~agent_name:(Some "operator"));
     let m0 = make_meta ~name:"beta" in
-    (match Keeper_types.write_meta ~force:true config m0 with
+    (match Keeper_meta_store.write_meta ~force:true config m0 with
      | Ok () -> ()
      | Error e -> fail ("seed write failed: " ^ e));
-    let caller_view = match Keeper_types.read_meta config "beta" with
+    let caller_view = match Keeper_meta_store.read_meta config "beta" with
       | Ok (Some m) -> m
       | _ -> fail "seed read failed"
     in
     (* Simulate a concurrent writer bumping the disk version while
        [caller_view] is held by the cycle-completion fiber. *)
     let racing = { caller_view with goal = "racing writer" } in
-    (match Keeper_types.write_meta config racing with
+    (match Keeper_meta_store.write_meta config racing with
      | Ok () -> ()
      | Error e -> fail ("racing write failed: " ^ e));
     (* Now the cycle attempts to write its own payload. CAS would fail
@@ -115,7 +115,7 @@ let test_retry_succeeds_after_concurrent_bump () =
         ()
     in
     (match
-       Keeper_types.write_meta_with_merge
+       Keeper_meta_store.write_meta_with_merge
          ~merge:Keeper_meta_merge.caller_wins config cycle_payload
      with
      | Ok () -> ()
@@ -126,7 +126,7 @@ let test_retry_succeeds_after_concurrent_bump () =
         ~labels:[("keeper_name", "beta")]
         ()
     in
-    let final = match Keeper_types.read_meta config "beta" with
+    let final = match Keeper_meta_store.read_meta config "beta" with
       | Ok (Some m) -> m
       | _ -> fail "final read failed"
     in
@@ -140,9 +140,9 @@ let test_is_version_conflict_error_classifies () =
   let conflict_msg = "meta version conflict for foo: expected 3, disk has 4" in
   let other_msg = "failed to write meta /tmp/x: Permission denied" in
   check bool "classifies version conflict" true
-    (Keeper_types.is_version_conflict_error conflict_msg);
+    (Keeper_meta_store.is_version_conflict_error conflict_msg);
   check bool "rejects unrelated error" false
-    (Keeper_types.is_version_conflict_error other_msg)
+    (Keeper_meta_store.is_version_conflict_error other_msg)
 
 let () =
   run "Keeper_types CAS retry (#9764/#9733/#9769)"

--- a/test/test_keeper_meta_heartbeat_retain_9733.ml
+++ b/test/test_keeper_meta_heartbeat_retain_9733.ml
@@ -1,5 +1,5 @@
 (** #9733 keeper_msg turn migration: pin the contract that
-    [Keeper_types.write_meta_with_merge ~merge:heartbeat_fields_from_disk]
+    [Keeper_meta_store.write_meta_with_merge ~merge:heartbeat_fields_from_disk]
     actually retains the disk-owned heartbeat fields after a CAS
     retry, while letting the caller's payload win at the cycle-owned
     fields.
@@ -58,13 +58,13 @@ let make_meta ~name =
   | Error e -> fail ("meta_of_json failed: " ^ e)
 
 let read_meta_exn config name =
-  match Keeper_types.read_meta config name with
+  match Keeper_meta_store.read_meta config name with
   | Ok (Some meta) -> meta
   | Ok None -> fail ("read_meta returned None for " ^ name)
   | Error err -> fail ("read_meta failed: " ^ err)
 
 let room_cursor meta room_id =
-  meta.Keeper_types.last_seen_seq_by_room
+  meta.Keeper_meta_contract.last_seen_seq_by_room
   |> List.find_map (fun (rid, seq) ->
        if String.equal rid room_id then Some seq else None)
   |> Option.value ~default:0
@@ -95,10 +95,10 @@ let test_caller_wins_cycle_disk_wins_heartbeat () =
       let m = make_meta ~name in
       { m with joined_room_ids = ["r1"] }
     in
-    (match Keeper_types.write_meta ~force:true config m0 with
+    (match Keeper_meta_store.write_meta ~force:true config m0 with
      | Ok () -> ()
      | Error e -> fail ("seed write failed: " ^ e));
-    let caller_view = match Keeper_types.read_meta config name with
+    let caller_view = match Keeper_meta_store.read_meta config name with
       | Ok (Some m) -> m
       | _ -> fail "seed read failed"
     in
@@ -106,7 +106,7 @@ let test_caller_wins_cycle_disk_wins_heartbeat () =
     let heartbeat_payload =
       { caller_view with joined_room_ids = ["r1"; "r2"] }
     in
-    (match Keeper_types.write_meta config heartbeat_payload with
+    (match Keeper_meta_store.write_meta config heartbeat_payload with
      | Ok () -> ()
      | Error e -> fail ("heartbeat write failed: " ^ e));
     (* Cycle fiber: had stale joined_room_ids; writes its own
@@ -121,7 +121,7 @@ let test_caller_wins_cycle_disk_wins_heartbeat () =
         ()
     in
     (match
-       Keeper_types.write_meta_with_merge
+       Keeper_meta_store.write_meta_with_merge
          ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
          config cycle_payload
      with
@@ -133,7 +133,7 @@ let test_caller_wins_cycle_disk_wins_heartbeat () =
         ~labels:[("keeper_name", name)]
         ()
     in
-    let final = match Keeper_types.read_meta config name with
+    let final = match Keeper_meta_store.read_meta config name with
       | Ok (Some m) -> m
       | _ -> fail "final read failed"
     in
@@ -159,13 +159,13 @@ let test_no_race_writes_first_attempt () =
     ignore (Coord.init config ~agent_name:(Some "operator"));
     let m0 = make_meta ~name:"smooth9733" in
     (match
-       Keeper_types.write_meta_with_merge
+       Keeper_meta_store.write_meta_with_merge
          ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
          config m0
      with
      | Ok () -> ()
      | Error e -> fail ("first write failed: " ^ e));
-    let on_disk = match Keeper_types.read_meta config "smooth9733" with
+    let on_disk = match Keeper_meta_store.read_meta config "smooth9733" with
       | Ok (Some m) -> m
       | _ -> fail "read failed"
     in
@@ -188,7 +188,7 @@ let test_message_cursor_updates_persist_before_turn () =
         last_seen_seq_by_room = [ ("default", 0) ];
       }
     in
-    (match Keeper_types.write_meta ~force:true config seed with
+    (match Keeper_meta_store.write_meta ~force:true config seed with
      | Ok () -> ()
      | Error e -> fail ("seed write failed: " ^ e));
     let before = read_meta_exn config name in
@@ -220,14 +220,14 @@ let test_message_cursor_updates_merge_after_cas_race () =
         goal = "seed";
       }
     in
-    (match Keeper_types.write_meta ~force:true config seed with
+    (match Keeper_meta_store.write_meta ~force:true config seed with
      | Ok () -> ()
      | Error e -> fail ("seed write failed: " ^ e));
     let observer_view = read_meta_exn config name in
     let racing_payload =
       { observer_view with goal = "concurrent writer wins other fields" }
     in
-    (match Keeper_types.write_meta config racing_payload with
+    (match Keeper_meta_store.write_meta config racing_payload with
      | Ok () -> ()
      | Error e -> fail ("racing write failed: " ^ e));
     let returned =

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -144,7 +144,7 @@ let write_persona_profile_exn config ~name =
        ])
 
 let write_corrupt_keeper_meta_exn config ~name =
-  write_file (Keeper_types.keeper_meta_path config name) "{not-json"
+  write_file (Keeper_types_profile.keeper_meta_path config name) "{not-json"
 
 let write_keeper_meta_exn ?(autoboot_enabled = true)
     ?(social_model = "bdi_speech_v1")
@@ -176,12 +176,12 @@ let write_keeper_meta_exn ?(autoboot_enabled = true)
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  match Keeper_types.write_meta ~force:true config meta with
+  match Keeper_meta_store.write_meta ~force:true config meta with
   | Ok () -> ()
   | Error e -> fail ("write_meta failed: " ^ e)
 
 let register_keeper_offline_exn config ~name =
-  match Keeper_types.read_meta config name with
+  match Keeper_meta_store.read_meta config name with
   | Ok (Some meta) ->
       ignore
         (Keeper_registry.register_offline ~base_path:config.base_path name meta)
@@ -258,7 +258,7 @@ let test_read_meta_resolved_rejects_meta_aliases () =
       write_keeper_meta_exn config ~name:"alpha-beta" ~trace_id:"trace-alpha";
       List.iter
         (fun alias ->
-          match Keeper_types.read_meta_resolved config alias with
+          match Keeper_meta_store.read_meta_resolved config alias with
           | Ok None -> ()
           | Error e -> fail ("read_meta_resolved failed: " ^ e)
           | Ok (Some (resolved_name, _)) ->
@@ -296,10 +296,10 @@ let test_keeper_listing_ignores_sidecar_json_files () =
         Filename.concat (Keeper_fs.keeper_dir config) "sangsu.dataset.json"
       in
       write_json dataset_path (`Assoc [ ("kind", `String "dataset") ]);
-      let names = Keeper_types.keeper_names config in
+      let names = Keeper_meta_store.keeper_names config in
       check (list string) "keeper_names filters sidecars"
         [ "dot.name"; "sangsu" ] names;
-      let keepalive_names = Keeper_types.keepalive_keeper_names config in
+      let keepalive_names = Keeper_meta_store.keepalive_keeper_names config in
       check (list string) "keepalive_keeper_names filters sidecars"
         [ "dot.name"; "sangsu" ] keepalive_names;
       let ctx = keeper_ctx env sw config "operator" in
@@ -420,7 +420,7 @@ let test_bootable_keeper_names_use_declarative_autoboot_true_over_stale_meta () 
       let bootable_names = Keeper_runtime.bootable_keeper_names config in
       check bool "declarative autoboot true restores bootable keeper" true
         (List.mem "verifier" bootable_names);
-      let keepalive_names = Keeper_types.keepalive_keeper_names config in
+      let keepalive_names = Keeper_meta_store.keepalive_keeper_names config in
       check bool "declarative autoboot true restores keepalive keeper" true
         (List.mem "verifier" keepalive_names);
       let exclusions =
@@ -502,7 +502,7 @@ let test_declarative_autoboot_disabled_skips_boot_without_meta () =
       let bootable_names = Keeper_runtime.bootable_keeper_names config in
       check bool "bootable list excludes declarative autoboot-disabled keeper" false
         (List.mem "sangsu" bootable_names);
-      let keepalive_names = Keeper_types.keepalive_keeper_names config in
+      let keepalive_names = Keeper_meta_store.keepalive_keeper_names config in
       check bool "keepalive list excludes declarative autoboot-disabled keeper" false
         (List.mem "sangsu" keepalive_names))
 
@@ -537,7 +537,7 @@ let test_autoboot_policy_resync_from_declarative_toml () =
       | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
       | Ok updated ->
           check bool "autoboot_enabled resynced from TOML" false
-            updated.Keeper_types.autoboot_enabled)
+            updated.Keeper_meta_contract.autoboot_enabled)
 
 let test_keeper_up_uses_toml_autoboot_default () =
   Eio_main.run @@ fun env ->
@@ -571,7 +571,7 @@ let test_keeper_up_uses_toml_autoboot_default () =
         | None -> fail "expected masc_keeper_up dispatch"
       in
       check bool "keeper_up ok" true ok;
-      match Keeper_types.read_meta config keeper_name with
+      match Keeper_meta_store.read_meta config keeper_name with
       | Ok (Some meta) ->
           check bool "autoboot_enabled defaulted from TOML" false
             meta.autoboot_enabled
@@ -648,7 +648,7 @@ also_allow = ["masc_tasks", "masc_transition"]
         | Ok meta -> meta
         | Error e -> fail ("meta_of_json failed: " ^ e)
       in
-      (match Keeper_types.write_meta ~force:true config stale_meta with
+      (match Keeper_meta_store.write_meta ~force:true config stale_meta with
        | Ok () -> ()
        | Error e -> fail ("write_meta failed: " ^ e));
       let ctx = keeper_ctx env sw config "operator" in
@@ -661,7 +661,7 @@ also_allow = ["masc_tasks", "masc_transition"]
         | None -> fail "expected masc_keeper_up dispatch"
       in
       check bool "keeper_up update ok" true ok;
-      match Keeper_types.read_meta config keeper_name with
+      match Keeper_meta_store.read_meta config keeper_name with
       | Ok (Some meta) ->
           check string "goal resynced" "fresh goal" meta.goal;
           check string "short_goal resynced" "fresh short" meta.short_goal;
@@ -679,13 +679,13 @@ also_allow = ["masc_tasks", "masc_transition"]
             (option string)
             "tool preset resynced"
             (Some "delivery")
-            (Keeper_types.tool_access_preset meta.tool_access
-             |> Option.map Keeper_types.tool_preset_to_string);
+            (Keeper_meta_tool_access.tool_access_preset meta.tool_access
+             |> Option.map Keeper_meta_tool_access.tool_preset_to_string);
           check
             (list string)
             "tool allowlist resynced"
             [ "masc_tasks"; "masc_transition" ]
-            (Keeper_types.tool_access_also_allowlist meta.tool_access);
+            (Keeper_meta_tool_access.tool_access_also_allowlist meta.tool_access);
           check
             (option (float 0.0001))
             "per provider timeout resynced"
@@ -801,7 +801,7 @@ let test_keeper_persona_audit_reports_durable_live_persona_keeper () =
       write_minimal_cascade_toml config_root;
       Unix.putenv "MASC_CONFIG_DIR" config_root;
       Config_dir_resolver.reset ();
-      (match Keeper_types.read_meta config "analyst" with
+      (match Keeper_meta_store.read_meta config "analyst" with
        | Ok (Some meta) ->
            ignore
              (Keeper_registry.register ~base_path:config.base_path "analyst"
@@ -949,7 +949,7 @@ let test_keeper_persona_audit_flags_stale_active_goal_ids () =
       write_minimal_cascade_toml config_root;
       Unix.putenv "MASC_CONFIG_DIR" config_root;
       Config_dir_resolver.reset ();
-      (match Keeper_types.read_meta config "analyst" with
+      (match Keeper_meta_store.read_meta config "analyst" with
        | Ok (Some meta) ->
            ignore
              (Keeper_registry.register ~base_path:config.base_path "analyst"

--- a/test/test_keeper_meta_merge.ml
+++ b/test/test_keeper_meta_merge.ml
@@ -20,7 +20,7 @@ let assert_eq_list ~msg expected got =
       (Printf.sprintf "%s: expected=[%s] got=[%s]" msg
          (String.concat ";" expected) (String.concat ";" got))
 
-let make_meta name : Keeper_types.keeper_meta =
+let make_meta name : Keeper_meta_contract.keeper_meta =
   let json = `Assoc [
     ("name", `String name);
     ("trace_id", `String ("test-trace-" ^ name));

--- a/test/test_keeper_path_ssot.ml
+++ b/test/test_keeper_path_ssot.ml
@@ -44,7 +44,7 @@ let make_meta ~name ~sandbox =
         ("trace_id", `String ("trace-" ^ name));
         ("goal", `String "path ssot invariant test");
         ( "sandbox_profile",
-          `String (Keeper_types.sandbox_profile_to_string sandbox) );
+          `String (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
@@ -95,17 +95,17 @@ let assert_ssot ~name ~sandbox =
        "[%s/%s] host_root_abs_of_meta must equal base_path / \
         allowed_root_rel_of_meta"
        name
-       (Keeper_types.sandbox_profile_to_string sandbox))
+       (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox))
     constructed host_abs
 
 let test_ssot_docker_keeper () =
-  assert_ssot ~name:"sangsu" ~sandbox:Keeper_types.Docker
+  assert_ssot ~name:"sangsu" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
 
 let test_ssot_local_keeper () =
-  assert_ssot ~name:"analyst" ~sandbox:Keeper_types.Local
+  assert_ssot ~name:"analyst" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local
 
 let test_ssot_docker_keeper_with_dashed_name () =
-  assert_ssot ~name:"masc-improver" ~sandbox:Keeper_types.Docker
+  assert_ssot ~name:"masc-improver" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
 
 (* ── Wrong-meta detection: changing the keeper name MUST change the root ── *)
 
@@ -116,8 +116,8 @@ let test_root_depends_on_keeper_name () =
      masc-improver request" symptom proves the roots are in fact
      name-distinct, so this invariant must hold. *)
   let config = make_config () in
-  let m1 = make_meta ~name:"masc-improver" ~sandbox:Keeper_types.Docker in
-  let m2 = make_meta ~name:"analyst" ~sandbox:Keeper_types.Docker in
+  let m1 = make_meta ~name:"masc-improver" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker in
+  let m2 = make_meta ~name:"analyst" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker in
   let r1 = Keeper_sandbox.host_root_abs_of_meta ~config m1 in
   let r2 = Keeper_sandbox.host_root_abs_of_meta ~config m2 in
   Alcotest.(check bool)
@@ -130,10 +130,10 @@ let test_root_depends_on_sandbox_profile () =
      metas that share a name but differ in profile must also diverge. *)
   let config = make_config () in
   let m_docker =
-    make_meta ~name:"sangsu" ~sandbox:Keeper_types.Docker
+    make_meta ~name:"sangsu" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   in
   let m_local =
-    make_meta ~name:"sangsu" ~sandbox:Keeper_types.Local
+    make_meta ~name:"sangsu" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local
   in
   let r_docker = Keeper_sandbox.host_root_abs_of_meta ~config m_docker in
   let r_local = Keeper_sandbox.host_root_abs_of_meta ~config m_local in
@@ -146,7 +146,7 @@ let test_root_depends_on_sandbox_profile () =
 
 let test_ssot_idempotent () =
   let config = make_config () in
-  let meta = make_meta ~name:"scholar" ~sandbox:Keeper_types.Docker in
+  let meta = make_meta ~name:"scholar" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker in
   let r1 = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   let r2 = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   Alcotest.(check string) "host_root_abs_of_meta is pure / idempotent" r1 r2
@@ -236,22 +236,22 @@ let assert_egress_path_ssot ~name ~sandbox =
        "[%s/%s] egress_policy_path must equal host_root_abs_of_meta / \
         egress.json"
        name
-       (Keeper_types.sandbox_profile_to_string sandbox))
+       (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox))
     expected actual
 
 let test_egress_path_docker () =
-  assert_egress_path_ssot ~name:"sangsu" ~sandbox:Keeper_types.Docker
+  assert_egress_path_ssot ~name:"sangsu" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
 
 let test_egress_path_local () =
-  assert_egress_path_ssot ~name:"ramarama" ~sandbox:Keeper_types.Local
+  assert_egress_path_ssot ~name:"ramarama" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local
 
 let test_egress_path_dashed () =
-  assert_egress_path_ssot ~name:"masc-improver" ~sandbox:Keeper_types.Docker
+  assert_egress_path_ssot ~name:"masc-improver" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
 
 let test_egress_path_distinct_per_keeper () =
   let config = make_config () in
-  let m1 = make_meta ~name:"executor" ~sandbox:Keeper_types.Docker in
-  let m2 = make_meta ~name:"analyst" ~sandbox:Keeper_types.Docker in
+  let m1 = make_meta ~name:"executor" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker in
+  let m2 = make_meta ~name:"analyst" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker in
   let p1 = Keeper_sandbox_docker.egress_policy_path ~config ~meta:m1 in
   let p2 = Keeper_sandbox_docker.egress_policy_path ~config ~meta:m2 in
   Alcotest.(check bool)
@@ -260,8 +260,8 @@ let test_egress_path_distinct_per_keeper () =
 
 let test_egress_path_distinct_per_profile () =
   let config = make_config () in
-  let m_docker = make_meta ~name:"executor" ~sandbox:Keeper_types.Docker in
-  let m_local = make_meta ~name:"executor" ~sandbox:Keeper_types.Local in
+  let m_docker = make_meta ~name:"executor" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker in
+  let m_local = make_meta ~name:"executor" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local in
   let p_docker =
     Keeper_sandbox_docker.egress_policy_path ~config ~meta:m_docker
   in

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -97,9 +97,9 @@ let mk_receipt
         ~required_tool_candidates
         ~missing_required_tools
         ()
-  ; sandbox_kind = Masc_mcp.Keeper_types.Local
+  ; sandbox_kind = Masc_mcp.Keeper_types_profile_sandbox.Local
   ; sandbox_root = None
-  ; network_mode = Masc_mcp.Keeper_types.Network_none
+  ; network_mode = Masc_mcp.Keeper_types_profile_sandbox.Network_none
   ; approval_profile = None
   ; approval_profile_derived = false
   ; cascade_name = Cascade_name.of_string_exn "tier-group.default"

--- a/test/test_keeper_paused_cas_retain_9733.ml
+++ b/test/test_keeper_paused_cas_retain_9733.ml
@@ -79,7 +79,7 @@ let test_overflow_pause_marks_auto_resumable () =
     let config = Coord.default_config base_dir in
     ignore (Coord.init config ~agent_name:(Some "operator"));
     let meta = make_meta ~name:"overflow-auto-resume-9733" in
-    (match Keeper_types.write_meta ~force:true config meta with
+    (match Keeper_meta_store.write_meta ~force:true config meta with
      | Ok () -> ()
      | Error e -> fail ("seed failed: " ^ e));
     ignore (Keeper_registry.register ~base_path:base_dir meta.name meta);
@@ -94,7 +94,7 @@ let test_overflow_pause_marks_auto_resumable () =
       "overflow pause gets initial auto_resume_after_sec"
       paused.auto_resume_after_sec;
     let persisted =
-      match Keeper_types.read_meta config meta.name with
+      match Keeper_meta_store.read_meta config meta.name with
       | Ok (Some m) -> m
       | Ok None -> fail "expected persisted meta"
       | Error e -> fail ("read_meta failed: " ^ e)
@@ -112,7 +112,7 @@ let test_sync_pause_auto_resume_flag_sets_backoff () =
     let config = Coord.default_config base_dir in
     ignore (Coord.init config ~agent_name:(Some "operator"));
     let meta = make_meta ~name:"sync-auto-resume-9733" in
-    (match Keeper_types.write_meta ~force:true config meta with
+    (match Keeper_meta_store.write_meta ~force:true config meta with
      | Ok () -> ()
      | Error e -> fail ("seed failed: " ^ e));
     ignore (Keeper_registry.register ~base_path:base_dir meta.name meta);
@@ -149,11 +149,11 @@ let test_pause_caller_wins_heartbeat_disk_wins () =
       let m = make_meta ~name:"pause-race-9733" in
       { m with paused = false; joined_room_ids = ["r1"] }
     in
-    (match Keeper_types.write_meta ~force:true config m0 with
+    (match Keeper_meta_store.write_meta ~force:true config m0 with
      | Ok () -> ()
      | Error e -> fail ("seed failed: " ^ e));
     let overflow_view =
-      match Keeper_types.read_meta config "pause-race-9733" with
+      match Keeper_meta_store.read_meta config "pause-race-9733" with
       | Ok (Some m) -> m
       | _ -> fail "seed read failed"
     in
@@ -161,7 +161,7 @@ let test_pause_caller_wins_heartbeat_disk_wins () =
     let heartbeat_payload =
       { overflow_view with joined_room_ids = ["r1"; "r2"] }
     in
-    (match Keeper_types.write_meta config heartbeat_payload with
+    (match Keeper_meta_store.write_meta config heartbeat_payload with
      | Ok () -> ()
      | Error e -> fail ("heartbeat write failed: " ^ e));
     (* Overflow fiber writes pause with a stale version (the one
@@ -173,13 +173,13 @@ let test_pause_caller_wins_heartbeat_disk_wins () =
        [joined_room_ids = [r1; r2]]. *)
     let pause_payload = { overflow_view with paused = true } in
     (match
-       Keeper_types.write_meta_with_merge
+       Keeper_meta_store.write_meta_with_merge
          ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
          config pause_payload
      with
      | Ok () -> ()
      | Error e -> fail ("pause merged write failed: " ^ e));
-    let final = match Keeper_types.read_meta config "pause-race-9733" with
+    let final = match Keeper_meta_store.read_meta config "pause-race-9733" with
       | Ok (Some m) -> m
       | _ -> fail "final read failed"
     in
@@ -206,29 +206,29 @@ let test_resume_caller_wins_heartbeat_disk_wins () =
       let m = make_meta ~name:"resume-race-9733" in
       { m with paused = true; joined_room_ids = ["r1"] }
     in
-    (match Keeper_types.write_meta ~force:true config m0 with
+    (match Keeper_meta_store.write_meta ~force:true config m0 with
      | Ok () -> ()
      | Error e -> fail ("seed failed: " ^ e));
     let resume_view =
-      match Keeper_types.read_meta config "resume-race-9733" with
+      match Keeper_meta_store.read_meta config "resume-race-9733" with
       | Ok (Some m) -> m
       | _ -> fail "seed read failed"
     in
     let heartbeat_payload =
       { resume_view with joined_room_ids = ["r1"; "r3"] }
     in
-    (match Keeper_types.write_meta config heartbeat_payload with
+    (match Keeper_meta_store.write_meta config heartbeat_payload with
      | Ok () -> ()
      | Error e -> fail ("heartbeat failed: " ^ e));
     let resume_payload = { resume_view with paused = false } in
     (match
-       Keeper_types.write_meta_with_merge
+       Keeper_meta_store.write_meta_with_merge
          ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
          config resume_payload
      with
      | Ok () -> ()
      | Error e -> fail ("resume merged write failed: " ^ e));
-    let final = match Keeper_types.read_meta config "resume-race-9733" with
+    let final = match Keeper_meta_store.read_meta config "resume-race-9733" with
       | Ok (Some m) -> m
       | _ -> fail "final read failed"
     in
@@ -254,7 +254,7 @@ let test_pause_sync_sets_auto_resume_backoff () =
         let m = make_meta ~name:"auto-resume-pause-152" in
         { m with paused = false; auto_resume_after_sec = None }
       in
-      (match Keeper_types.write_meta ~force:true config m0 with
+      (match Keeper_meta_store.write_meta ~force:true config m0 with
        | Ok () -> ()
        | Error e -> fail ("seed failed: " ^ e));
       ignore (Keeper_registry.register ~base_path:base_dir m0.name m0);
@@ -277,7 +277,7 @@ let test_pause_sync_sets_auto_resume_backoff () =
       in
       check bool "auto resume delay is positive" true (pause_delay > 0.0);
       let persisted =
-        match Keeper_types.read_meta config m0.name with
+        match Keeper_meta_store.read_meta config m0.name with
         | Ok (Some m) -> m
         | Ok None -> fail "persisted meta missing"
         | Error e -> fail ("persisted read failed: " ^ e)

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1353,7 +1353,7 @@ let test_record_spawn_slot_denied_emits_metric () =
 
 let make_eio_keeper_context env sw base_path =
   let config = Masc_mcp.Coord.default_config base_path in
-  { Keeper_types.config
+  { Masc_mcp.Keeper_types_profile.config
   ; agent_name = "operator"
   ; sw
   ; clock = Eio.Stdenv.clock env
@@ -1541,7 +1541,7 @@ let test_meta_write_sync_updates_registered_only () =
           Masc_mcp.Keeper_metrics.(to_string RegistryUpdateDropped)
           ~labels ()
       in
-      (match Keeper_types.write_meta ~force:true config (make_meta dormant_name) with
+      (match Masc_mcp.Keeper_meta_store.write_meta ~force:true config (make_meta dormant_name) with
        | Ok () -> ()
        | Error err -> fail ("write_meta dormant failed: " ^ err));
       let dropped_after =
@@ -1557,7 +1557,7 @@ let test_meta_write_sync_updates_registered_only () =
       let live_meta = make_meta live_name in
       ignore (R.register ~base_path live_name live_meta);
       let updated_meta = { live_meta with goal = "updated from disk write" } in
-      (match Keeper_types.write_meta ~force:true config updated_meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta ~force:true config updated_meta with
        | Ok () -> ()
        | Error err -> fail ("write_meta live failed: " ^ err));
       match R.get ~base_path live_name with
@@ -1705,12 +1705,12 @@ let test_directive_pause_persists_meta () =
     (fun () ->
       let config = make_test_config base_dir in
       let meta = make_meta "dpersist" in
-      (match Keeper_types.write_meta ~force:true config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta ~force:true config meta with
        | Ok () -> ()
        | Error err -> fail ("write_meta failed: " ^ err));
       ignore (R.register ~base_path:base_dir "dpersist" meta);
       KK.process_directive ~agent_name:"agent-dpersist" "pause";
-      match Keeper_types.read_meta config "dpersist" with
+      match Masc_mcp.Keeper_meta_store.read_meta config "dpersist" with
       | Ok (Some persisted) ->
           check bool "paused persisted" true persisted.paused
       | Ok None -> fail "expected persisted meta"
@@ -1724,12 +1724,12 @@ let test_directive_claim_persists_meta () =
     (fun () ->
       let config = make_test_config base_dir in
       let meta = make_meta "dclaimpersist" in
-      (match Keeper_types.write_meta ~force:true config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta ~force:true config meta with
        | Ok () -> ()
        | Error err -> fail ("write_meta failed: " ^ err));
       ignore (R.register ~base_path:base_dir "dclaimpersist" meta);
       KK.process_directive ~agent_name:"agent-dclaimpersist" "claim:T-77";
-      match Keeper_types.read_meta config "dclaimpersist" with
+      match Masc_mcp.Keeper_meta_store.read_meta config "dclaimpersist" with
       | Ok (Some persisted) ->
           (match persisted.current_task_id with
            | Some task_id ->
@@ -1810,8 +1810,8 @@ let test_board_signal_wakeup_ignores_unmatched_posts_without_opt_in () =
         let config = make_test_config base_dir in
         let alpha = make_meta "alpha" in
         let beta = make_meta "beta" in
-        ignore (Keeper_types.write_meta ~force:true config alpha);
-        ignore (Keeper_types.write_meta ~force:true config beta);
+        ignore (Masc_mcp.Keeper_meta_store.write_meta ~force:true config alpha);
+        ignore (Masc_mcp.Keeper_meta_store.write_meta ~force:true config beta);
         let entry_a = R.register ~base_path:base_dir "alpha" alpha in
         let entry_b = R.register ~base_path:base_dir "beta" beta in
         let post =
@@ -1856,8 +1856,8 @@ let test_board_signal_wakeup_only_wakes_opted_in_scope_keeper () =
         let opted_in_base = make_meta "opted-in" in
         let opted_in = { opted_in_base with room_signal_prompt_enabled = true } in
         let defaulted = make_meta "defaulted" in
-        ignore (Keeper_types.write_meta ~force:true config opted_in);
-        ignore (Keeper_types.write_meta ~force:true config defaulted);
+        ignore (Masc_mcp.Keeper_meta_store.write_meta ~force:true config opted_in);
+        ignore (Masc_mcp.Keeper_meta_store.write_meta ~force:true config defaulted);
         let entry_a = R.register ~base_path:base_dir "opted-in" opted_in in
         let entry_b = R.register ~base_path:base_dir "defaulted" defaulted in
         let post =
@@ -1907,7 +1907,7 @@ let test_board_signal_explicit_mention_resumes_paused_keeper () =
         Masc_mcp.Board_dispatch.init_jsonl ();
         let config = make_test_config base_dir in
         let paused = { (make_meta "sleepy") with paused = true } in
-        (match Keeper_types.write_meta ~force:true config paused with
+        (match Masc_mcp.Keeper_meta_store.write_meta ~force:true config paused with
          | Ok () -> ()
          | Error err -> fail ("write_meta failed: " ^ err));
         let entry = R.register ~base_path:base_dir "sleepy" paused in
@@ -1938,7 +1938,7 @@ let test_board_signal_explicit_mention_resumes_paused_keeper () =
         check int "paused keeper queued board stimulus" 1
           (Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:base_dir "sleepy"
            |> Keeper_event_queue.length);
-        (match Keeper_types.read_meta config "sleepy" with
+        (match Masc_mcp.Keeper_meta_store.read_meta config "sleepy" with
          | Ok (Some persisted) ->
            check bool "paused meta resumed" false persisted.paused
          | Ok None -> fail "expected persisted meta"
@@ -1964,8 +1964,8 @@ let test_board_signal_wakeup_keeps_thread_reply_after_self_comment () =
         let config = make_test_config base_dir in
         let participant = make_meta "participant" in
         let bystander = make_meta "bystander" in
-        ignore (Keeper_types.write_meta ~force:true config participant);
-        ignore (Keeper_types.write_meta ~force:true config bystander);
+        ignore (Masc_mcp.Keeper_meta_store.write_meta ~force:true config participant);
+        ignore (Masc_mcp.Keeper_meta_store.write_meta ~force:true config bystander);
         let entry_a = R.register ~base_path:base_dir "participant" participant in
         let entry_b = R.register ~base_path:base_dir "bystander" bystander in
         let post =

--- a/test/test_keeper_repo_readiness.ml
+++ b/test/test_keeper_repo_readiness.ml
@@ -4,7 +4,7 @@ open Alcotest
 
 module Keeper_types = Masc_mcp.Keeper_types
 
-let make_meta ?(sandbox = Keeper_types.Docker) name =
+let make_meta ?(sandbox = Masc_mcp.Keeper_types_profile_sandbox.Docker) name =
   let json =
     `Assoc
       [
@@ -13,7 +13,7 @@ let make_meta ?(sandbox = Keeper_types.Docker) name =
         ("trace_id", `String ("trace-" ^ name));
         ("goal", `String "repo readiness test");
         ( "sandbox_profile",
-          `String (Keeper_types.sandbox_profile_to_string sandbox) );
+          `String (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with

--- a/test/test_keeper_rollover_gate.ml
+++ b/test/test_keeper_rollover_gate.ml
@@ -27,46 +27,46 @@ let decision_testable =
 let overflow_class_is_recognized () =
   check bool "Sdk_token_budget_exceeded → overflow"
     true
-    (KR.blocker_class_indicates_overflow KT.Sdk_token_budget_exceeded)
+    (KR.blocker_class_indicates_overflow Masc_mcp.Keeper_meta_contract.Sdk_token_budget_exceeded)
 
 let non_overflow_classes_are_not_matched () =
   (* Exhaustive: every variant other than [Sdk_token_budget_exceeded] is
      not an overflow signal.  Adding a new [blocker_class] variant forces
      a compile error in [Keeper_rollover.blocker_class_indicates_overflow]
      — the catch-all is intentionally omitted. *)
-  let cases : KT.blocker_class list = [
-    KT.Cascade_exhausted KT.No_providers_available;
-    KT.Cascade_exhausted KT.All_providers_failed;
-    KT.Cascade_exhausted KT.Max_turns_exceeded;
-    KT.Capacity_backpressure;
-    KT.Ambiguous_post_commit_timeout;
-    KT.Ambiguous_post_commit_failure;
-    KT.Oas_agent_execution_timeout;
-    KT.Autonomous_slot_wait_timeout;
-    KT.Admission_queue_wait_timeout;
-    KT.Turn_timeout_after_queue_wait;
-    KT.Turn_timeout;
-    KT.Turn_timeout;
-    KT.Turn_livelock_blocked;
-    KT.Completion_contract_violation;
-    KT.No_tool_capable_provider;
-    KT.Fiber_unresolved;
-    KT.Stale_turn_timeout;
-    KT.Stale_fleet_batch;
-    KT.Sdk_max_turns_exceeded;
-    KT.Sdk_cost_budget_exceeded;
-    KT.Sdk_unrecognized_stop_reason;
-    KT.Sdk_idle_detected;
-    KT.Sdk_tool_retry_exhausted;
-    KT.Sdk_guardrail_violation;
-    KT.Sdk_tripwire_violation;
-    KT.Sdk_exit_condition_met;
+  let cases : Masc_mcp.Keeper_meta_contract.blocker_class list = [
+    Masc_mcp.Keeper_meta_contract.Cascade_exhausted Masc_mcp.Keeper_meta_contract.No_providers_available;
+    Masc_mcp.Keeper_meta_contract.Cascade_exhausted Masc_mcp.Keeper_meta_contract.All_providers_failed;
+    Masc_mcp.Keeper_meta_contract.Cascade_exhausted Masc_mcp.Keeper_meta_contract.Max_turns_exceeded;
+    Masc_mcp.Keeper_meta_contract.Capacity_backpressure;
+    Masc_mcp.Keeper_meta_contract.Ambiguous_post_commit_timeout;
+    Masc_mcp.Keeper_meta_contract.Ambiguous_post_commit_failure;
+    Masc_mcp.Keeper_meta_contract.Oas_agent_execution_timeout;
+    Masc_mcp.Keeper_meta_contract.Autonomous_slot_wait_timeout;
+    Masc_mcp.Keeper_meta_contract.Admission_queue_wait_timeout;
+    Masc_mcp.Keeper_meta_contract.Turn_timeout_after_queue_wait;
+    Masc_mcp.Keeper_meta_contract.Turn_timeout;
+    Masc_mcp.Keeper_meta_contract.Turn_timeout;
+    Masc_mcp.Keeper_meta_contract.Turn_livelock_blocked;
+    Masc_mcp.Keeper_meta_contract.Completion_contract_violation;
+    Masc_mcp.Keeper_meta_contract.No_tool_capable_provider;
+    Masc_mcp.Keeper_meta_contract.Fiber_unresolved;
+    Masc_mcp.Keeper_meta_contract.Stale_turn_timeout;
+    Masc_mcp.Keeper_meta_contract.Stale_fleet_batch;
+    Masc_mcp.Keeper_meta_contract.Sdk_max_turns_exceeded;
+    Masc_mcp.Keeper_meta_contract.Sdk_cost_budget_exceeded;
+    Masc_mcp.Keeper_meta_contract.Sdk_unrecognized_stop_reason;
+    Masc_mcp.Keeper_meta_contract.Sdk_idle_detected;
+    Masc_mcp.Keeper_meta_contract.Sdk_tool_retry_exhausted;
+    Masc_mcp.Keeper_meta_contract.Sdk_guardrail_violation;
+    Masc_mcp.Keeper_meta_contract.Sdk_tripwire_violation;
+    Masc_mcp.Keeper_meta_contract.Sdk_exit_condition_met;
   ] in
   List.iter
     (fun klass ->
       check bool
         (Printf.sprintf "non-overflow class: %s"
-           (KT.blocker_class_to_string klass))
+           (Masc_mcp.Keeper_meta_contract.blocker_class_to_string klass))
         false
         (KR.blocker_class_indicates_overflow klass))
     cases
@@ -74,11 +74,11 @@ let non_overflow_classes_are_not_matched () =
 (* Test fixtures for the typed blocker_info inputs.  Detail strings are
    intentionally redacted to placeholder text — the gate semantics depend
    only on [klass]. *)
-let overflow_info : KT.blocker_info =
-  { klass = KT.Sdk_token_budget_exceeded; detail = "<opaque-detail>" }
+let overflow_info : Masc_mcp.Keeper_meta_contract.blocker_info =
+  { klass = Masc_mcp.Keeper_meta_contract.Sdk_token_budget_exceeded; detail = "<opaque-detail>" }
 
-let non_overflow_info : KT.blocker_info =
-  { klass = KT.Sdk_max_turns_exceeded; detail = "<opaque-detail>" }
+let non_overflow_info : Masc_mcp.Keeper_meta_contract.blocker_info =
+  { klass = Masc_mcp.Keeper_meta_contract.Sdk_max_turns_exceeded; detail = "<opaque-detail>" }
 
 let gate_skips_when_auto_handoff_disabled () =
   let decision =
@@ -87,7 +87,7 @@ let gate_skips_when_auto_handoff_disabled () =
       ~cooldown_elapsed:true
       ~ratio:0.99
       ~handoff_threshold:0.85
-      ~last_outcome:KT.Proactive_error
+      ~last_outcome:Masc_mcp.Keeper_meta_contract.Proactive_error
       ~last_blocker_info:(Some overflow_info)
       ()
   in
@@ -101,7 +101,7 @@ let gate_skips_when_cooldown_active () =
       ~cooldown_elapsed:false
       ~ratio:0.99
       ~handoff_threshold:0.85
-      ~last_outcome:KT.Proactive_error
+      ~last_outcome:Masc_mcp.Keeper_meta_contract.Proactive_error
       ~last_blocker_info:(Some overflow_info)
       ()
   in
@@ -114,7 +114,7 @@ let gate_fires_on_ratio () =
       ~cooldown_elapsed:true
       ~ratio:0.90
       ~handoff_threshold:0.85
-      ~last_outcome:KT.Proactive_silent
+      ~last_outcome:Masc_mcp.Keeper_meta_contract.Proactive_silent
       ~last_blocker_info:None
       ()
   in
@@ -131,7 +131,7 @@ let gate_fires_on_persistent_overflow_despite_low_ratio () =
       ~cooldown_elapsed:true
       ~ratio:0.045  (* masc-improver snapshot 2026-04-14 *)
       ~handoff_threshold:0.85
-      ~last_outcome:KT.Proactive_error
+      ~last_outcome:Masc_mcp.Keeper_meta_contract.Proactive_error
       ~last_blocker_info:(Some overflow_info)
       ()
   in
@@ -145,7 +145,7 @@ let gate_reports_both_when_both_conditions_true () =
       ~cooldown_elapsed:true
       ~ratio:0.90
       ~handoff_threshold:0.85
-      ~last_outcome:KT.Proactive_error
+      ~last_outcome:Masc_mcp.Keeper_meta_contract.Proactive_error
       ~last_blocker_info:(Some overflow_info)
       ()
   in
@@ -161,7 +161,7 @@ let gate_requires_error_outcome_for_signal_trigger () =
       ~cooldown_elapsed:true
       ~ratio:0.2
       ~handoff_threshold:0.85
-      ~last_outcome:KT.Proactive_text_response
+      ~last_outcome:Masc_mcp.Keeper_meta_contract.Proactive_text_response
       ~last_blocker_info:(Some overflow_info)
       ()
   in
@@ -175,7 +175,7 @@ let gate_skips_below_all_thresholds () =
       ~cooldown_elapsed:true
       ~ratio:0.10
       ~handoff_threshold:0.85
-      ~last_outcome:KT.Proactive_silent
+      ~last_outcome:Masc_mcp.Keeper_meta_contract.Proactive_silent
       ~last_blocker_info:None
       ()
   in
@@ -189,7 +189,7 @@ let gate_fires_on_current_turn_overflow_signal () =
       ~cooldown_elapsed:true
       ~ratio:0.10
       ~handoff_threshold:0.85
-      ~last_outcome:KT.Proactive_text_response
+      ~last_outcome:Masc_mcp.Keeper_meta_contract.Proactive_text_response
       ~last_blocker_info:None
       ~current_turn_blocker_info:(Some overflow_info)
       ()
@@ -208,7 +208,7 @@ let gate_ignores_non_overflow_class_signal () =
       ~cooldown_elapsed:true
       ~ratio:0.10
       ~handoff_threshold:0.85
-      ~last_outcome:KT.Proactive_error
+      ~last_outcome:Masc_mcp.Keeper_meta_contract.Proactive_error
       ~last_blocker_info:(Some non_overflow_info)
       ~current_turn_blocker_info:(Some non_overflow_info)
       ()

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -41,16 +41,16 @@ let rec mkdir_p path =
 let write_persisted_meta_file config meta =
   let dir = Filename.concat (Coord.masc_root_dir config) "keepers" in
   mkdir_p dir;
-  let path = Filename.concat dir (meta.Keeper_types.name ^ ".json") in
-  write_file path (Yojson.Safe.pretty_to_string (Keeper_types.meta_to_json meta));
+  let path = Filename.concat dir (meta.Keeper_meta_contract.name ^ ".json") in
+  write_file path (Yojson.Safe.pretty_to_string (Keeper_meta_json.meta_to_json meta));
   path
 
 let seed_persisted_meta config meta =
   let path = write_persisted_meta_file config meta in
   Fs_compat.clear_fs ();
-  match Keeper_types.read_meta_file_path path with
+  match Keeper_meta_store.read_meta_file_path path with
   | Ok (Some _) -> (
-      match Keeper_types.read_meta config meta.Keeper_types.name with
+      match Keeper_meta_store.read_meta config meta.Keeper_meta_contract.name with
       | Ok (Some _) -> ()
       | Ok None -> fail ("persisted meta fixture not found via read_meta: " ^ path)
       | Error e -> fail ("persisted meta fixture read_meta failed: " ^ e))
@@ -162,7 +162,7 @@ instructions = "TOML instructions"
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
-      check string "goal" "TOML goal" updated.Keeper_types.goal;
+      check string "goal" "TOML goal" updated.Keeper_meta_contract.goal;
       check string "short_goal" "TOML short goal" updated.short_goal;
       check string "mid_goal" "TOML mid goal" updated.mid_goal;
       check string "long_goal" "TOML long goal" updated.long_goal;
@@ -172,7 +172,7 @@ instructions = "TOML instructions"
       check string "instructions" "TOML instructions" updated.instructions
 
 (* test_policy_resync removed: RFC-0164 deletion roadmap dropped
-   [policy_voice_enabled] from Keeper_types.keeper_meta. The test
+   [policy_voice_enabled] from Keeper_meta_contract.keeper_meta. The test
    keyed its TOML-overwrites-stale-JSON assertion on that field
    exclusively, so once the field went away the test no longer had
    a policy field to drive the assertion. test_sandbox_policy_resync
@@ -215,9 +215,9 @@ network_mode = "none"
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
       check string "sandbox_profile" "docker"
-        (Keeper_types.sandbox_profile_to_string updated.sandbox_profile);
+        (Keeper_types_profile_sandbox.sandbox_profile_to_string updated.sandbox_profile);
       check string "network_mode" "none"
-        (Keeper_types.network_mode_to_string updated.network_mode)
+        (Keeper_types_profile_sandbox.network_mode_to_string updated.network_mode)
 
 let test_keeper_up_create_uses_profile_default_sandbox_policy () =
   with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
@@ -266,12 +266,12 @@ network_mode = "inherit"
         | Some result -> fail ("keeper_up failed: " ^ Tool_result.message result)
         | None -> fail "missing keeper_up dispatch"
       in
-      match Keeper_types.read_meta config keeper_name with
+      match Keeper_meta_store.read_meta config keeper_name with
       | Ok (Some meta) ->
           check string "sandbox_profile from defaults" "docker"
-            (Keeper_types.sandbox_profile_to_string meta.sandbox_profile);
+            (Keeper_types_profile_sandbox.sandbox_profile_to_string meta.sandbox_profile);
           check string "network_mode from defaults" "inherit"
-            (Keeper_types.network_mode_to_string meta.network_mode)
+            (Keeper_types_profile_sandbox.network_mode_to_string meta.network_mode)
       | Ok None -> fail "keeper meta missing after keeper_up"
       | Error e -> fail ("read_meta failed: " ^ e))
 
@@ -324,8 +324,8 @@ also_allow = ["tool_execute", "tool_search_files"]
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
       let preset =
-        match Keeper_types.tool_access_preset updated.Keeper_types.tool_access with
-        | Some preset -> Keeper_types.tool_preset_to_string preset
+        match Keeper_meta_tool_access.tool_access_preset updated.Keeper_meta_contract.tool_access with
+        | Some preset -> Keeper_meta_tool_access.tool_preset_to_string preset
         | None -> fail "expected preset-based tool_access"
       in
       check string "tool_preset" "social" preset;
@@ -333,7 +333,7 @@ also_allow = ["tool_execute", "tool_search_files"]
         (list string)
         "tool_also_allow"
         [ "tool_execute"; "tool_search_files" ]
-        (Keeper_types.tool_access_also_allowlist updated.tool_access);
+        (Keeper_meta_tool_access.tool_access_also_allowlist updated.tool_access);
       check
         (list string)
         "allowed_paths"
@@ -389,11 +389,11 @@ preset = "social"
   let persisted_path = write_persisted_meta_file config initial_meta in
   Fs_compat.clear_fs ();
   check bool "persisted meta fixture exists" true (Sys.file_exists persisted_path);
-  (match Keeper_types.read_meta_file_path persisted_path with
+  (match Keeper_meta_store.read_meta_file_path persisted_path with
   | Ok (Some _) -> ()
   | Ok None -> fail "persisted meta fixture was not readable"
   | Error e -> fail ("persisted meta fixture read failed: " ^ e));
-  (match Keeper_types.read_meta config keeper_name with
+  (match Keeper_meta_store.read_meta config keeper_name with
   | Ok (Some _) -> ()
   | Ok None -> fail ("persisted meta fixture not found via read_meta: " ^ persisted_path)
   | Error e -> fail ("persisted meta fixture read_meta failed: " ^ e));
@@ -404,7 +404,7 @@ preset = "social"
         (option string)
         "tool_preset_source resynced from TOML"
         (Some "toml")
-        updated.Keeper_types.tool_preset_source
+        updated.Keeper_meta_contract.tool_preset_source
 
 let test_persona_no_longer_drives_tool_preset_source () =
   with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
@@ -463,11 +463,11 @@ persona_name = "%s"
   let persisted_path = write_persisted_meta_file config initial_meta in
   Fs_compat.clear_fs ();
   check bool "persisted meta fixture exists" true (Sys.file_exists persisted_path);
-  (match Keeper_types.read_meta_file_path persisted_path with
+  (match Keeper_meta_store.read_meta_file_path persisted_path with
   | Ok (Some _) -> ()
   | Ok None -> fail "persisted meta fixture was not readable"
   | Error e -> fail ("persisted meta fixture read failed: " ^ e));
-  (match Keeper_types.read_meta config keeper_name with
+  (match Keeper_meta_store.read_meta config keeper_name with
   | Ok (Some _) -> ()
   | Ok None -> fail ("persisted meta fixture not found via read_meta: " ^ persisted_path)
   | Error e -> fail ("persisted meta fixture read_meta failed: " ^ e));
@@ -478,7 +478,7 @@ persona_name = "%s"
         (option string)
         "persona does not drive tool_preset_source"
         None
-        updated.Keeper_types.tool_preset_source
+        updated.Keeper_meta_contract.tool_preset_source
 
 (** Test: explicit empty allowed_paths in TOML clears stale runtime JSON values. *)
 let test_allowed_paths_explicit_empty_clears_runtime () =
@@ -616,13 +616,13 @@ allowed_paths = ["workspace/example/project"]
         (option string)
         "custom access keeps no preset"
         None
-        (Keeper_types.tool_access_preset updated.Keeper_types.tool_access
-         |> Option.map Keeper_types.tool_preset_to_string);
+        (Keeper_meta_tool_access.tool_access_preset updated.Keeper_meta_contract.tool_access
+         |> Option.map Keeper_meta_tool_access.tool_preset_to_string);
       check
         (option (list string))
         "custom allowlist preserved"
         (Some [ "keeper_board_get"; "masc_status" ])
-        (Keeper_types.tool_access_custom_allowlist updated.tool_access);
+        (Keeper_meta_tool_access.tool_access_custom_allowlist updated.tool_access);
       check
         (list string)
         "allowed_paths"
@@ -714,8 +714,8 @@ preset = "delivery"
         (option string)
         "tool_preset from toml overlay"
         (Some "delivery")
-      (Keeper_types.tool_access_preset updated.tool_access
-         |> Option.map Keeper_types.tool_preset_to_string);
+      (Keeper_meta_tool_access.tool_access_preset updated.tool_access
+         |> Option.map Keeper_meta_tool_access.tool_preset_to_string);
       check
         (option string)
         "tool_preset_source from toml overlay"
@@ -761,7 +761,7 @@ per_provider_timeout = 45
         (option (float 0.0001))
         "integer TOML timeout updates runtime"
         (Some 45.0)
-        updated.Keeper_types.per_provider_timeout_s
+        updated.Keeper_meta_contract.per_provider_timeout_s
 
 let test_toml_invalid_per_provider_timeout_clears_stale_runtime () =
   with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
@@ -799,7 +799,7 @@ per_provider_timeout = 0
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
       check (option (float 0.0001)) "invalid TOML clears stale timeout"
-        None updated.Keeper_types.per_provider_timeout_s
+        None updated.Keeper_meta_contract.per_provider_timeout_s
 
 let test_persona_invalid_per_provider_timeout_clears_stale_runtime () =
   with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
@@ -851,7 +851,7 @@ persona_name = "%s"
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
       check (option (float 0.0001)) "invalid persona clears stale timeout"
-        None updated.Keeper_types.per_provider_timeout_s
+        None updated.Keeper_meta_contract.per_provider_timeout_s
 
 let test_meta_of_json_invalid_per_provider_timeout_is_ignored () =
   match
@@ -867,7 +867,7 @@ let test_meta_of_json_invalid_per_provider_timeout_is_ignored () =
   | Error e -> fail ("meta_of_json failed: " ^ e)
   | Ok meta ->
       check (option (float 0.0001)) "invalid persisted meta timeout ignored"
-        None meta.Keeper_types.per_provider_timeout_s
+        None meta.Keeper_meta_contract.per_provider_timeout_s
 
 (** Test: fields absent from TOML (None) preserve runtime JSON values. *)
 let test_none_preserves_runtime () =
@@ -908,7 +908,7 @@ goal = "minimal TOML"
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
       (* goal was in TOML → overwritten *)
-      check string "goal overwritten" "minimal TOML" updated.Keeper_types.goal;
+      check string "goal overwritten" "minimal TOML" updated.Keeper_meta_contract.goal;
       (* will was NOT in TOML → preserved from runtime *)
       check string "will preserved" "runtime will" updated.will;
       (* instructions was NOT in TOML → preserved from runtime *)
@@ -955,9 +955,9 @@ preset = "social"
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
-      check string "goal" "TOML goal" updated.Keeper_types.goal;
+      check string "goal" "TOML goal" updated.Keeper_meta_contract.goal;
       check string "cascade_name reset to keeper default"
-        ((Keeper_config.default_cascade_name ())) (Keeper_types.cascade_name_of_meta updated)
+        ((Keeper_config.default_cascade_name ())) (Keeper_meta_contract.cascade_name_of_meta updated)
 
 let test_social_model_resynced_from_declarative_defaults () =
   with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
@@ -995,7 +995,7 @@ social_model = "magentic_ledger_v1"
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
-      check string "goal resynced from TOML" "TOML goal" updated.Keeper_types.goal;
+      check string "goal resynced from TOML" "TOML goal" updated.Keeper_meta_contract.goal;
       check string "social_model resynced from TOML" "magentic_ledger_v1"
         updated.social_model
 
@@ -1035,7 +1035,7 @@ cascade_name = "missing_profile"
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Ok updated ->
       failf "expected unknown cascade_name to be rejected, got %s"
-        (Keeper_types.cascade_name_of_meta updated)
+        (Keeper_meta_contract.cascade_name_of_meta updated)
   | Error detail ->
       check bool "points at profile.cascade_name" true
         (contains_substring detail "profile.cascade_name");

--- a/test/test_keeper_runtime_denylist.ml
+++ b/test/test_keeper_runtime_denylist.ml
@@ -79,7 +79,7 @@ tool_denylist = ["toml-tool-x", "toml-tool-y"]
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
+  (match Keeper_meta_store.write_meta ~force:true config initial_meta with
   | Error e -> fail ("write_meta failed: " ^ e)
   | Ok () -> ());
   (* 3. Call ensure_keeper_meta — should resync denylist from TOML *)
@@ -91,9 +91,9 @@ tool_denylist = ["toml-tool-x", "toml-tool-y"]
         (list string)
         "returned meta denylist resynced from TOML"
         [ "toml-tool-x"; "toml-tool-y" ]
-        updated.Keeper_types.tool_denylist;
+        updated.Keeper_meta_contract.tool_denylist;
       (* 4b. Persisted meta also has TOML denylist *)
-      (match Keeper_types.read_meta config keeper_name with
+      (match Keeper_meta_store.read_meta config keeper_name with
       | Error e -> fail ("read_meta failed: " ^ e)
       | Ok None -> fail "meta should exist after ensure_keeper_meta"
       | Ok (Some persisted) ->
@@ -101,7 +101,7 @@ tool_denylist = ["toml-tool-x", "toml-tool-y"]
             (list string)
             "persisted meta denylist resynced from TOML"
             [ "toml-tool-x"; "toml-tool-y" ]
-            persisted.Keeper_types.tool_denylist))
+            persisted.Keeper_meta_contract.tool_denylist))
 
 let () =
   run "Keeper_runtime denylist resync"

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -911,10 +911,10 @@ let test_pre_dispatch_terminal_observation_invalidates_keeper_status_cache () =
       let config = Masc_mcp.Coord.default_config base_dir in
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "operator"));
       let meta = make_meta ~name:"pre-dispatch-status-cache" () in
-      (match Masc_mcp.Keeper_types.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> Alcotest.fail ("meta write failed: " ^ err));
-      let ctx : _ Masc_mcp.Keeper_types.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "operator";
@@ -2068,7 +2068,7 @@ let test_runtime_trace_api_surfaces_meta_read_error_without_trace_id () =
     (fun () ->
       let config = Masc_mcp.Coord.default_config base_dir in
       let keeper_name = "runtime-trace-corrupt-meta" in
-      let meta_path = Masc_mcp.Keeper_types.keeper_meta_path config keeper_name in
+      let meta_path = Masc_mcp.Keeper_types_profile.keeper_meta_path config keeper_name in
       Fs_compat.mkdir_p (Filename.dirname meta_path);
       append_raw_line meta_path "{not-json";
       let status, json =

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -45,7 +45,7 @@ let with_env name value f =
     f
 ;;
 
-let make_meta name : Masc_mcp.Keeper_types.keeper_meta =
+let make_meta name : Masc_mcp.Keeper_meta_contract.keeper_meta =
   match
     Masc_test_deps.meta_of_json_fixture
       (`Assoc

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -19,14 +19,14 @@ let make_meta
     ?(policy_voice_enabled = false)
     
     ?(name = "test-keeper")
-    ?(preset = Keeper_types.Full)
+    ?(preset = Keeper_meta_tool_access.Full)
     ?(also_allow = [])
     ?tool_access
-    () : Keeper_types.keeper_meta =
+    () : Keeper_meta_contract.keeper_meta =
   let tool_access =
     match tool_access with
     | Some access -> access
-    | None -> Keeper_types.Preset { preset; also_allow }
+    | None -> Keeper_meta_tool_access.Preset { preset; also_allow }
   in
   let json = `Assoc [
     ("name", `String name);
@@ -34,7 +34,7 @@ let make_meta
     ("trace_id", `String "safety-test-trace");
     ("policy_voice_enabled", `Bool policy_voice_enabled);
     
-    ("tool_access", Keeper_types.tool_access_to_json tool_access);
+    ("tool_access", Keeper_meta_tool_access.tool_access_to_json tool_access);
   ] in
   match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
@@ -191,7 +191,7 @@ let test_write_done_kills_all () =
   check (list string) "write_done returns empty" [] tools
 
 let test_all_keepers_get_full_toolset () =
-  let meta = make_meta ~preset:Keeper_types.Full () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Full () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "has tool_read_file" true (List.mem "tool_read_file" tools);
   check bool "has keeper_board_list" true (List.mem "keeper_board_list" tools);
@@ -199,34 +199,34 @@ let test_all_keepers_get_full_toolset () =
   check bool "has tool_search_files" true (List.mem "tool_search_files" tools)
 
 let test_all_keepers_have_research_tools () =
-  let meta = make_meta ~preset:Keeper_types.Research  () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Research  () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "research has library search" true (List.mem "keeper_library_search" tools);
   check bool "research has web search" true (List.mem "masc_web_search" tools);
   check bool "research has file search" true (List.mem "tool_search_files" tools)
 
 let test_heuristic_mode_tools () =
-  let meta = make_meta ~preset:Keeper_types.Minimal () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Minimal () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "heuristic returns nonempty tools" true (List.length tools > 0)
 
 let test_messaging_preset_tools () =
-  let meta = make_meta ~preset:Keeper_types.Messaging () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Messaging () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "has board tools" true (List.mem "keeper_board_post" tools);
   check bool "has tool_read_file" true (List.mem "tool_read_file" tools);
   check bool "has tool_search_files" true (List.mem "tool_search_files" tools)
 
 let test_execution_preset_has_repo_tools () =
-  let meta = make_meta ~preset:Keeper_types.Delivery () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Delivery () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "tool_search_files included" true (List.mem "tool_search_files" tools);
   check bool "tool_read_file included" true (List.mem "tool_read_file" tools);
   check bool "keeper_board_get included" true (List.mem "keeper_board_get" tools)
 
 let test_all_modes_produce_same_tools () =
-  let meta_a = make_meta ~preset:Keeper_types.Minimal () in
-  let meta_b = make_meta ~preset:Keeper_types.Full () in
+  let meta_a = make_meta ~preset:Keeper_meta_tool_access.Minimal () in
+  let meta_b = make_meta ~preset:Keeper_meta_tool_access.Full () in
   let tools_a = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta_a in
   let tools_b = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta_b in
   check bool "full has more tools" true (List.length tools_b > List.length tools_a)

--- a/test/test_keeper_sandbox_containment.ml
+++ b/test/test_keeper_sandbox_containment.ml
@@ -51,11 +51,11 @@ let make_meta ~name ~sandbox =
         ("trace_id", `String "test-trace-containment");
         ("policy_voice_enabled", `Bool false);
         ( "tool_access",
-          Keeper_types.tool_access_to_json
-            (Keeper_types.Preset
-               { preset = Keeper_types.Full; also_allow = [] }) );
+          Keeper_meta_tool_access.tool_access_to_json
+            (Keeper_meta_tool_access.Preset
+               { preset = Keeper_meta_tool_access.Full; also_allow = [] }) );
         ("sandbox_profile",
-         `String (Keeper_types.sandbox_profile_to_string sandbox));
+         `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox));
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
@@ -67,7 +67,7 @@ let make_meta ~name ~sandbox =
 let test_legacy_keeper_always_allowed () =
   with_tmp_base @@ fun base ->
   let config = Coord.default_config base in
-  let meta = make_meta ~name:"alice" ~sandbox:Keeper_types.Local in
+  let meta = make_meta ~name:"alice" ~sandbox:Keeper_types_profile_sandbox.Local in
   let outside = "/etc/passwd" in
   Alcotest.(check bool)
     "Local keeper bypasses containment"
@@ -79,7 +79,7 @@ let test_legacy_keeper_always_allowed () =
 let test_docker_keeper_blocks_outside () =
   with_tmp_base @@ fun base ->
   let config = Coord.default_config base in
-  let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker in
+  let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker in
   let outside = "/etc/passwd" in
   match
     Keeper_sandbox_containment.check_read_target ~config ~meta ~target:outside
@@ -97,7 +97,7 @@ let test_docker_keeper_blocks_outside () =
 let test_docker_keeper_allows_inside_playground () =
   with_tmp_base @@ fun base ->
   let config = Coord.default_config base in
-  let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker in
+  let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker in
   let bundle = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   let inside = Filename.concat bundle "mind/scratch.md" in
   Alcotest.(check bool) "playground-internal path is allowed"
@@ -109,7 +109,7 @@ let test_docker_keeper_allows_inside_playground () =
 let test_docker_git_creds_contained () =
   with_tmp_base @@ fun base ->
   let config = Coord.default_config base in
-  let meta = make_meta ~name:"poe" ~sandbox:Keeper_types.Docker in
+  let meta = make_meta ~name:"poe" ~sandbox:Keeper_types_profile_sandbox.Docker in
   let outside = "/etc/passwd" in
   Alcotest.(check bool) "Docker is also subject to containment"
     true
@@ -120,7 +120,7 @@ let test_docker_git_creds_contained () =
 let test_path_just_outside_playground_blocked () =
   with_tmp_base @@ fun base ->
   let config = Coord.default_config base in
-  let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker in
+  let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker in
   (* Sibling directory with a name that LOOKS like a prefix of the playground
      path; must still be blocked (prevents the classic prefix-without-slash
      containment bypass). *)

--- a/test/test_keeper_sandbox_docker_cwd_response.ml
+++ b/test/test_keeper_sandbox_docker_cwd_response.ml
@@ -35,7 +35,7 @@ let cleanup_dir path =
   in
   rm path
 
-let make_docker_meta ~name : Keeper_types.keeper_meta =
+let make_docker_meta ~name : Keeper_meta_contract.keeper_meta =
   let json =
     `Assoc
       [
@@ -46,7 +46,7 @@ let make_docker_meta ~name : Keeper_types.keeper_meta =
         ("allowed_paths", `List [ `String "*" ]);
         ( "sandbox_profile"
         , `String
-            (Keeper_types.sandbox_profile_to_string Keeper_types.Docker) );
+            (Keeper_types_profile_sandbox.sandbox_profile_to_string Keeper_types_profile_sandbox.Docker) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -164,8 +164,8 @@ let make_meta ?preset ~name ~sandbox () =
     | Some preset ->
         [
           ( "tool_access",
-            Keeper_types.tool_access_to_json
-              (Keeper_types.Preset { preset; also_allow = [] }) );
+            Masc_mcp.Keeper_meta_tool_access.tool_access_to_json
+              (Masc_mcp.Keeper_meta_tool_access.Preset { preset; also_allow = [] }) );
         ]
   in
   let json =
@@ -177,7 +177,7 @@ let make_meta ?preset ~name ~sandbox () =
          ("goal", `String "shell docker route test");
          ("allowed_paths", `List [ `String "*" ]);
          ( "sandbox_profile",
-           `String (Keeper_types.sandbox_profile_to_string sandbox) );
+           `String (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
        ]
       @ tool_access_fields)
   in
@@ -238,8 +238,8 @@ let setup_two_docker_keepers f =
   let config = Coord.default_config base in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
   Keeper_registry.clear ();
-  let meta_a = make_meta ~name:"keeper-a" ~sandbox:Keeper_types.Docker () in
-  let meta_b = make_meta ~name:"keeper-b" ~sandbox:Keeper_types.Docker () in
+  let meta_a = make_meta ~name:"keeper-a" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker () in
+  let meta_b = make_meta ~name:"keeper-b" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker () in
   let playground_a = Keeper_sandbox.host_root_abs_of_meta ~config meta_a in
   let playground_b = Keeper_sandbox.host_root_abs_of_meta ~config meta_b in
   ensure_dir playground_a;
@@ -475,13 +475,13 @@ let assert_docker_route_fires ~config ~meta ~playground =
 
 let test_readonly_ops_route_through_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   assert_docker_route_fires ~config ~meta ~playground
 
 let test_cat_legacy_keeper_skips_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
-  setup ~sandbox:Keeper_types.Local
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local
   @@ fun ~config ~meta ~playground ->
   let host_path = Filename.concat playground "mind/x" in
   ensure_dir (Filename.dirname host_path);
@@ -595,7 +595,7 @@ exit 0\n"
 let test_rg_no_match_remains_successful_in_docker_route () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_rg_no_match_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let host_path = Filename.concat playground "mind/demo.txt" in
   ensure_dir (Filename.dirname host_path);
@@ -618,7 +618,7 @@ let test_rg_no_match_remains_successful_in_docker_route () =
     (parse_field raw "matches" |> Json.to_list |> List.length)
 
 let test_unknown_workspace_op_is_unsupported_before_docker () =
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground:_ ->
   let raw =
     Agent_tool_command_runtime.handle_tool_search_files
@@ -639,7 +639,7 @@ let test_unknown_workspace_op_is_unsupported_before_docker () =
     (parse_string_field raw "op")
 
 let test_turn_sandbox_file_write_uses_host_bind_mount () =
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let runtime = Keeper_turn_sandbox_runtime.create ~config ~meta ~turn_id:1 () in
   let target = Filename.concat playground "nested/result.txt" in
@@ -764,7 +764,7 @@ let check_typed_validation_error needle raw =
     (response_mentions raw "error" needle)
 
 let test_execute_typed_env_wrapper_target_rejected () =
-  setup ~sandbox:Keeper_types.Local
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local
   @@ fun ~config ~meta ~playground ->
   Agent_tool_command_runtime.handle_tool_execute
     ~turn_sandbox_factory:None
@@ -777,7 +777,7 @@ let test_execute_typed_env_wrapper_target_rejected () =
   |> check_typed_validation_error "executable \"id\" not in readonly allowlist"
 
 let test_execute_typed_single_stage_pipeline_rejected () =
-  setup ~sandbox:Keeper_types.Local
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local
   @@ fun ~config ~meta ~playground ->
   Agent_tool_command_runtime.handle_tool_execute
     ~turn_sandbox_factory:None
@@ -791,7 +791,7 @@ let test_execute_typed_single_stage_pipeline_rejected () =
 
 let test_execute_typed_pipeline_falls_back_to_local_playground () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "missing:test" @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let raw =
     Agent_tool_command_runtime.handle_tool_execute
@@ -811,7 +811,7 @@ let test_execute_typed_pipeline_falls_back_to_local_playground () =
     (parse_string_field raw "sandbox_fallback")
 
 let test_execute_typed_pipeline_uses_local_shell_ir_dispatch () =
-  setup ~sandbox:Keeper_types.Local
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local
   @@ fun ~config ~meta ~playground ->
   Agent_tool_command_runtime.handle_tool_execute
     ~turn_sandbox_factory:None
@@ -830,7 +830,7 @@ let test_execute_typed_pipeline_uses_turn_sandbox_docker_runner () =
   else
     with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" image
     @@ fun () ->
-    setup ~sandbox:Keeper_types.Docker
+    setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
     @@ fun ~config ~meta ~playground ->
     let factory = Keeper_sandbox_factory.create ~config ~meta () in
     Fun.protect
@@ -852,7 +852,7 @@ let test_execute_typed_pipeline_uses_turn_sandbox_docker_runner () =
 
 let test_execute_routes_through_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
@@ -871,7 +871,7 @@ let test_execute_routes_through_docker () =
 
 let test_execute_legacy_skips_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
-  setup ~sandbox:Keeper_types.Local
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local
   @@ fun ~config ~meta ~playground ->
   let outside_cwd = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir outside_cwd) @@ fun () ->
@@ -963,7 +963,7 @@ exit 2\n"
 
 let test_execute_git_creds_routes_through_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
-  setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Delivery
+  setup_with_preset ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ~preset:Masc_mcp.Keeper_meta_tool_access.Delivery
   @@ fun ~config ~meta ~playground ->
   let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
   ensure_dir repo;
@@ -985,7 +985,7 @@ let test_execute_git_creds_routes_through_docker () =
 let test_execute_git_creds_uses_oneshot_with_turn_runtime () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Delivery
+  setup_with_preset ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ~preset:Masc_mcp.Keeper_meta_tool_access.Delivery
   @@ fun ~config ~meta ~playground ->
   seed_repo_cli_credential_mapping ~config ~keeper_name:meta.name ();
   let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
@@ -1028,7 +1028,7 @@ let test_execute_git_creds_uses_oneshot_with_turn_runtime () =
 let test_execute_git_creds_missing_bundle_is_structured_blocker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Delivery
+  setup_with_preset ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ~preset:Masc_mcp.Keeper_meta_tool_access.Delivery
   @@ fun ~config ~meta ~playground ->
   let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
   ensure_dir repo;
@@ -1061,7 +1061,7 @@ let test_execute_git_creds_missing_bundle_is_structured_blocker () =
 let test_execute_git_c_option_missing_dir_blocks_before_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Delivery
+  setup_with_preset ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ~preset:Masc_mcp.Keeper_meta_tool_access.Delivery
   @@ fun ~config ~meta ~playground ->
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
@@ -1082,7 +1082,7 @@ let test_execute_git_c_option_missing_dir_blocks_before_docker () =
 let test_execute_missing_playground_blocks_before_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
   let mount_source =
@@ -1101,7 +1101,7 @@ let test_execute_missing_playground_blocks_before_docker () =
       ~timeout_sec:5.0
       ~cmd:"pwd"
       ~git_creds_enabled:false
-      ~network_mode:Keeper_types.Network_inherit
+      ~network_mode:Masc_mcp.Keeper_types_profile_sandbox.Network_inherit
     with
     | Ok _ -> Alcotest.fail "expected missing playground to block before docker"
     | Error err -> err
@@ -1123,7 +1123,7 @@ let test_execute_missing_playground_blocks_before_docker () =
 let test_execute_git_c_bare_worktrees_from_root_uses_single_repo () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Delivery
+  setup_with_preset ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ~preset:Masc_mcp.Keeper_meta_tool_access.Delivery
   @@ fun ~config ~meta ~playground ->
   seed_repo_cli_credential_mapping ~config ~keeper_name:meta.name ();
   let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
@@ -1156,7 +1156,7 @@ let test_execute_git_c_bare_worktrees_from_root_uses_single_repo () =
 let test_execute_git_push_requires_write_preset_before_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   ensure_repo_cli_identity_bundle ~config Masc_mcp.Repo_cli_credentials.root_repo_cli_identity;
   let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
@@ -1189,7 +1189,7 @@ let test_execute_git_push_requires_write_preset_before_docker () =
 let test_execute_git_push_routes_through_git_creds_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Delivery
+  setup_with_preset ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ~preset:Masc_mcp.Keeper_meta_tool_access.Delivery
   @@ fun ~config ~meta ~playground ->
   seed_repo_cli_credential_mapping ~config ~keeper_name:meta.name ();
   let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
@@ -1223,7 +1223,7 @@ let test_execute_git_push_routes_through_git_creds_docker () =
 
 let test_tool_search_files_repo_review_is_unsupported () =
   with_tool_policy_config @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let raw =
     Agent_tool_command_runtime.handle_tool_search_files
@@ -1254,7 +1254,7 @@ let docker_run_line log_path =
 
 let test_docker_shell_missing_image_fails_before_run () =
   with_fake_docker fake_docker_missing_image_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
@@ -1270,7 +1270,7 @@ let test_docker_shell_missing_image_fails_before_run () =
       ~timeout_sec:5.0
       ~cmd:"pwd"
       ~git_creds_enabled:false
-      ~network_mode:Keeper_types.Network_none
+      ~network_mode:Masc_mcp.Keeper_types_profile_sandbox.Network_none
   with
   | Ok _ -> Alcotest.fail "expected missing image preflight error"
   | Error msg ->
@@ -1286,7 +1286,7 @@ let test_docker_shell_missing_image_fails_before_run () =
 
 let test_execute_missing_image_falls_back_to_local_playground () =
   with_fake_docker fake_docker_missing_image_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
@@ -1319,7 +1319,7 @@ let test_execute_missing_image_falls_back_to_local_playground () =
 
 let test_execute_outside_playground_rejects_before_image_preflight () =
   with_fake_docker fake_docker_missing_image_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground:_ ->
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
   let cwd = Filename.concat config.Coord.base_path "outside-playground" in
@@ -1355,7 +1355,7 @@ let test_execute_outside_playground_rejects_before_image_preflight () =
 
 let test_docker_shell_mounts_masc_config_runtime_paths () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let masc_root =
     Filename.concat config.Coord.base_path Common.masc_dirname
@@ -1379,7 +1379,7 @@ let test_docker_shell_mounts_masc_config_runtime_paths () =
       ~timeout_sec:5.0
       ~cmd:"pwd"
       ~git_creds_enabled:false
-      ~network_mode:Keeper_types.Network_none
+      ~network_mode:Masc_mcp.Keeper_types_profile_sandbox.Network_none
   with
   | Error msg -> Alcotest.failf "expected fake docker run, got %s" msg
   | Ok result ->
@@ -1424,7 +1424,7 @@ let test_docker_shell_mounts_masc_config_runtime_paths () =
     Alcotest.(check bool) "auth state not mounted" false
       (contains_substring line "/.masc/auth/")
 
-let run_git_creds_docker_shell ~config ~(meta : Keeper_types.keeper_meta) ~playground
+let run_git_creds_docker_shell ~config ~(meta : Masc_mcp.Keeper_meta_contract.keeper_meta) ~playground
     ~log_path =
   seed_default_mapping_if_missing ~config ~keeper_name:meta.name;
   let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
@@ -1446,7 +1446,7 @@ let run_git_creds_docker_shell ~config ~(meta : Keeper_types.keeper_meta) ~playg
     Keeper_sandbox_docker.run_docker_shell_command_with_status
       ~config ~meta ~cwd:playground ~timeout_sec:5.0
       ~cmd:"git status" ~git_creds_enabled:true
-      ~network_mode:Keeper_types.Network_inherit
+      ~network_mode:Masc_mcp.Keeper_types_profile_sandbox.Network_inherit
   with
   | Error msg ->
       Alcotest.failf "expected fake docker git-creds run, got %s" msg
@@ -1464,7 +1464,7 @@ let run_git_creds_docker_shell ~config ~(meta : Keeper_types.keeper_meta) ~playg
       docker_run_line log_path
 
 let test_sandbox_root_git_cwd_zero_repo_blocks_before_exec () =
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let cwd, error =
     resolve_sandbox_root_git_cwd_string ~config ~meta
@@ -1482,7 +1482,7 @@ let test_sandbox_root_git_cwd_zero_repo_blocks_before_exec () =
       (contains_substring msg "cwd=\"repos/<repo>\"")
 
 let test_sandbox_root_git_cwd_single_repo_auto_chdir () =
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
   ensure_dir repo;
@@ -1499,7 +1499,7 @@ let test_sandbox_root_git_cwd_single_repo_auto_chdir () =
   Alcotest.(check string) "auto cwd selects the only repo" repo cwd
 
 let test_sandbox_root_git_cwd_multi_repo_blocks_before_exec () =
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let repos = Filename.concat playground "repos" in
   let repo_a = Filename.concat repos "alpha" in
@@ -1527,7 +1527,7 @@ let test_sandbox_root_git_cwd_multi_repo_blocks_before_exec () =
       (contains_substring msg "alpha, beta")
 
 let test_sandbox_root_git_cwd_cd_chain_is_not_interpreted () =
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let repos = Filename.concat playground "repos" in
   let repo_a = Filename.concat repos "grpc-direct" in
@@ -1596,7 +1596,7 @@ let test_repo_hosting_cli_repo_api_misuse_uses_shell_semantics () =
 
 let test_git_creds_skips_missing_ssh_auth_sock () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   Config_dir_resolver.reset ();
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
@@ -1617,7 +1617,7 @@ let test_git_creds_skips_missing_ssh_auth_sock () =
 
 let test_git_creds_inherit_network_omits_invalid_network_flag () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
   let line =
@@ -1628,7 +1628,7 @@ let test_git_creds_inherit_network_omits_invalid_network_flag () =
 
 let test_git_creds_mounts_numeric_user_identity () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
   let line =
@@ -1663,7 +1663,7 @@ let test_git_creds_mounts_numeric_user_identity () =
 
 let test_git_creds_respects_keeper_alias_identity_mode () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   with_repo_cli_identity_toml ~config ~keeper_name:meta.name
     ~repo_cli_identity:"anyang-keepers" ~git_identity_mode:"keeper_alias"
@@ -1681,7 +1681,7 @@ let test_git_creds_respects_keeper_alias_identity_mode () =
 
 let test_git_creds_uses_configured_identity_mode () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   with_repo_cli_identity_toml ~config ~keeper_name:meta.name
     ~repo_cli_identity:"anyang-keepers" ~git_identity_mode:"repo_cli_identity"
@@ -1713,7 +1713,7 @@ let test_git_creds_mounts_only_selected_keeper_identity () =
     Masc_mcp.Repo_cli_credentials.repo_cli_config_dir_of_bundle
       (Masc_mcp.Repo_cli_credentials.bundle_root config ~repo_cli_identity:id)
   in
-  let run_for ~(meta : Keeper_types.keeper_meta) ~playground ~repo_cli_identity
+  let run_for ~(meta : Masc_mcp.Keeper_meta_contract.keeper_meta) ~playground ~repo_cli_identity
       ~other_identity ~log_name =
     with_repo_cli_identity_toml ~config ~keeper_name:meta.name
       ~repo_cli_identity ~git_identity_mode:"repo_cli_identity"
@@ -1779,7 +1779,7 @@ let test_git_creds_mounts_only_selected_keeper_identity () =
 let test_execute_fake_docker_executes () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
@@ -1799,7 +1799,7 @@ let test_execute_allows_validator_safe_pipe_redirect_in_docker_route () =
   with_tool_policy_config @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Delivery
+  setup_with_preset ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ~preset:Masc_mcp.Keeper_meta_tool_access.Delivery
   @@ fun ~config ~meta ~playground ->
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
@@ -1826,7 +1826,7 @@ let test_execute_allows_validator_safe_pipe_redirect_in_docker_route () =
 let test_execute_rg_no_match_remains_successful_in_docker_route () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_bash_rg_no_match_script @@ fun () ->
-  setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Delivery
+  setup_with_preset ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ~preset:Masc_mcp.Keeper_meta_tool_access.Delivery
   @@ fun ~config ~meta ~playground ->
   let lib =
     Filename.concat
@@ -1860,7 +1860,7 @@ let test_execute_rg_no_match_remains_successful_in_docker_route () =
 let test_execute_blocks_file_redirect_before_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Delivery
+  setup_with_preset ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ~preset:Masc_mcp.Keeper_meta_tool_access.Delivery
   @@ fun ~config ~meta ~playground ->
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
@@ -1888,7 +1888,7 @@ let test_execute_blocks_file_redirect_before_docker () =
 let test_execute_repo_checks_routes_through_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Delivery
+  setup_with_preset ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ~preset:Masc_mcp.Keeper_meta_tool_access.Delivery
   @@ fun ~config ~meta ~playground ->
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
@@ -1918,7 +1918,7 @@ let test_execute_repo_checks_routes_through_docker () =
 let test_execute_search_pipeline_exposes_structured_recovery_plan () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Delivery
+  setup_with_preset ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker ~preset:Masc_mcp.Keeper_meta_tool_access.Delivery
   @@ fun ~config ~meta ~playground ->
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
@@ -1943,7 +1943,7 @@ let test_execute_search_pipeline_exposes_structured_recovery_plan () =
 let test_execute_rewrites_host_path_command_for_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
+  setup ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let container_root = Keeper_sandbox.container_root meta.name in
   ensure_dir (Filename.concat (Filename.concat playground "repos") "masc-mcp");

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -98,7 +98,7 @@ let make_meta ~name ~sandbox =
         ("trace_id", `String ("trace-" ^ name));
         ("goal", `String "docker read test");
         ( "sandbox_profile",
-          `String (Keeper_types.sandbox_profile_to_string sandbox) );
+          `String (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
@@ -108,14 +108,14 @@ let make_meta ~name ~sandbox =
 (* ── should_route_read profile policy ────────────────────────────── *)
 
 let test_legacy_keeper_never_routes () =
-  let meta = make_meta ~name:"alice" ~sandbox:Keeper_types.Local in
+  let meta = make_meta ~name:"alice" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Local in
   Alcotest.(check bool) "legacy keeper never routes through docker"
     false
     (Keeper_sandbox_read_backend.should_route_read ~meta)
 
 let test_docker_keeper_routes () =
   let meta =
-    make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker
+    make_meta ~name:"minjae" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   in
   Alcotest.(check bool) "docker keeper routes through docker"
     true
@@ -123,7 +123,7 @@ let test_docker_keeper_routes () =
 
 let test_docker_git_creds_routes () =
   let meta =
-    make_meta ~name:"poe" ~sandbox:Keeper_types.Docker
+    make_meta ~name:"poe" ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   in
   Alcotest.(check bool) "docker git-creds also routes" true
     (Keeper_sandbox_read_backend.should_route_read ~meta)
@@ -135,7 +135,7 @@ let setup_config name =
   Unix.mkdir (Filename.concat base Common.masc_dirname) 0o755;
   let config = Coord.default_config base in
   let meta =
-    make_meta ~name ~sandbox:Keeper_types.Docker
+    make_meta ~name ~sandbox:Masc_mcp.Keeper_types_profile_sandbox.Docker
   in
   base, config, meta
 
@@ -623,13 +623,13 @@ let test_sandbox_container_label_args_include_managed_ttl () =
 
 let test_docker_network_args_follow_masc_policy () =
   let args_none, label_none =
-    Keeper_sandbox_runtime.docker_network_args Keeper_types.Network_none
+    Keeper_sandbox_runtime.docker_network_args Masc_mcp.Keeper_types_profile_sandbox.Network_none
   in
   Alcotest.(check (list string)) "network none passes docker flag"
     [ "--network"; "none" ] args_none;
   Alcotest.(check string) "network none label" "none" label_none;
   let args_inherit, label_inherit =
-    Keeper_sandbox_runtime.docker_network_args Keeper_types.Network_inherit
+    Keeper_sandbox_runtime.docker_network_args Masc_mcp.Keeper_types_profile_sandbox.Network_inherit
   in
   Alcotest.(check (list string)) "network inherit uses host network (#10431)"
     [ "--network"; "host" ] args_inherit;
@@ -987,7 +987,7 @@ let test_startup_preflight_skips_required_command_inventory () =
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   match
     Keeper_sandbox_runtime.ensure_keeper_startup_preflight
-      ~timeout_sec:5.0 ~sandbox_profile:Keeper_types.Docker
+      ~timeout_sec:5.0 ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Docker
   with
   | Error err -> Alcotest.failf "expected startup preflight to pass: %s" err
   | Ok () ->

--- a/test/test_keeper_sandbox_runner.ml
+++ b/test/test_keeper_sandbox_runner.ml
@@ -20,7 +20,7 @@ let cleanup_dir path =
   in
   rm path
 
-let make_meta ~sandbox : Keeper_types.keeper_meta =
+let make_meta ~sandbox : Keeper_meta_contract.keeper_meta =
   let json =
     `Assoc
       [ "name", `String "runner-test"
@@ -29,7 +29,7 @@ let make_meta ~sandbox : Keeper_types.keeper_meta =
       ; "goal", `String "sandbox runner boundary"
       ; "allowed_paths", `List [ `String "*" ]
       ; ( "sandbox_profile",
-          `String (Keeper_types.sandbox_profile_to_string sandbox) )
+          `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) )
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
@@ -46,7 +46,7 @@ module Fake_backend = struct
     "/fake/egress.json"
 
   let effective_sandbox_profile ~meta:_ =
-    Keeper_types.Docker, Keeper_types.Network_none
+    Keeper_types_profile_sandbox.Docker, Keeper_types_profile_sandbox.Network_none
 
   let ensure_runtime ~timeout_sec:_ =
     Ok [ "--fake-seccomp" ]
@@ -62,7 +62,7 @@ module Fake_backend = struct
     { status = Unix.WEXITED status
     ; output
     ; image = "fake-image"
-    ; network_label = Keeper_types.network_mode_to_string network_mode
+    ; network_label = Keeper_types_profile_sandbox.network_mode_to_string network_mode
     ; cwd
     ; semantic_status = None
     ; semantic_ok = status = 0
@@ -97,7 +97,7 @@ let with_fixture f =
     ~finally:(fun () -> cleanup_dir base)
     (fun () ->
        let config = Coord.default_config base in
-       let meta = make_meta ~sandbox:Keeper_types.Docker in
+       let meta = make_meta ~sandbox:Keeper_types_profile_sandbox.Docker in
        f ~config ~meta)
 
 let test_functor_delegates_user_shell () =
@@ -106,7 +106,7 @@ let test_functor_delegates_user_shell () =
       match
         Runner.run_shell_command_with_status ~config ~meta ~cwd:"/work"
           ~timeout_sec:5.0 ~cmd:"git status" ~git_creds_enabled:false
-          ~network_mode:Keeper_types.Network_none
+          ~network_mode:Keeper_types_profile_sandbox.Network_none
       with
       | Error e -> Alcotest.fail e
       | Ok result ->
@@ -123,7 +123,7 @@ let test_functor_delegates_trusted_tool () =
       match
         Runner.run_trusted_shell_command_with_status ~config ~meta ~cwd:"/work"
           ~timeout_sec:5.0 ~cmd:"gh pr view" ~git_creds_enabled:true
-          ~network_mode:Keeper_types.Network_inherit
+          ~network_mode:Keeper_types_profile_sandbox.Network_inherit
       with
       | Error e -> Alcotest.fail e
       | Ok result ->
@@ -141,8 +141,8 @@ let test_uses_backend_respects_profile () =
     ~finally:(fun () -> cleanup_dir base)
     (fun () ->
        let config = Coord.default_config base in
-       let docker_meta = make_meta ~sandbox:Keeper_types.Docker in
-       let local_meta = make_meta ~sandbox:Keeper_types.Local in
+       let docker_meta = make_meta ~sandbox:Keeper_types_profile_sandbox.Docker in
+       let local_meta = make_meta ~sandbox:Keeper_types_profile_sandbox.Local in
        let docker_cwd =
          Keeper_sandbox.host_root_abs_of_meta ~config docker_meta
        in
@@ -168,7 +168,7 @@ let test_local_route_does_not_force_backend_cwd () =
     ~finally:(fun () -> cleanup_dir base)
     (fun () ->
        let config = Coord.default_config base in
-       let meta = make_meta ~sandbox:Keeper_types.Local in
+       let meta = make_meta ~sandbox:Keeper_types_profile_sandbox.Local in
        let cwd = Keeper_sandbox.host_root_abs_of_meta ~config meta in
        let result =
          Keeper_sandbox_runner.run_command_with_status
@@ -186,7 +186,7 @@ let test_local_route_does_not_force_backend_cwd () =
              ; cwd = (fun () -> failwith "backend cwd evaluated on host route")
              ; command_text = "true"
              ; git_creds_enabled = false
-             ; network_mode = Keeper_types.Network_none
+             ; network_mode = Keeper_types_profile_sandbox.Network_none
              ; trust = Keeper_sandbox_runner.User_shell
              }
        in

--- a/test/test_keeper_sandbox_session_plan.ml
+++ b/test/test_keeper_sandbox_session_plan.ml
@@ -19,7 +19,7 @@ let plan () =
       ~container_root:"/keeper/alice"
       ~base_path:"/srv/masc"
       ~container_kind:"turn"
-      ~network_mode:Keeper_types.Network_none
+      ~network_mode:Keeper_types_profile_sandbox.Network_none
       ~host_root:"/var/masc/alice"
       ~uid:1234
       ~gid:5678
@@ -45,7 +45,7 @@ let test_invalid_meta_name () =
       ~container_root:"/r"
       ~base_path:"/b"
       ~container_kind:"turn"
-      ~network_mode:Keeper_types.Network_none
+      ~network_mode:Keeper_types_profile_sandbox.Network_none
       ~host_root:"/h"
       ~uid:1
       ~gid:1
@@ -65,7 +65,7 @@ let test_invalid_host_root () =
       ~container_root:"/r"
       ~base_path:"/b"
       ~container_kind:"turn"
-      ~network_mode:Keeper_types.Network_none
+      ~network_mode:Keeper_types_profile_sandbox.Network_none
       ~host_root:""
       ~uid:1
       ~gid:1
@@ -125,7 +125,7 @@ let test_env_overrides_extra () =
       ~container_root:"/r"
       ~base_path:"/b"
       ~container_kind:"turn"
-      ~network_mode:Keeper_types.Network_none
+      ~network_mode:Keeper_types_profile_sandbox.Network_none
       ~host_root:"/h"
       ~uid:1
       ~gid:1
@@ -178,7 +178,7 @@ let test_labels_ttl_sec () =
       ~container_root:"/r"
       ~base_path:"/b"
       ~container_kind:"turn"
-      ~network_mode:Keeper_types.Network_none
+      ~network_mode:Keeper_types_profile_sandbox.Network_none
       ~host_root:"/h"
       ~uid:1
       ~gid:1

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -375,7 +375,7 @@ let test_queue_head_timeout_diagnostic_names_fifo_blocker () =
   Alcotest.(check string)
     "queue head maps to admission queue blocker"
     "admission_queue_wait_timeout"
-    (KT.blocker_class_to_string blocker_class);
+    (Masc_mcp.Keeper_meta_contract.blocker_class_to_string blocker_class);
   let persisted, log_diagnostic =
     KHL.semaphore_wait_timeout_diagnostics ~cascade_name:"queue-cascade" timeout
   in
@@ -407,7 +407,7 @@ let test_autonomous_slot_timeout_keeps_holder_diagnostic () =
   Alcotest.(check string)
     "slot timeout maps to autonomous slot blocker"
     "autonomous_slot_wait_timeout"
-    (KT.blocker_class_to_string blocker_class);
+    (Masc_mcp.Keeper_meta_contract.blocker_class_to_string blocker_class);
   let _persisted, log_diagnostic =
     KHL.semaphore_wait_timeout_diagnostics ~cascade_name:"slot-cascade" timeout
   in

--- a/test/test_keeper_status_runtime.ml
+++ b/test/test_keeper_status_runtime.ml
@@ -20,7 +20,7 @@ let keeper_health_testable : KT.keeper_health Alcotest.testable =
 let make_meta ?(name = "keeper-exec-status-test")
     ?(trace_id = "trace-keeper-exec-status") () =
   match
-    KT.meta_of_json
+    Masc_mcp.Keeper_meta_json_parse.meta_of_json
       (`Assoc
         [
           ("name", `String name);
@@ -466,7 +466,7 @@ let test_diagnostic_ignores_stale_error_when_live_signal_is_newer () =
               base.runtime.proactive_rt with
               count_total = 5;
               last_ts = stale_error_ts;
-              last_outcome = KT.Proactive_error;
+              last_outcome = Masc_mcp.Keeper_meta_contract.Proactive_error;
               last_reason =
                 "unified:error:Timeout: Execution cancelled after 300.0s";
               last_preview = "Timeout: Execution cancelled after 300.0s";
@@ -497,8 +497,8 @@ let test_runtime_surface_derives_autonomous_slot_wait_timeout_from_meta () =
         {
           base.runtime with
           last_blocker =
-            Some (KT.blocker_info_of_class ~detail:reason
-                    KT.Autonomous_slot_wait_timeout);
+            Some (Masc_mcp.Keeper_meta_contract.blocker_info_of_class ~detail:reason
+                    Masc_mcp.Keeper_meta_contract.Autonomous_slot_wait_timeout);
         };
     }
   in
@@ -535,8 +535,8 @@ let test_runtime_surface_derives_cascade_exhausted_from_meta () =
         {
           base.runtime with
           last_blocker =
-            Some (KT.blocker_info_of_class ~detail:reason
-                    (KT.Cascade_exhausted KT.Connection_refused));
+            Some (Masc_mcp.Keeper_meta_contract.blocker_info_of_class ~detail:reason
+                    (Masc_mcp.Keeper_meta_contract.Cascade_exhausted Masc_mcp.Keeper_meta_contract.Connection_refused));
         };
     }
   in
@@ -582,8 +582,8 @@ let test_runtime_surface_names_no_tool_provider_details () =
         {
           base.runtime with
           last_blocker =
-            Some (KT.blocker_info_of_class ~detail:summary
-                    KT.No_tool_capable_provider);
+            Some (Masc_mcp.Keeper_meta_contract.blocker_info_of_class ~detail:summary
+                    Masc_mcp.Keeper_meta_contract.No_tool_capable_provider);
         };
     }
   in
@@ -618,9 +618,9 @@ let test_runtime_surface_routes_turn_timeout_to_runtime_action () =
               base.runtime with
               last_blocker =
                 Some
-                  (KT.blocker_info_of_class
+                  (Masc_mcp.Keeper_meta_contract.blocker_info_of_class
                      ~detail:"Provider stream exceeded the keeper turn timeout."
-                     KT.Turn_timeout);
+                     Masc_mcp.Keeper_meta_contract.Turn_timeout);
             };
         }
       in
@@ -654,9 +654,9 @@ let test_runtime_surface_routes_paused_timeout_to_paused_action () =
               base.runtime with
               last_blocker =
                 Some
-                  (KT.blocker_info_of_class
+                  (Masc_mcp.Keeper_meta_contract.blocker_info_of_class
                      ~detail:"Provider stream exceeded the keeper turn timeout."
-                     KT.Turn_timeout);
+                     Masc_mcp.Keeper_meta_contract.Turn_timeout);
             };
         }
       in
@@ -700,7 +700,7 @@ let test_status_bridge_does_not_fabricate_resumable_cli_session_blocker () =
     (option string)
     "resumable session is not a cascade blocker"
     None
-    (Option.map KT.blocker_class_to_string (KSB.blocker_class_of_sdk_error sdk_error))
+    (Option.map Masc_mcp.Keeper_meta_contract.blocker_class_to_string (KSB.blocker_class_of_sdk_error sdk_error))
 ;;
 
 let test_status_bridge_classifies_oas_agent_execution_timeout () =
@@ -728,7 +728,7 @@ let test_status_bridge_classifies_oas_agent_execution_timeout () =
          label
          (Some "oas_agent_execution_timeout")
          (Option.map
-            KT.blocker_class_to_string
+            Masc_mcp.Keeper_meta_contract.blocker_class_to_string
             (KSB.blocker_class_of_sdk_error sdk_error)))
     [ "structural api timeout", structural_api_timeout
     ; "typed agent execution timeout", typed_agent_timeout
@@ -743,10 +743,10 @@ let test_runtime_blocker_summary_is_not_reparsed_from_masc_error_payload () =
   let cascade_surface =
     KSB.runtime_blocker_surface_of_typed_class
       ~summary
-      (KT.Cascade_exhausted KT.No_providers_available)
+      (Masc_mcp.Keeper_meta_contract.Cascade_exhausted Masc_mcp.Keeper_meta_contract.No_providers_available)
   in
   let no_tool_surface =
-    KSB.runtime_blocker_surface_of_typed_class ~summary (KT.Cascade_exhausted KT.No_tool_capable)
+    KSB.runtime_blocker_surface_of_typed_class ~summary (Masc_mcp.Keeper_meta_contract.Cascade_exhausted Masc_mcp.Keeper_meta_contract.No_tool_capable)
   in
   check string "cascade summary stays opaque" summary cascade_surface.summary;
   check string "no-tool summary stays opaque" summary no_tool_surface.summary;
@@ -799,8 +799,8 @@ let test_runtime_surface_derives_continue_gate_from_persisted_ambiguous_blocker 
         {
           base.runtime with
           last_blocker =
-            Some (KT.blocker_info_of_class ~detail:reason
-                    KT.Ambiguous_post_commit_timeout);
+            Some (Masc_mcp.Keeper_meta_contract.blocker_info_of_class ~detail:reason
+                    Masc_mcp.Keeper_meta_contract.Ambiguous_post_commit_timeout);
         };
     }
   in
@@ -839,7 +839,7 @@ let test_runtime_surface_suppresses_stale_proactive_timeout_reason () =
             {
               base.runtime.proactive_rt with
               last_ts = now_ts -. 600.0;
-              last_outcome = KT.Proactive_error;
+              last_outcome = Masc_mcp.Keeper_meta_contract.Proactive_error;
               last_reason =
                 "unified:error:Internal error: Turn wall-clock timeout after 3600s (MASC_KEEPER_TURN_TIMEOUT_SEC)";
               last_preview =
@@ -969,7 +969,7 @@ let test_runtime_surface_maps_registry_failure_reason_blockers () =
 
 let test_runtime_surface_exposes_cascade_attempt_facts () =
   KR.clear ();
-  let attempt : KT.cascade_attempt_record =
+  let attempt : Masc_mcp.Keeper_meta_contract.cascade_attempt_record =
     { provider_id = "runpod_mtp.qwen36-35b-a3b-mtp.keeper"
     ; http_status = Some 524
     ; outcome = `Failure "connection closed by peer"
@@ -978,7 +978,7 @@ let test_runtime_surface_exposes_cascade_attempt_facts () =
   in
   let base =
     make_meta ~name:"runtime-cascade-attempt-facts-test" ()
-    |> KT.set_cascade_name "tier-group.strict_tool_candidates"
+    |> Masc_mcp.Keeper_meta_contract.set_cascade_name "tier-group.strict_tool_candidates"
   in
   let meta =
     { base with
@@ -1098,9 +1098,9 @@ let test_runtime_surface_prefers_typed_blocker_over_progress_narrative () =
         {
           base.runtime with
           last_blocker =
-            Some (KT.blocker_info_of_class
+            Some (Masc_mcp.Keeper_meta_contract.blocker_info_of_class
                     ~detail:"turn wall-clock timeout exceeded"
-                    KT.Turn_timeout);
+                    Masc_mcp.Keeper_meta_contract.Turn_timeout);
         };
     }
   in

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -206,7 +206,7 @@ let test_should_cleanup_dead_true () =
         ("sandbox_profile", `String "local");
         ("network_mode", `String "inherit");
       ] in
-      match KT.meta_of_json json with
+      match Masc_mcp.Keeper_meta_json_parse.meta_of_json json with
       | Ok meta -> meta
       | Error err -> fail err)
   in
@@ -226,7 +226,7 @@ let test_should_cleanup_dead_false_when_recent () =
         ("sandbox_profile", `String "local");
         ("network_mode", `String "inherit");
       ] in
-      match KT.meta_of_json json with
+      match Masc_mcp.Keeper_meta_json_parse.meta_of_json json with
       | Ok meta -> meta
       | Error err -> fail err)
   in
@@ -281,7 +281,7 @@ let make_meta name =
     ("sandbox_profile", `String "local");
     ("network_mode", `String "inherit");
   ] in
-  match KT.meta_of_json json with
+  match Masc_mcp.Keeper_meta_json_parse.meta_of_json json with
   | Ok meta -> meta
   | Error err -> fail ("make_meta: " ^ err)
 
@@ -471,10 +471,10 @@ let test_spawn_admission_denial_does_not_register_or_fork () =
   ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
   let name = "spawn-denied-no-fork" in
   let meta = make_meta name in
-  (match KT.write_meta config meta with
+  (match Masc_mcp.Keeper_meta_store.write_meta config meta with
    | Ok () -> ()
    | Error err -> fail err);
-  let ctx : _ KT.context =
+  let ctx : _ Masc_mcp.Keeper_types_profile.context =
     {
       config;
       agent_name = "supervisor";
@@ -700,16 +700,16 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
               base.runtime with
               last_blocker =
                 Some
-                  (KT.blocker_info_of_class
+                  (Masc_mcp.Keeper_meta_contract.blocker_info_of_class
                      ~detail:"turn outcome ambiguous after committed mutating tool call(s): [keeper_board_post]; retry disabled to avoid duplicate mutation; original_error=Completion contract [require_tool_use] violated"
-                     KT.Ambiguous_post_commit_timeout);
+                     Masc_mcp.Keeper_meta_contract.Ambiguous_post_commit_timeout);
             };
         }
       in
-      (match KT.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -745,7 +745,7 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
        | Ok () -> ()
        | Error err -> fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
       let resumed_meta =
-        match KT.read_meta config meta.name with
+        match Masc_mcp.Keeper_meta_store.read_meta config meta.name with
         | Ok (Some value) -> value
         | Ok None -> fail "expected resumed keeper meta"
         | Error err -> fail err
@@ -773,7 +773,7 @@ let test_restart_path_emits_attempt_and_started_outcome_metrics () =
       let config = Masc_mcp.Coord.default_config base_dir in
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
       let meta = make_meta name in
-      (match KT.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
@@ -792,7 +792,7 @@ let test_restart_path_emits_attempt_and_started_outcome_metrics () =
           Masc_mcp.Keeper_metrics.(to_string RestartOutcomes)
           ~labels:outcome_labels ()
       in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -851,7 +851,7 @@ let test_restart_path_emits_meta_unavailable_outcome_metric () =
           Masc_mcp.Keeper_metrics.(to_string RestartOutcomes)
           ~labels:outcome_labels ()
       in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -896,7 +896,7 @@ let test_max_restarts_exhaustion_emits_dead_alert () =
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
       let name = "dead-alert-keeper" in
       let meta = make_meta name in
-      (match KT.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
@@ -916,7 +916,7 @@ let test_max_restarts_exhaustion_emits_dead_alert () =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.(to_string DeadTotal)
       in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -956,12 +956,12 @@ let with_reap_ready_dead_keeper name f =
       let config = Masc_mcp.Coord.default_config base_dir in
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
       let meta = make_meta name in
-      (match KT.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
       ignore (Reg.register ~base_path:config.base_path name meta);
       Reg.mark_dead ~base_path:config.base_path name ~at:0.0;
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -1039,7 +1039,7 @@ let test_stale_storm_pause_skips_restart () =
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
       let name = "stale-storm-keeper" in
       let meta = make_meta name in
-      (match KT.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
@@ -1059,7 +1059,7 @@ let test_stale_storm_pause_skips_restart () =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.(to_string DeadTotal)
       in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -1083,7 +1083,7 @@ let test_stale_storm_pause_skips_restart () =
         baseline_dead after_dead;
       (* meta.paused must be true on disk so reconcile + future sweeps
          honor the pause across server restarts. *)
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused = true after storm pause"
              true m.paused;
@@ -1113,7 +1113,7 @@ let test_legacy_stale_fleet_batch_routes_to_restart_budget () =
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
       let name = "legacy-stale-fleet-batch-keeper" in
       let meta = make_meta name in
-      (match KT.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
@@ -1130,7 +1130,7 @@ let test_legacy_stale_fleet_batch_routes_to_restart_budget () =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.(to_string DeadTotal)
       in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -1147,7 +1147,7 @@ let test_legacy_stale_fleet_batch_routes_to_restart_budget () =
       in
       check (float 0.001) "legacy fleet batch follows restart/dead budget"
         (baseline_dead +. 1.0) after_dead;
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused stays false for legacy fleet batch"
              false m.paused
@@ -1170,7 +1170,7 @@ let test_provider_timeout_loop_pause_skips_restart () =
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
       let name = "provider-timeout-loop-keeper" in
       let meta = make_meta name in
-      (match KT.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
@@ -1187,7 +1187,7 @@ let test_provider_timeout_loop_pause_skips_restart () =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.(to_string DeadTotal)
       in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -1210,7 +1210,7 @@ let test_provider_timeout_loop_pause_skips_restart () =
         (baseline_pause +. 1.0) after_pause;
       check (float 0.001) "dead counter NOT incremented (budget loop is pause)"
         baseline_dead after_dead;
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused = true after provider timeout loop pause"
              true m.paused
@@ -1234,7 +1234,7 @@ let test_unresolved_watchdog_stopped_budget_loop_is_reaped () =
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
       let name = "unresolved-watchdog-stopped" in
       let meta = make_meta name in
-      (match KT.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
@@ -1243,7 +1243,7 @@ let test_unresolved_watchdog_stopped_budget_loop_is_reaped () =
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name
         (Some (Reg.Provider_timeout_loop { count = 3 }));
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -1254,14 +1254,14 @@ let test_unresolved_watchdog_stopped_budget_loop_is_reaped () =
         }
       in
       Sup.sweep_and_recover ctx;
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused = true after unresolved watchdog stop"
              true m.paused;
            check bool "provider timeout blocker class preserved"
              true
              (match m.runtime.last_blocker with
-              | Some b -> b.klass = KT.Turn_timeout
+              | Some b -> b.klass = Masc_mcp.Keeper_meta_contract.Turn_timeout
               | None -> false)
        | Ok None -> fail "meta missing after unresolved watchdog stop"
        | Error err -> fail ("read_meta failed: " ^ err));
@@ -1286,7 +1286,7 @@ let test_non_storm_crashed_restarts_normally () =
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
       let name = "non-storm-keeper" in
       let meta = make_meta name in
-      (match KT.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
@@ -1306,7 +1306,7 @@ let test_non_storm_crashed_restarts_normally () =
       let baseline_pause =
         Masc_mcp.Prometheus.metric_total "masc_keeper_stale_storm_paused_total"
       in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -1323,7 +1323,7 @@ let test_non_storm_crashed_restarts_normally () =
       check (float 0.001) "stale_storm_paused counter NOT incremented for non-storm"
         baseline_pause after_pause;
       (* meta.paused stays false. *)
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused stays false after non-storm crash"
              false m.paused
@@ -1351,7 +1351,7 @@ let test_storm_pause_requires_manual_resume () =
       (* Ensure no prior auto_resume_after_sec. *)
       check bool "initial auto_resume_after_sec = None"
         true (meta.auto_resume_after_sec = None);
-      (match KT.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
@@ -1360,7 +1360,7 @@ let test_storm_pause_requires_manual_resume () =
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name
         (Some (Reg.Stale_termination_storm { count = 5 }));
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -1373,7 +1373,7 @@ let test_storm_pause_requires_manual_resume () =
       Sup.sweep_and_recover ctx;
       (* Stale storms are operator-owned pauses: no timer should re-enter
          the same failed cascade/tool loop automatically. *)
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused = true" true m.paused;
            check bool "auto_resume_after_sec remains None"
@@ -1412,7 +1412,7 @@ let test_oas_auto_resume_after_sec_doubles_on_repause () =
           auto_resume_after_sec = Some 3600.0;
         }
       in
-      (match KT.write_meta config initial_meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config initial_meta with
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name initial_meta in
@@ -1421,7 +1421,7 @@ let test_oas_auto_resume_after_sec_doubles_on_repause () =
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name
         (Some (Reg.Provider_timeout_loop { count = 3 }));
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -1433,7 +1433,7 @@ let test_oas_auto_resume_after_sec_doubles_on_repause () =
       in
       Sup.sweep_and_recover ctx;
       (* Back-off must double: 3600 -> 7200. *)
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused = true" true m.paused;
            (match m.auto_resume_after_sec with
@@ -1477,7 +1477,7 @@ let test_sweep_auto_resumes_after_backoff () =
           updated_at = two_hours_ago;
         }
       in
-      (match KT.write_meta config paused_meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config paused_meta with
        | Ok () -> ()
        | Error err -> fail err);
       check bool "precondition: paused keeper is not bootable" false
@@ -1486,7 +1486,7 @@ let test_sweep_auto_resumes_after_backoff () =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.(to_string AutoResumedTotal)
       in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -1498,7 +1498,7 @@ let test_sweep_auto_resumes_after_backoff () =
       in
       Sup.sweep_and_recover ctx;
       (* meta.paused must be cleared after the back-off timer elapsed. *)
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused = false after auto-resume"
              false m.paused;
@@ -1549,7 +1549,7 @@ let test_sweep_auto_resumes_registered_paused_entry () =
           updated_at = two_hours_ago;
         }
       in
-      (match KT.write_meta config paused_meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config paused_meta with
        | Ok () -> ()
        | Error err -> fail err);
       let entry = Reg.register ~base_path:config.base_path name paused_meta in
@@ -1564,7 +1564,7 @@ let test_sweep_auto_resumes_registered_paused_entry () =
            check string "precondition: registry phase paused" "paused"
              (KSM.phase_to_string phase)
        | None -> fail "precondition: registry entry missing");
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -1575,7 +1575,7 @@ let test_sweep_auto_resumes_registered_paused_entry () =
         }
       in
       Sup.sweep_and_recover ctx;
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused = false after auto-resume" false m.paused
        | Ok None -> fail "meta missing after auto-resume"
@@ -1620,7 +1620,7 @@ let test_operator_pause_not_auto_resumed () =
           updated_at = two_hours_ago;
         }
       in
-      (match KT.write_meta config paused_meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config paused_meta with
        | Ok () -> ()
        | Error err -> fail err);
       check bool "precondition: operator pause is not bootable" false
@@ -1629,7 +1629,7 @@ let test_operator_pause_not_auto_resumed () =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.(to_string AutoResumedTotal)
       in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -1641,7 +1641,7 @@ let test_operator_pause_not_auto_resumed () =
       in
       Sup.sweep_and_recover ctx;
       (* meta.paused must remain true: operator pauses need human action. *)
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused stays true for operator pause"
              true m.paused
@@ -1681,7 +1681,7 @@ let test_turn_timeout_blocker_without_resume_policy_not_auto_resumed () =
           t.tm_hour t.tm_min t.tm_sec
       in
       let timeout_blocker =
-        KT.blocker_info_of_class ~detail:"turn_timeout" KT.Turn_timeout
+        Masc_mcp.Keeper_meta_contract.blocker_info_of_class ~detail:"turn_timeout" Masc_mcp.Keeper_meta_contract.Turn_timeout
       in
       let paused_meta =
         { (make_meta name) with
@@ -1699,7 +1699,7 @@ let test_turn_timeout_blocker_without_resume_policy_not_auto_resumed () =
         (Masc_mcp.Keeper_supervisor_types.paused_meta_auto_resume_due
            ~now:(Unix.time ())
            paused_meta);
-      (match KT.write_meta config paused_meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config paused_meta with
        | Ok () -> ()
        | Error err -> fail err);
       check bool "precondition: timeout pause is not bootable" false
@@ -1708,7 +1708,7 @@ let test_turn_timeout_blocker_without_resume_policy_not_auto_resumed () =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.(to_string AutoResumedTotal)
       in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -1719,7 +1719,7 @@ let test_turn_timeout_blocker_without_resume_policy_not_auto_resumed () =
         }
       in
       Sup.sweep_and_recover ctx;
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused stays true without explicit resume policy"
              true m.paused;
@@ -1728,7 +1728,7 @@ let test_turn_timeout_blocker_without_resume_policy_not_auto_resumed () =
            check bool "timeout blocker stays recorded for operator inspection"
              true
              (match m.runtime.last_blocker with
-              | Some info -> info.klass = KT.Turn_timeout
+              | Some info -> info.klass = Masc_mcp.Keeper_meta_contract.Turn_timeout
               | None -> false)
        | Ok None -> fail "meta missing"
        | Error err -> fail ("read_meta failed: " ^ err));
@@ -1777,9 +1777,9 @@ let test_capacity_blocker_without_resume_policy_not_auto_resumed () =
             { (make_meta name).runtime with
               last_blocker =
                 Some
-                  (KT.blocker_info_of_class
+                  (Masc_mcp.Keeper_meta_contract.blocker_info_of_class
                      ~detail:"capacity exhausted before explicit resume policy"
-                     KT.Capacity_backpressure);
+                     Masc_mcp.Keeper_meta_contract.Capacity_backpressure);
             };
         }
       in
@@ -1788,7 +1788,7 @@ let test_capacity_blocker_without_resume_policy_not_auto_resumed () =
         (Masc_mcp.Keeper_supervisor_types.paused_meta_auto_resume_due
            ~now:(Unix.time ())
            paused_meta);
-      (match KT.write_meta config paused_meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config paused_meta with
        | Ok () -> ()
        | Error err -> fail err);
       check bool "precondition: capacity pause is not bootable" false
@@ -1797,7 +1797,7 @@ let test_capacity_blocker_without_resume_policy_not_auto_resumed () =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Keeper_metrics.(to_string AutoResumedTotal)
       in
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         {
           config;
           agent_name = "supervisor";
@@ -1808,14 +1808,14 @@ let test_capacity_blocker_without_resume_policy_not_auto_resumed () =
         }
       in
       Sup.sweep_and_recover ctx;
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused stays true without explicit resume policy"
              true m.paused;
            check bool "capacity blocker stays recorded for operator inspection"
              true
              (match m.runtime.last_blocker with
-              | Some info -> info.klass = KT.Capacity_backpressure
+              | Some info -> info.klass = Masc_mcp.Keeper_meta_contract.Capacity_backpressure
               | None -> false)
        | Ok None -> fail "meta missing"
        | Error err -> fail ("read_meta failed: " ^ err));
@@ -1851,7 +1851,7 @@ let test_initial_auto_resume_capped_at_max () =
       let meta = make_meta name in
       check bool "precondition: auto_resume_after_sec = None"
         true (meta.auto_resume_after_sec = None);
-      (match KT.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
@@ -1907,11 +1907,11 @@ let test_persisted_blocker_survives_unregister () =
           runtime =
             {
               meta.runtime with
-              last_blocker = Some (KT.blocker_info_of_class ~detail:"test-blocker" KT.Turn_timeout);
+              last_blocker = Some (Masc_mcp.Keeper_meta_contract.blocker_info_of_class ~detail:"test-blocker" Masc_mcp.Keeper_meta_contract.Turn_timeout);
             };
         }
       in
-      (match KT.write_meta config meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
@@ -1920,18 +1920,18 @@ let test_persisted_blocker_survives_unregister () =
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name
         (Some (Reg.Stale_termination_storm { count = 5 }));
-      let ctx : _ KT.context =
+      let ctx : _ Masc_mcp.Keeper_types_profile.context =
         { config; agent_name = "supervisor"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = Some (Eio.Stdenv.net env) }
       in
       Sup.sweep_and_recover ctx;
       
       (* Check if blocker is persisted *)
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            (match m.runtime.last_blocker with
             | Some b ->
                 check string "meta.runtime.last_blocker" "test-blocker" b.detail;
-                check bool "meta.runtime.last_blocker.klass" true (b.klass = KT.Turn_timeout)
+                check bool "meta.runtime.last_blocker.klass" true (b.klass = Masc_mcp.Keeper_meta_contract.Turn_timeout)
             | None -> fail "expected blocker after storm pause");
        | Ok None -> fail "meta missing after storm pause"
        | Error err -> fail ("read_meta failed: " ^ err));
@@ -1940,12 +1940,12 @@ let test_persisted_blocker_survives_unregister () =
       Reg.unregister ~base_path:config.base_path name;
       
       (* Read again and verify *)
-      (match KT.read_meta config name with
+      (match Masc_mcp.Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            (match m.runtime.last_blocker with
             | Some b ->
                 check string "meta.runtime.last_blocker after unregister" "test-blocker" b.detail;
-                check bool "meta.runtime.last_blocker.klass after unregister" true (b.klass = KT.Turn_timeout)
+                check bool "meta.runtime.last_blocker.klass after unregister" true (b.klass = Masc_mcp.Keeper_meta_contract.Turn_timeout)
             | None -> fail "expected blocker after unregister")
        | Ok None -> fail "meta missing after unregister"
        | Error err -> fail ("read_meta failed: " ^ err)))
@@ -2352,7 +2352,7 @@ let () =
                 ignore (Reg.dispatch_event ~base_path:config.base_path name
                           KSM.Fiber_started);
                 Reg.set_started_at_for_test ~base_path:config.base_path name 1.0;
-                let ctx : _ KT.context =
+                let ctx : _ Masc_mcp.Keeper_types_profile.context =
                   {
                     config;
                     agent_name = "supervisor";
@@ -2441,7 +2441,7 @@ let () =
                 ignore (Reg.dispatch_event ~base_path:config.base_path name
                           KSM.Fiber_started);
                 Reg.set_started_at_for_test ~base_path:config.base_path name 1.0;
-                let ctx : _ KT.context =
+                let ctx : _ Masc_mcp.Keeper_types_profile.context =
                   {
                     config;
                     agent_name = "supervisor";

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -6,7 +6,7 @@ module CT = Cdal_types
 open Alcotest
 open Masc_mcp
 
-let make_test_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
+let make_test_meta ?(name = "test-keeper") () : Keeper_meta_contract.keeper_meta =
   match
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
@@ -24,7 +24,7 @@ let make_goal_scoped_meta goal_ids =
 ;;
 
 let make_meta_with_tools tools =
-  { (make_test_meta ()) with tool_access = Keeper_types.Custom tools }
+  { (make_test_meta ()) with tool_access = Keeper_meta_tool_access.Custom tools }
 ;;
 
 let make_ctx_work () = Keeper_context_runtime.create ~system_prompt:"test" ~max_tokens:4000
@@ -401,7 +401,7 @@ let claimed_task_for_agent config agent_name =
 ;;
 
 let check_no_task_claimed config meta =
-  match claimed_task_for_agent config meta.Keeper_types.agent_name with
+  match claimed_task_for_agent config meta.Keeper_meta_contract.agent_name with
   | None -> ()
   | Some task ->
     fail
@@ -432,19 +432,19 @@ let check_active_goal_scope_no_fallback json ~goal_id =
 ;;
 
 let with_registered_keeper config meta f =
-  Keeper_registry.unregister ~base_path:config.Coord.base_path meta.Keeper_types.name;
+  Keeper_registry.unregister ~base_path:config.Coord.base_path meta.Keeper_meta_contract.name;
   ignore
     (Keeper_registry.register_offline
        ~base_path:config.Coord.base_path
-       meta.Keeper_types.name
+       meta.Keeper_meta_contract.name
        meta);
   Fun.protect
     ~finally:(fun () ->
-      Keeper_registry.unregister ~base_path:config.Coord.base_path meta.Keeper_types.name)
+      Keeper_registry.unregister ~base_path:config.Coord.base_path meta.Keeper_meta_contract.name)
     f
 ;;
 
-let current_task_id_string (meta : Keeper_types.keeper_meta) =
+let current_task_id_string (meta : Keeper_meta_contract.keeper_meta) =
   Option.map Keeper_id.Task_id.to_string meta.current_task_id
 ;;
 
@@ -582,7 +582,7 @@ let test_claim_syncs_keeper_current_task_id () =
         (Some task_id)
         (current_task_id_string registry_meta);
       let persisted_meta =
-        match Keeper_types.read_meta config meta.name with
+        match Keeper_meta_store.read_meta config meta.name with
         | Ok (Some meta) -> meta
         | Ok None -> fail "expected persisted keeper meta"
         | Error msg -> fail msg
@@ -628,7 +628,7 @@ let test_release_clears_keeper_current_task_id () =
         None
         (current_task_id_string registry_meta);
       let persisted_meta =
-        match Keeper_types.read_meta config meta.name with
+        match Keeper_meta_store.read_meta config meta.name with
         | Ok (Some meta) -> meta
         | Ok None -> fail "expected persisted keeper meta"
         | Error msg -> fail msg
@@ -726,7 +726,7 @@ let test_stale_current_task_id_is_cleared_from_backlog () =
     in
     let meta = { (make_test_meta ()) with current_task_id = Some task_id } in
     with_registered_keeper config meta (fun () ->
-      (match Keeper_types.write_meta config meta with
+      (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error msg -> fail msg);
       let synced =
@@ -752,7 +752,7 @@ let test_run_context_uses_reconciled_current_task_id () =
       }
     in
     with_registered_keeper config meta (fun () ->
-      (match Keeper_types.write_meta config meta with
+      (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error msg -> fail msg);
       let ctx =
@@ -810,7 +810,7 @@ let test_multiple_active_tasks_selects_deterministic_current_task () =
         ~task_status:
           (Masc_domain.Claimed
              { assignee = meta.agent_name; claimed_at = "2026-05-02T00:01:00Z" });
-      (match Keeper_types.write_meta config meta with
+      (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error msg -> fail msg);
       let high_priority_task = task_by_title config "Newer high priority" in
@@ -863,7 +863,7 @@ let test_multiple_active_tasks_preserves_existing_current_task () =
              ; claimed_at = "2026-05-02T00:01:00Z"
              });
       let meta = { base_meta with current_task_id = Some sticky_task_id } in
-      (match Keeper_types.write_meta config meta with
+      (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error msg -> fail msg);
       let synced =
@@ -2224,7 +2224,7 @@ let test_submit_for_verification_transitions_task () =
                   "expected awaiting_verification, got %s"
                   (Masc_domain.string_of_task_status status)));
           let persisted_meta =
-            match Keeper_types.read_meta config meta.name with
+            match Keeper_meta_store.read_meta config meta.name with
             | Ok (Some meta) -> meta
             | Ok None -> fail "expected persisted keeper meta"
             | Error msg -> fail msg

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1159,8 +1159,8 @@ let test_persona_resolver_preserves_canonical_tool_access_and_allowed_paths () =
 }
 |};
   let expected_tool_access =
-    Masc_mcp.Keeper_types.tool_access_to_json
-      (Masc_mcp.Keeper_types.Custom [ "masc_status" ])
+    Masc_mcp.Keeper_meta_tool_access.tool_access_to_json
+      (Masc_mcp.Keeper_meta_tool_access.Custom [ "masc_status" ])
   in
   match
     Masc_mcp.Agent_tool_persona_runtime.resolved_keeper_args_from_persona

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -107,7 +107,7 @@ let test_committed_keepers_are_pr_work_capable () =
              match defaults.tool_preset with
              | None -> fail (Printf.sprintf "%s: tool_access.preset is required" file)
              | Some raw ->
-                 (match KT.tool_preset_of_string raw with
+                 (match Masc_mcp.Keeper_meta_tool_access.tool_preset_of_string raw with
                   | Some preset -> preset
                   | None -> fail (Printf.sprintf "%s: unknown preset %S" file raw))
            in
@@ -121,7 +121,7 @@ let test_committed_keepers_are_pr_work_capable () =
                     ( "tool_access",
                       `Assoc [
                         ("kind", `String "preset");
-                        ("preset", `String (KT.tool_preset_to_string preset));
+                        ("preset", `String (Masc_mcp.Keeper_meta_tool_access.tool_preset_to_string preset));
                         ("also_allow", `List []);
                       ] );
                     ("tool_denylist", `List []);
@@ -190,7 +190,7 @@ let test_verifier_config_hides_worker_lifecycle_tools () =
       let preset =
         match defaults.tool_preset with
         | Some raw -> (
-            match KT.tool_preset_of_string raw with
+            match Masc_mcp.Keeper_meta_tool_access.tool_preset_of_string raw with
             | Some preset -> preset
             | None -> fail (Printf.sprintf "unknown verifier preset %S" raw))
         | None -> fail "verifier tool_access.preset is required"
@@ -209,7 +209,7 @@ let test_verifier_config_hides_worker_lifecycle_tools () =
                    `Assoc
                      [
                        ("kind", `String "preset");
-                       ("preset", `String (KT.tool_preset_to_string preset));
+                       ("preset", `String (Masc_mcp.Keeper_meta_tool_access.tool_preset_to_string preset));
                        ( "also_allow",
                          `List (List.map (fun value -> `String value) also_allow) );
                      ] );

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -577,9 +577,9 @@ let test_execution_receipt_descriptor_summary_projects_descriptors () =
         ; missing_required_tools = []
         ; materialized_tools = [ "tool_read_file"; "tool_execute"; "keeper_time_now" ]
         }
-    ; sandbox_kind = Masc_mcp.Keeper_types.Local
+    ; sandbox_kind = Masc_mcp.Keeper_types_profile_sandbox.Local
     ; sandbox_root = None
-    ; network_mode = Masc_mcp.Keeper_types.Network_none
+    ; network_mode = Masc_mcp.Keeper_types_profile_sandbox.Network_none
     ; approval_profile = Some "manual"
     ; approval_profile_derived = false
     ; cascade_name = Cascade_name.of_string_exn "tier.test"

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -15,16 +15,16 @@ open Masc_mcp
 let make_meta
       ?(name = "test-keeper")
       ?(policy_voice_enabled = false)
-      ?(preset = Keeper_types.Full)
+      ?(preset = Keeper_meta_tool_access.Full)
       ?(also_allow = [])
       ?tool_access
       ()
-  : Keeper_types.keeper_meta
+  : Keeper_meta_contract.keeper_meta
   =
   let tool_access =
     match tool_access with
     | Some access -> access
-    | None -> Keeper_types.Preset { preset; also_allow }
+    | None -> Keeper_meta_tool_access.Preset { preset; also_allow }
   in
   let json =
     `Assoc
@@ -32,7 +32,7 @@ let make_meta
       ; "agent_name", `String name
       ; "trace_id", `String "test-trace-exposure"
       ; "policy_voice_enabled", `Bool policy_voice_enabled
-      ; "tool_access", Keeper_types.tool_access_to_json tool_access
+      ; "tool_access", Keeper_meta_tool_access.tool_access_to_json tool_access
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
@@ -135,7 +135,7 @@ let voice_tools =
 
 let test_voice_policy_enabled_exposes_voice_tools () =
   let meta =
-    make_meta ~policy_voice_enabled:true ~preset:Keeper_types.Delivery ()
+    make_meta ~policy_voice_enabled:true ~preset:Keeper_meta_tool_access.Delivery ()
   in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   List.iter
@@ -145,7 +145,7 @@ let test_voice_policy_enabled_exposes_voice_tools () =
 
 let test_voice_policy_disabled_hides_voice_tools () =
   let meta =
-    make_meta ~policy_voice_enabled:false ~preset:Keeper_types.Social ()
+    make_meta ~policy_voice_enabled:false ~preset:Keeper_meta_tool_access.Social ()
   in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   List.iter
@@ -154,7 +154,7 @@ let test_voice_policy_disabled_hides_voice_tools () =
 ;;
 
 let test_custom_empty_blocks_all_tools () =
-  let meta = make_meta ~tool_access:(Keeper_types.Custom []) () in
+  let meta = make_meta ~tool_access:(Keeper_meta_tool_access.Custom []) () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check int "custom empty blocks every tool" 0 (List.length tools)
 ;;
@@ -164,7 +164,7 @@ let test_custom_unknown_tool_names_are_dropped () =
   let meta =
     make_meta
       ~tool_access:
-        (Keeper_types.Custom [ "keeper_time_now"; "masc_status"; "totally_unknown_tool" ])
+        (Keeper_meta_tool_access.Custom [ "keeper_time_now"; "masc_status"; "totally_unknown_tool" ])
       ()
   in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
@@ -178,43 +178,43 @@ let test_custom_unknown_tool_names_are_dropped () =
    ============================================================ *)
 
 let test_delivery_preset_has_search_files_access () =
-  let meta = make_meta ~preset:Keeper_types.Delivery () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Delivery () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "has tool_search_files" true (has_tool "tool_search_files" tools)
 ;;
 
 let test_full_preset_includes_tool_edit_file () =
-  let meta = make_meta ~preset:Keeper_types.Full () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Full () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "has tool_edit_file" true (has_tool "tool_edit_file" tools)
 ;;
 
 let test_delivery_preset_includes_tool_edit_file () =
-  let meta = make_meta ~preset:Keeper_types.Delivery () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Delivery () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "has tool_edit_file" true (has_tool "tool_edit_file" tools)
 ;;
 
 let test_research_preset_includes_tool_edit_file () =
-  let meta = make_meta ~preset:Keeper_types.Research () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Research () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "has tool_edit_file" true (has_tool "tool_edit_file" tools)
 ;;
 
 let test_minimal_preset_excludes_tool_edit_file () =
-  let meta = make_meta ~preset:Keeper_types.Minimal () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Minimal () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "no tool_edit_file" false (has_tool "tool_edit_file" tools)
 ;;
 
 let test_minimal_preset_has_web_search () =
-  let meta = make_meta ~preset:Keeper_types.Minimal () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Minimal () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "has masc_web_search" true (has_tool "masc_web_search" tools)
 ;;
 
 let test_minimal_preset_has_approval_pending () =
-  let meta = make_meta ~preset:Keeper_types.Minimal () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Minimal () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   let schema_names =
     Agent_tool_dispatch_runtime.keeper_allowed_model_tools meta
@@ -248,9 +248,9 @@ let test_minimal_preset_has_approval_pending () =
 ;;
 
 let test_all_presets_have_approval_pending () =
-  Keeper_types.all_tool_presets
+  Keeper_meta_tool_access.all_tool_presets
   |> List.iter (fun preset ->
-    let label = Keeper_types.tool_preset_to_string preset in
+    let label = Keeper_meta_tool_access.tool_preset_to_string preset in
     let meta = make_meta ~preset () in
     let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
     let schema_names =
@@ -270,7 +270,7 @@ let test_all_presets_have_approval_pending () =
 ;;
 
 let test_feature_catalog_required_tools_reachable_by_full_keeper () =
-  let meta = make_meta ~preset:Keeper_types.Full () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Full () in
   let schema_names =
     Agent_tool_dispatch_runtime.keeper_allowed_model_tools meta
     |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
@@ -286,7 +286,7 @@ let test_feature_catalog_required_tools_reachable_by_full_keeper () =
 ;;
 
 let test_delivery_preset_has_tool_execute () =
-  let meta = make_meta ~preset:Keeper_types.Delivery () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Delivery () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "has tool_execute" true (has_tool "tool_execute" tools);
   check bool "has tool_search_files" true (has_tool "tool_search_files" tools)
@@ -311,8 +311,8 @@ let test_legacy_pr_schemas_removed () =
    ============================================================ *)
 
 let test_presets_have_different_tool_count () =
-  let minimal = make_meta ~preset:Keeper_types.Minimal () in
-  let full = make_meta ~preset:Keeper_types.Full () in
+  let minimal = make_meta ~preset:Keeper_meta_tool_access.Minimal () in
+  let full = make_meta ~preset:Keeper_meta_tool_access.Full () in
   let minimal_tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names minimal in
   let full_tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names full in
   check
@@ -323,14 +323,14 @@ let test_presets_have_different_tool_count () =
 ;;
 
 let test_messaging_preset_has_board_tools () =
-  let meta = make_meta ~preset:Keeper_types.Messaging () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Messaging () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "has keeper_board_get" true (has_tool "keeper_board_get" tools);
   check bool "has keeper_board_post" true (has_tool "keeper_board_post" tools)
 ;;
 
 let test_research_preset_has_read_tools () =
-  let meta = make_meta ~preset:Keeper_types.Research () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Research () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   (* keeper_read removed: dead alias with no schema, tool_read_file is the actual tool *)
   check bool "has tool_read_file" true (has_tool "tool_read_file" tools);
@@ -399,7 +399,7 @@ let test_fallback_floor_has_no_implicit_repo_tools () =
 ;;
 
 let test_core_coordination_presets_have_task_lifecycle_tools () =
-  [ "social", Keeper_types.Social; "messaging", Keeper_types.Messaging ]
+  [ "social", Keeper_meta_tool_access.Social; "messaging", Keeper_meta_tool_access.Messaging ]
   |> List.iter (fun (label, preset) ->
     let meta = make_meta ~preset () in
     let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
@@ -416,7 +416,7 @@ let test_core_coordination_presets_have_task_lifecycle_tools () =
 ;;
 
 let test_delivery_preset_has_coordination_tools () =
-  let meta = make_meta ~preset:Keeper_types.Delivery () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Delivery () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "has keeper_tasks_list" true (has_tool "keeper_tasks_list" tools);
   check bool "has keeper_task_claim" true (has_tool "keeper_task_claim" tools);
@@ -446,7 +446,7 @@ let test_delivery_preset_has_coordination_tools () =
 
 let test_verifier_identity_uses_verdict_only_task_surface () =
   let assert_verifier_surface name =
-    let meta = make_meta ~name ~preset:Keeper_types.Full () in
+    let meta = make_meta ~name ~preset:Keeper_meta_tool_access.Full () in
     let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
     check bool (name ^ " can list tasks") true (has_tool "keeper_tasks_list" tools);
     check bool (name ^ " can transition verdicts") true (has_tool "masc_transition" tools);
@@ -464,7 +464,7 @@ let test_verifier_identity_uses_verdict_only_task_surface () =
 
 (* Governance tool schemas are no longer registered. *)
 let test_messaging_preset_has_no_legacy_governance_tools () =
-  let meta = make_meta ~preset:Keeper_types.Messaging () in
+  let meta = make_meta ~preset:Keeper_meta_tool_access.Messaging () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check bool "governance status removed" false (has_tool "masc_governance_status" tools);
   check bool "petition submit removed" false (has_tool "masc_petition_submit" tools)
@@ -484,8 +484,8 @@ let test_research_plus_also_allow_combined () =
   let meta =
     make_meta
       ~tool_access:
-        (Keeper_types.Preset
-           { preset = Keeper_types.Research
+        (Keeper_meta_tool_access.Preset
+           { preset = Keeper_meta_tool_access.Research
            ; also_allow = [ "keeper_board_get"; "keeper_board_post" ]
            })
       ()
@@ -1461,7 +1461,7 @@ let () =
             | Some hint -> check bool "hint non-empty" true (String.length hint > 0)
             | None -> fail "masc_web_search should have a hint")
         ; test_case "all allowed tools have hints" `Quick (fun () ->
-            let meta = make_meta ~preset:Keeper_types.Messaging () in
+            let meta = make_meta ~preset:Keeper_meta_tool_access.Messaging () in
             let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
             let missing =
               List.filter (fun name -> Keeper_tool_policy.tool_hint_of name = None) tools
@@ -1488,7 +1488,7 @@ let () =
               `Assoc [ "kind", `String "custom"; "tools", `String "masc_status" ]
             in
             let outer = `Assoc [ "tool_access", json ] in
-            match Keeper_types.tool_access_of_meta_json outer with
+            match Keeper_meta_tool_access.tool_access_of_meta_json outer with
             | Error msg ->
               check
                 bool
@@ -1510,7 +1510,7 @@ let () =
                 ]
             in
             let outer = `Assoc [ "tool_access", json ] in
-            match Keeper_types.tool_access_of_meta_json outer with
+            match Keeper_meta_tool_access.tool_access_of_meta_json outer with
             | Ok (Custom tools) ->
               check bool "has masc_status" true (List.mem "masc_status" tools);
               check bool "has masc_broadcast" true (List.mem "masc_broadcast" tools)
@@ -1519,13 +1519,13 @@ let () =
         ; test_case "null tools field returns error" `Quick (fun () ->
             let json = `Assoc [ "kind", `String "custom"; "tools", `Null ] in
             let outer = `Assoc [ "tool_access", json ] in
-            match Keeper_types.tool_access_of_meta_json outer with
+            match Keeper_meta_tool_access.tool_access_of_meta_json outer with
             | Error _ -> ()
             | Ok _ -> fail "expected Error for null tools field")
         ; test_case "integer tools field returns error" `Quick (fun () ->
             let json = `Assoc [ "kind", `String "custom"; "tools", `Int 42 ] in
             let outer = `Assoc [ "tool_access", json ] in
-            match Keeper_types.tool_access_of_meta_json outer with
+            match Keeper_meta_tool_access.tool_access_of_meta_json outer with
             | Error _ -> ()
             | Ok _ -> fail "expected Error for integer tools field")
         ; test_case "non-string tool member returns error" `Quick (fun () ->
@@ -1536,7 +1536,7 @@ let () =
                 ]
             in
             let outer = `Assoc [ "tool_access", json ] in
-            match Keeper_types.tool_access_of_meta_json outer with
+            match Keeper_meta_tool_access.tool_access_of_meta_json outer with
             | Error _ -> ()
             | Ok _ -> fail "expected Error for non-string tools member")
         ] )

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -25,7 +25,7 @@ type keeper_case = {
 and fixture = {
   generic : Generic.fixture;
   config : Masc_mcp.Coord.config;
-  meta : Masc_mcp.Keeper_types.keeper_meta;
+  meta : Masc_mcp.Keeper_meta_contract.keeper_meta;
   ctx_snapshot : Masc_mcp.Keeper_types.working_context;
   tools : Agent_sdk.Tool.t list;
 }
@@ -91,9 +91,9 @@ let make_meta ?(name = "keeper-tool-matrix") () =
           ("trace_id", `String "keeper-tool-matrix-trace");
           ("allowed_paths", `List [ `String "*" ]);
           ( "tool_access",
-            Masc_mcp.Keeper_types.tool_access_to_json
-              (Masc_mcp.Keeper_types.Preset
-                 { preset = Masc_mcp.Keeper_types.Full; also_allow = [] } ) );
+            Masc_mcp.Keeper_meta_tool_access.tool_access_to_json
+              (Masc_mcp.Keeper_meta_tool_access.Preset
+                 { preset = Masc_mcp.Keeper_meta_tool_access.Full; also_allow = [] } ) );
         ])
   with
   | Ok meta -> meta

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -24,17 +24,17 @@ let ensure_wildcard_repo_mapping config keeper_name =
 
 let make_test_meta
       ?(name = "test-keeper")
-      ?(preset = Keeper_types.Full)
+      ?(preset = Keeper_meta_tool_access.Full)
       ?(also_allow = [])
       ?(allowed_paths = [ "*" ])
       ?tool_access
       ()
-  : Keeper_types.keeper_meta
+  : Keeper_meta_contract.keeper_meta
   =
   let tool_access =
     match tool_access with
     | Some access -> access
-    | None -> Keeper_types.Preset { preset; also_allow }
+    | None -> Keeper_meta_tool_access.Preset { preset; also_allow }
   in
   match
     Masc_test_deps.meta_of_json_fixture
@@ -43,7 +43,7 @@ let make_test_meta
           ; "agent_name", `String name
           ; "trace_id", `String "test-trace-001"
           ; "allowed_paths", `List (List.map (fun path -> `String path) allowed_paths)
-          ; "tool_access", Keeper_types.tool_access_to_json tool_access
+          ; "tool_access", Keeper_meta_tool_access.tool_access_to_json tool_access
           ])
   with
   | Ok meta -> meta
@@ -168,7 +168,7 @@ let find_tool name tools =
 let find_read_tool tools = find_tool "Read" tools
 
 let read_repo_dir meta =
-  Filename.concat "repos" meta.Keeper_types.name
+  Filename.concat "repos" meta.Keeper_meta_contract.name
 ;;
 
 let read_path meta path = Filename.concat (read_repo_dir meta) path
@@ -181,7 +181,7 @@ let ensure_read_repo_dir config meta =
 ;;
 
 let make_registered_tools ~config ~meta ~ctx_snapshot () =
-  let keeper_name = meta.Keeper_types.name in
+  let keeper_name = meta.Keeper_meta_contract.name in
   ignore (Keeper_registry.register ~base_path:config.Coord.base_path keeper_name meta);
   ensure_wildcard_repo_mapping config keeper_name;
   Keeper_tools_oas_bundle.make_tools ~config ~meta ~ctx_snapshot ()
@@ -904,11 +904,11 @@ let test_failure_tracking_is_independent_per_args () =
        | Ok _ -> fail "guardrail should block original failing args")
 ;;
 
-let make_research_meta ?tool_access () : Keeper_types.keeper_meta =
+let make_research_meta ?tool_access () : Keeper_meta_contract.keeper_meta =
   let tool_access =
     match tool_access with
     | Some access -> access
-    | None -> Keeper_types.Preset { preset = Keeper_types.Research; also_allow = [] }
+    | None -> Keeper_meta_tool_access.Preset { preset = Keeper_meta_tool_access.Research; also_allow = [] }
   in
   match
     Masc_test_deps.meta_of_json_fixture
@@ -917,14 +917,14 @@ let make_research_meta ?tool_access () : Keeper_types.keeper_meta =
           ; "agent_name", `String "test-researcher"
           ; "trace_id", `String "test-trace-research"
           ; "soul_profile", `String "research"
-          ; "tool_access", Keeper_types.tool_access_to_json tool_access
+          ; "tool_access", Keeper_meta_tool_access.tool_access_to_json tool_access
           ])
   with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_research_meta failed: %s" e)
 ;;
 
-let make_learned_meta () : Keeper_types.keeper_meta =
+let make_learned_meta () : Keeper_meta_contract.keeper_meta =
   match
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
@@ -932,8 +932,8 @@ let make_learned_meta () : Keeper_types.keeper_meta =
           ; "agent_name", `String "test-learned"
           ; "trace_id", `String "test-trace-learned"
           ; ( "tool_access"
-            , Keeper_types.tool_access_to_json
-                (Keeper_types.Preset { preset = Keeper_types.Full; also_allow = [] }) )
+            , Keeper_meta_tool_access.tool_access_to_json
+                (Keeper_meta_tool_access.Preset { preset = Keeper_meta_tool_access.Full; also_allow = [] }) )
           ])
   with
   | Ok meta -> meta

--- a/test/test_keeper_turn_up_create_meta_retry.ml
+++ b/test/test_keeper_turn_up_create_meta_retry.ml
@@ -41,13 +41,13 @@ let make_meta ~name =
   | Error err -> fail ("meta_of_json failed: " ^ err)
 
 let read_meta_exn config name =
-  match Keeper_types.read_meta config name with
+  match Keeper_meta_store.read_meta config name with
   | Ok (Some meta) -> meta
   | Ok None -> fail ("missing meta for " ^ name)
   | Error err -> fail ("read_meta failed: " ^ err)
 
 let write_meta_exn config meta =
-  match Keeper_types.write_meta config meta with
+  match Keeper_meta_store.write_meta config meta with
   | Ok () -> ()
   | Error err -> fail ("write_meta failed: " ^ err)
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -321,7 +321,7 @@ let test_observation_economic_modes () =
 
 (* ---------- Unified Prompt tests ---------- *)
 
-let make_meta name : Masc_mcp.Keeper_types.keeper_meta =
+let make_meta name : Masc_mcp.Keeper_meta_contract.keeper_meta =
   let json =
     `Assoc
       [ "name", `String name
@@ -334,7 +334,7 @@ let make_meta name : Masc_mcp.Keeper_types.keeper_meta =
   | Error e -> failwith ("meta_of_json failed: " ^ e)
 ;;
 
-let minimal_meta : Masc_mcp.Keeper_types.keeper_meta = make_meta "test-keeper"
+let minimal_meta : Masc_mcp.Keeper_meta_contract.keeper_meta = make_meta "test-keeper"
 
 let minimal_policy_meta =
   { minimal_meta with tool_access = Preset { preset = Minimal; also_allow = [] } }
@@ -1275,7 +1275,7 @@ let test_provider_cooldown_blocks_scheduled_turn_when_work_is_ready () =
 
 let test_provider_capacity_blocked_backlog_count_requires_non_fail_open_cooldown () =
   let default_meta =
-    Masc_mcp.Keeper_types.set_cascade_name
+    Masc_mcp.Keeper_meta_contract.set_cascade_name
       (Masc_mcp.Keeper_config.default_cascade_name ())
       minimal_meta
   in
@@ -1296,7 +1296,7 @@ let test_provider_capacity_blocked_backlog_count_requires_non_fail_open_cooldown
   in
   check int "healthy provider leaves backlog unblocked" 0 healthy;
   let fail_open_meta =
-    Masc_mcp.Keeper_types.set_cascade_name "scoring" minimal_meta
+    Masc_mcp.Keeper_meta_contract.set_cascade_name "scoring" minimal_meta
   in
   let fail_open_blocked =
     WO.provider_capacity_blocked_task_count
@@ -1310,7 +1310,7 @@ let test_provider_capacity_blocked_backlog_count_requires_non_fail_open_cooldown
 
 let test_provider_cooldown_keeps_scheduled_turn_open_when_fail_open_exists () =
   let meta =
-    { (Masc_mcp.Keeper_types.set_cascade_name "scoring" minimal_meta) with
+    { (Masc_mcp.Keeper_meta_contract.set_cascade_name "scoring" minimal_meta) with
       current_task_id =
         (match Masc_mcp.Keeper_id.Task_id.of_string "task-789" with
          | Ok value -> Some value
@@ -1828,7 +1828,7 @@ let test_bootstrap_turn_emits_scheduled_autonomous_channel () =
 
 let test_provider_cooldown_blocks_bootstrap_turn () =
   let meta =
-    { (Masc_mcp.Keeper_types.set_cascade_name
+    { (Masc_mcp.Keeper_meta_contract.set_cascade_name
          Masc_mcp.(Keeper_config.default_cascade_name ())
          minimal_meta)
       with
@@ -2022,7 +2022,7 @@ let test_min_interval_never_fires_for_bootstrap () =
 let test_provider_cooldown_blocks_min_interval_turn () =
   with_env "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC" "900" (fun () ->
     let meta =
-      { (Masc_mcp.Keeper_types.set_cascade_name
+      { (Masc_mcp.Keeper_meta_contract.set_cascade_name
            Masc_mcp.(Keeper_config.default_cascade_name ())
            minimal_meta)
         with
@@ -3561,7 +3561,7 @@ let test_metrics_text_response () =
     "proactive outcome text"
     true
     (updated.runtime.proactive_rt.last_outcome
-     = Masc_mcp.Keeper_types.Proactive_text_response);
+     = Masc_mcp.Keeper_meta_contract.Proactive_text_response);
   check
     int
     "no autonomous action"
@@ -3720,7 +3720,7 @@ let test_metrics_tool_response () =
     bool
     "proactive outcome tool"
     true
-    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_tool_use);
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_meta_contract.Proactive_tool_use);
   check
     int
     "autonomous_action +2"
@@ -3759,7 +3759,7 @@ let test_metrics_noop_response () =
     bool
     "proactive outcome silent"
     true
-    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_silent);
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_meta_contract.Proactive_silent);
   check
     int
     "autonomous unchanged"
@@ -3919,7 +3919,7 @@ let test_metrics_validated_evidence_counts_as_visible () =
     bool
     "validated evidence outcome is tool_use"
     true
-    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_tool_use);
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_meta_contract.Proactive_tool_use);
   check
     string
     "validated evidence preview"
@@ -3996,7 +3996,7 @@ let test_metrics_failed_validation_does_not_count_as_visible () =
     bool
     "outcome is silent"
     true
-    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_silent)
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_meta_contract.Proactive_silent)
 ;;
 
 let test_metrics_file_write_evidence_counts_as_visible () =
@@ -4041,7 +4041,7 @@ let test_metrics_file_write_evidence_counts_as_visible () =
     bool
     "file write evidence outcome is tool_use"
     true
-    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_tool_use);
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_meta_contract.Proactive_tool_use);
   check
     string
     "file write evidence preview"
@@ -4089,7 +4089,7 @@ let test_metrics_heartbeat_only_tool_response_is_maintenance_only () =
     bool
     "heartbeat-only outcome stays silent"
     true
-    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_silent);
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_meta_contract.Proactive_silent);
   check
     int
     "autonomous action unchanged"
@@ -4237,7 +4237,7 @@ let test_meta_migration_does_not_infer_visible_proactive_fields () =
       bool
       "legacy outcome unknown"
       true
-      (meta.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_unknown)
+      (meta.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_meta_contract.Proactive_unknown)
 ;;
 
 let test_append_metrics_snapshot_includes_cascade_observation () =
@@ -5716,7 +5716,7 @@ let test_run_keeper_cycle_livelock_block_returns_error () =
               (contains_substring
                  Yojson.Safe.Util.(receipt |> member "terminal_reason_code" |> to_string)
                  "turn_livelock:attempts_exhausted"));
-         (match Masc_mcp.Keeper_types.read_meta config meta.name with
+         (match Masc_mcp.Keeper_meta_store.read_meta config meta.name with
           | Ok (Some persisted) ->
             check bool "livelock persists paused keeper" true persisted.paused;
             check
@@ -5730,7 +5730,7 @@ let test_run_keeper_cycle_livelock_block_returns_error () =
                  string
                  "livelock blocker class"
                  "turn_livelock_blocked"
-                 (Masc_mcp.Keeper_types.blocker_class_to_string blocker.klass);
+                 (Masc_mcp.Keeper_meta_contract.blocker_class_to_string blocker.klass);
                check
                  bool
                  "livelock blocker detail"
@@ -5799,7 +5799,7 @@ let test_streaming_cancel_records_supervisor_stop_when_fiber_stop_set () =
          ~run_meta:meta
          ~run_generation:meta.runtime.generation
          ~cascade_name:
-           (oas_error_cascade_name (Masc_mcp.Keeper_types.cascade_name_of_meta meta))
+           (oas_error_cascade_name (Masc_mcp.Keeper_meta_contract.cascade_name_of_meta meta))
          ~keeper_turn_id:meta.runtime.usage.total_turns
          ();
        let supervisor_request_after =
@@ -6175,7 +6175,7 @@ let test_keeper_msg_async_failure_surface () =
        let config = Masc_mcp.Coord.default_config base_dir in
        ignore (Masc_mcp.Coord.init config ~agent_name:(Some "operator"));
        let meta = make_meta keeper_name in
-       (match Masc_mcp.Keeper_types.write_meta ~force:true config meta with
+       (match Masc_mcp.Keeper_meta_store.write_meta ~force:true config meta with
         | Ok () -> ()
         | Error err -> fail ("write_meta failed: " ^ err));
        let ctx : _ Masc_mcp.Tool_keeper.context =
@@ -6345,7 +6345,7 @@ let structured_cascade_max_turns_error () =
     (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
        { cascade_name =
            oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
-       ; reason = Keeper_types.Max_turns_exceeded
+       ; reason = Masc_mcp.Keeper_meta_contract.Max_turns_exceeded
        })
 ;;
 
@@ -6998,7 +6998,7 @@ let test_metrics_failure_response () =
     bool
     "proactive outcome error"
     true
-    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_error);
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_meta_contract.Proactive_error);
   check
     bool
     "failure reason tagged"
@@ -7906,7 +7906,7 @@ let test_cascade_exhausted_error_detected_from_structured_internal_error () =
       (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
          { cascade_name =
              oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
-         ; reason = Masc_mcp.Keeper_types.All_providers_failed
+         ; reason = Masc_mcp.Keeper_meta_contract.All_providers_failed
          })
   in
   check
@@ -7965,7 +7965,7 @@ let test_auto_recoverable_turn_error_includes_filtered_candidates_cascade_exhaus
       (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
          { cascade_name =
              oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
-         ; reason = Keeper_types.Candidates_filtered_after_cycles
+         ; reason = Masc_mcp.Keeper_meta_contract.Candidates_filtered_after_cycles
          })
   in
   check
@@ -8735,7 +8735,7 @@ let test_metrics_mixed_response () =
     "proactive outcome mixed"
     true
     (updated.runtime.proactive_rt.last_outcome
-     = Masc_mcp.Keeper_types.Proactive_mixed_response);
+     = Masc_mcp.Keeper_meta_contract.Proactive_mixed_response);
   check
     int
     "autonomous +1"
@@ -9300,9 +9300,9 @@ let test_social_model_previous_state_of_meta_restores_runtime_fields () =
         ; last_current_intention = "recover_tool_route"
         ; last_blocker =
             Some
-              (Keeper_types.blocker_info_of_class
+              (Masc_mcp.Keeper_meta_contract.blocker_info_of_class
                  ~detail:"tool route unavailable"
-                 Keeper_types.No_tool_capable_provider)
+                 Masc_mcp.Keeper_meta_contract.No_tool_capable_provider)
         ; last_need = "operator guidance"
         }
     }
@@ -9640,9 +9640,9 @@ let test_social_model_previous_state_of_meta_falls_back_for_unknown_model () =
         ; last_current_intention = "recover_tool_route"
         ; last_blocker =
             Some
-              (Keeper_types.blocker_info_of_class
+              (Masc_mcp.Keeper_meta_contract.blocker_info_of_class
                  ~detail:"tool route unavailable"
-                 Keeper_types.No_tool_capable_provider)
+                 Masc_mcp.Keeper_meta_contract.No_tool_capable_provider)
         ; last_need = "operator guidance"
         }
     }

--- a/test/test_keeper_unified_context_budget.ml
+++ b/test/test_keeper_unified_context_budget.ml
@@ -4,7 +4,7 @@ module KEC = Masc_mcp.Keeper_context_runtime
 module OMR = Masc_mcp.Cascade_runtime
 module UT = Masc_mcp.Keeper_unified_turn
 
-let make_meta name : Masc_mcp.Keeper_types.keeper_meta =
+let make_meta name : Masc_mcp.Keeper_meta_contract.keeper_meta =
   let json =
     `Assoc
       [
@@ -17,7 +17,7 @@ let make_meta name : Masc_mcp.Keeper_types.keeper_meta =
   | Ok m -> m
   | Error e -> failwith ("meta_of_json failed: " ^ e)
 
-let minimal_meta : Masc_mcp.Keeper_types.keeper_meta = make_meta "test-keeper"
+let minimal_meta : Masc_mcp.Keeper_meta_contract.keeper_meta = make_meta "test-keeper"
 
 let test_pure_local_labels_detection () =
   check

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -42,7 +42,7 @@ let sample_board_event : WO.pending_board_event =
     latest_external_preview = None;
   }
 
-let make_meta name : Masc_mcp.Keeper_types.keeper_meta =
+let make_meta name : Masc_mcp.Keeper_meta_contract.keeper_meta =
   let json =
     `Assoc
       [
@@ -55,7 +55,7 @@ let make_meta name : Masc_mcp.Keeper_types.keeper_meta =
   | Ok m -> m
   | Error e -> failwith ("meta_of_json failed: " ^ e)
 
-let minimal_meta : Masc_mcp.Keeper_types.keeper_meta = make_meta "test-keeper"
+let minimal_meta : Masc_mcp.Keeper_meta_contract.keeper_meta = make_meta "test-keeper"
 
 let test_task_verify_affordance_for_keeper () =
   let meta = { minimal_meta with mention_targets = [ "analyst" ] } in

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -62,7 +62,7 @@ let make_keeper_meta ?agent_name ?current_task_id ?(goal_ids = [])
      | Some tool_access ->
          [
            ( "tool_access",
-             Masc_mcp.Keeper_types.tool_access_to_json tool_access );
+             Masc_mcp.Keeper_meta_tool_access.tool_access_to_json tool_access );
          ]
      | None -> [])
   in
@@ -310,7 +310,7 @@ let test_runtime_mcp_keeper_log_context_uses_keeper_trace_and_current_turn () =
         (Some []) ctx.required_tools;
       check (option (list string)) "runtime mcp missing required tools empty"
         (Some []) ctx.missing_required_tools;
-      check (option string) "cascade profile" (Some (Masc_mcp.Keeper_types.cascade_name_of_meta meta))
+      check (option string) "cascade profile" (Some (Masc_mcp.Keeper_meta_contract.cascade_name_of_meta meta))
         ctx.cascade_profile)
 
 let test_runtime_mcp_keeper_log_context_loads_current_task_contract () =
@@ -333,7 +333,7 @@ let test_runtime_mcp_keeper_log_context_loads_current_task_contract () =
   let meta =
     make_keeper_meta
       ~current_task_id:"task-001"
-      ~tool_access:(Masc_mcp.Keeper_types.Custom [ "tool_execute" ])
+      ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "tool_execute" ])
       keeper_name
   in
   Fun.protect
@@ -455,7 +455,7 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
         (runtime_contract |> U.member "missing_required_tools" |> U.to_list
          |> List.length);
       check string "runtime contract cascade profile"
-        (Masc_mcp.Keeper_types.cascade_name_of_meta meta)
+        (Masc_mcp.Keeper_meta_contract.cascade_name_of_meta meta)
         (runtime_contract |> U.member "cascade_profile" |> U.to_string);
       let masc_root =
         Filename.concat base_path Common.masc_dirname
@@ -498,7 +498,7 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
         (trajectory_json |> U.member "runtime_contract" |> U.member "agent_name"
          |> U.to_string);
       check string "trajectory runtime cascade profile"
-        (Masc_mcp.Keeper_types.cascade_name_of_meta meta)
+        (Masc_mcp.Keeper_meta_contract.cascade_name_of_meta meta)
         (trajectory_json |> U.member "runtime_contract"
          |> U.member "cascade_profile" |> U.to_string);
       check string "trajectory action tool" "tool_execute"

--- a/test/test_memory_hooks.ml
+++ b/test/test_memory_hooks.ml
@@ -605,9 +605,9 @@ let test_execution_receipt_json_includes_memory_fields () =
         ; missing_required_tools = []
         ; materialized_tools = []
         }
-    ; sandbox_kind = Keeper_types.Local
+    ; sandbox_kind = Masc_mcp.Keeper_types_profile_sandbox.Local
     ; sandbox_root = None
-    ; network_mode = Keeper_types.Network_none
+    ; network_mode = Masc_mcp.Keeper_types_profile_sandbox.Network_none
     ; approval_profile = None
     ; approval_profile_derived = false
     ; cascade_name = Cascade_name.of_string_exn "test"
@@ -680,9 +680,9 @@ let test_execution_receipt_json_null_when_missing () =
         ; missing_required_tools = []
         ; materialized_tools = []
         }
-    ; sandbox_kind = Keeper_types.Local
+    ; sandbox_kind = Masc_mcp.Keeper_types_profile_sandbox.Local
     ; sandbox_root = None
-    ; network_mode = Keeper_types.Network_none
+    ; network_mode = Masc_mcp.Keeper_types_profile_sandbox.Network_none
     ; approval_profile = None
     ; approval_profile_derived = false
     ; cascade_name = Cascade_name.of_string_exn "test"

--- a/test/test_oas_error_kind_counter.ml
+++ b/test/test_oas_error_kind_counter.ml
@@ -70,7 +70,7 @@ let test_cascade_exhausted_kind () =
          {
            cascade_name = typed_cascade_name cascade_name;
            reason =
-             Masc_mcp.Keeper_types.Other_detail "all providers tried";
+             Masc_mcp.Keeper_meta_contract.Other_detail "all providers tried";
          })
   in
   Alcotest.(check (float 0.0001))

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2400,7 +2400,7 @@ let test_classify_masc_internal_error_roundtrip () =
       (Keeper_turn_driver.Cascade_exhausted
          { cascade_name =
              internal_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
-         ; reason = Keeper_types.All_providers_failed
+         ; reason = Keeper_meta_contract.All_providers_failed
          })
   in
   (match Keeper_turn_driver.classify_masc_internal_error cascade_err with
@@ -2411,8 +2411,8 @@ let test_classify_masc_internal_error_roundtrip () =
        (internal_cascade_name_to_string cascade_name);
      Alcotest.(check string)
        "cascade reason"
-       (Keeper_types.cascade_exhaustion_summary Keeper_types.All_providers_failed)
-       (Keeper_types.cascade_exhaustion_summary reason)
+       (Keeper_meta_contract.cascade_exhaustion_summary Keeper_meta_contract.All_providers_failed)
+       (Keeper_meta_contract.cascade_exhaustion_summary reason)
    | _ -> Alcotest.fail "expected structured cascade exhaustion");
   let accept_err =
     Keeper_turn_driver.sdk_error_of_masc_internal_error

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -65,7 +65,7 @@ let count_log_lines_with_prefix log prefix =
   |> List.length
 
 let read_keeper_meta_exn config keeper_name =
-  match Keeper_types.read_meta config keeper_name with
+  match Keeper_meta_store.read_meta config keeper_name with
   | Ok (Some meta) -> meta
   | Ok None -> Alcotest.fail ("keeper meta missing: " ^ keeper_name)
   | Error err -> Alcotest.fail ("keeper meta read failed: " ^ err)
@@ -74,7 +74,7 @@ let seed_keeper_meta_exn config keeper_name ~goal =
   let trace_id = "trace-" ^ keeper_name in
   let meta =
     match
-      Keeper_types.meta_of_json
+      Keeper_meta_json_parse.meta_of_json
         (`Assoc
           [
             ("name", `String keeper_name);
@@ -89,7 +89,7 @@ let seed_keeper_meta_exn config keeper_name ~goal =
     | Ok meta -> meta
     | Error err -> Alcotest.fail ("keeper meta fixture failed: " ^ err)
   in
-  (match Keeper_types.write_meta config meta with
+  (match Keeper_meta_store.write_meta config meta with
    | Ok () -> ()
    | Error err -> Alcotest.fail ("keeper meta seed failed: " ^ err));
   read_keeper_meta_exn config keeper_name
@@ -111,7 +111,7 @@ let with_fake_docker script f =
 let update_keeper_sandbox_mode config keeper_name ~sandbox_profile ~network_mode =
   let meta = read_keeper_meta_exn config keeper_name in
   match
-    Keeper_types.write_meta config
+    Keeper_meta_store.write_meta config
       { meta with sandbox_profile; network_mode }
   with
   | Ok () -> ()
@@ -121,8 +121,8 @@ let drift_keeper_identity config keeper_name ~agent_name =
   let meta = read_keeper_meta_exn config keeper_name in
   let previous_trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   match
-    Keeper_types.write_meta ~force:true config
-      { meta with agent_name; updated_at = Keeper_types.now_iso () }
+    Keeper_meta_store.write_meta ~force:true config
+      { meta with agent_name; updated_at = Masc_domain.now_iso () }
   with
   | Ok () -> previous_trace_id
   | Error err -> Alcotest.fail ("keeper identity drift write failed: " ^ err)
@@ -429,8 +429,8 @@ let test_keeper_sandbox_status_clarifies_visible_container_gap () =
       in
       Alcotest.(check bool) "keeper up ok" true ok;
       update_keeper_sandbox_mode config keeper_name
-        ~sandbox_profile:Keeper_types.Docker
-        ~network_mode:Keeper_types.Network_inherit;
+        ~sandbox_profile:Keeper_types_profile_sandbox.Docker
+        ~network_mode:Keeper_types_profile_sandbox.Network_inherit;
       Keeper_status_detail.invalidate_status_cache_for keeper_name;
       let state_dir = Filename.concat base_dir "fake-docker" in
       let state_file = Filename.concat state_dir "containers.tsv" in
@@ -774,8 +774,8 @@ let test_keeper_sandbox_status_fleet_reuses_docker_preflight () =
           in
           Alcotest.(check bool) ("keeper up ok: " ^ keeper_name) true ok;
           update_keeper_sandbox_mode config keeper_name
-            ~sandbox_profile:Keeper_types.Docker
-            ~network_mode:Keeper_types.Network_none)
+            ~sandbox_profile:Keeper_types_profile_sandbox.Docker
+            ~network_mode:Keeper_types_profile_sandbox.Network_none)
         keeper_names;
       let state_dir = Filename.concat base_dir "fake-docker" in
       let state_file = Filename.concat state_dir "containers.tsv" in
@@ -853,8 +853,8 @@ let test_keeper_status_detail_reuses_docker_preflight_cache () =
           in
           Alcotest.(check bool) ("keeper up ok: " ^ keeper_name) true ok;
           update_keeper_sandbox_mode config keeper_name
-            ~sandbox_profile:Keeper_types.Docker
-            ~network_mode:Keeper_types.Network_none)
+            ~sandbox_profile:Keeper_types_profile_sandbox.Docker
+            ~network_mode:Keeper_types_profile_sandbox.Network_none)
         keeper_names;
       let state_dir = Filename.concat base_dir "fake-docker" in
       let state_file = Filename.concat state_dir "containers.tsv" in
@@ -936,8 +936,8 @@ let test_keeper_sandbox_start_status_stop_with_fake_docker () =
       in
       Alcotest.(check bool) "keeper up ok" true ok;
       update_keeper_sandbox_mode config keeper_name
-        ~sandbox_profile:Keeper_types.Docker
-        ~network_mode:Keeper_types.Network_none;
+        ~sandbox_profile:Keeper_types_profile_sandbox.Docker
+        ~network_mode:Keeper_types_profile_sandbox.Network_none;
       Keeper_status_detail.invalidate_status_cache_for keeper_name;
       with_fake_docker fake_docker_managed_sandbox_script @@ fun () ->
       (match Sys.getenv_opt "MASC_TEST_FAKE_DOCKER_PATH" with
@@ -1165,8 +1165,8 @@ let test_keeper_turn_sandbox_factory_reuses_playground_runtime () =
         | Ok m ->
             {
               m with
-              sandbox_profile = Keeper_types.Docker;
-              network_mode = Keeper_types.Network_none;
+              sandbox_profile = Keeper_types_profile_sandbox.Docker;
+              network_mode = Keeper_types_profile_sandbox.Network_none;
             }
         | Error err -> Alcotest.fail ("keeper meta fixture failed: " ^ err)
       in
@@ -1414,7 +1414,7 @@ let test_keeper_up_resumes_auto_paused_keeper () =
         seed_keeper_meta_exn config keeper_name ~goal:"Resume a paused keeper"
       in
       let blocker_text =
-        Keeper_types.blocker_class_to_string Keeper_types.Turn_timeout
+        Keeper_meta_contract.blocker_class_to_string Keeper_meta_contract.Turn_timeout
       in
       let paused_meta =
         {
@@ -1425,12 +1425,12 @@ let test_keeper_up_resumes_auto_paused_keeper () =
             {
               meta.runtime with
               last_blocker =
-                Some (Keeper_types.blocker_info_of_class
-                        ~detail:blocker_text Keeper_types.Turn_timeout);
+                Some (Keeper_meta_contract.blocker_info_of_class
+                        ~detail:blocker_text Keeper_meta_contract.Turn_timeout);
             };
         }
       in
-      (match Keeper_types.write_meta config paused_meta with
+      (match Keeper_meta_store.write_meta config paused_meta with
        | Ok () -> ()
        | Error err -> Alcotest.fail ("paused meta write failed: " ^ err));
       ignore
@@ -1511,13 +1511,13 @@ let test_keeper_up_keeps_paused_keeper_with_continue_gate_blocker () =
                  the typed class is the only authoritative source — set it
                  directly. *)
               last_blocker =
-                Some (Keeper_types.blocker_info_of_class
+                Some (Keeper_meta_contract.blocker_info_of_class
                         ~detail:blocker_text
-                        Keeper_types.Ambiguous_post_commit_timeout);
+                        Keeper_meta_contract.Ambiguous_post_commit_timeout);
             };
         }
       in
-      (match Keeper_types.write_meta config paused_meta with
+      (match Keeper_meta_store.write_meta config paused_meta with
        | Ok () -> ()
        | Error err -> Alcotest.fail ("paused meta write failed: " ^ err));
       let ok, body =
@@ -1579,7 +1579,7 @@ let test_keeper_up_keeps_paused_keeper_with_pending_approval () =
         seed_keeper_meta_exn config keeper_name ~goal:"Stay paused behind approval"
       in
       let blocker_text =
-        Keeper_types.blocker_class_to_string Keeper_types.Turn_timeout
+        Keeper_meta_contract.blocker_class_to_string Keeper_meta_contract.Turn_timeout
       in
       let paused_meta =
         {
@@ -1590,12 +1590,12 @@ let test_keeper_up_keeps_paused_keeper_with_pending_approval () =
             {
               meta.runtime with
               last_blocker =
-                Some (Keeper_types.blocker_info_of_class
-                        ~detail:blocker_text Keeper_types.Turn_timeout);
+                Some (Keeper_meta_contract.blocker_info_of_class
+                        ~detail:blocker_text Keeper_meta_contract.Turn_timeout);
             };
         }
       in
-      (match Keeper_types.write_meta config paused_meta with
+      (match Keeper_meta_store.write_meta config paused_meta with
        | Ok () -> ()
        | Error err -> Alcotest.fail ("paused meta write failed: " ^ err));
       pending_id :=
@@ -2188,7 +2188,7 @@ let test_keeper_status_ignores_stale_cascade_observation () =
       in
       Alcotest.(check bool) "keeper up ok" true ok;
       let meta =
-        match Keeper_types.read_meta config keeper_name with
+        match Keeper_meta_store.read_meta config keeper_name with
         | Ok (Some meta) -> meta
         | Ok None -> Alcotest.fail "keeper meta missing after up"
         | Error err -> Alcotest.fail ("meta read failed: " ^ err)
@@ -2237,7 +2237,7 @@ let test_keeper_status_ignores_stale_cascade_observation () =
       let status_dump = Yojson.Safe.pretty_to_string status_json in
       Alcotest.(check (option string))
         ("current cascade name wins over stale metrics\n" ^ status_dump)
-        (Some (Keeper_types.cascade_name_of_meta meta))
+        (Some (Keeper_meta_contract.cascade_name_of_meta meta))
         (observability |> member "cascade_name" |> to_string_option);
       Alcotest.(check bool) "stale observation ignored" false
         (observability |> member "recent_turn_observation" |> to_bool);
@@ -2304,7 +2304,7 @@ let test_keeper_down_does_not_resolve_agent_name_alias () =
       Alcotest.(check bool) "keeper down remains idempotent for absent alias" true ok;
       Alcotest.(check bool) "down reports alias absent" true
         (contains_substring body ("keeper already absent: " ^ keeper_agent_name));
-      match Masc_mcp.Keeper_types.read_meta config keeper_name with
+      match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
       | Ok (Some meta) ->
           Alcotest.(check bool) "canonical keeper not paused via alias" false
             meta.paused
@@ -2667,13 +2667,13 @@ let test_keeper_down_only_pauses_current_base_path () =
       Alcotest.(check string) "down returns scoped keeper name" keeper_name
         Yojson.Safe.Util.(down_json |> member "name" |> to_string);
       let meta_a =
-        match Masc_mcp.Keeper_types.read_meta config_a keeper_name with
+        match Masc_mcp.Keeper_meta_store.read_meta config_a keeper_name with
         | Ok (Some meta) -> meta
         | Ok None -> Alcotest.fail "keeper meta missing in base path A"
         | Error err -> Alcotest.fail ("meta read failed in base path A: " ^ err)
       in
       let meta_b =
-        match Masc_mcp.Keeper_types.read_meta config_b keeper_name with
+        match Masc_mcp.Keeper_meta_store.read_meta config_b keeper_name with
         | Ok (Some meta) -> meta
         | Ok None -> Alcotest.fail "keeper meta missing in base path B"
         | Error err -> Alcotest.fail ("meta read failed in base path B: " ^ err)
@@ -2761,7 +2761,7 @@ proactive_enabled = true
       in
       Alcotest.(check bool) "keeper up ok" true ok;
       let meta =
-        match Masc_mcp.Keeper_types.read_meta config keeper_name with
+        match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
         | Ok (Some meta) -> meta
         | Ok None -> Alcotest.fail "keeper meta missing"
         | Error err -> Alcotest.fail ("meta read failed: " ^ err)
@@ -2778,13 +2778,13 @@ proactive_enabled = true
         | Ok parsed -> parsed
         | Error err ->
             Alcotest.fail
-              ("active_goal_ids parse failed: " ^ Keeper_types.tool_result_body err)
+              ("active_goal_ids parse failed: " ^ Keeper_types_profile.tool_result_body err)
       in
       let result =
         Keeper_turn_up_update.update_keeper keeper_ctx parsed_goal_update meta
       in
-      let ok = Keeper_types.tool_result_success result in
-      let msg = Keeper_types.tool_result_body result in
+      let ok = Keeper_types_profile.tool_result_success result in
+      let msg = Keeper_types_profile.tool_result_body result in
       Alcotest.(check bool) ("active_goal_ids update ok: " ^ msg) true ok;
       let meta = read_keeper_meta_exn config keeper_name in
       let parsed_bad_goal_update =
@@ -2799,13 +2799,13 @@ proactive_enabled = true
         | Ok parsed -> parsed
         | Error err ->
             Alcotest.fail
-              ("bad active_goal_ids parse failed: " ^ Keeper_types.tool_result_body err)
+              ("bad active_goal_ids parse failed: " ^ Keeper_types_profile.tool_result_body err)
       in
       let result =
         Keeper_turn_up_update.update_keeper keeper_ctx parsed_bad_goal_update meta
       in
-      let ok = Keeper_types.tool_result_success result in
-      let msg = Keeper_types.tool_result_body result in
+      let ok = Keeper_types_profile.tool_result_success result in
+      let msg = Keeper_types_profile.tool_result_body result in
       Alcotest.(check bool) "unknown active goal rejected" false ok;
       Alcotest.(check bool) "unknown active goal names surfaced" true
         (contains_substring msg "goal-missing");
@@ -2841,7 +2841,7 @@ proactive_enabled = true
         }
       in
       (match
-         Masc_mcp.Keeper_types.write_meta_with_merge
+         Masc_mcp.Keeper_meta_store.write_meta_with_merge
            ~merge:Masc_mcp.Keeper_meta_merge.caller_wins config mutated
        with
       | Ok () -> ()
@@ -2982,7 +2982,7 @@ proactive_enabled = true
           updated_at = Masc_domain.now_iso ();
         }
       in
-      (match Masc_mcp.Keeper_types.write_meta config zero_latency_meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config zero_latency_meta with
       | Ok () -> ()
       | Error err -> Alcotest.fail ("zero latency meta write failed: " ^ err));
       let zero_status, zero_json =
@@ -3015,18 +3015,18 @@ proactive_enabled = true
       Alcotest.(check bool) "effective system prompt includes world block" true
         (contains_substring effective_system_prompt "<world>");
       let stale_base =
-        match Masc_mcp.Keeper_types.read_meta config keeper_name with
+        match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
         | Ok (Some meta) -> meta
         | Ok None -> Alcotest.fail "keeper meta missing before stale write"
         | Error err ->
             Alcotest.fail ("keeper meta reload failed before stale write: " ^ err)
       in
       let stale_meta =
-        { (Keeper_types.set_cascade_name "vendor_mix_balanced" stale_base) with
+        { (Keeper_meta_contract.set_cascade_name "vendor_mix_balanced" stale_base) with
           updated_at = Masc_domain.now_iso ();
         }
       in
-      (match Masc_mcp.Keeper_types.write_meta config stale_meta with
+      (match Masc_mcp.Keeper_meta_store.write_meta config stale_meta with
       | Ok () -> ()
       | Error err -> Alcotest.fail ("stale meta write failed: " ^ err));
       let stale_status, stale_json =
@@ -3104,16 +3104,16 @@ let test_keeper_config_uses_backend_scoped_private_workspace_root () =
       in
       let local_rel =
         Masc_mcp.Keeper_sandbox.host_root_rel_of_profile
-          Keeper_types.Local keeper_name
+          Keeper_types_profile_sandbox.Local keeper_name
       in
       assert_config_root "local" local_rel (Filename.concat base_dir local_rel);
       update_keeper_sandbox_mode config keeper_name
-        ~sandbox_profile:Keeper_types.Docker
-        ~network_mode:Keeper_types.Network_none;
+        ~sandbox_profile:Keeper_types_profile_sandbox.Docker
+        ~network_mode:Keeper_types_profile_sandbox.Network_none;
       Keeper_status_detail.invalidate_status_cache_for keeper_name;
       let docker_rel =
         Masc_mcp.Keeper_sandbox.host_root_rel_of_profile
-          Keeper_types.Docker keeper_name
+          Keeper_types_profile_sandbox.Docker keeper_name
       in
       let docker_abs = Filename.concat base_dir docker_rel in
       assert_config_root "docker" docker_rel docker_abs;

--- a/test/test_operator_control_keeper_message.ml
+++ b/test/test_operator_control_keeper_message.ml
@@ -176,7 +176,7 @@ let test_keeper_msg_auto_execution_session_bridge () =
               in
               Alcotest.(check bool) "keeper down ok" true ok;
               let meta_after_down =
-                match Masc_mcp.Keeper_types.read_meta config keeper_name with
+                match Masc_mcp.Keeper_meta_store.read_meta config keeper_name with
                 | Ok (Some meta) -> meta
                 | Ok None -> Alcotest.fail "keeper meta removed unexpectedly"
                 | Error err -> Alcotest.fail ("meta read after down failed: " ^ err)

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -239,7 +239,7 @@ let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =
       Alcotest.(check bool) "keeper up ok" true ok;
       Keeper_keepalive.stop_keepalive keeper_name;
       let meta =
-        match Keeper_types.read_meta config keeper_name with
+        match Keeper_meta_store.read_meta config keeper_name with
         | Ok (Some meta) -> meta
         | Ok None -> Alcotest.fail "expected keeper meta"
         | Error err -> Alcotest.fail err
@@ -261,7 +261,7 @@ let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =
             };
         }
       in
-      (match Keeper_types.write_meta config updated_meta with
+      (match Keeper_meta_store.write_meta config updated_meta with
       | Ok () -> ()
       | Error err -> Alcotest.fail err);
       let metrics_store = Keeper_types_support.keeper_metrics_store config keeper_name in
@@ -379,14 +379,14 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
                 meta.runtime with
                 last_blocker =
                   Some
-                    (Keeper_types.blocker_info_of_class
+                    (Keeper_meta_contract.blocker_info_of_class
                        ~detail:"Completion contract [require_tool_use] violated: actionable keeper signal was present, but the model called no keeper tools"
-                       Keeper_types.Completion_contract_violation);
+                       Keeper_meta_contract.Completion_contract_violation);
               };
           }
         | Error err -> Alcotest.fail ("keeper meta fixture failed: " ^ err)
       in
-      (match Keeper_types.write_meta config meta with
+      (match Keeper_meta_store.write_meta config meta with
       | Ok () -> ()
       | Error err -> Alcotest.fail err);
       Dated_jsonl.append
@@ -522,7 +522,7 @@ let test_digest_room_includes_keeper_runtime_attention () =
       Alcotest.(check bool) "keeper up ok" true ok;
       Keeper_keepalive.stop_keepalive keeper_name;
       let meta =
-        match Keeper_types.read_meta config keeper_name with
+        match Keeper_meta_store.read_meta config keeper_name with
         | Ok (Some meta) -> meta
         | Ok None -> Alcotest.fail "expected keeper meta"
         | Error err -> Alcotest.fail err
@@ -536,13 +536,13 @@ let test_digest_room_includes_keeper_runtime_attention () =
               meta.runtime with
               last_blocker =
                 Some
-                  (Keeper_types.blocker_info_of_class
+                  (Keeper_meta_contract.blocker_info_of_class
                      ~detail:"Completion contract requires a keeper tool call"
-                     Keeper_types.Completion_contract_violation);
+                     Keeper_meta_contract.Completion_contract_violation);
             };
         }
       in
-      (match Keeper_types.write_meta config meta with
+      (match Keeper_meta_store.write_meta config meta with
       | Ok () -> ()
       | Error err -> Alcotest.fail err);
       let digest =
@@ -627,7 +627,7 @@ let test_lightweight_snapshot_preserves_receipt_latest_causal_event () =
       Alcotest.(check bool) "keeper up ok" true ok;
       Keeper_keepalive.stop_keepalive keeper_name;
       let meta =
-        match Keeper_types.read_meta config keeper_name with
+        match Keeper_meta_store.read_meta config keeper_name with
         | Ok (Some meta) -> meta
         | Ok None -> Alcotest.fail "expected keeper meta"
         | Error err -> Alcotest.fail err
@@ -928,7 +928,7 @@ let test_snapshot_lightweight_summary_keeps_tool_audit () =
             ("tools_used", `List []);
           ]);
       let meta =
-        match Keeper_types.read_meta config keeper_name with
+        match Keeper_meta_store.read_meta config keeper_name with
         | Ok (Some meta) -> meta
         | Ok None -> Alcotest.fail "expected keeper meta"
         | Error err -> Alcotest.fail err
@@ -1038,7 +1038,7 @@ let test_snapshot_lightweight_summary_keeps_recent_tools_distinct_from_latest ()
             ])
       done;
       let meta =
-        match Keeper_types.read_meta config keeper_name with
+        match Keeper_meta_store.read_meta config keeper_name with
         | Ok (Some meta) -> meta
         | Ok None -> Alcotest.fail "expected keeper meta"
         | Error err -> Alcotest.fail err

--- a/test/test_sandbox_session_executor.ml
+++ b/test/test_sandbox_session_executor.ml
@@ -28,7 +28,7 @@ let sample_plan ?(turn_id = 7) ?(meta_name = "alice") () =
       ~container_root:"/keeper/alice"
       ~base_path:"/srv/masc"
       ~container_kind:"turn"
-      ~network_mode:Keeper_types.Network_none
+      ~network_mode:Keeper_types_profile_sandbox.Network_none
       ~host_root:"/var/masc/alice"
       ~uid:1234
       ~gid:5678

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -792,7 +792,7 @@ let test_keeper_paths_use_cluster_root () =
   with_temp_dir "startup-cluster" (fun dir ->
       with_env "MASC_CLUSTER_NAME" (Some "cluster-alpha") (fun () ->
           let config = Coord.default_config dir in
-          let keeper_dir = Keeper_types.keeper_dir config in
+          let keeper_dir = Keeper_types_profile.keeper_dir config in
           let expected_root =
             Filename.concat
               (Filename.concat (Filename.concat dir Common.masc_dirname) "clusters")
@@ -906,7 +906,7 @@ let make_keeper_meta_json ?(name = "sangsu")
           ("last_model_used", `String "llama:auto");
         ])
   with
-  | Ok meta -> Keeper_types.meta_to_json meta |> Yojson.Safe.pretty_to_string
+  | Ok meta -> Keeper_meta_json.meta_to_json meta |> Yojson.Safe.pretty_to_string
   | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
 
 let make_keeper_meta ?(paused = false) ?(name = "sangsu")
@@ -934,26 +934,26 @@ let make_keeper_meta ?(paused = false) ?(name = "sangsu")
   | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
 
 let write_keeper_meta_exn config meta =
-  match Keeper_types.write_meta config meta with
+  match Keeper_meta_store.write_meta config meta with
   | Ok () -> ()
   | Error err -> Alcotest.fail ("keeper meta write failed: " ^ err)
 
 let with_running_keeper_metas config metas f =
   let base_path = config.Coord.base_path in
   List.iter
-    (fun (meta : Keeper_types.keeper_meta) ->
+    (fun (meta : Keeper_meta_contract.keeper_meta) ->
       Keeper_registry.unregister ~base_path meta.name;
       ignore (Keeper_registry.register ~base_path meta.name meta))
     metas;
   Fun.protect
     ~finally:(fun () ->
       List.iter
-        (fun (meta : Keeper_types.keeper_meta) ->
+        (fun (meta : Keeper_meta_contract.keeper_meta) ->
           Keeper_registry.unregister ~base_path meta.name)
         metas)
     f
 
-let mark_keeper_failing config (meta : Keeper_types.keeper_meta) =
+let mark_keeper_failing config (meta : Keeper_meta_contract.keeper_meta) =
   match
     Keeper_registry.dispatch_event
       ~base_path:config.Coord.base_path
@@ -1158,9 +1158,9 @@ let test_health_json_keeps_timeout_pause_without_policy_manual () =
               { (make_keeper_meta ()).runtime with
                 last_blocker =
                   Some
-                    (Keeper_types.blocker_info_of_class
+                    (Keeper_meta_contract.blocker_info_of_class
                        ~detail:"turn_timeout"
-                       Keeper_types.Turn_timeout);
+                       Keeper_meta_contract.Turn_timeout);
               };
           }
         in
@@ -1571,7 +1571,7 @@ let test_migrate_resident_keeper_dirs_promotes_valid_meta () =
         (make_keeper_meta_json ~name:"other" ~trace_id:"trace-other-live" ());
       Server_runtime_bootstrap.migrate_legacy_dirs state;
       let read_meta_exn path =
-        match Keeper_types.read_meta_file_path path with
+        match Keeper_meta_store.read_meta_file_path path with
         | Ok (Some meta) -> meta
         | Ok None -> Alcotest.failf "missing keeper meta at %s" path
         | Error err -> Alcotest.failf "failed to read keeper meta %s: %s" path err
@@ -1609,7 +1609,7 @@ let test_migrate_resident_keeper_dirs_keeps_fresher_current_meta () =
       Server_runtime_bootstrap.migrate_legacy_dirs state;
       let current_meta =
         match
-          Keeper_types.read_meta_file_path
+          Keeper_meta_store.read_meta_file_path
             (Filename.concat keepers_dir "sangsu.json")
         with
         | Ok (Some meta) -> meta
@@ -1658,14 +1658,14 @@ let test_blocking_bootstrap_promotes_legacy_keeper_meta_before_autoboot () =
       Alcotest.(check bool) "legacy keeper meta promoted during blocking bootstrap"
         true
         (Sys.file_exists
-           (Filename.concat (Keeper_types.keeper_dir state.Mcp_server.room_config)
+           (Filename.concat (Keeper_types_profile.keeper_dir state.Mcp_server.room_config)
               "sangsu.json"));
       Alcotest.(check bool) "legacy dir removed before later startup readers" false
         (Sys.file_exists legacy_dir);
       Alcotest.(check bool) "legacy traces stay deferred to lazy startup" true
         (Sys.file_exists legacy_trace_dir);
       let keepalive =
-        Keeper_types.keepalive_keeper_names state.Mcp_server.room_config
+        Keeper_meta_store.keepalive_keeper_names state.Mcp_server.room_config
       in
       Alcotest.(check (list string))
         "autoboot sees promoted keepers on first scan"

--- a/test/test_supervisor_start_predicate.ml
+++ b/test/test_supervisor_start_predicate.ml
@@ -84,7 +84,7 @@ let make_meta ?(paused = false) ?auto_resume_after_sec ?updated_at name =
       ; ("network_mode", `String "inherit")
       ]
   in
-  match KT.meta_of_json json with
+  match Masc_mcp.Keeper_meta_json_parse.meta_of_json json with
   | Error err -> fail ("meta_of_json failed: " ^ err)
   | Ok meta ->
     { meta with
@@ -94,7 +94,7 @@ let make_meta ?(paused = false) ?auto_resume_after_sec ?updated_at name =
     }
 
 let write_meta_exn config meta =
-  match KT.write_meta config meta with
+  match Masc_mcp.Keeper_meta_store.write_meta config meta with
   | Ok () -> ()
   | Error err -> fail ("write_meta failed: " ^ err)
 
@@ -210,7 +210,7 @@ let test_turn_timeout_pause_without_explicit_policy_does_not_start_sweep () =
   with_temp_masc_dir ~keeper_names:[ "timeout-due" ] (fun config ->
     let now = Unix.time () in
     let timeout_blocker =
-      KT.blocker_info_of_class ~detail:"turn_timeout" KT.Turn_timeout
+      Masc_mcp.Keeper_meta_contract.blocker_info_of_class ~detail:"turn_timeout" Masc_mcp.Keeper_meta_contract.Turn_timeout
     in
     let meta =
       { (make_meta

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -472,7 +472,7 @@ let test_diff_in_policy_deny () =
 (* 3-Layer Tool Gate tests                                           *)
 (* ================================================================ *)
 
-let make_gate_test_meta ?(name = "test-gate") () : Keeper_types.keeper_meta =
+let make_gate_test_meta ?(name = "test-gate") () : Keeper_meta_contract.keeper_meta =
   match Masc_test_deps.meta_of_json_fixture
     (`Assoc [("name", `String name); ("agent_name", `String name);
              ("trace_id", `String "test-trace-gate")]) with

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -63,7 +63,7 @@ let parse_create_response_json body =
     | None ->
         Alcotest.failf "expected JSON payload in create response: %s" body
 
-let make_keeper_meta ?(name = "judge-keeper") () : Keeper_types.keeper_meta =
+let make_keeper_meta ?(name = "judge-keeper") () : Keeper_meta_contract.keeper_meta =
   match
     Masc_test_deps.meta_of_json_fixture
       (`Assoc

--- a/test/test_tool_control_coverage.ml
+++ b/test/test_tool_control_coverage.ml
@@ -23,7 +23,7 @@ let seed_keeper_meta (ctx : Tool_control.context) name ~paused =
     | Ok meta -> { meta with paused }
     | Error err -> failwith ("meta fixture failed: " ^ err)
   in
-  match Keeper_types.write_meta ctx.config meta with
+  match Keeper_meta_store.write_meta ctx.config meta with
   | Ok () -> ()
   | Error err -> failwith ("meta write failed: " ^ err)
 

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1632,7 +1632,7 @@ let () = test "handle_claim_next_ignores_keeper_preset_for_open_claims" (fun () 
     | Ok meta -> meta
     | Error e -> failwith ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true ctx.config initial_meta with
+  (match Keeper_meta_store.write_meta ~force:true ctx.config initial_meta with
   | Ok () -> ()
   | Error e -> failwith ("write_meta failed: " ^ e));
   (match

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -349,7 +349,7 @@ let () =
          constructor will fail to compile here AND in
          tool_preset_to_string. *)
       Alcotest.test_case "witness covers all variants" `Quick (fun () ->
-        let open Masc_mcp.Keeper_types in
+        let open Masc_mcp.Keeper_meta_tool_access in
         let witness s =
           let actual = tool_preset_to_string s in
           if not (List.mem actual valid_tool_preset_strings) then
@@ -364,14 +364,14 @@ let () =
            If they ever diverge this test fails and a silently-dropped
            schema enum constructor is caught immediately. *)
         Alcotest.(check (list string)) "schema mirror == variant SSOT"
-          Masc_mcp.Keeper_types.valid_tool_preset_strings
+          Masc_mcp.Keeper_meta_tool_access.valid_tool_preset_strings
           Masc_mcp.Keeper_schema.tool_preset_enum_strings);
       Alcotest.test_case "TOML parser mirror stays in sync" `Quick (fun () ->
         (* Keeper_types_profile cannot depend on Keeper_types because
            Keeper_types includes it, so the raw TOML allow-list is mirrored
            there and guarded here. *)
         Alcotest.(check (list string)) "profile mirror == variant SSOT"
-          Masc_mcp.Keeper_types.valid_tool_preset_strings
+          Masc_mcp.Keeper_meta_tool_access.valid_tool_preset_strings
           Masc_mcp.Keeper_types_profile.valid_tool_preset_raw_strings);
       Alcotest.test_case "tool_access schema mirror stays in sync" `Quick (fun () ->
         let open Yojson.Safe.Util in
@@ -390,10 +390,10 @@ let () =
           |> List.map to_string
         in
       Alcotest.(check (list string)) "tool_access enum == variant SSOT"
-        Masc_mcp.Keeper_types.valid_tool_preset_strings
+        Masc_mcp.Keeper_meta_tool_access.valid_tool_preset_strings
         enum);
       Alcotest.test_case "room signal defaults follow keeper tool access" `Quick (fun () ->
-        let open Masc_mcp.Keeper_types in
+        let open Masc_mcp.Keeper_meta_tool_access in
         let check_access label expected access =
           Alcotest.(check bool) label expected
             (tool_access_default_room_signal_prompt_enabled
@@ -419,7 +419,7 @@ let () =
         check_access "custom board allowlist listens" true
           (Custom [ "keeper_board_post" ]));
       Alcotest.test_case "Social, Dispatch, and Delivery present" `Quick (fun () ->
-        let open Masc_mcp.Keeper_types in
+        let open Masc_mcp.Keeper_meta_tool_access in
         Alcotest.(check bool) "social present" true
           (List.mem "social" valid_tool_preset_strings);
         Alcotest.(check bool) "dispatch present" true

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -42,7 +42,7 @@ let require_write_ok label = function
   | Ok () -> ()
   | Error msg -> failf "%s: %s" label msg
 
-let make_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
+let make_meta ?(name = "test-keeper") () : Keeper_meta_contract.keeper_meta =
   match Masc_test_deps.meta_of_json_fixture
     (`Assoc [("name", `String name); ("agent_name", `String name);
              ("trace_id", `String "test-trace-warn")]) with
@@ -53,7 +53,7 @@ let make_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
     public names (via descriptor registry) + core_always_tools.
     RFC-0179 moved core_discovery_tools to public names while
     keeper_allowed_tool_names still returns internal names. *)
-let build_allowed_exec_set (meta : Keeper_types.keeper_meta) =
+let build_allowed_exec_set (meta : Keeper_meta_contract.keeper_meta) =
   let allowed_names = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   let internal_set = Keeper_tool_policy.tool_name_set allowed_names in
   (* Map internal names to public names via descriptor registry *)
@@ -71,7 +71,7 @@ let build_allowed_exec_set (meta : Keeper_types.keeper_meta) =
     (Keeper_tool_policy.tool_name_set Keeper_tool_registry.core_always_tools)
 
 (** Filter core_discovery_tools by preset (the fix). *)
-let filter_core_by_preset (meta : Keeper_types.keeper_meta) =
+let filter_core_by_preset (meta : Keeper_meta_contract.keeper_meta) =
   let allowed_set = build_allowed_exec_set meta in
   List.filter
     (fun name -> Keeper_tool_policy.StringSet.mem name allowed_set)
@@ -85,15 +85,15 @@ let write_only_tools = [ "Edit" ]
 let shell_bridge_tools = [ "Execute" ]
 
 let privileged_presets =
-  [ Keeper_types.Delivery; Keeper_types.Delivery; Keeper_types.Full ]
+  [ Keeper_meta_tool_access.Delivery; Keeper_meta_tool_access.Delivery; Keeper_meta_tool_access.Full ]
 
 let unprivileged_presets =
   [
-    Keeper_types.Minimal;
-    Keeper_types.Social;
-    Keeper_types.Messaging;
-    Keeper_types.Dispatch;
-    Keeper_types.Research;
+    Keeper_meta_tool_access.Minimal;
+    Keeper_meta_tool_access.Social;
+    Keeper_meta_tool_access.Messaging;
+    Keeper_meta_tool_access.Dispatch;
+    Keeper_meta_tool_access.Research;
   ]
 
 let test_privileged_preset_write_gates () =


### PR DESCRIPTION
## 목적

`origin/main`이 컴파일되지 않는 상태를 복구합니다. RFC-0205 "Keeper module consolidation / Remove Keeper_types facade — Phase 1" (#19399) + 연쇄 SSOT JSON-helper consolidation (#19398/#19406/#19409/#19410/#19403/#19415/#19420) + blocker_class 비대칭이 **캐논컬 타입·헬퍼는 옮기거나 변경했지만 호출부(caller) 갱신을 미완**으로 남겨, 다수 모듈이 unbound 참조·.ml↔.mli 비대칭·record field disambiguation 실패·arg-order 불일치로 빌드를 깨뜨렸습니다.

CI는 `PR ⊕ main`을 빌드하므로 main이 깨진 동안에는 **모든 PR이 green이 될 수 없었습니다**. 본 PR로 main 컴파일을 복구합니다. (검증: `e9f15603a` 단독 빌드 exit 1 → 본 브랜치 rebase 후 exit 0)

## RFC

RFC-0205 (Keeper module consolidation — Remove Keeper_types facade, Phase 1, #19399). 본 PR은 그 facade 제거 + SSOT helper 이동이 남긴 caller 미갱신을 **컴파일러가 컴파일 에러로 강제한 사이트들에 한해** 완성합니다. 새 추상화/우회를 추가하지 않습니다.

## 변경 범위 (클러스터별)

**① 캐논컬 타입 .ml↔.mli 정합화 (`lib/keeper/keeper_meta_contract.{ml,mli}`)**
- `cascade_exhaustion_reason`: `.ml`에만 있던 `No_tool_capable` 생성자를 `.mli`에도 추가 (비대칭 해소). 운영 의미 doc 주석 동반.
- `blocker_class`: `.mli`에만 있던 `No_tool_capable_provider` 생성자를 `.ml`에도 추가 + `blocker_class_to_string`/`blocker_class_of_serialized_string`/`blocker_class_continue_gate` 3개 exhaustive match에 명시적 case 추가 (catch-all 아님).
- `keeper_meta` record: `sandbox_profile`/`network_mode` field 타입을 `.mli`와 동일하게 `Keeper_types_profile.*`로 qualify.

**② 이동된 helper qualify (facade 제거 + SSOT 이동)**
- `meta_to_json`→`Keeper_meta_json`, `meta_of_json`→`Keeper_meta_json_parse`, `read_meta`/`write_meta_with_merge`→`Keeper_meta_store`, `keeper_meta_path`/`keeper_dir`/`room_seq_map_to_json`/`load_keeper_profile_defaults`→`Keeper_types_profile`, `validate_name`/`normalize_*`/`canonical_compaction_profile`/`keeper_compaction_policy_from_env`→`Keeper_config`, `present_json_keys`/`removed_keeper_meta_key_names`/`normalize_goal_horizon_text`/`resolve_goal_horizons`/`default_proactive_*`→`Keeper_config_text`, `scrub_persisted_keeper_meta_json`→`Keeper_meta_json_scrub`, `warn_unknown_keeper_meta_keys`→`Keeper_meta_json`, `dedupe_keep_order`→`Json_util`.
- 끊긴 module open 복원: `keeper_meta_store.{ml,mli}`·`keeper_meta_json_parse.{ml,mli}`에 `open Keeper_meta_contract` 등 (근거 주석 동반).

**③ option-unwrap match arm (#19410)**
- `Json_util` helper가 option을 반환하도록 바뀐 자리에서 `coord_goals.ml`의 match arm을 `| Some (\`List values) ->`로 unwrap.

**④ SSOT Json_util helper 치환 (`cascade_event_bridge.ml`)**
- `json_string_opt`→`Json_util.string_opt_to_json`, `payload_string_opt`→`Json_util.assoc_string_opt`, `payload_int_opt`→`Json_util.assoc_int_opt`.

**⑤ record field disambiguation**
- `keeper_meta` field가 다른 record에 shadow되는 자리에서 `meta.Keeper_meta_contract.<field>`로 명시하거나 param에 `(meta : Keeper_meta_contract.keeper_meta)` 타입 annotate (`keeper_unified_turn_success.ml` 6개, `keeper_registry.ml` sort comparator의 `count` 등).
- `ctx.sw`/`ctx.net` (`_ Keeper_types_profile.context`) → `ctx.Keeper_types_profile.{sw,net}`.

**⑥ #19420 arg-order 잔여 (`dashboard_execution.ml`, rebase 후 노출)**
- #19420이 `Json_util.get_string`/`get_object`를 `(json, key)` 순서로 바꿨으나 `assoc_member_if_object`/`lowercase_json_string` 2개 wrapper가 옛 `(key, json)` 순서로 호출하던 것을 SSOT 순서로 교정. (assoc-계열 `(key, json)` 관습과 get-계열 `(json, key)` 관습은 별개 — 각 호출부를 해당 시그니처에 맞춤.)

**테스트 (~88 파일)**
- `Keeper_types` facade가 더 이상 이동된 이름을 re-export하지 않으므로, 테스트의 `Keeper_types.<moved>`/`KT.<moved>` 참조를 실제 home 모듈로 기계적으로 마이그레이션. 각 이동 이름은 home이 정확히 1개. 단언/expected 값/test_case 수 보존 (+831/-831 균형 — 순수 라인 단위 리네임), skip/주석처리/trivial-pass 0건.

## 검증

- `dune build --root .` **exit 0**, `dune build @check --root .` **exit 0** (전 파일 컴파일+타입체크). dune-project의 pre-existing websocket 중복-의존성 경고는 본 변경 무관.
- 의미 검증: 모듈 2곳에 다른 값으로 정의된 유일한 helper `default_proactive_enabled` (`Keeper_config_text`=true / `keeper_persona_authoring_contract`=false)를 `Keeper_config_text`(true)로 한정 — 병렬 경로 `keeper_runtime.ml:192`가 동일 필드를 `Keeper_config.default_proactive_enabled`(true)로 해소하는 것과 일치 (config 도메인). 나머지 13개 helper는 home이 1개라 컴파일러 수용이 곧 정합성 증명.
- 금지 패턴 스캔: `Obj.magic` 0, 추가된 catch-all `| _ ->` 0, facade 재추가 0, 삭제 파일 0.

## 비-워크어라운드 선언

본 PR은 CLAUDE.md "워크어라운드 거부 기준"의 N-of-M(§3)에 표면상 닿지만 해당하지 않습니다: 추가 사이트를 *재량적으로 메우는 것*이 아니라, facade/SSOT 이동이 이미 끝나 **컴파일러가 모든 누락 사이트를 컴파일 에러로 강제**한 것을 type-driven으로 완결하는 것입니다. 새 string 분류기/catch-all/telemetry-as-fix 없음. 캐논컬 closed-sum 타입은 .ml↔.mli 일치로 오히려 강화됩니다.

WORKAROUND-WAIVED: 본 변경은 production-blocking(broken main)을 복구하는 컴파일러-강제 refactor 완결이며, 새 우회 패턴을 도입하지 않음 (N-of-M 시그니처는 "완성/잔여" 어휘에 대한 false positive). 지배 RFC = RFC-0205.

## Draft 사유

검증 완료(빌드+타입체크 green + diff 리뷰). Ready 전환은 masc-mcp Draft Auto-Merge Guard에 따라 사용자 라벨로만 수행합니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
