### PR TITLE
fix(dashboard): correct Json_util arg order in dashboard_execution (restore build)

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -206,7 +206,7 @@ let record_render_phase_timings (t : render_phase_timings_ms) =
 ;;
 
 let assoc_member_if_object key json =
-  Json_util.get_object key json
+  Json_util.get_object json key
 ;;
 
 let existing_keeper_trust_json keeper_json =
@@ -292,7 +292,7 @@ let keeper_runtime_trust_json keeper =
 ;;
 
 let lowercase_json_string key json =
-  Json_util.get_string key json |> Option.map String.lowercase_ascii
+  Json_util.get_string json key |> Option.map String.lowercase_ascii
 ;;
 
 let terminal_reason_json trust = member_assoc "latest_terminal_reason" trust


### PR DESCRIPTION
## 목적
origin/main **build 복구** — #19390 breakage의 마지막 arg-order dimension.

## 변경 (2줄)
`#19415`의 `Yojson.Safe.Util → Json_util` 마이그레이션이 `dashboard_execution.ml`의 두 `get_*` 호출을 옛 `(key, json)` 순으로 남김. Json_util `get_*`는 `(json, key)` 순. `#19420`이 coord_goals/test는 고쳤으나 이 둘을 놓침 → main 여전히 컴파일 불가(#19423가 경고한 dimension):
- `assoc_member_if_object`: `get_object key json` → `get_object json key`
- `lowercase_json_string`: `get_string key json` → `get_string json key`

## 검증
- `dune build --root . lib + test/test_dashboard_http_core.exe` **exit 0** (#19390로 막혀있던 full lib + native test link).
- 테스트 실행: shell-wire(RFC-0204 light-reads-shell_light 포함) / Phase 1 dashboard_auth_state / snapshot storage·metadata **전부 pass**.
- 사전존재 무관 실패: operator-snapshot cache test (`MASC_CONFIG_DIR` 미설정 환경).

## 영향
이 fix로 main green → #19414/#19416/#19419(RFC-0204 Phase1/2/A) 등 머지본 전부 런타임 검증 가능해짐.

RFC-WAIVED: 머지된 #19415/#19420 SSOT 마이그레이션의 mechanical arg-order 완성. gated subsystem 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
