### PR TITLE
fix(cascade): typed capacity_retry_after provenance to stop synthetic backoff laundering

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -68,7 +68,16 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
   (* All other MASC-internal classifications (and unclassified errors) fall
      through to the structured [match err with] below to derive the cascade
      outcome from the raw [sdk_error] payload. *)
-  | Some (Cascade_error_classify.Capacity_backpressure { detail; retry_after_sec; source; _ }) ->
+  | Some (Cascade_error_classify.Capacity_backpressure { detail; retry_after; source; _ }) ->
+    (* Re-expose only a concrete backoff as the Http [retry_after]; a synthetic
+       default is dropped to [None] so it is not re-derived as an explicit hint
+       on the next pass. *)
+    let retry_after_sec =
+      match retry_after with
+      | Cascade_internal_error.Explicit s -> Some s
+      | Cascade_internal_error.Synthetic_default _
+      | Cascade_internal_error.No_retry_hint -> None
+    in
     Some
       (Cascade_fsm.Call_err
          (Llm_provider.Http_client.ProviderFailure

--- a/lib/cascade/cascade_attempt_fsm_capacity_backpressure.ml
+++ b/lib/cascade/cascade_attempt_fsm_capacity_backpressure.ml
@@ -46,11 +46,16 @@ let sdk_error_capacity_backpressure_source (err : Agent_sdk.Error.sdk_error)
 let sdk_error_capacity_backpressure_retry_hint (err : Agent_sdk.Error.sdk_error)
   : capacity_backpressure_retry_hint option =
   match Cascade_error_classify.classify_masc_internal_error err with
-  | Some (Cascade_error_classify.Capacity_backpressure { retry_after_sec; _ }) ->
-    (match retry_after_sec with
-     | Some s when s > 0.0 -> Some (Cbr_explicit s)
-     | Some _ (* <= 0.0: treat as missing, fall back to synthetic *)
-     | None ->
+  | Some (Cascade_error_classify.Capacity_backpressure { retry_after; _ }) ->
+    (* Read provenance directly from the typed carrier: a [Synthetic_default]
+       can no longer reach the [Cbr_explicit] branch. *)
+    (match retry_after with
+     | Cascade_internal_error.Explicit s when s > 0.0 -> Some (Cbr_explicit s)
+     | Cascade_internal_error.Explicit _ ->
+       (* defensive: a non-positive explicit value is treated as missing *)
+       Some (Cbr_synthetic_default default_capacity_backpressure_backoff_sec)
+     | Cascade_internal_error.Synthetic_default s -> Some (Cbr_synthetic_default s)
+     | Cascade_internal_error.No_retry_hint ->
        Some (Cbr_synthetic_default default_capacity_backpressure_backoff_sec))
   | Some (Cascade_error_classify.Cascade_exhausted _)
   | Some (Cascade_error_classify.Resumable_cli_session _)

--- a/lib/cascade/cascade_error_from_sdk.ml
+++ b/lib/cascade/cascade_error_from_sdk.ml
@@ -78,14 +78,32 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
           | Some cascade_name, Some source, Some detail ->
             (match capacity_backpressure_source_of_string source with
              | Some source ->
+               (* Reconstruct provenance from the wire: a [retry_after_synthetic]
+                  flag distinguishes a fabricated default from a real backoff, so
+                  a synthetic value is never read back as explicit.  Legacy
+                  payloads (no flag) default to [Explicit]. *)
+               let retry_after_synthetic =
+                 match json with
+                 | `Assoc fields -> (
+                     match List.assoc_opt "retry_after_synthetic" fields with
+                     | Some (`Bool b) -> b
+                     | _ -> false)
+                 | _ -> false
+               in
+               let retry_after =
+                 match float_opt_of_assoc "retry_after_sec" json with
+                 | None -> Cascade_internal_error.No_retry_hint
+                 | Some s when retry_after_synthetic ->
+                   Cascade_internal_error.Synthetic_default s
+                 | Some s -> Cascade_internal_error.Explicit s
+               in
                Some
                  (Capacity_backpressure
                     {
                       cascade_name = Cascade_name.of_string_exn cascade_name;
                       source;
                       detail;
-                      retry_after_sec =
-                        float_opt_of_assoc "retry_after_sec" json;
+                      retry_after;
                     })
              | None -> None)
           | _ -> None)

--- a/lib/cascade/cascade_internal_error.ml
+++ b/lib/cascade/cascade_internal_error.ml
@@ -74,6 +74,25 @@ let retry_admission_denial_to_yojson = function
         ("remaining_turn_budget_s", `Float remaining_turn_budget_s);
       ]
 
+(** Provenance-preserving retry-after hint for capacity backpressure.
+
+    [Explicit] carries a concrete backoff to trust: an upstream-supplied
+    Retry-After (seconds, > 0) or a real locally-computed wait (e.g. a client
+    capacity cooldown).  [Synthetic_default] carries a fabricated fixed-default
+    backoff applied when no real signal was available.  [No_retry_hint] means
+    neither was available.
+
+    Keeping [Synthetic_default] distinct from [Explicit] at the type level
+    makes it impossible to launder a fabricated default into the explicit
+    path: the classifier and telemetry can always tell a real backoff from a
+    blind guess.  Replaces a [float option] carrier whose [None]->[Some
+    synthetic] injection (PR #19329) relabelled a synthetic backoff as an
+    explicit hint (audit 2026-05-29). *)
+type capacity_retry_after =
+  | Explicit of float
+  | Synthetic_default of float
+  | No_retry_hint
+
 type masc_internal_error =
   | Cascade_exhausted of {
       cascade_name : Cascade_name.t;
@@ -83,7 +102,7 @@ type masc_internal_error =
       cascade_name : Cascade_name.t;
       source : capacity_backpressure_source;
       detail : string;
-      retry_after_sec : float option;
+      retry_after : capacity_retry_after;
     }
   | Resumable_cli_session of {
       cascade_name : Cascade_name.t;
@@ -221,16 +240,28 @@ let masc_internal_error_to_json = function
         ("cascade_name", `String cascade_name);
         ("reason", Keeper_meta_contract.cascade_exhaustion_reason_to_json reason);
       ]
-  | Capacity_backpressure { cascade_name; source; detail; retry_after_sec } ->
+  | Capacity_backpressure { cascade_name; source; detail; retry_after } ->
     let cascade_name = cascade_name_to_string cascade_name in
+    (* Carry the backoff seconds for both real and synthetic hints (never
+       null when a backoff applies, satisfying telemetry consumers) plus an
+       explicit [retry_after_synthetic] flag so a synthetic default is never
+       read back as a provider hint on the JSON round-trip. *)
+    let retry_after_fields =
+      match retry_after with
+      | Explicit s ->
+        [ ("retry_after_sec", `Float s); ("retry_after_synthetic", `Bool false) ]
+      | Synthetic_default s ->
+        [ ("retry_after_sec", `Float s); ("retry_after_synthetic", `Bool true) ]
+      | No_retry_hint -> [ ("retry_after_sec", `Null) ]
+    in
     `Assoc
-      [
-        ("kind", `String "capacity_backpressure");
-        ("cascade_name", `String cascade_name);
-        ("source", `String (capacity_backpressure_source_to_string source));
-        ("detail", `String detail);
-        ("retry_after_sec", Json_util.float_opt_to_json retry_after_sec);
-      ]
+      ([
+         ("kind", `String "capacity_backpressure");
+         ("cascade_name", `String cascade_name);
+         ("source", `String (capacity_backpressure_source_to_string source));
+         ("detail", `String detail);
+       ]
+      @ retry_after_fields)
   | Resumable_cli_session { cascade_name; detail; exit_code } ->
     let cascade_name = cascade_name_to_string cascade_name in
     `Assoc
@@ -369,11 +400,13 @@ let summarize_provider_rejections rejections =
   | reasons -> String.concat "; " reasons
 
 let summary_of_masc_internal_error = function
-  | Capacity_backpressure { cascade_name; source; detail; retry_after_sec } ->
-      let retry_after =
-        match retry_after_sec with
-        | Some value -> Printf.sprintf "; retry_after=%.1fs" value
-        | None -> ""
+  | Capacity_backpressure { cascade_name; source; detail; retry_after } ->
+      let retry_after_suffix =
+        match retry_after with
+        | Explicit value -> Printf.sprintf "; retry_after=%.1fs" value
+        | Synthetic_default value ->
+          Printf.sprintf "; retry_after=%.1fs (synthetic)" value
+        | No_retry_hint -> ""
       in
       Some
         (Printf.sprintf
@@ -381,7 +414,7 @@ let summary_of_masc_internal_error = function
            (cascade_name_to_string cascade_name)
            (capacity_backpressure_source_to_string source)
            detail
-           retry_after)
+           retry_after_suffix)
   | No_tool_capable_provider
       {
         cascade_name;

--- a/lib/cascade/cascade_internal_error.mli
+++ b/lib/cascade/cascade_internal_error.mli
@@ -73,6 +73,18 @@ type retry_admission_denial =
 val retry_admission_denial_to_yojson :
   retry_admission_denial -> Yojson.Safe.t
 
+(** Provenance-preserving retry-after hint for capacity backpressure.
+    [Explicit] is a concrete backoff to trust (an upstream Retry-After or a
+    real locally-computed wait); [Synthetic_default] is a fabricated
+    fixed-default applied when no real signal was available; [No_retry_hint]
+    means neither.  Keeping synthetic distinct from explicit at the type level
+    prevents a fabricated default being laundered into the explicit path
+    (audit 2026-05-29, PR #19329). *)
+type capacity_retry_after =
+  | Explicit of float
+  | Synthetic_default of float
+  | No_retry_hint
+
 type masc_internal_error =
   | Cascade_exhausted of {
       cascade_name : Cascade_name.t;
@@ -82,7 +94,7 @@ type masc_internal_error =
       cascade_name : Cascade_name.t;
       source : capacity_backpressure_source;
       detail : string;
-      retry_after_sec : float option;
+      retry_after : capacity_retry_after;
     }
   | Resumable_cli_session of {
       cascade_name : Cascade_name.t;

--- a/lib/keeper/keeper_turn_driver_backpressure.ml
+++ b/lib/keeper/keeper_turn_driver_backpressure.ml
@@ -9,8 +9,9 @@ open Cascade_internal_error
 open Cascade_name
 
 (* Synthetic backoff default for paths where the upstream provides no
-   [retry_after] hint.  Mirrors the downstream fallback in
-   [Cascade_health_tracker] so that telemetry never emits [null]. *)
+   [retry_after] hint.  Carried as [Synthetic_default] so provenance is
+   preserved: telemetry shows the value with a synthetic flag rather than a
+   laundered explicit hint. *)
 let synthetic_retry_after_sec =
   Cascade_health_tracker_config.default_capacity_backpressure_backoff_sec
 
@@ -47,10 +48,10 @@ let capacity_backpressure_of_http_error ?source ~cascade_name last_err =
            source =
              Option.value source ~default:Provider_capacity;
            detail = message;
-           retry_after_sec =
+           retry_after =
              (match retry_after with
-              | Some _ -> retry_after
-              | None -> Some synthetic_retry_after_sec);
+              | Some s -> Explicit s
+              | None -> Synthetic_default synthetic_retry_after_sec);
          })
   | Some
       (Llm_provider.Http_client.NetworkError
@@ -64,7 +65,7 @@ let capacity_backpressure_of_http_error ?source ~cascade_name last_err =
            cascade_name;
            source = Option.value source ~default:Cascade_slot;
            detail = message;
-           retry_after_sec = Some synthetic_retry_after_sec;
+           retry_after = Synthetic_default synthetic_retry_after_sec;
          })
   | Some
       (Llm_provider.Http_client.HttpError _
@@ -78,14 +79,14 @@ let capacity_backpressure_of_http_error ?source ~cascade_name last_err =
     None
 
 let capacity_backpressure_of_pending ~cascade_name = function
-  | Some (source, detail, retry_after_sec) ->
+  | Some (source, detail, retry_after) ->
     Some
       (Capacity_backpressure
          {
            cascade_name;
            source;
            detail;
-           retry_after_sec;
+           retry_after;
          })
   | None -> None
 
@@ -104,10 +105,10 @@ let capacity_backpressure_of_sdk_error
               cascade_name;
               source = Provider_capacity;
               detail;
-              retry_after_sec =
+              retry_after =
                 (match retry_after with
-                 | Some _ -> retry_after
-                 | None -> Some synthetic_retry_after_sec);
+                 | Some s -> Explicit s
+                 | None -> Synthetic_default synthetic_retry_after_sec);
             }))
   | Agent_sdk.Error.Internal msg
     when message_looks_like_capacity_backpressure msg ->
@@ -118,7 +119,7 @@ let capacity_backpressure_of_sdk_error
               cascade_name;
               source = Provider_capacity;
               detail = msg;
-              retry_after_sec = Some synthetic_retry_after_sec;
+              retry_after = Synthetic_default synthetic_retry_after_sec;
             }))
   | Agent_sdk.Error.Api _
   | Agent_sdk.Error.Provider _

--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -19,10 +19,14 @@ val capacity_backpressure_of_http_error :
   Cascade_internal_error.masc_internal_error option
 
 (** Build a capacity-backpressure internal error from a pending
-    backpressure triple [(source, detail, retry_after_sec)]. *)
+    backpressure triple [(source, detail, retry_after)].  The retry-after
+    component carries its provenance ([Explicit] / [Synthetic_default] /
+    [No_retry_hint]) so a synthetic default is never read as an explicit
+    hint. *)
 val capacity_backpressure_of_pending :
   cascade_name:Cascade_name.t ->
-  (Cascade_internal_error.capacity_backpressure_source * string * float option) option ->
+  (Cascade_internal_error.capacity_backpressure_source * string
+   * Cascade_internal_error.capacity_retry_after) option ->
   Cascade_internal_error.masc_internal_error option
 
 (** Classify an SDK error into a capacity-backpressure error,

--- a/lib/keeper/keeper_turn_driver_cascade_health.ml
+++ b/lib/keeper/keeper_turn_driver_cascade_health.ml
@@ -131,9 +131,14 @@ let record_candidate_error candidate (sdk_err : Agent_sdk.Error.sdk_error) =
           (match sdk_error_capacity_backpressure_retry_hint sdk_err with
            | Some (Cbr_explicit s) -> Some (Some s)
            | Some (Cbr_synthetic_default s) ->
-             Log.Misc.warn
-               "cascade_capacity_backpressure: provider=%s retry_after_sec=null \
-                injecting synthetic backoff=%.1fs (error_kind=%s)"
+             (* No provider Retry-After; applying a synthetic backoff.  This is
+                expected for capacity exhaustion without an upstream hint, so it
+                is logged at INFO.  Provenance is preserved in the typed carrier
+                ([Synthetic_default]); it is not laundered into an explicit
+                hint. *)
+             Log.Misc.info
+               "cascade_capacity_backpressure: provider=%s no provider \
+                retry_after; using synthetic backoff=%.1fs (error_kind=%s)"
                provider_key s
                (Cascade_health_tracker.error_kind_to_string error_kind);
              Some (Some s)

--- a/lib/keeper/keeper_turn_driver_try_cascade.ml
+++ b/lib/keeper/keeper_turn_driver_try_cascade.ml
@@ -465,7 +465,13 @@ let rec run
       run ~on_success ?resume_checkpoint ?per_provider_timeout_s
         ~pre_dispatch_required_tool_rejections_rev
         ~last_capacity_backpressure:
-          (Client_capacity, capacity_detail, retry_after_s)
+          ( Client_capacity
+          , capacity_detail
+          , (* a computed client-capacity cooldown is a real backoff, not a
+               blind synthetic default *)
+            (match retry_after_s with
+             | Some s -> Cascade_internal_error.Explicit s
+             | None -> Cascade_internal_error.No_retry_hint) )
         ctx rest last_err
     | (`No_client_capacity | `Acquired _) as capacity_slot ->
     let capacity_release =

--- a/test/test_cascade_capacity_backpressure_synthetic_backoff.ml
+++ b/test/test_cascade_capacity_backpressure_synthetic_backoff.ml
@@ -1,20 +1,29 @@
-(** D12 — Synthetic typed backoff for [Capacity_backpressure] with
-    [retry_after_sec = None].
+(** D12 — Provenance-preserving typed backoff for [Capacity_backpressure].
 
-    Pre-fix behaviour: a MASC-internal [Capacity_backpressure] classification
-    with [retry_after_sec = null] arriving via the keeper turn driver fell
-    through to [Cascade_health_tracker.record_failure] (3-failure threshold).
-    The cascade then rotated immediately onto the same degraded provider
-    because no cooldown had been applied.
+    A MASC-internal [Capacity_backpressure] carries a typed
+    [Cascade_internal_error.capacity_retry_after]:
 
-    Post-fix behaviour: when [retry_after_sec = None], the consumer injects
-    a typed synthetic backoff
-    ([Cascade_health_tracker.default_capacity_backpressure_backoff_sec],
-    default 5.0s) so the cooldown path applies.  An explicit value is honored
-    verbatim. *)
+      - [Explicit s]            a concrete backoff to trust (upstream
+                                Retry-After or a real computed local wait)
+      - [Synthetic_default s]   a fabricated fixed default used when no real
+                                signal was available
+      - [No_retry_hint]         neither
+
+    The classifier maps a positive [Explicit] to [Cbr_explicit] and everything
+    else (synthetic, missing, non-positive) to [Cbr_synthetic_default] so a
+    cooldown is always applied instead of rotating immediately onto the same
+    degraded provider.
+
+    Regression guard (PR #19329 / audit 2026-05-29): a [Synthetic_default]
+    must NEVER be reclassified as [Cbr_explicit].  Previously the carrier was a
+    [float option] and a [Some synthetic] injection laundered a fabricated
+    default into the explicit-hint path; the typed carrier makes that
+    unrepresentable, and this test pins it across the serialize/deserialize
+    round-trip used by [sdk_error_of_masc_internal_error]. *)
 
 module FSM = Masc_mcp.Cascade_attempt_fsm
 module Classify = Masc_mcp.Cascade_error_classify
+module Internal = Masc_mcp.Cascade_internal_error
 module HT = Masc_mcp.Cascade_health_tracker
 
 let pp_hint fmt = function
@@ -25,7 +34,7 @@ let pp_hint fmt = function
 
 let hint_testable = Alcotest.testable pp_hint ( = )
 
-let mk_capacity_backpressure ?retry_after_sec
+let mk_capacity_backpressure ?(retry_after = Internal.No_retry_hint)
     ?(cascade_name = "test-cascade")
     ?(source = Classify.Provider_capacity)
     ?(detail = "provider capacity full") () =
@@ -35,24 +44,36 @@ let mk_capacity_backpressure ?retry_after_sec
         cascade_name = Cascade_name.of_string_exn cascade_name;
         source;
         detail;
-        retry_after_sec;
+        retry_after;
       }
   in
   Classify.sdk_error_of_masc_internal_error err
 
 let test_explicit_retry_after_honored () =
-  let err = mk_capacity_backpressure ~retry_after_sec:10.0 () in
+  let err = mk_capacity_backpressure ~retry_after:(Internal.Explicit 10.0) () in
   Alcotest.check hint_testable
-    "Capacity_backpressure retry_after_sec=Some 10.0 → Cbr_explicit 10.0"
+    "Capacity_backpressure Explicit 10.0 → Cbr_explicit 10.0"
     (Some (FSM.Cbr_explicit 10.0))
     (FSM.sdk_error_capacity_backpressure_retry_hint err)
 
 let test_missing_retry_after_uses_synthetic_default () =
-  let err = mk_capacity_backpressure ?retry_after_sec:None () in
+  let err = mk_capacity_backpressure ~retry_after:Internal.No_retry_hint () in
   let expected_default = HT.default_capacity_backpressure_backoff_sec in
   Alcotest.check hint_testable
-    "Capacity_backpressure retry_after_sec=None → Cbr_synthetic_default 5.0"
+    "Capacity_backpressure No_retry_hint → Cbr_synthetic_default default"
     (Some (FSM.Cbr_synthetic_default expected_default))
+    (FSM.sdk_error_capacity_backpressure_retry_hint err)
+
+let test_synthetic_default_not_laundered_as_explicit () =
+  (* The PR #19329 regression: a fabricated default carried as
+     [Synthetic_default 30.0] must classify as [Cbr_synthetic_default 30.0],
+     NEVER [Cbr_explicit 30.0].  This exercises the full
+     serialize -> deserialize -> classify round-trip, proving provenance
+     survives the JSON boundary via the [retry_after_synthetic] flag. *)
+  let err = mk_capacity_backpressure ~retry_after:(Internal.Synthetic_default 30.0) () in
+  Alcotest.check hint_testable
+    "Synthetic_default 30.0 → Cbr_synthetic_default 30.0 (not laundered to explicit)"
+    (Some (FSM.Cbr_synthetic_default 30.0))
     (FSM.sdk_error_capacity_backpressure_retry_hint err)
 
 let test_synthetic_default_is_positive_and_within_sane_bounds () =
@@ -70,18 +91,18 @@ let test_synthetic_default_is_positive_and_within_sane_bounds () =
     (default <= HT.soft_rate_limit_max_clamp_sec)
 
 let test_non_positive_retry_after_falls_back_to_synthetic () =
-  (* retry_after_sec=Some 0.0 or negative is semantically equivalent to
-     None — upstream gave no usable backoff hint, so the consumer must
-     inject the synthetic default rather than rotating immediately. *)
-  let err_zero = mk_capacity_backpressure ~retry_after_sec:0.0 () in
+  (* [Explicit 0.0] or negative is semantically equivalent to missing —
+     upstream gave no usable backoff hint, so the consumer must inject the
+     synthetic default rather than rotating immediately. *)
+  let err_zero = mk_capacity_backpressure ~retry_after:(Internal.Explicit 0.0) () in
   let expected_default = HT.default_capacity_backpressure_backoff_sec in
   Alcotest.check hint_testable
-    "retry_after_sec=Some 0.0 → Cbr_synthetic_default (treat as missing)"
+    "Explicit 0.0 → Cbr_synthetic_default (treat as missing)"
     (Some (FSM.Cbr_synthetic_default expected_default))
     (FSM.sdk_error_capacity_backpressure_retry_hint err_zero);
-  let err_neg = mk_capacity_backpressure ~retry_after_sec:(-1.0) () in
+  let err_neg = mk_capacity_backpressure ~retry_after:(Internal.Explicit (-1.0)) () in
   Alcotest.check hint_testable
-    "retry_after_sec=Some -1.0 → Cbr_synthetic_default (treat as missing)"
+    "Explicit -1.0 → Cbr_synthetic_default (treat as missing)"
     (Some (FSM.Cbr_synthetic_default expected_default))
     (FSM.sdk_error_capacity_backpressure_retry_hint err_neg)
 
@@ -109,6 +130,8 @@ let () =
             test_explicit_retry_after_honored;
           Alcotest.test_case "missing retry_after uses synthetic default" `Quick
             test_missing_retry_after_uses_synthetic_default;
+          Alcotest.test_case "synthetic default not laundered as explicit" `Quick
+            test_synthetic_default_not_laundered_as_explicit;
           Alcotest.test_case "synthetic default within sane bounds" `Quick
             test_synthetic_default_is_positive_and_within_sane_bounds;
           Alcotest.test_case "non-positive retry_after falls back" `Quick

--- a/test/test_cascade_error_classify_decoder.ml
+++ b/test/test_cascade_error_classify_decoder.ml
@@ -123,7 +123,7 @@ let test_roundtrip_capacity_backpressure () =
   match decoded with
   | Some
       (Classify.Capacity_backpressure
-         { cascade_name; source; detail; retry_after_sec }) ->
+         { cascade_name; source; detail; retry_after }) ->
     Alcotest.(check string)
       "cascade name preserved"
       "tier-group.primary"
@@ -136,6 +136,14 @@ let test_roundtrip_capacity_backpressure () =
       "detail preserved"
       "client capacity key provider_k is full"
       detail;
+    (* a wire value without [retry_after_synthetic] decodes to [Explicit]
+       (legacy default), preserving the seconds *)
+    let retry_after_sec =
+      match retry_after with
+      | Masc_mcp.Cascade_internal_error.Explicit s
+      | Masc_mcp.Cascade_internal_error.Synthetic_default s -> Some s
+      | Masc_mcp.Cascade_internal_error.No_retry_hint -> None
+    in
     Alcotest.(check (option (float 0.001)))
       "retry_after preserved"
       (Some 2.5)

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -41,7 +41,7 @@ let make_capacity_backpressure ?(source = Owne.Client_capacity)
          cascade_name = test_cascade;
          source;
          detail;
-         retry_after_sec = None;
+         retry_after = Masc_mcp.Cascade_internal_error.No_retry_hint;
        })
 
 let make_no_tool_capable () =

--- a/test/test_oas_error_kind_counter.ml
+++ b/test/test_oas_error_kind_counter.ml
@@ -89,7 +89,7 @@ let test_capacity_backpressure_kind () =
            cascade_name = typed_cascade_name cascade_name;
            source = OWN.Client_capacity;
            detail = "client capacity key provider_k is full";
-           retry_after_sec = None;
+           retry_after = Masc_mcp.Cascade_internal_error.No_retry_hint;
          })
   in
   Alcotest.(check (float 0.0001))


### PR DESCRIPTION
## 목표

`Capacity_backpressure` 의 `retry_after_sec : float option` 이 provider Retry-After 와 합성 기본값을 한 타입에 압축(complect)해, PR #19329 가 provider hint 없는 construction 사이트에 `Some synthetic_retry_after_sec` 을 주입할 수 있었습니다. 그러면 FSM 분류기의 `Some s > 0.0 -> Cbr_explicit` 분기를 타게 되어 **합성값이 explicit provider hint 로 세탁**되고, 정직한 `Cbr_synthetic_default` WARN + null 텔레메트리가 침묵되었습니다. (audit 2026-05-29 finding F2)

## 변경

provenance 를 타입으로 승격해 세탁을 표현 불가능하게 만들었습니다:

```ocaml
type capacity_retry_after =
  | Explicit of float          (* provider Retry-After 또는 계산된 실제 local wait *)
  | Synthetic_default of float (* 실제 신호 없을 때의 고정 기본값 *)
  | No_retry_hint
```

- 분류기가 `> 0.0` 추측 대신 provenance 직독 — `Synthetic_default` 는 절대 `Cbr_explicit` 도달 불가
- 텔레메트리: `Explicit`/`Synthetic_default` 모두 초를 emit (backoff 적용 시 null 없음) + `retry_after_synthetic:bool` → #19329 의 non-null 목표를 세탁 없이 달성. JSON round-trip 은 플래그로 provenance 복원 (legacy payload 은 `Explicit` 기본)
- 합성 backoff WARN → INFO 강등 (provider hint 없는 capacity 고갈에서 기대되는 정상 상황)

## 변경 파일 (13)

lib (9):
- carrier + `.mli`: `cascade_internal_error.ml` / `.mli`
- 분류기: `cascade_attempt_fsm_capacity_backpressure.ml`
- consumer: `cascade_attempt_fsm.ml`
- JSON 역직렬화: `cascade_error_from_sdk.ml`
- construction(4) + pending triple + `.mli`: `keeper_turn_driver_backpressure.ml` / `.mli`
- caller: `keeper_turn_driver_try_cascade.ml`
- WARN: `keeper_turn_driver_cascade_health.ml`

test (4):
- `test_cascade_capacity_backpressure_synthetic_backoff.ml` — typed API 마이그레이션 + F2 회귀 가드
- `test_cascade_error_classify_decoder.ml`, `test_keeper_error_classify_recoverable.ml`, `test_oas_error_kind_counter.ml` — carrier 필드명 변경에 따른 collateral 갱신

## 로컬 검증

- 변경 13파일(lib 9 + test 4) 타입 정합: 최신 base `ef7cc708c` 에서 `dune build .` 시 **내 파일/테스트 0 에러** (carrier→classifier→fsm→deserialize→construction→caller 전 체인 컴파일러 검증)
- 회귀 테스트: `Synthetic_default 30.0` 이 serialize/deserialize round-trip 후 `Cbr_synthetic_default 30.0` 로 남고 `Cbr_explicit` 로 세탁 안 됨 단언 (#19329 재발 가드)
- JSON wire 호환: `retry_after_sec` 키 유지(consumer 무영향) + `retry_after_synthetic` 추가(additive) — breaking 아님

## 남은 미검증 (base blocker)

- 최신 `origin/main` 의 잔여 pre-existing 컴파일 에러는 **`lib/dashboard/dashboard_execution.ml` 의 미완 SSOT 마이그레이션(34개 string-first 헬퍼 호출)** 으로, 본 PR 변경분과 무관합니다 (내 13파일 모두 clean).
- 따라서 **테스트 실행(green build)은 그 SSOT 마이그레이션이 main 에 완료된 뒤 rebase 로 가능**합니다. 그 전까지 CI red 예상 → Draft 유지.

## RFC / Workaround

- 변경 파일(`lib/cascade/*`, `lib/keeper/keeper_turn_driver_*`)은 RFC 게이트 대상(credential/sandbox/operator/gh/host_config/hooks/workflow) 아님.
- 본 PR 은 워크어라운드 *제거* 입니다: typed provenance sum 이 `float option` 세탁을 대체 — Workaround Bar §"Fallback Resolution(두 개념을 한 타입에 압축)" 의 근본 수정.

WORKAROUND-WAIVED: 본 PR 은 워크어라운드를 추가하지 않고 PR #19329 의 세탁(float-option provenance 압축)을 typed sum 으로 제거하는 근본 수정임. audit 2026-05-29 finding F2 의 권고 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
