### PR TITLE
fix(dashboard): correct Json_util.get_* arg order in execution helpers (#19415 follow-up)

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -206,7 +206,7 @@ let record_render_phase_timings (t : render_phase_timings_ms) =
 ;;
 
 let assoc_member_if_object key json =
-  Json_util.get_object key json
+  Json_util.get_object json key
 ;;
 
 let existing_keeper_trust_json keeper_json =
@@ -292,7 +292,7 @@ let keeper_runtime_trust_json keeper =
 ;;
 
 let lowercase_json_string key json =
-  Json_util.get_string key json |> Option.map String.lowercase_ascii
+  Json_util.get_string json key |> Option.map String.lowercase_ascii
 ;;
 
 let terminal_reason_json trust = member_assoc "latest_terminal_reason" trust


### PR DESCRIPTION
## 목적

#19423(RFC-0205 Phase 1 facade 복구) 머지 후 표면화된 **#19415의 arg-order 버그** 수정 — main green의 남은 블로커.

#19415("dashboard SSOT — Yojson.Safe.Util → Json_util")가 `dashboard_execution`에 헬퍼 2개를 추가하며 `Json_util.get_object`/`get_string`을 `(key, json)`으로 호출했습니다. 이 함수들은 `(json, key)` 순입니다:

```
let assoc_member_if_object key json = Json_util.get_object key json
let lowercase_json_string  key json = Json_util.get_string key json |> ...
```

facade breakage(RFC-0205 Phase 1)로 lib가 컴파일되지 않아 가려져 있다가, #19423(facade 복구) 머지 후 타입 에러로 표면화됩니다(string key가 `Yojson.Safe.t` 파라미터 자리로 흘러감). `(json, key)`로 swap.

## 검증

- `dune build @check` clean (0 errors).
- `DUNE_CACHE=disabled dune build .` (native link) exit 0.
- 1 file, 2 lines.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
