### PR TITLE
feat(cdal): judge verifies run reached completed terminal state

### DIFF
--- a/lib/cdal/cdal_judge.ml
+++ b/lib/cdal/cdal_judge.ml
@@ -166,6 +166,59 @@ let check_review_requirement (b : Cdal_loader.loaded_bundle) : Cdal_types.check_
 ;;
 
 (* ================================================================ *)
+(* Check 6: Runtime terminal status (completion precondition)       *)
+(* ================================================================ *)
+
+(* A run can only verify-complete its task/goal if it actually reached a
+   [Completed] terminal state. Before this check, judge ran only the four
+   containment checks plus review-requirement, so a [Cancelled]/[Timed_out]/
+   [Errored]/[Context_overflow] run could be judged [Satisfied] as long as
+   the containment checks passed — i.e. an unfinished run could verify task
+   completion. This stays within the [phase1_scoped_runtime_audit] scope:
+   it audits the proof's terminal [result_status], not deliverable
+   correctness (the typed evidence evaluator's job, out of Phase 1A scope). *)
+let check_result_status (b : Cdal_loader.loaded_bundle) : Cdal_types.check_result =
+  let check_id = "runtime.result_status" in
+  let module P = Masc_mcp_cdal_runtime.Cdal_proof in
+  match b.proof.result_status with
+  | P.Completed -> { check_id; status = Satisfied; findings = []; completeness_gaps = [] }
+  | P.Errored ->
+    (* Explicit runtime failure (hook/verifier crash, unexpected error):
+       the run did not complete successfully. *)
+    { check_id
+    ; status = Violated
+    ; findings =
+        [ { Cdal_types.check_id
+          ; event_id = None
+          ; observed = `String (P.result_status_to_string b.proof.result_status)
+          ; expected = `String (P.result_status_to_string P.Completed)
+          ; trace_ref = None
+          }
+        ]
+    ; completeness_gaps = []
+    }
+  | (P.Timed_out | P.Cancelled | P.Context_overflow) as status ->
+    (* Cut short before a completed terminal state (limit exceeded, policy
+       gate stop, or context exhaustion). Completion cannot be confirmed, so
+       the verdict is withheld ([Inconclusive] with a blocking gap) rather
+       than falsely [Satisfied] or falsely [Violated]. *)
+    { check_id
+    ; status = Inconclusive
+    ; findings = []
+    ; completeness_gaps =
+        [ { Cdal_types.artifact = "proof/status.json"
+          ; reason =
+              Printf.sprintf
+                "run terminated as %s, not completed; completion cannot be verified \
+                 from an unfinished run"
+                (P.result_status_to_string status)
+          ; impact = Blocks_verdict
+          }
+        ]
+    }
+;;
+
+(* ================================================================ *)
 (* Verdict derivation                                               *)
 (* ================================================================ *)
 
@@ -208,6 +261,7 @@ let judge (b : Cdal_loader.loaded_bundle) : Cdal_types.contract_verdict =
     ; check_contract_snapshot b
     ; check_required_artifact b
     ; check_review_requirement b
+    ; check_result_status b
     ]
   in
   let status = derive_status checks in

--- a/lib/cdal/cdal_judge.mli
+++ b/lib/cdal/cdal_judge.mli
@@ -1,13 +1,14 @@
-(** Cdal_judge -- Phase 1A contract judge with 5 active checks.
+(** Cdal_judge -- Phase 1A contract judge with 6 active checks.
 
     Evaluates a loaded proof bundle against its contract constraints:
     execution mode propagation and escalation, risk class match,
-    contract snapshot integrity, required artifact presence, and
-    review-requirement bridgeability.
+    contract snapshot integrity, required artifact presence,
+    review-requirement bridgeability, and runtime terminal status
+    (completion precondition).
 
     @since CDAL Phase 1A *)
 
-(** Evaluate all 5 checks and derive run-level verdict. *)
+(** Evaluate all 6 checks and derive run-level verdict. *)
 val judge : Cdal_loader.loaded_bundle -> Cdal_types.contract_verdict
 
 (** {2 Individual checks (exposed for testing)} *)
@@ -28,6 +29,12 @@ val check_required_artifact : Cdal_loader.loaded_bundle -> Cdal_types.check_resu
     Current OAS v1 evidence is warning-only, so review requirements remain
     [Inconclusive] until explicit verification occurs downstream. *)
 val check_review_requirement : Cdal_loader.loaded_bundle -> Cdal_types.check_result
+
+(** Check the proof's terminal [result_status]. Only a [Completed] run can be
+    [Satisfied]; [Errored] is [Violated]; [Timed_out]/[Cancelled]/
+    [Context_overflow] are [Inconclusive] with a blocking gap (completion
+    cannot be verified from an unfinished run). *)
+val check_result_status : Cdal_loader.loaded_bundle -> Cdal_types.check_result
 
 (** {2 Exec-outcome verifiable markers}
 

--- a/test/test_cdal_judge.ml
+++ b/test/test_cdal_judge.ml
@@ -18,6 +18,7 @@ let make_proof
       ?(requested = Masc_mcp_cdal_runtime.Execution_mode.Execute)
       ?(effective = Masc_mcp_cdal_runtime.Execution_mode.Execute)
       ?(risk_class = Masc_mcp_cdal_runtime.Risk_class.Low)
+      ?(result_status = Masc_mcp_cdal_runtime.Cdal_proof.Completed)
       ()
   : Masc_mcp_cdal_runtime.Cdal_proof.t
   =
@@ -40,7 +41,7 @@ let make_proof
   ; tool_trace_refs = []
   ; raw_evidence_refs = []
   ; checkpoint_ref = None
-  ; result_status = Completed
+  ; result_status
   ; started_at = 1000.0
   ; ended_at = 1001.0
   ; scope = None
@@ -75,6 +76,7 @@ let make_bundle
       ?(contract_risk = Masc_mcp_cdal_runtime.Risk_class.Low)
       ?contract_review_requirement
       ?(proof_raw_evidence_refs = [])
+      ?(proof_result_status = Masc_mcp_cdal_runtime.Cdal_proof.Completed)
       ?(contract_id_match = true)
       ()
   : CL.loaded_bundle
@@ -97,6 +99,7 @@ let make_bundle
       ~requested:proof_requested
       ~effective:proof_effective
       ~risk_class:proof_risk
+      ~result_status:proof_result_status
       ()
   in
   let proof = { proof with raw_evidence_refs = proof_raw_evidence_refs } in
@@ -120,7 +123,7 @@ let test_all_satisfied () =
     "satisfied"
     (CT.contract_status_to_string verdict.status);
   Alcotest.(check int) "no findings" 0 (List.length verdict.findings);
-  Alcotest.(check int) "5 check results" 5 (List.length verdict.check_results);
+  Alcotest.(check int) "6 check results" 6 (List.length verdict.check_results);
   List.iter
     (fun (cr : CT.check_result) ->
        Alcotest.(check string)
@@ -361,6 +364,88 @@ let test_findings_populated () =
 ;;
 
 (* ================================================================ *)
+(* test_result_status_completed_satisfied                            *)
+(* ================================================================ *)
+
+let test_result_status_completed_satisfied () =
+  let bundle = make_bundle () in
+  let cr = CJ.check_result_status bundle in
+  Alcotest.(check string) "status" "satisfied" (CT.contract_status_to_string cr.status);
+  Alcotest.(check int) "no findings" 0 (List.length cr.findings);
+  Alcotest.(check int) "no gaps" 0 (List.length cr.completeness_gaps)
+;;
+
+(* ================================================================ *)
+(* test_result_status_errored_violated                               *)
+(* ================================================================ *)
+
+let test_result_status_errored_violated () =
+  let bundle =
+    make_bundle ~proof_result_status:Masc_mcp_cdal_runtime.Cdal_proof.Errored ()
+  in
+  let cr = CJ.check_result_status bundle in
+  Alcotest.(check string) "status" "violated" (CT.contract_status_to_string cr.status);
+  Alcotest.(check int) "1 finding" 1 (List.length cr.findings);
+  let f = List.hd cr.findings in
+  Alcotest.(check string) "finding check_id" "runtime.result_status" f.check_id
+;;
+
+(* ================================================================ *)
+(* test_result_status_cancelled_inconclusive                         *)
+(* ================================================================ *)
+
+let test_result_status_cancelled_inconclusive () =
+  let bundle =
+    make_bundle ~proof_result_status:Masc_mcp_cdal_runtime.Cdal_proof.Cancelled ()
+  in
+  let cr = CJ.check_result_status bundle in
+  Alcotest.(check string)
+    "status"
+    "inconclusive"
+    (CT.contract_status_to_string cr.status);
+  Alcotest.(check int) "1 completeness gap" 1 (List.length cr.completeness_gaps);
+  let gap = List.hd cr.completeness_gaps in
+  Alcotest.(check string)
+    "gap impact"
+    "blocks_verdict"
+    (CT.completeness_impact_to_string gap.impact)
+;;
+
+(* ================================================================ *)
+(* test_verdict_incomplete_run_not_satisfied                         *)
+(* ================================================================ *)
+
+let test_verdict_incomplete_run_not_satisfied () =
+  (* All containment checks pass, but the run did not complete (Timed_out) —
+     the overall verdict must NOT be Satisfied; it is withheld as
+     Inconclusive. This is the gap the result_status check closes: an
+     unfinished run could previously verify task/goal completion. *)
+  let bundle =
+    make_bundle ~proof_result_status:Masc_mcp_cdal_runtime.Cdal_proof.Timed_out ()
+  in
+  let verdict = CJ.judge bundle in
+  Alcotest.(check string)
+    "status"
+    "inconclusive"
+    (CT.contract_status_to_string verdict.status)
+;;
+
+(* ================================================================ *)
+(* test_verdict_errored_run_violated                                 *)
+(* ================================================================ *)
+
+let test_verdict_errored_run_violated () =
+  let bundle =
+    make_bundle ~proof_result_status:Masc_mcp_cdal_runtime.Cdal_proof.Errored ()
+  in
+  let verdict = CJ.judge bundle in
+  Alcotest.(check string)
+    "status"
+    "violated"
+    (CT.contract_status_to_string verdict.status)
+;;
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -394,6 +479,18 @@ let () =
             "review requirement warning only"
             `Quick
             test_review_requirement_inconclusive_warning_only
+        ; Alcotest.test_case
+            "result_status completed satisfied"
+            `Quick
+            test_result_status_completed_satisfied
+        ; Alcotest.test_case
+            "result_status errored violated"
+            `Quick
+            test_result_status_errored_violated
+        ; Alcotest.test_case
+            "result_status cancelled inconclusive"
+            `Quick
+            test_result_status_cancelled_inconclusive
         ] )
     ; ( "verdict"
       , [ Alcotest.test_case "violated wins" `Quick test_verdict_priority_violated_wins
@@ -402,6 +499,14 @@ let () =
         ; Alcotest.test_case "loader metadata set" `Quick test_loader_metadata_set
         ; Alcotest.test_case "replay determinism" `Quick test_replay_determinism
         ; Alcotest.test_case "findings populated" `Quick test_findings_populated
+        ; Alcotest.test_case
+            "incomplete run not satisfied"
+            `Quick
+            test_verdict_incomplete_run_not_satisfied
+        ; Alcotest.test_case
+            "errored run violated"
+            `Quick
+            test_verdict_errored_run_violated
         ] )
     ]
 ;;


### PR DESCRIPTION
## 무엇

`Cdal_judge`(CDAL의 Task/Goal 검증 함수)에 **runtime terminal status 검증**을 추가합니다 — check 6 `runtime.result_status`.

## 왜

judge는 4개 containment check(`execution_mode` / `risk_class` / `contract_snapshot` / `required_artifact`) + `review_requirement`만 돌았고, **proof의 `result_status`를 보는 check가 없었습니다.** 결과:

> `result_status`가 `Errored` / `Timed_out` / `Cancelled` / `Context_overflow`인 run도 containment check만 통과하면 `Satisfied`로 판정될 수 있었음 — **완료되지 않은 run이 Task/Goal 완료를 verify하는 구멍.**

CDAL의 정의는 "Task/Goal이 *증거로* verified 됐나"입니다. 취소·타임아웃·에러로 끝난 run으로는 완료를 verify할 수 없습니다.

## 어떻게

`check_result_status` — `result_status` 5변형에 대한 exhaustive match (`_ ->` catch-all 없음 → 새 status 추가 시 컴파일러가 강제):

| result_status | verdict | 근거 |
|---|---|---|
| `Completed` | Satisfied | 완료 종료 도달 |
| `Errored` | Violated | 명시적 런타임 실패(hook/verifier crash) |
| `Timed_out` / `Cancelled` / `Context_overflow` | Inconclusive + `Blocks_verdict` gap | 완료 확인 불가 — 거짓 Satisfied/Violated 대신 verdict 보류 |

**스코프**: verdict의 `claim_scope = "phase1_scoped_runtime_audit"` 안에 머뭅니다 — proof의 terminal status를 audit할 뿐, deliverable 정확성(typed evidence evaluator, Phase 1A 범위 밖)은 판정하지 않습니다. presence-only theatre 아님 — "run이 완료 종료에 도달했는지"는 실제 완료 전제조건입니다.

## 테스트

- check-level 3: `completed→satisfied` / `errored→violated`(+finding) / `cancelled→inconclusive`(+blocking gap)
- verdict-level 2: **미완료(Timed_out) run은 전체 verdict가 Satisfied 아님 — Inconclusive로 보류** / errored run은 Violated
- `test_all_satisfied` check 수 5→6 갱신

## 검증 상태 (정직)

- ✅ `dune build lib/cdal/` **EXIT=0** — 구현이 `lib/cdal`에서 isolation 컴파일됨(broken 모듈과 독립).
- ⏳ **테스트 실행은 broken main에 막힘**: `test_cdal_judge.exe`가 monolithic `masc_mcp` lib 전체를 링크하는데, 현재 origin/main이 keeper/dashboard SSOT-consolidation 잔해로 9 에러 빌드 실패(`Unbound value json_int_opt` 등). 본 변경과 무관. **main green 시 즉시 실행 가능.**

Draft 유지 — main green 후 테스트 실행 + Ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
