### PR TITLE
chore(deps): remove duplicate websocket dependency in dune-project

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -72,7 +72,6 @@
   (httpun-eio (>= 0.2))
   (httpun-ws (>= 0.2))
   (httpun-ws-eio (>= 0.2))
-  (websocket (>= 2.17))
   (bigstringaf (>= 0.10))
   (eio (>= 1.0))
   (eio_main (>= 1.0))


### PR DESCRIPTION
## 목적
`dune-project`의 `depends` 필드에 `(websocket (>= 2.17))`가 **두 번**(line 46 cohttp 그룹, line 75 httpun-ws 그룹) 선언되어 매 빌드마다 `Warning: Duplicate dependency on package (websocket (>= 2.17))`가 출력되었습니다.

## 변경
- 중복된 httpun-ws 그룹의 line 75 항목 제거 (1줄 삭제)
- cohttp 그룹의 line 46 항목 유지 — `websocket` OCaml 패키지는 cohttp 기반 ws 라이브러리이므로 의미상 cohttp 그룹이 자연스러운 자리

## 검증
- `DUNE_CACHE=disabled dune build dune-project --root .` → duplicate 경고 사라짐 확인
- origin/main(52c01fdb6) base에서 작업, base는 `dune build @check` 에러 0개(green) 확인됨
- 빌드 동작 변화 없음 (동일 패키지 의존 1회 선언으로 정리, 버전 제약 동일)

## 배경
broken-main 복구 세션(`#19423`/`#19425`/`#19426`/`#19427`)에서 식별된 잔여 cleanup 항목. 같은 세션의 PR #19428(keeper_meta_contract drift)은 main이 이미 다른 경로로 해결하여 close 처리했고, 본 cleanup만 분리했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)