### PR TITLE
feat(cdal): judge enforces contract tool-denylist against captured tools

### DIFF
--- a/lib/cdal/cdal_judge.ml
+++ b/lib/cdal/cdal_judge.ml
@@ -219,6 +219,58 @@ let check_result_status (b : Cdal_loader.loaded_bundle) : Cdal_types.check_resul
 ;;
 
 (* ================================================================ *)
+(* Check 7: Contract tool-denylist containment (eval_criteria)      *)
+(* ================================================================ *)
+
+(* First consumer of [contract.eval_criteria] in the judge. [risk_contract.mli]
+   documents eval_criteria as "carried to the proof bundle and consumed", but
+   judge ignored it entirely — only [Keeper_turn_capture_v1] (the producer for
+   keeper turns, via [Keeper_cdal_contract.of_keeper_meta]) declares a
+   [tool_denylist], so this audits the declared denylist against the captured
+   capability set: a tool the contract DENIED must not appear in the run's
+   captured [capability_snapshot.tools].
+
+   Deterministic and conservative — exact string membership, so a vocabulary
+   mismatch only ever under-detects (no false [Violated]). The other criteria
+   kinds declare no tool denylist ([Verification_request] has no producer yet,
+   [Persona_probe] is deferred, [Contract_catalog_invariants] carries prose
+   invariants, [Free] is the migration escape), so there is nothing to enforce
+   for them here. Exhaustive match — a new criteria variant must be classified. *)
+let check_eval_criteria_tool_denylist (b : Cdal_loader.loaded_bundle)
+  : Cdal_types.check_result
+  =
+  let check_id = "runtime.tool_denylist" in
+  let module C = Masc_mcp_cdal_runtime.Criteria in
+  match b.contract.eval_criteria with
+  | C.Keeper_turn_capture_v1 { tool_denylist; _ } ->
+    let captured = b.proof.capability_snapshot.tools in
+    let present = List.filter (fun denied -> List.mem denied captured) tool_denylist in
+    (match present with
+     | [] -> { check_id; status = Satisfied; findings = []; completeness_gaps = [] }
+     | _ ->
+       { check_id
+       ; status = Violated
+       ; findings =
+           List.map
+             (fun denied : Cdal_types.contract_finding ->
+                { check_id
+                ; event_id = Some "denied_tool_captured"
+                ; observed = `String denied
+                ; expected = `String "absent (contract tool_denylist)"
+                ; trace_ref = None
+                })
+             present
+       ; completeness_gaps = []
+       })
+  | C.Contract_catalog_invariants _
+  | C.Verification_request _
+  | C.Persona_probe _
+  | C.Free _ ->
+    (* No tool denylist declared by these criteria kinds — nothing to enforce. *)
+    { check_id; status = Satisfied; findings = []; completeness_gaps = [] }
+;;
+
+(* ================================================================ *)
 (* Verdict derivation                                               *)
 (* ================================================================ *)
 
@@ -262,6 +314,7 @@ let judge (b : Cdal_loader.loaded_bundle) : Cdal_types.contract_verdict =
     ; check_required_artifact b
     ; check_review_requirement b
     ; check_result_status b
+    ; check_eval_criteria_tool_denylist b
     ]
   in
   let status = derive_status checks in

--- a/lib/cdal/cdal_judge.mli
+++ b/lib/cdal/cdal_judge.mli
@@ -1,14 +1,14 @@
-(** Cdal_judge -- Phase 1A contract judge with 6 active checks.
+(** Cdal_judge -- Phase 1A contract judge with 7 active checks.
 
     Evaluates a loaded proof bundle against its contract constraints:
     execution mode propagation and escalation, risk class match,
     contract snapshot integrity, required artifact presence,
-    review-requirement bridgeability, and runtime terminal status
-    (completion precondition).
+    review-requirement bridgeability, runtime terminal status
+    (completion precondition), and contract tool-denylist containment.
 
     @since CDAL Phase 1A *)
 
-(** Evaluate all 6 checks and derive run-level verdict. *)
+(** Evaluate all 7 checks and derive run-level verdict. *)
 val judge : Cdal_loader.loaded_bundle -> Cdal_types.contract_verdict
 
 (** {2 Individual checks (exposed for testing)} *)
@@ -35,6 +35,15 @@ val check_review_requirement : Cdal_loader.loaded_bundle -> Cdal_types.check_res
     [Context_overflow] are [Inconclusive] with a blocking gap (completion
     cannot be verified from an unfinished run). *)
 val check_result_status : Cdal_loader.loaded_bundle -> Cdal_types.check_result
+
+(** Check contract tool-denylist containment. First consumer of
+    [contract.eval_criteria]: when the criteria is [Keeper_turn_capture_v1],
+    a tool in its [tool_denylist] that also appears in the proof's captured
+    [capability_snapshot.tools] yields [Violated]; otherwise [Satisfied].
+    Other criteria kinds declare no tool denylist and are [Satisfied]. *)
+val check_eval_criteria_tool_denylist
+  :  Cdal_loader.loaded_bundle
+  -> Cdal_types.check_result
 
 (** {2 Exec-outcome verifiable markers}
 

--- a/test/test_cdal_judge.ml
+++ b/test/test_cdal_judge.ml
@@ -19,6 +19,7 @@ let make_proof
       ?(effective = Masc_mcp_cdal_runtime.Execution_mode.Execute)
       ?(risk_class = Masc_mcp_cdal_runtime.Risk_class.Low)
       ?(result_status = Masc_mcp_cdal_runtime.Cdal_proof.Completed)
+      ?(capability_tools = [ "read"; "write" ])
       ()
   : Masc_mcp_cdal_runtime.Cdal_proof.t
   =
@@ -32,7 +33,7 @@ let make_proof
   ; provider_snapshot =
       { provider_name = "test"; model_id = "test-model"; api_version = None }
   ; capability_snapshot =
-      { tools = [ "read"; "write" ]
+      { tools = capability_tools
       ; mcp_servers = []
       ; max_turns = 10
       ; max_tokens = Some 4096
@@ -48,10 +49,16 @@ let make_proof
   }
 ;;
 
+let default_eval_criteria =
+  Masc_mcp_cdal_runtime.Criteria.Free
+    (`Assoc [ "success_criteria", `List [ `String "tests pass" ] ])
+;;
+
 let make_contract
       ?(requested = Masc_mcp_cdal_runtime.Execution_mode.Execute)
       ?(risk_class = Masc_mcp_cdal_runtime.Risk_class.Low)
       ?review_requirement
+      ?(eval_criteria = default_eval_criteria)
       ()
   : Masc_mcp_cdal_runtime.Risk_contract.t
   =
@@ -61,9 +68,7 @@ let make_contract
       ; allowed_mutations = [ "tool_edit_file" ]
       ; review_requirement
       }
-  ; eval_criteria =
-      Masc_mcp_cdal_runtime.Criteria.Free
-        (`Assoc [ "success_criteria", `List [ `String "tests pass" ] ])
+  ; eval_criteria
   }
 ;;
 
@@ -77,6 +82,8 @@ let make_bundle
       ?contract_review_requirement
       ?(proof_raw_evidence_refs = [])
       ?(proof_result_status = Masc_mcp_cdal_runtime.Cdal_proof.Completed)
+      ?(proof_capability_tools = [ "read"; "write" ])
+      ?(eval_criteria = default_eval_criteria)
       ?(contract_id_match = true)
       ()
   : CL.loaded_bundle
@@ -86,6 +93,7 @@ let make_bundle
       ~requested:contract_requested
       ~risk_class:contract_risk
       ?review_requirement:contract_review_requirement
+      ~eval_criteria
       ()
   in
   let recomputed_contract_id = Masc_mcp_cdal_runtime.Risk_contract.contract_id contract in
@@ -100,6 +108,7 @@ let make_bundle
       ~effective:proof_effective
       ~risk_class:proof_risk
       ~result_status:proof_result_status
+      ~capability_tools:proof_capability_tools
       ()
   in
   let proof = { proof with raw_evidence_refs = proof_raw_evidence_refs } in
@@ -123,7 +132,7 @@ let test_all_satisfied () =
     "satisfied"
     (CT.contract_status_to_string verdict.status);
   Alcotest.(check int) "no findings" 0 (List.length verdict.findings);
-  Alcotest.(check int) "6 check results" 6 (List.length verdict.check_results);
+  Alcotest.(check int) "7 check results" 7 (List.length verdict.check_results);
   List.iter
     (fun (cr : CT.check_result) ->
        Alcotest.(check string)
@@ -446,6 +455,73 @@ let test_verdict_errored_run_violated () =
 ;;
 
 (* ================================================================ *)
+(* eval_criteria tool-denylist containment (check 7)                 *)
+(* ================================================================ *)
+
+let keeper_capture_criteria ?(tool_denylist = []) () : Masc_mcp_cdal_runtime.Criteria.t =
+  Masc_mcp_cdal_runtime.Criteria.Keeper_turn_capture_v1
+    { keeper_name = "k1"
+    ; agent_name = "a1"
+    ; sandbox_profile = "default"
+    ; sandbox_image = None
+    ; network_mode = "none"
+    ; tool_access = `Null
+    ; tool_denylist
+    ; allowed_paths = []
+    ; active_goal_ids = []
+    ; current_task_id = None
+    }
+;;
+
+let test_tool_denylist_violation () =
+  (* Contract denies "danger_tool" but the run captured it as available. *)
+  let bundle =
+    make_bundle
+      ~eval_criteria:(keeper_capture_criteria ~tool_denylist:[ "danger_tool" ] ())
+      ~proof_capability_tools:[ "read"; "danger_tool" ]
+      ()
+  in
+  let cr = CJ.check_eval_criteria_tool_denylist bundle in
+  Alcotest.(check string) "status" "violated" (CT.contract_status_to_string cr.status);
+  Alcotest.(check int) "1 finding" 1 (List.length cr.findings);
+  let f = List.hd cr.findings in
+  Alcotest.(check string) "finding check_id" "runtime.tool_denylist" f.check_id
+;;
+
+let test_tool_denylist_no_intersection_satisfied () =
+  let bundle =
+    make_bundle
+      ~eval_criteria:(keeper_capture_criteria ~tool_denylist:[ "danger_tool" ] ())
+      ~proof_capability_tools:[ "read"; "write" ]
+      ()
+  in
+  let cr = CJ.check_eval_criteria_tool_denylist bundle in
+  Alcotest.(check string) "status" "satisfied" (CT.contract_status_to_string cr.status);
+  Alcotest.(check int) "no findings" 0 (List.length cr.findings)
+;;
+
+let test_tool_denylist_non_keeper_criteria_satisfied () =
+  (* Free criteria (default) declares no denylist -> nothing to enforce. *)
+  let bundle = make_bundle () in
+  let cr = CJ.check_eval_criteria_tool_denylist bundle in
+  Alcotest.(check string) "status" "satisfied" (CT.contract_status_to_string cr.status)
+;;
+
+let test_verdict_tool_denylist_violation_wins () =
+  let bundle =
+    make_bundle
+      ~eval_criteria:(keeper_capture_criteria ~tool_denylist:[ "danger_tool" ] ())
+      ~proof_capability_tools:[ "danger_tool" ]
+      ()
+  in
+  let verdict = CJ.judge bundle in
+  Alcotest.(check string)
+    "status"
+    "violated"
+    (CT.contract_status_to_string verdict.status)
+;;
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -491,6 +567,18 @@ let () =
             "result_status cancelled inconclusive"
             `Quick
             test_result_status_cancelled_inconclusive
+        ; Alcotest.test_case
+            "tool denylist violation"
+            `Quick
+            test_tool_denylist_violation
+        ; Alcotest.test_case
+            "tool denylist no intersection satisfied"
+            `Quick
+            test_tool_denylist_no_intersection_satisfied
+        ; Alcotest.test_case
+            "tool denylist non-keeper criteria satisfied"
+            `Quick
+            test_tool_denylist_non_keeper_criteria_satisfied
         ] )
     ; ( "verdict"
       , [ Alcotest.test_case "violated wins" `Quick test_verdict_priority_violated_wins
@@ -507,6 +595,10 @@ let () =
             "errored run violated"
             `Quick
             test_verdict_errored_run_violated
+        ; Alcotest.test_case
+            "tool denylist violation wins"
+            `Quick
+            test_verdict_tool_denylist_violation_wins
         ] )
     ]
 ;;


### PR DESCRIPTION
## 무엇

`Cdal_judge`에 **contract tool-denylist 검증**을 추가합니다 — check 7 `runtime.tool_denylist`, **judge의 첫 `eval_criteria` 소비자**.

## 왜

`risk_contract.mli:7`은 `eval_criteria`를 "carried to the proof bundle **and consumed**"라 명시하지만 **judge는 `eval_criteria`를 전혀 안 읽었습니다**(carrier-vs-consumer drift). #19429(result_status)와 동일 계열의 구멍.

## 어떻게

typed criteria 중 `tool_denylist`를 선언하는 건 `Keeper_turn_capture_v1`(keeper turn마다 `Keeper_cdal_contract.of_keeper_meta`가 생성)뿐. `check_eval_criteria_tool_denylist`가 그 **declared denylist를 proof의 captured `capability_snapshot.tools`와 대조**:

| 조건 | verdict |
|---|---|
| 계약이 deny한 도구가 captured tool set에 존재 | **Violated** (finding: 어떤 도구인지) |
| 교집합 없음 / 빈 denylist | Satisfied |
| denylist 없는 criteria kind (`Verification_request`·`Persona_probe`·`Contract_catalog_invariants`·`Free`) | Satisfied (강제할 것 없음) |

- **결정론적·conservative**: 정확 문자열 membership → vocabulary mismatch 시 under-detect만(false Violated 없음).
- **exhaustive match**(`Criteria.t` 5변형, `_->` 없음) → 새 criteria 추가 시 컴파일러가 분류 강제.
- 스코프: `runtime.*`(declared denylist vs captured capability = runtime containment audit).

## 테스트

- check-level 3: `violation`(denied 도구 captured→Violated+finding) / `no-intersection`(Satisfied) / `non-keeper criteria`(Satisfied)
- verdict-level 1: denylist violation → 전체 verdict Violated
- `test_all_satisfied` check 수 6→7

## 검증

- ✅ `dune build lib/cdal/` **EXIT=0**
- ✅ `test/test_cdal_judge.exe` **23/23 pass** (main이 이제 빌드돼 전체 suite 실행 — #19429 테스트도 함께 green 재확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
