### PR TITLE
chore(cleanup): cascade 관련 tier 개념 제거

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -152,7 +152,7 @@ val sdk_error_capacity_backpressure_source :
   Cascade_error_classify.capacity_backpressure_source option
 (** [Some source] when the error classifies as a MASC-internal
     [Capacity_backpressure].  Callers use this to keep provider-owned
-    capacity failures separate from client/tier/cascade-slot backpressure
+    capacity failures separate from client/cascade-slot backpressure
     when projecting provider health. *)
 
 val sdk_error_capacity_backpressure_retry_hint :

--- a/lib/cascade/cascade_capacity_probe.mli
+++ b/lib/cascade/cascade_capacity_probe.mli
@@ -47,7 +47,7 @@ val can_probe : url:string -> bool
     recognises [url].  Pure: no IO. *)
 val cached : url:string -> ?now:float -> unit -> Cascade_throttle.capacity_info option
 
-(** [capacity url] is the 3-tier resolution chain:
+(** [capacity url] is the 3-level resolution chain:
     [Cascade_throttle] → registered probes' cache →
     [Cascade_client_capacity].  Identical semantics to the previous
     per-caller hardcoded chain. *)

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -67,7 +67,7 @@ type weighted_entry = {
 }
 
 (** Deprecated logical route keys must not be treated as concrete catalog
-    profiles. Qualified names such as ["tier.local_only"] are checked by their
+    profiles. Qualified names such as ["cascade.local_only"] are checked by their
     raw profile suffix. *)
 val is_deprecated_logical_profile_name : string -> bool
 

--- a/lib/cascade/cascade_declarative_hotpath.mli
+++ b/lib/cascade/cascade_declarative_hotpath.mli
@@ -70,7 +70,7 @@ type partial_load_result = {
 (** Result of a partial catalog load. [snapshot] always contains the
     subset of profiles whose internal cross-references resolved
     successfully. [errors] lists per-entry failures (unresolved
-    provider/model/binding/tier). [errors = []] is the all-clean case.
+    provider/model/binding). [errors = []] is the all-clean case.
 
     Surfacing both fields at the same time lets downstream callers (notably
     keeper toml validation) accept the valid subset while logging the

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -184,7 +184,7 @@ val record_failure :
     Prior to 0.160.0 this path called {!record_success} (the response
     technically arrived), which silently masked gate drift: a provider
     could rank 100% healthy while every call fell through to the next
-    cascade tier.
+    cascade.
 
     See {!record_failure} for [error_kind] / [error_reason] semantics.
 

--- a/lib/cascade/cascade_internal_error.mli
+++ b/lib/cascade/cascade_internal_error.mli
@@ -31,7 +31,7 @@ type provider_rejection = {
 (** {1 Capacity backpressure source}
 
     Names the system component that issued the backpressure signal.  Used by
-    operators and dashboards to attribute saturation to a specific tier. *)
+    operators and dashboards to attribute saturation to a specific cascade. *)
 
 type capacity_backpressure_source =
   | Provider_capacity

--- a/lib/cascade/cascade_routes.ml
+++ b/lib/cascade/cascade_routes.ml
@@ -110,7 +110,7 @@ let logical_use_of_string_opt raw =
              if String.equal normalized spec.key then Some spec.use else None)
 
 (* RFC-0058 v2 route encoding in the materialized JSON:
-   {"routes": {"X": {"target": "tier-..."}}}.
+   {"routes": {"X": {"target": "provider:model"}}}.
    The TOML materializer passes [routes.X] sub-tables through verbatim,
    so this consumer extracts the [target] field. *)
 let target_of_route_value : Yojson.Safe.t -> string option = function

--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -725,7 +725,7 @@ let run
         ~total_duration_ms:run_total_duration_ms
         ~status:(Dashboard_oas_bridge.Error { transient = false })
         error_response;
-      (* Demoted from WARN to DEBUG (task-239): this fires once per tier,
+      (* Demoted from WARN to DEBUG (task-239): this fires once per cascade,
          but a cascade caller (Keeper_turn_driver.run_named) retries on the
          next provider.  Emitting WARN/ERROR here creates noise on
          recovered cascades.  The cascade layer logs [cascade-fallback] at

--- a/lib/cascade/cascade_saturation_signal.ml
+++ b/lib/cascade/cascade_saturation_signal.ml
@@ -1,4 +1,4 @@
-(** Cascade_saturation_signal — Typed signal for tier saturation events.
+(** Cascade_saturation_signal — Typed signal for cascade saturation events.
 
     RFC-0153 Phase A.1. See .mli for full documentation.
 

--- a/lib/cascade/cascade_saturation_signal.mli
+++ b/lib/cascade/cascade_saturation_signal.mli
@@ -1,8 +1,8 @@
-(** Cascade_saturation_signal — Typed signal for tier saturation events.
+(** Cascade_saturation_signal — Typed signal for cascade saturation events.
 
     Phase A.1 of RFC-0153 (Cascade Backpressure & Tier Admission).
 
-    이 모듈은 cascade tier 가 "saturated" 상태일 때 caller 에게 전달되는
+    이 모듈은 cascade 가 "saturated" 상태일 때 caller 에게 전달되는
     typed signal 을 정의한다. 종전의 hard timer kill / "cascade exhausted"
     string 경로를 대체하는 *추가-only* 신호 채널.
 
@@ -12,7 +12,7 @@
     - caller (예: keeper_turn_driver) 가 남은 turn deadline + signal 종류
       를 보고 retry / wait / fail 을 결정.
     - Phase A.1 단독으로는 *동작 변경 없음*. Phase A.2 (caller dispatch),
-      Phase B (tier admission), Phase C (adaptive throttle) 가 본 signal
+      Phase B (cascade admission), Phase C (adaptive throttle) 가 본 signal
       을 입력으로 받음.
 
     외부 검증:

--- a/lib/cascade/cascade_strategy.mli
+++ b/lib/cascade/cascade_strategy.mli
@@ -159,7 +159,7 @@ val order_candidates :
     against the same saturated key.
 
     This function is pure and must not perform IO.  [cycle] is accepted
-    for call-site stability but no longer selects a tier (failover is
+    for call-site stability but no longer selects a cascade (failover is
     cycle-independent; health and capacity signals are re-read each
     cycle). *)
 

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -100,16 +100,6 @@ let all_flags : flag list = [
     default = true; category = "keeper";
     lifecycle = Active; since = "2.163.0" };
 
-  { env_name = "MASC_CASCADE_TIER_ADMISSION_ENABLED";
-    description = "Enforce per-tier cascade inflight admission before provider dispatch";
-    default = true; category = "keeper";
-    lifecycle = Active; since = "2.243.0" };
-
-  { env_name = "MASC_CASCADE_TIER_WAIT_ENABLED";
-    description = "Wait with bounded backoff when per-tier cascade admission is saturated";
-    default = false; category = "keeper";
-    lifecycle = Active; since = "0.19.30" };
-
   { env_name = "MASC_KEEPER_ALERT_ENABLED";
     description = "Master switch for keeper interesting alert detection";
     default = true; category = "keeper";

--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -11,7 +11,7 @@ type health_status =
 
 type runtime_pressure_class =
   | Client_capacity_full
-  | Tier_admission_full
+  | Cascade_admission_full
   | Provider_capacity
   | Provider_dns_failure
   | Provider_timeout
@@ -23,7 +23,7 @@ type runtime_pressure_class =
 
 let runtime_pressure_class_to_string = function
   | Client_capacity_full -> "client_capacity_full"
-  | Tier_admission_full -> "admission_full"
+  | Cascade_admission_full -> "admission_full"
   | Provider_capacity -> "provider_capacity"
   | Provider_dns_failure -> "provider_dns_failure"
   | Provider_timeout -> "provider_timeout"
@@ -37,7 +37,7 @@ let runtime_pressure_class_to_string = function
 let runtime_pressure_class_of_label label =
   match label |> String.trim |> String.lowercase_ascii with
   | "client_capacity_full" | "client_capacity" -> Some Client_capacity_full
-  | "admission_full" | "admission_capacity" -> Some Tier_admission_full
+  | "admission_full" | "admission_capacity" -> Some Cascade_admission_full
   | "provider_capacity" | "provider_capacity_full" | "capacity_backpressure" ->
     Some Provider_capacity
   | "provider_dns_failure" | "provider_dns" -> Some Provider_dns_failure
@@ -72,7 +72,7 @@ let provider_runtime_pressure_class ~code ~detail ~http_status ~cascade_name =
     || contains "inflight_capacity_full"
     || Option.is_some cascade_name
     || contains "admission="
-  then Tier_admission_full
+  then Cascade_admission_full
   else if
     contains "capacity_backpressure"
     || contains "capacity exhausted"

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -18,7 +18,7 @@ type health_status =
     persisted into skip observations and surfaced in fleet diagnostics. *)
 type runtime_pressure_class =
   | Client_capacity_full
-  | Tier_admission_full
+  | Cascade_admission_full
   | Provider_capacity
   | Provider_dns_failure
   | Provider_timeout

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -108,7 +108,7 @@ let with_temp_cascade_toml body f =
 let test_cascade_output_cap_not_context_window () =
   (* RFC-0058: ceilings resolve a concrete binding/alias key (route/profile
      ceiling resolution was removed with the tier concept). The narrowest
-     member of the former [tier.primary] is the [remote.long] binding. *)
+     member of the former [cascade.primary] is the [remote.long] binding. *)
   let cascade_name = Cascade_name.of_string_exn "remote.long" in
   with_temp_cascade_toml
     {|
@@ -142,7 +142,7 @@ target = "remote.long"
 
 let test_public_cap_helper_clamps_caller_override_to_cascade_ceiling () =
   (* RFC-0058: ceiling resolves the concrete [remote.narrow] binding key
-     (former sole member of [tier.primary]). *)
+     (former sole member of [cascade.primary]). *)
   let cascade_name = Cascade_name.of_string_exn "remote.narrow" in
   with_temp_cascade_toml
     {|
@@ -183,7 +183,7 @@ target = "remote.narrow"
 
 let test_resolve_max_tokens_caps_automatic_value_to_cascade_ceiling () =
   (* RFC-0058: ceilings resolve a concrete member key. The narrowest former
-     [tier.strict_tool_candidates] member is the provider_c alias, whose model
+     [cascade.strict_tool_candidates] member is the provider_c alias, whose model
      capability (16384) caps the alias [max-output] (64000). *)
   let cascade_name =
     Cascade_name.of_string_exn "cli_tool_c.provider_c-cli-coding.tool_candidate"

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -639,7 +639,7 @@ let test_soft_rate_limit_records_fingerprint () =
   let t = H.create () in
   H.record_soft_rate_limited t ~provider_key:"agent_llm_a-cli"
     ~error_kind:(kind "http_429")
-    ~error_reason:"rate limit exceeded for tier" ();
+    ~error_reason:"rate limit exceeded for cascade" ();
   let info = info_or_fail t ~provider_key:"agent_llm_a-cli" in
   match info.top_fingerprints with
   | [ (fp, count) ] ->

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -86,7 +86,7 @@ streaming = true
 is-default = true
 max-concurrent = 1
 
-[tier.primary]
+[cascade.primary]
 members = ["ollama.provider_h"]
 strategy = "failover"
 

--- a/test/test_config_doctor.ml
+++ b/test/test_config_doctor.ml
@@ -62,7 +62,7 @@ tools-support = true
 is-default = true
 max-concurrent = 1
 
-[tier.primary_profile]
+[cascade.primary_profile]
 members = ["ollama.qwen3"]
 strategy = "failover"
 
@@ -316,7 +316,7 @@ supports-response-format-json = true
 is-default = true
 max-concurrent = 1
 
-[tier.provider_k-coding-primary]
+[cascade.provider_k-coding-primary]
 members = ["cli_tool_a.agent_code-spark"]
 strategy = "failover"
 
@@ -408,7 +408,7 @@ supports-response-format-json = true
 is-default = true
 max-concurrent = 1
 
-[tier.provider_k-coding-primary]
+[cascade.provider_k-coding-primary]
 members = ["provider_k-coding.provider_k-5-1"]
 strategy = "failover"
 
@@ -490,7 +490,7 @@ supports-response-format-json = true
 is-default = true
 max-concurrent = 1
 
-[tier.agent_code-primary]
+[cascade.agent_code-primary]
 members = ["cli_tool_a.agent_code-spark"]
 strategy = "failover"
 

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -338,7 +338,7 @@ let cascade_toml ?(route_target = "default") ?(extra_route_targets = [])
   let profile_toml ~valid name =
     Printf.sprintf
       {|
-[tier.%s]
+[cascade.%s]
 members = [%S]
 
 [cascade.%s]
@@ -1332,10 +1332,10 @@ tools-support = true
 
 [custom.mock]
 
-[tier.primary]
+[cascade.primary]
 members = ["missing_provider.fake"]
 
-[tier.good]
+[cascade.good]
 members = ["custom.mock"]
 
 [cascade.primary]

--- a/test/test_keeper_cascade_profile_partial.ml
+++ b/test/test_keeper_cascade_profile_partial.ml
@@ -47,7 +47,7 @@ tools-support = true
 
 [ollama.qwen3]
 
-[tier.local]
+[cascade.local]
 members = ["ollama.qwen3"]
 strategy = "failover"
 

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -226,10 +226,10 @@ let test_rotation_skips_direct_tier_after_attempted_cascade () =
   | Some retry ->
     check
       string
-      "skip direct tier duplicate"
+      "skip direct cascade duplicate"
       "cascade.provider_k-coding-with-spark"
       retry.next_cascade
-  | None -> fail "Expected rotation to skip duplicate direct tier candidate"
+  | None -> fail "Expected rotation to skip duplicate direct cascade candidate"
 
 let test_required_tool_rotation_prioritizes_tool_route_before_fallback_hint () =
   let err =
@@ -551,7 +551,7 @@ let () =
         [
           test_case "catalog order is not prefixed by base cascade" `Quick
             test_catalog_rotation_preserves_order_without_base_injection;
-          test_case "skips direct tier after attempted cascade" `Quick
+          test_case "skips direct cascade after attempted cascade" `Quick
             test_rotation_skips_direct_tier_after_attempted_cascade;
           test_case "required-tool rotation prefers tool route before fallback hint" `Quick
             test_required_tool_rotation_prioritizes_tool_route_before_fallback_hint;
@@ -564,7 +564,7 @@ let () =
         ] );
       ( "normalized_cascade_name_bare_requalify",
         [
-          (* #19327: "bare tier name requalified with prefix" test removed. *)
+          (* #19327: "bare cascade name requalified with prefix" test removed. *)
           test_case "already-qualified name passes through" `Quick
             test_normalized_cascade_name_passes_through_already_qualified;
           test_case "config special names preserved" `Quick

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -79,12 +79,12 @@ let test_runtime_pressure_classifier () =
           }));
   Alcotest.check
     pressure_label_t
-    "tier admission"
+    "cascade admission"
     (Some "tier_admission_full")
     (pressure_label_of_failure_reason
        (R.Provider_runtime_error
           { code = "capacity_backpressure"
-          ; detail = "inflight_capacity_full tier=strict_tool_candidates"
+          ; detail = "inflight_capacity_full admission_key=strict_tool_candidates"
           ; provider_id = None
           ; http_status = None
           ; cascade_name = None

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -72,7 +72,7 @@ tools-support = true
 
 [custom.mock]
 
-[tier.primary]
+[cascade.primary]
 members = ["custom.mock"]
 
 [cascade.primary]

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -97,7 +97,7 @@ tools-support = true
 
 [custom.mock]
 
-[tier.primary]
+[cascade.primary]
 members = ["custom.mock"]
 
 [cascade.primary]

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -50,7 +50,7 @@ streaming = false
 [runtime_mock.%s]
 max-concurrent = 1
 
-[tier.%s_primary]
+[cascade.%s_primary]
 members = ["runtime_mock.%s"]
 
 [cascade.%s]

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -344,15 +344,15 @@ max-concurrent = 1
 [ollama.qwen3-small]
 max-concurrent = 1
 
-[tier.primary]
+[cascade.primary]
 members = ["ollama.qwen3"]
 strategy = "failover"
 
-[tier.backup]
+[cascade.backup]
 members = ["ollama.qwen3-small"]
 strategy = "failover"
 
-[tier.scoring]
+[cascade.scoring]
 keeper-assignable = false
 members = ["ollama.qwen3"]
 strategy = "failover"
@@ -563,11 +563,11 @@ tools-support = true
 [ollama.qwen3]
 max-concurrent = 1
 
-[tier.provider_k-coding-primary]
+[cascade.provider_k-coding-primary]
 members = ["ollama.qwen3"]
 strategy = "failover"
 
-[tier.ollama_cloud_primary]
+[cascade.ollama_cloud_primary]
 members = ["ollama.qwen3"]
 strategy = "failover"
 keeper-assignable = true
@@ -593,7 +593,7 @@ let test_catalog_validator_surfaces_adapter_errors () =
   (* A binding on a Messages_api provider (protocol provider_a-http) cannot be
      materialized: provider_kind_for_http_provider returns None for Messages_api,
      so resolve_binding_config emits a [Binding_resolution_failed] adapter error.
-     (This replaced the legacy [tier.X] member-resolution trigger.) *)
+     (This replaced the legacy [cascade.X] member-resolution trigger.) *)
   let cascade_toml =
     {|
 [providers.provider_a]
@@ -708,7 +708,7 @@ tools-support = true
 let test_runtime_validation_rejects_declarative_adapter_errors () =
   (* A binding on a Messages_api provider (protocol provider_a-http) yields a
      [Binding_resolution_failed] adapter error (provider_kind None) that runtime
-     validation rejects. (Replaced the legacy [tier.X] member-resolution trigger.) *)
+     validation rejects. (Replaced the legacy [cascade.X] member-resolution trigger.) *)
   let cascade_toml =
     {|
 [providers.provider_a]

--- a/test/test_keeper_turn_driver_exhaustion_log_source.ml
+++ b/test/test_keeper_turn_driver_exhaustion_log_source.ml
@@ -2,7 +2,7 @@
 
     [require_tool_use] completion-contract violations are deterministic
     provider/model behavior and already have typed handling. They should remain
-    visible, but not inflate the operator ERROR stream when every cascade tier
+    visible, but not inflate the operator ERROR stream when every cascade
     returns the same contract violation. *)
 
 open Alcotest

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -170,7 +170,7 @@ max-concurrent = 1
 %s
 %s
 %s
-[tier.%s]
+[cascade.%s]
 members = [%s]
 strategy = "failover"
 

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -442,7 +442,7 @@ api-name = "qwen3.6:35b-a3b-mlx-bf16"
 max-context = 32768
 tools-support = false
 
-[tier.invalid_local_lane]
+[cascade.invalid_local_lane]
 members = ["missing_provider.provider_h"]
 
 [cascade.invalid_local_lane]
@@ -482,13 +482,13 @@ tools-support = true
 
 [custom.stable]
 
-[tier.primary_profile]
+[cascade.primary_profile]
 members = ["custom.stable"]
 
 [cascade.primary_profile]
 tiers = ["primary_profile"]
 
-[tier.broken_profile]
+[cascade.broken_profile]
 members = ["missing_provider.fake"]
 
 [cascade.broken_profile]
@@ -517,13 +517,13 @@ tools-support = true
 
 [custom.stable]
 
-[tier.primary_profile]
+[cascade.primary_profile]
 members = ["missing_provider.fake"]
 
 [cascade.primary_profile]
 tiers = ["primary_profile"]
 
-[tier.secondary_profile]
+[cascade.secondary_profile]
 members = ["custom.stable"]
 
 [cascade.secondary_profile]


### PR DESCRIPTION
## 개요

PR #19381 / #19436 이후 남은 cascade 관련 tier 잔여 참조를 청소합니다.

## 변경 내용

### lib/
- **feature_flag_registry.ml**: 미사용 dead flag 2개 제거
  - `MASC_CASCADE_TIER_ADMISSION_ENABLED`
  - `MASC_CASCADE_TIER_WAIT_ENABLED`
- **keeper_health_probe.ml/mli**: `Tier_admission_full` → `Cascade_admission_full`
- **cascade_runner.ml**: "once per tier" → "once per cascade"
- **cascade_routes.ml**: 예시 문자열 업데이트
- **cascade_saturation_signal.ml/mli**: "tier saturation" → "cascade saturation"
- **cascade/ *.mli**: tier 언급 cascade로 교체

### test/
- `[tier.xxx]` TOML 헤더 → `[cascade.xxx]` (11개 파일)
- health_probe: "tier admission" → "cascade admission"
- health_tracker: "rate limit exceeded for tier" → "rate limit exceeded for cascade"
- error_classify_recoverable: "direct tier" → "direct cascade"
- exhaustion_log_source: "cascade tier" → "cascade"

## 검증

- `dune build @check` PASS

## RFC 체크

- 본 PR은 tier **제거** 작업으로 workaround 시그니처에 해당하지 않음.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
