### PR TITLE
refactor(cascade): remove tier-based local/non-local classification

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -152,7 +152,7 @@ val sdk_error_capacity_backpressure_source :
   Cascade_error_classify.capacity_backpressure_source option
 (** [Some source] when the error classifies as a MASC-internal
     [Capacity_backpressure].  Callers use this to keep provider-owned
-    capacity failures separate from client/tier/cascade-slot backpressure
+    capacity failures separate from client/cascade-slot backpressure
     when projecting provider health. *)
 
 val sdk_error_capacity_backpressure_retry_hint :

--- a/lib/cascade/cascade_capacity_probe.mli
+++ b/lib/cascade/cascade_capacity_probe.mli
@@ -47,7 +47,7 @@ val can_probe : url:string -> bool
     recognises [url].  Pure: no IO. *)
 val cached : url:string -> ?now:float -> unit -> Cascade_throttle.capacity_info option
 
-(** [capacity url] is the 3-tier resolution chain:
+(** [capacity url] is the 3-level resolution chain:
     [Cascade_throttle] → registered probes' cache →
     [Cascade_client_capacity].  Identical semantics to the previous
     per-caller hardcoded chain. *)

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -67,7 +67,7 @@ type weighted_entry = {
 }
 
 (** Deprecated logical route keys must not be treated as concrete catalog
-    profiles. Qualified names such as ["tier.local_only"] are checked by their
+    profiles. Qualified names such as ["cascade.local_only"] are checked by their
     raw profile suffix. *)
 val is_deprecated_logical_profile_name : string -> bool
 

--- a/lib/cascade/cascade_declarative_hotpath.mli
+++ b/lib/cascade/cascade_declarative_hotpath.mli
@@ -70,7 +70,7 @@ type partial_load_result = {
 (** Result of a partial catalog load. [snapshot] always contains the
     subset of profiles whose internal cross-references resolved
     successfully. [errors] lists per-entry failures (unresolved
-    provider/model/binding/tier). [errors = []] is the all-clean case.
+    provider/model/binding). [errors = []] is the all-clean case.
 
     Surfacing both fields at the same time lets downstream callers (notably
     keeper toml validation) accept the valid subset while logging the

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -184,7 +184,7 @@ val record_failure :
     Prior to 0.160.0 this path called {!record_success} (the response
     technically arrived), which silently masked gate drift: a provider
     could rank 100% healthy while every call fell through to the next
-    cascade tier.
+    cascade.
 
     See {!record_failure} for [error_kind] / [error_reason] semantics.
 

--- a/lib/cascade/cascade_internal_error.mli
+++ b/lib/cascade/cascade_internal_error.mli
@@ -31,7 +31,7 @@ type provider_rejection = {
 (** {1 Capacity backpressure source}
 
     Names the system component that issued the backpressure signal.  Used by
-    operators and dashboards to attribute saturation to a specific tier. *)
+    operators and dashboards to attribute saturation to a specific cascade. *)
 
 type capacity_backpressure_source =
   | Provider_capacity

--- a/lib/cascade/cascade_routes.ml
+++ b/lib/cascade/cascade_routes.ml
@@ -110,7 +110,7 @@ let logical_use_of_string_opt raw =
              if String.equal normalized spec.key then Some spec.use else None)
 
 (* RFC-0058 v2 route encoding in the materialized JSON:
-   {"routes": {"X": {"target": "tier-..."}}}.
+   {"routes": {"X": {"target": "provider:model"}}}.
    The TOML materializer passes [routes.X] sub-tables through verbatim,
    so this consumer extracts the [target] field. *)
 let target_of_route_value : Yojson.Safe.t -> string option = function

--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -725,7 +725,7 @@ let run
         ~total_duration_ms:run_total_duration_ms
         ~status:(Dashboard_oas_bridge.Error { transient = false })
         error_response;
-      (* Demoted from WARN to DEBUG (task-239): this fires once per tier,
+      (* Demoted from WARN to DEBUG (task-239): this fires once per cascade,
          but a cascade caller (Keeper_turn_driver.run_named) retries on the
          next provider.  Emitting WARN/ERROR here creates noise on
          recovered cascades.  The cascade layer logs [cascade-fallback] at

--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -36,33 +36,6 @@ let local_model_label model_id =
   | Some provider_id -> provider_id ^ ":" ^ model_id
   | None -> "auto"
 
-let provider_name_requires_local_discovery provider_name =
-  match Cascade_config_provider_binding.runtime_binding_of_label provider_name with
-  | Some binding -> binding_is_local_runtime binding
-  | None -> false
-
-let provider_name_is_local_or_custom provider_name =
-  let normalized = String.trim provider_name |> String.lowercase_ascii in
-  String.equal normalized "custom"
-  || provider_name_requires_local_discovery provider_name
-
-let is_local_only_cascade name =
-  let lc = name |> Keeper_cascade_profile.canonicalize |> String.lowercase_ascii in
-  let pattern = "local" in
-  let plen = String.length pattern in
-  let slen = String.length lc in
-  let rec loop i =
-    if i > slen - plen then false
-    else if String.sub lc i plen = pattern then true
-    else loop (i + 1)
-  in
-  loop 0
-
-let is_local_label label =
-  match provider_name_of_label label with
-  | Some pname -> provider_name_is_local_or_custom pname
-  | None -> false
-
 let is_typed_declarative_label_provider = function
   | "openai_compat" -> true
   | _ -> false
@@ -78,106 +51,19 @@ let default_model_strings ~cascade_name =
   let cascade_name =
     cascade_name |> cascade_name_to_string |> Keeper_cascade_profile.canonicalize
   in
-  let all_labels =
-    match Provider_runtime_projection.preferred_execution_model_labels () with
-    | [] ->
-      (* No preferred execution label is configured. Surface so dashboards can
-         alert on missing execution-lane config. *)
-      Cascade_metrics.on_default_label_fallback
-        ~cascade:cascade_name ~reason:"no_execution_labels";
-      [ Provider_runtime_projection.default_local_fallback_label () ]
-    | labels -> labels
-  in
-  if is_local_only_cascade cascade_name then
-    match List.filter is_local_label all_labels with
-    | [] ->
-      (* Local-only cascade but the resolved label set has no local
-         scheme — operator routed local traffic at a cascade with
-         only remote providers.  Iter 25 counter. *)
-      Cascade_metrics.on_default_label_fallback
-        ~cascade:cascade_name ~reason:"local_cascade_no_local";
-      [ Provider_runtime_projection.default_local_fallback_label () ]
-    | local -> local
-  else
-    all_labels
+  match Provider_runtime_projection.preferred_execution_model_labels () with
+  | [] ->
+    (* No preferred execution label is configured. Surface so dashboards can
+       alert on missing execution-lane config. *)
+    Cascade_metrics.on_default_label_fallback
+      ~cascade:cascade_name ~reason:"no_execution_labels";
+    [ Provider_runtime_projection.default_local_fallback_label () ]
+  | labels -> labels
 
-let labels_require_local_discovery (labels : string list) : bool =
-  List.exists
-    (fun label ->
-      match provider_name_of_label label with
-      | Some pname -> provider_name_requires_local_discovery pname
-      | None -> false)
-    labels
-
-(* RFC-0037 §4.3: surface partial Eio_context as a loud, warn-once
-   diagnostic instead of a silent skip.  The Provider_registry public
-   API on this module's downstream (Llm_provider) requires both [sw]
-   and [net] to probe — there is no register-without-probe path — so
-   we cannot register a fallback endpoint here.  What we *can* do is
-   tell the operator exactly why local discovery did not run, so they
-   can fix their bootstrap (typically: ensure [Eio_context] is
-   populated before the first cascade attempt that requires
-   discovery). *)
-let local_discovery_warned = Atomic.make false
-
-let warn_partial_eio_context_once ~sw_some ~net_some =
-  (* Iter 39: counter ticks on EVERY hit (independent of the
-     WARN-once dedup), so a caller-side regression that keeps
-     hitting this path after the first log line stays observable
-     via the metric. *)
-  Cascade_metrics.on_partial_eio_context ();
-  if not (Atomic.exchange local_discovery_warned true) then
-    Log.warn ~ctx:"CascadeRuntime"
-      "Local discovery skipped: Eio_context partial (sw=%b net=%b). \
-       Local providers (ollama, llama.cpp) will not be auto-discovered. \
-       Ensure Eio_context.set_switch and set_net run before the first \
-       cascade attempt that requires local discovery. (RFC-0037 §4.3)"
-      sw_some net_some
-
-let refresh_local_discovery_if_possible ?sw ?net (labels : string list) : bool =
-  if not (labels_require_local_discovery labels) then false
-  else
-    let sw =
-      match sw with Some value -> Some value | None -> Eio_context.get_switch_opt ()
-    in
-    let net =
-      match net with Some value -> Some value | None -> Eio_context.get_net_opt ()
-    in
-    match sw, net with
-    | Some sw, Some net ->
-        let before = Llm_provider.Provider_registry.discovered_max_context () in
-        (try
-           ignore
-             (Llm_provider.Provider_registry.refresh_llama_endpoints ~sw ~net ());
-           let after = Llm_provider.Provider_registry.discovered_max_context () in
-           (match before, after with
-            | Some prev, Some next when prev <> next ->
-                Log.info ~ctx:"CascadeRuntime"
-                  "refreshed local runtime context: %d -> %d" prev next
-            | None, Some next ->
-                Log.info ~ctx:"CascadeRuntime"
-                  "refreshed local runtime context: unset -> %d" next
-            | Some _, Some _ -> ()
-            | Some _, None | None, None -> ());
-           true
-         with
-         | Eio.Cancel.Cancelled _ as exn -> raise exn
-         | exn ->
-             (* Iter 40: counter ticks alongside the WARN log so the
-                swallow rate is alertable.  Previously the exception
-                arm logged once per occurrence (no dedup) but had no
-                Prometheus surface — operators could only spot
-                regressions by tailing logs. *)
-             Cascade_metrics.on_discovery_refresh_exception ();
-             Log.warn ~ctx:"CascadeRuntime"
-               "local runtime discovery refresh failed: %s"
-               (Printexc.to_string exn);
-             false)
-    | _ ->
-        warn_partial_eio_context_once
-          ~sw_some:(Option.is_some sw)
-          ~net_some:(Option.is_some net);
-        false
+(* Local discovery removed: tier-based local/non-local classification
+   no longer exists. All providers are treated uniformly. *)
+let refresh_local_discovery_if_possible ?sw:_ ?net:_ (_labels : string list) : bool =
+  false
 
 let context_floor = 4_096
 
@@ -270,31 +156,10 @@ module For_testing = struct
     resolve_primary_max_context_in_registry
 end
 
-let labels_are_pure_local (labels : string list) : bool =
-  labels <> []
-  &&
-  List.for_all
-    (fun label ->
-      match provider_name_of_label label with
-      | Some pname -> provider_name_is_local_or_custom pname
-      | None -> false)
-    labels
-
 let clamp_context_for_pure_local_labels ~(labels : string list) ~(max_context : int)
     : int =
-  if labels_are_pure_local labels
-  then begin
-    let clamped = min max_context Env_config.ContextCompact.small_local_floor in
-    (* Iter 49: tick a counter when the clamp actually reduces the
-       window (max_context > floor).  Same family as DD-020
-       max_tokens_ceiling_violation: local context clamps remain
-       observable so operators can spot cascade.toml settings being
-       clipped on local-only cascades. *)
-    if clamped < max_context then
-      Cascade_metrics.on_local_context_clamped ();
-    clamped
-  end
-  else max_context
+  ignore labels;
+  max_context
 
 let model_id_of_label label =
   match String.index_opt label ':' with
@@ -359,7 +224,7 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
           match provider_name_of_label label with
           | None -> true
           | Some pname ->
-              if provider_name_is_local_or_custom pname || is_typed_declarative_label_provider pname
+              if is_typed_declarative_label_provider pname
               then true
               else
                 match Llm_provider.Provider_registry.find default_registry pname with
@@ -375,8 +240,7 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
             match provider_name_of_label label with
             | None -> None
             | Some pname ->
-                if provider_name_is_local_or_custom pname
-                   || is_typed_declarative_label_provider pname
+                if is_typed_declarative_label_provider pname
                 then None
                 else
                   match Llm_provider.Provider_registry.find default_registry pname with

--- a/lib/cascade/cascade_runtime.mli
+++ b/lib/cascade/cascade_runtime.mli
@@ -15,12 +15,6 @@ val fallback_context_window : int
 val cascade_config_path : unit -> string option
 val provider_name_of_label : string -> string option
 val local_model_label : string -> string
-val labels_require_local_discovery : string list -> bool
-val refresh_local_discovery_if_possible :
-  ?sw:Eio.Switch.t ->
-  ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
-  string list ->
-  bool
 val effective_discovered_ctx : static_ctx:int -> discovered:int option -> int
 val max_context_of_label : string -> int
 val resolve_primary_max_context : string list -> int
@@ -29,9 +23,6 @@ module For_testing : sig
   val resolve_primary_max_context_in_registry :
     Llm_provider.Provider_registry.t -> string list -> int
 end
-val labels_are_pure_local : string list -> bool
-val clamp_context_for_pure_local_labels :
-  labels:string list -> max_context:int -> int
 val resolve_primary_model_id : string list -> string
 val default_local_model_label_and_id : unit -> string * string
 val ensure_api_keys_for_labels : string list -> (unit, string) result

--- a/lib/cascade/cascade_saturation_signal.ml
+++ b/lib/cascade/cascade_saturation_signal.ml
@@ -1,4 +1,4 @@
-(** Cascade_saturation_signal — Typed signal for tier saturation events.
+(** Cascade_saturation_signal — Typed signal for cascade saturation events.
 
     RFC-0153 Phase A.1. See .mli for full documentation.
 

--- a/lib/cascade/cascade_saturation_signal.mli
+++ b/lib/cascade/cascade_saturation_signal.mli
@@ -1,8 +1,8 @@
-(** Cascade_saturation_signal — Typed signal for tier saturation events.
+(** Cascade_saturation_signal — Typed signal for cascade saturation events.
 
     Phase A.1 of RFC-0153 (Cascade Backpressure & Tier Admission).
 
-    이 모듈은 cascade tier 가 "saturated" 상태일 때 caller 에게 전달되는
+    이 모듈은 cascade 가 "saturated" 상태일 때 caller 에게 전달되는
     typed signal 을 정의한다. 종전의 hard timer kill / "cascade exhausted"
     string 경로를 대체하는 *추가-only* 신호 채널.
 
@@ -12,7 +12,7 @@
     - caller (예: keeper_turn_driver) 가 남은 turn deadline + signal 종류
       를 보고 retry / wait / fail 을 결정.
     - Phase A.1 단독으로는 *동작 변경 없음*. Phase A.2 (caller dispatch),
-      Phase B (tier admission), Phase C (adaptive throttle) 가 본 signal
+      Phase B (cascade admission), Phase C (adaptive throttle) 가 본 signal
       을 입력으로 받음.
 
     외부 검증:

--- a/lib/cascade/cascade_strategy.mli
+++ b/lib/cascade/cascade_strategy.mli
@@ -159,7 +159,7 @@ val order_candidates :
     against the same saturated key.
 
     This function is pure and must not perform IO.  [cycle] is accepted
-    for call-site stability but no longer selects a tier (failover is
+    for call-site stability but no longer selects a cascade (failover is
     cycle-independent; health and capacity signals are re-read each
     cycle). *)
 

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -100,16 +100,6 @@ let all_flags : flag list = [
     default = true; category = "keeper";
     lifecycle = Active; since = "2.163.0" };
 
-  { env_name = "MASC_CASCADE_TIER_ADMISSION_ENABLED";
-    description = "Enforce per-tier cascade inflight admission before provider dispatch";
-    default = true; category = "keeper";
-    lifecycle = Active; since = "2.243.0" };
-
-  { env_name = "MASC_CASCADE_TIER_WAIT_ENABLED";
-    description = "Wait with bounded backoff when per-tier cascade admission is saturated";
-    default = false; category = "keeper";
-    lifecycle = Active; since = "0.19.30" };
-
   { env_name = "MASC_KEEPER_ALERT_ENABLED";
     description = "Master switch for keeper interesting alert detection";
     default = true; category = "keeper";

--- a/lib/keeper/keeper_cascade_resilience.ml
+++ b/lib/keeper/keeper_cascade_resilience.ml
@@ -33,7 +33,7 @@ let cascade_resilience_of_name raw_name =
   let pure_local =
     match model_labels with
     | [] -> false
-    | models -> Cascade_runtime.labels_are_pure_local models
+    | _models -> false
   in
   let blocker =
     match error with

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -337,10 +337,7 @@ let resolve_max_context_resolution ~requested_override (labels : string list)
     : max_context_resolution =
   let min_keeper_context = Keeper_config.min_keeper_context_tokens in
   let clamp resolved =
-    let local_clamped =
-      Cascade_runtime.clamp_context_for_pure_local_labels
-        ~labels ~max_context:resolved
-    in
+    let local_clamped = resolved in
     max min_keeper_context local_clamped
   in
   let primary_budget =

--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -11,7 +11,7 @@ type health_status =
 
 type runtime_pressure_class =
   | Client_capacity_full
-  | Tier_admission_full
+  | Cascade_admission_full
   | Provider_capacity
   | Provider_dns_failure
   | Provider_timeout
@@ -23,7 +23,7 @@ type runtime_pressure_class =
 
 let runtime_pressure_class_to_string = function
   | Client_capacity_full -> "client_capacity_full"
-  | Tier_admission_full -> "admission_full"
+  | Cascade_admission_full -> "admission_full"
   | Provider_capacity -> "provider_capacity"
   | Provider_dns_failure -> "provider_dns_failure"
   | Provider_timeout -> "provider_timeout"
@@ -37,7 +37,7 @@ let runtime_pressure_class_to_string = function
 let runtime_pressure_class_of_label label =
   match label |> String.trim |> String.lowercase_ascii with
   | "client_capacity_full" | "client_capacity" -> Some Client_capacity_full
-  | "admission_full" | "admission_capacity" -> Some Tier_admission_full
+  | "admission_full" | "admission_capacity" -> Some Cascade_admission_full
   | "provider_capacity" | "provider_capacity_full" | "capacity_backpressure" ->
     Some Provider_capacity
   | "provider_dns_failure" | "provider_dns" -> Some Provider_dns_failure
@@ -72,7 +72,7 @@ let provider_runtime_pressure_class ~code ~detail ~http_status ~cascade_name =
     || contains "inflight_capacity_full"
     || Option.is_some cascade_name
     || contains "admission="
-  then Tier_admission_full
+  then Cascade_admission_full
   else if
     contains "capacity_backpressure"
     || contains "capacity exhausted"

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -18,7 +18,7 @@ type health_status =
     persisted into skip observations and surfaced in fleet diagnostics. *)
 type runtime_pressure_class =
   | Client_capacity_full
-  | Tier_admission_full
+  | Cascade_admission_full
   | Provider_capacity
   | Provider_dns_failure
   | Provider_timeout

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -389,40 +389,10 @@ let local_discovery_refresh_for_test : (string list -> bool) option Atomic.t =
   Atomic.make None
 ;;
 
-let ensure_local_discovery_ready ?refresh (labels : string list) : (unit, string) result =
-  let refresh_for_test = Atomic.get local_discovery_refresh_for_test in
-  let refresh =
-    match refresh with
-    | Some f -> f
-    | None ->
-      (match refresh_for_test with
-       | Some f -> f
-       | None -> fun labels -> Cascade_runtime.refresh_local_discovery_if_possible labels)
-  in
-  let should_refresh =
-    match refresh_for_test with
-    | Some _ -> true
-    | None -> Cascade_runtime.labels_require_local_discovery labels
-  in
-  if not should_refresh
-  then Ok ()
-  else (
-    try
-      if refresh labels
-      then Ok ()
-      else
-        Error
-          (Printf.sprintf
-             "local discovery refresh required for labels [%s] but refresh failed"
-             (String.concat ", " labels))
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      Error
-        (Printf.sprintf
-           "local discovery refresh raised for labels [%s]: %s"
-           (String.concat ", " labels)
-           (Printexc.to_string exn)))
+(* Local discovery disabled: tier-based local/non-local classification
+   no longer exists. All providers are treated uniformly. *)
+let ensure_local_discovery_ready ?refresh:_ (_labels : string list) : (unit, string) result =
+  Ok ()
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -328,8 +328,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                     let resolved =
                       Cascade_runtime.resolve_max_cascade_context cascade_models
                     in
-                    Cascade_runtime.clamp_context_for_pure_local_labels
-                      ~labels:cascade_models ~max_context:resolved
+                    resolved
               in
               Progress.Tracker.step tracker ~message:"Initializing session directory" ();
               let trace_id = generate_trace_id () in

--- a/test/test_cascade_capability_gate.ml
+++ b/test/test_cascade_capability_gate.ml
@@ -108,7 +108,7 @@ let with_temp_cascade_toml body f =
 let test_cascade_output_cap_not_context_window () =
   (* RFC-0058: ceilings resolve a concrete binding/alias key (route/profile
      ceiling resolution was removed with the tier concept). The narrowest
-     member of the former [tier.primary] is the [remote.long] binding. *)
+     member of the former [cascade.primary] is the [remote.long] binding. *)
   let cascade_name = Cascade_name.of_string_exn "remote.long" in
   with_temp_cascade_toml
     {|
@@ -142,7 +142,7 @@ target = "remote.long"
 
 let test_public_cap_helper_clamps_caller_override_to_cascade_ceiling () =
   (* RFC-0058: ceiling resolves the concrete [remote.narrow] binding key
-     (former sole member of [tier.primary]). *)
+     (former sole member of [cascade.primary]). *)
   let cascade_name = Cascade_name.of_string_exn "remote.narrow" in
   with_temp_cascade_toml
     {|
@@ -183,7 +183,7 @@ target = "remote.narrow"
 
 let test_resolve_max_tokens_caps_automatic_value_to_cascade_ceiling () =
   (* RFC-0058: ceilings resolve a concrete member key. The narrowest former
-     [tier.strict_tool_candidates] member is the provider_c alias, whose model
+     [cascade.strict_tool_candidates] member is the provider_c alias, whose model
      capability (16384) caps the alias [max-output] (64000). *)
   let cascade_name =
     Cascade_name.of_string_exn "cli_tool_c.provider_c-cli-coding.tool_candidate"

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -639,7 +639,7 @@ let test_soft_rate_limit_records_fingerprint () =
   let t = H.create () in
   H.record_soft_rate_limited t ~provider_key:"agent_llm_a-cli"
     ~error_kind:(kind "http_429")
-    ~error_reason:"rate limit exceeded for tier" ();
+    ~error_reason:"rate limit exceeded for cascade" ();
   let info = info_or_fail t ~provider_key:"agent_llm_a-cli" in
   match info.top_fingerprints with
   | [ (fp, count) ] ->

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -86,7 +86,7 @@ streaming = true
 is-default = true
 max-concurrent = 1
 
-[tier.primary]
+[cascade.primary]
 members = ["ollama.provider_h"]
 strategy = "failover"
 

--- a/test/test_config_doctor.ml
+++ b/test/test_config_doctor.ml
@@ -62,7 +62,7 @@ tools-support = true
 is-default = true
 max-concurrent = 1
 
-[tier.primary_profile]
+[cascade.primary_profile]
 members = ["ollama.qwen3"]
 strategy = "failover"
 
@@ -316,7 +316,7 @@ supports-response-format-json = true
 is-default = true
 max-concurrent = 1
 
-[tier.provider_k-coding-primary]
+[cascade.provider_k-coding-primary]
 members = ["cli_tool_a.agent_code-spark"]
 strategy = "failover"
 
@@ -408,7 +408,7 @@ supports-response-format-json = true
 is-default = true
 max-concurrent = 1
 
-[tier.provider_k-coding-primary]
+[cascade.provider_k-coding-primary]
 members = ["provider_k-coding.provider_k-5-1"]
 strategy = "failover"
 
@@ -490,7 +490,7 @@ supports-response-format-json = true
 is-default = true
 max-concurrent = 1
 
-[tier.agent_code-primary]
+[cascade.agent_code-primary]
 members = ["cli_tool_a.agent_code-spark"]
 strategy = "failover"
 

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -338,7 +338,7 @@ let cascade_toml ?(route_target = "default") ?(extra_route_targets = [])
   let profile_toml ~valid name =
     Printf.sprintf
       {|
-[tier.%s]
+[cascade.%s]
 members = [%S]
 
 [cascade.%s]
@@ -1332,10 +1332,10 @@ tools-support = true
 
 [custom.mock]
 
-[tier.primary]
+[cascade.primary]
 members = ["missing_provider.fake"]
 
-[tier.good]
+[cascade.good]
 members = ["custom.mock"]
 
 [cascade.primary]

--- a/test/test_keeper_cascade_profile_partial.ml
+++ b/test/test_keeper_cascade_profile_partial.ml
@@ -47,7 +47,7 @@ tools-support = true
 
 [ollama.qwen3]
 
-[tier.local]
+[cascade.local]
 members = ["ollama.qwen3"]
 strategy = "failover"
 

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -226,10 +226,10 @@ let test_rotation_skips_direct_tier_after_attempted_cascade () =
   | Some retry ->
     check
       string
-      "skip direct tier duplicate"
+      "skip direct cascade duplicate"
       "cascade.provider_k-coding-with-spark"
       retry.next_cascade
-  | None -> fail "Expected rotation to skip duplicate direct tier candidate"
+  | None -> fail "Expected rotation to skip duplicate direct cascade candidate"
 
 let test_required_tool_rotation_prioritizes_tool_route_before_fallback_hint () =
   let err =
@@ -551,7 +551,7 @@ let () =
         [
           test_case "catalog order is not prefixed by base cascade" `Quick
             test_catalog_rotation_preserves_order_without_base_injection;
-          test_case "skips direct tier after attempted cascade" `Quick
+          test_case "skips direct cascade after attempted cascade" `Quick
             test_rotation_skips_direct_tier_after_attempted_cascade;
           test_case "required-tool rotation prefers tool route before fallback hint" `Quick
             test_required_tool_rotation_prioritizes_tool_route_before_fallback_hint;
@@ -564,7 +564,7 @@ let () =
         ] );
       ( "normalized_cascade_name_bare_requalify",
         [
-          (* #19327: "bare tier name requalified with prefix" test removed. *)
+          (* #19327: "bare cascade name requalified with prefix" test removed. *)
           test_case "already-qualified name passes through" `Quick
             test_normalized_cascade_name_passes_through_already_qualified;
           test_case "config special names preserved" `Quick

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -79,12 +79,12 @@ let test_runtime_pressure_classifier () =
           }));
   Alcotest.check
     pressure_label_t
-    "tier admission"
+    "cascade admission"
     (Some "tier_admission_full")
     (pressure_label_of_failure_reason
        (R.Provider_runtime_error
           { code = "capacity_backpressure"
-          ; detail = "inflight_capacity_full tier=strict_tool_candidates"
+          ; detail = "inflight_capacity_full admission_key=strict_tool_candidates"
           ; provider_id = None
           ; http_status = None
           ; cascade_name = None

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -72,7 +72,7 @@ tools-support = true
 
 [custom.mock]
 
-[tier.primary]
+[cascade.primary]
 members = ["custom.mock"]
 
 [cascade.primary]

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -97,7 +97,7 @@ tools-support = true
 
 [custom.mock]
 
-[tier.primary]
+[cascade.primary]
 members = ["custom.mock"]
 
 [cascade.primary]

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -50,7 +50,7 @@ streaming = false
 [runtime_mock.%s]
 max-concurrent = 1
 
-[tier.%s_primary]
+[cascade.%s_primary]
 members = ["runtime_mock.%s"]
 
 [cascade.%s]

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -344,15 +344,15 @@ max-concurrent = 1
 [ollama.qwen3-small]
 max-concurrent = 1
 
-[tier.primary]
+[cascade.primary]
 members = ["ollama.qwen3"]
 strategy = "failover"
 
-[tier.backup]
+[cascade.backup]
 members = ["ollama.qwen3-small"]
 strategy = "failover"
 
-[tier.scoring]
+[cascade.scoring]
 keeper-assignable = false
 members = ["ollama.qwen3"]
 strategy = "failover"
@@ -563,11 +563,11 @@ tools-support = true
 [ollama.qwen3]
 max-concurrent = 1
 
-[tier.provider_k-coding-primary]
+[cascade.provider_k-coding-primary]
 members = ["ollama.qwen3"]
 strategy = "failover"
 
-[tier.ollama_cloud_primary]
+[cascade.ollama_cloud_primary]
 members = ["ollama.qwen3"]
 strategy = "failover"
 keeper-assignable = true
@@ -593,7 +593,7 @@ let test_catalog_validator_surfaces_adapter_errors () =
   (* A binding on a Messages_api provider (protocol provider_a-http) cannot be
      materialized: provider_kind_for_http_provider returns None for Messages_api,
      so resolve_binding_config emits a [Binding_resolution_failed] adapter error.
-     (This replaced the legacy [tier.X] member-resolution trigger.) *)
+     (This replaced the legacy [cascade.X] member-resolution trigger.) *)
   let cascade_toml =
     {|
 [providers.provider_a]
@@ -708,7 +708,7 @@ tools-support = true
 let test_runtime_validation_rejects_declarative_adapter_errors () =
   (* A binding on a Messages_api provider (protocol provider_a-http) yields a
      [Binding_resolution_failed] adapter error (provider_kind None) that runtime
-     validation rejects. (Replaced the legacy [tier.X] member-resolution trigger.) *)
+     validation rejects. (Replaced the legacy [cascade.X] member-resolution trigger.) *)
   let cascade_toml =
     {|
 [providers.provider_a]

--- a/test/test_keeper_turn_driver_exhaustion_log_source.ml
+++ b/test/test_keeper_turn_driver_exhaustion_log_source.ml
@@ -2,7 +2,7 @@
 
     [require_tool_use] completion-contract violations are deterministic
     provider/model behavior and already have typed handling. They should remain
-    visible, but not inflate the operator ERROR stream when every cascade tier
+    visible, but not inflate the operator ERROR stream when every cascade
     returns the same contract violation. *)
 
 open Alcotest

--- a/test/test_keeper_unified_context_budget.ml
+++ b/test/test_keeper_unified_context_budget.ml
@@ -19,37 +19,6 @@ let make_meta name : Masc_mcp.Keeper_meta_contract.keeper_meta =
 
 let minimal_meta : Masc_mcp.Keeper_meta_contract.keeper_meta = make_meta "test-keeper"
 
-let test_pure_local_labels_detection () =
-  check
-    bool
-    "ollama-only cascade is pure local"
-    true
-    (OMR.labels_are_pure_local [ "ollama:qwen3.5:35b-a3b-nvfp4" ]);
-  check
-    bool
-    "mixed cascade is not pure local"
-    false
-    (OMR.labels_are_pure_local [ "provider_k:provider_k-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ])
-;;
-
-let test_clamp_context_for_pure_local_labels () =
-  let local_floor = Env_config.ContextCompact.small_local_floor in
-  check
-    int
-    "pure local max_context gets capped"
-    local_floor
-    (OMR.clamp_context_for_pure_local_labels
-       ~labels:[ "ollama:qwen3.5:35b-a3b-nvfp4" ]
-       ~max_context:262_144);
-  check
-    int
-    "mixed cascade keeps raw context"
-    262_144
-    (OMR.clamp_context_for_pure_local_labels
-       ~labels:[ "provider_k:provider_k-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ]
-       ~max_context:262_144)
-;;
-
 let test_resolved_max_context_for_turn_uses_primary_budget () =
   let labels = [ "provider_k:provider_k-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ] in
   let expected = OMR.resolve_primary_max_context labels in
@@ -58,7 +27,6 @@ let test_resolved_max_context_for_turn_uses_primary_budget () =
     "turn budget follows primary available model"
     expected
     (UT.resolved_max_context_for_turn ~meta:minimal_meta labels)
-;;
 
 let test_max_context_resolution_separates_override_and_effective_budget () =
   let labels = [ "unknown:model" ] in
@@ -76,7 +44,6 @@ let test_max_context_resolution_separates_override_and_effective_budget () =
     "effective budget caps to primary budget"
     resolution.primary_budget
     resolution.effective_budget
-;;
 
 let test_resolved_max_context_for_turn_uses_effective_budget () =
   let labels = [ "unknown:model" ] in
@@ -91,18 +58,12 @@ let test_resolved_max_context_for_turn_uses_effective_budget () =
     "turn dispatch budget is capped to effective budget"
     resolution.effective_budget
     (UT.resolved_max_context_for_turn ~meta labels)
-;;
 
 let () =
   run
     "keeper_unified_context_budget"
     [ ( "context_budget"
-      , [ test_case "pure local label detection" `Quick test_pure_local_labels_detection
-        ; test_case
-            "pure local context clamp"
-            `Quick
-            test_clamp_context_for_pure_local_labels
-        ; test_case
+      , [ test_case
             "turn context budget uses primary model"
             `Quick
             test_resolved_max_context_for_turn_uses_primary_budget
@@ -116,4 +77,3 @@ let () =
             test_resolved_max_context_for_turn_uses_effective_budget
         ] )
     ]
-;;

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -715,11 +715,7 @@ let test_default_model_strings_unknown () =
 
 let test_default_model_strings_local_only () =
   let models = Cascade_oas_runner.default_model_strings ~cascade_name:"local_only" in
-  Alcotest.(check bool) "local_only has models" true (models <> []);
-  Alcotest.(check bool)
-    "local_only stays local"
-    true
-    (Cascade_runtime.labels_are_pure_local models)
+  Alcotest.(check bool) "local_only has models" true (models <> [])
 ;;
 
 (** Test default_config_path with a controlled fixture so the result

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -170,7 +170,7 @@ max-concurrent = 1
 %s
 %s
 %s
-[tier.%s]
+[cascade.%s]
 members = [%s]
 strategy = "failover"
 

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -171,17 +171,6 @@ let test_resolve_primary_max_context_uses_first_available_label () =
     (Masc_mcp.Cascade_runtime.For_testing.resolve_primary_max_context_in_registry
        registry labels)
 
-let test_labels_require_local_discovery () =
-  check bool "llama labels refresh local discovery" true
-    (Masc_mcp.Cascade_runtime.labels_require_local_discovery
-       [ "llama:auto"; "provider_k:auto" ]);
-  check bool "mixed non-local labels skip refresh" false
-    (Masc_mcp.Cascade_runtime.labels_require_local_discovery
-       [ "provider_k:auto"; "agent_llm_a:auto" ]);
-  check bool "malformed labels skip refresh" false
-    (Masc_mcp.Cascade_runtime.labels_require_local_discovery
-       [ "default"; "provider_k:auto" ])
-
 let test_cascade_model_resolve_unregistered_default_provenance () =
   let resolved =
     Model_resolve.resolve_auto_model ~getenv:(fun _ -> None) "provider_d"
@@ -327,8 +316,6 @@ let () =
           test_case "max context of label" `Quick test_max_context_of_label;
           test_case "effective discovered ctx floor" `Quick
             test_effective_discovered_ctx;
-          test_case "local discovery label detection" `Quick
-            test_labels_require_local_discovery;
           test_case "cascade unregistered default provenance" `Quick
             test_cascade_model_resolve_unregistered_default_provenance;
           test_case "cascade env default provenance" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -442,7 +442,7 @@ api-name = "qwen3.6:35b-a3b-mlx-bf16"
 max-context = 32768
 tools-support = false
 
-[tier.invalid_local_lane]
+[cascade.invalid_local_lane]
 members = ["missing_provider.provider_h"]
 
 [cascade.invalid_local_lane]
@@ -482,13 +482,13 @@ tools-support = true
 
 [custom.stable]
 
-[tier.primary_profile]
+[cascade.primary_profile]
 members = ["custom.stable"]
 
 [cascade.primary_profile]
 tiers = ["primary_profile"]
 
-[tier.broken_profile]
+[cascade.broken_profile]
 members = ["missing_provider.fake"]
 
 [cascade.broken_profile]
@@ -517,13 +517,13 @@ tools-support = true
 
 [custom.stable]
 
-[tier.primary_profile]
+[cascade.primary_profile]
 members = ["missing_provider.fake"]
 
 [cascade.primary_profile]
 tiers = ["primary_profile"]
 
-[tier.secondary_profile]
+[cascade.secondary_profile]
 members = ["custom.stable"]
 
 [cascade.secondary_profile]


### PR DESCRIPTION
## 개요

tier-group/tier 문자열 제거(PR #19436, #19439) 이후에도 **의미적으로** tier 분류가 남아있던 코드를 제거합니다.

## 발견된 문제

`cascade_runtime.ml`의 `is_local_only_cascade` 함수는 cascade_name 문자열에 "local"이 포함되는지 substring match로 확인하여, local provider만 필터링하는 tier-like 분류를 수행했습니다. 이것은 문자열 교체로는 제거되지 않는 **의미적 tier 개념**입니다.

## 제거된 함수

- `is_local_only_cascade` — cascade_name substring "local" matcher
- `is_local_label` — provider local/custom classification
- `provider_name_is_local_or_custom` — "custom" string match + local discovery
- `provider_name_requires_local_discovery` — runtime binding localness probe
- `labels_are_pure_local` — "all labels are local" aggregate classifier
- `labels_require_local_discovery` — local-discovery-needed classifier
- `clamp_context_for_pure_local_labels` — context cap for "pure local" cascades

## 단순화된 함수

- `default_model_strings` — 항상 모든 label 반환; local-only filtering 제거
- `refresh_local_discovery_if_possible` — 항상 false 반환
- `ensure_api_keys_for_labels` — local/custom API key skip 제거
- `ensure_local_discovery_ready` — 항상 `Ok ()` 반환

## 검증

- `dune build @check` PASS

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
