### PR TITLE
refactor(cdal): remove sandbox/path/allowed_mutations constraint surface

### DIFF
--- a/lib/cdal/violation_record.ml
+++ b/lib/cdal/violation_record.ml
@@ -10,7 +10,6 @@
 type violation_kind = Masc_mcp_cdal_runtime.Mode_enforcer.violation_kind =
   | Mutating_in_diagnose
   | External_in_draft
-  | Scope_violation
 
 (** Re-export OAS canonical violation record. *)
 type t = Masc_mcp_cdal_runtime.Mode_enforcer.violation =
@@ -25,7 +24,6 @@ let violation_kind_of_string s =
   match String.lowercase_ascii s with
   | "mutating_in_diagnose" -> Ok Masc_mcp_cdal_runtime.Mode_enforcer.Mutating_in_diagnose
   | "external_in_draft" -> Ok Masc_mcp_cdal_runtime.Mode_enforcer.External_in_draft
-  | "scope_violation" -> Ok Masc_mcp_cdal_runtime.Mode_enforcer.Scope_violation
   | other -> Error (Printf.sprintf "unknown violation_kind: %s" other)
 ;;
 
@@ -76,5 +74,4 @@ let minimum_required_mode (v : t) : Masc_mcp_cdal_runtime.Execution_mode.t =
   match v.violation_kind with
   | Mutating_in_diagnose -> Masc_mcp_cdal_runtime.Execution_mode.Draft
   | External_in_draft -> Masc_mcp_cdal_runtime.Execution_mode.Execute
-  | Scope_violation -> Masc_mcp_cdal_runtime.Execution_mode.Execute
 ;;

--- a/lib/cdal/violation_record.mli
+++ b/lib/cdal/violation_record.mli
@@ -10,7 +10,6 @@
 type violation_kind = Masc_mcp_cdal_runtime.Mode_enforcer.violation_kind =
   | Mutating_in_diagnose (** workspace mutation attempted in Diagnose mode *)
   | External_in_draft (** external effect attempted in Draft mode *)
-  | Scope_violation (** violated allowed_mutations constraint *)
 
 (** A single violation record — re-exported from [Masc_mcp_cdal_runtime.Mode_enforcer.violation]. *)
 type t = Masc_mcp_cdal_runtime.Mode_enforcer.violation =
@@ -38,8 +37,7 @@ val of_json_list : Yojson.Safe.t -> (t list, string) result
 
 (** The minimum execution mode that would have prevented this violation.
     - [Mutating_in_diagnose] -> [Draft]
-    - [External_in_draft] -> [Execute]
-    - [Scope_violation] -> [Execute] *)
+    - [External_in_draft] -> [Execute] *)
 val minimum_required_mode : t -> Masc_mcp_cdal_runtime.Execution_mode.t
 
 (** Violation kind to/from string. Delegates to OAS canonical functions. *)

--- a/lib/cdal_runtime/criteria.ml
+++ b/lib/cdal_runtime/criteria.ml
@@ -8,10 +8,7 @@ type t =
   | Keeper_turn_capture_v1 of
       { keeper_name : string
       ; agent_name : string
-      ; sandbox_profile : string
-      ; sandbox_image : string option
       ; network_mode : string
-      ; allowed_paths : string list
       ; active_goal_ids : string list
       ; current_task_id : string option
       }
@@ -54,10 +51,7 @@ let to_yojson (t : t) : Yojson.Safe.t =
       [ "kind", `String "keeper_turn_capture_v1"
       ; "keeper_name", `String r.keeper_name
       ; "agent_name", `String r.agent_name
-      ; "sandbox_profile", `String r.sandbox_profile
       ; "network_mode", `String r.network_mode
-      ; "sandbox_image", Json_util.string_opt_to_json r.sandbox_image
-      ; "allowed_paths", Json_util.json_string_list r.allowed_paths
       ; "active_goal_ids", Json_util.json_string_list r.active_goal_ids
       ; "current_task_id_at_start", Json_util.string_opt_to_json r.current_task_id
       ]
@@ -124,16 +118,8 @@ let decode_keeper_turn_capture_v1 pairs =
   let* keeper_name = as_string keeper_name in
   let* agent_name = require pairs "agent_name" in
   let* agent_name = as_string agent_name in
-  let* sandbox_profile = require pairs "sandbox_profile" in
-  let* sandbox_profile = as_string sandbox_profile in
-  let* sandbox_image = as_string_opt (optional pairs "sandbox_image") in
   let* network_mode = require pairs "network_mode" in
   let* network_mode = as_string network_mode in
-  let* allowed_paths =
-    match assoc_lookup pairs "allowed_paths" with
-    | None -> Ok []
-    | Some v -> as_string_list v
-  in
   let* active_goal_ids =
     match assoc_lookup pairs "active_goal_ids" with
     | None -> Ok []
@@ -146,10 +132,7 @@ let decode_keeper_turn_capture_v1 pairs =
     (Keeper_turn_capture_v1
        { keeper_name
        ; agent_name
-       ; sandbox_profile
-       ; sandbox_image
        ; network_mode
-       ; allowed_paths
        ; active_goal_ids
        ; current_task_id
        })

--- a/lib/cdal_runtime/criteria.mli
+++ b/lib/cdal_runtime/criteria.mli
@@ -39,10 +39,7 @@ type t =
   | Keeper_turn_capture_v1 of
       { keeper_name : string
       ; agent_name : string
-      ; sandbox_profile : string
-      ; sandbox_image : string option
       ; network_mode : string
-      ; allowed_paths : string list
       ; active_goal_ids : string list
       ; current_task_id : string option
       }

--- a/lib/cdal_runtime/mode_enforcer.ml
+++ b/lib/cdal_runtime/mode_enforcer.ml
@@ -20,18 +20,15 @@ let json_kind_name = Effect_evidence.json_kind_name
 type violation_kind =
   | Mutating_in_diagnose
   | External_in_draft
-  | Scope_violation
 
 let violation_kind_to_string = function
   | Mutating_in_diagnose -> "mutating_in_diagnose"
   | External_in_draft -> "external_in_draft"
-  | Scope_violation -> "scope_violation"
 ;;
 
 let violation_kind_of_string = function
   | "mutating_in_diagnose" -> Ok Mutating_in_diagnose
   | "external_in_draft" -> Ok External_in_draft
-  | "scope_violation" -> Ok Scope_violation
   | s -> Error (Printf.sprintf "unknown violation_kind: %s" s)
 ;;
 
@@ -156,7 +153,6 @@ let register_tool_class name cls =
 
 type state =
   { effective_mode : Execution_mode.t
-  ; allowed_mutations : string list
   ; review_requirement : string option
   ; tool_classifications : (string * tool_effect_class) list
   ; mutable violations : violation list
@@ -168,7 +164,6 @@ type state =
 let create ~contract ~effective_mode ?(tool_classifications = []) () =
   let rc = contract.Risk_contract.runtime_constraints in
   { effective_mode
-  ; allowed_mutations = rc.allowed_mutations
   ; review_requirement = rc.review_requirement
   ; tool_classifications
   ; violations = []
@@ -397,9 +392,9 @@ let violation_kind_for_class st cls =
      | External_effect -> Some External_in_draft
      | Read_only | Local_mutation | Shell_dynamic -> None)
   | Execution_mode.Execute ->
-    if List.mem "workspace_only" st.allowed_mutations && cls = External_effect
-    then Some Scope_violation
-    else None
+    (* Execute mode imposes no tool-effect-class violation. CDAL does not
+       gate tool actions by path/mutation scope (assurance plane only). *)
+    None
 ;;
 
 let record_effect_evidence

--- a/lib/cdal_runtime/mode_enforcer.mli
+++ b/lib/cdal_runtime/mode_enforcer.mli
@@ -21,7 +21,6 @@ type tool_effect_class =
 type violation_kind =
   | Mutating_in_diagnose
   | External_in_draft
-  | Scope_violation
 
 val violation_kind_to_string : violation_kind -> string
 val violation_kind_of_string : string -> (violation_kind, string) result

--- a/lib/cdal_runtime/risk_contract.ml
+++ b/lib/cdal_runtime/risk_contract.ml
@@ -1,7 +1,6 @@
 type runtime_constraints =
   { requested_execution_mode : Execution_mode.t
   ; risk_class : Risk_class.t
-  ; allowed_mutations : string list
   ; review_requirement : string option
   }
 [@@deriving yojson, show]

--- a/lib/cdal_runtime/risk_contract.mli
+++ b/lib/cdal_runtime/risk_contract.mli
@@ -15,7 +15,6 @@
 type runtime_constraints =
   { requested_execution_mode : Execution_mode.t
   ; risk_class : Risk_class.t
-  ; allowed_mutations : string list
   ; review_requirement : string option
   }
 [@@deriving yojson, show]

--- a/lib/keeper/keeper_cdal_contract.ml
+++ b/lib/keeper/keeper_cdal_contract.ml
@@ -8,7 +8,6 @@ let of_keeper_meta (meta : Keeper_meta_contract.keeper_meta) : RC.t option =
   let runtime_constraints : RC.runtime_constraints =
     { requested_execution_mode = EM.Execute
     ; risk_class = RK.Low
-    ; allowed_mutations = []
     ; review_requirement = None
     }
   in
@@ -19,10 +18,7 @@ let of_keeper_meta (meta : Keeper_meta_contract.keeper_meta) : RC.t option =
     Crit.Keeper_turn_capture_v1
       { keeper_name = meta.name
       ; agent_name = meta.agent_name
-      ; sandbox_profile = Keeper_types_profile_sandbox.sandbox_profile_to_string meta.sandbox_profile
-      ; sandbox_image = meta.sandbox_image
       ; network_mode = Keeper_types_profile_sandbox.network_mode_to_string meta.network_mode
-      ; allowed_paths = meta.allowed_paths
       ; active_goal_ids = meta.active_goal_ids
       ; current_task_id
       }

--- a/lib/masc_contract_catalog.ml
+++ b/lib/masc_contract_catalog.ml
@@ -4,7 +4,6 @@ type contract_spec =
   ; invariants : string list
   ; requested_execution_mode : Masc_mcp_cdal_runtime.Execution_mode.t
   ; risk_class : Masc_mcp_cdal_runtime.Risk_class.t
-  ; allowed_mutations : string list
   ; review_requirement : string option
   }
 
@@ -19,7 +18,6 @@ let cascade_critical =
       ]
   ; requested_execution_mode = Masc_mcp_cdal_runtime.Execution_mode.Execute
   ; risk_class = Masc_mcp_cdal_runtime.Risk_class.Critical
-  ; allowed_mutations = [ "cascade_route"; "provider_fallback"; "telemetry_emit" ]
   ; review_requirement = None
   }
 ;;
@@ -34,8 +32,6 @@ let keeper_lifecycle =
       ]
   ; requested_execution_mode = Masc_mcp_cdal_runtime.Execution_mode.Draft
   ; risk_class = Masc_mcp_cdal_runtime.Risk_class.High
-  ; allowed_mutations =
-      [ "keeper_lifecycle_update"; "supervisor_restart"; "telemetry_emit" ]
   ; review_requirement = None
   }
 ;;
@@ -50,7 +46,6 @@ let dashboard_telemetry =
       ]
   ; requested_execution_mode = Masc_mcp_cdal_runtime.Execution_mode.Diagnose
   ; risk_class = Masc_mcp_cdal_runtime.Risk_class.Medium
-  ; allowed_mutations = []
   ; review_requirement = None
   }
 ;;
@@ -73,7 +68,6 @@ let to_risk_contract spec : Masc_mcp_cdal_runtime.Risk_contract.t =
   { runtime_constraints =
       { requested_execution_mode = spec.requested_execution_mode
       ; risk_class = spec.risk_class
-      ; allowed_mutations = spec.allowed_mutations
       ; review_requirement = spec.review_requirement
       }
   ; eval_criteria = eval_criteria spec

--- a/lib/masc_contract_catalog.mli
+++ b/lib/masc_contract_catalog.mli
@@ -10,7 +10,6 @@ type contract_spec =
   ; invariants : string list
   ; requested_execution_mode : Masc_mcp_cdal_runtime.Execution_mode.t
   ; risk_class : Masc_mcp_cdal_runtime.Risk_class.t
-  ; allowed_mutations : string list
   ; review_requirement : string option
   }
 

--- a/test/test_cdal_conformance.ml
+++ b/test/test_cdal_conformance.ml
@@ -17,7 +17,6 @@ let risk_contract_v1_json = {|{
   "runtime_constraints": {
     "requested_execution_mode": "draft",
     "risk_class": "medium",
-    "allowed_mutations": ["tool_edit_file"],
     "review_requirement": null
   },
   "eval_criteria": {
@@ -68,9 +67,6 @@ let test_risk_contract_fixture () =
       (EM.to_string rc.runtime_constraints.requested_execution_mode);
     check string "risk_class" "medium"
       (RK.to_string rc.runtime_constraints.risk_class);
-    check (list string) "allowed_mutations"
-      ["tool_edit_file"]
-      rc.runtime_constraints.allowed_mutations;
     check bool "review_requirement is None"
       true (Option.is_none rc.runtime_constraints.review_requirement);
     (* eval_criteria is typed (RFC-0109 Phase A). The fixture shape doesn't

--- a/test/test_cdal_criteria.ml
+++ b/test/test_cdal_criteria.ml
@@ -30,10 +30,7 @@ let test_keeper_turn_capture_v1_roundtrip () =
     (Crit.Keeper_turn_capture_v1
        { keeper_name = "k-1"
        ; agent_name = "agent-1"
-       ; sandbox_profile = "local"
-       ; sandbox_image = None
        ; network_mode = "none"
-       ; allowed_paths = [ "/p1"; "/p2" ]
        ; active_goal_ids = [ "g1"; "g2" ]
        ; current_task_id = Some "task-1"
        })

--- a/test/test_cdal_eval_v1.ml
+++ b/test/test_cdal_eval_v1.ml
@@ -50,7 +50,6 @@ let make_contract () : Masc_mcp_cdal_runtime.Risk_contract.t =
   { runtime_constraints =
       { requested_execution_mode = Execute
       ; risk_class = Low
-      ; allowed_mutations = [ "tool_edit_file" ]
       ; review_requirement = None
       }
   ; eval_criteria =
@@ -63,7 +62,6 @@ let make_contract_with_review_requirement () : Masc_mcp_cdal_runtime.Risk_contra
   { runtime_constraints =
       { requested_execution_mode = Execute
       ; risk_class = Low
-      ; allowed_mutations = [ "tool_edit_file" ]
       ; review_requirement = Some "human_review"
       }
   ; eval_criteria =

--- a/test/test_cdal_judge.ml
+++ b/test/test_cdal_judge.ml
@@ -58,7 +58,6 @@ let make_contract
   { runtime_constraints =
       { requested_execution_mode = requested
       ; risk_class
-      ; allowed_mutations = [ "tool_edit_file" ]
       ; review_requirement
       }
   ; eval_criteria =

--- a/test/test_cdal_loader.ml
+++ b/test/test_cdal_loader.ml
@@ -49,7 +49,6 @@ let make_contract () : Masc_mcp_cdal_runtime.Risk_contract.t =
   { runtime_constraints =
       { requested_execution_mode = Execute
       ; risk_class = Low
-      ; allowed_mutations = [ "tool_edit_file" ]
       ; review_requirement = None
       }
   ; eval_criteria =

--- a/test/test_cdal_mode_enforcer.ml
+++ b/test/test_cdal_mode_enforcer.ml
@@ -84,7 +84,7 @@ let test_all_workspace_rejects_external () =
 (* ── violation_kind round-trip ─────────────────────────────────── *)
 
 let test_violation_kind_round_trip () =
-  let all_kinds = [ Me.Mutating_in_diagnose; Me.External_in_draft; Me.Scope_violation ] in
+  let all_kinds = [ Me.Mutating_in_diagnose; Me.External_in_draft ] in
   List.iter
     (fun kind ->
        let json = Me.violation_kind_to_yojson kind in

--- a/test/test_cdal_risk_contract.ml
+++ b/test/test_cdal_risk_contract.ml
@@ -18,7 +18,6 @@ let check_bool = check bool
 let make_contract
       ?(mode = Em.Execute)
       ?(risk = Risk.Low)
-      ?(mutations = [])
       ?(review = None)
       ?(eval = Crit.Free `Null)
       ()
@@ -27,7 +26,6 @@ let make_contract
     Rc.
       { requested_execution_mode = mode
       ; risk_class = risk
-      ; allowed_mutations = mutations
       ; review_requirement = review
       }
   in
@@ -65,14 +63,6 @@ let test_contract_id_sensitive_to_risk () =
   check_bool "different risks, different ids" true (id1 <> id2)
 ;;
 
-let test_contract_id_sensitive_to_mutations () =
-  let c1 = make_contract ~mutations:[ "Write" ] () in
-  let c2 = make_contract ~mutations:[ "Write"; "Execute" ] () in
-  let id1 = Rc.contract_id c1 in
-  let id2 = Rc.contract_id c2 in
-  check_bool "different mutations, different ids" true (id1 <> id2)
-;;
-
 let test_contract_id_sensitive_to_review () =
   let c1 = make_contract ~review:None () in
   let c2 = make_contract ~review:(Some "human-approval") () in
@@ -99,7 +89,7 @@ let test_canonical_json_is_sorted () =
 ;;
 
 let test_canonical_json_no_whitespace () =
-  let c = make_contract ~mutations:[ "Write"; "Execute" ] () in
+  let c = make_contract () in
   let json = Rc.canonical_json c in
   check_bool "compact (no newline)" true (not (String.contains json '\n'))
 ;;
@@ -138,7 +128,6 @@ let test_round_trip_full () =
     make_contract
       ~mode:Em.Execute
       ~risk:Risk.Critical
-      ~mutations:[ "Write"; "Execute"; "Edit" ]
       ~review:(Some "dual-approval")
       ~eval:(Crit.Free (`Assoc [ "max_retries", `Int 3; "threshold", `Float 0.95 ]))
       ()
@@ -152,11 +141,6 @@ let test_round_trip_full () =
       (Em.equal rc.requested_execution_mode rc'.requested_execution_mode)
       true;
     check_bool "risk" (Risk.equal rc.risk_class rc'.risk_class) true;
-    check
-      int
-      "mutations length"
-      (List.length rc.allowed_mutations)
-      (List.length rc'.allowed_mutations);
     check_bool "review" (rc.review_requirement = rc'.review_requirement) true;
     check_string "contract_id preserved" (Rc.contract_id c) (Rc.contract_id c')
   | Error e -> failf "full contract round-trip failed: %s" e
@@ -170,10 +154,6 @@ let () =
         ; test_case "prefix md5:" `Quick test_contract_id_starts_with_md5
         ; test_case "sensitive to mode" `Quick test_contract_id_sensitive_to_mode
         ; test_case "sensitive to risk" `Quick test_contract_id_sensitive_to_risk
-        ; test_case
-            "sensitive to mutations"
-            `Quick
-            test_contract_id_sensitive_to_mutations
         ; test_case "sensitive to review" `Quick test_contract_id_sensitive_to_review
         ; test_case "sensitive to eval" `Quick test_contract_id_sensitive_to_eval
         ] )

--- a/test/test_keeper_cdal_contract.ml
+++ b/test/test_keeper_cdal_contract.ml
@@ -102,17 +102,14 @@ let test_keeper_meta_projects_capture_only_contract () =
   let constraints = contract.RC.runtime_constraints in
   check string "requested mode" "execute" (EM.to_string constraints.requested_execution_mode);
   check string "risk class" "low" (RK.to_string constraints.risk_class);
-  check (list string) "allowed mutations" [] constraints.allowed_mutations;
   check (option string) "review requirement" None constraints.review_requirement;
   (* Typed criteria assertion (RFC-0109 Phase A) *)
   (match contract.RC.eval_criteria with
    | Crit.Keeper_turn_capture_v1 r ->
      check string "keeper_name (typed)" "cdal-keeper" r.keeper_name;
      check string "agent_name (typed)" "cdal-keeper-agent" r.agent_name;
-     check string "sandbox_profile (typed)" "local" r.sandbox_profile;
      check string "network_mode (typed)" "none" r.network_mode;
      check (option string) "current_task_id (typed)" (Some "task-cdal-001") r.current_task_id;
-     check (list string) "allowed_paths (typed)" [ "/workspace/project" ] r.allowed_paths;
      check (list string) "active_goal_ids (typed)" [ "goal-cdal" ] r.active_goal_ids
    | other ->
      failf "expected Keeper_turn_capture_v1, got criteria_kind=%s" (Crit.criteria_kind other));
@@ -121,10 +118,8 @@ let test_keeper_meta_projects_capture_only_contract () =
   check_json_string "kind" "keeper_turn_capture_v1" criteria;
   check_json_string "keeper_name" "cdal-keeper" criteria;
   check_json_string "agent_name" "cdal-keeper-agent" criteria;
-  check_json_string "sandbox_profile" "local" criteria;
   check_json_string "network_mode" "none" criteria;
   check_json_string "current_task_id_at_start" "task-cdal-001" criteria;
-  check_json_list "allowed_paths" [ "/workspace/project" ] criteria;
   check_json_list "active_goal_ids" [ "goal-cdal" ] criteria
 ;;
 

--- a/test/test_masc_contract_catalog.ml
+++ b/test/test_masc_contract_catalog.ml
@@ -90,11 +90,6 @@ let test_risk_contract_projection_is_deterministic () =
     (Masc_mcp_cdal_runtime.Risk_contract.contract_id first)
     (Masc_mcp_cdal_runtime.Risk_contract.contract_id second);
   check
-    (list string)
-    "allowed mutations"
-    [ "keeper_lifecycle_update"; "supervisor_restart"; "telemetry_emit" ]
-    first.runtime_constraints.allowed_mutations;
-  check
     (option string)
     "review requirement"
     None


### PR DESCRIPTION
## 요약

CDAL의 sandbox/path/allowed_mutations 제약 표면을 제거합니다. CDAL은 assurance plane(Goal/Task 완성 verdict) 전용이며 tool action을 path/sandbox/mutation 스코프로 제약하지 않습니다. 이번 PR은 그 (비)제약을 인코딩하던 선언 필드를 들어냅니다.

선행 PR #19441(dead path-guard `autonomy_diff_guard` 제거)의 후속입니다.

## 제거 대상

| 위치 | 제거 |
|------|------|
| `Risk_contract.runtime_constraints` | `allowed_mutations` |
| `Criteria.Keeper_turn_capture_v1` | `sandbox_profile`, `sandbox_image`, `allowed_paths` |
| `Mode_enforcer` | `Scope_violation` variant + Execute-mode `workspace_only` 체크 + state `allowed_mutations` |
| `Violation_record` (lib/cdal) | `Scope_violation` 미러 |
| `Masc_contract_catalog.contract_spec` | `allowed_mutations` (+ 3 catalog 값) |
| `Keeper_cdal_contract` | 실제 keeper sandbox_profile/allowed_paths를 eval criteria로 projection하던 부분 |

## 안전성 (behavior-neutral)

- criteria의 sandbox/path 필드를 **판정에 읽는 소비자 0건** (순수 캡처).
- `Mode_enforcer.check_violation`은 production 호출부 0건 (evidence 기록만, 실제 tool 차단 안 함). `Scope_violation`은 실제로 발화한 적 없음.
- OCaml exhaustive match가 `Scope_violation` 제거 시 모든 소비처(to_string/of_string/minimum_required_mode/violation_record)를 컴파일 타임에 강제 갱신 — N-of-M 누락 없음.

## 보호 (out of scope)

- **실제 keeper 컨테이너 sandbox** (`Keeper_types_profile_sandbox.Docker/Local`, `operator_control`, `keeper_sandbox_runner`) — 별개 subsystem, 전혀 건드리지 않음.
- `Mode_enforcer.all_workspace_only` / `Mode_resolver.capability_cap` — tool-effect-class 기반 실행 모드 resolution이고 `allowed_mutations`와 무관(contract_runner 배선)이라 유지.
- friction_projection / reputation_ledger 테스트의 `"scope_violation"` 문자열은 opaque string key를 쓰는 별개 subsystem 샘플 데이터라 유지.

## Wire-format / proof_store 영향 (수용됨)

`Risk_contract.contract_id`는 canonical JSON의 md5라, 이 필드들을 제거하면 contract_id가 바뀌어 **기존 proof_store 엔트리가 해시로 재검증되지 않습니다**. 제약이 실제로 enforce된 적 없고 historical proof continuity가 불필요하므로 사용자 결정에 따라 수용합니다.

## 검증

- `dune build lib/cdal_runtime/` → exit 0 (criteria/risk_contract/mode_enforcer clean)
- 내가 건드린 파일에 새 컴파일 오류 0건
- full `dune build lib/` + 테스트 exe는 **사전 존재 main breakage**로 차단 (CDAL 무관: `keeper_recording_error_state`, `meta_cognition_snapshot`(clamp), `server_dashboard_http_keeper_api_types`(take_last), `dashboard_goals_types_attainment`(contains_ci), `keeper_turn_driver`). main green 복구 후 CI 재검증 필요.

RFC-WAIVED: CDAL assurance-plane 경계 정합을 위한 제약 표면 제거. credential/identity/operator/keeper_sandbox/hooks/workflow subsystem 미해당.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
