### PR TITLE
refactor(ssot): #19434 잔여 8파일 inline JSON 헬퍼 SSOT 통합

### DIFF
--- a/lib/bounded.ml
+++ b/lib/bounded.ml
@@ -392,8 +392,11 @@ let result_to_json result =
 
 (** Parse retry config from JSON *)
 let retry_config_of_json json =
-  let open Yojson.Safe.Util in
-  let retry = json |> member "retry" in
+  let retry =
+    match Json_util.assoc_member_opt "retry" json with
+    | None | Some `Null -> `Null
+    | Some v -> v
+  in
   if retry = `Null then
     default_retry_config
   else
@@ -413,17 +416,11 @@ let constraints_of_json json =
   if json = `Null then
     default_constraints
   else
-    let open Yojson.Safe.Util in
-    let get_int_opt key = Safe_ops.json_int_opt key json in
-    let get_float_opt key =
-      try Some (json |> member key |> to_float)
-      with Yojson.Safe.Util.Type_error _ -> None
-    in
     {
-      max_turns = get_int_opt "max_turns";
-      max_tokens = get_int_opt "max_tokens";
-      max_cost_usd = get_float_opt "max_cost_usd";
-      max_time_seconds = get_float_opt "max_time_seconds";
+      max_turns = Safe_ops.json_int_opt "max_turns" json;
+      max_tokens = Safe_ops.json_int_opt "max_tokens" json;
+      max_cost_usd = Json_util.get_float json "max_cost_usd";
+      max_time_seconds = Json_util.get_float json "max_time_seconds";
       hard_max_iterations =
         Safe_ops.json_int ~default:default_constraints.hard_max_iterations "hard_max_iterations" json;
       retry = retry_config_of_json json;
@@ -431,28 +428,45 @@ let constraints_of_json json =
 
 (** Parse goal from JSON *)
 let goal_of_json json =
-  let open Yojson.Safe.Util in
-  let path = json |> member "path" |> to_string in
-  let cond = json |> member "condition" in
+  let path = Json_util.get_string json "path" |> Option.value ~default:"" in
+  let cond =
+    match Json_util.assoc_member_opt "condition" json with
+    | None | Some `Null -> `Null
+    | Some v -> v
+  in
+  let safe_member key v =
+    match Json_util.assoc_member_opt key v with
+    | Some v -> v
+    | None -> `Null
+  in
+  let get_float_or key v =
+    Json_util.get_float v key |> Option.value ~default:0.0
+  in
   let condition =
-    if member "eq" cond <> `Null then
-      Eq (member "eq" cond)
-    else if member "neq" cond <> `Null then
-      Neq (member "neq" cond)
-    else if member "lt" cond <> `Null then
-      Lt (member "lt" cond |> to_float)
-    else if member "lte" cond <> `Null then
-      Lte (member "lte" cond |> to_float)
-    else if member "gt" cond <> `Null then
-      Gt (member "gt" cond |> to_float)
-    else if member "gte" cond <> `Null then
-      Gte (member "gte" cond |> to_float)
-    else if member "between" cond <> `Null then
-      match member "between" cond |> to_list with
-      | low :: high :: _ -> Between (low |> to_float, high |> to_float)
-      | _ -> invalid_arg "Bounded.rule_of_yojson: 'between' array must have at least 2 elements"
-    else if member "in" cond <> `Null then
-      In (member "in" cond |> to_list)
+    if Json_util.assoc_member_opt "eq" cond <> None then
+      Eq (safe_member "eq" cond)
+    else if Json_util.assoc_member_opt "neq" cond <> None then
+      Neq (safe_member "neq" cond)
+    else if Json_util.assoc_member_opt "lt" cond <> None then
+      Lt (get_float_or "lt" cond)
+    else if Json_util.assoc_member_opt "lte" cond <> None then
+      Lte (get_float_or "lte" cond)
+    else if Json_util.assoc_member_opt "gt" cond <> None then
+      Gt (get_float_or "gt" cond)
+    else if Json_util.assoc_member_opt "gte" cond <> None then
+      Gte (get_float_or "gte" cond)
+    else if Json_util.assoc_member_opt "between" cond <> None then
+      let to_float_raw = function
+        | `Float f -> f
+        | `Int i -> float_of_int i
+        | _ -> 0.0
+      in
+      (match safe_member "between" cond with
+       | `List (low :: high :: _) ->
+         Between (to_float_raw low, to_float_raw high)
+       | _ -> invalid_arg "Bounded.rule_of_yojson: 'between' array must have at least 2 elements")
+    else if Json_util.assoc_member_opt "in" cond <> None then
+      In (match safe_member "in" cond with `List l -> l | v -> [v])
     else
       Eq (`Bool true)  (* Default: look for truthy value *)
   in

--- a/lib/coord/coord_eio.ml
+++ b/lib/coord/coord_eio.ml
@@ -249,21 +249,21 @@ let room_state_to_json state =
   ]
 
 let room_state_of_json json =
-  let open Yojson.Safe.Util in
+  let m key = Option.value ~default:`Null (Json_util.assoc_member_opt key json) in
   try
     Ok {
-      protocol_version = json |> member "protocol_version" |> to_string;
-      started_at = json |> member "started_at" |> to_float;
-      last_updated = json |> member "last_updated" |> to_float;
-      active_agents = json |> member "active_agents" |> to_list |> List.map to_string;
-      message_seq = json |> member "message_seq" |> to_int;
+      protocol_version = (match m "protocol_version" with `String s -> s | _ -> raise (Invalid_argument "protocol_version"));
+      started_at = (match m "started_at" with `Float f -> f | `Int i -> float_of_int i | _ -> raise (Invalid_argument "started_at"));
+      last_updated = (match m "last_updated" with `Float f -> f | `Int i -> float_of_int i | _ -> raise (Invalid_argument "last_updated"));
+      active_agents = (match m "active_agents" with `List items -> List.filter_map (function `String s -> Some s | _ -> None) items | _ -> []);
+      message_seq = (match m "message_seq" with `Int i -> i | _ -> 0);
       (* Backward compat: default to 0 if event_seq missing from old state files *)
       event_seq = Safe_ops.json_int ~default:0 "event_seq" json;
-      mode = json |> member "mode" |> to_string;
-      paused = json |> member "paused" |> to_bool;
-      paused_by = json |> member "paused_by" |> to_string_option;
-      paused_at = json |> member "paused_at" |> to_float_option;
-      pause_reason = json |> member "pause_reason" |> to_string_option;
+      mode = (match m "mode" with `String s -> s | _ -> "");
+      paused = (match m "paused" with `Bool b -> b | _ -> false);
+      paused_by = Json_util.get_string json "paused_by";
+      paused_at = Json_util.get_float json "paused_at";
+      pause_reason = Json_util.get_string json "pause_reason";
     }
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -343,13 +343,13 @@ let agent_state_to_json agent =
   ]
 
 let agent_state_of_json json =
-  let open Yojson.Safe.Util in
+  let m key = Option.value ~default:`Null (Json_util.assoc_member_opt key json) in
   try
     Ok {
-      name = json |> member "name" |> to_string;
-      last_seen = json |> member "last_seen" |> to_float;
-      capabilities = json |> member "capabilities" |> to_list |> List.map to_string;
-      status = json |> member "status" |> to_string;
+      name = (match m "name" with `String s -> s | _ -> raise (Invalid_argument "name"));
+      last_seen = (match m "last_seen" with `Float f -> f | `Int i -> float_of_int i | _ -> raise (Invalid_argument "last_seen"));
+      capabilities = (match m "capabilities" with `List items -> List.filter_map (function `String s -> Some s | _ -> None) items | _ -> []);
+      status = (match m "status" with `String s -> s | _ -> raise (Invalid_argument "status"));
     }
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -466,7 +466,7 @@ let lock_info_to_json lock =
   ]
 
 let lock_info_of_json json =
-  let open Yojson.Safe.Util in
+  let m key = Option.value ~default:`Null (Json_util.assoc_member_opt key json) in
   try
     let parse_float = function
       | `Float f -> Some f
@@ -479,10 +479,10 @@ let lock_info_of_json json =
       | `String s -> Some s
       | _ -> None
     in
-    let resource_opt = parse_string (member "resource" json) in
-    let owner_opt = parse_string (member "owner" json) in
-    let acquired_at_opt = parse_float (member "acquired_at" json) in
-    let expires_at_opt = parse_float (member "expires_at" json) in
+    let resource_opt = parse_string (m "resource") in
+    let owner_opt = parse_string (m "owner") in
+    let acquired_at_opt = parse_float (m "acquired_at") in
+    let expires_at_opt = parse_float (m "expires_at") in
     match resource_opt, owner_opt, acquired_at_opt, expires_at_opt with
     | Some resource, Some owner, Some acquired_at, Some expires_at ->
         Ok { resource; owner; acquired_at; expires_at }
@@ -574,14 +574,14 @@ let message_to_json msg =
   ]
 
 let message_of_json json =
-  let open Yojson.Safe.Util in
+  let m key = Option.value ~default:`Null (Json_util.assoc_member_opt key json) in
   try
     Ok {
-      seq = json |> member "seq" |> to_int;
-      from_agent = json |> member "from" |> to_string;
-      content = json |> member "content" |> to_string;
-      mention = json |> member "mention" |> to_string_option;
-      timestamp = json |> member "timestamp" |> to_float;
+      seq = (match m "seq" with `Int i -> i | _ -> raise (Invalid_argument "seq"));
+      from_agent = (match m "from" with `String s -> s | _ -> raise (Invalid_argument "from"));
+      content = (match m "content" with `String s -> s | _ -> raise (Invalid_argument "content"));
+      mention = Json_util.get_string json "mention";
+      timestamp = (match m "timestamp" with `Float f -> f | `Int i -> float_of_int i | _ -> raise (Invalid_argument "timestamp"));
     }
   with
   | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/graphql_api.ml
+++ b/lib/graphql_api.ml
@@ -663,22 +663,13 @@ let handle_request ~config body_str =
   | Error msg ->
       { status = `Bad_request; body = graphql_error msg }
   | Ok payload ->
-      let open Yojson.Safe.Util in
-      let query =
-        match payload |> member "query" with
-        | `String q -> Some q
-        | _ -> None
-      in
+      let query = Json_util.get_string payload "query" in
       let variables_json =
-        match payload |> member "variables" with
-        | `Null -> None
-        | other -> Some other
+        match Json_util.assoc_member_opt "variables" payload with
+        | Some `Null -> None
+        | opt -> opt
       in
-      let operation_name =
-        match payload |> member "operationName" with
-        | `String s -> Some s
-        | _ -> None
-      in
+      let operation_name = Json_util.get_string payload "operationName" in
       (match query with
        | None ->
            { status = `Bad_request; body = graphql_error "Missing query field" }

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -189,16 +189,25 @@ let rec episode_to_json (e : episode) : Yojson.Safe.t =
     ]
 
 and episode_of_json json =
-  let open Yojson.Safe.Util in
-  { id = json |> member "id" |> to_string
-  ; timestamp = json |> member "timestamp" |> json_to_float
-  ; participants = json |> member "participants" |> to_list |> List.map to_string
-  ; event_type = json |> member "event_type" |> to_string
-  ; summary = json |> member "summary" |> to_string
-  ; outcome = json |> member "outcome" |> to_string |> outcome_of_string
-  ; learnings = json |> member "learnings" |> to_list |> List.map to_string
+  let m key = Option.value ~default:`Null (Json_util.assoc_member_opt key json) in
+  { id = Json_util.get_string json "id" |> Option.value ~default:""
+  ; timestamp = Json_util.get_float json "timestamp" |> Option.value ~default:0.0
+  ; participants = Json_util.get_string_list json "participants"
+  ; event_type = Json_util.get_string json "event_type" |> Option.value ~default:""
+  ; summary = Json_util.get_string json "summary" |> Option.value ~default:""
+  ; outcome =
+      Json_util.get_string json "outcome"
+      |> Option.value ~default:""
+      |> outcome_of_string
+  ; learnings = Json_util.get_string_list json "learnings"
   ; context =
-      json |> member "context" |> to_assoc |> List.map (fun (k, v) -> k, to_string v)
+      (match m "context" with
+       | `Assoc pairs ->
+         List.filter_map
+           (fun (k, v) ->
+              match v with `String s -> Some (k, s) | _ -> None)
+           pairs
+       | _ -> [])
   }
 
 and knowledge_to_json (k : knowledge) : Yojson.Safe.t =
@@ -214,15 +223,14 @@ and knowledge_to_json (k : knowledge) : Yojson.Safe.t =
     ]
 
 and knowledge_of_json json =
-  let open Yojson.Safe.Util in
-  { id = json |> member "id" |> to_string
-  ; topic = json |> member "topic" |> to_string
-  ; content = json |> member "content" |> to_string
-  ; confidence = json |> member "confidence" |> json_to_float
-  ; source = json |> member "source" |> to_string
-  ; created_at = json |> member "created_at" |> json_to_float
-  ; last_verified = json |> member "last_verified" |> json_to_float
-  ; references = json |> member "references" |> to_list |> List.map to_string
+  { id = Json_util.get_string json "id" |> Option.value ~default:""
+  ; topic = Json_util.get_string json "topic" |> Option.value ~default:""
+  ; content = Json_util.get_string json "content" |> Option.value ~default:""
+  ; confidence = Json_util.get_float json "confidence" |> Option.value ~default:0.0
+  ; source = Json_util.get_string json "source" |> Option.value ~default:""
+  ; created_at = Json_util.get_float json "created_at" |> Option.value ~default:0.0
+  ; last_verified = Json_util.get_float json "last_verified" |> Option.value ~default:0.0
+  ; references = Json_util.get_string_list json "references"
   }
 
 and pattern_to_json (p : pattern) : Yojson.Safe.t =
@@ -242,28 +250,19 @@ and pattern_to_json (p : pattern) : Yojson.Safe.t =
     ]
 
 and pattern_of_json json =
-  let open Yojson.Safe.Util in
-  { id = json |> member "id" |> to_string
-  ; name = json |> member "name" |> to_string
-  ; description = json |> member "description" |> to_string
-  ; trigger = json |> member "trigger" |> to_string
-  ; steps = json |> member "steps" |> to_list |> List.map to_string
-  ; success_rate = json |> member "success_rate" |> json_to_float
-  ; usage_count = json |> member "usage_count" |> to_int
-  ; last_used = json |> member "last_used" |> json_to_float
-  ; evolved_from = json |> member "evolved_from" |> to_string_option
-  ; effectiveness_used =
-      (match json |> member "effectiveness_used" with
-       | `Int n -> n
-       | _ -> 0)
-  ; effectiveness_unused =
-      (match json |> member "effectiveness_unused" with
-       | `Int n -> n
-       | _ -> 0)
+  { id = Json_util.get_string json "id" |> Option.value ~default:""
+  ; name = Json_util.get_string json "name" |> Option.value ~default:""
+  ; description = Json_util.get_string json "description" |> Option.value ~default:""
+  ; trigger = Json_util.get_string json "trigger" |> Option.value ~default:""
+  ; steps = Json_util.get_string_list json "steps"
+  ; success_rate = Json_util.get_float json "success_rate" |> Option.value ~default:0.0
+  ; usage_count = Json_util.get_int json "usage_count" |> Option.value ~default:0
+  ; last_used = Json_util.get_float json "last_used" |> Option.value ~default:0.0
+  ; evolved_from = Json_util.get_string json "evolved_from"
+  ; effectiveness_used = Json_util.get_int json "effectiveness_used" |> Option.value ~default:0
+  ; effectiveness_unused = Json_util.get_int json "effectiveness_unused" |> Option.value ~default:0
   ; effectiveness_last_check =
-      (match json |> member "effectiveness_last_check" with
-       | `Null -> 0.0
-       | other -> json_to_float other)
+      Json_util.get_float json "effectiveness_last_check" |> Option.value ~default:0.0
   }
 
 and cultural_value_to_json (c : cultural_value) : Yojson.Safe.t =
@@ -278,14 +277,13 @@ and cultural_value_to_json (c : cultural_value) : Yojson.Safe.t =
     ]
 
 and cultural_value_of_json json =
-  let open Yojson.Safe.Util in
-  { id = json |> member "id" |> to_string
-  ; name = json |> member "name" |> to_string
-  ; description = json |> member "description" |> to_string
-  ; weight = json |> member "weight" |> json_to_float
-  ; examples = json |> member "examples" |> to_list |> List.map to_string
-  ; anti_patterns = json |> member "anti_patterns" |> to_list |> List.map to_string
-  ; adopted_at = json |> member "adopted_at" |> json_to_float
+  { id = Json_util.get_string json "id" |> Option.value ~default:""
+  ; name = Json_util.get_string json "name" |> Option.value ~default:""
+  ; description = Json_util.get_string json "description" |> Option.value ~default:""
+  ; weight = Json_util.get_float json "weight" |> Option.value ~default:0.0
+  ; examples = Json_util.get_string_list json "examples"
+  ; anti_patterns = Json_util.get_string_list json "anti_patterns"
+  ; adopted_at = Json_util.get_float json "adopted_at" |> Option.value ~default:0.0
   }
 
 and succession_to_json (s : succession_policy) : Yojson.Safe.t =
@@ -298,15 +296,14 @@ and succession_to_json (s : succession_policy) : Yojson.Safe.t =
     ]
 
 and succession_of_json json =
-  let open Yojson.Safe.Util in
-  { onboarding_steps = json |> member "onboarding_steps" |> to_list |> List.map to_string
-  ; required_knowledge =
-      json |> member "required_knowledge" |> to_list |> List.map to_string
+  { onboarding_steps = Json_util.get_string_list json "onboarding_steps"
+  ; required_knowledge = Json_util.get_string_list json "required_knowledge"
   ; mentor_assignment =
-      json |> member "mentor_assignment" |> to_string |> mentor_of_string
-  ; probation_period = json |> member "probation_period" |> json_to_float
-  ; graduation_criteria =
-      json |> member "graduation_criteria" |> to_list |> List.map to_string
+      Json_util.get_string json "mentor_assignment"
+      |> Option.value ~default:"best_fit"
+      |> mentor_of_string
+  ; probation_period = Json_util.get_float json "probation_period" |> Option.value ~default:0.0
+  ; graduation_criteria = Json_util.get_string_list json "graduation_criteria"
   }
 
 and identity_to_json (i : identity) : Yojson.Safe.t =
@@ -319,12 +316,11 @@ and identity_to_json (i : identity) : Yojson.Safe.t =
     ]
 
 and identity_of_json json =
-  let open Yojson.Safe.Util in
-  { id = json |> member "id" |> to_string
-  ; name = json |> member "name" |> to_string
-  ; mission = json |> member "mission" |> to_string
-  ; founded_at = json |> member "founded_at" |> json_to_float
-  ; generation = json |> member "generation" |> to_int
+  { id = Json_util.get_string json "id" |> Option.value ~default:""
+  ; name = Json_util.get_string json "name" |> Option.value ~default:""
+  ; mission = Json_util.get_string json "mission" |> Option.value ~default:""
+  ; founded_at = Json_util.get_float json "founded_at" |> Option.value ~default:0.0
+  ; generation = Json_util.get_int json "generation" |> Option.value ~default:0
   }
 
 and memory_to_json (m : long_term_memory) : Yojson.Safe.t =
@@ -335,10 +331,19 @@ and memory_to_json (m : long_term_memory) : Yojson.Safe.t =
     ]
 
 and memory_of_json json =
-  let open Yojson.Safe.Util in
-  { episodic = json |> member "episodic" |> to_list |> List.map episode_of_json
-  ; semantic = json |> member "semantic" |> to_list |> List.map knowledge_of_json
-  ; procedural = json |> member "procedural" |> to_list |> List.map pattern_of_json
+  let m key = Option.value ~default:`Null (Json_util.assoc_member_opt key json) in
+  { episodic =
+      (match m "episodic" with
+       | `List items -> List.map episode_of_json items
+       | _ -> [])
+  ; semantic =
+      (match m "semantic" with
+       | `List items -> List.map knowledge_of_json items
+       | _ -> [])
+  ; procedural =
+      (match m "procedural" with
+       | `List items -> List.map pattern_of_json items
+       | _ -> [])
   }
 
 and institution_to_json (inst : institution) : Yojson.Safe.t =
@@ -352,13 +357,16 @@ and institution_to_json (inst : institution) : Yojson.Safe.t =
     ]
 
 and institution_of_json json =
-  let open Yojson.Safe.Util in
-  { identity = json |> member "identity" |> identity_of_json
-  ; memory = json |> member "memory" |> memory_of_json
-  ; culture = json |> member "culture" |> to_list |> List.map cultural_value_of_json
-  ; succession = json |> member "succession" |> succession_of_json
-  ; current_agents = json |> member "current_agents" |> to_list |> List.map to_string
-  ; alumni = json |> member "alumni" |> to_list |> List.map to_string
+  let m key = Option.value ~default:`Null (Json_util.assoc_member_opt key json) in
+  { identity = m "identity" |> identity_of_json
+  ; memory = m "memory" |> memory_of_json
+  ; culture =
+      (match m "culture" with
+       | `List items -> List.map cultural_value_of_json items
+       | _ -> [])
+  ; succession = m "succession" |> succession_of_json
+  ; current_agents = Json_util.get_string_list json "current_agents"
+  ; alumni = Json_util.get_string_list json "alumni"
   }
 ;;
 

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -359,11 +359,10 @@ let handle_get_prompt_eio state id params =
   match params with
   | None -> make_error_typed ~id Mcp_error_code.Invalid_params "Missing params"
   | Some (`Assoc _ as payload) ->
-    let open Yojson.Safe.Util in
-    (match payload |> member "name" with
-     | `String name ->
+    (match Json_util.assoc_member_opt "name" payload with
+     | Some (`String name) ->
        let arguments =
-         match payload |> member "arguments" with
+         match Option.value ~default:`Null (Json_util.assoc_member_opt "arguments" payload) with
          | `Assoc _ as args -> args
          | `Null -> `Assoc []
          | _ -> `Assoc []
@@ -382,12 +381,11 @@ let handle_get_prompt_eio state id params =
 ;;
 
 let handle_resources_subscribe_eio id ?mcp_session_id params =
-  let open Yojson.Safe.Util in
   match mcp_session_id, params with
   | None, _ -> make_error_typed ~id Mcp_error_code.Invalid_request "resources/subscribe requires an MCP session"
   | Some session_id, Some (`Assoc _ as payload) ->
-    (match payload |> member "uri" with
-     | `String uri ->
+    (match Json_util.assoc_member_opt "uri" payload with
+     | Some (`String uri) ->
        subscribe_resource_for_session ~session_id ~uri;
        make_response ~id (`Assoc [])
      | _ -> make_error_typed ~id Mcp_error_code.Invalid_params "Invalid params: uri must be a string")
@@ -396,12 +394,11 @@ let handle_resources_subscribe_eio id ?mcp_session_id params =
 ;;
 
 let handle_resources_unsubscribe_eio id ?mcp_session_id params =
-  let open Yojson.Safe.Util in
   match mcp_session_id, params with
   | None, _ -> make_error_typed ~id Mcp_error_code.Invalid_request "resources/unsubscribe requires an MCP session"
   | Some session_id, Some (`Assoc _ as payload) ->
-    (match payload |> member "uri" with
-     | `String uri ->
+    (match Json_util.assoc_member_opt "uri" payload with
+     | Some (`String uri) ->
        unsubscribe_resource_for_session ~session_id ~uri;
        make_response ~id (`Assoc [])
      | _ -> make_error_typed ~id Mcp_error_code.Invalid_params "Invalid params: uri must be a string")
@@ -680,7 +677,7 @@ let handle_request
                  | Some params ->
                    (try
                       let name =
-                        Yojson.Safe.Util.(params |> member "name" |> to_string)
+                        Json_util.get_string params "name" |> Option.value ~default:""
                       in
                       (* Issue #8699: exhaustive match on tool_profile.
                                Catch-all `_ -> Full` would silently elevate any

--- a/lib/tool_task_args.ml
+++ b/lib/tool_task_args.ml
@@ -6,18 +6,16 @@
 
     @since God file decomposition — extracted from tool_task.ml *)
 
-open Yojson.Safe.Util
-
 let parse_task_contract args =
-  match args |> member "contract" with
-  | `Null -> Ok None
-  | (`Assoc _ as json) -> (
+  match Json_util.assoc_member_opt "contract" args with
+  | None | Some `Null -> Ok None
+  | Some (`Assoc _ as json) -> (
       match Masc_domain.task_contract_of_yojson json with
       | Ok contract -> Ok (Some contract)
       | Error error ->
           Error
             (Printf.sprintf "Invalid contract payload: %s" error))
-  | other ->
+  | Some other ->
       Error
         (Printf.sprintf
            "contract must be an object when provided (received %s)"
@@ -45,8 +43,8 @@ let unknown_args ~valid_keys args =
    to keep the synthesized summary single-line. *)
 let synthesize_summary_from_siblings args =
   let pick key =
-    match args |> member key with
-    | `String s ->
+    match Json_util.assoc_member_opt key args with
+    | Some (`String s) ->
         let trimmed = String.trim s in
         if String.equal trimmed "" then None else Some trimmed
     | _ -> None
@@ -99,15 +97,15 @@ let transition_action_requires_summary : Masc_domain.task_action -> bool =
 let parse_handoff_context ~(agent_name : string)
     ~(action : Masc_domain.task_action) args =
   let summary_required = transition_action_requires_summary action in
-  match args |> member "handoff_context" with
-  | `Null ->
+  match Json_util.assoc_member_opt "handoff_context" args with
+  | None | Some `Null ->
     (* No handoff_context object provided. For entry-class actions this
        is the expected shape; for exit-class actions the caller's
        strict-release / contract checks downstream will surface the
        missing summary if the task contract demands it. We do not
        fabricate an empty handoff_context here. *)
     Ok None
-  | (`Assoc _ as json) -> (
+  | Some (`Assoc _ as json) -> (
       match Masc_domain.task_handoff_context_of_yojson json with
       | Error error ->
           Error
@@ -149,7 +147,7 @@ let parse_handoff_context ~(agent_name : string)
                    updated_at = Some (Masc_domain.now_iso ());
                    updated_by = Some agent_name;
                  }))
-  | other ->
+  | Some other ->
       Error
         (Printf.sprintf
            "handoff_context must be an object when provided (received %s)"

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -442,35 +442,30 @@ let task_status_to_yojson = function
       ]
 
 let task_status_of_yojson json =
-  let open Yojson.Safe.Util in
+  let req key = Json_util.get_string json key |> Option.value ~default:"" in
+  let opt key = Json_util.get_string json key in
   try
-    let status = json |> member "status" |> to_string in
-    match status with
+    match req "status" with
     | "todo" -> Ok Todo
     | "claimed" ->
-        let assignee = json |> member "assignee" |> to_string in
-        let claimed_at = json |> member "claimed_at" |> to_string in
-        Ok (Claimed { assignee; claimed_at })
+        Ok (Claimed { assignee = req "assignee"; claimed_at = req "claimed_at" })
     | "in_progress" ->
-        let assignee = json |> member "assignee" |> to_string in
-        let started_at = json |> member "started_at" |> to_string in
-        Ok (InProgress { assignee; started_at })
+        Ok (InProgress { assignee = req "assignee"; started_at = req "started_at" })
     | "done" ->
-        let assignee = json |> member "assignee" |> to_string in
-        let completed_at = json |> member "completed_at" |> to_string in
-        let notes = json |> member "notes" |> to_string_option in
-        Ok (Done { assignee; completed_at; notes })
+        Ok (Done { assignee = req "assignee"; completed_at = req "completed_at"; notes = opt "notes" })
     | "awaiting_verification" ->
-        let assignee = json |> member "assignee" |> to_string in
-        let submitted_at = json |> member "submitted_at" |> to_string in
-        let verification_id = json |> member "verification_id" |> to_string in
-        let deadline = json |> member "deadline" |> to_string_option in
-        Ok (AwaitingVerification { assignee; submitted_at; verification_id; deadline })
+        Ok (AwaitingVerification
+              { assignee = req "assignee"
+              ; submitted_at = req "submitted_at"
+              ; verification_id = req "verification_id"
+              ; deadline = opt "deadline"
+              })
     | "cancelled" ->
-        let cancelled_by = json |> member "cancelled_by" |> to_string in
-        let cancelled_at = json |> member "cancelled_at" |> to_string in
-        let reason = json |> member "reason" |> to_string_option in
-        Ok (Cancelled { cancelled_by; cancelled_at; reason })
+        Ok (Cancelled
+              { cancelled_by = req "cancelled_by"
+              ; cancelled_at = req "cancelled_at"
+              ; reason = opt "reason"
+              })
     | s -> Error ("Unknown task status: " ^ s)
   with e -> Error (Printexc.to_string e)
 
@@ -683,49 +678,46 @@ let task_to_yojson t =
   | _ -> `Assoc with_do_not_reclaim
 
 let task_of_yojson json =
-  let open Yojson.Safe.Util in
+  let req key = Json_util.get_string json key |> Option.value ~default:"" in
+  let opt key = Json_util.get_string json key in
+  let m key = Option.value ~default:`Null (Json_util.assoc_member_opt key json) in
   try
-    let id = json |> member "id" |> to_string in
-    let title = json |> member "title" |> to_string in
-    let description = json |> member "description" |> to_string_option |> Option.value ~default:"" in
-    let priority = json |> member "priority" |> to_int_option |> Option.value ~default:3 in
-    let files = json |> member "files" |> to_list |> List.map to_string in
-    let created_at = json |> member "created_at" |> to_string in
-    let created_by = json |> member "created_by" |> to_string_option in
-    let goal_id = json |> member "goal_id" |> to_string_option in
-    (* Parse optional stage field *)
-    let stage = match json |> member "stage" |> to_string_option with
+    let id = req "id" in
+    let title = req "title" in
+    let description = opt "description" |> Option.value ~default:"" in
+    let priority = Json_util.get_int json "priority" |> Option.value ~default:3 in
+    let files = Json_util.get_string_list json "files" in
+    let created_at = req "created_at" in
+    let created_by = opt "created_by" in
+    let goal_id = opt "goal_id" in
+    let stage = match opt "stage" with
       | Some s -> (match Task_stage.of_string s with Ok st -> Some st | Error _ -> None)
       | None -> None
     in
-    let contract = match json |> member "contract" with
+    let contract = match m "contract" with
       | `Null -> None
       | contract_json ->
           (match task_contract_of_yojson contract_json with
            | Ok contract -> Some contract
            | Error _ -> None)
     in
-    let handoff_context = match json |> member "handoff_context" with
+    let handoff_context = match m "handoff_context" with
       | `Null -> None
       | handoff_json ->
           (match task_handoff_context_of_yojson handoff_json with
            | Ok handoff_context -> Some handoff_context
            | Error _ -> None)
     in
-    let cycle_count =
-      json |> member "cycle_count" |> to_int_option |> Option.value ~default:0
-    in
+    let cycle_count = Json_util.get_int json "cycle_count" |> Option.value ~default:0 in
     let reclaim_policy =
-      match json |> member "reclaim_policy" with
+      match m "reclaim_policy" with
       | `Null -> None
       | reclaim_policy_json ->
           (match task_reclaim_policy_of_yojson reclaim_policy_json with
            | Ok policy -> Some policy
            | Error _ -> None)
     in
-    let do_not_reclaim_reason =
-      json |> member "do_not_reclaim_reason" |> to_string_option
-    in
+    let do_not_reclaim_reason = opt "do_not_reclaim_reason" in
     match task_status_of_yojson json with
     | Ok task_status ->
         Ok
@@ -842,13 +834,12 @@ let tempo_config_to_yojson c =
   ]
 
 let tempo_config_of_yojson json =
-  let open Yojson.Safe.Util in
   try
-    let mode_str = json |> member "mode" |> to_string in
-    let delay_ms = json |> member "delay_ms" |> to_int_option |> Option.value ~default:0 in
-    let reason = json |> member "reason" |> to_string_option in
-    let set_by = json |> member "set_by" |> to_string_option in
-    let set_at = json |> member "set_at" |> to_string_option in
+    let mode_str = Json_util.get_string json "mode" |> Option.value ~default:"" in
+    let delay_ms = Json_util.get_int json "delay_ms" |> Option.value ~default:0 in
+    let reason = Json_util.get_string json "reason" in
+    let set_by = Json_util.get_string json "set_by" in
+    let set_at = Json_util.get_string json "set_at" in
     match tempo_mode_of_string mode_str with
     | Ok mode -> Ok { mode; delay_ms; reason; set_by; set_at }
     | Error e -> Error e
@@ -869,9 +860,9 @@ let backlog_to_yojson b =
   ]
 
 let backlog_of_yojson json =
-  let open Yojson.Safe.Util in
+  let m key = Option.value ~default:`Null (Json_util.assoc_member_opt key json) in
   try
-    let tasks_json = json |> member "tasks" |> to_list in
+    let tasks_json = match m "tasks" with `List l -> l | _ -> [] in
     let tasks = List.filter_map (fun j ->
       match task_of_yojson j with Ok t -> Some t | Error _ -> None
     ) tasks_json in
@@ -885,12 +876,10 @@ let backlog_of_yojson json =
        failed] entries/day driven [stale-claims] GC to skip mutation,
        so claims never transitioned).  Tolerate missing/null fields. *)
     let last_updated =
-      json |> member "last_updated" |> to_string_option
-      |> Option.value ~default:""
+      Json_util.get_string json "last_updated" |> Option.value ~default:""
     in
     let version =
-      json |> member "version" |> to_int_option
-      |> Option.value ~default:1
+      Json_util.get_int json "version" |> Option.value ~default:1
     in
     Ok { tasks; last_updated; version }
   with e -> Error (Printexc.to_string e)
@@ -978,16 +967,16 @@ let a2a_task_to_yojson t =
   ]
 
 let a2a_task_of_yojson json =
-  let open Yojson.Safe.Util in
+  let req key = Json_util.get_string json key |> Option.value ~default:"" in
   try
-    let a2a_id = json |> member "id" |> to_string in
-    let from_agent = json |> member "from" |> to_string in
-    let to_agent = json |> member "to" |> to_string in
-    let a2a_message = json |> member "message" |> to_string in
-    let status_str = json |> member "status" |> to_string in
-    let a2a_result = json |> member "result" |> to_string_option in
-    let created_at = json |> member "createdAt" |> to_string in
-    let updated_at = json |> member "updatedAt" |> to_string in
+    let a2a_id = req "id" in
+    let from_agent = req "from" in
+    let to_agent = req "to" in
+    let a2a_message = req "message" in
+    let status_str = req "status" in
+    let a2a_result = Json_util.get_string json "result" in
+    let created_at = req "createdAt" in
+    let updated_at = req "updatedAt" in
     match a2a_task_status_of_string status_str with
     | Ok a2a_status -> Ok { a2a_id; from_agent; to_agent; a2a_message; a2a_status; a2a_result; created_at; updated_at }
     | Error e -> Error e
@@ -1013,13 +1002,13 @@ let portal_to_yojson p =
   ]
 
 let portal_of_yojson json =
-  let open Yojson.Safe.Util in
+  let req key = Json_util.get_string json key |> Option.value ~default:"" in
   try
-    let portal_from = json |> member "from" |> to_string in
-    let portal_target = json |> member "target" |> to_string in
-    let portal_opened_at = json |> member "openedAt" |> to_string in
-    let status_str = json |> member "status" |> to_string in
-    let task_count = json |> member "taskCount" |> to_int in
+    let portal_from = req "from" in
+    let portal_target = req "target" in
+    let portal_opened_at = req "openedAt" in
+    let status_str = req "status" in
+    let task_count = Json_util.get_int json "taskCount" |> Option.value ~default:0 in
     match portal_state_of_string status_str with
     | Ok portal_status -> Ok { portal_from; portal_target; portal_opened_at; portal_status; task_count }
     | Error e -> Error e

--- a/lib/worker_runtime_config.ml
+++ b/lib/worker_runtime_config.ml
@@ -55,24 +55,24 @@ let load_file_config path =
   if Sys.file_exists path then
     try
       let json = Safe_ops.read_json_eio path in
-        let open Yojson.Safe.Util in
-        let spawn_json = member "worker_spawn" json in
+        let m key src = Option.value ~default:`Null (Json_util.assoc_member_opt key src) in
+        let spawn_json = m "worker_spawn" json in
         let backend =
-          match spawn_json |> member "backend" with
+          match m "backend" spawn_json with
           | `String value -> (
               match Worker_execution_backend.of_string value with
               | Some backend -> backend
               | None -> default.worker_spawn.backend)
           | _ -> default.worker_spawn.backend
         in
-        let docker_json = spawn_json |> member "docker" in
+        let docker_json = m "docker" spawn_json in
         let image =
-          match docker_json |> member "image" with
+          match m "image" docker_json with
           | `String value when String.trim value <> "" -> value
           | _ -> default.worker_spawn.docker.image
         in
         let host_mcp_base_url =
-          match docker_json |> member "host_mcp_base_url" with
+          match m "host_mcp_base_url" docker_json with
           | `String value ->
               let trimmed = String.trim value in
               if trimmed = "" then None else Some trimmed


### PR DESCRIPTION
## 요약

닫힌 PR #19434(SSOT consolidation)의 **잔여 8파일**만 떼어 정리한다.
#19434는 96% 파일 중복 / 충돌 100+로 평행 PR(#19403/#19423/#19437)에 추월당해 CLOSED.
이 8파일은 그중 main이 아직 안 건드린 부분집합이라 충돌 없이 적용 가능하다.

- inline `Yojson.Safe.Util.member` / `to_string_option` → `Json_util.get_string` / `Json_util.assoc_member_opt`
  (둘 다 현재 main `lib/core/json_util.mli`에 이미 export됨 — 새 의존 추가 없음)
- 파일별 bespoke 헬퍼를 canonical `Json_util` / `String_util` / `Safe_ops`로 위임

## 변경 파일 (8)

`lib/bounded.ml`, `lib/coord/coord_eio.ml`, `lib/graphql_api.ml`, `lib/institution_eio.ml`,
`lib/mcp_server_eio_protocol.ml`, `lib/tool_task_args.ml`, `lib/types/types_core.ml`, `lib/worker_runtime_config.ml`

## 검증

- 최신 main(`90c41d882`) worktree 위에서 이 8파일 적용 후 `DUNE_CACHE=disabled dune build --root .` → 이 8파일에서 **에러 0**.

## 주의 (Draft 사유)

현재 origin/main 자체가 broken이다 (5 에러, 유발: **#19437** SSOT consolidation의
`take_last`/`contains_ci`/`clamp` alias 제거 + caller drift, `keeper_turn_driver` record→float desync).
본 PR과 **무관**하나, CI는 PR⊕main을 빌드하므로 main 복구 전까지 red다.
따라서 Draft로 두고, main green 복구 후 rebase → Ready 전환한다.

RFC-WAIVED: credential/keeper_sandbox/operator_control/hooks/workflow subsystem 미접촉. 순수 JSON/string 헬퍼 SSOT 위임(anti-pattern 추가 아닌 제거).

Refs #19442
