### PR TITLE
fix(build): restore 5 compilation errors on main (PR #19437 SSOT consolidation follow-up)

### DIFF
--- a/lib/dashboard/dashboard_goals_types_attainment.ml
+++ b/lib/dashboard/dashboard_goals_types_attainment.ml
@@ -14,6 +14,8 @@ open Dashboard_goals_types_accessor
 let clamp_float lower upper value =
   if value < lower then lower else if value > upper then upper else value
 
+let contains_ci = String_util.contains_substring_ci
+
 let pct_of_float value =
   int_of_float (floor (clamp_float 0.0 100.0 value +. 0.5))
 

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -704,7 +704,7 @@ let run_named
   let turn_deadline =
     match Eio_context.get_clock_opt () with
     | Some clock ->
-        let turn_budget = (Keeper_runtime_resolved.turn_timeout_sec ()).value in
+        let turn_budget = Keeper_runtime_resolved.turn_timeout_sec () in
         Some (Cascade_deadline.of_seconds_from_now ~clock turn_budget)
     | None -> None
   in

--- a/lib/keeper_recording_error_state/keeper_recording_error_state.mli
+++ b/lib/keeper_recording_error_state/keeper_recording_error_state.mli
@@ -61,6 +61,7 @@ type error_kind =
   | Cascade_resolution_failure (** Cascade tier/strategy resolution failure. *)
   | Unknown_phase_transition (** FSM unknown phase transition. *)
   | Auth_token_mismatch (** Auth/token mismatch family. *)
+  | Shutdown_artifact (** Shutdown artifact from supervisor. *)
   | Other (** Anything not yet promoted to its own arm. *)
 
 (** Stable label used in Prometheus dimensions and log dedupe keys.

--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -12,6 +12,11 @@ open Meta_cognition_types
 
 let rule_id_tension_tool_blockage = "tension:masc_tool_blockage"
 
+let clamp ~min_v ~max_v value =
+  if value < min_v then min_v
+  else if value > max_v then max_v
+  else value
+
 (* ================================================================ *)
 (* Data loading                                                     *)
 (* ================================================================ *)

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -356,3 +356,5 @@ let internal_history_json_to_trajectory_line (json : Yojson.Safe.t)
 
 let runtime_manifest_public_json row =
   Keeper_runtime_manifest.public_to_json row
+
+let take_last = List_util.take_last


### PR DESCRIPTION
## Summary

- `meta_cognition_snapshot.ml`: `clamp` was removed from `meta_cognition_types.ml` by PR #19437 but callers at lines 218, 330, 451 still referenced it. Added local definition.
- `keeper_recording_error_state.mli`: `Shutdown_artifact` variant existed in `.ml` but was missing from `.mli` interface declaration.
- `keeper_turn_driver.ml:707`: `turn_timeout_sec ()` returns `float` directly, not a record — stale `.value` accessor.
- `server_dashboard_http_keeper_api_types.ml`: `.mli` declared `take_last` but `.ml` had no implementation. Delegates to `List_util.take_last`.
- `dashboard_goals_types_attainment.ml`: `.mli` declared `contains_ci` but `.ml` had no implementation. Delegates to `String_util.contains_substring_ci`.

All 5 errors are interface/implementation drift exposed by PR #19437 SSOT consolidation.

## Test plan
- [ ] `dune build .` passes with 0 errors
- [ ] `dune build @runtest` passes
- [ ] MASC server starts and responds on port 8935

🤖 Generated with [Claude Code](https://claude.com/claude-code)