### PR TITLE
refactor(cdal): stop gating tool execution by mode (PreToolUse never skips)

### DIFF
--- a/lib/cdal_runtime/mode_enforcer.ml
+++ b/lib/cdal_runtime/mode_enforcer.ml
@@ -381,20 +381,15 @@ let evidence_effect_class_of_tool_class = function
   | Shell_dynamic -> Effect_evidence.Shell_dynamic
 ;;
 
-let violation_kind_for_class st cls =
-  match st.effective_mode with
-  | Execution_mode.Diagnose ->
-    (match cls with
-     | Local_mutation | External_effect -> Some Mutating_in_diagnose
-     | Read_only | Shell_dynamic -> None)
-  | Execution_mode.Draft ->
-    (match cls with
-     | External_effect -> Some External_in_draft
-     | Read_only | Local_mutation | Shell_dynamic -> None)
-  | Execution_mode.Execute ->
-    (* Execute mode imposes no tool-effect-class violation. CDAL does not
-       gate tool actions by path/mutation scope (assurance plane only). *)
-    None
+let violation_kind_for_class _st _cls =
+  (* CDAL does not gate tool actions by execution mode. Which tools an agent
+     may run is a control-plane concern, not part of CDAL's assurance ontology
+     (task/goal completion verdict). No tool call is ever classified as a
+     violation in any mode, so the PreToolUse hook never skips a tool. Effect
+     evidence is still recorded (as allowed) for the proof bundle. The
+     Mutating_in_diagnose / External_in_draft variants remain only for
+     decoding pre-existing proof records. *)
+  None
 ;;
 
 let record_effect_evidence


### PR DESCRIPTION
## 요약

CDAL이 실행 모드로 tool 실행을 게이팅하던 것을 중단합니다. 어떤 tool을 쓸 수 있는지는 control-plane 관심사이지 CDAL(task/goal 완성 verdict)의 온톨로지가 아닙니다.

`mode_enforcer`의 PreToolUse hook이 모드별로 tool을 Skip하고 있었습니다 (Diagnose→mutation, Draft→external), `contract_runner`를 통해 worker_oas/cascade_runner의 모든 contract run에 배선됨. `violation_kind_for_class`를 전 모드 `None`으로 바꿔 **PreToolUse가 절대 Skip하지 않게** 합니다 — tool은 모드로 차단되지 않습니다.

## 안전성

- task/goal 검증 무영향: `cdal_evidence_gate`/`cdal_verdict_gate`/`goal_verification`은 이 enforcement 경로에 의존 0. task 완성 게이트(`tool_task_contract_gate` → `Cdal_evidence_gate.decide`)는 mode_enforcer와 독립.
- effect evidence는 여전히 (allowed로) proof에 기록됨. `Mutating_in_diagnose`/`External_in_draft` variant는 기존 proof 레코드 디코딩용으로 유지.
- 검증: `dune build lib/cdal_runtime/` + `dune build lib/` exit 0, `test_cdal_mode_enforcer` 13/13 통과.

## 맥락

CDAL에서 tool 제어를 분리하는 작업의 Stage 1 (게이트 무력화). 더 큰 `Cdal_proof`/contract-runtime decommission(keeper telemetry/metrics에 엮임)은 별도 staged 작업.

RFC-WAIVED: assurance-plane 경계 정합을 위한 control 게이트 무력화, 1파일.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
