### PR TITLE
fix(keeper): replace hardcoded cascade names with live route resolution

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -2,6 +2,7 @@
 
 open Tool_args
 include Keeper_config_rp_helpers
+open Keeper_cascade_profile
 
 (** Upper bound for keeper time configs expressed in seconds.  Repeated
     seven times as the bare literal [172800] across this file before
@@ -15,11 +16,20 @@ let two_days_seconds_int = Masc_time_constants.day_int * 2
     naming the "1 day" intent at the call site. *)
 let one_day_seconds_int = Masc_time_constants.day_int
 
-let default_cascade_name () = "runpod:glm-coding-with-spark"
-let phase_recovery_cascade_name = "runpod:glm-coding-with-spark"
-let phase_buffer_cascade_name = "runpod:glm-coding-with-spark"
-let phase_routing_cascade_names = [ "runpod:glm-coding-with-spark" ]
-let tool_required_cascade_name = "runpod:glm-coding-with-spark"
+let default_cascade_name () =
+  try cascade_name_for_use Keeper_turn with _ -> "tool_strict"
+
+let phase_recovery_cascade_name =
+  try cascade_name_for_use Phase_recovery with _ -> "tool_strict"
+
+let phase_buffer_cascade_name =
+  try cascade_name_for_use Phase_buffer with _ -> "tool_strict"
+
+let phase_routing_cascade_names =
+  [ try cascade_name_for_use Routing with _ -> "tool_strict" ]
+
+let tool_required_cascade_name =
+  try cascade_name_for_use Tool_required with _ -> "tool_strict"
 
 (** Minimum context window (tokens) for any keeper turn.
     64k-class local models are valid keeper backends; do not clamp them upward

--- a/scripts/lint/no-provider-name-hardcoding.allowlist
+++ b/scripts/lint/no-provider-name-hardcoding.allowlist
@@ -4,9 +4,8 @@
 #
 # Format: path:line:literal
 lib/cascade/cascade_runtime.ml:37:auto
-lib/cascade/cascade_runtime.ml:46:custom
-lib/cascade/cascade_runtime.ml:67:openai_compat
-lib/cascade/cascade_runtime.ml:321:auto
+lib/cascade/cascade_runtime.ml:40:openai_compat
+lib/cascade/cascade_runtime.ml:186:auto
 lib/provider_runtime_projection.ml:108:auto
 lib/provider_runtime_projection.ml:206:auto
 lib/provider_runtime_projection.ml:254:openrouter


### PR DESCRIPTION
## Summary

- `keeper_config.ml`이 `"runpod:glm-coding-with-spark"` (PR #19440/#19445로 제거된 old tier-group 이름)를 모든 cascade name 상수에 하드코딩
- cascade catalog가 RFC-0058 프로파일 이름(`tool_strict`, `lite`)만 알기 때문에, 모든 keepalive turn에서 `cascade_resilience_cascade_resolution_error` 발생 → fleet-wide deadlock
- 5개 상수 + `keeper_llm_rerank_cascade` fallback을 `cascade_name_for_use` (live cascade.toml route config 읽기)로 대체
- route target이 provider binding이면 첫 번째 프로파일 이름으로 자동 fallback, `"tool_strict"`는 TOML 파싱 실패 시 safety net

## Root Cause

PR #19440/#19445가 tier/tier-group admission 시스템을 제거하면서 cascade.toml에서 old tier-group 이름이 사라졌지만, `keeper_config.ml`은 여전히 `"runpod:glm-coding-with-spark"`를 하드코딩하고 있었다.

## Fix Design

| Before | After |
|--------|-------|
| `"runpod:glm-coding-with-spark"` (string literal) | `cascade_name_for_use Keeper_turn` (live config query) |
| 하드코딩 → cascade.toml 변경 시 keeper_config 수정 필요 | self-healing → cascade.toml만 올바르면 자동 동작 |

## Test plan

- [ ] `dune build @check` 통과 확인
- [ ] Deploy 후 keepalive turn이 `cascade_resilience_cascade_resolution_error` 없이 정상 동작 확인
- [ ] system_log에서 keeper turn이 정상 claim/start/complete 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)