### PR TITLE
feat(runtime): cascade→Runtime substrate (B0+B2a) — additive Runtime module + materialize

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -8,6 +8,12 @@
 # api_format (Messages_api / Chat_completions_api / Ollama_api) and
 # reads everything else from this file. See RFC-0058 §2.4.
 
+# ── Runtime: global default ─────────────────────────────────────
+# cascade→Runtime 전환. routes/cascade_name 간접을 대체하는 글로벌 default
+# Runtime (binding key "provider.model"). 없으면 startup fail (silent fallback 금지).
+[runtime]
+default = "runpod_mtp.qwen-runpod"
+
 # ── Layer 1: Providers ──────────────────────────────────────────
 
 

--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -312,6 +312,26 @@ let resolve_binding_config (cfg : cascade_config)
         :: !errors;
       None
 
+(** cascade→Runtime 전환: 단일 binding 을 [Provider_config.t] 로 materialize.
+
+    [resolve_binding_config] 을 감싸 override/error-ref 를 result 로 평탄화한다.
+    Runtime 모듈이 routing(profile/route/cascade_name) 없이 binding 하나를
+    곧장 소비하기 위한 진입점. capabilities override 는 v1 에서 버린다
+    (alias 레이어와 함께 제거 대상). NB: cascade/ 삭제(B4) 시 이 builder
+    [provider_config_from_declared_provider] 를 살아남는 lib 로 이전해야 한다. *)
+let binding_to_provider_config (cfg : cascade_config) (binding : cascade_binding)
+    : (Llm_provider.Provider_config.t, string) result =
+  let errors = ref [] in
+  match resolve_binding_config cfg binding errors with
+  | Some (config, _override) -> Ok config
+  | None ->
+    let rendered =
+      match !errors with
+      | [] -> Printf.sprintf "%s.%s: unresolved binding" binding.provider_id binding.model_id
+      | es -> String.concat "; " (List.map show_adapter_error es)
+    in
+    Error rendered
+
 (* --- Alias overrides --- *)
 
 let apply_alias_overrides (base : Llm_provider.Provider_config.t)

--- a/lib/cascade/cascade_declarative_adapter.mli
+++ b/lib/cascade/cascade_declarative_adapter.mli
@@ -64,6 +64,14 @@ type adapted_catalog = {
 
 (** {1 Entry point} *)
 
+val binding_to_provider_config :
+  Cascade_declarative_types.cascade_config ->
+  Cascade_declarative_types.cascade_binding ->
+  (Llm_provider.Provider_config.t, string) result
+(** cascade→Runtime 전환: 단일 binding 을 routing 없이 [Provider_config.t] 로
+    materialize. provider/model resolve 실패 시 [Error] (silent fallback 없음).
+    capabilities override 와 alias 레이어는 버린다 (v1). *)
+
 val adapt_config : Cascade_declarative_types.cascade_config -> adapted_catalog
 (** [adapt_config cfg] converts a validated declarative config into an
     adapted catalog. Resolution errors are accumulated in

--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -813,6 +813,9 @@ let parse_toml (toml : Otoml.t) : (cascade_config, parse_error list) result =
   let routes = parse_routes toml in
   let system_targets = parse_system_targets toml in
   let profiles = parse_profiles toml in
+  let default_runtime_id =
+    Otoml.find_opt toml Otoml.get_string [ "runtime"; "default" ]
+  in
   if all_errors <> []
   then Error all_errors
   else (
@@ -821,7 +824,15 @@ let parse_toml (toml : Otoml.t) : (cascade_config, parse_error list) result =
     in
     let models = extract_after_all_errors_guard ~label:"models" models_result in
     Ok
-      { providers; models; bindings; aliases; routes; system_targets; profiles })
+      { providers
+      ; models
+      ; bindings
+      ; aliases
+      ; routes
+      ; system_targets
+      ; profiles
+      ; default_runtime_id
+      })
 ;;
 
 let parse_string (content : string) : (cascade_config, parse_error list) result =

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -352,6 +352,11 @@ type cascade_config =
   ; routes : cascade_route list
   ; system_targets : cascade_route list
   ; profiles : cascade_profile list
+  ; default_runtime_id : string option
+    (** RFC: cascade→Runtime 전환. [\[runtime\] default = "provider.model"]
+        TOML 테이블에서 파싱. routes/cascade_name 간접을 대체하는 글로벌
+        default Runtime 식별자. None 이면 Runtime.load_list 가 startup 에서
+        fail-fast (silent fallback 금지). *)
   }
 [@@deriving show, eq]
 

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -294,6 +294,9 @@ type cascade_config =
   ; routes : cascade_route list
   ; system_targets : cascade_route list
   ; profiles : cascade_profile list
+  ; default_runtime_id : string option
+    (** cascade→Runtime 전환. [\[runtime\] default = "provider.model"] TOML
+        에서 파싱. None 이면 Runtime.load_list 가 startup 에서 fail-fast. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -16,18 +16,25 @@ type t =
   ; provider : cascade_provider
   ; model : cascade_model_spec
   ; binding : cascade_binding
+  ; provider_config : Llm_provider.Provider_config.t
+    (** load 시점에 materialize 된 hot-path provider config. 소비자는
+        routing 없이 이걸 곧장 LLM dispatch 로 넘긴다. *)
   }
 
 let id_of_binding (b : cascade_binding) : string =
   Printf.sprintf "%s.%s" b.provider_id b.model_id
 ;;
 
-(** binding 을 Runtime 으로 변환. provider/model 이 [cfg] 에서 resolve 안 되면
-    [None] (fail-closed — partial-boot 없음). *)
+(** binding 을 Runtime 으로 변환. provider/model resolve 또는 provider_config
+    materialize 가 실패하면 [None] (fail-closed — partial-boot 없음, 해당
+    binding 은 가용 Runtime 목록에서 제외). *)
 let of_binding (cfg : cascade_config) (b : cascade_binding) : t option =
   match provider_of_id cfg b.provider_id, model_of_id cfg b.model_id with
   | Some provider, Some model ->
-    Some { id = id_of_binding b; provider; model; binding = b }
+    (match Cascade_declarative_adapter.binding_to_provider_config cfg b with
+     | Ok provider_config ->
+       Some { id = id_of_binding b; provider; model; binding = b; provider_config }
+     | Error _ -> None)
   | _ -> None
 ;;
 

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1,0 +1,66 @@
+(** Runtime = Provider + Model + Spec(binding).
+
+    cascade→Runtime 전환 (B0). cascade 의 routes/cascade_name/tier/profile
+    간접 레이어를 제거하고, binding(provider × model) 하나를 곧 하나의 Runtime
+    으로 본다. 소비자는 Runtime 목록 + default Runtime 을 직접 소비한다.
+
+    B0 는 additive: 기존 [Cascade_declarative_types] 를 합성만 한다(새 nominal
+    타입 없음 — 264파일 강결합에서 새 타입은 conversion 폭증을 부른다).
+    provider_cfg (hot-path materialize) 는 소비자 연결 단계(B2)에서 추가. *)
+
+open Cascade_declarative_types
+
+type t =
+  { id : string
+    (** binding key ["provider.model"], 예 ["runpod_mtp.qwen-runpod"] *)
+  ; provider : cascade_provider
+  ; model : cascade_model_spec
+  ; binding : cascade_binding
+  }
+
+let id_of_binding (b : cascade_binding) : string =
+  Printf.sprintf "%s.%s" b.provider_id b.model_id
+;;
+
+(** binding 을 Runtime 으로 변환. provider/model 이 [cfg] 에서 resolve 안 되면
+    [None] (fail-closed — partial-boot 없음). *)
+let of_binding (cfg : cascade_config) (b : cascade_binding) : t option =
+  match provider_of_id cfg b.provider_id, model_of_id cfg b.model_id with
+  | Some provider, Some model ->
+    Some { id = id_of_binding b; provider; model; binding = b }
+  | _ -> None
+;;
+
+(** TOML 에서 Runtime 목록과 default Runtime 을 로드한다.
+
+    fail-fast: [\[runtime\] default] 가 없거나 그 id 가 목록에 없으면 [Error].
+    silent fallback 일절 없음 (cascade→Runtime 비전: TOML 에 default 없으면
+    프로그램 실행 불가). *)
+let load_list ~(config_path : string) : (t list * t, string) result =
+  match Cascade_declarative_parser.parse_file config_path with
+  | Error errs ->
+    Error
+      (Printf.sprintf
+         "cascade config parse failed (%s): %d error(s)"
+         config_path
+         (List.length errs))
+  | Ok cfg ->
+    let runtimes = List.filter_map (of_binding cfg) cfg.bindings in
+    (match cfg.default_runtime_id with
+     | None ->
+       Error
+         (Printf.sprintf
+            "%s: [runtime].default is required (no default runtime configured; \
+             silent fallback removed)"
+            config_path)
+     | Some did ->
+       (match List.find_opt (fun (r : t) -> String.equal r.id did) runtimes with
+        | Some rt -> Ok (runtimes, rt)
+        | None ->
+          Error
+            (Printf.sprintf
+               "%s: [runtime].default = %S not found among %d runtimes"
+               config_path
+               did
+               (List.length runtimes))))
+;;

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -708,6 +708,7 @@ let test_duplicate_routes () =
         ]
     ; system_targets = []
     ; profiles = []
+    ; default_runtime_id = None
     }
   in
   let catalog = adapt_config cfg in

--- a/test/test_cascade_declarative_validator.ml
+++ b/test/test_cascade_declarative_validator.ml
@@ -148,6 +148,7 @@ let test_r3_unknown_binding () =
     routes = [];
     system_targets = [];
     profiles = [];
+    default_runtime_id = None;
   } in
   let errs = Cascade_declarative_validator.validate cfg in
   has_rule "R3" errs


### PR DESCRIPTION
## 목표

cascade → Runtime 전환의 **B0/B2a 단계**(additive Runtime 모듈 도입 + provider_config materialize)를, 풀빌드/테스트로 검증된 상태로 main에 안착시킵니다. 소비자(keeper turn dispatch) 전환(B3)과 `lib/cascade/` 삭제(B4)는 후속 PR로 분리합니다.

전환 비전: binding(provider×model) 하나가 곧 하나의 `Runtime`. `routes`/`cascade_name`/`tier`/`profile` 간접을 제거하고 소비자가 Runtime 목록 + `default_runtime`을 직접 소비. 이 PR은 그 **substrate만** 추가하며 기존 cascade 경로를 변경하지 않습니다(additive).

## 변경 파일 (9, +129/-1)

- `lib/runtime/runtime.ml` (신규, 73줄) — `type t = {id;provider;model;binding;provider_config}`. `load_list ~config_path : (t list * t) result` — default 미지정/미해결 시 `Error`(fail-fast, silent fallback 0). `of_binding`은 materialize 실패 binding을 풀에서 제외(fail-closed).
- `lib/cascade/cascade_declarative_adapter.ml/.mli` — `binding_to_provider_config` export (resolve_binding_config wrap, unresolved 시 `Error`). NB: B4에서 살아남는 lib로 이전 예정.
- `lib/cascade_decl/cascade_declarative_types.ml/.mli` — `cascade_config`에 `default_runtime_id : string option` 추가.
- `lib/cascade_decl/cascade_declarative_parser.ml` — `[runtime].default` 파싱.
- `config/cascade.toml` — `[runtime] default` 추가.
- `test/test_cascade_declarative_{adapter,validator}.ml` — fixture에 `default_runtime_id = None` 추가 (B0 필드 추가 follow-up).

## 로컬 검증

- 풀 default-target 빌드: `DUNE_CACHE=disabled dune build --root .` → **EXIT 0** (B2a 이후 처음으로 링크까지 green).
- `test/test_cascade_declarative_adapter.exe` → **17/17 통과**.
- `test/test_cascade_declarative_validator.exe` → **17/17 통과**.
- base가 broken이던 6종 컴파일 에러는 최신 main(#19450 복구) rebase로 해소됨.

## 남은 미검증 항목 (의도적 후속)

- `lib/runtime/runtime.ml` **자체 단위 테스트 없음** — `of_binding` fail-closed / `load_list` fail-fast 동작은 아직 테스트로 증명되지 않음. B3 이전 보강 필요.
- **소비자가 Runtime을 아직 소비하지 않음** — route/cascade_name 인다이렉션 여전히 살아있음. 이 PR은 substrate만.

## RFC

cascade→Runtime 전환 전체를 다루는 단일 RFC는 아직 없습니다. 본 PR의 declarative config 변경은 **RFC-0058 (declarative-cascade-config)** 영역의 additive 확장입니다. B3(소비자 gut)/B4(`lib/cascade/` 삭제)는 의미 변경 범위가 커서 별도 RFC로 설계 예정입니다.

RFC-WAIVED: substrate-only additive 변경(신규 Runtime 모듈 + 1 optional 필드). 기존 cascade 경로/credential/identity/operator/sandbox/dashboard/hooks 어디도 변경하지 않음. 의미 변경을 동반하는 B3/B4는 RFC 선행.

## Best Programmer self-review

- 타입 안전: `load_list`/`binding_to_provider_config` 모두 `result` 반환, unknown/unresolved를 `Error`로 처리(permissive default 회피).
- fail-fast: default 미지정 시 startup `Error` — silent fallback 도입 없음.
- 범위: additive only, 기존 동작 회귀 없음(풀빌드+기존 테스트 green).
- Magic string: `config/cascade.toml`의 `[runtime] default` 값은 config SSOT, 코드 하드코딩 아님.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
