### PR TITLE
feat(dashboard): Command 라우트 IA 정리 (Keeper Fleet 포인터 제거 / 긴급정지 헤더 승격 / Approvals 라벨)

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -33,6 +33,7 @@ import {
   SideRail,
 } from './components/dashboard-shell'
 import { ThemeSwitch } from './components/theme-switch'
+import { EmergencyStopControl } from './components/emergency-stop-control'
 import { TransportBeacon } from './components/transport-beacon'
 import { DashboardSurfaceTabs } from './components/dashboard-surface-tabs'
 import { SkipLink } from './components/skip-link'
@@ -283,6 +284,7 @@ export function App() {
           </div>
 
           <div class="flex shrink-0 flex-wrap items-center justify-end gap-2 max-[1080px]:justify-between">
+            <${EmergencyStopControl} />
             <${Suspense} fallback=${authStatusFallback()}>
               <${LazyAuthStatus} />
             <//>

--- a/dashboard/src/components/emergency-stop-control.test.ts
+++ b/dashboard/src/components/emergency-stop-control.test.ts
@@ -1,0 +1,141 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  fetchPauseStatus,
+  pauseRoom,
+  resumeRoom,
+  flowState,
+  flowLoading,
+  shellAuthSummary,
+  requestConfirm,
+  authAccess,
+} = vi.hoisted(() => ({
+  fetchPauseStatus: vi.fn().mockResolvedValue(undefined),
+  pauseRoom: vi.fn().mockResolvedValue(undefined),
+  resumeRoom: vi.fn().mockResolvedValue(undefined),
+  flowState: { value: 'running' as 'running' | 'paused' | 'initializing' | 'unknown' },
+  flowLoading: { value: false },
+  shellAuthSummary: { value: null },
+  requestConfirm: vi.fn().mockResolvedValue(true),
+  authAccess: { allowed: true, reason: null as string | null },
+}))
+
+vi.mock('./flow-control/flow-control-state', () => ({
+  fetchPauseStatus,
+  pauseRoom,
+  resumeRoom,
+  flowState,
+  flowLoading,
+}))
+
+vi.mock('../store', () => ({ shellAuthSummary }))
+
+vi.mock('../lib/dashboard-auth-access', () => ({
+  dashboardAuthAccess: () => authAccess,
+}))
+
+vi.mock('./common/confirm-dialog', () => ({ requestConfirm }))
+
+import { EmergencyStopControl } from './emergency-stop-control'
+
+async function flushUi(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('EmergencyStopControl', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    flowState.value = 'running'
+    flowLoading.value = false
+    shellAuthSummary.value = null
+    authAccess.allowed = true
+    authAccess.reason = null
+    requestConfirm.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+  })
+
+  it('renders an Emergency Stop button when running with worker access', async () => {
+    render(html`<${EmergencyStopControl} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Emergency Stop')
+    expect(container.querySelector('[data-testid="emergency-stop-control"]')).toBeTruthy()
+  })
+
+  it('pauses the namespace after the confirmation is accepted', async () => {
+    render(html`<${EmergencyStopControl} />`, container)
+    await flushUi()
+
+    const btn = container.querySelector('[data-testid="emergency-stop-control"]') as HTMLButtonElement
+    btn.click()
+    await flushUi()
+
+    expect(requestConfirm).toHaveBeenCalledTimes(1)
+    expect(pauseRoom).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not pause when the confirmation is declined', async () => {
+    requestConfirm.mockResolvedValue(false)
+    render(html`<${EmergencyStopControl} />`, container)
+    await flushUi()
+
+    const btn = container.querySelector('[data-testid="emergency-stop-control"]') as HTMLButtonElement
+    btn.click()
+    await flushUi()
+
+    expect(requestConfirm).toHaveBeenCalledTimes(1)
+    expect(pauseRoom).not.toHaveBeenCalled()
+  })
+
+  it('hides the Emergency Stop button when worker access is denied', async () => {
+    authAccess.allowed = false
+    authAccess.reason = 'viewer role cannot pause'
+    render(html`<${EmergencyStopControl} />`, container)
+    await flushUi()
+
+    expect(container.textContent).not.toContain('Emergency Stop')
+  })
+
+  it('shows a Paused badge and a Resume button when paused', async () => {
+    flowState.value = 'paused'
+    render(html`<${EmergencyStopControl} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Paused')
+    expect(container.textContent).toContain('Resume')
+  })
+
+  it('resumes the namespace when Resume is clicked', async () => {
+    flowState.value = 'paused'
+    render(html`<${EmergencyStopControl} />`, container)
+    await flushUi()
+
+    // Resume is the only button rendered in the paused state.
+    const btn = container.querySelector('button') as HTMLButtonElement
+    btn.click()
+    await flushUi()
+
+    expect(resumeRoom).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders nothing while the flow state is unknown', async () => {
+    flowState.value = 'unknown'
+    render(html`<${EmergencyStopControl} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toBe('')
+    expect(container.querySelector('[data-testid="emergency-stop-control"]')).toBeNull()
+  })
+})

--- a/dashboard/src/components/emergency-stop-control.ts
+++ b/dashboard/src/components/emergency-stop-control.ts
@@ -1,0 +1,68 @@
+// EmergencyStopControl — global header-resident namespace pause/resume control.
+//
+// Reuses the flow-control-state signals (flowState/flowLoading/pauseRoom/
+// resumeRoom), so this header control and the Command → Flow Control panel
+// share state automatically through preact signals — pausing here flips the
+// panel badge to 'Paused' without any extra wiring.
+//
+// Rendering contract:
+//   - running + worker access → red "Emergency Stop" button (confirm-gated)
+//   - paused                  → "Paused" badge (+ "Resume" button when allowed)
+//   - unknown / initializing  → nothing (keeps the header uncluttered)
+
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import { Square, Play } from 'lucide-preact'
+import { requestConfirm } from './common/confirm-dialog'
+import { ActionButton } from './common/button'
+import { CountBadge } from './common/badge'
+import { shellAuthSummary } from '../store'
+import { dashboardAuthAccess } from '../lib/dashboard-auth-access'
+import {
+  flowState,
+  flowLoading,
+  fetchPauseStatus,
+  pauseRoom,
+  resumeRoom,
+} from './flow-control/flow-control-state'
+
+export function EmergencyStopControl() {
+  useEffect(() => { void fetchPauseStatus() }, [])
+
+  const state = flowState.value
+  const loading = flowLoading.value
+  const access = dashboardAuthAccess(shellAuthSummary.value, 'worker')
+
+  if (state === 'paused') {
+    return html`
+      <div class="flex items-center gap-1.5" data-testid="emergency-stop-control">
+        <${CountBadge} tone="warn">Paused<//>
+        ${access.allowed ? html`
+          <${ActionButton} variant="ghost" size="sm" disabled=${loading}
+            onClick=${() => void resumeRoom()}>
+            <span class="inline-flex items-center gap-1"><${Play} size=${12} />Resume</span>
+          <//>
+        ` : null}
+      </div>
+    `
+  }
+
+  if (state === 'running' && access.allowed) {
+    return html`
+      <${ActionButton} variant="danger" size="sm" disabled=${loading}
+        testId="emergency-stop-control"
+        onClick=${async () => {
+          const confirmed = await requestConfirm({
+            title: 'Emergency Stop',
+            message: 'Pause the entire namespace now? All keeper activity halts until resumed.',
+            tone: 'danger',
+          })
+          if (confirmed) void pauseRoom()
+        }}>
+        <span class="inline-flex items-center gap-1"><${Square} size=${12} />Emergency Stop</span>
+      <//>
+    `
+  }
+
+  return null
+}

--- a/dashboard/src/components/operations-panel.test.ts
+++ b/dashboard/src/components/operations-panel.test.ts
@@ -105,7 +105,7 @@ describe('OperationsPanel', () => {
     const labels = Array.from(buttons).map(b => b.textContent?.trim())
     expect(labels).toContain('All')
     expect(labels).toContain('Intervene')
-    expect(labels).toContain('Governance')
+    expect(labels).toContain('Approvals')
     expect(labels).toContain('Surfaces')
     expect(labels).toContain('Inspector')
   })
@@ -128,7 +128,7 @@ describe('OperationsPanel', () => {
     await flushUi()
 
     const buttons = container.querySelectorAll('button[type="button"]')
-    const governanceBtn = Array.from(buttons).find(b => b.textContent?.trim() === 'Governance')
+    const governanceBtn = Array.from(buttons).find(b => b.textContent?.trim() === 'Approvals')
     expect(governanceBtn?.getAttribute('aria-selected')).toBe('true')
 
     const defaultBtn = Array.from(buttons).find(b => b.textContent?.trim() === 'All')

--- a/dashboard/src/components/operations-panel.ts
+++ b/dashboard/src/components/operations-panel.ts
@@ -16,7 +16,7 @@ const VALID_VIEWS: OpsView[] = ['default', 'ops', 'governance', 'surfaces', 'ins
 const VIEW_CHIPS: { key: OpsView; label: string }[] = [
   { key: 'default', label: 'All' },
   { key: 'ops', label: 'Intervene' },
-  { key: 'governance', label: 'Governance' },
+  { key: 'governance', label: 'Approvals' },
   { key: 'surfaces', label: 'Surfaces' },
   { key: 'inspector', label: 'Inspector' },
 ]

--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -138,7 +138,7 @@ describe('Ops surface', () => {
     expect(items[2]?.textContent).toContain('키퍼 메시지는 잠시 보류')
   }, 120000)
 
-  it('points to Monitor → Keeper Fleet instead of rendering its own keeper roster', async () => {
+  it('does not render its own keeper roster or fleet pointer (lives on Monitor → Keeper Fleet)', async () => {
     const {
       Ops,
       route,
@@ -180,10 +180,9 @@ describe('Ops surface', () => {
     expect(container.querySelector('[data-testid="keeper-utilities-panel"]')).toBeNull()
     expect(container.querySelector('[data-testid="keeper-action-panel"]')).toBeNull()
 
-    const pointer = container.querySelector('[data-testid="ops-keeper-fleet-link"]')
-    expect(pointer).toBeTruthy()
-    const link = pointer?.querySelector('a')
-    expect(link?.getAttribute('href')).toBe('#monitoring?section=agents')
+    // The keeper-fleet pointer card was removed: it had no action of its own,
+    // only a link to Monitor → Keeper Fleet (reachable from the sidebar).
+    expect(container.querySelector('[data-testid="ops-keeper-fleet-link"]')).toBeNull()
   }, 60000)
 
   it('renders the same single surface when active review items are present (no 3-column unhealthy branch)', async () => {

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -19,7 +19,6 @@ import {
 } from '../../workflow-context'
 import type { OperatorActionLogEntry, OperatorReviewDecision } from '../../types'
 import { QuickIntervene } from './quick-intervene'
-import { RouteLink } from '../common/route-link'
 import {
   actionTypeLabel,
   formatMessageContent,
@@ -234,25 +233,6 @@ export function Ops() {
       <section class="grid grid-cols-2 gap-4 max-[1200px]:grid-cols-1" aria-label="Operations controls">
         <div class="grid gap-4 order-1 max-[1200px]:order-2">
           <${QuickIntervene} />
-          <section
-            class="${CARD_STANDARD} grid gap-2"
-            data-testid="ops-keeper-fleet-link"
-            aria-label="Keeper fleet pointer"
-          >
-            <h2 class="text-sm font-semibold text-[var(--color-fg-secondary)]">Keeper Fleet</h2>
-            <p class="text-xs text-[var(--color-fg-muted)]">
-              Per-keeper pause, resume, boot, and shutdown live on Monitor → Keeper Fleet.
-              Operations focuses on intervention, governance, and approvals.
-            </p>
-            <${RouteLink}
-              tab="monitoring"
-              params=${{ section: 'agents' }}
-              class="inline-flex w-fit items-center gap-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] px-3 py-1.5 text-xs font-medium text-[var(--color-fg-primary)] hover:bg-[var(--color-bg-elevated)]"
-              title="Open Monitor → Keeper Fleet"
-            >
-              Open Keeper Fleet →
-            <//>
-          </section>
         </div>
 
         <section class="${CARD_STANDARD} grid gap-3 order-2 max-[1200px]:order-1" aria-label="Recent operator activity">


### PR DESCRIPTION
## 목표

Command 라우트 IA 정리. nav-telemetry(`/metrics`) 측정과 코드 분석으로 확인된 3가지를 손봤습니다.

## 변경

### 1. Keeper Fleet 포인터 카드 제거 (`ops/index.ts`)
Intervene 뷰의 "Keeper Fleet" 카드는 자체 동작이 없고 Monitor → Keeper Fleet로 가는 링크뿐이었습니다(sidebar로도 도달 가능). 죽은 바로가기라 제거하고 미사용 `RouteLink` import도 정리했습니다.

### 2. 긴급정지 헤더 승격 (`emergency-stop-control.ts` 신규 + `app.ts`)
기존 namespace pause/resume(`flow-control-state`)을 전역 헤더 상주 컨트롤로 올렸습니다. 어느 화면에서든 즉시 정지할 수 있습니다.
- `flow-control-state`의 signal을 **재사용**하므로 Command → Flow Control 패널과 상태가 자동 동기화됩니다(별도 배선 없음).
- worker role 가드 + 정지 전 confirm 다이얼로그.
- `running`일 때만 빨간 Emergency Stop, `paused`면 Paused 배지 + Resume, `unknown/initializing`이면 렌더 안 함.

### 3. `Governance` 칩 → `Approvals` (`operations-panel.ts`)
해당 뷰의 AI Judge는 `governance_judge` cascade route에 의존하는데 현재 로드 불가 상태(아래 follow-up)라, 살아있는 실질 기능인 approval queue를 라벨로 드러냈습니다. section key/URL(`governance`)은 유지.

## 로컬 검증
- `tsc --noEmit`: 0 에러
- `eslint`: 0 에러
- 변경 영역 테스트: 20 passed (emergency-stop 7 신규 + ops/index 6 + operations-panel 7)

## 범위 밖 (follow-up)
AI Judge 11/11 error는 이 PR과 무관한 **runtime config 문제**입니다 — `cascade.toml`이 옛 flat `"runtime"` profile 형식이라 RFC-0058 declarative 로더가 거부. 별도 이슈 #19456으로 기록했습니다. 해결 방향은 Runtime 마이그레이션 완료.

## 미검증
- 실제 브라우저에서 헤더 긴급정지 버튼의 시각 배치/반응형(좁은 폭) 확인은 안 했습니다. 단위 테스트로 렌더 분기만 검증.

RFC-WAIVED: dashboard IA-only 변경(credential/identity/operator control plane 미해당).
