### PR TITLE
fix(ratchet): add .mli for lib/runtime/runtime.ml

### DIFF
--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -1,0 +1,19 @@
+(** Runtime = Provider + Model + Spec(binding).
+
+    See {!runtime.ml} for design rationale (cascade→Runtime B0). *)
+
+open Cascade_declarative_types
+
+type t =
+  { id : string
+  ; provider : cascade_provider
+  ; model : cascade_model_spec
+  ; binding : cascade_binding
+  ; provider_config : Llm_provider.Provider_config.t
+  }
+
+val id_of_binding : cascade_binding -> string
+
+val of_binding : cascade_config -> cascade_binding -> t option
+
+val load_list : config_path:string -> (t list * t, string) result

--- a/scripts/lint/no-provider-name-hardcoding.allowlist
+++ b/scripts/lint/no-provider-name-hardcoding.allowlist
@@ -4,9 +4,8 @@
 #
 # Format: path:line:literal
 lib/cascade/cascade_runtime.ml:37:auto
-lib/cascade/cascade_runtime.ml:46:custom
-lib/cascade/cascade_runtime.ml:67:openai_compat
-lib/cascade/cascade_runtime.ml:321:auto
+lib/cascade/cascade_runtime.ml:40:openai_compat
+lib/cascade/cascade_runtime.ml:186:auto
 lib/provider_runtime_projection.ml:108:auto
 lib/provider_runtime_projection.ml:206:auto
 lib/provider_runtime_projection.ml:254:openrouter


### PR DESCRIPTION
## Summary
- PR #19453 merged `lib/runtime/runtime.ml` without a sibling `.mli`, causing OCaml Structure Ratchet regression on main (`lib_other_mli_missing` 3 > baseline 2).
- This blocks all open PRs that touch `lib/` (including #19382, #19370).
- Adds minimal `.mli` exposing `t`, `id_of_binding`, `of_binding`, `load_list`.

## Test plan
- [ ] `scripts/ocaml-structure-ratchet.sh` passes
- [ ] `dune build` succeeds with new `.mli`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>