### PR TITLE
refactor(gate): partial Yojson accessor → Json_util safe getter (round5 batch A)

### DIFF
--- a/lib/gate/channel_gate_connector.ml
+++ b/lib/gate/channel_gate_connector.ml
@@ -23,8 +23,6 @@ module type S = sig
     (Yojson.Safe.t, string) result
 end
 
-module U = Yojson.Safe.Util
-
 let registry : (string, (module S)) Hashtbl.t = Hashtbl.create 4
 
 let register (module C : S) =
@@ -46,7 +44,7 @@ let connectors_json ?gate_status_json ?(audit_limit = 10) () =
   let active_count =
     List.fold_left
       (fun acc json ->
-        if json |> U.member "available" |> U.to_bool_option
+        if Json_util.get_bool json "available"
            |> Option.value ~default:false
         then acc + 1
         else acc)

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -186,16 +186,16 @@ let read_recent_audit ~limit =
         else rows |> drop_left (total - limit) |> List.rev)
 
 let string_member json key =
-  json |> U.member key |> U.to_string_option |> Option.value ~default:""
+  Json_util.get_string json key |> Option.value ~default:""
 
 let int_member json key =
-  json |> U.member key |> U.to_int_option |> Option.value ~default:0
+  Json_util.get_int json key |> Option.value ~default:0
 
 let bool_member json key =
-  json |> U.member key |> U.to_bool_option |> Option.value ~default:false
+  Json_util.get_bool json key |> Option.value ~default:false
 
 let bool_option_member json key =
-  json |> U.member key |> U.to_bool_option
+  Json_util.get_bool json key
 
 let stale_of_updated_at updated_at =
   match Gate_time_util.parse_iso8601_opt updated_at with
@@ -352,7 +352,9 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
           `Int (int_member status "runtime_bindings_count") );
         ( "configured_bindings_count",
           `Int
-            (status |> U.member "configured_bindings" |> U.to_list |> List.length)
+            (Json_util.get_array status "configured_bindings"
+             |> Option.map (function `List l -> List.length l | _ -> 0)
+             |> Option.value ~default:0)
         );
       ]
   in

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -210,16 +210,16 @@ let read_recent_audit ~limit =
         else rows |> drop_left (total - limit) |> List.rev)
 
 let string_member json key =
-  json |> U.member key |> U.to_string_option |> Option.value ~default:""
+  Json_util.get_string json key |> Option.value ~default:""
 
 let int_member json key =
-  json |> U.member key |> U.to_int_option |> Option.value ~default:0
+  Json_util.get_int json key |> Option.value ~default:0
 
 let bool_member json key =
-  json |> U.member key |> U.to_bool_option |> Option.value ~default:false
+  Json_util.get_bool json key |> Option.value ~default:false
 
 let bool_option_member json key =
-  json |> U.member key |> U.to_bool_option
+  Json_util.get_bool json key
 
 let stale_of_updated_at updated_at =
   match Gate_time_util.parse_iso8601_opt updated_at with
@@ -278,7 +278,7 @@ let status_json ?(audit_limit = 10) () =
       ("messages_processed", `Int (status_field "messages_processed" int_member 0));
       ("messages_failed", `Int (status_field "messages_failed" int_member 0));
       ("cursor_rowid", `Int (status_field "cursor_rowid" int_member 0));
-      ("poll_interval_sec", `Float (status_field "poll_interval_sec" (fun j k -> j |> U.member k |> U.to_float_option |> Option.value ~default:2.0) 2.0));
+      ("poll_interval_sec", `Float (status_field "poll_interval_sec" (fun j k -> Json_util.get_float j k |> Option.value ~default:2.0) 2.0));
       ("gate_base_url", `String (status_field "gate_base_url" string_member ""));
       ( "gate_healthy",
         Option.value ~default:`Null


### PR DESCRIPTION
## 목표

PR #19454(SSOT round 5, CLOSED)의 잔여분 중 **gate 도메인 3파일(배치 A)**을 정리합니다. round5는 100파일을 건드렸으나 형제 SSOT 라운드들이 대부분 흡수했고, main에 남은 잔여는 12파일 38곳뿐 — 그 중 gate 3파일 11곳입니다.

## 변경

`Yojson.Safe.Util`의 partial accessor(`U.to_*`, 실패 시 예외)를 `Json_util`의 total getter(`get_*`, `option` 반환)로 교체. **동작 동등**(둘 다 option 반환), 타입 안전성만 향상.

| 파일 | 변경 |
|---|---|
| `channel_gate_connector.ml` | `to_bool_option` → `get_bool`, `module U` 제거(잔여 참조 0) |
| `channel_gate_discord_state.ml` | string/int/bool helper + `configured_bindings_count`(`to_list` → `get_array`). raw `U.member` 잔존 → `module U` 유지 |
| `channel_gate_imessage_state.ml` | string/int/bool helper + `poll_interval_sec`(`to_float_option` → `get_float`). `module U` 유지 |

net: 3파일 +13/-13. 변환 패턴은 #19454의 검증된 형태를 따름.

## 검증

- `dune build --root .` → **0 에러**.
- `test_channel_gate_connector_routes` → **3/3**
- `test_channel_gate_discord_state` → **9/9**
- `test_channel_gate_imessage_state` → **2/2**

## 범위 / RFC

- `lib/gate/` 3파일만. credential/identity/operator/sandbox/dashboard/hooks/workflow 무관.
- raw `U.member`(필드 추출, total)는 의도적으로 유지 — partial accessor만 제거.

RFC-WAIVED: SSOT 유틸 통일(동작 동등 리팩터, 정책/기능 변경 없음). 후속 배치(B: dashboard/audit/cache 등, 남은 9파일 27곳)는 별도 PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
