### PR TITLE
refactor(ssot): fix 10 U.member type-unsafe patterns in operator_control* (round 5 leftover)

### DIFF
--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -55,14 +55,10 @@ let keeper_diagnostic_for_name (ctx : 'a context) ~(name : string) =
              ~now_ts)
 
 let keeper_diagnostic_health_state json =
-  match U.member "health_state" json with
-  | `String value -> Some (String.lowercase_ascii value)
-  | _ -> None
+  Json_util.get_string json "health_state" |> Option.map String.lowercase_ascii
 
 let keeper_diagnostic_recoverable json =
-  match U.member "recoverable" json with
-  | `Bool value -> value
-  | _ -> false
+  Json_util.get_bool json "recoverable" |> Option.value ~default:false
 
 let keeper_recovery_outcome after_diagnostic =
   match keeper_diagnostic_health_state after_diagnostic with
@@ -185,9 +181,7 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
       in
       let* before_diagnostic = keeper_diagnostic_for_name ctx ~name:resolved_name in
       let recoverable =
-        match U.member "recoverable" before_diagnostic with
-        | `Bool value -> value
-        | _ -> false
+        Json_util.get_bool before_diagnostic "recoverable" |> Option.value ~default:false
       in
       if not recoverable then
         Ok
@@ -239,22 +233,19 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
         | None -> Error "payload.message is required"
       in
       let* () =
-        match request.payload |> U.member "models" with
-        | `Null -> Ok ()
-        | _ ->
+        match Json_util.get_object request.payload "models" with
+        | None -> Ok ()
+        | Some _ ->
             Error
               "legacy keeper model args removed for masc_keeper_msg: models. Use cascade_name; concrete provider/model identity is OAS-owned."
       in
       let direct_reply =
-        match request.payload |> U.member "direct_reply" with
-        | `Bool value -> value
-        | _ -> false
+        Json_util.get_bool request.payload "direct_reply" |> Option.value ~default:false
       in
       let timeout_sec =
-        match request.payload |> U.member "timeout_sec" with
-        | `Int value when value > 0 -> Some value
-        | `Float value when value > 0.0 -> Some (int_of_float (Float.ceil value))
-        | _ -> None
+        Json_util.get_float request.payload "timeout_sec"
+        |> Option.map (fun f -> int_of_float (Float.ceil f))
+        |> Option.filter (fun n -> n > 0)
       in
       let args =
         `Assoc

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -1,4 +1,3 @@
-module U = Yojson.Safe.Util
 include Operator_pending_confirm
 include Operator_digest
 
@@ -17,9 +16,7 @@ let degraded_keeper_runtime_identity_fields = Operator_control_snapshot_identity
 include Operator_control_snapshot_action_log
 
 let get_payload args =
-  match U.member "payload" args with
-  | `Assoc _ as payload -> payload
-  | _ -> `Assoc []
+  Json_util.get_object args "payload" |> Option.value ~default:(`Assoc [])
 ;;
 
 let merge_json_objects left right =

--- a/lib/operator/operator_control_snapshot_persistent_agents.ml
+++ b/lib/operator/operator_control_snapshot_persistent_agents.ml
@@ -101,9 +101,7 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
              let agent_status =
                match agent_json with
                | `Assoc _ ->
-                 (match agent_json |> U.member "status" with
-                  | `String status -> status
-                  | _ -> "unknown")
+                 Json_util.get_string agent_json "status" |> Option.value ~default:"unknown"
                | _ -> "unknown"
              in
              let context_snapshot = keeper_context_snapshot_of_meta config meta in

--- a/lib/operator/operator_control_snapshot_persistent_agents.ml
+++ b/lib/operator/operator_control_snapshot_persistent_agents.ml
@@ -18,7 +18,6 @@
     Both paths emit the same wire shape — `runtime_class="keeper"`
     plus the standard operator-dashboard keeper fields. *)
 
-module U = Yojson.Safe.Util
 include Operator_control_context_snapshot
 
 let persistent_agents_json ?keeper_names ?keeper_rows config =

--- a/lib/operator/operator_control_snapshot_tool_names.ml
+++ b/lib/operator/operator_control_snapshot_tool_names.ml
@@ -4,8 +4,6 @@
     Pure JSON/string helpers used to surface the recent tools a keeper
     has called in the operator's "recent" view. *)
 
-module U = Yojson.Safe.Util
-
 let merge_tool_name_lists primary secondary =
   let seen = Hashtbl.create 16 in
   let add acc raw_name =
@@ -20,23 +18,10 @@ let merge_tool_name_lists primary secondary =
 ;;
 
 let tool_names_of_recent_json (json : Yojson.Safe.t) =
-  let tools_used =
-    match U.member "tools_used" json with
-    | `List items ->
-      List.filter_map
-        (function
-          | `String value ->
-            let trimmed = String.trim value in
-            if trimmed = "" then None else Some trimmed
-          | _ -> None)
-        items
-    | _ -> []
-  in
+  let tools_used = Json_util.get_string_list json "tools_used" in
   let single_tool =
-    match U.member "tool" json with
-    | `String value ->
-      let trimmed = String.trim value in
-      if trimmed = "" then [] else [ trimmed ]
+    match Json_util.get_string json "tool" with
+    | Some value when String.trim value <> "" -> [ value ]
     | _ -> []
   in
   merge_tool_name_lists single_tool tools_used


### PR DESCRIPTION
## Summary

- Fix 10 remaining `U.member` + pattern-match type-unsafe patterns in `operator_control*` files
- These survived the round 5 rebase because conflicting files took HEAD's version, dropping our intended changes
- Replace raw `Yojson.Safe.Util.member` calls with `Json_util.get_*` canonical helpers

### Changes

| File | Pattern | Fix |
|------|---------|-----|
| `operator_control.ml` | `U.member "health_state"` → `` `String `` | `Json_util.get_string` |
| `operator_control.ml` | `U.member "recoverable"` → `` `Bool `` (×2) | `Json_util.get_bool` |
| `operator_control.ml` | `U.member "models"` → `` `Null `` check | `Json_util.get_object` + `None` check |
| `operator_control.ml` | `U.member "direct_reply"` → `` `Bool `` | `Json_util.get_bool` |
| `operator_control.ml` | `U.member "timeout_sec"` → `` `Int ``/`` `Float `` | `Json_util.get_float` + `ceil` |
| `operator_control_snapshot.ml` | `U.member "payload"` → `` `Assoc `` | `Json_util.get_object` |
| `operator_control_snapshot.ml` | dead `module U` | removed |
| `operator_control_snapshot_persistent_agents.ml` | `U.member "status"` → `` `String `` | `Json_util.get_string` |
| `operator_control_snapshot_tool_names.ml` | `U.member "tools_used"` → `` `List `` | `Json_util.get_string_list` |
| `operator_control_snapshot_tool_names.ml` | `U.member "tool"` → `` `String `` | `Json_util.get_string` |
| `operator_control_snapshot_tool_names.ml` | dead `module U` | removed |

## Test plan

- [ ] `dune build @check` passes (no new unbound modules)
- [ ] `dune build .` passes (full build)
- [ ] `dune runtest` passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)