### PR TITLE
refactor(ssot): remove dead JSON helpers from dashboard types (round 5 cleanup 2)

### DIFF
--- a/lib/cascade/cascade_config_resolve.ml
+++ b/lib/cascade/cascade_config_resolve.ml
@@ -94,15 +94,6 @@ let materialized_member_model_string json provider_id api_name =
          |> Option.map (fun prefix -> Printf.sprintf "%s:%s" prefix api_name)
        | None -> None)
 
-let json_string_list_member key json =
-  match Json_util.assoc_member_opt key json with
-  | Some (`List values) ->
-    values
-    |> List.filter_map (function
-         | `String value -> Some value
-         | _ -> None)
-  | _ -> []
-
 let materialized_model_api_name json model_id =
   match
     Option.bind (Json_util.assoc_member_opt "models" json) (fun models_json ->

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -125,41 +125,6 @@ let extract_keeper_name_for_post req_path suffix =
   in
   if is_valid_keeper_name raw then raw else ""
 
-let json_int_member_opt name json =
-  match Yojson.Safe.Util.member name json with
-  | `Int value -> Some value
-  | `Intlit raw -> int_of_string_opt raw
-  | _ -> None
-
-let json_string_member_opt name json =
-  match Yojson.Safe.Util.member name json with
-  | `String value -> Some value
-  | _ -> None
-
-let json_bool_member_opt name json =
-  match Yojson.Safe.Util.member name json with
-  | `Bool value -> Some value
-  | _ -> None
-
-let json_string_list_member name json =
-  match Yojson.Safe.Util.member name json with
-  | `List values ->
-    values
-    |> List.filter_map (function
-      | `String value when String.trim value <> "" -> Some value
-      | _ -> None)
-    |> Json_util.dedupe_keep_order
-  | _ -> []
-
-let json_string_opt = Json_util.string_opt_to_json
-let json_assoc_member_opt name json =
-  match Yojson.Safe.Util.member name json with
-  | `Assoc _ as value -> Some value
-  | _ -> None
-
-let json_string_value_opt = function
-  | `String value -> Some value
-  | _ -> None
 let manifest_row_matches ?turn_id keeper_name trace_id
     (row : Keeper_runtime_manifest.t) =
   String.equal row.keeper_name keeper_name

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -19,13 +19,8 @@ let empty_paused_keeper_scan =
 
 let sorted_unique_strings values = List.sort_uniq String.compare values
 
-let json_float_opt = function
-  | Some value -> `Float value
-  | None -> `Null
-
-let json_string_opt = function
-  | Some value -> `String value
-  | None -> `Null
+let json_float_opt = Json_util.float_opt_to_json
+let json_string_opt = Json_util.string_opt_to_json
 
 let effective_autoboot_enabled name (meta : Keeper_meta_contract.keeper_meta) =
   match (Keeper_types_profile.load_keeper_profile_defaults name).autoboot_enabled with


### PR DESCRIPTION
## Summary

- Remove 7 dead JSON accessor helpers from `server_dashboard_http_keeper_api_types.ml`
- These duplicated `Json_util` functions but had zero callers across the codebase
- Also removes dead `module U = Yojson.Safe.Util` from `operator_control_snapshot_persistent_agents.ml`

### Dead code removed

| Helper | `Json_util` equivalent |
|--------|----------------------|
| `json_int_member_opt` | `get_int` |
| `json_string_member_opt` | `get_string` |
| `json_bool_member_opt` | `get_bool` |
| `json_string_list_member` | `get_string_list` |
| `json_assoc_member_opt` | `get_object` |
| `json_string_opt` | `string_opt_to_json` |
| `json_string_value_opt` | (value-level, no equivalent needed) |

## Test plan

- [ ] `dune build @check` passes
- [ ] `dune build .` passes
- [ ] `dune runtest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)