### PR TITLE
fix(test): remove stale proof field from worker_runtime test

### DIFF
--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -126,7 +126,6 @@ let test_worker_runtime_helper_protocol_roundtrip () =
       session_id = "worker-session";
       raw_trace_run = None;
       api_response = None;
-      proof = None;
     }
   in
   let encoded =


### PR DESCRIPTION
## Problem

PR #19469 removed the `proof` field from `Lib.Worker_runtime.run_result`, but `test/test_worker_runtime.ml` was not updated. This causes a compile error in test builds.

## Fix

Remove the stale `proof = None;` line from the test record literal.

## Verification

- [x] Local diff reviewed (1 line removed)
- [ ] CI passing (awaiting)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
