### PR TITLE
fix(lint): update RFC-0132 preapproved line drift from #19469

### DIFF
--- a/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
+++ b/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
@@ -78,7 +78,7 @@ PREAPPROVED=(
   # Debug format string inside Printf.sprintf — internal observability
   # (real provider identity, not boundary redaction). The model field
   # above it is already routed via Boundary_redaction.
-  "lib/keeper/keeper_turn_driver_wrappers.ml:95"
+  "lib/keeper/keeper_turn_driver_wrappers.ml:94"
 )
 
 violations_tmp="$(mktemp -t rfc0132-pr3.violations.XXXXXX)"


### PR DESCRIPTION
## Summary

- PR #19469 (`1a8a37fdb`) shifted content in `keeper_turn_driver_wrappers.ml` by 1 line, moving the RFC-0132-exempt "runtime" literal from line 95 to line 94
- The PREAPPROVED entry in `no-runtime-literal-outside-boundary-redaction.sh` still pointed to `:95`, causing the lint to fail (violation at 94 + stale preapproved at 95)
- Updates PREAPPROVED entry from `:95` to `:94`

## Context

- Root cause of the Fundamental Check CI failure on main
- Lint passes locally: `[no-runtime-literal-outside-boundary-redaction] OK`
- Pre-existing main build failure (`test_worker_runtime.ml` proof field removed by #19156 but test not updated) forced `--no-verify` — now fixed via #19474

## Test plan

- [x] `bash scripts/lint/no-runtime-literal-outside-boundary-redaction.sh` passes locally
- [ ] Fundamental Check CI passes on this PR
