### PR TITLE
feat(shell-ir): value-consuming flags for Docker, Go, Cargo, Npm, Mvn, Gradle

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -3329,6 +3329,27 @@ parse None None 0 false args|}
     ; parse_body =
         Some
           {|
+(* Npm flags that consume the next token as their argument *)
+let npm_value_flags =
+  [ "--registry"
+  ; "--prefix"
+  ; "--cache"
+  ; "--userconfig"
+  ; "--tag"
+  ; "--scope"
+  ; "--auth-type"
+  ; "--otp"
+  ; "--loglevel"
+  ; "--timing"
+  ; "--workspace"; "-w"
+  ; "--omit"
+  ; "--install-strategy"
+  ; "--save-exact"; "-E"
+  ; "--save-bundle"; "-B"
+  ; "--proxy"; "--https-proxy"
+  ; "--no-proxy"
+  ]
+in
 let rec parse subcmd sd glb frc dd = function
   | [] ->
     (match subcmd with
@@ -3340,6 +3361,20 @@ let rec parse subcmd sd glb frc dd = function
   | "--global" :: rest when not dd -> parse subcmd sd true frc dd rest
   | "-g" :: rest when not dd -> parse subcmd sd true frc dd rest
   | "--force" :: rest when not dd -> parse subcmd sd glb true dd rest
+  (* Value-consuming flags: skip the flag and its argument *)
+  | arg :: _val :: rest
+    when not dd && String.length arg > 0 && arg.[0] = '-'
+         && List.mem arg npm_value_flags ->
+    parse subcmd sd glb frc dd rest
+  (* --flag=VALUE equal-sign form *)
+  | arg :: rest
+    when not dd && String.length arg > 2 && arg.[0] = '-' && arg.[1] = '-'
+         && (match String.index_opt arg '=' with
+              | Some i ->
+                let flag = String.sub arg 0 i in
+                List.mem flag npm_value_flags
+              | None -> false) ->
+    parse subcmd sd glb frc dd rest
   (* POSIX end-of-options: all remaining args are positional *)
   | "--" :: rest -> parse subcmd sd glb frc true rest
   | arg :: rest ->
@@ -3384,6 +3419,23 @@ parse None false false false false args|}
     ; parse_body =
         Some
           {|
+(* Cargo flags that consume the next token as their argument *)
+let cargo_value_flags =
+  [ "--target"; "--target-dir"
+  ; "--manifest-path"
+  ; "--color"
+  ; "--jobs"; "-j"
+  ; "--profile"
+  ; "--bin"; "--example"; "--test"; "--bench"
+  ; "--package"; "-p"
+  ; "--message-format"
+  ; "--out-dir"
+  ; "--config"
+  ; "--registry"; "--index"; "--token"
+  ; "--exclude"
+  ; "-Z"
+  ]
+in
 let rec parse subcmd rel verb feat dd = function
   | [] ->
     (match subcmd with
@@ -3394,27 +3446,39 @@ let rec parse subcmd rel verb feat dd = function
   | "--verbose" :: rest when not dd -> parse subcmd rel true feat dd rest
   | "-v" :: rest when not dd -> parse subcmd rel true feat dd rest
   | "--features" :: f :: rest when not dd -> parse subcmd rel verb (Some f) dd rest
+  (* Value-consuming flags: skip the flag and its argument *)
+  | arg :: _val :: rest
+    when not dd && String.length arg > 0 && arg.[0] = '-'
+         && List.mem arg cargo_value_flags ->
+    parse subcmd rel verb feat dd rest
+  (* --flag=VALUE equal-sign form for value-consuming flags *)
+  | arg :: rest
+    when not dd && String.length arg > 2 && arg.[0] = '-' && arg.[1] = '-'
+         && (match String.index_opt arg '=' with
+              | Some i ->
+                let flag = String.sub arg 0 i in
+                List.mem flag cargo_value_flags || flag = "--features"
+              | None -> false) ->
+    (match String.index_opt arg '=' with
+     | Some i when String.sub arg 0 i = "--features" ->
+       let f = String.sub arg (i + 1) (String.length arg - i - 1) in
+       parse subcmd rel verb (Some f) dd rest
+     | _ -> parse subcmd rel verb feat dd rest)
   (* POSIX end-of-options: all remaining args are positional *)
   | "--" :: rest -> parse subcmd rel verb feat true rest
   | arg :: rest ->
-    (* Handle --features=VALUE *)
-    if not dd && String.length arg > 11 && String.sub arg 0 11 = "--features="
-    then (
-      let f = String.sub arg 11 (String.length arg - 11) in
-      parse subcmd rel verb (Some f) dd rest)
-    else (
-      match subcmd with
-      | None when not dd -> parse (Some arg) rel verb feat dd rest
-      | _ ->
-        let rec collect acc = function
-          | [] -> List.rev acc
-          | x :: xs -> collect (x :: acc) xs
-        in
-        Some (Shell_ir_typed_types.W (Shell_ir_typed_types.Cargo {
-          subcommand = (match subcmd with Some s -> s | None -> arg);
-          release = rel; verbose = verb; features = feat;
-          rest = collect (match subcmd with Some _ -> [ arg ] | None -> []) rest
-        })))
+    (match subcmd with
+     | None when not dd -> parse (Some arg) rel verb feat dd rest
+     | _ ->
+       let rec collect acc = function
+         | [] -> List.rev acc
+         | x :: xs -> collect (x :: acc) xs
+       in
+       Some (Shell_ir_typed_types.W (Shell_ir_typed_types.Cargo {
+         subcommand = (match subcmd with Some s -> s | None -> arg);
+         release = rel; verbose = verb; features = feat;
+         rest = collect (match subcmd with Some _ -> [ arg ] | None -> []) rest
+       })))
 in
 parse None false false None false args|}
     ; no_expand_combined = false
@@ -3443,6 +3507,29 @@ parse None false false None false args|}
     ; parse_body =
         Some
           {|
+(* Go flags that consume the next token as their argument *)
+let go_value_flags =
+  [ "-o"
+  ; "-C"
+  ; "-ldflags"; "-asmflags"; "-gcflags"
+  ; "-tags"
+  ; "-mod"
+  ; "-count"
+  ; "-benchtime"
+  ; "-timeout"
+  ; "-run"; "-bench"
+  ; "-coverprofile"; "-covermode"; "-coverpkg"
+  ; "-cpuprofile"; "-memprofile"; "-blockprofile"; "-mutexprofile"
+  ; "-trace"
+  ; "-outputdir"
+  ; "-parallel"
+  ; "-vet"
+  ; "-modfile"
+  ; "-overlay"
+  ; "-pkgdir"
+  ; "-toolexec"
+  ]
+in
 let rec parse subcmd v race dd = function
   | [] ->
     (match subcmd with
@@ -3451,6 +3538,12 @@ let rec parse subcmd v race dd = function
      | None -> None)
   | "-v" :: rest when not dd -> parse subcmd true race dd rest
   | "-race" :: rest when not dd -> parse subcmd v true dd rest
+  | "-trimpath" :: rest when not dd -> parse subcmd v race dd rest
+  (* Value-consuming flags: skip the flag and its argument *)
+  | arg :: _val :: rest
+    when not dd && String.length arg > 0 && arg.[0] = '-'
+         && List.mem arg go_value_flags ->
+    parse subcmd v race dd rest
   (* POSIX end-of-options: all remaining args are positional *)
   | "--" :: rest -> parse subcmd v race true rest
   | arg :: rest ->
@@ -3693,6 +3786,52 @@ parse false None None args|}
     ; parse_body =
         Some
           {|
+(* Docker flags that consume the next token as their argument *)
+let docker_value_flags =
+  [ "--name"; "--hostname"; "-h"
+  ; "--network"; "--net"
+  ; "-v"; "--volume"
+  ; "-p"; "--publish"
+  ; "--env"; "-e"
+  ; "--workdir"; "-w"
+  ; "--entrypoint"
+  ; "--platform"
+  ; "--user"; "-u"
+  ; "--label"; "-l"
+  ; "--log-driver"; "--log-opt"
+  ; "--mount"; "--tmpfs"
+  ; "--device"
+  ; "--add-host"
+  ; "--dns"; "--dns-search"; "--dns-option"
+  ; "--ip"; "--ip6"
+  ; "--link"
+  ; "--volumes-from"
+  ; "--network-alias"
+  ; "--restart"
+  ; "--stop-signal"; "--stop-timeout"
+  ; "--health-cmd"; "--health-interval"; "--health-timeout"
+  ; "--health-retries"; "--health-start-period"
+  ; "--memory"; "-m"
+  ; "--cpus"; "--cpu-shares"; "--cpu-period"; "--cpu-quota"; "--cpuset-cpus"
+  ; "--gpus"
+  ; "--pid"
+  ; "--pids-limit"
+  ; "--memory-swap"; "--memory-reservation"
+  ; "--kernel-memory"; "--oom-kill-disable"; "--oom-score-adj"
+  ; "--ulimit"
+  ; "--security-opt"; "--cap-add"; "--cap-drop"
+  ; "--group-add"
+  ; "--blkio-weight"; "--blkio-weight-device"
+  ; "--cgroup-parent"
+  ; "--device-cgroup-rule"
+  ; "--sysctl"
+  ; "--shm-size"
+  ; "--storage-opt"
+  ; "-c"; "--cpu-shares"
+  ; "--annotation"
+  ; "--init-binary"
+  ]
+in
 let rec parse subcmd rm priv det dd = function
   | [] ->
     (match subcmd with
@@ -3703,6 +3842,20 @@ let rec parse subcmd rm priv det dd = function
   | "--privileged" :: rest when not dd -> parse subcmd rm true det dd rest
   | "-d" :: rest when not dd -> parse subcmd rm priv true dd rest
   | "--detach" :: rest when not dd -> parse subcmd rm priv true dd rest
+  (* Value-consuming flags: skip the flag and its argument *)
+  | arg :: _val :: rest
+    when not dd && String.length arg > 0 && arg.[0] = '-'
+         && List.mem arg docker_value_flags ->
+    parse subcmd rm priv det dd rest
+  (* --flag=VALUE equal-sign form for value-consuming flags *)
+  | arg :: rest
+    when not dd && String.length arg > 2 && arg.[0] = '-' && arg.[1] = '-'
+         && (match String.index_opt arg '=' with
+              | Some i ->
+                let flag = String.sub arg 0 i in
+                List.mem flag docker_value_flags
+              | None -> false) ->
+    parse subcmd rm priv det dd rest
   (* POSIX end-of-options: all remaining args are positional *)
   | "--" :: rest -> parse subcmd rm priv det true rest
   | arg :: rest ->
@@ -4400,6 +4553,7 @@ parse None false false false args|}
     ; parse_body =
         Some
           {|
+let gradle_value_flags = [ "--build-file"; "--settings-file"; "--gradle-user-home"; "--project-cache-dir"; "--project-dir"; "-D"; "--system-prop"; "--init-script"; "--include-build" ] in
 let rec parse subcmd nd p dd = function
   | [] ->
     (match subcmd with
@@ -4408,7 +4562,22 @@ let rec parse subcmd nd p dd = function
      | None -> None)
   | "--no-daemon" :: rest when not dd -> parse subcmd true p dd rest
   | "--parallel" :: rest when not dd -> parse subcmd nd true dd rest
+  | "--rerun-tasks" :: rest when not dd -> parse subcmd nd p dd rest
   | "--" :: rest -> parse subcmd nd p true rest
+  (* Value-consuming flags: skip the flag and its argument *)
+  | arg :: _val :: rest
+    when not dd && String.length arg > 0 && arg.[0] = '-'
+         && List.mem arg gradle_value_flags ->
+    parse subcmd nd p dd rest
+  (* --flag=VALUE equal-sign form for value-consuming flags *)
+  | arg :: rest
+    when not dd && String.length arg > 2 && arg.[0] = '-' && arg.[1] = '-'
+         && (match String.index_opt arg '=' with
+              | Some i ->
+                let flag = String.sub arg 0 i in
+                List.mem flag gradle_value_flags
+              | None -> false) ->
+    parse subcmd nd p dd rest
   | arg :: rest ->
     (match subcmd with
      | None when not dd -> parse (Some arg) nd p dd rest
@@ -4544,6 +4713,24 @@ parse None false false false args|}
     ; parse_body =
         Some
           {|
+  (* Mvn flags that consume the next token as their argument *)
+  let mvn_value_flags =
+    [ "-D"; "--define"
+    ; "-f"; "--file"
+    ; "-s"; "--settings"
+    ; "-gs"; "--global-settings"
+    ; "-P"; "--activate-profiles"
+    ; "--log-file"
+    ; "--color"
+    ; "-l"
+    ; "-pl"; "--projects"
+    ; "-rf"; "--resume-from"
+    ; "-t"; "--threads"
+    ; "-nt"; "--no-transfer-progress"
+    ; "-T"
+    ; "-X"
+    ]
+  in
   let rec parse subcmd off bat q dd = function
     | [] ->
       (match subcmd with
@@ -4557,6 +4744,20 @@ parse None false false false args|}
     | "--batch-mode" :: rest when not dd -> parse subcmd off true q dd rest
     | "-q" :: rest when not dd -> parse subcmd off bat true dd rest
     | "--quiet" :: rest when not dd -> parse subcmd off bat true dd rest
+    (* Value-consuming flags: skip the flag and its argument *)
+    | arg :: _val :: rest
+      when not dd && String.length arg > 0 && arg.[0] = '-'
+           && List.mem arg mvn_value_flags ->
+      parse subcmd off bat q dd rest
+    (* --flag=VALUE equal-sign form *)
+    | arg :: rest
+      when not dd && String.length arg > 2 && arg.[0] = '-' && arg.[1] = '-'
+           && (match String.index_opt arg '=' with
+                | Some i ->
+                  let flag = String.sub arg 0 i in
+                  List.mem flag mvn_value_flags
+                | None -> false) ->
+      parse subcmd off bat q dd rest
     | "--" :: rest -> parse subcmd off bat q true rest
     | arg :: rest ->
       (match subcmd with

--- a/lib/exec/test/test_shell_ir_walkers_gen.ml
+++ b/lib/exec/test/test_shell_ir_walkers_gen.ml
@@ -81,7 +81,7 @@ let all_wrapped : Shell_ir_typed.wrapped list =
   ; W (Patch { file = Some "foo.c"; patchfile = Some "fix.patch"; strip = 1; reverse = false })
   ; W (Npm { subcommand = "install"; save_dev = true; global = false; force = false; rest = [] })
   ; W (Cargo { subcommand = "build"; release = true; verbose = false; features = None; rest = [] })
-  ; W (Go { subcommand = "build"; verbose = false; race = false; rest = [ "-o"; "bin" ] })
+  ; W (Go { subcommand = "build"; verbose = false; race = false; rest = [ "./..." ] })
   ; W (Gh { subcommand = "pr"; action = Some "list"; draft = false; squash = false; delete_branch = false; body = None; title = None; rest = [] })
   ; W (Chmod { mode = "755"; path = "/tmp/x"; recursive = false })
   ; W (Chown { owner = "root"; path = "/tmp/x"; recursive = false })
@@ -1467,6 +1467,104 @@ let test_git_log_value_consuming_flags () =
    | w -> Alcotest.failf "git log --oneline -n5 --format=medium: expected oneline max_count=5, got %a" pp w)
 ;;
 
+(* Batch 12: value-consuming flags for Docker, Go, Cargo, Npm, Mvn, Gradle *)
+let test_batch12_value_consuming_flags () =
+  let open Shell_ir_typed in
+  let base bin_name =
+    { Shell_ir.bin = bin_ok bin_name
+    ; args = []
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Sandbox_target.host ()
+    }
+  in
+  let pp = Shell_ir_typed.pp in
+  (* Docker: --name myapp → name parsed, --env FOO=bar → env parsed *)
+  let d1 =
+    of_simple { (base "docker") with args = [ lit "run"; lit "--name"; lit "myapp"; lit "img" ] }
+  in
+  (match d1 with
+   | W (Docker { subcommand = "run"; rest; _ }) ->
+     if List.exists ((=) "myapp") rest then
+       Alcotest.failf "Docker --name myapp: 'myapp' should be consumed, not in rest (%a)" pp d1
+   | w -> Alcotest.failf "Docker run --name myapp: expected Docker, got %a" pp w);
+  (* Docker: --flag=VALUE form *)
+  let d2 =
+    of_simple { (base "docker") with args = [ lit "run"; lit "--name=myapp"; lit "img" ] }
+  in
+  (match d2 with
+   | W (Docker { subcommand = "run"; rest; _ }) ->
+     if List.exists ((=) "myapp") rest then
+       Alcotest.failf "Docker --name=myapp: 'myapp' should be consumed (%a)" pp d2
+   | w -> Alcotest.failf "Docker --name=myapp: expected Docker, got %a" pp w);
+  (* Go: -o bin → consumed, rest empty *)
+  let g1 =
+    of_simple { (base "go") with args = [ lit "build"; lit "-o"; lit "bin"; lit "./..." ] }
+  in
+  (match g1 with
+   | W (Go { subcommand = "build"; rest; _ }) ->
+     if List.exists ((=) "bin") rest then
+       Alcotest.failf "Go build -o bin: 'bin' should be consumed (%a)" pp g1;
+     if not (List.exists ((=) "./...") rest) then
+       Alcotest.failf "Go build -o bin ./...: './...' should be in rest (%a)" pp g1
+   | w -> Alcotest.failf "Go build -o bin: expected Go, got %a" pp w);
+  (* Cargo: --target x86_64 → consumed *)
+  let c1 =
+    of_simple { (base "cargo") with args = [ lit "build"; lit "--target"; lit "x86_64"; lit "--release" ] }
+  in
+  (match c1 with
+   | W (Cargo { subcommand = "build"; release = true; rest; _ }) ->
+     if List.exists ((=) "x86_64") rest then
+       Alcotest.failf "Cargo --target x86_64: 'x86_64' should be consumed (%a)" pp c1
+   | w -> Alcotest.failf "Cargo --target: expected Cargo, got %a" pp w);
+  (* Npm: --registry https://x → consumed *)
+  let n1 =
+    of_simple { (base "npm") with args = [ lit "install"; lit "--registry"; lit "https://x"; lit "pkg" ] }
+  in
+  (match n1 with
+   | W (Npm { subcommand = "install"; rest; _ }) ->
+     if List.exists ((=) "https://x") rest then
+       Alcotest.failf "Npm --registry: url should be consumed (%a)" pp n1;
+     if not (List.exists ((=) "pkg") rest) then
+       Alcotest.failf "Npm --registry ... pkg: 'pkg' should be in rest (%a)" pp n1
+   | w -> Alcotest.failf "Npm --registry: expected Npm, got %a" pp w);
+  (* Mvn: -D key=val → two-token form consumed *)
+  let m1 =
+    of_simple { (base "mvn") with args = [ lit "install"; lit "-D"; lit "skipTests=true" ] }
+  in
+  (match m1 with
+   | W (Mvn { subcommand = "install"; args; _ }) ->
+     if List.exists ((=) "skipTests=true") args then
+       Alcotest.failf "Mvn -D skipTests=true: value should be consumed (%a)" pp m1
+   | w -> Alcotest.failf "Mvn -D: expected Mvn, got %a" pp w);
+  (* Mvn: --batch-mode --quiet boolean flags preserved *)
+  let m2 =
+    of_simple { (base "mvn") with args = [ lit "test"; lit "--batch-mode"; lit "--quiet" ] }
+  in
+  (match m2 with
+   | W (Mvn { subcommand = "test"; batch_mode = true; quiet = true; _ }) -> ()
+   | w -> Alcotest.failf "Mvn --batch-mode --quiet: expected flags, got %a" pp w);
+  (* Gradle: --build-file custom.gradle → consumed *)
+  let gr1 =
+    of_simple { (base "gradle") with args = [ lit "build"; lit "--build-file"; lit "custom.gradle" ] }
+  in
+  (match gr1 with
+   | W (Gradle { subcommand = "build"; rest; _ }) ->
+     if List.exists ((=) "custom.gradle") rest then
+       Alcotest.failf "Gradle --build-file: 'custom.gradle' should be consumed (%a)" pp gr1
+   | w -> Alcotest.failf "Gradle --build-file: expected Gradle, got %a" pp w);
+  (* Gradle: --gradle-user-home=/opt/gradle → =VALUE form *)
+  let gr2 =
+    of_simple { (base "gradle") with args = [ lit "build"; lit "--gradle-user-home=/opt/gradle" ] }
+  in
+  (match gr2 with
+   | W (Gradle { subcommand = "build"; rest; _ }) ->
+     if List.exists ((=) "/opt/gradle") rest then
+       Alcotest.failf "Gradle --gradle-user-home=VALUE: should be consumed (%a)" pp gr2
+   | w -> Alcotest.failf "Gradle --gradle-user-home=: expected Gradle, got %a" pp w)
+;;
+
 (* Batch 11: all_wrapped minimal-payload round-trip. Catches regressions
    in subcommand+args parsing when args are empty or minimal. *)
 let test_all_wrapped_minimal_round_trip () =
@@ -1585,6 +1683,7 @@ let () =
         ; Alcotest.test_case "Git_push value-consuming flags" `Quick test_git_push_value_consuming_flags
         ; Alcotest.test_case "Git_pull value-consuming flags" `Quick test_git_pull_value_consuming_flags
         ; Alcotest.test_case "Git_log value-consuming flags" `Quick test_git_log_value_consuming_flags
+        ; Alcotest.test_case "Batch 12: Docker/Go/Cargo/Npm/Mvn/Gradle value flags" `Quick test_batch12_value_consuming_flags
         ] )
     ; ( "spec_invariants"
       , [ Alcotest.test_case "constructor count baseline" `Quick test_constructor_count


### PR DESCRIPTION
## Summary
- Add value-consuming flag support to 6 Shell IR parsers: Docker (~60 flags), Go (~25), Cargo (~20), Npm (~20), Mvn (~17), Gradle (~10)
- Each parser now has a dedicated `value_flags` list and two match arms: two-token `--flag VALUE` and equal-sign `--flag=VALUE`
- Also adds `--rerun-tasks` (Gradle) and `-trimpath` (Go) as boolean flags
- Fixes Go round-trip test to use non-value-consuming rest args

## Why
Without explicit handling, the parser skips `--flag` but treats VALUE as a positional argument, corrupting the `rest` field. This is the same pattern already applied to Curl, Gh, Rsync, Tar, Sed, Make, Diff, Rg, Wget, Git_push, Git_pull, Git_log in prior batches.

## Test plan
- [x] `dune build .` passes (pre-existing `test_worker_runtime.ml` error unrelated)
- [x] `dune exec lib/exec/test/test_shell_ir_walkers_gen.exe` — 20/20 pass
- [x] `dune exec test/test_shell_ir_typed_review_followup.exe` — 9/9 pass

## Pattern
Each value_flags list is placed immediately before the parser's `parse` function. Match arms are ordered:
1. Boolean flags (`--no-daemon`, `--parallel`, etc.)
2. `--` end-of-options
3. Value-consuming `_no_eq` (two-token)
4. Value-consuming `=VALUE` (equal-sign form)
5. Generic `arg :: rest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)