### PR TITLE
fix(build): resolve PR #19471 follow-up compilation errors

### DIFF
--- a/lib/autonomous/dune
+++ b/lib/autonomous/dune
@@ -5,6 +5,6 @@
  (public_name masc_mcp.autonomous)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags (:standard -w +4))
- (libraries shared_types multimodal yojson)
+ (libraries shared_types multimodal yojson masc_mcp.masc_core)
  (preprocess
   (pps ppx_tla)))

--- a/lib/chronicle_event/dune
+++ b/lib/chronicle_event/dune
@@ -16,4 +16,5 @@
  (wrapped false)
  (flags (:standard -w +4))
  (libraries
-  yojson))
+  yojson
+  masc_mcp.masc_core))

--- a/lib/dashboard_cascade_audit_runs.ml
+++ b/lib/dashboard_cascade_audit_runs.ml
@@ -9,7 +9,7 @@
 open Dashboard_cascade_helpers
 
 let json_list_member key json =
-  match json_assoc_member key json with
+  match Yojson.Safe.Util.member key json with
   | `List values -> values
   | _ -> []
 ;;
@@ -100,7 +100,7 @@ let last_attempt_error attempts =
 ;;
 
 let audit_run_json_of_record json =
-  let observation = json_assoc_member "observation" json in
+  let observation = Yojson.Safe.Util.member "observation" json in
   let attempts = json_list_member "attempts" observation in
   let fallback_events = json_list_member "fallback_events" observation in
   let selected_attempt_index = Json_util.assoc_int_opt "selected_index" observation in

--- a/lib/dashboard_cascade_config.ml
+++ b/lib/dashboard_cascade_config.ml
@@ -250,7 +250,7 @@ let validation_summary_json ?config_path () =
     in
     [ "validation_status", `String status
     ; ( "validation_errors"
-      , Json_util.json_string_list (json_string_list (json_assoc_member "errors" rejection_json))
+      , Json_util.json_string_list (Json_util.get_string_list rejection_json "errors")
       )
     ; "invalid_profiles", `List (List.map invalid_profile_to_json invalid_profiles)
     ]

--- a/lib/ide/dune
+++ b/lib/ide/dune
@@ -23,4 +23,5 @@
   ;; to route legacy records to their canonical-URL bucket. repo_manager
   ;; depends only on config/fs_compat/exec/log so the new edge introduces
   ;; no dependency cycle.
-  masc_mcp.repo_manager))
+  masc_mcp.repo_manager
+  masc_mcp.masc_core))

--- a/lib/keeper/keeper_run_tools_task_scope.mli
+++ b/lib/keeper/keeper_run_tools_task_scope.mli
@@ -1,7 +1,6 @@
 (** Task-scoped tool helpers for keeper run tools. *)
 
 val task_scope_tool_names : string list
-val json_string_opt : string -> Yojson.Safe.t -> string option
 
 val task_id_scope_of_tool_input :
   tool_name:string -> Yojson.Safe.t -> string option

--- a/lib/multimodal/dune
+++ b/lib/multimodal/dune
@@ -5,5 +5,5 @@
  (public_name masc_mcp.multimodal)
  ; RFC-0071 Phase 5 ratchet (warning 4)
  (flags (:standard -w +4))
- (libraries shared_types unix yojson)
+ (libraries shared_types unix yojson masc_mcp.masc_core)
  (preprocess (pps ppx_tla)))

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -6,8 +6,6 @@ type paused_keeper_scan = {
 }
 val empty_paused_keeper_scan : paused_keeper_scan
 val sorted_unique_strings : String.t list -> String.t list
-val json_float_opt : float option -> Yojson.Safe.t
-val json_string_opt : string option -> Yojson.Safe.t
 val effective_autoboot_enabled :
   string ->
   Keeper_meta_contract.keeper_meta -> bool

--- a/lib/shared_audit/dune
+++ b/lib/shared_audit/dune
@@ -5,4 +5,4 @@
  (public_name masc_mcp.shared_audit)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags (:standard -w +4))
- (libraries unix yojson digestif digestif.c jsonl_writer fs_compat))
+ (libraries unix yojson digestif digestif.c jsonl_writer fs_compat masc_mcp.masc_core))


### PR DESCRIPTION
## Problem

PR #19471 consolidated local JSON helpers into `Json_util` but left several follow-up issues causing compilation errors on main:

1. **5 modules** (`chronicle_event`, `shared_audit`, `autonomous`, `multimodal`, `ide`) now call `Json_util.kind_name` but their `dune` files lacked the `masc_mcp.masc_core` dependency.
2. **`dashboard_cascade_config.ml`** still called removed local helpers (`json_string_list`, `json_assoc_member`).
3. **`dashboard_cascade_audit_runs.ml`** still called removed `json_assoc_member`.
4. **`server_routes_http_runtime_fleet_scan.mli`** and **`keeper_run_tools_task_scope.mli`** declared removed helper values (`json_float_opt`, `json_string_opt`) causing mli/impl mismatch.

## Fix

- Add `masc_mcp.masc_core` to 5 `dune` files.
- Replace removed local helpers with `Json_util` / `Yojson.Safe.Util.member` equivalents in dashboard files.
- Remove stale value declarations from 2 `mli` files.

## Verification

- [x] `dune build --root .` passes (exit 0)
- [x] 9 files changed, +10/-11 lines (surgical scope)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
