### PR TITLE
fix(cascade): route targets use profile names instead of binding keys

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -734,63 +734,73 @@ temperature = 0.3
 max-output = 8192
 temperature = 0.3
 
-# ── Routes (simplified: direct model reference) ────────────────
+# ── Routes (profile name targets) ──────────────────────────────
 # Tier and tier-group concepts were removed in PR #19381.
-# All routes now use the provider:model string format.
+# Route targets MUST reference [profiles.*] names, NOT binding keys
+# (provider.model).  The cascade resolver (cascade_routes_resolve.ml)
+# matches targets against known_profile_names(); binding keys are in
+# a different namespace and cause silent fallback to the
+# alphabetically-first profile (see cascade_routes_resolve.ml:34).
+#
+# Profile → required_capabilities → matching providers:
+#   tool_strict  → runtime_mcp_tools, runtime_tool_events, runtime_mcp_http_headers → runpod_mtp
+#   lite         → runtime_mcp_tools, runtime_tool_events → runpod_mtp
+#   local        → (none) → any provider
+#   inline_tools → inline_tools, inline_tool_choice → cli_tool_a, cli_tool_b
 
 [routes.keeper_turn]
-target = "runpod_mtp.qwen-runpod"
+target = "tool_strict"
 
 [routes.phase_recovery]
-target = "runpod_mtp.qwen-runpod"
+target = "lite"
 
 [routes.phase_buffer]
-target = "runpod_mtp.qwen-runpod"
+target = "lite"
 
 [routes.tool_required]
-target = "runpod_mtp.qwen-runpod"
+target = "tool_strict"
 
 [routes.governance_judge]
-target = "runpod_mtp.qwen-runpod"
+target = "tool_strict"
 
 [routes.operator_judge]
-target = "runpod_mtp.qwen-runpod"
+target = "tool_strict"
 
 [routes.cross_verifier]
-target = "runpod_mtp.qwen-runpod"
+target = "tool_strict"
 
 [routes.verifier]
-target = "runpod_mtp.qwen-runpod"
+target = "tool_strict"
 
 [routes.adversarial_reviewer]
-target = "runpod_mtp.qwen-runpod"
+target = "tool_strict"
 
 [routes.auto_responder]
-target = "runpod_mtp.qwen-runpod"
+target = "lite"
 
 [routes.routing]
-target = "runpod_mtp.qwen-runpod"
+target = "lite"
 
 [routes.openai_compat]
-target = "runpod_mtp.qwen-runpod"
+target = "lite"
 
 [routes.persona_generation]
-target = "runpod_mtp.qwen-runpod"
+target = "lite"
 
 [routes.provider_benchmark]
-target = "runpod_mtp.qwen-runpod"
+target = "lite"
 
 [routes.llm_rerank]
-target = "runpod_mtp.qwen-runpod"
+target = "lite"
 
 [routes.simple_task]
-target = "runpod_mtp.qwen-runpod"
+target = "lite"
 
 [routes.moderate_task]
-target = "runpod_mtp.qwen-runpod"
+target = "lite"
 
 [routes.complex_task]
-target = "runpod_mtp.qwen-runpod"
+target = "lite"
 
 # ── Profiles (capability requirements per route class) ─────────
 


### PR DESCRIPTION
## Summary

- All 18 route targets in `cascade.toml` were set to the binding key `"runpod_mtp.qwen-runpod"` (`provider.model` format), but `cascade_routes_resolve.ml:34` compares them against `known_profile_names()` which returns profile names (`tool_strict`, `lite`, etc.)
- Since the binding key never matched any profile name, every route silently fell back to `"inline_tools"` (alphabetically first profile), causing `no_tool_capable_provider` errors (~205/day) because `inline_tools` requires `inline_tools` + `inline_tool_choice` capabilities that `runpod_mtp` doesn't have
- Fix: route targets now reference `[profiles.*]` names — tool-heavy routes → `"tool_strict"`, basic LLM routes → `"lite"`

## Root Cause

`cascade_routes_resolve.ml` resolves route targets via:
```ocaml
| Some target when List.mem target catalog_names -> target   (* catalog_names = ["tool_strict", "inline_tools", "lite", "local"] *)
| Some target -> ... fallback  (* always hit when target = "runpod_mtp.qwen-runpod" *)
```

The route target `"runpod_mtp.qwen-runpod"` is a **binding key** (provider.model), but `catalog_names` contains **profile names** (`tool_strict`, `inline_tools`, `lite`, `local`). `List.mem` always returned `false`, triggering the fallback to `List.hd catalog_names` = `"inline_tools"`.

## Fix

Changed all 18 route targets from the binding key to the correct profile name:

| Route | Old (binding key) | New (profile name) |
|-------|-------------------|-------------------|
| keeper_turn | runpod_mtp.qwen-runpod | **tool_strict** |
| tool_required | runpod_mtp.qwen-runpod | **tool_strict** |
| governance_judge | runpod_mtp.qwen-runpod | **tool_strict** |
| operator_judge | runpod_mtp.qwen-runpod | **tool_strict** |
| cross_verifier | runpod_mtp.qwen-runpod | **tool_strict** |
| verifier | runpod_mtp.qwen-runpod | **tool_strict** |
| adversarial_reviewer | runpod_mtp.qwen-runpod | **tool_strict** |
| phase_recovery | runpod_mtp.qwen-runpod | **lite** |
| phase_buffer | runpod_mtp.qwen-runpod | **lite** |
| auto_responder | runpod_mtp.qwen-runpod | **lite** |
| routing | runpod_mtp.qwen-runpod | **lite** |
| openai_compat | runpod_mtp.qwen-runpod | **lite** |
| persona_generation | runpod_mtp.qwen-runpod | **lite** |
| provider_benchmark | runpod_mtp.qwen-runpod | **lite** |
| llm_rerank | runpod_mtp.qwen-runpod | **lite** |
| simple_task | runpod_mtp.qwen-runpod | **lite** |
| moderate_task | runpod_mtp.qwen-runpod | **lite** |
| complex_task | runpod_mtp.qwen-runpod | **lite** |

## Profile → Provider mapping

```
tool_strict  → runtime_mcp_tools, runtime_tool_events, runtime_mcp_http_headers → runpod_mtp
lite         → runtime_mcp_tools, runtime_tool_events → runpod_mtp
local        → (none) → any provider
inline_tools → inline_tools, inline_tool_choice → cli_tool_a, cli_tool_b
```

## Impact

- Eliminates silent fallback to `"inline_tools"` for all routes
- Tool-heavy routes (`keeper_turn`, `governance_judge`, etc.) now correctly resolve to `"tool_strict"` → matched with `runpod_mtp` provider
- Basic LLM routes now correctly resolve to `"lite"` → matched with `runpod_mtp` provider
- Expected to eliminate `no_tool_capable_provider` errors (~205/day)

## Test plan

- [ ] CI passes (TOML config only, no OCaml code change)
- [ ] Verify `cascade_routes_resolve.ml:34` now matches `tool_strict` / `lite` against `known_profile_names()`
- [ ] Monitor fleet logs after deployment for `no_tool_capable_provider` error reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>