### PR TITLE
fix(keeper): resolve legacy tier-group cascade names to keeper_turn route

### DIFF
--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -408,9 +408,32 @@ let route_target_public_name ?config_path use =
   try Some (cascade_name_for_use ?config_path use |> public_name_of_target)
   with Failure _ -> None
 
-(* keeper-assignable guardrail removed 2026-05-28 — all cascade names pass through. *)
+(* keeper-assignable guardrail removed 2026-05-28, then re-narrowed 2026-05-29:
+   a keeper runtime turn must resolve to a real route target. After tier-group
+   removal (#19436/#19439) legacy "tier-group.*"/"tier.*" declared names are
+   neither logical-use routes nor catalog members, so [normalize_declared_name]
+   passes them through verbatim; the unresolved name then fails capability
+   resolution at dispatch (no_tool_capable_provider) and crash-loops the keeper.
+   An unresolvable declared name is substituted with the [Keeper_turn] route —
+   the logical route a keeper turn runs on — and the substitution is recorded
+   (RFC-0038 L4 I-Intent: substitution must be visible, not silent).
+   This is the keeper-runtime narrowing only; [normalize_declared_name] keeps
+   verbatim passthrough for non-runtime callers. *)
 let normalize_keeper_runtime_declared_name ?config_path raw =
-  normalize_declared_name ?config_path raw
+  let trimmed = String.trim raw in
+  match logical_use_of_string_opt trimmed with
+  | Some _ -> normalize_declared_name ?config_path raw
+  | None ->
+      (match
+         canonical_member_of_lookup_catalog
+           ~catalog:(catalog_lookup_names ?config_path ())
+           trimmed
+       with
+       | Some canonical -> canonical
+       | None ->
+           Cascade_metrics.on_route_resolve_fallback
+             ~reason:"keeper_runtime_declared_name_unresolved";
+           cascade_name_for_use ?config_path Keeper_turn)
 
 (* RFC-0149 §3.3 — "Parse, don't validate" reverse of the silent-fallback
   shape.  [resolve_live_with_catalog_result] returns [Ok cascade_name]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -50,6 +50,53 @@ let tool_required_cascade_name () =
     Masc_mcp.Keeper_cascade_profile.Tool_required
 ;;
 
+let keeper_turn_cascade_name () =
+  Masc_mcp.Keeper_cascade_profile.cascade_name_for_use
+    Masc_mcp.Keeper_cascade_profile.Keeper_turn
+;;
+
+let normalize_keeper_runtime_declared_name raw =
+  Masc_mcp.Keeper_cascade_profile.normalize_keeper_runtime_declared_name raw
+;;
+
+(* After tier removal a keeper whose declared name is a legacy "tier-group.*"/
+   "tier.*" value (neither a logical-use route nor a catalog member) must still
+   resolve to the Keeper_turn route, not pass the dead name through to capability
+   resolution (which crash-loops the keeper with no_tool_capable_provider). *)
+let test_keeper_runtime_declared_name_substitutes_unresolvable_with_keeper_turn () =
+  let expected = keeper_turn_cascade_name () in
+  check
+    string
+    "legacy tier-group.* declared name resolves to keeper_turn route"
+    expected
+    (normalize_keeper_runtime_declared_name "tier-group.glm-coding-with-spark");
+  check
+    string
+    "legacy tier.* declared name resolves to keeper_turn route"
+    expected
+    (normalize_keeper_runtime_declared_name "tier.local_llama");
+  check
+    string
+    "blank declared name resolves to keeper_turn route"
+    expected
+    (normalize_keeper_runtime_declared_name "")
+;;
+
+(* A declared name that is already a logical-use route must keep resolving
+   through that route — the narrowing only substitutes unresolvable names. *)
+let test_keeper_runtime_declared_name_preserves_logical_use_route () =
+  check
+    string
+    "logical-use keeper_turn resolves to the keeper_turn route target"
+    (keeper_turn_cascade_name ())
+    (normalize_keeper_runtime_declared_name "keeper_turn");
+  check
+    string
+    "logical-use tool_required resolves to the tool_required route target"
+    (tool_required_cascade_name ())
+    (normalize_keeper_runtime_declared_name "tool_required")
+;;
+
 let safe_lane_cascade_name = Masc_mcp.Cascade_capability_profile.safe_lane_cascade_name
 
 let has_prompt_root path =
@@ -11898,6 +11945,14 @@ let () =
             "resolved catalog without assignable candidates falls back"
             `Quick
             test_fail_open_rotation_cascades_from_catalog_empty_without_assignable_candidates
+        ; test_case
+            "keeper runtime declared name substitutes unresolvable with keeper_turn"
+            `Quick
+            test_keeper_runtime_declared_name_substitutes_unresolvable_with_keeper_turn
+        ; test_case
+            "keeper runtime declared name preserves logical-use route"
+            `Quick
+            test_keeper_runtime_declared_name_preserves_logical_use_route
         ] )
     ; ( "tool_classification"
       , [ test_case


### PR DESCRIPTION
## 목적 (live blocker)

cascade→Runtime 마이그레이션 과도기에 keeper fleet 전체(13 keepers)의 tool turn이
dispatch 전 `no_tool_capable_provider`로 실패하고 약 64초 주기로 crash-loop 중이다.
2026-05-29 live 진단 (active keeper 4종 전부 `failure:run_error` → defer/silent).

## Root cause

- `cascade.toml`은 logical-use route 체계(`routes.keeper_turn → runpod_mtp`,
  capabilities 정상 선언)로 마이그레이션 완료.
- 그러나 keeper config의 `cascade_name`은 tier 제거(#19436/#19439)로 catalog에서
  사라진 옛 `tier-group.*`/`tier.*` 이름을 유지.
- `Keeper_cascade_profile.normalize_declared_name`의 `| None -> trimmed`
  (keeper-assignable guardrail 제거 2026-05-28로 도입된 silent passthrough)가
  죽은 이름을 그대로 통과 → `provider_tool_support` capability filter가
  candidate 15개를 0으로 (`tool_filtered_candidate_count=0`,
  `require_tool_support=true`) → `no_tool_capable_provider` → crash loop.
- RFC-0038 I-Intent / RFC-0001 silent-substitution 안티패턴 위반.

## 변경

- `normalize_keeper_runtime_declared_name`: keeper runtime turn의 declared name이
  logical-use route도 catalog member도 아니면 `Keeper_turn` route로 substitute하고
  `Cascade_metrics.on_route_resolve_fallback`로 substitution을 기록.
- `normalize_declared_name`(non-runtime caller)은 verbatim passthrough 유지 — surgical.
- test 2건: legacy `tier-group.*`/`tier.*`/blank → keeper_turn route 검증,
  logical-use route(`keeper_turn`/`tool_required`) 보존 검증.

## 검증

- `dune build --root . @check` green (DUNE_CACHE=disabled, 격리 worktree _build).
- `dune build --root . @runtest --keep-going` exit 0 (test_keeper_unified 포함 전체 green).
- 직접 `exe` 실행은 `minimal_meta` top-level fixture가 config-seed 환경을 요구하므로
  dune runtest 경로로 검증.

## Workaround 자기검토 (CLAUDE.md §워크어라운드 거부 기준)

substitution이 "Fallback Resolution" 시그니처와 표면 유사하나 해당하지 않는다:

- 두 개념을 string에 압축한 결과의 fallback이 아니라, route intent를 보존하는 것
  (RFC-0038 I-Intent: declared intent → 명시적 route 결과).
- silent가 아니라 **visible** (`on_route_resolve_fallback`, RFC-0038 L4).
- 안티패턴의 *추가*가 아니라 *제거*다 — 5/28 도입된 silent passthrough를 닫는다.
- 근본 종착점은 cascade→Runtime 재탄생(RFC-0205)에서 `keeper.cascade_name` 필드 제거.
  본 PR은 그 전 과도기 안전망 + silent passthrough 제거.

Refs: RFC-0038 (cascade-routing-intent-preservation), RFC-0157 (cascade-pre-turn-required-tool-filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
