### PR TITLE
fix(cascade): align HTTP-probe capacity key with acquire path

### DIFF
--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -456,14 +456,26 @@ let http_probe_urls candidates =
 let register_http_probe_capable ~max_concurrent candidate =
   match candidate.http_probe_url with
   | None -> ()
-  | Some url ->
-      if not (Cascade_client_capacity.is_registered url) then
-        Cascade_client_capacity.register ~url ~max_concurrent;
+  | Some probe_url ->
+      (* BUGFIX: register under capacity_key (base_url:model_id) instead of
+         probe_url (base_url only) so that try_acquire — which uses
+         capacity_key — actually finds the entry.  Without this, Path B
+         (HTTP-probe) registrations create a separate slot keyed by bare
+         base_url that the acquire path never checks, silently bypassing
+         the capacity limit.
+
+         Probe URL registration (server-side health) still uses the bare
+         base_url because the HTTP probe endpoint is URL-level, not
+         model-level. *)
+      let cap_key = String.trim candidate.capacity_key in
+      if not (String.equal cap_key "") then
+        if not (Cascade_client_capacity.is_registered cap_key) then
+          Cascade_client_capacity.register ~url:cap_key ~max_concurrent;
       (match candidate.provider_cfg.kind with
        | Llm_provider.Provider_config.Ollama ->
-           Cascade_http_probe.register_url ~url
+           Cascade_http_probe.register_url ~url:probe_url
        | _ ->
-           Cascade_openai_probe.register_url ~url)
+           Cascade_openai_probe.register_url ~url:probe_url)
 
 let strategy_adapter : t Cascade_strategy.adapter =
   { health_key; capacity_key }

--- a/lib/cascade/cascade_strategy.ml
+++ b/lib/cascade/cascade_strategy.ml
@@ -90,6 +90,16 @@ let key_is_full ctx key =
   | None -> false
 
 let dedupe_full_capacity_keys adapter ctx cands =
+  (* When multiple candidates share the same capacity_key (same physical
+     provider), keep at most one per key when the key is at capacity.
+     This prevents N candidates for the same provider from all attempting
+     acquire on a full semaphore.
+
+     NOTE: Fairness across routes sharing the same provider is not yet
+     implemented.  The first candidate in list order wins; route priority
+     is therefore determined by cascade.toml ordering.  Route-level
+     fairness (weighted fair queuing or per-route reservation) requires
+     strategy-layer changes and is tracked separately. *)
   let seen_full = Hashtbl.create (List.length cands) in
   cands
   |> List.filter (fun c ->

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -302,7 +302,8 @@ let test_declared_client_capacity_registers_generic_endpoint () =
     (Some 2)
     (Masc_mcp.Cascade_runtime_candidate.declared_client_capacity candidate);
   Masc_mcp.Cascade_runtime_candidate.register_declared_client_capacity candidate;
-  match C.capacity "https://runpod.example/v1" with
+  (* capacity_key = base_url:model_id, not bare base_url *)
+  match C.capacity "https://runpod.example/v1:runpod-provider_h" with
   | None -> fail "declared endpoint capacity was not registered"
   | Some info ->
     check int "generic endpoint total" 2 info.total;


### PR DESCRIPTION
## Summary

- **Bug**: Path B (HTTP-probe registration in `register_http_probe_capable`) used bare `base_url` as the capacity key, while the acquire path (`try_acquire`) uses `capacity_key` = `base_url:model_id`. This key mismatch meant HTTP-probe capacity slots were never found by `try_acquire`, silently bypassing the concurrent request limit.
- **Fix**: `register_http_probe_capable` now registers under `capacity_key` (base_url:model_id) instead of `http_probe_url` (bare base_url). Server-side probe registration still uses bare base_url since HTTP probes are URL-level.
- **Test fix**: Pre-existing test failure in `test_declared_client_capacity_registers_generic_endpoint` — lookup key now matches the registration key format.
- **Cascade strategy**: Added documentation comment about route-level fairness gap in `dedupe_full_capacity_keys`.

## Files changed

- `lib/cascade/cascade_runtime_candidate.ml` — key alignment in `register_http_probe_capable`
- `lib/cascade/cascade_strategy.ml` — fairness TODO documentation
- `test/test_cascade_strategy.ml` — test key format fix

## Root cause

The capacity system has two registration paths:
- **Path A** (declared): `register_declared_client_capacity` → key = `base_url:model_id`
- **Path B** (HTTP probe): `register_http_probe_capable` → key was `base_url` only

The acquire path always uses `capacity_key` = `base_url:model_id`, so Path B registrations created orphaned slots that were never checked.

## What this does NOT fix

Route-level fairness: when 17 routes share the same physical provider (e.g., RunPod server), `dedupe_full_capacity_keys` collapses to one candidate per full key. The first route in cascade.toml order always wins. Fairness (weighted fair queuing or per-route reservation) requires strategy-layer changes tracked separately.

## Test plan

- [x] `dune build .` — clean
- [x] `dune build @check` — clean
- [x] `test_cascade_strategy` — 42/42 pass (was 41/42 on main)
- [x] `test_cascade_capacity_backpressure_cooldown` — 5/5 pass
- [x] `test_cascade_capacity_backpressure_synthetic_backoff` — 6/6 pass
- [x] `test_cascade_capacity_probe` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)