### PR TITLE
fix(ssot): consolidate ISO timestamps to Masc_domain (round 7)

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -296,8 +296,6 @@ let audit_entry_id ~timestamp ~agent_id ~action =
                                            ^ Printf.sprintf "%.6f" timestamp)) in
   Printf.sprintf "aud-%016Lx-%s" ms (String.sub hash 0 8)
 
-let format_iso8601 ts = Masc_domain.iso8601_of_unix_seconds ts
-
 (** Map outcome + action to O2 severity string. *)
 let audit_severity ~action ~outcome =
   match outcome with
@@ -377,7 +375,7 @@ let audit_event_json (entry : audit_entry) =
   let fields =
     [
       ("id", `String id);
-      ("ts", `String (format_iso8601 entry.timestamp));
+      ("ts", `String (Masc_domain.iso8601_of_unix_seconds entry.timestamp));
       ("actor", `String entry.agent_id);
       ("kind", `String kind);
       ("summary", `String (audit_summary ~action:entry.action ~details:entry.details));
@@ -461,7 +459,7 @@ let log_action
   append_entry config entry;
   (* Publish to the MASC event bus for real-time SSE streaming. *)
   let id = audit_entry_id ~timestamp:entry.timestamp ~agent_id ~action in
-  let ts = format_iso8601 entry.timestamp in
+  let ts = Masc_domain.iso8601_of_unix_seconds entry.timestamp in
   let kind = action_to_string action in
   let severity = audit_severity ~action ~outcome in
   let summary = audit_summary ~action ~details in

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -296,13 +296,7 @@ let audit_entry_id ~timestamp ~agent_id ~action =
                                            ^ Printf.sprintf "%.6f" timestamp)) in
   Printf.sprintf "aud-%016Lx-%s" ms (String.sub hash 0 8)
 
-(** Format a Unix timestamp as ISO 8601 UTC string. *)
-let format_iso8601 ts =
-  let t = Int64.to_int (Int64.of_float ts) in
-  let tm = Unix.gmtime (float_of_int t) in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
-    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+let format_iso8601 ts = Masc_domain.iso8601_of_unix_seconds ts
 
 (** Map outcome + action to O2 severity string. *)
 let audit_severity ~action ~outcome =

--- a/lib/auth_credential_token.ml
+++ b/lib/auth_credential_token.ml
@@ -59,16 +59,7 @@ let expires_at_for_auth_config auth_cfg =
       Time_compat.now ()
       +. (float_of_int auth_cfg.token_expiry_hours *. Masc_time_constants.hour)
     in
-    let tm = Unix.gmtime expiry in
-    Some
-      (Printf.sprintf
-         "%04d-%02d-%02dT%02d:%02d:%02dZ"
-         (tm.Unix.tm_year + 1900)
-         (tm.Unix.tm_mon + 1)
-         tm.Unix.tm_mday
-         tm.Unix.tm_hour
-         tm.Unix.tm_min
-         tm.Unix.tm_sec))
+    Some (Masc_domain.iso8601_of_unix_seconds expiry))
   else None
 ;;
 

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -875,12 +875,7 @@ let totals_of_karma_ledger events =
         "ts_iso": "YYYY-MM-DDTHH:MM:SSZ" }
     v} *)
 let karma_event_to_yojson (e : karma_event) : Yojson.Safe.t =
-  let tm = Unix.gmtime e.ts in
-  let ts_iso =
-    Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-      (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
-      tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
-  in
+  let ts_iso = Masc_domain.iso8601_of_unix_seconds e.ts in
   `Assoc [
     ("recipient",   `String e.recipient);
     ("voter",       `String e.voter);

--- a/lib/bounded.ml
+++ b/lib/bounded.ml
@@ -424,7 +424,7 @@ let constraints_of_json json =
 
 (** Parse goal from JSON *)
 let goal_of_json json =
-  let path = Json_util.get_string json "path" |> Option.value ~default:"" in
+  let path = Json_util.get_string_with_default json ~key:"path" ~default:"" in
   let cond =
     match Json_util.assoc_member_opt "condition" json with
     | None | Some `Null -> `Null

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -24,8 +24,6 @@ type t =
   }
 [@@deriving yojson { strict = false }]
 
-let iso8601_of_unix = Masc_domain.iso8601_of_unix_seconds
-
 let rec find_git_root dir =
   let git_marker = Filename.concat dir ".git" in
   if Sys.file_exists git_marker
@@ -304,7 +302,7 @@ let age_seconds ~now ts_opt =
 ;;
 
 let started_at_unix = Unix.gettimeofday ()
-let started_at_iso = iso8601_of_unix started_at_unix
+let started_at_iso = Masc_domain.iso8601_of_unix_seconds started_at_unix
 let resolved_executable_path = executable_path ()
 let resolved_executable_dir = Filename.dirname resolved_executable_path
 

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -24,12 +24,7 @@ type t =
   }
 [@@deriving yojson { strict = false }]
 
-let iso8601_of_unix ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf
-    "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
+let iso8601_of_unix = Masc_domain.iso8601_of_unix_seconds
     tm.Unix.tm_mday
     tm.Unix.tm_hour
     tm.Unix.tm_min

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -25,11 +25,6 @@ type t =
 [@@deriving yojson { strict = false }]
 
 let iso8601_of_unix = Masc_domain.iso8601_of_unix_seconds
-    tm.Unix.tm_mday
-    tm.Unix.tm_hour
-    tm.Unix.tm_min
-    tm.Unix.tm_sec
-;;
 
 let rec find_git_root dir =
   let git_marker = Filename.concat dir ".git" in

--- a/lib/coord/coord_gc.ml
+++ b/lib/coord/coord_gc.ml
@@ -259,12 +259,7 @@ let gc config ?(days=7) () =
     let now = Time_compat.now () in
     now -. (float_of_int days *. 24. *. 60. *. 60.)
   in
-  let cutoff_iso =
-    let tm = Unix.gmtime cutoff_time in
-    Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-      (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
-      tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
-  in
+  let cutoff_iso = Masc_domain.iso8601_of_unix_seconds cutoff_time in
 
   let backlog = read_backlog config in
   let stale_count = ref 0 in

--- a/lib/core/json_util.ml
+++ b/lib/core/json_util.ml
@@ -6,8 +6,8 @@
     Usage:
     {[
       open Json_util
-      let name = get_string_opt json "name" |> Option.value ~default:""
-      let age = get_int_opt json "age" |> Option.value ~default:0
+      let name = get_string_with_default json ~key:"name" ~default:""
+      let age = get_int json "age" |> Option.value ~default:0
     ]}
 *)
 

--- a/lib/core/json_util.ml
+++ b/lib/core/json_util.ml
@@ -205,32 +205,6 @@ let json_string_list_member name json =
   | _ -> []
 
 
-(** {1 Assoc field extraction}
-
-    Canonical [Assoc] field accessors for building typed JSON parsers.
-    Replaces per-module [assoc_member_opt] / [assoc_string_opt] etc. *)
-
-let assoc_member_opt name = function
-  | `Assoc fields -> List.assoc_opt name fields
-  | _ -> None
-
-let assoc_string_opt name json =
-  match assoc_member_opt name json with
-  | Some (`String value) when String.trim value <> "" -> Some value
-  | _ -> None
-
-let assoc_int_opt name json =
-  match assoc_member_opt name json with
-  | Some (`Int value) -> Some value
-  | Some (`Intlit raw) -> int_of_string_opt raw
-  | _ -> None
-
-let assoc_bool_opt name json =
-  match assoc_member_opt name json with
-  | Some (`Bool value) -> Some value
-  | _ -> None
-
-
 (** List utilities *)
 
 let dedupe_keep_order xs =

--- a/lib/dashboard/dashboard_briefing.ml
+++ b/lib/dashboard/dashboard_briefing.ml
@@ -36,10 +36,6 @@ type attention_context = Dashboard_briefing_assembly.attention_context = {
   json : Yojson.Safe.t;
 }
 
-let dedup_strings items =
-  List.sort_uniq String.compare
-    (List.filter_map String_util.trim_to_option items)
-
 let top_item items =
   match items with
   | item :: _ -> item

--- a/lib/dashboard/dashboard_briefing_agents.ml
+++ b/lib/dashboard/dashboard_briefing_agents.ml
@@ -5,10 +5,6 @@
 
 include Dashboard_utils
 
-let dedup_strings items =
-  List.sort_uniq String.compare
-    (List.filter_map String_util.trim_to_option items)
-
 let event_detail_json event_json =
   member_assoc "detail" event_json
 

--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -85,7 +85,7 @@ let keeper_tool_audit_json_fields config registry_lookup keeper agent_name =
               let latest_at = List.fold_left (fun acc (_, e) ->
                 max acc e.Keeper_types.last_used_at) 0.0 tracked in
               let at_str = if latest_at > 0.0
-                then Some (Dashboard_utils.iso_of_unix latest_at) else None in
+                then Some (Masc_domain.iso8601_of_unix_seconds latest_at) else None in
               (fallback_allowed, names, Some total, None, Some "keeper_dispatch", at_str)
             else
               ( fallback_allowed,

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -160,9 +160,7 @@ let skill_route_summary_of_keeper keeper =
                 source;
               ]))
 
-let dedup_strings items =
-  List.sort_uniq String.compare
-    (List.filter_map String_util.trim_to_option items)
+let dedup_strings = Dashboard_utils.dedup_strings
 
 (** severity_rank works on raw JSON strings — broader matching than Dashboard_utils.tone_rank.
     Used by dashboard_briefing / dashboard_briefing_assembly for external JSON data. *)

--- a/lib/dashboard/dashboard_goals_types_accessor.ml
+++ b/lib/dashboard/dashboard_goals_types_accessor.ml
@@ -155,8 +155,7 @@ let trust_needs_attention json =
 
 let trust_snapshot_unavailable json =
   String.equal
-    (Json_util.get_string json "disposition_reason"
-     |> Option.value ~default:"")
+    (Json_util.get_string_with_default json ~key:"disposition_reason" ~default:"")
     "runtime_trust_snapshot_unavailable"
 
 let trust_turn_id json =
@@ -177,14 +176,12 @@ let trust_latest_event_ts_unix json =
 
 let trust_sandbox_risk json =
   String.equal
-    (Json_util.get_string json "disposition_reason"
-     |> Option.value ~default:"")
+    (Json_util.get_string_with_default json ~key:"disposition_reason" ~default:"")
     "sandbox_violation"
 
 let trust_cascade_risk json =
   String.equal
-    (Json_util.get_string json "disposition_reason"
-     |> Option.value ~default:"")
+    (Json_util.get_string_with_default json ~key:"disposition_reason" ~default:"")
     "cascade_exhausted"
 
 let receipt_has_error json =

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -137,8 +137,6 @@ let with_lock (st : state) f =
   Eio.Mutex.use_rw ~protect:true st.mutex f
 
 
-let now_iso () = Masc_domain.now_iso ()
-
 let interval_sec () = Env_config.Dashboard_config.governance_judge_interval_sec
 
 let cache_ttl_sec () =
@@ -676,7 +674,7 @@ let compute_judgments
       let response = result.Cascade_runner.response in
       try
         let raw_text = Agent_sdk_response.text_of_response response in
-        let generated_at = now_iso () in
+        let generated_at = Masc_domain.now_iso () in
         let expires_at = Dashboard_utils.iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
         (* #9880: keep the internal fallback/counter for empty OAS model
            metadata, but do not project concrete model names into MASC-owned

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -283,8 +283,8 @@ let get_state base_path =
 let key_of kind id = kind ^ ":" ^ id
 
 let judgment_key json =
-  let kind = Json_util.get_string json "target_kind" |> Option.value ~default:"" in
-  let id = Json_util.get_string json "target_id" |> Option.value ~default:"" in
+  let kind = Json_util.get_string_with_default json ~key:"target_kind" ~default:"" in
+  let id = Json_util.get_string_with_default json ~key:"target_id" ~default:"" in
   key_of kind id
 
 let judgment_generated_at json =
@@ -560,14 +560,14 @@ let parse_required_guardrail_state json =
 
 let parse_item_judgment ~generated_at ~expires_at ~model_used:_ json =
   let target_kind =
-    Json_util.get_string json "kind" |> Option.value ~default:""
+    Json_util.get_string_with_default json ~key:"kind" ~default:""
     |> String.lowercase_ascii
   in
-  let target_id = Json_util.get_string json "id" |> Option.value ~default:"" in
+  let target_id = Json_util.get_string_with_default json ~key:"id" ~default:"" in
   if target_kind = "" || target_id = "" then Ok None
   else
     let summary =
-      normalize_text (Json_util.get_string json "summary" |> Option.value ~default:"")
+      normalize_text (Json_util.get_string_with_default json ~key:"summary" ~default:"")
     in
     if summary = "" then Ok None
     else

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -500,8 +500,7 @@ let parse_recommended_action json =
             ( "reason",
               `String
                 (normalize_text
-                   (Json_util.get_string action_json "reason"
-                  |> Option.value ~default:"")) );
+                   (Json_util.get_string_with_default action_json ~key:"reason" ~default:"")) );
             ("payload_preview", m "payload_preview" action_json);
           ])
   | _ -> None

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -675,7 +675,7 @@ let compute_judgments
       try
         let raw_text = Agent_sdk_response.text_of_response response in
         let generated_at = Masc_domain.now_iso () in
-        let expires_at = Dashboard_utils.iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
+        let expires_at = Masc_domain.iso8601_of_unix_seconds (Unix.gettimeofday () +. cache_ttl_sec ()) in
         (* #9880: keep the internal fallback/counter for empty OAS model
            metadata, but do not project concrete model names into MASC-owned
            dashboard or judgment JSON. *)

--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -215,11 +215,7 @@ let keeper_decisions_retention_json ~per_keeper_limit ~keeper_count =
 
 let k2_iso8601_of_unix ts_unix =
   if ts_unix <= 0.0 then ""
-  else
-    let t = Unix.gmtime ts_unix in
-    Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-      (t.Unix.tm_year + 1900) (t.Unix.tm_mon + 1) t.Unix.tm_mday
-      t.Unix.tm_hour t.Unix.tm_min t.Unix.tm_sec
+  else Masc_domain.iso8601_of_unix_seconds ts_unix
 
 let k2_stable_id ~prefix ~keeper_name ~ts_unix ~raw =
   let ms = Int64.of_float (ts_unix *. 1000.0) in

--- a/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
+++ b/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
@@ -70,17 +70,7 @@ let float_field_opt record field =
      | _ -> None)
   | _ -> None
 
-let string_list_field record field =
-  match record with
-  | `Assoc fields ->
-    (match List.assoc_opt field fields with
-     | Some (`List values) ->
-       values
-       |> List.filter_map (function
-         | `String value when String.trim value <> "" -> Some value
-         | _ -> None)
-     | _ -> [])
-  | _ -> []
+let string_list_field = Json_util.get_string_list
 
 let output_text record =
   match record with

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -205,7 +205,7 @@ let parse_room_judgment ~config ~generated_at ~generated_at_unix ~model_used:_ j
                (Json_util.get_bool json member_disagreement_with_truth
                |> Option.value ~default:false)
              ~generated_at ~generated_at_unix
-             ~fresh_until:(Dashboard_utils.iso_of_unix fresh_until_unix)
+             ~fresh_until:(Masc_domain.iso8601_of_unix_seconds fresh_until_unix)
              ~fresh_until_unix ~keeper_name ())
   | _ -> None
 
@@ -301,9 +301,9 @@ let refresh_once ~sw ~net
             st.last_error <- Some message)
     | Ok (model_used, result_json) ->
         let generated_at_unix = Unix.gettimeofday () in
-        let generated_at = Dashboard_utils.iso_of_unix generated_at_unix in
+        let generated_at = Masc_domain.iso8601_of_unix_seconds generated_at_unix in
         let expires_at =
-          Dashboard_utils.iso_of_unix (generated_at_unix +. float_of_int (room_ttl_sec ()))
+          Masc_domain.iso8601_of_unix_seconds (generated_at_unix +. float_of_int (room_ttl_sec ()))
         in
         let room_judgment =
           parse_room_judgment ~config ~generated_at ~generated_at_unix

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -131,12 +131,11 @@ let build_recommended_action ~actor ~target_type ~target_id json =
       (match action_type with
       | Some action_type when action_type <> "" && allowed_action_type action_type ->
           let severity =
-            Json_util.get_string json member_severity
-            |> Option.value ~default:severity_warn
+            Json_util.get_string_with_default json ~key:member_severity ~default:severity_warn
           in
           let reason =
             normalize_text
-              (Json_util.get_string json member_reason |> Option.value ~default:"")
+              (Json_util.get_string_with_default json ~key:member_reason ~default:"")
           in
           let suggested_payload =
             match Json_util.assoc_member_opt member_suggested_payload json with
@@ -183,7 +182,7 @@ let parse_room_judgment ~config ~generated_at ~generated_at_unix ~model_used:_ j
   | `Assoc _ ->
       let summary =
         normalize_text
-          (Json_util.get_string json member_summary |> Option.value ~default:"")
+          (Json_util.get_string_with_default json ~key:member_summary ~default:"")
       in
       if summary = "" then None
       else

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -138,7 +138,7 @@ let request_to_json (req : V.verification_request) : Yojson.Safe.t =
        unassigned rather than inventing a value. *)
     ("keeper", Json_util.string_opt_to_json req.verifier);
     ("status", `String status);
-    ("created_at", `String (Dashboard_utils.iso_of_unix req.created_at));
+    ("created_at", `String (Masc_domain.iso8601_of_unix_seconds req.created_at));
     ("submitted_by", `String req.worker);
     ("approved_by", Json_util.string_opt_to_json approved_by);
     ("completion_contract",
@@ -233,7 +233,7 @@ let rejection_row_json (req : V.verification_request) : Yojson.Safe.t =
     ("task_title", `String task_title);
     ("keeper", Json_util.string_opt_to_json approved_by);
     ("verdict_reason", `String verdict_reason);
-    ("created_at", `String (Dashboard_utils.iso_of_unix req.created_at));
+    ("created_at", `String (Masc_domain.iso8601_of_unix_seconds req.created_at));
   ]
 
 let is_rejected (req : V.verification_request) : bool =

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -188,7 +188,6 @@ let sort_desc (requests : V.verification_request list)
 
 let take = List.take
 
-let now_iso () = Masc_domain.now_iso ()
 let fd_pressure_fields () = Keeper_fd_pressure.projection_fields ()
 
 (* Compute the request-listing projection from an already-loaded list.
@@ -199,7 +198,7 @@ let requests_json_of_requests ?task_id ~limit all : Yojson.Safe.t =
   let sorted = sort_desc filtered in
   let trimmed = take limit sorted in
   `Assoc
-    ([ ("updated_at", `String (now_iso ()))
+    ([ ("updated_at", `String (Masc_domain.now_iso ()))
      ; ("total", `Int (List.length filtered))
      ; ("requests", `List (List.map request_to_json trimmed))
      ]
@@ -269,7 +268,7 @@ let summary_json_of_requests ~recent all : Yojson.Safe.t =
     |> List.map rejection_row_json
   in
   `Assoc
-    ([ ("updated_at", `String (now_iso ()))
+    ([ ("updated_at", `String (Masc_domain.now_iso ()))
      ; ("total", `Int total)
      ; ( "by_status"
        , `Assoc

--- a/lib/dashboard_tla_specs.ml
+++ b/lib/dashboard_tla_specs.ml
@@ -119,7 +119,6 @@ let list_specs () =
       | c -> c)
 ;;
 
-let iso_of_unix_time = Dashboard_utils.iso_of_unix
 ;;
 
 let entry_to_json e : Yojson.Safe.t =
@@ -129,7 +128,7 @@ let entry_to_json e : Yojson.Safe.t =
     ; "category", `String e.category
     ; "has_clean_cfg", `Bool e.has_clean_cfg
     ; "has_buggy_cfg", `Bool e.has_buggy_cfg
-    ; "mtime_iso", `String (iso_of_unix_time e.mtime)
+    ; "mtime_iso", `String (Masc_domain.iso8601_of_unix_seconds e.mtime)
     ]
 ;;
 
@@ -145,7 +144,7 @@ let specs_json () : Yojson.Safe.t =
   let root = specs_dir () in
   let entries = list_specs () in
   `Assoc
-    [ "updated_at", `String (iso_of_unix_time (Unix.gettimeofday ()))
+    [ "updated_at", `String (Masc_domain.iso8601_of_unix_seconds (Unix.gettimeofday ()))
     ; "specs_dir", specs_dir_json root
     ; "count", `Int (List.length entries)
     ; "entries", `List (List.map entry_to_json entries)
@@ -295,7 +294,7 @@ let list_tlc_results () =
 
 
 let option_time_json = function
-  | Some v -> `String (iso_of_unix_time v)
+  | Some v -> `String (Masc_domain.iso8601_of_unix_seconds v)
   | None -> `Null
 ;;
 
@@ -318,7 +317,7 @@ let tlc_results_json () : Yojson.Safe.t =
   let results_dir = tlc_results_dir () in
   let entries = list_tlc_results () in
   `Assoc
-    [ "updated_at", `String (iso_of_unix_time (Unix.gettimeofday ()))
+    [ "updated_at", `String (Masc_domain.iso8601_of_unix_seconds (Unix.gettimeofday ()))
     ; ( "results_dir"
       , if is_directory_safe results_dir
         then (

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -1,5 +1,3 @@
-let iso_of_unix unix_ts = Masc_domain.iso8601_of_unix_seconds unix_ts
-
 let parse_iso_opt = function
   | Some raw when String.trim raw <> "" -> (
       try Some (Masc_domain.parse_iso8601 raw) with Failure _ -> None)

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -1,8 +1,4 @@
-let iso_of_unix unix_ts =
-  let tm = Unix.gmtime unix_ts in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
-    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+let iso_of_unix unix_ts = Masc_domain.iso8601_of_unix_seconds unix_ts
 
 let parse_iso_opt = function
   | Some raw when String.trim raw <> "" -> (

--- a/lib/dashboard_utils/dashboard_utils.mli
+++ b/lib/dashboard_utils/dashboard_utils.mli
@@ -5,9 +5,6 @@
 
 (** {1 Time} *)
 
-val iso_of_unix : float -> string
-(** Format a Unix epoch as ISO-8601 in UTC, e.g. ["2026-04-28T10:34:12Z"]. *)
-
 val parse_iso_opt : string option -> float option
 (** Parse an ISO-8601 timestamp via {!Masc_domain.parse_iso8601}.
     Returns [None] for [None], empty/whitespace strings, or parse failures. *)

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -241,8 +241,7 @@ let record_human_label
 (* ================================================================ *)
 
 let string_field json key =
-  try (match Json_util.assoc_member_opt key json with Some (`String s) -> s | other -> raise (Yojson.Safe.Util.Type_error ("expected string", Option.value ~default:`Null other)))
-  with Yojson.Safe.Util.Type_error _ | Not_found -> ""
+  Json_util.get_string_with_default json ~key ~default:""
 
 (* ================================================================ *)
 (* Divergence analysis                                               *)

--- a/lib/eval_harness.ml
+++ b/lib/eval_harness.ml
@@ -318,7 +318,7 @@ let scenario_to_json (s : scenario) : Yojson.Safe.t =
 (** Parse a scenario from JSON (loaded from YAML→JSON or direct JSON). *)
 let scenario_of_json (json : Yojson.Safe.t) : (scenario, string) result =
   try
-    let str key = Json_util.get_string json key |> Option.value ~default:"" in
+    let str key = Json_util.get_string_with_default json ~key ~default:"" in
     let str_opt key default =
       match Json_util.assoc_member_opt key json with
       | Some (`String s) -> s

--- a/lib/gate/channel_gate_discord_names.ml
+++ b/lib/gate/channel_gate_discord_names.ml
@@ -46,7 +46,7 @@ let read_json_file_opt path =
   | Sys_error _ | Yojson.Json_error _ -> None
 
 let string_member json key =
-  Json_util.get_string json key |> Option.value ~default:""
+  Json_util.get_string_with_default json ~key ~default:""
 
 let string_assoc_of_member key json =
   match Json_util.get_object json key with

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -186,7 +186,7 @@ let read_recent_audit ~limit =
         else rows |> drop_left (total - limit) |> List.rev)
 
 let string_member json key =
-  Json_util.get_string json key |> Option.value ~default:""
+  Json_util.get_string_with_default json ~key ~default:""
 
 let int_member json key =
   Json_util.get_int json key |> Option.value ~default:0

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -210,7 +210,7 @@ let read_recent_audit ~limit =
         else rows |> drop_left (total - limit) |> List.rev)
 
 let string_member json key =
-  Json_util.get_string json key |> Option.value ~default:""
+  Json_util.get_string_with_default json ~key ~default:""
 
 let int_member json key =
   Json_util.get_int json key |> Option.value ~default:0

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -391,17 +391,7 @@ let handle_heartbeat
                    match Masc_domain.agent_of_yojson json with
                    | Ok agent ->
                      let now = Unix.gettimeofday () in
-                     let iso_now =
-                       let tm = Unix.gmtime now in
-                       Printf.sprintf
-                         "%04d-%02d-%02dT%02d:%02d:%02dZ"
-                         (1900 + tm.tm_year)
-                         (1 + tm.tm_mon)
-                         tm.tm_mday
-                         tm.tm_hour
-                         tm.tm_min
-                         tm.tm_sec
-                     in
+                     let iso_now = Masc_domain.iso8601_of_unix_seconds now in
                      let updated = { agent with Masc_domain.last_seen = iso_now } in
                      let content =
                        Yojson.Safe.to_string (Masc_domain.agent_to_yojson updated)

--- a/lib/handover_eio.ml
+++ b/lib/handover_eio.ml
@@ -106,7 +106,7 @@ let handover_to_json (h : handover_record) : Yojson.Safe.t =
 
 (** JSON to handover *)
 let handover_of_json (json : Yojson.Safe.t) : handover_record option =
-  let str key = Json_util.get_string json key |> Option.value ~default:"" in
+  let str key = Json_util.get_string_with_default json ~key ~default:"" in
   let str_opt key = Json_util.get_string json key in
   let str_list key = Json_util.get_string_list json key in
   let int_val key = Json_util.get_int json key |> Option.value ~default:0 in

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -190,14 +190,13 @@ let rec episode_to_json (e : episode) : Yojson.Safe.t =
 
 and episode_of_json json =
   let m key = Option.value ~default:`Null (Json_util.assoc_member_opt key json) in
-  { id = Json_util.get_string json "id" |> Option.value ~default:""
+  { id = Json_util.get_string_with_default json ~key:"id" ~default:""
   ; timestamp = Json_util.get_float json "timestamp" |> Option.value ~default:0.0
   ; participants = Json_util.get_string_list json "participants"
-  ; event_type = Json_util.get_string json "event_type" |> Option.value ~default:""
-  ; summary = Json_util.get_string json "summary" |> Option.value ~default:""
+  ; event_type = Json_util.get_string_with_default json ~key:"event_type" ~default:""
+  ; summary = Json_util.get_string_with_default json ~key:"summary" ~default:""
   ; outcome =
-      Json_util.get_string json "outcome"
-      |> Option.value ~default:""
+      Json_util.get_string_with_default json ~key:"outcome" ~default:""
       |> outcome_of_string
   ; learnings = Json_util.get_string_list json "learnings"
   ; context =
@@ -223,11 +222,11 @@ and knowledge_to_json (k : knowledge) : Yojson.Safe.t =
     ]
 
 and knowledge_of_json json =
-  { id = Json_util.get_string json "id" |> Option.value ~default:""
-  ; topic = Json_util.get_string json "topic" |> Option.value ~default:""
-  ; content = Json_util.get_string json "content" |> Option.value ~default:""
+  { id = Json_util.get_string_with_default json ~key:"id" ~default:""
+  ; topic = Json_util.get_string_with_default json ~key:"topic" ~default:""
+  ; content = Json_util.get_string_with_default json ~key:"content" ~default:""
   ; confidence = Json_util.get_float json "confidence" |> Option.value ~default:0.0
-  ; source = Json_util.get_string json "source" |> Option.value ~default:""
+  ; source = Json_util.get_string_with_default json ~key:"source" ~default:""
   ; created_at = Json_util.get_float json "created_at" |> Option.value ~default:0.0
   ; last_verified = Json_util.get_float json "last_verified" |> Option.value ~default:0.0
   ; references = Json_util.get_string_list json "references"
@@ -250,10 +249,10 @@ and pattern_to_json (p : pattern) : Yojson.Safe.t =
     ]
 
 and pattern_of_json json =
-  { id = Json_util.get_string json "id" |> Option.value ~default:""
-  ; name = Json_util.get_string json "name" |> Option.value ~default:""
-  ; description = Json_util.get_string json "description" |> Option.value ~default:""
-  ; trigger = Json_util.get_string json "trigger" |> Option.value ~default:""
+  { id = Json_util.get_string_with_default json ~key:"id" ~default:""
+  ; name = Json_util.get_string_with_default json ~key:"name" ~default:""
+  ; description = Json_util.get_string_with_default json ~key:"description" ~default:""
+  ; trigger = Json_util.get_string_with_default json ~key:"trigger" ~default:""
   ; steps = Json_util.get_string_list json "steps"
   ; success_rate = Json_util.get_float json "success_rate" |> Option.value ~default:0.0
   ; usage_count = Json_util.get_int json "usage_count" |> Option.value ~default:0
@@ -277,9 +276,9 @@ and cultural_value_to_json (c : cultural_value) : Yojson.Safe.t =
     ]
 
 and cultural_value_of_json json =
-  { id = Json_util.get_string json "id" |> Option.value ~default:""
-  ; name = Json_util.get_string json "name" |> Option.value ~default:""
-  ; description = Json_util.get_string json "description" |> Option.value ~default:""
+  { id = Json_util.get_string_with_default json ~key:"id" ~default:""
+  ; name = Json_util.get_string_with_default json ~key:"name" ~default:""
+  ; description = Json_util.get_string_with_default json ~key:"description" ~default:""
   ; weight = Json_util.get_float json "weight" |> Option.value ~default:0.0
   ; examples = Json_util.get_string_list json "examples"
   ; anti_patterns = Json_util.get_string_list json "anti_patterns"
@@ -299,8 +298,7 @@ and succession_of_json json =
   { onboarding_steps = Json_util.get_string_list json "onboarding_steps"
   ; required_knowledge = Json_util.get_string_list json "required_knowledge"
   ; mentor_assignment =
-      Json_util.get_string json "mentor_assignment"
-      |> Option.value ~default:"best_fit"
+      Json_util.get_string_with_default json ~key:"mentor_assignment" ~default:"best_fit"
       |> mentor_of_string
   ; probation_period = Json_util.get_float json "probation_period" |> Option.value ~default:0.0
   ; graduation_criteria = Json_util.get_string_list json "graduation_criteria"
@@ -316,9 +314,9 @@ and identity_to_json (i : identity) : Yojson.Safe.t =
     ]
 
 and identity_of_json json =
-  { id = Json_util.get_string json "id" |> Option.value ~default:""
-  ; name = Json_util.get_string json "name" |> Option.value ~default:""
-  ; mission = Json_util.get_string json "mission" |> Option.value ~default:""
+  { id = Json_util.get_string_with_default json ~key:"id" ~default:""
+  ; name = Json_util.get_string_with_default json ~key:"name" ~default:""
+  ; mission = Json_util.get_string_with_default json ~key:"mission" ~default:""
   ; founded_at = Json_util.get_float json "founded_at" |> Option.value ~default:0.0
   ; generation = Json_util.get_int json "generation" |> Option.value ~default:0
   }

--- a/lib/keeper/keeper_accountability_types_codec.ml
+++ b/lib/keeper/keeper_accountability_types_codec.ml
@@ -214,9 +214,6 @@ let event_date_string ts =
     tm.Unix.tm_mday
 ;;
 
-let iso8601_of_unix = Masc_domain.iso8601_of_unix_seconds
-;;
-
 let claim_event_of_json json =
   match json_string_opt "event_type" json with
   | Some "claim_created" ->

--- a/lib/keeper/keeper_accountability_types_codec.ml
+++ b/lib/keeper/keeper_accountability_types_codec.ml
@@ -214,16 +214,7 @@ let event_date_string ts =
     tm.Unix.tm_mday
 ;;
 
-let iso8601_of_unix ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf
-    "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
-    tm.Unix.tm_mday
-    tm.Unix.tm_hour
-    tm.Unix.tm_min
-    tm.Unix.tm_sec
+let iso8601_of_unix = Masc_domain.iso8601_of_unix_seconds
 ;;
 
 let claim_event_of_json json =

--- a/lib/keeper/keeper_accountability_types_codec.mli
+++ b/lib/keeper/keeper_accountability_types_codec.mli
@@ -92,7 +92,6 @@ val resolution_event_to_json :
         [> `List of [> `String of string ] list | `String of string ])
        list ]
 val event_date_string : float -> string
-val iso8601_of_unix : float -> string
 val claim_event_of_json : Yojson.Safe.t -> claim_event option
 val resolution_event_of_json : Yojson.Safe.t -> resolution_event option
 val read_window_entries : Coord_query.config -> Yojson.Safe.t list

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -73,8 +73,8 @@ type chat_message = {
 let parse_line ~file_path (line : string) : chat_message option =
   try
     let json = Yojson.Safe.from_string line in
-    let role = Json_util.get_string json "role" |> Option.value ~default:"" in
-    let content = Json_util.get_string json "content" |> Option.value ~default:"" in
+    let role = Json_util.get_string_with_default json ~key:"role" ~default:"" in
+    let content = Json_util.get_string_with_default json ~key:"content" ~default:"" in
     let ts =
       (try Some ((match Json_util.assoc_member_opt "ts" json with Some (`Float f) -> f | _ -> 0.0))
        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None) in

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -724,7 +724,6 @@ let map_proactive_rt (f : proactive_runtime -> proactive_runtime) (m : keeper_me
   { m with runtime = { m.runtime with proactive_rt = f m.runtime.proactive_rt } }
 ;;
 
-let now_iso () = Masc_domain.now_iso ()
 let keeper_legacy_model_arg_names = [ "models"; "allowed_models"; "active_model" ]
 
 let reject_legacy_model_args ~tool_name (args : Yojson.Safe.t) =

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -222,17 +222,7 @@ let read_meta_if_changed config name ~(last_mtime : float) : (Keeper_meta_contra
   read_candidate requested_name
 ;;
 
-let current_utc_timestamp () =
-  let t = Unix.gmtime (Unix.gettimeofday ()) in
-  Printf.sprintf
-    "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (t.tm_year + 1900)
-    (t.tm_mon + 1)
-    t.tm_mday
-    t.tm_hour
-    t.tm_min
-    t.tm_sec
-;;
+let current_utc_timestamp () = Masc_domain.now_iso ()
 
 let is_missing_progress_file_error exn =
   match exn with

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -447,7 +447,7 @@ let approval_state_json ~pending_approval_count ~pending_approvals ~latest_tool_
       ("latest_event_kind", Json_util.string_opt_to_json latest_event_kind);
       ( "latest_event_at",
         match Option.bind latest_approval_audit (json_float_opt_member "ts") with
-        | Some ts -> `String (iso_of_unix_seconds ts)
+        | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
         | None -> `Null );
       ( "matched_by",
         match latest_rule_match with

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -34,8 +34,6 @@ let assoc_json_opt key fields =
   | Some `Null | None -> None
   | Some value -> Some value
 
-let iso_of_unix_seconds ts =
-  Masc_domain.iso8601_of_unix_seconds ts
 
 let take = List.take
 
@@ -62,9 +60,9 @@ let timeline_event_json ?trace_id ?keeper_turn_id ?task_id ?(goal_ids = [])
   `Assoc
     [
       ("kind", `String kind);
-      ("ts", `String (iso_of_unix_seconds ts_unix));
+      ("ts", `String (Masc_domain.iso8601_of_unix_seconds ts_unix));
       ("ts_unix", `Float ts_unix);
-      ("observed_at", `String (iso_of_unix_seconds observed_at_unix));
+      ("observed_at", `String (Masc_domain.iso8601_of_unix_seconds observed_at_unix));
       ("observed_at_unix", `Float observed_at_unix);
       ("observation_only", `Bool observation_only);
       ("trace_id", Json_util.string_opt_to_json trace_id);

--- a/lib/keeper/keeper_runtime_trust_timeline.mli
+++ b/lib/keeper/keeper_runtime_trust_timeline.mli
@@ -19,8 +19,6 @@ val assoc_string_opt : string -> (string * Yojson.Safe.t) list -> string option
 
 val assoc_json_opt : string -> (string * Yojson.Safe.t) list -> Yojson.Safe.t option
 
-val iso_of_unix_seconds : float -> string
-
 val take : int -> 'a list -> 'a list
 
 val goal_ids_of_json : Yojson.Safe.t -> string list

--- a/lib/keeper/keeper_status_metrics.ml
+++ b/lib/keeper/keeper_status_metrics.ml
@@ -511,10 +511,10 @@ let json_iso_opt json =
       if trimmed <> "" then Some trimmed
       else
         let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" json in
-        if ts_unix > 0.0 then Some (Dashboard_utils.iso_of_unix ts_unix) else None
+        if ts_unix > 0.0 then Some (Masc_domain.iso8601_of_unix_seconds ts_unix) else None
   | None ->
       let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" json in
-      if ts_unix > 0.0 then Some (Dashboard_utils.iso_of_unix ts_unix) else None
+      if ts_unix > 0.0 then Some (Masc_domain.iso8601_of_unix_seconds ts_unix) else None
 
 let read_recent_metrics_lines config keeper_name =
   let store = Keeper_types_support.keeper_metrics_store config keeper_name in

--- a/lib/keeper_benchmark_canary.ml
+++ b/lib/keeper_benchmark_canary.ml
@@ -93,15 +93,7 @@ let compare_recommendation left right =
       | cmp -> cmp)
   | cmp -> cmp
 
-let generated_at_utc () =
-  let tm = Unix.gmtime (Unix.gettimeofday ()) in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
-    tm.Unix.tm_mday
-    tm.Unix.tm_hour
-    tm.Unix.tm_min
-    tm.Unix.tm_sec
+let generated_at_utc () = Masc_domain.now_iso ()
 
 let build_manifest ?source_summary_path
     (summary : Tool_call_quality_benchmark.benchmark_summary) : manifest =

--- a/lib/masc_context_injector.ml
+++ b/lib/masc_context_injector.ml
@@ -30,11 +30,7 @@ let key_tool_error_count = "session:tool_error_count"
 (* ================================================================ *)
 
 let iso8601_of_float (t : float) : string =
-  let open Unix in
-  let tm = gmtime t in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
-    tm.tm_hour tm.tm_min tm.tm_sec
+  Masc_domain.iso8601_of_unix_seconds t
 
 (* ================================================================ *)
 (* Injector factory                                                  *)

--- a/lib/masc_context_injector.ml
+++ b/lib/masc_context_injector.ml
@@ -29,9 +29,6 @@ let key_tool_error_count = "session:tool_error_count"
 (* ISO 8601 formatting                                               *)
 (* ================================================================ *)
 
-let iso8601_of_float (t : float) : string =
-  Masc_domain.iso8601_of_unix_seconds t
-
 (* ================================================================ *)
 (* Injector factory                                                  *)
 (* ================================================================ *)
@@ -50,7 +47,7 @@ let make ~(config : config) () : Agent_sdk.Hooks.context_injector =
     let elapsed = now -. config.start_time in
     Some Agent_sdk.Hooks.{
       context_updates = [
-        (key_wall_time, `String (iso8601_of_float now));
+        (key_wall_time, `String (Masc_domain.iso8601_of_unix_seconds now));
         (key_elapsed_seconds, `Float elapsed);
         (key_tool_call_count, `Int (Atomic.get call_count));
         (key_last_tool_name, `String tool_name);

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -323,7 +323,7 @@ let action_json ?actor_hint (ctx : _ context) args :
   let trace_id = trace_id "ops" in
   let started_at = Unix.gettimeofday () in
   if confirm_required request.action_type then (
-    let expires_at = Dashboard_utils.iso_of_unix (Unix.gettimeofday () +. remote_confirm_ttl_seconds) in
+    let expires_at = Masc_domain.iso8601_of_unix_seconds (Unix.gettimeofday () +. remote_confirm_ttl_seconds) in
     let* token = generate_confirm_token ~clock:ctx.clock ctx.config in
     let preview = preview_of_action request in
     let entry =

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -35,13 +35,13 @@ let judgment_write_json (ctx : 'a context) args =
   if summary = "" then Error "summary is required"
   else
     let now_unix = Unix.gettimeofday () in
-    let generated_at = Dashboard_utils.iso_of_unix now_unix in
+    let generated_at = Masc_domain.iso8601_of_unix_seconds now_unix in
     let fresh_ttl_sec =
       let default = default_fresh_ttl_sec surface in
       max 1 (get_int args "fresh_ttl_sec" default)
     in
     let fresh_until_unix = now_unix +. float_of_int fresh_ttl_sec in
-    let fresh_until = Dashboard_utils.iso_of_unix fresh_until_unix in
+    let fresh_until = Masc_domain.iso8601_of_unix_seconds fresh_until_unix in
     let confidence = get_float args "confidence" 0.5 in
     let keeper_name =
       match get_string_opt args "keeper_name" with

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -110,23 +110,23 @@ let pending_confirm_to_yojson (entry : pending_confirm) =
 
 let pending_confirm_of_yojson json =
   try
-    let token = Json_util.get_string json "token" |> Option.value ~default:"" in
+    let token = Json_util.get_string_with_default json ~key:"token" ~default:"" in
     let trace_id =
       match Json_util.get_string json "trace_id" with
       | Some value -> value
       | None -> trace_id "opc"
     in
-    let actor = Json_util.get_string json "actor" |> Option.value ~default:"" in
-    let action_type = Json_util.get_string json "action_type" |> Option.value ~default:"" in
-    let target_type = Json_util.get_string json "target_type" |> Option.value ~default:"" in
+    let actor = Json_util.get_string_with_default json ~key:"actor" ~default:"" in
+    let action_type = Json_util.get_string_with_default json ~key:"action_type" ~default:"" in
+    let target_type = Json_util.get_string_with_default json ~key:"target_type" ~default:"" in
     let target_id = Json_util.get_string json "target_id" in
     let payload =
       match Json_util.get_object json "payload" with
       | Some payload -> payload
       | None -> `Assoc []
     in
-    let delegated_tool = Json_util.get_string json "delegated_tool" |> Option.value ~default:"" in
-    let created_at = Json_util.get_string json "created_at" |> Option.value ~default:"" in
+    let delegated_tool = Json_util.get_string_with_default json ~key:"delegated_tool" ~default:"" in
+    let created_at = Json_util.get_string_with_default json ~key:"created_at" ~default:"" in
     let expires_at = Json_util.get_string json "expires_at" in
     Ok
       {

--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -33,16 +33,7 @@ type planning_context = {
 
 (* ===== Utility Functions ===== *)
 
-let now_iso () =
-  let t = Time_compat.now () in
-  let tm = Unix.gmtime t in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
-    tm.Unix.tm_mday
-    tm.Unix.tm_hour
-    tm.Unix.tm_min
-    tm.Unix.tm_sec
+let now_iso = Masc_domain.now_iso
 
 (** Create empty planning context *)
 let create_context ~task_id =

--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -33,11 +33,9 @@ type planning_context = {
 
 (* ===== Utility Functions ===== *)
 
-let now_iso = Masc_domain.now_iso
-
 (** Create empty planning context *)
 let create_context ~task_id =
-  let now = now_iso () in
+  let now = Masc_domain.now_iso () in
   {
     task_id;
     task_plan = "";
@@ -171,7 +169,7 @@ let update_plan (config : Coord.config) ~task_id ~content : (planning_context, s
           | Some { deliverable = Some value; _ } -> value
           | _ -> ctx.deliverable
         in
-        let updated = { ctx with task_plan; deliverable; updated_at = now_iso () } in
+        let updated = { ctx with task_plan; deliverable; updated_at = Masc_domain.now_iso () } in
         write_file_content (Filename.concat dir "task_plan.md") task_plan;
         (match parsed with
          | Some { deliverable = Some value; _ } ->
@@ -191,11 +189,11 @@ let add_note (config : Coord.config) ~task_id ~note : (planning_context, string)
     match load config ~task_id with
     | Error e -> Error e
     | Ok ctx ->
-        let timestamp = now_iso () in
+        let timestamp = Masc_domain.now_iso () in
         let formatted_note = Printf.sprintf "## [%s]\n%s\n" timestamp note in
         let updated = { ctx with
           notes = ctx.notes @ [note];
-          updated_at = now_iso ()
+          updated_at = Masc_domain.now_iso ()
         } in
         (* Append to notes.md *)
         let notes_path = Filename.concat dir "notes.md" in
@@ -221,7 +219,7 @@ let add_error (config : Coord.config) ~task_id ~error_type ~message ?context () 
     match ctx with
     | Error e -> Error e
     | Ok ctx ->
-        let timestamp = now_iso () in
+        let timestamp = Masc_domain.now_iso () in
         let error_entry = { timestamp; error_type; message; context; resolved = false } in
         let formatted_error = Printf.sprintf "## [%s] %s\n**Type**: %s\n%s\n%s\n---\n"
           timestamp
@@ -232,7 +230,7 @@ let add_error (config : Coord.config) ~task_id ~error_type ~message ?context () 
         in
         let updated = { ctx with
           errors = ctx.errors @ [error_entry];
-          updated_at = now_iso ()
+          updated_at = Masc_domain.now_iso ()
         } in
         (* Append to errors.md *)
         let errors_path = Filename.concat dir "errors.md" in
@@ -257,7 +255,7 @@ let resolve_error (config : Coord.config) ~task_id ~index : (planning_context, s
           let errors = List.mapi (fun i e ->
             if i = index then { e with resolved = true } else e
           ) ctx.errors in
-          let updated = { ctx with errors; updated_at = now_iso () } in
+          let updated = { ctx with errors; updated_at = Masc_domain.now_iso () } in
           let dir = planning_dir config task_id in
           write_file_content (Filename.concat dir "context.json")
             (Yojson.Safe.pretty_to_string (planning_context_to_yojson updated));
@@ -280,7 +278,7 @@ let set_deliverable (config : Coord.config) ~task_id ~content : (planning_contex
     match ctx with
     | Error e -> Error e
     | Ok ctx ->
-        let updated = { ctx with deliverable = content; updated_at = now_iso () } in
+        let updated = { ctx with deliverable = content; updated_at = Masc_domain.now_iso () } in
         write_file_content (Filename.concat dir "deliverable.md") content;
         write_file_content (Filename.concat dir "context.json")
           (Yojson.Safe.pretty_to_string (planning_context_to_yojson updated));

--- a/lib/repo_synthesis_benchmark.ml
+++ b/lib/repo_synthesis_benchmark.ml
@@ -186,8 +186,8 @@ let question_of_yojson (json : Yojson.Safe.t) =
       Some
         {
           question_id;
-          title = Json_util.get_string json "title" |> Option.value ~default:question_id;
-          question = Json_util.get_string json "question" |> Option.value ~default:"";
+          title = Json_util.get_string_with_default json ~key:"title" ~default:question_id;
+          question = Json_util.get_string_with_default json ~key:"question" ~default:"";
           artifact_scope = string_list_field "artifact_scope";
           required_claims = string_list_field "required_claims";
           gold_paths = string_list_field "gold_paths";
@@ -278,7 +278,7 @@ let score_summary_of_yojson (json : Yojson.Safe.t) =
   in
   {
     answer_set_label =
-      Json_util.get_string json "answer_set_label" |> Option.value ~default:"";
+      Json_util.get_string_with_default json ~key:"answer_set_label" ~default:"";
     question_count =
       Json_util.get_int json "question_count" |> Option.value ~default:0;
     answered_count =
@@ -338,12 +338,12 @@ let run_record_of_yojson (json : Yojson.Safe.t) =
       Some
         {
           benchmark_run_id;
-          created_at = Json_util.get_string json "created_at" |> Option.value ~default:"";
+          created_at = Json_util.get_string_with_default json ~key:"created_at" ~default:"";
           created_by = Json_util.get_string json "created_by";
-          goal = Json_util.get_string json "goal" |> Option.value ~default:"";
-          question = Json_util.get_string json "question" |> Option.value ~default:"";
+          goal = Json_util.get_string_with_default json ~key:"goal" ~default:"";
+          question = Json_util.get_string_with_default json ~key:"question" ~default:"";
           question_id = Json_util.get_string json "question_id";
-          repo_root = Json_util.get_string json "repo_root" |> Option.value ~default:"";
+          repo_root = Json_util.get_string_with_default json ~key:"repo_root" ~default:"";
           artifact_scope = string_list_field "artifact_scope";
           program_note = Json_util.get_string json "program_note";
           baseline_label = Json_util.get_string json "baseline_label";
@@ -352,8 +352,7 @@ let run_record_of_yojson (json : Yojson.Safe.t) =
           time_budget_sec =
             Json_util.get_int json "time_budget_sec" |> Option.value ~default:0;
           workload_profile =
-            Json_util.get_string json "workload_profile"
-            |> Option.value ~default:"coding_task";
+            Json_util.get_string_with_default json ~key:"workload_profile" ~default:"coding_task";
           operation_id = Json_util.get_string json "operation_id";
           trace_id = Json_util.get_string json "trace_id";
           session_id = Json_util.get_string json "session_id";
@@ -365,7 +364,7 @@ let run_record_of_yojson (json : Yojson.Safe.t) =
           case_refs = string_list_field "case_refs";
           planned_worker_roles = string_list_field "planned_worker_roles";
           recommended_next_tools = string_list_field "recommended_next_tools";
-          status = Json_util.get_string json "status" |> Option.value ~default:"started";
+          status = Json_util.get_string_with_default json ~key:"status" ~default:"started";
         }
 
 let make_run_id () =

--- a/lib/reputation_ledger_v2.ml
+++ b/lib/reputation_ledger_v2.ml
@@ -63,8 +63,6 @@ let get_store (config : Coord.config) : Dated_jsonl.t =
         Hashtbl.replace store_cache base_path store;
         store)
 
-let iso8601_of_unix = Masc_domain.iso8601_of_unix_seconds
-
 let event_date_string ts =
   let tm = Unix.gmtime ts in
   Printf.sprintf "%04d-%02d-%02d"
@@ -87,7 +85,7 @@ let tool_outcome_to_json (e : tool_outcome_event) : Yojson.Safe.t =
     ; ("tool_name", `String e.tool_name)
     ; ("success", `Bool e.success)
     ; ("ts", `Float e.timestamp)
-    ; ("ts_iso", `String (iso8601_of_unix e.timestamp))
+    ; ("ts_iso", `String (Masc_domain.iso8601_of_unix_seconds e.timestamp))
     ]
     @ opt_string_field "error_kind"
         (Option.map error_kind_to_string e.error_kind)
@@ -102,7 +100,7 @@ let goal_completion_to_json (e : goal_completion_event) : Yojson.Safe.t =
     ; ("completed_within_budget", `Bool e.completed_within_budget)
     ; ("on_topic", `Bool e.on_topic)
     ; ("ts", `Float e.timestamp)
-    ; ("ts_iso", `String (iso8601_of_unix e.timestamp))
+    ; ("ts_iso", `String (Masc_domain.iso8601_of_unix_seconds e.timestamp))
     ]
     @ opt_string_field "raw_trace_run_id" e.raw_trace_run_id)
 
@@ -112,7 +110,7 @@ let safety_violation_to_json (e : safety_violation_event) : Yojson.Safe.t =
     ; ("agent_id", `String e.agent_id)
     ; ("violation_kind", `String e.violation_kind)
     ; ("ts", `Float e.timestamp)
-    ; ("ts_iso", `String (iso8601_of_unix e.timestamp))
+    ; ("ts_iso", `String (Masc_domain.iso8601_of_unix_seconds e.timestamp))
     ]
     @ opt_string_field "tool_name" e.tool_name
     @ opt_string_field "raw_trace_run_id" e.raw_trace_run_id)

--- a/lib/reputation_ledger_v2.ml
+++ b/lib/reputation_ledger_v2.ml
@@ -63,12 +63,7 @@ let get_store (config : Coord.config) : Dated_jsonl.t =
         Hashtbl.replace store_cache base_path store;
         store)
 
-let iso8601_of_unix ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
-    tm.Unix.tm_mday tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+let iso8601_of_unix = Masc_domain.iso8601_of_unix_seconds
 
 let event_date_string ts =
   let tm = Unix.gmtime ts in

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -88,8 +88,6 @@ let ensure_run_dir config task_id =
   let dir = run_dir config task_id in
   if not (Sys.file_exists dir) then mkdir_p dir
 
-let now_iso () = Masc_domain.now_iso ()
-
 let read_text_file path =
   if Sys.file_exists path then
     Fs_compat.load_file path
@@ -129,7 +127,7 @@ let init config ~task_id ~agent_name : (run_record, string) result =
   try
     ensure_initialized config;
     ensure_run_dir config task_id;
-    let created_at = now_iso () in
+    let created_at = Masc_domain.now_iso () in
     let run = {
       task_id;
       agent_name;
@@ -175,7 +173,7 @@ let update_plan config ~task_id ~content : (run_record, string) result =
       match read_run config task_id with
       | Error e -> Error e
       | Ok run ->
-          let updated = { run with plan = content; updated_at = now_iso () } in
+          let updated = { run with plan = content; updated_at = Masc_domain.now_iso () } in
           let path = plan_path config task_id in
           write_text_file path content;
           write_run config updated;
@@ -189,7 +187,7 @@ let append_log config ~task_id ~note : (log_entry, string) result =
   try
     ensure_initialized config;
     ensure_run_dir config task_id;
-    let entry = { timestamp = now_iso (); note } in
+    let entry = { timestamp = Masc_domain.now_iso (); note } in
     let file = log_path config task_id in
     with_file_lock config file (fun () ->
       Fs_compat.append_jsonl file (log_entry_to_json entry)
@@ -211,7 +209,7 @@ let set_deliverable config ~task_id ~content : (run_record, string) result =
       match read_run config task_id with
       | Error e -> Error e
       | Ok run ->
-          let updated = { run with deliverable = content; updated_at = now_iso () } in
+          let updated = { run with deliverable = content; updated_at = Masc_domain.now_iso () } in
           let path = deliverable_path config task_id in
           write_text_file path content;
           write_run config updated;

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -136,14 +136,11 @@ let composite_config_drift_json ~config ~keeper_name =
     let sources = Keeper_status_bridge.source_provenance_json config meta in
     let override_fields = Json_util.get_string_list sources "override_fields" in
     let cascade_detail = find_override_field_source "model.cascade_name" sources in
-    let string_member key json =
-      match json_member key json with
-      | `String value -> Some value
-      | _ -> None
-    in
     let default_cascade_name, live_cascade_name =
       match cascade_detail with
-      | Some detail -> string_member "default_value" detail, string_member "live_value" detail
+      | Some detail ->
+        Json_util.get_string detail "default_value",
+        Json_util.get_string detail "live_value"
       | None -> None, None
     in
     let cascade_override = Option.is_some cascade_detail in

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -306,7 +306,7 @@ let internal_history_json_to_trajectory_line (json : Yojson.Safe.t)
         | _ ->
             match Safe_ops.json_string_opt "ts" json with
             | Some value when String.trim value <> "" -> value
-            | _ -> Dashboard_utils.iso_of_unix ts
+            | _ -> Masc_domain.iso8601_of_unix_seconds ts
       in
       Some
         (Trajectory.Thinking

--- a/lib/server/server_dashboard_http_link_preview.ml
+++ b/lib/server/server_dashboard_http_link_preview.ml
@@ -38,13 +38,8 @@ let cache_store ~ttl key preview =
       Hashtbl.replace preview_cache key
         { preview; expires_at = Time_compat.now () +. ttl })
 
-let json_string_opt_field fields key =
-  match List.assoc_opt key fields with
-  | Some (`String value) -> String_util.trim_to_option value
-  | _ -> None
-
 let error_reason_of_json = function
-  | `Assoc fields -> json_string_opt_field fields "error"
+  | `Assoc _ as json -> Json_util.assoc_string_opt "error" json
   | _ -> None
 
 let assoc_upsert fields key value =

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -101,18 +101,17 @@ let parse_keeper_chat_stream_request body_str =
     if not (match json with `Assoc _ -> true | _ -> false) then
       Error "request body must be a JSON object"
     else
-      let name = Json_util.get_string json "name" |> Option.value ~default:"" |> String.trim in
+      let name = Json_util.get_string_with_default json ~key:"name" ~default:"" |> String.trim in
       let message =
-        Json_util.get_string json "message" |> Option.value ~default:""
+        Json_util.get_string_with_default json ~key:"message" ~default:""
         |> String.trim
       in
       let channel =
-        Json_util.get_string json "channel" |> Option.value ~default:""
+        Json_util.get_string_with_default json ~key:"channel" ~default:""
         |> String.trim
       in
       let channel_user_id =
-        Json_util.get_string json "channel_user_id"
-        |> Option.value ~default:""
+        Json_util.get_string_with_default json ~key:"channel_user_id" ~default:""
         |> String.trim
       in
       let channel_user_name =

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -361,12 +361,7 @@ let serve_bonsai_index _request reqd =
     This endpoint must stay scoped to the live server [base_path]; returning
     static fixture rows here makes Bonsai look like an SSOT while showing a
     different keeper universe than the operator dashboard. *)
-let iso8601_utc_now () =
-  let open Unix in
-  let t = gmtime (gettimeofday ()) in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (t.tm_year + 1900) (t.tm_mon + 1) t.tm_mday
-    t.tm_hour t.tm_min t.tm_sec
+let iso8601_utc_now () = Masc_domain.now_iso ()
 
 let bonsai_keeper_status_of_phase phase =
   let module K = Masc_dashboard_api_types.Keepers in

--- a/lib/server/server_routes_http_routes_multimodal.ml
+++ b/lib/server/server_routes_http_routes_multimodal.ml
@@ -41,7 +41,7 @@ let case_contains ~(haystack : string) ~(needle : string) : bool =
       loop 0
 
 let json_string_field (json : Yojson.Safe.t) (field : string) : string =
-  Json_util.get_string json field |> Option.value ~default:""
+  Json_util.get_string_with_default json ~key:field ~default:""
 
 let json_created_by (json : Yojson.Safe.t) : string =
   match Json_util.assoc_member_opt "provenance" json with

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -223,29 +223,9 @@ let read_attempt_record ~base_path id =
       None)
 ;;
 
-let isoish_now () =
-  let tm = Unix.gmtime (Unix.time ()) in
-  Printf.sprintf
-    "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.tm_year + 1900)
-    (tm.tm_mon + 1)
-    tm.tm_mday
-    tm.tm_hour
-    tm.tm_min
-    tm.tm_sec
-;;
+let isoish_now () = Masc_domain.now_iso ()
 
-let isoish_at ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf
-    "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.tm_year + 1900)
-    (tm.tm_mon + 1)
-    tm.tm_mday
-    tm.tm_hour
-    tm.tm_min
-    tm.tm_sec
-;;
+let isoish_at ts = Masc_domain.iso8601_of_unix_seconds ts
 
 (** Make sure [.gate/runtime/<id>/] exists before atomic_write_file
     tries to rename into it. *)

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -23,11 +23,7 @@ let clamp ~min_v ~max_v v = max min_v (min max_v v)
 let take = List.take
 let drop = List.drop
 
-let iso8601_of_unix ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
-    tm.tm_hour tm.tm_min tm.tm_sec
+let iso8601_of_unix = Masc_domain.iso8601_of_unix_seconds
 
 (** Issue #8449 PR C: HTTP query-param sort_by parser. Delegates to
     [Board_dispatch.sort_order_of_string_opt] instead of duplicating

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -23,8 +23,6 @@ let clamp ~min_v ~max_v v = max min_v (min max_v v)
 let take = List.take
 let drop = List.drop
 
-let iso8601_of_unix = Masc_domain.iso8601_of_unix_seconds
-
 (** Issue #8449 PR C: HTTP query-param sort_by parser. Delegates to
     [Board_dispatch.sort_order_of_string_opt] instead of duplicating
     the inline match. HTTP semantics keep the "default to Hot" fallback
@@ -329,8 +327,8 @@ let board_post_dashboard_json ?(include_moderation = false)
           ("body", `String p.body);
           ("votes", if blind_active then `Null else `Int score);
           ("comment_count", `Int p.reply_count);
-          ("created_at_iso", `String (iso8601_of_unix p.created_at));
-          ("updated_at_iso", `String (iso8601_of_unix p.updated_at));
+          ("created_at_iso", `String (Masc_domain.iso8601_of_unix_seconds p.created_at));
+          ("updated_at_iso", `String (Masc_domain.iso8601_of_unix_seconds p.updated_at));
           ("hearth", Json_util.string_opt_to_json p.hearth);
           ("hearth_count", `Int (match p.hearth with Some _ -> 1 | None -> 0));
           ("author_identity", board_actor_identity_json author);

--- a/lib/server/server_utils.mli
+++ b/lib/server/server_utils.mli
@@ -41,14 +41,6 @@ val take : int -> 'a list -> 'a list
 val drop : int -> 'a list -> 'a list
 (** [drop n xs] is [List.drop n xs], symmetric with {!take}. *)
 
-(** {1 Time helpers} *)
-
-val iso8601_of_unix : float -> string
-(** [iso8601_of_unix ts] renders a Unix timestamp as
-    [YYYY-MM-DDTHH:MM:SSZ] (UTC, no fractional seconds, no
-    timezone offset other than [Z]).  Stable wire format —
-    dashboards parse this with the same regex across modules. *)
-
 (** {1 Board sort helpers} *)
 
 val board_sort_order_of_request :

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -246,7 +246,7 @@ let stats_to_json (s : agent_stats) : Yojson.Safe.t =
 
 let stats_of_json (json : Yojson.Safe.t) : agent_stats option =
   try
-    let name = Json_util.get_string json "name" |> Option.value ~default:"" in
+    let name = Json_util.get_string_with_default json ~key:"name" ~default:"" in
     let alpha = Json_util.get_float json "alpha" |> Option.value ~default:0.0 in
     let beta = Json_util.get_float json "beta" |> Option.value ~default:0.0 in
     let selections = Json_util.get_int json "selections" |> Option.value ~default:0 in

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -245,34 +245,32 @@ let stats_to_json (s : agent_stats) : Yojson.Safe.t =
   ]
 
 let stats_of_json (json : Yojson.Safe.t) : agent_stats option =
-  try
-    let name = Json_util.get_string_with_default json ~key:"name" ~default:"" in
-    let alpha = Json_util.get_float json "alpha" |> Option.value ~default:0.0 in
-    let beta = Json_util.get_float json "beta" |> Option.value ~default:0.0 in
-    let selections = Json_util.get_int json "selections" |> Option.value ~default:0 in
-    let last_selected_at = Json_util.get_float json "last_selected_at" |> Option.value ~default:0.0 in
-    let total_votes_up = Json_util.get_int json "total_votes_up" |> Option.value ~default:0 in
-    let total_votes_down = Json_util.get_int json "total_votes_down" |> Option.value ~default:0 in
-    let posts_created = Json_util.get_int json "posts_created" |> Option.value ~default:0 in
-    let comments_created = Json_util.get_int json "comments_created" |> Option.value ~default:0 in
-    let skips = Json_util.get_int json "skips" |> Option.value ~default:0 in
-    let guard_penalties_total = Json_util.get_int json "guard_penalties_total" |> Option.value ~default:0 in
-    let updated_at = Json_util.get_float json "updated_at" |> Option.value ~default:0.0 in
-    Some {
-      name;
-      alpha = Float.max min_prior alpha;
-      beta = Float.max min_prior beta;
-      selections;
-      last_selected_at;
-      total_votes_up;
-      total_votes_down;
-      posts_created;
-      comments_created;
-      skips;
-      guard_penalties_total;
-      updated_at;
-    }
-  with Yojson.Safe.Util.Type_error _ -> None
+  let name = Json_util.get_string_with_default json ~key:"name" ~default:"" in
+  let alpha = Json_util.get_float json "alpha" |> Option.value ~default:0.0 in
+  let beta = Json_util.get_float json "beta" |> Option.value ~default:0.0 in
+  let selections = Json_util.get_int json "selections" |> Option.value ~default:0 in
+  let last_selected_at = Json_util.get_float json "last_selected_at" |> Option.value ~default:0.0 in
+  let total_votes_up = Json_util.get_int json "total_votes_up" |> Option.value ~default:0 in
+  let total_votes_down = Json_util.get_int json "total_votes_down" |> Option.value ~default:0 in
+  let posts_created = Json_util.get_int json "posts_created" |> Option.value ~default:0 in
+  let comments_created = Json_util.get_int json "comments_created" |> Option.value ~default:0 in
+  let skips = Json_util.get_int json "skips" |> Option.value ~default:0 in
+  let guard_penalties_total = Json_util.get_int json "guard_penalties_total" |> Option.value ~default:0 in
+  let updated_at = Json_util.get_float json "updated_at" |> Option.value ~default:0.0 in
+  Some {
+    name;
+    alpha = Float.max min_prior alpha;
+    beta = Float.max min_prior beta;
+    selections;
+    last_selected_at;
+    total_votes_up;
+    total_votes_down;
+    posts_created;
+    comments_created;
+    skips;
+    guard_penalties_total;
+    updated_at;
+  }
 
 (** {1 Persistence} *)
 

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -528,13 +528,7 @@ let build_timeline (config : Coord.config) ~agent_name ~since_hours ~limit
         Float.round (diff /. 60.0)
     | _ -> 0.0
   in
-  let since_iso =
-    let tm = Unix.gmtime cutoff in
-    Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-      (tm.Unix.tm_year + 1900)
-      (tm.Unix.tm_mon + 1) tm.Unix.tm_mday tm.Unix.tm_hour tm.Unix.tm_min
-      tm.Unix.tm_sec
-  in
+  let since_iso = Masc_domain.iso8601_of_unix_seconds cutoff in
   let now_iso = Masc_domain.now_iso () in
   `Assoc
     [

--- a/lib/tool_assignment_telemetry.ml
+++ b/lib/tool_assignment_telemetry.ml
@@ -103,7 +103,7 @@ let event_to_json = function
 
 let event_of_json json : (tool_event, string) Result.t =
   try
-    match Json_util.get_string json "event_type" |> Option.value ~default:"" with
+    match Json_util.get_string_with_default json ~key:"event_type" ~default:"" with
     | "Assigned" ->
         let preset = Json_util.get_string json "preset" in
         let string_list field =
@@ -114,24 +114,24 @@ let event_of_json json : (tool_event, string) Result.t =
         in
         Ok
           (Assigned
-             { assignment_id = Json_util.get_string json "assignment_id" |> Option.value ~default:""
-             ; agent_id = Json_util.get_string json "agent_id" |> Option.value ~default:""
-             ; profile = Json_util.get_string json "profile" |> Option.value ~default:""
+             { assignment_id = Json_util.get_string_with_default json ~key:"assignment_id" ~default:""
+             ; agent_id = Json_util.get_string_with_default json ~key:"agent_id" ~default:""
+             ; profile = Json_util.get_string_with_default json ~key:"profile" ~default:""
              ; preset
              ; tool_list = string_list "tool_list"
              ; allow_set = string_list "allow_set"
              ; deny_set = string_list "deny_set"
-             ; config_hash = Json_util.get_string json "config_hash" |> Option.value ~default:""
-             ; reason = Json_util.get_string json "reason" |> Option.value ~default:""
+             ; config_hash = Json_util.get_string_with_default json ~key:"config_hash" ~default:""
+             ; reason = Json_util.get_string_with_default json ~key:"reason" ~default:""
              ; timestamp = Json_util.get_float json "timestamp" |> Option.value ~default:0.0
              })
     | "Called" ->
-        let source = Json_util.get_string json "source" |> Option.value ~default:"" in
+        let source = Json_util.get_string_with_default json ~key:"source" ~default:"" in
         Ok
           (Called
-             { assignment_id = Json_util.get_string json "assignment_id" |> Option.value ~default:""
-             ; tool_name = Json_util.get_string json "tool_name" |> Option.value ~default:""
-             ; arguments_hash = Json_util.get_string json "arguments_hash" |> Option.value ~default:""
+             { assignment_id = Json_util.get_string_with_default json ~key:"assignment_id" ~default:""
+             ; tool_name = Json_util.get_string_with_default json ~key:"tool_name" ~default:""
+             ; arguments_hash = Json_util.get_string_with_default json ~key:"arguments_hash" ~default:""
              ; source
              ; timestamp = Json_util.get_float json "timestamp" |> Option.value ~default:0.0
              })
@@ -142,8 +142,8 @@ let event_of_json json : (tool_event, string) Result.t =
         in
         Ok
           (Completed
-             { assignment_id = Json_util.get_string json "assignment_id" |> Option.value ~default:""
-             ; tool_name = Json_util.get_string json "tool_name" |> Option.value ~default:""
+             { assignment_id = Json_util.get_string_with_default json ~key:"assignment_id" ~default:""
+             ; tool_name = Json_util.get_string_with_default json ~key:"tool_name" ~default:""
              ; success = Json_util.get_bool json "success" |> Option.value ~default:false
              ; duration_ms = Json_util.get_float json "duration_ms" |> Option.value ~default:0.0
              ; error_kind

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
@@ -169,7 +169,7 @@ let tool_call_of_yojson json =
     tool_name =
       (match Json_util.get_string json "tool_name" with
        | Some value -> value
-       | None -> Json_util.get_string json "tool" |> Option.value ~default:"");
+       | None -> Json_util.get_string_with_default json ~key:"tool" ~default:"");
     success = Json_util.get_bool json "success" |> Option.value ~default:false;
     input = (match member_opt "input" json with Some value -> value | None -> `Assoc []);
     output = member_opt "output" json;

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -92,12 +92,12 @@ module JsonRpc = struct
   (** Parse JSON-RPC request *)
   let parse_request (json : Yojson.Safe.t) : (request, string) result =
     try
-      let jsonrpc = Json_util.get_string json "jsonrpc" |> Option.value ~default:"" in
+      let jsonrpc = Json_util.get_string_with_default json ~key:"jsonrpc" ~default:"" in
       if jsonrpc <> version then
         Error (Printf.sprintf "Invalid JSON-RPC version: %s" jsonrpc)
       else
         let id = Json_util.get_string json "id" in
-        let method_name = Json_util.get_string json "method" |> Option.value ~default:"" in
+        let method_name = Json_util.get_string_with_default json ~key:"method" ~default:"" in
         let params = Yojson.Safe.Util.member "params" json in
         Ok { id; method_name; params; headers = [] }
     with

--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -82,8 +82,8 @@ let agent_credential_to_yojson (c : agent_credential) =
 
 let agent_credential_of_yojson json =
   try
-    let agent_name = Json_util.get_string json "agent_name" |> Option.value ~default:"" in
-    let token = Json_util.get_string json "token" |> Option.value ~default:"" in
+    let agent_name = Json_util.get_string_with_default json ~key:"agent_name" ~default:"" in
+    let token = Json_util.get_string_with_default json ~key:"token" ~default:"" in
     let role =
       match Json_util.get_string json "role" with
       | Some s -> agent_role_of_string s
@@ -94,7 +94,7 @@ let agent_credential_of_yojson json =
     (match role with
      | Error e -> Error e
      | Ok role ->
-       let created_at = Json_util.get_string json "created_at" |> Option.value ~default:"" in
+       let created_at = Json_util.get_string_with_default json ~key:"created_at" ~default:"" in
        let expires_at = Json_util.get_string json "expires_at" in
        let id = Json_util.get_string json "id" |> Option.map Credential_id.of_string in
        let agent_id = Json_util.get_string json "agent_id" |> Option.map Agent_id.of_string in

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -442,7 +442,7 @@ let task_status_to_yojson = function
       ]
 
 let task_status_of_yojson json =
-  let req key = Json_util.get_string json key |> Option.value ~default:"" in
+  let req key = Json_util.get_string_with_default json ~key ~default:"" in
   let opt key = Json_util.get_string json key in
   try
     match req "status" with
@@ -678,7 +678,7 @@ let task_to_yojson t =
   | _ -> `Assoc with_do_not_reclaim
 
 let task_of_yojson json =
-  let req key = Json_util.get_string json key |> Option.value ~default:"" in
+  let req key = Json_util.get_string_with_default json ~key ~default:"" in
   let opt key = Json_util.get_string json key in
   let m key = Option.value ~default:`Null (Json_util.assoc_member_opt key json) in
   try
@@ -835,7 +835,7 @@ let tempo_config_to_yojson c =
 
 let tempo_config_of_yojson json =
   try
-    let mode_str = Json_util.get_string json "mode" |> Option.value ~default:"" in
+    let mode_str = Json_util.get_string_with_default json ~key:"mode" ~default:"" in
     let delay_ms = Json_util.get_int json "delay_ms" |> Option.value ~default:0 in
     let reason = Json_util.get_string json "reason" in
     let set_by = Json_util.get_string json "set_by" in
@@ -876,7 +876,7 @@ let backlog_of_yojson json =
        failed] entries/day driven [stale-claims] GC to skip mutation,
        so claims never transitioned).  Tolerate missing/null fields. *)
     let last_updated =
-      Json_util.get_string json "last_updated" |> Option.value ~default:""
+      Json_util.get_string_with_default json ~key:"last_updated" ~default:""
     in
     let version =
       Json_util.get_int json "version" |> Option.value ~default:1
@@ -967,7 +967,7 @@ let a2a_task_to_yojson t =
   ]
 
 let a2a_task_of_yojson json =
-  let req key = Json_util.get_string json key |> Option.value ~default:"" in
+  let req key = Json_util.get_string_with_default json ~key ~default:"" in
   try
     let a2a_id = req "id" in
     let from_agent = req "from" in
@@ -1002,7 +1002,7 @@ let portal_to_yojson p =
   ]
 
 let portal_of_yojson json =
-  let req key = Json_util.get_string json key |> Option.value ~default:"" in
+  let req key = Json_util.get_string_with_default json ~key ~default:"" in
   try
     let portal_from = req "from" in
     let portal_target = req "target" in

--- a/lib/voice/voice_session_manager.ml
+++ b/lib/voice/voice_session_manager.ml
@@ -80,9 +80,9 @@ let session_to_json session =
 
 let session_of_json json =
   {
-    session_id = Json_util.get_string json "session_id" |> Option.value ~default:"";
-    agent_id = Json_util.get_string json "agent_id" |> Option.value ~default:"";
-    voice = Json_util.get_string json "voice" |> Option.value ~default:"";
+    session_id = Json_util.get_string_with_default json ~key:"session_id" ~default:"";
+    agent_id = Json_util.get_string_with_default json ~key:"agent_id" ~default:"";
+    voice = Json_util.get_string_with_default json ~key:"voice" ~default:"";
     started_at = Json_util.get_float json "started_at" |> Option.value ~default:0.0;
     last_activity = Json_util.get_float json "last_activity" |> Option.value ~default:0.0;
     turn_count = Json_util.get_int json "turn_count" |> Option.value ~default:0;


### PR DESCRIPTION
## Summary
- Consolidates 4 remaining ISO timestamp reimplementations to canonical `Masc_domain` functions
- `server_routes_http_routes_sidecar.ml`: `isoish_now`/`isoish_at` → `Masc_domain.now_iso`/`iso8601_of_unix_seconds`
- `masc_grpc_service.ml`: inline ISO format → `Masc_domain.iso8601_of_unix_seconds`
- `auth_credential_token.ml`: inline expiry ISO → `Masc_domain.iso8601_of_unix_seconds`
- `keeper_meta_store.ml`: `current_utc_timestamp` → `Masc_domain.now_iso`

## Verified remaining ISO patterns (intentionally NOT changed)
- `masc_log/log.ml` — in `masc_log` library, no `masc_types` dependency
- `gate/gate_time_util.ml` — intentional duplicate, L1-8 comment explains
- `gate/channel_gate_metrics.ml` — in `masc_gate`, no `masc_types` dependency
- Date-only formats (`%04d-%02d-%02d`) — different purpose (file paths, day keys)
- Millisecond variants (`.%03dZ`) — different precision

## SSOT analysis findings (Dashboard area)
- `session_context` / `operation_context` type names duplicated across `dashboard_briefing_agents.ml` and `dashboard_execution_helpers.ml` with completely different fields (circular dependency avoidance)
- `runtime_snapshot` duplicated between governance_judge(18 fields) and operator_judge(8 fields) — intentional different domain scopes
- 5+ health/severity enums across dashboard — each serves different domain purpose

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>