### PR TITLE
refactor(runtime): B3 — cascade_name_for_use가 default Runtime 직접 소비

### DIFF
--- a/lib/cascade/cascade_routes_resolve.ml
+++ b/lib/cascade/cascade_routes_resolve.ml
@@ -10,32 +10,16 @@
     this module.  Callers that only need the configured route target
     without catalog cross-check use {!Cascade_routes} directly. *)
 
-let cascade_name_for_use ?config_path use =
-  let route_key = Cascade_routes.logical_use_key use in
-  let route_target =
-    Cascade_routes.configured_route_bindings ?config_path ()
-    |> List.find_map (fun (key, target) ->
-           if String.equal key route_key then Some target else None)
-  in
-  let catalog_names =
-    match Cascade_catalog_runtime.known_profile_names () with
-    | Ok names -> names
-    | Error _ -> []
-  in
-  let fallback =
-    Cascade_routes.fallback_name_for_catalog use ~catalog:catalog_names
-  in
-  match route_target with
-  | Some target when catalog_names = [] ->
-      Cascade_metrics.on_route_resolve_fallback ~reason:"catalog_unvalidated";
-      Cascade_routes.warn_unvalidated_route_target_once ~route_key ~target
-        ~fallback;
-      target
-  | Some target when List.mem target catalog_names -> target
-  | Some target ->
-      Cascade_metrics.on_route_resolve_fallback
-        ~reason:"target_not_in_catalog";
-      Cascade_routes.warn_invalid_route_target_once ~route_key ~target
-        ~fallback;
-      fallback
-  | None -> fallback
+let cascade_name_for_use ?config_path (_use : Cascade_routes.logical_use) =
+  (* B3: cascade routing 제거. use 별 route target 조회 / catalog validation /
+     fallback 을 모두 걷어내고, default Runtime 의 binding id 를 그대로 돌려준다.
+     (cascade→Runtime 비전: routes/cascade_name 간접은 의미 없음 — binding 하나가
+     곧 하나의 Runtime, 소비자는 default Runtime 을 직접 쓴다.)
+     default 미해결은 config 결함이므로 fail-fast — silent fallback 을 두지
+     않는다(예전 route.<key> fallback 은 잘못된 default 를 조용히 숨겼다). *)
+  match Runtime.default ?config_path () with
+  | Ok rt -> rt.Runtime.id
+  | Error msg ->
+      failwith
+        (Printf.sprintf "cascade_name_for_use: no default runtime resolved (%s)"
+           msg)

--- a/lib/cascade/cascade_routes_resolve.mli
+++ b/lib/cascade/cascade_routes_resolve.mli
@@ -7,8 +7,13 @@
 
 val cascade_name_for_use :
   ?config_path:string -> Cascade_routes.logical_use -> string
-(** Resolve the cascade name configured for [use], validating against the
-    runtime catalog.  Falls back to a generated "route.<key>" name when no
-    binding is configured or when the configured target is missing from
-    the catalog snapshot.  See {!Cascade_routes} for the catalog-free
-    variants. *)
+(** Return the default Runtime's binding id, ignoring [use].
+
+    B3 (cascade→Runtime): route/cascade_name indirection is gone — a binding
+    (provider × model) is a Runtime, and consumers use the default Runtime
+    directly.  [use] is accepted for signature compatibility but no longer
+    selects a route.
+
+    Raises [Failure] when no default Runtime can be resolved (missing config
+    path or no [\[runtime\] default]); this is a config defect, surfaced
+    fail-fast rather than hidden behind a fallback name. *)

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -71,3 +71,44 @@ let load_list ~(config_path : string) : (t list * t, string) result =
                did
                (List.length runtimes))))
 ;;
+
+(* ---- B3: process-cached default Runtime accessor ----
+   [load_list] 는 순수 함수(매 호출 TOML parse). 소비자(cascade_name_for_use
+   등)가 hot path 에서 default Runtime 을 요구하므로 resolved config_path 별로
+   memoize 한다. cascade catalog 캐시(cascade_catalog_runtime_cache.ml)와 동일한
+   Mutex + Fun.protect 패턴. *)
+let cache : (string, t list * t) Hashtbl.t = Hashtbl.create 4
+let cache_mu = Mutex.create ()
+
+let with_cache_lock f =
+  Mutex.lock cache_mu;
+  Fun.protect ~finally:(fun () -> Mutex.unlock cache_mu) f
+;;
+
+let resolve_config_path ?config_path () =
+  match config_path with
+  | Some _ as p -> p
+  | None -> Config_dir_resolver.cascade_path_opt ()
+;;
+
+(** memoized default Runtime.
+
+    [config_path] 미해결 또는 load 실패 시 [Error] (silent fallback 없음 —
+    소비자가 fail-fast 하도록). 성공 결과만 resolved path 별로 캐시한다. *)
+let default ?config_path () : (t, string) result =
+  match resolve_config_path ?config_path () with
+  | None -> Error "Runtime.default: no cascade config path resolved"
+  | Some path ->
+    (match with_cache_lock (fun () -> Hashtbl.find_opt cache path) with
+     | Some (_, dflt) -> Ok dflt
+     | None ->
+       (match load_list ~config_path:path with
+        | Error msg -> Error msg
+        | Ok (rts, dflt) ->
+          with_cache_lock (fun () -> Hashtbl.replace cache path (rts, dflt));
+          Ok dflt))
+;;
+
+let reset_cache_for_tests () =
+  with_cache_lock (fun () -> Hashtbl.reset cache)
+;;

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -17,3 +17,15 @@ type t =
 val id_of_binding : cascade_binding -> string
 val of_binding : cascade_config -> cascade_binding -> t option
 val load_list : config_path:string -> (t list * t, string) result
+
+val default : ?config_path:string -> unit -> (t, string) result
+(** Process-cached default Runtime.
+
+    [config_path] 미해결 또는 load 실패 시 [Error] (silent fallback 없음 —
+    소비자가 fail-fast 하도록). 성공 결과만 resolved path 별로 캐시한다.
+    [load_list] 는 순수(매 호출 TOML parse)이므로 hot-path 소비자를 위해
+    memoize 한다. *)
+
+val reset_cache_for_tests : unit -> unit
+(** [default] 의 process 캐시를 비운다. 테스트에서 config 변경을 반영하기 위해
+    사용. *)


### PR DESCRIPTION
## 목적

cascade→Runtime 전환 **B3 (소비자 gut)** 의 첫 함수. `cascade_name_for_use` 의 route/cascade_name 간접 레이어를 적출하고, 소비자가 **default Runtime 을 직접** 쓰게 한다.

## 배경

cascade→Runtime 비전: binding(provider × model) 하나가 곧 하나의 Runtime. routes/cascade_name/tier/profile 간접은 의미가 없다 — 소비자는 default Runtime 을 직접 소비한다. B0(#19453)에서 Runtime substrate(`load_list`)를 도입했고, B3 는 그 첫 소비자 전환이다.

## 변경

- **`lib/runtime/runtime.ml`**: process-cached `default` accessor 추가. `load_list` 는 순수(매 호출 TOML parse)이므로 hot-path 소비자를 위해 resolved config_path 별로 memoize (cascade catalog 캐시와 동일한 Mutex + Fun.protect 패턴). default 미해결은 `Error` (silent fallback 없음).
- **`lib/runtime/runtime.mli`**: `val default` / `val reset_cache_for_tests` export 추가 (#19460 이 추가한 .mli 가 새 accessor 를 가렸음).
- **`lib/cascade/cascade_routes_resolve.ml`**: `cascade_name_for_use` 본체 적출. use 별 route target 조회 / catalog validation / `route.<key>` fallback 을 모두 제거하고 default Runtime 의 binding id 를 반환. default 미해결은 config 결함이므로 `failwith` (fail-fast — 예전 fallback 은 잘못된 default 를 조용히 숨겼다).
- **`lib/cascade/cascade_routes_resolve.mli`**: 새 동작(use 무시, fail-fast) 에 맞게 docstring 갱신. 시그니처(`?config_path -> logical_use -> string`) 유지 → 37 call-site 무변경.

## 거동 변경

`cascade_name_for_use ~use` 가 이제 `use` 를 무시하고 항상 default Runtime 의 id 를 반환한다. `Keeper_cascade_profile.cascade_name_for_use` 가 이 함수의 직접 alias 이므로 전파된다.

## 검증

- `env DUNE_CACHE=disabled dune build --root .` EXIT 0 (green main `335a42b92` 위)
- 거동 변경 테스트(`test_keeper_unified`, `test_anti_rationalization_coverage`) 는 CI 에서 검증 — 로컬 실행 결과를 확인 후 본문 갱신 예정. 해당 테스트의 assertion 은 대부분 함수 출력을 decision 파이프라인 통과 후 자기 자신과 비교하는 **상대 비교**라 동일 default 로도 일관 유지 예상. 단 테스트 환경에 `[runtime] default` config 가 없으면 fail-fast raise 가능 — CI 결과로 확정.

## 후속 (이 PR 범위 아님)

B3 나머지 함수: `models_of_cascade_name`, `resolve_named_providers`, `cascade_name_of_meta` (operator_control* 사용 → RFC 게이트 필요). 이후 B4 에서 `lib/cascade/` 적출.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
