### PR TITLE
fix(keeper): graceful tool_access parse for empty/malformed JSON

### DIFF
--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -109,6 +109,7 @@ let tool_preset_of_string raw =
   | "research" -> Some Research
   | "delivery" -> Some Delivery
   | "full" -> Some Full
+  | "coding" -> Some Full (* backward-compat alias: coding preset removed, map to full *)
   | _ -> None
 ;;
 
@@ -224,6 +225,14 @@ let tool_access_of_meta_json (json : Yojson.Safe.t) =
         | Ok tools -> Ok (normalize_tool_access (Custom tools))
         | Error msg -> Error msg)
      | Some other -> Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
-     | None -> Error "keeper tool_access.kind required")
-  | _ -> Error "keeper tool_access must be an object"
+     | None ->
+       (* Empty tool_access: {} — missing kind field.
+          Safe to default: ensure_keeper_meta resyncs from TOML on bootstrap.
+          Without this, meta_of_json fails and recovery via
+          load_or_materialize_boot_meta also fails (handle_keeper_up calls
+          read_meta which hits the same parse error). *)
+       Ok (default_tool_access_of_meta_json ()))
+  | _ ->
+    (* tool_access missing or not an object — same recovery rationale. *)
+    Ok (default_tool_access_of_meta_json ())
 ;;

--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -180,10 +180,15 @@ let string_list_field_opt_result ?label ~field_name (json : Yojson.Safe.t) =
 ;;
 
 let default_tool_access_of_meta_json () =
+  (* tool_execute excluded from the default blocklist: keepers need it for
+     shell commands, file reads, git ops, and cascade tool filtering requires
+     it. Only file-mutation writes (edit/write_file) are blocked by default.
+     See fleet deadlock Layer 2 analysis (2026-05-30). *)
+  let non_default_writes = [ "tool_edit_file"; "tool_write_file" ] in
   let tools =
     Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
     |> List.filter (fun name ->
-           not (List.exists (String.equal name) write_tools))
+           not (List.exists (String.equal name) non_default_writes))
   in
   Custom (normalize_tool_names tools)
 ;;


### PR DESCRIPTION
## Summary
- `tool_access_of_meta_json` returned `Error` when JSON had empty `tool_access: {}` (missing `kind` field), causing fleet-wide keeper deadlock
- Added graceful fallback to default tool access when `tool_access` is empty/missing/malformed
- Added `"coding"` → `Full` backward-compat alias in `tool_preset_of_string`
- **NEW**: Include `tool_execute` in default tool_access (was excluded as write tool → cascade rejected all providers)

## Root Cause — Layer 1 (Parse Failure)
`meta_to_json` intentionally omits `tool_access` (TOML-only config per comment at lines 13-15 of `keeper_meta_json.ml`). But `tool_access_of_meta_json` required `tool_access.kind` — causing parse failures for any keeper JSON that had `tool_access: {}` or was blank/missing.

Error propagation chain:
```
tool_access: {} → no kind field → Error "keeper tool_access.kind required"
  → parse_keeper_policy fails → meta_of_json fails → read_meta fails
  → ensure_keeper_meta fails → no TOML resync runs
```

Recovery via `load_or_materialize_boot_meta` also failed because `handle_keeper_up` calls `read_meta` which hit the same parse error — creating an unrecoverable deadlock.

## Root Cause — Layer 2 (tool_execute Exclusion)
`default_tool_access_of_meta_json` excluded ALL `write_tools` including `tool_execute`. But cascade tool filtering requires `tool_execute` for all providers → keepers without explicit `tool_access` had 66+ tools required but `tool_execute` missing → all 9 cascade candidates rejected with `required_tool_unsupported`.

```
write_tools = ["tool_edit_file"; "tool_write_file"; "tool_execute"]
  → default excludes tool_execute
  → cascade requires tool_execute
  → "No tool-capable provider for cascade"
```

Fix: Only exclude `tool_edit_file` and `tool_write_file` from default. `tool_execute` (shell commands, file reads, git ops) is essential for basic keeper operation.

## Affected Keepers
- **7 blank (0-byte) JSON files**: analyst, garnet, imseonghan, nick0cave, qa-king, ramarama
- **2 REJECTED (cascade)**: verifier, umberto — Layer 2 fix resolves
- **2 TIMEOUT**: masc-improver, rondo — separate issue
- **2 OK**: sangsu, tech_glutton — worked despite missing tool_access

## Changes
1. **`tool_access_of_meta_json`**: Return `Ok (default_tool_access_of_meta_json ())` instead of `Error` for:
   - Empty `tool_access: {}` (missing `kind` field)
   - Non-object `tool_access` (e.g., string, array, null)
   - Missing `tool_access` field entirely
2. **`tool_preset_of_string`**: Added `| "coding" -> Some Full` backward-compat alias
3. **`default_tool_access_of_meta_json`**: Exclude only `tool_edit_file` and `tool_write_file` (not `tool_execute`)

## Why This Is Safe
- `default_tool_access_of_meta_json` returns `Custom` with all `Keeper_internal` tools MINUS file-mutation writes — safe default
- `ensure_keeper_meta` resyncs ALL declarative fields from TOML on bootstrap anyway — the JSON parse just needs to succeed to reach that point
- The TOML resync overwrites whatever default we provide here
- `tool_execute` is needed for shell commands, file reads, git ops — blocking it makes keepers non-functional

## Test Plan
- `dune build @check` — type-check passes
- CI: 38/39 checks SUCCESS (Draft Auto-Merge Guard expected failure for draft PR)
- Verify fleet keepers can bootstrap after deploy (no more `tool_access.kind required` or `No tool-capable provider` errors)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>