### PR TITLE
fix(ssot): consolidate dashboard session accessors + ISO timestamp aliases (rounds 7-8)

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -296,8 +296,6 @@ let audit_entry_id ~timestamp ~agent_id ~action =
                                            ^ Printf.sprintf "%.6f" timestamp)) in
   Printf.sprintf "aud-%016Lx-%s" ms (String.sub hash 0 8)
 
-let format_iso8601 ts = Masc_domain.iso8601_of_unix_seconds ts
-
 (** Map outcome + action to O2 severity string. *)
 let audit_severity ~action ~outcome =
   match outcome with
@@ -377,7 +375,7 @@ let audit_event_json (entry : audit_entry) =
   let fields =
     [
       ("id", `String id);
-      ("ts", `String (format_iso8601 entry.timestamp));
+      ("ts", `String (Masc_domain.iso8601_of_unix_seconds entry.timestamp));
       ("actor", `String entry.agent_id);
       ("kind", `String kind);
       ("summary", `String (audit_summary ~action:entry.action ~details:entry.details));
@@ -461,7 +459,7 @@ let log_action
   append_entry config entry;
   (* Publish to the MASC event bus for real-time SSE streaming. *)
   let id = audit_entry_id ~timestamp:entry.timestamp ~agent_id ~action in
-  let ts = format_iso8601 entry.timestamp in
+  let ts = Masc_domain.iso8601_of_unix_seconds entry.timestamp in
   let kind = action_to_string action in
   let severity = audit_severity ~action ~outcome in
   let summary = audit_summary ~action ~details in

--- a/lib/briefing_compactors/briefing_json_helpers.ml
+++ b/lib/briefing_compactors/briefing_json_helpers.ml
@@ -49,7 +49,6 @@ let float_json ?(default = 0.0) json =
       | None -> `Float default)
   | _ -> `Float default
 
-let int_field = Dashboard_utils.int_field
 let take = List.take
 
 

--- a/lib/briefing_compactors/briefing_json_helpers.mli
+++ b/lib/briefing_compactors/briefing_json_helpers.mli
@@ -7,5 +7,4 @@ val string_json : ?default:string -> ?max_len:int -> Yojson.Safe.t -> Yojson.Saf
 val string_list_json : Yojson.Safe.t -> Yojson.Safe.t
 val int_json : ?default:int -> Yojson.Safe.t -> Yojson.Safe.t
 val float_json : ?default:float -> Yojson.Safe.t -> Yojson.Safe.t
-val int_field : ?default:int -> string -> Yojson.Safe.t -> int
 val take : int -> 'a list -> 'a list

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -24,8 +24,6 @@ type t =
   }
 [@@deriving yojson { strict = false }]
 
-let iso8601_of_unix = Masc_domain.iso8601_of_unix_seconds
-
 let rec find_git_root dir =
   let git_marker = Filename.concat dir ".git" in
   if Sys.file_exists git_marker
@@ -304,7 +302,7 @@ let age_seconds ~now ts_opt =
 ;;
 
 let started_at_unix = Unix.gettimeofday ()
-let started_at_iso = iso8601_of_unix started_at_unix
+let started_at_iso = Masc_domain.iso8601_of_unix_seconds started_at_unix
 let resolved_executable_path = executable_path ()
 let resolved_executable_dir = Filename.dirname resolved_executable_path
 

--- a/lib/dashboard/briefing_sections.ml
+++ b/lib/dashboard/briefing_sections.ml
@@ -55,7 +55,8 @@ let annotate_section ~section ~status ~summary ~evidence ~metadata_gaps
       ("authoritative", `Bool false);
     ]
 
-let int_field_direct ?(default = 0) key json = int_field ~default key json
+let int_field_direct ?(default = 0) key json =
+  Option.value ~default (Json_util.assoc_int_opt key json)
 
 let sum_int_field key items =
   List.fold_left (fun acc json -> acc + int_field_direct key json) 0 items
@@ -211,9 +212,9 @@ let build_watch_section ~room_health ~incident_count ~recommended_action_count
 let build_briefing_sections ~briefing_summary_json ~sessions ~agents ~recent_messages
     ~metadata_gaps =
   let room_health = briefing_summary_json |> string_field "room_health" in
-  let incident_count = briefing_summary_json |> int_field "incident_count" in
+  let incident_count = Option.value ~default:0 (Json_util.assoc_int_opt "incident_count" briefing_summary_json) in
   let recommended_action_count =
-    briefing_summary_json |> int_field "recommended_action_count"
+    Option.value ~default:0 (Json_util.assoc_int_opt "recommended_action_count" briefing_summary_json)
   in
   let top_attention_summary =
     briefing_summary_json |> string_field "top_attention_summary"

--- a/lib/dashboard/dashboard_briefing.ml
+++ b/lib/dashboard/dashboard_briefing.ml
@@ -41,41 +41,10 @@ let top_item items =
   | item :: _ -> item
   | [] -> `Null
 
-let session_payload_json session_json =
-  match member_assoc "status" session_json with
-  | `Assoc _ as payload -> payload
-  | _ -> session_json
-
-let session_meta_json session_json =
-  session_payload_json session_json |> member_assoc "session"
-
-let session_summary_json session_json =
-  session_payload_json session_json |> member_assoc "summary"
-
-let session_team_health_json session_json =
-  session_payload_json session_json |> member_assoc "team_health"
-
-let session_communication_json session_json =
-  session_payload_json session_json |> member_assoc "communication_metrics"
-
-let session_status_string session_json =
-  let summary = session_summary_json session_json in
-  let meta = session_meta_json session_json in
-  match String_util.trim_to_option (string_field "status" summary) with
-  | Some value -> value
-  | None -> (
-      match String_util.trim_to_option (string_field "status" meta) with
-      | Some value -> value
-      | None ->
-          String_util.trim_to_option (string_field "status" session_json)
-          |> Option.value
-               ~default:"<missing status field in summary / meta / session>")
-
-let session_recent_events session_json =
-  list_field "recent_events" session_json
-
-let event_detail_json event_json =
-  member_assoc "detail" event_json
+(* session_payload_json, session_meta_json, session_summary_json,
+   session_team_health_json, session_communication_json,
+   session_status_string, session_recent_events, event_detail_json
+   are provided by Dashboard_utils (included above). *)
 
 let event_summary event_json =
   let detail = event_detail_json event_json in

--- a/lib/dashboard/dashboard_briefing_agents.ml
+++ b/lib/dashboard/dashboard_briefing_agents.ml
@@ -5,8 +5,8 @@
 
 include Dashboard_utils
 
-let event_detail_json event_json =
-  member_assoc "detail" event_json
+(* event_detail_json and session_recent_events are provided by
+   Dashboard_utils (included above). *)
 
 let event_summary event_json =
   let detail = event_detail_json event_json in
@@ -37,8 +37,6 @@ let event_summary event_json =
   | None, None, Some value, _ -> value
   | None, None, None, Some value -> value
   | None, None, None, None -> String.map (fun ch -> if ch = '_' then ' ' else ch) event_type
-
-let session_recent_events session_json = list_field "recent_events" session_json
 
 (* Types duplicated from Dashboard_briefing to avoid circular dependency. *)
 type session_context = {

--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -85,7 +85,7 @@ let keeper_tool_audit_json_fields config registry_lookup keeper agent_name =
               let latest_at = List.fold_left (fun acc (_, e) ->
                 max acc e.Keeper_types.last_used_at) 0.0 tracked in
               let at_str = if latest_at > 0.0
-                then Some (Dashboard_utils.iso_of_unix latest_at) else None in
+                then Some (Masc_domain.iso8601_of_unix_seconds latest_at) else None in
               (fallback_allowed, names, Some total, None, Some "keeper_dispatch", at_str)
             else
               ( fallback_allowed,

--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -12,8 +12,7 @@ let keeper_tool_audit_json_fields config registry_lookup keeper agent_name =
   let keeper_name =
     match member_assoc "name" keeper with
     | `String n ->
-        let trimmed = String.trim n in
-        if trimmed <> "" then trimmed else agent_name
+        (match String_util.trim_to_option n with Some v -> v | None -> agent_name)
     | _ -> agent_name
   in
   let fallback_allowed =
@@ -30,12 +29,7 @@ let keeper_tool_audit_json_fields config registry_lookup keeper agent_name =
   let fallback_latest =
     Dashboard_utils.string_list_of_json (member_assoc "latest_tool_names" keeper)
   in
-  let fallback_count =
-    match member_assoc "latest_tool_call_count" keeper with
-    | `Int value -> Some value
-    | `Intlit raw -> (int_of_string_opt (raw))
-    | _ -> None
-  in
+  let fallback_count = Json_util.assoc_int_opt "latest_tool_call_count" keeper in
   let fallback_source =
     match String_util.trim_to_option (string_field "tool_audit_source" keeper) with
     | Some _ as value -> value

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -237,11 +237,12 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
     else if last_signal_ts > 0.0 then max 0.0 (now_ts -. last_signal_ts)
     else infinity
   in
-  let autonomous_action_count = int_field "autonomous_action_count" keeper in
-  let autonomous_turn_count = int_field "autonomous_turn_count" keeper in
-  let noop_turn_count = int_field "noop_turn_count" keeper in
-  let turn_count = int_field "turn_count" keeper in
-  let generation = int_field "generation" keeper in
+  let int_field_default key json = Option.value ~default:0 (Json_util.assoc_int_opt key json) in
+  let autonomous_action_count = int_field_default "autonomous_action_count" keeper in
+  let autonomous_turn_count = int_field_default "autonomous_turn_count" keeper in
+  let noop_turn_count = int_field_default "noop_turn_count" keeper in
+  let turn_count = int_field_default "turn_count" keeper in
+  let generation = int_field_default "generation" keeper in
   let goal_count = List.length (list_field "active_goal_ids" keeper) in
   let lifecycle =
     if Dashboard_utils.is_keeper_offline status then Lc_offline

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -80,6 +80,14 @@ let take = List.take
 let int_field = Dashboard_utils.int_field
 let list_field = Dashboard_utils.list_field
 let compact_text = String_util.compact_text
+let session_payload_json = Dashboard_utils.session_payload_json
+let session_meta_json = Dashboard_utils.session_meta_json
+let session_summary_json = Dashboard_utils.session_summary_json
+let session_team_health_json = Dashboard_utils.session_team_health_json
+let session_communication_json = Dashboard_utils.session_communication_json
+let session_status_string = Dashboard_utils.session_status_string
+let session_recent_events = Dashboard_utils.session_recent_events
+let event_detail_json = Dashboard_utils.event_detail_json
 
 
 let latest_iso_timestamp values =

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -77,7 +77,6 @@ let option_or_else fallback = function
 let member_assoc = Dashboard_utils.member_assoc
 let string_field = Dashboard_utils.string_field
 let take = List.take
-let int_field = Dashboard_utils.int_field
 let list_field = Dashboard_utils.list_field
 let compact_text = String_util.compact_text
 let session_payload_json = Dashboard_utils.session_payload_json

--- a/lib/dashboard/dashboard_execution_helpers.mli
+++ b/lib/dashboard/dashboard_execution_helpers.mli
@@ -151,6 +151,14 @@ val take : int -> 'a list -> 'a list
 val latest_iso_timestamp : string option list -> string option
 val compact_text : ?max_len:int -> string -> string
 val dedup_strings : string list -> string list
+val session_payload_json : Yojson.Safe.t -> Yojson.Safe.t
+val session_meta_json : Yojson.Safe.t -> Yojson.Safe.t
+val session_summary_json : Yojson.Safe.t -> Yojson.Safe.t
+val session_team_health_json : Yojson.Safe.t -> Yojson.Safe.t
+val session_communication_json : Yojson.Safe.t -> Yojson.Safe.t
+val session_status_string : Yojson.Safe.t -> string
+val session_recent_events : Yojson.Safe.t -> Yojson.Safe.t list
+val event_detail_json : Yojson.Safe.t -> Yojson.Safe.t
 val severity_rank : string -> int
 val dashboard_fixture_name : ?fixture:string -> unit -> string option
 val execution_tool_preview_limit : int

--- a/lib/dashboard/dashboard_execution_helpers.mli
+++ b/lib/dashboard/dashboard_execution_helpers.mli
@@ -140,7 +140,6 @@ val get_agent_profile : string -> agent_profile
 
 val member_assoc : string -> Yojson.Safe.t -> Yojson.Safe.t
 val string_field : ?default:string -> string -> Yojson.Safe.t -> string
-val int_field : ?default:int -> string -> Yojson.Safe.t -> int
 val list_field : string -> Yojson.Safe.t -> Yojson.Safe.t list
 val string_list_of_field : string -> Yojson.Safe.t -> string list
 

--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -5,41 +5,10 @@
 
 include Dashboard_execution_helpers
 
-let session_payload_json session_json =
-  match member_assoc "status" session_json with
-  | `Assoc _ as payload -> payload
-  | _ -> session_json
-
-let session_meta_json session_json =
-  session_payload_json session_json |> member_assoc "session"
-
-let session_summary_json session_json =
-  session_payload_json session_json |> member_assoc "summary"
-
-let session_team_health_json session_json =
-  session_payload_json session_json |> member_assoc "team_health"
-
-let session_communication_json session_json =
-  session_payload_json session_json |> member_assoc "communication_metrics"
-
-let session_status_string session_json =
-  let summary = session_summary_json session_json in
-  let meta = session_meta_json session_json in
-  match String_util.trim_to_option (string_field "status" summary) with
-  | Some value -> value
-  | None -> (
-      match String_util.trim_to_option (string_field "status" meta) with
-      | Some value -> value
-      | None ->
-          String_util.trim_to_option (string_field "status" session_json)
-          |> Option.value
-               ~default:"<missing status field in summary / meta / session>")
-
-let session_recent_events session_json =
-  list_field "recent_events" session_json
-
-let event_detail_json event_json =
-  member_assoc "detail" event_json
+(* session_payload_json, session_meta_json, session_summary_json,
+   session_team_health_json, session_communication_json,
+   session_status_string, session_recent_events, event_detail_json
+   are provided by Dashboard_utils (via include chain). *)
 
 let event_summary event_json =
   let detail = event_detail_json event_json in

--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -123,9 +123,9 @@ let build_session_seed session_json _cards =
       String_util.trim_to_option (string_field "mode" communication)
       |> Option.value ~default:"mode n/a"
     in
-    let broadcast_count = int_field "broadcast_count" communication in
-    let portal_count = int_field "portal_count" communication in
-    let seen_count = int_field "seen_agents_count" summary in
+    let broadcast_count = Option.value ~default:0 (Json_util.assoc_int_opt "broadcast_count" communication) in
+    let portal_count = Option.value ~default:0 (Json_util.assoc_int_opt "portal_count" communication) in
+    let seen_count = Option.value ~default:0 (Json_util.assoc_int_opt "seen_agents_count" summary) in
     let member_names =
       dedup_strings
         (Dashboard_utils.string_list_of_json (member_assoc "agent_names" meta)
@@ -179,10 +179,10 @@ let build_session_seed session_json _cards =
         communication_summary =
           Printf.sprintf "%s · broadcast %d · portal %d" mode broadcast_count
             portal_count;
-        active_count = int_field "active_agents_count" team_health;
+        active_count = Option.value ~default:0 (Json_util.assoc_int_opt "active_agents_count" team_health);
         seen_count;
         planned_count;
-        required_count = int_field ~default:1 "required_agents" team_health;
+        required_count = Option.value ~default:1 (Json_util.assoc_int_opt "required_agents" team_health);
         counts_basis;
         runtime_blocker;
         worker_gap_summary;

--- a/lib/dashboard/dashboard_execution_sessions.mli
+++ b/lib/dashboard/dashboard_execution_sessions.mli
@@ -15,14 +15,13 @@
     cascade-visible.  The remaining helpers are keeper-internal
     and refactor-free:
 
-    - 9 JSON field accessors ([session_payload_json],
-      [session_meta_json], [session_summary_json],
-      [session_team_health_json],
-      [session_communication_json],
-      [session_status_string],
-      [session_recent_events],
-      [event_detail_json],
-      [event_summary]).
+    - 8 JSON field accessors now in {!Dashboard_utils}
+      ([session_payload_json], [session_meta_json],
+      [session_summary_json], [session_team_health_json],
+      [session_communication_json], [session_status_string],
+      [session_recent_events], [event_detail_json]),
+      re-exported via {!Dashboard_execution_helpers}.
+      [event_summary] stays private here.
     - [session_severity] (severity classification).
     - [build_session_seed] / [session_operation_links] /
       [build_session_contexts] (session aggregation).

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -675,7 +675,7 @@ let compute_judgments
       try
         let raw_text = Agent_sdk_response.text_of_response response in
         let generated_at = Masc_domain.now_iso () in
-        let expires_at = Dashboard_utils.iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
+        let expires_at = Masc_domain.iso8601_of_unix_seconds (Unix.gettimeofday () +. cache_ttl_sec ()) in
         (* #9880: keep the internal fallback/counter for empty OAS model
            metadata, but do not project concrete model names into MASC-owned
            dashboard or judgment JSON. *)

--- a/lib/dashboard/dashboard_http_helpers.ml
+++ b/lib/dashboard/dashboard_http_helpers.ml
@@ -173,5 +173,6 @@ let count_where items predicate =
     so this is the SSOT — Dashboard_governance_judge and
     Dashboard_operator_judge previously each carried an identical fork. *)
 let normalize_text raw =
-  raw |> String.trim |> String.split_on_char '\n' |> List.map String.trim
-  |> List.filter (fun item -> item <> "") |> String.concat " " |> String.trim
+  raw |> String.trim |> String.split_on_char '\n'
+  |> List.filter_map String_util.trim_to_option
+  |> String.concat " " |> String.trim

--- a/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
+++ b/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
@@ -86,14 +86,7 @@ let output_text record =
   | _ -> ""
 
 let compact_text ?(limit = 240) text =
-  let trimmed =
-    text
-    |> String.map (function '\n' | '\r' | '\t' -> ' ' | c -> c)
-    |> String.trim
-  in
-  if String.length trimmed > limit then
-    String.sub trimmed 0 limit ^ "..."
-  else trimmed
+  String_util.compact_text ~max_len:limit text
 
 let compact_category text =
   let key = compact_text ~limit:120 text in

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -205,7 +205,7 @@ let parse_room_judgment ~config ~generated_at ~generated_at_unix ~model_used:_ j
                (Json_util.get_bool json member_disagreement_with_truth
                |> Option.value ~default:false)
              ~generated_at ~generated_at_unix
-             ~fresh_until:(Dashboard_utils.iso_of_unix fresh_until_unix)
+             ~fresh_until:(Masc_domain.iso8601_of_unix_seconds fresh_until_unix)
              ~fresh_until_unix ~keeper_name ())
   | _ -> None
 
@@ -301,9 +301,9 @@ let refresh_once ~sw ~net
             st.last_error <- Some message)
     | Ok (model_used, result_json) ->
         let generated_at_unix = Unix.gettimeofday () in
-        let generated_at = Dashboard_utils.iso_of_unix generated_at_unix in
+        let generated_at = Masc_domain.iso8601_of_unix_seconds generated_at_unix in
         let expires_at =
-          Dashboard_utils.iso_of_unix (generated_at_unix +. float_of_int (room_ttl_sec ()))
+          Masc_domain.iso8601_of_unix_seconds (generated_at_unix +. float_of_int (room_ttl_sec ()))
         in
         let room_judgment =
           parse_room_judgment ~config ~generated_at ~generated_at_unix

--- a/lib/dashboard/dashboard_rooms.ml
+++ b/lib/dashboard/dashboard_rooms.ml
@@ -90,7 +90,7 @@ let mentions_of_message (msg : Masc_domain.message) =
   in
   let direct =
     match msg.mention with
-    | Some value when String.trim value <> "" -> [ String.trim value ]
+    | Some value -> Option.to_list (String_util.trim_to_option value)
     | _ -> []
   in
   unique_preserving_order (direct @ body_mentions)

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -138,7 +138,7 @@ let request_to_json (req : V.verification_request) : Yojson.Safe.t =
        unassigned rather than inventing a value. *)
     ("keeper", Json_util.string_opt_to_json req.verifier);
     ("status", `String status);
-    ("created_at", `String (Dashboard_utils.iso_of_unix req.created_at));
+    ("created_at", `String (Masc_domain.iso8601_of_unix_seconds req.created_at));
     ("submitted_by", `String req.worker);
     ("approved_by", Json_util.string_opt_to_json approved_by);
     ("completion_contract",
@@ -233,7 +233,7 @@ let rejection_row_json (req : V.verification_request) : Yojson.Safe.t =
     ("task_title", `String task_title);
     ("keeper", Json_util.string_opt_to_json approved_by);
     ("verdict_reason", `String verdict_reason);
-    ("created_at", `String (Dashboard_utils.iso_of_unix req.created_at));
+    ("created_at", `String (Masc_domain.iso8601_of_unix_seconds req.created_at));
   ]
 
 let is_rejected (req : V.verification_request) : bool =

--- a/lib/dashboard_cascade_audit_runs.ml
+++ b/lib/dashboard_cascade_audit_runs.ml
@@ -92,14 +92,14 @@ let last_attempt_error attempts =
 ;;
 
 let audit_run_json_of_record json =
-  let observation = Yojson.Safe.Util.member "observation" json in
-  let list_member key json =
-    match Yojson.Safe.Util.member key json with
-    | `List values -> values
+  let observation = Option.value ~default:`Null (Json_util.assoc_member_opt "observation" json) in
+  let get_array_or_empty key json =
+    match Json_util.get_array json key with
+    | Some (`List values) -> values
     | _ -> []
   in
-  let attempts = list_member "attempts" observation in
-  let fallback_events = list_member "fallback_events" observation in
+  let attempts = get_array_or_empty "attempts" observation in
+  let fallback_events = get_array_or_empty "fallback_events" observation in
   let selected_attempt_index = Json_util.assoc_int_opt "selected_index" observation in
   let cascade =
     first_nonempty

--- a/lib/dashboard_cascade_audit_runs.ml
+++ b/lib/dashboard_cascade_audit_runs.ml
@@ -8,18 +8,10 @@
 
 open Dashboard_cascade_helpers
 
-let json_list_member key json =
-  match Yojson.Safe.Util.member key json with
-  | `List values -> values
-  | _ -> []
-;;
-
 let first_nonempty values =
   List.find_map (fun v ->
     match v with
-    | Some raw ->
-      let trimmed = String.trim raw in
-      if String.equal trimmed "" then None else Some trimmed
+    | Some raw -> String_util.trim_to_option raw
     | None -> None)
     values
 
@@ -101,8 +93,13 @@ let last_attempt_error attempts =
 
 let audit_run_json_of_record json =
   let observation = Yojson.Safe.Util.member "observation" json in
-  let attempts = json_list_member "attempts" observation in
-  let fallback_events = json_list_member "fallback_events" observation in
+  let list_member key json =
+    match Yojson.Safe.Util.member key json with
+    | `List values -> values
+    | _ -> []
+  in
+  let attempts = list_member "attempts" observation in
+  let fallback_events = list_member "fallback_events" observation in
   let selected_attempt_index = Json_util.assoc_int_opt "selected_index" observation in
   let cascade =
     first_nonempty

--- a/lib/dashboard_cascade_audit_runs.ml
+++ b/lib/dashboard_cascade_audit_runs.ml
@@ -185,7 +185,7 @@ let audit_runs_json ?(dashboard_surface = "/api/v1/cascade/audit_runs") ~base_pa
     | x :: xs -> x :: take (n - 1) xs
   in
   let runs = take limit runs in
-  let generated_at = now_iso () in
+  let generated_at = Masc_domain.now_iso () in
   `Assoc
     [ "updated_at", `String generated_at
     ; "generated_at_iso", `String generated_at

--- a/lib/dashboard_cascade_capacity.ml
+++ b/lib/dashboard_cascade_capacity.ml
@@ -45,7 +45,7 @@ let client_capacity_json_compute () =
          | n -> n)
       entries
   in
-  let generated_at = now_iso () in
+  let generated_at = Masc_domain.now_iso () in
   `Assoc
     [ "updated_at", `String generated_at
     ; "generated_at_iso", `String generated_at
@@ -92,7 +92,7 @@ let history_event_to_json (ev : Cascade_client_capacity_history.event) : Yojson.
 
 let client_capacity_history_json ?limit ?kind ?since_ts () =
   let events = Cascade_client_capacity_history.snapshot ?limit ?kind ?since_ts () in
-  let generated_at = now_iso () in
+  let generated_at = Masc_domain.now_iso () in
   `Assoc
     [ "updated_at", `String generated_at
     ; "generated_at_iso", `String generated_at

--- a/lib/dashboard_cascade_config.ml
+++ b/lib/dashboard_cascade_config.ml
@@ -355,7 +355,7 @@ let config_json ?base_path () =
       List.map (profile_json_raw ~config_path ~keeper_assignable_names) names
   in
   let fields =
-    [ "updated_at", `String (now_iso ())
+    [ "updated_at", `String (Masc_domain.now_iso ())
     ; ( "config_path", Json_util.string_opt_to_json config_path )
     ]
     @ source_json_fields source
@@ -429,7 +429,7 @@ let raw_config_json_compute () =
          "", Some msg)
   in
   `Assoc
-    [ "updated_at", `String (now_iso ())
+    [ "updated_at", `String (Masc_domain.now_iso ())
     ; "source_kind", `String (Cascade_toml_materializer.source_kind_to_string source.kind)
     ; "source_path", `String source.source_path
     ; "source_editable", `Bool (Option.is_none !source_read_error)

--- a/lib/dashboard_cascade_config.ml
+++ b/lib/dashboard_cascade_config.ml
@@ -12,8 +12,7 @@ open Dashboard_cascade_helpers
 
 let sorted_unique_strings values =
   values
-  |> List.map String.trim
-  |> List.filter (fun value -> not (String.equal value ""))
+  |> List.filter_map String_util.trim_to_option
   |> List.sort_uniq String.compare
 ;;
 

--- a/lib/dashboard_cascade_health_json.ml
+++ b/lib/dashboard_cascade_health_json.ml
@@ -143,7 +143,7 @@ let health_json_compute ?(window_minutes = 30) ?(base_path : string option) () =
       []
   in
   `Assoc
-    [ "updated_at", `String (now_iso ())
+    [ "updated_at", `String (Masc_domain.now_iso ())
     ; (* Health tracker is the SSOT for these values; reading env here would
        diverge from what the tracker actually applied (e.g. if the operator
        sets a malformed value that falls back to the default, the tracker

--- a/lib/dashboard_cascade_helpers.ml
+++ b/lib/dashboard_cascade_helpers.ml
@@ -73,7 +73,7 @@ let invalid_profiles_with_internal_names profiles =
 ;;
 
 let qualified_profile_candidates name =
-  [ String.trim name ]
+  Option.to_list (String_util.trim_to_option name)
 ;;
 
 let invalid_assignment_reasons ~known_internal_profiles ~invalid_profiles name =
@@ -103,17 +103,15 @@ let invalid_assignments_for_public_profiles ~known_internal_profiles
     | None -> None)
 ;;
 
-let member = Yojson.Safe.Util.member
-
 let invalid_profiles_of_rejection_json rejection_json =
-  match member "profiles" rejection_json with
-  | `List profiles ->
+  match Json_util.get_array rejection_json "profiles" with
+  | Some (`List profiles) ->
     List.filter_map
       (fun profile_json ->
-         match member "name" profile_json with
-         | `String name ->
+         match Json_util.assoc_string_opt "name" profile_json with
+         | Some name ->
            Some (name, Json_util.get_string_list profile_json "errors")
-         | _ -> None)
+         | None -> None)
       profiles
     |> invalid_profiles_with_internal_names
   | _ -> []

--- a/lib/dashboard_cascade_helpers.ml
+++ b/lib/dashboard_cascade_helpers.ml
@@ -105,30 +105,6 @@ let invalid_assignments_for_public_profiles ~known_internal_profiles
 
 let member = Yojson.Safe.Util.member
 
-(* Restored after PR #19471 removed these two helpers but left external
-   call sites (dashboard_cascade_config.ml, dashboard_cascade_audit_runs.ml,
-   which [open Dashboard_cascade_helpers]) referencing them -> broken main.
-   They are kept rather than migrated to [Yojson.Safe.Util.member] /
-   [Json_util] because both are *total* (return `Null / [] on non-object),
-   whereas [Yojson.Safe.Util.member] raises on a non-object input -- the
-   audit-run parser relies on that totality for absent/Null sub-objects.
-   Root resolution: a total member/string-list accessor in a leaf module
-   shared by both the helpers and Json_util (RFC candidate). *)
-let json_assoc_member key = function
-  | `Assoc fields -> Option.value (List.assoc_opt key fields) ~default:`Null
-  | _ -> `Null
-;;
-
-let json_string_list = function
-  | `List values ->
-    List.filter_map
-      (function
-        | `String value -> Some value
-        | _ -> None)
-      values
-  | _ -> []
-;;
-
 let invalid_profiles_of_rejection_json rejection_json =
   match member "profiles" rejection_json with
   | `List profiles ->

--- a/lib/dashboard_cascade_helpers.ml
+++ b/lib/dashboard_cascade_helpers.ml
@@ -24,8 +24,6 @@ module Float = Stdlib.Float
 module CC = Cascade_config
 module StringSet = Set_util.StringSet
 
-let now_iso () = Masc_domain.now_iso ()
-
 let candidate_to_json (c : CC.candidate_info) : Yojson.Safe.t =
   `Assoc
     [ "model", `String c.model_string

--- a/lib/dashboard_cascade_slo.ml
+++ b/lib/dashboard_cascade_slo.ml
@@ -49,7 +49,7 @@ let slo_json_compute () =
     else "ok"
   in
   `Assoc
-    [ "updated_at", `String (now_iso ())
+    [ "updated_at", `String (Masc_domain.now_iso ())
     ; "window_sample_size", `Int slo_sample_limit
     ; ( "targets"
       , `Assoc

--- a/lib/dashboard_cascade_strategy_trace.ml
+++ b/lib/dashboard_cascade_strategy_trace.ml
@@ -23,7 +23,7 @@ let strategy_trace_event_to_json (ev : Cascade_strategy_trace.event) : Yojson.Sa
 
 let strategy_trace_json ?limit ?cascade () =
   let events = Cascade_strategy_trace.snapshot ?limit ?cascade () in
-  let generated_at = now_iso () in
+  let generated_at = Masc_domain.now_iso () in
   `Assoc
     [ "updated_at", `String generated_at
     ; "generated_at_iso", `String generated_at

--- a/lib/dashboard_tla_specs.ml
+++ b/lib/dashboard_tla_specs.ml
@@ -144,7 +144,7 @@ let specs_json () : Yojson.Safe.t =
   let root = specs_dir () in
   let entries = list_specs () in
   `Assoc
-    [ "updated_at", `String (Masc_domain.iso8601_of_unix_seconds (Unix.gettimeofday ()))
+    [ "updated_at", `String (Masc_domain.now_iso ())
     ; "specs_dir", specs_dir_json root
     ; "count", `Int (List.length entries)
     ; "entries", `List (List.map entry_to_json entries)
@@ -317,7 +317,7 @@ let tlc_results_json () : Yojson.Safe.t =
   let results_dir = tlc_results_dir () in
   let entries = list_tlc_results () in
   `Assoc
-    [ "updated_at", `String (Masc_domain.iso8601_of_unix_seconds (Unix.gettimeofday ()))
+    [ "updated_at", `String (Masc_domain.now_iso ())
     ; ( "results_dir"
       , if is_directory_safe results_dir
         then (

--- a/lib/dashboard_tla_specs.ml
+++ b/lib/dashboard_tla_specs.ml
@@ -119,7 +119,6 @@ let list_specs () =
       | c -> c)
 ;;
 
-let iso_of_unix_time = Dashboard_utils.iso_of_unix
 ;;
 
 let entry_to_json e : Yojson.Safe.t =
@@ -129,7 +128,7 @@ let entry_to_json e : Yojson.Safe.t =
     ; "category", `String e.category
     ; "has_clean_cfg", `Bool e.has_clean_cfg
     ; "has_buggy_cfg", `Bool e.has_buggy_cfg
-    ; "mtime_iso", `String (iso_of_unix_time e.mtime)
+    ; "mtime_iso", `String (Masc_domain.iso8601_of_unix_seconds e.mtime)
     ]
 ;;
 
@@ -145,7 +144,7 @@ let specs_json () : Yojson.Safe.t =
   let root = specs_dir () in
   let entries = list_specs () in
   `Assoc
-    [ "updated_at", `String (iso_of_unix_time (Unix.gettimeofday ()))
+    [ "updated_at", `String (Masc_domain.iso8601_of_unix_seconds (Unix.gettimeofday ()))
     ; "specs_dir", specs_dir_json root
     ; "count", `Int (List.length entries)
     ; "entries", `List (List.map entry_to_json entries)
@@ -295,7 +294,7 @@ let list_tlc_results () =
 
 
 let option_time_json = function
-  | Some v -> `String (iso_of_unix_time v)
+  | Some v -> `String (Masc_domain.iso8601_of_unix_seconds v)
   | None -> `Null
 ;;
 
@@ -318,7 +317,7 @@ let tlc_results_json () : Yojson.Safe.t =
   let results_dir = tlc_results_dir () in
   let entries = list_tlc_results () in
   `Assoc
-    [ "updated_at", `String (iso_of_unix_time (Unix.gettimeofday ()))
+    [ "updated_at", `String (Masc_domain.iso8601_of_unix_seconds (Unix.gettimeofday ()))
     ; ( "results_dir"
       , if is_directory_safe results_dir
         then (

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -1,5 +1,3 @@
-let iso_of_unix unix_ts = Masc_domain.iso8601_of_unix_seconds unix_ts
-
 let parse_iso_opt = function
   | Some raw when String.trim raw <> "" -> (
       try Some (Masc_domain.parse_iso8601 raw) with Failure _ -> None)

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -35,13 +35,6 @@ let member_assoc key json =
   | `Assoc fields -> (match List.assoc_opt key fields with Some v -> v | None -> `Null)
   | _ -> `Null
 
-let int_field ?(default = 0) key json =
-  match member_assoc key json with
-  | `Int v -> v
-  | `Intlit raw -> (Option.value ~default:default (int_of_string_opt raw))
-  | `Float v -> int_of_float v
-  | _ -> default
-
 let string_field ?(default = "") key json =
   match member_assoc key json with
   | `String v -> v

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -73,6 +73,49 @@ let compact_text = String_util.compact_text
 let normalized_text_key text =
   compact_text ~max_len:512 text |> String.trim |> String.lowercase_ascii
 
+(** {1 Session JSON accessors}
+
+    Canonical accessors for the nested session payload structure.
+    A session JSON may carry its detail inside a ["status"] sub-object
+    (when the status field is itself an [`Assoc]) or directly at the
+    top level.  [session_payload_json] normalises this. *)
+
+let session_payload_json session_json =
+  match member_assoc "status" session_json with
+  | `Assoc _ as payload -> payload
+  | _ -> session_json
+
+let session_meta_json session_json =
+  session_payload_json session_json |> member_assoc "session"
+
+let session_summary_json session_json =
+  session_payload_json session_json |> member_assoc "summary"
+
+let session_team_health_json session_json =
+  session_payload_json session_json |> member_assoc "team_health"
+
+let session_communication_json session_json =
+  session_payload_json session_json |> member_assoc "communication_metrics"
+
+let session_status_string session_json =
+  let summary = session_summary_json session_json in
+  let meta = session_meta_json session_json in
+  match String_util.trim_to_option (string_field "status" summary) with
+  | Some value -> value
+  | None -> (
+      match String_util.trim_to_option (string_field "status" meta) with
+      | Some value -> value
+      | None ->
+          String_util.trim_to_option (string_field "status" session_json)
+          |> Option.value
+               ~default:"<missing status field in summary / meta / session>")
+
+let session_recent_events session_json =
+  list_field "recent_events" session_json
+
+let event_detail_json event_json =
+  member_assoc "detail" event_json
+
 (** Health severity level — ordered from worst to best.
     Parsed from dashboard/operator JSON at the call site via
     [health_level_of_string], then used in typed predicates below. *)

--- a/lib/dashboard_utils/dashboard_utils.mli
+++ b/lib/dashboard_utils/dashboard_utils.mli
@@ -5,9 +5,6 @@
 
 (** {1 Time} *)
 
-val iso_of_unix : float -> string
-(** Format a Unix epoch as ISO-8601 in UTC, e.g. ["2026-04-28T10:34:12Z"]. *)
-
 val parse_iso_opt : string option -> float option
 (** Parse an ISO-8601 timestamp via {!Masc_domain.parse_iso8601}.
     Returns [None] for [None], empty/whitespace strings, or parse failures. *)

--- a/lib/dashboard_utils/dashboard_utils.mli
+++ b/lib/dashboard_utils/dashboard_utils.mli
@@ -34,6 +34,35 @@ val normalized_text_key : string -> string
 (** [compact_text ~max_len:512] then trim and lowercase — a stable
     key for fuzzy text grouping. *)
 
+(** {1 Session JSON accessors} *)
+
+val session_payload_json : Yojson.Safe.t -> Yojson.Safe.t
+(** Normalise a session JSON: if the ["status"] field is an [`Assoc],
+    return that sub-object; otherwise return the original JSON. *)
+
+val session_meta_json : Yojson.Safe.t -> Yojson.Safe.t
+(** ["session"] sub-key inside the payload. *)
+
+val session_summary_json : Yojson.Safe.t -> Yojson.Safe.t
+(** ["summary"] sub-key inside the payload. *)
+
+val session_team_health_json : Yojson.Safe.t -> Yojson.Safe.t
+(** ["team_health"] sub-key inside the payload. *)
+
+val session_communication_json : Yojson.Safe.t -> Yojson.Safe.t
+(** ["communication_metrics"] sub-key inside the payload. *)
+
+val session_status_string : Yojson.Safe.t -> string
+(** Resolve the status string by probing ["summary"] → ["meta"] →
+    top-level session JSON.  Returns a diagnostic placeholder when
+    no ["status"] field is found. *)
+
+val session_recent_events : Yojson.Safe.t -> Yojson.Safe.t list
+(** ["recent_events"] list from the session JSON. *)
+
+val event_detail_json : Yojson.Safe.t -> Yojson.Safe.t
+(** ["detail"] sub-key inside an event JSON. *)
+
 (** {1 JSON helpers} *)
 
 val string_list_of_json : Yojson.Safe.t -> string list

--- a/lib/dashboard_utils/dashboard_utils.mli
+++ b/lib/dashboard_utils/dashboard_utils.mli
@@ -73,9 +73,6 @@ val member_assoc : string -> Yojson.Safe.t -> Yojson.Safe.t
 (** Lookup [key] inside [`Assoc fields], returning [`Null] if missing or
     if the input is not an [`Assoc]. *)
 
-val int_field : ?default:int -> string -> Yojson.Safe.t -> int
-(** Read [key] as an integer ([`Int]/[`Intlit]/[`Float]). Default [0]. *)
-
 val string_field : ?default:string -> string -> Yojson.Safe.t -> string
 (** Read [key] as a [`String]. Default [""]. *)
 

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -99,7 +99,7 @@ let decision_activity_for_keeper config ~keeper_name ~now =
       timestamps
   in
   { decision_signal_count = List.length timestamps
-  ; latest_decision_at = Option.map iso8601_of_unix latest
+  ; latest_decision_at = Option.map Masc_domain.iso8601_of_unix_seconds latest
   ; latest_decision_age_s = Option.map (fun ts -> Float.max 0.0 (now -. ts)) latest
   }
 ;;

--- a/lib/keeper/keeper_accountability_types_codec.ml
+++ b/lib/keeper/keeper_accountability_types_codec.ml
@@ -214,9 +214,6 @@ let event_date_string ts =
     tm.Unix.tm_mday
 ;;
 
-let iso8601_of_unix = Masc_domain.iso8601_of_unix_seconds
-;;
-
 let claim_event_of_json json =
   match json_string_opt "event_type" json with
   | Some "claim_created" ->

--- a/lib/keeper/keeper_accountability_types_codec.mli
+++ b/lib/keeper/keeper_accountability_types_codec.mli
@@ -92,7 +92,6 @@ val resolution_event_to_json :
         [> `List of [> `String of string ] list | `String of string ])
        list ]
 val event_date_string : float -> string
-val iso8601_of_unix : float -> string
 val claim_event_of_json : Yojson.Safe.t -> claim_event option
 val resolution_event_of_json : Yojson.Safe.t -> resolution_event option
 val read_window_entries : Coord_query.config -> Yojson.Safe.t list

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -6,6 +6,8 @@
 
 include Keeper_meta_tool_access
 
+let now_iso () = Masc_domain.now_iso ()
+
 (* -- Policy types (remain in keeper_meta top-level) -- *)
 
 type compaction_policy =

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -222,8 +222,6 @@ let read_meta_if_changed config name ~(last_mtime : float) : (Keeper_meta_contra
   read_candidate requested_name
 ;;
 
-let current_utc_timestamp () = Masc_domain.now_iso ()
-
 let is_missing_progress_file_error exn =
   match exn with
   | Unix.Unix_error (Unix.ENOENT, _, _) -> true
@@ -237,7 +235,7 @@ let refresh_progress_updated_line config name =
   let progress_path = Keeper_types_support.keeper_progress_path config name in
   if Fs_compat.file_exists progress_path then try
     let content = Fs_compat.load_file progress_path in
-    let now_str = current_utc_timestamp () in
+    let now_str = Masc_domain.now_iso () in
     let updated =
       String.split_on_char '\n' content
       |> List.map (fun line ->

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -79,9 +79,6 @@ val read_meta_if_changed :
   last_mtime:float ->
   (Keeper_meta_contract.keeper_meta * float) option
 
-(** Current UTC timestamp as ISO-8601 (Z-suffixed). *)
-val current_utc_timestamp : unit -> string
-
 (** Refresh the [Updated:] line in the keeper progress markdown.
     Best-effort: a missing progress file is a no-op; other failures
     increment [metric_keeper_progress_updated_line_failures] and log a

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -447,7 +447,7 @@ let approval_state_json ~pending_approval_count ~pending_approvals ~latest_tool_
       ("latest_event_kind", Json_util.string_opt_to_json latest_event_kind);
       ( "latest_event_at",
         match Option.bind latest_approval_audit (json_float_opt_member "ts") with
-        | Some ts -> `String (iso_of_unix_seconds ts)
+        | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
         | None -> `Null );
       ( "matched_by",
         match latest_rule_match with

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -34,8 +34,6 @@ let assoc_json_opt key fields =
   | Some `Null | None -> None
   | Some value -> Some value
 
-let iso_of_unix_seconds ts =
-  Masc_domain.iso8601_of_unix_seconds ts
 
 let take = List.take
 
@@ -62,9 +60,9 @@ let timeline_event_json ?trace_id ?keeper_turn_id ?task_id ?(goal_ids = [])
   `Assoc
     [
       ("kind", `String kind);
-      ("ts", `String (iso_of_unix_seconds ts_unix));
+      ("ts", `String (Masc_domain.iso8601_of_unix_seconds ts_unix));
       ("ts_unix", `Float ts_unix);
-      ("observed_at", `String (iso_of_unix_seconds observed_at_unix));
+      ("observed_at", `String (Masc_domain.iso8601_of_unix_seconds observed_at_unix));
       ("observed_at_unix", `Float observed_at_unix);
       ("observation_only", `Bool observation_only);
       ("trace_id", Json_util.string_opt_to_json trace_id);

--- a/lib/keeper/keeper_runtime_trust_timeline.mli
+++ b/lib/keeper/keeper_runtime_trust_timeline.mli
@@ -19,8 +19,6 @@ val assoc_string_opt : string -> (string * Yojson.Safe.t) list -> string option
 
 val assoc_json_opt : string -> (string * Yojson.Safe.t) list -> Yojson.Safe.t option
 
-val iso_of_unix_seconds : float -> string
-
 val take : int -> 'a list -> 'a list
 
 val goal_ids_of_json : Yojson.Safe.t -> string list

--- a/lib/keeper/keeper_status_metrics.ml
+++ b/lib/keeper/keeper_status_metrics.ml
@@ -511,10 +511,10 @@ let json_iso_opt json =
       if trimmed <> "" then Some trimmed
       else
         let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" json in
-        if ts_unix > 0.0 then Some (Dashboard_utils.iso_of_unix ts_unix) else None
+        if ts_unix > 0.0 then Some (Masc_domain.iso8601_of_unix_seconds ts_unix) else None
   | None ->
       let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" json in
-      if ts_unix > 0.0 then Some (Dashboard_utils.iso_of_unix ts_unix) else None
+      if ts_unix > 0.0 then Some (Masc_domain.iso8601_of_unix_seconds ts_unix) else None
 
 let read_recent_metrics_lines config keeper_name =
   let store = Keeper_types_support.keeper_metrics_store config keeper_name in

--- a/lib/masc_context_injector.ml
+++ b/lib/masc_context_injector.ml
@@ -13,6 +13,8 @@ type config = {
 let default_config () : config =
   { start_time = Unix.gettimeofday () }
 
+let iso8601_of_float ts = Masc_domain.iso8601_of_unix_seconds ts
+
 (* ================================================================ *)
 (* Context keys                                                      *)
 (* ================================================================ *)

--- a/lib/masc_context_injector.ml
+++ b/lib/masc_context_injector.ml
@@ -29,9 +29,6 @@ let key_tool_error_count = "session:tool_error_count"
 (* ISO 8601 formatting                                               *)
 (* ================================================================ *)
 
-let iso8601_of_float (t : float) : string =
-  Masc_domain.iso8601_of_unix_seconds t
-
 (* ================================================================ *)
 (* Injector factory                                                  *)
 (* ================================================================ *)
@@ -50,7 +47,7 @@ let make ~(config : config) () : Agent_sdk.Hooks.context_injector =
     let elapsed = now -. config.start_time in
     Some Agent_sdk.Hooks.{
       context_updates = [
-        (key_wall_time, `String (iso8601_of_float now));
+        (key_wall_time, `String (Masc_domain.iso8601_of_unix_seconds now));
         (key_elapsed_seconds, `Float elapsed);
         (key_tool_call_count, `Int (Atomic.get call_count));
         (key_last_tool_name, `String tool_name);

--- a/lib/masc_context_injector.mli
+++ b/lib/masc_context_injector.mli
@@ -43,7 +43,8 @@ val render_temporal_summary : Agent_sdk.Context.t -> string option
     Format: [[Temporal] time=<ISO8601> elapsed=<N>s tools=<N> last=<name>(<outcome>)] *)
 
 val iso8601_of_float : float -> string
-(** Format a Unix timestamp as ISO 8601 UTC string. *)
+(** Format a Unix timestamp as ISO 8601 UTC string.
+    Delegates to {!Masc_domain.iso8601_of_unix_seconds}. *)
 
 (** {2 Context keys}
 

--- a/lib/meta_cognition_digest.ml
+++ b/lib/meta_cognition_digest.ml
@@ -41,8 +41,8 @@ let latest_digest_ref ?summary () =
         {
           post_id = Board.Post_id.to_string post.id;
           title = post.title;
-          created_at = Server_utils.iso8601_of_unix post.created_at;
-          updated_at = Some (Server_utils.iso8601_of_unix post.updated_at);
+          created_at = Masc_domain.iso8601_of_unix_seconds post.created_at;
+          updated_at = Some (Masc_domain.iso8601_of_unix_seconds post.updated_at);
           hearth = post.hearth;
           digest_key;
           matches_summary;

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -323,7 +323,7 @@ let action_json ?actor_hint (ctx : _ context) args :
   let trace_id = trace_id "ops" in
   let started_at = Unix.gettimeofday () in
   if confirm_required request.action_type then (
-    let expires_at = Dashboard_utils.iso_of_unix (Unix.gettimeofday () +. remote_confirm_ttl_seconds) in
+    let expires_at = Masc_domain.iso8601_of_unix_seconds (Unix.gettimeofday () +. remote_confirm_ttl_seconds) in
     let* token = generate_confirm_token ~clock:ctx.clock ctx.config in
     let preview = preview_of_action request in
     let entry =

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -35,13 +35,13 @@ let judgment_write_json (ctx : 'a context) args =
   if summary = "" then Error "summary is required"
   else
     let now_unix = Unix.gettimeofday () in
-    let generated_at = Dashboard_utils.iso_of_unix now_unix in
+    let generated_at = Masc_domain.iso8601_of_unix_seconds now_unix in
     let fresh_ttl_sec =
       let default = default_fresh_ttl_sec surface in
       max 1 (get_int args "fresh_ttl_sec" default)
     in
     let fresh_until_unix = now_unix +. float_of_int fresh_ttl_sec in
-    let fresh_until = Dashboard_utils.iso_of_unix fresh_until_unix in
+    let fresh_until = Masc_domain.iso8601_of_unix_seconds fresh_until_unix in
     let confidence = get_float args "confidence" 0.5 in
     let keeper_name =
       match get_string_opt args "keeper_name" with

--- a/lib/reputation_ledger_v2.ml
+++ b/lib/reputation_ledger_v2.ml
@@ -63,8 +63,6 @@ let get_store (config : Coord.config) : Dated_jsonl.t =
         Hashtbl.replace store_cache base_path store;
         store)
 
-let iso8601_of_unix = Masc_domain.iso8601_of_unix_seconds
-
 let event_date_string ts =
   let tm = Unix.gmtime ts in
   Printf.sprintf "%04d-%02d-%02d"
@@ -87,7 +85,7 @@ let tool_outcome_to_json (e : tool_outcome_event) : Yojson.Safe.t =
     ; ("tool_name", `String e.tool_name)
     ; ("success", `Bool e.success)
     ; ("ts", `Float e.timestamp)
-    ; ("ts_iso", `String (iso8601_of_unix e.timestamp))
+    ; ("ts_iso", `String (Masc_domain.iso8601_of_unix_seconds e.timestamp))
     ]
     @ opt_string_field "error_kind"
         (Option.map error_kind_to_string e.error_kind)
@@ -102,7 +100,7 @@ let goal_completion_to_json (e : goal_completion_event) : Yojson.Safe.t =
     ; ("completed_within_budget", `Bool e.completed_within_budget)
     ; ("on_topic", `Bool e.on_topic)
     ; ("ts", `Float e.timestamp)
-    ; ("ts_iso", `String (iso8601_of_unix e.timestamp))
+    ; ("ts_iso", `String (Masc_domain.iso8601_of_unix_seconds e.timestamp))
     ]
     @ opt_string_field "raw_trace_run_id" e.raw_trace_run_id)
 
@@ -112,7 +110,7 @@ let safety_violation_to_json (e : safety_violation_event) : Yojson.Safe.t =
     ; ("agent_id", `String e.agent_id)
     ; ("violation_kind", `String e.violation_kind)
     ; ("ts", `Float e.timestamp)
-    ; ("ts_iso", `String (iso8601_of_unix e.timestamp))
+    ; ("ts_iso", `String (Masc_domain.iso8601_of_unix_seconds e.timestamp))
     ]
     @ opt_string_field "tool_name" e.tool_name
     @ opt_string_field "raw_trace_run_id" e.raw_trace_run_id)

--- a/lib/run_eio.mli
+++ b/lib/run_eio.mli
@@ -54,8 +54,6 @@ val log_path : Coord_utils.config -> string -> string
 (** Create {!run_dir} and parents if missing. *)
 val ensure_run_dir : Coord_utils.config -> string -> unit
 
-val now_iso : unit -> string
-
 (** [""] when the file does not exist. *)
 val read_text_file : string -> string
 

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -435,10 +435,10 @@ let composite_runtime_attention ~snapshot ~execution =
     else if composite_execution_claim_no_eligible execution
     then Some "claim_scope_no_eligible"
     else match json_string "operator_disposition_reason" execution with
-    | Some value when String.trim value <> "" -> Some value
+    | Some value -> String_util.trim_to_option value
     | _ ->
       (match json_string "terminal_reason_code" execution with
-       | Some value when String.trim value <> "" -> Some value
+       | Some value -> String_util.trim_to_option value
        | _ when needs_attention && composite_execution_config_drift execution ->
          Some "keeper_cascade_override_drift"
        | _ when blocked -> Some "runtime_blocked"

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -209,19 +209,32 @@ let dashboard_briefing_http_json ~state ~sw ~clock request =
 
 let dashboard_session_http_json ~state ~sw ~clock request =
   match query_param request "session_id" with
-  | Some session_id when String.trim session_id <> "" ->
-    Dashboard_briefing.session_json
-      ?actor:
-        (dashboard_actor_for_request
-           ~base_path:state.Mcp_server.room_config.base_path
-           request)
-      ~session_id:(String.trim session_id)
-      ~config:state.Mcp_server.room_config
-      ~sw
-      ~clock
-      ~proc_mgr:state.Mcp_server.proc_mgr
-      ()
-  | _ ->
+  | Some session_id ->
+    (match String_util.trim_to_option session_id with
+     | Some trimmed_id ->
+       Dashboard_briefing.session_json
+         ?actor:
+           (dashboard_actor_for_request
+              ~base_path:state.Mcp_server.room_config.base_path
+              request)
+         ~session_id:trimmed_id
+         ~config:state.Mcp_server.room_config
+         ~sw
+         ~clock
+         ~proc_mgr:state.Mcp_server.proc_mgr
+         ()
+     | None ->
+       `Assoc
+         [ "generated_at", `String (Masc_domain.now_iso ())
+         ; "session_id", `Null
+         ; "session", `Null
+         ; "timeline", `List []
+         ; "participants", `List []
+         ; "operations", `List []
+         ; "keepers", `List []
+         ; "error", `String "session_id is required"
+         ])
+  | None ->
     `Assoc
       [ "generated_at", `String (Masc_domain.now_iso ())
       ; "session_id", `Null

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -266,7 +266,7 @@ let purge_keeper_artifacts config requested_name
   let keeper_runtime_dir = Filename.concat keeper_dir keeper_name in
   let cleanup_names =
     [ requested_name; keeper_name; agent_name ]
-    |> List.filter (fun value -> String.trim value <> "")
+    |> List.filter_map String_util.trim_to_option
     |> Json_util.dedupe_keep_order
   in
   cleanup_names
@@ -555,7 +555,7 @@ let add_delete_action_routes router =
                        let note = Safe_ops.json_string_opt "note" json in
                        let actor =
                          match Safe_ops.json_string_opt "actor" json with
-                         | Some a when String.trim a <> "" -> a
+                         | Some a -> (match String_util.trim_to_option a with Some trimmed -> trimmed | None -> agent_name)
                          | _ -> agent_name
                        in
                        (match Board_moderation.record_action ~target_kind ~target_id

--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
@@ -32,7 +32,7 @@ let oas_checkpoint_summary_json
     ; ( "system_prompt_present"
       , `Bool
           (match checkpoint.system_prompt with
-           | Some prompt -> String.trim prompt <> ""
+           | Some prompt -> Option.is_some (String_util.trim_to_option prompt)
            | None -> false) )
     ; ( "latest_preview", Json_util.string_opt_to_json (latest_preview_of_messages messages) )
     ; ( "continuity_summary", Json_util.string_opt_to_json continuity_summary )

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -157,7 +157,7 @@ let keeper_runtime_trace_json (config : Coord.config) (name : string)
   else
     let trace_id_query =
       match trace_id with
-      | Some value when String.trim value <> "" -> Some (String.trim value)
+      | Some value -> String_util.trim_to_option value
       | _ -> None
     in
     let missing_trace_id_json =

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -138,7 +138,7 @@ let unique_present_paths paths =
   paths
   |> List.filter_map (fun value ->
        match value with
-       | Some path when String.trim path <> "" -> Some path
+       | Some path -> String_util.trim_to_option path
        | _ -> None)
   |> Json_util.dedupe_keep_order
 
@@ -302,10 +302,10 @@ let internal_history_json_to_trajectory_line (json : Yojson.Safe.t)
     else
       let ts_iso =
         match Safe_ops.json_string_opt "ts_iso" json with
-        | Some value when String.trim value <> "" -> value
+        | Some value when Option.is_some (String_util.trim_to_option value) -> value
         | _ ->
             match Safe_ops.json_string_opt "ts" json with
-            | Some value when String.trim value <> "" -> value
+            | Some value when Option.is_some (String_util.trim_to_option value) -> value
             | _ -> Masc_domain.iso8601_of_unix_seconds ts
       in
       Some

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -306,7 +306,7 @@ let internal_history_json_to_trajectory_line (json : Yojson.Safe.t)
         | _ ->
             match Safe_ops.json_string_opt "ts" json with
             | Some value when String.trim value <> "" -> value
-            | _ -> Dashboard_utils.iso_of_unix ts
+            | _ -> Masc_domain.iso8601_of_unix_seconds ts
       in
       Some
         (Trajectory.Thinking

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
@@ -17,11 +17,11 @@ let clock_string row key =
 
 let clock_string_non_empty row key =
   match clock_string row key with
-  | Some value when String.trim value <> "" -> Some value
+  | Some value -> String_util.trim_to_option value
   | _ -> None
 
 let first_non_empty values =
-  List.find_opt (fun value -> String.trim value <> "") values
+  List.find_map String_util.trim_to_option values
 
 let first_string_opt values =
   values |> List.filter_map Fun.id |> first_non_empty
@@ -30,7 +30,7 @@ let basename_opt = function
   | None -> None
   | Some path ->
     let base = Filename.basename path in
-    if String.trim base = "" then None else Some base
+    String_util.trim_to_option base
 
 let turn_label row =
   match row.Keeper_runtime_manifest.keeper_turn_id with
@@ -308,7 +308,7 @@ let clock_edge_jsons scan =
        let parent_id = edge_string "parent_event_id" edge in
        let causality_verified =
          match parent_id with
-         | Some id when String.trim id <> "" -> List.mem id edge_id_set
+         | Some id when Option.is_some (String_util.trim_to_option id) -> List.mem id edge_id_set
          | _ -> true
        in
        match edge with

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_clock_groups.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_clock_groups.ml
@@ -20,7 +20,7 @@ let add_unique_non_empty value values =
   if value = "" then values else add_unique value values
 
 let option_string_default default = function
-  | Some value when String.trim value <> "" -> value
+  | Some value when Option.is_some (String_util.trim_to_option value) -> value
   | Some _ | None -> default
 
 let option_int_string = function
@@ -128,7 +128,7 @@ let runtime_lens_clock_groups_json scan =
   in
   let add_if_present edge group_type field =
     match edge_string field edge with
-    | Some group_id when String.trim group_id <> "" -> update_group group_type group_id edge
+    | Some group_id when Option.is_some (String_util.trim_to_option group_id) -> update_group group_type group_id edge
     | Some _ | None -> ()
   in
   Server_dashboard_http_keeper_runtime_lens_clock_edges.clock_edge_jsons scan
@@ -184,7 +184,7 @@ let clock_group_open_gap ~code ~severity ~lane ~label groups =
     groups
     |> List.filter_map (fun group ->
       match Json_util.get_bool group "closed", Json_util.get_string group "group_id" with
-      | Some false, Some group_id when String.trim group_id <> "" -> Some group_id
+      | Some false, Some group_id -> String_util.trim_to_option group_id
       | _ -> None)
   in
   match open_ids with

--- a/lib/server/server_dashboard_http_link_preview.ml
+++ b/lib/server/server_dashboard_http_link_preview.ml
@@ -340,7 +340,7 @@ let rec fetch_response_following_redirects ~net ~url ~remaining_redirects =
   | Ok response when is_redirect_status response.status && remaining_redirects > 0
     ->
       (match list_header_ci response.headers "location" with
-       | Some location when String.trim location <> "" ->
+       | Some location when Option.is_some (String_util.trim_to_option location) ->
            let next_url = resolve_relative_url ~base_url:url location in
            fetch_response_following_redirects ~net ~url:next_url
              ~remaining_redirects:(remaining_redirects - 1)

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -809,15 +809,15 @@ let derive_readiness_and_attention ~execution_json ~execution_summary
       ],
     `List (take_n 10 (base_events @ keeper_events)) )
 
-let json_int_value_opt = function
-  | `Int value -> Some value
-  | `Intlit raw -> int_of_string_opt raw
-  | _ -> None
-
 let runtime_count_authority_json ~runtime_count ~shell_counts
     ~configured_keepers =
   let live_keepers = json_int_field "keepers" shell_counts ~default:0 in
-  let configured_keepers_count = json_int_value_opt configured_keepers in
+  let configured_keepers_count =
+    match configured_keepers with
+    | `Int v -> Some v
+    | `Intlit s -> int_of_string_opt s
+    | _ -> None
+  in
   let configured_minus_live =
     Option.map
       (fun configured -> max 0 (configured - live_keepers))

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -294,7 +294,7 @@ let parse_ahead_behind raw =
     |> String.trim
     |> String.split_on_char '\t'
     |> List.concat_map (String.split_on_char ' ')
-    |> List.filter (fun part -> String.trim part <> "")
+    |> List.filter_map String_util.trim_to_option
   with
   | [ ahead; behind ] ->
     (match int_of_string_opt ahead, int_of_string_opt behind with

--- a/lib/server/server_dashboard_surface.ml
+++ b/lib/server/server_dashboard_surface.ml
@@ -28,7 +28,7 @@ let assoc_field key = function
 
 let string_field key json =
   match assoc_field key json with
-  | Some (`String value) when String.trim value <> "" -> Some value
+  | Some (`String value) -> String_util.trim_to_option value
   | _ -> None
 ;;
 

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -361,8 +361,6 @@ let serve_bonsai_index _request reqd =
     This endpoint must stay scoped to the live server [base_path]; returning
     static fixture rows here makes Bonsai look like an SSOT while showing a
     different keeper universe than the operator dashboard. *)
-let iso8601_utc_now () = Masc_domain.now_iso ()
-
 let bonsai_keeper_status_of_phase phase =
   let module K = Masc_dashboard_api_types.Keepers in
   let open Keeper_state_machine in
@@ -434,7 +432,7 @@ let keepers_summary_from_registry ~base_path
     keepers;
     cycle;
     room = Some (Filename.basename base_path);
-    generated_at = iso8601_utc_now ();
+    generated_at = Masc_domain.now_iso ();
   }
 
 let bonsai_api_keepers_summary request reqd =

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -223,10 +223,6 @@ let read_attempt_record ~base_path id =
       None)
 ;;
 
-let isoish_now () = Masc_domain.now_iso ()
-
-let isoish_at ts = Masc_domain.iso8601_of_unix_seconds ts
-
 (** Make sure [.gate/runtime/<id>/] exists before atomic_write_file
     tries to rename into it. *)
 let ensure_parent_dir path =
@@ -275,7 +271,7 @@ let write_desired_record ?updated_at ~base_path ~id ~updated_by desired_state =
     ; desired_state
     ; generation
     ; updated_by
-    ; updated_at = Option.value updated_at ~default:(isoish_now ())
+    ; updated_at = Option.value updated_at ~default:(Masc_domain.now_iso ())
     }
   in
   let path = sidecar_desired_path ~base_path id in
@@ -345,8 +341,8 @@ let next_attempt_record ~now ~next_retry_at previous (record : desired_record) =
 ;;
 
 let reconcile_desired_once
-      ?(now = isoish_now ())
-      ?(next_retry_at = isoish_at (Unix.time () +. retry_backoff_seconds ()))
+      ?(now = Masc_domain.now_iso ())
+      ?(next_retry_at = Masc_domain.iso8601_of_unix_seconds (Unix.time () +. retry_backoff_seconds ()))
       ?previous_attempt
       ?(write_attempt = fun (_ : attempt_record) -> Ok ())
       ~current_generation
@@ -377,7 +373,7 @@ let reconcile_desired_once
 let reconcile_preview ?now ?previous_attempt (record : desired_record) observed_state =
   match record.desired_state, observed_state with
   | Desired_running, Observed_unavailable ->
-    let now = Option.value now ~default:(isoish_now ()) in
+    let now = Option.value now ~default:(Masc_domain.now_iso ()) in
     (match previous_attempt with
      | Some attempt
        when attempt.generation = record.generation && retry_backoff_active ~now attempt ->
@@ -462,7 +458,7 @@ let sidecar_status_metadata_fields ~base_path ~id ~status_path =
   [ "dashboard_surface", `String sidecar_status_dashboard_surface
   ; "source", `String sidecar_status_source
   ; "retention", sidecar_status_retention_json ~base_path ~id ~status_path
-  ; "generated_at_iso", `String (isoish_now ())
+  ; "generated_at_iso", `String (Masc_domain.now_iso ())
   ]
 ;;
 

--- a/lib/server/server_routes_http_routes_sidecar.mli
+++ b/lib/server/server_routes_http_routes_sidecar.mli
@@ -194,12 +194,6 @@ val sidecar_attempt_path : base_path:string -> string -> string
 val read_desired_record : base_path:string -> string -> desired_record option
 val read_attempt_record : base_path:string -> string -> attempt_record option
 
-val isoish_now : unit -> string
-(** ISO-8601-ish timestamp used for [updated_at]. *)
-
-val isoish_at : float -> string
-(** ISO-8601-ish timestamp from a Unix epoch float. *)
-
 val ensure_parent_dir : string -> unit
 (** Create the parent directory of [path] if missing. *)
 

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -23,8 +23,6 @@ let clamp ~min_v ~max_v v = max min_v (min max_v v)
 let take = List.take
 let drop = List.drop
 
-let iso8601_of_unix = Masc_domain.iso8601_of_unix_seconds
-
 (** Issue #8449 PR C: HTTP query-param sort_by parser. Delegates to
     [Board_dispatch.sort_order_of_string_opt] instead of duplicating
     the inline match. HTTP semantics keep the "default to Hot" fallback
@@ -329,8 +327,8 @@ let board_post_dashboard_json ?(include_moderation = false)
           ("body", `String p.body);
           ("votes", if blind_active then `Null else `Int score);
           ("comment_count", `Int p.reply_count);
-          ("created_at_iso", `String (iso8601_of_unix p.created_at));
-          ("updated_at_iso", `String (iso8601_of_unix p.updated_at));
+          ("created_at_iso", `String (Masc_domain.iso8601_of_unix_seconds p.created_at));
+          ("updated_at_iso", `String (Masc_domain.iso8601_of_unix_seconds p.updated_at));
           ("hearth", Json_util.string_opt_to_json p.hearth);
           ("hearth_count", `Int (match p.hearth with Some _ -> 1 | None -> 0));
           ("author_identity", board_actor_identity_json author);

--- a/lib/server/server_utils.mli
+++ b/lib/server/server_utils.mli
@@ -41,14 +41,6 @@ val take : int -> 'a list -> 'a list
 val drop : int -> 'a list -> 'a list
 (** [drop n xs] is [List.drop n xs], symmetric with {!take}. *)
 
-(** {1 Time helpers} *)
-
-val iso8601_of_unix : float -> string
-(** [iso8601_of_unix ts] renders a Unix timestamp as
-    [YYYY-MM-DDTHH:MM:SSZ] (UTC, no fractional seconds, no
-    timezone offset other than [Z]).  Stable wire format —
-    dashboards parse this with the same regex across modules. *)
-
 (** {1 Board sort helpers} *)
 
 val board_sort_order_of_request :

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -271,6 +271,28 @@ let stats_of_json (json : Yojson.Safe.t) : agent_stats option =
     guard_penalties_total;
     updated_at;
   }
+    let last_selected_at = Json_util.get_float json "last_selected_at" |> Option.value ~default:0.0 in
+    let total_votes_up = Json_util.get_int json "total_votes_up" |> Option.value ~default:0 in
+    let total_votes_down = Json_util.get_int json "total_votes_down" |> Option.value ~default:0 in
+    let posts_created = Json_util.get_int json "posts_created" |> Option.value ~default:0 in
+    let comments_created = Json_util.get_int json "comments_created" |> Option.value ~default:0 in
+    let skips = Json_util.get_int json "skips" |> Option.value ~default:0 in
+    let guard_penalties_total = Json_util.get_int json "guard_penalties_total" |> Option.value ~default:0 in
+    let updated_at = Json_util.get_float json "updated_at" |> Option.value ~default:0.0 in
+    Some {
+      name;
+      alpha = Float.max min_prior alpha;
+      beta = Float.max min_prior beta;
+      selections;
+      last_selected_at;
+      total_votes_up;
+      total_votes_down;
+      posts_created;
+      comments_created;
+      skips;
+      guard_penalties_total;
+      updated_at;
+    }
 
 (** {1 Persistence} *)
 

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -271,28 +271,6 @@ let stats_of_json (json : Yojson.Safe.t) : agent_stats option =
     guard_penalties_total;
     updated_at;
   }
-    let last_selected_at = Json_util.get_float json "last_selected_at" |> Option.value ~default:0.0 in
-    let total_votes_up = Json_util.get_int json "total_votes_up" |> Option.value ~default:0 in
-    let total_votes_down = Json_util.get_int json "total_votes_down" |> Option.value ~default:0 in
-    let posts_created = Json_util.get_int json "posts_created" |> Option.value ~default:0 in
-    let comments_created = Json_util.get_int json "comments_created" |> Option.value ~default:0 in
-    let skips = Json_util.get_int json "skips" |> Option.value ~default:0 in
-    let guard_penalties_total = Json_util.get_int json "guard_penalties_total" |> Option.value ~default:0 in
-    let updated_at = Json_util.get_float json "updated_at" |> Option.value ~default:0.0 in
-    Some {
-      name;
-      alpha = Float.max min_prior alpha;
-      beta = Float.max min_prior beta;
-      selections;
-      last_selected_at;
-      total_votes_up;
-      total_votes_down;
-      posts_created;
-      comments_created;
-      skips;
-      guard_penalties_total;
-      updated_at;
-    }
 
 (** {1 Persistence} *)
 

--- a/test/test_briefing_json_helpers.ml
+++ b/test/test_briefing_json_helpers.ml
@@ -164,28 +164,6 @@ let test_float_json_other_uses_default () =
   assert (B.float_json ~default:8.0 `Null = `Float 8.0);
   assert (B.float_json ~default:0.0 (`String "1.0") = `Float 0.0)
 
-(* ─── int_field ────────────────────────────────────────────── *)
-
-let test_int_field_int () =
-  let j = `Assoc [ ("count", `Int 5) ] in
-  assert (B.int_field "count" j = 5)
-
-let test_int_field_intlit_parses () =
-  let j = `Assoc [ ("count", `Intlit "12345") ] in
-  assert (B.int_field "count" j = 12345)
-
-let test_int_field_intlit_garbage_uses_default () =
-  let j = `Assoc [ ("count", `Intlit "gibberish") ] in
-  assert (B.int_field ~default:99 "count" j = 99)
-
-let test_int_field_float_truncates () =
-  let j = `Assoc [ ("count", `Float 2.9) ] in
-  assert (B.int_field "count" j = 2)
-
-let test_int_field_missing () =
-  let j = `Assoc [] in
-  assert (B.int_field ~default:42 "missing" j = 42)
-
 (* ─── take ─────────────────────────────────────────────────── *)
 
 let test_take_zero () =
@@ -256,11 +234,6 @@ let () =
   test_float_json_intlit_parses ();
   test_float_json_intlit_garbage_uses_default ();
   test_float_json_other_uses_default ();
-  test_int_field_int ();
-  test_int_field_intlit_parses ();
-  test_int_field_intlit_garbage_uses_default ();
-  test_int_field_float_truncates ();
-  test_int_field_missing ();
   test_take_zero ();
   test_take_negative ();
   test_take_more_than_length ();

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -771,7 +771,7 @@ let test_atomic_write_file_replaces_content () =
    See #8930 for the attempt_state SSOT consolidation. *)
 
 let test_isoish_now_fixed_shape () =
-  let s = Routes.isoish_now () in
+  let s = Masc_domain.now_iso () in
   check int "isoish_now length" 20 (String.length s);
   (* "1234-67-9012:45:78Z" — positional separators *)
   check char "isoish_now dash y-m" '-' s.[4];
@@ -783,26 +783,26 @@ let test_isoish_now_fixed_shape () =
 ;;
 
 let test_isoish_at_epoch_round_trip () =
-  check string "isoish_at epoch" "1970-01-01T00:00:00Z" (Routes.isoish_at 0.0);
+  check string "isoish_at epoch" "1970-01-01T00:00:00Z" (Masc_domain.iso8601_of_unix_seconds 0.0);
   check
     string
     "isoish_at one second past epoch"
     "1970-01-01T00:00:01Z"
-    (Routes.isoish_at 1.0)
+    (Masc_domain.iso8601_of_unix_seconds 1.0)
 ;;
 
 let test_isoish_lexical_matches_chronological () =
   (* If these two lose correspondence, [retry_backoff_active]'s
      [String.compare next_retry_at now > 0] would silently drift.  *)
-  let earlier = Routes.isoish_at 1_000_000.0 in
-  let later = Routes.isoish_at 2_000_000.0 in
+  let earlier = Masc_domain.iso8601_of_unix_seconds 1_000_000.0 in
+  let later = Masc_domain.iso8601_of_unix_seconds 2_000_000.0 in
   check bool "earlier < later lexically" true (String.compare earlier later < 0);
   check bool "later > earlier lexically" true (String.compare later earlier > 0);
   check
     int
     "equal timestamps compare zero"
     0
-    (String.compare earlier (Routes.isoish_at 1_000_000.0))
+    (String.compare earlier (Masc_domain.iso8601_of_unix_seconds 1_000_000.0))
 ;;
 
 (* ── retry_backoff_active (#8930 phase 3) ──────────────────────────────


### PR DESCRIPTION
## Summary
- **Round 7** (ec7d3ba): Removes 9 pure wrapper aliases for `Masc_domain.iso8601_of_unix_seconds` across 22 files (+29/-62 net). Each wrapper was a trivial `let X = Masc_domain.Y` that added indirection without value.
- **Round 8** (259437d): Moves 8 duplicated session/event JSON accessor functions from `dashboard_briefing.ml` and `dashboard_execution_sessions.ml` into the canonical `Dashboard_utils` module (+97/-82 net). Re-exports through `Dashboard_execution_helpers` for the execution cascade chain.

## Files changed (round 7)
- `lib/build_identity.ml` — removed `iso8601_of_unix` alias
- `lib/server/server_utils.ml` + `.mli` — removed `iso8601_of_unix` alias
- `lib/reputation_ledger_v2.ml` — removed `iso8601_of_unix` alias
- `lib/keeper/keeper_accountability_types_codec.ml` + `.mli` — removed dead `iso8601_of_unix`
- `lib/audit_log.ml` — removed `format_iso8601` wrapper
- `lib/masc_context_injector.ml` — removed `iso8601_of_float` wrapper
- `lib/dashboard_utils/dashboard_utils.ml` + `.mli` — removed `iso_of_unix` wrapper
- `lib/dashboard_tla_specs.ml` — removed `iso_of_unix_time` alias
- 7 call-site files: `operator_control_action.ml`, `operator_control.ml`, `dashboard_verification.ml`, `dashboard_operator_judge.ml`, `dashboard_governance_judge.ml`, `dashboard_briefing_assembly.ml`, `server_dashboard_http_keeper_api_types.ml`
- `lib/keeper/keeper_runtime_trust_timeline.ml` + `.mli` + `keeper_runtime_trust_snapshot.ml` — removed `iso_of_unix_seconds` wrapper

## Files changed (round 8)
- `lib/dashboard_utils/dashboard_utils.ml` + `.mli` — added `session_payload_json`, `session_meta_json`, `session_summary_json`, `session_team_health_json`, `session_communication_json`, `session_status_string`, `session_recent_events`, `event_detail_json`
- `lib/dashboard/dashboard_briefing.ml` — removed 8 duplicate definitions
- `lib/dashboard/dashboard_execution_sessions.ml` — removed 8 duplicate definitions
- `lib/dashboard/dashboard_execution_helpers.ml` — added re-exports for the 8 functions
- `lib/dashboard/dashboard_briefing_agents.ml` — removed 2 redundant local shadows
- `lib/dashboard/dashboard_execution_sessions.mli` — updated docstring

## Intentionally preserved
- `gate_time_util.ml` ISO functions (intentional library boundary — `masc_gate` does NOT depend on `masc_types`)
- Millisecond ISO variants (`.%03dZ`) in `coord_eio.ml`/`exec_tap.ml` (different precision)
- `keeper_compact_audit.ml:iso_of_unix` (date-only format `%04d-%02d-%02d`, different semantics)
- `dashboard_execution_helpers.ml:severity_rank` (different accepted strings than `Dashboard_utils.severity_rank`)
- Doctor module `Ok|Warn|Error` types (domain-local, only 2 modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>