### PR TITLE
fix(run_eio,keeper_meta_contract): restore now_iso definitions

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -681,7 +681,9 @@ let () =
     ]
 ;;
 
-(* -- Updater helpers for nested record updates -- *)
+(* -- Updater helpers -- *)
+
+let now_iso () = Masc_domain.now_iso ()
 
 let map_runtime (f : agent_runtime_state -> agent_runtime_state) (m : keeper_meta)
   : keeper_meta

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -26,6 +26,8 @@ type log_entry = {
   note: string;
 }
 
+let now_iso () = Masc_domain.now_iso ()
+
 let run_record_to_json (r : run_record) : Yojson.Safe.t =
   `Assoc [
     ("task_id", `String r.task_id);


### PR DESCRIPTION
## Summary
- Commit `0cb301846a` removed `let now_iso` from `run_eio.ml` and `keeper_meta_contract.ml` but kept `val now_iso` in both `.mli` files
- Main builds pass due to stale `.cmi` cache in `_build`; all worktrees hit the mismatch and fail to build
- Restores the missing re-exports of `Masc_domain.now_iso`

## Test plan
- [x] `dune build --root .` passes
- [ ] All worktrees can build after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)