### PR TITLE
refactor(runtime): B2+B3 — gut cascade consumers + remove cascade_ref

### DIFF
--- a/lib/cascade/cascade_routes_resolve.ml
+++ b/lib/cascade/cascade_routes_resolve.ml
@@ -10,32 +10,5 @@
     this module.  Callers that only need the configured route target
     without catalog cross-check use {!Cascade_routes} directly. *)
 
-let cascade_name_for_use ?config_path use =
-  let route_key = Cascade_routes.logical_use_key use in
-  let route_target =
-    Cascade_routes.configured_route_bindings ?config_path ()
-    |> List.find_map (fun (key, target) ->
-           if String.equal key route_key then Some target else None)
-  in
-  let catalog_names =
-    match Cascade_catalog_runtime.known_profile_names () with
-    | Ok names -> names
-    | Error _ -> []
-  in
-  let fallback =
-    Cascade_routes.fallback_name_for_catalog use ~catalog:catalog_names
-  in
-  match route_target with
-  | Some target when catalog_names = [] ->
-      Cascade_metrics.on_route_resolve_fallback ~reason:"catalog_unvalidated";
-      Cascade_routes.warn_unvalidated_route_target_once ~route_key ~target
-        ~fallback;
-      target
-  | Some target when List.mem target catalog_names -> target
-  | Some target ->
-      Cascade_metrics.on_route_resolve_fallback
-        ~reason:"target_not_in_catalog";
-      Cascade_routes.warn_invalid_route_target_once ~route_key ~target
-        ~fallback;
-      fallback
-  | None -> fallback
+let cascade_name_for_use ?config_path:_ _use =
+  Runtime.get_default_runtime_id ()

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -640,10 +640,6 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
               ("models", `List []);
               ("models_resolved", `List []);
               ("primary_model", `Null);
-              ( "cascade_ref",
-                (match m.cascade_ref with
-                 | Some ref_ -> Cascade_ref.cascade_ref_to_json ref_
-                 | None -> `Null) );
               ("active_model", `Null);
               ("next_model_hint", `Null);
               ("sandbox_profile",

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -260,10 +260,6 @@ let keeper_config_json (config : Coord.config) (name : string)
           ("selected_cascade_name", `String cascade_name);
           ( "selected_cascade_canonical",
             selected_cascade_canonical_json );
-          ( "cascade_ref",
-            (match m.cascade_ref with
-             | Some ref_ -> Cascade_ref.cascade_ref_to_json ref_
-             | None -> `Null) );
           ("models", `List []);
           ("active_model", `Null);
           ("active_model_label", `Null);

--- a/lib/dashboard/dashboard_http_keeper_trust.ml
+++ b/lib/dashboard/dashboard_http_keeper_trust.ml
@@ -25,21 +25,15 @@ let keeper_trust_json ?(include_receipt = false)
     | None -> `Assoc [ ("profile", `Null); ("derived", `Bool false) ]
   in
   let cascade_json =
-    let cascade_ref_json =
-      match meta.cascade_ref with
-      | Some ref_ -> Cascade_ref.cascade_ref_to_json ref_
-      | None -> `Null
-    in
     match latest_receipt with
     | Some receipt -> (
         match Json_util.assoc_member_opt "cascade" receipt with
-        | Some (`Assoc fields) -> `Assoc (("cascade_ref", cascade_ref_json) :: fields)
-        | other -> Option.value ~default:`Null other)
+        | Some json -> json
+        | None -> `Null)
     | None ->
         `Assoc
           [
             ("name", `String (Keeper_meta_contract.cascade_name_of_meta meta));
-            ("cascade_ref", cascade_ref_json);
             ("selected_model", `Null);
             ("attempt_count", `Int 0);
             ("fallback_applied", `Bool false);

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -16,20 +16,15 @@ let two_days_seconds_int = Masc_time_constants.day_int * 2
     naming the "1 day" intent at the call site. *)
 let one_day_seconds_int = Masc_time_constants.day_int
 
-let default_cascade_name () =
-  try cascade_name_for_use Keeper_turn with _ -> "tool_strict"
+let default_cascade_name () = Runtime.get_default_runtime_id ()
 
-let phase_recovery_cascade_name =
-  try cascade_name_for_use Phase_recovery with _ -> "tool_strict"
+let phase_recovery_cascade_name = Runtime.get_default_runtime_id ()
 
-let phase_buffer_cascade_name =
-  try cascade_name_for_use Phase_buffer with _ -> "tool_strict"
+let phase_buffer_cascade_name = Runtime.get_default_runtime_id ()
 
-let phase_routing_cascade_names =
-  [ try cascade_name_for_use Routing with _ -> "tool_strict" ]
+let phase_routing_cascade_names = [ Runtime.get_default_runtime_id () ]
 
-let tool_required_cascade_name =
-  try cascade_name_for_use Tool_required with _ -> "tool_strict"
+let tool_required_cascade_name = Runtime.get_default_runtime_id ()
 
 (** Minimum context window (tokens) for any keeper turn.
     64k-class local models are valid keeper backends; do not clamp them upward

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -553,7 +553,6 @@ type keeper_meta =
   ; long_goal : string
   ; social_model : string
   ; models : string list
-  ; cascade_ref : Cascade_ref.cascade_ref option
   ; will : string
   ; needs : string
   ; desires : string
@@ -613,14 +612,6 @@ let cascade_name_of_meta (_m : keeper_meta) : string =
   Runtime.get_default_runtime_id ()
 ;;
 
-let set_cascade_name (name : string) (m : keeper_meta) : keeper_meta =
-  match Cascade_name.of_string name with
-  | Ok group ->
-    { m with cascade_ref = Some Cascade_ref.{ group; item = None } }
-  | Error (`Invalid_prefix | `Empty) ->
-    (* Non-canonical cascade name — keep existing cascade_ref unchanged *)
-    m
-;;
 
 let proactive_cycle_outcome_to_string = function
   | Proactive_never_started -> "never_started"

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -609,10 +609,8 @@ type keeper_meta =
   ; meta_version : int
   }
 
-let cascade_name_of_meta (m : keeper_meta) : string =
-  match m.cascade_ref with
-  | Some ref_ -> Cascade_name.to_string ref_.Cascade_ref.group
-  | _ -> (Keeper_config.default_cascade_name ())
+let cascade_name_of_meta (_m : keeper_meta) : string =
+  Runtime.get_default_runtime_id ()
 ;;
 
 let set_cascade_name (name : string) (m : keeper_meta) : keeper_meta =

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -326,7 +326,6 @@ type keeper_meta = {
   long_goal : string;
   social_model : string;
   models : string list;
-  cascade_ref : Cascade_ref.cascade_ref option;
   will : string;
   needs : string;
   desires : string;
@@ -382,23 +381,8 @@ type keeper_meta = {
 (** {1 Cascade name derivation} *)
 
 val cascade_name_of_meta : keeper_meta -> string
-(** [cascade_name_of_meta m] is the canonical cascade name for the keeper.
-
-    Resolution order:
-    1. If [m.cascade_ref] is [Some] and [.group] is non-empty, return [.group].
-    2. Otherwise return the current keeper default route. *)
-
-val set_cascade_name : string -> keeper_meta -> keeper_meta
-(** [set_cascade_name name m] returns a meta where [cascade_ref] is pinned
-    to [name]. The cascade_ref takes the
-    form [{ group = name; item = None }] so the group's traversal
-    strategy decides item selection at routing time.
-
-    Use this helper for every write that intends to change the keeper's
-    cascade routing target. For record-literal initialization (full
-    keeper_meta construction) callers must still set [cascade_ref]
-    explicitly; this helper applies only to update-style writes
-    ([{ m with ... }]). *)
+(** [cascade_name_of_meta m] returns the default runtime id.
+    Ignores [m] — kept for signature compatibility. *)
 
 (** {1 Outcome <-> string} *)
 

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -91,10 +91,6 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
         | Some uid -> Keeper_id.uid_to_yojson uid
         | None -> `Null )
     ; "oas_env", `Assoc (List.map (fun (k, v) -> k, `String v) m.oas_env)
-    ; "cascade_ref",
-      (match m.cascade_ref with
-       | Some ref_ -> Cascade_ref.cascade_ref_to_json ref_
-       | None -> `Null)
     ; "meta_version", `Int m.meta_version
     ]
 ;;
@@ -162,7 +158,6 @@ let fallback_canonical_keeper_meta_key_names =
   ; "current_task_id"
   ; "keeper_id"
   ; "oas_env"
-  ; "cascade_ref"
   ; "meta_version"
   ]
 ;;

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -19,7 +19,6 @@ type parsed_keeper_identity =
   ; pk_long_goal : string
   ; pk_social_model : string
   ; pk_cascade_name : string
-  ; pk_cascade_ref : Cascade_ref.cascade_ref option
   ; pk_will : string
   ; pk_needs : string
   ; pk_desires : string
@@ -136,13 +135,6 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
       ; pk_long_goal
       ; pk_social_model
       ; pk_cascade_name
-      ; pk_cascade_ref =
-        (match Json_util.assoc_member_opt "cascade_ref" json with
-         | Some `Null | Some (`Assoc []) | None -> None
-         | Some ref_json ->
-             (match Cascade_ref.cascade_ref_of_json ref_json with
-              | Some ref -> Some ref
-              | None -> Cascade_ref.cascade_ref_of_string pk_cascade_name))
       ; pk_will
       ; pk_needs
       ; pk_desires
@@ -587,30 +579,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                  not (validate_name (Keeper_id.Trace_id.to_string identity.pk_trace_id))
                then Error "invalid keeper meta (bad trace_id)"
                else
-                 let cascade_ref_result =
-                   match identity.pk_cascade_ref with
-                   | Some _ as ref_ -> Ok ref_
-                   | None ->
-                       let raw_cascade_name =
-                         String.trim identity.pk_cascade_name
-                       in
-                       if String.equal raw_cascade_name ""
-                       then Ok None
-                       else
-                         match Cascade_name.of_string raw_cascade_name with
-                         | Ok cn -> Ok (Some Cascade_ref.{ group = cn; item = None })
-                         | Error `Empty -> Ok None
-                         | Error `Invalid_prefix ->
-                             Error
-                               (Printf.sprintf
-                                  "invalid keeper meta cascade_name %S: expected \
-                                   canonical cascade prefix route."
-                                  identity.pk_cascade_name)
-                 in
-                 (match cascade_ref_result with
-                  | Error _ as e -> e
-                  | Ok cascade_ref ->
-                    Ok
+                 Ok
                    { id = None
                    ; name = identity.pk_name
                    ; agent_name =
@@ -622,7 +591,6 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                    ; mid_goal = identity.pk_mid_goal
                    ; long_goal = identity.pk_long_goal
                    ; social_model = identity.pk_social_model
-                   ; cascade_ref
                    ; models = []
                    ; will = identity.pk_will
                    ; needs = identity.pk_needs
@@ -687,7 +655,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                        (match Safe_ops.json_int_opt "meta_version" json with
                         | Some v -> v
                         | None -> 0)
-                   })))))
+                   }))))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -20,7 +20,6 @@ type parsed_keeper_identity =
   ; pk_long_goal : string
   ; pk_social_model : string
   ; pk_cascade_name : string
-  ; pk_cascade_ref : Cascade_ref.cascade_ref option
   ; pk_will : string
   ; pk_needs : string
   ; pk_desires : string

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -14,7 +14,7 @@
    Keeper_meta_json -> Keeper_meta_json_scrub -> Keeper_meta_json. *)
 let config_field_names =
   [ "goal"; "short_goal"; "mid_goal"; "long_goal"
-  ; "social_model"; "cascade_name"; "cascade_ref"
+  ; "social_model"; "cascade_name"
   ; "will"; "needs"; "desires"; "instructions"
   ; "sandbox_profile"; "sandbox_image"; "network_mode"; "allowed_paths"
   ; "tool_access"; "tool_preset_source"; "tool_denylist"

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -470,17 +470,6 @@ let ensure_keeper_meta config name =
         room_signal_prompt_enabled = target_room_signal_prompt_enabled;
         tool_denylist = target_denylist;
         social_model = target_social_model;
-        (* RFC-0041: cascade_ref is the SSOT after step 4 (B7). When
-           cascade_changed flips, materialize a fresh cascade_ref;
-           otherwise preserve [meta.cascade_ref] verbatim so an unrelated
-           reconcile never canonicalizes routing silently. *)
-        cascade_ref =
-          if cascade_changed then
-            Some Cascade_ref.{
-              group = resolved_target_cascade_name;
-              item = None;
-            }
-          else meta.cascade_ref;
         goal = target_goal;
         short_goal = target_short_goal;
         mid_goal = target_mid_goal;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -431,13 +431,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         long_goal;
 
         social_model;
-        cascade_ref =
-          Some Cascade_ref.{
-            group = Cascade_name.of_string_exn selected_cascade_name;
-            item = None;
-          };
-        (* RFC-0041 (post-step-4): cascade_ref is the SSOT; the legacy
-           cascade_name field was removed from keeper_meta. *)
         models = [];
         will;
         needs;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -271,23 +271,6 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     short_goal;
     mid_goal;
     long_goal;
-    cascade_ref =
-      (* RFC-0041 (post-step-4): cascade_ref is the SSOT.
-         An explicit tool arg is an operator reconfiguration request.
-         Otherwise TOML cascade_name takes precedence over runtime when
-         present; otherwise preserve the existing keeper's cascade_ref so
-         dashboard drift remains visible.  See #6747. *)
-      (let group =
-         (* WORKAROUND (#19327 follow-up): cascade_name→model field rename. *)
-         match p.cascade_name_opt, p.profile_defaults.model with
-         | Some name, _ -> name
-         | None, Some name -> name
-         | None, None ->
-           let prev = cascade_name_of_meta old in
-           if String.trim prev <> "" then prev
-           else (Keeper_config.default_cascade_name ())
-       in
-       Some Cascade_ref.{ group = Cascade_name.of_string_exn group; item = None });
     will = new_will;
     needs = new_needs;
     desires = new_desires;

--- a/lib/keeper/keeper_unified_turn_cascade_resolution.ml
+++ b/lib/keeper/keeper_unified_turn_cascade_resolution.ml
@@ -26,13 +26,7 @@ let resolve_cascade
   (* RFC-0041 Phase B4: when a specific item was selected by the
      proactive router, override (cascade_name_of_meta meta) so downstream
      cascade resolution uses the item's group. *)
-  let meta =
-    match selected_item with
-    | Some (group, item) ->
-      let cascade_ref = Some Cascade_ref.{ group = Cascade_name.of_string_exn group; item = Some item.id } in
-      { meta with cascade_ref }
-    | None -> meta
-  in
+  (* cascade_ref removed — Runtime model replaces cascade routing. *)
   let phase =
     match phase_opt with
     | Some p -> p
@@ -51,9 +45,8 @@ let resolve_cascade
     Keeper_metrics.(to_string FsmEdgeTransitions)
     ~labels:[ "edge", "ksm_to_kcl_routing" ]
     ();
-  let routed_meta = set_cascade_name routing.effective_cascade meta in
   let routed_labels =
-    Keeper_model_labels.configured_model_labels_of_meta routed_meta
+    Keeper_model_labels.configured_model_labels_of_meta meta
   in
   let resolved_cascade =
     Keeper_turn_liveness.fail_open_phase_buffer_when_unavailable
@@ -90,4 +83,4 @@ let resolve_cascade
        ])
   in
   append_cascade_routed_manifest ~cascade_name:resolved_cascade ~decision;
-  { resolved_meta = routed_meta; resolved_cascade }
+  { resolved_meta = meta; resolved_cascade }

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -32,10 +32,8 @@ let build_cascade_execution
     , Agent_sdk.Error.sdk_error )
     result
   =
-  let cascade_name_string = Cascade_name.to_string cascade_name in
-  let meta_for_cascade = set_cascade_name cascade_name_string meta in
   let model_labels =
-    Keeper_context_runtime.effective_model_labels_for_turn meta_for_cascade
+    Keeper_context_runtime.effective_model_labels_for_turn meta
   in
   match Keeper_types_support.ensure_api_keys_for_labels model_labels with
   | Error e -> Error (Agent_sdk.Error.Internal e)

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -70,4 +70,22 @@ let load_list ~(config_path : string) : (t list * t, string) result =
                config_path
                did
                (List.length runtimes))))
+
+(* ---- Lazy default runtime singleton ---- *)
+
+let default_runtime_ref : t option ref = ref None
+
+let init_default ~config_path =
+  match load_list ~config_path with
+  | Ok (_, rt) ->
+    default_runtime_ref := Some rt;
+    Ok ()
+  | Error _ as e -> e
+
+let get_default_runtime () = !default_runtime_ref
+
+let get_default_runtime_id () =
+  match !default_runtime_ref with
+  | Some rt -> rt.id
+  | None -> "tool_strict"
 ;;

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -17,3 +17,13 @@ type t =
 val id_of_binding : cascade_binding -> string
 val of_binding : cascade_config -> cascade_binding -> t option
 val load_list : config_path:string -> (t list * t, string) result
+
+(** {1 Lazy default runtime singleton}
+
+    Initialized once at startup via {!init_default}.  All consumer
+    code that previously resolved a cascade name now calls
+    {!get_default_runtime_id} instead. *)
+
+val init_default : config_path:string -> (unit, string) result
+val get_default_runtime : unit -> t option
+val get_default_runtime_id : unit -> string

--- a/lib/server/server_routes_http_routes_dashboard_cascade_meta.ml
+++ b/lib/server/server_routes_http_routes_dashboard_cascade_meta.ml
@@ -10,9 +10,7 @@ let sync_keeper_cascade_meta ~(config : Coord.config) ~(name : string)
   match Keeper_meta_store.read_meta config name with
   | Error msg -> Error ("read_meta failed after TOML update: " ^ msg)
   | Ok (Some meta) ->
-      let updated =
-        { (Keeper_meta_contract.set_cascade_name cascade_name meta) with updated_at }
-      in
+      let updated = { meta with updated_at } in
       (match Keeper_meta_store.write_meta ~force:true config updated with
        | Ok () ->
            let registered =
@@ -27,7 +25,7 @@ let sync_keeper_cascade_meta ~(config : Coord.config) ~(name : string)
        | None -> Ok false
        | Some entry ->
            let updated =
-             { (Keeper_meta_contract.set_cascade_name cascade_name entry.meta) with updated_at }
+             { entry.meta with updated_at }
            in
            (match Keeper_meta_store.write_meta ~force:true config updated with
             | Ok () ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -422,6 +422,20 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr
           ~fs ~env ()
       in
+      (* Initialize the default Runtime singleton from cascade TOML.
+         Must happen after Config_dir_resolver is set up (inside
+         create_server_state) and before any cascade name resolution. *)
+      (match Cascade_runtime.cascade_config_path () with
+       | Some config_path ->
+         (match Runtime.init_default ~config_path with
+          | Ok () ->
+            Log.Server.info "Runtime default initialized: %s"
+              (Runtime.get_default_runtime_id ())
+          | Error msg ->
+            Log.Server.error "Runtime.init_default failed: %s" msg)
+       | None ->
+         Log.Server.warn
+           "No cascade config path; Runtime default not initialized");
       let provider_health = Provider_health.create state.room_config in
       Provider_health.set_active provider_health;
       Provider_health.start_probe_fiber ~sw ~env provider_health;

--- a/test/test_keeper_status_runtime.ml
+++ b/test/test_keeper_status_runtime.ml
@@ -979,7 +979,6 @@ let test_runtime_surface_exposes_cascade_attempt_facts () =
   in
   let base =
     make_meta ~name:"runtime-cascade-attempt-facts-test" ()
-    |> Keeper_meta_contract.set_cascade_name "cascade.strict_tool_candidates"
   in
   let meta =
     { base with

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1322,11 +1322,7 @@ let test_provider_cooldown_blocks_scheduled_turn_when_work_is_ready () =
 ;;
 
 let test_provider_capacity_blocked_backlog_count_requires_non_fail_open_cooldown () =
-  let default_meta =
-    Masc_mcp.Keeper_meta_contract.set_cascade_name
-      (Masc_mcp.Keeper_config.default_cascade_name ())
-      minimal_meta
-  in
+  let default_meta = minimal_meta in
   let blocked =
     WO.provider_capacity_blocked_task_count
       ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> Some 3599)
@@ -1344,7 +1340,7 @@ let test_provider_capacity_blocked_backlog_count_requires_non_fail_open_cooldown
   in
   check int "healthy provider leaves backlog unblocked" 0 healthy;
   let fail_open_meta =
-    Masc_mcp.Keeper_meta_contract.set_cascade_name "scoring" minimal_meta
+    minimal_meta
   in
   let fail_open_blocked =
     WO.provider_capacity_blocked_task_count
@@ -1358,7 +1354,7 @@ let test_provider_capacity_blocked_backlog_count_requires_non_fail_open_cooldown
 
 let test_provider_cooldown_keeps_scheduled_turn_open_when_fail_open_exists () =
   let meta =
-    { (Masc_mcp.Keeper_meta_contract.set_cascade_name "scoring" minimal_meta) with
+    { minimal_meta with
       current_task_id =
         (match Masc_mcp.Keeper_id.Task_id.of_string "task-789" with
          | Ok value -> Some value
@@ -1876,10 +1872,7 @@ let test_bootstrap_turn_emits_scheduled_autonomous_channel () =
 
 let test_provider_cooldown_blocks_bootstrap_turn () =
   let meta =
-    { (Masc_mcp.Keeper_meta_contract.set_cascade_name
-         Masc_mcp.(Keeper_config.default_cascade_name ())
-         minimal_meta)
-      with
+    { minimal_meta with
       proactive = { enabled = true; idle_sec = 300; cooldown_sec = 1800 }
     ; runtime =
         { minimal_meta.runtime with
@@ -2070,10 +2063,7 @@ let test_min_interval_never_fires_for_bootstrap () =
 let test_provider_cooldown_blocks_min_interval_turn () =
   with_env "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC" "900" (fun () ->
     let meta =
-      { (Masc_mcp.Keeper_meta_contract.set_cascade_name
-           Masc_mcp.(Keeper_config.default_cascade_name ())
-           minimal_meta)
-        with
+      { minimal_meta with
         proactive = { enabled = true; idle_sec = 0; cooldown_sec = 600 }
       ; runtime =
           { minimal_meta.runtime with

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -3022,7 +3022,7 @@ proactive_enabled = true
             Alcotest.fail ("keeper meta reload failed before stale write: " ^ err)
       in
       let stale_meta =
-        { (Keeper_meta_contract.set_cascade_name "vendor_mix_balanced" stale_base) with
+        { stale_base with
           updated_at = Masc_domain.now_iso ();
         }
       in


### PR DESCRIPTION
## Summary
- **B2**: Gut cascade consumer functions to use `Runtime.get_default_runtime_id()` instead of cascade routing logic. 105 call-sites updated via signature-preserving replacement.
- **B3**: Remove `cascade_ref` field from `keeper_meta` type and delete `set_cascade_name` function. cascade_ref (RFC-0041 group/item position pointer) is meaningless under the Runtime model.

## Changes
- `cascade_name_for_use` → `Runtime.get_default_runtime_id()` (cascade_routes_resolve.ml)
- `cascade_name_of_meta` → returns `Runtime.get_default_runtime_id()` (keeper_meta_contract.ml)
- 5 cascade name constants in keeper_config.ml → `Runtime.get_default_runtime_id()`
- Runtime lazy singleton initialization in server_runtime_bootstrap.ml
- cascade_ref field removed from keeper_meta type (.ml + .mli)
- set_cascade_name function removed (.ml + .mli)
- cascade_ref JSON serialization/parse removed
- cascade_ref dashboard display removed (3 files)
- cascade_ref keeper record construction removed (4 files)
- cascade_ref JSON scrub config removed
- 3 test files updated

## B4 (separate PR)
- Delete `lib/cascade/` (150+ files) + `lib/cascade_ref/` (3 files)
- Migrate 183 files with remaining cascade module references
- Clean up cascade sub-libraries in dune

## Test plan
- `dune build @check` — type-check passes
- `dune build` — full build passes
- `dune build @runtest` — running

🤖 Generated with [Claude Code](https://claude.com/claude-code)