### PR TITLE
refactor(keeper): cascade→Runtime 숙청 — dead per-phase cascade override 적출 (slice 1)

### DIFF
--- a/lib/keeper/keeper_cascade_routing.ml
+++ b/lib/keeper/keeper_cascade_routing.ml
@@ -16,33 +16,22 @@ type routing_decision = {
 
 let select_cascade ~(base_cascade : string) ~(phase : Keeper_state_machine.phase)
     : routing_decision =
-  let decision =
+  (* cascade→Runtime 숙청: per-phase cascade override 제거. cascade 세계에서는
+     Failing -> routes.phase_recovery, Compacting/HandingOff -> routes.phase_buffer
+     로 갈렸지만, Runtime 모델에서는 binding 하나가 곧 하나의 Runtime 이고 모든
+     phase 가 동일한 default Runtime 을 쓴다 (phase_recovery_cascade_name ==
+     phase_buffer_cascade_name == get_default_runtime_id()). override 분기는 죽은
+     추상화이므로 항등으로 collapse 한다. phase 는 reason 진단용으로만 유지하고,
+     override 가 더 이상 없으므로 on_phase_override 텔레메트리도 제거한다. *)
+  let reason =
     match phase with
-    | Running ->
-        { effective_cascade = base_cascade;
-          reason = "healthy, using configured cascade" }
-    | Failing ->
-        { effective_cascade = Keeper_config.phase_recovery_cascade_name;
-          reason = "failing phase: phase recovery route" }
-    | Compacting | HandingOff ->
-        { effective_cascade = Keeper_config.phase_buffer_cascade_name;
-          reason = "buffer operation: diagnostic route; hot path blocks new turns" }
-    | Overflowed ->
-        { effective_cascade = base_cascade;
-          reason = "overflowed phase: turn blocked upstream pending compaction" }
-    | Draining | Paused ->
-        { effective_cascade = base_cascade;
-          reason = "non-executable phase: turn blocked upstream" }
+    | Running -> "healthy, using configured runtime"
+    | Failing | Compacting | HandingOff | Overflowed | Draining | Paused ->
+        "single runtime: no per-phase cascade override"
     | Offline | Stopped | Dead | Zombie | Crashed | Restarting ->
-        { effective_cascade = base_cascade;
-          reason = "non-turn phase (blocked upstream)" }
+        "non-turn phase (blocked upstream)"
   in
-  if not (String.equal decision.effective_cascade base_cascade) then
-    Cascade_metrics.on_phase_override
-      ~phase:(Keeper_state_machine.phase_to_string phase)
-      ~from_cascade:base_cascade
-      ~to_cascade:decision.effective_cascade;
-  decision
+  { effective_cascade = base_cascade; reason }
 
 let route_effective_cascade_for_tool_requirement
     ~(effective_cascade : string) ~(tool_requirement : Keeper_agent_tool_surface.tool_requirement) :


### PR DESCRIPTION
## 목적

cascade→Runtime 전환 **숙청 슬라이스 1**: 죽은 per-phase cascade override 적출.

## 배경

cascade 세계에서 `Keeper_cascade_routing.select_cascade` 는 keeper phase 에 따라 effective cascade 를 갈랐다:
- `Failing` → `routes.phase_recovery`
- `Compacting`/`HandingOff` → `routes.phase_buffer`
- 그 외 → `base_cascade`

Runtime 모델에서는 binding(provider × model) 하나가 곧 하나의 Runtime 이고, 모든 phase 가 동일한 default Runtime 을 쓴다. 즉 `phase_recovery_cascade_name == phase_buffer_cascade_name == get_default_runtime_id()` 로 수렴 — 세 갈래가 같은 값을 반환한다. **override 분기는 죽은 추상화**다.

## 변경

- `lib/keeper/keeper_cascade_routing.ml`: `select_cascade` 의 per-phase override 를 항등으로 collapse. effective_cascade 는 항상 `base_cascade`. `phase` 는 reason 진단용으로만 유지. override 가 사라졌으므로 `Cascade_metrics.on_phase_override` 텔레메트리 호출도 제거.

## 거동 변경

`select_cascade` 가 이제 모든 phase 에 대해 `base_cascade` 를 반환한다(이전엔 Failing/Compacting/HandingOff 가 phase_recovery/phase_buffer route 로 갈렸으나 그 route 들이 동일 default Runtime 으로 수렴). golden table 테스트(12 phase)를 새 계약에 맞게 갱신.

## 검증

- lib/test 빌드 통과
- `test_keeper_cascade_routing`, `test_keeper_fsm_joints`(select_cascade golden table) 갱신 후 통과

## 후속 (이 PR 범위 아님 — 숙청 시리즈)

- `keeper_config` phase_* cascade name 상수 collapse (다수 String.equal 비교 사이트)
- `keeper_turn_liveness.fail_open_phase_buffer_when_unavailable` 죽은 liveness probe 적출
- ambient `Runtime.get_default_runtime_id()` 싱글톤 제거 + explicit Runtime.t 주입
- TLA+ `KeeperCoreTriad.SelectCascade` spec 동기화

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
