### PR TITLE
fix(keeper): default tool_access to Preset Full for cascade provider gap

### DIFF
--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -180,17 +180,14 @@ let string_list_field_opt_result ?label ~field_name (json : Yojson.Safe.t) =
 ;;
 
 let default_tool_access_of_meta_json () =
-  (* tool_execute excluded from the default blocklist: keepers need it for
-     shell commands, file reads, git ops, and cascade tool filtering requires
-     it. Only file-mutation writes (edit/write_file) are blocked by default.
-     See fleet deadlock Layer 2 analysis (2026-05-30). *)
-  let non_default_writes = [ "tool_edit_file"; "tool_write_file" ] in
-  let tools =
-    Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
-    |> List.filter (fun name ->
-           not (List.exists (String.equal name) non_default_writes))
-  in
-  Custom (normalize_tool_names tools)
+  (* Preset Full with all_candidates=true: keepers without explicit tool_access
+     get the complete tool set (keeper_* + config + injected masc_* tools).
+     This ensures cascade filtering can find providers with required tools like
+     masc_transition. Write-intent restrictions are handled by task contract
+     gating, not by default tool access exclusion.
+     See fleet deadlock Layer 2 analysis (2026-05-30) + cascade provider
+     gap analysis (2026-05-30). *)
+  Preset { preset = Full; also_allow = [] }
 ;;
 
 let tool_access_of_meta_json (json : Yojson.Safe.t) =


### PR DESCRIPTION
## Summary
- Keepers without explicit `tool_access` defaulted to `Custom [Keeper_internal surface - write_tools]`, which excluded all `masc_*` coordination tools
- Cascade filtering requires providers with all required tools (including `masc_transition`); no keeper qualified
- Changed `default_tool_access_of_meta_json` from `Custom` to `Preset Full` (all_candidates=true)
- Write-intent restrictions handled by task contract gating, not default tool access exclusion

## Root Cause
The verifier cascade showed "No tool-capable provider for cascade tier-group.glm-coding-with-spark; required_tools=[...masc_transition...]". Investigation traced the full tool surface resolution pipeline:

1. `default_tool_access_of_meta_json()` returned `Custom [Keeper_internal surface tools - write_tools]`
2. `Keeper_internal` surface only contains `keeper_*` prefixed names — `masc_transition` and other `masc_*` tools are absent
3. Cascade filtering checks if each provider's tool set includes all required tools
4. No keeper had `masc_transition` in their default tool set → all 15 cascade candidates rejected

## Fix
Changed `default_tool_access_of_meta_json` to return `Preset { preset = Full; also_allow = [] }`:
- `Full` preset has `all_candidates=true` → returns complete tool set (config + keeper_internal + injected masc_* tools)
- `masc_transition` and all coordination tools now available by default
- `tool_denylist` mechanism still works for restricting specific tools

## Test plan
- [ ] `dune build @check` passes
- [ ] Verify verifier keeper can claim tasks with masc_transition
- [ ] Verify cascade filtering finds providers with required tools
- [ ] Verify write-intent task contracts still gate properly

## Related
- Fleet deadlock Layer 2 analysis (2026-05-30)
- PR #19493 (tool_execute default inclusion)
- Verifier.json `last_proactive_reason` error trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)