### PR TITLE
test: add eq-form value-consuming parser coverage

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -895,6 +895,12 @@ let rec parse recursive case_sensitive files_with_matches pattern path = functio
          && arg.[0] = '-' && arg.[1] = 'e' ->
     let p = String.sub arg 2 (String.length arg - 2) in
     parse recursive case_sensitive files_with_matches (Some p) path rest
+  (* --regexp=PATTERN eq-form *)
+  | arg :: rest
+    when String.length arg > 9
+         && String.sub arg 0 9 = "--regexp=" ->
+    let p = String.sub arg 9 (String.length arg - 9) in
+    parse recursive case_sensitive files_with_matches (Some p) path rest
   (* --color=auto and similar --flag=VALUE forms: skip *)
   | arg :: rest
     when String.length arg > 2
@@ -1261,6 +1267,13 @@ let rec parse message amend = function
        (match rest with
         | m :: rest' -> parse (Some m) !has_a rest'
         | _ -> None))
+  | arg :: rest
+    when String.length arg > 10
+         && String.sub arg 0 10 = "--message=" ->
+    let m = String.sub arg 10 (String.length arg - 10) in
+    (match message with
+     | None -> parse (Some m) amend rest
+     | Some _ -> None)
   | "--" :: rest -> parse message amend rest
   | arg :: rest ->
     if String.length arg > 0 && arg.[0] = '-'
@@ -1549,6 +1562,11 @@ let rec parse reverse numeric unique key file = function
     (try parse reverse numeric unique (Some (int_of_string n)) file rest
      with Failure _ -> None)
   | "-t" :: _ :: rest | "--field-separator" :: _ :: rest -> parse reverse numeric unique key file rest  (* -t/--field-separator SEP *)
+  (* --field-separator=SEP *)
+  | arg :: rest
+    when String.length arg > 18
+         && String.sub arg 0 18 = "--field-separator=" ->
+    parse reverse numeric unique key file rest
   (* --key=N form *)
   | arg :: rest
     when String.length arg > 6
@@ -3069,6 +3087,17 @@ let rec parse in_place ext_re suppress expr file dd = function
   | "-n" :: rest | "--quiet" :: rest | "--silent" :: rest when not dd -> parse in_place ext_re true expr file dd rest
   (* POSIX end-of-options: remaining are expression, file *)
   | "--" :: rest -> parse in_place ext_re suppress expr file true rest
+  (* --expression=EXPR and --file=FILE eq-forms *)
+  | arg :: rest
+    when not dd && String.length arg > 14
+         && String.sub arg 0 14 = "--expression=" ->
+    let e = String.sub arg 14 (String.length arg - 14) in
+    parse in_place ext_re suppress (Some e) file dd rest
+  | arg :: rest
+    when not dd && String.length arg > 7
+         && String.sub arg 0 7 = "--file=" ->
+    let f = String.sub arg 7 (String.length arg - 7) in
+    parse in_place ext_re suppress (Some f) file dd rest
   | arg :: rest ->
     if not dd && String.length arg > 0 && arg.[0] = '-'
     then parse in_place ext_re suppress expr file dd rest

--- a/lib/exec/test/test_shell_ir_walkers_gen.ml
+++ b/lib/exec/test/test_shell_ir_walkers_gen.ml
@@ -2798,6 +2798,63 @@ let test_long_form_value_consuming_flags () =
    | w -> Alcotest.failf "Tail --lines 10: expected lines=10, got %a" pp w)
 ;;
 
+let test_eq_form_value_consuming_flags () =
+  let base cmd =
+    { Shell_ir.bin = bin_ok cmd
+    ; args = []
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Sandbox_target.host ()
+    }
+  in
+  let lit s = Shell_ir.Lit (s, Shell_ir.default_meta) in
+  let of_simple s = Shell_ir_typed.of_simple s in
+  let pp fmt w = Shell_ir_typed.pp fmt w in
+  (* Sort: --field-separator=, *)
+  let sort =
+    of_simple { (base "sort") with args = [ lit "--field-separator=,"; lit "file.txt" ] }
+  in
+  (match sort with
+   | W (Sort { file = Some "file.txt"; _ }) -> ()
+   | w -> Alcotest.failf "Sort --field-separator=,: expected file=file.txt, got %a" pp w);
+  (* Grep: --regexp=pattern file.txt *)
+  let grep =
+    of_simple { (base "grep") with args = [ lit "--regexp=foo"; lit "file.txt" ] }
+  in
+  (match grep with
+   | W (Grep { pattern = "foo"; path = Some "file.txt"; _ }) -> ()
+   | w -> Alcotest.failf "Grep --regexp=foo: expected pattern=foo, got %a" pp w);
+  (* Git_commit: --message=msg *)
+  let gc =
+    of_simple { (base "git") with args = [ lit "commit"; lit "--message=hello world" ] }
+  in
+  (match gc with
+   | W (Git_commit { message = "hello world"; _ }) -> ()
+   | w -> Alcotest.failf "Git_commit --message=hello world: expected msg=hello world, got %a" pp w);
+  (* Head: --lines=5 file.txt *)
+  let head =
+    of_simple { (base "head") with args = [ lit "--lines=5"; lit "file.txt" ] }
+  in
+  (match head with
+   | W (Head { lines = 5; path = "file.txt"; _ }) -> ()
+   | w -> Alcotest.failf "Head --lines=5: expected lines=5, got %a" pp w);
+  (* Tail: --lines=10 file.txt *)
+  let tail =
+    of_simple { (base "tail") with args = [ lit "--lines=10"; lit "file.txt" ] }
+  in
+  (match tail with
+   | W (Tail { lines = 10; path = "file.txt"; _ }) -> ()
+   | w -> Alcotest.failf "Tail --lines=10: expected lines=10, got %a" pp w);
+  (* Sed: --expression / --file eq-forms *)
+  let sed =
+    of_simple { (base "sed") with args = [ lit "--expression=s/foo/bar/"; lit "--file=script.sed"; lit "input.txt" ] }
+  in
+  (match sed with
+   | W (Sed { expression = "script.sed"; file = "input.txt"; _ }) -> ()
+   | w -> Alcotest.failf "Sed --expression/--file eq-form: expected expression=script.sed, file=input.txt, got %a" pp w)
+;;
+
 let () =
   Alcotest.run
     "shell_ir_walkers_gen"
@@ -2873,6 +2930,10 @@ let () =
             "Long-form value-consuming flags (--field-separator, --regexp, --message, --expression, --file, --lines)"
             `Quick
             test_long_form_value_consuming_flags
+        ; Alcotest.test_case
+            "eq-form value-consuming flags (--field-separator=, --regexp=P, --message=M, --lines=N)"
+            `Quick
+            test_eq_form_value_consuming_flags
         ] )
     ; ( "spec_invariants"
       , [ Alcotest.test_case "is_eq_form_flag helper" `Quick test_is_eq_form_flag


### PR DESCRIPTION
This PR adds parser coverage for remaining eq-form flags and registers tests: --regexp, --message, --lines, --field-separator, plus related parser updates in bin/gen_shell_ir_walkers.ml.