### PR TITLE
refactor(keeper): cascade→Runtime 강력한 숙청 — dead per-phase cascade names collapse

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -16,15 +16,13 @@ let two_days_seconds_int = Masc_time_constants.day_int * 2
     naming the "1 day" intent at the call site. *)
 let one_day_seconds_int = Masc_time_constants.day_int
 
+(* cascade→Runtime 숙청: per-phase cascade name 구분 제거. cascade 세계의
+   phase_recovery / phase_buffer / tool_required / routing 은 서로 다른 route
+   였으나, Runtime 모델에서는 모든 phase 가 동일한 default Runtime 을 쓴다 —
+   넷 다 default_cascade_name () 으로 수렴하는 죽은 구분이었다. 단일 함수로
+   collapse 하고, eager 모듈-레벨 baking(module-init 시점 미초기화 싱글톤 읽기)
+   도 함께 제거한다. *)
 let default_cascade_name () = Runtime.get_default_runtime_id ()
-
-let phase_recovery_cascade_name = Runtime.get_default_runtime_id ()
-
-let phase_buffer_cascade_name = Runtime.get_default_runtime_id ()
-
-let phase_routing_cascade_names = [ Runtime.get_default_runtime_id () ]
-
-let tool_required_cascade_name = Runtime.get_default_runtime_id ()
 
 (** Minimum context window (tokens) for any keeper turn.
     64k-class local models are valid keeper backends; do not clamp them upward

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -7,32 +7,15 @@
 
 (** {1 Core Constants} *)
 
-(** Default cascade name for keeper turns. Resolved each call against
-    the live [Cascade_catalog_runtime] snapshot so the answer reflects
-    the currently-installed catalog rather than module-init state. Falls
-    back to [Cascade_routes.cascade_name_for_use Keeper_turn] when the
-    snapshot is not yet available (early boot).
+(** Default cascade name for keeper turns = the default Runtime's id.
+
+    cascade→Runtime 숙청: 이전의 phase_recovery / phase_buffer /
+    tool_required / phase_routing 구분은 모두 동일한 default Runtime 으로
+    수렴하는 죽은 추상화였으므로 이 단일 thunk 로 collapse 되었다.
     @since v2.128.0
     @since RFC-0066 Phase 1: changed from a string value to a thunk
     (issue #14624). *)
 val default_cascade_name : unit -> string
-
-(** Cascade name for recovery turns (Failing phase). In the two-profile
-    catalog this resolves to the canonical keeper cascade.
-    @since Core Triad *)
-val phase_recovery_cascade_name : string
-
-(** Cascade name for buffer operations (Compacting, HandingOff). In the
-    two-profile catalog this resolves to the canonical keeper cascade.
-    @since Core Triad *)
-val phase_buffer_cascade_name : string
-
-(** Cascade names that are selected by keeper phase-routing rather than by
-    keeper-assignable profile choice. *)
-val phase_routing_cascade_names : string list
-
-(** Cascade name for turns that must use a tool-capable provider lane. *)
-val tool_required_cascade_name : string
 
 (** Minimum context window (tokens) for any keeper turn. *)
 val min_keeper_context_tokens : int

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -292,7 +292,7 @@ let fallback_cascade_for_unavailable_profile
   if not (String.equal normalized_effective normalized_base)
   then Some normalized_base
   else if
-    String.equal normalized_effective Keeper_config.phase_buffer_cascade_name
+    String.equal normalized_effective (Keeper_config.default_cascade_name ())
     || String.equal normalized_effective (Keeper_config.default_cascade_name ())
   then None
   else Some (Keeper_config.default_cascade_name ())
@@ -305,25 +305,25 @@ let degraded_retry_after_recoverable_error
     Keeper_cascade_profile.normalize_declared_name effective_cascade
   in
   let effective_is_declared_phase_buffer =
-    is_declared_phase_alias effective_cascade Keeper_config.phase_buffer_cascade_name
+    is_declared_phase_alias effective_cascade (Keeper_config.default_cascade_name ())
   in
   let effective_is_declared_phase_recovery =
     is_declared_phase_alias
       effective_cascade
-      Keeper_config.phase_recovery_cascade_name
+      (Keeper_config.default_cascade_name ())
   in
   let phase_recovery_retry fallback_reason =
     Some
       {
-        next_cascade = Keeper_config.phase_recovery_cascade_name;
+        next_cascade = (Keeper_config.default_cascade_name ());
         fallback_reason;
       }
   in
   if tool_requirement = Required
      || effective_is_declared_phase_buffer
      || effective_is_declared_phase_recovery
-     || String.equal normalized_effective Keeper_config.phase_buffer_cascade_name
-     || String.equal normalized_effective Keeper_config.phase_recovery_cascade_name
+     || String.equal normalized_effective (Keeper_config.default_cascade_name ())
+     || String.equal normalized_effective (Keeper_config.default_cascade_name ())
   then None
   else if Keeper_turn_driver.sdk_error_is_hard_quota err then
     phase_recovery_retry Hard_quota
@@ -504,9 +504,9 @@ let normalized_cascade_name ~catalog_names name =
   let trimmed = String.trim name in
   if List.exists (String.equal trimmed) catalog_names then trimmed
   else if
-    String.equal trimmed Keeper_config.phase_buffer_cascade_name
-    || String.equal trimmed Keeper_config.phase_recovery_cascade_name
-    || String.equal trimmed Keeper_config.tool_required_cascade_name
+    String.equal trimmed (Keeper_config.default_cascade_name ())
+    || String.equal trimmed (Keeper_config.default_cascade_name ())
+    || String.equal trimmed (Keeper_config.default_cascade_name ())
   then trimmed
   else Keeper_cascade_profile.normalize_declared_name trimmed
 
@@ -519,7 +519,7 @@ let required_tool_rotation_candidate
   let routed_phase_buffer_is_distinct =
     not
       (String.equal
-         Keeper_config.phase_buffer_cascade_name
+         (Keeper_config.default_cascade_name ())
          (Keeper_config.default_cascade_name ()))
   in
   (* Required-tool turns may still use the phase-recovery route when the catalog
@@ -528,17 +528,17 @@ let required_tool_rotation_candidate
      required-tool turns into a control/recovery lane. *)
   not
     ((routed_phase_buffer_is_distinct
-      && String.equal normalized Keeper_config.phase_buffer_cascade_name))
+      && String.equal normalized (Keeper_config.default_cascade_name ())))
   && (allow_phase_recovery
       || not
-           (String.equal normalized Keeper_config.phase_recovery_cascade_name))
+           (String.equal normalized (Keeper_config.default_cascade_name ())))
   && not (Cascade_capability_profile.is_system_cascade_name normalized)
 
 let tool_required_rotation_cascade_name () =
   try
     Keeper_cascade_profile.cascade_name_for_use
       Keeper_cascade_profile.Tool_required
-  with Failure _ -> Keeper_config.tool_required_cascade_name
+  with Failure _ -> (Keeper_config.default_cascade_name ())
 
 let default_degraded_rotation_candidates
     ~catalog_names

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -374,7 +374,7 @@ let normalize_cascade_name raw =
     | _ -> []
   in
   let known =
-    Keeper_config.phase_routing_cascade_names
+    [ Keeper_config.default_cascade_name () ]
     @ catalog
   in
   if List.mem (String.lowercase_ascii normalized) known

--- a/lib/keeper/keeper_turn_cascade_budget_routing.ml
+++ b/lib/keeper/keeper_turn_cascade_budget_routing.ml
@@ -75,10 +75,10 @@ let active_fail_open_rotation_cascades () =
     ()
 
 let tool_required_rotation_cascade_name () =
-  try
-    Keeper_cascade_profile.cascade_name_for_use Keeper_cascade_profile.Tool_required
-  with
-  | Failure _ -> Keeper_config.tool_required_cascade_name
+  (* cascade→Runtime 숙청: cascade_name_for_use 는 use 무시하고 default
+     Runtime id 를 반환(raise 없음). tool_required 구분이 죽었으므로
+     default_cascade_name 으로 collapse. *)
+  Keeper_config.default_cascade_name ()
 
 let next_fail_open_cascade_for_turn
       ?rotation_cascades

--- a/lib/keeper/keeper_turn_liveness.ml
+++ b/lib/keeper/keeper_turn_liveness.ml
@@ -36,8 +36,8 @@ let decide_phase_buffer_liveness
     Keeper_cascade_profile.normalize_declared_name effective_cascade
   in
   if
-    (not (String.equal normalized_effective Keeper_config.phase_buffer_cascade_name))
-    || String.equal normalized_base Keeper_config.phase_buffer_cascade_name
+    (not (String.equal normalized_effective (Keeper_config.default_cascade_name ())))
+    || String.equal normalized_base (Keeper_config.default_cascade_name ())
   then Keep_effective_cascade normalized_effective
   else (
     let probeable_urls =

--- a/lib/keeper/keeper_world_observation_provider_cooldown.ml
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.ml
@@ -20,9 +20,7 @@ let fallback_cascade_for_provider_cooldown
   in
   if not (String.equal normalized_effective normalized_base)
   then Some normalized_base
-  else if
-    String.equal normalized_effective Keeper_config.phase_buffer_cascade_name
-    || String.equal normalized_effective (Keeper_config.default_cascade_name ())
+  else if String.equal normalized_effective (Keeper_config.default_cascade_name ())
   then None
   else Some (Keeper_config.default_cascade_name ())
 

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -526,7 +526,7 @@ let append_execution_receipt
       degraded_retry_cascade =
         Some
           (Cascade_name.of_string_exn
-             Lib.Keeper_config.phase_recovery_cascade_name);
+             (Lib.Keeper_config.default_cascade_name ()));
       fallback_reason = Some Lib.Keeper_error_classify.Turn_timeout;
       cascade_rotation_attempts =
         [
@@ -536,7 +536,7 @@ let append_execution_receipt
                 Lib.(Keeper_config.default_cascade_name ());
             to_cascade =
               Cascade_name.of_string_exn
-                Lib.Keeper_config.phase_recovery_cascade_name;
+                (Lib.Keeper_config.default_cascade_name ());
             reason = Lib.Keeper_error_classify.Turn_timeout;
             outcome = Lib.Keeper_execution_receipt.Rotation_retry_scheduled;
             slot_release_at_phase =
@@ -862,7 +862,7 @@ let test_execution_trust_surfaces_latest_receipt () =
               (trust_row |> member "trust" |> member "cascade"
              |> member "degraded_retry_applied" |> to_bool);
             check (option string) "execution trust row preserves degraded retry lane"
-              (Some Lib.Keeper_config.phase_recovery_cascade_name)
+              (Some (Lib.Keeper_config.default_cascade_name ()))
               (trust_row |> member "trust" |> member "cascade"
              |> member "degraded_retry_cascade" |> to_string_option);
             check (option string) "execution trust row preserves fallback reason"
@@ -870,7 +870,7 @@ let test_execution_trust_surfaces_latest_receipt () =
               (trust_row |> member "trust" |> member "cascade"
              |> member "fallback_reason" |> to_string_option);
             check string "execution trust row preserves rotation target"
-              Lib.Keeper_config.phase_recovery_cascade_name
+              (Lib.Keeper_config.default_cascade_name ())
               (trust_row |> member "trust" |> member "cascade"
              |> member "rotation_attempts" |> to_list |> List.hd
              |> member "to_cascade" |> to_string);

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -735,7 +735,7 @@ let append_execution_receipt
       Cascade_passed_to_next_model)
     ?(degraded_retry_applied = true)
     ?(degraded_retry_cascade =
-      Some Masc_mcp.Keeper_config.phase_recovery_cascade_name)
+      Some (Masc_mcp.Keeper_config.default_cascade_name ()))
     ?(fallback_reason = Some Masc_mcp.Keeper_error_classify.Turn_timeout)
     ?(required_tool_candidates = [])
     ?started_at

--- a/test/test_keeper_cascade_routing.ml
+++ b/test/test_keeper_cascade_routing.ml
@@ -91,17 +91,17 @@ let test_tool_required_turn_preserves_routed_cascade () =
   check string "required tool turns preserve routed cascade"
     "primary" r.effective_cascade;
   check bool "required tool turns do not rewrite to strict cascade" false
-    (String.equal Masc_mcp.Keeper_config.tool_required_cascade_name
+    (String.equal (Masc_mcp.Keeper_config.default_cascade_name ())
        r.effective_cascade)
 
 let test_tool_required_turn_preserves_phase_recovery () =
   let r =
     Routing.route_effective_cascade_for_tool_requirement
-      ~effective_cascade:Masc_mcp.Keeper_config.phase_recovery_cascade_name
+      ~effective_cascade:(Masc_mcp.Keeper_config.default_cascade_name ())
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Required
   in
   check string "required tool turns preserve phase recovery"
-    Masc_mcp.Keeper_config.phase_recovery_cascade_name r.effective_cascade
+    (Masc_mcp.Keeper_config.default_cascade_name ()) r.effective_cascade
 
 let test_all_phases_have_reason () =
   List.iter (fun phase ->

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -486,10 +486,10 @@ let test_normalized_cascade_name_preserves_config_special_names () =
   let catalog_names = [] in
   let result =
     KEC.normalized_cascade_name ~catalog_names
-      Masc_mcp.Keeper_config.phase_buffer_cascade_name
+      (Masc_mcp.Keeper_config.default_cascade_name ())
   in
   check string "phase_buffer preserved as-is"
-    Masc_mcp.Keeper_config.phase_buffer_cascade_name result
+    (Masc_mcp.Keeper_config.default_cascade_name ()) result
 
 let test_normalized_cascade_name_falls_through_to_declared_name () =
   let catalog_names = [ "primary" ] in

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4977,7 +4977,7 @@ let test_append_decision_record_persists_tool_calls () =
            ~latency_ms:42
            ~outcome:"success"
            ~degraded_retry_applied:true
-           ~degraded_retry_cascade:KC.phase_recovery_cascade_name
+           ~degraded_retry_cascade:(KC.default_cascade_name ())
            ~fallback_reason:"turn_timeout"
            ~turn_mode:UM.Tool_use
            ~result:(Some result)
@@ -5049,7 +5049,7 @@ let test_append_decision_record_persists_tool_calls () =
        check
          (option string)
          "degraded retry cascade persisted"
-         (Some KC.phase_recovery_cascade_name)
+         (Some (KC.default_cascade_name ()))
          Yojson.Safe.Util.(json |> member "degraded_retry_cascade" |> to_string_option);
        check
          (option string)
@@ -6186,7 +6186,7 @@ let test_decide_phase_buffer_liveness_keeps_phase_buffer_route () =
   match
     UT.decide_phase_buffer_liveness
       ~base_cascade:"scoring"
-      ~effective_cascade:KC.phase_buffer_cascade_name
+      ~effective_cascade:(KC.default_cascade_name ())
       [ label; label ]
   with
   | UT.Keep_effective_cascade cascade ->
@@ -6203,7 +6203,7 @@ let test_fail_open_local_only_when_probe_fails () =
     UT.fail_open_phase_buffer_when_unavailable
       ~probe_base_url:(fun _ -> false)
       ~base_cascade:"scoring"
-      ~effective_cascade:KC.phase_buffer_cascade_name
+      ~effective_cascade:(KC.default_cascade_name ())
       [ "ollama:qwen3.6:35b-a3b-mlx-bf16" ]
   in
   check
@@ -6237,7 +6237,7 @@ let test_fail_open_local_only_preserves_healthy_local_only () =
     UT.fail_open_phase_buffer_when_unavailable
       ~probe_base_url:(fun _ -> true)
       ~base_cascade:"scoring"
-      ~effective_cascade:KC.phase_buffer_cascade_name
+      ~effective_cascade:(KC.default_cascade_name ())
       [ "ollama:qwen3.6:35b-a3b-mlx-bf16" ]
   in
   check
@@ -6312,7 +6312,7 @@ let test_degraded_retry_after_recoverable_error_uses_local_recovery_for_hard_quo
   in
   expect_degraded_retry
     "hard quota degraded retry"
-    KC.phase_recovery_cascade_name
+    (KC.default_cascade_name ())
     "hard_quota"
     degraded_retry
 ;;
@@ -6335,7 +6335,7 @@ let test_degraded_retry_after_recoverable_error_uses_local_recovery_for_resumabl
   in
   expect_degraded_retry
     "resumable session degraded retry"
-    KC.phase_recovery_cascade_name
+    (KC.default_cascade_name ())
     "resumable_cli_session"
     degraded_retry
 ;;
@@ -6354,7 +6354,7 @@ let test_degraded_retry_after_recoverable_error_includes_admission_queue_timeout
   in
   expect_degraded_retry
     "admission queue timeout degraded retry"
-    KC.phase_recovery_cascade_name
+    (KC.default_cascade_name ())
     "admission_queue_timeout"
     degraded_retry
 ;;
@@ -6369,7 +6369,7 @@ let test_degraded_retry_after_recoverable_error_includes_turn_timeout () =
   in
   expect_degraded_retry
     "turn timeout degraded retry"
-    KC.phase_recovery_cascade_name
+    (KC.default_cascade_name ())
     "turn_timeout"
     degraded_retry
 ;;
@@ -6392,7 +6392,7 @@ let test_degraded_retry_after_recoverable_error_includes_provider_timeout () =
   in
   expect_degraded_retry
     "provider timeout degraded retry"
-    KC.phase_recovery_cascade_name
+    (KC.default_cascade_name ())
     "provider_timeout"
     degraded_retry
 ;;
@@ -6406,7 +6406,7 @@ let test_degraded_retry_after_recoverable_error_includes_max_turns () =
   in
   expect_degraded_retry
     "max turns degraded retry"
-    KC.phase_recovery_cascade_name
+    (KC.default_cascade_name ())
     "max_turns"
     degraded_retry
 ;;
@@ -6424,7 +6424,7 @@ let test_degraded_retry_after_recoverable_error_blocks_required_tools () =
 let test_degraded_retry_after_recoverable_error_does_not_broaden_local_only () =
   let degraded_retry =
     EC.degraded_retry_after_recoverable_error
-      ~effective_cascade:KC.phase_buffer_cascade_name
+      ~effective_cascade:(KC.default_cascade_name ())
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       (wrapped_claude_limit_error ())
   in
@@ -6434,7 +6434,7 @@ let test_degraded_retry_after_recoverable_error_does_not_broaden_local_only () =
 let test_degraded_retry_after_recoverable_error_does_not_broaden_local_recovery () =
   let degraded_retry =
     EC.degraded_retry_after_recoverable_error
-      ~effective_cascade:KC.phase_recovery_cascade_name
+      ~effective_cascade:(KC.default_cascade_name ())
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       (wrapped_claude_limit_error ())
   in
@@ -6462,7 +6462,7 @@ let test_fallback_cascade_for_unavailable_profile_prefers_base_after_phase_overr
   let fallback =
     EC.fallback_cascade_for_unavailable_profile
       ~base_cascade:"scoring"
-      ~effective_cascade:KC.phase_recovery_cascade_name
+      ~effective_cascade:(KC.default_cascade_name ())
   in
   check
     (option string)
@@ -6512,7 +6512,7 @@ let test_next_fail_open_cascade_for_turn_suppresses_exhausted_rotation_group () 
       ~attempted_cascades:
         [ "scoring"
         ; KC.default_cascade_name ()
-        ; KC.phase_recovery_cascade_name
+        ; (KC.default_cascade_name ())
         ; safe_lane_cascade_name
         ]
       (wrapped_claude_limit_error ())
@@ -6572,12 +6572,12 @@ let test_next_fail_open_cascade_for_turn_uses_catalog_rotation_profile () =
   let degraded_retry =
     UT.next_fail_open_cascade_for_turn
       ~rotation_cascades:
-        [ KC.default_cascade_name (); KC.phase_recovery_cascade_name; "ollama_only" ]
+        [ KC.default_cascade_name (); (KC.default_cascade_name ()); "ollama_only" ]
       ~base_cascade:"scoring"
       ~effective_cascade:"scoring"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       ~attempted_cascades:
-        [ "scoring"; KC.default_cascade_name (); KC.phase_recovery_cascade_name ]
+        [ "scoring"; KC.default_cascade_name (); (KC.default_cascade_name ()) ]
       (wrapped_claude_limit_error ())
   in
   expect_degraded_retry
@@ -6607,7 +6607,7 @@ let test_next_fail_open_cascade_for_turn_does_not_inject_default_when_catalog_om
 let test_next_fail_open_cascade_for_required_tool_filters_local_recovery_catalog () =
   let degraded_retry =
     UT.next_fail_open_cascade_for_turn
-      ~rotation_cascades:[ KC.phase_recovery_cascade_name; "required_safe" ]
+      ~rotation_cascades:[ (KC.default_cascade_name ()); "required_safe" ]
       ~base_cascade:(KC.default_cascade_name ())
       ~effective_cascade:"strict_exec"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Required
@@ -6624,7 +6624,7 @@ let test_next_fail_open_cascade_for_required_tool_filters_local_recovery_catalog
 let test_next_fail_open_cascade_for_required_tool_rejects_local_recovery_only_catalog () =
   let degraded_retry =
     UT.next_fail_open_cascade_for_turn
-      ~rotation_cascades:[ KC.phase_recovery_cascade_name ]
+      ~rotation_cascades:[ (KC.default_cascade_name ()) ]
       ~base_cascade:"strict_exec"
       ~effective_cascade:"strict_exec"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Required
@@ -6659,7 +6659,7 @@ let test_next_fail_open_cascade_for_required_tool_does_not_fall_through_to_manua
 let test_degraded_rotation_after_recoverable_error_filters_required_catalog_directly () =
   let degraded_retry =
     EC.degraded_rotation_after_recoverable_error
-      ~rotation_cascades:[ KC.phase_recovery_cascade_name; " primary " ]
+      ~rotation_cascades:[ (KC.default_cascade_name ()); " primary " ]
       ~base_cascade:"strict_exec"
       ~effective_cascade:"strict_exec"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Required
@@ -6711,7 +6711,7 @@ let test_degraded_rotation_after_recoverable_error_normalizes_catalog_directly (
 let test_degraded_rotation_prefers_fallback_hint_over_catalog () =
   let degraded_retry =
     EC.degraded_rotation_after_recoverable_error
-      ~rotation_cascades:[ KC.phase_recovery_cascade_name; "primary" ]
+      ~rotation_cascades:[ (KC.default_cascade_name ()); "primary" ]
       ~fallback_hint:"local_with_kimi_coding_with_glm"
       ~base_cascade:"ollama_only"
       ~effective_cascade:"ollama_only"
@@ -6729,7 +6729,7 @@ let test_degraded_rotation_prefers_fallback_hint_over_catalog () =
 let test_degraded_rotation_skips_already_attempted_fallback_hint () =
   let degraded_retry =
     EC.degraded_rotation_after_recoverable_error
-      ~rotation_cascades:[ KC.phase_recovery_cascade_name; "primary" ]
+      ~rotation_cascades:[ (KC.default_cascade_name ()); "primary" ]
       ~fallback_hint:"local_with_kimi_coding_with_glm"
       ~base_cascade:"ollama_only"
       ~effective_cascade:"ollama_only"
@@ -6739,7 +6739,7 @@ let test_degraded_rotation_skips_already_attempted_fallback_hint () =
   in
   expect_degraded_retry
     "exhausted hint falls through to catalog"
-    KC.phase_recovery_cascade_name
+    (KC.default_cascade_name ())
     "hard_quota"
     degraded_retry
 ;;
@@ -6747,7 +6747,7 @@ let test_degraded_rotation_skips_already_attempted_fallback_hint () =
 let test_degraded_rotation_ignores_blank_fallback_hint () =
   let degraded_retry =
     EC.degraded_rotation_after_recoverable_error
-      ~rotation_cascades:[ KC.phase_recovery_cascade_name; "primary" ]
+      ~rotation_cascades:[ (KC.default_cascade_name ()); "primary" ]
       ~fallback_hint:"   "
       ~base_cascade:"ollama_only"
       ~effective_cascade:"ollama_only"
@@ -6757,7 +6757,7 @@ let test_degraded_rotation_ignores_blank_fallback_hint () =
   in
   expect_degraded_retry
     "blank hint behaves like no hint"
-    KC.phase_recovery_cascade_name
+    (KC.default_cascade_name ())
     "hard_quota"
     degraded_retry
 ;;
@@ -6766,7 +6766,7 @@ let test_fail_open_rotation_cascades_from_catalog_merges_reserved_and_assignable
   let rotation =
     UT.fail_open_rotation_cascades_from_catalog
       ~catalog_names:
-        [ KC.default_cascade_name (); KC.phase_recovery_cascade_name; "ollama_only" ]
+        [ KC.default_cascade_name (); (KC.default_cascade_name ()); "ollama_only" ]
       ~keeper_assignable:[ KC.default_cascade_name (); "ollama_only" ]
       ()
   in
@@ -6781,7 +6781,7 @@ let test_fail_open_rotation_cascades_from_catalog_preserves_catalog_order () =
   let rotation =
     UT.fail_open_rotation_cascades_from_catalog
       ~catalog_names:
-        [ "ollama_only"; KC.phase_recovery_cascade_name; KC.default_cascade_name () ]
+        [ "ollama_only"; (KC.default_cascade_name ()); KC.default_cascade_name () ]
       ~keeper_assignable:[ KC.default_cascade_name (); "ollama_only" ]
       ()
   in


### PR DESCRIPTION
refactor(keeper): collapse dead per-phase cascade names (cascade→Runtime 숙청 2)

Runtime 모델에서는 binding 하나가 곧 하나의 Runtime, 모든 phase 가 동일한
default Runtime 을 쓴다. keeper_config 의 phase_recovery / phase_buffer /
tool_required / phase_routing cascade name 4종은 모두
get_default_runtime_id() == default_cascade_name() 으로 수렴하는 죽은 구분이었다.

- keeper_config.ml/.mli: phase_recovery_cascade_name / phase_buffer_cascade_name
  / phase_routing_cascade_names / tool_required_cascade_name 4 eager 상수 제거,
  default_cascade_name () 단일 thunk 로 collapse. eager module-init baking 도 제거.
- keeper_error_classify.ml: 15 비교 사이트의 phase_* → default_cascade_name().
- keeper_world_observation_provider_cooldown.ml: redundant OR (phase_buffer ||
  default) 분기 collapse.
- keeper_turn_cascade_budget_routing.ml: tool_required_rotation_cascade_name 의
  죽은 try/with fallback collapse.
- keeper_turn_liveness.ml, keeper_persona_authoring.ml: phase_* → default.
- test: KC.phase_* / Keeper_config.phase_* 참조 ~50 사이트를 default_cascade_name()
  으로 갱신 (behavior-preserving — 전부 동일 default).

검증: lib 빌드 통과 (test 컴파일 진행). 후속(같은 PR): liveness probe 기계
(decide_phase_buffer_liveness / fail_open) 적출 + 무의미 per-phase 테스트 숙청.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
