### PR TITLE
fix: align keeper base model with runpod_mtp binding

### DIFF
--- a/config/keepers/base.toml
+++ b/config/keepers/base.toml
@@ -9,7 +9,7 @@
 # disabling autoboot for this file. discover_keepers_toml still loads it
 # as a profile-defaults source for downstream keepers.
 autoboot_enabled = false
-model = "runpod:glm-coding-with-spark"
+model = "runpod_mtp.qwen-runpod"
 sandbox_profile = "docker"
 network_mode = "inherit"
 repo_cli_identity = "anyang-keepers"


### PR DESCRIPTION
The keeper base model was still using the legacy identifier runpod:glm-coding-with-spark, which does not resolve to the tool-capable runpod_mtp binding. This caused tool_strict capability-profile mismatch and no-tool-capable routing.\n\nThis changes config/keepers/base.toml to runpod_mtp.qwen-runpod.