### PR TITLE
fix(keeper): drop phase_* re-decls from toml facade mlis (#19506 follow-up)

### DIFF
--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -1,8 +1,4 @@
 val default_cascade_name : unit -> string
-val phase_recovery_cascade_name : string
-val phase_buffer_cascade_name : string
-val phase_routing_cascade_names : string list
-val tool_required_cascade_name : string
 val min_keeper_context_tokens : int
 val max_keeper_context_tokens : int
 val alert_error_detail_max_chars : int

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -1,8 +1,4 @@
 val default_cascade_name : unit -> string
-val phase_recovery_cascade_name : string
-val phase_buffer_cascade_name : string
-val phase_routing_cascade_names : string list
-val tool_required_cascade_name : string
 val min_keeper_context_tokens : int
 val max_keeper_context_tokens : int
 val alert_error_detail_max_chars : int

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -1,8 +1,4 @@
 val default_cascade_name : unit -> string
-val phase_recovery_cascade_name : string
-val phase_buffer_cascade_name : string
-val phase_routing_cascade_names : string list
-val tool_required_cascade_name : string
 val min_keeper_context_tokens : int
 val max_keeper_context_tokens : int
 val alert_error_detail_max_chars : int

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -1,8 +1,4 @@
 val default_cascade_name : unit -> string
-val phase_recovery_cascade_name : string
-val phase_buffer_cascade_name : string
-val phase_routing_cascade_names : string list
-val tool_required_cascade_name : string
 val min_keeper_context_tokens : int
 val max_keeper_context_tokens : int
 val alert_error_detail_max_chars : int


### PR DESCRIPTION
fix(keeper): drop phase_* re-decls from toml facade mlis (#19506 follow-up)

#19506 이 keeper_config 에서 phase_recovery/phase_buffer/phase_routing/
tool_required cascade name 4 상수를 제거했으나, include Keeper_config 체인의
facade .mli 4개(normalizers/parser/toml/io)가 이들을 명시 재선언 → .ml 미제공
mismatch 로 main lib 컴파일 실패. facade .mli 에서도 4개 제거.

별개 선존 breakage(이 PR 무관): keeper_meta_tool_access.ml:111 이 Preset 생성자
사용하나 타입은 Custom-only (#19499 tool_preset 제거 vs #19501 Preset Full 추가
split-brain). 해당 세션 reconcile 필요.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
