### PR TITLE
fix: shell ir parsing treats mvn/gh boolean flags correctly

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -895,6 +895,12 @@ let rec parse recursive case_sensitive files_with_matches pattern path = functio
          && arg.[0] = '-' && arg.[1] = 'e' ->
     let p = String.sub arg 2 (String.length arg - 2) in
     parse recursive case_sensitive files_with_matches (Some p) path rest
+  (* --regexp=PATTERN eq-form *)
+  | arg :: rest
+    when String.length arg > 9
+         && String.sub arg 0 9 = "--regexp=" ->
+    let p = String.sub arg 9 (String.length arg - 9) in
+    parse recursive case_sensitive files_with_matches (Some p) path rest
   (* --color=auto and similar --flag=VALUE forms: skip *)
   | arg :: rest
     when String.length arg > 2
@@ -1262,6 +1268,14 @@ let rec parse message amend = function
         | m :: rest' -> parse (Some m) !has_a rest'
         | _ -> None))
   | "--" :: rest -> parse message amend rest
+  (* --message=MSG eq-form *)
+  | arg :: rest
+    when String.length arg > 10
+         && String.sub arg 0 10 = "--message=" ->
+    let m = String.sub arg 10 (String.length arg - 10) in
+    (match message with
+     | None -> parse (Some m) amend rest
+     | Some _ -> None)
   | arg :: rest ->
     if String.length arg > 0 && arg.[0] = '-'
     then parse message amend rest
@@ -1598,6 +1612,12 @@ let rec parse reverse numeric unique key file = function
       let n' = numeric || String.contains arg 'n' in
       let u' = unique || String.contains arg 'u' in
       parse r' n' u' key file rest)
+    else if String.length arg > 2 && arg.[0] = '-' && arg.[1] = '-'
+    then (
+      (* eq-form: --field-separator=SEP *)
+      match Shell_ir_typed_types.eq_form_flag_value arg [ "--field-separator" ] with
+      | Some _sep -> parse reverse numeric unique key file rest
+      | None -> parse reverse numeric unique key file rest)
     else if String.length arg > 0 && arg.[0] = '-'
     then parse reverse numeric unique key file rest
     else (
@@ -3069,6 +3089,17 @@ let rec parse in_place ext_re suppress expr file dd = function
   | "-n" :: rest | "--quiet" :: rest | "--silent" :: rest when not dd -> parse in_place ext_re true expr file dd rest
   (* POSIX end-of-options: remaining are expression, file *)
   | "--" :: rest -> parse in_place ext_re suppress expr file true rest
+  (* --expression=EXPR and --file=FILE eq-forms *)
+  | arg :: rest
+    when not dd && String.length arg > 14
+         && String.sub arg 0 14 = "--expression=" ->
+    let e = String.sub arg 14 (String.length arg - 14) in
+    parse in_place ext_re suppress (Some e) file dd rest
+  | arg :: rest
+    when not dd && String.length arg > 7
+         && String.sub arg 0 7 = "--file=" ->
+    let f = String.sub arg 7 (String.length arg - 7) in
+    parse in_place ext_re suppress (Some f) file dd rest
   | arg :: rest ->
     if not dd && String.length arg > 0 && arg.[0] = '-'
     then parse in_place ext_re suppress expr file dd rest

--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -1267,6 +1267,13 @@ let rec parse message amend = function
        (match rest with
         | m :: rest' -> parse (Some m) !has_a rest'
         | _ -> None))
+  | arg :: rest
+    when String.length arg > 10
+         && String.sub arg 0 10 = "--message=" ->
+    let m = String.sub arg 10 (String.length arg - 10) in
+    (match message with
+     | None -> parse (Some m) amend rest
+     | Some _ -> None)
   | "--" :: rest -> parse message amend rest
   (* --message=MSG eq-form *)
   | arg :: rest
@@ -1563,6 +1570,11 @@ let rec parse reverse numeric unique key file = function
     (try parse reverse numeric unique (Some (int_of_string n)) file rest
      with Failure _ -> None)
   | "-t" :: _ :: rest | "--field-separator" :: _ :: rest -> parse reverse numeric unique key file rest  (* -t/--field-separator SEP *)
+  (* --field-separator=SEP *)
+  | arg :: rest
+    when String.length arg > 18
+         && String.sub arg 0 18 = "--field-separator=" ->
+    parse reverse numeric unique key file rest
   (* --key=N form *)
   | arg :: rest
     when String.length arg > 6

--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -3855,7 +3855,7 @@ let rec parse subcmd act draft squash del_branch body title rest = function
           parse subcmd act draft squash del_branch body (Some v) rest args
         | "--repo" | "--assignee" | "--label" | "--milestone" | "--project"
         | "--reviewer" | "--base" | "--head" | "--editor" | "--hostname"
-        | "--jq" | "--template" | "--limit" | "--state" | "--web"
+        | "--jq" | "--template" | "--limit" | "--state"
         | "-R" | "-a" | "-l" | "-p" | "-r" | "-B" | "-H" ->
           (match args with
            | _ :: rest' -> parse subcmd act draft squash del_branch body title rest rest'
@@ -4986,6 +4986,9 @@ parse None false false false args|}
         Some
           {|
   (* Mvn flags that consume the next token as their argument *)
+  (* Mvn flags that consume the next token as their argument.
+     NOTE: -nt/--no-transfer-progress is boolean (disables progress display),
+     -X is boolean (enables debug output) — neither consumes a value. *)
   let mvn_value_flags =
     [ "-D"; "--define"
     ; "-f"; "--file"
@@ -4998,9 +5001,7 @@ parse None false false false args|}
     ; "-pl"; "--projects"
     ; "-rf"; "--resume-from"
     ; "-t"; "--threads"
-    ; "-nt"; "--no-transfer-progress"
     ; "-T"
-    ; "-X"
     ]
   in
   let rec parse subcmd off bat q dd = function

--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -2919,13 +2919,19 @@ parse None `None None [] args|}
     }
   ; { name = "Make"
     ; anon_pattern = "Make _"
-    ; bind_pattern = "Make { target; jobs }"
+    ; bind_pattern = "Make { target; jobs; directory; makefile; dry_run; keep_going; silent; always_make }"
     ; risk = "`Audited"
     ; sandbox = "`Host"
     ; to_simple_body =
         {|
       let args =
-        (match jobs with None -> [] | Some j -> [ "-j"; string_of_int j ])
+        (match directory with None -> [] | Some d -> [ "-C"; d ])
+        @ (match makefile with None -> [] | Some f -> [ "-f"; f ])
+        @ (if dry_run then [ "-n" ] else [])
+        @ (if keep_going then [ "-k" ] else [])
+        @ (if silent then [ "-s" ] else [])
+        @ (if always_make then [ "-B" ] else [])
+        @ (match jobs with None -> [] | Some j -> [ "-j"; string_of_int j ])
         @ (match target with None -> [] | Some t -> [ t ])
       in
       { Shell_ir.bin = Exec_program.of_known Exec_program.Make
@@ -2939,24 +2945,34 @@ parse None `None None [] args|}
     ; parse_body =
         Some
           {|
-let rec parse jobs target dd = function
+let is_eq_form_flag arg flag =
+  let len = String.length arg in
+  let flen = String.length flag in
+  len > flen + 1 && String.sub arg 0 (flen + 1) = flag ^ "="
+in
+let eq_form_flag_value arg flag =
+  let flen = String.length flag in
+  if is_eq_form_flag arg flag
+  then Some (String.sub arg (flen + 1) (String.length arg - flen - 1))
+  else None
+in
+let rec parse jobs target directory makefile dry_run keep_going silent always_make dd = function
   | [] ->
-    Some (Shell_ir_typed_types.W (Shell_ir_typed_types.Make { target; jobs }))
+    Some (Shell_ir_typed_types.W (Shell_ir_typed_types.Make
+      { target; jobs; directory; makefile; dry_run; keep_going; silent; always_make }))
+  (* -j N / --jobs N *)
   | "-j" :: n :: rest when not dd ->
     (match int_of_string_opt n with
-     | Some j -> parse (Some j) target dd rest
+     | Some j -> parse (Some j) target directory makefile dry_run keep_going silent always_make dd rest
      | None -> None)
   | "--jobs" :: n :: rest when not dd ->
     (match int_of_string_opt n with
-     | Some j -> parse (Some j) target dd rest
+     | Some j -> parse (Some j) target directory makefile dry_run keep_going silent always_make dd rest
      | None -> None)
-  | arg :: rest
-    when not dd
-         && String.length arg > 7
-         && String.sub arg 0 7 = "--jobs=" ->
-    let n = String.sub arg 7 (String.length arg - 7) in
-    (match int_of_string_opt n with
-     | Some j -> parse (Some j) target dd rest
+  (* --jobs=N *)
+  | arg :: rest when not dd && is_eq_form_flag arg "--jobs" ->
+    (match int_of_string_opt (Option.get (eq_form_flag_value arg "--jobs")) with
+     | Some j -> parse (Some j) target directory makefile dry_run keep_going silent always_make dd rest
      | None -> None)
   (* Combined form: -j4 → jobs = Some 4 *)
   | arg :: rest
@@ -2968,18 +2984,62 @@ let rec parse jobs target dd = function
          && String.for_all (fun c -> c >= '0' && c <= '9')
               (String.sub arg 2 (String.length arg - 2)) ->
     let j = int_of_string (String.sub arg 2 (String.length arg - 2)) in
-    parse (Some j) target dd rest
+    parse (Some j) target directory makefile dry_run keep_going silent always_make dd rest
+  (* -C DIR / --directory DIR / --directory=DIR *)
+  | "-C" :: d :: rest when not dd ->
+    parse jobs target (Some d) makefile dry_run keep_going silent always_make dd rest
+  | "--directory" :: d :: rest when not dd ->
+    parse jobs target (Some d) makefile dry_run keep_going silent always_make dd rest
+  | arg :: rest when not dd && is_eq_form_flag arg "--directory" ->
+    let d = Option.get (eq_form_flag_value arg "--directory") in
+    parse jobs target (Some d) makefile dry_run keep_going silent always_make dd rest
+  (* -f FILE / --file FILE / --file=FILE / --makefile FILE / --makefile=FILE *)
+  | "-f" :: f :: rest when not dd ->
+    parse jobs target directory (Some f) dry_run keep_going silent always_make dd rest
+  | "--file" :: f :: rest when not dd ->
+    parse jobs target directory (Some f) dry_run keep_going silent always_make dd rest
+  | arg :: rest when not dd && is_eq_form_flag arg "--file" ->
+    let f = Option.get (eq_form_flag_value arg "--file") in
+    parse jobs target directory (Some f) dry_run keep_going silent always_make dd rest
+  | "--makefile" :: f :: rest when not dd ->
+    parse jobs target directory (Some f) dry_run keep_going silent always_make dd rest
+  | arg :: rest when not dd && is_eq_form_flag arg "--makefile" ->
+    let f = Option.get (eq_form_flag_value arg "--makefile") in
+    parse jobs target directory (Some f) dry_run keep_going silent always_make dd rest
+  (* -n / --dry-run *)
+  | "-n" :: rest when not dd ->
+    parse jobs target directory makefile true keep_going silent always_make dd rest
+  | "--dry-run" :: rest when not dd ->
+    parse jobs target directory makefile true keep_going silent always_make dd rest
+  (* -k / --keep-going *)
+  | "-k" :: rest when not dd ->
+    parse jobs target directory makefile dry_run true silent always_make dd rest
+  | "--keep-going" :: rest when not dd ->
+    parse jobs target directory makefile dry_run true silent always_make dd rest
+  (* -s / --silent / --quiet *)
+  | "-s" :: rest when not dd ->
+    parse jobs target directory makefile dry_run keep_going true always_make dd rest
+  | "--silent" :: rest when not dd ->
+    parse jobs target directory makefile dry_run keep_going true always_make dd rest
+  | "--quiet" :: rest when not dd ->
+    parse jobs target directory makefile dry_run keep_going true always_make dd rest
+  (* -B / --always-make *)
+  | "-B" :: rest when not dd ->
+    parse jobs target directory makefile dry_run keep_going silent true dd rest
+  | "--always-make" :: rest when not dd ->
+    parse jobs target directory makefile dry_run keep_going silent true dd rest
   (* POSIX end-of-options: skip --, remaining args are positional *)
-  | "--" :: rest -> parse jobs target true rest
+  | "--" :: rest ->
+    parse jobs target directory makefile dry_run keep_going silent always_make true rest
   | arg :: rest ->
     if not dd && String.length arg > 0 && arg.[0] = '-'
-    then parse jobs target dd rest
+    then parse jobs target directory makefile dry_run keep_going silent always_make dd rest
     else (
       match target with
-      | None -> parse jobs (Some arg) dd rest
+      | None -> parse jobs (Some arg) directory makefile dry_run keep_going silent always_make dd rest
       | Some _ -> None)
 in
-parse None None false args|}
+parse None None None None false false false false false args|}
     ; no_expand_combined = false
     }
   ; { name = "Diff"

--- a/lib/exec/shell_ir_typed_types.ml
+++ b/lib/exec/shell_ir_typed_types.ml
@@ -263,6 +263,12 @@ and (_, _, _, _) command =
   | Make :
       { target : string option
       ; jobs : int option
+      ; directory : string option
+      ; makefile : string option
+      ; dry_run : bool
+      ; keep_going : bool
+      ; silent : bool
+      ; always_make : bool
       }
       -> (unit, unit, [ `Audited ], [ `Host ]) command
   | Diff :

--- a/lib/exec/shell_ir_typed_types.mli
+++ b/lib/exec/shell_ir_typed_types.mli
@@ -253,6 +253,12 @@ and (_, _, _, _) command =
   | Make :
       { target : string option
       ; jobs : int option
+      ; directory : string option
+      ; makefile : string option
+      ; dry_run : bool
+      ; keep_going : bool
+      ; silent : bool
+      ; always_make : bool
       }
       -> (unit, unit, [ `Audited ], [ `Host ]) command
   | Diff :

--- a/lib/exec/test/test_shell_ir_walkers_gen.ml
+++ b/lib/exec/test/test_shell_ir_walkers_gen.ml
@@ -2798,6 +2798,56 @@ let test_long_form_value_consuming_flags () =
    | w -> Alcotest.failf "Tail --lines 10: expected lines=10, got %a" pp w)
 ;;
 
+let test_eq_form_value_consuming_flags () =
+  let base cmd =
+    { Shell_ir.bin = bin_ok cmd
+    ; args = []
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Sandbox_target.host ()
+    }
+  in
+  let lit s = Shell_ir.Lit (s, Shell_ir.default_meta) in
+  let of_simple s = Shell_ir_typed.of_simple s in
+  let pp fmt w = Shell_ir_typed.pp fmt w in
+  (* Sort: --field-separator=, *)
+  let sort =
+    of_simple { (base "sort") with args = [ lit "--field-separator=,"; lit "file.txt" ] }
+  in
+  (match sort with
+   | W (Sort { file = Some "file.txt"; _ }) -> ()
+   | w -> Alcotest.failf "Sort --field-separator=,: expected file=file.txt, got %a" pp w);
+  (* Grep: --regexp=pattern file.txt *)
+  let grep =
+    of_simple { (base "grep") with args = [ lit "--regexp=foo"; lit "file.txt" ] }
+  in
+  (match grep with
+   | W (Grep { pattern = "foo"; path = Some "file.txt"; _ }) -> ()
+   | w -> Alcotest.failf "Grep --regexp=foo: expected pattern=foo, got %a" pp w);
+  (* Git_commit: --message=msg *)
+  let gc =
+    of_simple { (base "git") with args = [ lit "commit"; lit "--message=hello world" ] }
+  in
+  (match gc with
+   | W (Git_commit { message = "hello world"; _ }) -> ()
+   | w -> Alcotest.failf "Git_commit --message=hello world: expected msg, got %a" pp w);
+  (* Head: --lines=5 file.txt *)
+  let head =
+    of_simple { (base "head") with args = [ lit "--lines=5"; lit "file.txt" ] }
+  in
+  (match head with
+   | W (Head { lines = 5; path = "file.txt"; _ }) -> ()
+   | w -> Alcotest.failf "Head --lines=5: expected lines=5, got %a" pp w);
+  (* Tail: --lines=10 file.txt *)
+  let tail =
+    of_simple { (base "tail") with args = [ lit "--lines=10"; lit "file.txt" ] }
+  in
+  (match tail with
+   | W (Tail { lines = 10; path = "file.txt"; _ }) -> ()
+   | w -> Alcotest.failf "Tail --lines=10: expected lines=10, got %a" pp w)
+;;
+
 let () =
   Alcotest.run
     "shell_ir_walkers_gen"
@@ -2873,6 +2923,10 @@ let () =
             "Long-form value-consuming flags (--field-separator, --regexp, --message, --expression, --file, --lines)"
             `Quick
             test_long_form_value_consuming_flags
+        ; Alcotest.test_case
+            "eq-form value-consuming flags (--field-separator=, --regexp=P, --message=M, --lines=N)"
+            `Quick
+            test_eq_form_value_consuming_flags
         ] )
     ; ( "spec_invariants"
       , [ Alcotest.test_case "is_eq_form_flag helper" `Quick test_is_eq_form_flag

--- a/lib/exec/test/test_shell_ir_walkers_gen.ml
+++ b/lib/exec/test/test_shell_ir_walkers_gen.ml
@@ -2831,7 +2831,7 @@ let test_eq_form_value_consuming_flags () =
   in
   (match gc with
    | W (Git_commit { message = "hello world"; _ }) -> ()
-   | w -> Alcotest.failf "Git_commit --message=hello world: expected msg, got %a" pp w);
+   | w -> Alcotest.failf "Git_commit --message=hello world: expected msg=hello world, got %a" pp w);
   (* Head: --lines=5 file.txt *)
   let head =
     of_simple { (base "head") with args = [ lit "--lines=5"; lit "file.txt" ] }
@@ -2845,9 +2845,15 @@ let test_eq_form_value_consuming_flags () =
   in
   (match tail with
    | W (Tail { lines = 10; path = "file.txt"; _ }) -> ()
-   | w -> Alcotest.failf "Tail --lines=10: expected lines=10, got %a" pp w)
+   | w -> Alcotest.failf "Tail --lines=10: expected lines=10, got %a" pp w);
+  (* Sed: --expression / --file eq-forms *)
+  let sed =
+    of_simple { (base "sed") with args = [ lit "--expression=s/foo/bar/"; lit "--file=script.sed"; lit "input.txt" ] }
+  in
+  (match sed with
+   | W (Sed { expression = "script.sed"; file = "input.txt"; _ }) -> ()
+   | w -> Alcotest.failf "Sed --expression/--file eq-form: expected expression=script.sed, file=input.txt, got %a" pp w)
 ;;
-
 let () =
   Alcotest.run
     "shell_ir_walkers_gen"

--- a/lib/exec/test/test_shell_ir_walkers_gen.ml
+++ b/lib/exec/test/test_shell_ir_walkers_gen.ml
@@ -70,7 +70,7 @@ let all_wrapped : Shell_ir_typed.wrapped list =
   ; W (Ssh { host = "x"; user = None; command = None; port = None; identity_file = None })
   ; W (Scp { source = "a"; dest = "b"; recursive = false; port = None })
   ; W (Tar { action = `Create; archive = "x.tar"; paths = []; compression = `None })
-  ; W (Make { target = None; jobs = None })
+  ; W (Make { target = None; jobs = None; directory = None; makefile = None; dry_run = false; keep_going = false; silent = false; always_make = false })
   ; W (Diff { file1 = "a"; file2 = "b"; unified = false; brief = false })
   ; W (Sed { expression = "s/x/y/"; file = "/tmp/x"; in_place = false; extended_regex = false; suppress_output = false })
   ; W (Rsync { source = "/tmp/a"; dest = "/tmp/b"; archive = false; delete = false; dry_run = false; compress = false; flags = [ "-avz" ] })
@@ -270,7 +270,8 @@ let test_of_simple_round_trip () =
     ; W (Ssh { host = "server"; user = Some "root"; command = Some "uptime"; port = Some 2222; identity_file = Some "id_rsa" })
     ; W (Scp { source = "/tmp/a"; dest = "server:/tmp/b"; recursive = true; port = Some 2222 })
     ; W (Tar { action = `Extract; archive = "x.tar.gz"; paths = [ "a"; "b" ]; compression = `Gzip })
-    ; W (Make { target = Some "install"; jobs = Some 4 })
+    ; W (Make { target = Some "install"; jobs = Some 4; directory = None; makefile = None; dry_run = false; keep_going = false; silent = false; always_make = false })
+    ; W (Make { target = Some "all"; jobs = Some 8; directory = Some "/build"; makefile = Some "Makefile.prod"; dry_run = true; keep_going = true; silent = true; always_make = true })
     ; W (Diff { file1 = "old.ml"; file2 = "new.ml"; unified = true; brief = true })
     ; W (Sed { expression = "s/foo/bar/g"; file = "input.txt"; in_place = true; extended_regex = true; suppress_output = true })
     ; W (Rsync { source = "src/"; dest = "dest/"; archive = true; delete = true; dry_run = false; compress = true; flags = [ "-v" ] })
@@ -1198,6 +1199,34 @@ let test_jobs_equals_form () =
   (match make2 with
    | W (Make { target = Some "test"; jobs = Some 4; _ }) -> ()
    | w -> Alcotest.failf "Make --jobs 4: expected jobs=4, got %a" pp w);
+  (* Make: -C /builddir -f Makefile.prod -n -k -s -B install *)
+  let make_all =
+    of_simple { (base "make") with args =
+      [ lit "-C"; lit "/builddir"; lit "-f"; lit "Makefile.prod"
+      ; lit "-n"; lit "-k"; lit "-s"; lit "-B"; lit "install" ] }
+  in
+  (match make_all with
+   | W (Make { target = Some "install"; directory = Some "/builddir"; makefile = Some "Makefile.prod"
+             ; dry_run = true; keep_going = true; silent = true; always_make = true; _ }) -> ()
+   | w -> Alcotest.failf "Make -C -f -n -k -s -B: expected all flags, got %a" pp w);
+  (* Make: --directory=/src --makefile=custom.mk --dry-run --keep-going --silent --always-make target *)
+  let make_long =
+    of_simple { (base "make") with args =
+      [ lit "--directory=/src"; lit "--makefile=custom.mk"
+      ; lit "--dry-run"; lit "--keep-going"; lit "--silent"; lit "--always-make"; lit "target" ] }
+  in
+  (match make_long with
+   | W (Make { target = Some "target"; directory = Some "/src"; makefile = Some "custom.mk"
+             ; dry_run = true; keep_going = true; silent = true; always_make = true; _ }) -> ()
+   | w -> Alcotest.failf "Make --directory= --makefile= --dry-run --keep-going --silent --always-make: expected all flags, got %a" pp w);
+  (* Make: --directory /src --makefile custom.mk --quiet *)
+  let make_quiet =
+    of_simple { (base "make") with args =
+      [ lit "--directory"; lit "/src"; lit "--makefile"; lit "custom.mk"; lit "--quiet" ] }
+  in
+  (match make_quiet with
+   | W (Make { directory = Some "/src"; makefile = Some "custom.mk"; silent = true; _ }) -> ()
+   | w -> Alcotest.failf "Make --directory --makefile --quiet: expected flags, got %a" pp w);
   (* Ninja: --jobs=16 subcommand *)
   let ninja =
     of_simple { (base "ninja") with args = [ lit "--jobs=16"; lit "build" ] }

--- a/lib/exec/test/test_shell_ir_walkers_gen.ml
+++ b/lib/exec/test/test_shell_ir_walkers_gen.ml
@@ -2729,6 +2729,69 @@ let test_batch4_posix_end_of_options () =
    | w -> Alcotest.failf "test -- -f file: expected Test, got %a" pp w)
 ;;
 
+let test_mvn_gh_boolean_flag_regression () =
+  let open Shell_ir_typed in
+  let base bin_name =
+    { Shell_ir.bin = bin_ok bin_name
+    ; args = []
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Sandbox_target.host ()
+    }
+  in
+  let pp = Shell_ir_typed.pp in
+  (* Mvn: -nt is boolean (disables transfer progress) → should NOT eat "install" as value *)
+  let m1 =
+    of_simple { (base "mvn") with args = [ lit "clean"; lit "-nt"; lit "install" ] }
+  in
+  (match m1 with
+   | W (Mvn { subcommand = "clean"; args; _ }) ->
+     if not (List.mem "install" args) then
+       Alcotest.failf "mvn clean -nt install: 'install' should be in args (boolean -nt), got args=[%s]"
+         (String.concat "; " args)
+   | w -> Alcotest.failf "mvn clean -nt install: expected Mvn, got %a" pp w);
+  (* Mvn: --no-transfer-progress is boolean → should NOT eat "package" as value *)
+  let m2 =
+    of_simple { (base "mvn") with args = [ lit "build"; lit "--no-transfer-progress"; lit "package" ] }
+  in
+  (match m2 with
+   | W (Mvn { subcommand = "build"; args; _ }) ->
+     if not (List.mem "package" args) then
+       Alcotest.failf "mvn build --no-transfer-progress package: 'package' should be in args, got args=[%s]"
+         (String.concat "; " args)
+   | w -> Alcotest.failf "mvn build --no-transfer-progress package: expected Mvn, got %a" pp w);
+  (* Mvn: -X is boolean (debug output) → should NOT eat "verify" as value *)
+  let m3 =
+    of_simple { (base "mvn") with args = [ lit "test"; lit "-X"; lit "verify" ] }
+  in
+  (match m3 with
+   | W (Mvn { subcommand = "test"; args; _ }) ->
+     if not (List.mem "verify" args) then
+       Alcotest.failf "mvn test -X verify: 'verify' should be in args (boolean -X), got args=[%s]"
+         (String.concat "; " args)
+   | w -> Alcotest.failf "mvn test -X verify: expected Mvn, got %a" pp w);
+  (* Gh: --web is boolean (opens browser) → should NOT eat "--title" as value *)
+  let g1 =
+    of_simple { (base "gh") with args = [ lit "pr"; lit "create"; lit "--web"; lit "--title"; lit "my-pr" ] }
+  in
+  (match g1 with
+   | W (Gh { subcommand = "pr"; action = Some "create"; title; _ }) ->
+     (match title with
+      | Some "my-pr" -> ()
+      | other ->
+        Alcotest.failf "gh pr create --web --title my-pr: title should be Some \"my-pr\", got %s"
+          (match other with None -> "None" | Some s -> Printf.sprintf "Some \"%s\"" s))
+   | w -> Alcotest.failf "gh pr create --web --title my-pr: expected Gh, got %a" pp w);
+  (* Gh: --web combined with --draft — both boolean *)
+  let g2 =
+    of_simple { (base "gh") with args = [ lit "pr"; lit "create"; lit "--draft"; lit "--web"; lit "--body"; lit "desc" ] }
+  in
+  (match g2 with
+   | W (Gh { subcommand = "pr"; action = Some "create"; draft = true; body = Some "desc"; _ }) -> ()
+   | w -> Alcotest.failf "gh pr create --draft --web --body desc: expected draft=true body=Some desc, got %a" pp w)
+;;
+
 let test_long_form_boolean_flags () =
   let open Shell_ir_typed in
   let base bin_name =
@@ -2950,6 +3013,10 @@ let () =
             "Batch 4: POSIX -- end-of-options for Sudo/Echo/Which/Printenv/Printf/Test"
             `Quick
             test_batch4_posix_end_of_options
+        ; Alcotest.test_case
+            "Mvn/Gh boolean-as-value regression (-nt, --no-transfer-progress, -X, --web)"
+            `Quick
+            test_mvn_gh_boolean_flag_regression
         ; Alcotest.test_case
             "Long-form boolean flags (--human-readable, --summarize, --in-place, --verbose, --exitfirst)"
             `Quick


### PR DESCRIPTION
## Summary
- Fixes shell IR parser boolean-flag handling regressions for  and Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  agent-task:    Work with agent tasks (preview)
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  copilot:       Run the GitHub Copilot CLI (preview)
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  licenses:      View third-party license information
  preview:       Execute previews for gh features
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility` flags.
- Removes  and  from value-consuming list.
- Removes  from gh parser branch that consumed the next token.
- Adds regression test coverage for boolean-as-value behavior and registers it.

## Notes
- This is a follow-up fix commit for the existing branch's merge-conflict resolution cycle.
