### PR TITLE
refactor(keeper): cascade→Runtime 숙청 3 — dead phase-buffer liveness probe machinery 적출

### DIFF
--- a/lib/keeper/keeper_turn_liveness.ml
+++ b/lib/keeper/keeper_turn_liveness.ml
@@ -11,82 +11,12 @@ open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 
-type phase_buffer_liveness_decision =
-  | Keep_effective_cascade of string
-  | Probe_phase_buffer_urls of
-      { effective_cascade : string
-      ; fallback_cascade : string
-      ; probeable_base_urls : string list
-      }
-
-let decide_phase_buffer_liveness
-      ?resolve_runtime_url
-      ~(base_cascade : string)
-      ~(effective_cascade : string)
-      (labels : string list)
-  : phase_buffer_liveness_decision
-  =
-  let resolve_runtime_url =
-    match resolve_runtime_url with
-    | Some resolve_runtime_url -> resolve_runtime_url
-    | None -> Cascade_runtime_candidate.runtime_url_of_label
-  in
-  let normalized_base = Keeper_cascade_profile.normalize_declared_name base_cascade in
-  let normalized_effective =
-    Keeper_cascade_profile.normalize_declared_name effective_cascade
-  in
-  if
-    (not (String.equal normalized_effective (Keeper_config.default_cascade_name ())))
-    || String.equal normalized_base (Keeper_config.default_cascade_name ())
-  then Keep_effective_cascade normalized_effective
-  else (
-    let probeable_urls =
-      labels
-      |> List.filter_map resolve_runtime_url
-      |> List.filter (fun url -> Cascade_capacity_probe.can_probe ~url)
-      |> dedupe_keep_order
-    in
-    match probeable_urls with
-    | [] -> Keep_effective_cascade normalized_effective
-    | probeable_base_urls ->
-      Probe_phase_buffer_urls
-        { effective_cascade = normalized_effective
-        ; fallback_cascade = normalized_base
-        ; probeable_base_urls
-        })
-;;
-
-let fail_open_phase_buffer_when_unavailable
-      ?resolve_runtime_url
-      ?probe_base_url
-      ~(base_cascade : string)
-      ~(effective_cascade : string)
-      (labels : string list)
-  : string
-  =
-  match
-    decide_phase_buffer_liveness ?resolve_runtime_url ~base_cascade ~effective_cascade labels
-  with
-  | Keep_effective_cascade cascade -> cascade
-  | Probe_phase_buffer_urls { effective_cascade; fallback_cascade; probeable_base_urls } ->
-    let probe_base_url =
-      match probe_base_url with
-      | Some probe -> Some probe
-      | None ->
-        (match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
-         | Some sw, Some net ->
-           Some
-             (fun base_url ->
-               Option.is_some (Cascade_capacity_probe.probe ~sw ~net ~url:base_url ()))
-         | _ -> None)
-    in
-    (match probe_base_url with
-     | None -> effective_cascade
-     | Some probe ->
-       if List.exists probe probeable_base_urls
-       then effective_cascade
-       else fallback_cascade)
-;;
+(* cascade→Runtime 숙청: phase-buffer liveness probe 기계 제거.
+   per-phase cascade override 가 사라진 뒤(단일 runtime) effective_cascade 는
+   항상 base_cascade 와 같으므로 decide_phase_buffer_liveness 의 probe 분기
+   (effective == phase_buffer && base != phase_buffer 일 때만 발동)는 죽은
+   코드였다. fail_open_phase_buffer_when_unavailable 도 항상 effective_cascade
+   를 그대로 반환 — 호출자(resolve_cascade)가 직접 base 를 쓴다. *)
 
 (** PR-B: saturation pre-skip support (provider-agnostic).
 

--- a/lib/keeper/keeper_turn_liveness.mli
+++ b/lib/keeper/keeper_turn_liveness.mli
@@ -11,37 +11,10 @@ open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 
-(** Deterministic decision for the phase-buffer fallback boundary. This
-    does not probe runtime liveness; it only decides whether the selected
-    labels resolve to runtime URLs that [Cascade_capacity_probe.can_probe]
-    before preserving the canonical phase-buffer route. The provider/model
-    label resolver stays behind [Cascade_runtime_candidate]. *)
-type phase_buffer_liveness_decision =
-  | Keep_effective_cascade of string
-  | Probe_phase_buffer_urls of
-      { effective_cascade : string
-      ; fallback_cascade : string
-      ; probeable_base_urls : string list
-      }
-
-val decide_phase_buffer_liveness
-  :  ?resolve_runtime_url:(string -> string option)
-  -> base_cascade:string
-  -> effective_cascade:string
-  -> string list
-  -> phase_buffer_liveness_decision
-
-(** When phase routing temporarily forces the phase-buffer route, fail open to the
-    keeper's configured base cascade if no registered local-capable probe
-    reports the endpoint as serving. Only the canonical phase-buffer route
-    is treated as the phase routing boundary. *)
-val fail_open_phase_buffer_when_unavailable
-  :  ?resolve_runtime_url:(string -> string option)
-  -> ?probe_base_url:(string -> bool)
-  -> base_cascade:string
-  -> effective_cascade:string
-  -> string list
-  -> string
+(* cascade→Runtime 숙청: phase-buffer liveness probe 기계
+   (phase_buffer_liveness_decision / decide_phase_buffer_liveness /
+   fail_open_phase_buffer_when_unavailable) 제거. 단일 runtime 에서 effective ==
+   base 라 probe 분기가 죽은 코드였다. *)
 
 (** Configurable livelock detection max attempts. *)
 val turn_livelock_max_attempts : unit -> int

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -174,38 +174,8 @@ val ensure_local_discovery_ready
   -> string list
   -> (unit, string) result
 
-(** Deterministic decision for the phase-buffer fallback boundary. This
-    does not probe runtime liveness; it only decides whether the selected
-    labels resolve to a probeable runtime URL before preserving the configured
-    [routes.phase_buffer] target. Removed route aliases are left as raw
-    names; only canonical route keys resolve through routes before this
-    decision. *)
-type phase_buffer_liveness_decision =
-  | Keep_effective_cascade of string
-  | Probe_phase_buffer_urls of
-      { effective_cascade : string
-      ; fallback_cascade : string
-      ; probeable_base_urls : string list
-      }
-
-val decide_phase_buffer_liveness
-  :  ?resolve_runtime_url:(string -> string option)
-  -> base_cascade:string
-  -> effective_cascade:string
-  -> string list
-  -> phase_buffer_liveness_decision
-
-(** When phase routing temporarily forces the phase-buffer route, fail open to the
-    keeper's configured base cascade if the probeable runtime endpoint is
-    unavailable. Removed route aliases are not treated as phase-buffer
-    targets. Exposed for targeted tests. *)
-val fail_open_phase_buffer_when_unavailable
-  :  ?resolve_runtime_url:(string -> string option)
-  -> ?probe_base_url:(string -> bool)
-  -> base_cascade:string
-  -> effective_cascade:string
-  -> string list
-  -> string
+(* cascade→Runtime 숙청: phase-buffer liveness probe 기계 재export 제거
+   (Keeper_turn_liveness 에서 적출됨 — 단일 runtime 에서 죽은 코드). *)
 
 (** Pure merge step for runtime-owned fail-open rotation candidates. The
     active path feeds this from the live cascade catalog: catalog order is

--- a/lib/keeper/keeper_unified_turn_cascade_resolution.ml
+++ b/lib/keeper/keeper_unified_turn_cascade_resolution.ml
@@ -45,28 +45,16 @@ let resolve_cascade
     Keeper_metrics.(to_string FsmEdgeTransitions)
     ~labels:[ "edge", "ksm_to_kcl_routing" ]
     ();
-  let routed_labels =
-    Keeper_model_labels.configured_model_labels_of_meta meta
-  in
-  let resolved_cascade =
-    Keeper_turn_liveness.fail_open_phase_buffer_when_unavailable
-      ~base_cascade:(cascade_name_of_meta meta)
-      ~effective_cascade:routing.effective_cascade
-      routed_labels
-  in
+  (* cascade→Runtime 숙청: phase_buffer liveness fail-open 제거. 단일 runtime
+     에서 effective == base 라 fail_open 은 항상 effective 를 그대로 반환했다 —
+     resolved_cascade 는 곧 routing.effective_cascade. *)
+  let resolved_cascade = routing.effective_cascade in
   Log.Keeper.debug
     "%s: cascade routing: %s -> %s (reason: %s)"
     meta.name
     (cascade_name_of_meta meta)
     routing.effective_cascade
     routing.reason;
-  if not (String.equal resolved_cascade routing.effective_cascade)
-  then
-    Log.Keeper.warn
-      "%s: phase_buffer unavailable for labels [%s]; falling back to base cascade %s"
-      meta.name
-      (String.concat ", " routed_labels)
-      resolved_cascade;
   let decision =
     `Assoc
       (Keeper_cascade_engine.manifest_fields
@@ -76,10 +64,9 @@ let resolve_cascade
          ("effective_cascade", `String routing.effective_cascade);
          ("resolved_cascade", `String resolved_cascade);
          ("routing_reason", `String routing.reason);
-         ( "fail_opened",
-           `Bool
-             (not (String.equal resolved_cascade routing.effective_cascade))
-         );
+         (* fail_opened: phase_buffer liveness fail-open 제거 후 항상 false.
+            manifest schema 호환을 위해 필드는 유지. *)
+         ("fail_opened", `Bool false);
        ])
   in
   append_cascade_routed_manifest ~cascade_name:resolved_cascade ~decision;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -35,11 +35,6 @@ let oas_error_cascade_name raw =
   |> Cascade_name.of_string_exn
 ;;
 
-let phase_buffer_cascade_name () =
-  Masc_mcp.Keeper_cascade_profile.cascade_name_for_use
-    Masc_mcp.Keeper_cascade_profile.Phase_buffer
-;;
-
 let phase_recovery_cascade_name () =
   Masc_mcp.Keeper_cascade_profile.cascade_name_for_use
     Masc_mcp.Keeper_cascade_profile.Phase_recovery
@@ -6151,101 +6146,9 @@ let runtime_url_of_label label =
   | None -> fail ("expected model label to resolve to runtime URL: " ^ label)
 ;;
 
-let test_decide_phase_buffer_liveness_keeps_non_local_effective () =
-  match
-    UT.decide_phase_buffer_liveness
-      ~resolve_runtime_url:(fun _ -> fail "resolver should not run")
-      ~base_cascade:"keeper_unified"
-      ~effective_cascade:"default"
-      [ "not-a-real-label" ]
-  with
-  | UT.Keep_effective_cascade cascade ->
-    check string "keeps selected cascade" (KC.default_cascade_name ()) cascade
-  | UT.Probe_phase_buffer_urls _ -> fail "unexpected local-only probe decision"
-;;
-
-let test_decide_phase_buffer_liveness_keeps_explicit_local_only () =
-  match
-    UT.decide_phase_buffer_liveness
-      ~resolve_runtime_url:(fun _ -> fail "resolver should not run")
-      ~base_cascade:"local_only"
-      ~effective_cascade:"local_only"
-      [ "not-a-real-label" ]
-  with
-  | UT.Keep_effective_cascade cascade ->
-    check
-      string
-      "removed local_only alias stays raw"
-      "local_only"
-      cascade
-  | UT.Probe_phase_buffer_urls _ -> fail "unexpected local-only probe decision"
-;;
-
-let test_decide_phase_buffer_liveness_keeps_phase_buffer_route () =
-  let label = "ollama:qwen3.6:35b-a3b-mlx-bf16" in
-  match
-    UT.decide_phase_buffer_liveness
-      ~base_cascade:"scoring"
-      ~effective_cascade:(KC.default_cascade_name ())
-      [ label; label ]
-  with
-  | UT.Keep_effective_cascade cascade ->
-    check
-      string
-      "phase-buffer route is not probed as a local-only lane"
-      (phase_buffer_cascade_name ())
-      cascade
-  | UT.Probe_phase_buffer_urls _ -> fail "unexpected local-only probe decision"
-;;
-
-let test_fail_open_local_only_when_probe_fails () =
-  let cascade =
-    UT.fail_open_phase_buffer_when_unavailable
-      ~probe_base_url:(fun _ -> false)
-      ~base_cascade:"scoring"
-      ~effective_cascade:(KC.default_cascade_name ())
-      [ "ollama:qwen3.6:35b-a3b-mlx-bf16" ]
-  in
-  check
-    string
-    "keeps configured phase-buffer route"
-    (phase_buffer_cascade_name ())
-    cascade
-;;
-
-let test_fail_open_local_only_preserves_explicit_local_only_base () =
-  let probe_calls = ref 0 in
-  let cascade =
-    UT.fail_open_phase_buffer_when_unavailable
-      ~probe_base_url:(fun _ ->
-        incr probe_calls;
-        false)
-      ~base_cascade:"local_only"
-      ~effective_cascade:"local_only"
-      [ "ollama:qwen3.6:35b-a3b-mlx-bf16" ]
-  in
-  check int "probe not called" 0 !probe_calls;
-  check
-    string
-    "removed local_only alias stays raw"
-    "local_only"
-    cascade
-;;
-
-let test_fail_open_local_only_preserves_healthy_local_only () =
-  let cascade =
-    UT.fail_open_phase_buffer_when_unavailable
-      ~probe_base_url:(fun _ -> true)
-      ~base_cascade:"scoring"
-      ~effective_cascade:(KC.default_cascade_name ())
-      [ "ollama:qwen3.6:35b-a3b-mlx-bf16" ]
-  in
-  check
-    string
-    "healthy ollama keeps phase-buffer route"
-    (phase_buffer_cascade_name ())
-    cascade
-;;
+(* cascade→Runtime 숙청: phase-buffer liveness probe 테스트 6종 제거
+   (decide_phase_buffer_liveness / fail_open_phase_buffer_when_unavailable —
+   Keeper_turn_liveness 에서 적출된 죽은 probe 기계). *)
 
 let wrapped_claude_limit_error () =
   Agent_sdk.Error.Api
@@ -11776,30 +11679,7 @@ let () =
             "async keeper_msg preflight surfaces discovery failure"
             `Quick
             test_keeper_msg_async_failure_surface
-        ; test_case
-            "local_only liveness decision keeps non-local route"
-            `Quick
-            test_decide_phase_buffer_liveness_keeps_non_local_effective
-        ; test_case
-            "local_only liveness decision keeps explicit local base"
-            `Quick
-            test_decide_phase_buffer_liveness_keeps_explicit_local_only
-        ; test_case
-            "local_only liveness decision keeps phase-buffer route"
-            `Quick
-            test_decide_phase_buffer_liveness_keeps_phase_buffer_route
-        ; test_case
-            "local_only fail-open falls back when ollama is down"
-            `Quick
-            test_fail_open_local_only_when_probe_fails
-        ; test_case
-            "explicit local_only does not fail-open"
-            `Quick
-            test_fail_open_local_only_preserves_explicit_local_only_base
-        ; test_case
-            "healthy local_only stays selected"
-            `Quick
-            test_fail_open_local_only_preserves_healthy_local_only
+        (* cascade→Runtime 숙청: phase-buffer liveness probe 테스트 등록 6종 제거. *)
         ; test_case
             "hard quota degraded retry uses local_recovery"
             `Quick


### PR DESCRIPTION
refactor(keeper): purge dead phase-buffer liveness probe machinery (숙청 3)

cascade→Runtime 전환 후 per-phase cascade override 가 제거되어(단일 runtime)
keeper turn 의 effective_cascade 는 항상 base_cascade 와 같다. 이로 인해
phase-buffer liveness probe 기계가 죽은 코드가 되었다:

- decide_phase_buffer_liveness 의 probe 분기는 (effective == phase_buffer &&
  base != phase_buffer) 일 때만 발동하는데, 단일 runtime 에서 effective == base
  라 절대 진입 불가 → 항상 Keep_effective.
- fail_open_phase_buffer_when_unavailable 도 항상 effective_cascade 를 그대로
  반환 → 호출자(resolve_cascade)가 routing.effective_cascade 를 직접 쓴다.

변경:
- keeper_turn_liveness.ml/.mli: phase_buffer_liveness_decision 타입 +
  decide_phase_buffer_liveness + fail_open_phase_buffer_when_unavailable 제거.
  livelock config 함수(turn_livelock_*)는 유지.
- keeper_unified_turn.mli: 위 3종 재export 제거.
- keeper_unified_turn_cascade_resolution.ml: 핫패스에서 fail_open 호출 제거,
  resolved_cascade = routing.effective_cascade. 죽은 warn 제거. manifest
  fail_opened 필드는 schema 호환 위해 false 고정 유지.
- test_keeper_unified.ml: 죽은 liveness probe 테스트 6종(decide 3 + fail_open 3)
  + 등록 + unused 로컬 헬퍼(phase_buffer_cascade_name) 제거.

검증: env DUNE_CACHE 무관 dune build --root . EXIT 0 (lib + test 전체). 5 파일
+23/-283.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
