### PR TITLE
fix(dashboard): align navigation labels and redirects with runtime rebrand

### DIFF
--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -104,7 +104,7 @@ describe('monitoring navigation labels', () => {
     expect(labelFor('agents')).toBe('Keeper Fleet')
     expect(labelFor('fleet-health')).toBe('Tool Monitor')
     expect(labelFor('runtime')).toBe('Runtime')
-    expect(labelFor('observatory')).toBe('Evidence Timeline')
+    expect(labelFor('observatory')).toBe('Observatory')
     expect(labelFor('transport-health')).toBeUndefined()
     expect(labelFor('feature-health')).toBeUndefined()
     expect(labelFor('cognition')).toBeUndefined()
@@ -239,22 +239,22 @@ describe('normalizeRouteParams backward compat (RFC-MASC-006 Phase 0)', () => {
     expect(result.view).toBe('event-log')
   })
 
-  it('redirects legacy activity URL to observatory and upgrades ag_range to range', () => {
+  it('falls back invalid activity section to default agents and upgrades ag_range to range', () => {
     const result = normalizeRouteParams('monitoring', {
       section: 'activity',
       ag_range: '6h',
       keeper: 'nova',
     })
-    expect(result.section).toBe('observatory')
+    expect(result.section).toBe('agents')
     expect(result.range).toBe('6h')
     expect(result.ag_range).toBeUndefined()
     expect(result.keeper).toBe('nova')
   })
 
-  it('redirects live collaboration to the observatory live view', () => {
+  it('falls back invalid live section to default agents', () => {
     const result = normalizeRouteParams('monitoring', { section: 'live' })
-    expect(result.section).toBe('observatory')
-    expect(result.view).toBe('live')
+    expect(result.section).toBe('agents')
+    expect(result.view).toBeUndefined()
   })
 
   it('redirects standalone runtime diagnostics into runtime views', () => {
@@ -280,12 +280,12 @@ describe('normalizeRouteParams backward compat (RFC-MASC-006 Phase 0)', () => {
     expect(result.view).toBe('attribution')
   })
 
-  it('drops unsupported legacy all-range when redirecting activity to observatory', () => {
+  it('falls back invalid activity with unsupported all-range to default agents', () => {
     const result = normalizeRouteParams('monitoring', {
       section: 'activity',
       ag_range: 'all',
     })
-    expect(result.section).toBe('observatory')
+    expect(result.section).toBe('agents')
     expect(result.range).toBeUndefined()
     expect(result.ag_range).toBeUndefined()
   })
@@ -294,10 +294,6 @@ describe('normalizeRouteParams backward compat (RFC-MASC-006 Phase 0)', () => {
 describe('SECTION_REDIRECTS table (consolidation Phase -1)', () => {
   it('exposes the sessions → agents redirect as reference contract', () => {
     expect(SECTION_REDIRECTS['monitoring:sessions']).toEqual({ section: 'agents' })
-  })
-
-  it('exposes the activity → observatory redirect as reference contract', () => {
-    expect(SECTION_REDIRECTS['monitoring:activity']).toEqual({ section: 'observatory' })
   })
 
   it('is the single source of truth for legacy section remaps', () => {
@@ -365,13 +361,13 @@ describe('normalizeRouteParams query param preservation', () => {
     expect(result.session_id).toBe('s-9')
   })
 
-  it('preserves keeper filter through the activity → observatory redirect', () => {
+  it('preserves keeper filter through invalid activity fallback to agents', () => {
     const result = normalizeRouteParams('monitoring', {
       section: 'activity',
       keeper: 'nova',
       ag_range: '24h',
     })
-    expect(result.section).toBe('observatory')
+    expect(result.section).toBe('agents')
     expect(result.keeper).toBe('nova')
     expect(result.range).toBe('24h')
   })

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -96,7 +96,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     id: 'monitoring',
     label: 'Monitor',
     icon: 'monitoring',
-    description: 'Keeper operations, tools, cascade, and evidence',
+    description: 'Keeper operations, tools, runtime, and evidence',
     defaultTab: 'monitoring',
     defaultParams: { section: 'agents' },
     tabs: ['monitoring'],
@@ -191,7 +191,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     },
     {
       id: 'observatory',
-      label: 'Evidence Timeline',
+      label: 'Observatory',
       description: 'Activity and runtime evidence.',
       params: { section: 'observatory' },
     },
@@ -370,8 +370,6 @@ type TabSectionKey = `${TabId}:${string}`
 export const SECTION_REDIRECTS: Record<TabSectionKey, SectionRedirect> = {
   // RFC-MASC-006 Phase 0: sessions stub removed
   'monitoring:sessions': { section: 'agents' },
-  'monitoring:activity': { section: 'observatory' },
-  'monitoring:live': { section: 'observatory', view: 'live' },
 
   // Dashboard consolidation Phase 1: monitoring surface
   'monitoring:telemetry':    { section: 'fleet-health', view: 'event-log' },


### PR DESCRIPTION
Follow-up to #19510 — removes remaining "Evidence Timeline" and "Cascade & Runtime" labels from navigation.ts and navigation.test.ts that were missed in the initial purge due to the PR being merged before the final navigation.ts amend.

Changes:
- navigation.ts: section label "Evidence Timeline" → "Observatory", remove monitoring:activity and monitoring:live redirects, update description.
- navigation.test.ts: update all test expectations for activity/live redirect removal and label changes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
