### PR TITLE
refactor(tool-access): flatten tool_access wrapper to string list

### DIFF
--- a/lib/keeper/agent_tool_execute_runtime.ml
+++ b/lib/keeper/agent_tool_execute_runtime.ml
@@ -322,8 +322,9 @@ let handle_tool_execute
       args
   in
   let write_enabled =
-    let (Custom names) = meta.tool_access in
-    List.exists (fun n -> n = "tool_edit_file" || n = "tool_write_file") names
+    List.exists
+      (fun n -> n = "tool_edit_file" || n = "tool_write_file")
+      meta.tool_access
   in
   if has_typed_execute_input_key args
   then

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -564,7 +564,7 @@ type keeper_meta =
   ; sandbox_image : string option
   ; network_mode : Keeper_types_profile.network_mode
   ; allowed_paths : string list
-  ; tool_access : tool_access
+  ; tool_access : string list
   ; tool_denylist : string list
   ; mention_targets : string list
   ; room_signal_prompt_enabled : bool

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -334,7 +334,7 @@ type keeper_meta = {
   sandbox_image : string option;
   network_mode : Keeper_types_profile.network_mode;
   allowed_paths : string list;
-  tool_access : tool_access;
+  tool_access : string list;
   tool_denylist : string list;
   mention_targets : string list;
   room_signal_prompt_enabled : bool;

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -30,7 +30,7 @@ type parsed_keeper_policy =
   ; pp_sandbox_image : string option
   ; pp_network_mode : network_mode
   ; pp_allowed_paths : string list
-  ; pp_tool_access : tool_access
+  ; pp_tool_access : string list
   ; pp_tool_denylist : string list
   ; pp_mention_targets : string list
   ; pp_room_signal_prompt_enabled : bool

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -32,7 +32,7 @@ type parsed_keeper_policy =
   ; pp_sandbox_image : string option
   ; pp_network_mode : network_mode
   ; pp_allowed_paths : string list
-  ; pp_tool_access : tool_access
+  ; pp_tool_access : string list
   ; pp_tool_denylist : string list
   ; pp_mention_targets : string list
   ; pp_room_signal_prompt_enabled : bool

--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -1,12 +1,11 @@
-(** Keeper meta tool-access contract and JSON helpers.
+(** Keeper meta tool-access helpers.
 
     Included by [Keeper_meta_contract] so [Keeper_types.*] keeps the same
-    public API while tool preset/access policy is isolated from the broader
-    keeper meta runtime contract. *)
+    public API.  A keeper's tool access is simply the list of tool names it
+    may call — [keeper_meta.tool_access : string list].  There is no wrapper
+    type: the allowlist IS the policy. *)
 
 open Keeper_types_profile
-
-type tool_access = Custom of string list
 
 let tool_names_include_board name_list =
   List.exists
@@ -17,8 +16,10 @@ let tool_names_include_board name_list =
     name_list
 ;;
 
-let tool_access_default_room_signal_prompt_enabled ~default = function
-  | Custom tool_names -> default || tool_names_include_board tool_names
+(** Keep [room_signal_prompt] on when [default] is set or the allowlist
+    contains any board tool. *)
+let tool_access_default_room_signal_prompt_enabled ~default tool_names =
+  default || tool_names_include_board tool_names
 ;;
 
 let normalize_tool_names names =
@@ -38,7 +39,7 @@ let legacy_keeper_internal_tool_names =
      silently expand missing [tool_access] migrations.
      Write tools are excluded so that keepers without explicit [tool_access]
      cannot claim write-intent tasks.  Keepers that need write access must
-     use [Custom] with explicit write tool names. *)
+     list explicit write tool names. *)
   Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
   |> List.filter (fun name ->
          not (String.starts_with ~prefix:"masc_" name)
@@ -56,17 +57,13 @@ let legacy_session_min_tool_names =
 ;;
 
 let migrate_legacy_restricted_tools names =
-  Custom (normalize_tool_names (legacy_keeper_internal_tool_names @ names))
+  normalize_tool_names (legacy_keeper_internal_tool_names @ names)
 ;;
 
-let normalize_tool_access (Custom names) = Custom (normalize_tool_names names)
+let normalize_tool_access names = normalize_tool_names names
 
-let tool_access_custom_allowlist (Custom names) = names
-
-let tool_access_to_json (Custom names) =
-  `Assoc
-    [ "kind", `String "custom"; "tools", `List (List.map (fun s -> `String s) names) ]
-;;
+(** Encode a tool allowlist as a JSON array of tool names. *)
+let tool_access_to_json names = `List (List.map (fun s -> `String s) names)
 
 let json_member_present key (json : Yojson.Safe.t) =
   match json with
@@ -107,19 +104,29 @@ let default_tool_access_of_meta_json () =
      gating, not by default tool access exclusion.
      See fleet deadlock Layer 2 analysis (2026-05-30) + cascade provider
      gap analysis (2026-05-30). *)
-  Custom (normalize_tool_names
-    (Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal))
+  normalize_tool_names (Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal)
 ;;
 
+(** Parse [tool_access] from persisted meta JSON.
+    Canonical form is a JSON array of tool names.
+    Legacy forms are accepted for backward compat:
+    - [{ "kind": "custom", "tools": [...] }] → the [tools] array
+    - [{ "kind": "preset", ... }] → default surface (presets removed) *)
 let tool_access_of_meta_json (json : Yojson.Safe.t) =
   match Json_util.assoc_member_opt "tool_access" json with
-  | Some `Null -> Ok (default_tool_access_of_meta_json ())
+  | Some `Null | None -> Ok (default_tool_access_of_meta_json ())
+  | Some (`List _ as list_json) ->
+    (match
+       string_list_field_result ~field_name:"tool_access"
+         (`Assoc [ "tool_access", list_json ])
+     with
+     | Ok tools -> Ok (normalize_tool_access tools)
+     | Error msg -> Error msg)
   | Some (`Assoc _ as access_json) ->
-    let kind = Json_util.get_string access_json "kind" in
-    (match kind with
+    (match Json_util.get_string access_json "kind" with
      | Some "preset" ->
        (* Legacy preset entries: fall back to default access.
-          Keeper bootstrap resyncs from TOML which now requires explicit custom lists. *)
+          Keeper bootstrap resyncs from TOML which now requires explicit lists. *)
        Log.Keeper.warn
          "keeper meta has deprecated tool_access.kind='preset'; \
           defaulting to keeper_internal surface until next bootstrap";
@@ -131,17 +138,15 @@ let tool_access_of_meta_json (json : Yojson.Safe.t) =
             ~label:"tool_access.tools"
             access_json
         with
-        | Ok tools -> Ok (normalize_tool_access (Custom tools))
+        | Ok tools -> Ok (normalize_tool_access tools)
         | Error msg -> Error msg)
      | Some other -> Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
      | None ->
        (* Empty tool_access: {} — missing kind field.
-          Safe to default: ensure_keeper_meta resyncs from TOML on bootstrap.
-          Without this, meta_of_json fails and recovery via
-          load_or_materialize_boot_meta also fails (handle_keeper_up calls
-          read_meta which hits the same parse error). *)
+          Safe to default: ensure_keeper_meta resyncs from TOML on bootstrap. *)
        Ok (default_tool_access_of_meta_json ()))
-  | _ ->
-    (* tool_access missing or not an object — same recovery rationale. *)
-    Ok (default_tool_access_of_meta_json ())
+  | Some other ->
+    Error
+      (Printf.sprintf "keeper tool_access must be an array of strings (received %s)"
+         (Json_util.kind_name other))
 ;;

--- a/lib/keeper/keeper_meta_tool_access.mli
+++ b/lib/keeper/keeper_meta_tool_access.mli
@@ -1,32 +1,27 @@
-(** Keeper tool-access policy types and JSON helpers.
+(** Keeper tool-access helpers.
 
-    Defines the canonical [tool_access] ADT and parsers for persisted
-    keeper meta JSON.  Named presets have been removed; keepers declare
-    an explicit [Custom] tool list. *)
-
-type tool_access = Custom of string list
+    A keeper's tool access is the list of tool names it may call —
+    [keeper_meta.tool_access : string list].  There is no wrapper type;
+    the allowlist IS the policy. *)
 
 (** Returns true if any name in the list resolves to a [Tool_name.is_board]
     tool. Used to detect implicit board surface. *)
 val tool_names_include_board : string list -> bool
 
-(** Decide whether a [tool_access] should keep [room_signal_prompt] on:
-    Custom → true when the list contains any board tool (or [default] is
-    true). *)
+(** Keep [room_signal_prompt] on when [default] is set or the allowlist
+    contains any board tool. *)
 val tool_access_default_room_signal_prompt_enabled :
-  default:bool -> tool_access -> bool
+  default:bool -> string list -> bool
 
 (** Trim, drop blanks, dedupe (preserve first-seen order). *)
 val normalize_tool_names : string list -> string list
 
-(** Sort Custom lists for stable comparison and hash. *)
-val normalize_tool_access : tool_access -> tool_access
+(** Trim, drop blanks, dedupe a tool allowlist (alias of
+    {!normalize_tool_names}, kept for call-site clarity). *)
+val normalize_tool_access : string list -> string list
 
-val tool_access_custom_allowlist : tool_access -> string list
-
-(** Encode a [tool_access] as the canonical
-    [{ "kind": "custom", "tools": [...] }] JSON object. *)
-val tool_access_to_json : tool_access -> Yojson.Safe.t
+(** Encode a tool allowlist as a JSON array of tool names. *)
+val tool_access_to_json : string list -> Yojson.Safe.t
 
 (** True if [json] has a non-null member at [key] (top level). *)
 val json_member_present : string -> Yojson.Safe.t -> bool
@@ -47,12 +42,12 @@ val string_list_field_opt_result :
   Yojson.Safe.t ->
   (string list, string) result
 
-(** Default [tool_access] for missing/null fields:
+(** Default tool allowlist for missing/null fields:
     [Keeper_internal] surface with write tools excluded. *)
-val default_tool_access_of_meta_json : unit -> tool_access
+val default_tool_access_of_meta_json : unit -> string list
 
-(** Parse [tool_access] from persisted meta JSON, accepting "custom" kind.
-    Legacy "preset" kind falls back to [default_tool_access_of_meta_json]
-    with a deprecation warning. *)
+(** Parse [tool_access] from persisted meta JSON.  Canonical form is a JSON
+    array of tool names; legacy [{ "kind": "custom"/"preset", ... }] objects
+    are accepted for backward compat. *)
 val tool_access_of_meta_json :
-  Yojson.Safe.t -> (tool_access, string) result
+  Yojson.Safe.t -> (string list, string) result

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -153,7 +153,7 @@ let resynced_tool_access
     (defaults : Keeper_types_profile.keeper_profile_defaults)
     (meta : keeper_meta) =
   match defaults.tool_custom_list with
-  | Some tools -> Custom (normalize_tool_names tools)
+  | Some tools -> normalize_tool_names tools
   | None -> meta.tool_access
 
 let ensure_keeper_meta config name =

--- a/lib/keeper/keeper_runtime.mli
+++ b/lib/keeper/keeper_runtime.mli
@@ -92,7 +92,7 @@ val effective_declarative_cascade_name :
 
 val resynced_tool_access :
   Keeper_types_profile.keeper_profile_defaults ->
-  Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.tool_access
+  Keeper_meta_contract.keeper_meta -> string list
 (** Re-derive the tool-access record after merging profile defaults so
     the meta-level [preset] and per-tool overrides stay consistent. *)
 

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -255,10 +255,7 @@ let last_turn_safe_tool_names () =
     "last_turn_safe"
 
 let tool_policy_of_meta (meta : keeper_meta) =
-  let allow =
-    match meta.tool_access with
-    | Custom allowlist -> Tool_access_policy.Names allowlist
-  in
+  let allow = Tool_access_policy.Names meta.tool_access in
   {
     Tool_access_policy.allow;
     deny = Tool_access_policy.Names meta.tool_denylist;
@@ -425,12 +422,8 @@ let keeper_universe_tool_names (meta : keeper_meta) : string list =
     See #4637 (Samchon harness: absence > prohibition). *)
 let keeper_tool_search_scope (meta : keeper_meta) : string list =
   let lookup = tool_access_lookup_of_meta meta in
-  let preset_tools =
-    match meta.tool_access with
-    | Custom allowlist -> allowlist
-  in
-  let from_preset =
-    preset_tools
+  let from_allowlist =
+    meta.tool_access
     |> List.filter (fun name ->
          StringSet.mem name lookup.candidate_set
          && not (StringSet.mem name lookup.deny_set))
@@ -439,7 +432,7 @@ let keeper_tool_search_scope (meta : keeper_meta) : string list =
     Keeper_tool_registry.core_always_tools
     |> List.filter (fun name -> not (StringSet.mem name lookup.deny_set))
   in
-  dedupe_tool_names (from_preset @ from_core)
+  dedupe_tool_names (from_allowlist @ from_core)
 
 (** Shared schema assembly: computes the full tool schema list once.
     [masc_schemas_fn] selects policy-filtered or universe-filtered MASC schemas

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -31,7 +31,7 @@ type parsed_args = {
   compaction_message_gate_opt : int option;
   compaction_token_gate_opt : int option;
   continuity_compaction_cooldown_sec_opt : int option;
-  tool_access_opt : tool_access option;
+  tool_access_opt : string list option;
   tool_denylist_opt : string list option;
   auto_handoff_opt : bool option;
   handoff_threshold_opt : float option;
@@ -144,7 +144,7 @@ let reject_legacy_tool_access_kind access_json =
   | _ -> Ok ()
 
 let parse_tool_access_input (args : Yojson.Safe.t) :
-    (tool_access option, string) result =
+    (string list option, string) result =
   let removed_tool_policy_keys =
     present_json_keys
       [ "tool_preset"; "tool_also_allow"; "tool_custom_allowlist" ]

--- a/lib/keeper/keeper_turn_up_args.mli
+++ b/lib/keeper/keeper_turn_up_args.mli
@@ -33,7 +33,7 @@ type parsed_args =
   ; compaction_message_gate_opt : int option
   ; compaction_token_gate_opt : int option
   ; continuity_compaction_cooldown_sec_opt : int option
-  ; tool_access_opt : tool_access option
+  ; tool_access_opt : string list option
   ; tool_denylist_opt : string list option
   ; auto_handoff_opt : bool option
   ; handoff_threshold_opt : float option
@@ -88,7 +88,7 @@ val reject_legacy_tool_access_kind :
     Legacy top-level tool-policy args are rejected. *)
 val parse_tool_access_input :
   Yojson.Safe.t ->
-  (tool_access option, string) result
+  (string list option, string) result
 
 (** Top-level parser: project the [keeper_up] tool args JSON to a
     [parsed_args] record, or return a [tool_result] error envelope. *)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -185,7 +185,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                 | Some access -> access
                 | None ->
                     (match p.profile_defaults.tool_custom_list with
-                     | Some tools -> Custom (normalize_tool_names tools)
+                     | Some tools -> normalize_tool_names tools
                      | None -> default_tool_access_of_meta_json ())
               in
               let room_signal_prompt_enabled =

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -132,7 +132,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     | Some access -> access
     | None ->
         (match p.profile_defaults.tool_custom_list with
-         | Some tools -> Custom (normalize_tool_names tools)
+         | Some tools -> normalize_tool_names tools
          | None -> old.tool_access)
   in
   let room_signal_prompt_enabled =

--- a/test/test_agent_tool_dispatch_runtime.ml
+++ b/test/test_agent_tool_dispatch_runtime.ml
@@ -51,7 +51,7 @@ let make_meta ?(name = "keeper-exec-tools") ?(policy_voice_enabled = false) ?too
     match tool_access with
     | Some value -> value
     | None ->
-        Masc_mcp.Keeper_meta_tool_access.Custom []
+        []
   in
   match
     Masc_test_deps.meta_of_json_fixture
@@ -163,7 +163,7 @@ let test_malformed_json_like_payload_detected () =
 
 let test_execute_with_outcome_policy_gate_is_failure () =
   with_exec_fixture
-    ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "keeper_tools_list" ])
+    ~tool_access:([ "keeper_tools_list" ])
     "agent_tool_dispatch_runtime_policy_gate"
     (fun ~config ~meta ~ctx_work ->
       let result =
@@ -195,7 +195,7 @@ let test_tool_not_allowed_increments_counter () =
   let tool = "tool_read_file" in
   let reason = "not_in_allow_set" in
   with_exec_fixture
-    ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "keeper_tools_list" ])
+    ~tool_access:([ "keeper_tools_list" ])
     "agent_tool_dispatch_runtime_not_allowed_counter"
     (fun ~config ~meta ~ctx_work ->
       let before = counter_for_tool_not_allowed ~keeper ~tool ~reason in
@@ -229,7 +229,7 @@ let test_tool_not_allowed_denied_by_policy_counter () =
           ; ("allowed_paths", `List [ `String "*" ])
           ; ( "tool_access"
             , Masc_mcp.Keeper_meta_tool_access.tool_access_to_json
-                (Masc_mcp.Keeper_meta_tool_access.Custom [ "keeper_board_post" ]) )
+                ([ "keeper_board_post" ]) )
           ; ( "tool_denylist"
             , `List [ `String "keeper_board_post" ] )
           ])
@@ -268,7 +268,7 @@ let test_tool_not_allowed_reason_label_is_bounded () =
   (* Verify that the reason label written into the JSON payload is one
      of the three bounded vocabulary values, not a free-form string. *)
   with_exec_fixture
-    ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "keeper_tools_list" ])
+    ~tool_access:([ "keeper_tools_list" ])
     "agent_tool_dispatch_runtime_reason_bounded"
     (fun ~config ~meta ~ctx_work ->
       let result =
@@ -289,7 +289,7 @@ let test_keeper_tools_list_json_uses_typed_groups () =
     make_meta
       ~policy_voice_enabled:true
       ~tool_access:
-        (Masc_mcp.Keeper_meta_tool_access.Custom
+        (
            [ "keeper_board_post";
              "keeper_board_fake";
              "keeper_voice_speak";

--- a/test/test_agent_tool_execute_safety.ml
+++ b/test/test_agent_tool_execute_safety.ml
@@ -744,7 +744,7 @@ let make_write_enabled_meta name =
         ("goal", `String "write-enabled Execute test");
         ( "tool_access",
           Keeper_meta_tool_access.tool_access_to_json
-            (Keeper_meta_tool_access.Custom ["tool_edit_file"; "tool_write_file"]) );
+            (["tool_edit_file"; "tool_write_file"]) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -182,7 +182,7 @@ let make_test_meta name =
           ("trace_id", `String ("trace-" ^ name));
           ( "tool_access",
             Lib.Keeper_meta_tool_access.tool_access_to_json
-              (Lib.Keeper_meta_tool_access.Custom []) );
+              ([]) );
         ])
   with
   | Ok meta -> meta

--- a/test/test_dashboard_briefing.ml
+++ b/test/test_dashboard_briefing.ml
@@ -418,7 +418,7 @@ let test_dashboard_briefing_keeper_brief_registry_lookup_scoped_to_base_path () 
             ("trace_id", `String ("trace-" ^ name));
             ( "tool_access",
               Lib.Keeper_meta_tool_access.tool_access_to_json
-                (Lib.Keeper_meta_tool_access.Custom []) );
+                ([]) );
           ])
     with
     | Ok meta -> meta

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -40,7 +40,7 @@ let make_test_meta ?(name = "keeper-sangsu") ?(agent_name = "keeper-sangsu-agent
                ("trace_id", `String "test-trace-accountability");
                ( "tool_access",
                  Keeper_meta_tool_access.tool_access_to_json
-                   (Keeper_meta_tool_access.Custom []) );
+                   ([]) );
              ])
   with
   | Ok meta -> meta

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -25,7 +25,7 @@ let make_meta_ref (name : string) : Masc_mcp.Keeper_meta_contract.keeper_meta re
     ("trace_id", `String "keeper-guards-test");
     ("tool_access",
       Masc_mcp.Keeper_meta_tool_access.tool_access_to_json
-        (Masc_mcp.Keeper_meta_tool_access.Custom []));
+        ([]));
   ] in
   match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> ref meta

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -100,7 +100,7 @@ let make_meta ?(name = "keeper-bridge-test") ?tool_access ?(tool_denylist = [])
     match tool_access with
     | Some access -> access
     | None ->
-        Masc_mcp.Keeper_meta_tool_access.Custom []
+        []
   in
   match Masc_test_deps.meta_of_json_fixture
     (`Assoc
@@ -148,7 +148,7 @@ let test_inject_stores_filtered_masc () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_meta_tool_access.Custom
+        (
            [ "masc_status"; "masc_broadcast"; "masc_messages" ])
       ()
   in
@@ -180,7 +180,7 @@ let test_messaging_preset_exposes_board () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_meta_tool_access.Custom [])
+        ([])
       ()
   in
   let names = KET.keeper_allowed_tool_names meta in
@@ -199,7 +199,7 @@ let test_custom_opens_specific_tools_only () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_meta_tool_access.Custom
+        (
            [ "masc_status"; "masc_tasks"; "masc_join" ])
       ()
   in
@@ -219,7 +219,7 @@ let test_deny_overrides_allow () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_meta_tool_access.Custom
+        (
            [ "masc_status"; "masc_tasks"; "masc_join" ])
       ~tool_denylist:[ "masc_tasks" ] ()
   in
@@ -232,7 +232,7 @@ let test_deny_overrides_allow () =
 let test_custom_empty_blocks_all () =
   prime_keeper_bridge ();
   let meta =
-    make_meta ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom []) ()
+    make_meta ~tool_access:([]) ()
   in
   let names = KET.keeper_allowed_tool_names meta in
   Alcotest.(check int) "no tools" 0 (List.length names)
@@ -242,7 +242,7 @@ let test_preset_with_also_allow_opens_extra_tool () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_meta_tool_access.Custom [])
+        ([])
       ()
   in
   let names = KET.keeper_allowed_tool_names meta in
@@ -259,7 +259,7 @@ let test_custom_keeps_registered_inline_board_tool () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_meta_tool_access.Custom
+        (
            [ "keeper_board_post"; "masc_who" ])
       ()
   in
@@ -283,7 +283,7 @@ let test_dashboard_tool_count_uses_schema_ssot () =
       let meta =
         make_meta
           ~tool_access:
-            (Masc_mcp.Keeper_meta_tool_access.Custom [ bridge_name ])
+            ([ bridge_name ])
           ()
       in
       let allowed = KET.keeper_allowed_tool_names meta in
@@ -446,8 +446,7 @@ let test_tool_access_preset_empty_json_preserved () =
     | Error e -> failwith e
   in
   (* Legacy "preset" JSON now falls back to default_tool_access_of_meta_json on load *)
-  match meta.Masc_mcp.Keeper_meta_contract.tool_access with
-  | Masc_mcp.Keeper_meta_tool_access.Custom _ -> ()
+  ignore meta.Masc_mcp.Keeper_meta_contract.tool_access
 
 let test_tool_access_custom_empty_json_preserved () =
   let meta =
@@ -468,9 +467,8 @@ let test_tool_access_custom_empty_json_preserved () =
     | Ok meta -> meta
     | Error e -> failwith e
   in
-  match meta.Masc_mcp.Keeper_meta_contract.tool_access with
-  | Masc_mcp.Keeper_meta_tool_access.Custom names ->
-      Alcotest.(check int) "custom empty preserved" 0 (List.length names)
+  let names = meta.Masc_mcp.Keeper_meta_contract.tool_access in
+  Alcotest.(check int) "custom empty preserved" 0 (List.length names)
 
 let test_tool_access_invalid_kind_rejected () =
   match Masc_test_deps.meta_of_json_fixture
@@ -589,7 +587,7 @@ let test_allowlist_gates_shard_tools () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_meta_tool_access.Custom
+        (
            [ "masc_status"; "masc_tasks" ])
       ()
   in
@@ -615,7 +613,7 @@ let test_approval_pending_bridge_uses_keeper_safe_inline_dispatch () =
       let config = Coord.default_config dir in
       let meta =
         make_meta
-          ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "masc_approval_pending" ])
+          ~tool_access:([ "masc_approval_pending" ])
           ()
       in
       with_registered_keeper ~config meta (fun () ->
@@ -652,7 +650,7 @@ let test_read_only_preflight_accepts_sandbox_relative_repo_path () =
           make_meta
             ~name:"masc-improver"
             ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Docker
-            ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "tool_read_file" ])
+            ~tool_access:([ "tool_read_file" ])
             ()
         in
         with_registered_keeper ~config meta (fun () ->
@@ -711,7 +709,7 @@ let test_write_preflight_accepts_docker_container_repo_path () =
           make_meta
             ~name:"sangsu"
             ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Docker
-            ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "tool_edit_file" ])
+            ~tool_access:([ "tool_edit_file" ])
             ()
         in
         with_registered_keeper ~config meta (fun () ->
@@ -778,7 +776,7 @@ let test_write_preflight_accepts_sandbox_relative_repo_path () =
           make_meta
             ~name:keeper_name
             ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Docker
-            ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "tool_edit_file" ])
+            ~tool_access:([ "tool_edit_file" ])
             ()
         in
         ignore (Masc_mcp.Keeper_registry.register ~base_path:dir keeper_name meta);
@@ -814,7 +812,7 @@ let test_schemas_match_names () =
   let meta =
     make_meta
       ~tool_access:
-        (Masc_mcp.Keeper_meta_tool_access.Custom
+        (
            [ "masc_status"; "masc_join"; "masc_tasks" ])
       ()
   in

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -327,7 +327,7 @@ also_allow = ["tool_execute", "tool_search_files"]
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
-      let (Keeper_meta_tool_access.Custom tools) = updated.Keeper_meta_contract.tool_access in
+      let tools = updated.Keeper_meta_contract.tool_access in
       check bool "has custom tool_access" true (tools <> []);
       check
         (list string)
@@ -473,16 +473,10 @@ allowed_paths = ["workspace/example/project"]
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
       check
-        (option string)
-        "custom access keeps no preset"
-        None
-        ((fun _ -> None) updated.Keeper_meta_contract.tool_access
-         |> Option.map Keeper_meta_tool_access.(fun _ -> "custom"));
-      check
         (list string)
         "custom allowlist preserved"
         [ "keeper_board_get"; "masc_status" ]
-        (Keeper_meta_tool_access.tool_access_custom_allowlist updated.tool_access);
+        updated.tool_access;
       check
         (list string)
         "allowed_paths"

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -24,7 +24,7 @@ let make_meta
   let tool_access =
     match tool_access with
     | Some access -> access
-    | None -> Keeper_meta_tool_access.Custom []
+    | None -> []
   in
   let json = `Assoc [
     ("name", `String name);

--- a/test/test_keeper_sandbox_containment.ml
+++ b/test/test_keeper_sandbox_containment.ml
@@ -52,7 +52,7 @@ let make_meta ~name ~sandbox =
         ("policy_voice_enabled", `Bool false);
         ( "tool_access",
           Keeper_meta_tool_access.tool_access_to_json
-            (Keeper_meta_tool_access.Custom []) );
+            ([]) );
         ("sandbox_profile",
          `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox));
       ]

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -168,7 +168,7 @@ let make_meta ?preset ~name ~sandbox () =
         [
           ( "tool_access",
             Keeper_meta_tool_access.tool_access_to_json
-              (Keeper_meta_tool_access.Custom []) );
+              ([]) );
         ]
   in
   let json =

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -23,7 +23,7 @@ let make_goal_scoped_meta goal_ids =
 ;;
 
 let make_meta_with_tools tools =
-  { (make_test_meta ()) with tool_access = Keeper_meta_tool_access.Custom tools }
+  { (make_test_meta ()) with tool_access = tools }
 ;;
 
 let make_ctx_work () = Keeper_context_runtime.create ~system_prompt:"test" ~max_tokens:4000

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1148,7 +1148,7 @@ let test_persona_resolver_preserves_canonical_tool_access_and_allowed_paths () =
 |};
   let expected_tool_access =
     Masc_mcp.Keeper_meta_tool_access.tool_access_to_json
-      (Masc_mcp.Keeper_meta_tool_access.Custom [ "masc_status" ])
+      ([ "masc_status" ])
   in
   match
     Masc_mcp.Agent_tool_persona_runtime.resolved_keeper_args_from_persona

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -22,7 +22,7 @@ let make_meta
   let tool_access =
     match tool_access with
     | Some access -> access
-    | None -> Keeper_meta_tool_access.Custom []
+    | None -> []
   in
   let json =
     `Assoc
@@ -152,7 +152,7 @@ let test_voice_policy_disabled_hides_voice_tools () =
 ;;
 
 let test_custom_empty_blocks_all_tools () =
-  let meta = make_meta ~tool_access:(Keeper_meta_tool_access.Custom []) () in
+  let meta = make_meta ~tool_access:([]) () in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   check int "custom empty blocks every tool" 0 (List.length tools)
 ;;
@@ -162,7 +162,7 @@ let test_custom_unknown_tool_names_are_dropped () =
   let meta =
     make_meta
       ~tool_access:
-        (Keeper_meta_tool_access.Custom [ "keeper_time_now"; "masc_status"; "totally_unknown_tool" ])
+        ([ "keeper_time_now"; "masc_status"; "totally_unknown_tool" ])
       ()
   in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
@@ -480,7 +480,7 @@ let test_research_plus_also_allow_combined () =
   let meta =
     make_meta
       ~tool_access:
-        (Keeper_meta_tool_access.Custom [])
+        ([])
       ()
   in
   let tools = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
@@ -1504,7 +1504,7 @@ let () =
             in
             let outer = `Assoc [ "tool_access", json ] in
             match Keeper_meta_tool_access.tool_access_of_meta_json outer with
-            | Ok (Custom tools) ->
+            | Ok tools ->
               check bool "has masc_status" true (List.mem "masc_status" tools);
               check bool "has masc_broadcast" true (List.mem "masc_broadcast" tools)
             | Error msg -> fail ("unexpected error: " ^ msg))

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -92,7 +92,7 @@ let make_meta ?(name = "keeper-tool-matrix") () =
           ("allowed_paths", `List [ `String "*" ]);
           ( "tool_access",
             Masc_mcp.Keeper_meta_tool_access.tool_access_to_json
-              (Masc_mcp.Keeper_meta_tool_access.Custom [] ) );
+              ([] ) );
         ])
   with
   | Ok meta -> meta

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -32,7 +32,7 @@ let make_test_meta
   let tool_access =
     match tool_access with
     | Some access -> access
-    | None -> Keeper_meta_tool_access.Custom []
+    | None -> []
   in
   match
     Masc_test_deps.meta_of_json_fixture
@@ -906,7 +906,7 @@ let make_research_meta ?tool_access () : Keeper_meta_contract.keeper_meta =
   let tool_access =
     match tool_access with
     | Some access -> access
-    | None -> Keeper_meta_tool_access.Custom []
+    | None -> []
   in
   match
     Masc_test_deps.meta_of_json_fixture
@@ -931,7 +931,7 @@ let make_learned_meta () : Keeper_meta_contract.keeper_meta =
           ; "trace_id", `String "test-trace-learned"
           ; ( "tool_access"
             , Keeper_meta_tool_access.tool_access_to_json
-                (Keeper_meta_tool_access.Custom []) )
+                ([]) )
           ])
   with
   | Ok meta -> meta

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -385,7 +385,7 @@ let make_meta name : Masc_mcp.Keeper_meta_contract.keeper_meta =
 let minimal_meta : Masc_mcp.Keeper_meta_contract.keeper_meta = make_meta "test-keeper"
 
 let minimal_policy_meta =
-  { minimal_meta with tool_access = Custom [] }
+  { minimal_meta with tool_access = [] }
 ;;
 
 let room_signal_meta = { minimal_meta with room_signal_prompt_enabled = true }
@@ -3205,10 +3205,10 @@ let test_tool_guidance_uses_registered_keeper_tool_schemas () =
   Masc_mcp.Agent_tool_dispatch_runtime.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
   let module Guidance = Masc_mcp.Keeper_tool_guidance in
   let social_meta =
-    { minimal_meta with tool_access = Custom [] }
+    { minimal_meta with tool_access = [] }
   in
   let coding_meta =
-    { minimal_meta with tool_access = Custom [] }
+    { minimal_meta with tool_access = [] }
   in
   let social_allowed = Masc_mcp.Agent_tool_dispatch_runtime.keeper_allowed_tool_names social_meta in
   let coding_allowed = Masc_mcp.Agent_tool_dispatch_runtime.keeper_allowed_tool_names coding_meta in
@@ -7053,7 +7053,7 @@ let test_prompt_includes_board_activity_section () =
   let board_meta =
     { minimal_meta with
       tool_access =
-        Custom []
+        []
     }
   in
   let sys, user =

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -333,7 +333,7 @@ let test_runtime_mcp_keeper_log_context_loads_current_task_contract () =
   let meta =
     make_keeper_meta
       ~current_task_id:"task-001"
-      ~tool_access:(Masc_mcp.Keeper_meta_tool_access.Custom [ "tool_execute" ])
+      ~tool_access:([ "tool_execute" ])
       keeper_name
   in
   Fun.protect

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -501,7 +501,7 @@ let test_universe_superset_of_policy () =
   init_keeper_tool_registry ();
   let base = make_gate_test_meta () in
   let meta = { base with
-    tool_access = Custom [];
+    tool_access = [];
     tool_denylist = [];
   } in
   let policy = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
@@ -517,7 +517,7 @@ let test_minimal_preset_includes_core_masc () =
   init_keeper_tool_registry ();
   let base = make_gate_test_meta ~name:"test-minimal" () in
   let meta = { base with
-    tool_access = Custom [];
+    tool_access = [];
     tool_denylist = [];
   } in
   let universe = Agent_tool_dispatch_runtime.keeper_universe_tool_names meta in
@@ -538,7 +538,7 @@ let test_preset_universe_subset_of_global () =
   init_keeper_tool_registry ();
   let base = make_gate_test_meta () in
   let meta = { base with
-    tool_access = Custom [];
+    tool_access = [];
     tool_denylist = [];
   } in
   let scoped = Agent_tool_dispatch_runtime.keeper_tool_search_scope meta in
@@ -554,7 +554,7 @@ let test_preset_universe_includes_core () =
   init_keeper_tool_registry ();
   let base = make_gate_test_meta ~name:"test-scoped" () in
   let meta = { base with
-    tool_access = Custom [];
+    tool_access = [];
     tool_denylist = [];
   } in
   let scoped = Agent_tool_dispatch_runtime.keeper_tool_search_scope meta in
@@ -573,7 +573,7 @@ let test_dispatch_preset_routes_pm_tools () =
   init_keeper_tool_registry ();
   let base = make_gate_test_meta ~name:"test-dispatch" () in
   let meta = { base with
-    tool_access = Custom [];
+    tool_access = [];
     tool_denylist = [];
   } in
   let allowed = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
@@ -616,7 +616,7 @@ let test_delivery_preset_routes_coordination_read_models () =
   init_keeper_tool_registry ();
   let base = make_gate_test_meta ~name:"test-delivery-coordination-read" () in
   let meta = { base with
-    tool_access = Custom [];
+    tool_access = [];
     tool_denylist = [];
   } in
   let allowed = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
@@ -637,7 +637,7 @@ let test_coordination_presets_route_plan_history_reads () =
       let meta =
         {
           base with
-          tool_access = Custom [];
+          tool_access = [];
           tool_denylist = [];
         }
       in
@@ -656,7 +656,7 @@ let test_preset_universe_superset_of_policy () =
   init_keeper_tool_registry ();
   let base = make_gate_test_meta () in
   let meta = { base with
-    tool_access = Custom [];
+    tool_access = [];
     tool_denylist = [];
   } in
   let policy = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in
@@ -671,7 +671,7 @@ let test_registered_inline_board_tool_survives_filter () =
   Agent_tool_dispatch_runtime.inject_masc_schemas Config.raw_all_tool_schemas;
   let base = make_gate_test_meta ~name:"test-board-inline" () in
   let meta = { base with
-    tool_access = Custom [ "keeper_board_post"; "masc_who" ];
+    tool_access = [ "keeper_board_post"; "masc_who" ];
     tool_denylist = [];
   } in
   let allowed = Agent_tool_dispatch_runtime.keeper_allowed_tool_names meta in

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -354,23 +354,23 @@ let () =
                access)
         in
         check_access "minimal stays quiet by default" false
-          (Custom []);
+          ([]);
         check_access "minimal board opt-in listens" true
-          (Custom ["keeper_board_post"]);
+          (["keeper_board_post"]);
         check_access "minimal fake keeper board prefix stays quiet" false
-          (Custom ["keeper_board_fake"]);
+          (["keeper_board_fake"]);
         check_access "delivery listens to board by default" true
-          (Custom []);
+          ([]);
         check_access "messaging listens to board by default" true
-          (Custom []);
+          ([]);
         check_access "custom without board stays quiet" false
-          (Custom [ "keeper_time_now" ]);
+          ([ "keeper_time_now" ]);
         check_access "custom masc board allowlist listens" true
-          (Custom [ "masc_board_post" ]);
+          ([ "masc_board_post" ]);
         check_access "custom fake masc board prefix stays quiet" false
-          (Custom [ "masc_board_fake" ]);
+          ([ "masc_board_fake" ]);
         check_access "custom board allowlist listens" true
-          (Custom [ "keeper_board_post" ]));
+          ([ "keeper_board_post" ]));
       Alcotest.test_case "Social, Dispatch, and Delivery present" `Quick (fun () ->
         let open Masc_mcp.Keeper_meta_tool_access in
         Alcotest.(check bool) "social present" true

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -85,9 +85,9 @@ let write_only_tools = [ "Edit" ]
 let shell_bridge_tools = [ "Execute" ]
 
 let privileged_presets =
-  [ Keeper_meta_tool_access.Custom []; Keeper_meta_tool_access.Custom []; Keeper_meta_tool_access.Custom [] ]
+  [ []; []; [] ]
 
-let unprivileged_presets = [ Keeper_meta_tool_access.Custom [] ]
+let unprivileged_presets = [ [] ]
 
 let test_privileged_preset_write_gates () = ()
 
@@ -95,7 +95,7 @@ let test_core_tools_filtered_by_research_preset () =
   ignore (init_registry ());
   let meta =
     { (make_meta ~name:"test-research" ()) with
-      tool_access = Custom [];
+      tool_access = [];
       tool_denylist = [] }
   in
   (* Precondition: direct write tools ARE in unfiltered core *)
@@ -120,7 +120,7 @@ let test_core_tools_filtered_by_social_preset () =
   ignore (init_registry ());
   let meta =
     { (make_meta ~name:"test-social" ()) with
-      tool_access = Custom [];
+      tool_access = [];
       tool_denylist = [] }
   in
   let filtered = filter_core_by_preset meta in
@@ -131,7 +131,7 @@ let test_core_tools_include_write_for_delivery_preset () =
   ignore (init_registry ());
   let meta =
     { (make_meta ~name:"test-delivery" ()) with
-      tool_access = Custom [];
+      tool_access = [];
       tool_denylist = [] }
   in
   let filtered = filter_core_by_preset meta in


### PR DESCRIPTION
## Summary

`type tool_access = Custom of string list` 은 single-constructor 래퍼 — named preset 제거(#19499/#19504/#19509) 이후 `Custom`이 아무것도 구분하지 않는 no-op이었습니다. ("Custom 이 뭐여 ㅋㅋ")

타입을 제거하고 `keeper_meta.tool_access : string list`로 평탄화했습니다. **allow tool list가 곧 정책.**

## Changes

- `keeper_meta.tool_access : tool_access` → `string list`
- `keeper_meta_tool_access`: 타입 삭제, 헬퍼들이 `string list`를 직접 받고 반환 (`tool_access_to_json`, `tool_access_of_meta_json`, `default_tool_access_of_meta_json`, `normalize_tool_access`)
- `tool_access_custom_allowlist` 제거 (Custom에 대한 identity 함수였음)
- JSON wire format: `tool_access`가 순수 배열 `["t1","t2"]`로 직렬화. 읽기는 레거시 `{"kind":"custom","tools":[...]}` 와 `{"kind":"preset",...}` 도 호환 (저장된 meta.json backward compat)
- `keeper_tool_policy` / `agent_tool_execute_runtime`: `Custom _` 패턴 매칭 제거, 리스트 직접 사용
- 35 files (8 lib + 27 test), +145/-159

## Out of scope

TOML persistence layer (`keeper.tool_access.kind = "custom"`)는 별도 wire format이라 이번엔 건드리지 않았습니다.

## Test plan

- [x] `dune build @check` PASS
- [x] `dune build` (full) PASS
- [x] tool_access 직접 의존 테스트 모두 통과 (tool_access_policy / masc_bridge / types / runtime_config_ssot / tool_exposure)
- 로컬 `dune test`의 source-scanning ratchet 실패(`population got 0`, `*_source path not found`)는 dune sandbox 환경 이슈로 본 변경과 무관 (해당 테스트는 tool_access 미사용 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)