### PR TITLE
fix(cascade): unbreak main — accept [runtime] namespace + profile-name route targets

### DIFF
--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -369,6 +369,12 @@ let render_toml_to_yojson toml =
          shape for JSON-shaped readers such as route decoding. *)
     let is_rfc_0058_namespace = function
       | "providers" | "models" -> true
+      (* [runtime] is the cascade→Runtime substrate namespace (#19453):
+         a top-level table holding the default runtime binding key. It is
+         a declarative namespace, not a legacy flat cascade profile, so it
+         passes through verbatim to the materialized JSON for the Runtime
+         consumer rather than tripping the flat-profile rejection below. *)
+      | "runtime" -> true
       | _ -> false
     in
     let rec loop acc = function

--- a/lib/cascade_decl/cascade_declarative_validator.ml
+++ b/lib/cascade_decl/cascade_declarative_validator.ml
@@ -43,6 +43,15 @@ let alias_keys (cfg : cascade_config) : string list =
     cfg.aliases
 ;;
 
+(* Route/system targets reference [profiles.*] names under the
+   cascade→Runtime model (#19482): the resolver matches targets against
+   known profile names, capability resolution then maps the profile to a
+   binding. R7/R8 verify referential integrity of the target name, so the
+   valid-target set includes profile names alongside binding/alias keys. *)
+let profile_names (cfg : cascade_config) : string list =
+  List.map (fun (p : cascade_profile) -> p.name) cfg.profiles
+;;
+
 (* Build a name-keyed Hashtbl once for O(1) membership.  Eight
    validator rules below (R1-R8) used to do [List.mem key list]
    per filtered item, paying O(items × |list|).  Several rules also
@@ -142,7 +151,9 @@ let validate_alias_max_input (cfg : cascade_config) : validation_error list =
 (* --- R7: Route targets exist --- *)
 
 let validate_route_targets (cfg : cascade_config) : validation_error list =
-  let all_targets_set = name_set (binding_keys cfg @ alias_keys cfg) in
+  let all_targets_set =
+    name_set (binding_keys cfg @ alias_keys cfg @ profile_names cfg)
+  in
   List.filter_map
     (fun (r : cascade_route) ->
        if Hashtbl.mem all_targets_set r.target


### PR DESCRIPTION
## 목적

`config/cascade.toml` 이 **"Cascade TOML validity gate"** (`test/test_cascade_config_validity.ml`) 에서 main 을 깨뜨리고 있었다. 두 개의 config-only 마이그레이션 PR 이 대응 코드 갱신 없이 머지된 결과:

1. **#19453** — `[runtime]` cascade→Runtime substrate namespace 추가
2. **#19482** — route target 을 binding key → `[profiles.*]` 이름으로 변경

각각 validator/materializer 를 동기화하지 않아 checked-in seed 가 **두 독립 레이어**에서 실패:

| seed | 레이어 | 증상 |
|---|---|---|
| 0 | declarative validator **R7** | route target `"tool_strict"`/`"lite"` 가 프로필 이름인데 `validate_route_targets` 는 binding/alias key 만 허용 → `route target ... does not resolve to any binding or alias` |
| 1 | runtime **materializer** | `[runtime]` top-level table 이 known namespace 도 provider binding 도 아니라 flat-profile guard 가 거부 → `flat cascade TOML profile "runtime" is no longer supported` |

## Forward-fix (revert 아님 — 두 PR 모두 의도된 마이그레이션 단계)

- **`cascade_toml_materializer.ml`**: `is_rfc_0058_namespace` 에 `"runtime"` 추가 → `[runtime]` table 이 flat-profile 거부에 걸리지 않고 materialized JSON 으로 passthrough (Runtime consumer 소비, #19453 의도).
- **`cascade_declarative_validator.ml`**: `profile_names` helper 추가 + R7 valid-target set 에 포함. R7 은 target 이름의 referential integrity 검증이고, 새 모델에서 target 은 프로필 이름일 수 있다(resolver 가 profile → capability → binding 으로 downstream resolve). binding/alias key 도 backward-compat 으로 계속 허용. R8/system 은 미변경(seed 에 `[system]` 없음, system target 이 프로필 이름을 쓴다는 증거 없음).

2 files +18/-1.

## 검증

- 로컬: host load 166 으로 full build SIGTERM 위험 → targeted `dune build @test/runtest-test_cascade_config_validity` 시도 중. **CI 를 권위 게이트로 사용** (CI 는 PR⊕main 빌드라 main red 여도 이 PR 이 두 테스트를 PASS 로 돌리면 그대로 드러남 = broken-main fix 의 정확한 검증 메커니즘).
- 진단: in-flight fix 없음 확인 (catalog_runtime/declarative_validator/cascade.toml 건드리는 OPEN PR 0건, #19484 는 별개 keeper route fix 로 MERGED). race 없음.

RFC-WAIVED: gated subsystem(credential/identity/operator_control/keeper_sandbox/hooks/workflow) 미접촉. cascade→Runtime 마이그레이션의 validator/materializer namespace 동기화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
