### PR TITLE
refactor(preset): purge dead keeper_preset_defaults module

### DIFF
--- a/lib/keeper/keeper_preset_defaults.ml
+++ b/lib/keeper/keeper_preset_defaults.ml
@@ -1,4 +1,0 @@
-(* keeper_preset_defaults: formerly held tool_preset string parsing helpers.
-   Named presets have been removed; keepers use explicit Custom tool lists.
-   This module is retained as an empty stub to avoid breaking any external
-   references until callers are fully migrated. *)

--- a/lib/keeper/keeper_preset_defaults.mli
+++ b/lib/keeper/keeper_preset_defaults.mli
@@ -1,1 +1,0 @@
-(* keeper_preset_defaults: empty stub — tool presets removed. *)


### PR DESCRIPTION
## 목적
preset 숙청 마무리. named-preset 시스템 제거(#19499/#19504/#19509) 후 고아가 된 dead 모듈 제거.

## 변경
- 삭제: keeper_preset_defaults (.ml/.mli) — production·test 참조 0건

## 검증
- 전수 참조 스캔: `Keeper_preset_defaults` 0 hits (자기 파일 제외)
- dune build @check --root . exit 0

RFC-WAIVED: dead-module 삭제, production 동작 변화 0
