### PR TITLE
fix(runtime): fail-fast on missing/broken default Runtime at boot

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -424,7 +424,12 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       in
       (* Initialize the default Runtime singleton from cascade TOML.
          Must happen after Config_dir_resolver is set up (inside
-         create_server_state) and before any cascade name resolution. *)
+         create_server_state) and before any cascade name resolution.
+
+         fail-fast: a missing config path or a missing/broken [runtime].default
+         is fatal — the server cannot route turns without a default Runtime, so
+         booting into a half-configured state only defers the failure to the
+         first turn (cascade→Runtime vision: no silent fallback). *)
       (match Cascade_runtime.cascade_config_path () with
        | Some config_path ->
          (match Runtime.init_default ~config_path with
@@ -432,10 +437,14 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
             Log.Server.info "Runtime default initialized: %s"
               (Runtime.get_default_runtime_id ())
           | Error msg ->
-            Log.Server.error "Runtime.init_default failed: %s" msg)
+            Log.Server.error
+              "Runtime.init_default failed (fatal, refusing to boot): %s" msg;
+            exit 1)
        | None ->
-         Log.Server.warn
-           "No cascade config path; Runtime default not initialized");
+         Log.Server.error
+           "No cascade config path; cannot initialize default Runtime \
+            (fatal, refusing to boot)";
+         exit 1);
       let provider_health = Provider_health.create state.room_config in
       Provider_health.set_active provider_health;
       Provider_health.start_probe_fiber ~sw ~env provider_health;


### PR DESCRIPTION
## Problem

서버가 default Runtime을 초기화하지 못해도 **부팅을 거부하지 않았습니다** — `Log.error`(또는 config path 없을 땐 `Log.warn`)만 찍고 half-configured 상태로 부팅을 계속했습니다. default Runtime 없이는 turn을 라우팅할 수 없으므로, 이는 실패를 첫 turn으로 미루고 진짜 원인을 숨길 뿐입니다.

사용자 요구: **"Default Runtime 설정이 없거나 고장났으면 서버 부팅이 안 되어야 함"** (fail-fast).

## Fix

두 케이스 모두 부팅 시점에 fatal(`exit 1`)로 — 기존 base-path startup guard와 동일 패턴:

- `Runtime.init_default` 실패 (`[runtime].default` 누락, 또는 default id가 로드된 runtime 목록에 없음) → `exit 1`
- cascade config path 자체가 없음 → `exit 1`

cascade→Runtime 비전("silent fallback removed")을 부팅 경로에서 실현합니다. `Runtime.load_list`는 이미 이 케이스들에 `Error`를 반환합니다 (runtime.ml:46-72) — 부팅 코드가 이제 그것을 swallow하지 않고 프로세스 종료로 전파합니다.

## Scope / testing note

변경은 `run` 통합 진입점(host/port bind) 안에 있고 어떤 단위 테스트도 이를 호출하지 않으며, `exit 1`은 프로세스 동작입니다. 따라서 단위 테스트보다 **코드 리뷰 + 수동 검증**(cascade.toml에서 `[runtime].default` 제거 → 서버 부팅 거부)으로 커버됩니다. 바탕이 되는 `Runtime.load_list`의 Error 반환 로직은 변경하지 않았습니다.

`get_default_runtime_id`의 `"tool_strict"` fallback은 정상 부팅 경로에서 이제 dead(default가 Some 보장)이나, 완전 제거는 호출 순서 계약을 바꾸므로 별도 검토로 남깁니다.

## Test plan

- [x] `dune build @check` PASS
- [x] `dune build` (full) PASS
- [ ] 수동: `[runtime].default` 제거 시 부팅 거부 (reviewer/배포 시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)