### PR TITLE
fix(runtime): unblock governance judge — cascade_name/capability mismatch

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -496,7 +496,7 @@ let parse_verdict (text : string) : (verdict, string) result =
     because different model architectures have different blindspots.
     See: Provider_a "Harness Design" blog analysis. *)
 let default_evaluator_cascade =
-  Runtime.get_default_runtime_id ()
+  Runtime.get_default_cascade_name ()
 ;;
 
 (* ================================================================ *)

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -96,7 +96,7 @@ let agent_type_of_mention = Mention.agent_type_of_mention
 (* --- MODEL mode: shared cascade + in-process MASC HTTP tools/call --- *)
 
 let cascade_name_for_agent_type _agent_type =
-  Runtime.get_default_runtime_id ()
+  Runtime.get_default_cascade_name ()
 
 (** Validate model response using structural fields, not text heuristics.
     Guardrail principle: accept unless there is a clear structural reason to reject.

--- a/lib/cascade/cascade_routes_resolve.ml
+++ b/lib/cascade/cascade_routes_resolve.ml
@@ -10,5 +10,11 @@
     this module.  Callers that only need the configured route target
     without catalog cross-check use {!Cascade_routes} directly. *)
 
+(* cascade→Runtime hotfix: return valid profile name instead of
+   binding key.  The cascade profile resolver only accepts profile
+   names ("tool_strict", "lite"), not binding keys like
+   "runpod_mtp.qwen36-35b-a3b-mtp".  All 18 routes target the same
+   binding which satisfies [tool_strict].  Module will be deleted
+   when cascade layer is fully removed. *)
 let cascade_name_for_use ?config_path:_ _use =
-  Runtime.get_default_runtime_id ()
+  "tool_strict"

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -648,7 +648,7 @@ let compute_judgments
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.result)
     ~build_facts =
   let cascade_name =
-    Runtime.get_default_runtime_id ()
+    Runtime.get_default_cascade_name ()
   in
   match
     (* build_facts() is moved inside the bridge so a deadlock in
@@ -733,7 +733,7 @@ let append_judgments base_path judgments =
 
 let should_backoff ~sw ~net =
   let cascade_name =
-    Runtime.get_default_runtime_id ()
+    Runtime.get_default_cascade_name ()
   in
   try
     let capacity =

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -215,7 +215,7 @@ let compute_judgments
     ~facts_json =
   let prompt = prompt_for_facts facts_json in
   let cascade_name =
-    Runtime.get_default_runtime_id ()
+    Runtime.get_default_cascade_name ()
   in
   match
     (* #9629: caller uses run_with_caller so this judge inherits
@@ -258,7 +258,7 @@ let compute_judgments
 
 let should_backoff ~sw ~net =
   let cascade_name =
-    Runtime.get_default_runtime_id ()
+    Runtime.get_default_cascade_name ()
   in
   try
     let capacity =

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -153,12 +153,12 @@ let declarative_tool_policy_for_provider_ids provider_ids =
         Some (tool_policy_of_decl_capabilities provider.Decl.capabilities))
 ;;
 
+(* CLI transport removal in progress: any binding with supports_tools
+   can carry runtime MCP.  The transport-based split was only needed to
+   distinguish CLI runtimes (implicit tool access) from HTTP providers.
+   With CLI removal, supports_tools is the sole signal. *)
 let binding_supports_runtime_mcp_http_headers (binding : Runtime_binding.t) =
-  match binding.Runtime_binding.transport with
-  | Runtime_binding.Cli -> binding.Runtime_binding.capabilities.supports_tools
-  | Runtime_binding.Http
-  | Runtime_binding.Managed
-  | Runtime_binding.Custom_provider_d_compat -> false
+  binding.Runtime_binding.capabilities.supports_tools
 ;;
 
 let fallback_tool_policy_for_config (provider_cfg : Llm_provider.Provider_config.t) =

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -84,8 +84,15 @@ let init_default ~config_path =
 
 let get_default_runtime () = !default_runtime_ref
 
+(** Binding key of the default runtime (for logging/identity). *)
 let get_default_runtime_id () =
   match !default_runtime_ref with
   | Some rt -> rt.id
   | None -> "tool_strict"
+
+(** Cascade profile name for LLM dispatch.  Use this — NOT
+    [get_default_runtime_id] — as [cascade_name] in [run_named]
+    and similar cascade dispatch functions.  Full cascade removal
+    will eliminate this distinction entirely. *)
+let get_default_cascade_name () = "tool_strict"
 ;;

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -26,4 +26,8 @@ val load_list : config_path:string -> (t list * t, string) result
 
 val init_default : config_path:string -> (unit, string) result
 val get_default_runtime : unit -> t option
+(** Binding key of the default runtime (for logging/identity). *)
 val get_default_runtime_id : unit -> string
+
+(** Cascade profile name for LLM dispatch. *)
+val get_default_cascade_name : unit -> string

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -108,7 +108,7 @@ let route_keeper ~config ~sw ~clock ~keeper_name ~message : (string, string) res
 let route_cascade ~message ~system_prompt ~max_tokens ~temperature
   : (string, Openai_compat_error_map.t) result =
   let cascade_name =
-    Runtime.get_default_runtime_id ()
+    Runtime.get_default_cascade_name ()
   in
   match
     Masc_oas_bridge.run_with_caller

--- a/lib/tool_deep_review.ml
+++ b/lib/tool_deep_review.ml
@@ -152,7 +152,7 @@ let handle_deep_review
           (`Assoc [ ("error", `String msg) ])
     | Ok prompt ->
         let cascade_name =
-          Runtime.get_default_runtime_id ()
+          Runtime.get_default_cascade_name ()
         in
         match
           Masc_oas_bridge.run_with_caller

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -93,7 +93,7 @@ let verify (req : Core.verification_request) : (Core.verdict, string) result =
           (sprintf "Invalid verdict format: %s" msg)
     in
     let cascade_name =
-      Runtime.get_default_runtime_id ()
+      Runtime.get_default_cascade_name ()
     in
     match
       Keeper_turn_driver_wrappers.run_named_with_masc_tools


### PR DESCRIPTION
## 문제

Governance judge `compute_judgments`가 매 사이클마다 `no_tool_capable_provider`로 실패.

## 근본 원인 (3단계 체인)

1. `Runtime.get_default_runtime_id()` 가 binding key(`runpod_mtp.qwen36-35b-a3b-mtp`)를 반환하지만, 9개 dispatch caller가 이를 `cascade_name`으로 사용. Profile resolver는 profile 이름(`tool_strict`, `lite`)만 인식.
2. `cascade_routes_resolve.cascade_name_for_use` stub도 같은 binding key 반환.
3. `binding_supports_runtime_mcp_http_headers` 가 CLI transport에만 runtime MCP 허용. HTTP provider는 항상 `runtime_mcp=false`.

## 수정 (11 files, +32/-15)

| 변경 | 내용 |
|------|------|
| `Runtime.get_default_cascade_name()` 추가 | 항상 `"tool_strict"` 반환 |
| 9개 caller 교체 | `get_default_runtime_id()` → `get_default_cascade_name()` |
| `cascade_name_for_use` 수정 | binding key 대신 `"tool_strict"` 반환 |
| capability fallback 간소화 | transport 구분 없이 `supports_tools`만 확인 |

## 검증

```
governance compute_judgments outcome=ok duration=34.191s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
