### PR TITLE
feat(runtime): cascade→Runtime substrate (RFC-0206 P1-P3 + L0/L1 restore)

### DIFF
--- a/docs/rfc/RFC-0206-runtime-concept-cascade-rebirth.md
+++ b/docs/rfc/RFC-0206-runtime-concept-cascade-rebirth.md
@@ -141,4 +141,41 @@ P1-P3(자립 schema/parser/adapter + runtime.ml 재배선 + `tool_strict` 제거
 
 세부 file-level 매핑은 Phase U 워크플로(8-cluster understand) 산출.
 
+## 10. Substrate 설계 (Phase U 종합, 2026-05-30)
+
+8-cluster understand 워크플로(w93dm28ba) 종합 + 저자 override. dependency layer 순서로 실행한다(monolithic lib → 전부 green 돼야 머지).
+
+### L0 — lib/runtime 추가 (keeper 의존 0, 최우선)
+
+- **transport/dispatch 부분그래프 restore-rename** (RFC §9.2): `cascade_transport`(+14 transport_* 하위) + `cascade_agent_context` + `cascade_wire_overlay` + `cascade_oas_runner` + `cascade_runner` → `Runtime_transport*` / `Runtime_agent_context` / `Runtime_wire_overlay` / `Runtime_oas_runner` / `Runtime_agent`. ~3000 LoC, 결정론적 rename. 경계 rewire: `Cascade_config`→`Runtime_schema`/`Runtime`, `Cascade_name`→`string`, `Cascade_observation` 참조(runner 2건) 외과 제거.
+- **`Runtime_agent`** (dispatch entry): `stop_reason`/`run_result`(cascade_observation 필드 제거)/`response`/`cli_transport_overrides` 타입 + `run`/`run_with_masc_tools` single-binding wrapper(Agent_sdk.Agent.run 위).
+- **`runtime_constants`**: `fallback_context_window = 128000`.
+- **`runtime_deadline`**: `of_seconds_from_now` 등 (Cascade_deadline 단순 이식).
+- **`Runtime.config_path : unit -> string option`** 추가 (Cascade_runtime.cascade_config_path 대체).
+- 샘플링 상수: `Llm_provider.Constants.Worker_sampling`(외부 lib, 존재 시 reuse) — 신규 모듈 회피.
+
+### L1 — lib/keeper substrate (L0 + 생존 keeper_meta_contract 의존)
+
+- **`keeper_event_bridge`** ← Cascade_event_bridge (start/native_event_to_json, 동일 시그니처).
+- **`keeper_event_publisher`** ← Cascade_events (publish_keeper_lifecycle/snapshot, Masc_event_bus.get).
+- **`keeper_binding_health`** ← Cascade_health_tracker (per-binding, global 싱글톤 제거; record_success/failure/rejected/...).
+- **`keeper_attempt_metrics`** + **`keeper_audit`** ← Cascade_observation (single attempt metadata demote; `cascade_name`→`binding_id:string`).
+- **`keeper_attempt_liveness`** ← Cascade_attempt_liveness(+config/observer) (per-attempt streaming liveness FSM, Eio Switch).
+- **`keeper_preflight_health_tracker`** ← Cascade_preflight_state (global/record/is_disabled/reset_on_health_recovery/reason_slug).
+- **error classify**: 신규 모듈 0 — `Keeper_meta_contract`가 이미 `masc_internal_error`/codec/provider_rejection/capacity_backpressure_source 소유(RFC-0142). 소비자는 `Cascade_error_classify.X`/`Cascade_internal_error.X` → `Keeper_meta_contract.X`.
+
+### DISCARD / DELETE-CALLSITE (substrate 0)
+
+- **catalog**: `Cascade_catalog_runtime.{snapshot,Validated,Validated_with_rejections,Serving_last_known_good,state_to_yojson,rejection_*,resolve_strategy,resolve_*_max_concurrent,resolve_declared_name}` — routing 아티팩트, callsite 삭제.
+- **routing**: `Cascade_routes.logical_use`→string literal("keeper_turn"), `Cascade_routes_resolve.cascade_name_for_use`→`Runtime.get_default_runtime_id ()`, `Cascade_strategy.*`/`Cascade_strategy_trace.record` → **callsite에서 identity/no-op inline** (⚠️ 저자 override: U 에이전트가 제안한 `Runtime_strategy` 신규 모듈은 multi-candidate 재성장이므로 **거부**. single binding에서 order_candidates는 항등, record_choice는 no-op).
+- **misc**: `Cascade_trust_persist.start_snapshot_fiber` → 삭제(JSONL 스냅샷 불요, 관측은 Neo4j/Prometheus).
+
+### L2 — consumer rewire (120 파일)
+
+L0+L1 위로 재배선. mechanical(naming Cascade_name→string 49파일, error→Keeper_meta_contract, misc 상수) + semantic(dispatch run_result destructure 25파일, catalog DELETE-CALLSITE, fsm). naming은 batch 가능, semantic은 파일별.
+
+### 검증 순서
+
+L0 scratch 컴파일 → L1 (keeper_meta_contract 링크 필요, 전체 lib 빌드) → L2 후 full build green + `rg -w 'Cascade_[a-z][A-Za-z_]*\.' lib bin` = 0 (생존 variant 생성자 `Cascade_idle` 등은 잔존 허용, P6 rename).
+
 RFC-WAIVED 근거(상위 #19536): 사용자 명시 지시에 따른 cascade→Runtime 재탄생. 본 RFC가 그 구현 단계의 설계 SSOT를 제공한다.

--- a/docs/rfc/RFC-0206-runtime-concept-cascade-rebirth.md
+++ b/docs/rfc/RFC-0206-runtime-concept-cascade-rebirth.md
@@ -107,4 +107,38 @@ cascade 5-state(`Idle/Selecting/Trying/Done/Exhausted`)는 다중후보 selectio
 - P6: fail-fast mutation-test (default 누락/오류 시 반드시 Error)
 - 최종: full build green + `rg -w 'Cascade_[A-Za-z_]+' lib bin` = 0
 
+## 9. P4/P5 범위 정밀 측정 (2026-05-30, measured)
+
+P1-P3(자립 schema/parser/adapter + runtime.ml 재배선 + `tool_strict` 제거)은 완료·격리 컴파일 검증(scratch EXIT=0)·커밋됨. P4/P5 진입 전 dangling 범위를 정밀 측정해 초기 추정(844/122)을 교정했다.
+
+### 9.1 surviving vs dangling 분류 (결정적)
+
+`rg 'Cascade_[A-Za-z_]+'`의 862 occurrence는 dangling 여부 무관 집계였다. 64개 distinct 심볼을 생존-정의 여부로 분류:
+
+- **21 심볼 = keeper 소유 variant 생성자**(생존 keeper 모듈에 정의, 컴파일 정상). `Cascade_idle/selecting/trying/done/exhausted`(keeper_registry_types/keeper_composite_observer/keeper_meta_contract), `Cascade_routed`(keeper_runtime_manifest_types), `Cascade_admitted/backpressured`(keeper_heartbeat_loop), `Cascade_attempts_exhausted`(keeper_turn_disposition) 등. **마이그레이션 대상 아님.** RFC §4대로 `keeper_meta_contract.Cascade_exhausted`는 frozen seam(operator 대시보드 파싱)이라 보존. rename(Cascade_idle→Turn_idle)은 P6 선택 polish.
+- **30+ 심볼 = dangling 모듈 참조**(삭제된 cascade 모듈). 이것만이 컴파일 차단. **진짜 범위: 120 파일 / 507 모듈-접근 occurrence** (lib/keeper 83, lib 17, dashboard 9, server 4, otel/local/config/operator 7).
+
+### 9.2 dispatch 부분그래프 = restore-rename (rewrite 아님)
+
+최대 비용은 dispatch cluster. `Cascade_runner`(61 ref) 소비 심볼의 35/61은 **타입 참조**(`stop_reason`/`run_result`/`response`/`cli_transport_overrides` — 전부 `Cascade_agent_context`/`Cascade_transport` 별칭), 실함수 호출은 `run`/`run_with_masc_tools`/`resolve_tool_lane` ~4건.
+
+전이 폐쇄: cascade_runner(785줄) + cascade_agent_context(390) + cascade_transport(407) + cascade_oas_runner(500) + cascade_transport_*(~14 하위모듈) + cascade_wire_overlay ≈ 2500줄. **그러나 측정 결과 이 부분그래프는 routing/strategy/health/selection 의존이 0**(cascade_transport는 자기 하위모듈 + `Cascade_config` + circular `Cascade_runner`만 의존). cascade_runner.run body의 selection 오염은 `Cascade_observation` 단 2건.
+
+→ RFC §5 INHERIT(transport + api_format 3-variant dispatch 보존)와 부합. dispatch substrate = transport/dispatch/config 부분그래프를 `Runtime_*` 네임스페이스로 **restore + 결정론적 rename**(내부 `Cascade_config`→Runtime_schema, `Cascade_observation` 2건 외과 처리). 2500줄 재작성이 아니라 mechanical rename이라 workflow fan-out 적합.
+
+### 9.3 cluster별 전략 (P4/P5 application)
+
+| cluster | dangling 모듈 | 전략 |
+|---------|--------------|------|
+| dispatch | Cascade_runner/oas_runner/agent_context/transport(+14 sub)/wire_overlay | **restore-rename → Runtime_***; selection 2건 외과 제거 |
+| catalog-config-types | Cascade_catalog_runtime/runtime/runtime_candidate/config/decl/declarative_* | 이미 구축된 lib/runtime(Runtime/Runtime_schema/Runtime_toml/Runtime_adapter)로 mechanical 치환 |
+| error-events | Cascade_error_classify/internal_error/event_bridge/events/inference | 생존 keeper_meta_contract 재사용 / 일부 re-home |
+| health-capacity-obs | Cascade_health_tracker/observation/saturation_signal/capacity_probe/slot | DISCARD 싱글톤, observation→single attempt metadata demote |
+| fsm-liveness-preflight | Cascade_fsm/attempt_fsm/preflight_state/attempt_liveness*/deadline | keeper_turn_phase substrate / delete |
+| routing | Cascade_routing/routes/strategy | DISCARD callsite |
+| naming | Cascade_name | raw string id |
+| misc | Cascade_worker_defaults/agent_context/trust_persist | per-symbol 분류 |
+
+세부 file-level 매핑은 Phase U 워크플로(8-cluster understand) 산출.
+
 RFC-WAIVED 근거(상위 #19536): 사용자 명시 지시에 따른 cascade→Runtime 재탄생. 본 RFC가 그 구현 단계의 설계 SSOT를 제공한다.

--- a/docs/rfc/RFC-0206-runtime-concept-cascade-rebirth.md
+++ b/docs/rfc/RFC-0206-runtime-concept-cascade-rebirth.md
@@ -1,0 +1,110 @@
+# RFC-0206: Runtime 개념 — cascade→Runtime 재탄생
+
+- Status: Draft
+- Date: 2026-05-30
+- Supersedes 라우팅 레이어: RFC-0038(routing-intent), RFC-0041(group-item-hierarchy), RFC-0058 §Layer-4/5(routes/aliases), RFC-0181(routes+phonebook dual-SSOT)
+- Builds on: RFC-0058(provider/model/binding 선언 스키마, Layers 1-3), keeper_meta_contract(HEAD; exhaustion 분류)
+- Context: PR #19536이 `lib/cascade*`(170+파일) 전면 삭제 + 빌드 의도적 broken. 본 RFC는 그 후속 "Runtime 구현 채우기"의 설계 SSOT.
+
+## 1. 동기
+
+cascade는 다중 provider failover 프레임워크였다: `cascade_name`/`routes`/`tier`/`profile` 간접 레이어로 코드 호출지점을 설정에 매핑하고, 여러 후보를 health/capacity 신호로 정렬해 순차 시도했다. 30개 RFC가 이 추상화를 키웠고 264파일이 강결합됐다.
+
+#19536은 이 개념을 코드베이스에서 제거했다. 남은 것은 소비자 쪽 844개 dangling `Cascade_*` 참조(122파일, keeper 82)와, 거의 빈 `lib/runtime`(2파일, 그마저 삭제된 `Cascade_declarative_types`에 의존해 컴파일 불가)이다.
+
+본 RFC는 cascade를 1:1 복구하지 않는다. **Runtime을 자립 개념으로 정의하고 구현을 채운다.**
+
+## 2. Runtime 개념
+
+Runtime은 하나의 완전히 materialize된 (Provider × Model × Binding) triple과, dispatch 대상인 hot-path `Llm_provider.Provider_config.t`다. resolution graph의 노드가 아니라 **독립 값**이다.
+
+- 시스템은 `config/cascade.toml`(파일명 rename은 deferred)을 flat `Runtime.t list` + 정확히 1개 default `Runtime.t`로 로드한다. default는 `[runtime].default = "provider.model"` 키로 선택한다.
+- `cascade_name` 없음, `routes`/`logical_use` enum 없음, tier escalation 없음, profile 간접 없음. 각 binding 셀이 곧 하나의 Runtime이며 `"provider.model"` 문자열 키로 식별된다.
+- 소비자는 list와 default를 직접 받아 `runtime.provider_config`를 LLM에 넘긴다. in-band routing 0.
+- 다중후보 failover(Selecting/Trying 루프, weighted-random, round-robin, fallback chain)는 제거된다. Runtime은 단일 사전선택 provider를 나타내며 atomic하게 성공/실패한다. cross-runtime 재시도가 필요하면 그것은 in-turn FSM이 아니라 명시적 상위 supervisor 결정이다.
+
+### 2.1 불변식: fail-fast
+
+`[runtime].default`가 없거나, default id가 resolvable binding 중에 없으면 load 시점에 `Error`이고 startup을 abort한다. silent fallback 없음. (현재 `runtime.ml`의 `"tool_strict"` 하드코딩 fallback은 Unknown→Permissive 안티패턴이므로 **제거**한다 — §6 R1.)
+
+## 3. 자립 타입 (P1)
+
+삭제된 `Cascade_declarative_types`를 `lib/runtime/runtime_schema.ml(.mli)`의 자립 타입으로 재구현한다. `Cascade_` 네임스페이스로 재성장시키지 않는다.
+
+| 타입 | 형태 | 대체 |
+|------|------|------|
+| `api_format` | `Messages_api \| Chat_completions_api \| Ollama_api` | `cascade_api_format` |
+| `transport` | `Http of string \| Cli of string` | `cascade_transport` |
+| `credential` | `Env of string \| File of string \| Inline of string` | `cascade_credential` |
+| `thinking_control_format` | `No_thinking_control \| Thinking_object \| Chat_template_kwargs` | `cascade_thinking_control_format` |
+| `capabilities` | 10-field provider 행동 record + `capabilities_default` | `cascade_capabilities` |
+| `model_capabilities` | 24-field record (`Llm_provider.Capabilities` 미러) + default | `cascade_model_capabilities` |
+| `provider` | Layer 1 record (id/display_name/protocol/api_format/transport/is_non_interactive/credentials/capabilities/headers). log·healthcheck sub-record는 v1에서 parse-and-ignore | `cascade_provider` |
+| `model_spec` | Layer 2 record (id/api_name/tools_support/max_context/thinking_support/max_thinking_budget/streaming/capabilities/match_prefixes) | `cascade_model_spec` |
+| `binding` | Layer 3 record (provider_id/model_id/is_default/max_concurrent/price_*/keep_alive/num_ctx) + `binding_key` | `cascade_binding` |
+| `config` | `{ providers; models; bindings; default_runtime_id }` — **routes/system_targets/profiles/aliases DROP** | `cascade_config` minus routing |
+
+조회 헬퍼 `provider_of_id : config -> string -> provider option`, `model_of_id : config -> string -> model_spec option`도 함께 자립화한다.
+
+## 4. FSM 추출 (routes/tiers 폐기)
+
+cascade 5-state(`Idle/Selecting/Trying/Done/Exhausted`)는 다중후보 selection FSM으로 살아남지 않는다. Selecting/Trying/round-robin/fallback은 single-binding 모델에서 소멸한다.
+
+그러나 keeper 소비자(`keeper_composite_observer`, `keeper_registry`의 packed state, 5개 invariant)가 이를 turn-observation/FSM-invariant로 매치한다. 재배치:
+
+- **keeper 소유 slimmed enum**: `keeper_turn_phase = Turn_idle | Turn_dispatching | Turn_done | Turn_exhausted`. `Trying → Turn_dispatching`, `Selecting`은 삭제(in-turn 선택 없음).
+- `Cascade_routed` event_kind, `Cascade_backpressured` 신호는 단일 dispatch 이벤트 + turn-terminal `Timeout`/`Admission_denied` 에러로 collapse(capacity 거부는 더 이상 provider-level backpressure가 아님).
+- **exhaustion 분류는 재생성 금지**: `keeper_meta_contract.cascade_exhaustion_reason`(10 variant: Connection_refused/Dns_failure/No_providers_available/All_providers_failed/Candidates_filtered_after_cycles/Max_turns_exceeded/Structural_attempt_timeout/Capacity_exhausted/No_tool_capable/Other_detail) + `blocker_class`(`Cascade_exhausted` carrier)는 HEAD에 이미 keeper-owned로 생존(`keeper_meta_contract.mli:139-196`). **그대로 재사용.** 이 표면은 operator 대시보드가 파싱하는 frozen seam이므로 rename 금지.
+- `check_no_cascade_before_measurement` 등 5개 invariant는 keeper concern으로 생존하되 `Turn_dispatching` gate로 retarget.
+
+## 5. 계승 / 폐기
+
+**계승(INHERIT):**
+- `keeper_meta_contract`의 exhaustion_reason + blocker_class (frozen, 재사용)
+- `Llm_provider.Provider_config.t`를 `Runtime.t.provider_config` hot-path 대상으로 (외부 OAS lib, 생존)
+- RFC-0058 절대 원칙: 코드는 provider/model 이름을 모른다 — provider 추가 = TOML 항목만, 재컴파일 없음
+- RFC-0058 §4.1 load-time validation = `Runtime.load_list`의 fail-fast gate
+- per-binding capacity slot(`binding.max_concurrent`)이 URL 기반 capacity registry 대체 (RFC-0058 §5)
+- api_format 3-variant dispatch를 provider 정체성과 분리
+
+**폐기(DISCARD):**
+- `Cascade_name.t` 문자열 wrapper(~90 ref) → raw string id, 검증은 TOML load 경계에서만
+- `Cascade_routes`/`cascade_routes_resolve`/`logical_use` enum
+- `Cascade_strategy` + strategy kind ADT + trace (single Failover)
+- `Cascade_fsm` 다중후보 `decide()`(Accept/Try_next/Exhausted) → atomic success/fail
+- round-robin cursor, fallback_events/hops, multi-tier escalation
+- `Cascade_observation` state-bearing record → 단일 attempt metadata(latency_ms/error/outcome)로 demote
+- 전역 `Cascade_health_tracker.global` 싱글톤(cascade-name 축) → per-runtime-key health를 명시 전달
+- `cascade_source` enum, weighted_entry_drop, route→catalog→profile 2단 resolution
+- `Cascade_phonebook_*`/`Cascade_routing_policy`/`Cascade_capability_profile` registry
+- Layer 4 per-use overrides(alias), route, system_targets, profile
+- `get_default_runtime_id`의 `"tool_strict"` 하드코딩 fallback
+
+## 6. 구현 단계
+
+| Phase | 목표 | 파일 | unblocks |
+|-------|------|------|----------|
+| **P1** | `runtime_schema.ml(.mli)` 10 type group + defaults + provider_of_id/model_of_id/binding_key. 삭제 모듈 의존 0. `open Cascade_declarative_types` 대체 | ~4 | Runtime.t가 자립 타입으로 컴파일; P2 타깃 스키마 확보 |
+| **P2** | `runtime_toml.ml`(Otoml→config), `runtime_adapter.ml`(binding→Provider_config.t). load_list/of_binding 배선. cascade.toml fixture + no-default fixture(Error) 검증 | ~7 | load_list end-to-end; init_default; startup fail-fast |
+| **P3** | singleton 경계 결정. ref 기반 유지 + `"tool_strict"` fallback 삭제(uninit→fail loud). eager-init crash 회피(lazy/explicit + test fixture) | ~5 | 90 사이트 안전 re-home |
+| **P4** | keeper 소비자 re-home(dominant 77파일). Cascade_name/runner/error_classify/catalog_runtime → raw id, get_default_runtime_id, keeper_meta_contract, keeper_turn_phase. 5파일 batch | ~16 batch | 844 dangling 대부분 해소 |
+| **P5** | 주변 소비자: config_doctor, dashboard runtime lens, admission_queue, server, otel, operator. dune deps에서 cascade lib 제거 | ~21 | full build green; dangling 0 |
+| **P6** | invariant retarget(`Turn_dispatching`), load_list fail-fast test(no-default→Error, bad-id→Error, subset filtering), mutation-test | ~6 | 검증 가능한 완료 기준 |
+
+## 7. 리스크
+
+- **R1 (silent-default landmine):** `"tool_strict"` fallback은 init 순서가 틀리면 90 사이트가 조작된 id를 받는다 — Unknown→Permissive 안티패턴. P3에서 삭제(Error/raise on uninit), 이월 금지.
+- **R2 (eager-init crash):** 메모리 2026-05-30 B3 `cascade_name_for_use` gut이 fail-fast raise + eager module-level binding으로 config-less 바이너리(테스트) startup crash 때문에 DEFER됨. Runtime 싱글톤도 동일 위험 — init을 lazy/explicit로 유지하고 test runtime fixture 제공.
+- **R3 (병렬 충돌):** 다른 세션이 동일 파일에서 cascade purge 진행 중(feat/cascade-name-cleanup 174파일, host load 110+). P4 전 `masc_broadcast` + in-flight PR scan 필수(broken-main race #19424 재발 방지).
+- **R4 (재성장):** runtime_toml/runtime_adapter를 minimal하게. aliases/routes/profiles 파싱 전면 drop, validator dual-mode·longest-prefix model matching은 binding이 실제 fuzzy resolution을 요구하기 전엔 포팅 금지.
+- **R5 (frozen seam):** `keeper_meta_contract`의 `blocker_class_to_string` literal을 operator 대시보드가 파싱. `Cascade_exhausted` rename은 alerting을 깬다. reuse, refactor 금지.
+- **R6 (CI surface gate):** `Detect Changed Surfaces`가 types-only P1을 no-surface로 오분류해 Build/Test skip한 전례(2026-05-28). gate가 `lib/runtime/`에 trigger되는지 검증.
+
+## 8. 검증
+
+- P1: `dune build lib/runtime/ --root .` 통과 (keeper broken 무관하게 runtime lib 자립 컴파일)
+- P2: cascade.toml fixture 로드 성공 + no-default fixture → `Error`
+- P6: fail-fast mutation-test (default 누락/오류 시 반드시 Error)
+- 최종: full build green + `rg -w 'Cascade_[A-Za-z_]+' lib bin` = 0
+
+RFC-WAIVED 근거(상위 #19536): 사용자 명시 지시에 따른 cascade→Runtime 재탄생. 본 RFC가 그 구현 단계의 설계 SSOT를 제공한다.

--- a/docs/rfc/RFC-0206-runtime-concept-cascade-rebirth.md
+++ b/docs/rfc/RFC-0206-runtime-concept-cascade-rebirth.md
@@ -174,6 +174,30 @@ P1-P3(자립 schema/parser/adapter + runtime.ml 재배선 + `tool_strict` 제거
 
 L0+L1 위로 재배선. mechanical(naming Cascade_name→string 49파일, error→Keeper_meta_contract, misc 상수) + semantic(dispatch run_result destructure 25파일, catalog DELETE-CALLSITE, fsm). naming은 batch 가능, semantic은 파일별.
 
+### L0 substrate ADDITION (semantic 경계 매핑, measured 2026-05-30)
+
+restored substrate + 120 consumer가 참조하는 semantic 심볼의 확정 매핑:
+
+| 삭제 심볼 | refs | 대체 |
+|-----------|------|------|
+| `Cascade_config.parse_model_string` | 10 | **신규** `Runtime.parse_model_string : string -> Provider_config.t option` (Runtime_adapter 경유, "provider/model" 파싱) |
+| `Cascade_config.split_provider_model` | 1 | inline `String.split_on_char '/'` 또는 Runtime helper |
+| `Cascade_config.filter_healthy_strict` / `health_filter_rejection_to_string` | 2 | keeper_binding_health 또는 discard (single binding = 필터 불요) |
+| `Cascade_config.resolve_strategy` | 1 | DISCARD (routing) |
+| `Cascade_runtime.models_of_cascade_name(_result)` | 8 | single-binding collapse: `[ (get_default_runtime ()).model ]` (multi-candidate 리스트→단일) |
+| `Cascade_runtime.fallback_context_window` | 5 | **신규** `Runtime_constants.fallback_context_window = 128000` |
+| `Cascade_runtime.cascade_config_path` | 5 | **신규** `Runtime.config_path : unit -> string option` |
+| `Cascade_runtime.{local_model_label,default_model_strings,resolve_*_context,max_output_tokens_ceiling*,local_capacity_for_selections,ensure_api_keys_for_labels}` | ~15 | Runtime.t/Runtime_schema 조회로 collapse (single binding) |
+| `Cascade_metrics.on_{provider_cooldown,cascade_audit_failure,resolve_live_fallback,cascade_metrics_eviction}` | 9 | **신규** `Runtime_metrics.on_*` prometheus emitter (오염 cascade_metrics 미복원; 순수 카운터만) |
+| `Cascade_capability_profile.{provider_satisfies_profile,is_system_cascade_name}` | 2 | DISCARD/predicate (profile 제거) |
+| `Cascade_observation` (substrate 내) | 4 | `Keeper_observation` (L1 restored) |
+| `Cascade_runner` (substrate 내) | 2 | `Runtime_agent` (L0 rename 누락분) |
+| `Cascade_name` (substrate 내) | 11 | `string` (type), 호출 제거(to_string/of_string_exn) |
+| `Cascade_tier_wait_scheduler` | 1 | DISCARD (tier 제거됨 #19436) |
+| `Cascade_error_classify` (substrate 내) | 1 | `Keeper_meta_contract` |
+
+신규 substrate addition 모듈: `runtime_constants`(fallback_context_window), `runtime_metrics`(on_* emitter), `Runtime`에 `parse_model_string`/`config_path`/model-resolution 헬퍼 추가.
+
 ### 검증 순서
 
 L0 scratch 컴파일 → L1 (keeper_meta_contract 링크 필요, 전체 lib 빌드) → L2 후 full build green + `rg -w 'Cascade_[a-z][A-Za-z_]*\.' lib bin` = 0 (생존 variant 생성자 `Cascade_idle` 등은 잔존 허용, P6 rename).

--- a/lib/keeper/keeper_attempt_liveness.ml
+++ b/lib/keeper/keeper_attempt_liveness.ml
@@ -1,0 +1,170 @@
+(** Cascade attempt-level streaming liveness gate (RFC-0022 PR-1/4).
+
+    Implementation of the decision table in
+    [docs/rfc/RFC-0022-cascade-attempt-liveness.md] §4.5.
+
+    Pure FSM. No IO, no clock read, no fiber. Caller (PR-2) supplies
+    monotonic timestamps via {!event} and consumes {!output} for
+    Prometheus / log emission. *)
+
+type budget = {
+  ttft_max : float;
+  inter_chunk_max : float;
+  attempt_wall_max : float;
+}
+
+(* Conservative first-attempt budget used before the runtime has observed a
+   successful sample for the concrete provider/model candidate. Later attempts
+   are tuned from successful TTFT/inter-chunk/wall samples in
+   [Keeper_attempt_liveness_config]. *)
+let bootstrap : budget =
+  { ttft_max = 600.0; inter_chunk_max = 120.0; attempt_wall_max = 1800.0 }
+
+module Stream_chunk = struct
+  type kind =
+    | Thinking_delta
+    | Answer_delta
+    | Tool_call_start of { tool_name : string }
+    | Tool_call_arg_delta
+    | Tool_call_complete
+    | Substrate_event of { kind : string }
+    | Heartbeat
+    | Done
+end
+
+type failure =
+  | No_first_token
+  | Inter_chunk_idle
+  | Wall_exceeded
+  | Provider_error of string
+
+let failure_kind_label = function
+  | No_first_token -> "no_first_token"
+  | Inter_chunk_idle -> "inter_chunk_idle"
+  | Wall_exceeded -> "wall_exceeded"
+  | Provider_error _ -> "provider_error"
+
+type state =
+  | Awaiting of { started_at : float }
+  | Streaming of { started_at : float; last_chunk_at : float }
+  | Failed of failure
+  | Success
+
+let initial ~started_at = Awaiting { started_at }
+
+let is_terminal = function
+  | Failed _ | Success -> true
+  | Awaiting _ | Streaming _ -> false
+
+type event =
+  | Chunk of Stream_chunk.kind * float
+  | Tick of float
+  | Provider_wire_error of string
+
+type output =
+  | Continue
+  | Outcome of failure
+  | Completed
+
+(** Metric recorder — caller (e.g. cascade_attempt_liveness_observer)
+    supplies callbacks for TTFT seconds, TBT seconds, and liveness outcome.
+    Pure FSM stays IO-free; side effects live in the recorder. *)
+type recorder = {
+  record_ttft : float -> unit;
+  record_inter_chunk : float -> unit;
+  record_liveness_outcome : failure option -> unit;
+}
+
+let null_recorder = {
+  record_ttft = (fun _ -> ());
+  record_inter_chunk = (fun _ -> ());
+  record_liveness_outcome = (fun _ -> ());
+}
+
+(* Decision table — RFC-0022 §4.5.
+
+   Invariants enforced here:
+   - S1: every chunk except Done advances last_chunk_at.
+   - S2: Done in Streaming → Success terminal; no further state moves.
+   - T1: Heartbeat / Thinking_delta both count as motion.
+   - L2: TTFT and inter-chunk checks fire before wall when both expire
+         on the same tick (caller of cascade_fsm gets the most specific
+         kill class; matches §1 invariant L2 "no double kill"). Wall still
+         applies in Awaiting, so a shorter attempt wall can kill a no-first-byte
+         attempt before the TTFT ceiling. *)
+
+let step ?(recorder = null_recorder) (b : budget) (s : state) (e : event)
+  : state * output =
+  match s, e with
+  (* Terminal states absorb every event without moving. The FSM does
+     not re-enter Awaiting once it has left. *)
+  | (Failed _ as fs), _ -> (fs, Continue)
+  | (Success as ss), _ -> (ss, Continue)
+
+  (* Awaiting × chunk(Done): provider returned Done before producing
+     any token. Treat as Success (caller's accept predicate decides
+     whether the empty body is acceptable; this FSM only tracks
+     liveness). *)
+  | Awaiting _, Chunk (Stream_chunk.Done, _) ->
+      (Success, Completed)
+
+  (* Awaiting × chunk(any non-Done): transition to Streaming. *)
+  | Awaiting { started_at }, Chunk (_, received_at) ->
+      let ttft_seconds = received_at -. started_at in
+      recorder.record_ttft ttft_seconds;
+      ( Streaming { started_at; last_chunk_at = received_at }
+      , Continue )
+
+  (* Awaiting × Tick: check TTFT first, wall second.
+     [now - started_at >= ttft_max] is the more specific no-first-token
+     failure. [attempt_wall_max] still applies while Awaiting so an attempt
+     with a shorter global wall cannot wait forever for a first chunk. *)
+  | Awaiting { started_at }, Tick now ->
+      let wall = now -. started_at in
+      if wall >= b.ttft_max then begin
+        recorder.record_liveness_outcome (Some No_first_token);
+        (Failed No_first_token, Outcome No_first_token)
+      end else if wall >= b.attempt_wall_max then begin
+        recorder.record_liveness_outcome (Some Wall_exceeded);
+        (Failed Wall_exceeded, Outcome Wall_exceeded)
+      end else
+        (s, Continue)
+
+  (* Awaiting × Provider_wire_error: provider failed before any chunk;
+     classify as wire error, not liveness — let cascade FSM decide. *)
+  | Awaiting _, Provider_wire_error msg ->
+      recorder.record_liveness_outcome (Some (Provider_error msg));
+      ( Failed (Provider_error msg)
+      , Outcome (Provider_error msg) )
+
+  (* Streaming × chunk(Done): success. *)
+  | Streaming _, Chunk (Stream_chunk.Done, _) ->
+      (Success, Completed)
+
+  (* Streaming × chunk(any non-Done): advance last_chunk_at. *)
+  | Streaming { started_at; last_chunk_at = prev_last }, Chunk (_, received_at) ->
+      let tbt_seconds = received_at -. prev_last in
+      recorder.record_inter_chunk tbt_seconds;
+      ( Streaming { started_at; last_chunk_at = received_at }
+      , Continue )
+
+  (* Streaming × Tick: check inter-chunk first, wall second.
+     Per L2, the more specific kill class wins when both expire on
+     the same tick — inter-chunk is more specific (gap-based) than
+     wall (cumulative). *)
+  | Streaming { started_at; last_chunk_at }, Tick now ->
+      let gap = now -. last_chunk_at in
+      let wall = now -. started_at in
+      if gap >= b.inter_chunk_max then begin
+        recorder.record_liveness_outcome (Some Inter_chunk_idle);
+        (Failed Inter_chunk_idle, Outcome Inter_chunk_idle)
+      end else if wall >= b.attempt_wall_max then begin
+        recorder.record_liveness_outcome (Some Wall_exceeded);
+        (Failed Wall_exceeded, Outcome Wall_exceeded)
+      end else
+        (s, Continue)
+
+  | Streaming _, Provider_wire_error msg ->
+      recorder.record_liveness_outcome (Some (Provider_error msg));
+      ( Failed (Provider_error msg)
+      , Outcome (Provider_error msg) )

--- a/lib/keeper/keeper_attempt_liveness.mli
+++ b/lib/keeper/keeper_attempt_liveness.mli
@@ -1,0 +1,217 @@
+(** Cascade attempt-level streaming liveness gate (RFC-0022 PR-1/4).
+
+    Pure FSM that fails the *current cascade attempt* — not the turn —
+    when a provider stops emitting evidence of forward motion. Three
+    independent kill classes:
+
+    - {!No_first_token}     — provider produces no chunk within [ttft_max]
+    - {!Inter_chunk_idle}   — gap between consecutive chunks exceeds [inter_chunk_max]
+    - {!Wall_exceeded}      — total attempt wall-clock exceeds [attempt_wall_max]
+
+    See [docs/rfc/RFC-0022-cascade-attempt-liveness.md] §4 for the design.
+
+    {1 Layer separation}
+
+    This is the in-attempt layer (§1 of RFC-0022). It must not collide
+    with:
+
+    - RFC-0009 {b pre-attempt} provider trust (cascade order)
+    - RFC-0012 {b cross-attempt} turn-level mid-progress watchdog
+
+    Every chunk that advances this module's clock must also advance
+    RFC-0012's [last_progress_at] (Invariant L1). The wiring is a
+    caller responsibility — see [keeper_hooks_oas.ml] in PR-3.
+
+    {1 Scope of this PR}
+
+    This PR-1 ships the pure FSM module + property tests only.
+    Production cascade behaviour is unchanged: no caller in
+    [cascade_runtime.ml] consumes [step] yet. Wiring lands in PR-2 of
+    the RFC-0022 stack, behind [MASC_CASCADE_ATTEMPT_LIVENESS=observe]
+    by default (§9 Phase A).
+
+    @stability Evolving
+    @since 0.190.0 *)
+
+(** {1 Liveness budget} *)
+
+type budget = {
+  ttft_max : float;
+  (** Time to first chunk. Awaiting-state deadline. *)
+
+  inter_chunk_max : float;
+  (** Maximum gap between consecutive chunks once streaming starts. *)
+
+  attempt_wall_max : float;
+  (** Hard backstop on total attempt wall-clock duration. *)
+}
+
+val bootstrap : budget
+(** Conservative first-attempt budget used only until
+    {!Keeper_attempt_liveness_config} has recent successful samples for the
+    concrete provider/model candidate. *)
+
+(** {1 Stream chunk taxonomy}
+
+    Defines what counts as a chunk for the purpose of advancing the
+    liveness clock (Invariant S1 of RFC-0022 §4.4). *)
+
+module Stream_chunk : sig
+  type kind =
+    | Thinking_delta
+        (** Adaptive-reasoning model thinking token delta.
+            Counts as motion (Invariant T1). *)
+
+    | Answer_delta
+        (** Answer token delta. *)
+
+    | Tool_call_start of { tool_name : string }
+        (** Provider declared a tool call. *)
+
+    | Tool_call_arg_delta
+        (** Provider streaming tool-call arguments. *)
+
+    | Tool_call_complete
+        (** Provider finished a tool call. *)
+
+    | Substrate_event of { kind : string }
+        (** Provider-specific protocol event (e.g. [oas:event]). *)
+
+    | Heartbeat
+        (** Protocol-level keepalive. Permitted only as a liveness
+            signal during long thinking / tool-call windows; clients
+            MUST NOT emit Heartbeat without underlying real activity
+            (§4.4 Invariant S3). *)
+
+    | Done
+        (** Terminal — attempt success. After Done no further chunks
+            are accepted (§4.4 Invariant S2). *)
+end
+
+(** {1 Failure class}
+
+    Reported back to the cascade FSM so it can attribute the kill to
+    liveness (not a wire error) and advance to the next provider. *)
+
+type failure =
+  | No_first_token
+  | Inter_chunk_idle
+  | Wall_exceeded
+  | Provider_error of string
+
+val failure_kind_label : failure -> string
+(** Stable label for telemetry / Prometheus counter. One of
+    [no_first_token | inter_chunk_idle | wall_exceeded | provider_error]. *)
+
+(** {1 FSM state} *)
+
+type state =
+  | Awaiting of { started_at : float }
+      (** No chunks received yet. Subject to [ttft_max]. *)
+
+  | Streaming of { started_at : float; last_chunk_at : float }
+      (** At least one chunk received. Subject to [inter_chunk_max]
+          and [attempt_wall_max]. *)
+
+  | Failed of failure
+      (** Terminal failure. *)
+
+  | Success
+      (** Terminal success ({!Stream_chunk.Done} observed). *)
+
+val initial : started_at:float -> state
+(** Construct an initial [Awaiting] state. *)
+
+val is_terminal : state -> bool
+(** [true] iff [Failed _] or [Success]. *)
+
+(** {1 Event}
+
+    Inputs to {!step}. The decision table in RFC-0022 §4.5 enumerates
+    every (state, event) pair.
+
+    {2 Timestamp contract (caller responsibility)}
+
+    All [float] timestamps in [Chunk] / [Tick] payloads ([received_at],
+    [now]) MUST satisfy:
+
+    - {b finite}: not [Float.nan], [Float.infinity] or [neg_infinity]
+    - {b non-negative}: a monotonic seconds reading from the same
+      clock source used to construct {!initial}'s [started_at]
+    - {b monotonically non-decreasing} across consecutive events fed
+      to the same FSM instance
+
+    Validation lives in the wiring layer (PR-2 [cascade_runtime.ml]
+    + PR-3 [keeper_hooks_oas.ml]) — this module is a pure FSM and
+    trusts its inputs. Feeding non-finite or out-of-order timestamps
+    produces undefined liveness behaviour. *)
+
+type event =
+  | Chunk of Stream_chunk.kind * float
+      (** Provider emitted a chunk. The [float] is the monotonic
+          [received_at]; see Timestamp contract above. *)
+
+  | Tick of float
+      (** Clock tick at monotonic time. Triggers TTFT, inter-chunk and
+          wall checks; see Timestamp contract above. *)
+
+  | Provider_wire_error of string
+      (** Provider returned an error (HTTP, network, parse). The string
+          is for diagnostic only — caller decides retryability. *)
+
+(** {1 Output}
+
+    Side-effect signal returned alongside the next state. Callers in
+    PR-2 emit Prometheus counters and structured logs based on
+    [Outcome]. *)
+
+type output =
+  | Continue
+      (** No transition observable to caller. *)
+
+  | Outcome of failure
+      (** Attempt failed; cascade FSM should advance to next provider. *)
+
+  | Completed
+      (** Attempt succeeded. *)
+
+(** Metric recorder — caller supplies callbacks for TTFT seconds, TBT
+    seconds, and liveness outcome observation.  [null_recorder] is the
+    default so the pure FSM stays IO-free unless a caller explicitly
+    wires metrics. *)
+type recorder = {
+  record_ttft : float -> unit;
+  record_inter_chunk : float -> unit;
+  record_liveness_outcome : failure option -> unit;
+}
+
+val null_recorder : recorder
+
+(** {1 Decision function}
+
+    {b Pure}: no IO, no clock read, no allocation outside what OCaml
+    pattern-match constructs. Tests exercise the full decision table
+    by feeding hand-crafted [(state, event)] pairs.
+
+    {2 Event ordering contract}
+
+    Deadlines fire on [Tick] only — by design (RFC-0022 §4.5 + §4.4
+    Invariant S1). To bound the late-chunk window the {b caller} MUST:
+
+    {ol
+    {- emit [Tick] at a cadence ≤ [min budget.ttft_max
+       budget.inter_chunk_max] for the active state, and}
+    {- when both an overdue [Tick] and a late [Chunk] are observable
+       at the wiring layer, deliver the overdue [Tick] {b first} so
+       the FSM can transition to [Failed] before the chunk reopens
+       the streaming clock.}}
+
+    Concretely the PR-2 wiring (`cascade_runtime.ml`) drives this via
+    a single fiber that drains the chunk queue and emits a [Tick]
+    after each empty poll; PR-3 (`keeper_hooks_oas.ml`) carries the
+    same ordering guarantee into the RFC-0012 lockstep clock. Callers
+    that fan chunks and ticks across separate fibers must enforce this
+    ordering themselves (e.g. via a single [Lwt_stream] / [Eio.Stream]
+    pulled by one consumer). *)
+
+val step : ?recorder:recorder -> budget -> state -> event -> state * output

--- a/lib/keeper/keeper_attempt_liveness_config.ml
+++ b/lib/keeper/keeper_attempt_liveness_config.ml
@@ -1,0 +1,242 @@
+(* See cascade_attempt_liveness_config.mli for documentation.
+
+   RFC-0022 PR-2/4 §2 — tri-state env flag + living budget map. *)
+
+type mode =
+  | Off
+  | Observe
+  | Enforce
+
+let mode_label = function
+  | Off -> "off"
+  | Observe -> "observe"
+  | Enforce -> "enforce"
+
+let env_var_name = "MASC_CASCADE_ATTEMPT_LIVENESS"
+
+let parse_mode raw =
+  match String.trim raw with
+  | "off" -> Off
+  | "observe" -> Observe
+  | "enforce" -> Enforce
+  | value ->
+    raise
+      (Env_config_core.Config_error
+         (Printf.sprintf
+            "%s must be one of off|observe|enforce, got %S"
+            env_var_name
+            value))
+
+(* Cached after first read so mid-attempt env edits do not split-brain the
+   observer. *)
+let mode_cache : mode option ref = ref None
+
+let current_mode () =
+  match !mode_cache with
+  | Some m -> m
+  | None ->
+      let m =
+        match Sys.getenv_opt env_var_name with
+        | None -> Enforce
+        | Some raw -> parse_mode raw
+      in
+      mode_cache := Some m;
+      m
+
+let reset_cache_for_test () = mode_cache := None
+
+type success_sample =
+  { ttft_ms : float
+  ; max_inter_chunk_ms : float
+  ; wall_ms : float
+  }
+
+type budget_source =
+  | Bootstrap
+  | Observed_success of { samples : int }
+
+type resolved_budget =
+  { budget : Keeper_attempt_liveness.budget
+  ; source : budget_source
+  }
+
+let budget_source_label = function
+  | Bootstrap -> "bootstrap"
+  | Observed_success _ -> "observed_success"
+
+let success_history : (string, success_sample list) Hashtbl.t = Hashtbl.create 64
+let success_history_order : string list ref = ref []
+let success_history_mu = Stdlib.Mutex.create ()
+
+let with_success_history_lock f =
+  Stdlib.Mutex.lock success_history_mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock success_history_mu) f
+
+let success_history_limit =
+  match Sys.getenv_opt "MASC_CASCADE_LIVENESS_SUCCESS_HISTORY_SIZE" with
+  | None | Some "" -> 32
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some n -> max 1 (min 256 n)
+     | None -> 32)
+
+let success_history_candidate_limit =
+  match Sys.getenv_opt "MASC_CASCADE_LIVENESS_SUCCESS_CANDIDATES" with
+  | None | Some "" -> 128
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some n -> max 1 (min 2048 n)
+     | None -> 128)
+
+let finite_non_negative v = Float.is_finite v && Float.compare v 0.0 >= 0
+
+let valid_sample (s : success_sample) =
+  finite_non_negative s.ttft_ms
+  && finite_non_negative s.max_inter_chunk_ms
+  && finite_non_negative s.wall_ms
+
+(* RFC-0132 PR-2: liveness candidate key = external boundary; redact via SSOT. *)
+let runtime_candidate_key =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
+
+let normalize_candidate_key raw =
+  let key = String.trim raw in
+  if key = "" then None else Some runtime_candidate_key
+
+let take = List.take
+
+let take_drop limit values =
+  let rec loop n kept = function
+    | [] -> List.rev kept, []
+    | rest when n <= 0 -> List.rev kept, rest
+    | x :: rest -> loop (n - 1) (x :: kept) rest
+  in
+  loop limit [] values
+
+let remember_candidate_key key =
+  success_history_order
+  := key
+     :: List.filter
+          (fun existing -> not (String.equal existing key))
+          !success_history_order;
+  let kept, evicted =
+    take_drop success_history_candidate_limit !success_history_order
+  in
+  success_history_order := kept;
+  List.iter (Hashtbl.remove success_history) evicted
+
+let record_success_sample ~candidate_key (sample : success_sample) =
+  match normalize_candidate_key candidate_key with
+  | None -> ()
+  | Some key when not (valid_sample sample) -> ()
+  | Some key ->
+    with_success_history_lock (fun () ->
+        remember_candidate_key key;
+        let current =
+          match Hashtbl.find_opt success_history key with
+          | Some samples -> samples
+          | None -> []
+        in
+        Hashtbl.replace success_history key (take success_history_limit (sample :: current)))
+
+let reset_success_history_for_test () =
+  with_success_history_lock (fun () ->
+      Hashtbl.clear success_history;
+      success_history_order := [])
+
+let success_sample_count_for_test ~candidate_key =
+  match normalize_candidate_key candidate_key with
+  | None -> 0
+  | Some key ->
+    with_success_history_lock (fun () ->
+        match Hashtbl.find_opt success_history key with
+        | Some samples -> List.length samples
+        | None -> 0)
+
+let percentile p values =
+  match List.sort Float.compare values with
+  | [] -> None
+  | sorted ->
+    let len = List.length sorted in
+    let raw_idx = int_of_float (ceil (p *. float_of_int len)) - 1 in
+    let idx = max 0 (min (len - 1) raw_idx) in
+    List.nth_opt sorted idx
+
+let seconds_of_ms ms = ms /. 1000.0
+
+let clamp_float ~floor ~ceiling v =
+  Float.max floor (Float.min ceiling v)
+
+let tuned_seconds ~floor ~ceiling ~multiplier ~add seconds =
+  clamp_float ~floor ~ceiling ((seconds *. multiplier) +. add)
+
+let budget_of_samples samples =
+  let p95 field = percentile 0.95 (List.map field samples) in
+  match p95 (fun s -> s.ttft_ms), p95 (fun s -> s.max_inter_chunk_ms),
+        p95 (fun s -> s.wall_ms) with
+  | Some ttft_ms, Some inter_ms, Some wall_ms ->
+    let ttft_max =
+      tuned_seconds
+        ~floor:30.0
+        ~ceiling:900.0
+        ~multiplier:1.5
+        ~add:5.0
+        (seconds_of_ms ttft_ms)
+    in
+    let inter_chunk_max =
+      tuned_seconds
+        ~floor:20.0
+        ~ceiling:240.0
+        ~multiplier:2.0
+        ~add:5.0
+        (seconds_of_ms inter_ms)
+    in
+    let observed_wall =
+      tuned_seconds
+        ~floor:180.0
+        ~ceiling:Masc_time_constants.hour
+        ~multiplier:1.4
+        ~add:30.0
+        (seconds_of_ms wall_ms)
+    in
+    let attempt_wall_max =
+      Float.max observed_wall (ttft_max +. inter_chunk_max)
+    in
+    { Keeper_attempt_liveness.ttft_max = ttft_max
+    ; inter_chunk_max
+    ; attempt_wall_max
+    }
+  | _ -> Keeper_attempt_liveness.bootstrap
+
+let budget_for_candidate ~candidate_key =
+  let key = normalize_candidate_key candidate_key in
+  let samples =
+    match key with
+    | None -> []
+    | Some key ->
+      with_success_history_lock (fun () ->
+          match Hashtbl.find_opt success_history key with
+          | Some samples -> samples
+          | None -> [])
+  in
+  match samples with
+  | [] -> { budget = Keeper_attempt_liveness.bootstrap; source = Bootstrap }
+  | samples ->
+    { budget = budget_of_samples samples
+    ; source = Observed_success { samples = List.length samples }
+    }
+
+(* RFC-0022 §1 — see .mli for contract. *)
+let outer_wall_for_attempt
+    ~mode ~observer_attached ~per_provider_timeout_s ~candidate_key =
+  match mode, observer_attached with
+  | Enforce, true -> None
+  | _, true ->
+      let resolved = budget_for_candidate ~candidate_key in
+      let budget_wall =
+        resolved.budget.Keeper_attempt_liveness.attempt_wall_max
+      in
+      Option.map
+        (fun t -> Float.max t budget_wall)
+        per_provider_timeout_s
+  | _, false -> per_provider_timeout_s

--- a/lib/keeper/keeper_attempt_liveness_config.mli
+++ b/lib/keeper/keeper_attempt_liveness_config.mli
@@ -1,0 +1,114 @@
+(** Tri-state env flag + living budget selection for the cascade
+    attempt-liveness gate (RFC-0022 PR-2/4 §2).
+
+    The flag [MASC_CASCADE_ATTEMPT_LIVENESS] selects one of three modes:
+
+    - [off]      — wrapper bypassed entirely, baseline behaviour.
+    - [observe]  — observer constructed; counters emit; never raises.
+    - [enforce]  — observer raises [Liveness_kill] via [Eio.Switch.fail]
+                   on the first {!Keeper_attempt_liveness.Outcome}.
+
+    When the env var is absent, current production default is [enforce].
+    Explicit values must be exactly [off], [observe], or [enforce]; empty,
+    boolean-like, rollout-era, and otherwise unparseable values raise
+    {!Env_config_core.Config_error}.
+
+    The mode is read once and cached on first call so that mid-attempt env
+    edits do not split-brain the observer.
+
+    @stability Evolving
+    @since 0.190.0 *)
+
+type mode =
+  | Off
+  | Observe
+  | Enforce
+
+val current_mode : unit -> mode
+(** Cached env-flag read. First call reads
+    [MASC_CASCADE_ATTEMPT_LIVENESS] and caches the result. Subsequent
+    calls return the cached value. *)
+
+val mode_label : mode -> string
+(** Stable label for telemetry / Prometheus counter values. One of
+    [off | observe | enforce]. *)
+
+type success_sample =
+  { ttft_ms : float
+  ; max_inter_chunk_ms : float
+  ; wall_ms : float
+  }
+(** Successful attempt timing sample for the neutral runtime candidate lane.
+    Values are milliseconds and are recorded only after the liveness FSM
+    reaches [Success]. Failed, killed, or rejected attempts do not train future
+    budgets. *)
+
+type budget_source =
+  | Bootstrap
+  | Observed_success of { samples : int }
+
+type resolved_budget =
+  { budget : Keeper_attempt_liveness.budget
+  ; source : budget_source
+  }
+
+val budget_source_label : budget_source -> string
+(** Stable debug/receipt label: [bootstrap] or [observed_success]. *)
+
+val runtime_candidate_key : string
+(** Neutral candidate key used for MASC-side liveness budget storage. Concrete
+    provider/model identities stay on the OAS side and are not retained here. *)
+
+val budget_for_candidate : candidate_key:string -> resolved_budget
+(** Resolve the budget for the neutral runtime candidate lane. [candidate_key]
+    is accepted for source compatibility, but any non-empty value is normalized
+    to {!runtime_candidate_key}. When no successful samples exist, returns
+    {!Keeper_attempt_liveness.bootstrap} with [source = Bootstrap]. *)
+
+val record_success_sample :
+  candidate_key:string -> success_sample -> unit
+(** Append a successful attempt timing sample to the neutral runtime candidate
+    lane. Invalid negative/non-finite values are ignored. The runtime lane keeps
+    at most [MASC_CASCADE_LIVENESS_SUCCESS_HISTORY_SIZE] samples. *)
+
+val reset_cache_for_test : unit -> unit
+(** Test-only: reset the cached flag read so a new value of
+    [MASC_CASCADE_ATTEMPT_LIVENESS] takes effect. Production callers
+    must not invoke this. *)
+
+val reset_success_history_for_test : unit -> unit
+(** Test-only: clear the in-process success-history budget store. *)
+
+val success_sample_count_for_test : candidate_key:string -> int
+(** Test-only: number of retained samples in the neutral runtime lane selected
+    by [candidate_key]. Empty keys return [0]. *)
+
+val outer_wall_for_attempt
+  :  mode:mode
+  -> observer_attached:bool
+  -> per_provider_timeout_s:float option
+  -> candidate_key:string
+  -> float option
+(** RFC-0022 §1 — backstop wall for the legacy [per_provider_timeout_s]
+    knob.
+
+    Decides what (if anything) {!Eio.Time.with_timeout_exn} should
+    enforce around an attempt, given the active liveness mode and
+    whether an observer is attached.
+
+    - [Enforce] + observer attached: returns [None]. The observer is
+      the authority and drives [Switch.fail] on TTFT, inter-chunk, or
+      attempt wall budget breach. The legacy outer wall must not
+      pre-empt it.
+    - [Off] / [Observe] + observer attached: returns
+      [Some (max t (budget_for_candidate ~candidate_key).budget.attempt_wall_max)]
+      when [per_provider_timeout_s = Some t]. Successful prior attempts for
+      the same candidate can raise the legacy wall so a slow-but-honest stream
+      is not killed before the liveness observer's own deadline.
+    - No observer attached (any mode): returns [per_provider_timeout_s]
+      unchanged. Without an observer there is no per-provider budget
+      to clamp against, so the caller's legacy knob is honored as-is.
+    - No legacy timeout configured ([per_provider_timeout_s = None]):
+      returns [None] (no outer wall).
+
+    @since 0.20.0 *)

--- a/lib/keeper/keeper_attempt_liveness_observer.ml
+++ b/lib/keeper/keeper_attempt_liveness_observer.ml
@@ -1,0 +1,406 @@
+(* See cascade_attempt_liveness_observer.mli for documentation.
+
+   RFC-0022 PR-2/4 §4-5 — observer constructor, on_event wrapper,
+   tick fiber, finalizer. *)
+
+module L = Keeper_attempt_liveness
+module Cfg = Keeper_attempt_liveness_config
+module Runtime_binding = Agent_sdk.Provider_runtime_binding
+
+exception Liveness_kill of L.failure
+
+type t = {
+  mode : Cfg.mode;
+  budget : L.budget;
+  cascade_label : string;
+  provider_label : string;
+  candidate_key : string option;
+  external_wait : (unit -> bool) option;
+  started_at : float;
+  first_chunk_at : float option ref;
+  last_chunk_at : float option ref;
+  max_inter_chunk_s : float ref;
+  success_sample : (string * Cfg.success_sample) option ref;
+  state : L.state ref;
+  sw_ref : Eio.Switch.t option ref;
+  finalized : bool ref;
+  stop_tick_p : unit Eio.Promise.t;
+  stop_tick_r : unit Eio.Promise.u;
+  stop_tick_requested : bool Atomic.t;
+}
+
+let mode (t : t) : Cfg.mode = t.mode
+
+(* RFC-0132 PR-2: liveness observer public label = external boundary; redact via SSOT. *)
+let public_runtime_provider_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_provider_label
+let public_other_provider_label = "other"
+
+let normalize_provider_label label = String.trim label |> String.lowercase_ascii
+
+let provider_prefix raw =
+  match String.index_opt raw ':' with
+  | Some idx when idx > 0 -> String.sub raw 0 idx
+  | _ -> raw
+;;
+
+let public_known_provider_label label =
+  let normalized = normalize_provider_label label in
+  if normalized = ""
+  then None
+  else
+    match Runtime_binding.find normalized with
+    | Some binding -> Some binding.Runtime_binding.id
+    | None ->
+      (match Llm_provider.Capabilities.capabilities_for_provider_label normalized with
+       | Some _ -> Some normalized
+       | None -> None)
+;;
+
+let public_provider_label_of_raw raw =
+  let raw = String.trim raw in
+  if raw = "" || String.equal raw public_runtime_provider_label
+  then public_runtime_provider_label
+  else
+    match public_known_provider_label (provider_prefix raw) with
+    | Some provider -> provider
+    | None -> public_other_provider_label
+;;
+
+let create
+      ~mode
+      ~budget
+      ~cascade_label
+      ?(provider_label = public_runtime_provider_label)
+      ?external_wait
+      ?candidate_key
+      ~started_at
+      ()
+  =
+  let stop_tick_p, stop_tick_r = Eio.Promise.create () in
+  {
+    mode;
+    budget;
+    cascade_label;
+    provider_label = public_provider_label_of_raw provider_label;
+    candidate_key;
+    external_wait;
+    started_at;
+    first_chunk_at = ref None;
+    last_chunk_at = ref None;
+    max_inter_chunk_s = ref 0.0;
+    success_sample = ref None;
+    state = ref (L.initial ~started_at);
+    sw_ref = ref None;
+    finalized = ref false;
+    stop_tick_p;
+    stop_tick_r;
+    stop_tick_requested = Atomic.make false;
+  }
+
+let current_state_for_test (t : t) : L.state = !(t.state)
+
+(* -- Prometheus emission ------------------------------------------- *)
+
+let kill_labels (t : t) (failure : L.failure) =
+  [
+    ("mode", Cfg.mode_label t.mode);
+    ("kind", L.failure_kind_label failure);
+    ("cascade", t.cascade_label);
+    ("provider", t.provider_label);
+  ]
+
+let observed_labels (t : t) ~outcome =
+  [
+    ("cascade", t.cascade_label);
+    ("provider", t.provider_label);
+    ("outcome", outcome);
+  ]
+
+let emit_kill_counter (t : t) (failure : L.failure) =
+  Prometheus.inc_counter Prometheus.metric_cascade_attempt_liveness_kill
+    ~labels:(kill_labels t failure) ()
+
+(* -- Event translation -------------------------------------------- *)
+
+(* Translate an SSE event into a {!Stream_chunk.kind}, returning
+   None for events that the FSM should not see (e.g. Ping that does
+   not advance the clock — RFC §4.4 invariant S3 forbids treating
+   raw Ping as motion).
+
+   MessageStop maps to Done; ContentBlockDelta maps to the matching
+   Answer/Thinking delta; ContentBlockStart with content_type
+   "tool_use" maps to Tool_call_start; SSEError and explicit parser
+   failures map to wire errors; MessageStart / MessageDelta / Ping /
+   ContentBlockStop are ignored as they are protocol scaffolding
+   without forward motion. *)
+
+let event_to_chunk_kind (evt : Agent_sdk.Types.sse_event)
+    : L.Stream_chunk.kind option =
+  match evt with
+  | Agent_sdk.Types.MessageStop -> Some L.Stream_chunk.Done
+  | Agent_sdk.Types.ContentBlockDelta { delta; _ } -> (
+      match delta with
+      | TextDelta _ -> Some L.Stream_chunk.Answer_delta
+      | ThinkingDelta _ -> Some L.Stream_chunk.Thinking_delta
+      | InputJsonDelta _ -> Some L.Stream_chunk.Tool_call_arg_delta)
+  | Agent_sdk.Types.ContentBlockStart { content_type; tool_name; _ } -> (
+      match content_type with
+      | "tool_use" ->
+          Some
+            (L.Stream_chunk.Tool_call_start
+               { tool_name = Option.value ~default:"" tool_name })
+      | _ -> None)
+  | Agent_sdk.Types.ContentBlockStop _ ->
+      Some L.Stream_chunk.Tool_call_complete
+  | Agent_sdk.Types.MessageStart _ -> None
+  | Agent_sdk.Types.MessageDelta _ -> None
+  | Agent_sdk.Types.Ping -> None
+  | Agent_sdk.Types.SSEError _ -> None
+  | Agent_sdk.Types.SSEParseFailed _ -> None
+  | Agent_sdk.Types.SSEUnknownEventType _ -> None
+
+let wire_error_of_event (evt : Agent_sdk.Types.sse_event) : string option =
+  match evt with
+  | Agent_sdk.Types.SSEError msg -> Some msg
+  | Agent_sdk.Types.SSEParseFailed { reason; _ } ->
+      Some ("sse_parse_failed: " ^ reason)
+  | Agent_sdk.Types.SSEUnknownEventType { event_type; _ } ->
+      Some ("sse_unknown_event_type: " ^ event_type)
+  | _ -> None
+
+(* -- React to FSM output ------------------------------------------ *)
+
+let react_to_output (t : t) (output : L.output) : unit =
+  match output with
+  | L.Continue -> ()
+  | L.Completed -> ()
+  | L.Outcome failure ->
+      emit_kill_counter t failure;
+      (match t.mode with
+       | Cfg.Off -> ()  (* unreachable: caller bypassed wrapper *)
+       | Cfg.Observe -> ()  (* shadow only — never raise *)
+       | Cfg.Enforce -> (
+           match !(t.sw_ref) with
+           | Some sw -> Eio.Switch.fail sw (Liveness_kill failure)
+           | None ->
+               (* Enforce without a switch wired is a programmer error;
+                  log and degrade to Observe rather than raise. *)
+               Log.Misc.warn
+                 "cascade_attempt_liveness: enforce mode but no switch \
+                  registered (cascade=%s provider=%s); shadowing kill"
+                 t.cascade_label t.provider_label))
+
+(* -- on_event wrapper --------------------------------------------- *)
+
+let now_seconds () = Time_compat.now ()
+
+let observe_chunk_clock (t : t) ~(at : float) : unit =
+  (match !(t.first_chunk_at) with
+   | None -> t.first_chunk_at := Some at
+   | Some _ -> ());
+  (match !(t.last_chunk_at) with
+   | None -> ()
+   | Some prev ->
+     let gap = at -. prev in
+     if Float.is_finite gap && gap > !(t.max_inter_chunk_s)
+     then t.max_inter_chunk_s := gap);
+  t.last_chunk_at := Some at
+
+let prometheus_recorder (t : t) : L.recorder =
+  let labels = [ ("cascade", t.cascade_label); ("provider", t.provider_label) ] in
+  {
+    L.record_ttft = (fun seconds ->
+        Prometheus.observe_histogram Prometheus.metric_cascade_ttfb_seconds
+          ~labels seconds);
+    record_inter_chunk = (fun seconds ->
+        Prometheus.observe_histogram Prometheus.metric_cascade_inter_chunk_seconds
+          ~labels seconds);
+    record_liveness_outcome = (fun _ -> ());
+  }
+
+let stop_tick_fiber (t : t) : unit =
+  if Atomic.compare_and_set t.stop_tick_requested false true then
+    Eio.Promise.resolve t.stop_tick_r ()
+
+let step_with_event (t : t) (evt : Agent_sdk.Types.sse_event) : unit =
+  if L.is_terminal !(t.state) then ()
+  else
+    let now = now_seconds () in
+    let liveness_event =
+      match wire_error_of_event evt with
+      | Some msg -> Some (L.Provider_wire_error msg)
+      | None -> (
+          match event_to_chunk_kind evt with
+          | None -> None
+          | Some kind -> Some (L.Chunk (kind, now)))
+    in
+    match liveness_event with
+    | None -> ()
+    | Some le ->
+        (match le with
+         | L.Chunk (_, at) -> observe_chunk_clock t ~at
+         | L.Tick _ | L.Provider_wire_error _ -> ());
+        let new_state, output =
+          L.step ~recorder:(prometheus_recorder t) t.budget !(t.state) le
+        in
+        t.state := new_state;
+        if L.is_terminal new_state then stop_tick_fiber t;
+        react_to_output t output
+
+let external_wait_active (t : t) : bool =
+  match t.external_wait with
+  | None -> false
+  | Some f ->
+    (try f () with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Log.Misc.warn
+         "cascade_attempt_liveness: external_wait predicate raised \
+          (cascade=%s provider=runtime): %s"
+         t.cascade_label
+         (Printexc.to_string exn);
+       false)
+
+let wrap_on_event (t : t)
+    (original : (Agent_sdk.Types.sse_event -> unit) option)
+    : (Agent_sdk.Types.sse_event -> unit) option =
+  match t.mode with
+  | Cfg.Off -> original
+  | Cfg.Observe | Cfg.Enforce ->
+      let wrapped (evt : Agent_sdk.Types.sse_event) : unit =
+        (* Run the original first so baseline semantics never lose an
+           event even if the FSM step would raise (defensive — Observe
+           must not raise; Enforce raises only via Switch.fail). *)
+        Eio_guard.check_if_ready ();
+        (match original with
+         | None -> ()
+         | Some f -> (
+             try f evt with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+                 Log.Misc.warn
+                   "cascade_attempt_liveness: original on_event raised \
+                    (cascade=%s provider=runtime): %s"
+                   t.cascade_label
+                   (Printexc.to_string exn)));
+        Eio_guard.check_if_ready ();
+        try step_with_event t evt with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | Liveness_kill _ as e -> raise e
+        | exn ->
+            Log.Misc.warn
+              "cascade_attempt_liveness: step raised (cascade=%s \
+               provider=runtime): %s"
+              t.cascade_label (Printexc.to_string exn)
+      in
+      Some wrapped
+
+(* -- Tick fiber --------------------------------------------------- *)
+
+let tick_interval_seconds (b : L.budget) : float =
+  let smaller = Float.min b.ttft_max b.inter_chunk_max in
+  Float.max 0.5 (smaller /. 4.0)
+
+let register_attempt_switch (t : t) ~(sw : Eio.Switch.t) : unit =
+  match t.mode with
+  | Cfg.Off -> ()
+  | Cfg.Observe | Cfg.Enforce -> t.sw_ref := Some sw
+
+let start_tick_fiber (t : t) ~(sw : Eio.Switch.t)
+    ~(clock : _ Eio.Time.clock) : unit =
+  match t.mode with
+  | Cfg.Off -> ()
+  | Cfg.Observe | Cfg.Enforce ->
+      register_attempt_switch t ~sw;
+      let interval = tick_interval_seconds t.budget in
+      let await_tick_or_stop () =
+        Eio.Fiber.first
+          (fun () ->
+             Eio.Time.sleep clock interval;
+             `Tick)
+          (fun () ->
+             Eio.Promise.await t.stop_tick_p;
+             `Stop)
+      in
+      Eio.Fiber.fork ~sw (fun () ->
+          let rec loop () =
+            if L.is_terminal !(t.state) then ()
+            else begin
+              match await_tick_or_stop () with
+              | `Stop -> ()
+              | `Tick ->
+                if L.is_terminal !(t.state) then ()
+                else begin
+                  let now = now_seconds () in
+                  let event =
+                    if external_wait_active t
+                    then L.Chunk (L.Stream_chunk.Heartbeat, now)
+                    else L.Tick now
+                  in
+                  (match event with
+                   | L.Chunk (_, at) -> observe_chunk_clock t ~at
+                   | L.Tick _ | L.Provider_wire_error _ -> ());
+                  let new_state, output =
+                    L.step ~recorder:(prometheus_recorder t)
+                      t.budget !(t.state) event
+                  in
+                  t.state := new_state;
+                  (try react_to_output t output
+                   with Liveness_kill _ as e -> raise e);
+                  loop ()
+                end
+            end
+          in
+          try loop () with
+          (* Cooperative cancel: re-raise so the parent switch sees the
+             signal propagate out of this fiber. Previously [-> ()] which
+             absorbed the cancel and broke Eio back-propagation conventions
+             (every other live-loop fiber in lib/keeper/keeper_keepalive.ml,
+             lib/keeper/keeper_heartbeat_loop.ml does the explicit re-raise). *)
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          (* Liveness_kill is the loop's own terminator: the body raises it
+             via [react_to_output] when the budget is exceeded and we want
+             the fiber to exit cleanly without surfacing the exception to
+             the parent. Intentional absorption. *)
+          | Liveness_kill _ -> ()
+          | exn ->
+              Log.Misc.warn
+                "cascade_attempt_liveness tick fiber crashed (cascade=%s \
+                 provider=%s): %s"
+                t.cascade_label t.provider_label (Printexc.to_string exn))
+
+(* -- Finalize ----------------------------------------------------- *)
+
+let outcome_of_state = function
+  | L.Success -> "success"
+  | L.Failed (L.No_first_token | L.Inter_chunk_idle | L.Wall_exceeded) ->
+      "kill"
+  | L.Failed (L.Provider_error _) -> "wire_error"
+  | L.Awaiting _ | L.Streaming _ -> "wire_error"
+
+let finalize (t : t) : unit =
+  if !(t.finalized) then ()
+  else begin
+    t.finalized := true;
+    stop_tick_fiber t;
+    match t.mode with
+    | Cfg.Off -> ()
+    | Cfg.Observe | Cfg.Enforce ->
+        let outcome = outcome_of_state !(t.state) in
+        (match !(t.state), t.candidate_key, !(t.first_chunk_at), !(t.last_chunk_at) with
+         | L.Success, Some candidate_key, Some first_chunk_at, Some last_chunk_at ->
+           t.success_sample :=
+             Some
+               ( candidate_key
+               , { Cfg.ttft_ms = (first_chunk_at -. t.started_at) *. 1000.0
+                 ; max_inter_chunk_ms = !(t.max_inter_chunk_s) *. 1000.0
+                 ; wall_ms = (last_chunk_at -. t.started_at) *. 1000.0
+                 } )
+         | _ -> ());
+        Prometheus.inc_counter
+          Prometheus.metric_cascade_attempt_liveness_observed
+          ~labels:(observed_labels t ~outcome) ()
+  end
+
+let success_sample_for_candidate (t : t) = !(t.success_sample)

--- a/lib/keeper/keeper_attempt_liveness_observer.mli
+++ b/lib/keeper/keeper_attempt_liveness_observer.mli
@@ -1,0 +1,149 @@
+(** Cascade attempt-liveness observer (RFC-0022 PR-2/4 §4-5).
+
+    Glue layer between {!Keeper_attempt_liveness} (pure FSM) and the
+    streaming attempt loop in [oas_worker_named.ml]. Owns:
+
+    - The mutable FSM state ref bound to one cascade attempt.
+    - Translation from [Agent_sdk.Types.sse_event] to
+      {!Keeper_attempt_liveness.Stream_chunk.kind}.
+    - Tick fiber forked under the caller's [Eio.Switch.t] that polls
+      the FSM at [min(ttft_max, inter_chunk_max) / 4] cadence and can be
+      stopped explicitly when the provider attempt has already returned.
+    - Prometheus counter emission per outcome.
+
+    {1 No-kill in Observe mode}
+
+    Structural guarantee (RFC §4 contract):
+
+    - [Off] mode: caller short-circuits before constructing the
+      observer. [{!create}] in [Off] returns a no-op handle.
+    - [Observe] mode: counters fire but neither [Switch.fail] nor any
+      exception leaves this module. The wrapped [on_event] callback is
+      bit-identical to the baseline (delegates to the original) plus
+      side-effecting telemetry only.
+    - [Enforce] mode: on the first [Outcome] the observer calls
+      [Eio.Switch.fail sw {!Liveness_kill}] so the surrounding
+      [Cascade_runner.run] tears down via Eio cancellation.
+
+    {1 Tick fiber lifetime}
+
+    The tick fiber is forked under the same [~sw] that owns
+    [Cascade_runner.run], but a provider can return a terminal error
+    before the streaming FSM sees a terminal event. Callers must invoke
+    {!stop_tick_fiber} on attempt completion before leaving the switch;
+    otherwise a pending no-token tick loop can keep the attempt switch open
+    until its long bootstrap budget expires.
+
+    @stability Evolving
+    @since 0.190.0 *)
+
+exception Liveness_kill of Keeper_attempt_liveness.failure
+(** Raised via [Eio.Switch.fail] in {!Enforce} mode when the FSM
+    emits an {!Keeper_attempt_liveness.Outcome}. The argument is the
+    classified failure carried into the cascade FSM by the caller. *)
+
+type t
+(** Opaque per-attempt observer handle. *)
+
+val create :
+  mode:Keeper_attempt_liveness_config.mode ->
+  budget:Keeper_attempt_liveness.budget ->
+  cascade_label:string ->
+  ?provider_label:string ->
+  ?external_wait:(unit -> bool) ->
+  ?candidate_key:string ->
+  started_at:float ->
+  unit ->
+  t
+(** Build an observer for one cascade attempt.
+
+    [provider_label], when supplied, is a public bounded provider bucket used
+    for Prometheus grouping. Empty or unrecognized labels fall back to a stable
+    non-raw bucket.
+
+    [candidate_key], when supplied, is the OAS/provider-runtime candidate key
+    used only for internal budget history and any successful timing sample
+    exposed by {!success_sample_for_candidate}. It is not emitted as a public
+    Prometheus label.
+
+    [external_wait], when supplied, returns true while the attempt is blocked
+    on a non-provider wait such as MASC HITL approval. During that window the
+    tick fiber feeds liveness heartbeats instead of idle ticks, so operator
+    latency is not classified as provider stream idleness.
+
+    [started_at] is the monotonic wall-clock the caller already captured for
+    the attempt start.
+
+    The observer does not own the switch — see [start_tick_fiber]. *)
+
+val wrap_on_event :
+  t ->
+  (Agent_sdk.Types.sse_event -> unit) option ->
+  (Agent_sdk.Types.sse_event -> unit) option
+(** [wrap_on_event obs original] returns a callback that forwards every
+    event to [original] (preserving baseline semantics) and feeds a
+    derived {!Keeper_attempt_liveness.Chunk} into the FSM.
+
+    Mode contract:
+    - [Off]: returns [original] unchanged (no allocation).
+    - [Observe]: returns [Some f] where [f] always calls [original]
+      then the FSM step + telemetry.
+    - [Enforce]: same as [Observe] plus may [Eio.Switch.fail] on
+      [Outcome]. *)
+
+val register_attempt_switch :
+  t ->
+  sw:Eio.Switch.t ->
+  unit
+(** Register the provider-attempt switch used by enforce mode.
+
+    This is separate from {!start_tick_fiber} so callers without an
+    available Eio clock can still scope [Liveness_kill] cancellation to the
+    current provider attempt. *)
+
+val start_tick_fiber :
+  t ->
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  unit
+(** Fork a sibling fiber under [~sw] that calls [Keeper_attempt_liveness.step]
+    with [Tick now] every [min(ttft_max, inter_chunk_max) / 4] seconds
+    until the FSM reaches a terminal state or [~sw] dies.
+
+    No-op when the observer mode is {!Off} or when [Off] short-circuit
+    elided observer construction at the call site. The fiber holds a
+    reference to [t] only — no other shared state — and dies with the
+    parent switch (Invariant §8 cancellation cleanup). *)
+
+val stop_tick_fiber : t -> unit
+(** Request the tick fiber to stop.
+
+    This is idempotent and cancellation-safe. It does not mutate the FSM
+    outcome; callers still use {!finalize} to emit the observed outcome. *)
+
+val finalize : t -> unit
+(** Emit the [observed_total] counter once with the final outcome
+    label inferred from the FSM state at finalization time:
+
+    - [Success]    -> [outcome=success]
+    - [Failed _]   -> [outcome=kill] for liveness kills, or
+                       [outcome=wire_error] for [Provider_error].
+    - [Awaiting _]
+    | [Streaming _] -> [outcome=wire_error] (caller terminated the
+      attempt before the FSM saw a Done — typically a wire
+      cancellation or upstream exception).
+
+    Idempotent: calling twice emits the counter once. *)
+
+val success_sample_for_candidate :
+  t -> (string * Keeper_attempt_liveness_config.success_sample) option
+(** Return the successful timing sample captured by {!finalize}, paired
+    with the concrete provider/model candidate key. This function does not
+    mutate the living budget store; callers must record the sample only after
+    their own acceptance gate has accepted the response. *)
+
+val current_state_for_test : t -> Keeper_attempt_liveness.state
+(** Test-only accessor. Production callers must not depend on this. *)
+
+val mode : t -> Keeper_attempt_liveness_config.mode
+(** Reflect the mode that was captured at observer construction. *)

--- a/lib/keeper/keeper_binding_health.ml
+++ b/lib/keeper/keeper_binding_health.ml
@@ -1,0 +1,915 @@
+(** Reactive health tracking for cascade providers.
+
+    Tracks per-provider success/failure rates using a rolling time window.
+    Providers in cooldown (consecutive failures exceed threshold) are
+    temporarily skipped.  Health data feeds into weighted cascade selection
+    via {!effective_weight}.
+
+    Design: LiteLLM cooldown + OpenRouter rolling-window hybrid.
+    See RFC-OAS-006 Phase 2.
+
+    Thread safety: uses [Stdlib.Mutex] (not Eio.Mutex) for cross-fiber
+    safety without Eio dependency in the hot path.  Critical sections are
+    small (record append + list scan).
+
+    @since 0.137.0 *)
+
+let window_sec = Keeper_binding_health_config.window_sec
+let cooldown_threshold = Keeper_binding_health_config.cooldown_threshold
+let cooldown_sec = Keeper_binding_health_config.cooldown_sec
+let hard_quota_cooldown_sec = Keeper_binding_health_config.hard_quota_cooldown_sec
+let terminal_failure_cooldown_sec =
+  Keeper_binding_health_config.terminal_failure_cooldown_sec
+
+let soft_rate_limit_cooldown_sec =
+  Keeper_binding_health_config.soft_rate_limit_cooldown_sec
+
+let soft_rate_limit_max_clamp_sec =
+  Keeper_binding_health_config.soft_rate_limit_max_clamp_sec
+
+let default_capacity_backpressure_backoff_sec =
+  Keeper_binding_health_config.default_capacity_backpressure_backoff_sec
+
+let latency_ring_size = Keeper_binding_health_config.latency_ring_size
+let confidence_ring_size = Keeper_binding_health_config.confidence_ring_size
+let cost_ring_size = Keeper_binding_health_config.cost_ring_size
+let cooldown_config_for = Keeper_binding_health_config.cooldown_config_for
+
+
+(* ── Types ────────────────────────────────────── *)
+
+(* [Rejected] is the third outcome kind introduced in 0.160.0.  It
+   represents "response arrived but the cascade's accept predicate
+   rejected it" — behaviorally equivalent to [Failure] (same cooldown
+   trigger, same success-rate impact) but visible to the dashboard so
+   operators can tell a down provider apart from one whose outputs are
+   consistently unusable. *)
+(* [Hard_quota] is the fourth outcome kind introduced in 0.161.0.  It
+   represents "provider returned a terminal quota-exhaustion error (balance
+   0, monthly quota reached, resource exhausted)" — classified via OAS
+   [Llm_provider.Retry.is_hard_quota].  Unlike [Failure], a single event
+   triggers an immediate long cooldown ([hard_quota_cooldown_sec]); the
+   [cooldown_threshold] does not apply because retry on the next cascade
+   tick is pointless when the upstream account is out of credit. *)
+(* [Terminal_failure] represents structural provider/adapter failures that are
+   deterministic for the current runtime state.  A provider CLI
+   resumable-session conflict is the motivating case: fallback is correct for
+   the current call, but repeatedly attempting the same provider first on every
+   later call only adds latency and silently degrades cascade diversity. *)
+(* [Soft_rate_limited] represents a transient HTTP 429 — provider is healthy
+   but momentarily over its rate budget.  Distinct from [Failure] so a single
+   event triggers an immediate (short) cooldown without waiting for the
+   [cooldown_threshold] consecutive-failure count.  Distinct from [Hard_quota]
+   because the provider is expected to recover within seconds, not hours. *)
+type outcome =
+  | Success
+  | Failure
+  | Rejected
+  | Hard_quota
+  | Terminal_failure
+  | Soft_rate_limited
+  | Capacity_backpressure
+
+type event = {
+  time: float;  (* Unix timestamp *)
+  outcome: outcome;
+}
+
+type provider_state = {
+  mutable events: event list;  (* newest first *)
+  mutable consecutive_failures: int;
+  mutable cooldown_until: float;  (* 0.0 = not in cooldown *)
+  fingerprint_counts: (string, int) Hashtbl.t;
+  (* Per-fingerprint cumulative counter (lifetime, no rolling decay).
+     Phase 0 observability anchor for "which error keeps recurring".
+     Updated under [t.mu]. *)
+  mutable last_failure_at: float;  (* 0.0 = none *)
+  (* Latency ring buffer for recent successful-call durations (ms).
+     Allocated lazily on first sample to avoid an empty array per
+     never-tracked provider.  Capacity is bounded by [latency_ring_size]
+     at module-load time.  When [latency_ring_size <= 0] the ring stays
+     [None] forever and percentile reads return [None]. *)
+  mutable latency_ring: float array option;
+  mutable latency_count: int;     (* slots filled, capped at array length *)
+  mutable latency_cursor: int;    (* next insertion index, wraps mod length *)
+  (* Confidence ring buffer for avg log probability per token from LLM
+     responses.  Mirrors the latency ring pattern: lazy allocation,
+     drop-oldest on overflow, bounded by [confidence_ring_size].
+     Values are negative log probs — lower (more negative) = higher
+     confidence in the response quality. *)
+  mutable confidence_ring: float array option;
+  mutable confidence_count: int;
+  mutable confidence_cursor: int;
+  (* Cost ring buffer for per-request inference cost (USD).  Mirrors the
+     latency ring pattern: lazy allocation, drop-oldest, bounded by
+     [cost_ring_size].  Values are non-negative USD amounts. *)
+  mutable cost_ring: float array option;
+  mutable cost_count: int;
+  mutable cost_cursor: int;
+}
+
+type t = {
+  providers: (string, provider_state) Hashtbl.t;
+  mu: Stdlib.Mutex.t;
+}
+
+type error_kind = Error_kind of string
+
+let error_kind_of_string value = Error_kind value
+let error_kind_to_string (Error_kind value) = value
+
+type provider_restore = {
+  restore_provider_key : string;
+  restore_consecutive_failures : int;
+  restore_cooldown_until : float option;
+  restore_last_failure_at : float option;
+  restore_top_fingerprints : (string * int) list;
+  restore_latency_ms : float option;
+  restore_confidence : float option;
+  restore_cost_usd : float option;
+}
+
+(* ── Constructor ──────────────────────────────── *)
+
+let create () : t = {
+  providers = Hashtbl.create 8;
+  mu = Stdlib.Mutex.create ();
+}
+
+(* #9873: Stdlib.Mutex, not Eio.Mutex, per the module doc at line 11.
+
+   The drift (doc said Stdlib, code used Eio) caused 12 test failures
+   in test_keeper_unified because [Eio.Mutex.use_rw] depends on the
+   [Cancel.Get_context] effect handler, which is only installed
+   inside an [Eio_main.run] event loop. Tests calling
+   [provider_cooldown_remaining_sec_for_cascade → provider_info]
+   outside that loop propagate [Stdlib.Effect.Unhandled].
+
+   Stdlib.Mutex has no effect dependency — a keeper scheduling
+   check can run under an Eio fiber OR a bare test, and in either
+   case the critical section (record append + list scan) is small
+   enough to be pure-blocking without the cooperative-yield
+   semantics Eio.Mutex provides.
+
+   Per feedback memory feedback_ocaml5-mutex-selection.md:
+   - Same domain Eio.Mutex → EDEADLK risk on reentrant paths
+   - Cross-domain Stdlib.Mutex or Eio.Promise
+   This module is cross-fiber but single-domain; Stdlib.Mutex is
+   the correct pick and matches the documented design. *)
+let with_lock t f =
+  Stdlib.Mutex.lock t.mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock t.mu)
+    (fun () -> f ())
+
+let get_or_create_state t key =
+  match Hashtbl.find_opt t.providers key with
+  | Some s -> s
+  | None ->
+    let s = {
+      events = [];
+      consecutive_failures = 0;
+      cooldown_until = 0.0;
+      fingerprint_counts = Hashtbl.create 4;
+      last_failure_at = 0.0;
+      latency_ring = None;
+      latency_count = 0;
+      latency_cursor = 0;
+      confidence_ring = None;
+      confidence_count = 0;
+      confidence_cursor = 0;
+      cost_ring = None;
+      cost_count = 0;
+      cost_cursor = 0;
+    } in
+    Hashtbl.replace t.providers key s;
+    s
+
+let finite_positive = function
+  | Some value when Float.is_finite value && value > 0.0 -> Some value
+  | _ -> None
+
+let restore_latency_sample state = function
+  | Some lat_ms when latency_ring_size > 0
+                     && Float.is_finite lat_ms
+                     && lat_ms > 0.0 ->
+    let ring = Array.make latency_ring_size 0.0 in
+    ring.(0) <- lat_ms;
+    state.latency_ring <- Some ring;
+    state.latency_count <- 1;
+    state.latency_cursor <- (if latency_ring_size = 1 then 0 else 1)
+  | _ -> ()
+
+let restore_confidence_sample state = function
+  | Some confidence when confidence_ring_size > 0
+                         && Float.is_finite confidence ->
+    let ring = Array.make confidence_ring_size 0.0 in
+    ring.(0) <- confidence;
+    state.confidence_ring <- Some ring;
+    state.confidence_count <- 1;
+    state.confidence_cursor <- (if confidence_ring_size = 1 then 0 else 1)
+  | _ -> ()
+
+let restore_cost_sample state = function
+  | Some cost_usd when cost_ring_size > 0
+                       && Float.is_finite cost_usd
+                       && cost_usd >= 0.0 ->
+    let ring = Array.make cost_ring_size 0.0 in
+    ring.(0) <- cost_usd;
+    state.cost_ring <- Some ring;
+    state.cost_count <- 1;
+    state.cost_cursor <- (if cost_ring_size = 1 then 0 else 1)
+  | _ -> ()
+
+let restore_providers t providers =
+  with_lock t (fun () ->
+    let now = Unix.gettimeofday () in
+    List.fold_left
+      (fun restored row ->
+        let provider_key = String.trim row.restore_provider_key in
+        if String.equal provider_key ""
+        then restored
+        else (
+          let state = get_or_create_state t provider_key in
+          state.consecutive_failures <- max 0 row.restore_consecutive_failures;
+          state.cooldown_until
+          <- (match finite_positive row.restore_cooldown_until with
+              | Some ts when ts > now -> ts
+              | _ -> 0.0);
+          state.last_failure_at
+          <- (match finite_positive row.restore_last_failure_at with
+              | Some ts -> ts
+              | None -> 0.0);
+          Hashtbl.reset state.fingerprint_counts;
+          List.iter
+            (fun (fp, count) ->
+              let fp = String.trim fp in
+              if (not (String.equal fp "")) && count > 0
+              then Hashtbl.replace state.fingerprint_counts fp count)
+            row.restore_top_fingerprints;
+          restore_latency_sample state row.restore_latency_ms;
+          restore_confidence_sample state row.restore_confidence;
+          restore_cost_sample state row.restore_cost_usd;
+          restored + 1))
+      0
+      providers)
+
+(* Append [latency_ms] to the per-provider ring buffer.  Allocates the
+   array lazily on first valid sample so providers that never report
+   timing never pay for the slot.  Drops samples that are non-finite or
+   non-positive — a successful-call duration of 0 or NaN is a caller bug
+   we don't want polluting the percentile. *)
+let push_latency state lat_ms =
+  if latency_ring_size <= 0 then ()
+  else if not (Float.is_finite lat_ms) || lat_ms <= 0.0 then ()
+  else begin
+    let ring =
+      match state.latency_ring with
+      | Some r -> r
+      | None ->
+        let r = Array.make latency_ring_size 0.0 in
+        state.latency_ring <- Some r;
+        r
+    in
+    ring.(state.latency_cursor) <- lat_ms;
+    state.latency_cursor <- (state.latency_cursor + 1) mod latency_ring_size;
+    if state.latency_count < latency_ring_size then
+      state.latency_count <- state.latency_count + 1
+  end
+
+(* Append [conf] (avg log prob per token) to the per-provider confidence ring.
+   Accepts negative values — most LLM log probs are negative.  Non-finite
+   values are silently dropped.  Same lazy-allocation pattern as
+   [push_latency]. *)
+let push_confidence state conf =
+  if confidence_ring_size <= 0 then ()
+  else if not (Float.is_finite conf) then ()
+  else begin
+    let ring =
+      match state.confidence_ring with
+      | Some r -> r
+      | None ->
+        let r = Array.make confidence_ring_size 0.0 in
+        state.confidence_ring <- Some r;
+        r
+    in
+    ring.(state.confidence_cursor) <- conf;
+    state.confidence_cursor <- (state.confidence_cursor + 1) mod confidence_ring_size;
+    if state.confidence_count < confidence_ring_size then
+      state.confidence_count <- state.confidence_count + 1
+  end
+
+let push_cost state cost =
+  if cost_ring_size <= 0 then ()
+  else if not (Float.is_finite cost) || cost < 0.0 then ()
+  else begin
+    let ring =
+      match state.cost_ring with
+      | Some r -> r
+      | None ->
+        let r = Array.make cost_ring_size 0.0 in
+        state.cost_ring <- Some r;
+        r
+    in
+    ring.(state.cost_cursor) <- cost;
+    state.cost_cursor <- (state.cost_cursor + 1) mod cost_ring_size;
+    if state.cost_count < cost_ring_size then
+      state.cost_count <- state.cost_count + 1
+  end
+
+(* Build a stable fingerprint from caller-provided classification.
+   Format: "kind|hash8(reason)" — kind defaults to "unclassified",
+   hash suffix is omitted when reason is absent or empty.  Hash is
+   MD5-truncated to 8 hex chars: collision-tolerant for an
+   observability-only counter. *)
+let make_fingerprint ?error_kind ?error_reason () =
+  let kind =
+    match error_kind with
+    | Some k ->
+      let trimmed = String.trim (error_kind_to_string k) in
+      if trimmed = "" then "unclassified" else trimmed
+    | _ -> "unclassified"
+  in
+  match error_reason with
+  | None -> kind
+  | Some r ->
+    let r = String.trim r in
+    if r = "" then kind
+    else
+      let h = Digest.to_hex (Digest.string r) in
+      let h_short =
+        if String.length h >= 8 then String.sub h 0 8 else h
+      in
+      kind ^ "|" ^ h_short
+
+let bump_fingerprint state fp =
+  let prev =
+    match Hashtbl.find_opt state.fingerprint_counts fp with
+    | Some n -> n
+    | None -> 0
+  in
+  Hashtbl.replace state.fingerprint_counts fp (prev + 1)
+
+(* ── Recording ────────────────────────────────── *)
+
+let prune_old_events now events =
+  let cutoff = now -. window_sec in
+  List.filter (fun e -> e.time >= cutoff) events
+
+let record t ~provider_key ~outcome ?error_kind ?error_reason
+    ?retry_after_s ?latency_ms ?confidence ?cost_usd ~now () =
+  with_lock t (fun () ->
+    let state = get_or_create_state t provider_key in
+    let event = { time = now; outcome } in
+    state.events <- event :: prune_old_events now state.events;
+    let bump_failure_fp () =
+      let fp = make_fingerprint ?error_kind ?error_reason () in
+      bump_fingerprint state fp;
+      state.last_failure_at <- now
+    in
+    match outcome with
+    | Success ->
+      state.consecutive_failures <- 0;
+      (* Clear cooldown on success — provider recovered *)
+      state.cooldown_until <- 0.0;
+      (* Append latency sample when caller provided one.  Non-success
+         outcomes don't contribute to the percentile — a 200ms timeout
+         and a 200ms successful response are not the same signal. *)
+      (match latency_ms with
+       | Some ms -> push_latency state ms
+       | None -> ());
+      (match confidence with
+       | Some c -> push_confidence state c
+       | None -> ());
+      (match cost_usd with
+       | Some c -> push_cost state c
+       | None -> ())
+    | Failure | Rejected ->
+      (* Rejected responses indicate unusable output (gate reject, empty
+         body, schema miss).  Treat identically to Failure for cooldown
+         and consecutive-failure tracking — a provider whose responses
+         are consistently rejected is as useless as one that never
+         responds.  The outcome tag is preserved in [events] so
+         [provider_info] can count Rejected separately for dashboards. *)
+      state.consecutive_failures <- state.consecutive_failures + 1;
+      bump_failure_fp ();
+      let (threshold, cooldown_dur) = cooldown_config_for ~provider_key in
+      if state.consecutive_failures >= threshold then begin
+        let new_until = now +. cooldown_dur in
+        if new_until > state.cooldown_until then begin
+          state.cooldown_until <- new_until;
+          Cascade_metrics.on_provider_cooldown
+            ~provider:provider_key ~reason:"failure_threshold";
+          Prometheus.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
+            ~labels:[("provider", provider_key)] cooldown_dur
+        end
+      end
+    | Soft_rate_limited ->
+      (* Transient HTTP 429.  Apply an immediate short cooldown so the
+         current cascade cycle skips this provider for the next selection
+         tick — without forcing the [cooldown_threshold] count-to-three
+         that [Failure] uses.  Honor caller-supplied Retry-After when
+         present; clamp positive values to [soft_rate_limit_max_clamp_sec]
+         to prevent a misclassified hard quota from silently producing
+         a multi-minute blackout.  Negative / zero / absent values fall
+         back to [soft_rate_limit_cooldown_sec].  As with the other
+         immediate-cooldown paths, never shorten an already-longer
+         cooldown (e.g. concurrent hard_quota + soft_rl events). *)
+      state.consecutive_failures <- state.consecutive_failures + 1;
+      bump_failure_fp ();
+      let cooldown_dur =
+        match retry_after_s with
+        | Some s when s > 0.0 -> Float.min s soft_rate_limit_max_clamp_sec
+        | _ -> soft_rate_limit_cooldown_sec
+      in
+      let new_until = now +. cooldown_dur in
+      if new_until > state.cooldown_until then begin
+        state.cooldown_until <- new_until;
+        Cascade_metrics.on_provider_cooldown
+          ~provider:provider_key ~reason:"soft_rate_limit";
+        Prometheus.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
+          ~labels:[("provider", provider_key)] cooldown_dur
+      end
+    | Capacity_backpressure ->
+      (* Capacity exhaustion is transient load, not persistent health
+         degradation.  Do NOT increment consecutive_failures.
+         Apply cooldown using the upstream retry_after hint when present,
+         or a synthetic default otherwise, so the fleet-level backoff
+         logic can detect all-provider-cooldown and wait for recovery
+         instead of thrashing through every provider every turn. *)
+      let cooldown_dur =
+        match retry_after_s with
+        | Some s when s > 0.0 -> Float.min s soft_rate_limit_max_clamp_sec
+        | _ -> default_capacity_backpressure_backoff_sec
+      in
+      let new_until = now +. cooldown_dur in
+      if new_until > state.cooldown_until then begin
+        state.cooldown_until <- new_until;
+        Cascade_metrics.on_provider_cooldown
+          ~provider:provider_key ~reason:"capacity_backpressure";
+        Prometheus.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
+          ~labels:[("provider", provider_key)] cooldown_dur
+      end
+    | Hard_quota ->
+      (* Hard-quota errors (balance depleted, quota exceeded, resource
+         exhausted) don't recover on short-window retries — set a long
+         cooldown immediately regardless of [consecutive_failures].  We
+         still increment the counter for dashboard continuity.  Preserve
+         an already-longer cooldown (e.g. if two hard-quota events fire
+         concurrently and the second arrives first in wall time). *)
+      state.consecutive_failures <- state.consecutive_failures + 1;
+      bump_failure_fp ();
+      let new_until = now +. hard_quota_cooldown_sec in
+      if new_until > state.cooldown_until then begin
+        state.cooldown_until <- new_until;
+        Cascade_metrics.on_provider_cooldown
+          ~provider:provider_key ~reason:"hard_quota";
+        Prometheus.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
+          ~labels:[("provider", provider_key)] hard_quota_cooldown_sec
+      end
+    | Terminal_failure ->
+      (* Terminal structural errors are not quota exhaustion, but they have the
+         same retry shape: the next cascade tick will hit the same provider
+         state and fail again.  Cool down immediately to keep fallback from
+         becoming a hidden tax on every request.  #10441: the
+         [apply_trust_failure_locked] step was removed by #10412 (Phase 1
+         revert).  Keep [bump_failure_fp] for fingerprint history but discard
+         its return value — there's no trust adjustment to feed it into. *)
+      state.consecutive_failures <- state.consecutive_failures + 1;
+      bump_failure_fp ();
+      let new_until = now +. terminal_failure_cooldown_sec in
+      if new_until > state.cooldown_until then begin
+        state.cooldown_until <- new_until;
+        Cascade_metrics.on_provider_cooldown
+          ~provider:provider_key ~reason:"terminal_failure";
+        Prometheus.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
+          ~labels:[("provider", provider_key)] terminal_failure_cooldown_sec
+      end)
+
+let record_success t ~provider_key ?latency_ms ?confidence ?cost_usd () =
+  record t ~provider_key ~outcome:Success ?latency_ms ?confidence ?cost_usd
+    ~now:(Unix.gettimeofday ()) ()
+
+let record_failure t ~provider_key ?error_kind ?error_reason () =
+  record t ~provider_key ~outcome:Failure ?error_kind ?error_reason
+    ~now:(Unix.gettimeofday ()) ()
+
+let record_rejected t ~provider_key ?error_kind ?error_reason () =
+  record t ~provider_key ~outcome:Rejected ?error_kind ?error_reason
+    ~now:(Unix.gettimeofday ()) ()
+
+let record_hard_quota t ~provider_key ?error_kind ?error_reason () =
+  record t ~provider_key ~outcome:Hard_quota ?error_kind ?error_reason
+    ~now:(Unix.gettimeofday ()) ()
+
+let record_terminal_failure t ~provider_key ?error_kind ?error_reason () =
+  record t ~provider_key ~outcome:Terminal_failure ?error_kind ?error_reason
+    ~now:(Unix.gettimeofday ()) ()
+
+let record_soft_rate_limited t ~provider_key ?retry_after_s ?error_kind
+    ?error_reason () =
+  record t ~provider_key ~outcome:Soft_rate_limited ?error_kind ?error_reason
+    ?retry_after_s ~now:(Unix.gettimeofday ()) ()
+
+let record_capacity_backpressure t ~provider_key ?retry_after_s ?error_kind
+    ?error_reason ~now () =
+  record t ~provider_key ~outcome:Capacity_backpressure ?error_kind ?error_reason
+    ?retry_after_s ~now ()
+
+(* ── Queries ──────────────────────────────────── *)
+
+(** Success rate in the rolling window.  Returns 1.0 for unknown
+    providers (optimistic default — no data means no reason to penalize). *)
+let success_rate t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> 1.0
+    | Some state ->
+      let now = Unix.gettimeofday () in
+      let recent = prune_old_events now state.events in
+      match recent with
+      | [] -> 1.0
+      | _ ->
+        let successes = List.length
+            (List.filter (fun e -> e.outcome = Success) recent) in
+        float_of_int successes /. float_of_int (List.length recent))
+
+(** Whether the provider is currently in cooldown.  A cooled-down provider
+    should be skipped in cascade selection.
+
+    @return [true] if in cooldown AND cooldown has not expired *)
+let is_in_cooldown t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> false
+    | Some state ->
+      let now = Unix.gettimeofday () in
+      if state.cooldown_until > now then true
+      else begin
+        (* Expired cooldown — clear it *)
+        if state.cooldown_until > 0.0 then
+          state.cooldown_until <- 0.0;
+        false
+      end)
+
+(** [is_capacity_constrained t ~provider_key] returns [true] when the
+    provider's most recent event is [Capacity_backpressure] and the
+    resulting cooldown has not yet expired.  Used for pre-admission
+    filtering: skip providers that recently signalled capacity exhaustion
+    before spending OAS body budget on a doomed attempt. *)
+let is_capacity_constrained t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> false
+    | Some state ->
+      (* DET-OK: read-only time check, same pattern as is_in_cooldown:546 *)
+      let now = Unix.gettimeofday () in
+      (* If general cooldown is still active, check if it was capacity-induced *)
+      if state.cooldown_until > now
+      then (
+        match state.events with
+        | { outcome = Capacity_backpressure; _ } :: _ -> true
+        | _ -> false)
+      else false)
+
+let check_circuit_breaker t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> Ok ()
+    | Some state ->
+      let now = Unix.gettimeofday () in
+      if state.cooldown_until > now then
+        let remaining = max 0 (int_of_float (Float.ceil (state.cooldown_until -. now))) in
+        Error (Printf.sprintf "provider cooldown active; retry in %ds" remaining)
+      else begin
+        if state.cooldown_until > 0.0 then
+          state.cooldown_until <- 0.0;
+        Ok ()
+      end)
+
+(** Compute effective weight for a provider.
+
+    [effective_weight = config_weight * success_rate]
+
+    Providers in cooldown get weight 0 (skipped).  Unknown providers
+    get their full config weight (optimistic). *)
+let effective_weight t ~provider_key ~config_weight =
+  if is_in_cooldown t ~provider_key then 0
+  else
+    let rate = success_rate t ~provider_key in
+    max 1 (int_of_float (float_of_int config_weight *. rate))
+
+(** Summary for debugging/telemetry. *)
+let provider_summary t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> Printf.sprintf "%s: no data" provider_key
+    | Some state ->
+      let now = Unix.gettimeofday () in
+      let recent = prune_old_events now state.events in
+      let total = List.length recent in
+      let successes = List.length
+          (List.filter (fun e -> e.outcome = Success) recent) in
+      let in_cd = state.cooldown_until > now in
+      Printf.sprintf "%s: %d/%d ok (%.0f%%) consec_fail=%d cooldown=%b"
+        provider_key successes total
+        (if total > 0 then 100.0 *. float_of_int successes /. float_of_int total else 100.0)
+        state.consecutive_failures in_cd)
+
+(** Structured provider snapshot — shared by [provider_info] and [all_providers].
+    Built inside the mutex so the snapshot is consistent. *)
+type provider_info = {
+  provider_key : string;
+  success_rate : float;
+  consecutive_failures : int;
+  in_cooldown : bool;
+  cooldown_expires_at : float option;
+  events_in_window : int;
+  rejected_in_window : int;
+  top_fingerprints : (string * int) list;
+  last_failure_at : float option;
+  p50_latency_ms : float option;
+  p95_latency_ms : float option;
+  latency_samples : int;
+  avg_confidence : float option;
+  confidence_samples : int;
+  avg_cost_usd : float option;
+  cost_samples : int;
+  health_score : float;
+}
+
+(* Compute the [pct]-th percentile (0.0–1.0) of the populated portion of
+   the latency ring.  [None] when no samples have been recorded.
+
+   Method: copy the populated slice into a fresh array, sort ascending,
+   pick by linear-interpolation between adjacent ranks (NIST H.7 / type
+   7 — same convention numpy / pandas use).  The full distribution is
+   only needed for monitoring, not for high-frequency strategy reads,
+   so the O(n log n) sort on n≤[latency_ring_size] (default 100) is
+   intentionally simple and bounded. *)
+let percentile_locked state pct =
+  match state.latency_ring with
+  | None -> None
+  | Some ring when state.latency_count = 0 -> ignore ring; None
+  | Some ring ->
+    let n = state.latency_count in
+    let buf = Array.sub ring 0 n in
+    Array.sort Float.compare buf;
+    if n = 1 then Some buf.(0)
+    else
+      let rank = pct *. float_of_int (n - 1) in
+      let lo = int_of_float (Float.floor rank) in
+      let hi = int_of_float (Float.ceil rank) in
+      if lo = hi then Some buf.(lo)
+      else
+        let frac = rank -. float_of_int lo in
+        Some (buf.(lo) *. (1.0 -. frac) +. buf.(hi) *. frac)
+
+(* Average of populated confidence ring values.  [None] when no samples. *)
+let avg_confidence_locked state =
+  match state.confidence_ring with
+  | None -> None
+  | Some ring when state.confidence_count = 0 -> ignore ring; None
+  | Some ring ->
+    let n = state.confidence_count in
+    let sum = ref 0.0 in
+    for i = 0 to n - 1 do sum := !sum +. ring.(i) done;
+    Some (!sum /. float_of_int n)
+
+(* Average of populated cost ring values.  [None] when no samples. *)
+let avg_cost_locked state =
+  match state.cost_ring with
+  | None -> None
+  | Some ring when state.cost_count = 0 -> ignore ring; None
+  | Some ring ->
+    let n = state.cost_count in
+    let sum = ref 0.0 in
+    for i = 0 to n - 1 do sum := !sum +. ring.(i) done;
+    Some (!sum /. float_of_int n)
+
+(* Derive a cost score in [0.2, 1.0] from the average cost ring.
+   Lower average cost = higher score.  Banded thresholds:
+     avg < $0.01  → 1.0  (cheap)
+     avg < $0.05  → 0.8
+     avg < $0.10  → 0.6
+     avg < $0.25  → 0.4
+     otherwise    → 0.2  (expensive)
+   Returns [None] when no cost samples exist so the caller defaults to 1.0. *)
+let cost_score_of_avg = function
+  | None -> None
+  | Some avg ->
+    let score =
+      if avg < 0.01 then 1.0
+      else if avg < 0.05 then 0.8
+      else if avg < 0.10 then 0.6
+      else if avg < 0.25 then 0.4
+      else 0.2
+    in
+    Some score
+
+let take_first_n n lst =
+  let rec loop k acc = function
+    | [] -> List.rev acc
+    | _ when k <= 0 -> List.rev acc
+    | x :: rest -> loop (k - 1) (x :: acc) rest
+  in
+  loop n [] lst
+
+(** Composite health score: success_rate * speed_score * cost_score.
+    - speed_score: p95 latency based. None = 1.0 (no penalty without data).
+    - cost_score: banded thresholds from {!cost_score_of_avg} over the
+      average cost ring populated by {!record_event} when [cost_usd]
+      is provided. None = 1.0 (no penalty until samples accumulate).
+
+    The function is total in the score arguments — callers receive the
+    multiplied score regardless of whether samples exist. Read together
+    with {!build_info_locked} which feeds [avg_cost_locked] through
+    [cost_score_of_avg]; the dashboard's per-provider cost banding is
+    therefore wired end-to-end (no longer a stub). *)
+
+(* p95 latency band thresholds (milliseconds).  Each band maps to a
+   speed_score multiplier: <=excellent → 1.0, <=good → 0.8,
+   <=fair → 0.6, <=poor → 0.4, else → 0.2. *)
+let p95_latency_excellent_ms = 5000.0
+let p95_latency_good_ms = 15000.0
+let p95_latency_fair_ms = 30000.0
+let p95_latency_poor_ms = 60000.0
+
+let compute_health_score ~success_rate ~p95_latency_ms_opt ~cost_score_opt =
+  let speed_score =
+    match p95_latency_ms_opt with
+    | None -> 1.0
+    | Some p95 ->
+        if p95 <= p95_latency_excellent_ms then 1.0
+        else if p95 <= p95_latency_good_ms then 0.8
+        else if p95 <= p95_latency_fair_ms then 0.6
+        else if p95 <= p95_latency_poor_ms then 0.4
+        else 0.2
+  in
+  let cost_score = match cost_score_opt with None -> 1.0 | Some s -> s in
+  success_rate *. speed_score *. cost_score
+
+let build_info_locked ~now ~key state =
+  let recent = prune_old_events now state.events in
+  let total = List.length recent in
+  let successes = List.length
+      (List.filter (fun e -> e.outcome = Success) recent) in
+  let rejected = List.length
+      (List.filter (fun e -> e.outcome = Rejected) recent) in
+  let rate =
+    if total = 0 then 1.0
+    else float_of_int successes /. float_of_int total
+  in
+  let in_cd = state.cooldown_until > now in
+  let top_fingerprints =
+    Hashtbl.fold (fun fp count acc -> (fp, count) :: acc)
+      state.fingerprint_counts []
+    |> List.sort (fun (_, a) (_, b) -> compare b a)
+    |> take_first_n 3
+  in
+  let last_failure_at =
+    if state.last_failure_at > 0.0 then Some state.last_failure_at else None
+  in
+  let p50_latency_ms = percentile_locked state 0.50 in
+  let p95_latency_ms = percentile_locked state 0.95 in
+  let avg_confidence = avg_confidence_locked state in
+  let avg_cost_usd = avg_cost_locked state in
+  let cost_score_opt = cost_score_of_avg avg_cost_usd in
+  let health_score =
+    compute_health_score ~success_rate:rate
+      ~p95_latency_ms_opt:p95_latency_ms
+      ~cost_score_opt
+  in
+  Prometheus.set_gauge Prometheus.metric_cascade_provider_health_score
+    ~labels:[ ("provider_key", key) ]
+    health_score;
+  {
+    provider_key = key;
+    success_rate = rate;
+    consecutive_failures = state.consecutive_failures;
+    in_cooldown = in_cd;
+    cooldown_expires_at = (if in_cd then Some state.cooldown_until else None);
+    events_in_window = total;
+    rejected_in_window = rejected;
+    top_fingerprints;
+    last_failure_at;
+    p50_latency_ms;
+    p95_latency_ms;
+    latency_samples = state.latency_count;
+    avg_confidence;
+    confidence_samples = state.confidence_count;
+    avg_cost_usd;
+    cost_samples = state.cost_count;
+    health_score;
+  }
+
+let provider_info t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> None
+    | Some state ->
+      Some (build_info_locked ~now:(Unix.gettimeofday ()) ~key:provider_key state))
+
+(** Evict tracker entries whose rolling window has fully aged out and
+    whose cooldown has expired — they carry no information but would
+    still appear on the dashboard as stale rows.  [consecutive_failures]
+    is intentionally ignored: without an active cooldown or recent
+    events, the counter is just a leftover that will be reset on the
+    next call anyway. *)
+let evict_idle t =
+  with_lock t (fun () ->
+    let now = Unix.gettimeofday () in
+    let to_remove =
+      Hashtbl.fold
+        (fun key state acc ->
+          let recent = prune_old_events now state.events in
+          if recent = [] && state.cooldown_until <= now then key :: acc
+          else acc)
+        t.providers
+        []
+    in
+    List.iter (Hashtbl.remove t.providers) to_remove;
+    List.length to_remove)
+
+let all_providers t =
+  (* Opportunistic maintenance: reaping aged-out entries here keeps the
+     dashboard's provider list stable without a separate maintenance
+     fiber.  Dashboard polls every 30s, so this is bounded. *)
+  let _ : int = evict_idle t in
+  with_lock t (fun () ->
+    let now = Unix.gettimeofday () in
+    Hashtbl.fold
+      (fun key state acc -> build_info_locked ~now ~key state :: acc)
+      t.providers
+      []
+    |> List.sort (fun a b -> String.compare a.provider_key b.provider_key))
+
+(* ── Outcome window queries ────────────────────── *)
+
+type outcome_kind =
+  | Outcome_success
+  | Outcome_failure
+  | Outcome_rejected
+  | Outcome_hard_quota
+  | Outcome_terminal_failure
+  | Outcome_soft_rate_limited
+  | Outcome_capacity_backpressure
+
+let outcome_matches kind ev =
+  (* Enumerate every [outcome_kind] x [outcome] pair so the compiler
+     flags any new variant added to either type. Adding e.g. an
+     [Outcome_circuit_break] kind without a matching [Circuit_break]
+     outcome (or vice versa) would silently inherit [false] under the
+     previous [_, _ -> false] catch-all, masking a probable mismatch.
+     Same FSM Sparse Match anti-pattern as PRs #14716, #14762, #14790,
+     #14806. *)
+  match kind, ev.outcome with
+  | Outcome_success, Success
+  | Outcome_failure, Failure
+  | Outcome_rejected, Rejected
+  | Outcome_hard_quota, Hard_quota
+  | Outcome_terminal_failure, Terminal_failure
+  | Outcome_soft_rate_limited, Soft_rate_limited
+  | Outcome_capacity_backpressure, Capacity_backpressure -> true
+  | Outcome_success,
+      (Failure | Rejected | Hard_quota | Terminal_failure | Soft_rate_limited | Capacity_backpressure)
+  | Outcome_failure,
+      (Success | Rejected | Hard_quota | Terminal_failure | Soft_rate_limited | Capacity_backpressure)
+  | Outcome_rejected,
+      (Success | Failure | Hard_quota | Terminal_failure | Soft_rate_limited | Capacity_backpressure)
+  | Outcome_hard_quota,
+      (Success | Failure | Rejected | Terminal_failure | Soft_rate_limited | Capacity_backpressure)
+  | Outcome_terminal_failure,
+      (Success | Failure | Rejected | Hard_quota | Soft_rate_limited | Capacity_backpressure)
+  | Outcome_soft_rate_limited,
+      (Success | Failure | Rejected | Hard_quota | Terminal_failure | Capacity_backpressure)
+  | Outcome_capacity_backpressure,
+      (Success | Failure | Rejected | Hard_quota | Terminal_failure | Soft_rate_limited) -> false
+
+(* Count [outcome] events recorded for [provider_key] within the last
+   [window_s] seconds.  We piggyback on the same event ring used by
+   [success_rate]; older events have already been pruned to
+   [window_sec], so a caller-supplied [window_s] larger than that is
+   silently truncated by the storage layer.  Returns 0 for unknown
+   providers, non-positive [window_s], or no in-window matches. *)
+let recent_outcome_count t ~provider_key ~outcome ~window_s =
+  if window_s <= 0.0 then 0
+  else
+    with_lock t (fun () ->
+      match Hashtbl.find_opt t.providers provider_key with
+      | None -> 0
+      | Some state ->
+        let now = Unix.gettimeofday () in
+        let cutoff = now -. window_s in
+        List.fold_left
+          (fun acc ev ->
+             if ev.time >= cutoff && outcome_matches outcome ev then acc + 1
+             else acc)
+          0
+          state.events)
+
+(* ── Global singleton ─────────────────────────── *)
+
+(** Global health tracker shared across all cascade calls in this process.
+    Thread-safe via internal Mutex. *)
+let global : t = create ()

--- a/lib/keeper/keeper_binding_health.mli
+++ b/lib/keeper/keeper_binding_health.mli
@@ -1,0 +1,433 @@
+(** Reactive health tracking for cascade providers.
+
+    Tracks per-provider success/failure rates using a rolling time window.
+    Providers in cooldown (consecutive failures exceed threshold) are
+    temporarily skipped.
+
+    Thread-safe via internal [Stdlib.Mutex].
+
+    @since 0.137.0 *)
+
+(** {1 Runtime configuration (env-driven, read once at module load)}
+
+    The env var prefix is [MASC_CASCADE_*]. *)
+
+val window_sec : float
+(** Rolling window duration in seconds.  Default 300.0 (5 min). *)
+
+val cooldown_threshold : int
+(** Consecutive failures before cooldown activates.  Default 3. *)
+
+val cooldown_sec : float
+(** Cooldown duration in seconds.  Default 30.0. *)
+
+val hard_quota_cooldown_sec : float
+(** Cooldown duration applied immediately on a hard-quota-classified error
+    (balance depleted, monthly quota reached, resource exhausted).  Unlike
+    {!cooldown_sec}, no threshold is required — one hard-quota event is
+    enough.  Default 3600.0 (1h).
+
+    Env: [MASC_CASCADE_HARD_QUOTA_COOLDOWN_SEC].
+
+    @since 0.161.0 *)
+
+val terminal_failure_cooldown_sec : float
+(** Cooldown duration applied immediately on a terminal structural
+    provider/adapter failure, such as a provider CLI resumable-session conflict.
+    Unlike {!cooldown_sec}, no threshold is required.  Default 3600.0 (1h).
+
+    Env: [MASC_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC]. *)
+
+val soft_rate_limit_cooldown_sec : float
+(** Default cooldown applied immediately on a transient HTTP 429 (soft
+    rate-limit) when no Retry-After hint is available.  Distinct from
+    {!cooldown_sec} because a single 429 should already deprioritize the
+    provider for the remainder of the current cascade cycle — the
+    [cooldown_threshold] count-to-three semantics are wrong for transient
+    rate limits.  Default 10.0 (10s).
+
+    Env: [MASC_CASCADE_SOFT_RATE_LIMIT_COOLDOWN_SEC]. *)
+
+val soft_rate_limit_max_clamp_sec : float
+(** Upper clamp for caller-supplied [retry_after_s] when recording a soft
+    rate-limit event.  Providers occasionally return Retry-After values
+    measured in minutes or hours; honoring those literally would silently
+    promote a transient 429 into a long blackout.  Anything that exceeds
+    this clamp should be classified as {!record_hard_quota} by the
+    caller, not as a soft rate-limit.  Default 120.0 (2 min).
+
+    Env: [MASC_CASCADE_SOFT_RATE_LIMIT_MAX_CLAMP_SEC]. *)
+
+val default_capacity_backpressure_backoff_sec : float
+(** Synthetic typed backoff applied when an upstream [Capacity_backpressure]
+    error arrives with [retry_after_sec = None].  Without this, the cascade
+    rotates immediately onto the next candidate and frequently lands back
+    on the same degraded provider before any recovery window has elapsed.
+    Default 5.0 (5s) — shorter than {!soft_rate_limit_cooldown_sec} because
+    capacity backpressure is a short-window signal (peers usually recover
+    faster than 429-bearing providers), but non-zero so the cascade does
+    not immediately re-select the just-rejected provider.
+
+    Env: [MASC_CASCADE_CAPACITY_BACKPRESSURE_DEFAULT_BACKOFF_SEC]. *)
+
+val latency_ring_size : int
+(** Number of recent successful-call latencies retained per provider for
+    percentile observation.  The ring buffer is per-provider; older
+    samples are silently overwritten as new successes arrive.
+
+    A small ring is intentional — strategy decisions only need a
+    "recent" sense of how fast the provider has been responding, not a
+    full distribution.  100 samples cover ~5–15 minutes of activity for
+    a busy provider while staying small enough to sort cheaply on every
+    [provider_info] read.
+
+    Default 100, env [MASC_CASCADE_LATENCY_RING_SIZE].  Values [<= 0]
+    disable latency tracking entirely (the ring is treated as empty and
+    [p50_latency_ms] / [p95_latency_ms] always return [None]). *)
+
+val confidence_ring_size : int
+(** Number of recent avg-log-probability samples retained per provider.
+    Mirrors {!latency_ring_size} semantics: ring buffer, drop-oldest,
+    lazy allocation.  Default 100, env
+    [MASC_CASCADE_CONFIDENCE_RING_SIZE].  Values [<= 0] disable
+    confidence tracking. *)
+
+val cost_ring_size : int
+(** Number of recent per-request cost samples retained per provider.
+    Mirrors {!latency_ring_size} semantics: ring buffer, drop-oldest,
+    lazy allocation.  Default 100, env [MASC_CASCADE_COST_RING_SIZE].
+    Values [<= 0] disable cost tracking.  @since 0.191.0 *)
+
+
+(** Opaque health tracker state. *)
+type t
+
+(** Typed wrapper for provider-health error classifications. Dashboard
+    fingerprints and summaries continue to render the stable string label. *)
+type error_kind = private Error_kind of string
+
+val error_kind_of_string : string -> error_kind
+val error_kind_to_string : error_kind -> string
+
+(** Create a new empty tracker. *)
+val create : unit -> t
+
+(** Durable provider state that can be restored after process restart.
+
+    Cooldown, failure count, and error fingerprints prevent a restart from
+    immediately retrying a provider that was just circuit-broken.  The optional
+    routing hints seed the bounded latency/confidence/cost rings from the last
+    persisted snapshot so weighted cascade selection does not restart with a
+    fully cold view of recent provider performance. *)
+type provider_restore = {
+  restore_provider_key : string;
+  restore_consecutive_failures : int;
+  restore_cooldown_until : float option;
+  restore_last_failure_at : float option;
+  restore_top_fingerprints : (string * int) list;
+  restore_latency_ms : float option;
+  restore_confidence : float option;
+  restore_cost_usd : float option;
+}
+
+(** Restore durable provider state into a tracker.
+    Returns the number of non-empty provider rows applied. *)
+val restore_providers : t -> provider_restore list -> int
+
+(** Record a successful provider call. Clears cooldown and resets
+    consecutive failure counter.
+
+    Optional [latency_ms] is the wall-clock duration of the provider
+    call in milliseconds.  When supplied, it is appended to a small
+    per-provider ring buffer and surfaced as [p50_latency_ms] /
+    [p95_latency_ms] on {!provider_info}.  Strategies can use the
+    p50/p95 to prefer faster providers when success rates are
+    comparable.  Negative or non-finite values are silently dropped
+    (the success itself is still recorded). *)
+val record_success :
+  t ->
+  provider_key:string ->
+  ?latency_ms:float ->
+  ?confidence:float ->
+  ?cost_usd:float ->
+  unit ->
+  unit
+
+(** Record a failed provider call. Increments consecutive failure
+    counter; triggers cooldown when threshold is reached.
+
+    Optional [error_kind] (e.g. "auth", "timeout", "schema") and
+    [error_reason] (raw error string) are folded into a stable
+    fingerprint [error_kind|hash8(reason)] and accumulated in
+    [provider_info.top_fingerprints] for observability. Both default
+    to [None] (unclassified) which is still recorded under the synthetic
+    fingerprint ["unclassified"].
+
+    @since 0.174.0 *)
+val record_failure :
+  t ->
+  provider_key:string ->
+  ?error_kind:error_kind ->
+  ?error_reason:string ->
+  unit ->
+  unit
+
+(** Record a provider call where the response arrived but was rejected
+    by the cascade's [accept] predicate (e.g. empty body, schema gate).
+
+    Behaves like {!record_failure} for cooldown / weight purposes — a
+    provider whose outputs are consistently unusable should be skipped —
+    but is counted separately in [provider_info.rejected_in_window] so
+    the dashboard can distinguish "provider down" from "provider returns
+    garbage".
+
+    Prior to 0.160.0 this path called {!record_success} (the response
+    technically arrived), which silently masked gate drift: a provider
+    could rank 100% healthy while every call fell through to the next
+    cascade.
+
+    See {!record_failure} for [error_kind] / [error_reason] semantics.
+
+    @since 0.160.0 *)
+val record_rejected :
+  t ->
+  provider_key:string ->
+  ?error_kind:error_kind ->
+  ?error_reason:string ->
+  unit ->
+  unit
+
+(** Record a provider call that failed with a hard-quota error (balance
+    depleted, monthly quota reached, resource exhausted — classified
+    upstream via [Llm_provider.Retry.is_hard_quota]).
+
+    Unlike {!record_failure}, this triggers an immediate long cooldown
+    ({!hard_quota_cooldown_sec}, default 1h) with no threshold — a
+    provider whose account is out of credit will not recover within the
+    regular [cooldown_sec] window, and weighted_random re-selection just
+    wastes cascade turns.
+
+    Preserves an already-longer cooldown if one exists (no regression).
+    Counts toward [consecutive_failures] for dashboard continuity and
+    toward [events_in_window] in {!provider_info}.
+
+    See {!record_failure} for [error_kind] / [error_reason] semantics.
+
+    @since 0.161.0 *)
+val record_hard_quota :
+  t ->
+  provider_key:string ->
+  ?error_kind:error_kind ->
+  ?error_reason:string ->
+  unit ->
+  unit
+
+(** Record a provider call that failed with a terminal structural
+    provider/adapter error.
+
+    This uses immediate long cooldown semantics like {!record_hard_quota},
+    but is kept distinct from quota exhaustion so the caller can classify
+    adapter/session failures without pretending the account is out of credit.
+
+    See {!record_failure} for [error_kind] / [error_reason] semantics. *)
+val record_terminal_failure :
+  t ->
+  provider_key:string ->
+  ?error_kind:error_kind ->
+  ?error_reason:string ->
+  unit ->
+  unit
+
+(** Record a transient HTTP 429 (rate-limit) response.
+
+    Unlike {!record_failure}, a single soft rate-limit triggers an
+    immediate short cooldown so the cascade can fall over to the next
+    candidate within the same turn instead of returning to the same
+    provider on the next selection tick.  No threshold applies.
+
+    [retry_after_s] is the value parsed from the upstream HTTP
+    [Retry-After] header (RFC 7231: integer seconds or HTTP-date).
+    When present, cooldown is set to [min retry_after_s
+    soft_rate_limit_max_clamp_sec]; otherwise cooldown defaults to
+    {!soft_rate_limit_cooldown_sec}.  Negative or zero values fall back
+    to the default.  Caller is responsible for upgrading sustained 429
+    bursts to {!record_hard_quota} when appropriate (e.g. monthly quota
+    boundaries) — this function intentionally never extends past
+    [soft_rate_limit_max_clamp_sec] regardless of header value.
+
+    Preserves an already-longer cooldown if one exists (no regression).
+
+    See {!record_failure} for [error_kind] / [error_reason] semantics. *)
+val record_soft_rate_limited :
+  t ->
+  provider_key:string ->
+  ?retry_after_s:float ->
+  ?error_kind:error_kind ->
+  ?error_reason:string ->
+  unit ->
+  unit
+
+(** [record_capacity_backpressure] is like {!record_soft_rate_limited}
+    but tags the event as [Capacity_backpressure] and uses
+    [default_capacity_backpressure_backoff_sec] as the synthetic default.
+    A single capacity-exhaustion event triggers immediate cooldown so the
+    cascade skips the provider for the rest of the cycle without waiting
+    for the [cooldown_threshold] consecutive-failure count.
+
+    See {!record_failure} for [error_kind] / [error_reason] semantics. *)
+val record_capacity_backpressure :
+  t ->
+  provider_key:string ->
+  ?retry_after_s:float ->
+  ?error_kind:error_kind ->
+  ?error_reason:string ->
+  now:float ->
+  unit ->
+  unit
+
+(** Drop tracker entries whose rolling window is empty AND whose cooldown
+    has expired.  Intended as opportunistic maintenance — idle providers
+    carry no information but keep growing the hashtable (and pollute the
+    dashboard).
+
+    @return number of entries evicted.
+    @since 0.160.0 *)
+val evict_idle : t -> int
+
+(** Success rate in the rolling window (0.0 to 1.0).
+    Returns 1.0 for unknown providers (optimistic default). *)
+val success_rate : t -> provider_key:string -> float
+
+(** Whether the provider is currently in cooldown (should be skipped). *)
+val is_in_cooldown : t -> provider_key:string -> bool
+
+(** Whether the provider is in capacity backpressure cooldown specifically.
+    Used for pre-admission filtering to skip providers that recently
+    signalled capacity exhaustion, avoiding wasted OAS body budget. *)
+val is_capacity_constrained : t -> provider_key:string -> bool
+
+(** Compute effective weight for weighted cascade selection.
+
+    [effective_weight = config_weight * success_rate]
+
+    Returns 0 for providers in cooldown.
+    Returns full [config_weight] for unknown providers. *)
+val effective_weight : t -> provider_key:string -> config_weight:int -> int
+
+(** Human-readable summary for debugging/telemetry. *)
+val provider_summary : t -> provider_key:string -> string
+
+(** Structured summary for telemetry/dashboard consumption.
+
+    @since 0.139.0 *)
+type provider_info = {
+  provider_key : string;
+  success_rate : float;               (** 0.0 to 1.0, 1.0 if unknown *)
+  consecutive_failures : int;
+  in_cooldown : bool;
+  cooldown_expires_at : float option; (** Unix timestamp, Some iff [in_cooldown] *)
+  events_in_window : int;             (** Events retained in rolling window *)
+  rejected_in_window : int;           (** Subset of [events_in_window] whose outcome was [Rejected]. @since 0.160.0 *)
+  top_fingerprints : (string * int) list;
+  (** Top-N error fingerprints with cumulative counts (descending), capped
+      at 3.  Fingerprint format: ["error_kind|hash8(error_reason)"] —
+      built by {!record_failure} / {!record_rejected} / {!record_hard_quota}
+      from caller-provided classifications.  Empty list when no failures
+      have been recorded.  @since 0.174.0 *)
+  last_failure_at : float option;
+  (** Unix timestamp of the most recent non-success event, or [None] if
+      none.  Phase 0 observability anchor for "did this provider fail
+      recently".  @since 0.174.0 *)
+  p50_latency_ms : float option;
+  (** 50th-percentile (median) of recent successful-call latencies in
+      milliseconds, computed from the per-provider ring buffer
+      (see {!latency_ring_size}).  [None] when no latency samples have
+      been recorded — either because [record_success] was never called
+      with [~latency_ms], or because [latency_ring_size <= 0].  Strategies
+      may use this to prefer faster providers when success rates and
+      cooldown state are comparable.  @since 0.180.0 *)
+  p95_latency_ms : float option;
+  (** 95th-percentile of recent successful-call latencies in milliseconds.
+      Same source and [None] semantics as {!p50_latency_ms}.  Useful for
+      flagging tail-latency regressions in observability dashboards.
+      @since 0.180.0 *)
+  latency_samples : int;
+  (** Number of latency samples currently retained in the ring buffer.
+      [0] iff both percentile fields are [None].  Bounded by
+      {!latency_ring_size}.  @since 0.180.0 *)
+  avg_confidence : float option;
+  (** Mean of recent avg-log-probability samples from the per-provider
+      confidence ring.  [None] when no samples have been recorded.
+      Lower (more negative) values indicate higher response confidence.
+      @since 0.183.0 *)
+  confidence_samples : int;
+  (** Number of confidence samples currently retained.  [0] iff
+      [avg_confidence] is [None].  Bounded by {!confidence_ring_size}.
+      @since 0.183.0 *)
+  avg_cost_usd : float option;
+  (** Mean of recent per-request cost samples from the per-provider cost
+      ring.  [None] when no cost data has been recorded.  Used as input
+      to the composite health score's cost component — providers with
+      lower average cost score higher.
+      @since 0.191.0 *)
+  cost_samples : int;
+  (** Number of cost samples currently retained.  [0] iff
+      [avg_cost_usd] is [None].  Bounded by {!cost_ring_size}.
+      @since 0.191.0 *)
+  health_score : float;
+  (** Composite health score (0.0–1.0) combining success_rate,
+      speed_score (from p95 latency), and cost_score.
+      @since 0.190.0 *)
+}
+
+(** Structured info for a single provider. Returns [None] if untracked.
+    @since 0.139.0 *)
+val provider_info : t -> provider_key:string -> provider_info option
+
+(** Snapshot of all tracked providers.
+    Useful for dashboards and telemetry endpoints.
+    @since 0.139.0 *)
+val all_providers : t -> provider_info list
+
+(** Outcome variant exposed for {!recent_outcome_count} window queries.
+    Mirrors the internal classification — kept abstract elsewhere to
+    keep the recording surface narrow.
+
+    @since 0.183.0 *)
+type outcome_kind =
+  | Outcome_success
+  | Outcome_failure
+  | Outcome_rejected
+  | Outcome_hard_quota
+  | Outcome_terminal_failure
+  | Outcome_soft_rate_limited
+  | Outcome_capacity_backpressure
+
+(** [recent_outcome_count t ~provider_key ~outcome ~window_s] returns the
+    number of events of [outcome] recorded for [provider_key] within the
+    last [window_s] seconds.
+
+    Useful as a recency signal for adaptive weighting — e.g. counting
+    [Outcome_soft_rate_limited] events in a 60s window so the strategy
+    can de-prioritise providers that just hit a 429 burst, even after
+    their cooldown expires.
+
+    Returns 0 for unknown providers, when no matching event is in
+    window, or when [window_s] is non-positive.  The window is
+    silently clamped to the rolling event-retention window of the
+    tracker (see {!window_sec}) — events older than that have already
+    been pruned and cannot be counted.
+
+    @since 0.183.0 *)
+val recent_outcome_count :
+  t ->
+  provider_key:string ->
+  outcome:outcome_kind ->
+  window_s:float ->
+  int
+
+(** Global singleton tracker shared across all cascade calls. *)
+val global : t
+
+val check_circuit_breaker : t -> provider_key:string -> (unit, string) result
+(** Check whether the provider cooldown gate allows a request. *)

--- a/lib/keeper/keeper_binding_health_config.ml
+++ b/lib/keeper/keeper_binding_health_config.ml
@@ -1,0 +1,175 @@
+(** Env-driven runtime configuration for {!Keeper_binding_health}. *)
+
+let read_float_setting ~primary ~default () =
+  match Sys.getenv_opt primary with
+  | None -> default
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = ""
+      then default
+      else (
+        match Safe_ops.float_of_string_safe trimmed with
+        | Some value -> value
+        | None ->
+            Log.Misc.warn
+              "Invalid float for %s=%S, using default %.1f"
+              primary
+              raw
+              default;
+            default)
+
+let read_int_setting ~primary ~default () =
+  match Sys.getenv_opt primary with
+  | None -> default
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = ""
+      then default
+      else (
+        match Safe_ops.int_of_string_safe trimmed with
+        | Some value -> value
+        | None ->
+            Log.Misc.warn
+              "Invalid int for %s=%S, using default %d"
+              primary
+              raw
+              default;
+            default)
+
+(** Rolling window duration in seconds.  Events older than this are
+    discarded on read.  Default: 300s (5 minutes), matching OpenRouter's
+    rolling percentile window. *)
+let window_sec =
+  read_float_setting
+    ~primary:"MASC_CASCADE_HEALTH_WINDOW_SEC"
+    ~default:300.0
+    ()
+
+(** Number of consecutive failures before cooldown activates.
+    Default: 3, matching LiteLLM's [allowed_fails] concept. *)
+let cooldown_threshold =
+  read_int_setting
+    ~primary:"MASC_CASCADE_COOLDOWN_THRESHOLD"
+    ~default:3
+    ()
+
+(** Cooldown duration in seconds.  During cooldown, the provider is
+    skipped (not attempted).  Default: 30s, matching the provider
+    circuit-breaker OPEN threshold used by the cascade.  Hard quota and
+    terminal provider errors use separate long cooldowns. *)
+let cooldown_sec =
+  read_float_setting
+    ~primary:"MASC_CASCADE_COOLDOWN_SEC"
+    ~default:30.0
+    ()
+
+let local_cooldown_threshold =
+  Int.max 1
+    (read_int_setting
+       ~primary:"MASC_LOCAL_COOLDOWN_THRESHOLD"
+       ~default:5
+       ())
+
+let local_cooldown_sec =
+  Float.max 1.0
+    (read_float_setting
+       ~primary:"MASC_LOCAL_COOLDOWN_SEC"
+       ~default:10.0
+       ())
+
+let local_runtime_auth = function
+  | Agent_sdk.Provider_runtime_binding.No_auth -> true
+  | Api_key_env _ | Cli_cached_login | Oauth_cached_login | Setup_token_env _
+  | File _ | Exec _ -> false
+
+let local_runtime_base_url base_url =
+  match Uri.of_string (String.trim base_url) |> Uri.host with
+  | Some host -> Masc_network_defaults.is_loopback_host_opt (Some host)
+  | None -> false
+
+let runtime_binding_is_local (binding : Agent_sdk.Provider_runtime_binding.t) =
+  local_runtime_auth binding.auth && local_runtime_base_url binding.base_url
+
+let provider_key_is_local provider_key =
+  let key = String.trim provider_key |> String.lowercase_ascii in
+  String.equal key "custom"
+  ||
+  match Agent_sdk.Provider_runtime_binding.find key with
+  | Some binding -> runtime_binding_is_local binding
+  | None -> false
+
+let cooldown_config_for ~provider_key =
+  if provider_key_is_local provider_key
+  then local_cooldown_threshold, local_cooldown_sec
+  else cooldown_threshold, cooldown_sec
+
+(** Cooldown duration for provider calls classified as hard-quota exhaustion
+    (account balance depleted, monthly quota reached, resource exhausted).
+    Unlike transient 429s, hard-quota errors will not recover within a short
+    window: retrying on the next cascade tick just wastes a turn.  This
+    cooldown is applied immediately on the first such error (no threshold)
+    and is significantly longer than {!cooldown_sec}. *)
+let hard_quota_cooldown_sec =
+  read_float_setting
+    ~primary:"MASC_CASCADE_HARD_QUOTA_COOLDOWN_SEC"
+    ~default:Masc_time_constants.hour
+    ()
+
+(** Cooldown duration for provider calls classified as terminal structural
+    failures, where retrying the same provider on the next cascade tick is
+    expected to reproduce the same failure until operator/runtime state changes. *)
+let terminal_failure_cooldown_sec =
+  read_float_setting
+    ~primary:"MASC_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC"
+    ~default:Masc_time_constants.hour
+    ()
+
+(** Default cooldown applied immediately on a transient HTTP 429. *)
+let soft_rate_limit_cooldown_sec =
+  read_float_setting
+    ~primary:"MASC_CASCADE_SOFT_RATE_LIMIT_COOLDOWN_SEC"
+    ~default:10.0
+    ()
+
+(** Upper clamp for caller-supplied Retry-After. *)
+let soft_rate_limit_max_clamp_sec =
+  read_float_setting
+    ~primary:"MASC_CASCADE_SOFT_RATE_LIMIT_MAX_CLAMP_SEC"
+    ~default:120.0
+    ()
+
+(** Synthetic backoff for [Capacity_backpressure] with no [retry_after_sec].
+
+    5.0 s was too short — providers rotated back into selection before
+    upstream capacity recovered, causing immediate re-failure and
+    keeper-turn thrashing (task-536).  30.0 s gives a reasonable
+    recovery window while still clamping to
+    [soft_rate_limit_max_clamp_sec] when a real [retry_after] hint is
+    present.
+
+    Override via [MASC_CASCADE_CAPACITY_BACKPRESSURE_DEFAULT_BACKOFF_SEC]. *)
+let default_capacity_backpressure_backoff_sec =
+  read_float_setting
+    ~primary:"MASC_CASCADE_CAPACITY_BACKPRESSURE_DEFAULT_BACKOFF_SEC"
+    ~default:30.0
+    ()
+
+let read_ring_size env_name =
+  match Sys.getenv_opt env_name with
+  | None -> 100
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = ""
+      then 100
+      else (
+        match Safe_ops.int_of_string_safe trimmed with
+        | Some n -> n
+        | None ->
+            Log.Misc.warn "Invalid int for %s=%S, using default 100" env_name raw;
+            100)
+
+(** Per-provider ring buffer size for recent successful-call latency. *)
+let latency_ring_size = read_ring_size "MASC_CASCADE_LATENCY_RING_SIZE"
+
+let confidence_ring_size = read_ring_size "MASC_CASCADE_CONFIDENCE_RING_SIZE"
+let cost_ring_size = read_ring_size "MASC_CASCADE_COST_RING_SIZE"

--- a/lib/keeper/keeper_binding_health_config.mli
+++ b/lib/keeper/keeper_binding_health_config.mli
@@ -1,0 +1,21 @@
+(** Env-driven runtime configuration for {!Keeper_binding_health}. *)
+
+val window_sec : float
+val cooldown_threshold : int
+val cooldown_sec : float
+val hard_quota_cooldown_sec : float
+val terminal_failure_cooldown_sec : float
+val soft_rate_limit_cooldown_sec : float
+val soft_rate_limit_max_clamp_sec : float
+val default_capacity_backpressure_backoff_sec : float
+(** Synthetic backoff applied when a [Capacity_backpressure] error arrives
+    without an explicit [retry_after_sec] hint.  Sized below
+    {!soft_rate_limit_cooldown_sec} (10s) — capacity backpressure is a
+    short-window signal that a different provider is probably ready
+    sooner — but above zero so the cascade does not immediately rotate
+    onto the same degraded provider.  Tunable via
+    [MASC_CASCADE_CAPACITY_BACKPRESSURE_DEFAULT_BACKOFF_SEC]. *)
+val latency_ring_size : int
+val confidence_ring_size : int
+val cost_ring_size : int
+val cooldown_config_for : provider_key:string -> int * float

--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -1,0 +1,818 @@
+(** OAS Event_bus → SSE Bridge.
+
+    Subscribes to all events on the OAS Event_bus (both MASC Custom
+    events and OAS native lifecycle events) and relays them as SSE
+    broadcasts to connected dashboard clients.
+
+    OAS native events (ToolCalled, TurnCompleted, etc.) are serialized
+    to a uniform JSON format with an "oas:" prefix so consumers can
+    distinguish them from MASC-originated events.
+
+    Since OAS 0.123.0 every event carries an envelope with
+    [correlation_id], [run_id], and [ts]. These are always emitted
+    in the SSE JSON so downstream consumers can join events into
+    causal chains offline.
+
+    @since 2.96.0
+    @modified 2.255.0 — accept OAS native events (#5620)
+    @modified 2.260.0 — emit envelope correlation_id/run_id (oas#845) *)
+
+open Keeper_event_bridge_inference
+open Keeper_event_bridge_error_json
+
+(** Drain interval: how often we poll the Event_bus subscription.
+    Lower default keeps the dashboard close to real-time, while staying
+    runtime-tunable for quieter deployments. *)
+let drain_interval_s () = Env_config.Oas_sse.drain_interval_sec
+
+let payload_agent_name payload =
+  (* Check [agent_name], [agent], then [keeper_name] for Custom events
+     whose publisher stores the per-agent attribution under the
+     keeper-specific key (e.g. [masc:keeper:snapshot],
+     [masc:keeper:lifecycle]).  Without this fallback the top-level
+     envelope [agent_name] is Null for 9%+ of daily events, breaking
+     per-agent filters over the Dated_jsonl store under [.masc/oas-events/].
+     See #7827. *)
+  match Json_util.get_string payload "agent_name" with
+  | Some _ as value -> value
+  | None ->
+    (match Json_util.get_string payload "agent" with
+     | Some _ as value -> value
+     | None -> Json_util.get_string payload "keeper_name")
+;;
+
+let emit_native_event_log (evt : Agent_sdk.Event_bus.event) (json : Yojson.Safe.t) =
+  let log_at level message =
+    Log.emit level ~module_name:"oas:event" ~details:json message
+  in
+  let log_routine message =
+    Log.emit_routine ~module_name:"oas:event" ~details:json message
+  in
+  let log message = log_at Log.Info message in
+  match evt.payload with
+  | Agent_sdk.Event_bus.AgentStarted { agent_name; task_id } ->
+    log (Printf.sprintf "agent started agent=%s task_id=%s" agent_name task_id)
+  | Agent_sdk.Event_bus.AgentCompleted { agent_name; task_id; elapsed; _ } ->
+    log
+      (Printf.sprintf
+         "agent completed agent=%s task_id=%s elapsed_s=%.3f"
+         agent_name
+         task_id
+         elapsed)
+  | Agent_sdk.Event_bus.TurnStarted { agent_name; turn } ->
+    log (Printf.sprintf "turn started agent=%s turn=%d" agent_name turn)
+  | Agent_sdk.Event_bus.TurnCompleted { agent_name; turn } ->
+    log (Printf.sprintf "turn completed agent=%s turn=%d" agent_name turn)
+  | Agent_sdk.Event_bus.ToolCalled { agent_name; tool_name; _ } ->
+    log (Printf.sprintf "tool called agent=%s tool_name=%s" agent_name tool_name)
+  | Agent_sdk.Event_bus.ToolCompleted { agent_name; tool_name; _ } ->
+    log (Printf.sprintf "tool completed agent=%s tool_name=%s" agent_name tool_name)
+  | Agent_sdk.Event_bus.TurnReady { agent_name; turn; tool_names } ->
+    (* [substrate:tool_surface] — deterministic per-turn snapshot of the
+         tool list the LLM actually sees this turn (after guardrails,
+         operator policy, tool_filter_override).  Emitted as a single
+         grep-friendly line with a stable hash so operators can confirm
+         which tools were on the LLM's surface for a given turn without
+         enabling verbose tool dumps. *)
+    let names_hash = Digest.to_hex (Digest.string (String.concat "\n" tool_names)) in
+    log_routine
+      (Printf.sprintf
+         "[substrate:tool_surface] agent=%s turn=%d count=%d names_hash=%s"
+         agent_name
+         turn
+         (List.length tool_names)
+         (String.sub names_hash 0 16))
+  | Agent_sdk.Event_bus.ContextCompacted
+      { agent_name; before_tokens; after_tokens; phase } ->
+    log
+      (Printf.sprintf
+         "context compacted agent=%s before_tokens=%d after_tokens=%d phase=%s"
+         agent_name
+         before_tokens
+         after_tokens
+         phase)
+  | Agent_sdk.Event_bus.ContextOverflowImminent
+      { agent_name; estimated_tokens; limit_tokens; ratio } ->
+    log
+      (Printf.sprintf
+         "context overflow imminent agent=%s estimated_tokens=%d limit_tokens=%d \
+          ratio=%.3f"
+         agent_name
+         estimated_tokens
+         limit_tokens
+         ratio)
+  | Agent_sdk.Event_bus.ContextCompactStarted { agent_name; trigger } ->
+    log (Printf.sprintf "context compact started agent=%s trigger=%s" agent_name trigger)
+  (* Variants below previously absorbed by [_ -> ()] catch-all.  Each is
+     enumerated explicitly so adding a new [Agent_sdk.Event_bus.payload]
+     variant fails the build instead of silently dropping the log line. *)
+  | Agent_sdk.Event_bus.AgentFailed _
+  | Agent_sdk.Event_bus.HandoffRequested _
+  | Agent_sdk.Event_bus.HandoffCompleted _
+  | Agent_sdk.Event_bus.ElicitationCompleted _
+  | Agent_sdk.Event_bus.ContentReplacementReplaced _
+  | Agent_sdk.Event_bus.ContentReplacementKept _
+  | Agent_sdk.Event_bus.SlotSchedulerObserved _
+  | Agent_sdk.Event_bus.InferenceTelemetry _
+  | Agent_sdk.Event_bus.Custom _ -> ()
+;;
+
+(** Build the SSE JSON wrapper. [correlation_id] and [run_id] are
+    mandatory (from the envelope); all other fields are optional. *)
+let wrap_event
+      ~ts
+      ~correlation_id
+      ~run_id
+      ~event_type
+      ~payload
+      ?agent_name
+      ?task_id
+      ?turn
+      ?tool_name
+      ()
+  =
+  `Assoc
+    [ "type", `String ("oas:" ^ event_type)
+    ; "event_type", `String event_type
+    ; "ts_unix", `Float ts
+    ; "correlation_id", `String correlation_id
+    ; "run_id", `String run_id
+    ; "agent_name", Json_util.string_opt_to_json_trimmed agent_name
+    ; "task_id", Json_util.string_opt_to_json_trimmed task_id
+    ; "turn", Option.fold ~none:`Null ~some:(fun value -> `Int value) turn
+    ; "tool_name", Json_util.string_opt_to_json_trimmed tool_name
+    ; "payload", payload
+    ]
+;;
+
+(** Serialize an OAS event to JSON for SSE relay + durable storage.
+    Reads envelope metadata ([correlation_id], [run_id], [ts]) from
+    [evt.meta] and includes them in every emitted JSON object.
+
+    The match below intentionally combines explicit per-variant arms
+    with a final [other] catch-all that produces a kind-only fallback
+    via [Agent_sdk.Event_bus.payload_kind].  The catch-all is "redundant" at
+    every individual snapshot of the OAS variant set (warning 11), but
+    it is a deliberate future-proof against the OAS pin-bump P0 class
+    (#10490, #10574, #10584).  Without the catch-all, every new
+    upstream variant breaks main with [-warn-error +8] until the
+    consumer is migrated; with it, the relay degrades to a
+    kind-labelled placeholder while emitting three operator signals:
+
+    - WARN log [oas_event_bridge: SSE-degraded ...] including the
+      offending [kind], correlation ids, timestamp, and the explicit
+      file:function where the migration arm should be added.
+    - Counter [masc_oas_bridge_unmigrated_payload_kind_total{kind}]
+      ({!Prometheus.metric_oas_bridge_unmigrated_payload_kind}) so the
+      degradation rate is visible to Prometheus without log scraping.
+    - SSE payload [note] + [migration_target] fields so dashboard code
+      can render the partial-data row distinctly and link the operator
+      back to the file that needs editing.
+
+    Suppressing warning 11 ([@warning "-11"]) is therefore the entire
+    point of this function's shape — do not remove it without also
+    removing the catch-all. *)
+let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t option =
+  let { Agent_sdk.Event_bus.correlation_id; run_id; ts; _ } = evt.meta in
+  let wrap = wrap_event ~ts ~correlation_id ~run_id in
+  match[@warning "-11"] evt.payload with
+  | Agent_sdk.Event_bus.AgentStarted { agent_name; task_id } ->
+    let payload =
+      `Assoc [ "agent_name", `String agent_name; "task_id", `String task_id ]
+    in
+    Some (wrap ~event_type:"agent_started" ~payload ~agent_name ~task_id ())
+  | Agent_sdk.Event_bus.AgentCompleted { agent_name; task_id; elapsed; result } ->
+    (match result with
+     | Ok (response : Agent_sdk.Types.api_response) ->
+       let provider =
+         inference_provider_bucket ~provider:"" ~model:response.model
+       in
+       let model_bucket = inference_model_bucket ~provider:"" ~model:response.model in
+       let cost_usd =
+         match response.usage with
+         | Some usage -> usage.cost_usd
+         | None -> None
+       in
+       observe_inference_cost ~provider ~model_bucket cost_usd
+     | Error _ -> ());
+    let payload =
+      `Assoc
+        ([ "agent_name", `String agent_name
+         ; "task_id", `String task_id
+         ; "elapsed_s", `Float elapsed
+         ]
+         @ agent_completed_result_fields result)
+    in
+    Some (wrap ~event_type:"agent_completed" ~payload ~agent_name ~task_id ())
+  | Agent_sdk.Event_bus.AgentFailed { agent_name; task_id; error; elapsed } ->
+    let payload =
+      `Assoc
+        ([ "agent_name", `String agent_name
+         ; "task_id", `String task_id
+         ; "elapsed_s", `Float elapsed
+         ]
+         @ agent_failed_error_fields error)
+    in
+    Some (wrap ~event_type:"agent_failed" ~payload ~agent_name ~task_id ())
+  | Agent_sdk.Event_bus.ToolCalled { agent_name; tool_name; _ } ->
+    let payload =
+      `Assoc [ "agent_name", `String agent_name; "tool_name", `String tool_name ]
+    in
+    Some (wrap ~event_type:"tool_called" ~payload ~agent_name ~tool_name ())
+  | Agent_sdk.Event_bus.ToolCompleted { agent_name; tool_name; _ } ->
+    let payload =
+      `Assoc [ "agent_name", `String agent_name; "tool_name", `String tool_name ]
+    in
+    Some (wrap ~event_type:"tool_completed" ~payload ~agent_name ~tool_name ())
+  | Agent_sdk.Event_bus.TurnStarted { agent_name; turn } ->
+    let payload = `Assoc [ "agent_name", `String agent_name; "turn", `Int turn ] in
+    Some (wrap ~event_type:"turn_started" ~payload ~agent_name ~turn ())
+  | Agent_sdk.Event_bus.TurnCompleted { agent_name; turn } ->
+    let payload = `Assoc [ "agent_name", `String agent_name; "turn", `Int turn ] in
+    Some (wrap ~event_type:"turn_completed" ~payload ~agent_name ~turn ())
+  | Agent_sdk.Event_bus.TurnReady { agent_name; turn; tool_names } ->
+    let names_hash = Digest.to_hex (Digest.string (String.concat "\n" tool_names)) in
+    let payload =
+      `Assoc
+        [ "agent_name", `String agent_name
+        ; "turn", `Int turn
+        ; "count", `Int (List.length tool_names)
+        ; "names_hash", `String (String.sub names_hash 0 16)
+        ; "tool_names", `List (List.map (fun name -> `String name) tool_names)
+        ]
+    in
+    Some (wrap ~event_type:"turn_ready" ~payload ~agent_name ~turn ())
+  | Agent_sdk.Event_bus.HandoffRequested { from_agent; to_agent; reason } ->
+    let payload =
+      `Assoc
+        [ "from_agent", `String from_agent
+        ; "to_agent", `String to_agent
+        ; "reason", `String reason
+        ]
+    in
+    Some (wrap ~event_type:"handoff_requested" ~payload ~agent_name:from_agent ())
+  | Agent_sdk.Event_bus.HandoffCompleted { from_agent; to_agent; elapsed } ->
+    let payload =
+      `Assoc
+        [ "from_agent", `String from_agent
+        ; "to_agent", `String to_agent
+        ; "elapsed_s", `Float elapsed
+        ]
+    in
+    Some (wrap ~event_type:"handoff_completed" ~payload ~agent_name:from_agent ())
+  | Agent_sdk.Event_bus.ContextCompacted
+      { agent_name; before_tokens; after_tokens; phase } ->
+    (* #9935: compaction completed — clears any pending
+         imminent and fires action-taken counter. *)
+    Context_overflow_action_tracker.record_action ~keeper_name:agent_name;
+    let payload =
+      `Assoc
+        [ "agent_name", `String agent_name
+        ; "before_tokens", `Int before_tokens
+        ; "after_tokens", `Int after_tokens
+        ; "phase", `String phase
+        ]
+    in
+    Some (wrap ~event_type:"context_compacted" ~payload ~agent_name ())
+  | Agent_sdk.Event_bus.ElicitationCompleted _ -> None (* Internal; no SSE relay needed *)
+  | Agent_sdk.Event_bus.ContextOverflowImminent
+      { agent_name; estimated_tokens; limit_tokens; ratio } ->
+    (* #9935: track imminent→action pairing so an unanswered
+         overflow (no compact_started/compacted within grace
+         window) is observable via metric + warn log, rather
+         than silently burning out as provider_timeout. *)
+    Prometheus.set_gauge
+      Prometheus.metric_oas_context_overflow_ratio
+      ~labels:[ "agent_name", agent_name ]
+      ratio;
+    Context_overflow_action_tracker.record_imminent
+      ~keeper_name:agent_name
+      ~ts:(Time_compat.now ());
+    let payload =
+      `Assoc
+        [ "agent_name", `String agent_name
+        ; "estimated_tokens", `Int estimated_tokens
+        ; "limit_tokens", `Int limit_tokens
+        ; "ratio", `Float ratio
+        ]
+    in
+    Some (wrap ~event_type:"context_overflow_imminent" ~payload ~agent_name ())
+  | Agent_sdk.Event_bus.ContextCompactStarted { agent_name; trigger } ->
+    (* #9935: compaction started — clears pending imminent
+         and fires action-taken counter. *)
+    Context_overflow_action_tracker.record_action ~keeper_name:agent_name;
+    Prometheus.inc_counter
+      Prometheus.metric_oas_context_compaction_total
+      ~labels:[ "agent_name", agent_name; "trigger", trigger ]
+      ();
+    let payload =
+      `Assoc [ "agent_name", `String agent_name; "trigger", `String trigger ]
+    in
+    Some (wrap ~event_type:"context_compact_started" ~payload ~agent_name ())
+  | Agent_sdk.Event_bus.ContentReplacementReplaced
+      { tool_use_id; preview; original_chars; seen_count_after } ->
+    let payload =
+      `Assoc
+        [ "tool_use_id", `String tool_use_id
+        ; "preview", `String preview
+        ; "original_chars", `Int original_chars
+        ; "seen_count_after", `Int seen_count_after
+        ]
+    in
+    Some (wrap ~event_type:"content_replacement_replaced" ~payload ())
+  | Agent_sdk.Event_bus.ContentReplacementKept { tool_use_id; seen_count_after } ->
+    let payload =
+      `Assoc
+        [ "tool_use_id", `String tool_use_id; "seen_count_after", `Int seen_count_after ]
+    in
+    Some (wrap ~event_type:"content_replacement_kept" ~payload ())
+  | Agent_sdk.Event_bus.SlotSchedulerObserved
+      { max_slots; active; available; queue_length; state } ->
+    let state_str =
+      match state with
+      | Agent_sdk.Event_bus.Idle -> "idle"
+      | Agent_sdk.Event_bus.Queued -> "queued"
+      | Agent_sdk.Event_bus.Saturated -> "saturated"
+    in
+    let payload =
+      `Assoc
+        [ "max_slots", `Int max_slots
+        ; "active", `Int active
+        ; "available", `Int available
+        ; "queue_length", `Int queue_length
+        ; "state", `String state_str
+        ]
+    in
+    Some (wrap ~event_type:"slot_scheduler_observed" ~payload ())
+  | Agent_sdk.Event_bus.Custom (name, payload) ->
+    (* Wire compatibility: dashboard consumers historically decoded
+         [masc:broadcast] / [masc:keeper:snapshot] (all colons).
+         Internally MASC now emits dot-separated names per OAS Custom
+         convention ([masc.broadcast], [masc.keeper.snapshot]).
+         Translate EVERY dot to colon for [masc.*] events so existing
+         SSE consumers continue to decode the full multi-segment name. *)
+    let event_type =
+      if String.length name > 5 && String.starts_with ~prefix:"masc." name
+      then String.map (fun c -> if c = '.' then ':' else c) name
+      else name
+    in
+    Some
+      (wrap
+         ~event_type
+         ~payload
+         ?agent_name:(payload_agent_name payload)
+         ?task_id:(Json_util.assoc_string_opt "task_id" payload)
+         ?turn:(Json_util.assoc_int_opt "turn" payload)
+         ?tool_name:(Json_util.assoc_string_opt "tool_name" payload)
+         ())
+  | Agent_sdk.Event_bus.InferenceTelemetry
+      { provider
+      ; model
+      ; prompt_tokens
+      ; completion_tokens
+      ; prompt_ms
+      ; decode_ms
+      ; decode_tok_s
+      ; _
+      } ->
+    (* Per-token telemetry from OAS#1202; not surfaced over SSE. Preserve
+         the aggregate signal with bounded Prometheus labels so operators can
+         see model-family/token-bin trends without flooding SSE consumers or
+         creating raw-model cardinality. *)
+    observe_inference_telemetry
+      ~provider
+      ~model
+      ~prompt_tokens
+      ~completion_tokens
+      ~prompt_ms
+      ~decode_ms
+      ~decode_tok_s;
+    None
+  | other ->
+    (* Graceful fallback for OAS variants that ship before this consumer
+         is migrated to an explicit shape (#10584).  Pre-fix, the match
+         above was exhaustive and the OAS pin bump that introduced
+         [InferenceTelemetry] (#10490) and [Stale_turn_timeout] (#10574)
+         broke main with [-warn-error +8] partial-match errors.
+
+         [Agent_sdk.Event_bus.payload_kind] is co-located with the [payload]
+         variant in OAS — adding a new variant upstream forces an
+         entry there in the same patch, so the snake_case label is
+         always accurate.  Emit a kind-only SSE event so subscribers
+         see *something happened* (with stable [event_type] for
+         filtering) instead of having the whole stream fail to parse.
+
+         [note] + [migration_target] flag the partial-data shape so
+         dashboards can render it as a placeholder rather than treating
+         it as a complete payload, and tell the operator *where* to add
+         the explicit arm.  The warn log gives operators a per-process
+         signal that an OAS variant has shipped without a masc-mcp
+         consumer migration; the
+         [masc_oas_bridge_unmigrated_payload_kind_total{kind}] counter
+         gives them the per-process *rate*, surfaced on the Prometheus
+         scrape so dashboards can alert without log scraping. *)
+    let kind = Agent_sdk.Event_bus.payload_kind other in
+    Prometheus.inc_counter
+      Prometheus.metric_oas_bridge_unmigrated_payload_kind
+      ~labels:[ "kind", kind ]
+      ();
+    Log.Misc.warn
+      "oas_event_bridge: SSE-degraded to kind-only payload for unmigrated OAS \
+       variant kind=%s correlation_id=%s run_id=%s ts=%f fix: add explicit arm in \
+       lib/cascade/cascade_event_bridge.ml::native_event_to_json for this kind"
+      kind
+      correlation_id
+      run_id
+      ts;
+    let payload =
+      `Assoc
+        [ "kind", `String kind
+        ; ( "note"
+          , `String
+              "kind-only fallback; explicit arm not yet wired in \
+               cascade_event_bridge.native_event_to_json" )
+        ; ( "migration_target"
+          , `String "lib/cascade/cascade_event_bridge.ml::native_event_to_json" )
+        ]
+    in
+    Some (wrap ~event_type:kind ~payload ())
+;;
+
+let relay_max_attempts = 3
+let relay_max_queue_depth = 256
+
+type relay_stage =
+  | Append
+  | Broadcast
+
+type pending_relay =
+  { json : Yojson.Safe.t
+  ; attempts : int
+  ; appended : bool
+  }
+
+type relay_result =
+  | Delivered
+  | Retryable_failure of pending_relay * relay_stage * exn
+
+let relay_stage_to_string = function
+  | Append -> "append"
+  | Broadcast -> "broadcast"
+;;
+
+let relay_event_type json =
+  match Json_util.assoc_string_opt "event_type" json with
+  | Some value -> value
+  | None ->
+    (match Json_util.assoc_string_opt "type" json with
+     | Some value -> value
+     | None -> "unknown")
+;;
+
+let relay_event_is_presence_class json =
+  match relay_event_type json with
+  | "masc:keeper:snapshot" -> true
+  | _ -> false
+;;
+
+let broadcast_relay_json json =
+  Sse.broadcast_to All json;
+  if relay_event_is_presence_class json
+  then (
+    try Sse.broadcast_presence json with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Misc.warn "oas_event_bridge: presence relay failed: %s" (Printexc.to_string exn))
+;;
+
+let update_relay_queue_depth pending =
+  Prometheus.set_gauge
+    Prometheus.metric_oas_sse_relay_queue_depth
+    (float_of_int (List.length pending))
+;;
+
+let emit_relay_retry_log
+      ~(pending : pending_relay)
+      ~(stage : relay_stage)
+      ~(attempt : int)
+      exn
+  =
+  Log.Misc.warn
+    "oas_event_bridge: retrying event_type=%s stage=%s attempt=%d/%d correlation_id=%s \
+     run_id=%s error=%s"
+    (relay_event_type pending.json)
+    (relay_stage_to_string stage)
+    attempt
+    relay_max_attempts
+    (Option.value ~default:"<none>" (Json_util.assoc_string_opt "correlation_id" pending.json))
+    (Option.value ~default:"<none>" (Json_util.assoc_string_opt "run_id" pending.json))
+    (Printexc.to_string exn)
+;;
+
+let emit_relay_drop_log
+      ~(pending : pending_relay)
+      ~(stage_label : string)
+      ~(attempts : int)
+  =
+  Log.Server.error
+    "oas_event_bridge: dropping event_type=%s stage=%s attempts=%d correlation_id=%s \
+     run_id=%s"
+    (relay_event_type pending.json)
+    stage_label
+    attempts
+    (Option.value ~default:"<none>" (Json_util.assoc_string_opt "correlation_id" pending.json))
+    (Option.value ~default:"<none>" (Json_util.assoc_string_opt "run_id" pending.json))
+;;
+
+let broadcast_drop_marker
+      ~(pending : pending_relay)
+      ~(stage_label : string)
+      ~(attempts : int)
+  =
+  let marker =
+    `Assoc
+      [ "type", `String "oas:relay_dropped"
+      ; "event_type", `String "relay_dropped"
+      ; "ts_unix", `Float (Time_compat.now ())
+      ; ( "correlation_id"
+        , Json_util.string_opt_to_json
+            (Json_util.assoc_string_opt "correlation_id" pending.json) )
+      ; ( "run_id"
+        , Json_util.string_opt_to_json
+            (Json_util.assoc_string_opt "run_id" pending.json) )
+      ; ( "agent_name"
+        , Json_util.string_opt_to_json
+            (Json_util.assoc_string_opt "agent_name" pending.json) )
+      ; "failed_stage", `String stage_label
+      ; "attempts", `Int attempts
+      ; "original_event_type", `String (relay_event_type pending.json)
+      ]
+  in
+  try Sse.broadcast_to All marker with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    (* P2 silent-failure fix: previously only logged.  The drop
+         marker is the operator-visible signal that an OAS event was
+         dropped after exhausting retries; if the drop marker also
+         fails to broadcast, operators are blind to the drop entirely.
+         Counter is distinct from masc_sse_broadcast_failures_total
+         (PR-C #11075) so the recovery-path failure rate is visible
+         in isolation from normal broadcast failures. *)
+    Transport_metrics.inc_relay_drop_marker_failure ();
+    Log.Misc.warn
+      "oas_event_bridge: drop marker broadcast failed: %s"
+      (Printexc.to_string exn)
+;;
+
+let prepare_pending_event evt =
+  match native_event_to_json evt with
+  | None -> None
+  | Some json ->
+    (* OAS event payloads may carry tool output or user-facing text that
+         contains invalid UTF-8 bytes (e.g. truncated multi-byte sequences
+         from subprocess captures). Scrub once before the event enters the
+         retry queue so every retry uses the same sanitized payload. *)
+    let json = Inference_utils.sanitize_json_utf8 json in
+    emit_native_event_log evt json;
+    Some { json; attempts = 0; appended = false }
+;;
+
+let deliver_pending_with
+      ~(append_json : Yojson.Safe.t -> unit)
+      ~(broadcast_json : Yojson.Safe.t -> unit)
+      (pending : pending_relay)
+  =
+  let pending =
+    if pending.appended
+    then pending
+    else (
+      append_json pending.json;
+      { pending with appended = true })
+  in
+  try
+    broadcast_json pending.json;
+    Delivered
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Retryable_failure (pending, Broadcast, exn)
+;;
+
+let oas_event_retention_days_default = 30
+
+let resolve_oas_event_retention_days = function
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some days when days > 0 -> Some days
+     | Some _ -> None
+     | None -> Some oas_event_retention_days_default)
+  | None -> Some oas_event_retention_days_default
+;;
+
+let oas_event_retention_days () =
+  resolve_oas_event_retention_days (Sys.getenv_opt "MASC_OAS_EVENTS_RETENTION_DAYS")
+;;
+
+let deliver_pending ?store_ref (pending : pending_relay) =
+  let append_json =
+    match store_ref with
+    | None -> fun _json -> ()
+    | Some store_ref ->
+      fun json ->
+        let store = !store_ref in
+        (try Dated_jsonl.append store json with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           let retention_days = oas_event_retention_days () in
+           store_ref :=
+             Dated_jsonl.create
+               ~base_dir:(Dated_jsonl.base_dir store)
+               ?retention_days
+               ();
+           raise exn)
+  in
+  try deliver_pending_with ~append_json ~broadcast_json:broadcast_relay_json pending with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Retryable_failure (pending, Append, exn)
+;;
+
+let should_drain_subscription pending =
+  (* Do not move new OAS bus events into the local retry queue while
+     failed relays are still pending.  The OAS subscriber stream is
+     bounded, so leaving it undrained applies publisher backpressure
+     instead of dropping the oldest local relay event. *)
+  pending = []
+;;
+
+let prepare_pending_events events = List.filter_map prepare_pending_event events
+
+let rec process_pending ?store_ref acc = function
+  | [] -> List.rev acc
+  | pending :: rest ->
+    (match deliver_pending ?store_ref pending with
+     | Delivered -> process_pending ?store_ref acc rest
+     | Retryable_failure (pending, stage, exn) ->
+       let attempt = pending.attempts + 1 in
+       let fd_pressure =
+         Keeper_fd_pressure.active () || Keeper_fd_pressure.is_fd_exhaustion_exn exn
+       in
+       let disk_pressure =
+         Keeper_disk_pressure.active ()
+         || Keeper_disk_pressure.is_disk_exhaustion_exn exn
+       in
+       if disk_pressure
+       then Keeper_disk_pressure.note_exception ~site:"oas_event_bridge.relay" exn;
+       if fd_pressure || disk_pressure
+       then (
+         if fd_pressure
+         then Keeper_fd_pressure.note_exception ~site:"oas_event_bridge.relay" exn;
+         Prometheus.inc_counter
+           Prometheus.metric_oas_sse_relay_drops
+           ~labels:[ "stage", relay_stage_to_string stage ]
+           ();
+         let stage_label =
+           relay_stage_to_string stage
+           ^ (if fd_pressure then ":fd_pressure" else ":disk_pressure")
+         in
+         emit_relay_drop_log ~pending ~stage_label ~attempts:attempt;
+         broadcast_drop_marker ~pending ~stage_label ~attempts:attempt;
+         process_pending ?store_ref acc rest)
+       else if attempt >= relay_max_attempts
+       then (
+         Prometheus.inc_counter
+           Prometheus.metric_oas_sse_relay_drops
+           ~labels:[ "stage", relay_stage_to_string stage ]
+           ();
+         emit_relay_drop_log
+           ~pending
+           ~stage_label:(relay_stage_to_string stage)
+           ~attempts:attempt;
+         broadcast_drop_marker
+           ~pending
+           ~stage_label:(relay_stage_to_string stage)
+           ~attempts:attempt;
+         process_pending ?store_ref acc rest)
+       else (
+         Prometheus.inc_counter
+           Prometheus.metric_oas_sse_relay_retries
+           ~labels:[ "stage", relay_stage_to_string stage ]
+           ();
+         emit_relay_retry_log ~pending ~stage ~attempt exn;
+         process_pending ?store_ref ({ pending with attempts = attempt } :: acc) rest))
+;;
+
+type bridge_pending_relay = pending_relay
+type bridge_relay_stage = relay_stage
+type bridge_relay_result = relay_result
+
+let oas_event_store ~config =
+  let retention_days = oas_event_retention_days () in
+  Dated_jsonl.create
+    ~base_dir:(Filename.concat (Coord.masc_root_dir config) "oas-events")
+    ?retention_days
+    ()
+;;
+
+let deliver_pending_with_impl = deliver_pending_with
+
+module For_testing = struct
+  type pending_relay =
+    { json : Yojson.Safe.t
+    ; attempts : int
+    ; appended : bool
+    }
+
+  type relay_stage =
+    | Append
+    | Broadcast
+
+  type relay_result =
+    | Delivered
+    | Retryable_failure of pending_relay * relay_stage * exn
+
+  let make_pending json = { json; attempts = 0; appended = false }
+  let relay_max_queue_depth = relay_max_queue_depth
+  let resolve_oas_event_retention_days = resolve_oas_event_retention_days
+
+  let to_pending (pending : pending_relay) : bridge_pending_relay =
+    { json = pending.json; attempts = pending.attempts; appended = pending.appended }
+  ;;
+
+  let of_pending (pending : bridge_pending_relay) : pending_relay =
+    { json = pending.json; attempts = pending.attempts; appended = pending.appended }
+  ;;
+
+  (* Issue #8676: convert directly between the outer [relay_stage] and the
+     [For_testing.relay_stage] mirror. The previous string-roundtrip carried
+     a permissive [_ -> Broadcast] catch-all that would silently misclassify
+     any future outer constructor as [Broadcast] in test stage assertions
+     (#8605 anti-pattern). Direct match makes adding a constructor a
+     compile error here, forcing the test mirror to stay in sync. *)
+  let of_stage : bridge_relay_stage -> relay_stage = function
+    | Append -> Append
+    | Broadcast -> Broadcast
+  ;;
+
+  let of_result (result : bridge_relay_result) =
+    match result with
+    | Delivered -> Delivered
+    | Retryable_failure (pending, stage, exn) ->
+      Retryable_failure (of_pending pending, of_stage stage, exn)
+  ;;
+
+  let deliver_pending_with ~append_json ~broadcast_json pending =
+    deliver_pending_with_impl ~append_json ~broadcast_json (to_pending pending)
+    |> of_result
+  ;;
+
+  let should_drain_subscription pending =
+    should_drain_subscription (List.map to_pending pending)
+  ;;
+end
+
+let start_impl ~interval_s ~sw ~clock ~(config : Coord.config) ~bus =
+  let store = ref (oas_event_store ~config) in
+  let sub =
+    Agent_sdk_metrics_bridge.subscribe
+      ~purpose:"sse_bridge"
+      ~filter:Agent_sdk.Event_bus.accept_all
+      bus
+  in
+  Eio.Switch.on_release sw (fun () -> Agent_sdk_metrics_bridge.unsubscribe bus sub);
+  let pending = ref [] in
+  update_relay_queue_depth !pending;
+  Eio.Fiber.fork ~sw (fun () ->
+    let rec loop () =
+      (try
+         pending := process_pending ~store_ref:store [] !pending;
+         if should_drain_subscription !pending
+         then (
+           let events = Agent_sdk_metrics_bridge.drain sub in
+           pending := prepare_pending_events events;
+           pending := process_pending ~store_ref:store [] !pending);
+         update_relay_queue_depth !pending
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Log.Misc.warn
+           "oas_event_bridge: relay iteration failed: %s"
+           (Printexc.to_string exn));
+      Eio.Time.sleep clock interval_s;
+      loop ()
+    in
+    loop ())
+;;
+
+(** Background fiber: drain events and relay to SSE. *)
+let start ~sw ~clock ~(config : Coord.config) ~bus =
+  start_impl ~interval_s:(drain_interval_s ()) ~sw ~clock ~config ~bus
+;;
+
+let start_with_interval
+      ~drain_interval_s:interval_s
+      ~sw
+      ~clock
+      ~(config : Coord.config)
+      ~bus
+  =
+  start_impl ~interval_s ~sw ~clock ~config ~bus
+;;

--- a/lib/keeper/keeper_event_bridge.mli
+++ b/lib/keeper/keeper_event_bridge.mli
@@ -1,0 +1,67 @@
+(** OAS Event_bus → SSE Bridge.
+
+    Subscribes to all OAS Event_bus events, relays them as SSE broadcasts
+    to connected dashboard clients, and durably appends the same event stream
+    to [.masc/oas-events/].
+
+    @since 2.96.0 *)
+
+(** Start the bridge fiber. Subscribes to [bus], drains events on an
+    env-configurable interval
+    ([MASC_OAS_SSE_DRAIN_INTERVAL_SEC], default 0.25s),
+    broadcasts each as an SSE event, and appends each serializable event to
+    the cluster-aware [.masc/oas-events/] store for offline/debug replay.
+    The durable store prunes old date-split files on append using
+    [MASC_OAS_EVENTS_RETENTION_DAYS] (default 30; non-positive disables).
+    Runs as a background Eio fiber under [sw]. *)
+val start :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  config:Coord.config ->
+  bus:Agent_sdk.Event_bus.t ->
+  unit
+
+val start_with_interval :
+  drain_interval_s:float ->
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  config:Coord.config ->
+  bus:Agent_sdk.Event_bus.t ->
+  unit
+(** Start the bridge fiber with an explicit drain interval.
+    Test-only surface — production uses [start] which reads
+    [MASC_OAS_SSE_DRAIN_INTERVAL_SEC] from the environment. *)
+
+(** Serialize a single OAS event to SSE JSON.
+    Exposed for unit testing. *)
+val native_event_to_json : Agent_sdk.Event_bus.event -> Yojson.Safe.t option
+
+module For_testing : sig
+  type pending_relay = private {
+    json : Yojson.Safe.t;
+    attempts : int;
+    appended : bool;
+  }
+
+  type relay_stage = private
+    | Append
+    | Broadcast
+
+  type relay_result = private
+    | Delivered
+    | Retryable_failure of pending_relay * relay_stage * exn
+
+  val make_pending : Yojson.Safe.t -> pending_relay
+
+  val relay_max_queue_depth : int
+
+  val resolve_oas_event_retention_days : string option -> int option
+
+  val should_drain_subscription : pending_relay list -> bool
+
+  val deliver_pending_with :
+    append_json:(Yojson.Safe.t -> unit) ->
+    broadcast_json:(Yojson.Safe.t -> unit) ->
+    pending_relay ->
+    relay_result
+end

--- a/lib/keeper/keeper_event_bridge_error_json.ml
+++ b/lib/keeper/keeper_event_bridge_error_json.ml
@@ -1,0 +1,423 @@
+let stop_reason_to_wire = function
+  | Agent_sdk.Types.EndTurn -> "end_turn"
+  | Agent_sdk.Types.StopToolUse -> "tool_use"
+  | Agent_sdk.Types.MaxTokens -> "max_tokens"
+  | Agent_sdk.Types.StopSequence -> "stop_sequence"
+  | Agent_sdk.Types.Unknown value -> value
+;;
+
+let agent_completed_usage_fields (response : Agent_sdk.Types.api_response) =
+  match response.usage with
+  | None -> [ "usage_reported", `Bool false ]
+  | Some usage ->
+    [ "usage_reported", `Bool true
+    ; "input_tokens", `Int usage.input_tokens
+    ; "output_tokens", `Int usage.output_tokens
+    ; "cache_creation_input_tokens", `Int usage.cache_creation_input_tokens
+    ; "cache_read_input_tokens", `Int usage.cache_read_input_tokens
+    ; "total_tokens", `Int (usage.input_tokens + usage.output_tokens)
+    ; ( "cost_usd"
+      , match usage.cost_usd with
+        | Some cost -> `Float cost
+        | None -> `Null )
+    ]
+;;
+
+let agent_completed_result_fields = function
+  | Ok (response : Agent_sdk.Types.api_response) ->
+    [ "success", `Bool true
+    ; "result", `String "ok"
+    ; "response_id", `String response.id
+    ; "model", `String response.model
+    ; "stop_reason", `String (stop_reason_to_wire response.stop_reason)
+    ]
+    @ agent_completed_usage_fields response
+  | Error error ->
+    [ "success", `Bool false
+    ; "result", `String "error"
+    ; "error", `String (Agent_sdk.Error.to_string error)
+    ; "usage_reported", `Bool false
+    ]
+;;
+
+;;
+
+let json_contract_violation_detail
+  (detail : Agent_sdk.Completion_contract_violation_detail.t option)
+  =
+  match detail with
+  | None -> `Null
+  | Some (detail : Agent_sdk.Completion_contract_violation_detail.t) ->
+    `Assoc
+      [ ( "called_tools"
+        , Json_util.json_string_list
+            detail.Agent_sdk.Completion_contract_violation_detail.called_tools )
+      ; ( "satisfying_tools"
+        , Json_util.json_string_list
+            detail.Agent_sdk.Completion_contract_violation_detail.satisfying_tools )
+      ; ( "rejection_reasons"
+        , `List
+            (List.map
+               (fun (tool_name, reason) ->
+                  `Assoc
+                    [ "tool_name", `String tool_name; "reason", `String reason ])
+               detail.Agent_sdk.Completion_contract_violation_detail.rejection_reasons) )
+      ]
+;;
+
+let network_error_kind_to_wire = function
+  | Llm_provider.Http_client.Connection_refused -> "connection_refused"
+  | Llm_provider.Http_client.Dns_failure -> "dns_failure"
+  | Llm_provider.Http_client.Tls_error -> "tls_error"
+  | Llm_provider.Http_client.Timeout -> "timeout"
+  | Llm_provider.Http_client.Local_resource_exhaustion -> "local_resource_exhaustion"
+  | Llm_provider.Http_client.End_of_file -> "end_of_file"
+  | Llm_provider.Http_client.Unknown -> "unknown"
+;;
+
+let sdk_api_error_fields = function
+  | Agent_sdk.Retry.RateLimited { retry_after; message } ->
+    [ "variant", `String "rate_limited"
+    ; "message", `String message
+    ; "retry_after_s", Json_util.float_opt_to_json retry_after
+    ]
+  | Agent_sdk.Retry.Overloaded { message } ->
+    [ "variant", `String "overloaded"; "message", `String message ]
+  | Agent_sdk.Retry.ServerError { status; message } ->
+    [ "variant", `String "server_error"
+    ; "status", `Int status
+    ; "message", `String message
+    ]
+  | Agent_sdk.Retry.AuthError { message } ->
+    [ "variant", `String "auth_error"; "message", `String message ]
+  | Agent_sdk.Retry.InvalidRequest { message } ->
+    [ "variant", `String "invalid_request"; "message", `String message ]
+  | Agent_sdk.Retry.NotFound { message } ->
+    [ "variant", `String "not_found"; "message", `String message ]
+  | Agent_sdk.Retry.ContextOverflow { message; limit } ->
+    [ "variant", `String "context_overflow"
+    ; "message", `String message
+    ; "limit", Json_util.int_opt_to_json limit
+    ]
+  | Agent_sdk.Retry.NetworkError { message; kind } ->
+    [ "variant", `String "network_error"
+    ; "message", `String message
+    ; "network_kind", `String (network_error_kind_to_wire kind)
+    ]
+  | Agent_sdk.Retry.Timeout { message } ->
+    [ "variant", `String "timeout"; "message", `String message ]
+;;
+
+let sdk_agent_error_fields = function
+  | Agent_sdk.Error.MaxTurnsExceeded { turns; limit } ->
+    [ "variant", `String "max_turns_exceeded"; "turns", `Int turns; "limit", `Int limit ]
+  | Agent_sdk.Error.TokenBudgetExceeded { kind; used; limit } ->
+    [ "variant", `String "token_budget_exceeded"
+    ; "kind", `String kind
+    ; "used", `Int used
+    ; "limit", `Int limit
+    ]
+  | Agent_sdk.Error.CostBudgetExceeded { spent_usd; limit_usd } ->
+    [ "variant", `String "cost_budget_exceeded"
+    ; "spent_usd", `Float spent_usd
+    ; "limit_usd", `Float limit_usd
+    ]
+  | Agent_sdk.Error.CostBudgetUnenforceable { model_id = _; limit_usd } ->
+    (* RFC-0132 PR-2: event surface model value = external boundary; redact via SSOT.
+       The "runtime" JSON key is a schema field name (not a label). *)
+    [ "variant", `String "cost_budget_unenforceable"
+    ; "runtime",
+      `String
+        (Boundary_redaction.to_string Boundary_redaction.runtime_model_label)
+    ; "limit_usd", `Float limit_usd
+    ]
+  | Agent_sdk.Error.UnrecognizedStopReason { reason } ->
+    [ "variant", `String "unrecognized_stop_reason"; "reason", `String reason ]
+  | Agent_sdk.Error.IdleDetected { consecutive_idle_turns } ->
+    [ "variant", `String "idle_detected"
+    ; "consecutive_idle_turns", `Int consecutive_idle_turns
+    ]
+  | Agent_sdk.Error.ToolRetryExhausted { attempts; limit; detail } ->
+    [ "variant", `String "tool_retry_exhausted"
+    ; "attempts", `Int attempts
+    ; "limit", `Int limit
+    ; "detail", `String detail
+    ]
+  | Agent_sdk.Error.CompletionContractViolation
+      { contract; reason; violation_detail } ->
+    [ "variant", `String "completion_contract_violation"
+    ; "contract", `String (Agent_sdk.Completion_contract_id.to_string contract)
+    ; "reason", `String reason
+    ; "violation_detail", json_contract_violation_detail violation_detail
+    ]
+  | Agent_sdk.Error.GuardrailViolation { validator; reason } ->
+    [ "variant", `String "guardrail_violation"
+    ; "validator", `String validator
+    ; "reason", `String reason
+    ]
+  | Agent_sdk.Error.TripwireViolation { tripwire; reason } ->
+    [ "variant", `String "tripwire_violation"
+    ; "tripwire", `String tripwire
+    ; "reason", `String reason
+    ]
+  | Agent_sdk.Error.ExitConditionMet { turn } ->
+    [ "variant", `String "exit_condition_met"; "turn", `Int turn ]
+  | Agent_sdk.Error.InputRequired { request_id; participant_name; question; _ } ->
+    [ "variant", `String "input_required"
+    ; "request_id", `String request_id
+    ; "participant_name", Json_util.string_opt_to_json participant_name
+    ; "question", `String question
+    ]
+  | Agent_sdk.Error.AgentExecutionTimeout
+      { elapsed_sec; timeout_sec; turn_count; max_turns } ->
+    [ "variant", `String "agent_execution_timeout"
+    ; "elapsed_sec", `Float elapsed_sec
+    ; "timeout_sec", `Float timeout_sec
+    ; "turn_count", `Int turn_count
+    ; "max_turns", `Int max_turns
+    ]
+;;
+
+let sdk_mcp_error_fields = function
+  | Agent_sdk.Error.ServerStartFailed { command; detail } ->
+    [ "variant", `String "server_start_failed"
+    ; "command", `String command
+    ; "detail", `String detail
+    ]
+  | Agent_sdk.Error.InitializeFailed { detail } ->
+    [ "variant", `String "initialize_failed"; "detail", `String detail ]
+  | Agent_sdk.Error.ToolListFailed { detail } ->
+    [ "variant", `String "tool_list_failed"; "detail", `String detail ]
+  | Agent_sdk.Error.ToolCallFailed { tool_name; detail } ->
+    [ "variant", `String "tool_call_failed"
+    ; "tool_name", `String tool_name
+    ; "detail", `String detail
+    ]
+  | Agent_sdk.Error.HttpTransportFailed { url; detail } ->
+    [ "variant", `String "http_transport_failed"
+    ; "url", `String url
+    ; "detail", `String detail
+    ]
+;;
+
+let sdk_config_error_fields = function
+  | Agent_sdk.Error.MissingEnvVar { var_name } ->
+    [ "variant", `String "missing_env_var"; "var_name", `String var_name ]
+  | Agent_sdk.Error.UnsupportedProvider { detail } ->
+    [ "variant", `String "unsupported_provider"; "detail", `String detail ]
+  | Agent_sdk.Error.InvalidConfig { field; detail } ->
+    [ "variant", `String "invalid_config"
+    ; "field", `String field
+    ; "detail", `String detail
+    ]
+;;
+
+let sdk_serialization_error_fields = function
+  | Agent_sdk.Error.JsonParseError { detail } ->
+    [ "variant", `String "json_parse_error"; "detail", `String detail ]
+  | Agent_sdk.Error.VersionMismatch { expected; got } ->
+    [ "variant", `String "version_mismatch"; "expected", `Int expected; "got", `Int got ]
+  | Agent_sdk.Error.UnknownVariant { type_name; value } ->
+    [ "variant", `String "unknown_variant"
+    ; "type_name", `String type_name
+    ; "value", `String value
+    ]
+;;
+
+let sdk_io_error_fields = function
+  | Agent_sdk.Error.FileOpFailed { op; path; detail } ->
+    [ "variant", `String "file_op_failed"
+    ; "op", `String op
+    ; "path", `String path
+    ; "detail", `String detail
+    ]
+  | Agent_sdk.Error.ValidationFailed { detail } ->
+    [ "variant", `String "validation_failed"; "detail", `String detail ]
+;;
+
+let sdk_orchestration_error_fields = function
+  | Agent_sdk.Error.UnknownAgent { name } ->
+    [ "variant", `String "unknown_agent"; "name", `String name ]
+  | Agent_sdk.Error.TaskTimeout { task_id } ->
+    [ "variant", `String "task_timeout"; "task_id", `String task_id ]
+  | Agent_sdk.Error.DiscoveryFailed { url; detail } ->
+    [ "variant", `String "discovery_failed"
+    ; "url", `String url
+    ; "detail", `String detail
+    ]
+;;
+
+let sdk_a2a_error_fields = function
+  | Agent_sdk.Error.TaskNotFound { task_id } ->
+    [ "variant", `String "task_not_found"; "task_id", `String task_id ]
+  | Agent_sdk.Error.InvalidTransition { task_id; from_state; to_state } ->
+    [ "variant", `String "invalid_transition"
+    ; "task_id", `String task_id
+    ; "from_state", `String from_state
+    ; "to_state", `String to_state
+    ]
+  | Agent_sdk.Error.MessageSendFailed { task_id; detail } ->
+    [ "variant", `String "message_send_failed"
+    ; "task_id", `String task_id
+    ; "detail", `String detail
+    ]
+  | Agent_sdk.Error.ProtocolError { detail } ->
+    [ "variant", `String "protocol_error"; "detail", `String detail ]
+  | Agent_sdk.Error.StoreCapacityExceeded { current; max } ->
+    [ "variant", `String "store_capacity_exceeded"
+    ; "current", `Int current
+    ; "max", `Int max
+    ]
+;;
+
+let sdk_provider_error_fields error =
+  let message = Llm_provider.Error.to_string error in
+  match error with
+  | Llm_provider.Error.MissingApiKey { var_name } ->
+    [ "variant", `String "missing_api_key"
+    ; "message", `String message
+    ; "var_name", `String var_name
+    ]
+  | Llm_provider.Error.InvalidConfig { field; detail } ->
+    [ "variant", `String "invalid_config"
+    ; "message", `String message
+    ; "field", `String field
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.ParseError { detail } ->
+    [ "variant", `String "parse_error"
+    ; "message", `String message
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.UnknownVariant { type_name; value } ->
+    [ "variant", `String "unknown_variant"
+    ; "message", `String message
+    ; "type_name", `String type_name
+    ; "value", `String value
+    ]
+  | Llm_provider.Error.ProviderUnavailable { provider; detail } ->
+    [ "variant", `String "provider_unavailable"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.RateLimit { provider; retry_after; detail } ->
+    [ "variant", `String "rate_limited"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "retry_after_s", Json_util.float_opt_to_json retry_after
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.HardQuota { provider; retry_after; detail } ->
+    [ "variant", `String "hard_quota"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "retry_after_s", Json_util.float_opt_to_json retry_after
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.CapacityExhausted
+      { scope; affected; retry_after; detail } ->
+    [ "variant", `String "capacity_backpressure"
+    ; "message", `String message
+    ; "capacity_scope", `String (Llm_provider.Error.capacity_scope_to_string scope)
+    ; "affected", Json_util.json_string_list affected
+    ; "retry_after_s", Json_util.float_opt_to_json retry_after
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.AuthError { provider; detail } ->
+    [ "variant", `String "auth_error"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.ServerError { provider; code; transient; detail } ->
+    [ "variant", `String "server_error"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "status", `Int code
+    ; "transient", `Bool transient
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.NetworkError
+      { provider; kind; timeout_phase; detail } ->
+    [ "variant", `String "network_error"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "network_kind", `String (network_error_kind_to_wire kind)
+    ; ( "timeout_phase"
+      , match timeout_phase with
+        | Some phase -> `String (Llm_provider.Http_client.timeout_phase_to_label phase)
+        | None -> `Null )
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.Timeout { provider; timeout_phase; detail } ->
+    [ "variant", `String "timeout"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; ( "timeout_phase"
+      , match timeout_phase with
+        | Some phase -> `String (Llm_provider.Http_client.timeout_phase_to_label phase)
+        | None -> `Null )
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.InvalidRequest { provider; reason } ->
+    [ "variant", `String "invalid_request"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "reason", `String reason
+    ]
+  | Llm_provider.Error.NotFound { provider; detail } ->
+    [ "variant", `String "not_found"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "detail", `String detail
+    ]
+  | Llm_provider.Error.ProviderTerminal { provider; reason; detail } ->
+    [ "variant", `String "provider_terminal"
+    ; "message", `String message
+    ; "provider", `String provider
+    ; "reason", `String reason
+    ; "detail", `String detail
+    ]
+;;
+
+let sdk_error_detail_fields (error : Agent_sdk.Error.sdk_error) =
+  match error with
+  | Agent_sdk.Error.Api error -> sdk_api_error_fields error
+  | Agent_sdk.Error.Provider error -> sdk_provider_error_fields error
+  | Agent_sdk.Error.Agent error -> sdk_agent_error_fields error
+  | Agent_sdk.Error.Mcp error -> sdk_mcp_error_fields error
+  | Agent_sdk.Error.Config error -> sdk_config_error_fields error
+  | Agent_sdk.Error.Serialization error -> sdk_serialization_error_fields error
+  | Agent_sdk.Error.Io error -> sdk_io_error_fields error
+  | Agent_sdk.Error.Orchestration error -> sdk_orchestration_error_fields error
+  | Agent_sdk.Error.A2a error -> sdk_a2a_error_fields error
+  | Agent_sdk.Error.Internal message ->
+    [ "variant", `String "internal"; "message", `String message ]
+;;
+
+let sdk_error_json error =
+  let domain = Keeper_agent_error.sdk_error_kind error in
+  let code =
+    Keeper_agent_error.terminal_reason_code_of_sdk_error_typed error
+    |> Keeper_turn_terminal_code.to_wire
+  in
+  `Assoc
+    ([ "domain", `String domain
+     ; "code", `String code
+     ; "retryable", `Bool (Agent_sdk.Error.is_retryable error)
+     ]
+     @ sdk_error_detail_fields error)
+;;
+
+let agent_failed_error_fields error =
+  [ "error", `String (Agent_sdk.Error.to_string error)
+  ; "error_domain", `String (Keeper_agent_error.sdk_error_kind error)
+  ; ( "error_code"
+    , `String
+        (Keeper_agent_error.terminal_reason_code_of_sdk_error_typed error
+         |> Keeper_turn_terminal_code.to_wire) )
+  ; "error_retryable", `Bool (Agent_sdk.Error.is_retryable error)
+  ; "error_detail", sdk_error_json error
+  ]
+;;

--- a/lib/keeper/keeper_event_bridge_error_json.mli
+++ b/lib/keeper/keeper_event_bridge_error_json.mli
@@ -1,0 +1,9 @@
+(** JSON field builders for OAS agent completion/failure SSE events. *)
+
+val agent_completed_result_fields
+  :  (Agent_sdk.Types.api_response, Agent_sdk.Error.sdk_error) result
+  -> (string * Yojson.Safe.t) list
+
+val agent_failed_error_fields
+  :  Agent_sdk.Error.sdk_error
+  -> (string * Yojson.Safe.t) list

--- a/lib/keeper/keeper_event_bridge_inference.ml
+++ b/lib/keeper/keeper_event_bridge_inference.ml
@@ -1,0 +1,74 @@
+(* RFC-0166: the previous body of [inference_model_bucket] was a
+   substring classifier over upstream LLM provider names
+   ("provider_c"/"agent_llm_a"/"provider_d"/"provider_f"/"provider_k"/"provider_h"/"llama"). The
+   server-side enumeration is removed: histogram label cardinality
+   becomes 1 ("upstream") rather than a closed enum of providers.
+   Per-provider partitioning, if needed, is now the dashboard's
+   responsibility against the raw [provider] / [model] fields in
+   the event payload, not a server-coded bucket. *)
+let inference_model_bucket ~provider:_ ~model:_ = "upstream"
+
+let inference_provider_bucket ~provider ~model:_ =
+  let provider = String.trim provider in
+  if provider = "" then "upstream" else provider
+;;
+
+let positive_finite value =
+  value > 0.0
+  &&
+  match classify_float value with
+  | FP_nan | FP_infinite -> false
+  | FP_normal | FP_subnormal | FP_zero -> true
+;;
+
+let tok_per_sec_from_ms ~tokens ~ms =
+  match tokens, ms with
+  | Some tokens, Some ms when tokens > 0 && positive_finite ms ->
+    Some (float_of_int tokens /. (ms /. 1000.0))
+  | _ -> None
+;;
+
+let observe_inference_rate metric ~model_bucket = function
+  | Some rate when positive_finite rate ->
+    Prometheus.observe_histogram metric ~labels:[ "model_bucket", model_bucket ] rate
+  | _ -> ()
+;;
+
+let observe_inference_telemetry
+      ~provider
+      ~model
+      ~prompt_tokens
+      ~completion_tokens
+      ~prompt_ms
+      ~decode_ms
+      ~decode_tok_s
+  =
+  let model_bucket = inference_model_bucket ~provider ~model in
+  (* Token counts are NOT emitted here.  The authoritative per-request
+     token counter is [on_token_usage] -> [Llm_metric_bridge.emit_token_usage]
+     with precise {provider, model} labels.  This function retains only
+     the latency/rate metrics (prompt_tok/s, decode_tok/s) that are
+     unique to the [InferenceTelemetry] event payload. *)
+  observe_inference_rate
+    Prometheus.metric_oas_inference_prompt_tok_per_sec
+    ~model_bucket
+    (tok_per_sec_from_ms ~tokens:prompt_tokens ~ms:prompt_ms);
+  let decode_tok_s =
+    match decode_tok_s with
+    | Some rate when positive_finite rate -> Some rate
+    | _ -> tok_per_sec_from_ms ~tokens:completion_tokens ~ms:decode_ms
+  in
+  observe_inference_rate
+    Prometheus.metric_oas_inference_decode_tok_per_sec
+    ~model_bucket
+    decode_tok_s
+;;
+
+let observe_inference_cost ~provider ~model_bucket = function
+  | Some cost when positive_finite cost ->
+    Prometheus.observe_histogram
+      Prometheus.metric_oas_inference_cost_usd
+      ~labels:[ "provider", provider; "model_bucket", model_bucket ]
+      cost
+  | _ -> ()
+;;

--- a/lib/keeper/keeper_event_bridge_inference.mli
+++ b/lib/keeper/keeper_event_bridge_inference.mli
@@ -1,0 +1,16 @@
+val inference_model_bucket : provider:string -> model:string -> string
+
+val inference_provider_bucket : provider:string -> model:string -> string
+
+val observe_inference_telemetry :
+  provider:string ->
+  model:string ->
+  prompt_tokens:int option ->
+  completion_tokens:int option ->
+  prompt_ms:float option ->
+  decode_ms:float option ->
+  decode_tok_s:float option ->
+  unit
+
+val observe_inference_cost :
+  provider:string -> model_bucket:string -> float option -> unit

--- a/lib/keeper/keeper_event_publisher.ml
+++ b/lib/keeper/keeper_event_publisher.ml
@@ -1,0 +1,175 @@
+(** MASC Event_bus publishers for runtime events.
+
+    Publishes MASC coordination events (broadcasts, heartbeats, board
+    posts, task transitions, keeper lifecycle, audit) to the MASC-owned
+    Event_bus. Events follow dot-separated snake_case naming per OAS
+    Custom-name convention: [masc.broadcast], [masc.heartbeat],
+    [masc.keeper.lifecycle], ...
+
+    Every publish routes to [Masc_event_bus.get ()] so the OAS/MASC
+    layer boundary is preserved. OAS's [event_bus.mli:103-107]
+    explicitly warns against publishing domain events onto OAS's bus.
+
+    Wire format on SSE output keeps colon separators ("masc.broadcast")
+    for dashboard compatibility — the translation is done by the SSE
+    relay, not here.
+
+    @since 2.90.0 (bus-separated since 2.353.0) *)
+
+(* Route every publish to the MASC-owned bus. This closes the OAS boundary
+   violation where MASC was publishing Custom("masc:...") onto OAS's shared
+   bus. *)
+let masc_publish event =
+  match Masc_event_bus.get () with
+  | Some mb -> Agent_sdk_metrics_bridge.publish mb event
+  | None -> ()
+
+(** Publish a broadcast event to the shared Event_bus. *)
+let publish_broadcast ~agent_name ~content =
+  let payload = `Assoc [
+    ("agent_name", `String agent_name);
+    ("content", `String content);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.broadcast", payload)))
+
+(** Publish a heartbeat event to the shared Event_bus. *)
+let publish_heartbeat ~agent_name ~turn ~context_pct =
+  let payload = `Assoc [
+    ("agent_name", `String agent_name);
+    ("turn", `Int turn);
+    ("context_pct", `Float context_pct);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.heartbeat", payload)))
+
+(** Publish a task state change event to the shared Event_bus.
+    #8605 family: [transition] is the canonical [Masc_domain.task_action]
+    variant -- typos at call sites fail to compile. JSON wire format
+    ("claim" / "start" / "done" / ...) is preserved via
+    [Masc_domain.task_action_to_string]. Sibling refactor of #8846 (the
+    Coord-side hook for the same transition vocabulary). *)
+let publish_task_transition ~agent_name ~task_id
+    ~(transition : Masc_domain.task_action) =
+  let payload = `Assoc [
+    ("agent_name", `String agent_name);
+    ("task_id", `String task_id);
+    ("transition", `String (Masc_domain.task_action_to_string transition));
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.task_transition", payload)))
+
+(** {1 Keeper Snapshot Events} *)
+
+(** Publish a keeper snapshot event to the OAS Event_bus.
+    Emitted alongside SSE broadcast in keeper_keepalive. *)
+let publish_keeper_snapshot ~keeper_name
+    ~generation ~context_ratio ~message_count =
+  let payload = `Assoc [
+    ("keeper_name", `String keeper_name);
+    ("generation", `Int generation);
+    ("context_ratio", `Float context_ratio);
+    ("message_count", `Int message_count);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc.keeper.snapshot", payload)))
+
+(** {1 Keeper Lifecycle Events} *)
+
+(** Publish a keeper keepalive lifecycle event.
+
+    Event names are pinned by
+    {!Keeper_lifecycle_events.all_event_names}, which covers both the
+    custom verbs (\[started\] / \[reconciled\] / \[restarted\] /
+    \[dead_cleaned\] / \[self_preservation\] / \[paused_pruned\]) and
+    the phase-derived names (\[stopped\] / \[crashed\] / \[dead\] /
+    \[running\]).
+
+    Issue #8575: the previous docstring listed only five names, so
+    operators silently missed the cleanup and self-healing events
+    (\[reconciled\] / \[dead_cleaned\] / \[self_preservation\] /
+    \[paused_pruned\] / \[admission_denied\]) — exactly the events that signal supervisor
+    recovery actions where observability matters most. Subscribe to
+    {!Keeper_lifecycle_events.all_event_names} to receive the full
+    stream; the sync test in [test_types.ml ::
+    lifecycle_events_ssot] asserts every literal still emitted by
+    [Keeper_supervisor] / [Keeper_keepalive] lives in the SSOT. *)
+(* #8856 / #8605 family: [event] is now the unified
+   [Keeper_lifecycle_events.lifecycle_event] variant -- typos at the
+   16 supervisor/keepalive call sites fail to compile. JSON wire
+   format ("event" + optional "phase" field) is preserved
+   bit-identically:
+     - Custom_event { verb; phase = None }  -> event=verb, phase=null
+     - Custom_event { verb; phase = Some p } -> event=verb, phase=p
+     - Phase_event p                          -> event=p, phase=p
+   The legacy ?phase optional argument is folded into the variant. *)
+let publish_keeper_lifecycle
+    ~(event : Keeper_lifecycle_events.lifecycle_event)
+    ~keeper_name ~detail () =
+  let phase_json =
+    match Keeper_lifecycle_events.lifecycle_event_phase event with
+    | Some phase ->
+      `String (Keeper_state_machine.phase_to_string phase)
+    | None -> `Null
+  in
+  let event_str = Keeper_lifecycle_events.lifecycle_event_to_string event in
+  let payload = `Assoc [
+    ("event", `String event_str);
+    ("keeper_name", `String keeper_name);
+    ("phase", phase_json);
+    ("detail", `String detail);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc.keeper.lifecycle", payload)))
+
+(** Publish a structured keeper-Dead event.
+
+    Emitted when [Keeper_supervisor.sweep_and_recover] gives up on a keeper
+    after [restart_count >= max_restarts]. Operators should treat this as
+    actionable: the supervisor will NOT retry the keeper. Independent from
+    the [event="dead"] entry on [masc.keeper.lifecycle] (which is unstructured
+    free-form [detail]) so subscribers can filter on a stable topic and pull
+    the structured fields directly. Topic: [masc.keeper.dead]. *)
+let publish_keeper_dead
+    ~keeper_name ~reason ~restart_count ~last_failure_reason () =
+  let last_failure_json = Json_util.string_opt_to_json last_failure_reason in
+  let payload = `Assoc [
+    ("keeper_name", `String keeper_name);
+    ("reason", `String reason);
+    ("restart_count", `Int restart_count);
+    ("last_failure_reason", last_failure_json);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc.keeper.dead", payload)))
+
+(** {1 Audit Ledger Events} *)
+
+(** Publish a global audit ledger event to the MASC Event_bus.
+
+    Emitted by [Audit_log.log_action] after each entry is persisted,
+    giving dashboard clients a real-time stream of audit events via
+    SSE without polling.  Wire event name: [masc.audit_event].
+
+    The shape mirrors the O2 spec: [{id, ts, actor, kind, target,
+    summary, severity, payload}]. *)
+let publish_audit_event ~id ~ts ~actor ~kind ?target ~summary ~severity
+    ?payload () =
+  let target_json = Json_util.string_opt_to_json target in
+  let payload_json = match payload with
+    | Some p -> p
+    | None -> `Null
+  in
+  let event_payload = `Assoc [
+    ("id", `String id);
+    ("ts", `String ts);
+    ("actor", `String actor);
+    ("kind", `String kind);
+    ("target", target_json);
+    ("summary", `String summary);
+    ("severity", `String severity);
+    ("payload", payload_json);
+  ] in
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.audit_event", event_payload)))

--- a/lib/keeper/keeper_event_publisher.mli
+++ b/lib/keeper/keeper_event_publisher.mli
@@ -1,0 +1,131 @@
+(** Keeper_event_publisher — MASC Event_bus publishers for runtime events.
+
+    Publishes MASC coordination events (broadcasts, heartbeats,
+    board posts, task transitions, keeper lifecycle, audit) to the
+    **MASC-owned** Event_bus.  Events follow dot-separated
+    snake_case naming per OAS Custom-name convention:
+    [masc.broadcast], [masc.heartbeat], [masc.keeper.lifecycle],
+    ...
+
+    Every publish routes to {!Masc_event_bus.get} so the OAS/MASC
+    layer boundary is preserved.  OAS's [event_bus.mli:103-107]
+    explicitly warns against publishing domain events onto OAS's bus.
+
+    Wire format on SSE output keeps colon separators
+    ([masc.broadcast]) for dashboard compatibility — translation
+    is done by the SSE relay, not here.
+
+    @since 2.90.0 (bus-separated since 2.353.0) *)
+
+(** {1 Active publishers} *)
+
+val publish_broadcast :
+  agent_name:string -> content:string -> unit
+(** Publishes [masc.broadcast] with payload
+    [{agent_name, content, timestamp}]. *)
+
+val publish_heartbeat :
+  agent_name:string ->
+  turn:int ->
+  context_pct:float ->
+  unit
+(** Publishes [masc.heartbeat] with payload
+    [{agent_name, turn, context_pct, timestamp}]. *)
+
+val publish_task_transition :
+  agent_name:string ->
+  task_id:string ->
+  transition:Masc_domain.task_action ->
+  unit
+(** Publishes [masc.task_transition] with payload
+    [{agent_name, task_id, transition, timestamp}].
+
+    [transition] is the canonical {!Masc_domain.task_action} variant
+    (#8605 family) — typos at call sites fail to compile.
+    Wire format ([["claim"]] / [["start"]] / [["done"]] / ...)
+    preserved via {!Masc_domain.task_action_to_string}.  Sibling
+    refactor of #8846 (Coord-side hook for the same transition
+    vocabulary). *)
+
+(** {1 Keeper snapshot + lifecycle} *)
+
+val publish_keeper_snapshot :
+  keeper_name:string ->
+  generation:int ->
+  context_ratio:float ->
+  message_count:int ->
+  unit
+(** Publishes [masc.keeper.snapshot] with payload
+    [{keeper_name, generation, context_ratio, message_count, timestamp}].
+    Emitted alongside SSE broadcast in [keeper_keepalive]. *)
+
+val publish_keeper_lifecycle :
+  event:Keeper_lifecycle_events.lifecycle_event ->
+  keeper_name:string ->
+  detail:string ->
+  unit ->
+  unit
+(** Publishes [masc.keeper.lifecycle] with payload
+    [{event, keeper_name, phase, detail, timestamp}].
+
+    [event] is the unified
+    {!Keeper_lifecycle_events.lifecycle_event} variant (#8856
+    / #8605 family) — typos at the 16 supervisor / keepalive
+    call sites fail to compile.
+
+    {2 Wire format pinned}
+
+    JSON wire format preserved bit-identically across the
+    variant unification:
+    - [Custom_event { verb; phase = None }] → [event=verb], [phase=null]
+    - [Custom_event { verb; phase = Some p }] → [event=verb], [phase=p]
+    - [Phase_event p] → [event=p], [phase=p]
+
+    Subscribe to {!Keeper_lifecycle_events.all_event_names} to
+    receive the full stream.  Issue #8575: prior docstring
+    listed only five names, so operators silently missed
+    cleanup / self-healing events ([reconciled],
+    [dead_cleaned], [self_preservation], [paused_pruned]) —
+    exactly the events that signal supervisor recovery actions
+    where observability matters most. *)
+
+val publish_keeper_dead :
+  keeper_name:string ->
+  reason:string ->
+  restart_count:int ->
+  last_failure_reason:string option ->
+  unit ->
+  unit
+(** Publishes [masc.keeper.dead] with payload
+    [{keeper_name, reason, restart_count, last_failure_reason, timestamp}].
+
+    Emitted when {!Keeper_supervisor.sweep_and_recover} gives
+    up on a keeper after [restart_count >= max_restarts].
+    Operators should treat this as actionable: the supervisor
+    will NOT retry the keeper.
+
+    Independent from the [event="dead"] entry on
+    [masc.keeper.lifecycle] (which is unstructured free-form
+    [detail]) so subscribers can filter on a stable topic and
+    pull the structured fields directly. *)
+
+(** {1 Audit Ledger Events} *)
+
+val publish_audit_event :
+  id:string ->
+  ts:string ->
+  actor:string ->
+  kind:string ->
+  ?target:string ->
+  summary:string ->
+  severity:string ->
+  ?payload:Yojson.Safe.t ->
+  unit ->
+  unit
+(** Publishes [masc.audit_event] to the MASC Event_bus.
+
+    Emitted by {!Audit_log.log_action} after each entry is persisted.
+    Dashboard clients receive a real-time stream of global audit events
+    via SSE without polling.
+
+    Shape: [{id, ts, actor, kind, target?, summary, severity, payload?}]. *)

--- a/lib/keeper/keeper_observation.ml
+++ b/lib/keeper/keeper_observation.ml
@@ -1,0 +1,731 @@
+(** Keeper_observation — Cascade metrics types, observation building, and recording.
+
+    Tracks per-cascade call counts, model selection distribution, fallback
+    hops, and per-attempt latency/error detail. Aggregate counters stay
+    in-process (mutable Hashtbl), while per-call observations are also
+    appended to a dated JSONL audit log under [.masc/cascade_audit].
+
+    @since God file decomposition — extracted from oas_worker.ml *)
+
+(* ================================================================ *)
+(* Cascade types                                                     *)
+(* ================================================================ *)
+
+type cascade_observation = {
+  cascade_name : Cascade_name.t;
+  strategy : string option;
+  configured_labels : string list;
+  candidate_models : string list;
+  primary_model : string option;
+  selected_model : string option;
+  selected_model_raw : string option;
+  selected_index : int option;
+  fallback_hops : int option;
+  fallback_applied : bool;
+  attempts : cascade_attempt list;
+  fallback_events : cascade_fallback_event list;
+  attempt_details_available : bool;
+  attempt_details_source : string;
+  oas_internal_cascade_allowed : bool;
+}
+
+and cascade_attempt = {
+  attempt_index : int;
+  model_id : string;
+  model_label : string option;
+  latency_ms : int option;
+  error : string option;
+}
+
+and cascade_fallback_event = {
+  from_model_id : string;
+  from_model_label : string option;
+  to_model_id : string;
+  to_model_label : string option;
+  reason : string;
+}
+
+module StringMap = Set_util.StringMap
+
+(* RFC-0132 PR-2: cascade observation OAS/dashboard surface = external boundary; redact via SSOT. *)
+let public_runtime_model_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
+
+type cascade_counter = {
+  calls : int;
+  successes : int;
+  failures : int;
+  rejected : int;
+  fallback_calls : int;
+  total_attempts : int;
+  total_fallback_events : int;
+  last_selected_model : string option;
+  last_selected_index : int option;
+  last_candidate_models : string list;
+  last_attempts : cascade_attempt list;
+  last_fallback_events : cascade_fallback_event list;
+  last_attempt_details_available : bool;
+  last_attempt_details_source : string option;
+  last_used_at : float;
+  selected_models : int StringMap.t;
+  attempted_models : int StringMap.t;
+  errored_models : int StringMap.t;
+}
+
+let cascade_max_keys = 256
+
+let create_cascade_counter ~now () =
+  {
+    calls = 0;
+    successes = 0;
+    failures = 0;
+    rejected = 0;
+    fallback_calls = 0;
+    total_attempts = 0;
+    total_fallback_events = 0;
+    last_selected_model = None;
+    last_selected_index = None;
+    last_candidate_models = [];
+    last_attempts = [];
+    last_fallback_events = [];
+    last_attempt_details_available = false;
+    last_attempt_details_source = None;
+    last_used_at = now;
+    selected_models = StringMap.empty;
+    attempted_models = StringMap.empty;
+    errored_models = StringMap.empty;
+  }
+
+type cascade_eviction = {
+  name : string;
+  calls : int;
+  last_used_at : float;
+}
+
+let find_cascade_eviction_candidate counters =
+  StringMap.fold
+    (fun name (counter : cascade_counter) best ->
+      match best with
+      | None ->
+          Some { name; calls = counter.calls; last_used_at = counter.last_used_at }
+      | Some current ->
+          if counter.calls < current.calls
+             || (counter.calls = current.calls
+                 && counter.last_used_at < current.last_used_at)
+          then
+            Some
+              { name; calls = counter.calls; last_used_at = counter.last_used_at }
+          else
+            best)
+    counters None
+
+
+(* ================================================================ *)
+(* Provider label helpers                                            *)
+(* ================================================================ *)
+
+(** Map provider_kind to a cascade-label prefix. Delegates to the
+    current OAS registry helper so endpoint-distinct providers track
+    the pinned agent_sdk behavior. The function does not enumerate
+    specific providers; the registry resolves them. *)
+let provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
+  match Agent_sdk.Provider_runtime_binding.binding_for_provider_config cfg with
+  | Some binding -> binding.Agent_sdk.Provider_runtime_binding.id
+  | None -> Llm_provider.Provider_registry.provider_name_of_config cfg
+
+let display_provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
+  provider_name_of_config cfg
+
+let model_label_of_config (cfg : Llm_provider.Provider_config.t) =
+  Printf.sprintf "%s:%s" (display_provider_name_of_config cfg) cfg.model_id
+
+let strip_latest_suffix s =
+  let trimmed = String.trim s in
+  if String.length trimmed > 7
+     && String.sub trimmed (String.length trimmed - 7) 7 = ":latest"
+  then String.sub trimmed 0 (String.length trimmed - 7)
+  else trimmed
+
+(* ================================================================ *)
+(* Observation building                                              *)
+(* ================================================================ *)
+
+let cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
+    ~(candidate_count : int)
+    ~(selected_model_raw : string option)
+    ?(attempts = [])
+    ?(fallback_events = [])
+    ?(attempt_details_available = false)
+    ?(attempt_details_source = "opaque_named_cascade")
+    ?(oas_internal_cascade_allowed = false)
+    () : cascade_observation =
+  let candidate_models =
+    List.init (max 0 candidate_count) (fun _ -> public_runtime_model_label)
+  in
+  let primary_model =
+    match candidate_models with first :: _ -> Some first | [] -> None
+  in
+  let selected_index = None in
+  (* Thread the caller-supplied raw model attribution into both fields.
+     Without this, success rows lose model attribution at construction
+     time and downstream consumers (model_inference_metrics
+     parse_telemetry_entry, execution receipts, composite observer)
+     drop the row as Missing_success_model. Public-surface redaction to
+     [public_runtime_model_label] happens at the redacted JSON emitter
+     layer, not at observation construction. *)
+  let selected_model = selected_model_raw in
+  let fallback_hops = Option.map (fun idx -> max 0 idx) selected_index in
+  let fallback_applied =
+    match fallback_hops with
+    | Some hops -> hops > 0
+    | None -> false
+  in
+  {
+    cascade_name;
+    strategy;
+    configured_labels = [];
+    candidate_models;
+    primary_model;
+    selected_model;
+    selected_model_raw;
+    selected_index;
+    fallback_hops;
+    fallback_applied;
+    attempts;
+    fallback_events;
+    attempt_details_available;
+    attempt_details_source;
+    oas_internal_cascade_allowed;
+  }
+
+(* ================================================================ *)
+(* Metrics capture callbacks                                         *)
+(* ================================================================ *)
+
+type cascade_metrics_capture = {
+  mutable next_attempt_index : int;
+  mutable attempts_rev : cascade_attempt list;
+  mutable fallback_events_rev : cascade_fallback_event list;
+}
+
+(* Non-redacted JSON encoders for the internal audit log
+   (cascade_observation_to_json → record_cascade_audit). Sibling fields
+   in the same observation envelope (selected_model, primary_model,
+   candidate_models) are already emitted as real strings; the per-attempt
+   and per-fallback model_id were the only fields collapsed to the
+   [public_runtime] placeholder by #15040. Sibling parity restored.
+
+   The redacted variants for external boundaries (keeper metrics consumed
+   by dashboard/OAS) live in lib/keeper/keeper_unified_metrics.ml as
+   [redacted_cascade_attempt_to_json] etc. and intentionally omit
+   model_id/model_label entirely. Those are not touched here. *)
+let cascade_attempt_to_json (attempt : cascade_attempt) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("attempt_index", `Int attempt.attempt_index);
+      ("model_id", `String attempt.model_id);
+      ("model_label", Json_util.string_opt_to_json attempt.model_label);
+      ("latency_ms", Json_util.int_opt_to_json attempt.latency_ms);
+      ("error", Json_util.string_opt_to_json attempt.error);
+    ]
+
+let cascade_fallback_event_to_json (event : cascade_fallback_event) :
+    Yojson.Safe.t =
+  `Assoc
+    [
+      ("from_model_id", `String event.from_model_id);
+      ("from_model_label", Json_util.string_opt_to_json event.from_model_label);
+      ("to_model_id", `String event.to_model_id);
+      ("to_model_label", Json_util.string_opt_to_json event.to_model_label);
+      ("reason", `String event.reason);
+    ]
+
+let update_first_attempt_if ~predicate ~update attempts_rev =
+  let rec loop = function
+    | [] -> None
+    | attempt :: rest ->
+        if predicate attempt then Some (update attempt :: rest)
+        else Option.map (fun rest' -> attempt :: rest') (loop rest)
+  in
+  loop attempts_rev
+
+let record_attempt_start (capture : cascade_metrics_capture) ~model_id:_ =
+  let attempt_index = capture.next_attempt_index in
+  capture.next_attempt_index <- capture.next_attempt_index + 1;
+  capture.attempts_rev <-
+    {
+      attempt_index;
+      model_id = public_runtime_model_label;
+      model_label = None;
+      latency_ms = None;
+      error = None;
+    }
+    :: capture.attempts_rev
+
+(** [cascade_attempt_terminal_event_json] builds the structured details payload
+    emitted to system_log when a cascade candidate reaches its terminal state
+    (success: latency_ms set, error none; failure: error set). The shape is the
+    contract for downstream log analysers and external operators looking for
+    "why did the cascade exhaust" signals. Errors are recorded verbatim — no
+    string-based classification at this layer (see #12817 spirit and the
+    project memory rule "no string matching for classification"). *)
+let cascade_attempt_terminal_event_json ?slot_release_at_phase
+    ?productive_phase_elapsed_ms ?retry_phase_elapsed_ms ~model_id:_
+    ~model_label:_
+    ~latency_ms ~error () =
+  let outcome = if Option.is_some error then "failure" else "success" in
+  `Assoc
+    [
+      ("event", `String "cascade_attempt_terminal");
+      ("model_id", `String public_runtime_model_label);
+      ("model_label", `Null);
+      ( "latency_ms", Json_util.int_opt_to_json latency_ms );
+      ("outcome", `String outcome);
+      ( "error_message", Json_util.string_opt_to_json error );
+      ( "slot_release_at_phase", Json_util.string_opt_to_json slot_release_at_phase );
+      ( "productive_phase_elapsed_ms", Json_util.int_opt_to_json productive_phase_elapsed_ms );
+      ( "retry_phase_elapsed_ms", Json_util.int_opt_to_json retry_phase_elapsed_ms );
+    ]
+
+let log_cascade_attempt_terminal ~model_id ~model_label ~latency_ms ~error =
+  let outcome = if Option.is_some error then "failure" else "success" in
+  let details =
+    cascade_attempt_terminal_event_json ~model_id ~model_label ~latency_ms
+      ~error ()
+  in
+  let summary =
+    Printf.sprintf
+      "cascade candidate terminal: model=%s outcome=%s latency_ms=%s"
+      public_runtime_model_label outcome
+      (match latency_ms with Some n -> string_of_int n | None -> "n/a")
+  in
+  Log.Telemetry.emit Log.Info ~details summary
+
+let ensure_terminal_attempt (capture : cascade_metrics_capture)
+    ~model_id:_ ~(latency_ms : int option) ~(error : string option) =
+  let model_id = public_runtime_model_label in
+  let is_open attempt =
+    String.equal attempt.model_id model_id
+    && Option.is_none attempt.latency_ms
+    && Option.is_none attempt.error
+  in
+  let update attempt = { attempt with latency_ms; error } in
+  let model_label = None in
+  (match update_first_attempt_if ~predicate:is_open ~update capture.attempts_rev with
+  | Some attempts_rev -> capture.attempts_rev <- attempts_rev
+  | None ->
+      let attempt_index = capture.next_attempt_index in
+      capture.next_attempt_index <- capture.next_attempt_index + 1;
+      capture.attempts_rev <-
+        {
+          attempt_index;
+          model_id;
+          model_label;
+          latency_ms;
+          error;
+        }
+        :: capture.attempts_rev);
+  log_cascade_attempt_terminal ~model_id ~model_label ~latency_ms ~error
+
+let record_attempt_terminal = ensure_terminal_attempt
+
+let record_fallback_event (capture : cascade_metrics_capture)
+    ~from_model:_ ~to_model:_ ~(reason : string) =
+  capture.fallback_events_rev <-
+    {
+      from_model_id = public_runtime_model_label;
+      from_model_label = None;
+      to_model_id = public_runtime_model_label;
+      to_model_label = None;
+      reason;
+    }
+    :: capture.fallback_events_rev
+
+let cascade_metrics_for_candidates ~candidate_count:(_ : int) () =
+  let capture =
+    { next_attempt_index = 0; attempts_rev = []; fallback_events_rev = [] }
+  in
+  let metrics =
+    Oas_compat.Metrics.make
+      ~on_cache_hit:(fun ~model_id ->
+        Llm_metric_bridge.emit_cache_hit ~model_id)
+      ~on_cache_miss:(fun ~model_id ->
+        Llm_metric_bridge.emit_cache_miss ~model_id)
+      ~on_request_start:(fun ~model_id ->
+        record_attempt_start capture ~model_id;
+        Llm_metric_bridge.emit_request_start ~model_id)
+      ~on_request_end:(fun ~model_id ~latency_ms ->
+        ensure_terminal_attempt capture ~model_id ~latency_ms ~error:None;
+        (* Forward to Prometheus so per-model latency is visible on
+           the dashboard. Without this, the cascade capture records
+           latency internally but never exports it — the global
+           Llm_metric_bridge sink is not consulted because this
+           per-call metrics object takes precedence. *)
+        match latency_ms with
+        | Some latency_ms ->
+            Llm_metric_bridge.emit_request_latency ~model_id ~latency_ms ()
+        | None -> ())
+      ~on_error:(fun ~model_id ~error ->
+        ensure_terminal_attempt capture ~model_id ~latency_ms:None
+          ~error:(Some error);
+        Llm_metric_bridge.emit_error ~model_id ~error)
+      ~on_capability_drop:(fun ~model_id ~field ->
+        (* The explicit cascade metrics object bypasses the global
+           Llm_metric_bridge sink, so capability-drop telemetry must be
+           forwarded here just like latency and HTTP status. *)
+        Llm_metric_bridge.emit_capability_drop ~model_id ~field)
+      ~on_http_status:(fun ~provider ~model_id ~status ->
+        (* Forward HTTP status to the Prometheus counter. When callers
+           pass this per-call metrics sink explicitly (cascade
+           observation path), OAS does not consult the global
+           Llm_metric_bridge sink, so we must re-emit here to avoid
+           blackholing provider counters for captured turns.
+           Delegating to [Llm_metric_bridge.emit_http_status] keeps
+           the label shape a single source of truth. *)
+        Llm_metric_bridge.emit_http_status ~provider ~model_id ~status)
+      ~on_circuit_state:(fun ~provider ~model_id ~provider_key ~state ->
+        Llm_metric_bridge.emit_circuit_state ~provider ~model_id ~provider_key
+          ~state)
+      ~on_retry:(fun ~provider ~model_id ~attempt ->
+        Llm_metric_bridge.emit_retry ~provider ~model_id ~attempt)
+      ~on_token_usage:(fun ~provider ~model_id ~input_tokens ~output_tokens ->
+        Llm_metric_bridge.emit_token_usage
+          ~provider ~model_id ~input_tokens ~output_tokens)
+      ~on_tool_calls:(fun ~provider ~model_id ~count ->
+        Llm_metric_bridge.emit_tool_calls ~provider ~model_id ~count)
+      ()
+  in
+  (capture, metrics)
+
+let cascade_observation_with_metrics ~cascade_name ?strategy ~configured_labels
+    ~(candidate_count : int)
+    ~(selected_model_raw : string option) ~(capture : cascade_metrics_capture)
+    ?(oas_internal_cascade_allowed = false)
+    () =
+  cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
+    ~candidate_count ~selected_model_raw
+    ~attempts:(List.rev capture.attempts_rev)
+    ~fallback_events:(List.rev capture.fallback_events_rev)
+    ~attempt_details_available:true
+    ~attempt_details_source:"oas_metrics_callbacks"
+    ~oas_internal_cascade_allowed
+    ()
+
+(* ================================================================ *)
+(* JSON serialization                                                *)
+(* ================================================================ *)
+
+let cascade_observation_to_json (obs : cascade_observation) : Yojson.Safe.t =
+  let cascade_name =
+    Cascade_name.to_string obs.cascade_name
+  in
+  `Assoc
+    [
+      ("cascade_name", `String cascade_name);
+      ("strategy", Json_util.string_opt_to_json obs.strategy);
+      ( "configured_labels",
+        `List (List.map (fun label -> `String label) obs.configured_labels) );
+      ( "candidate_models",
+        `List (List.map (fun label -> `String label) obs.candidate_models) );
+      ("primary_model", Json_util.string_opt_to_json obs.primary_model);
+      ("selected_model", Json_util.string_opt_to_json obs.selected_model);
+      ("selected_model_raw", Json_util.string_opt_to_json obs.selected_model_raw);
+      ("selected_index", Json_util.int_opt_to_json obs.selected_index);
+      ("fallback_hops", Json_util.int_opt_to_json obs.fallback_hops);
+      ("fallback_applied", `Bool obs.fallback_applied);
+      ( "attempts",
+        `List (List.map cascade_attempt_to_json obs.attempts) );
+      ( "fallback_events",
+        `List
+          (List.map cascade_fallback_event_to_json obs.fallback_events) );
+      ("attempt_details_available", `Bool obs.attempt_details_available);
+      ("attempt_details_source", `String obs.attempt_details_source);
+      ("oas_internal_cascade_allowed", `Bool obs.oas_internal_cascade_allowed);
+    ]
+
+let get_cascade_audit_store store_opt =
+  match store_opt with
+  | Some store -> Some store
+  | None ->
+      let base_path = Env_config_core.base_path () in
+      let dir =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "cascade_audit"
+      in
+      (match Dated_jsonl.create ~base_dir:dir () with
+      | store -> Some store
+      | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+      | exception exn ->
+          (* Iter 47: tick counter so audit-subsystem health is
+             observable.  Audit failure here disables the subsystem
+             for the process lifetime — operators need to know. *)
+          Cascade_metrics.on_cascade_audit_failure ~stage:"store_creation";
+          Log.Misc.warn "cascade audit store creation failed: %s"
+            (Printexc.to_string exn);
+          None)
+
+let cascade_outcome_to_string = function
+  | `Success -> "success"
+  | `Failure -> "failure"
+  | `Rejected -> "rejected"
+
+(* Promotes the most-recent fallback event reason as a top-level field for
+   first-class aggregation/alerting (issue #11081).  Last (not first) event
+   is chosen because for terminal Failure/Rejected outcomes the final event's
+   reason is the actual cause of exhaustion; the first event reflects only
+   the initial fallback trigger.  Empty list -> null. *)
+let top_level_reason_of_observation (observation : cascade_observation option) =
+  match observation with
+  | None -> `Null
+  | Some obs ->
+      (match List.rev obs.fallback_events with
+      | last :: _ -> `String last.reason
+      | [] -> `Null)
+
+let keeper_name_to_json keeper_name =
+  match keeper_name with
+  | Some name when String.trim name <> "" -> `String name
+  | _ -> `Null
+
+let cascade_audit_json ~now ~keeper_name ~cascade_name ~observation ~outcome =
+  let cascade_name =
+    Cascade_name.to_string cascade_name
+  in
+  `Assoc
+    [
+      ("ts", `Float now);
+      ("keeper_name", keeper_name_to_json keeper_name);
+      ("cascade_name", `String cascade_name);
+      ("outcome", `String (cascade_outcome_to_string outcome));
+      ("top_level_reason", top_level_reason_of_observation observation);
+      ( "observation",
+        match observation with
+        | Some obs -> cascade_observation_to_json obs
+        | None -> `Null );
+    ]
+
+let record_cascade_audit store_opt ~now ~keeper_name ~cascade_name ~observation
+    ~outcome =
+  let cascade_name_string =
+    Cascade_name.to_string cascade_name
+  in
+  match store_opt with
+  | None -> ()
+  | Some store ->
+      (try
+         Dated_jsonl.append store
+           (cascade_audit_json ~now ~keeper_name ~cascade_name ~observation
+              ~outcome)
+       with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+          (* Iter 47: tick counter per-record append failure rate
+             alertable.  Single-event audit loss compounds over
+             time for post-incident analysis. *)
+          Cascade_metrics.on_cascade_audit_failure ~stage:"append";
+          Log.Misc.warn "cascade audit append failed cascade=%s error=%s"
+            cascade_name_string (Printexc.to_string exn))
+
+(* ================================================================ *)
+(* Aggregate metrics recording                                       *)
+(* ================================================================ *)
+
+let increment_counter map key =
+  let count = Option.value ~default:0 (StringMap.find_opt key map) in
+  StringMap.add key (count + 1) map
+
+let distribution_json map =
+  StringMap.fold
+    (fun model count acc ->
+      `Assoc [ ("model", `String model); ("count", `Int count) ] :: acc)
+    map []
+  |> List.sort (fun left right ->
+         let count_of = function
+           | `Assoc fields ->
+               (match List.assoc_opt "count" fields with
+               | Some (`Int count) -> count
+               | _ -> 0)
+           | _ -> 0
+         in
+         Int.compare (count_of right) (count_of left))
+
+let attempt_model_display (attempt : cascade_attempt) =
+  match attempt.model_label with
+  | Some label when String.trim label <> "" -> label
+  | _ -> attempt.model_id
+
+type msg =
+  | Record_cascade of {
+      keeper_name : string option;
+      cascade_name : Cascade_name.t;
+      observation : cascade_observation option;
+      outcome : [ `Success | `Failure | `Rejected ];
+      now : float;
+    }
+  | Get_metrics_json of Yojson.Safe.t Eio.Promise.u
+  | Reset_counters_for_test
+
+type state = {
+  counters : cascade_counter StringMap.t;
+  audit_store : Dated_jsonl.t option;
+}
+
+let stream = Eio.Stream.create 1024
+
+let handle_record state ~now ~keeper_name ~cascade_name ~observation ~outcome =
+  let cascade_name_string =
+    Cascade_name.to_string cascade_name
+  in
+  let counters = state.counters in
+  let counter, counters, evicted =
+    match StringMap.find_opt cascade_name_string counters with
+    | Some c -> (c, counters, None)
+    | None ->
+        let (counters_after_evict, evicted) =
+          if StringMap.cardinal counters >= cascade_max_keys then
+            match find_cascade_eviction_candidate counters with
+            | Some candidate -> (StringMap.remove candidate.name counters, Some candidate)
+            | None -> (counters, None)
+          else (counters, None)
+        in
+        let c = create_cascade_counter ~now () in
+        (c, StringMap.add cascade_name_string c counters_after_evict, evicted)
+  in
+  let counter = { counter with calls = counter.calls + 1; last_used_at = now } in
+  let counter =
+    match observation with
+    | Some obs ->
+        let counter = { counter with
+          last_candidate_models = obs.candidate_models;
+          last_selected_model = obs.selected_model;
+          last_selected_index = obs.selected_index;
+          last_attempts = obs.attempts;
+          last_fallback_events = obs.fallback_events;
+          last_attempt_details_available = obs.attempt_details_available;
+          last_attempt_details_source = Some obs.attempt_details_source;
+          fallback_calls = if obs.fallback_applied then counter.fallback_calls + 1 else counter.fallback_calls;
+          total_attempts = counter.total_attempts + List.length obs.attempts;
+          total_fallback_events = counter.total_fallback_events + List.length obs.fallback_events;
+        } in
+        let counter =
+          match obs.selected_model with
+          | Some model when String.trim model <> "" ->
+              { counter with selected_models = increment_counter counter.selected_models model }
+          | _ -> counter
+        in
+        List.fold_left (fun c attempt ->
+          let model = attempt_model_display attempt in
+          let c = { c with attempted_models = increment_counter c.attempted_models model } in
+          match attempt.error with
+          | Some _ -> { c with errored_models = increment_counter c.errored_models model }
+          | None -> c
+        ) counter obs.attempts
+    | None -> counter
+  in
+  let counter =
+    match outcome with
+    | `Success -> { counter with successes = counter.successes + 1 }
+    | `Failure -> { counter with failures = counter.failures + 1 }
+    | `Rejected -> { counter with rejected = counter.rejected + 1 }
+  in
+  Option.iter
+    (fun candidate ->
+      (* Iter 45: counter ticks on every eviction so the rate is
+         alertable.  WARN log already prints per-eviction detail
+         (cascade name, age, etc.); metric makes rate aggregation
+         tractable. *)
+      Cascade_metrics.on_cascade_metrics_eviction ();
+      Log.Misc.warn
+        "cascade metrics evicted key=%s calls=%d last_used_at=%.3f to admit %s (limit=%d)"
+        candidate.name candidate.calls candidate.last_used_at cascade_name_string
+        cascade_max_keys)
+    evicted;
+  let audit_store_next = get_cascade_audit_store state.audit_store in
+  record_cascade_audit audit_store_next ~now ~keeper_name ~cascade_name
+    ~observation ~outcome;
+  {
+    counters = StringMap.add cascade_name_string counter counters;
+    audit_store = audit_store_next;
+  }
+
+let handle_get_metrics state p =
+  let counters = state.counters in
+  let entries =
+    StringMap.fold
+      (fun name (c : cascade_counter) acc ->
+        let error_rate =
+          if c.calls > 0 then
+            float_of_int (c.failures + c.rejected) /. float_of_int c.calls
+          else
+            0.0
+        in
+        `Assoc
+          [
+            ("cascade_name", `String name);
+            ("calls", `Int c.calls);
+            ("successes", `Int c.successes);
+            ("failures", `Int c.failures);
+            ("rejected", `Int c.rejected);
+            ("fallback_calls", `Int c.fallback_calls);
+            ("total_attempts", `Int c.total_attempts);
+            ("total_fallback_events", `Int c.total_fallback_events);
+            ("last_selected_model", Json_util.string_opt_to_json c.last_selected_model);
+            ("last_selected_index", Json_util.int_opt_to_json c.last_selected_index);
+            ( "last_candidate_models",
+              `List (List.map (fun model -> `String model) c.last_candidate_models) );
+            ( "last_attempts",
+              `List (List.map cascade_attempt_to_json c.last_attempts) );
+            ( "last_fallback_events",
+              `List
+                (List.map cascade_fallback_event_to_json c.last_fallback_events) );
+            ("last_attempt_details_available", `Bool c.last_attempt_details_available);
+            ( "last_attempt_details_source",
+              Json_util.string_opt_to_json c.last_attempt_details_source );
+            ("selected_models", `List (distribution_json c.selected_models));
+            ("attempted_models", `List (distribution_json c.attempted_models));
+            ("errored_models", `List (distribution_json c.errored_models));
+            ("error_rate", `Float error_rate);
+          ]
+        :: acc)
+      counters []
+  in
+  let json = `List
+    (List.sort
+       (fun a b ->
+         let get_calls j = Json_util.get_int j "calls" |> Option.value ~default:0 in
+         Int.compare (get_calls b) (get_calls a))
+       entries)
+  in
+  Eio.Promise.resolve p json
+
+let run_actor () =
+  let rec loop state =
+    match Eio.Stream.take stream with
+    | Record_cascade { keeper_name; cascade_name; observation; outcome; now } ->
+        loop
+          (handle_record state ~now ~keeper_name ~cascade_name ~observation
+             ~outcome)
+    | Get_metrics_json p ->
+        handle_get_metrics state p;
+        loop state
+    | Reset_counters_for_test ->
+        loop { counters = StringMap.empty; audit_store = None }
+  in
+  loop { counters = StringMap.empty; audit_store = None }
+
+let start_actor_if_needed ~sw =
+  Eio.Fiber.fork_daemon ~sw run_actor
+
+let record_cascade ?keeper_name ~observation ~cascade_name ~outcome () =
+  let now = Time_compat.now () in
+  Eio.Stream.add stream
+    (Record_cascade { keeper_name; cascade_name; observation; outcome; now })
+
+let cascade_metrics_json () =
+  let p, u = Eio.Promise.create () in
+  Eio.Stream.add stream (Get_metrics_json u);
+  Eio.Promise.await p
+
+let reset_cascade_counters_for_test () =
+  Eio.Stream.add stream Reset_counters_for_test

--- a/lib/keeper/keeper_observation.mli
+++ b/lib/keeper/keeper_observation.mli
@@ -1,0 +1,226 @@
+(** Keeper_observation — cascade observation, metrics
+    capture, and a single-actor cascade-counter store.
+
+    The .ml splits into two concerns:
+    - {b Cascade observation}: the {!cascade_observation}
+      record + companion attempt / fallback events,
+      built per-turn in {!Keeper_turn_driver} via the
+      {!cascade_metrics_for_candidates} +
+      {!cascade_observation_with_metrics} pair.
+    - {b Cascade audit actor}: a single-fiber consumer
+      ({!start_actor_if_needed}) that drains an
+      [Eio.Stream] of {!record_cascade} /
+      {!record_fallback_event} requests so concurrent
+      callers do not contend on the in-memory counter
+      maps.
+
+    Dotted callers ({!Keeper_observation.X}) and the
+    cascade-include consumer rely on the surface pinned here.
+
+    Internal helpers stay private at this boundary
+    ([cascade_attempt] / [cascade_fallback_event] type
+    bodies (exposed as part of {!cascade_observation}'s
+    [attempts] / [fallback_events] fields with their full
+    record shape),
+    [cascade_counter] type, [StringMap],
+    [cascade_max_keys], [create_cascade_counter],
+    [cascade_eviction] type, [find_cascade_eviction_candidate],
+    [display_provider_name_of_config], [strip_latest_suffix],
+    [cascade_observation_of_candidates],
+    [cascade_attempt_to_json], [cascade_fallback_event_to_json],
+    [update_first_attempt_if], [record_attempt_start],
+    [ensure_terminal_attempt],
+    [cascade_observation_to_json], [get_cascade_audit_store],
+    [cascade_outcome_to_string],
+    [top_level_reason_of_observation],
+    [keeper_name_to_json], [cascade_audit_json],
+    [record_cascade_audit], [increment_counter],
+    [distribution_json], [attempt_model_display],
+    [msg], [state] types, the [stream] queue,
+    [handle_record], [handle_get_metrics], [run_actor],
+    [cascade_metrics_json]). *)
+
+(** {1 Cascade observation types} *)
+
+type cascade_attempt = {
+  attempt_index : int;
+  model_id : string;
+  model_label : string option;
+  latency_ms : int option;
+  error : string option;
+}
+
+type cascade_fallback_event = {
+  from_model_id : string;
+  from_model_label : string option;
+  to_model_id : string;
+  to_model_label : string option;
+  reason : string;
+}
+
+type cascade_observation = {
+  cascade_name : Cascade_name.t;
+  strategy : string option;
+  configured_labels : string list;
+  candidate_models : string list;
+  primary_model : string option;
+  selected_model : string option;
+  selected_model_raw : string option;
+  selected_index : int option;
+  fallback_hops : int option;
+  fallback_applied : bool;
+  attempts : cascade_attempt list;
+  fallback_events : cascade_fallback_event list;
+  attempt_details_available : bool;
+  attempt_details_source : string;
+  oas_internal_cascade_allowed : bool;
+}
+(** Per-turn cascade execution snapshot.  [attempts] is
+    in chronological order (the internal capture stores
+    it reversed and {!cascade_observation_with_metrics}
+    flips it on materialise).  [attempt_details_source]
+    distinguishes the capture path (the canonical
+    [oas_metrics_callbacks] tag vs legacy fallbacks) so
+    operators can tell at-a-glance whether the per-call
+    metrics sink was wired. *)
+
+(** {1 Provider config helpers} *)
+
+val provider_name_of_config :
+  Llm_provider.Provider_config.t -> string
+(** Canonical provider slug from a config. Free-form string used as
+    the cascade counter key; the function does not enumerate
+    specific providers. *)
+
+val model_label_of_config :
+  Llm_provider.Provider_config.t -> string
+(** Canonical [provider:model] label (e.g.
+    ["provider_a:model-a-opus"]).  Compatibility helper for legacy
+    tests and callers; current public attempt/fallback projections use
+    runtime-lane labels instead. *)
+
+(** {1 Cascade metrics capture} *)
+
+type cascade_metrics_capture
+(** Mutable accumulator threaded through OAS's per-call
+    metrics sink to record per-attempt latency / errors
+    and per-fallback events.  Held abstract because
+    callers do not pattern-match on the internal
+    counter / list state — they construct one via
+    {!cascade_metrics_for_candidates}, hand it to OAS
+    through [Oas_compat.Metrics.make], then materialise
+    a {!cascade_observation} via
+    {!cascade_observation_with_metrics}. *)
+
+val cascade_attempt_terminal_event_json :
+  ?slot_release_at_phase:string ->
+  ?productive_phase_elapsed_ms:int ->
+  ?retry_phase_elapsed_ms:int ->
+  model_id:string ->
+  model_label:string option ->
+  latency_ms:int option ->
+  error:string option ->
+  unit ->
+  Yojson.Safe.t
+(** Builds the structured JSON payload emitted to system_log for one
+    cascade candidate's terminal state. Exposed for tests so the shape
+    contract (`event`, `model_id`, `model_label`, `latency_ms`, `outcome`,
+    `error_message`, `slot_release_at_phase`,
+    `productive_phase_elapsed_ms`, `retry_phase_elapsed_ms`) is locked
+    against silent drift; downstream operators grep on these field names
+    when tracing why a cascade exhausted or why a keeper released its turn
+    slot instead of scheduling another degraded retry. *)
+
+val record_attempt_terminal :
+  cascade_metrics_capture ->
+  model_id:string ->
+  latency_ms:int option ->
+  error:string option ->
+  unit
+(** Records one terminal provider attempt in [capture]. This is for
+    named-cascade runners that receive provider-attempt completion
+    directly but cannot thread OAS's per-call metrics sink through the
+    provider invocation path. *)
+
+val cascade_metrics_for_candidates :
+  candidate_count:int ->
+  unit ->
+  cascade_metrics_capture * Llm_provider.Metrics.t
+(** Builds the [(capture, metrics)] pair the per-call
+    metrics path consumes.  Wires
+    [Llm_metric_bridge.emit_request_latency] and
+    [emit_http_status] into the metrics callbacks so the
+    Prometheus dashboard does not blackhole captured
+    turns (the per-call sink takes precedence over the
+    global [Llm_metric_bridge] when both are wired). *)
+
+val cascade_observation_with_metrics :
+  cascade_name:Cascade_name.t ->
+  ?strategy:string ->
+  configured_labels:string list ->
+  candidate_count:int ->
+  selected_model_raw:string option ->
+  capture:cascade_metrics_capture ->
+  ?oas_internal_cascade_allowed:bool ->
+  unit ->
+  cascade_observation
+(** Materialises a {!cascade_observation} from a finished
+    capture.  [attempts] / [fallback_events] are flipped
+    into chronological order;
+    [attempt_details_source] is set to
+    ["oas_metrics_callbacks"] to flag that the per-call
+    metrics path was wired. *)
+
+(** {1 Fallback recorder} *)
+
+val record_fallback_event :
+  cascade_metrics_capture ->
+  from_model:string ->
+  to_model:string ->
+  reason:string ->
+  unit
+(** Appends a fallback event to [capture].  The public event keeps the
+    historical field names but records runtime-lane labels rather than
+    concrete provider/model identities. *)
+
+(** {1 Cascade audit actor} *)
+
+val start_actor_if_needed : sw:Eio.Switch.t -> unit
+(** Spawns the single audit-actor fiber under [sw] if it
+    has not already been started in the current process.
+    Idempotent — a second call is a no-op so the bootstrap
+    paths can call it from multiple entry points. *)
+
+val record_cascade :
+  ?keeper_name:string ->
+  observation:cascade_observation option ->
+  cascade_name:Cascade_name.t ->
+  outcome:[ `Success | `Failure | `Rejected ] ->
+  unit ->
+  unit
+(** Posts a record-cascade message onto the audit stream.
+    The actor consumes it asynchronously, bumping the
+    per-cascade counters and persisting the audit JSON
+    via {!record_cascade_audit}.  Non-blocking — the
+    caller does not wait for the actor to drain. *)
+
+val reset_cascade_counters_for_test : unit -> unit
+(** Posts a reset message onto the stream.  Test-only
+    isolator; no-op outside the actor's lifetime. *)
+
+(** {1 JSON projections (cascade-include consumers)} *)
+
+val cascade_metrics_json : unit -> Yojson.Safe.t
+(** Posts a [Get_metrics_json] request to the actor and
+    waits on the resulting promise.  Returns the
+    aggregated cascade-counter JSON snapshot for the
+    operator dashboard.  Pinned because
+    [lib/oas_worker.mli] re-exposes it via the
+    [include Keeper_observation] cascade. *)
+
+val cascade_observation_to_json :
+  cascade_observation -> Yojson.Safe.t
+(** Wire encoder for {!cascade_observation} — flattens
+    [attempts] / [fallback_events] / outcome metadata
+    into a single [`Assoc].  Pinned because the cascade-
+    include consumer ([oas_worker.mli]) re-exposes it. *)

--- a/lib/keeper/keeper_preflight_health_tracker.ml
+++ b/lib/keeper/keeper_preflight_health_tracker.ml
@@ -1,0 +1,201 @@
+(** Implementation: see [Keeper_preflight_health_tracker.mli] for surface docs.
+
+    Closed sum types only — no catch-all branches in this file. *)
+
+type reason =
+  | Health_check_failed_repeatedly
+  | Permanent_unhealthy
+  | Transient_unhealthy
+  | Rate_limited_long_window
+
+type fingerprint = {
+  cascade_name : string;
+  provider : string;
+  reason : reason;
+}
+
+type record_outcome =
+  [ `First
+  | `Repeated of int
+  | `Threshold_disable of int
+  | `Already_disabled
+  ]
+
+let default_threshold = 5
+
+(** TTL in seconds after which a disabled provider is automatically
+    re-enabled. Prevents permanent cascade death-spiral when the
+    underlying issue (network blip, cold start, rate-limit window)
+    resolves itself (GitHub #18502). *)
+let disabled_ttl_seconds = 600.0
+
+(* Stable kebab-case slug for log interpolation and metric labels. *)
+let reason_slug = function
+  | Health_check_failed_repeatedly -> "health-check-failed-repeatedly"
+  | Permanent_unhealthy -> "permanent-unhealthy"
+  | Transient_unhealthy -> "transient-unhealthy"
+  | Rate_limited_long_window -> "rate-limited-long-window"
+;;
+
+(* Owned metric names. Following the cascade_metrics.ml RFC-0043 pattern
+   (module owns its constants; [Prometheus.ml]'s register_all() may mirror
+   for /metrics endpoint registration later). *)
+let metric_preflight_unhealthy_skip =
+  "masc_cascade_preflight_unhealthy_skip_total"
+;;
+
+let metric_provider_disabled = "masc_cascade_provider_disabled_total"
+let metric_provider_re_enabled = "masc_cascade_provider_re_enabled_total"
+
+(* ── State ──────────────────────────────────────────────────────── *)
+
+(* [Hashtbl] keyed by an opaque triple to avoid string interpolation
+   collisions when cascade_name or provider contain separators. *)
+module Key = struct
+  type t = fingerprint
+
+  let equal (a : t) (b : t) =
+    String.equal a.cascade_name b.cascade_name
+    && String.equal a.provider b.provider
+    && a.reason = b.reason
+  ;;
+
+  let hash (k : t) =
+    Hashtbl.hash (k.cascade_name, k.provider, reason_slug k.reason)
+  ;;
+end
+
+module FpTbl = Hashtbl.Make (Key)
+
+(* Per-provider disabled set membership — separate from fingerprint
+   counts so [is_disabled] is O(1) without scanning all fingerprints. *)
+module StrTbl = Hashtbl.Make (struct
+  type t = string
+
+  let equal = String.equal
+  let hash = Hashtbl.seeded_hash 0
+end)
+
+type t = {
+  counts : int FpTbl.t;
+  disabled : (float * string) StrTbl.t;
+      (** Maps provider → (disabled_at_timestamp, cascade_name).
+          The timestamp enables TTL-based auto-expiry so providers
+          don't stay disabled forever (GitHub #18502). *)
+  mu : Stdlib.Mutex.t;
+      (* Stdlib.Mutex selected per feedback_ocaml5-mutex-selection.md:
+         cross-fiber, single-domain, no Eio effect dependency. The
+         critical section is small (table lookup + counter bump). *)
+  threshold : int;
+}
+
+let create ?(threshold = default_threshold) () =
+  {
+    counts = FpTbl.create 16;
+    disabled = StrTbl.create 8;
+    mu = Stdlib.Mutex.create ();
+    threshold;
+  }
+;;
+
+let global = create ()
+
+let with_lock t f =
+  Stdlib.Mutex.lock t.mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock t.mu) (fun () -> f ())
+;;
+
+(* ── Public API ─────────────────────────────────────────────────── *)
+
+let record ?(clock = Time_compat.now) t ~cascade_name ~provider ~reason : record_outcome =
+  let fp = { cascade_name; provider; reason } in
+  with_lock t (fun () ->
+    (* Always tick the per-call counter so dashboards see absolute
+       skip volume (independent of disable transitions). *)
+    Prometheus.inc_counter metric_preflight_unhealthy_skip
+      ~labels:
+        [ ("cascade", cascade_name)
+        ; ("provider", provider)
+        ; ("reason", reason_slug reason)
+        ]
+      ();
+    if StrTbl.mem t.disabled provider
+    then `Already_disabled
+    else (
+      let prev = FpTbl.find_opt t.counts fp |> Option.value ~default:0 in
+      let next = prev + 1 in
+      FpTbl.replace t.counts fp next;
+      if next = 1
+      then `First
+      else if next >= t.threshold
+      then (
+        StrTbl.replace t.disabled provider (clock (), cascade_name);
+        Prometheus.inc_counter metric_provider_disabled
+          ~labels:
+            [ ("cascade", cascade_name)
+            ; ("provider", provider)
+            ; ("reason", reason_slug reason)
+            ]
+          ();
+        `Threshold_disable next)
+      else `Repeated next))
+;;
+
+let is_disabled ?(clock = Time_compat.now) t ~provider =
+  with_lock t (fun () ->
+    match StrTbl.find_opt t.disabled provider with
+    | None -> false
+    | Some (disabled_at, _cascade_name) ->
+      let age = clock () -. disabled_at in
+      if age >= disabled_ttl_seconds
+      then (
+        (* Auto-expire: provider has been disabled long enough that the
+           underlying issue may have resolved (GitHub #18502). *)
+        StrTbl.remove t.disabled provider;
+        (* Drop all fingerprints so next record starts from First. *)
+        let stale_keys =
+          FpTbl.fold
+            (fun fp _count acc ->
+              if String.equal fp.provider provider then fp :: acc else acc)
+            t.counts
+            []
+        in
+        List.iter (fun fp -> FpTbl.remove t.counts fp) stale_keys;
+        Prometheus.inc_counter metric_provider_re_enabled
+          ~labels:[ ("provider", provider); ("reason", "ttl_auto_expire") ]
+          ();
+        false)
+      else true)
+;;
+
+let reset_on_health_recovery t ~provider =
+  with_lock t (fun () ->
+    let was_disabled = Option.is_some (StrTbl.find_opt t.disabled provider) in
+    StrTbl.remove t.disabled provider;
+    (* Drop all fingerprints for this provider, regardless of reason. *)
+    let stale_keys =
+      FpTbl.fold
+        (fun fp _count acc ->
+          if String.equal fp.provider provider then fp :: acc else acc)
+        t.counts
+        []
+    in
+    List.iter (fun fp -> FpTbl.remove t.counts fp) stale_keys;
+    if was_disabled
+    then
+      Prometheus.inc_counter metric_provider_re_enabled
+        ~labels:[ ("provider", provider) ]
+        ();
+    was_disabled)
+;;
+
+let disabled_providers t =
+  with_lock t (fun () ->
+    StrTbl.fold (fun provider (_ts, _tg) acc -> provider :: acc) t.disabled [])
+;;
+
+let reset_for_test t =
+  with_lock t (fun () ->
+    FpTbl.reset t.counts;
+    StrTbl.reset t.disabled)
+;;

--- a/lib/keeper/keeper_preflight_health_tracker.mli
+++ b/lib/keeper/keeper_preflight_health_tracker.mli
@@ -1,0 +1,121 @@
+(** Cascade preflight unhealthy-skip escalation state.
+
+    Tracks repeated [preflight skipped N unhealthy ...] events per
+    (cascade_name, provider, reason) fingerprint. After [threshold_disable]
+    consecutive skips of the same fingerprint, the provider is registered
+    in an in-memory disabled list and a single ERROR-class escalation is
+    emitted (instead of a WARN per skip).
+
+    A successful health recovery (caller invokes
+    [reset_on_health_recovery]) clears all fingerprints for that provider
+    and removes it from the disabled list, emitting one INFO transition.
+
+    {1 Design notes}
+
+    - Routing semantics are preserved: the disabled list is advisory.
+      Callers may still attempt the provider; this module only changes
+      the {e log-level cadence}, not routing.
+    - State is in-memory only (per-process). Survives across cascade
+      attempts in one keeper-server lifetime; rebuilt at restart.
+    - Closed sum types only, no catch-all match.
+
+    {1 References}
+
+    - MASC/OAS Error-Warn Reduction Goal — 2026-05-18 §P3 (provider
+      cascade exhaustion).
+    - System log slice 2026-05-18, last 30min:
+      [strict_tool_candidates: preflight skipped 1 unhealthy] x35,
+      [provider_k-coding-with-spark: preflight skipped 1 unhealthy] x12. *)
+
+(** Reason for a single preflight unhealthy-skip event. Closed sum,
+    extend by adding a constructor (compiler enforces exhaustive
+    match downstream). *)
+type reason =
+  | Health_check_failed_repeatedly
+      (** Local-endpoint /health probe failed on the immediately
+          preceding cycle; same provider URL keeps failing. *)
+  | Permanent_unhealthy
+      (** Endpoint advertises a non-recoverable status (e.g. 410,
+          model-not-found, configuration error). *)
+  | Transient_unhealthy
+      (** Endpoint failed but the failure class is expected to
+          self-heal (e.g. cold-start, brief network blip). *)
+  | Rate_limited_long_window
+      (** Endpoint is healthy but currently rate-limited; the limit
+          window is long enough to count as a preflight skip. *)
+
+(** Fingerprint of a single skip event. *)
+type fingerprint = {
+  cascade_name : string;  (** Cascade name (e.g. ["strict_tool_candidates"]). *)
+  provider : string;  (** Provider key or endpoint URL. *)
+  reason : reason;
+}
+
+(** Outcome of [record]: [`First] means this is a brand-new
+    fingerprint (or just-reset); [`Repeated n] means [n]th occurrence
+    (1-based after the first, so n>=2) but threshold not yet reached;
+    [`Threshold_disable n] means the fingerprint crossed
+    [threshold_disable] (n is the consecutive count, n=threshold) — the
+    caller should emit a single ERROR escalation and add the provider
+    to the disabled list. Subsequent matching records return
+    [`Already_disabled] until [reset_on_health_recovery] is called. *)
+type record_outcome =
+  [ `First
+  | `Repeated of int
+  | `Threshold_disable of int
+  | `Already_disabled
+  ]
+
+(** Default consecutive-skip threshold. Crossing this triggers
+    [`Threshold_disable]. *)
+val default_threshold : int
+
+(** TTL in seconds after which a disabled provider is automatically
+    re-enabled, even without an explicit [reset_on_health_recovery]
+    call (GitHub #18502). *)
+val disabled_ttl_seconds : float
+
+(** Opaque tracker handle. The module exposes a process-singleton
+    [global], but creating local instances is supported for tests. *)
+type t
+
+(** Create a fresh tracker. Tests should call this for isolation
+    instead of using [global]. [threshold] defaults to
+    [default_threshold]. *)
+val create : ?threshold:int -> unit -> t
+
+(** Process-singleton tracker used by production code paths. *)
+val global : t
+
+(** Record one preflight unhealthy-skip event. Returns the outcome,
+    which the caller uses to decide log level and disable-list
+    registration. Increments
+    [masc_cascade_preflight_unhealthy_skip_total] (always) and
+    [masc_cascade_provider_disabled_total] (on the [`Threshold_disable]
+    transition). *)
+val record :
+  ?clock:(unit -> float) ->
+  t -> cascade_name:string -> provider:string -> reason:reason -> record_outcome
+
+(** True iff the provider is currently in the disabled list (i.e. some
+    fingerprint crossed threshold and recovery has not happened yet).
+    Disabled entries older than [disabled_ttl_seconds] are automatically
+    expired and re-enabled (returns [false]). *)
+val is_disabled : ?clock:(unit -> float) -> t -> provider:string -> bool
+
+(** Clear all fingerprints for the given provider and remove it from
+    the disabled list. Returns [true] iff the provider was previously
+    disabled (callers use this to emit a single INFO line on
+    transition). *)
+val reset_on_health_recovery : t -> provider:string -> bool
+
+(** Snapshot of currently disabled providers. Order is unspecified;
+    callers should sort for stable output. *)
+val disabled_providers : t -> string list
+
+(** Render a [reason] as a stable, kebab-case slug for log
+    interpolation and metric labels. *)
+val reason_slug : reason -> string
+
+(** Reset the entire tracker to its initial state. Test-only helper. *)
+val reset_for_test : t -> unit

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1,37 +1,37 @@
 (** Runtime = Provider + Model + Spec(binding).
 
-    cascade→Runtime 전환 (B0). cascade 의 routes/cascade_name/tier/profile
+    cascade→Runtime 전환 (RFC-0206). cascade 의 routes/cascade_name/tier/profile
     간접 레이어를 제거하고, binding(provider × model) 하나를 곧 하나의 Runtime
     으로 본다. 소비자는 Runtime 목록 + default Runtime 을 직접 소비한다.
 
-    B0 는 additive: 기존 [Cascade_declarative_types] 를 합성만 한다(새 nominal
-    타입 없음 — 264파일 강결합에서 새 타입은 conversion 폭증을 부른다).
-    provider_cfg (hot-path materialize) 는 소비자 연결 단계(B2)에서 추가. *)
+    타입은 자립 모듈 {!Runtime_schema} 소유 (삭제된 [Cascade_declarative_types]
+    대체). parse 는 {!Runtime_toml}, hot-path materialize 는 {!Runtime_adapter}
+    가 담당한다 — 셋 다 [Cascade_*] 코드 의존 0. *)
 
-open Cascade_declarative_types
+open Runtime_schema
 
 type t =
   { id : string
     (** binding key ["provider.model"], 예 ["runpod_mtp.qwen-runpod"] *)
-  ; provider : cascade_provider
-  ; model : cascade_model_spec
-  ; binding : cascade_binding
+  ; provider : provider
+  ; model : model_spec
+  ; binding : binding
   ; provider_config : Llm_provider.Provider_config.t
     (** load 시점에 materialize 된 hot-path provider config. 소비자는
         routing 없이 이걸 곧장 LLM dispatch 로 넘긴다. *)
   }
 
-let id_of_binding (b : cascade_binding) : string =
-  Printf.sprintf "%s.%s" b.provider_id b.model_id
-;;
+(* id 파생의 단일 출처는 {!Runtime_schema.binding_key} — runtime 을 id 로
+   인덱싱하는 모든 호출자와 동일한 ["provider.model"] 규칙을 공유한다. *)
+let id_of_binding (b : binding) : string = binding_key b
 
 (** binding 을 Runtime 으로 변환. provider/model resolve 또는 provider_config
     materialize 가 실패하면 [None] (fail-closed — partial-boot 없음, 해당
     binding 은 가용 Runtime 목록에서 제외). *)
-let of_binding (cfg : cascade_config) (b : cascade_binding) : t option =
+let of_binding (cfg : config) (b : binding) : t option =
   match provider_of_id cfg b.provider_id, model_of_id cfg b.model_id with
   | Some provider, Some model ->
-    (match Cascade_declarative_adapter.binding_to_provider_config cfg b with
+    (match Runtime_adapter.binding_to_provider_config cfg b with
      | Ok provider_config ->
        Some { id = id_of_binding b; provider; model; binding = b; provider_config }
      | Error _ -> None)
@@ -44,11 +44,11 @@ let of_binding (cfg : cascade_config) (b : cascade_binding) : t option =
     silent fallback 일절 없음 (cascade→Runtime 비전: TOML 에 default 없으면
     프로그램 실행 불가). *)
 let load_list ~(config_path : string) : (t list * t, string) result =
-  match Cascade_declarative_parser.parse_file config_path with
+  match Runtime_toml.parse_file config_path with
   | Error errs ->
     Error
       (Printf.sprintf
-         "cascade config parse failed (%s): %d error(s)"
+         "runtime config parse failed (%s): %d error(s)"
          config_path
          (List.length errs))
   | Ok cfg ->
@@ -84,8 +84,17 @@ let init_default ~config_path =
 
 let get_default_runtime () = !default_runtime_ref
 
+(* fail-fast: uninitialized = startup-ordering bug, NOT a recoverable
+   condition. 이전 [| None -> "tool_strict"] 하드코딩 fallback 은 90 사이트에
+   조작된 id 를 흘리는 Unknown→Permissive 안티패턴이라 제거했다 (RFC-0206 §2.1).
+   불변식: [init_default] 가 startup 에서 성공해야 한다(아니면 startup abort).
+   NB(R2): 함수 호출 시점에만 raise 하므로 호출자는 이 값을 모듈 top-level
+   [let] 로 eager 바인딩하면 안 된다(config-less 테스트 바이너리 load crash). *)
 let get_default_runtime_id () =
   match !default_runtime_ref with
   | Some rt -> rt.id
-  | None -> "tool_strict"
+  | None ->
+    failwith
+      "Runtime.get_default_runtime_id: default runtime not initialized; \
+       Runtime.init_default must run at startup (no silent fallback — RFC-0206 §2.1)"
 ;;

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -1,21 +1,22 @@
 (** Runtime = Provider + Model + Spec(binding).
 
-    cascade→Runtime 전환 (B0). cascade 의 routes/cascade_name/tier/profile
+    cascade→Runtime 전환 (RFC-0206). cascade 의 routes/cascade_name/tier/profile
     간접 레이어를 제거하고, binding(provider × model) 하나를 곧 하나의 Runtime
-    으로 본다. 소비자는 Runtime 목록 + default Runtime 을 직접 소비한다. *)
+    으로 본다. 소비자는 Runtime 목록 + default Runtime 을 직접 소비한다.
+    타입은 자립 모듈 {!Runtime_schema} 소유. *)
 
-open Cascade_declarative_types
+open Runtime_schema
 
 type t =
   { id : string
-  ; provider : cascade_provider
-  ; model : cascade_model_spec
-  ; binding : cascade_binding
+  ; provider : provider
+  ; model : model_spec
+  ; binding : binding
   ; provider_config : Llm_provider.Provider_config.t
   }
 
-val id_of_binding : cascade_binding -> string
-val of_binding : cascade_config -> cascade_binding -> t option
+val id_of_binding : binding -> string
+val of_binding : config -> binding -> t option
 val load_list : config_path:string -> (t list * t, string) result
 
 (** {1 Lazy default runtime singleton}
@@ -26,4 +27,9 @@ val load_list : config_path:string -> (t list * t, string) result
 
 val init_default : config_path:string -> (unit, string) result
 val get_default_runtime : unit -> t option
+
 val get_default_runtime_id : unit -> string
+(** @raise Failure if {!init_default} has not run. No silent fallback
+    (RFC-0206 §2.1): an unresolved default is a startup-ordering bug, not a
+    recoverable condition. Callers must invoke this at runtime, never as a
+    module-level [let] binding (would crash config-less test binaries). *)

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -1,0 +1,334 @@
+(** Single-binding → [Provider_config.t] materialization (RFC-0206 §5).
+
+    Re-homed from the deleted [Cascade_declarative_adapter]. Keeps only the
+    binding materialization path:
+
+    - TOML provider.id -> declared provider metadata (via {!Runtime_schema})
+    - provider metadata + model spec -> {!Llm_provider.Provider_config.t}
+
+    Routing (aliases / routes / system_targets / capability profiles /
+    strategy mapping) and the typed [adapter_error] aggregate are dropped: a
+    Runtime is one pre-selected binding. Errors are surfaced as
+    [(_, string) result] so the caller fails fast (no silent fallback).
+
+    The three identity helpers ([normalize_provider_id], [headers_with_auth],
+    [normalize_openai_compat_request_path]) lived only in the deleted
+    [Cascade_config_provider_binding] and are inlined here so this module has
+    no [Cascade_*] dependency.
+
+    @stability Internal *)
+
+module Runtime_binding = Agent_sdk.Provider_runtime_binding
+
+(* --- Inlined from the deleted [Cascade_config_provider_binding] --- *)
+
+(* Trim, lowercase, and replace [-] with [_] in a provider identifier so
+   label/binding lookups are case- and separator-insensitive. *)
+let normalize_provider_id provider_id =
+  String.trim provider_id
+  |> String.lowercase_ascii
+  |> String.map (fun c -> if c = '-' then '_' else c)
+;;
+
+let headers_with_auth ~(kind : Llm_provider.Provider_config.provider_kind) ~api_key =
+  let base = [ ("Content-Type", "application/json") ] in
+  if api_key = ""
+  then base
+  else (
+    match kind with
+    | Provider_a | Provider_c ->
+      ("x-api-key", api_key) :: ("provider_a-version", "2023-06-01") :: base
+    | Provider_d_compat | Ollama | Provider_f | Provider_k | Cli_tool_d | Provider_h ->
+      ("Authorization", "Bearer " ^ api_key) :: base
+    | Cli_tool_b | Cli_tool_c | Cli_tool_a -> [])
+;;
+
+let trim_trailing_slash path =
+  if String.length path > 1 && String.ends_with ~suffix:"/" path
+  then String.sub path 0 (String.length path - 1)
+  else path
+;;
+
+let is_digit c = c >= '0' && c <= '9'
+
+let is_version_segment s =
+  let len = String.length s in
+  len >= 2
+  && s.[0] = 'v'
+  &&
+  let rec all_digits i = i >= len || (is_digit s.[i] && all_digits (i + 1)) in
+  all_digits 1
+;;
+
+let last_path_segment path =
+  match String.rindex_opt path '/' with
+  | Some idx -> String.sub path (idx + 1) (String.length path - idx - 1)
+  | None -> path
+;;
+
+let strip_leading_version request_path =
+  let len = String.length request_path in
+  if len >= 4 && request_path.[0] = '/' && request_path.[1] = 'v' && is_digit request_path.[2]
+  then (
+    let rec find_slash i =
+      if i >= len then len
+      else if request_path.[i] = '/' then i
+      else find_slash (i + 1)
+    in
+    let slash_pos = find_slash 2 in
+    String.sub request_path slash_pos (len - slash_pos))
+  else request_path
+;;
+
+let normalize_openai_compat_request_path ~base_url ~request_path =
+  let request_path =
+    match String.trim request_path with
+    | "" -> Masc_network_defaults.openai_chat_completions_path
+    | path -> path
+  in
+  let base_path = Uri.path (Uri.of_string base_url) |> trim_trailing_slash in
+  if base_path = "" || base_path = "/"
+  then request_path
+  else (
+    let duplicated_prefix = base_path ^ "/" in
+    if String.starts_with ~prefix:duplicated_prefix request_path
+    then (
+      let suffix_start = String.length base_path + 1 in
+      "/"
+      ^ String.sub request_path suffix_start (String.length request_path - suffix_start))
+    else if is_version_segment (last_path_segment base_path)
+            && String.length request_path >= 4
+            && request_path.[0] = '/'
+            && request_path.[1] = 'v'
+            && is_digit request_path.[2]
+    then strip_leading_version request_path
+    else request_path)
+;;
+
+(* --- Provider resolution --- *)
+
+let runtime_binding_id label =
+  match Runtime_binding.find label with
+  | Some binding -> Some binding.Runtime_binding.id
+  | None -> None
+;;
+
+let resolve_provider_prefix (provider_id : string) : string option =
+  match runtime_binding_id provider_id with
+  | Some _ as found -> found
+  | None ->
+    let normalized = normalize_provider_id provider_id in
+    runtime_binding_id normalized
+;;
+
+let find_registry_entry (provider_id : string)
+    : Llm_provider.Provider_registry.entry option =
+  let registry = Llm_provider.Provider_registry.default () in
+  match Llm_provider.Provider_registry.find registry provider_id with
+  | Some _ as found -> found
+  | None ->
+    (match resolve_provider_prefix provider_id with
+     | Some prefix -> Llm_provider.Provider_registry.find registry prefix
+     | None -> None)
+;;
+
+(* --- Credential materialization --- *)
+
+let credential_env_candidates = function
+  | "OLLAMA_CLOUD_API_KEY" -> [ "OLLAMA_CLOUD_API_KEY"; "OLLAMA_API_KEY" ]
+  | key -> [ key ]
+;;
+
+let api_key_from_env key =
+  credential_env_candidates key
+  |> List.find_map (fun env ->
+         match Sys.getenv_opt env with
+         | Some value when String.trim value <> "" -> Some value
+         | _ -> None)
+  |> Option.value ~default:""
+;;
+
+let api_key_of_credential ?registry_entry (credential : Runtime_schema.credential option) =
+  match credential with
+  | Some (Env key) -> api_key_from_env key
+  | Some (Inline value) -> value
+  | Some (File _) -> ""
+  | None ->
+    (match registry_entry with
+     | Some entry ->
+       let env = entry.Llm_provider.Provider_registry.defaults.api_key_env in
+       if env = ""
+       then ""
+       else
+         (* NDT-OK: credential materialization is the provider boundary;
+            catalog parsing stays deterministic. *)
+         api_key_from_env env
+     | None -> "")
+;;
+
+(* --- Provider kind resolution --- *)
+
+let provider_kind_of_cli_provider (provider : Runtime_schema.provider)
+    : Llm_provider.Provider_config.provider_kind option =
+  let resolve_kind raw = Llm_provider.Provider_config.provider_kind_of_string raw in
+  match resolve_kind provider.id with
+  | Some kind when Llm_provider.Provider_config.is_subprocess_cli kind -> Some kind
+  | _ ->
+    (match resolve_provider_prefix provider.id with
+     | Some prefix ->
+       (match resolve_kind prefix with
+        | Some kind when Llm_provider.Provider_config.is_subprocess_cli kind -> Some kind
+        | _ -> None)
+     | None -> None)
+;;
+
+let provider_kind_for_http_provider ?registry_entry (provider : Runtime_schema.provider)
+    : Llm_provider.Provider_config.provider_kind option =
+  match provider.api_format with
+  | Ollama_api -> Some Llm_provider.Provider_config.Ollama
+  | Chat_completions_api ->
+    Some
+      (match registry_entry with
+       | Some entry ->
+         let kind = entry.Llm_provider.Provider_registry.defaults.kind in
+         if kind = Llm_provider.Provider_config.Ollama
+         then Llm_provider.Provider_config.Provider_d_compat
+         else kind
+       | None -> Llm_provider.Provider_config.Provider_d_compat)
+  | Messages_api -> None
+;;
+
+let request_path_for_http_provider ~(provider : Runtime_schema.provider) ~registry_entry ~kind
+    ~base_url =
+  let request_path =
+    match provider.api_format, kind with
+    | Runtime_schema.Chat_completions_api, Llm_provider.Provider_config.Provider_d_compat ->
+      Masc_network_defaults.chat_completions_path
+    | _ ->
+      (match registry_entry with
+       | Some entry -> entry.Llm_provider.Provider_registry.defaults.request_path
+       | None -> Llm_provider.Provider_config.request_path_default_for_kind kind)
+  in
+  match kind with
+  | Llm_provider.Provider_config.Provider_d_compat ->
+    normalize_openai_compat_request_path ~base_url ~request_path
+  | _ -> request_path
+;;
+
+(* --- Model capability projection --- *)
+
+let supports_tool_choice_override_of_model_spec (spec : Runtime_schema.model_spec) =
+  match spec.capabilities with
+  | Some capabilities -> Some capabilities.supports_tool_choice
+  | None -> None
+;;
+
+let max_output_tokens_of_model_spec (spec : Runtime_schema.model_spec) =
+  match spec.capabilities with
+  | Some capabilities -> capabilities.max_output_tokens
+  | None -> None
+;;
+
+let effective_max_tokens_for_model spec requested =
+  match requested, max_output_tokens_of_model_spec spec with
+  | Some configured, Some capability -> Some (min configured capability)
+  | Some configured, None -> Some configured
+  | None, Some capability -> Some capability
+  | None, None -> None
+;;
+
+(* --- provider × model spec → Provider_config.t ---
+
+   v1 drops the [Provider_tool_support.runtime_capabilities_override] that the
+   deleted adapter carried alongside the config (it was paired with the
+   now-removed alias layer); [binding_to_provider_config] never consumed it. *)
+let provider_config_from_declared_provider (provider : Runtime_schema.provider)
+    (spec : Runtime_schema.model_spec) ~(max_tokens : int option)
+    : Llm_provider.Provider_config.t option =
+  let registry_entry = find_registry_entry provider.id in
+  let supports_tool_choice_override = supports_tool_choice_override_of_model_spec spec in
+  let max_tokens = effective_max_tokens_for_model spec max_tokens in
+  match provider.transport with
+  | Http base_url ->
+    let base_url = Masc_network_defaults.normalize_loopback_base_url base_url in
+    (match provider_kind_for_http_provider ?registry_entry provider with
+     | Some kind ->
+       let request_path =
+         request_path_for_http_provider ~provider ~registry_entry ~kind ~base_url
+       in
+       let api_key = api_key_of_credential ?registry_entry provider.credentials in
+       let auth_headers = headers_with_auth ~kind ~api_key in
+       let custom_headers = Option.value ~default:[] provider.headers in
+       (* TOML-declared custom headers override generated auth headers by key.
+          This allows operators to set provider-specific headers (e.g.
+          provider_a-version) while preserving auth and Content-Type. *)
+       let custom_keys = List.map fst custom_headers in
+       let headers =
+         custom_headers
+         @ List.filter (fun (k, _) -> not (List.mem k custom_keys)) auth_headers
+       in
+       Some
+         (Llm_provider.Provider_config.make
+            ~kind
+            ~model_id:spec.api_name
+            ~base_url
+            ~api_key
+            ~headers
+            ~request_path
+            ~max_context:spec.max_context
+            ?supports_tool_choice_override
+            ?max_tokens
+            ())
+     | None -> None)
+  | Cli _ ->
+    (match provider_kind_of_cli_provider provider with
+     | Some kind ->
+       Some
+         (Llm_provider.Provider_config.make
+            ~kind
+            ~model_id:spec.api_name
+            ~base_url:""
+            ~api_key:(api_key_of_credential ?registry_entry provider.credentials)
+            ~headers:(Option.value ~default:[] provider.headers)
+            ~max_context:spec.max_context
+            ?supports_tool_choice_override
+            ?max_tokens
+            ())
+     | None -> None)
+;;
+
+(* --- binding → Provider_config.t ---
+
+   Replaces the deleted [resolve_binding_config]/[binding_to_provider_config]
+   pair. The typed [adapter_error] list is collapsed into [(_, string) result]
+   strings; the override carrier is dropped (see above). *)
+let binding_to_provider_config (cfg : Runtime_schema.config) (binding : Runtime_schema.binding)
+    : (Llm_provider.Provider_config.t, string) result =
+  match Runtime_schema.model_of_id cfg binding.model_id with
+  | None -> Error (Printf.sprintf "model not found: %s" binding.model_id)
+  | Some spec ->
+    let max_tokens =
+      match binding.price_input, binding.price_output with
+      | Some input_cost, Some _ when input_cost > 0.0 -> Some spec.max_context
+      | _ -> None
+    in
+    (match Runtime_schema.provider_of_id cfg binding.provider_id with
+     | None -> Error (Printf.sprintf "provider not found: %s" binding.provider_id)
+     | Some provider ->
+       (match provider_config_from_declared_provider provider spec ~max_tokens with
+        | None ->
+          Error
+            (Printf.sprintf
+               "%s.%s: binding resolution failed (provider transport/kind unmapped)"
+               binding.provider_id
+               binding.model_id)
+        | Some config ->
+          if binding.max_concurrent > 0
+          then
+            Ok
+              { config with
+                Llm_provider.Provider_config.internal_model_rotation_count =
+                  Some binding.max_concurrent
+              }
+          else Ok config))
+;;

--- a/lib/runtime/runtime_adapter.mli
+++ b/lib/runtime/runtime_adapter.mli
@@ -1,0 +1,25 @@
+(** Single-binding → hot-path [Provider_config.t] materialization (RFC-0206 §5).
+
+    Re-homed from the deleted [Cascade_declarative_adapter], keeping only the
+    binding materialization path. Routing layers — aliases, routes,
+    system_targets, capability profiles, [Cascade_strategy] mapping, the
+    [adapted_catalog] aggregate, and the typed [adapter_error] list — are
+    intentionally dropped (a Runtime is one pre-selected binding, not a
+    routed catalog). Types are owned by {!Runtime_schema}.
+
+    @stability Internal *)
+
+val binding_to_provider_config
+  :  Runtime_schema.config
+  -> Runtime_schema.binding
+  -> (Llm_provider.Provider_config.t, string) result
+(** Materialize one binding into the hot-path {!Llm_provider.Provider_config.t}.
+
+    Resolution chain (no routing):
+    - [binding.provider_id] -> {!Runtime_schema.provider_of_id}
+    - [binding.model_id] -> {!Runtime_schema.model_of_id}
+    - provider transport + model spec -> {!Llm_provider.Provider_config.make}
+
+    Returns [Error reason] (no silent fallback) when the provider or model id
+    is unresolved, or when the provider transport/kind cannot be mapped to a
+    concrete provider config. *)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -1,0 +1,785 @@
+(** Runtime_agent — Config, build, and run for OAS agent execution.
+
+    Contains the [config] type, [build], [run], and [run_with_masc_tools]
+    functions. All model-selection and cascade logic lives in
+    {!Cascade_observation} and {!Keeper_turn_driver}.
+
+    @since God file decomposition — extracted from oas_worker.ml *)
+
+(* ================================================================ *)
+(* Configuration                                                     *)
+(* ================================================================ *)
+
+type stop_reason =
+  Runtime_agent_context.stop_reason =
+  | Completed
+  | TurnBudgetExhausted of { turns_used : int; limit : int }
+  | MutationBoundaryReached of { turns_used : int; tool_name : string option }
+
+type cli_transport_overrides =
+  Runtime_transport.cli_transport_overrides = {
+  cwd : string option;
+  claude_mcp_config : string option;
+  claude_allowed_tools : string list option;
+  claude_permission_mode : string option;
+  claude_max_turns : int option;
+  gemini_yolo : bool option;
+  cli_subprocess_idle_sec : float option;
+}
+
+type config =
+  Runtime_agent_context.config = {
+  name : string;
+  provider_cfg : Llm_provider.Provider_config.t;
+  provider : Agent_sdk.Provider.config;
+  model_id : string;
+  priority : Llm_provider.Request_priority.t option;
+  system_prompt : string;
+  tools : Agent_sdk.Tool.t list;
+  runtime_mcp_policy :
+    Llm_provider.Llm_transport.runtime_mcp_policy option;
+  max_turns : int;
+  max_idle_turns : int;
+  stream_idle_timeout_s : float option;
+  max_execution_time_s : float option;
+  body_timeout_s : float option;
+  max_tokens : int;
+  max_input_tokens : int option;
+  max_cost_usd : float option;
+  temperature : float;
+  hooks : Agent_sdk.Hooks.hooks option;
+  context_reducer : Agent_sdk.Context_reducer.t option;
+  guardrails : Agent_sdk.Guardrails.t option;
+  event_bus : Agent_sdk.Event_bus.t option;
+  checkpoint_dir : string option;
+  session_id : string option;
+  description : string option;
+  memory : Agent_sdk.Memory.t option;
+  initial_messages : Agent_sdk.Types.message list;
+  raw_trace : Agent_sdk.Raw_trace.t option;
+  tool_retry_policy : Agent_sdk.Tool_retry_policy.t option;
+  required_tool_satisfaction :
+    Agent_sdk.Completion_contract.required_tool_satisfaction;
+  enable_thinking : bool option;
+  transport : Masc_grpc_transport.t;
+  allowed_paths : string list;
+  checkpoint_sidecar : Yojson.Safe.t option;
+  cache_system_prompt : bool;
+  yield_on_tool : bool;
+  compact_ratio : float option;
+  oas_auto_context_overflow_retry : bool;
+  context_injector : Agent_sdk.Hooks.context_injector option;
+  context : Agent_sdk.Context.t option;
+  slot_id : int option;
+  approval : Agent_sdk.Hooks.approval_callback option;
+  exit_condition : (int -> bool) option;
+  exit_condition_result : (int -> stop_reason * string option) option;
+  summarizer : (Agent_sdk.Types.message list -> string) option;
+  cli_transport_overrides : cli_transport_overrides option;
+      (** Custom summarizer for OAS [Budget_strategy.reduce_for_budget]
+          Emergency-phase compaction. Defaults to OAS's extractive
+          default. Keeper workers inject [Keeper_summarizer.keeper_summarizer]
+          to scrub [STATE] blocks before the 100-char truncation. *)
+}
+
+let default_config = Runtime_agent_context.default_config
+
+type run_result = {
+  response : Agent_sdk.Types.api_response;
+  checkpoint : Agent_sdk.Checkpoint.t option;
+  session_id : string;
+  turns : int;
+  trace_ref : Agent_sdk.Raw_trace.run_ref option;
+  run_validation : Agent_sdk.Raw_trace.run_validation option;
+  cascade_observation : Cascade_observation.cascade_observation option;
+  stop_reason : stop_reason;
+}
+
+type worker_lifecycle_classification =
+  { event : string
+  ; status : string
+  ; error : string option
+  }
+
+let worker_lifecycle_classification_of_result = function
+  | Ok _ -> { event = "completed"; status = "completed"; error = None }
+  | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _)) ->
+    { event = "completed"; status = "budget_exhausted"; error = None }
+  | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionTimeout _)) ->
+    { event = "failed"; status = "agent_execution_timeout"; error = None }
+  | Error e ->
+    { event = "failed"; status = "failed"; error = Some (Agent_sdk.Error.to_string e) }
+
+(* ================================================================ *)
+(* Internal: resolve provider                                        *)
+(* ================================================================ *)
+
+(** Resolve a model label string to an OAS Provider.config.
+    Uses MASC [Cascade_config.parse_model_string] (with Provider_registry as SSOT).
+    Explicit model-label execution must never silently substitute a
+    discovery-only model. Callers are expected to validate labels
+    before reaching this helper. *)
+type label_resolution_error =
+  Runtime_transport.label_resolution_error =
+  | Invalid_model_label of string
+
+let label_resolution_error_to_string =
+  Runtime_transport.label_resolution_error_to_string
+
+let label_resolution_error_to_sdk_error =
+  Runtime_transport.label_resolution_error_to_sdk_error
+
+let resolve_provider_config_of_label =
+  Runtime_transport.resolve_provider_config_of_label
+
+let invalid_runtime_config =
+  Runtime_transport.invalid_runtime_config
+
+let cli_model_override =
+  Runtime_transport.cli_model_override
+
+let provider_caps_of_config =
+  Runtime_transport.provider_caps_of_config
+
+let provider_supports_inline_tools =
+  Runtime_transport.provider_supports_inline_tools
+
+let provider_supports_runtime_mcp_lane =
+  Runtime_transport.provider_supports_runtime_mcp_lane
+
+let dedupe_preserve_order =
+  Runtime_transport.dedupe_preserve_order
+
+let public_mcp_tool_names_of_oas_tools =
+  Runtime_transport.public_mcp_tool_names_of_oas_tools
+
+let public_mcp_tool_requires_bound_actor =
+  Runtime_transport.public_mcp_tool_requires_bound_actor
+
+let runtime_mcp_tool_requires_bound_actor =
+  Runtime_transport.runtime_mcp_tool_requires_bound_actor
+
+let runtime_mcp_policy_with_masc_agent_name =
+  Runtime_transport.runtime_mcp_policy_with_masc_agent_name
+
+let cli_tool_a_can_auth_keeper_bound_runtime_mcp =
+  Runtime_transport.cli_tool_a_can_auth_keeper_bound_runtime_mcp
+
+let runtime_mcp_policy_for_provider =
+  Runtime_transport.runtime_mcp_policy_for_provider
+
+let public_mcp_tools_of_oas_tools =
+  Runtime_transport.public_mcp_tools_of_oas_tools
+
+let tool_names_are_public_mcp =
+  Runtime_transport.tool_names_are_public_mcp
+
+let public_mcp_runtime_policy_of_tool_names =
+  Runtime_transport.public_mcp_runtime_policy_of_tool_names
+
+let runtime_mcp_policy_of_tool_names =
+  Runtime_transport.runtime_mcp_policy_of_tool_names
+
+let provider_label =
+  Runtime_transport.provider_label
+
+let cli_tool_d_max_turns_hard_cap =
+  Runtime_transport.cli_tool_d_max_turns_hard_cap
+
+let provider_effective_max_turns =
+  Runtime_transport.provider_effective_max_turns
+
+let resolve_tool_lane_for_oas_tools =
+  Runtime_transport.resolve_tool_lane_for_oas_tools
+
+let make_per_call_switch_transport =
+  Runtime_transport.make_per_call_switch_transport
+
+let non_http_transport_of_provider =
+  Runtime_transport.non_http_transport_of_provider
+
+let request_runtime_fields_on_base_config
+    ~(base : Llm_provider.Provider_config.t)
+    (req_config : Llm_provider.Provider_config.t)
+  =
+  { base with
+    max_tokens = req_config.max_tokens;
+    temperature = req_config.temperature;
+    top_p = req_config.top_p;
+    top_k = req_config.top_k;
+    min_p = req_config.min_p;
+    system_prompt = req_config.system_prompt;
+    enable_thinking = req_config.enable_thinking;
+    thinking_budget = req_config.thinking_budget;
+    clear_thinking = req_config.clear_thinking;
+    tool_stream = req_config.tool_stream;
+    tool_choice = req_config.tool_choice;
+    disable_parallel_tool_use = req_config.disable_parallel_tool_use;
+    response_format = req_config.response_format;
+    output_schema = req_config.output_schema;
+    cache_system_prompt = req_config.cache_system_prompt;
+    supports_tool_choice_override =
+      (match req_config.supports_tool_choice_override with
+       | Some _ as override -> override
+       | None -> base.supports_tool_choice_override);
+    seed = req_config.seed;
+  }
+
+let provider_resource_slot_transport
+    ~(kind : Fd_accountant.kind)
+    (transport : Llm_provider.Llm_transport.t)
+  : Llm_provider.Llm_transport.t =
+  { complete_sync =
+      (fun req ->
+        Fd_accountant.with_slot ~kind (fun () ->
+          transport.complete_sync req));
+    complete_stream =
+      (fun ?on_telemetry ~on_event req ->
+        Fd_accountant.with_slot ~kind (fun () ->
+          transport.complete_stream ?on_telemetry ~on_event req));
+  }
+
+let provider_http_slot_transport transport =
+  provider_resource_slot_transport ~kind:Provider_http transport
+
+let provider_cli_slot_transport transport =
+  provider_resource_slot_transport ~kind:Provider_cli transport
+
+let provider_config_preserving_http_transport
+    ~sw
+    ~net
+    ~(provider_cfg : Llm_provider.Provider_config.t)
+  : Llm_provider.Llm_transport.t =
+  let http_transport = Llm_provider.Complete.make_http_transport ~sw ~net in
+  let patch_request (req : Llm_provider.Llm_transport.completion_request) =
+    { req with
+      config =
+        request_runtime_fields_on_base_config ~base:provider_cfg req.config;
+    }
+  in
+  provider_http_slot_transport
+    { complete_sync =
+      (fun req ->
+        (* RFC-0095 Phase 0 diagnostic trace — verify which transport path is invoked
+           per turn for each provider. Removed at Phase 0 closeout. *)
+        Log.Misc.debug
+          "rfc0095-trace: cascade_runner http_transport.complete_sync invoked";
+        http_transport.complete_sync (patch_request req));
+      complete_stream =
+      (fun ?on_telemetry ~on_event req ->
+        (* RFC-0095 Phase 0 diagnostic trace — verify which transport path is invoked
+           per turn for each provider. Removed at Phase 0 closeout. *)
+        Log.Misc.debug
+          "rfc0095-trace: cascade_runner http_transport.complete_stream invoked";
+        http_transport.complete_stream ?on_telemetry ~on_event
+          (patch_request req));
+    }
+
+let transport_for_provider ~sw ~net ~provider_cfg ?runtime_mcp_policy
+    ?cli_transport_overrides () =
+  if
+    Llm_provider.Provider_config.is_subprocess_cli
+      provider_cfg.Llm_provider.Provider_config.kind
+  then
+    match
+      non_http_transport_of_provider ~sw ~provider_cfg ?runtime_mcp_policy
+        ?cli_transport_overrides ()
+    with
+    | Ok (Some transport) -> Ok (Some (provider_cli_slot_transport transport))
+    | Ok None -> Ok None
+    | Error _ as err -> err
+  else
+    Ok
+      (Some
+         (provider_config_preserving_http_transport ~sw ~net ~provider_cfg))
+
+module For_testing = struct
+  let request_runtime_fields_on_base_config =
+    request_runtime_fields_on_base_config
+
+  let provider_http_slot_transport = provider_http_slot_transport
+  let provider_cli_slot_transport = provider_cli_slot_transport
+end
+
+(* ================================================================ *)
+(* Internal: event publishing                                        *)
+(* ================================================================ *)
+
+let publish_lifecycle =
+  Keeper_oas_checkpoint.publish_lifecycle
+
+let provider_lifecycle_attrs (config : config) =
+  let provider_cfg = config.provider_cfg in
+  let provider_kind =
+    Llm_provider.Provider_config.string_of_provider_kind provider_cfg.kind
+  in
+  let nonempty_string key value =
+    let value = String.trim value in
+    if value = "" then [] else [ (key, `String value) ]
+  in
+  let endpoint =
+    match String.trim provider_cfg.base_url, String.trim provider_cfg.request_path with
+    | "", _ -> []
+    | base_url, "" -> [ ("endpoint", `String base_url) ]
+    | base_url, request_path -> [ ("endpoint", `String (base_url ^ request_path)) ]
+  in
+  [
+    ("provider_kind", `String provider_kind);
+    ("model_id", `String config.model_id);
+    ("provider_model_id", `String provider_cfg.model_id);
+    ("max_tokens", `Int config.max_tokens);
+    ("max_turns", `Int config.max_turns);
+  ]
+  @ nonempty_string "base_url" provider_cfg.base_url
+  @ nonempty_string "request_path" provider_cfg.request_path
+  @ endpoint
+
+(* ================================================================ *)
+(* Internal: checkpoint persistence                                  *)
+(* ================================================================ *)
+
+let persist_checkpoint =
+  Keeper_oas_checkpoint.persist_checkpoint
+
+let build_checkpoint =
+  Keeper_oas_checkpoint.build_checkpoint
+
+let partial_response_of_stop =
+  Keeper_oas_checkpoint.partial_response_of_stop
+
+(* ================================================================ *)
+(* Build                                                             *)
+(* ================================================================ *)
+
+let build
+    ~(sw : Eio.Switch.t)
+    ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
+    ~(config : config)
+  : (Agent_sdk.Agent.t, Agent_sdk.Error.sdk_error) result =
+  match
+    transport_for_provider ~sw ~net ~provider_cfg:config.provider_cfg
+      ?runtime_mcp_policy:config.runtime_mcp_policy
+      ?cli_transport_overrides:config.cli_transport_overrides
+      ()
+  with
+  | Error _ as e -> e
+  | Ok transport ->
+      let builder =
+        Runtime_agent_context.builder_without_approval ~net ~config ?transport ()
+      in
+      let builder =
+        match config.approval with
+        | Some cb -> Agent_sdk.Builder.with_approval cb builder
+        | None -> builder
+      in
+      Agent_sdk.Builder.build_safe builder
+
+(* ================================================================ *)
+(* Idle-detail enrichment                                           *)
+(* ================================================================ *)
+
+(** Enrich an [Agent_sdk.Error.to_string] detail with the name of the most
+    recently called tool when the error is an "Idle detected" failure.
+    For all other error strings the input is returned unchanged.
+
+    Exposed at module level so it can be unit-tested independently of
+    the network-bound [run] function. *)
+let enrich_idle_detail =
+  Keeper_oas_checkpoint.enrich_idle_detail
+
+let run_duration_ms_since started_at =
+  Float.max 0.0 ((Unix.gettimeofday () -. started_at) *. 1000.0)
+
+let dashboard_status_of_stop_reason = function
+  | Completed -> Dashboard_oas_bridge.Success
+  | TurnBudgetExhausted _ -> Dashboard_oas_bridge.Timeout
+  | MutationBoundaryReached _ ->
+      Dashboard_oas_bridge.Cancelled { reason = "mutation_boundary_reached" }
+
+let record_dashboard_oas_response ~config ~total_duration_ms ?serialization_ms
+    ~status (response : Agent_sdk.Types.api_response) =
+  try
+    (* RFC-0132 PR-2: dashboard surface = external boundary; redact via SSOT. *)
+    Dashboard_oas_bridge.record_response
+      ~provider_id:
+        (Boundary_redaction.to_string Boundary_redaction.runtime_provider_label)
+      ~model_id:
+        (Boundary_redaction.to_string Boundary_redaction.runtime_model_label)
+      ~total_duration_ms ?serialization_ms ~status response
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+      Log.Misc.warn
+        "oas_worker %s: dashboard_oas_bridge record failed: %s"
+        config.name (Printexc.to_string exn)
+
+let close_agent_for_cleanup ?(propagate_cancel = true) ~config agent =
+  try Agent_sdk.Agent.close agent with
+  | Eio.Cancel.Cancelled _ as e ->
+      Log.Misc.warn
+        "oas_worker %s: agent close cancelled during cleanup"
+        config.name;
+      if propagate_cancel then raise e
+  | close_exn ->
+      Log.Misc.warn "oas_worker %s: agent close failed during cleanup: %s"
+        config.name (Printexc.to_string close_exn)
+
+(* ================================================================ *)
+(* Resume from checkpoint                                            *)
+(* ================================================================ *)
+
+(** Build an Agent.t from a checkpoint via [Agent.resume], overriding
+    per-turn config values from the MASC config.
+
+    The checkpoint provides: messages, turn_count, usage_stats.
+    The MASC config provides: provider, model_id, system_prompt,
+    max_turns, temperature, tools, hooks, guardrails, etc.
+
+    [max_turns] and [max_cost_usd] are adjusted to account for
+    cumulative values in the checkpoint — the keeper's per-call budget
+    is added on top of the checkpoint's accumulated state.
+
+    @boundary-contract
+    - MASC owns: per-turn config selection (model, temperature, tools,
+      system_prompt), per-turn budget allocation, checkpoint field patching
+      to align MASC intent with OAS resume semantics.
+    - OAS owns: cumulative token/cost accounting, turn_count tracking,
+      Agent.resume state restoration, loop guard enforcement.
+    - Neither may: MASC must not set [max_total_tokens] (OAS SSOT for
+      cumulative budgets); OAS must not override MASC model/temperature
+      selection after resume. *)
+let resume_from_checkpoint
+    ~(sw : Eio.Switch.t)
+    ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
+    ~(config : config)
+    ~(checkpoint : Agent_sdk.Checkpoint.t)
+  : (Agent_sdk.Agent.t, Agent_sdk.Error.sdk_error) result =
+  match
+    transport_for_provider ~sw ~net ~provider_cfg:config.provider_cfg
+      ?runtime_mcp_policy:config.runtime_mcp_policy
+      ?cli_transport_overrides:config.cli_transport_overrides
+      ()
+  with
+  | Error _ as e -> e
+  | Ok transport ->
+      let prepared_resume =
+        Runtime_agent_context.prepare_resume ~config ~checkpoint
+      in
+      Log.Misc.info
+        "oas_worker %s: resume checkpoint_turn_count=%d per_call_turn_budget=%d effective_max_turns=%d"
+        config.name checkpoint.turn_count config.max_turns
+        prepared_resume.agent_config.max_turns;
+      let options = { prepared_resume.options with transport } in
+      Ok
+        (Agent_sdk.Agent.resume ~net ~checkpoint:prepared_resume.patched_checkpoint
+           ~tools:config.tools ?context:config.context
+           ~options ~config:prepared_resume.agent_config
+           ~auto_context_overflow_retry:config.oas_auto_context_overflow_retry
+           ())
+
+(* ================================================================ *)
+(* Run                                                               *)
+(* ================================================================ *)
+
+let run
+    ~(sw : Eio.Switch.t)
+    ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
+    ~(config : config)
+    ?oas_checkpoint
+    ?(on_event : (Agent_sdk.Types.sse_event -> unit) option)
+    ?(on_yield : (unit -> unit) option)
+    ?(on_resume : (unit -> unit) option)
+    ?(agent_ref : Agent_sdk.Agent.t option ref option)
+    (goal : string)
+  : (run_result, Agent_sdk.Error.sdk_error) result =
+  let session_id = match config.session_id with
+    | Some id -> id
+    | None ->
+      Printf.sprintf "%s-%d-%06x"
+        config.name
+        (int_of_float (Time_compat.now () *. 1000.0))
+        (Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFFF)
+  in
+  (match config.transport with
+  | Masc_grpc_transport.Local -> ()
+  | t ->
+    Log.Misc.info "oas_worker %s: transport=%s"
+      config.name (Masc_grpc_transport.to_string t));
+  Option.iter (fun bus ->
+    publish_lifecycle bus ~name:config.name ~event:"build" ~detail:goal
+      ~attrs:(provider_lifecycle_attrs config)
+      ()
+  ) config.event_bus;
+  let agent_result = match oas_checkpoint with
+    | Some checkpoint ->
+      (try resume_from_checkpoint ~sw ~net ~config ~checkpoint
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Log.Misc.warn "oas_worker %s: resume_from_checkpoint failed (%s), falling back to build"
+           config.name (Printexc.to_string exn);
+         build ~sw ~net ~config)
+    | None -> build ~sw ~net ~config
+  in
+  match agent_result with
+  | Error e ->
+    Option.iter (fun bus ->
+      publish_lifecycle bus ~name:config.name ~event:"build_error"
+        ~detail:(Agent_sdk.Error.to_string e)
+        ~error:(Agent_sdk.Error.to_string e)
+        ~status:"build_error"
+        ~session_id
+        ~attrs:(provider_lifecycle_attrs config)
+        ()
+    ) config.event_bus;
+    Error e
+  | Ok agent ->
+  (match agent_ref with Some r -> r := Some agent | None -> ());
+  let run_started_at = Unix.gettimeofday () in
+  (try
+    let result =
+      (* Pass the process-level Eio clock when available so agent_sdk's
+         [with_optional_timeout] can fire on hang when the caller has
+         also set [config.max_execution_time_s]. Both inputs must be
+         [Some] for the timeout to engage; absent either, behaviour is
+         historical (block until provider closes). *)
+      let clock =
+        match Process_eio.get_clock () with
+        | Ok c -> Some c
+        | Error _ -> None
+      in
+      match on_event with
+      | Some cb -> Agent_sdk.Agent.run_stream ~sw ?clock ?on_yield ?on_resume ~on_event:cb agent goal
+      | None -> Agent_sdk.Agent.run ~sw ?clock ?on_yield ?on_resume agent goal
+    in
+    let run_total_duration_ms = run_duration_ms_since run_started_at in
+    let checkpoint =
+      let ckpt =
+        build_checkpoint ~session_id
+          ?checkpoint_sidecar:config.checkpoint_sidecar agent
+      in
+      (match config.checkpoint_dir with
+       | Some dir ->
+         (match persist_checkpoint ~dir ~session_id ckpt with
+          | Ok () -> ()
+          | Error err ->
+            Log.Misc.error "oas_worker: %s" err)
+       | None -> ());
+      Some ckpt
+    in
+    Option.iter (fun bus ->
+      let lifecycle = worker_lifecycle_classification_of_result result in
+      publish_lifecycle bus ~name:config.name ~event:lifecycle.event
+        ~detail:(Printf.sprintf "session=%s" session_id)
+        ?error:lifecycle.error
+        ~session_id
+        ~status:lifecycle.status
+        ~attrs:(provider_lifecycle_attrs config)
+        ()
+    ) config.event_bus;
+    let turns = (Agent_sdk.Agent.state agent).turn_count in
+    let trace_ref = Agent_sdk.Agent.last_raw_trace_run agent in
+    let close_after_success () =
+      close_agent_for_cleanup ~propagate_cancel:false ~config agent
+    in
+    let run_validation =
+      match trace_ref with
+      | Some ref_ ->
+        (match Agent_sdk.Raw_trace_query.validate_run ref_ with
+         | Ok v -> Some v
+         | Error err ->
+           Log.Misc.warn "oas_worker: run_validation failed: %s"
+             (Agent_sdk.Error.to_string err);
+           None)
+      | None -> None
+    in
+    (match result with
+    | Ok response ->
+      close_after_success ();
+      record_dashboard_oas_response ~config
+        ~total_duration_ms:run_total_duration_ms
+        ~status:Dashboard_oas_bridge.Success response;
+      Ok
+        {
+          response;
+          checkpoint;
+          session_id;
+          turns;
+          trace_ref;
+          run_validation;
+          cascade_observation = None;
+          stop_reason = Completed;
+        }
+    | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded r)) ->
+      close_after_success ();
+      let partial_response =
+        partial_response_of_stop
+          ~session_id
+          ~text:(Printf.sprintf
+            "[turn budget exhausted: %d/%d turns used]" r.turns r.limit)
+      in
+      record_dashboard_oas_response ~config
+        ~total_duration_ms:run_total_duration_ms
+        ~status:Dashboard_oas_bridge.Timeout partial_response;
+      Ok
+        {
+          response = partial_response;
+          checkpoint;
+          session_id;
+          turns;
+          trace_ref;
+          run_validation;
+          cascade_observation = None;
+          stop_reason = TurnBudgetExhausted { turns_used = r.turns; limit = r.limit };
+        }
+    | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.ExitConditionMet r)) -> (
+      match config.exit_condition_result with
+      | Some render ->
+        close_after_success ();
+        let stop_reason, response_text_opt = render r.turn in
+        let response_text =
+          match response_text_opt with
+          | Some text when String.trim text <> "" -> text
+          | _ -> Printf.sprintf "[exit condition met at turn %d]" r.turn
+        in
+        let partial_response =
+          partial_response_of_stop
+            ~session_id
+            ~text:response_text
+        in
+        record_dashboard_oas_response ~config
+          ~total_duration_ms:run_total_duration_ms
+          ~status:(dashboard_status_of_stop_reason stop_reason)
+          partial_response;
+        Ok
+          {
+            response = partial_response;
+            checkpoint;
+            session_id;
+            turns;
+            trace_ref;
+            run_validation;
+            cascade_observation = None;
+            stop_reason;
+          }
+      | None ->
+        close_agent_for_cleanup ~propagate_cancel:false ~config agent;
+        Error (Agent_sdk.Error.Agent (Agent_sdk.Error.ExitConditionMet r)))
+    | Error
+        (Agent_sdk.Error.Agent
+           (Agent_sdk.Error.AgentExecutionTimeout r as agent_err)) ->
+      let partial_response =
+        partial_response_of_stop
+          ~session_id
+          ~text:
+            (Printf.sprintf
+               "[agent execution timeout: elapsed=%.1fs timeout=%.1fs turns=%d/%d]"
+               r.elapsed_sec
+               r.timeout_sec
+               r.turn_count
+               r.max_turns)
+      in
+      record_dashboard_oas_response
+        ~config
+        ~total_duration_ms:run_total_duration_ms
+        ~status:Dashboard_oas_bridge.Timeout
+        partial_response;
+      close_agent_for_cleanup ~propagate_cancel:false ~config agent;
+      Error (Agent_sdk.Error.Agent agent_err)
+    | Error err ->
+      let detail = Agent_sdk.Error.to_string err in
+      let detail =
+        enrich_idle_detail detail (Agent_sdk.Agent.state agent).messages
+      in
+      let error_response =
+        partial_response_of_stop ~session_id ~text:detail
+      in
+      record_dashboard_oas_response ~config
+        ~total_duration_ms:run_total_duration_ms
+        ~status:(Dashboard_oas_bridge.Error { transient = false })
+        error_response;
+      (* Demoted from WARN to DEBUG (task-239): this fires once per cascade,
+         but a cascade caller (Keeper_turn_driver.run_named) retries on the
+         next provider.  Emitting WARN/ERROR here creates noise on
+         recovered cascades.  The cascade layer logs [cascade-fallback] at
+         INFO when it retries and emits ERROR only on full exhaustion. *)
+      Log.Misc.debug "oas_worker: agent errored: %s" detail;
+      close_agent_for_cleanup ~propagate_cancel:false ~config agent;
+      Error err)
+  with
+  | Eio.Cancel.Cancelled _ as exn ->
+    close_agent_for_cleanup ~propagate_cancel:false ~config agent;
+    raise exn
+  | exn ->
+    let bt = Printexc.get_backtrace () in
+    close_agent_for_cleanup ~config agent;
+    let detail =
+      Printf.sprintf "execution exception: %s" (Printexc.to_string exn)
+    in
+    let error_response =
+      partial_response_of_stop ~session_id ~text:detail
+    in
+    record_dashboard_oas_response ~config
+      ~total_duration_ms:(run_duration_ms_since run_started_at)
+      ~status:(Dashboard_oas_bridge.Error { transient = false })
+      error_response;
+    Log.Misc.error "oas_worker %s: execution exception: %s\nBacktrace: %s"
+      config.name (Printexc.to_string exn) bt;
+    (* Keep the typed internal-error envelope, but construct it locally so
+       Runtime_agent does not depend on Cascade_error_classify. *)
+    let typed_internal_error =
+      "[masc_oas_error] "
+      ^ Yojson.Safe.to_string
+          (`Assoc
+            [ "kind", `String "internal_unhandled_exception"
+            ; "site", `String "cascade_runner.execute"
+            ; "exn_repr", `String (Printexc.to_string exn)
+            ])
+    in
+    Error (Agent_sdk.Error.Internal typed_internal_error))
+
+(* ================================================================ *)
+(* Convenience: run_with_masc_tools                                  *)
+(* ================================================================ *)
+
+let run_with_masc_tools
+    ~(sw : Eio.Switch.t)
+    ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
+    ~(config : config)
+    ~(masc_tools : Masc_domain.tool_schema list)
+    ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.result)
+    ?on_event
+    ?on_yield
+    ?on_resume
+    (goal : string)
+  : (run_result, Agent_sdk.Error.sdk_error) result =
+  match
+    public_mcp_runtime_policy_of_tool_names
+      (List.map (fun (td : Masc_domain.tool_schema) -> td.name) masc_tools)
+  with
+  | Some runtime_mcp_policy
+    when Provider_tool_support.provider_supports_runtime_mcp_policy
+           config.provider_cfg runtime_mcp_policy ->
+      let config = { config with runtime_mcp_policy = Some runtime_mcp_policy } in
+      run ~sw ~net ~config ?on_event ?on_yield ?on_resume goal
+  | _ when masc_tools = [] ->
+      run ~sw ~net ~config ?on_event ?on_yield ?on_resume goal
+  | _ when provider_supports_inline_tools config.provider_cfg ->
+      let oas_tools =
+        List.map
+          (fun (td : Masc_domain.tool_schema) ->
+            Tool_bridge.oas_tool_of_masc
+              ~name:td.name
+              ~description:td.description
+              ~input_schema:td.input_schema
+              (fun input -> dispatch ~name:td.name ~args:input))
+          masc_tools
+      in
+      let config = { config with tools = oas_tools @ config.tools } in
+      run ~sw ~net ~config ?on_event ?on_yield ?on_resume goal
+  | _ ->
+      Error
+        (invalid_runtime_config "tool_support"
+           (Printf.sprintf
+              "%s does not support inline tools or request-scoped runtime MCP tools"
+              (provider_label config.provider_cfg)))

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -1,0 +1,296 @@
+(** Runtime_agent — config, build, and run entry points
+    for OAS agent execution.
+
+    Thin facade over {!Runtime_agent_context},
+    {!Runtime_transport}, and
+    {!Keeper_oas_checkpoint}.  External callers reach
+    the run/config entry points via [Runtime_agent.X];
+    provider transport internals (CLI / MCP wire formats,
+    runtime policy projections, and transport-local
+    diagnostics) are owned by {!Runtime_transport}.
+
+    All model-selection and cascade logic lives in
+    {!Cascade_observation} and {!Keeper_turn_driver}.
+
+    Internal helpers stay private at this boundary
+    ([invalid_runtime_config],
+    [cli_model_override],
+    [provider_supports_inline_tools],
+    [provider_supports_runtime_mcp_lane],
+    [dedupe_preserve_order],
+    [public_mcp_tool_names_of_oas_tools],
+    [public_mcp_tool_requires_bound_actor],
+    [public_mcp_tools_of_oas_tools],
+    [tool_names_are_public_mcp],
+    [non_http_transport_of_provider],
+    [persist_checkpoint], [build_checkpoint],
+    [partial_response_of_stop]). *)
+
+(** {1 Stop reason} *)
+
+type stop_reason = Runtime_agent_context.stop_reason =
+  | Completed
+  | TurnBudgetExhausted of { turns_used : int; limit : int }
+  | MutationBoundaryReached of {
+      turns_used : int;
+      tool_name : string option;
+    }
+(** Why the run terminated.  [Completed] is the success
+    path; [TurnBudgetExhausted] fires when the per-call
+    [max_turns] is hit; [MutationBoundaryReached] fires
+    when the keeper hit a mutation tool while in
+    read-only mode (the [tool_name] surfaces which tool
+    triggered the gate). *)
+
+(** {1 CLI transport overrides} *)
+
+type cli_transport_overrides =
+  Runtime_transport.cli_transport_overrides = {
+  cwd : string option;
+  claude_mcp_config : string option;
+  claude_allowed_tools : string list option;
+  claude_permission_mode : string option;
+  claude_max_turns : int option;
+  gemini_yolo : bool option;
+  cli_subprocess_idle_sec : float option;
+}
+(** Per-call overrides threaded into local CLI transports.
+    [cli_subprocess_idle_sec] is honoured by transports that execute their
+    subprocess directly; see {!Runtime_transport.cli_transport_overrides}. *)
+
+(** {1 Config} *)
+
+type config = Runtime_agent_context.config = {
+  name : string;
+  provider_cfg : Llm_provider.Provider_config.t;
+  provider : Agent_sdk.Provider.config;
+  model_id : string;
+  priority : Llm_provider.Request_priority.t option;
+  system_prompt : string;
+  tools : Agent_sdk.Tool.t list;
+  runtime_mcp_policy :
+    Llm_provider.Llm_transport.runtime_mcp_policy option;
+  max_turns : int;
+  max_idle_turns : int;
+  stream_idle_timeout_s : float option;
+  max_execution_time_s : float option;
+  body_timeout_s : float option;
+  max_tokens : int;
+  max_input_tokens : int option;
+  max_cost_usd : float option;
+  temperature : float;
+  hooks : Agent_sdk.Hooks.hooks option;
+  context_reducer : Agent_sdk.Context_reducer.t option;
+  guardrails : Agent_sdk.Guardrails.t option;
+  event_bus : Agent_sdk.Event_bus.t option;
+  checkpoint_dir : string option;
+  session_id : string option;
+  description : string option;
+  memory : Agent_sdk.Memory.t option;
+  initial_messages : Agent_sdk.Types.message list;
+  raw_trace : Agent_sdk.Raw_trace.t option;
+  tool_retry_policy : Agent_sdk.Tool_retry_policy.t option;
+  required_tool_satisfaction :
+    Agent_sdk.Completion_contract.required_tool_satisfaction;
+  enable_thinking : bool option;
+  transport : Masc_grpc_transport.t;
+  allowed_paths : string list;
+  checkpoint_sidecar : Yojson.Safe.t option;
+  cache_system_prompt : bool;
+  yield_on_tool : bool;
+  compact_ratio : float option;
+  oas_auto_context_overflow_retry : bool;
+  context_injector : Agent_sdk.Hooks.context_injector option;
+  context : Agent_sdk.Context.t option;
+  slot_id : int option;
+  approval : Agent_sdk.Hooks.approval_callback option;
+  exit_condition : (int -> bool) option;
+  exit_condition_result : (int -> stop_reason * string option) option;
+  summarizer : (Agent_sdk.Types.message list -> string) option;
+  cli_transport_overrides : cli_transport_overrides option;
+}
+
+val default_config :
+  name:string ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  system_prompt:string ->
+  tools:Agent_sdk.Tool.t list ->
+  config
+(** Builds a {!config} populated with sensible defaults
+    for every field except the four required ones.
+    Caller mutates fields in place via record copy
+    ([\{ cfg with ... \}]) before passing to {!build} or
+    {!resume_from_checkpoint}. *)
+
+(** {1 Run result} *)
+
+type run_result = {
+  response : Agent_sdk.Types.api_response;
+  checkpoint : Agent_sdk.Checkpoint.t option;
+  session_id : string;
+  turns : int;
+  trace_ref : Agent_sdk.Raw_trace.run_ref option;
+  run_validation : Agent_sdk.Raw_trace.run_validation option;
+  cascade_observation : Cascade_observation.cascade_observation option;
+  stop_reason : stop_reason;
+}
+
+type worker_lifecycle_classification =
+  { event : string
+  ; status : string
+  ; error : string option
+  }
+
+val worker_lifecycle_classification_of_result :
+  (run_result, Agent_sdk.Error.sdk_error) result -> worker_lifecycle_classification
+
+
+(** {1 Label resolution} *)
+
+val label_resolution_error_to_string :
+  Runtime_transport.label_resolution_error -> string
+val label_resolution_error_to_sdk_error :
+  Runtime_transport.label_resolution_error ->
+  Agent_sdk.Error.sdk_error
+
+val resolve_provider_config_of_label :
+  string -> (Llm_provider.Provider_config.t,
+             Runtime_transport.label_resolution_error) result
+
+(** {1 Provider helpers} *)
+
+val provider_caps_of_config :
+  Llm_provider.Provider_config.t ->
+  Llm_provider.Capabilities.capabilities
+val provider_label : Llm_provider.Provider_config.t -> string
+val cli_tool_d_max_turns_hard_cap : int
+val provider_effective_max_turns :
+  Llm_provider.Provider_config.provider_kind -> int -> int
+
+(** {1 Runtime-MCP policy} *)
+
+val runtime_mcp_tool_requires_bound_actor : string -> bool
+val runtime_mcp_policy_with_masc_agent_name :
+  ?include_internal_token:bool ->
+  agent_name:string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy ->
+  Llm_provider.Llm_transport.runtime_mcp_policy
+val cli_tool_a_can_auth_keeper_bound_runtime_mcp :
+  agent_name:string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy ->
+  bool
+val runtime_mcp_policy_for_provider :
+  provider_cfg:Llm_provider.Provider_config.t ->
+  agent_name:string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+val public_mcp_runtime_policy_of_tool_names :
+  ?agent_name:string ->
+  string list ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+val runtime_mcp_policy_of_tool_names :
+  ?agent_name:string ->
+  ?allow_keeper_internal:bool ->
+  string list ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+val resolve_tool_lane_for_oas_tools :
+  ?agent_name:string ->
+  ?tool_requirement:[ `Required | `Optional ] ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  tools:Agent_sdk.Tool.t list ->
+  unit ->
+  ( Agent_sdk.Tool.t list
+    * Llm_provider.Llm_transport.runtime_mcp_policy option,
+    Agent_sdk.Error.sdk_error )
+  result
+
+(** {1 Per-call switch transport} *)
+
+val make_per_call_switch_transport :
+  (sw:Eio.Switch.t -> Llm_provider.Llm_transport.t) ->
+  Llm_provider.Llm_transport.t
+
+module For_testing : sig
+  val request_runtime_fields_on_base_config :
+    base:Llm_provider.Provider_config.t ->
+    Llm_provider.Provider_config.t ->
+    Llm_provider.Provider_config.t
+
+  val provider_http_slot_transport :
+    Llm_provider.Llm_transport.t -> Llm_provider.Llm_transport.t
+
+  val provider_cli_slot_transport :
+    Llm_provider.Llm_transport.t -> Llm_provider.Llm_transport.t
+end
+
+(** {1 Lifecycle / checkpoint helpers (re-exported)} *)
+
+val publish_lifecycle :
+  Agent_sdk.Event_bus.t ->
+  name:string ->
+  event:string ->
+  detail:string ->
+  ?error:string ->
+  ?session_id:string ->
+  ?status:string ->
+  ?attrs:(string * Yojson.Safe.t) list ->
+  unit ->
+  unit
+val enrich_idle_detail :
+  string -> Agent_sdk.Types.message list -> string
+
+(** {1 Build / resume / run} *)
+
+val build :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  config:config ->
+  (Agent_sdk.Agent.t, Agent_sdk.Error.sdk_error) result
+(** Builds an [Agent_sdk.Agent.t] from a {!config} ready for a
+    fresh run.  Resolves the per-call non-HTTP transport
+    via {!non_http_transport_of_provider}; threads
+    [config.approval] into the OAS builder when present. *)
+
+val resume_from_checkpoint :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  config:config ->
+  checkpoint:Agent_sdk.Checkpoint.t ->
+  (Agent_sdk.Agent.t, Agent_sdk.Error.sdk_error) result
+(** Resumes from a persisted checkpoint.  Uses
+    [Runtime_agent_context.prepare_resume] to reconcile
+    [checkpoint.turn_count] with the current
+    [config.max_turns]. *)
+
+val run :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  config:config ->
+  ?oas_checkpoint:Agent_sdk.Checkpoint.t ->
+  ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
+  ?on_yield:(unit -> unit) ->
+  ?on_resume:(unit -> unit) ->
+  ?agent_ref:Agent_sdk.Agent.t option ref ->
+  string ->
+  (run_result, Agent_sdk.Error.sdk_error) result
+(** Runs an OAS agent against [goal].  When
+    [oas_checkpoint] is present, {!resume_from_checkpoint}
+    is used; otherwise {!build} produces a fresh agent.
+    Returns the wrapped {!run_result}; errors propagate
+    as [Agent_sdk.Error.sdk_error]. *)
+
+val run_with_masc_tools :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  config:config ->
+  masc_tools:Masc_domain.tool_schema list ->
+  dispatch:(name:string -> args:Yojson.Safe.t -> Tool_result.result) ->
+  ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
+  ?on_yield:(unit -> unit) ->
+  ?on_resume:(unit -> unit) ->
+  string ->
+  (run_result, Agent_sdk.Error.sdk_error) result
+(** Variant of {!run} that wires MASC public-MCP tools
+    into the agent through [dispatch].  Used by the
+    keeper-runtime path that needs to expose MCP-style
+    tools to the model alongside OAS tools. *)

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -1,0 +1,390 @@
+(** Runtime_agent_context — Shared config and agent assembly helpers.
+
+    This module owns the shared [config] surface plus the pure/defaulted
+    preparation logic used by both [build] and [resume_from_checkpoint].
+    [Runtime_agent] remains the public facade and still performs the
+    approval wiring and final [build_safe] / [Agent.resume] calls. *)
+
+type stop_reason =
+  | Completed
+  | TurnBudgetExhausted of
+      { turns_used : int
+      ; limit : int
+      }
+  | MutationBoundaryReached of
+      { turns_used : int
+      ; tool_name : string option
+      }
+
+type config =
+  { name : string
+  ; provider_cfg : Llm_provider.Provider_config.t
+  ; provider : Agent_sdk.Provider.config
+  ; model_id : string
+  ; priority : Llm_provider.Request_priority.t option
+  ; system_prompt : string
+  ; tools : Agent_sdk.Tool.t list
+  ; runtime_mcp_policy : Llm_provider.Llm_transport.runtime_mcp_policy option
+  ; max_turns : int
+  ; max_idle_turns : int
+  ; stream_idle_timeout_s : float option
+  ; max_execution_time_s : float option
+    (** Wall-clock ceiling for one [Agent_sdk.Agent.run] / [run_stream]
+          call. When [Some s] AND a clock is available at the call site,
+          agent_sdk's [with_optional_timeout] returns
+          [Error (Api (Retry.Timeout {...}))] after [s] seconds — the
+          cascade FSM already maps [Retry.Timeout] to a fallback signal,
+          so this is the canonical knob to bound a hung [run_stream]
+          when a provider closes the connection without [end_turn].
+          Default [None] preserves the historical behaviour
+          (block indefinitely on stream-parser hang). *)
+  ; body_timeout_s : float option
+    (** Total HTTP streaming body-consumption ceiling. This is forwarded to
+        OAS's [with_body_timeout] and complements [stream_idle_timeout_s]:
+        idle timeout catches inter-line silence, while body timeout bounds
+        the whole response body callback. Non-HTTP transports ignore it. *)
+  ; max_tokens : int
+  ; max_input_tokens : int option
+  ; max_cost_usd : float option
+  ; temperature : float
+  ; hooks : Agent_sdk.Hooks.hooks option
+  ; context_reducer : Agent_sdk.Context_reducer.t option
+  ; guardrails : Agent_sdk.Guardrails.t option
+  ; event_bus : Agent_sdk.Event_bus.t option
+  ; checkpoint_dir : string option
+  ; session_id : string option
+  ; description : string option
+  ; memory : Agent_sdk.Memory.t option
+  ; initial_messages : Agent_sdk.Types.message list
+  ; raw_trace : Agent_sdk.Raw_trace.t option
+  ; tool_retry_policy : Agent_sdk.Tool_retry_policy.t option
+  ; required_tool_satisfaction : Agent_sdk.Completion_contract.required_tool_satisfaction
+  ; enable_thinking : bool option
+  ; transport : Masc_grpc_transport.t
+  ; allowed_paths : string list
+  ; checkpoint_sidecar : Yojson.Safe.t option
+  ; cache_system_prompt : bool
+  ; yield_on_tool : bool
+  ; compact_ratio : float option
+  ; oas_auto_context_overflow_retry : bool
+  ; context_injector : Agent_sdk.Hooks.context_injector option
+  ; context : Agent_sdk.Context.t option
+  ; slot_id : int option
+  ; approval : Agent_sdk.Hooks.approval_callback option
+  ; exit_condition : (int -> bool) option
+  ; exit_condition_result : (int -> stop_reason * string option) option
+  ; summarizer : (Agent_sdk.Types.message list -> string) option
+  ; cli_transport_overrides : Runtime_transport.cli_transport_overrides option
+    (** Custom summarizer for OAS [Budget_strategy.reduce_for_budget]
+          Emergency-phase compaction. Defaults to OAS's extractive
+          default. Keeper workers inject [Keeper_summarizer.keeper_summarizer]
+          to scrub [STATE] blocks before the 100-char truncation. *)
+  }
+
+let default_config
+      ~name
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~system_prompt
+      ~tools
+  : config
+  =
+  let provider =
+    Agent_sdk.Provider.config_of_provider_config provider_cfg
+    |> Runtime_wire_overlay.apply ~provider_cfg
+  in
+  { name
+  ; provider_cfg
+  ; provider
+  ; model_id = provider_cfg.model_id
+  ; priority = None
+  ; system_prompt
+  ; tools
+  ; runtime_mcp_policy = None
+  ; max_turns = 20
+  ; max_idle_turns = 3
+  ; stream_idle_timeout_s = None
+  ; max_execution_time_s = None
+  ; body_timeout_s = None
+  ; max_tokens = Llm_provider.Constants.Inference_profile.agent_default.max_tokens
+  ; max_input_tokens = None
+  ; max_cost_usd = None
+  ; temperature = Llm_provider.Constants.Inference_profile.agent_default.temperature
+  ; hooks = None
+  ; context_reducer = None
+  ; guardrails = None
+  ; event_bus = None
+  ; checkpoint_dir = None
+  ; session_id = None
+  ; description = None
+  ; memory = None
+  ; initial_messages = []
+  ; raw_trace = None
+  ; tool_retry_policy = None
+  ; required_tool_satisfaction = Agent_sdk.Completion_contract.any_tool_call_satisfies
+  ; enable_thinking = None
+  ; transport = Masc_grpc_transport.from_env ()
+  ; allowed_paths = []
+  ; checkpoint_sidecar = None
+  ; cache_system_prompt = false
+  ; yield_on_tool = false
+  ; compact_ratio = None
+  ; oas_auto_context_overflow_retry = true
+  ; context_injector = None
+  ; context = None
+  ; slot_id = None
+  ; approval = None
+  ; exit_condition = None
+  ; exit_condition_result = None
+  ; summarizer = None
+  ; cli_transport_overrides = None
+  }
+;;
+
+let guardrails_of_config (config : config) =
+  let tool_names = List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) config.tools in
+  match config.guardrails with
+  | Some g -> g
+  | None ->
+    { Agent_sdk.Guardrails.default with
+      tool_filter =
+        (if tool_names <> []
+         then Agent_sdk.Guardrails.AllowList tool_names
+         else Agent_sdk.Guardrails.AllowAll)
+    }
+;;
+
+let builder_without_approval
+      ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
+      ~(config : config)
+      ?transport
+      ()
+  : Agent_sdk.Builder.t
+  =
+  let guardrails = guardrails_of_config config in
+  let builder =
+    Agent_sdk.Builder.create ~net ~model:config.model_id
+    |> Agent_sdk.Builder.with_name config.name
+    |> Agent_sdk.Builder.with_system_prompt config.system_prompt
+    |> Agent_sdk.Builder.with_max_tokens config.max_tokens
+    |> Agent_sdk.Builder.with_max_turns config.max_turns
+    |> Agent_sdk.Builder.with_max_idle_turns config.max_idle_turns
+    |> Agent_sdk.Builder.with_temperature config.temperature
+    |> Agent_sdk.Builder.with_provider config.provider
+    |> Agent_sdk.Builder.with_tools config.tools
+    |> Agent_sdk.Builder.with_guardrails guardrails
+    |> Agent_sdk.Builder.with_missing_approval_callback_policy
+         Agent_sdk.Hooks.Reject_without_callback
+  in
+  let builder =
+    match config.stream_idle_timeout_s with
+    | Some timeout_s -> Agent_sdk.Builder.with_stream_idle_timeout timeout_s builder
+    | None -> builder
+  in
+  let builder =
+    match config.max_execution_time_s with
+    | Some s -> Agent_sdk.Builder.with_max_execution_time s builder
+    | None -> builder
+  in
+  let builder =
+    match config.body_timeout_s with
+    | Some s -> Agent_sdk.Builder.with_body_timeout s builder
+    | None -> builder
+  in
+  let builder =
+    if config.tools <> []
+    then Agent_sdk.Builder.with_tool_choice Agent_sdk.Types.Auto builder
+    else builder
+  in
+  let builder =
+    match config.hooks with
+    | Some h -> Agent_sdk.Builder.with_hooks h builder
+    | None -> builder
+  in
+  let builder =
+    match config.context_reducer with
+    | Some r -> Agent_sdk.Builder.with_context_reducer r builder
+    | None -> builder
+  in
+  let builder =
+    match config.description with
+    | Some d -> Agent_sdk.Builder.with_description d builder
+    | None -> builder
+  in
+  let builder =
+    match config.memory with
+    | Some m -> Agent_sdk.Builder.with_memory m builder
+    | None -> builder
+  in
+  let builder =
+    match config.raw_trace with
+    | Some raw_trace -> Agent_sdk.Builder.with_raw_trace raw_trace builder
+    | None -> builder
+  in
+  let builder =
+    match config.tool_retry_policy with
+    | Some policy -> Agent_sdk.Builder.with_tool_retry_policy policy builder
+    | None -> builder
+  in
+  let builder =
+    Agent_sdk.Builder.with_required_tool_satisfaction
+      config.required_tool_satisfaction
+      builder
+  in
+  let builder =
+    match config.enable_thinking with
+    | Some enabled -> Agent_sdk.Builder.with_enable_thinking enabled builder
+    | None -> builder
+  in
+  let builder =
+    match config.priority with
+    | Some priority -> Agent_sdk.Builder.with_priority priority builder
+    | None -> builder
+  in
+  let builder =
+    match config.max_cost_usd with
+    | Some usd -> Agent_sdk.Builder.with_max_cost_usd usd builder
+    | None -> builder
+  in
+  let builder =
+    match config.max_input_tokens with
+    | Some tokens -> Agent_sdk.Builder.with_max_input_tokens tokens builder
+    | None -> builder
+  in
+  let builder =
+    match config.runtime_mcp_policy with
+    | Some policy -> Agent_sdk.Builder.with_runtime_mcp_policy policy builder
+    | None -> builder
+  in
+  let builder =
+    if config.cache_system_prompt
+    then Agent_sdk.Builder.with_cache_system_prompt true builder
+    else builder
+  in
+  let builder =
+    if config.yield_on_tool
+    then Agent_sdk.Builder.with_yield_on_tool true builder
+    else builder
+  in
+  let builder =
+    if config.allowed_paths <> []
+    then Agent_sdk.Builder.with_allowed_paths config.allowed_paths builder
+    else builder
+  in
+  let builder =
+    if config.initial_messages <> []
+    then Agent_sdk.Builder.with_initial_messages config.initial_messages builder
+    else builder
+  in
+  let builder =
+    match config.compact_ratio with
+    | Some ratio -> Agent_sdk.Builder.with_context_thresholds ~compact_ratio:ratio builder
+    | None -> builder
+  in
+  let builder =
+    Agent_sdk.Builder.with_auto_context_overflow_retry
+      config.oas_auto_context_overflow_retry
+      builder
+  in
+  let builder =
+    match config.context_injector with
+    | Some injector -> Agent_sdk.Builder.with_context_injector injector builder
+    | None -> builder
+  in
+  let builder =
+    match config.context with
+    | Some ctx -> Agent_sdk.Builder.with_context ctx builder
+    | None -> builder
+  in
+  let builder =
+    match config.slot_id with
+    | Some id -> Agent_sdk.Builder.with_slot_id id builder
+    | None -> builder
+  in
+  let builder =
+    match config.exit_condition with
+    | Some cond -> Agent_sdk.Builder.with_exit_condition cond builder
+    | None -> builder
+  in
+  let builder =
+    match config.summarizer with
+    | Some s -> Agent_sdk.Builder.with_summarizer s builder
+    | None -> builder
+  in
+  match transport with
+  | Some transport -> Agent_sdk.Builder.with_transport transport builder
+  | None -> builder
+;;
+
+type prepared_resume =
+  { patched_checkpoint : Agent_sdk.Checkpoint.t
+  ; agent_config : Agent_sdk.Types.agent_config
+  ; options : Agent_sdk.Agent.options
+  }
+
+let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
+  : prepared_resume
+  =
+  let effective_max_turns = checkpoint.turn_count + config.max_turns in
+  let effective_max_cost_usd =
+    match config.max_cost_usd with
+    | Some budget -> Some (checkpoint.usage.estimated_cost_usd +. budget)
+    | None -> None
+  in
+  let patched_checkpoint =
+    { checkpoint with
+      Agent_sdk.Checkpoint.model = config.model_id
+    ; system_prompt = Some config.system_prompt
+    ; temperature = Some config.temperature
+    ; enable_thinking = config.enable_thinking
+    ; cache_system_prompt = config.cache_system_prompt
+    ; max_input_tokens = config.max_input_tokens
+    ; max_total_tokens = None
+    }
+  in
+  let agent_config : Agent_sdk.Types.agent_config =
+    { Agent_sdk.Types.default_config with
+      name = config.name
+    ; model = config.model_id
+    ; system_prompt = Some config.system_prompt
+    ; max_tokens = Some config.max_tokens
+    ; max_turns = effective_max_turns
+    ; temperature = Some config.temperature
+    ; enable_thinking = config.enable_thinking
+    ; cache_system_prompt = config.cache_system_prompt
+    ; max_input_tokens = config.max_input_tokens
+    ; max_cost_usd = effective_max_cost_usd
+    ; yield_on_tool = config.yield_on_tool
+    ; context_compact_ratio = config.compact_ratio
+    ; priority = config.priority
+    ; exit_condition = config.exit_condition
+    }
+  in
+  let options : Agent_sdk.Agent.options =
+    { Agent_sdk.Agent.default_options with
+      provider = Some config.provider
+    ; hooks = Option.value ~default:Agent_sdk.Hooks.empty config.hooks
+    ; max_idle_turns = config.max_idle_turns
+    ; stream_idle_timeout_s = config.stream_idle_timeout_s
+    ; max_execution_time_s = config.max_execution_time_s
+    ; body_timeout_s = config.body_timeout_s
+    ; guardrails = guardrails_of_config config
+    ; context_reducer = config.context_reducer
+    ; context_injector = config.context_injector
+    ; event_bus = config.event_bus
+    ; memory = config.memory
+    ; raw_trace = config.raw_trace
+    ; tool_retry_policy = config.tool_retry_policy
+    ; required_tool_satisfaction = config.required_tool_satisfaction
+    ; allowed_paths = config.allowed_paths
+    ; description = config.description
+    ; approval = config.approval
+    ; missing_approval_callback_policy =
+        Agent_sdk.Hooks.Reject_without_callback
+    ; slot_id = config.slot_id
+    ; runtime_mcp_policy = config.runtime_mcp_policy
+    ; summarizer = config.summarizer
+    ; priority = config.priority
+    }
+  in
+  { patched_checkpoint; agent_config; options }
+;;

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -1,0 +1,139 @@
+(** Runtime_agent_context — shared {!config} surface and agent
+    assembly helpers.
+
+    Owns the shared per-worker {!config} record + pure / defaulted
+    preparation logic shared by both
+    {!Runtime_agent.build} and
+    {!Runtime_agent.resume_from_checkpoint}.
+    {!Runtime_agent} remains the public facade and still
+    performs the approval wiring and final
+    [build_safe] / [Agent.resume] calls.
+
+    Internal: \[guardrails_of_config\] (ToolName-list extraction
+    used by builder) stays private — it is consumed only inside
+    {!builder_without_approval}. *)
+
+(** {1 Stop reason} *)
+
+(** Why a worker run terminated. *)
+type stop_reason =
+  | Completed
+  | TurnBudgetExhausted of { turns_used : int; limit : int }
+  | MutationBoundaryReached of {
+      turns_used : int;
+      tool_name : string option;
+    }
+
+(** {1 Per-worker config} *)
+
+type config = {
+  name : string;
+  provider_cfg : Llm_provider.Provider_config.t;
+  provider : Agent_sdk.Provider.config;
+  model_id : string;
+  priority : Llm_provider.Request_priority.t option;
+  system_prompt : string;
+  tools : Agent_sdk.Tool.t list;
+  runtime_mcp_policy :
+    Llm_provider.Llm_transport.runtime_mcp_policy option;
+  max_turns : int;
+  max_idle_turns : int;
+  stream_idle_timeout_s : float option;
+  max_execution_time_s : float option;
+      (** Wall-clock ceiling for one [Agent.run] / [run_stream] call.
+          When [Some] AND a clock is available, agent_sdk returns
+          [Retry.Timeout] after [s] seconds. Default [None] preserves
+          historical block-on-hang behaviour. *)
+  body_timeout_s : float option;
+      (** Total HTTP streaming body-consumption ceiling forwarded to
+          OAS [Builder.with_body_timeout]. Complements
+          [stream_idle_timeout_s]: idle timeout catches inter-line
+          silence, body timeout bounds the whole body callback.
+          Non-HTTP transports ignore it. *)
+  max_tokens : int;
+  max_input_tokens : int option;
+  max_cost_usd : float option;
+  temperature : float;
+  hooks : Agent_sdk.Hooks.hooks option;
+  context_reducer : Agent_sdk.Context_reducer.t option;
+  guardrails : Agent_sdk.Guardrails.t option;
+  event_bus : Agent_sdk.Event_bus.t option;
+  checkpoint_dir : string option;
+  session_id : string option;
+  description : string option;
+  memory : Agent_sdk.Memory.t option;
+  initial_messages : Agent_sdk.Types.message list;
+  raw_trace : Agent_sdk.Raw_trace.t option;
+  tool_retry_policy : Agent_sdk.Tool_retry_policy.t option;
+  required_tool_satisfaction :
+    Agent_sdk.Completion_contract.required_tool_satisfaction;
+  enable_thinking : bool option;
+  transport : Masc_grpc_transport.t;
+  allowed_paths : string list;
+  checkpoint_sidecar : Yojson.Safe.t option;
+  cache_system_prompt : bool;
+  yield_on_tool : bool;
+  compact_ratio : float option;
+  oas_auto_context_overflow_retry : bool;
+  context_injector : Agent_sdk.Hooks.context_injector option;
+  context : Agent_sdk.Context.t option;
+  slot_id : int option;
+  approval : Agent_sdk.Hooks.approval_callback option;
+  exit_condition : (int -> bool) option;
+  exit_condition_result : (int -> stop_reason * string option) option;
+  summarizer : (Agent_sdk.Types.message list -> string) option;
+  cli_transport_overrides :
+    Runtime_transport.cli_transport_overrides option;
+}
+(** Per-worker configuration.  49 fields — concrete record because
+    callers ({!Runtime_agent}, keeper workers) construct + tweak
+    fields field-by-field at the dispatch site. *)
+
+(** {1 Default config builder} *)
+
+val default_config :
+  name:string ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  system_prompt:string ->
+  tools:Agent_sdk.Tool.t list ->
+  config
+(** [default_config ~name ~provider_cfg ~system_prompt ~tools]
+    returns a {!config} populated with sensible defaults for every
+    field except the four required ones.  Caller mutates fields
+    in place via record copy ([{ cfg with ... }]) before passing
+    to {!builder_without_approval} or {!prepare_resume}. *)
+
+(** {1 Builder (no approval)} *)
+
+val builder_without_approval :
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  config:config ->
+  ?transport:Llm_provider.Llm_transport.t ->
+  unit ->
+  Agent_sdk.Builder.t
+(** [builder_without_approval ~net ~config ?transport ()] builds an
+    {!Agent_sdk.Builder.t} from [config] without wiring approval
+    callbacks.  Approval wiring is the responsibility of the
+    public facade ({!Runtime_agent}) which adds the approval
+    callback before calling [Builder.build_safe]. *)
+
+(** {1 Resume preparation} *)
+
+type prepared_resume = {
+  patched_checkpoint : Agent_sdk.Checkpoint.t;
+  agent_config : Agent_sdk.Types.agent_config;
+  options : Agent_sdk.Agent.options;
+}
+(** Output of {!prepare_resume}.  [patched_checkpoint] has
+    [turn_count] and budget fields adjusted so that resume picks
+    up where the previous run left off without re-counting
+    consumed turns. *)
+
+val prepare_resume :
+  config:config -> checkpoint:Agent_sdk.Checkpoint.t -> prepared_resume
+(** [prepare_resume ~config ~checkpoint] computes the patched
+    checkpoint + agent_config + options for an
+    [Agent.resume] call.  Pure — no side effects.  The patched
+    checkpoint extends [config.max_turns] beyond the consumed
+    [checkpoint.turn_count] so the resumed run gets a fresh
+    turn budget instead of inheriting the exhausted one. *)

--- a/lib/runtime/runtime_constants.ml
+++ b/lib/runtime/runtime_constants.ml
@@ -1,0 +1,10 @@
+(** Runtime numeric constants (RFC-0206 cascade→Runtime rebirth).
+
+    Re-homes the constants that lived on the deleted [Cascade_runtime] module
+    and were referenced by surviving consumers (relay, dashboard health,
+    context compaction). No routing/catalog state — pure named values. *)
+
+(** Context-window size assumed when a model declares none and discovery
+    yields nothing. Mirrors the deleted [Cascade_runtime.fallback_context_window].
+    128k is the conservative floor across the supported provider matrix. *)
+let fallback_context_window = 128_000

--- a/lib/runtime/runtime_constants.mli
+++ b/lib/runtime/runtime_constants.mli
@@ -1,0 +1,5 @@
+(** Runtime numeric constants (RFC-0206). Re-homed from deleted [Cascade_runtime]. *)
+
+val fallback_context_window : int
+(** Context-window size assumed when a model declares none and discovery yields
+    nothing (128000). Mirrors deleted [Cascade_runtime.fallback_context_window]. *)

--- a/lib/runtime/runtime_deadline.ml
+++ b/lib/runtime/runtime_deadline.ml
@@ -1,0 +1,22 @@
+type t = { expires_at_s : float }
+
+let create ~expires_at_s = { expires_at_s }
+
+let of_seconds_from_now ~clock secs =
+  { expires_at_s = Eio.Time.now clock +. secs }
+
+let expires_at d = d.expires_at_s
+
+let remaining_at ~now_s d = Float.max 0.0 (d.expires_at_s -. now_s)
+
+let composed_attempt_budget_at ~now_s ~deadline ~amplifier =
+  Float.min amplifier (remaining_at ~now_s deadline)
+
+let is_expired_at ~now_s d = remaining_at ~now_s d = 0.0
+
+let remaining_seconds ~clock d = remaining_at ~now_s:(Eio.Time.now clock) d
+
+let composed_attempt_budget ~clock ~deadline ~amplifier =
+  composed_attempt_budget_at ~now_s:(Eio.Time.now clock) ~deadline ~amplifier
+
+let is_expired ~clock d = is_expired_at ~now_s:(Eio.Time.now clock) d

--- a/lib/runtime/runtime_deadline.mli
+++ b/lib/runtime/runtime_deadline.mli
@@ -1,0 +1,67 @@
+(** Cascade per-attempt deadline value carrying a wall-clock time horizon.
+
+    RFC-0192 § 2 invariant carrier:
+    [effective_attempt_budget(i) = min(default_amplifier, deadline - now())]
+
+    PR-1 establishes the type and math helpers; PR-2 wires it into
+    [Cascade_tier_wait_scheduler.try_admission_or_wait]; PR-3 has
+    [Keeper_agent_run] compute it from [admission_wait_timeout_sec] and
+    thread through the keeper turn driver chain.
+
+    The pure {!remaining_at} / {!composed_attempt_budget_at} variants take
+    an explicit [now_s] so the math is unit-testable without an Eio runtime.
+    The clock-bearing wrappers ({!of_seconds_from_now} etc.) call
+    {!Eio.Time.now} under the hood and are tested via integration. *)
+
+type t
+
+(** {1 Construction} *)
+
+(** [create ~expires_at_s] is the wall-clock absolute time when this
+    deadline elapses. Exposed primarily for tests. *)
+val create : expires_at_s:float -> t
+
+(** [of_seconds_from_now ~clock secs] is a deadline [secs] in the future
+    relative to [clock]. Use this in production code. *)
+val of_seconds_from_now :
+  clock:float Eio.Time.clock_ty Eio.Resource.t -> float -> t
+
+(** [expires_at d] is the underlying wall-clock seconds since Unix epoch.
+    Exposed for telemetry and logging; do not use for arithmetic — prefer
+    {!remaining_seconds} / {!composed_attempt_budget} to keep callers
+    independent of the time source. *)
+val expires_at : t -> float
+
+(** {1 Pure math (unit-testable, no Eio runtime needed)} *)
+
+(** [remaining_at ~now_s d] is [max 0.0 (expires_at d -. now_s)]. Never
+    negative; an expired deadline returns [0.0]. *)
+val remaining_at : now_s:float -> t -> float
+
+(** [composed_attempt_budget_at ~now_s ~deadline ~amplifier] is the
+    RFC-0192 § 2 invariant:
+    [min amplifier (remaining_at ~now_s deadline)].
+
+    [amplifier] is the per-attempt default (existing
+    [Env_config_keeper.CascadeTierWait.timeout_s ()]) and acts as the
+    upper bound. [deadline] acts as the lower bound. The result is
+    never negative. *)
+val composed_attempt_budget_at :
+  now_s:float -> deadline:t -> amplifier:float -> float
+
+(** [is_expired_at ~now_s d] is [remaining_at ~now_s d = 0.0]. *)
+val is_expired_at : now_s:float -> t -> bool
+
+(** {1 Clock-bearing convenience wrappers (for production callers)} *)
+
+val remaining_seconds :
+  clock:float Eio.Time.clock_ty Eio.Resource.t -> t -> float
+
+val composed_attempt_budget :
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  deadline:t ->
+  amplifier:float ->
+  float
+
+val is_expired :
+  clock:float Eio.Time.clock_ty Eio.Resource.t -> t -> bool

--- a/lib/runtime/runtime_metrics.ml
+++ b/lib/runtime/runtime_metrics.ml
@@ -1,0 +1,31 @@
+(** Runtime telemetry emitters (RFC-0206 cascade→Runtime rebirth).
+
+    Re-homes the prometheus counter ticks that surviving consumers still call
+    from the deleted [Cascade_metrics]. ONLY the consumer-referenced emitters
+    are ported; the routing-aware aggregation in [Cascade_metrics]
+    (depended on Cascade_routes/Cascade_runtime/Cascade_inference) is NOT
+    restored — it was the routing layer RFC-0206 §5 discards.
+
+    The prometheus metric-name strings are preserved verbatim
+    ([masc_cascade_*_total]): they are an operator-facing seam (Grafana
+    dashboards / alert rules query them by name), so renaming the module does
+    not rename the series. *)
+
+let metric_provider_cooldown = "masc_cascade_provider_cooldown_total"
+let metric_cascade_metrics_eviction = "masc_cascade_metrics_eviction_total"
+let metric_cascade_audit_failure = "masc_cascade_audit_failure_total"
+
+let on_provider_cooldown ~provider ~reason =
+  Prometheus.inc_counter
+    metric_provider_cooldown
+    ~labels:[ ("provider", provider); ("reason", reason) ]
+    ()
+;;
+
+let on_cascade_metrics_eviction () =
+  Prometheus.inc_counter metric_cascade_metrics_eviction ()
+;;
+
+let on_cascade_audit_failure ~stage =
+  Prometheus.inc_counter metric_cascade_audit_failure ~labels:[ ("stage", stage) ] ()
+;;

--- a/lib/runtime/runtime_metrics.mli
+++ b/lib/runtime/runtime_metrics.mli
@@ -1,0 +1,15 @@
+(** Runtime telemetry emitters (RFC-0206). Re-homed prometheus counter ticks
+    from deleted [Cascade_metrics]; metric-name strings preserved verbatim
+    (operator dashboard seam). *)
+
+val on_provider_cooldown : provider:string -> reason:string -> unit
+(** Tick the per-provider cooldown-entry counter
+    ([masc_cascade_provider_cooldown_total]). *)
+
+val on_cascade_metrics_eviction : unit -> unit
+(** Tick the metrics LRU eviction counter
+    ([masc_cascade_metrics_eviction_total]). *)
+
+val on_cascade_audit_failure : stage:string -> unit
+(** Tick the audit subsystem failure counter
+    ([masc_cascade_audit_failure_total]). *)

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -1,0 +1,500 @@
+(** Runtime_oas_runner — Eio context, cascade resolution, runtime MCP policy.
+
+    Extracted from oas_worker_named.ml (God file decomposition).
+    Provides cascade profile defaults, Eio context validation,
+    provider resolution, and tool-support filtering.
+
+    @since God file decomposition *)
+
+(* Cascade profile defaults (moved from Cascade module) *)
+
+let default_config_path = Cascade_runtime.cascade_config_path
+
+let default_model_strings ~cascade_name =
+  Cascade_runtime.default_model_strings
+    ~cascade_name:(Cascade_name.of_string_exn cascade_name)
+
+(* Named model execution *)
+
+let require_eio ?sw ?net () =
+  let sw =
+    match sw with
+    | Some s -> Some s
+    | None -> Eio_context.get_switch_opt ()
+  in
+  let net =
+    match net with
+    | Some n -> Some n
+    | None -> Eio_context.get_net_opt ()
+  in
+  match sw, net with
+  | Some sw, Some net -> Ok (sw, net)
+  | None, _ -> Error "Eio switch not available (running outside server context)"
+  | _, None -> Error "Eio net not available (running outside server context)"
+
+let eio_context_error_to_sdk_error detail =
+  Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field = "eio_context"; detail })
+
+let cascade_catalog_error_to_sdk_error detail =
+  Agent_sdk.Error.Config
+    (Agent_sdk.Error.InvalidConfig { field = "cascade_name"; detail })
+
+(** Resolve cascade provider configs via MASC Cascade_config.
+    Returns Provider_config.t list for the downstream OAS runtime,
+    bypassing the old Model_spec facade. *)
+let resolve_cascade_providers
+      ?provider_filter
+      ?(require_tool_choice_support = false)
+      ?(require_tool_support = false)
+      ?runtime_mcp_policy
+      ~cascade_name
+      ()
+  =
+  Cascade_runtime.resolve_named_providers_result_strict
+    ?provider_filter
+    ?runtime_mcp_policy
+    ~require_tool_choice_support
+    ~require_tool_support
+    ~cascade_name
+    ()
+
+let keeper_agent_name_opt (keeper_name : string) =
+  let keeper_name = String.trim keeper_name in
+  if keeper_name = "" then None else Some (Keeper_identity.keeper_agent_name keeper_name)
+
+let runtime_mcp_policy_for_tools ~(keeper_name : string) (tools : Agent_sdk.Tool.t list) =
+  let agent_name = keeper_agent_name_opt keeper_name in
+  let runtime_tool_names =
+    tools
+    |> List.filter (fun (tool : Agent_sdk.Tool.t) ->
+      Tool_catalog.is_public_mcp tool.schema.name
+      || (Option.is_some agent_name
+          && Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool.schema.name))
+    |> List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name)
+  in
+  let has_keeper_internal =
+    List.exists
+      (Tool_catalog.is_on_surface Tool_catalog.Keeper_internal)
+      runtime_tool_names
+  in
+  match
+    ( Runtime_agent.runtime_mcp_policy_of_tool_names
+        ?agent_name
+        ~allow_keeper_internal:has_keeper_internal
+        runtime_tool_names
+    , agent_name )
+  with
+  | Some policy, Some agent_name ->
+    Some (Runtime_agent.runtime_mcp_policy_with_masc_agent_name ~agent_name policy)
+  | Some policy, None -> Some policy
+  | None, _ -> None
+
+let keeper_internal_tool_names_for_runtime_surface
+      ~(keeper_name : string)
+      (tools : Agent_sdk.Tool.t list)
+  =
+  match keeper_agent_name_opt keeper_name with
+  | None -> []
+  | Some _ ->
+    tools
+    |> List.filter (fun (tool : Agent_sdk.Tool.t) ->
+      Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool.schema.name)
+    |> List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name)
+    |> List.sort_uniq String.compare
+
+let keeper_internal_tools_require_materialized_runtime_surface
+      ~(keeper_name : string)
+      (tools : Agent_sdk.Tool.t list)
+  =
+  keeper_internal_tool_names_for_runtime_surface ~keeper_name tools <> []
+
+let runtime_mcp_policy_for_provider
+      ~(keeper_name : string)
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option)
+  =
+  let agent_name = keeper_agent_name_opt keeper_name |> Option.value ~default:"" in
+  Runtime_agent.runtime_mcp_policy_for_provider ~provider_cfg ~agent_name policy_opt
+
+let cli_tool_a_cannot_carry_keeper_bound_runtime_mcp
+      ~(keeper_name : string)
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option)
+  =
+  (* RFC-0058 §2.4: dispatch by local tool-delivery policy, not provider name. *)
+  if
+    not
+      (Provider_tool_support
+       .provider_requires_per_keeper_bridging_for_bound_actor_tools
+         provider_cfg)
+  then false
+  else (
+    match keeper_agent_name_opt keeper_name, policy_opt with
+    | Some agent_name, Some policy
+      when Option.is_some (Keeper_identity.keeper_name_from_agent_name agent_name) ->
+      (not
+         (Runtime_agent.cli_tool_a_can_auth_keeper_bound_runtime_mcp ~agent_name policy))
+      && List.exists
+           Runtime_agent.runtime_mcp_tool_requires_bound_actor
+           policy.allowed_tool_names
+    | _ -> false)
+
+(* #10681: per-provider rejection reason produced by the cascade filter.
+   When the filter empties the cascade, operators previously saw only a
+   flat list of provider names; root-cause classification required
+   re-running each predicate by hand. The reason is now attached to the
+   provider in the WARN log so the next [no_tool_capable_provider] event
+   pinpoints the failing check on the first read.
+
+   Order of preference (mirrors the filter's short-circuit):
+   0. [Capability_profile_mismatch profile] — the provider's declared
+      capabilities do not satisfy the profile's
+      [required_capability_profile] (e.g. [tool_strict] requiring
+      [runtime_mcp_tools], [runtime_tool_events], [runtime_mcp_http_headers]).
+   1. [Codex_keeper_bound_actor_required] — cli_tool_a cannot carry a
+      runtime MCP policy that requires bound-actor tools (keeper-scoped).
+   2. [Tool_lane_unsupported] — [resolve_tool_lane_for_oas_tools]
+      returned [Error], typically transport/auth/capability mismatch
+      surfaced by [Runtime_agent].
+   3. [Required_tool_use { reason }] — the inline-tool-choice / runtime
+      MCP capability gate from [Provider_tool_support]. Re-uses the
+      existing [rejection_reason] so dashboards stay consistent with
+      [masc_cascade_filter_rejection_total]. *)
+type filter_rejection_reason =
+  | Capability_profile_mismatch of string
+  | Codex_keeper_bound_actor_required
+  | Tool_lane_unsupported
+  | Required_tool_use of Provider_tool_support.rejection_reason
+
+let filter_rejection_reason_label = function
+  | Capability_profile_mismatch profile ->
+    Printf.sprintf "capability_profile_mismatch:%s" profile
+  | Codex_keeper_bound_actor_required -> "codex_keeper_bound_actor_required"
+  | Tool_lane_unsupported -> "tool_lane_unsupported"
+  | Required_tool_use r -> Provider_tool_support.rejection_reason_label r
+
+let codex_keeper_bound_skip_seen : (string, float) Hashtbl.t = Hashtbl.create 16
+let codex_keeper_bound_skip_seen_mutex = Mutex.create ()
+let codex_keeper_bound_skip_restate_sec = Masc_time_constants.hour
+
+let codex_keeper_bound_skip_should_emit ~label ~provider_label ~keeper_name ~reason_label =
+  let key = Printf.sprintf "%s|%s|%s|%s" label provider_label keeper_name reason_label in
+  let now = Unix.gettimeofday () in
+  Mutex.lock codex_keeper_bound_skip_seen_mutex;
+  let first =
+    match Hashtbl.find_opt codex_keeper_bound_skip_seen key with
+    | None -> true
+    | Some last -> now -. last >= codex_keeper_bound_skip_restate_sec
+  in
+  if first then Hashtbl.replace codex_keeper_bound_skip_seen key now;
+  Mutex.unlock codex_keeper_bound_skip_seen_mutex;
+  first
+
+let codex_keeper_bound_skip_log_message ~label ~keeper_name provider_cfg reason =
+  match reason with
+  | Codex_keeper_bound_actor_required ->
+    Some
+      (Printf.sprintf
+         "cascade %s: skipped provider=%s for keeper=%s reason=%s"
+         label
+         (Provider_tool_support.provider_debug_label provider_cfg)
+         keeper_name
+         (filter_rejection_reason_label reason))
+  | Capability_profile_mismatch _ | Tool_lane_unsupported | Required_tool_use _ -> None
+
+let log_codex_keeper_bound_skip ~label ~keeper_name provider_cfg reason =
+  match codex_keeper_bound_skip_log_message ~label ~keeper_name provider_cfg reason with
+  | None -> ()
+  | Some message ->
+    let provider_label = Provider_tool_support.provider_debug_label provider_cfg in
+    let reason_label = filter_rejection_reason_label reason in
+    if
+      codex_keeper_bound_skip_should_emit
+        ~label
+        ~provider_label
+        ~keeper_name
+        ~reason_label
+    then
+      Log.Misc.info
+        "%s; repeated identical skip decisions demoted to DEBUG for the next %.0fs"
+        message
+        codex_keeper_bound_skip_restate_sec
+    else Log.Misc.debug "%s" message
+
+let classify_filter_rejection
+      ~(keeper_name : string)
+      ?runtime_mcp_policy
+      ?(tools = [])
+      ?required_capability_profile
+      ~require_tool_choice_support
+      ~require_tool_support
+      (provider_cfg : Llm_provider.Provider_config.t)
+  : filter_rejection_reason option
+  =
+  let profile_mismatch =
+    match required_capability_profile with
+    | None -> None
+    | Some profile ->
+      let caps = Provider_tool_support.capabilities_of_config provider_cfg in
+      if not (Cascade_capability_profile.provider_satisfies_profile profile caps)
+      then Some (Capability_profile_mismatch profile)
+      else None
+  in
+  match profile_mismatch with
+  | Some _ -> profile_mismatch
+  | None ->
+    if
+      cli_tool_a_cannot_carry_keeper_bound_runtime_mcp
+        ~keeper_name
+        ~provider_cfg
+        runtime_mcp_policy
+    then Some Codex_keeper_bound_actor_required
+    else (
+      let normalized_runtime_mcp_policy =
+        runtime_mcp_policy_for_provider ~keeper_name ~provider_cfg runtime_mcp_policy
+      in
+      let tool_lane_supported =
+        match tools with
+        | [] -> true
+        | _ ->
+          (match
+             Runtime_agent.resolve_tool_lane_for_oas_tools
+               ?agent_name:(keeper_agent_name_opt keeper_name)
+               ~tool_requirement:
+                 (if require_tool_choice_support || require_tool_support
+                  then `Required
+                  else `Optional)
+               ~provider_cfg
+               ~tools
+               ()
+           with
+           | Ok _ -> true
+           | Error _ -> false)
+      in
+      if not tool_lane_supported
+      then Some Tool_lane_unsupported
+      else (
+        match
+          Provider_tool_support.classify_rejection
+            ?runtime_mcp_policy:normalized_runtime_mcp_policy
+            ~require_tool_choice_support
+            ~require_tool_support
+            provider_cfg
+        with
+        | Some reason -> Some (Required_tool_use reason)
+        | None -> None))
+
+(* #11060: cascade-empty WARN dedupe.
+
+   When the tool-use gate empties a cascade (every configured
+   provider rejected — e.g. [keeper_unified] with only [cli_tool_a]
+   providers under a keeper-bound runtime MCP policy), the WARN
+   fires once per filtering invocation. Field log: 18 identical
+   WARN events / 49 min for a single misconfigured cascade — the
+   genuine signal (operator must edit cascade.toml) drowns in its
+   own repeats and shares the WARN level with normal degraded-mode
+   noise.
+
+   This dedupe boosts the first occurrence per
+   [(label, rejection_signature)] to ERROR with an operator-action
+   hint, and demotes subsequent identical signatures to DEBUG. The
+   one-hour [restate_sec] period re-emits the ERROR if the
+   misconfiguration persists, so an operator who missed the first
+   alert still sees the gap. The signature is sorted so the same
+   rejection set in different argument order does not bypass the
+   cache. *)
+let cascade_empty_warn_seen : (string, float) Hashtbl.t = Hashtbl.create 16
+let cascade_empty_warn_seen_mutex = Mutex.create ()
+let cascade_empty_warn_restate_sec = Masc_time_constants.hour
+
+let signature_of_rejected_providers rejected =
+  rejected
+  |> List.map (fun (cfg, reason) ->
+    Printf.sprintf
+      "%s:%s"
+      (Provider_tool_support.provider_debug_label cfg)
+      (filter_rejection_reason_label reason))
+  |> List.sort String.compare
+  |> String.concat ","
+
+let cascade_empty_should_emit_first ~label ~signature =
+  let key = label ^ "|" ^ signature in
+  let now = Unix.gettimeofday () in
+  Mutex.lock cascade_empty_warn_seen_mutex;
+  let first =
+    match Hashtbl.find_opt cascade_empty_warn_seen key with
+    | None -> true
+    | Some last -> now -. last >= cascade_empty_warn_restate_sec
+  in
+  if first then Hashtbl.replace cascade_empty_warn_seen key now;
+  Mutex.unlock cascade_empty_warn_seen_mutex;
+  first
+
+(** RFC-0027 PR-9b dual-track swap. When the tool-use gate rejects a
+    primary provider and the caller supplied a [secondary_resolver],
+    invoke it to obtain a candidate fallback provider. The fallback is
+    re-classified through the same gate; on pass it replaces the primary
+    in [kept], on failure (or when no secondary is configured) the
+    primary stays in [rejected].
+
+    Observability:
+    - Successful swap -> [emit_fallback_triggered ~kind:"dual_track_swap" ~detail:"swapped"]
+    - Secondary also rejected -> [emit_fallback_triggered ~kind:"dual_track_swap" ~detail:"<secondary_reason>"]
+    - No secondary configured -> no extra metric (the caller's existing
+      [cascade_empty:<reason>] capability_drop already covers this case).
+    The function is total and never raises; secondary parsing errors are
+    surfaced as [None] by the resolver. *)
+let attempt_secondary_swap
+      ~keeper_name
+      ?runtime_mcp_policy
+      ?required_capability_profile
+      ~tools
+      ~require_tool_choice_support
+      ~require_tool_support
+      ~(secondary_resolver :
+         int -> Llm_provider.Provider_config.t -> Llm_provider.Provider_config.t option)
+      ~(provider_index : int)
+      (primary, primary_reason)
+  : ( Llm_provider.Provider_config.t
+      , Llm_provider.Provider_config.t * filter_rejection_reason )
+      Either.t
+  =
+  match secondary_resolver provider_index primary with
+  | None -> Either.Right (primary, primary_reason)
+  | Some secondary ->
+    (* RFC-0027 PR-9c: per-secondary accounting label. The secondary's
+       [provider_kind] is a closed enum from
+       [Llm_provider.Provider_config.string_of_provider_kind], so label
+       cardinality stays bounded without putting concrete model ids on the
+       metric axis. *)
+    let secondary_kind_label =
+      Llm_provider.Provider_config.string_of_provider_kind secondary.kind
+    in
+    (match
+       classify_filter_rejection
+         ~keeper_name
+         ?runtime_mcp_policy
+         ?required_capability_profile
+         ~tools
+         ~require_tool_choice_support
+         ~require_tool_support
+         secondary
+     with
+     | None ->
+       Llm_metric_bridge.emit_fallback_triggered
+         ~kind:"dual_track_swap"
+         ~detail:(Printf.sprintf "swapped:%s" secondary_kind_label);
+       Either.Left secondary
+     | Some secondary_reason ->
+       (* Both primary and secondary rejected: keep the primary in
+             rejected so the cascade-empty WARN signature stays anchored
+             on the user-declared model. The secondary's rejection is
+             surfaced as a separate metric so operators can audit which
+             dual-track entries are uselessly configured. The kind label
+             rides on the rejection detail too, so the same
+             [secondary_kind] series is queryable across swap success /
+             swap failure outcomes. *)
+       Llm_metric_bridge.emit_fallback_triggered
+         ~kind:"dual_track_swap"
+         ~detail:
+           (Printf.sprintf
+              "rejected:%s:%s"
+              secondary_kind_label
+              (filter_rejection_reason_label secondary_reason));
+       Either.Right (primary, primary_reason))
+
+let filter_candidate_providers_for_tool_support
+      ~(keeper_name : string)
+      ?runtime_mcp_policy
+      ?(tools = [])
+      ~require_tool_choice_support
+      ~require_tool_support
+      ?required_capability_profile
+      ?secondary_resolver
+      ~label
+      (provider_cfgs : Llm_provider.Provider_config.t list)
+  =
+  if (not require_tool_choice_support) && not require_tool_support
+     && Option.is_none required_capability_profile
+  then provider_cfgs
+  else (
+    let kept_rev, rejected_rev, _ =
+      List.fold_left
+        (fun (kept, rejected, provider_index) provider_cfg ->
+           match
+             classify_filter_rejection
+               ~keeper_name
+               ?runtime_mcp_policy
+               ?required_capability_profile
+               ~tools
+               ~require_tool_choice_support
+               ~require_tool_support
+               provider_cfg
+           with
+           | None -> provider_cfg :: kept, rejected, provider_index + 1
+           | Some reason ->
+             log_codex_keeper_bound_skip ~label ~keeper_name provider_cfg reason;
+             let swap =
+               match secondary_resolver with
+               | None -> Either.Right (provider_cfg, reason)
+               | Some resolver ->
+                 attempt_secondary_swap
+                   ~keeper_name
+                   ?runtime_mcp_policy
+                   ?required_capability_profile
+                   ~tools
+                   ~require_tool_choice_support
+                   ~require_tool_support
+                   ~secondary_resolver:resolver
+                   ~provider_index
+                   (provider_cfg, reason)
+             in
+             (match swap with
+              | Either.Left secondary -> secondary :: kept, rejected, provider_index + 1
+              | Either.Right rejected_provider ->
+                kept, rejected_provider :: rejected, provider_index + 1))
+        ([], [], 0)
+        provider_cfgs
+    in
+    let kept = List.rev kept_rev in
+    let rejected = List.rev rejected_rev in
+    if kept = [] && provider_cfgs <> []
+    then (
+      let signature = signature_of_rejected_providers rejected in
+      (* Forward each rejection to the Prometheus capability_drop counter so
+         operators can alert on cascade-empty silently dropping requests.
+         The WARN log below describes the systemic cause; the per-rejection
+         metric records every provider lost so dashboards can attribute
+         which provider/reason combination drove the drop. *)
+      List.iter
+        (fun (provider_cfg, reason) ->
+           let reason_label = filter_rejection_reason_label reason in
+           Llm_metric_bridge.emit_capability_drop
+             ~model_id:provider_cfg.Llm_provider.Provider_config.model_id
+             ~field:(Printf.sprintf "cascade_empty:%s" reason_label);
+           (* §7.3.2 Zero Silent Failure: also feed the unified
+             fallback counter so the dashboard panel sees a single
+             numerator across all fallback classes. *)
+           Llm_metric_bridge.emit_fallback_triggered
+             ~kind:"cascade_empty"
+             ~detail:reason_label)
+        rejected;
+      if cascade_empty_should_emit_first ~label ~signature
+      then
+        Log.Misc.error
+          "[#11060/#11356] cascade %s: provider-normalized tool-use gate removed all \
+           providers (rejections=[%s]) — operator action: edit cascade.toml so \
+           this cascade has at least one candidate whose declared capabilities satisfy \
+           the required tool-use gate, or relax the keeper's required tool surface. \
+           Required gate accepts inline tool_choice support or a compatible runtime-MCP \
+           lane. Alternatively detach the keeper from this cascade. Subsequent \
+           identical-signature rejections demoted to DEBUG for the next %.0fs"
+          label
+          signature
+          cascade_empty_warn_restate_sec
+      else
+        Log.Misc.debug
+          "[#11060] cascade %s: repeated all-providers-rejected (rejections=[%s])"
+          label
+          signature);
+    kept)

--- a/lib/runtime/runtime_oas_runner.mli
+++ b/lib/runtime/runtime_oas_runner.mli
@@ -1,0 +1,136 @@
+(** Runtime_oas_runner — Eio context, cascade resolution, runtime MCP policy.
+
+    Extracted from oas_worker_named.ml (God file decomposition).
+    Provides cascade profile defaults, Eio context validation,
+    provider resolution, and tool-support filtering.
+
+    This module is [include]d by {!Keeper_turn_driver}; all bindings are
+    re-exported by the facade.  @since God file decomposition *)
+
+(** {1 Cascade profile defaults} *)
+
+val default_config_path : unit -> string option
+(** Alias for [Cascade_runtime.cascade_config_path]. *)
+
+val default_model_strings : cascade_name:string -> string list
+(** Alias for [Cascade_runtime.default_model_strings]. *)
+
+(** {1 Eio context validation} *)
+
+val require_eio :
+  ?sw:Eio.Switch.t -> ?net:Eio_context.eio_net -> unit ->
+  (Eio.Switch.t * Eio_context.eio_net, string) result
+(** Validate that an Eio switch and network are available in the current
+    context.  Returns [Ok (sw, net)] when both are present, or [Error msg]
+    when running outside a server context. *)
+
+val eio_context_error_to_sdk_error : string -> Agent_sdk.Error.sdk_error
+(** Lift a context-missing diagnostic string into an [Agent_sdk.Error.Config]
+    error with field ["eio_context"]. *)
+
+val cascade_catalog_error_to_sdk_error : string -> Agent_sdk.Error.sdk_error
+(** Lift a cascade-catalog diagnostic into an [Agent_sdk.Error.Config]
+    error with field ["cascade_name"]. *)
+
+(** {1 Provider resolution} *)
+
+val resolve_cascade_providers :
+  ?provider_filter:string list ->
+  ?require_tool_choice_support:bool ->
+  ?require_tool_support:bool ->
+  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
+  cascade_name:Cascade_name.t -> unit ->
+  (Llm_provider.Provider_config.t list, string) result
+(** Resolve cascade provider configs via MASC Cascade_config. *)
+
+val keeper_agent_name_opt : string -> string option
+(** Derive the agent name from a keeper name; [None] when the name is empty. *)
+
+val runtime_mcp_policy_for_tools :
+  keeper_name:string -> Agent_sdk.Tool.t list ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+(** Build a runtime MCP policy from the tool list, honouring public MCP tools
+    and keeper-internal surface classifications. *)
+
+val keeper_internal_tool_names_for_runtime_surface :
+  keeper_name:string -> Agent_sdk.Tool.t list -> string list
+(** Keeper-internal tool names that require a keeper-bound runtime surface for
+    the given keeper. Empty when [keeper_name] is blank. *)
+
+val keeper_internal_tools_require_materialized_runtime_surface :
+  keeper_name:string -> Agent_sdk.Tool.t list -> bool
+(** [true] when the active tool surface contains keeper-internal tools that
+    must not be silently dropped by an optional CLI/runtime-MCP lane. *)
+
+val runtime_mcp_policy_for_provider :
+  keeper_name:string ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+(** Normalise a runtime MCP policy for a specific provider, injecting the
+    keeper's agent name when applicable. *)
+
+val cli_tool_a_cannot_carry_keeper_bound_runtime_mcp :
+  keeper_name:string ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  bool
+(** [true] when the provider is cli_tool_a and the policy includes tools that
+    require a bound-actor (keeper-scoped) runtime MCP — cli_tool_a cannot
+    carry these across its CLI subprocess boundary. *)
+
+(** {1 Provider filter rejection classification} *)
+
+type filter_rejection_reason =
+  | Capability_profile_mismatch of string
+  | Codex_keeper_bound_actor_required
+  | Tool_lane_unsupported
+  | Required_tool_use of Provider_tool_support.rejection_reason
+(** Why a provider was rejected by the cascade filter.  Order mirrors the
+    filter's short-circuit priority. *)
+
+val filter_rejection_reason_label : filter_rejection_reason -> string
+
+val classify_filter_rejection :
+  keeper_name:string ->
+  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
+  ?tools:Agent_sdk.Tool.t list ->
+  ?required_capability_profile:string ->
+  require_tool_choice_support:bool ->
+  require_tool_support:bool ->
+  Llm_provider.Provider_config.t ->
+  filter_rejection_reason option
+(** Classify why a single provider would be rejected by the tool-use gate.
+    When [required_capability_profile] is provided, the provider must
+    satisfy the named profile via {!Cascade_capability_profile} or it is
+    rejected with [Capability_profile_mismatch]. *)
+
+val filter_candidate_providers_for_tool_support :
+  keeper_name:string ->
+  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
+  ?tools:Agent_sdk.Tool.t list ->
+  require_tool_choice_support:bool ->
+  require_tool_support:bool ->
+  ?required_capability_profile:string ->
+  ?secondary_resolver:
+    (int ->
+     Llm_provider.Provider_config.t ->
+     Llm_provider.Provider_config.t option) ->
+  label:string ->
+  Llm_provider.Provider_config.t list ->
+  Llm_provider.Provider_config.t list
+(** Filter provider candidates through the tool-use gate.  When the gate
+    empties the list, emits a deduplicated diagnostic (ERROR on first
+    occurrence per signature, DEBUG on repeats).
+
+    @param required_capability_profile When set, providers whose
+    declared capabilities do not satisfy the named profile are rejected
+    before any other gate checks.
+    @param secondary_resolver RFC-0027 PR-9b dual-track callback. When
+    set, each rejected primary is offered to the resolver; if it returns
+    a [Some secondary] candidate that itself passes the tool-use gate,
+    the secondary replaces the primary in the kept list. The function
+    is invoked at most once per rejected primary, with the primary's
+    zero-based position in the original candidate list, after the initial
+    classification, so it does not affect the hot path when no entries
+    have a [secondary] declaration. *)

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -1,0 +1,204 @@
+(** Self-standing Runtime configuration types (RFC-0206, cascade→Runtime rebirth).
+
+    Provider × Model × Binding declarative schema (RFC-0058 layers 1-3),
+    re-homed from the deleted [Cascade_declarative_types] as types owned by
+    [lib/runtime/]. The routing layers (RFC-0058 layer 4 aliases, layer 5
+    routes/profiles, and the strategy ADT) are intentionally NOT ported: a
+    Runtime is a single pre-selected (provider × model) binding, so there is
+    no routing indirection to model. *)
+
+(** {1 API format & transport} *)
+
+type api_format =
+  | Messages_api
+  | Chat_completions_api
+  | Ollama_api
+[@@deriving show, eq]
+
+type transport =
+  | Http of string
+  | Cli of string
+[@@deriving show, eq]
+
+type credential =
+  | Env of string
+  | File of string
+  | Inline of string
+[@@deriving show, eq]
+
+(** {1 Layer 1: Provider — how to connect} *)
+
+(** Per-provider behavioral capabilities (RFC-0058 §2.4). Describes how the
+    transport/tool lane must be driven for a provider, independent of model. *)
+type capabilities =
+  { supports_inline_tools : bool
+  ; supports_runtime_mcp_tools : bool
+  ; supports_runtime_tool_events : bool
+  ; supports_runtime_mcp_http_headers : bool
+  ; requires_per_keeper_bridging_for_bound_actor_tools : bool
+  ; identity_runtime_mcp_header_keys : string list
+  ; argv_prompt_preflight : bool
+  ; uses_anthropic_caching : bool
+  ; max_turns_per_attempt : int option
+  ; tolerates_bound_actor_fallback : bool
+  }
+[@@deriving show, eq]
+
+let capabilities_default =
+  { supports_inline_tools = false
+  ; supports_runtime_mcp_tools = false
+  ; supports_runtime_tool_events = false
+  ; supports_runtime_mcp_http_headers = false
+  ; requires_per_keeper_bridging_for_bound_actor_tools = false
+  ; identity_runtime_mcp_header_keys = []
+  ; argv_prompt_preflight = false
+  ; uses_anthropic_caching = false
+  ; max_turns_per_attempt = None
+  ; tolerates_bound_actor_fallback = false
+  }
+;;
+
+(** [providers.<id>] — connection + behavior. The deleted
+    [cascade_provider]'s [log]/[healthcheck] sub-records are dropped from v1:
+    no live Runtime consumer reads them, and the TOML parser parses-and-ignores
+    those sub-tables (RFC-0206 §3). [headers] is retained for per-provider HTTP
+    header injection. *)
+type provider =
+  { id : string
+  ; display_name : string
+  ; protocol : string
+  ; api_format : api_format
+  ; transport : transport
+  ; is_non_interactive : bool
+  ; credentials : credential option
+  ; capabilities : capabilities option
+  ; headers : (string * string) list option
+  }
+[@@deriving show, eq]
+
+(** {1 Layer 2: Model — what it can do} *)
+
+(** How an OpenAI-compat backend's request body encodes "enable thinking".
+    Pinned on the model because the same physical model can be served by
+    backends with different thinking-control wire shapes. *)
+type thinking_control_format =
+  | No_thinking_control
+  | Thinking_object
+  | Chat_template_kwargs
+[@@deriving show, eq]
+
+(** Per-model capabilities, mirroring OAS [Llm_provider.Capabilities] for the
+    fields callers branch on. Fields already present on {!model_spec}
+    ([tools_support]/[thinking_support]/[max_context]/[streaming]) are not
+    duplicated here, to avoid two-SSOT drift. *)
+type model_capabilities =
+  { max_output_tokens : int option
+  ; supports_parallel_tool_calls : bool
+  ; supports_tool_choice : bool
+  ; supports_extended_thinking : bool
+  ; supports_reasoning_budget : bool
+  ; thinking_control_format : thinking_control_format
+  ; supports_image_input : bool
+  ; supports_audio_input : bool
+  ; supports_video_input : bool
+  ; supports_multimodal_inputs : bool
+  ; supports_response_format_json : bool
+  ; supports_structured_output : bool
+  ; supports_native_streaming : bool
+  ; supports_caching : bool
+  ; supports_prompt_caching : bool
+  ; prompt_cache_alignment : int option
+  ; supports_top_k : bool
+  ; supports_min_p : bool
+  ; supports_seed : bool
+  ; emits_usage_tokens : bool
+  ; supports_computer_use : bool
+  }
+[@@deriving show, eq]
+
+let model_capabilities_default =
+  { max_output_tokens = None
+  ; supports_parallel_tool_calls = false
+  ; supports_tool_choice = false
+  ; supports_extended_thinking = false
+  ; supports_reasoning_budget = false
+  ; thinking_control_format = No_thinking_control
+  ; supports_image_input = false
+  ; supports_audio_input = false
+  ; supports_video_input = false
+  ; supports_multimodal_inputs = false
+  ; supports_response_format_json = false
+  ; supports_structured_output = false
+  ; supports_native_streaming = false
+  ; supports_caching = false
+  ; supports_prompt_caching = false
+  ; prompt_cache_alignment = None
+  ; supports_top_k = false
+  ; supports_min_p = false
+  ; supports_seed = false
+  ; (* stricter default: most providers report usage; CLI wrappers opt out *)
+    emits_usage_tokens = true
+  ; supports_computer_use = false
+  }
+;;
+
+(** [models.<id>] — capability declaration. [match_prefixes] empty = match only
+    exact [api_name] equality; non-empty = match any requested model id starting
+    with one of the prefixes (longest-prefix-first; resolver lives outside the
+    schema and is added only if a binding needs fuzzy resolution — RFC-0206 R4). *)
+type model_spec =
+  { id : string
+  ; api_name : string
+  ; tools_support : bool
+  ; max_context : int
+  ; thinking_support : bool
+  ; max_thinking_budget : int option
+  ; streaming : bool
+  ; capabilities : model_capabilities option
+  ; match_prefixes : string list
+  }
+[@@deriving show, eq]
+
+(** {1 Layer 3: Binding — provider × model} *)
+
+type binding =
+  { provider_id : string
+  ; model_id : string
+  ; is_default : bool
+  ; max_concurrent : int
+  ; price_input : float option
+  ; price_output : float option
+  ; keep_alive : string option
+  ; num_ctx : int option
+  }
+[@@deriving show, eq]
+
+(** {1 Top-level config}
+
+    Routes/aliases/profiles/system_targets/strategy from the deleted
+    [cascade_config] are dropped (RFC-0206 §5): the single-binding Runtime model
+    has no routing layer. *)
+type config =
+  { providers : provider list
+  ; models : model_spec list
+  ; bindings : binding list
+  ; default_runtime_id : string option
+  }
+[@@deriving show, eq]
+
+(** {1 Lookups} *)
+
+let provider_of_id (cfg : config) (id : string) : provider option =
+  List.find_opt (fun (p : provider) -> String.equal p.id id) cfg.providers
+;;
+
+let model_of_id (cfg : config) (id : string) : model_spec option =
+  List.find_opt (fun (m : model_spec) -> String.equal m.id id) cfg.models
+;;
+
+(** Runtime id derived from a binding: ["provider.model"]. Single source of id
+    derivation, shared by {!Runtime.id_of_binding} and any caller indexing
+    runtimes by id. *)
+let binding_key (b : binding) : string =
+  Printf.sprintf "%s.%s" b.provider_id b.model_id
+;;

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -1,0 +1,141 @@
+(** Self-standing Runtime configuration types (RFC-0206, cascade→Runtime rebirth).
+
+    Provider × Model × Binding declarative schema (RFC-0058 layers 1-3),
+    re-homed from the deleted [Cascade_declarative_types] as types owned by
+    [lib/runtime/]. Routing layers (aliases/routes/profiles/strategy) are
+    intentionally dropped: a Runtime is a single pre-selected binding. *)
+
+(** {1 API format & transport} *)
+
+type api_format =
+  | Messages_api
+  | Chat_completions_api
+  | Ollama_api
+[@@deriving show, eq]
+
+type transport =
+  | Http of string
+  | Cli of string
+[@@deriving show, eq]
+
+type credential =
+  | Env of string
+  | File of string
+  | Inline of string
+[@@deriving show, eq]
+
+(** {1 Layer 1: Provider} *)
+
+type capabilities =
+  { supports_inline_tools : bool
+  ; supports_runtime_mcp_tools : bool
+  ; supports_runtime_tool_events : bool
+  ; supports_runtime_mcp_http_headers : bool
+  ; requires_per_keeper_bridging_for_bound_actor_tools : bool
+  ; identity_runtime_mcp_header_keys : string list
+  ; argv_prompt_preflight : bool
+  ; uses_anthropic_caching : bool
+  ; max_turns_per_attempt : int option
+  ; tolerates_bound_actor_fallback : bool
+  }
+[@@deriving show, eq]
+
+(** All-false / empty / [None] defaults; used when [\[providers.<id>.capabilities\]]
+    is absent. *)
+val capabilities_default : capabilities
+
+type provider =
+  { id : string
+  ; display_name : string
+  ; protocol : string
+  ; api_format : api_format
+  ; transport : transport
+  ; is_non_interactive : bool
+  ; credentials : credential option
+  ; capabilities : capabilities option
+  ; headers : (string * string) list option
+  }
+[@@deriving show, eq]
+
+(** {1 Layer 2: Model} *)
+
+type thinking_control_format =
+  | No_thinking_control
+  | Thinking_object
+  | Chat_template_kwargs
+[@@deriving show, eq]
+
+type model_capabilities =
+  { max_output_tokens : int option
+  ; supports_parallel_tool_calls : bool
+  ; supports_tool_choice : bool
+  ; supports_extended_thinking : bool
+  ; supports_reasoning_budget : bool
+  ; thinking_control_format : thinking_control_format
+  ; supports_image_input : bool
+  ; supports_audio_input : bool
+  ; supports_video_input : bool
+  ; supports_multimodal_inputs : bool
+  ; supports_response_format_json : bool
+  ; supports_structured_output : bool
+  ; supports_native_streaming : bool
+  ; supports_caching : bool
+  ; supports_prompt_caching : bool
+  ; prompt_cache_alignment : int option
+  ; supports_top_k : bool
+  ; supports_min_p : bool
+  ; supports_seed : bool
+  ; emits_usage_tokens : bool
+  ; supports_computer_use : bool
+  }
+[@@deriving show, eq]
+
+(** All-false / [None] defaults, except [emits_usage_tokens = true] (most
+    providers report usage; CLI wrappers opt out). Used when
+    [\[models.<id>.capabilities\]] is absent. *)
+val model_capabilities_default : model_capabilities
+
+type model_spec =
+  { id : string
+  ; api_name : string
+  ; tools_support : bool
+  ; max_context : int
+  ; thinking_support : bool
+  ; max_thinking_budget : int option
+  ; streaming : bool
+  ; capabilities : model_capabilities option
+  ; match_prefixes : string list
+  }
+[@@deriving show, eq]
+
+(** {1 Layer 3: Binding} *)
+
+type binding =
+  { provider_id : string
+  ; model_id : string
+  ; is_default : bool
+  ; max_concurrent : int
+  ; price_input : float option
+  ; price_output : float option
+  ; keep_alive : string option
+  ; num_ctx : int option
+  }
+[@@deriving show, eq]
+
+(** {1 Top-level config} *)
+
+type config =
+  { providers : provider list
+  ; models : model_spec list
+  ; bindings : binding list
+  ; default_runtime_id : string option
+  }
+[@@deriving show, eq]
+
+(** {1 Lookups} *)
+
+val provider_of_id : config -> string -> provider option
+val model_of_id : config -> string -> model_spec option
+
+(** Runtime id derived from a binding: ["provider.model"]. *)
+val binding_key : binding -> string

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -1,0 +1,559 @@
+(** Declarative Runtime TOML parser (RFC-0206, cascade→Runtime rebirth).
+
+    Re-homed from the deleted [Cascade_declarative_parser]. Parses RFC-0058
+    layers 1-3 plus [[runtime].default] into a self-standing
+    {!Runtime_schema.config}. Reserved top-level namespaces: providers,
+    models, runtime (plus the dropped routing namespaces system, routes,
+    profiles, which are still reserved so they are never mistaken for a
+    provider table). Any other top-level table is a provider table, with
+    sub-tables as model bindings.
+
+    Routing layers are intentionally NOT parsed (see {!Runtime_toml} mli):
+    Layer 4 aliases, Layer 5 routes/system/profiles, and the
+    strategy/cycle-policy/scoring tables are dropped from
+    {!Runtime_schema}, so this parser neither reads nor populates them. *)
+
+type parse_error =
+  { path : string
+  ; message : string
+  }
+[@@deriving show]
+
+(* --- Error accumulation --- *)
+
+let error path message = [ { path; message } ]
+
+(* Partition a list of per-entry parse results into a single
+   collected result. Either every entry parsed (return [Ok all]),
+   or at least one entry failed (return [Error] with every error
+   concatenated). Removes the historical two-pass pattern where the
+   success branch carried a dead [Error _ -> None] arm guarded by a
+   prior [if errs <> []]: with this helper the dead arm cannot be
+   written, so a future caller cannot accidentally re-introduce a
+   silent drop. *)
+let partition_results
+  (results : ('a, parse_error list) result list)
+  : ('a list, parse_error list) result
+  =
+  let oks, errs =
+    List.partition_map
+      (function
+        | Ok x -> Either.Left x
+        | Error e -> Either.Right e)
+      results
+  in
+  if errs <> [] then Error (List.concat errs) else Ok oks
+;;
+
+(* --- Protocol string -> Runtime_schema.api_format --- *)
+
+let api_format_of_protocol (s : string)
+  : (Runtime_schema.api_format, string) result
+  =
+  match s with
+  | "provider_a-cli" | "provider_a-http" -> Ok Runtime_schema.Messages_api
+  | "provider_d-cli" | "provider_d-http" | "provider_f-cli" | "provider_c-cli" ->
+    Ok Runtime_schema.Chat_completions_api
+  | "ollama-http" -> Ok Runtime_schema.Ollama_api
+  | _ ->
+    Error
+      (Printf.sprintf
+         "unknown protocol %S: expected one of provider_a-cli, provider_a-http, \
+          provider_d-cli, provider_d-http, provider_f-cli, provider_c-cli, \
+          ollama-http"
+         s)
+;;
+
+(* --- Transport extraction --- *)
+
+let transport_of_provider (tbl : Otoml.t) (id : string)
+  : (Runtime_schema.transport, string) result
+  =
+  let endpoint = Otoml.find_opt tbl Otoml.get_string [ "endpoint" ] in
+  let command = Otoml.find_opt tbl Otoml.get_string [ "command" ] in
+  match endpoint, command with
+  | Some url, None -> Ok (Runtime_schema.Http url)
+  | None, Some cmd -> Ok (Runtime_schema.Cli cmd)
+  | Some _, Some _ ->
+    Error (Printf.sprintf "provider %s: cannot specify both 'endpoint' and 'command'" id)
+  | None, None ->
+    Error (Printf.sprintf "provider %s: must specify either 'endpoint' or 'command'" id)
+;;
+
+(* --- Layer 1: Providers --- *)
+
+let parse_credential (tbl : Otoml.t) (path : string)
+  : (Runtime_schema.credential, parse_error list) result
+  =
+  let cred_type = Otoml.find tbl Otoml.get_string [ "type" ] in
+  match cred_type with
+  | "env" ->
+    (match Otoml.find_opt tbl Otoml.get_string [ "key" ] with
+     | Some key -> Ok (Runtime_schema.Env key)
+     | None -> Error (error (path ^ ".key") "credential type 'env' requires 'key'"))
+  | "file" ->
+    (match Otoml.find_opt tbl Otoml.get_string [ "path" ] with
+     | Some p -> Ok (Runtime_schema.File p)
+     | None -> Error (error (path ^ ".path") "credential type 'file' requires 'path'"))
+  | "inline" ->
+    (match Otoml.find_opt tbl Otoml.get_string [ "value" ] with
+     | Some v -> Ok (Runtime_schema.Inline v)
+     | None -> Error (error (path ^ ".value") "credential type 'inline' requires 'value'"))
+  | t -> Error (error (path ^ ".type") (Printf.sprintf "unknown credential type %S" t))
+;;
+
+let parse_capabilities ~(path : string) (tbl : Otoml.t) : Runtime_schema.capabilities =
+  let b key = Otoml.find_or ~default:false tbl Otoml.get_boolean [ key ] in
+  let string_list_field key =
+    match Otoml.find_opt tbl Fun.id [ key ] with
+    | None -> []
+    | Some v ->
+      (* RFC-0145 — narrow to the only exception [Otoml.get_array]
+         raises on a wrong-typed value.  Unrelated runtime exceptions
+         propagate. *)
+      (try Otoml.get_array Otoml.get_string v with
+       | Otoml.Type_error _ ->
+         Logs.warn (fun m ->
+           m
+             "runtime_toml: %s.capabilities.%s — expected string array, ignoring"
+             path
+             key);
+         [])
+  in
+  let positive_int_opt_field key =
+    (* Reject non-positive values at parse time: a cap of 0 or -N would
+       clamp every attempt to a meaningless budget downstream. *)
+    match Otoml.find_opt tbl Otoml.get_integer [ key ] with
+    | None -> None
+    | Some n when n > 0 -> Some n
+    | Some n ->
+      Logs.warn (fun m ->
+        m
+          "runtime_toml: %s.capabilities.%s = %d — expected positive integer, ignoring"
+          path
+          key
+          n);
+      None
+  in
+  { Runtime_schema.supports_inline_tools = b "supports-inline-tools"
+  ; supports_runtime_mcp_tools = b "supports-runtime-mcp-tools"
+  ; supports_runtime_tool_events = b "supports-runtime-tool-events"
+  ; supports_runtime_mcp_http_headers = b "supports-runtime-mcp-http-headers"
+  ; requires_per_keeper_bridging_for_bound_actor_tools =
+      b "requires-per-keeper-bridging-for-bound-actor-tools"
+  ; identity_runtime_mcp_header_keys =
+      string_list_field "identity-runtime-mcp-header-keys"
+  ; argv_prompt_preflight = b "argv-prompt-preflight"
+  ; uses_anthropic_caching = b "uses-provider_a-caching"
+  ; max_turns_per_attempt = positive_int_opt_field "max-turns-per-attempt"
+  ; tolerates_bound_actor_fallback = b "tolerates-bound-actor-fallback"
+  }
+;;
+
+(** Parse a [providers.<id>.headers] sub-table into a sorted association
+    list. Caller invokes only when the sub-table key exists, so the
+    returned list distinguishes "declared but empty / all entries rejected"
+    (empty list) from "no sub-table" (caller passes [None]).
+
+    Non-table values at the sub-table position emit a WARN and yield an
+    empty list. Non-string header values emit a per-entry WARN and are
+    dropped. The result is sorted by key for deterministic show/eq. *)
+let parse_headers (tbl : Otoml.t) (path : string) : (string * string) list =
+  match Otoml.get_table tbl with
+  (* RFC-0145 — narrow to the only exception [Otoml.get_table] raises
+     on a non-table value.  Unrelated runtime exceptions propagate. *)
+  | exception Otoml.Type_error _ ->
+    Logs.warn (fun m ->
+      m
+        "runtime_toml: %s — expected TOML table, got non-table value; treating as empty"
+        path);
+    []
+  | entries ->
+    let pairs =
+      List.filter_map
+        (fun (k, v) ->
+           match Otoml.get_string v with
+           | s -> Some (k, s)
+           (* RFC-0145 — narrow to the only exception [Otoml.get_string]
+              raises on a non-string value. *)
+           | exception Otoml.Type_error _ ->
+             Logs.warn (fun m ->
+               m "runtime_toml: %s.%s — non-string header value, ignoring" path k);
+             None)
+        entries
+    in
+    List.sort (fun (a, _) (b, _) -> String.compare a b) pairs
+;;
+
+let parse_provider (id : string) (tbl : Otoml.t)
+  : (Runtime_schema.provider, parse_error list) result
+  =
+  let path = Printf.sprintf "providers.%s" id in
+  let display_name =
+    match Otoml.find_opt tbl Otoml.get_string [ "display-name" ] with
+    | Some n -> n
+    | None ->
+      (match Otoml.find_opt tbl Otoml.get_string [ "provider-name" ] with
+       | Some n -> n
+       | None -> id)
+  in
+  let protocol_result =
+    match Otoml.find_opt tbl Otoml.get_string [ "protocol" ] with
+    | Some p ->
+      (match api_format_of_protocol p with
+       | Ok fmt -> Ok (p, fmt)
+       | Error e -> Error e)
+    | None -> Error "missing required field 'protocol'"
+  in
+  let transport_result = transport_of_provider tbl id in
+  match protocol_result, transport_result with
+  | Error e, _ -> Error (error (path ^ ".protocol") e)
+  | _, Error e -> Error (error path e)
+  | Ok (protocol, api_format), Ok transport ->
+    let is_non_interactive =
+      Otoml.find_or ~default:false tbl Otoml.get_boolean [ "is-non-interactive" ]
+    in
+    let credentials =
+      match Otoml.find_opt tbl Fun.id [ "credentials" ] with
+      | Some cred_tbl ->
+        (match parse_credential cred_tbl (path ^ ".credentials") with
+         | Ok c -> Some c
+         | Error errs ->
+           (* [parse_credential] always wraps its single failure through
+              the [error] helper which builds a 1-element list, so the
+              [[]] branch is unreachable.  Typed for exhaustiveness so a
+              future change to the error-shape contract does not silently
+              lose the diagnostic. *)
+           let detail =
+             match errs with
+             | [] -> "<empty error list>"
+             | e :: _ -> Printf.sprintf "%s: %s" e.path e.message
+           in
+           Logs.warn (fun m -> m "runtime_toml: %s" detail);
+           None)
+      | None -> None
+    in
+    let capabilities =
+      Otoml.find_opt tbl Fun.id [ "capabilities" ]
+      |> Option.map (parse_capabilities ~path)
+    in
+    (* [providers.<id>.log] and [providers.<id>.healthcheck] sub-tables are
+       parse-and-ignore: their fields were dropped from
+       {!Runtime_schema.provider}, so they are neither read nor populated.
+       Leaving them in a TOML file is not an error. *)
+    let headers =
+      match Otoml.find_opt tbl Fun.id [ "headers" ] with
+      | None -> None
+      | Some h_tbl -> Some (parse_headers h_tbl (path ^ ".headers"))
+    in
+    Ok
+      { Runtime_schema.id
+      ; display_name
+      ; protocol
+      ; api_format
+      ; transport
+      ; is_non_interactive
+      ; credentials
+      ; capabilities
+      ; headers
+      }
+;;
+
+let parse_providers (toml : Otoml.t)
+  : (Runtime_schema.provider list, parse_error list) result
+  =
+  match Otoml.find_opt toml Fun.id [ "providers" ] with
+  | None -> Ok []
+  | Some providers_tbl ->
+    let entries = Otoml.get_table providers_tbl in
+    partition_results (List.map (fun (id, tbl) -> parse_provider id tbl) entries)
+;;
+
+(* --- Layer 2: Models --- *)
+
+let parse_thinking_control_format ~(path : string) (raw : string)
+  : Runtime_schema.thinking_control_format
+  =
+  match String.lowercase_ascii (String.trim raw) with
+  | "" | "none" | "no-thinking-control" | "no_thinking_control" ->
+    Runtime_schema.No_thinking_control
+  | "thinking-object" | "thinking_object" -> Runtime_schema.Thinking_object
+  | "chat-template-kwargs" | "chat_template_kwargs" -> Runtime_schema.Chat_template_kwargs
+  | other ->
+    Logs.warn (fun m ->
+      m
+        "runtime_toml: %s.capabilities.thinking-control-format = %S — expected one of \
+         none|thinking-object|chat-template-kwargs, defaulting to none"
+        path
+        other);
+    Runtime_schema.No_thinking_control
+;;
+
+let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
+  : Runtime_schema.model_capabilities
+  =
+  let b key = Otoml.find_or ~default:false tbl Otoml.get_boolean [ key ] in
+  let b_default_true key = Otoml.find_or ~default:true tbl Otoml.get_boolean [ key ] in
+  let positive_int_opt_field key =
+    match Otoml.find_opt tbl Otoml.get_integer [ key ] with
+    | None -> None
+    | Some n when n > 0 -> Some n
+    | Some n ->
+      Logs.warn (fun m ->
+        m
+          "runtime_toml: %s.capabilities.%s = %d — expected positive integer, ignoring"
+          path
+          key
+          n);
+      None
+  in
+  let thinking_control_format =
+    match Otoml.find_opt tbl Otoml.get_string [ "thinking-control-format" ] with
+    | None -> Runtime_schema.No_thinking_control
+    | Some raw -> parse_thinking_control_format ~path raw
+  in
+  { Runtime_schema.max_output_tokens = positive_int_opt_field "max-output-tokens"
+  ; supports_parallel_tool_calls = b "supports-parallel-tool-calls"
+  ; supports_tool_choice = b "supports-tool-choice"
+  ; supports_extended_thinking = b "supports-extended-thinking"
+  ; supports_reasoning_budget = b "supports-reasoning-budget"
+  ; thinking_control_format
+  ; supports_image_input = b "supports-image-input"
+  ; supports_audio_input = b "supports-audio-input"
+  ; supports_video_input = b "supports-video-input"
+  ; supports_multimodal_inputs = b "supports-multimodal-inputs"
+  ; supports_response_format_json = b "supports-response-format-json"
+  ; supports_structured_output = b "supports-structured-output"
+  ; supports_native_streaming = b "supports-native-streaming"
+  ; supports_caching = b "supports-caching"
+  ; supports_prompt_caching = b "supports-prompt-caching"
+  ; prompt_cache_alignment = positive_int_opt_field "prompt-cache-alignment"
+  ; supports_top_k = b "supports-top-k"
+  ; supports_min_p = b "supports-min-p"
+  ; supports_seed = b "supports-seed"
+  ; emits_usage_tokens = b_default_true "emits-usage-tokens"
+  ; supports_computer_use = b "supports-computer-use"
+  }
+;;
+
+let parse_model (id : string) (tbl : Otoml.t)
+  : (Runtime_schema.model_spec, parse_error list) result
+  =
+  let path = Printf.sprintf "models.%s" id in
+  let api_name =
+    match Otoml.find_opt tbl Otoml.get_string [ "api-name" ] with
+    | Some n -> n
+    | None ->
+      (match Otoml.find_opt tbl Otoml.get_string [ "model-name" ] with
+       | Some n -> n
+       | None -> id)
+  in
+  let max_context = Otoml.find_or ~default:(-1) tbl Otoml.get_integer [ "max-context" ] in
+  if max_context <= 0
+  then Error (error (path ^ ".max-context") "missing or invalid max-context")
+  else (
+    let tools_support =
+      Otoml.find_or ~default:false tbl Otoml.get_boolean [ "tools-support" ]
+    in
+    let thinking_support =
+      Otoml.find_or ~default:false tbl Otoml.get_boolean [ "thinking-support" ]
+    in
+    let max_thinking_budget =
+      Otoml.find_opt tbl Otoml.get_integer [ "max-thinking-budget" ]
+    in
+    let streaming = Otoml.find_or ~default:true tbl Otoml.get_boolean [ "streaming" ] in
+    let capabilities =
+      Otoml.find_opt tbl Fun.id [ "capabilities" ]
+      |> Option.map (parse_model_capabilities ~path:(path ^ ".capabilities"))
+    in
+    let match_prefixes =
+      match Otoml.find_opt tbl Fun.id [ "match-prefixes" ] with
+      | None -> []
+      | Some v ->
+        (* RFC-0145 — narrow to the only exception [Otoml.get_array]
+           raises on a wrong-typed value.  Unrelated runtime exceptions
+           propagate. *)
+        (try
+           Otoml.get_array Otoml.get_string v
+           |> List.filter_map (fun s ->
+             let trimmed = String.trim s in
+             if String.length trimmed = 0
+             then (
+               Logs.warn (fun m ->
+                 m "runtime_toml: %s.match-prefixes contains empty entry, ignoring" path);
+               None)
+             else Some trimmed)
+         with
+         | Otoml.Type_error _ ->
+           Logs.warn (fun m ->
+             m "runtime_toml: %s.match-prefixes — expected string array, ignoring" path);
+           [])
+    in
+    Ok
+      { Runtime_schema.id
+      ; api_name
+      ; tools_support
+      ; max_context
+      ; thinking_support
+      ; max_thinking_budget
+      ; streaming
+      ; capabilities
+      ; match_prefixes
+      })
+;;
+
+let parse_models (toml : Otoml.t)
+  : (Runtime_schema.model_spec list, parse_error list) result
+  =
+  match Otoml.find_opt toml Fun.id [ "models" ] with
+  | None -> Ok []
+  | Some models_tbl ->
+    let entries = Otoml.get_table models_tbl in
+    partition_results (List.map (fun (id, tbl) -> parse_model id tbl) entries)
+;;
+
+(* --- Reserved namespace detection --- *)
+
+(* The dropped routing namespaces (system, routes, profiles) remain
+   reserved: keeping them out of the provider-table scan ensures a stale
+   [[routes]]/[[profiles]] table in an existing cascade.toml is silently
+   ignored rather than misread as a provider with bogus model bindings. *)
+let reserved_namespaces =
+  [ "providers"; "models"; "system"; "routes"; "profiles"; "runtime" ]
+;;
+
+let is_reserved (name : string) : bool = List.mem name reserved_namespaces
+
+(* --- Layer 3: Bindings from provider tables --- *)
+
+(* [Otoml.t] is a 3rd-party closed variant with 12 value constructors;
+   this parser only ever distinguishes "table-shaped" (TomlTable /
+   TomlInlineTable) from everything else. Enumerating the other 10 once
+   here satisfies warning 4 and means an [otoml] version bump that adds a
+   value constructor breaks exactly this site rather than a dozen call
+   sites. *)
+let is_toml_table : Otoml.t -> bool = function
+  | Otoml.TomlTable _ | Otoml.TomlInlineTable _ -> true
+  | Otoml.TomlString _ | Otoml.TomlInteger _ | Otoml.TomlFloat _
+  | Otoml.TomlBoolean _ | Otoml.TomlOffsetDateTime _ | Otoml.TomlLocalDateTime _
+  | Otoml.TomlLocalDate _ | Otoml.TomlLocalTime _ | Otoml.TomlArray _
+  | Otoml.TomlTableArray _ -> false
+
+let parse_binding_fields (provider_id : string) (model_id : string) (tbl : Otoml.t)
+  : Runtime_schema.binding
+  =
+  let is_default = Otoml.find_or ~default:false tbl Otoml.get_boolean [ "is-default" ] in
+  (* RFC-0058 §3.4: max-concurrent is REQUIRED. The sentinel value 0
+     here makes the omission visible to the validator instead of
+     silently throttling every binding to 1. *)
+  let max_concurrent =
+    match Otoml.find_opt tbl Otoml.get_integer [ "max-concurrent" ] with
+    | Some n -> n
+    | None -> 0
+  in
+  let price_input = Otoml.find_opt tbl Otoml.get_float [ "price-input" ] in
+  let price_output = Otoml.find_opt tbl Otoml.get_float [ "price-output" ] in
+  let keep_alive = Otoml.find_opt tbl Otoml.get_string [ "keep-alive" ] in
+  let num_ctx = Otoml.find_opt tbl Otoml.get_integer [ "num-ctx" ] in
+  { Runtime_schema.provider_id
+  ; model_id
+  ; is_default
+  ; max_concurrent
+  ; price_input
+  ; price_output
+  ; keep_alive
+  ; num_ctx
+  }
+;;
+
+(* Parse one provider table ([<provider>.*]) into its Layer-3 bindings.
+   Each direct sub-key is a model binding. Layer-4 aliases ([<p>.<m>.<a>])
+   are dropped: when a model entry contains nested sub-tables (the former
+   alias declarations), only the model's own leaf fields are used to build
+   the binding; the nested sub-tables are ignored. *)
+let parse_provider_table (provider_id : string) (tbl : Otoml.t)
+  : Runtime_schema.binding list
+  =
+  let entries = Otoml.get_table tbl in
+  List.map
+    (fun (model_id, sub) ->
+       if is_toml_table sub
+       then (
+         (* [sub] is TomlTable/TomlInlineTable (per [is_toml_table]); both
+            unwrap to a (key, value) list via [Otoml.get_table]. The
+            nested sub-tables (Layer-4 aliases) are filtered out so the
+            binding is built from this model's leaf fields only. *)
+         let fields = Otoml.get_table sub in
+         let leaf_fields = List.filter (fun (_, v) -> not (is_toml_table v)) fields in
+         let synthetic_tbl = Otoml.TomlTable leaf_fields in
+         parse_binding_fields provider_id model_id synthetic_tbl)
+       else parse_binding_fields provider_id model_id sub)
+    entries
+;;
+
+let parse_bindings (toml : Otoml.t) : Runtime_schema.binding list =
+  let top_entries = Otoml.get_table toml in
+  (* Only top-level tables can describe a provider; scalar / array entries
+     (e.g. an operator-authored ["comment = ..."]) would crash
+     [Otoml.get_table] in [parse_provider_table]. *)
+  let provider_tables =
+    List.filter
+      (fun (name, value) -> (not (is_reserved name)) && is_toml_table value)
+      top_entries
+  in
+  List.concat_map
+    (fun (provider_id, tbl) -> parse_provider_table provider_id tbl)
+    provider_tables
+;;
+
+(* --- Top-level parse --- *)
+
+(* Extract the [Ok] payload from a parse result that the caller has
+   just proven via the [all_errors = []] guard. The [Error _] branch
+   is statically unreachable; reaching it indicates a refactor has
+   desynchronized the collect site from the extraction site. Crash with
+   [invalid_arg] rather than silently substituting an empty list,
+   which would mask a corrupt config. *)
+let extract_after_all_errors_guard ~label = function
+  | Ok x -> x
+  | Error _ ->
+    invalid_arg
+      (Printf.sprintf
+         "runtime_toml.parse_toml: %s — guarded extraction reached Error branch; \
+          collect/extract desync"
+         label)
+;;
+
+let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) result =
+  let providers_result = parse_providers toml in
+  let models_result = parse_models toml in
+  let errs = function Ok _ -> [] | Error errs -> errs in
+  let all_errors = errs providers_result @ errs models_result in
+  let bindings = parse_bindings toml in
+  let default_runtime_id =
+    Otoml.find_opt toml Otoml.get_string [ "runtime"; "default" ]
+  in
+  if all_errors <> []
+  then Error all_errors
+  else (
+    let providers =
+      extract_after_all_errors_guard ~label:"providers" providers_result
+    in
+    let models = extract_after_all_errors_guard ~label:"models" models_result in
+    Ok { Runtime_schema.providers; models; bindings; default_runtime_id })
+;;
+
+let parse_string (content : string) : (Runtime_schema.config, parse_error list) result =
+  match Otoml.Parser.from_string_result content with
+  | Ok toml -> parse_toml toml
+  | Error msg -> Error [ { path = "<parse>"; message = msg } ]
+;;
+
+let parse_file (path : string) : (Runtime_schema.config, parse_error list) result =
+  try
+    let toml = Otoml.Parser.from_file path in
+    parse_toml toml
+  with
+  | Otoml.Parse_error (_, msg) -> Error [ { path; message = msg } ]
+  | Sys_error msg -> Error [ { path; message = msg } ]
+;;

--- a/lib/runtime/runtime_toml.mli
+++ b/lib/runtime/runtime_toml.mli
@@ -1,0 +1,39 @@
+(** Declarative Runtime TOML parser (RFC-0206, cascade→Runtime rebirth).
+
+    Re-homed from the deleted [Cascade_declarative_parser]. Parses only
+    RFC-0058 layers 1-3 plus [\[runtime\].default] into a self-standing
+    {!Runtime_schema.config}:
+
+    - [\[providers.*\]] — Layer 1
+    - [\[models.*\]] — Layer 2
+    - [<provider>.<model>] binding tables — Layer 3
+    - [\[runtime\].default] — the default Runtime id ([provider.model])
+
+    The routing layers are intentionally NOT parsed: Layer 4 aliases
+    ([<p>.<m>.<a>]), Layer 5 [\[routes\]]/[\[system\]]/[\[profiles\]], and the
+    strategy/cycle-policy/scoring tables are dropped. A Runtime is a single
+    pre-selected (provider × model) binding, so there is no routing
+    indirection to model. *)
+
+type parse_error =
+  { path : string  (** TOML path where the error occurred *)
+  ; message : string
+  }
+[@@deriving show]
+
+val parse_string : string -> (Runtime_schema.config, parse_error list) result
+(** Parse a TOML string into a Runtime config.
+    Returns [Ok config] on success, [Error errors] with all
+    parse errors found. *)
+
+val parse_file : string -> (Runtime_schema.config, parse_error list) result
+(** Parse a TOML file into a Runtime config. *)
+
+(** {1 Internal: protocol resolution} *)
+
+val api_format_of_protocol : string -> (Runtime_schema.api_format, string) result
+(** Map a TOML protocol string to a {!Runtime_schema.api_format} variant. *)
+
+val transport_of_provider :
+  Otoml.t -> string -> (Runtime_schema.transport, string) result
+(** Extract transport ([Http] or [Cli]) from a provider TOML table. *)

--- a/lib/runtime/runtime_transport.ml
+++ b/lib/runtime/runtime_transport.ml
@@ -1,0 +1,407 @@
+(** Runtime_transport — Transport and tool-lane helpers for OAS worker exec.
+
+    Keeps provider label resolution, runtime MCP lane selection, and per-call
+    CLI transport construction separate from the build/run orchestration in
+    {!Runtime_agent}. *)
+
+(* cli_transport_overrides type extracted to
+   [Runtime_transport_cli_overrides] (godfile decomp). *)
+type cli_transport_overrides = Runtime_transport_cli_overrides.cli_transport_overrides =
+  { cwd : string option
+  ; claude_mcp_config : string option
+  ; claude_allowed_tools : string list option
+  ; claude_permission_mode : string option
+  ; claude_max_turns : int option
+  ; gemini_yolo : bool option
+  ; cli_subprocess_idle_sec : float option
+  }
+
+(* OAS owns provider subprocess hard caps. This constant is a
+   backward-compat re-export for tests and operator-facing labels only;
+   MASC does not clamp provider-internal max_turns before dispatch. *)
+let cli_tool_d_max_turns_hard_cap =
+  Llm_provider.Provider_config.max_turns_hard_cap
+    Llm_provider.Provider_config.Cli_tool_d
+  |> Option.value ~default:30
+;;
+
+let provider_effective_max_turns _kind requested = requested
+
+(* RFC-0167: the client-named omission-dedup module
+   [Runtime_transport_codex_omission_dedup] (#10097) was removed in
+   the big-bang sweep. The structural omission of keeper-bound runtime
+   MCP tools (when the runtime adapter requires per-keeper bridging
+   but no per-keeper bearer is available) is still detected and
+   reported through the [Error (invalid_runtime_config ...)] path
+   below — only the WARN-dedup + per-tool Prometheus counter were
+   removed. *)
+
+(** Resolve a model label string to an OAS Provider.config.
+    Uses MASC [Cascade_config.parse_model_string] (with Provider_registry as SSOT).
+    Explicit model-label execution must never silently substitute a
+    discovery-only model. Callers are expected to validate labels
+    before reaching this helper. *)
+type label_resolution_error = Runtime_transport_label_resolution.label_resolution_error =
+  | Invalid_model_label of string
+
+let label_resolution_error_to_string = Runtime_transport_label_resolution.label_resolution_error_to_string
+let label_resolution_error_to_sdk_error = Runtime_transport_label_resolution.label_resolution_error_to_sdk_error
+let resolve_provider_config_of_label = Runtime_transport_label_resolution.resolve_provider_config_of_label
+let invalid_runtime_config = Runtime_transport_label_resolution.invalid_runtime_config
+
+let cli_model_override = Runtime_transport_cli_config.cli_model_override
+
+(* CLI MCP config JSON serializer extracted to
+   [Runtime_transport_cli_mcp_config_json] (godfile decomp). *)
+let json_of_string_pairs = Runtime_transport_cli_mcp_config_json.json_of_string_pairs
+let json_of_cli_mcp_server = Runtime_transport_cli_mcp_config_json.json_of_cli_mcp_server
+
+let cli_mcp_config_json_of_policy =
+  Runtime_transport_cli_mcp_config_json.cli_mcp_config_json_of_policy
+;;
+
+let provider_caps_of_config = Provider_tool_support.oas_capabilities_of_config
+let provider_supports_inline_tools = Provider_tool_support.provider_supports_inline_tools
+
+let provider_supports_runtime_mcp_lane =
+  Provider_tool_support.provider_supports_runtime_mcp_lane
+;;
+
+let dedupe_preserve_order (items : string list) =
+  let seen = Hashtbl.create (List.length items) in
+  List.filter
+    (fun item ->
+       if Hashtbl.mem seen item
+       then false
+       else (
+         Hashtbl.add seen item ();
+         true))
+    items
+;;
+
+let upsert_http_header = Runtime_transport_authorization.upsert_http_header
+(* String_util.trim_nonempty + first_nonempty_env + runtime-MCP policy header helpers
+   extracted to [Runtime_transport_mcp_policy_helpers] (godfile decomp). *)
+let first_nonempty_env = Runtime_transport_mcp_policy_helpers.first_nonempty_env
+let keeper_name_of_agent_name = Runtime_transport_authorization.keeper_name_of_agent_name
+
+let runtime_mcp_policy_with_masc_agent_name =
+  Runtime_transport_mcp_policy_helpers.runtime_mcp_policy_with_masc_agent_name
+;;
+
+let runtime_mcp_policy_without_http_headers =
+  Runtime_transport_mcp_policy_helpers.runtime_mcp_policy_without_http_headers
+;;
+
+let is_authorization_header = Runtime_transport_authorization.is_authorization_header
+let authorization_header_from_policy = Runtime_transport_authorization.authorization_header_from_policy
+let per_keeper_authorization_header = Runtime_transport_authorization.per_keeper_authorization_header
+let runtime_mcp_policy_uses_bound_actor_tools = Runtime_transport_authorization.runtime_mcp_policy_uses_bound_actor_tools
+let add_masc_authorization_header = Runtime_transport_authorization.add_masc_authorization_header
+
+(* Per-keeper authorization bridging extracted to
+   [Runtime_transport_auth_bridging] (godfile decomp). *)
+let cli_tool_a_can_auth_keeper_bound_runtime_mcp = Runtime_transport_auth_bridging.cli_tool_a_can_auth_keeper_bound_runtime_mcp
+let bridged_runtime_mcp_policy_for_agent = Runtime_transport_auth_bridging.bridged_runtime_mcp_policy_for_agent
+
+(* Provider-driven runtime MCP policy resolver extracted to
+   [Runtime_transport_runtime_policy_provider] (godfile decomp). *)
+let runtime_mcp_policy_for_provider = Runtime_transport_runtime_policy_provider.runtime_mcp_policy_for_provider
+let cli_runtime_mcp_jsons = Runtime_transport_runtime_policy_provider.cli_runtime_mcp_jsons
+let public_mcp_tool_names_of_oas_tools =
+  Runtime_transport_mcp_tool_classifier.public_mcp_tool_names_of_oas_tools
+;;
+
+let public_mcp_tools_of_oas_tools =
+  Runtime_transport_mcp_tool_classifier.public_mcp_tools_of_oas_tools
+;;
+
+let tool_names_are_public_mcp =
+  Runtime_transport_mcp_tool_classifier.tool_names_are_public_mcp
+;;
+
+let runtime_mcp_tool_requires_bound_actor =
+  Runtime_transport_mcp_tool_classifier.runtime_mcp_tool_requires_bound_actor
+;;
+
+let public_mcp_tool_requires_bound_actor =
+  Runtime_transport_mcp_tool_classifier.public_mcp_tool_requires_bound_actor
+;;
+
+let tool_names_are_runtime_mcp =
+  Runtime_transport_mcp_tool_classifier.tool_names_are_runtime_mcp
+;;
+
+;;
+
+let runtime_mcp_policy_of_tool_names = Runtime_transport_runtime_mcp_policy_of_tool_names.runtime_mcp_policy_of_tool_names
+let public_mcp_runtime_policy_of_tool_names = Runtime_transport_runtime_mcp_policy_of_tool_names.public_mcp_runtime_policy_of_tool_names
+
+let provider_label = Runtime_transport_cli_config.provider_label
+
+let cli_model_for_provider_config =
+  Runtime_transport_cli_config.cli_model_for_provider_config
+;;
+
+let cli_command_for_provider_config =
+  Runtime_transport_cli_config.cli_command_for_provider_config
+;;
+
+let cli_process_name_for_provider_config =
+  Runtime_transport_cli_config.cli_process_name_for_provider_config
+;;
+
+let cli_runtime_config_json_for_provider =
+  Runtime_transport_cli_config.cli_runtime_config_json_for_provider
+;;
+
+let cli_direct_binding_extra_env =
+  Runtime_transport_cli_config.cli_direct_binding_extra_env
+;;
+
+let resolve_tool_lane_for_oas_tools
+      ?agent_name
+      ?(tool_requirement = `Required)
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~(tools : Agent_sdk.Tool.t list)
+      ()
+  : ( Agent_sdk.Tool.t list * Llm_provider.Llm_transport.runtime_mcp_policy option
+      , Agent_sdk.Error.sdk_error )
+      result
+  =
+  let public_tools = public_mcp_tools_of_oas_tools tools in
+  let public_tool_names = public_mcp_tool_names_of_oas_tools public_tools in
+  let requested_agent_name = Option.bind agent_name String_util.trim_nonempty in
+  let keeper_internal_tool_names =
+    match requested_agent_name with
+    | Some agent_name when Option.is_some (keeper_name_of_agent_name agent_name) ->
+      tools
+      |> List.filter (fun (tool : Agent_sdk.Tool.t) ->
+        Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool.schema.name)
+      |> List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name)
+      |> dedupe_preserve_order
+    | _ -> []
+  in
+  let requires_per_keeper_bridging =
+    Provider_tool_support
+    .provider_requires_per_keeper_bridging_for_bound_actor_tools
+      provider_cfg
+  in
+  let provider_can_auth_keeper_bound_actor_tools =
+    match requested_agent_name with
+    | Some agent_name
+      when requires_per_keeper_bridging
+           && Option.is_some (keeper_name_of_agent_name agent_name) ->
+      Option.is_some (per_keeper_authorization_header ~agent_name)
+    | _ -> false
+  in
+  let omitted_keeper_bound_actor_tools =
+    match requested_agent_name with
+    | Some agent_name
+      when requires_per_keeper_bridging
+           && Option.is_some (keeper_name_of_agent_name agent_name)
+           && not provider_can_auth_keeper_bound_actor_tools ->
+      List.filter
+        runtime_mcp_tool_requires_bound_actor
+        (public_tool_names @ keeper_internal_tool_names)
+    | _ -> []
+  in
+  (* RFC-0167: previously routed [omitted_keeper_bound_actor_tools] through
+     [Runtime_transport_codex_omission_dedup.record_cli_tool_a_omission_for_agent]
+     for WARN-dedup + per-tool counter. The dedup module was a
+     client-named adapter (cli_tool_a wire-quirk) and is removed; the
+     omission is now silently reflected only in the [Error
+     (invalid_runtime_config ...)] returned below. *)
+  if tool_requirement = `Required && omitted_keeper_bound_actor_tools <> []
+  then (
+    let detail =
+      Printf.sprintf
+        "%s cannot satisfy required keeper-bound runtime MCP tools omitted by the runtime adapter: \
+         %s"
+        (provider_label provider_cfg)
+        (String.concat ", " (List.sort String.compare omitted_keeper_bound_actor_tools))
+    in
+    Error (invalid_runtime_config "tool_support" detail))
+  else (
+    let public_tool_names =
+      if omitted_keeper_bound_actor_tools = []
+      then public_tool_names
+      else
+        List.filter
+          (fun tool_name -> not (public_mcp_tool_requires_bound_actor tool_name))
+          public_tool_names
+    in
+    let keeper_internal_tool_names =
+      if omitted_keeper_bound_actor_tools = []
+      then keeper_internal_tool_names
+      else
+        List.filter
+          (fun tool_name -> not (runtime_mcp_tool_requires_bound_actor tool_name))
+          keeper_internal_tool_names
+    in
+    let runtime_tool_names =
+      dedupe_preserve_order (public_tool_names @ keeper_internal_tool_names)
+    in
+    (* RFC-0167 (was #12676): When all tools were bound-actor and got
+       stripped on an optional turn, runtime_tool_names is empty. The
+       keeper may still use an MCP connection for discovery, so build a
+       minimal connect-only
+       policy with the server URL and auth but no allowed_tool_names. Required
+       turns reject above because a zero-tool policy cannot satisfy the tool
+       contract. *)
+    let runtime_mcp_policy =
+      if runtime_tool_names = [] && omitted_keeper_bound_actor_tools <> []
+      then (
+        let env_token = first_nonempty_env [ "MASC_MCP_TOKEN" ] in
+        let per_keeper_token =
+          match env_token, requested_agent_name with
+          | None, Some name ->
+            let base_path = Env_config_core.base_path () in
+            Auth.load_raw_token base_path ~agent_name:name
+          | _ -> None
+        in
+        let auth_headers =
+          match env_token, per_keeper_token with
+          | Some raw, _ -> [ "Authorization", "Bearer " ^ raw ]
+          | None, Some raw -> [ "Authorization", "Bearer " ^ raw ]
+          | None, None -> []
+        in
+        Some
+          { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+            servers =
+              [ Llm_provider.Llm_transport.Http_server
+                  { name = "masc"
+                  ; url = Env_config_runtime.Local_runtime.mcp_url ()
+                  ; headers = auth_headers
+                  }
+              ]
+          ; allowed_server_names = [ "masc" ]
+          ; allowed_tool_names = []
+          ; strict = false
+          ; disable_builtin_tools = false
+          }
+        |> runtime_mcp_policy_for_provider
+             ~provider_cfg
+             ~agent_name:(Option.value ~default:"" requested_agent_name))
+      else
+        runtime_mcp_policy_of_tool_names
+          ?agent_name:requested_agent_name
+          ~allow_keeper_internal:(keeper_internal_tool_names <> [])
+          runtime_tool_names
+        |> runtime_mcp_policy_for_provider
+             ~provider_cfg
+             ~agent_name:(Option.value ~default:"" requested_agent_name)
+    in
+    match runtime_mcp_policy with
+    | Some runtime_mcp_policy
+      when Provider_tool_support.provider_supports_runtime_mcp_policy
+             provider_cfg
+             runtime_mcp_policy -> Ok ([], Some runtime_mcp_policy)
+    | _ when tools = [] -> Ok (tools, None)
+    | _ when provider_supports_inline_tools provider_cfg -> Ok (tools, None)
+    | _ when tool_requirement = `Optional -> Ok ([], None)
+    | _ ->
+      let detail =
+        let runtime_mcp_requires_http_headers =
+          match runtime_mcp_policy with
+          | Some policy ->
+            Provider_tool_support.runtime_mcp_policy_requires_unsupported_http_headers
+              provider_cfg
+              policy
+          | None -> false
+        in
+        if
+          public_tool_names <> []
+          && runtime_mcp_requires_http_headers
+          && provider_supports_runtime_mcp_lane provider_cfg
+        then
+          Printf.sprintf
+            "%s does not support request-scoped runtime MCP HTTP headers required by \
+             public MCP tools"
+            (provider_label provider_cfg)
+        else if public_tool_names <> []
+        then
+          Printf.sprintf
+            "%s does not support inline tools or request-scoped runtime MCP tools"
+            (provider_label provider_cfg)
+        else
+          Printf.sprintf "%s does not support inline tools" (provider_label provider_cfg)
+      in
+      Error (invalid_runtime_config "tool_support" detail))
+;;
+
+(* JSON-stream CLI transport (665 LOC nested module) extracted to
+   [Runtime_transport_json_stream_cli_local] (godfile decomp).
+   Module alias preserves type identity; [Runtime_transport.mli]
+   signature constraint continues to apply unchanged. *)
+module Json_stream_cli_transport_local = Runtime_transport_json_stream_cli_local
+
+let json_stream_cli_transport_ctor
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~runtime_mcp_policy
+      ~cli_transport_overrides
+  =
+  let cwd =
+    Option.bind cli_transport_overrides (fun overrides ->
+      overrides.Runtime_transport_cli_overrides.cwd)
+  in
+  let stdout_idle_timeout_s =
+    Option.bind cli_transport_overrides (fun overrides ->
+      overrides.Runtime_transport_cli_overrides.cli_subprocess_idle_sec)
+  in
+  let mcp_config_json = cli_runtime_mcp_jsons ~base:[] runtime_mcp_policy in
+  let model = cli_model_for_provider_config provider_cfg in
+  let config_json = cli_runtime_config_json_for_provider provider_cfg in
+  let extra_env = cli_direct_binding_extra_env provider_cfg in
+  let cli_path =
+    cli_command_for_provider_config provider_cfg
+    |> Option.value ~default:Json_stream_cli_transport_local.default_config.cli_path
+  in
+  let process_name = cli_process_name_for_provider_config provider_cfg in
+  let config =
+    { Json_stream_cli_transport_local.default_config with
+      cli_path
+    ; process_name
+    ; model
+    ; cwd
+    ; config_json
+    ; mcp_config_json
+    ; extra_env
+    ; stdout_idle_timeout_s
+    }
+  in
+  match Process_eio.get_proc_mgr () with
+  | Error detail -> Error (invalid_runtime_config "proc_mgr" detail)
+  | Ok mgr ->
+    Ok
+      (Runtime_transport_cli_ctors.make_per_call_switch_transport (fun ~sw ->
+         Json_stream_cli_transport_local.create ~sw ~mgr ~config))
+;;
+
+let () =
+  Runtime_transport_non_http_registry.register_non_http_transport
+    ~kind:Llm_provider.Provider_config.Cli_tool_c
+    ~ctor:json_stream_cli_transport_ctor
+;;
+
+(* CLI transport constructors + per-call switch wrapping + ctor
+   registration extracted to [Runtime_transport_cli_ctors]
+   (godfile decomp). The sibling's top-level [let () = ...]
+   block registers the 4 ctors into
+   [Runtime_transport_non_http_registry] at module-load time. *)
+let make_per_call_switch_transport = Runtime_transport_cli_ctors.make_per_call_switch_transport
+
+(* CLI argv UTF-8 sanitization extracted to
+   [Runtime_transport_cli_argv_sanitize] (godfile decomp). *)
+let sanitize_runtime_mcp_server_for_cli =
+  Runtime_transport_cli_argv_sanitize.sanitize_runtime_mcp_server_for_cli
+;;
+
+let sanitize_runtime_mcp_policy_for_cli =
+  Runtime_transport_cli_argv_sanitize.sanitize_runtime_mcp_policy_for_cli
+;;
+
+let sanitize_cli_completion_request_for_argv =
+  Runtime_transport_cli_argv_sanitize.sanitize_cli_completion_request_for_argv
+;;
+let non_http_transport_of_provider = Runtime_transport_non_http_registry.non_http_transport_of_provider

--- a/lib/runtime/runtime_transport.mli
+++ b/lib/runtime/runtime_transport.mli
@@ -1,0 +1,292 @@
+(** Runtime_transport — Transport and tool-lane helpers for OAS worker exec.
+
+    Keeps provider label resolution, runtime MCP lane selection, and per-call
+    CLI transport construction separate from the build/run orchestration in
+    {!Runtime_agent}. *)
+
+(** Per-call overrides forwarded to CLI transports.  Each field is consulted
+    only by the matching provider kind; missing fields fall back to the
+    transport's [default_config]. *)
+type cli_transport_overrides = {
+  cwd : string option;
+  claude_mcp_config : string option;
+  claude_allowed_tools : string list option;
+  claude_permission_mode : string option;
+  claude_max_turns : int option;
+  gemini_yolo : bool option;
+  cli_subprocess_idle_sec : float option;
+      (** When [Some s], the CLI subprocess is aborted via SIGINT if no
+          stdout line arrives within [s] seconds.  Currently honoured
+          only by [Json_stream_cli_transport_local], which calls
+          [Cli_common_subprocess.run_stream_lines] directly.  Other CLI
+          transports route through agent_sdk [Transport_*_cli.create]
+          configs that do not yet expose [stdout_idle_timeout_s]; an
+          OAS upstream change is needed to honour this field there. *)
+}
+
+(** Hard cap for Claude Code's internal agent loop.  MASC may run a keeper
+    for more turns overall, but a single Claude Code subprocess attempt must
+    not receive that keeper-level budget unchanged. *)
+val cli_tool_d_max_turns_hard_cap : int
+
+(** Clamp provider-internal max_turns to provider hard constraints. *)
+val provider_effective_max_turns :
+  Llm_provider.Provider_config.provider_kind -> int -> int
+
+val sanitize_cli_completion_request_for_argv :
+  Llm_provider.Llm_transport.completion_request ->
+  Llm_provider.Llm_transport.completion_request
+(** Scrub request text that CLI transports may flatten into argv.
+
+    Codex CLI passes sub-threshold prompts as a positional argument, so any
+    invalid UTF-8 in history, system prompt, or request-scoped MCP overrides
+    can make the subprocess fail before the cascade reaches provider logic. *)
+
+(* RFC-0167: the client-named omission-dedup helpers
+   ([cli_tool_a_omission_fingerprint], [cli_tool_a_omission_fingerprint_seen],
+   [record_cli_tool_a_omission], [record_cli_tool_a_omission_for_agent],
+   [reset_cli_tool_a_omission_dedup_for_tests]) were removed in the
+   big-bang sweep along with [Runtime_transport_codex_omission_dedup].
+   Structural omission detection remains in the resolver below. *)
+
+(** Failure modes for {!resolve_provider_config_of_label}. *)
+type label_resolution_error =
+  | Invalid_model_label of string
+
+(** Render a label-resolution error for log/diagnostic surfaces. *)
+val label_resolution_error_to_string : label_resolution_error -> string
+
+(** Lift a label-resolution error into the OAS SDK error envelope. *)
+val label_resolution_error_to_sdk_error :
+  label_resolution_error -> Agent_sdk.Error.sdk_error
+
+(** Resolve a model label string to a provider config via the MASC cascade
+    parser.  Explicit labels never silently fall through to discovery-only
+    models — unresolved labels return [Error (Invalid_model_label _)]. *)
+val resolve_provider_config_of_label :
+  string -> (Llm_provider.Provider_config.t, label_resolution_error) result
+
+(** Construct an [Agent_sdk.Error.InvalidConfig] with the supplied [field] name and
+    [detail] text. *)
+val invalid_runtime_config : string -> string -> Agent_sdk.Error.sdk_error
+
+(** Normalize a CLI [model_id] to an explicit override.  Returns [None] when
+    the model id is empty or [auto] (case-insensitive after trim). *)
+val cli_model_override : string -> string option
+
+(** OAS capability snapshot for a provider config.  Alias for
+    {!Provider_tool_support.oas_capabilities_of_config}. *)
+val provider_caps_of_config :
+  Llm_provider.Provider_config.t -> Llm_provider.Capabilities.capabilities
+
+(** Whether a provider can accept inline tool definitions on a request.
+    Alias for {!Provider_tool_support.provider_supports_inline_tools}. *)
+val provider_supports_inline_tools :
+  ?override:Provider_tool_support.runtime_capabilities_override ->
+  Llm_provider.Provider_config.t -> bool
+
+(** Whether a provider supports the runtime MCP tool lane.  Alias for
+    {!Provider_tool_support.provider_supports_runtime_mcp_lane}. *)
+val provider_supports_runtime_mcp_lane :
+  ?override:Provider_tool_support.runtime_capabilities_override ->
+  Llm_provider.Provider_config.t -> bool
+
+(** Render the [mcpServers] config JSON consumed by JSON-stream CLI transports, filtering
+    by [policy.allowed_server_names].  Returns [None] when no allowed
+    server remains after filtering. *)
+val cli_mcp_config_json_of_policy :
+  Llm_provider.Llm_transport.runtime_mcp_policy -> string option
+
+(** Resolve a CLI provider model name from explicit provider config first,
+    then from the OAS runtime binding default/supported-model projection.
+    Returns [None] when the CLI binding does not publish a default. *)
+val cli_model_for_provider_config :
+  Llm_provider.Provider_config.t -> string option
+
+(** Render root config JSON (default_model + providers + models) for a
+    JSON-stream CLI provider.  Returns [None] when either the model
+    resolution or the auth value resolution fails. *)
+val cli_runtime_config_json_for_provider :
+  Llm_provider.Provider_config.t -> string option
+
+(** Drop duplicates from a list while preserving the first-seen order. *)
+val dedupe_preserve_order : string list -> string list
+
+(** Extract the [name] field of every OAS tool. *)
+val public_mcp_tool_names_of_oas_tools : Agent_sdk.Tool.t list -> string list
+
+(** Filter [tools] to those whose name is a public MCP tool per
+    {!Tool_catalog.is_public_mcp}. *)
+val public_mcp_tools_of_oas_tools : Agent_sdk.Tool.t list -> Agent_sdk.Tool.t list
+
+(** Whether every name in [tool_names] is a public MCP tool.  Empty input
+    returns [false]. *)
+val tool_names_are_public_mcp : string list -> bool
+
+(** Whether a runtime MCP tool requires a request-scoped actor binding (alias
+    for {!Tool_catalog.requires_actor_binding}). *)
+val runtime_mcp_tool_requires_bound_actor : string -> bool
+
+(** Whether a public MCP tool requires a request-scoped actor binding. *)
+val public_mcp_tool_requires_bound_actor : string -> bool
+
+(** Inject identity headers ([x-masc-agent-name], [x-masc-keeper-name]) into
+    the [masc] HTTP server entry of [policy] when [agent_name] is non-empty.
+    [x-masc-internal-token] is also injected by default when
+    [MASC_INTERNAL_MCP_TOKEN] is available; pass
+    [~include_internal_token:false] for providers such as [cli_tool_a] that
+    cannot carry auth-bearing request headers.  Other servers are passed
+    through. *)
+val runtime_mcp_policy_with_masc_agent_name :
+  ?include_internal_token:bool ->
+  agent_name:string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy ->
+  Llm_provider.Llm_transport.runtime_mcp_policy
+
+val cli_tool_a_can_auth_keeper_bound_runtime_mcp :
+  agent_name:string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy ->
+  bool
+(** [true] when [agent_name] maps to a keeper with a persisted raw bearer
+    token and [policy] contains actor-bound runtime MCP tools.  Codex CLI
+    can carry that token via OAS [bearer_token_env_var] without placing it in
+    argv. *)
+
+(** Provider-specific shaping of the runtime MCP policy.  For Cli_tool_a the
+    policy is stripped to Codex-safe headers: [Authorization: Bearer ...]
+    plus non-secret MASC identity headers.  Other providers receive the policy
+    with [runtime_mcp_policy_with_masc_agent_name] applied when [agent_name] is
+    non-empty. *)
+val runtime_mcp_policy_for_provider :
+  provider_cfg:Llm_provider.Provider_config.t ->
+  agent_name:string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+
+(** Compose JSON-stream CLI [--mcp-config] arguments from a [base] list and
+    an optional runtime MCP policy.  Output is deduped, preserving order. *)
+val cli_runtime_mcp_jsons :
+  base:string list ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  string list
+
+(** Build the runtime MCP policy that exposes [tool_names] back to the
+    provider's CLI.  Returns [None] when the tool set is not eligible for
+    the runtime MCP lane (e.g. mixed surface, missing keeper identity for
+    keeper-internal tools, or empty input). *)
+val runtime_mcp_policy_of_tool_names :
+  ?agent_name:string ->
+  ?allow_keeper_internal:bool ->
+  string list ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+
+(** Public-only variant of {!runtime_mcp_policy_of_tool_names}.  Forwards
+    without [allow_keeper_internal]. *)
+val public_mcp_runtime_policy_of_tool_names :
+  ?agent_name:string ->
+  string list ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+
+(** Human-readable [provider_kind:model_id] label. *)
+val provider_label : Llm_provider.Provider_config.t -> string
+
+(** Decide whether [tools] are served via runtime MCP lane, inline, or
+    rejected as unsupported.  Returns [(remaining_inline_tools, policy)]:
+    - [(_, Some policy)] — runtime MCP lane carries the tools (inline list
+      is empty in that case).
+    - [(tools, None)] — fall back to inline tools (when supported by the
+      provider).
+    - [Error sdk_error] — provider supports neither lane.
+
+    Cli_tool_a + keeper-bound actor tools use the per-keeper raw bearer
+    token when it is available, routed through OAS [bearer_token_env_var].
+    When no per-keeper token exists, they trigger the [#10097] omission
+    counter/log path. Required turns reject because the omitted tools cannot
+    satisfy the tool contract; optional turns keep the prior degraded
+    discovery path and exclude those tools from the resulting policy. *)
+val resolve_tool_lane_for_oas_tools :
+  ?agent_name:string ->
+  ?tool_requirement:[ `Required | `Optional ] ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  tools:Agent_sdk.Tool.t list ->
+  unit ->
+  ( Agent_sdk.Tool.t list
+    * Llm_provider.Llm_transport.runtime_mcp_policy option,
+    Agent_sdk.Error.sdk_error )
+  result
+
+(** Wrap a CLI transport factory in a per-call sub-switch so that any
+    pipe/process resources allocated by the factory are deterministically
+    released at the end of each completion call. *)
+val make_per_call_switch_transport :
+  (sw:Eio.Switch.t -> Llm_provider.Llm_transport.t) ->
+  Llm_provider.Llm_transport.t
+
+(** Construct a non-HTTP CLI transport for [provider_cfg].  Returns [Ok None]
+    for HTTP-shaped providers.  Returns [Error] when the process manager is not
+    initialized. *)
+val non_http_transport_of_provider :
+  sw:Eio.Switch.t ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
+  ?cli_transport_overrides:cli_transport_overrides ->
+  unit ->
+  (Llm_provider.Llm_transport.t option, Agent_sdk.Error.sdk_error) result
+
+(** JSON-stream print-mode CLI transport.  Owned by the transport layer;
+    runner facades must not re-export this protocol-local surface. *)
+module Json_stream_cli_transport_local : sig
+  type config = {
+    cli_path : string;
+    process_name : string;
+    model : string option;
+    cwd : string option;
+    config_json : string option;
+    mcp_config_json : string list;
+    extra_env : (string * string) list;
+    cancel : unit Eio.Promise.t option;
+    stdout_idle_timeout_s : float option;
+        (** When [Some s], the CLI subprocess is aborted via SIGINT if no
+            stdout line arrives within [s] seconds.  Forwarded to
+            [Llm_provider.Cli_common_subprocess.run_stream_lines] together
+            with the process clock obtained from [Process_eio.get_clock].
+            Defaults to [None] (no idle bound; rely on the outer keeper
+            turn timeout). *)
+  }
+
+  val default_config : config
+
+  (** Build the CLI argv from a config + per-call request, deciding
+      whether the prompt goes via [-p] or stdin. Non-ASCII or large prompts
+      use stdin to avoid Python CLI setproctitle UTF-8 decode crashes. *)
+  val build_args :
+    config:config ->
+    req_config:Llm_provider.Provider_config.t ->
+    mcp_config_json:string list ->
+    prompt:string ->
+    string list
+
+  (** Whether a CLI stderr line should be forwarded to the default
+      stderr logger.  Drops the [resume hint] lines, which are noise. *)
+  val should_log_stderr_line : string -> bool
+
+  (** Constant detail string used for typed resumable-session reports. *)
+  val resumable_session_detail : string
+
+  (** Reclassify a [NetworkError] from the CLI into [AcceptRejected] when
+      the message indicates a permanent per-provider error
+      (auth/config/model), a local CLI startup crash, or an exit-75
+      resumable-session process status.  Other variants pass through. *)
+  val classify_cli_error :
+    ('a, Llm_provider.Http_client.http_error) result ->
+    ('a, Llm_provider.Http_client.http_error) result
+
+  (** Create a JSON-stream CLI completion transport bound to [sw].  The transport
+      runs [<cli> --print --output-format stream-json ...] via [mgr] and
+      parses JSONL output into OAS response/event blocks. *)
+  val create :
+    sw:Eio.Switch.t ->
+    mgr:_ Eio.Process.mgr ->
+    config:config ->
+    Llm_provider.Llm_transport.t
+end

--- a/lib/runtime/runtime_transport_auth_bridging.ml
+++ b/lib/runtime/runtime_transport_auth_bridging.ml
@@ -1,0 +1,72 @@
+(** Per-keeper authorization bridging for runtime MCP policies.
+    Extracted from [cascade_transport.ml] (godfile decomp). Two
+    helpers:
+
+    - [cli_tool_a_can_auth_keeper_bound_runtime_mcp] — predicate that
+      decides whether the Codex CLI route can mint a per-keeper
+      Authorization header for a bound-actor MCP policy.
+
+    - [bridged_runtime_mcp_policy_for_agent] — the RFC-0058 §2.4
+      capability-driven projection: strip inbound HTTP headers,
+      re-inject MASC identity headers, and source the Authorization
+      header from the bound-actor branch or the inbound MASC entry. *)
+
+module Authorization = Runtime_transport_authorization
+module Mcp_policy_helpers = Runtime_transport_mcp_policy_helpers
+
+let cli_tool_a_can_auth_keeper_bound_runtime_mcp ~agent_name policy =
+  Authorization.runtime_mcp_policy_uses_bound_actor_tools policy
+  && Option.is_some (Authorization.per_keeper_authorization_header ~agent_name)
+;;
+
+(* RFC-0058 §2.4 capability-driven projection.
+
+   Header lifecycle (in this order, no early exits):
+   1. [runtime_mcp_policy_without_http_headers] strips ALL HTTP headers
+      from every [Http_server] in the policy. This step is
+      unconditional — any inbound [Authorization] is gone before any
+      decision below.
+   2. [runtime_mcp_policy_with_masc_agent_name] re-injects only the
+      non-secret MASC identity headers.
+   3. The [Authorization] header is then sourced from one of two
+      branches:
+        - if [runtime_mcp_policy_uses_bound_actor_tools policy = true],
+          from [Auth.load_raw_token] via
+          [per_keeper_authorization_header ~agent_name];
+        - else, read from the *inbound* policy's [name = "masc"]
+          [Http_server] entry via [authorization_header_from_policy]
+          (which reads [policy.servers], not [stripped.servers], so it
+          recovers the MASC bearer that the caller provided).
+      When either branch yields [None], the returned policy carries no
+      [Authorization] header — there is no fall-through to the inbound
+      policy's non-masc headers, which were removed in step 1.
+
+   Invariant: this function is only reached from the dispatch site when the
+   provider-tool policy says per-keeper bridging is required, i.e. the runtime
+   cannot carry arbitrary per-request HTTP headers.  Body is intentionally
+   identical in semantics to the prior [codex_runtime_mcp_policy_for_agent] —
+   the rename removes the provider-name leak from the dispatch site without
+   altering behavior.
+
+   A future adapter with [requires_per_keeper_bridging = true] but
+   different transport semantics (e.g. native per-keeper header
+   injection) should be handled by an explicit dispatch arm at the
+   call site, not by adding a new flag parameter here — adding such
+   a flag now would introduce a code path no current provider exercises
+   and risks a silent header-preservation regression (see Copilot
+   review of PR #14885). *)
+let bridged_runtime_mcp_policy_for_agent ~agent_name policy =
+  let stripped =
+    Mcp_policy_helpers.runtime_mcp_policy_without_http_headers policy
+    |> Mcp_policy_helpers.runtime_mcp_policy_with_masc_agent_name
+         ~include_internal_token:false ~agent_name
+  in
+  let authorization_header =
+    if Authorization.runtime_mcp_policy_uses_bound_actor_tools policy
+    then Authorization.per_keeper_authorization_header ~agent_name
+    else Authorization.authorization_header_from_policy policy
+  in
+  match authorization_header with
+  | Some header -> Authorization.add_masc_authorization_header header stripped
+  | None -> stripped
+;;

--- a/lib/runtime/runtime_transport_auth_bridging.mli
+++ b/lib/runtime/runtime_transport_auth_bridging.mli
@@ -1,0 +1,15 @@
+(** Per-keeper authorization bridging for runtime MCP policies. *)
+
+val cli_tool_a_can_auth_keeper_bound_runtime_mcp :
+  agent_name:string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy ->
+  bool
+(** [true] when Codex CLI can mint a per-keeper Authorization header for
+    actor-bound runtime MCP tools. *)
+
+val bridged_runtime_mcp_policy_for_agent :
+  agent_name:string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy ->
+  Llm_provider.Llm_transport.runtime_mcp_policy
+(** Strip inbound HTTP headers, re-inject MASC identity headers, and attach the
+    selected Authorization header when available. *)

--- a/lib/runtime/runtime_transport_authorization.ml
+++ b/lib/runtime/runtime_transport_authorization.ml
@@ -1,0 +1,90 @@
+(** Authorization header helpers for cascade runtime MCP transport,
+    extracted from cascade_transport.ml.
+
+    Pure functions over runtime-MCP policy + per-keeper auth headers;
+    no protocol/transport state owned here. *)
+
+let upsert_http_header ~key ~value headers =
+  let key_lc = String.lowercase_ascii key in
+  let retained =
+    List.filter
+      (fun (existing_key, _) ->
+         not (String.equal (String.lowercase_ascii existing_key) key_lc))
+      headers
+  in
+  (key, value) :: retained
+;;
+
+let keeper_name_of_agent_name agent_name =
+  let prefix = "keeper-" in
+  let suffix = "-agent" in
+  let value = String.trim agent_name in
+  let vlen = String.length value in
+  let plen = String.length prefix in
+  let slen = String.length suffix in
+  if
+    vlen > plen + slen
+    && String.sub value 0 plen = prefix
+    && String.sub value (vlen - slen) slen = suffix
+  then Some (String.sub value plen (vlen - plen - slen))
+  else None
+;;
+
+let is_authorization_header (key, value) =
+  String.equal (String.lowercase_ascii (String.trim key)) "authorization"
+  && String.starts_with ~prefix:"Bearer " (String.trim value)
+;;
+
+let authorization_header_from_policy
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  =
+  List.find_map
+    (function
+      | Llm_provider.Llm_transport.Http_server { name = "masc"; headers; _ } ->
+        List.find_opt is_authorization_header headers
+      (* Only the [Http_server] entry whose [name = "masc"] carries the
+         per-request Authorization header. Other named [Http_server]s and
+         [Stdio_server]s contribute no auth header on this lane. New
+         transport variants must re-decide explicitly. *)
+      | Llm_provider.Llm_transport.Http_server _
+      | Llm_provider.Llm_transport.Stdio_server _ -> None)
+    policy.servers
+;;
+
+let per_keeper_authorization_header ~agent_name =
+  match keeper_name_of_agent_name agent_name with
+  | None -> None
+  | Some _ ->
+    let base_path = Env_config_core.base_path () in
+    Auth.load_raw_token base_path ~agent_name
+    |> Option.map (fun raw -> "Authorization", "Bearer " ^ raw)
+;;
+
+let runtime_mcp_policy_uses_bound_actor_tools
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  =
+  List.exists Tool_catalog.requires_actor_binding policy.allowed_tool_names
+;;
+
+let add_masc_authorization_header
+      authorization_header
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  =
+  let servers =
+    List.map
+      (function
+        | Llm_provider.Llm_transport.Http_server ({ name = "masc"; headers; _ } as server)
+          ->
+          Llm_provider.Llm_transport.Http_server
+            { server with
+              headers =
+                upsert_http_header
+                  ~key:(fst authorization_header)
+                  ~value:(snd authorization_header)
+                  headers
+            }
+        | server -> server)
+      policy.servers
+  in
+  { policy with servers }
+;;

--- a/lib/runtime/runtime_transport_authorization.mli
+++ b/lib/runtime/runtime_transport_authorization.mli
@@ -1,0 +1,21 @@
+(** Authorization header helpers for cascade runtime MCP transport. *)
+
+val upsert_http_header :
+  key:string -> value:string -> (string * string) list -> (string * string) list
+
+val keeper_name_of_agent_name : string -> string option
+val is_authorization_header : string * string -> bool
+
+val authorization_header_from_policy :
+  Llm_provider.Llm_transport.runtime_mcp_policy -> (string * string) option
+
+val per_keeper_authorization_header :
+  agent_name:string -> (string * string) option
+
+val runtime_mcp_policy_uses_bound_actor_tools :
+  Llm_provider.Llm_transport.runtime_mcp_policy -> bool
+
+val add_masc_authorization_header :
+  string * string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy ->
+  Llm_provider.Llm_transport.runtime_mcp_policy

--- a/lib/runtime/runtime_transport_cli_argv_sanitize.ml
+++ b/lib/runtime/runtime_transport_cli_argv_sanitize.ml
@@ -1,0 +1,64 @@
+(* UTF-8 argv sanitization for CLI-driven LLM transports.
+
+   CLI-bound providers (agent_code, cli_tool_d, provider_f, json-stream variants)
+   cannot accept invalid UTF-8 in argv/env/payload without misbehaving;
+   this layer scrubs strings through [Inference_utils.sanitize_text_utf8]
+   before they cross the transport boundary.
+
+   Extracted from [Runtime_transport] (godfile decomp). All functions
+   are pure mappings over [Llm_provider.Llm_transport] values. *)
+
+let sanitize_runtime_mcp_server_for_cli =
+  let sanitize = Inference_utils.sanitize_text_utf8 in
+  function
+  | Llm_provider.Llm_transport.Stdio_server { name; command; args; env } ->
+    Llm_provider.Llm_transport.Stdio_server
+      { name = sanitize name
+      ; command = sanitize command
+      ; args = List.map sanitize args
+      ; env = List.map (fun (key, value) -> sanitize key, sanitize value) env
+      }
+  | Llm_provider.Llm_transport.Http_server { name; url; headers } ->
+    Llm_provider.Llm_transport.Http_server
+      { name = sanitize name
+      ; url = sanitize url
+      ; headers = List.map (fun (key, value) -> sanitize key, sanitize value) headers
+      }
+;;
+
+let sanitize_runtime_mcp_policy_for_cli
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  =
+  let sanitize = Inference_utils.sanitize_text_utf8 in
+  { policy with
+    servers = List.map sanitize_runtime_mcp_server_for_cli policy.servers
+  ; allowed_server_names = List.map sanitize policy.allowed_server_names
+  ; allowed_tool_names = List.map sanitize policy.allowed_tool_names
+  ; permission_mode = Option.map sanitize policy.permission_mode
+  ; approval_mode = Option.map sanitize policy.approval_mode
+  }
+;;
+
+let sanitize_cli_completion_request_for_argv
+      (req : Llm_provider.Llm_transport.completion_request)
+  =
+  { req with
+    config =
+      { req.config with
+        system_prompt =
+          Option.map Inference_utils.sanitize_text_utf8 req.config.system_prompt
+      }
+  ; messages = Inference_utils.sanitize_messages_utf8 req.messages
+  ; runtime_mcp_policy =
+      Option.map sanitize_runtime_mcp_policy_for_cli req.runtime_mcp_policy
+  }
+;;
+
+let make_cli_argv_sanitizing_transport (transport : Llm_provider.Llm_transport.t) =
+  { Llm_provider.Llm_transport.complete_sync =
+      (fun req -> transport.complete_sync (sanitize_cli_completion_request_for_argv req))
+  ; complete_stream =
+      (fun ?on_telemetry:_ ~on_event req ->
+         transport.complete_stream ~on_event (sanitize_cli_completion_request_for_argv req))
+  }
+;;

--- a/lib/runtime/runtime_transport_cli_argv_sanitize.mli
+++ b/lib/runtime/runtime_transport_cli_argv_sanitize.mli
@@ -1,0 +1,21 @@
+(** UTF-8 argv sanitization for CLI-driven LLM transports.
+
+    CLI providers reject invalid UTF-8 in argv/env/payloads; these
+    helpers scrub strings through [Inference_utils.sanitize_text_utf8]
+    before the request crosses the transport boundary. *)
+
+val sanitize_runtime_mcp_server_for_cli
+  :  Llm_provider.Llm_transport.runtime_mcp_server
+  -> Llm_provider.Llm_transport.runtime_mcp_server
+
+val sanitize_runtime_mcp_policy_for_cli
+  :  Llm_provider.Llm_transport.runtime_mcp_policy
+  -> Llm_provider.Llm_transport.runtime_mcp_policy
+
+val sanitize_cli_completion_request_for_argv
+  :  Llm_provider.Llm_transport.completion_request
+  -> Llm_provider.Llm_transport.completion_request
+
+val make_cli_argv_sanitizing_transport
+  :  Llm_provider.Llm_transport.t
+  -> Llm_provider.Llm_transport.t

--- a/lib/runtime/runtime_transport_cli_config.ml
+++ b/lib/runtime/runtime_transport_cli_config.ml
@@ -1,0 +1,215 @@
+;;
+
+(* Duplicated locally to avoid sibling -> parent cycle. *)
+let dedupe_preserve_order (items : string list) =
+  let seen = Hashtbl.create (List.length items) in
+  List.filter
+    (fun item ->
+       if Hashtbl.mem seen item
+       then false
+       else (
+         Hashtbl.add seen item ();
+         true))
+    items
+;;
+
+let cli_model_override model_id =
+  match String.lowercase_ascii (String.trim model_id) with
+  | "" | "auto" -> None
+  | _ -> Some (String.trim model_id)
+;;
+
+let provider_label (provider_cfg : Llm_provider.Provider_config.t) =
+  Printf.sprintf
+    "%s:%s"
+    (Llm_provider.Provider_config.string_of_provider_kind provider_cfg.kind)
+    provider_cfg.model_id
+;;
+
+let provider_config_runtime_binding (provider_cfg : Llm_provider.Provider_config.t) =
+  Agent_sdk.Provider_runtime_binding.binding_for_provider_config provider_cfg
+;;
+
+let runtime_binding_default_model (binding : Agent_sdk.Provider_runtime_binding.t) =
+  match String_util.option_trim binding.default_model with
+  | Some model -> Some model
+  | None ->
+    (match binding.capabilities.supported_models with
+     | Some (model :: _) -> String_util.option_trim (Some model)
+     | Some [] | None -> None)
+;;
+
+let cli_model_for_provider_config (provider_cfg : Llm_provider.Provider_config.t) =
+  match cli_model_override provider_cfg.model_id with
+  | Some explicit -> Some explicit
+  | None -> Option.bind (provider_config_runtime_binding provider_cfg) runtime_binding_default_model
+;;
+
+let cli_command_for_provider_config provider_cfg =
+  Option.bind (provider_config_runtime_binding provider_cfg) (fun binding ->
+    String_util.option_trim binding.Agent_sdk.Provider_runtime_binding.command)
+;;
+
+let basename_of_command command =
+  command
+  |> String.split_on_char '/'
+  |> List.rev
+  |> List.find_opt (fun segment -> String.trim segment <> "")
+  |> Option.value ~default:command
+;;
+
+let cli_process_name_for_provider_config provider_cfg =
+  cli_command_for_provider_config provider_cfg
+  |> Option.map basename_of_command
+  |> Option.value ~default:"json_stream_cli"
+;;
+
+let nonempty_opt value =
+  match value with
+  | Some value -> String_util.option_trim (Some value)
+  | None -> None
+;;
+
+let direct_binding_candidates_for_cli_binding
+      (binding : Agent_sdk.Provider_runtime_binding.t)
+  =
+  [ binding.credential_scope; binding.command ]
+  |> List.filter_map nonempty_opt
+  |> dedupe_preserve_order
+;;
+
+let binding_is_direct_runtime (binding : Agent_sdk.Provider_runtime_binding.t) =
+  match binding.transport with
+  | Agent_sdk.Provider_runtime_binding.Http
+  | Agent_sdk.Provider_runtime_binding.Managed
+  | Agent_sdk.Provider_runtime_binding.Custom_provider_d_compat -> true
+  | Agent_sdk.Provider_runtime_binding.Cli -> false
+;;
+
+let direct_binding_for_cli_provider_config provider_cfg =
+  match provider_config_runtime_binding provider_cfg with
+  | None -> None
+  | Some binding ->
+    direct_binding_candidates_for_cli_binding binding
+    |> List.find_map (fun label ->
+      match Agent_sdk.Provider_runtime_binding.find label with
+      | Some direct when binding_is_direct_runtime direct -> Some direct
+      | Some _
+      | None -> None)
+;;
+
+let auth_env_names_of_binding (binding : Agent_sdk.Provider_runtime_binding.t) =
+  let auth_env =
+    match binding.auth with
+    | Agent_sdk.Provider_runtime_binding.Api_key_env env
+    | Agent_sdk.Provider_runtime_binding.Setup_token_env env -> [ env ]
+    | Agent_sdk.Provider_runtime_binding.No_auth
+    | Agent_sdk.Provider_runtime_binding.Cli_cached_login
+    | Agent_sdk.Provider_runtime_binding.Oauth_cached_login
+    | Agent_sdk.Provider_runtime_binding.File _
+    | Agent_sdk.Provider_runtime_binding.Exec _ -> []
+  in
+  binding.api_key_env :: auth_env
+  |> List.filter_map (fun env -> String_util.option_trim (Some env))
+  |> dedupe_preserve_order
+;;
+
+let binding_api_base_url (binding : Agent_sdk.Provider_runtime_binding.t) =
+  let base_url = String.trim binding.base_url in
+  if String.equal base_url ""
+  then None
+  else (
+    let request_path = String.trim binding.request_path in
+    if String.equal request_path ""
+    then Some base_url
+    else (
+      let request_path =
+        if String.starts_with ~prefix:"/" request_path
+        then request_path
+        else "/" ^ request_path
+      in
+      let path_prefix =
+        match String.rindex_opt request_path '/' with
+        | Some 0
+        | None -> ""
+        | Some idx -> String.sub request_path 0 idx
+      in
+      Some (Env_config_core.strip_trailing_slashes base_url ^ path_prefix)))
+;;
+
+let first_nonempty_env names =
+  List.find_map (fun name -> Sys.getenv_opt name |> String_util.option_trim) names
+;;
+
+let cli_direct_auth_value
+      ?(direct_binding = direct_binding_for_cli_provider_config)
+      (provider_cfg : Llm_provider.Provider_config.t)
+  =
+  match String_util.option_trim (Some provider_cfg.api_key) with
+  | Some key -> Some key
+  | None ->
+    (match direct_binding provider_cfg with
+     | Some binding -> first_nonempty_env (auth_env_names_of_binding binding)
+     | None -> None)
+;;
+
+let cli_backing_runtime
+      ?(direct_binding = direct_binding_for_cli_provider_config)
+      provider_cfg
+  =
+  Option.bind (direct_binding provider_cfg) (fun binding ->
+    match binding_api_base_url binding with
+    | Some api_base_url -> Some (binding, api_base_url)
+    | None -> None)
+;;
+
+let cli_runtime_config_json_for_provider (provider_cfg : Llm_provider.Provider_config.t)
+  : string option
+  =
+  match
+    ( cli_model_for_provider_config provider_cfg
+    , cli_direct_auth_value provider_cfg
+    , cli_backing_runtime provider_cfg )
+  with
+  | Some model_name, Some _, Some (binding, api_base_url) ->
+    let provider_name = binding.Agent_sdk.Provider_runtime_binding.id in
+    let max_context_size =
+      Cascade_config.resolve_provider_model_max_context
+        ~provider_name
+        model_name
+    in
+    let config_json =
+      `Assoc
+        [ "default_model", `String model_name
+        ; ( "providers"
+          , `Assoc
+              [ ( provider_name
+                , `Assoc
+                    [ "type", `String provider_name
+                    ; "base_url", `String api_base_url
+                    ; "api_key", `String ""
+                    ] )
+              ] )
+        ; ( "models"
+          , `Assoc
+              [ ( model_name
+                , `Assoc
+                    [ "provider", `String provider_name
+                    ; "model", `String model_name
+                    ; "max_context_size", `Int max_context_size
+                    ] )
+              ] )
+        ]
+    in
+    Some (Yojson.Safe.to_string config_json)
+  | _ -> None
+;;
+
+let cli_direct_binding_extra_env (provider_cfg : Llm_provider.Provider_config.t) =
+  match direct_binding_for_cli_provider_config provider_cfg, cli_direct_auth_value provider_cfg with
+  | Some binding, Some key ->
+    (match auth_env_names_of_binding binding with
+     | env_name :: _ -> [ env_name, key ]
+     | [] -> [])
+  | _ -> []
+;;

--- a/lib/runtime/runtime_transport_cli_config.mli
+++ b/lib/runtime/runtime_transport_cli_config.mli
@@ -1,0 +1,7 @@
+val cli_model_override : string -> string option
+val provider_label : Llm_provider.Provider_config.t -> string
+val cli_model_for_provider_config : Llm_provider.Provider_config.t -> string option
+val cli_command_for_provider_config : Llm_provider.Provider_config.t -> string option
+val cli_process_name_for_provider_config : Llm_provider.Provider_config.t -> string
+val cli_runtime_config_json_for_provider : Llm_provider.Provider_config.t -> string option
+val cli_direct_binding_extra_env : Llm_provider.Provider_config.t -> (string * string) list

--- a/lib/runtime/runtime_transport_cli_ctors.ml
+++ b/lib/runtime/runtime_transport_cli_ctors.ml
@@ -1,0 +1,138 @@
+(** CLI transport constructors + registration, extracted from
+    [cascade_transport.ml] (godfile decomp).
+
+    Builds on prior cascade extractions:
+    - [Runtime_transport_cli_overrides] (#17393): cli_transport_overrides
+      type + default
+    - [Runtime_transport_non_http_registry] (#17428): registry +
+      register_non_http_transport
+    - [Runtime_transport_cli_config]: provider config readers
+    - [Runtime_transport_cli_argv_sanitize]: make_cli_argv_sanitizing_transport
+    - [Runtime_transport_runtime_policy_provider]: cli_runtime_mcp_jsons
+
+    Contents:
+
+    - [make_per_call_switch_transport factory] — wraps each
+      transport call in its own [Eio.Switch] so leftover pipe/process
+      resources release deterministically at call-end, even for
+      long-lived keepers.
+
+    - [with_proc_mgr f] — pulls [Process_eio.get_proc_mgr ()] and
+      threads it as a [~mgr] arg, surfacing the
+      [invalid_runtime_config "proc_mgr" detail] error if the
+      process manager isn't initialized.
+
+    - 4 transport constructors: [cli_tool_d_transport_ctor],
+      [cli_tool_b_transport_ctor], [json_stream_cli_transport_ctor]
+      (used by Provider_c CLI), [cli_tool_a_transport_ctor]. Each reads
+      [cli_transport_overrides] from the caller (falling back to
+      defaults), builds the provider's transport-specific config,
+      and returns a per-call switched transport wrapped in
+      [Process_eio.get_proc_mgr]. The agent_code ctor additionally
+      wraps in [make_cli_argv_sanitizing_transport] for UTF-8 argv
+      hygiene.
+
+    - Top-level [let () = ...] registration block that wires the 4
+      ctors into [Runtime_transport_non_http_registry] at module
+      load time, keyed by [Llm_provider.Provider_config.Cli_tool_d],
+      [.Cli_tool_b], [.Cli_tool_c], [.Cli_tool_a]. The sibling's
+      ordering invariant: this block fires *after* the registry's
+      Hashtbl is created (sibling depends on
+      [Runtime_transport_non_http_registry]), so by the time any
+      caller invokes [non_http_transport_of_provider] at runtime,
+      the registry is populated. *)
+
+module Cli_overrides = Runtime_transport_cli_overrides
+module Cli_config = Runtime_transport_cli_config
+module Cli_argv_sanitize = Runtime_transport_cli_argv_sanitize
+module Registry = Runtime_transport_non_http_registry
+module Label_resolution = Runtime_transport_label_resolution
+
+let make_per_call_switch_transport
+      (factory : sw:Eio.Switch.t -> Llm_provider.Llm_transport.t)
+  : Llm_provider.Llm_transport.t
+  =
+  let with_call_switch f = Eio.Switch.run (fun sw -> f (factory ~sw)) in
+  { complete_sync =
+      (fun req -> with_call_switch (fun transport -> transport.complete_sync req))
+  ; complete_stream =
+      (fun ?on_telemetry:_ ~on_event req ->
+        with_call_switch (fun transport -> transport.complete_stream ~on_event req))
+  }
+;;
+
+let with_proc_mgr (f : mgr:_ -> Llm_provider.Llm_transport.t) =
+  match Process_eio.get_proc_mgr () with
+  | Error detail -> Error (Label_resolution.invalid_runtime_config "proc_mgr" detail)
+  | Ok mgr -> Ok (f ~mgr)
+;;
+
+let cli_tool_d_transport_ctor
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~runtime_mcp_policy:_
+      ~cli_transport_overrides
+  =
+  let overrides =
+    Option.value ~default:Cli_overrides.default_cli_transport_overrides cli_transport_overrides
+  in
+  let config =
+    { Llm_provider.Transport_cli_tool_d.default_config with
+      model = Cli_config.cli_model_override provider_cfg.model_id
+    ; cwd = overrides.cwd
+    ; mcp_config = overrides.claude_mcp_config
+    ; allowed_tools = Option.value ~default:[] overrides.claude_allowed_tools
+    ; permission_mode = overrides.claude_permission_mode
+    ; max_turns = overrides.claude_max_turns
+    }
+  in
+  with_proc_mgr (fun ~mgr ->
+    make_per_call_switch_transport (fun ~sw ->
+      Llm_provider.Transport_cli_tool_d.create ~sw ~mgr ~config))
+;;
+
+let cli_tool_b_transport_ctor
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~runtime_mcp_policy:_
+      ~cli_transport_overrides
+  =
+  let overrides =
+    Option.value ~default:Cli_overrides.default_cli_transport_overrides cli_transport_overrides
+  in
+  let config =
+    { Llm_provider.Transport_cli_tool_b.default_config with
+      model = Cli_config.cli_model_override provider_cfg.model_id
+    ; cwd = overrides.cwd
+    ; yolo = Option.value ~default:true overrides.gemini_yolo
+    }
+  in
+  with_proc_mgr (fun ~mgr ->
+    make_per_call_switch_transport (fun ~sw ->
+      Llm_provider.Transport_cli_tool_b.create ~sw ~mgr ~config))
+;;
+
+let cli_tool_a_transport_ctor
+      ~provider_cfg:_
+      ~runtime_mcp_policy:_
+      ~cli_transport_overrides
+  =
+  let cwd = Option.bind cli_transport_overrides (fun overrides -> overrides.Cli_overrides.cwd) in
+  with_proc_mgr (fun ~mgr ->
+    Cli_argv_sanitize.make_cli_argv_sanitizing_transport
+      (make_per_call_switch_transport (fun ~sw ->
+         Llm_provider.Transport_cli_tool_a.create
+           ~sw
+           ~mgr
+           ~config:{ Llm_provider.Transport_cli_tool_a.default_config with cwd })))
+;;
+
+let () =
+  Registry.register_non_http_transport
+    ~kind:Llm_provider.Provider_config.Cli_tool_d
+    ~ctor:cli_tool_d_transport_ctor;
+  Registry.register_non_http_transport
+    ~kind:Llm_provider.Provider_config.Cli_tool_b
+    ~ctor:cli_tool_b_transport_ctor;
+  Registry.register_non_http_transport
+    ~kind:Llm_provider.Provider_config.Cli_tool_a
+    ~ctor:cli_tool_a_transport_ctor
+;;

--- a/lib/runtime/runtime_transport_cli_ctors.mli
+++ b/lib/runtime/runtime_transport_cli_ctors.mli
@@ -1,0 +1,4 @@
+(** CLI transport constructors and registration side effects. *)
+
+val make_per_call_switch_transport :
+  (sw:Eio.Switch.t -> Llm_provider.Llm_transport.t) -> Llm_provider.Llm_transport.t

--- a/lib/runtime/runtime_transport_cli_mcp_config_json.ml
+++ b/lib/runtime/runtime_transport_cli_mcp_config_json.ml
@@ -1,0 +1,54 @@
+(* CLI MCP config JSON serializer.
+
+   Builds the `{ "mcpServers": { name: { ... } } }` JSON document that
+   CLI providers (agent_code, cli_tool_d, provider_f variants) expect as
+   --mcp-config argv. Filters servers by the runtime mcp policy's
+   allowed_server_names whitelist (empty = allow all).
+
+   Extracted from [Runtime_transport] (godfile decomp). Pure mapping
+   over [Llm_provider.Llm_transport] values. *)
+
+let json_of_string_pairs pairs = `Assoc (List.map (fun (k, v) -> k, `String v) pairs)
+
+let json_of_cli_mcp_server = function
+  | Llm_provider.Llm_transport.Stdio_server { command; args; env; _ } ->
+    `Assoc
+      [ "command", `String command
+      ; "args", `List (List.map (fun arg -> `String arg) args)
+      ; "env", json_of_string_pairs env
+      ]
+  | Llm_provider.Llm_transport.Http_server { url; headers; _ } ->
+    `Assoc [ "url", `String url; "headers", json_of_string_pairs headers ]
+;;
+
+let cli_mcp_config_json_of_policy
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  : string option
+  =
+  let allowed_server_name name =
+    match policy.allowed_server_names with
+    | [] -> true
+    | names -> List.mem name names
+  in
+  let servers =
+    List.filter
+      (fun server ->
+         allowed_server_name (Llm_provider.Llm_transport.runtime_mcp_server_name server))
+      policy.servers
+  in
+  match servers with
+  | [] -> None
+  | servers ->
+    let config_json =
+      `Assoc
+        [ ( "mcpServers"
+          , `Assoc
+              (List.map
+                 (fun server ->
+                    ( Llm_provider.Llm_transport.runtime_mcp_server_name server
+                    , json_of_cli_mcp_server server ))
+                 servers) )
+        ]
+    in
+    Some (Yojson.Safe.to_string config_json)
+;;

--- a/lib/runtime/runtime_transport_cli_mcp_config_json.mli
+++ b/lib/runtime/runtime_transport_cli_mcp_config_json.mli
@@ -1,0 +1,16 @@
+(** CLI MCP config JSON serializer.
+
+    Builds the [{"mcpServers": {name: {...}}}] document that CLI
+    providers (agent_code, cli_tool_d, provider_f variants) expect as
+    [--mcp-config] argv. Returns [None] when the runtime mcp policy's
+    allowed_server_names whitelist removes every server. *)
+
+val json_of_string_pairs : (string * string) list -> Yojson.Safe.t
+
+val json_of_cli_mcp_server
+  :  Llm_provider.Llm_transport.runtime_mcp_server
+  -> Yojson.Safe.t
+
+val cli_mcp_config_json_of_policy
+  :  Llm_provider.Llm_transport.runtime_mcp_policy
+  -> string option

--- a/lib/runtime/runtime_transport_cli_overrides.ml
+++ b/lib/runtime/runtime_transport_cli_overrides.ml
@@ -1,0 +1,50 @@
+(** CLI-transport override record + default, extracted from
+    [cascade_transport.ml] (godfile decomp).
+
+    [cli_transport_overrides] is the public record of per-keeper
+    overrides honoured by the cascade transport layer when binding a
+    subprocess CLI provider (Claude Code / Provider_f CLI / Codex CLI /
+    Provider_c CLI). Each field is honoured by exactly one provider kind;
+    missing fields fall back to the transport's [default_config].
+
+    [default_cli_transport_overrides] is the no-overrides record used
+    as the [Option.value ~default] target by the CLI transport ctors
+    when no [?cli_transport_overrides] is supplied.
+
+    This sibling owns the canonical definition; the parent re-exports
+    via a transparent type alias so existing callers
+    ([Runtime_agent.cli_transport_overrides] alias and the keeper
+    layer's record-typed forwarders) keep working unchanged.
+
+    Extracted as an enabling step for follow-up extraction of the
+    [non_http_transport_registry] dispatcher — which references this
+    type via its [non_http_transport_ctor] function-type signature. *)
+
+type cli_transport_overrides =
+  { cwd : string option
+  ; claude_mcp_config : string option
+  ; claude_allowed_tools : string list option
+  ; claude_permission_mode : string option
+  ; claude_max_turns : int option
+  ; gemini_yolo : bool option
+  ; cli_subprocess_idle_sec : float option
+    (* When [Some s], the CLI subprocess is aborted via SIGINT if no
+     stdout line arrives within [s] seconds. Currently honoured only
+     by [Json_stream_cli_transport_local], which calls
+     [Cli_common_subprocess.run_stream_lines] directly. The other CLI
+     transports (cli_tool_d, cli_tool_b, cli_tool_a) route through
+     agent_sdk [Transport_*_cli.create] whose configs do not yet
+     expose [stdout_idle_timeout_s]; an OAS upstream change is needed
+     to honour this field there. *)
+  }
+
+let default_cli_transport_overrides =
+  { cwd = None
+  ; claude_mcp_config = None
+  ; claude_allowed_tools = None
+  ; claude_permission_mode = None
+  ; claude_max_turns = None
+  ; gemini_yolo = None
+  ; cli_subprocess_idle_sec = None
+  }
+;;

--- a/lib/runtime/runtime_transport_cli_overrides.mli
+++ b/lib/runtime/runtime_transport_cli_overrides.mli
@@ -1,0 +1,15 @@
+(** CLI-transport override record extracted from [Runtime_transport]. *)
+
+type cli_transport_overrides =
+  { cwd : string option
+  ; claude_mcp_config : string option
+  ; claude_allowed_tools : string list option
+  ; claude_permission_mode : string option
+  ; claude_max_turns : int option
+  ; gemini_yolo : bool option
+  ; cli_subprocess_idle_sec : float option
+  }
+(** Per-call overrides forwarded to CLI transports. *)
+
+val default_cli_transport_overrides : cli_transport_overrides
+(** No-overrides default used when a transport receives no explicit override. *)

--- a/lib/runtime/runtime_transport_json_stream_cli_local.ml
+++ b/lib/runtime/runtime_transport_json_stream_cli_local.ml
@@ -1,0 +1,619 @@
+(** JSON-stream CLI completion transport, extracted from
+    [cascade_transport.ml] as a top-level module (godfile decomp).
+
+    This module was previously embedded as a nested
+    [module Json_stream_cli_transport_local] inside
+    [Runtime_transport] (665 LOC). Moving it to a separate file
+    preserves all type identities + value bindings — the parent
+    file retains a 1-line module alias
+    [module Json_stream_cli_transport_local =
+       Runtime_transport_json_stream_cli_local], and the
+    [Runtime_transport.mli] signature constraint continues to
+    apply unchanged.
+
+    External callers reference
+    [Runtime_transport.Json_stream_cli_transport_local.*] — those
+    paths keep working through the alias. *)
+
+module Runtime_policy_provider = Runtime_transport_runtime_policy_provider
+
+type config =
+  { cli_path : string
+  ; process_name : string
+  ; model : string option
+  ; cwd : string option
+  ; config_json : string option
+  ; mcp_config_json : string list
+  ; extra_env : (string * string) list
+  ; cancel : unit Eio.Promise.t option
+  ; stdout_idle_timeout_s : float option
+  }
+
+let default_config =
+  { cli_path = "json-stream-cli"
+  ; process_name = "json_stream_cli"
+  ; model = None
+  ; cwd = None
+  ; config_json = None
+  ; mcp_config_json = []
+  ; extra_env = []
+  ; cancel = None
+  ; stdout_idle_timeout_s = None
+  }
+;;
+
+(* Some Python CLI launchers import [setproctitle] before processing the
+   request. UTF-8 prompts in argv can make setproctitle's import-time
+   [getproctitle()] decode fail before the CLI reads the prompt, so keep
+   non-ASCII or large prompts out of argv and stream them via stdin. *)
+let default_prompt_argv_threshold = 16 * 1024
+
+let prompt_argv_threshold () =
+  match Sys.getenv_opt "MASC_JSON_STREAM_CLI_PROMPT_ARGV_THRESHOLD" with
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some value when value >= 0 -> value
+     | _ -> default_prompt_argv_threshold)
+  | None -> default_prompt_argv_threshold
+;;
+
+let prompt_exceeds_argv_budget prompt = String.length prompt >= prompt_argv_threshold ()
+
+let prompt_contains_non_ascii prompt =
+  let rec loop idx =
+    idx < String.length prompt && (Char.code prompt.[idx] > 0x7f || loop (idx + 1))
+  in
+  loop 0
+;;
+
+let prompt_needs_stdin prompt =
+  prompt_exceeds_argv_budget prompt || prompt_contains_non_ascii prompt
+;;
+
+let sanitize_for_cli_prompt prompt = Inference_utils.sanitize_text_utf8 prompt
+
+let stdin_for_prompt prompt =
+  let prompt = sanitize_for_cli_prompt prompt in
+  if prompt_needs_stdin prompt then Some prompt else None
+;;
+
+let cli_model_override ~(config : config) ~(req_config : Llm_provider.Provider_config.t)
+  =
+  match String.trim req_config.model_id |> String.lowercase_ascii with
+  | "" | "auto" -> config.model
+  | _ -> Some (String.trim req_config.model_id)
+;;
+
+let build_args
+      ~(config : config)
+      ~(req_config : Llm_provider.Provider_config.t)
+      ~(mcp_config_json : string list)
+      ~prompt
+  =
+  let prompt = sanitize_for_cli_prompt prompt in
+  let prompt_via_stdin = prompt_needs_stdin prompt in
+  let args = ref [ config.cli_path; "--print"; "--output-format"; "stream-json" ] in
+  let add xs = args := !args @ xs in
+  (match config.config_json with
+   | Some json -> add [ "--config"; json ]
+   | None -> ());
+  if not prompt_via_stdin then add [ "-p"; prompt ];
+  (match cli_model_override ~config ~req_config with
+   | Some model -> add [ "--model"; model ]
+   | None -> ());
+  (match config.cwd with
+   | Some dir when String.trim dir <> "" -> add [ "--work-dir"; dir ]
+   | None | Some _ -> ());
+  List.iter (fun json -> add [ "--mcp-config"; json ]) mcp_config_json;
+  (match req_config.enable_thinking with
+   | Some true -> add [ "--thinking" ]
+   | Some false -> add [ "--no-thinking" ]
+   | None -> ());
+  !args
+;;
+
+let json_of_argument_string = function
+  | None | Some "" -> Ok (`Assoc [])
+  | Some raw ->
+    let raw = String.trim raw in
+    if raw = ""
+    then Ok (`Assoc [])
+    else (
+      try Ok (Yojson.Safe.from_string raw) with
+      | Yojson.Json_error msg -> Error msg)
+;;
+
+let blocks_of_message_content json =
+  match json with
+  | `String text when String.trim text = "" -> []
+  | `String text -> [ Agent_sdk.Types.Text text ]
+  | `List items -> List.filter_map Llm_provider.Api_common.content_block_of_json items
+  | `Null -> []
+  | other -> [ Agent_sdk.Types.Text (Yojson.Safe.to_string other) ]
+;;
+
+let tool_use_of_json json =
+  try
+    let fn = json |> Json_util.assoc_member_opt "function" |> Option.value ~default:`Null in
+    let id = Llm_provider.Cli_common_json.member_str "id" json in
+    let name = Llm_provider.Cli_common_json.member_str "name" fn in
+    match Json_util.get_string fn "arguments" |> json_of_argument_string with
+    | Ok args -> Ok (Some (Agent_sdk.Types.ToolUse { id; name; input = args }))
+    | Error msg ->
+      Error
+        (Printf.sprintf "invalid CLI tool arguments JSON for tool %S: %s" name msg)
+  with
+  | Yojson.Safe.Util.Type_error _ -> Ok None
+;;
+
+let tool_uses_of_json calls =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | call :: rest ->
+      (match tool_use_of_json call with
+       | Ok (Some block) -> loop (block :: acc) rest
+       | Ok None -> loop acc rest
+       | Error _ as err -> err)
+  in
+  loop [] calls
+;;
+
+let tool_result_of_json json =
+  match Json_util.get_string json "tool_call_id" with
+  | Some tool_use_id ->
+    let content_json = json |> Json_util.assoc_member_opt "content" in
+    let content, parsed_json =
+      match content_json with
+      | Some (`String text) -> text, Agent_sdk.Types.try_parse_json text
+      | Some `Null | None -> "", None
+      | Some other -> Yojson.Safe.to_string other, Some other
+    in
+    Some
+      (Agent_sdk.Types.ToolResult
+         { tool_use_id; content; is_error = false; json = parsed_json })
+  | None -> None
+;;
+
+let parse_json_line line =
+  Yojson.Safe.from_string (Inference_utils.sanitize_text_utf8 line)
+;;
+
+let blocks_of_output_line line =
+  try
+    let json = parse_json_line line in
+    match Json_util.get_string json "role" with
+    | Some "assistant" ->
+      let content = blocks_of_message_content (Json_util.assoc_member_opt "content" json |> Option.value ~default:`Null) in
+      let tool_uses_result =
+        match Json_util.assoc_member_opt "tool_calls" json with
+        | Some (`List calls) -> tool_uses_of_json calls
+        | _ -> Ok []
+      in
+      Result.map (fun tool_uses -> content @ tool_uses) tool_uses_result
+    | Some "tool" ->
+      (match tool_result_of_json json with
+       | Some block -> Ok [ block ]
+       | None -> Ok [])
+    | _ -> Ok []
+  with
+  | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> Ok []
+;;
+
+let response_id_of_lines lines =
+  let find_id line =
+    try
+      let json = parse_json_line line in
+      match Json_util.get_string json "id" with
+      | Some id when String.trim id <> "" -> Some id
+      | _ ->
+        (match Json_util.get_string json "session_id" with
+         | Some id when String.trim id <> "" -> Some id
+         | _ -> None)
+    with
+    | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+  in
+  List.find_map find_id lines |> Option.value ~default:"cli-json-stream"
+;;
+
+let response_model_of_lines ~model_id lines =
+  let find_model line =
+    try
+      let json = parse_json_line line in
+      match Json_util.get_string json "model" with
+      | Some model when String.trim model <> "" -> Some model
+      | _ -> None
+    with
+    | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+  in
+  List.find_map find_model lines |> Option.value ~default:model_id
+;;
+
+let parse_jsonl_result ~model_id lines =
+  let content_result =
+    let rec loop acc = function
+      | [] -> Ok (List.concat (List.rev acc))
+      | line :: rest ->
+        (match blocks_of_output_line line with
+         | Ok blocks -> loop (blocks :: acc) rest
+         | Error _ as err -> err)
+    in
+    loop [] lines
+  in
+  match content_result with
+  | Error message ->
+    Error (Llm_provider.Http_client.NetworkError { message; kind = Unknown })
+  | Ok [] ->
+    Error
+      (Llm_provider.Http_client.NetworkError
+         { message = "no messages parsed from CLI JSON-stream output"; kind = Unknown })
+  | Ok content ->
+    Ok
+      { Agent_sdk.Types.id = response_id_of_lines lines
+      ; model = response_model_of_lines ~model_id lines
+      ; stop_reason = Agent_sdk.Types.EndTurn
+      ; content
+      ; usage = None
+      ; telemetry = None
+      }
+;;
+
+let events_of_block ~index = function
+  | Agent_sdk.Types.Text text ->
+    [ Agent_sdk.Types.ContentBlockStart
+        { index; content_type = "text"; tool_id = None; tool_name = None }
+    ; Agent_sdk.Types.ContentBlockDelta
+        { index; delta = Agent_sdk.Types.TextDelta text }
+    ; Agent_sdk.Types.ContentBlockStop { index }
+    ]
+  | Agent_sdk.Types.Thinking { content; _ } ->
+    [ Agent_sdk.Types.ContentBlockStart
+        { index; content_type = "thinking"; tool_id = None; tool_name = None }
+    ; Agent_sdk.Types.ContentBlockDelta
+        { index; delta = Agent_sdk.Types.ThinkingDelta content }
+    ; Agent_sdk.Types.ContentBlockStop { index }
+    ]
+  | Agent_sdk.Types.ToolUse { id; name; input } ->
+    [ Agent_sdk.Types.ContentBlockStart
+        { index; content_type = "tool_use"; tool_id = Some id; tool_name = Some name }
+    ; Agent_sdk.Types.ContentBlockDelta
+        { index; delta = Agent_sdk.Types.InputJsonDelta (Yojson.Safe.to_string input) }
+    ; Agent_sdk.Types.ContentBlockStop { index }
+    ]
+  | Agent_sdk.Types.ToolResult { tool_use_id; content; _ } ->
+    [ Agent_sdk.Types.ContentBlockStart
+        { index
+        ; content_type = "tool_result"
+        ; tool_id = Some tool_use_id
+        ; tool_name = None
+        }
+    ; Agent_sdk.Types.ContentBlockDelta
+        { index; delta = Agent_sdk.Types.TextDelta content }
+    ; Agent_sdk.Types.ContentBlockStop { index }
+    ]
+  | Agent_sdk.Types.RedactedThinking _
+  | Agent_sdk.Types.Image _
+  | Agent_sdk.Types.Document _
+  | Agent_sdk.Types.Audio _ -> []
+;;
+
+let emit_blocks ~on_event ~start_index blocks =
+  List.fold_left
+    (fun index block ->
+       match events_of_block ~index block with
+       | [] -> index
+       | events ->
+         List.iter on_event events;
+         index + 1)
+    start_index
+    blocks
+;;
+
+let resumable_session_detail =
+  "CLI JSON-stream transport reported a resumable session. Resumable session \
+   available via -r."
+;;
+
+let resume_hint_marker = "to resume this session:"
+
+let is_resume_hint_line line =
+  let trimmed = String.trim line in
+  trimmed <> "" && String_util.contains_substring_ci trimmed resume_hint_marker
+;;
+
+let should_log_stderr_line line =
+  let trimmed = String.trim line in
+  trimmed <> "" && not (is_resume_hint_line trimmed)
+;;
+
+let on_stderr_line ~process_name line =
+  if should_log_stderr_line line
+  then
+    Llm_provider.Cli_common_subprocess.default_on_stderr_line ~name:process_name line
+;;
+
+let index_of_substring text marker =
+  let marker_len = String.length marker in
+  let text_len = String.length text in
+  let rec loop idx =
+    if marker_len = 0
+    then Some idx
+    else if idx + marker_len > text_len
+    then None
+    else if String.sub text idx marker_len = marker
+    then Some idx
+    else loop (idx + 1)
+  in
+  loop 0
+;;
+
+let exit_code_span_of_message message =
+  let marker = " exited with code " in
+  match index_of_substring message marker with
+  | None -> None
+  | Some marker_start ->
+    let code_start = marker_start + String.length marker in
+    (match String.index_from_opt message code_start ':' with
+     | None -> None
+     | Some colon ->
+       let raw = String.sub message code_start (colon - code_start) |> String.trim in
+       Option.map (fun code -> code, colon) (int_of_string_opt raw))
+;;
+
+let exit_code_of_message message =
+  Option.map fst (exit_code_span_of_message message)
+;;
+
+let exit_payload_of_message message =
+  match exit_code_span_of_message message with
+  | None -> None
+  | Some (_, colon) ->
+    Some
+      (String.sub message (colon + 1) (String.length message - colon - 1)
+       |> String.trim)
+;;
+
+let resumable_session_detail_for_exit_code code =
+  Printf.sprintf
+    "CLI JSON-stream transport reported a resumable session (exit %d). \
+     Resumable session available via -r."
+    code
+;;
+
+let redact_resume_hint_lines text =
+  text
+  |> String.split_on_char '\n'
+  |> List.map String.trim
+  |> List.filter (fun line -> line <> "" && not (is_resume_hint_line line))
+  |> String.concat "\n"
+  |> String.trim
+;;
+
+let cli_reject_reason ~code message =
+  let payload =
+    match exit_payload_of_message message with
+    | Some payload -> redact_resume_hint_lines payload
+    | None -> redact_resume_hint_lines message
+  in
+  let detail = if payload = "" then "" else " " ^ payload in
+  Printf.sprintf
+    "provider CLI rejected the request (exit %d). This is usually a permanent \
+     auth/config/model error rather than a transient transport failure.%s"
+    code
+    detail
+;;
+
+let text_looks_like_process_title_unicode_crash text =
+  String_util.contains_substring_ci text "UnicodeDecodeError"
+  && String_util.contains_substring_ci text "setproctitle"
+;;
+
+let classify_cli_error = function
+  | Error (Llm_provider.Http_client.NetworkError { message; _ }) as err ->
+    if text_looks_like_process_title_unicode_crash message
+    then
+      Error
+        (Llm_provider.Http_client.AcceptRejected
+           { reason =
+               "provider CLI startup crash while setting process title \
+                (UnicodeDecodeError). This is a local CLI/runtime failure, not keeper \
+                auth or sandbox failure; rejecting without retry so the cascade can \
+                move on. "
+               ^ message
+           })
+    else (
+      match exit_code_of_message message with
+      | Some 1 ->
+        Error
+          (Llm_provider.Http_client.AcceptRejected
+             { reason = cli_reject_reason ~code:1 message })
+      | Some 75 ->
+        Error
+          (Llm_provider.Http_client.AcceptRejected
+             { reason = resumable_session_detail_for_exit_code 75 })
+      | _ -> err)
+  | other -> other
+;;
+
+let warn_external_tools_once warned tools =
+  if !warned || tools = []
+  then ()
+  else (
+    warned := true;
+    Log.Misc.warn
+      "CLI JSON-stream print mode ignores OAS req.tools. Provider-native built-in tools and \
+       configured MCP servers remain available; external OAS tool callbacks require a \
+       future wire-mode transport.")
+;;
+
+let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) =
+  let warned = ref false in
+  { Llm_provider.Llm_transport.complete_sync =
+      (fun (req : Llm_provider.Llm_transport.completion_request) ->
+        warn_external_tools_once warned req.tools;
+        let messages =
+          Llm_provider.Cli_common_prompt.non_system_messages req.messages
+        in
+        let system_prompt =
+          Llm_provider.Cli_common_prompt.system_prompt_of
+            ~req_config:req.config
+            req.messages
+        in
+        let prompt =
+          Llm_provider.Cli_common_prompt.prompt_of_messages
+            ~include_tool_blocks:true
+            messages
+          |> fun prompt ->
+          Llm_provider.Cli_common_prompt.prompt_with_system_prompt
+            ~prompt
+            ~system_prompt
+        in
+        let prompt = sanitize_for_cli_prompt prompt in
+        let model_id =
+          match cli_model_override ~config ~req_config:req.config with
+          | Some model -> model
+          | None -> req.config.model_id
+        in
+        let mcp_config_json =
+          Runtime_policy_provider.cli_runtime_mcp_jsons ~base:config.mcp_config_json req.runtime_mcp_policy
+        in
+        let argv = build_args ~config ~req_config:req.config ~mcp_config_json ~prompt in
+        let seen_lines = ref [] in
+        let on_line line =
+          if String.trim line <> "" then seen_lines := line :: !seen_lines
+        in
+        let stdout_idle_timeout_s = config.stdout_idle_timeout_s in
+        let clock_opt =
+          match stdout_idle_timeout_s with
+          | None -> None
+          | Some _ ->
+            (match Process_eio.get_clock () with
+             | Ok c -> Some c
+             | Error _ -> None)
+        in
+        let run_result, measured_latency_ms =
+          Inference_utils.timed (fun () ->
+            Llm_provider.Cli_common_subprocess.run_stream_lines
+              ~sw
+              ~mgr
+              ?clock:clock_opt
+              ?stdout_idle_timeout_s
+              ~name:config.process_name
+              ~cwd:config.cwd
+              ~extra_env:config.extra_env
+              ~on_stderr_line:(on_stderr_line ~process_name:config.process_name)
+              ?stdin_content:(stdin_for_prompt prompt)
+              ~on_line
+              ?cancel:config.cancel
+              argv)
+        in
+        match run_result with
+        | Error _ as err ->
+          { Llm_provider.Llm_transport.response = classify_cli_error err
+          ; latency_ms = Some measured_latency_ms
+          }
+        | Ok { latency_ms; _ } ->
+          let response = parse_jsonl_result ~model_id (List.rev !seen_lines) in
+          { Llm_provider.Llm_transport.response; latency_ms = Some latency_ms })
+  ; complete_stream =
+      (fun ?on_telemetry:_
+        ~on_event
+        (req : Llm_provider.Llm_transport.completion_request) ->
+        warn_external_tools_once warned req.tools;
+        let messages =
+          Llm_provider.Cli_common_prompt.non_system_messages req.messages
+        in
+        let system_prompt =
+          Llm_provider.Cli_common_prompt.system_prompt_of
+            ~req_config:req.config
+            req.messages
+        in
+        let prompt =
+          Llm_provider.Cli_common_prompt.prompt_of_messages
+            ~include_tool_blocks:true
+            messages
+          |> fun prompt ->
+          Llm_provider.Cli_common_prompt.prompt_with_system_prompt
+            ~prompt
+            ~system_prompt
+        in
+        let prompt = sanitize_for_cli_prompt prompt in
+        let model_id =
+          match cli_model_override ~config ~req_config:req.config with
+          | Some model -> model
+          | None -> req.config.model_id
+        in
+        let mcp_config_json =
+          Runtime_policy_provider.cli_runtime_mcp_jsons ~base:config.mcp_config_json req.runtime_mcp_policy
+        in
+        let argv = build_args ~config ~req_config:req.config ~mcp_config_json ~prompt in
+        let seen_lines = ref [] in
+        let next_index = ref 0 in
+        let started = ref false in
+        let parse_error = ref None in
+        let ensure_started () =
+          if not !started
+          then (
+            started := true;
+            on_event
+              (Agent_sdk.Types.MessageStart
+                 { id = "cli-json-stream"; model = model_id; usage = None }))
+        in
+        let on_line line =
+          match !parse_error with
+          | Some _ -> ()
+          | None ->
+            if String.trim line <> ""
+            then (
+              seen_lines := line :: !seen_lines;
+              match blocks_of_output_line line with
+              | Error message -> parse_error := Some message
+              | Ok blocks ->
+                if blocks <> []
+                then (
+                  ensure_started ();
+                  next_index := emit_blocks ~on_event ~start_index:!next_index blocks))
+        in
+        let stdout_idle_timeout_s = config.stdout_idle_timeout_s in
+        let clock_opt =
+          match stdout_idle_timeout_s with
+          | None -> None
+          | Some _ ->
+            (match Process_eio.get_clock () with
+             | Ok c -> Some c
+             | Error _ -> None)
+        in
+        match
+          classify_cli_error
+            (Llm_provider.Cli_common_subprocess.run_stream_lines
+               ~sw
+               ~mgr
+               ?clock:clock_opt
+               ?stdout_idle_timeout_s
+               ~name:config.process_name
+               ~cwd:config.cwd
+               ~extra_env:config.extra_env
+               ~on_stderr_line:(on_stderr_line ~process_name:config.process_name)
+               ?stdin_content:(stdin_for_prompt prompt)
+               ~on_line
+               ?cancel:config.cancel
+               argv)
+        with
+        | Error _ as err -> err
+        | Ok _ ->
+          (match !parse_error with
+           | Some message ->
+             Error (Llm_provider.Http_client.NetworkError { message; kind = Unknown })
+           | None ->
+             (match parse_jsonl_result ~model_id (List.rev !seen_lines) with
+              | Error _ as err -> err
+              | Ok resp as ok ->
+                if !started
+                then (
+                  on_event
+                    (Agent_sdk.Types.MessageDelta
+                       { stop_reason = Some resp.stop_reason; usage = resp.usage });
+                  on_event Agent_sdk.Types.MessageStop)
+                else Llm_provider.Cli_common_synthetic_events.replay ~on_event resp;
+                ok)))
+  }
+;;

--- a/lib/runtime/runtime_transport_json_stream_cli_local.mli
+++ b/lib/runtime/runtime_transport_json_stream_cli_local.mli
@@ -1,0 +1,35 @@
+(** JSON-stream CLI completion transport. *)
+
+type config =
+  { cli_path : string
+  ; process_name : string
+  ; model : string option
+  ; cwd : string option
+  ; config_json : string option
+  ; mcp_config_json : string list
+  ; extra_env : (string * string) list
+  ; cancel : unit Eio.Promise.t option
+  ; stdout_idle_timeout_s : float option
+  }
+
+val default_config : config
+
+val build_args
+  :  config:config
+  -> req_config:Llm_provider.Provider_config.t
+  -> mcp_config_json:string list
+  -> prompt:string
+  -> string list
+
+val should_log_stderr_line : string -> bool
+val resumable_session_detail : string
+
+val classify_cli_error
+  :  ('a, Llm_provider.Http_client.http_error) result
+  -> ('a, Llm_provider.Http_client.http_error) result
+
+val create
+  :  sw:Eio.Switch.t
+  -> mgr:_ Eio.Process.mgr
+  -> config:config
+  -> Llm_provider.Llm_transport.t

--- a/lib/runtime/runtime_transport_label_resolution.ml
+++ b/lib/runtime/runtime_transport_label_resolution.ml
@@ -1,0 +1,37 @@
+(** Model-label resolution errors + resolver, extracted from
+    cascade_transport.ml.
+
+    Maps a string label to a {!Llm_provider.Provider_config.t} via
+    {!Cascade_config.parse_model_string}; unresolved labels become
+    [Error (Invalid_model_label _)] — execution never falls back to
+    discovery-only models. *)
+
+type label_resolution_error = Invalid_model_label of string
+
+let label_resolution_error_to_string = function
+  | Invalid_model_label label -> Printf.sprintf "invalid model label %S" label
+;;
+
+let label_resolution_error_to_sdk_error err =
+  Agent_sdk.Error.Config
+    (Agent_sdk.Error.InvalidConfig
+       { field = "model_label"; detail = label_resolution_error_to_string err })
+;;
+
+let resolve_provider_config_of_label (label : string)
+  : (Llm_provider.Provider_config.t, label_resolution_error) result
+  =
+  match Cascade_config.parse_model_string label with
+  | Some pc -> Ok pc
+  | None ->
+    Log.error
+      ~ctx:"oas_worker_exec"
+      "refusing unresolved explicit model label=%S; execution never falls back to \
+       discovery-only models"
+      label;
+    Error (Invalid_model_label label)
+;;
+
+let invalid_runtime_config field detail =
+  Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail })
+;;

--- a/lib/runtime/runtime_transport_label_resolution.mli
+++ b/lib/runtime/runtime_transport_label_resolution.mli
@@ -1,0 +1,11 @@
+(** Model-label resolution for cascade runtime transport. *)
+
+type label_resolution_error = Invalid_model_label of string
+
+val label_resolution_error_to_string : label_resolution_error -> string
+val label_resolution_error_to_sdk_error : label_resolution_error -> Agent_sdk.Error.sdk_error
+
+val resolve_provider_config_of_label :
+  string -> (Llm_provider.Provider_config.t, label_resolution_error) result
+
+val invalid_runtime_config : string -> string -> Agent_sdk.Error.sdk_error

--- a/lib/runtime/runtime_transport_mcp_policy_helpers.ml
+++ b/lib/runtime/runtime_transport_mcp_policy_helpers.ml
@@ -1,0 +1,74 @@
+(** Runtime-MCP policy header helpers, extracted from
+    [cascade_transport.ml]. Two pure transforms over
+    [Llm_provider.Llm_transport.runtime_mcp_policy]:
+
+    - [runtime_mcp_policy_with_masc_agent_name] injects x-masc-agent-name
+      (+ optional internal token / keeper-name) into the "masc" HTTP
+      server headers.
+    - [runtime_mcp_policy_without_http_headers] strips all headers from
+      every HTTP server. *)
+
+let upsert_http_header = Runtime_transport_authorization.upsert_http_header
+let keeper_name_of_agent_name = Runtime_transport_authorization.keeper_name_of_agent_name
+
+;;
+
+let first_nonempty_env names =
+  List.find_map (fun name -> Sys.getenv_opt name |> String_util.option_trim) names
+;;
+
+let runtime_mcp_policy_with_masc_agent_name
+      ?(include_internal_token = true)
+      ~(agent_name : string)
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  =
+  let agent_name = String.trim agent_name in
+  if String.equal agent_name ""
+  then policy
+  else (
+    let servers =
+      List.map
+        (function
+          | Llm_provider.Llm_transport.Http_server ({ name; headers; _ } as server)
+            when String.equal name "masc" ->
+            let headers =
+              upsert_http_header ~key:"x-masc-agent-name" ~value:agent_name headers
+            in
+            let headers =
+              if include_internal_token
+              then (
+                match
+                  ( first_nonempty_env [ "MASC_INTERNAL_MCP_TOKEN" ]
+                  , keeper_name_of_agent_name agent_name )
+                with
+                | Some token, Some _ ->
+                  upsert_http_header ~key:"x-masc-internal-token" ~value:token headers
+                | _ -> headers)
+              else headers
+            in
+            let headers =
+              match keeper_name_of_agent_name agent_name with
+              | Some keeper_name ->
+                upsert_http_header ~key:"x-masc-keeper-name" ~value:keeper_name headers
+              | None -> headers
+            in
+            Llm_provider.Llm_transport.Http_server { server with headers }
+          | server -> server)
+        policy.servers
+    in
+    { policy with servers })
+;;
+
+let runtime_mcp_policy_without_http_headers
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  =
+  let servers =
+    List.map
+      (function
+        | Llm_provider.Llm_transport.Http_server server ->
+          Llm_provider.Llm_transport.Http_server { server with headers = [] }
+        | server -> server)
+      policy.servers
+  in
+  { policy with servers }
+;;

--- a/lib/runtime/runtime_transport_mcp_policy_helpers.mli
+++ b/lib/runtime/runtime_transport_mcp_policy_helpers.mli
@@ -1,0 +1,18 @@
+(** Runtime-MCP policy header helpers, extracted from [Runtime_transport]. *)
+
+(** Trim an optional string and return [None] for blank values. *)
+
+val first_nonempty_env : string list -> string option
+(** Return the first configured, non-blank environment variable value. *)
+
+val runtime_mcp_policy_with_masc_agent_name :
+  ?include_internal_token:bool ->
+  agent_name:string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy ->
+  Llm_provider.Llm_transport.runtime_mcp_policy
+(** Inject non-secret MASC identity headers into the [masc] HTTP server entry. *)
+
+val runtime_mcp_policy_without_http_headers :
+  Llm_provider.Llm_transport.runtime_mcp_policy ->
+  Llm_provider.Llm_transport.runtime_mcp_policy
+(** Strip all HTTP headers from runtime MCP server entries. *)

--- a/lib/runtime/runtime_transport_mcp_tool_classifier.ml
+++ b/lib/runtime/runtime_transport_mcp_tool_classifier.ml
@@ -1,0 +1,38 @@
+(* MCP tool surface classification.
+
+   Pulled out of [cascade_transport.ml] to shrink the godfile. Pure
+   functions over Tool_catalog membership predicates - no shared state,
+   no I/O. *)
+
+let public_mcp_tool_names_of_oas_tools (tools : Agent_sdk.Tool.t list) =
+  List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) tools
+;;
+
+let public_mcp_tools_of_oas_tools (tools : Agent_sdk.Tool.t list) =
+  List.filter
+    (fun (tool : Agent_sdk.Tool.t) -> Tool_catalog.is_public_mcp tool.schema.name)
+    tools
+;;
+
+let tool_names_are_public_mcp (tool_names : string list) =
+  tool_names <> [] && List.for_all Tool_catalog.is_public_mcp tool_names
+;;
+
+let runtime_mcp_tool_requires_bound_actor tool_name =
+  Tool_catalog.requires_actor_binding tool_name
+;;
+
+let public_mcp_tool_requires_bound_actor tool_name =
+  Tool_catalog.is_public_mcp tool_name && runtime_mcp_tool_requires_bound_actor tool_name
+;;
+
+let tool_names_are_runtime_mcp ?(allow_keeper_internal = false) (tool_names : string list)
+  =
+  tool_names <> []
+  && List.for_all
+       (fun tool_name ->
+          Tool_catalog.is_public_mcp tool_name
+          || (allow_keeper_internal
+              && Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool_name))
+       tool_names
+;;

--- a/lib/runtime/runtime_transport_mcp_tool_classifier.mli
+++ b/lib/runtime/runtime_transport_mcp_tool_classifier.mli
@@ -1,0 +1,14 @@
+(** MCP tool surface classification: which OAS tool names are exposed as
+    public MCP, which require bound-actor authentication, and which name
+    sets can be routed as runtime MCP. *)
+
+val public_mcp_tool_names_of_oas_tools : Agent_sdk.Tool.t list -> string list
+val public_mcp_tools_of_oas_tools : Agent_sdk.Tool.t list -> Agent_sdk.Tool.t list
+val tool_names_are_public_mcp : string list -> bool
+val runtime_mcp_tool_requires_bound_actor : string -> bool
+val public_mcp_tool_requires_bound_actor : string -> bool
+
+val tool_names_are_runtime_mcp
+  :  ?allow_keeper_internal:bool
+  -> string list
+  -> bool

--- a/lib/runtime/runtime_transport_non_http_registry.ml
+++ b/lib/runtime/runtime_transport_non_http_registry.ml
@@ -1,0 +1,88 @@
+(** Non-HTTP transport registry + dispatcher, extracted from
+    [cascade_transport.ml] (godfile decomp).
+
+    Builds on the [Runtime_transport_cli_overrides] type extraction
+    (#17393) — the [non_http_transport_ctor] function-type signature
+    references [cli_transport_overrides] which had to move first.
+
+    Three pieces shipped together:
+
+    - [type non_http_transport_ctor] — function type for a CLI
+      transport constructor. Each ctor takes ownership of
+      [Process_eio.get_proc_mgr] so the registry's value type stays a
+      plain function (no row-polymorphic Eio mgr leaks into the
+      Hashtbl).
+
+    - [non_http_transport_registry] — the per-process Hashtbl that
+      maps each [Llm_provider.Provider_config.provider_kind] to its
+      registered ctor. Populated by the parent's top-level
+      [let () = register_non_http_transport ~kind ... ~ctor:...]
+      block at module load.
+
+    - [register_non_http_transport ~kind ~ctor] — registration entry
+      point invoked by the parent's [let () = ...] block.
+
+    - [non_http_transport_of_provider ~sw ~provider_cfg
+        ?runtime_mcp_policy ?cli_transport_overrides ()] —
+      runtime dispatcher. Looks up [provider_cfg.kind] in the
+      registry, invokes the registered ctor, forwards the result.
+      Fail-fast policy: missing registration for a subprocess CLI
+      kind returns [Error invalid_runtime_config]. Falling through to
+      [Ok None] would route the request to the HTTP lane, which
+      cannot serve a CLI provider. HTTP-shaped providers correctly
+      return [Ok None]; they live behind a different transport
+      selector upstream. *)
+
+module Label_resolution = Runtime_transport_label_resolution
+module Cli_overrides = Runtime_transport_cli_overrides
+
+type non_http_transport_ctor =
+  provider_cfg:Llm_provider.Provider_config.t
+  -> runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option
+  -> cli_transport_overrides:Cli_overrides.cli_transport_overrides option
+  -> (Llm_provider.Llm_transport.t, Agent_sdk.Error.sdk_error) result
+
+let non_http_transport_registry
+  : (Llm_provider.Provider_config.provider_kind, non_http_transport_ctor) Hashtbl.t
+  =
+  Hashtbl.create 8
+;;
+
+let register_non_http_transport ~kind ~ctor =
+  Hashtbl.replace non_http_transport_registry kind ctor
+;;
+
+let non_http_transport_of_provider
+      ~(sw : Eio.Switch.t)
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ?runtime_mcp_policy
+      ?cli_transport_overrides
+      ()
+  : (Llm_provider.Llm_transport.t option, Agent_sdk.Error.sdk_error) result
+  =
+  let _ = sw in
+  match Hashtbl.find_opt non_http_transport_registry provider_cfg.kind with
+  | Some ctor ->
+    (match ctor ~provider_cfg ~runtime_mcp_policy ~cli_transport_overrides with
+     | Ok transport -> Ok (Some transport)
+     | Error _ as e -> e)
+  | None ->
+    (* Fail-fast for subprocess CLI kinds that have no registered ctor:
+       falling through to [Ok None] would route the request to the HTTP
+       lane, which cannot serve a CLI provider. HTTP-shaped providers
+       correctly return [Ok None]; they live behind a different transport
+       selector upstream. *)
+    if Llm_provider.Provider_config.is_subprocess_cli provider_cfg.kind
+    then
+      Error
+        (Label_resolution.invalid_runtime_config
+           "non_http_transport_registry"
+           (Printf.sprintf
+              "no non-HTTP transport constructor registered for subprocess \
+               CLI kind %s — registry initializer (cascade_transport.ml \
+               top-level [let ()]) is out of sync with the \
+               Llm_provider.Provider_config.provider_kind variant"
+              (Llm_provider.Provider_config.string_of_provider_kind
+                 provider_cfg.kind)))
+    else Ok None
+;;

--- a/lib/runtime/runtime_transport_non_http_registry.mli
+++ b/lib/runtime/runtime_transport_non_http_registry.mli
@@ -1,0 +1,25 @@
+(** Non-HTTP cascade transport registry and dispatcher. *)
+
+type non_http_transport_ctor =
+  provider_cfg:Llm_provider.Provider_config.t ->
+  runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  cli_transport_overrides:
+    Runtime_transport_cli_overrides.cli_transport_overrides option ->
+  (Llm_provider.Llm_transport.t, Agent_sdk.Error.sdk_error) result
+
+val register_non_http_transport :
+  kind:Llm_provider.Provider_config.provider_kind ->
+  ctor:non_http_transport_ctor ->
+  unit
+(** Register a constructor for a non-HTTP provider kind. *)
+
+val non_http_transport_of_provider :
+  sw:Eio.Switch.t ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
+  ?cli_transport_overrides:
+    Runtime_transport_cli_overrides.cli_transport_overrides ->
+  unit ->
+  (Llm_provider.Llm_transport.t option, Agent_sdk.Error.sdk_error) result
+(** Resolve a provider config to a registered non-HTTP transport when one
+    exists; subprocess CLI kinds fail fast when no constructor is registered. *)

--- a/lib/runtime/runtime_transport_runtime_mcp_policy_of_tool_names.ml
+++ b/lib/runtime/runtime_transport_runtime_mcp_policy_of_tool_names.ml
@@ -1,0 +1,130 @@
+(** Runtime-MCP policy builder for tool-name lists, extracted from
+    [cascade_transport.ml] (godfile decomp).
+
+    - [runtime_mcp_policy_of_tool_names] — builds a runtime MCP policy
+      pinned to the local [masc] HTTP server. Resolves
+      [Authorization]/internal-keeper headers via:
+      1. [MASC_INTERNAL_MCP_TOKEN] env + keeper-name when a
+         [Keeper_internal] surface tool is requested, OR
+      2. [MASC_MCP_TOKEN] env, falling back to the per-keeper raw
+         token at [<base_path>/.masc/auth/<agent_name>.token]
+         (Phase A F1: CLI-spawned subprocesses without parent env).
+      Returns [None] when the tools aren't runtime-MCP-eligible, or
+      when a Keeper_internal tool was requested without
+      keeper_name/internal_keeper_token.
+    - [public_mcp_runtime_policy_of_tool_names] — public-only
+      forwarder (no [allow_keeper_internal] knob). *)
+
+module Mcp_policy_helpers = Runtime_transport_mcp_policy_helpers
+module Authorization = Runtime_transport_authorization
+module Mcp_tool_classifier = Runtime_transport_mcp_tool_classifier
+
+(* Duplicated locally to avoid sibling -> parent cycle. The parent
+   keeps its own copy because three other sites there call it. *)
+let dedupe_preserve_order (items : string list) =
+  let seen = Hashtbl.create (List.length items) in
+  List.filter
+    (fun item ->
+       if Hashtbl.mem seen item
+       then false
+       else (
+         Hashtbl.add seen item ();
+         true))
+    items
+;;
+
+(* Duplicated locally for the same reason — 4-line idempotent helper
+   used only by this sibling. *)
+;;
+
+let runtime_mcp_policy_of_tool_names
+      ?agent_name
+      ?(allow_keeper_internal = false)
+      (tool_names : string list)
+  : Llm_provider.Llm_transport.runtime_mcp_policy option
+  =
+  let tool_names = dedupe_preserve_order tool_names in
+  let has_keeper_internal =
+    List.exists (Tool_catalog.is_on_surface Tool_catalog.Keeper_internal) tool_names
+  in
+  if not (Mcp_tool_classifier.tool_names_are_runtime_mcp ~allow_keeper_internal tool_names)
+  then None
+  else (
+    let agent_name = Option.bind agent_name String_util.trim_nonempty in
+    let keeper_name = Option.bind agent_name Authorization.keeper_name_of_agent_name in
+    let internal_keeper_token =
+      Mcp_policy_helpers.first_nonempty_env [ "MASC_INTERNAL_MCP_TOKEN" ]
+    in
+    if
+      has_keeper_internal
+      && (Option.is_none keeper_name || Option.is_none internal_keeper_token)
+    then None
+    else (
+      let masc_headers =
+        match keeper_name, internal_keeper_token with
+        | Some keeper_name, Some token ->
+          let agent_header =
+            match agent_name with
+            | Some agent_name -> [ "x-masc-agent-name", agent_name ]
+            | None -> []
+          in
+          Auth_resolve.emit_resolution_trace
+            ~cascade:"runtime_mcp_policy"
+            ~keeper_id:(Some keeper_name)
+            ~provider_label:"masc-mcp"
+            ~outcome:
+              (Ok { Auth_resolve.raw = token; source = Auth_resolve.Internal_keeper_env });
+          ("x-masc-internal-token", token)
+          :: ("x-masc-keeper-name", keeper_name)
+          :: agent_header
+        | _ ->
+          let env_token = Mcp_policy_helpers.first_nonempty_env [ "MASC_MCP_TOKEN" ] in
+          (* Phase A F1: when MASC_MCP_TOKEN is unset, fall back to the
+             per-keeper raw token at <base_path>/.masc/auth/<agent_name>.token.
+             This wires CLI-spawned subprocesses that callback to masc-mcp tools
+             but do not inherit the parent process env. *)
+          let per_keeper_token =
+            match env_token, agent_name with
+            | None, Some name ->
+              let base_path = Env_config_core.base_path () in
+              Auth.load_raw_token base_path ~agent_name:name
+            | _ -> None
+          in
+          let resolved : (Auth_resolve.token, Auth_resolve.auth_error) result =
+            match env_token, per_keeper_token with
+            | Some raw, _ -> Ok { Auth_resolve.raw; source = Auth_resolve.Mcp_bearer_env }
+            | None, Some raw ->
+              Ok { Auth_resolve.raw; source = Auth_resolve.Per_keeper_token_file }
+            | None, None ->
+              Error (Auth_resolve.Api_key_env_unset { var_name = "MASC_MCP_TOKEN" })
+          in
+          Auth_resolve.emit_resolution_trace
+            ~cascade:"runtime_mcp_policy"
+            ~keeper_id:keeper_name
+            ~provider_label:"masc-mcp"
+            ~outcome:resolved;
+          (match resolved with
+           | Ok { raw; _ } -> [ "Authorization", "Bearer " ^ raw ]
+           | Error _ -> [])
+      in
+      Some
+        { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+          servers =
+            [ Llm_provider.Llm_transport.Http_server
+                { name = "masc"
+                ; url = Env_config_runtime.Local_runtime.mcp_url ()
+                ; headers = masc_headers
+                }
+            ]
+        ; allowed_server_names = [ "masc" ]
+        ; allowed_tool_names = tool_names
+        ; strict = true
+        ; disable_builtin_tools = true
+        }))
+;;
+
+let public_mcp_runtime_policy_of_tool_names ?agent_name (tool_names : string list)
+  : Llm_provider.Llm_transport.runtime_mcp_policy option
+  =
+  runtime_mcp_policy_of_tool_names ?agent_name tool_names
+;;

--- a/lib/runtime/runtime_transport_runtime_mcp_policy_of_tool_names.mli
+++ b/lib/runtime/runtime_transport_runtime_mcp_policy_of_tool_names.mli
@@ -1,0 +1,14 @@
+(** Runtime-MCP policy builder for tool-name lists. *)
+
+val runtime_mcp_policy_of_tool_names :
+  ?agent_name:string ->
+  ?allow_keeper_internal:bool ->
+  string list ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+(** Build a strict [masc] runtime MCP policy for eligible tool names. *)
+
+val public_mcp_runtime_policy_of_tool_names :
+  ?agent_name:string ->
+  string list ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+(** Public-only variant of {!runtime_mcp_policy_of_tool_names}. *)

--- a/lib/runtime/runtime_transport_runtime_policy_provider.ml
+++ b/lib/runtime/runtime_transport_runtime_policy_provider.ml
@@ -1,0 +1,82 @@
+(** Provider-driven runtime MCP policy resolver + CLI JSON merger,
+    extracted from [cascade_transport.ml] (godfile decomp). Two
+    helpers:
+
+    - [runtime_mcp_policy_for_provider] — RFC-0058 §2.4 dispatch by
+      local tool-delivery policy ([requires_per_keeper_bridging]),
+      not by provider name. Resolves the policy through one of four
+      branches based on the (policy, bridging_required, agent_name)
+      triple. Missing [agent_name] with a provider that requires
+      per-keeper bridging now fails closed instead of preserving an
+      unauthenticated header-stripping path.
+
+    - [cli_runtime_mcp_jsons] — merges a [~base] list of MCP JSON
+      strings with the [cli_mcp_config_json_of_policy] projection of
+      a runtime MCP policy, deduping while preserving the original
+      order. *)
+
+module Mcp_policy_helpers = Runtime_transport_mcp_policy_helpers
+module Auth_bridging = Runtime_transport_auth_bridging
+module Cli_mcp_config_json = Runtime_transport_cli_mcp_config_json
+
+(* Duplicated locally to avoid sibling -> parent cycle. The parent
+   keeps its own copy because three other sites there call it; both
+   copies are identical 11-line list-dedup helpers. *)
+let dedupe_preserve_order (items : string list) =
+  let seen = Hashtbl.create (List.length items) in
+  List.filter
+    (fun item ->
+       if Hashtbl.mem seen item
+       then false
+       else (
+         Hashtbl.add seen item ();
+         true))
+    items
+;;
+
+let runtime_mcp_policy_for_provider
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~(agent_name : string)
+      (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option)
+  =
+  let agent_name =
+    let trimmed = String.trim agent_name in
+    if String.equal trimmed "" then None else Some trimmed
+  in
+  (* Dispatch by local tool-delivery policy, not by provider name
+     (RFC-0058 §2.4).  [requires_per_keeper_bridging] gates the
+     strip-and-bridge path. *)
+  let requires_per_keeper_bridging =
+    Provider_tool_support
+    .provider_requires_per_keeper_bridging_for_bound_actor_tools
+      provider_cfg
+  in
+  match policy_opt, requires_per_keeper_bridging, agent_name with
+  | Some policy, true, Some agent_name ->
+    (* Per-request HTTP headers are stripped and only MASC identity headers
+         plus the per-keeper [Authorization] header survive — so runtime MCP
+         tools still authenticate without leaking secrets via argv. *)
+    Some (Auth_bridging.bridged_runtime_mcp_policy_for_agent ~agent_name policy)
+  | Some _policy, true, None ->
+    (* No keeper identity means no safe per-keeper bridge. Returning
+       [None] makes the caller either fall back to inline tools (when
+       supported) or surface a tool-support error instead of running
+       runtime MCP tools unauthenticated. *)
+    None
+  | Some policy, false, Some agent_name ->
+    Some (Mcp_policy_helpers.runtime_mcp_policy_with_masc_agent_name ~agent_name policy)
+  | Some policy, false, None -> Some policy
+  | None, _, _ -> None
+;;
+
+let cli_runtime_mcp_jsons
+      ~(base : string list)
+      (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option)
+  =
+  let request_json =
+    match policy_opt with
+    | Some policy -> Option.to_list (Cli_mcp_config_json.cli_mcp_config_json_of_policy policy)
+    | None -> []
+  in
+  dedupe_preserve_order (base @ request_json)
+;;

--- a/lib/runtime/runtime_transport_runtime_policy_provider.mli
+++ b/lib/runtime/runtime_transport_runtime_policy_provider.mli
@@ -1,0 +1,14 @@
+(** Provider-driven runtime MCP policy resolver and CLI JSON merger. *)
+
+val runtime_mcp_policy_for_provider :
+  provider_cfg:Llm_provider.Provider_config.t ->
+  agent_name:string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+(** Shape a runtime MCP policy according to provider tool-delivery capability. *)
+
+val cli_runtime_mcp_jsons :
+  base:string list ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  string list
+(** Merge base CLI MCP JSON entries with a runtime-policy projection. *)

--- a/lib/runtime/runtime_wire_overlay.ml
+++ b/lib/runtime/runtime_wire_overlay.ml
@@ -1,0 +1,165 @@
+(** Wire-layer overlays that MASC applies after OAS resolves a provider config.
+
+    This module owns transport-shape repairs, not provider/model identity.
+    Provider and model truth remains in OAS plus cascade.toml. *)
+
+let auth_header_authorization = "Authorization"
+
+let api_key_from_env name =
+  match String.trim name with
+  | "" -> ""
+  | env_name ->
+    (match Sys.getenv_opt env_name with
+     | Some value -> value
+     | None -> "")
+;;
+
+let auth_headers_for_provider_cfg
+      ~(api_key : string)
+      (provider_cfg : Llm_provider.Provider_config.t)
+  =
+  let headers = provider_cfg.headers in
+  if String.trim api_key = ""
+  then headers
+  else (
+    match provider_cfg.kind with
+    | Provider_a | Provider_c -> ("x-api-key", api_key) :: headers
+    | Provider_f | Cli_tool_d | Cli_tool_b | Cli_tool_c | Cli_tool_a -> headers
+    | Provider_d_compat | Ollama | Provider_k | Provider_h ->
+      ("Authorization", "Bearer " ^ api_key) :: headers)
+;;
+
+let request_kind_of_provider_cfg (provider_cfg : Llm_provider.Provider_config.t) =
+  match provider_cfg.kind with
+  | Provider_a | Provider_c -> Agent_sdk.Provider.Provider_a_messages
+  | Provider_d_compat
+  | Ollama
+  | Provider_f
+  | Provider_k
+  | Provider_h
+  | Cli_tool_d
+  | Cli_tool_b
+  | Cli_tool_c
+  | Cli_tool_a -> Agent_sdk.Provider.Openai_chat_completions
+;;
+
+let agent_capabilities_of_llm_capabilities
+      (caps : Llm_provider.Capabilities.capabilities)
+  : Agent_sdk.Provider.capabilities
+  =
+  { max_context_tokens = caps.max_context_tokens
+  ; max_output_tokens = caps.max_output_tokens
+  ; supports_tools = caps.supports_tools
+  ; supports_tool_choice = caps.supports_tool_choice
+  ; supports_parallel_tool_calls = caps.supports_parallel_tool_calls
+  ; supports_runtime_mcp_tools = caps.supports_runtime_mcp_tools
+  ; supports_runtime_tool_events = caps.supports_runtime_tool_events
+  ; supports_reasoning = caps.supports_reasoning
+  ; supports_extended_thinking = caps.supports_extended_thinking
+  ; supports_reasoning_budget = caps.supports_reasoning_budget
+  ; thinking_control_format = caps.thinking_control_format
+  ; supports_response_format_json = caps.supports_response_format_json
+  ; supports_structured_output = caps.supports_structured_output
+  ; supports_multimodal_inputs = caps.supports_multimodal_inputs
+  ; supports_image_input = caps.supports_image_input
+  ; supports_audio_input = caps.supports_audio_input
+  ; supports_video_input = caps.supports_video_input
+  ; modality_priority = caps.modality_priority
+  ; supports_native_streaming = caps.supports_native_streaming
+  ; supports_system_prompt = caps.supports_system_prompt
+  ; supports_caching = caps.supports_caching
+  ; supports_prompt_caching = caps.supports_prompt_caching
+  ; prompt_cache_alignment = caps.prompt_cache_alignment
+  ; supports_top_k = caps.supports_top_k
+  ; supports_min_p = caps.supports_min_p
+  ; supports_seed = caps.supports_seed
+  ; supports_seed_with_images = caps.supports_seed_with_images
+  ; supports_computer_use = caps.supports_computer_use
+  ; supports_code_execution = caps.supports_code_execution
+  ; emits_usage_tokens = caps.emits_usage_tokens
+  ; supported_models = caps.supported_models
+  }
+;;
+
+let register_capability_overlay_provider
+      ~(name : string)
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+  =
+  let capabilities =
+    Agent_sdk.Provider_runtime_binding.capabilities_for_provider_config provider_cfg
+    |> agent_capabilities_of_llm_capabilities
+  in
+  Agent_sdk.Provider.register_provider
+    { name
+    ; request_kind = request_kind_of_provider_cfg provider_cfg
+    ; request_path = provider_cfg.request_path
+    ; capabilities
+    ; build_body =
+        (fun ~config:_ ~messages:_ ?tools:_ () ->
+           invalid_arg
+             "MASC cascade capability overlay providers require an injected \
+              Llm_transport")
+    ; parse_response =
+        (fun _ ->
+           invalid_arg
+             "MASC cascade capability overlay providers require an injected \
+              Llm_transport")
+    ; resolve =
+        (fun provider ->
+           let api_key =
+             match String.trim provider_cfg.api_key with
+             | "" -> api_key_from_env provider.Agent_sdk.Provider.api_key_env
+             | value -> value
+           in
+           Ok
+             ( provider_cfg.base_url
+             , api_key
+             , auth_headers_for_provider_cfg ~api_key provider_cfg ))
+    }
+;;
+
+let apply_capability_overlay
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      (provider : Agent_sdk.Provider.config)
+  =
+  match provider_cfg.supports_tool_choice_override with
+  | None -> provider
+  | Some _ ->
+    let name = Llm_provider.Provider_registry.provider_name_of_config provider_cfg in
+    let registry = Llm_provider.Provider_registry.default () in
+    (match Llm_provider.Provider_registry.find registry name with
+     | None -> provider
+     | Some _ ->
+       register_capability_overlay_provider ~name ~provider_cfg;
+       { provider with provider = Agent_sdk.Provider.Custom_registered { name } })
+;;
+
+let apply
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      (provider : Agent_sdk.Provider.config)
+  : Agent_sdk.Provider.config
+  =
+  let provider =
+    match provider_cfg.kind, provider.provider with
+    | ( Llm_provider.Provider_config.Provider_d_compat
+      , Agent_sdk.Provider.Local { base_url } )
+      when not
+             (String.equal
+                provider_cfg.request_path
+                Masc_network_defaults.openai_chat_completions_path) ->
+      let api_key_trimmed = String.trim provider_cfg.api_key in
+      let auth_header =
+        if String.equal api_key_trimmed "" then None else Some auth_header_authorization
+      in
+      let static_token =
+        if String.equal api_key_trimmed "" then None else Some api_key_trimmed
+      in
+      { provider with
+        provider =
+          Agent_sdk.Provider.OpenAICompat
+            { base_url; auth_header; path = provider_cfg.request_path; static_token }
+      }
+    | _ -> provider
+  in
+  apply_capability_overlay ~provider_cfg provider
+;;

--- a/lib/runtime/runtime_wire_overlay.mli
+++ b/lib/runtime/runtime_wire_overlay.mli
@@ -1,0 +1,7 @@
+(** Wire-layer overlays applied after OAS resolves a provider config. *)
+
+val apply :
+  provider_cfg:Llm_provider.Provider_config.t ->
+  Agent_sdk.Provider.config ->
+  Agent_sdk.Provider.config
+


### PR DESCRIPTION
## 목적

PR #19536이 `lib/cascade*`(170+파일)를 의도적으로 삭제하며 빌드를 broken 상태로 둔 뒤, cascade→Runtime "재탄생"의 **substrate(기반 레이어)를 복원**합니다. 본 PR은 후속 consumer rewire(L2)가 올라설 canonical foundation을 제공합니다.

설계 SSOT: `docs/rfc/RFC-0206-runtime-concept-cascade-rebirth.md` (이 브랜치에 포함). §9 범위 측정, §10 substrate 매핑.

## 범위 (substrate만, consumer rewire는 후속)

- **P1-P3 자립 Runtime 코어** (`492b3c12a7`): `lib/runtime/runtime_schema` + `runtime_toml`(parser) + `runtime_adapter` + `runtime.ml` 재배선. 삭제된 `Cascade_declarative_*` 의존 제거. `get_default_runtime_id`의 `"tool_strict"` silent fallback을 fail-fast(`failwith`)로 교체 (RFC-0206 §2.1, Unknown→Permissive 안티패턴 제거).
- **L0 transport/dispatch 부분그래프** (`c5bda7ebbc`): 19모듈/38파일을 `Runtime_*` 네임스페이스로 결정론적 restore-rename. 이 부분그래프는 routing/strategy/health/selection 의존이 0인 clean provider transport라 RFC-0206 §5 INHERIT에 따라 재작성 없이 이식.
- **L1 keeper substrate** (`fdc66af4c3`): event_bridge/event_publisher/attempt_liveness/preflight_health/observation/binding_health 12모듈/24파일을 `keeper_*`로 restore-rename. 오염된 `cascade_metrics`(routing 의존)는 의도적으로 미복원.
- **L0 추가** (`34b5c91711`): `Runtime_constants`(fallback_context_window=128000) + `Runtime_metrics`(prometheus emitter, metric 이름은 operator 대시보드 seam이라 보존).

## 검증

- P1-P3 4개 모듈 + `masc_network_defaults`는 격리 scratch project에서 실제 외부 deps(agent_sdk/llm_provider/otoml)에 대해 컴파일 EXIT=0. P2 산출물은 별도 adversarial review "clean".
- restore-rename은 결정론적(perl, BSD-sed-safe). within-subgraph 모듈 상호참조 일관 치환 확인.

## 남은 작업 (후속 PR)

monolithic lib이라 **consumer rewire 120파일 + substrate-internal 41 rewire가 전부 끝나야** full build가 green이 됩니다. 본 PR 단독으로는 빌드되지 않습니다(main이 #19536으로 이미 의도적 broken). 남은 매핑은 RFC-0206 §10에 leaf 수준까지 정의돼 있습니다.

## 협업

MASC task-627(Cascade consumer cleanup after #19536) claim + broadcast 완료. 경쟁 worktree(cascade-nuke/cascade-kill-tool-strict)는 `get_default_cascade_name="tool_strict"` shim 방향(여전히 컴파일 불가)이며, 본 substrate만 실제 컴파일 가능한 기반입니다.

RFC: `docs/rfc/RFC-0206-runtime-concept-cascade-rebirth.md`
WORKAROUND-WAIVED: 본 PR은 워크어라운드를 *제거*함(tool_strict silent fallback 삭제, routing-오염 cascade_metrics 미복원). 본문의 "tool_strict"/"fallback"/"shim" 언급은 모두 *제거 대상*을 서술한 것.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
