### PR TITLE
refactor(runtime): cascade→Runtime consumer rewire — substrate complete + 386 dangling refs cleared (RFC-0206 L2)

### DIFF
--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -22,7 +22,7 @@
 
 type waiter_info =
   { keeper_name : string
-  ; cascade_name : Cascade_name.t
+  ; cascade_name : string
   ; enqueue_ts : float
   ; priority : Llm_provider.Request_priority.t
   }
@@ -241,7 +241,7 @@ let snapshot_json () =
                   [ "keeper_name", `String w.keeper_name
                   ; ( "cascade_name"
                     , `String
-                        (Cascade_name.to_string w.cascade_name) )
+                        (w.cascade_name) )
                   ; ( "priority"
                     , `String (Llm_provider.Request_priority.to_string w.priority) )
                   ; "wait_seconds", `Float (now -. w.enqueue_ts)

--- a/lib/admission_queue.mli
+++ b/lib/admission_queue.mli
@@ -14,7 +14,7 @@
 (** Metadata carried per waiter — for observability, not scheduling. *)
 type waiter_info = {
   keeper_name : string;
-  cascade_name : Cascade_name.t;
+  cascade_name : string;
   enqueue_ts : float;
   priority : Llm_provider.Request_priority.t;
 }
@@ -39,7 +39,7 @@ val with_permit :
   ?wait_timeout_sec:float ->
   priority:Llm_provider.Request_priority.t ->
   keeper_name:string ->
-  cascade_name:Cascade_name.t ->
+  cascade_name:string ->
   (unit -> 'a) ->
   ('a, [> `Host_resource_saturated of string ]) result
 (** Run [f] in passthrough mode and record inflight observation for metrics
@@ -52,7 +52,7 @@ val with_permit :
 val try_with_permit :
   priority:Llm_provider.Request_priority.t ->
   keeper_name:string ->
-  cascade_name:Cascade_name.t ->
+  cascade_name:string ->
   (unit -> 'a) ->
   'a option
 (** Non-blocking variant. Returns [None] if host resources are saturated. *)

--- a/lib/admission_queue_metrics.mli
+++ b/lib/admission_queue_metrics.mli
@@ -19,14 +19,14 @@ val rejection_reason_label : rejection_reason -> string
 
 val on_acquire :
   keeper_name:string ->
-  cascade_name:Cascade_name.t ->
+  cascade_name:string ->
   wait_ms:int ->
   unit
 (** Called after successful acquire. Increments inflight gauge,
     records wait time histogram. *)
 
 val on_release :
-  keeper_name:string -> cascade_name:Cascade_name.t -> unit
+  keeper_name:string -> cascade_name:string -> unit
 (** Called on release. Decrements inflight gauge. *)
 
 val on_reject : surface:rejection_surface -> reason:rejection_reason -> unit

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -465,7 +465,7 @@ let log_action
   let summary = audit_summary ~action ~details in
   let target = audit_target ~action ~details in
   let payload_opt = if details = `Null then None else Some details in
-  Cascade_events.publish_audit_event ~id ~ts ~actor:agent_id ~kind ?target
+  Keeper_event_publisher.publish_audit_event ~id ~ts ~actor:agent_id ~kind ?target
     ~summary ~severity ?payload:payload_opt ()
 
 (** Convenience functions for common events *)

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -125,7 +125,7 @@ let call_model_direct_sync ~agent_type ~prompt =
       )
     with
     | Ok result ->
-        let resp = result.Cascade_runner.response in
+        let resp = result.Runtime_agent.response in
         let text = Agent_sdk_response.text_of_response resp in
         debug_log
           (Printf.sprintf "MODEL_USED %s for agent_type=%s"

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -414,7 +414,7 @@ module KeeperKeepalive = struct
 
   (** Maximum turns per single OAS Agent.run call.
       Keeper resumes via checkpoint in the next keepalive cycle when
-      {!Cascade_runner.TurnBudgetExhausted} is returned.
+      {!Runtime_agent.TurnBudgetExhausted} is returned.
       Previous default of 200 caused "ambiguous partial commit" errors:
       the 300s timeout would fire mid-turn after tools had already executed,
       leaving the keeper in an ambiguous state. With 30 turns per call and
@@ -479,7 +479,7 @@ module KeeperKeepalive = struct
       this catches the case where a single bulk read hangs without
       producing line breaks.
 
-      Opt-in: unset env leaves [None] so {!Cascade_agent_context} skips
+      Opt-in: unset env leaves [None] so {!Runtime_agent_context} skips
       the builder wiring. Set to a value strictly less than the effective
       OAS attempt cap for attempt-level fall-forward; set
       [<= stream_idle_timeout_sec] for a strict overall cap.

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -444,7 +444,7 @@ let required_keeper_internal_tool : Agent_sdk.Tool.t =
 let provider_required_keeper_internal_tool_issue provider_cfg =
   let resolved =
     try
-      Cascade_runner.resolve_tool_lane_for_oas_tools
+      Runtime_agent.resolve_tool_lane_for_oas_tools
         ~agent_name:doctor_keeper_agent_name
         ~tool_requirement:`Required
         ~provider_cfg

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -285,7 +285,7 @@ let resolve_strategies
           (* Fallback: minimal observation when none provided. *)
           { context_ratio = 0.5; active_agent_count = 1;
             unclaimed_task_count = 0; is_single_focused_task = true;
-            context_window = Cascade_runtime.fallback_context_window;
+            context_window = Runtime_constants.fallback_context_window;
             is_local_model = false }
       in
       (* Resolve once — no recursive Dynamic *)

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -670,7 +670,7 @@ let compute_judgments
   with
   | Error err -> Error (Agent_sdk.Error.to_string err)
   | Ok result -> (
-      let response = result.Cascade_runner.response in
+      let response = result.Runtime_agent.response in
       try
         let raw_text = Agent_sdk_response.text_of_response response in
         let generated_at = Masc_domain.now_iso () in

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -269,7 +269,7 @@ let pre_compact_event_of_json json =
       ; strategies = Safe_ops.json_string_list "strategies" json
       ; context_window =
           Safe_ops.json_int
-            ~default:Cascade_runtime.fallback_context_window
+            ~default:Runtime_constants.fallback_context_window
             "context_window"
             json
       ; is_local_model = Safe_ops.json_bool ~default:false "is_local_model" json
@@ -356,7 +356,7 @@ let wake_payload_event_of_json json =
       ; model_id = public_runtime_model_id
       ; context_window =
           Safe_ops.json_int
-            ~default:Cascade_runtime.fallback_context_window
+            ~default:Runtime_constants.fallback_context_window
             "context_window"
             json
       ; approx_body_bytes = Safe_ops.json_int ~default:0 "approx_body_bytes" json

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -252,7 +252,7 @@ let keeper_config_json (config : Coord.config) (name : string)
       let selected_cascade_canonical_json =
         match live_keeper_cascade_name_result cascade_name with
         | Ok runtime ->
-          `String (Cascade_name.to_string runtime)
+          `String (runtime)
         | Error (`Unresolved _) -> `Null
       in
       let execution =

--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -15,7 +15,7 @@ let runtime_warning_ctx_ratio =
    ([Keeper_cascade_profile.resolve_live]) were removed in the §3.3
    sunset closeout. *)
 let live_keeper_cascade_name_result (raw : string) :
-    (Cascade_name.t, [ `Unresolved of string ]) result =
+    (string, [ `Unresolved of string ]) result =
   Keeper_cascade_profile.resolve_live_result raw
 
 let compute_health_score

--- a/lib/dashboard/dashboard_http_keeper_types.mli
+++ b/lib/dashboard/dashboard_http_keeper_types.mli
@@ -16,7 +16,7 @@ val runtime_warning_ctx_ratio : float
     [Env_config_keeper.DashboardHealth]. *)
 
 val live_keeper_cascade_name_result :
-  string -> (Cascade_name.t, [ `Unresolved of string ]) result
+  string -> (string, [ `Unresolved of string ]) result
 (** Resolve a raw cascade name to its live (post-rotation) identifier.
     Returns [Error (`Unresolved raw)] when the input cannot be resolved
     to any catalog member; the caller is expected to surface the

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -232,7 +232,7 @@ let compute_judgments
   with
   | Error err -> Error (Agent_sdk.Error.to_string err)
   | Ok result -> (
-      let response = result.Cascade_runner.response in
+      let response = result.Runtime_agent.response in
       try
         (* See dashboard_governance_judge.ml for rationale: LLMs frequently
            wrap JSON in ```json … ``` markdown fences. Lenient_json strips

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -520,8 +520,7 @@ let execute_single_agent_run ~sw ~net ~run_id ~provider ~model ~prompt =
                provider)
         else (
           let inference_cascade_name =
-            Cascade_name.of_string_exn
-              (Runtime.get_default_runtime_id ())
+                          (Runtime.get_default_runtime_id ())
           in
           match
             Masc_oas_bridge.run_with_caller

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -482,7 +482,7 @@ let resolve_provider_run_request ~provider ~model_opt ~prompt =
 
 (** Check if a model label is runnable (has provider config + auth). *)
 let is_label_runnable (label : string) : bool =
-  match Cascade_config.parse_model_string label with
+  match Runtime_model_string.parse_model_string label with
   | None -> false
   | Some _cfg ->
       (* Extract provider prefix and check the OAS runtime binding. *)
@@ -510,7 +510,7 @@ let execute_single_agent_run ~sw ~net ~run_id ~provider ~model ~prompt =
         "single-agent run resolved run_id=%s provider=%s requested_model=%s model_label=%s"
         run_id provider model label;
       (* Validate label parses *)
-      match Cascade_config.parse_model_string label with
+      match Runtime_model_string.parse_model_string label with
       | None -> Error (Printf.sprintf "Cannot parse model: %s" label)
       | Some _cfg ->
         if not (is_label_runnable label) then

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -318,8 +318,8 @@ let terminal_reason_code_of_sdk_error = function
   | Agent_sdk.Error.Orchestration _ -> "orchestration_error"
   | Agent_sdk.Error.A2a _ -> "a2a_error"
   | Agent_sdk.Error.Internal msg -> (
-    match Cascade_error_classify.classify_masc_internal_error_of_string msg with
-    | Some err -> Cascade_error_classify.kind_of_masc_internal_error err
+    match Keeper_meta_contract.classify_masc_internal_error_of_string msg with
+    | Some err -> Keeper_meta_contract.kind_of_masc_internal_error err
     | None -> "internal_error")
 ;;
 
@@ -366,7 +366,7 @@ let checkpoint_persistence_error ~keeper_name ~detail =
 
 let cascade_outcome_of_observation
     : _ -> Keeper_execution_receipt.cascade_outcome = function
-  | Some (obs : Cascade_observation.cascade_observation) when obs.fallback_applied ->
+  | Some (obs : Keeper_observation.cascade_observation) when obs.fallback_applied ->
     Keeper_execution_receipt.Cascade_passed_to_next_model
   | Some _ -> Keeper_execution_receipt.Cascade_completed
   | None -> Keeper_execution_receipt.Cascade_not_observed

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -102,5 +102,5 @@ val checkpoint_persistence_error
     ([Cascade_passed_to_next_model] / [Cascade_completed] /
     [Cascade_not_observed]). *)
 val cascade_outcome_of_observation
-  :  Cascade_observation.cascade_observation option
+  :  Keeper_observation.cascade_observation option
   -> Keeper_execution_receipt.cascade_outcome

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -46,7 +46,7 @@ type run_result =
   ; model_used : string
   ; prompt_metrics : prompt_metrics
   ; ctx_composition : ctx_composition_metrics
-  ; cascade_observation : Cascade_observation.cascade_observation option
+  ; cascade_observation : Keeper_observation.cascade_observation option
   ; turn_count : int
   ; tool_calls_made : int
   ; usage : Agent_sdk.Types.api_usage
@@ -56,7 +56,7 @@ type run_result =
   ; checkpoint : Agent_sdk.Checkpoint.t option
   ; trace_ref : Agent_sdk.Raw_trace.run_ref option
   ; run_validation : Agent_sdk.Raw_trace.run_validation option
-  ; stop_reason : Cascade_runner.stop_reason
+  ; stop_reason : Runtime_agent.stop_reason
   ; inference_telemetry : Agent_sdk.Types.inference_telemetry option
   ; tool_surface : tool_surface_metrics
   ; pre_dispatch_compacted : bool

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -16,7 +16,7 @@ type run_result =
   ; model_used : string
   ; prompt_metrics : Keeper_agent_prompt_metrics.prompt_metrics
   ; ctx_composition : Keeper_agent_prompt_metrics.ctx_composition_metrics
-  ; cascade_observation : Cascade_observation.cascade_observation option
+  ; cascade_observation : Keeper_observation.cascade_observation option
   ; turn_count : int
   ; tool_calls_made : int
   ; usage : Agent_sdk.Types.api_usage
@@ -26,7 +26,7 @@ type run_result =
   ; checkpoint : Agent_sdk.Checkpoint.t option
   ; trace_ref : Agent_sdk.Raw_trace.run_ref option
   ; run_validation : Agent_sdk.Raw_trace.run_validation option
-  ; stop_reason : Cascade_runner.stop_reason
+  ; stop_reason : Runtime_agent.stop_reason
   ; inference_telemetry : Agent_sdk.Types.inference_telemetry option
   ; tool_surface : Keeper_agent_tool_surface.tool_surface_metrics
   ; pre_dispatch_compacted : bool

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -73,7 +73,7 @@ let run_turn
       ~(build_turn_prompt :
          base_system_prompt:string -> messages:Agent_sdk.Types.message list -> turn_prompt)
       ~(user_message : string)
-      ~(cascade_name : Cascade_name.t)
+      ~(cascade_name : string)
       ?world_observation
       ?(turn_affordances = [])
       ?(required_tool_names = [])
@@ -139,7 +139,7 @@ let run_turn
   Eio.Switch.run @@ fun turn_sw ->
   Eio_context.with_turn_switch turn_sw
   @@ fun () ->
-  let cascade_name_string = Cascade_name.to_string cascade_name in
+  let cascade_name_string = cascade_name in
   (* Steps 0–4: inference params, session dir, checkpoint, base prompt,
      working context, checkpoint hygiene — all in Keeper_run_context. *)
   let ctx =

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -171,12 +171,12 @@ let run_turn
     | Error internal_error ->
       let detail =
         Option.value
-          ~default:(Cascade_error_classify.kind_of_masc_internal_error internal_error)
-          (Cascade_error_classify.summary_of_masc_internal_error internal_error)
+          ~default:(Keeper_meta_contract.kind_of_masc_internal_error internal_error)
+          (Keeper_meta_contract.summary_of_masc_internal_error internal_error)
       in
       Log.Keeper.error "%s: %s" meta.name detail;
       ( ctx.max_tokens,
-        Some (Cascade_error_classify.sdk_error_of_masc_internal_error internal_error) )
+        Some (Keeper_meta_contract.sdk_error_of_masc_internal_error internal_error) )
   in
   let context_injector = ctx.context_injector in
   let shared_context = ctx.shared_context in
@@ -560,7 +560,7 @@ let run_turn
                  | None -> None)
             ; cli_subprocess_idle_sec
             }
-            : Cascade_runner.cli_transport_overrides)
+            : Runtime_agent.cli_transport_overrides)
        in
        Keeper_agent_run_phase0_telemetry.record_if_enabled
          ~meta

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -91,7 +91,7 @@ val run_turn
   -> build_turn_prompt:
        (base_system_prompt:string -> messages:Agent_sdk.Types.message list -> turn_prompt)
   -> user_message:string
-  -> cascade_name:Cascade_name.t
+  -> cascade_name:string
   -> ?world_observation:Keeper_world_observation.world_observation
   -> ?turn_affordances:string list
   -> ?required_tool_names:string list

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -22,7 +22,7 @@ let finalize
     ~memory
     ~actual_keeper_tool_names
     ~actual_keeper_tool_names_ref
-    ~(result : Cascade_runner.run_result)
+    ~(result : Runtime_agent.run_result)
     ~checkpoint_persistence_error
     ~post_turn_t0
     ?provider_filter

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -143,7 +143,7 @@ let finalize
       Keeper_agent_error.terminal_reason_code_of_sdk_error_typed err
       |> Keeper_turn_terminal_code.to_wire
   in
-  let cascade_observation : Cascade_observation.cascade_observation option =
+  let cascade_observation : Keeper_observation.cascade_observation option =
     !receipt_cascade_observation_ref
   in
   let ( extra_system_context_digest

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -25,12 +25,12 @@ let degraded_retry_cascade_of_wire ?(log_invalid = true) ~keeper_name raw =
       ; "route." ^ trimmed
       ]
     in
+    (* RFC-0206: a runtime id is a raw string (no cascade-name prefix
+       validation / re-qualification). Accept the first non-empty candidate. *)
     let rec first_valid = function
       | [] -> None
       | candidate :: rest ->
-        (match Cascade_name.of_string candidate with
-         | Ok cascade -> Some cascade
-         | Error _ -> first_valid rest)
+        if String.trim candidate = "" then first_valid rest else Some candidate
     in
     match first_valid candidates with
     | Some _ as parsed -> parsed
@@ -248,7 +248,7 @@ let finalize
             (Keeper_execution_receipt.outcome_kind_to_string receipt.outcome) );
         ("terminal_reason_code", `String receipt.terminal_reason_code);
         ( "cascade_name",
-          `String (Cascade_name.to_string receipt.cascade_name) );
+          `String (receipt.cascade_name) );
         ("cascade_attempt_count", `Int receipt.cascade_attempt_count);
         ("cascade_fallback_applied", `Bool receipt.cascade_fallback_applied);
         ( "cascade_outcome",
@@ -296,7 +296,7 @@ let finalize
       ~trace_id:receipt.trace_id ~generation:receipt.generation
       ~keeper_turn_id:manifest_keeper_turn_id ~event
       ?oas_turn_count
-      ~cascade_name:(Cascade_name.to_string receipt.cascade_name)
+      ~cascade_name:(receipt.cascade_name)
       ~status ~decision ~receipt_path ?tool_call_log_path ()
     |> Keeper_runtime_manifest.append_best_effort ~site config
   in

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -6,9 +6,9 @@ type finalized = {
 }
 
 let stop_reason_label = function
-  | Cascade_runner.Completed -> "completed"
-  | Cascade_runner.TurnBudgetExhausted _ -> "budget_exhausted"
-  | Cascade_runner.MutationBoundaryReached { tool_name; _ } ->
+  | Runtime_agent.Completed -> "completed"
+  | Runtime_agent.TurnBudgetExhausted _ -> "budget_exhausted"
+  | Runtime_agent.MutationBoundaryReached { tool_name; _ } ->
     (match tool_name with
      | Some tool -> Printf.sprintf "mutation_boundary(%s)" tool
      | None -> "mutation_boundary")

--- a/lib/keeper/keeper_agent_run_response_text.mli
+++ b/lib/keeper/keeper_agent_run_response_text.mli
@@ -5,13 +5,13 @@ type finalized = {
   response_text : string;
 }
 
-val stop_reason_label : Cascade_runner.stop_reason -> string
+val stop_reason_label : Runtime_agent.stop_reason -> string
 
 val finalize :
   keeper_name:string ->
   goal:string ->
   actual_keeper_tool_names:string list ->
   fallback_tool_names:string list ->
-  stop_reason:Cascade_runner.stop_reason ->
+  stop_reason:Runtime_agent.stop_reason ->
   raw_response_text:string ->
   finalized

--- a/lib/keeper/keeper_attempt_liveness_observer.mli
+++ b/lib/keeper/keeper_attempt_liveness_observer.mli
@@ -23,12 +23,12 @@
       side-effecting telemetry only.
     - [Enforce] mode: on the first [Outcome] the observer calls
       [Eio.Switch.fail sw {!Liveness_kill}] so the surrounding
-      [Cascade_runner.run] tears down via Eio cancellation.
+      [Runtime_agent.run] tears down via Eio cancellation.
 
     {1 Tick fiber lifetime}
 
     The tick fiber is forked under the same [~sw] that owns
-    [Cascade_runner.run], but a provider can return a terminal error
+    [Runtime_agent.run], but a provider can return a terminal error
     before the streaming FSM sees a terminal event. Callers must invoke
     {!stop_tick_fiber} on attempt completion before leaving the switch;
     otherwise a pending no-token tick loop can keep the attempt switch open

--- a/lib/keeper/keeper_binding_health.ml
+++ b/lib/keeper/keeper_binding_health.ml
@@ -398,7 +398,7 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
         let new_until = now +. cooldown_dur in
         if new_until > state.cooldown_until then begin
           state.cooldown_until <- new_until;
-          Cascade_metrics.on_provider_cooldown
+          Runtime_metrics.on_provider_cooldown
             ~provider:provider_key ~reason:"failure_threshold";
           Prometheus.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
             ~labels:[("provider", provider_key)] cooldown_dur
@@ -425,7 +425,7 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       let new_until = now +. cooldown_dur in
       if new_until > state.cooldown_until then begin
         state.cooldown_until <- new_until;
-        Cascade_metrics.on_provider_cooldown
+        Runtime_metrics.on_provider_cooldown
           ~provider:provider_key ~reason:"soft_rate_limit";
         Prometheus.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
           ~labels:[("provider", provider_key)] cooldown_dur
@@ -445,7 +445,7 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       let new_until = now +. cooldown_dur in
       if new_until > state.cooldown_until then begin
         state.cooldown_until <- new_until;
-        Cascade_metrics.on_provider_cooldown
+        Runtime_metrics.on_provider_cooldown
           ~provider:provider_key ~reason:"capacity_backpressure";
         Prometheus.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
           ~labels:[("provider", provider_key)] cooldown_dur
@@ -462,7 +462,7 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       let new_until = now +. hard_quota_cooldown_sec in
       if new_until > state.cooldown_until then begin
         state.cooldown_until <- new_until;
-        Cascade_metrics.on_provider_cooldown
+        Runtime_metrics.on_provider_cooldown
           ~provider:provider_key ~reason:"hard_quota";
         Prometheus.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
           ~labels:[("provider", provider_key)] hard_quota_cooldown_sec
@@ -480,7 +480,7 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       let new_until = now +. terminal_failure_cooldown_sec in
       if new_until > state.cooldown_until then begin
         state.cooldown_until <- new_until;
-        Cascade_metrics.on_provider_cooldown
+        Runtime_metrics.on_provider_cooldown
           ~provider:provider_key ~reason:"terminal_failure";
         Prometheus.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
           ~labels:[("provider", provider_key)] terminal_failure_cooldown_sec

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -29,8 +29,8 @@ let last_tool_name receipt =
 
 let cascade_rotation_attempt_to_json attempt =
   `Assoc
-    [ "from_cascade", `String (Cascade_name.to_string attempt.from_cascade)
-    ; "to_cascade", `String (Cascade_name.to_string attempt.to_cascade)
+    [ "from_cascade", `String (attempt.from_cascade)
+    ; "to_cascade", `String (attempt.to_cascade)
     ; ( "reason"
       , `String (Keeper_error_classify.degraded_retry_reason_to_string attempt.reason) )
     ; "outcome", `String (cascade_rotation_outcome_to_string attempt.outcome)
@@ -477,7 +477,7 @@ let to_json (receipt : t) =
       ~required_tools:receipt.tool_surface.required_tools
       ~required_tool_candidates:receipt.tool_surface.required_tool_candidates
       ~missing_required_tools:receipt.tool_surface.missing_required_tools
-      ~cascade_profile:(Cascade_name.to_string receipt.cascade_name)
+      ~cascade_profile:(receipt.cascade_name)
       ()
   in
   let action_radius =
@@ -563,7 +563,7 @@ let to_json (receipt : t) =
           ] )
     ; ( "cascade"
       , `Assoc
-          [ "name", `String (Cascade_name.to_string receipt.cascade_name)
+          [ "name", `String (receipt.cascade_name)
           ; "selected_model", `Null
           ; "attempt_count", `Int receipt.cascade_attempt_count
           ; "fallback_applied", `Bool receipt.cascade_fallback_applied
@@ -572,7 +572,7 @@ let to_json (receipt : t) =
           ; "degraded_retry_applied", `Bool receipt.degraded_retry_applied
           ; ( "degraded_retry_cascade"
             , match receipt.degraded_retry_cascade with
-              | Some value -> `String (Cascade_name.to_string value)
+              | Some value -> `String (value)
               | None -> `Null )
           ; ( "fallback_reason"
             , match receipt.fallback_reason with
@@ -726,7 +726,7 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
     ; ( "current_task_id", string_opt_json receipt.current_task_id )
     ; "goal_ids", list_json receipt.goal_ids
     ; "response_text_present", `Bool receipt.response_text_present
-    ; "cascade_name", `String (Cascade_name.to_string receipt.cascade_name)
+    ; "cascade_name", `String (receipt.cascade_name)
     ; "cascade_outcome", `String (cascade_outcome_to_string receipt.cascade_outcome)
     ; ( "tool_contract_result"
       , `String (tool_contract_result_to_string receipt.tool_contract_result) )
@@ -928,7 +928,7 @@ let stale_broadcast_payload
       ~stale_seconds
       ~last_turn_ts
   =
-  let cascade_name_string = Cascade_name.to_string cascade_name in
+  let cascade_name_string = cascade_name in
   let failure_reason_text = stale_broadcast_failure_reason_text failure_reason in
   let failure_reason_cohort = stale_broadcast_failure_cohort failure_reason in
   `Assoc
@@ -965,7 +965,7 @@ let emit_stale_keeper_broadcast
       ~stale_seconds
       ~last_turn_ts
   =
-  let cascade_name_string = Cascade_name.to_string cascade_name in
+  let cascade_name_string = cascade_name in
   let payload =
     stale_broadcast_payload
       ~keeper_name

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -178,8 +178,8 @@ val decode_contract_violation_reason
   -> (string * string list * string list) option
 
 type cascade_rotation_attempt =
-  { from_cascade : Cascade_name.t
-  ; to_cascade : Cascade_name.t
+  { from_cascade : string
+  ; to_cascade : string
   ; reason : Keeper_error_classify.degraded_retry_reason
   ; outcome : cascade_rotation_outcome
   ; slot_release_at_phase : slot_release_phase option
@@ -218,14 +218,14 @@ type t =
   ; network_mode : Keeper_types_profile_sandbox.network_mode
   ; approval_profile : string option
   ; approval_profile_derived : bool
-  ; cascade_name : Cascade_name.t
+  ; cascade_name : string
   ; cascade_selected_model : string option
   ; cascade_attempt_count : int
   ; cascade_fallback_applied : bool
   ; cascade_outcome : cascade_outcome
   ; oas_internal_cascade_allowed : bool
   ; degraded_retry_applied : bool
-  ; degraded_retry_cascade : Cascade_name.t option
+  ; degraded_retry_cascade : string option
   ; fallback_reason : Keeper_error_classify.degraded_retry_reason option
   ; cascade_rotation_attempts : cascade_rotation_attempt list
   ; stop_reason : Runtime_agent.stop_reason option
@@ -313,7 +313,7 @@ val operator_broadcast_payload
 val stale_broadcast_payload
   :  keeper_name:string
   -> agent_name:string
-  -> cascade_name:Cascade_name.t
+  -> cascade_name:string
   -> trace_id:string
   -> generation:int
   -> failure_reason:Keeper_registry.failure_reason option
@@ -334,7 +334,7 @@ val emit_stale_keeper_broadcast
   :  Coord.config
   -> keeper_name:string
   -> agent_name:string
-  -> cascade_name:Cascade_name.t
+  -> cascade_name:string
   -> trace_id:string
   -> generation:int
   -> failure_reason:Keeper_registry.failure_reason option

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -228,7 +228,7 @@ type t =
   ; degraded_retry_cascade : Cascade_name.t option
   ; fallback_reason : Keeper_error_classify.degraded_retry_reason option
   ; cascade_rotation_attempts : cascade_rotation_attempt list
-  ; stop_reason : Cascade_runner.stop_reason option
+  ; stop_reason : Runtime_agent.stop_reason option
   ; error_kind : error_kind option
   ; error_message : string option
   ; started_at : string
@@ -242,7 +242,7 @@ type t =
   ; pre_dispatch_compaction_after_tokens : int option
   }
 
-val stop_reason_to_string : Cascade_runner.stop_reason -> string
+val stop_reason_to_string : Runtime_agent.stop_reason -> string
 val sandbox_kind_of_meta : Keeper_meta_contract.keeper_meta -> Keeper_types_profile_sandbox.sandbox_profile
 val to_json : t -> Yojson.Safe.t
 

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -261,8 +261,8 @@ let decode_contract_violation_reason (wire : string)
 ;;
 
 type cascade_rotation_attempt =
-  { from_cascade : Cascade_name.t
-  ; to_cascade : Cascade_name.t
+  { from_cascade : string
+  ; to_cascade : string
   ; reason : Keeper_error_classify.degraded_retry_reason
   ; outcome : cascade_rotation_outcome
   ; slot_release_at_phase : slot_release_phase option
@@ -301,14 +301,14 @@ type t =
   ; network_mode : Keeper_types_profile_sandbox.network_mode
   ; approval_profile : string option
   ; approval_profile_derived : bool
-  ; cascade_name : Cascade_name.t
+  ; cascade_name : string
   ; cascade_selected_model : string option
   ; cascade_attempt_count : int
   ; cascade_fallback_applied : bool
   ; cascade_outcome : cascade_outcome
   ; oas_internal_cascade_allowed : bool
   ; degraded_retry_applied : bool
-  ; degraded_retry_cascade : Cascade_name.t option
+  ; degraded_retry_cascade : string option
   ; fallback_reason : Keeper_error_classify.degraded_retry_reason option
   ; cascade_rotation_attempts : cascade_rotation_attempt list
   ; stop_reason : Runtime_agent.stop_reason option

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -311,7 +311,7 @@ type t =
   ; degraded_retry_cascade : Cascade_name.t option
   ; fallback_reason : Keeper_error_classify.degraded_retry_reason option
   ; cascade_rotation_attempts : cascade_rotation_attempt list
-  ; stop_reason : Cascade_runner.stop_reason option
+  ; stop_reason : Runtime_agent.stop_reason option
   ; error_kind : error_kind option
   ; error_message : string option
   ; started_at : string
@@ -326,10 +326,10 @@ type t =
   }
 
 let stop_reason_to_string = function
-  | Cascade_runner.Completed -> "completed"
-  | Cascade_runner.TurnBudgetExhausted { turns_used; limit } ->
+  | Runtime_agent.Completed -> "completed"
+  | Runtime_agent.TurnBudgetExhausted { turns_used; limit } ->
     Printf.sprintf "turn_budget_exhausted:%d/%d" turns_used limit
-  | Cascade_runner.MutationBoundaryReached { turns_used; tool_name } ->
+  | Runtime_agent.MutationBoundaryReached { turns_used; tool_name } ->
     (match tool_name with
      | Some tool -> Printf.sprintf "mutation_boundary:%s:%d" tool turns_used
      | None -> Printf.sprintf "mutation_boundary:%d" turns_used)

--- a/lib/keeper/keeper_execution_receipt_types.mli
+++ b/lib/keeper/keeper_execution_receipt_types.mli
@@ -79,8 +79,8 @@ val decode_tool_list : string -> string list option
 val decode_contract_violation_reason :
   string -> (string * string list * string list) option
 type cascade_rotation_attempt = {
-  from_cascade : Cascade_name.t;
-  to_cascade : Cascade_name.t;
+  from_cascade : string;
+  to_cascade : string;
   reason : Keeper_error_classify.degraded_retry_reason;
   outcome : cascade_rotation_outcome;
   slot_release_at_phase : slot_release_phase option;
@@ -118,14 +118,14 @@ type t = {
   network_mode : Keeper_types_profile_sandbox.network_mode;
   approval_profile : string option;
   approval_profile_derived : bool;
-  cascade_name : Cascade_name.t;
+  cascade_name : string;
   cascade_selected_model : string option;
   cascade_attempt_count : int;
   cascade_fallback_applied : bool;
   cascade_outcome : cascade_outcome;
   oas_internal_cascade_allowed : bool;
   degraded_retry_applied : bool;
-  degraded_retry_cascade : Cascade_name.t option;
+  degraded_retry_cascade : string option;
   fallback_reason :
     Keeper_error_classify.degraded_retry_reason option;
   cascade_rotation_attempts : cascade_rotation_attempt list;

--- a/lib/keeper/keeper_execution_receipt_types.mli
+++ b/lib/keeper/keeper_execution_receipt_types.mli
@@ -129,7 +129,7 @@ type t = {
   fallback_reason :
     Keeper_error_classify.degraded_retry_reason option;
   cascade_rotation_attempts : cascade_rotation_attempt list;
-  stop_reason : Cascade_runner.stop_reason option;
+  stop_reason : Runtime_agent.stop_reason option;
   error_kind : error_kind option;
   error_message : string option;
   started_at : string;
@@ -142,7 +142,7 @@ type t = {
   pre_dispatch_compaction_before_tokens : int option;
   pre_dispatch_compaction_after_tokens : int option;
 }
-val stop_reason_to_string : Cascade_runner.stop_reason -> string
+val stop_reason_to_string : Runtime_agent.stop_reason -> string
 val enrich_contract_violation_reason : t -> string
 val sandbox_kind_of_meta :
   Keeper_meta_contract.keeper_meta -> Keeper_types_profile_sandbox.sandbox_profile

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -477,7 +477,7 @@ let write_heartbeat_snapshot
          ~labels:[("keeper", meta_current.name)]
          ();
        Log.Keeper.error "heartbeat SSE broadcast failed: %s" (Printexc.to_string exn));
-    Cascade_events.publish_keeper_snapshot
+    Keeper_event_publisher.publish_keeper_snapshot
       ~keeper_name:meta_current.name
       ~generation:meta_current.runtime.generation
       ~context_ratio:context_ratio_v

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -82,7 +82,7 @@ let write_heartbeat_snapshot
   in
   let cascade_models =
     Cascade_runtime.models_of_cascade_name
-      (Cascade_name.of_string_exn (Keeper_meta_contract.cascade_name_of_meta meta_current))
+      ((Keeper_meta_contract.cascade_name_of_meta meta_current))
   in
   let max_cascade_context =
     let resolution =

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -546,7 +546,7 @@ let publish_keeper_lifecycle
       ()
   : unit
   =
-  Cascade_events.publish_keeper_lifecycle ~event ~keeper_name ~detail ()
+  Keeper_event_publisher.publish_keeper_lifecycle ~event ~keeper_name ~detail ()
 ;;
 
 (** Phase-event helper: the wire event name IS the phase name. *)

--- a/lib/keeper/keeper_lifecycle_audit.mli
+++ b/lib/keeper/keeper_lifecycle_audit.mli
@@ -13,7 +13,7 @@ val record :
   unit
 (** [record ~keeper_name ~event_name ~phase ~detail] appends an event to the
     per-keeper ring buffer.  Called by
-    [Cascade_events.publish_keeper_lifecycle] and the supervisor's
+    [Keeper_event_publisher.publish_keeper_lifecycle] and the supervisor's
     [publish_lifecycle] helper so every lifecycle event is captured. *)
 
 val recent_json : keeper_name:string -> limit:int -> Yojson.Safe.t

--- a/lib/keeper/keeper_lifecycle_events.ml
+++ b/lib/keeper/keeper_lifecycle_events.ml
@@ -1,9 +1,9 @@
 (** Issue #8575: SSOT for the [event] string emitted by
-    {!Cascade_events.publish_keeper_lifecycle}.
+    {!Keeper_event_publisher.publish_keeper_lifecycle}.
 
     The supervisor and keepalive together emit twelve distinct event
     names through that function. The docstring on
-    [Cascade_events.publish_keeper_lifecycle] previously listed only five
+    [Keeper_event_publisher.publish_keeper_lifecycle] previously listed only five
     of them, so operators reading the doc subscribed to the
     phase-derived events ([started] / [stopped] / [crashed] /
     [restarted] / [dead]) and silently missed the cleanup /
@@ -90,7 +90,7 @@ let all_event_names : string list =
     This sum type unifies the two pre-existing typed vocabularies
     ([t] for the custom verbs, [Keeper_state_machine.phase] for the
     4 phase-derived names) so the wire string is computed inside
-    [Cascade_events.publish_keeper_lifecycle] from a fully-typed argument.
+    [Keeper_event_publisher.publish_keeper_lifecycle] from a fully-typed argument.
     A typo at the call site is now a build error.
 
     Note: importing [Keeper_state_machine] here breaks the

--- a/lib/keeper/keeper_lifecycle_events.mli
+++ b/lib/keeper/keeper_lifecycle_events.mli
@@ -27,7 +27,7 @@ val all_event_names : string list
 
 (** {1 Unified lifecycle event sum type (#8856)}
 
-    Wire vocabulary for [Cascade_events.publish_keeper_lifecycle]. The
+    Wire vocabulary for [Keeper_event_publisher.publish_keeper_lifecycle]. The
     [Custom_event] case carries an optional phase context that the
     legacy [?phase] argument used to provide; [Phase_event] is the case
     where the wire event name IS the phase name. *)

--- a/lib/keeper/keeper_model_labels.ml
+++ b/lib/keeper/keeper_model_labels.ml
@@ -7,4 +7,4 @@ let configured_model_labels_of_meta (m : keeper_meta) : string list =
      [meta.models] and benchmark-canary labels are legacy hints and can carry
      stale provider strings across reconfiguration. *)
   Cascade_runtime.models_of_cascade_name
-    (Cascade_name.of_string_exn (cascade_name_of_meta m))
+    ((cascade_name_of_meta m))

--- a/lib/keeper/keeper_observation.ml
+++ b/lib/keeper/keeper_observation.ml
@@ -12,7 +12,7 @@
 (* ================================================================ *)
 
 type cascade_observation = {
-  cascade_name : Cascade_name.t;
+  cascade_name : string;
   strategy : string option;
   configured_labels : string list;
   candidate_models : string list;
@@ -417,7 +417,7 @@ let cascade_observation_with_metrics ~cascade_name ?strategy ~configured_labels
 
 let cascade_observation_to_json (obs : cascade_observation) : Yojson.Safe.t =
   let cascade_name =
-    Cascade_name.to_string obs.cascade_name
+    obs.cascade_name
   in
   `Assoc
     [
@@ -490,7 +490,7 @@ let keeper_name_to_json keeper_name =
 
 let cascade_audit_json ~now ~keeper_name ~cascade_name ~observation ~outcome =
   let cascade_name =
-    Cascade_name.to_string cascade_name
+    cascade_name
   in
   `Assoc
     [
@@ -508,7 +508,7 @@ let cascade_audit_json ~now ~keeper_name ~cascade_name ~observation ~outcome =
 let record_cascade_audit store_opt ~now ~keeper_name ~cascade_name ~observation
     ~outcome =
   let cascade_name_string =
-    Cascade_name.to_string cascade_name
+    cascade_name
   in
   match store_opt with
   | None -> ()
@@ -558,7 +558,7 @@ let attempt_model_display (attempt : cascade_attempt) =
 type msg =
   | Record_cascade of {
       keeper_name : string option;
-      cascade_name : Cascade_name.t;
+      cascade_name : string;
       observation : cascade_observation option;
       outcome : [ `Success | `Failure | `Rejected ];
       now : float;
@@ -575,7 +575,7 @@ let stream = Eio.Stream.create 1024
 
 let handle_record state ~now ~keeper_name ~cascade_name ~observation ~outcome =
   let cascade_name_string =
-    Cascade_name.to_string cascade_name
+    cascade_name
   in
   let counters = state.counters in
   let counter, counters, evicted =

--- a/lib/keeper/keeper_observation.ml
+++ b/lib/keeper/keeper_observation.ml
@@ -460,7 +460,7 @@ let get_cascade_audit_store store_opt =
           (* Iter 47: tick counter so audit-subsystem health is
              observable.  Audit failure here disables the subsystem
              for the process lifetime — operators need to know. *)
-          Cascade_metrics.on_cascade_audit_failure ~stage:"store_creation";
+          Runtime_metrics.on_cascade_audit_failure ~stage:"store_creation";
           Log.Misc.warn "cascade audit store creation failed: %s"
             (Printexc.to_string exn);
           None)
@@ -523,7 +523,7 @@ let record_cascade_audit store_opt ~now ~keeper_name ~cascade_name ~observation
           (* Iter 47: tick counter per-record append failure rate
              alertable.  Single-event audit loss compounds over
              time for post-incident analysis. *)
-          Cascade_metrics.on_cascade_audit_failure ~stage:"append";
+          Runtime_metrics.on_cascade_audit_failure ~stage:"append";
           Log.Misc.warn "cascade audit append failed cascade=%s error=%s"
             cascade_name_string (Printexc.to_string exn))
 
@@ -635,7 +635,7 @@ let handle_record state ~now ~keeper_name ~cascade_name ~observation ~outcome =
          alertable.  WARN log already prints per-eviction detail
          (cascade name, age, etc.); metric makes rate aggregation
          tractable. *)
-      Cascade_metrics.on_cascade_metrics_eviction ();
+      Runtime_metrics.on_cascade_metrics_eviction ();
       Log.Misc.warn
         "cascade metrics evicted key=%s calls=%d last_used_at=%.3f to admit %s (limit=%d)"
         candidate.name candidate.calls candidate.last_used_at cascade_name_string

--- a/lib/keeper/keeper_observation.mli
+++ b/lib/keeper/keeper_observation.mli
@@ -59,7 +59,7 @@ type cascade_fallback_event = {
 }
 
 type cascade_observation = {
-  cascade_name : Cascade_name.t;
+  cascade_name : string;
   strategy : string option;
   configured_labels : string list;
   candidate_models : string list;
@@ -155,7 +155,7 @@ val cascade_metrics_for_candidates :
     global [Llm_metric_bridge] when both are wired). *)
 
 val cascade_observation_with_metrics :
-  cascade_name:Cascade_name.t ->
+  cascade_name:string ->
   ?strategy:string ->
   configured_labels:string list ->
   candidate_count:int ->
@@ -194,7 +194,7 @@ val start_actor_if_needed : sw:Eio.Switch.t -> unit
 val record_cascade :
   ?keeper_name:string ->
   observation:cascade_observation option ->
-  cascade_name:Cascade_name.t ->
+  cascade_name:string ->
   outcome:[ `Success | `Failure | `Rejected ] ->
   unit ->
   unit

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -899,7 +899,7 @@ let handle_persona_generate ctx args =
                      "persona generation failed: %s"
                      (Agent_sdk.Error.to_string err)))
            | Ok result ->
-             let raw_text = Agent_sdk_response.text_of_response result.Cascade_runner.response in
+             let raw_text = Agent_sdk_response.text_of_response result.Runtime_agent.response in
              (try
                 let parsed = Llm_provider.Lenient_json.parse raw_text in
                 let handle = parsed_handle_payload fallback_handle parsed in

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -114,7 +114,7 @@ let prepare_run_context
     in
     resolution.Config_dir_resolver.config_root.path
   in
-  let cascade_config_path = Cascade_runtime.cascade_config_path () in
+  let cascade_config_path = Runtime.config_path () in
   let gemini_mcp_disabled = keeper_oas_context.gemini_mcp_disabled in
   let approval_mode_effective = keeper_oas_context.gemini_approval_mode in
   let approval_mode_derived = keeper_oas_context.gemini_approval_mode_derived in

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -40,7 +40,7 @@ let prepare_run_context
       ~(meta : keeper_meta)
       ~(base_dir : string)
       ~(max_context : int)
-      ~(cascade_name : Cascade_name.t)
+      ~(cascade_name : string)
       ?temperature
       ?max_tokens
       ?shared_context

--- a/lib/keeper/keeper_run_context.mli
+++ b/lib/keeper/keeper_run_context.mli
@@ -37,7 +37,7 @@ val prepare_run_context :
   -> meta:keeper_meta
   -> base_dir:string
   -> max_context:int
-  -> cascade_name:Cascade_name.t
+  -> cascade_name:string
   -> ?temperature:float
   -> ?max_tokens:int
   -> ?shared_context:Agent_sdk.Context.t

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -87,8 +87,8 @@ type agent_setup = Keeper_run_tools_hooks.agent_setup =
   ; tool_usage_before : (string * int) list
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
-  ; receipt_stop_reason_ref : Cascade_runner.stop_reason option ref
-  ; receipt_cascade_observation_ref : Cascade_observation.cascade_observation option ref
+  ; receipt_stop_reason_ref : Runtime_agent.stop_reason option ref
+  ; receipt_cascade_observation_ref : Keeper_observation.cascade_observation option ref
   ; receipt_response_text_present_ref : bool ref
   ; reported_tool_names_ref : string list ref
   ; observed_tool_names_ref : string list ref

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -124,7 +124,7 @@ val prepare_agent_setup
   -> start_turn_count:int
   -> generation:int
   -> max_turns:int
-  -> cascade_name:Cascade_name.t
+  -> cascade_name:string
   -> is_retry:bool
   -> turn_affordances:string list
   -> required_tool_names:string list

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -98,8 +98,8 @@ type agent_setup =
   ; tool_usage_before : (string * int) list
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
-  ; receipt_stop_reason_ref : Cascade_runner.stop_reason option ref
-  ; receipt_cascade_observation_ref : Cascade_observation.cascade_observation option ref
+  ; receipt_stop_reason_ref : Runtime_agent.stop_reason option ref
+  ; receipt_cascade_observation_ref : Keeper_observation.cascade_observation option ref
   ; receipt_response_text_present_ref : bool ref
   ; reported_tool_names_ref : string list ref
   ; observed_tool_names_ref : string list ref

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -24,8 +24,8 @@ type agent_setup =
   ; tool_usage_before : (string * int) list
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
-  ; receipt_stop_reason_ref : Cascade_runner.stop_reason option ref
-  ; receipt_cascade_observation_ref : Cascade_observation.cascade_observation option ref
+  ; receipt_stop_reason_ref : Runtime_agent.stop_reason option ref
+  ; receipt_cascade_observation_ref : Keeper_observation.cascade_observation option ref
   ; receipt_response_text_present_ref : bool ref
   ; reported_tool_names_ref : string list ref
   ; observed_tool_names_ref : string list ref
@@ -56,8 +56,8 @@ type ctx =
   ; actual_keeper_tool_names_ref : string list ref
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
-  ; receipt_stop_reason_ref : Cascade_runner.stop_reason option ref
-  ; receipt_cascade_observation_ref : Cascade_observation.cascade_observation option ref
+  ; receipt_stop_reason_ref : Runtime_agent.stop_reason option ref
+  ; receipt_cascade_observation_ref : Keeper_observation.cascade_observation option ref
   ; receipt_response_text_present_ref : bool ref
   ; tool_usage_before : (string * int) list
   ; tools : Agent_sdk.Tool.t list

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -25,7 +25,7 @@ let prepare_agent_setup
       ~(start_turn_count : int)
       ~(generation : int)
       ~(max_turns : int)
-      ~(cascade_name : Cascade_name.t)
+      ~(cascade_name : string)
       ~(is_retry : bool)
       ~(turn_affordances : string list)
       ~(required_tool_names : string list)
@@ -43,7 +43,7 @@ let prepare_agent_setup
       ()
   : (Keeper_run_tools_hooks.agent_setup, Agent_sdk.Error.sdk_error) result
   =
-  let cascade_name_string = Cascade_name.to_string cascade_name in
+  let cascade_name_string = cascade_name in
   let manifest_keeper_turn_id =
     match runtime_manifest_context with
     | Some ctx -> ctx.Keeper_runtime_manifest.manifest_keeper_turn_id

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -411,11 +411,11 @@ let prepare_agent_setup
   let actual_keeper_tool_names_ref : string list ref = ref [] in
   let receipt_turn_count_ref : int option ref = ref None in
   let receipt_model_used_ref : string option ref = ref None in
-  let receipt_stop_reason_ref : Cascade_runner.stop_reason option ref =
+  let receipt_stop_reason_ref : Runtime_agent.stop_reason option ref =
     ref None
   in
   let receipt_cascade_observation_ref
-    : Cascade_observation.cascade_observation option ref
+    : Keeper_observation.cascade_observation option ref
     =
     ref None
   in

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -333,7 +333,7 @@ let ensure_keeper_meta config name =
        register as a semantic change. *)
     let cascade_changed =
       Keeper_cascade_profile.normalize_declared_name (cascade_name_of_meta meta)
-      <> Cascade_name.to_string resolved_target_cascade_name
+      <> resolved_target_cascade_name
     in
     (* #10061: persisted state vs TOML source can differ by a single
        trailing newline when OCaml string literals round-trip through

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -56,7 +56,7 @@ val stream_idle_timeout_for_total_timeout : total_timeout_s:float -> float
 (** Total HTTP body-consumption deadline override.
     [None] (env unset) lets the cascade attempt fall back to the per-
     attempt [max_execution_time]. [Some s] is forwarded to
-    [Cascade_agent_context.body_timeout_s] -> [Builder.with_body_timeout],
+    [Runtime_agent_context.body_timeout_s] -> [Builder.with_body_timeout],
     surfacing [Retry.Timeout] before the turn cap so cascade falls
     forward at the attempt boundary.
 

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -539,8 +539,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                      ~keeper_name:meta.name
                      ~agent_name:meta.agent_name
                      ~cascade_name:
-                       (Cascade_name.of_string_exn
-                          (Keeper_meta_contract.cascade_name_of_meta meta))
+                       (                          (Keeper_meta_contract.cascade_name_of_meta meta))
                      ~trace_id:
                        (Keeper_id.Trace_id.to_string
                           entry.meta.runtime.trace_id)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -342,7 +342,7 @@ let sweep_and_recover (ctx : _ context) =
        let last_fr_str =
          Option.map Keeper_registry.failure_reason_to_string entry.last_failure_reason
        in
-       Cascade_events.publish_keeper_dead
+       Keeper_event_publisher.publish_keeper_dead
          ~keeper_name:entry.name
          ~reason:msg
          ~restart_count:entry.restart_count

--- a/lib/keeper/keeper_supervisor_publish_lifecycle.ml
+++ b/lib/keeper/keeper_supervisor_publish_lifecycle.ml
@@ -32,7 +32,7 @@ let publish_lifecycle
   in
   (* #12798: record in the per-keeper lifecycle audit ring for dashboard. *)
   Keeper_lifecycle_audit.record ~keeper_name ~event_name ~phase ~detail;
-  Cascade_events.publish_keeper_lifecycle ~event ~keeper_name ~detail ()
+  Keeper_event_publisher.publish_keeper_lifecycle ~event ~keeper_name ~detail ()
 ;;
 
 (** Phase-event helper: the wire event name IS the phase name. *)

--- a/lib/keeper/keeper_supervisor_startup_helpers.ml
+++ b/lib/keeper/keeper_supervisor_startup_helpers.ml
@@ -16,8 +16,8 @@ let keep_last_n n item lst =
 
 let committed_tools_of_ambiguous_blocker (blocker : string) =
   let trimmed = String.trim blocker in
-  match Cascade_error_classify.classify_masc_internal_error_of_string trimmed with
-  | Some (Cascade_error_classify.Ambiguous_post_commit { tools; _ }) -> tools
+  match Keeper_meta_contract.classify_masc_internal_error_of_string trimmed with
+  | Some (Keeper_meta_contract.Ambiguous_post_commit { tools; _ }) -> tools
   | _ ->
     (* Legacy: extract from bracket notation "prefix: [tool1, tool2]; ..." *)
     (match String.index_opt trimmed '[' with

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -150,15 +150,14 @@ let preflight_keeper_msg ctx args : (unit, string) result =
         (match
            Keeper_cascade_resilience.cascade_resilience_error_message
              (Keeper_cascade_resilience.cascade_resilience_of_name
-                (Cascade_name.to_string turn_cascade_name))
+                (turn_cascade_name))
          with
          | Some e -> Error e
          | None ->
         let effective_models =
           if direct_reply then
             Cascade_runtime.models_of_cascade_name
-              (Cascade_name.of_string_exn
-                 (Cascade_name.to_string turn_cascade_name))
+              (                 (turn_cascade_name))
           else
             effective_model_labels_for_turn meta
         in
@@ -230,7 +229,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       (match
          Keeper_cascade_resilience.cascade_resilience_error_message
            (Keeper_cascade_resilience.cascade_resilience_of_name
-              (Cascade_name.to_string turn_cascade_name))
+              (turn_cascade_name))
        with
        | Some e ->
          Progress.stop_tracking turn_task_id;
@@ -252,8 +251,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       let effective_models =
         if direct_reply then
           Cascade_runtime.models_of_cascade_name
-            (Cascade_name.of_string_exn
-               (Cascade_name.to_string turn_cascade_name))
+            (               (turn_cascade_name))
               else
           effective_model_labels_for_turn meta
       in
@@ -498,8 +496,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     ~build_turn_prompt
                     ~user_message:message
                     ~cascade_name:
-                      (Cascade_name.of_string_exn
-                         (Cascade_name.to_string turn_cascade_name))
+                      (                         (turn_cascade_name))
                     ~world_observation
                     ~turn_affordances
                     ~required_tool_names

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -100,8 +100,8 @@ let run_named
   let cascade_name =
     Keeper_cascade_profile.normalize_declared_name cascade_name
   in
-  let error_cascade_name = Cascade_name.of_string_exn cascade_name in
-  let runtime_cascade_name = Cascade_name.of_string_exn cascade_name in
+  let error_cascade_name = cascade_name in
+  let runtime_cascade_name = cascade_name in
   let runtime_mcp_policy = runtime_mcp_policy_for_tools ~keeper_name tools in
   (* Keeper-internal tools cannot degrade to a text-only CLI palette: the
      model would see no callable schema and emit misleading diagnostics. *)
@@ -824,7 +824,7 @@ let run_named
   let record_trace ~cycle ~candidates_out ~backoff_ms ~kind =
     Cascade_strategy_trace.record {
       ts = Unix.gettimeofday ();
-      cascade_name = Cascade_name.of_string_exn cascade_name;
+      cascade_name = cascade_name;
       strategy = strategy_name;
       cycle;
       candidates_in = List.length candidates;
@@ -876,7 +876,7 @@ let run_named
          cycle_loop (n + 1))
   in
   let admission_cascade_name =
-    Cascade_name.of_string_exn cascade_name
+    cascade_name
   in
   match Admission_queue.with_permit ?wait_timeout_sec
     ~priority:queue_priority ~keeper_name:name ~cascade_name:admission_cascade_name

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -13,7 +13,7 @@ open Cascade_name
 (* Sub-module includes (God file decomposition).
    Each sub-module is self-contained; the facade re-exports everything
    so existing callers do not need qualification. *)
-include Cascade_oas_runner
+include Runtime_oas_runner
 include Cascade_error_classify
 include Cascade_attempt_fsm
 include Keeper_turn_driver_helpers
@@ -89,7 +89,7 @@ let run_named
     ?net
     ?per_provider_timeout_s
     ()
-  : (Cascade_runner.run_result, Agent_sdk.Error.sdk_error) result =
+  : (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result =
   let cascade_engine = Keeper_cascade_engine.keeper_managed in
   match Keeper_cascade_engine.guard_keeper_hot_path cascade_engine with
   | Error msg -> Error (Agent_sdk.Error.Internal msg)
@@ -177,12 +177,12 @@ let run_named
                reason;
              kept,
              ({ provider_label; reason }
-               : Cascade_error_classify.provider_rejection)
+               : Keeper_meta_contract.provider_rejection)
              :: rejected
            in
            match
              Cascade_runtime_candidate.resolve_tool_lane_for_oas_tools
-               ?agent_name:(Cascade_oas_runner.keeper_agent_name_opt keeper_name)
+               ?agent_name:(Runtime_oas_runner.keeper_agent_name_opt keeper_name)
                ~tool_requirement:`Required
                ~tools
                candidate
@@ -260,7 +260,7 @@ let run_named
   in
   (* RFC: MASC/OAS Error-Warn Reduction Goal — 2026-05-18 §P3.
      For each unhealthy endpoint, record the preflight-skip event in
-     [Cascade_preflight_state.global]. After N consecutive skips of
+     [Keeper_preflight_health_tracker.global]. After N consecutive skips of
      the same (cascade, endpoint, reason) fingerprint we escalate to
      ERROR once and register the endpoint in the in-process disabled
      list — subsequent identical skips return [`Already_disabled] and
@@ -273,11 +273,11 @@ let run_named
   List.iter
     (fun endpoint ->
       let outcome =
-        Cascade_preflight_state.record
-          Cascade_preflight_state.global
+        Keeper_preflight_health_tracker.record
+          Keeper_preflight_health_tracker.global
           ~cascade_name
           ~provider:endpoint
-          ~reason:Cascade_preflight_state.Health_check_failed_repeatedly
+          ~reason:Keeper_preflight_health_tracker.Health_check_failed_repeatedly
       in
       match outcome with
       | `First ->
@@ -286,16 +286,16 @@ let run_named
            provider dispatch: [%s] (reason=%s, first occurrence)"
           cascade_name
           endpoint
-          (Cascade_preflight_state.reason_slug
-             Cascade_preflight_state.Health_check_failed_repeatedly)
+          (Keeper_preflight_health_tracker.reason_slug
+             Keeper_preflight_health_tracker.Health_check_failed_repeatedly)
       | `Repeated n ->
         Log.Misc.warn
           "cascade %s: preflight skipped 1 unhealthy local endpoint(s) before \
            provider dispatch: [%s] (reason=%s, consecutive=%d)"
           cascade_name
           endpoint
-          (Cascade_preflight_state.reason_slug
-             Cascade_preflight_state.Health_check_failed_repeatedly)
+          (Keeper_preflight_health_tracker.reason_slug
+             Keeper_preflight_health_tracker.Health_check_failed_repeatedly)
           n
       | `Threshold_disable n ->
         Log.Misc.error
@@ -305,8 +305,8 @@ let run_named
           cascade_name
           endpoint
           n
-          (Cascade_preflight_state.reason_slug
-             Cascade_preflight_state.Health_check_failed_repeatedly)
+          (Keeper_preflight_health_tracker.reason_slug
+             Keeper_preflight_health_tracker.Health_check_failed_repeatedly)
       | `Already_disabled ->
         (* Drop noise: this endpoint is in the disabled list and has
            already emitted its ERROR escalation. *)
@@ -319,12 +319,12 @@ let run_named
   List.iter
     (fun (url, healthy) ->
       if healthy
-         && Cascade_preflight_state.is_disabled
-              Cascade_preflight_state.global ~provider:url
+         && Keeper_preflight_health_tracker.is_disabled
+              Keeper_preflight_health_tracker.global ~provider:url
       then
         let recovered =
-          Cascade_preflight_state.reset_on_health_recovery
-            Cascade_preflight_state.global ~provider:url
+          Keeper_preflight_health_tracker.reset_on_health_recovery
+            Keeper_preflight_health_tracker.global ~provider:url
         in
         if recovered
         then
@@ -495,7 +495,7 @@ let run_named
             ; required_tool_names
             ; provider_rejections =
                 List.map
-                  (fun (r : Cascade_internal_error.provider_rejection) ->
+                  (fun (r : Keeper_meta_contract.provider_rejection) ->
                      (r.provider_label, r.reason))
                   provider_rejections
             }
@@ -516,7 +516,7 @@ let run_named
        | Some manifest_ctx, Some append ->
          let provider_rejection_reasons =
            provider_rejections
-           |> List.map (fun (r : Cascade_error_classify.provider_rejection) ->
+           |> List.map (fun (r : Keeper_meta_contract.provider_rejection) ->
                   r.reason)
            |> Json_util.dedupe_keep_order
          in
@@ -582,7 +582,7 @@ let run_named
   | _ ->
   let candidate_count = List.length candidates in
   let capture, _metrics =
-    Cascade_observation.cascade_metrics_for_candidates ~candidate_count ()
+    Keeper_observation.cascade_metrics_for_candidates ~candidate_count ()
   in
   let cascade_strategy_name_ref = ref None in
   let name = Printf.sprintf "oas-%s" cascade_name in
@@ -709,7 +709,7 @@ let run_named
     match Eio_context.get_clock_opt () with
     | Some clock ->
         let turn_budget = Keeper_runtime_resolved.turn_timeout_sec () in
-        Some (Cascade_deadline.of_seconds_from_now ~clock turn_budget)
+        Some (Runtime_deadline.of_seconds_from_now ~clock turn_budget)
     | None -> None
   in
   let try_cascade_ctx : Keeper_turn_driver_try_cascade.try_cascade_ctx = {
@@ -781,7 +781,7 @@ let run_named
   let _ = sw, net in
   let adapter = Cascade_runtime_candidate.strategy_adapter in
   let signal_ctx : Cascade_strategy.signal_ctx = {
-    health = Cascade_health_tracker.global;
+    health = Keeper_binding_health.global;
     capacity = Cascade_capacity_probe.capacity;
     now = Unix.gettimeofday ();
     rand_int = Random.int;
@@ -805,12 +805,12 @@ let run_named
   in
   let cascade_exhausted_after_filter ~cycle =
     let observation =
-      Cascade_observation.cascade_observation_with_metrics
+      Keeper_observation.cascade_observation_with_metrics
         ~cascade_name:error_cascade_name
         ?strategy:!cascade_strategy_name_ref ~configured_labels
         ~candidate_count ~selected_model_raw:error_selected_model_raw ~capture ()
     in
-    Cascade_observation.record_cascade ~keeper_name
+    Keeper_observation.record_cascade ~keeper_name
       ~cascade_name:error_cascade_name
       ~outcome:`Failure ~observation:(Some observation) ();
     Error

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -128,7 +128,7 @@ val run_named :
   ?on_resume:(unit -> unit) ->
   ?agent_ref:Agent_sdk.Agent.t option ref ->
   ?transport:Masc_grpc_transport.t ->
-  ?cli_transport_overrides:Cascade_runner.cli_transport_overrides ->
+  ?cli_transport_overrides:Runtime_agent.cli_transport_overrides ->
   ?allowed_paths:string list ->
   ?checkpoint_sidecar:Yojson.Safe.t ->
   ?cache_system_prompt:bool ->
@@ -142,7 +142,7 @@ val run_named :
   ?enable_thinking:bool ->
   ?approval:Agent_sdk.Hooks.approval_callback ->
   ?exit_condition:(int -> bool) ->
-  ?exit_condition_result:(int -> Cascade_runner.stop_reason * string option) ->
+  ?exit_condition_result:(int -> Runtime_agent.stop_reason * string option) ->
   ?summarizer:(Agent_sdk.Types.message list -> string) ->
   ?oas_checkpoint:Agent_sdk.Checkpoint.t ->
   ?event_bus:Agent_sdk.Event_bus.t ->
@@ -153,7 +153,7 @@ val run_named :
   ?net:Eio_context.eio_net ->
   ?per_provider_timeout_s:float ->
   unit ->
-  (Cascade_runner.run_result, Agent_sdk.Error.sdk_error) result
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
 (** Run a single [Agent.run] call with MASC-driven cascade model fallback.
     MASC drives the cascade FSM directly: resolves cascade providers,
     tries each with OAS, and uses [Cascade_fsm.decide] on failure.

--- a/lib/keeper/keeper_turn_driver_backpressure.ml
+++ b/lib/keeper/keeper_turn_driver_backpressure.ml
@@ -13,7 +13,7 @@ open Cascade_name
    preserved: telemetry shows the value with a synthetic flag rather than a
    laundered explicit hint. *)
 let synthetic_retry_after_sec =
-  Cascade_health_tracker_config.default_capacity_backpressure_backoff_sec
+  Keeper_binding_health_config.default_capacity_backpressure_backoff_sec
 
 let capacity_backpressure_source_of_http_error = function
   | Llm_provider.Http_client.NetworkError

--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -14,7 +14,7 @@ val capacity_backpressure_source_of_http_error :
     when the error indicates capacity exhaustion. *)
 val capacity_backpressure_of_http_error :
   ?source:Keeper_meta_contract.capacity_backpressure_source ->
-  cascade_name:Cascade_name.t ->
+  cascade_name:string ->
   Llm_provider.Http_client.http_error option ->
   Keeper_meta_contract.masc_internal_error option
 
@@ -24,7 +24,7 @@ val capacity_backpressure_of_http_error :
     [No_retry_hint]) so a synthetic default is never read as an explicit
     hint. *)
 val capacity_backpressure_of_pending :
-  cascade_name:Cascade_name.t ->
+  cascade_name:string ->
   (Keeper_meta_contract.capacity_backpressure_source * string
    * Keeper_meta_contract.capacity_retry_after) option ->
   Keeper_meta_contract.masc_internal_error option
@@ -33,7 +33,7 @@ val capacity_backpressure_of_pending :
     when the error indicates provider capacity exhaustion or a
     backpressure-like internal message. *)
 val capacity_backpressure_of_sdk_error :
-  cascade_name:Cascade_name.t ->
+  cascade_name:string ->
   message_looks_like_capacity_backpressure:(string -> bool) ->
   sdk_error_of_masc_internal_error:(Keeper_meta_contract.masc_internal_error ->
                                     Agent_sdk.Error.sdk_error) ->

--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -8,15 +8,15 @@
 (** Classify an HTTP error into a backpressure source, if applicable. *)
 val capacity_backpressure_source_of_http_error :
   Llm_provider.Http_client.http_error ->
-  Cascade_internal_error.capacity_backpressure_source option
+  Keeper_meta_contract.capacity_backpressure_source option
 
 (** Build a capacity-backpressure internal error from an HTTP error,
     when the error indicates capacity exhaustion. *)
 val capacity_backpressure_of_http_error :
-  ?source:Cascade_internal_error.capacity_backpressure_source ->
+  ?source:Keeper_meta_contract.capacity_backpressure_source ->
   cascade_name:Cascade_name.t ->
   Llm_provider.Http_client.http_error option ->
-  Cascade_internal_error.masc_internal_error option
+  Keeper_meta_contract.masc_internal_error option
 
 (** Build a capacity-backpressure internal error from a pending
     backpressure triple [(source, detail, retry_after)].  The retry-after
@@ -25,9 +25,9 @@ val capacity_backpressure_of_http_error :
     hint. *)
 val capacity_backpressure_of_pending :
   cascade_name:Cascade_name.t ->
-  (Cascade_internal_error.capacity_backpressure_source * string
-   * Cascade_internal_error.capacity_retry_after) option ->
-  Cascade_internal_error.masc_internal_error option
+  (Keeper_meta_contract.capacity_backpressure_source * string
+   * Keeper_meta_contract.capacity_retry_after) option ->
+  Keeper_meta_contract.masc_internal_error option
 
 (** Classify an SDK error into a capacity-backpressure error,
     when the error indicates provider capacity exhaustion or a
@@ -35,7 +35,7 @@ val capacity_backpressure_of_pending :
 val capacity_backpressure_of_sdk_error :
   cascade_name:Cascade_name.t ->
   message_looks_like_capacity_backpressure:(string -> bool) ->
-  sdk_error_of_masc_internal_error:(Cascade_internal_error.masc_internal_error ->
+  sdk_error_of_masc_internal_error:(Keeper_meta_contract.masc_internal_error ->
                                     Agent_sdk.Error.sdk_error) ->
   Agent_sdk.Error.sdk_error ->
   Agent_sdk.Error.sdk_error option

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -112,7 +112,7 @@ let provider_rejection_for_required_tool_unsupported ~provider_label
          provider_label
          (String.concat ", " missing_required_tools);
    }
-    : Cascade_error_classify.provider_rejection)
+    : Keeper_meta_contract.provider_rejection)
 
 let no_tool_capable_provider_of_pre_dispatch_rejections ~cascade_name
     ~configured_labels ~runtime_manifest_required_tool_names ~runtime_mcp_policy
@@ -133,13 +133,13 @@ let no_tool_capable_provider_of_pre_dispatch_rejections ~cascade_name
         ; required_tool_names
         ; provider_rejections =
             List.map
-              (fun (r : Cascade_error_classify.provider_rejection) ->
+              (fun (r : Keeper_meta_contract.provider_rejection) ->
                  (r.provider_label, r.reason))
               rejections
         }
       in
       Some
-        (Cascade_error_classify.Cascade_exhausted
+        (Keeper_meta_contract.Cascade_exhausted
            {
              cascade_name;
              reason = Keeper_meta_contract.No_tool_capable (Some detail);
@@ -188,7 +188,7 @@ let provider_rejections_for_no_tool_error
                   Cascade_runtime_candidate.provider_label candidate;
                 reason;
               }
-               : Cascade_error_classify.provider_rejection))
+               : Keeper_meta_contract.provider_rejection))
 
 let apply_stream_idle_timeout_default = function
   | Some _ as v -> v

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -38,7 +38,7 @@ val required_tool_lane_unavailable_error :
 val provider_rejection_for_required_tool_unsupported :
   provider_label:string ->
   missing_required_tools:string list ->
-  Cascade_error_classify.provider_rejection
+  Keeper_meta_contract.provider_rejection
 
 val no_tool_capable_provider_of_pre_dispatch_rejections :
   cascade_name:Cascade_name.t ->
@@ -46,9 +46,9 @@ val no_tool_capable_provider_of_pre_dispatch_rejections :
   runtime_manifest_required_tool_names:string list ->
   runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option ->
   tools:Agent_sdk.Tool.t list ->
-  required_lane_provider_rejections:Cascade_error_classify.provider_rejection list ->
-  pre_dispatch_provider_rejections:Cascade_error_classify.provider_rejection list ->
-  Cascade_error_classify.masc_internal_error option
+  required_lane_provider_rejections:Keeper_meta_contract.provider_rejection list ->
+  pre_dispatch_provider_rejections:Keeper_meta_contract.provider_rejection list ->
+  Keeper_meta_contract.masc_internal_error option
 
 type empty_candidate_classification =
   | Tool_capability_empty
@@ -83,7 +83,7 @@ val provider_rejections_for_no_tool_error :
   require_tool_choice_support:bool ->
   require_tool_support:bool ->
   Cascade_runtime_candidate.t list ->
-  Cascade_error_classify.provider_rejection list
+  Keeper_meta_contract.provider_rejection list
 
 val apply_stream_idle_timeout_default : float option -> float option
 

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -41,7 +41,7 @@ val provider_rejection_for_required_tool_unsupported :
   Keeper_meta_contract.provider_rejection
 
 val no_tool_capable_provider_of_pre_dispatch_rejections :
-  cascade_name:Cascade_name.t ->
+  cascade_name:string ->
   configured_labels:string list ->
   runtime_manifest_required_tool_names:string list ->
   runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option ->

--- a/lib/keeper/keeper_turn_driver_named_resolution.mli
+++ b/lib/keeper/keeper_turn_driver_named_resolution.mli
@@ -16,6 +16,6 @@ val resolve :
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   ?provider_filter:string list ->
   cascade_name:string ->
-  runtime_cascade_name:Cascade_name.t ->
+  runtime_cascade_name:string ->
   unit ->
   t

--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -141,13 +141,13 @@ let success_selected_model_raw candidate =
 let error_selected_model_raw = None
 
 let health_error_kind label =
-  Cascade_health_tracker.error_kind_of_string label
+  Keeper_binding_health.error_kind_of_string label
 
 let record_candidate_health_success candidate ~latency_ms =
   Cascade_runtime_candidate.health_keys candidate
   |> List.iter (fun provider_key ->
-    Cascade_health_tracker.record_success
-      Cascade_health_tracker.global
+    Keeper_binding_health.record_success
+      Keeper_binding_health.global
       ~provider_key
       ~latency_ms
       ())
@@ -156,8 +156,8 @@ let record_candidate_health_rejected candidate ~reason =
   let error_kind = health_error_kind "accept_rejected" in
   Cascade_runtime_candidate.health_keys candidate
   |> List.iter (fun provider_key ->
-    Cascade_health_tracker.record_rejected
-      Cascade_health_tracker.global
+    Keeper_binding_health.record_rejected
+      Keeper_binding_health.global
       ~provider_key
       ~error_kind
       ~error_reason:reason
@@ -171,8 +171,8 @@ let record_candidate_health_error candidate sdk_err =
     let error_kind = health_error_kind "hard_quota" in
     health_keys
     |> List.iter (fun provider_key ->
-      Cascade_health_tracker.record_hard_quota
-        Cascade_health_tracker.global
+      Keeper_binding_health.record_hard_quota
+        Keeper_binding_health.global
         ~provider_key
         ~error_kind
         ~error_reason
@@ -182,8 +182,8 @@ let record_candidate_health_error candidate sdk_err =
     let error_kind = health_error_kind "terminal_provider_runtime_failure" in
     health_keys
     |> List.iter (fun provider_key ->
-      Cascade_health_tracker.record_terminal_failure
-        Cascade_health_tracker.global
+      Keeper_binding_health.record_terminal_failure
+        Keeper_binding_health.global
         ~provider_key
         ~error_kind
         ~error_reason
@@ -193,8 +193,8 @@ let record_candidate_health_error candidate sdk_err =
     let error_kind = health_error_kind "required_tool_contract_violation" in
     health_keys
     |> List.iter (fun provider_key ->
-      Cascade_health_tracker.record_terminal_failure
-        Cascade_health_tracker.global
+      Keeper_binding_health.record_terminal_failure
+        Keeper_binding_health.global
         ~provider_key
         ~error_kind
         ~error_reason
@@ -205,8 +205,8 @@ let record_candidate_health_error candidate sdk_err =
       let error_kind = health_error_kind "soft_rate_limited" in
       health_keys
       |> List.iter (fun provider_key ->
-        Cascade_health_tracker.record_soft_rate_limited
-          Cascade_health_tracker.global
+        Keeper_binding_health.record_soft_rate_limited
+          Keeper_binding_health.global
           ~provider_key
           ?retry_after_s
           ~error_kind
@@ -216,8 +216,8 @@ let record_candidate_health_error candidate sdk_err =
       let error_kind = health_error_kind "provider_error" in
       health_keys
       |> List.iter (fun provider_key ->
-        Cascade_health_tracker.record_failure
-          Cascade_health_tracker.global
+        Keeper_binding_health.record_failure
+          Keeper_binding_health.global
           ~provider_key
           ~error_kind
           ~error_reason

--- a/lib/keeper/keeper_turn_driver_provider_attempt.mli
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.mli
@@ -54,7 +54,7 @@ val success_selected_model_raw :
   Cascade_runtime_candidate.t -> string option
 
 val error_selected_model_raw : string option
-val health_error_kind : string -> Cascade_health_tracker.error_kind
+val health_error_kind : string -> Keeper_binding_health.error_kind
 
 val record_candidate_health_success :
   Cascade_runtime_candidate.t -> latency_ms:float -> unit

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -46,7 +46,7 @@ type try_provider_ctx =
   ; raw_trace : Agent_sdk.Raw_trace.t option
   ; (* Transport *)
     transport_resolved : Masc_grpc_transport.t
-  ; cli_transport_overrides : Cascade_runner.cli_transport_overrides option
+  ; cli_transport_overrides : Runtime_agent.cli_transport_overrides option
   ; runtime_mcp_policy : Llm_provider.Llm_transport.runtime_mcp_policy option
   ; (* Session / checkpoint *)
     allowed_paths : string list
@@ -62,7 +62,7 @@ type try_provider_ctx =
   ; enable_thinking : bool option
   ; approval : Agent_sdk.Hooks.approval_callback option
   ; exit_condition : (int -> bool) option
-  ; exit_condition_result : (int -> Cascade_runner.stop_reason * string option) option
+  ; exit_condition_result : (int -> Runtime_agent.stop_reason * string option) option
   ; summarizer : (Agent_sdk.Types.message list -> string) option
   ; oas_checkpoint : Agent_sdk.Checkpoint.t option
   ; (* Eio concurrency *)
@@ -198,7 +198,7 @@ let run_try_provider
   let config_result =
     match
       Cascade_runtime_candidate.resolve_tool_lane_for_oas_tools
-        ?agent_name:(Cascade_oas_runner.keeper_agent_name_opt ctx.keeper_name)
+        ?agent_name:(Runtime_oas_runner.keeper_agent_name_opt ctx.keeper_name)
         ~tool_requirement:
           (if ctx.require_tool_choice_support || ctx.require_tool_support
            then `Required
@@ -352,15 +352,15 @@ let run_try_provider
   match config_result with
   | Error err -> Error err, None, None
   | Ok config ->
-    let liveness_mode = Cascade_attempt_liveness_config.current_mode () in
+    let liveness_mode = Keeper_attempt_liveness_config.current_mode () in
     (* MASC stores one neutral runtime-lane budget; concrete provider/model
        identities remain on the OAS side.  Prometheus receives only the public,
        bounded provider bucket for TTFT/inter-chunk grouping. *)
-    let candidate_key = Cascade_attempt_liveness_config.runtime_candidate_key in
+    let candidate_key = Keeper_attempt_liveness_config.runtime_candidate_key in
     let provider_label = Cascade_runtime_candidate.provider_label candidate in
     let liveness_observer_opt =
       match liveness_mode with
-      | Cascade_attempt_liveness_config.Off ->
+      | Keeper_attempt_liveness_config.Off ->
         (* RFC-0095 Phase 0 diagnostic trace — capture Off-mode turns. Combined with
            the existing Observe/Enforce-branch log below, this gives full visibility
            into whether the streaming master switch is the gating factor for
@@ -372,23 +372,23 @@ let run_try_provider
           provider_label
           candidate_key;
         None
-      | Cascade_attempt_liveness_config.Observe | Cascade_attempt_liveness_config.Enforce
+      | Keeper_attempt_liveness_config.Observe | Keeper_attempt_liveness_config.Enforce
         ->
         let resolved_budget =
-          Cascade_attempt_liveness_config.budget_for_candidate ~candidate_key
+          Keeper_attempt_liveness_config.budget_for_candidate ~candidate_key
         in
         Log.Misc.debug
           "cascade_attempt_liveness: candidate=%s provider=%s budget_source=%s ttft=%.1fs \
            inter_chunk=%.1fs wall=%.1fs"
           candidate_key
           provider_label
-          (Cascade_attempt_liveness_config.budget_source_label
+          (Keeper_attempt_liveness_config.budget_source_label
              resolved_budget.source)
-          resolved_budget.budget.Cascade_attempt_liveness.ttft_max
-          resolved_budget.budget.Cascade_attempt_liveness.inter_chunk_max
-          resolved_budget.budget.Cascade_attempt_liveness.attempt_wall_max;
+          resolved_budget.budget.Keeper_attempt_liveness.ttft_max
+          resolved_budget.budget.Keeper_attempt_liveness.inter_chunk_max
+          resolved_budget.budget.Keeper_attempt_liveness.attempt_wall_max;
         let obs =
-          Cascade_attempt_liveness_observer.create
+          Keeper_attempt_liveness_observer.create
             ~mode:liveness_mode
             ~budget:resolved_budget.budget
             ~cascade_label:ctx.cascade_name
@@ -405,16 +405,16 @@ let run_try_provider
     let finalize_liveness () =
       match liveness_observer_opt with
       | None -> ()
-      | Some obs -> Cascade_attempt_liveness_observer.finalize obs
+      | Some obs -> Keeper_attempt_liveness_observer.finalize obs
     in
     let liveness_success_sample () =
       match liveness_observer_opt with
       | None -> None
       | Some obs ->
-        Cascade_attempt_liveness_observer.success_sample_for_candidate obs
+        Keeper_attempt_liveness_observer.success_sample_for_candidate obs
     in
     let liveness_timeout_error failure =
-      let kind = Cascade_attempt_liveness.failure_kind_label failure in
+      let kind = Keeper_attempt_liveness.failure_kind_label failure in
       Agent_sdk.Error.Api
         (Timeout
            { message =
@@ -428,20 +428,20 @@ let run_try_provider
       let stop_liveness_tick () =
         match liveness_observer_opt with
         | None -> ()
-        | Some obs -> Cascade_attempt_liveness_observer.stop_tick_fiber obs
+        | Some obs -> Keeper_attempt_liveness_observer.stop_tick_fiber obs
       in
       let run_attempt () =
         try
           Eio.Switch.run (fun attempt_sw ->
             (match liveness_observer_opt with
              | Some obs ->
-               Cascade_attempt_liveness_observer.register_attempt_switch
+               Keeper_attempt_liveness_observer.register_attempt_switch
                  obs
                  ~sw:attempt_sw
              | None -> ());
             (match liveness_observer_opt, Eio_context.get_clock_opt () with
              | Some obs, Some clock ->
-               Cascade_attempt_liveness_observer.start_tick_fiber
+               Keeper_attempt_liveness_observer.start_tick_fiber
                  obs
                  ~sw:attempt_sw
                  ~clock
@@ -451,7 +451,7 @@ let run_try_provider
               match liveness_observer_opt with
               | None -> ctx.on_event
               | Some obs ->
-                Cascade_attempt_liveness_observer.wrap_on_event obs ctx.on_event
+                Keeper_attempt_liveness_observer.wrap_on_event obs ctx.on_event
             in
             match f ~attempt_sw ~liveness_on_event with
             | result ->
@@ -462,7 +462,7 @@ let run_try_provider
               stop_liveness_tick ();
               Printexc.raise_with_backtrace exn bt)
         with
-        | Cascade_attempt_liveness_observer.Liveness_kill failure ->
+        | Keeper_attempt_liveness_observer.Liveness_kill failure ->
           Error (liveness_timeout_error failure)
         | Eio.Cancel.Cancelled _ as e -> raise e
       in
@@ -490,7 +490,7 @@ let run_try_provider
                 in
                 let run_fn () =
                   Eio_guard.check_if_ready ();
-                  Cascade_runner.run
+                  Runtime_agent.run
                     ~sw:attempt_sw
                     ~net:ctx.net
                     ~config
@@ -502,7 +502,7 @@ let run_try_provider
                     ctx.goal
                 in
                 let outer_wall_for_provider =
-                  Cascade_attempt_liveness_config.outer_wall_for_attempt
+                  Keeper_attempt_liveness_config.outer_wall_for_attempt
                     ~mode:liveness_mode
                     ~observer_attached:(Option.is_some liveness_observer_opt)
                     ~per_provider_timeout_s

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -18,7 +18,7 @@ open Result.Syntax
 type try_provider_ctx =
   { (* Cascade identity *)
     cascade_name : string
-  ; error_cascade_name : Cascade_name.t
+  ; error_cascade_name : string
   ; keeper_name : string
   ; name : string
   ; (* Agent config — fields passed through the runtime candidate boundary. *)

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -29,7 +29,7 @@ type try_provider_ctx =
       Agent_sdk.Completion_contract.required_tool_satisfaction
   ; raw_trace : Agent_sdk.Raw_trace.t option
   ; transport_resolved : Masc_grpc_transport.t
-  ; cli_transport_overrides : Cascade_runner.cli_transport_overrides option
+  ; cli_transport_overrides : Runtime_agent.cli_transport_overrides option
   ; runtime_mcp_policy : Llm_provider.Llm_transport.runtime_mcp_policy option
   ; allowed_paths : string list
   ; checkpoint_sidecar : Yojson.Safe.t option
@@ -44,7 +44,7 @@ type try_provider_ctx =
   ; enable_thinking : bool option
   ; approval : Agent_sdk.Hooks.approval_callback option
   ; exit_condition : (int -> bool) option
-  ; exit_condition_result : (int -> Cascade_runner.stop_reason * string option) option
+  ; exit_condition_result : (int -> Runtime_agent.stop_reason * string option) option
   ; summarizer : (Agent_sdk.Types.message list -> string) option
   ; oas_checkpoint : Agent_sdk.Checkpoint.t option
   ; sw : Eio.Switch.t
@@ -67,9 +67,9 @@ val run_try_provider :
   ?resume_checkpoint:Agent_sdk.Checkpoint.t ->
   ?per_provider_timeout_s:float ->
   Cascade_runtime_candidate.t ->
-  (Cascade_runner.run_result, Agent_sdk.Error.sdk_error) result
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
   * Agent_sdk.Checkpoint.t option
-  * (string * Cascade_attempt_liveness_config.success_sample) option
+  * (string * Keeper_attempt_liveness_config.success_sample) option
 
 module For_testing : sig
   val sanitize_runtime_mcp_external_tool_choice :

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -2,7 +2,7 @@
 
 type try_provider_ctx =
   { cascade_name : string
-  ; error_cascade_name : Cascade_name.t
+  ; error_cascade_name : string
   ; keeper_name : string
   ; name : string
   ; goal : string

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -40,7 +40,7 @@ let run_model_by_label
     ?sw
     ?net
     ()
-  : (Cascade_runner.run_result, Agent_sdk.Error.sdk_error) result =
+  : (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result =
   let stream_idle_timeout_s = apply_stream_idle_timeout_default stream_idle_timeout_s in
   let* config =
     Cascade_config_builder.config_for_label ~name:"oas-label-model" ~model_label ~system_prompt
@@ -52,8 +52,8 @@ let run_model_by_label
       ~description:(Some (Printf.sprintf "model_label:%s" model_label))
       ()
   in
-  match Cascade_oas_runner.require_eio ?sw ?net () with
-  | Error e -> Error (Cascade_oas_runner.eio_context_error_to_sdk_error e)
+  match Runtime_oas_runner.require_eio ?sw ?net () with
+  | Error e -> Error (Runtime_oas_runner.eio_context_error_to_sdk_error e)
   | Ok (sw, net) ->
       let transport_resolved = match transport with
         | Some t -> t
@@ -73,7 +73,7 @@ let run_model_by_label
               ~scope:(Printf.sprintf "model_label:%s" model_label)
               ~config ~goal
               (fun () ->
-                match Cascade_runner.run ~sw ~net ~config ?on_event  goal with
+                match Runtime_agent.run ~sw ~net ~config ?on_event  goal with
                 | Ok result when accept result.response -> Ok result
                 | Ok result ->
                     Error
@@ -133,7 +133,7 @@ let run_named_with_masc_tools
     ?sw
     ?net
     ()
-  : (Cascade_runner.run_result, Agent_sdk.Error.sdk_error) result =
+  : (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result =
   let oas_tools = List.map (fun (td : Masc_domain.tool_schema) ->
     Tool_bridge.oas_tool_of_masc
       ~name:td.name ~description:td.description
@@ -177,7 +177,7 @@ let run_model_with_masc_tools
     ?sw
     ?net
     ()
-  : (Cascade_runner.run_result, Agent_sdk.Error.sdk_error) result =
+  : (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result =
   let stream_idle_timeout_s = apply_stream_idle_timeout_default stream_idle_timeout_s in
   let* config =
     Cascade_config_builder.config_for_label ~name:"oas-explicit-model" ~model_label ~system_prompt
@@ -187,8 +187,8 @@ let run_model_with_masc_tools
       ~description:(Some (Printf.sprintf "model_label:%s" model_label))
       ()
   in
-  match Cascade_oas_runner.require_eio ?sw ?net () with
-  | Error e -> Error (Cascade_oas_runner.eio_context_error_to_sdk_error e)
+  match Runtime_oas_runner.require_eio ?sw ?net () with
+  | Error e -> Error (Runtime_oas_runner.eio_context_error_to_sdk_error e)
   | Ok (sw, net) ->
       let transport_resolved = match transport with
         | Some t -> t
@@ -208,7 +208,7 @@ let run_model_with_masc_tools
               ~scope:(Printf.sprintf "explicit_model:%s" model_label)
               ~config ~goal
               (fun () ->
-                Cascade_runner.run_with_masc_tools ~sw ~net ~config ~masc_tools ~dispatch  ?on_event
+                Runtime_agent.run_with_masc_tools ~sw ~net ~config ~masc_tools ~dispatch  ?on_event
                   goal))
       with
       | Ok result -> result

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -62,7 +62,7 @@ let run_model_by_label
       let config = { config with transport = transport_resolved } in
       match
         let admission_cascade_name =
-          Cascade_name.of_string_exn model_label
+          model_label
         in
         Admission_queue.with_permit ?wait_timeout_sec
           ~priority:Llm_provider.Request_priority.Proactive
@@ -197,7 +197,7 @@ let run_model_with_masc_tools
       let config = { config with raw_trace; transport = transport_resolved } in
       match
         let admission_cascade_name =
-          Cascade_name.of_string_exn model_label
+          model_label
         in
         Admission_queue.with_permit ?wait_timeout_sec
           ~priority:Llm_provider.Request_priority.Proactive

--- a/lib/keeper/keeper_turn_driver_wrappers.mli
+++ b/lib/keeper/keeper_turn_driver_wrappers.mli
@@ -35,7 +35,7 @@ val run_model_by_label :
   ?sw:Eio.Switch.t ->
   ?net:Eio_context.eio_net ->
   unit ->
-  (Cascade_runner.run_result, Agent_sdk.Error.sdk_error) result
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
 (** Run a single [Agent.run] using a model label string
     (e.g. ["llama:qwen3.5"]).  Validates the label before execution. *)
 
@@ -72,7 +72,7 @@ val run_named_with_masc_tools :
   ?sw:Eio.Switch.t ->
   ?net:Eio_context.eio_net ->
   unit ->
-  (Cascade_runner.run_result, Agent_sdk.Error.sdk_error) result
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
 (** [run_named] variant that bridges MASC tool schemas into OAS tools
     via {!Tool_bridge.oas_tool_of_masc}. *)
 
@@ -101,5 +101,5 @@ val run_model_with_masc_tools :
   ?sw:Eio.Switch.t ->
   ?net:Eio_context.eio_net ->
   unit ->
-  (Cascade_runner.run_result, Agent_sdk.Error.sdk_error) result
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
 (** [run_model_by_label] variant that bridges MASC tool schemas into OAS tools. *)

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -201,7 +201,7 @@ let record_pre_dispatch_terminal_observation
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(generation : int)
-      ~(cascade_name : Cascade_name.t)
+      ~(cascade_name : string)
       ~(outcome : Keeper_execution_receipt.outcome_kind)
       ~(terminal_reason_code : string)
       ~(activity_kind : string)
@@ -213,7 +213,7 @@ let record_pre_dispatch_terminal_observation
   : unit
   =
   let cascade_name_string =
-    Cascade_name.to_string cascade_name
+    cascade_name
   in
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   let started_at = now_iso () in

--- a/lib/keeper/keeper_turn_helpers.mli
+++ b/lib/keeper/keeper_turn_helpers.mli
@@ -67,7 +67,7 @@ val record_pre_dispatch_terminal_observation :
   config:Coord.config ->
   meta:keeper_meta ->
   generation:int ->
-  cascade_name:Cascade_name.t ->
+  cascade_name:string ->
   outcome:Keeper_execution_receipt.outcome_kind ->
   terminal_reason_code:string ->
   activity_kind:string ->

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -125,7 +125,7 @@ let parse_cascade_name_opt args =
         (* keeper-assignable guardrail removed 2026-05-28 — validate existence only. *)
         match
           Cascade_runtime.models_of_cascade_name_result
-            (Cascade_name.of_string_exn normalized)
+            (normalized)
         with
         | Ok _ -> Ok (Some normalized)
         | Error detail ->

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -284,7 +284,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
               in
               let cascade_models =
                 Cascade_runtime.models_of_cascade_name
-                  (Cascade_name.of_string_exn selected_cascade_name)
+                  (selected_cascade_name)
               in
               (match
                  Keeper_turn_helpers.ensure_local_discovery_ready

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -308,10 +308,10 @@ let append_decision_record
               in
                 let stop_reason_str =
                   match r.stop_reason with
-                  | Cascade_runner.Completed -> "completed"
-                  | Cascade_runner.TurnBudgetExhausted { turns_used; limit } ->
+                  | Runtime_agent.Completed -> "completed"
+                  | Runtime_agent.TurnBudgetExhausted { turns_used; limit } ->
                       Printf.sprintf "turn_budget_exhausted(%d/%d)" turns_used limit
-                  | Cascade_runner.MutationBoundaryReached { turns_used; tool_name } ->
+                  | Runtime_agent.MutationBoundaryReached { turns_used; tool_name } ->
                       (match tool_name with
                        | Some tool ->
                            Printf.sprintf "mutation_boundary(%d:%s)" turns_used tool

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -260,8 +260,7 @@ let append_decision_record
                 match r.cascade_observation with
                 | Some co ->
                     let cascade_name =
-                      Cascade_name.to_string
-                        co.cascade_name
+                                              co.cascade_name
                     in
                     [
                       ("cascade_name", `String cascade_name);

--- a/lib/keeper/keeper_unified_metrics_failure.ml
+++ b/lib/keeper/keeper_unified_metrics_failure.ml
@@ -122,7 +122,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
 	                  ; _
 	                  }) ->
             let cascade_name =
-              Cascade_name.to_string cascade_name
+              cascade_name
             in
             Prometheus.inc_counter
               Keeper_metrics.(to_string NoToolProvider)

--- a/lib/keeper/keeper_unified_metrics_json_support.ml
+++ b/lib/keeper/keeper_unified_metrics_json_support.ml
@@ -45,7 +45,7 @@ let provider_context_json ~(meta : keeper_meta)
         ]
 
 let redacted_cascade_attempt_to_json
-    (attempt : Cascade_observation.cascade_attempt) : Yojson.Safe.t =
+    (attempt : Keeper_observation.cascade_attempt) : Yojson.Safe.t =
   `Assoc
     [ "attempt_index", `Int attempt.attempt_index
     ; ( "latency_ms", Json_util.int_opt_to_json attempt.latency_ms )
@@ -54,12 +54,12 @@ let redacted_cascade_attempt_to_json
 ;;
 
 let redacted_cascade_fallback_event_to_json
-    (event : Cascade_observation.cascade_fallback_event) : Yojson.Safe.t =
+    (event : Keeper_observation.cascade_fallback_event) : Yojson.Safe.t =
   `Assoc [ "reason", `String event.reason ]
 ;;
 
 let redacted_cascade_observation_to_json
-    (obs : Cascade_observation.cascade_observation) : Yojson.Safe.t =
+    (obs : Keeper_observation.cascade_observation) : Yojson.Safe.t =
   let cascade_name =
     Cascade_name.to_string obs.cascade_name
   in

--- a/lib/keeper/keeper_unified_metrics_json_support.ml
+++ b/lib/keeper/keeper_unified_metrics_json_support.ml
@@ -29,7 +29,7 @@ let provider_context_json ~(meta : keeper_meta)
       let cascade_name =
         match r.cascade_observation with
         | Some observation ->
-            Cascade_name.to_string observation.cascade_name
+            observation.cascade_name
         | None -> cascade_name_of_meta meta
       in
       `Assoc
@@ -61,7 +61,7 @@ let redacted_cascade_fallback_event_to_json
 let redacted_cascade_observation_to_json
     (obs : Keeper_observation.cascade_observation) : Yojson.Safe.t =
   let cascade_name =
-    Cascade_name.to_string obs.cascade_name
+    obs.cascade_name
   in
   `Assoc
     [ "cascade_name", `String cascade_name

--- a/lib/keeper/keeper_unified_metrics_json_support.mli
+++ b/lib/keeper/keeper_unified_metrics_json_support.mli
@@ -12,7 +12,7 @@ val provider_context_json :
   Yojson.Safe.t
 
 val redacted_cascade_observation_to_json :
-  Cascade_observation.cascade_observation -> Yojson.Safe.t
+  Keeper_observation.cascade_observation -> Yojson.Safe.t
 
 val tool_contract_json :
   tool_call_count:int ->

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -82,7 +82,7 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
     match result.cascade_observation with
     | Some observation ->
       Cascade_name.to_string
-        observation.Cascade_observation.cascade_name
+        observation.Keeper_observation.cascade_name
     | None -> (cascade_name_of_meta meta)
   in
   (* #9933: same latency bucket, split by provider/model/cascade.

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -81,8 +81,7 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
   let cascade_profile =
     match result.cascade_observation with
     | Some observation ->
-      Cascade_name.to_string
-        observation.Keeper_observation.cascade_name
+              observation.Keeper_observation.cascade_name
     | None -> (cascade_name_of_meta meta)
   in
   (* #9933: same latency bucket, split by provider/model/cascade.

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -167,7 +167,7 @@ let run_keeper_cycle
          let profile_defaults =
            Keeper_types_profile.load_keeper_profile_defaults meta.name
          in
-         let effective_cascade_runtime_name = Cascade_name.of_string_exn effective_cascade_name in
+         let effective_cascade_runtime_name = effective_cascade_name in
          (match
             Keeper_unified_turn_pre_dispatch.build_cascade_execution
               ~meta
@@ -204,12 +204,12 @@ let run_keeper_cycle
                      ; _
                      }) ->
                 Keeper_turn_fsm.Failure_no_tool_capable_provider
-                  { cascade_name = Cascade_name.to_string cascade_name
+                  { cascade_name = cascade_name
                   ; detail = error_message
                   }
               | _ when EC.is_cascade_exhausted_error err ->
                 Keeper_turn_fsm.Failure_cascade_unavailable
-                  { base = Cascade_name.to_string effective_cascade_runtime_name
+                  { base = effective_cascade_runtime_name
                   ; resolved = None
                   }
               | _ ->
@@ -400,7 +400,7 @@ let run_keeper_cycle
                      ?slot_release_at_phase
                      ?productive_phase_elapsed_ms
                      ?retry_phase_elapsed_ms
-                     ~(from_cascade : Cascade_name.t)
+                     ~(from_cascade : string)
                      ~(retry : EC.degraded_retry)
                      ~(outcome : Keeper_execution_receipt.cascade_rotation_outcome)
                      (err : Agent_sdk.Error.sdk_error)
@@ -670,7 +670,7 @@ let run_keeper_cycle
                                 ; _
                                 }) ->
                            Keeper_turn_fsm.Failure_no_tool_capable_provider
-                             { cascade_name = Cascade_name.to_string cascade_name
+                             { cascade_name = cascade_name
                              ; detail = short_preview e_str
                              }
                          | _ ->
@@ -691,7 +691,7 @@ let run_keeper_cycle
                     "%s: keeper cycle FAILED cascade=%s max_context=%d context_budget=%d \
                      primary_budget=%d requested_override=%s latency=%dms%s error=%s"
                     meta.name
-                    (Cascade_name.to_string final_execution.cascade_name)
+                    (final_execution.cascade_name)
                     final_execution.max_context
                     final_execution.max_context_resolution.effective_budget
                     final_execution.max_context_resolution.primary_budget

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -224,7 +224,7 @@ val record_streaming_cancelled_observation
   :  config:Coord.config
   -> run_meta:Keeper_meta_contract.keeper_meta
   -> run_generation:int
-  -> cascade_name:Cascade_name.t
+  -> cascade_name:string
   -> keeper_turn_id:int
   -> unit
   -> unit

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -300,7 +300,7 @@ let run (ctx : ctx)
              ~estimated_input_tokens:prompt_timeout_estimate_tokens
              ~max_turns
          with
-        | Error (denial : Cascade_internal_error.retry_admission_denial) ->
+        | Error (denial : Keeper_meta_contract.retry_admission_denial) ->
           Error
             (Keeper_turn_driver.sdk_error_of_masc_internal_error
                (Keeper_turn_driver.Retry_admission_denied

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -57,7 +57,7 @@ type ctx =
       : ?slot_release_at_phase:Keeper_execution_receipt.slot_release_phase
       -> ?productive_phase_elapsed_ms:int
       -> ?retry_phase_elapsed_ms:int
-      -> from_cascade:Cascade_name.t
+      -> from_cascade:string
       -> retry:EC.degraded_retry
       -> outcome:Keeper_execution_receipt.cascade_rotation_outcome
       -> Agent_sdk.Error.sdk_error
@@ -82,7 +82,7 @@ let run (ctx : ctx)
       ~(user_message : string)
       ~(registry_base_path : string)
       ~(degraded_retry_slot_phase_budget_sec : float)
-      ~(record_streaming_cancelled_observation : config:Coord.config -> run_meta:keeper_meta -> run_generation:int -> cascade_name:Cascade_name.t -> keeper_turn_id:int -> unit -> unit)
+      ~(record_streaming_cancelled_observation : config:Coord.config -> run_meta:keeper_meta -> run_generation:int -> cascade_name:string -> keeper_turn_id:int -> unit -> unit)
       ~(cascade_name_of_meta : keeper_meta -> string)
       ~(start_background_turn_event_bus_drain : clock:float Eio.Time.clock_ty Eio.Resource.t -> unit)
   : (Keeper_agent_run.run_result, Agent_sdk.Error.sdk_error) result
@@ -224,7 +224,7 @@ let run (ctx : ctx)
       input
     in
     let execution_cascade_name =
-      Cascade_name.to_string execution.cascade_name
+      execution.cascade_name
     in
     let mark_terminal_error err =
       match EC.extract_input_required err with
@@ -496,9 +496,11 @@ let run (ctx : ctx)
                ~meta
                ~profile_defaults
                ~cascade_name:
-                 (Cascade_name.of_string_or
-                    ~fallback:execution.cascade_name
-                    degraded_retry.next_cascade)
+                 (* RFC-0206: raw runtime id (no prefix validation); keep the
+                    empty→fallback behaviour only. *)
+                 (if String.trim degraded_retry.next_cascade = ""
+                  then execution.cascade_name
+                  else degraded_retry.next_cascade)
            with
            | Error fail_open_err ->
              let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
@@ -529,7 +531,7 @@ let run (ctx : ctx)
              Error fail_open_err
            | Ok next_execution ->
              let next_execution_cascade_name =
-               Cascade_name.to_string next_execution.cascade_name
+               next_execution.cascade_name
              in
              if Option.is_none !retry_phase_started_at
              then retry_phase_started_at := Some (Eio.Time.now clock);
@@ -762,8 +764,7 @@ let run (ctx : ctx)
         ; is_retry = false
         ; allow_degraded_wall_clock_retry_budget = false
         ; attempted_cascades =
-            [ Cascade_name.to_string
-                initial_execution.cascade_name
+            [                 initial_execution.cascade_name
             ]
         })
   with

--- a/lib/keeper/keeper_unified_turn_phase_gate.ml
+++ b/lib/keeper/keeper_unified_turn_phase_gate.ml
@@ -53,8 +53,7 @@ let decide_and_record
       ~meta
       ~generation
       ~cascade_name:
-        (Cascade_name.of_string_exn
-           (cascade_name_of_meta meta))
+        (           (cascade_name_of_meta meta))
       ~outcome:`Cancelled
       ~terminal_reason_code:"supervisor_stop"
       ~activity_kind:"keeper.turn_cancelled"
@@ -94,8 +93,7 @@ let decide_and_record
         ~meta
         ~generation
         ~cascade_name:
-          (Cascade_name.of_string_exn
-             (cascade_name_of_meta meta))
+          (             (cascade_name_of_meta meta))
         ~outcome:`Skipped
         ~terminal_reason_code
         ~activity_kind:"keeper.turn_skipped"
@@ -131,8 +129,7 @@ let decide_and_record
         ~meta
         ~generation
         ~cascade_name:
-          (Cascade_name.of_string_exn
-             (cascade_name_of_meta meta))
+          (             (cascade_name_of_meta meta))
         ~outcome:`Error
         ~terminal_reason_code
         ~activity_kind:"keeper.turn_blocked"

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -27,7 +27,7 @@ let resolve_unified_max_tokens_fallback
 let build_cascade_execution
       ~(meta : keeper_meta)
       ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
-      ~(cascade_name : Cascade_name.t)
+      ~(cascade_name : string)
   : ( Keeper_turn_cascade_budget.cascade_execution
     , Agent_sdk.Error.sdk_error )
     result

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -78,7 +78,7 @@ let build_cascade_execution
         with
         | Error err ->
           Error
-            (Cascade_error_classify.sdk_error_of_masc_internal_error err)
+            (Keeper_meta_contract.sdk_error_of_masc_internal_error err)
         | Ok max_tokens ->
           Ok
             { Keeper_turn_cascade_budget.cascade_name

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.mli
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.mli
@@ -15,7 +15,7 @@
 val build_cascade_execution
   :  meta:Keeper_meta_contract.keeper_meta
   -> profile_defaults:Keeper_types_profile.keeper_profile_defaults
-  -> cascade_name:Cascade_name.t
+  -> cascade_name:string
   -> ( Keeper_turn_cascade_budget.cascade_execution
      , Agent_sdk.Error.sdk_error )
      result

--- a/lib/keeper/keeper_unified_turn_rotation_attempt.ml
+++ b/lib/keeper/keeper_unified_turn_rotation_attempt.ml
@@ -3,22 +3,16 @@ let build
       ?slot_release_at_phase
       ?productive_phase_elapsed_ms
       ?retry_phase_elapsed_ms
-      ~(from_cascade : Cascade_name.t)
+      ~(from_cascade : string)
       ~(retry : Keeper_error_classify.degraded_retry)
       ~(outcome : Keeper_execution_receipt.cascade_rotation_outcome)
       (err : Agent_sdk.Error.sdk_error)
   : Keeper_execution_receipt.cascade_rotation_attempt
   =
   { from_cascade
-  ; to_cascade =
-      (match Cascade_name.of_string retry.next_cascade with
-       | Ok t -> t
-       | Error (`Invalid_prefix | `Empty) ->
-         Log.Misc.warn
-           "rotation_attempt: next_cascade %S is not a qualified cascade name, \
-            falling back to from_cascade"
-           retry.next_cascade;
-         from_cascade)
+  ; (* RFC-0206: cascade-name validation moved to the TOML load boundary; a
+       runtime id is a raw string accepted as-is (no prefix check here). *)
+    to_cascade = retry.next_cascade
   ; reason = retry.fallback_reason
   ; outcome
   ; slot_release_at_phase

--- a/lib/keeper/keeper_unified_turn_rotation_attempt.mli
+++ b/lib/keeper/keeper_unified_turn_rotation_attempt.mli
@@ -9,7 +9,7 @@ val build
   -> ?slot_release_at_phase:Keeper_execution_receipt.slot_release_phase
   -> ?productive_phase_elapsed_ms:int
   -> ?retry_phase_elapsed_ms:int
-  -> from_cascade:Cascade_name.t
+  -> from_cascade:string
   -> retry:Keeper_error_classify.degraded_retry
   -> outcome:Keeper_execution_receipt.cascade_rotation_outcome
   -> Agent_sdk.Error.sdk_error

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -304,19 +304,19 @@ let emit_usage_metrics_and_log
   =
   let outcome_str =
     match result.Keeper_agent_run.stop_reason with
-    | Cascade_runner.Completed -> "completed"
-    | Cascade_runner.TurnBudgetExhausted { turns_used; limit; _ } ->
+    | Runtime_agent.Completed -> "completed"
+    | Runtime_agent.TurnBudgetExhausted { turns_used; limit; _ } ->
       Printf.sprintf "budget_exhausted(%d/%d)" turns_used limit
-    | Cascade_runner.MutationBoundaryReached { turns_used; tool_name } ->
+    | Runtime_agent.MutationBoundaryReached { turns_used; tool_name } ->
       (match tool_name with
        | Some tool -> Printf.sprintf "mutation_boundary(%d:%s)" turns_used tool
        | None -> Printf.sprintf "mutation_boundary(%d)" turns_used)
   in
   let outcome_label =
     match result.stop_reason with
-    | Cascade_runner.Completed -> "success"
-    | Cascade_runner.TurnBudgetExhausted _ -> "budget_exhausted"
-    | Cascade_runner.MutationBoundaryReached _ -> "mutation_boundary"
+    | Runtime_agent.Completed -> "success"
+    | Runtime_agent.TurnBudgetExhausted _ -> "budget_exhausted"
+    | Runtime_agent.MutationBoundaryReached _ -> "mutation_boundary"
   in
   Prometheus.inc_counter
     Keeper_metrics.(to_string Turns)
@@ -434,7 +434,7 @@ let persist_success_meta ~config ~original_meta ~updated_meta =
 
 let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
   match result.Keeper_agent_run.stop_reason with
-  | Cascade_runner.TurnBudgetExhausted { turns_used; limit } ->
+  | Runtime_agent.TurnBudgetExhausted { turns_used; limit } ->
     Log.Keeper.info
       "keeper:%s turn budget exhausted (%d/%d), checkpoint saved — will resume next cycle"
       updated_meta.name
@@ -443,7 +443,7 @@ let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
     Keeper_registry.reset_turn_failures
       ~base_path:config.Coord.base_path
       updated_meta.name
-  | Cascade_runner.MutationBoundaryReached { tool_name; _ } ->
+  | Runtime_agent.MutationBoundaryReached { tool_name; _ } ->
     Log.Keeper.info
       "keeper:%s mutation boundary reached after %s, checkpoint saved — will resume next cycle"
       updated_meta.name
@@ -453,7 +453,7 @@ let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
     Keeper_registry.reset_turn_failures
       ~base_path:config.base_path
       updated_meta.name
-  | Cascade_runner.Completed ->
+  | Runtime_agent.Completed ->
     Keeper_registry.reset_turn_failures
       ~base_path:config.base_path
       updated_meta.name

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -144,13 +144,13 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
              Printf.sprintf
                "no tool-capable provider found (cascade=%s labels=[%s] \
                 required_tools=[%s]%s)"
-               (Cascade_name.to_string ntcp_cascade_name)
+               (ntcp_cascade_name)
                (String.concat ", " detail.configured_labels)
                (String.concat ", " detail.required_tool_names)
                rejection_summary
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = Some (Cascade_name.to_string ntcp_cascade_name)
+         ; cascade_name = Some (ntcp_cascade_name)
          })
   | Some
       (Keeper_meta_contract.Cascade_exhausted
@@ -164,7 +164,7 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; detail = "no tool-capable provider found"
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = Some (Cascade_name.to_string ntcp_cascade_name)
+         ; cascade_name = Some (ntcp_cascade_name)
          })
   (* Generic Cascade_exhausted catch-all — after No_tool_capable specifics *)
   | Some (Keeper_meta_contract.Cascade_exhausted { reason; cascade_name }) ->
@@ -174,7 +174,7 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; detail
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = Some (Cascade_name.to_string cascade_name)
+         ; cascade_name = Some (cascade_name)
          })
   | Some (Keeper_meta_contract.Capacity_backpressure { detail = capacity_detail; _ }) ->
     Some
@@ -380,7 +380,7 @@ let record_streaming_cancelled_observation
       ~(config : Coord.config)
       ~(run_meta : Keeper_meta_contract.keeper_meta)
       ~(run_generation : int)
-      ~(cascade_name : Cascade_name.t)
+      ~(cascade_name : string)
       ~(keeper_turn_id : int)
       ()
   : unit

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -115,10 +115,10 @@ let cascade_exhaustion_reason_code
 ;;
 
 let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
-  match Cascade_error_classify.classify_masc_internal_error_of_string raw_error with
+  match Keeper_meta_contract.classify_masc_internal_error_of_string raw_error with
   (* No_tool_capable specific cases first — more specific than generic Cascade_exhausted *)
   | Some
-      (Cascade_error_classify.Cascade_exhausted
+      (Keeper_meta_contract.Cascade_exhausted
          { cascade_name = ntcp_cascade_name
          ; reason = Keeper_meta_contract.No_tool_capable (Some detail)
          ; _
@@ -153,7 +153,7 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; cascade_name = Some (Cascade_name.to_string ntcp_cascade_name)
          })
   | Some
-      (Cascade_error_classify.Cascade_exhausted
+      (Keeper_meta_contract.Cascade_exhausted
          { cascade_name = ntcp_cascade_name
          ; reason = Keeper_meta_contract.No_tool_capable None
          ; _
@@ -167,7 +167,7 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; cascade_name = Some (Cascade_name.to_string ntcp_cascade_name)
          })
   (* Generic Cascade_exhausted catch-all — after No_tool_capable specifics *)
-  | Some (Cascade_error_classify.Cascade_exhausted { reason; cascade_name }) ->
+  | Some (Keeper_meta_contract.Cascade_exhausted { reason; cascade_name }) ->
     Some
       (Keeper_registry.Provider_runtime_error
          { code = cascade_exhaustion_reason_code reason
@@ -176,7 +176,7 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; http_status = None
          ; cascade_name = Some (Cascade_name.to_string cascade_name)
          })
-  | Some (Cascade_error_classify.Capacity_backpressure { detail = capacity_detail; _ }) ->
+  | Some (Keeper_meta_contract.Capacity_backpressure { detail = capacity_detail; _ }) ->
     Some
       (Keeper_registry.Provider_runtime_error
          { code = "capacity_backpressure"
@@ -186,23 +186,23 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; cascade_name = None
          })
   | Some
-      ( Cascade_error_classify.Resumable_cli_session _
-      | Cascade_error_classify.Accept_rejected _
-      | Cascade_error_classify.Admission_queue_timeout _
-      | Cascade_error_classify.Admission_queue_rejected _
-      | Cascade_error_classify.Turn_timeout _
-      | Cascade_error_classify.Provider_timeout _
-      | Cascade_error_classify.Max_tokens_ceiling_violation _
-      | Cascade_error_classify.Ambiguous_post_commit _
+      ( Keeper_meta_contract.Resumable_cli_session _
+      | Keeper_meta_contract.Accept_rejected _
+      | Keeper_meta_contract.Admission_queue_timeout _
+      | Keeper_meta_contract.Admission_queue_rejected _
+      | Keeper_meta_contract.Turn_timeout _
+      | Keeper_meta_contract.Provider_timeout _
+      | Keeper_meta_contract.Max_tokens_ceiling_violation _
+      | Keeper_meta_contract.Ambiguous_post_commit _
       (* RFC-0158: pre-dispatch admission denial is not a cascade-exhaustion
          reason; the keeper decided not to attempt a provider call. *)
-      | Cascade_error_classify.Retry_admission_denied _
+      | Keeper_meta_contract.Retry_admission_denied _
       (* RFC-0159 Phase A: typed [Internal_*] variants are not
          cascade-exhaustion reasons; they map to opaque
          internal-error events upstream. *)
-      | Cascade_error_classify.Internal_unhandled_exception _
-      | Cascade_error_classify.Internal_bridge_exception _
-      | Cascade_error_classify.Internal_contract_rejected _ )
+      | Keeper_meta_contract.Internal_unhandled_exception _
+      | Keeper_meta_contract.Internal_bridge_exception _
+      | Keeper_meta_contract.Internal_contract_rejected _ )
   | None -> None
 ;;
 

--- a/lib/keeper/keeper_unified_turn_types.mli
+++ b/lib/keeper/keeper_unified_turn_types.mli
@@ -79,7 +79,7 @@ val record_streaming_cancelled_observation :
   config:Coord.config ->
   run_meta:Keeper_meta_contract.keeper_meta ->
   run_generation:int ->
-  cascade_name:Cascade_name.t ->
+  cascade_name:string ->
   keeper_turn_id:int ->
   unit ->
   unit

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -768,7 +768,7 @@ let keeper_cycle_decision
           if should_run
           then
             provider_cooldown_remaining_sec
-              ~cascade_name:(Cascade_name.of_string_exn cascade_name)
+              ~cascade_name:(cascade_name)
           else None
         in
         let provider_cooldown_fail_open =

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -271,11 +271,11 @@ val effective_scheduled_autonomous_cooldown :
   ?consecutive_noop_count:int -> unit -> int
 
 val provider_cooldown_remaining_sec_for_cascade :
-  cascade_name:Cascade_name.t -> int option
+  cascade_name:string -> int option
 
 val provider_capacity_blocked_task_count :
   ?provider_cooldown_remaining_sec:
-    (cascade_name:Cascade_name.t -> int option) ->
+    (cascade_name:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta ->
   claimable_task_count:int ->
   unit ->
@@ -294,12 +294,12 @@ val should_inject_entropic_oscillation :
 
 val keeper_cycle_decision :
   ?provider_cooldown_remaining_sec:
-    (cascade_name:Cascade_name.t -> int option) ->
+    (cascade_name:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> keeper_cycle_decision
 
 val unified_turn_decision :
   ?provider_cooldown_remaining_sec:
-    (cascade_name:Cascade_name.t -> int option) ->
+    (cascade_name:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> keeper_cycle_decision
 
 val should_run_keeper_cycle :

--- a/lib/keeper/keeper_world_observation_provider_cooldown.ml
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.ml
@@ -38,8 +38,8 @@ let provider_cooldown_remaining_sec_for_cascade
     let provider_infos =
       List.map
         (fun provider_key ->
-           Cascade_health_tracker.provider_info
-             Cascade_health_tracker.global
+           Keeper_binding_health.provider_info
+             Keeper_binding_health.global
              ~provider_key)
         runtime_health_keys
     in
@@ -50,13 +50,13 @@ let provider_cooldown_remaining_sec_for_cascade
       if
         not
           (List.for_all
-             (fun info -> info.Cascade_health_tracker.in_cooldown)
+             (fun info -> info.Keeper_binding_health.in_cooldown)
              provider_infos)
       then None
       else (
         let now = Time_compat.now () in
         provider_infos
-        |> List.filter_map (fun info -> info.Cascade_health_tracker.cooldown_expires_at)
+        |> List.filter_map (fun info -> info.Keeper_binding_health.cooldown_expires_at)
         |> List.map (fun expires_at ->
           int_of_float (Float.max 0.0 (Float.ceil (expires_at -. now))))
         |> function

--- a/lib/keeper/keeper_world_observation_provider_cooldown.ml
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.ml
@@ -25,7 +25,7 @@ let fallback_cascade_for_provider_cooldown
   else Some (Keeper_config.default_cascade_name ())
 
 let provider_cooldown_remaining_sec_for_cascade
-      ~(cascade_name : Cascade_name.t)
+      ~(cascade_name : string)
   : int option
   =
   let runtime_health_keys =
@@ -75,7 +75,7 @@ let provider_capacity_blocked_task_count
     let cascade_name = cascade_name_of_meta meta in
     match
       provider_cooldown_remaining_sec
-        ~cascade_name:(Cascade_name.of_string_exn cascade_name)
+        ~cascade_name:(cascade_name)
     with
     | Some _
       when Option.is_none

--- a/lib/keeper/keeper_world_observation_provider_cooldown.mli
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.mli
@@ -4,10 +4,10 @@ val fallback_cascade_for_provider_cooldown :
   string option
 
 val provider_cooldown_remaining_sec_for_cascade :
-  cascade_name:Cascade_name.t -> int option
+  cascade_name:string -> int option
 
 val provider_capacity_blocked_task_count :
-  ?provider_cooldown_remaining_sec:(cascade_name:Cascade_name.t -> int option) ->
+  ?provider_cooldown_remaining_sec:(cascade_name:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta ->
   claimable_task_count:int ->
   unit ->

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -378,7 +378,7 @@ let build_local_shell_tools ~room_config ~worker_name ~workdir =
     Returns Error when the label cannot be parsed. *)
 let oas_provider_of_label (label : string) :
     (Agent_sdk.Provider.config, string) result =
-  match Cascade_config.parse_model_string label with
+  match Runtime_model_string.parse_model_string label with
   | Some pc -> Ok (Agent_sdk.Provider.config_of_provider_config pc)
   | None ->
     let msg = Printf.sprintf "Cannot parse model label: %S (expected provider:model)" label in
@@ -389,7 +389,7 @@ let oas_provider_of_label (label : string) :
     Returns the provider config and model_id on success. *)
 let resolve_oas_provider_of_label (label : string) :
     (Agent_sdk.Provider.config * string, string) result =
-  match Cascade_config.parse_model_string label with
+  match Runtime_model_string.parse_model_string label with
   | None -> Error (Printf.sprintf "Cannot parse model: %s" label)
   | Some pc ->
     Ok
@@ -467,8 +467,8 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
       max_tokens = Some (local_worker_max_tokens ());
       max_turns;
       temperature = Some Llm_provider.Constants.Inference_profile.worker_default.temperature;
-      top_p = Some Cascade_worker_defaults.top_p;
-      top_k = Some Cascade_worker_defaults.top_k;
+      top_p = Some Llm_provider.Constants.Worker_sampling.top_p;
+      top_k = Some Llm_provider.Constants.Worker_sampling.top_k;
       (* min_p is effectively disabled (0.0) and some cloud providers
          reject the field itself even when the value is a no-op. *)
       min_p = None;
@@ -482,7 +482,7 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
     | None ->
         { Agent_sdk.Guardrails.tool_filter =
             Agent_sdk.Guardrails.AllowList (oas_tool_names tools);
-          max_tool_calls_per_turn = Some Cascade_worker_defaults.max_tool_calls_per_turn;
+          max_tool_calls_per_turn = Some Llm_provider.Constants.Worker_sampling.max_tool_calls_per_turn;
         }
   in
   let options =

--- a/lib/local/worker_container.mli
+++ b/lib/local/worker_container.mli
@@ -171,7 +171,7 @@ val oas_provider_of_label :
   string -> (Agent_sdk.Provider.config, string) result
 (** Parses a model label (e.g. ["openai:gpt-4.1"]) into an
     {!Agent_sdk.Provider.config}.  Errors when
-    {!Cascade_config.parse_model_string} returns [None]. *)
+    {!Runtime_model_string.parse_model_string} returns [None]. *)
 
 val resolve_oas_provider_of_label :
   string -> (Agent_sdk.Provider.config * string, string) result

--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -133,8 +133,8 @@ let run_safe ~caller ~timeout_s fn =
        classifier can route bridge-boundary failures off the
        [Reason_internal_error] catch-all. *)
     Error
-      (Cascade_error_classify.sdk_error_of_masc_internal_error
-         (Cascade_error_classify.Internal_bridge_exception
+      (Keeper_meta_contract.sdk_error_of_masc_internal_error
+         (Keeper_meta_contract.Internal_bridge_exception
             { caller; exn_repr = Printexc.to_string exn }))
 
 (** [run_with_caller ~caller fn] — single entry point that resolves

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -529,13 +529,13 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
      Missed when #10664 introduced the actor model. *)
   Session.start_loop registry ~sw;
   (* Same sweep miss as Session.start_loop above: PR #10730 introduced
-     [Cascade_observation] as an Eio actor (mailbox + Promise.await) but
+     [Keeper_observation] as an Eio actor (mailbox + Promise.await) but
      never wired its [start_actor_if_needed] into a bootstrap path.
      [cascade_metrics_json ()] (called from [tool_unified.ml:summary_report],
      which the dashboard tool inspector hits) does
      [Stream.add Get_metrics_json u; Promise.await p]. Without an actor
      fiber draining [stream], the await blocks forever. *)
-  Cascade_observation.start_actor_if_needed ~sw;
+  Keeper_observation.start_actor_if_needed ~sw;
   (* Wire notification harness: subscription events → session queues *)
   Subscriptions.set_session_push_fn (fun event ->
     Session.push_notification_to_active_agents registry ~event

--- a/lib/operator/operator_control_snapshot_identity_fields.ml
+++ b/lib/operator/operator_control_snapshot_identity_fields.ml
@@ -23,7 +23,7 @@ let keeper_runtime_identity_fields (meta : Keeper_meta_contract.keeper_meta) =
   let canonical_json =
     match Keeper_cascade_profile.resolve_live_result cascade_name with
     | Ok runtime ->
-      `String (Cascade_name.to_string runtime)
+      `String (runtime)
     | Error (`Unresolved _) -> cascade_name_json
   in
   [ "cascade_name", cascade_name_json

--- a/lib/otel/otel_genai.ml
+++ b/lib/otel/otel_genai.ml
@@ -83,7 +83,7 @@ let keeper_turn_attrs
       ~is_retry
       ~current_task_id
   =
-  let cascade_name = Cascade_name.to_string cascade_name in
+  let cascade_name = cascade_name in
   let optional_attrs =
     match current_task_id with
     | None -> []

--- a/lib/otel/otel_genai.mli
+++ b/lib/otel/otel_genai.mli
@@ -42,7 +42,7 @@ val keeper_turn_span_name : keeper_name:string -> string
 val keeper_turn_attrs
   :  keeper_name:string
   -> agent_name:string
-  -> cascade_name:Cascade_name.t
+  -> cascade_name:string
   -> trace_id:string
   -> generation:int
   -> max_context:int
@@ -58,7 +58,7 @@ val tool_execution_attrs : tool_name:string -> attr list
 val with_keeper_turn_span
   :  keeper_name:string
   -> agent_name:string
-  -> cascade_name:Cascade_name.t
+  -> cascade_name:string
   -> trace_id:string
   -> generation:int
   -> max_context:int

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -184,7 +184,7 @@ let metric_oas_bus_publish_block_seconds = "masc_oas_bus_publish_block_seconds_t
 let metric_oas_bus_publish = "masc_oas_bus_publish_total"
 let metric_oas_bus_capacity = "masc_oas_bus_capacity"
 
-(* Catch-all entries in [Cascade_event_bridge.native_event_to_json]
+(* Catch-all entries in [Keeper_event_bridge.native_event_to_json]
    for OAS payload variants that have not yet received an explicit
    arm in this consumer.  A non-zero rate per [kind] label means an
    upstream OAS pin bump shipped a new payload variant before the

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -195,7 +195,7 @@ val metric_oas_bus_capacity : string
 (** Counter: OAS [Agent_sdk.Event_bus.payload] variants that the
     cascade event bridge did not have an explicit arm for and
     degraded to a kind-only SSE payload via the catch-all in
-    [Cascade_event_bridge.native_event_to_json].  Labels: [kind]
+    [Keeper_event_bridge.native_event_to_json].  Labels: [kind]
     carries [Agent_sdk.Event_bus.payload_kind other] (snake_case,
     one-to-one with the upstream OAS payload constructor name —
     cardinality is bounded by the OAS variant set and grows only
@@ -203,7 +203,7 @@ val metric_oas_bus_capacity : string
 
     A non-zero rate means an OAS pin bump shipped a new payload
     variant before the masc-mcp consumer was migrated.  The catch-all
-    is deliberate (see [Cascade_event_bridge.native_event_to_json])
+    is deliberate (see [Keeper_event_bridge.native_event_to_json])
     but degrades SSE subscribers to a kind-only payload, so this
     counter is the per-process signal that an explicit arm needs
     to be added.  Fix: extend the explicit match in

--- a/lib/provider_kind_resolver.ml
+++ b/lib/provider_kind_resolver.ml
@@ -9,7 +9,7 @@ type resolution =
   | Custom_url of { model_id : string; base_url : string }
   | Unknown of string
 
-(* Reuse the same split semantics as Cascade_config.split_provider_model
+(* Reuse the same split semantics as Runtime_model_string.split_provider_model
    so that both paths agree on what "provider:model" means. Duplicated
    here (rather than imported) to avoid a circular dependency between
    this module and Cascade_config, which delegates to us. *)
@@ -36,7 +36,7 @@ let resolve (spec : string) : resolution =
          "malformed spec %S: expected \"provider:model\" or \"custom:model@url\""
          spec)
   | Some ("custom", rest) ->
-    let model_id, base_url = Cascade_model_resolve.parse_custom_model rest in
+    let model_id, base_url = Runtime_model_resolve.parse_custom_model rest in
     if model_id = "" then
       Unknown
         (Printf.sprintf "malformed custom spec %S: empty model id" spec)

--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -114,9 +114,9 @@ let default_registry = Llm_provider.Provider_registry.default ()
     Resolution order:
     1. Capabilities.for_model_id — per-model override (e.g. <provider>-<model> -> max_context)
     2. Provider_registry.find — provider-level default (e.g. <provider_slug> -> max_context)
-    3. {!Cascade_runtime.fallback_context_window} *)
+    3. {!Runtime_constants.fallback_context_window} *)
 let resolve_max_context model =
-  let fallback = Cascade_runtime.fallback_context_window in
+  let fallback = Runtime_constants.fallback_context_window in
   (* Layer 1: per-model capabilities (e.g. <provider>-<model> -> max_context) *)
   let from_caps =
     match Llm_provider.Capabilities.for_model_id model with

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -98,3 +98,11 @@ let get_default_runtime_id () =
       "Runtime.get_default_runtime_id: default runtime not initialized; \
        Runtime.init_default must run at startup (no silent fallback — RFC-0206 §2.1)"
 ;;
+
+(* Path to the runtime config TOML (re-homed from deleted
+   [Cascade_runtime.cascade_config_path]). Delegates to the surviving
+   [Config_dir_resolver]; the file is still [cascade.toml] (rename deferred). *)
+let config_path () : string option =
+  Config_dir_resolver.log_warnings ~context:"Runtime" ();
+  Config_dir_resolver.cascade_path_opt ()
+;;

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -100,7 +100,7 @@ let get_default_runtime_id () =
 ;;
 
 (* Path to the runtime config TOML (re-homed from deleted
-   [Cascade_runtime.cascade_config_path]). Delegates to the surviving
+   [Runtime.config_path]). Delegates to the surviving
    [Config_dir_resolver]; the file is still [cascade.toml] (rename deferred). *)
 let config_path () : string option =
   Config_dir_resolver.log_warnings ~context:"Runtime" ();

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -33,3 +33,8 @@ val get_default_runtime_id : unit -> string
     (RFC-0206 §2.1): an unresolved default is a startup-ordering bug, not a
     recoverable condition. Callers must invoke this at runtime, never as a
     module-level [let] binding (would crash config-less test binaries). *)
+
+val config_path : unit -> string option
+(** Path to the runtime config TOML, or [None] if unresolved. Re-homed from
+    deleted [Cascade_runtime.cascade_config_path] (delegates to
+    [Config_dir_resolver]). *)

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -36,5 +36,5 @@ val get_default_runtime_id : unit -> string
 
 val config_path : unit -> string option
 (** Path to the runtime config TOML, or [None] if unresolved. Re-homed from
-    deleted [Cascade_runtime.cascade_config_path] (delegates to
+    deleted [Runtime.config_path] (delegates to
     [Config_dir_resolver]). *)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -2,7 +2,7 @@
 
     Contains the [config] type, [build], [run], and [run_with_masc_tools]
     functions. All model-selection and cascade logic lives in
-    {!Cascade_observation} and {!Keeper_turn_driver}.
+    {!Keeper_observation} and {!Keeper_turn_driver}.
 
     @since God file decomposition — extracted from oas_worker.ml *)
 
@@ -91,7 +91,7 @@ type run_result = {
   turns : int;
   trace_ref : Agent_sdk.Raw_trace.run_ref option;
   run_validation : Agent_sdk.Raw_trace.run_validation option;
-  cascade_observation : Cascade_observation.cascade_observation option;
+  cascade_observation : Keeper_observation.cascade_observation option;
   stop_reason : stop_reason;
 }
 
@@ -115,7 +115,7 @@ let worker_lifecycle_classification_of_result = function
 (* ================================================================ *)
 
 (** Resolve a model label string to an OAS Provider.config.
-    Uses MASC [Cascade_config.parse_model_string] (with Provider_registry as SSOT).
+    Uses MASC [Runtime_model_string.parse_model_string] (with Provider_registry as SSOT).
     Explicit model-label execution must never silently substitute a
     discovery-only model. Callers are expected to validate labels
     before reaching this helper. *)
@@ -726,7 +726,7 @@ let run
     Log.Misc.error "oas_worker %s: execution exception: %s\nBacktrace: %s"
       config.name (Printexc.to_string exn) bt;
     (* Keep the typed internal-error envelope, but construct it locally so
-       Runtime_agent does not depend on Cascade_error_classify. *)
+       Runtime_agent does not depend on Keeper_meta_contract. *)
     let typed_internal_error =
       "[masc_oas_error] "
       ^ Yojson.Safe.to_string

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -10,7 +10,7 @@
     diagnostics) are owned by {!Runtime_transport}.
 
     All model-selection and cascade logic lives in
-    {!Cascade_observation} and {!Keeper_turn_driver}.
+    {!Keeper_observation} and {!Keeper_turn_driver}.
 
     Internal helpers stay private at this boundary
     ([invalid_runtime_config],
@@ -131,7 +131,7 @@ type run_result = {
   turns : int;
   trace_ref : Agent_sdk.Raw_trace.run_ref option;
   run_validation : Agent_sdk.Raw_trace.run_validation option;
-  cascade_observation : Cascade_observation.cascade_observation option;
+  cascade_observation : Keeper_observation.cascade_observation option;
   stop_reason : stop_reason;
 }
 

--- a/lib/runtime/runtime_constants.ml
+++ b/lib/runtime/runtime_constants.ml
@@ -5,6 +5,6 @@
     context compaction). No routing/catalog state — pure named values. *)
 
 (** Context-window size assumed when a model declares none and discovery
-    yields nothing. Mirrors the deleted [Cascade_runtime.fallback_context_window].
+    yields nothing. Mirrors the deleted [Runtime_constants.fallback_context_window].
     128k is the conservative floor across the supported provider matrix. *)
 let fallback_context_window = 128_000

--- a/lib/runtime/runtime_constants.mli
+++ b/lib/runtime/runtime_constants.mli
@@ -2,4 +2,4 @@
 
 val fallback_context_window : int
 (** Context-window size assumed when a model declares none and discovery yields
-    nothing (128000). Mirrors deleted [Cascade_runtime.fallback_context_window]. *)
+    nothing (128000). Mirrors deleted [Runtime_constants.fallback_context_window]. *)

--- a/lib/runtime/runtime_model_resolve.ml
+++ b/lib/runtime/runtime_model_resolve.ml
@@ -1,0 +1,168 @@
+(** Model ID resolution for cascade provider labels.
+
+    Pure functions that map user-facing [auto] selectors through the OAS
+    provider runtime binding projection. Provider-specific alias/catalog truth
+    belongs upstream in OAS, not in MASC cascade code.
+    No side effects beyond reading environment variables.
+
+    @since 0.92.0 extracted from Cascade_config *)
+
+type model_selector =
+  | Concrete of string
+  | Auto
+
+let model_selector_of_string s =
+  if String.equal (String.lowercase_ascii (String.trim s)) "auto"
+  then Auto
+  else Concrete s
+;;
+
+type model_resolution_provenance =
+  | Explicit_input
+  | Env_default of string
+  | Binding_default
+  | Discovery
+  | Unresolved_auto
+
+type model_resolution =
+  { requested_model_id : string
+  ; resolved_model_id : string
+  ; provenance : model_resolution_provenance
+  }
+
+let env_value_opt ?(getenv = Sys.getenv_opt) var =
+  match getenv var with
+  | Some v ->
+    let trimmed = String.trim v in
+    if String.equal trimmed "" then None else Some trimmed
+  | None -> None
+;;
+
+let explicit_resolution requested_model_id resolved_model_id =
+  { requested_model_id; resolved_model_id; provenance = Explicit_input }
+;;
+
+let unresolved_auto requested_model_id =
+  { requested_model_id
+  ; resolved_model_id = requested_model_id
+  ; provenance = Unresolved_auto
+  }
+;;
+
+let binding_default requested_model_id resolved_model_id =
+  { requested_model_id; resolved_model_id; provenance = Binding_default }
+;;
+
+let default_resolution ?getenv provider_name ~requested_model_id =
+  match
+    Provider_runtime_projection.default_model_candidate_for_cascade_prefix
+      ?getenv
+      provider_name
+  with
+  | Some
+      { source = Provider_runtime_projection.Env_var env_var
+      ; model_id = resolved_model_id
+      } ->
+    { requested_model_id; resolved_model_id; provenance = Env_default env_var }
+  | Some
+      { source = Provider_runtime_projection.Binding_default
+      ; model_id = resolved_model_id
+      } ->
+    binding_default requested_model_id resolved_model_id
+  | None -> unresolved_auto requested_model_id
+;;
+
+let env_fragment value =
+  value
+  |> String.map (function
+    | 'a' .. 'z' as c -> Char.uppercase_ascii c
+    | 'A' .. 'Z' | '0' .. '9' as c -> c
+    | _ -> '_')
+;;
+
+let csv_items raw =
+  raw
+  |> String.split_on_char ','
+  |> List.map String.trim
+  |> List.filter (fun value -> not (String.equal value ""))
+;;
+
+let default_auto_models_for_profile (profile : Provider_runtime_projection.provider_profile)
+  =
+  match profile.supported_models, profile.runtime_kind with
+  | _ :: _ as models, _ -> Some models
+  | [], Provider_runtime_projection.Cli_agent -> Some [ "auto" ]
+  | [], (Provider_runtime_projection.Local | Provider_runtime_projection.Direct_api) ->
+    None
+;;
+
+let auto_models_for_cascade_prefix ?getenv provider_name =
+  match Provider_runtime_projection.provider_profile_for_cascade_prefix provider_name with
+  | None -> None
+  | Some profile ->
+    let defaults = default_auto_models_for_profile profile in
+    let env_var = "MASC_" ^ env_fragment profile.id ^ "_AUTO_MODELS" in
+    (match env_value_opt ?getenv env_var with
+     | Some raw ->
+       (match csv_items raw with
+        | [] -> defaults
+        | items -> Some items)
+     | None -> defaults)
+;;
+
+(** Resolve "auto" and aliases to concrete model IDs.
+    Cloud APIs generally require concrete model names, and local
+    providers (llama, ollama) also cannot accept the literal "auto" model ID.
+
+    For local providers, "auto" is resolved via {!Llm_provider.Discovery.first_discovered_model_id}
+    which returns models from the last endpoint probe. Callers should
+    resolve the model_id before invoking [Llm_provider.Discovery.endpoint_for_model]
+    to avoid routing mismatches. *)
+let resolve_auto_model
+      ?getenv
+      ?(discover = Llm_provider.Discovery.first_discovered_model_id)
+      provider_name
+      selector
+  =
+  let model_id =
+    match selector with
+    | Concrete s -> s
+    | Auto -> "auto"
+  in
+  match Provider_runtime_projection.provider_profile_for_cascade_prefix provider_name with
+  | Some { runtime_kind = Provider_runtime_projection.Local; _ } ->
+    (match selector with
+     | Auto ->
+       (match discover () with
+        | Some resolved_model_id ->
+          { requested_model_id = model_id; resolved_model_id; provenance = Discovery }
+        | None -> default_resolution ?getenv provider_name ~requested_model_id:model_id)
+     | Concrete _ -> explicit_resolution model_id (String.trim model_id))
+  | Some _ ->
+    (match selector with
+     | Auto -> default_resolution ?getenv provider_name ~requested_model_id:model_id
+     | Concrete _ -> explicit_resolution model_id (String.trim model_id))
+  | None ->
+    (match selector with
+     | Auto -> unresolved_auto model_id
+     | Concrete _ -> explicit_resolution model_id (String.trim model_id))
+;;
+
+let resolve_auto_model_id provider_name model_id =
+  (resolve_auto_model provider_name (model_selector_of_string model_id)).resolved_model_id
+;;
+
+let parse_custom_model model_id =
+  match String.index_opt model_id '@' with
+  | Some at_idx ->
+    let model = String.sub model_id 0 at_idx in
+    let url = String.sub model_id (at_idx + 1) (String.length model_id - at_idx - 1) in
+    model, url
+  | None ->
+    let url =
+      match env_value_opt "CUSTOM_LLM_BASE_URL" with
+      | Some u -> u
+      | None -> Llm_provider.Discovery.default_endpoint
+    in
+    model_id, url
+;;

--- a/lib/runtime/runtime_model_resolve.mli
+++ b/lib/runtime/runtime_model_resolve.mli
@@ -1,0 +1,53 @@
+(** Model ID resolution through OAS runtime provider bindings.
+
+    Pure functions that map [auto] to runtime binding defaults or local
+    discovery. Provider-specific alias/catalog truth belongs upstream in OAS.
+
+    @since 0.92.0 extracted from Cascade_config
+
+    @stability Internal
+    @since 0.93.1 *)
+
+type model_selector =
+  | Concrete of string
+  | Auto
+
+val model_selector_of_string : string -> model_selector
+
+type model_resolution_provenance =
+  | Explicit_input
+  | Env_default of string
+  | Binding_default
+  | Discovery
+  | Unresolved_auto
+
+type model_resolution =
+  { requested_model_id : string
+  ; resolved_model_id : string
+  ; provenance : model_resolution_provenance
+  }
+
+(** Resolve provider:auto expansion for any registered cascade provider. *)
+val auto_models_for_cascade_prefix
+  :  ?getenv:(string -> string option)
+  -> string
+  -> string list option
+
+(** Resolve ["auto"] for any provider. Local providers resolve ["auto"] via
+    {!Llm_provider.Discovery.first_discovered_model_id}; non-local providers
+    use OAS runtime binding defaults. *)
+val resolve_auto_model
+  :  ?getenv:(string -> string option)
+  -> ?discover:(unit -> string option)
+  -> string
+  -> model_selector
+  -> model_resolution
+
+val resolve_auto_model_id : string -> string -> string
+
+(** Parse a "model@url" custom model spec.
+    Returns [(model_id, base_url)].
+    Without [@], uses [CUSTOM_LLM_BASE_URL] env or the local discovery
+    default endpoint. Prefer explicit cascade provider endpoints for
+    operator-configured routing. *)
+val parse_custom_model : string -> string * string

--- a/lib/runtime/runtime_model_string.ml
+++ b/lib/runtime/runtime_model_string.ml
@@ -1,0 +1,220 @@
+(** Model-label string → [Provider_config.t] resolution (RFC-0206).
+
+    Re-homed from the deleted [Cascade_config_parser.parse_model_string] path.
+    Resolves a ["provider:model"] (or ["custom:model@url"]) label to a hot-path
+    {!Llm_provider.Provider_config.t} using {!Llm_provider.Provider_registry} as
+    the single source of truth — NO cascade routing/weighted-entry machinery is
+    ported (the weighted-entry / selection / strategy parsing stayed deleted).
+
+    Provider identity helpers live in {!Runtime_provider_binding}; auto-model
+    resolution in {!Runtime_model_resolve}; kind classification in
+    {!Provider_kind_resolver} (all surviving). *)
+
+module Binding = Runtime_provider_binding
+
+let default_registry = Llm_provider.Provider_registry.default ()
+
+(** Split a ["provider:model_id"] string at the first colon. [None] if the
+    colon is missing, leading, or trailing. *)
+let split_provider_model (s : string) : (string * string) option =
+  match String.index_opt s ':' with
+  | None -> None
+  | Some idx ->
+    if idx = 0 || idx >= String.length s - 1
+    then None
+    else (
+      let provider_name = String.sub s 0 idx |> String.trim |> String.lowercase_ascii in
+      let model_id = String.sub s (idx + 1) (String.length s - idx - 1) |> String.trim in
+      if model_id = "" then None else Some (provider_name, model_id))
+;;
+
+(** Build a config for ["custom:model@url"] specs. *)
+let make_custom_config
+  ~temperature
+  ~max_tokens
+  ?system_prompt
+  ?supports_tool_choice_override
+  ?keep_alive
+  ?num_ctx
+  model_id
+  =
+  let actual_model, base_url = Runtime_model_resolve.parse_custom_model model_id in
+  if actual_model = ""
+  then None
+  else
+    Some
+      (Llm_provider.Provider_config.make
+         ~kind:Provider_d_compat
+         ~model_id:actual_model
+         ~base_url
+         ~request_path:
+           (Binding.normalize_openai_compat_request_path
+              ~base_url
+              ~request_path:Masc_network_defaults.openai_chat_completions_path)
+         ~temperature
+         ~max_tokens
+         ?system_prompt
+         ?supports_tool_choice_override
+         ?keep_alive
+         ?num_ctx
+         ())
+;;
+
+(** Resolve the effective API-key env var: per-provider override, then
+    wildcard ["*"], then registry default. Empty entries fall through. *)
+let resolve_effective_api_key_env
+  ~(api_key_env_overrides : (string * string) list)
+  ~(provider_name : string)
+  ~(registry_default : string)
+  =
+  let find_non_empty key =
+    match List.assoc_opt key api_key_env_overrides with
+    | Some v when v <> "" -> Some v
+    | _ -> None
+  in
+  match find_non_empty provider_name with
+  | Some env -> env
+  | None ->
+    (match find_non_empty "*" with
+     | Some env -> env
+     | None -> registry_default)
+;;
+
+(** Build a {!Llm_provider.Provider_config.t} from a resolved registry entry. *)
+let make_registry_config
+  ~temperature
+  ~max_tokens
+  ?system_prompt
+  ?(api_key_env_overrides = [])
+  ?supports_tool_choice_override
+  ?keep_alive
+  ?num_ctx
+  ~provider_name
+  ~model_id
+  (entry : Llm_provider.Provider_registry.entry)
+  =
+  let defaults = entry.defaults in
+  let effective_api_key_env =
+    resolve_effective_api_key_env
+      ~api_key_env_overrides
+      ~provider_name
+      ~registry_default:defaults.api_key_env
+  in
+  let api_key =
+    if effective_api_key_env = ""
+    then ""
+    else Sys.getenv_opt effective_api_key_env |> Option.value ~default:""
+  in
+  let headers = Binding.headers_with_auth ~kind:defaults.kind ~api_key in
+  let discover =
+    if Binding.provider_name_matches_kind_default provider_name Ollama
+    then
+      Some
+        (fun () ->
+          Llm_provider.Discovery.first_discovered_model_id_for_url defaults.base_url)
+    else if Binding.provider_name_matches_default_local_openai_runtime provider_name
+    then Some Llm_provider.Discovery.first_discovered_model_id
+    else None
+  in
+  let model_resolution =
+    Runtime_model_resolve.resolve_auto_model
+      ?discover
+      provider_name
+      (Runtime_model_resolve.model_selector_of_string model_id)
+  in
+  let resolved_model_id = model_resolution.resolved_model_id in
+  let base_url =
+    if Binding.provider_name_matches_default_local_openai_runtime provider_name
+    then (
+      match Llm_provider.Discovery.endpoint_for_model resolved_model_id with
+      | Some url -> url
+      | None -> Llm_provider.Provider_registry.next_llama_endpoint ())
+    else defaults.base_url
+  in
+  let request_path =
+    match defaults.kind with
+    | Provider_d_compat ->
+      Binding.normalize_openai_compat_request_path
+        ~base_url
+        ~request_path:defaults.request_path
+    | _ -> defaults.request_path
+  in
+  let max_context =
+    let caps =
+      Option.value
+        ~default:entry.capabilities
+        (Llm_provider.Capabilities.for_model_id resolved_model_id)
+    in
+    match caps.max_context_tokens with
+    | Some n -> n
+    | None -> entry.max_context
+  in
+  Llm_provider.Provider_config.make
+    ~kind:defaults.kind
+    ~model_id:resolved_model_id
+    ~base_url
+    ~api_key
+    ~headers
+    ~request_path
+    ~temperature
+    ~max_tokens
+    ~max_context
+    ?system_prompt
+    ?supports_tool_choice_override
+    ?keep_alive
+    ?num_ctx
+    ()
+;;
+
+(** Resolve a ["provider:model"] / ["custom:model@url"] label to a hot-path
+    provider config, or [None] when the provider is unregistered, unavailable,
+    or the spec is malformed. Kind classification goes through the sum-typed
+    {!Provider_kind_resolver} (Provider_registry as SSOT) — unknown specs are
+    never flattened to [Provider_d_compat]. *)
+let parse_model_string
+  ?(temperature = Llm_provider.Constants.Inference.default_temperature)
+  ?(max_tokens = Llm_provider.Constants.Inference.default_max_tokens)
+  ?system_prompt
+  ?(api_key_env_overrides = [])
+  ?supports_tool_choice_override
+  ?keep_alive
+  ?num_ctx
+  (s : string)
+  : Llm_provider.Provider_config.t option
+  =
+  let trimmed = String.trim s in
+  match split_provider_model trimmed with
+  | Some ("custom", model_id) ->
+    make_custom_config
+      ~temperature
+      ~max_tokens
+      ?system_prompt
+      ?supports_tool_choice_override
+      ?keep_alive
+      ?num_ctx
+      model_id
+  | _ ->
+    (match Provider_kind_resolver.resolve s with
+     | Unknown _ -> None
+     | Custom_url _ -> None
+     | Registered { provider_name; model_id; kind = resolved_kind } ->
+       (match Llm_provider.Provider_registry.find default_registry provider_name with
+        | None -> None
+        | Some entry when not (entry.is_available ()) -> None
+        | Some entry ->
+          if entry.defaults.kind <> resolved_kind
+          then None
+          else
+            Some
+              (make_registry_config
+                 ~temperature
+                 ~max_tokens
+                 ?system_prompt
+                 ~api_key_env_overrides
+                 ?supports_tool_choice_override
+                 ?keep_alive
+                 ?num_ctx
+                 ~provider_name
+                 ~model_id
+                 entry)))
+;;

--- a/lib/runtime/runtime_model_string.mli
+++ b/lib/runtime/runtime_model_string.mli
@@ -1,0 +1,22 @@
+(** Model-label string → [Provider_config.t] resolution (RFC-0206).
+    Re-homed from deleted [Cascade_config_parser.parse_model_string]; resolves
+    a ["provider:model"] / ["custom:model@url"] label via Provider_registry
+    (SSOT). No cascade routing/weighted-entry machinery. *)
+
+val split_provider_model : string -> (string * string) option
+(** Split ["provider:model_id"] at the first colon; [None] if missing/leading/
+    trailing colon or empty model id. *)
+
+val parse_model_string
+  :  ?temperature:float
+  -> ?max_tokens:int
+  -> ?system_prompt:string
+  -> ?api_key_env_overrides:(string * string) list
+  -> ?supports_tool_choice_override:bool
+  -> ?keep_alive:string
+  -> ?num_ctx:int
+  -> string
+  -> Llm_provider.Provider_config.t option
+(** Resolve a model label to a hot-path provider config. [None] when the
+    provider is unregistered, unavailable, or the spec is malformed. Unknown
+    specs are never flattened to a default kind (Provider_kind_resolver SSOT). *)

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -12,7 +12,7 @@ let default_config_path = Runtime.config_path
 
 let default_model_strings ~cascade_name =
   Cascade_runtime.default_model_strings
-    ~cascade_name:(Cascade_name.of_string_exn cascade_name)
+    ~cascade_name:(cascade_name)
 
 (* Named model execution *)
 

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -8,7 +8,7 @@
 
 (* Cascade profile defaults (moved from Cascade module) *)
 
-let default_config_path = Cascade_runtime.cascade_config_path
+let default_config_path = Runtime.config_path
 
 let default_model_strings ~cascade_name =
   Cascade_runtime.default_model_strings

--- a/lib/runtime/runtime_oas_runner.mli
+++ b/lib/runtime/runtime_oas_runner.mli
@@ -10,7 +10,7 @@
 (** {1 Cascade profile defaults} *)
 
 val default_config_path : unit -> string option
-(** Alias for [Cascade_runtime.cascade_config_path]. *)
+(** Alias for [Runtime.config_path]. *)
 
 val default_model_strings : cascade_name:string -> string list
 (** Alias for [Cascade_runtime.default_model_strings]. *)

--- a/lib/runtime/runtime_oas_runner.mli
+++ b/lib/runtime/runtime_oas_runner.mli
@@ -39,7 +39,7 @@ val resolve_cascade_providers :
   ?require_tool_choice_support:bool ->
   ?require_tool_support:bool ->
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
-  cascade_name:Cascade_name.t -> unit ->
+  cascade_name:string -> unit ->
   (Llm_provider.Provider_config.t list, string) result
 (** Resolve cascade provider configs via MASC Cascade_config. *)
 

--- a/lib/runtime/runtime_provider_binding.ml
+++ b/lib/runtime/runtime_provider_binding.ml
@@ -1,0 +1,186 @@
+(** Provider identity helpers shared across {!Cascade_config} submodules.
+
+    Extracted from the original [cascade_config.ml] godfile to give the
+    parsing/selection/resolve/strategy submodules a stable lowest layer.
+    Surface is unchanged: {!Cascade_config} re-exports every function in
+    this module so external callers continue to use the facade.
+
+    @stability Internal *)
+
+module Runtime_binding = Agent_sdk.Provider_runtime_binding
+
+let normalize_provider_id provider_id =
+  String.trim provider_id
+  |> String.lowercase_ascii
+  |> String.map (fun c -> if c = '-' then '_' else c)
+;;
+
+let runtime_binding_of_label label =
+  match Runtime_binding.find label with
+  | Some _ as found -> found
+  | None -> Runtime_binding.find (normalize_provider_id label)
+;;
+
+let provider_name_of_kind (kind : Llm_provider.Provider_config.provider_kind) =
+  let cfg =
+    Llm_provider.Provider_config.make ~kind ~model_id:"auto" ~base_url:"" ()
+  in
+  Llm_provider.Provider_registry.provider_name_of_config cfg
+;;
+
+let cascade_prefix_of_provider_kind kind =
+  let provider_name = provider_name_of_kind kind in
+  match runtime_binding_of_label provider_name with
+  | Some binding -> binding.Runtime_binding.id
+  | None -> provider_name
+;;
+
+let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
+  match Runtime_binding.binding_for_provider_config cfg with
+  | Some binding -> binding.Runtime_binding.id
+  | None -> Llm_provider.Provider_registry.provider_name_of_config cfg
+;;
+
+let provider_health_key_of_config (cfg : Llm_provider.Provider_config.t) =
+  match cfg.kind with
+  | Llm_provider.Provider_config.Provider_d_compat ->
+    let base_url = String.trim cfg.base_url in
+    if base_url = ""
+    then provider_label_of_config cfg
+    else Printf.sprintf "%s:%s@%s" (provider_label_of_config cfg) cfg.model_id base_url
+  | _ -> provider_label_of_config cfg
+;;
+
+let binding_auth_is_no_auth (binding : Runtime_binding.t) =
+  match binding.Runtime_binding.auth with
+  | Runtime_binding.No_auth -> true
+  | Runtime_binding.Api_key_env _
+  | Runtime_binding.Cli_cached_login
+  | Runtime_binding.Oauth_cached_login
+  | Runtime_binding.Setup_token_env _
+  | Runtime_binding.File _
+  | Runtime_binding.Exec _ -> false
+;;
+
+let binding_base_url_is_loopback (binding : Runtime_binding.t) =
+  let base_url = String.trim binding.Runtime_binding.base_url in
+  if base_url = ""
+  then false
+  else Uri.of_string base_url |> Uri.host |> Masc_network_defaults.is_loopback_host_opt
+;;
+
+let runtime_kind_of_binding (binding : Runtime_binding.t) =
+  match binding.Runtime_binding.transport with
+  | Runtime_binding.Cli -> "cli_agent"
+  | Runtime_binding.Http | Runtime_binding.Managed | Runtime_binding.Custom_provider_d_compat ->
+    if binding_auth_is_no_auth binding && binding_base_url_is_loopback binding
+    then "local"
+    else "direct_api"
+;;
+
+let is_binding_local_openai_runtime (binding : Runtime_binding.t) =
+  binding.Runtime_binding.kind = Llm_provider.Provider_config.Provider_d_compat
+  && String.equal (runtime_kind_of_binding binding) "local"
+;;
+
+let default_local_openai_runtime_provider_id () =
+  Runtime_binding.all ()
+  |> List.find_opt is_binding_local_openai_runtime
+  |> Option.map (fun binding -> binding.Runtime_binding.id)
+;;
+
+let provider_name_matches_default_local_openai_runtime provider_name =
+  match default_local_openai_runtime_provider_id () with
+  | Some id -> String.equal (normalize_provider_id provider_name) (normalize_provider_id id)
+  | None -> false
+;;
+
+let provider_name_matches_kind_default provider_name kind =
+  String.equal
+    (normalize_provider_id provider_name)
+    (normalize_provider_id (provider_name_of_kind kind))
+;;
+
+let display_provider_name provider_name =
+  match runtime_binding_of_label provider_name with
+  | Some binding -> binding.Runtime_binding.id
+  | None -> String.trim provider_name
+;;
+
+(* Build headers list with Authorization when api_key is present.
+   Provider_a/Provider_c use x-api-key; OpenAI-compat (including GLM) uses Bearer. *)
+let headers_with_auth ~(kind : Llm_provider.Provider_config.provider_kind) ~api_key =
+  let base = [("Content-Type", "application/json")] in
+  if api_key = "" then base
+    else match kind with
+    | Provider_a | Provider_c ->
+        ("x-api-key", api_key)
+        :: ("provider_a-version", "2023-06-01")
+        :: base
+    | Provider_d_compat | Ollama | Provider_f | Provider_k | Cli_tool_d | Provider_h ->
+        ("Authorization", "Bearer " ^ api_key) :: base
+    | Cli_tool_b | Cli_tool_c | Cli_tool_a -> []
+
+let trim_trailing_slash path =
+  if String.length path > 1 && String.ends_with ~suffix:"/" path then
+    String.sub path 0 (String.length path - 1)
+  else path
+
+let is_digit c = c >= '0' && c <= '9'
+
+let is_version_segment s =
+  let len = String.length s in
+  len >= 2
+  && s.[0] = 'v'
+  && let rec all_digits i =
+       i >= len || (is_digit s.[i] && all_digits (i + 1))
+     in
+     all_digits 1
+
+let last_path_segment path =
+  match String.rindex_opt path '/' with
+  | Some idx -> String.sub path (idx + 1) (String.length path - idx - 1)
+  | None -> path
+
+let strip_leading_version request_path =
+  let len = String.length request_path in
+  if len >= 4 && request_path.[0] = '/' && request_path.[1] = 'v'
+     && is_digit request_path.[2]
+  then
+    let rec find_slash i =
+      if i >= len then len
+      else if request_path.[i] = '/' then i
+      else find_slash (i + 1)
+    in
+    let slash_pos = find_slash 2 in
+    String.sub request_path slash_pos (len - slash_pos)
+  else
+    request_path
+
+let normalize_openai_compat_request_path ~base_url ~request_path =
+  let request_path =
+    match String.trim request_path with
+    | "" -> Masc_network_defaults.openai_chat_completions_path
+    | path -> path
+  in
+  let base_path =
+    Uri.path (Uri.of_string base_url) |> trim_trailing_slash
+  in
+  if base_path = "" || base_path = "/" then
+    request_path
+  else
+    let duplicated_prefix = base_path ^ "/" in
+    if String.starts_with ~prefix:duplicated_prefix request_path then
+      let suffix_start = String.length base_path + 1 in
+      "/"
+      ^ String.sub request_path suffix_start
+          (String.length request_path - suffix_start)
+    else if is_version_segment (last_path_segment base_path)
+         && String.length request_path >= 4
+         && request_path.[0] = '/'
+         && request_path.[1] = 'v'
+         && is_digit request_path.[2]
+    then
+      strip_leading_version request_path
+    else
+      request_path

--- a/lib/runtime/runtime_provider_binding.mli
+++ b/lib/runtime/runtime_provider_binding.mli
@@ -1,0 +1,56 @@
+(** Provider identity helpers shared across {!Cascade_config} submodules.
+
+    All functions are pure with respect to the runtime binding registry and
+    {!Llm_provider} SSOTs. No I/O. Intentionally kept stdlib-light: the
+    callers in {!Cascade_config_parser}, {!Cascade_config_selection},
+    {!Cascade_config_resolve}, and {!Cascade_config_strategy_resolve} pick up
+    these helpers as their lowest layer.
+
+    @stability Internal *)
+
+module Runtime_binding = Agent_sdk.Provider_runtime_binding
+
+val normalize_provider_id : string -> string
+(** Trim, lowercase, and replace [-] with [_] in a provider identifier so
+    label/binding lookups are case- and separator-insensitive. *)
+
+val runtime_binding_of_label : string -> Runtime_binding.t option
+(** Look up a runtime binding by raw label, falling back to
+    {!normalize_provider_id}-normalized form. *)
+
+val provider_name_of_kind :
+  Llm_provider.Provider_config.provider_kind -> string
+
+val cascade_prefix_of_provider_kind :
+  Llm_provider.Provider_config.provider_kind -> string
+
+val provider_label_of_config : Llm_provider.Provider_config.t -> string
+
+val provider_health_key_of_config : Llm_provider.Provider_config.t -> string
+(** Key used by {!Cascade_health_tracker}. For OpenAI-compatible configs
+    the model and base URL are appended so each endpoint is tracked
+    independently. *)
+
+val binding_auth_is_no_auth : Runtime_binding.t -> bool
+
+val binding_base_url_is_loopback : Runtime_binding.t -> bool
+
+val runtime_kind_of_binding : Runtime_binding.t -> string
+(** ["cli_agent"] | ["local"] | ["direct_api"]. *)
+
+val default_local_openai_runtime_provider_id : unit -> string option
+
+val provider_name_matches_default_local_openai_runtime : string -> bool
+
+val provider_name_matches_kind_default :
+  string -> Llm_provider.Provider_config.provider_kind -> bool
+
+val display_provider_name : string -> string
+
+val headers_with_auth :
+  kind:Llm_provider.Provider_config.provider_kind ->
+  api_key:string ->
+  (string * string) list
+
+val normalize_openai_compat_request_path :
+  base_url:string -> request_path:string -> string

--- a/lib/runtime/runtime_transport.ml
+++ b/lib/runtime/runtime_transport.ml
@@ -37,7 +37,7 @@ let provider_effective_max_turns _kind requested = requested
    removed. *)
 
 (** Resolve a model label string to an OAS Provider.config.
-    Uses MASC [Cascade_config.parse_model_string] (with Provider_registry as SSOT).
+    Uses MASC [Runtime_model_string.parse_model_string] (with Provider_registry as SSOT).
     Explicit model-label execution must never silently substitute a
     discovery-only model. Callers are expected to validate labels
     before reaching this helper. *)

--- a/lib/runtime/runtime_transport_label_resolution.ml
+++ b/lib/runtime/runtime_transport_label_resolution.ml
@@ -2,7 +2,7 @@
     cascade_transport.ml.
 
     Maps a string label to a {!Llm_provider.Provider_config.t} via
-    {!Cascade_config.parse_model_string}; unresolved labels become
+    {!Runtime_model_string.parse_model_string}; unresolved labels become
     [Error (Invalid_model_label _)] — execution never falls back to
     discovery-only models. *)
 
@@ -21,7 +21,7 @@ let label_resolution_error_to_sdk_error err =
 let resolve_provider_config_of_label (label : string)
   : (Llm_provider.Provider_config.t, label_resolution_error) result
   =
-  match Cascade_config.parse_model_string label with
+  match Runtime_model_string.parse_model_string label with
   | Some pc -> Ok pc
   | None ->
     Log.error

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -270,8 +270,8 @@ let start_keeper_loops
   in
   Masc_event_bus.set masc_event_bus;
   (* Event_bus → SSE bridge: relay both OAS and MASC buses to dashboard *)
-  Cascade_event_bridge.start ~sw ~clock ~config:state.room_config ~bus:event_bus;
-  Cascade_event_bridge.start ~sw ~clock ~config:state.room_config ~bus:masc_event_bus;
+  Keeper_event_bridge.start ~sw ~clock ~config:state.room_config ~bus:event_bus;
+  Keeper_event_bridge.start ~sw ~clock ~config:state.room_config ~bus:masc_event_bus;
   (* Compaction audit: subscribe to ContextCompactStarted/ContextCompacted and
      persist paired rows to [base_path/data/harness-compact/YYYY-MM/DD.jsonl]
      with rolling 14-day retention (override via

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -40,7 +40,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     | _ -> ());
   Tool_metrics_persist.start_flush_fiber ~sw ~clock ~base_path:state.room_config.base_path;
   (* Cascade trust JSONL snapshot fiber (Phase 0b observability).  Polls
-     [Cascade_health_tracker.global] every minute and appends one JSON
+     [Keeper_binding_health.global] every minute and appends one JSON
      object per tick to base_path/cascade_trust/YYYY-MM/DD.jsonl.  Phase 1
      (in-memory trust_score) consumes these snapshots offline to calibrate
      reward / decay defaults instead of magic numbers. *)

--- a/lib/server/server_routes_http_dashboard_provider_logs.ml
+++ b/lib/server/server_routes_http_dashboard_provider_logs.ml
@@ -40,7 +40,7 @@ let provider_log_error_json ~surface message =
     ]
 
 let load_provider_log_config () =
-  match Cascade_runtime.cascade_config_path () with
+  match Runtime.config_path () with
   | None -> Error "cascade config path unavailable"
   | Some path -> (
       match Cascade_declarative_parser.parse_file path with

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -430,7 +430,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          is fatal — the server cannot route turns without a default Runtime, so
          booting into a half-configured state only defers the failure to the
          first turn (cascade→Runtime vision: no silent fallback). *)
-      (match Cascade_runtime.cascade_config_path () with
+      (match Runtime.config_path () with
        | Some config_path ->
          (match Runtime.init_default ~config_path with
           | Ok () ->

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -203,7 +203,7 @@ let oas_completion_at ?runtime_pool ~model_id ~prompt ~max_tokens ~timeout_sec (
       let started = Time_compat.now () in
       let model_label = model_label_for_pool ~model_id runtime_pool in
       match
-        Cascade_config.parse_model_string ~max_tokens model_label
+        Runtime_model_string.parse_model_string ~max_tokens model_label
       with
       | None ->
           ( { success = false; latency_ms = 0; error = Some ("invalid model label: " ^ model_label) },

--- a/lib/tool_unified.ml
+++ b/lib/tool_unified.ml
@@ -123,5 +123,5 @@ let summary_report () : Yojson.Safe.t =
        Hashtbl dispatch path is now the only code path so the field
        carried no signal. *)
     ("registered_count", `Int (Tool_dispatch.registered_count ()));
-    ("cascade_metrics", Cascade_observation.cascade_metrics_json ());
+    ("cascade_metrics", Keeper_observation.cascade_metrics_json ());
   ]

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -56,8 +56,8 @@ let agent_config_of_worker_meta
   ; max_tokens = Some max_tokens
   ; max_turns = effective_max_turns meta
   ; temperature = Some Llm_provider.Constants.Inference_profile.worker_default.temperature
-  ; top_p = Some Cascade_worker_defaults.top_p
-  ; top_k = Some Cascade_worker_defaults.top_k
+  ; top_p = Some Llm_provider.Constants.Worker_sampling.top_p
+  ; top_k = Some Llm_provider.Constants.Worker_sampling.top_k
   ; (* min_p intentionally omitted: the constant is 0.0 (no-op) and some
        cloud providers (Groq, GLM) reject the field itself with
        "Invalid request: property 'min_p' is unsupported". OAS capability
@@ -158,7 +158,7 @@ let build_agent
     | None ->
       { Agent_sdk.Guardrails.tool_filter = AllowList tool_names
       ; max_tool_calls_per_turn =
-          Some Cascade_worker_defaults.max_tool_calls_per_turn
+          Some Llm_provider.Constants.Worker_sampling.max_tool_calls_per_turn
       }
   in
   let builder =
@@ -171,8 +171,8 @@ let build_agent
     | None -> b)
     |> Agent_sdk.Builder.with_max_turns config.max_turns
     |> Agent_sdk.Builder.with_temperature Llm_provider.Constants.Inference_profile.worker_default.temperature
-    |> Agent_sdk.Builder.with_top_p Cascade_worker_defaults.top_p
-    |> Agent_sdk.Builder.with_top_k Cascade_worker_defaults.top_k
+    |> Agent_sdk.Builder.with_top_p Llm_provider.Constants.Worker_sampling.top_p
+    |> Agent_sdk.Builder.with_top_k Llm_provider.Constants.Worker_sampling.top_k
     (* with_min_p intentionally omitted — see agent_config_of_worker_meta
        above for the reason. min_p of 0.0 is a no-op and cloud providers
        (Groq, GLM) reject the field itself. *)


### PR DESCRIPTION
## 목적

PR #19544(substrate foundation)에 이어 cascade→Runtime **consumer rewire**를 진행합니다. 삭제된 `Cascade_*` 모듈 참조를 복원된 `Runtime_*`/`Keeper_*` substrate로 재배선합니다. RFC: `docs/rfc/RFC-0206-runtime-concept-cascade-rebirth.md` (§9 범위, §10 매핑표).

## 변경

- **substrate 완성** (`cc934673a1`): `runtime_model_resolve` + `runtime_provider_binding` + `runtime_model_string`(parse_model_string fresh, Provider_registry SSOT) + `Runtime.config_path`. consumer rewire가 의존하는 마지막 공유 모듈.
- **mechanical rename** (`bf1545bc6f`): 결정론적 perl로 138파일의 same-module-restored 참조 일괄 치환 (Cascade_runner→Runtime_agent, Cascade_observation→Keeper_observation, Cascade_health_tracker→Keeper_binding_health, Cascade_transport*→Runtime_transport*, error_classify/internal_error→Keeper_meta_contract 등). **228 dangling ref 제거.**
- **Cascade_name → raw string** (`b9d0f38f67`): 128 refs. `Cascade_name.t`→`string`, 항등 변환(to_string/of_string_exn) 제거, of_string/of_string_or 3곳 수작업 collapse. RFC §5대로 문자열 wrapper 폐기 (shim 모듈 생성 거부 — 그건 금지된 워크어라운드).

**dangling 526 → 158.**

## 남은 작업 (이 PR 단독으로는 빌드되지 않음)

monolithic lib green은 다음이 모두 필요합니다(build @check가 노출):
- **(a)** 잔여 `Cascade_X.` 158 semantic refs — catalog snapshot/routing/runtime_candidate/inference의 DELETE-CALLSITE 및 single-binding collapse (RFC §10).
- **(b)** cascade purge의 선존 2nd-class 삭제모듈 refs — `Prometheus_cascade_metric_names`, `Keeper_cascade_profile/budget/engine`, `Oas_compat`(#19543 purge). 이 PR 범위 밖이지만 green엔 필요.

즉 "lib green"은 cascade purge **전체 consumer 복구**의 일부이며 다중 세션이 수렴 중입니다. 본 PR은 그 표면을 526→158로 축소합니다.

RFC: `docs/rfc/RFC-0206-runtime-concept-cascade-rebirth.md`
WORKAROUND-WAIVED: 본 PR은 워크어라운드를 *제거*함 (Cascade_name shim 생성 거부, routing-오염 cascade_metrics 미복원, tool_strict 이미 삭제). "shim"/"tool_strict" 언급은 거부/제거 대상 서술.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
