### PR TITLE
fix(dashboard): purge cascade consumers + retire dead WS parse worker

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -83,45 +83,6 @@ export type {
   ConfigEntrySource,
   DashboardConfigResponse,
 } from './schemas/dashboard-config'
-export {
-  fetchCascadeAuditRuns,
-  fetchCascadeClientCapacity,
-  fetchCascadeClientCapacityHistory,
-  fetchCascadeConfig,
-  fetchCascadeConfigRaw,
-  fetchCascadeHealth,
-  fetchCascadeProfiles,
-  fetchCascadeSlo,
-  fetchCascadeStrategyTrace,
-  updateCascadeConfigRaw,
-  updateKeeperCascade,
-} from './dashboard-cascade'
-export type {
-  CascadeAuditHop,
-  CascadeAuditHopStatus,
-  CascadeAuditRun,
-  CascadeAuditRunsResponse,
-  CascadeCandidate,
-  CascadeCapacityEventKind,
-  CascadeClientCapacityEntry,
-  CascadeClientCapacityHistoryEvent,
-  CascadeClientCapacityHistoryResponse,
-  CascadeClientCapacityResponse,
-  CascadeConfigResponse,
-  CascadeHealthProvider,
-  CascadeHealthResponse,
-  CascadeProviderStatus,
-  CascadeInvalidProfile,
-  CascadeKeeperProfile,
-  CascadeProfile,
-  CascadeRawConfigResponse,
-  CascadeSloResponse,
-  CascadeSloStatus,
-  CascadeStrategyTraceEvent,
-  CascadeStrategyTraceKind,
-  CascadeStrategyTraceResponse,
-  CascadeValidationStatus,
-} from './dashboard-cascade'
 export { reportToolHostFailure } from './tool-host-failure'
 export { fetchDashboardBootstrap, fetchDashboardShell } from './dashboard-hot'
 

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -13,7 +13,6 @@ import { Sparkline } from './common/sparkline'
 import { TextInput } from './common/input'
 import { ActivityHeatmap } from './activity-heatmap'
 import { KeeperPhaseTimeline } from './keeper-phase-strip'
-import { CascadeWaterfallPanel } from './cascade-waterfall'
 import { CollapsibleSection } from './common/collapsible'
 import {
   buildActionTimelineGroups,
@@ -454,7 +453,6 @@ export function ObservatoryActivityPanels() {
       <//>
 
       <${CollapsibleSection} title="캐스케이드 워터폴" mountWhenOpen>
-        <${CascadeWaterfallPanel} />
       <//>
 
       ${data && (data.stats.event_count ?? 0) > 0 ? html`

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -4,7 +4,6 @@ import { fetchBoard } from '../../api/board'
 import type { BoardPost } from '../../types/core'
 import { bridgePostsToTrace } from './anchored-thread-trace-bridge'
 import { unixishToMs } from '../../lib/format-time'
-import { bridgeCascadeEventsToTrace } from './cascade-hop-trace-bridge'
 import { bridgeDecisionsToTrace } from './decision-log-trace-bridge'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
 import { KeeperBadge } from '../keeper-badge'
@@ -12,10 +11,6 @@ import {
   fetchKeeperDecisions,
   type KeeperDecision,
 } from '../../api/dashboard'
-import {
-  fetchCascadeStrategyTrace,
-  type CascadeStrategyTraceEvent,
-} from '../../api/dashboard-cascade'
 import {
   createAnchoredThreadRailStore,
   type AnchoredThread,
@@ -66,7 +61,6 @@ const CONVERSATION_CONTEXT_BADGE_STYLE = {
 
 const EMPTY_POSTS: ReadonlyArray<BoardPost> = []
 const EMPTY_DECISIONS: ReadonlyArray<KeeperDecision> = []
-const EMPTY_CASCADE: ReadonlyArray<CascadeStrategyTraceEvent> = []
 
 interface ConversationContextSummary {
   readonly label: string
@@ -76,7 +70,6 @@ interface ConversationContextSummary {
 type ReplayRailItem =
   | { readonly source: 'thread'; readonly timestamp_ms: number; readonly post: BoardPost }
   | { readonly source: 'decision'; readonly id: string; readonly timestamp_ms: number; readonly decision: KeeperDecision }
-  | { readonly source: 'cascade'; readonly id: string; readonly timestamp_ms: number; readonly cascade: CascadeStrategyTraceEvent }
 
 async function fetchBoardPosts(): Promise<ReadonlyArray<BoardPost>> {
   try {
@@ -92,14 +85,6 @@ async function fetchKeeperDecisionEvents(): Promise<ReadonlyArray<KeeperDecision
     return (await fetchKeeperDecisions(200)).events
   } catch {
     return EMPTY_DECISIONS
-  }
-}
-
-async function fetchCascadeReplayEvents(): Promise<ReadonlyArray<CascadeStrategyTraceEvent>> {
-  try {
-    return (await fetchCascadeStrategyTrace({ limit: 200 })).events
-  } catch {
-    return EMPTY_CASCADE
   }
 }
 
@@ -131,7 +116,6 @@ export function IdeConversationRail() {
   const threadStore = useMemo(() => createAnchoredThreadRailStore(activeIdeFile.value), [])
   const [posts, setPosts] = useState<ReadonlyArray<BoardPost>>(EMPTY_POSTS)
   const [decisions, setDecisions] = useState<ReadonlyArray<KeeperDecision>>(EMPTY_DECISIONS)
-  const [cascadeEvents, setCascadeEvents] = useState<ReadonlyArray<CascadeStrategyTraceEvent>>(EMPTY_CASCADE)
   const [focusedId, setFocusedId] = useState<string | null>(null)
   const [replayUntilMs, setReplayUntilMs] = useState<number | null>(ideReplayUntilMs.value)
   const [activeFile, setActiveFile] = useState(activeIdeFile.value)
@@ -156,12 +140,10 @@ export function IdeConversationRail() {
     void Promise.all([
       fetchBoardPosts(),
       fetchKeeperDecisionEvents(),
-      fetchCascadeReplayEvents(),
-    ]).then(([nextPosts, nextDecisions, nextCascadeEvents]) => {
+    ]).then(([nextPosts, nextDecisions]) => {
       if (cancelled) return
       setPosts(nextPosts)
       setDecisions(nextDecisions)
-      setCascadeEvents(nextCascadeEvents)
     })
     return () => { cancelled = true }
   }, [])
@@ -201,15 +183,6 @@ export function IdeConversationRail() {
     knownPostIds.current = bridgePostsToTrace(posts.map(postToTraceInput), knownPostIds.current)
   }, [posts])
 
-  // RFC-0028 PR-δ-2 cascade-hop producer: each cascade strategy_trace
-  // event becomes a keeper-trace event the first time it is observed.
-  // Dedup key is `cascade:${cascade_name}:${cycle}:${ts}` so a server
-  // restart that resets cycle counters cannot collide with prior runs.
-  const knownCascadeKeys = useRef<ReadonlySet<string>>(new Set())
-  useEffect(() => {
-    knownCascadeKeys.current = bridgeCascadeEventsToTrace(cascadeEvents, knownCascadeKeys.current)
-  }, [cascadeEvents])
-
   // RFC-0028 PR-δ-3 decision-log producer: each KeeperDecision becomes a
   // keeper-trace event the first time it is observed. Dedup key is
   // `decision:${keeper_name}:${ts_unix}:${event_type}` since the
@@ -218,7 +191,7 @@ export function IdeConversationRail() {
   useEffect(() => {
     knownDecisionKeys.current = bridgeDecisionsToTrace(decisions, knownDecisionKeys.current)
   }, [decisions])
-  const replayItems = replayRailItems(posts, decisions, cascadeEvents)
+  const replayItems = replayRailItems(posts, decisions)
   const replayEvents = replayEventsForItems(replayItems)
   const visibleItemIds = new Set(filterReplayEvents(replayEvents, replayUntilMs).map(event => event.id))
   const visibleItems = replayUntilMs === null || replayEvents.length === 0
@@ -245,8 +218,7 @@ export function IdeConversationRail() {
         <span>REACTION THREAD</span>
         <span>
           ${visibleCounts.thread}/${posts.length} threads ·
-          ${visibleCounts.decision}/${decisions.length} decisions ·
-          ${visibleCounts.cascade}/${cascadeEvents.length} cascade
+          ${visibleCounts.decision}/${decisions.length} decisions
         </span>
       </div>
       <div class="ide-rail-scope" aria-label="Keeper workspace scope">
@@ -290,7 +262,6 @@ export function postsToAnchoredThreads(
 export function replayRailItems(
   posts: ReadonlyArray<BoardPost>,
   decisions: ReadonlyArray<KeeperDecision>,
-  cascadeEvents: ReadonlyArray<CascadeStrategyTraceEvent>,
 ): ReplayRailItem[] {
   return [
     ...posts.map(post => ({
@@ -303,12 +274,6 @@ export function replayRailItems(
       id: `decision-${index}`,
       timestamp_ms: unixishToMs(decision.ts_unix),
       decision,
-    })),
-    ...cascadeEvents.map((cascade, index) => ({
-      source: 'cascade' as const,
-      id: `cascade-${index}`,
-      timestamp_ms: unixishToMs(cascade.ts),
-      cascade,
     })),
   ]
     .filter(event => Number.isFinite(event.timestamp_ms))
@@ -383,7 +348,7 @@ function symbolHintFromText(text: string): string | undefined {
 function sourceCounts(items: ReadonlyArray<ReplayRailItem>) {
   return items.reduce(
     (acc, item) => ({ ...acc, [item.source]: acc[item.source] + 1 }),
-    { thread: 0, decision: 0, cascade: 0 },
+    { thread: 0, decision: 0 },
   )
 }
 
@@ -403,10 +368,7 @@ function ReplayRailCard(
       overlay,
     )
   }
-  if (item.source === 'decision') {
-    return DecisionCard(item, entries, overlay)
-  }
-  return CascadeCard(item)
+  return DecisionCard(item, entries, overlay)
 }
 
 function PostCard(
@@ -707,67 +669,6 @@ function decisionTelemetryQuery(decision: KeeperDecision, timestampMs: number): 
     decision.outcome ? `outcome:${decision.outcome}` : null,
     decision.tool ? `tool:${decision.tool}` : null,
     decision.model_used ? `model:${decision.model_used}` : null,
-    Number.isFinite(timestampMs) ? `ts:${Math.floor(timestampMs / 1000)}` : null,
-  ])
-}
-
-function CascadeCard(item: Extract<ReplayRailItem, { source: 'cascade' }>) {
-  const event = item.cascade
-  const routeLinks = cascadeRouteLinks(item)
-  const contextSummary = conversationContextSummary(routeLinks)
-  return html`
-    <li style=${{ display: 'block' }}>
-      <div
-        data-replay-source="cascade"
-        style=${{
-          display: 'grid',
-          gap: 'var(--sp-1)',
-          padding: 'var(--sp-2)',
-          background: 'var(--color-bg-elevated)',
-          border: '1px solid var(--color-border-default)',
-          borderLeft: '2px solid var(--color-accent-fg)',
-          borderRadius: 'var(--r-2)',
-        }}
-      >
-        <div style=${{ display: 'flex', alignItems: 'center', gap: 'var(--sp-2)' }}>
-          <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-accent-fg)', letterSpacing: '0.05em' }}>CASCADE</span>
-          <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-secondary)' }}>${event.cascade_name}</span>
-          ${contextSummary ? ConversationContextBadge(contextSummary) : null}
-          <span style=${{ marginLeft: 'auto', fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${formatThreadTime(item.timestamp_ms)}</span>
-        </div>
-        <p style=${{ margin: 0, color: 'var(--color-fg-secondary)', fontSize: 'var(--fs-12)' }}>
-          ${event.strategy} · ${event.kind} · ${event.candidates_in}->${event.candidates_out}
-        </p>
-        ${routeLinks.length > 0 ? html`
-          <div class="ide-conversation-route-links" aria-label="Cascade operational links">
-            ${routeLinks.map(link => ConversationRouteLink(link))}
-          </div>
-        ` : null}
-      </div>
-    </li>
-  `
-}
-
-function cascadeRouteLinks(
-  item: Extract<ReplayRailItem, { source: 'cascade' }>,
-): ReadonlyArray<IdeContextRouteLink> {
-  const event = item.cascade
-  return routeLinksForContext({
-    surface: 'Cascade',
-    label: `${event.cascade_name} ${event.kind}`,
-    sourceId: `cascade-${event.cascade_name}-${event.cycle}-${item.timestamp_ms}`,
-    telemetry: true,
-    telemetryQuery: cascadeTelemetryQuery(event, item.timestamp_ms),
-  })
-}
-
-function cascadeTelemetryQuery(event: CascadeStrategyTraceEvent, timestampMs: number): string {
-  return compactRouteQuery([
-    'cascade',
-    event.cascade_name,
-    `strategy:${event.strategy}`,
-    `cycle:${event.cycle}`,
-    `kind:${event.kind}`,
     Number.isFinite(timestampMs) ? `ts:${Math.floor(timestampMs / 1000)}` : null,
   ])
 }

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -5,12 +5,9 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import {
-  fetchCascadeProfiles,
   fetchDashboardGoalsTree,
   fetchKeeperConfig,
   patchKeeperConfig,
-  updateKeeperCascade,
-  type CascadeInvalidProfile,
 } from '../api/dashboard'
 import type { KeeperConfigUpdatePayload, SandboxProfile, SandboxNetworkMode, SharedMemoryScope } from '../api/dashboard'
 import type { GoalTreeNode, KeeperConfig, KeeperHookSlot } from '../types'
@@ -37,19 +34,11 @@ function MutedLabel({ children }: { children: unknown }) {
 const configResource = createAsyncResource<KeeperConfig>()
 const configState = configResource.state
 const configKeeperName = signal<string>('')
-type CascadeProfileCatalog = {
-  profiles: string[]
-  invalid_profiles: CascadeInvalidProfile[]
-}
-const cascadeProfilesResource = createAsyncResource<CascadeProfileCatalog>()
-const cascadeProfilesState = cascadeProfilesResource.state
 const goalOptionsResource = createAsyncResource<GoalTreeNode[]>()
 const goalOptionsState = goalOptionsResource.state
 const editMode = signal(false)
 const saving = signal(false)
 const saveError = signal<string | null>(null)
-const cascadeSaving = signal(false)
-const cascadeSaveError = signal<string | null>(null)
 
 // Draft values for editable fields (only used in edit mode)
 type EditDraft = {
@@ -264,14 +253,11 @@ export async function loadKeeperConfig(
 
 export function resetKeeperConfig(): void {
   configResource.reset()
-  cascadeProfilesResource.reset()
   goalOptionsResource.reset()
   configKeeperName.value = ''
   editMode.value = false
   editDraft.value = null
   saveError.value = null
-  cascadeSaveError.value = null
-  cascadeSaving.value = false
   runtimeDraft.value = null
   runtimeSaving.value = false
   hookFilterQuery.value = ''
@@ -289,13 +275,6 @@ export function peekKeeperConfigLoadStatus(
   const state = configState.value
   if (configKeeperName.value !== name) return 'other'
   return state.status
-}
-
-async function loadCascadeProfiles(options?: { force?: boolean }): Promise<void> {
-  const force = options?.force === true
-  if (!force && cascadeProfilesState.value.status === 'loaded') return
-  if (force) cascadeProfilesResource.reset()
-  await cascadeProfilesResource.load(() => fetchCascadeProfiles())
 }
 
 function flattenGoalTree(nodes: readonly GoalTreeNode[]): GoalTreeNode[] {
@@ -595,14 +574,10 @@ function cascadeSelectionSummary(c: KeeperConfig): string {
 
 export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   const state = configState.value
-  const cascadeState = cascadeProfilesState.value
 
   // Trigger load on first render or name change
   if (configKeeperName.value !== keeperName || state.status === 'idle') {
     void loadKeeperConfig(keeperName)
-  }
-  if (cascadeState.status === 'idle') {
-    void loadCascadeProfiles()
   }
   if (goalOptionsState.value.status === 'idle') {
     void loadGoalOptions()
@@ -662,25 +637,6 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     editMode.value = false
     editDraft.value = null
     saveError.value = null
-  }
-
-  async function saveCascadeSelection(nextCascadeName: string) {
-    const currentCascade = c.execution.selected_cascade_name || ''
-    if (!nextCascadeName || nextCascadeName === currentCascade) return
-    cascadeSaving.value = true
-    cascadeSaveError.value = null
-    try {
-      await updateKeeperCascade(keeperName, nextCascadeName)
-      await loadKeeperConfig(keeperName, { force: true })
-      await loadCascadeProfiles({ force: true })
-      showToast(`cascade 변경 완료: ${nextCascadeName}`, 'success')
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'cascade 변경 실패'
-      cascadeSaveError.value = message
-      showToast(message, 'error')
-    } finally {
-      cascadeSaving.value = false
-    }
   }
 
   async function saveConfig() {
@@ -772,19 +728,6 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     </details>
   `
 
-  const cascadeProfiles = cascadeState.status === 'loaded' ? cascadeState.data.profiles : []
-  const invalidCascadeProfiles =
-    cascadeState.status === 'loaded' ? cascadeState.data.invalid_profiles : []
-  const cascadeOptions = [
-    ...cascadeProfiles,
-    ...invalidCascadeProfiles.map((profile) => profile.name),
-  ]
-  const currentCascade = c.execution.selected_cascade_name || ''
-  const hasCascadeSelector =
-    currentCascade !== '' || cascadeOptions.length > 0 || cascadeState.status === 'loading'
-  const invalidCascadeSummary = invalidCascadeProfiles
-    .map((profile) => `${profile.name}: ${profile.errors.join('; ')}`)
-    .join(' | ')
   const goalState = goalOptionsState.value
   const goalOptionsLoaded = goalState.status === 'loaded'
   const goalOptions: GoalTreeNode[] = goalOptionsLoaded ? goalState.data : []
@@ -819,46 +762,8 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${MajorSectionHeader} title="소스" />
       <${Callout}
         title="Cascade 선택"
-        body=${hasCascadeSelector
-          ? '이 selector는 keeper TOML의 cascade_name 을 바꿉니다. catalog authoring source와 generated runtime JSON 경로는 아래 읽기 전용 메타데이터를 보세요.'
-          : cascadeSelectionSummary(c)}
+        body=${cascadeSelectionSummary(c)}
       />
-      ${hasCascadeSelector
-        ? html`
-            <label class="flex flex-col gap-1.5 py-2 px-3 rounded-[var(--r-1)] border border-card-border/50 bg-card/20 backdrop-blur-sm mb-1.5">
-              <${MutedLabel}>활성 cascade profile</${MutedLabel}>
-              <select
-                class="rounded-[var(--r-1)] border border-card-border/60 bg-[var(--color-bg-elevated)] px-3 py-2 text-xs font-semibold text-text-strong disabled:opacity-60"
-                value=${currentCascade}
-                disabled=${cascadeSaving.value || cascadeState.status === 'loading' || cascadeOptions.length === 0}
-                onChange=${(event: Event) => {
-                  const next = (event.currentTarget as HTMLSelectElement).value
-                  void saveCascadeSelection(next)
-                }}
-              >
-                ${currentCascade !== '' && !cascadeOptions.includes(currentCascade)
-                  ? html`<option value=${currentCascade}>${currentCascade}</option>`
-                  : null}
-                ${cascadeOptions.map((profileName) => html`
-                  <option value=${profileName}>${profileName}</option>
-                `)}
-              </select>
-              <span class="text-2xs text-[var(--color-fg-disabled)]">
-                ${cascadeSaving.value
-                  ? 'cascade_name 저장 중...'
-                  : cascadeState.status === 'loading'
-                    ? '사용 가능한 cascade profile 로딩 중...'
-                    : '변경 시 keeper manifest의 cascade_name 이 즉시 갱신됩니다.'}
-              </span>
-              ${cascadeSaveError.value
-                ? html`<span class="text-2xs text-[var(--color-status-err)]" role="alert">${cascadeSaveError.value}</span>`
-                : null}
-              ${invalidCascadeProfiles.length > 0
-                ? html`<span class="text-2xs text-[var(--color-status-warn)]">invalid profile ${invalidCascadeProfiles.length}개: ${invalidCascadeSummary}</span>`
-                : null}
-            </label>
-          `
-        : null}
       <${ConfigRow} label="기본 소스" value=${c.sources.default_source_kind || MISSING_DATA_DASH} />
       <${ConfigRow} label="선택 cascade" value=${c.execution.selected_cascade_name || MISSING_DATA_DASH} />
       ${c.execution.selected_cascade_canonical

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -1,11 +1,9 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
-import { useEffect, useState } from 'preact/hooks'
-import { fetchCascadeProfiles, updateKeeperCascade } from '../api/dashboard'
+import { useState } from 'preact/hooks'
 import { TimeAgo } from './common/time-ago'
-import { showToast } from './common/toast'
 import type { Keeper } from '../types'
-import { refreshDashboard, keepers } from '../store'
+import { keepers } from '../store'
 import { KeeperPhaseAndStage } from './keeper-phase-indicator'
 import { keeperDisplayModel } from '../lib/keeper-runtime-display'
 
@@ -21,102 +19,6 @@ function KeeperModelChip({ keeper }: { keeper: Keeper }) {
       class="inline-flex items-center py-0.5 px-2 rounded-[var(--r-1)] text-3xs font-mono bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-20)]"
       title=${`${display.label}: ${display.value}`}
     >${display.value}</span>
-  `
-}
-
-function KeeperCascadeSelector({ keeper }: { keeper: Keeper }) {
-  const [cascadeProfiles, setCascadeProfiles] = useState<Awaited<ReturnType<typeof fetchCascadeProfiles>> | null>(null)
-  const [draftCascade, setDraftCascade] = useState<{
-    keeperName: string
-    from: string
-    cascade: string
-  } | null>(null)
-
-  useEffect(() => {
-    let cancelled = false
-    fetchCascadeProfiles()
-      .then((next) => {
-        if (!cancelled) setCascadeProfiles(next)
-      })
-      .catch((err) => {
-        // P1 silent-failure fix: an empty selector previously rendered
-        // identically to "no profiles to switch between" (line 69 returns
-        // null when profiles + invalid_profiles <= 1).  Surfacing the
-        // failure to the console lets an operator distinguish "fetch
-        // failed" from "no profiles configured" via DevTools.
-        if (!cancelled) {
-          console.warn('[keeper-cascade-selector] fetchCascadeProfiles failed', err)
-        }
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-  const fallbackCascade = keeper.cascade_name || '(no cascade)'
-  const currentCascade = draftCascade?.keeperName === keeper.name && draftCascade.from === fallbackCascade
-    ? draftCascade.cascade
-    : fallbackCascade
-  const profiles = cascadeProfiles?.profiles ?? []
-  const invalidProfiles = cascadeProfiles?.invalid_profiles ?? []
-  if (profiles.length + invalidProfiles.length <= 1) return null
-
-  const invalidSummary = invalidProfiles
-    .map((profile) => `${profile.name}: ${profile.errors.join(' | ')}`)
-    .join('\n')
-  const knownValues = new Set([
-    ...profiles,
-    ...invalidProfiles.map((profile) => profile.name),
-  ])
-
-  return html`
-    <div class="flex min-w-0 items-center gap-1.5">
-      <select
-        aria-label="Cascade 프로필 선택"
-        class="min-w-0 max-w-full py-0.5 px-1 rounded-[var(--r-1)] text-3xs font-mono bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)] border border-[var(--color-border-default)] cursor-pointer"
-        title=${invalidProfiles.length > 0
-          ? `Cascade 프로필\n\n비활성화된 잘못된 프로필:\n${invalidSummary}`
-          : 'Cascade 프로필'}
-        value=${currentCascade}
-        onChange=${(e: Event) => {
-          const val = (e.target as HTMLSelectElement).value
-          const draft = { keeperName: keeper.name, from: fallbackCascade, cascade: val }
-          setDraftCascade(draft)
-          updateKeeperCascade(keeper.name, val)
-            .then(() => {
-              refreshDashboard()
-            })
-            .catch((err) => {
-              setDraftCascade((current) => current === draft ? null : current)
-              const msg = err instanceof Error ? err.message : 'Cascade 변경 실패'
-              showToast(msg, 'error')
-            })
-        }}
-      >
-        ${!knownValues.has(currentCascade) && currentCascade
-          ? html`<option value=${currentCascade}>${currentCascade} (current)</option>`
-          : null}
-        ${profiles.map((profile) => html`<option value=${profile}>${profile}</option>`)}
-        ${invalidProfiles.length > 0
-          ? html`<option disabled>──────── invalid ────────</option>`
-          : null}
-        ${invalidProfiles.map((profile) => html`
-          <option
-            value=${profile.name}
-            disabled
-            title=${profile.errors.join(' | ')}
-          >${profile.name} (invalid)</option>
-        `)}
-      </select>
-      ${invalidProfiles.length > 0
-        ? html`
-            <span
-              class="inline-flex items-center py-0.5 px-1.5 rounded-[var(--r-1)] text-3xs font-semibold bg-[var(--bad-10)] text-[var(--rose-light)] border border-[var(--bad-30)]"
-              title=${invalidSummary}
-            >${invalidProfiles.length} invalid</span>
-          `
-        : null}
-    </div>
   `
 }
 
@@ -188,7 +90,6 @@ export function KeeperDetailHeaderInfo({
           <h2 id=${titleId} class="m-0 text-lg font-semibold text-[var(--color-fg-primary)]">${keeper.name}</h2>
           <${KeeperPhaseAndStage} phase=${keeper.phase} pipelineStage=${keeper.pipeline_stage} phaseEnteredAtSec=${phaseEnteredAtSec} />
           <${KeeperModelChip} keeper=${keeper} />
-          <${KeeperCascadeSelector} keeper=${keeper} />
         </div>
         ${keeper.koreanName || keeper.created_at ? html`
           <div class="flex flex-wrap items-center gap-2 text-xs text-[var(--color-fg-muted)]">

--- a/dashboard/src/components/runtime-panel.test.ts
+++ b/dashboard/src/components/runtime-panel.test.ts
@@ -27,9 +27,6 @@ async function loadRuntimePanel() {
   vi.doMock('./cost-dashboard', () => ({
     CostDashboard: ({ view }: { view?: string }) => html`<div data-testid="cost-dashboard" data-view=${view ?? 'cost'}>CostDashboard</div>`,
   }))
-  vi.doMock('./cascade-inspector', () => ({
-    CascadeInspector: () => html`<div data-testid="cascade-inspector">CascadeInspector</div>`,
-  }))
   vi.doMock('./common/filter-chips', () => ({
     FilterChips: ({ chips, value }: { chips: { key: string; label: string }[]; value: string }) => html`
       <div data-testid="filter-chips" data-value=${value}>
@@ -68,23 +65,20 @@ describe('RuntimePanel', () => {
     vi.doUnmock('./prometheus-metrics')
     vi.doUnmock('./verification-specs-panel')
     vi.doUnmock('./cost-dashboard')
-    vi.doUnmock('./cascade-inspector')
     vi.doUnmock('./common/filter-chips')
     vi.doUnmock('./common/route-link')
   })
 
-  it('renders runtime panels by default and links cascade config to its canonical surface', async () => {
+  it('renders runtime panels and diagnostics links by default', async () => {
     route.value.params = {}
     const { RuntimePanel } = await loadRuntimePanel()
     render(html`<${RuntimePanel} />`, container)
     await flushUi()
 
     expect(container.textContent).toContain('OasHealthChip')
-    expect(container.textContent).toContain('Open Cascade Config')
     const routeLinks = Array.from(container.querySelectorAll('[data-testid="route-link"]'))
       .map(link => link.getAttribute('data-section'))
     expect(routeLinks).toEqual([
-      'cascade-config',
       'transport-health',
       'doctor',
       'feature-health',
@@ -92,7 +86,6 @@ describe('RuntimePanel', () => {
     expect(container.textContent).toContain('Diagnostics')
     expect(container.textContent).toContain('Transport diagnostics')
     expect(container.textContent).toContain('Feature cleanup')
-    expect(container.textContent).not.toContain('CascadeConfigPanel')
     expect(container.textContent).toContain('RuntimeMonitor')
     expect(container.textContent).toContain('PrometheusMetrics')
     expect(container.textContent).toContain('VerificationSpecsPanel')
@@ -122,14 +115,14 @@ describe('RuntimePanel', () => {
   })
 
   it('explicit drill-down views bypass progressive disclosure', async () => {
-    route.value.params = { view: 'inspector' }
+    route.value.params = { view: 'prometheus' }
     const { RuntimePanel } = await loadRuntimePanel()
     render(html`<${RuntimePanel} />`, container)
     await flushUi()
 
-    const inspector = container.querySelector('[data-testid="cascade-inspector"]')
-    expect(inspector).not.toBeNull()
-    expect(inspector?.closest('details')).toBeNull()
+    const prometheus = container.querySelector('[data-testid="prometheus"]')
+    expect(prometheus).not.toBeNull()
+    expect(prometheus?.closest('details')).toBeNull()
   })
 
   it('renders only OasHealthChip and RuntimeMonitor for providers view', async () => {
@@ -162,20 +155,18 @@ describe('RuntimePanel', () => {
 
     const chips = container.querySelectorAll('[data-testid="chip"]')
     // Chips are split across two FilterChips strips (Primary then Advanced)
-    // with a divider between them. Total count and label set unchanged; the
-    // positional order now reflects the Primary[default, providers, inspector]
-    // → Advanced[cost, audit, heuristics, stress, prometheus, verification]
-    // layout.
-    expect(chips.length).toBe(9)
+    // with a divider between them. The positional order reflects the
+    // Primary[default, providers] → Advanced[cost, audit, heuristics, stress,
+    // prometheus, verification] layout.
+    expect(chips.length).toBe(8)
     expect(chips[0]?.textContent).toBe('전체')
     expect(chips[1]?.textContent).toBe('런타임')
-    expect(chips[2]?.textContent).toBe('검사기')
-    expect(chips[3]?.textContent).toBe('비용 / 지연')
-    expect(chips[4]?.textContent).toBe('감사')
-    expect(chips[5]?.textContent).toBe('휴리스틱')
-    expect(chips[6]?.textContent).toBe('스트레스')
-    expect(chips[7]?.textContent).toBe('메트릭')
-    expect(chips[8]?.textContent).toBe('형식검증')
+    expect(chips[2]?.textContent).toBe('비용 / 지연')
+    expect(chips[3]?.textContent).toBe('감사')
+    expect(chips[4]?.textContent).toBe('휴리스틱')
+    expect(chips[5]?.textContent).toBe('스트레스')
+    expect(chips[6]?.textContent).toBe('메트릭')
+    expect(chips[7]?.textContent).toBe('형식검증')
   })
 
   it('routes runtime diagnostic views through CostDashboard', async () => {

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -34,7 +34,6 @@ import { RuntimeMonitor } from './runtime-monitor'
 import { PrometheusMetrics } from './prometheus-metrics'
 import { VerificationSpecsPanel } from './verification-specs-panel'
 import { TelemetryPanel, isTelemetryView, TELEMETRY_VIEW_CHIPS } from './telemetry-panel'
-import { CascadeInspector } from './cascade-inspector'
 import { RouteLink } from './common/route-link'
 
 type RuntimeView =
@@ -44,7 +43,6 @@ type RuntimeView =
   | 'audit'
   | 'heuristics'
   | 'stress'
-  | 'inspector'
   | 'prometheus'
   | 'verification'
 
@@ -55,7 +53,6 @@ const RUNTIME_VIEWS: RuntimeView[] = [
   'audit',
   'heuristics',
   'stress',
-  'inspector',
   'prometheus',
   'verification',
 ]
@@ -76,7 +73,6 @@ const activeView = computed<RuntimeView>(() => {
 const PRIMARY_VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
   { key: 'default', label: '전체' },
   { key: 'providers', label: '런타임' },
-  { key: 'inspector', label: '검사기' },
 ]
 
 // Advanced chips are infra/billing telemetry plus the raw / formal layers.
@@ -97,31 +93,6 @@ function updateViewParam(view: RuntimeView): void {
       ? { section: 'runtime' }
       : { section: 'runtime', view },
   )
-}
-
-function CascadeConfigCanonicalLink() {
-  return html`
-    <section
-      class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3"
-      aria-label="Cascade canonical surface"
-    >
-      <div class="flex flex-wrap items-center justify-between gap-3">
-        <div class="min-w-0">
-          <div class="text-sm font-semibold text-text-strong">Cascade Config</div>
-          <div class="mt-1 max-w-2xl text-xs leading-relaxed text-text-muted">
-            Providers, models, and routing rules are managed in the dedicated Cascade Config surface.
-          </div>
-        </div>
-        <${RouteLink}
-          tab="monitoring"
-          params=${{ section: 'cascade-config' }}
-          class="inline-flex min-h-9 items-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2 text-xs font-semibold text-text-strong transition-colors hover:border-[var(--color-border-strong)] hover:bg-[var(--color-bg-elevated)]"
-        >
-          Open Cascade Config
-        <//>
-      </div>
-    </section>
-  `
 }
 
 function HiddenDiagnosticsLinks() {
@@ -203,15 +174,12 @@ export function RuntimePanel() {
           `
         : isTelemetryView(view)
           ? html`<${TelemetryPanel} view=${view} />`
-        : view === 'inspector'
-          ? html`<${CascadeInspector} />`
         : view === 'prometheus'
           ? html`<${PrometheusMetrics} />`
         : view === 'verification'
           ? html`<${VerificationSpecsPanel} />`
         : html`
             <${OasHealthChip} />
-            <${CascadeConfigCanonicalLink} />
             <${HiddenDiagnosticsLinks} />
             <${CollapsibleSection} id="runtime-details-providers" title="런타임">
               <${RuntimeMonitor} />

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -9,7 +9,7 @@ import { sectionItemsForTab } from '../config/navigation'
 import { LoadingState } from './common/feedback-state'
 
 export type StatusSection =
-  | 'observatory' | 'journey' | 'agents' | 'runtime' | 'cascade-config'
+  | 'observatory' | 'journey' | 'agents' | 'runtime'
   | 'fleet-health' | 'doctor' | 'transport-health'
   | 'feature-health'
   | 'cognition'
@@ -37,9 +37,6 @@ const LazyAgentsUnified = lazy(async () => ({
 }))
 const LazyRuntimePanel = lazy(async () => ({
   default: (await import('./runtime-panel')).RuntimePanel,
-}))
-const LazyCascadeConfigPanel = lazy(async () => ({
-  default: (await import('./cascade-config-panel')).CascadeConfigPanel,
 }))
 const LazyFleetHealthPanel = lazy(async () => ({
   default: (await import('./fleet-health-panel')).FleetHealthPanel,
@@ -79,8 +76,6 @@ function renderSection(section: StatusSection) {
       return html`<${LazyJourneyPanel} />`
     case 'runtime':
       return html`<${LazyRuntimePanel} />`
-    case 'cascade-config':
-      return html`<${LazyCascadeConfigPanel} />`
     case 'fleet-health':
       return html`<${LazyFleetHealthPanel} />`
     case 'doctor':

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -150,7 +150,6 @@ describe('monitoring navigation labels', () => {
     expect(ids).toContain('fleet-health')
     expect(ids).toContain('runtime')
     expect(ids).toContain('observatory')
-    expect(allIds).toContain('cascade-config')
     expect(allIds).toContain('doctor')
     expect(allIds).toContain('transport-health')
     expect(allIds).toContain('feature-health')
@@ -191,7 +190,6 @@ describe('monitoring navigation labels', () => {
     const hiddenIds = sections.filter(item => item.hidden).map(item => item.id)
 
     expect(hiddenIds).toEqual([
-      'cascade-config',
       'doctor',
       'transport-health',
       'feature-health',
@@ -258,19 +256,9 @@ describe('normalizeRouteParams backward compat (RFC-MASC-006 Phase 0)', () => {
   })
 
   it('redirects standalone runtime diagnostics into runtime views', () => {
-    expect(normalizeRouteParams('monitoring', { section: 'cascade-inspector' })).toMatchObject({
-      section: 'runtime',
-      view: 'inspector',
-    })
     expect(normalizeRouteParams('monitoring', { section: 'cost' })).toMatchObject({
       section: 'runtime',
       view: 'cost',
-    })
-  })
-
-  it('redirects legacy runtime cascade view to the dedicated cascade config surface', () => {
-    expect(normalizeRouteParams('monitoring', { section: 'runtime', view: 'cascade' })).toMatchObject({
-      section: 'cascade-config',
     })
   })
 

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -18,7 +18,6 @@ type SurfaceSectionId =
   | 'agents'
   | 'cognition'
   | 'runtime'
-  | 'cascade-config' // Dedicated entry for cascade.toml TOML editor (formerly buried inside runtime/cascade view)
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
   | 'doctor'         // Dedicated entry for /api/v1/dashboard/doctor (formerly buried inside Command → Operations → Inspector → "진단" sub-tab)
   | 'transport-health' // Dedicated entry for /api/v1/dashboard/transport-health (was 5-hop buried inside Command → Operations → Inspector → "서버 설정" → ServerConfig → TransportHealthPanel)
@@ -194,13 +193,6 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'Observatory',
       description: 'Activity and runtime evidence.',
       params: { section: 'observatory' },
-    },
-    {
-      id: 'cascade-config',
-      label: 'Runtime Config',
-      description: 'Runtime providers, models and rules.',
-      params: { section: 'cascade-config' },
-      hidden: true,
     },
     {
       id: 'doctor',
@@ -379,7 +371,6 @@ export const SECTION_REDIRECTS: Record<TabSectionKey, SectionRedirect> = {
   'monitoring:attribution':   { section: 'fleet-health', view: 'attribution' },
   'monitoring:fsm-hub':      { section: 'agents', view: 'fsm' },
   'monitoring:metrics':      { section: 'runtime' },
-  'monitoring:cascade-inspector': { section: 'runtime', view: 'inspector' },
   'monitoring:cost': { section: 'runtime', view: 'cost' },
 
   // Dashboard consolidation Phase 1+6: command surface
@@ -433,11 +424,6 @@ export function normalizeRouteParams(tabId: TabId, params: Record<string, string
 
   if (!validSectionIds(typedTabId).includes(next.section as SurfaceSectionId)) {
     next.section = defaultParamsForTab(tabId).section ?? ''
-  }
-
-  if (tabId === 'monitoring' && next.section === 'runtime' && next.view === 'cascade') {
-    next.section = 'cascade-config'
-    delete next.view
   }
 
   if (!(tabId === 'code' && next.section === 'ide-shell')) {

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -31,10 +31,6 @@ type PendingRpc = {
   reject: (err: Error) => void
   timeout: ReturnType<typeof setTimeout>
 }
-type ParseWorkerJob = {
-  data: string
-  timeout: ReturnType<typeof setTimeout>
-}
 type DashboardRouteState = Pick<RouteState, 'tab' | 'params'>
 
 interface DashboardWsDiscovery {
@@ -127,62 +123,6 @@ export function clearDashboardWsDiscoveryCacheForTests(): void {
 // lets batch() coalesce all signal mutations in a single frame.
 const pendingInbound: Array<string | unknown> = []
 let flushHandle = 0
-
-// Phase 2 (PR-4.5): Offload JSON/SSE parsing to a Web Worker so the
-// main thread never blocks on large payloads.
-let parseWorker: Worker | null = null
-let workerJobId = 0
-const workerJobs = new Map<number, ParseWorkerJob>()
-
-function deliverParsedPayloads(payloads: unknown[]): void {
-  for (const payload of payloads) {
-    pendingInbound.push(payload)
-  }
-  scheduleFlush()
-}
-
-function fallbackParseWorkerJob(id: number): void {
-  const job = workerJobs.get(id)
-  if (!job) return
-  workerJobs.delete(id)
-  clearTimeout(job.timeout)
-  pendingInbound.push(job.data)
-  scheduleFlush()
-}
-
-function fallbackAllParseWorkerJobs(): void {
-  for (const id of Array.from(workerJobs.keys())) {
-    fallbackParseWorkerJob(id)
-  }
-  parseWorker?.terminate()
-  parseWorker = null
-}
-
-function initParseWorker(): Worker | null {
-  if (parseWorker) return parseWorker
-  if (typeof Worker === 'undefined') return null
-  try {
-    parseWorker = new Worker(
-      new URL('./workers/dashboard-ws.worker.ts', import.meta.url),
-    )
-    parseWorker.onmessage = (event) => {
-      const { id, payloads } = event.data as {
-        id: number
-        payloads: unknown[]
-      }
-      const job = workerJobs.get(id)
-      if (!job) return
-      workerJobs.delete(id)
-      clearTimeout(job.timeout)
-      deliverParsedPayloads(Array.isArray(payloads) ? payloads : [])
-    }
-    parseWorker.onerror = fallbackAllParseWorkerJobs
-    parseWorker.onmessageerror = fallbackAllParseWorkerJobs
-    return parseWorker
-  } catch {
-    return null
-  }
-}
 
 function scheduleFlush(): void {
   if (flushHandle) return
@@ -562,23 +502,10 @@ function processInboundMessage(data: string): void {
 
 function handleMessage(data: unknown): void {
   if (typeof data !== 'string') return
-  const worker = initParseWorker()
-  if (worker) {
-    const id = ++workerJobId
-    workerJobs.set(id, {
-      data,
-      timeout: setTimeout(() => {
-        fallbackParseWorkerJob(id)
-      }, DASHBOARD_WS_PARSE_TIMEOUT_MS),
-    })
-    try {
-      worker.postMessage({ id, data })
-    } catch {
-      fallbackParseWorkerJob(id)
-      parseWorker = null
-    }
-    return
-  }
+  // Inbound frames are parsed inline on the main thread. The PR-4.5 worker
+  // parse-offload path was retired when its source module
+  // (workers/dashboard-ws.worker.ts) was removed in dead-store sweep #18352;
+  // the worker had been failing to load and falling back here ever since.
   pendingInbound.push(data)
   scheduleFlush()
 }

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -49,11 +49,6 @@ async function refreshSurfaceReadinessSurface(): Promise<void> {
   await refreshSurfaceReadiness()
 }
 
-async function refreshCascadeInspectorSurface(): Promise<void> {
-  const { refreshCascadeInspector } = await import('./components/cascade-inspector')
-  await refreshCascadeInspector()
-}
-
 type RefreshTask =
   | 'shell'
   | 'namespaceTruth'
@@ -68,7 +63,6 @@ type RefreshTask =
   | 'toolQuality'
   | 'inspector'
   | 'surfaceReadiness'
-  | 'cascadeInspector'
   | 'operatorSnapshot'
   | 'operatorRoomDigest'
 
@@ -102,9 +96,6 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       }
       if (routeState.params.section === 'cognition') {
         return ['namespaceTruth', 'execution', 'missionSnapshot']
-      }
-      if (routeState.params.section === 'runtime' && routeState.params.view === 'inspector') {
-        return ['cascadeInspector']
       }
       // fleet-health: view-aware refresh (Phase 1 contract from tab-refresh.test.ts)
       if (routeState.params.section === 'fleet-health') {
@@ -172,7 +163,6 @@ const REFRESHERS: Record<RefreshTask, (routeState: Pick<RouteState, 'tab' | 'par
     void refreshDoctorSurface()
   },
   surfaceReadiness: () => { void refreshSurfaceReadinessSurface() },
-  cascadeInspector: () => { void refreshCascadeInspectorSurface() },
   operatorSnapshot: () => { void refreshOperatorSnapshot({ force: true }) },
   operatorRoomDigest: () => { void refreshOperatorRoomDigest({ force: true }) },
 }


### PR DESCRIPTION
## 문제

`masc-mcp` dashboard가 **옛 빌드(2026-05-25)로 서빙**되는 증상.

근본 원인은 **vite build가 깨져 있어서**입니다. PR #19536 (cascade purge)가
dashboard TS의 cascade 모듈 6개를 삭제했지만 이를 import하던 consumer는 정리하지
않아, `vite build`가 첫 unresolved import에서 실패했습니다. `make build`가 호출하는
`scripts/build-dashboard-if-needed.sh`는 이 실패를 `(non-fatal)`로 삼키고 exit 0
하므로, OCaml 바이너리는 새로 빌드되지만 SPA 산출물(`assets/dashboard/`)은 5/25
빌드본 그대로 남아 서빙됐습니다. (서버는 FS를 live로 읽으므로 재시작과는 무관.)

## 변경

삭제된 모듈을 참조하는 모든 dangling import 제거:

- `api/dashboard.ts` — `./dashboard-cascade` re-export 블록 제거
- `tab-refresh.ts` — cascadeInspector refresh task 제거
- `components/runtime-panel.ts` — inspector view + `CascadeInspector` + `CascadeConfigCanonicalLink` 제거
- `components/status.ts` / `config/navigation.ts` — cascade-config section, cascade-inspector redirect, runtime/cascade normalize 규칙 제거
- `components/ide/ide-conversation-rail.ts` — cascade replay rail 전체(source variant, `CascadeCard`, fetch, hop-trace bridge) 제거
- `components/activity-graph.ts` — `CascadeWaterfallPanel` 제거
- `components/keeper-config-panel.ts` / `keeper-detail-shell.ts` — cascade profile selector(`fetchCascadeProfiles`/`updateKeeperCascade`) 제거. 읽기 전용 `KeeperConfig` cascade 필드 표시는 유지

별건으로, `dashboard-ws.ts`의 죽은 WS parse-worker scaffolding을 제거했습니다.
worker source(`workers/dashboard-ws.worker.ts`)는 dead-store sweep #18352에서
삭제됐지만 `new Worker(new URL(...))` 참조가 남아 있었고, vite가 이 엔트리를
빌드타임에 정적 해석하면서 cascade 에러를 걷어내자 드러났습니다. worker는 #18352
이후 한 번도 로드된 적 없이 항상 inline parse로 폴백해 왔으므로, inline 경로로
단순화한 것은 동작 보존입니다.

## 검증

- `vite build` (pnpm run build): green, `✓ 2952 modules transformed`
- `vitest run navigation.test.ts runtime-panel.test.ts`: **53 passed** (cascade 동작을 검증하던 테스트 7개를 새 동작에 맞게 갱신)
- 변경 src 12파일, +28/-517. dangling import 0건 (grep 검증)

## 병합 후 필요 조치

이 PR은 worktree 산출물만 갱신합니다. 실행 중인 서버는 메인 repo의
`assets/dashboard`를 읽으므로, 병합 후 메인 repo에서 `make build`(또는 dashboard에서
`pnpm build`)를 1회 실행하면 서버 재시작 없이 다음 브라우저 로드부터 신선한
dashboard가 서빙됩니다.

RFC-WAIVED: dashboard SPA consumer 정리 + dead-code 제거. credential/operator/keeper sandbox/hooks/workflow subsystem 미해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
