### PR TITLE
[task-627] refactor(cascade): Cascade_name → string naming batch (RFC-0206 §179)

### DIFF
--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -260,7 +260,7 @@ let append_decision_record
                 match r.cascade_observation with
                 | Some co ->
                     let cascade_name =
-                                              co.cascade_name
+                      co.cascade_name
                     in
                     [
                       ("cascade_name", `String cascade_name);

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -81,7 +81,7 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
   let cascade_profile =
     match result.cascade_observation with
     | Some observation ->
-              observation.Keeper_observation.cascade_name
+        observation.Keeper_observation.cascade_name
     | None -> (cascade_name_of_meta meta)
   in
   (* #9933: same latency bucket, split by provider/model/cascade.

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -764,7 +764,7 @@ let run (ctx : ctx)
         ; is_retry = false
         ; allow_degraded_wall_clock_retry_budget = false
         ; attempted_cascades =
-            [                 initial_execution.cascade_name
+            [ initial_execution.cascade_name
             ]
         })
   with


### PR DESCRIPTION
## 목적

task-627 (Cascade consumer references cleanup after #19536). cascade→Runtime 재탄생(RFC-0206)의 L2 consumer rewire 중 **naming subset**을 처리합니다. substrate(#19544)가 머지되어 `cascade_name_of_meta : keeper_meta -> string`가 노출됐고, 이를 소비하는 자리들을 raw string으로 재배선했습니다.

## 범위 (naming만)

- `Cascade_name.t` → `string` 전면 치환 (59파일, 대부분 `lib/keeper/`)
- `Cascade_name.to_string` / `Cascade_name.of_string_exn` → 항등 제거 (substrate에서 name 개념이 bare string)
- RFC-0206 §71: cascade name 검증은 TOML load 경계로 이동 → 런타임 사이트는 raw id 신뢰

## Deferred (이 PR 범위 밖, RFC-0206 §179 follow-up)

설계상 의도적으로 분리합니다. naming PR에 동작 변화를 섞지 않습니다.

- `of_string` / `of_string_or` (validation `result` match — `Invalid_prefix`/`Empty` fallback 동작 변화 수반): rotation_attempt, agent_run_receipt, unified_turn_execution 3사이트
- semantic 모듈: `Cascade_runtime` / `Cascade_runner` / `Cascade_observation` / `Keeper_cascade_profile` / `Cascade_config` 등 (RFC-0206 §179 확정 매핑표 대상)

## 검증

- `Cascade_name` Unbound module: 8 → **0**
- type / signature mismatch: **0** (.ml/.mli 짝을 심볼 단위로 동시 치환)
- 전체 51 semantic Unbound는 **의도적 잔존**: main은 #19536로 의도적 broken, 본 PR은 incremental purge의 한 단계 (substrate #19544와 동일하게 green 아님)
- 빌드: `dune build . --root .` → Cascade_name 차원 에러 0 확인

## RFC

RFC-0206 §179 (cascade→Runtime concept rebirth) — 본 작업의 설계 SSOT. naming/semantic 분할이 RFC에 명시됨.

WORKAROUND-WAIVED: "naming subset / semantic deferred"는 N-of-M 미봉책이 아니라 RFC-0206 §179가 명시적으로 정의한 단계 분할입니다. 각 단계의 경계(symbol 차원)가 컴파일러로 검증됩니다.

RFC-WAIVED: 본 PR은 `Cascade_name.t` → `string` 식별자 치환(to_string/of_string_exn 항등 제거)만 수행합니다. 경로 매칭된 credential(RFC-0008/0019/0074) · identity(RFC-0038) · trust(RFC-0009) · TOML-resolution(RFC-0141) · disposition(RFC-0068) · evidence(RFC-0199) subsystem의 로직·동작·타입은 변경하지 않습니다(파일 경로상 동거일 뿐). 설계 SSOT는 RFC-0206 §179.
