### PR TITLE
refactor(keeper): cascade→Runtime 전멸 — FSM gate (cascade_state 제거 + compaction re-home) [RFC-0206 L2]

### DIFF
--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -15,7 +15,7 @@ let degraded_retry_cascade_of_wire ?(log_invalid = true) ~keeper_name raw =
   if String.equal trimmed "" then None
   else
     let normalized_declared =
-      try Keeper_cascade_profile.normalize_declared_name trimmed with
+      try String.trim trimmed with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | _ -> trimmed
     in

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -284,10 +284,10 @@ let fallback_cascade_for_unavailable_profile
     ~(base_cascade : string)
     ~(effective_cascade : string) : string option =
   let normalized_base =
-    Keeper_cascade_profile.normalize_declared_name base_cascade
+    String.trim base_cascade
   in
   let normalized_effective =
-    Keeper_cascade_profile.normalize_declared_name effective_cascade
+    String.trim effective_cascade
   in
   if not (String.equal normalized_effective normalized_base)
   then Some normalized_base
@@ -302,7 +302,7 @@ let degraded_retry_after_recoverable_error
     ~(tool_requirement : Keeper_agent_tool_surface.tool_requirement)
     (err : Agent_sdk.Error.sdk_error) : degraded_retry option =
   let normalized_effective =
-    Keeper_cascade_profile.normalize_declared_name effective_cascade
+    String.trim effective_cascade
   in
   let effective_is_declared_phase_buffer =
     is_declared_phase_alias effective_cascade (Keeper_config.default_cascade_name ())
@@ -508,7 +508,7 @@ let normalized_cascade_name ~catalog_names name =
     || String.equal trimmed (Keeper_config.default_cascade_name ())
     || String.equal trimmed (Keeper_config.default_cascade_name ())
   then trimmed
-  else Keeper_cascade_profile.normalize_declared_name trimmed
+  else String.trim trimmed
 
 let required_tool_rotation_candidate
     ?(allow_phase_recovery = false)

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -367,7 +367,7 @@ let normalize_social_model raw =
 ;;
 
 let normalize_cascade_name raw =
-  let normalized = Keeper_cascade_profile.normalize_declared_name raw in
+  let normalized = String.trim raw in
   let catalog =
     try Keeper_cascade_profile.catalog_names () with
     | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -19,10 +19,12 @@ include Keeper_registry_types_turn_phase
    [Keeper_registry_types_decision] (500-line decomp). *)
 include Keeper_registry_types_decision
 
-(* Cascade and compaction FSM types, witnesses, transitions, spec violation
-   types, and resolvers extracted to [Keeper_registry_types_cascade]
-   (500-line decomp). *)
-include Keeper_registry_types_cascade
+(* Compaction-stage (KMC) FSM types, witnesses, transitions, and spec
+   violations re-homed to [Keeper_registry_types_compaction] (RFC-0206). The
+   cascade selection FSM that shared the deleted [Keeper_registry_types_cascade]
+   module is removed — single-binding Runtime has no Selecting/Trying loop; turn
+   lifecycle is the surviving [turn_phase] FSM. *)
+include Keeper_registry_types_compaction
 
 type turn_measurement =
   { tm_captured_at : float
@@ -77,7 +79,6 @@ and turn_observation =
   ; last_progress_kind : string option
   ; turn_phase : packed_turn_phase
   ; decision_stage : packed_decision_stage
-  ; cascade_state : packed_cascade_state
   ; measurement : turn_measurement option
   ; measurement_bind_count : int
   ; selected_model : string option
@@ -88,7 +89,6 @@ and completed_turn_observation =
   ; ct_started_at : float
   ; ct_ended_at : float
   ; ct_decision_stage : packed_decision_stage
-  ; ct_cascade_state : packed_cascade_state
   ; ct_selected_model : string option
   }
 
@@ -109,32 +109,26 @@ let registry_key ~base_path name =
   base_path ^ "\x1f" ^ name
 ;;
 
-let turn_phase_of_cascade_state (s : packed_cascade_state) : packed_turn_phase =
-  match s with
-  | Packed Cascade_idle -> Packed Turn_prompting
-  | Packed Cascade_selecting -> Packed Turn_routing
-  | Packed Cascade_trying -> Packed Turn_executing
-  | Packed Cascade_done -> Packed Turn_finalizing
-  | Packed Cascade_exhausted -> Packed Turn_exhausted
-;;
-
 let completed_turn_outcome_of_observation (obs : turn_observation)
   : Keeper_transition_audit.completed_turn_outcome
   =
-  (* P1 silent-failure fix: the previous wildcard `| _ -> Turn_failed`
-     meant that adding a new variant to either ADT (decision_stage or
-     cascade_state) would silently fall through to Turn_failed without
-     a compile error.  Spelling out every variant lets the OCaml
-     exhaustiveness checker catch missing cases at build time. *)
+  (* RFC-0206: the cascade selection FSM was removed; turn substantiveness is
+     now read off the surviving [turn_phase] projection. Terminal
+     [Turn_finalizing] (the phase the deleted [turn_phase_of_cascade_state]
+     mapped [Cascade_done] onto) = substantive; every other phase = failed.
+     Exhaustive match (no wildcard) so a new turn_phase or decision_stage
+     variant fails the build rather than silently degrading to Turn_failed. *)
   match obs.decision_stage with
   | Packed Decision_gate_rejected -> Keeper_transition_audit.Turn_gate_rejected
   | Packed (Decision_undecided | Decision_guard_ok | Decision_tool_policy_selected) ->
-    (match obs.cascade_state with
-     | Packed Cascade_done -> Keeper_transition_audit.Turn_substantive
-     | Packed Cascade_idle
-     | Packed Cascade_selecting
-     | Packed Cascade_trying
-     | Packed Cascade_exhausted -> Keeper_transition_audit.Turn_failed)
+    (match obs.turn_phase with
+     | Packed Turn_finalizing -> Keeper_transition_audit.Turn_substantive
+     | Packed Turn_idle
+     | Packed Turn_prompting
+     | Packed Turn_routing
+     | Packed Turn_executing
+     | Packed Turn_compacting
+     | Packed Turn_exhausted -> Keeper_transition_audit.Turn_failed)
 ;;
 
 (* RFC-0002 Event Dispatch — lifecycle_event_origin type + pure helpers. *)

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -349,123 +349,6 @@ module Decision_transition : sig
   val to_tag : ('from, 'to_) t -> string
 end
 
-type cascade_state =
-  | Cascade_idle [@tla.idle]
-  | Cascade_selecting [@tla.active]
-  | Cascade_trying [@tla.active]
-  | Cascade_done [@tla.terminal]
-  | Cascade_exhausted [@tla.terminal]
-[@@deriving tla]
-
-(** {1 Cascade state GADT infrastructure (Cycle 21 / Tier B5)} *)
-
-type cascade_idle
-type cascade_selecting
-type cascade_trying
-type cascade_done
-type cascade_exhausted
-
-type 'a cascade_state_witness =
-  | Cascade_idle : cascade_idle cascade_state_witness
-  | Cascade_selecting : cascade_selecting cascade_state_witness
-  | Cascade_trying : cascade_trying cascade_state_witness
-  | Cascade_done : cascade_done cascade_state_witness
-  | Cascade_exhausted : cascade_exhausted cascade_state_witness
-
-type packed_cascade_state =
-  | Packed : 'a cascade_state_witness -> packed_cascade_state
-
-val cascade_state_to_witness : cascade_state -> packed_cascade_state
-val witness_to_cascade_state : packed_cascade_state -> cascade_state
-
-(** Diagnostic label using the constructor name (e.g.
-    ["Cascade_exhausted"]).  Used by the [Cascade_transition_violation]
-    [Printexc] printer to render the rejected pair. *)
-val packed_cascade_state_label : packed_cascade_state -> string
-
-(** RFC-0072 Phase 1: GADT-encoded cascade transitions.
-
-    Enumerates the 13 valid cross-state transitions of the 5-variant
-    [cascade_state] FSM.  The 7 forbidden pairs ([Idle -> Trying/Done/
-    Exhausted], [Selecting -> Done/Exhausted], [Done <-> Exhausted]) have
-    no constructor and are therefore type-unrepresentable.  Idempotent
-    self-loops are not represented (they are mutator-boundary no-ops). *)
-module Cascade_transition : sig
-  type ('from, 'to_) t =
-    | Idle_to_selecting : (cascade_idle, cascade_selecting) t
-    | Selecting_to_idle : (cascade_selecting, cascade_idle) t
-    | Selecting_to_trying : (cascade_selecting, cascade_trying) t
-    | Trying_to_idle : (cascade_trying, cascade_idle) t
-    | Trying_to_selecting : (cascade_trying, cascade_selecting) t
-    | Trying_to_done : (cascade_trying, cascade_done) t
-    | Trying_to_exhausted : (cascade_trying, cascade_exhausted) t
-    | Done_to_idle : (cascade_done, cascade_idle) t
-    | Done_to_selecting : (cascade_done, cascade_selecting) t
-    | Done_to_trying : (cascade_done, cascade_trying) t
-    | Exhausted_to_idle : (cascade_exhausted, cascade_idle) t
-    | Exhausted_to_selecting : (cascade_exhausted, cascade_selecting) t
-    | Exhausted_to_trying : (cascade_exhausted, cascade_trying) t
-
-  type packed = Packed_transition : ('a, 'b) t -> packed
-
-  val to_tag : ('a, 'b) t -> string
-end
-
-(** RFC-0072 Phase 1: typed error for cascade transition spec violations.
-    Each forbidden pair has its own constructor; replaces the prior
-    string-formatted [Invalid_argument] payload at the validator. *)
-type cascade_transition_spec_violation =
-  | Idle_to_trying
-  | Idle_to_done
-  | Idle_to_exhausted
-  | Selecting_to_done
-  | Selecting_to_exhausted
-  | Done_to_exhausted
-  | Exhausted_to_done
-
-val cascade_transition_spec_violation_to_tag
-  :  cascade_transition_spec_violation
-  -> string
-
-(** RFC-0072 Phase 5: raised by [validate_cascade_transition] and
-    [set_turn_cascade_state] on a forbidden cascade transition, carrying
-    the typed [cascade_transition_spec_violation] payload (replaces the
-    prior string-formatted [Invalid_argument]).  [where] is a diagnostic
-    label naming the raising function.  A [Printexc] printer is registered
-    so [Printexc.to_string] reproduces the original message text. *)
-exception
-  Cascade_transition_violation of
-    { where : string
-    ; from : packed_cascade_state
-    ; to_ : packed_cascade_state
-    ; violation : cascade_transition_spec_violation
-    }
-
-(** RFC-0072 Phase 1: resolve a (from, target) packed pair to one of
-    three outcomes: a typed transition value, an idempotent no-op, or a
-    typed spec violation.  Phase 2 will route [set_turn_cascade_state]
-    through this resolver. *)
-type cascade_resolve_outcome =
-  | Resolved_transition of Cascade_transition.packed
-  | Resolved_idempotent
-  | Resolved_violation of cascade_transition_spec_violation
-
-val resolve_cascade_transition
-  :  from:packed_cascade_state
-  -> target:packed_cascade_state
-  -> cascade_resolve_outcome
-
-(** Raises [Cascade_transition_violation] with the typed payload.
-    Previously a private helper inside Keeper_registry; exposed via the
-    intra-library split because [validate_cascade_transition] in
-    Keeper_registry calls it after moving the exception here. *)
-val raise_cascade_transition_violation
-  :  where:string
-  -> from:packed_cascade_state
-  -> to_:packed_cascade_state
-  -> violation:cascade_transition_spec_violation
-  -> 'a
-
 type compaction_stage =
   | Compaction_accumulating [@tla.idle]
   | Compaction_compacting [@tla.active]
@@ -638,7 +521,6 @@ and turn_observation = {
           refreshed [last_progress_at]. *)
   turn_phase : packed_turn_phase;
   decision_stage : packed_decision_stage;
-  cascade_state : packed_cascade_state;
   measurement : turn_measurement option;
   measurement_bind_count : int;
       (** Number of [Context_measured] snapshots bound to this live turn.
@@ -652,7 +534,6 @@ and completed_turn_observation = {
   ct_started_at : float;
   ct_ended_at : float;
   ct_decision_stage : packed_decision_stage;
-  ct_cascade_state : packed_cascade_state;
   ct_selected_model : string option;
 }
 
@@ -666,13 +547,8 @@ val try_resolve_done :
     after the intra-library split; not intended for external callers. *)
 val registry_key : base_path:string -> string -> string
 
-(** Pure mapping from cascade_state witness to its parent turn_phase
-    witness. Used by composite observer derivations. *)
-val turn_phase_of_cascade_state :
-  packed_cascade_state -> packed_turn_phase
-
 (** Classify a live turn_observation into a completed_turn_outcome
-    using exhaustive pattern matching on (decision_stage, cascade_state).
+    using exhaustive pattern matching on (decision_stage, turn_phase).
     Pure function, no state access. *)
 val completed_turn_outcome_of_observation :
   turn_observation -> Keeper_transition_audit.completed_turn_outcome

--- a/lib/keeper/keeper_registry_types_compaction.ml
+++ b/lib/keeper/keeper_registry_types_compaction.ml
@@ -1,0 +1,102 @@
+(** Keeper_registry_types_compaction — compaction-stage (KMC) FSM types and
+    transitions.
+
+    Re-homed from the deleted [Keeper_registry_types_cascade] (RFC-0206
+    cascade→Runtime rebirth). The compaction FSM is independent of the removed
+    cascade selection FSM — it tracks the keeper's context-compaction
+    sub-lifecycle (accumulate → compact → done) and survives the cascade purge.
+    Only the cascade_state half of the deleted module is dropped; this module
+    carries the compaction half verbatim so its GADT witnesses, transition
+    matrix, typed spec violations, and [Printexc] printer keep their contracts. *)
+
+type compaction_stage =
+  | Compaction_accumulating [@tla.idle]
+  | Compaction_compacting [@tla.active]
+  | Compaction_done [@tla.terminal]
+[@@deriving tla]
+
+(* Phantom witness types for compaction_stage GADT (Tier B5 pattern). *)
+type compaction_accumulating = |
+type compaction_compacting = |
+type compaction_done = |
+
+type 'a compaction_stage_witness =
+  | Compaction_accumulating : compaction_accumulating compaction_stage_witness
+  | Compaction_compacting : compaction_compacting compaction_stage_witness
+  | Compaction_done : compaction_done compaction_stage_witness
+
+type packed_compaction_stage =
+  | Packed : 'a compaction_stage_witness -> packed_compaction_stage
+
+let compaction_stage_to_witness : compaction_stage -> packed_compaction_stage = function
+  | Compaction_accumulating -> Packed Compaction_accumulating
+  | Compaction_compacting -> Packed Compaction_compacting
+  | Compaction_done -> Packed Compaction_done
+;;
+
+let witness_to_compaction_stage : packed_compaction_stage -> compaction_stage = function
+  | Packed Compaction_accumulating -> Compaction_accumulating
+  | Packed Compaction_compacting -> Compaction_compacting
+  | Packed Compaction_done -> Compaction_done
+;;
+
+(* Diagnostic label using the constructor name (e.g. ["Compaction_done"]).
+   Used by the [Compaction_transition_violation] [Printexc] printer.
+   Distinct from [Keeper_composite_observer.compaction_stage_to_string]
+   which emits a snake_case form for dashboards. *)
+let packed_compaction_stage_label : packed_compaction_stage -> string = function
+  | Packed Compaction_accumulating -> "Compaction_accumulating"
+  | Packed Compaction_compacting -> "Compaction_compacting"
+  | Packed Compaction_done -> "Compaction_done"
+;;
+
+(* RFC-0072 Phase 6: typed error for forbidden compaction-stage transitions.
+   One constructor per of the 3 forbidden pairs in the compaction matrix
+   (3 idempotent + 3 valid cross-state + 3 forbidden = 9 = 3×3).  Mirrors
+   [turn_phase_transition_spec_violation]; smaller because the compaction axis
+   has only 3 states. *)
+type compaction_transition_spec_violation =
+  | Accumulating_to_done
+  | Done_to_accumulating
+  | Done_to_compacting
+
+let compaction_transition_spec_violation_to_tag = function
+  | Accumulating_to_done -> "accumulating->done"
+  | Done_to_accumulating -> "done->accumulating"
+  | Done_to_compacting -> "done->compacting"
+;;
+
+(* RFC-0072 Phase 6: typed exception for forbidden compaction transitions.
+   Replaces the prior bare [assert (match ... -> bool)] inside
+   [validate_compaction_transition], whose [Assert_failure] carried only a
+   file/line — not the rejected (from, to) pair.  Mirrors
+   [Turn_phase_transition_violation]: the typed
+   [compaction_transition_spec_violation] payload travels on the exception, and
+   a [Printexc] printer renders the labelled message. *)
+exception
+  Compaction_transition_violation of
+    { where : string
+    ; from : packed_compaction_stage
+    ; to_ : packed_compaction_stage
+    ; violation : compaction_transition_spec_violation
+    }
+
+let compaction_transition_violation_message ~where ~from ~to_ ~violation =
+  Printf.sprintf
+    "%s: invalid compaction transition %s -> %s (spec_violation=%s)"
+    where
+    (packed_compaction_stage_label from)
+    (packed_compaction_stage_label to_)
+    (compaction_transition_spec_violation_to_tag violation)
+;;
+
+let raise_compaction_transition_violation ~where ~from ~to_ ~violation =
+  raise (Compaction_transition_violation { where; from; to_; violation })
+;;
+
+let () =
+  Printexc.register_printer (function
+    | Compaction_transition_violation { where; from; to_; violation } ->
+      Some (compaction_transition_violation_message ~where ~from ~to_ ~violation)
+    | _ -> None)
+;;

--- a/lib/keeper/keeper_registry_types_compaction.mli
+++ b/lib/keeper/keeper_registry_types_compaction.mli
@@ -1,0 +1,71 @@
+(** Keeper_registry_types_compaction — compaction-stage (KMC) FSM types and
+    transitions.
+
+    Re-homed from the deleted [Keeper_registry_types_cascade] (RFC-0206). The
+    compaction sub-lifecycle is independent of the removed cascade selection
+    FSM and survives the cascade purge. *)
+
+type compaction_stage =
+  | Compaction_accumulating [@tla.idle]
+  | Compaction_compacting [@tla.active]
+  | Compaction_done [@tla.terminal]
+[@@deriving tla]
+
+(** {1 Compaction stage GADT infrastructure (Cycle 21 / Tier B5)} *)
+
+type compaction_accumulating
+type compaction_compacting
+type compaction_done
+
+type 'a compaction_stage_witness =
+  | Compaction_accumulating : compaction_accumulating compaction_stage_witness
+  | Compaction_compacting : compaction_compacting compaction_stage_witness
+  | Compaction_done : compaction_done compaction_stage_witness
+
+type packed_compaction_stage =
+  | Packed : 'a compaction_stage_witness -> packed_compaction_stage
+
+val compaction_stage_to_witness : compaction_stage -> packed_compaction_stage
+val witness_to_compaction_stage : packed_compaction_stage -> compaction_stage
+
+(** Diagnostic label using the constructor name (e.g. ["Compaction_done"]).
+    Used by the [Compaction_transition_violation] [Printexc] printer. *)
+val packed_compaction_stage_label : packed_compaction_stage -> string
+
+(** RFC-0072 Phase 6: typed error for the 3 forbidden compaction-stage
+    transitions (3 idempotent + 3 valid + 3 forbidden = 9 = 3×3). *)
+type compaction_transition_spec_violation =
+  | Accumulating_to_done
+  | Done_to_accumulating
+  | Done_to_compacting
+
+val compaction_transition_spec_violation_to_tag
+  :  compaction_transition_spec_violation
+  -> string
+
+(** RFC-0072 Phase 6: raised by [validate_compaction_transition] on a
+    forbidden compaction transition, carrying the typed
+    [compaction_transition_spec_violation] payload. [where] is a diagnostic
+    label naming the raising function. A [Printexc] printer is registered so
+    [Printexc.to_string] renders the labelled message. *)
+exception
+  Compaction_transition_violation of
+    { where : string
+    ; from : packed_compaction_stage
+    ; to_ : packed_compaction_stage
+    ; violation : compaction_transition_spec_violation
+    }
+
+val compaction_transition_violation_message
+  :  where:string
+  -> from:packed_compaction_stage
+  -> to_:packed_compaction_stage
+  -> violation:compaction_transition_spec_violation
+  -> string
+
+val raise_compaction_transition_violation
+  :  where:string
+  -> from:packed_compaction_stage
+  -> to_:packed_compaction_stage
+  -> violation:compaction_transition_spec_violation
+  -> 'a

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -332,7 +332,7 @@ let ensure_keeper_meta config name =
        name. Normalize the meta side only so alias cleanup does not
        register as a semantic change. *)
     let cascade_changed =
-      Keeper_cascade_profile.normalize_declared_name (cascade_name_of_meta meta)
+      String.trim (cascade_name_of_meta meta)
       <> resolved_target_cascade_name
     in
     (* #10061: persisted state vs TOML source can differ by a single

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -98,7 +98,7 @@ let run_named
   | Error e -> Error (eio_context_error_to_sdk_error e)
   | Ok (sw, net) ->
   let cascade_name =
-    Keeper_cascade_profile.normalize_declared_name cascade_name
+    String.trim cascade_name
   in
   let error_cascade_name = cascade_name in
   let runtime_cascade_name = cascade_name in

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -118,7 +118,7 @@ let parse_cascade_name_opt args =
   | None -> Ok None
   | Some raw ->
       let normalized =
-        Keeper_cascade_profile.normalize_declared_name raw |> String.trim
+        String.trim raw |> String.trim
       in
       if normalized = "" then Error "cascade_name must not be empty"
       else

--- a/lib/keeper/keeper_world_observation_provider_cooldown.ml
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.ml
@@ -14,9 +14,9 @@ let fallback_cascade_for_provider_cooldown
       ~(effective_cascade : string)
   : string option
   =
-  let normalized_base = Keeper_cascade_profile.normalize_declared_name base_cascade in
+  let normalized_base = String.trim base_cascade in
   let normalized_effective =
-    Keeper_cascade_profile.normalize_declared_name effective_cascade
+    String.trim effective_cascade
   in
   if not (String.equal normalized_effective normalized_base)
   then Some normalized_base

--- a/lib/model_inference_metrics_parser.ml
+++ b/lib/model_inference_metrics_parser.ml
@@ -41,7 +41,7 @@ let private_provider_hint_of_fields (fields : (string * Yojson.Safe.t) list) =
 let cascade_model_attribution_of_fields (fields : (string * Yojson.Safe.t) list) =
   match json_string_field_opt "cascade_name" fields with
   | Some cascade_name ->
-    Some (Keeper_cascade_profile.canonicalize cascade_name ^ " (cascade)")
+    Some ((fun s -> s) cascade_name ^ " (cascade)")
   | None -> None
 ;;
 


### PR DESCRIPTION
## Summary

RFC-0206 cascade→Runtime **annihilation**, deep-core L2 — stacked on the merged substrate/consumer/Cascade_name/CLI PRs (#19544, #19549, #19552, #19554). User directive: 전멸 (remove the cascade concept, no legacy, no fallback) — collapse, not rename.

This PR clears the FSM-gate layer of the remaining dangling cascade refs on `main` (which is intentionally red mid-migration).

## 변경 내용

- **cascade selection FSM 제거**: `turn_observation`/`completed_turn_observation`에서 `cascade_state`/`ct_cascade_state` 필드 제거 (turn lifecycle은 이미 존재하는 `turn_phase` FSM이 담당; cascade_state는 redundant projection이었음). `turn_phase_of_cascade_state` 삭제, `completed_turn_outcome_of_observation`를 `obs.turn_phase` 매칭으로 retarget (`Turn_finalizing` = substantive). exhaustive match 유지 (wildcard 회귀 없음).
- **compaction(KMC) FSM re-home**: 삭제된 `Keeper_registry_types_cascade`가 cascade 선택 FSM과 **함께 품고 있던** compaction-stage FSM(생존 대상)을 독립 모듈 `Keeper_registry_types_compaction`으로 분리 (GADT witness + Printexc printer verbatim, 동작 변화 0). `keeper_registry_types`가 cascade 모듈 대신 이걸 include.
- **profile name 정규화 collapse**: `Keeper_cascade_profile.normalize_declared_name` → `String.trim` (삭제된 함수는 trim + route/catalog 해석이었고, routing이 전멸되므로 trim이 정확한 collapse), `canonicalize` → identity.

## Frozen seam 보존

`keeper_meta_contract.blocker_class.Cascade_exhausted` (operator 대시보드가 `blocker_class_to_string` 파싱)는 별개 타입이라 **건드리지 않음**.

## 검증

- `dune build @check --root .`: **47 → 39 errors** (이 PR이 건드린 `keeper_registry_types.{ml,mli}` + 신규 compaction 모듈은 에러 소스 0 = core sound).
- 빌드는 **의도적으로 아직 red**: 남은 dangling은 cascade dispatch 엔진(`Cascade_runtime_candidate` 25멤버 / `Cascade_runtime` 12멤버 / `Keeper_turn_cascade_budget` / `Keeper_cascade_engine` / `keeper_turn_driver` run_named 멀티후보 루프 / catalog)으로, 후속 PR에서 single-binding으로 collapse.

RFC: RFC-0206 (cascade→Runtime rebirth). 이 PR은 그 §L2 annihilation 단계.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
