### PR TITLE
fix(cascade-rewire): inline deleted module refs — first wave

### DIFF
--- a/lib/keeper/keeper_observation.ml
+++ b/lib/keeper/keeper_observation.ml
@@ -345,16 +345,16 @@ let cascade_metrics_for_candidates ~candidate_count:(_ : int) () =
   let capture =
     { next_attempt_index = 0; attempts_rev = []; fallback_events_rev = [] }
   in
-  let metrics =
-    Oas_compat.Metrics.make
-      ~on_cache_hit:(fun ~model_id ->
-        Llm_metric_bridge.emit_cache_hit ~model_id)
-      ~on_cache_miss:(fun ~model_id ->
-        Llm_metric_bridge.emit_cache_miss ~model_id)
-      ~on_request_start:(fun ~model_id ->
+  let metrics : Llm_provider.Metrics.t =
+    { Llm_provider.Metrics.
+      on_cache_hit = (fun ~model_id ->
+        Llm_metric_bridge.emit_cache_hit ~model_id);
+      on_cache_miss = (fun ~model_id ->
+        Llm_metric_bridge.emit_cache_miss ~model_id);
+      on_request_start = (fun ~model_id ->
         record_attempt_start capture ~model_id;
-        Llm_metric_bridge.emit_request_start ~model_id)
-      ~on_request_end:(fun ~model_id ~latency_ms ->
+        Llm_metric_bridge.emit_request_start ~model_id);
+      on_request_end = (fun ~model_id ~latency_ms ->
         ensure_terminal_attempt capture ~model_id ~latency_ms ~error:None;
         (* Forward to Prometheus so per-model latency is visible on
            the dashboard. Without this, the cascade capture records
@@ -364,36 +364,40 @@ let cascade_metrics_for_candidates ~candidate_count:(_ : int) () =
         match latency_ms with
         | Some latency_ms ->
             Llm_metric_bridge.emit_request_latency ~model_id ~latency_ms ()
-        | None -> ())
-      ~on_error:(fun ~model_id ~error ->
+        | None -> ());
+      on_error = (fun ~model_id ~error ->
         ensure_terminal_attempt capture ~model_id ~latency_ms:None
           ~error:(Some error);
-        Llm_metric_bridge.emit_error ~model_id ~error)
-      ~on_capability_drop:(fun ~model_id ~field ->
-        (* The explicit cascade metrics object bypasses the global
+        Llm_metric_bridge.emit_error ~model_id ~error);
+      on_capability_drop = (fun ~model_id ~field ->
+        (* The explicit metrics object bypasses the global
            Llm_metric_bridge sink, so capability-drop telemetry must be
            forwarded here just like latency and HTTP status. *)
-        Llm_metric_bridge.emit_capability_drop ~model_id ~field)
-      ~on_http_status:(fun ~provider ~model_id ~status ->
+        Llm_metric_bridge.emit_capability_drop ~model_id ~field);
+      on_http_status = (fun ~provider ~model_id ~status ->
         (* Forward HTTP status to the Prometheus counter. When callers
-           pass this per-call metrics sink explicitly (cascade
-           observation path), OAS does not consult the global
-           Llm_metric_bridge sink, so we must re-emit here to avoid
-           blackholing provider counters for captured turns.
-           Delegating to [Llm_metric_bridge.emit_http_status] keeps
-           the label shape a single source of truth. *)
-        Llm_metric_bridge.emit_http_status ~provider ~model_id ~status)
-      ~on_circuit_state:(fun ~provider ~model_id ~provider_key ~state ->
+           pass this per-call metrics sink explicitly, OAS does not
+           consult the global Llm_metric_bridge sink, so we must
+           re-emit here to avoid blackholing provider counters for
+           captured turns. *)
+        Llm_metric_bridge.emit_http_status ~provider ~model_id ~status);
+      on_circuit_state = (fun ~provider ~model_id ~provider_key ~state ->
         Llm_metric_bridge.emit_circuit_state ~provider ~model_id ~provider_key
-          ~state)
-      ~on_retry:(fun ~provider ~model_id ~attempt ->
-        Llm_metric_bridge.emit_retry ~provider ~model_id ~attempt)
-      ~on_token_usage:(fun ~provider ~model_id ~input_tokens ~output_tokens ->
+          ~state);
+      on_retry = (fun ~provider ~model_id ~attempt ->
+        Llm_metric_bridge.emit_retry ~provider ~model_id ~attempt);
+      on_token_usage = (fun ~provider ~model_id ~input_tokens ~output_tokens ->
         Llm_metric_bridge.emit_token_usage
-          ~provider ~model_id ~input_tokens ~output_tokens)
-      ~on_tool_calls:(fun ~provider ~model_id ~count ->
-        Llm_metric_bridge.emit_tool_calls ~provider ~model_id ~count)
-      ()
+          ~provider ~model_id ~input_tokens ~output_tokens);
+      on_tool_calls = (fun ~provider ~model_id ~count ->
+        Llm_metric_bridge.emit_tool_calls ~provider ~model_id ~count);
+      on_streaming_first_chunk = (fun ~provider ~model_id ~ttfrc_ms ->
+        Llm_metric_bridge.emit_streaming_first_chunk ~provider ~model_id
+          ~ttfrc_ms);
+      on_streaming_chunk = (fun ~provider ~model_id ~chunk_index ~inter_chunk_ms ->
+        Llm_metric_bridge.emit_streaming_chunk ~provider ~model_id
+          ~chunk_index ~inter_chunk_ms);
+    }
   in
   (capture, metrics)
 

--- a/lib/keeper/keeper_observation.mli
+++ b/lib/keeper/keeper_observation.mli
@@ -108,7 +108,7 @@ type cascade_metrics_capture
     callers do not pattern-match on the internal
     counter / list state — they construct one via
     {!cascade_metrics_for_candidates}, hand it to OAS
-    through [Oas_compat.Metrics.make], then materialise
+    through a direct [Llm_provider.Metrics.t] record, then materialise
     a {!cascade_observation} via
     {!cascade_observation_with_metrics}. *)
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -101,7 +101,24 @@ let metric_coord_claim_post_provision_failures =
    intentional 120s/180s budgets in persona authoring / deep_review. *)
 include Prometheus_oas_metric_names
 
-include Prometheus_cascade_metric_names
+(* Inlined from deleted Prometheus_cascade_metric_names (cascade purge). *)
+let metric_cascade_strategy_decisions = "masc_cascade_strategy_decisions_total"
+let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
+let metric_cascade_attempt_liveness_kill = "masc_cascade_attempt_liveness_kill_total"
+let metric_cascade_attempt_liveness_observed = "masc_cascade_attempt_liveness_observed_total"
+let metric_cascade_ttfb_seconds = "masc_cascade_ttfb_seconds"
+let metric_cascade_inter_chunk_seconds = "masc_cascade_inter_chunk_seconds"
+let metric_cascade_provider_health_score = "masc_cascade_provider_health_score"
+let metric_cascade_decisions = "masc_cascade_decisions_total"
+let metric_cascade_fallbacks = "masc_cascade_fallbacks_total"
+let metric_cascade_providers_exhausted = "masc_cascade_providers_exhausted_total"
+let metric_cascade_routing_phase_overrides = "masc_cascade_routing_phase_overrides_total"
+let metric_cascade_server_error_skip_total = "masc_cascade_server_error_skip_total"
+let metric_cascade_pre_dispatch_required_tool_filtered = "masc_cascade_pre_dispatch_required_tool_filtered_total"
+let metric_cascade_fallback_cycle_detected_total = "masc_cascade_fallback_cycle_detected_total"
+let metric_provider_health_probe_skipped = "masc_provider_health_probe_skipped_total"
+let metric_provider_actual_health_status = "masc_provider_actual_health_status"
+let metric_provider_health_probe_error = "masc_provider_health_probe_error_total"
 
 include Prometheus_runtime_metric_names
 

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -86,7 +86,24 @@ include module type of Prometheus_core_metric_names
 
 include module type of Prometheus_policy_metric_names
 
-include module type of Prometheus_cascade_metric_names
+(* Inlined from deleted Prometheus_cascade_metric_names (cascade purge). *)
+val metric_cascade_strategy_decisions : string
+val metric_cascade_capacity_events : string
+val metric_cascade_attempt_liveness_kill : string
+val metric_cascade_attempt_liveness_observed : string
+val metric_cascade_ttfb_seconds : string
+val metric_cascade_inter_chunk_seconds : string
+val metric_cascade_provider_health_score : string
+val metric_cascade_decisions : string
+val metric_cascade_fallbacks : string
+val metric_cascade_providers_exhausted : string
+val metric_cascade_routing_phase_overrides : string
+val metric_cascade_server_error_skip_total : string
+val metric_cascade_pre_dispatch_required_tool_filtered : string
+val metric_cascade_fallback_cycle_detected_total : string
+val metric_provider_health_probe_skipped : string
+val metric_provider_actual_health_status : string
+val metric_provider_health_probe_error : string
 
 (** Counter incremented once per breach event when [update_entry] drops
     cross [orphan_drop_threshold] inside [orphan_drop_window_sec] for a

--- a/lib/prometheus_builtin_metric_names.ml
+++ b/lib/prometheus_builtin_metric_names.ml
@@ -76,7 +76,24 @@ let metric_coord_claim_post_provision_failures =
    intentional 120s/180s budgets in persona authoring / deep_review. *)
 include Prometheus_oas_metric_names
 
-include Prometheus_cascade_metric_names
+(* Inlined from deleted Prometheus_cascade_metric_names (cascade purge). *)
+let metric_cascade_strategy_decisions = "masc_cascade_strategy_decisions_total"
+let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
+let metric_cascade_attempt_liveness_kill = "masc_cascade_attempt_liveness_kill_total"
+let metric_cascade_attempt_liveness_observed = "masc_cascade_attempt_liveness_observed_total"
+let metric_cascade_ttfb_seconds = "masc_cascade_ttfb_seconds"
+let metric_cascade_inter_chunk_seconds = "masc_cascade_inter_chunk_seconds"
+let metric_cascade_provider_health_score = "masc_cascade_provider_health_score"
+let metric_cascade_decisions = "masc_cascade_decisions_total"
+let metric_cascade_fallbacks = "masc_cascade_fallbacks_total"
+let metric_cascade_providers_exhausted = "masc_cascade_providers_exhausted_total"
+let metric_cascade_routing_phase_overrides = "masc_cascade_routing_phase_overrides_total"
+let metric_cascade_server_error_skip_total = "masc_cascade_server_error_skip_total"
+let metric_cascade_pre_dispatch_required_tool_filtered = "masc_cascade_pre_dispatch_required_tool_filtered_total"
+let metric_cascade_fallback_cycle_detected_total = "masc_cascade_fallback_cycle_detected_total"
+let metric_provider_health_probe_skipped = "masc_provider_health_probe_skipped_total"
+let metric_provider_actual_health_status = "masc_provider_actual_health_status"
+let metric_provider_health_probe_error = "masc_provider_health_probe_error_total"
 
 include Prometheus_runtime_metric_names
 

--- a/lib/prometheus_builtin_metric_names.mli
+++ b/lib/prometheus_builtin_metric_names.mli
@@ -87,7 +87,24 @@ val metric_pool_create_total : string
 
 include module type of Prometheus_policy_metric_names
 
-include module type of Prometheus_cascade_metric_names
+(* Inlined from deleted Prometheus_cascade_metric_names (cascade purge). *)
+val metric_cascade_strategy_decisions : string
+val metric_cascade_capacity_events : string
+val metric_cascade_attempt_liveness_kill : string
+val metric_cascade_attempt_liveness_observed : string
+val metric_cascade_ttfb_seconds : string
+val metric_cascade_inter_chunk_seconds : string
+val metric_cascade_provider_health_score : string
+val metric_cascade_decisions : string
+val metric_cascade_fallbacks : string
+val metric_cascade_providers_exhausted : string
+val metric_cascade_routing_phase_overrides : string
+val metric_cascade_server_error_skip_total : string
+val metric_cascade_pre_dispatch_required_tool_filtered : string
+val metric_cascade_fallback_cycle_detected_total : string
+val metric_provider_health_probe_skipped : string
+val metric_provider_actual_health_status : string
+val metric_provider_health_probe_error : string
 
 (** Counter incremented once per breach event when [update_entry] drops
     cross [orphan_drop_threshold] inside [orphan_drop_window_sec] for a

--- a/lib/server/server_routes_http_dashboard_provider_logs.ml
+++ b/lib/server/server_routes_http_dashboard_provider_logs.ml
@@ -1,236 +1,44 @@
-(** Provider log projections for dashboard HTTP routes. *)
+(** Provider log projections for dashboard HTTP routes.
 
-module Cascade_decl = Cascade_declarative_types
-
+    After cascade purge, provider log configuration was removed from
+    Runtime_schema.provider. The endpoint returns an empty provider list
+    until provider log config is re-introduced in the runtime model. *)
 
 let provider_log_surface = "/api/v1/dashboard/provider-logs"
 let provider_log_tail_surface = "/api/v1/dashboard/provider-logs/tail"
-let provider_log_default_lines = 200
-let provider_log_max_lines = 3000
-let provider_log_default_max_bytes = 1_048_576
-let provider_log_hard_max_bytes = 4_194_304
 
-let clamp_int ~min_value ~max_value value = max min_value (min max_value value)
-
-let string_starts_with = String.starts_with
-
-let expand_provider_log_path raw =
-  let path = String.trim raw in
-  match Sys.getenv_opt "HOME" with
-  | Some home when string_starts_with ~prefix:"~/" path ->
-      home ^ String.sub path 1 (String.length path - 1)
-  | Some home when string_starts_with ~prefix:"$HOME/" path ->
-      home ^ String.sub path 5 (String.length path - 5)
-  | _ -> path
-
-let provider_log_parse_errors_json errors =
-  errors
-  |> List.map (fun (err : Runtime_toml.parse_error) ->
-         Printf.sprintf "%s: %s" err.path err.message)
-  |> String.concat "; "
-
-let provider_log_error_json ~surface message =
+let dashboard_provider_logs_json () =
   `Assoc
     [
       ("generated_at_iso", `String (Masc_domain.now_iso ()));
-      ("dashboard_surface", `String surface);
-      ("source", `String "cascade_provider_log");
-      ("ok", `Bool false);
-      ("error", `String message);
+      ("dashboard_surface", `String provider_log_surface);
+      ("source", `String "runtime_provider_log");
+      ("ok", `Bool true);
+      ("providers", `List []);
     ]
-
-let load_provider_log_config () =
-  match Runtime.config_path () with
-  | None -> Error "cascade config path unavailable"
-  | Some path -> (
-      match Runtime_toml.parse_file path with
-      | Ok cfg -> Ok (path, cfg)
-      | Error errors -> Error (provider_log_parse_errors_json errors))
-
-let provider_log_metadata_json
-    ~(config_path : string)
-    (provider : Cascade_decl.cascade_provider)
-    (log : Cascade_decl.cascade_provider_log) =
-  let resolved_path =
-    match log.path with
-    | Some path -> `String (expand_provider_log_path path)
-    | None -> `Null
-  in
-  `Assoc
-    [
-      ("id", `String provider.id);
-      ("display_name", `String provider.display_name);
-      ("protocol", `String provider.protocol);
-      ("enabled", `Bool log.enabled);
-      ("path", Json_util.string_option_to_yojson log.path);
-      ("resolved_path", resolved_path);
-      ("default_lines", Json_util.int_option_to_yojson log.default_lines);
-      ("max_bytes", Json_util.int_option_to_yojson log.max_bytes);
-      ("cascade_config_path", `String config_path);
-    ]
-
-let dashboard_provider_logs_json () =
-  match load_provider_log_config () with
-  | Error message ->
-      `Assoc
-        [
-          ("generated_at_iso", `String (Masc_domain.now_iso ()));
-          ("dashboard_surface", `String provider_log_surface);
-          ("source", `String "cascade_provider_log");
-          ("ok", `Bool false);
-          ("error", `String message);
-          ("providers", `List []);
-        ]
-  | Ok (config_path, cfg) ->
-      let providers =
-        cfg.providers
-        |> List.filter_map (fun (provider : Cascade_decl.cascade_provider) ->
-               match provider.log with
-               | None -> None
-               | Some log -> Some (provider_log_metadata_json ~config_path provider log))
-      in
-      `Assoc
-        [
-          ("generated_at_iso", `String (Masc_domain.now_iso ()));
-          ("dashboard_surface", `String provider_log_surface);
-          ("source", `String "cascade_provider_log");
-          ("ok", `Bool true);
-          ("providers", `List providers);
-        ]
-
-let configured_provider_log provider_id cfg =
-  match
-    List.find_opt
-      (fun (provider : Cascade_decl.cascade_provider) ->
-        String.equal provider.id provider_id)
-      cfg.Cascade_decl.providers
-  with
-  | None -> None
-  | Some provider -> (
-    match provider.Cascade_decl.log with
-    | Some log -> Some (provider, log)
-    | None -> None)
-
-let drop_first = function
-  | [] -> []
-  | _ :: rest -> rest
-
-let drop_trailing_empty lines =
-  match List.rev lines with
-  | "" :: rest -> List.rev rest
-  | _ -> lines
-
-let rec drop_n n lines =
-  if n <= 0
-  then lines
-  else
-    match lines with
-    | [] -> []
-    | _ :: rest -> drop_n (n - 1) rest
-
-let tail_list ~limit lines =
-  let length = List.length lines in
-  drop_n (length - min length limit) lines
-
-let read_provider_log_tail ~path ~lines ~max_bytes =
-  let ic = open_in_bin path in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () ->
-      let file_len = in_channel_length ic in
-      let start = max 0 (file_len - max_bytes) in
-      let read_len = file_len - start in
-      seek_in ic start;
-      let raw = really_input_string ic read_len in
-      let parsed =
-        raw
-        |> String.split_on_char '\n'
-        |> (fun parts -> if start > 0 then drop_first parts else parts)
-        |> drop_trailing_empty
-        |> List.map String_util.strip_trailing_cr
-        |> tail_list ~limit:lines
-      in
-      List.mapi
-        (fun index text -> `Assoc [ ("line", `Int (index + 1)); ("text", `String text) ])
-        parsed)
-
-let provider_log_int_or_default opt fallback =
-  match opt with
-  | Some value -> value
-  | None -> fallback
 
 let dashboard_provider_log_tail_json request =
-  let error status message =
-    (status, provider_log_error_json ~surface:provider_log_tail_surface message)
-  in
   let provider_id =
     match Server_utils.query_param request "provider" with
     | Some raw -> String.trim raw
     | None -> ""
   in
+  let error status message =
+    ( status,
+      `Assoc
+        [
+          ("generated_at_iso", `String (Masc_domain.now_iso ()));
+          ("dashboard_surface", `String provider_log_tail_surface);
+          ("source", `String "runtime_provider_log");
+          ("ok", `Bool false);
+          ("error", `String message);
+        ] )
+  in
   if String.equal provider_id ""
   then error `Bad_request "provider query parameter is required"
   else
-    match load_provider_log_config () with
-    | Error message -> error `Internal_server_error message
-    | Ok (config_path, cfg) -> (
-      match configured_provider_log provider_id cfg with
-      | None ->
-        error `Not_found
-          (Printf.sprintf "provider %S has no configured log" provider_id)
-      | Some (_provider, log) when not log.enabled ->
-        error `Forbidden
-          (Printf.sprintf "provider %S log tail is disabled" provider_id)
-      | Some (_provider, { path = None; _ }) ->
-        error `Bad_request
-          (Printf.sprintf "provider %S log path is not configured" provider_id)
-      | Some (provider, ({ path = Some raw_path; _ } as log)) ->
-        let path = expand_provider_log_path raw_path in
-        if String.equal path "" || Filename.is_relative path
-        then
-          error `Bad_request
-            "provider log path must be absolute after ~/ or $HOME expansion"
-        else
-          let default_lines =
-            provider_log_int_or_default log.default_lines provider_log_default_lines
-            |> clamp_int ~min_value:1 ~max_value:provider_log_max_lines
-          in
-          let requested_lines =
-            Server_utils.int_query_param request "lines" ~default:default_lines
-            |> clamp_int ~min_value:1 ~max_value:provider_log_max_lines
-          in
-          let max_bytes =
-            provider_log_int_or_default log.max_bytes provider_log_default_max_bytes
-            |> clamp_int ~min_value:1 ~max_value:provider_log_hard_max_bytes
-          in
-          (try
-             let entries =
-               read_provider_log_tail ~path ~lines:requested_lines ~max_bytes
-             in
-             ( `OK,
-               `Assoc
-                 [
-                   ("generated_at_iso", `String (Masc_domain.now_iso ()));
-                   ("dashboard_surface", `String provider_log_tail_surface);
-                   ("source", `String "cascade_provider_log_file");
-                   ("ok", `Bool true);
-                   ( "provider",
-                     `Assoc
-                       [
-                         ("id", `String provider.id);
-                         ("display_name", `String provider.display_name);
-                         ("protocol", `String provider.protocol);
-                       ] );
-                   ("log", provider_log_metadata_json ~config_path provider log);
-                   ( "query",
-                     `Assoc
-                       [
-                         ("lines", `Int requested_lines);
-                         ("max_bytes", `Int max_bytes);
-                       ] );
-                   ("returned", `Int (List.length entries));
-                   ("entries", `List entries);
-                 ] )
-           with
-           | Sys_error message -> error `Internal_server_error message
-           | exn -> error `Internal_server_error (Printexc.to_string exn)))
+    error `Not_found
+      (Printf.sprintf
+         "provider %S has no configured log (provider log config not yet \
+          migrated to runtime model)"
+         provider_id)

--- a/test/stanzas/test_ci_hardening_source.inc
+++ b/test/stanzas/test_ci_hardening_source.inc
@@ -1,4 +1,4 @@
 (test
  (name test_ci_hardening_source)
  (modules test_ci_hardening_source)
- (libraries alcotest unix str yojson masc_mcp.masc_types masc_mcp masc_mcp.cascade_name))
+ (libraries alcotest unix str yojson masc_mcp.masc_types masc_mcp))


### PR DESCRIPTION
## Summary

Inline references to cascade-purged modules to reduce build errors from ~50 to ~32. Mechanical fixes only — remaining errors need architectural Cascade→Runtime migration.

## What changed

### Oas_compat.Metrics → direct record (keeper_observation.ml)
- `Oas_compat.Metrics.make ~on_cache_hit:... ~on_error:... ()` → `Llm_provider.Metrics.t` record literal with identical callbacks
- Added `on_streaming_first_chunk` and `on_streaming_chunk` fields (previously defaulted)
- Fixed `~latency_ms` → `~ttfrc_ms` for `on_streaming_first_chunk` signature

### Prometheus_cascade_metric_names inlined (4 files)
- `prometheus.ml/mli` + `prometheus_builtin_metric_names.ml/mli`: replaced `include Prometheus_cascade_metric_names` with 17 inline `let`/`val` bindings

### dashboard_provider_logs.ml simplified
- Removed all `Cascade_decl.cascade_provider`/`cascade_provider_log` type dependencies
- Endpoint now returns empty provider list (provider log config was cascade-specific, not in Runtime_schema)

### test stanza cleanup
- Removed `masc_mcp.cascade_name` library reference from test_ci_hardening_source.inc

## Remaining errors (14 types, ~32 sites)

These require architectural decisions, not mechanical rename:

| Module | Sites | Nature |
|--------|-------|--------|
| `Cascade_runtime` | 7 | Core routing functions (models_of_cascade_name, local_capacity, etc.) |
| `Cascade_runtime_candidate` | 6 | Provider candidate resolution |
| `Keeper_turn_cascade_budget` | 3 | Turn-level cascade budget |
| `packed_cascade_state` | 2 | Cascade FSM state type |
| `Cascade_catalog_runtime` | 2 | Runtime catalog lookup |
| `Llm_provider.Constants.Worker_sampling` | 2 | OAS pin issue |
| `Keeper_cascade_profile` | 2 | Keeper cascade profile |
| Others (5 types) | 1 each | Various type/value references |

## Stats

8 files changed, +134/-254

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
