### PR TITLE
refactor(cascade): Cascade_runtime model/context collapse to single-binding (RFC-0206 L2)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -158,7 +158,7 @@ let run_turn
   let meta = ctx.meta in
   let temperature = ctx.temperature in
   let max_output_ceiling =
-    Cascade_runtime.max_output_tokens_ceiling_of_cascade_name cascade_name
+    None
   in
   let max_tokens, pre_dispatch_max_tokens_error =
     match

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -333,21 +333,18 @@ let effective_model_labels_for_turn (m : keeper_meta) : string list =
       then dedupe_keep_order (model :: configured)
       else configured
 
-let resolve_max_context_resolution ~requested_override (labels : string list)
+let resolve_max_context_resolution ~requested_override (_labels : string list)
     : max_context_resolution =
   let min_keeper_context = Keeper_config.min_keeper_context_tokens in
   let clamp resolved =
     let local_clamped = resolved in
     max min_keeper_context local_clamped
   in
-  let primary_budget =
-    Cascade_runtime.resolve_primary_max_context labels
-    |> clamp
-  in
-  let cascade_budget =
-    Cascade_runtime.resolve_max_cascade_context labels
-    |> clamp
-  in
+  (* RFC-0206 single-binding: cascade label scans removed. Primary and cascade
+     budgets both resolve to the default runtime's model context window. *)
+  let default_budget = Runtime.default_max_context () |> clamp in
+  let primary_budget = default_budget in
+  let cascade_budget = default_budget in
   let turn_budget =
     match requested_override with
     | Some requested when requested > 0 ->

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -81,7 +81,7 @@ let write_heartbeat_snapshot
     Keeper_types_support.keeper_metrics_store ctx.config meta_current.name
   in
   let cascade_models =
-    Cascade_runtime.models_of_cascade_name
+    Provider_runtime_projection.default_execution_model_strings
       ((Keeper_meta_contract.cascade_name_of_meta meta_current))
   in
   let max_cascade_context =

--- a/lib/keeper/keeper_model_labels.ml
+++ b/lib/keeper/keeper_model_labels.ml
@@ -6,5 +6,5 @@ let configured_model_labels_of_meta (m : keeper_meta) : string list =
   (* Runtime dispatch must be cascade-catalog authoritative.  Persisted
      [meta.models] and benchmark-canary labels are legacy hints and can carry
      stale provider strings across reconfiguration. *)
-  Cascade_runtime.models_of_cascade_name
+  Provider_runtime_projection.default_execution_model_strings
     ((cascade_name_of_meta m))

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -156,7 +156,7 @@ let preflight_keeper_msg ctx args : (unit, string) result =
          | None ->
         let effective_models =
           if direct_reply then
-            Cascade_runtime.models_of_cascade_name
+            Provider_runtime_projection.default_execution_model_strings
               (                 (turn_cascade_name))
           else
             effective_model_labels_for_turn meta
@@ -250,7 +250,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       in
       let effective_models =
         if direct_reply then
-          Cascade_runtime.models_of_cascade_name
+          Provider_runtime_projection.default_execution_model_strings
             (               (turn_cascade_name))
               else
           effective_model_labels_for_turn meta

--- a/lib/keeper/keeper_turn_driver_named_resolution.ml
+++ b/lib/keeper/keeper_turn_driver_named_resolution.ml
@@ -29,7 +29,7 @@ let resolve ~sw ~net ?provider_filter ~cascade_name ~runtime_cascade_name () =
   in
   {
     configured_labels_result =
-      Cascade_runtime.models_of_cascade_name_result runtime_cascade_name;
+      Provider_runtime_projection.default_execution_model_strings_result runtime_cascade_name;
     candidate_cfgs_result;
     secondary_resolver;
   }

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -124,7 +124,7 @@ let parse_cascade_name_opt args =
       else
         (* keeper-assignable guardrail removed 2026-05-28 — validate existence only. *)
         match
-          Cascade_runtime.models_of_cascade_name_result
+          Provider_runtime_projection.default_execution_model_strings_result
             (normalized)
         with
         | Ok _ -> Ok (Some normalized)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -283,7 +283,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                   ~fallback_token:env_token_gate
               in
               let cascade_models =
-                Cascade_runtime.models_of_cascade_name
+                Provider_runtime_projection.default_execution_model_strings
                   (selected_cascade_name)
               in
               (match

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -308,11 +308,9 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
               let primary_max_context =
                 match p.max_context_override_opt with
                 | Some v -> v
-                | None ->
-                    let resolved =
-                      Cascade_runtime.resolve_max_cascade_context cascade_models
-                    in
-                    resolved
+                (* RFC-0206 single-binding: context budget = default runtime's
+                   model window (cascade label scan removed). *)
+                | None -> Runtime.default_max_context ()
               in
               Progress.Tracker.step tracker ~message:"Initializing session directory" ();
               let trace_id = generate_trace_id () in

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -16,10 +16,13 @@ let session_base_dir_ (config : Coord.config) =
   let d = Filename.concat (Coord.masc_root_dir config) "traces" in
   ensure_dir_ d
 
-(** Check API key availability using model label strings.
-    Delegates to Cascade_runtime which owns MASC cascade resolution. *)
-let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
-  Cascade_runtime.ensure_api_keys_for_labels labels
+(** RFC-0206 single-binding: API keys for the default runtime are resolved at
+    startup, so there is no per-label key check. Retained as a total no-op so
+    callers keep their result-shaped contract.
+    Runtime behavior changed: per-label key availability is no longer probed;
+    verify keeper turn startup at deploy. *)
+let ensure_api_keys_for_labels (_labels : string list) : (unit, string) result =
+  Ok ()
 
 (** Single-file metrics path kept for fallback reads. *)
 let keeper_metrics_path config name =

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -67,8 +67,7 @@ let build_cascade_execution
                 ~profile_defaults)
        in
        let max_output_ceiling =
-         Cascade_runtime.max_output_tokens_ceiling_of_cascade_name
-           cascade_name
+         None
        in
        (match
           Cascade_inference.validate_max_tokens_within_ceiling

--- a/lib/keeper/keeper_world_observation_provider_cooldown.ml
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.ml
@@ -29,7 +29,7 @@ let provider_cooldown_remaining_sec_for_cascade
   : int option
   =
   let runtime_health_keys =
-    Cascade_runtime.models_of_cascade_name cascade_name
+    Provider_runtime_projection.default_execution_model_strings cascade_name
     |> Cascade_runtime_candidate.runtime_health_keys_of_labels
   in
   match runtime_health_keys with

--- a/lib/provider_runtime_projection.ml
+++ b/lib/provider_runtime_projection.ml
@@ -266,3 +266,18 @@ let preferred_execution_model_labels () =
         |> List.filter participates_in_auto_detection
         |> List.filter_map auto_label_for_binding))
 ;;
+
+(* RFC-0206 single-binding: cascade routing removed. Model strings come
+   directly from the projection; the deleted [Cascade_runtime] layer only
+   wrapped this with cascade-name canonicalization + metrics. The
+   [_cascade_name] argument is retained at call sites but no longer selects
+   a model set — every keeper uses the default runtime. *)
+let default_execution_model_strings _cascade_name =
+  match preferred_execution_model_labels () with
+  | [] -> [ default_local_fallback_label () ]
+  | labels -> labels
+;;
+
+let default_execution_model_strings_result cascade_name =
+  Ok (default_execution_model_strings cascade_name)
+;;

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -106,3 +106,26 @@ let config_path () : string option =
   Config_dir_resolver.log_warnings ~context:"Runtime" ();
   Config_dir_resolver.cascade_path_opt ()
 ;;
+
+(* RFC-0206 single-binding: the deleted [Cascade_runtime.resolve_*_max_context]
+   scanned model labels across a cascade's candidates and folded the max. Under
+   single-binding every keeper uses the default runtime, so the context budget
+   is that runtime's [model.max_context]. Falls back to
+   [Runtime_constants.fallback_context_window] when the default is not yet
+   initialized (config-less test binaries). *)
+let default_max_context () : int =
+  match get_default_runtime () with
+  | Some rt -> rt.model.max_context
+  | None -> Runtime_constants.fallback_context_window
+;;
+
+(* RFC-0206 single-binding: the deleted
+   [Cascade_runtime.default_local_model_label_and_id] scanned configured/available
+   labels and returned the model-id substring. Under single-binding the model
+   name sent to the runtime endpoint is the default runtime's [model.api_name].
+   Falls back to ["auto"] before {!init_default} runs. *)
+let default_model_api_name () : string =
+  match get_default_runtime () with
+  | Some rt -> rt.model.api_name
+  | None -> "auto"
+;;

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -38,3 +38,15 @@ val config_path : unit -> string option
 (** Path to the runtime config TOML, or [None] if unresolved. Re-homed from
     deleted [Runtime.config_path] (delegates to
     [Config_dir_resolver]). *)
+
+val default_max_context : unit -> int
+(** Context-window budget of the default runtime's model (RFC-0206
+    single-binding). Replaces the deleted [Cascade_runtime.resolve_*_max_context]
+    label scans. Falls back to [Runtime_constants.fallback_context_window]
+    before {!init_default} runs. *)
+
+val default_model_api_name : unit -> string
+(** API model name of the default runtime, sent to the runtime completion
+    endpoint (RFC-0206 single-binding). Replaces the deleted
+    [Cascade_runtime.default_local_model_label_and_id]. Falls back to ["auto"]
+    before {!init_default} runs. *)

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -11,8 +11,7 @@
 let default_config_path = Runtime.config_path
 
 let default_model_strings ~cascade_name =
-  Cascade_runtime.default_model_strings
-    ~cascade_name:(cascade_name)
+  Provider_runtime_projection.default_execution_model_strings cascade_name
 
 (* Named model execution *)
 

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -157,7 +157,7 @@ let model_label_for_pool ~model_id runtime_pool =
   | Some pool ->
       let trimmed = String.trim pool in
       if is_oas_managed_runtime_pool (Some trimmed) then
-        Cascade_runtime.local_model_label model_id
+        model_id
       else
         let base_url =
           if
@@ -169,7 +169,7 @@ let model_label_for_pool ~model_id runtime_pool =
             runtime_base_url_for_pool runtime_pool
         in
         Printf.sprintf "custom:%s@%s" model_id base_url
-  | None -> Cascade_runtime.local_model_label model_id
+  | None -> model_id
 
 let ensure_runtime_reachable ?runtime_pool ~timeout_sec () =
   let base_url = runtime_base_url_for_pool runtime_pool |> String.trim in

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -117,9 +117,8 @@ let finalize_runtime_breakdown json =
         ]
   | _ -> json
 
-let default_local_model_id () =
-  let _label, model_id = Cascade_runtime.default_local_model_label_and_id () in
-  model_id
+(* RFC-0206 single-binding: bench the default runtime's model directly. *)
+let default_local_model_id () = Runtime.default_model_api_name ()
 
 let is_oas_managed_runtime_pool = function
   | None -> true

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -611,7 +611,7 @@ and resume_worker_via_oas
   in
   let resume_model_id = resume_model_id_of_checkpoint meta checkpoint in
   let* resume_provider =
-    oas_provider_of_label (Cascade_runtime.local_model_label resume_model_id)
+    oas_provider_of_label (resume_model_id)
     |> Result.map_error (fun e ->
       Printf.sprintf "checkpoint resume (model %S): %s" resume_model_id e)
   in


### PR DESCRIPTION
## 목표

cascade→Runtime 마이그레이션(RFC-0206 L2)의 `Cascade_runtime` consumer rewire. single-binding 모델에서 cascade-name 기반 model/context/key 해석을 제거하고 default runtime 직접 소비로 전환한다. #19549/#19556/#19557 계열 증분.

## 변경 (2 커밋, mechanical typed collapse)

1. `a85e2c0bd7` — model-strings + 자명 helper:
   - `models_of_cascade_name(_result)` / `default_model_strings` → `Provider_runtime_projection.default_execution_model_strings(_result)`
   - `local_model_label` → identity (model id가 곧 label)
   - `ensure_api_keys_for_labels` → `Ok ()` (default runtime 키는 startup에 resolve)
   - `max_output_tokens_ceiling_of_cascade_name` → `None` (model_spec에 per-cascade ceiling 없음)
2. `8709cfb0ed` — context + model-id:
   - `Runtime.default_max_context` / `Runtime.default_model_api_name` 추가 — default runtime의 `model_spec`에서 파생
   - `resolve_primary_max_context` / `resolve_max_cascade_context` → `default_max_context`
   - `default_local_model_label_and_id` → `default_model_api_name` (bench가 default runtime의 api_name을 completion endpoint로 전송)

## 검증

- 격리 빌드(`dune build . --root .`): `Cascade_runtime` Unbound 6→2, 편집한 파일 회귀 0.
- single-binding 의미 변화는 타입체커가 검증 불가 → 각 커밋에 `verify keeper turn at deploy` 명시. 배포 시 keeper turn context budget + local bench 동작 확인 필요.

## 의도적으로 포함하지 않은 것 (RFC-shaped, mechanical 아님)

남은 `Cascade_runtime` 2개는 contract를 바꾸는 behavioral 변경이라 제외한다. 근사 collapse는 silent regression이므로 거부:

- `local_capacity_for_selections` / `should_backoff`: live Discovery probe(server-reported `process_available`) ≠ MASC slot 회계(`allocated_slots`). 근사 시 backpressure 의미 손실. 지지 모듈(`Cascade_throttle`/`Cascade_catalog_runtime`) 삭제됨 → `Local_runtime_pool` 재배선은 design 결정.
- `resolve_named_providers_result_strict`: `[rt.provider_config]` 단순 반환은 `require_tool_support` / `provider_filter` 를 드롭 → tool-capable provider를 요구한 keeper가 non-tool provider로 silent 진행할 위험.

## 빌드 상태

이 PR만으로 green 불가(의도). lib는 whole-program(`include_subdirs`)이고 `Cascade_runtime` 외 ~10 모듈이 잔존: `Cascade_runtime_candidate`(4), `Keeper_turn_cascade_budget`(3), `Prometheus_cascade_metric_names`(2), `Keeper_cascade_profile`(2), `Cascade_config`/`Cascade_inference`/`Cascade_catalog_runtime`/`Cascade_error_classify`/`Keeper_cascade_engine`(각 1). 별개 stream: `Llm_provider`(agent_sdk rename) 2, `Oas_compat`(#19554 잔재) 1.

RFC-0206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
