### PR TITLE
fix(cascade): reconcile #19565 — restore should_backoff + single-binding resolve_named (RFC-0206 L2)

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -731,22 +731,20 @@ let append_judgments base_path judgments =
   let store = get_judgments_store base_path in
   List.iter (fun json -> Dated_jsonl.append store json) judgments
 
-let should_backoff ~sw ~net =
-  let cascade_name =
-    Runtime.get_default_runtime_id ()
-  in
-  try
-    let capacity =
-      Cascade_runtime.local_capacity_for_selections ~sw ~net
-        [ cascade_name ]
-    in
-    capacity.all_discovered && capacity.endpoints_found > 0
-    && capacity.process_available <= 0
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    Log.Governance.warn
-      "capacity check failed in should_backoff: %s"
-      (Printexc.to_string exn);
-    false
+let should_backoff ~sw:_ ~net:_ =
+  (* RFC-0206 single-binding: the deleted
+     [Cascade_runtime.local_capacity_for_selections] probed local-runtime
+     endpoint queues live. Under single-binding the runtime pool tracks lease
+     saturation directly, so back off when every configured concurrency slot on
+     a healthy runtime is already leased.
+     NB: this reads MASC's own lease accounting ([allocated_slots]), not the
+     server-reported queue depth ([process_available]) the old probe used — a
+     documented semantic shift, not a removal. Restoring a true live server-queue
+     probe is RFC-shaped follow-up. *)
+  let configured = Local_runtime_pool.configured_capacity () in
+  configured > 0
+  && Local_runtime_pool.healthy_runtime_count () > 0
+  && Local_runtime_pool.allocated_slots () >= configured
 
 let mark_compute_start (st : state) =
   (* Publish the gauge inside the lock so concurrent refresh_once runs

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -256,22 +256,20 @@ let compute_judgments
       | exn ->
           Error (Printf.sprintf "Operator judge parse error: %s" (Printexc.to_string exn)))
 
-let should_backoff ~sw ~net =
-  let cascade_name =
-    Runtime.get_default_runtime_id ()
-  in
-  try
-    let capacity =
-      Cascade_runtime.local_capacity_for_selections ~sw ~net
-        [ cascade_name ]
-    in
-    capacity.all_discovered && capacity.endpoints_found > 0
-    && capacity.process_available <= 0
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    Log.Dashboard.warn
-      "operator: capacity check failed in should_backoff: %s"
-      (Printexc.to_string exn);
-    false
+let should_backoff ~sw:_ ~net:_ =
+  (* RFC-0206 single-binding: the deleted
+     [Cascade_runtime.local_capacity_for_selections] probed local-runtime
+     endpoint queues live. Under single-binding the runtime pool tracks lease
+     saturation directly, so back off when every configured concurrency slot on
+     a healthy runtime is already leased.
+     NB: this reads MASC's own lease accounting ([allocated_slots]), not the
+     server-reported queue depth ([process_available]) the old probe used — a
+     documented semantic shift, not a removal. Restoring a true live server-queue
+     probe is RFC-shaped follow-up. *)
+  let configured = Local_runtime_pool.configured_capacity () in
+  configured > 0
+  && Local_runtime_pool.healthy_runtime_count () > 0
+  && Local_runtime_pool.allocated_slots () >= configured
 
 let refresh_once ~sw ~net
     ~(masc_tools : Masc_domain.tool_schema list)

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -21,8 +21,6 @@ type tool_policy =
   ; tolerates_bound_actor_fallback : bool
   }
 
-module Decl = Cascade_declarative_types
-module Parser = Cascade_declarative_parser
 module Runtime_binding = Agent_sdk.Provider_runtime_binding
 
 let default_tool_policy =
@@ -34,124 +32,6 @@ let default_tool_policy =
 ;;
 
 let normalize_label label = String.trim label |> String.lowercase_ascii
-
-let normalize_provider_id_variant label ~map_char =
-  normalize_label label |> String.map map_char
-;;
-
-let provider_id_candidates label =
-  let raw = normalize_label label in
-  [ raw
-  ; normalize_provider_id_variant label ~map_char:(fun c ->
-      if c = '-' then '_' else c)
-  ; normalize_provider_id_variant label ~map_char:(fun c ->
-      if c = '_' then '-' else c)
-  ]
-  |> List.filter (fun value -> not (String.equal value ""))
-  |> List.sort_uniq String.compare
-;;
-
-let provider_id_candidates_of_config (provider_cfg : Llm_provider.Provider_config.t) =
-  let from_binding =
-    Runtime_binding.binding_for_provider_config provider_cfg
-    |> Option.map (fun binding -> binding.Runtime_binding.id)
-    |> Option.to_list
-  in
-  let from_registry =
-    [ Llm_provider.Provider_registry.provider_name_of_config provider_cfg ]
-  in
-  from_binding @ from_registry
-  |> List.concat_map provider_id_candidates
-  |> List.sort_uniq String.compare
-;;
-
-let provider_id_candidates_of_kind kind =
-  let provider_cfg =
-    Llm_provider.Provider_config.make ~kind ~model_id:"auto" ~base_url:"" ()
-  in
-  provider_id_candidates_of_config provider_cfg
-;;
-
-let rec repo_seed_cascade_path_from dir =
-  let candidate =
-    Filename.concat (Filename.concat dir "config") Config_dir_resolver.cascade_toml_filename
-  in
-  if Sys.file_exists candidate
-  then Some candidate
-  else (
-    let parent = Filename.dirname dir in
-    if String.equal parent dir then None else repo_seed_cascade_path_from parent)
-;;
-
-let repo_seed_cascade_path () = repo_seed_cascade_path_from (Sys.getcwd ())
-
-let cascade_policy_path () =
-  match Config_dir_resolver.cascade_path_opt () with
-  | Some path -> Some path
-  | None -> repo_seed_cascade_path ()
-;;
-
-type cached_cascade =
-  { path : string
-  ; mtime : float
-  ; parsed : Decl.cascade_config option
-  }
-
-let cascade_cache : cached_cascade option ref = ref None
-
-let file_mtime path =
-  try Some (Unix.stat path).Unix.st_mtime with
-  | Unix.Unix_error _ -> None
-;;
-
-let parse_cascade_policy path =
-  match Parser.parse_file path with
-  | Ok cfg -> Some cfg
-  | Error _ -> None
-;;
-
-let cascade_policy_config () =
-  match cascade_policy_path () with
-  | None -> None
-  | Some path ->
-    (match file_mtime path with
-     | None -> None
-     | Some mtime ->
-       (match !cascade_cache with
-        | Some cached
-          when String.equal cached.path path && Float.equal cached.mtime mtime ->
-          cached.parsed
-        | _ ->
-          let parsed = parse_cascade_policy path in
-          cascade_cache := Some { path; mtime; parsed };
-          parsed))
-;;
-
-let tool_policy_of_decl_capabilities
-      (caps : Decl.cascade_capabilities option)
-  =
-  match caps with
-  | None -> default_tool_policy
-  | Some c ->
-    { supports_runtime_mcp_http_headers = c.supports_runtime_mcp_http_headers
-    ; requires_per_keeper_bridging_for_bound_actor_tools =
-        c.requires_per_keeper_bridging_for_bound_actor_tools
-    ; identity_runtime_mcp_header_keys = c.identity_runtime_mcp_header_keys
-    ; tolerates_bound_actor_fallback = c.tolerates_bound_actor_fallback
-    }
-;;
-
-let declarative_tool_policy_for_provider_ids provider_ids =
-  match cascade_policy_config () with
-  | None -> None
-  | Some cfg ->
-    provider_ids
-    |> List.find_map (fun provider_id ->
-      match Decl.provider_of_id cfg provider_id with
-      | None -> None
-      | Some provider ->
-        Some (tool_policy_of_decl_capabilities provider.Decl.capabilities))
-;;
 
 let binding_supports_runtime_mcp_http_headers (binding : Runtime_binding.t) =
   match binding.Runtime_binding.transport with
@@ -179,10 +59,9 @@ let fallback_tool_policy_for_config (provider_cfg : Llm_provider.Provider_config
     }
 ;;
 
-let tool_policy_for_config provider_cfg =
-  match declarative_tool_policy_for_provider_ids (provider_id_candidates_of_config provider_cfg) with
-  | Some policy -> policy
-  | None -> fallback_tool_policy_for_config provider_cfg
+(* RFC-0206: cascade-config tool-policy overrides removed. Under single-binding
+   the binding-derived policy is the sole source. *)
+let tool_policy_for_config provider_cfg = fallback_tool_policy_for_config provider_cfg
 ;;
 
 let fallback_tool_policy_for_kind kind =
@@ -192,10 +71,7 @@ let fallback_tool_policy_for_kind kind =
   fallback_tool_policy_for_config provider_cfg
 ;;
 
-let tool_policy_for_kind kind =
-  match declarative_tool_policy_for_provider_ids (provider_id_candidates_of_kind kind) with
-  | Some policy -> policy
-  | None -> fallback_tool_policy_for_kind kind
+let tool_policy_for_kind kind = fallback_tool_policy_for_kind kind
 ;;
 
 (** Whether the resolved provider config is a CLI runtime (Claude Code,

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -42,20 +42,28 @@ let cascade_catalog_error_to_sdk_error detail =
     Returns Provider_config.t list for the downstream OAS runtime,
     bypassing the old Model_spec facade. *)
 let resolve_cascade_providers
-      ?provider_filter
+      ?provider_filter:_
       ?(require_tool_choice_support = false)
       ?(require_tool_support = false)
       ?runtime_mcp_policy
-      ~cascade_name
+      ~cascade_name:_
       ()
   =
-  Cascade_runtime.resolve_named_providers_result_strict
-    ?provider_filter
-    ?runtime_mcp_policy
-    ~require_tool_choice_support
-    ~require_tool_support
-    ~cascade_name
-    ()
+  (* RFC-0206 single-binding: cascade catalog resolution removed. The providers
+     are the default runtime's single provider_config, passed through the same
+     required tool-use gate so require_tool_support is honored (a non-tool
+     default is filtered out, not silently used). [provider_filter] is moot with
+     one provider. *)
+  match Runtime.get_default_runtime () with
+  | None -> Error "no default runtime configured"
+  | Some rt ->
+    Ok
+      (Provider_tool_support.apply_required_tool_use_filter
+         ?runtime_mcp_policy
+         ~require_tool_choice_support
+         ~require_tool_support
+         ~label:rt.Runtime.id
+         [ rt.Runtime.provider_config ])
 
 let keeper_agent_name_opt (keeper_name : string) =
   let keeper_name = String.trim keeper_name in


### PR DESCRIPTION
## 목표

#19565 (`annihilate Cascade_runtime → Runtime_model_labels`)의 **재조정**. #19565는 같은 base에서 출발했으나 제 #19562가 먼저 머지돼 CONFLICTING 상태이고, behavioral 함수 `should_backoff`를 `false`로 갈아 **saturation backpressure를 silent 제거**하는 regression이 있었다. 이 PR이 그 2개 behavioral 함수를 single-binding 스타일로 제대로 처리해 #19565를 supersede한다.

## 변경 (2 커밋)

### 1. `e1a78b3a12` — should_backoff regression 수정
`dashboard_governance_judge` / `dashboard_operator_judge`의 `should_backoff`가 삭제된 `Cascade_runtime.local_capacity_for_selections`를 참조. #19565는 `false`로 처리(backpressure 제거) → judge들이 포화된 로컬 런타임에 계속 LLM 호출을 얹어 keeper turn과 슬롯 경쟁.

생존한 `Local_runtime_pool`로 재배선: 건강한 런타임의 설정 동시성 슬롯이 모두 leased일 때 backoff (`allocated_slots >= configured_capacity && healthy_runtime_count > 0`).

의미 변화는 in-code로 명시: 이건 MASC의 lease 회계지 옛 probe의 server-reported queue depth(`process_available`)가 아니다 — 제거가 아니라 documented semantic shift. 진짜 live server-queue probe 복원은 RFC-shaped follow-up. `false`보다 실제 saturation 신호를 보존하는 쪽을 택함.

### 2. `24a17c4237` — resolve_named single-binding + cascade-config tool policy 제거
- `runtime_oas_runner.resolve_cascade_providers`: 삭제된 `Cascade_runtime.resolve_named_providers_result_strict` → default runtime의 단일 `provider_config`를 `Provider_tool_support.apply_required_tool_use_filter`에 통과. **`require_tool_support` 보존** — non-tool default는 필터링되지 silent 사용 안 됨.
- `provider_tool_support`: cascade-config tool-policy 경로(`Cascade_declarative_types`/`Cascade_declarative_parser` 캐시, `declarative_tool_policy_for_provider_ids` + `provider_id_candidates` 헬퍼) 제거. `tool_policy_for_config`/`for_kind`는 binding 파생(`fallback_tool_policy_for_config`)으로 단일화 — single-binding의 유일 소스. 해소 안 되던 `Decl` alias 제거.

## 검증

- `Cascade_runtime` 모듈 Unbound **→ 0** (격리 빌드 `dune build . --root .`).
- 편집한 파일(2 dashboard, runtime_oas_runner, provider_tool_support) 회귀 0.
- single-binding 의미 변화는 타입체커 검증 불가 → should_backoff saturation 동작 + resolve_named tool-support 필터링 배포 시 확인 필요.

## #19565 처리 권장

이 PR이 #19565의 behavioral 커버리지를 supersede한다(mechanical은 #19562가 이미 머지). #19565의 221줄 `Runtime_model_labels` substrate는 per-label registry scan을 보존하는데, 이는 single-binding directive가 무의미하게 만든 multi-candidate 시대 로직이라 채택하지 않았다. **#19565는 close 권장.**

## 빌드 상태

이 PR만으로 green 불가(의도). `Cascade_runtime`/`Cascade_declarative_types`는 0이 됐으나 남은 cascade 모듈(`Cascade_runtime_candidate`, `Cascade_capability_profile`, `Keeper_turn_cascade_budget`, `Keeper_meta_contract` 잔재 등)은 broader RFC-0206 L2 purge 영역.

RFC-0206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
