### PR TITLE
feat(tool_name): Fs_write variant + typed tool_access helpers

### DIFF
--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -155,7 +155,7 @@ let risk_of_keeper (k : Tool_name.Keeper.t) : risk_level =
   | Tasks_list | Time_now | Tool_search | Tools_list | Voice_agent
   | Voice_listen | Voice_session_end | Voice_sessions | Voice_speak -> Low
   | Task_claim | Task_create | Voice_session_start -> Medium
-  | Board_sub_board_create | Board_sub_board_update | Fs_edit -> High
+  | Board_sub_board_create | Board_sub_board_update | Fs_edit | Fs_write -> High
   | Board_sub_board_delete | Task_force_done | Task_force_release -> Critical
 ;;
 

--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -29,8 +29,11 @@ let normalize_tool_names names =
   |> dedupe_keep_order
 ;;
 
-let write_tools =
-  [ "tool_edit_file"; "tool_write_file"; "tool_execute" ]
+let write_tools_typed =
+  [ Tool_name.Keeper.Fs_edit; Tool_name.Keeper.Fs_write; Tool_name.Keeper.Execute ]
+;;
+
+let write_tools = List.map Tool_name.Keeper.to_string write_tools_typed
 ;;
 
 let legacy_keeper_internal_tool_names =
@@ -145,6 +148,84 @@ let tool_access_of_meta_json (json : Yojson.Safe.t) =
        (* Empty tool_access: {} — missing kind field.
           Safe to default: ensure_keeper_meta resyncs from TOML on bootstrap. *)
        Ok (default_tool_access_of_meta_json ()))
+  | Some other ->
+    Error
+      (Printf.sprintf "keeper tool_access must be an array of strings (received %s)"
+         (Json_util.kind_name other))
+;;
+
+(* ── Typed boundary helpers ───────────────────────────────────────── *)
+
+(** Convert normalized string names to typed keeper tools at the parse
+    boundary.  Unknown names are silently dropped — this is the ingress
+    gate where stringly-typed input becomes compile-time verified. *)
+let tool_access_of_string_list names =
+  names |> normalize_tool_names |> List.filter_map Tool_name.Keeper.of_string
+;;
+
+(** Serialize typed tools back to strings for JSON output. *)
+let tool_access_to_string_list tools =
+  List.map Tool_name.Keeper.to_string tools
+;;
+
+(** Typed variant of [tool_names_include_board]. *)
+let tool_names_include_board_typed tools =
+  List.exists Tool_name.Keeper.is_board tools
+;;
+
+(** Typed variant of [tool_access_default_room_signal_prompt_enabled]. *)
+let tool_access_default_room_signal_prompt_enabled_typed ~default tools =
+  default || tool_names_include_board_typed tools
+;;
+
+(** Deduplicate a typed tool list preserving first-seen order. *)
+let normalize_tool_access_typed tools = dedupe_keep_order tools
+;;
+
+(** Encode a typed tool allowlist as a JSON array of tool names. *)
+let tool_access_to_json_typed tools =
+  `List (List.map (fun t -> `String (Tool_name.Keeper.to_string t)) tools)
+;;
+
+(** Default typed tool allowlist: [Keeper_internal] surface with write tools
+    excluded, parsed through the typed boundary. *)
+let default_tool_access_of_meta_json_typed () =
+  Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
+  |> tool_access_of_string_list
+  |> List.filter (fun tool -> not (List.mem tool write_tools_typed))
+;;
+
+(** Parse [tool_access] from persisted meta JSON into typed tools.
+    Same legacy forms as [tool_access_of_meta_json] but returns typed
+    variants.  Unknown names are silently dropped at the boundary. *)
+let tool_access_of_meta_json_typed (json : Yojson.Safe.t) =
+  match Json_util.assoc_member_opt "tool_access" json with
+  | Some `Null | None -> Ok (default_tool_access_of_meta_json_typed ())
+  | Some (`List _ as list_json) ->
+    (match
+       string_list_field_result ~field_name:"tool_access"
+         (`Assoc [ "tool_access", list_json ])
+     with
+     | Ok tools -> Ok (tool_access_of_string_list tools)
+     | Error msg -> Error msg)
+  | Some (`Assoc _ as access_json) ->
+    (match Json_util.get_string access_json "kind" with
+     | Some "preset" ->
+       Log.Keeper.warn
+         "keeper meta has deprecated tool_access.kind='preset'; \
+          defaulting to keeper_internal surface until next bootstrap";
+       Ok (default_tool_access_of_meta_json_typed ())
+     | Some "custom" ->
+       (match
+          string_list_field_result
+            ~field_name:"tools"
+            ~label:"tool_access.tools"
+            access_json
+        with
+        | Ok tools -> Ok (tool_access_of_string_list tools)
+        | Error msg -> Error msg)
+     | Some other -> Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
+     | None -> Ok (default_tool_access_of_meta_json_typed ()))
   | Some other ->
     Error
       (Printf.sprintf "keeper tool_access must be an array of strings (received %s)"

--- a/lib/keeper/keeper_meta_tool_access.mli
+++ b/lib/keeper/keeper_meta_tool_access.mli
@@ -51,3 +51,36 @@ val default_tool_access_of_meta_json : unit -> string list
     are accepted for backward compat. *)
 val tool_access_of_meta_json :
   Yojson.Safe.t -> (string list, string) result
+
+(** {1 Typed boundary helpers}
+
+    These functions operate on [Tool_name.Keeper.t] directly, providing
+    compile-time safety.  String conversion happens only at parse/serialize
+    boundaries. *)
+
+val tool_access_of_string_list : string list -> Tool_name.Keeper.t list
+(** Convert string names to typed tools at the ingress boundary.
+    Unknown names are silently dropped. *)
+
+val tool_access_to_string_list : Tool_name.Keeper.t list -> string list
+(** Serialize typed tools to strings for egress boundaries. *)
+
+val tool_names_include_board_typed : Tool_name.Keeper.t list -> bool
+(** Typed variant: true if any tool in the list is a board tool. *)
+
+val tool_access_default_room_signal_prompt_enabled_typed :
+  default:bool -> Tool_name.Keeper.t list -> bool
+(** Typed variant of [tool_access_default_room_signal_prompt_enabled]. *)
+
+val normalize_tool_access_typed : Tool_name.Keeper.t list -> Tool_name.Keeper.t list
+(** Deduplicate a typed tool list preserving first-seen order. *)
+
+val tool_access_to_json_typed : Tool_name.Keeper.t list -> Yojson.Safe.t
+(** Encode a typed tool allowlist as JSON. *)
+
+val default_tool_access_of_meta_json_typed : unit -> Tool_name.Keeper.t list
+(** Default typed tool allowlist from [Keeper_internal] surface. *)
+
+val tool_access_of_meta_json_typed :
+  Yojson.Safe.t -> (Tool_name.Keeper.t list, string) result
+(** Parse [tool_access] from JSON into typed tools. *)

--- a/lib/tool_catalog_inference.ml
+++ b/lib/tool_catalog_inference.ml
@@ -75,7 +75,7 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Keeper TK.Tools_list
   | TN.Keeper TK.Voice_sessions ->
       Some Read_only
-  | TN.Keeper TK.Fs_edit -> Some Playground_write
+  | TN.Keeper (TK.Fs_edit | TK.Fs_write) -> Some Playground_write
   | TN.Keeper TK.Memory_write ->
       Some Masc_coordination
   | TN.Keeper TK.Board_comment
@@ -244,7 +244,7 @@ let tool_group_of_typed_tool_name = function
       | TK.Voice_speak ) ->
       Some Voice
   | TN.Keeper
-      (TK.Execute | TK.Fs_edit | TK.Fs_read | TK.Ide_annotate | TK.Search_files) ->
+      (TK.Execute | TK.Fs_edit | TK.Fs_write | TK.Fs_read | TK.Ide_annotate | TK.Search_files) ->
       Some Filesystem
   | TN.Keeper
       ( TK.Broadcast

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -42,6 +42,7 @@ module Keeper = struct
     | Broadcast
     | Context_status
     | Fs_edit
+    | Fs_write
     | Fs_read
     | Ide_annotate
     | Handoff
@@ -89,6 +90,7 @@ module Keeper = struct
     | Broadcast -> "keeper_broadcast"
     | Context_status -> "keeper_context_status"
     | Fs_edit -> "tool_edit_file"
+    | Fs_write -> "tool_write_file"
     | Fs_read -> "tool_read_file"
     | Ide_annotate -> "keeper_ide_annotate"
     | Handoff -> "keeper_handoff"
@@ -136,7 +138,8 @@ module Keeper = struct
     | "keeper_board_sub_board_update" -> Some Board_sub_board_update
     | "keeper_broadcast" -> Some Broadcast
     | "keeper_context_status" -> Some Context_status
-    | "tool_edit_file" | "tool_write_file" -> Some Fs_edit
+    | "tool_edit_file" -> Some Fs_edit
+    | "tool_write_file" -> Some Fs_write
     | "tool_read_file" -> Some Fs_read
     | "keeper_ide_annotate" -> Some Ide_annotate
     | "keeper_handoff" -> Some Handoff

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -24,6 +24,7 @@ module Keeper : sig
     | Broadcast
     | Context_status
     | Fs_edit
+    | Fs_write
     | Fs_read
     | Ide_annotate
     | Handoff

--- a/lib/tool_resource_axis.ml
+++ b/lib/tool_resource_axis.ml
@@ -138,7 +138,7 @@ let classify_keeper_tool (tool : Tool_name.Keeper.t) args =
   match tool with
   | Tool_name.Keeper.Execute -> typed_execute_args_class args
   | Search_files -> classify_structured_shell_op args
-  | Fs_edit -> Filesystem_write
+  | Fs_edit | Fs_write -> Filesystem_write
   | Fs_read | Tool_search -> Filesystem_read
   | Memory_write | Handoff -> Filesystem_write
   | Memory_search | Library_read | Library_search -> Filesystem_read

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -8,7 +8,7 @@ let all_keeper : Tool_name.Keeper.t list =
   [ Execute; Board_comment; Board_comment_vote
   ; Board_curation_read; Board_curation_submit
   ; Board_get; Board_list; Board_post; Board_search; Board_stats; Board_vote
-  ; Broadcast; Context_status; Fs_edit; Fs_read
+  ; Broadcast; Context_status; Fs_edit; Fs_write; Fs_read
   ; Handoff; Library_read; Library_search; Memory_search
   ; Search_files; Stay_silent
   ; Task_claim; Task_create; Task_done; Task_submit_for_verification


### PR DESCRIPTION
## 변경 내용

### Tool_name.Keeper.t
- \`Fs_write\` variant 추가 — \`tool_write_file\`의 대칭 매핑 완성
  - \`of_string "tool_write_file"\` → \`Some Fs_write\`
  - \`to_string Fs_write\` → \`"tool_write_file"\`
  - 기존: \`of_string\`은 \`Fs_edit\`로 매핑, \`to_string\`은 \`"tool_edit_file"\` → 비대칭

### Keeper_meta_tool_access
- typed boundary helper 8개 추가:
  - \`tool_access_of_string_list\` — string list → \`Tool_name.Keeper.t list\`
  - \`tool_access_to_string_list\` — 역변환
  - \`tool_names_include_board_typed\` — typed 기반 board 감지
  - \`normalize_tool_access_typed\` — typed dedupe
  - \`tool_access_to_json_typed\` — typed JSON 직렬화
  - \`default_tool_access_of_meta_json_typed\` — typed 기본값
  - \`tool_access_of_meta_json_typed\` — JSON 파싱 → typed
- \`write_tools\`를 \`write_tools_typed\`에서 파생
- 기존 string 기반 API는 유지 (backward compat)

### Non-exhaustive match 수정
- \`governance_pipeline_risk\`: Fs_write → High risk
- \`tool_resource_axis\`: Fs_write → Filesystem_write
- \`tool_catalog_inference\`: Fs_write → Playground_write / Filesystem group

## 기반
- base: \`origin/main\` (broken — cascade→Runtime 마이그레이션 후유증)
- 이 PR은 structural refactoring만, 동작 변경 없음

## 검증
- \`lib/core\` (tool_name 포함) 빌드 확인
- Fs_write 관련 non-exhaustive match 에러 해소 확인

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
