### PR TITLE
refactor(runtime): make keeper turn use runtime id

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -609,8 +609,12 @@ type keeper_meta =
   ; meta_version : int
   }
 
-let cascade_name_of_meta (_m : keeper_meta) : string =
+let runtime_id_of_meta (_m : keeper_meta) : string =
   Runtime.get_default_runtime_id ()
+;;
+
+let cascade_name_of_meta (m : keeper_meta) : string =
+  runtime_id_of_meta m
 ;;
 
 
@@ -732,7 +736,7 @@ let reject_legacy_model_args ~tool_name (args : Yojson.Safe.t) =
     Error
       (Printf.sprintf
          "legacy keeper model args removed for %s: %s. Use cascade_name; concrete \
-          provider/model identity is OAS-owned."
+          provider/model identity is resolved from the default runtime."
          tool_name
          (String.concat ", " fields))
 ;;

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -376,11 +376,18 @@ type keeper_meta = {
   meta_version : int;
 }
 
-(** {1 Cascade name derivation} *)
+(** {1 Runtime id derivation} *)
+
+val runtime_id_of_meta : keeper_meta -> string
+(** [runtime_id_of_meta m] returns the default runtime id.
+    Ignores [m] because keeper-level provider/model selection has been
+    collapsed to the single default Runtime binding. *)
+
+(** {1 Legacy cascade compatibility} *)
 
 val cascade_name_of_meta : keeper_meta -> string
-(** [cascade_name_of_meta m] returns the default runtime id.
-    Ignores [m] — kept for signature compatibility. *)
+(** Compatibility alias for {!runtime_id_of_meta}.
+    Kept while older JSON fields and call sites still use [cascade_name]. *)
 
 (** {1 Outcome <-> string} *)
 
@@ -455,5 +462,5 @@ val keeper_legacy_model_arg_names : string list
 val reject_legacy_model_args :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 (** Reject retired keeper model-selection input fields at tool/API boundaries.
-    Model and provider identity is resolved from [cascade_name] and the cascade
-    catalog, not per-call keeper arguments. *)
+    Model and provider identity is resolved from the default Runtime binding,
+    not per-call keeper arguments. *)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -98,15 +98,12 @@ let direct_turn_observation ~(config : Coord.config) (meta : keeper_meta) :
     ~config
     ~meta
 
-let resolve_turn_cascade_name (meta : keeper_meta) =
-  let raw_name = String.trim (Keeper_meta_contract.cascade_name_of_meta meta) in
-  match Cascade_catalog_runtime.resolve_declared_name ~raw_name () with
-  | Ok cascade_name -> Ok cascade_name
-  | Error detail ->
-      Error
-        (Printf.sprintf
-           "invalid cascade_name %S for keeper %s: %s"
-           raw_name meta.name detail)
+let resolve_turn_runtime_id (meta : keeper_meta) =
+  let runtime_id = String.trim (Keeper_meta_contract.runtime_id_of_meta meta) in
+  if runtime_id = "" then
+    Error (Printf.sprintf "invalid runtime_id for keeper %s: empty" meta.name)
+  else
+    Ok runtime_id
 
 let keeper_msg_timeout_override args =
   match get_float_opt args "timeout_sec" with
@@ -144,20 +141,20 @@ let preflight_keeper_msg ctx args : (unit, string) result =
     match ensure_keeper_exists ~ctx ~name with
     | Error e -> Error e
     | Ok meta ->
-      match resolve_turn_cascade_name meta with
+      match resolve_turn_runtime_id meta with
       | Error e -> Error e
-      | Ok turn_cascade_name ->
+      | Ok turn_runtime_id ->
         (match
            Keeper_cascade_resilience.cascade_resilience_error_message
              (Keeper_cascade_resilience.cascade_resilience_of_name
-                (turn_cascade_name))
+                (turn_runtime_id))
          with
          | Some e -> Error e
          | None ->
         let effective_models =
           if direct_reply then
             Provider_runtime_projection.default_execution_model_strings
-              (                 (turn_cascade_name))
+              (                 (turn_runtime_id))
           else
             effective_model_labels_for_turn meta
         in
@@ -221,15 +218,15 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       let turn_tracker = Progress.start_tracking ~task_id:turn_task_id ~total_steps:5 () in
       Progress.Tracker.step turn_tracker ~message:"Preparing keeper turn configuration" ();
       let meta = meta0 in
-      match resolve_turn_cascade_name meta with
+      match resolve_turn_runtime_id meta with
       | Error e ->
         Progress.stop_tracking turn_task_id;
         tool_result_error ("" ^ e)
-      | Ok turn_cascade_name ->
+      | Ok turn_runtime_id ->
       (match
          Keeper_cascade_resilience.cascade_resilience_error_message
            (Keeper_cascade_resilience.cascade_resilience_of_name
-              (turn_cascade_name))
+              (turn_runtime_id))
        with
        | Some e ->
          Progress.stop_tracking turn_task_id;
@@ -251,7 +248,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       let effective_models =
         if direct_reply then
           Provider_runtime_projection.default_execution_model_strings
-            (               (turn_cascade_name))
+            (               (turn_runtime_id))
               else
           effective_model_labels_for_turn meta
       in
@@ -496,7 +493,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     ~build_turn_prompt
                     ~user_message:message
                     ~cascade_name:
-                      (                         (turn_cascade_name))
+                      (                         (turn_runtime_id))
                     ~world_observation
                     ~turn_affordances
                     ~required_tool_names


### PR DESCRIPTION
## Summary

- add `runtime_id_of_meta` as the canonical keeper runtime identity helper
- keep `cascade_name_of_meta` as a compatibility alias while older JSON fields/callers remain
- stop validating keeper message turns through `Cascade_catalog_runtime.resolve_declared_name`; direct turns now use the default Runtime id directly

## Why

This is step 1 of changing the remaining cascade content itself, not just deleting names. The hot-path keeper turn should treat the value as the single default Runtime binding, not as a cascade route/profile resolved through the retired catalog.

## Validation

Not run; user requested PR creation and this is a draft slice on a currently broken cascade->Runtime migration mainline.
