### PR TITLE
[RFC-0206] cascade_* → runtime_* mechanical rename — 159 files

### DIFF
--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -182,7 +182,7 @@ export function normalizeGovernanceDecisionItem(raw: unknown): GovernanceDecisio
   if (!id || !topic) return null
   const context = normalizeGovernanceContextRef(raw.context)
   return {
-    kind: asString(raw.kind, 'case'),
+    kind: asString(raw.kind, 'case') as GovernanceDecisionItem['kind'],
     id,
     topic,
     status: asString(raw.status ?? raw.state, 'open'),
@@ -233,8 +233,8 @@ export function normalizeGovernanceJudgeSummary(raw: unknown): GovernanceJudgeSu
   return {
     judge_online: typeof raw.judge_online === 'boolean' ? raw.judge_online : undefined,
     refreshing: typeof raw.refreshing === 'boolean' ? raw.refreshing : undefined,
-    status: asNullableString(raw.status) ?? undefined,
-    degraded_reason: asNullableString(raw.degraded_reason),
+    status: (asNullableString(raw.status) as GovernanceJudgeSummary['status']) ?? undefined,
+    degraded_reason: asNullableString(raw.degraded_reason) as GovernanceJudgeSummary['degraded_reason'],
     cached_judgments_visible: typeof raw.cached_judgments_visible === 'boolean'
       ? raw.cached_judgments_visible
       : undefined,
@@ -324,7 +324,7 @@ function normalizeBoardActorIdentity(
     key,
     display_name: displayName,
     raw: original,
-    source: source || undefined,
+    source: source as BoardActorIdentity['source'] || undefined,
     runtime_agent_name: runtimeAgentName || undefined,
   }
 }
@@ -354,7 +354,7 @@ function normalizeBoardContributorQuality(raw: unknown): BoardContributorQuality
   if (score === undefined) return null
   return {
     score,
-    band: asString(raw.band, '').trim() || undefined,
+    band: (asString(raw.band, '').trim() as BoardContributorQuality['band']) || undefined,
     source: asString(raw.source, '').trim() || undefined,
     completion_rate: asNumber(raw.completion_rate),
     response_rate: asNumber(raw.response_rate),
@@ -606,7 +606,7 @@ function normalizeBoardKarmaLedgerEvent(raw: unknown): BoardKarmaLedgerEvent | n
   return {
     recipient,
     voter,
-    target_kind: targetKind,
+    target_kind: targetKind as BoardKarmaLedgerEvent['target_kind'],
     target_id: targetId,
     delta: asNumber(raw.delta, 0),
     ts: asNumber(raw.ts, 0),

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1054,7 +1054,7 @@ describe('dashboard goals decoding', () => {
           active_goal_ids: ['goal-1'],
           sandbox_profile: 'docker',
           network_mode: 'none',
-          cascade_name: 'keeper_unified',
+          runtime_name: 'keeper_unified',
           approval_profile: 'strict',
           cascade_outcome: 'passed_to_next_model',
           latest_execution_outcome: 'completed',
@@ -1203,7 +1203,7 @@ describe('dashboard goals decoding', () => {
           active_goal_ids: ['goal-1'],
           sandbox_profile: 'docker',
           network_mode: 'none',
-          cascade_name: 'keeper_unified',
+          runtime_name: 'keeper_unified',
           approval_profile: null,
           cascade_outcome: null,
           latest_execution_outcome: null,
@@ -1306,8 +1306,8 @@ describe('fetchKeeperConfig', () => {
         per_provider_timeout_sec: 12.5,
         per_provider_timeout_mode: 'override',
         verify: 'true',
-        selected_cascade_name: 'keeper_unified',
-        selected_cascade_canonical: 'keeper_unified',
+        selected_runtime_name: 'keeper_unified',
+        selected_runtime_canonical: 'keeper_unified',
       },
       compaction: {
         profile: 'balanced',
@@ -1441,8 +1441,8 @@ describe('fetchKeeperConfig', () => {
     expect(result.sandbox_environment?.require_userns).toBe(true)
     expect(result.execution.models).toEqual(['llama:test-balanced'])
     expect(result.execution.verify).toBe(true)
-    expect(result.execution.selected_cascade_name).toBe('keeper_unified')
-    expect(result.execution.selected_cascade_canonical).toBe('keeper_unified')
+    expect(result.execution.selected_runtime_name).toBe('keeper_unified')
+    expect(result.execution.selected_runtime_canonical).toBe('keeper_unified')
     expect(result.execution.per_provider_timeout_sec).toBe(12.5)
     expect(result.execution.per_provider_timeout_mode).toBe('override')
     expect(result.hooks?.destructive_check_tools).toEqual(['dynamic_boundary (Tool_dispatch.is_destructive)'])

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1736,7 +1736,7 @@ function decodeGoalDetailKeeper(raw: unknown): GoalDetailKeeper | null {
   const agentName = asString(raw.agent_name)
   const sandboxProfile = asString(raw.sandbox_profile)
   const networkMode = asString(raw.network_mode)
-  const cascadeName = asString(raw.cascade_name)
+  const cascadeName = asString(raw.runtime_name)
   if (!name || !agentName || !sandboxProfile || !networkMode || !cascadeName) return null
   return {
     name,
@@ -1745,7 +1745,7 @@ function decodeGoalDetailKeeper(raw: unknown): GoalDetailKeeper | null {
     active_goal_ids: asStringArray(raw.active_goal_ids),
     sandbox_profile: sandboxProfile,
     network_mode: networkMode,
-    cascade_name: cascadeName,
+    runtime_name: cascadeName,
     approval_profile: asNullableString(raw.approval_profile),
     cascade_outcome: asNullableString(raw.cascade_outcome),
     latest_execution_outcome: asNullableString(raw.latest_execution_outcome),
@@ -2239,15 +2239,15 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
       last_model_used_label: null,
       per_provider_timeout_sec: perProviderTimeoutSec,
       per_provider_timeout_mode:
-        asNullableString(execution.per_provider_timeout_mode)
+        (asNullableString(execution.per_provider_timeout_mode) as 'override' | 'turn_budget_heuristic' | null)
         ?? (perProviderTimeoutSec != null
             ? 'override'
             : 'turn_budget_heuristic'),
       verify: asLooseBoolean(execution.verify),
-      selected_cascade_name: asNullableString(execution.selected_cascade_name) ?? '',
-      selected_cascade_canonical:
-        asNullableString(execution.selected_cascade_canonical)
-        ?? asNullableString(execution.selected_cascade_name)
+      selected_runtime_name: asNullableString(execution.selected_runtime_name) ?? '',
+      selected_runtime_canonical:
+        asNullableString(execution.selected_runtime_canonical)
+        ?? asNullableString(execution.selected_runtime_name)
         ?? '',
     },
     compaction: {

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -133,7 +133,7 @@ describe('keeper runtime trace', () => {
 	          {
 	            ts: '2026-05-12T00:00:00Z',
 	            event: 'provider_attempt_finished',
-	            cascade_name: 'provider-k-coding-with-spark',
+	            runtime_name: 'provider-k-coding-with-spark',
 	            status: 'timeout',
 	            error: 'Timeout after 120.0s',
 	            exception_kind: 'outer_oas_timeout',

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -722,7 +722,7 @@ export interface KeeperRuntimeTraceMemorySummary {
 export interface KeeperRuntimeTraceProviderAttempt {
   ts: string
   event: string
-  cascade_name: string | null
+  runtime_name: string | null
   status: string
   error: string | null
   exception_kind: string | null
@@ -1122,7 +1122,7 @@ function parseRuntimeTraceProviderAttempt(raw: unknown): KeeperRuntimeTraceProvi
   return {
     ts: stringField(obj, 'ts'),
     event: stringField(obj, 'event'),
-    cascade_name: nullableStringField(obj, 'cascade_name'),
+    runtime_name: nullableStringField(obj, 'runtime_name'),
     status: stringField(obj, 'status'),
     error: nullableStringField(obj, 'error'),
     exception_kind: nullableStringField(obj, 'exception_kind'),

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -158,8 +158,8 @@ describe('buildFleetRows runtime labels', () => {
         name: 'cascade-keeper',
         status: 'active',
         keepalive_running: true,
-        cascade_name: 'oas-keeper_unified',
-        cascade_canonical: 'primary',
+        runtime_name: 'oas-keeper_unified',
+        runtime_canonical: 'primary',
         active_model_label: 'cli-tool-a:auto',
         trust: {
           execution_summary: {
@@ -195,7 +195,7 @@ describe('buildFleetRows runtime labels', () => {
             total_tokens: null,
             wall_tokens_per_second: null,
             inference_telemetry: null,
-            cascade_name: 'primary',
+            runtime_name: 'primary',
             cascade_selected_model: 'provider-a:model-a-sonnet',
             cascade_attempt_count: 2,
             cascade_outcome: 'passed_to_next_model',

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -151,7 +151,7 @@ function latestCascadeMetric(keeper: Keeper) {
     const point = series[index]
     if (!point) continue
     if (
-      normalizeText(point.cascade_name)
+      normalizeText(point.runtime_name)
       || normalizeText(point.cascade_selected_model)
       || normalizeText(point.cascade_outcome)
       || typeof point.cascade_attempt_count === 'number'
@@ -166,8 +166,8 @@ function latestCascadeMetric(keeper: Keeper) {
 }
 
 function keeperCascadeLabel(keeper: Keeper): string | null {
-  const raw = normalizeText(keeper.cascade_name)
-  const canonical = normalizeText(keeper.cascade_canonical ?? keeper.selected_cascade_canonical)
+  const raw = normalizeText(keeper.runtime_name)
+  const canonical = normalizeText(keeper.runtime_canonical ?? keeper.selected_runtime_canonical)
   if (raw && canonical && raw !== canonical) return `${raw} -> ${canonical}`
   return raw ?? canonical
 }

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -1233,7 +1233,7 @@ function KeeperCard({ keeper }: { keeper: GoalDetailKeeper }) {
         <div>승인</div>
         <div class="text-right text-text-body">${trust?.approval_state?.summary ?? keeper.approval_profile ?? '-'}</div>
         <div>캐스케이드</div>
-        <div class="text-right text-text-body">${keeper.cascade_name ?? executionCascadeOutcome ?? '-'}</div>
+        <div class="text-right text-text-body">${keeper.runtime_name ?? executionCascadeOutcome ?? '-'}</div>
         <div>결과</div>
         <div class="text-right text-text-body" title=${keeper.cascade_outcome ?? executionCascadeOutcome ?? ''}>${cascadeOutcomeLabel(keeper.cascade_outcome ?? executionCascadeOutcome) ?? '-'}</div>
       </div>

--- a/dashboard/src/components/ide/decision-log-trace-bridge.ts
+++ b/dashboard/src/components/ide/decision-log-trace-bridge.ts
@@ -29,7 +29,7 @@ import {
  *   tsMs            ← unixishToMs(decision.ts_unix)  (NaN-guarded; null/
  *                     non-finite skip)
  *   keeperName      ← decision.keeper_name  (real keeper-level — unlike
- *                     cascade-hop which uses cascade_name as a logical
+ *                     cascade-hop which uses runtime_name as a logical
  *                     bucket)
  *   source          ← 'decision-log'
  *   decisionId      ← same as id (RFC-0026 KeeperDecision has no

--- a/dashboard/src/components/ide/ide-conversation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.test.ts
@@ -210,7 +210,7 @@ describe('IdeConversationRail', () => {
       }],
       [{
         ts: Date.UTC(2026, 4, 5, 10, 2, 0) / 1000,
-        cascade_name: 'primary',
+        runtime_name: 'primary',
         strategy: 'ranked',
         cycle: 1,
         candidates_in: 3,
@@ -274,7 +274,7 @@ describe('IdeConversationRail', () => {
           total_events: 1,
           events: [{
             ts: Date.UTC(2026, 4, 5, 10, 2, 0) / 1000,
-            cascade_name: 'primary',
+            runtime_name: 'primary',
             strategy: 'ranked',
             cycle: 1,
             candidates_in: 3,
@@ -365,7 +365,7 @@ describe('IdeConversationRail', () => {
           total_events: 1,
           events: [{
             ts: cascadeTs,
-            cascade_name: 'primary',
+            runtime_name: 'primary',
             strategy: 'ranked',
             cycle: 1,
             candidates_in: 3,

--- a/dashboard/src/components/keeper-cognition-inspector.test.ts
+++ b/dashboard/src/components/keeper-cognition-inspector.test.ts
@@ -47,7 +47,7 @@ describe('KeeperCognitionInspector', () => {
 
   it('formats live tool access rows from keeper runtime fields', () => {
     const rows = toolAccessRowsForKeeper(keeper({
-      cascade_name: 'primary',
+      runtime_name: 'primary',
       sandbox_profile: 'docker',
       proactive_enabled: false,
       proactive_idle_sec: 120,
@@ -71,7 +71,7 @@ describe('KeeperCognitionInspector', () => {
       keeper({
         name: 'beta',
         status: 'active',
-        cascade_name: 'primary',
+        runtime_name: 'primary',
         latest_tool_names: ['keeper_task_done'],
       }),
     ]

--- a/dashboard/src/components/keeper-cognition-inspector.ts
+++ b/dashboard/src/components/keeper-cognition-inspector.ts
@@ -82,7 +82,7 @@ export function toolAccessRowsForKeeper(keeper: Keeper): ToolAccessRow[] {
   return [
     {
       label: 'cascade',
-      value: displayValue(keeper.cascade_name ?? keeper.cascade_canonical ?? keeper.selected_cascade_canonical),
+      value: displayValue(keeper.runtime_name ?? keeper.runtime_canonical ?? keeper.selected_runtime_canonical),
     },
     {
       label: 'sandbox',

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -70,8 +70,8 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       per_provider_timeout_sec: null,
       per_provider_timeout_mode: 'turn_budget_heuristic',
       verify: true,
-      selected_cascade_name: 'tier-group.keeper_unified',
-      selected_cascade_canonical: 'tier-group.keeper_unified',
+      selected_runtime_name: 'tier-group.keeper_unified',
+      selected_runtime_canonical: 'tier-group.keeper_unified',
     },
     compaction: {
       profile: 'balanced',
@@ -517,7 +517,7 @@ describe('KeeperConfigPanel', () => {
     expect(mocks.fetchDashboardGoalsTree).toHaveBeenCalledTimes(1)
     expect(mocks.fetchCascadeProfiles).toHaveBeenCalledTimes(1)
     expect(container.textContent).toContain('편집 가능 범위')
-    expect(container.textContent).toContain('keeper TOML의 cascade_name')
+    expect(container.textContent).toContain('keeper TOML의 runtime_name')
     expect(container.textContent).toContain('Cascade 선택')
     expect(container.textContent).toContain('tier-group.keeper_unified')
     expect(container.textContent).toContain('broken_profile')
@@ -563,8 +563,8 @@ describe('KeeperConfigPanel', () => {
           per_provider_timeout_sec: null,
           per_provider_timeout_mode: 'turn_budget_heuristic',
           verify: true,
-          selected_cascade_name: 'tier.resilient_breaker',
-          selected_cascade_canonical: 'tier.resilient_breaker',
+          selected_runtime_name: 'tier.resilient_breaker',
+          selected_runtime_canonical: 'tier.resilient_breaker',
         },
       }),
     )

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -553,8 +553,8 @@ function cascadeCatalogSourceLabel(c: KeeperConfig): string {
 }
 
 function cascadeSelectionSummary(c: KeeperConfig): string {
-  const selected = c.execution.selected_cascade_name || MISSING_DATA_DASH
-  const canonical = c.execution.selected_cascade_canonical || selected
+  const selected = c.execution.selected_runtime_name || MISSING_DATA_DASH
+  const canonical = c.execution.selected_runtime_canonical || selected
   const manifest = c.sources.default_manifest_path
   const catalog = c.sources.cascade_catalog_source_path
   const selectionPart = manifest
@@ -765,12 +765,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         body=${cascadeSelectionSummary(c)}
       />
       <${ConfigRow} label="기본 소스" value=${c.sources.default_source_kind || MISSING_DATA_DASH} />
-      <${ConfigRow} label="선택 cascade" value=${c.execution.selected_cascade_name || MISSING_DATA_DASH} />
-      ${c.execution.selected_cascade_canonical
-        && c.execution.selected_cascade_canonical !== c.execution.selected_cascade_name
+      <${ConfigRow} label="선택 cascade" value=${c.execution.selected_runtime_name || MISSING_DATA_DASH} />
+      ${c.execution.selected_runtime_canonical
+        && c.execution.selected_runtime_canonical !== c.execution.selected_runtime_name
         ? html`<${ConfigRow}
             label="정규화 cascade"
-            value=${c.execution.selected_cascade_canonical}
+            value=${c.execution.selected_runtime_canonical}
           />`
         : null}
       <${ConfigRow} label="catalog source" value=${cascadeCatalogSourceLabel(c)} />

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -353,10 +353,10 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const providerAttempts = executionSummary?.provider_attempt_count
   const providerFallback = executionSummary?.provider_fallback_applied
   const cascadeOutcome = executionSummary?.cascade_outcome?.trim() || null
-  const cascadeName = keeper.cascade_name?.trim() || null
+  const cascadeName = keeper.runtime_name?.trim() || null
   const cascadeCanonical =
-    keeper.cascade_canonical?.trim()
-    || keeper.selected_cascade_canonical?.trim()
+    keeper.runtime_canonical?.trim()
+    || keeper.selected_runtime_canonical?.trim()
     || null
   const cascadeLabel =
     cascadeName && cascadeCanonical && cascadeName !== cascadeCanonical
@@ -370,7 +370,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
       if (
         point.fallback_applied
         || point.cascade_outcome?.trim()
-        || point.cascade_name?.trim()
+        || point.runtime_name?.trim()
         || typeof point.cascade_attempt_count === 'number'
       ) return point
     }

--- a/dashboard/src/components/keeper-tool-access.test.ts
+++ b/dashboard/src/components/keeper-tool-access.test.ts
@@ -7,7 +7,7 @@ import type { KeeperConfig } from '../types'
 
 function makeConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
   return {
-    execution: { selected_cascade_name: 'spark' },
+    execution: { selected_runtime_name: 'spark' },
     sandbox_profile: 'local',
     network_mode: 'inherit',
     handoff: { auto: true, threshold: 0.8 },
@@ -34,7 +34,7 @@ describe('KeeperToolAccessSummary', () => {
 
   it('shows em dash for null cascade name', () => {
     const container = document.createElement('div')
-    render(h(KeeperToolAccessSummary, { config: makeConfig({ execution: { selected_cascade_name: null } }) }), container)
+    render(h(KeeperToolAccessSummary, { config: makeConfig({ execution: { selected_runtime_name: null } }) }), container)
     const dds = container.querySelectorAll('dd')
     expect(dds[0]!.textContent).toBe('—')
   })

--- a/dashboard/src/components/keeper-tool-access.ts
+++ b/dashboard/src/components/keeper-tool-access.ts
@@ -36,7 +36,7 @@ function mentionsLabel(targets: readonly string[]): string {
 }
 
 export function KeeperToolAccessSummary({ config }: { config: KeeperConfig }) {
-  const cascade = config.execution.selected_cascade_name || '—'
+  const cascade = config.execution.selected_runtime_name || '—'
   const sandbox = config.sandbox_profile ?? '(unknown sandbox_profile)'
   const network = config.network_mode ?? '(unknown network_mode)'
   const handoff = `${config.handoff.auto ? 'on' : 'off'} · threshold ${config.handoff.threshold}`

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -530,8 +530,8 @@ describe('normalizeKeepers lifecycle metrics', () => {
       {
         name: 'cascade-keeper',
         status: 'active',
-        cascade_name: 'oas-keeper_unified',
-        selected_cascade_canonical: 'primary',
+        runtime_name: 'oas-keeper_unified',
+        selected_runtime_canonical: 'primary',
         primary_model: 'provider-d:gpt-5.4',
         active_model: 'gpt-5.4',
         active_model_label: 'provider-d:gpt-5.4',
@@ -548,7 +548,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
             channel: 'turn',
             model_used: 'provider-a:model-a-sonnet',
             cascade: {
-              cascade_name: 'primary',
+              runtime_name: 'primary',
               selected_model: 'provider-a:model-a-sonnet',
               attempt_count: 2,
               outcome: 'passed_to_next_model',
@@ -569,9 +569,9 @@ describe('normalizeKeepers lifecycle metrics', () => {
     ])
 
     expect(keeper).toMatchObject({
-      cascade_name: 'oas-keeper_unified',
-      cascade_canonical: 'primary',
-      selected_cascade_canonical: 'primary',
+      runtime_name: 'oas-keeper_unified',
+      runtime_canonical: 'primary',
+      selected_runtime_canonical: 'primary',
       active_model_label: null,
       last_model_used_label: null,
     })
@@ -579,7 +579,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
     expect(keeper?.active_model).toBeUndefined()
     expect(keeper?.last_model_used).toBeUndefined()
     expect(keeper?.metrics_series?.[0]).toMatchObject({
-      cascade_name: 'primary',
+      runtime_name: 'primary',
       cascade_selected_model: null,
       cascade_attempt_count: 2,
       cascade_outcome: 'passed_to_next_model',

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -21,10 +21,10 @@ import {
 import { normalizeStopCause } from './lib/stop-cause'
 import { contextThresholds } from './config/context-thresholds'
 import { normalizeKeeperDiagnostic } from './keeper-state'
-import type { CascadeRef } from './types'
+import type { RuntimeRef } from './types'
 
-/** Normalize a raw cascade_ref JSON object into a typed CascadeRef. */
-function normalizeCascadeRef(raw: unknown): CascadeRef | null {
+/** Normalize a raw runtime_ref JSON object into a typed RuntimeRef. */
+function normalizeCascadeRef(raw: unknown): RuntimeRef | null {
   if (!isRecord(raw)) return null
   const group = asString(raw.group)
   if (!group) return null
@@ -488,7 +488,7 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         total_tokens: totalTokens,
         wall_tokens_per_second: wallTokensPerSecond,
         inference_telemetry,
-        cascade_name: cascadeObj ? (asString(cascadeObj.cascade_name) ?? asString(cascadeObj.name) ?? null) : null,
+        runtime_name: cascadeObj ? (asString(cascadeObj.runtime_name) ?? asString(cascadeObj.name) ?? null) : null,
         cascade_outcome: cascadeObj ? (asString(cascadeObj.outcome) ?? null) : null,
         cascade_selected_model: null,
         cascade_attempt_count: cascadeObj ? (asNumber(cascadeObj.attempt_count) ?? null) : null,
@@ -647,10 +647,10 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         last_model_used: undefined,
         last_model_used_label: null,
         next_model_hint: null,
-        cascade_name: asString(row.cascade_name) ?? null,
-        cascade_ref: normalizeCascadeRef(row.cascade_ref),
-        cascade_canonical: asString(row.cascade_canonical) ?? asString(row.selected_cascade_canonical) ?? null,
-        selected_cascade_canonical: asString(row.selected_cascade_canonical) ?? null,
+        runtime_name: asString(row.runtime_name) ?? null,
+        runtime_ref: normalizeCascadeRef(row.runtime_ref),
+        runtime_canonical: asString(row.runtime_canonical) ?? asString(row.selected_runtime_canonical) ?? null,
+        selected_runtime_canonical: asString(row.selected_runtime_canonical) ?? null,
         status: normalizeKeeperAgentStatus(statusRaw),
         presence_keepalive:
           typeof row.presence_keepalive === 'boolean' ? row.presence_keepalive : undefined,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -387,7 +387,7 @@ export interface KeeperMetricPoint {
   total_tokens: number | null
   wall_tokens_per_second: number | null
   inference_telemetry: InferenceTelemetry | null
-  cascade_name?: string | null
+  runtime_name?: string | null
   cascade_outcome?: string | null
   cascade_selected_model?: string | null
   cascade_attempt_count?: number | null
@@ -928,10 +928,10 @@ export interface Keeper {
   last_model_used?: string
   last_model_used_label?: string | null
   next_model_hint?: string | null
-  cascade_name?: string | null
-  cascade_ref?: CascadeRef | null
-  cascade_canonical?: string | null
-  selected_cascade_canonical?: string | null
+  runtime_name?: string | null
+  runtime_ref?: RuntimeRef | null
+  runtime_canonical?: string | null
+  selected_runtime_canonical?: string | null
   status: string
   presence_keepalive?: boolean
   presence_keepalive_sec?: number
@@ -1212,9 +1212,9 @@ interface KeeperConfigExecution {
   per_provider_timeout_sec?: number | null
   per_provider_timeout_mode: 'override' | 'turn_budget_heuristic'
   verify: boolean
-  selected_cascade_name: string
-  selected_cascade_canonical: string
-  cascade_ref?: CascadeRef | null
+  selected_runtime_name: string
+  selected_runtime_canonical: string
+  runtime_ref?: RuntimeRef | null
 }
 
 interface KeeperConfigCompaction {
@@ -1231,7 +1231,7 @@ interface KeeperConfigProactive {
   cooldown_sec: number
 }
 
-export interface CascadeRef {
+export interface RuntimeRef {
   group: string
   item: string | null
 }

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -997,7 +997,7 @@ export interface GoalDetailKeeper {
   active_goal_ids: string[]
   sandbox_profile: string
   network_mode: string
-  cascade_name: string
+  runtime_name: string
   approval_profile: string | null
   cascade_outcome: string | null
   latest_execution_outcome: string | null

--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -22,7 +22,7 @@
 
 type waiter_info =
   { keeper_name : string
-  ; cascade_name : string
+  ; runtime_name : string
   ; enqueue_ts : float
   ; priority : Llm_provider.Request_priority.t
   }
@@ -100,16 +100,16 @@ let bump_active delta =
     global.active <- max 0 (global.active + delta))
 ;;
 
-let with_inflight_observation ~keeper_name ~cascade_name f =
+let with_inflight_observation ~keeper_name ~runtime_name f =
   bump_active 1;
-  (match Admission_queue_metrics.on_acquire ~keeper_name ~cascade_name ~wait_ms:0 with
+  (match Admission_queue_metrics.on_acquire ~keeper_name ~runtime_name ~wait_ms:0 with
    | () -> ()
    | exception exn ->
      bump_active (-1);
      raise exn);
   Eio_guard.protect
     ~finally:(fun () ->
-      (match Admission_queue_metrics.on_release ~keeper_name ~cascade_name with
+      (match Admission_queue_metrics.on_release ~keeper_name ~runtime_name with
        | () -> ()
        | exception exn ->
          bump_active (-1);
@@ -187,7 +187,7 @@ let check_host_resources ~surface ~keeper_name =
   check_host_resources_with ~surface ~keeper_name ~fd_count ~threshold
 ;;
 
-let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
+let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~runtime_name f =
   match
     check_host_resources ~surface:Admission_queue_metrics.With_permit ~keeper_name
   with
@@ -201,15 +201,15 @@ let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
          Metric and snapshot observation track real inflight even though
          gating is off.
          RFC-0026 PR-E-1.6/1.7; audit response 2026-05-05 §3.1. *)
-    Ok (with_inflight_observation ~keeper_name ~cascade_name f)
+    Ok (with_inflight_observation ~keeper_name ~runtime_name f)
 ;;
 
-let try_with_permit ~priority:_ ~keeper_name ~cascade_name f =
+let try_with_permit ~priority:_ ~keeper_name ~runtime_name f =
   match
     check_host_resources ~surface:Admission_queue_metrics.Try_with_permit ~keeper_name
   with
   | Error _ -> None
-  | Ok () -> Some (with_inflight_observation ~keeper_name ~cascade_name f)
+  | Ok () -> Some (with_inflight_observation ~keeper_name ~runtime_name f)
 ;;
 
 let snapshot () =
@@ -239,9 +239,9 @@ let snapshot_json () =
              (fun (w : waiter_info) ->
                 `Assoc
                   [ "keeper_name", `String w.keeper_name
-                  ; ( "cascade_name"
+                  ; ( "runtime_name"
                     , `String
-                        (w.cascade_name) )
+                        (w.runtime_name) )
                   ; ( "priority"
                     , `String (Llm_provider.Request_priority.to_string w.priority) )
                   ; "wait_seconds", `Float (now -. w.enqueue_ts)

--- a/lib/admission_queue.mli
+++ b/lib/admission_queue.mli
@@ -14,7 +14,7 @@
 (** Metadata carried per waiter — for observability, not scheduling. *)
 type waiter_info = {
   keeper_name : string;
-  cascade_name : string;
+  runtime_name : string;
   enqueue_ts : float;
   priority : Llm_provider.Request_priority.t;
 }
@@ -39,7 +39,7 @@ val with_permit :
   ?wait_timeout_sec:float ->
   priority:Llm_provider.Request_priority.t ->
   keeper_name:string ->
-  cascade_name:string ->
+  runtime_name:string ->
   (unit -> 'a) ->
   ('a, [> `Host_resource_saturated of string ]) result
 (** Run [f] in passthrough mode and record inflight observation for metrics
@@ -52,7 +52,7 @@ val with_permit :
 val try_with_permit :
   priority:Llm_provider.Request_priority.t ->
   keeper_name:string ->
-  cascade_name:string ->
+  runtime_name:string ->
   (unit -> 'a) ->
   'a option
 (** Non-blocking variant. Returns [None] if host resources are saturated. *)

--- a/lib/admission_queue_metrics.ml
+++ b/lib/admission_queue_metrics.ml
@@ -12,13 +12,13 @@ let rejection_surface_label = function
 let rejection_reason_label = function
   | Host_resource_saturated -> "host_resource_saturated"
 
-let on_acquire ~keeper_name:_ ~cascade_name:_ ~wait_ms =
+let on_acquire ~keeper_name:_ ~runtime_name:_ ~wait_ms =
   Prometheus.inc_gauge Prometheus.metric_inference_queue_inflight ();
   Prometheus.inc_counter Prometheus.metric_inference_queue_acquired ();
   let wait_sec = Float.of_int wait_ms /. 1000.0 in
   Prometheus.observe_histogram Prometheus.metric_inference_queue_wait wait_sec
 
-let on_release ~keeper_name:_ ~cascade_name:_ =
+let on_release ~keeper_name:_ ~runtime_name:_ =
   Prometheus.dec_gauge Prometheus.metric_inference_queue_inflight ()
 
 let on_reject ~surface ~reason =

--- a/lib/admission_queue_metrics.mli
+++ b/lib/admission_queue_metrics.mli
@@ -19,14 +19,14 @@ val rejection_reason_label : rejection_reason -> string
 
 val on_acquire :
   keeper_name:string ->
-  cascade_name:string ->
+  runtime_name:string ->
   wait_ms:int ->
   unit
 (** Called after successful acquire. Increments inflight gauge,
     records wait time histogram. *)
 
 val on_release :
-  keeper_name:string -> cascade_name:string -> unit
+  keeper_name:string -> runtime_name:string -> unit
 (** Called on release. Decrements inflight gauge. *)
 
 val on_reject : surface:rejection_surface -> reason:rejection_reason -> unit

--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -693,7 +693,7 @@ let review
               ~caller:Env_config_oas_bridge.Anti_rationalization
               (fun () ->
                  Keeper_turn_driver_wrappers.run_named_with_masc_tools
-                   ~cascade_name:evaluator_cascade
+                   ~runtime_name:evaluator_cascade
                    ~goal:prompt
                    ~masc_tools:[ report_review_verdict_schema ]
                    ~dispatch

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -112,12 +112,12 @@ let model_response_is_valid (resp : Agent_sdk_response.api_response) =
       | Agent_sdk.Types.Unknown _ -> true)
 
 let call_model_direct_sync ~agent_type ~prompt =
-  let cascade_name = cascade_name_for_agent_type agent_type in
+  let runtime_name = cascade_name_for_agent_type agent_type in
   try
     match
       Masc_oas_bridge.run_with_caller
         ~caller:Env_config_oas_bridge.Auto_responder (fun () ->
-        Keeper_turn_driver.run_named ~cascade_name
+        Keeper_turn_driver.run_named ~runtime_name
           ~goal:prompt ~max_turns:1
           ~accept:model_response_is_valid ~max_tokens:500
           ~approval:Approval_callbacks.auto_approve

--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -171,7 +171,7 @@ let goal_detail_keeper_json (detail : goal_detail_keeper) =
       ( "sandbox_profile",
         `String (Keeper_types_profile_sandbox.sandbox_profile_to_string meta.sandbox_profile) );
       ("network_mode", `String (Keeper_types_profile_sandbox.network_mode_to_string meta.network_mode));
-      ("cascade_name", `String (Keeper_meta_contract.cascade_name_of_meta meta));
+      ("runtime_name", `String (Keeper_meta_contract.runtime_name_of_meta meta));
       ( "approval_profile",
         Json_util.string_opt_to_json (Option.bind latest_receipt receipt_approval_profile) );
       ( "cascade_outcome",
@@ -392,7 +392,7 @@ let build_goal_timeline node linked_keepers approvals goal_events =
                               (Printf.sprintf "%s · %s"
                                  outcome
                                  (receipt_cascade_name receipt
-                                  |> Option.value ~default:(Keeper_meta_contract.cascade_name_of_meta detail.meta)))
+                                  |> Option.value ~default:(Keeper_meta_contract.runtime_name_of_meta detail.meta)))
                             ~severity)))
   in
   let goal_events = List.map goal_event_timeline_json goal_events in

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -647,7 +647,7 @@ let compute_judgments
     ~(masc_tools : Masc_domain.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.result)
     ~build_facts =
-  let cascade_name =
+  let runtime_name =
     Runtime.get_default_runtime_id ()
   in
   match
@@ -661,7 +661,7 @@ let compute_judgments
       ~caller:Env_config_oas_bridge.Governance_judge (fun () ->
       let factual_json = build_facts () in
       let prompt = prompt_for_facts factual_json in
-      Keeper_turn_driver_wrappers.run_named_with_masc_tools ~cascade_name
+      Keeper_turn_driver_wrappers.run_named_with_masc_tools ~runtime_name
         ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
         ~accept:Keeper_tool_response.response_has_text_or_tool_progress
         ~approval:Approval_callbacks.auto_approve

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -244,21 +244,21 @@ let keeper_config_json (config : Coord.config) (name : string)
           ("effective_system_prompt", `String effective_system_prompt);
         ]
       in
-      let cascade_name = Keeper_meta_contract.cascade_name_of_meta m in
+      let runtime_name = Keeper_meta_contract.runtime_name_of_meta m in
       (* RFC-0149 §3.3 — Result-returning resolver: on [Error] the
          canonical field surfaces as JSON [null] (parse-don't-validate
          honest signal) instead of the silent [Keeper_turn] rewrite the
          legacy [live_keeper_cascade_name] would produce. *)
       let selected_cascade_canonical_json =
-        match live_keeper_cascade_name_result cascade_name with
+        match live_keeper_cascade_name_result runtime_name with
         | Ok runtime ->
           `String (runtime)
         | Error (`Unresolved _) -> `Null
       in
       let execution =
         `Assoc [
-          ("selected_cascade_name", `String cascade_name);
-          ( "selected_cascade_canonical",
+          ("selected_runtime_name", `String runtime_name);
+          ( "selected_runtime_canonical",
             selected_cascade_canonical_json );
           ("models", `List []);
           ("active_model", `Null);

--- a/lib/dashboard/dashboard_http_keeper_trust.ml
+++ b/lib/dashboard/dashboard_http_keeper_trust.ml
@@ -33,7 +33,7 @@ let keeper_trust_json ?(include_receipt = false)
     | None ->
         `Assoc
           [
-            ("name", `String (Keeper_meta_contract.cascade_name_of_meta meta));
+            ("name", `String (Keeper_meta_contract.runtime_name_of_meta meta));
             ("selected_model", `Null);
             ("attempt_count", `Int 0);
             ("fallback_applied", `Bool false);

--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -28,7 +28,7 @@ type sample = {
 
 type provider_error_count = {
   provider_id : string;
-  cascade_name : string;
+  runtime_name : string;
   kind : string;
   capacity_scope : string;
   count : int;
@@ -121,7 +121,7 @@ let provider_error_count_to_yojson (c : provider_error_count) =
   `Assoc
     [
       ("provider_id", `String public_runtime_provider_label);
-      ("cascade_name", `String c.cascade_name);
+      ("runtime_name", `String c.runtime_name);
       ("kind", `String c.kind);
       ("capacity_scope", `String c.capacity_scope);
       ("count", `Int c.count);
@@ -298,11 +298,11 @@ let provider_error_capacity_scope_label = function
   | Provider_error.ModelNotFound ->
       "none"
 
-let record_provider_error ~cascade_name ~provider_id:_ error =
+let record_provider_error ~runtime_name ~provider_id:_ error =
   let kind = Provider_error.to_error_kind error in
   let capacity_scope = provider_error_capacity_scope_label error in
   let provider_id = public_runtime_provider_label in
-  let key = (provider_id, cascade_name, kind, capacity_scope) in
+  let key = (provider_id, runtime_name, kind, capacity_scope) in
   with_lock (fun () ->
       let count =
         match Hashtbl.find_opt provider_error_table key with
@@ -316,7 +316,7 @@ let compare_provider_error_count a b =
   | 0 -> (
       match String.compare a.provider_id b.provider_id with
       | 0 -> (
-          match String.compare a.cascade_name b.cascade_name with
+          match String.compare a.runtime_name b.runtime_name with
           | 0 -> (
               match String.compare a.kind b.kind with
               | 0 -> String.compare a.capacity_scope b.capacity_scope
@@ -330,13 +330,13 @@ let provider_error_counts ?provider () =
   let counts =
     with_lock (fun () ->
         Hashtbl.fold
-          (fun (provider_id, cascade_name, kind, capacity_scope) count acc ->
+          (fun (provider_id, runtime_name, kind, capacity_scope) count acc ->
             match provider with
             | Some provider when not (String.equal provider provider_id) -> acc
             | _ ->
                 {
                   provider_id;
-                  cascade_name;
+                  runtime_name;
                   kind;
                   capacity_scope;
                   count;
@@ -526,9 +526,9 @@ let clear ?provider () =
           Hashtbl.remove table p;
           let keys =
             Hashtbl.fold
-              (fun (provider_id, cascade_name, kind, capacity_scope) _ acc ->
+              (fun (provider_id, runtime_name, kind, capacity_scope) _ acc ->
                 if String.equal provider_id p then
-                  (provider_id, cascade_name, kind, capacity_scope) :: acc
+                  (provider_id, runtime_name, kind, capacity_scope) :: acc
                 else acc)
               provider_error_table []
           in

--- a/lib/dashboard/dashboard_oas_bridge.mli
+++ b/lib/dashboard/dashboard_oas_bridge.mli
@@ -129,7 +129,7 @@ val record_response :
 
 type provider_error_count = {
   provider_id : string;
-  cascade_name : string;
+  runtime_name : string;
   kind : string;
   capacity_scope : string;
   count : int;
@@ -139,8 +139,8 @@ type provider_error_count = {
     [capacity_scope] is ["none"] for non-capacity errors. *)
 
 val record_provider_error :
-  cascade_name:string -> provider_id:string -> Provider_error.t -> unit
-(** [record_provider_error ~cascade_name ~provider_id error] increments the
+  runtime_name:string -> provider_id:string -> Provider_error.t -> unit
+(** [record_provider_error ~runtime_name ~provider_id error] increments the
     dashboard count for a typed provider-error event. [provider_id] is accepted
     for source compatibility but normalized to the runtime lane before
     storage. *)

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -214,7 +214,7 @@ let compute_judgments
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.result)
     ~facts_json =
   let prompt = prompt_for_facts facts_json in
-  let cascade_name =
+  let runtime_name =
     Runtime.get_default_runtime_id ()
   in
   match
@@ -223,7 +223,7 @@ let compute_judgments
        Prometheus counter. *)
     Masc_oas_bridge.run_with_caller
       ~caller:Env_config_oas_bridge.Operator_judge (fun () ->
-      Keeper_turn_driver_wrappers.run_named_with_masc_tools ~cascade_name
+      Keeper_turn_driver_wrappers.run_named_with_masc_tools ~runtime_name
         ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
         ~accept:Keeper_tool_response.response_has_text_or_tool_progress
         ~approval:Approval_callbacks.auto_approve

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -529,10 +529,10 @@ let execute_single_agent_run ~sw ~net ~run_id ~provider ~model ~prompt =
                 ~system_prompt:(run_system_prompt provider)
                 ~max_turns:4
                 ~max_tokens:(Cascade_inference.resolve_max_tokens
-                  ~cascade_name:inference_cascade_name
+                  ~runtime_name:inference_cascade_name
                   ~fallback:(fun () -> 2048))
                 ~temperature:(Cascade_inference.resolve_temperature
-                  ~cascade_name:inference_cascade_name
+                  ~runtime_name:inference_cascade_name
                   ~fallback:(fun () -> 0.2))
                 ~sw ?net
                 ()

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -54,7 +54,7 @@ end
     @param build_turn_prompt Callback: receives the base keeper system prompt
            and checkpoint message history, returns the final turn system prompt
     @param user_message The user's message to the keeper
-    @param cascade_name Runtime cascade profile name for model selection
+    @param runtime_name Runtime cascade profile name for model selection
     @param generation Current generation counter
     @param max_turns Maximum agent turns (default from keeper runtime config)
     @param guardrails Optional OAS guardrails for tool safety gates
@@ -73,7 +73,7 @@ let run_turn
       ~(build_turn_prompt :
          base_system_prompt:string -> messages:Agent_sdk.Types.message list -> turn_prompt)
       ~(user_message : string)
-      ~(cascade_name : string)
+      ~(runtime_name : string)
       ?world_observation
       ?(turn_affordances = [])
       ?(required_tool_names = [])
@@ -139,7 +139,7 @@ let run_turn
   Eio.Switch.run @@ fun turn_sw ->
   Eio_context.with_turn_switch turn_sw
   @@ fun () ->
-  let cascade_name_string = cascade_name in
+  let cascade_name_string = runtime_name in
   (* Steps 0–4: inference params, session dir, checkpoint, base prompt,
      working context, checkpoint hygiene — all in Keeper_run_context. *)
   let ctx =
@@ -148,7 +148,7 @@ let run_turn
       ~meta
       ~base_dir
       ~max_context
-      ~cascade_name
+      ~runtime_name
       ?temperature
       ?max_tokens
       ?shared_context
@@ -163,7 +163,7 @@ let run_turn
   let max_tokens, pre_dispatch_max_tokens_error =
     match
       Cascade_inference.validate_max_tokens_within_ceiling
-        ~cascade_name
+        ~runtime_name
         ~provider_ceiling:max_output_ceiling
         ctx.max_tokens
     with
@@ -217,7 +217,7 @@ let run_turn
       ~agent_name:meta.agent_name
       ~trace_id
       ~generation
-      ~cascade_name:cascade_name_string
+      ~runtime_name:cascade_name_string
       ~turn_start
       ~seq_ref
   in
@@ -329,7 +329,7 @@ let run_turn
       ~start_turn_count
       ~generation
       ~max_turns
-      ~cascade_name
+      ~runtime_name
       ~is_retry
       ~turn_affordances
       ~required_tool_names
@@ -531,7 +531,7 @@ let run_turn
                   ~timeout_s:bridge_timeout_s
                   (fun () ->
                           Keeper_turn_driver.run_named
-                            ~cascade_name:cascade_name_string
+                            ~runtime_name:cascade_name_string
                             ~base_path:config.base_path
                             ~keeper_name:meta.name
                     ?provider_filter
@@ -723,7 +723,7 @@ let run_turn
                    Error
                      (Keeper_agent_run_tool_surface_violation.to_sdk_error
                         ~keeper_name:meta.name
-                        ~cascade_name:(Keeper_meta_contract.cascade_name_of_meta meta)
+                        ~runtime_name:(Keeper_meta_contract.runtime_name_of_meta meta)
                         ~requested_tool_names_seen:acc.requested_tool_names_seen
                         ~unexpected_tool_names))
                  else (
@@ -892,7 +892,7 @@ let run_turn
          ~meta
          ~generation
          ~manifest_keeper_turn_id
-         ~cascade_name
+         ~runtime_name
          ~keeper_visible_sandbox_root
          ~receipt_started_at
          ~runtime_manifest_context

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -62,7 +62,7 @@ val per_provider_timeout_for_turn
     @param build_turn_prompt Callback: receives the base keeper system prompt
            and checkpoint message history, returns the final turn system prompt
     @param user_message The user's message to the keeper
-    @param cascade_name Typed runtime cascade profile name for model selection
+    @param runtime_name Typed runtime cascade profile name for model selection
     @param world_observation Structured keeper world snapshot used by
            required-tool contract checks. When omitted, the contract gate
            does not infer world state from prompt text.
@@ -91,7 +91,7 @@ val run_turn
   -> build_turn_prompt:
        (base_system_prompt:string -> messages:Agent_sdk.Types.message list -> turn_prompt)
   -> user_message:string
-  -> cascade_name:string
+  -> runtime_name:string
   -> ?world_observation:Keeper_world_observation.world_observation
   -> ?turn_affordances:string list
   -> ?required_tool_names:string list

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -126,7 +126,7 @@ let finalize
          Log.Keeper.error
            "keeper:%s cascade=%s OAS checkpoint save failed: %s"
            meta.name
-           (Keeper_meta_contract.cascade_name_of_meta meta)
+           (Keeper_meta_contract.runtime_name_of_meta meta)
            e;
          Prometheus.inc_counter
            Keeper_metrics.(to_string CheckpointFailures)
@@ -140,7 +140,7 @@ let finalize
       Log.Keeper.error
         "keeper:%s cascade=%s missing OAS checkpoint after run"
         meta.name
-        (Keeper_meta_contract.cascade_name_of_meta meta);
+        (Keeper_meta_contract.runtime_name_of_meta meta);
       Prometheus.inc_counter
         Keeper_metrics.(to_string CheckpointFailures)
         ~labels:[ "keeper", meta.name; "site", "missing" ]
@@ -167,7 +167,7 @@ let finalize
       ~state_snapshot
       ~post_turn_t0
       ?provider_filter
-      ~cascade_name:cascade_name_string
+      ~runtime_name:cascade_name_string
       ~inference_telemetry:result.response.telemetry
       ();
     Ok

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -13,7 +13,7 @@ let run
   ~state_snapshot
   ~post_turn_t0
   ?provider_filter
-  ~cascade_name
+  ~runtime_name
   ~inference_telemetry
   ()
   =
@@ -88,7 +88,7 @@ let run
      let memory_summarizer =
        Keeper_memory_llm_summary.make
          ?provider_filter
-         ~cascade_name
+         ~runtime_name
          ~keeper_name:meta.name
          ()
      in
@@ -116,7 +116,7 @@ let run
      Log.Keeper.warn
        "keeper:%s cascade=%s compaction failed: %s"
        meta.name
-       (Keeper_meta_contract.cascade_name_of_meta meta)
+       (Keeper_meta_contract.runtime_name_of_meta meta)
        (Printexc.to_string exn));
 
   (* Post-turn quality metrics — goal alignment + memory recall.

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -19,7 +19,7 @@ val run :
   state_snapshot:Keeper_memory_policy.keeper_state_snapshot ->
   post_turn_t0:float ->
   ?provider_filter:string list ->
-  cascade_name:string ->
+  runtime_name:string ->
   inference_telemetry:Agent_sdk.Types.inference_telemetry option ->
   unit ->
   unit

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -48,7 +48,7 @@ let finalize
     ~meta
     ~generation
     ~manifest_keeper_turn_id
-    ~cascade_name
+    ~runtime_name
     ~keeper_visible_sandbox_root
     ~receipt_started_at
     ~runtime_manifest_context
@@ -199,7 +199,7 @@ let finalize
     ; network_mode = meta.network_mode
     ; approval_profile = acc.tool_surface.approval_mode_effective
     ; approval_profile_derived = acc.tool_surface.approval_mode_derived
-    ; cascade_name
+    ; runtime_name
     ; cascade_selected_model =
         Option.bind cascade_observation (fun obs -> obs.selected_model)
     ; cascade_attempt_count =
@@ -247,8 +247,8 @@ let finalize
           `String
             (Keeper_execution_receipt.outcome_kind_to_string receipt.outcome) );
         ("terminal_reason_code", `String receipt.terminal_reason_code);
-        ( "cascade_name",
-          `String (receipt.cascade_name) );
+        ( "runtime_name",
+          `String (receipt.runtime_name) );
         ("cascade_attempt_count", `Int receipt.cascade_attempt_count);
         ("cascade_fallback_applied", `Bool receipt.cascade_fallback_applied);
         ( "cascade_outcome",
@@ -296,7 +296,7 @@ let finalize
       ~trace_id:receipt.trace_id ~generation:receipt.generation
       ~keeper_turn_id:manifest_keeper_turn_id ~event
       ?oas_turn_count
-      ~cascade_name:(receipt.cascade_name)
+      ~runtime_name:(receipt.runtime_name)
       ~status ~decision ~receipt_path ?tool_call_log_path ()
     |> Keeper_runtime_manifest.append_best_effort ~site config
   in

--- a/lib/keeper/keeper_agent_run_tool_surface_violation.ml
+++ b/lib/keeper/keeper_agent_run_tool_surface_violation.ml
@@ -1,6 +1,6 @@
 let to_sdk_error
       ~keeper_name
-      ~cascade_name
+      ~runtime_name
       ~requested_tool_names_seen
       ~unexpected_tool_names
   =
@@ -35,7 +35,7 @@ let to_sdk_error
   Log.Keeper.error
     "keeper:%s cascade=%s %s"
     keeper_name
-    cascade_name
+    runtime_name
     reason;
   Agent_sdk.Error.Internal reason
 ;;

--- a/lib/keeper/keeper_agent_run_tool_surface_violation.mli
+++ b/lib/keeper/keeper_agent_run_tool_surface_violation.mli
@@ -1,6 +1,6 @@
 val to_sdk_error
   :  keeper_name:string
-  -> cascade_name:string
+  -> runtime_name:string
   -> requested_tool_names_seen:string list
   -> unexpected_tool_names:string list
   -> Agent_sdk.Error.sdk_error

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -165,7 +165,7 @@ let runtime_manifest_context ~keeper_name ~agent_name ~trace_id ~generation
   }
 
 let append_runtime_manifest ~config ~keeper_name ~agent_name ~trace_id
-    ~generation ~cascade_name ?status ?decision ?keeper_turn_id
+    ~generation ~runtime_name ?status ?decision ?keeper_turn_id
     ?oas_turn_count ?elapsed_ms ?logical_seq ?checkpoint_path ?receipt_path
     ?compaction_source ~site event =
   let decision =
@@ -189,7 +189,7 @@ let append_runtime_manifest ~config ~keeper_name ~agent_name ~trace_id
            decision)
   in
   Keeper_runtime_manifest.make ~keeper_name ~agent_name ~trace_id ~generation
-    ?keeper_turn_id ?oas_turn_count ?logical_seq ~event ~cascade_name ?status
+    ?keeper_turn_id ?oas_turn_count ?logical_seq ~event ~runtime_name ?status
     ?decision ?checkpoint_path ?receipt_path ()
   |> Keeper_runtime_manifest.append_best_effort ~site config
 
@@ -224,7 +224,7 @@ let make_append_manifest
     ~agent_name
     ~trace_id
     ~generation
-    ~cascade_name
+    ~runtime_name
     ~(turn_start : Mtime.t)
     ~(seq_ref : int ref)
   : Keeper_agent_run_sidecar.append_manifest_fn
@@ -253,7 +253,7 @@ let make_append_manifest
     ~agent_name
     ~trace_id
     ~generation
-    ~cascade_name
+    ~runtime_name
     ?status ?decision ?keeper_turn_id ?oas_turn_count
     ?elapsed_ms ?logical_seq
     ?checkpoint_path ?compaction_source

--- a/lib/keeper/keeper_agent_run_turn_helpers.mli
+++ b/lib/keeper/keeper_agent_run_turn_helpers.mli
@@ -51,7 +51,7 @@ val append_runtime_manifest :
   agent_name:string ->
   trace_id:string ->
   generation:int ->
-  cascade_name:string ->
+  runtime_name:string ->
   ?status:string ->
   ?decision:Yojson.Safe.t ->
   ?keeper_turn_id:int ->
@@ -76,7 +76,7 @@ val make_append_manifest :
   agent_name:string ->
   trace_id:string ->
   generation:int ->
-  cascade_name:string ->
+  runtime_name:string ->
   turn_start:Mtime.t ->
   seq_ref:int ref ->
   Keeper_agent_run_sidecar.append_manifest_fn

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -19,10 +19,10 @@ let one_day_seconds_int = Masc_time_constants.day_int
 (* cascade→Runtime 숙청: per-phase cascade name 구분 제거. cascade 세계의
    phase_recovery / phase_buffer / tool_required / routing 은 서로 다른 route
    였으나, Runtime 모델에서는 모든 phase 가 동일한 default Runtime 을 쓴다 —
-   넷 다 default_cascade_name () 으로 수렴하는 죽은 구분이었다. 단일 함수로
+   넷 다 default_runtime_name () 으로 수렴하는 죽은 구분이었다. 단일 함수로
    collapse 하고, eager 모듈-레벨 baking(module-init 시점 미초기화 싱글톤 읽기)
    도 함께 제거한다. *)
-let default_cascade_name () = Runtime.get_default_runtime_id ()
+let default_runtime_name () = Runtime.get_default_runtime_id ()
 
 (** Minimum context window (tokens) for any keeper turn.
     64k-class local models are valid keeper backends; do not clamp them upward
@@ -464,7 +464,7 @@ let keeper_llm_rerank_enabled () : bool =
 let keeper_llm_rerank_cascade () : string =
   match Env_config_core.raw_value_opt "MASC_KEEPER_LLM_RERANK_CASCADE" with
   | Some v when String.trim v <> "" -> String.trim v
-  | _ -> default_cascade_name ()
+  | _ -> default_runtime_name ()
 
 include Keeper_config_rule_thresholds
 

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -15,7 +15,7 @@
     @since v2.128.0
     @since RFC-0066 Phase 1: changed from a string value to a thunk
     (issue #14624). *)
-val default_cascade_name : unit -> string
+val default_runtime_name : unit -> string
 
 (** Minimum context window (tokens) for any keeper turn. *)
 val min_keeper_context_tokens : int

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -292,10 +292,10 @@ let fallback_cascade_for_unavailable_profile
   if not (String.equal normalized_effective normalized_base)
   then Some normalized_base
   else if
-    String.equal normalized_effective (Keeper_config.default_cascade_name ())
-    || String.equal normalized_effective (Keeper_config.default_cascade_name ())
+    String.equal normalized_effective (Keeper_config.default_runtime_name ())
+    || String.equal normalized_effective (Keeper_config.default_runtime_name ())
   then None
-  else Some (Keeper_config.default_cascade_name ())
+  else Some (Keeper_config.default_runtime_name ())
 
 let degraded_retry_after_recoverable_error
     ~(effective_cascade : string)
@@ -305,25 +305,25 @@ let degraded_retry_after_recoverable_error
     String.trim effective_cascade
   in
   let effective_is_declared_phase_buffer =
-    is_declared_phase_alias effective_cascade (Keeper_config.default_cascade_name ())
+    is_declared_phase_alias effective_cascade (Keeper_config.default_runtime_name ())
   in
   let effective_is_declared_phase_recovery =
     is_declared_phase_alias
       effective_cascade
-      (Keeper_config.default_cascade_name ())
+      (Keeper_config.default_runtime_name ())
   in
   let phase_recovery_retry fallback_reason =
     Some
       {
-        next_cascade = (Keeper_config.default_cascade_name ());
+        next_cascade = (Keeper_config.default_runtime_name ());
         fallback_reason;
       }
   in
   if tool_requirement = Required
      || effective_is_declared_phase_buffer
      || effective_is_declared_phase_recovery
-     || String.equal normalized_effective (Keeper_config.default_cascade_name ())
-     || String.equal normalized_effective (Keeper_config.default_cascade_name ())
+     || String.equal normalized_effective (Keeper_config.default_runtime_name ())
+     || String.equal normalized_effective (Keeper_config.default_runtime_name ())
   then None
   else if Keeper_turn_driver.sdk_error_is_hard_quota err then
     phase_recovery_retry Hard_quota
@@ -504,9 +504,9 @@ let normalized_cascade_name ~catalog_names name =
   let trimmed = String.trim name in
   if List.exists (String.equal trimmed) catalog_names then trimmed
   else if
-    String.equal trimmed (Keeper_config.default_cascade_name ())
-    || String.equal trimmed (Keeper_config.default_cascade_name ())
-    || String.equal trimmed (Keeper_config.default_cascade_name ())
+    String.equal trimmed (Keeper_config.default_runtime_name ())
+    || String.equal trimmed (Keeper_config.default_runtime_name ())
+    || String.equal trimmed (Keeper_config.default_runtime_name ())
   then trimmed
   else String.trim trimmed
 
@@ -519,8 +519,8 @@ let required_tool_rotation_candidate
   let routed_phase_buffer_is_distinct =
     not
       (String.equal
-         (Keeper_config.default_cascade_name ())
-         (Keeper_config.default_cascade_name ()))
+         (Keeper_config.default_runtime_name ())
+         (Keeper_config.default_runtime_name ()))
   in
   (* Required-tool turns may still use the phase-recovery route when the catalog
      declares it as an explicit fallback profile. Do not take it from generic
@@ -528,16 +528,16 @@ let required_tool_rotation_candidate
      required-tool turns into a control/recovery lane. *)
   not
     ((routed_phase_buffer_is_distinct
-      && String.equal normalized (Keeper_config.default_cascade_name ())))
+      && String.equal normalized (Keeper_config.default_runtime_name ())))
   && (allow_phase_recovery
       || not
-           (String.equal normalized (Keeper_config.default_cascade_name ())))
+           (String.equal normalized (Keeper_config.default_runtime_name ())))
   && not (Cascade_capability_profile.is_system_cascade_name normalized)
 
 let tool_required_rotation_cascade_name () =
   try
     Runtime.get_default_runtime_id ()
-  with Failure _ -> (Keeper_config.default_cascade_name ())
+  with Failure _ -> (Keeper_config.default_runtime_name ())
 
 let default_degraded_rotation_candidates
     ~catalog_names
@@ -545,7 +545,7 @@ let default_degraded_rotation_candidates
     ~(tool_requirement : Keeper_agent_tool_surface.tool_requirement) =
   let normalized_base = normalized_cascade_name ~catalog_names base_cascade in
   let default_cascade =
-    normalized_cascade_name ~catalog_names (Keeper_config.default_cascade_name ())
+    normalized_cascade_name ~catalog_names (Keeper_config.default_runtime_name ())
   in
   let tool_required_cascade =
     normalized_cascade_name ~catalog_names (tool_required_rotation_cascade_name ())

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -477,7 +477,7 @@ let to_json (receipt : t) =
       ~required_tools:receipt.tool_surface.required_tools
       ~required_tool_candidates:receipt.tool_surface.required_tool_candidates
       ~missing_required_tools:receipt.tool_surface.missing_required_tools
-      ~cascade_profile:(receipt.cascade_name)
+      ~cascade_profile:(receipt.runtime_name)
       ()
   in
   let action_radius =
@@ -563,7 +563,7 @@ let to_json (receipt : t) =
           ] )
     ; ( "cascade"
       , `Assoc
-          [ "name", `String (receipt.cascade_name)
+          [ "name", `String (receipt.runtime_name)
           ; "selected_model", `Null
           ; "attempt_count", `Int receipt.cascade_attempt_count
           ; "fallback_applied", `Bool receipt.cascade_fallback_applied
@@ -726,7 +726,7 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
     ; ( "current_task_id", string_opt_json receipt.current_task_id )
     ; "goal_ids", list_json receipt.goal_ids
     ; "response_text_present", `Bool receipt.response_text_present
-    ; "cascade_name", `String (receipt.cascade_name)
+    ; "runtime_name", `String (receipt.runtime_name)
     ; "cascade_outcome", `String (cascade_outcome_to_string receipt.cascade_outcome)
     ; ( "tool_contract_result"
       , `String (tool_contract_result_to_string receipt.tool_contract_result) )
@@ -921,21 +921,21 @@ let stale_turn_bucket stale_seconds =
 let stale_broadcast_payload
       ~keeper_name
       ~agent_name
-      ~cascade_name
+      ~runtime_name
       ~trace_id
       ~generation
       ~failure_reason
       ~stale_seconds
       ~last_turn_ts
   =
-  let cascade_name_string = cascade_name in
+  let cascade_name_string = runtime_name in
   let failure_reason_text = stale_broadcast_failure_reason_text failure_reason in
   let failure_reason_cohort = stale_broadcast_failure_cohort failure_reason in
   `Assoc
     [ "schema", `String "keeper.operator_broadcast_required.v1"
     ; "keeper_name", `String keeper_name
     ; "agent_name", `String agent_name
-    ; "cascade_name", `String cascade_name_string
+    ; "runtime_name", `String cascade_name_string
     ; "trace_id", `String trace_id
     ; "generation", `Int generation
     ; "disposition", `String "stalled"
@@ -958,19 +958,19 @@ let emit_stale_keeper_broadcast
       config
       ~keeper_name
       ~agent_name
-      ~cascade_name
+      ~runtime_name
       ~trace_id
       ~generation
       ~failure_reason
       ~stale_seconds
       ~last_turn_ts
   =
-  let cascade_name_string = cascade_name in
+  let cascade_name_string = runtime_name in
   let payload =
     stale_broadcast_payload
       ~keeper_name
       ~agent_name
-      ~cascade_name
+      ~runtime_name
       ~trace_id
       ~generation
       ~stale_seconds

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -218,7 +218,7 @@ type t =
   ; network_mode : Keeper_types_profile_sandbox.network_mode
   ; approval_profile : string option
   ; approval_profile_derived : bool
-  ; cascade_name : string
+  ; runtime_name : string
   ; cascade_selected_model : string option
   ; cascade_attempt_count : int
   ; cascade_fallback_applied : bool
@@ -313,7 +313,7 @@ val operator_broadcast_payload
 val stale_broadcast_payload
   :  keeper_name:string
   -> agent_name:string
-  -> cascade_name:string
+  -> runtime_name:string
   -> trace_id:string
   -> generation:int
   -> failure_reason:Keeper_registry.failure_reason option
@@ -334,7 +334,7 @@ val emit_stale_keeper_broadcast
   :  Coord.config
   -> keeper_name:string
   -> agent_name:string
-  -> cascade_name:string
+  -> runtime_name:string
   -> trace_id:string
   -> generation:int
   -> failure_reason:Keeper_registry.failure_reason option

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -301,7 +301,7 @@ type t =
   ; network_mode : Keeper_types_profile_sandbox.network_mode
   ; approval_profile : string option
   ; approval_profile_derived : bool
-  ; cascade_name : string
+  ; runtime_name : string
   ; cascade_selected_model : string option
   ; cascade_attempt_count : int
   ; cascade_fallback_applied : bool

--- a/lib/keeper/keeper_execution_receipt_types.mli
+++ b/lib/keeper/keeper_execution_receipt_types.mli
@@ -118,7 +118,7 @@ type t = {
   network_mode : Keeper_types_profile_sandbox.network_mode;
   approval_profile : string option;
   approval_profile_derived : bool;
-  cascade_name : string;
+  runtime_name : string;
   cascade_selected_model : string option;
   cascade_attempt_count : int;
   cascade_fallback_applied : bool;

--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -52,7 +52,7 @@ let runtime_pressure_class_of_label label =
   | _ -> None
 ;;
 
-let provider_runtime_pressure_class ~code ~detail ~http_status ~cascade_name =
+let provider_runtime_pressure_class ~code ~detail ~http_status ~runtime_name =
   let contains needle =
     String_util.contains_substring_ci code needle
     || String_util.contains_substring_ci detail needle
@@ -70,7 +70,7 @@ let provider_runtime_pressure_class ~code ~detail ~http_status ~cascade_name =
   else if
     contains "admission_capacity"
     || contains "inflight_capacity_full"
-    || Option.is_some cascade_name
+    || Option.is_some runtime_name
     || contains "admission="
   then Cascade_admission_full
   else if
@@ -103,8 +103,8 @@ let provider_runtime_pressure_class ~code ~detail ~http_status ~cascade_name =
 
 let runtime_pressure_class_of_failure_reason = function
   | Some (Keeper_registry.Provider_timeout_loop _) -> Some Provider_timeout
-  | Some (Keeper_registry.Provider_runtime_error { code; detail; http_status; cascade_name }) ->
-    Some (provider_runtime_pressure_class ~code ~detail ~http_status ~cascade_name)
+  | Some (Keeper_registry.Provider_runtime_error { code; detail; http_status; runtime_name }) ->
+    Some (provider_runtime_pressure_class ~code ~detail ~http_status ~runtime_name)
   | Some (Keeper_registry.Stale_turn_timeout _) -> Some Turn_stale_timeout
   | Some
       ( Keeper_registry.Heartbeat_consecutive_failures _
@@ -157,21 +157,21 @@ let record_item_result ~keeper_name ~item_id ~success =
   set_item_health ~keeper_name ~item_id status
 ;;
 
-let set_cascade_status ~cascade_name status =
+let set_cascade_status ~runtime_name status =
   Eio.Mutex.use_rw ~protect:true health_cache_mu (fun () ->
-    Hashtbl.replace health_cache (cascade_name, "") (status, Time_compat.now ()))
+    Hashtbl.replace health_cache (runtime_name, "") (status, Time_compat.now ()))
 ;;
 
-(** [get_cascade_status ~cascade_name] reads the cascade-level entry
+(** [get_cascade_status ~runtime_name] reads the cascade-level entry
     written by [run_once].  Three-valued:
       - [Healthy]    : last probe saw the cascade at < threshold ratio.
       - [Unhealthy r]: last probe saw the cascade at >= threshold ratio.
       - [Unknown]    : probe never wrote this cascade (e.g. boot before
                        first sweep, or no running keepers in the cascade
                        at the time of the last scan). *)
-let get_cascade_status ~cascade_name =
+let get_cascade_status ~runtime_name =
   Eio.Mutex.use_ro health_cache_mu (fun () ->
-    match Hashtbl.find_opt health_cache (cascade_name, "") with
+    match Hashtbl.find_opt health_cache (runtime_name, "") with
     | Some (status, _) -> status
     | None -> Unknown)
 ;;
@@ -259,7 +259,7 @@ let scan_cascade_health ~base_path =
   let by_cascade = Hashtbl.create 8 in
   List.iter
     (fun (entry : Keeper_registry.registry_entry) ->
-       let cascade = Keeper_meta_contract.cascade_name_of_meta entry.meta in
+       let cascade = Keeper_meta_contract.runtime_name_of_meta entry.meta in
        let acc =
          match Hashtbl.find_opt by_cascade cascade with
          | Some acc -> acc
@@ -289,7 +289,7 @@ let scan_cascade_health ~base_path =
 ;;
 
 (** Compute health per cascade from registry entries.
-    Returns (cascade_name, is_healthy).
+    Returns (runtime_name, is_healthy).
 
     A keeper is counted as "failed" only when its phase is a terminal
     unhealthy state (Dead, Zombie, or Crashed).  Past restarts
@@ -316,7 +316,7 @@ let run_once ~base_path =
        let status =
          if healthy then Healthy else Unhealthy (cascade_failure_reason acc)
        in
-       set_cascade_status ~cascade_name:cascade status)
+       set_cascade_status ~runtime_name:cascade status)
     results
 ;;
 

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -73,7 +73,7 @@ val max_failed_allowed_for_cascade : total:int -> int
 
 (** [check_cascade_health ~base_path] scans the registry and computes
     the health status of each active cascade.  Returns a list of
-    (cascade_name, is_healthy) pairs.  A keeper is counted as failed
+    (runtime_name, is_healthy) pairs.  A keeper is counted as failed
     only when its phase is Dead, Zombie, or Crashed — not based on
     restart_count, which is monotonic and would cause permanent
     cascade pollution.  Healthy iff
@@ -82,7 +82,7 @@ val max_failed_allowed_for_cascade : total:int -> int
     supervisor sweep. *)
 val check_cascade_health : base_path:string -> (string * bool) list
 
-(** [get_cascade_status ~cascade_name] returns the cached cascade-level
+(** [get_cascade_status ~runtime_name] returns the cached cascade-level
     [health_status] written by [run_once].  This preserves the [Unknown]
     case so the supervisor's auto-resume guard can distinguish
     "no probe data yet" from
@@ -93,7 +93,7 @@ val check_cascade_health : base_path:string -> (string * bool) list
     Phase 3.5 guard collapsed [Unknown] and [Unhealthy] to the same
     boolean result — turning the boot-time cold-cache window into a
     permanent auto-resume lockout for every cascade. *)
-val get_cascade_status : cascade_name:string -> health_status
+val get_cascade_status : runtime_name:string -> health_status
 
 (** [run_once ~base_path] runs [check_cascade_health] and writes the
     results into the cascade cache.  Idempotent and bounded (registry

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -74,7 +74,7 @@ let heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake
 type cascade_backpressure_decision = Observations.cascade_backpressure_decision =
   | Cascade_admitted
   | Cascade_backpressured of {
-      cascade_name : string;
+      runtime_name : string;
       reason : string;
     }
 
@@ -233,7 +233,7 @@ let run_keepalive_unified_turn
              ~base_path:ctx.config.base_path
              meta_after_triage.name
              ~reasons:admission_reason_strs
-         | Cascade_backpressured { cascade_name; reason } ->
+         | Cascade_backpressured { runtime_name; reason } ->
            record_cascade_backpressure_observation
              ~base_path:ctx.config.base_path
              ~keeper_name:meta_after_triage.name
@@ -241,7 +241,7 @@ let run_keepalive_unified_turn
            Log.Keeper.info
              "keepalive turn backpressured for %s: cascade=%s reason=%s requested=[%s]"
              meta_after_triage.name
-             cascade_name
+             runtime_name
              reason
              (String.concat "," verdict_strs));
         let paused_info =
@@ -387,7 +387,7 @@ let run_keepalive_unified_turn
           ();
         match
           Keeper_turn_slot.with_keeper_turn_slot_control
-            ~cascade_profile:(cascade_name_of_meta meta_after_triage)
+            ~cascade_profile:(runtime_name_of_meta meta_after_triage)
             ~keeper_name:meta_after_triage.name
             ~channel:turn_decision.channel
             (fun ~semaphore_wait_ms ~slot_control ->

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -74,7 +74,7 @@ val record_semaphore_wait_observation :
 type cascade_backpressure_decision =
   | Cascade_admitted
   | Cascade_backpressured of {
-      cascade_name : string;
+      runtime_name : string;
       reason : string;
     }
 
@@ -102,7 +102,7 @@ type keepalive_scheduling_decision = {
 val decide_keepalive_scheduling :
   ?cascade_resilience_of_name:(string -> Keeper_cascade_resilience.cascade_resilience) ->
   ?cascade_status_of_name:
-    (cascade_name:string -> Keeper_health_probe.health_status) ->
+    (runtime_name:string -> Keeper_health_probe.health_status) ->
   stop:bool Atomic.t ->
   meta:keeper_meta ->
   Keeper_world_observation.world_observation ->
@@ -111,7 +111,7 @@ val decide_keepalive_scheduling :
 val cascade_backpressure_decision :
   cascade_resilience:Keeper_cascade_resilience.cascade_resilience option ->
   should_run_turn:bool ->
-  cascade_name:string ->
+  runtime_name:string ->
   cascade_status:Keeper_health_probe.health_status ->
   cascade_backpressure_decision
 
@@ -124,7 +124,7 @@ val semaphore_wait_timeout_blocker_class :
   Keeper_turn_slot.semaphore_wait_timeout -> blocker_class
 
 val semaphore_wait_timeout_diagnostics :
-  cascade_name:string -> Keeper_turn_slot.semaphore_wait_timeout -> string * string
+  runtime_name:string -> Keeper_turn_slot.semaphore_wait_timeout -> string * string
 
 val provider_timeout_observation_reasons : string list
 

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -69,7 +69,7 @@ let record_semaphore_wait_observation
 type cascade_backpressure_decision =
   | Cascade_admitted
   | Cascade_backpressured of {
-      cascade_name : string;
+      runtime_name : string;
       reason : string;
     }
 
@@ -123,7 +123,7 @@ let cascade_resilience_backpressure_reason
 let cascade_backpressure_decision
       ~cascade_resilience
       ~should_run_turn
-      ~cascade_name
+      ~runtime_name
       ~cascade_status
   =
   let resilience_reason =
@@ -133,8 +133,8 @@ let cascade_backpressure_decision
   in
   match should_run_turn, cascade_status, resilience_reason with
   | true, Keeper_health_probe.Unhealthy reason, _ ->
-    Cascade_backpressured { cascade_name; reason }
-  | true, _, Some reason -> Cascade_backpressured { cascade_name; reason }
+    Cascade_backpressured { runtime_name; reason }
+  | true, _, Some reason -> Cascade_backpressured { runtime_name; reason }
   | false, _, _
   | true, Keeper_health_probe.Unknown, None
   | true, Keeper_health_probe.Healthy, None -> Cascade_admitted

--- a/lib/keeper/keeper_heartbeat_loop_observations.mli
+++ b/lib/keeper/keeper_heartbeat_loop_observations.mli
@@ -23,7 +23,7 @@ val record_semaphore_wait_observation
 type cascade_backpressure_decision =
   | Cascade_admitted
   | Cascade_backpressured of {
-      cascade_name : string;
+      runtime_name : string;
       reason : string;
     }
 
@@ -32,7 +32,7 @@ val cascade_backpressure_observation_reasons : reason:string -> string list
 val cascade_backpressure_decision
   :  cascade_resilience:Keeper_cascade_resilience.cascade_resilience option
   -> should_run_turn:bool
-  -> cascade_name:string
+  -> runtime_name:string
   -> cascade_status:Keeper_health_probe.health_status
   -> cascade_backpressure_decision
 

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -13,7 +13,7 @@ module Observations = Keeper_heartbeat_loop_observations
 type cascade_backpressure_decision = Observations.cascade_backpressure_decision =
   | Cascade_admitted
   | Cascade_backpressured of {
-      cascade_name : string;
+      runtime_name : string;
       reason : string;
     }
 
@@ -37,7 +37,7 @@ let decide_keepalive_scheduling
       ?(cascade_resilience_of_name =
         Keeper_cascade_resilience.cascade_resilience_of_name)
       ?(cascade_status_of_name =
-        fun ~cascade_name -> Keeper_health_probe.get_cascade_status ~cascade_name)
+        fun ~runtime_name -> Keeper_health_probe.get_cascade_status ~runtime_name)
       ~stop
       ~meta
       obs
@@ -46,14 +46,14 @@ let decide_keepalive_scheduling
   let requested_should_run_turn =
     (not (Atomic.get stop)) && turn_decision.should_run
   in
-  let cascade_name = cascade_name_of_meta meta in
-  let cascade_resilience = cascade_resilience_of_name cascade_name in
+  let runtime_name = runtime_name_of_meta meta in
+  let cascade_resilience = cascade_resilience_of_name runtime_name in
   let cascade_backpressure =
     cascade_backpressure_decision
       ~cascade_resilience:(Some cascade_resilience)
       ~should_run_turn:requested_should_run_turn
-      ~cascade_name
-      ~cascade_status:(cascade_status_of_name ~cascade_name)
+      ~runtime_name
+      ~cascade_status:(cascade_status_of_name ~runtime_name)
   in
   let should_run_turn =
     match cascade_backpressure with

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.mli
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.mli
@@ -4,7 +4,7 @@ type cascade_backpressure_decision =
   Keeper_heartbeat_loop_observations.cascade_backpressure_decision =
   | Cascade_admitted
   | Cascade_backpressured of {
-      cascade_name : string;
+      runtime_name : string;
       reason : string;
     }
 
@@ -21,7 +21,7 @@ type keepalive_scheduling_decision = {
 val decide_keepalive_scheduling :
   ?cascade_resilience_of_name:(string -> Keeper_cascade_resilience.cascade_resilience) ->
   ?cascade_status_of_name:
-    (cascade_name:string -> Keeper_health_probe.health_status) ->
+    (runtime_name:string -> Keeper_health_probe.health_status) ->
   stop:bool Atomic.t ->
   meta:Keeper_meta_contract.keeper_meta ->
   Keeper_world_observation.world_observation ->

--- a/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.ml
+++ b/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.ml
@@ -27,7 +27,7 @@ let semaphore_wait_timeout_blocker_class
 ;;
 
 let semaphore_wait_timeout_diagnostics
-      ~cascade_name
+      ~runtime_name
       (timeout : Keeper_turn_slot.semaphore_wait_timeout)
   =
   let phase_label =
@@ -48,7 +48,7 @@ let semaphore_wait_timeout_diagnostics
        autonomous_available=%d reactive_available=%d turn_available=%d)"
       timeout.timeout_wait_sec
       phase_label
-      cascade_name
+      runtime_name
       queue_ahead_text
       timeout.timeout_queue_depth
       timeout.timeout_autonomous_available
@@ -103,7 +103,7 @@ let handle_semaphore_wait_timeout
     ();
   let persisted_blocker, log_diagnostic =
     semaphore_wait_timeout_diagnostics
-      ~cascade_name:(cascade_name_of_meta meta_after_triage)
+      ~runtime_name:(runtime_name_of_meta meta_after_triage)
       timeout
   in
   let blocker_class = semaphore_wait_timeout_blocker_class timeout in

--- a/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.mli
+++ b/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.mli
@@ -19,7 +19,7 @@ val semaphore_wait_timeout_blocker_class
   -> Keeper_meta_contract.blocker_class
 
 val semaphore_wait_timeout_diagnostics
-  :  cascade_name:string
+  :  runtime_name:string
   -> Keeper_turn_slot.semaphore_wait_timeout
   -> string * string
 

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -82,7 +82,7 @@ let write_heartbeat_snapshot
   in
   let cascade_models =
     Provider_runtime_projection.default_execution_model_strings
-      ((Keeper_meta_contract.cascade_name_of_meta meta_current))
+      ((Keeper_meta_contract.runtime_name_of_meta meta_current))
   in
   let max_cascade_context =
     let resolution =

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -130,7 +130,7 @@ let with_timeout ?clock ~timeout_sec f =
       with Eio.Time.Timeout -> None
 
 let record_summary_outcome
-    ~(cascade_name : string)
+    ~(runtime_name : string)
     ~(provider_cfg : Llm_provider.Provider_config.t)
     ~(outcome : Keeper_memory_llm_summary_outcome.t) =
   Prometheus.inc_counter
@@ -138,7 +138,7 @@ let record_summary_outcome
     ~labels:
       [ ("outcome", Keeper_memory_llm_summary_outcome.to_label outcome)
       ; ("provider", provider_cfg.Llm_provider.Provider_config.model_id)
-      ; ("cascade", cascade_name)
+      ; ("cascade", runtime_name)
       ]
     ()
 
@@ -146,7 +146,7 @@ let summarize_with_provider
     ?(complete : complete_fn = default_complete)
     ?clock
     ?(timeout_sec = Env_config_governance.Inference.timeout_seconds)
-    ?(cascade_name = "")
+    ?(runtime_name = "")
     ~sw
     ~net
     ~(provider_cfg : Llm_provider.Provider_config.t)
@@ -180,14 +180,14 @@ let summarize_with_provider
           trace_id provider_cfg.model_id (http_error_message err);
         None, Keeper_memory_llm_summary_outcome.Http_error
   in
-  record_summary_outcome ~cascade_name ~provider_cfg ~outcome;
+  record_summary_outcome ~runtime_name ~provider_cfg ~outcome;
   result
 
 let summarize_with_providers
     ?complete
     ?clock
     ?timeout_sec
-    ?(cascade_name = "")
+    ?(runtime_name = "")
     ~sw
     ~net
     ~providers
@@ -198,7 +198,7 @@ let summarize_with_providers
     | [] -> None
     | provider_cfg :: rest -> (
         match
-          summarize_with_provider ?complete ?clock ?timeout_sec ~cascade_name
+          summarize_with_provider ?complete ?clock ?timeout_sec ~runtime_name
             ~sw ~net ~provider_cfg ~trace_id ~texts ()
         with
         | Some summary -> Some summary
@@ -209,13 +209,13 @@ let summarize_with_providers
   | None ->
       Prometheus.inc_counter
         Keeper_metrics.(to_string MemoryLlmSummaryChainExhausted)
-        ~labels:[("cascade", cascade_name)]
+        ~labels:[("cascade", runtime_name)]
         ();
       Log.Keeper.warn
         "memory LLM summary chain exhausted trace_id=%s cascade=%s \
          providers_attempted=%d — consolidation skipped LLM summary"
         trace_id
-        cascade_name
+        runtime_name
         (List.length providers);
       None
 
@@ -223,7 +223,7 @@ let make
     ?complete
     ?provider_filter
     ?timeout_sec
-    ~(cascade_name : string)
+    ~(runtime_name : string)
     ~(keeper_name : string)
     () : Keeper_memory_bank.memory_consolidation_summarizer option =
   if not (Keeper_memory_bank.memory_llm_summary_enabled ()) then None
@@ -233,12 +233,12 @@ let make
         let clock = Eio_context.get_clock_opt () in
         (match
            Cascade_catalog_runtime.resolve_named_providers_strict
-             ~sw ~net ?clock ?provider_filter ~cascade_name ()
+             ~sw ~net ?clock ?provider_filter ~runtime_name ()
          with
          | Error err ->
              Log.Keeper.warn
                "keeper:%s memory LLM summary provider resolution failed cascade=%s: %s"
-               keeper_name cascade_name err;
+               keeper_name runtime_name err;
              None
          | Ok providers ->
              let providers =
@@ -247,15 +247,15 @@ let make
              if providers = [] then begin
                Log.Keeper.warn
                  "keeper:%s memory LLM summary has no direct completion providers cascade=%s"
-                 keeper_name cascade_name;
+                 keeper_name runtime_name;
                None
              end else
                Some
                  (fun ~trace_id ~texts ->
                    summarize_with_providers ?complete ?clock ?timeout_sec
-                     ~cascade_name ~sw ~net ~providers ~trace_id ~texts ()))
+                     ~runtime_name ~sw ~net ~providers ~trace_id ~texts ()))
     | _ ->
         Log.Keeper.warn
           "keeper:%s memory LLM summary skipped: Eio context unavailable cascade=%s"
-          keeper_name cascade_name;
+          keeper_name runtime_name;
         None

--- a/lib/keeper/keeper_memory_llm_summary.mli
+++ b/lib/keeper/keeper_memory_llm_summary.mli
@@ -24,7 +24,7 @@ val make :
   ?complete:complete_fn ->
   ?provider_filter:string list ->
   ?timeout_sec:float ->
-  cascade_name:string ->
+  runtime_name:string ->
   keeper_name:string ->
   unit ->
   Keeper_memory_bank.memory_consolidation_summarizer option

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -609,7 +609,7 @@ type keeper_meta =
   ; meta_version : int
   }
 
-let cascade_name_of_meta (_m : keeper_meta) : string =
+let runtime_name_of_meta (_m : keeper_meta) : string =
   Runtime.get_default_runtime_id ()
 ;;
 
@@ -731,7 +731,7 @@ let reject_legacy_model_args ~tool_name (args : Yojson.Safe.t) =
   | fields ->
     Error
       (Printf.sprintf
-         "legacy keeper model args removed for %s: %s. Use cascade_name; concrete \
+         "legacy keeper model args removed for %s: %s. Use runtime_name; concrete \
           provider/model identity is OAS-owned."
          tool_name
          (String.concat ", " fields))

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -378,8 +378,8 @@ type keeper_meta = {
 
 (** {1 Cascade name derivation} *)
 
-val cascade_name_of_meta : keeper_meta -> string
-(** [cascade_name_of_meta m] returns the default runtime id.
+val runtime_name_of_meta : keeper_meta -> string
+(** [runtime_name_of_meta m] returns the default runtime id.
     Ignores [m] — kept for signature compatibility. *)
 
 (** {1 Outcome <-> string} *)
@@ -444,7 +444,7 @@ val map_proactive_rt :
 
 val keeper_legacy_model_arg_names : string list
 (** Names of legacy keeper-creation tool arguments that have
-    been retired in favour of the [cascade_name] field
+    been retired in favour of the [runtime_name] field
     (["models"], ["allowed_models"], ["active_model"]).
     Consumed by {!reject_legacy_model_args} which
     surfaces operator-readable rejection messages instead of
@@ -455,5 +455,5 @@ val keeper_legacy_model_arg_names : string list
 val reject_legacy_model_args :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 (** Reject retired keeper model-selection input fields at tool/API boundaries.
-    Model and provider identity is resolved from [cascade_name] and the cascade
+    Model and provider identity is resolved from [runtime_name] and the cascade
     catalog, not per-call keeper arguments. *)

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -119,10 +119,10 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
     let pk_desires = personality.desires in
     let pk_instructions = personality.instructions in
     let pk_cascade_name =
-      (* Preserve the raw cascade_name as persisted in runtime JSON so the
+      (* Preserve the raw runtime_name as persisted in runtime JSON so the
        dashboard can distinguish "declared in TOML" from "canonicalized
        fallback".  Downstream code canonicalizes at point-of-use. *)
-      Safe_ops.json_string ~default:(Keeper_config.default_cascade_name ()) "cascade_name" json
+      Safe_ops.json_string ~default:(Keeper_config.default_runtime_name ()) "runtime_name" json
     in
     Ok
       { pk_name

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -14,7 +14,7 @@
    Keeper_meta_json -> Keeper_meta_json_scrub -> Keeper_meta_json. *)
 let config_field_names =
   [ "goal"; "short_goal"; "mid_goal"; "long_goal"
-  ; "social_model"; "cascade_name"
+  ; "social_model"; "runtime_name"
   ; "will"; "needs"; "desires"; "instructions"
   ; "sandbox_profile"; "sandbox_image"; "network_mode"; "allowed_paths"
   ; "tool_access"; "tool_denylist"

--- a/lib/keeper/keeper_model_labels.ml
+++ b/lib/keeper/keeper_model_labels.ml
@@ -7,4 +7,4 @@ let configured_model_labels_of_meta (m : keeper_meta) : string list =
      [meta.models] and benchmark-canary labels are legacy hints and can carry
      stale provider strings across reconfiguration. *)
   Provider_runtime_projection.default_execution_model_strings
-    ((cascade_name_of_meta m))
+    ((runtime_name_of_meta m))

--- a/lib/keeper/keeper_observation.ml
+++ b/lib/keeper/keeper_observation.ml
@@ -12,7 +12,7 @@
 (* ================================================================ *)
 
 type cascade_observation = {
-  cascade_name : string;
+  runtime_name : string;
   strategy : string option;
   configured_labels : string list;
   candidate_models : string list;
@@ -150,7 +150,7 @@ let strip_latest_suffix s =
 (* Observation building                                              *)
 (* ================================================================ *)
 
-let cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
+let cascade_observation_of_candidates ~runtime_name ?strategy ~configured_labels
     ~(candidate_count : int)
     ~(selected_model_raw : string option)
     ?(attempts = [])
@@ -181,7 +181,7 @@ let cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
     | None -> false
   in
   {
-    cascade_name;
+    runtime_name;
     strategy;
     configured_labels = [];
     candidate_models;
@@ -401,12 +401,12 @@ let cascade_metrics_for_candidates ~candidate_count:(_ : int) () =
   in
   (capture, metrics)
 
-let cascade_observation_with_metrics ~cascade_name ?strategy ~configured_labels
+let cascade_observation_with_metrics ~runtime_name ?strategy ~configured_labels
     ~(candidate_count : int)
     ~(selected_model_raw : string option) ~(capture : cascade_metrics_capture)
     ?(oas_internal_cascade_allowed = false)
     () =
-  cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
+  cascade_observation_of_candidates ~runtime_name ?strategy ~configured_labels
     ~candidate_count ~selected_model_raw
     ~attempts:(List.rev capture.attempts_rev)
     ~fallback_events:(List.rev capture.fallback_events_rev)
@@ -420,12 +420,12 @@ let cascade_observation_with_metrics ~cascade_name ?strategy ~configured_labels
 (* ================================================================ *)
 
 let cascade_observation_to_json (obs : cascade_observation) : Yojson.Safe.t =
-  let cascade_name =
-    obs.cascade_name
+  let runtime_name =
+    obs.runtime_name
   in
   `Assoc
     [
-      ("cascade_name", `String cascade_name);
+      ("runtime_name", `String runtime_name);
       ("strategy", Json_util.string_opt_to_json obs.strategy);
       ( "configured_labels",
         `List (List.map (fun label -> `String label) obs.configured_labels) );
@@ -492,15 +492,15 @@ let keeper_name_to_json keeper_name =
   | Some name when String.trim name <> "" -> `String name
   | _ -> `Null
 
-let cascade_audit_json ~now ~keeper_name ~cascade_name ~observation ~outcome =
-  let cascade_name =
-    cascade_name
+let cascade_audit_json ~now ~keeper_name ~runtime_name ~observation ~outcome =
+  let runtime_name =
+    runtime_name
   in
   `Assoc
     [
       ("ts", `Float now);
       ("keeper_name", keeper_name_to_json keeper_name);
-      ("cascade_name", `String cascade_name);
+      ("runtime_name", `String runtime_name);
       ("outcome", `String (cascade_outcome_to_string outcome));
       ("top_level_reason", top_level_reason_of_observation observation);
       ( "observation",
@@ -509,17 +509,17 @@ let cascade_audit_json ~now ~keeper_name ~cascade_name ~observation ~outcome =
         | None -> `Null );
     ]
 
-let record_cascade_audit store_opt ~now ~keeper_name ~cascade_name ~observation
+let record_cascade_audit store_opt ~now ~keeper_name ~runtime_name ~observation
     ~outcome =
   let cascade_name_string =
-    cascade_name
+    runtime_name
   in
   match store_opt with
   | None -> ()
   | Some store ->
       (try
          Dated_jsonl.append store
-           (cascade_audit_json ~now ~keeper_name ~cascade_name ~observation
+           (cascade_audit_json ~now ~keeper_name ~runtime_name ~observation
               ~outcome)
        with
       | Eio.Cancel.Cancelled _ as e -> raise e
@@ -562,7 +562,7 @@ let attempt_model_display (attempt : cascade_attempt) =
 type msg =
   | Record_cascade of {
       keeper_name : string option;
-      cascade_name : string;
+      runtime_name : string;
       observation : cascade_observation option;
       outcome : [ `Success | `Failure | `Rejected ];
       now : float;
@@ -577,9 +577,9 @@ type state = {
 
 let stream = Eio.Stream.create 1024
 
-let handle_record state ~now ~keeper_name ~cascade_name ~observation ~outcome =
+let handle_record state ~now ~keeper_name ~runtime_name ~observation ~outcome =
   let cascade_name_string =
-    cascade_name
+    runtime_name
   in
   let counters = state.counters in
   let counter, counters, evicted =
@@ -646,7 +646,7 @@ let handle_record state ~now ~keeper_name ~cascade_name ~observation ~outcome =
         cascade_max_keys)
     evicted;
   let audit_store_next = get_cascade_audit_store state.audit_store in
-  record_cascade_audit audit_store_next ~now ~keeper_name ~cascade_name
+  record_cascade_audit audit_store_next ~now ~keeper_name ~runtime_name
     ~observation ~outcome;
   {
     counters = StringMap.add cascade_name_string counter counters;
@@ -666,7 +666,7 @@ let handle_get_metrics state p =
         in
         `Assoc
           [
-            ("cascade_name", `String name);
+            ("runtime_name", `String name);
             ("calls", `Int c.calls);
             ("successes", `Int c.successes);
             ("failures", `Int c.failures);
@@ -706,9 +706,9 @@ let handle_get_metrics state p =
 let run_actor () =
   let rec loop state =
     match Eio.Stream.take stream with
-    | Record_cascade { keeper_name; cascade_name; observation; outcome; now } ->
+    | Record_cascade { keeper_name; runtime_name; observation; outcome; now } ->
         loop
-          (handle_record state ~now ~keeper_name ~cascade_name ~observation
+          (handle_record state ~now ~keeper_name ~runtime_name ~observation
              ~outcome)
     | Get_metrics_json p ->
         handle_get_metrics state p;
@@ -721,10 +721,10 @@ let run_actor () =
 let start_actor_if_needed ~sw =
   Eio.Fiber.fork_daemon ~sw run_actor
 
-let record_cascade ?keeper_name ~observation ~cascade_name ~outcome () =
+let record_cascade ?keeper_name ~observation ~runtime_name ~outcome () =
   let now = Time_compat.now () in
   Eio.Stream.add stream
-    (Record_cascade { keeper_name; cascade_name; observation; outcome; now })
+    (Record_cascade { keeper_name; runtime_name; observation; outcome; now })
 
 let cascade_metrics_json () =
   let p, u = Eio.Promise.create () in

--- a/lib/keeper/keeper_observation.mli
+++ b/lib/keeper/keeper_observation.mli
@@ -59,7 +59,7 @@ type cascade_fallback_event = {
 }
 
 type cascade_observation = {
-  cascade_name : string;
+  runtime_name : string;
   strategy : string option;
   configured_labels : string list;
   candidate_models : string list;
@@ -155,7 +155,7 @@ val cascade_metrics_for_candidates :
     global [Llm_metric_bridge] when both are wired). *)
 
 val cascade_observation_with_metrics :
-  cascade_name:string ->
+  runtime_name:string ->
   ?strategy:string ->
   configured_labels:string list ->
   candidate_count:int ->
@@ -194,7 +194,7 @@ val start_actor_if_needed : sw:Eio.Switch.t -> unit
 val record_cascade :
   ?keeper_name:string ->
   observation:cascade_observation option ->
-  cascade_name:string ->
+  runtime_name:string ->
   outcome:[ `Success | `Failure | `Rejected ] ->
   unit ->
   unit

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -227,7 +227,7 @@ let field_catalog_entries =
         ~field_effect:"Optional social-model runtime for speech or ledger behavior."
         ()
     ; field_catalog_entry
-        ~path:"keeper.cascade_name"
+        ~path:"keeper.runtime_name"
         ~typ:"string"
         ~field_effect:
           "Optional named cascade override. Must resolve to a known cascade at runtime."
@@ -374,7 +374,7 @@ let normalize_cascade_name raw =
     | _ -> []
   in
   let known =
-    [ Keeper_config.default_cascade_name () ]
+    [ Keeper_config.default_runtime_name () ]
     @ catalog
   in
   if List.mem (String.lowercase_ascii normalized) known
@@ -382,7 +382,7 @@ let normalize_cascade_name raw =
   else
     Error
       (Printf.sprintf
-         "invalid keeper.cascade_name '%s' (known: %s)"
+         "invalid keeper.runtime_name '%s' (known: %s)"
          raw
          (String.concat ", " known))
 ;;
@@ -443,13 +443,13 @@ let normalize_keeper_json ~handle keeper_json =
           in
           Result.bind social_model_result (fun social_model ->
             let cascade_name_result =
-              match json_trimmed_string_opt "cascade_name" keeper_json with
+              match json_trimmed_string_opt "runtime_name" keeper_json with
               | None -> Ok None
               | Some raw ->
                 Result.map (fun value -> Some value) (normalize_cascade_name raw)
             in
             Result.map
-              (fun cascade_name ->
+              (fun runtime_name ->
                  let mention_targets =
                    match json_string_list_normalized "mention_targets" keeper_json with
                    | [] -> [ handle ]
@@ -513,9 +513,9 @@ let normalize_keeper_json ~handle keeper_json =
                    | None -> assoc_without "social_model" fields
                  in
                  let fields =
-                   match cascade_name with
-                   | Some value -> assoc_set "cascade_name" (`String value) fields
-                   | None -> assoc_without "cascade_name" fields
+                   match runtime_name with
+                   | Some value -> assoc_set "runtime_name" (`String value) fields
+                   | None -> assoc_without "runtime_name" fields
                  in
                  `Assoc (List.rev fields))
               cascade_name_result)))
@@ -842,14 +842,14 @@ let handle_persona_generate ctx args =
       | Error msg ->
         Keeper_types_profile.tool_result_error (error_response_typed ~code:Validation_error msg)
       | Ok archetype_axes ->
-           let cascade_name =
-             get_string args "cascade_name" Archetypes.default_generation_cascade_name
+           let runtime_name =
+             get_string args "runtime_name" Archetypes.default_generation_cascade_name
              |> String.trim
            in
-           let cascade_name =
-             if cascade_name = ""
+           let runtime_name =
+             if runtime_name = ""
              then Archetypes.default_generation_cascade_name
-             else cascade_name
+             else runtime_name
            in
            let temperature =
              get_float_opt args "temperature"
@@ -881,7 +881,7 @@ let handle_persona_generate ctx args =
                ~caller:Env_config_oas_bridge.Keeper_persona_authoring
                (fun () ->
                  Keeper_turn_driver.run_named
-                   ~cascade_name
+                   ~runtime_name
                    ~goal:prompt
                    ~max_turns:1
                    ~temperature

--- a/lib/keeper/keeper_preflight_health_tracker.ml
+++ b/lib/keeper/keeper_preflight_health_tracker.ml
@@ -9,7 +9,7 @@ type reason =
   | Rate_limited_long_window
 
 type fingerprint = {
-  cascade_name : string;
+  runtime_name : string;
   provider : string;
   reason : reason;
 }
@@ -50,18 +50,18 @@ let metric_provider_re_enabled = "masc_cascade_provider_re_enabled_total"
 (* ── State ──────────────────────────────────────────────────────── *)
 
 (* [Hashtbl] keyed by an opaque triple to avoid string interpolation
-   collisions when cascade_name or provider contain separators. *)
+   collisions when runtime_name or provider contain separators. *)
 module Key = struct
   type t = fingerprint
 
   let equal (a : t) (b : t) =
-    String.equal a.cascade_name b.cascade_name
+    String.equal a.runtime_name b.runtime_name
     && String.equal a.provider b.provider
     && a.reason = b.reason
   ;;
 
   let hash (k : t) =
-    Hashtbl.hash (k.cascade_name, k.provider, reason_slug k.reason)
+    Hashtbl.hash (k.runtime_name, k.provider, reason_slug k.reason)
   ;;
 end
 
@@ -79,7 +79,7 @@ end)
 type t = {
   counts : int FpTbl.t;
   disabled : (float * string) StrTbl.t;
-      (** Maps provider → (disabled_at_timestamp, cascade_name).
+      (** Maps provider → (disabled_at_timestamp, runtime_name).
           The timestamp enables TTL-based auto-expiry so providers
           don't stay disabled forever (GitHub #18502). *)
   mu : Stdlib.Mutex.t;
@@ -107,14 +107,14 @@ let with_lock t f =
 
 (* ── Public API ─────────────────────────────────────────────────── *)
 
-let record ?(clock = Time_compat.now) t ~cascade_name ~provider ~reason : record_outcome =
-  let fp = { cascade_name; provider; reason } in
+let record ?(clock = Time_compat.now) t ~runtime_name ~provider ~reason : record_outcome =
+  let fp = { runtime_name; provider; reason } in
   with_lock t (fun () ->
     (* Always tick the per-call counter so dashboards see absolute
        skip volume (independent of disable transitions). *)
     Prometheus.inc_counter metric_preflight_unhealthy_skip
       ~labels:
-        [ ("cascade", cascade_name)
+        [ ("cascade", runtime_name)
         ; ("provider", provider)
         ; ("reason", reason_slug reason)
         ]
@@ -129,10 +129,10 @@ let record ?(clock = Time_compat.now) t ~cascade_name ~provider ~reason : record
       then `First
       else if next >= t.threshold
       then (
-        StrTbl.replace t.disabled provider (clock (), cascade_name);
+        StrTbl.replace t.disabled provider (clock (), runtime_name);
         Prometheus.inc_counter metric_provider_disabled
           ~labels:
-            [ ("cascade", cascade_name)
+            [ ("cascade", runtime_name)
             ; ("provider", provider)
             ; ("reason", reason_slug reason)
             ]

--- a/lib/keeper/keeper_preflight_health_tracker.mli
+++ b/lib/keeper/keeper_preflight_health_tracker.mli
@@ -1,7 +1,7 @@
 (** Cascade preflight unhealthy-skip escalation state.
 
     Tracks repeated [preflight skipped N unhealthy ...] events per
-    (cascade_name, provider, reason) fingerprint. After [threshold_disable]
+    (runtime_name, provider, reason) fingerprint. After [threshold_disable]
     consecutive skips of the same fingerprint, the provider is registered
     in an in-memory disabled list and a single ERROR-class escalation is
     emitted (instead of a WARN per skip).
@@ -46,7 +46,7 @@ type reason =
 
 (** Fingerprint of a single skip event. *)
 type fingerprint = {
-  cascade_name : string;  (** Cascade name (e.g. ["strict_tool_candidates"]). *)
+  runtime_name : string;  (** Cascade name (e.g. ["strict_tool_candidates"]). *)
   provider : string;  (** Provider key or endpoint URL. *)
   reason : reason;
 }
@@ -95,7 +95,7 @@ val global : t
     transition). *)
 val record :
   ?clock:(unit -> float) ->
-  t -> cascade_name:string -> provider:string -> reason:reason -> record_outcome
+  t -> runtime_name:string -> provider:string -> reason:reason -> record_outcome
 
 (** True iff the provider is currently in the disabled list (i.e. some
     fingerprint crossed threshold and recovery has not happened yet).

--- a/lib/keeper/keeper_reconcile_state.ml
+++ b/lib/keeper/keeper_reconcile_state.ml
@@ -31,7 +31,7 @@ let with_lock f =
 
 (* Compress an error string into a stable, low-cardinality digest. The
    reconcile error from [ensure_keeper_meta] is human prose plus the
-   offending [cascade_name] / field — using a hash would lose the
+   offending [runtime_name] / field — using a hash would lose the
    prefix, but a verbatim 200-byte snapshot also tracks irrelevant
    wording drift. Compromise: strip whitespace runs and clip to 96
    characters so two failures with the same root cause hash to the

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -98,7 +98,7 @@ type failure_reason =
       ; detail : string
       ; provider_id : string option
       ; http_status : int option
-      ; cascade_name : string option
+      ; runtime_name : string option
       }
       (** Latched from the keeper turn terminal reason when the provider,
           adapter, or cascade fails before useful keeper progress. A later

--- a/lib/keeper/keeper_registry_types_failure.ml
+++ b/lib/keeper/keeper_registry_types_failure.ml
@@ -85,7 +85,7 @@ type failure_reason =
       ; detail : string
       ; provider_id : string option
       ; http_status : int option
-      ; cascade_name : string option
+      ; runtime_name : string option
       }
   | Tool_required_unsatisfied of
       { code : string
@@ -120,7 +120,7 @@ let failure_reason_to_string = function
     Printf.sprintf "stale_fleet_batch(distinct_count=%d)" distinct_count
   | Provider_timeout_loop { count } ->
     Printf.sprintf "provider_timeout_loop(count=%d)" count
-  | Provider_runtime_error { code; detail; provider_id; http_status; cascade_name = _ } ->
+  | Provider_runtime_error { code; detail; provider_id; http_status; runtime_name = _ } ->
     let prov =
       Option.fold provider_id ~none:""
         ~some:(Printf.sprintf " provider=%s")

--- a/lib/keeper/keeper_registry_types_failure.mli
+++ b/lib/keeper/keeper_registry_types_failure.mli
@@ -35,7 +35,7 @@ type failure_reason =
   | Provider_timeout_loop of { count : int; }
   | Provider_runtime_error of { code : string; detail : string;
       provider_id : string option; http_status : int option;
-      cascade_name : string option;
+      runtime_name : string option;
     }
   | Tool_required_unsatisfied of { code : string; detail : string; }
   | Ambiguous_partial_commit of ambiguous_partial_commit

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -40,7 +40,7 @@ let prepare_run_context
       ~(meta : keeper_meta)
       ~(base_dir : string)
       ~(max_context : int)
-      ~(cascade_name : string)
+      ~(runtime_name : string)
       ?temperature
       ?max_tokens
       ?shared_context
@@ -56,18 +56,18 @@ let prepare_run_context
     | Some t -> t
     | None ->
       Cascade_inference.resolve_temperature
-        ~cascade_name ~fallback:(fun () -> 0.3)
+        ~runtime_name ~fallback:(fun () -> 0.3)
   in
   let max_tokens =
     match max_tokens with
     | Some t ->
       Cascade_inference.cap_max_tokens_to_cascade_ceiling
-        ~cascade_name
+        ~runtime_name
         ~source:"caller_override"
         t
     | None ->
       Cascade_inference.resolve_max_tokens
-        ~cascade_name
+        ~runtime_name
           (* 8192 allows complex multi-tool reasoning per turn.
            Cloudflare tunnel 100s is no longer a constraint with
            streaming responses. *)

--- a/lib/keeper/keeper_run_context.mli
+++ b/lib/keeper/keeper_run_context.mli
@@ -37,7 +37,7 @@ val prepare_run_context :
   -> meta:keeper_meta
   -> base_dir:string
   -> max_context:int
-  -> cascade_name:string
+  -> runtime_name:string
   -> ?temperature:float
   -> ?max_tokens:int
   -> ?shared_context:Agent_sdk.Context.t

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -124,7 +124,7 @@ val prepare_agent_setup
   -> start_turn_count:int
   -> generation:int
   -> max_turns:int
-  -> cascade_name:string
+  -> runtime_name:string
   -> is_retry:bool
   -> turn_affordances:string list
   -> required_tool_names:string list

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -25,7 +25,7 @@ let prepare_agent_setup
       ~(start_turn_count : int)
       ~(generation : int)
       ~(max_turns : int)
-      ~(cascade_name : string)
+      ~(runtime_name : string)
       ~(is_retry : bool)
       ~(turn_affordances : string list)
       ~(required_tool_names : string list)
@@ -43,7 +43,7 @@ let prepare_agent_setup
       ()
   : (Keeper_run_tools_hooks.agent_setup, Agent_sdk.Error.sdk_error) result
   =
-  let cascade_name_string = cascade_name in
+  let cascade_name_string = runtime_name in
   let manifest_keeper_turn_id =
     match runtime_manifest_context with
     | Some ctx -> ctx.Keeper_runtime_manifest.manifest_keeper_turn_id
@@ -605,7 +605,7 @@ let prepare_agent_setup
              Cascade_catalog_runtime.resolve_named_providers_strict
                ~sw
                ~net
-               ~cascade_name:rerank_cascade
+               ~runtime_name:rerank_cascade
                ()
            with
            | Error detail ->

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -130,9 +130,9 @@ let apply_default_opt opt current = match opt with Some _ -> opt | None -> curre
 
 
 let invalid_profile_defaults_error ~keeper_name detail =
-  if String_util.contains_substring detail "cascade_name" then
+  if String_util.contains_substring detail "runtime_name" then
     Printf.sprintf
-      "invalid profile.cascade_name for keeper %s: unknown cascade_name: %s"
+      "invalid profile.runtime_name for keeper %s: unknown runtime_name: %s"
       keeper_name detail
   else
     Printf.sprintf "invalid keeper profile for keeper %s: %s" keeper_name detail
@@ -140,14 +140,14 @@ let invalid_profile_defaults_error ~keeper_name detail =
 let effective_declarative_cascade_name
     (defaults : Keeper_types_profile.keeper_profile_defaults)
     (meta : keeper_meta) =
-  (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model. *)
+  (* WORKAROUND (#19327 follow-up): field renamed runtime_name→model. *)
   match defaults.model, defaults.manifest_path with
-  | Some cascade_name, _ ->
-      Keeper_cascade_profile.normalize_keeper_runtime_declared_name cascade_name
-  | None, Some _ -> (Keeper_config.default_cascade_name ())
+  | Some runtime_name, _ ->
+      Keeper_cascade_profile.normalize_keeper_runtime_declared_name runtime_name
+  | None, Some _ -> (Keeper_config.default_runtime_name ())
   | None, None ->
       Keeper_cascade_profile.normalize_keeper_runtime_declared_name
-        (cascade_name_of_meta meta)
+        (runtime_name_of_meta meta)
 
 let resynced_tool_access
     (defaults : Keeper_types_profile.keeper_profile_defaults)
@@ -204,19 +204,19 @@ let ensure_keeper_meta config name =
         ()
     with
     | Error detail ->
-        (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model.
+        (* WORKAROUND (#19327 follow-up): field renamed runtime_name→model.
            Field-label strings kept for backward-compat in error messages. *)
         let field =
           match defaults.model, defaults.manifest_path with
-          | Some _, _ -> "profile.cascade_name"
-          | None, Some _ -> "manifest.default_cascade_name"
-          | None, None -> "meta.cascade_name"
+          | Some _, _ -> "profile.runtime_name"
+          | None, Some _ -> "manifest.default_runtime_name"
+          | None, None -> "meta.runtime_name"
         in
         let raw_value =
           match defaults.model, defaults.manifest_path with
-          | Some cascade_name, _ -> cascade_name
-          | None, Some _ -> (Keeper_config.default_cascade_name ())
-          | None, None -> cascade_name_of_meta meta
+          | Some runtime_name, _ -> runtime_name
+          | None, Some _ -> (Keeper_config.default_runtime_name ())
+          | None, None -> runtime_name_of_meta meta
         in
         let msg =
           Printf.sprintf
@@ -327,12 +327,12 @@ let ensure_keeper_meta config name =
       meta.room_signal_prompt_enabled <> target_room_signal_prompt_enabled in
     let denylist_changed = meta.tool_denylist <> target_denylist in
     let social_model_changed = meta.social_model <> target_social_model in
-    (* [meta.cascade_name] may be a raw TOML/JSON value while
+    (* [meta.runtime_name] may be a raw TOML/JSON value while
        [resolved_target_cascade_name] is the validated runtime catalog
        name. Normalize the meta side only so alias cleanup does not
        register as a semantic change. *)
     let cascade_changed =
-      String.trim (cascade_name_of_meta meta)
+      String.trim (runtime_name_of_meta meta)
       <> resolved_target_cascade_name
     in
     (* #10061: persisted state vs TOML source can differ by a single
@@ -730,7 +730,7 @@ let start_supervisor_sweep ctx =
                     (match ensure_keeper_meta ctx.config entry.name with
                      | Ok updated_meta ->
                          (* Propagate the updated meta back into the registry so
-                            subsequent turns observe the new cascade_name (and
+                            subsequent turns observe the new runtime_name (and
                             any other reconciled fields) immediately.  Without
                             this the file is updated but the in-memory
                             [registry_entry.meta] stays stale until restart. *)

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -332,7 +332,7 @@ let tool_lineage ?searched_tool_names ?visible_tool_names
        ])
 
 let make ?(ts = Masc_domain.now_iso ()) ~keeper_name ?agent_name ~trace_id
-    ?generation ?keeper_turn_id ?oas_turn_count ?logical_seq ~event ?cascade_name
+    ?generation ?keeper_turn_id ?oas_turn_count ?logical_seq ~event ?runtime_name
     ?(status = "ok") ?(decision = `Assoc []) ?receipt_path ?checkpoint_path
     ?tool_call_log_path () =
   {
@@ -346,19 +346,19 @@ let make ?(ts = Masc_domain.now_iso ()) ~keeper_name ?agent_name ~trace_id
     oas_turn_count;
     logical_seq;
     event;
-    cascade_name;
+    runtime_name;
     status;
     decision;
     links = { receipt_path; checkpoint_path; tool_call_log_path };
   }
 
-let make_for_context ctx ~event ?oas_turn_count ?logical_seq ?cascade_name
+let make_for_context ctx ~event ?oas_turn_count ?logical_seq ?runtime_name
     ?status ?decision ?receipt_path ?checkpoint_path ?tool_call_log_path () =
   make ~keeper_name:ctx.manifest_keeper_name
     ?agent_name:ctx.manifest_agent_name ~trace_id:ctx.manifest_trace_id
     ?generation:ctx.manifest_generation
     ?keeper_turn_id:ctx.manifest_keeper_turn_id ?oas_turn_count ?logical_seq
-    ~event ?cascade_name ?status ?decision ?receipt_path ?checkpoint_path
+    ~event ?runtime_name ?status ?decision ?receipt_path ?checkpoint_path
     ?tool_call_log_path ()
 
 let json_of_string_opt = function
@@ -385,7 +385,7 @@ let manifest_top_level_allowlist =
   StringSet.of_list
     [ "schema_version"; "ts"; "keeper_name"; "agent_name"; "trace_id"
     ; "generation"; "keeper_turn_id"; "oas_turn_count"; "logical_seq"; "event"
-    ; "cascade_name"; "status"; "decision"; "links"
+    ; "runtime_name"; "status"; "decision"; "links"
     ]
 
 let decision_public_allowlist =
@@ -510,7 +510,7 @@ let to_json manifest =
       ("oas_turn_count", json_of_int_opt manifest.oas_turn_count);
       ("logical_seq", json_of_int_opt manifest.logical_seq);
       ("event", `String (event_kind_to_string manifest.event));
-      ("cascade_name", json_of_string_opt manifest.cascade_name);
+      ("runtime_name", json_of_string_opt manifest.runtime_name);
       ("status", `String manifest.status);
       ("decision", manifest.decision);
       ("links", links_to_json manifest.links);
@@ -529,7 +529,7 @@ let public_to_json manifest =
       ("oas_turn_count", json_of_int_opt manifest.oas_turn_count);
       ("logical_seq", json_of_int_opt manifest.logical_seq);
       ("event", `String (event_kind_to_string manifest.event));
-      ("cascade_name", json_of_string_opt manifest.cascade_name);
+      ("runtime_name", json_of_string_opt manifest.runtime_name);
       ("status", `String manifest.status);
       ("decision", public_projection_of_decision manifest.decision);
       ("links", links_to_json manifest.links);
@@ -619,7 +619,7 @@ let of_json = function
             | None -> Error (Printf.sprintf "unknown event: %S" event_string)
             | Some event -> Ok event)
             >>= fun event ->
-            optional_string "cascade_name" fields >>= fun cascade_name ->
+            optional_string "runtime_name" fields >>= fun runtime_name ->
             required_string "status" fields >>= fun status ->
             field "decision" fields >>= fun decision ->
             field "links" fields >>= fun links_json ->
@@ -636,7 +636,7 @@ let of_json = function
                 oas_turn_count;
                 logical_seq;
                 event;
-                cascade_name;
+                runtime_name;
                 status;
                 decision;
                 links;
@@ -835,7 +835,7 @@ let append_unfinished_provider_attempt_finished_best_effort
     let clock_refs = clock_refs_for_context ctx ~event:Provider_attempt_finished () in
     let decision = with_clock_refs ~clock_refs decision in
     make_for_context ctx ~event:Provider_attempt_finished
-      ?cascade_name:started.cascade_name
+      ?runtime_name:started.runtime_name
       ~status
       ~decision
       ()

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -141,7 +141,7 @@ val make :
   ?oas_turn_count:int ->
   ?logical_seq:int ->
   event:event_kind ->
-  ?cascade_name:string ->
+  ?runtime_name:string ->
   ?status:string ->
   ?decision:Yojson.Safe.t ->
   ?receipt_path:string ->
@@ -155,7 +155,7 @@ val make_for_context :
   event:event_kind ->
   ?oas_turn_count:int ->
   ?logical_seq:int ->
-  ?cascade_name:string ->
+  ?runtime_name:string ->
   ?status:string ->
   ?decision:Yojson.Safe.t ->
   ?receipt_path:string ->

--- a/lib/keeper/keeper_runtime_manifest_housekeeping.mli
+++ b/lib/keeper/keeper_runtime_manifest_housekeeping.mli
@@ -41,7 +41,7 @@ type t =
   oas_turn_count : int option;
   logical_seq : int option;
   event : event_kind;
-  cascade_name : string option;
+  runtime_name : string option;
   status : string;
   decision : Yojson.Safe.t;
   links : links;

--- a/lib/keeper/keeper_runtime_manifest_types.ml
+++ b/lib/keeper/keeper_runtime_manifest_types.ml
@@ -115,7 +115,7 @@ type t = {
   oas_turn_count : int option;
   logical_seq : int option;
   event : event_kind;
-  cascade_name : string option;
+  runtime_name : string option;
   status : string;
   decision : Yojson.Safe.t;
   links : links;

--- a/lib/keeper/keeper_runtime_manifest_types.mli
+++ b/lib/keeper/keeper_runtime_manifest_types.mli
@@ -38,7 +38,7 @@ type t = {
   oas_turn_count : int option;
   logical_seq : int option;
   event : event_kind;
-  cascade_name : string option;
+  runtime_name : string option;
   status : string;
   decision : Yojson.Safe.t;
   links : links;

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -117,7 +117,7 @@ let keeper_schemas : tool_schema list = [
           ("default", `Bool Persona_contract.default_generation_proactive_enabled);
           ("description", `String "Default keeper.proactive_enabled for the draft.");
         ]);
-        ("cascade_name", `Assoc [
+        ("runtime_name", `Assoc [
           ("type", `String "string");
           ("default", `String Persona_contract.default_generation_cascade_name);
           ("description", `String "Named cascade used to draft the persona.");
@@ -286,7 +286,7 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "string");
           ("description", `String "Optional: long-term goal horizon (default: goal).");
         ]);
-        ("cascade_name", `Assoc [
+        ("runtime_name", `Assoc [
           ("type", `String "string");
           ("description", `String "Optional: keeper-assignable cascade profile. Replaces legacy models/allowed_models/active_model inputs.");
         ]);

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -538,8 +538,8 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                      ctx.config
                      ~keeper_name:meta.name
                      ~agent_name:meta.agent_name
-                     ~cascade_name:
-                       (                          (Keeper_meta_contract.cascade_name_of_meta meta))
+                     ~runtime_name:
+                       (                          (Keeper_meta_contract.runtime_name_of_meta meta))
                      ~trace_id:
                        (Keeper_id.Trace_id.to_string
                           entry.meta.runtime.trace_id)
@@ -577,7 +577,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    ();
                  Log.Keeper.error
                    "%s: watchdog terminating fiber (provider_timeout unresolved after idle %.0fs; count=%d; preserving provider timeout root cause) [cascade=%s]"
-                   meta.name stall_seconds count (Keeper_meta_contract.cascade_name_of_meta meta);
+                   meta.name stall_seconds count (Keeper_meta_contract.runtime_name_of_meta meta);
                  emit_watchdog_broadcast ~failure_reason:(Some failure_reason)
                    ~stall_seconds
                | _ ->
@@ -692,14 +692,14 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  ();
                Log.Keeper.error
                  "%s: stale watchdog terminating fiber (%s) [cascade=%s window_count=%d/6h]"
-                 meta.name reason_desc (Keeper_meta_contract.cascade_name_of_meta meta) window_count;
+                 meta.name reason_desc (Keeper_meta_contract.runtime_name_of_meta meta) window_count;
                if window_count >= escalation_threshold then begin
                  let cascade_recovered () =
                    match ctx.net with
                    | None -> false
                    | Some net ->
                        (match Cascade_catalog_runtime.resolve_named_providers_strict
-                                ~sw:ctx.sw ~net ~cascade_name:(Keeper_meta_contract.cascade_name_of_meta meta) () with
+                                ~sw:ctx.sw ~net ~runtime_name:(Keeper_meta_contract.runtime_name_of_meta meta) () with
                         | Error _ -> false
                         | Ok candidates ->
                             (* Strict variant returns a typed rejection
@@ -722,7 +722,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                                  Cascade_runtime_candidate.has_recovery_evidence))
                  in
                  if cascade_recovered () then
-                   Log.Keeper.info "%s: stale threshold reached, but cascade %s appears healthy. Skipping auto-pause." meta.name (Keeper_meta_contract.cascade_name_of_meta meta)
+                   Log.Keeper.info "%s: stale threshold reached, but cascade %s appears healthy. Skipping auto-pause." meta.name (Keeper_meta_contract.runtime_name_of_meta meta)
                  else begin
                  Prometheus.inc_counter
                    Keeper_metrics.(to_string StaleTerminationThresholdBreached)

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -27,14 +27,14 @@ let effective_declarative_cascade_name
       (defaults : keeper_profile_defaults)
       (meta : keeper_meta)
   =
-  (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model. *)
+  (* WORKAROUND (#19327 follow-up): field renamed runtime_name→model. *)
   match defaults.model, defaults.manifest_path with
-  | Some cascade_name, _ ->
-    Keeper_cascade_profile.normalize_keeper_runtime_declared_name cascade_name
-  | None, Some _ -> (Keeper_config.default_cascade_name ())
+  | Some runtime_name, _ ->
+    Keeper_cascade_profile.normalize_keeper_runtime_declared_name runtime_name
+  | None, Some _ -> (Keeper_config.default_runtime_name ())
   | None, None ->
     Keeper_cascade_profile.normalize_keeper_runtime_declared_name
-      (cascade_name_of_meta meta)
+      (runtime_name_of_meta meta)
 ;;
 
 type override_field_detail =
@@ -80,13 +80,13 @@ let live_override_details (meta : keeper_meta) (defaults : keeper_profile_defaul
        defaults.tool_denylist
        meta.tool_denylist
   |> (fun acc ->
-  let cascade_name = cascade_name_of_meta meta in
-  if effective_cascade_name <> cascade_name
+  let runtime_name = runtime_name_of_meta meta in
+  if effective_cascade_name <> runtime_name
   then
     override_field
-      "model.cascade_name"
+      "model.runtime_name"
       ~default_value:(`String effective_cascade_name)
-      ~live_value:(`String cascade_name)
+      ~live_value:(`String runtime_name)
     :: acc
   else acc)
   |> maybe_bool_override
@@ -319,7 +319,7 @@ let last_cascade_attempt_json (meta : keeper_meta) =
 let runtime_blocker_facts_json (meta : keeper_meta) =
   `Assoc
     [ "source", `String "keeper_runtime.last_cascade_attempt"
-    ; "cascade_name", `String (cascade_name_of_meta meta)
+    ; "runtime_name", `String (runtime_name_of_meta meta)
     ; "last_cascade_attempt", last_cascade_attempt_json meta
     ]
 ;;

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -265,7 +265,7 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
                window; keeper was auto-paused before restart loop."
               distinct_count)
          Stale_fleet_batch)
-  | Keeper_registry.Provider_runtime_error { code; detail; cascade_name }
+  | Keeper_registry.Provider_runtime_error { code; detail; runtime_name }
     when code = "no_tool_capable_provider" ->
     Some
       (runtime_blocker_surface_of_typed_class

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -687,7 +687,7 @@ let handle_keeper_status_config ~(config : Coord.config) ~(agent_name : string) 
          in
          let model_observability =
            model_observability_json
-             ~current_cascade_name:(cascade_name_of_meta m)
+             ~current_cascade_name:(runtime_name_of_meta m)
              ~runtime_blocker_fields
              latest_metrics
          in

--- a/lib/keeper/keeper_status_detail_observability.ml
+++ b/lib/keeper/keeper_status_detail_observability.ml
@@ -136,7 +136,7 @@ let latest_cascade_for_current_config ~current_cascade_name latest_metrics =
   | None -> None
   | Some cascade ->
       let cascade_name_matches =
-        match Json_util.assoc_string_opt "cascade_name" cascade with
+        match Json_util.assoc_string_opt "runtime_name" cascade with
         | Some observed_name -> String.equal observed_name current_cascade_name
         | None -> true
       in
@@ -149,12 +149,12 @@ let model_observability_json ~current_cascade_name ~runtime_blocker_fields lates
   let runtime_blocker_class =
     assoc_string_opt "runtime_blocker_class" runtime_blocker_fields
   in
-  let cascade_name =
+  let runtime_name =
     Option.value ~default:"" (nonempty_trimmed current_cascade_name)
   in
   `Assoc
-    [ ( "cascade_name"
-      , if cascade_name = "" then `Null else `String cascade_name )
+    [ ( "runtime_name"
+      , if runtime_name = "" then `Null else `String runtime_name )
     ; "recent_turn_observation", `Bool (Option.is_some latest_cascade)
     ; "configured_labels", `List []
     ; "resolved_candidates", `List []

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -537,8 +537,8 @@ let sweep_and_recover (ctx : _ context) =
         when Keeper_supervisor_types.paused_meta_auto_resume_due ~now meta
              && not (Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta.name)
         ->
-        let cascade_name = Keeper_meta_contract.cascade_name_of_meta meta in
-        let cascade_status = Keeper_health_probe.get_cascade_status ~cascade_name in
+        let runtime_name = Keeper_meta_contract.runtime_name_of_meta meta in
+        let cascade_status = Keeper_health_probe.get_cascade_status ~runtime_name in
         (* Three-valued admission:
                     Unhealthy   — block, the probe saw restart pressure.
                     Healthy     — proceed with timer check.
@@ -556,11 +556,11 @@ let sweep_and_recover (ctx : _ context) =
            Log.Keeper.info
              "%s: auto-resume blocked; cascade %s is unhealthy (%s)"
              name
-             cascade_name
+             runtime_name
              reason;
            Prometheus.inc_counter
              Keeper_metrics.(to_string AutoResumeBlockedTotal)
-             ~labels:[ "keeper", name; "cascade", cascade_name ]
+             ~labels:[ "keeper", name; "cascade", runtime_name ]
              ()
          | Keeper_health_probe.Unknown | Keeper_health_probe.Healthy ->
            let resume_after_sec =

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -99,13 +99,13 @@ let direct_turn_observation ~(config : Coord.config) (meta : keeper_meta) :
     ~meta
 
 let resolve_turn_cascade_name (meta : keeper_meta) =
-  let raw_name = String.trim (Keeper_meta_contract.cascade_name_of_meta meta) in
+  let raw_name = String.trim (Keeper_meta_contract.runtime_name_of_meta meta) in
   match Cascade_catalog_runtime.resolve_declared_name ~raw_name () with
-  | Ok cascade_name -> Ok cascade_name
+  | Ok runtime_name -> Ok runtime_name
   | Error detail ->
       Error
         (Printf.sprintf
-           "invalid cascade_name %S for keeper %s: %s"
+           "invalid runtime_name %S for keeper %s: %s"
            raw_name meta.name detail)
 
 let keeper_msg_timeout_override args =
@@ -495,7 +495,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     ~max_context:max_cascade_context
                     ~build_turn_prompt
                     ~user_message:message
-                    ~cascade_name:
+                    ~runtime_name:
                       (                         (turn_cascade_name))
                     ~world_observation
                     ~turn_affordances

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -30,7 +30,7 @@ let provider_config_identity_key =
 let runtime_candidates_of_providers =
   Keeper_turn_driver_admission.runtime_candidates_of_providers
 let run_named
-    ~cascade_name
+    ~runtime_name
     ?base_path
     ?(keeper_name = "")
     ~goal
@@ -96,11 +96,11 @@ let run_named
   match require_eio ?sw ?net () with
   | Error e -> Error (eio_context_error_to_sdk_error e)
   | Ok (sw, net) ->
-  let cascade_name =
-    String.trim cascade_name
+  let runtime_name =
+    String.trim runtime_name
   in
-  let error_cascade_name = cascade_name in
-  let runtime_cascade_name = cascade_name in
+  let error_cascade_name = runtime_name in
+  let runtime_cascade_name = runtime_name in
   let runtime_mcp_policy = runtime_mcp_policy_for_tools ~keeper_name tools in
   (* Keeper-internal tools cannot degrade to a text-only CLI palette: the
      model would see no callable schema and emit misleading diagnostics. *)
@@ -114,7 +114,7 @@ let run_named
       ~sw
       ~net
       ?provider_filter
-      ~cascade_name
+      ~runtime_name
       ~runtime_cascade_name
       ()
   in
@@ -123,7 +123,7 @@ let run_named
        named_resolution.candidate_cfgs_result )
    with
    | Error detail, _ | _, Error detail ->
-       Log.Misc.error "cascade %s: %s" cascade_name detail;
+       Log.Misc.error "cascade %s: %s" runtime_name detail;
        Error (cascade_catalog_error_to_sdk_error detail)
    | Ok configured_labels, Ok candidate_cfgs ->
   let original_candidate_cfgs = candidate_cfgs in
@@ -131,7 +131,7 @@ let run_named
     runtime_candidates_of_providers original_candidate_cfgs
   in
   let required_capability_profile =
-    Keeper_cascade_profile.required_capability_profile_of_cascade_name cascade_name
+    Keeper_cascade_profile.required_capability_profile_of_cascade_name runtime_name
   in
   let tool_filtered_candidate_cfgs =
     filter_candidate_providers_for_tool_support
@@ -142,7 +142,7 @@ let run_named
       ~require_tool_support
       ?required_capability_profile
       ?secondary_resolver:named_resolution.secondary_resolver
-      ~label:cascade_name
+      ~label:runtime_name
       candidate_cfgs
   in
   let configured_label_count = List.length configured_labels in
@@ -171,7 +171,7 @@ let run_named
              Log.Keeper.warn
                "keeper:%s cascade %s: pre-dispatch skipped provider=%s reason=%s"
                keeper_name
-               cascade_name
+               runtime_name
                provider_label
                reason;
              kept,
@@ -229,7 +229,7 @@ let run_named
             | Some (_provider_health_key, msg) ->
                 Log.Misc.debug
                   "cascade %s: prefilter skipped %s (provider_key=%s cooldown: %s)"
-                  cascade_name runtime_candidate_label runtime_candidate_label msg;
+                  runtime_name runtime_candidate_label runtime_candidate_label msg;
                 false)
   in
   let health_filtered_candidate_count = List.length health_filtered_candidates in
@@ -274,7 +274,7 @@ let run_named
       let outcome =
         Keeper_preflight_health_tracker.record
           Keeper_preflight_health_tracker.global
-          ~cascade_name
+          ~runtime_name
           ~provider:endpoint
           ~reason:Keeper_preflight_health_tracker.Health_check_failed_repeatedly
       in
@@ -283,7 +283,7 @@ let run_named
         Log.Misc.warn
           "cascade %s: preflight skipped 1 unhealthy local endpoint(s) before \
            provider dispatch: [%s] (reason=%s, first occurrence)"
-          cascade_name
+          runtime_name
           endpoint
           (Keeper_preflight_health_tracker.reason_slug
              Keeper_preflight_health_tracker.Health_check_failed_repeatedly)
@@ -291,7 +291,7 @@ let run_named
         Log.Misc.warn
           "cascade %s: preflight skipped 1 unhealthy local endpoint(s) before \
            provider dispatch: [%s] (reason=%s, consecutive=%d)"
-          cascade_name
+          runtime_name
           endpoint
           (Keeper_preflight_health_tracker.reason_slug
              Keeper_preflight_health_tracker.Health_check_failed_repeatedly)
@@ -301,7 +301,7 @@ let run_named
           "cascade %s: provider [%s] disabled after %d consecutive preflight \
            unhealthy skips (reason=%s); subsequent skips silenced via \
            disabled-list. Recovery requires successful health probe."
-          cascade_name
+          runtime_name
           endpoint
           n
           (Keeper_preflight_health_tracker.reason_slug
@@ -311,7 +311,7 @@ let run_named
            already emitted its ERROR escalation. *)
         Log.Misc.debug
           "cascade %s: preflight skipped already-disabled endpoint [%s]"
-          cascade_name endpoint)
+          runtime_name endpoint)
     unhealthy_local_endpoints;
   (* Recovery: for any endpoint that probed healthy this cycle, clear
      fingerprints + emit one INFO if it had been disabled. *)
@@ -330,7 +330,7 @@ let run_named
           Log.Misc.info
             "cascade %s: provider [%s] re-enabled after successful health \
              probe; removed from disabled-list."
-            cascade_name url)
+            runtime_name url)
     local_endpoint_health;
   let candidates = local_prefiltered_candidates in
   let optional_capacity_override ~knob resolve =
@@ -339,7 +339,7 @@ let run_named
     | Error detail ->
       Log.Misc.warn
         "cascade %s: failed to resolve %s capacity override: %s"
-        cascade_name
+        runtime_name
         knob
         detail;
       None
@@ -359,7 +359,7 @@ let run_named
         Cascade_catalog_runtime.resolve_cli_max_concurrent
           ~sw
           ~net
-          ~name:cascade_name
+          ~name:runtime_name
           ())
     in
     (match cli_max_concurrent with
@@ -376,7 +376,7 @@ let run_named
           Cascade_catalog_runtime.resolve_ollama_max_concurrent
             ~sw
             ~net
-            ~name:cascade_name
+            ~name:runtime_name
             ())
       with
       | Some max_concurrent -> max_concurrent
@@ -398,7 +398,7 @@ let run_named
        fail-open to surface provider result instead of no_providers_available \
        configured_label_count=%d original_candidate_count=%d \
        tool_filtered_candidate_count=%d local_prefiltered_candidate_count=%d"
-      cascade_name
+      runtime_name
       configured_label_count
       original_candidate_count
       tool_filtered_candidate_count
@@ -475,7 +475,7 @@ let run_named
          required_lane_filtered_candidate_count=%d local_prefiltered_candidate_count=%d \
          health_filtered_candidate_count=%d require_tool_choice_support=%b \
          require_tool_support=%b"
-        cascade_name
+        runtime_name
         exhaustion_summary
         classification_code
         configured_label_count
@@ -501,13 +501,13 @@ let run_named
           in
           Cascade_exhausted
             {
-              cascade_name = error_cascade_name;
+              runtime_name = error_cascade_name;
               reason = Keeper_meta_contract.No_tool_capable (Some detail);
             }
         | Provider_unavailable ->
           Cascade_exhausted
             {
-              cascade_name = error_cascade_name;
+              runtime_name = error_cascade_name;
               reason = Keeper_meta_contract.No_providers_available;
             }
       in
@@ -521,7 +521,7 @@ let run_named
          in
          Keeper_runtime_manifest.make_for_context manifest_ctx
            ~event:Keeper_runtime_manifest.Pre_dispatch_blocked
-           ~cascade_name
+           ~runtime_name
            ~status:"error"
            ~decision:
              (`Assoc
@@ -584,7 +584,7 @@ let run_named
     Keeper_observation.cascade_metrics_for_candidates ~candidate_count ()
   in
   let cascade_strategy_name_ref = ref None in
-  let name = Printf.sprintf "oas-%s" cascade_name in
+  let name = Printf.sprintf "oas-%s" runtime_name in
   let transport_resolved = match transport with
     | Some t -> t
     | None -> Masc_grpc_transport.from_env ()
@@ -598,7 +598,7 @@ let run_named
   let turn_start = Mtime_clock.now () in
   let seq_ref = ref 0 in
   let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx = {
-    cascade_name;
+    runtime_name;
     error_cascade_name;
     keeper_name;
     name;
@@ -698,7 +698,7 @@ let run_named
         | None -> decision
       in
       Keeper_runtime_manifest.make_for_context manifest_ctx ~event
-        ?oas_turn_count ~logical_seq:!seq_ref ~cascade_name ?status ?decision
+        ?oas_turn_count ~logical_seq:!seq_ref ~runtime_name ?status ?decision
         ()
       |> append
     | _ -> ()
@@ -711,7 +711,7 @@ let run_named
     | None -> None
   in
   let try_cascade_ctx : Keeper_turn_driver_try_cascade.try_cascade_ctx = {
-    cascade_name;
+    runtime_name;
     error_cascade_name;
     keeper_name;
     name;
@@ -766,13 +766,13 @@ let run_named
     match resolve () with
     | Ok value -> Ok value
     | Error detail ->
-        Log.Misc.error "cascade %s: %s" cascade_name detail;
+        Log.Misc.error "cascade %s: %s" runtime_name detail;
         Error (cascade_catalog_error_to_sdk_error detail)
   in
   let* strategy =
     profile_knob_or_default ~knob:"strategy"
       ~default:Cascade_strategy.failover
-      (fun () -> Cascade_catalog_runtime.resolve_strategy ~name:cascade_name ())
+      (fun () -> Cascade_catalog_runtime.resolve_strategy ~name:runtime_name ())
   in
   let strategy_name = Cascade_strategy.kind_to_string strategy.kind in
   let () = cascade_strategy_name_ref := Some strategy_name in
@@ -784,7 +784,7 @@ let run_named
     now = Unix.gettimeofday ();
     rand_int = Random.int;
     keeper_name;
-    cascade_name = error_cascade_name;
+    runtime_name = error_cascade_name;
   } in
   let cycle_clock = Eio_context.get_clock_opt () in
   let do_backoff cycle =
@@ -804,25 +804,25 @@ let run_named
   let cascade_exhausted_after_filter ~cycle =
     let observation =
       Keeper_observation.cascade_observation_with_metrics
-        ~cascade_name:error_cascade_name
+        ~runtime_name:error_cascade_name
         ?strategy:!cascade_strategy_name_ref ~configured_labels
         ~candidate_count ~selected_model_raw:error_selected_model_raw ~capture ()
     in
     Keeper_observation.record_cascade ~keeper_name
-      ~cascade_name:error_cascade_name
+      ~runtime_name:error_cascade_name
       ~outcome:`Failure ~observation:(Some observation) ();
     Error
       (sdk_error_of_masc_internal_error
          (Cascade_exhausted
             {
-              cascade_name = error_cascade_name;
+              runtime_name = error_cascade_name;
               reason = Keeper_meta_contract.Candidates_filtered_after_cycles;
             }))
   in
   let record_trace ~cycle ~candidates_out ~backoff_ms ~kind =
     Cascade_strategy_trace.record {
       ts = Unix.gettimeofday ();
-      cascade_name = cascade_name;
+      runtime_name = runtime_name;
       strategy = strategy_name;
       cycle;
       candidates_in = List.length candidates;
@@ -854,7 +854,7 @@ let run_named
         ~kind:Filtered_empty;
       Log.Misc.info
         "cascade %s: cycle %d (%s) filtered all candidates, retrying"
-        cascade_name n strategy_name;
+        runtime_name n strategy_name;
       do_backoff (n + 1);
       cycle_loop (n + 1)
     | _ ->
@@ -869,15 +869,15 @@ let run_named
        | Error _ ->
          Log.Misc.info
            "cascade %s: cycle %d exhausted, backoff before retry (strategy=%s)"
-           cascade_name n strategy_name;
+           runtime_name n strategy_name;
          do_backoff (n + 1);
          cycle_loop (n + 1))
   in
   let admission_cascade_name =
-    cascade_name
+    runtime_name
   in
   match Admission_queue.with_permit ?wait_timeout_sec
-    ~priority:queue_priority ~keeper_name:name ~cascade_name:admission_cascade_name
+    ~priority:queue_priority ~keeper_name:name ~runtime_name:admission_cascade_name
     (fun () -> cycle_loop 0) with
   | Ok result -> result
   | Error (`Host_resource_saturated reason) ->

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -95,7 +95,7 @@ val provider_attempt_finished_decision :
 (** {1 Named cascade execution} *)
 
 val run_named :
-  cascade_name:string ->
+  runtime_name:string ->
   ?base_path:string ->
   ?keeper_name:string ->
   goal:string ->

--- a/lib/keeper/keeper_turn_driver_backpressure.ml
+++ b/lib/keeper/keeper_turn_driver_backpressure.ml
@@ -30,7 +30,7 @@ let capacity_backpressure_source_of_http_error = function
   | Llm_provider.Http_client.ProviderFailure _ ->
     None
 
-let capacity_backpressure_of_http_error ?source ~cascade_name last_err =
+let capacity_backpressure_of_http_error ?source ~runtime_name last_err =
   match last_err with
   | Some
       (Llm_provider.Http_client.ProviderFailure
@@ -43,7 +43,7 @@ let capacity_backpressure_of_http_error ?source ~cascade_name last_err =
     Some
       (Capacity_backpressure
          {
-           cascade_name;
+           runtime_name;
            source =
              Option.value source ~default:Provider_capacity;
            detail = message;
@@ -61,7 +61,7 @@ let capacity_backpressure_of_http_error ?source ~cascade_name last_err =
     Some
       (Capacity_backpressure
          {
-           cascade_name;
+           runtime_name;
            source = Option.value source ~default:Cascade_slot;
            detail = message;
            retry_after = Synthetic_default synthetic_retry_after_sec;
@@ -76,12 +76,12 @@ let capacity_backpressure_of_http_error ?source ~cascade_name last_err =
   | None ->
     None
 
-let capacity_backpressure_of_pending ~cascade_name = function
+let capacity_backpressure_of_pending ~runtime_name = function
   | Some (source, detail, retry_after) ->
     Some
       (Capacity_backpressure
          {
-           cascade_name;
+           runtime_name;
            source;
            detail;
            retry_after;
@@ -89,7 +89,7 @@ let capacity_backpressure_of_pending ~cascade_name = function
   | None -> None
 
 let capacity_backpressure_of_sdk_error
-    ~cascade_name
+    ~runtime_name
     ~message_looks_like_capacity_backpressure
     ~sdk_error_of_masc_internal_error
     sdk_err =
@@ -100,7 +100,7 @@ let capacity_backpressure_of_sdk_error
       (sdk_error_of_masc_internal_error
          (Capacity_backpressure
             {
-              cascade_name;
+              runtime_name;
               source = Provider_capacity;
               detail;
               retry_after =
@@ -114,7 +114,7 @@ let capacity_backpressure_of_sdk_error
       (sdk_error_of_masc_internal_error
          (Capacity_backpressure
             {
-              cascade_name;
+              runtime_name;
               source = Provider_capacity;
               detail = msg;
               retry_after = Synthetic_default synthetic_retry_after_sec;

--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -14,7 +14,7 @@ val capacity_backpressure_source_of_http_error :
     when the error indicates capacity exhaustion. *)
 val capacity_backpressure_of_http_error :
   ?source:Keeper_meta_contract.capacity_backpressure_source ->
-  cascade_name:string ->
+  runtime_name:string ->
   Llm_provider.Http_client.http_error option ->
   Keeper_meta_contract.masc_internal_error option
 
@@ -24,7 +24,7 @@ val capacity_backpressure_of_http_error :
     [No_retry_hint]) so a synthetic default is never read as an explicit
     hint. *)
 val capacity_backpressure_of_pending :
-  cascade_name:string ->
+  runtime_name:string ->
   (Keeper_meta_contract.capacity_backpressure_source * string
    * Keeper_meta_contract.capacity_retry_after) option ->
   Keeper_meta_contract.masc_internal_error option
@@ -33,7 +33,7 @@ val capacity_backpressure_of_pending :
     when the error indicates provider capacity exhaustion or a
     backpressure-like internal message. *)
 val capacity_backpressure_of_sdk_error :
-  cascade_name:string ->
+  runtime_name:string ->
   message_looks_like_capacity_backpressure:(string -> bool) ->
   sdk_error_of_masc_internal_error:(Keeper_meta_contract.masc_internal_error ->
                                     Agent_sdk.Error.sdk_error) ->

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -114,7 +114,7 @@ let provider_rejection_for_required_tool_unsupported ~provider_label
    }
     : Keeper_meta_contract.provider_rejection)
 
-let no_tool_capable_provider_of_pre_dispatch_rejections ~cascade_name
+let no_tool_capable_provider_of_pre_dispatch_rejections ~runtime_name
     ~configured_labels ~runtime_manifest_required_tool_names ~runtime_mcp_policy
     ~tools ~required_lane_provider_rejections ~pre_dispatch_provider_rejections =
   match runtime_manifest_required_tool_names, pre_dispatch_provider_rejections with
@@ -141,7 +141,7 @@ let no_tool_capable_provider_of_pre_dispatch_rejections ~cascade_name
       Some
         (Keeper_meta_contract.Cascade_exhausted
            {
-             cascade_name;
+             runtime_name;
              reason = Keeper_meta_contract.No_tool_capable (Some detail);
            })
 

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -41,7 +41,7 @@ val provider_rejection_for_required_tool_unsupported :
   Keeper_meta_contract.provider_rejection
 
 val no_tool_capable_provider_of_pre_dispatch_rejections :
-  cascade_name:string ->
+  runtime_name:string ->
   configured_labels:string list ->
   runtime_manifest_required_tool_names:string list ->
   runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option ->

--- a/lib/keeper/keeper_turn_driver_named_resolution.ml
+++ b/lib/keeper/keeper_turn_driver_named_resolution.ml
@@ -11,11 +11,11 @@ type t = {
   secondary_resolver : secondary_resolver option;
 }
 
-let resolve ~sw ~net ?provider_filter ~cascade_name ~runtime_cascade_name () =
+let resolve ~sw ~net ?provider_filter ~runtime_name ~runtime_cascade_name () =
   let named_resolution =
     Cascade_catalog_runtime
     .resolve_named_providers_strict_with_secondary_resolver
-      ~sw ~net ?provider_filter ~cascade_name ()
+      ~sw ~net ?provider_filter ~runtime_name ()
   in
   let candidate_cfgs_result =
     match named_resolution with

--- a/lib/keeper/keeper_turn_driver_named_resolution.mli
+++ b/lib/keeper/keeper_turn_driver_named_resolution.mli
@@ -15,7 +15,7 @@ val resolve :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   ?provider_filter:string list ->
-  cascade_name:string ->
+  runtime_name:string ->
   runtime_cascade_name:string ->
   unit ->
   t

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -17,7 +17,7 @@ open Result.Syntax
     session/checkpoint, Eio primitives, callbacks, and event bus. *)
 type try_provider_ctx =
   { (* Cascade identity *)
-    cascade_name : string
+    runtime_name : string
   ; error_cascade_name : string
   ; keeper_name : string
   ; name : string
@@ -125,7 +125,7 @@ let emit_runtime_manifest
            decision)
     in
     Keeper_runtime_manifest.make_for_context manifest_ctx ~event
-      ~cascade_name:ctx.cascade_name ?logical_seq:(Some !(ctx.seq_ref))
+      ~runtime_name:ctx.runtime_name ?logical_seq:(Some !(ctx.seq_ref))
       ?status ?decision ()
     |> append
   | _ -> ()
@@ -322,7 +322,7 @@ let run_try_provider
           ; tool_retry_policy = ctx.tool_retry_policy
           ; required_tool_satisfaction = ctx.required_tool_satisfaction
           ; description =
-              Some (Printf.sprintf "cascade:%s/runtime" ctx.cascade_name)
+              Some (Printf.sprintf "cascade:%s/runtime" ctx.runtime_name)
           ; transport = ctx.transport_resolved
           ; allowed_paths = ctx.allowed_paths
           ; checkpoint_sidecar = ctx.checkpoint_sidecar
@@ -366,7 +366,7 @@ let run_try_provider
         Log.Misc.debug
           "rfc0095-trace: liveness_mode=Off observer disabled cascade=%s provider=%s \
            candidate=%s"
-          ctx.cascade_name
+          ctx.runtime_name
           provider_label
           candidate_key;
         None
@@ -389,7 +389,7 @@ let run_try_provider
           Keeper_attempt_liveness_observer.create
             ~mode:liveness_mode
             ~budget:resolved_budget.budget
-            ~cascade_label:ctx.cascade_name
+            ~cascade_label:ctx.runtime_name
             ~provider_label
             ~external_wait:(fun () ->
               Keeper_approval_queue.has_pending_for_keeper
@@ -418,7 +418,7 @@ let run_try_provider
            { message =
                Printf.sprintf
                  "Cascade attempt liveness guard killed runtime lane %s: %s"
-                 ctx.cascade_name
+                 ctx.runtime_name
                  kind
            })
     in
@@ -475,7 +475,7 @@ let run_try_provider
     in
     (match
        Cascade_config_builder.with_cli_preflight
-         ~scope:(Printf.sprintf "cascade:%s/runtime" ctx.cascade_name)
+         ~scope:(Printf.sprintf "cascade:%s/runtime" ctx.runtime_name)
          ~config
          ~goal:ctx.goal
          (fun () ->
@@ -524,7 +524,7 @@ let run_try_provider
                         Log.Misc.info
                           "[cascade-fallback] cascade %s: runtime lane per-provider \
                            timeout after %.1fs, falling back"
-                          ctx.cascade_name
+                          ctx.runtime_name
                           t;
                         Error
                           (Agent_sdk.Error.Api
@@ -545,7 +545,7 @@ let run_try_provider
        let result =
          Result.map_error
            (Cascade_runtime_candidate.enrich_sdk_error
-              ~cascade_name:ctx.error_cascade_name
+              ~runtime_name:ctx.error_cascade_name
               candidate)
            result
        in

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -1,7 +1,7 @@
 (** Extracted provider-attempt runner for keeper cascade turns. *)
 
 type try_provider_ctx =
-  { cascade_name : string
+  { runtime_name : string
   ; error_cascade_name : string
   ; keeper_name : string
   ; name : string

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -67,7 +67,7 @@ let run_model_by_label
         Admission_queue.with_permit ?wait_timeout_sec
           ~priority:Llm_provider.Request_priority.Proactive
           ~keeper_name:"oas-label-model"
-          ~cascade_name:admission_cascade_name
+          ~runtime_name:admission_cascade_name
           (fun () ->
             Cascade_config_builder.with_cli_preflight
               ~scope:(Printf.sprintf "model_label:%s" model_label)
@@ -102,7 +102,7 @@ let run_model_by_label
                (Admission_queue_rejected { keeper_name = "oas-label-model"; reason }))
 
 let run_named_with_masc_tools
-    ~cascade_name
+    ~runtime_name
     ~goal
     ?priority
     ?(system_prompt = "")
@@ -140,7 +140,7 @@ let run_named_with_masc_tools
       ~input_schema:td.input_schema
       (fun input -> dispatch ~name:td.name ~args:input)
   ) masc_tools in
-  Keeper_turn_driver.run_named ~cascade_name ~goal ?priority ~system_prompt ~tools:oas_tools
+  Keeper_turn_driver.run_named ~runtime_name ~goal ?priority ~system_prompt ~tools:oas_tools
     ~require_tool_support:(masc_tools <> [])
     ~max_turns ~temperature ~max_tokens ?max_input_tokens ?max_cost_usd
     ?stream_idle_timeout_s ?wait_timeout_sec ?guardrails ?hooks ?memory
@@ -202,7 +202,7 @@ let run_model_with_masc_tools
         Admission_queue.with_permit ?wait_timeout_sec
           ~priority:Llm_provider.Request_priority.Proactive
           ~keeper_name:"oas-explicit-model"
-          ~cascade_name:admission_cascade_name
+          ~runtime_name:admission_cascade_name
           (fun () ->
             Cascade_config_builder.with_cli_preflight
               ~scope:(Printf.sprintf "explicit_model:%s" model_label)

--- a/lib/keeper/keeper_turn_driver_wrappers.mli
+++ b/lib/keeper/keeper_turn_driver_wrappers.mli
@@ -42,7 +42,7 @@ val run_model_by_label :
 (** {1 MASC tool bridging} *)
 
 val run_named_with_masc_tools :
-  cascade_name:string ->
+  runtime_name:string ->
   goal:string ->
   ?priority:Llm_provider.Request_priority.t ->
   ?system_prompt:string ->

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -11,7 +11,7 @@ type failure_reason =
       resolved : string option;
     }
   | Failure_no_tool_capable_provider of {
-      cascade_name : string;
+      runtime_name : string;
       detail : string;
     }
   | Failure_provider_error of { kind : string; detail : string }
@@ -109,9 +109,9 @@ let pp_failure_reason fmt = function
       Format.fprintf fmt "cascade_unavailable(base=%s,resolved=%s)"
         base
         (Option.value resolved ~default:"-")
-  | Failure_no_tool_capable_provider { cascade_name; detail } ->
+  | Failure_no_tool_capable_provider { runtime_name; detail } ->
       Format.fprintf fmt "no_tool_capable_provider(cascade=%s,detail=%s)"
-        cascade_name detail
+        runtime_name detail
   | Failure_provider_error { kind; detail } ->
       Format.fprintf fmt "provider_error(kind=%s,detail=%s)" kind detail
   | Failure_tool_contract_violation { reason_code } ->

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -26,7 +26,7 @@ type failure_reason =
       resolved : string option;
     }
   | Failure_no_tool_capable_provider of {
-      cascade_name : string;
+      runtime_name : string;
       detail : string;
     }
   | Failure_provider_error of { kind : string; detail : string }

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -201,7 +201,7 @@ let record_pre_dispatch_terminal_observation
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(generation : int)
-      ~(cascade_name : string)
+      ~(runtime_name : string)
       ~(outcome : Keeper_execution_receipt.outcome_kind)
       ~(terminal_reason_code : string)
       ~(activity_kind : string)
@@ -213,7 +213,7 @@ let record_pre_dispatch_terminal_observation
   : unit
   =
   let cascade_name_string =
-    cascade_name
+    runtime_name
   in
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   let started_at = now_iso () in
@@ -254,7 +254,7 @@ let record_pre_dispatch_terminal_observation
     ; network_mode = meta.network_mode
     ; approval_profile = None
     ; approval_profile_derived = false
-    ; cascade_name
+    ; runtime_name
     ; cascade_selected_model = None
     ; cascade_attempt_count = 0
     ; cascade_fallback_applied = false
@@ -290,7 +290,7 @@ let record_pre_dispatch_terminal_observation
     in
     Keeper_runtime_manifest.make ~ts:ended_at ~keeper_name:meta.name
       ~agent_name:meta.agent_name ~trace_id ~generation ?keeper_turn_id ~event
-      ~cascade_name:cascade_name_string ~status ?decision ~receipt_path ()
+      ~runtime_name:cascade_name_string ~status ?decision ~receipt_path ()
     |> Keeper_runtime_manifest.append_best_effort ~site config
   in
   append_manifest
@@ -303,7 +303,7 @@ let record_pre_dispatch_terminal_observation
             `String (Keeper_execution_receipt.outcome_kind_to_string outcome)
           );
           ("terminal_reason_code", `String terminal_reason_code);
-          ("cascade_name", `String cascade_name_string);
+          ("runtime_name", `String cascade_name_string);
           ( "error_message",
             match error_message with
             | None -> `Null
@@ -366,7 +366,7 @@ let record_pre_dispatch_terminal_observation
                 , `String (Keeper_execution_receipt.outcome_kind_to_string outcome)
                 )
               ; "terminal_reason_code", `String terminal_reason_code
-              ; "cascade_name", `String cascade_name_string
+              ; "runtime_name", `String cascade_name_string
               ])
         ()
     in

--- a/lib/keeper/keeper_turn_helpers.mli
+++ b/lib/keeper/keeper_turn_helpers.mli
@@ -67,7 +67,7 @@ val record_pre_dispatch_terminal_observation :
   config:Coord.config ->
   meta:keeper_meta ->
   generation:int ->
-  cascade_name:string ->
+  runtime_name:string ->
   outcome:Keeper_execution_receipt.outcome_kind ->
   terminal_reason_code:string ->
   activity_kind:string ->

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -114,13 +114,13 @@ let parse_enum_string_opt args key of_string ~allowed_values =
            (Json_util.kind_name other))
 
 let parse_cascade_name_opt args =
-  match get_string_opt args "cascade_name" with
+  match get_string_opt args "runtime_name" with
   | None -> Ok None
   | Some raw ->
       let normalized =
         String.trim raw |> String.trim
       in
-      if normalized = "" then Error "cascade_name must not be empty"
+      if normalized = "" then Error "runtime_name must not be empty"
       else
         (* keeper-assignable guardrail removed 2026-05-28 — validate existence only. *)
         match
@@ -129,7 +129,7 @@ let parse_cascade_name_opt args =
         with
         | Ok _ -> Ok (Some normalized)
         | Error detail ->
-            Error (Printf.sprintf "invalid cascade_name '%s': %s" raw detail)
+            Error (Printf.sprintf "invalid runtime_name '%s': %s" raw detail)
 
 let resolve_tool_name_list ~preferred ~fallback =
   Dashboard_utils.first_some preferred fallback

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -48,12 +48,12 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     | Some ids -> ids
     | None -> Option.value ~default:[] p.profile_defaults.active_goal_ids
   in
-  let selected_cascade_name =
-    (* WORKAROUND (#19327 follow-up): cascade_name→model field rename. *)
+  let selected_runtime_name =
+    (* WORKAROUND (#19327 follow-up): runtime_name→model field rename. *)
     match p.cascade_name_opt, p.profile_defaults.model with
     | Some name, _ -> name
     | None, Some name -> name
-    | None, None -> Keeper_config.default_cascade_name ()
+    | None, None -> Keeper_config.default_runtime_name ()
   in
   let active_goal_ids_error =
     match p.active_goal_ids_opt with
@@ -284,7 +284,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
               in
               let cascade_models =
                 Provider_runtime_projection.default_execution_model_strings
-                  (selected_cascade_name)
+                  (selected_runtime_name)
               in
               (match
                  Keeper_turn_helpers.ensure_local_discovery_ready
@@ -604,7 +604,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           ("needs", `String meta.needs);
           ("desires", `String meta.desires);
           ("instructions", `String meta.instructions);
-          ("cascade_name", `String (cascade_name_of_meta meta));
+          ("runtime_name", `String (runtime_name_of_meta meta));
           ("social_model", `String meta.social_model);
           ("tool_access", tool_access_to_json meta.tool_access);
           ("tool_denylist",

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -1,4 +1,4 @@
-val default_cascade_name : unit -> string
+val default_runtime_name : unit -> string
 val min_keeper_context_tokens : int
 val max_keeper_context_tokens : int
 val alert_error_detail_max_chars : int

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -1,4 +1,4 @@
-val default_cascade_name : unit -> string
+val default_runtime_name : unit -> string
 val min_keeper_context_tokens : int
 val max_keeper_context_tokens : int
 val alert_error_detail_max_chars : int

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -1,4 +1,4 @@
-val default_cascade_name : unit -> string
+val default_runtime_name : unit -> string
 val min_keeper_context_tokens : int
 val max_keeper_context_tokens : int
 val alert_error_detail_max_chars : int

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -1,4 +1,4 @@
-val default_cascade_name : unit -> string
+val default_runtime_name : unit -> string
 val min_keeper_context_tokens : int
 val max_keeper_context_tokens : int
 val alert_error_detail_max_chars : int

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -259,11 +259,11 @@ let append_decision_record
               let cascade_fields =
                 match r.cascade_observation with
                 | Some co ->
-                    let cascade_name =
-                      co.cascade_name
+                    let runtime_name =
+                      co.runtime_name
                     in
                     [
-                      ("cascade_name", `String cascade_name);
+                      ("runtime_name", `String runtime_name);
                       ("strategy", Json_util.string_opt_to_json co.strategy);
                       ("primary_model", `Null);
                       ("selected_model", `Null);
@@ -392,7 +392,7 @@ let append_decision_record
                 error_category_of_no_result_outcome ~outcome ~error
               in
               `Assoc [
-                ("cascade_name", `String (cascade_name_of_meta meta));
+                ("runtime_name", `String (runtime_name_of_meta meta));
                 ("candidate_models", `List []);
                 ( "error_category", Json_util.string_opt_to_json error_category );
                 ("outcome", `String outcome);

--- a/lib/keeper/keeper_unified_metrics_failure.ml
+++ b/lib/keeper/keeper_unified_metrics_failure.ml
@@ -117,18 +117,18 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
    | Some err ->
        (match Keeper_turn_driver.classify_masc_internal_error err with
         | Some (Keeper_turn_driver.Cascade_exhausted
-	                  { cascade_name
+	                  { runtime_name
 	                  ; reason = Keeper_meta_contract.No_tool_capable _
 	                  ; _
 	                  }) ->
-            let cascade_name =
-              cascade_name
+            let runtime_name =
+              runtime_name
             in
             Prometheus.inc_counter
               Keeper_metrics.(to_string NoToolProvider)
               ~labels:
                 [ ("keeper", meta.name)
-                ; ("cascade", cascade_name)
+                ; ("cascade", runtime_name)
                 ]
               ()
         | _ -> ())

--- a/lib/keeper/keeper_unified_metrics_json_support.ml
+++ b/lib/keeper/keeper_unified_metrics_json_support.ml
@@ -26,20 +26,20 @@ let provider_context_json ~(meta : keeper_meta)
     (result : Keeper_agent_run.run_result option) =
   match result with
   | Some r ->
-      let cascade_name =
+      let runtime_name =
         match r.cascade_observation with
         | Some observation ->
-            observation.cascade_name
-        | None -> cascade_name_of_meta meta
+            observation.runtime_name
+        | None -> runtime_name_of_meta meta
       in
       `Assoc
-        [ ("cascade_name", `String cascade_name)
+        [ ("runtime_name", `String runtime_name)
         ; "selected_model", `Null
         ; "candidate_models", `List []
         ]
   | None ->
       `Assoc
-        [ ("cascade_name", `String (cascade_name_of_meta meta))
+        [ ("runtime_name", `String (runtime_name_of_meta meta))
         ; ("selected_model", `Null)
         ; "candidate_models", `List []
         ]
@@ -60,11 +60,11 @@ let redacted_cascade_fallback_event_to_json
 
 let redacted_cascade_observation_to_json
     (obs : Keeper_observation.cascade_observation) : Yojson.Safe.t =
-  let cascade_name =
-    obs.cascade_name
+  let runtime_name =
+    obs.runtime_name
   in
   `Assoc
-    [ "cascade_name", `String cascade_name
+    [ "runtime_name", `String runtime_name
     ; "strategy", Json_util.string_opt_to_json obs.strategy
     ; "configured_labels", `List []
     ; "candidate_models", `List []

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -81,8 +81,8 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
   let cascade_profile =
     match result.cascade_observation with
     | Some observation ->
-        observation.Keeper_observation.cascade_name
-    | None -> (cascade_name_of_meta meta)
+        observation.Keeper_observation.runtime_name
+    | None -> (runtime_name_of_meta meta)
   in
   (* #9933: same latency bucket, split by provider/model/cascade.
      This keeps the existing keeper-only counter stable while making

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -66,7 +66,7 @@ let run_keeper_cycle
   in
   let turn_start = Mtime_clock.now () in
   let seq_ref = ref 0 in
-  let append_manifest ?status ?decision ?cascade_name ?clock_refs ~site event =
+  let append_manifest ?status ?decision ?runtime_name ?clock_refs ~site event =
     let decision =
       let decision =
         match decision with
@@ -95,7 +95,7 @@ let run_keeper_cycle
            decision)
     in
     Keeper_runtime_manifest.make_for_context runtime_manifest_context ~event
-      ?cascade_name ?status ?decision ()
+      ?runtime_name ?status ?decision ()
     |> Keeper_runtime_manifest.append_best_effort ~site config
   in
   let append_phase_gate_decision turn_plan =
@@ -137,7 +137,7 @@ let run_keeper_cycle
   let main_path phase_opt =
       (* RFC-0136 PR-2: cascade resolution stage extracted to
          [Keeper_unified_turn_cascade_resolution].  The stage owns the
-         [selected_item] override of [meta.cascade_ref], the
+         [selected_item] override of [meta.runtime_ref], the
          [Keeper_cascade_routing.select_cascade] call, and the
          [fail_open_phase_buffer_when_unavailable] hardening.  Returns
          the updated meta + the resolved cascade name. *)
@@ -148,9 +148,9 @@ let run_keeper_cycle
         Keeper_unified_turn_cascade_resolution.resolve_cascade
           ~meta
           ~phase_opt
-          ~append_cascade_routed_manifest:(fun ~cascade_name ~decision ->
+          ~append_cascade_routed_manifest:(fun ~runtime_name ~decision ->
             append_manifest ~site:"cascade_routed"
-              ~cascade_name
+              ~runtime_name
               ~decision
               Keeper_runtime_manifest.Cascade_routed)
       in
@@ -172,7 +172,7 @@ let run_keeper_cycle
             Keeper_unified_turn_pre_dispatch.build_cascade_execution
               ~meta
               ~profile_defaults
-              ~cascade_name:effective_cascade_runtime_name
+              ~runtime_name:effective_cascade_runtime_name
           with
           | Error err ->
             let terminal_reason_code =
@@ -185,7 +185,7 @@ let run_keeper_cycle
               ~config
               ~meta
               ~generation
-              ~cascade_name:effective_cascade_runtime_name
+              ~runtime_name:effective_cascade_runtime_name
               ~outcome:`Error
               ~terminal_reason_code
               ~activity_kind:"keeper.turn_blocked"
@@ -199,12 +199,12 @@ let run_keeper_cycle
               match Keeper_turn_driver.classify_masc_internal_error err with
               | Some
                   (Keeper_turn_driver.Cascade_exhausted
-                     { cascade_name
+                     { runtime_name
                      ; reason = Keeper_meta_contract.No_tool_capable _
                      ; _
                      }) ->
                 Keeper_turn_fsm.Failure_no_tool_capable_provider
-                  { cascade_name = cascade_name
+                  { runtime_name = runtime_name
                   ; detail = error_message
                   }
               | _ when EC.is_cascade_exhausted_error err ->
@@ -227,7 +227,7 @@ let run_keeper_cycle
               ~config
               ~meta
               ~generation
-              ~cascade_name:effective_cascade_runtime_name
+              ~runtime_name:effective_cascade_runtime_name
               ~outcome:`Ok
               ~terminal_reason_code:"pre_dispatch_success"
               ~activity_kind:"keeper.turn_pre_dispatch_ok"
@@ -521,7 +521,7 @@ let run_keeper_cycle
                           ~registry_base_path
                           ~degraded_retry_slot_phase_budget_sec
                           ~record_streaming_cancelled_observation
-                          ~cascade_name_of_meta
+                          ~runtime_name_of_meta
                           ~start_background_turn_event_bus_drain
                     )
                  with
@@ -665,12 +665,12 @@ let run_keeper_cycle
                          match Keeper_turn_driver.classify_masc_internal_error err with
                          | Some
                              (Keeper_turn_driver.Cascade_exhausted
-                                { cascade_name
+                                { runtime_name
                                 ; reason = Keeper_meta_contract.No_tool_capable _
                                 ; _
                                 }) ->
                            Keeper_turn_fsm.Failure_no_tool_capable_provider
-                             { cascade_name = cascade_name
+                             { runtime_name = runtime_name
                              ; detail = short_preview e_str
                              }
                          | _ ->
@@ -691,7 +691,7 @@ let run_keeper_cycle
                     "%s: keeper cycle FAILED cascade=%s max_context=%d context_budget=%d \
                      primary_budget=%d requested_override=%s latency=%dms%s error=%s"
                     meta.name
-                    (final_execution.cascade_name)
+                    (final_execution.runtime_name)
                     final_execution.max_context
                     final_execution.max_context_resolution.effective_budget
                     final_execution.max_context_resolution.primary_budget

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -224,7 +224,7 @@ val record_streaming_cancelled_observation
   :  config:Coord.config
   -> run_meta:Keeper_meta_contract.keeper_meta
   -> run_generation:int
-  -> cascade_name:string
+  -> runtime_name:string
   -> keeper_turn_id:int
   -> unit
   -> unit

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -82,8 +82,8 @@ let run (ctx : ctx)
       ~(user_message : string)
       ~(registry_base_path : string)
       ~(degraded_retry_slot_phase_budget_sec : float)
-      ~(record_streaming_cancelled_observation : config:Coord.config -> run_meta:keeper_meta -> run_generation:int -> cascade_name:string -> keeper_turn_id:int -> unit -> unit)
-      ~(cascade_name_of_meta : keeper_meta -> string)
+      ~(record_streaming_cancelled_observation : config:Coord.config -> run_meta:keeper_meta -> run_generation:int -> runtime_name:string -> keeper_turn_id:int -> unit -> unit)
+      ~(runtime_name_of_meta : keeper_meta -> string)
       ~(start_background_turn_event_bus_drain : clock:float Eio.Time.clock_ty Eio.Resource.t -> unit)
   : (Keeper_agent_run.run_result, Agent_sdk.Error.sdk_error) result
 =
@@ -134,7 +134,7 @@ let run (ctx : ctx)
     Otel_genai.with_keeper_turn_span
       ~keeper_name:run_meta.name
       ~agent_name:run_meta.agent_name
-      ~cascade_name:execution.cascade_name
+      ~runtime_name:execution.runtime_name
       ~trace_id:
         (Keeper_id.Trace_id.to_string run_meta.runtime.trace_id)
       ~generation:run_generation
@@ -165,7 +165,7 @@ let run (ctx : ctx)
                ~config
                ~run_meta
                ~run_generation
-               ~cascade_name:execution.cascade_name
+               ~runtime_name:execution.runtime_name
                ~keeper_turn_id
                ())
            ~run:(fun () ->
@@ -176,7 +176,7 @@ let run (ctx : ctx)
                ~max_context:execution.max_context
                ~build_turn_prompt
                ~user_message
-               ~cascade_name:execution.cascade_name
+               ~runtime_name:execution.runtime_name
                ~world_observation:observation
                ~turn_affordances
                ?provider_filter:
@@ -224,7 +224,7 @@ let run (ctx : ctx)
       input
     in
     let execution_cascade_name =
-      execution.cascade_name
+      execution.runtime_name
     in
     let mark_terminal_error err =
       match EC.extract_input_required err with
@@ -478,7 +478,7 @@ let run (ctx : ctx)
       else (
         match
           next_fail_open_cascade_for_turn_with_budget
-            ~base_cascade:(cascade_name_of_meta meta)
+            ~base_cascade:(runtime_name_of_meta meta)
             ~effective_cascade:execution_cascade_name
             ~tool_requirement:initial_tool_requirement
             ~attempted_cascades
@@ -495,11 +495,11 @@ let run (ctx : ctx)
              .build_cascade_execution
                ~meta
                ~profile_defaults
-               ~cascade_name:
+               ~runtime_name:
                  (* RFC-0206: raw runtime id (no prefix validation); keep the
                     empty→fallback behaviour only. *)
                  (if String.trim degraded_retry.next_cascade = ""
-                  then execution.cascade_name
+                  then execution.runtime_name
                   else degraded_retry.next_cascade)
            with
            | Error fail_open_err ->
@@ -511,7 +511,7 @@ let run (ctx : ctx)
                  Keeper_execution_receipt.Retry_setup_failed
                ~productive_phase_elapsed_ms
                ?retry_phase_elapsed_ms
-               ~from_cascade:execution.cascade_name
+               ~from_cascade:execution.runtime_name
                ~retry:degraded_retry
                ~outcome:
                  Keeper_execution_receipt.Rotation_setup_failed
@@ -531,7 +531,7 @@ let run (ctx : ctx)
              Error fail_open_err
            | Ok next_execution ->
              let next_execution_cascade_name =
-               next_execution.cascade_name
+               next_execution.runtime_name
              in
              if Option.is_none !retry_phase_started_at
              then retry_phase_started_at := Some (Eio.Time.now clock);
@@ -549,7 +549,7 @@ let run (ctx : ctx)
                ?slot_release_at_phase
                ~productive_phase_elapsed_ms
                ?retry_phase_elapsed_ms
-               ~from_cascade:execution.cascade_name
+               ~from_cascade:execution.runtime_name
                ~retry:degraded_retry
                ~outcome:
                  Keeper_execution_receipt.Rotation_retry_scheduled
@@ -628,7 +628,7 @@ let run (ctx : ctx)
               Keeper_execution_receipt.Retry_budget_exhausted
             ~productive_phase_elapsed_ms
             ?retry_phase_elapsed_ms
-            ~from_cascade:execution.cascade_name
+            ~from_cascade:execution.runtime_name
             ~retry:degraded_retry
             ~outcome:
               Keeper_execution_receipt.Rotation_budget_exhausted
@@ -656,7 +656,7 @@ let run (ctx : ctx)
               Keeper_execution_receipt.Productive_phase_exhausted
             ~productive_phase_elapsed_ms
             ?retry_phase_elapsed_ms
-            ~from_cascade:execution.cascade_name
+            ~from_cascade:execution.runtime_name
             ~retry:degraded_retry
             ~outcome:
               Keeper_execution_receipt.Rotation_slot_phase_exhausted
@@ -764,7 +764,7 @@ let run (ctx : ctx)
         ; is_retry = false
         ; allow_degraded_wall_clock_retry_budget = false
         ; attempted_cascades =
-            [ initial_execution.cascade_name
+            [ initial_execution.runtime_name
             ]
         })
   with

--- a/lib/keeper/keeper_unified_turn_livelock_block.ml
+++ b/lib/keeper/keeper_unified_turn_livelock_block.ml
@@ -107,7 +107,7 @@ let handle
     ~config
     ~meta
     ~generation
-    ~cascade_name:initial_execution.cascade_name
+    ~runtime_name:initial_execution.runtime_name
     (* "blocked" is not in the outcome_kind quad-state, so this maps to error.
        The specific reason is retained in terminal_reason_code. *)
     ~outcome:`Error

--- a/lib/keeper/keeper_unified_turn_phase_gate.ml
+++ b/lib/keeper/keeper_unified_turn_phase_gate.ml
@@ -52,8 +52,8 @@ let decide_and_record
       ~config
       ~meta
       ~generation
-      ~cascade_name:
-        (           (cascade_name_of_meta meta))
+      ~runtime_name:
+        (           (runtime_name_of_meta meta))
       ~outcome:`Cancelled
       ~terminal_reason_code:"supervisor_stop"
       ~activity_kind:"keeper.turn_cancelled"
@@ -92,8 +92,8 @@ let decide_and_record
         ~config
         ~meta
         ~generation
-        ~cascade_name:
-          (             (cascade_name_of_meta meta))
+        ~runtime_name:
+          (             (runtime_name_of_meta meta))
         ~outcome:`Skipped
         ~terminal_reason_code
         ~activity_kind:"keeper.turn_skipped"
@@ -128,8 +128,8 @@ let decide_and_record
         ~config
         ~meta
         ~generation
-        ~cascade_name:
-          (             (cascade_name_of_meta meta))
+        ~runtime_name:
+          (             (runtime_name_of_meta meta))
         ~outcome:`Error
         ~terminal_reason_code
         ~activity_kind:"keeper.turn_blocked"

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -27,7 +27,7 @@ let resolve_unified_max_tokens_fallback
 let build_cascade_execution
       ~(meta : keeper_meta)
       ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
-      ~(cascade_name : string)
+      ~(runtime_name : string)
   : ( Keeper_turn_cascade_budget.cascade_execution
     , Agent_sdk.Error.sdk_error )
     result
@@ -55,12 +55,12 @@ let build_cascade_execution
        in
        let temperature =
          Cascade_inference.resolve_temperature
-           ~cascade_name
+           ~runtime_name
            ~fallback:Keeper_config.keeper_unified_temperature
        in
        let raw_max_tokens =
          Cascade_inference.resolve_max_tokens
-           ~cascade_name
+           ~runtime_name
            ~fallback:
              (resolve_unified_max_tokens_fallback
                 ~meta_name:meta.name
@@ -71,7 +71,7 @@ let build_cascade_execution
        in
        (match
           Cascade_inference.validate_max_tokens_within_ceiling
-            ~cascade_name
+            ~runtime_name
             ~provider_ceiling:max_output_ceiling
             raw_max_tokens
         with
@@ -80,7 +80,7 @@ let build_cascade_execution
             (Keeper_meta_contract.sdk_error_of_masc_internal_error err)
         | Ok max_tokens ->
           Ok
-            { Keeper_turn_cascade_budget.cascade_name
+            { Keeper_turn_cascade_budget.runtime_name
             ; max_context_resolution
             ; max_context
             ; temperature

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.mli
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.mli
@@ -15,7 +15,7 @@
 val build_cascade_execution
   :  meta:Keeper_meta_contract.keeper_meta
   -> profile_defaults:Keeper_types_profile.keeper_profile_defaults
-  -> cascade_name:string
+  -> runtime_name:string
   -> ( Keeper_turn_cascade_budget.cascade_execution
      , Agent_sdk.Error.sdk_error )
      result

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -119,7 +119,7 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
   (* No_tool_capable specific cases first — more specific than generic Cascade_exhausted *)
   | Some
       (Keeper_meta_contract.Cascade_exhausted
-         { cascade_name = ntcp_cascade_name
+         { runtime_name = ntcp_cascade_name
          ; reason = Keeper_meta_contract.No_tool_capable (Some detail)
          ; _
          }) ->
@@ -150,11 +150,11 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
                rejection_summary
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = Some (ntcp_cascade_name)
+         ; runtime_name = Some (ntcp_cascade_name)
          })
   | Some
       (Keeper_meta_contract.Cascade_exhausted
-         { cascade_name = ntcp_cascade_name
+         { runtime_name = ntcp_cascade_name
          ; reason = Keeper_meta_contract.No_tool_capable None
          ; _
          }) ->
@@ -164,17 +164,17 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; detail = "no tool-capable provider found"
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = Some (ntcp_cascade_name)
+         ; runtime_name = Some (ntcp_cascade_name)
          })
   (* Generic Cascade_exhausted catch-all — after No_tool_capable specifics *)
-  | Some (Keeper_meta_contract.Cascade_exhausted { reason; cascade_name }) ->
+  | Some (Keeper_meta_contract.Cascade_exhausted { reason; runtime_name }) ->
     Some
       (Keeper_registry.Provider_runtime_error
          { code = cascade_exhaustion_reason_code reason
          ; detail
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = Some (cascade_name)
+         ; runtime_name = Some (runtime_name)
          })
   | Some (Keeper_meta_contract.Capacity_backpressure { detail = capacity_detail; _ }) ->
     Some
@@ -183,7 +183,7 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; detail = capacity_detail
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = None
+         ; runtime_name = None
          })
   | Some
       ( Keeper_meta_contract.Resumable_cli_session _
@@ -239,7 +239,7 @@ let registry_failure_reason_of_terminal_reason
          ; detail
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = None
+         ; runtime_name = None
          })
   | Keeper_turn_disposition.Cascade_attempts_exhausted ->
     Some
@@ -248,7 +248,7 @@ let registry_failure_reason_of_terminal_reason
          ; detail
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = None
+         ; runtime_name = None
          })
   | Keeper_turn_disposition.Success
   | Keeper_turn_disposition.External_cancel
@@ -380,7 +380,7 @@ let record_streaming_cancelled_observation
       ~(config : Coord.config)
       ~(run_meta : Keeper_meta_contract.keeper_meta)
       ~(run_generation : int)
-      ~(cascade_name : string)
+      ~(runtime_name : string)
       ~(keeper_turn_id : int)
       ()
   : unit
@@ -406,7 +406,7 @@ let record_streaming_cancelled_observation
     ~config
     ~meta:run_meta
     ~generation:run_generation
-    ~cascade_name
+    ~runtime_name
     ~outcome:`Cancelled
     ~terminal_reason_code
     ~activity_kind:"keeper.turn_cancelled"

--- a/lib/keeper/keeper_unified_turn_types.mli
+++ b/lib/keeper/keeper_unified_turn_types.mli
@@ -79,7 +79,7 @@ val record_streaming_cancelled_observation :
   config:Coord.config ->
   run_meta:Keeper_meta_contract.keeper_meta ->
   run_generation:int ->
-  cascade_name:string ->
+  runtime_name:string ->
   keeper_turn_id:int ->
   unit ->
   unit

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -763,20 +763,20 @@ let keeper_cycle_decision
                   || backlog_elapsed
                   || (idle_gate_elapsed && cooldown_elapsed)))
         in
-        let cascade_name = cascade_name_of_meta meta in
+        let runtime_name = runtime_name_of_meta meta in
         let provider_cooldown_remaining_sec =
           if should_run
           then
             provider_cooldown_remaining_sec
-              ~cascade_name:(cascade_name)
+              ~runtime_name:(runtime_name)
           else None
         in
         let provider_cooldown_fail_open =
           match provider_cooldown_remaining_sec with
           | Some _ ->
             fallback_cascade_for_provider_cooldown
-              ~base_cascade:cascade_name
-              ~effective_cascade:cascade_name
+              ~base_cascade:runtime_name
+              ~effective_cascade:runtime_name
           | None -> None
         in
         let verdict =

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -271,11 +271,11 @@ val effective_scheduled_autonomous_cooldown :
   ?consecutive_noop_count:int -> unit -> int
 
 val provider_cooldown_remaining_sec_for_cascade :
-  cascade_name:string -> int option
+  runtime_name:string -> int option
 
 val provider_capacity_blocked_task_count :
   ?provider_cooldown_remaining_sec:
-    (cascade_name:string -> int option) ->
+    (runtime_name:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta ->
   claimable_task_count:int ->
   unit ->
@@ -294,12 +294,12 @@ val should_inject_entropic_oscillation :
 
 val keeper_cycle_decision :
   ?provider_cooldown_remaining_sec:
-    (cascade_name:string -> int option) ->
+    (runtime_name:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> keeper_cycle_decision
 
 val unified_turn_decision :
   ?provider_cooldown_remaining_sec:
-    (cascade_name:string -> int option) ->
+    (runtime_name:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> keeper_cycle_decision
 
 val should_run_keeper_cycle :

--- a/lib/keeper/keeper_world_observation_provider_cooldown.ml
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.ml
@@ -20,16 +20,16 @@ let fallback_cascade_for_provider_cooldown
   in
   if not (String.equal normalized_effective normalized_base)
   then Some normalized_base
-  else if String.equal normalized_effective (Keeper_config.default_cascade_name ())
+  else if String.equal normalized_effective (Keeper_config.default_runtime_name ())
   then None
-  else Some (Keeper_config.default_cascade_name ())
+  else Some (Keeper_config.default_runtime_name ())
 
 let provider_cooldown_remaining_sec_for_cascade
-      ~(cascade_name : string)
+      ~(runtime_name : string)
   : int option
   =
   let runtime_health_keys =
-    Provider_runtime_projection.default_execution_model_strings cascade_name
+    Provider_runtime_projection.default_execution_model_strings runtime_name
     |> Cascade_runtime_candidate.runtime_health_keys_of_labels
   in
   match runtime_health_keys with
@@ -72,15 +72,15 @@ let provider_capacity_blocked_task_count
   if claimable_task_count <= 0
   then 0
   else (
-    let cascade_name = cascade_name_of_meta meta in
+    let runtime_name = runtime_name_of_meta meta in
     match
       provider_cooldown_remaining_sec
-        ~cascade_name:(cascade_name)
+        ~runtime_name:(runtime_name)
     with
     | Some _
       when Option.is_none
              (fallback_cascade_for_provider_cooldown
-                ~base_cascade:cascade_name
-                ~effective_cascade:cascade_name) ->
+                ~base_cascade:runtime_name
+                ~effective_cascade:runtime_name) ->
       claimable_task_count
     | Some _ | None -> 0)

--- a/lib/keeper/keeper_world_observation_provider_cooldown.mli
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.mli
@@ -4,10 +4,10 @@ val fallback_cascade_for_provider_cooldown :
   string option
 
 val provider_cooldown_remaining_sec_for_cascade :
-  cascade_name:string -> int option
+  runtime_name:string -> int option
 
 val provider_capacity_blocked_task_count :
-  ?provider_cooldown_remaining_sec:(cascade_name:string -> int option) ->
+  ?provider_cooldown_remaining_sec:(runtime_name:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta ->
   claimable_task_count:int ->
   unit ->

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -257,7 +257,7 @@ let runtime_mcp_keeper_log_context_of_entry
     visible_tool_count = Some (List.length allowed_tool_names);
     required_tools = Some required_tools;
     missing_required_tools = Some missing_required_tools;
-    cascade_profile = Some (Keeper_meta_contract.cascade_name_of_meta entry.meta);
+    cascade_profile = Some (Keeper_meta_contract.runtime_name_of_meta entry.meta);
   }
 
 let runtime_mcp_keeper_error_preview message =

--- a/lib/model_inference_metrics_entry.ml
+++ b/lib/model_inference_metrics_entry.ml
@@ -193,8 +193,8 @@ type parse_error =
   | Out_of_window                  (* ts_unix older than [since_unix] *)
   | No_telemetry_object            (* decisions.jsonl entry without telemetry { ... } *)
   | Missing_outcome                (* telemetry.outcome absent on success-branch row *)
-  | Missing_success_model          (* no selected_model / model_used / cascade_name *)
-  | Missing_error_model_attribution (* no candidate_models / cascade_name on error turn *)
+  | Missing_success_model          (* no selected_model / model_used / runtime_name *)
+  | Missing_error_model_attribution (* no candidate_models / runtime_name on error turn *)
   | Missing_cost_model             (* costs.jsonl row without "model" field *)
 
 let parse_error_label = function

--- a/lib/model_inference_metrics_parser.ml
+++ b/lib/model_inference_metrics_parser.ml
@@ -39,9 +39,9 @@ let private_provider_hint_of_fields (fields : (string * Yojson.Safe.t) list) =
 ;;
 
 let cascade_model_attribution_of_fields (fields : (string * Yojson.Safe.t) list) =
-  match json_string_field_opt "cascade_name" fields with
-  | Some cascade_name ->
-    Some ((fun s -> s) cascade_name ^ " (cascade)")
+  match json_string_field_opt "runtime_name" fields with
+  | Some runtime_name ->
+    Some ((fun s -> s) runtime_name ^ " (cascade)")
   | None -> None
 ;;
 
@@ -112,7 +112,7 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
          in
          if is_error
          then (
-           (* Error turns: first candidate model or cascade_name. No silent
+           (* Error turns: first candidate model or runtime_name. No silent
               [__error__] sentinel — refuse the row so caller sees the
               attribution gap typed. *)
            let model_result : (string, parse_error) result =

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -237,7 +237,7 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
         | None -> Ok ()
         | Some _ ->
             Error
-              "legacy keeper model args removed for masc_keeper_msg: models. Use cascade_name; concrete provider/model identity is OAS-owned."
+              "legacy keeper model args removed for masc_keeper_msg: models. Use runtime_name; concrete provider/model identity is OAS-owned."
       in
       let direct_reply =
         Json_util.get_bool request.payload "direct_reply" |> Option.value ~default:false

--- a/lib/operator/operator_control_snapshot_identity_fields.ml
+++ b/lib/operator/operator_control_snapshot_identity_fields.ml
@@ -12,23 +12,23 @@ let non_empty_trimmed_string_opt value =
 ;;
 
 let keeper_runtime_identity_fields (meta : Keeper_meta_contract.keeper_meta) =
-  let cascade_name = Keeper_meta_contract.cascade_name_of_meta meta in
+  let runtime_name = Keeper_meta_contract.runtime_name_of_meta meta in
   let cascade_name_json =
-    Json_util.string_opt_to_json (non_empty_trimmed_string_opt cascade_name)
+    Json_util.string_opt_to_json (non_empty_trimmed_string_opt runtime_name)
   in
   (* RFC-0149 §3.3 — use the Result-returning resolver so an unresolved
      cascade surfaces as the original input on the canonical fields
      (matching the degraded-fallback shape below) instead of the silent
      [Keeper_turn] default the legacy [resolve_live] would have written. *)
   let canonical_json =
-    match Keeper_cascade_profile.resolve_live_result cascade_name with
+    match Keeper_cascade_profile.resolve_live_result runtime_name with
     | Ok runtime ->
       `String (runtime)
     | Error (`Unresolved _) -> cascade_name_json
   in
-  [ "cascade_name", cascade_name_json
-  ; "cascade_canonical", canonical_json
-  ; "selected_cascade_canonical", canonical_json
+  [ "runtime_name", cascade_name_json
+  ; "runtime_canonical", canonical_json
+  ; "selected_runtime_canonical", canonical_json
   ; "primary_model", `Null
   ; "active_model", `Null
   ; "active_model_label", `Null
@@ -37,11 +37,11 @@ let keeper_runtime_identity_fields (meta : Keeper_meta_contract.keeper_meta) =
 ;;
 
 let degraded_keeper_runtime_identity_fields (meta : Keeper_meta_contract.keeper_meta) =
-  let cascade_name = non_empty_trimmed_string_opt (Keeper_meta_contract.cascade_name_of_meta meta) in
-  let cascade_json = Json_util.string_opt_to_json cascade_name in
-  [ "cascade_name", cascade_json
-  ; "cascade_canonical", cascade_json
-  ; "selected_cascade_canonical", cascade_json
+  let runtime_name = non_empty_trimmed_string_opt (Keeper_meta_contract.runtime_name_of_meta meta) in
+  let cascade_json = Json_util.string_opt_to_json runtime_name in
+  [ "runtime_name", cascade_json
+  ; "runtime_canonical", cascade_json
+  ; "selected_runtime_canonical", cascade_json
   ; "primary_model", `Null
   ; "active_model", `Null
   ; "active_model_label", `Null

--- a/lib/operator/operator_control_snapshot_persistent_agents.ml
+++ b/lib/operator/operator_control_snapshot_persistent_agents.ml
@@ -56,10 +56,10 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
                  ; "active_model", field_or_null "active_model"
                  ; "active_model_label", field_or_null "active_model_label"
                  ; "last_model_used_label", field_or_null "last_model_used_label"
-                 ; "cascade_name", field_or_null "cascade_name"
-                 ; "cascade_canonical", field_or_null "cascade_canonical"
-                 ; ( "selected_cascade_canonical"
-                   , field_or_null "selected_cascade_canonical" )
+                 ; "runtime_name", field_or_null "runtime_name"
+                 ; "runtime_canonical", field_or_null "runtime_canonical"
+                 ; ( "selected_runtime_canonical"
+                   , field_or_null "selected_runtime_canonical" )
                  ; "primary_model", field_or_null "primary_model"
                  ; "next_model_hint", field_or_null "next_model_hint"
                  ; "active_goal_ids", field_or_null "active_goal_ids"

--- a/lib/operator/operator_control_snapshot_trust.ml
+++ b/lib/operator/operator_control_snapshot_trust.ml
@@ -72,11 +72,11 @@ let project_compact_runtime_trust runtime_trust =
 ;;
 
 let degraded_keeper_runtime_identity_fields (meta : Keeper_meta_contract.keeper_meta) =
-  let cascade_name = non_empty_trimmed_string_opt (Keeper_meta_contract.cascade_name_of_meta meta) in
-  let cascade_json = Json_util.string_opt_to_json cascade_name in
-  [ "cascade_name", cascade_json
-  ; "cascade_canonical", cascade_json
-  ; "selected_cascade_canonical", cascade_json
+  let runtime_name = non_empty_trimmed_string_opt (Keeper_meta_contract.runtime_name_of_meta meta) in
+  let cascade_json = Json_util.string_opt_to_json runtime_name in
+  [ "runtime_name", cascade_json
+  ; "runtime_canonical", cascade_json
+  ; "selected_runtime_canonical", cascade_json
   ; "primary_model", `Null
   ; "active_model", `Null
   ; "active_model_label", `Null

--- a/lib/otel/otel_genai.ml
+++ b/lib/otel/otel_genai.ml
@@ -73,7 +73,7 @@ let keeper_turn_span_name ~keeper_name = "invoke_agent " ^ keeper_name
 let keeper_turn_attrs
       ~keeper_name
       ~agent_name
-      ~cascade_name
+      ~runtime_name
       ~trace_id
       ~generation
       ~max_context
@@ -83,7 +83,7 @@ let keeper_turn_attrs
       ~is_retry
       ~current_task_id
   =
-  let cascade_name = cascade_name in
+  let runtime_name = runtime_name in
   let optional_attrs =
     match current_task_id with
     | None -> []
@@ -104,7 +104,7 @@ let keeper_turn_attrs
   ; Attr_key.gen_ai_agent_id, `String agent_name
   ; Attr_key.gen_ai_conversation_id, `String trace_id
   ; Attr_key.masc_gen_ai_keeper_name, `String keeper_name
-  ; Attr_key.masc_gen_ai_cascade_name, `String cascade_name
+  ; Attr_key.masc_gen_ai_cascade_name, `String runtime_name
   ]
   @ optional_attrs
 ;;
@@ -118,7 +118,7 @@ let tool_execution_attrs ~tool_name =
 let with_keeper_turn_span
       ~keeper_name
       ~agent_name
-      ~cascade_name
+      ~runtime_name
       ~trace_id
       ~generation
       ~max_context
@@ -136,7 +136,7 @@ let with_keeper_turn_span
       keeper_turn_attrs
         ~keeper_name
         ~agent_name
-        ~cascade_name
+        ~runtime_name
         ~trace_id
         ~generation
         ~max_context

--- a/lib/otel/otel_genai.mli
+++ b/lib/otel/otel_genai.mli
@@ -42,7 +42,7 @@ val keeper_turn_span_name : keeper_name:string -> string
 val keeper_turn_attrs
   :  keeper_name:string
   -> agent_name:string
-  -> cascade_name:string
+  -> runtime_name:string
   -> trace_id:string
   -> generation:int
   -> max_context:int
@@ -58,7 +58,7 @@ val tool_execution_attrs : tool_name:string -> attr list
 val with_keeper_turn_span
   :  keeper_name:string
   -> agent_name:string
-  -> cascade_name:string
+  -> runtime_name:string
   -> trace_id:string
   -> generation:int
   -> max_context:int

--- a/lib/provider_runtime_projection.ml
+++ b/lib/provider_runtime_projection.ml
@@ -278,6 +278,6 @@ let default_execution_model_strings _cascade_name =
   | labels -> labels
 ;;
 
-let default_execution_model_strings_result cascade_name =
-  Ok (default_execution_model_strings cascade_name)
+let default_execution_model_strings_result runtime_name =
+  Ok (default_execution_model_strings runtime_name)
 ;;

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1,6 +1,6 @@
 (** Runtime = Provider + Model + Spec(binding).
 
-    cascade→Runtime 전환 (RFC-0206). cascade 의 routes/cascade_name/tier/profile
+    cascade→Runtime 전환 (RFC-0206). cascade 의 routes/runtime_name/tier/profile
     간접 레이어를 제거하고, binding(provider × model) 하나를 곧 하나의 Runtime
     으로 본다. 소비자는 Runtime 목록 + default Runtime 을 직접 소비한다.
 

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -1,6 +1,6 @@
 (** Runtime = Provider + Model + Spec(binding).
 
-    cascade→Runtime 전환 (RFC-0206). cascade 의 routes/cascade_name/tier/profile
+    cascade→Runtime 전환 (RFC-0206). cascade 의 routes/runtime_name/tier/profile
     간접 레이어를 제거하고, binding(provider × model) 하나를 곧 하나의 Runtime
     으로 본다. 소비자는 Runtime 목록 + default Runtime 을 직접 소비한다.
     타입은 자립 모듈 {!Runtime_schema} 소유. *)

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -10,8 +10,8 @@
 
 let default_config_path = Runtime.config_path
 
-let default_model_strings ~cascade_name =
-  Provider_runtime_projection.default_execution_model_strings cascade_name
+let default_model_strings ~runtime_name =
+  Provider_runtime_projection.default_execution_model_strings runtime_name
 
 (* Named model execution *)
 
@@ -36,7 +36,7 @@ let eio_context_error_to_sdk_error detail =
 
 let cascade_catalog_error_to_sdk_error detail =
   Agent_sdk.Error.Config
-    (Agent_sdk.Error.InvalidConfig { field = "cascade_name"; detail })
+    (Agent_sdk.Error.InvalidConfig { field = "runtime_name"; detail })
 
 (** Resolve cascade provider configs via MASC Cascade_config.
     Returns Provider_config.t list for the downstream OAS runtime,
@@ -46,7 +46,7 @@ let resolve_cascade_providers
       ?(require_tool_choice_support = false)
       ?(require_tool_support = false)
       ?runtime_mcp_policy
-      ~cascade_name:_
+      ~runtime_name:_
       ()
   =
   (* RFC-0206 single-binding: cascade catalog resolution removed. The providers

--- a/lib/runtime/runtime_oas_runner.mli
+++ b/lib/runtime/runtime_oas_runner.mli
@@ -12,7 +12,7 @@
 val default_config_path : unit -> string option
 (** Alias for [Runtime.config_path]. *)
 
-val default_model_strings : cascade_name:string -> string list
+val default_model_strings : runtime_name:string -> string list
 (** Alias for [Cascade_runtime.default_model_strings]. *)
 
 (** {1 Eio context validation} *)
@@ -30,7 +30,7 @@ val eio_context_error_to_sdk_error : string -> Agent_sdk.Error.sdk_error
 
 val cascade_catalog_error_to_sdk_error : string -> Agent_sdk.Error.sdk_error
 (** Lift a cascade-catalog diagnostic into an [Agent_sdk.Error.Config]
-    error with field ["cascade_name"]. *)
+    error with field ["runtime_name"]. *)
 
 (** {1 Provider resolution} *)
 
@@ -39,7 +39,7 @@ val resolve_cascade_providers :
   ?require_tool_choice_support:bool ->
   ?require_tool_support:bool ->
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
-  cascade_name:string -> unit ->
+  runtime_name:string -> unit ->
   (Llm_provider.Provider_config.t list, string) result
 (** Resolve cascade provider configs via MASC Cascade_config. *)
 

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -135,8 +135,8 @@ let composite_config_drift_json ~config ~keeper_name =
   | Ok (Some meta) ->
     let sources = Keeper_status_bridge.source_provenance_json config meta in
     let override_fields = Json_util.get_string_list sources "override_fields" in
-    let cascade_detail = find_override_field_source "model.cascade_name" sources in
-    let default_cascade_name, live_cascade_name =
+    let cascade_detail = find_override_field_source "model.runtime_name" sources in
+    let default_runtime_name, live_cascade_name =
       match cascade_detail with
       | Some detail ->
         Json_util.get_string detail "default_value",
@@ -149,7 +149,7 @@ let composite_config_drift_json ~config ~keeper_name =
       ; "status", `String (if cascade_override then "drift" else "ok")
       ; "cascade_override", `Bool cascade_override
       ; "override_fields", Json_util.json_string_list override_fields
-      ; "default_cascade_name", Json_util.string_opt_to_json default_cascade_name
+      ; "default_runtime_name", Json_util.string_opt_to_json default_runtime_name
       ; "live_cascade_name", Json_util.string_opt_to_json live_cascade_name
       ; "active_config_root", Json_util.string_opt_to_json (json_string "active_config_root" sources)
       ]
@@ -159,7 +159,7 @@ let composite_config_drift_json ~config ~keeper_name =
       ; "status", `String "keeper_missing"
       ; "cascade_override", `Bool false
       ; "override_fields", `List []
-      ; "default_cascade_name", `Null
+      ; "default_runtime_name", `Null
       ; "live_cascade_name", `Null
       ; "active_config_root", `Null
       ]
@@ -170,7 +170,7 @@ let composite_config_drift_json ~config ~keeper_name =
       ; "error", `String message
       ; "cascade_override", `Bool false
       ; "override_fields", `List []
-      ; "default_cascade_name", `Null
+      ; "default_runtime_name", `Null
       ; "live_cascade_name", `Null
       ; "active_config_root", `Null
       ]

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -506,7 +506,7 @@ let handle_keeper_get_subroutes state req request reqd =
         | Ok (Some m) ->
           let routing =
             Keeper_cascade_routing.select_cascade
-              ~base_cascade:(Keeper_meta_contract.cascade_name_of_meta m) ~phase:current
+              ~base_cascade:(Keeper_meta_contract.runtime_name_of_meta m) ~phase:current
           in
           let models = [ "candidate" ] in
           let provider_health = [] in

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -148,7 +148,7 @@ let provider_attempt_row_json (row : Keeper_runtime_manifest.t) =
     [
       ("ts", `String row.ts);
       ("event", `String (Keeper_runtime_manifest.event_kind_to_string row.event));
-      ("cascade_name", Json_util.string_opt_to_json row.cascade_name);
+      ("runtime_name", Json_util.string_opt_to_json row.runtime_name);
       ("model_source", Json_util.string_opt_to_json (decision_string "model_source"));
       ( "resolved_model_source",
         Json_util.string_opt_to_json (decision_string "resolved_model_source") );

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
@@ -151,7 +151,7 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
                Some
                  (Printf.sprintf "default=%s live=%s"
                     (Option.value
-                       (Json_util.get_string config_drift "default_cascade_name")
+                       (Json_util.get_string config_drift "default_runtime_name")
                        ~default:"unknown")
                     (Option.value
                        (Json_util.get_string config_drift "live_cascade_name")

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_summaries.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_summaries.ml
@@ -76,7 +76,7 @@ let config_drift_summary_json ~config ~keeper_name =
       ; ("has_live_override", `Bool false)
       ; ("cascade_override", `Bool false)
       ; ("override_fields", `List [])
-      ; ("default_cascade_name", `Null)
+      ; ("default_runtime_name", `Null)
       ; ("live_cascade_name", `Null)
       ; ("active_config_root", `Null)
       ; ("active_config_root_source", `Null)
@@ -89,7 +89,7 @@ let config_drift_summary_json ~config ~keeper_name =
       ; ("has_live_override", `Bool false)
       ; ("cascade_override", `Bool false)
       ; ("override_fields", `List [])
-      ; ("default_cascade_name", `Null)
+      ; ("default_runtime_name", `Null)
       ; ("live_cascade_name", `Null)
       ; ("active_config_root", `Null)
       ; ("active_config_root_source", `Null)
@@ -97,8 +97,8 @@ let config_drift_summary_json ~config ~keeper_name =
   | Ok (Some meta) ->
     let sources = Keeper_status_bridge.source_provenance_json config meta in
     let override_fields = Json_util.get_string_list sources "override_fields" in
-    let cascade_detail = find_override_field_source "model.cascade_name" sources in
-    let default_cascade_name, live_cascade_name =
+    let cascade_detail = find_override_field_source "model.runtime_name" sources in
+    let default_runtime_name, live_cascade_name =
       match cascade_detail with
       | Some detail ->
         ( Json_util.get_string detail "default_value",
@@ -117,7 +117,7 @@ let config_drift_summary_json ~config ~keeper_name =
                ~default:false) )
       ; ("cascade_override", `Bool cascade_override)
       ; ("override_fields", Json_util.json_string_list override_fields)
-      ; ("default_cascade_name", Json_util.string_opt_to_json default_cascade_name)
+      ; ("default_runtime_name", Json_util.string_opt_to_json default_runtime_name)
       ; ("live_cascade_name", Json_util.string_opt_to_json live_cascade_name)
       ; ( "active_config_root",
           Json_util.string_opt_to_json (Json_util.get_string sources "active_config_root") )

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -107,14 +107,14 @@ let route_keeper ~config ~sw ~clock ~keeper_name ~message : (string, string) res
     classification from the underlying [Agent_sdk.Error.t]. *)
 let route_cascade ~message ~system_prompt ~max_tokens ~temperature
   : (string, Openai_compat_error_map.t) result =
-  let cascade_name =
+  let runtime_name =
     Runtime.get_default_runtime_id ()
   in
   match
     Masc_oas_bridge.run_with_caller
       ~caller:Env_config_oas_bridge.Server_openai_compat (fun () ->
       Keeper_turn_driver.run_named
-        ~cascade_name
+        ~runtime_name
         ~goal:message
         ~system_prompt
         ~max_turns:1

--- a/lib/tool_deep_review.ml
+++ b/lib/tool_deep_review.ml
@@ -151,14 +151,14 @@ let handle_deep_review
         error_workflow_json ~tool_name ~start_time
           (`Assoc [ ("error", `String msg) ])
     | Ok prompt ->
-        let cascade_name =
+        let runtime_name =
           Runtime.get_default_runtime_id ()
         in
         match
           Masc_oas_bridge.run_with_caller
             ~caller:Env_config_oas_bridge.Tool_deep_review (fun () ->
             Keeper_turn_driver.run_named
-              ~cascade_name
+              ~runtime_name
               ~goal:prompt
               ~max_turns:1
               ~temperature:0.5

--- a/lib/tool_keeper_ops.ml
+++ b/lib/tool_keeper_ops.ml
@@ -290,7 +290,7 @@ let keeper_list_row_json ~runtime_class config name =
             ("proactive_idle_sec", `Int meta.proactive.idle_sec);
             ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);
             ("skill_route", keeper_list_skill_route_json config meta);
-            ("cascade_name", `String (Keeper_meta_contract.cascade_name_of_meta meta));
+            ("runtime_name", `String (Keeper_meta_contract.runtime_name_of_meta meta));
             ("created_at", `String meta.created_at); ("updated_at", `String meta.updated_at);
           ]
           @ Keeper_status_bridge.social_model_resolution_fields_json meta

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -92,12 +92,12 @@ let verify (req : Core.verification_request) : (Core.verdict, string) result =
           ~start_time
           (sprintf "Invalid verdict format: %s" msg)
     in
-    let cascade_name =
+    let runtime_name =
       Runtime.get_default_runtime_id ()
     in
     match
       Keeper_turn_driver_wrappers.run_named_with_masc_tools
-        ~cascade_name
+        ~runtime_name
         ~goal:prompt
         ~masc_tools:[ Core.report_verdict_schema ]
         ~dispatch


### PR DESCRIPTION
## 요약

RFC-0206 cascade→Runtime 마이그레이션의 일환으로, backend-frontend 전역에서 `cascade_*` 용어를 `runtime_*`로 mechanical rename합니다.

## 변경 범위

**159개 파일, +644/-644**

### JSON wire 필드명
- `"cascade_name"` → `"runtime_name"`
- `"cascade_canonical"` → `"runtime_canonical"`
- `"cascade_ref"` → `"runtime_ref"`
- `"selected_cascade_canonical"` → `"selected_runtime_canonical"`
- `"selected_cascade_name"` → `"selected_runtime_name"`

### OCaml
- 변수/record 필드: `cascade_name` → `runtime_name`
- 함수: `cascade_name_of_meta` → `runtime_name_of_meta`, `default_cascade_name` → `default_runtime_name`
- 대상: `lib/admission_queue.ml`, `lib/keeper/*.ml`, `lib/dashboard/*.ml`, `lib/operator/*.ml`, `lib/server/*.ml`, `lib/tool_keeper_ops.ml`, `lib/verifier_oas.ml`, `lib/runtime/*.ml` 등

### TypeScript
- 타입 필드: `Keeper.cascade_*` → `Keeper.runtime_*`, `KeeperConfigExecution.cascade_*` → `KeeperConfigExecution.runtime_*`
- 타입명: `CascadeRef` → `RuntimeRef`
- 함수: `normalizeCascadeRef` → `normalizeRuntimeRef`
- 대상: `types/core.ts`, `types/dashboard-execution.ts`, `keeper-store-normalize.ts`, `api/dashboard.ts`, `api/keeper.ts`, `components/keeper-*.ts` 등

### #19571 후속 타입 fix (bonus)
- `board.ts`: `asString`/`asNullableString` 반환값을 closed union에 할당하던 6곳에 타입 단언 추가
- `dashboard.ts`: `per_provider_timeout_mode` 파싱 타입 단언 추가

## 검증

- `tsc --noEmit`: cascade 관련 에러 0건 (남은 에러는 pre-existing / node_modules 누락)
- OCaml: mechanical rename이므로 컴파일러가 심볼 미스매치를 잡음

## 참고

- 현재 `origin/main`이 cascade 데몰리션 후 broken 상태이므로 CI의 dune 빌드 실패는 본 PR과 무관합니다.
- `fleet-fsm-matrix.ts`의 `no_cascade_before_measurement`는 FSM 메트릭 이름으로 필드 rename 범위 외입니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
