### PR TITLE
refactor(runtime): accept runtime id for keeper creation

### DIFF
--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -171,7 +171,7 @@ let goal_detail_keeper_json (detail : goal_detail_keeper) =
       ( "sandbox_profile",
         `String (Keeper_types_profile_sandbox.sandbox_profile_to_string meta.sandbox_profile) );
       ("network_mode", `String (Keeper_types_profile_sandbox.network_mode_to_string meta.network_mode));
-      ("cascade_name", `String (Keeper_meta_contract.cascade_name_of_meta meta));
+      ("runtime_id", `String (Keeper_meta_contract.cascade_name_of_meta meta));
       ( "approval_profile",
         Json_util.string_opt_to_json (Option.bind latest_receipt receipt_approval_profile) );
       ( "cascade_outcome",

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -249,7 +249,7 @@ let keeper_config_json (config : Coord.config) (name : string)
          canonical field surfaces as JSON [null] (parse-don't-validate
          honest signal) instead of the silent [Keeper_turn] rewrite the
          legacy [live_keeper_cascade_name] would produce. *)
-      let selected_cascade_canonical_json =
+      let selected_runtime_canonical_json =
         match live_keeper_cascade_name_result cascade_name with
         | Ok runtime ->
           `String (runtime)
@@ -257,9 +257,9 @@ let keeper_config_json (config : Coord.config) (name : string)
       in
       let execution =
         `Assoc [
-          ("selected_cascade_name", `String cascade_name);
-          ( "selected_cascade_canonical",
-            selected_cascade_canonical_json );
+          ("selected_runtime_id", `String cascade_name);
+          ( "selected_runtime_canonical",
+            selected_runtime_canonical_json );
           ("models", `List []);
           ("active_model", `Null);
           ("active_model_label", `Null);

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -735,7 +735,7 @@ let reject_legacy_model_args ~tool_name (args : Yojson.Safe.t) =
   | fields ->
     Error
       (Printf.sprintf
-         "legacy keeper model args removed for %s: %s. Use cascade_name; concrete \
+         "legacy keeper model args removed for %s: %s. Use runtime_id; concrete \
           provider/model identity is resolved from the default runtime."
          tool_name
          (String.concat ", " fields))

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -118,31 +118,50 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
     let pk_needs = personality.needs in
     let pk_desires = personality.desires in
     let pk_instructions = personality.instructions in
-    let pk_cascade_name =
+    let pk_cascade_name_result =
       (* RFC-0206: [runtime_id] is the canonical persisted/input name if a
          pre-scrub JSON payload still carries model-selection state.
-         [cascade_name] is accepted only as a legacy alias for older files. *)
-      match Safe_ops.json_string_opt "runtime_id" json with
-      | Some runtime_id when String.trim runtime_id <> "" -> String.trim runtime_id
-      | Some _ | None ->
-        Safe_ops.json_string ~default:(Keeper_config.default_cascade_name ()) "cascade_name" json
+         [cascade_name] is accepted only as a legacy alias for older files.
+         If both appear with different non-empty values, fail loud instead of
+         silently choosing one model-selection identity. *)
+      let runtime_id_opt =
+        Safe_ops.json_string_opt "runtime_id" json |> Option.map String.trim
+      in
+      let legacy_cascade_name_opt =
+        Safe_ops.json_string_opt "cascade_name" json |> Option.map String.trim
+      in
+      match runtime_id_opt, legacy_cascade_name_opt with
+      | Some runtime_id, Some legacy_cascade_name
+        when runtime_id <> "" && legacy_cascade_name <> ""
+             && runtime_id <> legacy_cascade_name ->
+        Error
+          (Printf.sprintf
+             "keeper meta parse error: runtime_id (%s) and legacy cascade_name (%s) \
+              disagree"
+             runtime_id legacy_cascade_name)
+      | Some runtime_id, _ when runtime_id <> "" -> Ok runtime_id
+      | _, Some legacy_cascade_name when legacy_cascade_name <> "" -> Ok legacy_cascade_name
+      | _ -> Ok (Keeper_config.default_cascade_name ())
     in
-    Ok
-      { pk_name
-      ; pk_agent_name
-      ; pk_trace_id
-      ; pk_trace_history
-      ; pk_goal
-      ; pk_short_goal
-      ; pk_mid_goal
-      ; pk_long_goal
-      ; pk_social_model
-      ; pk_cascade_name
-      ; pk_will
-      ; pk_needs
-      ; pk_desires
-      ; pk_instructions
-      }
+    (match pk_cascade_name_result with
+     | Error e -> Error e
+     | Ok pk_cascade_name ->
+       Ok
+         { pk_name
+         ; pk_agent_name
+         ; pk_trace_id
+         ; pk_trace_history
+         ; pk_goal
+         ; pk_short_goal
+         ; pk_mid_goal
+         ; pk_long_goal
+         ; pk_social_model
+         ; pk_cascade_name
+         ; pk_will
+         ; pk_needs
+         ; pk_desires
+         ; pk_instructions
+         })
 ;;
 
 (* Fail-loud sandbox policy field parsing.

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -119,10 +119,13 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
     let pk_desires = personality.desires in
     let pk_instructions = personality.instructions in
     let pk_cascade_name =
-      (* Preserve the raw cascade_name as persisted in runtime JSON so the
-       dashboard can distinguish "declared in TOML" from "canonicalized
-       fallback".  Downstream code canonicalizes at point-of-use. *)
-      Safe_ops.json_string ~default:(Keeper_config.default_cascade_name ()) "cascade_name" json
+      (* RFC-0206: [runtime_id] is the canonical persisted/input name if a
+         pre-scrub JSON payload still carries model-selection state.
+         [cascade_name] is accepted only as a legacy alias for older files. *)
+      match Safe_ops.json_string_opt "runtime_id" json with
+      | Some runtime_id when String.trim runtime_id <> "" -> String.trim runtime_id
+      | Some _ | None ->
+        Safe_ops.json_string ~default:(Keeper_config.default_cascade_name ()) "cascade_name" json
     in
     Ok
       { pk_name

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -14,7 +14,7 @@
    Keeper_meta_json -> Keeper_meta_json_scrub -> Keeper_meta_json. *)
 let config_field_names =
   [ "goal"; "short_goal"; "mid_goal"; "long_goal"
-  ; "social_model"; "cascade_name"
+  ; "social_model"; "runtime_id"; "cascade_name"
   ; "will"; "needs"; "desires"; "instructions"
   ; "sandbox_profile"; "sandbox_image"; "network_mode"; "allowed_paths"
   ; "tool_access"; "tool_denylist"

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -852,14 +852,20 @@ let handle_persona_generate ctx args =
       | Error msg ->
         Keeper_types_profile.tool_result_error (error_response_typed ~code:Validation_error msg)
       | Ok archetype_axes ->
-           let cascade_name =
-             get_string args "cascade_name" Archetypes.default_generation_cascade_name
-             |> String.trim
-           in
-           let cascade_name =
-             if cascade_name = ""
-             then Archetypes.default_generation_cascade_name
-             else cascade_name
+           let runtime_id =
+             let trimmed_arg key =
+               match get_string_opt args key with
+               | None -> None
+               | Some raw ->
+                 let value = String.trim raw in
+                 if value = "" then None else Some value
+             in
+             match trimmed_arg "runtime_id" with
+             | Some value -> value
+             | None ->
+               (match trimmed_arg "cascade_name" with
+                | Some value -> value
+                | None -> Archetypes.default_generation_cascade_name)
            in
            let temperature =
              get_float_opt args "temperature"
@@ -891,7 +897,7 @@ let handle_persona_generate ctx args =
                ~caller:Env_config_oas_bridge.Keeper_persona_authoring
                (fun () ->
                  Keeper_turn_driver.run_named
-                   ~cascade_name
+                   ~cascade_name:runtime_id
                    ~goal:prompt
                    ~max_turns:1
                    ~temperature

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -227,10 +227,10 @@ let field_catalog_entries =
         ~field_effect:"Optional social-model runtime for speech or ledger behavior."
         ()
     ; field_catalog_entry
-        ~path:"keeper.cascade_name"
+        ~path:"keeper.runtime_id"
         ~typ:"string"
         ~field_effect:
-          "Optional named cascade override. Must resolve to a known cascade at runtime."
+          "Optional runtime id override. Must resolve to a known runtime at runtime."
         ()
   ]
 ;;
@@ -366,7 +366,7 @@ let normalize_social_model raw =
          (String.concat ", " Keeper_types_profile.valid_social_model_strings))
 ;;
 
-let normalize_cascade_name raw =
+let normalize_runtime_id raw =
   let normalized = String.trim raw in
   let catalog =
     try Keeper_cascade_profile.catalog_names () with
@@ -382,7 +382,7 @@ let normalize_cascade_name raw =
   else
     Error
       (Printf.sprintf
-         "invalid keeper.cascade_name '%s' (known: %s)"
+         "invalid keeper.runtime_id '%s' (known: %s)"
          raw
          (String.concat ", " known))
 ;;
@@ -442,14 +442,24 @@ let normalize_keeper_json ~handle keeper_json =
               Result.map (fun value -> Some value) (normalize_social_model raw)
           in
           Result.bind social_model_result (fun social_model ->
-            let cascade_name_result =
-              match json_trimmed_string_opt "cascade_name" keeper_json with
-              | None -> Ok None
-              | Some raw ->
-                Result.map (fun value -> Some value) (normalize_cascade_name raw)
+            let runtime_id_result =
+              match
+                ( json_trimmed_string_opt "runtime_id" keeper_json
+                , json_trimmed_string_opt "cascade_name" keeper_json )
+              with
+              | Some runtime_id, Some legacy_cascade_name
+                when runtime_id <> legacy_cascade_name ->
+                Error
+                  (Printf.sprintf
+                     "keeper.runtime_id (%s) and legacy keeper.cascade_name (%s) must match"
+                     runtime_id
+                     legacy_cascade_name)
+              | Some raw, _ | None, Some raw ->
+                Result.map (fun value -> Some value) (normalize_runtime_id raw)
+              | None, None -> Ok None
             in
             Result.map
-              (fun cascade_name ->
+              (fun runtime_id ->
                  let mention_targets =
                    match json_string_list_normalized "mention_targets" keeper_json with
                    | [] -> [ handle ]
@@ -513,12 +523,12 @@ let normalize_keeper_json ~handle keeper_json =
                    | None -> assoc_without "social_model" fields
                  in
                  let fields =
-                   match cascade_name with
-                   | Some value -> assoc_set "cascade_name" (`String value) fields
-                   | None -> assoc_without "cascade_name" fields
+                   match runtime_id with
+                   | Some value -> assoc_set "runtime_id" (`String value) fields
+                   | None -> assoc_without "runtime_id" fields
                  in
                  `Assoc (List.rev fields))
-              cascade_name_result)))
+              runtime_id_result)))
   | other ->
     Error
       (Printf.sprintf

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -132,7 +132,7 @@ let apply_default_opt opt current = match opt with Some _ -> opt | None -> curre
 let invalid_profile_defaults_error ~keeper_name detail =
   if String_util.contains_substring detail "cascade_name" then
     Printf.sprintf
-      "invalid profile.cascade_name for keeper %s: unknown cascade_name: %s"
+      "invalid profile.runtime_id for keeper %s: unknown runtime_id: %s"
       keeper_name detail
   else
     Printf.sprintf "invalid keeper profile for keeper %s: %s" keeper_name detail
@@ -140,7 +140,7 @@ let invalid_profile_defaults_error ~keeper_name detail =
 let effective_declarative_cascade_name
     (defaults : Keeper_types_profile.keeper_profile_defaults)
     (meta : keeper_meta) =
-  (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model. *)
+  (* [runtime_id] is canonical; [model] remains the legacy storage slot. *)
   match defaults.model, defaults.manifest_path with
   | Some cascade_name, _ ->
       Keeper_cascade_profile.normalize_keeper_runtime_declared_name cascade_name
@@ -208,9 +208,9 @@ let ensure_keeper_meta config name =
            Field-label strings kept for backward-compat in error messages. *)
         let field =
           match defaults.model, defaults.manifest_path with
-          | Some _, _ -> "profile.cascade_name"
+          | Some _, _ -> "profile.runtime_id"
           | None, Some _ -> "manifest.default_cascade_name"
-          | None, None -> "meta.cascade_name"
+          | None, None -> "meta.runtime_id"
         in
         let raw_value =
           match defaults.model, defaults.manifest_path with

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -204,8 +204,7 @@ let ensure_keeper_meta config name =
         ()
     with
     | Error detail ->
-        (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model.
-           Field-label strings kept for backward-compat in error messages. *)
+        (* [runtime_id] is canonical; [model] remains the legacy storage slot. *)
         let field =
           match defaults.model, defaults.manifest_path with
           | Some _, _ -> "profile.runtime_id"
@@ -327,7 +326,7 @@ let ensure_keeper_meta config name =
       meta.room_signal_prompt_enabled <> target_room_signal_prompt_enabled in
     let denylist_changed = meta.tool_denylist <> target_denylist in
     let social_model_changed = meta.social_model <> target_social_model in
-    (* [meta.cascade_name] may be a raw TOML/JSON value while
+    (* [meta runtime id] may be a raw TOML/JSON value while
        [resolved_target_cascade_name] is the validated runtime catalog
        name. Normalize the meta side only so alias cleanup does not
        register as a semantic change. *)

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -286,9 +286,13 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "string");
           ("description", `String "Optional: long-term goal horizon (default: goal).");
         ]);
+        ("runtime_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: Runtime binding id for keeper execution. Replaces legacy models/allowed_models/active_model inputs.");
+        ]);
         ("cascade_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Optional: keeper-assignable cascade profile. Replaces legacy models/allowed_models/active_model inputs.");
+          ("description", `String "Legacy alias for runtime_id. If both are provided they must match.");
         ]);
         ("instructions", `Assoc [
           ("type", `String "string");

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -117,10 +117,10 @@ let keeper_schemas : tool_schema list = [
           ("default", `Bool Persona_contract.default_generation_proactive_enabled);
           ("description", `String "Default keeper.proactive_enabled for the draft.");
         ]);
-        ("cascade_name", `Assoc [
+        ("runtime_id", `Assoc [
           ("type", `String "string");
           ("default", `String Persona_contract.default_generation_cascade_name);
-          ("description", `String "Named cascade used to draft the persona.");
+          ("description", `String "Runtime id used to draft the persona.");
         ]);
         ("temperature", `Assoc [
           ("type", `String "number");
@@ -289,10 +289,6 @@ let keeper_schemas : tool_schema list = [
         ("runtime_id", `Assoc [
           ("type", `String "string");
           ("description", `String "Optional: Runtime binding id for keeper execution. Replaces legacy models/allowed_models/active_model inputs.");
-        ]);
-        ("cascade_name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Legacy alias for runtime_id. If both are provided they must match.");
         ]);
         ("instructions", `Assoc [
           ("type", `String "string");

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -27,7 +27,7 @@ let effective_declarative_cascade_name
       (defaults : keeper_profile_defaults)
       (meta : keeper_meta)
   =
-  (* WORKAROUND (#19327 follow-up): field renamed cascade_name→model. *)
+  (* [runtime_id] is canonical; [model] remains the legacy storage slot. *)
   match defaults.model, defaults.manifest_path with
   | Some cascade_name, _ ->
     Keeper_cascade_profile.normalize_keeper_runtime_declared_name cascade_name
@@ -84,7 +84,7 @@ let live_override_details (meta : keeper_meta) (defaults : keeper_profile_defaul
   if effective_cascade_name <> cascade_name
   then
     override_field
-      "model.cascade_name"
+      "model.runtime_id"
       ~default_value:(`String effective_cascade_name)
       ~live_value:(`String cascade_name)
     :: acc

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -319,7 +319,7 @@ let last_cascade_attempt_json (meta : keeper_meta) =
 let runtime_blocker_facts_json (meta : keeper_meta) =
   `Assoc
     [ "source", `String "keeper_runtime.last_cascade_attempt"
-    ; "cascade_name", `String (cascade_name_of_meta meta)
+    ; "runtime_id", `String (cascade_name_of_meta meta)
     ; "last_cascade_attempt", last_cascade_attempt_json meta
     ]
 ;;

--- a/lib/keeper/keeper_status_detail_observability.ml
+++ b/lib/keeper/keeper_status_detail_observability.ml
@@ -136,7 +136,12 @@ let latest_cascade_for_current_config ~current_cascade_name latest_metrics =
   | None -> None
   | Some cascade ->
       let cascade_name_matches =
-        match Json_util.assoc_string_opt "cascade_name" cascade with
+        let observed_runtime_id =
+          match Json_util.assoc_string_opt "runtime_id" cascade with
+          | Some value -> Some value
+          | None -> Json_util.assoc_string_opt "cascade_name" cascade
+        in
+        match observed_runtime_id with
         | Some observed_name -> String.equal observed_name current_cascade_name
         | None -> true
       in
@@ -149,12 +154,12 @@ let model_observability_json ~current_cascade_name ~runtime_blocker_fields lates
   let runtime_blocker_class =
     assoc_string_opt "runtime_blocker_class" runtime_blocker_fields
   in
-  let cascade_name =
+  let runtime_id =
     Option.value ~default:"" (nonempty_trimmed current_cascade_name)
   in
   `Assoc
-    [ ( "cascade_name"
-      , if cascade_name = "" then `Null else `String cascade_name )
+    [ ( "runtime_id"
+      , if runtime_id = "" then `Null else `String runtime_id )
     ; "recent_turn_observation", `Bool (Option.is_some latest_cascade)
     ; "configured_labels", `List []
     ; "resolved_candidates", `List []

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -16,7 +16,7 @@ type parsed_args = {
   short_goal_opt : string option;
   mid_goal_opt : string option;
   long_goal_opt : string option;
-  cascade_name_opt : string option;
+  runtime_id_opt : string option;
   allowed_paths_opt : string list option;
   autoboot_enabled_opt : bool option;
   sandbox_profile_opt : sandbox_profile option;
@@ -113,23 +113,34 @@ let parse_enum_string_opt args key of_string ~allowed_values =
         (Printf.sprintf "%s must be a string (received %s)" key
            (Json_util.kind_name other))
 
-let parse_cascade_name_opt args =
-  match get_string_opt args "cascade_name" with
+let parse_runtime_id_field_opt args key =
+  match get_string_opt args key with
   | None -> Ok None
   | Some raw ->
-      let normalized =
-        String.trim raw |> String.trim
-      in
-      if normalized = "" then Error "cascade_name must not be empty"
+      let normalized = String.trim raw in
+      if normalized = "" then Error (Printf.sprintf "%s must not be empty" key)
       else
-        (* keeper-assignable guardrail removed 2026-05-28 — validate existence only. *)
         match
-          Provider_runtime_projection.default_execution_model_strings_result
-            (normalized)
+          Provider_runtime_projection.default_execution_model_strings_result normalized
         with
         | Ok _ -> Ok (Some normalized)
         | Error detail ->
-            Error (Printf.sprintf "invalid cascade_name '%s': %s" raw detail)
+            Error (Printf.sprintf "invalid %s '%s': %s" key raw detail)
+
+let parse_runtime_id_opt args =
+  match
+    parse_runtime_id_field_opt args "runtime_id",
+    parse_runtime_id_field_opt args "cascade_name"
+  with
+  | Error msg, _ | _, Error msg -> Error msg
+  | Ok (Some runtime_id), Ok (Some legacy_cascade_name)
+    when runtime_id <> legacy_cascade_name ->
+      Error
+        (Printf.sprintf
+           "runtime_id (%s) and legacy cascade_name (%s) must match"
+           runtime_id legacy_cascade_name)
+  | Ok (Some runtime_id), _ -> Ok (Some runtime_id)
+  | Ok None, Ok legacy_cascade_name_opt -> Ok legacy_cascade_name_opt
 
 let resolve_tool_name_list ~preferred ~fallback =
   Dashboard_utils.first_some preferred fallback
@@ -216,7 +227,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let short_goal_opt = parse_goal_horizon_opt args "short_goal" in
     let mid_goal_opt = parse_goal_horizon_opt args "mid_goal" in
     let long_goal_opt = parse_goal_horizon_opt args "long_goal" in
-    let cascade_name_opt_res = parse_cascade_name_opt args in
+    let runtime_id_opt_res = parse_runtime_id_opt args in
     let autoboot_enabled_opt = get_bool_opt args "autoboot_enabled" in
     let mention_targets_in = get_string_list args "mention_targets" in
     let max_context_override_opt =
@@ -269,9 +280,9 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let will_opt = parse_self_model_opt args "will" in
     let needs_opt = parse_self_model_opt args "needs" in
     let desires_opt = parse_self_model_opt args "desires" in
-    match tool_denylist_opt_res, cascade_name_opt_res with
+    match tool_denylist_opt_res, runtime_id_opt_res with
     | Error msg, _ | _, Error msg -> Error (tool_result_error msg)
-    | Ok tool_denylist_opt, Ok cascade_name_opt ->
+    | Ok tool_denylist_opt, Ok runtime_id_opt ->
     Ok {
       name;
       compaction_profile_opt;
@@ -279,7 +290,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       short_goal_opt;
       mid_goal_opt;
       long_goal_opt;
-      cascade_name_opt;
+      runtime_id_opt;
       allowed_paths_opt;
       active_goal_ids_opt;
       autoboot_enabled_opt;

--- a/lib/keeper/keeper_turn_up_args.mli
+++ b/lib/keeper/keeper_turn_up_args.mli
@@ -18,7 +18,7 @@ type parsed_args =
   ; short_goal_opt : string option
   ; mid_goal_opt : string option
   ; long_goal_opt : string option
-  ; cascade_name_opt : string option
+  ; runtime_id_opt : string option
   ; allowed_paths_opt : string list option
   ; autoboot_enabled_opt : bool option
   ; sandbox_profile_opt : sandbox_profile option

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -48,9 +48,11 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     | Some ids -> ids
     | None -> Option.value ~default:[] p.profile_defaults.active_goal_ids
   in
-  let selected_cascade_name =
-    (* WORKAROUND (#19327 follow-up): cascade_name→model field rename. *)
-    match p.cascade_name_opt, p.profile_defaults.model with
+  let selected_runtime_id =
+    (* RFC-0206: [runtime_id] is the canonical selector.  The profile
+       [model] field is legacy bootstrap input kept only until profile TOML
+       is renamed. *)
+    match p.runtime_id_opt, p.profile_defaults.model with
     | Some name, _ -> name
     | None, Some name -> name
     | None, None -> Keeper_config.default_cascade_name ()
@@ -282,13 +284,13 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                   ~fallback_message:env_message_gate
                   ~fallback_token:env_token_gate
               in
-              let cascade_models =
+              let runtime_models =
                 Provider_runtime_projection.default_execution_model_strings
-                  (selected_cascade_name)
+                  selected_runtime_id
               in
               (match
                  Keeper_turn_helpers.ensure_local_discovery_ready
-                   cascade_models
+                   runtime_models
                with
                | Ok () -> ()
                | Error msg ->
@@ -604,6 +606,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           ("needs", `String meta.needs);
           ("desires", `String meta.desires);
           ("instructions", `String meta.instructions);
+          ("runtime_id", `String (runtime_id_of_meta meta));
           ("cascade_name", `String (cascade_name_of_meta meta));
           ("social_model", `String meta.social_model);
           ("tool_access", tool_access_to_json meta.tool_access);

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -607,7 +607,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           ("desires", `String meta.desires);
           ("instructions", `String meta.instructions);
           ("runtime_id", `String (runtime_id_of_meta meta));
-          ("cascade_name", `String (cascade_name_of_meta meta));
           ("social_model", `String meta.social_model);
           ("tool_access", tool_access_to_json meta.tool_access);
           ("tool_denylist",

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -126,7 +126,38 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
                      raw))
         | None -> Ok ())
   in
-  (* model field: simple provider:model string, no validation needed *)
+  let runtime_id_result =
+    let trimmed key =
+      match str key with
+      | None -> None
+      | Some raw ->
+        let value = String.trim raw in
+        if value = "" then None else Some value
+    in
+    let runtime_id = trimmed "runtime_id" in
+    let legacy_model = trimmed "model" in
+    let legacy_cascade_name = trimmed "cascade_name" in
+    let conflict left_name left_value right_name right_value =
+      Error
+        (Printf.sprintf
+           "keeper.%s (%s) and legacy keeper.%s (%s) must match"
+           left_name left_value right_name right_value)
+    in
+    match runtime_id, legacy_model, legacy_cascade_name with
+    | Some runtime_id, Some legacy_model, _
+      when runtime_id <> legacy_model ->
+      conflict "runtime_id" runtime_id "model" legacy_model
+    | Some runtime_id, _, Some legacy_cascade_name
+      when runtime_id <> legacy_cascade_name ->
+      conflict "runtime_id" runtime_id "cascade_name" legacy_cascade_name
+    | None, Some legacy_model, Some legacy_cascade_name
+      when legacy_model <> legacy_cascade_name ->
+      conflict "model" legacy_model "cascade_name" legacy_cascade_name
+    | Some runtime_id, _, _ -> Ok (Some runtime_id)
+    | None, Some legacy_model, _ -> Ok (Some legacy_model)
+    | None, None, Some legacy_cascade_name -> Ok (Some legacy_cascade_name)
+    | None, None, None -> Ok None
+  in
   let result =
     Result.bind result (fun () ->
         let has_proactive_idle = has "proactive_idle_sec" in
@@ -143,8 +174,12 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   let result =
     Result.bind result (fun () -> tool_access_defaults_result)
   in
+  let result =
+    Result.bind result (fun tool_custom_list ->
+      Result.map (fun runtime_id_opt -> tool_custom_list, runtime_id_opt) runtime_id_result)
+  in
   Result.map
-    (fun tool_custom_list ->
+    (fun (tool_custom_list, runtime_id_opt) ->
       {
         id = None;
         manifest_path = None;
@@ -199,7 +234,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         max_turns_per_call_scheduled_autonomous =
           int_ "max_turns_per_call_scheduled_autonomous";
         social_model = normalize_social_model_opt (str "social_model");
-        model = str "model";
+        model = runtime_id_opt;
         models = None;
         oas_env = extract_oas_env_from_doc doc;
         unknown_toml_keys = [];
@@ -244,7 +279,9 @@ let parsed_field_key_names =
   ; "max_turns_per_call"
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
+  ; "runtime_id"
   ; "model"
+  ; "cascade_name"
   ]
 
 (** Canonical TOML key names used by [detect_unknown_keeper_toml_keys].
@@ -291,7 +328,9 @@ let canonical_keeper_toml_key_names =
   ; "max_turns_per_call"
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
+  ; "runtime_id"
   ; "model"
+  ; "cascade_name"
   ]
 
 let loader_level_keeper_toml_key_names = [ "base" ]

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -237,7 +237,7 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
         | None -> Ok ()
         | Some _ ->
             Error
-              "legacy keeper model args removed for masc_keeper_msg: models. Use cascade_name; concrete provider/model identity is OAS-owned."
+              "legacy keeper model args removed for masc_keeper_msg: models. Use cascade_name; concrete provider/model identity is resolved from the default runtime."
       in
       let direct_reply =
         Json_util.get_bool request.payload "direct_reply" |> Option.value ~default:false

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -237,7 +237,7 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
         | None -> Ok ()
         | Some _ ->
             Error
-              "legacy keeper model args removed for masc_keeper_msg: models. Use cascade_name; concrete provider/model identity is resolved from the default runtime."
+              "legacy keeper model args removed for masc_keeper_msg: models. Use runtime_id; concrete provider/model identity is resolved from the default runtime."
       in
       let direct_reply =
         Json_util.get_bool request.payload "direct_reply" |> Option.value ~default:false

--- a/lib/operator/operator_control_snapshot_identity_fields.ml
+++ b/lib/operator/operator_control_snapshot_identity_fields.ml
@@ -1,8 +1,8 @@
 (** Keeper runtime identity field builders for the operator control
     snapshot, extracted from [operator_control_snapshot.ml]. Three
     helpers: a trimmed-string predicate, the live identity-fields list
-    (with cascade resolution), and the degraded fallback that elides
-    the resolved-cascade lookup. *)
+    (with runtime resolution), and the degraded fallback that elides
+    the resolved-runtime lookup. *)
 
 open Operator_pending_confirm
 
@@ -17,7 +17,7 @@ let keeper_runtime_identity_fields (meta : Keeper_meta_contract.keeper_meta) =
     Json_util.string_opt_to_json (non_empty_trimmed_string_opt cascade_name)
   in
   (* RFC-0149 §3.3 — use the Result-returning resolver so an unresolved
-     cascade surfaces as the original input on the canonical fields
+     runtime surfaces as the original input on the canonical fields
      (matching the degraded-fallback shape below) instead of the silent
      [Keeper_turn] default the legacy [resolve_live] would have written. *)
   let canonical_json =
@@ -26,9 +26,9 @@ let keeper_runtime_identity_fields (meta : Keeper_meta_contract.keeper_meta) =
       `String (runtime)
     | Error (`Unresolved _) -> cascade_name_json
   in
-  [ "cascade_name", cascade_name_json
-  ; "cascade_canonical", canonical_json
-  ; "selected_cascade_canonical", canonical_json
+  [ "runtime_id", cascade_name_json
+  ; "runtime_canonical", canonical_json
+  ; "selected_runtime_canonical", canonical_json
   ; "primary_model", `Null
   ; "active_model", `Null
   ; "active_model_label", `Null
@@ -39,9 +39,9 @@ let keeper_runtime_identity_fields (meta : Keeper_meta_contract.keeper_meta) =
 let degraded_keeper_runtime_identity_fields (meta : Keeper_meta_contract.keeper_meta) =
   let cascade_name = non_empty_trimmed_string_opt (Keeper_meta_contract.cascade_name_of_meta meta) in
   let cascade_json = Json_util.string_opt_to_json cascade_name in
-  [ "cascade_name", cascade_json
-  ; "cascade_canonical", cascade_json
-  ; "selected_cascade_canonical", cascade_json
+  [ "runtime_id", cascade_json
+  ; "runtime_canonical", cascade_json
+  ; "selected_runtime_canonical", cascade_json
   ; "primary_model", `Null
   ; "active_model", `Null
   ; "active_model_label", `Null

--- a/lib/operator/operator_control_snapshot_persistent_agents.ml
+++ b/lib/operator/operator_control_snapshot_persistent_agents.ml
@@ -56,10 +56,10 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
                  ; "active_model", field_or_null "active_model"
                  ; "active_model_label", field_or_null "active_model_label"
                  ; "last_model_used_label", field_or_null "last_model_used_label"
-                 ; "cascade_name", field_or_null "cascade_name"
-                 ; "cascade_canonical", field_or_null "cascade_canonical"
-                 ; ( "selected_cascade_canonical"
-                   , field_or_null "selected_cascade_canonical" )
+                 ; "runtime_id", field_or_null "runtime_id"
+                 ; "runtime_canonical", field_or_null "runtime_canonical"
+                 ; ( "selected_runtime_canonical"
+                   , field_or_null "selected_runtime_canonical" )
                  ; "primary_model", field_or_null "primary_model"
                  ; "next_model_hint", field_or_null "next_model_hint"
                  ; "active_goal_ids", field_or_null "active_goal_ids"

--- a/lib/operator/operator_control_snapshot_trust.ml
+++ b/lib/operator/operator_control_snapshot_trust.ml
@@ -74,9 +74,9 @@ let project_compact_runtime_trust runtime_trust =
 let degraded_keeper_runtime_identity_fields (meta : Keeper_meta_contract.keeper_meta) =
   let cascade_name = non_empty_trimmed_string_opt (Keeper_meta_contract.cascade_name_of_meta meta) in
   let cascade_json = Json_util.string_opt_to_json cascade_name in
-  [ "cascade_name", cascade_json
-  ; "cascade_canonical", cascade_json
-  ; "selected_cascade_canonical", cascade_json
+  [ "runtime_id", cascade_json
+  ; "runtime_canonical", cascade_json
+  ; "selected_runtime_canonical", cascade_json
   ; "primary_model", `Null
   ; "active_model", `Null
   ; "active_model_label", `Null

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -135,32 +135,32 @@ let composite_config_drift_json ~config ~keeper_name =
   | Ok (Some meta) ->
     let sources = Keeper_status_bridge.source_provenance_json config meta in
     let override_fields = Json_util.get_string_list sources "override_fields" in
-    let cascade_detail = find_override_field_source "model.runtime_id" sources in
-    let default_cascade_name, live_cascade_name =
-      match cascade_detail with
+    let runtime_detail = find_override_field_source "model.runtime_id" sources in
+    let default_runtime_id, live_runtime_id =
+      match runtime_detail with
       | Some detail ->
         Json_util.get_string detail "default_value",
         Json_util.get_string detail "live_value"
       | None -> None, None
     in
-    let cascade_override = Option.is_some cascade_detail in
+    let runtime_override = Option.is_some runtime_detail in
     `Assoc
       [ "present", `Bool true
-      ; "status", `String (if cascade_override then "drift" else "ok")
-      ; "cascade_override", `Bool cascade_override
+      ; "status", `String (if runtime_override then "drift" else "ok")
+      ; "runtime_override", `Bool runtime_override
       ; "override_fields", Json_util.json_string_list override_fields
-      ; "default_cascade_name", Json_util.string_opt_to_json default_cascade_name
-      ; "live_cascade_name", Json_util.string_opt_to_json live_cascade_name
+      ; "default_runtime_id", Json_util.string_opt_to_json default_runtime_id
+      ; "live_runtime_id", Json_util.string_opt_to_json live_runtime_id
       ; "active_config_root", Json_util.string_opt_to_json (json_string "active_config_root" sources)
       ]
   | Ok None ->
     `Assoc
       [ "present", `Bool false
       ; "status", `String "keeper_missing"
-      ; "cascade_override", `Bool false
+      ; "runtime_override", `Bool false
       ; "override_fields", `List []
-      ; "default_cascade_name", `Null
-      ; "live_cascade_name", `Null
+      ; "default_runtime_id", `Null
+      ; "live_runtime_id", `Null
       ; "active_config_root", `Null
       ]
   | Error message ->
@@ -168,10 +168,10 @@ let composite_config_drift_json ~config ~keeper_name =
       [ "present", `Bool false
       ; "status", `String "read_error"
       ; "error", `String message
-      ; "cascade_override", `Bool false
+      ; "runtime_override", `Bool false
       ; "override_fields", `List []
-      ; "default_cascade_name", `Null
-      ; "live_cascade_name", `Null
+      ; "default_runtime_id", `Null
+      ; "live_runtime_id", `Null
       ; "active_config_root", `Null
       ]
 ;;
@@ -330,7 +330,7 @@ let composite_execution_claim_no_eligible execution =
 let composite_execution_config_drift execution =
   match json_member "config_drift" execution with
   | `Assoc _ as config_drift ->
-    Option.value ~default:false (json_bool "cascade_override" config_drift)
+    Option.value ~default:false (json_bool "runtime_override" config_drift)
   | _ -> false
 ;;
 
@@ -440,7 +440,7 @@ let composite_runtime_attention ~snapshot ~execution =
       (match json_string "terminal_reason_code" execution with
        | Some value -> String_util.trim_to_option value
        | _ when needs_attention && composite_execution_config_drift execution ->
-         Some "keeper_cascade_override_drift"
+         Some "keeper_runtime_override_drift"
        | _ when blocked -> Some "runtime_blocked"
        | _ -> None)
   in

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -135,7 +135,7 @@ let composite_config_drift_json ~config ~keeper_name =
   | Ok (Some meta) ->
     let sources = Keeper_status_bridge.source_provenance_json config meta in
     let override_fields = Json_util.get_string_list sources "override_fields" in
-    let cascade_detail = find_override_field_source "model.cascade_name" sources in
+    let cascade_detail = find_override_field_source "model.runtime_id" sources in
     let default_cascade_name, live_cascade_name =
       match cascade_detail with
       | Some detail ->

--- a/lib/server/server_dashboard_http_keeper_api_summary_aggregates.ml
+++ b/lib/server/server_dashboard_http_keeper_api_summary_aggregates.ml
@@ -32,7 +32,7 @@ let provider_attempts_summary_json (scan : runtime_manifest_scan) : Yojson.Safe.
       , Json_util.string_opt_to_json (terminal_decision_string "capability_source") )
     ; ( "terminal_fallback_authority"
       , Json_util.string_opt_to_json (terminal_decision_string "fallback_authority") )
-    ; ( "terminal_provider_source_cascade"
+    ; ( "terminal_provider_source_runtime"
       , Json_util.string_opt_to_json (terminal_decision_string "provider_source_cascade") )
     ; "terminal_error", Json_util.string_opt_to_json (terminal_decision_string "error")
     ; ( "terminal_exception_kind"

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -148,13 +148,13 @@ let provider_attempt_row_json (row : Keeper_runtime_manifest.t) =
     [
       ("ts", `String row.ts);
       ("event", `String (Keeper_runtime_manifest.event_kind_to_string row.event));
-      ("cascade_name", Json_util.string_opt_to_json row.cascade_name);
+      ("runtime_id", Json_util.string_opt_to_json row.cascade_name);
       ("model_source", Json_util.string_opt_to_json (decision_string "model_source"));
       ( "resolved_model_source",
         Json_util.string_opt_to_json (decision_string "resolved_model_source") );
       ("capability_source", Json_util.string_opt_to_json (decision_string "capability_source"));
       ("fallback_authority", Json_util.string_opt_to_json (decision_string "fallback_authority"));
-      ( "provider_source_cascade",
+      ( "provider_source_runtime",
         Json_util.string_opt_to_json (decision_string "provider_source_cascade") );
       ("status", `String row.status);
       ("error", Json_util.string_opt_to_json (decision_string "error"));

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -169,11 +169,13 @@ let runtime_trace_keeps_provider_attempt_provenance_key = function
   | "resolved_model_source"
   | "capability_source"
   | "fallback_authority"
+  | "provider_source_runtime"
   | "provider_source_cascade"
   | "terminal_model_source"
   | "terminal_resolved_model_source"
   | "terminal_capability_source"
   | "terminal_fallback_authority"
+  | "terminal_provider_source_runtime"
   | "terminal_provider_source_cascade" ->
     true
   | _ -> false

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
@@ -83,9 +83,9 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
   let claim_status = Json_util.get_string claim_scope "status" in
   let claim_mode = Json_util.get_string claim_scope "mode" in
   let claim_excluded_count = Json_util.get_int claim_scope "excluded_count" in
-  let cascade_override =
+  let runtime_override =
     Option.value
-      (Json_util.get_bool config_drift "cascade_override")
+      (Json_util.get_bool config_drift "runtime_override")
       ~default:false
   in
   let pre_dispatch_reason =
@@ -142,19 +142,19 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
            gaps
        | _ -> gaps)
   |> (fun gaps ->
-       if cascade_override then
+       if runtime_override then
          add
-           { code = "keeper_cascade_override_drift"
+           { code = "keeper_runtime_override_drift"
            ; severity = "warn"
-           ; lane = "masc_policy_cascade"
+           ; lane = "masc_policy_runtime"
            ; detail =
                Some
                  (Printf.sprintf "default=%s live=%s"
                     (Option.value
-                       (Json_util.get_string config_drift "default_cascade_name")
+                       (Json_util.get_string config_drift "default_runtime_id")
                        ~default:"unknown")
                     (Option.value
-                       (Json_util.get_string config_drift "live_cascade_name")
+                       (Json_util.get_string config_drift "live_runtime_id")
                        ~default:"unknown"))
            }
            gaps
@@ -165,7 +165,7 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
          add
            { code = "route_tool_capability_gap"
            ; severity = "bad"
-           ; lane = "masc_policy_cascade"
+           ; lane = "masc_policy_runtime"
            ; detail = Some "pre-dispatch blocked because route cannot materialize required tools"
            }
            gaps
@@ -190,7 +190,7 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
          add
            { code = "provider_lane_unresolved"
            ; severity = "bad"
-           ; lane = "masc_policy_cascade"
+           ; lane = "masc_policy_runtime"
            ; detail = Some "tool surface/provider attempt exists without provider_lane_resolved"
            }
            gaps
@@ -224,7 +224,7 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
          add
            { code = "provider_lane_unresolved"
            ; severity = "warn"
-           ; lane = "masc_policy_cascade"
+           ; lane = "masc_policy_runtime"
            ; detail = Some "required tools exist but provider lane materialization is unknown"
            }
            gaps
@@ -393,7 +393,7 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
          then
            { code = "cascade_decision_missing"
            ; severity = "warn"
-           ; lane = "masc_policy_cascade"
+           ; lane = "masc_policy_runtime"
            ; detail = Some "turn started but no cascade_routed event recorded"
            }
            :: gaps

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_summaries.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_summaries.ml
@@ -97,7 +97,7 @@ let config_drift_summary_json ~config ~keeper_name =
   | Ok (Some meta) ->
     let sources = Keeper_status_bridge.source_provenance_json config meta in
     let override_fields = Json_util.get_string_list sources "override_fields" in
-    let cascade_detail = find_override_field_source "model.cascade_name" sources in
+    let cascade_detail = find_override_field_source "model.runtime_id" sources in
     let default_cascade_name, live_cascade_name =
       match cascade_detail with
       | Some detail ->

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_summaries.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_summaries.ml
@@ -74,10 +74,10 @@ let config_drift_summary_json ~config ~keeper_name =
       ; ("status", `String "read_error")
       ; ("error", `String message)
       ; ("has_live_override", `Bool false)
-      ; ("cascade_override", `Bool false)
+      ; ("runtime_override", `Bool false)
       ; ("override_fields", `List [])
-      ; ("default_cascade_name", `Null)
-      ; ("live_cascade_name", `Null)
+      ; ("default_runtime_id", `Null)
+      ; ("live_runtime_id", `Null)
       ; ("active_config_root", `Null)
       ; ("active_config_root_source", `Null)
       ]
@@ -87,38 +87,38 @@ let config_drift_summary_json ~config ~keeper_name =
       ; ("status", `String "keeper_missing")
       ; ("error", `Null)
       ; ("has_live_override", `Bool false)
-      ; ("cascade_override", `Bool false)
+      ; ("runtime_override", `Bool false)
       ; ("override_fields", `List [])
-      ; ("default_cascade_name", `Null)
-      ; ("live_cascade_name", `Null)
+      ; ("default_runtime_id", `Null)
+      ; ("live_runtime_id", `Null)
       ; ("active_config_root", `Null)
       ; ("active_config_root_source", `Null)
       ]
   | Ok (Some meta) ->
     let sources = Keeper_status_bridge.source_provenance_json config meta in
     let override_fields = Json_util.get_string_list sources "override_fields" in
-    let cascade_detail = find_override_field_source "model.runtime_id" sources in
-    let default_cascade_name, live_cascade_name =
-      match cascade_detail with
+    let runtime_detail = find_override_field_source "model.runtime_id" sources in
+    let default_runtime_id, live_runtime_id =
+      match runtime_detail with
       | Some detail ->
         ( Json_util.get_string detail "default_value",
           Json_util.get_string detail "live_value" )
       | None -> (None, None)
     in
-    let cascade_override = Option.is_some cascade_detail in
+    let runtime_override = Option.is_some runtime_detail in
     `Assoc
       [ ("present", `Bool true)
-      ; ("status", `String (if cascade_override then "drift" else "ok"))
+      ; ("status", `String (if runtime_override then "drift" else "ok"))
       ; ("error", `Null)
       ; ( "has_live_override",
           `Bool
             (Option.value
                (Json_util.get_bool sources "has_live_override")
                ~default:false) )
-      ; ("cascade_override", `Bool cascade_override)
+      ; ("runtime_override", `Bool runtime_override)
       ; ("override_fields", Json_util.json_string_list override_fields)
-      ; ("default_cascade_name", Json_util.string_opt_to_json default_cascade_name)
-      ; ("live_cascade_name", Json_util.string_opt_to_json live_cascade_name)
+      ; ("default_runtime_id", Json_util.string_opt_to_json default_runtime_id)
+      ; ("live_runtime_id", Json_util.string_opt_to_json live_runtime_id)
       ; ( "active_config_root",
           Json_util.string_opt_to_json (Json_util.get_string sources "active_config_root") )
       ; ( "active_config_root_source",

--- a/lib/tool_keeper_ops.ml
+++ b/lib/tool_keeper_ops.ml
@@ -290,6 +290,7 @@ let keeper_list_row_json ~runtime_class config name =
             ("proactive_idle_sec", `Int meta.proactive.idle_sec);
             ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);
             ("skill_route", keeper_list_skill_route_json config meta);
+            ("runtime_id", `String (Keeper_meta_contract.runtime_id_of_meta meta));
             ("cascade_name", `String (Keeper_meta_contract.cascade_name_of_meta meta));
             ("created_at", `String meta.created_at); ("updated_at", `String meta.updated_at);
           ]

--- a/scripts/harness/workload/keeper_continuity_validation.sh
+++ b/scripts/harness/workload/keeper_continuity_validation.sh
@@ -503,7 +503,7 @@ create_keeper() {
       handoff_threshold:$handoff_threshold,
       handoff_cooldown_sec:30,
       drift_enabled:false
-    } + (if ($cascade_name | length) > 0 then {cascade_name:$cascade_name} else {} end)')"
+    } + (if ($cascade_name | length) > 0 then {runtime_id:$cascade_name} else {} end)')"
   call_mcp_tool 1100 "masc_keeper_up" "$args" 60
 }
 
@@ -666,7 +666,7 @@ finalize_report() {
         base_path:$base_path,
         server_log:$server_log,
         keeper_name:$keeper_name,
-        cascade_name:$cascade_name,
+        runtime_id:$cascade_name,
         target_phases:$target_phases
       },
       evidence:{
@@ -996,7 +996,7 @@ real_run() {
       append_phase "recovery" "fail" "keeper_down failed: $LAST_TOOL_ERROR" "$snapshot_file" "$heartbeat_file"
     else
       sleep 1
-      if ! call_mcp_tool 1500 "masc_keeper_up" "$(jq -cn --arg name "$KEEPER_NAME" --arg cascade_name "$KEEPER_CASCADE_NAME" '{name:$name} + (if ($cascade_name | length) > 0 then {cascade_name:$cascade_name} else {} end)')" 30; then
+      if ! call_mcp_tool 1500 "masc_keeper_up" "$(jq -cn --arg name "$KEEPER_NAME" --arg cascade_name "$KEEPER_CASCADE_NAME" '{name:$name} + (if ($cascade_name | length) > 0 then {runtime_id:$cascade_name} else {} end)')" 30; then
         snapshot_info="$(capture_snapshot recovery-up)"
         snapshot_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
         heartbeat_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1997,8 +1997,8 @@ let test_keeper_continuity_harness_auth_contracts () =
   check bool "continuity harness sends bearer token through MCP helper" true
     (file_contains_pattern harness
        {|mcp_call_tool "$req_id" "$tool_name" "$args_json" "${MCP_SESSION_ID:-}" "$MCP_TOKEN" "$MCP_URL"|});
-  check bool "continuity harness uses cascade_name instead of legacy models" true
-    (file_contains_pattern harness {|cascade_name:$cascade_name|});
+  check bool "continuity harness uses runtime_id instead of legacy models" true
+    (file_contains_pattern harness {|runtime_id:$cascade_name|});
   check bool "continuity harness no longer sends legacy models" true
     (file_not_contains_pattern harness {|models:$models|});
   check bool "continuity harness no longer sends removed keepalive args" true
@@ -2012,11 +2012,11 @@ let test_keeper_continuity_harness_auth_contracts () =
     (file_contains_pattern harness {|wait_for_keeper_status_condition|});
   check bool "continuity harness proves liveness with total_turns" true
     (file_contains_pattern harness {|.meta.total_turns|});
-  check bool "keeper_up schema exposes cascade_name" true
-    (file_contains_pattern "lib/keeper/keeper_schema.ml" {|("cascade_name"|});
-  check bool "keeper_up parser stores cascade_name arg" true
+  check bool "keeper_up schema exposes runtime_id" true
+    (file_contains_pattern "lib/keeper/keeper_schema.ml" {|("runtime_id"|});
+  check bool "keeper_up parser stores runtime_id arg" true
     (file_contains_pattern "lib/keeper/keeper_turn_up_args.ml"
-       {|cascade_name_opt_res = parse_cascade_name_opt args|})
+       {|runtime_id_opt_res = parse_runtime_id_opt args|})
 
 let test_mission_briefing_memory_guard_contracts () =
   check bool "mission briefing snapshot disables keeper payload" true

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -702,12 +702,12 @@ let test_dashboard_execution_surfaces_keeper_diagnostic () =
               (row |> member "diagnostic" |> member "health_state" <> `Null);
             check bool "diagnostic next action surfaced" true
               (row |> member "diagnostic" |> member "next_action_path" <> `Null);
-            check string "raw cascade surfaced on execution keeper row"
+            check string "runtime id surfaced on execution keeper row"
               Lib.(Keeper_config.default_cascade_name ())
-              (row |> member "cascade_name" |> to_string);
-            check string "canonical cascade surfaced on execution keeper row"
+              (row |> member "runtime_id" |> to_string);
+            check string "canonical runtime surfaced on execution keeper row"
               Lib.(Keeper_config.default_cascade_name ())
-              (row |> member "cascade_canonical" |> to_string);
+              (row |> member "runtime_canonical" |> to_string);
             check bool "primary model omitted on execution keeper row" true
               (row |> member "primary_model" = `Null);
             check bool "active model label omitted on execution keeper row" true

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -85,7 +85,7 @@ let rewrite_goal_updated_at config ~goal_id ~updated_at =
   in
   Goal_store.write_state config { state with updated_at; goals }
 
-let test_cascade_name = "cascade.test"
+let test_runtime_id = "cascade.test"
 
 let make_keeper_meta ~name ~goal_id =
   match
@@ -96,7 +96,7 @@ let make_keeper_meta ~name ~goal_id =
           ("agent_name", `String (name ^ "-agent"));
           ("trace_id", `String ("trace-" ^ name));
           ("goal", `String "Goal-linked keeper");
-          ("cascade_name", `String test_cascade_name);
+          ("runtime_id", `String test_runtime_id);
         ])
   with
   | Ok meta -> { meta with active_goal_ids = [ goal_id ] }

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -103,7 +103,7 @@ let test_parse_keeper_chat_stream_request_rejects_legacy_model_args () =
       | Error err ->
           check string ("legacy field rejected: " ^ field)
             (Printf.sprintf
-               "legacy keeper model args removed for masc_keeper_msg: %s. Use cascade_name; concrete provider/model identity is OAS-owned."
+               "legacy keeper model args removed for masc_keeper_msg: %s. Use cascade_name; concrete provider/model identity is resolved from the default runtime."
                field)
             err)
     cases

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -103,7 +103,7 @@ let test_parse_keeper_chat_stream_request_rejects_legacy_model_args () =
       | Error err ->
           check string ("legacy field rejected: " ^ field)
             (Printf.sprintf
-               "legacy keeper model args removed for masc_keeper_msg: %s. Use cascade_name; concrete provider/model identity is resolved from the default runtime."
+               "legacy keeper model args removed for masc_keeper_msg: %s. Use runtime_id; concrete provider/model identity is resolved from the default runtime."
                field)
             err)
     cases

--- a/test/test_keeper_identity_parse.ml
+++ b/test/test_keeper_identity_parse.ml
@@ -36,9 +36,10 @@ let test_explicit_keeper_name_is_not_nickname_canonicalized () =
         "personality-resync-test" meta.name
   | Error e -> fail ("expected Ok, got Error: " ^ e)
 
-let test_removed_keeper_cascade_alias_rejected () =
-  (* Removed route aliases must fail at the persisted JSON boundary instead
-     of silently collapsing to the keeper route. *)
+let test_legacy_cascade_name_alias_tolerated () =
+  (* [cascade_name] is now only a legacy alias for pre-scrub persisted
+     payloads. It must remain readable while callers migrate to
+     [runtime_id]. *)
   let json =
     `Assoc
       [
@@ -50,22 +51,15 @@ let test_removed_keeper_cascade_alias_rejected () =
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
-  | Error msg ->
-      check bool "error mentions cascade_name" true
-        (try
-           ignore
-             (Str.search_forward (Str.regexp_string "cascade_name") msg 0);
-           true
-         with
-         | Not_found -> false)
   | Ok meta ->
-      fail
-        ("expected removed alias rejection, got "
-         ^ Keeper_meta_contract.cascade_name_of_meta meta)
+      check string "legacy alias collapses to default runtime"
+        (Runtime.get_default_runtime_id ())
+        (Keeper_meta_contract.runtime_id_of_meta meta)
+  | Error e -> fail ("expected legacy cascade_name alias to parse, got Error: " ^ e)
 
-let test_unknown_bare_cascade_name_rejected () =
-  (* Bare cascade names are no longer accepted. Operators must use
-     canonical cascade./tier./route. names. *)
+let test_conflicting_runtime_id_and_legacy_cascade_name_rejected () =
+  (* Dual-write migration must fail loud when the canonical [runtime_id]
+     and legacy [cascade_name] disagree. *)
   let json =
     `Assoc
       [
@@ -73,25 +67,25 @@ let test_unknown_bare_cascade_name_rejected () =
         ("agent_name", `String "keeper-cheolsu-agent");
         ("trace_id", `String "cheolsu-001");
         ("goal", `String "test");
-        ("cascade_name", `String "playground_experiment_xyz");
+        ("runtime_id", `String "runtime-a");
+        ("cascade_name", `String "runtime-b");
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
   | Error msg ->
-      check bool "error mentions canonical prefix" true
+      check bool "error mentions runtime_id" true
         (try
            ignore
              (Str.search_forward
-                (Str.regexp_string "canonical cascade prefix")
+                (Str.regexp_string "runtime_id")
                 msg
                 0);
            true
          with
          | Not_found -> false)
   | Ok meta ->
-      fail
-        ("expected bare cascade rejection, got "
-         ^ Keeper_meta_contract.cascade_name_of_meta meta)
+      fail ("expected runtime_id/cascade_name conflict rejection, got "
+            ^ Keeper_meta_contract.runtime_id_of_meta meta)
 
 let test_missing_trace_id () =
   let json =
@@ -136,10 +130,10 @@ let () =
       , [ test_case "valid trace_id" `Quick test_valid_trace_id
         ; test_case "explicit keeper name is not nickname-canonicalized" `Quick
             test_explicit_keeper_name_is_not_nickname_canonicalized
-        ; test_case "removed keeper cascade alias rejected" `Quick
-            test_removed_keeper_cascade_alias_rejected
-        ; test_case "unknown bare cascade name rejected" `Quick
-            test_unknown_bare_cascade_name_rejected
+        ; test_case "legacy cascade_name alias tolerated" `Quick
+            test_legacy_cascade_name_alias_tolerated
+        ; test_case "conflicting runtime_id and legacy cascade_name rejected" `Quick
+            test_conflicting_runtime_id_and_legacy_cascade_name_rejected
         ; test_case "missing trace_id field" `Quick test_missing_trace_id
         ; test_case "empty trace_id" `Quick test_empty_trace_id
         ; test_case "invalid trace_id (..)" `Quick test_invalid_trace_id

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -847,15 +847,15 @@ social_model = "magentic_ledger_v1"
       check string "social_model resynced from TOML" "magentic_ledger_v1"
         updated.social_model
 
-(** Test: authored nonblank unknown cascade_name is rejected. *)
+(** Test: authored nonblank unknown runtime_id is rejected. *)
 ;;
-let test_unknown_cascade_name_rejected () =
+let test_unknown_runtime_id_rejected () =
   with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
   with_config_dir @@ fun config_dir ->
   Fs_compat.clear_fs ();
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let keeper_name = "unknown-cascade-name-test" in
+  let keeper_name = "unknown-runtime-id-test" in
   let keepers_toml_dir = Filename.concat config_dir "keepers" in
   Unix.mkdir keepers_toml_dir 0o755;
   write_file
@@ -863,7 +863,7 @@ let test_unknown_cascade_name_rejected () =
     {|[keeper]
 sandbox_profile = "docker"
 goal = "TOML goal"
-cascade_name = "missing_profile"
+runtime_id = "missing_profile"
 |};
   let config = Coord.default_config room_dir in
   let initial_meta =
@@ -873,7 +873,7 @@ cascade_name = "missing_profile"
           [
             ("name", `String keeper_name);
             ("agent_name", `String keeper_name);
-            ("trace_id", `String "trace-unknown-cascade-name");
+            ("trace_id", `String "trace-unknown-runtime-id");
             ("goal", `String "stale goal");
           ])
     with
@@ -883,13 +883,13 @@ cascade_name = "missing_profile"
   seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Ok updated ->
-      failf "expected unknown cascade_name to be rejected, got %s"
+      failf "expected unknown runtime_id to be rejected, got %s"
         (Keeper_meta_contract.cascade_name_of_meta updated)
   | Error detail ->
-      check bool "points at profile.cascade_name" true
-        (contains_substring detail "profile.cascade_name");
-      check bool "mentions unknown cascade_name" true
-        (contains_substring detail "unknown cascade_name")
+      check bool "points at profile.runtime_id" true
+        (contains_substring detail "profile.runtime_id");
+      check bool "mentions unknown runtime_id" true
+        (contains_substring detail "unknown runtime_id")
 
 (** Test: room presence sync updates stale agent capabilities from live keeper meta. *)
 ;;
@@ -944,11 +944,11 @@ let test_toml_update_existing () =
   let input = {|[keeper]
 sandbox_profile = "docker"
 goal = "old goal"
-cascade_name = "default"
+runtime_id = "default"
 instructions = "keep this"
 |} in
   match Keeper_toml_loader.update_field_in_content
-          ~table:"keeper" ~key:"cascade_name" ~value:"local_only" input with
+          ~table:"keeper" ~key:"runtime_id" ~value:"local_only" input with
   | Error e -> fail ("update failed: " ^ e)
   | Ok result ->
       check bool "contains new value"
@@ -957,9 +957,9 @@ instructions = "keep this"
       (match Keeper_toml_loader.parse_toml result with
        | Error e -> fail ("re-parse failed: " ^ e)
        | Ok doc ->
-         check (option string) "cascade_name updated"
+         check (option string) "runtime_id updated"
            (Some "local_only")
-           (Keeper_toml_loader.toml_string_opt doc "keeper.cascade_name");
+           (Keeper_toml_loader.toml_string_opt doc "keeper.runtime_id");
          check (option string) "goal preserved"
            (Some "old goal")
            (Keeper_toml_loader.toml_string_opt doc "keeper.goal");
@@ -975,15 +975,15 @@ sandbox_profile = "docker"
 goal = "test"
 |} in
   match Keeper_toml_loader.update_field_in_content
-          ~table:"keeper" ~key:"cascade_name" ~value:"local_only" input with
+          ~table:"keeper" ~key:"runtime_id" ~value:"local_only" input with
   | Error e -> fail ("update failed: " ^ e)
   | Ok result ->
       (match Keeper_toml_loader.parse_toml result with
        | Error e -> fail ("re-parse failed: " ^ e)
        | Ok doc ->
-         check (option string) "cascade_name inserted"
+         check (option string) "runtime_id inserted"
            (Some "local_only")
-           (Keeper_toml_loader.toml_string_opt doc "keeper.cascade_name");
+           (Keeper_toml_loader.toml_string_opt doc "keeper.runtime_id");
          check (option string) "goal preserved"
            (Some "test")
            (Keeper_toml_loader.toml_string_opt doc "keeper.goal"))
@@ -995,7 +995,7 @@ let test_toml_update_no_table () =
 goal = "orphan"
 |} in
   match Keeper_toml_loader.update_field_in_content
-          ~table:"keeper" ~key:"cascade_name" ~value:"x" input with
+          ~table:"keeper" ~key:"runtime_id" ~value:"x" input with
   | Ok _ -> fail "should have returned Error for missing table"
   | Error _ -> ()
 
@@ -1109,9 +1109,9 @@ let () =
             `Quick
             test_social_model_resynced_from_declarative_defaults;
           test_case
-            "unknown nonblank cascade_name is rejected"
+            "unknown nonblank runtime_id is rejected"
             `Quick
-            test_unknown_cascade_name_rejected;
+            test_unknown_runtime_id_rejected;
           test_case
             "room presence sync overwrites stale agent capabilities"
             `Quick

--- a/test/test_keeper_status_runtime.ml
+++ b/test/test_keeper_status_runtime.ml
@@ -996,8 +996,8 @@ let test_runtime_surface_exposes_cascade_attempt_facts () =
   let facts = runtime |> member "runtime_blocker_facts" in
   check string "facts source" "keeper_runtime.last_cascade_attempt"
     (facts |> member "source" |> to_string);
-  check string "facts cascade" "cascade.strict_tool_candidates"
-    (facts |> member "cascade_name" |> to_string);
+  check string "facts runtime id" "cascade.strict_tool_candidates"
+    (facts |> member "runtime_id" |> to_string);
   let last_attempt = facts |> member "last_cascade_attempt" in
   check string "attempt provider_id" attempt.provider_id
     (last_attempt |> member "provider_id" |> to_string);

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -924,7 +924,7 @@ max_turns_per_call_scheduled_autonomous = 0
        check int "zero autonomous falls back" 10
          (KTP.effective_max_turns_per_call_scheduled_autonomous d))
 
-let test_profile_rejects_removed_keeper_cascade_alias () =
+let test_profile_accepts_legacy_cascade_name_alias () =
   let input = {|
 [keeper]
 goal = "test"
@@ -934,15 +934,12 @@ cascade_name = "oas-coding_first"
   | Error e -> fail e
   | Ok doc ->
     (match KTP.profile_defaults_of_toml doc with
-     | Error e ->
-       check bool "removed alias rejected" true
-         (try
-            ignore
-              (Str.search_forward (Str.regexp_string "invalid cascade_name") e 0);
-            true
-          with
-          | Not_found -> false)
-     | Ok _ -> fail "expected removed keeper cascade alias rejection")
+     | Error e -> fail e
+     | Ok defaults ->
+       check (option string)
+         "legacy cascade_name aliases runtime id"
+         (Some "oas-coding_first")
+         defaults.model)
 
 let test_persona_resolver_defaults_to_research_tool_access () =
   with_personas_dir @@ fun personas_dir ->
@@ -1941,8 +1938,8 @@ let () =
             test_profile_rejects_removed_initiative_keys;
           test_case "legacy allowed_providers rejected" `Quick
             test_profile_rejects_legacy_allowed_providers;
-          test_case "removed keeper cascade alias rejected" `Quick
-            test_profile_rejects_removed_keeper_cascade_alias;
+          test_case "legacy cascade_name aliases runtime id" `Quick
+            test_profile_accepts_legacy_cascade_name_alias;
           test_case "max_turns overrides parsed and applied" `Quick
             test_profile_max_turns_overrides;
           test_case "max_turns defaults when absent" `Quick

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -833,7 +833,7 @@ let test_profile_rejects_legacy_allowed_providers () =
 [keeper]
 goal = "test"
 allowed_providers = ["Ollama", "GLM"]
-cascade_name = "primary"
+runtime_id = "primary"
 |} in
   match TL.parse_toml input with
   | Error e -> fail e
@@ -1444,7 +1444,7 @@ let test_detect_unknown_keys_empty_when_all_canonical () =
 goal = "canonical"
 mention_targets = ["a", "b"]
 autoboot_enabled = false
-cascade_name = "primary"
+runtime_id = "primary"
 repo_cli_identity = "anyang-keepers"
 git_identity_mode = "keeper_alias"
 active_goal_ids = ["goal-runtime"]

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -670,7 +670,7 @@ let test_load_keeper_toml_inherits_base_defaults () =
     (fun () ->
       write_file base_path {|
 [keeper]
-cascade_name = "route.keeper_turn"
+runtime_id = "route.keeper_turn"
 sandbox_profile = "docker"
 network_mode = "inherit"
 repo_cli_identity = "anyang-keepers"
@@ -686,8 +686,8 @@ persona_name = "sangsu"
       | Error e -> fail e
       | Ok (name, defaults) ->
           check string "name from filename" "sangsu" name;
-          (* #19327: field renamed cascade_name→model. *)
-          check (option string) "base cascade" (Some "route.keeper_turn")
+          (* #19574: [runtime_id] is canonical; [model] is legacy storage. *)
+          check (option string) "base runtime_id" (Some "route.keeper_turn")
             defaults.model;
           check (option string) "base sandbox" (Some "docker")
             (Option.map KTP.sandbox_profile_to_string defaults.sandbox_profile);

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -420,39 +420,39 @@ let test_base_config_avoids_hidden_shell_tool_names () =
         false
         (contains ~needle:"tool_search_files" instructions)
 
-let test_cascade_name_rejects_unknown () =
+let test_runtime_id_rejects_unknown () =
   let result =
     with_temp_toml
-      "[keeper]\nname = \"testkeeper\"\ncascade_name = \"definitely_missing_profile\"\n"
+      "[keeper]\nname = \"testkeeper\"\nruntime_id = \"definitely_missing_profile\"\n"
       KTP.load_keeper_toml
   in
   match result with
-  | Ok _ -> fail "definitely_missing_profile cascade_name should be rejected"
+  | Ok _ -> fail "definitely_missing_profile runtime_id should be rejected"
   | Error e ->
-      check bool "error mentions cascade_name" true
-        (contains ~needle:"invalid cascade_name" e)
+      check bool "error mentions runtime_id" true
+        (contains ~needle:"invalid runtime_id" e)
 
-let test_cascade_name_accepts_known () =
+let test_runtime_id_accepts_known () =
   with_repo_config_dir @@ fun () ->
-  let check_ok label cascade_name =
+  let check_ok label runtime_id =
     let result =
       with_temp_toml
-        (Printf.sprintf "[keeper]\nname = \"testkeeper\"\ncascade_name = \"%s\"\n"
-           cascade_name)
+        (Printf.sprintf "[keeper]\nname = \"testkeeper\"\nruntime_id = \"%s\"\n"
+           runtime_id)
         KTP.load_keeper_toml
     in
     match result with
     | Ok _ -> ()
     | Error e ->
         fail (Printf.sprintf "%s: '%s' should be accepted but got: %s" label
-                cascade_name e)
+                runtime_id e)
   in
   check_ok "primary variant" "primary";
   check_ok "local_only phase-routing" "local_only";
   check_ok "local_recovery phase-routing" "local_recovery";
   check_ok "tool_use_strict reserved tool lane" "tool_use_strict"
 
-let test_cascade_name_accepts_tool_lane_without_catalog () =
+let test_runtime_id_accepts_tool_lane_without_catalog () =
   let missing_dir =
     Filename.concat (Filename.get_temp_dir_name ())
       "missing-masc-config-for-tool-use-strict"
@@ -469,7 +469,7 @@ let test_cascade_name_accepts_tool_lane_without_catalog () =
     (fun () ->
       let result =
         with_temp_toml
-          "[keeper]\nname = \"testkeeper\"\ncascade_name = \"tool_use_strict\"\n"
+          "[keeper]\nname = \"testkeeper\"\nruntime_id = \"tool_use_strict\"\n"
           KTP.load_keeper_toml
       in
       match result with
@@ -481,7 +481,7 @@ let test_cascade_name_accepts_tool_lane_without_catalog () =
                 a readable live catalog: %s"
                e))
 
-let test_cascade_name_accepts_catalog_entry () =
+let test_runtime_id_accepts_catalog_entry () =
   with_repo_config_dir @@ fun () ->
   (* Tests that the live declarative catalog is consulted during
      validation. *)
@@ -503,7 +503,7 @@ let test_cascade_name_accepts_catalog_entry () =
   in
   let result =
     with_temp_toml
-      (Printf.sprintf "[keeper]\nname = \"testkeeper\"\ncascade_name = \"%s\"\n"
+      (Printf.sprintf "[keeper]\nname = \"testkeeper\"\nruntime_id = \"%s\"\n"
          test_name)
       KTP.load_keeper_toml
   in
@@ -514,12 +514,12 @@ let test_cascade_name_accepts_catalog_entry () =
       if catalog = [] then ()
       else fail (Printf.sprintf "%s should be accepted: %s" test_name e)
 
-let test_cascade_name_accepts_unrouted_assignable_catalog_entry () =
+let test_runtime_id_accepts_unrouted_assignable_catalog_entry () =
   with_temp_config_dir minimal_cascade_profile_metadata_toml
   @@ fun ~config_root:_ ~cascade_path:_ ->
   let result =
     with_temp_toml
-      "[keeper]\nname = \"testkeeper\"\ncascade_name = \"backup\"\n"
+      "[keeper]\nname = \"testkeeper\"\nruntime_id = \"backup\"\n"
       KTP.load_keeper_toml
   in
   match result with
@@ -767,18 +767,18 @@ let () =
               with_repo_config_dir
                 test_verifier_config_hides_worker_lifecycle_tools);
         ] );
-      ( "cascade_name validation",
+      ( "runtime_id validation",
         [
-          test_case "rejects unknown cascade_name" `Quick
-            test_cascade_name_rejects_unknown;
-          test_case "accepts known cascade names" `Quick
-            test_cascade_name_accepts_known;
+          test_case "rejects unknown runtime_id" `Quick
+            test_runtime_id_rejects_unknown;
+          test_case "accepts known runtime ids" `Quick
+            test_runtime_id_accepts_known;
           test_case "accepts reserved tool lane without live catalog" `Quick
-            test_cascade_name_accepts_tool_lane_without_catalog;
+            test_runtime_id_accepts_tool_lane_without_catalog;
           test_case "accepts live catalog entry" `Quick
-            test_cascade_name_accepts_catalog_entry;
+            test_runtime_id_accepts_catalog_entry;
           test_case "accepts unrouted assignable catalog entry" `Quick
-            test_cascade_name_accepts_unrouted_assignable_catalog_entry;
+            test_runtime_id_accepts_unrouted_assignable_catalog_entry;
           test_case "keeper runtime ignores non-keeper route target" `Quick
             test_keeper_runtime_declared_name_ignores_non_keeper_route_target;
           test_case "runtime rejects declarative parse errors" `Quick

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -2877,9 +2877,9 @@ proactive_enabled = true
         Masc_mcp.(Keeper_config.default_cascade_name ())
         (json |> member "execution" |> member "selected_cascade_name"
        |> to_string);
-      Alcotest.(check string) "selected cascade canonical"
+      Alcotest.(check string) "selected runtime canonical"
         Masc_mcp.(Keeper_config.default_cascade_name ())
-        (json |> member "execution" |> member "selected_cascade_canonical"
+        (json |> member "execution" |> member "selected_runtime_canonical"
        |> to_string);
       let expected_default_models =
         Masc_mcp.Cascade_runtime.models_of_cascade_name
@@ -3039,7 +3039,7 @@ proactive_enabled = true
        |> to_string);
       Alcotest.(check string) "stale cascade falls back to live default"
         Masc_mcp.(Keeper_config.default_cascade_name ())
-        (stale_json |> member "execution" |> member "selected_cascade_canonical"
+        (stale_json |> member "execution" |> member "selected_runtime_canonical"
        |> to_string);
       Alcotest.(check (list string)) "stale cascade models use live default"
         expected_default_models

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -2873,9 +2873,9 @@ proactive_enabled = true
         (json |> member "proactive" |> member "enabled" |> to_bool);
       Alcotest.(check string) "default source kind" "toml"
         (json |> member "sources" |> member "default_source_kind" |> to_string);
-      Alcotest.(check string) "selected cascade name"
+      Alcotest.(check string) "selected runtime id"
         Masc_mcp.(Keeper_config.default_cascade_name ())
-        (json |> member "execution" |> member "selected_cascade_name"
+        (json |> member "execution" |> member "selected_runtime_id"
        |> to_string);
       Alcotest.(check string) "selected runtime canonical"
         Masc_mcp.(Keeper_config.default_cascade_name ())
@@ -3033,9 +3033,9 @@ proactive_enabled = true
         Masc_mcp.Dashboard_http_keeper.keeper_config_json config keeper_name
       in
       Alcotest.(check bool) "stale config still found" true (stale_status = `OK);
-      Alcotest.(check string) "stale cascade raw name preserved"
+      Alcotest.(check string) "stale runtime id preserved"
         "vendor_mix_balanced"
-        (stale_json |> member "execution" |> member "selected_cascade_name"
+        (stale_json |> member "execution" |> member "selected_runtime_id"
        |> to_string);
       Alcotest.(check string) "stale cascade falls back to live default"
         Masc_mcp.(Keeper_config.default_cascade_name ())

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -2094,9 +2094,9 @@ let test_keeper_status_exposes_model_observability () =
       let runtime_trust = status_json |> member "runtime_trust" in
       let status_dump = Yojson.Safe.pretty_to_string status_json in
       Alcotest.(check (option string))
-        ("cascade name surfaced\n" ^ status_dump)
+        ("runtime id surfaced\n" ^ status_dump)
         (Some Masc_mcp.(Keeper_config.default_cascade_name ()))
-        (observability |> member "cascade_name" |> to_string_option);
+        (observability |> member "runtime_id" |> to_string_option);
       Alcotest.(check bool) "recent turn observation true" true
         (observability |> member "recent_turn_observation" |> to_bool);
       Alcotest.(check (list string)) "configured labels omitted" []
@@ -2236,9 +2236,9 @@ let test_keeper_status_ignores_stale_cascade_observation () =
       let observability = status_json |> member "model_observability" in
       let status_dump = Yojson.Safe.pretty_to_string status_json in
       Alcotest.(check (option string))
-        ("current cascade name wins over stale metrics\n" ^ status_dump)
+        ("current runtime id wins over stale metrics\n" ^ status_dump)
         (Some (Keeper_meta_contract.cascade_name_of_meta meta))
-        (observability |> member "cascade_name" |> to_string_option);
+        (observability |> member "runtime_id" |> to_string_option);
       Alcotest.(check bool) "stale observation ignored" false
         (observability |> member "recent_turn_observation" |> to_bool);
       Alcotest.(check (list string))


### PR DESCRIPTION
## Summary

- parse `runtime_id` as the canonical keeper creation runtime selector
- keep `cascade_name` as a legacy alias and reject requests where both fields disagree
- rename the keeper creation bootstrap local-discovery path from cascade models to runtime models
- include `runtime_id` in the keeper creation response while retaining `cascade_name` as a compatibility field

## Why

This is the next slice after #19572. The remaining cascade migration should change the content semantics: keeper creation should no longer treat the value as a cascade profile/route selector. `runtime_id` is now the canonical boundary; `cascade_name` is only a legacy compatibility alias while callers migrate.

## Validation

Not run; continuing the requested draft-slice iteration on the currently broken cascade->Runtime migration mainline.
