### PR TITLE
refactor(runtime): expose runtime id in OAS bridge counts

### DIFF
--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -121,7 +121,7 @@ let provider_error_count_to_yojson (c : provider_error_count) =
   `Assoc
     [
       ("provider_id", `String public_runtime_provider_label);
-      ("cascade_name", `String c.cascade_name);
+      ("runtime_id", `String c.cascade_name);
       ("kind", `String c.kind);
       ("capacity_scope", `String c.capacity_scope);
       ("count", `Int c.count);

--- a/test/test_dashboard_oas_bridge.ml
+++ b/test/test_dashboard_oas_bridge.ml
@@ -386,9 +386,9 @@ let test_summary_json_contains_provider_error_counts () =
       "runtime"
       (count |> Json.member "provider_id" |> Json.to_string);
     Alcotest.(check string)
-      "cascade"
+      "runtime id"
       "primary"
-      (count |> Json.member "cascade_name" |> Json.to_string);
+      (count |> Json.member "runtime_id" |> Json.to_string);
     Alcotest.(check string)
       "kind"
       "auth_error"


### PR DESCRIPTION
## Summary

- expose provider error count runtime identity as `runtime_id` instead of `cascade_name`
- update the dashboard OAS bridge test expectation to the new key

## Why

Follow-up slice after #19574 was merged. This continues replacing user-facing Cascade terminology with Runtime identity terminology while leaving internal legacy cascade plumbing untouched.

## Validation

Not run; continuing the requested iterative cleanup.
