### PR TITLE
refactor(runtime): stop preserving provider source cascade keys

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -170,13 +170,12 @@ let runtime_trace_keeps_provider_attempt_provenance_key = function
   | "capability_source"
   | "fallback_authority"
   | "provider_source_runtime"
-  | "provider_source_cascade"
   | "terminal_model_source"
   | "terminal_resolved_model_source"
   | "terminal_capability_source"
   | "terminal_fallback_authority"
   | "terminal_provider_source_runtime"
-  | "terminal_provider_source_cascade" ->
+  ->
     true
   | _ -> false
 


### PR DESCRIPTION
## Summary

- stop preserving legacy `provider_source_cascade` decision keys in dashboard runtime-trace redaction
- keep the runtime-facing `provider_source_runtime` and `terminal_provider_source_runtime` keys as the allowed provenance fields

## Why

Follow-up slice after #19576. Runtime-facing dashboard output should no longer keep the old Cascade provider-source key alive when the renamed runtime key is available.

## Validation

Not run; continuing the requested iterative cleanup.
