### PR TITLE
docs(runtime): use runtime id in config boundary docs

### DIFF
--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -87,7 +87,7 @@ OAS  ──does not know──→ MASC
 | Checkpoint integration | Mostly complete, sidecar debt remains | OAS checkpoint is used in shared worker/runtime paths. New keeper checkpoint writes keep continuity state out of `working_context`: `patch_checkpoint_last_assistant` strips visible `[STATE]`, stores replay metadata on the assistant message, and clears `Checkpoint.working_context`. Compatibility readers still accept legacy structured sidecars, and feature-flagged autonomous/resilience/multimodal adapters may store neutral sidecar metadata in `working_context`. |
 | Memory bridge | Partial complete | long-term + procedural + institution episodic are bridged; broader memory unification is still separate |
 | Team-session swarm | Removed | `lib/team_session/` module purged; MASC no longer owns a session orchestration surface. OAS Swarm Runner is the sole substrate; consumers drive swarm runs via OAS primitives directly. |
-| Provider/model identity ownership | OAS-owned | MASC resolves logical `cascade_name` / runtime lane intent only; concrete provider/model selection and cost identity are OAS-owned. Legacy `allowed_providers` inputs are rejected |
+| Provider/model identity ownership | OAS-owned | MASC resolves logical `runtime_id` / runtime lane intent only; concrete provider/model selection and cost identity are OAS-owned. Legacy `allowed_providers` inputs are rejected |
 
 ## Boundary Audit Snapshot
 

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -610,4 +610,4 @@ dir-local local-dev에서는 `.masc/`가 target 디렉토리 내부를 가리키
 
 ### 12.6 모델 실행
 
-모델 선택은 `cascade.toml`이 유일한 권위다. keeper_meta의 `cascade_name` (기본 `"primary"`)이 keeper-assignable profile을 지정하고, `Cascade_runtime`가 실행 모델을 결정한다. keeper 설정에 모델 필드를 직접 지정하지 않는다.
+모델 선택은 `cascade.toml`이 유일한 권위다. keeper_meta의 `runtime_id` (기본 `"primary"`)가 keeper-assignable runtime을 지정하고, runtime resolver가 실행 모델을 결정한다. keeper 설정에 모델 필드를 직접 지정하지 않는다.


### PR DESCRIPTION
## Summary
- update configuration docs to describe keeper model selection with runtime_id
- update OAS/MASC boundary docs to name runtime_id as the logical runtime lane identifier

## Tests
- Not run (not requested).