### PR TITLE
[RFC-0206] cascade→Runtime L2 빌드 green 복구 (WIP: error 도메인+engine)

### DIFF
--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -519,21 +519,17 @@ let execute_single_agent_run ~sw ~net ~run_id ~provider ~model ~prompt =
                "Provider '%s' is not runnable in dashboard single-agent mode"
                provider)
         else (
-          let inference_cascade_name =
-                          (Runtime.get_default_runtime_id ())
-          in
+          (* RFC-0206 single-binding: per-cascade inference overrides removed
+             with the cascade purge; the dashboard test-run uses static
+             defaults (max_tokens=2048, temperature=0.2). *)
           match
             Masc_oas_bridge.run_with_caller
               ~caller:Env_config_oas_bridge.Dashboard_provider_runs (fun () ->
               Keeper_turn_driver_wrappers.run_model_by_label ~model_label:label ~goal:prompt
                 ~system_prompt:(run_system_prompt provider)
                 ~max_turns:4
-                ~max_tokens:(Cascade_inference.resolve_max_tokens
-                  ~cascade_name:inference_cascade_name
-                  ~fallback:(fun () -> 2048))
-                ~temperature:(Cascade_inference.resolve_temperature
-                  ~cascade_name:inference_cascade_name
-                  ~fallback:(fun () -> 0.2))
+                ~max_tokens:2048
+                ~temperature:0.2
                 ~sw ?net
                 ()
             )

--- a/lib/keeper/keeper_attempt_liveness_observer.ml
+++ b/lib/keeper/keeper_attempt_liveness_observer.ml
@@ -382,7 +382,9 @@ let finalize (t : t) : unit =
     match t.mode with
     | Cfg.Off -> ()
     | Cfg.Observe | Cfg.Enforce ->
-        let outcome = outcome_of_state !(t.state) in
+        (* RFC-0206: the cascade observation that consumed [outcome_of_state]
+           was removed with the cascade purge; success-sampling below reads
+           [t.state] directly. *)
         (match !(t.state), t.candidate_key, !(t.first_chunk_at), !(t.last_chunk_at) with
          | L.Success, Some candidate_key, Some first_chunk_at, Some last_chunk_at ->
            t.success_sample :=

--- a/lib/keeper/keeper_cascade_engine.ml
+++ b/lib/keeper/keeper_cascade_engine.ml
@@ -1,0 +1,42 @@
+(** Keeper-owned cascade execution boundary. *)
+
+type oas_dispatch_mode = Single_provider_agent_run
+
+type t = {
+  engine_id : string;
+  oas_dispatch_mode : oas_dispatch_mode;
+  allows_oas_internal_cascade : bool;
+}
+
+let keeper_managed =
+  {
+    engine_id = "masc_keeper_named_cascade";
+    oas_dispatch_mode = Single_provider_agent_run;
+    allows_oas_internal_cascade = false;
+  }
+
+let to_string t = t.engine_id
+
+let oas_dispatch_mode t = t.oas_dispatch_mode
+
+let oas_dispatch_mode_to_string = function
+  | Single_provider_agent_run -> "single_provider_agent_run"
+
+let allows_oas_internal_cascade t = t.allows_oas_internal_cascade
+
+let guard_keeper_hot_path t =
+  match t.oas_dispatch_mode, t.allows_oas_internal_cascade with
+  | Single_provider_agent_run, false -> Ok ()
+  | Single_provider_agent_run, true ->
+      Error
+        (Printf.sprintf
+           "keeper cascade engine %s must not delegate provider fallback to OAS"
+           t.engine_id)
+
+let manifest_fields t =
+  [
+    ("cascade_engine", `String (to_string t));
+    ( "oas_dispatch_mode",
+      `String (oas_dispatch_mode_to_string (oas_dispatch_mode t)) );
+    ("oas_internal_cascade_allowed", `Bool (allows_oas_internal_cascade t));
+  ]

--- a/lib/keeper/keeper_cascade_engine.mli
+++ b/lib/keeper/keeper_cascade_engine.mli
@@ -1,0 +1,20 @@
+(** Keeper-owned cascade execution boundary.
+
+    Keepers resolve and iterate named cascade providers in MASC, then hand OAS
+    a single-provider agent run for each attempt.  This module makes that
+    boundary an explicit value so runtime manifests and tests do not rely only
+    on source-text guards. *)
+
+type oas_dispatch_mode = Single_provider_agent_run
+
+type t
+
+val keeper_managed : t
+val to_string : t -> string
+val oas_dispatch_mode : t -> oas_dispatch_mode
+val oas_dispatch_mode_to_string : oas_dispatch_mode -> string
+val allows_oas_internal_cascade : t -> bool
+val guard_keeper_hot_path : t -> (unit, string) result
+
+(** Fields suitable for splicing into runtime-manifest decision JSON. *)
+val manifest_fields : t -> (string * Yojson.Safe.t) list

--- a/lib/keeper/keeper_cascade_sync_failure_site.ml
+++ b/lib/keeper/keeper_cascade_sync_failure_site.ml
@@ -1,0 +1,10 @@
+type t =
+  | Resume_sync
+  | Pause_sync
+  | Ambiguous_partial_pause
+
+let to_label = function
+  | Resume_sync -> "resume_sync"
+  | Pause_sync -> "pause_sync"
+  | Ambiguous_partial_pause -> "ambiguous_partial_pause"
+;;

--- a/lib/keeper/keeper_cascade_sync_failure_site.mli
+++ b/lib/keeper/keeper_cascade_sync_failure_site.mli
@@ -1,0 +1,12 @@
+(** Keeper_cascade_sync_failure_site — closed sum for [site] label on
+    [metric_keeper_cascade_sync_failures] (now 3 sites across
+    keeper_turn_cascade_budget.ml + keeper_unified_turn.ml). *)
+
+type t =
+  | Resume_sync
+  | Pause_sync
+  | Ambiguous_partial_pause
+  (** Post-mutating-tool ambiguous-pause path in keeper_unified_turn.ml.
+          Operator-disposition equivalent of post-commit ambiguity. *)
+
+val to_label : t -> string

--- a/lib/keeper/keeper_error_from_sdk.ml
+++ b/lib/keeper/keeper_error_from_sdk.ml
@@ -1,0 +1,318 @@
+(** Keeper_error_from_sdk — Reverse-direction SDK envelope decoders for the
+    [masc_internal_error] ADT.
+
+    The forward direction (variant -> JSON, variant -> SDK error) lives in
+    {!Keeper_meta_contract}; this module owns the matching reverse direction:
+
+    - {!parse_masc_internal_error_json} — JSON value produced by
+      {!Keeper_meta_contract.masc_internal_error_to_json} back into a
+      typed variant;
+    - {!classify_masc_internal_error_of_string} — raw string entry point
+      that locates the [[masc_oas_error]] prefix anywhere in the text;
+    - {!classify_masc_internal_error} — SDK error entry point for
+      [Agent_sdk.Error.Internal] values that carry or wrap the prefix.
+
+    RFC-0142 Phase 2 PR-2 extracted these three functions from
+    {!Keeper_masc_error_classify}; the facade in that module continues to
+    re-export them so existing callers compile unchanged.
+
+    @since RFC-0142 Phase 2 *)
+
+open Keeper_meta_contract
+
+let parse_masc_internal_error_json (json : Yojson.Safe.t) :
+    masc_internal_error option =
+  let int_opt_of_assoc key = function
+    | `Assoc fields -> (
+        match List.assoc_opt key fields with
+        | Some (`Int value) -> Some value
+        | Some (`Intlit value) -> int_of_string_opt value
+        | _ -> None)
+    | _ -> None
+  in
+  let float_opt_of_assoc key = function
+    | `Assoc fields -> (
+        match List.assoc_opt key fields with
+        | Some (`Float value) -> Some value
+        | Some (`Int value) -> Some (float_of_int value)
+        | Some (`Intlit value) ->
+            Option.map float_of_int (int_of_string_opt value)
+        | _ -> None)
+    | _ -> None
+  in
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt "kind" fields with
+      | Some (`String "cascade_exhausted") -> (
+          match string_opt_of_assoc "cascade_name" json with
+          | Some cascade_name ->
+            (* If the reason payload does not round-trip through a typed
+               [cascade_exhaustion_reason] variant, the entire payload is
+               returned as [None] so the caller treats the SDK error as
+               opaque. Synthesizing a sentinel reason here would be
+               indistinguishable from a real cascade-reason value and
+               poison downstream typed pattern matches. *)
+            let reason_opt =
+              match List.assoc_opt "reason"
+                      (match json with `Assoc fields -> fields | _ -> []) with
+              | Some json_val ->
+                  Keeper_meta_contract.cascade_exhaustion_reason_of_json json_val
+              | None -> None
+            in
+            (match reason_opt with
+             | Some reason ->
+               Some
+                 (Cascade_exhausted
+                    {
+                      cascade_name = cascade_name;
+                      reason;
+                    })
+             | None -> None)
+          | None -> None)
+      | Some (`String "capacity_backpressure") -> (
+          match
+            string_opt_of_assoc "cascade_name" json,
+            string_opt_of_assoc "source" json,
+            string_opt_of_assoc "detail" json
+          with
+          | Some cascade_name, Some source, Some detail ->
+            (match capacity_backpressure_source_of_string source with
+             | Some source ->
+               (* Reconstruct provenance from the wire: a [retry_after_synthetic]
+                  flag distinguishes a fabricated default from a real backoff, so
+                  a synthetic value is never read back as explicit.  Legacy
+                  payloads (no flag) default to [Explicit]. *)
+               let retry_after_synthetic =
+                 match json with
+                 | `Assoc fields -> (
+                     match List.assoc_opt "retry_after_synthetic" fields with
+                     | Some (`Bool b) -> b
+                     | _ -> false)
+                 | _ -> false
+               in
+               let retry_after =
+                 match float_opt_of_assoc "retry_after_sec" json with
+                 | None -> Keeper_meta_contract.No_retry_hint
+                 | Some s when retry_after_synthetic ->
+                   Keeper_meta_contract.Synthetic_default s
+                 | Some s -> Keeper_meta_contract.Explicit s
+               in
+               Some
+                 (Capacity_backpressure
+                    {
+                      cascade_name = cascade_name;
+                      source;
+                      detail;
+                      retry_after;
+                    })
+             | None -> None)
+          | _ -> None)
+      | Some (`String "resumable_cli_session") -> (
+          match string_opt_of_assoc "cascade_name" json, string_opt_of_assoc "detail" json with
+          | Some cascade_name, Some detail ->
+            Some
+              (Resumable_cli_session
+                 {
+                   cascade_name = cascade_name;
+                   detail;
+                   exit_code = int_opt_of_assoc "exit_code" json;
+                 })
+          | _ -> None)
+      | Some (`String "no_tool_capable_provider") -> (
+          match string_opt_of_assoc "cascade_name" json with
+          | Some cascade_name ->
+            let configured_labels =
+              string_list_of_assoc "configured_labels" json
+            in
+            let required_tool_names =
+              string_list_of_assoc "required_tool_names" json
+            in
+            let rejections =
+              match
+                provider_rejections_of_assoc "provider_rejections" json
+              with
+              | [] ->
+                provider_rejection_reasons_of_assoc
+                  "rejection_reasons" json
+              | provider_rejections -> provider_rejections
+            in
+            let detail : Keeper_meta_contract.no_tool_capable_detail =
+              { configured_labels
+              ; required_tool_names
+              ; provider_rejections =
+                  List.map (fun r -> (r.provider_label, r.reason)) rejections
+              }
+            in
+            Some
+              (Cascade_exhausted
+                 {
+                   cascade_name = cascade_name;
+                   reason = Keeper_meta_contract.No_tool_capable (Some detail);
+                 })
+          | None -> None)
+      | Some (`String "accept_rejected") -> (
+          match string_opt_of_assoc "scope" json, string_opt_of_assoc "reason" json with
+          | Some scope, Some reason ->
+            Some
+              (Accept_rejected
+                 {
+                   scope;
+                   model = string_opt_of_assoc "model" json;
+                   reason;
+                 })
+          | _ -> None)
+      | Some (`String "admission_queue_timeout") -> (
+          match string_opt_of_assoc "keeper_name" json,
+                string_opt_of_assoc "cascade_name" json
+          with
+          | Some keeper_name, Some cascade_name ->
+            let wait_sec =
+              match json with
+              | `Assoc fields -> (
+                  match List.assoc_opt "wait_sec" fields with
+                  | Some (`Float v) -> v
+                  | _ -> 0.0)
+              | _ -> 0.0
+            in
+            Some
+              (Admission_queue_timeout
+                 {
+                   keeper_name;
+                   cascade_name = cascade_name;
+                   wait_sec;
+                 })
+          | _ -> None)
+      | Some (`String "admission_queue_rejected") -> (
+          match string_opt_of_assoc "keeper_name" json,
+                string_opt_of_assoc "reason" json
+          with
+          | Some keeper_name, Some reason ->
+            Some (Admission_queue_rejected { keeper_name; reason })
+          | _ -> None)
+      | Some (`String "turn_timeout") -> (
+          match json with
+          | `Assoc fields -> (
+              match List.assoc_opt "elapsed_sec" fields with
+              | Some (`Float v) ->
+                Some (Turn_timeout { elapsed_sec = v })
+              | _ -> None)
+          | _ -> None)
+      | Some (`String "provider_timeout") -> (
+          match json with
+          | `Assoc fields -> (
+              match
+                List.assoc_opt "budget_sec" fields,
+                List.assoc_opt "keeper_turn_timeout_sec" fields,
+                List.assoc_opt "estimated_input_tokens" fields,
+                List.assoc_opt "source" fields
+              with
+              | Some (`Float budget_sec),
+                Some (`Float keeper_turn_timeout_sec),
+                Some (`Int estimated_input_tokens),
+                Some (`String source) ->
+                  Some
+                    (Provider_timeout
+                       {
+                         budget_sec;
+                         keeper_turn_timeout_sec;
+                         estimated_input_tokens;
+                         source;
+                         remaining_turn_budget_sec =
+                           float_opt_of_assoc
+                             "remaining_turn_budget_sec" json;
+                         min_required_sec =
+                           Option.value ~default:0.0
+                             (float_opt_of_assoc "min_required_sec" json);
+                         phase =
+                           Option.value ~default:"unknown"
+                             (string_opt_of_assoc "phase" json);
+                       })
+              | _ -> None)
+          | _ -> None)
+      | Some (`String "max_tokens_ceiling_violation") -> (
+          match
+            string_opt_of_assoc "cascade_name" json,
+            int_opt_of_assoc "requested_max_tokens" json,
+            int_opt_of_assoc "provider_ceiling" json
+          with
+          | Some cascade_name, Some requested_max_tokens, Some provider_ceiling ->
+            Some
+              (Max_tokens_ceiling_violation
+                 {
+                   cascade_name = cascade_name;
+                   requested_max_tokens;
+                   provider_ceiling;
+                   reason =
+                     Option.value ~default:"unknown"
+                       (string_opt_of_assoc "reason" json);
+                 })
+          | _ -> None)
+      | Some (`String "ambiguous_post_commit") -> (
+          match string_opt_of_assoc "original_error" json with
+          | Some original_error ->
+            let is_timeout =
+              match json with
+              | `Assoc fields -> (
+                  match List.assoc_opt "is_timeout" fields with
+                  | Some (`Bool b) -> b
+                  | _ -> false)
+              | _ -> false
+            in
+            let tools =
+              match json with
+              | `Assoc fields -> (
+                  match List.assoc_opt "tools" fields with
+                  | Some (`List values) ->
+                    values
+                    |> List.filter_map (function
+                         | `String value -> Some value
+                         | _ -> None)
+                  | _ -> [])
+              | _ -> []
+            in
+            Some (Ambiguous_post_commit { is_timeout; tools; original_error })
+          | _ -> None)
+      | Some (`String "internal_unhandled_exception") -> (
+          match string_opt_of_assoc "site" json,
+                string_opt_of_assoc "exn_repr" json
+          with
+          | Some site, Some exn_repr ->
+            Some (Internal_unhandled_exception { site; exn_repr })
+          | _ -> None)
+      | Some (`String "internal_bridge_exception") -> (
+          match string_opt_of_assoc "caller" json,
+                string_opt_of_assoc "exn_repr" json
+          with
+          | Some caller, Some exn_repr ->
+            Some (Internal_bridge_exception { caller; exn_repr })
+          | _ -> None)
+      | Some (`String "internal_contract_rejected") -> (
+          match string_opt_of_assoc "reason" json with
+          | Some reason -> Some (Internal_contract_rejected { reason })
+          | _ -> None)
+      | _ -> None)
+  | _ -> None
+
+let classify_masc_internal_error_of_string (raw : string) :
+    masc_internal_error option =
+  let prefix = masc_internal_error_prefix in
+  let prefix_len = String.length prefix in
+  let raw_len = String.length raw in
+  let rec find_prefix start =
+    if start + prefix_len > raw_len then None
+    else if String.sub raw start prefix_len = prefix then Some start
+    else find_prefix (start + 1)
+  in
+  match find_prefix 0 with
+  | None -> None
+  | Some prefix_start ->
+    let payload_start = prefix_start + prefix_len in
+    let payload = String.sub raw payload_start (raw_len - payload_start) in
+    (try parse_masc_internal_error_json (Yojson.Safe.from_string payload)
+     with Yojson.Json_error _ -> None)
+
+let classify_masc_internal_error (err : Agent_sdk.Error.sdk_error) :
+    masc_internal_error option =
+  match err with
+  | Agent_sdk.Error.Internal msg -> classify_masc_internal_error_of_string msg
+  | _ -> None

--- a/lib/keeper/keeper_error_from_sdk.mli
+++ b/lib/keeper/keeper_error_from_sdk.mli
@@ -1,0 +1,25 @@
+(** Reverse-direction SDK envelope decoders for the [masc_internal_error] ADT.
+    See {!Keeper_meta_contract} for the forward codec.
+
+    @since RFC-0142 Phase 2 *)
+
+val parse_masc_internal_error_json :
+  Yojson.Safe.t -> Keeper_meta_contract.masc_internal_error option
+(** Parse a JSON value produced by
+    {!Keeper_meta_contract.masc_internal_error_to_json} back into the
+    [masc_internal_error] variant.  Returns [None] when the JSON shape does
+    not match any known constructor. *)
+
+val classify_masc_internal_error_of_string :
+  string -> Keeper_meta_contract.masc_internal_error option
+(** Parse a [masc_internal_error] from a raw string that may contain the
+    [[masc_oas_error]] prefix anywhere (e.g. embedded in a blocker text
+    wrapper).  Returns [None] when the prefix is absent or the JSON payload
+    is malformed. *)
+
+val classify_masc_internal_error :
+  Agent_sdk.Error.sdk_error -> Keeper_meta_contract.masc_internal_error option
+(** Parse an SDK error back into a [masc_internal_error] when it carries the
+    [[masc_oas_error]] prefix, including wrapped [Internal] messages where the
+    prefix is embedded inside a larger diagnostic.  Returns [None] when the
+    prefix is absent or the JSON payload is malformed. *)

--- a/lib/keeper/keeper_masc_error_classify.ml
+++ b/lib/keeper/keeper_masc_error_classify.ml
@@ -1,0 +1,89 @@
+(** Keeper_masc_error_classify — SDK error parser and substring classifier on top of
+    the {!Keeper_meta_contract} ADT.
+
+    RFC-0142 Phase 2 PR-1: the [masc_internal_error] ADT, its JSON codec, the
+    Prometheus accounting, and the per-variant kind/cascade_name labels were
+    moved to {!Keeper_meta_contract}.  This module now owns only:
+
+    - {!admission_wait_timeout_error} — construction-site helper that logs
+      and returns the [Admission_queue_timeout] variant as a [result];
+    - {!parse_masc_internal_error_json} — JSON parser that turns the typed
+      envelope written by [sdk_error_of_masc_internal_error] back into a
+      [masc_internal_error];
+    - {!classify_masc_internal_error*} — entry points for SDK errors and raw
+      strings carrying the envelope;
+    - {!sdk_error_is_server_rejected_parse_error} — the contained substring
+      classifier described in [keeper_meta_contract.ml]; this is the canonical
+      substring SSOT for "server rejected the request body".  Substring use
+      here is unavoidable because the upstream payload is a raw SDK string.
+
+    The {!Keeper_meta_contract} surface (types, [masc_internal_error_to_json],
+    [sdk_error_of_masc_internal_error], summaries, labels, metric name) is
+    re-exported via [include] so callers that reference
+    [Keeper_masc_error_classify.masc_internal_error], [Keeper_masc_error_classify.Cascade_exhausted],
+    etc. continue to compile unchanged.
+
+    @since God file decomposition *)
+
+open Result.Syntax
+
+include Keeper_meta_contract
+
+let admission_wait_timeout_error
+    ~(keeper_name : string)
+    ~(cascade_name : string)
+    ~(priority : Llm_provider.Request_priority.t)
+    (wait_ms : int) =
+  let wait_sec = float_of_int wait_ms /. 1000.0 in
+  let cascade_name_string = cascade_name in
+  let msg =
+    Printf.sprintf
+      "Admission queue wait timeout after %.1fs (wait_ms=%d, keeper=%s, cascade=%s, priority=%s)"
+      wait_sec wait_ms keeper_name cascade_name_string
+      (Llm_provider.Request_priority.to_string priority)
+  in
+  Log.Misc.warn "%s" msg;
+  Error
+    (sdk_error_of_masc_internal_error
+       (Admission_queue_timeout { keeper_name; cascade_name; wait_sec }))
+
+(** RFC-0142 Phase 2 PR-2: the JSON parser and SDK envelope decoders moved
+    to {!Keeper_error_from_sdk}; re-exported below so callers that reference
+    [Keeper_masc_error_classify.parse_masc_internal_error_json],
+    [Keeper_masc_error_classify.classify_masc_internal_error_of_string], and
+    [Keeper_masc_error_classify.classify_masc_internal_error] compile unchanged. *)
+
+let parse_masc_internal_error_json = Keeper_error_from_sdk.parse_masc_internal_error_json
+let classify_masc_internal_error_of_string = Keeper_error_from_sdk.classify_masc_internal_error_of_string
+let classify_masc_internal_error = Keeper_error_from_sdk.classify_masc_internal_error
+
+let string_contains_substring = String_util.string_contains_substring
+
+let sdk_error_is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) =
+  match err with
+  | Agent_sdk.Error.Provider (Llm_provider.Error.ParseError _) -> true
+  | Agent_sdk.Error.Api (InvalidRequest { message }) ->
+    let lower = String.lowercase_ascii message in
+    (string_contains_substring ~needle:"can't find closing" lower
+     || string_contains_substring ~needle:"find end of" lower)
+    || string_contains_substring ~needle:"unexpected character in json" lower
+    || string_contains_substring ~needle:"unterminated" lower
+    || string_contains_substring ~needle:"parse error" lower
+  | Agent_sdk.Error.Api
+      ( RateLimited _
+      | Overloaded _
+      | ServerError _
+      | AuthError _
+      | NotFound _
+      | ContextOverflow _
+      | NetworkError _
+      | Timeout _ )
+  | Agent_sdk.Error.Provider _
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> false

--- a/lib/keeper/keeper_masc_error_classify.mli
+++ b/lib/keeper/keeper_masc_error_classify.mli
@@ -1,0 +1,46 @@
+(** Keeper_masc_error_classify — SDK typed-envelope parser and the
+    {!admission_wait_timeout_error} construction helper.
+
+    RFC-0142 Phase 2 PR-1: the [masc_internal_error] ADT, its JSON codec, the
+    Prometheus accounting, and the per-variant kind/cascade_name labels live in
+    {!Keeper_meta_contract}.  This module [include]s that surface so callers
+    that reference [Keeper_masc_error_classify.masc_internal_error],
+    [Keeper_masc_error_classify.Cascade_exhausted], etc. continue to compile
+    unchanged.
+
+    @since God file decomposition *)
+
+(** {1 Re-exported [masc_internal_error] surface} *)
+
+include module type of Keeper_meta_contract
+
+(** {1 Construction helpers} *)
+
+val admission_wait_timeout_error :
+  keeper_name:string ->
+  cascade_name:string ->
+  priority:Llm_provider.Request_priority.t ->
+  int ->
+  (string, Agent_sdk.Error.sdk_error) result
+(** Build an [Admission_queue_timeout] error from a wait duration in ms. *)
+
+(** {1 Parsers} *)
+
+val classify_masc_internal_error :
+  Agent_sdk.Error.sdk_error -> masc_internal_error option
+(** Parse an SDK error back into a [masc_internal_error] when it carries the
+    [[masc_oas_error]] prefix, including wrapped [Internal] messages where the
+    prefix is embedded inside a larger diagnostic.  Returns [None] when the
+    prefix is absent or the JSON payload is malformed. *)
+
+val classify_masc_internal_error_of_string :
+  string -> masc_internal_error option
+(** Parse a [masc_internal_error] from a raw string that may contain
+    the [[masc_oas_error]] prefix anywhere (e.g. in a blocker text with
+    "Internal error: [masc_oas_error] ..." wrapper).  Returns [None]
+    when the prefix is absent or the JSON payload is malformed. *)
+
+val sdk_error_is_server_rejected_parse_error :
+  Agent_sdk.Error.sdk_error -> bool
+(** [true] when the provider rejected the request body before processing it
+    because the JSON/request payload could not be parsed. *)

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -736,3 +736,535 @@ let reject_legacy_model_args ~tool_name (args : Yojson.Safe.t) =
          tool_name
          (String.concat ", " fields))
 ;;
+
+
+(* === masc_internal_error (re-homed) ===
+   RFC-0142 + RFC-0206: masc_internal_error error-classify subsystem.
+   Re-homed from deleted [Cascade_internal_error] (cascade purge #19536);
+   [Cascade_name.t] collapsed to [string] (single-binding Runtime, RFC-0206 5).
+   Consumers already reference [Keeper_meta_contract.X] (prior partial rename);
+   this supplies the definitions so those references resolve.
+   FOLLOW-UP: extract into an included sub-file once green (file now ~1260 lines). *)
+
+let cascade_name_to_string (s : string) = s
+
+type provider_rejection = {
+  provider_label : string;
+  reason : string;
+}
+
+type capacity_backpressure_source =
+  | Provider_capacity
+  | Client_capacity
+  | Cascade_slot
+
+let capacity_backpressure_source_to_string = function
+  | Provider_capacity -> "provider_capacity"
+  | Client_capacity -> "client_capacity"
+  | Cascade_slot -> "cascade_slot"
+
+let capacity_backpressure_source_of_string = function
+  | "provider_capacity" -> Some Provider_capacity
+  | "client_capacity" -> Some Client_capacity
+  | "cascade_slot" -> Some Cascade_slot
+  | _ -> None
+
+(* RFC-0158: typed denial reason carried by {!Retry_admission_denied}.
+   Defined here (cascade layer) to avoid a dependency cycle with
+   [Keeper_turn_cascade_budget].  The keeper layer re-exports via
+   [type retry_admission_denial = Cascade_internal_error.retry_admission_denial]. *)
+type retry_admission_denial =
+  | Retry_budget_below_min of {
+      projected_usable_budget_s : float;
+      min_required_s : float;
+      remaining_turn_budget_s : float;
+      adaptive_timeout_s : float;
+      allow_wall_clock_retry_budget : bool;
+    }
+  | First_attempt_budget_below_min of {
+      projected_usable_budget_s : float;
+      min_required_s : float;
+      remaining_turn_budget_s : float;
+    }
+
+let retry_admission_denial_to_yojson = function
+  | Retry_budget_below_min
+      { projected_usable_budget_s; min_required_s; remaining_turn_budget_s;
+        adaptive_timeout_s; allow_wall_clock_retry_budget } ->
+    `Assoc
+      [
+        ("kind", `String "retry_budget_below_min");
+        ("projected_usable_budget_s", `Float projected_usable_budget_s);
+        ("min_required_s", `Float min_required_s);
+        ("remaining_turn_budget_s", `Float remaining_turn_budget_s);
+        ("adaptive_timeout_s", `Float adaptive_timeout_s);
+        ("allow_wall_clock_retry_budget", `Bool allow_wall_clock_retry_budget);
+      ]
+  | First_attempt_budget_below_min
+      { projected_usable_budget_s; min_required_s; remaining_turn_budget_s } ->
+    `Assoc
+      [
+        ("kind", `String "first_attempt_budget_below_min");
+        ("projected_usable_budget_s", `Float projected_usable_budget_s);
+        ("min_required_s", `Float min_required_s);
+        ("remaining_turn_budget_s", `Float remaining_turn_budget_s);
+      ]
+
+(** Provenance-preserving retry-after hint for capacity backpressure.
+
+    [Explicit] carries a concrete backoff to trust: an upstream-supplied
+    Retry-After (seconds, > 0) or a real locally-computed wait (e.g. a client
+    capacity cooldown).  [Synthetic_default] carries a fabricated fixed-default
+    backoff applied when no real signal was available.  [No_retry_hint] means
+    neither was available.
+
+    Keeping [Synthetic_default] distinct from [Explicit] at the type level
+    makes it impossible to launder a fabricated default into the explicit
+    path: the classifier and telemetry can always tell a real backoff from a
+    blind guess.  Replaces a [float option] carrier whose [None]->[Some
+    synthetic] injection (PR #19329) relabelled a synthetic backoff as an
+    explicit hint (audit 2026-05-29). *)
+type capacity_retry_after =
+  | Explicit of float
+  | Synthetic_default of float
+  | No_retry_hint
+
+type masc_internal_error =
+  | Cascade_exhausted of {
+      cascade_name : string;
+      reason : cascade_exhaustion_reason;
+    }
+  | Capacity_backpressure of {
+      cascade_name : string;
+      source : capacity_backpressure_source;
+      detail : string;
+      retry_after : capacity_retry_after;
+    }
+  | Resumable_cli_session of {
+      cascade_name : string;
+      detail : string;
+      exit_code : int option;
+    }
+  (* [No_tool_capable_provider] reclassified into [Cascade_exhausted
+     { reason = No_tool_capable _ }] — see keeper_meta_contract.ml. *)
+  | Accept_rejected of {
+      scope : string;
+      model : string option;
+      reason : string;
+    }
+  | Admission_queue_timeout of {
+      keeper_name : string;
+      cascade_name : string;
+      wait_sec : float;
+    }
+  | Admission_queue_rejected of {
+      keeper_name : string;
+      reason : string;
+    }
+  | Turn_timeout of {
+      elapsed_sec : float;
+    }
+  | Provider_timeout of {
+      budget_sec : float;
+      keeper_turn_timeout_sec : float;
+      estimated_input_tokens : int;
+      source : string;
+      remaining_turn_budget_sec : float option;
+      min_required_sec : float;
+      phase : string;
+    }
+  | Max_tokens_ceiling_violation of {
+      cascade_name : string;
+      requested_max_tokens : int;
+      provider_ceiling : int;
+      reason : string;
+    }
+  | Ambiguous_post_commit of {
+      is_timeout : bool;
+      tools : string list;
+      original_error : string;
+    }
+  (* RFC-0158: pre-dispatch admission denial — the keeper decided not to
+     attempt a provider call because the remaining turn budget was below
+     the minimum required for a single attempt.  Distinct from
+     [Provider_timeout] (case 1: provider tried and timed out) because
+     admission denial never reached the provider; cascade rotation and
+     supervisor pause-policy should treat it differently. *)
+  | Retry_admission_denied of {
+      denial_reason : retry_admission_denial;
+      is_retry : bool;
+    }
+  (* RFC-0159 Phase A: typed substrate for the three raw exception
+     construction sites previously emitting [Agent_sdk.Error.Internal
+     (Printexc.to_string exn)] payloads that the classifier could not
+     parse, falling through to the [Reason_internal_error] catch-all. *)
+  | Internal_unhandled_exception of {
+      site : string;
+      exn_repr : string;
+    }
+  | Internal_bridge_exception of {
+      caller : string;
+      exn_repr : string;
+    }
+  | Internal_contract_rejected of {
+      reason : string;
+    }
+
+let masc_internal_error_prefix = "[masc_oas_error] "
+
+let string_list_of_assoc key json =
+  match Json_field.list json key |> Json_field.to_option with
+  | None -> []
+  | Some values ->
+    values
+    |> List.filter_map (function
+         | `String value -> Some value
+         | _ -> None)
+;;
+
+let provider_rejection_of_json json =
+  let provider_label =
+    Json_field.string json "provider_label" |> Json_field.to_option
+    |> Option.value ~default:""
+  in
+  match Json_field.string json "reason" |> Json_field.to_option with
+  | Some reason -> Some { provider_label; reason }
+  | None -> None
+;;
+
+let provider_rejections_of_assoc key json =
+  match Json_field.list json key |> Json_field.to_option with
+  | None -> []
+  | Some values -> List.filter_map provider_rejection_of_json values
+;;
+
+let provider_rejection_reasons_of_assoc key json =
+  string_list_of_assoc key json
+  |> List.map (fun reason -> { provider_label = ""; reason })
+
+let provider_rejection_reasons rejections =
+  rejections
+  |> List.map (fun r -> String.trim r.reason)
+  |> List.filter (fun reason -> reason <> "")
+  |> Json_util.dedupe_keep_order
+
+let provider_rejections_json rejections =
+  `List
+    (List.map
+       (fun r ->
+         `Assoc
+           [
+             ("provider_label", `String r.provider_label);
+             ("reason", `String r.reason);
+           ])
+       rejections)
+
+let string_opt_of_assoc key json =
+  Json_field.string json key |> Json_field.to_option
+;;
+
+let masc_internal_error_to_json = function
+  | Cascade_exhausted { cascade_name; reason } ->
+    let cascade_name = cascade_name_to_string cascade_name in
+    `Assoc
+      [
+        ("kind", `String "cascade_exhausted");
+        ("cascade_name", `String cascade_name);
+        ("reason", cascade_exhaustion_reason_to_json reason);
+      ]
+  | Capacity_backpressure { cascade_name; source; detail; retry_after } ->
+    let cascade_name = cascade_name_to_string cascade_name in
+    (* Carry the backoff seconds for both real and synthetic hints (never
+       null when a backoff applies, satisfying telemetry consumers) plus an
+       explicit [retry_after_synthetic] flag so a synthetic default is never
+       read back as a provider hint on the JSON round-trip. *)
+    let retry_after_fields =
+      match retry_after with
+      | Explicit s ->
+        [ ("retry_after_sec", `Float s); ("retry_after_synthetic", `Bool false) ]
+      | Synthetic_default s ->
+        [ ("retry_after_sec", `Float s); ("retry_after_synthetic", `Bool true) ]
+      | No_retry_hint -> [ ("retry_after_sec", `Null) ]
+    in
+    `Assoc
+      ([
+         ("kind", `String "capacity_backpressure");
+         ("cascade_name", `String cascade_name);
+         ("source", `String (capacity_backpressure_source_to_string source));
+         ("detail", `String detail);
+       ]
+      @ retry_after_fields)
+  | Resumable_cli_session { cascade_name; detail; exit_code } ->
+    let cascade_name = cascade_name_to_string cascade_name in
+    `Assoc
+      [
+        ("kind", `String "resumable_cli_session");
+        ("cascade_name", `String cascade_name);
+        ("detail", `String detail);
+        ("exit_code", Json_util.int_opt_to_json exit_code);
+      ]
+  | Accept_rejected { scope; model; reason } ->
+    `Assoc
+      [
+        ("kind", `String "accept_rejected");
+        ("scope", `String scope);
+        ("model", Json_util.string_opt_to_json model);
+        ("reason", `String reason);
+      ]
+  | Admission_queue_timeout { keeper_name; cascade_name; wait_sec } ->
+    let cascade_name = cascade_name_to_string cascade_name in
+    `Assoc
+      [
+        ("kind", `String "admission_queue_timeout");
+        ("keeper_name", `String keeper_name);
+        ("cascade_name", `String cascade_name);
+        ("wait_sec", `Float wait_sec);
+      ]
+  | Admission_queue_rejected { keeper_name; reason } ->
+    `Assoc
+      [
+        ("kind", `String "admission_queue_rejected");
+        ("keeper_name", `String keeper_name);
+        ("reason", `String reason);
+      ]
+  | Turn_timeout { elapsed_sec } ->
+    `Assoc
+      [
+        ("kind", `String "turn_timeout");
+        ("elapsed_sec", `Float elapsed_sec);
+      ]
+  | Provider_timeout
+      {
+        budget_sec;
+        keeper_turn_timeout_sec;
+        estimated_input_tokens;
+        source;
+        remaining_turn_budget_sec;
+        min_required_sec;
+        phase;
+      } ->
+    `Assoc
+      [
+        ("kind", `String "provider_timeout");
+        ("budget_sec", `Float budget_sec);
+        ("keeper_turn_timeout_sec", `Float keeper_turn_timeout_sec);
+        ("estimated_input_tokens", `Int estimated_input_tokens);
+        ("source", `String source);
+        ( "remaining_turn_budget_sec",
+          Json_util.float_opt_to_json remaining_turn_budget_sec );
+        ("min_required_sec", `Float min_required_sec);
+        ("phase", `String phase);
+      ]
+  | Max_tokens_ceiling_violation
+      { cascade_name; requested_max_tokens; provider_ceiling; reason } ->
+    let cascade_name = cascade_name_to_string cascade_name in
+    `Assoc
+      [
+        ("kind", `String "max_tokens_ceiling_violation");
+        ("cascade_name", `String cascade_name);
+        ("requested_max_tokens", `Int requested_max_tokens);
+        ("provider_ceiling", `Int provider_ceiling);
+        ("reason", `String reason);
+      ]
+  | Ambiguous_post_commit { is_timeout; tools; original_error } ->
+    `Assoc
+      [
+        ("kind", `String "ambiguous_post_commit");
+        ("is_timeout", `Bool is_timeout);
+        ("tools", Json_util.json_string_list tools);
+        ("original_error", `String original_error);
+      ]
+  | Retry_admission_denied { denial_reason; is_retry } ->
+    `Assoc
+      [
+        ("kind", `String "retry_admission_denied");
+        ("denial_reason", retry_admission_denial_to_yojson denial_reason);
+        ("is_retry", `Bool is_retry);
+      ]
+  | Internal_unhandled_exception { site; exn_repr } ->
+    `Assoc
+      [
+        ("kind", `String "internal_unhandled_exception");
+        ("site", `String site);
+        ("exn_repr", `String exn_repr);
+      ]
+  | Internal_bridge_exception { caller; exn_repr } ->
+    `Assoc
+      [
+        ("kind", `String "internal_bridge_exception");
+        ("caller", `String caller);
+        ("exn_repr", `String exn_repr);
+      ]
+  | Internal_contract_rejected { reason } ->
+    `Assoc
+      [
+        ("kind", `String "internal_contract_rejected");
+        ("reason", `String reason);
+      ]
+
+let summarize_list ?(empty = "none") values =
+  match values with
+  | [] -> empty
+  | _ -> String.concat ", " values
+
+let summarize_provider_rejections rejections =
+  match provider_rejection_reasons rejections with
+  | [] -> "none"
+  | reasons -> String.concat "; " reasons
+
+let summary_of_masc_internal_error = function
+  | Capacity_backpressure { cascade_name; source; detail; retry_after } ->
+      let retry_after_suffix =
+        match retry_after with
+        | Explicit value -> Printf.sprintf "; retry_after=%.1fs" value
+        | Synthetic_default value ->
+          Printf.sprintf "; retry_after=%.1fs (synthetic)" value
+        | No_retry_hint -> ""
+      in
+      Some
+        (Printf.sprintf
+           "Capacity backpressure blocked cascade %s; source=%s; detail=%s%s"
+           (cascade_name_to_string cascade_name)
+           (capacity_backpressure_source_to_string source)
+           detail
+           retry_after_suffix)
+  | Provider_timeout
+      {
+        budget_sec;
+        keeper_turn_timeout_sec;
+        estimated_input_tokens;
+        source;
+        remaining_turn_budget_sec;
+        min_required_sec;
+        phase;
+      } ->
+      let remaining =
+        match remaining_turn_budget_sec with
+        | Some value -> Printf.sprintf "%.1fs" value
+        | None -> "unknown"
+      in
+      Some
+        (Printf.sprintf
+           "Provider timeout exhausted; phase=%s; source=%s; budget=%.1fs; remaining=%s; min_required=%.1fs; estimated_input_tokens=%d; keeper_turn_timeout=%.1fs"
+           phase source budget_sec remaining min_required_sec
+           estimated_input_tokens keeper_turn_timeout_sec)
+  | Max_tokens_ceiling_violation
+      { cascade_name; requested_max_tokens; provider_ceiling; reason } ->
+    Some
+      (Printf.sprintf
+         "Invalid max_tokens budget for cascade %s; requested_max_tokens=%d; provider_ceiling=%d; reason=%s"
+         (cascade_name_to_string cascade_name)
+         requested_max_tokens
+         provider_ceiling
+         reason)
+  (* Variants without a custom long-form summary: callers fall back to
+     [kind_of_masc_internal_error] / the JSON payload.  Enumerated
+     explicitly so adding a new [masc_internal_error] variant forces
+     a decision on whether it deserves a long-form summary string. *)
+  | Retry_admission_denied { denial_reason; is_retry } ->
+      Some
+        (Printf.sprintf
+           "Pre-dispatch admission denied; is_retry=%b; reason=%s"
+           is_retry
+           (retry_admission_denial_to_yojson denial_reason
+            |> Yojson.Safe.to_string))
+  | Cascade_exhausted { cascade_name; reason = No_tool_capable (Some detail) } ->
+    let cascade_name = cascade_name_to_string cascade_name in
+    Some
+      (Printf.sprintf
+         "No tool-capable provider for cascade %s; required_tools=[%s]; rejected_candidate_count=%d; configured_candidate_count=%d"
+         cascade_name
+         (summarize_list detail.required_tool_names)
+         (List.length detail.provider_rejections)
+         (List.length detail.configured_labels))
+  | Cascade_exhausted _
+  | Resumable_cli_session _
+  | Accept_rejected _
+  | Admission_queue_timeout _
+  | Admission_queue_rejected _
+  | Turn_timeout _
+  | Ambiguous_post_commit _
+  | Internal_unhandled_exception _
+  | Internal_bridge_exception _
+  | Internal_contract_rejected _ -> None
+
+(* #9933: classify emitted [masc_oas_error] payloads by kind so
+   dashboards and Grafana alerts can watch the fleet-wide rate per
+   error class (cascade_exhausted vs provider_timeout vs
+   ambiguous_post_commit, etc.) rather than reading the free-form
+   BDI blocker string.  Historical provider-timeout events accumulated across 9 keepers in 24h
+   without an aggregate signal — this counter is the per-kind surface.
+
+   Emit point is this constructor so all 14 call sites of
+   [sdk_error_of_masc_internal_error] are covered automatically,
+   without changing their signatures or threading [keeper_name]
+   through callers that do not have it readily.  A follow-up PR
+   can add a [keeper] label once every construction site has the
+   name in scope. *)
+let masc_oas_error_total_metric = "masc_oas_error_total"
+
+let () =
+  Prometheus.register_counter
+    ~name:masc_oas_error_total_metric
+    ~help:
+      "Total MASC-internal errors emitted as Agent_sdk.Error.Internal \
+       payloads, classified by structured error kind. Labels: \
+       kind (cascade_exhausted | capacity_backpressure | resumable_cli_session | \
+       accept_rejected | \
+       admission_queue_timeout | admission_queue_rejected | \
+       turn_timeout | provider_timeout | retry_admission_denied | \
+       max_tokens_ceiling_violation | \
+       ambiguous_post_commit | internal_unhandled_exception | \
+       internal_bridge_exception | internal_contract_rejected), \
+       cascade_name (originating cascade or \"unknown\" for \
+       cascade-less variants)."
+    ()
+
+let kind_of_masc_internal_error = function
+  | Cascade_exhausted _ -> "cascade_exhausted"
+  | Capacity_backpressure _ -> "capacity_backpressure"
+  | Resumable_cli_session _ -> "resumable_cli_session"
+  | Accept_rejected _ -> "accept_rejected"
+  | Admission_queue_timeout _ -> "admission_queue_timeout"
+  | Admission_queue_rejected _ -> "admission_queue_rejected"
+  | Turn_timeout _ -> "turn_timeout"
+  | Provider_timeout _ -> "provider_timeout"
+  | Max_tokens_ceiling_violation _ -> "max_tokens_ceiling_violation"
+  | Ambiguous_post_commit _ -> "ambiguous_post_commit"
+  | Retry_admission_denied _ -> "retry_admission_denied"
+  | Internal_unhandled_exception _ -> "internal_unhandled_exception"
+  | Internal_bridge_exception _ -> "internal_bridge_exception"
+  | Internal_contract_rejected _ -> "internal_contract_rejected"
+
+(* #10285: which cascade emitted this error.  See sibling docstring
+   in cascade_error_classify.ml history for the rationale — operators
+   could not attribute cascade-level error rates without this label. *)
+let cascade_name_of_masc_internal_error = function
+  | Cascade_exhausted { cascade_name; _ }
+  | Capacity_backpressure { cascade_name; _ }
+  | Resumable_cli_session { cascade_name; _ }
+  | Admission_queue_timeout { cascade_name; _ }
+  | Max_tokens_ceiling_violation { cascade_name; _ } ->
+      let cascade_name = cascade_name_to_string cascade_name in
+      if String.equal (String.trim cascade_name) "" then "unknown"
+      else cascade_name
+  | Accept_rejected _
+  | Admission_queue_rejected _
+  | Turn_timeout _
+  | Provider_timeout _
+  | Retry_admission_denied _
+  | Ambiguous_post_commit _
+  | Internal_unhandled_exception _
+  | Internal_bridge_exception _
+  | Internal_contract_rejected _ -> "unknown"
+
+let sdk_error_of_masc_internal_error err =
+  Prometheus.inc_counter masc_oas_error_total_metric
+    ~labels:
+      [
+        ("kind", kind_of_masc_internal_error err);
+        ("cascade_name", cascade_name_of_masc_internal_error err);
+      ]
+    ();
+  Agent_sdk.Error.Internal
+    (masc_internal_error_prefix ^ Yojson.Safe.to_string (masc_internal_error_to_json err))

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -457,3 +457,198 @@ val reject_legacy_model_args :
 (** Reject retired keeper model-selection input fields at tool/API boundaries.
     Model and provider identity is resolved from [cascade_name] and the cascade
     catalog, not per-call keeper arguments. *)
+
+(** {1 masc_internal_error error-classify subsystem (RFC-0142 + RFC-0206)}
+    Re-homed from deleted [Cascade_internal_error]; cascade_name is now [string]. *)
+
+(** {1 Provider rejection payload}
+
+    Carried inside [Cascade_exhausted { reason = No_tool_capable _ }] to
+    record per-candidate rejection reasons.  The
+    {!provider_rejection_reasons_of_assoc} and {!provider_rejections_of_assoc}
+    JSON helpers are internal to this module and used by the parser in
+    {!Cascade_error_classify}. *)
+
+type provider_rejection = {
+  provider_label : string;
+  reason : string;
+}
+
+(** {1 Capacity backpressure source}
+
+    Names the system component that issued the backpressure signal.  Used by
+    operators and dashboards to attribute saturation to a specific cascade. *)
+
+type capacity_backpressure_source =
+  | Provider_capacity
+  | Client_capacity
+  | Cascade_slot
+
+val capacity_backpressure_source_to_string :
+  capacity_backpressure_source -> string
+
+val capacity_backpressure_source_of_string :
+  string -> capacity_backpressure_source option
+
+(** {1 [masc_internal_error] ADT}
+
+    Closed-sum type for every structured cascade-layer failure that crosses
+    the [Agent_sdk.Error.Internal _] boundary.  New variants belong here;
+    growing the {!Cascade_error_classify} substring catch-all is the
+    anti-pattern this RFC is closing. *)
+
+(** RFC-0158: typed denial reason carried by {!Retry_admission_denied}.
+    Defined here (cascade layer) to avoid a dependency cycle with
+    [Keeper_turn_cascade_budget].  The keeper layer re-exports via
+    [type retry_admission_denial = Cascade_internal_error.retry_admission_denial]. *)
+
+type retry_admission_denial =
+  | Retry_budget_below_min of {
+      projected_usable_budget_s : float;
+      min_required_s : float;
+      remaining_turn_budget_s : float;
+      adaptive_timeout_s : float;
+      allow_wall_clock_retry_budget : bool;
+    }
+  | First_attempt_budget_below_min of {
+      projected_usable_budget_s : float;
+      min_required_s : float;
+      remaining_turn_budget_s : float;
+    }
+
+val retry_admission_denial_to_yojson :
+  retry_admission_denial -> Yojson.Safe.t
+
+(** Provenance-preserving retry-after hint for capacity backpressure.
+    [Explicit] is a concrete backoff to trust (an upstream Retry-After or a
+    real locally-computed wait); [Synthetic_default] is a fabricated
+    fixed-default applied when no real signal was available; [No_retry_hint]
+    means neither.  Keeping synthetic distinct from explicit at the type level
+    prevents a fabricated default being laundered into the explicit path
+    (audit 2026-05-29, PR #19329). *)
+type capacity_retry_after =
+  | Explicit of float
+  | Synthetic_default of float
+  | No_retry_hint
+
+type masc_internal_error =
+  | Cascade_exhausted of {
+      cascade_name : string;
+      reason : cascade_exhaustion_reason;
+    }
+  | Capacity_backpressure of {
+      cascade_name : string;
+      source : capacity_backpressure_source;
+      detail : string;
+      retry_after : capacity_retry_after;
+    }
+  | Resumable_cli_session of {
+      cascade_name : string;
+      detail : string;
+      exit_code : int option;
+    }
+  (* [No_tool_capable_provider] reclassified into [Cascade_exhausted
+     { reason = No_tool_capable _ }] — see keeper_meta_contract.ml. *)
+  | Accept_rejected of {
+      scope : string;
+      model : string option;
+      reason : string;
+    }
+  | Admission_queue_timeout of {
+      keeper_name : string;
+      cascade_name : string;
+      wait_sec : float;
+    }
+  | Admission_queue_rejected of {
+      keeper_name : string;
+      reason : string;
+    }
+  | Turn_timeout of { elapsed_sec : float }
+  | Provider_timeout of {
+      budget_sec : float;
+      keeper_turn_timeout_sec : float;
+      estimated_input_tokens : int;
+      source : string;
+      remaining_turn_budget_sec : float option;
+      min_required_sec : float;
+      phase : string;
+    }
+  | Max_tokens_ceiling_violation of {
+      cascade_name : string;
+      requested_max_tokens : int;
+      provider_ceiling : int;
+      reason : string;
+    }
+  | Ambiguous_post_commit of {
+      is_timeout : bool;
+      tools : string list;
+      original_error : string;
+    }
+  (** RFC-0158: pre-dispatch admission denial.  The keeper decided not to
+      attempt a provider call because the remaining turn budget was below the
+      minimum required for a single attempt.  Semantically distinct from
+      [Provider_timeout]: admission denial never reached the provider, so
+      cascade rotation and supervisor pause-policy should treat it differently.
+
+      [denial_reason] carries the typed budget breakdown from
+      {!Keeper_turn_cascade_budget.retry_admission_denial}; [is_retry]
+      distinguishes retry-path from first-attempt denials. *)
+  | Retry_admission_denied of {
+      denial_reason : retry_admission_denial;
+      is_retry : bool;
+    }
+  (** RFC-0159 Phase A: typed substrate for raw [Agent_sdk.Error.Internal]
+      construction sites.  Before Phase A, three sites built [Internal] with
+      [Printexc.to_string exn] payloads that the classifier could not parse,
+      so all of them fell through to the [Reason_internal_error] catch-all
+      bucket.  These variants prefix the payload with the typed
+      [[masc_oas_error]] envelope so {!Cascade_error_classify.classify_masc_internal_error}
+      can route them to dedicated kinds. *)
+  | Internal_unhandled_exception of { site : string; exn_repr : string }
+  | Internal_bridge_exception of { caller : string; exn_repr : string }
+  | Internal_contract_rejected of { reason : string }
+
+(** {1 Codec} *)
+
+val masc_internal_error_prefix : string
+(** Envelope prefix used in [Agent_sdk.Error.Internal _] payloads built by
+    {!sdk_error_of_masc_internal_error}.  The parser in
+    {!Cascade_error_classify} matches on this prefix. *)
+
+val masc_internal_error_to_json : masc_internal_error -> Yojson.Safe.t
+
+(** {2 Per-field helpers used by the parser in {!Cascade_error_classify}} *)
+
+val string_list_of_assoc : string -> Yojson.Safe.t -> string list
+val provider_rejection_of_json : Yojson.Safe.t -> provider_rejection option
+val provider_rejections_of_assoc :
+  string -> Yojson.Safe.t -> provider_rejection list
+val provider_rejection_reasons_of_assoc :
+  string -> Yojson.Safe.t -> provider_rejection list
+val provider_rejection_reasons : provider_rejection list -> string list
+val string_opt_of_assoc : string -> Yojson.Safe.t -> string option
+
+(** {1 Summaries and labels} *)
+
+val summary_of_masc_internal_error : masc_internal_error -> string option
+(** Operator-facing concise summary for structured errors where the raw JSON
+    payload is too noisy for dashboard cards. *)
+
+val kind_of_masc_internal_error : masc_internal_error -> string
+(** Short label for each variant, used as the [kind] Prometheus label. *)
+
+val cascade_name_of_masc_internal_error : masc_internal_error -> string
+(** Cascade name from the error payload, or ["unknown"] for variants that
+    fire outside cascade context. *)
+
+(** {1 Prometheus accounting} *)
+
+val masc_oas_error_total_metric : string
+(** Prometheus counter metric name for structured MASC OAS errors.  Registered
+    by this module at first load; do not register again. *)
+
+val sdk_error_of_masc_internal_error :
+  masc_internal_error -> Agent_sdk.Error.sdk_error
+(** Convert a [masc_internal_error] to an SDK error, bumping the
+    [masc_oas_error_total] Prometheus counter with [kind] and [cascade_name]
+    labels. *)

--- a/lib/keeper/keeper_provider_outcome.ml
+++ b/lib/keeper/keeper_provider_outcome.ml
@@ -1,0 +1,25 @@
+(** Keeper_provider_outcome — provider call outcome type.
+
+    Re-homed from the deleted [Cascade_fsm] module (RFC-0206 L2). The pure
+    failover [decide] routing engine and its [Cascade_metrics]/
+    [Cascade_health_filter] dependencies were intentionally dropped: they had
+    no live callers under single-binding. See the .mli for the full rationale. *)
+
+type provider_outcome =
+  | Call_ok of Llm_provider.Types.api_response [@tla.symbol "call_ok"]
+  | Call_err of Llm_provider.Http_client.http_error [@tla.symbol "call_err"]
+  | Accept_rejected of {
+      response : Llm_provider.Types.api_response;
+      reason : string;
+    }
+      [@tla.symbol "accept_rejected"]
+[@@deriving tla]
+
+let provider_outcome_to_string = function
+  | Call_ok _ -> "call-ok"
+  | Call_err _ -> "call-err"
+  | Accept_rejected _ -> "accept-rejected"
+
+let provider_outcome_option_to_string = function
+  | Some outcome -> "some-" ^ provider_outcome_to_string outcome
+  | None -> "none"

--- a/lib/keeper/keeper_provider_outcome.mli
+++ b/lib/keeper/keeper_provider_outcome.mli
@@ -1,0 +1,20 @@
+(** Keeper_provider_outcome — provider call outcome type.
+
+    Re-homed from the deleted [Cascade_fsm] module (RFC-0206 L2). The
+    multi-provider failover [decide]/[decision] routing engine was NOT
+    re-homed: it had no live callers (referenced only in doc comments) and
+    belongs to the cascade routing layer being collapsed under single-binding.
+    Only the [provider_outcome] type and its string projections survive; they
+    are consumed by the typed SDK-error classification layer
+    ([Keeper_sdk_error_classify]) and the turn-driver facade. *)
+
+type provider_outcome =
+  | Call_ok of Llm_provider.Types.api_response
+  | Call_err of Llm_provider.Http_client.http_error
+  | Accept_rejected of {
+      response : Llm_provider.Types.api_response;
+      reason : string;
+    }
+
+val provider_outcome_to_string : provider_outcome -> string
+val provider_outcome_option_to_string : provider_outcome option -> string

--- a/lib/keeper/keeper_sdk_error_classify.ml
+++ b/lib/keeper/keeper_sdk_error_classify.ml
@@ -208,35 +208,14 @@ let openai_compat_not_found_hint_marker = "OpenAI-compatible endpoint returned 4
 
 let cascade_name_to_string = Fun.id
 
-let resolve_provider_api_key_env_name ~cascade_name ~provider_cfg =
-  let cascade_name = cascade_name_to_string cascade_name in
-  let provider_name =
-    Llm_provider.Provider_registry.provider_name_of_config provider_cfg
-  in
-  let fallback_env =
-    Llm_provider.Provider_config.default_api_key_env provider_cfg.kind
-    |> Option.value ~default:""
-  in
-  let resolve_from_overrides overrides =
-    let find_non_empty key =
-      match List.assoc_opt key overrides with
-      | Some value when String.trim value <> "" -> Some value
-      | _ -> None
-    in
-    match find_non_empty provider_name with
-    | Some env_name -> env_name
-    | None ->
-      (match find_non_empty "*" with
-       | Some env_name -> env_name
-       | None -> fallback_env)
-  in
-  match Cascade_oas_runner.default_config_path () with
-  | Some config_path ->
-    let overrides =
-      Cascade_config.resolve_api_key_env ~config_path ~name:cascade_name
-    in
-    resolve_from_overrides overrides
-  | None -> fallback_env
+let resolve_provider_api_key_env_name ~cascade_name:_
+    ~(provider_cfg : Llm_provider.Provider_config.t) =
+  (* RFC-0206 L2: per-cascade api_key_env overrides were read from the cascade
+     config layer ([Cascade_config]/[Cascade_oas_runner]), which is removed
+     under single-binding. Runtime now resolves the provider api_key directly,
+     so the AuthError hint falls back to the provider's default api_key env. *)
+  Llm_provider.Provider_config.default_api_key_env provider_cfg.kind
+  |> Option.value ~default:""
 
 let enrich_sdk_error ~cascade_name
     ~(provider_cfg : Llm_provider.Provider_config.t)
@@ -248,8 +227,7 @@ let enrich_sdk_error ~cascade_name
       Printf.sprintf "%s (%s: %s)" message hint_marker detail
   in
   match err with
-  | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError { message })
-    when not (Llm_provider.Provider_config.is_subprocess_cli provider_cfg.kind) ->
+  | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError { message }) ->
     let env_name =
       match resolve_provider_api_key_env_name ~cascade_name ~provider_cfg with
       | "" -> "configured provider API key env"
@@ -519,9 +497,9 @@ let sdk_error_is_hard_quota (err : Agent_sdk.Error.sdk_error) : bool =
 let provider_label provider =
   match String.trim provider with
   | "" ->
-      Prometheus.inc_counter
-        Prometheus.metric_cascade_attempt_empty_provider_label
-        ();
+      (* RFC-0206 L2: the cascade-attempt empty-provider-label counter was
+         removed with the cascade Prometheus metrics. The WARN below is kept
+         so an empty provider (a call-site bug) is not silently substituted. *)
       let bt =
         Printexc.raw_backtrace_to_string (Printexc.get_callstack 6)
       in
@@ -724,59 +702,14 @@ let emit_oas_run_timeout_metric ~cascade_name ~provider:_ err =
         ()
   | _ -> ()
 
-let classify_saturation_signal_kind
-    (err : Agent_sdk.Error.sdk_error) :
-    Cascade_saturation_signal.kind option =
-  let typed_kind =
-    match Keeper_masc_error_classify.classify_masc_internal_error err with
-    | Some (Keeper_masc_error_classify.Provider_timeout _) ->
-        Some Cascade_saturation_signal.K_time_cap_fired
-    | _ -> None
-  in
-  match typed_kind with
-  | Some _ as kind -> kind
-  | None -> (
-    match err with
-    | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _) ->
-        Some Cascade_saturation_signal.K_provider_rate_limited
-    | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _)
-    | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _)
-    | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
-    | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError _)
-    | Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest _)
-    | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
-    | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)
-    | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError _)
-    | Agent_sdk.Error.Provider _
-    | Agent_sdk.Error.Agent _
-    | Agent_sdk.Error.Mcp _
-    | Agent_sdk.Error.Config _
-    | Agent_sdk.Error.Serialization _
-    | Agent_sdk.Error.Io _
-    | Agent_sdk.Error.Orchestration _
-    | Agent_sdk.Error.A2a _
-    | Agent_sdk.Error.Internal _ -> None)
-
-let maybe_emit_cascade_saturation_signal ~cascade_name ~provider:_ err =
-  if Env_config_keeper.CascadeSaturationSignal.enabled () then
-    match classify_saturation_signal_kind err with
-    | None -> ()
-    | Some kind ->
-        let cascade_name_str =
-          provider_label (cascade_name_to_string cascade_name)
-        in
-        Prometheus.inc_counter
-          Keeper_metrics.(to_string CascadeSaturationSignal)
-          ~labels:
-            [
-              (label_kind, Cascade_saturation_signal.kind_to_string kind);
-              (label_cascade, cascade_name_str);
-            ]
-          ()
+(* RFC-0206 L2: cascade saturation-signal telemetry removed. The cascade
+   routing abstraction it instrumented (multi-provider failover) no longer
+   exists under single-binding, so [classify_saturation_signal_kind] and
+   [maybe_emit_cascade_saturation_signal] had no remaining meaning and were
+   dropped along with the deleted [Cascade_saturation_signal] module. *)
 
 let emit_sdk_provider_error_metric ~cascade_name ~provider err =
   emit_oas_run_timeout_metric ~cascade_name ~provider err;
-  maybe_emit_cascade_saturation_signal ~cascade_name ~provider err;
   match sdk_error_to_provider_error ~provider err with
   | None -> None
   | Some provider_error ->

--- a/lib/keeper/keeper_sdk_error_classify.ml
+++ b/lib/keeper/keeper_sdk_error_classify.ml
@@ -1,0 +1,828 @@
+(** Keeper_sdk_error_classify — SDK error to FSM outcome, session/resumption analysis.
+
+    Extracted from oas_worker_named.ml (God file decomposition).
+    Converts OAS SDK errors into Keeper_provider_outcome provider outcomes,
+    classifies CLI-wrapped hard-quota patterns,
+    and enriches errors with provider-specific hints.
+
+    @since God file decomposition *)
+
+(* DEPRECATED (RFC-0057 Phase 2): These string classifiers will be
+   replaced by typed Provider_error variants. The new dispatch path
+   receives CliWrapped { kind = Hard_quota | ... }
+   directly from the provider adapter, eliminating the need for
+   substring reconstruction.
+
+   During the transition window, these functions remain for
+   backward compatibility with old provider adapters that still
+   emit InvalidRequest { message }. They will be removed once
+   the Llm_provider opam pin is bumped to the RFC-0057 Phase 1
+   version. *)
+let retry_message_looks_like_not_found (message : string) : bool =
+  String_util.contains_substring_ci message "not found"
+  || String_util.contains_substring_ci message "status code: 404"
+  || String_util.contains_substring_ci message "404 page not found"
+
+let label_provider = "provider"
+let label_kind = "kind"
+let label_cascade_name = "cascade_name"
+let label_capacity_scope = "capacity_scope"
+let label_cascade = "cascade"
+let label_source = "source"
+let fallback_class_hard_quota = "hard_quota"
+let fallback_class_max_turns = "max_turns"
+let fallback_class_required_tool_contract_violation =
+  "required_tool_contract_violation"
+
+let retry_message_looks_like_model_access_denied (message : string) : bool =
+  String_util.contains_substring_ci message "permission to access"
+  || String_util.contains_substring_ci message "not have access to"
+  || String_util.contains_substring_ci message "does not have access to"
+  || String_util.contains_substring_ci message "not authorized to access"
+
+let provider_capacity_scope_to_http =
+  Keeper_sdk_error_classify_http_error.provider_capacity_scope_to_http
+let provider_error_to_http_error =
+  Keeper_sdk_error_classify_http_error.provider_error_to_http_error
+
+let capacity_backpressure_source_to_failure_scope = function
+  | Keeper_masc_error_classify.Provider_capacity ->
+    Llm_provider.Http_client.Failure_scope_provider
+  | Keeper_masc_error_classify.Client_capacity ->
+    Llm_provider.Http_client.Failure_scope_account
+  | Keeper_masc_error_classify.Cascade_slot ->
+    Llm_provider.Http_client.Failure_scope_unknown
+
+(** Convert an OAS sdk_error into a Keeper_provider_outcome provider_outcome.
+    API-level errors and model-capability-dependent agent errors are
+    cascadeable (a different provider may succeed).  Structural agent
+    errors (budget, idle, exit) are not — they would recur on any model. *)
+let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
+    : Keeper_provider_outcome.provider_outcome option =
+  match Keeper_masc_error_classify.classify_masc_internal_error err with
+  | Some (Keeper_masc_error_classify.Resumable_cli_session { detail; _ }) ->
+    Some
+      (Keeper_provider_outcome.Call_err
+         (Llm_provider.Http_client.NetworkError
+            { message = detail; kind = Llm_provider.Http_client.Unknown }))
+  (* All other MASC-internal classifications (and unclassified errors) fall
+     through to the structured [match err with] below to derive the cascade
+     outcome from the raw [sdk_error] payload. *)
+  | Some (Keeper_masc_error_classify.Capacity_backpressure { detail; retry_after; source; _ }) ->
+    (* Re-expose only a concrete backoff as the Http [retry_after]; a synthetic
+       default is dropped to [None] so it is not re-derived as an explicit hint
+       on the next pass. *)
+    let retry_after_sec =
+      match retry_after with
+      | Keeper_meta_contract.Explicit s -> Some s
+      | Keeper_meta_contract.Synthetic_default _
+      | Keeper_meta_contract.No_retry_hint -> None
+    in
+    Some
+      (Keeper_provider_outcome.Call_err
+         (Llm_provider.Http_client.ProviderFailure
+            { kind =
+                Llm_provider.Http_client.Capacity_exhausted
+                  { scope = capacity_backpressure_source_to_failure_scope source
+                  ; retry_after = retry_after_sec
+                  ; model = None
+                  }
+            ; message = detail
+            }))
+  | Some (Keeper_masc_error_classify.Cascade_exhausted _)
+
+  | Some (Keeper_masc_error_classify.Accept_rejected _)
+  | Some (Keeper_masc_error_classify.Admission_queue_timeout _)
+  | Some (Keeper_masc_error_classify.Admission_queue_rejected _)
+  | Some (Keeper_masc_error_classify.Turn_timeout _)
+  | Some (Keeper_masc_error_classify.Provider_timeout _)
+  | Some (Keeper_masc_error_classify.Max_tokens_ceiling_violation _)
+  | Some (Keeper_masc_error_classify.Ambiguous_post_commit _)
+  (* RFC-0158: admission denial falls through — no provider was attempted,
+     so there is no cascade-outcome to derive from the provider response. *)
+  | Some (Keeper_masc_error_classify.Retry_admission_denied _)
+  (* RFC-0159 Phase A: opaque internal failures fall through to the raw
+     sdk_error match below; they have no typed cascade-outcome mapping. *)
+  | Some (Keeper_masc_error_classify.Internal_unhandled_exception _)
+  | Some (Keeper_masc_error_classify.Internal_bridge_exception _)
+  | Some (Keeper_masc_error_classify.Internal_contract_rejected _)
+  | None -> (
+  match err with
+  | Agent_sdk.Error.Api api_err ->
+    let http_err = match[@warning "-8"] api_err with
+      | Llm_provider.Retry.InvalidRequest { message } ->
+        if retry_message_looks_like_model_access_denied message then
+          Llm_provider.Http_client.ProviderFailure
+            {
+              kind =
+                Llm_provider.Http_client.Capability_mismatch
+                  { capability = Some "model_access" };
+              message;
+            }
+        else
+          let code =
+            if retry_message_looks_like_not_found message then 404 else 400
+          in
+          Llm_provider.Http_client.HttpError { code; body = message }
+      | Llm_provider.Retry.ContextOverflow { message; _ } ->
+        Llm_provider.Http_client.HttpError { code = 400; body = message }
+      | Llm_provider.Retry.RateLimited { message; _ } ->
+        Llm_provider.Http_client.HttpError { code = 429; body = message }
+      | Llm_provider.Retry.NotFound { message } ->
+        Llm_provider.Http_client.HttpError { code = 404; body = message }
+      | Llm_provider.Retry.ServerError { status; message } ->
+        Llm_provider.Http_client.HttpError { code = status; body = message }
+      | Llm_provider.Retry.AuthError { message } ->
+        Llm_provider.Http_client.HttpError { code = 401; body = message }
+      | Llm_provider.Retry.Overloaded { message } ->
+        Llm_provider.Http_client.HttpError { code = 529; body = message }
+      | Llm_provider.Retry.NetworkError { message; kind } ->
+        Llm_provider.Http_client.NetworkError { message; kind }
+      | Llm_provider.Retry.Timeout { message } ->
+        Llm_provider.Http_client.NetworkError
+          { message; kind = Llm_provider.Http_client.Timeout }
+    in
+    Some (Keeper_provider_outcome.Call_err http_err)
+  | Agent_sdk.Error.Provider provider_err ->
+    Some (Keeper_provider_outcome.Call_err (provider_error_to_http_error provider_err))
+  (* Model-capability errors: the next provider may handle these.
+     CompletionContractViolation: model returned text when tool_use was
+     required — a different model with better tool calling may succeed.
+     UnrecognizedStopReason: model returned a non-standard stop reason
+     that this provider does not map — another provider may not. *)
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.CompletionContractViolation { reason; _ }) ->
+    Some (Keeper_provider_outcome.Call_err
+      (Llm_provider.Http_client.AcceptRejected { reason }))
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.UnrecognizedStopReason { reason }) ->
+    Some (Keeper_provider_outcome.Call_err
+      (Llm_provider.Http_client.AcceptRejected { reason }))
+  | Agent_sdk.Error.Config
+      (Agent_sdk.Error.InvalidConfig { field = "runtime_mcp_auth"; detail })
+  | Agent_sdk.Error.Config
+      (Agent_sdk.Error.InvalidConfig { field = "tool_support"; detail }) ->
+    Some
+      (Keeper_provider_outcome.Call_err
+         (Llm_provider.Http_client.AcceptRejected { reason = detail }))
+  (* Other Agent error variants are structural (budget, idle, exit, retries,
+     guardrails, tripwires) and would recur on any model — not cascadeable. *)
+  | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
+  | Agent_sdk.Error.Agent (AgentExecutionTimeout _)
+  | Agent_sdk.Error.Agent (TokenBudgetExceeded _)
+  | Agent_sdk.Error.Agent (CostBudgetExceeded _)
+  | Agent_sdk.Error.Agent (CostBudgetUnenforceable _)
+  | Agent_sdk.Error.Agent (IdleDetected _)
+  | Agent_sdk.Error.Agent (ToolRetryExhausted _)
+  | Agent_sdk.Error.Agent (GuardrailViolation _)
+  | Agent_sdk.Error.Agent (TripwireViolation _)
+  | Agent_sdk.Error.Agent (ExitConditionMet _)
+  | Agent_sdk.Error.Agent (InputRequired _) -> None
+  (* Other Config errors (different InvalidConfig field, MissingEnvVar,
+     UnsupportedProvider) and non-Api / non-Agent / non-Config families are
+     not cascade-recoverable. *)
+  | Agent_sdk.Error.Config (InvalidConfig _)
+  | Agent_sdk.Error.Config (MissingEnvVar _)
+  | Agent_sdk.Error.Config (UnsupportedProvider _)
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> None)
+
+let sdk_error_is_model_access_denied (err : Agent_sdk.Error.sdk_error) =
+  match sdk_error_to_cascade_outcome err with
+  | Some
+      (Keeper_provider_outcome.Call_err
+         (Llm_provider.Http_client.ProviderFailure
+            {
+              kind =
+                Llm_provider.Http_client.Capability_mismatch
+                  { capability = Some "model_access" };
+              _;
+            })) ->
+    true
+  | _ -> false
+
+let provider_auth_hint_marker = "Provider auth returned 401"
+let openai_compat_not_found_hint_marker = "OpenAI-compatible endpoint returned 404"
+
+let cascade_name_to_string = Fun.id
+
+let resolve_provider_api_key_env_name ~cascade_name ~provider_cfg =
+  let cascade_name = cascade_name_to_string cascade_name in
+  let provider_name =
+    Llm_provider.Provider_registry.provider_name_of_config provider_cfg
+  in
+  let fallback_env =
+    Llm_provider.Provider_config.default_api_key_env provider_cfg.kind
+    |> Option.value ~default:""
+  in
+  let resolve_from_overrides overrides =
+    let find_non_empty key =
+      match List.assoc_opt key overrides with
+      | Some value when String.trim value <> "" -> Some value
+      | _ -> None
+    in
+    match find_non_empty provider_name with
+    | Some env_name -> env_name
+    | None ->
+      (match find_non_empty "*" with
+       | Some env_name -> env_name
+       | None -> fallback_env)
+  in
+  match Cascade_oas_runner.default_config_path () with
+  | Some config_path ->
+    let overrides =
+      Cascade_config.resolve_api_key_env ~config_path ~name:cascade_name
+    in
+    resolve_from_overrides overrides
+  | None -> fallback_env
+
+let enrich_sdk_error ~cascade_name
+    ~(provider_cfg : Llm_provider.Provider_config.t)
+    (err : Agent_sdk.Error.sdk_error) =
+  let append_hint message hint_marker detail =
+    if String_util.contains_substring_ci message hint_marker then
+      message
+    else
+      Printf.sprintf "%s (%s: %s)" message hint_marker detail
+  in
+  match err with
+  | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError { message })
+    when not (Llm_provider.Provider_config.is_subprocess_cli provider_cfg.kind) ->
+    let env_name =
+      match resolve_provider_api_key_env_name ~cascade_name ~provider_cfg with
+      | "" -> "configured provider API key env"
+      | value -> value
+    in
+    let detail =
+      if String.trim provider_cfg.api_key = "" then
+        Printf.sprintf "%s is empty or unset in this process" env_name
+      else
+        Printf.sprintf
+          "%s was loaded and the auth header was populated; verify that it is valid for the configured provider"
+          env_name
+    in
+    Agent_sdk.Error.Api
+      (Llm_provider.Retry.AuthError
+         {
+           message =
+             append_hint message provider_auth_hint_marker detail;
+         })
+  | Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest { message })
+    when retry_message_looks_like_not_found message ->
+    (* Endpoint URL hint is shape-agnostic data — every provider_cfg carries
+       [base_url] / [request_path] (empty strings for CLI agents) — so the
+       not_found hint applies to any provider whose retry message matches the
+       not_found pattern.  CLI providers' not_found errors rarely surface
+       through this code path (they emit text errors, not the OpenAI-compat
+       InvalidRequest shape), so the practical effect is a no-op for CLI
+       agents while still helping HTTP providers (provider_d-compat, provider_k, etc.)
+       diagnose endpoint drift.  RFC-0058 §2.4: no closed-variant dispatch. *)
+    let detail =
+      Printf.sprintf "base_url=%s request_path=%s endpoint=%s"
+        provider_cfg.base_url provider_cfg.request_path
+        (provider_cfg.base_url ^ provider_cfg.request_path)
+    in
+    Agent_sdk.Error.Api
+      (Llm_provider.Retry.InvalidRequest
+         {
+           message =
+             append_hint message openai_compat_not_found_hint_marker detail;
+         })
+  | _ -> err
+
+(** CLI-wrapped error variants where quota signals may appear serialized as
+    text.  AuthError, NotFound, ContextOverflow, and Timeout never carry
+    quota information — excluding them avoids unnecessary substring scans
+    and makes the structural filter explicit. *)
+let api_error_message_for_quota_scan (api_err : Llm_provider.Retry.api_error)
+    : string option =
+  match api_err with
+  | Llm_provider.Retry.RateLimited { message; _ } ->
+    (* Structured hard-quota check is handled separately by
+       [Llm_provider.Retry.is_hard_quota]; this extractor is for the
+       CLI-wrapped fallback path only.  RateLimited messages are included
+       here so the compound CLI-exit-code heuristic can still fire on
+       messages that [is_hard_quota] does not cover. *)
+    Some message
+  | Llm_provider.Retry.NetworkError { message; _ } -> Some message
+  | Llm_provider.Retry.Overloaded { message } -> Some message
+  | Llm_provider.Retry.ServerError { message; _ } -> Some message
+  (* InvalidRequest covers Provider_a's HTTP 400 user-set monthly cap
+     ("You have reached your specified API usage limits...").  Without
+     this branch, direct (non-CLI) API calls treat the cap as a
+     retryable client error and the cascade burns its full turn budget
+     on a permanent failure.  Observed 2026-04-29. *)
+  | Llm_provider.Retry.InvalidRequest { message } -> Some message
+  | Llm_provider.Retry.AuthError _
+  | Llm_provider.Retry.NotFound _
+  | Llm_provider.Retry.ContextOverflow _
+  | Llm_provider.Retry.Timeout _ ->
+    None
+
+(** Substring indicators for hard-quota signals in CLI-wrapped error text.
+
+    These are necessary because CLI transports (Provider_f CLI, Claude Code CLI)
+    serialize provider errors as plain text in [NetworkError.message] or
+    [InvalidRequest.message].  The structured [Llm_provider.Retry.is_hard_quota]
+    only inspects the [RateLimited] variant, so CLI-wrapped messages require
+    text-level pattern matching.
+
+    [Llm_provider.Retry.is_hard_quota_message] exists in the external library
+    but is not exposed in its .mli, so these indicators cannot delegate to it.
+    If it becomes public in a future agent_sdk release, this list can be
+    replaced with a call to that function plus the CLI-specific extras. *)
+let cli_wrapped_hard_quota_indicators = [
+  "hard_quota";
+  "terminalquotaerror";
+  "quota_exhausted";
+  "exhausted your capacity on this model";
+  "quota will reset after";
+  "\"api_error_status\":429";
+  "you've hit your limit";
+  "monthly usage limit";
+  "org's monthly usage limit";
+  "resets apr ";
+  (* Provider_a console usage-limit error (HTTP 400 invalid_request_error,
+     observed 2026-04-29 with 2-day reset window).  Body shape:
+       {"type":"error","error":{"type":"invalid_request_error",
+        "message":"You have reached your specified API usage limits.
+        You will regain access on YYYY-MM-DD at HH:MM UTC."}}
+     Earlier 429-based indicators don't match because Provider_a now
+     returns 400 with the user-set monthly cap.  Without these markers
+     [sdk_error_is_hard_quota] returns false → cascade keeps retrying
+     cli_tool_d:auto for the full OAS turn budget (~60min). *)
+  "reached your specified api usage limits";
+  "you will regain access on";
+]
+
+let message_looks_like_cli_wrapped_hard_quota (message : string) : bool =
+  let contains needle =
+    String_util.contains_substring_ci message needle
+  in
+  List.exists contains cli_wrapped_hard_quota_indicators
+  ||
+  (contains "exited with code 1"
+   && contains "\"api_error_status\":429"
+   && contains "you've hit your limit")
+
+let capacity_backpressure_indicators = [
+  "client capacity";
+  "capacity exhausted";
+  "local_resource_exhaustion";
+  "slot full";
+]
+
+let message_looks_like_capacity_backpressure (message : string) : bool =
+  let contains needle =
+    String_util.contains_substring_ci message needle
+  in
+  List.exists contains capacity_backpressure_indicators
+
+let exit_code_of_message (message : string) : int option =
+  let prefix = "exited with code " in
+  match String.index_opt message ' ' with
+  | None -> None
+  | Some first_space ->
+      let search_from = first_space + 1 in
+      if search_from >= String.length message then None
+      else
+        let suffix =
+          String.sub message search_from (String.length message - search_from)
+        in
+        if not (String.starts_with ~prefix suffix) then None
+        else
+          match String.index_from_opt suffix (String.length prefix) ':' with
+          | None -> None
+          | Some colon ->
+              let raw =
+                String.sub suffix (String.length prefix)
+                  (colon - String.length prefix)
+                |> String.trim
+              in
+              int_of_string_opt raw
+
+let sdk_error_is_resumable_cli_session (err : Agent_sdk.Error.sdk_error) : bool =
+  match Keeper_masc_error_classify.classify_masc_internal_error err with
+  | Some (Keeper_masc_error_classify.Resumable_cli_session _) -> true
+  | _ -> false
+
+let message_looks_like_terminal_provider_runtime_failure message =
+  let contains needle = String_util.contains_substring_ci message needle in
+  (contains "provider cli rejected" && contains "exit 1")
+  || (contains "provider cli startup crash" && contains "unicodedecodeerror")
+  || contains "unicodedecodeerror"
+  || (contains "jsonrpcmessage"
+      && (contains "validationerror" || contains "invalid json"))
+  || (contains "error parsing sse message"
+      && (contains "jsonrpc" || contains "jsonrpcmessage"))
+
+(* D6 fix: typed network-class terminals.
+
+   [Llm_provider.Retry.NetworkError] carries a structured
+   [Http_client.network_error_kind].  Pre-fix the classifier only inspected
+   the embedded [message] string, so a single endpoint outage materialised
+   as 3–5 retry events before cooldown.  Treating
+   [Connection_refused]/[Dns_failure] as terminal directly off the typed
+   variant collapses one outage to one event (~70% reduction of the
+   residual network-class storm).
+
+   The remaining [network_error_kind] arms ([Tls_error], [Timeout],
+   [Local_resource_exhaustion], [End_of_file], [Unknown]) are *not*
+   reclassified here: TLS/timeout/EOF can be transient and have separate
+   policy paths upstream, and [Local_resource_exhaustion] is the OS-level
+   class handled by [System_error_class]. *)
+let network_error_kind_is_terminal
+    (kind : Llm_provider.Http_client.network_error_kind) : bool =
+  match kind with
+  | Llm_provider.Http_client.Connection_refused -> true
+  | Llm_provider.Http_client.Dns_failure -> true
+  | Llm_provider.Http_client.Tls_error
+  | Llm_provider.Http_client.Timeout
+  | Llm_provider.Http_client.Local_resource_exhaustion
+  | Llm_provider.Http_client.End_of_file
+  | Llm_provider.Http_client.Unknown -> false
+
+let sdk_error_is_terminal_provider_runtime_failure
+    (err : Agent_sdk.Error.sdk_error) : bool =
+  let direct_typed_network =
+    match err with
+    | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError { kind; _ }) ->
+        network_error_kind_is_terminal kind
+    | _ -> false
+  in
+  let direct_api_message =
+    match err with
+    | Agent_sdk.Error.Api
+        (Llm_provider.Retry.NetworkError { message; _ }
+        | Llm_provider.Retry.Overloaded { message }
+        | Llm_provider.Retry.ServerError { message; _ }
+        | Llm_provider.Retry.InvalidRequest { message }
+        | Llm_provider.Retry.RateLimited { message; _ }
+        | Llm_provider.Retry.AuthError { message }
+        | Llm_provider.Retry.NotFound { message }
+        | Llm_provider.Retry.ContextOverflow { message; _ }
+        | Llm_provider.Retry.Timeout { message }) ->
+        message_looks_like_terminal_provider_runtime_failure message
+    | _ -> false
+  in
+  direct_typed_network
+  || direct_api_message
+  || message_looks_like_terminal_provider_runtime_failure
+       (Agent_sdk.Error.to_string err)
+
+let sdk_error_is_required_tool_contract_violation
+    (err : Agent_sdk.Error.sdk_error) : bool =
+  match err with
+  | Agent_sdk.Error.Agent
+      (Agent_sdk.Error.CompletionContractViolation { contract; _ }) ->
+    contract = Agent_sdk.Completion_contract_id.Require_tool_use
+  | _ -> false
+
+let sdk_error_is_hard_quota (err : Agent_sdk.Error.sdk_error) : bool =
+  match err with
+  | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) -> true
+  | Agent_sdk.Error.Api api_err ->
+    (* Layer 1: structured variant check — [is_hard_quota] inspects the
+       [RateLimited] variant for known hard-quota message patterns. *)
+    Llm_provider.Retry.is_hard_quota api_err
+    ||
+    (* Layer 2: CLI-wrapped fallback — extract message from variants that
+       may carry serialized CLI output, then scan for quota indicators.
+       Variants excluded by [api_error_message_for_quota_scan] (AuthError,
+       NotFound, ContextOverflow, Timeout) never carry quota signals. *)
+    (match api_error_message_for_quota_scan api_err with
+     | Some message ->
+       message_looks_like_cli_wrapped_hard_quota message
+     | None -> false)
+  (* Non-Api error families never carry provider-level hard-quota signals. *)
+  | Agent_sdk.Error.Provider _
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> false
+
+(* [provider_label] sanitises an upstream-supplied provider string
+   into a metric/log label value.  Empty / whitespace-only input
+   is replaced with the literal "unknown" so Prometheus labels stay
+   well-formed.  The replacement is fail-open by design (we never
+   want metric emission to itself raise), but the empty case is
+   almost always a bug at the call site — the caller forgot to
+   thread a real provider through.  WARN + counter make the
+   substitution visible so the root call site can be traced and
+   fixed; the helper itself does not change behaviour. *)
+let provider_label provider =
+  match String.trim provider with
+  | "" ->
+      Prometheus.inc_counter
+        Prometheus.metric_cascade_attempt_empty_provider_label
+        ();
+      let bt =
+        Printexc.raw_backtrace_to_string (Printexc.get_callstack 6)
+      in
+      Log.Misc.warn
+        "[cascade_attempt:empty_provider_label] provider_label received \
+         empty/blank input; substituting \"unknown\".  Fix the call \
+         site that passed an empty provider through \
+         Keeper_sdk_error_classify.provider_label. Callstack (top 6):\n%s"
+        bt;
+      "unknown"
+  | value -> value
+
+(* RFC-0132 PR-2: cascade-fsm public surface label = external boundary; redact via SSOT. *)
+let public_runtime_provider_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_provider_label
+
+let provider_error_capacity_scope = function
+  | Llm_provider.Error.CapacityModel -> `Model
+  | Llm_provider.Error.CapacityAccount
+  | Llm_provider.Error.CapacityRegion
+  | Llm_provider.Error.CapacityProvider
+  | Llm_provider.Error.CapacityUnknown ->
+      `Provider
+
+let provider_error_should_cascade = function
+  | Llm_provider.Error.RateLimit _
+  | Llm_provider.Error.HardQuota _
+  | Llm_provider.Error.CapacityExhausted _
+  | Llm_provider.Error.ProviderUnavailable _
+  | Llm_provider.Error.ParseError _
+  | Llm_provider.Error.Timeout _ ->
+      true
+  | Llm_provider.Error.ServerError { transient; _ } -> transient
+  | Llm_provider.Error.NetworkError
+      { kind = Llm_provider.Http_client.Tls_error
+             | Llm_provider.Http_client.Local_resource_exhaustion; _ } ->
+      false
+  | Llm_provider.Error.NetworkError _ -> true
+  | Llm_provider.Error.MissingApiKey _
+  | Llm_provider.Error.InvalidConfig _
+  | Llm_provider.Error.UnknownVariant _
+  | Llm_provider.Error.AuthError _
+  | Llm_provider.Error.InvalidRequest _
+  | Llm_provider.Error.NotFound _
+  | Llm_provider.Error.ProviderTerminal _ ->
+      false
+
+let transient_http_status code =
+  code = 408 || code = 409 || code = 425 || code = 429 || code >= 500
+
+let provider_capacity ?(scope = `Provider) _provider =
+  Some (Provider_error.CapacityBackpressure { scope })
+
+let retry_api_error_to_provider_error ~provider ~capacity_backpressure api_error =
+  let provider = provider_label provider in
+  match api_error with
+  | Llm_provider.Retry.RateLimited { retry_after; _ } ->
+      if capacity_backpressure then provider_capacity provider
+      else Some (Provider_error.RateLimit { retry_after })
+  | Llm_provider.Retry.Overloaded _ ->
+      if capacity_backpressure then provider_capacity provider
+      else Some (Provider_error.ServerError { code = 529; transient = true })
+  | Llm_provider.Retry.ServerError { status; _ } ->
+      Some
+        (Provider_error.ServerError
+           { code = status; transient = transient_http_status status })
+  | Llm_provider.Retry.AuthError _ -> Some Provider_error.AuthError
+  | Llm_provider.Retry.InvalidRequest { message } ->
+      if capacity_backpressure then provider_capacity provider
+      else Some (Provider_error.InvalidRequest { reason = message })
+  | Llm_provider.Retry.NotFound { message } ->
+      Some (Provider_error.InvalidRequest { reason = message })
+  | Llm_provider.Retry.ContextOverflow _ ->
+      provider_capacity ~scope:`Model provider
+  | Llm_provider.Retry.NetworkError _
+  | Llm_provider.Retry.Timeout _ ->
+      if capacity_backpressure then provider_capacity provider else None
+
+let sdk_provider_error_to_provider_error = function
+  | Llm_provider.Error.RateLimit { retry_after; _ } ->
+      Some (Provider_error.RateLimit { retry_after })
+  | Llm_provider.Error.HardQuota { detail; _ } ->
+      Some (Provider_error.CliWrappedHardQuota { detail })
+  | Llm_provider.Error.CapacityExhausted { scope; _ } ->
+      Some
+        (Provider_error.CapacityBackpressure
+           { scope = provider_error_capacity_scope scope })
+  | Llm_provider.Error.AuthError _
+  | Llm_provider.Error.MissingApiKey _ ->
+      Some Provider_error.AuthError
+  | Llm_provider.Error.ServerError { code; transient; _ } ->
+      Some (Provider_error.ServerError { code; transient })
+  | Llm_provider.Error.InvalidRequest { reason; _ } ->
+      Some (Provider_error.InvalidRequest { reason })
+  | Llm_provider.Error.NotFound _ -> Some Provider_error.ModelNotFound
+  | Llm_provider.Error.InvalidConfig { detail; _ } ->
+      Some (Provider_error.InvalidRequest { reason = detail })
+  | Llm_provider.Error.ProviderTerminal { detail; _ } ->
+      Some (Provider_error.InvalidRequest { reason = detail })
+  | Llm_provider.Error.ProviderUnavailable _ ->
+      Some (Provider_error.ServerError { code = 503; transient = false })
+  | Llm_provider.Error.ParseError _
+  | Llm_provider.Error.UnknownVariant _
+  | Llm_provider.Error.NetworkError _
+  | Llm_provider.Error.Timeout _ ->
+      None
+let sdk_error_to_provider_error ~provider err =
+  match err with
+  | Agent_sdk.Error.Api api_err ->
+      retry_api_error_to_provider_error ~provider
+        ~capacity_backpressure:(sdk_error_is_hard_quota err)
+        api_err
+  | Agent_sdk.Error.Provider provider_err ->
+      sdk_provider_error_to_provider_error provider_err
+  (* Non-Api families do not map to a provider-level error. *)
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> None
+
+let provider_error_total_metric = "masc_provider_error_total"
+
+let () =
+  Prometheus.register_counter
+    ~name:provider_error_total_metric
+    ~help:
+      "Total provider-level errors classified during cascade \
+       attempts (rate limit, auth failure, capacity exhaustion, \
+       server error, invalid request). Labels: kind \
+       (Provider_error.to_error_kind), provider (neutral runtime \
+       label), cascade_name (originating cascade), capacity_scope \
+       (CapacityExhausted scope or \"none\")."
+    ()
+
+let provider_error_capacity_scope_label = function
+  | Provider_error.CapacityBackpressure { scope } ->
+      Provider_error.scope_to_string scope
+  | Provider_error.RateLimit _
+  | Provider_error.AuthError
+  | Provider_error.ServerError _
+  | Provider_error.InvalidRequest _
+  | Provider_error.CliWrappedHardQuota _
+  | Provider_error.CliWrappedMaxTurns _
+  | Provider_error.CliWrappedResumableSession _
+  | Provider_error.PermissionDenied _
+  | Provider_error.ModelNotFound ->
+      "none"
+
+let emit_provider_error_metric ~cascade_name ~provider error =
+  let cascade_name = provider_label (cascade_name_to_string cascade_name) in
+  let provider = provider_label provider in
+  Dashboard_oas_bridge.record_provider_error ~cascade_name ~provider_id:provider
+    error;
+  Prometheus.inc_counter provider_error_total_metric
+    ~labels:
+      [
+        (label_kind, Provider_error.to_error_kind error);
+        (label_provider, public_runtime_provider_label);
+        (label_cascade_name, cascade_name);
+        (label_capacity_scope, provider_error_capacity_scope_label error);
+      ]
+    ()
+
+let timeout_phase_label_of_sdk_error (err : Agent_sdk.Error.sdk_error) : string =
+  match err with
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.Timeout { timeout_phase = Some phase; _ })
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.NetworkError { timeout_phase = Some phase; _ }) ->
+      Llm_provider.Http_client.timeout_phase_to_label phase
+  | _ -> label_provider
+
+let emit_oas_run_timeout_metric ~cascade_name ~provider:_ err =
+  match err with
+  | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _) ->
+      let cascade_name = provider_label (cascade_name_to_string cascade_name) in
+      Prometheus.inc_counter Keeper_metrics.(to_string OasRunTimeout)
+        ~labels:
+          [
+            (label_cascade, cascade_name);
+            (label_provider, public_runtime_provider_label);
+            (label_source, timeout_phase_label_of_sdk_error err);
+          ]
+        ()
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.Timeout _
+      | Llm_provider.Error.NetworkError { timeout_phase = Some _; _ }) ->
+      let cascade_name = provider_label (cascade_name_to_string cascade_name) in
+      Prometheus.inc_counter Keeper_metrics.(to_string OasRunTimeout)
+        ~labels:
+          [
+            (label_cascade, cascade_name);
+            (label_provider, public_runtime_provider_label);
+            (label_source, timeout_phase_label_of_sdk_error err);
+          ]
+        ()
+  | _ -> ()
+
+let classify_saturation_signal_kind
+    (err : Agent_sdk.Error.sdk_error) :
+    Cascade_saturation_signal.kind option =
+  let typed_kind =
+    match Keeper_masc_error_classify.classify_masc_internal_error err with
+    | Some (Keeper_masc_error_classify.Provider_timeout _) ->
+        Some Cascade_saturation_signal.K_time_cap_fired
+    | _ -> None
+  in
+  match typed_kind with
+  | Some _ as kind -> kind
+  | None -> (
+    match err with
+    | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _) ->
+        Some Cascade_saturation_signal.K_provider_rate_limited
+    | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError _)
+    | Agent_sdk.Error.Provider _
+    | Agent_sdk.Error.Agent _
+    | Agent_sdk.Error.Mcp _
+    | Agent_sdk.Error.Config _
+    | Agent_sdk.Error.Serialization _
+    | Agent_sdk.Error.Io _
+    | Agent_sdk.Error.Orchestration _
+    | Agent_sdk.Error.A2a _
+    | Agent_sdk.Error.Internal _ -> None)
+
+let maybe_emit_cascade_saturation_signal ~cascade_name ~provider:_ err =
+  if Env_config_keeper.CascadeSaturationSignal.enabled () then
+    match classify_saturation_signal_kind err with
+    | None -> ()
+    | Some kind ->
+        let cascade_name_str =
+          provider_label (cascade_name_to_string cascade_name)
+        in
+        Prometheus.inc_counter
+          Keeper_metrics.(to_string CascadeSaturationSignal)
+          ~labels:
+            [
+              (label_kind, Cascade_saturation_signal.kind_to_string kind);
+              (label_cascade, cascade_name_str);
+            ]
+          ()
+
+let emit_sdk_provider_error_metric ~cascade_name ~provider err =
+  emit_oas_run_timeout_metric ~cascade_name ~provider err;
+  maybe_emit_cascade_saturation_signal ~cascade_name ~provider err;
+  match sdk_error_to_provider_error ~provider err with
+  | None -> None
+  | Some provider_error ->
+      emit_provider_error_metric ~cascade_name ~provider provider_error;
+      Some provider_error
+
+
+include Keeper_sdk_error_classify_capacity_backpressure
+
+let sdk_error_is_max_turns_exceeded (err : Agent_sdk.Error.sdk_error) : bool =
+  match Keeper_masc_error_classify.classify_masc_internal_error err with
+  | Some
+      (Keeper_masc_error_classify.Cascade_exhausted
+         { reason = Keeper_meta_contract.Max_turns_exceeded; _ }) ->
+      true
+  | Some (Keeper_masc_error_classify.Cascade_exhausted _)
+  | Some (Keeper_masc_error_classify.Capacity_backpressure _)
+  | Some (Keeper_masc_error_classify.Resumable_cli_session _)
+
+  | Some (Keeper_masc_error_classify.Accept_rejected _)
+  | Some (Keeper_masc_error_classify.Admission_queue_timeout _)
+  | Some (Keeper_masc_error_classify.Admission_queue_rejected _)
+  | Some (Keeper_masc_error_classify.Turn_timeout _)
+  | Some (Keeper_masc_error_classify.Provider_timeout _)
+  | Some (Keeper_masc_error_classify.Max_tokens_ceiling_violation _)
+  | Some (Keeper_masc_error_classify.Ambiguous_post_commit _)
+  (* RFC-0158: admission denial is not max-turns-exceeded. *)
+  | Some (Keeper_masc_error_classify.Retry_admission_denied _)
+  (* RFC-0159 Phase A: opaque internal failures are not max-turns-exceeded. *)
+  | Some (Keeper_masc_error_classify.Internal_unhandled_exception _)
+  | Some (Keeper_masc_error_classify.Internal_bridge_exception _)
+  | Some (Keeper_masc_error_classify.Internal_contract_rejected _) ->
+      false
+  | None -> (
+      match err with
+      | Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _) -> true
+      | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionTimeout _) -> false
+      | Agent_sdk.Error.Api _ -> false
+      | Agent_sdk.Error.Provider _ -> false
+      | Agent_sdk.Error.Internal _ -> false
+      | _ -> false)
+
+let sdk_error_cascade_fallback_class (err : Agent_sdk.Error.sdk_error) :
+    string option =
+  if sdk_error_is_hard_quota err then Some fallback_class_hard_quota
+  else if sdk_error_is_max_turns_exceeded err then Some fallback_class_max_turns
+  else if sdk_error_is_required_tool_contract_violation err then
+    Some fallback_class_required_tool_contract_violation
+  else None

--- a/lib/keeper/keeper_sdk_error_classify.mli
+++ b/lib/keeper/keeper_sdk_error_classify.mli
@@ -1,0 +1,203 @@
+(** Keeper_sdk_error_classify — SDK error to FSM outcome, session/resumption analysis.
+
+    Extracted from oas_worker_named.ml (God file decomposition).
+    Converts OAS SDK errors into Keeper_provider_outcome provider outcomes,
+    classifies CLI-wrapped hard-quota patterns,
+    and enriches errors with provider-specific hints.
+
+    This module is [include]d by {!Keeper_turn_driver}; all bindings are
+    re-exported by the facade.  @since God file decomposition *)
+
+(** {1 Cascade outcome classification} *)
+
+val sdk_error_to_cascade_outcome :
+  Agent_sdk.Error.sdk_error -> Keeper_provider_outcome.provider_outcome option
+(** Convert an SDK error into a cascade FSM provider outcome.
+    API-level errors and model-capability-dependent agent errors are
+    cascadeable.  Structural agent errors (budget, idle, exit) are not. *)
+
+(** {1 Error enrichment} *)
+
+val enrich_sdk_error :
+  cascade_name:string ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  Agent_sdk.Error.sdk_error -> Agent_sdk.Error.sdk_error
+(** Enrich an SDK error with provider-specific diagnostic hints
+    (e.g. API-key auth, OpenAI-compat 404). *)
+
+(** {1 CLI-wrapped error pattern classification} *)
+
+val message_looks_like_cli_wrapped_hard_quota : string -> bool
+(** Detect hard-quota indicators in CLI-wrapped error messages. *)
+
+val message_looks_like_capacity_backpressure : string -> bool
+(** Detect capacity-backpressure indicators in error messages. *)
+
+val cli_wrapped_hard_quota_indicators : string list
+(** List of substring indicators for CLI-wrapped hard quota. *)
+
+val exit_code_of_message : string -> int option
+(** Extract an exit code from a CLI error message string. *)
+
+val retry_message_looks_like_not_found : string -> bool
+(** Detect "not found" / 404 patterns in retry error messages. *)
+
+(** {1 SDK error predicates} *)
+
+val sdk_error_is_resumable_cli_session : Agent_sdk.Error.sdk_error -> bool
+(** [true] only for typed [Resumable_cli_session] envelopes. Raw CLI output
+    is transport-local text and is not promoted at this boundary. *)
+
+val sdk_error_is_terminal_provider_runtime_failure :
+  Agent_sdk.Error.sdk_error -> bool
+(** [true] for deterministic provider/adapter crashes that should enter the
+    immediate long cooldown lane instead of waiting for generic failure
+    thresholding. *)
+
+val sdk_error_is_model_access_denied : Agent_sdk.Error.sdk_error -> bool
+(** [true] for deterministic model-access denials that should cool down the
+    concrete provider/model pair without poisoning sibling models. *)
+
+val sdk_error_is_required_tool_contract_violation :
+  Agent_sdk.Error.sdk_error -> bool
+(** [true] when a provider/model violated the required-tool-use contract by
+    returning no usable tool call for a strict tool-choice turn. *)
+
+val sdk_error_is_hard_quota : Agent_sdk.Error.sdk_error -> bool
+(** [true] when the error represents a hard usage quota that will not
+    recover within the cascade turn budget. *)
+
+val retry_api_error_to_provider_error :
+  provider:string ->
+  capacity_backpressure:bool ->
+  Llm_provider.Retry.api_error ->
+  Provider_error.t option
+(** Convert an SDK retry error into the additive provider-error contract.
+    [capacity_backpressure] is explicit so the production body classifier
+    stays at this OAS boundary instead of moving into [Provider_error]. *)
+
+val sdk_error_to_provider_error :
+  provider:string -> Agent_sdk.Error.sdk_error -> Provider_error.t option
+(** Convert API-level SDK errors into provider errors. Non-API structural
+    errors return [None]. *)
+
+val provider_error_total_metric : string
+(** Prometheus counter for additive provider-error variant emission. *)
+
+val emit_provider_error_metric :
+  cascade_name:string ->
+  provider:string ->
+  Provider_error.t ->
+  unit
+(** Emit one provider-error variant event while preserving existing
+    string-based health tracker labels. *)
+
+val emit_sdk_provider_error_metric :
+  cascade_name:string ->
+  provider:string ->
+  Agent_sdk.Error.sdk_error ->
+  Provider_error.t option
+(** Convert and emit an SDK provider error. Returns the converted variant
+    so callers/tests can assert the same decision without reparsing metrics. *)
+
+(** {1 Cascade saturation signal label SSOT (RFC-0153)}
+
+    Modules that emit to {!Keeper_metrics.(to_string CascadeSaturationSignal)}
+    MUST reuse these labels and {!provider_label} so Prometheus sees one
+    coherent series across emitters (cascade FSM + keeper_turn_driver
+    Phase B.2 admission). *)
+
+val label_kind : string
+
+val label_cascade : string
+
+val provider_label : string -> string
+(** Sanitize a free-form label value before stamping it onto a Prometheus
+    counter. Empty values are remapped to a fixed placeholder and counted
+    on [metric_cascade_attempt_empty_provider_label] for root-cause tracing. *)
+
+val sdk_error_soft_rate_limited :
+  Agent_sdk.Error.sdk_error -> float option option
+(** [Some (Some retry_after)] for non-quota 429 responses with a parsed
+    [retry_after].  [Some None] when [retry_after] is absent.
+    [None] for non-429 or hard-quota-429 errors. *)
+
+val sdk_error_capacity_backpressure_retry_after_s :
+  Agent_sdk.Error.sdk_error -> float option option
+(** [Some (Some retry_after)] for a [Provider.CapacityExhausted] error
+    carrying a parsed [retry_after].  [Some None] when [retry_after] is
+    absent.  [None] for all other errors.  Mirrors
+    {!sdk_error_soft_rate_limited} so [Cascade_health_tracker.record_soft_rate_limited]
+    can be reused for the immediate-cooldown semantics — one capacity
+    rejection is enough to deprioritize the provider, threshold-counting
+    via [record_failure] would burn additional cascade attempts on the
+    same exhausted provider. *)
+
+(** Typed extraction of the retry-after hint carried by a MASC-internal
+    [Capacity_backpressure] classification.  The outer [Capacity_backpressure]
+    variant differs from {!sdk_error_capacity_backpressure_retry_after_s} which
+    targets the raw [Provider.CapacityExhausted] SDK error — both can flow
+    through the same keeper turn driver but only the typed variant carries
+    [retry_after_sec : float option]. *)
+type capacity_backpressure_retry_hint =
+  | Cbr_explicit of float
+    (** Upstream supplied [retry_after_sec = Some s]. *)
+  | Cbr_synthetic_default of float
+    (** Upstream omitted the hint ([retry_after_sec = None]); the consumer
+        injects {!Cascade_health_tracker.default_capacity_backpressure_backoff_sec}
+        to prevent immediate cascade re-rotation onto the same provider. *)
+
+val sdk_error_capacity_backpressure_source :
+  Agent_sdk.Error.sdk_error ->
+  Keeper_masc_error_classify.capacity_backpressure_source option
+(** [Some source] when the error classifies as a MASC-internal
+    [Capacity_backpressure].  Callers use this to keep provider-owned
+    capacity failures separate from client/cascade-slot backpressure
+    when projecting provider health. *)
+
+val sdk_error_capacity_backpressure_retry_hint :
+  Agent_sdk.Error.sdk_error -> capacity_backpressure_retry_hint option
+(** [Some hint] when the error classifies as
+    [Keeper_masc_error_classify.Capacity_backpressure], with [hint] indicating
+    whether the upstream hint was honored or a synthetic default injected.
+    [None] for any other classification. *)
+
+val sdk_error_is_max_turns_exceeded : Agent_sdk.Error.sdk_error -> bool
+
+val sdk_error_cascade_fallback_class :
+  Agent_sdk.Error.sdk_error -> string option
+(** Stable class label for cascade fallback logs/audit reasons.  This keeps
+    operator-facing [top_level_reason] aggregation on typed causes instead of
+    generic SDK/Internal wrapper strings. *)
+
+(** {1 Metric labels} *)
+
+val label_kind : string
+
+val label_cascade : string
+
+val provider_label : string -> string
+
+(** {1 Provider auth helpers} *)
+
+val resolve_provider_api_key_env_name :
+  cascade_name:string ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  string
+
+val provider_auth_hint_marker : string
+val openai_compat_not_found_hint_marker : string
+
+(** {1 Saturation-signal metric labels and provider sanitiser} *)
+
+val label_kind : string
+(** Prometheus label key for the saturation-signal kind. *)
+
+val label_cascade : string
+(** Prometheus label key for the cascade name. *)
+
+val provider_label : string -> string
+(** Sanitise an upstream-supplied provider string into a Prometheus
+    label value; empty/blank inputs emit a callstack-tagged warning
+    via {!Prometheus.metric_cascade_attempt_empty_provider_label} and
+    fall back to a fixed placeholder. *)

--- a/lib/keeper/keeper_sdk_error_classify_capacity_backpressure.ml
+++ b/lib/keeper/keeper_sdk_error_classify_capacity_backpressure.ml
@@ -1,0 +1,103 @@
+(** Keeper_sdk_error_classify_capacity_backpressure — Capacity backpressure
+    and soft rate-limit classification from SDK errors.
+
+    Extracted from [cascade_attempt_fsm.ml] during godfile decomposition.
+    Pure functions over [Agent_sdk.Error.sdk_error].
+
+    @since God file decomposition *)
+
+(* DET-OK: synthetic default backoff when provider omits Retry-After *)
+let default_capacity_backpressure_backoff_sec =
+  Keeper_binding_health_config.default_capacity_backpressure_backoff_sec
+
+let sdk_error_capacity_backpressure_retry_after_s (err : Agent_sdk.Error.sdk_error)
+  : float option option =
+  match err with
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.CapacityExhausted { retry_after; _ }) ->
+    Some retry_after
+  | _ -> None
+
+type capacity_backpressure_retry_hint =
+  | Cbr_explicit of float
+  | Cbr_synthetic_default of float
+
+let sdk_error_capacity_backpressure_source (err : Agent_sdk.Error.sdk_error)
+  : Keeper_masc_error_classify.capacity_backpressure_source option =
+  match Keeper_masc_error_classify.classify_masc_internal_error err with
+  | Some (Keeper_masc_error_classify.Capacity_backpressure { source; _ }) ->
+    Some source
+  | Some (Keeper_masc_error_classify.Cascade_exhausted _)
+  | Some (Keeper_masc_error_classify.Resumable_cli_session _)
+
+  | Some (Keeper_masc_error_classify.Accept_rejected _)
+  | Some (Keeper_masc_error_classify.Admission_queue_timeout _)
+  | Some (Keeper_masc_error_classify.Admission_queue_rejected _)
+  | Some (Keeper_masc_error_classify.Turn_timeout _)
+  | Some (Keeper_masc_error_classify.Provider_timeout _)
+  | Some (Keeper_masc_error_classify.Max_tokens_ceiling_violation _)
+  | Some (Keeper_masc_error_classify.Ambiguous_post_commit _)
+  | Some (Keeper_masc_error_classify.Retry_admission_denied _)
+  | Some (Keeper_masc_error_classify.Internal_unhandled_exception _)
+  | Some (Keeper_masc_error_classify.Internal_bridge_exception _)
+  | Some (Keeper_masc_error_classify.Internal_contract_rejected _)
+  | None -> None
+
+let sdk_error_capacity_backpressure_retry_hint (err : Agent_sdk.Error.sdk_error)
+  : capacity_backpressure_retry_hint option =
+  match Keeper_masc_error_classify.classify_masc_internal_error err with
+  | Some (Keeper_masc_error_classify.Capacity_backpressure { retry_after; _ }) ->
+    (* Read provenance directly from the typed carrier: a [Synthetic_default]
+       can no longer reach the [Cbr_explicit] branch. *)
+    (match retry_after with
+     | Keeper_meta_contract.Explicit s when s > 0.0 -> Some (Cbr_explicit s)
+     | Keeper_meta_contract.Explicit _ ->
+       (* defensive: a non-positive explicit value is treated as missing *)
+       Some (Cbr_synthetic_default default_capacity_backpressure_backoff_sec)
+     | Keeper_meta_contract.Synthetic_default s -> Some (Cbr_synthetic_default s)
+     | Keeper_meta_contract.No_retry_hint ->
+       Some (Cbr_synthetic_default default_capacity_backpressure_backoff_sec))
+  | Some (Keeper_masc_error_classify.Cascade_exhausted _)
+  | Some (Keeper_masc_error_classify.Resumable_cli_session _)
+
+  | Some (Keeper_masc_error_classify.Accept_rejected _)
+  | Some (Keeper_masc_error_classify.Admission_queue_timeout _)
+  | Some (Keeper_masc_error_classify.Admission_queue_rejected _)
+  | Some (Keeper_masc_error_classify.Turn_timeout _)
+  | Some (Keeper_masc_error_classify.Provider_timeout _)
+  | Some (Keeper_masc_error_classify.Max_tokens_ceiling_violation _)
+  | Some (Keeper_masc_error_classify.Ambiguous_post_commit _)
+  | Some (Keeper_masc_error_classify.Retry_admission_denied _)
+  | Some (Keeper_masc_error_classify.Internal_unhandled_exception _)
+  | Some (Keeper_masc_error_classify.Internal_bridge_exception _)
+  | Some (Keeper_masc_error_classify.Internal_contract_rejected _)
+  | None -> None
+
+let sdk_error_soft_rate_limited (err : Agent_sdk.Error.sdk_error)
+  : float option option =
+  match err with
+  | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited { retry_after; _ } as api_err)
+    when not (Llm_provider.Retry.is_hard_quota api_err) ->
+    Some retry_after
+  | Agent_sdk.Error.Provider (Llm_provider.Error.RateLimit { retry_after; _ }) ->
+    Some retry_after
+  (* Hard-quota RateLimited is handled separately and other Api / non-Api
+     errors do not represent soft rate limiting. *)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _)
+  | Agent_sdk.Error.Provider _
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> None

--- a/lib/keeper/keeper_sdk_error_classify_capacity_backpressure.mli
+++ b/lib/keeper/keeper_sdk_error_classify_capacity_backpressure.mli
@@ -1,0 +1,19 @@
+val default_capacity_backpressure_backoff_sec : float
+
+val sdk_error_capacity_backpressure_retry_after_s :
+  Agent_sdk.Error.sdk_error -> float option option
+
+type capacity_backpressure_retry_hint =
+  | Cbr_explicit of float
+  | Cbr_synthetic_default of float
+
+val sdk_error_capacity_backpressure_source :
+  Agent_sdk.Error.sdk_error ->
+  Keeper_masc_error_classify.capacity_backpressure_source option
+
+val sdk_error_capacity_backpressure_retry_hint :
+  Agent_sdk.Error.sdk_error ->
+  capacity_backpressure_retry_hint option
+
+val sdk_error_soft_rate_limited :
+  Agent_sdk.Error.sdk_error -> float option option

--- a/lib/keeper/keeper_sdk_error_classify_http_error.ml
+++ b/lib/keeper/keeper_sdk_error_classify_http_error.ml
@@ -1,0 +1,94 @@
+(** Provider-error -> HTTP-error typed mappers for the cascade attempt
+    FSM.
+
+    [provider_capacity_scope_to_http] — closed 5-arm map from
+    [Llm_provider.Error.capacity_scope] to
+    [Llm_provider.Http_client.failure_scope].
+
+    [provider_error_to_http_error] — closed 14-arm map from
+    [Agent_sdk.Error.provider_error] to
+    [Llm_provider.Http_client.http_error]. Each arm converts an OAS-
+    surfaced provider error variant into the dashboard-rendered HTTP
+    failure typed envelope (HttpError + status code, ProviderFailure
+    + structured kind, AcceptRejected, ProviderTerminal,
+    TimeoutError, NetworkError).
+
+    Pure typed-to-typed conversion — no parent state, no I/O. All
+    arms are exhaustive (compiler-enforced). Verbatim extract from
+    [Keeper_sdk_error_classify]; all callers are internal to the parent. *)
+
+let provider_capacity_scope_to_http = function
+  | Llm_provider.Error.CapacityModel -> Llm_provider.Http_client.Failure_scope_model
+  | Llm_provider.Error.CapacityAccount ->
+    Llm_provider.Http_client.Failure_scope_account
+  | Llm_provider.Error.CapacityRegion ->
+    Llm_provider.Http_client.Failure_scope_region
+  | Llm_provider.Error.CapacityProvider ->
+    Llm_provider.Http_client.Failure_scope_provider
+  | Llm_provider.Error.CapacityUnknown ->
+    Llm_provider.Http_client.Failure_scope_unknown
+
+let provider_error_to_http_error (err : Agent_sdk.Error.provider_error)
+  : Llm_provider.Http_client.http_error =
+  let module E = Llm_provider.Error in
+  let message = E.to_string err in
+  match err with
+  | E.MissingApiKey _ | E.InvalidConfig _ ->
+    Llm_provider.Http_client.AcceptRejected { reason = message }
+  | E.ParseError { detail } ->
+    Llm_provider.Http_client.ProviderFailure
+      { kind = Llm_provider.Http_client.Provider_parse_error { parser = None }
+      ; message = detail
+      }
+  | E.UnknownVariant { type_name; value } ->
+    Llm_provider.Http_client.ProviderFailure
+      { kind =
+          Llm_provider.Http_client.Unknown_provider_failure
+            { reason = Some (Printf.sprintf "%s:%s" type_name value) }
+      ; message
+      }
+  | E.ProviderUnavailable { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 503; body = detail }
+  | E.RateLimit { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 429; body = detail }
+  | E.HardQuota { retry_after; detail; _ } ->
+    Llm_provider.Http_client.ProviderFailure
+      { kind = Llm_provider.Http_client.Hard_quota { retry_after }
+      ; message = detail
+      }
+  | E.CapacityExhausted { scope; affected; retry_after; detail } ->
+    Llm_provider.Http_client.ProviderFailure
+      { kind =
+          Llm_provider.Http_client.Capacity_exhausted
+            { scope = provider_capacity_scope_to_http scope
+            ; retry_after
+            ; model = List.find_opt (fun value -> String.trim value <> "") affected
+            }
+      ; message = detail
+      }
+  | E.AuthError { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 401; body = detail }
+  | E.ServerError { code; detail; _ } ->
+    Llm_provider.Http_client.HttpError { code; body = detail }
+  | E.NetworkError { timeout_phase = Some phase; detail; _ } ->
+    Llm_provider.Http_client.TimeoutError { message = detail; phase }
+  | E.NetworkError { kind; timeout_phase = None; detail; _ } ->
+    Llm_provider.Http_client.NetworkError { message = detail; kind }
+  | E.Timeout { timeout_phase; detail; _ } ->
+    let phase =
+      match timeout_phase with
+      | Some phase -> phase
+      | None ->
+        (* DET-OK: OAS provider omitted timeout_phase; Unknown_timeout is an
+           explicit typed sentinel, not a permissive branch heuristic. *)
+        Llm_provider.Http_client.Unknown_timeout
+    in
+    Llm_provider.Http_client.TimeoutError
+      { message = detail; phase }
+  | E.InvalidRequest { reason; _ } ->
+    Llm_provider.Http_client.HttpError { code = 400; body = reason }
+  | E.NotFound { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 404; body = detail }
+  | E.ProviderTerminal { reason; detail; _ } ->
+    Llm_provider.Http_client.ProviderTerminal
+      { kind = Llm_provider.Http_client.Other reason; message = detail }

--- a/lib/keeper/keeper_sdk_error_classify_http_error.mli
+++ b/lib/keeper/keeper_sdk_error_classify_http_error.mli
@@ -1,0 +1,10 @@
+(** Provider-error -> HTTP-error typed mappers for the cascade attempt
+    FSM. *)
+
+val provider_capacity_scope_to_http
+  :  Llm_provider.Error.capacity_scope
+  -> Llm_provider.Http_client.provider_failure_scope
+
+val provider_error_to_http_error
+  :  Agent_sdk.Error.provider_error
+  -> Llm_provider.Http_client.http_error

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -1,0 +1,831 @@
+(* Keeper_turn_cascade_budget — cascade execution types, fail-open rotation,
+   provider timeout budget resolution, context overflow observation, keeper pause/resume
+   sync, partial-commit continue gate, and context budget resolution.
+
+   Extracted from keeper_unified_turn.ml (L501-1079) during the god-file split. *)
+
+open Keeper_types
+open Keeper_meta_contract
+open Keeper_meta_store
+open Keeper_types_profile
+open Keeper_context_runtime
+module EC = Keeper_error_classify
+
+type cascade_execution = {
+  cascade_name : string;
+  max_context_resolution : Keeper_context_runtime.max_context_resolution;
+  max_context : int;
+  temperature : float;
+  max_tokens : int;
+}
+
+let next_fail_open_cascade_for_turn =
+  Keeper_turn_cascade_budget_routing.next_fail_open_cascade_for_turn
+
+let sdk_error_kind = Keeper_turn_cascade_budget_routing.sdk_error_kind
+let record_turn_failure_stress =
+  Keeper_turn_cascade_budget_routing.record_turn_failure_stress
+
+include Keeper_turn_cascade_budget_provider_timeout
+
+(* RFC-OAS-XXX (Team JJ §6) POC, 2026-05-21
+   ------------------------------------------------------------------
+   Typed admission decision for an upcoming cascade attempt.
+
+   Background: 1077/24h [provider_timeout] events, ~74% from retry
+   paths ([adaptive_*_retry] / [turn_budget_*_retry]). The current caller in
+   [Keeper_unified_turn.ml:589-615] calls
+   [resolve_bounded_provider_timeout_budget_with_turn_budget] and, when it
+   returns [None] for a retry, emits a turn-owned timeout instead of
+   minting an [Provider_timeout] root cause. That keeps two
+   different failure semantics into one wire code:
+     (a) the cascade attempt never started because admission budget
+         was insufficient, and
+     (b) an actual provider attempt ran and the server timed out.
+   Mixing them inflates the [provider_timeout] signature and hides
+   the retry-admission rate.
+
+   This function returns a typed admission decision. It does NOT
+   change emission semantics on its own — that requires a new
+   [masc_internal_error] variant ([Retry_admission_denied]) which is
+   surface-breaking and deferred to RFC. The gate is exposed so
+   callers can branch before invoking the attempt loop, and so that
+   a subsequent PR can swap the emission path without touching the
+   gate logic.
+
+   Anti-pattern self-check (software-development.md §workaround):
+   - Not telemetry-as-fix (§1): does not add a counter; returns a
+     typed Result that the caller must consume.
+   - Not string classifier (§2): closed-sum reason, no substring.
+   - Not N-of-M (§3): single SSOT function; the followup variant
+     change is the natural typed boundary expansion. *)
+
+type retry_admission_denial =
+  Keeper_meta_contract.retry_admission_denial =
+  | Retry_budget_below_min of {
+      projected_usable_budget_s : float;
+      min_required_s : float;
+      remaining_turn_budget_s : float;
+      adaptive_timeout_s : float;
+      allow_wall_clock_retry_budget : bool;
+    }
+  | First_attempt_budget_below_min of {
+      projected_usable_budget_s : float;
+      min_required_s : float;
+      remaining_turn_budget_s : float;
+    }
+
+type attempt_kind = Keeper_turn_cascade_budget_admission.attempt_kind =
+  | First_attempt
+  | Retry_attempt
+
+let attempt_kind_is_retry =
+  Keeper_turn_cascade_budget_admission.attempt_kind_is_retry
+let retry_admission_denial_to_yojson =
+  Keeper_meta_contract.retry_admission_denial_to_yojson
+
+let decide_retry_admission_for_turn
+    ~(remaining_turn_budget_s : float)
+    ~(attempt_kind : attempt_kind)
+    ~(allow_wall_clock_retry_budget : bool)
+    ~(estimated_input_tokens : int)
+    ~(max_turns : int) : (unit, retry_admission_denial) result =
+  let runtime = Keeper_runtime_resolved.current () in
+  let adaptive_timeout_sec = Keeper_runtime_resolved.oas_call_timeout_sec () in
+  let is_retry = attempt_kind_is_retry attempt_kind in
+  if is_retry then
+    let time_spent_in_turn =
+      runtime.turn_timeout_sec.value -. remaining_turn_budget_s
+    in
+    let usable_retry_budget = adaptive_timeout_sec -. time_spent_in_turn in
+    let usable_wall_clock_budget =
+      remaining_turn_budget_s -. provider_timeout_guard_sec
+    in
+    let projected_usable_budget_s =
+      if usable_retry_budget >= min_provider_timeout_budget_sec then
+        usable_retry_budget
+      else if allow_wall_clock_retry_budget then usable_wall_clock_budget
+      else usable_retry_budget
+    in
+    if remaining_turn_budget_s <= 0.0 then
+      Error
+        (Retry_budget_below_min
+           {
+             projected_usable_budget_s;
+             min_required_s = min_provider_timeout_budget_sec;
+             remaining_turn_budget_s;
+             adaptive_timeout_s = adaptive_timeout_sec;
+             allow_wall_clock_retry_budget;
+           })
+    else if usable_retry_budget >= min_provider_timeout_budget_sec then Ok ()
+    else if
+      allow_wall_clock_retry_budget
+      && usable_wall_clock_budget >= min_provider_timeout_budget_sec
+    then Ok ()
+    else
+      Error
+        (Retry_budget_below_min
+           {
+             projected_usable_budget_s;
+             min_required_s = min_provider_timeout_budget_sec;
+             remaining_turn_budget_s;
+             adaptive_timeout_s = adaptive_timeout_sec;
+             allow_wall_clock_retry_budget;
+           })
+  else
+    let usable_budget = remaining_turn_budget_s -. provider_timeout_guard_sec in
+    if usable_budget >= min_provider_timeout_budget_sec then Ok ()
+    else
+      Error
+        (First_attempt_budget_below_min
+           {
+             projected_usable_budget_s = usable_budget;
+             min_required_s = min_provider_timeout_budget_sec;
+             remaining_turn_budget_s;
+           })
+
+(* PR #13120 review: declared in [Env_config_keeper.KeeperRetryBackoff]
+   so the env knob catalog generator at [bin/env_knob_catalog.ml]
+   picks it up — that generator only scans [lib/config/env_config_*.ml],
+   so a knob declared here would silently drift from
+   [docs/runtime-tunables.md] and from [env_config_snapshot]. *)
+let degraded_retry_slot_phase_budget_sec =
+  Env_config_keeper.KeeperRetryBackoff.degraded_retry_slot_phase_budget_sec
+;;
+
+let degraded_retry_slot_phase_available ~(time_spent_in_turn_s : float) : bool =
+  Float.max 0.0 time_spent_in_turn_s < degraded_retry_slot_phase_budget_sec
+
+let cascade_reason_is_structural_attempt_timeout
+    (reason : Keeper_meta_contract.cascade_exhaustion_reason) : bool =
+  (* Typed match only. Producers must construct [Structural_attempt_timeout]
+     explicitly; free-form OAS-ceiling-looking text remains [Other_detail].
+     Enumerate every constructor so a new reason variant fails to compile here
+     rather than silently falling through to [false]. *)
+  match reason with
+  | Keeper_meta_contract.Structural_attempt_timeout _ -> true
+  | Keeper_meta_contract.Connection_refused
+  | Keeper_meta_contract.Dns_failure
+  | Keeper_meta_contract.No_providers_available
+  | Keeper_meta_contract.All_providers_failed
+  | Keeper_meta_contract.Candidates_filtered_after_cycles
+  | Keeper_meta_contract.Max_turns_exceeded
+  | Keeper_meta_contract.Capacity_exhausted
+  | Keeper_meta_contract.No_tool_capable _
+  | Keeper_meta_contract.Other_detail _ -> false
+
+let degraded_retry_bypasses_slot_phase_guard
+    (err : Agent_sdk.Error.sdk_error) : bool =
+  (* Enumerate every [masc_internal_error] variant plus [None] so the
+     compiler flags any new constructor here. The old [_ -> false] silently
+     extended the "not a budget exhaustion" set whenever a new error class
+     was added to Keeper_masc_error_classify, which is exactly the wrong default
+     for a guard that decides whether to bypass slot-phase admission. *)
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Provider_timeout _) -> true
+  | Some (Keeper_turn_driver.Cascade_exhausted { reason; _ })
+    when cascade_reason_is_structural_attempt_timeout reason ->
+      true
+  | Some
+      ( Keeper_turn_driver.Cascade_exhausted _
+      | Keeper_turn_driver.Capacity_backpressure _
+      | Keeper_turn_driver.Resumable_cli_session _
+
+      | Keeper_turn_driver.Accept_rejected _
+      | Keeper_turn_driver.Admission_queue_timeout _
+      | Keeper_turn_driver.Admission_queue_rejected _
+      | Keeper_turn_driver.Turn_timeout _
+      | Keeper_turn_driver.Max_tokens_ceiling_violation _
+      | Keeper_turn_driver.Ambiguous_post_commit _
+      (* RFC-0158: admission denial is not an OAS-budget timeout bypass. *)
+      | Keeper_turn_driver.Retry_admission_denied _
+      (* RFC-0159 Phase A: Internal_* variants are not OAS-budget timeouts. *)
+      | Keeper_turn_driver.Internal_unhandled_exception _
+      | Keeper_turn_driver.Internal_bridge_exception _
+      | Keeper_turn_driver.Internal_contract_rejected _ )
+  | None ->
+    false
+
+let reclassify_provider_timeout_for_attempt
+    ~(provider_timeout_budget : provider_timeout_budget option)
+    (err : Agent_sdk.Error.sdk_error) : Agent_sdk.Error.sdk_error =
+  match err, provider_timeout_budget with
+  | Agent_sdk.Error.Api (Timeout { message }), Some _
+    when EC.is_structural_oas_timeout_message message ->
+      err
+  | _ -> err
+
+let attempt_watchdog_outer_turn_reserve_sec = 1.0
+
+let attempt_watchdog_timeout_sec
+    ~(remaining_turn_budget_s : float)
+    (provider_timeout_budget : provider_timeout_budget) : float =
+  let desired =
+    provider_timeout_budget.effective_timeout_sec +. provider_timeout_guard_sec
+  in
+  let cap_before_outer_timeout =
+    Float.max 0.001
+      (remaining_turn_budget_s -. attempt_watchdog_outer_turn_reserve_sec)
+  in
+  let floor =
+    Float.min min_provider_timeout_budget_sec cap_before_outer_timeout
+  in
+  Float.max floor (Float.min desired cap_before_outer_timeout)
+
+type degraded_retry_budget_decision =
+  | No_degraded_retry
+  | Degraded_retry_slot_phase_exhausted of EC.degraded_retry
+  | Degraded_retry_budget_exhausted of EC.degraded_retry
+  | Degraded_retry_allowed of EC.degraded_retry
+
+let next_fail_open_cascade_for_turn_with_budget
+    ~(base_cascade : string)
+    ~(effective_cascade : string)
+    ~(tool_requirement : Keeper_agent_tool_surface.tool_requirement)
+    ~(attempted_cascades : string list)
+    ~(estimated_input_tokens : int)
+    ~(max_turns : int)
+    ?time_spent_in_turn_s
+    ~(remaining_turn_budget_s : float)
+    (err : Agent_sdk.Error.sdk_error) : degraded_retry_budget_decision =
+  match
+    next_fail_open_cascade_for_turn
+      ~base_cascade ~effective_cascade ~tool_requirement
+      ~attempted_cascades err
+  with
+  | None -> No_degraded_retry
+  | Some retry ->
+      (* The candidate is always a retry, so use per-attempt budget semantics
+         regardless of whether the current attempt was itself a retry. *)
+      let first_contract_rotation =
+        EC.is_required_tool_contract_violation err
+        && List.length attempted_cascades <= 1
+      in
+      if
+        match time_spent_in_turn_s with
+        | Some time_spent_in_turn_s ->
+            (not (degraded_retry_slot_phase_available ~time_spent_in_turn_s))
+            && not (degraded_retry_bypasses_slot_phase_guard err)
+            && not first_contract_rotation
+        | None -> false
+      then Degraded_retry_slot_phase_exhausted retry
+      else if
+        provider_retry_budget_available_for_turn
+          ~allow_wall_clock_retry_budget:true
+          ~is_retry:true ~estimated_input_tokens ~max_turns
+          ~remaining_turn_budget_s
+      then Degraded_retry_allowed retry
+      else Degraded_retry_budget_exhausted retry
+
+type turn_event_bus_overflow =
+  Keeper_turn_cascade_budget_event_bus.turn_event_bus_overflow = {
+  estimated_tokens : int;
+  limit_tokens : int;
+}
+
+type turn_event_bus_compaction =
+  Keeper_turn_cascade_budget_event_bus.turn_event_bus_compaction = {
+  before_tokens : int;
+  after_tokens : int;
+  tokens_freed : int;
+  phase_hint : string;
+}
+
+type turn_event_bus_summary =
+  Keeper_turn_cascade_budget_event_bus.turn_event_bus_summary = {
+  correlation_id : string option;
+  run_id : string option;
+  caused_by : string option;
+  event_count : int;
+  payload_kinds : string list;
+  overflow_imminent : turn_event_bus_overflow option;
+  context_compact_started_count : int;
+  context_compacted_count : int;
+  last_compaction : turn_event_bus_compaction option;
+}
+
+let empty_turn_event_bus_summary =
+  Keeper_turn_cascade_budget_event_bus.empty_turn_event_bus_summary
+
+let merge_turn_event_bus_summary =
+  Keeper_turn_cascade_budget_event_bus.merge_turn_event_bus_summary
+
+let add_payload_kind =
+  Keeper_turn_cascade_budget_event_bus.add_payload_kind
+
+let summarize_turn_event_bus
+    (events : Agent_sdk.Event_bus.event list) : turn_event_bus_summary =
+  List.fold_left
+    (fun acc (evt : Agent_sdk.Event_bus.event) ->
+      let correlation_id =
+        match acc.correlation_id with
+        | Some _ -> acc.correlation_id
+        | None -> Some evt.meta.correlation_id
+      in
+      let run_id =
+        match acc.run_id with
+        | Some _ -> acc.run_id
+        | None -> Some evt.meta.run_id
+      in
+      let caused_by =
+        match acc.caused_by with
+        | Some _ -> acc.caused_by
+        | None -> evt.meta.caused_by
+      in
+      let acc =
+        { acc with
+          correlation_id;
+          run_id;
+          caused_by;
+          event_count = acc.event_count + 1;
+          payload_kinds =
+            add_payload_kind acc.payload_kinds
+              (Agent_sdk.Event_bus.payload_kind evt.payload);
+        }
+      in
+      match evt.payload with
+      | Agent_sdk.Event_bus.ContextOverflowImminent
+          { estimated_tokens; limit_tokens; _ } ->
+          {
+            acc with
+            overflow_imminent =
+              Some { estimated_tokens; limit_tokens };
+          }
+      | Agent_sdk.Event_bus.ContextCompactStarted _ ->
+          {
+            acc with
+            context_compact_started_count =
+              acc.context_compact_started_count + 1;
+          }
+      | Agent_sdk.Event_bus.ContextCompacted
+          { before_tokens; after_tokens; phase; _ } ->
+          {
+            acc with
+            context_compacted_count = acc.context_compacted_count + 1;
+            last_compaction =
+              Some
+                {
+                  before_tokens;
+                  after_tokens;
+                  tokens_freed = max 0 (before_tokens - after_tokens);
+                  phase_hint = phase;
+                };
+          }
+      | _ -> acc)
+    empty_turn_event_bus_summary
+    events
+
+let context_overflow_event_of_error
+    ~(fallback_tokens : int)
+    ?(turn_event_bus : turn_event_bus_summary =
+      empty_turn_event_bus_summary)
+    (err : Agent_sdk.Error.sdk_error) : Keeper_state_machine.event =
+  match turn_event_bus.overflow_imminent with
+  | Some { estimated_tokens; limit_tokens } ->
+      Keeper_state_machine.Context_overflow_detected
+        {
+          source = `Oas_signal;
+          token_count = max 0 estimated_tokens;
+          limit_tokens = Some limit_tokens;
+        }
+  | None ->
+      match err with
+      | Agent_sdk.Error.Agent (TokenBudgetExceeded { kind = "Input"; used; limit }) ->
+          Keeper_state_machine.Context_overflow_detected
+            {
+              source = `Oas_signal;
+              token_count = used;
+              limit_tokens = Some limit;
+            }
+      | Agent_sdk.Error.Api (ContextOverflow { limit; _ }) ->
+          Keeper_state_machine.Context_overflow_detected
+            {
+              source = `Prompt_rejected;
+              token_count = Option.value ~default:(max 0 fallback_tokens) limit;
+              limit_tokens = limit;
+            }
+      | _ ->
+          Keeper_state_machine.Context_overflow_detected
+            {
+              source = `Oas_signal;
+              token_count = max 0 fallback_tokens;
+              limit_tokens = None;
+            }
+
+let pause_keeper_for_overflow
+    ~(config : Coord.config)
+    ~(meta : keeper_meta)
+    ~(reason : string) : keeper_meta =
+  match
+    Keeper_supervisor_pause_policy.handle_auto_pause_from_meta
+      ~config
+      ~meta
+      ~reason_tag:"overflow"
+      ~lifecycle_detail:(Printf.sprintf "context_overflow %s" reason)
+      ~log_message:(Printf.sprintf "keeper paused after unresolved context overflow (%s)" reason)
+      ~blocker_class:None
+      ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
+      ()
+  with
+  | Ok paused_meta ->
+    (* Issue #8581: latch the retry-exhausted condition BEFORE the
+       Operator_pause that drives the Paused phase.  The SSOT
+       function already dispatched [Operator_pause]; we only need
+       the extra [Compact_retry_exhausted] signal here. *)
+    dispatch_keeper_phase_event
+      ~config
+      ~keeper_name:meta.name
+      Keeper_state_machine.Compact_retry_exhausted;
+    Keeper_registry.set_failure_reason
+      ~base_path:config.base_path
+      meta.name
+      (Some Keeper_registry.Turn_overflow_pause);
+    paused_meta
+  | Error _err ->
+    (* Fallback: write failed but we must not leave the caller with
+       an unpaused keeper.  Replicate the old in-memory pause path
+       (registry update + events) so the scheduling loop skips this
+       keeper on the next tick.  The write failure is already logged
+       and counted by [handle_auto_pause_from_meta]. *)
+    let paused_meta =
+      { meta with
+        paused = true;
+        auto_resume_after_sec =
+          Keeper_supervisor_pause_policy.auto_resume_after_sec_for_policy
+            meta
+            Keeper_supervisor_pause_policy.Auto_resume_with_backoff;
+        updated_at = now_iso ();
+      }
+    in
+    Keeper_registry.update_meta ~base_path:config.base_path meta.name paused_meta;
+    Keeper_registry.set_failure_reason
+      ~base_path:config.base_path
+      meta.name
+      (Some Keeper_registry.Turn_overflow_pause);
+    dispatch_keeper_phase_event
+      ~config
+      ~keeper_name:meta.name
+      Keeper_state_machine.Compact_retry_exhausted;
+    dispatch_keeper_phase_event
+      ~config
+      ~keeper_name:meta.name
+      Keeper_state_machine.Operator_pause;
+    paused_meta
+
+let sync_keeper_paused_state_impl
+    ~(resume_policy : Keeper_supervisor_pause_policy.crash_pause_resume_policy option)
+    ~(config : Coord.config)
+    ~(meta : keeper_meta)
+    ~(paused : bool) : (keeper_meta, string) result =
+  let auto_resume_after_sec =
+    match paused, resume_policy with
+    | true, Some policy ->
+      Keeper_supervisor_pause_policy.auto_resume_after_sec_for_policy meta policy
+    | _ -> meta.auto_resume_after_sec
+  in
+  let synced_meta =
+    {
+      meta with
+      paused;
+      auto_resume_after_sec;
+      updated_at = now_iso ();
+    }
+  in
+  (* #9733: pause/resume sync is operator-driven; the [paused]
+     field is cycle-owned at this site, so use the same merged-CAS
+     write as overflow pause + unified-turn failure paths.  Without
+     this, an operator pause/resume that races a heartbeat tick
+     can land partially (paused field correct on disk, but write
+     reports failure) which leaves the registry update unsync'd
+     with disk. *)
+  match
+    write_meta_with_merge
+      ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+      config synced_meta
+  with
+  | Error err ->
+      Prometheus.inc_counter
+        Keeper_metrics.(to_string WriteMetaFailures)
+        ~labels:[("keeper", meta.name);
+                 ("phase",
+                  if paused then "pause_sync" else "resume_sync")]
+        ();
+      Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
+        ~config
+        ~keeper_name:meta.name
+        ~side_effect:(Printf.sprintf "%s sync write_meta"
+                        (if paused then "pause" else "resume"))
+        ~severity:`Error
+        err;
+      Error (Printf.sprintf "failed to write meta: %s" err)
+  | Ok () ->
+      Keeper_registry.update_meta ~base_path:config.base_path meta.name synced_meta;
+      Keeper_turn_helpers.dispatch_keeper_phase_event_checked
+        ~config
+        ~keeper_name:meta.name
+        ~side_effect:(Printf.sprintf "%s sync phase update"
+                        (if paused then "pause" else "resume"))
+        (if paused
+         then Keeper_state_machine.Operator_pause
+         else Keeper_state_machine.Operator_resume);
+      (if not paused then
+         match Keeper_registry.get ~base_path:config.base_path meta.name with
+         (* tla-lint: allow-mutation: fiber signal — wake on resume from cascade budget gate *)
+         | Some entry -> Atomic.set entry.fiber_wakeup true
+         | None ->
+             Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
+               ~config
+               ~keeper_name:meta.name
+               ~side_effect:"resume sync fiber wakeup"
+               "registry entry missing after metadata update");
+      Ok synced_meta
+
+let sync_keeper_paused_state ~(config : Coord.config) ~(meta : keeper_meta) ~paused
+  =
+  sync_keeper_paused_state_impl ~resume_policy:None ~config ~meta ~paused
+
+let sync_keeper_paused_state_with_resume_policy
+    ~(config : Coord.config)
+    ~(meta : keeper_meta)
+    ~(paused : bool)
+    ~(resume_policy : Keeper_supervisor_pause_policy.crash_pause_resume_policy)
+  : (keeper_meta, string) result
+  =
+  sync_keeper_paused_state_impl
+    ~resume_policy:(Some resume_policy)
+    ~config
+    ~meta
+    ~paused
+
+let current_keeper_meta ~(config : Coord.config) ~(fallback_meta : keeper_meta) =
+  match Keeper_registry.get ~base_path:config.base_path fallback_meta.name with
+  | Some entry -> entry.meta
+  | None -> fallback_meta
+
+type post_turn_resilience_handles = {
+  resilience_audit_store : Shared_audit.Store.t option;
+  resilience_strategy_executor : Resilience.Recovery.strategy_executor option;
+  sync_lifecycle_meta : post_turn_lifecycle -> post_turn_lifecycle;
+}
+
+let resilience_audit_dir
+    ~(config : Coord.config)
+    ~(keeper_name : string) : string =
+  let masc_root =
+    Common.masc_dir_from_base_path ~base_path:config.base_path
+  in
+  Filename.concat
+    (Filename.concat masc_root "resilience_audit")
+    (Coord_utils.safe_filename keeper_name)
+
+let short_resilience_detail detail =
+  let detail = String.trim detail in
+  if String.length detail <= 240 then detail
+  else String.sub detail 0 240 ^ "..."
+
+let resilience_execution_event_to_string = function
+  | Resilience.Recovery.RetryAttempt { attempt; max_attempts } ->
+      Printf.sprintf "retry_attempt(%d/%d)" attempt max_attempts
+  | Resilience.Recovery.RetryBackoff { attempt; delay_s; error } ->
+      Printf.sprintf "retry_backoff(attempt=%d,delay_s=%.3f,error=%s)"
+        attempt delay_s (short_resilience_detail error)
+  | Resilience.Recovery.FallbackApply { value; confidence_delta } ->
+      Printf.sprintf "fallback_apply(value=%s,confidence_delta=%.3f)"
+        (short_resilience_detail value) confidence_delta
+  | Resilience.Recovery.HandoffRequest { message; preserve_state } ->
+      Printf.sprintf "handoff_request(preserve_state=%b,message=%s)"
+        preserve_state (short_resilience_detail message)
+  | Resilience.Recovery.AbortRun { reason } ->
+      Printf.sprintf "abort_run(reason=%s)"
+        (short_resilience_detail reason)
+
+let make_post_turn_resilience_executor
+    ~(config : Coord.config)
+    ~(meta : keeper_meta)
+    ~(on_paused : keeper_meta -> unit)
+  : Resilience.Recovery.strategy_executor =
+  let pause_for_operator ~code ~detail =
+    let detail = short_resilience_detail detail in
+    let latest_meta = current_keeper_meta ~config ~fallback_meta:meta in
+    Keeper_registry.set_failure_reason ~base_path:config.base_path meta.name
+      (Some
+         (Keeper_registry.Provider_runtime_error
+            { code; detail; provider_id = None; http_status = None
+            ; cascade_name = None
+            }));
+    match
+      sync_keeper_paused_state_with_resume_policy
+        ~config
+        ~meta:latest_meta
+        ~paused:true
+        ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
+    with
+    | Ok paused_meta ->
+        on_paused paused_meta;
+        Ok ()
+    | Error err -> Error err
+  in
+  let fail_and_pause ~code ~detail =
+    let detail = short_resilience_detail detail in
+    match pause_for_operator ~code ~detail with
+    | Ok () -> detail
+    | Error err -> Printf.sprintf "%s (pause failed: %s)" detail err
+  in
+  {
+    Resilience.Recovery.run_retry_attempt =
+      (fun ~attempt ->
+        let detail =
+          Printf.sprintf
+            "post-turn resilience retry attempt %d has no operation-specific \
+             retry callback; paused for operator recovery"
+            attempt
+        in
+        Resilience.Recovery.Fatal_failure
+          (fail_and_pause ~code:"resilience_retry_unbound" ~detail));
+    sleep =
+      (fun delay_s ->
+        if delay_s > 0.0 then
+          match Eio_context.get_clock_opt () with
+          | Some clock -> Eio.Time.sleep clock delay_s
+          | None -> ());
+    on_event =
+      (fun event ->
+        Log.Keeper.warn "keeper:%s post-turn resilience event: %s"
+          meta.name (resilience_execution_event_to_string event));
+    apply_fallback =
+      (fun ~value ~confidence_delta ->
+        let detail =
+          Printf.sprintf
+            "post-turn resilience fallback has no typed target \
+             (value=%s confidence_delta=%.3f); paused for operator recovery"
+            (short_resilience_detail value) confidence_delta
+        in
+        Error
+          (fail_and_pause ~code:"resilience_fallback_unbound" ~detail));
+    request_handoff =
+      (fun ~message ~preserve_state ->
+        let detail =
+          Printf.sprintf
+            "post-turn resilience handoff requested preserve_state=%b: %s"
+            preserve_state message
+        in
+        pause_for_operator ~code:"resilience_handoff" ~detail);
+    abort =
+      (fun ~reason ->
+        let detail =
+          Printf.sprintf
+            "post-turn resilience abort requested: %s"
+            reason
+        in
+        pause_for_operator ~code:"resilience_abort" ~detail);
+  }
+
+let post_turn_resilience_handles
+    ~(config : Coord.config)
+    ~(meta : keeper_meta) : post_turn_resilience_handles =
+  let paused_meta = ref None in
+  let sync_lifecycle_meta lifecycle =
+    match !paused_meta with
+    | None -> lifecycle
+    | Some paused ->
+        { lifecycle with
+          updated_meta =
+            { lifecycle.updated_meta with
+              paused = paused.paused;
+              updated_at = paused.updated_at;
+              auto_resume_after_sec = paused.auto_resume_after_sec;
+            };
+        }
+  in
+  if not (Resilience.Keeper_bridge.masc_resilience_enabled ()) then
+    {
+      resilience_audit_store = None;
+      resilience_strategy_executor = None;
+      sync_lifecycle_meta;
+    }
+  else
+    match
+      (try
+         Ok
+           (Shared_audit.Store.create
+              ~base_dir:(resilience_audit_dir ~config ~keeper_name:meta.name))
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn -> Error (Printexc.to_string exn))
+    with
+    | Error detail ->
+        Prometheus.inc_counter Keeper_metrics.(to_string OasExecutionErrors)
+          ~labels:[("keeper", meta.name); ("phase", Keeper_oas_execution_error_phase.(to_label Resilience_audit_store))]
+          ();
+        Log.Keeper.error
+          "keeper:%s resilience audit store unavailable; execution disabled: %s"
+          meta.name detail;
+        {
+          resilience_audit_store = None;
+          resilience_strategy_executor = None;
+          sync_lifecycle_meta;
+        }
+    | Ok audit_store ->
+        let executor =
+          make_post_turn_resilience_executor ~config ~meta
+            ~on_paused:(fun meta -> paused_meta := Some meta)
+        in
+        {
+          resilience_audit_store = Some audit_store;
+          resilience_strategy_executor = Some executor;
+          sync_lifecycle_meta;
+        }
+
+let enqueue_partial_commit_continue_gate
+    ~(config : Coord.config)
+    ~(meta : keeper_meta)
+    ~(failure_reason : Keeper_registry.failure_reason)
+    ~(committed_tools : string list)
+    ~(error_detail : string) : string =
+  let reason_text = Keeper_registry.failure_reason_to_string failure_reason in
+  let input =
+    `Assoc [
+      ("kind", `String "continue_gate_required");
+      ("keeper_name", `String meta.name);
+      ("failure_reason", `String reason_text);
+      ("error_detail", `String error_detail);
+      ("committed_tools", `List (List.map (fun tool -> `String tool) committed_tools));
+    ]
+  in
+  Keeper_approval_queue.submit_pending
+    ~keeper_name:meta.name
+    ~tool_name:"keeper_continue_after_partial_commit"
+    ~input
+    ~risk_level:Keeper_approval_queue.Critical
+    ~base_path:config.base_path
+    ~on_resolution:(fun decision ->
+      let latest_meta = current_keeper_meta ~config ~fallback_meta:meta in
+      match decision with
+      | Agent_sdk.Hooks.Approve
+      | Agent_sdk.Hooks.Edit _ ->
+        (match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:false with
+         | Ok resumed_meta ->
+             Keeper_registry.set_failure_reason ~base_path:config.base_path meta.name None;
+             Keeper_registry.reset_turn_failures ~base_path:config.base_path meta.name;
+             Log.Keeper.info
+               "%s: partial-commit continue gate approved; auto-resumed keeper"
+               resumed_meta.name
+         | Error err ->
+             Log.Keeper.error
+               "%s: partial-commit continue gate approved but keeper resume sync failed: %s"
+               meta.name err);
+             Prometheus.inc_counter
+               Keeper_metrics.(to_string CascadeSyncFailures)
+               ~labels:[("keeper", meta.name); ("site", Keeper_cascade_sync_failure_site.(to_label Resume_sync))]
+               ()
+      | Agent_sdk.Hooks.Reject reason ->
+        (match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:true with
+         | Ok paused_meta ->
+             Keeper_registry.set_failure_reason
+               ~base_path:config.base_path meta.name
+               (Some failure_reason);
+             Log.Keeper.warn
+               "%s: partial-commit continue gate rejected; keeper remains paused (%s)"
+               paused_meta.name reason
+         | Error err ->
+             Log.Keeper.error
+               "%s: partial-commit continue gate rejected but keeper pause sync failed: %s (reason=%s)"
+               meta.name err reason);
+             Prometheus.inc_counter
+               Keeper_metrics.(to_string CascadeSyncFailures)
+               ~labels:[("keeper", meta.name); ("site", Keeper_cascade_sync_failure_site.(to_label Pause_sync))]
+               ())
+    ()
+
+(* Dedupe "mixed cascade context budget" log: the values are constant
+   per (keeper_name, model_labels) because cascade config is static at
+   startup.  Logging per turn produces 15-20 duplicates per keeper per
+   minute under load. Track (name, primary, cascade_max) tuples we've
+   already announced and skip subsequent identical log lines. *)
+let cascade_budget_logged : (string * int * int, unit) Hashtbl.t =
+  Hashtbl.create 16
+
+let resolved_max_context_for_turn
+    ~(meta : keeper_meta)
+    (model_labels : string list) : int =
+  let resolution =
+    Keeper_context_runtime.resolve_max_context_resolution
+      ~requested_override:meta.max_context_override model_labels
+  in
+  if resolution.primary_budget < resolution.cascade_budget then begin
+    let key = (meta.name, resolution.primary_budget, resolution.cascade_budget) in
+    if not (Hashtbl.mem cascade_budget_logged key) then begin
+      Hashtbl.add cascade_budget_logged key ();
+      Log.Keeper.info
+        "%s: mixed cascade context budget primary=%d cascade_max=%d; using primary for initial turn budget"
+        meta.name resolution.primary_budget resolution.cascade_budget
+    end
+  end;
+   (match resolution.requested_override with
+    | Some requested ->
+     Log.Keeper.debug
+       "%s: using max_context_override=%d context_budget=%d primary_budget=%d effective_budget=%d"
+       meta.name requested resolution.turn_budget resolution.primary_budget
+       resolution.effective_budget
+   | None -> ());
+  resolution.effective_budget

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -1,0 +1,314 @@
+(* Keeper_turn_cascade_budget — cascade execution types, fail-open rotation,
+   provider timeout budget resolution, context overflow observation, keeper pause/resume
+   sync, partial-commit continue gate, and context budget resolution.
+
+   Public sub-module included by [Keeper_unified_turn]. *)
+
+open Keeper_types
+open Keeper_meta_contract
+open Keeper_types_profile
+open Keeper_context_runtime
+module EC = Keeper_error_classify
+
+type cascade_execution = {
+  cascade_name : string;
+  max_context_resolution : max_context_resolution;
+  max_context : int;
+  temperature : float;
+  max_tokens : int;
+}
+
+val next_fail_open_cascade_for_turn :
+  base_cascade:string ->
+  effective_cascade:string ->
+  tool_requirement:Keeper_agent_tool_surface.tool_requirement ->
+  attempted_cascades:string list ->
+  Agent_sdk.Error.sdk_error ->
+  EC.degraded_retry option
+(** Required-tool retries do not fall through to the generic keeper-assignable
+    rotation catalog. They stay on the base cascade, the configured
+    [routes.tool_required] target, or an explicit [fallback_cascade] hint so
+    request-scoped runtime-MCP turns cannot degrade into manual CLI lanes that
+    cannot carry the request-scoped tool policy. *)
+
+val sdk_error_kind : Agent_sdk.Error.sdk_error -> string
+
+val record_turn_failure_stress :
+  meta:keeper_meta ->
+  is_auto_recoverable:bool ->
+  consecutive:int ->
+  threshold:int ->
+  err:Agent_sdk.Error.sdk_error ->
+  unit
+
+val provider_timeout_guard_sec : float
+(** Retry guard floor (seconds). *)
+
+val min_provider_timeout_budget_sec : float
+(** Minimum provider timeout budget (seconds). *)
+
+val first_attempt_degraded_retry_reserve_sec : float
+(** Wall-clock reserve kept from non-retry attempts so one degraded
+    retry can still satisfy [provider_timeout_guard_sec] +
+    [min_provider_timeout_budget_sec]. *)
+
+val sdk_error_kind : Agent_sdk.Error.sdk_error -> string
+
+type provider_timeout_budget = {
+  effective_timeout_sec : float;
+  adaptive_timeout_sec : float;
+  keeper_turn_timeout_sec : float;
+  remaining_turn_budget_sec : float;
+  estimated_input_tokens : int;
+  max_turns : int;
+  source : string;
+}
+
+val provider_timeout_budget_to_yojson :
+  provider_timeout_budget -> Yojson.Safe.t
+
+val resolve_bounded_provider_timeout_budget_with_turn_budget :
+  allow_wall_clock_retry_budget:bool ->
+  is_retry:bool ->
+  estimated_input_tokens:int ->
+  max_turns:int ->
+  remaining_turn_budget_s:float ->
+  provider_timeout_budget option
+(** Resolves the per-provider timeout inside the outer keeper turn
+    budget. Non-retry attempts keep a small degraded-retry reserve when
+    the remaining wall-clock budget is large enough; retry attempts use
+    the remaining per-attempt or one-shot degraded wall-clock budget. *)
+
+val allow_wall_clock_retry_budget_for_attempt :
+  is_retry:bool ->
+  degraded_rotation_first_attempt:bool ->
+  attempt:int ->
+  attempted_cascades:string list ->
+  bool
+
+val bounded_provider_timeout_for_turn_budget_with_turn_budget :
+  estimated_input_tokens:int ->
+  max_turns:int ->
+  remaining_turn_budget_s:float ->
+  float option
+
+val bounded_provider_timeout_for_turn_budget :
+  estimated_input_tokens:int ->
+  remaining_turn_budget_s:float ->
+  float option
+
+val provider_retry_budget_available_for_turn :
+  allow_wall_clock_retry_budget:bool ->
+  is_retry:bool ->
+  estimated_input_tokens:int ->
+  max_turns:int ->
+  remaining_turn_budget_s:float ->
+  bool
+
+(** RFC-OAS-XXX (Team JJ §6) — typed retry admission decision.
+
+    Distinguishes "admission denied before any provider attempt"
+    from "provider attempt ran and OAS server timed out". The
+    existing call surface in [Keeper_unified_turn] emits
+    [Turn_timeout] instead of minting an [Provider_timeout] root cause
+    for the former case, which collapses both semantics into one
+    metric. This function exposes the typed decision so callers can
+    branch on the closed-sum reason. The matching error variant
+    ([Retry_admission_denied]) is RFC-deferred. *)
+
+type retry_admission_denial =
+  Keeper_meta_contract.retry_admission_denial =
+  | Retry_budget_below_min of {
+      projected_usable_budget_s : float;
+      min_required_s : float;
+      remaining_turn_budget_s : float;
+      adaptive_timeout_s : float;
+      allow_wall_clock_retry_budget : bool;
+    }
+  | First_attempt_budget_below_min of {
+      projected_usable_budget_s : float;
+      min_required_s : float;
+      remaining_turn_budget_s : float;
+    }
+
+type attempt_kind = First_attempt | Retry_attempt
+
+val retry_admission_denial_to_yojson :
+  retry_admission_denial -> Yojson.Safe.t
+
+val decide_retry_admission_for_turn :
+  remaining_turn_budget_s:float ->
+  attempt_kind:attempt_kind ->
+  allow_wall_clock_retry_budget:bool ->
+  estimated_input_tokens:int ->
+  max_turns:int ->
+  (unit, retry_admission_denial) result
+
+val degraded_retry_slot_phase_budget_sec : float
+(** Maximum outer-slot hold time before degraded cascade rotation is
+    suppressed. This is a guardrail for #12888: once the productive
+    phase has already consumed this much wall clock, rotation should end
+    the cycle instead of holding the same slot for another provider
+    attempt. provider-timeout failures may still rotate to the next
+    degraded cascade when retry budget remains, because the failed attempt
+    already represents the budgeted provider wait. *)
+
+val degraded_retry_slot_phase_available :
+  time_spent_in_turn_s:float -> bool
+
+val reclassify_provider_timeout_for_attempt :
+  provider_timeout_budget:provider_timeout_budget option ->
+  Agent_sdk.Error.sdk_error ->
+  Agent_sdk.Error.sdk_error
+(** Preserve upstream structural timeout errors instead of minting a synthetic
+    [Provider_timeout] root cause.  Kept as a named hook while the
+    provider-timeout root-cause ADT is introduced in a later PR. *)
+
+val attempt_watchdog_timeout_sec :
+  remaining_turn_budget_s:float ->
+  provider_timeout_budget ->
+  float
+(** Wall-clock watchdog for a single cascade attempt.
+
+    The watchdog fires after the OAS per-attempt budget plus the normal
+    finalization guard, while reserving a small outer-turn margin before the
+    enclosing keeper turn wall-clock timeout. This keeps a hung provider
+    attempt on the structured [provider_timeout] path, where degraded cascade
+    rotation can still run, instead of falling through to terminal
+    [turn_timeout]. *)
+
+type degraded_retry_budget_decision =
+  | No_degraded_retry
+  | Degraded_retry_slot_phase_exhausted of EC.degraded_retry
+  | Degraded_retry_budget_exhausted of EC.degraded_retry
+  | Degraded_retry_allowed of EC.degraded_retry
+
+val next_fail_open_cascade_for_turn_with_budget :
+  base_cascade:string ->
+  effective_cascade:string ->
+  tool_requirement:Keeper_agent_tool_surface.tool_requirement ->
+  attempted_cascades:string list ->
+  estimated_input_tokens:int ->
+  max_turns:int ->
+  ?time_spent_in_turn_s:float ->
+  remaining_turn_budget_s:float ->
+  Agent_sdk.Error.sdk_error ->
+  degraded_retry_budget_decision
+
+type turn_event_bus_overflow = {
+  estimated_tokens : int;
+  limit_tokens : int;
+}
+
+type turn_event_bus_compaction = {
+  before_tokens : int;
+  after_tokens : int;
+  tokens_freed : int;
+  phase_hint : string;
+}
+
+type turn_event_bus_summary = {
+  correlation_id : string option;
+  run_id : string option;
+  caused_by : string option;
+  event_count : int;
+  payload_kinds : string list;
+  overflow_imminent : turn_event_bus_overflow option;
+  context_compact_started_count : int;
+  context_compacted_count : int;
+  last_compaction : turn_event_bus_compaction option;
+}
+
+val empty_turn_event_bus_summary : turn_event_bus_summary
+
+val merge_turn_event_bus_summary :
+  turn_event_bus_summary -> turn_event_bus_summary -> turn_event_bus_summary
+
+val summarize_turn_event_bus :
+  Agent_sdk.Event_bus.event list -> turn_event_bus_summary
+
+val context_overflow_event_of_error :
+  fallback_tokens:int ->
+  ?turn_event_bus:turn_event_bus_summary ->
+  Agent_sdk.Error.sdk_error ->
+  Keeper_state_machine.event
+
+val pause_keeper_for_overflow :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  reason:string ->
+  keeper_meta
+(** Pause a keeper after unresolved context overflow. Writes meta with merge-CAS
+    and dispatches [Compact_retry_exhausted] then [Operator_pause]. Returns the
+    paused meta. *)
+
+val sync_keeper_paused_state :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  paused:bool ->
+  (keeper_meta, string) result
+(** Persist paused/resumed state before mutating the live registry/phase.
+    Returns [Error] when disk sync fails so callers can surface the failure
+    instead of silently diverging runtime vs persisted state. *)
+
+val sync_keeper_paused_state_with_resume_policy :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  paused:bool ->
+  resume_policy:Keeper_supervisor_pause_policy.crash_pause_resume_policy ->
+  (keeper_meta, string) result
+(** Like {!sync_keeper_paused_state}, but also applies [resume_policy] when
+    pausing so automatic pause paths can enter the supervisor self-healing
+    sweep instead of becoming an indefinite manual pause. *)
+
+val current_keeper_meta :
+  config:Coord.config ->
+  fallback_meta:keeper_meta ->
+  keeper_meta
+(** Read the latest meta from the registry, falling back to the given
+    [fallback_meta] when the registry entry is missing. *)
+
+type post_turn_resilience_handles = {
+  resilience_audit_store : Shared_audit.Store.t option;
+  resilience_strategy_executor : Resilience.Recovery.strategy_executor option;
+  sync_lifecycle_meta :
+    Keeper_context_runtime.post_turn_lifecycle ->
+    Keeper_context_runtime.post_turn_lifecycle;
+}
+(** Runtime handles for the feature-flagged post-turn resilience wire-in.
+
+    When [MASC_RESILIENCE] is off or the audit store cannot be opened, both
+    handles are [None] and [sync_lifecycle_meta] is identity. When execution
+    pauses a keeper for operator handoff/abort, [sync_lifecycle_meta] folds the
+    persisted paused meta back into the lifecycle so the caller's normal final
+    meta write does not accidentally unpause it. *)
+
+val resilience_audit_dir :
+  config:Coord.config ->
+  keeper_name:string ->
+  string
+(** Per-keeper audit root for resilience recovery envelopes. *)
+
+val post_turn_resilience_handles :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  post_turn_resilience_handles
+(** Create per-turn resilience audit/executor handles. The audit store is
+    per keeper to respect [Shared_audit.Store]'s single-writer chain
+    contract. *)
+
+val enqueue_partial_commit_continue_gate :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  failure_reason:Keeper_registry.failure_reason ->
+  committed_tools:string list ->
+  error_detail:string ->
+  string
+
+val resolved_max_context_for_turn :
+  meta:keeper_meta ->
+  string list ->
+  int
+(** Resolve the initial keeper turn context budget. Uses the first available
+    model in the cascade rather than the largest fallback model, so lifecycle
+    context math matches the provider that will receive the first request. *)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -8,14 +8,13 @@
     @since God file decomposition — extracted from oas_worker.ml *)
 
 open Result.Syntax
-open Cascade_name
 
 (* Sub-module includes (God file decomposition).
    Each sub-module is self-contained; the facade re-exports everything
    so existing callers do not need qualification. *)
 include Runtime_oas_runner
-include Cascade_error_classify
-include Cascade_attempt_fsm
+include Keeper_masc_error_classify
+include Keeper_sdk_error_classify
 include Keeper_turn_driver_helpers
 
 include Keeper_turn_driver_provider_attempt

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -17,12 +17,12 @@
     manual type copy so the interface stays structurally identical to the
     implementation's [include Cascade_error_classify]. *)
 
-include module type of Cascade_error_classify
+include module type of Keeper_masc_error_classify
 
 (** {1 Cascade error helpers} *)
 
 val sdk_error_to_cascade_outcome :
-  Agent_sdk.Error.sdk_error -> Cascade_fsm.provider_outcome option
+  Agent_sdk.Error.sdk_error -> Keeper_provider_outcome.provider_outcome option
 
 val message_looks_like_cli_wrapped_hard_quota : string -> bool
 

--- a/lib/keeper/keeper_turn_driver_backpressure.ml
+++ b/lib/keeper/keeper_turn_driver_backpressure.ml
@@ -5,8 +5,7 @@
 
     @since God file decomposition *)
 
-open Cascade_internal_error
-open Cascade_name
+open Keeper_meta_contract
 
 (* Synthetic backoff default for paths where the upstream provides no
    [retry_after] hint.  Carried as [Synthetic_default] so provenance is

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -467,8 +467,8 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
       max_tokens = Some (local_worker_max_tokens ());
       max_turns;
       temperature = Some Llm_provider.Constants.Inference_profile.worker_default.temperature;
-      top_p = Some Llm_provider.Constants.Worker_sampling.top_p;
-      top_k = Some Llm_provider.Constants.Worker_sampling.top_k;
+      top_p = Some Runtime_constants.Worker_sampling.top_p;
+      top_k = Some Runtime_constants.Worker_sampling.top_k;
       (* min_p is effectively disabled (0.0) and some cloud providers
          reject the field itself even when the value is a no-op. *)
       min_p = None;
@@ -482,7 +482,7 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
     | None ->
         { Agent_sdk.Guardrails.tool_filter =
             Agent_sdk.Guardrails.AllowList (oas_tool_names tools);
-          max_tool_calls_per_turn = Some Llm_provider.Constants.Worker_sampling.max_tool_calls_per_turn;
+          max_tool_calls_per_turn = Some Runtime_constants.Worker_sampling.max_tool_calls_per_turn;
         }
   in
   let options =

--- a/lib/runtime/runtime_constants.ml
+++ b/lib/runtime/runtime_constants.ml
@@ -8,3 +8,13 @@
     yields nothing. Mirrors the deleted [Runtime_constants.fallback_context_window].
     128k is the conservative floor across the supported provider matrix. *)
 let fallback_context_window = 128_000
+
+(** Worker-turn sampling defaults, re-homed from the deleted
+    [Cascade_worker_defaults]. Local/container worker turns send these to the
+    completion endpoint when the caller does not override them. Values verbatim
+    from the pre-purge module (RFC-0206 cascade→Runtime rebirth). *)
+module Worker_sampling = struct
+  let top_p = 0.95
+  let top_k = 20
+  let max_tool_calls_per_turn = 12
+end

--- a/lib/runtime/runtime_constants.mli
+++ b/lib/runtime/runtime_constants.mli
@@ -3,3 +3,11 @@
 val fallback_context_window : int
 (** Context-window size assumed when a model declares none and discovery yields
     nothing (128000). Mirrors deleted [Runtime_constants.fallback_context_window]. *)
+
+(** Worker-turn sampling defaults, re-homed from the deleted
+    [Cascade_worker_defaults] (RFC-0206). *)
+module Worker_sampling : sig
+  val top_p : float
+  val top_k : int
+  val max_tool_calls_per_turn : int
+end

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -56,8 +56,8 @@ let agent_config_of_worker_meta
   ; max_tokens = Some max_tokens
   ; max_turns = effective_max_turns meta
   ; temperature = Some Llm_provider.Constants.Inference_profile.worker_default.temperature
-  ; top_p = Some Llm_provider.Constants.Worker_sampling.top_p
-  ; top_k = Some Llm_provider.Constants.Worker_sampling.top_k
+  ; top_p = Some Runtime_constants.Worker_sampling.top_p
+  ; top_k = Some Runtime_constants.Worker_sampling.top_k
   ; (* min_p intentionally omitted: the constant is 0.0 (no-op) and some
        cloud providers (Groq, GLM) reject the field itself with
        "Invalid request: property 'min_p' is unsupported". OAS capability
@@ -158,7 +158,7 @@ let build_agent
     | None ->
       { Agent_sdk.Guardrails.tool_filter = AllowList tool_names
       ; max_tool_calls_per_turn =
-          Some Llm_provider.Constants.Worker_sampling.max_tool_calls_per_turn
+          Some Runtime_constants.Worker_sampling.max_tool_calls_per_turn
       }
   in
   let builder =
@@ -171,8 +171,8 @@ let build_agent
     | None -> b)
     |> Agent_sdk.Builder.with_max_turns config.max_turns
     |> Agent_sdk.Builder.with_temperature Llm_provider.Constants.Inference_profile.worker_default.temperature
-    |> Agent_sdk.Builder.with_top_p Llm_provider.Constants.Worker_sampling.top_p
-    |> Agent_sdk.Builder.with_top_k Llm_provider.Constants.Worker_sampling.top_k
+    |> Agent_sdk.Builder.with_top_p Runtime_constants.Worker_sampling.top_p
+    |> Agent_sdk.Builder.with_top_k Runtime_constants.Worker_sampling.top_k
     (* with_min_p intentionally omitted — see agent_config_of_worker_meta
        above for the reason. min_p of 0.0 is a no-op and cloud providers
        (Groq, GLM) reject the field itself. *)


### PR DESCRIPTION
## 목적

RFC-0206 cascade→Runtime L2 마이그레이션의 **빌드 green 복구** (진행 중, Draft).

origin/main은 cascade 추상화 제거(#19536) 후 **의도적으로 broken** 상태입니다. 삭제된 cascade 모듈을 참조하는 consumer 코드를 Runtime/keeper 도메인으로 재배선합니다.

## 이번 진척 (6커밋, origin/main rebase 위)

- **error 도메인 전체 re-home**: `masc_internal_error` ADT+codec → `Keeper_meta_contract` 키스톤 / `keeper_provider_outcome`(provider_outcome 타입, routing `decide` 제외) / `keeper_error_from_sdk` / `keeper_masc_error_classify` / `keeper_sdk_error_classify`(attempt_fsm) + `capacity_backpressure`/`http_error` sub-module (health_tracker 915줄은 상수 redirect로 회피)
- **facade `keeper_turn_driver` error surface 연결**
- **engine**: `keeper_cascade_engine`(42줄 single-provider dispatch boundary, routing 아님) 그대로 부활

### dead-by-design 제거 (workaround 아님)

RFC-0206에서 cascade 개념 자체가 제거되어 무의미해진 코드를 제거한 것이며, symptom 억제(stub/catch-all/telemetry-as-fix)가 아닙니다:

- cascade saturation/attempt **telemetry 제거** — cascade routing이 사라져 측정 대상이 없음
- per-cascade api_key override → provider default **단순화** — single-binding은 provider api_key를 직접 해석
- deprecated `subprocess_cli` guard 제거 — CLI transport 개념 폐기(사용자 확인)

WORKAROUND-WAIVED: 위 제거는 cascade 추상화 폐기에 따른 dead code 정리이며 대체 RFC 불필요(RFC-0206 자체가 근거).

## 남은 작업 (멀티세션)

- **C** `Keeper_turn_cascade_budget` (831줄 re-home, sync_failure_site tail)
- **FSM** `packed_cascade_state` (#19556 annihilation 완성, 25파일)
- **B/E** routing collapse (`run_named` 엔진을 single-binding으로 재설계 — RFC 설계 필요, 단순 grind 금지)

## 검증 상태

- 로컬 환경: `agent_sdk` 0.200.7(병렬 OAS 세션용) vs origin/main `opam.locked` 0.194.0 drift로 로컬 full-green 검증 불가. **error-domain 모듈 빌드 에러 0 확인**.
- 최종 검증은 CI(0.194.0)에서 수행.

RFC-0206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
