### PR TITLE
Remove Cascade config resolution surface

### DIFF
--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -81,8 +81,6 @@ describe('ConfigResolutionPanel', () => {
           status: 'warn',
           warnings: ['Resolved config child is missing: keepers'],
           config_root: { path: '/tmp/runtime/config', exists: true, source: 'env' },
-          cascade_authoring: { path: '/tmp/runtime/config/cascade.toml', exists: true, source: 'env' },
-          cascade: { path: '/tmp/runtime/config/cascade.toml', exists: true, source: 'env' },
           prompts: { path: '/tmp/runtime/config/prompts', exists: true, source: 'env' },
           keepers: { path: '/tmp/runtime/config/keepers', exists: false, source: 'env' },
           personas: { path: '/tmp/custom-personas', exists: false, source: 'invalid_env' },
@@ -141,13 +139,10 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('/tmp/runtime/config')
     expect(container.textContent).toContain('env override')
     expect(container.textContent).toContain('Resolved config child is missing: keepers')
-    expect(container.textContent).toContain('cascade.toml')
     expect(container.textContent).toContain('TOML-only')
-    expect(container.textContent).toContain('authoring=runtime')
     expect(container.textContent).toContain('repo seed not active')
     expect(container.textContent).toContain('root-relative')
     expect(container.textContent).toContain('under config root')
-    expect(container.textContent).not.toContain('/tmp/runtime/config/cascade.toml')
     expect(container.textContent).toContain('/tmp/custom-personas')
     expect(container.textContent).toContain('invalid env')
     expect(container.textContent).toContain('/tmp/workspace/.masc')
@@ -174,8 +169,6 @@ describe('ConfigResolutionPanel', () => {
           status: 'ready',
           warnings: [],
           config_root: { path: '/tmp/root-config', exists: true, source: 'env' },
-          cascade_authoring: { path: '/tmp/root-config/cascade.toml', exists: true, source: 'env' },
-          cascade: { path: '/tmp/root-config/cascade.toml', exists: true, source: 'env' },
           prompts: { path: '/tmp/root-config/prompts', exists: true, source: 'env' },
           keepers: { path: '/tmp/root-config/keepers', exists: true, source: 'cwd' },
           personas: { path: '/tmp/root-config/personas', exists: true, source: 'env' },
@@ -198,8 +191,6 @@ describe('ConfigResolutionPanel', () => {
           status: 'ready',
           warnings: [],
           config_root: { path: '/tmp/root', exists: true, source: 'env' },
-          cascade_authoring: { path: '/tmp/root/cascade.toml', exists: true, source: 'env' },
-          cascade: { path: '/tmp/root/cascade.toml', exists: true, source: 'env' },
           prompts: { path: '/tmp/root/prompts', exists: true, source: 'env' },
           keepers: { path: '/tmp/root/keepers', exists: true, source: 'env' },
           personas: { path: '/tmp/root-extra/personas', exists: true, source: 'env' },
@@ -219,8 +210,6 @@ describe('ConfigResolutionPanel', () => {
           status: 'ready',
           warnings: [],
           config_root: { path: '/tmp/root', exists: true, source: 'env' },
-          cascade_authoring: { path: '/tmp/root/cascade.toml', exists: false, source: 'env' },
-          cascade: { path: '/tmp/root', exists: true, source: 'env' },
           prompts: { path: '/tmp/root/prompts', exists: true, source: 'env' },
           keepers: { path: '/tmp/root/keepers', exists: true, source: 'env' },
           personas: { path: '/tmp/root/personas', exists: true, source: 'env' },
@@ -240,8 +229,6 @@ describe('ConfigResolutionPanel', () => {
           status: 'ready',
           warnings: [],
           config_root: { path: '/', exists: true, source: 'cwd' },
-          cascade_authoring: { path: '/etc/cascade.toml', exists: true, source: 'cwd' },
-          cascade: { path: '/etc/cascade.toml', exists: true, source: 'cwd' },
           prompts: { path: '/var/prompts', exists: true, source: 'cwd' },
           keepers: { path: '/opt/keepers', exists: true, source: 'cwd' },
           personas: { path: '/srv/personas', exists: true, source: 'cwd' },
@@ -249,8 +236,6 @@ describe('ConfigResolutionPanel', () => {
       />`,
       container,
     )
-
-    expect(container.textContent).toContain('etc/cascade.toml')
     expect(container.textContent).toContain('root-relative')
   })
 
@@ -261,8 +246,6 @@ describe('ConfigResolutionPanel', () => {
           status: 'ready',
           warnings: [],
           config_root: { path: '/tmp/project/.masc/config', exists: true, source: 'local_masc' },
-          cascade_authoring: { path: '/tmp/project/.masc/config/cascade.toml', exists: true, source: 'local_masc' },
-          cascade: { path: '/tmp/project/.masc/config/cascade.toml', exists: true, source: 'local_masc' },
           prompts: { path: '/tmp/project/.masc/config/prompts', exists: true, source: 'local_masc' },
           keepers: { path: '/tmp/project/.masc/config/keepers', exists: true, source: 'local_masc' },
           personas: { path: '/tmp/project/.masc/config/personas', exists: true, source: 'local_masc' },
@@ -282,8 +265,6 @@ describe('ConfigResolutionPanel', () => {
           status: 'ready',
           warnings: [],
           config_root: { path: '/tmp/project/config', exists: true, source: 'cwd' },
-          cascade_authoring: { path: '/tmp/project/config/cascade.toml', exists: true, source: 'cwd' },
-          cascade: { path: '/tmp/project/config/cascade.toml', exists: true, source: 'cwd' },
           prompts: { path: '/tmp/project/config/prompts', exists: true, source: 'cwd' },
           keepers: { path: '/tmp/project/config/keepers', exists: true, source: 'cwd' },
           personas: { path: '/tmp/project/config/personas', exists: true, source: 'cwd' },

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -209,29 +209,21 @@ function isRepoFallbackSource(source: string): boolean {
   return source === 'cwd' || source === 'exe_relative'
 }
 
-function sameResolvedPath(left: DashboardConfigResolutionItem, right: DashboardConfigResolutionItem): boolean {
-  return normalizePath(left.path) === normalizePath(right.path)
-}
-
 function ConfigTopologySummary({
   resolution,
 }: {
   resolution: DashboardConfigResolution
 }) {
-  const authoringMatchesRuntime = sameResolvedPath(resolution.cascade_authoring, resolution.cascade)
   const repoFallbackActive = isRepoFallbackSource(resolution.config_root.source)
 
   return html`
     <div class="mb-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-hover)] px-3 py-2">
       <div class="flex flex-wrap items-center gap-2">
         <${StatusChip} tone="neutral" uppercase=${false}>TOML-only<//>
-        <${StatusChip} tone=${authoringMatchesRuntime ? 'ok' : 'warn'} uppercase=${false}>
-          ${authoringMatchesRuntime ? 'authoring=runtime' : 'authoring/runtime split'}
-        <//>
         <${StatusChip} tone=${repoFallbackActive ? 'warn' : 'neutral'} uppercase=${false}>
           ${repoFallbackActive ? 'repo config active' : 'repo seed not active'}
         <//>
-        <span class="text-xs text-[var(--color-fg-muted)]">cascade.toml source follows the resolved config root</span>
+        <span class="text-xs text-[var(--color-fg-muted)]">runtime config follows the resolved config root</span>
       </div>
     </div>
   `
@@ -606,18 +598,6 @@ export function ConfigResolutionPanel({
                   rootPath=${rootPath}
                   rootSource=${rootSource}
                   isRoot=${true}
-                />
-                <${ConfigRow}
-                  label="cascade authoring"
-                  item=${resolution.cascade_authoring}
-                  rootPath=${rootPath}
-                  rootSource=${rootSource}
-                />
-                <${ConfigRow}
-                  label="cascade source"
-                  item=${resolution.cascade}
-                  rootPath=${rootPath}
-                  rootSource=${rootSource}
                 />
                 <${ConfigRow}
                   label="prompts"

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -65,8 +65,6 @@ export interface DashboardConfigResolution {
   status: 'ready' | 'warn' | 'invalid_env' | 'missing'
   warnings: string[]
   config_root: DashboardConfigResolutionItem
-  cascade_authoring: DashboardConfigResolutionItem
-  cascade: DashboardConfigResolutionItem
   prompts: DashboardConfigResolutionItem
   keepers: DashboardConfigResolutionItem
   personas: DashboardConfigResolutionItem

--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -29,8 +29,6 @@ type resolution = {
   status : status;
   warnings : string list;
   config_root : path_item;
-  cascade_authoring : path_item;
-  cascade : path_item;
   prompts : path_item;
   keepers : path_item;
   personas : path_item;
@@ -182,8 +180,6 @@ let to_json (resolution : resolution) =
       ( "warnings",
         `List (List.map (fun warning -> `String warning) resolution.warnings) );
       ("config_root", item_to_json resolution.config_root);
-      ("cascade_authoring", item_to_json resolution.cascade_authoring);
-      ("cascade", item_to_json resolution.cascade);
       ("prompts", item_to_json resolution.prompts);
       ("keepers", item_to_json resolution.keepers);
       ("personas", item_to_json resolution.personas);
@@ -300,15 +296,11 @@ let inputs_from_env () =
 
 let resolve_with inputs =
   let config_root, root_warnings = config_root_resolution inputs in
-  let cascade_authoring = file_item config_root cascade_toml_filename in
-  let cascade = cascade_authoring in
   let prompts = child_item config_root "prompts" in
   let keepers = child_item config_root "keepers" in
   let personas, persona_warnings = personas_item inputs config_root in
   let missing_child_warnings =
-    (* RFC-0058 §9: [cascade.toml] is the only cascade source. *)
-    [ ("cascade.toml", cascade_authoring.exists)
-    ; ("prompts", prompts.exists)
+    [ ("prompts", prompts.exists)
     ; ("keepers", keepers.exists)
     ; ("personas", personas.exists)
     ]
@@ -332,8 +324,6 @@ let resolve_with inputs =
     status;
     warnings;
     config_root;
-    cascade_authoring;
-    cascade;
     prompts;
     keepers;
     personas;
@@ -352,17 +342,17 @@ let resolve () =
 let reset () =
   cached_resolution := None
 
-(* RFC-0058 §9: the on-disk cascade source is [cascade.toml]. *)
 let cascade_path_opt () =
   let resolution = resolve () in
   match resolution.config_root.source with
-  | Env | Local_masc when resolution.cascade_authoring.exists ->
-      Some resolution.cascade_authoring.path
+  | Env | Local_masc ->
+      let path = Filename.concat resolution.config_root.path cascade_toml_filename in
+      if Sys.file_exists path then Some path else None
   | Env | Local_masc | Invalid_env | Missing ->
       None
 
 let cascade_path_candidate () =
-  (resolve ()).cascade_authoring.path
+  Filename.concat (resolve ()).config_root.path cascade_toml_filename
 
 let cascade_toml_path_candidate () =
   Filename.concat (resolve ()).config_root.path cascade_toml_filename

--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -3,7 +3,6 @@ module StringSet = Set_util.StringSet
 (** SSOT for config filenames documented in [docs/TOML-RELOAD-MATRIX.md].
     Consumed by the resolver here and by config loaders elsewhere in the
     codebase. Issue #8414. *)
-let cascade_toml_filename = "cascade.toml"
 let tool_policy_toml_filename = "tool_policy.toml"
 let keeper_runtime_toml_filename = "keeper_runtime.toml"
 
@@ -186,12 +185,14 @@ let to_json (resolution : resolution) =
     ]
 
 let config_signature_exists config_dir =
-  let cascade_toml = Filename.concat config_dir cascade_toml_filename in
+  let keeper_runtime_toml = Filename.concat config_dir keeper_runtime_toml_filename in
+  let tool_policy_toml = Filename.concat config_dir tool_policy_toml_filename in
   let prompts = Filename.concat config_dir "prompts" in
   let keepers = Filename.concat config_dir "keepers" in
   let personas = Filename.concat config_dir "personas" in
   existing_dir config_dir
-  && (existing_file cascade_toml
+  && (existing_file keeper_runtime_toml
+     || existing_file tool_policy_toml
      || existing_dir prompts || existing_dir keepers
      || existing_dir personas)
 
@@ -341,21 +342,6 @@ let resolve () =
 
 let reset () =
   cached_resolution := None
-
-let cascade_path_opt () =
-  let resolution = resolve () in
-  match resolution.config_root.source with
-  | Env | Local_masc ->
-      let path = Filename.concat resolution.config_root.path cascade_toml_filename in
-      if Sys.file_exists path then Some path else None
-  | Env | Local_masc | Invalid_env | Missing ->
-      None
-
-let cascade_path_candidate () =
-  Filename.concat (resolve ()).config_root.path cascade_toml_filename
-
-let cascade_toml_path_candidate () =
-  Filename.concat (resolve ()).config_root.path cascade_toml_filename
 
 let prompts_dir () =
   (resolve ()).prompts.path

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -31,8 +31,6 @@ type resolution = {
   status : status;
   warnings : string list;
   config_root : path_item;
-  cascade_authoring : path_item;
-  cascade : path_item;
   prompts : path_item;
   keepers : path_item;
   personas : path_item;
@@ -73,15 +71,13 @@ val reset : unit -> unit
 
     Convenience functions that call [resolve ()] internally. *)
 
-(** Path to the on-disk cascade source ([cascade.toml]) when the config
-    root resolves to a usable directory and the file exists. Returns
-    [None] when the resolver state is [Invalid_env]/[Missing] or the
-    file is absent. *)
+(** Path to the legacy runtime config file when the config root resolves to a
+    usable directory and the file exists. Returns [None] when the resolver
+    state is [Invalid_env]/[Missing] or the file is absent. *)
 val cascade_path_opt : unit -> string option
 
-(** Candidate path to the on-disk cascade source ([cascade.toml]),
-    independent of whether the file exists. Useful for diagnostics that
-    want to surface the expected path. *)
+(** Candidate path to the legacy runtime config file, independent of whether
+    the file exists. *)
 val cascade_path_candidate : unit -> string
 val prompts_dir : unit -> string
 val keepers_dir : unit -> string

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -47,7 +47,6 @@ type inputs = {
 (** {1 SSOT filenames}
 
     Documented in [docs/TOML-RELOAD-MATRIX.md]. *)
-val cascade_toml_filename : string
 val tool_policy_toml_filename : string
 val keeper_runtime_toml_filename : string
 
@@ -71,14 +70,6 @@ val reset : unit -> unit
 
     Convenience functions that call [resolve ()] internally. *)
 
-(** Path to the legacy runtime config file when the config root resolves to a
-    usable directory and the file exists. Returns [None] when the resolver
-    state is [Invalid_env]/[Missing] or the file is absent. *)
-val cascade_path_opt : unit -> string option
-
-(** Candidate path to the legacy runtime config file, independent of whether
-    the file exists. *)
-val cascade_path_candidate : unit -> string
 val prompts_dir : unit -> string
 val keepers_dir : unit -> string
 val personas_dir_opt : unit -> string option

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -99,12 +99,17 @@ let get_default_runtime_id () =
        Runtime.init_default must run at startup (no silent fallback — RFC-0206 §2.1)"
 ;;
 
-(* Path to the runtime config TOML (re-homed from deleted
-   [Runtime.config_path]). Delegates to the surviving
-   [Config_dir_resolver]; the file is still [cascade.toml] (rename deferred). *)
 let config_path () : string option =
   Config_dir_resolver.log_warnings ~context:"Runtime" ();
-  Config_dir_resolver.cascade_path_opt ()
+  let resolution = Config_dir_resolver.resolve () in
+  match resolution.config_root.source with
+  | Env | Local_masc ->
+      let path =
+        Filename.concat resolution.config_root.path
+          Config_dir_resolver.keeper_runtime_toml_filename
+      in
+      if Sys.file_exists path then Some path else None
+  | Invalid_env | Missing -> None
 ;;
 
 (* RFC-0206 single-binding: the deleted [Cascade_runtime.resolve_*_max_context]

--- a/lib/server/server_runtime_config_root_bootstrap.ml
+++ b/lib/server/server_runtime_config_root_bootstrap.ml
@@ -195,14 +195,6 @@ let bootstrap_base_path_config_root ~base_path =
         Log.Server.info "bootstrapped base-path config root: %s <- %s" config_root source
       | None ->
         ensure_config_root_scaffold config_root;
-        (* RFC-0058 §9.3: cascade.toml is the only cascade source.
-           [""] is the smallest valid TOML document — a document
-           with no tables and no keys; the materializer parses it
-           and renders an empty in-memory catalog. *)
-        let cascade_path =
-          Filename.concat config_root Config_dir_resolver.cascade_toml_filename
-        in
-        if not (Sys.file_exists cascade_path) then Fs_compat.save_file cascade_path "";
         Log.Server.warn
           "bootstrapped minimal base-path config root without versioned source: %s"
           config_root);

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -251,8 +251,6 @@ let test_env_override_valid () =
     (Config_dir_resolver.status_to_string resolution.status);
   check string "root source" "env"
     (Config_dir_resolver.source_to_string resolution.config_root.source);
-  check bool "cascade authoring exists" true resolution.cascade_authoring.exists;
-  check bool "cascade exists" true resolution.cascade.exists;
   check bool "prompts exists" true resolution.prompts.exists
 
 let test_env_override_valid_with_toml_only_root () =
@@ -266,14 +264,7 @@ let test_env_override_valid_with_toml_only_root () =
     (Config_dir_resolver.status_to_string resolution.status);
   check string "root source" "env"
     (Config_dir_resolver.source_to_string resolution.config_root.source);
-  check bool "cascade authoring exists" true resolution.cascade_authoring.exists;
-  check string "cascade authoring path targets toml"
-    (Filename.concat config "cascade.toml")
-    resolution.cascade_authoring.path;
-  check bool "cascade points at toml" true resolution.cascade.exists;
-  check string "cascade path targets toml"
-    (Filename.concat config "cascade.toml")
-    resolution.cascade.path
+  check bool "prompts absent in toml-only root" false resolution.prompts.exists
 
 let test_env_override_invalid_no_fallback () =
   let invalid = "/tmp/definitely-missing-masc-config-dir" in
@@ -286,7 +277,6 @@ let test_env_override_invalid_no_fallback () =
     (Config_dir_resolver.status_to_string resolution.status);
   check string "root source" "invalid_env"
     (Config_dir_resolver.source_to_string resolution.config_root.source);
-  check bool "cascade missing" false resolution.cascade.exists;
   check bool "warnings present" true (resolution.warnings <> [])
 
 let test_cwd_config_is_seed_only_not_fallback () =
@@ -300,8 +290,7 @@ let test_cwd_config_is_seed_only_not_fallback () =
     (Config_dir_resolver.status_to_string resolution.status);
   check string "root source" "missing"
     (Config_dir_resolver.source_to_string resolution.config_root.source);
-  check bool "cascade hidden because repo config is seed-only"
-    false resolution.cascade.exists
+  check bool "warnings present" true (resolution.warnings <> [])
 
 let test_cwd_config_remains_seed_only () =
   with_temp_dir "config-dir-cwd-seed-only" @@ fun cwd ->

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1973,13 +1973,6 @@ let test_startup_state_json_includes_runtime_resolution () =
               ("exists", `Bool true);
               ("source", `String "local_masc");
             ] );
-        ( "cascade_authoring",
-          `Assoc
-            [
-              ("path", `String "/tmp/runtime-root/.masc/config/cascade.toml");
-              ("exists", `Bool false);
-              ("source", `String "local_masc");
-            ] );
       ]
   in
   Server_startup_state.note_runtime_resolution ~path_diagnostics
@@ -1994,11 +1987,6 @@ let test_startup_state_json_includes_runtime_resolution () =
     "/tmp/runtime-root/.masc/config"
     (json |> member "config_resolution" |> member "config_root" |> member "path"
    |> to_string)
-  ;
-  Alcotest.(check bool) "startup cascade authoring path surfaced" true
-    (match json |> member "config_resolution" |> member "cascade_authoring" |> member "path" with
-     | `String value -> String.length value > 0
-     | _ -> false)
 
 let test_create_server_state_records_runtime_resolution () =
   with_temp_dir "startup-create-state" (fun dir ->
@@ -2023,10 +2011,6 @@ let test_create_server_state_records_runtime_resolution () =
       Alcotest.(check string) "create_server_state records config root"
         (Filename.concat dir ".masc/config")
         (json |> member "config_resolution" |> member "config_root" |> member "path"
-       |> to_string);
-      Alcotest.(check string) "create_server_state records cascade authoring path"
-        (Filename.concat dir ".masc/config/cascade.toml")
-        (json |> member "config_resolution" |> member "cascade_authoring" |> member "path"
        |> to_string);
       Alcotest.(check string) "create_server_state records effective masc root"
         (Unix.realpath (Filename.concat dir Common.masc_dirname))


### PR DESCRIPTION
## Summary
- remove `cascade_authoring` and `cascade` from config-dir resolution records and dashboard config-resolution UI
- stop warning on missing `cascade.toml` as a config-root child
- remove startup/config-dir tests that asserted Cascade authoring/source paths as surfaced topology
- remove `Config_dir_resolver.cascade_*` legacy path accessors
- stop bootstrapping empty `cascade.toml`; `Runtime.config_path` now targets `keeper_runtime.toml`

## Validation
- Not run. Continuing Cascade/catalog removal; build breakage is accepted for this cleanup.