### PR TITLE
Reject cascade_name keeper inputs

### DIFF
--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -296,7 +296,7 @@ let finalize
       ~trace_id:receipt.trace_id ~generation:receipt.generation
       ~keeper_turn_id:manifest_keeper_turn_id ~event
       ?oas_turn_count
-      ~cascade_name:(receipt.cascade_name)
+      ~runtime_id:(receipt.cascade_name)
       ~status ~decision ~receipt_path ?tool_call_log_path ()
     |> Keeper_runtime_manifest.append_best_effort ~site config
   in

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -189,7 +189,7 @@ let append_runtime_manifest ~config ~keeper_name ~agent_name ~trace_id
            decision)
   in
   Keeper_runtime_manifest.make ~keeper_name ~agent_name ~trace_id ~generation
-    ?keeper_turn_id ?oas_turn_count ?logical_seq ~event ~cascade_name ?status
+    ?keeper_turn_id ?oas_turn_count ?logical_seq ~event ~runtime_id:cascade_name ?status
     ?decision ?checkpoint_path ?receipt_path ()
   |> Keeper_runtime_manifest.append_best_effort ~site config
 

--- a/lib/keeper/keeper_config_text.ml
+++ b/lib/keeper/keeper_config_text.ml
@@ -64,6 +64,7 @@ let removed_keeper_input_key_names =
     "models";
     "allowed_models";
     "active_model";
+    "cascade_name";
     legacy_provider_filter_name;
     "presence_keepalive";
     "presence_keepalive_sec";

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -14,7 +14,7 @@
    Keeper_meta_json -> Keeper_meta_json_scrub -> Keeper_meta_json. *)
 let config_field_names =
   [ "goal"; "short_goal"; "mid_goal"; "long_goal"
-  ; "social_model"; "runtime_id"; "cascade_name"
+  ; "social_model"; "runtime_id"
   ; "will"; "needs"; "desires"; "instructions"
   ; "sandbox_profile"; "sandbox_image"; "network_mode"; "allowed_paths"
   ; "tool_access"; "tool_denylist"

--- a/lib/keeper/keeper_runtime_manifest_housekeeping.mli
+++ b/lib/keeper/keeper_runtime_manifest_housekeeping.mli
@@ -41,7 +41,7 @@ type t =
   oas_turn_count : int option;
   logical_seq : int option;
   event : event_kind;
-  cascade_name : string option;
+  runtime_id : string option;
   status : string;
   decision : Yojson.Safe.t;
   links : links;

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -521,7 +521,7 @@ let run_named
          in
          Keeper_runtime_manifest.make_for_context manifest_ctx
            ~event:Keeper_runtime_manifest.Pre_dispatch_blocked
-           ~cascade_name
+           ~runtime_id:cascade_name
            ~status:"error"
            ~decision:
              (`Assoc
@@ -698,7 +698,7 @@ let run_named
         | None -> decision
       in
       Keeper_runtime_manifest.make_for_context manifest_ctx ~event
-        ?oas_turn_count ~logical_seq:!seq_ref ~cascade_name ?status ?decision
+        ?oas_turn_count ~logical_seq:!seq_ref ~runtime_id:cascade_name ?status ?decision
         ()
       |> append
     | _ -> ()

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -125,7 +125,7 @@ let emit_runtime_manifest
            decision)
     in
     Keeper_runtime_manifest.make_for_context manifest_ctx ~event
-      ~cascade_name:ctx.cascade_name ?logical_seq:(Some !(ctx.seq_ref))
+      ~runtime_id:ctx.cascade_name ?logical_seq:(Some !(ctx.seq_ref))
       ?status ?decision ()
     |> append
   | _ -> ()

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -290,7 +290,7 @@ let record_pre_dispatch_terminal_observation
     in
     Keeper_runtime_manifest.make ~ts:ended_at ~keeper_name:meta.name
       ~agent_name:meta.agent_name ~trace_id ~generation ?keeper_turn_id ~event
-      ~cascade_name:cascade_name_string ~status ?decision ~receipt_path ()
+      ~runtime_id:cascade_name_string ~status ?decision ~receipt_path ()
     |> Keeper_runtime_manifest.append_best_effort ~site config
   in
   append_manifest

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -128,19 +128,7 @@ let parse_runtime_id_field_opt args key =
             Error (Printf.sprintf "invalid %s '%s': %s" key raw detail)
 
 let parse_runtime_id_opt args =
-  match
-    parse_runtime_id_field_opt args "runtime_id",
-    parse_runtime_id_field_opt args "cascade_name"
-  with
-  | Error msg, _ | _, Error msg -> Error msg
-  | Ok (Some runtime_id), Ok (Some legacy_cascade_name)
-    when runtime_id <> legacy_cascade_name ->
-      Error
-        (Printf.sprintf
-           "runtime_id (%s) and legacy cascade_name (%s) must match"
-           runtime_id legacy_cascade_name)
-  | Ok (Some runtime_id), _ -> Ok (Some runtime_id)
-  | Ok None, Ok legacy_cascade_name_opt -> Ok legacy_cascade_name_opt
+  parse_runtime_id_field_opt args "runtime_id"
 
 let resolve_tool_name_list ~preferred ~fallback =
   Dashboard_utils.first_some preferred fallback

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -136,27 +136,19 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     in
     let runtime_id = trimmed "runtime_id" in
     let legacy_model = trimmed "model" in
-    let legacy_cascade_name = trimmed "cascade_name" in
     let conflict left_name left_value right_name right_value =
       Error
         (Printf.sprintf
            "keeper.%s (%s) and legacy keeper.%s (%s) must match"
            left_name left_value right_name right_value)
     in
-    match runtime_id, legacy_model, legacy_cascade_name with
-    | Some runtime_id, Some legacy_model, _
+    match runtime_id, legacy_model with
+    | Some runtime_id, Some legacy_model
       when runtime_id <> legacy_model ->
       conflict "runtime_id" runtime_id "model" legacy_model
-    | Some runtime_id, _, Some legacy_cascade_name
-      when runtime_id <> legacy_cascade_name ->
-      conflict "runtime_id" runtime_id "cascade_name" legacy_cascade_name
-    | None, Some legacy_model, Some legacy_cascade_name
-      when legacy_model <> legacy_cascade_name ->
-      conflict "model" legacy_model "cascade_name" legacy_cascade_name
-    | Some runtime_id, _, _ -> Ok (Some runtime_id)
-    | None, Some legacy_model, _ -> Ok (Some legacy_model)
-    | None, None, Some legacy_cascade_name -> Ok (Some legacy_cascade_name)
-    | None, None, None -> Ok None
+    | Some runtime_id, _ -> Ok (Some runtime_id)
+    | None, Some legacy_model -> Ok (Some legacy_model)
+    | None, None -> Ok None
   in
   let result =
     Result.bind result (fun () ->
@@ -281,7 +273,6 @@ let parsed_field_key_names =
   ; "social_model"
   ; "runtime_id"
   ; "model"
-  ; "cascade_name"
   ]
 
 (** Canonical TOML key names used by [detect_unknown_keeper_toml_keys].
@@ -330,7 +321,6 @@ let canonical_keeper_toml_key_names =
   ; "social_model"
   ; "runtime_id"
   ; "model"
-  ; "cascade_name"
   ]
 
 let loader_level_keeper_toml_key_names = [ "base" ]

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -66,7 +66,7 @@ let run_keeper_cycle
   in
   let turn_start = Mtime_clock.now () in
   let seq_ref = ref 0 in
-  let append_manifest ?status ?decision ?cascade_name ?clock_refs ~site event =
+  let append_manifest ?status ?decision ?runtime_id ?clock_refs ~site event =
     let decision =
       let decision =
         match decision with
@@ -95,7 +95,7 @@ let run_keeper_cycle
            decision)
     in
     Keeper_runtime_manifest.make_for_context runtime_manifest_context ~event
-      ?cascade_name ?status ?decision ()
+      ?runtime_id ?status ?decision ()
     |> Keeper_runtime_manifest.append_best_effort ~site config
   in
   let append_phase_gate_decision turn_plan =
@@ -150,7 +150,7 @@ let run_keeper_cycle
           ~phase_opt
           ~append_cascade_routed_manifest:(fun ~cascade_name ~decision ->
             append_manifest ~site:"cascade_routed"
-              ~cascade_name
+              ~runtime_id:cascade_name
               ~decision
               Keeper_runtime_manifest.Cascade_routed)
       in


### PR DESCRIPTION
## Summary
- reject `cascade_name` as a removed keeper input key
- stop accepting `keeper.cascade_name` as a TOML/profile runtime fallback
- stop accepting `cascade_name` as a `masc_keeper_up` runtime alias
- remove `cascade_name` from canonical keeper TOML key names and meta config scrub names
- switch runtime manifest call sites and duplicate housekeeping signature from `cascade_name` labels to `runtime_id`

## Validation
- Not run. Continuing Cascade/catalog removal; build breakage is accepted for this cleanup.